### PR TITLE
Split up ConfigureAll

### DIFF
--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -70,6 +70,7 @@ func mainInner(g *libkb.GlobalContext) error {
 	if err = g.ConfigureAll(cl, cmd); err != nil {
 		return err
 	}
+	g.StartupMessage()
 
 	warnNonProd(g.Log, g.Env)
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -249,13 +249,17 @@ func (u Usage) UseKeyring() bool {
 }
 
 func (g *GlobalContext) ConfigureAll(line CommandLine, cmd Command) error {
-	var err error
 
 	g.SetCommandLine(line)
 
 	g.ConfigureLogging()
 
 	usage := cmd.GetUsage()
+	return g.ConfigureUsage(usage)
+}
+
+func (g *GlobalContext) ConfigureUsage(usage Usage) error {
+	var err error
 
 	if usage.Config {
 		if err = g.ConfigureConfig(); err != nil {
@@ -299,7 +303,6 @@ func (g *GlobalContext) ConfigureAll(line CommandLine, cmd Command) error {
 		return err
 	}
 
-	G.StartupMessage()
 	return nil
 }
 


### PR DESCRIPTION
Minor tweak allows you to configure from `libkb.Usage` object. Removes the need for a "dummy command".

Also moving the debug StartupMessage into main since it's a CLI thing.
