### PR TITLE
logger: add proper stubs for null

### DIFF
--- a/go/logger/null.go
+++ b/go/logger/null.go
@@ -1,14 +1,37 @@
 package logger
 
+import (
+	keybase1 "github.com/keybase/client/protocol/go"
+	"golang.org/x/net/context"
+)
+
 type Null struct{}
 
 func NewNull() *Null {
 	return &Null{}
 }
 
-func (l *Null) Debug(format string, args ...interface{})    {}
-func (l *Null) Info(format string, args ...interface{})     {}
-func (l *Null) Warning(format string, args ...interface{})  {}
-func (l *Null) Notice(format string, args ...interface{})   {}
-func (l *Null) Errorf(format string, args ...interface{})   {}
-func (l *Null) Critical(format string, args ...interface{}) {}
+// Verify Null fully implements the Logger interface.
+var _ Logger = (*Null)(nil)
+
+func (l *Null) Debug(format string, args ...interface{})                       {}
+func (l *Null) Info(format string, args ...interface{})                        {}
+func (l *Null) Warning(format string, args ...interface{})                     {}
+func (l *Null) Notice(format string, args ...interface{})                      {}
+func (l *Null) Errorf(format string, args ...interface{})                      {}
+func (l *Null) Critical(format string, args ...interface{})                    {}
+func (l *Null) CCriticalf(ctx context.Context, fmt string, arg ...interface{}) {}
+func (l *Null) Fatalf(fmt string, arg ...interface{})                          {}
+func (l *Null) CFatalf(ctx context.Context, fmt string, arg ...interface{})    {}
+func (l *Null) Profile(fmts string, arg ...interface{})                        {}
+func (l *Null) CDebugf(ctx context.Context, fmt string, arg ...interface{})    {}
+func (l *Null) CInfof(ctx context.Context, fmt string, arg ...interface{})     {}
+func (l *Null) CNoticef(ctx context.Context, fmt string, arg ...interface{})   {}
+func (l *Null) CWarningf(ctx context.Context, fmt string, arg ...interface{})  {}
+func (l *Null) CErrorf(ctx context.Context, fmt string, arg ...interface{})    {}
+func (l *Null) Error(fmt string, arg ...interface{})                           {}
+func (l *Null) Configure(style string, debug bool, filename string)            {}
+func (l *Null) RotateLogFile() error                                           { return nil }
+func (l *Null) AddExternalLogger(ExternalLogger) uint64                        { return 0 }
+func (l *Null) RemoveExternalLogger(uint64)                                    {}
+func (l *Null) SetExternalLogLevel(level keybase1.LogLevel)                    {}

--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -80,6 +80,9 @@ func New(module string) *Standard {
 	return NewWithCallDepth(module, 0)
 }
 
+// Verify Standard fully implements the Logger interface.
+var _ Logger = (*Standard)(nil)
+
 // NewWithCallDepth creates a new Standard logger for module, and when
 // printing file names and line numbers, it goes extraCallDepth up the
 // stack from where logger was invoked.

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -33,6 +33,9 @@ func NewTestLogger(log TestLogBackend) *TestLogger {
 	return &TestLogger{log: log}
 }
 
+// Verify TestLogger fully implements the Logger interface.
+var _ Logger = (*TestLogger)(nil)
+
 func prefixCaller(fmts string) string {
 	// The testing library doesn't let us control the stack depth, so
 	// just print the file and line number ourselves.


### PR DESCRIPTION
I wanted to use the `Null` implementation and noticed the issue.
