### PR TITLE
Refine kbfs event protocol

### DIFF
--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -1827,15 +1827,16 @@ const (
 	FSNotificationType_ENCRYPTING FSNotificationType = 0
 	FSNotificationType_DECRYPTING FSNotificationType = 1
 	FSNotificationType_SIGNING    FSNotificationType = 2
-	FSNotificationType_REKEYING   FSNotificationType = 3
+	FSNotificationType_VERIFYING  FSNotificationType = 3
+	FSNotificationType_REKEYING   FSNotificationType = 4
 )
 
 type FSNotification struct {
-	TopLevelFolder   string             `codec:"topLevelFolder" json:"topLevelFolder"`
-	Filename         string             `codec:"filename" json:"filename"`
-	Status           string             `codec:"status" json:"status"`
-	StatusCode       FSStatusCode       `codec:"statusCode" json:"statusCode"`
-	NotificationType FSNotificationType `codec:"notificationType" json:"notificationType"`
+	PublicTopLevelFolder bool               `codec:"publicTopLevelFolder" json:"publicTopLevelFolder"`
+	Filename             string             `codec:"filename" json:"filename"`
+	Status               string             `codec:"status" json:"status"`
+	StatusCode           FSStatusCode       `codec:"statusCode" json:"statusCode"`
+	NotificationType     FSNotificationType `codec:"notificationType" json:"notificationType"`
 }
 
 type FSEventArg struct {

--- a/protocol/avdl/kbfs_common.avdl
+++ b/protocol/avdl/kbfs_common.avdl
@@ -11,11 +11,12 @@ protocol kbfsCommon {
 		ENCRYPTING_0,
 		DECRYPTING_1,
 		SIGNING_2,
-		REKEYING_3
+		VERIFYING_3,
+		REKEYING_4
 	}
 
 	record FSNotification {
-		string topLevelFolder;
+		boolean publicTopLevelFolder;
 		string filename;
 		string status;
 		FSStatusCode statusCode;

--- a/protocol/js/keybase_v1.js
+++ b/protocol/js/keybase_v1.js
@@ -304,7 +304,8 @@ export default {
       'encrypting': 0,
       'decrypting': 1,
       'signing': 2,
-      'rekeying': 3
+      'verifying': 3,
+      'rekeying': 4
     }
   },
   'Kex2Provisionee': {
@@ -402,7 +403,8 @@ export default {
       'encrypting': 0,
       'decrypting': 1,
       'signing': 2,
-      'rekeying': 3
+      'verifying': 3,
+      'rekeying': 4
     }
   },
   'NotifySession': {},

--- a/protocol/json/kbfs.json
+++ b/protocol/json/kbfs.json
@@ -8,13 +8,13 @@
   }, {
     "type" : "enum",
     "name" : "FSNotificationType",
-    "symbols" : [ "ENCRYPTING_0", "DECRYPTING_1", "SIGNING_2", "REKEYING_3" ]
+    "symbols" : [ "ENCRYPTING_0", "DECRYPTING_1", "SIGNING_2", "VERIFYING_3", "REKEYING_4" ]
   }, {
     "type" : "record",
     "name" : "FSNotification",
     "fields" : [ {
-      "name" : "topLevelFolder",
-      "type" : "string"
+      "name" : "publicTopLevelFolder",
+      "type" : "boolean"
     }, {
       "name" : "filename",
       "type" : "string"

--- a/protocol/json/notify_fs.json
+++ b/protocol/json/notify_fs.json
@@ -8,13 +8,13 @@
   }, {
     "type" : "enum",
     "name" : "FSNotificationType",
-    "symbols" : [ "ENCRYPTING_0", "DECRYPTING_1", "SIGNING_2", "REKEYING_3" ]
+    "symbols" : [ "ENCRYPTING_0", "DECRYPTING_1", "SIGNING_2", "VERIFYING_3", "REKEYING_4" ]
   }, {
     "type" : "record",
     "name" : "FSNotification",
     "fields" : [ {
-      "name" : "topLevelFolder",
-      "type" : "string"
+      "name" : "publicTopLevelFolder",
+      "type" : "boolean"
     }, {
       "name" : "filename",
       "type" : "string"

--- a/protocol/objc/KBRPC.h
+++ b/protocol/objc/KBRPC.h
@@ -378,11 +378,12 @@ typedef NS_ENUM (NSInteger, KBRFSNotificationType) {
 	KBRFSNotificationTypeEncrypting = 0,
 	KBRFSNotificationTypeDecrypting = 1,
 	KBRFSNotificationTypeSigning = 2,
-	KBRFSNotificationTypeRekeying = 3,
+	KBRFSNotificationTypeVerifying = 3,
+	KBRFSNotificationTypeRekeying = 4,
 };
 
 @interface KBRFSNotification : KBRObject
-@property NSString *topLevelFolder;
+@property BOOL publicTopLevelFolder;
 @property NSString *filename;
 @property NSString *status;
 @property KBRFSStatusCode statusCode;
@@ -1513,12 +1514,6 @@ typedef NS_ENUM (NSInteger, KBRPromptDefault) {
 
 @end
 
-@interface KBRKex2ProvisionerRequest : KBRRequest
-
-- (void)kexStart:(void (^)(NSError *error))completion;
-
-@end
-
 @interface KBRKex2ProvisioneeRequest : KBRRequest
 
 - (void)hello:(KBRHelloRequestParams *)params completion:(void (^)(NSError *error, NSString *helloRes))completion;
@@ -1528,6 +1523,12 @@ typedef NS_ENUM (NSInteger, KBRPromptDefault) {
 - (void)didCounterSign:(KBRDidCounterSignRequestParams *)params completion:(void (^)(NSError *error))completion;
 
 - (void)didCounterSignWithSig:(NSData *)sig completion:(void (^)(NSError *error))completion;
+
+@end
+
+@interface KBRKex2ProvisionerRequest : KBRRequest
+
+- (void)kexStart:(void (^)(NSError *error))completion;
 
 @end
 

--- a/protocol/objc/KBRPC.m
+++ b/protocol/objc/KBRPC.m
@@ -679,17 +679,6 @@
 
 @end
 
-@implementation KBRKex2ProvisionerRequest
-
-- (void)kexStart:(void (^)(NSError *error))completion {
-  NSDictionary *rparams = @{};
-  [self.client sendRequestWithMethod:@"keybase.1.Kex2Provisioner.kexStart" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
-    completion(error);
-  }];
-}
-
-@end
-
 @implementation KBRKex2ProvisioneeRequest
 
 - (void)hello:(KBRHelloRequestParams *)params completion:(void (^)(NSError *error, NSString *helloRes))completion {
@@ -726,6 +715,17 @@
 - (void)didCounterSignWithSig:(NSData *)sig completion:(void (^)(NSError *error))completion {
   NSDictionary *rparams = @{@"sig": KBRValue(sig)};
   [self.client sendRequestWithMethod:@"keybase.1.Kex2Provisionee.didCounterSign" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
+    completion(error);
+  }];
+}
+
+@end
+
+@implementation KBRKex2ProvisionerRequest
+
+- (void)kexStart:(void (^)(NSError *error))completion {
+  NSDictionary *rparams = @{};
+  [self.client sendRequestWithMethod:@"keybase.1.Kex2Provisioner.kexStart" params:rparams sessionId:self.sessionId completion:^(NSError *error, id retval) {
     completion(error);
   }];
 }
@@ -3286,6 +3286,7 @@
 - (instancetype)initWithParams:(NSArray *)params {
   if ((self = [super initWithParams:params])) {
     self.sessionID = [params[0][@"sessionID"] integerValue];
+    self.username = params[0][@"username"];
   }
   return self;
 }
@@ -3334,7 +3335,6 @@
 - (instancetype)initWithParams:(NSArray *)params {
   if ((self = [super initWithParams:params])) {
     self.sessionID = [params[0][@"sessionID"] integerValue];
-    self.username = params[0][@"username"];
   }
   return self;
 }


### PR DESCRIPTION
After actually integrating with kbfs, made some
refinements to the protocol.

Instead of TopLevelFolder, just pass a boolean for
public/private TLF.

Added 'verifying' status for reading public blocks.

r? @maxtaco 