### PR TITLE
Use setImmediate to avoid setting state during a state transition

### DIFF
--- a/react-native/react/native/remote-component-loader.js
+++ b/react-native/react/native/remote-component-loader.js
@@ -41,7 +41,7 @@ class RemoteStore {
 
   _publishChange () {
     this.listeners.forEach(l => {
-      l()
+      setImmediate(l)
     })
   }
 }
@@ -82,7 +82,7 @@ class RemoteComponentLoader extends Component {
         if (this.state.loaded === false) {
           currentWindow.show()
         }
-        this.setState({props: props, loaded: true})
+        setImmediate(() => this.setState({props: props, loaded: true}))
       }
     })
 


### PR DESCRIPTION
Only two changes for so much problems...

I think this fixes the issue where loading... remains on the remote tracker popup but not on the one in the app.

It may also fix the issue where tracker popup keeps getting focused.

### The issue

We were calling setState when we were in the middle of a state transition (we randomly got into this problem, which is why it was hard to reproduce). When you call setState in a state transition, setState doesn't work, so you don't get the updates.

### Debugging

To help provoke this bug, I sent a bunch of dummy messages alongside the updateState ipc message, and called setState on all the dummy messages. See this branch for actual code: https://github.com/keybase/client/compare/outofsync-debug?expand=1

Good news is the ipc does send messages in order (even after being stressed)

Relevant stack overflow: http://stackoverflow.com/questions/31420402/why-does-this-error-exist-invariant-violation-cannot-update-during-an-existin

@keybase/react-hackers 