### PR TITLE
Fix 'no device id set' lksec error during provisioning

### DIFF
--- a/go/libkb/lksec.go
+++ b/go/libkb/lksec.go
@@ -108,7 +108,7 @@ func (s *LKSec) Load(lctx LoginContext) (err error) {
 		s.G().Log.Debug("| Fetching secret key")
 		devid := s.G().Env.GetDeviceID()
 		if devid.IsNil() {
-			err = fmt.Errorf("no device id set")
+			err = fmt.Errorf("lksec load: no device id set, thus can't fetch secret key")
 			return err
 		}
 

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -625,12 +625,14 @@ func (s *LoginState) passphraseLogin(lctx LoginContext, username, passphrase str
 		if err != nil {
 			// Ignore any errors storing the secret.
 			s.G().Log.Debug("(ignoring) error getting lksec secret for SecretStore: %s", err)
+			return nil
 		}
 		secretStore := NewSecretStore(s.G(), NewNormalizedUsername(username))
 		storeSecretErr := secretStore.StoreSecret(secret)
 		if storeSecretErr != nil {
 			// Ignore any errors storing the secret.
 			s.G().Log.Debug("(ignoring) StoreSecret error: %s", storeSecretErr)
+			return nil
 		}
 	}
 

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -616,13 +616,14 @@ func (s *LoginState) passphraseLogin(lctx LoginContext, username, passphrase str
 		lks := NewLKSec(pps, res.uid, s.G())
 		secret, err := lks.GetSecret(lctx)
 		if err != nil {
-			return err
+			// Ignore any errors storing the secret.
+			s.G().Log.Debug("(ignoring) error getting lksec secret for SecretStore: %s", err)
 		}
 		secretStore := NewSecretStore(s.G(), NewNormalizedUsername(username))
-		// Ignore any errors storing the secret.
 		storeSecretErr := secretStore.StoreSecret(secret)
 		if storeSecretErr != nil {
-			s.G().Log.Warning("StoreSecret error: %s", storeSecretErr)
+			// Ignore any errors storing the secret.
+			s.G().Log.Debug("(ignoring) StoreSecret error: %s", storeSecretErr)
 		}
 	}
 

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -607,7 +607,14 @@ func (s *LoginState) passphraseLogin(lctx LoginContext, username, passphrase str
 	}
 
 	s.G().Log.Debug("passphraseLogin success")
-	if storeSecret {
+
+	// If storeSecret is set and there is a device ID, then try to store the secret.
+	//
+	// Ignore most of the errors.
+	//
+	// Can get here without a device ID during device provisioning as this is used to establish a login
+	// session before the device keys are generated.
+	if storeSecret && !s.G().Env.GetDeviceID().IsNil() {
 		s.G().Log.Debug("passphraseLogin: storeSecret set, so saving secret in secret store")
 		pps := lctx.PassphraseStreamCache().PassphraseStream()
 		if pps == nil {

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -369,7 +369,7 @@ func (t *TestSecretUI) GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.
 
 func (t *TestSecretUI) GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (keybase1.GetPassphraseRes, error) {
 	t.CalledGetKBPassphrase = true
-	return keybase1.GetPassphraseRes{Passphrase: t.Passphrase}, nil
+	return keybase1.GetPassphraseRes{Passphrase: t.Passphrase, StoreSecret: t.StoreSecret}, nil
 }
 
 func (t *TestSecretUI) GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) (string, error) {


### PR DESCRIPTION
During LoginWithPrompt, it's possible for the user to
select secret storage and it tries to store the secret
right after establishing a login session with the API
server.

This works fine on a provisioned device, but if the
LoginWithPrompt is being called to establish a login
session for device provsioning, then there is no device
ID yet, and thus secret storage is not possible.

Before this change, LoginWithPrompt would return an
error and provisioning would bail out.

It would be nice to turn off the checkbox for secret
store in this case.  That would require more code
changes.  This is a minimal change to fix the bug.

Fixes part of keybase/keybase-issues#1822
where there is a "no device id set" error.

r? @maxtaco 