### PR TITLE
Add tracking to tracker popup

### DIFF
--- a/desktop/app/main.js
+++ b/desktop/app/main.js
@@ -59,3 +59,20 @@ installer(err => {
   }
   splash()
 })
+
+// Simple ipc logging for debugging remote windows
+
+ipc.on('console.log', (event, args) => {
+  console.log('From remote console.log')
+  console.log.apply(console, args)
+})
+
+ipc.on('console.warn', (event, arg) => {
+  console.log('From remote console.warn')
+  console.log.apply(console, args)
+})
+
+ipc.on('console.error', (event, args) => {
+  console.log('From remote console.error')
+  console.log.apply(console, args)
+})

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -63,10 +63,13 @@ export function onFollowChecked (newFollowCheckedValue: boolean, username: strin
 }
 
 export function onRefollow (username: string): Action {
-  console.log('onRefollow')
-  return {
-    type: Constants.onRefollow,
-    payload: {username}
+  return (dispatch, getState) => {
+    console.log('onRefollow')
+    trackUser(username, getState())
+    dispatch({
+      type: Constants.onRefollow,
+      payload: {username}
+    })
   }
 }
 

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -88,14 +88,15 @@ export function onFollowHelp (username: string): Action {
 
 function trackUser (username: string, state: {tracker: RootTrackerState}): Promise<boolean> {
   const trackers = state.tracker.trackers
-  const shouldFollow = trackers[username] && trackers[username].shouldFollow
-  const trackToken = trackers[username] && trackers[username].trackToken
+  const trackerState = trackers[username]
+  const {shouldFollow, trackToken} = (trackerState || {})
+
   const options: TrackOptions = {
     localOnly: false,
     bypassConfirm: false
   }
 
-  if (trackToken && shouldFollow) {
+  if (trackerState && trackToken && shouldFollow) {
     return new Promise((resolve, reject) => {
       engine.rpc('track.trackWithToken', {trackToken, options}, {}, (err, response) => {
         if (err) {

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -73,11 +73,24 @@ export function onRefollow (username: string): Action {
   }
 }
 
-export function onUnfollow (username: string): Action {
-  console.log('onUnfollow')
-  return {
-    type: Constants.onUnfollow,
-    payload: {username}
+export function onUnfollow (username: string): (dispatch: Dispatch, getState: () => {tracker: RootTrackerState}) => void {
+  return (dispatch, getState) => {
+    engine.rpc('track.untrack', {username}, {}, (err, response) => {
+      if (err) {
+        console.log('err untracking', err)
+      } else {
+        dispatch({
+          type: Constants.reportLastTrack,
+          payload: {username}
+        })
+        console.log('success in untracking')
+      }
+    })
+
+    dispatch({
+      type: Constants.onUnfollow,
+      payload: {username}
+    })
   }
 }
 

--- a/react-native/react/constants/tracker.js
+++ b/react-native/react/constants/tracker.js
@@ -37,3 +37,5 @@ export const onFollowHelp = 'tracker:onFollowHelp'
 export const onFollowChecked = 'tracker:onFollowChecked'
 
 export const decideToShowTracker = 'tracker:decideToShowTracker'
+
+export const updateTrackToken = 'tracker:updateTrackToken'

--- a/react-native/react/native/remote-component-loader.js
+++ b/react-native/react/native/remote-component-loader.js
@@ -6,6 +6,12 @@ import {ipcRenderer} from 'electron'
 
 const currentWindow = remote.getCurrentWindow()
 
+window.console.log = (...args) => ipcRenderer.send('console.log', args)
+
+window.console.warn = (...args) => ipcRenderer.send('console.warn', args)
+
+window.console.error = (...args) => ipcRenderer.send('console.error', args)
+
 class RemoteStore {
   constructor (props) {
     ipcRenderer.on('stateChange', (event, arg) => {

--- a/react-native/react/native/remote-component-loader.js
+++ b/react-native/react/native/remote-component-loader.js
@@ -26,7 +26,7 @@ class RemoteStore {
   dispatch (action) {
     // TODO use our middlewares
     if (action.constructor === Function) {
-      action(a => this.dispatch(a))
+      action(a => this.dispatch(a), () => this.getState())
     } else {
       ipcRenderer.send('dispatchAction', action)
     }

--- a/react-native/react/reducers/tracker.js
+++ b/react-native/react/reducers/tracker.js
@@ -91,8 +91,11 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
         closed: true,
         shouldFollow: false // don't follow if they close x out the window
       }
-    case Constants.onRefollow: // TODO
-      return state
+    case Constants.onRefollow:
+      return {
+        ...state,
+        closed: true
+      }
     case Constants.onUnfollow: // TODO
       return state
 

--- a/react-native/react/reducers/tracker.js
+++ b/react-native/react/reducers/tracker.js
@@ -25,10 +25,11 @@ export type TrackerState = {
   userInfo: UserInfo,
   proofs: Array<Proof>,
   closed: boolean,
+  trackToken: ?string,
   lastTrack: ?TrackSummary
 }
 
-type State = {
+export type State = {
   serverStarted: boolean,
   trackers: {[key: string]: TrackerState}
 }
@@ -50,6 +51,7 @@ function initialTrackerState (username: string): TrackerState {
     reason: '', // TODO: get the reason
     closed: true,
     lastTrack: null,
+    trackToken: null,
     userInfo: {
       fullname: '', // TODO get this info,
       followersCount: -1,
@@ -72,6 +74,11 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
       return {
         ...state,
         shouldFollow
+      }
+    case Constants.updateTrackToken:
+      return {
+        ...state,
+        trackToken: action.payload && action.payload.trackToken
       }
     case Constants.onCloseFromActionBar:
       return {
@@ -195,8 +202,7 @@ export default function (state: State = initialState, action: Action): State {
       ...state,
       trackers: {
         ...state.trackers,
-        // $FlowIssue computed
-        [action.payload.username]: newTrackerState
+        [username]: newTrackerState
       }
     }
   } else {


### PR DESCRIPTION
This makes the track and close functionality work.

Up next is the refollow/untrack logic (in a different PR)

There is a subtle error here that may come back to haunt us. It's that the remote window that makes the rpc call to track also get's closed by the same action. So we aren't able to get the results back from the rpc. In this case we don't need them, but we might in other things.

I have a couple of ideas, but I'd love to hear unbiased thoughts!

@keybase/react-hackers 