### PR TITLE
Always-on main window desktop

### DIFF
--- a/desktop/app/hidden-window-notifications.js
+++ b/desktop/app/hidden-window-notifications.js
@@ -1,10 +1,10 @@
 import Window from './window'
+// TODO: move this to the main renderer
 
 // Electron doesn't currently support showing notifications from the main
 // process, so we'll use a hidden window to show them for us.
 // https://github.com/atom/electron/issues/3359
 const window = new Window('notifier', {show: false})
-window.show()
 
 export default function (title, opts) {
   window.window.webContents.send('notify', title, opts)

--- a/desktop/app/main.js
+++ b/desktop/app/main.js
@@ -39,7 +39,7 @@ if (process.platform === 'darwin') {
   mb.app.on('quit', () => { mb.tray.destroy() })
 }
 
-ipc.on('showMain', () => { mainWindow.show() })
-ipc.on('showTracker', () => { trackerWindow.show() })
+ipc.on('showMain', () => { mainWindow.show(true) })
+ipc.on('showTracker', () => { trackerWindow.show(true) })
 
 splash()

--- a/desktop/app/main.js
+++ b/desktop/app/main.js
@@ -15,13 +15,6 @@ const mb = menubar({
   icon: 'Icon.png'
 })
 
-const trackerWindow = new Window('tracker', {
-  width: 500, height: 300,
-  resizable: false,
-  fullscreen: false,
-  frame: false
-})
-
 const mainWindow = new Window('index', {
   width: 1600,
   height: 1200,
@@ -40,6 +33,5 @@ if (process.platform === 'darwin') {
 }
 
 ipc.on('showMain', () => { mainWindow.show(true) })
-ipc.on('showTracker', () => { trackerWindow.show(true) })
 
 splash()

--- a/desktop/app/window.js
+++ b/desktop/app/window.js
@@ -9,7 +9,7 @@ export default class Window {
     this.releaseDockIcon = null
   }
 
-  show () {
+  show (shouldShowDockIcon) {
     if (this.window) {
       if (!this.window.isFocused()) {
         this.window.focus()
@@ -18,7 +18,7 @@ export default class Window {
     }
 
     this.window = new BrowserWindow(this.opts)
-    this.releaseDockIcon = showDockIcon()
+    this.releaseDockIcon = shouldShowDockIcon ? showDockIcon() : null
     this.window.loadURL(`file://${__dirname}/../renderer/${this.filename}.html`)
 
     this.window.on('closed', () => {

--- a/desktop/app/window.js
+++ b/desktop/app/window.js
@@ -1,5 +1,6 @@
 import BrowserWindow from 'browser-window'
 import showDockIcon from './dockIcon'
+import {app} from 'electron'
 
 export default class Window {
   constructor (filename, opts) {
@@ -7,10 +8,22 @@ export default class Window {
     this.opts = opts || {}
     this.window = null
     this.releaseDockIcon = null
+
+    app.on('before-quit', () => {
+      this.window && this.window.destroy()
+    })
+
+    app.on('ready', () => {
+      this.window = new BrowserWindow({show: false, ...this.opts})
+      this.window.loadURL(`file://${__dirname}/../renderer/${this.filename}.html`)
+    })
   }
 
   show (shouldShowDockIcon) {
     if (this.window) {
+      if (!this.window.isVisible()) {
+        this.window.show()
+      }
       if (!this.window.isFocused()) {
         this.window.focus()
       }
@@ -20,6 +33,18 @@ export default class Window {
     this.window = new BrowserWindow(this.opts)
     this.releaseDockIcon = shouldShowDockIcon ? showDockIcon() : null
     this.window.loadURL(`file://${__dirname}/../renderer/${this.filename}.html`)
+
+    // We don't really want to close the window since it'll keep track of the main app state.
+    // So instead we'll hide it
+    this.window.on('close', event => {
+      // Prevent an actual close
+      event.preventDefault()
+      this.window.hide()
+      if (this.releaseDockIcon) {
+        this.releaseDockIcon()
+        this.releaseDockIcon = null
+      }
+    })
 
     this.window.on('closed', () => {
       this.window = null

--- a/desktop/renderer/launcher.html
+++ b/desktop/renderer/launcher.html
@@ -16,13 +16,11 @@ button {
 </style>
 
 <button type=button id=showMain>Main</button>
-<button type=button id=showTracker>Tracker popup</button>
 <button type=button id=quit>Quit</button>
 
 <script>
 const ipc = require('electron').ipcRenderer;
 
 showMain.addEventListener('click', () => { ipc.send('showMain'); })
-showTracker.addEventListener('click', () => { ipc.send('showTracker'); })
 quit.addEventListener('click', () => { require('remote').require('app').quit(); })
 </script>


### PR DESCRIPTION
Let's talk about this.

## Current Architecture
There is the main thread which handles spawning new windows and the menu bar. This is the node only thread. There is no chromium here. This always exists.

There is the renderer. This is where our main app window is being rendered and our redux store lives and most interactions are happening (including the tracker popup). This (currently) doesn't always exist (i.e. if the main window is closed, it goes away)

## Problems with current architecture

### Single source of truth is transient
It's nice to have one definitive source of truth. Currently that's our main window. The problem with our current implementation is that if we want to spawn a new window using our source of truth we can't.

> why?

Because the main window may not exist, and the main thread does not have the source of truth.

### Possible Solutions
1. We can instead store the state on the main thread.
  1. Now we have to make the main renderer ask the main thread about state everytime it does something (or at least implement some caching/diff logic)

1. We can make the main renderer (the main part of the app) always alive
  1. This means there is no change to our existing code

### React Popups
It's nice to model popups (like the tracker popup) in terms of react components (they are part of the UI, and are themselves composed of react components). 
The problem with our current implementation is that we can only declare react components in the main window. 

### Possible Solutions

1. Meta react component that handles making windows in the main thread. (Wouldn't use react proper since it's node only) instead it would provide similar lifecycle methods to handle when we show the main app and when we show popups.
  1. This seems like a rabbit hole to me 

1. Have an always alive main renderer that uses the existing RemoteComponent abstraction
  1. No code change to support popups, no change in our abstractions.

## Always-on main renderer
So the intersection of solutions to the previous problems lead to an always on renderer that handles all the logic of our app (including popups) and is the single source of truth.

## What happens on Close?

Currently we hide the main window when you hit close.
When you quit the app it actually destroys the window.


@keybase/react-hackers 