### PR TITLE
keybase launchd install,uninstall,list,status

### DIFF
--- a/go/client/cmd_launchd_osx.go
+++ b/go/client/cmd_launchd_osx.go
@@ -1,0 +1,116 @@
+// +build darwin
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+)
+
+func NewCmdLaunchd(cl *libcmdline.CommandLine) cli.Command {
+	return cli.Command{
+		Name:        "launchd",
+		Usage:       "keybase launchd [subcommands...]",
+		Description: "Manage keybase launchd services",
+		Subcommands: []cli.Command{
+			NewCmdLaunchdInstall(cl),
+			NewCmdLaunchdUninstall(cl),
+			NewCmdLaunchdList(cl),
+			NewCmdLaunchdStatus(cl),
+		},
+	}
+}
+
+func NewCmdLaunchdInstall(cl *libcmdline.CommandLine) cli.Command {
+	return cli.Command{
+		Name:        "install",
+		Usage:       "keybase launchd install <label> <path/to/keybase>",
+		Description: "Install a keybase launchd service",
+		Action: func(c *cli.Context) {
+			run := func() error {
+				args := c.Args()
+				if len(args) < 1 {
+					return fmt.Errorf("No label specified")
+				}
+				if len(args) < 2 {
+					return fmt.Errorf("No path to keybase executable specified")
+				}
+				return Install(G.Env.GetHome(), args[0], args[1], G.Env.GetLogDir())
+			}
+			cl.ChooseCommand(&cmdLaunchd{run}, "install", c)
+			cl.SetForkCmd(libcmdline.NoFork)
+		},
+	}
+}
+
+func NewCmdLaunchdUninstall(cl *libcmdline.CommandLine) cli.Command {
+	return cli.Command{
+		Name:        "uninstall",
+		Usage:       "keybase launchd uninstall <label>",
+		Description: "Uninstall a keybase launchd service",
+		Action: func(c *cli.Context) {
+			run := func() error {
+				args := c.Args()
+				if len(args) < 1 {
+					return fmt.Errorf("No label specified")
+				}
+				return Uninstall(G.Env.GetHome(), args[0])
+			}
+			cl.ChooseCommand(&cmdLaunchd{run}, "uninstall", c)
+			cl.SetForkCmd(libcmdline.NoFork)
+		},
+	}
+}
+
+func NewCmdLaunchdList(cl *libcmdline.CommandLine) cli.Command {
+	return cli.Command{
+		Name:        "list",
+		Usage:       "keybase launchd list",
+		Description: "List keybase launchd services",
+		Action: func(c *cli.Context) {
+			run := func() error {
+				return ShowServices(G.Env.GetHome())
+			}
+			cl.ChooseCommand(&cmdLaunchd{run}, "list", c)
+			cl.SetForkCmd(libcmdline.NoFork)
+		},
+	}
+}
+
+func NewCmdLaunchdStatus(cl *libcmdline.CommandLine) cli.Command {
+	return cli.Command{
+		Name:        "status",
+		Usage:       "keybase launchd status <label>",
+		Description: "Status for keybase launchd service",
+		Action: func(c *cli.Context) {
+			run := func() error {
+				args := c.Args()
+				if len(args) < 1 {
+					return fmt.Errorf("No label specified")
+				}
+				return ShowStatus(G.Env.GetHome(), args[0])
+			}
+			cl.ChooseCommand(&cmdLaunchd{run}, "status", c)
+			cl.SetForkCmd(libcmdline.NoFork)
+		},
+	}
+}
+
+type cmdLaunchd struct {
+	run func() error
+}
+
+func (c cmdLaunchd) ParseArgv(*cli.Context) error {
+	return nil
+}
+
+func (c cmdLaunchd) Run() error {
+	return c.run()
+}
+
+func (c *cmdLaunchd) GetUsage() libkb.Usage {
+	return libkb.Usage{}
+}

