### PR TITLE
Make the client capable of reporting the commit hash from which it wa…

### DIFF
--- a/go/client/cmd_version.go
+++ b/go/client/cmd_version.go
@@ -111,7 +111,7 @@ func (v *CmdVersion) runLocal() {
 	case modeNormal:
 		dui.Printf("%s%s\n", prfx, libkb.VersionString())
 	case modeVerbose:
-		libkb.VersionMessage(func(s string) { dui.Printf("%s\n", s) })
+		v.G().VersionMessage(func(s string) { dui.Printf("%s\n", s) })
 	}
 }
 

--- a/go/keybase/generate_windows.go
+++ b/go/keybase/generate_windows.go
@@ -2,6 +2,12 @@
 
 package main
 
+//go:generate cmd /c echo // Auto generated > ../libkb/hash_windows.go
+//go:generate cmd /c echo package libkb >> ../libkb/hash_windows.go
+//go:generate cmd /c echo func (g *GlobalContext) Hash() string { >> ../libkb/hash_windows.go
+//go:generate cmd /c echo|set /p dummyName=return  >> ../libkb/hash_windows.go
+//go:generate cmd /c git log -n 1 --pretty=format:"%H" >> ../libkb/hash_windows.go
+//go:generate cmd /c echo } >> ../libkb/hash_windows.go
 //go:generate go build ../winresource
 //go:generate ./winresource.exe
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -176,14 +176,21 @@ func (g *GlobalContext) ConfigureKeyring() error {
 	return nil
 }
 
-func VersionMessage(linefn func(string)) {
+type GitHashGetter interface {
+	Hash() string
+}
+
+func (g *GlobalContext) VersionMessage(linefn func(string)) {
 	linefn(fmt.Sprintf("Keybase CLI %s", VersionString()))
 	linefn(fmt.Sprintf("- Built with %s", runtime.Version()))
+	if h, ok := interface{}(g).(GitHashGetter); ok {
+		linefn(fmt.Sprintf("- Git hash: %s", h.Hash()))
+	}
 	linefn("- Visit https://keybase.io for more details")
 }
 
 func (g *GlobalContext) StartupMessage() {
-	VersionMessage(func(s string) { g.Log.Debug(s) })
+	g.VersionMessage(func(s string) { g.Log.Debug(s) })
 }
 
 func (g *GlobalContext) ConfigureAPI() error {

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -60,7 +60,7 @@ func (h ConfigHandler) GetConfig(_ context.Context, sessionID int) (keybase1.Con
 	c.VersionShort = libkb.Version
 
 	var v []string
-	libkb.VersionMessage(func(s string) {
+	h.G().VersionMessage(func(s string) {
 		v = append(v, s)
 	})
 	c.VersionFull = strings.Join(v, "\n")


### PR DESCRIPTION
…s built.

Note this has no effect on other platforms, or if "go generate" is not run.

```
c:\work\src\github.com\keybase\client\go\keybase>keybase version -f v
- WARNING Running in devel mode
Keybase CLI 1.0.5-2
- Built with go1.5.1
- Git hash: 32409a5b280dac123d0c80fa92aad37936520be1    <--*THIS*
- Visit https://keybase.io for more details
```