### PR TITLE
Track local if user answers 'no' to track remote question

### DIFF
--- a/go/client/identify_ui.go
+++ b/go/client/identify_ui.go
@@ -27,7 +27,7 @@ func (i *IdentifyUIServer) DelegateIdentifyUI(_ context.Context) (int, error) {
 	return 0, libkb.UIDelegationUnavailableError{}
 }
 
-func (i *IdentifyUIServer) Confirm(_ context.Context, arg keybase1.ConfirmArg) (bool, error) {
+func (i *IdentifyUIServer) Confirm(_ context.Context, arg keybase1.ConfirmArg) (keybase1.ConfirmResult, error) {
 	return i.ui.Confirm(&arg.Outcome)
 }
 

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -194,11 +194,12 @@ func (ui *FakeIdentifyUI) FinishSocialProofCheck(proof keybase1.RemoteProof, res
 	}
 	ui.Proofs[proof.Key] = proof.Value
 }
-func (ui *FakeIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (confirmed bool, err error) {
+func (ui *FakeIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (result keybase1.ConfirmResult, err error) {
 	ui.Lock()
 	defer ui.Unlock()
 	ui.Outcome = outcome
-	confirmed = outcome.TrackOptions.BypassConfirm
+	result.IdentityConfirmed = outcome.TrackOptions.BypassConfirm
+	result.RemoteConfirmed = outcome.TrackOptions.BypassConfirm
 	return
 }
 func (ui *FakeIdentifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency) {

--- a/go/engine/pgp_pull.go
+++ b/go/engine/pgp_pull.go
@@ -152,12 +152,12 @@ func (e *PGPPullEngine) processUserWhenLoggedOut(ctx *Context, u string) error {
 	// prompt if the identify is correct
 	outcome := ieng.Outcome().Export()
 	outcome.ForPGPPull = true
-	confirmed, err := ctx.IdentifyUI.Confirm(outcome)
+	result, err := ctx.IdentifyUI.Confirm(outcome)
 	if err != nil {
 		return err
 	}
 
-	if !confirmed {
+	if !result.IdentityConfirmed {
 		e.G().Log.Warning("Not confirmed; skipping key import")
 		return nil
 	}

--- a/go/engine/track.go
+++ b/go/engine/track.go
@@ -67,12 +67,18 @@ func (e *TrackEngine) Run(ctx *Context) error {
 
 	// prompt if the identify is correct
 	outcome := ieng.Outcome().Export()
-	confirmed, err := ctx.IdentifyUI.Confirm(outcome)
+	result, err := ctx.IdentifyUI.Confirm(outcome)
 	if err != nil {
 		return err
 	}
-	if !confirmed {
+	if !result.IdentityConfirmed {
 		return fmt.Errorf("Track not confirmed")
+	}
+
+	// if they didn't specify local only on the command line, then if they answer no to posting
+	// the tracking statement publicly to keybase, change LocalOnly to true here:
+	if !e.arg.Options.LocalOnly && !result.RemoteConfirmed {
+		e.arg.Options.LocalOnly = true
 	}
 
 	targ := &TrackTokenArg{

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -232,7 +232,7 @@ type IdentifyUI interface {
 	Start(string)
 	FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult)
 	FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult)
-	Confirm(*keybase1.IdentifyOutcome) (bool, error)
+	Confirm(*keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error)
 	DisplayCryptocurrency(keybase1.Cryptocurrency)
 	DisplayKey(keybase1.IdentifyKey)
 	ReportLastTrack(*keybase1.TrackSummary)

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -1559,6 +1559,11 @@ type LinkCheckResult struct {
 	Hint        *SigHint     `codec:"hint,omitempty" json:"hint,omitempty"`
 }
 
+type ConfirmResult struct {
+	IdentityConfirmed bool `codec:"identityConfirmed" json:"identityConfirmed"`
+	RemoteConfirmed   bool `codec:"remoteConfirmed" json:"remoteConfirmed"`
+}
+
 type DelegateIdentifyUIArg struct {
 }
 
@@ -1630,7 +1635,7 @@ type IdentifyUiInterface interface {
 	FinishSocialProofCheck(context.Context, FinishSocialProofCheckArg) error
 	DisplayCryptocurrency(context.Context, DisplayCryptocurrencyArg) error
 	ReportTrackToken(context.Context, ReportTrackTokenArg) error
-	Confirm(context.Context, ConfirmArg) (bool, error)
+	Confirm(context.Context, ConfirmArg) (ConfirmResult, error)
 	Finish(context.Context, int) error
 }
 
@@ -1883,7 +1888,7 @@ func (c IdentifyUiClient) ReportTrackToken(ctx context.Context, __arg ReportTrac
 	return
 }
 
-func (c IdentifyUiClient) Confirm(ctx context.Context, __arg ConfirmArg) (res bool, err error) {
+func (c IdentifyUiClient) Confirm(ctx context.Context, __arg ConfirmArg) (res ConfirmResult, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.identifyUi.confirm", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -124,10 +124,10 @@ func (u *RemoteIdentifyUI) FinishSocialProofCheck(p keybase1.RemoteProof, lcr ke
 	return
 }
 
-func (u *RemoteIdentifyUI) Confirm(io *keybase1.IdentifyOutcome) (confirmed bool, err error) {
+func (u *RemoteIdentifyUI) Confirm(io *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
 	if u.skipPrompt {
 		u.G().Log.Debug("skipping Confirm for %q", io.Username)
-		return true, nil
+		return keybase1.ConfirmResult{IdentityConfirmed: true}, nil
 	}
 	return u.uicli.Confirm(context.TODO(), keybase1.ConfirmArg{SessionID: u.sessionID, Outcome: *io})
 }

--- a/go/systests/delegate_ui_test.go
+++ b/go/systests/delegate_ui_test.go
@@ -130,11 +130,13 @@ func (d *delegateUI) DisplayCryptocurrency(context.Context, keybase1.DisplayCryp
 	}
 	return nil
 }
-func (d *delegateUI) Confirm(context.Context, keybase1.ConfirmArg) (bool, error) {
-	if err := d.checkStarted(); err != nil {
-		return false, err
+func (d *delegateUI) Confirm(context.Context, keybase1.ConfirmArg) (res keybase1.ConfirmResult, err error) {
+	if err = d.checkStarted(); err != nil {
+		return res, err
 	}
-	return true, nil
+	res.IdentityConfirmed = true
+	res.RemoteConfirmed = true
+	return res, nil
 }
 func (d *delegateUI) Finish(context.Context, int) error {
 	if err := d.checkStarted(); err != nil {

--- a/protocol/avdl/identify_ui.avdl
+++ b/protocol/avdl/identify_ui.avdl
@@ -60,6 +60,11 @@ protocol identifyUi {
     union { null, SigHint } hint;
   }
 
+  record ConfirmResult {
+    boolean identityConfirmed; // true if the user answers yes to "Is this the user you wanted?"
+    boolean remoteConfirmed;   // true if the user answers yes to "Publicly write tracking statement to server?"
+  }
+
   // The IdentifyUI can be delegated to another process.  Call this function
   // to initialize the delegated UI; it returns the sessionID to use in the
   // following exchange. Return 0 on failure.
@@ -75,6 +80,6 @@ protocol identifyUi {
   void finishSocialProofCheck(int sessionID, RemoteProof rp, LinkCheckResult lcr);
   void displayCryptocurrency(int sessionID, Cryptocurrency c);
   void reportTrackToken(int sessionID, string trackToken);
-  boolean confirm(int sessionID, IdentifyOutcome outcome);
+  ConfirmResult confirm(int sessionID, IdentifyOutcome outcome);
   void finish(int sessionID);
 }

--- a/protocol/json/identify_ui.json
+++ b/protocol/json/identify_ui.json
@@ -447,6 +447,16 @@
       "name" : "hint",
       "type" : [ "null", "SigHint" ]
     } ]
+  }, {
+    "type" : "record",
+    "name" : "ConfirmResult",
+    "fields" : [ {
+      "name" : "identityConfirmed",
+      "type" : "boolean"
+    }, {
+      "name" : "remoteConfirmed",
+      "type" : "boolean"
+    } ]
   } ],
   "messages" : {
     "delegateIdentifyUI" : {
@@ -560,7 +570,7 @@
         "name" : "outcome",
         "type" : "IdentifyOutcome"
       } ],
-      "response" : "boolean"
+      "response" : "ConfirmResult"
     },
     "finish" : {
       "request" : [ {


### PR DESCRIPTION
Required protocol change to IdentifyUI.Confirm to
encapsulate identity and remote confirmations.

r? @maxtaco 

@keybase/react-hackers (esp. @MarcoPolo):  IdentifyUI.Confirm result changed from bool to ConfirmResult.  You should set ConfirmResult.RemoteConfirmed to true in all cases as desktop app always does remote tracks.  And set ConfirmResult.IdentityConfirmed as you did before in response to this call.