### PR TITLE
print brew instructions on Mac

### DIFF
--- a/go/libkb/constants_devel.go
+++ b/go/libkb/constants_devel.go
@@ -3,5 +3,3 @@
 package libkb
 
 const DefaultRunMode = DevelRunMode
-
-const PackageName = "keybase"

--- a/go/libkb/constants_release.go
+++ b/go/libkb/constants_release.go
@@ -5,5 +5,3 @@ package libkb
 // Production run mode currently still unsafe.
 // This will cause the build to fail for this tag on purpose.
 //const DefaultRunMode = ProductionRunMode
-//
-//const PackageName = "keybase"

--- a/go/libkb/constants_staging.go
+++ b/go/libkb/constants_staging.go
@@ -3,5 +3,3 @@
 package libkb
 
 const DefaultRunMode = StagingRunMode
-
-const PackageName = "kbstage"

--- a/go/libkb/upgrade_instructions.go
+++ b/go/libkb/upgrade_instructions.go
@@ -25,18 +25,32 @@ func linuxUpgradeInstructions() {
 		return err == nil
 	}
 
+	packageName := "keybase"
+	if DefaultRunMode == DevelRunMode {
+		packageName = "kbdev"
+	} else if DefaultRunMode == StagingRunMode {
+		packageName = "kbstage"
+	}
+
 	if hasPackageManager("apt-get") {
-		printUpgradeCommand("sudo apt-get update && sudo apt-get install " + PackageName)
+		printUpgradeCommand("sudo apt-get update && sudo apt-get install " + packageName)
 	} else if hasPackageManager("dnf") {
-		printUpgradeCommand("sudo dnf upgrade " + PackageName)
+		printUpgradeCommand("sudo dnf upgrade " + packageName)
 	} else if hasPackageManager("yum") {
-		printUpgradeCommand("sudo yum upgrade " + PackageName)
+		printUpgradeCommand("sudo yum upgrade " + packageName)
 	}
 }
 
 func darwinUpgradeInstructions() {
+	packageName := "keybase"
+	if DefaultRunMode == DevelRunMode {
+		packageName = "keybase/beta/kbdev"
+	} else if DefaultRunMode == StagingRunMode {
+		packageName = "keybase/beta/kbstage"
+	}
+
 	if IsBrewBuild {
-		printUpgradeCommand("brew update && brew upgrade " + PackageName)
+		printUpgradeCommand("brew update && brew upgrade " + packageName)
 	}
 	// TODO: non-brew update instructions
 }


### PR DESCRIPTION
Addresses #730 in the simplest possible way.

@gabriel two (ish) important questions:
1) Do we expect all keybase installations to use brew for the initial release? If not, should we have some mechanism of detecting whether your current install is a brew install?
2) Do we plan on  a package name that is something other than "keybase"? If so, should this message refer to some string constant that you (and I on Linux) will change for our early public builds?
