### PR TITLE
removing skipImport and pushSecret options from api

### DIFF
--- a/go/client/cmd_pgp_import.go
+++ b/go/client/cmd_pgp_import.go
@@ -25,10 +25,6 @@ func NewCmdPGPImport(cl *libcmdline.CommandLine) cli.Command {
 				Name:  "i, infile",
 				Usage: "specify an infile (stdin by default)",
 			},
-			cli.BoolFlag{
-				Name:  "push-secret",
-				Usage: "push an encrypted copy of the secret key to the server",
-			},
 		},
 	}
 }
@@ -43,7 +39,6 @@ func (s *CmdPGPImport) ParseArgv(ctx *cli.Context) error {
 	nargs := len(ctx.Args())
 	var err error
 
-	s.arg.PushSecret = ctx.Bool("push-secret")
 	s.infile = ctx.String("infile")
 
 	if nargs > 0 {

--- a/go/client/cmd_pgp_select.go
+++ b/go/client/cmd_pgp_select.go
@@ -11,9 +11,8 @@ import (
 )
 
 type CmdPGPSelect struct {
-	query      string
-	multi      bool
-	skipImport bool
+	query string
+	multi bool
 }
 
 func (v *CmdPGPSelect) ParseArgv(ctx *cli.Context) (err error) {
@@ -24,7 +23,6 @@ func (v *CmdPGPSelect) ParseArgv(ctx *cli.Context) (err error) {
 	}
 	if err == nil {
 		v.multi = ctx.Bool("multi")
-		v.skipImport = ctx.Bool("no-import")
 	}
 	return err
 }
@@ -43,7 +41,7 @@ func (v *CmdPGPSelect) Run() error {
 		return err
 	}
 
-	err = c.PGPSelect(keybase1.PGPSelectArg{FingerprintQuery: v.query, AllowMulti: v.multi, SkipImport: v.skipImport})
+	err = c.PGPSelect(keybase1.PGPSelectArg{FingerprintQuery: v.query, AllowMulti: v.multi})
 	PGPMultiWarn(err)
 	return err
 }
@@ -60,10 +58,6 @@ func NewCmdPGPSelect(cl *libcmdline.CommandLine) cli.Command {
 			cli.BoolFlag{
 				Name:  "multi",
 				Usage: "Allow multiple PGP keys",
-			},
-			cli.BoolFlag{
-				Name:  "no-import",
-				Usage: "Don't import private key to Keybase's private keychain",
 			},
 		},
 	}

