### PR TITLE
paperkey provisioning: remove username, passphrase prompt

### DIFF
--- a/go/engine/common.go
+++ b/go/engine/common.go
@@ -89,5 +89,40 @@ func findPaperKeys(ctx *Context, g *libkb.GlobalContext, me *libkb.User) (*keypa
 	}
 
 	return &keypair{sigKey: sigKey, encKey: encKey}, nil
+}
 
+// fetchLKS gets the encrypted LKS client half from the server.
+// It uses encKey to decrypt it.  It also returns the passphrase
+// generation.
+func fetchLKS(ctx *Context, g *libkb.GlobalContext, encKey libkb.GenericKey) (libkb.PassphraseGeneration, []byte, error) {
+	arg := libkb.APIArg{
+		Endpoint:    "passphrase/recover",
+		NeedSession: true,
+		Args: libkb.HTTPArgs{
+			"kid": encKey.GetKID(),
+		},
+	}
+	if ctx.LoginContext != nil {
+		arg.SessionR = ctx.LoginContext.LocalSession()
+	}
+	res, err := g.API.Get(arg)
+	if err != nil {
+		return 0, nil, err
+	}
+	ctext, err := res.Body.AtKey("ctext").GetString()
+	if err != nil {
+		return 0, nil, err
+	}
+	ppGen, err := res.Body.AtKey("passphrase_generation").GetInt()
+	if err != nil {
+		return 0, nil, err
+	}
+
+	//  Now try to decrypt with the unlocked device key
+	msg, _, err := encKey.DecryptFromString(ctext)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return libkb.PassphraseGeneration(ppGen), msg, nil
 }

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -76,7 +76,7 @@ func SignupFakeUserWithArg(tc libkb.TestContext, fu *FakeUser, arg SignupEngineR
 		LogUI:    tc.G.UI.GetLogUI(),
 		GPGUI:    &gpgtestui{},
 		SecretUI: fu.NewSecretUI(),
-		LoginUI:  libkb.TestLoginUI{Username: fu.Username},
+		LoginUI:  &libkb.TestLoginUI{Username: fu.Username},
 	}
 	s := NewSignupEngine(&arg, tc.G)
 	err := RunEngine(s, ctx)
@@ -104,7 +104,7 @@ func CreateAndSignupFakeUserSafe(g *libkb.GlobalContext, prefix string) (*FakeUs
 		LogUI:    g.UI.GetLogUI(),
 		GPGUI:    &gpgtestui{},
 		SecretUI: fu.NewSecretUI(),
-		LoginUI:  libkb.TestLoginUI{Username: fu.Username},
+		LoginUI:  &libkb.TestLoginUI{Username: fu.Username},
 	}
 	s := NewSignupEngine(&arg, g)
 	err = RunEngine(s, ctx)
@@ -125,7 +125,7 @@ func CreateAndSignupFakeUserGPG(tc libkb.TestContext, prefix string) *FakeUser {
 		LogUI:    tc.G.UI.GetLogUI(),
 		GPGUI:    &gpgtestui{},
 		SecretUI: fu.NewSecretUI(),
-		LoginUI:  libkb.TestLoginUI{Username: fu.Username},
+		LoginUI:  &libkb.TestLoginUI{Username: fu.Username},
 	}
 	s := NewSignupEngine(&arg, tc.G)
 	err := RunEngine(s, ctx)
