### PR TITLE
ios init with homedir/run_mode

### DIFF
--- a/go/loopback/main.go
+++ b/go/loopback/main.go
@@ -36,17 +36,17 @@ func (n debuggingConfig) GetLocalRPCDebug() string {
 func (n debuggingConfig) GetRunMode() (libkb.RunMode, error) {
 	if n.runMode == nil {
 		return libkb.DevelRunMode, nil
-	} else {
-		return libkb.StringToRunMode(*n.runMode)
 	}
+
+	return libkb.StringToRunMode(*n.runMode)
 }
 
 func (n debuggingConfig) GetHome() string {
 	if n.homeDir == nil {
 		return ""
-	} else {
-		return *n.homeDir
 	}
+
+	return *n.homeDir
 }
 
 func (d dummyCmd) GetUsage() libkb.Usage {
@@ -74,7 +74,6 @@ func Init(homeDir string, runMode string) {
 func WriteB64(str string) {
 	data, err := base64.StdEncoding.DecodeString(str)
 	if err == nil {
-		start(debuggingConfig{})
 		con.Write(data)
 	} else {
 		fmt.Println("write error:", err, str)
@@ -84,7 +83,6 @@ func WriteB64(str string) {
 // Blocking read, returns base64 encoded msgpack rpc payload
 func ReadB64() string {
 	data := make([]byte, 50*1024)
-	start(debuggingConfig{})
 
 	n, err := con.Read(data)
 	if n > 0 && err == nil {

--- a/react-native/ios/Keybase/AppDelegate.h
+++ b/react-native/ios/Keybase/AppDelegate.h
@@ -6,8 +6,10 @@
 
 #import <UIKit/UIKit.h>
 
+@class Engine;
+
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (nonatomic, strong) UIWindow *window;
-
+@property (nonatomic, strong) Engine *engine;
 @end

--- a/react-native/ios/Keybase/AppDelegate.m
+++ b/react-native/ios/Keybase/AppDelegate.m
@@ -5,18 +5,33 @@
 //
 
 #import "AppDelegate.h"
-
 #import "RCTRootView.h"
+#import "ObjcEngine.h"
 
 // Set this to 1 to use the application bundle to hold the react JS
 #define REACT_EMBEDDED_BUNDLE 0
 
+// TODO load off of settings screen
+static NSString* const HOME_DIR = nil; //@"home2";
+static NSString* const RUN_MODE = @"devel";
 
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    NSURL *jsCodeLocation;
+  [self setupEngine];
+  UIView * rootView = [self setupReactWithOptions:launchOptions];
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [[UIViewController alloc] init];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+  return YES;
+}
+
+- (UIView*) setupReactWithOptions:(NSDictionary *)options {
+  NSURL *jsCodeLocation;
 
 #if (REACT_EMBEDDED_BUNDLE)
   // http://facebook.github.io/react-native/docs/runningondevice.html
@@ -32,21 +47,38 @@
 
   // sanity check if you're running on device
   #if !(TARGET_IPHONE_SIMULATOR)
-#warning "You're testing dynamic react on your device. DON'T deploy a build like this"
+    #warning "You're testing dynamic react on your device. DON'T deploy a build like this"
   #endif
 #endif
 
-  RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
-                                                      moduleName:@"Keybase"
-                                               initialProperties:nil
-                                                   launchOptions:launchOptions];
+  return [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
+                                     moduleName:@"Keybase"
+                              initialProperties:nil
+                                  launchOptions:options];
+}
 
-  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [[UIViewController alloc] init];
-  rootViewController.view = rootView;
-  self.window.rootViewController = rootViewController;
-  [self.window makeKeyAndVisible];
-  return YES;
+- (void) setupEngine {
+  NSFileManager* fileManager = [NSFileManager defaultManager];
+  NSArray* possibleURLs = [fileManager URLsForDirectory:NSApplicationSupportDirectory
+                                              inDomains:NSUserDomainMask];
+  NSString* appDirectory = @"";
+
+  if ([possibleURLs count] > 0) {
+    NSURL* appSupportDir = nil;
+
+    appSupportDir = [possibleURLs objectAtIndex:0];
+
+    if (HOME_DIR.length) {
+      appSupportDir = [appSupportDir URLByAppendingPathComponent:HOME_DIR];
+    }
+
+    appDirectory = [appSupportDir path];
+  }
+
+  NSDictionary * settings = @{ @"runmode": RUN_MODE,
+                               @"homedir": appDirectory};
+
+  self.engine = [[Engine alloc] initWithSettings:settings];
 }
 
 @end

--- a/react-native/ios/Keybase/ObjcEngine.h
+++ b/react-native/ios/Keybase/ObjcEngine.h
@@ -8,8 +8,6 @@
 
 #import <Foundation/Foundation.h>
 
-#import "RCTBridgeModule.h"
-
-@interface ObjcEngine : NSObject<RCTBridgeModule>
-
+@interface Engine : NSObject
+- (instancetype) initWithSettings:(NSDictionary*) settings;
 @end

--- a/react-native/ios/Keybase/ObjcEngine.m
+++ b/react-native/ios/Keybase/ObjcEngine.m
@@ -9,15 +9,16 @@
 #import "ObjcEngine.h"
 #import <keybase/keybase.h>
 #import "RCTEventDispatcher.h"
+#import "AppDelegate.h"
 
-@interface Engine : NSObject
+@interface Engine()
 
 @property dispatch_queue_t readQueue;
 @property dispatch_queue_t writeQueue;
 @property (weak) RCTBridge *bridge;
 
 - (void)startReadLoop;
-- (void)initQueues;
+- (void)setupQueues;
 - (void)runWithData:(NSString*) data;
 - (void)reset;
 
@@ -27,26 +28,21 @@
 
 static NSString * const eventName = @"objc-engine-event";
 
-+ (instancetype)sharedInstance
-{
-  static Engine *sharedInstance = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    sharedInstance = [[Engine alloc] init];
-  });
-  return sharedInstance;
-}
-
-- (instancetype) init {
+- (instancetype) initWithSettings:(NSDictionary*) settings {
   if ((self = [super init])) {
-    [self initQueues];
+    [self setupKeybaseWithSettings:settings];
+    [self setupQueues];
     [self startReadLoop];
   }
 
   return self;
 }
 
-- (void) initQueues {
+- (void) setupKeybaseWithSettings:(NSDictionary*) settings {
+  GoKeybaseInit(settings[@"homedir"], settings[@"runmode"]);
+}
+
+- (void) setupQueues {
   self.readQueue = dispatch_queue_create ("go_bridge_queue_read", DISPATCH_QUEUE_SERIAL);
   self.writeQueue = dispatch_queue_create ("go_bridge_queue_write", DISPATCH_QUEUE_SERIAL);
 }
@@ -78,22 +74,32 @@ static NSString * const eventName = @"objc-engine-event";
 
 #pragma mark - Engine exposed to react
 
+@interface ObjcEngine : NSObject<RCTBridgeModule>
+@property (readonly) ObjcEngine* engine;
+@end
+
 @implementation ObjcEngine
+
+- (Engine*) engine {
+  AppDelegate * delegate = [UIApplication sharedApplication].delegate;
+  return delegate.engine;
+}
 
 RCT_EXPORT_MODULE();
 
 // required by reactnative
 @synthesize bridge = _bridge;
 
+
 RCT_EXPORT_METHOD(runWithData: (NSString*) data)
 {
-  [Engine sharedInstance].bridge = _bridge;
-  [[Engine sharedInstance] runWithData: data];
+  self.engine.bridge = _bridge;
+  [self.engine runWithData: data];
 }
 
 RCT_EXPORT_METHOD(reset)
 {
-  [[Engine sharedInstance] reset];
+  [self.engine reset];
 }
 
 - (NSDictionary *)constantsToExport


### PR DESCRIPTION
@MarcoPolo  Note this is a PR to merge into your android branch.

@gabriel this makes the changes to make the engine not an actual singleton but a single instance held by the app delegate

i made some todos (github issues) to actually make a dev settings screen to set things like the runmode and homedir, but its just a static const up top for now
