### PR TITLE
adding patch for packager to use .mobile files

### DIFF
--- a/react-native/ResolutionRequest.patch
+++ b/react-native/ResolutionRequest.patch
@@ -1,0 +1,10 @@
++++ ./node_modules/react-native/packager/react-packager/src/DependencyResolver/DependencyGraph/ResolutionRequest.js	2015-10-23 13:25:58.000000000 -0400
+@@ -278,6 +278,8 @@
+       } else if (this._platform != null &&
+                  this._fastfs.fileExists(potentialModulePath + '.' + this._platform + '.js')) {
+         file = potentialModulePath + '.' + this._platform + '.js';
++      } else if (this._fastfs.fileExists(potentialModulePath + '.mobile.js')) {
++        file = potentialModulePath + '.mobile.js';
+       } else if (this._fastfs.fileExists(potentialModulePath + '.js')) {
+         file = potentialModulePath + '.js';
+       } else if (this._fastfs.fileExists(potentialModulePath + '.json')) {


### PR DESCRIPTION
@cjb @Sidnicious @MarcoPolo this'll allow us to use blah.mobile.js files for shared ios and android

we have to patch the packager,,,,, blurg
