### PR TITLE
Remove unused import

### DIFF
--- a/go/client/commands_release.go
+++ b/go/client/commands_release.go
@@ -5,8 +5,6 @@
 package client
 
 import (
-	"runtime"
-
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 )


### PR DESCRIPTION
This wasn't being used and broke the release build.

Maybe we should add a step in travis that tries to build the client?
