### PR TITLE
Fix command required (it's not)

### DIFF
--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -53,8 +53,7 @@ func mainInner(g *libkb.GlobalContext) error {
 	}
 
 	if cmd == nil {
-		err = fmt.Errorf("No command selected")
-		return err
+		return nil
 	}
 
 	if !cl.IsService() {


### PR DESCRIPTION
The default command is help, so it's ok if no command is passed in.

This also fixes `--help`.
