### PR TITLE
Contextify SecretStore

### DIFF
--- a/go/engine/deprovision.go
+++ b/go/engine/deprovision.go
@@ -5,8 +5,9 @@ package engine
 
 import (
 	"fmt"
-	"github.com/keybase/client/go/libkb"
 	"os"
+
+	"github.com/keybase/client/go/libkb"
 )
 
 // XXX: THIS ENGINE DELETES SECRET KEYS. Deleting the wrong secret keys can
@@ -79,7 +80,7 @@ func (e *DeprovisionEngine) Run(ctx *Context) (err error) {
 		ctx.LogUI.Warning("To do that yourself, use `keybase device remove` from a logged in device.")
 	}
 
-	if clearSecretErr := libkb.ClearStoredSecret(e.username); clearSecretErr != nil {
+	if clearSecretErr := libkb.ClearStoredSecret(e.G(), e.username); clearSecretErr != nil {
 		e.G().Log.Warning("ClearStoredSecret error: %s", clearSecretErr)
 	}
 

--- a/go/engine/deprovision_test.go
+++ b/go/engine/deprovision_test.go
@@ -63,7 +63,7 @@ func TestDeprovision(t *testing.T) {
 	}
 
 	if libkb.HasSecretStore() {
-		secretStore := libkb.NewSecretStore(fu.NormalizedUsername())
+		secretStore := libkb.NewSecretStore(tc.G, fu.NormalizedUsername())
 		_, err := secretStore.RetrieveSecret()
 		if err != nil {
 			t.Fatal(err)
@@ -103,7 +103,7 @@ func TestDeprovision(t *testing.T) {
 	}
 
 	if libkb.HasSecretStore() {
-		secretStore := libkb.NewSecretStore(fu.NormalizedUsername())
+		secretStore := libkb.NewSecretStore(tc.G, fu.NormalizedUsername())
 		secret, err := secretStore.RetrieveSecret()
 		if err == nil {
 			t.Errorf("Unexpectedly got secret %v", secret)
@@ -148,7 +148,7 @@ func TestDeprovisionLoggedOut(t *testing.T) {
 	}
 
 	if libkb.HasSecretStore() {
-		secretStore := libkb.NewSecretStore(fu.NormalizedUsername())
+		secretStore := libkb.NewSecretStore(tc.G, fu.NormalizedUsername())
 		_, err := secretStore.RetrieveSecret()
 		if err != nil {
 			t.Fatal(err)
@@ -193,7 +193,7 @@ func TestDeprovisionLoggedOut(t *testing.T) {
 	}
 
 	if libkb.HasSecretStore() {
-		secretStore := libkb.NewSecretStore(fu.NormalizedUsername())
+		secretStore := libkb.NewSecretStore(tc.G, fu.NormalizedUsername())
 		secret, err := secretStore.RetrieveSecret()
 		if err == nil {
 			t.Errorf("Unexpectedly got secret %v", secret)

--- a/go/engine/login_state_test.go
+++ b/go/engine/login_state_test.go
@@ -333,7 +333,7 @@ func userHasStoredSecretViaConfiguredAccounts(tc *libkb.TestContext, username st
 }
 
 func userHasStoredSecretViaSecretStore(tc *libkb.TestContext, username string) bool {
-	secretStore := libkb.NewSecretStore(libkb.NewNormalizedUsername(username))
+	secretStore := libkb.NewSecretStore(tc.G, libkb.NewNormalizedUsername(username))
 	if secretStore == nil {
 		tc.T.Errorf("SecretStore for %s unexpectedly nil", username)
 		return false
@@ -399,7 +399,7 @@ func TestLoginWithStoredSecret(t *testing.T) {
 
 	Logout(tc)
 
-	if err := libkb.ClearStoredSecret(fu.NormalizedUsername()); err != nil {
+	if err := libkb.ClearStoredSecret(tc.G, fu.NormalizedUsername()); err != nil {
 		t.Error(err)
 	}
 
@@ -508,7 +508,7 @@ func TestLoginWithPassphraseWithStore(t *testing.T) {
 		t.Error(err)
 	}
 
-	if err := libkb.ClearStoredSecret(fu.NormalizedUsername()); err != nil {
+	if err := libkb.ClearStoredSecret(tc.G, fu.NormalizedUsername()); err != nil {
 		t.Error(err)
 	}
 
@@ -549,7 +549,7 @@ func TestSignupWithStoreThenLogin(t *testing.T) {
 		t.Error(err)
 	}
 
-	if err := libkb.ClearStoredSecret(fu.NormalizedUsername()); err != nil {
+	if err := libkb.ClearStoredSecret(tc.G, fu.NormalizedUsername()); err != nil {
 		t.Error(err)
 	}
 

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -131,7 +131,7 @@ func (e *PaperKeyGen) makeEncKey(seed []byte) error {
 func (e *PaperKeyGen) getClientHalfFromSecretStore() ([]byte, libkb.PassphraseGeneration, error) {
 	zeroGen := libkb.PassphraseGeneration(0)
 
-	secretStore := libkb.NewSecretStore(e.arg.Me.GetNormalizedName())
+	secretStore := libkb.NewSecretStore(e.G(), e.arg.Me.GetNormalizedName())
 	if secretStore == nil {
 		return nil, zeroGen, errors.New("No secret store available")
 	}

--- a/go/engine/passphrase_change.go
+++ b/go/engine/passphrase_change.go
@@ -394,7 +394,7 @@ func (c *PassphraseChange) findAndDecryptPrivatePGPKeys(ctx *Context) ([]libkb.G
 		blocks = append(blocks, syncKeys...)
 	}
 
-	secretRetriever := libkb.NewSecretStore(c.me.GetNormalizedName())
+	secretRetriever := libkb.NewSecretStore(c.G(), c.me.GetNormalizedName())
 
 	// avoid duplicates:
 	keys := make(map[keybase1.KID]libkb.GenericKey)

--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -174,7 +174,7 @@ func (s *SignupEngine) registerDevice(a libkb.LoginContext, ctx *Context, device
 		// (instead of when we first get the value of
 		// StoreSecret) as the username may change during the
 		// signup process.
-		secretStore := libkb.NewSecretStore(s.me.GetNormalizedName())
+		secretStore := libkb.NewSecretStore(s.G(), s.me.GetNormalizedName())
 		secret, err := s.lks.GetSecret(a)
 		if err != nil {
 			return err

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -166,7 +166,7 @@ func TestLocalKeySecurityStoreSecret(t *testing.T) {
 	defer tc.Cleanup()
 	fu := NewFakeUserOrBust(t, "se")
 
-	secretStore := libkb.NewSecretStore(fu.NormalizedUsername())
+	secretStore := libkb.NewSecretStore(tc.G, fu.NormalizedUsername())
 	if secretStore == nil {
 		t.Skip("No SecretStore on this platform")
 	}

--- a/go/engine/track_token.go
+++ b/go/engine/track_token.go
@@ -159,7 +159,7 @@ func (e *TrackToken) storeRemoteTrack(ctx *Context) (err error) {
 	var secretStore libkb.SecretStore
 	if e.arg.Me != nil {
 		e.lockedKey.SetUID(e.arg.Me.GetUID())
-		secretStore = libkb.NewSecretStore(e.arg.Me.GetNormalizedName())
+		secretStore = libkb.NewSecretStore(e.G(), e.arg.Me.GetNormalizedName())
 	}
 	// need to unlock private key
 	e.signingKeyPriv, err = e.lockedKey.PromptAndUnlock(ctx.LoginContext, "tracking signature", e.lockedWhich, secretStore, ctx.SecretUI, nil, e.arg.Me)

--- a/go/libkb/keyring.go
+++ b/go/libkb/keyring.go
@@ -341,7 +341,7 @@ func (k *Keyrings) GetSecretKeyWithoutPrompt(lctx LoginContext, ska SecretKeyArg
 		err = NoUsernameError{}
 		return nil, err
 	}
-	secretStore := NewSecretStore(ska.Me.GetNormalizedName())
+	secretStore := NewSecretStore(k.G(), ska.Me.GetNormalizedName())
 
 	skb, _, err := k.GetSecretKeyLocked(lctx, ska)
 	if err != nil {
@@ -369,7 +369,7 @@ func (k *Keyrings) GetSecretKeyAndSKBWithPrompt(lctx LoginContext, ska SecretKey
 	var secretStore SecretStore
 	if ska.Me != nil {
 		skb.SetUID(ska.Me.GetUID())
-		secretStore = NewSecretStore(ska.Me.GetNormalizedName())
+		secretStore = NewSecretStore(k.G(), ska.Me.GetNormalizedName())
 	}
 	if key, err = skb.PromptAndUnlock(lctx, reason, which, secretStore, secretUI, nil, ska.Me); err != nil {
 		key = nil

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -618,7 +618,7 @@ func (s *LoginState) passphraseLogin(lctx LoginContext, username, passphrase str
 		if err != nil {
 			return err
 		}
-		secretStore := NewSecretStore(NewNormalizedUsername(username))
+		secretStore := NewSecretStore(s.G(), NewNormalizedUsername(username))
 		// Ignore any errors storing the secret.
 		storeSecretErr := secretStore.StoreSecret(secret)
 		if storeSecretErr != nil {
@@ -798,7 +798,7 @@ func (s *LoginState) loginWithStoredSecret(lctx LoginContext, username string) e
 	}
 
 	getSecretKeyFn := func(keyrings *Keyrings, me *User) (GenericKey, error) {
-		secretRetriever := NewSecretStore(me.GetNormalizedName())
+		secretRetriever := NewSecretStore(s.G(), me.GetNormalizedName())
 		ska := SecretKeyArg{
 			Me:      me,
 			KeyType: DeviceSigningKeyType,
@@ -826,7 +826,7 @@ func (s *LoginState) loginWithPassphrase(lctx LoginContext, username, passphrase
 	getSecretKeyFn := func(keyrings *Keyrings, me *User) (GenericKey, error) {
 		var secretStorer SecretStorer
 		if storeSecret {
-			secretStorer = NewSecretStore(me.GetNormalizedName())
+			secretStorer = NewSecretStore(s.G(), me.GetNormalizedName())
 		}
 		key, err := keyrings.GetSecretKeyWithPassphrase(lctx, me, passphrase, secretStorer)
 		if err != nil {

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -21,8 +21,8 @@ type SecretStore interface {
 	ClearSecret() error
 }
 
-// NewSecretStore(username string), HasSecretStore(),
-// GetUsersWithStoredSecrets() ([]string, error), and
+// NewSecretStore(g *GlobalContext, username string), HasSecretStore(),
+// GetUsersWithStoredSecrets(g *GlobalContext) ([]string, error), and
 // GetTerminalPrompt() are defined in platform-specific files.
 
 func GetConfiguredAccounts(g *GlobalContext) ([]keybase1.ConfiguredAccount, error) {

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -63,8 +63,8 @@ func GetConfiguredAccounts(g *GlobalContext) ([]keybase1.ConfiguredAccount, erro
 	return configuredAccounts, nil
 }
 
-func ClearStoredSecret(username NormalizedUsername) error {
-	secretStore := NewSecretStore(username)
+func ClearStoredSecret(g *GlobalContext, username NormalizedUsername) error {
+	secretStore := NewSecretStore(g, username)
 	if secretStore == nil {
 		return nil
 	}

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -41,7 +41,7 @@ func GetConfiguredAccounts(g *GlobalContext) ([]keybase1.ConfiguredAccount, erro
 		}
 	}
 
-	storedSecretUsernames, err := GetUsersWithStoredSecrets()
+	storedSecretUsernames, err := GetUsersWithStoredSecrets(g)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libkb/secret_store_external.go
+++ b/go/libkb/secret_store_external.go
@@ -40,6 +40,8 @@ type secretStoreAccountName struct {
 	accountName      string
 }
 
+var _ SecretStore = secretStoreAccountName{}
+
 func (s secretStoreAccountName) StoreSecret(secret []byte) (err error) {
 	return s.externalKeyStore.StoreSecret(s.accountName, secret)
 }
@@ -52,7 +54,7 @@ func (s secretStoreAccountName) ClearSecret() (err error) {
 	return s.externalKeyStore.ClearSecret(s.accountName)
 }
 
-func NewSecretStore(username NormalizedUsername) SecretStore {
+func NewSecretStore(g *GlobalContext, username NormalizedUsername) SecretStore {
 	externalKeyStore := getGlobalExternalKeyStore()
 	if externalKeyStore == nil {
 		return nil

--- a/go/libkb/secret_store_external.go
+++ b/go/libkb/secret_store_external.go
@@ -67,7 +67,7 @@ func HasSecretStore() bool {
 	return getGlobalExternalKeyStore() != nil
 }
 
-func GetUsersWithStoredSecrets() ([]string, error) {
+func GetUsersWithStoredSecrets(g *GlobalContext) ([]string, error) {
 	externalKeyStore := getGlobalExternalKeyStore()
 	if externalKeyStore == nil {
 		return nil, nil

--- a/go/libkb/secret_store_ios.go
+++ b/go/libkb/secret_store_ios.go
@@ -45,7 +45,7 @@ func HasSecretStore() bool {
 	return true
 }
 
-func GetUsersWithStoredSecrets() ([]string, error) {
+func GetUsersWithStoredSecrets(g *GlobalContext) ([]string, error) {
 	return keychain.GetAccountsForService(G.Env.GetStoredSecretServiceName())
 }
 

--- a/go/libkb/secret_store_ios.go
+++ b/go/libkb/secret_store_ios.go
@@ -19,11 +19,11 @@ func (k KeychainSecretStore) getServiceName() string {
 }
 
 func (k KeychainSecretStore) getAccessGroup() string {
+	// GetStoredSecretAccessGroup MUST be "" for the simulator
 	return k.G().Env.GetStoredSecretAccessGroup()
 }
 
 func (k KeychainSecretStore) StoreSecret(secret []byte) (err error) {
-	// GetStoredSecretAccessGroup MUST be "" for the simulator
 	item := keychain.NewGenericPassword(k.getServiceName(), k.accountName, "", secret, k.getAccessGroup())
 	item.SetSynchronizable(keychain.SynchronizableNo)
 	item.SetAccessible(keychain.AccessibleWhenUnlockedThisDeviceOnly)

--- a/go/libkb/secret_store_ios.go
+++ b/go/libkb/secret_store_ios.go
@@ -5,13 +5,14 @@
 
 package libkb
 
-import (
-	keychain "github.com/keybase/go-keychain"
-)
+import keychain "github.com/keybase/go-keychain"
 
 type KeychainSecretStore struct {
+	Contextified
 	accountName string
 }
+
+var _ SecretStore = KeychainSecretStore{}
 
 func (k KeychainSecretStore) StoreSecret(secret []byte) (err error) {
 	// GetStoredSecretAccessGroup MUST be "" for the simulator
@@ -33,8 +34,11 @@ func (k KeychainSecretStore) ClearSecret() (err error) {
 	return keychain.DeleteItem(query)
 }
 
-func NewSecretStore(username NormalizedUsername) SecretStore {
-	return KeychainSecretStore{string(username)}
+func NewSecretStore(g *GlobalContext, username NormalizedUsername) SecretStore {
+	return KeychainSecretStore{
+		Contextified: NewContextified(g),
+		accountName:  string(username),
+	}
 }
 
 func HasSecretStore() bool {

--- a/go/libkb/secret_store_none.go
+++ b/go/libkb/secret_store_none.go
@@ -5,7 +5,7 @@
 
 package libkb
 
-func NewSecretStore(username NormalizedUsername) SecretStore {
+func NewSecretStore(g *GlobalContext, username NormalizedUsername) SecretStore {
 	return nil
 }
 

--- a/go/libkb/secret_store_none.go
+++ b/go/libkb/secret_store_none.go
@@ -13,7 +13,7 @@ func HasSecretStore() bool {
 	return false
 }
 
-func GetUsersWithStoredSecrets() ([]string, error) {
+func GetUsersWithStoredSecrets(g *GlobalContext) ([]string, error) {
 	return nil, nil
 }
 

--- a/go/libkb/secret_store_osx.go
+++ b/go/libkb/secret_store_osx.go
@@ -89,7 +89,7 @@ func HasSecretStore() bool {
 	return true
 }
 
-func GetUsersWithStoredSecrets() ([]string, error) {
+func GetUsersWithStoredSecrets(g *GlobalContext) ([]string, error) {
 	return kc.GetAllAccountNames(G.Env.GetStoredSecretServiceName())
 }
 

--- a/go/libkb/secret_store_osx.go
+++ b/go/libkb/secret_store_osx.go
@@ -12,10 +12,13 @@ import (
 )
 
 type KeychainSecretStore struct {
+	Contextified
 	accountName NormalizedUsername
 }
 
-func (kss *KeychainSecretStore) StoreSecret(secret []byte) (err error) {
+var _ SecretStore = KeychainSecretStore{}
+
+func (kss KeychainSecretStore) StoreSecret(secret []byte) (err error) {
 	G.Log.Debug("+ StoreSecret(%s, %d)", kss.accountName, len(secret))
 	defer func() {
 		G.Log.Debug("- StoreSecret -> %s", ErrToOk(err))
@@ -32,7 +35,7 @@ func (kss *KeychainSecretStore) StoreSecret(secret []byte) (err error) {
 	return
 }
 
-func (kss *KeychainSecretStore) RetrieveSecret() (secret []byte, err error) {
+func (kss KeychainSecretStore) RetrieveSecret() (secret []byte, err error) {
 	G.Log.Debug("+ RetrieveSecret(%s)", kss.accountName)
 	defer func() {
 		G.Log.Debug("- RetrieveSecret -> %s", ErrToOk(err))
@@ -56,7 +59,7 @@ func (kss *KeychainSecretStore) RetrieveSecret() (secret []byte, err error) {
 	return
 }
 
-func (kss *KeychainSecretStore) ClearSecret() (err error) {
+func (kss KeychainSecretStore) ClearSecret() (err error) {
 	G.Log.Debug("+ ClearSecret(%s)", kss.accountName)
 	defer func() {
 		G.Log.Debug("- ClearSecret -> %s", ErrToOk(err))
@@ -75,8 +78,11 @@ func (kss *KeychainSecretStore) ClearSecret() (err error) {
 	return
 }
 
-func NewSecretStore(username NormalizedUsername) SecretStore {
-	return &KeychainSecretStore{username}
+func NewSecretStore(g *GlobalContext, username NormalizedUsername) SecretStore {
+	return KeychainSecretStore{
+		Contextified: NewContextified(g),
+		accountName:  username,
+	}
 }
 
 func HasSecretStore() bool {

--- a/go/libkb/secret_store_osx.go
+++ b/go/libkb/secret_store_osx.go
@@ -18,32 +18,36 @@ type KeychainSecretStore struct {
 
 var _ SecretStore = KeychainSecretStore{}
 
-func (kss KeychainSecretStore) StoreSecret(secret []byte) (err error) {
-	G.Log.Debug("+ StoreSecret(%s, %d)", kss.accountName, len(secret))
+func (k KeychainSecretStore) getServiceName() string {
+	return k.G().Env.GetStoredSecretServiceName()
+}
+
+func (k KeychainSecretStore) StoreSecret(secret []byte) (err error) {
+	k.G().Log.Debug("+ StoreSecret(%s, %d)", k.accountName, len(secret))
 	defer func() {
-		G.Log.Debug("- StoreSecret -> %s", ErrToOk(err))
+		k.G().Log.Debug("- StoreSecret -> %s", ErrToOk(err))
 	}()
 
 	// base64-encode to make it easy to work with Keychain Access.
 	encodedSecret := base64.StdEncoding.EncodeToString(secret)
 	attributes := kc.GenericPasswordAttributes{
-		ServiceName: G.Env.GetStoredSecretServiceName(),
-		AccountName: kss.accountName.String(),
+		ServiceName: k.getServiceName(),
+		AccountName: k.accountName.String(),
 		Password:    []byte(encodedSecret),
 	}
 	err = kc.RemoveAndAddGenericPassword(&attributes)
 	return
 }
 
-func (kss KeychainSecretStore) RetrieveSecret() (secret []byte, err error) {
-	G.Log.Debug("+ RetrieveSecret(%s)", kss.accountName)
+func (k KeychainSecretStore) RetrieveSecret() (secret []byte, err error) {
+	k.G().Log.Debug("+ RetrieveSecret(%s)", k.accountName)
 	defer func() {
-		G.Log.Debug("- RetrieveSecret -> %s", ErrToOk(err))
+		k.G().Log.Debug("- RetrieveSecret -> %s", ErrToOk(err))
 	}()
 
 	attributes := kc.GenericPasswordAttributes{
-		ServiceName: G.Env.GetStoredSecretServiceName(),
-		AccountName: kss.accountName.String(),
+		ServiceName: k.getServiceName(),
+		AccountName: k.accountName.String(),
 	}
 
 	encodedSecret, err := kc.FindGenericPassword(&attributes)
@@ -59,15 +63,15 @@ func (kss KeychainSecretStore) RetrieveSecret() (secret []byte, err error) {
 	return
 }
 
-func (kss KeychainSecretStore) ClearSecret() (err error) {
-	G.Log.Debug("+ ClearSecret(%s)", kss.accountName)
+func (k KeychainSecretStore) ClearSecret() (err error) {
+	k.G().Log.Debug("+ ClearSecret(%s)", k.accountName)
 	defer func() {
-		G.Log.Debug("- ClearSecret -> %s", ErrToOk(err))
+		k.G().Log.Debug("- ClearSecret -> %s", ErrToOk(err))
 	}()
 
 	attributes := kc.GenericPasswordAttributes{
-		ServiceName: G.Env.GetStoredSecretServiceName(),
-		AccountName: kss.accountName.String(),
+		ServiceName: k.getServiceName(),
+		AccountName: k.accountName.String(),
 	}
 
 	err = kc.FindAndRemoveGenericPassword(&attributes)
@@ -90,7 +94,7 @@ func HasSecretStore() bool {
 }
 
 func GetUsersWithStoredSecrets(g *GlobalContext) ([]string, error) {
-	return kc.GetAllAccountNames(G.Env.GetStoredSecretServiceName())
+	return kc.GetAllAccountNames(g.Env.GetStoredSecretServiceName())
 }
 
 func GetTerminalPrompt() string {

--- a/go/libkb/secret_store_test.go
+++ b/go/libkb/secret_store_test.go
@@ -112,8 +112,8 @@ func TestSecretStoreOps(t *testing.T) {
 	}
 }
 
-func getUsersWithPrefixAndStoredSecrets(prefix string) ([]string, error) {
-	usernames, err := GetUsersWithStoredSecrets()
+func getUsersWithPrefixAndStoredSecrets(g *GlobalContext, prefix string) ([]string, error) {
+	usernames, err := GetUsersWithStoredSecrets(g)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func TestGetUsersWithStoredSecrets(t *testing.T) {
 
 	prefix := generateTestPrefix(t)
 
-	usernames, err := getUsersWithPrefixAndStoredSecrets(prefix)
+	usernames, err := getUsersWithPrefixAndStoredSecrets(tc.G, prefix)
 	if err != nil {
 		t.Error(err)
 	}
@@ -156,7 +156,7 @@ func TestGetUsersWithStoredSecrets(t *testing.T) {
 		}
 	}
 
-	usernames, err = getUsersWithPrefixAndStoredSecrets(prefix)
+	usernames, err = getUsersWithPrefixAndStoredSecrets(tc.G, prefix)
 	if err != nil {
 		t.Error(err)
 	}
@@ -179,7 +179,7 @@ func TestGetUsersWithStoredSecrets(t *testing.T) {
 		}
 	}
 
-	usernames, err = getUsersWithPrefixAndStoredSecrets(prefix)
+	usernames, err = getUsersWithPrefixAndStoredSecrets(tc.G, prefix)
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/libkb/secret_store_test.go
+++ b/go/libkb/secret_store_test.go
@@ -54,6 +54,9 @@ func TestSecretStoreOps(t *testing.T) {
 		t.Skip("Skipping test since there is no secret store")
 	}
 
+	tc := SetupTest(t, "secret store ops")
+	defer tc.Cleanup()
+
 	prefix := generateTestPrefix(t)
 
 	username := prefix + "username"
@@ -61,7 +64,7 @@ func TestSecretStoreOps(t *testing.T) {
 	expectedSecret1 := []byte("test secret 1")
 	expectedSecret2 := []byte("test secret 2")
 
-	secretStore := NewSecretStore(nu)
+	secretStore := NewSecretStore(tc.G, nu)
 
 	var err error
 
@@ -131,6 +134,9 @@ func TestGetUsersWithStoredSecrets(t *testing.T) {
 		t.Skip("Skipping test since there is no secret store")
 	}
 
+	tc := SetupTest(t, "get users with stored secrets")
+	defer tc.Cleanup()
+
 	prefix := generateTestPrefix(t)
 
 	usernames, err := getUsersWithPrefixAndStoredSecrets(prefix)
@@ -144,7 +150,7 @@ func TestGetUsersWithStoredSecrets(t *testing.T) {
 	expectedUsernames := make([]string, 10)
 	for i := 0; i < len(expectedUsernames); i++ {
 		expectedUsernames[i] = fmt.Sprintf("%saccount with unicode テスト %d", prefix, i)
-		secretStore := NewSecretStore(NewNormalizedUsername(expectedUsernames[i]))
+		secretStore := NewSecretStore(tc.G, NewNormalizedUsername(expectedUsernames[i]))
 		if err := secretStore.StoreSecret([]byte{}); err != nil {
 			t.Error(err)
 		}
@@ -166,7 +172,7 @@ func TestGetUsersWithStoredSecrets(t *testing.T) {
 	}
 
 	for i := 0; i < len(expectedUsernames); i++ {
-		secretStore := NewSecretStore(NewNormalizedUsername(expectedUsernames[i]))
+		secretStore := NewSecretStore(tc.G, NewNormalizedUsername(expectedUsernames[i]))
 		err = secretStore.ClearSecret()
 		if err != nil {
 			t.Error(err)

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -163,7 +163,7 @@ func (tc *TestContext) ResetLoginState() {
 }
 
 func (tc TestContext) ClearAllStoredSecrets() error {
-	usernames, err := GetUsersWithStoredSecrets()
+	usernames, err := GetUsersWithStoredSecrets(tc.G)
 	if err != nil {
 		return err
 	}

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -169,7 +169,7 @@ func (tc TestContext) ClearAllStoredSecrets() error {
 	}
 	for _, username := range usernames {
 		nu := NewNormalizedUsername(username)
-		err = ClearStoredSecret(nu)
+		err = ClearStoredSecret(tc.G, nu)
 		if err != nil {
 			return err
 		}

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -60,7 +60,7 @@ func (h *LoginHandler) RecoverAccountFromEmailAddress(_ context.Context, email s
 }
 
 func (h *LoginHandler) ClearStoredSecret(_ context.Context, arg keybase1.ClearStoredSecretArg) error {
-	return libkb.ClearStoredSecret(libkb.NewNormalizedUsername(arg.Username))
+	return libkb.ClearStoredSecret(h.G(), libkb.NewNormalizedUsername(arg.Username))
 }
 
 func (h *LoginHandler) PaperKey(_ context.Context, sessionID int) error {


### PR DESCRIPTION
Pass in test GlobalContext in SecretStore tests, so
that it doesn't crash when run individually.