### PR TITLE
Fix wrong error message

### DIFF
--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -176,7 +176,7 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 
 		var emsg string
 		if arg.Self {
-			emsg = "You don't have a public key; try `keybase push` if you have a key; or `keybase pgp gen` if you don't"
+			emsg = "You don't have a public key; try `keybase pgp select` or `keybase pgp import` if you have a key; or `keybase pgp gen` if you don't"
 		}
 		err = NoKeyError{emsg}
 	}


### PR DESCRIPTION
should tell you to use keybase pgp gen instead of keybase gen.

@patrickxb 
