### PR TITLE
Don't use a goroutine for logging to external loggers

### DIFF
--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -322,7 +322,7 @@ func (log *Standard) logToExternalLoggers(level keybase1.LogLevel, format string
 	}
 
 	for _, externalLogger := range log.externalLoggers {
-		go externalLogger.Log(level, format, args)
+		externalLogger.Log(level, format, args)
 	}
 }
 


### PR DESCRIPTION
We made log forwarding from service to client happen asynchronously due to some potential performance concerns, but this has the retrospectively-predictable consequences that:

* messages arrive out of order to the client!
* the client completes a command and exits, but how many of the log messages from that command we see at the client's end depends on a race between the client process exiting, and receiving messages.

The result is that log forwarding's pretty useless.  I think we should either disable the asynchrony (as in this PR) or do something more drastic to log forwarding itself.

@oconnor663 @patrickxb @maxtaco What do you think?