### PR TITLE
minimum target 8.0 and update alamo fire to use swift 2

### DIFF
--- a/react-native/ios/Keybase.xcodeproj/project.pbxproj
+++ b/react-native/ios/Keybase.xcodeproj/project.pbxproj
@@ -718,6 +718,7 @@
 					"$(SRCROOT)/KeybaseGo",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Keybase/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -753,6 +754,7 @@
 					"$(SRCROOT)/KeybaseGo",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Keybase/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -924,6 +926,7 @@
 					"$(SRCROOT)/KeybaseGo",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Keybase/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",

--- a/react-native/ios/Podfile.lock
+++ b/react-native/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - Alamofire (1.3.1)
+  - Alamofire (2.0.1)
 
 DEPENDENCIES:
   - Alamofire
 
 SPEC CHECKSUMS:
-  Alamofire: e4ab637e3195b645c814b87a652373439e59f2a4
+  Alamofire: 1d8e208d616fbbfd2391b15eae766d07c96cdc49
 
 COCOAPODS: 0.38.2


### PR DESCRIPTION
@MarcoPolo Updates ios target to 8 and updates podfiles so xcode 7 works
