### PR TITLE
Consistent cli options. Removing invalid uid option.

### DIFF
--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -62,10 +62,10 @@ func (p CommandLine) GetServerURI() string {
 	return p.GetGString("server")
 }
 func (p CommandLine) GetConfigFilename() string {
-	return p.GetGString("config")
+	return p.GetGString("config-file")
 }
 func (p CommandLine) GetSessionFilename() string {
-	return p.GetGString("session")
+	return p.GetGString("session-file")
 }
 func (p CommandLine) GetDbFilename() string {
 	return p.GetGString("db")
@@ -249,11 +249,11 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 			Usage: fmt.Sprintf("specify server API (default: %s)", libkb.ServerURI),
 		},
 		cli.StringFlag{
-			Name:  "config, c",
+			Name:  "config-file, c",
 			Usage: "specify an (alternate) master config file",
 		},
 		cli.StringFlag{
-			Name:  "session",
+			Name:  "session-file",
 			Usage: "specify an alternate session data file",
 		},
 		cli.StringFlag{
@@ -267,10 +267,6 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 		cli.StringFlag{
 			Name:  "username, u",
 			Usage: "specify Keybase username of the current user",
-		},
-		cli.StringFlag{
-			Name:  "uid, i",
-			Usage: "specify Keybase UID for current user",
 		},
 		cli.StringFlag{
 			Name:  "pinentry",

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -317,13 +317,13 @@ func (f JSONConfigFile) GetServerURI() string {
 	return f.GetTopLevelString("server")
 }
 func (f JSONConfigFile) GetConfigFilename() string {
-	return f.GetTopLevelString("config")
+	return f.GetTopLevelString("config_file")
 }
 func (f JSONConfigFile) GetSecretKeyringTemplate() string {
 	return f.GetTopLevelString("secret_keyring")
 }
 func (f JSONConfigFile) GetSessionFilename() string {
-	return f.GetTopLevelString("session")
+	return f.GetTopLevelString("session_file")
 }
 func (f JSONConfigFile) GetDbFilename() string {
 	return f.GetTopLevelString("db")


### PR DESCRIPTION
All our other file options use -file (pid-file, sock-file, log-file).
The inconsistency was bothering me.
