### PR TITLE
gpg: fixes for shell out during login

### DIFF
--- a/go/client/cmd_stress.go
+++ b/go/client/cmd_stress.go
@@ -325,3 +325,6 @@ func (c *CmdStress) GetSecret(_ context.Context, arg keybase1.GetSecretArg) (res
 func (c *CmdStress) GetPassphrase(_ context.Context, arg keybase1.GetPassphraseArg) (res keybase1.GetPassphraseRes, err error) {
 	return
 }
+func (c *CmdStress) Sign(_ context.Context, arg keybase1.SignArg) (string, error) {
+	return "", nil
+}

--- a/go/client/main.go
+++ b/go/client/main.go
@@ -12,6 +12,6 @@ var G = libkb.G
 var GlobUI *UI
 
 func InitUI() {
-	GlobUI = &UI{}
+	GlobUI = &UI{Contextified: libkb.NewContextified(G)}
 	G.SetUI(GlobUI)
 }

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -19,6 +19,7 @@ import (
 )
 
 type UI struct {
+	libkb.Contextified
 	Terminal    *Terminal
 	SecretEntry *SecretEntry
 }
@@ -410,7 +411,7 @@ func (ui *UI) GetLogUI() libkb.LogUI {
 }
 
 func (ui *UI) GetGPGUI() libkb.GPGUI {
-	return NewGPGUI(ui.GetTerminalUI(), false)
+	return NewGPGUI(ui.G(), ui.GetTerminalUI(), false)
 }
 
 func (ui *UI) GetProvisionUI(role libkb.KexRole) libkb.ProvisionUI {

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
 )
 
 func SetupEngineTest(tb testing.TB, name string) libkb.TestContext {
@@ -162,7 +163,7 @@ func (fu *FakeUser) LoginWithSecretUI(secui libkb.SecretUI, g *libkb.GlobalConte
 		SecretUI:    secui,
 		LoginUI:     &libkb.TestLoginUI{Username: fu.Username},
 	}
-	li := NewLogin(g, libkb.DeviceTypeDesktop, fu.Username)
+	li := NewLogin(g, libkb.DeviceTypeDesktop, fu.Username, keybase1.ClientType_CLI)
 	return RunEngine(li, ctx)
 }
 

--- a/go/engine/gpg_test.go
+++ b/go/engine/gpg_test.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
 )
 
