### PR TITLE
Only rerender the Tab Bar if the titles have changed

### DIFF
--- a/react-native/react/native/tab-bar.android.js
+++ b/react-native/react/native/tab-bar.android.js
@@ -38,6 +38,24 @@ export default class TabBar extends Component {
     super(props)
   }
 
+  shouldComponentUpdate (nextProps, nextState) {
+    // If the titles are the same, then we aren't going to rerender.
+    const oldTabs = this.props.children
+    const newTabs = nextProps.children
+    const oldTitles = oldTabs.map((t) => t.props.title)
+    const newTitles = newTabs.map((t) => t.props.title)
+    if (oldTitles.length !== newTitles.length) {
+      return true
+    }
+
+    oldTitles.forEach((oldTitle, i) => {
+      if (oldTitle !== newTitles[i]) {
+        return true
+      }
+    })
+    return false
+  }
+
   render () {
     const tabs = this.props.children
     const titles = tabs.map((t) => t.props.title)


### PR DESCRIPTION
This relies on the assumption that we aren't going to be passing in a new component with the same exact title into the tab bar. So far we haven't even changed the tab bar after creating it so I think that is a safe assumption.

This prevents rerenders from the tab bar item, so only the children are rerendering!

Bonus: componentWillMount works as expected now :fireworks: 

@keybase/react-hackers 
