### PR TITLE
Env GetServerURI should get default from run mode.

### DIFF
--- a/go/libkb/client.go
+++ b/go/libkb/client.go
@@ -73,15 +73,6 @@ func (e *Env) GenClientConfig() (*ClientConfig, error) {
 	serverURI := e.GetServerURI()
 
 	if serverURI == "" {
-		runMode := RunMode(e.GetRunMode())
-		serverURI = ServerLookup[runMode]
-		if serverURI == "" {
-			err := fmt.Errorf("No server URL for run mode: %s", runMode)
-			return nil, err
-		}
-	}
-
-	if serverURI == "" {
 		err := fmt.Errorf("Cannot find a server URL")
 		return nil, err
 	}

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -295,6 +295,7 @@ func (e *Env) GetServerURI() string {
 		func() string { return e.cmd.GetServerURI() },
 		func() string { return os.Getenv("KEYBASE_SERVER_URI") },
 		func() string { return e.config.GetServerURI() },
+		func() string { return ServerLookup[e.GetRunMode()] },
 	)
 }
 


### PR DESCRIPTION
Fixes bug where env.GetServerURI returns ""
