### PR TITLE
Use unique secret store services for each test

### DIFF
--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -4,7 +4,6 @@
 package libkb
 
 import (
-	keybase1 "github.com/keybase/client/go/protocol"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	keybase1 "github.com/keybase/client/go/protocol"
 )
 
 type NullConfiguration struct{}
@@ -108,8 +109,12 @@ type TestParameters struct {
 	GPGHome        string
 	GPGOptions     []string
 	Debug          bool
-	Devel          bool // Whether we are in Devel Mode
-	RuntimeDir     string
+	// Whether we are in Devel Mode
+	Devel bool
+	// If we're in dev mode, the name for this test, with a random
+	// suffix.
+	DevelName  string
+	RuntimeDir string
 }
 
 func (tp TestParameters) GetDebug() (bool, bool) {

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -4,6 +4,7 @@
 package libkb
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -763,7 +764,9 @@ func (e *Env) GetStoredSecretServiceName() string {
 		panic("Invalid run mode")
 	}
 	if e.Test.Devel {
-		serviceName = serviceName + "-test"
+		// Append DevelName so that tests won't clobber each
+		// other's keychain entries on shutdown.
+		serviceName += fmt.Sprintf("-test (%s)", e.Test.DevelName)
 	}
 	return serviceName
 }

--- a/go/libkb/secret_store_external.go
+++ b/go/libkb/secret_store_external.go
@@ -7,6 +7,10 @@ package libkb
 
 import "sync"
 
+// TODO: Make this implementation use GetStoredSecretServiceName(), as
+// otherwise tests will clobber each other's passwords. See
+// https://keybase.atlassian.net/browse/CORE-1934 .
+
 // ExternalKeyStore is the interface for the actual (external) keystore.
 type ExternalKeyStore interface {
 	RetrieveSecret(username string) ([]byte, error)

--- a/go/libkb/secret_store_test.go
+++ b/go/libkb/secret_store_test.go
@@ -4,11 +4,8 @@
 package libkb
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 )
 
@@ -41,14 +38,6 @@ func (tss *TestSecretStore) ClearSecret() error {
 	return nil
 }
 
