### PR TITLE
Change GetEmailOrUsername prompt to just username

### DIFF
--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -483,8 +483,8 @@ func NewLoginUI(t libkb.TerminalUI, noPrompt bool) LoginUI {
 }
 
 func (l LoginUI) GetEmailOrUsername(_ context.Context, _ int) (string, error) {
-	return PromptWithChecker(PromptDescriptorLoginUsername, l.parent, "Your keybase username or email", false,
-		libkb.CheckEmailOrUsername)
+	return PromptWithChecker(PromptDescriptorLoginUsername, l.parent, "Your keybase username", false,
+		libkb.CheckUsername)
 }
 
 func (l LoginUI) PromptRevokePaperKeys(_ context.Context, arg keybase1.PromptRevokePaperKeysArg) (bool, error) {


### PR DESCRIPTION
This is temporary, but for now, only allowing login via
username.  The Checker changed to just username as well.

No protocol changes.

CORE-2017 addresses fixing this so that login via email
address works again.

r? @maxtaco 