### PR TITLE
Show a single notification rather than {starting,finished}

### DIFF
--- a/react-native/react/native/notification-listeners.desktop.js
+++ b/react-native/react/native/notification-listeners.desktop.js
@@ -28,6 +28,12 @@ export default {
       [enums.kbfs.FSStatusCode.error]: 'Errored'
     }[notification.statusCode]
 
+    if (notification.statusCode === enums.kbfs.FSStatusCode.finish) {
+      // Since we're aggregating dir operations and not showing state,
+      // let's ignore file-finished notifications.
+      return
+    }
+
     const basedir = notification.filename.split(path.sep)[0]
     let tlf
     if (notification.publicTopLevelFolder) {
@@ -38,7 +44,11 @@ export default {
       tlf = `/private/${basedir}`
     }
 
-    const title = `KBFS: ${action} ${state}`
+    let title = `KBFS: ${action}`
+    // Don't show starting or finished, but do show error.
+    if (notification.statusCode === enums.kbfs.FSStatusCode.error) {
+      title += ` ${state}`
+    }
     const body = `Files in ${tlf} ${notification.status}`
 
     function rateLimitAllowsNotify(action, state, tlf) {

--- a/react-native/react/native/notification-listeners.desktop.js
+++ b/react-native/react/native/notification-listeners.desktop.js
@@ -23,9 +23,9 @@ export default {
     }[notification.notificationType]
 
     const state = {
-      [enums.kbfs.FSStatusCode.start]: 'Starting',
-      [enums.kbfs.FSStatusCode.finish]: 'Finished',
-      [enums.kbfs.FSStatusCode.error]: 'Errored'
+      [enums.kbfs.FSStatusCode.start]: 'starting',
+      [enums.kbfs.FSStatusCode.finish]: 'finished',
+      [enums.kbfs.FSStatusCode.error]: 'errored'
     }[notification.statusCode]
 
     if (notification.statusCode === enums.kbfs.FSStatusCode.finish) {


### PR DESCRIPTION
@keybase/react-hackers 

Before this PR, copying 20 files at once results in:
```
KBFS: Encrypting and uploading Starting
Files in /public/cjb
KBFS: Encrypting and uploading Finished
Files in /public/cjb
```
and the "finished" comes when the first file finishes, because while the text is per-dir, the code is operating per-file.  (And subsequent file notifications aren't seen because they're rate-limited.)

This PR switches to:
```
KBFS: Encrypting and uploading
Files in /public/cjb
```
No 'finished' notification, and no mention of 'started'.  But if the event is an error, we will show:
```
KBFS: Encrypting and uploading errored
Files in /public/cjb
```