### PR TITLE
Add GetPinSecret to protocol

### DIFF
--- a/go/client/cmd_stress.go
+++ b/go/client/cmd_stress.go
@@ -322,6 +322,6 @@ func (c *CmdStress) GetSecret(_ context.Context, arg keybase1.GetSecretArg) (res
 	return
 }
 
-func (c *CmdStress) GetPinSecret(_ context.Context, arg keybase1.GetPinSecretArg) (res keybase1.GetPassphraseRes, err error) {
+func (c *CmdStress) GetPassphrase(_ context.Context, arg keybase1.GetPassphraseArg) (res keybase1.GetPassphraseRes, err error) {
 	return
 }

--- a/go/client/cmd_stress.go
+++ b/go/client/cmd_stress.go
@@ -321,3 +321,7 @@ func (c *CmdStress) GetNewPassphrase(_ context.Context, arg keybase1.GetNewPassp
 func (c *CmdStress) GetSecret(_ context.Context, arg keybase1.GetSecretArg) (res keybase1.SecretEntryRes, err error) {
 	return
 }
+
+func (c *CmdStress) GetPinSecret(_ context.Context, arg keybase1.GetPinSecretArg) (res keybase1.GetPassphraseRes, err error) {
+	return
+}

--- a/go/client/cmd_test_passphrase.go
+++ b/go/client/cmd_test_passphrase.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
+)
+
+func NewCmdTestPassphrase(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "test-passphrase",
+		Usage: "Test the GetPassphrase protocol",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdTestPassphrase{Contextified: libkb.NewContextified(g)}, "test-passphrase", c)
+		},
+	}
+}
+
+type CmdTestPassphrase struct {
+	libkb.Contextified
+}
+
+func (s *CmdTestPassphrase) ParseArgv(ctx *cli.Context) error {
+	return nil
+}
+
+func (s *CmdTestPassphrase) GetUsage() libkb.Usage {
+	return libkb.Usage{}
+}
+
+func (s *CmdTestPassphrase) Run() (err error) {
+	s.G().Log.Debug("+ CmdTestPassphrase.Run")
+	defer func() { s.G().Log.Debug("- CmdTestPassphrase.Run -> %s", libkb.ErrToOk(err)) }()
+
+	guiArg := keybase1.GUIEntryArg{
+		WindowTitle: "Keybase Test Passphrase",
+		Prompt:      "Enter a test passphrase",
+		Features: keybase1.GUIEntryFeatures{
+			SecretStorage: keybase1.SecretStorageFeature{
+				Allow: true,
+				Label: "store your test passphrase",
+			},
+		},
+	}
+	res, err := s.G().UI.GetSecretUI().GetPassphrase(guiArg, nil)
+	if err != nil {
+		return err
+	}
+
+	s.G().Log.Debug("result: %+v", res)
+
+	return nil
+}

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -19,6 +19,7 @@ func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext
 		NewCmdFuse(cl, g),
 		NewCmdShowNotifications(cl, g),
 		NewCmdStress(cl),
+		NewCmdTestPassphrase(cl, g),
 	}
 }
 

--- a/go/client/secret.go
+++ b/go/client/secret.go
@@ -39,6 +39,6 @@ func (s *SecretUIServer) GetPaperKeyPassphrase(_ context.Context, arg keybase1.G
 	return s.eng.GetPaperKeyPassphrase(arg)
 }
 
