### PR TITLE
Add simple desktop notification for logout

### DIFF
--- a/desktop/renderer/index.desktop.js
+++ b/desktop/renderer/index.desktop.js
@@ -9,7 +9,7 @@ import configureStore from '../../react-native/react/store/configure-store'
 import Nav from '../../react-native/react/nav'
 import { DevTools, DebugPanel, LogMonitor } from 'redux-devtools/lib/react'
 import injectTapEventPlugin from 'react-tap-event-plugin'
-import { enableNotifications, bindNotifications, unbindNotifications} from '../../react-native/react/native/notifications'
+import { enableNotifications, bindNotifications } from '../../react-native/react/native/notifications'
 const store = configureStore()
 
 class Keybase extends BaseComponent {
@@ -21,18 +21,18 @@ class Keybase extends BaseComponent {
 
     // Bind Notifications
     enableNotifications()
-    bindNotifications()
+    this.unbindNotifications = bindNotifications()
   }
 
   componentWillUnmount () {
-    unbindNotifications()
+    this.unbindNotifications()
   }
 
   render () {
     return (
       <div>
         <DebugPanel top right bottom>
-          <DevTools store={store} monitor={LogMonitor} visibleOnLoad={true} />
+          <DevTools store={store} monitor={LogMonitor} visibleOnLoad/>
         </DebugPanel>
         <Provider store={store}>
           {() => {

--- a/desktop/renderer/index.desktop.js
+++ b/desktop/renderer/index.desktop.js
@@ -9,6 +9,7 @@ import configureStore from '../../react-native/react/store/configure-store'
 import Nav from '../../react-native/react/nav'
 import { DevTools, DebugPanel, LogMonitor } from 'redux-devtools/lib/react'
 import injectTapEventPlugin from 'react-tap-event-plugin'
+import { enableNotifications, bindNotifications, unbindNotifications} from '../../react-native/react/native/notifications'
 const store = configureStore()
 
 class Keybase extends BaseComponent {
@@ -17,6 +18,14 @@ class Keybase extends BaseComponent {
 
     // Used by material-ui widgets.
     injectTapEventPlugin()
+
+    // Bind Notifications
+    enableNotifications()
+    bindNotifications()
+  }
+
+  componentWillUnmount () {
+    unbindNotifications()
   }
 
   render () {

--- a/react-native/react/engine/index.js
+++ b/react-native/react/engine/index.js
@@ -79,7 +79,7 @@ class Engine {
   }
 
   listenGeneralIncomingRpc (method, listener) {
-    if (this.generalListeners[method] == null) {
+    if (!this.generalListeners[method]) {
       this.generalListeners[method] = []
     }
     this.generalListeners[method].push(listener)
@@ -150,7 +150,7 @@ class Engine {
       }
 
       callMap[method](param, wrappedResponse)
-    } else if (sessionID == null && this.generalListeners[method]) {
+    } else if (!sessionID && this.generalListeners[method]) {
       this._generalIncomingRpc(method, param, response)
     } else {
       console.log(`Unknown incoming rpc: ${sessionID} ${method}`)

--- a/react-native/react/engine/index.js
+++ b/react-native/react/engine/index.js
@@ -51,11 +51,14 @@ class Engine {
   }
 
   listenOnConnect (f) {
+    // The transport is already connected, so let's call this function right away
     if (!this.rpcClient.transport.needsConnect) {
       f()
-    } else {
-      this.onConnectFns.push(f)
     }
+
+    // Regardless if we were connected or not, we'll add this to the callback fns
+    // that should be called when we connect.
+    this.onConnectFns.push(f)
   }
 
   getSessionID () {

--- a/react-native/react/native/notifications.desktop.js
+++ b/react-native/react/native/notifications.desktop.js
@@ -1,0 +1,35 @@
+'use strict'
+/* @flow */
+
+import engine from '../engine'
+
+const param = {
+  channels: {
+    session: true,
+    users: true
+  }
+}
+
+export function enableNotifications () {
+  console.log('setting up notification')
+  engine.listenOnConnect(() => {
+    engine.rpc('notifyCtl.toggleNotifications', param, {}, (error, response) => {
+      if (error != null) {
+        console.error('error in toggling notifications: ', error)
+      }
+      console.log('Enabled Notifications')
+    })
+  })
+}
+
+export function bindNotifications () {
+  engine.listenGeneralIncomingRpc('keybase.1.NotifySession.loggedOut', logoutNotification)
+}
+
+export function unbindNotifications () {
+  engine.unlistenGeneralIncomingRpc('keybase.1.NotifySession.loggedOut', logoutNotification)
+}
+
+function logoutNotification (param) {
+  new Notification('Logged Out')
+}

--- a/react-native/react/native/notifications.desktop.js
+++ b/react-native/react/native/notifications.desktop.js
@@ -3,33 +3,39 @@
 
 import engine from '../engine'
 
-const param = {
-  channels: {
-    session: true,
-    users: true
-  }
-}
-
 export function enableNotifications () {
   console.log('setting up notification')
+
+  const param = {
+    channels: {
+      session: true,
+      users: true
+    }
+  }
+
   engine.listenOnConnect(() => {
     engine.rpc('notifyCtl.toggleNotifications', param, {}, (error, response) => {
       if (error != null) {
         console.error('error in toggling notifications: ', error)
+      } else {
+        console.log('Enabled Notifications')
       }
-      console.log('Enabled Notifications')
     })
   })
 }
 
-export function bindNotifications () {
-  engine.listenGeneralIncomingRpc('keybase.1.NotifySession.loggedOut', logoutNotification)
+const listeners = {
+  'keybase.1.NotifySession.loggedOut': logoutNotification
 }
 
-export function unbindNotifications () {
-  engine.unlistenGeneralIncomingRpc('keybase.1.NotifySession.loggedOut', logoutNotification)
+// Returns function that should be called to unbind listeners
+export function bindNotifications () {
+  Object.keys(listeners).forEach(k => engine.listenGeneralIncomingRpc(k, listeners[k]))
+  return () => {
+    Object.keys(listeners).forEach(k => engine.unlistenGeneralIncomingRpc(k, listeners[k]))
+  }
 }
 
 function logoutNotification (param) {
-  new Notification('Logged Out')
+  new Notification('Logged Out') // eslint-disable-line
 }


### PR DESCRIPTION
### Context

We'll want desktop notifications on the app. It'll work through the desktop app and be sent from the service.

@chrisnojima and I talked yesterday and think it might make more sense to handle all the notifications when we build the shim app. However we'd still need to figure out the basics of notifications. This does just that.

### Changes to Engine
This is the first rpc request where the service can, at any point, send a message to the client. I've tentatively named it `generalIncomingRpc` (but we can change it). 

Added: 
* bind to a `generalIncomingRpc` with a method name.
* Unbind ^

We'll also want the ability to enable notifications as soon as we connect to the transport, so now there is a new `engine.listenOnConnect` that will let call a callback when the engine has connected.

### Notification type

I figured the easiest thing we could do is reuse chormiums existing [desktop notification](https://developer.mozilla.org/en-US/docs/Web/API/notification). It uses the native notification on mac and works the same on linux/windows. I tested it with (awesomewm and kde) on ~~windows~~ linux.

@keybase/react-hackers 
