### PR TITLE
using manual babelrc to ensure correct things are turned on

### DIFF
--- a/ios/.babelrc
+++ b/ios/.babelrc
@@ -1,0 +1,26 @@
+// Keep in sync with packager/transformer.js
+{
+  "retainLines": true,
+  "compact": true,
+  "comments": false,
+  "whitelist": [
+    "es6.arrowFunctions",
+    "es6.blockScoping",
+    // This is the only place where we differ from transformer.js
+    "es6.constants",
+    "es6.classes",
+    "es6.destructuring",
+    "es6.parameters",
+    "es6.properties.computed",
+    "es6.properties.shorthand",
+    "es6.spread",
+    "es6.templateLiterals",
+    "es7.asyncFunctions",
+    "es7.trailingFunctionCommas",
+    "es7.objectRestSpread",
+    "flow",
+    "react",
+    "regenerator"
+  ],
+  "sourceMaps": false
+}


### PR DESCRIPTION
This should fix those weird errors about 'const' not existing

@MarcoPolo 
