### PR TITLE
set the version number to 0.0.1

### DIFF
--- a/go/libkb/version.go
+++ b/go/libkb/version.go
@@ -1,4 +1,4 @@
 package libkb
 
 // Current version (Use semantic versioning, http://semver.org/)
-const Version = "1.0.0-beta.8"
+const Version = "0.0.1"


### PR DESCRIPTION
Previously it was "1.0.0-beta.8". This was making the RPM package
builder angry, because it doesn't like dashes. Use a version that
actually reflects the state of the codebase and avoids special tags.