@@ -143,7 +143,7 @@ func CreateAndSignupFakeUserCustomArg(tc libkb.TestContext, prefix string, fmod 
 		LogUI:    tc.G.UI.GetLogUI(),
 		GPGUI:    &gpgtestui{},
 		SecretUI: fu.NewSecretUI(),
-		LoginUI:  libkb.TestLoginUI{Username: fu.Username},
+		LoginUI:  &libkb.TestLoginUI{Username: fu.Username},
 	}
 	s := NewSignupEngine(&arg, tc.G)
 	err := RunEngine(s, ctx)

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -326,14 +326,16 @@ func TestProvisionPaper(t *testing.T) {
 	tc2 := SetupEngineTest(t, "login")
 	defer tc2.Cleanup()
 
-	secui := fu.NewSecretUI()
-	secui.BackupPassphrase = loginUI.PaperPhrase
-
+	secUI := fu.NewSecretUI()
+	secUI.BackupPassphrase = loginUI.PaperPhrase
+	provUI := newTestProvisionUIPaper()
+	provUI.verbose = true
+	provLoginUI := &libkb.TestLoginUI{Username: fu.Username}
 	ctx = &Context{
-		ProvisionUI: newTestProvisionUIPaper(),
+		ProvisionUI: provUI,
 		LogUI:       tc2.G.UI.GetLogUI(),
-		SecretUI:    secui,
-		LoginUI:     &libkb.TestLoginUI{Username: fu.Username},
+		SecretUI:    secUI,
+		LoginUI:     provLoginUI,
 		GPGUI:       &gpgtestui{},
 	}
 	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "")
@@ -347,6 +349,13 @@ func TestProvisionPaper(t *testing.T) {
 
 	if err := AssertProvisioned(tc2); err != nil {
 		t.Fatal(err)
+	}
+
+	if provUI.calledChooseDeviceType != 0 {
+		t.Errorf("expected 0 calls to ChooseDeviceType, got %d", provUI.calledChooseDeviceType)
+	}
+	if provLoginUI.CalledGetEmailOrUsername != 0 {
+		t.Errorf("expected 0 calls to GetEmailOrUsername, got %d", provLoginUI.CalledGetEmailOrUsername)
 	}
 }
 