--- a/go/client/cmd_non_osx.go
+++ b/go/client/cmd_non_osx.go
@@ -1,0 +1,12 @@
+// +build !darwin
+
+package client
+
+import (
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+)
+
+func NewCmdLaunchd(cl *libcmdline.CommandLine) cli.Command {
+	return cli.Command{}
+}

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -20,6 +20,7 @@ func GetCommands(cl *libcmdline.CommandLine) []cli.Command {
 		NewCmdDoctor(cl),
 		NewCmdFavorite(cl),
 		NewCmdID(cl),
+		NewCmdLaunchd(cl),
 		NewCmdList(cl),
 		NewCmdLogin(cl),
 		NewCmdLogout(cl),

--- a/go/client/commands_release.go
+++ b/go/client/commands_release.go
@@ -5,6 +5,8 @@
 package client
 
 import (
+	"runtime"
+
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 )
@@ -19,6 +21,7 @@ func GetCommands(cl *libcmdline.CommandLine) []cli.Command {
 		NewCmdDevice(cl),
 		NewCmdDoctor(cl),
 		NewCmdID(cl),
+		NewCmdLaunchd(cl),
 		NewCmdList(cl),
 		NewCmdLogin(cl),
 		NewCmdLogout(cl),

--- a/go/client/launchd.go
+++ b/go/client/launchd.go
@@ -1,0 +1,243 @@
+// +build darwin
+
+package client
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/keybase/client/go/libkb"
+)
+
+// Service defines a service
+type Service struct {
+	homeDir string
+	label   string
+}
+
+// NewService constructs a launchd service.
+func NewService(homeDir string, label string) Service {
+	return Service{
+		homeDir: homeDir,
+		label:   label,
+	}
+}
+
+// Load will load the service
+func (s Service) Load(force bool) error {
+	G.Log.Info("Loading %s", s.label)
+	// Unload first if we're forcing
+	plistDest := s.plistDestination()
+	if force {
+		exec.Command("/bin/launchctl", "unload", plistDest).Output()
+	}
+	_, err := exec.Command("/bin/launchctl", "load", "-w", plistDest).Output()
+	return err
+}
+
+// Unload will unload the service
+func (s Service) Unload() error {
+	plistDest := s.plistDestination()
+	G.Log.Info("Unloading %s", s.label)
+	_, err := exec.Command("/bin/launchctl", "unload", plistDest).Output()
+	return err
+}
+
+// Install will install the launchd service
+func (s Service) Install(binPath string, logDir string) (err error) {
+	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+		return err
+	}
+	plist := s.plist(binPath, logDir)
+	plistDest := s.plistDestination()
+
+	G.Log.Info("Saving %s", plistDest)
+	file := libkb.NewFile(plistDest, []byte(plist), 0644)
+	err = file.Save()
+	if err != nil {
+		return
+	}
+
+	err = s.Load(true)
+	return
+}
+
+// Uninstall will uninstall the launchd service
+func (s Service) Uninstall() (err error) {
+	err = s.Unload()
+	if err != nil {
+		return
+	}
+
+	plistDest := s.plistDestination()
+	if _, err := os.Stat(plistDest); err == nil {
+		G.Log.Info("Removing %s", plistDest)
+		err = os.Remove(plistDest)
+	}
+	return
+}
+
+// ListServices will return keybase services.
+func ListServices(homeDir string) ([]Service, error) {
+	files, err := ioutil.ReadDir(launchAgentDir(homeDir))
+	if err != nil {
+		return nil, err
+	}
+	var services []Service
+	for _, f := range files {
+		name := f.Name()
+		suffix := ".plist"
+		// We care about services that contain the word "keybase"
+		if strings.Contains(name, "keybase") && strings.HasSuffix(name, suffix) {
+			label := name[0 : len(name)-len(suffix)]
+			service := NewService(homeDir, label)
+			services = append(services, service)
+		}
+	}
+	return services, nil
+}
+
+// ServiceStatus defines status for a service
+type ServiceStatus struct {
+	label          string
+	pid            string // May be blank if not set, or a number "123"
+	lastExitStatus string // Will be blank if pid > 0, or a number "123"
+}
+
+// Description returns service status info
+func (s ServiceStatus) Description() string {
+	var status string
+	infos := []string{}
+	if s.pid != "" {
+		status = "Running"
+		infos = append(infos, fmt.Sprintf("(pid=%s)", s.pid))
+	} else {
+		status = "Not Running"
+	}
+	if s.lastExitStatus != "" {
+		infos = append(infos, fmt.Sprintf("exit=%s", s.lastExitStatus))
+	}
+	return status + " " + strings.Join(infos, ", ")
+}
+
+// Status returns service status
+func (s Service) Status() (status ServiceStatus, err error) {
+	out, err := exec.Command("/bin/launchctl", "list").Output()
+	if err != nil {
+		return
+	}
+
+	scanner := bufio.NewScanner(bytes.NewBuffer(out))
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		if len(fields) == 3 && fields[2] == s.label {
+			if fields[0] != "-" {
+				status.pid = fields[0]
+			}
+			if fields[1] != "-" {
+				status.lastExitStatus = fields[1]
+			}
+			status.label = fields[2]
+			break
+		}
+	}
+
+	// If pid is set and > 0, then clear lastExitStatus which is the
+	// exit status of the previous run and doesn't mean anything for
+	// the current state. Clearing it to avoid confusion.
+	pid, _ := strconv.ParseInt(status.pid, 0, 64)
+	if status.pid != "" && pid > 0 {
+		status.lastExitStatus = ""
+	}
+
+	return
+}
+
+// ShowServices ouputs keybase service info
+func ShowServices(homeDir string) (err error) {
+	services, err := ListServices(homeDir)
+	if err != nil {
+		return
+	}
+	if len(services) > 0 {
+		G.Log.Info("Found %s:", libkb.Pluralize(len(services), "service", "services"))
+		for _, service := range services {
+			status, err := service.Status()
+			if err != nil {
+				G.Log.Info("%s: %v", service.label, err)
+			} else {
+				G.Log.Info("%s: %s", service.label, status.Description())
+			}
+		}
+	} else {
+		G.Log.Info("No services")
+	}
+	return
+}
+
+// Install will install a keybase service
+func Install(homeDir string, label string, installBin string, logDir string) (err error) {
+	service := NewService(homeDir, label)
+	err = service.Install(installBin, logDir)
+	return
+}
+
+// Uninstall will uninstall a keybase service
+func Uninstall(homeDir string, label string) error {
+	service := NewService(homeDir, label)
+	return service.Uninstall()
+}
+
+// ShowStatus shows status info for a service
+func ShowStatus(homeDir string, label string) error {
+	service := NewService(homeDir, label)
+	status, err := service.Status()
+	if err != nil {
+		return err
+	}
+	G.Log.Info(status.Description())
+	return nil
+}
+
+func launchAgentDir(homeDir string) string {
+	return filepath.Join(homeDir, "Library", "LaunchAgents")
+}
+
+func (s Service) plistDestination() string {
+	return filepath.Join(launchAgentDir(s.homeDir), s.label+".plist")
+}
+
+func (s Service) plist(binPath string, logDir string) string {
+	logFile := filepath.Join(logDir, s.label+".G.Log")
+
+	return `<?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>` + s.label + `</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>` + binPath + `</string>
+        <string>--G.Log-format=file</string>
+        <string>service</string>
+      </array>
+      <key>KeepAlive</key>
+      <true/>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>StandardErrorPath</key>
+      <string>` + logFile + `</string>
+      <key>StandardOutPath</key>
+      <string>` + logFile + `</string>
+    </dict>
+    </plist>`
+}

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -365,7 +365,20 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 	app.Commands = []cli.Command{}
 }
 
