### PR TITLE
Fix passphrase change (CLI and web)

### DIFF
--- a/go/client/cmd_signup.go
+++ b/go/client/cmd_signup.go
@@ -215,7 +215,7 @@ func (s *CmdSignup) prompt() (err error) {
 
 	f := s.fields.passphraseRetry
 	if f.Disabled || libkb.IsYes(f.GetValue()) {
-		var res keybase1.GetNewPassphraseRes
+		var res keybase1.GetPassphraseRes
 		res, err = s.G().UI.GetSecretUI().GetNewPassphrase(arg)
 		if err != nil {
 			return

--- a/go/client/cmd_stress.go
+++ b/go/client/cmd_stress.go
@@ -306,16 +306,16 @@ func (c *CmdStress) secretUIProtocol() rpc.Protocol {
 	return keybase1.SecretUiProtocol(c)
 }
 
-func (c *CmdStress) GetKeybasePassphrase(_ context.Context, arg keybase1.GetKeybasePassphraseArg) (string, error) {
-	return c.passphrase, nil
+func (c *CmdStress) GetKeybasePassphrase(_ context.Context, arg keybase1.GetKeybasePassphraseArg) (keybase1.GetPassphraseRes, error) {
+	return keybase1.GetPassphraseRes{Passphrase: c.passphrase}, nil
 }
 
 func (c *CmdStress) GetPaperKeyPassphrase(_ context.Context, arg keybase1.GetPaperKeyPassphraseArg) (string, error) {
 	return "", nil
 }
 
-func (c *CmdStress) GetNewPassphrase(_ context.Context, arg keybase1.GetNewPassphraseArg) (keybase1.GetNewPassphraseRes, error) {
-	return keybase1.GetNewPassphraseRes{Passphrase: c.passphrase}, nil
+func (c *CmdStress) GetNewPassphrase(_ context.Context, arg keybase1.GetNewPassphraseArg) (keybase1.GetPassphraseRes, error) {
+	return keybase1.GetPassphraseRes{Passphrase: c.passphrase}, nil
 }
 
 func (c *CmdStress) GetSecret(_ context.Context, arg keybase1.GetSecretArg) (res keybase1.SecretEntryRes, err error) {

--- a/go/client/secret.go
+++ b/go/client/secret.go
@@ -27,11 +27,11 @@ func (s *SecretUIServer) GetSecret(_ context.Context, arg keybase1.GetSecretArg)
 	return
 }
 
-func (s *SecretUIServer) GetNewPassphrase(_ context.Context, arg keybase1.GetNewPassphraseArg) (keybase1.GetNewPassphraseRes, error) {
+func (s *SecretUIServer) GetNewPassphrase(_ context.Context, arg keybase1.GetNewPassphraseArg) (keybase1.GetPassphraseRes, error) {
 	return s.eng.GetNewPassphrase(arg)
 }
 
-func (s *SecretUIServer) GetKeybasePassphrase(_ context.Context, arg keybase1.GetKeybasePassphraseArg) (string, error) {
+func (s *SecretUIServer) GetKeybasePassphrase(_ context.Context, arg keybase1.GetKeybasePassphraseArg) (keybase1.GetPassphraseRes, error) {
 	return s.eng.GetKeybasePassphrase(arg)
 }
 

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -596,7 +596,7 @@ func (ui *UI) Shutdown() error {
 	return err
 }
 
-func (ui SecretUI) GetNewPassphrase(earg keybase1.GetNewPassphraseArg) (eres keybase1.GetNewPassphraseRes, err error) {
+func (ui SecretUI) GetNewPassphrase(earg keybase1.GetNewPassphraseArg) (eres keybase1.GetPassphraseRes, err error) {
 
 	arg := libkb.PromptArg{
 		TerminalPrompt: earg.TerminalPrompt,
@@ -645,15 +645,15 @@ func (ui SecretUI) GetNewPassphrase(earg keybase1.GetNewPassphraseArg) (eres key
 	return
 }
 
-func (ui SecretUI) GetKeybasePassphrase(arg keybase1.GetKeybasePassphraseArg) (text string, err error) {
+func (ui SecretUI) GetKeybasePassphrase(arg keybase1.GetKeybasePassphraseArg) (res keybase1.GetPassphraseRes, err error) {
 	desc := fmt.Sprintf("Please enter the Keybase passphrase for %s (12+ characters)", arg.Username)
-	text, _, err = ui.ppprompt(libkb.PromptArg{
+	res.Passphrase, res.StoreSecret, err = ui.ppprompt(libkb.PromptArg{
 		TerminalPrompt: "keybase passphrase",
 		PinentryPrompt: "Your passphrase",
 		PinentryDesc:   desc,
 		Checker:        &libkb.CheckPassphraseSimple,
 		RetryMessage:   arg.Retry,
-		UseSecretStore: false,
+		UseSecretStore: true,
 	})
 	return
 }

--- a/go/engine/crypto_test.go
+++ b/go/engine/crypto_test.go
@@ -4,6 +4,7 @@
 package engine
 
 import (
+	"runtime/debug"
 	"testing"
 
 	"golang.org/x/crypto/nacl/box"
@@ -172,6 +173,7 @@ func cachedSecretKey(tc libkb.TestContext, ktype libkb.SecretKeyType) (key libkb
 func assertCachedSecretKey(tc libkb.TestContext, ktype libkb.SecretKeyType) {
 	skey, err := cachedSecretKey(tc, ktype)
 	if err != nil {
+		debug.PrintStack()
 		tc.T.Fatalf("error getting cached secret key: %s", err)
 	}
 	if skey == nil {
@@ -200,6 +202,12 @@ func TestCachedSecretKey(t *testing.T) {
 
 	u := CreateAndSignupFakeUser(tc, "login")
 
+	assertCachedSecretKey(tc, libkb.DeviceSigningKeyType)
+	assertCachedSecretKey(tc, libkb.DeviceEncryptionKeyType)
+
+	Logout(tc)
+	u.LoginOrBust(tc)
+
 	assertNotCachedSecretKey(tc, libkb.DeviceSigningKeyType)
 	assertNotCachedSecretKey(tc, libkb.DeviceEncryptionKeyType)
 
@@ -217,7 +225,6 @@ func TestCachedSecretKey(t *testing.T) {
 	Logout(tc)
 	u.LoginOrBust(tc)
 
-	// login caches this...
-	assertCachedSecretKey(tc, libkb.DeviceSigningKeyType)
+	assertNotCachedSecretKey(tc, libkb.DeviceSigningKeyType)
 	assertNotCachedSecretKey(tc, libkb.DeviceEncryptionKeyType)
 }

--- a/go/engine/device_keygen.go
+++ b/go/engine/device_keygen.go
@@ -108,6 +108,10 @@ func (e *DeviceKeygen) SigningKey() libkb.NaclKeyPair {
 	return e.naclSignGen.GetKeyPair()
 }
 
+func (e *DeviceKeygen) EncryptionKey() libkb.NaclKeyPair {
+	return e.naclEncGen.GetKeyPair()
+}
+
 // Push pushes the generated keys to the api server and stores the
 // local key security server half on the api server as well.
 func (e *DeviceKeygen) Push(ctx *Context, pargs *DeviceKeygenPushArgs) error {

--- a/go/engine/device_wrap.go
+++ b/go/engine/device_wrap.go
@@ -13,7 +13,8 @@ import (
 type DeviceWrap struct {
 	args *DeviceWrapArgs
 
-	signingKey libkb.GenericKey
+	signingKey    libkb.GenericKey
+	encryptionKey libkb.GenericKey
 	libkb.Contextified
 }
 
@@ -94,10 +95,15 @@ func (e *DeviceWrap) Run(ctx *Context) error {
 	}
 
 	e.signingKey = kgEng.SigningKey()
+	e.encryptionKey = kgEng.EncryptionKey()
 
 	return nil
 }
 
 func (e *DeviceWrap) SigningKey() libkb.GenericKey {
 	return e.signingKey
+}
+
+func (e *DeviceWrap) EncryptionKey() libkb.GenericKey {
+	return e.encryptionKey
 }

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -299,6 +299,12 @@ func (e *Kex2Provisionee) APIArgs() (token, csrf string) {
 	return string(e.sessionToken), string(e.csrfToken)
 }
 
+// Invalidate implements libkb.SessionReader interface.
+func (e *Kex2Provisionee) Invalidate() {
+	e.sessionToken = ""
+	e.csrfToken = ""
+}
+
 // IsLoggedIn implements libkb.SessionReader interface.  For the
 // sake of kex2 provisionee, we are logged in because we have a
 // session token.

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -299,6 +299,18 @@ func (e *Kex2Provisionee) APIArgs() (token, csrf string) {
 	return string(e.sessionToken), string(e.csrfToken)
 }
 
+// IsLoggedIn implements libkb.SessionReader interface.  For the
+// sake of kex2 provisionee, we are logged in because we have a
+// session token.
+func (e *Kex2Provisionee) IsLoggedIn() bool {
+	return true
+}
+
+// Logout implements libkb.SessionReader interface.  Noop.
+func (e *Kex2Provisionee) Logout() error {
+	return nil
+}
+
 // Device returns the new device struct.
 func (e *Kex2Provisionee) Device() *libkb.Device {
 	return e.device

--- a/go/engine/login_state_test.go
+++ b/go/engine/login_state_test.go
@@ -95,14 +95,14 @@ func (m *GetSecretMock) GetSecret(arg keybase1.SecretEntryArg, _ *keybase1.Secre
 	return &keybase1.SecretEntryRes{Text: m.Passphrase, StoreSecret: storeSecret}, nil
 }
 
-func (m *GetSecretMock) GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.GetNewPassphraseRes, error) {
+func (m *GetSecretMock) GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.GetPassphraseRes, error) {
 	m.LastErr = errors.New("GetNewPassphrase unexpectedly called")
-	return keybase1.GetNewPassphraseRes{Passphrase: "invalid passphrase"}, m.LastErr
+	return keybase1.GetPassphraseRes{Passphrase: "invalid passphrase"}, m.LastErr
 }
 
-func (m *GetSecretMock) GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (string, error) {
+func (m *GetSecretMock) GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (keybase1.GetPassphraseRes, error) {
 	m.LastErr = errors.New("GetKeybasePassphrase unexpectedly called")
-	return "invalid passphrase", m.LastErr
+	return keybase1.GetPassphraseRes{Passphrase: "invalid passphrase"}, m.LastErr
 }
 
 func (m *GetSecretMock) GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) (string, error) {
@@ -180,43 +180,6 @@ func TestLoginNonexistent(t *testing.T) {
 	}
 }
 
-// Test that the login prompts for a passphrase for the pubkey first.
-func TestLoginWithPromptPubkey(t *testing.T) {
-	tc := SetupEngineTest(t, "login with prompt (pubkey)")
-	defer tc.Cleanup()
-
-	fu := CreateAndSignupFakeUser(tc, "lwpp")
-
-	Logout(tc)
-
-	mockGetSecret := &GetSecretMock{
-		Passphrase: fu.Passphrase,
-	}
-	if err := tc.G.LoginState().LoginWithPrompt("", nil, mockGetSecret, nil); err != nil {
-		t.Error(err)
-	}
-
-	mockGetSecret.CheckLastErr(t)
-
-	if !mockGetSecret.Called {
-		t.Errorf("secretUI.GetSecret() unexpectedly not called")
-	}
-
-	Logout(tc)
-
-	mockGetSecret.Called = false
-	if err := tc.G.LoginState().LoginWithPrompt(fu.Username, nil, mockGetSecret, nil); err != nil {
-		t.Error(err)
-	}
-
-	if !mockGetSecret.Called {
-		t.Errorf("secretUI.GetSecret() unexpectedly not called")
-	}
-
-	// The interaction with the loginUI is covered by
-	// TestLoginWithPromptPassphrase below.
-}
-
 type GetUsernameMock struct {
 	Username string
 	Called   bool
@@ -251,27 +214,28 @@ func (m *GetUsernameMock) CheckLastErr(t *testing.T) {
 }
 
 type GetKeybasePassphraseMock struct {
-	Passphrase string
-	Called     bool
-	LastErr    error
+	Passphrase  string
+	StoreSecret bool
+	Called      bool
+	LastErr     error
 }
 
 func (m *GetKeybasePassphraseMock) GetSecret(keybase1.SecretEntryArg, *keybase1.SecretEntryArg) (*keybase1.SecretEntryRes, error) {
 	return nil, errors.New("Fail pubkey login")
 }
 
-func (m *GetKeybasePassphraseMock) GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.GetNewPassphraseRes, error) {
+func (m *GetKeybasePassphraseMock) GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.GetPassphraseRes, error) {
 	m.LastErr = errors.New("GetNewPassphrase unexpectedly called")
-	return keybase1.GetNewPassphraseRes{Passphrase: "invalid passphrase"}, m.LastErr
+	return keybase1.GetPassphraseRes{Passphrase: "invalid passphrase"}, m.LastErr
 }
 
-func (m *GetKeybasePassphraseMock) GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (string, error) {
+func (m *GetKeybasePassphraseMock) GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (keybase1.GetPassphraseRes, error) {
 	if m.Called {
 		m.LastErr = errors.New("GetKeybasePassphrase unexpectedly called more than once")
-		return "invalid passphrase", m.LastErr
+		return keybase1.GetPassphraseRes{Passphrase: "invalid passphrase"}, m.LastErr
 	}
 	m.Called = true
-	return m.Passphrase, nil
+	return keybase1.GetPassphraseRes{Passphrase: m.Passphrase, StoreSecret: m.StoreSecret}, nil
 }
 
 func (m *GetKeybasePassphraseMock) GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) (string, error) {
@@ -399,18 +363,18 @@ func TestLoginWithStoredSecret(t *testing.T) {
 		t.Errorf("User %s unexpectedly has a stored secret", fu.Username)
 	}
 
-	mockGetSecret := &GetSecretMock{
+	mockGetPassphrase := &GetKeybasePassphraseMock{
 		Passphrase:  fu.Passphrase,
 		StoreSecret: true,
 	}
-	if err := tc.G.LoginState().LoginWithPrompt("", nil, mockGetSecret, nil); err != nil {
-		t.Error(err)
+	if err := tc.G.LoginState().LoginWithPrompt("", nil, mockGetPassphrase, nil); err != nil {
+		t.Fatal(err)
 	}
 
-	mockGetSecret.CheckLastErr(t)
+	mockGetPassphrase.CheckLastErr(t)
 
-	if !mockGetSecret.Called {
-		t.Errorf("secretUI.GetSecret() unexpectedly not called")
+	if !mockGetPassphrase.Called {
+		t.Errorf("secretUI.GetKeybasePassphrase() unexpectedly not called")
 	}
 
 	Logout(tc)

--- a/go/engine/passphrase_change_test.go
+++ b/go/engine/passphrase_change_test.go
@@ -181,8 +181,8 @@ func TestPassphraseChangeAfterPubkeyLogin(t *testing.T) {
 
 	secui := u.NewSecretUI()
 	u.LoginWithSecretUI(secui, tc.G)
-	if !secui.CalledGetSecret {
-		t.Errorf("get secret not called")
+	if !secui.CalledGetKBPassphrase {
+		t.Errorf("get keybase passphrase not called")
 	}
 
 	newPassphrase := "password1234"
@@ -279,6 +279,7 @@ func TestPassphraseChangeUnknownNoPSCache(t *testing.T) {
 
 	tc.G.LoginState().Account(func(a *libkb.Account) {
 		a.ClearStreamCache()
+		a.ClearCachedSecretKeys()
 	}, "clear stream cache")
 
 	newPassphrase := "password1234"

--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -175,7 +175,7 @@ func (s *SignupEngine) registerDevice(a libkb.LoginContext, ctx *Context, device
 		// StoreSecret) as the username may change during the
 		// signup process.
 		secretStore := libkb.NewSecretStore(s.me.GetNormalizedName())
-		secret, err := s.lks.GetSecret()
+		secret, err := s.lks.GetSecret(a)
 		if err != nil {
 			return err
 		}
@@ -185,6 +185,10 @@ func (s *SignupEngine) registerDevice(a libkb.LoginContext, ctx *Context, device
 			s.G().Log.Warning("StoreSecret error: %s", storeSecretErr)
 		}
 	}
+
+	// is there any reason *not* to do this?
+	ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType}, s.signingKey)
+	ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceEncryptionKeyType}, eng.EncryptionKey())
 
 	s.G().Log.Debug("registered new device: %s", s.G().Env.GetDeviceID())
 	s.G().Log.Debug("eldest kid: %s", s.me.GetEldestKID())

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -68,17 +68,17 @@ func TestSignupEngine(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mockGetSecret := &GetSecretMock{
+	mockGetPassphrase := &GetKeybasePassphraseMock{
 		Passphrase: fu.Passphrase,
 	}
-	if err = tc.G.LoginState().LoginWithPrompt(fu.Username, nil, mockGetSecret, nil); err != nil {
+	if err = tc.G.LoginState().LoginWithPrompt(fu.Username, nil, mockGetPassphrase, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	mockGetSecret.CheckLastErr(t)
+	mockGetPassphrase.CheckLastErr(t)
 
-	if !mockGetSecret.Called {
-		t.Errorf("secretUI.GetSecret() unexpectedly not called")
+	if !mockGetPassphrase.Called {
+		t.Errorf("secretUI.GetKeybasePassphrase() unexpectedly not called")
 	}
 
 	if err = AssertDeviceID(tc.G); err != nil {
@@ -180,7 +180,7 @@ func TestLocalKeySecurityStoreSecret(t *testing.T) {
 	arg.StoreSecret = true
 	s := SignupFakeUserWithArg(tc, fu, arg)
 
-	secret, err := s.lks.GetSecret()
+	secret, err := s.lks.GetSecret(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -376,11 +376,11 @@ func (a *InternalAPIEngine) checkSessionExpired(arg APIArg, status *jsonw.Wrappe
 	if !loggedIn {
 		return nil
 	}
-	a.G().Log.Debug("local session -> is logged in, remote -> not logged in.  logging user out:")
+	a.G().Log.Debug("local session -> is logged in, remote -> not logged in.  invalidating local session:")
 	if arg.SessionR != nil {
-		arg.SessionR.Logout()
+		arg.SessionR.Invalidate()
 	} else {
-		a.G().Logout()
+		a.G().LoginState().LocalSession(func(s *Session) { s.Invalidate() }, "api - checkSessionExpired")
 	}
 	return LoginRequiredError{Context: "your session has expired."}
 }

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -438,13 +438,13 @@ func (e LoginRequiredError) Error() string {
 type ReloginRequiredError struct{}
 
 func (e ReloginRequiredError) Error() string {
-	return "Login required due to an unexpected error since your previous login."
+	return "Login required due to an unexpected error since your previous login"
 }
 
 type DeviceRequiredError struct{}
 
 func (e DeviceRequiredError) Error() string {
-	return "Provisioned device required; login to provision this device"
+	return "Login required"
 }
 
 //=============================================================================

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -80,7 +80,7 @@ func (g *GlobalContext) Init() {
 	g.Env = NewEnv(nil, nil)
 	g.Service = false
 	g.createLoginState()
-	g.NotifyRouter = NewNotifyRouter()
+	g.NotifyRouter = NewNotifyRouter(g)
 }
 
 // requires lock on loginStateMu before calling

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -267,8 +267,8 @@ type ProveUI interface {
 
 type SecretUI interface {
 	GetSecret(pinentry keybase1.SecretEntryArg, terminal *keybase1.SecretEntryArg) (*keybase1.SecretEntryRes, error)
-	GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.GetNewPassphraseRes, error)
-	GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (string, error)
+	GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.GetPassphraseRes, error)
+	GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (keybase1.GetPassphraseRes, error)
 	GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) (string, error)
 }
 

--- a/go/libkb/lksec.go
+++ b/go/libkb/lksec.go
@@ -136,13 +136,13 @@ func (s *LKSec) Load(lctx LoginContext) (err error) {
 	return nil
 }
 
-func (s *LKSec) GetSecret() (secret []byte, err error) {
+func (s *LKSec) GetSecret(lctx LoginContext) (secret []byte, err error) {
 	s.G().Log.Debug("+ LKsec:GetSecret()")
 	defer func() {
 		s.G().Log.Debug("- LKSec::GetSecret() -> %s", ErrToOk(err))
 	}()
 
-	if err = s.Load(nil); err != nil {
+	if err = s.Load(lctx); err != nil {
 		return
 	}
 

--- a/go/libkb/lksec.go
+++ b/go/libkb/lksec.go
@@ -179,7 +179,7 @@ func (s *LKSec) Decrypt(lctx LoginContext, src []byte) (res []byte, gen Passphra
 	}()
 
 	if err = s.Load(lctx); err != nil {
-		return nil, 0, fmt.Errorf("lksec decrypt Load err: %s", err)
+		return nil, 0, err
 	}
 	var nonce [24]byte
 	copy(nonce[:], src[0:24])

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -153,9 +153,6 @@ func (s *LoginState) Logout() error {
 	err := s.loginHandle(func(a LoginContext) error {
 		return s.logout(a)
 	}, nil, "logout")
-	if err == nil {
-		s.G().NotifyRouter.HandleLogout()
-	}
 	return err
 }
 

--- a/go/libkb/session.go
+++ b/go/libkb/session.go
@@ -297,17 +297,14 @@ func (s *Session) check() error {
 // Invalidate marks the session as invalid and posts a logout
 // notification.
 func (s *Session) Invalidate() {
-	s.G().Log.Debug("invalidating session")
-	s.clearState()
-	s.G().NotifyRouter.HandleLogout()
-}
-
-func (s *Session) clearState() {
+	s.G().Log.Debug("+ invalidating session")
 	s.valid = false
 	s.mtime = time.Time{}
 	s.token = ""
 	s.csrf = ""
 	s.checked = false
+	s.G().NotifyRouter.HandleLogout()
+	s.G().Log.Debug("- session invalidated")
 }
 
 func (s *Session) HasSessionToken() bool {
@@ -325,9 +322,10 @@ func (s *Session) postLogout() error {
 		Endpoint:    "logout",
 		NeedSession: true,
 	})
-	if err == nil {
-		s.clearState()
-	}
+
+	// Invalidate even if we hit an error.
+	s.Invalidate()
+
 	return err
 }
 

--- a/go/libkb/session.go
+++ b/go/libkb/session.go
@@ -15,6 +15,8 @@ import (
 
 type SessionReader interface {
 	APIArgs() (token, csrf string)
+	IsLoggedIn() bool
+	Logout() error
 }
 
 type Session struct {

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -378,7 +378,7 @@ func (s *SKB) lksUnlock(lctx LoginContext, pps *PassphraseStream, secretStorer S
 
 	if secretStorer != nil {
 		var secret []byte
-		secret, err = lks.GetSecret()
+		secret, err = lks.GetSecret(lctx)
 		if err != nil {
 			unlocked = nil
 			return

--- a/go/libkb/skb_test.go
+++ b/go/libkb/skb_test.go
@@ -128,7 +128,7 @@ func TestBasicSecretStore(t *testing.T) {
 	defer tc.Cleanup()
 
 	lks := makeTestLKSec(t, G)
-	expectedSecret, err := lks.GetSecret()
+	expectedSecret, err := lks.GetSecret(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestCorruptSecretStore(t *testing.T) {
 	defer tc.Cleanup()
 
 	lks := makeTestLKSec(t, G)
-	expectedSecret, err := lks.GetSecret()
+	expectedSecret, err := lks.GetSecret(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -348,14 +348,14 @@ func (t *TestSecretUI) GetSecret(p keybase1.SecretEntryArg, terminal *keybase1.S
 	}, nil
 }
 
-func (t *TestSecretUI) GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.GetNewPassphraseRes, error) {
+func (t *TestSecretUI) GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.GetPassphraseRes, error) {
 	t.CalledGetNewPassphrase = true
-	return keybase1.GetNewPassphraseRes{Passphrase: t.Passphrase}, nil
+	return keybase1.GetPassphraseRes{Passphrase: t.Passphrase}, nil
 }
 
-func (t *TestSecretUI) GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (string, error) {
+func (t *TestSecretUI) GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (keybase1.GetPassphraseRes, error) {
 	t.CalledGetKBPassphrase = true
-	return t.Passphrase, nil
+	return keybase1.GetPassphraseRes{Passphrase: t.Passphrase}, nil
 }
 
 func (t *TestSecretUI) GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) (string, error) {

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -3829,7 +3829,7 @@ type SecretEntryRes struct {
 	StoreSecret bool   `codec:"storeSecret" json:"storeSecret"`
 }
 
-type GetNewPassphraseRes struct {
+type GetPassphraseRes struct {
 	Passphrase  string `codec:"passphrase" json:"passphrase"`
 	StoreSecret bool   `codec:"storeSecret" json:"storeSecret"`
 }
@@ -3862,8 +3862,8 @@ type GetPaperKeyPassphraseArg struct {
 
 type SecretUiInterface interface {
 	GetSecret(context.Context, GetSecretArg) (SecretEntryRes, error)
-	GetNewPassphrase(context.Context, GetNewPassphraseArg) (GetNewPassphraseRes, error)
-	GetKeybasePassphrase(context.Context, GetKeybasePassphraseArg) (string, error)
+	GetNewPassphrase(context.Context, GetNewPassphraseArg) (GetPassphraseRes, error)
+	GetKeybasePassphrase(context.Context, GetKeybasePassphraseArg) (GetPassphraseRes, error)
 	GetPaperKeyPassphrase(context.Context, GetPaperKeyPassphraseArg) (string, error)
 }
 
@@ -3948,12 +3948,12 @@ func (c SecretUiClient) GetSecret(ctx context.Context, __arg GetSecretArg) (res 
 	return
 }
 
-func (c SecretUiClient) GetNewPassphrase(ctx context.Context, __arg GetNewPassphraseArg) (res GetNewPassphraseRes, err error) {
+func (c SecretUiClient) GetNewPassphrase(ctx context.Context, __arg GetNewPassphraseArg) (res GetPassphraseRes, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.secretUi.getNewPassphrase", []interface{}{__arg}, &res)
 	return
 }
 
-func (c SecretUiClient) GetKeybasePassphrase(ctx context.Context, __arg GetKeybasePassphraseArg) (res string, err error) {
+func (c SecretUiClient) GetKeybasePassphrase(ctx context.Context, __arg GetKeybasePassphraseArg) (res GetPassphraseRes, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.secretUi.getKeybasePassphrase", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/handler.go
+++ b/go/service/handler.go
@@ -64,13 +64,13 @@ func (l *SecretUI) GetSecret(pinentry keybase1.SecretEntryArg, terminal *keybase
 }
 
 // GetNewPassphrase gets a new passphrase from pinentry
-func (l *SecretUI) GetNewPassphrase(arg keybase1.GetNewPassphraseArg) (keybase1.GetNewPassphraseRes, error) {
+func (l *SecretUI) GetNewPassphrase(arg keybase1.GetNewPassphraseArg) (keybase1.GetPassphraseRes, error) {
 	arg.SessionID = l.sessionID
 	return l.cli.GetNewPassphrase(context.TODO(), arg)
 }
 
 // GetKeybasePassphrase gets the current keybase passphrase from pinentry.
-func (l *SecretUI) GetKeybasePassphrase(arg keybase1.GetKeybasePassphraseArg) (string, error) {
+func (l *SecretUI) GetKeybasePassphrase(arg keybase1.GetKeybasePassphraseArg) (keybase1.GetPassphraseRes, error) {
 	arg.SessionID = l.sessionID
 	return l.cli.GetKeybasePassphrase(context.TODO(), arg)
 }

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -296,4 +296,14 @@ func TestSignupLogout(t *testing.T) {
 	if err := <-stopCh; err != nil {
 		t.Fatal(err)
 	}
+
+	// Check that we only get one notification, not two
+	select {
+	case _, ok := <-nh.logoutCh:
+		if ok {
+			t.Fatal("Received an extra logout notification!")
+		}
+	default:
+	}
+
 }

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -7,14 +7,15 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"testing"
+
 	"github.com/keybase/client/go/client"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
 	"github.com/keybase/client/go/service"
 	rpc "github.com/keybase/go-framed-msgpack-rpc"
 	context "golang.org/x/net/context"
-	"io"
-	"testing"
 )
 
 type signupInfo struct {
@@ -69,13 +70,13 @@ func (n *signupUI) GetGPGUI() libkb.GPGUI {
 	return client.NewGPGUI(n.GetTerminalUI(), false)
 }
 
-func (n *signupSecretUI) GetNewPassphrase(arg keybase1.GetNewPassphraseArg) (res keybase1.GetNewPassphraseRes, err error) {
+func (n *signupSecretUI) GetNewPassphrase(arg keybase1.GetNewPassphraseArg) (res keybase1.GetPassphraseRes, err error) {
 	res.Passphrase = n.info.passphrase
 	n.G().Log.Debug("| GetNewPassphrase: %v -> %v", arg, res)
 	return res, err
 }
 
-func (n *signupSecretUI) GetKeybasePassphrase(arg keybase1.GetKeybasePassphraseArg) (res string, err error) {
+func (n *signupSecretUI) GetKeybasePassphrase(arg keybase1.GetKeybasePassphraseArg) (res keybase1.GetPassphraseRes, err error) {
 	err = fmt.Errorf("GetKeybasePassphrase unimplemented")
 	return res, err
 }

--- a/protocol/avdl/secret_ui.avdl
+++ b/protocol/avdl/secret_ui.avdl
@@ -21,23 +21,19 @@ protocol secretUi {
 
   SecretEntryRes getSecret(int sessionID, SecretEntryArg pinentry, union { null, SecretEntryArg } terminal);
 
-  record GetNewPassphraseRes {
+  record GetPassphraseRes {
     string passphrase;
     boolean storeSecret;
   }
 
-  GetNewPassphraseRes getNewPassphrase(int sessionID,
+  GetPassphraseRes getNewPassphrase(int sessionID,
     string terminalPrompt,
     string pinentryDesc,
     string pinentryPrompt,
     string retryMessage,
     boolean useSecretStore);
 
-  /**
-    This is used only for passphrase login, so we don't need to use the secret
-    store.
-    */
-  string getKeybasePassphrase(int sessionID, string username, string retry);
+  GetPassphraseRes getKeybasePassphrase(int sessionID, string username, string retry);
 
   string getPaperKeyPassphrase(int sessionID, string username);
 }

--- a/protocol/json/secret_ui.json
+++ b/protocol/json/secret_ui.json
@@ -198,7 +198,7 @@
     } ]
   }, {
     "type" : "record",
-    "name" : "GetNewPassphraseRes",
+    "name" : "GetPassphraseRes",
     "fields" : [ {
       "name" : "passphrase",
       "type" : "string"
@@ -241,10 +241,9 @@
         "name" : "useSecretStore",
         "type" : "boolean"
       } ],
-      "response" : "GetNewPassphraseRes"
+      "response" : "GetPassphraseRes"
     },
     "getKeybasePassphrase" : {
-      "doc" : "This is used only for passphrase login, so we don't need to use the secret\n    store.",
       "request" : [ {
         "name" : "sessionID",
         "type" : "int"
@@ -255,7 +254,7 @@
         "name" : "retry",
         "type" : "string"
       } ],
-      "response" : "string"
+      "response" : "GetPassphraseRes"
     },
     "getPaperKeyPassphrase" : {
       "request" : [ {

--- a/protocol/objc/KBRPC.h
+++ b/protocol/objc/KBRPC.h
@@ -487,7 +487,7 @@ typedef NS_ENUM (NSInteger, KBRDeviceType) {
 @property BOOL storeSecret;
 @end
 
-@interface KBRGetNewPassphraseRes : KBRObject
+@interface KBRGetPassphraseRes : KBRObject
 @property NSString *passphrase;
 @property BOOL storeSecret;
 @end
@@ -1777,17 +1777,13 @@ typedef NS_ENUM (NSInteger, KBRPromptDefault) {
 
 - (void)getSecretWithPinentry:(KBRSecretEntryArg *)pinentry terminal:(KBRSecretEntryArg *)terminal completion:(void (^)(NSError *error, KBRSecretEntryRes *secretEntryRes))completion;
 
-- (void)getNewPassphrase:(KBRGetNewPassphraseRequestParams *)params completion:(void (^)(NSError *error, KBRGetNewPassphraseRes *getNewPassphraseRes))completion;
+- (void)getNewPassphrase:(KBRGetNewPassphraseRequestParams *)params completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion;
 
-- (void)getNewPassphraseWithTerminalPrompt:(NSString *)terminalPrompt pinentryDesc:(NSString *)pinentryDesc pinentryPrompt:(NSString *)pinentryPrompt retryMessage:(NSString *)retryMessage useSecretStore:(BOOL)useSecretStore completion:(void (^)(NSError *error, KBRGetNewPassphraseRes *getNewPassphraseRes))completion;
+- (void)getNewPassphraseWithTerminalPrompt:(NSString *)terminalPrompt pinentryDesc:(NSString *)pinentryDesc pinentryPrompt:(NSString *)pinentryPrompt retryMessage:(NSString *)retryMessage useSecretStore:(BOOL)useSecretStore completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion;
 
-/*!
- This is used only for passphrase login, so we don't need to use the secret
- store.
- */
-- (void)getKeybasePassphrase:(KBRGetKeybasePassphraseRequestParams *)params completion:(void (^)(NSError *error, NSString *str))completion;
+- (void)getKeybasePassphrase:(KBRGetKeybasePassphraseRequestParams *)params completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion;
 
-- (void)getKeybasePassphraseWithUsername:(NSString *)username retry:(NSString *)retry completion:(void (^)(NSError *error, NSString *str))completion;
+- (void)getKeybasePassphraseWithUsername:(NSString *)username retry:(NSString *)retry completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion;
 
 - (void)getPaperKeyPassphrase:(KBRGetPaperKeyPassphraseRequestParams *)params completion:(void (^)(NSError *error, NSString *str))completion;
 

--- a/protocol/objc/KBRPC.m
+++ b/protocol/objc/KBRPC.m
@@ -1691,50 +1691,50 @@
   }];
 }
 
-- (void)getNewPassphrase:(KBRGetNewPassphraseRequestParams *)params completion:(void (^)(NSError *error, KBRGetNewPassphraseRes *getNewPassphraseRes))completion {
+- (void)getNewPassphrase:(KBRGetNewPassphraseRequestParams *)params completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion {
   NSDictionary *rparams = @{@"terminalPrompt": KBRValue(params.terminalPrompt), @"pinentryDesc": KBRValue(params.pinentryDesc), @"pinentryPrompt": KBRValue(params.pinentryPrompt), @"retryMessage": KBRValue(params.retryMessage), @"useSecretStore": @(params.useSecretStore)};
   [self.client sendRequestWithMethod:@"keybase.1.secretUi.getNewPassphrase" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
     if (error) {
       completion(error, nil);
       return;
     }
-    KBRGetNewPassphraseRes *result = retval ? [MTLJSONAdapter modelOfClass:KBRGetNewPassphraseRes.class fromJSONDictionary:retval error:&error] : nil;
+    KBRGetPassphraseRes *result = retval ? [MTLJSONAdapter modelOfClass:KBRGetPassphraseRes.class fromJSONDictionary:retval error:&error] : nil;
     completion(error, result);
   }];
 }
 
-- (void)getNewPassphraseWithTerminalPrompt:(NSString *)terminalPrompt pinentryDesc:(NSString *)pinentryDesc pinentryPrompt:(NSString *)pinentryPrompt retryMessage:(NSString *)retryMessage useSecretStore:(BOOL)useSecretStore completion:(void (^)(NSError *error, KBRGetNewPassphraseRes *getNewPassphraseRes))completion {
+- (void)getNewPassphraseWithTerminalPrompt:(NSString *)terminalPrompt pinentryDesc:(NSString *)pinentryDesc pinentryPrompt:(NSString *)pinentryPrompt retryMessage:(NSString *)retryMessage useSecretStore:(BOOL)useSecretStore completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion {
   NSDictionary *rparams = @{@"terminalPrompt": KBRValue(terminalPrompt), @"pinentryDesc": KBRValue(pinentryDesc), @"pinentryPrompt": KBRValue(pinentryPrompt), @"retryMessage": KBRValue(retryMessage), @"useSecretStore": @(useSecretStore)};
   [self.client sendRequestWithMethod:@"keybase.1.secretUi.getNewPassphrase" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
     if (error) {
       completion(error, nil);
       return;
     }
-    KBRGetNewPassphraseRes *result = retval ? [MTLJSONAdapter modelOfClass:KBRGetNewPassphraseRes.class fromJSONDictionary:retval error:&error] : nil;
+    KBRGetPassphraseRes *result = retval ? [MTLJSONAdapter modelOfClass:KBRGetPassphraseRes.class fromJSONDictionary:retval error:&error] : nil;
     completion(error, result);
   }];
 }
 
-- (void)getKeybasePassphrase:(KBRGetKeybasePassphraseRequestParams *)params completion:(void (^)(NSError *error, NSString *str))completion {
+- (void)getKeybasePassphrase:(KBRGetKeybasePassphraseRequestParams *)params completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion {
   NSDictionary *rparams = @{@"username": KBRValue(params.username), @"retry": KBRValue(params.retry)};
   [self.client sendRequestWithMethod:@"keybase.1.secretUi.getKeybasePassphrase" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
     if (error) {
       completion(error, nil);
       return;
     }
-    NSString *result = retval ? [MTLJSONAdapter modelOfClass:NSString.class fromJSONDictionary:retval error:&error] : nil;
+    KBRGetPassphraseRes *result = retval ? [MTLJSONAdapter modelOfClass:KBRGetPassphraseRes.class fromJSONDictionary:retval error:&error] : nil;
     completion(error, result);
   }];
 }
 
-- (void)getKeybasePassphraseWithUsername:(NSString *)username retry:(NSString *)retry completion:(void (^)(NSError *error, NSString *str))completion {
+- (void)getKeybasePassphraseWithUsername:(NSString *)username retry:(NSString *)retry completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion {
   NSDictionary *rparams = @{@"username": KBRValue(username), @"retry": KBRValue(retry)};
   [self.client sendRequestWithMethod:@"keybase.1.secretUi.getKeybasePassphrase" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
     if (error) {
       completion(error, nil);
       return;
     }
-    NSString *result = retval ? [MTLJSONAdapter modelOfClass:NSString.class fromJSONDictionary:retval error:&error] : nil;
+    KBRGetPassphraseRes *result = retval ? [MTLJSONAdapter modelOfClass:KBRGetPassphraseRes.class fromJSONDictionary:retval error:&error] : nil;
     completion(error, result);
   }];
 }
@@ -4801,7 +4801,7 @@
 @implementation KBRSecretEntryRes
 @end
 
-@implementation KBRGetNewPassphraseRes
+@implementation KBRGetPassphraseRes
 @end
 
 @implementation KBRSession


### PR DESCRIPTION
Changing passphrase (standard update) via CLI was broken:  subsequent pubkey login attempts failed and left user in weird state.

This was fixed by not allowing secret keys to be unlocked via passphrase during pubkey login.  You can only do pubkey login if you have a secret store (or happen to have your secret keys cached, which is unlikely since they are nil after logout).

Also, changing the passphrase on the website invalidates any existing sessions.  So command line client could think it is logged in, but server disagrees.  Added a check to api.go to handle this situation.  When it occurs, it will log the user out and tell them their session has expired.

r? @maxtaco 