### PR TITLE
Fix unknown username bug in login via passphrase

### DIFF
--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -345,15 +345,6 @@ func (e *LoginProvision) makeDeviceKeysWithSigner(ctx *Context, signer libkb.Gen
 // addEldestDeviceKey makes the device keys the eldest keys for
 // e.user.
 func (e *LoginProvision) addEldestDeviceKey(ctx *Context) error {
-	e.G().Log.Debug("addEldestDeviceKey: setting username to %q", e.arg.Username)
-	nu := libkb.NewNormalizedUsername(e.arg.Username)
-	if err := e.G().Env.GetConfigWriter().SwitchUser(nu); err != nil {
-		e.G().Log.Debug("SwitchUser error: %s", err)
-	}
-	e.G().LoginState().Account(func(a *libkb.Account) {
-		a.EnsureUsername(nu)
-	}, "LoginProvision.addEldestDeviceKey")
-
 	args, err := e.makeDeviceWrapArgs(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
In particular, for web users without keys logging in.

https://github.com/keybase/keybase-issues/issues/1855

This also fixes another bug where logging in on a device
with another account would try to get the passphrase for
the original account instead of for the username
specified during login (either via UI or command line).

Added/clarified tests for both situations.  Verified
that they fail without fix, pass with fix.

r? @maxtaco 