+func filter(cmds []cli.Command, fn func(cli.Command) bool) []cli.Command {
+	var filter []cli.Command
+	for _, cmd := range cmds {
+		if fn(cmd) {
+			filter = append(filter, cmd)
+		}
+	}
+	return filter
+}
+
 func (p *CommandLine) AddCommands(cmds []cli.Command) {
+	cmds = filter(cmds, func(c cli.Command) bool {
+		return c.Name != ""
+	})
 	p.app.Commands = append(p.app.Commands, cmds...)
 }
 

--- a/go/libkb/file.go
+++ b/go/libkb/file.go
@@ -1,0 +1,34 @@
+package libkb
+
+import (
+	"io"
+	"os"
+)
+
+// File defines a default SafeWriter implementation
+type File struct {
+	filename string
+	data     []byte
+	perm     os.FileMode
+}
+
+// NewFile returns a File
+func NewFile(filename string, data []byte, perm os.FileMode) File {
+	return File{filename, data, perm}
+}
+
+// Save file
+func (f File) Save() error {
+	return SafeWriteToFile(f, f.perm)
+}
+
+// GetFilename is for SafeWriter
+func (f File) GetFilename() string {
+	return f.filename
+}
+
+// WriteTo is for SafeWriter
+func (f File) WriteTo(w io.Writer) (int64, error) {
+	n, err := w.Write(f.data)
+	return int64(n), err
+}

