### PR TITLE
Integrate base62-encoding with the raw encryption/decryption format

### DIFF
--- a/go/encoding/basex/base58.go
+++ b/go/encoding/basex/base58.go
@@ -1,9 +1,0 @@
-// Copyright 2015 Keybase, Inc. All rights reserved. Use of
-// this source code is governed by the included BSD license.
-
-package basex
-
-const base58EncodeStd = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-
-// Base58StdEncoding is the standard base58-encoding
-var Base58StdEncoding = NewEncoding(base58EncodeStd, 19)

--- a/go/encoding/basex/base64_compat_test.go
+++ b/go/encoding/basex/base64_compat_test.go
@@ -8,7 +8,7 @@ import (
 const encodeURL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
 
 func newBase64URLEncoding() *Encoding {
-	return NewEncoding(encodeURL, 3)
+	return NewEncoding(encodeURL, 3, "")
 }
 
 func TestHelloWorld(t *testing.T) {

--- a/go/encoding/basex/bases.go
+++ b/go/encoding/basex/bases.go
@@ -1,0 +1,34 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package basex
+
+// skipChars are the chars that we allow in the body but can be skipped
+// in the below encodings. Note that if a character is listed both in the
+// skipChar last and in the alphabet list, it isn't skipped. See the specifics
+// of NewEncoding() for more details.
+//
+// Note that this skip char list is in ASCII order
+const skipChars = "\t\n\r !\"#$%&'()*+,-./0:;<=>?@IOl[\\]^_`{|}~"
+
+// Bitcoin-style encoding
+const base58EncodeStd = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+// Base58StdEncoding is the standard base58-encoding, with Strict mode enforcing
+// no foreign characters
+var Base58StdEncodingStrict = NewEncoding(base58EncodeStd, 19, "")
+
+// Base58StdEncoding is the standard base58-encoding. Foreign characters are ignored
+// as long as they're from the blessed set.
+var Base58StdEncoding = NewEncoding(base58EncodeStd, 19, skipChars)
+
+// Unlike Base64, we put the digits first.
+const base62EncodeStd = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+// Base62StdEncoding is the standard 62-encoding, with a 32-byte input block and, a
+// 43-byte output block. Strict mode is on, so no foreign characters.
+var Base62StdEncodingStrict = NewEncoding(base62EncodeStd, 32, "")
+
+// Base62StdEncoding is the standard 62-encoding, with a 32-byte input block and, a
+// 43-byte output block. Foreign chracters are ignored
+var Base62StdEncoding = NewEncoding(base62EncodeStd, 32, skipChars)

--- a/go/encoding/basex/basex_test.go
+++ b/go/encoding/basex/basex_test.go
@@ -10,7 +10,7 @@ import (
 
 func decode(strict bool, dst, src []byte) (int, error) {
 	if strict {
-		return Base58StdEncoding.DecodeStrict(dst, src)
+		return Base58StdEncodingStrict.Decode(dst, src)
 	}
 	return Base58StdEncoding.Decode(dst, src)
 }

--- a/go/encoding/basex/go_base64_test.go
+++ b/go/encoding/basex/go_base64_test.go
@@ -323,10 +323,11 @@ func TestDecodeCorrupt(t *testing.T) {
 		{"AA=A", 2},
 		{"A=", 1},
 		{"A==", 1},
+		{"A䦕==", 1},
 	}
 	for _, tc := range testCases {
 		dbuf := make([]byte, Base58StdEncoding.DecodedLen(len(tc.input)))
-		_, err := Base58StdEncoding.DecodeStrict(dbuf, []byte(tc.input))
+		_, err := Base58StdEncodingStrict.Decode(dbuf, []byte(tc.input))
 		if tc.offset == -1 {
 			if err != nil {
 				t.Error("Decoder wrongly detected coruption in", tc.input)

--- a/go/kbcmf/armor.go
+++ b/go/kbcmf/armor.go
@@ -1,0 +1,275 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package kbcmf
+
+import (
+	"bytes"
+	"fmt"
+	basex "github.com/keybase/client/go/encoding/basex"
+	"io"
+	"io/ioutil"
+	"strings"
+)
+
+// ArmorParams specify armor formatting, encoding and punctuation.
+type ArmorParams struct {
+	// BytesPerWord is the number of characters in each "word" of output.
+	// We'll put spaces between words.
+	BytesPerWord int
+	// WordsPerLine is the number of words for each line of output. We'll
+	// put newlines between two subsequent lines of output.
+	WordsPerLine int
+	// Punctuation is the byte inserted after the three "sentences" of
+	// our encoding -- the header, the body and the footer.
+	Punctuation byte
+	// Encoding is the basex encoding to use, including strictness parameters
+	Encoding *basex.Encoding
+}
+
+type armorEncoderStream struct {
+	buf     *bytes.Buffer
+	footer  string
+	encoded io.Writer
+	encoder io.WriteCloser
+	nWords  int
+	params  ArmorParams
+}
+
+func (s *armorEncoderStream) Write(b []byte) (n int, err error) {
+	n, err = s.encoder.Write(b)
+	if err != nil {
+		return n, err
+	}
+	s.spaceAndOutputBuffer()
+	return n, err
+}
+
+func (s *armorEncoderStream) spaceAndOutputBuffer() error {
+	for s.buf.Len() > s.params.BytesPerWord {
+		buf := s.buf.Next(s.params.BytesPerWord)
+		s.nWords++
+		sep := byte(' ')
+		if s.nWords%s.params.WordsPerLine == 0 {
+			sep = byte('\n')
+		}
+		if _, err := s.encoded.Write(buf); err != nil {
+			return err
+		}
+		if _, err := s.encoded.Write([]byte{sep}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *armorEncoderStream) Close() (err error) {
+	if err = s.encoder.Close(); err != nil {
+		return err
+	}
+	if err := s.spaceAndOutputBuffer(); err != nil {
+		return err
+	}
+	lst := s.buf.Bytes()
+	if _, err := s.encoded.Write([]byte(lst)); err != nil {
+		return err
+	}
+	s.nWords++
+	pad := ""
+	if len(lst) == s.params.BytesPerWord {
+		if s.nWords%s.params.WordsPerLine == 0 {
+			pad = "\n"
+		} else {
+			pad = " "
+		}
+	}
+	if _, err := fmt.Fprintf(s.encoded, "%s%c\n\n%s%c\n", pad, s.params.Punctuation, s.footer, s.params.Punctuation); err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewArmorEncoderStream makes a new Armor encoding stream, using the given encoding
+// Pass it an `encoded` stream writer to write the
+// encoded stream to.  Also pass a header, and a footer string.  It will
+// return an io.WriteCloser on success, that you can write raw (unencoded) data to.
+// An error will be returned if there is trouble writing the header to encoded.
+//
+// To make the output look pretty, a space is inserted every 15 characters of output,
+// and a newline is inserted every 200 words.
+func NewArmorEncoderStream(encoded io.Writer, header string, footer string, params ArmorParams) (io.WriteCloser, error) {
+	ret := &armorEncoderStream{
+		buf:     new(bytes.Buffer),
+		encoded: encoded,
+		footer:  footer,
+		params:  params,
+	}
+	ret.encoder = basex.NewEncoder(params.Encoding, ret.buf)
+	if _, err := fmt.Fprintf(encoded, "%s%c\n\n", header, params.Punctuation); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// ArmorSeal takes an input plaintext and returns and output armor encoding
+// as a string, or an error if a problem was encountered. Also provide a header
+// and a footer to frame the message.
+func ArmorSeal(plaintext []byte, header string, footer string, params ArmorParams) (string, error) {
+	var buf bytes.Buffer
+	enc, err := NewArmorEncoderStream(&buf, header, footer, params)
+	if err != nil {
+		return "", err
+	}
+	if _, err := enc.Write(plaintext); err != nil {
+		return "", err
+	}
+	if err := enc.Close(); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// Frame is a way to read the frame out of a Decoder stream.
+type Frame interface {
+	// GetHeader() returns the frame associated with this stream, or an error
+	GetHeader() (string, error)
+	// GetFooter() returns the frame associated with this stream, or an error
+	GetFooter() (string, error)
+}
+
+type fdsState int
+
+const (
+	fdsHeader fdsState = iota
+	fdsBody
+	fdsFooter
+	fdsEndOfStream
+)
+
+type framedDecoderStream struct {
+	header []byte
+	footer []byte
+	state  fdsState
+	params ArmorParams
+	r      *PunctuatedReader
+}
+
+// Read from a framedDeecoderStream. The frame is the "BEGIN FOO." block
+// at the footer, and the "END FOO." block at the end.
+func (s *framedDecoderStream) Read(p []byte) (n int, err error) {
+
+	// The largest frame we'll accept before we show an overflow.
+	frameLim := 8192
+
+	if s.state == fdsHeader {
+		s.header, err = s.r.ReadUntilPunctuation(frameLim)
+		if err != nil {
+			return 0, err
+		}
+		s.state = fdsBody
+	}
+
+	if s.state == fdsBody {
+		n, err = s.r.Read(p)
+		if err == ErrPunctuated {
+			err = nil
+			s.state = fdsFooter
+		}
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	if s.state == fdsFooter {
+		s.footer, err = s.r.ReadUntilPunctuation(frameLim)
+		if err != nil {
+			return 0, err
+		}
+		s.state = fdsEndOfStream
+	}
+
+	if s.state == fdsEndOfStream {
+		err = s.consumeUntilEOF()
+		if err == io.EOF && n > 0 {
+			err = nil
+		}
+	}
+
+	return n, err
+}
+
+// consume the stream until we hit an EOF. For all data we consume, make
+// sure that it's a valid byte as far as our underlying decoder is concerned.
+// We might considering clamping down here on the number of characters we're willing
+// to accept after the message is over. But for now, we're quite liberal.
+func (s *framedDecoderStream) consumeUntilEOF() error {
+	var buf [4096]byte
+	for {
+		n, err := s.r.Read(buf[:])
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.EOF
+		}
+		if !s.isValidByteSequence(buf[0:n]) {
+			return ErrTrailingGarbage
+		}
+	}
+}
+
+// isValidByteSequence checks if the byte sequence is valid as far as our
+// underlying encoder is concerned. This is usually quite liberal, and excludes
+// non-ASCII and ASCII control characters, but leaves everything else in.
+func (s *framedDecoderStream) isValidByteSequence(p []byte) bool {
+	for _, b := range p {
+		if !s.params.Encoding.IsValidByte(b) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *framedDecoderStream) toASCII(buf []byte) (string, error) {
+	if !s.isValidByteSequence(buf) {
+		return "", ErrBadArmorFrame
+	}
+	return strings.TrimSpace(string(buf)), nil
+}
+
+func (s *framedDecoderStream) GetFooter() (string, error) { return s.toASCII(s.footer) }
+func (s *framedDecoderStream) GetHeader() (string, error) { return s.toASCII(s.header) }
+
+// NewArmorDecoderStream is used to decode armored encoding. It returns a stream you
+// can read from, and also a Frame you can query to see what the open/close
+// frame markers were.
+func NewArmorDecoderStream(r io.Reader, params ArmorParams) (io.Reader, Frame, error) {
+	fds := &framedDecoderStream{r: NewPunctuatedReader(r, params.Punctuation), params: params}
+	ret := basex.NewDecoder(params.Encoding, fds)
+	return ret, fds, nil
+}
+
+// ArmorOpen runs armor stream decoding, but on a string, and it outputs a string.
+func ArmorOpen(msg string, params ArmorParams) (body []byte, header string, footer string, err error) {
+	var dec io.Reader
+	var frame Frame
+	buf := bytes.NewBufferString(msg)
+	dec, frame, err = NewArmorDecoderStream(buf, params)
+	if err != nil {
+		return
+	}
+	body, err = ioutil.ReadAll(dec)
+	if err != nil {
+		return
+	}
+	if header, err = frame.GetHeader(); err != nil {
+		return
+	}
+	if footer, err = frame.GetFooter(); err != nil {
+		return
+	}
+	return body, header, footer, nil
+}

--- a/go/kbcmf/armor62.go
+++ b/go/kbcmf/armor62.go
@@ -1,0 +1,51 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package kbcmf
+
+import (
+	basex "github.com/keybase/client/go/encoding/basex"
+	"io"
+)
+
+// Armor62Params are the armoring parameters we recommend for use with
+// a generic armorer.  It specifies the spaces between words, the spacing
+// between lines, some simple punctuation, and an encoding alphabet.
+var Armor62Params = ArmorParams{
+	BytesPerWord: 15,
+	WordsPerLine: 200,
+	Punctuation:  byte('.'),
+	Encoding:     basex.Base62StdEncoding,
+}
+
+// NewArmor62EncoderStream makes a new Armor 62 encoding stream, using the base62-alphabet
+// and a 32/43 encoding rate strategy. Pass it an `encoded` stream writer to write the
+// encoded stream to.  Also pass a header, and a footer string.  It will
+// return an io.WriteCloser on success, that you can write raw (unencoded) data to.
+// An error will be returned if there is trouble writing the header to encoded.
+//
+// To make the output look pretty, a space is inserted every 15 characters of output,
+// and a newline is inserted every 200 words.
+func NewArmor62EncoderStream(encoded io.Writer, header string, footer string) (io.WriteCloser, error) {
+	return NewArmorEncoderStream(encoded, header, footer, Armor62Params)
+}
+
+// Armor62Seal takes an input plaintext and returns and output armor encoding
+// as a string, or an error if a problem was encountered. Also provide a header
+// and a footer to frame the message. Uses Base62 encoding scheme
+func Armor62Seal(plaintext []byte, header string, footer string) (string, error) {
+	return ArmorSeal(plaintext, header, footer, Armor62Params)
+}
+
+// NewArmor62DecoderStream is used to decode input base62-armoring format. It returns
+// a stream you can read from, and also a Frame you can query to see what the open/close
+// frame markers were.
+func NewArmor62DecoderStream(r io.Reader) (io.Reader, Frame, error) {
+	return NewArmorDecoderStream(r, Armor62Params)
+}
+
+// Armor62Open runs armor stream decoding, but on a string, and it outputs
+// a string.
+func Armor62Open(msg string) (body []byte, header string, footer string, err error) {
+	return ArmorOpen(msg, Armor62Params)
+}

--- a/go/kbcmf/armor62_decrypt.go
+++ b/go/kbcmf/armor62_decrypt.go
@@ -1,0 +1,57 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package kbcmf
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+)
+
+// NewDearmor62DecryptStream makes a new stream that dearmors and decrypts the given
+// Reader stream. Pass it a keyring so that it can lookup
+func NewDearmor62DecryptStream(ciphertext io.Reader, kr Keyring) (plaintext io.Reader, frame Frame, err error) {
+	dearmored, frame, err := NewArmor62DecoderStream(ciphertext)
+	if err != nil {
+		return nil, nil, err
+	}
+	r, err := NewDecryptStream(dearmored, kr)
+	if err != nil {
+		return nil, nil, err
+	}
+	return r, frame, nil
+}
+
+// Dearmor62DecryptOpen takes an armor62'ed, encrypted ciphertext and attempts to
+// dearmor and decrypt it, using the provided keyring. Checks that the frames in the
+// armor are as expected.
+func Dearmor62DecryptOpen(ciphertext string, kr Keyring) (plaintext []byte, err error) {
+	buf := bytes.NewBufferString(ciphertext)
+	s, frame, err := NewDearmor62DecryptStream(buf, kr)
+	if err != nil {
+		return nil, err
+	}
+	out, err := ioutil.ReadAll(s)
+	if err != nil {
+		return nil, err
+	}
+	if err = checkArmor62Frame(frame); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func checkArmor62Frame(frame Frame) error {
+	if hdr, err := frame.GetHeader(); err != nil {
+		return err
+	} else if hdr != EncryptionArmorHeader {
+		return ErrBadArmorHeader{EncryptionArmorHeader, hdr}
+	}
+	if ftr, err := frame.GetFooter(); err != nil {
+		return err
+	} else if ftr != EncryptionArmorFooter {
+		return ErrBadArmorFooter{EncryptionArmorFooter, ftr}
+	}
+	return nil
+}

--- a/go/kbcmf/armor62_encrypt.go
+++ b/go/kbcmf/armor62_encrypt.go
@@ -1,0 +1,66 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package kbcmf
+
+import (
+	"bytes"
+	"io"
+)
+
+type closeForwarder []io.WriteCloser
+
+func (c closeForwarder) Write(b []byte) (int, error) {
+	return c[0].Write(b)
+}
+
+func (c closeForwarder) Close() error {
+	for _, w := range c {
+		if e := w.Close(); e != nil {
+			return e
+		}
+	}
+	return nil
+}
+
+// NewEncryptArmor62Stream creates a stream that consumes plaintext data.
+// It will write out encrypted data to the io.Writer passed in as ciphertext.
+// The encryption is from the specified sender, and is encrypted for the
+// given receivers.  Note that receivers as specified as two-dimensional array.
+// Each inner group of receivers shares the same pairwise MAC-key, so should
+// represent a logic receiver split across multiple devices.  Each group of
+// receivers represents a mutually distrustful set of receivers, and will each
+// get their own pairwise-MAC keys.
+//
+// The ciphertext is additionally armored with the recommended armor62-style format
+//
+// Returns an io.WriteCloser that accepts plaintext data to be encrypted; and
+// also returns an error if initialization failed.
+func NewEncryptArmor62Stream(ciphertext io.Writer, sender BoxSecretKey, receivers [][]BoxPublicKey) (plaintext io.WriteCloser, err error) {
+	enc, err := NewArmor62EncoderStream(ciphertext, EncryptionArmorHeader, EncryptionArmorFooter)
+	if err != nil {
+		return nil, err
+	}
+	out, err := NewEncryptStream(enc, sender, receivers)
+	if err != nil {
+		return nil, err
+	}
+	return closeForwarder([]io.WriteCloser{out, enc}), nil
+}
+
+// EncryptArmor62Seal is the non-streaming version of NewEncryptArmor62Stream, which
+// inputs a plaintext (in bytes) and output a ciphertext (as a string).
+func EncryptArmor62Seal(plaintext []byte, sender BoxSecretKey, receivers [][]BoxPublicKey) (string, error) {
+	var buf bytes.Buffer
+	enc, err := NewEncryptArmor62Stream(&buf, sender, receivers)
+	if err != nil {
+		return "", err
+	}
+	if _, err := enc.Write(plaintext); err != nil {
+		return "", err
+	}
+	if err := enc.Close(); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/go/kbcmf/armor62_encrypt_test.go
+++ b/go/kbcmf/armor62_encrypt_test.go
@@ -1,0 +1,111 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package kbcmf
+
+import (
+	"bytes"
+	"crypto/rand"
+	"github.com/keybase/client/go/encoding/basex"
+	"io/ioutil"
+	"testing"
+)
+
+func encryptArmor62RandomData(t *testing.T, sz int) ([]byte, string) {
+	msg := randomMsg(t, sz)
+	if _, err := rand.Read(msg); err != nil {
+		t.Fatal(err)
+	}
+	sndr := newBoxKey(t)
+	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+
+	ciphertext, err := EncryptArmor62Seal(msg, *sndr, receivers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return msg, ciphertext
+}
+
+func TestEncryptArmor62(t *testing.T) {
+	plaintext, ciphertext := encryptArmor62RandomData(t, 1024)
+	plaintext2, err := Dearmor62DecryptOpen(ciphertext, kr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(plaintext, plaintext2) {
+		t.Fatalf("bad message back out")
+	}
+}
+
+func TestDearmor62DecryptSlowReader(t *testing.T) {
+	sz := 1024*16 + 3
+	msg := randomMsg(t, sz)
+	if _, err := rand.Read(msg); err != nil {
+		t.Fatal(err)
+	}
+	sndr := newBoxKey(t)
+	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+
+	ciphertext, err := EncryptArmor62Seal(msg, *sndr, receivers)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec, frame, err := NewDearmor62DecryptStream(&slowReader{[]byte(ciphertext)}, kr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plaintext, err := ioutil.ReadAll(dec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkArmor62Frame(frame); err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(plaintext, msg) {
+		t.Fatalf("bad message back out")
+	}
+}
+
+func TestBadArmor62(t *testing.T) {
+	_, ciphertext := encryptArmor62RandomData(t, 24)
+	bad1 := ciphertext[0:2] + "䁕" + ciphertext[2:]
+	if _, err := Dearmor62DecryptOpen(bad1, kr); err != ErrBadArmorFrame {
+		t.Fatalf("Wanted error %v but got %v", ErrBadArmorFrame, err)
+	}
+	if _, _, _, err := Armor62Open(bad1); err != ErrBadArmorFrame {
+		t.Fatalf("Wanted error %v but got %v", ErrBadArmorFrame, err)
+	}
+
+	bad2 := ciphertext[0:1] + "z" + ciphertext[2:]
+	_, err := Dearmor62DecryptOpen(bad2, kr)
+	if _, ok := err.(ErrBadArmorHeader); !ok {
+		t.Fatalf("Wanted of type ErrBadArmorHeader; got %v", err)
+	}
+
+	l := len(ciphertext)
+	bad3 := ciphertext[0:(l-8)] + "z" + ciphertext[(l-7):]
+	_, err = Dearmor62DecryptOpen(bad3, kr)
+	if _, ok := err.(ErrBadArmorFooter); !ok {
+		t.Fatalf("Wanted of type ErrBadArmorFooter; got %v", err)
+	}
+
+	bad4 := ciphertext + "䁕"
+	_, err = Dearmor62DecryptOpen(bad4, kr)
+	if err != ErrTrailingGarbage {
+		t.Fatalf("Wanted error %v but got %v", ErrTrailingGarbage, err)
+	}
+
+	bad5 := ciphertext[0:(l-8)] + "䁕" + ciphertext[(l-7):]
+	if _, _, _, err := Armor62Open(bad5); err != ErrBadArmorFrame {
+		t.Fatalf("Wanted error %v but got %v", ErrBadArmorFrame, err)
+	}
+	half := l >> 1
+	bad6 := ciphertext[0:half] + "䁕" + ciphertext[(half+1):]
+	_, _, _, err = Armor62Open(bad6)
+	if _, ok := err.(basex.CorruptInputError); !ok {
+		t.Fatalf("Wanted error of type CorruptInputError but got %v", err)
+	}
+}

--- a/go/kbcmf/armor_test.go
+++ b/go/kbcmf/armor_test.go
@@ -1,0 +1,140 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package kbcmf
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"testing"
+)
+
+func msg(sz int) []byte {
+	res := make([]byte, sz)
+	for i := 0; i < sz; i++ {
+		res[i] = byte(i % 256)
+	}
+	return res
+}
+
+const hdr = "BEGIN KBr ENCRYPTED MESSAGE"
+const ftr = "END KBr ENCRYPTED MESSAGE"
+
+func testArmor(t *testing.T, sz int) {
+	m := msg(sz)
+	a, e := Armor62Seal(m, hdr, ftr)
+	if e != nil {
+		t.Fatal(e)
+	}
+	m2, hdr2, ftr2, err := Armor62Open(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(m, m2) {
+		t.Errorf("Buffers disagreed: %v != %v (%d v %d)\n", m, m2, len(m), len(m2))
+	}
+	if hdr != hdr2 {
+		t.Errorf("headers disagreed: %s != %s", hdr, hdr2)
+	}
+	if ftr != ftr2 {
+		t.Errorf("headers disagreed: %s != %s", ftr, ftr2)
+	}
+}
+
+func TestArmor128(t *testing.T) {
+	testArmor(t, 128)
+}
+
+func TestArmor512(t *testing.T) {
+	testArmor(t, 512)
+}
+
+func TestArmor1024(t *testing.T) {
+	testArmor(t, 1024)
+}
+
+func TestArmor8192(t *testing.T) {
+	testArmor(t, 8192)
+}
+func TestArmor65536(t *testing.T) {
+	testArmor(t, 65536)
+}
+
+func TestSlowWriter(t *testing.T) {
+	m := msg(1024 * 16)
+	var out bytes.Buffer
+	enc, err := NewArmor62EncoderStream(&out, hdr, ftr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range m {
+		if _, err = enc.Write([]byte{c}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err = enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+	m2, hdr2, ftr2, err := Armor62Open(out.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(m, m2) {
+		t.Fatal("Buffer mismatch")
+	}
+	if ftr != ftr2 {
+		t.Fatal("footer mismatch")
+	}
+	if hdr != hdr2 {
+		t.Fatal("header mismatch")
+	}
+}
+
+type slowReader struct {
+	buf []byte
+}
+
+func (sr *slowReader) Read(b []byte) (int, error) {
+	if len(sr.buf) == 0 {
+		return 0, io.EOF
+	}
+	b[0] = sr.buf[0]
+	sr.buf = sr.buf[1:]
+	return 1, nil
+}
+
+func TestSlowReader(t *testing.T) {
+	var sr slowReader
+	m := msg(1024 * 32)
+	a, err := Armor62Seal(m, hdr, ftr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sr.buf = []byte(a)
+	dec, frame, err := NewArmor62DecoderStream(&sr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m2, err := ioutil.ReadAll(dec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(m, m2) {
+		t.Fatalf("buffer mismatch")
+	}
+	hdr2, err := frame.GetHeader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hdr != hdr2 {
+		t.Fatalf("header mismatch: %s != %s", hdr, hdr2)
+	}
+	ftr2, err := frame.GetFooter()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ftr != ftr2 {
+		t.Fatalf("header mismatch: %s != %s", ftr, ftr2)
+	}
+}

--- a/go/kbcmf/common.go
+++ b/go/kbcmf/common.go
@@ -62,9 +62,9 @@ func hmacSHA512(key []byte, data []byte) []byte {
 	return hasher.Sum(nil)[0:32]
 }
 
-func hashNonceAndAuthTag(nonce *Nonce, ciphertext []byte) ([]byte, error) {
+func hashNonceAndAuthTag(nonce *Nonce, ciphertext []byte) []byte {
 	var buf bytes.Buffer
 	buf.Write((*nonce)[:])
 	buf.Write(ciphertext[0:poly1305.TagSize])
-	return buf.Bytes(), nil
+	return buf.Bytes()
 }

--- a/go/kbcmf/const.go
+++ b/go/kbcmf/const.go
@@ -31,3 +31,11 @@ const PacketVersion1 PacketVersion = 1
 
 // EncryptionBlockSize is by default 1MB and can't currently be tweaked.
 const EncryptionBlockSize int = 1048576
+
+// EncryptionArmorHeader is the header that marks the start of an encrypted
+// armored KB message
+const EncryptionArmorHeader = "BEGIN KBr ENCRYPTED MESSAGE"
+
+// EncryptionArmorFooter is the footer that marks the end of an encrypted
+// armored KB message
+const EncryptionArmorFooter = "END KBr ENCRYPTED MESSAGE"

--- a/go/kbcmf/errors.go
+++ b/go/kbcmf/errors.go
@@ -29,11 +29,6 @@ var (
 	// ErrBadFrame indiciates improper msgpack framing
 	ErrBadFrame = errors.New("bad msgpack framing byte")
 
-	// ErrUnexpectedEOF is produced when an EOF happens unexpectedly when parsing an
-	// incoming encryption. Usually it means a message was truncated, but could indicate
-	// malicious truncation
-	ErrUnexpectedEOF = errors.New("unexpected EOF; the message was truncated")
-
 	// ErrInsufficientRandomness is generated when the encryption fails to collect
 	// enough randomness to proceed.  We're using the standard crypto/rand source
 	// of randomness, so this should never happen
@@ -46,8 +41,8 @@ var (
 	// Should never happen, so not exported.
 	errPacketUnderflow = errors.New("no negative packet numbers allowed")
 
-	// A temporary error that isn't exported
-	errAgain = errors.New("unavailable; try again")
+	// ErrBadArmorFrame shows up when the ASCII armor frame has non-ASCII
+	ErrBadArmorFrame = errors.New("bad frame found; had non-ASCII")
 )
 
 // ErrMACMismatch is generated when a MAC fails to check properly. It specifies
@@ -91,6 +86,29 @@ type ErrBadNonce struct {
 	byteLen int
 }
 
+// ErrBadArmorHeader shows up when we get the wrong value for our header
+type ErrBadArmorHeader struct {
+	wanted   string
+	received string
+}
+
+// ErrBadArmorFooter shows up when we get the wrong value for our header
+type ErrBadArmorFooter struct {
+	wanted   string
+	received string
+}
+
+func (e ErrBadArmorFooter) Error() string {
+	return fmt.Sprintf("Bad encryption armor footer; wanted '%s' but got '%s'",
+		e.wanted, e.received)
+}
+
+func (e ErrBadArmorHeader) Error() string {
+	return fmt.Sprintf("Bad encryption armor header; wanted '%s' but got '%s'",
+		e.wanted, e.received)
+}
+
+// = errors.New("bad armor header; unexpected text")
 func (e ErrWrongPacketTag) Error() string {
 	return fmt.Sprintf("In packet %d: wanted tag=%d; got tag=%d", e.seqno, e.wanted, e.received)
 }

--- a/go/kbcmf/errors.go
+++ b/go/kbcmf/errors.go
@@ -108,7 +108,6 @@ func (e ErrBadArmorHeader) Error() string {
 		e.wanted, e.received)
 }
 
-// = errors.New("bad armor header; unexpected text")
 func (e ErrWrongPacketTag) Error() string {
 	return fmt.Sprintf("In packet %d: wanted tag=%d; got tag=%d", e.seqno, e.wanted, e.received)
 }

--- a/go/kbcmf/fmp.go
+++ b/go/kbcmf/fmp.go
@@ -4,7 +4,6 @@
 package kbcmf
 
 import (
-	"bytes"
 	"github.com/ugorji/go/codec"
 	"io"
 )
@@ -32,162 +31,27 @@ func decodeFromBytes(p interface{}, b []byte) error {
 	return codec.NewDecoderBytes(b, codecHandle()).Decode(p)
 }
 
-type peek1Buffer struct {
-	bytes.Buffer
-	ch *byte
-}
-
-func (p *peek1Buffer) Peek() (byte, error) {
-	if p.ch != nil {
-		return *p.ch, nil
-	}
-	ch, err := p.ReadByte()
-	if err != nil {
-		return 0, err
-	}
-	p.ch = &ch
-	return ch, nil
-}
-
-func (p *peek1Buffer) Len() int {
-	ret := p.Buffer.Len()
-	if p.ch != nil {
-		ret++
-	}
-	return ret
-}
-
-func (p *peek1Buffer) Next(n int) []byte {
-	var ret []byte
-	if n == 0 {
-		return nil
-	}
-
-	if p.ch != nil {
-		n--
-		ret = []byte{*p.ch}
-		p.ch = nil
-	}
-	return append(ret, p.Buffer.Next(n)...)
-}
-
 type framedMsgpackStream struct {
-	buf           peek1Buffer
-	eof           bool
-	packetLenNext int
-	err           error
-	seqno         PacketSeqno
+	decoder *codec.Decoder
+	seqno   PacketSeqno
 }
 
-var _ io.WriteCloser = (*framedMsgpackStream)(nil)
-
-func (f *framedMsgpackStream) Write(b []byte) (n int, err error) {
-	return f.buf.Write(b)
+func newFramedMsgpackStream(r io.Reader) *framedMsgpackStream {
+	return &framedMsgpackStream{decoder: codec.NewDecoder(r, codecHandle())}
 }
 
-func (f *framedMsgpackStream) Close() error {
-	if f.err != nil {
-		return f.err
+func (r *framedMsgpackStream) Read(i interface{}) (ret PacketSeqno, err error) {
+	var frame int
+	if err = r.decoder.Decode(&frame); err != nil {
+		return ret, err
 	}
-	f.eof = true
-	return nil
-}
-
-func (f *framedMsgpackStream) Decode(i interface{}) (ret PacketSeqno, err error) {
-	if f.err != nil {
-		return 0, f.err
+	if frame == 0 {
+		return 0, ErrBadFrame
 	}
-	for f.packetLenNext == 0 {
-		err := f.decodeFrame()
-		if err == errAgain {
-			return 0, err
-		}
-		if err != nil {
-			f.err = err
-			return 0, err
-		}
+	if err = r.decoder.Decode(i); err != nil {
+		return ret, err
 	}
-	err = f.decodePacket(i)
-
-	// Unexpected EOF here
-	if err == errAgain && f.eof {
-		err = ErrUnexpectedEOF
-		f.err = err
-	} else if err != nil && err != errAgain {
-		f.err = err
-	} else if err == nil {
-		ret = f.seqno
-		f.seqno++
-	}
+	ret = r.seqno
+	r.seqno++
 	return ret, err
-}
-
-func (f *framedMsgpackStream) decodePacket(i interface{}) error {
-	if f.buf.Len() < f.packetLenNext {
-		return errAgain
-	}
-	buf := f.buf.Next(f.packetLenNext)
-	if len(buf) != f.packetLenNext {
-		return ErrBadFrame
-	}
-	err := decodeFromBytes(i, buf)
-	f.packetLenNext = 0
-	return err
-}
-
-// This is a hack of sorts, in which we've taken the important
-// parts of the Msgpack spec for reading an int from the string.
-func msgpackFrameLen(b byte) int {
-	if b < 0x80 {
-		return 1
-	}
-	if b == 0xcc {
-		return 2
-	}
-	if b == 0xcd {
-		return 3
-	}
-	if b == 0xce {
-		return 5
-	}
-	return 0
-}
-
-func (f *framedMsgpackStream) decodeFrame() error {
-	if f.buf.Len() == 0 {
-		if f.eof {
-			return io.EOF
-		}
-		return errAgain
-	}
-
-	var f0 byte
-	var err error
-
-	// First get the frame's framing byte! This will tell us
-	// how many more bytes we need to grab.  This is a bit of
-	// an abstraction violation, but one worth it for implementation
-	// simplicity and efficiency.
-	if f0, err = f.buf.Peek(); err != nil {
-		return err
-	}
-
-	frameLen := msgpackFrameLen(f0)
-	if frameLen == 0 {
-		return ErrBadFrame
-	}
-
-	if f.buf.Len() < frameLen {
-		if f.eof {
-			return ErrUnexpectedEOF
-		}
-		return errAgain
-	}
-
-	buf := f.buf.Next(frameLen)
-	if len(buf) != frameLen {
-		return ErrBadFrame
-	}
-	err = decodeFromBytes(&f.packetLenNext, buf)
-	return err
 }

--- a/go/kbcmf/punctuated_reader.go
+++ b/go/kbcmf/punctuated_reader.go
@@ -1,0 +1,133 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package kbcmf
+
+import (
+	"bytes"
+	"errors"
+	"io"
+)
+
+// PunctuatedReader is a stream reader that reads until it hits a usual
+// error OR until it hits a punctuation character. In that latter case
+// it returns an `ErrPunctuation` "error" so that way callers can tell
+// the difference between a normal EOF and a "punctuated" EOF.
+type PunctuatedReader struct {
+	r              io.Reader
+	punctuation    [1]byte
+	nextSegment    []byte
+	thisSegment    []byte
+	errThisSegment error
+	buf            [4096]byte
+}
+
+// ErrPunctuated is produced when a punctuation character is found in the stream.
+// It can be returned along with data, unlike usual errors.
+var ErrPunctuated = errors.New("found punctuation in stream")
+
+// ErrOverflow is returned if we were looking for punctuation but our quota was
+// overflowed before we found the needed character.
+var ErrOverflow = errors.New("buffer was overflowed before we found punctuation")
+
+// Read from the PunctuatedReader, potentially returning an `ErrPunctuation`
+// if a punctuation character was found.
+func (p *PunctuatedReader) Read(out []byte) (n int, err error) {
+
+	// First deal with the case that we had a "short copy" to our target buffer
+	// in a previous call of the read function.
+	if len(p.thisSegment) > 0 {
+		n = copy(out, p.thisSegment)
+		p.thisSegment = p.thisSegment[n:]
+		if len(p.thisSegment) == 0 {
+			err = p.errThisSegment
+			p.errThisSegment = nil
+		}
+		return n, err
+	}
+
+	// In this case we have no previous short copy, so now we deal with
+	// two cases --- we had, from a previous iteration, some stuff after the
+	// punctuation. Or we need to read again.
+	var src []byte
+	usedBuffer := false
+	if len(p.nextSegment) > 0 {
+		src = p.nextSegment
+		usedBuffer = true
+		p.nextSegment = nil
+	} else {
+		n, err = p.r.Read(out)
+		if err != nil {
+			return n, err
+		}
+		src = out[0:n]
+	}
+
+	// Now look for punctuation. If we find it, we need to keep the remaining
+	// data in the buffer (to the right of the punctuation mark) for the next
+	// time through the loop. Note that that new buffer can itself have subsequent
+	// punctuation, so we'll have to perform the check again here.
+	foundPunc := false
+	if i := bytes.Index(src, p.punctuation[:]); i >= 0 {
+		p.nextSegment = src[(i + 1):]
+		src = src[0:i]
+		n = len(src)
+		foundPunc = true
+	}
+
+	// If we used a buffer, copy into the output buffer, and potentially deal
+	// with a "short copy" situation in which we couldn't fit all of the data
+	// into the given buffer.
+	if usedBuffer {
+		n = copy(out, src)
+		p.thisSegment = src[n:]
+	}
+
+	// If we found punctuation, we have to set an error accordingly. However,
+	// in the "short copy" situation just above, we can't return the error just
+	// yet, we need to do so when that buffer is drained.
+	if foundPunc {
+		if len(p.thisSegment) > 0 {
+			p.errThisSegment = ErrPunctuated
+		} else {
+			err = ErrPunctuated
+		}
+	}
+
+	return n, err
+}
+
+// ReadUntilPunctuation reads from the stream until it find a desired
+// punctuation byte. If it wasn't found before EOF, it will return io.ErrUnexpectedEOF.
+// If it wasn't found before lim bytes are consumed, then it will return ErrOverflow.
+func (p *PunctuatedReader) ReadUntilPunctuation(lim int) (res []byte, err error) {
+	for {
+		var n int
+		n, err = p.Read(p.buf[:])
+		if err == ErrPunctuated || err == nil {
+			res = append(res, p.buf[0:n]...)
+			if err == ErrPunctuated {
+				err = nil
+				return res, err
+			}
+			if len(res) >= lim {
+				return nil, ErrOverflow
+			}
+		} else if err != nil {
+			if err == io.EOF {
+				err = io.ErrUnexpectedEOF
+			}
+			return nil, err
+		} else if n == 0 {
+			return nil, io.ErrUnexpectedEOF
+		}
+	}
+}
+
+// NewPunctuatedReader returns a new PunctuatedReader given an underlying
+// read stream and a punctuation byte.
+func NewPunctuatedReader(r io.Reader, p byte) *PunctuatedReader {
+	ret := &PunctuatedReader{r: r}
+	ret.punctuation[0] = p
+	return ret
+}

--- a/go/kbcmf/punctuated_reader_test.go
+++ b/go/kbcmf/punctuated_reader_test.go
@@ -1,0 +1,78 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package kbcmf
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+const testText = `Loving in truth, and fain in verse my love to show
+That she (dear She) might take some pleasure of my pain:
+Pleasure might cause her read, reading might make her know,
+Knowledge might pity win, and pity grace obtain;
+I sought fit words to paint the blackest face of woe,
+Studying inventions fine, her wits to entertain:
+Oft turning others’ leaves, to see if thence would flow
+Some fresh and fruitful showers upon my sun-burn’d brain.
+But words came halting forth, wanting Invention’s stay,
+Invention, Nature’s child, fled step-dame Study’s blows,
+And others’ feet still seem’d but strangers in my way.
+Thus, great with child to speak, and helpless in my throes,
+Biting my truant pen, beating myself for spite--
+“Fool,” said my Muse to me, “look in thy heart and write.”
+
+Loving, and wishing to show my love in verse,
+So that Stella might find pleasure in my pain,
+So that pleasure might make her read, and reading make her know me,
+And knowledge might win pity for me, and pity might obtain grace,
+I looked for fitting words to depict the darkest face of sadness,
+Studying clever creations in order to entertain her mind,
+Often turning others’ pages to see if, from them,
+Fresh and fruitful ideas would flow into my brain.
+But words came out lamely, lacking the support of Imagination:
+Imagination, nature’s child, fled the blows of Study, her stepmother:
+And the writings (‘feet’) of others seemed only alien things in the way.
+So while pregnant with the desire to speak, helpless with the birth pangs,
+Biting at my pen which disobeyed me, beating myself in anger,
+My Muse said to me ‘Fool, look in your heart and write.’
+`
+
+func TestPunctuatedReaderRegularReads(t *testing.T) {
+	buf := bytes.NewBufferString(testText)
+	r := NewPunctuatedReader(buf, '.')
+	for i := 0; i < 6; i++ {
+		_, err := r.ReadUntilPunctuation(1024)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err := r.ReadUntilPunctuation(1024)
+	if err != io.ErrUnexpectedEOF {
+		t.Fatalf("Wrong error; wanted %v but got %v", io.ErrUnexpectedEOF, err)
+	}
+}
+
+func TestPunctuatedReaderSlowReads(t *testing.T) {
+	r := NewPunctuatedReader(&slowReader{[]byte(testText)}, '.')
+	for i := 0; i < 6; i++ {
+		_, err := r.ReadUntilPunctuation(1024)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err := r.ReadUntilPunctuation(1024)
+	if err != io.ErrUnexpectedEOF {
+		t.Fatalf("Wrong error; wanted %v but got %v", io.ErrUnexpectedEOF, err)
+	}
+}
+
+func TestPunctuatedReaderSlowReadsOverflow(t *testing.T) {
+	r := NewPunctuatedReader(&slowReader{[]byte(testText)}, '.')
+	_, err := r.ReadUntilPunctuation(20)
+	if err != ErrOverflow {
+		t.Fatalf("Wrong error; wanted %v but got %v", ErrOverflow, err)
+	}
+}


### PR DESCRIPTION
- Closes maxtaco/CORE-2031
- Puts an additional layer around encoding, which is the begin/end framing and also punctuation.
- Fix the decryptor, which should have been a reader but was intead a writer.  This also greatly simplified the code.
- Codify the strict/loose encoding distinction, and close CORE-2004
- lints and good test coverage