### PR TITLE
Fix build on Android 4.4

### DIFF
--- a/react-native/react/nav.android.js
+++ b/react-native/react/nav.android.js
@@ -143,7 +143,7 @@ export default class Nav extends Component {
                 <TouchableNativeFeedback
                   onPress={ () => this.refs.drawer && this.refs.drawer.openDrawer() }
                   delayPressIn={0}
-                  background={TouchableNativeFeedback.Ripple('grey', true)} >
+                  background={TouchableNativeFeedback.SelectableBackground()} >
                   <View>
                     <Image style={[styles.toolbarImage, {marginTop: 4}]} resizeMode={'contain'} source={require('image!ic_menu_black_24dp')}/>
                   </View>
@@ -158,7 +158,7 @@ export default class Nav extends Component {
                   <TouchableNativeFeedback
                     onPress={ () => console.log('todo: show search')}
                     delayPressIn={0}
-                    background={TouchableNativeFeedback.Ripple('grey', true)} >
+                    background={TouchableNativeFeedback.SelectableBackground()}>
                     <View>
                       <Image style={styles.toolbarImage} resizeMode={'contain'} source={require('image!ic_search_black_24dp')}/>
                     </View>


### PR DESCRIPTION
TouchableNativeFeedback.Ripple() is only available on Android 5+ (API 21) but our in-house devices are Android 4.4 (API 19), so this crashes hard.
