### PR TITLE
auth: add general purpose timed tokens

### DIFF
--- a/go/auth/errors.go
+++ b/go/auth/errors.go
@@ -5,6 +5,16 @@ package auth
 
 import "fmt"
 
+type InvalidTokenTypeError struct {
+	ExpectedTokenType string
+	ReceivedTokenType string
+}
+
+func (e InvalidTokenTypeError) Error() string {
+	return fmt.Sprintf("Invalid token type, expected: %s, received: %s",
+		e.ExpectedTokenType, e.ReceivedTokenType)
+}
+
 type MaxTokenExpiresError struct {
 	CreationTime int64
 	ExpireIn     int

--- a/go/auth/errors.go
+++ b/go/auth/errors.go
@@ -1,0 +1,31 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package auth
+
+import "fmt"
+
+type MaxTokenExpiresError struct {
+	CreationTime int64
+	ExpireIn     int
+	Now          int64
+	MaxExpireIn  int
+	Remaining    int
+}
+
+func (e MaxTokenExpiresError) Error() string {
+	return fmt.Sprintf("Max token expiration exceeded, ctime/expire_in: %d/%d, "+
+		"now/max: %d/%d, remaining: %d", e.CreationTime, e.ExpireIn,
+		e.Now, e.MaxExpireIn, e.Remaining)
+}
+
+type TokenExpiredError struct {
+	CreationTime int64
+	ExpireIn     int
+	Now          int64
+}
+
+func (e TokenExpiredError) Error() string {
+	return fmt.Sprintf("Token expired, ctime/expire_in: %d/%d, now: %d",
+		e.CreationTime, e.ExpireIn, e.Now)
+}

--- a/go/auth/token.go
+++ b/go/auth/token.go
@@ -7,13 +7,13 @@
 package auth
 
 import (
+	"bytes"
 	"encoding/json"
 	"math"
 	"time"
 
 	libkb "github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
-	jsonw "github.com/keybase/go-jsonw"
 )
 
 const CurrentTokenVersion = 1
@@ -144,12 +144,10 @@ func (t Token) ClientVersion() string {
 }
 
 func parseToken(token []byte) (*Token, error) {
-	jw, err := jsonw.Unmarshal(token)
-	if err != nil {
-		return nil, err
-	}
+        decoder := json.NewDecoder(bytes.NewReader(token))
+	decoder.UseNumber()
 	var t Token
-	if err = jw.UnmarshalAgain(&t); err != nil {
+	if err := decoder.Decode(&t); err != nil {
 		return nil, err
 	}
 	return &t, nil

--- a/go/auth/token.go
+++ b/go/auth/token.go
@@ -77,12 +77,10 @@ func (t Token) String() string {
 }
 
 func VerifyToken(signature, tokenType string, maxExpireIn int) (*Token, error) {
-	_, token, _, err := libkb.NaclVerifyAndExtract(signature)
-	if err != nil {
+	var t *Token
+	if _, token, _, err := libkb.NaclVerifyAndExtract(signature); err != nil {
 		return nil, err
-	}
-	t, err := parseToken(token)
-	if err != nil {
+	} else if t, err = parseToken(token); err != nil {
 		return nil, err
 	}
 	if tokenType != t.Type() {

--- a/go/auth/token.go
+++ b/go/auth/token.go
@@ -1,0 +1,240 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+//
+// Code used to support authentication tokens for arbitrary purposes.
+//
+package auth
+
+import (
+	"time"
+
+	libkb "github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
+	jsonw "github.com/keybase/go-jsonw"
+)
+
+const (
+	CurrentTokenVersion = 1
+	MaxExpireIn         = 24 * 60 * 60 // 1 day
+)
+
+type Token struct {
+	User          keybase1.UID
+	Username      libkb.NormalizedUsername
+	Key           keybase1.KID
+	TokenType     string
+	CreationTime  int64
+	ExpireIn      int
+	Tag           string
+	Version       int
+	ClientName    string
+	ClientVersion string
+}
+
+func NewToken(user keybase1.UID, username libkb.NormalizedUsername, key keybase1.KID,
+	tokenType string, expireIn int, clientName string, clientVersion string) *Token {
+	return &Token{
+		User:          user,
+		Username:      username,
+		Key:           key,
+		TokenType:     tokenType,
+		CreationTime:  time.Now().Unix(),
+		ExpireIn:      expireIn,
+		ClientName:    clientName,
+		ClientVersion: clientVersion,
+	}
+}
+
+func ParseToken(token string) (*Token, error) {
+	jw, err := jsonw.Unmarshal([]byte(token))
+	if err != nil {
+		return nil, err
+	}
+	t := &Token{}
+	if err := t.fromJSON(jw); err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+func (arg Token) Bytes() []byte {
+	var err error
+	var tmp []byte
+	if tmp, err = arg.toJSON().Marshal(); err != nil {
+		return []byte{}
+	}
+	return tmp
+}
+
+func (arg Token) String() string {
+	return string(arg.Bytes())
+}
+
+func (arg Token) Verify(signature string) error {
+	key, err := libkb.ImportKeypairFromKID(arg.Key)
+	if err != nil {
+		return err
+	}
+	if _, err := key.VerifyString(signature, arg.Bytes()); err != nil {
+		return err
+	}
+	remaining := arg.TimeRemaining()
+	if remaining > MaxExpireIn {
+		return MaxTokenExpiresError{
+			CreationTime: arg.CreationTime,
+			ExpireIn:     arg.ExpireIn,
+			Now:          time.Now().Unix(),
+			MaxExpireIn:  MaxExpireIn,
+			Remaining:    remaining,
+		}
+	}
+	if remaining <= 0 {
+		return TokenExpiredError{
+			CreationTime: arg.CreationTime,
+			ExpireIn:     arg.ExpireIn,
+			Now:          time.Now().Unix(),
+		}
+	}
+	return nil
+}
+
+func (arg Token) TimeRemaining() int {
+	now := time.Now().Unix()
+	expires := arg.CreationTime + int64(arg.ExpireIn)
+	return int(expires - now)
+}
+
+type keySection struct {
+	User     keybase1.UID
+	Username libkb.NormalizedUsername
+	Key      keybase1.KID
+}
+
+func (arg keySection) toJSON() *jsonw.Wrapper {
+	ret := jsonw.NewDictionary()
+	ret.SetKey("kid", jsonw.NewString(arg.Key.String()))
+	ret.SetKey("uid", jsonw.NewString(arg.User.String()))
+	ret.SetKey("username", jsonw.NewString(arg.Username.String()))
+	return ret
+}
+
+func (arg *keySection) fromJSON(key *jsonw.Wrapper) error {
+	kid, err := key.AtPath("kid").GetString()
+	if err != nil {
+		return err
+	}
+	uid, err := key.AtPath("uid").GetString()
+	if err != nil {
+		return err
+	}
+	name, err := key.AtPath("username").GetString()
+	if err != nil {
+		return err
+	}
+	arg.Key = keybase1.KID(kid)
+	arg.User = keybase1.UID(uid)
+	arg.Username = libkb.NormalizedUsername(name)
+	return nil
+}
+
+type clientSection struct {
+	Name    string
+	Version string
+}
+
+func (arg clientSection) toJSON() *jsonw.Wrapper {
+	ret := jsonw.NewDictionary()
+	ret.SetKey("name", jsonw.NewString(arg.Name))
+	ret.SetKey("version", jsonw.NewString(arg.Version))
+	return ret
+}
+
+func (arg *clientSection) fromJSON(client *jsonw.Wrapper) error {
+	name, err := client.AtPath("name").GetString()
+	if err != nil {
+		return err
+	}
+	version, err := client.AtPath("version").GetString()
+	if err != nil {
+		return err
+	}
+	arg.Name = name
+	arg.Version = version
+	return nil
+}
+
+func (arg Token) toJSON() *jsonw.Wrapper {
+	ret := jsonw.NewDictionary()
+	ret.SetKey("tag", jsonw.NewString("signature"))
+	ret.SetKey("ctime", jsonw.NewInt64(arg.CreationTime))
+	ret.SetKey("expire_in", jsonw.NewInt(arg.ExpireIn))
+
+	body := jsonw.NewDictionary()
+	body.SetKey("version", jsonw.NewInt(CurrentTokenVersion))
+	body.SetKey("type", jsonw.NewString(arg.TokenType))
+
+	key := keySection{
+		User:     arg.User,
+		Username: arg.Username,
+		Key:      arg.Key,
+	}.toJSON()
+	body.SetKey("key", key)
+	ret.SetKey("body", body)
+
+	client := clientSection{
+		Name:    arg.ClientName,
+		Version: arg.ClientVersion,
+	}.toJSON()
+	ret.SetKey("client", client)
+	return ret
+}
+
+func (arg *Token) fromJSON(token *jsonw.Wrapper) error {
+	tag, err := token.AtPath("tag").GetString()
+	if err != nil {
+		return err
+	}
+	ctime, err := token.AtPath("ctime").GetInt64()
+	if err != nil {
+		return err
+	}
+	expireIn, err := token.AtPath("expire_in").GetInt()
+	if err != nil {
+		return err
+	}
+
+	body := token.AtPath("body")
+	tokenType, err := body.AtPath("type").GetString()
+	if err != nil {
+		return err
+	}
+	version, err := body.AtPath("version").GetInt()
+	if err != nil {
+		return err
+	}
+
+	key := body.AtPath("key")
+	var ks keySection
+	if err := ks.fromJSON(key); err != nil {
+		return err
+	}
+
+	client := token.AtPath("client")
+	var cs clientSection
+	if err := cs.fromJSON(client); err != nil {
+		return err
+	}
+
+	arg.User = ks.User
+	arg.Username = ks.Username
+	arg.Key = ks.Key
+	arg.TokenType = tokenType
+	arg.CreationTime = ctime
+	arg.ExpireIn = expireIn
+	arg.Tag = tag
+	arg.Version = version
+	arg.ClientName = cs.Name
+	arg.ClientVersion = cs.Version
+	return nil
+}

--- a/go/auth/token.go
+++ b/go/auth/token.go
@@ -64,6 +64,7 @@ func NewToken(uid keybase1.UID, username libkb.NormalizedUsername, kid keybase1.
 		Tag:          "signature",
 	}
 }
+
 func (t Token) Bytes() []byte {
 	bytes, err := json.Marshal(&t)
 	if err != nil {

--- a/go/auth/token.go
+++ b/go/auth/token.go
@@ -144,7 +144,7 @@ func (t Token) ClientVersion() string {
 }
 
 func parseToken(token []byte) (*Token, error) {
-        decoder := json.NewDecoder(bytes.NewReader(token))
+	decoder := json.NewDecoder(bytes.NewReader(token))
 	decoder.UseNumber()
 	var t Token
 	if err := decoder.Decode(&t); err != nil {

--- a/go/auth/token_test.go
+++ b/go/auth/token_test.go
@@ -18,7 +18,7 @@ func TestTokenVerifyToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	name := libkb.NormalizedUsername("alice")
+	name := libkb.NewNormalizedUsername("alice")
 	uid := libkb.UsernameToUID(name.String())
 	expireIn := 10
 	tokenType := "test"
@@ -47,7 +47,7 @@ func TestTokenExpired(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	name := libkb.NormalizedUsername("bob")
+	name := libkb.NewNormalizedUsername("bob")
 	uid := libkb.UsernameToUID(name.String())
 	expireIn := 0
 	tokenType := "test"
@@ -70,7 +70,7 @@ func TestMaxExpires(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	name := libkb.NormalizedUsername("charlie")
+	name := libkb.NewNormalizedUsername("charlie")
 	uid := libkb.UsernameToUID(name.String())
 	expireIn := testMaxTokenExpireIn + 1
 	tokenType := "test"
@@ -93,7 +93,7 @@ func TestTokenTypeInvalid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	name := libkb.NormalizedUsername("dana")
+	name := libkb.NewNormalizedUsername("dana")
 	uid := libkb.UsernameToUID(name.String())
 	expireIn := 10
 	tokenType := "test"

--- a/go/auth/token_test.go
+++ b/go/auth/token_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	libkb "github.com/keybase/client/go/libkb"
-	keybase1 "github.com/keybase/client/go/protocol"
 )
 
 const testMaxTokenExpireIn = 60
@@ -18,8 +17,8 @@ func TestTokenVerifyToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	uid := keybase1.UID("01")
 	name := libkb.NormalizedUsername("alice")
+	uid := libkb.UsernameToUID(name.String())
 	expireIn := 10
 	token := NewToken(uid, name, keyPair.GetKID(), "test", expireIn, "test", "1")
 	sig, _, err := keyPair.SignToString(token.Bytes())
@@ -62,8 +61,8 @@ func TestTokenExpired(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	uid := keybase1.UID("01")
 	name := libkb.NormalizedUsername("alice")
+	uid := libkb.UsernameToUID(name.String())
 	expireIn := 0
 	token := NewToken(uid, name, keyPair.GetKID(), "test", expireIn, "test", "1")
 	sig, _, err := keyPair.SignToString(token.Bytes())
@@ -82,8 +81,8 @@ func TestMaxExpires(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	uid := keybase1.UID("01")
 	name := libkb.NormalizedUsername("alice")
+	uid := libkb.UsernameToUID(name.String())
 	expireIn := testMaxTokenExpireIn + 1
 	token := NewToken(uid, name, keyPair.GetKID(), "test", expireIn, "test", "1")
 	sig, _, err := keyPair.SignToString(token.Bytes())
@@ -102,8 +101,8 @@ func TestTokenTypeInvalid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	uid := keybase1.UID("01")
 	name := libkb.NormalizedUsername("alice")
+	uid := libkb.UsernameToUID(name.String())
 	expireIn := 10
 	token := NewToken(uid, name, keyPair.GetKID(), "test", expireIn, "test", "1")
 	sig, _, err := keyPair.SignToString(token.Bytes())

--- a/go/auth/token_test.go
+++ b/go/auth/token_test.go
@@ -23,26 +23,26 @@ func TestTokenParse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if token.User != uid {
-		t.Fatal(fmt.Errorf("UID mismatch, expected: %s, got %s", uid, token.User))
+	if token.UID() != uid {
+		t.Fatal(fmt.Errorf("UID mismatch, expected: %s, got %s", uid, token.UID()))
 	}
-	if token.Key != kid {
-		t.Fatal(fmt.Errorf("KID mismatch, expected: %s, got %s", kid, token.Key))
+	if token.KID() != kid {
+		t.Fatal(fmt.Errorf("KID mismatch, expected: %s, got %s", kid, token.KID()))
 	}
-	if token.Username != name {
-		t.Fatal(fmt.Errorf("Username mismatch, expected: %s, got %s", name, token.Username))
+	if token.Username() != name {
+		t.Fatal(fmt.Errorf("Username mismatch, expected: %s, got %s", name, token.Username()))
 	}
-	if token.TokenType != "test" {
-		t.Fatal(fmt.Errorf("TokenType mismatch, expected: test, got %s", token.TokenType))
+	if token.Type() != "test" {
+		t.Fatal(fmt.Errorf("TokenType mismatch, expected: test, got %s", token.Type()))
 	}
 	if token.ExpireIn != expireIn {
 		t.Fatal(fmt.Errorf("ExpireIn mismatch, expected: %d, got %d", expireIn, token.ExpireIn))
 	}
-	if token.ClientName != "test" {
-		t.Fatal(fmt.Errorf("ClientName mismatch, expected: test, got %s", token.ClientName))
+	if token.ClientName() != "test" {
+		t.Fatal(fmt.Errorf("ClientName mismatch, expected: test, got %s", token.ClientName()))
 	}
-	if token.ClientVersion != "1" {
-		t.Fatal(fmt.Errorf("ClientVersion mismatch, expected: 1, got %s", token.ClientVersion))
+	if token.ClientVersion() != "1" {
+		t.Fatal(fmt.Errorf("ClientVersion mismatch, expected: 1, got %s", token.ClientVersion()))
 	}
 }
 

--- a/go/auth/token_test.go
+++ b/go/auth/token_test.go
@@ -1,0 +1,106 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package auth
+
+import (
+	"fmt"
+	"testing"
+
+	libkb "github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
+)
+
+func TestTokenParse(t *testing.T) {
+	uid := keybase1.UID("01")
+	kid := keybase1.KID("02")
+	name := libkb.NormalizedUsername("alice")
+	expireIn := 10
+	token := NewToken(uid, name, kid, "test", expireIn, "test", "1")
+	token, err := ParseToken(token.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token.User != uid {
+		t.Fatal(fmt.Errorf("UID mismatch, expected: %s, got %s", uid, token.User))
+	}
+	if token.Key != kid {
+		t.Fatal(fmt.Errorf("KID mismatch, expected: %s, got %s", kid, token.Key))
+	}
+	if token.Username != name {
+		t.Fatal(fmt.Errorf("Username mismatch, expected: %s, got %s", name, token.Username))
+	}
+	if token.TokenType != "test" {
+		t.Fatal(fmt.Errorf("TokenType mismatch, expected: test, got %s", token.TokenType))
+	}
+	if token.ExpireIn != expireIn {
+		t.Fatal(fmt.Errorf("ExpireIn mismatch, expected: %d, got %d", expireIn, token.ExpireIn))
+	}
+	if token.ClientName != "test" {
+		t.Fatal(fmt.Errorf("ClientName mismatch, expected: test, got %s", token.ClientName))
+	}
+	if token.ClientVersion != "1" {
+		t.Fatal(fmt.Errorf("ClientVersion mismatch, expected: 1, got %s", token.ClientVersion))
+	}
+}
+
+func TestTokenVerify(t *testing.T) {
+	keyPair, err := libkb.GenerateNaclSigningKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	uid := keybase1.UID("01")
+	name := libkb.NormalizedUsername("alice")
+	expireIn := 10
+	token := NewToken(uid, name, keyPair.GetKID(), "test", expireIn, "test", "1")
+	sig, _, err := keyPair.SignToString(token.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := token.Verify("nope"); err == nil {
+		t.Fatal(fmt.Errorf("expected verification failure"))
+	}
+	if err := token.Verify(sig); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTokenExpired(t *testing.T) {
+	keyPair, err := libkb.GenerateNaclSigningKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	uid := keybase1.UID("01")
+	name := libkb.NormalizedUsername("alice")
+	expireIn := 0
+	token := NewToken(uid, name, keyPair.GetKID(), "test", expireIn, "test", "1")
+	sig, _, err := keyPair.SignToString(token.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = token.Verify(sig)
+	_, expired := err.(TokenExpiredError)
+	if !expired {
+		t.Fatal(fmt.Errorf("expected token expired error"))
+	}
+}
+
+func TestMaxExpires(t *testing.T) {
+	keyPair, err := libkb.GenerateNaclSigningKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	uid := keybase1.UID("01")
+	name := libkb.NormalizedUsername("alice")
+	expireIn := MaxExpireIn + 1
+	token := NewToken(uid, name, keyPair.GetKID(), "test", expireIn, "test", "1")
+	sig, _, err := keyPair.SignToString(token.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = token.Verify(sig)
+	_, maxExpires := err.(MaxTokenExpiresError)
+	if !maxExpires {
+		t.Fatal(fmt.Errorf("expected max token expires error"))
+	}
+}

--- a/go/libkb/generickey.go
+++ b/go/libkb/generickey.go
@@ -118,3 +118,7 @@ func ParseGenericKey(bundle string) (GenericKey, error) {
 func isPGPBundle(armored string) bool {
 	return strings.HasPrefix(armored, "-----BEGIN PGP")
 }
+
+func GenericKeyEqual(k1, k2 GenericKey) bool {
+	return k1.GetKID().Equal(k2.GetKID())
+}


### PR DESCRIPTION
This is just for the basic timed token object. Will add KBFS usage in a separate PR. As it turns out libkbfs only has access to the current public DH key KID and not the Ed25519 key KID. I hacked it enough to make sure this code works end-to-end but that part still needs cleanup.