--- a/go/engine/fakeusers_test.go
+++ b/go/engine/fakeusers_test.go
@@ -105,7 +105,7 @@ func createFakeUserWithPGPOnly(t *testing.T, tc libkb.TestContext) *FakeUser {
 	gen.AddDefaultUID()
 	peng := NewPGPKeyImportEngine(PGPKeyImportEngineArg{
 		Gen:        &gen,
-		PushSecret: true,
+		pushSecret: true,
 		Lks:        s.lks,
 		NoSave:     true,
 	})

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -145,7 +145,7 @@ func TestIdPGPNotEldest(t *testing.T) {
 	u := CreateAndSignupFakeUser(tc, "login")
 	ctx := &Context{LogUI: tc.G.UI.GetLogUI(), SecretUI: u.NewSecretUI()}
 	_, _, key := armorKey(t, tc, u.Email)
-	eng, err := NewPGPKeyImportEngineFromBytes([]byte(key), true, tc.G)
+	eng, err := newPGPKeyImportEngineFromBytesPushSecret([]byte(key), true, tc.G)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/pgp_export_key_test.go
+++ b/go/engine/pgp_export_key_test.go
@@ -16,7 +16,7 @@ func TestPGPExportOptions(t *testing.T) {
 	ctx := &Context{LogUI: tc.G.UI.GetLogUI(), SecretUI: secui}
 
 	fp, kid, key := armorKey(t, tc, u.Email)
-	eng, err := NewPGPKeyImportEngineFromBytes([]byte(key), true, tc.G)
+	eng, err := newPGPKeyImportEngineFromBytesPushSecret([]byte(key), true, tc.G)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -30,13 +30,14 @@ type PGPKeyImportEngineArg struct {
 	Ctx        *libkb.GlobalContext
 	Lks        *libkb.LKSec
 	NoSave     bool
-	PushSecret bool
+	pushSecret bool
 	AllowMulti bool
 	DoExport   bool
 	DoUnlock   bool
 }
 
-func NewPGPKeyImportEngineFromBytes(key []byte, pushPrivate bool, gc *libkb.GlobalContext) (eng *PGPKeyImportEngine, err error) {
+// Internally we allow setting pushPrivate but externally we do not
+func newPGPKeyImportEngineFromBytesPushSecret(key []byte, pushPrivate bool, gc *libkb.GlobalContext) (eng *PGPKeyImportEngine, err error) {
 	var bundle *libkb.PGPKeyBundle
 	if libkb.IsArmored(key) {
 		bundle, err = libkb.ReadPrivateKeyFromString(string(key))
@@ -48,7 +49,7 @@ func NewPGPKeyImportEngineFromBytes(key []byte, pushPrivate bool, gc *libkb.Glob
 	}
 	arg := PGPKeyImportEngineArg{
 		Pregen:     bundle,
-		PushSecret: pushPrivate,
+		pushSecret: pushPrivate,
 		AllowMulti: true,
 		DoExport:   false,
 		DoUnlock:   true,
@@ -56,6 +57,10 @@ func NewPGPKeyImportEngineFromBytes(key []byte, pushPrivate bool, gc *libkb.Glob
 	}
 	eng = NewPGPKeyImportEngine(arg)
 	return
+}
+
+func NewPGPKeyImportEngineFromBytes(key []byte, gc *libkb.GlobalContext) (eng *PGPKeyImportEngine, err error) {
+	return newPGPKeyImportEngineFromBytesPushSecret(key, false, gc)
 }
 
 func (e *PGPKeyImportEngine) loadMe() (err error) {
@@ -277,7 +282,7 @@ func (e *PGPKeyImportEngine) generate(ctx *Context) (err error) {
 		}
 	}
 
-	if e.arg.PushSecret {
+	if e.arg.pushSecret {
 		if err = e.prepareSecretPush(ctx); err != nil {
 			return
 		}

--- a/go/engine/pgp_import_key_test.go
+++ b/go/engine/pgp_import_key_test.go
@@ -23,7 +23,7 @@ func TestPGPImportAndExport(t *testing.T) {
 	// try all four permutations of push options:
 
 	fp, _, key := armorKey(t, tc, u.Email)
-	eng, err := NewPGPKeyImportEngineFromBytes([]byte(key), false, tc.G)
+	eng, err := newPGPKeyImportEngineFromBytesPushSecret([]byte(key), false, tc.G)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestPGPImportAndExport(t *testing.T) {
 	}
 
 	fp, _, key = armorKey(t, tc, u.Email)
-	eng, err = NewPGPKeyImportEngineFromBytes([]byte(key), true, tc.G)
+	eng, err = newPGPKeyImportEngineFromBytesPushSecret([]byte(key), true, tc.G)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func TestPGPImportPublicKey(t *testing.T) {
 	tc := SetupEngineTest(t, "pgpsave")
 	defer tc.Cleanup()
 
-	_, err := NewPGPKeyImportEngineFromBytes([]byte(pubkeyIssue325), false, tc.G)
+	_, err := NewPGPKeyImportEngineFromBytes([]byte(pubkeyIssue325), tc.G)
 	if err == nil {
 		t.Fatal("import of public key didn't generate error")
 	}
@@ -110,7 +110,7 @@ func TestIssue454(t *testing.T) {
 	CreateAndSignupFakeUser(tc, "login")
 	secui := &libkb.TestSecretUI{Passphrase: "test"}
 	ctx := &Context{LogUI: tc.G.UI.GetLogUI(), SecretUI: secui}
-	eng, err := NewPGPKeyImportEngineFromBytes([]byte(keyIssue454), false, tc.G)
+	eng, err := NewPGPKeyImportEngineFromBytes([]byte(keyIssue454), tc.G)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/service/pgp.go
+++ b/go/service/pgp.go
@@ -130,7 +130,7 @@ func (h *PGPHandler) PGPImport(arg keybase1.PGPImportArg) error {
 		SecretUI: h.getSecretUI(arg.SessionID),
 		LogUI:    h.getLogUI(arg.SessionID),
 	}
-	eng, err := engine.NewPGPKeyImportEngineFromBytes(arg.Key, arg.PushSecret, nil)
+	eng, err := engine.NewPGPKeyImportEngineFromBytes(arg.Key, nil)
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func (h *PGPHandler) PGPDeletePrimary(sessionID int) (err error) {
 }
 
 func (h *PGPHandler) PGPSelect(sarg keybase1.PGPSelectArg) error {
-	arg := engine.GPGImportKeyArg{Query: sarg.FingerprintQuery, AllowMulti: sarg.AllowMulti, SkipImport: sarg.SkipImport}
+	arg := engine.GPGImportKeyArg{Query: sarg.FingerprintQuery, AllowMulti: sarg.AllowMulti}
 	gpg := engine.NewGPGImportKeyEngine(&arg, G)
 	ctx := &engine.Context{
 		GPGUI:    h.getGPGUI(sarg.SessionID),

--- a/protocol/avdl/pgp.avdl
+++ b/protocol/avdl/pgp.avdl
@@ -61,7 +61,7 @@ protocol pgp {
 
 	PGPSigVerification pgpVerify(int sessionID, Stream source, PGPVerifyOptions opts);
 
-	void pgpImport(int sessionID, bytes key, boolean pushSecret);
+	void pgpImport(int sessionID, bytes key);
 
 	record KeyInfo {
 		string fingerprint;
@@ -93,7 +93,7 @@ protocol pgp {
 	void pgpDeletePrimary(int sessionID);
 
 	// select an existing key and add to kb
-	void pgpSelect(int sessionID, string fingerprintQuery, boolean allowMulti, boolean skipImport);
+	void pgpSelect(int sessionID, string fingerprintQuery, boolean allowMulti);
 
 	// push updated key(s) to the server
 	void pgpUpdate(int sessionID, boolean all, array<string> fingerprints);

--- a/protocol/go/keybase_v1.go
+++ b/protocol/go/keybase_v1.go
@@ -2031,9 +2031,8 @@ type PGPVerifyArg struct {
 }
 
 type PGPImportArg struct {
-	SessionID  int    `codec:"sessionID" json:"sessionID"`
-	Key        []byte `codec:"key" json:"key"`
-	PushSecret bool   `codec:"pushSecret" json:"pushSecret"`
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	Key       []byte `codec:"key" json:"key"`
 }
 
 type PGPExportArg struct {
@@ -2073,7 +2072,6 @@ type PGPSelectArg struct {
 	SessionID        int    `codec:"sessionID" json:"sessionID"`
 	FingerprintQuery string `codec:"fingerprintQuery" json:"fingerprintQuery"`
 	AllowMulti       bool   `codec:"allowMulti" json:"allowMulti"`
-	SkipImport       bool   `codec:"skipImport" json:"skipImport"`
 }
 
 type PGPUpdateArg struct {

--- a/protocol/json/pgp.json
+++ b/protocol/json/pgp.json
@@ -504,9 +504,6 @@
       }, {
         "name" : "key",
         "type" : "bytes"
-      }, {
-        "name" : "pushSecret",
-        "type" : "boolean"
       } ],
       "response" : "null"
     },
@@ -597,9 +594,6 @@
         "type" : "string"
       }, {
         "name" : "allowMulti",
-        "type" : "boolean"
-      }, {
-        "name" : "skipImport",
         "type" : "boolean"
       } ],
       "response" : "null"

--- a/protocol/objc/KBRPC.h
+++ b/protocol/objc/KBRPC.h
@@ -872,7 +872,6 @@ typedef NS_ENUM (NSInteger, KBRPromptDefault) {
 @interface KBRPgpImportRequestParams : KBRRequestParams
 @property NSInteger sessionID;
 @property NSData *key;
-@property BOOL pushSecret;
 @end
 @interface KBRPgpExportRequestParams : KBRRequestParams
 @property NSInteger sessionID;
@@ -905,7 +904,6 @@ typedef NS_ENUM (NSInteger, KBRPromptDefault) {
 @property NSInteger sessionID;
 @property NSString *fingerprintQuery;
 @property BOOL allowMulti;
-@property BOOL skipImport;
 @end
 @interface KBRPgpUpdateRequestParams : KBRRequestParams
 @property NSInteger sessionID;
@@ -1423,7 +1421,7 @@ typedef NS_ENUM (NSInteger, KBRPromptDefault) {
 
 - (void)pgpImport:(KBRPgpImportRequestParams *)params completion:(void (^)(NSError *error))completion;
 
-- (void)pgpImportWithKey:(NSData *)key pushSecret:(BOOL)pushSecret completion:(void (^)(NSError *error))completion;
+- (void)pgpImportWithKey:(NSData *)key completion:(void (^)(NSError *error))completion;
 
 - (void)pgpExport:(KBRPgpExportRequestParams *)params completion:(void (^)(NSError *error, NSArray *items))completion;
 
@@ -1449,7 +1447,7 @@ typedef NS_ENUM (NSInteger, KBRPromptDefault) {
 
 - (void)pgpSelect:(KBRPgpSelectRequestParams *)params completion:(void (^)(NSError *error))completion;
 
-- (void)pgpSelectWithFingerprintQuery:(NSString *)fingerprintQuery allowMulti:(BOOL)allowMulti skipImport:(BOOL)skipImport completion:(void (^)(NSError *error))completion;
+- (void)pgpSelectWithFingerprintQuery:(NSString *)fingerprintQuery allowMulti:(BOOL)allowMulti completion:(void (^)(NSError *error))completion;
 
 - (void)pgpUpdate:(KBRPgpUpdateRequestParams *)params completion:(void (^)(NSError *error))completion;
 

--- a/protocol/objc/KBRPC.m
+++ b/protocol/objc/KBRPC.m
@@ -1130,14 +1130,14 @@
 }
 
 - (void)pgpImport:(KBRPgpImportRequestParams *)params completion:(void (^)(NSError *error))completion {
-  NSDictionary *rparams = @{@"key": KBRValue(params.key), @"pushSecret": @(params.pushSecret)};
+  NSDictionary *rparams = @{@"key": KBRValue(params.key)};
   [self.client sendRequestWithMethod:@"keybase.1.pgp.pgpImport" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
     completion(error);
   }];
 }
 
-- (void)pgpImportWithKey:(NSData *)key pushSecret:(BOOL)pushSecret completion:(void (^)(NSError *error))completion {
-  NSDictionary *rparams = @{@"key": KBRValue(key), @"pushSecret": @(pushSecret)};
+- (void)pgpImportWithKey:(NSData *)key completion:(void (^)(NSError *error))completion {
+  NSDictionary *rparams = @{@"key": KBRValue(key)};
   [self.client sendRequestWithMethod:@"keybase.1.pgp.pgpImport" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
     completion(error);
   }];
@@ -1251,14 +1251,14 @@
 }
 
 - (void)pgpSelect:(KBRPgpSelectRequestParams *)params completion:(void (^)(NSError *error))completion {
-  NSDictionary *rparams = @{@"fingerprintQuery": KBRValue(params.fingerprintQuery), @"allowMulti": @(params.allowMulti), @"skipImport": @(params.skipImport)};
+  NSDictionary *rparams = @{@"fingerprintQuery": KBRValue(params.fingerprintQuery), @"allowMulti": @(params.allowMulti)};
   [self.client sendRequestWithMethod:@"keybase.1.pgp.pgpSelect" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
     completion(error);
   }];
 }
 
-- (void)pgpSelectWithFingerprintQuery:(NSString *)fingerprintQuery allowMulti:(BOOL)allowMulti skipImport:(BOOL)skipImport completion:(void (^)(NSError *error))completion {
-  NSDictionary *rparams = @{@"fingerprintQuery": KBRValue(fingerprintQuery), @"allowMulti": @(allowMulti), @"skipImport": @(skipImport)};
+- (void)pgpSelectWithFingerprintQuery:(NSString *)fingerprintQuery allowMulti:(BOOL)allowMulti completion:(void (^)(NSError *error))completion {
+  NSDictionary *rparams = @{@"fingerprintQuery": KBRValue(fingerprintQuery), @"allowMulti": @(allowMulti)};
   [self.client sendRequestWithMethod:@"keybase.1.pgp.pgpSelect" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
     completion(error);
   }];
@@ -3245,7 +3245,6 @@
   if ((self = [super initWithParams:params])) {
     self.sessionID = [params[0][@"sessionID"] integerValue];
     self.key = params[0][@"key"];
-    self.pushSecret = [params[0][@"pushSecret"] boolValue];
   }
   return self;
 }
@@ -3369,7 +3368,6 @@
     self.sessionID = [params[0][@"sessionID"] integerValue];
     self.fingerprintQuery = params[0][@"fingerprintQuery"];
     self.allowMulti = [params[0][@"allowMulti"] boolValue];
-    self.skipImport = [params[0][@"skipImport"] boolValue];
   }
   return self;
 }


### PR DESCRIPTION
fixes #563. Several things going on here
- [x] Removes the ability of the client to pass PushSecret
- [x] Keeps tests that do require this behavior, using a new unexported function
- [x] Internal function delegates to the unexported function, but always passes false
- [ ] Removes the ability of the client to pass SkipImport options

@patrickxb feedback please
@Sidnicious fixes #563 
