### PR TITLE
kbcmf: nuke the Nonce and take the hash of the ephmeral public key instead

### DIFF
--- a/go/kbcmf/common.go
+++ b/go/kbcmf/common.go
@@ -62,6 +62,15 @@ func hmacSHA512(key []byte, data []byte) []byte {
 	return hasher.Sum(nil)[0:32]
 }
 
+func keyToNonce(nonce *Nonce, pk BoxPublicKey) {
+	raw := *pk.ToRawBoxKeyPointer()
+	nonceRandLen := 20
+	hasher := sha512.New()
+	hasher.Write(raw[:])
+	res := hasher.Sum(nil)
+	copy((*nonce)[0:nonceRandLen], res)
+}
+
 func hashNonceAndAuthTag(nonce *Nonce, ciphertext []byte) []byte {
 	var buf bytes.Buffer
 	buf.Write((*nonce)[:])

--- a/go/kbcmf/decrypt.go
+++ b/go/kbcmf/decrypt.go
@@ -183,7 +183,7 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 	}
 
 	var nonce Nonce
-	copy(nonce[:], hdr.Nonce)
+	keyToNonce(&nonce, ephemeralKey)
 
 	secretKey, senderPublicRawKey, i, err := ds.tryVisibleReceivers(hdr, &nonce, ephemeralKey)
 	if err != nil {

--- a/go/kbcmf/encrypt.go
+++ b/go/kbcmf/encrypt.go
@@ -165,18 +165,8 @@ func (es *encryptStream) init(sender BoxSecretKey, receivers [][]BoxPublicKey) e
 		return err
 	}
 
-	// Only fill the first 20 bytes of the nonce. The remaining 4
-	// we'll increment with every call to Box
-	nonceRandLen := 20
 	var nonce Nonce
-	if err := randomFill(nonce[:nonceRandLen]); err != nil {
-		return err
-	}
-
-	// We don't necessarily have to copy our header nonce into place,
-	// but if feels safer, since we modify the nonce below
-	eh.Nonce = make([]byte, nonceRandLen)
-	copy(eh.Nonce, nonce[:])
+	keyToNonce(&nonce, ephemeralKey.GetPublicKey())
 
 	var i uint32
 

--- a/go/kbcmf/encrypt_test.go
+++ b/go/kbcmf/encrypt_test.go
@@ -1099,26 +1099,6 @@ func TestCorruptHeader(t *testing.T) {
 		t.Fatalf("got wrong received in error message: %d", ebv.received)
 	}
 
-	// Test bad Nonce length
-	teo = testEncryptionOptions{
-		blockSize: 1024,
-		corruptHeader: func(eh *EncryptionHeader) {
-			eh.Nonce = make([]byte, 24)
-		},
-	}
-	ciphertext, err = testSeal(msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = Open(ciphertext, kr)
-	if ebn, ok := err.(ErrBadNonce); !ok {
-		t.Fatalf("Got wrong error; wanted 'Bad Nonce' but got %v", err)
-	} else if int(ebn.seqno) != 0 {
-		t.Fatalf("Wanted a failure in packet %d but got %d", 0, ebn.seqno)
-	} else if ebn.byteLen != 24 {
-		t.Fatalf("got wrong byte len in message: %d", ebn.byteLen)
-	}
-
 	// Test Bad Sender Key
 	teo = testEncryptionOptions{
 		blockSize: 1024,

--- a/go/kbcmf/errors.go
+++ b/go/kbcmf/errors.go
@@ -88,13 +88,6 @@ type ErrBadVersion struct {
 	received PacketVersion
 }
 
-// ErrBadNonce is produced when a header nonce is of the wrong size;
-// it should be 20 bytes.
-type ErrBadNonce struct {
-	seqno   PacketSeqno
-	byteLen int
-}
-
 // ErrBadArmorHeader shows up when we get the wrong value for our header
 type ErrBadArmorHeader struct {
 	wanted   string
@@ -122,9 +115,6 @@ func (e ErrWrongPacketTag) Error() string {
 }
 func (e ErrBadVersion) Error() string {
 	return fmt.Sprintf("In packet %d: unsupported version (%d)", e.seqno, e.received)
-}
-func (e ErrBadNonce) Error() string {
-	return fmt.Sprintf("In packet %d: bad nonce; wrong lengh (%d)", e.seqno, e.byteLen)
 }
 func (e ErrBadCiphertext) Error() string {
 	return fmt.Sprintf("In packet %d: bad ciphertext; failed Poly1305", e)

--- a/go/kbcmf/packets.go
+++ b/go/kbcmf/packets.go
@@ -21,11 +21,10 @@ type receiverKeysCiphertexts struct {
 // It contains the encryptions of the session keys, and various
 // message metadata.
 type EncryptionHeader struct {
-	Nonce     []byte                    `codec:"nonce"`
+	Version   PacketVersion             `codec:"vers"`
+	Tag       PacketTag                 `codec:"tag"`
 	Receivers []receiverKeysCiphertexts `codec:"rcvrs"`
 	Sender    []byte                    `codec:"sender"`
-	Tag       PacketTag                 `codec:"tag"`
-	Version   PacketVersion             `codec:"vers"`
 	seqno     PacketSeqno
 }
 
@@ -52,11 +51,6 @@ func (h *EncryptionHeader) validate() error {
 	}
 	if h.Version != PacketVersion1 {
 		return ErrBadVersion{h.seqno, h.Version}
-	}
-	// We leave off 4 bytes of the nonce, since it's a counter
-	// incremented for each public key
-	if len(h.Nonce) != len(Nonce{})-4 {
-		return ErrBadNonce{h.seqno, len(h.Nonce)}
 	}
 
 	if err := verifyRawKey(h.Sender); err != nil {

--- a/go/kbcmf/tweakable_encryptor_test.go
+++ b/go/kbcmf/tweakable_encryptor_test.go
@@ -158,18 +158,8 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers [][]BoxPublicK
 		return err
 	}
 
-	// Only fill the first 20 bytes of the nonce. The remaining 4
-	// we'll increment with every call to Box
-	nonceRandLen := 20
 	var nonce Nonce
-	if err := randomFill(nonce[:nonceRandLen]); err != nil {
-		return err
-	}
-
-	// We don't necessarily have to copy our header nonce into place,
-	// but if feels safer, since we modify the nonce below
-	eh.Nonce = make([]byte, nonceRandLen)
-	copy(eh.Nonce, nonce[:])
+	keyToNonce(&nonce, ephemeralKey.GetPublicKey())
 
 	d := make(map[string]struct{})
 


### PR DESCRIPTION
this saves ~20 bytes of data and also eliminates some error cases