### PR TITLE
kex2: duplex secure channel

### DIFF
--- a/go/kex2/transport.go
+++ b/go/kex2/transport.go
@@ -1,0 +1,487 @@
+package kex2
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"github.com/ugorji/go/codec"
+	"golang.org/x/crypto/nacl/secretbox"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// DeviceID is a 16-byte identifier that each side of key exchange has. It's
+// used primarily to tell sender from receiver.
+type DeviceID [16]byte
+
+// SessionID is a 32-byte session identifier that's derived from the shared
+// session secret. It's used to route messages on the server side.
+type SessionID [32]byte
+
+// Secret is the 32-byte shared secret identifier
+type Secret [32]byte
+
+// Seqno increments on every message sent from a Kex sender.
+type Seqno uint32
+
+// Eq returns true if the two device IDs are equal
+func (d DeviceID) Eq(d2 DeviceID) bool {
+	return hmac.Equal(d[:], d2[:])
+}
+
+// Eq returns true if the two session IDs are equal
+func (s SessionID) Eq(s2 SessionID) bool {
+	return hmac.Equal(s[:], s2[:])
+}
+
+// MessageRouter is a stateful message router that will be implemented by
+// JSON/REST calls to the Keybase API server.
+type MessageRouter interface {
+
+	// Post a message, or if `msg = nil`, mark the EOF
+	Post(I SessionID, sender DeviceID, seqno Seqno, msg []byte) error
+
+	// Get messages on the channel.  Only poll for `poll` milliseconds. If the timeout
+	// elapses without any data ready, then `ErrTimedOut` is returned as an error.
+	// Several messages can be returned at once, which should be processed in serial.
+	// They are guaranteed to be in order; otherwise, there was an issue.
+	// On close of the connection, Get returns an empty array and an error of type `io.EOF`
+	Get(I SessionID, receiver DeviceID, seqno Seqno, poll time.Duration) (msg [][]byte, err error)
+}
+
+// Conn is a struct that obeys the net.Conn interface. It establishes a session abstraction
+// over a message channel bounced off the Keybase API server, applying the appropriate
+// e2e encryption/MAC'ing.
+type Conn struct {
+	router    MessageRouter
+	secret    Secret
+	sessionID SessionID
+	deviceID  DeviceID
+
+	// Protects the read path. There should only be one reader outstanding at once.
+	readMutex    sync.Mutex
+	readSeqno    Seqno
+	readDeadline time.Time
+	readTimeout  time.Duration
+	bufferedMsgs [][]byte
+
+	// Protects the write path. There should only be one writer oustanding at once.
+	writeMutex sync.Mutex
+	writeSeqno Seqno
+
+	// Protects the setting of error states. Only one thread should be setting or
+	// accessing these errors at a time.
+	errMutex sync.Mutex
+	readErr  error
+	writeErr error
+}
+
+const sessionIDText = "Kex v2 Session ID"
+
+// NewConn establishes a Kex session based on the given secret. Will work for
+// both ends of the connection, regardless of which order the two started
+// their conntection. Will communicate with the other end via the given message router.
+// You can specify an optional timeout to cancel any reads longer than that timeout.
+func NewConn(r MessageRouter, s Secret, d DeviceID, readTimeout time.Duration) (con net.Conn, err error) {
+	mac := hmac.New(sha256.New, []byte(s[:]))
+	mac.Write([]byte(sessionIDText))
+	tmp := mac.Sum(nil)
+	var sessionID SessionID
+	copy(sessionID[:], tmp)
+	ret := &Conn{
+		router:      r,
+		secret:      s,
+		sessionID:   sessionID,
+		deviceID:    d,
+		readSeqno:   0,
+		readTimeout: readTimeout,
+		writeSeqno:  0,
+	}
+	return ret, nil
+}
+
+// TimedoutError is for operations that timed out; for instance, if no read
+// data was available before the deadline.
+type timedoutError struct{}
+
+// Error returns the string representation of this error
+func (t timedoutError) Error() string { return "operation timed out" }
+
+// Temporary returns if the error is retriable
+func (t timedoutError) Temporary() bool { return true }
+
+// Timeout returns if this error is a timeout
+func (t timedoutError) Timeout() bool { return true }
+
+// ErrTimedOut is the signleton error we use if the operation timedout.
+var ErrTimedOut net.Error = timedoutError{}
+
+// ErrUnimplemented indicates the given method isn't implemented
+var ErrUnimplemented = errors.New("unimplemented")
+
+// ErrBadMetadata indicates that the metadata outside the encrypted message
+// didn't match what was inside.
+var ErrBadMetadata = errors.New("bad metadata")
+
+// ErrBadDecryption indicates that a ciphertext failed to decrypt or MAC properly
+var ErrDecryption = errors.New("decryption failed")
+
+// ErrNotEnoughRandomness indicates that encryption failed due to insufficient
+// randomness
+var ErrNotEnoughRandomness = errors.New("not enough random data")
+
+// ErrBadPacketSequence indicates that packets arrived out of order from the
+// server (which they shouldn't).
+var ErrBadPacketSequence = errors.New("packets arrived out-of-order")
+
+// ErrWrongSession indicatest that the given session didn't match the
+// clients expectations
+var ErrWrongSession = errors.New("got message for wrong Session ID")
+
+// ErrSelfReceive indicates that the client received a message sent by
+// itself, which should never happen
+var ErrSelfRecieve = errors.New("got message back that we sent")
+
+// ErrAgain indicates that no data was available to read, but the
+// reader was in non-blocking mode, so to try again later.
+var ErrAgain = errors.New("no data were ready to read")
+
+func (c *Conn) setReadError(e error) error {
+	c.errMutex.Lock()
+	c.readErr = e
+	c.errMutex.Unlock()
+	return e
+}
+
+func (c *Conn) setWriteError(e error) error {
+	c.errMutex.Lock()
+	c.writeErr = e
+	c.errMutex.Unlock()
+	return e
+}
+
+func (c *Conn) getErrorForWrite() error {
+	var err error
+	c.errMutex.Lock()
+	if c.readErr != nil && c.readErr != io.EOF {
+		err = c.readErr
+	} else if c.writeErr != nil {
+		err = c.writeErr
+	}
+	c.errMutex.Unlock()
+	return err
+}
+
+func (c *Conn) getErrorForRead() error {
+	var err error
+	c.errMutex.Lock()
+	if c.readErr != nil {
+		err = c.readErr
+	} else if c.writeErr != nil && c.writeErr != io.EOF {
+		err = c.writeErr
+	}
+	c.errMutex.Unlock()
+	return err
+}
+
+type outerMsg struct {
+	_struct   bool      `codec:",toarray"`
+	SenderID  DeviceID  `codec:"senderID"`
+	SessionID SessionID `codec:"sessionID"`
+	Seqno     Seqno     `codec:"seqno"`
+	Nonce     [24]byte  `codec:"nonce"`
+	Payload   []byte    `codec:"payload"`
+}
+
+type innerMsg struct {
+	_struct   bool      `codec:",toarray"`
+	SenderID  DeviceID  `codec:"senderID"`
+	SessionID SessionID `codec:"sessionID"`
+	Seqno     Seqno     `codec:"seqno"`
+	Payload   []byte    `codec:"payload"`
+}
+
+func (c *Conn) decryptIncomingMessage(msg []byte) (int, error) {
+	var err error
+	mh := codec.MsgpackHandle{WriteExt: true}
+	dec := codec.NewDecoderBytes(msg, &mh)
+	var om outerMsg
+	err = dec.Decode(&om)
+	if err != nil {
+		return 0, err
+	}
+	var plaintext []byte
+	var ok bool
+	plaintext, ok = secretbox.Open(plaintext, om.Payload, &om.Nonce, (*[32]byte)(&c.secret))
+	if !ok {
+		return 0, ErrDecryption
+	}
+	dec = codec.NewDecoderBytes(plaintext, &mh)
+	var im innerMsg
+	err = dec.Decode(&im)
+	if err != nil {
+		return 0, err
+	}
+	if !om.SenderID.Eq(im.SenderID) || !om.SessionID.Eq(im.SessionID) || om.Seqno != im.Seqno {
+		return 0, ErrBadMetadata
+	}
+	if !im.SessionID.Eq(c.sessionID) {
+		return 0, ErrWrongSession
+	}
+	if im.SenderID.Eq(c.deviceID) {
+		return 0, ErrSelfRecieve
+	}
+
+	if im.Seqno != c.readSeqno+1 {
+		return 0, ErrBadPacketSequence
+	}
+	c.readSeqno = im.Seqno
+
+	c.bufferedMsgs = append(c.bufferedMsgs, im.Payload)
+	return len(im.Payload), nil
+}
+
+func (c *Conn) decryptIncomingMessages(msgs [][]byte) (int, error) {
+	var ret int
+	for _, msg := range msgs {
+		n, e := c.decryptIncomingMessage(msg)
+		if e != nil {
+			return ret, e
+		}
+		ret += n
+	}
+	return ret, nil
+}
+
+func (c *Conn) readBufferedMsgsIntoBytes(out []byte) (int, error) {
+	p := 0
+	for p < len(out) {
+		rem := len(out) - p
+		if len(c.bufferedMsgs) > 0 {
+			front := c.bufferedMsgs[0]
+			n := len(front)
+			if rem < n {
+				n = rem
+				copy(out[p:(p+n)], front[0:n])
+				c.bufferedMsgs[0] = front[n:]
+			} else {
+				copy(out[p:(p+n)], front[:])
+				c.bufferedMsgs = c.bufferedMsgs[1:]
+			}
+			p += n
+		} else {
+			break
+		}
+	}
+	return p, nil
+}
+
+func (c *Conn) pollLoop(poll time.Duration) (msgs [][]byte, err error) {
+
+	var totalWaitTime time.Duration
+
+	start := time.Now()
+	for {
+		newPoll := poll - totalWaitTime
+		msgs, err = c.router.Get(c.sessionID, c.deviceID, c.readSeqno, newPoll)
+		totalWaitTime = time.Since(start)
+
+		if err != ErrTimedOut || totalWaitTime >= poll {
+			return
+		}
+	}
+
+}
+
+// Read data from the connection, returning plaintext data if all
+// cryptographic checks passed. Obeys the `net.Conn` interface.
+// Returns the number of bytes read into the output buffer.
+func (c *Conn) Read(out []byte) (n int, err error) {
+
+	c.readMutex.Lock()
+	defer c.readMutex.Unlock()
+
+	// The first error kills the whole stream
+	if err = c.getErrorForRead(); err != nil {
+		return 0, err
+	}
+	// First see if there's anything buffered, and read that
+	// out now.
+	if n, err = c.readBufferedMsgsIntoBytes(out); err != nil {
+		return 0, c.setReadError(err)
+	}
+	if n > 0 {
+		return n, nil
+	}
+
+	var poll time.Duration
+	if !c.readDeadline.IsZero() {
+		poll = c.readDeadline.Sub(time.Now())
+		if poll.Nanoseconds() < 0 {
+			return 0, c.setReadError(ErrTimedOut)
+		}
+	} else {
+		poll = c.readTimeout
+	}
+
+	var msgs [][]byte
+	msgs, err = c.pollLoop(poll)
+
+	// If the router returned messages and also indicated the end of the connection,
+	// the semantics of Read() are to not return EOF until the next time through.
+	if len(msgs) > 0 && err == io.EOF {
+		err = nil
+	}
+
+	if err != nil {
+		return 0, c.setReadError(err)
+	}
+	if len(msgs) == 0 {
+		return 0, c.setReadError(io.EOF)
+	}
+	if _, err = c.decryptIncomingMessages(msgs); err != nil {
+		return 0, c.setReadError(err)
+	}
+	if n, err = c.readBufferedMsgsIntoBytes(out); err != nil {
+		return 0, c.setReadError(err)
+	}
+	return n, nil
+}
+
+func (c *Conn) encryptOutgoingMessage(seqno Seqno, buf []byte) (ret []byte, err error) {
+	var nonce [24]byte
+	var n int
+
+	if n, err = rand.Read(nonce[:]); err != nil {
+		return nil, err
+	} else if n != 24 {
+		return nil, ErrNotEnoughRandomness
+	}
+	im := innerMsg{
+		SenderID:  c.deviceID,
+		SessionID: c.sessionID,
+		Seqno:     seqno,
+		Payload:   buf,
+	}
+	mh := codec.MsgpackHandle{WriteExt: true}
+	var imPacked []byte
+	enc := codec.NewEncoderBytes(&imPacked, &mh)
+	if err = enc.Encode(im); err != nil {
+		return nil, err
+	}
+	ciphertext := secretbox.Seal(nil, imPacked, &nonce, (*[32]byte)(&c.secret))
+
+	om := outerMsg{
+		SenderID:  c.deviceID,
+		SessionID: c.sessionID,
+		Seqno:     seqno,
+		Nonce:     nonce,
+		Payload:   ciphertext,
+	}
+	enc = codec.NewEncoderBytes(&ret, &mh)
+	if err = enc.Encode(om); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (c *Conn) nextWriteSeqno() Seqno {
+	c.writeSeqno++
+	return c.writeSeqno
+}
+
+// Write data to the connection, encrypting and MAC'ing along the way.
+// Obeys the `net.Conn` interface
+func (c *Conn) Write(buf []byte) (n int, err error) {
+	var ctext []byte
+
+	c.writeMutex.Lock()
+	defer c.writeMutex.Unlock()
+
+	// The first error kills the whole stream
+	if err = c.getErrorForWrite(); err != nil {
+		return 0, err
+	}
+
+	seqno := c.nextWriteSeqno()
+
+	ctext, err = c.encryptOutgoingMessage(seqno, buf)
+	if err != nil {
+		return 0, c.setWriteError(err)
+	}
+
+	if err = c.router.Post(c.sessionID, c.deviceID, seqno, ctext); err != nil {
+		return 0, err
+	}
+
+	return len(ctext), nil
+}
+
+// Close the connection to the server, sending a `Post()` message to the
+// `MessageRouter` with `eof` set to `true`. Fulfills the
+// `net.Conn` interface
+func (c *Conn) Close() error {
+
+	c.writeMutex.Lock()
+	defer c.writeMutex.Unlock()
+
+	// The first error kills the whole stream
+	if err := c.getErrorForWrite(); err != nil {
+		return err
+	}
+
+	if err := c.router.Post(c.sessionID, c.deviceID, c.nextWriteSeqno(), nil); err != nil {
+		return err
+	}
+	c.setWriteError(io.EOF)
+	return nil
+}
+
+// LocalAddr returns the local network address, fulfilling the `net.Conn interface`
+func (c *Conn) LocalAddr() (addr net.Addr) {
+	return
+}
+
+// RemoteAddr returns the remote network address, fulfilling the `net.Conn interface`
+func (c *Conn) RemoteAddr() (addr net.Addr) {
+	return
+}
+
+// SetDeadline sets the read and write deadlines associated
+// with the connection. It is equivalent to calling both
+// SetReadDeadline and SetWriteDeadline.
+//
+// A deadline is an absolute time after which I/O operations
+// fail with a timeout (see type Error) instead of
+// blocking. The deadline applies to all future I/O, not just
+// the immediately following call to Read or Write.
+//
+// An idle timeout can be implemented by repeatedly extending
+// the deadline after successful Read or Write calls.
+//
+// A zero value for t means I/O operations will not time out.
+func (c *Conn) SetDeadline(t time.Time) error {
+	return c.SetReadDeadline(t)
+}
+
+// SetReadDeadline sets the deadline for future Read calls.
+// A zero value for t means Read will not time out.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	c.readMutex.Lock()
+	c.readDeadline = t
+	c.readMutex.Unlock()
+	return nil
+}
+
+// SetWriteDeadline sets the deadline for future Write calls.
+// Even if write times out, it may return n > 0, indicating that
+// some of the data was successfully written.
+// A zero value for t means Write will not time out.
+// We're not implementing this feature for now, so make it an error
+// if we try to do so.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	return ErrUnimplemented
+}

