### PR TITLE
Windows terminal support

### DIFF
--- a/go/client/color.go
+++ b/go/client/color.go
@@ -89,16 +89,6 @@ func colorByteSequence(code int) []byte {
 func (cp CodePair) OpenBytes() []byte  { return colorByteSequence(cp.Open) }
 func (cp CodePair) CloseBytes() []byte { return colorByteSequence(cp.Close) }
 
-func HasColor() bool {
-	// TODO Color should be based on whether log format supports it
-	logFormatHasColor := map[string]bool{
-		"":        true,
-		"default": true,
-		"fancy":   true,
-	}
-	return logFormatHasColor[G.Env.GetLogFormat()]
-}
-
 func ColorOpen(which string) []byte {
 	if !HasColor() {
 		return nil

--- a/go/client/color_nix.go
+++ b/go/client/color_nix.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+package client
+
+func HasColor() bool {
+	// TODO Color should be based on whether log format supports it
+	logFormatHasColor := map[string]bool{
+		"":        true,
+		"default": true,
+		"fancy":   true,
+	}
+	return logFormatHasColor[G.Env.GetLogFormat()]
+}

--- a/go/client/color_windows.go
+++ b/go/client/color_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package client
+
+func HasColor() bool {
+	// This is used for embedding color codes in UI strings,
+	// which won't work in Windows
+	return false
+}

--- a/go/logger/formats_nix.go
+++ b/go/logger/formats_nix.go
@@ -1,0 +1,10 @@
+// +build !windows
+
+package logger
+
+const (
+	fancyFormat   = "%{color}%{time:15:04:05.000000} ▶ [%{level:.4s} %{module} %{shortfile}] %{id:03x}%{color:reset} %{message}"
+	plainFormat   = "[%{level:.4s}] %{id:03x} %{message}"
+	fileFormat    = "%{time:15:04:05.000000} ▶ [%{level:.4s} %{module} %{shortfile}] %{id:03x} %{message}"
+	defaultFormat = "%{color}▶ %{level} %{message}%{color:reset}"
+)

--- a/go/logger/formats_windows.go
+++ b/go/logger/formats_windows.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package logger
+
+// These had a weird unicode character which made it look messy on Windows
+
+const (
+	fancyFormat   = "%{color}%{time:15:04:05.000000} - [%{level:.4s} %{module} %{shortfile}] %{id:03x}%{color:reset} %{message}"
+	plainFormat   = "[%{level:.4s}] %{id:03x} %{message}"
+	fileFormat    = "%{time:15:04:05.000000} - [%{level:.4s} %{module} %{shortfile}] %{id:03x} %{message}"
+	defaultFormat = "%{color}- %{level} %{message}%{color:reset}"
+)

--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -12,13 +12,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-const (
-	fancyFormat   = "%{color}%{time:15:04:05.000000} ▶ [%{level:.4s} %{module} %{shortfile}] %{id:03x}%{color:reset} %{message}"
-	plainFormat   = "[%{level:.4s}] %{id:03x} %{message}"
-	fileFormat    = "%{time:15:04:05.000000} ▶ [%{level:.4s} %{module} %{shortfile}] %{id:03x} %{message}"
-	defaultFormat = "%{color}▶ %{level} %{message}%{color:reset}"
-)
-
 const permDir os.FileMode = 0700
 
 var initLoggingBackendOnce sync.Once

--- a/go/minterm/minterm.go
+++ b/go/minterm/minterm.go
@@ -9,13 +9,10 @@ import (
 
 	"github.com/keybase/gopass"
 	"github.com/keybase/miniline"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 // MinTerm is a minimal terminal interface.
 type MinTerm struct {
-	tty    *os.File
-	in     *os.File
 	out    *os.File
 	width  int
 	height int
@@ -34,31 +31,14 @@ func New() (*MinTerm, error) {
 	return m, nil
 }
 
-func (m *MinTerm) open() error {
-	f, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
-	if err != nil {
-		return err
-	}
-	m.tty = f
-	m.out = m.tty
-	m.in = m.tty
-	fd := int(m.tty.Fd())
-	w, h, err := terminal.GetSize(fd)
-	if err != nil {
-		return err
-	}
-	m.width, m.height = w, h
-	return nil
-}
-
 // Shutdown closes the terminal.
 func (m *MinTerm) Shutdown() error {
-	if m.tty == nil {
+	if m.out == nil {
 		return nil
 	}
 	// this can hang waiting for newline, so do it in a goroutine.
 	// application shutting down, so will get closed by os anyway...
-	go m.tty.Close()
+	go m.out.Close()
 	return nil
 }
 

--- a/go/minterm/minterm_nix.go
+++ b/go/minterm/minterm_nix.go
@@ -1,0 +1,23 @@
+// +build !windows
+
+package minterm
+
+import (
+	"golang.org/x/crypto/ssh/terminal"
+	"os"
+)
+
+func (m *MinTerm) open() error {
+	f, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	m.out = f
+	fd := int(m.out.Fd())
+	w, h, err := terminal.GetSize(fd)
+	if err != nil {
+		return err
+	}
+	m.width, m.height = w, h
+	return nil
+}

--- a/go/minterm/minterm_windows.go
+++ b/go/minterm/minterm_windows.go
@@ -1,0 +1,24 @@
+// +build windows
+
+package minterm
+
+import (
+	"golang.org/x/crypto/ssh/terminal"
+	"os"
+)
+
+func (m *MinTerm) open() error {
+	fout, err := os.OpenFile("CONOUT$", os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+
+	m.out = fout
+	fd := int(m.out.Fd())
+	w, h, err := terminal.GetSize(fd)
+	if err != nil {
+		return err
+	}
+	m.width, m.height = w, h
+	return nil
+}


### PR DESCRIPTION
Please see also https://github.com/keybase/go-logging/pull/1
Some colors are now supported with this, but unfortunately much of the UI has the ansi terminal codes baked in to the prompt strings, which I have not attempted to unravel here.
@maxtaco @oconnor663 
