### PR TITLE
Check eldest KID in ComputeKeyDiffs, fix ugly warning messages when eldest key not pgp key

### DIFF
--- a/go/client/cmd_pgp_update.go
+++ b/go/client/cmd_pgp_update.go
@@ -56,7 +56,7 @@ func NewCmdPGPUpdate(cl *libcmdline.CommandLine) cli.Command {
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(&CmdPGPUpdate{}, "update", c)
 		},
-		Description: `'keybase pgp update' pushed updated PGP public keys to the server.
+		Description: `'keybase pgp update' pushes updated PGP public keys to the server.
    Public PGP keys are exported from your local GPG keyring and sent
    to the Keybase server, where they will supersede PGP keys that have been
    previously updated. This feature is for updating PGP subkeys, identities,

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -154,7 +154,7 @@ func TestTrackMultiple(t *testing.T) {
 func TestTrackNewUserWithPGP(t *testing.T) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
-	fu := createFakeUserWithPGPSibkey(tc, "track")
+	fu := createFakeUserWithPGPSibkey(tc)
 	Logout(tc)
 
 	tracker := CreateAndSignupFakeUser(tc, "track")

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -151,6 +151,20 @@ func TestTrackMultiple(t *testing.T) {
 	trackAlice(tc, fu)
 }
 
+func TestTrackNewUserWithPGP(t *testing.T) {
+	tc := SetupEngineTest(t, "track")
+	defer tc.Cleanup()
+	fu := createFakeUserWithPGPSibkey(tc, "track")
+	Logout(tc)
+
+	tracker := CreateAndSignupFakeUser(tc, "track")
+	t.Logf("first track:")
+	runTrack(tc, tracker, fu.Username)
+
+	t.Logf("second track:")
+	runTrack(tc, tracker, fu.Username)
+}
+
 // see issue #578
 func TestTrackRetrack(t *testing.T) {
 	tc := SetupEngineTest(t, "track")

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -422,15 +422,12 @@ func trackedKeyFromJSON(jw *jsonw.Wrapper) (TrackedKey, error) {
 		return TrackedKey{}, err
 	}
 	ret.KID = kid
-	// TODO: Should we tolerate missing fingerprints? Will "body.track.key"
-	// ever be a non-PGP key, for example? I'm *very* hesitant about defining a
-	// new type that's basically a FOKID, right after we did all that work to
-	// delete FOKID.
+
+	// It's ok if key_fingerprint doesn't exist.  But if it does, then include it:
 	fp, err := GetPGPFingerprint(jw.AtKey("key_fingerprint"))
-	if err != nil {
-		return TrackedKey{}, err
+	if err == nil && fp != nil {
+		ret.Fingerprint = *fp
 	}
-	ret.Fingerprint = *fp
 	return ret, nil
 }
 

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -438,6 +438,8 @@ func (l *TrackChainLink) GetTrackedKeys() ([]TrackedKey, error) {
 
 	var res []TrackedKey
 
+	// note that this section is the eldest key.
+	// it can contain pgp or nacl keys.
 	keyJSON := l.payloadJSON.AtPath("body.track.key")
 	if !keyJSON.IsNil() {
 		tracked, err := trackedKeyFromJSON(keyJSON)

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -438,18 +438,6 @@ func (l *TrackChainLink) GetTrackedKeys() ([]TrackedKey, error) {
 
 	var res []TrackedKey
 
-	// note that this section is the eldest key.
-	// it can contain pgp or nacl keys.
-	keyJSON := l.payloadJSON.AtPath("body.track.key")
-	if !keyJSON.IsNil() {
-		tracked, err := trackedKeyFromJSON(keyJSON)
-		if err != nil {
-			return nil, err
-		}
-		res = append(res, tracked)
-		set[tracked.KID] = true
-	}
-
 	pgpKeysJSON := l.payloadJSON.AtPath("body.track.pgp_keys")
 	if !pgpKeysJSON.IsNil() {
 		n, err := pgpKeysJSON.Len()
@@ -469,6 +457,18 @@ func (l *TrackChainLink) GetTrackedKeys() ([]TrackedKey, error) {
 		}
 	}
 	return res, nil
+}
+
+func (l *TrackChainLink) GetEldestKID() (kid keybase1.KID, err error) {
+	keyJSON := l.payloadJSON.AtPath("body.track.key")
+	if keyJSON.IsNil() {
+		return kid, nil
+	}
+	tracked, err := trackedKeyFromJSON(keyJSON)
+	if err != nil {
+		return kid, err
+	}
+	return tracked.KID, nil
 }
 
 func (l *TrackChainLink) GetTrackedUID() (keybase1.UID, error) {

--- a/go/libkb/identify_state.go
+++ b/go/libkb/identify_state.go
@@ -95,7 +95,7 @@ func (s *IdentifyState) ComputeKeyDiffs(dhook func(keybase1.IdentifyKey)) {
 	observedEldest := s.u.GetEldestKID()
 	if s.track != nil {
 		trackedEldest := s.track.GetEldestKID()
-		if observedEldest != trackedEldest {
+		if observedEldest.NotEqual(trackedEldest) {
 			diff := TrackDiffNewEldest{tracked: trackedEldest, observed: observedEldest}
 			s.res.KeyDiffs = append(s.res.KeyDiffs, diff)
 			display(observedEldest, diff)

--- a/go/libkb/identify_state.go
+++ b/go/libkb/identify_state.go
@@ -104,9 +104,11 @@ func (s *IdentifyState) ComputeKeyDiffs(dhook func(keybase1.IdentifyKey)) {
 	for _, kid := range found {
 		var diff TrackDiff
 		if s.track != nil && !trackedMap[kid] {
+			G.Log.Warning("TrackDiffNew")
 			diff = TrackDiffNew{}
 			s.res.KeyDiffs = append(s.res.KeyDiffs, diff)
 		} else if s.track != nil {
+			G.Log.Warning("TrackDiffNone")
 			diff = TrackDiffNone{}
 		}
 		display(kid, diff)
@@ -114,6 +116,7 @@ func (s *IdentifyState) ComputeKeyDiffs(dhook func(keybase1.IdentifyKey)) {
 
 	for _, kid := range tracked {
 		if !foundMap[kid] {
+			G.Log.Warning("TrackDiffRevoked")
 			fp := s.u.GetKeyFamily().kid2pgp[kid]
 			diff := TrackDiffRevoked{fp}
 			s.res.KeyDiffs = append(s.res.KeyDiffs, diff)

--- a/go/libkb/track.go
+++ b/go/libkb/track.go
@@ -122,6 +122,14 @@ func (l TrackLookup) GetTrackedKeys() []TrackedKey {
 	return ret
 }
 
+func (l TrackLookup) GetEldestKID() keybase1.KID {
+	ret, err := l.link.GetEldestKID()
+	if err != nil {
+		G.Log.Warning("Error in lookup of eldest KID: %s", err)
+	}
+	return ret
+}
+
 func (l TrackLookup) IsRemote() bool {
 	return l.link.IsRemote()
 }
@@ -294,6 +302,27 @@ func (t TrackDiffRemoteChanged) GetTrackDiffType() keybase1.TrackDiffType {
 }
 func (t TrackDiffRemoteChanged) IsSameAsTracked() bool {
 	return false
+}
+
+type TrackDiffNewEldest struct {
+	tracked  keybase1.KID
+	observed keybase1.KID
+}
+
+func (t TrackDiffNewEldest) BreaksTracking() bool {
+	return true
+}
+func (t TrackDiffNewEldest) IsSameAsTracked() bool {
+	return false
+}
+func (t TrackDiffNewEldest) GetTrackDiffType() keybase1.TrackDiffType {
+	return keybase1.TrackDiffType_NEW_ELDEST
+}
+func (t TrackDiffNewEldest) ToDisplayString() string {
+	return fmt.Sprintf("Changed from %s to %s", t.tracked, t.observed)
+}
+func (t TrackDiffNewEldest) ToDisplayMarkup() *Markup {
+	return NewMarkup(t.ToDisplayString())
 }
 
 func NewTrackLookup(link *TrackChainLink) *TrackLookup {

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -1425,6 +1425,7 @@ const (
 	TrackDiffType_REMOTE_FAIL    TrackDiffType = 6
 	TrackDiffType_REMOTE_WORKING TrackDiffType = 7
 	TrackDiffType_REMOTE_CHANGED TrackDiffType = 8
+	TrackDiffType_NEW_ELDEST     TrackDiffType = 9
 )
 
 type TrackDiff struct {

--- a/protocol/avdl/identify_common.avdl
+++ b/protocol/avdl/identify_common.avdl
@@ -13,7 +13,8 @@ protocol identifyCommon {
 		NEW_5,
 		REMOTE_FAIL_6,
 		REMOTE_WORKING_7,
-		REMOTE_CHANGED_8
+		REMOTE_CHANGED_8,
+		NEW_ELDEST_9
 	}
 
 	record TrackDiff {

--- a/protocol/js/keybase_v1.js
+++ b/protocol/js/keybase_v1.js
@@ -205,7 +205,8 @@ export default {
       'new': 5,
       'remoteFail': 6,
       'remoteWorking': 7,
-      'remoteChanged': 8
+      'remoteChanged': 8,
+      'newEldest': 9
     },
     'TrackStatus': {
       'newOk': 1,
@@ -296,7 +297,8 @@ export default {
       'new': 5,
       'remoteFail': 6,
       'remoteWorking': 7,
-      'remoteChanged': 8
+      'remoteChanged': 8,
+      'newEldest': 9
     },
     'TrackStatus': {
       'newOk': 1,
@@ -608,7 +610,8 @@ export default {
       'new': 5,
       'remoteFail': 6,
       'remoteWorking': 7,
-      'remoteChanged': 8
+      'remoteChanged': 8,
+      'newEldest': 9
     },
     'TrackStatus': {
       'newOk': 1,
@@ -704,7 +707,8 @@ export default {
       'new': 5,
       'remoteFail': 6,
       'remoteWorking': 7,
-      'remoteChanged': 8
+      'remoteChanged': 8,
+      'newEldest': 9
     },
     'TrackStatus': {
       'newOk': 1,
@@ -919,7 +923,8 @@ export default {
       'new': 5,
       'remoteFail': 6,
       'remoteWorking': 7,
-      'remoteChanged': 8
+      'remoteChanged': 8,
+      'newEldest': 9
     },
     'TrackStatus': {
       'newOk': 1,

--- a/protocol/json/identify.json
+++ b/protocol/json/identify.json
@@ -174,7 +174,7 @@
   }, {
     "type" : "enum",
     "name" : "TrackDiffType",
-    "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8" ]
+    "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8", "NEW_ELDEST_9" ]
   }, {
     "type" : "record",
     "name" : "TrackDiff",

--- a/protocol/json/identify_ui.json
+++ b/protocol/json/identify_ui.json
@@ -174,7 +174,7 @@
   }, {
     "type" : "enum",
     "name" : "TrackDiffType",
-    "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8" ]
+    "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8", "NEW_ELDEST_9" ]
   }, {
     "type" : "record",
     "name" : "TrackDiff",

--- a/protocol/json/pgp.json
+++ b/protocol/json/pgp.json
@@ -174,7 +174,7 @@
   }, {
     "type" : "enum",
     "name" : "TrackDiffType",
-    "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8" ]
+    "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8", "NEW_ELDEST_9" ]
   }, {
     "type" : "record",
     "name" : "TrackDiff",

--- a/protocol/json/prove.json
+++ b/protocol/json/prove.json
@@ -174,7 +174,7 @@
   }, {
     "type" : "enum",
     "name" : "TrackDiffType",
-    "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8" ]
+    "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8", "NEW_ELDEST_9" ]
   }, {
     "type" : "record",
     "name" : "TrackDiff",

--- a/protocol/json/track.json
+++ b/protocol/json/track.json
@@ -174,7 +174,7 @@
   }, {
     "type" : "enum",
     "name" : "TrackDiffType",
-    "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8" ]
+    "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8", "NEW_ELDEST_9" ]
   }, {
     "type" : "record",
     "name" : "TrackDiff",


### PR DESCRIPTION
r? @maxtaco 

Fixes https://keybase.atlassian.net/browse/CORE-2112 and also fixes https://keybase.atlassian.net/browse/CORE-231