-func (s *SecretUIServer) GetPinSecret(_ context.Context, arg keybase1.GetPinSecretArg) (keybase1.GetPassphraseRes, error) {
-	return s.eng.GetPinSecret(arg.Pinentry, arg.Terminal)
+func (s *SecretUIServer) GetPassphrase(_ context.Context, arg keybase1.GetPassphraseArg) (keybase1.GetPassphraseRes, error) {
+	return s.eng.GetPassphrase(arg.Pinentry, arg.Terminal)
 }

--- a/go/client/secret.go
+++ b/go/client/secret.go
@@ -38,3 +38,7 @@ func (s *SecretUIServer) GetKeybasePassphrase(_ context.Context, arg keybase1.Ge
 func (s *SecretUIServer) GetPaperKeyPassphrase(_ context.Context, arg keybase1.GetPaperKeyPassphraseArg) (string, error) {
 	return s.eng.GetPaperKeyPassphrase(arg)
 }
+
+func (s *SecretUIServer) GetPinSecret(_ context.Context, arg keybase1.GetPinSecretArg) (keybase1.GetPassphraseRes, error) {
+	return s.eng.GetPinSecret(arg.Pinentry, arg.Terminal)
+}

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -688,6 +688,24 @@ func (ui SecretUI) GetPaperKeyPassphrase(arg keybase1.GetPaperKeyPassphraseArg) 
 	return
 }
 
+func (ui SecretUI) GetPinSecret(pin keybase1.PinEntryArg, term *keybase1.SecretEntryArg) (res keybase1.GetPassphraseRes, err error) {
+	// if this gets called, then the delegate ui wasn't available.
+	// so only use the terminal
+	if term == nil {
+		term = &keybase1.SecretEntryArg{
+			Prompt:         pin.Prompt,
+			UseSecretStore: pin.AllowSecretStorage,
+		}
+	}
+	s, err := ui.parent.Terminal.GetSecret(term)
+	if err != nil {
+		return res, err
+	}
+	res.Passphrase = s.Text
+	res.StoreSecret = s.StoreSecret
+	return res, nil
+}
+
 func (ui SecretUI) ppprompt(arg libkb.PromptArg) (text string, storeSecret bool, err error) {
 
 	first := true

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -688,13 +688,13 @@ func (ui SecretUI) GetPaperKeyPassphrase(arg keybase1.GetPaperKeyPassphraseArg) 
 	return
 }
 
-func (ui SecretUI) GetPinSecret(pin keybase1.PinEntryArg, term *keybase1.SecretEntryArg) (res keybase1.GetPassphraseRes, err error) {
+func (ui SecretUI) GetPassphrase(pin keybase1.GUIEntryArg, term *keybase1.SecretEntryArg) (res keybase1.GetPassphraseRes, err error) {
 	// if this gets called, then the delegate ui wasn't available.
 	// so only use the terminal
 	if term == nil {
 		term = &keybase1.SecretEntryArg{
 			Prompt:         pin.Prompt,
-			UseSecretStore: pin.AllowSecretStorage,
+			UseSecretStore: pin.Features.SecretStorage.Allow,
 		}
 	}
 	s, err := ui.parent.Terminal.GetSecret(term)

--- a/go/engine/login_state_test.go
+++ b/go/engine/login_state_test.go
@@ -110,7 +110,7 @@ func (m *GetSecretMock) GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg)
 	return "invalid passphrase", m.LastErr
 }
 
-func (m *GetSecretMock) GetPinSecret(p keybase1.PinEntryArg, terminal *keybase1.SecretEntryArg) (res keybase1.GetPassphraseRes, err error) {
+func (m *GetSecretMock) GetPassphrase(p keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (res keybase1.GetPassphraseRes, err error) {
 	return
 }
 
@@ -253,7 +253,7 @@ func (m *GetKeybasePassphraseMock) CheckLastErr(t *testing.T) {
 	}
 }
 
-func (m *GetKeybasePassphraseMock) GetPinSecret(p keybase1.PinEntryArg, terminal *keybase1.SecretEntryArg) (res keybase1.GetPassphraseRes, err error) {
+func (m *GetKeybasePassphraseMock) GetPassphrase(p keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (res keybase1.GetPassphraseRes, err error) {
 	return
 }
 

--- a/go/engine/login_state_test.go
+++ b/go/engine/login_state_test.go
@@ -110,6 +110,10 @@ func (m *GetSecretMock) GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg)
 	return "invalid passphrase", m.LastErr
 }
 
+func (m *GetSecretMock) GetPinSecret(p keybase1.PinEntryArg, terminal *keybase1.SecretEntryArg) (res keybase1.GetPassphraseRes, err error) {
+	return
+}
+
 func (m *GetSecretMock) CheckLastErr(t *testing.T) {
 	if m.LastErr != nil {
 		t.Fatal(m.LastErr)
@@ -247,6 +251,10 @@ func (m *GetKeybasePassphraseMock) CheckLastErr(t *testing.T) {
 	if m.LastErr != nil {
 		t.Fatal(m.LastErr)
 	}
+}
+
+func (m *GetKeybasePassphraseMock) GetPinSecret(p keybase1.PinEntryArg, terminal *keybase1.SecretEntryArg) (res keybase1.GetPassphraseRes, err error) {
+	return
 }
 
 // Test that the login falls back to a passphrase login if pubkey

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -276,6 +276,7 @@ type SecretUI interface {
 	GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.GetPassphraseRes, error)
 	GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (keybase1.GetPassphraseRes, error)
 	GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) (string, error)
+	GetPinSecret(pinentry keybase1.PinEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error)
 }
 
 type LogUI interface {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -276,7 +276,7 @@ type SecretUI interface {
 	GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.GetPassphraseRes, error)
 	GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (keybase1.GetPassphraseRes, error)
 	GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) (string, error)
-	GetPinSecret(pinentry keybase1.PinEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error)
+	GetPassphrase(pinentry keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error)
 }
 
 type LogUI interface {

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -364,11 +364,11 @@ func (t *TestSecretUI) GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) 
 	return t.BackupPassphrase, nil
 }
 
