### PR TITLE
Print a warning message when you are on a non prod run mode

### DIFF
--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -43,7 +43,7 @@ func main() {
 func warnNonProd(log logger.Logger, e *libkb.Env) {
 	mode := e.GetRunMode()
 	if mode != libkb.ProductionRunMode {
-		log.Warning(fmt.Sprintf("Running in %s mode", mode))
+		log.Warning("Running in %s mode", mode)
 	}
 }
 


### PR DESCRIPTION
Looks like: 
![screen shot 2015-09-02 at 6 22 45 pm](https://cloud.githubusercontent.com/assets/594035/9669206/961dc66c-523a-11e5-8e42-9324f702104a.png)

Addresses: #749 

This will change a bit when https://github.com/keybase/client/pull/744 gets merged, but it's a small change (and I can wait until that gets merged before merging this)
