### PR TITLE
put logs under ~/.cache/keybase/ instead of /run/user/...

### DIFF
--- a/go/libkb/home.go
+++ b/go/libkb/home.go
@@ -92,10 +92,6 @@ func (x XdgPosix) ChdirDir() (ret string, err error) {
 }
 
 func (x XdgPosix) LogDir() string {
-	ret := x.xdgRuntimeDir()
-	if len(ret) != 0 {
-		return ret
-	}
 	return x.CacheDir()
 }
 


### PR DESCRIPTION
The latter is always wiped out on shutdown. That's not what we want to
happen to our logs.
