### PR TITLE
Flow .19

### DIFF
--- a/react-native/.flowconfig
+++ b/react-native/.flowconfig
@@ -1,5 +1,8 @@
 [ignore]
 
+# TODO: unignore react-native when we upgrade to .16
+.*/node_modules/react-native
+
 # TODO: unignore these:
 .*/react/index.js
 .*/react/router/global-routes.js

--- a/react-native/.flowconfig
+++ b/react-native/.flowconfig
@@ -68,8 +68,6 @@ munge_underscores=true
 
 module.name_mapper='^image![a-zA-Z0-9$_-]+$' -> 'GlobalImageStub'
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.png$' -> 'RelativeImageStub'
-module.name_mapper= '\.\/serialize' -> './serialize.mobile.js'
-module.name_mapper= '\.\/.*-render' -> 'View'
 
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
@@ -81,4 +79,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
 
 [version]
-0.17.0
+0.19.0

--- a/react-native/.flowconfig
+++ b/react-native/.flowconfig
@@ -71,6 +71,7 @@ munge_underscores=true
 
 module.name_mapper='^image![a-zA-Z0-9$_-]+$' -> 'GlobalImageStub'
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.png$' -> 'RelativeImageStub'
+module.name_mapper='^\..*base-react$' -> 'React'
 
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe

--- a/react-native/react/base-react.js.flow
+++ b/react-native/react/base-react.js.flow
@@ -1,0 +1,4 @@
+declare export default react
+declare export var StyleSheet: {
+  create: (x: any) => any
+};

--- a/react-native/react/base-react.js.flow
+++ b/react-native/react/base-react.js.flow
@@ -1,4 +1,0 @@
-declare export default react
-declare export var StyleSheet: {
-  create: (x: any) => any
-};

--- a/react-native/react/base-redux.js.flow
+++ b/react-native/react/base-redux.js.flow
@@ -1,0 +1,1 @@
+declare export default any

--- a/react-native/react/constants/config.js
+++ b/react-native/react/constants/config.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 export type NavState = 'navStartingUp' | 'navNeedsRegistration' | 'navNeedsLogin' | 'navLoggedIn' | 'navErrorStartingUp'
 
 // Constants

--- a/react-native/react/engine/call-map-middleware.js
+++ b/react-native/react/engine/call-map-middleware.js
@@ -1,3 +1,4 @@
+/* @flow */
 
 export type Endpoint = (params: any) => (Promise<any> | any)
 
@@ -16,7 +17,6 @@ function flattenNextLevel (separator: string, key: string, value: any): CallMap 
         {}
     )
   } else {
-    // $FlowIssue Computed property keys not supported
     return {[key]: value}
   }
 }

--- a/react-native/react/native/remote-manager.desktop.js
+++ b/react-native/react/native/remote-manager.desktop.js
@@ -1,8 +1,6 @@
 /* @flow */
 
-// $FlowIssue base-react
 import React, {Component} from '../base-react'
-// $FlowIssue base-redux
 import {connect} from '../base-redux'
 
 import {bindActionCreators} from 'redux'

