### PR TITLE
Allow a label to be passed into service.

### DIFF
--- a/go/launchd/launchd.go
+++ b/go/launchd/launchd.go
@@ -291,7 +291,14 @@ func (p Plist) plist() string {
 	}
 
 	pargs := []string{}
+
+	// First arg is the keybase executable
 	pargs = append(pargs, encodeString(p.binPath))
+
+	// Pass the label so clients can see where service was installed
+	labelArg := fmt.Sprintf("--label=%s", p.label)
+	pargs = append(pargs, encodeString(labelArg))
+
 	for _, arg := range p.args {
 		pargs = append(pargs, encodeString(arg))
 	}

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -84,6 +84,9 @@ func (p CommandLine) GetUsername() libkb.NormalizedUsername {
 func (p CommandLine) GetLogFormat() string {
 	return p.GetGString("log-format")
 }
+func (p CommandLine) GetLabel() string {
+	return p.GetGString("label")
+}
 func (p CommandLine) GetGpgHome() string {
 	return p.GetGString("gpg-home")
 }
@@ -298,6 +301,10 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 		cli.StringFlag{
 			Name:  "log-format",
 			Usage: "Log format (default, plain, file, fancy).",
+		},
+		cli.StringFlag{
+			Name:  "label",
+			Usage: "Specifying a label can help identify services.",
 		},
 		cli.StringFlag{
 			Name:  "pgpdir, gpgdir",

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -424,6 +424,9 @@ func (f JSONConfigFile) GetAutoFork() (bool, bool) {
 func (f JSONConfigFile) GetLogFormat() string {
 	return f.GetTopLevelString("log_format")
 }
+func (f JSONConfigFile) GetLabel() string {
+	return f.GetTopLevelString("label")
+}
 func (f JSONConfigFile) GetStandalone() (bool, bool) {
 	return f.GetTopLevelBool("standalone")
 }

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -68,6 +68,9 @@ func (n NullConfiguration) GetDebug() (bool, bool) {
 func (n NullConfiguration) GetLogFormat() string {
 	return ""
 }
+func (n NullConfiguration) GetLabel() string {
+	return ""
+}
 func (n NullConfiguration) GetAPIDump() (bool, bool) {
 	return false, false
 }
@@ -374,6 +377,14 @@ func (e *Env) GetLogFormat() string {
 		func() string { return e.cmd.GetLogFormat() },
 		func() string { return os.Getenv("KEYBASE_LOG_FORMAT") },
 		func() string { return e.config.GetLogFormat() },
+	)
+}
+
+func (e *Env) GetLabel() string {
+	return e.GetString(
+		func() string { return e.cmd.GetLabel() },
+		func() string { return os.Getenv("KEYBASE_LABEL") },
+		func() string { return e.config.GetLabel() },
 	)
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -29,6 +29,7 @@ type CommandLine interface {
 	GetDebug() (bool, bool)
 	GetProxy() string
 	GetLogFormat() string
+	GetLabel() string
 	GetGpgHome() string
 	GetAPIDump() (bool, bool)
 	GetUserCacheSize() (int, bool)
@@ -89,6 +90,7 @@ type ConfigReader interface {
 	GetUserConfigForUsername(s NormalizedUsername) (*UserConfig, error)
 	GetProxy() string
 	GetLogFormat() string
+	GetLabel() string
 	GetGpgHome() string
 	GetBundledCA(host string) string
 	GetStringAtPath(string) (string, bool)

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -47,6 +47,7 @@ func (h ConfigHandler) GetConfig(sessionID int) (keybase1.Config, error) {
 	}
 
 	c.ConfigPath = G.Env.GetConfigFilename()
+	c.Label = G.Env.GetLabel()
 
 	return c, nil
 }

--- a/protocol/avdl/config.avdl
+++ b/protocol/avdl/config.avdl
@@ -16,6 +16,7 @@ protocol config {
 	record Config {
 		string serverURI;
 		string socketFile;
+		string label;
 		boolean gpgExists;
 		string gpgPath;
 		string version;

--- a/protocol/go/keybase_v1.go
+++ b/protocol/go/keybase_v1.go
@@ -283,6 +283,7 @@ type GetCurrentStatusRes struct {
 type Config struct {
 	ServerURI  string `codec:"serverURI" json:"serverURI"`
 	SocketFile string `codec:"socketFile" json:"socketFile"`
+	Label      string `codec:"label" json:"label"`
 	GpgExists  bool   `codec:"gpgExists" json:"gpgExists"`
 	GpgPath    string `codec:"gpgPath" json:"gpgPath"`
 	Version    string `codec:"version" json:"version"`

--- a/protocol/json/config.json
+++ b/protocol/json/config.json
@@ -181,6 +181,9 @@
       "name" : "socketFile",
       "type" : "string"
     }, {
+      "name" : "label",
+      "type" : "string"
+    }, {
       "name" : "gpgExists",
       "type" : "boolean"
     }, {

--- a/protocol/objc/KBRPC.h
+++ b/protocol/objc/KBRPC.h
@@ -87,6 +87,7 @@ typedef NS_ENUM (NSInteger, KBRLogLevel) {
 @interface KBRConfig : KBRObject
 @property NSString *serverURI;
 @property NSString *socketFile;
+@property NSString *label;
 @property BOOL gpgExists;
 @property NSString *gpgPath;
 @property NSString *version;


### PR DESCRIPTION
This helps me figure out how a service running was installed, either by
homebrew or by the app. This is really helpful, for dealing with how to
upgrade from homebrew.
