### PR TITLE
Desktop - Server RPC (for stuff like delegate identify ui)

### DIFF
--- a/react-native/.flowconfig
+++ b/react-native/.flowconfig
@@ -14,20 +14,17 @@
 .*/react/local-debug.js
 
 # Ignoring these for now
-.*desktop.js
 .*/desktop/.*
 .*/node_modules/redux-devtools/.*
 .*/node_modules/react-redux/node_modules/invariant/.*
 .*/react/packager/.*
-.*/react/native/.*
 .*/react/purepack/.*
 .*/react/framed-msgpack-rpc/.*
 .*/react/iced-error/.*
 .*/react/debug/.*
-.*/react/engine/.*
 .*/react/tracker/.*
 
-# Ignore .*-render.js files
+# Ignore .*-render.platform.js files
 .*-render\.android\.js
 .*-render\.ios\.js
 .*-render\.mobile\.js

--- a/react-native/.flowconfig
+++ b/react-native/.flowconfig
@@ -74,6 +74,8 @@ munge_underscores=true
 module.name_mapper='^image![a-zA-Z0-9$_-]+$' -> 'GlobalImageStub'
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.png$' -> 'RelativeImageStub'
 module.name_mapper= '\.\/serialize' -> './serialize.mobile.js'
+module.name_mapper= '\.\/.*-render' -> 'View'
+module.name_mapper= '.*constants\/platform' -> 'platform-constants'
 
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe

--- a/react-native/.flowconfig
+++ b/react-native/.flowconfig
@@ -25,6 +25,13 @@
 .*/react/iced-error/.*
 .*/react/debug/.*
 .*/react/engine/.*
+.*/react/tracker/.*
+
+# Ignore .*-render.js files
+.*-render\.android\.js
+.*-render\.ios\.js
+.*-render\.mobile\.js
+.*-render\.desktop\.js
 
 # Some react native errors in flow type
 .*/node_modules/react-native/Libraries/Animated/src/Interpolation.js

--- a/react-native/react/engine/call-map-middleware.js
+++ b/react-native/react/engine/call-map-middleware.js
@@ -1,0 +1,41 @@
+
+export type Endpoint = (params: any) => (Promise<any> | any)
+
+export type NestedCallMap = { [key: string]: (NestedCallMap | Endpoint) }
+export type CallMap = { [key: string]: Endpoint }
+
+export function flattenCallMap (endpointMap: NestedCallMap): CallMap {
+  return flattenNextLevel('', '', endpointMap)
+}
+
+function flattenNextLevel (separator: string, key: string, value: any): CallMap {
+  if (typeof value === 'object') {
+    const submap = value
+    return Object.keys(value).reduce(
+      (memo, subkey) => Object.assign(memo, flattenNextLevel('.', key + separator + subkey, submap[subkey])),
+        {}
+    )
+  } else {
+    // $FlowIssue Computed property keys not supported
+    return {[key]: value}
+  }
+}
+
+export function promisifyResponses (endpoints: CallMap): CallMap {
+  return Object.keys(endpoints).reduce(
+    (memo, k) => {
+      memo[k] = (param, response) => {
+        const rMaybePromise = endpoints[k](param)
+
+        // Did the endpoint return a promise or not?
+        if (!!rMaybePromise && rMaybePromise.constructor === Promise) {
+          rMaybePromise.then((v) => response.result(v))
+        } else {
+          response.result(rMaybePromise)
+        }
+      }
+      return memo
+    },
+    {}
+  )
+}

--- a/react-native/react/engine/server.js
+++ b/react-native/react/engine/server.js
@@ -1,38 +1,75 @@
 'use strict'
 /* @flow */
 
-type Endpoint = (params: any) => (Promise<any> | any)
+/**
+ * Server abstraction for incoming RPC's
+ *
+ * The service will make call to us, and we'll want to be able to handle them.
+ * Here is the general dance:
+ *
+ * +---------------------------------------------+
+ * | Key:                                        |
+ * |  <- : incoming rpc                          |
+ * |    ->: reply to incoming rpc (note indent)  |
+ * +---------------------------------------------+
+ *
+ *
+ * <- Some `start` message telling us to start a session
+ *    -> reply with the our session id for the session
+ * ...
+ * <-     various messages going back in forth (i.e. updates on tracking status)
+ *    ->  reply back
+ * ...
+ *
+ * <- Some `end` message telling us the service is done with this session
+ *    -> reply to acknowledge
+ *
+ *
+ * ## The Server Abstraction
+ * This class provides an abstraction to the rpc messaging system above.
+ *
+ *
+ * You specify what the start and end message is.
+ * You specify a function that returns a map of functions (aka endpoints) to be called during the session
+ *
+ * 1. The server will create the session when it gets the `start` message, and call your endpointMapFn function
+ * with the params it got from the service from the `start` message
+ *
+ * 2. It will map incoming calls during the session to functions defined in the endpointMapFn
+ *
+ * 3. When it receives the `end` message it will clean up the session call map.
+ *
+ */
 
