### PR TITLE
Change mapStateToProps to default to empty props

### DIFF
--- a/react-native/react/login2/index.js
+++ b/react-native/react/login2/index.js
@@ -25,9 +25,6 @@ export default class Login extends Component {
 
   static parseRoute (store, currentPath, nextPath) {
     return {
-      componentAtTop: {
-        mapStateToProps: state => { return {} }
-      },
       subRoutes: {
         welcome: Welcome,
         register: Register

--- a/react-native/react/login2/register/index.js
+++ b/react-native/react/login2/register/index.js
@@ -23,7 +23,6 @@ export default class Register extends Component {
   static parseRoute (store, currentPath, nextPath) {
     return {
       componentAtTop: {
-        mapStateToProps: state => { return {} },
         props: {
           gotoExistingDevicePage: () => store.dispatch(routeAppend('regExistingDevice')),
           gotoPaperKeyPage: () => store.dispatch(routeAppend('regPaperKey')),

--- a/react-native/react/login2/register/paper-key/index.js
+++ b/react-native/react/login2/register/paper-key/index.js
@@ -35,9 +35,6 @@ export default class PaperKey extends Component {
 
   static parseRoute (store, currentPath, nextPath) {
     return {
-      componentAtTop: {
-        mapStateToProps: state => { return {} }
-      },
       props: {
         submit: () => store.dispatch(navigateTo(['login2', 'register', 'setPublicName']))
       }

--- a/react-native/react/login2/welcome/index.js
+++ b/react-native/react/login2/welcome/index.js
@@ -36,7 +36,6 @@ export default class Welcome extends Component {
   static parseRoute (store, currentPath, nextPath) {
     return {
       componentAtTop: {
-        mapStateToProps: state => { return {} },
         hideNavBar: true,
         props: {
           gotoLoginPage: () => store.dispatch(routeAppend('login')),

--- a/react-native/react/login2/welcome/signup.js
+++ b/react-native/react/login2/welcome/signup.js
@@ -24,11 +24,7 @@ export default class Signup extends Component {
   }
 
   static parseRoute (store, currentPath, nextPath) {
-    return {
-      componentAtTop: {
-        mapStateToProps: state => { return {} }
-      }
-    }
+    return {}
   }
 }
 

--- a/react-native/react/nav.ios.js
+++ b/react-native/react/nav.ios.js
@@ -200,13 +200,6 @@ export default class Nav extends Component {
       </View>
     )
   }
-
-  static parseRoute () {
-    return {
-      componentAtTop: { component: Nav },
-      parseNextRoute: null
-    }
-  }
 }
 
 Nav.propTypes = {

--- a/react-native/react/router/meta-navigator.js
+++ b/react-native/react/router/meta-navigator.js
@@ -113,7 +113,7 @@ class MetaNavigator extends Component {
         renderScene={(route, navigator) => {
           return (
             <View style={{flex: 1, marginTop: route.hideNavBar ? 0 : this.props.navBarHeight}}>
-              {React.createElement(connect(route.mapStateToProps || (state => state))(route.component), {...route.props})}
+              {React.createElement(connect(route.mapStateToProps || (state => { return {} }))(route.component), {...route.props})}
             </View>
           )
         }}

--- a/react-native/react/tabs/more/index.js
+++ b/react-native/react/tabs/more/index.js
@@ -87,7 +87,6 @@ export default class More extends Component {
     return {
       componentAtTop: {
         title: 'More',
-        mapStateToProps: state => { return {} },
         props: {
           navigateTo: uri => store.dispatch(navigateTo(uri)),
           logout: () => store.dispatch(logout()),

--- a/react-native/react/tabs/start-up.js
+++ b/react-native/react/tabs/start-up.js
@@ -1,20 +1,12 @@
 import React, { Component, View, Text } from 'react-native'
 
 class RegisterPlaceHolder extends Component {
-  constructor (props) {
-    super(props)
-  }
-
   render () {
     return (<View><Text>TODO when kex2 is done import Registration from './login2/register'</Text></View>)
   }
 }
 
 export default class Startup extends Component {
-  constructor (props) {
-    super(props)
-  }
-
   render () {
     return <View><Text>Loading...</Text></View>
   }


### PR DESCRIPTION
Changes the default behavior of mapStateToProps to return an empty object.
@keybase/react-hackers 
