### PR TITLE
kbcmf: build on 32-bit platforms

### DIFF
--- a/go/kbcmf/const.go
+++ b/go/kbcmf/const.go
@@ -42,4 +42,4 @@ const EncryptionArmorFooter = "END KEYBASE ENCRYPTED MESSAGE"
 
 // groupIDMask is OR'ed into group IDs, so that they all are encoded as full
 // 32-bit integers
-const groupIDMask = 0x80000000
+const groupIDMask uint32 = 0x80000000

--- a/go/kbcmf/decrypt.go
+++ b/go/kbcmf/decrypt.go
@@ -232,9 +232,12 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 }
 
 func (ds *decryptStream) checkMAC(bl *EncryptionBlock, b []byte) error {
+	if (ds.keys.GroupID & groupIDMask) != groupIDMask {
+		return ErrBadGroupID(ds.keys.GroupID)
+	}
 	gid := (ds.keys.GroupID ^ groupIDMask)
 
-	if len(bl.MACs) <= gid {
+	if int64(len(bl.MACs)) <= int64(gid) {
 		return ErrBadGroupID(gid)
 	}
 

--- a/go/kbcmf/decrypt.go
+++ b/go/kbcmf/decrypt.go
@@ -237,7 +237,7 @@ func (ds *decryptStream) checkMAC(bl *EncryptionBlock, b []byte) error {
 	}
 	gid := (ds.keys.GroupID ^ groupIDMask)
 
-	if int64(len(bl.MACs)) <= int64(gid) {
+	if gid < 0 || int64(len(bl.MACs)) <= int64(gid) {
 		return ErrBadGroupID(gid)
 	}
 

--- a/go/kbcmf/encrypt.go
+++ b/go/kbcmf/encrypt.go
@@ -198,7 +198,7 @@ func (es *encryptStream) init(sender BoxSecretKey, receivers [][]BoxPublicKey) e
 			}
 
 			pt := receiverKeysPlaintext{
-				GroupID:    (gid | groupIDMask),
+				GroupID:    (uint32(gid) | groupIDMask),
 				SessionKey: es.sessionKey[:],
 				MACKey:     macKey[:],
 			}

--- a/go/kbcmf/packets.go
+++ b/go/kbcmf/packets.go
@@ -6,7 +6,7 @@ package kbcmf
 import ()
 
 type receiverKeysPlaintext struct {
-	GroupID    int    `codec:"gid"`
+	GroupID    uint32 `codec:"gid"`
 	MACKey     []byte `codec:"mac,omitempty"`
 	SessionKey []byte `codec:"sess"`
 }

--- a/go/kbcmf/tweakable_encryptor_test.go
+++ b/go/kbcmf/tweakable_encryptor_test.go
@@ -195,7 +195,7 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers [][]BoxPublicK
 			d[kidString] = struct{}{}
 
 			pt := receiverKeysPlaintext{
-				GroupID:    (gid | groupIDMask),
+				GroupID:    (uint32(gid) | groupIDMask),
 				SessionKey: pes.sessionKey[:],
 				MACKey:     macKey[:],
 			}


### PR DESCRIPTION
- add a test to see what happens if the top bit of a groupID isn't set