### PR TITLE
Move some info log to debug on version restart

### DIFF
--- a/go/client/versionfix.go
+++ b/go/client/versionfix.go
@@ -72,7 +72,7 @@ func FixVersionClash(g *libkb.GlobalContext, cl libkb.CommandLine) (err error) {
 		return err
 	}
 	time.Sleep(10 * time.Millisecond)
-	g.Log.Info("Waiting for shutdown...")
+	g.Log.Debug("Waiting for shutdown...")
 	time.Sleep(1 * time.Second)
 
 	if serviceConfig.ForkType == keybase1.ForkType_AUTO {

--- a/go/libkb/socket.go
+++ b/go/libkb/socket.go
@@ -5,8 +5,9 @@ package libkb
 
 import (
 	"fmt"
-	rpc "github.com/keybase/go-framed-msgpack-rpc"
 	"net"
+
+	rpc "github.com/keybase/go-framed-msgpack-rpc"
 )
 
 // NewSocket() (Socket, err) is defined in the various platform-specific socket_*.go files.
@@ -55,7 +56,7 @@ func (g *GlobalContext) GetSocket(clearError bool) (net.Conn, rpc.Transporter, e
 		needWrapper = true
 	} else if g.SocketWrapper.xp != nil && !g.SocketWrapper.xp.IsConnected() {
 		// need reconnect
-		G.Log.Info("rpc transport disconnected, reconnecting...")
+		G.Log.Debug("rpc transport disconnected, reconnecting...")
 		needWrapper = true
 	}
 

--- a/go/service/ctl.go
+++ b/go/service/ctl.go
@@ -27,7 +27,7 @@ func NewCtlHandler(xp rpc.Transporter, v *Service, g *libkb.GlobalContext) *CtlH
 
 // Stop is called on the rpc keybase.1.ctl.stop, which shuts down the service.
 func (c *CtlHandler) Stop(_ context.Context, args keybase1.StopArg) error {
-	c.G().Log.Info("Received stop(%d) RPC; shutting down", args.ExitCode)
+	c.G().Log.Debug("Received stop(%d) RPC; shutting down", args.ExitCode)
 	go func() {
 		c.service.Stop(args.ExitCode)
 	}()


### PR DESCRIPTION
The output is a bit verbose after getting the version restart, so changing these to debug?

