### PR TITLE
Get passphrase stream before secret entry

### DIFF
--- a/go/engine/device_add.go
+++ b/go/engine/device_add.go
@@ -69,8 +69,7 @@ func (e *DeviceAdd) Run(ctx *Context) (err error) {
 	}
 
 	// create provisioner engine
-	provisioner := NewKex2Provisioner(e.G(), secret.Secret())
-	provisioner.SetPassphraseStream(pps)
+	provisioner := NewKex2Provisioner(e.G(), secret.Secret(), pps)
 
 	var canceler func()
 

--- a/go/engine/kex2_provisioner.go
+++ b/go/engine/kex2_provisioner.go
@@ -26,11 +26,12 @@ type Kex2Provisioner struct {
 var _ kex2.Provisioner = (*Kex2Provisioner)(nil)
 
 // NewKex2Provisioner creates a Kex2Provisioner engine.
-func NewKex2Provisioner(g *libkb.GlobalContext, secret kex2.Secret) *Kex2Provisioner {
+func NewKex2Provisioner(g *libkb.GlobalContext, secret kex2.Secret, pps *libkb.PassphraseStream) *Kex2Provisioner {
 	return &Kex2Provisioner{
 		Contextified: libkb.NewContextified(g),
 		secret:       secret,
 		secretCh:     make(chan kex2.Secret),
+		pps:          pps,
 	}
 }
 
@@ -58,13 +59,11 @@ func (e *Kex2Provisioner) SubConsumers() []libkb.UIConsumer {
 }
 
 // Run starts the provisioner engine.
-func (e *Kex2Provisioner) Run(ctx *Context) (err error) {
-	e.G().Log.Debug("+ Kex2Provisioner.Run()")
-	defer func() { e.G().Log.Debug("- Kex2Provisioner.Run() -> %s", libkb.ErrToOk(err)) }()
-
+func (e *Kex2Provisioner) Run(ctx *Context) error {
 	// before starting provisioning, need to load some information:
 
 	// load self:
+	var err error
 	e.me, err = libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
 	if err != nil {
 		return err
@@ -119,11 +118,6 @@ func (e *Kex2Provisioner) Run(ctx *Context) (err error) {
 // secret channel.
 func (e *Kex2Provisioner) AddSecret(s kex2.Secret) {
 	e.secretCh <- s
-}
-
-// SetPassphraseStream populates the passphrase stream.
-func (e *Kex2Provisioner) SetPassphraseStream(pps *libkb.PassphraseStream) {
-	e.pps = pps
 }
 
 // GetLogFactory implements GetLogFactory in kex2.Provisioner.

--- a/go/engine/kex2_test.go
+++ b/go/engine/kex2_test.go
@@ -72,7 +72,7 @@ func TestKex2Provision(t *testing.T) {
 			SecretUI:    userX.NewSecretUI(),
 			ProvisionUI: &testProvisionUI{},
 		}
-		provisioner := NewKex2Provisioner(tcX.G, secretX)
+		provisioner := NewKex2Provisioner(tcX.G, secretX, nil)
 		go provisioner.AddSecret(secretY)
 		if err := RunEngine(provisioner, ctx); err != nil {
 			t.Errorf("provisioner error: %s", err)

--- a/go/engine/xlogin_test.go
+++ b/go/engine/xlogin_test.go
@@ -56,7 +56,7 @@ func TestXLogin(t *testing.T) {
 	}()
 
 	// start provisioner
-	provisioner := NewKex2Provisioner(tcX.G, secretX)
+	provisioner := NewKex2Provisioner(tcX.G, secretX, nil)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()


### PR DESCRIPTION
Before, if passphrase stream needed, it would be
prompted for via pinentry at same time as device secret
in terminal.

Now, if passphrase stream is needed, it is retrieved
before the device secret prompt.

r? @oconnor663 
