### PR TITLE
better TTY lookup and plumb it through

### DIFF
--- a/go/client/gpg_ui.go
+++ b/go/client/gpg_ui.go
@@ -22,10 +22,11 @@ type GPGUI struct {
 	libkb.Contextified
 	parent   libkb.TerminalUI
 	noPrompt bool
+	tty      string
 }
 
-func NewGPGUI(g *libkb.GlobalContext, t libkb.TerminalUI, np bool) GPGUI {
-	return GPGUI{Contextified: libkb.NewContextified(g), parent: t, noPrompt: np}
+func NewGPGUI(g *libkb.GlobalContext, t libkb.TerminalUI, np bool, tty string) GPGUI {
+	return GPGUI{Contextified: libkb.NewContextified(g), parent: t, noPrompt: np, tty: tty}
 }
 
 func (g GPGUI) SelectKeyID(_ context.Context, keys []keybase1.GPGKey) (string, error) {
@@ -89,5 +90,6 @@ func (g GPGUI) Sign(_ context.Context, arg keybase1.SignArg) (string, error) {
 	if err := cli.Configure(); err != nil {
 		return "", err
 	}
+	cli.SetTTY(g.tty)
 	return cli.Sign(*fp, arg.Msg)
 }

--- a/go/client/secret_entry.go
+++ b/go/client/secret_entry.go
@@ -12,39 +12,45 @@ import (
 )
 
 type SecretEntry struct {
+	libkb.Contextified
 	pinentry *pinentry.Pinentry
 	terminal *Terminal
 	initRes  *error
+	tty      string
 }
 
 type Printer interface {
 	Printf(format string, a ...interface{}) (n int, err error)
 }
 
-func NewSecretEntry(t *Terminal) *SecretEntry {
-	return &SecretEntry{terminal: t}
+func NewSecretEntry(g *libkb.GlobalContext, t *Terminal, tty string) *SecretEntry {
+	return &SecretEntry{
+		Contextified: libkb.NewContextified(g),
+		terminal:     t,
+		tty:          tty,
+	}
 }
 
 func (se *SecretEntry) Init() (err error) {
 
-	G.Log.Debug("+ SecretEntry.Init()")
+	se.G().Log.Debug("+ SecretEntry.Init()")
 
 	if se.initRes != nil {
-		G.Log.Debug("- SecretEntry.Init() -> cached %s", libkb.ErrToOk(*se.initRes))
+		se.G().Log.Debug("- SecretEntry.Init() -> cached %s", libkb.ErrToOk(*se.initRes))
 		return *se.initRes
 	}
 
-	if G.Env.GetNoPinentry() {
-		G.Log.Debug("| Pinentry skipped due to config")
+	if se.G().Env.GetNoPinentry() {
+		se.G().Log.Debug("| Pinentry skipped due to config")
 	} else {
-		pe := pinentry.New(G.Env.GetPinentry(), G.Log)
+		pe := pinentry.New(se.G().Env.GetPinentry(), se.G().Log, se.tty)
 		if e2, fatalerr := pe.Init(); fatalerr != nil {
 			err = fatalerr
 		} else if e2 != nil {
-			G.Log.Debug("| Pinentry initialization failed: %s", e2)
+			se.G().Log.Debug("| Pinentry initialization failed: %s", e2)
 		} else {
 			se.pinentry = pe
-			G.Log.Debug("| Pinentry initialized")
+			se.G().Log.Debug("| Pinentry initialized")
 		}
 	}
 
@@ -56,7 +62,7 @@ func (se *SecretEntry) Init() (err error) {
 
 	se.initRes = &err
 
-	G.Log.Debug("- SecretEntry.Init() -> %s", libkb.ErrToOk(err))
+	se.G().Log.Debug("- SecretEntry.Init() -> %s", libkb.ErrToOk(err))
 	return err
 }
 

--- a/go/libkb/gpg_cli.go
+++ b/go/libkb/gpg_cli.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"sync"
 )
@@ -16,6 +17,7 @@ type GpgCLI struct {
 	path    string
 	options []string
 	version string
+	tty     string
 
 	mutex *sync.Mutex
 
@@ -31,6 +33,10 @@ func NewGpgCLI(g *GlobalContext, logUI LogUI) *GpgCLI {
 		mutex:        new(sync.Mutex),
 		logUI:        logUI,
 	}
+}
+
+func (g *GpgCLI) SetTTY(t string) {
+	g.tty = t
 }
 
 func (g *GpgCLI) Configure() (err error) {
@@ -303,5 +309,9 @@ func (g *GpgCLI) MakeCmd(args []string) *exec.Cmd {
 		nargs = append([]string{"--no-tty"}, nargs...)
 	}
 	g.logUI.Debug("| running Gpg: %s %v", g.path, nargs)
-	return exec.Command(g.path, nargs...)
+	ret := exec.Command(g.path, nargs...)
+	if g.tty != "" {
+		ret.Env = append(os.Environ(), "GPG_TTY="+g.tty)
+	}
+	return ret
 }

--- a/go/pinentry/pinentry.go
+++ b/go/pinentry/pinentry.go
@@ -32,10 +32,11 @@ type Pinentry struct {
 	log     logger.Logger
 }
 
-func New(envprog string, log logger.Logger) *Pinentry {
+func New(envprog string, log logger.Logger, tty string) *Pinentry {
 	return &Pinentry{
 		prog: envprog,
 		log:  log,
+		tty:  tty,
 	}
 }
 

--- a/go/pinentry/pinentry_nix.go
+++ b/go/pinentry/pinentry_nix.go
@@ -106,19 +106,5 @@ func FindPinentry(log logger.Logger) (string, error) {
 }
 
 func (pe *Pinentry) GetTerminalName() {
-	tty, err := os.Readlink("/proc/self/fd/0")
-	if err != nil {
-		pe.log.Debug("| Can't find terminal name via /proc lookup: %s", err)
-
-		// try /dev/tty
-		tty = "/dev/tty"
-		_, err = os.Stat("/dev/tty")
-		if err != nil {
-			pe.log.Debug("| stat /dev/tty failed: %s", err)
-			return
-		}
-	}
-
-	pe.log.Debug("| found tty=%s", tty)
-	pe.tty = tty
+	// Noop on all platforms but windows
 }

--- a/go/spotty/README.md
+++ b/go/spotty/README.md
@@ -1,0 +1,9 @@
+# spotty
+
+This is a port of [keybase/node-spotty](https://github.com/keybase/node-spotty),
+a mechanism to read the current TTY that should work on both Linux and OSX.
+
+## THIS MODULE CANNOT BE TESTED!
+
+Or at least, not with Go's test framework, because Go test
+[closes /dev/tty](https://groups.google.com/forum/#!topic/golang-nuts/w6TTJpw9stA).

--- a/go/spotty/spotty_nix.go
+++ b/go/spotty/spotty_nix.go
@@ -1,0 +1,58 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
+
+package spotty
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"syscall"
+)
+
+func sameFile(ss1 *syscall.Stat_t, fi os.FileInfo) bool {
+	if ss2, ok := fi.Sys().(*syscall.Stat_t); ok {
+		return ss2.Dev == ss1.Dev && ss2.Rdev == ss1.Rdev && ss1.Ino == ss2.Ino
+	}
+	return false
+}
+
+// Discover which named TTY we have open as FD=0. Will return empty string or an error
+// if nothing was found, or if there was a problem, respectively. Will not work on Windows.
+func Discover() (string, error) {
+	var sstat syscall.Stat_t
+	if err := syscall.Fstat(0, &sstat); err != nil {
+		return "", err
+	}
+	res, err := findFileIn(&sstat, "/dev", regexp.MustCompile(`^tty[A-Za-z0-9]+$`))
+	if err != nil {
+		return "", err
+	}
+	if len(res) > 0 {
+		return res, nil
+	}
+	res, err = findFileIn(&sstat, "/dev/pts", regexp.MustCompile(`^[0-9]+$`))
+	return res, err
+}
+
+func findFileIn(ss *syscall.Stat_t, dir string, re *regexp.Regexp) (string, error) {
+	v, err := ioutil.ReadDir(dir)
+	if err != nil {
+		if _, ok := err.(*os.PathError); ok {
+			return "", nil
+		}
+		return "", err
+	}
+	for _, fi := range v {
+		if !re.MatchString(fi.Name()) {
+			continue
+		}
+		if sameFile(ss, fi) {
+			return filepath.Join(dir, fi.Name()), nil
+		}
+	}
+	return "", nil
+}

--- a/go/spotty/spotty_nix.go
+++ b/go/spotty/spotty_nix.go
@@ -15,7 +15,7 @@ import (
 
 func sameFile(ss1 *syscall.Stat_t, fi os.FileInfo) bool {
 	if ss2, ok := fi.Sys().(*syscall.Stat_t); ok {
-		return ss2.Dev == ss1.Dev && ss2.Rdev == ss1.Rdev && ss1.Ino == ss2.Ino
+		return ss1.Dev == ss2.Dev && ss1.Rdev == ss2.Rdev && ss1.Ino == ss2.Ino
 	}
 	return false
 }

--- a/go/spotty/spotty_windows.go
+++ b/go/spotty/spotty_windows.go
@@ -5,10 +5,6 @@
 
 package spotty
 
-import (
-	"errors"
-)
-
 // Discover does nothing on Windows
 func Discover() (string, error) {
 	return "", nil

--- a/go/spotty/spotty_windows.go
+++ b/go/spotty/spotty_windows.go
@@ -1,0 +1,15 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build windows
+
+package spotty
+
+import (
+	"errors"
+)
+
+// Discover does nothing on Windows
+func Discover() (string, error) {
+	return "", nil
+}

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -67,7 +67,7 @@ func (n *signupUI) GetLoginUI() libkb.LoginUI {
 }
 
 func (n *signupUI) GetGPGUI() libkb.GPGUI {
-	return client.NewGPGUI(n.G(), n.GetTerminalUI(), false)
+	return client.NewGPGUI(n.G(), n.GetTerminalUI(), false, "")
 }
 
 func (n *signupSecretUI) GetNewPassphrase(arg keybase1.GetNewPassphraseArg) (res keybase1.GetPassphraseRes, err error) {


### PR DESCRIPTION
- use spotty for divining the correct TTY
- pass via GPG_TTY to calls to gpg from the client
- pass into pinentry/ class for direct invocations