### PR TITLE
Remove ClearSocketError

### DIFF
--- a/go/client/fork_server_nix.go
+++ b/go/client/fork_server_nix.go
@@ -63,12 +63,11 @@ func ForkServerNix(cl libkb.CommandLine) error {
 func pingLoop() error {
 	var err error
 	for i := 0; i < 10; i++ {
-		_, _, err = G.GetSocket()
+		_, _, err = G.GetSocket(true)
 		if err == nil {
 			G.Log.Debug("Connected (%d)", i)
 			return nil
 		}
-		G.ClearSocketError()
 		G.Log.Debug("Failed to connect to socket (%d): %s", i, err)
 		err = nil
 		time.Sleep(200 * time.Millisecond)

--- a/go/client/rpc.go
+++ b/go/client/rpc.go
@@ -7,14 +7,14 @@ import (
 )
 
 func GetRPCClient() (ret *rpc.Client, xp rpc.Transporter, err error) {
-	if _, xp, err = G.GetSocket(); err == nil {
+	if _, xp, err = G.GetSocket(false); err == nil {
 		ret = rpc.NewClient(xp, libkb.ErrorUnwrapper{})
 	}
 	return
 }
 
 func GetRPCServer() (ret *rpc.Server, xp rpc.Transporter, err error) {
-	if _, xp, err = G.GetSocket(); err == nil {
+	if _, xp, err = G.GetSocket(false); err == nil {
 		ret = rpc.NewServer(xp, libkb.WrapError)
 	}
 	if err != nil {

--- a/go/libkb/socket.go
+++ b/go/libkb/socket.go
@@ -85,13 +85,7 @@ func (g *GlobalContext) BindToSocket() (net.Listener, error) {
 	return BindToSocket(g.SocketInfo)
 }
 
-func (g *GlobalContext) ClearSocketError() {
-	g.socketWrapperMu.Lock()
-	g.SocketWrapper = nil
-	g.socketWrapperMu.Unlock()
-}
-
-func (g *GlobalContext) GetSocket() (net.Conn, rpc.Transporter, error) {
+func (g *GlobalContext) GetSocket(clearError bool) (net.Conn, rpc.Transporter, error) {
 
 	// Protect all global socket wrapper manipulation with a
 	// lock to prevent race conditions.
@@ -122,5 +116,10 @@ func (g *GlobalContext) GetSocket() (net.Conn, rpc.Transporter, error) {
 		g.SocketWrapper = &sw
 	}
 
-	return g.SocketWrapper.conn, g.SocketWrapper.xp, g.SocketWrapper.err
+	sw := g.SocketWrapper
+	if sw.err != nil && clearError {
+		g.SocketWrapper = nil
+	}
+
+	return sw.conn, sw.xp, sw.err
 }

--- a/go/loopback/main.go
+++ b/go/loopback/main.go
@@ -83,7 +83,7 @@ func Reset() {
 
 	var err error
 	libkb.G.SocketWrapper = nil
-	con, _, err = libkb.G.GetSocket()
+	con, _, err = libkb.G.GetSocket(false)
 
 	if err != nil {
 		fmt.Println("loopback socker error:", err)


### PR DESCRIPTION
Instead have a boolean parameter to GetSocket().

KBFS may call GetSocket() from multiple goroutines, so
ClearSocketError is racy in that context.
