### PR TITLE
only short circuit chain loading if the eldest kid matches the chain tip

### DIFF
--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -66,13 +66,8 @@ func TestCreateFakeUserNoKeys(t *testing.T) {
 	}
 
 	ckf := me.GetComputedKeyFamily()
-	if ckf != nil {
-		t.Errorf("user has a computed key family.  they shouldn't...")
-
-		active := me.GetComputedKeyFamily().HasActiveKey()
-		if active {
-			t.Errorf("user has an active key, but they should have no keys")
-		}
+	if ckf.HasActiveKey() {
+		t.Errorf("user has an active key, but they should have no keys")
 	}
 }
 


### PR DESCRIPTION
@maxtaco, for the first half of https://keybase.atlassian.net/browse/CORE-2152

Previously we could get into the following confusing situation:

1) You just reset your account.
2) You haven't added any new links yet.
3) I have your pre-reset key family cached, in association with your
   last chain link.

What used to happen in SigChainLoader.Load(), is that it would confirm
your "chain freshness" (which just means you have no new *links*), and
then it would check to see if it had cached state for you (it did), and
finally it would short-circuit and return that old state. This caused at
least one real error, where HasActiveKey got confused after your own
account reset.

Now we only allow the early return if your Merkle leaf eldest KID also
matches the eldest KID of the last chain link. Additionally, we set
`localCki` in the eldest KID == nil case, in VerifySigsAndComputeKeys,
to prevent us from nonetheless falling back to the stale cache.