--- a/react-native/react/native/remote-manager.desktop.js
+++ b/react-native/react/native/remote-manager.desktop.js
@@ -12,7 +12,8 @@ export type RemoteManagerProps = {
   registerIdentifyUi: () => void,
   onCloseFromHeader: () => void,
   trackerServerStarted: boolean,
-  trackerServerActive: boolean
+  trackerServerActive: boolean,
+  trackerClosed: boolean
 }
 
 class RemoteManager extends Component {

--- a/react-native/react/reducers/config.js
+++ b/react-native/react/reducers/config.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 import * as Constants from '../constants/config'
 import * as LoginConstants from '../constants/login'
 import type {NavState} from '../constants/config'

--- a/react-native/react/reducers/serialize.js.flow
+++ b/react-native/react/reducers/serialize.js.flow
@@ -1,0 +1,2 @@
+import type {State} from '../constants/reducer'
+declare export default function foo(state: State, action: any): State;

--- a/react-native/react/reducers/tabbed-router.js
+++ b/react-native/react/reducers/tabbed-router.js
@@ -22,17 +22,11 @@ const emptyRouterState: RouterState = LocalDebug.overrideRouterState ? LocalDebu
 const initialState: TabbedRouterState = Immutable.fromJS({
   // a map from tab name to router obj
   tabs: {
-    // $FlowIssue flow doesn't support computed keys
     [startupTab]: emptyRouterState,
-    // $FlowIssue flow doesn't support computed keys
     [folderTab]: emptyRouterState,
-    // $FlowIssue flow doesn't support computed keys
     [chatTab]: emptyRouterState,
-    // $FlowIssue flow doesn't support computed keys
     [peopleTab]: emptyRouterState,
-    // $FlowIssue flow doesn't support computed keys
     [devicesTab]: emptyRouterState,
-    // $FlowIssue flow doesn't support computed keys
     [moreTab]: emptyRouterState
   },
   activeTab: LocalDebug.overrideActiveTab ? LocalDebug.overrideActiveTab : moreTab

--- a/react-native/react/reducers/tracker.js
+++ b/react-native/react/reducers/tracker.js
@@ -224,23 +224,14 @@ function proofStateToSimpleProofState (proofState: ProofState): SimpleProofState
 
 function trackDiffToSimpleProofMeta (diff: identifyUi_TrackDiffType): ?SimpleProofMeta {
   return {
-    // $FlowIssue no computed
     [0]: null, /* 'NONE_0' */
-    // $FlowIssue no computed
     [1]: null, /* 'ERROR_1' */
-    // $FlowIssue no computed
     [2]: null, /* 'CLASH_2' */
-    // $FlowIssue no computed
     [3]: null, /* 'REVOKED_3' */
-    // $FlowIssue no computed
     [4]: metaUpgraded, /* 'UPGRADED_4' */
-    // $FlowIssue no computed
     [5]: metaNew, /* 'NEW_5' */
-    // $FlowIssue no computed
     [6]: null, /* 'REMOTE_FAIL_6' */
-    // $FlowIssue no computed
     [7]: null, /* 'REMOTE_WORKING_7' */
-    // $FlowIssue no computed
     [8]: null /* 'REMOTE_CHANGED_8' */
   }[diff]
 }

--- a/react-native/react/styles/common.js
+++ b/react-native/react/styles/common.js
@@ -1,3 +1,4 @@
+/* @flow */
 import {StyleSheet} from '../base-react'
 import native, {styles as nativeStyles} from './common.native'
 

--- a/react-native/react/styles/common.js
+++ b/react-native/react/styles/common.js
@@ -1,4 +1,5 @@
 /* @flow */
+// $FlowIssue Pulling non react things from react
 import {StyleSheet} from '../base-react'
 import native, {styles as nativeStyles} from './common.native'
 

--- a/react-native/react/styles/common.native.js.flow
+++ b/react-native/react/styles/common.native.js.flow
@@ -1,0 +1,6 @@
+declare export default {
+  navBarHeight: number;
+  tabBarHeight: number;
+}
+
+declare export var styles: Object

--- a/react-native/react/tracker/action.render.desktop.js
+++ b/react-native/react/tracker/action.render.desktop.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-// $FlowIssue base-react
 import React, {Component} from '../base-react'
 import {FlatButton} from 'material-ui'
 

--- a/react-native/react/tracker/bio.render.desktop.js
+++ b/react-native/react/tracker/bio.render.desktop.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-// $FlowIssue base-react
 import React, {Component} from '../base-react'
 import {Paper} from 'material-ui'
 import commonStyles, {colors} from '../styles/common'

--- a/react-native/react/tracker/header.render.desktop.js
+++ b/react-native/react/tracker/header.render.desktop.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-// $FlowIssue base-react
 import React, {Component} from '../base-react'
 import path from 'path'
 import commonStyles from '../styles/common'

--- a/react-native/react/tracker/index.js
+++ b/react-native/react/tracker/index.js
@@ -1,8 +1,6 @@
 /* @flow */
 
-// $FlowIssue base-react
 import React, {Component} from '../base-react'
-// $FlowIssue base-redux
 import {connect} from '../base-redux'
 // $FlowIssue .desktop issue
 import Render from './render'

--- a/react-native/react/tracker/proofs.render.desktop.js
+++ b/react-native/react/tracker/proofs.render.desktop.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-// $FlowIssue base-react
 import React, {Component} from '../base-react'
 import commonStyles, {colors} from '../styles/common'
 
@@ -19,9 +18,7 @@ export default class ProofsRender extends Component {
 
   renderProofRow (proof: Proof): ReactElement {
     const metaColor = proof.meta ? {
-      // $FlowIssue no computed
       [metaNew]: colors.orange,
-      // $FlowIssue no computed
       [metaUpgraded]: colors.orange
     }[proof.meta] : null
 

--- a/react-native/react/tracker/render.desktop.js
+++ b/react-native/react/tracker/render.desktop.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-// $FlowIssue base-react
 import React, {Component} from '../base-react'
 
 import Header from './header.render.desktop'


### PR DESCRIPTION
This version of flow is really nice!

Some new things include being able to define a `.flow` file. This will help with our platform files.

Say we have `foo.render.desktop.js` and `foo.render.mobile.js`, we can declare their types in `foo.render.js.flow` and flow will use that as their type interface.

Another cool thing is the React Component inference works correctly now!

So say you have something like

```js
class Foo extends Component {
 props: {bar: number};
 ...
}
```

and you try to do something like

```js
 const foo = <Foo bar={'nan'}/> // will fail with an error
 const foo = <Foo /> // will also fail because you didn't pass bar!
```

this also removes a bunch of our // $FlowIssues.

I, for one, welcome our typed overlords.
@keybase/react-hackers 