### PR TITLE
Moving --label option to service definition

### DIFF
--- a/go/client/cmd_launchd_osx.go
+++ b/go/client/cmd_launchd_osx.go
@@ -53,13 +53,13 @@ func NewCmdLaunchdInstall(cl *libcmdline.CommandLine) cli.Command {
 			binPath := args[1]
 
 			plistArgs := []string{}
-			plistArgs = append(plistArgs, fmt.Sprintf("--label=%s", label))
 			plistArgs = append(plistArgs, "--log-format=file")
 			runMode := c.String("run-mode")
 			if runMode != "" {
 				plistArgs = append(plistArgs, fmt.Sprintf("--run-mode=%s", runMode))
 			}
 			plistArgs = append(plistArgs, "service")
+			plistArgs = append(plistArgs, fmt.Sprintf("--label=%s", label))
 
 			envVars := make(map[string]string)
 			envVars["PATH"] = "/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin"

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -80,9 +80,6 @@ func (p CommandLine) GetProxy() string {
 func (p CommandLine) GetLogFormat() string {
 	return p.GetGString("log-format")
 }
-func (p CommandLine) GetLabel() string {
-	return p.GetGString("label")
-}
 func (p CommandLine) GetGpgHome() string {
 	return p.GetGString("gpg-home")
 }
@@ -97,6 +94,9 @@ func (p CommandLine) GetPinentry() string {
 }
 func (p CommandLine) GetGString(s string) string {
 	return p.ctx.GlobalString(s)
+}
+func (p CommandLine) GetString(s string) string {
+	return p.ctx.String(s)
 }
 func (p CommandLine) GetGInt(s string) int {
 	return p.ctx.GlobalInt(s)

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -424,9 +424,6 @@ func (f JSONConfigFile) GetAutoFork() (bool, bool) {
 func (f JSONConfigFile) GetLogFormat() string {
 	return f.GetTopLevelString("log_format")
 }
-func (f JSONConfigFile) GetLabel() string {
-	return f.GetTopLevelString("label")
-}
 func (f JSONConfigFile) GetStandalone() (bool, bool) {
 	return f.GetTopLevelBool("standalone")
 }

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -56,6 +56,7 @@ func (n NullConfiguration) GetUserConfigForUsername(s NormalizedUsername) (*User
 	return nil, nil
 }
 func (n NullConfiguration) GetGString(string) string          { return "" }
+func (n NullConfiguration) GetString(string) string           { return "" }
 func (n NullConfiguration) GetBool(string, bool) (bool, bool) { return false, false }
 
 func (n NullConfiguration) GetAllUsernames() (NormalizedUsername, []NormalizedUsername, error) {
@@ -66,9 +67,6 @@ func (n NullConfiguration) GetDebug() (bool, bool) {
 	return false, false
 }
 func (n NullConfiguration) GetLogFormat() string {
-	return ""
-}
-func (n NullConfiguration) GetLabel() string {
 	return ""
 }
 func (n NullConfiguration) GetAPIDump() (bool, bool) {
@@ -381,9 +379,8 @@ func (e *Env) GetLogFormat() string {
 
 func (e *Env) GetLabel() string {
 	return e.GetString(
-		func() string { return e.cmd.GetLabel() },
+		func() string { return e.cmd.GetString("label") },
 		func() string { return os.Getenv("KEYBASE_LABEL") },
-		func() string { return e.config.GetLabel() },
 	)
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -28,7 +28,6 @@ type CommandLine interface {
 	GetDebug() (bool, bool)
 	GetProxy() string
 	GetLogFormat() string
-	GetLabel() string
 	GetGpgHome() string
 	GetAPIDump() (bool, bool)
 	GetUserCacheSize() (int, bool)
@@ -53,6 +52,7 @@ type CommandLine interface {
 
 	// Lower-level functions
 	GetGString(string) string
+	GetString(string) string
 	GetBool(string, bool) (bool, bool)
 }
 
@@ -89,7 +89,6 @@ type ConfigReader interface {
 	GetUserConfigForUsername(s NormalizedUsername) (*UserConfig, error)
 	GetProxy() string
 	GetLogFormat() string
-	GetLabel() string
 	GetGpgHome() string
 	GetBundledCA(host string) string
 	GetStringAtPath(string) (string, bool)

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -253,6 +253,10 @@ func NewCmdService(cl *libcmdline.CommandLine) cli.Command {
 				Name:  "chdir",
 				Usage: "Specify where to run as a daemon (via chdir)",
 			},
+			cli.StringFlag{
+				Name:  "label",
+				Usage: "Specifying a label can help identify services.",
+			},
 		},
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewService(true /* isDaemon */), "service", c)


### PR DESCRIPTION
Instead of `keybase --label=foo service` it should be `keybase service --label=foo`.

I added a GetString to command line since want to read a non-global flag from command line.
