### PR TITLE
allow HTTPS proofs to imply HTTP, in TrackSet subtraction

### DIFF
--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -295,6 +295,16 @@ func (sb ServiceBlock) ToIDString() string {
 	return sb.typ + "://" + sb.id
 }
 
+func (sb ServiceBlock) ToImpliedIDStrings() []string {
+	// This allows the existence of an HTTPS proof to suppress tracking errors
+	// caused by removing an HTTP proof. This comes up when a site that was
+	// HTTP becomes an HTTP->HTTPS redirect.
+	if sb.typ == "https" {
+		return []string{"http://" + sb.id}
+	}
+	return []string{}
+}
+
 func (sb ServiceBlock) ToKeyValuePair() (string, string) {
 	return sb.typ, sb.id
 }

--- a/go/libkb/pgp_key.go
+++ b/go/libkb/pgp_key.go
@@ -677,6 +677,10 @@ func (p PGPFingerprint) ToIDString() string {
 	return p.String()
 }
 
+func (p PGPFingerprint) ToImpliedIDStrings() []string {
+	return []string{}
+}
+
 func (p PGPFingerprint) ToKeyValuePair() (string, string) {
 	return "fingerprint", p.ToIDString()
 }

--- a/go/libkb/remote_proof_links.go
+++ b/go/libkb/remote_proof_links.go
@@ -162,6 +162,10 @@ func (p ProofLinkWithState) ToIDString() string {
 	return p.link.ToIDString()
 }
 
+func (p ProofLinkWithState) ToImpliedIDStrings() []string {
+	return []string{}
+}
+
 func (p ProofLinkWithState) ToKeyValuePair() (string, string) {
 	return p.link.ToKeyValuePair()
 }

--- a/go/libkb/track.go
+++ b/go/libkb/track.go
@@ -15,6 +15,7 @@ import (
 // tracking statement, or a PGP Fingerprint!
 type TrackIDComponent interface {
 	ToIDString() string
+	ToImpliedIDStrings() []string
 	ToKeyValuePair() (string, string)
 	GetProofState() keybase1.ProofState
 	LastWriterWins() bool
@@ -68,6 +69,12 @@ func (ts TrackSet) HasMember(t TrackIDComponent) bool {
 		_, found = ts.services[k]
 	} else {
 		_, found = ts.ids[t.ToIDString()]
+		// One ID might also imply another for the purpose of subtraction
+		// (namely, HTTPS implies HTTP).
+		for _, impliedID := range t.ToImpliedIDStrings() {
+			_, implied := ts.ids[impliedID]
+			found = found || implied
+		}
 	}
 	return found
 }

--- a/go/libkb/track.go
+++ b/go/libkb/track.go
@@ -35,6 +35,11 @@ func NewTrackSet() *TrackSet {
 
 func (ts TrackSet) Add(t TrackIDComponent) {
 	ts.ids[t.ToIDString()] = t
+	// One ID might also imply another for the purpose of TrackSet subtraction
+	// (namely, HTTPS implies HTTP).
+	for _, impliedID := range t.ToImpliedIDStrings() {
+		ts.services[impliedID] = true
+	}
 	if t.LastWriterWins() {
 		k, _ := t.ToKeyValuePair()
 		ts.services[k] = true
@@ -69,12 +74,6 @@ func (ts TrackSet) HasMember(t TrackIDComponent) bool {
 		_, found = ts.services[k]
 	} else {
 		_, found = ts.ids[t.ToIDString()]
-		// One ID might also imply another for the purpose of subtraction
-		// (namely, HTTPS implies HTTP).
-		for _, impliedID := range t.ToImpliedIDStrings() {
-			_, implied := ts.ids[impliedID]
-			found = found || implied
-		}
 	}
 	return found
 }


### PR DESCRIPTION
A site can move from HTTP (or HTTP+HTTPS) to an HTTP->HTTPS redirect.
This currently breaks tracking statements. Instead, allow the existence
of an HTTPS proof to mean "it's ok if the HTTP proof goes away".