-type ServerEndpoints = { [key: string]: (ServerEndpoints | Endpoint) }
-type FlatServerEndpoints = { [key: string]: Endpoint }
+import type { CallMap } from './call-map-middleware'
 
 type Engine = any
 
 export default class Server {
   startMethodName: string;
   engine: Engine;
-  endpointsFn: (params: any, end: () => void) => FlatServerEndpoints;
+  endpointsFn: (params: any, end: () => void) => CallMap;
 
-  constructor (engine: Engine, startMethodName: string, endMethodName: string, endpointMapFn: (params: any) => ServerEndpoints) {
+  constructor (engine: Engine, startMethodName: string, endMethodName: string, endpointMapFn: (params: any) => CallMap) {
     this.engine = engine
     this.startMethodName = startMethodName
 
     this.endpointsFn = (params, end) => {
-      const endpoints = this.parseEndpoint(endpointMapFn(params))
+      const endpoints = endpointMapFn(params)
 
       // End the server when endMethodName is called
       if (endMethodName) {
         const originalEndMethod = endpoints[endMethodName]
-        endpoints[endMethodName] = (params) => {
+        endpoints[endMethodName] = (params, response) => {
           end()
           // If there was something that is assigned to this endpoint we'll call it
           if (originalEndMethod) {
-            return originalEndMethod(params)
+            return originalEndMethod(params, response)
           }
         }
       }
 
-      return this.promisifyResponses(endpoints)
+      return endpoints
     }
   }
 
@@ -40,43 +77,12 @@ export default class Server {
     this.engine.listenServerInit(this.startMethodName, (param, cbs) => this.init(param, cbs))
   }
 
-  init (params: any, {start, end}: {start: (endpoints: FlatServerEndpoints) => void, end: () => void}) {
+  init (params: any, {start, end}: {start: (endpoints: CallMap) => void, end: () => void}) {
     start(this.endpointsFn(params, end))
   }
+}
 
-  parseEndpoint (endpointMap: ServerEndpoints): FlatServerEndpoints {
-    return this.parseNextLevel('', '', endpointMap)
-  }
-
-  parseNextLevel (separator: string, key: string, value: any): FlatServerEndpoints {
-    if (typeof value === 'object') {
-      const submap = value
-      return Object.keys(value).reduce(
-        (memo, subkey) => Object.assign(memo, this.parseNextLevel('.', key + separator + subkey, submap[subkey])),
-        {}
-      )
-    } else {
-      // $FlowIssue Computed property keys not supported
-      return {[key]: value}
-    }
-  }
-
-  promisifyResponses (endpoints: FlatServerEndpoints): FlatServerEndpoints {
-    return Object.keys(endpoints).reduce(
-      (memo, k) => {
-        memo[k] = (param, response) => {
-          const rMaybePromise = endpoints[k](param)
-
-          // Did the endpoint return a promise or not?
-          if (!!rMaybePromise && rMaybePromise.constructor === Promise) {
-            rMaybePromise.then((v) => response.result(v))
-          } else {
-            response.result(rMaybePromise)
-          }
-        }
-        return memo
-      },
-      {}
-    )
-  }
+export function createServer (engine: Engine, startMethodName: string, endMethodName: string, endpointMapFn: (params: any) => CallMap): void {
+  const s = new Server(engine, startMethodName, endMethodName, endpointMapFn)
+  s.listen()
 }

--- a/react-native/react/engine/server.js
+++ b/react-native/react/engine/server.js
@@ -1,0 +1,70 @@
+'use strict'
+/* @flow */
+
+export default class Server {
+  constructor (engine, startMethodName, endMethodName, endpointMapFn) {
+    this.engine = engine
+    this.startMethodName = startMethodName
+
+    this.endpointsFn = (params, end) => {
+      const endpoints = this.parseEndpoint(endpointMapFn(params))
+
+      // End the server when endMethodName is called
+      if (endMethodName) {
+        const originalEndMethod = endpoints[endMethodName]
+        endpoints[endMethodName] = (params) => {
+          end()
+          // If there was something that is assigned to this endpoint we'll call it
+          if (originalEndMethod) {
+            return originalEndMethod(params)
+          }
+        }
+      }
+
+      return this.promisifyResponses(endpoints)
+    }
+  }
+
+  listen () {
+    this.engine.listenServerInit(this.startMethodName, (param, cbs) => this.init(param, cbs))
+  }
+
+  init (params, {start, end}) {
+    start(this.endpointsFn(params, end))
+  }
+
+  parseEndpoint (endpointMap) {
+    return this.parseNextLevel('', '', endpointMap)
+  }
+
+  parseNextLevel (separator, key, value) {
+    if (typeof value === 'object') {
+      const submap = value
+      return Object.keys(value).reduce(
+        (memo, subkey) => Object.assign(memo, this.parseNextLevel('.', key + separator + subkey, submap[subkey])),
+        {}
+      )
+    } else {
+      return {[key]: value}
+    }
+  }
+
+  promisifyResponses (endpoints) {
+    return Object.keys(endpoints).reduce(
+      (memo, k) => {
+        memo[k] = (param, response) => {
+          const rMaybePromise = endpoints[k](param)
+
+          // Did the endpoint return a promise or not?
+          if (!!rMaybePromise && rMaybePromise.constructor === Promise) {
+            rMaybePromise.then((v) => response.result(v))
+          } else {
+            response.result(rMaybePromise)
+          }
+        }
+        return memo
+      },
+      {}
+    )
+  }
+}

--- a/react-native/react/flow-interface.js
+++ b/react-native/react/flow-interface.js
@@ -6,6 +6,10 @@ declare module 'Interpolation' {
   declare var exports: any;
 }
 
+declare module 'platform-constants' {
+  declare var exports: {isDev: boolean};
+}
+
 // Algebraic data types
 // This is a bit hacky, but it gives you strong gaurantees.
 

--- a/react-native/react/flow-interface.js
+++ b/react-native/react/flow-interface.js
@@ -10,6 +10,13 @@ declare module 'platform-constants' {
   declare var exports: {isDev: boolean};
 }
 
+declare module 'redux-devtools' {
+  declare var exports: any;
+}
+
+declare class Notification {
+}
+
 // Algebraic data types
 // This is a bit hacky, but it gives you strong gaurantees.
 

--- a/react-native/react/native/notifications.desktop.js
+++ b/react-native/react/native/notifications.desktop.js
@@ -2,7 +2,8 @@
 /* @flow */
 
 import engine from '../engine'
-import Server from '../engine/server'
+import { flattenCallMap, promisifyResponses } from '../engine/call-map-middleware'
+import { createServer } from '../engine/server'
 
 export function enableNotifications () {
   console.log('setting up notification')
@@ -69,14 +70,12 @@ export function enableNotifications () {
       }
     }
 
-    const identifyUIServer = new Server(
+    createServer(
       engine,
       'keybase.1.identifyUi.delegateIdentifyUI',
       'keybase.1.identifyUi.finish',
-      (params) => { return { keybase: { '1': { identifyUi } } } }
+      params => promisifyResponses(flattenCallMap({ keybase: { '1': { identifyUi } } }))
     )
-
-    identifyUIServer.listen()
   })
 }
 

--- a/react-native/react/native/notifications.desktop.js
+++ b/react-native/react/native/notifications.desktop.js
@@ -73,7 +73,7 @@ export function enableNotifications () {
       engine,
       'keybase.1.identifyUi.delegateIdentifyUI',
       'keybase.1.identifyUi.finish',
-      (params) => { return { keybase: { 1: { identifyUi } } } }
+      (params) => { return { keybase: { '1': { identifyUi } } } }
     )
 
     identifyUIServer.listen()
@@ -85,7 +85,7 @@ const listeners = {
 }
 
 // Returns function that should be called to unbind listeners
-export function bindNotifications () {
+export function bindNotifications (): () => void {
   Object.keys(listeners).forEach(k => engine.listenGeneralIncomingRpc(k, listeners[k]))
   return () => {
     Object.keys(listeners).forEach(k => engine.unlistenGeneralIncomingRpc(k, listeners[k]))

--- a/react-native/react/native/notifications.desktop.js
+++ b/react-native/react/native/notifications.desktop.js
@@ -2,6 +2,7 @@
 /* @flow */
 
 import engine from '../engine'
+import Server from '../engine/server'
 
 export function enableNotifications () {
   console.log('setting up notification')
@@ -21,6 +22,61 @@ export function enableNotifications () {
         console.log('Enabled Notifications')
       }
     })
+
+    // TODO move this somewhere else
+    engine.rpc('delegateUiCtl.registerIdentifyUI', {}, {}, (error, response) => {
+      if (error != null) {
+        console.error('error in registering identify ui: ', error)
+      } else {
+        console.log('Registered identify ui')
+      }
+    })
+
+    type IdentifyKey = any
+
+    const identifyUi = {
+      start: (params: {sessionID: number, username: string}) => {
+        console.log('starting identify ui server instance')
+      },
+      displayKey: (params: {sessionID: number, key: IdentifyKey}) => {
+        console.log('displaying key', params)
+      },
+      reportLastTrack: (params: {sessionID: number, track: any}) => {
+        console.log('Report last track', params)
+      },
+      launchNetworkChecks: (params: {sessionID: number, identity: any, user: any}) => {
+        console.log('network checks', params)
+      },
+      displayTrackStatement: (params: {sessionID: number, stmt: string}) => {
+        console.log('display track statements', params)
+      },
+
+      finishWebProofCheck: (params: {sessionID: number, rp: any, lcr: any}) => {
+        console.log('finish web proof', params)
+      },
+      finishSocialProofCheck: (params: {sessionID: number, rp: any, lcr: any}) => {
+        console.log('finish social proof', params)
+      },
+      displayCryptocurrency: (params: {sessionID: number, c: any}) => {
+        console.log('finish displayCryptocurrency', params)
+      },
+      confirm: (params: {sessionID: number, outcome: any}): bool => {
+        console.log('confirm', params)
+        return true
+      },
+      finish: (params: {sessionID: number}) => {
+        console.log('finish', params)
+      }
+    }
+
+    const identifyUIServer = new Server(
+      engine,
+      'keybase.1.identifyUi.delegateIdentifyUI',
+      'keybase.1.identifyUi.finish',
+      (params) => { return { keybase: { 1: { identifyUi } } } }
+    )
+
+    identifyUIServer.listen()
   })
 }
 