@@ -462,9 +471,10 @@ func TestProvisionDupDevice(t *testing.T) {
 }
 
 type testProvisionUI struct {
-	secretCh chan kex2.Secret
-	method   keybase1.ProvisionMethod
-	verbose  bool
+	secretCh               chan kex2.Secret
+	method                 keybase1.ProvisionMethod
+	verbose                bool
+	calledChooseDeviceType int
 }
 
 func newTestProvisionUI() *testProvisionUI {
@@ -512,7 +522,8 @@ func (u *testProvisionUI) ChooseProvisioningMethod(_ context.Context, _ keybase1
 }
 
 func (u *testProvisionUI) ChooseDeviceType(_ context.Context, _ int) (keybase1.DeviceType, error) {
-	u.printf("ChooseProvisionerDevice")
+	u.printf("ChooseDeviceType")
+	u.calledChooseDeviceType++
 	return keybase1.DeviceType_DESKTOP, nil
 }
 

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -357,6 +357,9 @@ func TestProvisionPaper(t *testing.T) {
 	if provLoginUI.CalledGetEmailOrUsername != 0 {
 		t.Errorf("expected 0 calls to GetEmailOrUsername, got %d", provLoginUI.CalledGetEmailOrUsername)
 	}
+	if secUI.CalledGetKBPassphrase {
+		t.Error("expected no calls to GetKeybasePassphrase, but it was called")
+	}
 }
 
 // Provision device using a private GPG key (not synced to keybase

--- a/go/engine/paperkey_primary_test.go
+++ b/go/engine/paperkey_primary_test.go
@@ -25,7 +25,7 @@ func TestPaperKeyPrimary(t *testing.T) {
 	}
 
 	ctx := &Context{
-		LoginUI: libkb.TestLoginUI{},
+		LoginUI: &libkb.TestLoginUI{},
 	}
 	args := &PaperKeyPrimaryArgs{
 		Me:         me,

--- a/go/engine/paperkey_test.go
+++ b/go/engine/paperkey_test.go
@@ -64,7 +64,7 @@ func TestPaperKey(t *testing.T) {
 
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
-		LoginUI:  libkb.TestLoginUI{},
+		LoginUI:  &libkb.TestLoginUI{},
 		SecretUI: &libkb.TestSecretUI{},
 	}
 	eng := NewPaperKey(tc.G)
@@ -115,7 +115,7 @@ func TestPaperKeyRevoke(t *testing.T) {
 
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
-		LoginUI:  libkb.TestLoginUI{RevokeBackup: true},
+		LoginUI:  &libkb.TestLoginUI{RevokeBackup: true},
 		SecretUI: &libkb.TestSecretUI{},
 	}
 
@@ -158,7 +158,7 @@ func TestPaperKeyNoRevoke(t *testing.T) {
 
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
-		LoginUI:  libkb.TestLoginUI{RevokeBackup: false},
+		LoginUI:  &libkb.TestLoginUI{RevokeBackup: false},
 		SecretUI: &libkb.TestSecretUI{},
 	}
 
@@ -198,7 +198,7 @@ func TestPaperKeyGenWithSecretStore(t *testing.T) {
 		tc libkb.TestContext, fu *FakeUser, secretUI libkb.SecretUI) {
 		ctx := &Context{
 			LogUI:    tc.G.UI.GetLogUI(),
-			LoginUI:  libkb.TestLoginUI{},
+			LoginUI:  &libkb.TestLoginUI{},
 			SecretUI: secretUI,
 		}
 		eng := NewPaperKey(tc.G)

--- a/go/engine/passphrase_change_test.go
+++ b/go/engine/passphrase_change_test.go
@@ -312,7 +312,7 @@ func TestPassphraseChangeUnknownBackupKey(t *testing.T) {
 
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
-		LoginUI:  libkb.TestLoginUI{},
+		LoginUI:  &libkb.TestLoginUI{},
 		SecretUI: &libkb.TestSecretUI{},
 	}
 	beng := NewPaperKey(tc.G)
@@ -354,7 +354,7 @@ func TestPassphraseChangeLoggedOutBackupKey(t *testing.T) {
 
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
-		LoginUI:  libkb.TestLoginUI{},
+		LoginUI:  &libkb.TestLoginUI{},
 		SecretUI: &libkb.TestSecretUI{},
 	}
 	beng := NewPaperKey(tc.G)
@@ -409,7 +409,7 @@ func TestPassphraseChangeLoggedOutBackupKeySecretStore(t *testing.T) {
 	secretUI := libkb.TestSecretUI{}
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
-		LoginUI:  libkb.TestLoginUI{},
+		LoginUI:  &libkb.TestLoginUI{},
 		SecretUI: &secretUI,
 	}
 	beng := NewPaperKey(tc.G)
@@ -532,7 +532,7 @@ func TestPassphraseChangeLoggedOutBackupKeyPlusPGP(t *testing.T) {
 
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
-		LoginUI:  libkb.TestLoginUI{},
+		LoginUI:  &libkb.TestLoginUI{},
 		SecretUI: &libkb.TestSecretUI{},
 	}
 	beng := NewPaperKey(tc.G)
@@ -606,7 +606,7 @@ func TestPassphraseChangeLoggedOutBackupKeySecretStorePGP(t *testing.T) {
 	secretUI := libkb.TestSecretUI{}
 	ctx = &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
-		LoginUI:  libkb.TestLoginUI{},
+		LoginUI:  &libkb.TestLoginUI{},
 		SecretUI: &secretUI,
 	}
 	beng := NewPaperKey(tc.G)

--- a/go/engine/reset_test.go
+++ b/go/engine/reset_test.go
@@ -35,7 +35,7 @@ func TestReset(t *testing.T) {
 		LogUI:    tc.G.UI.GetLogUI(),
 		GPGUI:    &gpgtestui{},
 		SecretUI: fu.NewSecretUI(),
-		LoginUI:  libkb.TestLoginUI{Username: fu.Username},
+		LoginUI:  &libkb.TestLoginUI{Username: fu.Username},
 	}
 	s := NewSignupEngine(&arg, tc.G)
 	err := RunEngine(s, ctx)

--- a/go/engine/unlock_test.go
+++ b/go/engine/unlock_test.go
@@ -30,7 +30,7 @@ func TestUnlock(t *testing.T) {
 
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
-		LoginUI:  libkb.TestLoginUI{},
+		LoginUI:  &libkb.TestLoginUI{},
 		SecretUI: fu.NewSecretUI(),
 	}
 
@@ -64,7 +64,7 @@ func TestUnlockNoop(t *testing.T) {
 
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
-		LoginUI:  libkb.TestLoginUI{},
+		LoginUI:  &libkb.TestLoginUI{},
 		SecretUI: fu.NewSecretUI(),
 	}
 

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -58,7 +58,7 @@ func CreateAndSignupFakeUser(prefix string, g *libkb.GlobalContext) (*FakeUser, 
 		LogUI:    g.UI.GetLogUI(),
 		GPGUI:    &gpgtestui{},
 		SecretUI: fu.NewSecretUI(),
-		LoginUI:  libkb.TestLoginUI{Username: fu.Username},
+		LoginUI:  &libkb.TestLoginUI{Username: fu.Username},
 	}
 	s := engine.NewSignupEngine(&arg, g)
 	if err := engine.RunEngine(s, ctx); err != nil {

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -126,10 +126,12 @@ func (a *Account) CreateStreamCache(tsec *triplesec.Cipher, pps *PassphraseStrea
 
 // SetStreamGeneration sets the passphrase generation on the cached stream
 // if it exists, and otherwise will wind up warning of a problem.
-func (a *Account) SetStreamGeneration(gen PassphraseGeneration) {
+func (a *Account) SetStreamGeneration(gen PassphraseGeneration, nilPPStreamOK bool) {
 	ps := a.PassphraseStreamRef()
 	if ps == nil {
-		a.G().Log.Warning("Passphrase stream was nil; unexpected")
+		if !nilPPStreamOK {
+			a.G().Log.Warning("Passphrase stream was nil; unexpected")
+		}
 	} else {
 		ps.SetGeneration(gen)
 	}

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -364,22 +364,24 @@ func (t *TestSecretUI) GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) 
 }
 
 type TestLoginUI struct {
-	Username     string
-	RevokeBackup bool
+	Username                 string
+	RevokeBackup             bool
+	CalledGetEmailOrUsername int
 }
 
-func (t TestLoginUI) GetEmailOrUsername(_ context.Context, _ int) (string, error) {
+func (t *TestLoginUI) GetEmailOrUsername(_ context.Context, _ int) (string, error) {
+	t.CalledGetEmailOrUsername++
 	return t.Username, nil
 }
 
-func (t TestLoginUI) PromptRevokePaperKeys(_ context.Context, arg keybase1.PromptRevokePaperKeysArg) (bool, error) {
+func (t *TestLoginUI) PromptRevokePaperKeys(_ context.Context, arg keybase1.PromptRevokePaperKeysArg) (bool, error) {
 	return t.RevokeBackup, nil
 }
 
-func (t TestLoginUI) DisplayPaperKeyPhrase(_ context.Context, arg keybase1.DisplayPaperKeyPhraseArg) error {
+func (t *TestLoginUI) DisplayPaperKeyPhrase(_ context.Context, arg keybase1.DisplayPaperKeyPhraseArg) error {
 	return nil
 }
 
-func (t TestLoginUI) DisplayPrimaryPaperKey(_ context.Context, arg keybase1.DisplayPrimaryPaperKeyArg) error {
+func (t *TestLoginUI) DisplayPrimaryPaperKey(_ context.Context, arg keybase1.DisplayPrimaryPaperKeyArg) error {
 	return nil
 }


### PR DESCRIPTION
paperkey provisioning no longer requires username or passphrase.

r? @maxtaco 