### PR TITLE
Only enable log forwarding if RPC debugging is off

### DIFF
--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -99,9 +99,13 @@ func mainInner(g *libkb.GlobalContext) error {
 		// mode (as opposed to standalone). Register a global LogUI so that
 		// calls to G.Log() in the daemon can be copied to us. This is
 		// something of a hack on the daemon side.
-		err = registerGlobalLogUI(g)
-		if err != nil {
-			return err
+		if g.Env.GetLocalRPCDebug() != "" {
+			g.Log.Info("Disabling log forwarding due to RPC debugging.")
+		} else {
+			err = registerGlobalLogUI(g)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Otherwise we see perpetual spew from a feedback loop between the two.

Fixes #862.
