### PR TITLE
Create locked file on Windows

### DIFF
--- a/go/libkb/flock.go
+++ b/go/libkb/flock.go
@@ -1,9 +1,7 @@
 package libkb
 
 import (
-	"fmt"
 	"os"
-	"syscall"
 )
 
 type LockPIDFile struct {
@@ -13,31 +11,6 @@ type LockPIDFile struct {
 
 func NewLockPIDFile(s string) *LockPIDFile {
 	return &LockPIDFile{name: s}
-}
-
-// Lock writes the pid to filename after acquiring a lock on the file.
-// When the process exits, the lock will be released.
-func (f *LockPIDFile) Lock() (err error) {
-	// os.OpenFile adds syscall.O_CLOEXEC automatically
-	if f.file, err = os.OpenFile(f.name, os.O_CREATE|os.O_RDWR, 0600); err != nil {
-		return PIDFileLockError{f.name}
-	}
-
-	// LOCK_EX = exclusive
-	// LOCK_NB = nonblocking
-	if err = syscall.Flock(int(f.file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		f.file.Close()
-		f.file = nil
-		return PIDFileLockError{f.name}
-	}
-
-	pid := os.Getpid()
-	fmt.Fprintf(f.file, "%d", pid)
-	f.file.Sync()
-
-	G.Log.Debug("Locked pidfile %s for pid=%d", f.name, pid)
-
-	return nil
 }
 
 func (f *LockPIDFile) Close() (err error) {

--- a/go/libkb/flock_nix.go
+++ b/go/libkb/flock_nix.go
@@ -1,0 +1,34 @@
+// +build !windows
+
+package libkb
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// Lock writes the pid to filename after acquiring a lock on the file.
+// When the process exits, the lock will be released.
+func (f *LockPIDFile) Lock() (err error) {
+
+	if f.file, err = os.OpenFile(f.name, os.O_CREATE|os.O_RDWR, 0600); err != nil {
+		return PIDFileLockError{f.name}
+	}
+
+	// LOCK_EX = exclusive
+	// LOCK_NB = nonblocking
+	if err = syscall.Flock(int(f.file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		f.file.Close()
+		f.file = nil
+		return PIDFileLockError{f.name}
+	}
+
+	pid := os.Getpid()
+	fmt.Fprintf(f.file, "%d", pid)
+	f.file.Sync()
+
+	G.Log.Debug("Locked pidfile %s for pid=%d", f.name, pid)
+
+	return nil
+}

--- a/go/libkb/flock_windows.go
+++ b/go/libkb/flock_windows.go
@@ -1,0 +1,36 @@
+// +build windows
+
+package libkb
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// Open the file with exclusive access (locked to other processes)
+// When the process exits, the lock will be released.
+func (f *LockPIDFile) Lock() (err error) {
+	pathp, err := syscall.UTF16PtrFromString(f.name)
+	if err != nil {
+		return PIDFileLockError{f.name}
+	}
+	access := uint32(syscall.GENERIC_READ | syscall.GENERIC_WRITE)
+	createmode := uint32(syscall.OPEN_ALWAYS)
+	sharemode := uint32(0) // os.Open always uses FILE_SHARE_READ | FILE_SHARE_WRITE
+	var sa *syscall.SecurityAttributes
+	r, err := syscall.CreateFile(pathp, access, sharemode, sa, createmode, syscall.FILE_ATTRIBUTE_NORMAL, 0)
+	if err != nil {
+		return PIDFileLockError{f.name}
+	}
+	// this is what os.openFile does
+	f.file = os.NewFile(uintptr(r), f.name)
+
+	pid := os.Getpid()
+	fmt.Fprintf(f.file, "%d", pid)
+	f.file.Sync()
+
+	G.Log.Debug("Locked pidfile %s for pid=%d", f.name, pid)
+
+	return nil
+}

--- a/go/libkb/socket.go
+++ b/go/libkb/socket.go
@@ -1,5 +1,3 @@
-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
-
 package libkb
 
 import (

--- a/go/libkb/util_windows.go
+++ b/go/libkb/util_windows.go
@@ -1,0 +1,20 @@
+// +build windows
+
+package libkb
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// LookPath searches for an executable binary named file
+// in the directories named by the PATH environment variable.
+// If file contains a slash, it is tried directly and the PATH is not consulted.
+
+func canExec(s string) error {
+	if strings.IndexAny(s, `:\/`) == -1 {
+		s = s + "/"
+	}
+	_, err := exec.LookPath(s)
+	return err
+}


### PR DESCRIPTION
Makes libkb build on windows. Tested by running this and attempting to open/modify testfile separately before responding to the prompt.

```
func test_flock() {

    lpFile := libkb.NewLockPIDFile("testfile")
    err := lpFile.Lock()
    if err != nil {
        fmt.Println(err)
    } else {
        _, _ = miniline.ReadLine("Enter something to continue ")
    }
    _ = lpFile
}
```

@maxtaco @patrickxb 
