### PR TITLE
Broken 32 bit build

### DIFF
--- a/go/kbcmf/const.go
+++ b/go/kbcmf/const.go
@@ -42,4 +42,4 @@ const EncryptionArmorFooter = "END KEYBASE ENCRYPTED MESSAGE"
 
 // groupIDMask is OR'ed into group IDs, so that they all are encoded as full
 // 32-bit integers
-const groupIDMask = 0x80000000
+const groupIDMask uint = 0x80000000

--- a/go/kbcmf/decrypt.go
+++ b/go/kbcmf/decrypt.go
@@ -232,7 +232,7 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 }
 
 func (ds *decryptStream) checkMAC(bl *EncryptionBlock, b []byte) error {
-	gid := (ds.keys.GroupID ^ groupIDMask)
+	gid := int(ds.keys.GroupID ^ groupIDMask)
 
 	if len(bl.MACs) <= gid {
 		return ErrBadGroupID(gid)

--- a/go/kbcmf/encrypt.go
+++ b/go/kbcmf/encrypt.go
@@ -198,7 +198,7 @@ func (es *encryptStream) init(sender BoxSecretKey, receivers [][]BoxPublicKey) e
 			}
 
 			pt := receiverKeysPlaintext{
-				GroupID:    (gid | groupIDMask),
+				GroupID:    (uint(gid) | groupIDMask),
 				SessionKey: es.sessionKey[:],
 				MACKey:     macKey[:],
 			}

--- a/go/kbcmf/packets.go
+++ b/go/kbcmf/packets.go
@@ -6,7 +6,7 @@ package kbcmf
 import ()
 
 type receiverKeysPlaintext struct {
-	GroupID    int    `codec:"gid"`
+	GroupID    uint   `codec:"gid"`
 	MACKey     []byte `codec:"mac,omitempty"`
 	SessionKey []byte `codec:"sess"`
 }


### PR DESCRIPTION
This doesn't show up on 64 bit builds because int (and uint) defaults to 64 bits, depending on GOARCH. It may be better to just declare these int64.
```
c:\work\src\github.com\keybase\client\go\keybase>go build -tags production
# github.com/keybase/client/go/kbcmf
..\kbcmf\decrypt.go:235: constant 2147483648 overflows int
..\kbcmf\encrypt.go:201: constant 2147483648 overflows int
```
@maxtaco