--- a/go/kex2/transport_test.go
+++ b/go/kex2/transport_test.go
@@ -1,0 +1,535 @@
+package kex2
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+type message struct {
+	seqno Seqno
+	msg   []byte
+}
+
+type simplexSession struct {
+	sender   DeviceID
+	receiver DeviceID
+	eof      bool
+	ch       chan message
+}
+
+var zeroDeviceID DeviceID
+
+func (d DeviceID) isZero() bool {
+	return d.Eq(zeroDeviceID)
+}
+
+func newSimplexSession(s DeviceID, r DeviceID) *simplexSession {
+	return &simplexSession{
+		sender:   s,
+		receiver: r,
+		eof:      false,
+		ch:       make(chan message, 100),
+	}
+}
+
+type session struct {
+	id    SessionID
+	left  *simplexSession
+	right *simplexSession
+}
+
+type mockRouter struct {
+	behavior int
+	maxPoll  time.Duration
+	sessions map[SessionID]*session
+}
+
+const (
+	GoodRouter                   = 0
+	BadRouterCorruptedSession    = 1 << iota
+	BadRouterCorruptedSender     = 1 << iota
+	BadRouterCorruptedCiphertext = 1 << iota
+	BadRouterReorder             = 1 << iota
+	BadRouterDrop                = 1 << iota
+)
+
+func corruptMessage(behavior int, msg []byte) {
+	if (behavior & BadRouterCorruptedSession) != 0 {
+		msg[23] ^= 0x80
+	}
+	if (behavior & BadRouterCorruptedSender) != 0 {
+		msg[10] ^= 0x40
+	}
+	if (behavior & BadRouterCorruptedCiphertext) != 0 {
+		msg[len(msg)-10] ^= 0x01
+	}
+}
+
+func newMockRouter() *mockRouter {
+	return &mockRouter{
+		behavior: GoodRouter,
+		sessions: make(map[SessionID]*session),
+	}
+}
+
+func newMockRouterWithBehavior(b int) *mockRouter {
+	return &mockRouter{
+		behavior: b,
+		sessions: make(map[SessionID]*session),
+	}
+}
+
+func newMockRouterWithBehaviorAndMaxPoll(b int, mp time.Duration) *mockRouter {
+	return &mockRouter{
+		behavior: b,
+		maxPoll:  mp,
+		sessions: make(map[SessionID]*session),
+	}
+}
+
+func (ss *simplexSession) post(seqno Seqno, msg []byte) error {
+	ss.ch <- message{seqno, msg}
+	return nil
+}
+
+func (s *session) findOrMakeSimplexSession(sender DeviceID, receiver DeviceID) (ss *simplexSession, err error) {
+
+	myeq := func(a DeviceID, b DeviceID) bool {
+		return a.Eq(b) || a.isZero() || b.isZero()
+	}
+
+	myfix := func(ss *simplexSession, s DeviceID, r DeviceID) {
+		if ss.sender.isZero() && !s.isZero() {
+			ss.sender = s
+		}
+		if ss.receiver.isZero() && !r.isZero() {
+			ss.receiver = r
+		}
+	}
+
+	if s.left == nil {
+		s.left = newSimplexSession(sender, receiver)
+		return s.left, nil
+	}
+	if myeq(s.left.sender, sender) && myeq(s.left.receiver, receiver) {
+		myfix(s.left, sender, receiver)
+		return s.left, nil
+	}
+
+	if s.right == nil {
+		s.right = newSimplexSession(sender, receiver)
+		return s.right, nil
+	}
+	if myeq(s.right.sender, sender) && myeq(s.right.receiver, receiver) {
+		myfix(s.right, sender, receiver)
+		if !myeq(s.right.sender, s.left.receiver) || !myeq(s.left.sender, s.right.receiver) {
+			return nil, errors.New("sender/receiver cross-mismatch")
+		}
+		return s.right, nil
+	}
+	return nil, errors.New("mysterious third party in this session")
+}
+
+func (mr *mockRouter) findOrMakeSimplexSession(I SessionID, sender DeviceID, receiver DeviceID) (ss *simplexSession, err error) {
+	sess, ok := mr.sessions[I]
+	if !ok {
+		sess = &session{I, nil, nil}
+		mr.sessions[I] = sess
+	}
+	return sess.findOrMakeSimplexSession(sender, receiver)
+}
+
+func (mr *mockRouter) Post(I SessionID, sender DeviceID, seqno Seqno, msg []byte) error {
+	ss, err := mr.findOrMakeSimplexSession(I, sender, zeroDeviceID)
+	if err != nil {
+		return err
+	}
+	corruptMessage(mr.behavior, msg)
+	return ss.post(seqno, msg)
+}
+
+func (ss *simplexSession) get(seqno Seqno, poll time.Duration, behavior int) (ret [][]byte, err error) {
+	if ss.eof {
+		return nil, io.EOF
+	}
+	timeout := false
+	hitEOF := false
+	handleMessage := func(msg message) {
+		if msg.msg == nil {
+			hitEOF = true
+			ss.eof = true
+		} else {
+			ret = append(ret, msg.msg)
+		}
+	}
+	if poll.Nanoseconds() > 0 {
+		select {
+		case msg := <-ss.ch:
+			handleMessage(msg)
+		case <-time.After(poll):
+			timeout = true
+		}
+	}
+	if !timeout {
+	loopMessages:
+		for {
+			select {
+			case msg := <-ss.ch:
+				handleMessage(msg)
+			default:
+				break loopMessages
+			}
+		}
+	}
+
+	if hitEOF {
+		err = io.EOF
+	}
+
+	if len(ret) == 0 && err != io.EOF {
+		if poll.Nanoseconds() > 0 {
+			err = ErrTimedOut
+		} else {
+			err = ErrAgain
+		}
+	}
+
+	if (behavior&BadRouterReorder) != 0 && len(ret) > 1 {
+		ret[0], ret[1] = ret[1], ret[0]
+	}
+	if (behavior&BadRouterDrop) != 0 && len(ret) > 1 {
+		ret = ret[1:]
+	}
+
+	return ret, err
+}
+
+func (mr *mockRouter) Get(I SessionID, receiver DeviceID, seqno Seqno, poll time.Duration) ([][]byte, error) {
+	ss, err := mr.findOrMakeSimplexSession(I, zeroDeviceID, receiver)
+	if err != nil {
+		return nil, err
+	}
+	if mr.maxPoll > time.Duration(0) && poll > mr.maxPoll {
+		poll = mr.maxPoll
+	}
+	return ss.get(seqno, poll, mr.behavior)
+}
+
+func genSecret(t *testing.T) (ret Secret) {
+	_, err := rand.Read([]byte(ret[:]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ret
+}
+
+func genDeviceID(t *testing.T) (ret DeviceID) {
+	_, err := rand.Read([]byte(ret[:]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ret
+}
+
+func genNewConn(t *testing.T, mr MessageRouter, s Secret, d DeviceID, rt time.Duration) net.Conn {
+	ret, err := NewConn(mr, s, d, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ret
+}
+
+func genConnPair(t *testing.T, behavior int, readTimeout time.Duration) (c1 net.Conn, c2 net.Conn, d1 DeviceID, d2 DeviceID) {
+	r := newMockRouterWithBehavior(behavior)
+	s := genSecret(t)
+	d1 = genDeviceID(t)
+	d2 = genDeviceID(t)
+	c1 = genNewConn(t, r, s, d1, readTimeout)
+	c2 = genNewConn(t, r, s, d2, readTimeout)
+	return
+}
+
+func TestHello(t *testing.T) {
+	c1, c2, _, _ := genConnPair(t, GoodRouter, time.Duration(0))
+	txt := []byte("hello friend")
+	if _, err := c1.Write(txt); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 100)
+	if n, err := c2.Read(buf); err != nil {
+		t.Fatal(err)
+	} else if n != len(txt) {
+		t.Fatal("bad read len")
+	} else if !bytes.Equal(buf[0:n], txt) {
+		t.Fatal("wrong message back")
+	}
+	txt2 := []byte("pong PONG pong PONG pong PONG")
+	if _, err := c2.Write(txt2); err != nil {
+		t.Fatal(err)
+	} else if n, err := c1.Read(buf); err != nil {
+		t.Fatal(err)
+	} else if n != len(txt2) {
+		t.Fatal("bad read len")
+	} else if !bytes.Equal(buf[0:n], txt2) {
+		t.Fatal("wrong ponged text")
+	}
+	return
+}
+
+func TestBadMetadata(t *testing.T) {
+
+	testBehavior := func(b int, t *testing.T, wanted error) {
+		c1, c2, _, _ := genConnPair(t, b, time.Duration(0))
+		txt := []byte("hello friend")
+		if _, err := c1.Write(txt); err != nil {
+			t.Fatal(err)
+		}
+		buf := make([]byte, 100)
+		if _, err := c2.Read(buf); err == nil {
+			t.Fatalf("behavior %d: wanted an error, didn't get one", b)
+		} else if err != wanted {
+			t.Fatalf("behavior %d: wanted error '%v', got '%v'", b, err, wanted)
+		}
+	}
+	testBehavior(BadRouterCorruptedSession, t, ErrBadMetadata)
+	testBehavior(BadRouterCorruptedSender, t, ErrBadMetadata)
+	testBehavior(BadRouterCorruptedCiphertext, t, ErrDecryption)
+}
+
+func TestReadDeadline(t *testing.T) {
+	c1, c2, _, _ := genConnPair(t, GoodRouter, time.Duration(0))
+	wait := time.Duration(10) * time.Millisecond
+	c2.SetReadDeadline(time.Now().Add(wait))
+	go func() {
+		time.Sleep(wait * 2)
+		c1.Write([]byte("hello friend"))
+	}()
+	buf := make([]byte, 100)
+	_, err := c2.Read(buf)
+	if err != ErrTimedOut {
+		t.Fatalf("wanted a read timeout")
+	}
+}
+
+func TestReadTimeout(t *testing.T) {
+	wait := time.Duration(10) * time.Millisecond
+	c1, c2, _, _ := genConnPair(t, GoodRouter, wait)
+	go func() {
+		time.Sleep(wait * 2)
+		c1.Write([]byte("hello friend"))
+	}()
+	buf := make([]byte, 100)
+	_, err := c2.Read(buf)
+	if err != ErrTimedOut {
+		t.Fatalf("wanted a read timeout")
+	}
+}
+
+func TestReadDelayedWrite(t *testing.T) {
+	c1, c2, _, _ := genConnPair(t, GoodRouter, time.Duration(0))
+	wait := time.Duration(10) * time.Millisecond
+	c2.SetReadDeadline(time.Now().Add(wait))
+	text := "hello friend"
+	go func() {
+		time.Sleep(wait / 2)
+		c1.Write([]byte(text))
+	}()
+	buf := make([]byte, 100)
+	n, err := c2.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(text) {
+		t.Fatalf("wrong read length")
+	}
+}
+
+func TestMultipleWritesOneRead(t *testing.T) {
+	c1, c2, _, _ := genConnPair(t, GoodRouter, time.Duration(0))
+	msgs := []string{
+		"Alas, poor Yorick! I knew him, Horatio: a fellow",
+		"of infinite jest, of most excellent fancy: he hath",
+		"borne me on his back a thousand times; and now, how",
+		"abhorred in my imagination it is! my gorge rims at",
+		"it.",
+	}
+	for i, m := range msgs {
+		if i > 0 {
+			m = "\n" + m
+		}
+		if _, err := c1.Write([]byte(m)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	buf := make([]byte, 1000)
+	if n, err := c2.Read(buf); err != nil {
+		t.Fatal(err)
+	} else if strings.Join(msgs, "\n") != string(buf[0:n]) {
+		t.Fatal("string mismatch")
+	}
+}
+
+func TestOneWriteMultipleReads(t *testing.T) {
+	c1, c2, _, _ := genConnPair(t, GoodRouter, time.Duration(0))
+	msg := `Crows maunder on the petrified fairway.
+Absence! My heart grows tense
+as though a harpoon were sparring for the kill.`
+	if _, err := c1.Write([]byte(msg)); err != nil {
+		return
+	}
+	small := make([]byte, 3)
+	var buf []byte
+	for {
+		if n, err := c2.Read(small); err != nil && err != ErrAgain {
+			t.Fatal(err)
+		} else if n == 0 {
+			if err != ErrAgain {
+				t.Fatalf("exepcted ErrAgain if we read 0 bytes, but got %v", err)
+			}
+			break
+		} else {
+			buf = append(buf, small[0:n]...)
+		}
+	}
+	if string(buf) != msg {
+		t.Fatal("message mismatch")
+	}
+}
+
+func TestReorder(t *testing.T) {
+	c1, c2, _, _ := genConnPair(t, BadRouterReorder, time.Duration(0))
+	msgs := []string{
+		"Alas, poor Yorick! I knew him, Horatio: a fellow",
+		"of infinite jest, of most excellent fancy: he hath",
+		"borne me on his back a thousand times; and now, how",
+		"abhorred in my imagination it is! my gorge rims at",
+		"it.",
+	}
+	for i, m := range msgs {
+		if i > 0 {
+			m = "\n" + m
+		}
+		if _, err := c1.Write([]byte(m)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	buf := make([]byte, 1000)
+	if _, err := c2.Read(buf); err != ErrBadPacketSequence {
+		t.Fatalf("expected an ErrBadPacketSequence; got %v", err)
+	}
+}
+
+func TestDrop(t *testing.T) {
+	c1, c2, _, _ := genConnPair(t, BadRouterDrop, time.Duration(0))
+	msgs := []string{
+		"Alas, poor Yorick! I knew him, Horatio: a fellow",
+		"of infinite jest, of most excellent fancy: he hath",
+		"borne me on his back a thousand times; and now, how",
+		"abhorred in my imagination it is! my gorge rims at",
+		"it.",
+	}
+	for i, m := range msgs {
+		if i > 0 {
+			m = "\n" + m
+		}
+		if _, err := c1.Write([]byte(m)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	buf := make([]byte, 1000)
+	if _, err := c2.Read(buf); err != ErrBadPacketSequence {
+		t.Fatalf("expected an ErrBadPacketSequence; got %v", err)
+	}
+}
+
+func TestClose(t *testing.T) {
+	c1, c2, _, _ := genConnPair(t, GoodRouter, time.Duration(4)*time.Second)
+	msg := "Hello friend. I'm going to mic drop."
+	if _, err := c1.Write([]byte(msg)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c1.Close(); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 1000)
+	if n, err := c2.Read(buf); err != nil {
+		t.Fatal(err)
+	} else if n != len(msg) {
+		t.Fatal("short read")
+	} else if string(buf[0:n]) != msg {
+		t.Fatal("wrong msg")
+	}
+
+	// Assert we get an EOF now and forever...
+	for i := 0; i < 3; i++ {
+		if n, err := c2.Read(buf); err != io.EOF {
+			t.Fatalf("expected EOF, but got err = %v", err)
+		} else if n != 0 {
+			t.Fatalf("Expected 0-length read, but got %d", n)
+		}
+	}
+}
+
+func TestErrAgain(t *testing.T) {
+	_, c2, _, _ := genConnPair(t, GoodRouter, time.Duration(0))
+	buf := make([]byte, 100)
+	if n, err := c2.Read(buf); err != ErrAgain {
+		t.Fatalf("wanted ErrAgain, but got err = %v", err)
+	} else if n != 0 {
+		t.Fatalf("Wanted 0 bytes back; got %d", n)
+	}
+}
+
+func TestPollLoopSuccess(t *testing.T) {
+
+	wait := time.Duration(8) * time.Millisecond
+	r := newMockRouterWithBehaviorAndMaxPoll(GoodRouter, wait/32)
+	s := genSecret(t)
+	d1 := genDeviceID(t)
+	d2 := genDeviceID(t)
+	c1 := genNewConn(t, r, s, d1, wait)
+	c2 := genNewConn(t, r, s, d2, wait)
+
+	text := "poll for this, will you?"
+
+	go func() {
+		time.Sleep(wait / 4)
+		c1.Write([]byte(text))
+	}()
+	buf := make([]byte, 100)
+	n, err := c2.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(text) {
+		t.Fatalf("wrong read length")
+	}
+}
+
+func TestPollLoopTimeout(t *testing.T) {
+
+	wait := time.Duration(8) * time.Millisecond
+	r := newMockRouterWithBehaviorAndMaxPoll(GoodRouter, wait/32)
+	s := genSecret(t)
+	d1 := genDeviceID(t)
+	d2 := genDeviceID(t)
+	c1 := genNewConn(t, r, s, d1, wait)
+	c2 := genNewConn(t, r, s, d2, wait)
+
+	text := "poll for this, will you?"
+
+	go func() {
+		time.Sleep(wait * 2)
+		c1.Write([]byte(text))
+	}()
+	buf := make([]byte, 100)
+	if _, err := c2.Read(buf); err != ErrTimedOut {
+		t.Fatalf("Wanted ErrTimedOut; got %v", err)
+	}
+}


### PR DESCRIPTION
This commit introduces a kex2 secure channel.  The function of the server is mocked-out
via the MessageRouter interface.  Eventually we can supply API endpoints on the server
to handle the implementation here.

Tested pretty well but there could be bugs.

The next step is to build an RPC layer on top of this, and then circle back to find
any bugs that crop up along the way.

Closes #1015
