### PR TITLE
Allow senders & receivers to hide their identity

### DIFF
--- a/go/kbcmf/armor62_encrypt_test.go
+++ b/go/kbcmf/armor62_encrypt_test.go
@@ -19,7 +19,7 @@ func encryptArmor62RandomData(t *testing.T, sz int) ([]byte, string) {
 	sndr := newBoxKey(t)
 	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
 
-	ciphertext, err := EncryptArmor62Seal(msg, *sndr, receivers)
+	ciphertext, err := EncryptArmor62Seal(msg, sndr, receivers)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestDearmor62DecryptSlowReader(t *testing.T) {
 	sndr := newBoxKey(t)
 	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
 
-	ciphertext, err := EncryptArmor62Seal(msg, *sndr, receivers)
+	ciphertext, err := EncryptArmor62Seal(msg, sndr, receivers)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/kbcmf/const.go
+++ b/go/kbcmf/const.go
@@ -39,3 +39,7 @@ const EncryptionArmorHeader = "BEGIN KBr ENCRYPTED MESSAGE"
 // EncryptionArmorFooter is the footer that marks the end of an encrypted
 // armored KB message
 const EncryptionArmorFooter = "END KBr ENCRYPTED MESSAGE"
+
+// groupIDMask is OR'ed into group IDs, so that they all are encoded as full
+// 32-bit integers
+const groupIDMask = 0x80000000

--- a/go/kbcmf/decrypt.go
+++ b/go/kbcmf/decrypt.go
@@ -131,7 +131,7 @@ func (ds *decryptStream) assertEndOfStream() error {
 	return err
 }
 
-func (ds *decryptStream) tryVisibileReceivers(hdr *EncryptionHeader, nonce *Nonce, ephemeralKey BoxPublicKey) (BoxSecretKey, []byte, int, error) {
+func (ds *decryptStream) tryVisibleReceivers(hdr *EncryptionHeader, nonce *Nonce, ephemeralKey BoxPublicKey) (BoxSecretKey, []byte, int, error) {
 	var kids [][]byte
 	for _, r := range hdr.Receivers {
 		if r.KID != nil {
@@ -185,7 +185,7 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 	var nonce Nonce
 	copy(nonce[:], hdr.Nonce)
 
-	secretKey, senderPublicRawKey, i, err := ds.tryVisibileReceivers(hdr, &nonce, ephemeralKey)
+	secretKey, senderPublicRawKey, i, err := ds.tryVisibleReceivers(hdr, &nonce, ephemeralKey)
 	if err != nil {
 		return err
 	}

--- a/go/kbcmf/decrypt.go
+++ b/go/kbcmf/decrypt.go
@@ -158,7 +158,11 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 		return err
 	}
 
-	// Lookup the sender's secret key in our keyring, and import
+	if err := verifyRawKey(senderPublicKey); err != nil {
+		return err
+	}
+
+	// Lookup the sender's public key in our keyring, and import
 	// it for use. However, if the sender key is the same as the ephemeral
 	// key, then assume "anonymous mode", so use the already imported anonymous
 	// key.

--- a/go/kbcmf/encrypt_test.go
+++ b/go/kbcmf/encrypt_test.go
@@ -1097,7 +1097,7 @@ func TestCorruptHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = Open(ciphertext, kr)
-	if err != ErrBadEphemeralKey {
+	if err != ErrBadSenderKey {
 		t.Fatalf("Bad error: wanted %v but got %v", ErrBadEphemeralKey, err)
 	}
 

--- a/go/kbcmf/errors.go
+++ b/go/kbcmf/errors.go
@@ -51,6 +51,10 @@ var (
 	// ErrBadReceivers shows up when you pass a bad receivers object -- either one
 	// that was empty, or one that had an empty group.
 	ErrBadReceivers = errors.New("bad receivers argument")
+
+	// ErrBadSenderKey is returned if a key with the wrong number of bytes
+	// is discovered in the encryption header.
+	ErrBadSenderKey = errors.New("bad sender key; must be 32 bytes")
 )
 
 // ErrMACMismatch is generated when a MAC fails to check properly. It specifies

--- a/go/kbcmf/errors.go
+++ b/go/kbcmf/errors.go
@@ -43,6 +43,14 @@ var (
 
 	// ErrBadArmorFrame shows up when the ASCII armor frame has non-ASCII
 	ErrBadArmorFrame = errors.New("bad frame found; had non-ASCII")
+
+	// ErrBadEphemeralKey is for when an ephemeral key fails to be properly
+	// imported.
+	ErrBadEphemeralKey = errors.New("bad ephermal key in header")
+
+	// ErrBadReceivers shows up when you pass a bad receivers object -- either one
+	// that was empty, or one that had an empty group.
+	ErrBadReceivers = errors.New("bad receivers argument")
 )
 
 // ErrMACMismatch is generated when a MAC fails to check properly. It specifies

--- a/go/kbcmf/key.go
+++ b/go/kbcmf/key.go
@@ -63,7 +63,7 @@ type Keyring interface {
 	LookupBoxPublicKey(kid []byte) BoxPublicKey
 
 	// ImportEphemeralKey imports the ephemeral key into
-	// BoxPublicKey format.  This key has never been seen before, so
+	// BoxPublicKey format. This key has never been seen before, so
 	// will be ephemeral.
 	ImportEphemeralKey(kid []byte) BoxPublicKey
 }

--- a/go/kbcmf/key.go
+++ b/go/kbcmf/key.go
@@ -24,6 +24,10 @@ type BoxPublicKey interface {
 	// ToRawBoxKeyPointer returns this public key as a *[32]byte,
 	// for use with nacl.box.Seal
 	ToRawBoxKeyPointer() *RawBoxKey
+
+	// CreateEmphemeralKey creates an ephemeral key of the same type,
+	// but totally random.
+	CreateEphemeralKey() (BoxSecretKey, error)
 }
 
 // Nonce is a NaCl-style nonce, with 24 bytes of data, some of which can be
@@ -41,6 +45,25 @@ type BoxSecretKey interface {
 	// abd the give public key as the sender key.
 	Unbox(sender BoxPublicKey, nonce *Nonce, msg []byte) ([]byte, error)
 
-	// GetPublicKey gets the public key associated with this secret key
+	// GetPublicKey gets the public key associated with this secret key.
 	GetPublicKey() BoxPublicKey
+}
+
+// Keyring is an interface used with decryption; it is call to recover
+// public or private keys during the decryption process. Calls can block
+// on network action.
+type Keyring interface {
+	// LookupBoxSecretKey looks in the Keyring for the secret key corresponding
+	// to one of the given Key IDs.  Returns the index and the key on success,
+	// or -1 and nil on failure.
+	LookupBoxSecretKey(kids [][]byte) (int, BoxSecretKey)
+
+	// LookupBoxPublicKey returns a public key given the specified key ID.
+	// For most cases, the key ID will be the key itself.
+	LookupBoxPublicKey(kid []byte) BoxPublicKey
+
+	// ImportEphemeralKey imports the ephemeral key into
+	// BoxPublicKey format.  This key has never been seen before, so
+	// will be ephemeral.
+	ImportEphemeralKey(kid []byte) BoxPublicKey
 }

--- a/go/kbcmf/key.go
+++ b/go/kbcmf/key.go
@@ -28,11 +28,20 @@ type BoxPublicKey interface {
 	// CreateEmphemeralKey creates an ephemeral key of the same type,
 	// but totally random.
 	CreateEphemeralKey() (BoxSecretKey, error)
+
+	// HideIdentity returns true if we should hide the identity of this
+	// key in our output message format.
+	HideIdentity() bool
 }
 
 // Nonce is a NaCl-style nonce, with 24 bytes of data, some of which can be
 // counter values, and some of which can be truly random values.
 type Nonce [24]byte
+
+// BoxPrecomputedSharedKey results from a Precomputation below.
+type BoxPrecomputedSharedKey interface {
+	Unbox(nonce *Nonce, msg []byte) ([]byte, error)
+}
 
 // BoxSecretKey is the secret key corresponding to a BoxPublicKey
 type BoxSecretKey interface {
@@ -47,6 +56,9 @@ type BoxSecretKey interface {
 
 	// GetPublicKey gets the public key associated with this secret key.
 	GetPublicKey() BoxPublicKey
+
+	// Precompute computes a DH with the given key
+	Precompute(sender BoxPublicKey) BoxPrecomputedSharedKey
 }
 
 // Keyring is an interface used with decryption; it is call to recover
@@ -61,6 +73,10 @@ type Keyring interface {
 	// LookupBoxPublicKey returns a public key given the specified key ID.
 	// For most cases, the key ID will be the key itself.
 	LookupBoxPublicKey(kid []byte) BoxPublicKey
+
+	// GetAllSecretKeys returns all keys, needed if we want to support
+	// "hidden" receivers via trial and error
+	GetAllSecretKeys() []BoxSecretKey
 
 	// ImportEphemeralKey imports the ephemeral key into
 	// BoxPublicKey format. This key has never been seen before, so

--- a/go/kbcmf/packets.go
+++ b/go/kbcmf/packets.go
@@ -11,20 +11,21 @@ type receiverKeysPlaintext struct {
 	SessionKey []byte `codec:"sess"`
 }
 
-type receiverKeysCiphertext struct {
-	KID  []byte `codec:"key_id"`
-	Keys []byte `codec:"keys"`
+type receiverKeysCiphertexts struct {
+	KID    []byte `codec:"key_id,omitempty"`
+	Sender []byte `codec:"sender"`
+	Keys   []byte `codec:"keys"`
 }
 
 // EncryptionHeader is the first packet in an encrypted message.
 // It contains the encryptions of the session keys, and various
 // message metadata.
 type EncryptionHeader struct {
-	Version   PacketVersion            `codec:"vers"`
-	Tag       PacketTag                `codec:"tag"`
-	Nonce     []byte                   `codec:"nonce"`
-	Receivers []receiverKeysCiphertext `codec:"rcvrs"`
-	Sender    []byte                   `codec:"sender"`
+	Version   PacketVersion             `codec:"vers"`
+	Tag       PacketTag                 `codec:"tag"`
+	Nonce     []byte                    `codec:"nonce"`
+	Receivers []receiverKeysCiphertexts `codec:"rcvrs"`
+	Sender    []byte                    `codec:"sender"`
 	seqno     PacketSeqno
 }
 

--- a/go/kbcmf/packets.go
+++ b/go/kbcmf/packets.go
@@ -39,6 +39,13 @@ type EncryptionBlock struct {
 	seqno      PacketSeqno
 }
 
+func verifyRawKey(k []byte) error {
+	if len(k) != len(RawBoxKey{}) {
+		return ErrBadSenderKey
+	}
+	return nil
+}
+
 func (h *EncryptionHeader) validate() error {
 	if h.Tag != PacketTagEncryptionHeader {
 		return ErrWrongPacketTag{h.seqno, PacketTagEncryptionHeader, h.Tag}
@@ -51,6 +58,11 @@ func (h *EncryptionHeader) validate() error {
 	if len(h.Nonce) != len(Nonce{})-4 {
 		return ErrBadNonce{h.seqno, len(h.Nonce)}
 	}
+
+	if err := verifyRawKey(h.Sender); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/go/kbcmf/packets.go
+++ b/go/kbcmf/packets.go
@@ -13,29 +13,29 @@ type receiverKeysPlaintext struct {
 
 type receiverKeysCiphertexts struct {
 	KID    []byte `codec:"key_id,omitempty"`
-	Sender []byte `codec:"sender"`
 	Keys   []byte `codec:"keys"`
+	Sender []byte `codec:"sender"`
 }
 
 // EncryptionHeader is the first packet in an encrypted message.
 // It contains the encryptions of the session keys, and various
 // message metadata.
 type EncryptionHeader struct {
-	Version   PacketVersion             `codec:"vers"`
-	Tag       PacketTag                 `codec:"tag"`
 	Nonce     []byte                    `codec:"nonce"`
 	Receivers []receiverKeysCiphertexts `codec:"rcvrs"`
 	Sender    []byte                    `codec:"sender"`
+	Tag       PacketTag                 `codec:"tag"`
+	Version   PacketVersion             `codec:"vers"`
 	seqno     PacketSeqno
 }
 
 // EncryptionBlock contains a block of encrypted data. It cointains
 // the ciphertext, and any necessary MACs.
 type EncryptionBlock struct {
-	Version    PacketVersion `codec:"vers"`
-	Tag        PacketTag     `codec:"tag"`
 	Ciphertext []byte        `codec:"ctext"`
 	MACs       [][]byte      `codec:"macs"`
+	Tag        PacketTag     `codec:"tag"`
+	Version    PacketVersion `codec:"vers"`
 	seqno      PacketSeqno
 }
 

--- a/go/kbcmf/tweakable_encryptor_test.go
+++ b/go/kbcmf/tweakable_encryptor_test.go
@@ -177,14 +177,10 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers [][]BoxPublicK
 
 	for gid, group := range receivers {
 		var macKey SymmetricKey
-		if len(receivers) > 1 {
-			if err := randomFill(macKey[:]); err != nil {
-				return err
-			}
-			pes.macGroups = append(pes.macGroups, macKey)
-		} else {
-			gid = -1
+		if err := randomFill(macKey[:]); err != nil {
+			return err
 		}
+		pes.macGroups = append(pes.macGroups, macKey)
 
 		if pes.options.corruptMacKey != nil {
 			pes.options.corruptMacKey(&macKey, gid)
@@ -199,11 +195,9 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers [][]BoxPublicK
 			d[kidString] = struct{}{}
 
 			pt := receiverKeysPlaintext{
-				GroupID:    gid,
+				GroupID:    (gid | groupIDMask),
 				SessionKey: pes.sessionKey[:],
-			}
-			if gid >= 0 {
-				pt.MACKey = macKey[:]
+				MACKey:     macKey[:],
 			}
 
 			if pes.options.corruptReceiverKeysPlaintext != nil {


### PR DESCRIPTION
- introduce a new outer ephemeral key
- that's actually the encryption key for truly anonymous senders
- for hidden senders, it encrypts the actually sender public key
- test coverage
- remove cruft from the test library