-func (t *TestSecretUI) GetPinSecret(p keybase1.PinEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
+func (t *TestSecretUI) GetPassphrase(p keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
 	t.CalledGetPinSecret = true
 	return keybase1.GetPassphraseRes{
 		Passphrase:  t.Passphrase,
-		StoreSecret: p.AllowSecretStorage && t.StoreSecret,
+		StoreSecret: p.Features.SecretStorage.Allow && t.StoreSecret,
 	}, nil
 }
 

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -337,7 +337,7 @@ type TestSecretUI struct {
 	CalledGetKBPassphrase  bool
 	CalledGetBUPassphrase  bool
 	CalledGetNewPassphrase bool
-	CalledGetPinSecret     bool
+	CalledGetPassphrase    bool
 }
 
 func (t *TestSecretUI) GetSecret(p keybase1.SecretEntryArg, terminal *keybase1.SecretEntryArg) (*keybase1.SecretEntryRes, error) {
@@ -365,7 +365,7 @@ func (t *TestSecretUI) GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) 
 }
 
 func (t *TestSecretUI) GetPassphrase(p keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
-	t.CalledGetPinSecret = true
+	t.CalledGetPassphrase = true
 	return keybase1.GetPassphraseRes{
 		Passphrase:  t.Passphrase,
 		StoreSecret: p.Features.SecretStorage.Allow && t.StoreSecret,

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -337,6 +337,7 @@ type TestSecretUI struct {
 	CalledGetKBPassphrase  bool
 	CalledGetBUPassphrase  bool
 	CalledGetNewPassphrase bool
+	CalledGetPinSecret     bool
 }
 
 func (t *TestSecretUI) GetSecret(p keybase1.SecretEntryArg, terminal *keybase1.SecretEntryArg) (*keybase1.SecretEntryRes, error) {
@@ -361,6 +362,14 @@ func (t *TestSecretUI) GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (k
 func (t *TestSecretUI) GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) (string, error) {
 	t.CalledGetBUPassphrase = true
 	return t.BackupPassphrase, nil
+}
+
+func (t *TestSecretUI) GetPinSecret(p keybase1.PinEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
+	t.CalledGetPinSecret = true
+	return keybase1.GetPassphraseRes{
+		Passphrase:  t.Passphrase,
+		StoreSecret: p.AllowSecretStorage && t.StoreSecret,
+	}, nil
 }
 
 type TestLoginUI struct {

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -3964,6 +3964,7 @@ type GUIEntryFeatures struct {
 type GUIEntryArg struct {
 	WindowTitle string           `codec:"windowTitle" json:"windowTitle"`
 	Prompt      string           `codec:"prompt" json:"prompt"`
+	RetryLabel  string           `codec:"retryLabel" json:"retryLabel"`
 	Features    GUIEntryFeatures `codec:"features" json:"features"`
 }
 

--- a/go/service/handler.go
+++ b/go/service/handler.go
@@ -83,8 +83,8 @@ func (l *SecretUI) GetPaperKeyPassphrase(arg keybase1.GetPaperKeyPassphraseArg) 
 }
 
 // GetPinSecret gets the current keybase passphrase from delegated pinentry.
-func (l *SecretUI) GetPinSecret(pinentry keybase1.PinEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
-	return l.cli.GetPinSecret(context.TODO(), keybase1.GetPinSecretArg{SessionID: l.sessionID, Pinentry: pinentry, Terminal: terminal})
+func (l *SecretUI) GetPassphrase(pinentry keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
+	return l.cli.GetPassphrase(context.TODO(), keybase1.GetPassphraseArg{SessionID: l.sessionID, Pinentry: pinentry, Terminal: terminal})
 }
 
 func (h *BaseHandler) rpcClient() *rpc.Client {

--- a/go/service/handler.go
+++ b/go/service/handler.go
@@ -82,6 +82,11 @@ func (l *SecretUI) GetPaperKeyPassphrase(arg keybase1.GetPaperKeyPassphraseArg) 
 	return l.cli.GetPaperKeyPassphrase(context.TODO(), arg)
 }
 
+// GetPinSecret gets the current keybase passphrase from delegated pinentry.
+func (l *SecretUI) GetPinSecret(pinentry keybase1.PinEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
+	return l.cli.GetPinSecret(context.TODO(), keybase1.GetPinSecretArg{SessionID: l.sessionID, Pinentry: pinentry, Terminal: terminal})
+}
+
 func (h *BaseHandler) rpcClient() *rpc.Client {
 	return h.cli
 }

--- a/go/systests/secret_ui_test.go
+++ b/go/systests/secret_ui_test.go
@@ -88,6 +88,7 @@ type secretUI struct {
 	getNewPassphrase      bool
 	getPaperKeyPassphrase bool
 	getSecret             bool
+	getPinSecret          bool
 }
 
 // secretUI implements the keybase1.IdentifyUiInterface
@@ -114,6 +115,11 @@ func (s *secretUI) GetPaperKeyPassphrase(context.Context, keybase1.GetPaperKeyPa
 
 func (s *secretUI) GetSecret(context.Context, keybase1.GetSecretArg) (res keybase1.SecretEntryRes, err error) {
 	s.getSecret = true
+	return res, nil
+}
+
+func (s *secretUI) GetPinSecret(context.Context, keybase1.GetPinSecretArg) (res keybase1.GetPassphraseRes, err error) {
+	s.getPinSecret = true
 	return res, nil
 }
 

--- a/go/systests/secret_ui_test.go
+++ b/go/systests/secret_ui_test.go
@@ -88,7 +88,7 @@ type secretUI struct {
 	getNewPassphrase      bool
 	getPaperKeyPassphrase bool
 	getSecret             bool
-	getPinSecret          bool
+	getPassphrase         bool
 }
 
 // secretUI implements the keybase1.IdentifyUiInterface
@@ -119,7 +119,7 @@ func (s *secretUI) GetSecret(context.Context, keybase1.GetSecretArg) (res keybas
 }
 
 func (s *secretUI) GetPassphrase(context.Context, keybase1.GetPassphraseArg) (res keybase1.GetPassphraseRes, err error) {
-	s.getPinSecret = true
+	s.getPassphrase = true
 	return res, nil
 }
 

--- a/go/systests/secret_ui_test.go
+++ b/go/systests/secret_ui_test.go
@@ -118,7 +118,7 @@ func (s *secretUI) GetSecret(context.Context, keybase1.GetSecretArg) (res keybas
 	return res, nil
 }
 
-func (s *secretUI) GetPinSecret(context.Context, keybase1.GetPinSecretArg) (res keybase1.GetPassphraseRes, err error) {
+func (s *secretUI) GetPassphrase(context.Context, keybase1.GetPassphraseArg) (res keybase1.GetPassphraseRes, err error) {
 	s.getPinSecret = true
 	return res, nil
 }

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -91,7 +91,7 @@ func (n *signupSecretUI) GetSecret(pinentry keybase1.SecretEntryArg, terminal *k
 	return res, err
 }
 
-func (n *signupSecretUI) GetPinSecret(p keybase1.PinEntryArg, terminal *keybase1.SecretEntryArg) (res keybase1.GetPassphraseRes, err error) {
+func (n *signupSecretUI) GetPassphrase(p keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (res keybase1.GetPassphraseRes, err error) {
 	err = fmt.Errorf("GetPinSecret unimplemented")
 	return res, err
 }

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -92,7 +92,7 @@ func (n *signupSecretUI) GetSecret(pinentry keybase1.SecretEntryArg, terminal *k
 }
 
 func (n *signupSecretUI) GetPassphrase(p keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (res keybase1.GetPassphraseRes, err error) {
-	err = fmt.Errorf("GetPinSecret unimplemented")
+	err = fmt.Errorf("GetPassphrase unimplemented")
 	return res, err
 }
 

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -91,6 +91,11 @@ func (n *signupSecretUI) GetSecret(pinentry keybase1.SecretEntryArg, terminal *k
 	return res, err
 }
 
+func (n *signupSecretUI) GetPinSecret(p keybase1.PinEntryArg, terminal *keybase1.SecretEntryArg) (res keybase1.GetPassphraseRes, err error) {
+	err = fmt.Errorf("GetPinSecret unimplemented")
+	return res, err
+}
+
 func (n *signupTerminalUI) Prompt(pd libkb.PromptDescriptor, s string) (ret string, err error) {
 	switch pd {
 	case client.PromptDescriptorSignupUsername:

--- a/protocol/avdl/secret_ui.avdl
+++ b/protocol/avdl/secret_ui.avdl
@@ -49,6 +49,7 @@ protocol secretUi {
   record GUIEntryArg {
     string windowTitle;
     string prompt;
+    string retryLabel;
     GUIEntryFeatures features;
   }
 

--- a/protocol/avdl/secret_ui.avdl
+++ b/protocol/avdl/secret_ui.avdl
@@ -37,13 +37,21 @@ protocol secretUi {
 
   string getPaperKeyPassphrase(int sessionID, string username);
 
-  record PinEntryArg {
-    string windowTitle;
-    string prompt;
-    boolean allowSecretStorage;
-    string secretStorageLabel;
+  record SecretStorageFeature {
+    boolean allow;
+    string label;
   }
 
-  GetPassphraseRes getPinSecret(int sessionID, PinEntryArg pinentry, union { null, SecretEntryArg } terminal);
+  record GUIEntryFeatures {
+    SecretStorageFeature secretStorage;
+  }
+
+  record GUIEntryArg {
+    string windowTitle;
+    string prompt;
+    GUIEntryFeatures features;
+  }
+
+  GetPassphraseRes getPassphrase(int sessionID, GUIEntryArg pinentry, union { null, SecretEntryArg } terminal);
 }
 

--- a/protocol/avdl/secret_ui.avdl
+++ b/protocol/avdl/secret_ui.avdl
@@ -36,4 +36,14 @@ protocol secretUi {
   GetPassphraseRes getKeybasePassphrase(int sessionID, string username, string retry);
 
   string getPaperKeyPassphrase(int sessionID, string username);
+
+  record PinEntryArg {
+    string windowTitle;
+    string prompt;
+    boolean allowSecretStorage;
+    string secretStorageLabel;
+  }
+
+  GetPassphraseRes getPinSecret(int sessionID, PinEntryArg pinentry, union { null, SecretEntryArg } terminal);
 }
+

--- a/protocol/json/secret_ui.json
+++ b/protocol/json/secret_ui.json
@@ -233,6 +233,9 @@
       "name" : "prompt",
       "type" : "string"
     }, {
+      "name" : "retryLabel",
+      "type" : "string"
+    }, {
       "name" : "features",
       "type" : "GUIEntryFeatures"
     } ]

--- a/protocol/json/secret_ui.json
+++ b/protocol/json/secret_ui.json
@@ -206,6 +206,22 @@
       "name" : "storeSecret",
       "type" : "boolean"
     } ]
+  }, {
+    "type" : "record",
+    "name" : "PinEntryArg",
+    "fields" : [ {
+      "name" : "windowTitle",
+      "type" : "string"
+    }, {
+      "name" : "prompt",
+      "type" : "string"
+    }, {
+      "name" : "allowSecretStorage",
+      "type" : "boolean"
+    }, {
+      "name" : "secretStorageLabel",
+      "type" : "string"
+    } ]
   } ],
   "messages" : {
     "getSecret" : {
@@ -265,6 +281,19 @@
         "type" : "string"
       } ],
       "response" : "string"
+    },
+    "getPinSecret" : {
+      "request" : [ {
+        "name" : "sessionID",
+        "type" : "int"
+      }, {
+        "name" : "pinentry",
+        "type" : "PinEntryArg"
+      }, {
+        "name" : "terminal",
+        "type" : [ "null", "SecretEntryArg" ]
+      } ],
+      "response" : "GetPassphraseRes"
     }
   }
 }

--- a/protocol/json/secret_ui.json
+++ b/protocol/json/secret_ui.json
@@ -208,7 +208,24 @@
     } ]
   }, {
     "type" : "record",
-    "name" : "PinEntryArg",
+    "name" : "SecretStorageFeature",
+    "fields" : [ {
+      "name" : "allow",
+      "type" : "boolean"
+    }, {
+      "name" : "label",
+      "type" : "string"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "GUIEntryFeatures",
+    "fields" : [ {
+      "name" : "secretStorage",
+      "type" : "SecretStorageFeature"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "GUIEntryArg",
     "fields" : [ {
       "name" : "windowTitle",
       "type" : "string"
@@ -216,11 +233,8 @@
       "name" : "prompt",
       "type" : "string"
     }, {
-      "name" : "allowSecretStorage",
-      "type" : "boolean"
-    }, {
-      "name" : "secretStorageLabel",
-      "type" : "string"
+      "name" : "features",
+      "type" : "GUIEntryFeatures"
     } ]
   } ],
   "messages" : {
@@ -282,13 +296,13 @@
       } ],
       "response" : "string"
     },
-    "getPinSecret" : {
+    "getPassphrase" : {
       "request" : [ {
         "name" : "sessionID",
         "type" : "int"
       }, {
         "name" : "pinentry",
-        "type" : "PinEntryArg"
+        "type" : "GUIEntryArg"
       }, {
         "name" : "terminal",
         "type" : [ "null", "SecretEntryArg" ]

--- a/protocol/objc/KBRPC.h
+++ b/protocol/objc/KBRPC.h
@@ -506,11 +506,19 @@ typedef NS_ENUM (NSInteger, KBRDeviceType) {
 @property BOOL storeSecret;
 @end
 
-@interface KBRPinEntryArg : KBRObject
+@interface KBRSecretStorageFeature : KBRObject
+@property BOOL allow;
+@property NSString *label;
+@end
+
+@interface KBRGUIEntryFeatures : KBRObject
+@property KBRSecretStorageFeature *secretStorage;
+@end
+
+@interface KBRGUIEntryArg : KBRObject
 @property NSString *windowTitle;
 @property NSString *prompt;
-@property BOOL allowSecretStorage;
-@property NSString *secretStorageLabel;
+@property KBRGUIEntryFeatures *features;
 @end
 
 @interface KBRSession : KBRObject
@@ -1087,9 +1095,9 @@ typedef NS_ENUM (NSInteger, KBRPromptDefault) {
 @property NSInteger sessionID;
 @property NSString *username;
 @end
-@interface KBRGetPinSecretRequestParams : KBRRequestParams
+@interface KBRGetPassphraseRequestParams : KBRRequestParams
 @property NSInteger sessionID;
-@property KBRPinEntryArg *pinentry;
+@property KBRGUIEntryArg *pinentry;
 @property KBRSecretEntryArg *terminal;
 @end
 @interface KBRCurrentSessionRequestParams : KBRRequestParams
@@ -1832,9 +1840,9 @@ typedef NS_ENUM (NSInteger, KBRPromptDefault) {
 
 - (void)getPaperKeyPassphraseWithUsername:(NSString *)username completion:(void (^)(NSError *error, NSString *str))completion;
 
-- (void)getPinSecret:(KBRGetPinSecretRequestParams *)params completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion;
+- (void)getPassphrase:(KBRGetPassphraseRequestParams *)params completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion;
 
-- (void)getPinSecretWithPinentry:(KBRPinEntryArg *)pinentry terminal:(KBRSecretEntryArg *)terminal completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion;
+- (void)getPassphraseWithPinentry:(KBRGUIEntryArg *)pinentry terminal:(KBRSecretEntryArg *)terminal completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion;
 
 @end
 

--- a/protocol/objc/KBRPC.h
+++ b/protocol/objc/KBRPC.h
@@ -506,6 +506,13 @@ typedef NS_ENUM (NSInteger, KBRDeviceType) {
 @property BOOL storeSecret;
 @end
 
+@interface KBRPinEntryArg : KBRObject
+@property NSString *windowTitle;
+@property NSString *prompt;
+@property BOOL allowSecretStorage;
+@property NSString *secretStorageLabel;
+@end
+
 @interface KBRSession : KBRObject
 @property NSString *uid;
 @property NSString *username;
@@ -1079,6 +1086,11 @@ typedef NS_ENUM (NSInteger, KBRPromptDefault) {
 @interface KBRGetPaperKeyPassphraseRequestParams : KBRRequestParams
 @property NSInteger sessionID;
 @property NSString *username;
+@end
+@interface KBRGetPinSecretRequestParams : KBRRequestParams
+@property NSInteger sessionID;
+@property KBRPinEntryArg *pinentry;
+@property KBRSecretEntryArg *terminal;
 @end
 @interface KBRCurrentSessionRequestParams : KBRRequestParams
 @property NSInteger sessionID;
@@ -1819,6 +1831,10 @@ typedef NS_ENUM (NSInteger, KBRPromptDefault) {
 - (void)getPaperKeyPassphrase:(KBRGetPaperKeyPassphraseRequestParams *)params completion:(void (^)(NSError *error, NSString *str))completion;
 
 - (void)getPaperKeyPassphraseWithUsername:(NSString *)username completion:(void (^)(NSError *error, NSString *str))completion;
+
+- (void)getPinSecret:(KBRGetPinSecretRequestParams *)params completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion;
+
+- (void)getPinSecretWithPinentry:(KBRPinEntryArg *)pinentry terminal:(KBRSecretEntryArg *)terminal completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion;
 
 @end
 

--- a/protocol/objc/KBRPC.h
+++ b/protocol/objc/KBRPC.h
@@ -518,6 +518,7 @@ typedef NS_ENUM (NSInteger, KBRDeviceType) {
 @interface KBRGUIEntryArg : KBRObject
 @property NSString *windowTitle;
 @property NSString *prompt;
+@property NSString *retryLabel;
 @property KBRGUIEntryFeatures *features;
 @end
 

--- a/protocol/objc/KBRPC.m
+++ b/protocol/objc/KBRPC.m
@@ -1802,6 +1802,30 @@
   }];
 }
 
+- (void)getPinSecret:(KBRGetPinSecretRequestParams *)params completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion {
+  NSDictionary *rparams = @{@"pinentry": KBRValue(params.pinentry), @"terminal": KBRValue(params.terminal)};
+  [self.client sendRequestWithMethod:@"keybase.1.secretUi.getPinSecret" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
+    if (error) {
+      completion(error, nil);
+      return;
+    }
+    KBRGetPassphraseRes *result = retval ? [MTLJSONAdapter modelOfClass:KBRGetPassphraseRes.class fromJSONDictionary:retval error:&error] : nil;
+    completion(error, result);
+  }];
+}
+
+- (void)getPinSecretWithPinentry:(KBRPinEntryArg *)pinentry terminal:(KBRSecretEntryArg *)terminal completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion {
+  NSDictionary *rparams = @{@"pinentry": KBRValue(pinentry), @"terminal": KBRValue(terminal)};
+  [self.client sendRequestWithMethod:@"keybase.1.secretUi.getPinSecret" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
+    if (error) {
+      completion(error, nil);
+      return;
+    }
+    KBRGetPassphraseRes *result = retval ? [MTLJSONAdapter modelOfClass:KBRGetPassphraseRes.class fromJSONDictionary:retval error:&error] : nil;
+    completion(error, result);
+  }];
+}
+
 @end
 
 @implementation KBRSessionRequest
@@ -4208,6 +4232,24 @@
 }
 @end
 
+@implementation KBRGetPinSecretRequestParams
+
+- (instancetype)initWithParams:(NSArray *)params {
+  if ((self = [super initWithParams:params])) {
+    self.sessionID = [params[0][@"sessionID"] integerValue];
+    self.pinentry = [MTLJSONAdapter modelOfClass:KBRPinEntryArg.class fromJSONDictionary:params[0][@"pinentry"] error:nil];
+    self.terminal = [MTLJSONAdapter modelOfClass:KBRSecretEntryArg.class fromJSONDictionary:params[0][@"terminal"] error:nil];
+  }
+  return self;
+}
+
++ (instancetype)params {
+  KBRGetPinSecretRequestParams *p = [[self alloc] init];
+  // Add default values
+  return p;
+}
+@end
+
 @implementation KBRCurrentSessionRequestParams
 
 - (instancetype)initWithParams:(NSArray *)params {
@@ -4836,6 +4878,9 @@
 @end
 
 @implementation KBRGetPassphraseRes
+@end
+
+@implementation KBRPinEntryArg
 @end
 
 @implementation KBRSession

--- a/protocol/objc/KBRPC.m
+++ b/protocol/objc/KBRPC.m
@@ -1802,9 +1802,9 @@
   }];
 }
 
-- (void)getPinSecret:(KBRGetPinSecretRequestParams *)params completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion {
+- (void)getPassphrase:(KBRGetPassphraseRequestParams *)params completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion {
   NSDictionary *rparams = @{@"pinentry": KBRValue(params.pinentry), @"terminal": KBRValue(params.terminal)};
-  [self.client sendRequestWithMethod:@"keybase.1.secretUi.getPinSecret" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
+  [self.client sendRequestWithMethod:@"keybase.1.secretUi.getPassphrase" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
     if (error) {
       completion(error, nil);
       return;
@@ -1814,9 +1814,9 @@
   }];
 }
 
-- (void)getPinSecretWithPinentry:(KBRPinEntryArg *)pinentry terminal:(KBRSecretEntryArg *)terminal completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion {
+- (void)getPassphraseWithPinentry:(KBRGUIEntryArg *)pinentry terminal:(KBRSecretEntryArg *)terminal completion:(void (^)(NSError *error, KBRGetPassphraseRes *getPassphraseRes))completion {
   NSDictionary *rparams = @{@"pinentry": KBRValue(pinentry), @"terminal": KBRValue(terminal)};
-  [self.client sendRequestWithMethod:@"keybase.1.secretUi.getPinSecret" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
+  [self.client sendRequestWithMethod:@"keybase.1.secretUi.getPassphrase" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
     if (error) {
       completion(error, nil);
       return;
@@ -4232,19 +4232,19 @@
 }
 @end
 
-@implementation KBRGetPinSecretRequestParams
+@implementation KBRGetPassphraseRequestParams
 
 - (instancetype)initWithParams:(NSArray *)params {
   if ((self = [super initWithParams:params])) {
     self.sessionID = [params[0][@"sessionID"] integerValue];
-    self.pinentry = [MTLJSONAdapter modelOfClass:KBRPinEntryArg.class fromJSONDictionary:params[0][@"pinentry"] error:nil];
+    self.pinentry = [MTLJSONAdapter modelOfClass:KBRGUIEntryArg.class fromJSONDictionary:params[0][@"pinentry"] error:nil];
     self.terminal = [MTLJSONAdapter modelOfClass:KBRSecretEntryArg.class fromJSONDictionary:params[0][@"terminal"] error:nil];
   }
   return self;
 }
 
 + (instancetype)params {
-  KBRGetPinSecretRequestParams *p = [[self alloc] init];
+  KBRGetPassphraseRequestParams *p = [[self alloc] init];
   // Add default values
   return p;
 }
@@ -4880,7 +4880,13 @@
 @implementation KBRGetPassphraseRes
 @end
 
-@implementation KBRPinEntryArg
+@implementation KBRSecretStorageFeature
+@end
+
+@implementation KBRGUIEntryFeatures
+@end
+
+@implementation KBRGUIEntryArg
 @end
 
 @implementation KBRSession


### PR DESCRIPTION
Added a new func to SecretUI protocol for integration w/ electron pinentry.

The new argument is:

    record PinEntryArg {
        string windowTitle;
        string prompt;
        boolean allowSecretStorage;
        string secretStorageLabel;
    }

and it returns GetPassphraseRes.

Nothing calls this yet, but if the desktop app registers as a secret ui delegate and a change is made to call GetPinSecret() instead of GetSecret() somewhere, integration with the electron pinentry should be testable.

r? @cjb 