### PR TITLE
eliminate the space before the ellipsis in paper key names

### DIFF
--- a/go/libkb/device.go
+++ b/go/libkb/device.go
@@ -43,7 +43,7 @@ func NewPaperDevice(passphrasePrefix string) (*Device, error) {
 		return nil, err
 	}
 	s := DeviceStatusActive
-	desc := fmt.Sprintf("Paper Key (%s ...)", passphrasePrefix)
+	desc := fmt.Sprintf("Paper Key (%s...)", passphrasePrefix)
 
 	d := &Device{
 		ID:          did,


### PR DESCRIPTION
I think this style is more standard.

@patrickxb, what do you think?
