### PR TITLE
Add Demo code for promises based flow

### DIFF
--- a/react-native/react/tabs/more/flow-route.js
+++ b/react-native/react/tabs/more/flow-route.js
@@ -1,0 +1,129 @@
+'use strict'
+
+import React, { Component, View, Text } from 'react-native'
+import { routeAppend } from '../../actions/router'
+import Button from '../../common-adapters/button'
+
+const FlowComponentProps = {
+  onNext: React.PropTypes.func.isRequired,
+  onError: React.PropTypes.func.isRequired
+}
+
+class A extends Component {
+  render () {
+    return (
+      <View style={{flex: 1, justifyContent: 'center'}}>
+        <Text style={{textAlign: 'center'}}> A </Text>
+        <Button onPress={this.props.onNext}>
+          <Text>Next Step</Text>
+        </Button>
+      </View>
+    )
+  }
+}
+
+A.propTypes = FlowComponentProps
+
+class B extends Component {
+  render () {
+    return (
+      <View style={{flex: 1, justifyContent: 'center'}}>
+        <Text style={{textAlign: 'center'}}> B </Text>
+        <Button onPress={this.props.onNext}>
+          <Text>Next Step</Text>
+        </Button>
+        <Button onPress={this.props.onError}>
+          <Text>Fail!</Text>
+        </Button>
+      </View>
+    )
+  }
+}
+
+B.propTypes = FlowComponentProps
+
+class C extends Component {
+  render () {
+    return (
+      <View style={{flex: 1, justifyContent: 'center'}}>
+        <Text style={{textAlign: 'center'}}> C </Text>
+      </View>
+    )
+  }
+}
+
+C.propTypes = FlowComponentProps
+
+class D extends Component {
+  render () {
+    return (
+      <View style={{flex: 1, justifyContent: 'center'}}>
+        <Text style={{textAlign: 'center'}}> D </Text>
+      </View>
+    )
+  }
+}
+
+D.propTypes = FlowComponentProps
+
+function ComponentPromise (dispatch) {
+  return (component, mapStateToProps) => {
+    return () => {
+      return new Promise((resolve, reject) => {
+        dispatch(routeAppend({
+          path: component,
+          mapStateToProps: (state) => {
+            return Object.assign({
+              onNext: resolve,
+              onError: reject
+            },
+            mapStateToProps && mapStateToProps(state))
+          }
+        }))
+      })
+    }
+  }
+}
+
+export default class FlowDemo extends Component {
+  componentWillMount () {
+    const { componentPromise } = this.props
+    componentPromise(A)()
+      .then(componentPromise(B))
+      .catch(componentPromise(D))
+      .then(componentPromise(C))
+  }
+
+  render () {
+    return (
+      <View style={{flex: 1, justifyContent: 'center'}}>
+        <Text style={{textAlign: 'center'}}> Loading Flow Demo... </Text>
+      </View>
+    )
+  }
+
+  static parseRoute (store, currentPath, nextPath, uri) {
+    const lastPath = uri.last()
+
+    if (lastPath === currentPath) {
+      return {
+        componentAtTop: {
+          mapStateToProps: () => { return {componentPromise: ComponentPromise(store.dispatch)} },
+          title: 'Flow Demo'
+        }
+      }
+    }
+
+    return {
+      componentAtTop: {
+        component: lastPath.get('path'),
+        mapStateToProps: lastPath.get('mapStateToProps'),
+        hideNavBar: true
+      }
+    }
+  }
+}
+
+FlowDemo.propTypes = {
+  componentPromise: React.PropTypes.func.isRequired
+}

--- a/react-native/react/tabs/more/index.js
+++ b/react-native/react/tabs/more/index.js
@@ -43,6 +43,9 @@ export default class More extends Component {
         {name: 'Nav debug', hasChildren: true, onClick: () => {
           this.props.navigateTo(['navDebug'])
         }},
+        {name: 'Flow Routing Demo', hasChildren: true, onClick: () => {
+          this.props.navigateTo(['flowRoute'])
+        }},
         {name: 'Bridging', hasChildren: true, onClick: () => {
           this.props.navigateTo(['bridging'])
         }},
@@ -101,6 +104,7 @@ export default class More extends Component {
         navDebug: require('../../debug/nav-debug'),
         bridging: require('../../debug/bridging-tabs'),
         login: require('../../login'),
+        flowRoute: require('./flow-route'),
         login2: require('../../login2')
       }
     }


### PR DESCRIPTION
This implements this flow of screens:

```
  +----+   +----+   +----+                                            
  |    |   |    |   |    |                                            
  | A  | ->| B  | ->| C  |                                            
  |    |   |    |   |    |                                            
  +----+   +----+   +----+                                            
             |
           onerror
             |
             v
           +----+ 
           |    | 
           | D  | 
           |    | 
           +----+ 

```

where `A`, `B`, `C`, & `D` are components that gets an onNext and onError prop. Imagine `B` is somewhere an error could have happened so it could call on error which should correctly route it to `D` or it could call onNext which would route it to `C`. But `B` should ​_not_​ know about `C` or `D`.

Not planning on merging this exact code, just want to talk about it
