### PR TITLE
Add advanced HelpTopic, remove global options display

### DIFF
--- a/go/client/help.go
+++ b/go/client/help.go
@@ -4,6 +4,26 @@ import (
 	"github.com/keybase/cli"
 )
 
+func GetHelpTopics() []cli.HelpTopic {
+	return []cli.HelpTopic{
+		advancedHT,
+	}
+}
+
+var advancedHT = cli.HelpTopic{
+	Name:  "advanced",
+	Usage: "description of advanced global options",
+	Body: `Keybase commands can run with various command line flags to
+configure global options.  To use, add the flags before the command name:
+
+   {{ .Name }} [global options] command [command options]
+
+GLOBAL OPTIONS:
+   {{range .Flags}}{{ . }}
+   {{end}}
+	`,
+}
+
 // Custom help templates for cli package
 
 func init() {
@@ -24,9 +44,9 @@ VERSION:
    {{end}}{{if .Commands}}
 COMMANDS:
    {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
-   {{end}}{{end}}{{if .Flags}}
-GLOBAL OPTIONS:
-   {{range .Flags}}{{.}}
+   {{end}}{{end}}{{if .HelpTopics}}
+ADDITIONAL HELP TOPICS:
+   {{range .HelpTopics}}{{.Name}}{{ "\t\t" }}{{.Usage}}
    {{end}}{{end}}{{if .Copyright }}
 COPYRIGHT:
    {{.Copyright}}

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -51,6 +51,7 @@ func mainInner(g *libkb.GlobalContext) error {
 	cl := libcmdline.NewCommandLine(true, client.GetExtraFlags())
 	cl.AddCommands(client.GetCommands(cl))
 	cl.AddCommands(service.GetCommands(cl))
+	cl.AddHelpTopics(client.GetHelpTopics())
 
 	var err error
 	cmd, err = cl.Parse(os.Args)

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -329,14 +329,6 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 		app.Flags = append(app.Flags, extraFlags...)
 	}
 
-	// Finally, add help if we asked for it
-	if addHelp {
-		app.Action = func(c *cli.Context) {
-			p.cmd = &CmdGeneralHelp{CmdBaseHelp{c}}
-			p.ctx = c
-			p.name = "help"
-		}
-	}
 	app.Commands = []cli.Command{}
 }
 
@@ -406,4 +398,10 @@ func (p *CommandLine) Parse(args []string) (cmd Command, err error) {
 
 func (p *CommandLine) SetOutputWriter(w io.Writer) {
 	p.app.Writer = w
+}
+
+// AddHelpTopics appends topics to the list of help topics for
+// this app.
+func (p *CommandLine) AddHelpTopics(topics []cli.HelpTopic) {
+	p.app.HelpTopics = append(p.app.HelpTopics, topics...)
 }


### PR DESCRIPTION
With new HelpTopic feature in keybase/cli
afca8e2de89ac3486e8e61af44d21da8cedb4487
the app can have help topics not associated with
commands.

Moved all the global options into an `advanced` help
topic.  So `keybase help advanced` will show the global
options.  And `keybase help` will show all the help
topics.

Fixes #887 

CC @maxtaco @gabriel 
