### PR TITLE
Allow running tests in devel or staging

### DIFF
--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -167,7 +167,6 @@ func setupTestContext(t *testing.T, nm string) (tc TestContext, err error) {
 	tc.Tp.GPGHome = tc.Tp.Home
 	tc.Tp.GPGOptions = []string{"--homedir=" + tc.Tp.GPGHome}
 
-	tc.Tp.ServerURI = DevelServerURI
 	tc.Tp.Debug = false
 	tc.Tp.Devel = true
 	g.Env.Test = tc.Tp


### PR DESCRIPTION
For: https://github.com/keybase/client/issues/750

We talked about disabling dangerous tests on prod, but it turns out you can't even get to a state to run dangerous/registration tests on prod.

You couldn't even run tests against staging. Which is a problem because we want external contributors to be able to run their tests against staging so they don't have to have a local instance of the server.

This currently fails on staging because of errors like:
​`user t_doug has no active keys`​

and

​`Result is: 429 Too Many Requests`​

but those errors are orthogonal to this code. So we can review this and deal with those errors separately.
