### PR TITLE
Fix for #680

### DIFF
--- a/go/libkb/lksec.go
+++ b/go/libkb/lksec.go
@@ -21,12 +21,16 @@ type LKSec struct {
 }
 
 func NewLKSec(pps *PassphraseStream, uid keybase1.UID, gc *GlobalContext) *LKSec {
-	return &LKSec{
-		clientHalf:   pps.LksClientHalf(),
-		ppGen:        pps.Generation(),
+	res := &LKSec{
 		uid:          uid,
 		Contextified: NewContextified(gc),
 	}
+
+	if pps != nil {
+		res.clientHalf = pps.LksClientHalf()
+		res.ppGen = pps.Generation()
+	}
+	return res
 }
 
 func NewLKSecWithClientHalf(clientHalf []byte, ppgen PassphraseGeneration, uid keybase1.UID, gc *GlobalContext) *LKSec {

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -110,6 +110,14 @@ func (key *PGPKeyBundle) ToLksSKB(lks *LKSec) (ret *SKB, err error) {
 	return ret, nil
 }
 
+func (s *SKB) Dump() {
+	if s == nil {
+		s.G().Log.Debug("SKB Dump:  skb is nil\n")
+		return
+	}
+	s.G().Log.Debug("skb: %+v, uid = %s\n", s, s.uid)
+}
+
 func (s *SKB) newLKSec(pps *PassphraseStream) *LKSec {
 	if s.newLKSecForTest != nil {
 		return s.newLKSecForTest(pps.LksClientHalf())


### PR DESCRIPTION
- removed bail-out if passphrase stream cache not available
- setting uid on pgp keyring blocks

all tests pass, as do command line repro steps in #680.
