### PR TITLE
Don't cache errors in ResolveCache, fixes #784

### DIFF
--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -64,14 +64,18 @@ func resolveUID(au AssertionURL) ResolveResult {
 	}
 
 	r := resolveUsername(au)
+
 	if r.err != nil {
+		// Don't add to the cache if the resolve failed.
 		return r
 	}
 
-	if au.IsKeybase() {
-		G.ResolveCache.Put(ck, r)
+	if !au.IsKeybase() {
+		// Don't add to the cache if it's a mutable identity.
+		return r
 	}
 
+	G.ResolveCache.Put(ck, r)
 	return r
 }
 


### PR DESCRIPTION
Some open questions here:
- I'm sure we agree that "connection refused" shouldn't be cached.  But should other types of errors, like "user not found"? ( If so, is there a way other than string compare to distinguish them?)
- Should I add tests for this?  Not sure how I'd mock/simulate a network problem.