@@ -45,6 +46,18 @@ func (g *gpgtestui) WantToAddGPGKey(_ context.Context, _ int) (bool, error) {
 func (g *gpgtestui) ConfirmDuplicateKeyChosen(_ context.Context, _ int) (bool, error) {
 	g.keyChosenCount++
 	return true, nil
+}
+
+func (g *gpgtestui) Sign(_ context.Context, arg keybase1.SignArg) (string, error) {
+	fp, err := libkb.PGPFingerprintFromSlice(arg.Fingerprint)
+	if err != nil {
+		return "", err
+	}
+	cli := libkb.G.GetGpgClient()
+	if err := cli.Configure(); err != nil {
+		return "", err
+	}
+	return cli.Sign(*fp, arg.Msg)
 }
 
 type gpgcanceltestui struct {

--- a/go/engine/login.go
+++ b/go/engine/login.go
@@ -7,8 +7,8 @@ package engine
 
 import (
 	"errors"
-
 	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
 )
 
 var errNoConfig = errors.New("No user config available")
@@ -19,16 +19,18 @@ type Login struct {
 	libkb.Contextified
 	deviceType string
 	username   string
+	clientType keybase1.ClientType
 }
 
 // NewLogin creates a Login engine.  username is optional.
 // deviceType should be libkb.DeviceTypeDesktop or
 // libkb.DeviceTypeMobile.
-func NewLogin(g *libkb.GlobalContext, deviceType, username string) *Login {
+func NewLogin(g *libkb.GlobalContext, deviceType string, username string, ct keybase1.ClientType) *Login {
 	return &Login{
 		Contextified: libkb.NewContextified(g),
 		deviceType:   deviceType,
 		username:     username,
+		clientType:   ct,
 	}
 }
 
@@ -78,6 +80,7 @@ func (e *Login) Run(ctx *Context) error {
 	darg := &LoginProvisionArg{
 		DeviceType: e.deviceType,
 		Username:   e.username,
+		ClientType: e.clientType,
 	}
 	deng := NewLoginProvision(e.G(), darg)
 	return RunEngine(deng, ctx)

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -31,6 +31,7 @@ type LoginProvision struct {
 type LoginProvisionArg struct {
 	DeviceType string // desktop or mobile
 	Username   string // optional
+	ClientType keybase1.ClientType
 }
 
 // NewLoginProvision creates a LoginProvision engine.  username
@@ -613,7 +614,7 @@ func (e *LoginProvision) chooseGPGKey(ctx *Context) (libkb.GenericKey, error) {
 	}
 
 	// create a GPGKey shell around gpg cli with fp, kid
-	return libkb.NewGPGKey(e.G(), fp, kid), nil
+	return libkb.NewGPGKey(e.G(), fp, kid, ctx.GPGUI, e.arg.ClientType), nil
 }
 
 // chooseAndImportGPGKey asks the user to select a gpg key to use,

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -155,7 +155,7 @@ func TestLogin(t *testing.T) {
 		SecretUI:    &libkb.TestSecretUI{},
 		GPGUI:       &gpgtestui{},
 	}
-	eng := NewLogin(tcY.G, libkb.DeviceTypeDesktop, "")
+	eng := NewLogin(tcY.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 
 	var wg sync.WaitGroup
 
@@ -215,7 +215,7 @@ func TestProvisionPassphraseFail(t *testing.T) {
 		SecretUI:    &libkb.TestSecretUI{},
 		GPGUI:       &gpgtestui{},
 	}
-	eng := NewLogin(tcY.G, libkb.DeviceTypeDesktop, "")
+	eng := NewLogin(tcY.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	err := RunEngine(eng, ctx)
 	if err == nil {
 		t.Fatal("expected login to fail, but it ran without error")
@@ -248,7 +248,7 @@ func TestProvisionPassphraseNoKeys(t *testing.T) {
 		SecretUI:    &libkb.TestSecretUI{Passphrase: passphrase},
 		GPGUI:       &gpgtestui{},
 	}
-	eng := NewLogin(tc.G, libkb.DeviceTypeDesktop, "")
+	eng := NewLogin(tc.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -283,7 +283,7 @@ func TestProvisionPassphraseSyncedPGP(t *testing.T) {
 		SecretUI:    u1.NewSecretUI(),
 		GPGUI:       &gpgtestui{},
 	}
-	eng := NewLogin(tc.G, libkb.DeviceTypeDesktop, "")
+	eng := NewLogin(tc.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -341,7 +341,7 @@ func TestProvisionPaper(t *testing.T) {
 		LoginUI:     provLoginUI,
 		GPGUI:       &gpgtestui{},
 	}
-	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "")
+	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -394,7 +394,7 @@ func TestProvisionGPGImport(t *testing.T) {
 		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
 		GPGUI:       &gpgtestui{},
 	}
-	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "")
+	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -438,7 +438,7 @@ func TestProvisionGPGSign(t *testing.T) {
 		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
 		GPGUI:       &gpgtestui{},
 	}
-	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "")
+	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +487,7 @@ func TestProvisionGPGSignSecretStore(t *testing.T) {
 		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
 		GPGUI:       &gpgtestui{},
 	}
-	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "")
+	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -530,7 +530,7 @@ func TestProvisionDupDevice(t *testing.T) {
 		SecretUI:    &libkb.TestSecretUI{},
 		GPGUI:       &gpgtestui{},
 	}
-	eng := NewLogin(tcY.G, libkb.DeviceTypeDesktop, "")
+	eng := NewLogin(tcY.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 
 	var wg sync.WaitGroup
 
@@ -595,7 +595,7 @@ func TestProvisionPassphraseNoKeysMultipleAccounts(t *testing.T) {
 		SecretUI:    &libkb.TestSecretUI{Passphrase: passphrase},
 		GPGUI:       &gpgtestui{},
 	}
-	eng := NewLogin(tc.G, libkb.DeviceTypeDesktop, username)
+	eng := NewLogin(tc.G, libkb.DeviceTypeDesktop, username, keybase1.ClientType_CLI)
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/pgp_pull.go
+++ b/go/engine/pgp_pull.go
@@ -171,9 +171,7 @@ func (e *PGPPullEngine) processUserWhenLoggedOut(ctx *Context, u string) error {
 
 func (e *PGPPullEngine) Run(ctx *Context) error {
 
-	e.gpgClient = libkb.NewGpgCLI(libkb.GpgCLIArg{
-		LogUI: ctx.LogUI,
-	})
+	e.gpgClient = libkb.NewGpgCLI(e.G(), ctx.LogUI)
 	err := e.gpgClient.Configure()
 	if err != nil {
 		return err

--- a/go/engine/pgp_pull_test.go
+++ b/go/engine/pgp_pull_test.go
@@ -34,9 +34,7 @@ func untrackUserList(tc libkb.TestContext, fu *FakeUser, trackedUsers []string) 
 }
 
 func createGpgClient(tc libkb.TestContext) *libkb.GpgCLI {
-	gpgClient := libkb.NewGpgCLI(libkb.GpgCLIArg{
-		LogUI: tc.G.UI.GetLogUI(),
-	})
+	gpgClient := libkb.NewGpgCLI(tc.G, tc.G.UI.GetLogUI())
 	err := gpgClient.Configure()
 	if err != nil {
 		tc.T.Fatal("Error while configuring gpg client.")

--- a/go/engine/pgp_update.go
+++ b/go/engine/pgp_update.go
@@ -64,9 +64,7 @@ func (e *PGPUpdateEngine) Run(ctx *Context) error {
 		return fmt.Errorf("You have more than one PGP key. To update all of them, use --all.")
 	}
 
-	gpgCLI := libkb.NewGpgCLI(libkb.GpgCLIArg{
-		LogUI: ctx.LogUI,
-	})
+	gpgCLI := libkb.NewGpgCLI(e.G(), ctx.LogUI)
 	err = gpgCLI.Configure()
 	if err != nil {
 		return err

--- a/go/engine/pgp_update_test.go
+++ b/go/engine/pgp_update_test.go
@@ -61,9 +61,7 @@ func TestPGPUpdate(t *testing.T) {
 	// Modify the key by deleting the subkey.
 	bundle.Subkeys = []openpgp.Subkey{}
 
-	gpgCLI := libkb.NewGpgCLI(libkb.GpgCLIArg{
-		LogUI: tc.G.UI.GetLogUI(),
-	})
+	gpgCLI := libkb.NewGpgCLI(tc.G, tc.G.UI.GetLogUI())
 	err := gpgCLI.Configure()
 	if err != nil {
 		t.Fatal("Error initializing GpgCLI", err)

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -155,7 +155,7 @@ func TestTrackAfterRevoke(t *testing.T) {
 		LoginUI:     &libkb.TestLoginUI{Username: u.Username},
 		GPGUI:       &gpgtestui{},
 	}
-	li := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "")
+	li := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
 	if err := RunEngine(li, ctx); err != nil {
 		t.Fatal(err)
 	}

--- a/go/kbtest/ui.go
+++ b/go/kbtest/ui.go
@@ -44,3 +44,7 @@ func (g *gpgtestui) WantToAddGPGKey(_ context.Context, _ int) (bool, error) {
 func (g *gpgtestui) ConfirmDuplicateKeyChosen(_ context.Context, _ int) (bool, error) {
 	return true, nil
 }
+
+func (g *gpgtestui) Sign(_ context.Context, _ keybase1.SignArg) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -360,7 +360,7 @@ func (g *GlobalContext) OutputBytes(b []byte) {
 
 func (g *GlobalContext) GetGpgClient() *GpgCLI {
 	if g.GpgClient == nil {
-		g.GpgClient = NewGpgCLI(GpgCLIArg{})
+		g.GpgClient = NewGpgCLI(g, nil)
 	}
 	return g.GpgClient
 }

--- a/go/libkb/gpg_cli_test.go
+++ b/go/libkb/gpg_cli_test.go
@@ -34,7 +34,7 @@ func TestGPGImportSecret(t *testing.T) {
 	if err := tc.GenerateGPGKeyring("no@no.no"); err != nil {
 		t.Fatal(err)
 	}
-	cli := NewGpgCLI(GpgCLIArg{})
+	cli := NewGpgCLI(tc.G, nil)
 	if err := cli.Configure(); err != nil {
 		t.Fatal(err)
 	}

--- a/go/libkb/pgp_key.go
+++ b/go/libkb/pgp_key.go
@@ -58,6 +58,15 @@ func PGPFingerprintFromHex(s string) (*PGPFingerprint, error) {
 	return ret, err
 }
 
+func PGPFingerprintFromSlice(b []byte) (*PGPFingerprint, error) {
+	if len(b) != PGPFingerprintLen {
+		return nil, fmt.Errorf("Bad fingerprint; wrong length: %d", PGPFingerprintLen)
+	}
+	var fp PGPFingerprint
+	copy(fp[:], b)
+	return &fp, nil
+}
+
 func PGPFingerprintFromHexNoError(s string) *PGPFingerprint {
 	if len(s) == 0 {
 		return nil

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -1174,6 +1174,13 @@ func (c FavoriteClient) FavoriteList(ctx context.Context, sessionID int) (res []
 	return
 }
 
+type ClientType int
+
+const (
+	ClientType_CLI ClientType = 0
+	ClientType_GUI ClientType = 1
+)
+
 type GPGKey struct {
 	Algorithm  string        `codec:"algorithm" json:"algorithm"`
 	KeyID      string        `codec:"keyID" json:"keyID"`
@@ -1205,11 +1212,17 @@ type SelectKeyArg struct {
 	Keys      []GPGKey `codec:"keys" json:"keys"`
 }
 
+type SignArg struct {
+	Msg         []byte `codec:"msg" json:"msg"`
+	Fingerprint []byte `codec:"fingerprint" json:"fingerprint"`
+}
+
 type GpgUiInterface interface {
 	WantToAddGPGKey(context.Context, int) (bool, error)
 	ConfirmDuplicateKeyChosen(context.Context, int) (bool, error)
 	SelectKeyAndPushOption(context.Context, SelectKeyAndPushOptionArg) (SelectKeyRes, error)
 	SelectKey(context.Context, SelectKeyArg) (string, error)
+	Sign(context.Context, SignArg) (string, error)
 }
 
 func GpgUiProtocol(i GpgUiInterface) rpc.Protocol {
@@ -1280,6 +1293,22 @@ func GpgUiProtocol(i GpgUiInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"sign": {
+				MakeArg: func() interface{} {
+					ret := make([]SignArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]SignArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]SignArg)(nil), args)
+						return
+					}
+					ret, err = i.Sign(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -1307,6 +1336,11 @@ func (c GpgUiClient) SelectKeyAndPushOption(ctx context.Context, __arg SelectKey
 
 func (c GpgUiClient) SelectKey(ctx context.Context, __arg SelectKeyArg) (res string, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.gpgUi.selectKey", []interface{}{__arg}, &res)
+	return
+}
+
+func (c GpgUiClient) Sign(ctx context.Context, __arg SignArg) (res string, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.gpgUi.sign", []interface{}{__arg}, &res)
 	return
 }
 
@@ -2134,9 +2168,10 @@ type GetConfiguredAccountsArg struct {
 }
 
 type LoginArg struct {
-	SessionID  int    `codec:"sessionID" json:"sessionID"`
-	DeviceType string `codec:"deviceType" json:"deviceType"`
-	Username   string `codec:"username" json:"username"`
+	SessionID  int        `codec:"sessionID" json:"sessionID"`
+	DeviceType string     `codec:"deviceType" json:"deviceType"`
+	Username   string     `codec:"username" json:"username"`
+	ClientType ClientType `codec:"clientType" json:"clientType"`
 }
 
 type ClearStoredSecretArg struct {

--- a/go/service/gpg.go
+++ b/go/service/gpg.go
@@ -38,3 +38,6 @@ func (r *RemoteGPGUI) WantToAddGPGKey(ctx context.Context, _ int) (bool, error) 
 func (r *RemoteGPGUI) ConfirmDuplicateKeyChosen(ctx context.Context, _ int) (bool, error) {
 	return r.uicli.ConfirmDuplicateKeyChosen(ctx, r.sessionID)
 }
+func (r *RemoteGPGUI) Sign(ctx context.Context, arg keybase1.SignArg) (string, error) {
+	return r.uicli.Sign(ctx, arg)
+}

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -90,6 +90,6 @@ func (h *LoginHandler) Login(_ context.Context, arg keybase1.LoginArg) error {
 		SecretUI:    h.getSecretUI(arg.SessionID),
 		GPGUI:       h.getGPGUI(arg.SessionID),
 	}
-	eng := engine.NewLogin(h.G(), arg.DeviceType, arg.Username)
+	eng := engine.NewLogin(h.G(), arg.DeviceType, arg.Username, arg.ClientType)
 	return engine.RunEngine(eng, ctx)
 }

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -67,7 +67,7 @@ func (n *signupUI) GetLoginUI() libkb.LoginUI {
 }
 
 func (n *signupUI) GetGPGUI() libkb.GPGUI {
-	return client.NewGPGUI(n.GetTerminalUI(), false)
+	return client.NewGPGUI(n.G(), n.GetTerminalUI(), false)
 }
 
 func (n *signupSecretUI) GetNewPassphrase(arg keybase1.GetNewPassphraseArg) (res keybase1.GetPassphraseRes, err error) {

--- a/protocol/avdl/common.avdl
+++ b/protocol/avdl/common.avdl
@@ -81,4 +81,9 @@ protocol Common {
 		CRITICAL_6,
 		FATAL_7
 	}
+
+	enum ClientType {
+		CLI_0,
+		GUI_1
+	}
 }

--- a/protocol/avdl/gpg_ui.avdl
+++ b/protocol/avdl/gpg_ui.avdl
@@ -20,4 +20,5 @@ protocol gpgUi {
   boolean confirmDuplicateKeyChosen(int sessionID);
   SelectKeyRes selectKeyAndPushOption(int sessionID, array<GPGKey> keys);
   string selectKey(int sessionID, array<GPGKey> keys);
+  string sign(bytes msg, bytes fingerprint);
 }

--- a/protocol/avdl/login.avdl
+++ b/protocol/avdl/login.avdl
@@ -18,11 +18,11 @@ protocol login {
 
   /**
     Performs login.  deviceType should be libkb.DeviceTypeDesktop
-    or libkb.DeviceTypeMobile.  username is optional.  
-    If the current device isn't provisioned, this function will 
+    or libkb.DeviceTypeMobile.  username is optional.
+    If the current device isn't provisioned, this function will
     provision it.
     */
-  void login(int sessionID, string deviceType, string username);
+  void login(int sessionID, string deviceType, string username, ClientType clientType);
 
   /**
     Removes any existing stored secret for the given username.

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -843,6 +843,10 @@ export type gpgUi_Stream = {
 
 export type gpgUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
+export type gpgUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
 export type gpgUi_GPGKey = {
   algorithm: string;
   keyID: string;
@@ -1584,6 +1588,8 @@ export type login_Stream = {
 }
 
 export type login_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
+
+export type login_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
 export type login_ConfiguredAccount = {
   username: string;

--- a/protocol/js/keybase_v1.js
+++ b/protocol/js/keybase_v1.js
@@ -119,6 +119,10 @@ export default {
       'error': 5,
       'critical': 6,
       'fatal': 7
+    },
+    'ClientType': {
+      'cli': 0,
+      'gui': 1
     }
   },
   'identify': {
@@ -352,6 +356,10 @@ export default {
       'error': 5,
       'critical': 6,
       'fatal': 7
+    },
+    'ClientType': {
+      'cli': 0,
+      'gui': 1
     }
   },
   'loginUi': {

--- a/protocol/json/gpg_ui.json
+++ b/protocol/json/gpg_ui.json
@@ -159,6 +159,10 @@
     "name" : "LogLevel",
     "symbols" : [ "NONE_0", "DEBUG_1", "INFO_2", "NOTICE_3", "WARN_4", "ERROR_5", "CRITICAL_6", "FATAL_7" ]
   }, {
+    "type" : "enum",
+    "name" : "ClientType",
+    "symbols" : [ "CLI_0", "GUI_1" ]
+  }, {
     "type" : "record",
     "name" : "GPGKey",
     "fields" : [ {
@@ -229,6 +233,16 @@
           "type" : "array",
           "items" : "GPGKey"
         }
+      } ],
+      "response" : "string"
+    },
+    "sign" : {
+      "request" : [ {
+        "name" : "msg",
+        "type" : "bytes"
+      }, {
+        "name" : "fingerprint",
+        "type" : "bytes"
       } ],
       "response" : "string"
     }

--- a/protocol/json/login.json
+++ b/protocol/json/login.json
@@ -159,6 +159,10 @@
     "name" : "LogLevel",
     "symbols" : [ "NONE_0", "DEBUG_1", "INFO_2", "NOTICE_3", "WARN_4", "ERROR_5", "CRITICAL_6", "FATAL_7" ]
   }, {
+    "type" : "enum",
+    "name" : "ClientType",
+    "symbols" : [ "CLI_0", "GUI_1" ]
+  }, {
     "type" : "record",
     "name" : "ConfiguredAccount",
     "fields" : [ {
@@ -182,7 +186,7 @@
       }
     },
     "login" : {
-      "doc" : "Performs login.  deviceType should be libkb.DeviceTypeDesktop\n    or libkb.DeviceTypeMobile.  username is optional.  \n    If the current device isn't provisioned, this function will \n    provision it.",
+      "doc" : "Performs login.  deviceType should be libkb.DeviceTypeDesktop\n    or libkb.DeviceTypeMobile.  username is optional.\n    If the current device isn't provisioned, this function will\n    provision it.",
       "request" : [ {
         "name" : "sessionID",
         "type" : "int"
@@ -192,6 +196,9 @@
       }, {
         "name" : "username",
         "type" : "string"
+      }, {
+        "name" : "clientType",
+        "type" : "ClientType"
       } ],
       "response" : "null"
     },


### PR DESCRIPTION
- Use --no-tty if we're forking from the service
- Say whether we're calling login from the CLI or the GUI, and use the reverse-sign technique if possible
- allow --emulate-gui flag in login in devel mode, so we can test the service forking GPG
- Ship fingerprints in binary over msgpack
- strip out dead code
- contextify GPG client