### PR TITLE
Update authentication proofs to use new auth section

### DIFF
--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -378,8 +378,11 @@ func (u *User) AuthenticationProof(key GenericKey, session string, ei int) (ret 
 	if _, err = rand.Read(nonce[:]); err != nil {
 		return
 	}
-	body.SetKey("nonce", jsonw.NewString(hex.EncodeToString(nonce[:])))
-	body.SetKey("session", jsonw.NewString(session))
+	auth := jsonw.NewDictionary()
+	auth.SetKey("nonce", jsonw.NewString(hex.EncodeToString(nonce[:])))
+	auth.SetKey("session", jsonw.NewString(session))
+
+	body.SetKey("auth", auth)
 	return
 }
 


### PR DESCRIPTION
All tests pass except this:

```
--- FAIL: TestSearch (0.01s)
    search_test.go:32: Expected at least 2 search results for 'tacovontaco'. Got 0.
```

...but it seems that even without this patch and with the previous version of the server, I still get this error.

@maxtaco 

This PR fixes #604 
