### PR TITLE
hide devtools, prod runtime by default

### DIFF
--- a/desktop/renderer/index.desktop.js
+++ b/desktop/renderer/index.desktop.js
@@ -7,6 +7,7 @@ import configureStore from '../../react-native/react/store/configure-store'
 import Nav from '../../react-native/react/nav'
 import injectTapEventPlugin from 'react-tap-event-plugin'
 import {isDev} from '../../react-native/react/constants/platform'
+import {reduxDevToolsSelect} from '../../react-native/react/local-debug.desktop'
 
 // For Remote Components
 import RemoteManager from '../../react-native/react/native/remote-manager'
@@ -74,7 +75,7 @@ class Keybase extends Component {
       return (
         <div>
           <DebugPanel top right bottom>
-            <DevTools store={store} monitor={LogMonitor} visibleOnLoad/>
+            <DevTools store={store} monitor={LogMonitor} visibleOnLoad={false} select={reduxDevToolsSelect}/>
           </DebugPanel>
           {this.renderNav()}
         </div>

--- a/react-native/react/constants/platform.native.desktop.js
+++ b/react-native/react/constants/platform.native.desktop.js
@@ -5,7 +5,12 @@ export const isDev = process.env.NODE_ENV === 'development'
 export const OS = OS_DESKTOP
 export const isMobile = false
 
-const runMode = process.env.KEYBASE_RUN_MODE || 'devel'
+const runMode = process.env.KEYBASE_RUN_MODE || 'prod'
+
+if (isDev) {
+  console.log(`Run mode: ${runMode}`)
+}
+
 const envedPathOSX = {
   staging: 'KeybaseStaging',
   devel: 'KeybaseDevel',

--- a/react-native/react/local-debug.desktop.js
+++ b/react-native/react/local-debug.desktop.js
@@ -13,7 +13,8 @@ let config = {
   allowStartupFailure: false,
   printRPC: false,
   showDevTools: false,
-  showAllTrackers: false
+  showAllTrackers: false,
+  reduxDevToolsSelect: state => state // only watch a subset of the store
 }
 
 if (isDev && false) {
@@ -24,6 +25,7 @@ if (isDev && false) {
   config.printRPC = true
   config.showDevTools = true
   config.showAllTrackers = true
+  config.reduxDevToolsSelect = state => state.tracker
 }
 
 export const {
@@ -33,5 +35,6 @@ export const {
   allowStartupFailure,
   printRPC,
   showDevTools,
-  showAllTrackers
+  showAllTrackers,
+  reduxDevToolsSelect
 } = config


### PR DESCRIPTION
@keybase/react-hackers 

So the open dev-tools is really slow, we can still have it but keep it closed and its waaaaaay faster. 
So by default its now hidden, hit control+h to make it show up

also if there's no run_mode use prod, I think this makes more sense, if you disagree let's discuss