--- a/go/libkb/file_test.go
+++ b/go/libkb/file_test.go
@@ -1,0 +1,19 @@
+package libkb
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFileSave(t *testing.T) {
+	filename := "file_test.tmp"
+
+	defer os.Remove(filename)
+
+	file := NewFile(filename, []byte("test data"), 0644)
+	t.Logf("Saving")
+	err := file.Save()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/go/libkb/keyring.go
+++ b/go/libkb/keyring.go
@@ -137,7 +137,7 @@ func (k KeyringFile) WriteTo(w io.Writer) (int64, error) {
 func (k KeyringFile) GetFilename() string { return k.filename }
 
 func (k KeyringFile) Save() error {
-	return SafeWriteToFile(k)
+	return SafeWriteToFile(k, 0)
 }
 
 type SecretKeyType int

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -553,7 +553,7 @@ func (k *SKBKeyringFile) Save(lui LogUI) error {
 	if !k.dirty {
 		return nil
 	}
-	if err := SafeWriteToFile(*k); err != nil {
+	if err := SafeWriteToFile(*k, 0); err != nil {
 		return err
 	}
 	k.dirty = false

--- a/go/libkb/tmpfile.go
+++ b/go/libkb/tmpfile.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+// TempFile creates a termporary file. Use mode=0 for default permissions.
 func TempFile(prefix string, mode os.FileMode) (string, *os.File, error) {
 	buf, err := RandBytes(20)
 	if err != nil {

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -127,10 +127,11 @@ type SafeWriter interface {
 	WriteTo(io.Writer) (int64, error)
 }
 
-func SafeWriteToFile(t SafeWriter) error {
+// SafeWriteToFile to safely write to a file. Use mode=0 for default permissions.
+func SafeWriteToFile(t SafeWriter, mode os.FileMode) error {
 	fn := t.GetFilename()
 	G.Log.Debug(fmt.Sprintf("+ Writing to %s", fn))
-	tmpfn, tmp, err := TempFile(fn, PermFile)
+	tmpfn, tmp, err := TempFile(fn, mode)
 	G.Log.Debug(fmt.Sprintf("| Temporary file generated: %s", tmpfn))
 	if err != nil {
 		return err
@@ -146,12 +147,23 @@ func SafeWriteToFile(t SafeWriter) error {
 			os.Remove(tmpfn)
 		}
 	} else {
-		G.Log.Error(fmt.Sprintf("Error writing temporary keyring %s: %s", tmpfn, err))
+		G.Log.Error(fmt.Sprintf("Error writing temporary file %s: %s", tmpfn, err))
 		tmp.Close()
 		os.Remove(tmpfn)
 	}
 	G.Log.Debug(fmt.Sprintf("- Wrote to %s -> %s", fn, ErrToOk(err)))
 	return err
+}
+
+// Pluralize returns pluralized string with value.
+// For example,
+//   Pluralize(1, "zebra", "zebras") => "1 zebra"
+//   Pluralize(2, "zebra", "zebras") => "2 zebras"
+func Pluralize(n int, singular string, plural string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, singular)
+	}
+	return fmt.Sprintf("%d %s", n, plural)
 }
 
 func IsIn(needle string, haystack []string, ci bool) bool {

--- a/go/libkb/version.go
+++ b/go/libkb/version.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 )
 
-// Current version (should be MAJOR.MINOR.PATCH)
+// Version as MAJOR.MINOR.PATCH
 const Version = "1.0.0"
-const Build = "9"
 
+// Build number
+const Build = "11"
+
+// VersionString returns semantic version string.
 // If devel, include build in version string (for development releases), for
 // example, "1.2.3-400". Otherwise only return version string as
 // MAJOR.MINOR.PATCH. For example, "1.2.3".

--- a/osx/Install/brew/README.md
+++ b/osx/Install/brew/README.md
@@ -1,14 +1,20 @@
 
-Tag release: v1.0.0-beta.8
-Update source archive ...client/archive/v1.0.0-beta.8.tar.gz
-Update source archive SHA256 in keybase.rb: `shasum -a 256 client-1.0.0-beta.8.tar.gz`
+Tag release: v1.0.0-8 (should match libkb/version.go)
+Update source archive ...client/archive/v1.0.0-8.tar.gz
+Update source archive SHA256 in keybase.rb: `shasum -a 256 client-1.0.0-8.tar.gz`
 
-To bottle:
+To create bottle:
 
     brew install --build-bottle keybase.rb
-    brew bottle keybase.rb
 
-
-To build from source:
+To install from source:
 
     brew install --build-from-source keybase.rb
+
+To install from bottle:
+
+    brew install --force-bottle keybase.rb
+
+To install locally, edit formula to use your GOPATH, and then:
+
+    brew install --HEAD keybase.rb

--- a/osx/Install/brew/keybase.rb
+++ b/osx/Install/brew/keybase.rb
@@ -2,73 +2,35 @@ class Keybase < Formula
   desc "Keybase"
   homepage "https://keybase.io/"
 
-  # Just for testing since brew can't access private repo
-  url "https://keybase-app.s3.amazonaws.com/client-1.0.0-beta.8.tar.gz"
-  #url "https://github.com/keybase/client/archive/v1.0.0-beta.8.tar.gz"
+  #url "https://github.com/keybase/client/archive/v1.0.0-11.tar.gz"
+  #sha256 "645bf9ea42bd8ea17f1212a1d04ac3aafab4faa70bbe9da4ae66ebc4e18b8e47"
 
-  sha256 "645bf9ea42bd8ea17f1212a1d04ac3aafab4faa70bbe9da4ae66ebc4e18b8e47"
   head "https://github.com/keybase/client.git"
-  version "1.0.0-beta.8"
+  version "1.0.0-11"
 
-  bottle do
-    cellar :any
-
-    # Just for testing since brew can't access private repo
-    root_url "https://keybase-app.s3.amazonaws.com"
-    #root_url "https://github.com/keybase/client/releases/download/v1.0.0-beta.8"
-
-    sha256 "3c8eeac9fd3012158713f477d907ddae806c4c910da568ec971c9fb33ed055b2" => :yosemite
-  end
+  # bottle do
+  #   cellar :any
+  #   root_url "https://github.com/keybase/client/releases/download/v1.0.0-11"
+  #   sha256 "3c8eeac9fd3012158713f477d907ddae806c4c910da568ec971c9fb33ed055b2" => :yosemite
+  # end
 
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    system "go", "get", "-u", "github.com/keybase/client/go/keybase"
+    # ENV["GOPATH"] = buildpath
+    # system "go", "get", "-u", "github.com/keybase/client/go/keybase"
+
+    # Currently doing local installs since repo is private
+    ENV["GOPATH"] = "/Users/gabe/Projects/go"
     system "go", "build", "-a", "github.com/keybase/client/go/keybase"
+
+
     bin.install "keybase"
-  end
-
-  def post_install
-    # Automatically restart (unload/load) the service
-    Dir.glob("#{opt_prefix}/*.plist").each do |plist_source_path|
-      plist_dest_path = "#{ENV['HOME']}/Library/LaunchAgents/#{File.basename(plist_source_path)}"
-
-      rm plist_dest_path
-      cp plist_source_path, "#{ENV['HOME']}/Library/LaunchAgents/"
-
-      system "launchctl", "unload", plist_dest_path
-      system "launchctl", "load", "-w", plist_dest_path
-    end
-  end
-
-  def plist; <<-EOS.undent
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/keybase</string>
-        <string>--log-format=file</string>
-        <string>service</string>
-      </array>
-      <key>KeepAlive</key>
-      <true/>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>StandardErrorPath</key>
-      <string>#{ENV['HOME']}/Library/Logs/#{plist_name}.log</string>
-      <key>StandardOutPath</key>
-      <string>#{ENV['HOME']}/Library/Logs/#{plist_name}.log</string>
-    </dict>
-    </plist>
-    EOS
+    keybase_bin = "#{bin}/keybase"
+    system keybase_bin, "launchd", "install", "homebrew.mxcl.keybase", keybase_bin
   end
 
   test do
-    system "#{bin}/keybase", "version"
+    system "#{bin}/keybase", "version", "-d"
   end
 end


### PR DESCRIPTION
The brew formula will install the `keybase` executable and then run:

`/path/to/keybase launchd install homebrew.mxcl.keybase /path/to/keybase`

This doesn't include automatically repairing or starting the service if it's not running. That can come next.

It does report useful information via `keybase launchd list` which will help with debugging if there are issues.
