### PR TITLE
kex2: RPC layer

### DIFF
--- a/go/kex2/provisionee.go
+++ b/go/kex2/provisionee.go
@@ -1,0 +1,132 @@
+package kex2
+
+import (
+	keybase1 "github.com/keybase/client/go/protocol"
+	"github.com/maxtaco/go-framed-msgpack-rpc/rpc2"
+	"time"
+)
+
+type provisionee struct {
+	baseDevice
+	arg  ProvisioneeArg
+	done chan error
+}
+
+// Provisionee is an interface that abstracts out the crypto and session
+// management that a provisionee needs to do as part of the protocol.
+type Provisionee interface {
+	GetLogFactory() rpc2.LogFactory
+	HandleHello(keybase1.HelloArg) (keybase1.HelloRes, error)
+	HandleDidCounterSign([]byte) error
+}
+
+// ProvisioneeArg provides the details that a provisionee needs in order
+// to run its course
+type ProvisioneeArg struct {
+	KexBaseArg
+	Provisionee Provisionee
+}
+
+func newProvisionee(arg ProvisioneeArg) *provisionee {
+	ret := &provisionee{
+		baseDevice: baseDevice{
+			start: make(chan struct{}),
+		},
+		arg:  arg,
+		done: make(chan error),
+	}
+	return ret
+}
+
+// RunProvisionee runs a provisioner given the necessary arguments.
+func RunProvisionee(arg ProvisioneeArg) error {
+	p := newProvisionee(arg)
+	return p.run()
+}
+
+// Hello is called via the RPC server interface by the remote client.
+// It in turn delegates the work to the passed in Provisionee interface,
+// calling HandleHello()
+func (p *provisionee) Hello(arg keybase1.HelloArg) (res keybase1.HelloRes, err error) {
+	close(p.start)
+	res, err = p.arg.Provisionee.HandleHello(arg)
+	if err != nil {
+		p.done <- err
+	}
+	return res, err
+}
+
+// DidCounterSign is called via the RPC server interface by the remote client.
+// It in turn delegates the work to the passed in Provisionee interface,
+// calling HandleDidCounterSign()
+func (p *provisionee) DidCounterSign(sig []byte) (err error) {
+	err = p.arg.Provisionee.HandleDidCounterSign(sig)
+	p.done <- err
+	return err
+}
+
+func (p *provisionee) run() (err error) {
+
+	if err = p.setDeviceID(); err != nil {
+		return err
+	}
+
+	if err = p.startServer(p.arg.Secret); err != nil {
+		return err
+	}
+
+	if err = p.pickFirstConnection(); err != nil {
+		return err
+	}
+
+	err = <-p.done
+
+	return err
+}
+
+func (p *provisionee) EOFHook(e error) {
+	p.done <- e
+	return
+}
+
+func (p *provisionee) startServer(s Secret) (err error) {
+	if p.conn, err = NewConn(p.arg.Mr, s, p.deviceID, p.arg.Timeout); err != nil {
+		return err
+	}
+	prot := keybase1.Kex2ProvisioneeProtocol(p)
+	p.xp = rpc2.NewTransport(p.conn, p.arg.Provisionee.GetLogFactory(), nil)
+	srv := rpc2.NewServer(p.xp, nil)
+	if err = srv.Register(prot); err != nil {
+		return err
+	}
+	if err = srv.RegisterEOFHook(func(e error) { p.EOFHook(e) }); err != nil {
+		return err
+	}
+	return srv.Run(true)
+}
+
+func (p *provisionee) pickFirstConnection() (err error) {
+	select {
+	case <-p.start:
+	case sec := <-p.arg.SecretChannel:
+		p.conn.Close()
+		err = p.startServer(sec)
+		if err != nil {
+			return err
+		}
+		cli := keybase1.Kex2ProvisionerClient{Cli: rpc2.NewClient(p.xp, nil)}
+		if err = cli.KexStart(); err != nil {
+			return err
+		}
+	case <-p.arg.Ctx.Done():
+		err = ErrCanceled
+	case <-time.After(p.arg.Timeout):
+		err = ErrTimedOut
+	}
+	return
+}
+
+func (p *provisionee) setDeviceID() (err error) {
+	p.deviceID, err = p.arg.getDeviceID()
+	return err
+}

