### PR TITLE
Remove unused args to ping endpoint

### DIFF
--- a/go/client/cmd_ping.go
+++ b/go/client/cmd_ping.go
@@ -11,14 +11,7 @@ import (
 type CmdPing struct{}
 
 func (v *CmdPing) Run() error {
-	_, err := G.API.Post(libkb.APIArg{
-		Endpoint: "ping",
-		Args: libkb.HTTPArgs{
-			"alice":   libkb.S{Val: "hi alice"},
-			"bob":     libkb.I{Val: 1000},
-			"charlie": libkb.B{Val: true},
-		},
-	})
+	_, err := G.API.Post(libkb.APIArg{Endpoint: "ping"})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The ping endpoint doesn't look at these anymore
