### PR TITLE
Move terminal keychain prompt message into secret_store*.go

### DIFF
--- a/go/client/terminal.go
+++ b/go/client/terminal.go
@@ -104,9 +104,7 @@ func (t Terminal) GetSecret(arg *keybase1.SecretEntryArg) (res *keybase1.SecretE
 	if arg.UseSecretStore {
 		// TODO: Default to 'No' and dismiss the question for
 		// about a day if 'No' is selected.
-		//
-		// TODO: Come up with prompts for other platforms.
-		res.StoreSecret, err = t.PromptYesNo("Store your key in Apple's local keychain?", PromptDefaultYes)
+		res.StoreSecret, err = t.PromptYesNo(libkb.GetTerminalPrompt(), PromptDefaultYes)
 		if err != nil {
 			return
 		}

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -18,9 +18,9 @@ type SecretStore interface {
 	ClearSecret() error
 }
 
-// NewSecretStore(username string), HasSecretStore(), and
-// GetUsersWithStoredSecrets() ([]string, error) are defined in
-// platform-specific files.
+// NewSecretStore(username string), HasSecretStore(),
+// GetUsersWithStoredSecrets() ([]string, error), and
+// GetTerminalPrompt() are defined in platform-specific files.
 
 func GetConfiguredAccounts() ([]keybase1.ConfiguredAccount, error) {
 	usernames, err := GetUsersWithStoredSecrets()

--- a/go/libkb/secret_store_non_osx.go
+++ b/go/libkb/secret_store_non_osx.go
@@ -13,3 +13,8 @@ func HasSecretStore() bool {
 func GetUsersWithStoredSecrets() ([]string, error) {
 	return nil, nil
 }
+
+func GetTerminalPrompt() string {
+	// TODO: Come up with specific prompts for other platforms.
+	return "Store your key in the local secret store?"
+}

--- a/go/libkb/secret_store_osx.go
+++ b/go/libkb/secret_store_osx.go
@@ -88,3 +88,7 @@ func HasSecretStore() bool {
 func GetUsersWithStoredSecrets() ([]string, error) {
 	return kc.GetAllAccountNames(keychainServiceName)
 }
+
+func GetTerminalPrompt() string {
+	return "Store your key in Apple's local keychain?"
+}


### PR DESCRIPTION
This keeps all platform-specific stuff in secret_store*.go.
