### PR TITLE
Initial implementation of the KB Crypto msg format

### DIFF
--- a/go/copyright.sh
+++ b/go/copyright.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-FILES=`find . -type f -name '*.go' | grep -Ev "^./vendor/"`
+FILES=`find $1 -type f -name '*.go' | grep -Ev "^./vendor/"`
 
 for f in $FILES
 do

--- a/go/kbcmf/common.go
+++ b/go/kbcmf/common.go
@@ -1,0 +1,67 @@
+package kbcmf
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/binary"
+	"github.com/ugorji/go/codec"
+	"golang.org/x/crypto/poly1305"
+)
+
+// encryptionBlockNumber describes which block number we're at in the sequence
+// of encrypted blocks. Each encrypted block of course fits into a packet.
+type encryptionBlockNumber uint64
+
+func codecHandle() *codec.MsgpackHandle {
+	var mh codec.MsgpackHandle
+	mh.WriteExt = true
+	return &mh
+}
+
+func randomFill(b []byte) (err error) {
+	l := len(b)
+	n, err := rand.Read(b)
+	if err != nil {
+		return err
+	}
+	if n != l {
+		return ErrInsufficientRandomness
+	}
+	return nil
+}
+
+func (n *Nonce) writeCounter(i uint64) {
+	binary.BigEndian.PutUint64((*n)[16:], i)
+}
+
+func (n *Nonce) writeCounter32(i uint32) {
+	binary.BigEndian.PutUint32((*n)[20:], i)
+}
+
+func (e encryptionBlockNumber) newCounterNonce() *Nonce {
+	var ret Nonce
+	ret.writeCounter(uint64(e))
+	return &ret
+}
+
+func (e encryptionBlockNumber) check() error {
+	if e >= encryptionBlockNumber(0xffffffffffffffff) {
+		return ErrPacketOverflow
+	}
+	return nil
+}
+
+func hmacSHA512(key []byte, data []byte) []byte {
+	hasher := hmac.New(sha512.New, key)
+	hasher.Write(data)
+	return hasher.Sum(nil)[0:32]
+}
+
+func hashCryptoBlock(nonce *Nonce, ciphertext []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.Write((*nonce)[:])
+	buf.Write(ciphertext[0:poly1305.TagSize])
+	return buf.Bytes(), nil
+}

