### PR TITLE
Installer can lookup bundled version instead of storing in plist

### DIFF
--- a/go/client/cmd_launchd_osx.go
+++ b/go/client/cmd_launchd_osx.go
@@ -228,10 +228,9 @@ func (v *CmdLaunchdList) Run() error {
 
 type CmdLaunchdStatus struct {
 	libkb.Contextified
-	format        string
-	label         string
-	name          string
-	bundleVersion string
+	format string
+	label  string
+	name   string
 }
 
 func NewCmdLaunchdStatusRunner(g *libkb.GlobalContext) *CmdLaunchdStatus {
@@ -250,7 +249,6 @@ func (v *CmdLaunchdStatus) ParseArgv(ctx *cli.Context) error {
 		return fmt.Errorf("No service name specified.")
 	}
 	v.name = args[0]
-	v.bundleVersion = ctx.String("bundle-version")
 	v.format = ctx.String("format")
 	return nil
 }
@@ -258,9 +256,9 @@ func (v *CmdLaunchdStatus) ParseArgv(ctx *cli.Context) error {
 func (v *CmdLaunchdStatus) Run() error {
 	var st keybase1.ServiceStatus
 	if v.name == "service" {
-		st = keybaseServiceStatus(v.G(), v.label, v.bundleVersion)
+		st = keybaseServiceStatus(v.G(), v.label)
 	} else if v.name == "kbfs" {
-		st = kbfsServiceStatus(v.G(), v.label, v.bundleVersion)
+		st = kbfsServiceStatus(v.G(), v.label)
 	} else {
 		return fmt.Errorf("Invalid service name: %s", v.name)
 	}

--- a/go/libkb/version.go
+++ b/go/libkb/version.go
@@ -15,7 +15,7 @@ import (
 const Version = "1.0.4"
 
 // Build number
-const Build = "0"
+const Build = "3"
 
 // VersionString returns semantic version string.
 func VersionString() string {

--- a/osx/Install/build-bin.sh
+++ b/osx/Install/build-bin.sh
@@ -7,8 +7,6 @@ cd $dir
 
 bin_src=$dir/bin
 mkdir -p $bin_src
-plist=$dir/../Keybase/Info.plist
-
 
 build() {
   tags=$1
@@ -21,29 +19,6 @@ build() {
   GO15VENDOREXPERIMENT=0 go build -tags "$tags" -o $bin_src/$kbfs_bin github.com/keybase/kbfs/kbfsfuse
 }
 
-update_version() {
-  service_bin=$1
-  kbfs_bin=$2
-  # Read the versions and build numbers
-  echo "Checking version info..."
-  kb_service_version="`$bin_src/$service_bin version -S | cut -f1 -d '-'`"
-  kb_service_build="`$bin_src/$service_bin version -S | cut -f2 -d '-'`"
-
-  kbfs_version="`$bin_src/$kbfs_bin --version 2>&1 | cut -f1 -d '-'`"
-  kbfs_build="`$bin_src/$kbfs_bin --version 2>&1 | cut -f2 -d '-'`"
-
-  echo "Version (Build):"
-  echo "  $service_bin: $kb_service_version ($kb_service_build)"
-  echo "  $kbfs_bin: $kbfs_version ($kbfs_build)"
-
-  echo "Updating plist..."
-  /usr/libexec/plistBuddy -c "Set :KBServiceVersion '${kb_service_version}'" $plist
-  /usr/libexec/plistBuddy -c "Set :KBServiceBuild '${kb_service_build}'" $plist
-  /usr/libexec/plistBuddy -c "Set :KBFSVersion '${kbfs_version}'" $plist
-  /usr/libexec/plistBuddy -c "Set :KBFSBuild '${kbfs_build}'" $plist
-}
-
-build devel kbdev kbfsdev
-build staging kbstage kbfsstage
+#build devel kbdev kbfsdev
+#build staging kbstage kbfsstage
 build production keybase kbfs
-update_version keybase kbfs

--- a/osx/KBKit/KBKit/Component/KBFSService.m
+++ b/osx/KBKit/KBKit/Component/KBFSService.m
@@ -15,7 +15,6 @@
 @interface KBFSService ()
 @property NSString *label;
 @property NSString *servicePath;
-@property KBSemVersion *bundleVersion;
 @property KBRServiceStatus *serviceStatus;
 
 @property YOView *infoView;
@@ -27,8 +26,6 @@
   if ((self = [self initWithConfig:config name:@"KBFS" info:@"The filesystem service" image:[KBIcons imageForIcon:KBIconNetwork]])) {
     _label = label;
     _servicePath = servicePath;
-    NSDictionary *info = NSBundle.mainBundle.infoDictionary;
-    _bundleVersion = [KBSemVersion version:info[@"KBFSVersion"] build:info[@"KBFSBuild"]];
   }
   return self;
 }
@@ -88,7 +85,7 @@
 }
 
 - (void)refreshComponent:(KBRefreshComponentCompletion)completion {
-  [KBKeybaseLaunchd status:[self.config serviceBinPathWithPathOptions:0 servicePath:_servicePath] name:@"kbfs" bundleVersion:_bundleVersion completion:^(NSError *error, KBRServiceStatus *serviceStatus) {
+  [KBKeybaseLaunchd status:[self.config serviceBinPathWithPathOptions:0 servicePath:_servicePath] name:@"kbfs" completion:^(NSError *error, KBRServiceStatus *serviceStatus) {
     self.serviceStatus = serviceStatus;
     self.componentStatus = [KBComponentStatus componentStatusWithServiceStatus:serviceStatus];
     [self componentDidUpdate];

--- a/osx/KBKit/KBKit/Component/KBKeybaseLaunchd.h
+++ b/osx/KBKit/KBKit/Component/KBKeybaseLaunchd.h
@@ -21,7 +21,7 @@ typedef void (^KBOnServiceStatuses)(NSError *error, NSArray *serviceStatuses);
 
 + (void)list:(NSString *)binPath name:(NSString *)name completion:(KBOnServiceStatuses)completion;
 
-+ (void)status:(NSString *)binPath name:(NSString *)name bundleVersion:(KBSemVersion *)bundleVersion completion:(KBOnServiceStatus)completion;
++ (void)status:(NSString *)binPath name:(NSString *)name completion:(KBOnServiceStatus)completion;
 
 + (void)run:(NSString *)binPath args:(NSArray *)args completion:(KBCompletion)completion;
 

--- a/osx/KBKit/KBKit/Component/KBKeybaseLaunchd.m
+++ b/osx/KBKit/KBKit/Component/KBKeybaseLaunchd.m
@@ -41,9 +41,8 @@
   }];
 }
 
-+ (void)status:(NSString *)binPath name:(NSString *)name bundleVersion:(KBSemVersion *)bundleVersion completion:(KBOnServiceStatus)completion {
-  NSString *bundleVersionFlag = NSStringWithFormat(@"--bundle-version=%@", [bundleVersion description]);
-  [KBTask executeForJSONWithCommand:binPath args:@[@"launchd", @"status", @"--format=json", bundleVersionFlag, name] completion:^(NSError *error, id value) {
++ (void)status:(NSString *)binPath name:(NSString *)name completion:(KBOnServiceStatus)completion {
+  [KBTask executeForJSONWithCommand:binPath args:@[@"launchd", @"status", @"--format=json", name] completion:^(NSError *error, id value) {
     KBRServiceStatus *status = [MTLJSONAdapter modelOfClass:KBRServiceStatus.class fromJSONDictionary:value error:&error];
     completion(nil, status);
   }];

--- a/osx/KBKit/KBKit/Component/KBService.m
+++ b/osx/KBKit/KBKit/Component/KBService.m
@@ -20,7 +20,6 @@
 
 @property NSString *label;
 @property NSString *servicePath;
-@property KBSemVersion *bundleVersion;
 
 @property KBRServiceStatus *serviceStatus;
 
@@ -33,8 +32,6 @@
   if ((self = [self initWithConfig:config name:@"Service" info:@"The Keybase service" image:[KBIcons imageForIcon:KBIconNetwork]])) {
     _label = label;
     _servicePath = servicePath;
-    NSDictionary *info = NSBundle.mainBundle.infoDictionary;
-    _bundleVersion = [KBSemVersion version:info[@"KBServiceVersion"] build:info[@"KBServiceBuild"]];
   }
   return self;
 }
@@ -77,7 +74,7 @@
 }
 
 - (void)refreshComponent:(KBRefreshComponentCompletion)completion {
-  [KBKeybaseLaunchd status:[self.config serviceBinPathWithPathOptions:0 servicePath:self.servicePath] name:@"service" bundleVersion:_bundleVersion completion:^(NSError *error, KBRServiceStatus *serviceStatus) {
+  [KBKeybaseLaunchd status:[self.config serviceBinPathWithPathOptions:0 servicePath:self.servicePath] name:@"service"  completion:^(NSError *error, KBRServiceStatus *serviceStatus) {
     self.serviceStatus = serviceStatus;
     self.componentStatus = [KBComponentStatus componentStatusWithServiceStatus:serviceStatus];
     [self componentDidUpdate];

--- a/osx/Keybase/Info.plist
+++ b/osx/Keybase/Info.plist
@@ -24,10 +24,6 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>50</string>
-	<key>KBFSBuild</key>
-	<string>25</string>
-	<key>KBFSVersion</key>
-	<string>1.0.0</string>
 	<key>KBFuseBuild</key>
 	<string>3.0.9</string>
 	<key>KBFuseVersion</key>
@@ -36,10 +32,6 @@
 	<string>60</string>
 	<key>KBHelperVersion</key>
 	<string>1.0.17</string>
-	<key>KBServiceBuild</key>
-	<string>0</string>
-	<key>KBServiceVersion</key>
-	<string>1.0.3</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
I was doing this really roundabout way of storing what the versions of the bundled binaries were.
The installer can look this up when it runs since it know the paths to the binaries. This simplifies stuff and makes the installer even simpler/smarter, and fixes a bug where the installer wasn't restarting services on upgrade.