### PR TITLE
Using different default run mode for release.

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -32,8 +32,6 @@ var ServerLookup = map[RunMode]string{
 	ProductionRunMode: ProductionServerURI,
 }
 
-const DefaultRunMode = DevelRunMode
-
 const (
 	ConfigFile  = "config.json"
 	SessionFile = "session.json"

--- a/go/libkb/constants_devel.go
+++ b/go/libkb/constants_devel.go
@@ -1,0 +1,5 @@
+// +build !release
+
+package libkb
+
+const DefaultRunMode = DevelRunMode

--- a/go/libkb/constants_release.go
+++ b/go/libkb/constants_release.go
@@ -1,0 +1,5 @@
+// +build release
+
+package libkb
+
+const DefaultRunMode = StagingRunMode


### PR DESCRIPTION
When I am building the homebrew, it can specify release tag. This is so client and service default run modes match to staging in this case. `go build -tags release ...`
