### PR TITLE
Fix menubar icon when starting from app bundle (Electron)

### DIFF
--- a/desktop/app/main.js
+++ b/desktop/app/main.js
@@ -8,12 +8,17 @@ const ipc = require('electron').ipcMain
 const Window = require('./window')
 const splash = require('./splash')
 const installer = require('./installer')
+const app = require('electron').app
+const path = require('path')
+
+const appPath = app.getAppPath()
+const menubarIconPath = path.resolve(appPath, "Icon.png")
 
 const mb = menubar({
   index: `file://${__dirname}/../renderer/launcher.html`,
   width: 200, height: 250,
   preloadWindow: true,
-  icon: 'Icon.png',
+  icon: menubarIconPath,
   showDockIcon: true
 })
 

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -64,10 +64,14 @@ build() {
   # Copy icon files
   cp $client_dir/osx/Install/appdmg/Keybase.icns .
 
+  # Move menubar icon into app path
+  mv $build_dir/desktop/Icon*.png $build_dir
+
   # Copy and modify package.json to point to main from one dir up
   cp desktop/package.json .
   json -I -f package.json -e 'this.main="desktop/app/main.js"'
 
+  # Including dev dependencies for debug, we should use --production when doing real releases
   npm install #--production
 }
 


### PR DESCRIPTION
Files need to be loaded with appPath for them to resolve when starting from packaged app bundle.

cc @cjb 