### PR TITLE
autofork: fix bug introduced in e65e694c92e7994ae33be1dc7fbe517e19e6b269

### DIFF
--- a/go/client/fork_server_nix.go
+++ b/go/client/fork_server_nix.go
@@ -38,7 +38,7 @@ func ForkServerNix(cl libkb.CommandLine) error {
 	// If we try to get an exclusive lock and succeed, it means we
 	// need to relaunch the daemon since it's dead
 	G.Log.Debug("Getting flock")
-	err := srv.GetExclusiveLock()
+	err := srv.GetExclusiveLockWithoutAutoUnlock()
 	if err == nil {
 		G.Log.Debug("Flocked! Server must have died")
 		srv.ReleaseLock()


### PR DESCRIPTION
The bug was that the autofork parent deletes both pid files, one explicitly and the second implicitly on shutdown.

Close #927
