### PR TITLE
openpgp: Add S2K Gnu Dummy support

### DIFF
--- a/go/vendor/github.com/keybase/go-crypto/openpgp/packet/packet.go
+++ b/go/vendor/github.com/keybase/go-crypto/openpgp/packet/packet.go
@@ -11,8 +11,8 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/des"
-	"github.com/keybase/go-crypto/openpgp/errors"
 	"golang.org/x/crypto/cast5"
+	"github.com/keybase/go-crypto/openpgp/errors"
 	"io"
 	"math/big"
 )

--- a/go/vendor/github.com/keybase/go-crypto/openpgp/packet/symmetric_key_encrypted.go
+++ b/go/vendor/github.com/keybase/go-crypto/openpgp/packet/symmetric_key_encrypted.go
@@ -48,6 +48,9 @@ func (ske *SymmetricKeyEncrypted) parse(r io.Reader) error {
 	if err != nil {
 		return err
 	}
+	if ske.s2k == nil {
+		return errors.UnsupportedError("can't use dummy S2K for symmetric key encryption")
+	}
 
 	encryptedKey := make([]byte, maxSessionKeySizeInBytes)
 	// The session key may follow. We just have to try and read to find

--- a/go/vendor/github.com/keybase/go-crypto/openpgp/patch.sh
+++ b/go/vendor/github.com/keybase/go-crypto/openpgp/patch.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 patch < sig-v3.patch
+patch < s2k-gnu-dummy.patch
 find . -type f -name '*.go' -exec sed -i'' -e 's/golang.org\/x\/crypto\/openpgp/github.com\/keybase\/go-crypto\/openpgp/' {} \;
 find . -type f -name '*.go-e' -exec rm {} \;
 go test ./...

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -99,8 +99,8 @@
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp",
-			"revision": "67d171e99a58463b40209d86a5438f5b708d8ad0",
-			"revisionTime": "2015-10-12T10:46:00-04:00"
+			"revision": "00b6b19a18594ef73187d6c1d98c8acb11a55b07",
+			"revisionTime": "2015-11-24T14:07:52-05:00"
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp/armor",
@@ -124,13 +124,13 @@
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp/packet",
-			"revision": "67d171e99a58463b40209d86a5438f5b708d8ad0",
-			"revisionTime": "2015-10-12T10:46:00-04:00"
+			"revision": "00b6b19a18594ef73187d6c1d98c8acb11a55b07",
+			"revisionTime": "2015-11-24T14:07:52-05:00"
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp/s2k",
-			"revision": "67d171e99a58463b40209d86a5438f5b708d8ad0",
-			"revisionTime": "2015-10-12T10:46:00-04:00"
+			"revision": "00b6b19a18594ef73187d6c1d98c8acb11a55b07",
+			"revisionTime": "2015-11-24T14:07:52-05:00"
 		},
 		{
 			"path": "github.com/keybase/go-framed-msgpack-rpc",


### PR DESCRIPTION
Most of the work is in our fork of Go-Crypto. 
This commit just vendors it in.