### PR TITLE
Create the hidden window for notifications

### DIFF
--- a/desktop/app/hidden-window-notifications.js
+++ b/desktop/app/hidden-window-notifications.js
@@ -5,6 +5,7 @@ import Window from './window'
 // process, so we'll use a hidden window to show them for us.
 // https://github.com/atom/electron/issues/3359
 const window = new Window('notifier', {show: false})
+window.createWindow()
 
 export default function (title, opts) {
   window.window.webContents.send('notify', title, opts)

--- a/desktop/app/window.js
+++ b/desktop/app/window.js
@@ -14,9 +14,7 @@ export default class Window {
     })
 
     app.on('ready', () => {
-      this.window = new BrowserWindow({show: false, ...this.opts})
-      this.window.loadURL(`file://${__dirname}/../renderer/${this.filename}.html`)
-      this.bindWindowListeners()
+      this.createWindow()
     })
   }
 
@@ -42,6 +40,16 @@ export default class Window {
     })
   }
 
+  createWindow() {
+    if (this.window) {
+      return
+    }
+
+    this.window = new BrowserWindow({show: false, ...this.opts})
+    this.window.loadURL(`file://${__dirname}/../renderer/${this.filename}.html`)
+    this.bindWindowListeners()
+  }
+
   show (shouldShowDockIcon) {
     if (this.window) {
       if (!this.window.isVisible()) {
@@ -53,10 +61,7 @@ export default class Window {
       return
     }
 
-    this.window = new BrowserWindow(this.opts)
-    this.window.loadURL(`file://${__dirname}/../renderer/${this.filename}.html`)
-    this.bindWindowListeners()
-
+    this.createWindow()
     this.releaseDockIcon = shouldShowDockIcon ? showDockIcon() : null
 
     if (this.opts.openDevTools) {


### PR DESCRIPTION
TODO: We should move this stuff to be handled by the main window,
instead of keeping a window alive just for notifications

I broke this when I changed the main window to be always-on. Sorry

@keybase/react-hackers