### PR TITLE
stop trying to create a prompter in `keybase signup --batch`

### DIFF
--- a/go/client/cmd_signup.go
+++ b/go/client/cmd_signup.go
@@ -110,7 +110,6 @@ func (s *CmdSignup) ParseArgv(ctx *cli.Context) error {
 		}
 
 		s.passphrase = s.defaultPassphrase
-		s.prompter = NewPrompter(s.fields.ToList(), s.G().UI.GetTerminalUI())
 		s.doPrompt = false
 	} else {
 		s.doPrompt = true


### PR DESCRIPTION
Because this is done as part of ParseArgv(), it happens before the
global InitUI() call is made in mainInner(). That means that UI is nil
and GetTerminalUI() throws.

As far as I can tell though, we don't need this line at all. Setting
doPrompt=false prevents us from ever using it.

@patrickxb @maxtaco 