--- a/go/kex2/provisioner.go
+++ b/go/kex2/provisioner.go
@@ -1,0 +1,171 @@
+package kex2
+
+import (
+	"errors"
+	keybase1 "github.com/keybase/client/go/protocol"
+	"github.com/maxtaco/go-framed-msgpack-rpc/rpc2"
+	"golang.org/x/net/context"
+	"net"
+	"time"
+)
+
+type baseDevice struct {
+	conn     net.Conn
+	xp       *rpc2.Transport
+	deviceID DeviceID
+	start    chan struct{}
+	canceled bool
+}
+
+type provisioner struct {
+	baseDevice
+	arg ProvisionerArg
+}
+
+// ErrCanceled is returned if Kex is canceled by the caller via the Context argument
+var ErrCanceled = errors.New("kex canceled by caller")
+
+// Provisioner is an interface that abstracts out the crypto and session
+// management that a provisioner needs to do as part of the protocol.
+type Provisioner interface {
+	GetHelloArg() keybase1.HelloArg
+	CounterSign(keybase1.HelloRes) ([]byte, error)
+	GetLogFactory() rpc2.LogFactory
+}
+
+// KexBaseArg are arguments common to both Provisioner and Provisionee
+type KexBaseArg struct {
+	Ctx           context.Context
+	Mr            MessageRouter
+	Secret        Secret
+	DeviceID      keybase1.DeviceID // For now, this deviceID is different from the one in the transport
+	SecretChannel <-chan Secret
+	Timeout       time.Duration
+}
+
+// ProvisionerArg provides the details that a provisioner needs in order
+// to run its course
+type ProvisionerArg struct {
+	KexBaseArg
+	Provisioner Provisioner
+}
+
+func newProvisioner(arg ProvisionerArg) *provisioner {
+	ret := &provisioner{
+		baseDevice: baseDevice{
+			start: make(chan struct{}),
+		},
+		arg: arg,
+	}
+	return ret
+}
+
+// RunProvisioner runs a provisioner given the necessary arguments.
+func RunProvisioner(arg ProvisionerArg) error {
+	p := newProvisioner(arg)
+	err := p.run()
+	p.close() // ignore any errors in closing the channel
+	return err
+}
+
+func (p *provisioner) close() (err error) {
+	if p.conn != nil {
+		err = p.conn.Close()
+	}
+	return err
+}
+
+func (p *provisioner) KexStart() error {
+	close(p.start)
+	return nil
+}
+
+func (p *provisioner) run() (err error) {
+	if err = p.setDeviceID(); err != nil {
+		return err
+	}
+	if err = p.pickFirstConnection(); err != nil {
+		return err
+	}
+	if err = p.runProtocolWithCancel(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (k KexBaseArg) getDeviceID() (ret DeviceID, err error) {
+	err = k.DeviceID.ToBytes([]byte(ret[:]))
+	return ret, err
+}
+
+func (p *provisioner) setDeviceID() (err error) {
+	p.deviceID, err = p.arg.getDeviceID()
+	return err
+}
+
+func (p *provisioner) pickFirstConnection() (err error) {
+	var conn net.Conn
+	if conn, err = NewConn(p.arg.Mr, p.arg.Secret, p.deviceID, p.arg.Timeout); err != nil {
+		return err
+	}
+
+	prot := keybase1.Kex2ProvisionerProtocol(p)
+	xp := rpc2.NewTransport(conn, p.arg.Provisioner.GetLogFactory(), nil)
+	srv := rpc2.NewServer(xp, nil)
+	if err = srv.Register(prot); err != nil {
+		return err
+	}
+	if err = srv.Run(true); err != nil {
+		return err
+	}
+
+	select {
+	case <-p.start:
+		p.conn = conn
+		p.xp = xp
+	case sec := <-p.arg.SecretChannel:
+		if p.conn, err = NewConn(p.arg.Mr, sec, p.deviceID, p.arg.Timeout); err != nil {
+			return err
+		}
+		p.xp = rpc2.NewTransport(p.conn, p.arg.Provisioner.GetLogFactory(), nil)
+		conn.Close()
+	case <-p.arg.Ctx.Done():
+		err = ErrCanceled
+	case <-time.After(p.arg.Timeout):
+		err = ErrTimedOut
+	}
+	return
+}
+
+func (p *provisioner) runProtocolWithCancel() (err error) {
+	ch := make(chan error)
+	go func() {
+		ch <- p.runProtocol()
+	}()
+	select {
+	case <-p.arg.Ctx.Done():
+		p.canceled = true
+		return ErrCanceled
+	case err = <-ch:
+		return err
+	}
+}
+
+func (p *provisioner) runProtocol() (err error) {
+	cli := keybase1.Kex2ProvisioneeClient{Cli: rpc2.NewClient(p.xp, nil)}
+	var res keybase1.HelloRes
+	if res, err = cli.Hello(p.arg.Provisioner.GetHelloArg()); err != nil {
+		return
+	}
+	if p.canceled {
+		return ErrCanceled
+	}
+	var counterSigned []byte
+	if counterSigned, err = p.arg.Provisioner.CounterSign(res); err != nil {
+		return err
+	}
+	if err = cli.DidCounterSign(counterSigned); err != nil {
+		return err
+	}
+	return nil
+}

--- a/go/protocol/extras.go
+++ b/go/protocol/extras.go
@@ -117,6 +117,21 @@ func DeviceIDFromBytes(b [DeviceIDLen]byte) DeviceID {
 	return DeviceID(hex.EncodeToString(b[:]))
 }
 
+func (d DeviceID) ToBytes(out []byte) error {
+	tmp, err := hex.DecodeString(string(d))
+	if err != nil {
+		return err
+	}
+	if len(tmp) != DeviceIDLen {
+		return fmt.Errorf("Bad device ID; wanted %d bytes but got %d", DeviceIDLen, len(tmp))
+	}
+	if len(out) != DeviceIDLen {
+		return fmt.Errorf("Need to output to a slice with %d bytes", DeviceIDLen)
+	}
+	copy(out[:], tmp)
+	return nil
+}
+
 func DeviceIDFromSlice(b []byte) (DeviceID, error) {
 	if len(b) != DeviceIDLen {
 		return "", fmt.Errorf("invalid byte slice for DeviceID: len == %d, expected %d", len(b), DeviceIDLen)
@@ -147,6 +162,10 @@ func (d DeviceID) IsNil() bool {
 
 func (d DeviceID) Exists() bool {
 	return !d.IsNil()
+}
+
+func (d DeviceID) Eq(d2 DeviceID) bool {
+	return d.Eq(d2)
 }
 
 func UIDFromString(s string) (UID, error) {

--- a/go/vendor/github.com/maxtaco/go-framed-msgpack-rpc/rpc2/client.go
+++ b/go/vendor/github.com/maxtaco/go-framed-msgpack-rpc/rpc2/client.go
@@ -1,13 +1,11 @@
 package rpc2
 
-import ()
-
 type Client struct {
-	xp          *Transport
+	xp          Transporter
 	unwrapError UnwrapErrorFunc
 }
 
-func NewClient(xp *Transport, f UnwrapErrorFunc) *Client {
+func NewClient(xp Transporter, f UnwrapErrorFunc) *Client {
 	return &Client{xp, f}
 }
 

--- a/go/vendor/github.com/maxtaco/go-framed-msgpack-rpc/rpc2/message.go
+++ b/go/vendor/github.com/maxtaco/go-framed-msgpack-rpc/rpc2/message.go
@@ -10,6 +10,10 @@ type Message struct {
 	nDecoded int
 }
 
+func NewMessage(t Transporter, nFields int) Message {
+	return Message{t, nFields, 0}
+}
+
 func (m *Message) Decode(i interface{}) (err error) {
 	err = m.t.Decode(i)
 	if err == nil {

--- a/go/vendor/github.com/maxtaco/go-framed-msgpack-rpc/rpc2/server.go
+++ b/go/vendor/github.com/maxtaco/go-framed-msgpack-rpc/rpc2/server.go
@@ -14,6 +14,12 @@ func (s *Server) Register(p Protocol) (err error) {
 	return s.xp.dispatcher.RegisterProtocol(p)
 }
 
+// RegisterEOFHook registers a callback that's called when there's
+// and EOF condition on the underlying channel.
+func (s *Server) RegisterEOFHook(h EOFHook) error {
+	return s.xp.dispatcher.RegisterEOFHook(h)
+}
+
 func (s *Server) Run(bg bool) error {
 	return s.xp.run(bg)
 }

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -98,9 +98,14 @@
 			"revisionTime": "2015-05-20T12:37:12-04:00"
 		},
 		{
+			"path": "github.com/maxtaco/go-framed-msgpack-rpc",
+			"revision": "5bc8b1e1cabf1c2eaf81a19d82562df4cf6a2352",
+			"revisionTime": "2015-10-05T22:14:12-04:00"
+		},
+		{
 			"path": "github.com/maxtaco/go-framed-msgpack-rpc/rpc2",
-			"revision": "c4d171b43eec575a772d95cca21f89ac395cd1d0",
-			"revisionTime": "2015-05-01T14:28:35-04:00"
+			"revision": "5bc8b1e1cabf1c2eaf81a19d82562df4cf6a2352",
+			"revisionTime": "2015-10-05T22:14:12-04:00"
 		},
 		{
 			"path": "github.com/op/go-logging",

--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -25,6 +25,8 @@ build-stamp: \
 	json/gpg_ui.json \
 	json/identify.json \
 	json/identify_ui.json \
+	json/kex2provisioner.json \
+	json/kex2provisionee.json \
 	json/locksmith_ui.json \
 	json/log_ui.json \
 	json/login.json \

--- a/protocol/avdl/kex2provisionee.avdl
+++ b/protocol/avdl/kex2provisionee.avdl
@@ -1,0 +1,19 @@
+
+@namespace("keybase.1")
+protocol Kex2Provisionee {
+	import idl "common.avdl";
+
+	record PassphraseStream {
+		bytes passphraseStream;
+		int generation	;
+	}
+
+	@typedef("string")
+	record SessionToken {}
+
+	@typedef("string")
+	record HelloRes {}
+
+	HelloRes hello(UID uid, SessionToken token, PassphraseStream pps, string sigBody);
+	void didCounterSign(bytes sig);
+}

--- a/protocol/avdl/kex2provisioner.avdl
+++ b/protocol/avdl/kex2provisioner.avdl
@@ -1,0 +1,6 @@
+
+@namespace("keybase.1")
+protocol Kex2Provisioner {
+	@notify("")
+	void kexStart();
+}

--- a/protocol/js/keybase_v1.js
+++ b/protocol/js/keybase_v1.js
@@ -297,6 +297,19 @@ module.exports = {
       "updateOk": 6
     }
   },
+  "Kex2Provisionee": {
+    "LogLevel": {
+      "none": 0,
+      "debug": 1,
+      "info": 2,
+      "notice": 3,
+      "warn": 4,
+      "error": 5,
+      "critical": 6,
+      "fatal": 7
+    }
+  },
+  "Kex2Provisioner": {},
   "locksmithUi": {
     "LogLevel": {
       "none": 0,

--- a/protocol/json/kex2provisionee.json
+++ b/protocol/json/kex2provisionee.json
@@ -1,0 +1,207 @@
+{
+  "protocol" : "Kex2Provisionee",
+  "namespace" : "keybase.1",
+  "types" : [ {
+    "type" : "record",
+    "name" : "Time",
+    "fields" : [ ],
+    "typedef" : "long"
+  }, {
+    "type" : "record",
+    "name" : "StringKVPair",
+    "fields" : [ {
+      "name" : "key",
+      "type" : "string"
+    }, {
+      "name" : "value",
+      "type" : "string"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "Status",
+    "fields" : [ {
+      "name" : "code",
+      "type" : "int"
+    }, {
+      "name" : "name",
+      "type" : "string"
+    }, {
+      "name" : "desc",
+      "type" : "string"
+    }, {
+      "name" : "fields",
+      "type" : {
+        "type" : "array",
+        "items" : "StringKVPair"
+      }
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UID",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
+    "type" : "record",
+    "name" : "DeviceID",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
+    "type" : "record",
+    "name" : "SigID",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
+    "type" : "record",
+    "name" : "KID",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
+    "type" : "record",
+    "name" : "Text",
+    "fields" : [ {
+      "name" : "data",
+      "type" : "string"
+    }, {
+      "name" : "markup",
+      "type" : "boolean"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "PGPIdentity",
+    "fields" : [ {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "comment",
+      "type" : "string"
+    }, {
+      "name" : "email",
+      "type" : "string"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "PublicKey",
+    "fields" : [ {
+      "name" : "KID",
+      "type" : "KID"
+    }, {
+      "name" : "PGPFingerprint",
+      "type" : "string"
+    }, {
+      "name" : "PGPIdentities",
+      "type" : {
+        "type" : "array",
+        "items" : "PGPIdentity"
+      }
+    }, {
+      "name" : "isSibkey",
+      "type" : "boolean"
+    }, {
+      "name" : "isEldest",
+      "type" : "boolean"
+    }, {
+      "name" : "parentID",
+      "type" : "string"
+    }, {
+      "name" : "deviceID",
+      "type" : "DeviceID"
+    }, {
+      "name" : "deviceDescription",
+      "type" : "string"
+    }, {
+      "name" : "deviceType",
+      "type" : "string"
+    }, {
+      "name" : "cTime",
+      "type" : "Time"
+    }, {
+      "name" : "eTime",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "User",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "Device",
+    "fields" : [ {
+      "name" : "type",
+      "type" : "string"
+    }, {
+      "name" : "name",
+      "type" : "string"
+    }, {
+      "name" : "deviceID",
+      "type" : "DeviceID"
+    }, {
+      "name" : "cTime",
+      "type" : "Time"
+    }, {
+      "name" : "mTime",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "Stream",
+    "fields" : [ {
+      "name" : "fd",
+      "type" : "int"
+    } ]
+  }, {
+    "type" : "enum",
+    "name" : "LogLevel",
+    "symbols" : [ "NONE_0", "DEBUG_1", "INFO_2", "NOTICE_3", "WARN_4", "ERROR_5", "CRITICAL_6", "FATAL_7" ]
+  }, {
+    "type" : "record",
+    "name" : "PassphraseStream",
+    "fields" : [ {
+      "name" : "passphraseStream",
+      "type" : "bytes"
+    }, {
+      "name" : "generation",
+      "type" : "int"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "SessionToken",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
+    "type" : "record",
+    "name" : "HelloRes",
+    "fields" : [ ],
+    "typedef" : "string"
+  } ],
+  "messages" : {
+    "hello" : {
+      "request" : [ {
+        "name" : "uid",
+        "type" : "UID"
+      }, {
+        "name" : "token",
+        "type" : "SessionToken"
+      }, {
+        "name" : "pps",
+        "type" : "PassphraseStream"
+      }, {
+        "name" : "sigBody",
+        "type" : "string"
+      } ],
+      "response" : "HelloRes"
+    },
+    "didCounterSign" : {
+      "request" : [ {
+        "name" : "sig",
+        "type" : "bytes"
+      } ],
+      "response" : "null"
+    }
+  }
+}

--- a/protocol/json/kex2provisioner.json
+++ b/protocol/json/kex2provisioner.json
@@ -1,0 +1,12 @@
+{
+  "protocol" : "Kex2Provisioner",
+  "namespace" : "keybase.1",
+  "types" : [ ],
+  "messages" : {
+    "kexStart" : {
+      "notify" : "",
+      "request" : [ ],
+      "response" : "null"
+    }
+  }
+}

--- a/protocol/objc/KBRPC.h
+++ b/protocol/objc/KBRPC.h
@@ -329,6 +329,11 @@ typedef NS_ENUM (NSInteger, KBRTrackStatus) {
 @property KBRSigHint *hint;
 @end
 
+@interface KBRPassphraseStream : KBRObject
+@property NSData *passphraseStream;
+@property NSInteger generation;
+@end
+
 typedef NS_ENUM (NSInteger, KBRDeviceSignerKind) {
 	KBRDeviceSignerKindDevice = 0,
 	KBRDeviceSignerKindPgp = 1,
@@ -455,13 +460,6 @@ typedef NS_ENUM (NSInteger, KBRPromptOverwriteType) {
 	KBRPromptOverwriteTypeSocial = 0,
 	KBRPromptOverwriteTypeSite = 1,
 };
-
-@interface KBRSessionToken : KBRObject
-@property NSString *uid;
-@property NSString *sid;
-@property NSInteger generated;
-@property NSInteger lifetime;
-@end
 
 @interface KBRSecretEntryArg : KBRObject
 @property NSString *desc;
@@ -774,6 +772,15 @@ typedef NS_ENUM (NSInteger, KBRPromptDefault) {
 @end
 @interface KBRFinishRequestParams : KBRRequestParams
 @property NSInteger sessionID;
+@end
+@interface KBRHelloRequestParams : KBRRequestParams
+@property NSString *uid;
+@property NSString *token;
+@property KBRPassphraseStream *pps;
+@property NSString *sigBody;
+@end
+@interface KBRDidCounterSignRequestParams : KBRRequestParams
+@property NSData *sig;
 @end
 @interface KBRPromptDeviceNameRequestParams : KBRRequestParams
 @property NSInteger sessionID;
@@ -1389,6 +1396,24 @@ typedef NS_ENUM (NSInteger, KBRPromptDefault) {
 
 @end
 
+@interface KBRKex2ProvisioneeRequest : KBRRequest
+
+- (void)hello:(KBRHelloRequestParams *)params completion:(void (^)(NSError *error, NSString *helloRes))completion;
+
+- (void)helloWithUid:(NSString *)uid token:(NSString *)token pps:(KBRPassphraseStream *)pps sigBody:(NSString *)sigBody completion:(void (^)(NSError *error, NSString *helloRes))completion;
+
+- (void)didCounterSign:(KBRDidCounterSignRequestParams *)params completion:(void (^)(NSError *error))completion;
+
+- (void)didCounterSignWithSig:(NSData *)sig completion:(void (^)(NSError *error))completion;
+
+@end
+
+@interface KBRKex2ProvisionerRequest : KBRRequest
+
+- (void)kexStart:(void (^)(NSError *error))completion;
+
+@end
+
 @interface KBRLocksmithUiRequest : KBRRequest
 
 - (void)promptDeviceName:(void (^)(NSError *error, NSString *str))completion;
@@ -1625,9 +1650,9 @@ typedef NS_ENUM (NSInteger, KBRPromptDefault) {
 
 @interface KBRQuotaRequest : KBRRequest
 
-- (void)verifySession:(KBRVerifySessionRequestParams *)params completion:(void (^)(NSError *error, KBRSessionToken *sessionToken))completion;
+- (void)verifySession:(KBRVerifySessionRequestParams *)params completion:(void (^)(NSError *error, NSString *sessionToken))completion;
 
-- (void)verifySessionWithSession:(NSString *)session completion:(void (^)(NSError *error, KBRSessionToken *sessionToken))completion;
+- (void)verifySessionWithSession:(NSString *)session completion:(void (^)(NSError *error, NSString *sessionToken))completion;
 
 @end
 

--- a/protocol/objc/KBRPC.m
+++ b/protocol/objc/KBRPC.m
@@ -696,6 +696,59 @@
 
 @end
 
+@implementation KBRKex2ProvisioneeRequest
+
+- (void)hello:(KBRHelloRequestParams *)params completion:(void (^)(NSError *error, NSString *helloRes))completion {
+  NSDictionary *rparams = @{@"uid": KBRValue(params.uid), @"token": KBRValue(params.token), @"pps": KBRValue(params.pps), @"sigBody": KBRValue(params.sigBody)};
+  [self.client sendRequestWithMethod:@"keybase.1.Kex2Provisionee.hello" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
+    if (error) {
+      completion(error, nil);
+      return;
+    }
+    NSString *result = retval ? [MTLJSONAdapter modelOfClass:NSString.class fromJSONDictionary:retval error:&error] : nil;
+    completion(error, result);
+  }];
+}
+
+- (void)helloWithUid:(NSString *)uid token:(NSString *)token pps:(KBRPassphraseStream *)pps sigBody:(NSString *)sigBody completion:(void (^)(NSError *error, NSString *helloRes))completion {
+  NSDictionary *rparams = @{@"uid": KBRValue(uid), @"token": KBRValue(token), @"pps": KBRValue(pps), @"sigBody": KBRValue(sigBody)};
+  [self.client sendRequestWithMethod:@"keybase.1.Kex2Provisionee.hello" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
+    if (error) {
+      completion(error, nil);
+      return;
+    }
+    NSString *result = retval ? [MTLJSONAdapter modelOfClass:NSString.class fromJSONDictionary:retval error:&error] : nil;
+    completion(error, result);
+  }];
+}
+
+- (void)didCounterSign:(KBRDidCounterSignRequestParams *)params completion:(void (^)(NSError *error))completion {
+  NSDictionary *rparams = @{@"sig": KBRValue(params.sig)};
+  [self.client sendRequestWithMethod:@"keybase.1.Kex2Provisionee.didCounterSign" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
+    completion(error);
+  }];
+}
+
+- (void)didCounterSignWithSig:(NSData *)sig completion:(void (^)(NSError *error))completion {
+  NSDictionary *rparams = @{@"sig": KBRValue(sig)};
+  [self.client sendRequestWithMethod:@"keybase.1.Kex2Provisionee.didCounterSign" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
+    completion(error);
+  }];
+}
+
+@end
+
+@implementation KBRKex2ProvisionerRequest
+
+- (void)kexStart:(void (^)(NSError *error))completion {
+  NSDictionary *rparams = @{};
+  [self.client sendRequestWithMethod:@"keybase.1.Kex2Provisioner.kexStart" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
+    completion(error);
+  }];
+}
+
+@end
+
 @implementation KBRLocksmithUiRequest
 
 - (void)promptDeviceName:(void (^)(NSError *error, NSString *str))completion {
@@ -1552,26 +1605,26 @@
 
 @implementation KBRQuotaRequest
 
-- (void)verifySession:(KBRVerifySessionRequestParams *)params completion:(void (^)(NSError *error, KBRSessionToken *sessionToken))completion {
+- (void)verifySession:(KBRVerifySessionRequestParams *)params completion:(void (^)(NSError *error, NSString *sessionToken))completion {
   NSDictionary *rparams = @{@"session": KBRValue(params.session)};
   [self.client sendRequestWithMethod:@"keybase.1.quota.verifySession" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
     if (error) {
       completion(error, nil);
       return;
     }
-    KBRSessionToken *result = retval ? [MTLJSONAdapter modelOfClass:KBRSessionToken.class fromJSONDictionary:retval error:&error] : nil;
+    NSString *result = retval ? [MTLJSONAdapter modelOfClass:NSString.class fromJSONDictionary:retval error:&error] : nil;
     completion(error, result);
   }];
 }
 
-- (void)verifySessionWithSession:(NSString *)session completion:(void (^)(NSError *error, KBRSessionToken *sessionToken))completion {
+- (void)verifySessionWithSession:(NSString *)session completion:(void (^)(NSError *error, NSString *sessionToken))completion {
   NSDictionary *rparams = @{@"session": KBRValue(session)};
   [self.client sendRequestWithMethod:@"keybase.1.quota.verifySession" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
     if (error) {
       completion(error, nil);
       return;
     }
-    KBRSessionToken *result = retval ? [MTLJSONAdapter modelOfClass:KBRSessionToken.class fromJSONDictionary:retval error:&error] : nil;
+    NSString *result = retval ? [MTLJSONAdapter modelOfClass:NSString.class fromJSONDictionary:retval error:&error] : nil;
     completion(error, result);
   }];
 }
@@ -3046,6 +3099,41 @@
 
 + (instancetype)params {
   KBRFinishRequestParams *p = [[self alloc] init];
+  // Add default values
+  return p;
+}
+@end
+
+@implementation KBRHelloRequestParams
+
+- (instancetype)initWithParams:(NSArray *)params {
+  if ((self = [super initWithParams:params])) {
+    self.uid = params[0][@"uid"];
+    self.token = params[0][@"token"];
+    self.pps = [MTLJSONAdapter modelOfClass:KBRPassphraseStream.class fromJSONDictionary:params[0][@"pps"] error:nil];
+    self.sigBody = params[0][@"sigBody"];
+  }
+  return self;
+}
+
++ (instancetype)params {
+  KBRHelloRequestParams *p = [[self alloc] init];
+  // Add default values
+  return p;
+}
+@end
+
+@implementation KBRDidCounterSignRequestParams
+
+- (instancetype)initWithParams:(NSArray *)params {
+  if ((self = [super initWithParams:params])) {
+    self.sig = params[0][@"sig"];
+  }
+  return self;
+}
+
++ (instancetype)params {
+  KBRDidCounterSignRequestParams *p = [[self alloc] init];
   // Add default values
   return p;
 }
@@ -4702,6 +4790,9 @@
 @implementation KBRLinkCheckResult
 @end
 
+@implementation KBRPassphraseStream
+@end
+
 @implementation KBRDeviceSigner
 @end
 
@@ -4746,9 +4837,6 @@
 @end
 
 @implementation KBRStartProofResult
-@end
-
-@implementation KBRSessionToken
 @end
 
 @implementation KBRSecretEntryArg


### PR DESCRIPTION
This (squashed) commit is the new RPC layer for KEX2, with some pretty good tests.
It relies on #1015 (the KEX2 transport) and also a new version of maxtaco/go-framed-msgpack-rpc,
which we're soon to upgrade to keybase/go-framed-msgpack-rpc

It might still need some more tests, but I wonder if we should continue to build on top
of this library before we add more.

Closes #1050 

(This PR instead of a previous PR, since the kex2 transport is now merged into master).
