### PR TITLE
Debugging Prints for #680

### DIFF
--- a/go/libkb/pgp_dec.go
+++ b/go/libkb/pgp_dec.go
@@ -46,6 +46,7 @@ func PGPDecrypt(source io.Reader, sink io.Writer, kr openpgp.KeyRing) (*Signatur
 		r = b.Body
 	}
 
+	G.Log.Debug("Calling into openpgp ReadMessage for decryption")
 	md, err := openpgp.ReadMessage(r, kr, nil, nil)
 	if err != nil {
 		if err == errors.ErrKeyIncorrect {


### PR DESCRIPTION
This bug is likely limited to standalone mode, OR!!! in server mode
when the user doesn't have any data in their passphrase stream cacche.

The problem is that if the passphrase stream cache is empty, we just
bail out entirely on attempting to load secret keys. Clearly this
is a bug, but I'm not sure what was intended. Need input from @patrickxb

Note I think that even if we fix this, the behavior of #681 is still
broken.

r: @patrickxb 
