### PR TITLE
Fix keybase engine's handling of react native's lifecycle

### DIFF
--- a/react-native/android/app/src/main/java/io/keybase/android/MainActivity.java
+++ b/react-native/android/app/src/main/java/io/keybase/android/MainActivity.java
@@ -20,7 +20,7 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Init(this.getFilesDir().getPath(), "staging");
+        Init(this.getFilesDir().getPath(), "staging", "");
 
         mReactRootView = new ReactRootView(this);
         mReactInstanceManager = ReactInstanceManager.builder()

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -15,7 +15,7 @@
     "immutable": "^3.7.5",
     "moment": "^2.10.6",
     "qrcode-generator": "^1.0.0",
-    "react-native": "^0.11.0",
+    "react-native": "^0.11.4",
     "react-native-camera": "^0.3.5",
     "react-redux": "^2.1.2",
     "redux": "^3.0.0",

--- a/react-native/react/tabs/more/index.js
+++ b/react-native/react/tabs/more/index.js
@@ -24,6 +24,13 @@ export default class More extends Component {
 
     this.state = {
       dataSource: ds.cloneWithRows([
+        {name: 'Login', onClick: () => {
+          this.props.dispatch(navigateTo(['login']))
+        }},
+        {name: 'reset', onClick: () => {
+          require('../../engine').reset()
+          console.log('Engine reset!');
+        }},
         {name: 'Sign Out', onClick: () => {
           this.props.dispatch(LoginActions.logout())
         }},


### PR DESCRIPTION
Turns out react native invalidates the old react context (which is what you use to send events to the JS side) when you reload JS.

Not sure how this was working before, mostly magic probably.

This properly listens to the lifecycle on the react context and recreates the engine accordingly, resetting freely to be safe.

@chrisnojima  