--- a/go/kbcmf/common.go
+++ b/go/kbcmf/common.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package kbcmf
 
 import (

--- a/go/kbcmf/const.go
+++ b/go/kbcmf/const.go
@@ -1,0 +1,30 @@
+package kbcmf
+
+// PacketTag is an int used to describe what "tag" or "type" of packet it is.
+type PacketTag int
+
+// PacketVersion is an int used to capture the packet version. Right now, only
+// Version=1 is supported
+type PacketVersion int
+
+// PacketSeqno is a special int type used to describe which packet in the
+// sequence we're dealing with.  The header is always at seqno=0. Other packets
+// follow. Note that there is a distinction between PacketSeqno and EncryptionBlockNumber.
+// In general, the former is one more than the latter.
+type PacketSeqno int
+
+// PacketTagEncryptionHeader is a packet tag to describe the first packet
+// in an encryption message.
+const PacketTagEncryptionHeader PacketTag = 1
+
+// PacketTagEncryptionBlock is a packet tag to describe the body of an encryption.
+const PacketTagEncryptionBlock PacketTag = 2
+
+// PacketTagSignature is a packet tag for describing a signature packet
+const PacketTagSignature PacketTag = 3
+
+// PacketVersion1 is currently the only supported packet version
+const PacketVersion1 PacketVersion = 1
+
+// EncryptionBlockSize is by default 1MB and can't currently be tweaked.
+const EncryptionBlockSize int = 1048576

--- a/go/kbcmf/const.go
+++ b/go/kbcmf/const.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package kbcmf
 
 // PacketTag is an int used to describe what "tag" or "type" of packet it is.

--- a/go/kbcmf/decrypt.go
+++ b/go/kbcmf/decrypt.go
@@ -1,0 +1,235 @@
+package kbcmf
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"golang.org/x/crypto/nacl/secretbox"
+	"io"
+)
+
+// Keyring is an interface used with decryption; it is call to recover
+// public or private keys during the decryption process. Calls can block
+// on network action.
+type Keyring interface {
+	// LookupBoxSecretKey looks in the Keyring for the secret key corresponding
+	// to one of the given Key IDs.  Returns the index and the key on success,
+	// or -1 and nil on failure.
+	LookupBoxSecretKey(kids [][]byte) (int, BoxSecretKey)
+
+	// LookupBoxPublicKey returns a public key given the specified key ID.
+	// For most cases, the key ID will be the key itself.
+	LookupBoxPublicKey(kid []byte) BoxPublicKey
+}
+
+type publicDecryptStream struct {
+	output     io.Writer
+	ring       Keyring
+	fmps       *framedMsgpackStream
+	err        error
+	state      int
+	keys       *receiverKeysPlaintext
+	sessionKey SymmetricKey
+}
+
+func (pds *publicDecryptStream) Write(b []byte) (n int, err error) {
+	if pds.err != nil {
+		return 0, pds.err
+	}
+	if n, pds.err = pds.fmps.Write(b); pds.err != nil {
+		return 0, pds.err
+	}
+	if pds.err = pds.decode(); pds.err != nil {
+		return 0, pds.err
+	}
+	return n, nil
+}
+
+func (pds *publicDecryptStream) Close() (err error) {
+	if pds.err != nil {
+		return pds.err
+	}
+	if pds.err = pds.fmps.Close(); pds.err != nil {
+		return pds.err
+	}
+	pds.err = pds.decode()
+	return pds.err
+}
+
+func (pds *publicDecryptStream) decode() error {
+	var err error
+	var seqno PacketSeqno
+
+	for err == nil {
+		switch pds.state {
+		case 0:
+			var hdr EncryptionHeader
+			seqno, err = pds.fmps.Decode(&hdr)
+			if err == nil {
+				hdr.seqno = seqno
+				err = pds.processEncryptionHeader(&hdr)
+				if err == nil {
+					pds.state++
+				}
+			}
+		case 1:
+			var eb EncryptionBlock
+			seqno, err = pds.fmps.Decode(&eb)
+			var done bool
+			if err == nil {
+				eb.seqno = seqno
+				done, err = pds.processEncryptionBlock(&eb)
+				if err == nil && done {
+					pds.state++
+				}
+			}
+		case 2:
+			var i interface{}
+			_, err = pds.fmps.Decode(&i)
+			if err == nil {
+				err = ErrTrailingGarbage
+			}
+			if err == io.EOF {
+				pds.state++
+			}
+		}
+	}
+
+	if err == errAgain {
+		err = nil
+	}
+
+	// EOFs are only allowed in state 4; otherwise, it's a failure
+	if err == io.EOF {
+		if pds.state == 3 {
+			err = nil
+		} else {
+			err = ErrUnexpectedEOF
+		}
+	}
+
+	return err
+}
+
+func (pds *publicDecryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
+	if err := hdr.validate(); err != nil {
+		return err
+	}
+	var kids [][]byte
+	for _, r := range hdr.Receivers {
+		kids = append(kids, r.KID)
+	}
+	i, sk := pds.ring.LookupBoxSecretKey(kids)
+	if sk == nil || i < 0 {
+		return ErrNoDecryptionKey
+	}
+	pk := pds.ring.LookupBoxPublicKey(hdr.Sender)
+	if pk == nil {
+		return ErrNoSenderKey
+	}
+	var nonce Nonce
+	copy(nonce[:], hdr.Nonce)
+	nonce.writeCounter32(uint32(i))
+	keysPacked, err := sk.Unbox(pk, &nonce, hdr.Receivers[i].Keys)
+	if err != nil {
+		return err
+	}
+
+	var keys receiverKeysPlaintext
+	if err = decodeFromBytes(&keys, keysPacked); err != nil {
+		return err
+	}
+	pds.keys = &keys
+	copy(pds.sessionKey[:], pds.keys.SessionKey)
+
+	return nil
+}
+
+func (pds *publicDecryptStream) checkMAC(bl *EncryptionBlock, b []byte) error {
+	if pds.keys.GroupID < 0 {
+		if len(pds.keys.MACKey) != 0 {
+			return ErrUnexpectedMAC(bl.seqno)
+		}
+		return nil
+	}
+	if len(bl.MACs) <= pds.keys.GroupID {
+		return ErrBadGroupID(pds.keys.GroupID)
+	}
+
+	if len(pds.keys.MACKey) == 0 {
+		return ErrNoGroupMACKey
+	}
+
+	mac := hmacSHA512(pds.keys.MACKey, b)
+	if !hmac.Equal(mac, bl.MACs[pds.keys.GroupID]) {
+		return ErrMACMismatch(bl.seqno)
+	}
+	return nil
+}
+
+func (pds *publicDecryptStream) processEncryptionBlock(bl *EncryptionBlock) (bool, error) {
+	if err := bl.validate(); err != nil {
+		return false, err
+	}
+
+	if bl.seqno <= 0 {
+		return false, errPacketUnderflow
+	}
+
+	blockNum := encryptionBlockNumber(bl.seqno - 1)
+
+	if err := blockNum.check(); err != nil {
+		return false, err
+	}
+
+	nonce := blockNum.newCounterNonce()
+
+	if sum, err := hashCryptoBlock(nonce, bl.Ciphertext); err != nil {
+		return false, err
+	} else if err := pds.checkMAC(bl, sum[:]); err != nil {
+		return false, err
+	}
+
+	plaintext, ok := secretbox.Open([]byte{}, bl.Ciphertext, (*[24]byte)(nonce), (*[32]byte)(&pds.sessionKey))
+	if !ok {
+		return false, ErrBadCiphertext(bl.seqno)
+	}
+
+	// The encoding of the empty buffer implies the EOF.  But otherwise, all mechanisms are the same.
+	if len(plaintext) == 0 {
+		return true, nil
+	}
+	_, err := pds.output.Write(plaintext)
+	return false, err
+
+}
+
+// NewPublicDecryptStream starts a streaming decryption. You should give it an io.Writer
+// to write plaintext output to, and also a Keyring to lookup private and public keys
+// as necessary. The stream will only ever write validated data.  It returns
+// an io.Writer that you can write the ciphertext stream to, and an error if anything
+// goes wrong in the construction process.
+func NewPublicDecryptStream(plaintext io.Writer, keyring Keyring) (ciphertext io.WriteCloser, err error) {
+	pds := &publicDecryptStream{
+		output: plaintext,
+		ring:   keyring,
+		fmps:   new(framedMsgpackStream),
+	}
+	return pds, nil
+}
+
+// Open simply opens a ciphertext given the set of keys in the specified keyring.
+// It return a plaintext on sucess, and an error on failure.
+func Open(ciphertext []byte, keyring Keyring) (plaintext []byte, err error) {
+	var buf bytes.Buffer
+	ds, err := NewPublicDecryptStream(&buf, keyring)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := ds.Write(ciphertext); err != nil {
+		return nil, err
+	}
+	if err := ds.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/go/kbcmf/decrypt.go
+++ b/go/kbcmf/decrypt.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package kbcmf
 
 import (

--- a/go/kbcmf/encrypt.go
+++ b/go/kbcmf/encrypt.go
@@ -1,0 +1,223 @@
+package kbcmf
+
+import (
+	"bytes"
+	"encoding/hex"
+	"golang.org/x/crypto/nacl/secretbox"
+	"io"
+)
+
+type publicEncryptStream struct {
+	output     io.Writer
+	header     *EncryptionHeader
+	sessionKey SymmetricKey
+	buffer     bytes.Buffer
+	inblock    []byte
+	macGroups  []SymmetricKey
+
+	numBlocks encryptionBlockNumber // the lower 64 bits of the nonce
+
+	didHeader bool
+	eof       bool
+	err       error
+}
+
+func (pes *publicEncryptStream) Write(plaintext []byte) (int, error) {
+
+	if !pes.didHeader {
+		pes.didHeader = true
+		pes.err = encodeNewPacket(pes.output, pes.header)
+	}
+
+	if pes.err != nil {
+		return 0, pes.err
+	}
+
+	var ret int
+	if ret, pes.err = pes.buffer.Write(plaintext); pes.err != nil {
+		return 0, pes.err
+	}
+	for pes.buffer.Len() >= EncryptionBlockSize {
+		pes.err = pes.encryptBlock()
+		if pes.err != nil {
+			return 0, pes.err
+		}
+	}
+	return ret, nil
+}
+
+func (pes *publicEncryptStream) macForAllGroups(b []byte) [][]byte {
+	var macs [][]byte
+	for _, key := range pes.macGroups {
+		mac := hmacSHA512(key[:], b)
+		macs = append(macs, mac)
+	}
+	return macs
+}
+
+func (pes *publicEncryptStream) encryptBlock() error {
+	var n int
+	var err error
+	n, err = pes.buffer.Read(pes.inblock[:])
+	if err != nil {
+		return nil
+	}
+	return pes.encryptBytes(pes.inblock[0:n])
+}
+
+func (pes *publicEncryptStream) encryptBytes(b []byte) error {
+
+	if err := pes.numBlocks.check(); err != nil {
+		return err
+	}
+
+	nonce := pes.numBlocks.newCounterNonce()
+	ciphertext := secretbox.Seal([]byte{}, b, (*[24]byte)(nonce), (*[32]byte)(&pes.sessionKey))
+	// Compute the MAC over the nonce and the ciphertext
+	sum, err := hashCryptoBlock(nonce, ciphertext)
+	if err != nil {
+		return err
+	}
+	macs := pes.macForAllGroups(sum)
+	block := EncryptionBlock{
+		Version:    PacketVersion1,
+		Tag:        PacketTagEncryptionBlock,
+		Ciphertext: ciphertext,
+		MACs:       macs,
+	}
+
+	if err = encodeNewPacket(pes.output, block); err != nil {
+		return nil
+	}
+
+	pes.numBlocks++
+	return nil
+}
+
+func (pes *publicEncryptStream) init(sender BoxSecretKey, receivers [][]BoxPublicKey) error {
+	eh := &EncryptionHeader{
+		Version:   PacketVersion1,
+		Tag:       PacketTagEncryptionHeader,
+		Sender:    sender.GetPublicKey().ToKID(),
+		Receivers: make([]receiverKeysCiphertext, 0, len(receivers)),
+	}
+	pes.header = eh
+	if err := randomFill(pes.sessionKey[:]); err != nil {
+		return err
+	}
+
+	// Only fill the first 20 bytes of the nonce. The remaining 4
+	// we'll increment with every call to Box
+	nonceRandLen := 20
+	var nonce Nonce
+	if err := randomFill(nonce[:nonceRandLen]); err != nil {
+		return err
+	}
+
+	// We don't necessarily have to copy our header nonce into place,
+	// but if feels safer, since we modify the nonce below
+	eh.Nonce = make([]byte, nonceRandLen)
+	copy(eh.Nonce, nonce[:])
+
+	d := make(map[string]struct{})
+
+	var i uint32
+
+	for gid, group := range receivers {
+		var macKey SymmetricKey
+		if len(receivers) > 1 {
+			if err := randomFill(macKey[:]); err != nil {
+				return err
+			}
+			pes.macGroups = append(pes.macGroups, macKey)
+		} else {
+			gid = -1
+		}
+		for _, receiver := range group {
+			kid := receiver.ToKID()
+			kidString := hex.EncodeToString(kid)
+			if _, found := d[kidString]; found {
+				return ErrRepeatedKey(kid)
+			}
+			d[kidString] = struct{}{}
+
+			pt := receiverKeysPlaintext{
+				GroupID:    gid,
+				SessionKey: pes.sessionKey[:],
+			}
+			if gid >= 0 {
+				pt.MACKey = macKey[:]
+			}
+			pte, err := encodeToBytes(pt)
+			if err != nil {
+				return err
+			}
+			nonce.writeCounter32(i)
+			i++
+			ptec, err := sender.Box(receiver, &nonce, pte)
+			if err != nil {
+				return err
+			}
+
+			rkc := receiverKeysCiphertext{
+				KID:  kid,
+				Keys: ptec,
+			}
+			eh.Receivers = append(eh.Receivers, rkc)
+		}
+	}
+	return nil
+}
+
+func (pes *publicEncryptStream) Close() error {
+	for pes.buffer.Len() > 0 {
+		err := pes.encryptBlock()
+		if err != nil {
+			return err
+		}
+	}
+	return pes.writeFooter()
+}
+
+func (pes *publicEncryptStream) writeFooter() error {
+	return pes.encryptBytes([]byte{})
+}
+
+// NewPublicEncryptStream creates a stream that consumes plaintext data.
+// It will write out encrypted data to the io.Writer passed in as ciphertext.
+// The encryption is from the specified sender, and is encrypted for the
+// given receivers.  Note that receivers as specified as two-dimensional array.
+// Each inner group of receivers shares the same pairwise MAC-key, so should
+// represent a logic receiver split across multiple devices.  Each group of
+// receivers represents a mutually distrustful set of receivers, and will each
+// get their own pairwise-MAC keys.
+//
+// Returns an io.WriteClose that accepts plaintext data to be encrypted; and
+// also returns an error if initialization failed.
+func NewPublicEncryptStream(ciphertext io.Writer, sender BoxSecretKey, receivers [][]BoxPublicKey) (plaintext io.WriteCloser, err error) {
+	pes := &publicEncryptStream{
+		output:  ciphertext,
+		inblock: make([]byte, EncryptionBlockSize),
+	}
+	if err := pes.init(sender, receivers); err != nil {
+		return nil, err
+	}
+	return pes, nil
+}
+
+// Seal a plaintext from the given sender, for the specified receiver groups.
+// Returns a ciphertext, or an error if something bad happened.
+func Seal(plaintext []byte, sender BoxSecretKey, receivers [][]BoxPublicKey) (out []byte, err error) {
+	var buf bytes.Buffer
+	es, err := NewPublicEncryptStream(&buf, sender, receivers)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := es.Write(plaintext); err != nil {
+		return nil, err
+	}
+	if err := es.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/go/kbcmf/encrypt.go
+++ b/go/kbcmf/encrypt.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package kbcmf
 
 import (

--- a/go/kbcmf/encrypt_test.go
+++ b/go/kbcmf/encrypt_test.go
@@ -1,0 +1,1090 @@
+package kbcmf
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"golang.org/x/crypto/nacl/box"
+	"testing"
+)
+
+type boxPublicKey struct {
+	key RawBoxKey
+}
+
+type boxSecretKey struct {
+	pub boxPublicKey
+	key RawBoxKey
+}
+
+type keyring struct {
+	keys map[string]BoxSecretKey
+}
+
+func newKeyring() *keyring {
+	return &keyring{
+		keys: make(map[string]BoxSecretKey),
+	}
+}
+
+func (r *keyring) insert(k BoxSecretKey) {
+	r.keys[hex.EncodeToString(k.GetPublicKey().ToKID())] = k
+}
+
+func (r *keyring) LookupBoxPublicKey(kid []byte) BoxPublicKey {
+	priv := r.keys[hex.EncodeToString(kid)]
+	if priv == nil {
+		return nil
+	}
+	return priv.GetPublicKey()
+}
+
+func (r *keyring) LookupBoxSecretKey(kids [][]byte) (int, BoxSecretKey) {
+	for i, kid := range kids {
+		if key, _ := r.keys[hex.EncodeToString(kid)]; key != nil {
+			return i, key
+		}
+	}
+	return -1, nil
+}
+
+func (b boxPublicKey) ToRawBoxKeyPointer() *RawBoxKey {
+	return &b.key
+}
+
+func (b boxPublicKey) ToKID() []byte {
+	ret := append([]byte{0x01, 0x21}, b.key[:]...)
+	ret = append(ret, byte(0x0a))
+	return ret
+}
+
+func (b boxSecretKey) GetPublicKey() BoxPublicKey {
+	return b.pub
+}
+
+func (b boxSecretKey) Box(receiver BoxPublicKey, nonce *Nonce, msg []byte) ([]byte, error) {
+	var tmp [32]byte
+	box.Precompute(&tmp, (*[32]byte)(receiver.ToRawBoxKeyPointer()), (*[32]byte)(&b.key))
+	ret := box.Seal([]byte{}, msg, (*[24]byte)(nonce),
+		(*[32]byte)(receiver.ToRawBoxKeyPointer()), (*[32]byte)(&b.key))
+	return ret, nil
+}
+
+var errPublicKeyDecryptionFailed = errors.New("public key decryption failed")
+
+func (b boxSecretKey) Unbox(sender BoxPublicKey, nonce *Nonce, msg []byte) ([]byte, error) {
+	var tmp [32]byte
+	box.Precompute(&tmp, (*[32]byte)(sender.ToRawBoxKeyPointer()), (*[32]byte)(&b.key))
+	out, ok := box.Open([]byte{}, msg, (*[24]byte)(nonce),
+		(*[32]byte)(sender.ToRawBoxKeyPointer()), (*[32]byte)(&b.key))
+	if !ok {
+		return nil, errPublicKeyDecryptionFailed
+	}
+	return out, nil
+}
+
+var kr = newKeyring()
+
+func newBoxKeyNoInsert(t *testing.T) *boxSecretKey {
+	pk, sk, err := box.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("In gen key: %s", err)
+	}
+	var tmp [32]byte
+	box.Precompute(&tmp, pk, sk)
+	ret := &boxSecretKey{}
+	copy(ret.key[:], (*sk)[:])
+	copy(ret.pub.key[:], (*pk)[:])
+	return ret
+}
+
+func newBoxKey(t *testing.T) *boxSecretKey {
+	ret := newBoxKeyNoInsert(t)
+	kr.insert(ret)
+	return ret
+}
+
+func TestSmallEncryptionOneReceiver(t *testing.T) {
+	msg := []byte("secret message!")
+	testRoundTrip(t, msg, nil, nil)
+}
+
+func TestMediumEncryptionOneReceiver(t *testing.T) {
+	buf := make([]byte, 1024*10)
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	testRoundTrip(t, buf, nil, nil)
+}
+
+func TestBiggishEncryptionOneReceiver(t *testing.T) {
+	buf := make([]byte, 1024*100)
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	testRoundTrip(t, buf, nil, nil)
+}
+
+type options struct {
+	writeSize int
+}
+
+func randomMsg(t *testing.T, sz int) []byte {
+	out := make([]byte, sz)
+	if _, err := rand.Read(out); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func testRealEncryptor(t *testing.T, sz int) {
+	msg := make([]byte, sz)
+	if _, err := rand.Read(msg); err != nil {
+		t.Fatal(err)
+	}
+	sndr := newBoxKey(t)
+	var out bytes.Buffer
+	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+	strm, err := NewPublicEncryptStream(&out, *sndr, receivers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := strm.Write(msg); err != nil {
+		t.Fatal(err)
+	}
+	if err := strm.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var out2 bytes.Buffer
+	strm2, err := NewPublicDecryptStream(&out2, kr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := strm2.Write(out.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := strm2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(out2.Bytes(), msg) {
+		t.Fatal("decryption mismatch")
+	}
+}
+
+func TestRealEncryptorSmall(t *testing.T) {
+	testRealEncryptor(t, 101)
+}
+
+func TestRealEncryptorBig(t *testing.T) {
+	testRealEncryptor(t, 1024*1024*3)
+}
+
+func testRoundTrip(t *testing.T, msg []byte, receivers [][]BoxPublicKey, opts *options) {
+	sndr := newBoxKey(t)
+	var out bytes.Buffer
+	if receivers == nil {
+		receivers = [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+	}
+	strm, err := newTestPublicEncryptStream(&out, *sndr, receivers,
+		testEncryptionOptions{blockSize: 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := strm.Write(msg); err != nil {
+		t.Fatal(err)
+	}
+	if err := strm.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var out2 bytes.Buffer
+	strm2, err := NewPublicDecryptStream(&out2, kr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if opts != nil && opts.writeSize != 0 {
+		buf := out.Bytes()
+		for len(buf) > 0 {
+			end := opts.writeSize
+			if end > len(buf) {
+				end = len(buf)
+			}
+			if n, err := strm2.Write(buf[0:end]); err != nil {
+				t.Fatal(err)
+			} else {
+				buf = buf[n:]
+			}
+		}
+	} else {
+		if _, err := strm2.Write(out.Bytes()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := strm2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(out2.Bytes(), msg) {
+		t.Fatal("decryption mismatch")
+	}
+}
+
+func TestRoundTripMedium6Receivers(t *testing.T) {
+	msg := make([]byte, 1024*3)
+	if _, err := rand.Read(msg); err != nil {
+		t.Fatal(err)
+	}
+	receivers := [][]BoxPublicKey{
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKey(t).GetPublicKey(),
+		},
+	}
+	testRoundTrip(t, msg, receivers, nil)
+}
+
+func TestRoundTripSmall6Receivers(t *testing.T) {
+	msg := []byte("hoppy halloween")
+	if _, err := rand.Read(msg); err != nil {
+		t.Fatal(err)
+	}
+	receivers := [][]BoxPublicKey{
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKey(t).GetPublicKey(),
+		},
+	}
+	testRoundTrip(t, msg, receivers, nil)
+}
+
+func TestReceiverNotFound(t *testing.T) {
+	sndr := newBoxKey(t)
+	msg := []byte("those who die stay with us forever, as bones")
+	var out bytes.Buffer
+	receivers := [][]BoxPublicKey{
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+	}
+
+	strm, err := newTestPublicEncryptStream(&out, *sndr, receivers,
+		testEncryptionOptions{blockSize: 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := strm.Write(msg); err != nil {
+		t.Fatal(err)
+	}
+	if err := strm.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var out2 bytes.Buffer
+	strm2, err := NewPublicDecryptStream(&out2, kr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := strm2.Write(out.Bytes()); err != ErrNoDecryptionKey {
+		t.Fatal("exepcted an ErrNoDecryptionkey")
+	}
+}
+
+func TestTruncation(t *testing.T) {
+	sndr := newBoxKey(t)
+	var out bytes.Buffer
+	msg := []byte("this message is going to be truncated")
+	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+	strm, err := newTestPublicEncryptStream(&out, *sndr, receivers,
+		testEncryptionOptions{blockSize: 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := strm.Write(msg); err != nil {
+		t.Fatal(err)
+	}
+	if err := strm.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var out2 bytes.Buffer
+	strm2, err := NewPublicDecryptStream(&out2, kr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ciphertext := out.Bytes()
+	trunced1 := ciphertext[0 : len(ciphertext)-51]
+
+	if _, err := strm2.Write(trunced1); err != nil {
+		t.Fatal(err)
+	}
+	if err := strm2.Close(); err != ErrUnexpectedEOF {
+		t.Fatalf("Wanted an ErrUnexpectedEOF; got %v\n", err)
+	}
+}
+
+func TestMediumEncryptionOneReceiverSmallWrites(t *testing.T) {
+	buf := make([]byte, 1024*10)
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	testRoundTrip(t, buf, nil, &options{writeSize: 1})
+}
+
+func TestMediumEncryptionOneReceiverSmallishWrites(t *testing.T) {
+	buf := make([]byte, 1024*10)
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	testRoundTrip(t, buf, nil, &options{writeSize: 7})
+}
+
+func TestMediumEncryptionOneReceiverMediumWrites(t *testing.T) {
+	buf := make([]byte, 1024*10)
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	testRoundTrip(t, buf, nil, &options{writeSize: 79})
+}
+
+func testSealAndOpen(t *testing.T, sz int) {
+	sender := newBoxKey(t)
+	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+	plaintext := make([]byte, sz)
+	if _, err := rand.Read(plaintext); err != nil {
+		t.Fatal(err)
+	}
+	ciphertext, err := Seal(plaintext, sender, receivers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plaintext2, err := Open(ciphertext, kr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(plaintext, plaintext2) {
+		t.Fatal("decryption mismatch")
+	}
+}
+
+func TestSealAndOpenSmall(t *testing.T) {
+	testSealAndOpen(t, 103)
+}
+
+func TestSealAndOpenBig(t *testing.T) {
+	testSealAndOpen(t, 1024*1024*3)
+}
+
+func TestSealAndOpenTwoGroups(t *testing.T) {
+	sender := newBoxKey(t)
+	receivers := [][]BoxPublicKey{
+		[]BoxPublicKey{newBoxKeyNoInsert(t).GetPublicKey()},
+		[]BoxPublicKey{newBoxKey(t).GetPublicKey()},
+	}
+	plaintext := make([]byte, 1024*10)
+	if _, err := rand.Read(plaintext); err != nil {
+		t.Fatal(err)
+	}
+	ciphertext, err := Seal(plaintext, sender, receivers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plaintext2, err := Open(ciphertext, kr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(plaintext, plaintext2) {
+		t.Fatal("decryption mismatch")
+	}
+}
+
+func TestRepeatedKey(t *testing.T) {
+	sender := newBoxKey(t)
+	pk := newBoxKey(t).GetPublicKey()
+	receivers := [][]BoxPublicKey{
+		[]BoxPublicKey{pk},
+		[]BoxPublicKey{pk},
+	}
+	plaintext := randomMsg(t, 1024*3)
+	_, err := Seal(plaintext, sender, receivers)
+	if _, ok := err.(ErrRepeatedKey); !ok {
+		t.Fatalf("Wanted a repeated key error; got %v", err)
+	}
+}
+
+func TestCorruptHeaderNonce(t *testing.T) {
+	msg := randomMsg(t, 129)
+	teo := testEncryptionOptions{
+		corruptHeaderNonce: func(n *Nonce, gid int, rid int) {
+			(*n)[4] ^= 1
+		},
+	}
+	sender := newBoxKey(t)
+	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+	ciphertext, err := testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if err != errPublicKeyDecryptionFailed {
+		t.Fatalf("Wanted an error %v; got %v", errPublicKeyDecryptionFailed, err)
+	}
+}
+
+func TestCorruptHeaderNonceG2R1(t *testing.T) {
+	msg := randomMsg(t, 129)
+	teo := testEncryptionOptions{
+		corruptHeaderNonce: func(n *Nonce, gid int, rid int) {
+			if gid == 2 && rid == 1 {
+				(*n)[4] ^= 1
+			}
+		},
+	}
+	sender := newBoxKey(t)
+	receivers := [][]BoxPublicKey{
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKey(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+	}
+	ciphertext, err := testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if err != errPublicKeyDecryptionFailed {
+		t.Fatalf("Wanted an error %v; got %v", errPublicKeyDecryptionFailed, err)
+	}
+
+	// If someone else's encryption was tampered with, we don't care and
+	// shouldn't get an error.
+	teo = testEncryptionOptions{
+		corruptHeaderNonce: func(n *Nonce, gid int, rid int) {
+			if gid == 2 && rid == 3 {
+				(*n)[4] ^= 1
+			}
+		},
+	}
+	ciphertext, err = testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCorruptReceiverKeysCiphertextG2R1(t *testing.T) {
+	msg := randomMsg(t, 129)
+	teo := testEncryptionOptions{
+		corruptReceiverKeysCiphertext: func(rkc *receiverKeysCiphertext, gid int, rid int) {
+			if gid == 2 && rid == 1 {
+				rkc.Keys[35] ^= 1
+			}
+		},
+	}
+	sender := newBoxKey(t)
+	receivers := [][]BoxPublicKey{
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKey(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+	}
+	ciphertext, err := testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if err != errPublicKeyDecryptionFailed {
+		t.Fatalf("Wanted an error %v; got %v", errPublicKeyDecryptionFailed, err)
+	}
+
+	// If someone else's encryption was tampered with, we don't care and
+	// shouldn't get an error.
+	teo = testEncryptionOptions{
+		corruptReceiverKeysCiphertext: func(rkc *receiverKeysCiphertext, gid int, rid int) {
+			if gid == 2 && rid == 2 {
+				rkc.Keys[35] ^= 1
+			}
+		},
+	}
+	ciphertext, err = testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCorruptRewceiverKeys tests what happens if the encryptor messes up in
+// formulating the **plaintext** input of the encrypted session keys.  We try
+// fiddling all of the keys below, in the case of multiple receivers in multiple
+// groups.
+func TestCorruptReceiverKeysPlaintextG1R0(t *testing.T) {
+	msg := randomMsg(t, 129)
+
+	// First try to supply a bogus group ID that's out of bounds.
+	teo := testEncryptionOptions{
+		corruptReceiverKeysPlaintext: func(rkp *receiverKeysPlaintext, gid int, rid int) {
+			if gid == 1 && rid == 0 {
+				rkp.GroupID = 100
+			}
+		},
+	}
+	sender := newBoxKey(t)
+	receivers := [][]BoxPublicKey{
+		[]BoxPublicKey{
+			newBoxKeyNoInsert(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+		[]BoxPublicKey{
+			newBoxKey(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+	}
+	ciphertext, err := testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if badgroup, ok := err.(ErrBadGroupID); !ok {
+		t.Fatalf("Wanted a 'Bad Group ID' error")
+	} else if int(badgroup) != 100 {
+		t.Fatalf("Wrong bad group (wanted 100, got %d)", badgroup)
+	}
+
+	// Now supply the wrong group ID
+	teo = testEncryptionOptions{
+		corruptReceiverKeysPlaintext: func(rkp *receiverKeysPlaintext, gid int, rid int) {
+			if gid == 1 && rid == 0 {
+				rkp.GroupID = 0
+			}
+		},
+	}
+	ciphertext, err = testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if mm, ok := err.(ErrMACMismatch); !ok {
+		t.Fatalf("Wanted MAC mismatch error but got %v", err)
+	} else if int(mm) != 1 {
+		t.Fatalf("Wanted a failure in packet %d, but got %d", 1, mm)
+	}
+
+	// Now zero out the MAC key even though one was explicitly promised for
+	// this operation.
+	teo = testEncryptionOptions{
+		corruptReceiverKeysPlaintext: func(rkp *receiverKeysPlaintext, gid int, rid int) {
+			if gid == 1 && rid == 0 {
+				rkp.MACKey = nil
+			}
+		},
+	}
+	ciphertext, err = testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if err != ErrNoGroupMACKey {
+		t.Fatalf("Got wrong error; wanted %v but got %v", ErrNoGroupMACKey, err)
+	}
+
+	// Now corrupt the MAC key
+	teo = testEncryptionOptions{
+		corruptReceiverKeysPlaintext: func(rkp *receiverKeysPlaintext, gid int, rid int) {
+			if gid == 1 && rid == 0 {
+				rkp.MACKey[3] ^= 1
+			}
+		},
+	}
+	ciphertext, err = testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if mm, ok := err.(ErrMACMismatch); !ok {
+		t.Fatalf("Got wrong error; wanted MAC mismatch but got %v", err)
+	} else if int(mm) != 1 {
+		t.Fatalf("Wanted a failure in packet %d but got %d", 1, mm)
+	}
+
+	// Finally let's corrupt the session key
+	teo = testEncryptionOptions{
+		corruptReceiverKeysPlaintext: func(rkp *receiverKeysPlaintext, gid int, rid int) {
+			if gid == 1 && rid == 0 {
+				sk := make([]byte, len(rkp.SessionKey))
+				copy(sk, rkp.SessionKey)
+				sk[3] ^= 1
+				rkp.SessionKey = sk
+			}
+		},
+	}
+	ciphertext, err = testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if mm, ok := err.(ErrBadCiphertext); !ok {
+		t.Fatalf("Got wrong error; wanted 'Bad Ciphertext' but got %v", err)
+	} else if int(mm) != 1 {
+		t.Fatalf("Wanted a failure in packet %d but got %d", 1, mm)
+	}
+
+}
+
+func TestCorruptReceiverKeysPlaintextOneGroup(t *testing.T) {
+	msg := randomMsg(t, 129)
+
+	// First try to supply a bogus group ID that's out of bounds.
+	teo := testEncryptionOptions{
+		corruptReceiverKeysPlaintext: func(rkp *receiverKeysPlaintext, gid int, rid int) {
+			if gid == -1 && rid == 0 {
+				rkp.GroupID = 100
+			}
+		},
+	}
+	sender := newBoxKey(t)
+	receivers := [][]BoxPublicKey{
+		[]BoxPublicKey{
+			newBoxKey(t).GetPublicKey(),
+			newBoxKeyNoInsert(t).GetPublicKey(),
+		},
+	}
+	ciphertext, err := testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if badgroup, ok := err.(ErrBadGroupID); !ok {
+		t.Fatalf("Wanted a 'Bad Group ID' error; got %v", err)
+	} else if int(badgroup) != 100 {
+		t.Fatalf("Wrong bad group (wanted 100, got %d)", badgroup)
+	}
+
+	// Now supply the wrong group ID
+	teo = testEncryptionOptions{
+		corruptReceiverKeysPlaintext: func(rkp *receiverKeysPlaintext, gid int, rid int) {
+			if gid == -1 && rid == 0 {
+				rkp.GroupID = 0
+			}
+		},
+	}
+	ciphertext, err = testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if bgid, ok := err.(ErrBadGroupID); !ok {
+		t.Fatalf("Wanted MAC mismatch error but got %v", err)
+	} else if int(bgid) != 0 {
+		t.Fatalf("Wanted a failure in group %d, but got %d", 0, bgid)
+	}
+
+	// Now zero out the MAC key even though one was explicitly promised for
+	// this operation.
+	teo = testEncryptionOptions{
+		corruptReceiverKeysPlaintext: func(rkp *receiverKeysPlaintext, gid int, rid int) {
+			if gid == -1 && rid == 0 {
+				rkp.MACKey = make([]byte, 32)
+			}
+		},
+	}
+	ciphertext, err = testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if eum, ok := err.(ErrUnexpectedMAC); !ok {
+		t.Fatalf("Got wrong error; wanted 'Unexpected MAC' but got %v", err)
+	} else if int(eum) != 1 {
+		t.Fatalf("Got wrong packet; wanted %d but got %d", 1, eum)
+	}
+
+	// Finally let's corrupt the session key
+	teo = testEncryptionOptions{
+		corruptReceiverKeysPlaintext: func(rkp *receiverKeysPlaintext, gid int, rid int) {
+			if gid == -1 && rid == 0 {
+				sk := make([]byte, len(rkp.SessionKey))
+				copy(sk, rkp.SessionKey)
+				sk[3] ^= 1
+				rkp.SessionKey = sk
+			}
+		},
+	}
+	ciphertext, err = testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if mm, ok := err.(ErrBadCiphertext); !ok {
+		t.Fatalf("Got wrong error; wanted 'Bad Ciphertext' but got %v", err)
+	} else if int(mm) != 1 {
+		t.Fatalf("Wanted a failure in packet %d but got %d", 1, mm)
+	}
+
+}
+
+func TestMissingFooter(t *testing.T) {
+	sender := newBoxKey(t)
+	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+	msg := randomMsg(t, 1024*9)
+	ciphertext, err := testSeal(msg, sender, receivers, testEncryptionOptions{
+		skipFooter: true,
+		blockSize:  1024,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if err != ErrUnexpectedEOF {
+		t.Fatalf("Wanted %v but got %v", ErrUnexpectedEOF, err)
+	}
+}
+
+func TestCorruptEncryption(t *testing.T) {
+	sender := newBoxKey(t)
+	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+	msg := randomMsg(t, 1024*9)
+
+	// First check that a corrupted ciphertext fails the Poly1305
+	ciphertext, err := testSeal(msg, sender, receivers, testEncryptionOptions{
+		blockSize: 1024,
+		corruptEncryptionBlock: func(eb *EncryptionBlock, ebn encryptionBlockNumber) {
+			if ebn == 2 {
+				eb.Ciphertext[40] ^= 1
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if mm, ok := err.(ErrBadCiphertext); !ok {
+		t.Fatalf("Got wrong error; wanted 'Bad Ciphertext' but got %v", err)
+	} else if int(mm) != 3 {
+		t.Fatalf("Wanted a failure in packet %d but got %d", 3, mm)
+	}
+
+	// Next check that a corruption of the Poly1305 tags causes a failure
+	ciphertext, err = testSeal(msg, sender, receivers, testEncryptionOptions{
+		blockSize: 1024,
+		corruptEncryptionBlock: func(eb *EncryptionBlock, ebn encryptionBlockNumber) {
+			if ebn == 2 {
+				eb.Ciphertext[2] ^= 1
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if mm, ok := err.(ErrBadCiphertext); !ok {
+		t.Fatalf("Got wrong error; wanted 'Bad Ciphertext' but got %v", err)
+	} else if int(mm) != 3 {
+		t.Fatalf("Wanted a failure in packet %d but got %d", 3, mm)
+	}
+
+	// Next check what happens if we mangle the Version
+	ciphertext, err = testSeal(msg, sender, receivers, testEncryptionOptions{
+		blockSize: 1024,
+		corruptEncryptionBlock: func(eb *EncryptionBlock, ebn encryptionBlockNumber) {
+			if ebn == 2 {
+				eb.Version = PacketVersion(2)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if ebv, ok := err.(ErrBadVersion); !ok {
+		t.Fatalf("Got wrong error; wanted 'Bad Version' but got %v", err)
+	} else if int(ebv.seqno) != 3 {
+		t.Fatalf("Wanted a failure in packet %d but got %d", 3, ebv.seqno)
+	} else if ebv.received != PacketVersion(2) {
+		t.Fatalf("got wrong version # in error message: %d", ebv.received)
+	}
+
+	// Next check what happens if we mangle the Tag
+	ciphertext, err = testSeal(msg, sender, receivers, testEncryptionOptions{
+		blockSize: 1024,
+		corruptEncryptionBlock: func(eb *EncryptionBlock, ebn encryptionBlockNumber) {
+			if ebn == 2 {
+				eb.Tag = PacketTagEncryptionHeader
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if ebv, ok := err.(ErrWrongPacketTag); !ok {
+		t.Fatalf("Got wrong error; wanted 'Bad Version' but got %v", err)
+	} else if int(ebv.seqno) != 3 {
+		t.Fatalf("Wanted a failure in packet %d but got %d", 3, ebv.seqno)
+	} else if ebv.wanted != PacketTagEncryptionBlock {
+		t.Fatalf("got wrong version wanted in error message: %d", ebv.wanted)
+	} else if ebv.received != PacketTagEncryptionHeader {
+		t.Fatalf("got wrong version received error message: %d", ebv.received)
+	}
+
+	// Next check what happens if we mangle the MAC
+	receivers = [][]BoxPublicKey{
+		[]BoxPublicKey{newBoxKeyNoInsert(t).GetPublicKey()},
+		[]BoxPublicKey{newBoxKey(t).GetPublicKey()},
+	}
+	ciphertext, err = testSeal(msg, sender, receivers, testEncryptionOptions{
+		blockSize: 1024,
+		corruptEncryptionBlock: func(eb *EncryptionBlock, ebn encryptionBlockNumber) {
+			if ebn == 2 {
+				eb.MACs[1][5] ^= 1
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if mm, ok := err.(ErrMACMismatch); !ok {
+		t.Fatalf("Expected a 'MAC Mismatch' error but got %v", err)
+	} else if int(mm) != 3 {
+		t.Fatalf("Wanted error packet %d but got %d", 3, mm)
+	}
+
+	// Next check what happens if we swap macs for blocks 0 and 1 for 2 rewceivers
+	msg = randomMsg(t, 1024*2-1)
+	ciphertext, err = testSeal(msg, sender, receivers, testEncryptionOptions{
+		blockSize: 1024,
+		corruptNonce: func(n *Nonce, ebn encryptionBlockNumber) {
+			var nn *Nonce
+			switch ebn {
+			case 1:
+				nn = encryptionBlockNumber(0).newCounterNonce()
+			case 0:
+				nn = encryptionBlockNumber(1).newCounterNonce()
+			case 2:
+				nn = n
+			default:
+				t.Fatalf("didn't expected packet %d", ebn)
+			}
+			*n = *nn
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if emm, ok := err.(ErrMACMismatch); !ok {
+		t.Fatalf("Expected a 'mac mismatch' error but got %v", err)
+	} else if int(emm) != 1 {
+		t.Fatalf("Wanted error packet %d but got %d", 1, emm)
+	}
+
+	// Next check what happens if we swap macs for blocks 0 and 1 for 1 receiver
+	msg = randomMsg(t, 1024*2-1)
+	receivers = [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+	ciphertext, err = testSeal(msg, sender, receivers, testEncryptionOptions{
+		blockSize: 1024,
+		corruptNonce: func(n *Nonce, ebn encryptionBlockNumber) {
+			var nn *Nonce
+			switch ebn {
+			case 1:
+				nn = encryptionBlockNumber(0).newCounterNonce()
+			case 0:
+				nn = encryptionBlockNumber(1).newCounterNonce()
+			case 2:
+				nn = n
+			default:
+				t.Fatalf("didn't expected packet %d", ebn)
+			}
+			*n = *nn
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if ebct, ok := err.(ErrBadCiphertext); !ok {
+		t.Fatalf("Expected a 'bad ciphertext' error but got %v", err)
+	} else if int(ebct) != 1 {
+		t.Fatalf("Wanted error packet %d but got %d", 1, ebct)
+	}
+}
+
+func TestCorruptNonce(t *testing.T) {
+	msg := randomMsg(t, 1024*11)
+	teo := testEncryptionOptions{
+		blockSize: 1024,
+		corruptNonce: func(n *Nonce, ebn encryptionBlockNumber) {
+			if ebn == 2 {
+				(*n)[23]++
+			}
+		},
+	}
+	sender := newBoxKey(t)
+	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+	ciphertext, err := testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if bcte, ok := err.(ErrBadCiphertext); !ok {
+		t.Fatalf("Wanted error 'ErrBadCiphertext' but got %v", err)
+	} else if int(bcte) != 3 {
+		t.Fatalf("wrong packet; wanted %d but got %d", 3, bcte)
+	}
+}
+
+func TestCorruptHeader(t *testing.T) {
+	msg := randomMsg(t, 1024*11)
+
+	// Test bad Header version
+	teo := testEncryptionOptions{
+		blockSize: 1024,
+		corruptHeader: func(eh *EncryptionHeader) {
+			eh.Version = PacketVersion(2)
+		},
+	}
+	sender := newBoxKey(t)
+	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+	ciphertext, err := testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if ebv, ok := err.(ErrBadVersion); !ok {
+		t.Fatalf("Got wrong error; wanted 'Bad Version' but got %v", err)
+	} else if int(ebv.seqno) != 0 {
+		t.Fatalf("Wanted a failure in packet %d but got %d", 0, ebv.seqno)
+	} else if ebv.received != PacketVersion(2) {
+		t.Fatalf("got wrong version # in error message: %d", ebv.received)
+	}
+
+	// Test bad header Tag
+	teo = testEncryptionOptions{
+		blockSize: 1024,
+		corruptHeader: func(eh *EncryptionHeader) {
+			eh.Tag = PacketTagEncryptionBlock
+		},
+	}
+	ciphertext, err = testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if ebv, ok := err.(ErrWrongPacketTag); !ok {
+		t.Fatalf("Got wrong error; wanted 'Bad Version' but got %v", err)
+	} else if int(ebv.seqno) != 0 {
+		t.Fatalf("Wanted a failure in packet %d but got %d", 0, ebv.seqno)
+	} else if ebv.wanted != PacketTagEncryptionHeader {
+		t.Fatalf("got wrong wanted in error message: %d", ebv.wanted)
+	} else if ebv.received != PacketTagEncryptionBlock {
+		t.Fatalf("got wrong received in error message: %d", ebv.received)
+	}
+
+	// Test bad Nonce length
+	teo = testEncryptionOptions{
+		blockSize: 1024,
+		corruptHeader: func(eh *EncryptionHeader) {
+			eh.Nonce = make([]byte, 24)
+		},
+	}
+	ciphertext, err = testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if ebn, ok := err.(ErrBadNonce); !ok {
+		t.Fatalf("Got wrong error; wanted 'Bad Nonce' but got %v", err)
+	} else if int(ebn.seqno) != 0 {
+		t.Fatalf("Wanted a failure in packet %d but got %d", 0, ebn.seqno)
+	} else if ebn.byteLen != 24 {
+		t.Fatalf("got wrong byte len in message: %d", ebn.byteLen)
+	}
+}
+
+func TestNoSenderKey(t *testing.T) {
+	sender := newBoxKeyNoInsert(t)
+	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+	msg := randomMsg(t, 1024*9)
+	ciphertext, err := testSeal(msg, sender, receivers, testEncryptionOptions{
+		blockSize: 1024,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Open(ciphertext, kr)
+	if err != ErrNoSenderKey {
+		t.Fatalf("Wanted %v but got %v", ErrNoSenderKey, err)
+	}
+}
+
+func TestSealAndOpenTrailingGarbage(t *testing.T) {
+	sender := newBoxKey(t)
+	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+	plaintext := randomMsg(t, 1024*3)
+	ciphertext, err := Seal(plaintext, sender, receivers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	buf.Write(ciphertext)
+	encodeNewPacket(&buf, randomMsg(t, 14))
+	_, err = Open(buf.Bytes(), kr)
+	if err != ErrTrailingGarbage {
+		t.Fatalf("Wanted 'ErrTrailingGarbage' but got %v", err)
+	}
+}

--- a/go/kbcmf/encrypt_test.go
+++ b/go/kbcmf/encrypt_test.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package kbcmf
 
 import (

--- a/go/kbcmf/errors.go
+++ b/go/kbcmf/errors.go
@@ -1,0 +1,114 @@
+package kbcmf
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrNoDecryptionKey is an error indicating no decryption key was found for the
+	// incoming message. You'll get one of these if you respond to a Keyring.LookupSecretBoxKey
+	// request with a (-1,nil) return value.
+	ErrNoDecryptionKey = errors.New("no decryption key found for message")
+
+	// ErrNoSenderKey indicates that on decryption we couldn't find a public key
+	// for the sender.
+	ErrNoSenderKey = errors.New("no sender key found for message")
+
+	// ErrTrailingGarbage indicates that additional msgpack packets were found after the
+	// end of the encryption stream.
+	ErrTrailingGarbage = errors.New("trailing garbage found at end of message")
+
+	// ErrPacketOverflow indicates that more than (2^64-2) packets were found in an encryption
+	// stream.  This would indicate a very big message, and results in an error here.
+	ErrPacketOverflow = errors.New("no more than 2^32 packets in a message are supported")
+
+	// ErrBadFrame indiciates improper msgpack framing
+	ErrBadFrame = errors.New("bad msgpack framing byte")
+
+	// ErrUnexpectedEOF is produced when an EOF happens unexpectedly when parsing an
+	// incoming encryption. Usually it means a message was truncated, but could indicate
+	// malicious truncation
+	ErrUnexpectedEOF = errors.New("unexpected EOF; the message was truncated")
+
+	// ErrInsufficientRandomness is generated when the encryption fails to collect
+	// enough randomness to proceed.  We're using the standard crypto/rand source
+	// of randomness, so this should never happen
+	ErrInsufficientRandomness = errors.New("could not collect enough randomness")
+
+	// ErrNoGroupMACKey is produced when we lack a group MAC key but the authenticated
+	// ciphertexts indicated that one was required.
+	ErrNoGroupMACKey = errors.New("no group MAC key, but we needed one")
+
+	// Should never happen, so not exported.
+	errPacketUnderflow = errors.New("no negative packet numbers allowed")
+
+	// A temporary error that isn't exported
+	errAgain = errors.New("unavailable; try again")
+)
+
+// ErrMACMismatch is generated when a MAC fails to check properly. It specifies
+// which Packet sequence number the bad packet was in.
+type ErrMACMismatch PacketSeqno
+
+// ErrBadCiphertext is generated when decryption fails due to improper authentication. It specifies
+// which Packet sequence number the bad packet was in.
+type ErrBadCiphertext PacketSeqno
+
+// ErrUnexpectedMAC is produced when an encryption includes an additional MAC but
+// none was needed.
+type ErrUnexpectedMAC PacketSeqno
+
+// ErrRepeatedKey is produced during encryption if a key is repeated; keys must be
+// unique.
+type ErrRepeatedKey []byte
+
+// ErrBadGroupID is produced if a GroupID is encountered that out-of-range
+type ErrBadGroupID int
+
+// ErrWrongPacketTag is produced if one packet tag was expected, but a packet
+// of another tag was found.
+type ErrWrongPacketTag struct {
+	seqno    PacketSeqno
+	wanted   PacketTag
+	received PacketTag
+}
+
+// ErrBadVersion is returned if a packet of an unsupported version is found.
+// Current, only Version1 is supported.
+type ErrBadVersion struct {
+	seqno    PacketSeqno
+	received PacketVersion
+}
+
+// ErrBadNonce is produced when a header nonce is of the wrong size;
+// it should be 20 bytes.
+type ErrBadNonce struct {
+	seqno   PacketSeqno
+	byteLen int
+}
+
+func (e ErrWrongPacketTag) Error() string {
+	return fmt.Sprintf("In packet %d: wanted tag=%d; got tag=%d", e.seqno, e.wanted, e.received)
+}
+func (e ErrBadVersion) Error() string {
+	return fmt.Sprintf("In packet %d: unsupported version (%d)", e.seqno, e.received)
+}
+func (e ErrBadNonce) Error() string {
+	return fmt.Sprintf("In packet %d: bad nonce; wrong lengh (%d)", e.seqno, e.byteLen)
+}
+func (e ErrBadCiphertext) Error() string {
+	return fmt.Sprintf("In packet %d: bad ciphertext; failed Poly1305", e)
+}
+func (e ErrUnexpectedMAC) Error() string {
+	return fmt.Sprintf("In packet %d: unexpected MAC (there was only 1 receiver)", e)
+}
+func (e ErrMACMismatch) Error() string {
+	return fmt.Sprintf("In packet %d: MAC mismatch", e)
+}
+func (e ErrRepeatedKey) Error() string {
+	return fmt.Sprintf("Repeated recipient key: %x", e)
+}
+func (e ErrBadGroupID) Error() string {
+	return fmt.Sprintf("Bad group ID (no MAC keys available for it): %d", e)
+}

--- a/go/kbcmf/errors.go
+++ b/go/kbcmf/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package kbcmf
 
 import (

--- a/go/kbcmf/fmp.go
+++ b/go/kbcmf/fmp.go
@@ -1,0 +1,190 @@
+package kbcmf
+
+import (
+	"bytes"
+	"github.com/ugorji/go/codec"
+	"io"
+)
+
+func encodeNewPacket(w io.Writer, p interface{}) error {
+	buf, err := encodeToBytes(p)
+	if err != nil {
+		return err
+	}
+	l, err := encodeToBytes(len(buf))
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(append(l, buf...))
+	return err
+}
+
+func encodeToBytes(i interface{}) ([]byte, error) {
+	var encoded []byte
+	err := codec.NewEncoderBytes(&encoded, codecHandle()).Encode(i)
+	return encoded, err
+}
+
+func decodeFromBytes(p interface{}, b []byte) error {
+	return codec.NewDecoderBytes(b, codecHandle()).Decode(p)
+}
+
+type peek1Buffer struct {
+	bytes.Buffer
+	ch *byte
+}
+
+func (p *peek1Buffer) Peek() (byte, error) {
+	if p.ch != nil {
+		return *p.ch, nil
+	}
+	ch, err := p.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	p.ch = &ch
+	return ch, nil
+}
+
+func (p *peek1Buffer) Len() int {
+	ret := p.Buffer.Len()
+	if p.ch != nil {
+		ret++
+	}
+	return ret
+}
+
+func (p *peek1Buffer) Next(n int) []byte {
+	var ret []byte
+	if n == 0 {
+		return nil
+	}
+
+	if p.ch != nil {
+		n--
+		ret = []byte{*p.ch}
+		p.ch = nil
+	}
+	return append(ret, p.Buffer.Next(n)...)
+}
+
+type framedMsgpackStream struct {
+	buf           peek1Buffer
+	eof           bool
+	packetLenNext int
+	err           error
+	seqno         PacketSeqno
+}
+
+var _ io.WriteCloser = (*framedMsgpackStream)(nil)
+
+func (f *framedMsgpackStream) Write(b []byte) (n int, err error) {
+	return f.buf.Write(b)
+}
+
+func (f *framedMsgpackStream) Close() error {
+	if f.err != nil {
+		return f.err
+	}
+	f.eof = true
+	return nil
+}
+
+func (f *framedMsgpackStream) Decode(i interface{}) (ret PacketSeqno, err error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	for f.packetLenNext == 0 {
+		err := f.decodeFrame()
+		if err == errAgain {
+			return 0, err
+		}
+		if err != nil {
+			f.err = err
+			return 0, err
+		}
+	}
+	err = f.decodePacket(i)
+
+	// Unexpected EOF here
+	if err == errAgain && f.eof {
+		err = ErrUnexpectedEOF
+		f.err = err
+	} else if err != nil && err != errAgain {
+		f.err = err
+	} else if err == nil {
+		ret = f.seqno
+		f.seqno++
+	}
+	return ret, err
+}
+
+func (f *framedMsgpackStream) decodePacket(i interface{}) error {
+	if f.buf.Len() < f.packetLenNext {
+		return errAgain
+	}
+	buf := f.buf.Next(f.packetLenNext)
+	if len(buf) != f.packetLenNext {
+		return ErrBadFrame
+	}
+	err := decodeFromBytes(i, buf)
+	f.packetLenNext = 0
+	return err
+}
+
+// This is a hack of sorts, in which we've taken the important
+// parts of the Msgpack spec for reading an int from the string.
+func msgpackFrameLen(b byte) int {
+	if b < 0x80 {
+		return 1
+	}
+	if b == 0xcc {
+		return 2
+	}
+	if b == 0xcd {
+		return 3
+	}
+	if b == 0xce {
+		return 5
+	}
+	return 0
+}
+
+func (f *framedMsgpackStream) decodeFrame() error {
+	if f.buf.Len() == 0 {
+		if f.eof {
+			return io.EOF
+		}
+		return errAgain
+	}
+
+	var f0 byte
+	var err error
+
+	// First get the frame's framing byte! This will tell us
+	// how many more bytes we need to grab.  This is a bit of
+	// an abstraction violation, but one worth it for implementation
+	// simplicity and efficiency.
+	if f0, err = f.buf.Peek(); err != nil {
+		return err
+	}
+
+	frameLen := msgpackFrameLen(f0)
+	if frameLen == 0 {
+		return ErrBadFrame
+	}
+
+	if f.buf.Len() < frameLen {
+		if f.eof {
+			return ErrUnexpectedEOF
+		}
+		return errAgain
+	}
+
+	buf := f.buf.Next(frameLen)
+	if len(buf) != frameLen {
+		return ErrBadFrame
+	}
+	err = decodeFromBytes(&f.packetLenNext, buf)
+	return err
+}

--- a/go/kbcmf/fmp.go
+++ b/go/kbcmf/fmp.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package kbcmf
 
 import (

--- a/go/kbcmf/key.go
+++ b/go/kbcmf/key.go
@@ -1,0 +1,43 @@
+package kbcmf
+
+import ()
+
+// RawBoxKey is the raw byte-representation of what a box key should
+// look like --- a static 32-byte buffer
+type RawBoxKey [32]byte
+
+// SymmetricKey is a template for a symmetric key, a 32-byte static
+// buffer.  Used for both NaCl SecretBox and also HMAC keys.
+type SymmetricKey [32]byte
+
+// BoxPublicKey is an generic interface to NaCl's public key Box function.
+type BoxPublicKey interface {
+
+	// ToKID outputs the "key ID" that corresponds to this BoxPublicKey.
+	// You can do whatever you'd like here, but probably it makes sense just
+	// to output the public key as is.
+	ToKID() []byte
+
+	// ToRawBoxKeyPointer returns this public key as a *[32]byte,
+	// for use with nacl.box.Seal
+	ToRawBoxKeyPointer() *RawBoxKey
+}
+
+// Nonce is a NaCl-style nonce, with 24 bytes of data, some of which can be
+// counter values, and some of which can be truly random values.
+type Nonce [24]byte
+
+// BoxSecretKey is the secret key corresponding to a BoxPublicKey
+type BoxSecretKey interface {
+
+	// Box boxes up data, sent from this secret key, and to the receiver
+	// specified.
+	Box(receiver BoxPublicKey, nonce *Nonce, msg []byte) ([]byte, error)
+
+	// Unobx opens up the box, using this secret key as the receiver key
+	// abd the give public key as the sender key.
+	Unbox(sender BoxPublicKey, nonce *Nonce, msg []byte) ([]byte, error)
+
+	// GetPublicKey gets the public key associated with this secret key
+	GetPublicKey() BoxPublicKey
+}

--- a/go/kbcmf/key.go
+++ b/go/kbcmf/key.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package kbcmf
 
 import ()

--- a/go/kbcmf/packets.go
+++ b/go/kbcmf/packets.go
@@ -1,0 +1,61 @@
+package kbcmf
+
+import ()
+
+type receiverKeysPlaintext struct {
+	GroupID    int    `codec:"gid"`
+	MACKey     []byte `codec:"mac,omitempty"`
+	SessionKey []byte `codec:"sess"`
+}
+
+type receiverKeysCiphertext struct {
+	KID  []byte `codec:"kid"`
+	Keys []byte `codec:"keys"`
+}
+
+// EncryptionHeader is the first packet in an encrypted message.
+// It contains the encryptions of the session keys, and various
+// message metadata.
+type EncryptionHeader struct {
+	Version   PacketVersion            `codec:"vers"`
+	Tag       PacketTag                `codec:"tag"`
+	Nonce     []byte                   `codec:"nonce"`
+	Receivers []receiverKeysCiphertext `codec:"rcvrs"`
+	Sender    []byte                   `codec:"sender"`
+	seqno     PacketSeqno
+}
+
+// EncryptionBlock contains a block of encrypted data. It cointains
+// the ciphertext, and any necessary MACs.
+type EncryptionBlock struct {
+	Version    PacketVersion `codec:"vers"`
+	Tag        PacketTag     `codec:"tag"`
+	Ciphertext []byte        `codec:"ctext"`
+	MACs       [][]byte      `codec:"macs"`
+	seqno      PacketSeqno
+}
+
+func (h *EncryptionHeader) validate() error {
+	if h.Tag != PacketTagEncryptionHeader {
+		return ErrWrongPacketTag{h.seqno, PacketTagEncryptionHeader, h.Tag}
+	}
+	if h.Version != PacketVersion1 {
+		return ErrBadVersion{h.seqno, h.Version}
+	}
+	// We leave off 4 bytes of the nonce, since it's a counter
+	// incremented for each public key
+	if len(h.Nonce) != len(Nonce{})-4 {
+		return ErrBadNonce{h.seqno, len(h.Nonce)}
+	}
+	return nil
+}
+
+func (b *EncryptionBlock) validate() error {
+	if b.Tag != PacketTagEncryptionBlock {
+		return ErrWrongPacketTag{b.seqno, PacketTagEncryptionBlock, b.Tag}
+	}
+	if b.Version != PacketVersion1 {
+		return ErrBadVersion{b.seqno, b.Version}
+	}
+	return nil
+}

--- a/go/kbcmf/packets.go
+++ b/go/kbcmf/packets.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package kbcmf
 
 import ()

--- a/go/kbcmf/tweakable_encryptor_test.go
+++ b/go/kbcmf/tweakable_encryptor_test.go
@@ -1,0 +1,269 @@
+package kbcmf
+
+import (
+	"bytes"
+	"encoding/hex"
+	"golang.org/x/crypto/nacl/secretbox"
+	"io"
+)
+
+type testEncryptionOptions struct {
+	blockSize                     int
+	skipFooter                    bool
+	corruptEncryptionBlock        func(bl *EncryptionBlock, ebn encryptionBlockNumber)
+	corruptNonce                  func(n *Nonce, ebn encryptionBlockNumber)
+	corruptMacKey                 func(k *SymmetricKey, i int)
+	corruptReceiverKeysPlaintext  func(rk *receiverKeysPlaintext, gid int, rid int)
+	corruptReceiverKeysCiphertext func(rk *receiverKeysCiphertext, gid int, rid int)
+	corruptHeaderNonce            func(n *Nonce, gid int, rid int)
+	corruptHeader                 func(eh *EncryptionHeader)
+}
+
+func (eo testEncryptionOptions) getBlockSize() int {
+	if eo.blockSize == 0 {
+		return EncryptionBlockSize
+	}
+	return eo.blockSize
+}
+
+type testPublicEncryptStream struct {
+	output     io.Writer
+	header     *EncryptionHeader
+	sessionKey SymmetricKey
+	buffer     bytes.Buffer
+	inblock    []byte
+	macGroups  []SymmetricKey
+	options    testEncryptionOptions
+
+	numBlocks encryptionBlockNumber // the lower 64 bits of the nonce
+
+	didHeader bool
+	eof       bool
+	err       error
+}
+
+func (pes *testPublicEncryptStream) Write(plaintext []byte) (int, error) {
+
+	if !pes.didHeader {
+		pes.didHeader = true
+		pes.err = encodeNewPacket(pes.output, pes.header)
+	}
+
+	if pes.err != nil {
+		return 0, pes.err
+	}
+
+	var ret int
+	if ret, pes.err = pes.buffer.Write(plaintext); pes.err != nil {
+		return 0, pes.err
+	}
+	for pes.buffer.Len() >= pes.options.getBlockSize() {
+		pes.err = pes.encryptBlock()
+		if pes.err != nil {
+			return 0, pes.err
+		}
+	}
+	return ret, nil
+}
+
+func (pes *testPublicEncryptStream) macForAllGroups(b []byte) [][]byte {
+	var macs [][]byte
+	for _, key := range pes.macGroups {
+		mac := hmacSHA512(key[:], b)
+		macs = append(macs, mac)
+	}
+	return macs
+}
+
+func (pes *testPublicEncryptStream) encryptBlock() error {
+	var n int
+	var err error
+	n, err = pes.buffer.Read(pes.inblock[:])
+	if err != nil {
+		return nil
+	}
+	return pes.encryptBytes(pes.inblock[0:n])
+}
+
+func (pes *testPublicEncryptStream) encryptBytes(b []byte) error {
+
+	if err := pes.numBlocks.check(); err != nil {
+		return err
+	}
+
+	nonce := pes.numBlocks.newCounterNonce()
+
+	if pes.options.corruptNonce != nil {
+		pes.options.corruptNonce(nonce, pes.numBlocks)
+	}
+
+	ciphertext := secretbox.Seal([]byte{}, b, (*[24]byte)(nonce), (*[32]byte)(&pes.sessionKey))
+	// Compute the MAC over the nonce and the ciphertext
+	sum, err := hashCryptoBlock(nonce, ciphertext)
+	if err != nil {
+		return err
+	}
+	macs := pes.macForAllGroups(sum)
+	block := EncryptionBlock{
+		Version:    PacketVersion1,
+		Tag:        PacketTagEncryptionBlock,
+		Ciphertext: ciphertext,
+		MACs:       macs,
+	}
+
+	if pes.options.corruptEncryptionBlock != nil {
+		pes.options.corruptEncryptionBlock(&block, pes.numBlocks)
+	}
+
+	if err = encodeNewPacket(pes.output, block); err != nil {
+		return nil
+	}
+
+	pes.numBlocks++
+	return nil
+}
+
+func (pes *testPublicEncryptStream) init(sender BoxSecretKey, receivers [][]BoxPublicKey) error {
+	eh := &EncryptionHeader{
+		Version:   PacketVersion1,
+		Tag:       PacketTagEncryptionHeader,
+		Sender:    sender.GetPublicKey().ToKID(),
+		Receivers: make([]receiverKeysCiphertext, 0, len(receivers)),
+	}
+	pes.header = eh
+	if err := randomFill(pes.sessionKey[:]); err != nil {
+		return err
+	}
+
+	// Only fill the first 20 bytes of the nonce. The remaining 4
+	// we'll increment with every call to Box
+	nonceRandLen := 20
+	var nonce Nonce
+	if err := randomFill(nonce[:nonceRandLen]); err != nil {
+		return err
+	}
+
+	// We don't necessarily have to copy our header nonce into place,
+	// but if feels safer, since we modify the nonce below
+	eh.Nonce = make([]byte, nonceRandLen)
+	copy(eh.Nonce, nonce[:])
+
+	d := make(map[string]struct{})
+
+	var i uint32
+
+	for gid, group := range receivers {
+		var macKey SymmetricKey
+		if len(receivers) > 1 {
+			if err := randomFill(macKey[:]); err != nil {
+				return err
+			}
+			pes.macGroups = append(pes.macGroups, macKey)
+		} else {
+			gid = -1
+		}
+
+		if pes.options.corruptMacKey != nil {
+			pes.options.corruptMacKey(&macKey, gid)
+		}
+
+		for rid, receiver := range group {
+			kid := receiver.ToKID()
+			kidString := hex.EncodeToString(kid)
+			if _, found := d[kidString]; found {
+				return ErrRepeatedKey(kid)
+			}
+			d[kidString] = struct{}{}
+
+			pt := receiverKeysPlaintext{
+				GroupID:    gid,
+				SessionKey: pes.sessionKey[:],
+			}
+			if gid >= 0 {
+				pt.MACKey = macKey[:]
+			}
+
+			if pes.options.corruptReceiverKeysPlaintext != nil {
+				pes.options.corruptReceiverKeysPlaintext(&pt, gid, rid)
+			}
+
+			pte, err := encodeToBytes(pt)
+			if err != nil {
+				return err
+			}
+			nonce.writeCounter32(i)
+
+			if pes.options.corruptHeaderNonce != nil {
+				pes.options.corruptHeaderNonce(&nonce, gid, rid)
+			}
+
+			i++
+			ptec, err := sender.Box(receiver, &nonce, pte)
+			if err != nil {
+				return err
+			}
+
+			rkc := receiverKeysCiphertext{
+				KID:  kid,
+				Keys: ptec,
+			}
+
+			if pes.options.corruptReceiverKeysCiphertext != nil {
+				pes.options.corruptReceiverKeysCiphertext(&rkc, gid, rid)
+			}
+
+			eh.Receivers = append(eh.Receivers, rkc)
+		}
+	}
+	if pes.options.corruptHeader != nil {
+		pes.options.corruptHeader(eh)
+	}
+	return nil
+}
+
+func (pes *testPublicEncryptStream) Close() error {
+	for pes.buffer.Len() > 0 {
+		err := pes.encryptBlock()
+		if err != nil {
+			return err
+		}
+	}
+	return pes.writeFooter()
+}
+
+func (pes *testPublicEncryptStream) writeFooter() error {
+	var err error
+	if !pes.options.skipFooter {
+		err = pes.encryptBytes([]byte{})
+	}
+	return err
+}
+
+// Options are available mainly for testing.  Can't think of a good reason for
+// end-users to have to specify options.
+func newTestPublicEncryptStream(ciphertext io.Writer, sender BoxSecretKey, receivers [][]BoxPublicKey, options testEncryptionOptions) (plaintext io.WriteCloser, err error) {
+	pes := &testPublicEncryptStream{
+		output:  ciphertext,
+		options: options,
+		inblock: make([]byte, options.getBlockSize()),
+	}
+	if err := pes.init(sender, receivers); err != nil {
+		return nil, err
+	}
+	return pes, nil
+}
+
+func testSeal(plaintext []byte, sender BoxSecretKey, receivers [][]BoxPublicKey, options testEncryptionOptions) (out []byte, err error) {
+	var buf bytes.Buffer
+	es, err := newTestPublicEncryptStream(&buf, sender, receivers, options)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := es.Write(plaintext); err != nil {
+		return nil, err
+	}
+	if err := es.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/go/kbcmf/tweakable_encryptor_test.go
+++ b/go/kbcmf/tweakable_encryptor_test.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package kbcmf
 
 import (


### PR DESCRIPTION
- test coverage up to 85%, that's good enough for now
- some basic Go-style comments roughed in, but more are needed, and we need to clean them up
- all major features implemented
- no remaining major TODOs
- might want to clean up terminology and maybe do away w/ the seqno v blocknum distinction
- probably ready for review
- would like some more tests of the framed-msgpack decoder