-func generateTestPrefix(t *testing.T) string {
-	buf := make([]byte, 5)
-	if _, err := rand.Read(buf); err != nil {
-		t.Fatal(err)
-	}
-	return fmt.Sprintf("test_%s_", hex.EncodeToString(buf))
-}
-
 func TestSecretStoreOps(t *testing.T) {
 	if !HasSecretStore() {
 		t.Skip("Skipping test since there is no secret store")
@@ -57,10 +46,7 @@ func TestSecretStoreOps(t *testing.T) {
 	tc := SetupTest(t, "secret store ops")
 	defer tc.Cleanup()
 
-	prefix := generateTestPrefix(t)
-
-	username := prefix + "username"
-	nu := NewNormalizedUsername(username)
+	nu := NewNormalizedUsername("username")
 	expectedSecret1 := []byte("test secret 1")
 	expectedSecret2 := []byte("test secret 2")
 
@@ -112,23 +98,6 @@ func TestSecretStoreOps(t *testing.T) {
 	}
 }
 
-func getUsersWithPrefixAndStoredSecrets(g *GlobalContext, prefix string) ([]string, error) {
-	usernames, err := GetUsersWithStoredSecrets(g)
-	if err != nil {
-		return nil, err
-	}
-
-	var testUsernames []string
-
-	for _, username := range usernames {
-		if strings.HasPrefix(username, prefix) {
-			testUsernames = append(testUsernames, username)
-		}
-	}
-
-	return testUsernames, nil
-}
-
 func TestGetUsersWithStoredSecrets(t *testing.T) {
 	if !HasSecretStore() {
 		t.Skip("Skipping test since there is no secret store")
@@ -137,9 +106,7 @@ func TestGetUsersWithStoredSecrets(t *testing.T) {
 	tc := SetupTest(t, "get users with stored secrets")
 	defer tc.Cleanup()
 
-	prefix := generateTestPrefix(t)
-
-	usernames, err := getUsersWithPrefixAndStoredSecrets(tc.G, prefix)
+	usernames, err := GetUsersWithStoredSecrets(tc.G)
 	if err != nil {
 		t.Error(err)
 	}
@@ -149,14 +116,14 @@ func TestGetUsersWithStoredSecrets(t *testing.T) {
 
 	expectedUsernames := make([]string, 10)
 	for i := 0; i < len(expectedUsernames); i++ {
-		expectedUsernames[i] = fmt.Sprintf("%saccount with unicode テスト %d", prefix, i)
+		expectedUsernames[i] = fmt.Sprintf("account with unicode テスト %d", i)
 		secretStore := NewSecretStore(tc.G, NewNormalizedUsername(expectedUsernames[i]))
 		if err := secretStore.StoreSecret([]byte{}); err != nil {
 			t.Error(err)
 		}
 	}
 
-	usernames, err = getUsersWithPrefixAndStoredSecrets(tc.G, prefix)
+	usernames, err = GetUsersWithStoredSecrets(tc.G)
 	if err != nil {
 		t.Error(err)
 	}
@@ -179,7 +146,7 @@ func TestGetUsersWithStoredSecrets(t *testing.T) {
 		}
 	}
 
-	usernames, err = getUsersWithPrefixAndStoredSecrets(tc.G, prefix)
+	usernames, err = GetUsersWithStoredSecrets(tc.G)
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -6,6 +6,8 @@
 package libkb
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -179,7 +181,7 @@ func (tc TestContext) ClearAllStoredSecrets() error {
 
 var setupTestMu sync.Mutex
 
-func setupTestContext(tb testing.TB, nm string, tcPrev *TestContext) (tc TestContext, err error) {
+func setupTestContext(tb testing.TB, name string, tcPrev *TestContext) (tc TestContext, err error) {
 	setupTestMu.Lock()
 	defer setupTestMu.Unlock()
 
@@ -191,13 +193,20 @@ func setupTestContext(tb testing.TB, nm string, tcPrev *TestContext) (tc TestCon
 		g.Log = logger.NewTestLogger(tb)
 	}
 
+	buf := make([]byte, 5)
+	if _, err = rand.Read(buf); err != nil {
+		return
+	}
+	// Uniquify name, since multiple tests may use the same name.
+	name = fmt.Sprintf("%s %s", name, hex.EncodeToString(buf))
+
 	g.Init()
-	g.Log.Debug("SetupTest %s", nm)
+	g.Log.Debug("SetupTest %s", name)
 
 	// Set up our testing parameters.  We might add others later on
 	if tcPrev != nil {
 		tc.Tp = tcPrev.Tp
-	} else if tc.Tp.Home, err = ioutil.TempDir(os.TempDir(), nm); err != nil {
+	} else if tc.Tp.Home, err = ioutil.TempDir(os.TempDir(), name); err != nil {
 		return
 	}
 
@@ -207,6 +216,7 @@ func setupTestContext(tb testing.TB, nm string, tcPrev *TestContext) (tc TestCon
 
 	tc.Tp.Debug = false
 	tc.Tp.Devel = true
+	tc.Tp.DevelName = name
 
 	g.Env.Test = tc.Tp
 
@@ -247,9 +257,9 @@ func setupTestContext(tb testing.TB, nm string, tcPrev *TestContext) (tc TestCon
 	return
 }
 
-func SetupTest(tb testing.TB, nm string) (tc TestContext) {
+func SetupTest(tb testing.TB, name string) (tc TestContext) {
 	var err error
-	tc, err = setupTestContext(tb, nm, nil)
+	tc, err = setupTestContext(tb, name, nil)
 	if err != nil {
 		tb.Fatal(err)
 	}


### PR DESCRIPTION
This will prevent tests from clobbering each other's
keychain entries.

This will fix
https://keybase.atlassian.net/browse/CORE-1934 .