--- a/react-native/react/store/configure-store.desktop.js
+++ b/react-native/react/store/configure-store.desktop.js
@@ -14,6 +14,6 @@ const createStoreWithMiddleware = compose(
   devTools()
 )(createStore)
 
-export default function configureStore (initialState) {
+export default function configureStore (initialState: ?any) {
   return createStoreWithMiddleware(rootReducer, initialState)
 }

--- a/react-native/react/tabs/chat.js
+++ b/react-native/react/tabs/chat.js
@@ -1,5 +1,4 @@
 'use strict'
-/* @flow */
 
 import React, { Component } from '../base-react'
 import ChatRender from './chat-render'

--- a/react-native/react/tabs/devices/index.js
+++ b/react-native/react/tabs/devices/index.js
@@ -1,5 +1,4 @@
 'use strict'
-/* @flow */
 
 import React, { Component } from '../../base-react'
 

--- a/react-native/react/tabs/folders.js
+++ b/react-native/react/tabs/folders.js
@@ -1,5 +1,4 @@
 'use strict'
-/* @flow */
 
 import React, { Component } from '../base-react'
 import FoldersRender from './folders-render'

--- a/react-native/react/tabs/no-tab.js
+++ b/react-native/react/tabs/no-tab.js
@@ -1,5 +1,4 @@
 'use strict'
-/* @flow */
 
 import React, { Component } from '../base-react'
 import NoTabRender from './no-tab-render'


### PR DESCRIPTION
## Context
So far the desktop has been the client and `keybased` has been the server. With the new ability to delegate the identify ui, `keybased` will be the client and desktop will be the server. So we need some new code that will make this pattern simple. That's what this PR introduces. Along with a demo of the identify ui action being printed out in the console

This is a continuation of @maxtaco's ideas on this: https://github.com/keybase/client/pull/1304.

The changes where inspired by wanting to avoid having to manually deal with the start/end functions to call and wanting to be able to simple return values or promises of values from the endpoints.

You should take a look at `react-native/react/native/notifications.desktop.js` first to see how it works. Then you can look at the engine stuff to see how it's implemented.

## Server RPC

A call is made from `keybased` to the desktop to start the `identifyUI` this is called: `'keybase.1.identifyUi.delegateIdentifyUI'`.

The client replies with a sessionId to use for the session. It creates a new endpoint map using the `endpointMapFn` that's passed in as the 4th argument. The state of the session is within that scope, so if you need extra state that should be closed over.

After exchanging messages, `keybased` is finally done and sends `keybase.1.identifyUi.finish` to the desktop. We can listen to that message in the endpoint map like normal, and it will automatically clean up listeners in the callmap for us.

Future PR will include actually spawning the tracker popup window and stuff.


## Types

I also did some type fixing stuff so `.*desktop.js` is no longer being ignored, and this has no flow type errors.

@keybase/react-hackers 