### PR TITLE
Add a list of supported services to "keybase help prove".

### DIFF
--- a/go/libkb/proof_checkers.go
+++ b/go/libkb/proof_checkers.go
@@ -33,15 +33,5 @@ func NewProofChecker(l RemoteProofChainLink) (ProofChecker, ProofError) {
 	return hook(l)
 }
 
-func ListProofCheckers() (proofCheckers []string) {
-	for k := range _dispatch {
-		// Rooter's a test social network for keybase proofs.
-		if k != "rooter" {
-			proofCheckers = append(proofCheckers, k)
-		}
-	}
-	return proofCheckers
-}
-
 //
 //=============================================================================

--- a/go/libkb/proof_checkers_devel.go
+++ b/go/libkb/proof_checkers_devel.go
@@ -1,0 +1,11 @@
+// +build !production,!staging
+
+package libkb
+
+// ListProofCheckers returns the supported networks for "keybase prove".
+func ListProofCheckers() (proofCheckers []string) {
+	for k := range _dispatch {
+		proofCheckers = append(proofCheckers, k)
+	}
+	return proofCheckers
+}

--- a/go/libkb/proof_checkers_production.go
+++ b/go/libkb/proof_checkers_production.go
@@ -1,0 +1,14 @@
+// +build production staging
+
+package libkb
+
+// ListProofCheckers returns the supported networks for "keybase prove".
+func ListProofCheckers() (proofCheckers []string) {
+	for k := range _dispatch {
+		// Rooter's a test social network for keybase proofs.
+		if k != "rooter" {
+			proofCheckers = append(proofCheckers, k)
+		}
+	}
+	return proofCheckers
+}


### PR DESCRIPTION
Node client lists them, Go client doesn't.

Fixes CORE-1894.
