### PR TITLE
auth: add CheckUsers; rename Check -> CheckUserKey

### DIFF
--- a/go/client/cmd_ca.go
+++ b/go/client/cmd_ca.go
@@ -63,7 +63,7 @@ func (c *CmdCA) runPromptLoop() error {
 			continue
 		}
 
-		if e2 := ca.Check(context.TODO(), uid, un, kid); e2 != nil {
+		if e2 := ca.CheckUserKey(context.TODO(), uid, &un, &kid); e2 != nil {
 			c.G().Log.Errorf("Bad check: %s", e2)
 		}
 


### PR DESCRIPTION
This is to allow the mdserver to validate:

1) UIDs present in a folder handle represent real users on TLF creation.
2) User and subkey tuple exists when storing a server-side key half on rekey.

KBFS side: https://github.com/keybase/kbfs/pull/501
