### PR TITLE
Check passphrase stream exists before device prov

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -101,6 +101,7 @@ const (
 	SCGeneric                = 218
 	SCAlreadyLoggedIn        = 235
 	SCCanceled               = 237
+	SCReloginRequired        = 274
 	SCBadSignupUsernameTaken = 701
 	SCKeyNotFound            = 901
 	SCKeyInUse               = 907

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -429,6 +429,12 @@ func (e LoginRequiredError) Error() string {
 	return msg
 }
 
+type ReloginRequiredError struct{}
+
+func (e ReloginRequiredError) Error() string {
+	return "Login required due to an unexpected error since your previous login."
+}
+
 //=============================================================================
 
 type LogoutError struct{}

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -214,6 +214,8 @@ func ImportStatusAsError(s *keybase1.Status) error {
 		return ReceiverDeviceError{Msg: s.Desc}
 	case SCBadKexPhrase:
 		return InvalidKexPhraseError{}
+	case SCReloginRequired:
+		return ReloginRequiredError{}
 	default:
 		ase := AppStatusError{
 			Code:   s.Code,
@@ -721,6 +723,14 @@ func (e InvalidKexPhraseError) ToStatus() keybase1.Status {
 	return keybase1.Status{
 		Code: SCBadKexPhrase,
 		Name: "SC_BAD_KEX_PHRASE",
+		Desc: e.Error(),
+	}
+}
+
+func (e ReloginRequiredError) ToStatus() keybase1.Status {
+	return keybase1.Status{
+		Code: SCReloginRequired,
+		Name: "SC_RELOGIN_REQUIRED",
 		Desc: e.Error(),
 	}
 }


### PR DESCRIPTION
The passphrase stream cache needs to exist before a
device is provisioned.  Locksmith had an error for
this situation before, but it left the user in an odd
state.

With these changes, it ensures that the passphrase
stream is available before attempting to device
provision or repair the user's device keys.

Also, the login engine detects a missing passphrase
stream before trying to use Locksmith to provision a
device.  If it's missing, it logs the user out and tells
them to log in again.

This should fix #872.

One way to get into this state is:
1. The user is logging in for the first time on a device.
2. Before the device is provisioned, the login is canceled or
   interrupted, but they do successfully get a login
   session.
3. The daemon restarts (`ctl stop`, machine reboot, bug, etc.)
4. The login session is still valid, so the next login attempt
   does not require a passphrase, and the passphrase
   stream has been lost due to daemon restart.

There's a new test for this scenario: TestLoginRestartProvision
It exhibited similar behavior to the stack trace in #872
and is fixed by these changes.
