### PR TITLE
Use sockets file for pipe naming

### DIFF
--- a/go/libkb/socket.go
+++ b/go/libkb/socket.go
@@ -15,6 +15,11 @@ type Socket interface {
 	DialSocket() (net.Conn, error)
 }
 
+type SocketInfo struct {
+	Contextified
+	file string
+}
+
 type SocketWrapper struct {
 	conn net.Conn
 	xp   rpc.Transporter

--- a/go/libkb/socket_nix.go
+++ b/go/libkb/socket_nix.go
@@ -11,12 +11,7 @@ import (
 	"strings"
 )
 
-type SocketUnix struct {
-	Contextified
-	file string
-}
-
-func (s SocketUnix) BindToSocket() (ret net.Listener, err error) {
+func (s SocketInfo) BindToSocket() (ret net.Listener, err error) {
 	if err = MakeParentDirs(s.file); err != nil {
 		return
 	}
@@ -24,7 +19,7 @@ func (s SocketUnix) BindToSocket() (ret net.Listener, err error) {
 	return net.Listen("unix", s.file)
 }
 
-func (s SocketUnix) DialSocket() (ret net.Conn, err error) {
+func (s SocketInfo) DialSocket() (ret net.Conn, err error) {
 	s.G().Log.Debug("Dialing unix:%s", s.file)
 	return net.Dial("unix", s.file)
 }
@@ -33,7 +28,7 @@ func NewSocket(g *GlobalContext) (ret Socket, err error) {
 	var s string
 	s, err = g.Env.GetSocketFile()
 	if err == nil {
-		ret = SocketUnix{
+		ret = SocketInfo{
 			Contextified: NewContextified(g),
 			file:         s,
 		}
@@ -42,6 +37,6 @@ func NewSocket(g *GlobalContext) (ret Socket, err error) {
 }
 
 // net.errClosing isn't exported, so do this.. UGLY!
-func IsSocketClosedError(e error) (bool) {
+func IsSocketClosedError(e error) bool {
 	return strings.HasSuffix(e.Error(), "use of closed network connection")
 }

--- a/go/libkb/socket_windows.go
+++ b/go/libkb/socket_windows.go
@@ -9,43 +9,36 @@ package libkb
 import (
 	"errors"
 	"net"
-	"os/user"
+	"path/filepath"
+	"strings"
 
 	"github.com/natefinch/npipe"
 )
 
-type SocketNamedPipe struct {
-	Contextified
-	pipename string
-}
-
-// user.Current() includes machine name on windows, but
-// this is still only a local pipe because of the dot
-// following the doulble backslashes.
-// If the service ever runs under a different account than
-// current user, this will have to be revisited.
 func NewSocket(g *GlobalContext) (ret Socket, err error) {
-	currentUser, err := user.Current()
+	var s string
+	s, err = g.Env.GetSocketFile()
 	if err != nil {
 		return
 	}
-	if len(currentUser.Username) == 0 {
-		err = errors.New("Empty username, can't make pipe")
+	if len(s) == 0 {
+		err = errors.New("Empty SocketFile, can't make pipe")
 		return
 	}
-	return SocketNamedPipe{
+	s = strings.TrimPrefix(s, filepath.VolumeName(s))
+	return SocketInfo{
 		Contextified: NewContextified(g),
-		pipename:     `\\.\pipe\kbservice\` + currentUser.Username,
+		file:         `\\.\pipe\kbservice` + s,
 	}, nil
 }
 
-func (s SocketNamedPipe) BindToSocket() (ret net.Listener, err error) {
-	s.G().Log.Info("Binding to pipe:%s", s.pipename)
-	return npipe.Listen(s.pipename)
+func (s SocketInfo) BindToSocket() (ret net.Listener, err error) {
+	s.G().Log.Info("Binding to pipe:%s", s.file)
+	return npipe.Listen(s.file)
 }
 
-func (s SocketNamedPipe) DialSocket() (ret net.Conn, err error) {
-	return npipe.Dial(s.pipename)
+func (s SocketInfo) DialSocket() (ret net.Conn, err error) {
+	return npipe.Dial(s.file)
 }
 
 func IsSocketClosedError(e error) bool {

--- a/go/libkb/socket_windows_test.go
+++ b/go/libkb/socket_windows_test.go
@@ -8,11 +8,19 @@ package libkb
 import (
 	"bufio"
 	"fmt"
+	"path/filepath"
 	"sync"
 	"testing"
-
-	"github.com/keybase/client/go/logger"
 )
+
+func setupTest(t *testing.T, nm string) *TestContext {
+	tc := SetupTest(t, nm)
+	tc.SetRuntimeDir(filepath.Join(tc.Tp.Home, "socket_windows_test"))
+	if err := tc.G.ConfigureSocketInfo(); err != nil {
+		t.Fatal(err)
+	}
+	return &tc
+}
 
 // It would be better to test across process boundaries, but this is better
 // than nothing: across gofuncs. We start a server func, then send it a string,
@@ -23,11 +31,11 @@ import (
 // open each others' named pipes.
 func TestWindowsNamedPipe(t *testing.T) {
 
-	var testContext = GlobalContext{
-		Log: logger.New("socket_windows_test"),
-	}
+	tc := setupTest(t, "socket_windows_test")
 
-	listenSocket, err := NewSocket(&testContext)
+	defer tc.Cleanup()
+
+	listenSocket, err := NewSocket(tc.G)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +64,7 @@ func TestWindowsNamedPipe(t *testing.T) {
 		}
 	}()
 
-	sendSocket, err := NewSocket(&testContext)
+	sendSocket, err := NewSocket(tc.G)
 	namedPipeClient(sendSocket, t)
 	wg.Wait()
 }


### PR DESCRIPTION
I had gone too far afield with pipe naming. This makes systests pass now on windows.
@maxtaco @patrickxb 