### PR TITLE
Ratelimit kbfs notifications

### DIFF
--- a/react-native/react/constants/platform.native.desktop.js
+++ b/react-native/react/constants/platform.native.desktop.js
@@ -18,6 +18,10 @@ function findSocketRoot () {
     'linux': `${process.env.XDG_RUNTIME_DIR}/keybase.${runMode}/`
   }
 
+  if (runMode === 'prod') {
+    paths['linux'] = `${process.env.XDG_RUNTIME_DIR}/keybase/`
+  }
+
   return paths[process.platform]
 }
 

--- a/react-native/react/constants/platform.native.desktop.js
+++ b/react-native/react/constants/platform.native.desktop.js
@@ -15,11 +15,7 @@ const envedPathOSX = {
 function findSocketRoot () {
   const paths = {
     'darwin': `${process.env.HOME}/Library/Caches/${envedPathOSX[runMode]}/`,
-    'linux': `${process.env.XDG_RUNTIME_DIR}/keybase.${runMode}/`
-  }
-
-  if (runMode === 'prod') {
-    paths['linux'] = `${process.env.XDG_RUNTIME_DIR}/keybase/`
+    'linux': runMode === 'prod' ? `${process.env.XDG_RUNTIME_DIR}/keybase/` : `${process.env.XDG_RUNTIME_DIR}/keybase.${runMode}/`
   }
 
   return paths[process.platform]

--- a/react-native/react/native/notification-listeners.desktop.js
+++ b/react-native/react/native/notification-listeners.desktop.js
@@ -1,5 +1,6 @@
 import notify from '../../../desktop/app/hidden-window-notifications'
 import enums from '../../react/constants/types/keybase_v1'
+import path from 'path'
 import type {FSNotification} from '../../react/constants/types/flow-types'
 
 // TODO: Once we have access to the Redux store from the thread running

--- a/react-native/react/native/notification-listeners.desktop.js
+++ b/react-native/react/native/notification-listeners.desktop.js
@@ -2,6 +2,10 @@ import notify from '../../../desktop/app/hidden-window-notifications'
 import enums from '../../react/constants/types/keybase_v1'
 import type {FSNotification} from '../../react/constants/types/flow-types'
 
+// TODO: Once we have access to the Redux store from the thread running
+// notification listeners, store the sentNotifications map in it.
+var sentNotifications = {}
+
 export default {
   'keybase.1.NotifySession.loggedOut': () => {
     notify('Logged Out')
@@ -23,11 +27,42 @@ export default {
       [enums.kbfs.FSStatusCode.error]: 'Errored'
     }[notification.statusCode]
 
-    const pubPriv = notification.publicTopLevelFolder ? '[Public]' : '[Private]'
+    const basedir = notification.filename.split('/')[0]
+    let tlf
+    if (notification.publicTopLevelFolder) {
+      // Public filenames look like cjb#public/foo.txt
+      tlf = '/public/' + basedir.replace('#public', '')
+    } else {
+      // Private filenames look like cjb/foo.txt
+      tlf = '/private/' + basedir
+    }
 
     const title = `KBFS: ${action} ${state}`
-    const body = `File: ${notification.filename} ${pubPriv} ${notification.status}`
+    const body = `Files in ${tlf} ${notification.status}`
 
-    notify(title, {body})
+    function rateLimitAllowsNotify(action, state, tlf) {
+      if (!(action in sentNotifications)) {
+        sentNotifications[action] = {}
+      }
+      if (!(state in sentNotifications[action])) {
+        sentNotifications[action][state] = {}
+      }
+
+      // 20s in msec
+      const delay = 20000
+      const now = new Date()
+
+      if (!(tlf in sentNotifications[action][state]) || now - sentNotifications[action][state][tlf] > delay) {
+        sentNotifications[action][state][tlf] = now
+        return true
+      }
+      // We've already notified recently, ignore this one.
+      return false
+    }
+
+    // Get the top-level dir name
+    if (rateLimitAllowsNotify(action, state, tlf)) {
+      notify(title, {body})
+    }
   }
 }

--- a/react-native/react/native/notification-listeners.desktop.js
+++ b/react-native/react/native/notification-listeners.desktop.js
@@ -27,14 +27,14 @@ export default {
       [enums.kbfs.FSStatusCode.error]: 'Errored'
     }[notification.statusCode]
 
-    const basedir = notification.filename.split('/')[0]
+    const basedir = notification.filename.split(path.sep)[0]
     let tlf
     if (notification.publicTopLevelFolder) {
       // Public filenames look like cjb#public/foo.txt
-      tlf = '/public/' + basedir.replace('#public', '')
+      tlf = `/public/${basedir.replace('#public', '')}`
     } else {
       // Private filenames look like cjb/foo.txt
-      tlf = '/private/' + basedir
+      tlf = `/private/${basedir}`
     }
 
     const title = `KBFS: ${action} ${state}`

--- a/react-native/react/native/notification-listeners.desktop.js
+++ b/react-native/react/native/notification-listeners.desktop.js
@@ -52,15 +52,16 @@ export default {
       const delay = 20000
       const now = new Date()
 
+      // If we haven't notified for {action,state,tlf} or it was >20s ago, do it.
       if (!(tlf in sentNotifications[action][state]) || now - sentNotifications[action][state][tlf] > delay) {
         sentNotifications[action][state][tlf] = now
         return true
       }
+
       // We've already notified recently, ignore this one.
       return false
     }
 
-    // Get the top-level dir name
     if (rateLimitAllowsNotify(action, state, tlf)) {
       notify(title, {body})
     }


### PR DESCRIPTION
Here's a quick and dirty ratelimiting of KBFS notifications.

After sending out a few notifications, here's what the `sentNotifications` object looks like:
```js
{ 
  Decrypting: 
   { Starting: { '/private/cjb': Tue Dec 01 2015 16:22:07 GMT-0500 (EST) },
     Finished: { '/private/cjb': Tue Dec 01 2015 16:22:07 GMT-0500 (EST) } },
  Verifying: 
   { Starting: { '/public/chris': Tue Dec 01 2015 16:23:46 GMT-0500 (EST) },
     Finished: { '/public/chris': Tue Dec 01 2015 16:23:46 GMT-0500 (EST) } }
}
```

Style-wise, was splitting out `rateLimitAllowsNotify()` a good idea?

Also includes a fix for Linux runMode==prod.
