### PR TITLE
Fix PGP command line user interface

### DIFF
--- a/go/client/cmd_pgp_encrypt.go
+++ b/go/client/cmd_pgp_encrypt.go
@@ -80,6 +80,7 @@ type CmdPGPEncrypt struct {
 	noSelf       bool
 	keyQuery     string
 	binaryOut    bool
+	skipTrack    bool
 }
 
 func (c *CmdPGPEncrypt) Run() error {
@@ -105,6 +106,7 @@ func (c *CmdPGPEncrypt) Run() error {
 		NoSelf:       c.noSelf,
 		BinaryOut:    c.binaryOut,
 		KeyQuery:     c.keyQuery,
+		SkipTrack:    c.skipTrack,
 		TrackOptions: c.trackOptions,
 	}
 	arg := keybase1.PGPEncryptArg{Source: src, Sink: snk, Opts: opts}
@@ -131,6 +133,7 @@ func (c *CmdPGPEncrypt) ParseArgv(ctx *cli.Context) error {
 		BypassConfirm: ctx.Bool("y"),
 	}
 	c.sign = ctx.Bool("sign")
+	c.skipTrack = ctx.Bool("skip-track")
 	c.keyQuery = ctx.String("key")
 	c.binaryOut = ctx.Bool("binary")
 	return nil

--- a/go/client/cmd_pgp_verify.go
+++ b/go/client/cmd_pgp_verify.go
@@ -31,11 +31,6 @@ func NewCmdPGPVerify(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Com
 				Name:  "i, infile",
 				Usage: "Specify an input file.",
 			},
-			cli.BoolFlag{
-				Name:  "l, local",
-				Usage: "Only track locally, don't send a statement to the server.",
-			},
-
 			cli.StringFlag{
 				Name:  "m, message",
 				Usage: "Provide the message on the command line.",
@@ -44,10 +39,6 @@ func NewCmdPGPVerify(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Com
 				Name:  "S, signed-by",
 				Usage: "Assert signed by the given user (can use user assertion format).",
 			},
-			cli.BoolFlag{
-				Name:  "y",
-				Usage: "Approve remote tracking without prompting.",
-			},
 		},
 	}
 }
@@ -55,7 +46,6 @@ func NewCmdPGPVerify(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Com
 type CmdPGPVerify struct {
 	libkb.Contextified
 	UnixFilter
-	trackOptions     keybase1.TrackOptions
 	detachedFilename string
 	detachedData     []byte
 	signedBy         string
@@ -81,9 +71,8 @@ func (c *CmdPGPVerify) Run() error {
 	arg := keybase1.PGPVerifyArg{
 		Source: src,
 		Opts: keybase1.PGPVerifyOptions{
-			TrackOptions: c.trackOptions,
-			Signature:    c.detachedData,
-			SignedBy:     c.signedBy,
+			Signature: c.detachedData,
+			SignedBy:  c.signedBy,
 		},
 	}
 	_, err = cli.PGPVerify(context.TODO(), arg)
@@ -101,10 +90,6 @@ func (c *CmdPGPVerify) ParseArgv(ctx *cli.Context) error {
 	infile := ctx.String("infile")
 	if err := c.FilterInit(msg, infile, "/dev/null"); err != nil {
 		return err
-	}
-	c.trackOptions = keybase1.TrackOptions{
-		LocalOnly:     ctx.Bool("local"),
-		BypassConfirm: ctx.Bool("y"),
 	}
 	c.signedBy = ctx.String("signed-by")
 	c.detachedFilename = ctx.String("detached")

--- a/go/client/pgp_ui.go
+++ b/go/client/pgp_ui.go
@@ -1,0 +1,32 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	humanize "github.com/dustin/go-humanize"
+	"golang.org/x/net/context"
+
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
+	rpc "github.com/keybase/go-framed-msgpack-rpc"
+)
+
+type PgpUI struct {
+	parent *UI
+}
+
+func NewPgpUIProtocol(g *libkb.GlobalContext) rpc.Protocol {
+	return keybase1.PGPUiProtocol(g.UI.GetPgpUI())
+}
+
+func (p PgpUI) OutputSignatureSuccess(_ context.Context, arg keybase1.OutputSignatureSuccessArg) error {
+	signedAt := keybase1.FromTime(arg.SignedAt)
+	if signedAt.IsZero() {
+		p.parent.Printf("Signature verified. Signed by %s.\n", arg.Username)
+	} else {
+		p.parent.Printf("Signature verified. Signed by %s %s (%s).\n", arg.Username, humanize.Time(signedAt), signedAt)
+	}
+	p.parent.Printf("PGP Fingerprint: %s.\n", arg.Fingerprint)
+	return nil
+}

--- a/go/client/secret_entry.go
+++ b/go/client/secret_entry.go
@@ -5,10 +5,10 @@ package client
 
 import (
 	"fmt"
-
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/pinentry"
 	keybase1 "github.com/keybase/client/go/protocol"
+	"io"
 )
 
 type SecretEntry struct {
@@ -17,10 +17,6 @@ type SecretEntry struct {
 	terminal *Terminal
 	initRes  *error
 	tty      string
-}
-
-type Printer interface {
-	Printf(format string, a ...interface{}) (n int, err error)
 }
 
 func NewSecretEntry(g *libkb.GlobalContext, t *Terminal, tty string) *SecretEntry {
@@ -66,7 +62,7 @@ func (se *SecretEntry) Init() (err error) {
 	return err
 }
 
-func (se *SecretEntry) Get(arg keybase1.SecretEntryArg, termArg *keybase1.SecretEntryArg, printer Printer) (res *keybase1.SecretEntryRes, err error) {
+func (se *SecretEntry) Get(arg keybase1.SecretEntryArg, termArg *keybase1.SecretEntryArg, w io.Writer) (res *keybase1.SecretEntryRes, err error) {
 
 	if err = se.Init(); err != nil {
 		return
@@ -74,7 +70,7 @@ func (se *SecretEntry) Get(arg keybase1.SecretEntryArg, termArg *keybase1.Secret
 
 	if pe := se.pinentry; pe != nil {
 		if len(arg.Reason) > 0 {
-			printer.Printf("Collecting your passphrase for %s.\n", arg.Reason)
+			fmt.Fprintf(w, "Collecting your passphrase for %s.\n", arg.Reason)
 		}
 		res, err = pe.Get(arg)
 	} else if se.terminal == nil {

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -447,6 +447,10 @@ func (ui *UI) GetProvisionUI(role libkb.KexRole) libkb.ProvisionUI {
 	return ProvisionUI{parent: ui, role: role}
 }
 
+func (ui *UI) GetPgpUI() libkb.PgpUI {
+	return PgpUI{parent: ui}
+}
+
 //============================================================
 
 type ProveUI struct {

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -931,14 +931,6 @@ func (ui *UI) Output(s string) error {
 	return err
 }
 
-func (ui *UI) OutputWriter() io.Writer {
-	return os.Stdout
-}
-
-func (ui *UI) ErrorWriter() io.Writer {
-	return os.Stderr
-}
-
 func (ui *UI) Printf(format string, a ...interface{}) (n int, err error) {
 	return fmt.Fprintf(ui.OutputWriter(), format, a...)
 }

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -448,7 +448,8 @@ func (ui *UI) GetProvisionUI(role libkb.KexRole) libkb.ProvisionUI {
 }
 
 func (ui *UI) GetPgpUI() libkb.PgpUI {
-	return PgpUI{parent: ui}
+	// PGPUI goes to stderr so it doesn't munge up stdout
+	return PgpUI{w: ui.ErrorWriter()}
 }
 
 //============================================================
@@ -614,7 +615,7 @@ type SecretUI struct {
 }
 
 func (ui SecretUI) GetSecret(pinentry keybase1.SecretEntryArg, term *keybase1.SecretEntryArg) (*keybase1.SecretEntryRes, error) {
-	return ui.parent.SecretEntry.Get(pinentry, term, ui.parent)
+	return ui.parent.SecretEntry.Get(pinentry, term, ui.parent.ErrorWriter())
 }
 
 func (ui *UI) Configure() error {
@@ -928,6 +929,14 @@ func (ui *UI) DefaultTabWriter() *tabwriter.Writer {
 func (ui *UI) Output(s string) error {
 	_, err := ui.OutputWriter().Write([]byte(s))
 	return err
+}
+
+func (ui *UI) OutputWriter() io.Writer {
+	return os.Stdout
+}
+
+func (ui *UI) ErrorWriter() io.Writer {
+	return os.Stderr
 }
 
 func (ui *UI) Printf(format string, a ...interface{}) (n int, err error) {

--- a/go/client/ui_nix.go
+++ b/go/client/ui_nix.go
@@ -13,3 +13,7 @@ import (
 func (ui *UI) OutputWriter() io.Writer {
 	return os.Stdout
 }
+
+func (ui *UI) ErrorWriter() io.Writer {
+	return os.Stderr
+}

--- a/go/client/ui_windows.go
+++ b/go/client/ui_windows.go
@@ -17,8 +17,6 @@ var (
 	setConsoleTextAttributeProc = kernel32DLL.NewProc("SetConsoleTextAttribute")
 )
 
-var CW ColorWriter
-
 type WORD uint16
 
 const (
@@ -77,10 +75,17 @@ var codesWin = map[byte]WORD{
 
 // Return our writer so we can override Write()
 func (ui *UI) OutputWriter() io.Writer {
-	return &CW
+	return &ColorWriter{os.Stdout, io.Stdout.Fd()}
+}
+
+// Return our writer so we can override Write()
+func (ui *UI) ErrorWriter() io.Writer {
+	return &ColorWriter{os.Stderr, io.Stderr.Fd()}
 }
 
 type ColorWriter struct {
+	w  io.Writer
+	fd int
 }
 
 // Rough emulation of Ansi terminal codes.
@@ -101,7 +106,7 @@ func (cw *ColorWriter) Write(p []byte) (n int, err error) {
 			controlIndex = nextIndex + 2
 		}
 
-		os.Stdout.Write(p[0:nextIndex])
+		cw.w.Write(p[0:nextIndex])
 
 		if controlIndex != -1 {
 			// The control code is written as separate ascii digits. usually 2,
@@ -115,7 +120,7 @@ func (cw *ColorWriter) Write(p []byte) (n int, err error) {
 				controlIndex++
 			}
 			if code, ok := codesWin[controlCode]; ok {
-				setConsoleTextAttribute(os.Stdout.Fd(), code)
+				setConsoleTextAttribute(cw.fd, code)
 			}
 			nextIndex = controlIndex + 1
 		}

--- a/go/client/ui_windows.go
+++ b/go/client/ui_windows.go
@@ -75,17 +75,17 @@ var codesWin = map[byte]WORD{
 
 // Return our writer so we can override Write()
 func (ui *UI) OutputWriter() io.Writer {
-	return &ColorWriter{os.Stdout, io.Stdout.Fd()}
+	return &ColorWriter{os.Stdout, os.Stdout.Fd()}
 }
 
 // Return our writer so we can override Write()
 func (ui *UI) ErrorWriter() io.Writer {
-	return &ColorWriter{os.Stderr, io.Stderr.Fd()}
+	return &ColorWriter{os.Stderr, os.Stderr.Fd()}
 }
 
 type ColorWriter struct {
 	w  io.Writer
-	fd int
+	fd uintptr
 }
 
 // Rough emulation of Ansi terminal codes.

--- a/go/engine/context.go
+++ b/go/engine/context.go
@@ -15,6 +15,7 @@ type Context struct {
 	LoginUI     libkb.LoginUI
 	SecretUI    libkb.SecretUI
 	IdentifyUI  libkb.IdentifyUI
+	PgpUI       libkb.PgpUI
 	ProveUI     libkb.ProveUI
 	ProvisionUI libkb.ProvisionUI
 
@@ -33,6 +34,8 @@ func (c *Context) HasUI(kind libkb.UIKind) bool {
 		return c.SecretUI != nil
 	case libkb.IdentifyUIKind:
 		return c.IdentifyUI != nil
+	case libkb.PgpUIKind:
+		return c.PgpUI != nil
 	case libkb.ProveUIKind:
 		return c.ProveUI != nil
 	case libkb.ProvisionUIKind:

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -174,6 +174,7 @@ type FakeIdentifyUI struct {
 	Keys            map[libkb.PGPFingerprint]*keybase1.TrackDiff
 	DisplayKeyCalls int
 	Outcome         *keybase1.IdentifyOutcome
+	StartCount      int
 	sync.Mutex
 }
 
@@ -219,6 +220,9 @@ func (ui *FakeIdentifyUI) DisplayKey(ik keybase1.IdentifyKey) {
 func (ui *FakeIdentifyUI) ReportLastTrack(*keybase1.TrackSummary) {
 }
 func (ui *FakeIdentifyUI) Start(username string) {
+	ui.Lock()
+	defer ui.Unlock()
+	ui.StartCount++
 }
 func (ui *FakeIdentifyUI) Finish() {}
 func (ui *FakeIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) {

--- a/go/engine/identify.go
+++ b/go/engine/identify.go
@@ -274,6 +274,7 @@ func (e *Identify) loadExpr(assertion string) error {
 	if err != nil {
 		return fmt.Errorf("assertion parse error: %s", err)
 	}
+	fmt.Printf("assertion: %q, expr: %q\n", assertion, expr)
 	e.userExpr = expr
 	return nil
 }

--- a/go/engine/identify.go
+++ b/go/engine/identify.go
@@ -274,7 +274,6 @@ func (e *Identify) loadExpr(assertion string) error {
 	if err != nil {
 		return fmt.Errorf("assertion parse error: %s", err)
 	}
-	fmt.Printf("assertion: %q, expr: %q\n", assertion, expr)
 	e.userExpr = expr
 	return nil
 }

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -329,7 +329,6 @@ func TestProvisionPaper(t *testing.T) {
 	secUI := fu.NewSecretUI()
 	secUI.BackupPassphrase = loginUI.PaperPhrase
 	provUI := newTestProvisionUIPaper()
-	provUI.verbose = true
 	provLoginUI := &libkb.TestLoginUI{Username: fu.Username}
 	ctx = &Context{
 		ProvisionUI: provUI,

--- a/go/engine/pgp_common.go
+++ b/go/engine/pgp_common.go
@@ -21,13 +21,4 @@ func OutputSignatureSuccess(ctx *Context, fingerprint libkb.PGPFingerprint, owne
 		SignedAt:    keybase1.TimeFromSeconds(signatureTime.Unix()),
 	}
 	ctx.PgpUI.OutputSignatureSuccess(context.TODO(), arg)
-
-	/*
-		if signatureTime.IsZero() {
-			ctx.LogUI.Notice("Signature verified. Signed by %s.", owner.GetName())
-		} else {
-			ctx.LogUI.Notice("Signature verified. Signed by %s %s (%s).", owner.GetName(), humanize.Time(signatureTime), signatureTime)
-		}
-		ctx.LogUI.Notice("PGP Fingerprint: %s.", fingerprint)
-	*/
 }

--- a/go/engine/pgp_common.go
+++ b/go/engine/pgp_common.go
@@ -6,16 +6,28 @@ package engine
 import (
 	"time"
 
-	"github.com/dustin/go-humanize"
+	"golang.org/x/net/context"
+
+	// humanize "github.com/dustin/go-humanize"
 	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
 )
 
 // OutputSignatureSuccess prints the details of a successful verification.
 func OutputSignatureSuccess(ctx *Context, fingerprint libkb.PGPFingerprint, owner *libkb.User, signatureTime time.Time) {
-	if signatureTime.IsZero() {
-		ctx.LogUI.Notice("Signature verified. Signed by %s.", owner.GetName())
-	} else {
-		ctx.LogUI.Notice("Signature verified. Signed by %s %s (%s).", owner.GetName(), humanize.Time(signatureTime), signatureTime)
+	arg := keybase1.OutputSignatureSuccessArg{
+		Fingerprint: fingerprint.String(),
+		Username:    owner.GetName(),
+		SignedAt:    keybase1.TimeFromSeconds(signatureTime.Unix()),
 	}
-	ctx.LogUI.Notice("PGP Fingerprint: %s.", fingerprint)
+	ctx.PgpUI.OutputSignatureSuccess(context.TODO(), arg)
+
+	/*
+		if signatureTime.IsZero() {
+			ctx.LogUI.Notice("Signature verified. Signed by %s.", owner.GetName())
+		} else {
+			ctx.LogUI.Notice("Signature verified. Signed by %s %s (%s).", owner.GetName(), humanize.Time(signatureTime), signatureTime)
+		}
+		ctx.LogUI.Notice("PGP Fingerprint: %s.", fingerprint)
+	*/
 }

--- a/go/engine/pgp_decrypt.go
+++ b/go/engine/pgp_decrypt.go
@@ -68,7 +68,7 @@ func (e *PGPDecrypt) Run(ctx *Context) (err error) {
 
 	e.G().Log.Debug("| ScanKeys")
 
-	sk, err := NewScanKeys(ctx.SecretUI, ctx.IdentifyUI, &e.arg.TrackOptions, e.G())
+	sk, err := NewScanKeys(ctx.SecretUI, e.G())
 	if err != nil {
 		return err
 	}

--- a/go/engine/pgp_decrypt.go
+++ b/go/engine/pgp_decrypt.go
@@ -48,7 +48,7 @@ func (e *PGPDecrypt) Prereqs() Prereqs {
 
 // RequiredUIs returns the required UIs.
 func (e *PGPDecrypt) RequiredUIs() []libkb.UIKind {
-	return []libkb.UIKind{libkb.SecretUIKind, libkb.LogUIKind}
+	return []libkb.UIKind{libkb.SecretUIKind, libkb.LogUIKind, libkb.PgpUIKind}
 }
 
 // SubConsumers returns the other UI consumers for this engine.

--- a/go/engine/pgp_decrypt_test.go
+++ b/go/engine/pgp_decrypt_test.go
@@ -251,11 +251,12 @@ func TestPGPDecryptSignedIdentify(t *testing.T) {
 	recipient.LoginOrBust(tcRecipient)
 
 	idUI := &FakeIdentifyUI{}
+	pgpUI := &TestPgpUI{}
 	ctx = &Context{
 		IdentifyUI: idUI,
 		SecretUI:   recipient.NewSecretUI(),
 		LogUI:      tcRecipient.G.UI.GetLogUI(),
-		PgpUI:      &TestPgpUI{},
+		PgpUI:      pgpUI,
 	}
 
 	// decrypt it
@@ -277,8 +278,8 @@ func TestPGPDecryptSignedIdentify(t *testing.T) {
 	if idUI.User.Username != signer.Username {
 		t.Errorf("idUI username: %q, expected %q", idUI.User.Username, signer.Username)
 	}
-	if idUI.Outcome == nil {
-		t.Fatal("identify ui outcome is nil")
+	if pgpUI.OutputCount != 1 {
+		t.Errorf("PgpUI output called %d times, expected 1", pgpUI.OutputCount)
 	}
 }
 
@@ -387,10 +388,10 @@ func TestPGPDecryptClearsign(t *testing.T) {
 }
 
 type TestPgpUI struct {
-	outputCalled bool
+	OutputCount int
 }
 
 func (t *TestPgpUI) OutputSignatureSuccess(context.Context, keybase1.OutputSignatureSuccessArg) error {
-	t.outputCalled = true
+	t.OutputCount++
 	return nil
 }

--- a/go/engine/pgp_decrypt_test.go
+++ b/go/engine/pgp_decrypt_test.go
@@ -200,7 +200,6 @@ func TestPGPDecryptSignedOther(t *testing.T) {
 		Source:       bytes.NewReader(out),
 		Sink:         decoded,
 		AssertSigned: true,
-		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
 	}
 	dec := NewPGPDecrypt(decarg, tcRecipient.G)
 	if err := RunEngine(dec, ctx); err != nil {
@@ -265,7 +264,6 @@ func TestPGPDecryptSignedIdentify(t *testing.T) {
 		Source:       bytes.NewReader(out),
 		Sink:         decoded,
 		AssertSigned: false,
-		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
 	}
 	dec := NewPGPDecrypt(decarg, tcRecipient.G)
 	if err := RunEngine(dec, ctx); err != nil {

--- a/go/engine/pgp_decrypt_test.go
+++ b/go/engine/pgp_decrypt_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
 )
@@ -18,6 +20,7 @@ func decengctx(fu *FakeUser, tc libkb.TestContext) *Context {
 		IdentifyUI: &FakeIdentifyUI{},
 		SecretUI:   fu.NewSecretUI(),
 		LogUI:      tc.G.UI.GetLogUI(),
+		PgpUI:      &TestPgpUI{},
 	}
 }
 
@@ -184,7 +187,12 @@ func TestPGPDecryptSignedOther(t *testing.T) {
 	recipient.LoginOrBust(tcRecipient)
 
 	rtrackUI := &FakeIdentifyUI{}
-	ctx = &Context{IdentifyUI: rtrackUI, SecretUI: recipient.NewSecretUI(), LogUI: tcRecipient.G.UI.GetLogUI()}
+	ctx = &Context{
+		IdentifyUI: rtrackUI,
+		SecretUI:   recipient.NewSecretUI(),
+		LogUI:      tcRecipient.G.UI.GetLogUI(),
+		PgpUI:      &TestPgpUI{},
+	}
 
 	// decrypt it
 	decoded := libkb.NewBufferCloser()
@@ -243,7 +251,12 @@ func TestPGPDecryptSignedIdentify(t *testing.T) {
 	recipient.LoginOrBust(tcRecipient)
 
 	idUI := &FakeIdentifyUI{}
-	ctx = &Context{IdentifyUI: idUI, SecretUI: recipient.NewSecretUI(), LogUI: tcRecipient.G.UI.GetLogUI()}
+	ctx = &Context{
+		IdentifyUI: idUI,
+		SecretUI:   recipient.NewSecretUI(),
+		LogUI:      tcRecipient.G.UI.GetLogUI(),
+		PgpUI:      &TestPgpUI{},
+	}
 
 	// decrypt it
 	decoded := libkb.NewBufferCloser()
@@ -371,4 +384,13 @@ func TestPGPDecryptClearsign(t *testing.T) {
 			t.Errorf("%s: signature status entity is nil", test.name)
 		}
 	}
+}
+
+type TestPgpUI struct {
+	outputCalled bool
+}
+
+func (t *TestPgpUI) OutputSignatureSuccess(context.Context, keybase1.OutputSignatureSuccessArg) error {
+	t.outputCalled = true
+	return nil
 }

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/keybase/client/go/libkb"
@@ -16,6 +17,7 @@ type PGPEncryptArg struct {
 	Recips       []string // user assertions
 	Source       io.Reader
 	Sink         io.WriteCloser
+	SkipTrack    bool
 	NoSign       bool
 	NoSelf       bool
 	BinaryOutput bool
@@ -27,6 +29,7 @@ type PGPEncryptArg struct {
 // for a set of users.  It will track them if necessary.
 type PGPEncrypt struct {
 	arg *PGPEncryptArg
+	me  *libkb.User
 	libkb.Contextified
 }
 
@@ -78,18 +81,19 @@ func (e *PGPEncrypt) Run(ctx *Context) error {
 		if !e.arg.NoSelf {
 			return libkb.LoginRequiredError{Context: "you must be logged in to encrypt for yourself"}
 		}
+	} else {
+		me, err := libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
+		if err != nil {
+			return err
+		}
+		e.me = me
 	}
 
 	var mykey *libkb.PGPKeyBundle
 	var signer *libkb.PGPKeyBundle
 	if !e.arg.NoSign {
-		me, err := libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
-		if err != nil {
-			return err
-		}
-
 		ska := libkb.SecretKeyArg{
-			Me:       me,
+			Me:       e.me,
 			KeyType:  libkb.PGPKeyType,
 			KeyQuery: e.arg.KeyQuery,
 		}
@@ -106,14 +110,14 @@ func (e *PGPEncrypt) Run(ctx *Context) error {
 		signer = mykey
 	}
 
-	var skipTrack = true
-	if e.arg.TrackOptions.BypassConfirm {
-		skipTrack = false
+	usernames, err := e.verifyUsers(ctx, e.arg.Recips, ok)
+	if err != nil {
+		return err
 	}
 
 	kfarg := &PGPKeyfinderArg{
-		Users:        e.arg.Recips,
-		SkipTrack:    skipTrack,
+		Users:        usernames,
+		SkipTrack:    e.arg.SkipTrack,
 		TrackOptions: e.arg.TrackOptions,
 	}
 
@@ -177,6 +181,59 @@ func (e *PGPEncrypt) loadSelfKey() (*libkb.PGPKeyBundle, error) {
 		return nil, libkb.NoKeyError{Msg: "No PGP key found for encrypting for self"}
 	}
 	return keys[0], nil
+}
+
+func (e *PGPEncrypt) verifyUsers(ctx *Context, assertions []string, loggedIn bool) ([]string, error) {
+	var names []string
+	for _, userAssert := range assertions {
+		var err error
+		var username string
+		if loggedIn && !e.arg.SkipTrack {
+			username, err = e.trackUser(ctx, userAssert)
+		} else {
+			username, err = e.identifyUser(ctx, userAssert)
+		}
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, username)
+	}
+	return names, nil
+}
+
+func (e *PGPEncrypt) trackUser(ctx *Context, assertion string) (string, error) {
+	e.G().Log.Debug("pgp encrypt: tracking user %q", assertion)
+	arg := &TrackEngineArg{
+		Me:                e.me,
+		UserAssertion:     assertion,
+		Options:           e.arg.TrackOptions,
+		AllowSelfIdentify: true,
+	}
+	eng := NewTrackEngine(arg, e.G())
+	if err := RunEngine(eng, ctx); err != nil {
+		// ignore SelfTrackError
+		if _, ok := err.(libkb.SelfTrackError); !ok {
+			return "", err
+		}
+	}
+	if eng.User() == nil {
+		if e.me != nil {
+			panic(fmt.Sprintf("nil user after tracking %q (me = %q)", assertion, e.me.GetName()))
+		} else {
+			panic(fmt.Sprintf("nil user after tracking %q (me = nil too)", assertion))
+		}
+	}
+	return eng.User().GetName(), nil
+}
+
+func (e *PGPEncrypt) identifyUser(ctx *Context, assertion string) (string, error) {
+	e.G().Log.Debug("pgp encrypt: identifying user %q", assertion)
+	arg := NewIdentifyArg(assertion, false, false)
+	eng := NewIdentify(arg, e.G())
+	if err := RunEngine(eng, ctx); err != nil {
+		return "", err
+	}
+	return eng.User().GetName(), nil
 }
 
 // keyset maintains a set of pgp keys, preserving insertion order.

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -116,9 +116,7 @@ func (e *PGPEncrypt) Run(ctx *Context) error {
 	}
 
 	kfarg := &PGPKeyfinderArg{
-		Users:        usernames,
-		SkipTrack:    e.arg.SkipTrack,
-		TrackOptions: e.arg.TrackOptions,
+		Usernames: usernames,
 	}
 
 	kf := NewPGPKeyfinder(kfarg, e.G())

--- a/go/engine/pgp_encrypt_test.go
+++ b/go/engine/pgp_encrypt_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
 )
 
 func TestPGPEncrypt(t *testing.T) {
@@ -23,10 +24,11 @@ func TestPGPEncrypt(t *testing.T) {
 
 	sink := libkb.NewBufferCloser()
 	arg := &PGPEncryptArg{
-		Recips: []string{"t_alice", "t_bob+kbtester1@twitter", "t_charlie+tacovontaco@twitter"},
-		Source: strings.NewReader("track and encrypt, track and encrypt"),
-		Sink:   sink,
-		NoSign: true,
+		Recips:       []string{"t_alice", "t_bob+kbtester1@twitter", "t_charlie+tacovontaco@twitter"},
+		Source:       strings.NewReader("track and encrypt, track and encrypt"),
+		Sink:         sink,
+		NoSign:       true,
+		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
 	}
 
 	eng := NewPGPEncrypt(arg, tc.G)
@@ -52,10 +54,11 @@ func TestPGPEncryptSelfNoKey(t *testing.T) {
 
 	sink := libkb.NewBufferCloser()
 	arg := &PGPEncryptArg{
-		Recips: []string{"t_alice", "t_bob+kbtester1@twitter", "t_charlie+tacovontaco@twitter"},
-		Source: strings.NewReader("track and encrypt, track and encrypt"),
-		Sink:   sink,
-		NoSign: true,
+		Recips:       []string{"t_alice", "t_bob+twitter:kbtester1", "t_charlie+twitter:tacovontaco"},
+		Source:       strings.NewReader("track and encrypt, track and encrypt"),
+		Sink:         sink,
+		NoSign:       true,
+		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
 	}
 
 	eng := NewPGPEncrypt(arg, tc.G)
@@ -80,10 +83,11 @@ func TestPGPEncryptNoTrack(t *testing.T) {
 
 	sink := libkb.NewBufferCloser()
 	arg := &PGPEncryptArg{
-		Recips: []string{"t_alice", "t_bob+kbtester1@twitter", "t_charlie+tacovontaco@twitter"},
-		Source: strings.NewReader("identify and encrypt, identify and encrypt"),
-		Sink:   sink,
-		NoSign: true,
+		Recips:    []string{"t_alice", "t_bob+kbtester1@twitter", "t_charlie+tacovontaco@twitter"},
+		Source:    strings.NewReader("identify and encrypt, identify and encrypt"),
+		Sink:      sink,
+		NoSign:    true,
+		SkipTrack: true,
 	}
 
 	eng := NewPGPEncrypt(arg, tc.G)
@@ -115,10 +119,11 @@ func TestPGPEncryptSelfTwice(t *testing.T) {
 	msg := "encrypt for self only once"
 	sink := libkb.NewBufferCloser()
 	arg := &PGPEncryptArg{
-		Recips: []string{u.Username},
-		Source: strings.NewReader(msg),
-		Sink:   sink,
-		NoSign: true,
+		Recips:       []string{u.Username},
+		Source:       strings.NewReader(msg),
+		Sink:         sink,
+		NoSign:       true,
+		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
 	}
 
 	eng := NewPGPEncrypt(arg, tc.G)

--- a/go/engine/pgp_encrypt_test.go
+++ b/go/engine/pgp_encrypt_test.go
@@ -136,6 +136,7 @@ func TestPGPEncryptSelfTwice(t *testing.T) {
 	}
 	dec := NewPGPDecrypt(decarg, tc.G)
 	ctx.LogUI = tc.G.UI.GetLogUI()
+	ctx.PgpUI = &TestPgpUI{}
 	if err := RunEngine(dec, ctx); err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/pgp_keyfinder.go
+++ b/go/engine/pgp_keyfinder.go
@@ -7,24 +7,19 @@ import (
 	"fmt"
 
 	"github.com/keybase/client/go/libkb"
-	keybase1 "github.com/keybase/client/go/protocol"
 )
 
 // PGPKeyfinder is an engine to find PGP Keys for users (loaded by
 // assertions), possibly tracking them if necessary.
 type PGPKeyfinder struct {
-	arg      *PGPKeyfinderArg
-	uplus    []*UserPlusKeys
-	loggedIn bool
-	me       *libkb.User
-	runerr   error
+	arg    *PGPKeyfinderArg
+	uplus  []*UserPlusKeys
+	runerr error
 	libkb.Contextified
 }
 
 type PGPKeyfinderArg struct {
-	Users        []string
-	SkipTrack    bool
-	TrackOptions keybase1.TrackOptions
+	Usernames []string // must be keybase usernames
 }
 
 // NewPGPKeyfinder creates a PGPKeyfinder engine.
@@ -52,16 +47,12 @@ func (e *PGPKeyfinder) RequiredUIs() []libkb.UIKind {
 
 // SubConsumers returns the other UI consumers for this engine.
 func (e *PGPKeyfinder) SubConsumers() []libkb.UIConsumer {
-	return []libkb.UIConsumer{
-		&TrackEngine{},
-		&Identify{},
-	}
+	return []libkb.UIConsumer{}
 }
 
 // Run starts the engine.
 func (e *PGPKeyfinder) Run(ctx *Context) error {
-	e.setup(ctx)
-	e.verifyUsers(ctx)
+	e.loadUsers(ctx)
 	e.loadKeys(ctx)
 	return e.runerr
 }
@@ -72,78 +63,13 @@ func (e *PGPKeyfinder) UsersPlusKeys() []*UserPlusKeys {
 	return e.uplus
 }
 
-func (e *PGPKeyfinder) setup(ctx *Context) {
-	if e.runerr != nil {
-		return
-	}
-
-	ok, err := IsLoggedIn(e, ctx)
-	if err != nil {
-		e.runerr = err
-		return
-	}
-	e.loggedIn = ok
-}
-
-func (e *PGPKeyfinder) verifyUsers(ctx *Context) {
-	if e.runerr != nil {
-		return
-	}
-
-	if e.loggedIn && !e.arg.SkipTrack {
-		e.loadMe()
-	}
-
-	e.loadUsers(ctx)
-
-	/*
-		if e.loggedIn && !e.arg.SkipTrack {
-			e.loadMe()
-			e.trackUsers(ctx)
-		} else {
-			e.identifyUsers(ctx)
-		}
-	*/
-}
-
-func (e *PGPKeyfinder) trackUsers(ctx *Context) {
-	if e.runerr != nil {
-		return
-	}
-
-	// need to track any users we aren't tracking
-	for _, u := range e.arg.Users {
-		if err := e.trackUser(ctx, u); err != nil {
-			// ignore self track errors
-			if _, ok := err.(libkb.SelfTrackError); !ok {
-				e.runerr = err
-				return
-			}
-		}
-	}
-}
-
-func (e *PGPKeyfinder) identifyUsers(ctx *Context) {
-	if e.runerr != nil {
-		return
-	}
-
-	// need to identify all the users
-	for _, u := range e.arg.Users {
-		if err := e.identifyUser(ctx, u); err != nil {
-			e.runerr = err
-			return
-		}
-	}
-}
-
 // don't identify or track, just load the users
 func (e *PGPKeyfinder) loadUsers(ctx *Context) {
 	if e.runerr != nil {
 		return
 	}
 
-	for _, u := range e.arg.Users {
+	for _, u := range e.arg.Usernames {
 		arg := libkb.NewLoadUserByNameArg(e.G(), u)
 		user, err := libkb.LoadUser(arg)
 		if err != nil {
@@ -171,53 +97,10 @@ func (e *PGPKeyfinder) loadKeys(ctx *Context) {
 	}
 }
 
-func (e *PGPKeyfinder) trackUser(ctx *Context, username string) error {
-	e.G().Log.Debug("tracking user %q", username)
-	arg := &TrackEngineArg{
-		Me:            e.me,
-		UserAssertion: username,
-		Options:       e.arg.TrackOptions,
-	}
-	eng := NewTrackEngine(arg, e.G())
-	if err := RunEngine(eng, ctx); err != nil {
-		return err
-	}
-	e.addUser(eng.User(), true)
-	return nil
-}
-
-// PC: maybe we need to bring the TrackUI back for the
-// context...so that this one can use an IdentifyUI and trackUser
-// can use a TrackUI...
-func (e *PGPKeyfinder) identifyUser(ctx *Context, user string) error {
-	arg := NewIdentifyArg(user, false, false)
-	eng := NewIdentify(arg, e.G())
-	if err := RunEngine(eng, ctx); err != nil {
-		return err
-	}
-	e.addUser(eng.User(), false)
-	return nil
-}
-
 type UserPlusKeys struct {
 	User      *libkb.User
 	IsTracked bool
 	Keys      []*libkb.PGPKeyBundle
-}
-
-func (e *PGPKeyfinder) loadMe() {
-	if e.runerr != nil {
-		return
-	}
-	if e.me != nil {
-		return
-	}
-	me, err := libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
-	if err != nil {
-		e.runerr = err
-		return
-	}
-	e.me = me
 }
 
 func (e *PGPKeyfinder) addUser(user *libkb.User, tracked bool) {

--- a/go/engine/pgp_keyfinder.go
+++ b/go/engine/pgp_keyfinder.go
@@ -92,10 +92,18 @@ func (e *PGPKeyfinder) verifyUsers(ctx *Context) {
 
 	if e.loggedIn && !e.arg.SkipTrack {
 		e.loadMe()
-		e.trackUsers(ctx)
-	} else {
-		e.identifyUsers(ctx)
 	}
+
+	e.loadUsers(ctx)
+
+	/*
+		if e.loggedIn && !e.arg.SkipTrack {
+			e.loadMe()
+			e.trackUsers(ctx)
+		} else {
+			e.identifyUsers(ctx)
+		}
+	*/
 }
 
 func (e *PGPKeyfinder) trackUsers(ctx *Context) {
@@ -127,6 +135,24 @@ func (e *PGPKeyfinder) identifyUsers(ctx *Context) {
 			return
 		}
 	}
+}
+
+// don't identify or track, just load the users
+func (e *PGPKeyfinder) loadUsers(ctx *Context) {
+	if e.runerr != nil {
+		return
+	}
+
+	for _, u := range e.arg.Users {
+		arg := libkb.NewLoadUserByNameArg(e.G(), u)
+		user, err := libkb.LoadUser(arg)
+		if err != nil {
+			e.runerr = err
+			return
+		}
+		e.addUser(user, false)
+	}
+
 }
 
 func (e *PGPKeyfinder) loadKeys(ctx *Context) {

--- a/go/engine/pgp_keyfinder_test.go
+++ b/go/engine/pgp_keyfinder_test.go
@@ -26,7 +26,7 @@ func TestPGPKeyfinder(t *testing.T) {
 
 	ctx := &Context{IdentifyUI: trackUI, SecretUI: u.NewSecretUI()}
 	arg := &PGPKeyfinderArg{
-		Users:     []string{"t_alice", "t_bob+kbtester1@twitter", "t_charlie+tacovontaco@twitter"},
+		Users:     []string{"t_alice", "t_bob", "t_charlie"},
 		SkipTrack: true,
 	}
 	eng := NewPGPKeyfinder(arg, tc.G)
@@ -50,7 +50,7 @@ func TestPGPKeyfinderLoggedOut(t *testing.T) {
 
 	ctx := &Context{IdentifyUI: trackUI, SecretUI: &libkb.TestSecretUI{}}
 	arg := &PGPKeyfinderArg{
-		Users: []string{"t_alice", "t_bob+kbtester1@twitter", "t_charlie+tacovontaco@twitter"},
+		Users: []string{"t_alice", "t_bob", "t_charlie"},
 	}
 	eng := NewPGPKeyfinder(arg, tc.G)
 	if err := RunEngine(eng, ctx); err != nil {

--- a/go/engine/pgp_keyfinder_test.go
+++ b/go/engine/pgp_keyfinder_test.go
@@ -5,11 +5,7 @@
 
 package engine
 
-import (
-	"testing"
-
-	"github.com/keybase/client/go/libkb"
-)
+import "testing"
 
 func TestPGPKeyfinder(t *testing.T) {
 	tc := SetupEngineTest(t, "PGPKeyfinder")
@@ -20,14 +16,9 @@ func TestPGPKeyfinder(t *testing.T) {
 	trackAlice(tc, u)
 	defer untrackAlice(tc, u)
 
-	trackUI := &FakeIdentifyUI{
-		Proofs: make(map[string]string),
-	}
-
-	ctx := &Context{IdentifyUI: trackUI, SecretUI: u.NewSecretUI()}
+	ctx := &Context{}
 	arg := &PGPKeyfinderArg{
-		Users:     []string{"t_alice", "t_bob", "t_charlie"},
-		SkipTrack: true,
+		Usernames: []string{"t_alice", "t_bob", "t_charlie"},
 	}
 	eng := NewPGPKeyfinder(arg, tc.G)
 	if err := RunEngine(eng, ctx); err != nil {
@@ -44,13 +35,9 @@ func TestPGPKeyfinderLoggedOut(t *testing.T) {
 	tc := SetupEngineTest(t, "PGPKeyfinder")
 	defer tc.Cleanup()
 
-	trackUI := &FakeIdentifyUI{
-		Proofs: make(map[string]string),
-	}
-
-	ctx := &Context{IdentifyUI: trackUI, SecretUI: &libkb.TestSecretUI{}}
+	ctx := &Context{}
 	arg := &PGPKeyfinderArg{
-		Users: []string{"t_alice", "t_bob", "t_charlie"},
+		Usernames: []string{"t_alice", "t_bob", "t_charlie"},
 	}
 	eng := NewPGPKeyfinder(arg, tc.G)
 	if err := RunEngine(eng, ctx); err != nil {

--- a/go/engine/pgp_sign.go
+++ b/go/engine/pgp_sign.go
@@ -128,6 +128,5 @@ func (p *PGPSignEngine) Run(ctx *Context) (err error) {
 			p.G().Log.Debug("Empty source file.")
 		}
 	}
-
 	return
 }

--- a/go/engine/pgp_test.go
+++ b/go/engine/pgp_test.go
@@ -227,7 +227,6 @@ func (p *pgpPair) doDecrypt(msg string, arg *PGPDecryptArg) (int, int) {
 	ctx := decengctx(p.recipient, p.tcR)
 	arg.Source = strings.NewReader(msg)
 	arg.Sink = libkb.NewBufferCloser()
-	arg.TrackOptions = keybase1.TrackOptions{BypassConfirm: true}
 	dec := NewPGPDecrypt(arg, p.tcR.G)
 	if err := RunEngine(dec, ctx); err != nil {
 		debug.PrintStack()
@@ -239,8 +238,7 @@ func (p *pgpPair) doDecrypt(msg string, arg *PGPDecryptArg) (int, int) {
 func (p *pgpPair) verify(msg string) (int, int) {
 	ctx := decengctx(p.recipient, p.tcR)
 	arg := &PGPVerifyArg{
-		Source:       strings.NewReader(msg),
-		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
+		Source: strings.NewReader(msg),
 	}
 	eng := NewPGPVerify(arg, p.tcR.G)
 	if err := RunEngine(eng, ctx); err != nil {
@@ -252,9 +250,8 @@ func (p *pgpPair) verify(msg string) (int, int) {
 func (p *pgpPair) verifyAssertSignedBySender(msg string) (int, int) {
 	ctx := decengctx(p.recipient, p.tcR)
 	arg := &PGPVerifyArg{
-		Source:       strings.NewReader(msg),
-		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
-		SignedBy:     p.sender.Username,
+		Source:   strings.NewReader(msg),
+		SignedBy: p.sender.Username,
 	}
 	eng := NewPGPVerify(arg, p.tcR.G)
 	if err := RunEngine(eng, ctx); err != nil {
@@ -266,8 +263,7 @@ func (p *pgpPair) verifyAssertSignedBySender(msg string) (int, int) {
 func (p *pgpPair) verifySelf(msg string) (int, int) {
 	ctx := decengctx(p.sender, p.tcS)
 	arg := &PGPVerifyArg{
-		Source:       strings.NewReader(msg),
-		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
+		Source: strings.NewReader(msg),
 	}
 	eng := NewPGPVerify(arg, p.tcS.G)
 	if err := RunEngine(eng, ctx); err != nil {
@@ -279,9 +275,8 @@ func (p *pgpPair) verifySelf(msg string) (int, int) {
 func (p *pgpPair) verifyAssertSignedBySelf(msg string) (int, int) {
 	ctx := decengctx(p.sender, p.tcS)
 	arg := &PGPVerifyArg{
-		Source:       strings.NewReader(msg),
-		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
-		SignedBy:     p.sender.Username,
+		Source:   strings.NewReader(msg),
+		SignedBy: p.sender.Username,
 	}
 	eng := NewPGPVerify(arg, p.tcS.G)
 	if err := RunEngine(eng, ctx); err != nil {

--- a/go/engine/pgp_test.go
+++ b/go/engine/pgp_test.go
@@ -4,9 +4,12 @@
 package engine
 
 import (
+	"runtime/debug"
+	"strings"
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
 )
 
 func TestGenerateNewPGPKey(t *testing.T) {
@@ -30,4 +33,275 @@ func TestGenerateNewPGPKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestPGPUserInterface(t *testing.T) {
+	p := newPgpPair(t)
+	defer p.cleanup()
+
+	p.assert(!p.senderTracksRecipient(), "sender shouldn't track recipient")
+	p.assert(!p.recipientTracksSender(), "recipient shouldn't track sender")
+
+	// encrypt, not signed
+	notSigned, idCount := p.encrypt(false)
+
+	// test that identify ui was shown once to sender for recipient
+	p.assertEqual(idCount, 1, "identify ui count")
+	// test that sender tracks recipient
+	p.assert(p.senderTracksRecipient(), "after encrypt, sender should track recipient")
+	p.assert(!p.recipientTracksSender(), "after encrypt, recipient shouldn't track sender")
+
+	// encrypt, signed
+	signed, idCount := p.encrypt(true)
+
+	// test that identify ui was shown once to sender for recipient
+	p.assertEqual(idCount, 1, "identify ui count")
+	// test that sender tracks recipient
+	p.assert(p.senderTracksRecipient(), "after encrypt, sender should track recipient")
+	p.assert(!p.recipientTracksSender(), "after encrypt, recipient shouldn't track sender")
+
+	// decrypt, not signed
+	p.checkIdentifyUIAndPgpUI("decrypt not signed", p.decrypt, notSigned, 0)
+
+	// decrypt signed
+	p.checkIdentifyUIAndPgpUI("decrypt signed", p.decrypt, signed, 1)
+
+	// decrypt signed, assert signed by anyone
+	p.checkIdentifyUIAndPgpUI("decrypt assert signed", p.decryptAssertSigned, signed, 1)
+
+	// decrypt signed with user assertion
+	p.checkIdentifyUIAndPgpUI("decrypt assert signed by", p.decryptAssertSignedBySender, signed, 1)
+
+	// decrypt signed by self
+	p.checkIdentifyUIAndPgpUI("decrypt self", p.decryptSelf, signed, 1)
+
+	// decrypt assert signed by self
+	p.checkIdentifyUIAndPgpUI("decrypt assert signed by self", p.decryptAssertSignedBySelf, signed, 1)
+
+	// verify signed
+	p.checkIdentifyUIAndPgpUI("verify signed", p.verify, signed, 1)
+
+	// verify signed with assertion
+	p.checkIdentifyUIAndPgpUI("verify assert signed by", p.verifyAssertSignedBySender, signed, 1)
+
+	// verify signed by self
+	p.checkIdentifyUIAndPgpUI("verify self", p.verifySelf, signed, 1)
+
+	// verify assert signed by self
+	p.checkIdentifyUIAndPgpUI("verify assert signed by self", p.verifyAssertSignedBySelf, signed, 1)
+}
+
+type pgpPair struct {
+	t         *testing.T
+	tcS       libkb.TestContext
+	tcR       libkb.TestContext
+	sender    *FakeUser
+	recipient *FakeUser
+}
+
+func newPgpPair(t *testing.T) *pgpPair {
+	p := pgpPair{t: t}
+	p.tcS = SetupEngineTest(t, "sender")
+	p.sender = createFakeUserWithPGPSibkey(p.tcS)
+
+	p.tcR = SetupEngineTest(t, "recip")
+	p.recipient = createFakeUserWithPGPSibkey(p.tcR)
+	return &p
+}
+
+func (p *pgpPair) cleanup() {
+	p.tcS.Cleanup()
+	p.tcR.Cleanup()
+}
+
+func (p *pgpPair) assert(b bool, m string) {
+	if b {
+		return
+	}
+	p.t.Error(m)
+}
+
+func (p *pgpPair) assertEqual(actual, expected int, m string) {
+	if actual == expected {
+		return
+	}
+	p.t.Errorf("%s: %d, expected %d", m, actual, expected)
+}
+
+func (p *pgpPair) checkIdentifyUIAndPgpUI(name string, f func(string) (int, int), m string, n int) {
+	idCount, sigCount := f(m)
+
+	// test that identify ui was shown n times
+	p.assertEqual(idCount, n, name+": identify ui count")
+	// test that recipient does not track sender
+	p.assert(!p.recipientTracksSender(), name+": recipient shouldn't track sender")
+	// test that signature success was shown n times
+	p.assertEqual(sigCount, n, name+": sig ui count")
+}
+
+func (p *pgpPair) senderTracksRecipient() bool {
+	return p.isTracking(p.tcS, p.recipient.Username)
+}
+
+func (p *pgpPair) recipientTracksSender() bool {
+	return p.isTracking(p.tcR, p.sender.Username)
+}
+
+func (p *pgpPair) isTracking(meContext libkb.TestContext, username string) bool {
+	me, err := libkb.LoadMe(libkb.NewLoadUserArg(meContext.G))
+	if err != nil {
+		p.t.Fatal(err)
+	}
+	them, err := libkb.LoadUser(libkb.NewLoadUserByNameArg(meContext.G, username))
+	if err != nil {
+		p.t.Fatal(err)
+	}
+	s, err := me.TrackChainLinkFor(them.GetName(), them.GetUID())
+	if err != nil {
+		p.t.Fatal(err)
+	}
+	return s != nil
+}
+
+func (p *pgpPair) encrypt(sign bool) (string, int) {
+	ctx := &Context{IdentifyUI: &FakeIdentifyUI{}, SecretUI: p.sender.NewSecretUI()}
+	sink := libkb.NewBufferCloser()
+	arg := &PGPEncryptArg{
+		Recips:       []string{p.recipient.Username},
+		Source:       strings.NewReader("thank you for your order"),
+		Sink:         sink,
+		NoSign:       !sign,
+		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
+	}
+
+	eng := NewPGPEncrypt(arg, p.tcS.G)
+	if err := RunEngine(eng, ctx); err != nil {
+		p.t.Fatal(err)
+	}
+
+	out := sink.Bytes()
+
+	return string(out), p.idc(ctx)
+}
+
+func (p *pgpPair) decrypt(msg string) (int, int) {
+	return p.doDecrypt(msg, &PGPDecryptArg{})
+}
+
+func (p *pgpPair) decryptAssertSigned(msg string) (int, int) {
+	return p.doDecrypt(msg, &PGPDecryptArg{AssertSigned: true})
+}
+
+func (p *pgpPair) decryptAssertSignedBySender(msg string) (int, int) {
+	return p.doDecrypt(msg, &PGPDecryptArg{SignedBy: p.sender.Username})
+}
+
+func (p *pgpPair) decryptSelf(msg string) (int, int) {
+	ctx := decengctx(p.sender, p.tcS)
+	arg := &PGPDecryptArg{
+		Source: strings.NewReader(msg),
+		Sink:   libkb.NewBufferCloser(),
+	}
+	dec := NewPGPDecrypt(arg, p.tcS.G)
+	if err := RunEngine(dec, ctx); err != nil {
+		p.t.Fatal(err)
+	}
+	return p.idc(ctx), p.sigc(ctx)
+}
+
+func (p *pgpPair) decryptAssertSignedBySelf(msg string) (int, int) {
+	ctx := decengctx(p.sender, p.tcS)
+	arg := &PGPDecryptArg{
+		Source:   strings.NewReader(msg),
+		Sink:     libkb.NewBufferCloser(),
+		SignedBy: p.sender.Username,
+	}
+	dec := NewPGPDecrypt(arg, p.tcS.G)
+	if err := RunEngine(dec, ctx); err != nil {
+		p.t.Fatal(err)
+	}
+	return p.idc(ctx), p.sigc(ctx)
+}
+
+func (p *pgpPair) doDecrypt(msg string, arg *PGPDecryptArg) (int, int) {
+	ctx := decengctx(p.recipient, p.tcR)
+	arg.Source = strings.NewReader(msg)
+	arg.Sink = libkb.NewBufferCloser()
+	arg.TrackOptions = keybase1.TrackOptions{BypassConfirm: true}
+	dec := NewPGPDecrypt(arg, p.tcR.G)
+	if err := RunEngine(dec, ctx); err != nil {
+		debug.PrintStack()
+		p.t.Fatal(err)
+	}
+	return p.idc(ctx), p.sigc(ctx)
+}
+
+func (p *pgpPair) verify(msg string) (int, int) {
+	ctx := decengctx(p.recipient, p.tcR)
+	arg := &PGPVerifyArg{
+		Source:       strings.NewReader(msg),
+		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
+	}
+	eng := NewPGPVerify(arg, p.tcR.G)
+	if err := RunEngine(eng, ctx); err != nil {
+		p.t.Fatal(err)
+	}
+	return p.idc(ctx), p.sigc(ctx)
+}
+
+func (p *pgpPair) verifyAssertSignedBySender(msg string) (int, int) {
+	ctx := decengctx(p.recipient, p.tcR)
+	arg := &PGPVerifyArg{
+		Source:       strings.NewReader(msg),
+		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
+		SignedBy:     p.sender.Username,
+	}
+	eng := NewPGPVerify(arg, p.tcR.G)
+	if err := RunEngine(eng, ctx); err != nil {
+		p.t.Fatal(err)
+	}
+	return p.idc(ctx), p.sigc(ctx)
+}
+
+func (p *pgpPair) verifySelf(msg string) (int, int) {
+	ctx := decengctx(p.sender, p.tcS)
+	arg := &PGPVerifyArg{
+		Source:       strings.NewReader(msg),
+		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
+	}
+	eng := NewPGPVerify(arg, p.tcS.G)
+	if err := RunEngine(eng, ctx); err != nil {
+		p.t.Fatal(err)
+	}
+	return p.idc(ctx), p.sigc(ctx)
+}
+
+func (p *pgpPair) verifyAssertSignedBySelf(msg string) (int, int) {
+	ctx := decengctx(p.sender, p.tcS)
+	arg := &PGPVerifyArg{
+		Source:       strings.NewReader(msg),
+		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
+		SignedBy:     p.sender.Username,
+	}
+	eng := NewPGPVerify(arg, p.tcS.G)
+	if err := RunEngine(eng, ctx); err != nil {
+		p.t.Fatal(err)
+	}
+	return p.idc(ctx), p.sigc(ctx)
+}
+
+func (p *pgpPair) idc(ctx *Context) int {
+	ui, ok := ctx.IdentifyUI.(*FakeIdentifyUI)
+	if !ok {
+		p.t.Fatalf("not FakeIdentifyUI: %T", ctx.IdentifyUI)
+	}
+	return ui.StartCount
+}
+
+func (p *pgpPair) sigc(ctx *Context) int {
+	ui, ok := ctx.PgpUI.(*TestPgpUI)
+	if !ok {
+		p.t.Fatalf("not TestPgpUI: %T", ctx.PgpUI)
+	}
+	return ui.OutputCount
 }

--- a/go/engine/pgp_verify.go
+++ b/go/engine/pgp_verify.go
@@ -54,7 +54,7 @@ func (e *PGPVerify) Prereqs() Prereqs {
 
 // RequiredUIs returns the required UIs.
 func (e *PGPVerify) RequiredUIs() []libkb.UIKind {
-	return []libkb.UIKind{}
+	return []libkb.UIKind{libkb.PgpUIKind}
 }
 
 // SubConsumers returns the other UI consumers for this engine.

--- a/go/engine/pgp_verify.go
+++ b/go/engine/pgp_verify.go
@@ -92,6 +92,7 @@ func (e *PGPVerify) runAttached(ctx *Context) error {
 		Source:       e.peek,
 		Sink:         libkb.NopWriteCloser{W: ioutil.Discard},
 		AssertSigned: true,
+		SignedBy:     e.arg.SignedBy,
 		TrackOptions: e.arg.TrackOptions,
 	}
 	eng := NewPGPDecrypt(arg, e.G())
@@ -100,10 +101,6 @@ func (e *PGPVerify) runAttached(ctx *Context) error {
 	}
 	e.signStatus = eng.SignatureStatus()
 	e.owner = eng.Owner()
-
-	if err := e.checkSignedBy(ctx); err != nil {
-		return err
-	}
 
 	return nil
 }

--- a/go/engine/pgp_verify.go
+++ b/go/engine/pgp_verify.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 
 	"github.com/keybase/client/go/libkb"
-	keybase1 "github.com/keybase/client/go/protocol"
 	"github.com/keybase/go-crypto/openpgp"
 	"github.com/keybase/go-crypto/openpgp/armor"
 	"github.com/keybase/go-crypto/openpgp/clearsign"
@@ -19,10 +18,9 @@ import (
 )
 
 type PGPVerifyArg struct {
-	Source       io.Reader
-	Signature    []byte
-	SignedBy     string
-	TrackOptions keybase1.TrackOptions
+	Source    io.Reader
+	Signature []byte
+	SignedBy  string
 }
 
 // PGPVerify is an engine.
@@ -93,7 +91,6 @@ func (e *PGPVerify) runAttached(ctx *Context) error {
 		Sink:         libkb.NopWriteCloser{W: ioutil.Discard},
 		AssertSigned: true,
 		SignedBy:     e.arg.SignedBy,
-		TrackOptions: e.arg.TrackOptions,
 	}
 	eng := NewPGPDecrypt(arg, e.G())
 	if err := RunEngine(eng, ctx); err != nil {

--- a/go/engine/pgp_verify.go
+++ b/go/engine/pgp_verify.go
@@ -107,7 +107,7 @@ func (e *PGPVerify) runAttached(ctx *Context) error {
 
 // runDetached verifies a detached signature
 func (e *PGPVerify) runDetached(ctx *Context) error {
-	sk, err := NewScanKeys(ctx.SecretUI, ctx.IdentifyUI, &e.arg.TrackOptions, e.G())
+	sk, err := NewScanKeys(ctx.SecretUI, e.G())
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (e *PGPVerify) runClearsign(ctx *Context) error {
 		return err
 	}
 
-	sk, err := NewScanKeys(ctx.SecretUI, ctx.IdentifyUI, &e.arg.TrackOptions, e.G())
+	sk, err := NewScanKeys(ctx.SecretUI, e.G())
 	if err != nil {
 		return err
 	}

--- a/go/engine/pgp_verify_test.go
+++ b/go/engine/pgp_verify_test.go
@@ -135,7 +135,7 @@ func verify(ctx *Context, tc libkb.TestContext, msg, sig, name string, valid boo
 	if !ok {
 		tc.T.Fatalf("%s: invalid pgp ui: %T", name, ctx.PgpUI)
 	}
-	if !p.outputCalled {
+	if p.OutputCount == 0 {
 		tc.T.Errorf("%s: did not output signature success", name)
 	}
 }

--- a/go/engine/pgp_verify_test.go
+++ b/go/engine/pgp_verify_test.go
@@ -104,9 +104,8 @@ func signEnc(ctx *Context, tc libkb.TestContext, msg string) string {
 
 func verify(ctx *Context, tc libkb.TestContext, msg, sig, name string, valid bool) {
 	arg := &PGPVerifyArg{
-		Source:       strings.NewReader(msg),
-		Signature:    []byte(sig),
-		TrackOptions: keybase1.TrackOptions{BypassConfirm: true},
+		Source:    strings.NewReader(msg),
+		Signature: []byte(sig),
 	}
 	eng := NewPGPVerify(arg, tc.G)
 	if err := RunEngine(eng, ctx); err != nil {

--- a/go/engine/pgp_verify_test.go
+++ b/go/engine/pgp_verify_test.go
@@ -21,6 +21,7 @@ func TestPGPVerify(t *testing.T) {
 		IdentifyUI: &FakeIdentifyUI{},
 		SecretUI:   fu.NewSecretUI(),
 		LogUI:      tc.G.UI.GetLogUI(),
+		PgpUI:      &TestPgpUI{},
 	}
 
 	msg := "If you wish to stop receiving notifications from this topic, please click or visit the link below to unsubscribe:"
@@ -129,5 +130,12 @@ func verify(ctx *Context, tc libkb.TestContext, msg, sig, name string, valid boo
 	if s.CalledGetKBPassphrase {
 		tc.T.Errorf("%s: called get kb passphrase, shouldn't have", name)
 		s.CalledGetKBPassphrase = false // reset it for next caller
+	}
+	p, ok := ctx.PgpUI.(*TestPgpUI)
+	if !ok {
+		tc.T.Fatalf("%s: invalid pgp ui: %T", name, ctx.PgpUI)
+	}
+	if !p.outputCalled {
+		tc.T.Errorf("%s: did not output signature success", name)
 	}
 }

--- a/go/engine/scankeys_test.go
+++ b/go/engine/scankeys_test.go
@@ -11,7 +11,7 @@ func TestScanKeys(t *testing.T) {
 
 	fu := CreateAndSignupFakeUser(tc, "login")
 
-	sk, err := NewScanKeys(fu.NewSecretUI(), &FakeIdentifyUI{}, nil, tc.G)
+	sk, err := NewScanKeys(fu.NewSecretUI(), tc.G)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,7 +27,7 @@ func TestScanKeysSync(t *testing.T) {
 	defer tc.Cleanup()
 	fu := createFakeUserWithPGPOnly(t, tc)
 
-	sk, err := NewScanKeys(fu.NewSecretUI(), &FakeIdentifyUI{}, nil, tc.G)
+	sk, err := NewScanKeys(fu.NewSecretUI(), tc.G)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/track.go
+++ b/go/engine/track.go
@@ -11,10 +11,11 @@ import (
 )
 
 type TrackEngineArg struct {
-	UserAssertion    string
-	Me               *libkb.User
-	Options          keybase1.TrackOptions
-	ForceRemoteCheck bool
+	UserAssertion     string
+	Me                *libkb.User
+	Options           keybase1.TrackOptions
+	ForceRemoteCheck  bool
+	AllowSelfIdentify bool
 }
 
 type TrackEngine struct {
@@ -56,6 +57,7 @@ func (e *TrackEngine) SubConsumers() []libkb.UIConsumer {
 
 func (e *TrackEngine) Run(ctx *Context) error {
 	iarg := NewIdentifyTrackArg(e.arg.UserAssertion, true, e.arg.ForceRemoteCheck, e.arg.Options)
+	iarg.AllowSelf = e.arg.AllowSelfIdentify
 	ieng := NewIdentify(iarg, e.G())
 	if err := RunEngine(ieng, ctx); err != nil {
 		e.G().Log.Info("identify run err: %s", err)

--- a/go/engine/track.go
+++ b/go/engine/track.go
@@ -60,7 +60,6 @@ func (e *TrackEngine) Run(ctx *Context) error {
 	iarg.AllowSelf = e.arg.AllowSelfIdentify
 	ieng := NewIdentify(iarg, e.G())
 	if err := RunEngine(ieng, ctx); err != nil {
-		e.G().Log.Info("identify run err: %s", err)
 		return err
 	}
 

--- a/go/libkb/assertion.go
+++ b/go/libkb/assertion.go
@@ -6,7 +6,6 @@ package libkb
 import (
 	"fmt"
 	"regexp"
-	"runtime/debug"
 	"strings"
 
 	keybase1 "github.com/keybase/client/go/protocol"
@@ -297,7 +296,6 @@ func (a AssertionUID) Check() (err error) {
 
 func (a AssertionSocial) Check() (err error) {
 	if ok, found := _socialNetworks[strings.ToLower(a.Key)]; !ok || !found {
-		debug.PrintStack()
 		err = fmt.Errorf("Unknown social network: %s", a.Key)
 	}
 	return

--- a/go/libkb/assertion.go
+++ b/go/libkb/assertion.go
@@ -6,6 +6,7 @@ package libkb
 import (
 	"fmt"
 	"regexp"
+	"runtime/debug"
 	"strings"
 
 	keybase1 "github.com/keybase/client/go/protocol"
@@ -296,6 +297,7 @@ func (a AssertionUID) Check() (err error) {
 
 func (a AssertionSocial) Check() (err error) {
 	if ok, found := _socialNetworks[strings.ToLower(a.Key)]; !ok || !found {
+		debug.PrintStack()
 		err = fmt.Errorf("Unknown social network: %s", a.Key)
 	}
 	return

--- a/go/libkb/assertion_test.go
+++ b/go/libkb/assertion_test.go
@@ -123,3 +123,23 @@ func TestAssertions2(t *testing.T) {
 		}
 	}
 }
+
+func TestAssertions3(t *testing.T) {
+	a := "t_bob+twitter:kbtester1"
+	goodProofsets := []ProofSet{
+		*NewProofSet([]Proof{
+			{"twitter", "kbtester1"},
+			{"keybase", "t_bob"},
+		}),
+	}
+	expr, err := AssertionParseAndOnly(a)
+	if err != nil {
+		t.Errorf("Error parsing %s: %s", a, err)
+	} else {
+		for i, proofset := range goodProofsets {
+			if !expr.MatchSet(proofset) {
+				t.Errorf("proofset %d failed to match", i)
+			}
+		}
+	}
+}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -342,6 +342,7 @@ type UI interface {
 	GetLogUI() LogUI
 	GetGPGUI() GPGUI
 	GetProvisionUI(role KexRole) ProvisionUI
+	GetPgpUI() PgpUI
 	Configure() error
 	Shutdown() error
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -298,6 +298,10 @@ type GPGUI interface {
 	keybase1.GpgUiInterface
 }
 
+type PgpUI interface {
+	keybase1.PGPUiInterface
+}
+
 type ProvisionUI interface {
 	keybase1.ProvisionUiInterface
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -319,6 +319,7 @@ type PromptDescriptor int
 type TerminalUI interface {
 	OutputWriter() io.Writer
 	Output(string) error
+	ErrorWriter() io.Writer
 	Printf(fmt string, args ...interface{}) (int, error)
 	PromptYesNo(PromptDescriptor, string, PromptDefault) (bool, error)
 	Prompt(PromptDescriptor, string) (string, error)

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -323,6 +323,9 @@ func (n *nullui) GetGPGUI() GPGUI {
 func (n *nullui) GetLogUI() LogUI {
 	return n.gctx.Log
 }
+func (n *nullui) GetPgpUI() PgpUI {
+	return nil
+}
 func (n *nullui) GetProvisionUI(KexRole) ProvisionUI {
 	return nil
 }

--- a/go/libkb/uigroup.go
+++ b/go/libkb/uigroup.go
@@ -15,6 +15,7 @@ const (
 	ProveUIKind
 	SecretUIKind
 	ProvisionUIKind
+	PgpUIKind
 )
 
 func (u UIKind) String() string {
@@ -33,6 +34,8 @@ func (u UIKind) String() string {
 		return "SecretUI"
 	case ProvisionUIKind:
 		return "ProvisionUI"
+	case PgpUIKind:
+		return "PgpUI"
 	}
 	panic(fmt.Sprintf("unhandled uikind: %d", u))
 }

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -3213,15 +3213,13 @@ type PGPSigVerification struct {
 }
 
 type PGPDecryptOptions struct {
-	AssertSigned bool         `codec:"assertSigned" json:"assertSigned"`
-	SignedBy     string       `codec:"signedBy" json:"signedBy"`
-	TrackOptions TrackOptions `codec:"trackOptions" json:"trackOptions"`
+	AssertSigned bool   `codec:"assertSigned" json:"assertSigned"`
+	SignedBy     string `codec:"signedBy" json:"signedBy"`
 }
 
 type PGPVerifyOptions struct {
-	SignedBy     string       `codec:"signedBy" json:"signedBy"`
-	TrackOptions TrackOptions `codec:"trackOptions" json:"trackOptions"`
-	Signature    []byte       `codec:"signature" json:"signature"`
+	SignedBy  string `codec:"signedBy" json:"signedBy"`
+	Signature []byte `codec:"signature" json:"signature"`
 }
 
 type KeyInfo struct {

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -3650,6 +3650,50 @@ func (c PGPClient) PGPUpdate(ctx context.Context, __arg PGPUpdateArg) (err error
 	return
 }
 
+type OutputSignatureSuccessArg struct {
+	SessionID   int    `codec:"sessionID" json:"sessionID"`
+	Fingerprint string `codec:"fingerprint" json:"fingerprint"`
+	Username    string `codec:"username" json:"username"`
+	SignedAt    Time   `codec:"signedAt" json:"signedAt"`
+}
+
+type PGPUiInterface interface {
+	OutputSignatureSuccess(context.Context, OutputSignatureSuccessArg) error
+}
+
+func PGPUiProtocol(i PGPUiInterface) rpc.Protocol {
+	return rpc.Protocol{
+		Name: "keybase.1.pgpUi",
+		Methods: map[string]rpc.ServeHandlerDescription{
+			"outputSignatureSuccess": {
+				MakeArg: func() interface{} {
+					ret := make([]OutputSignatureSuccessArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]OutputSignatureSuccessArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]OutputSignatureSuccessArg)(nil), args)
+						return
+					}
+					err = i.OutputSignatureSuccess(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+		},
+	}
+}
+
+type PGPUiClient struct {
+	Cli GenericClient
+}
+
+func (c PGPUiClient) OutputSignatureSuccess(ctx context.Context, __arg OutputSignatureSuccessArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.pgpUi.outputSignatureSuccess", []interface{}{__arg}, nil)
+	return
+}
+
 type CheckProofStatus struct {
 	Found     bool        `codec:"found" json:"found"`
 	Status    ProofStatus `codec:"status" json:"status"`

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -3201,6 +3201,7 @@ type PGPEncryptOptions struct {
 	NoSelf       bool         `codec:"noSelf" json:"noSelf"`
 	BinaryOut    bool         `codec:"binaryOut" json:"binaryOut"`
 	KeyQuery     string       `codec:"keyQuery" json:"keyQuery"`
+	SkipTrack    bool         `codec:"skipTrack" json:"skipTrack"`
 	TrackOptions TrackOptions `codec:"trackOptions" json:"trackOptions"`
 }
 

--- a/go/service/handler.go
+++ b/go/service/handler.go
@@ -123,6 +123,10 @@ func (h *BaseHandler) getProvisionUI(sessionID int) libkb.ProvisionUI {
 	return NewRemoteProvisionUI(sessionID, h.rpcClient())
 }
 
+func (h *BaseHandler) getPgpUI(sessionID int) libkb.PgpUI {
+	return NewRemotePgpUI(sessionID, h.rpcClient())
+}
+
 func (h *BaseHandler) getStreamUICli() *keybase1.StreamUiClient {
 	return &keybase1.StreamUiClient{Cli: h.rpcClient()}
 }

--- a/go/service/pgp.go
+++ b/go/service/pgp.go
@@ -57,6 +57,7 @@ func (h *PGPHandler) PGPEncrypt(_ context.Context, arg keybase1.PGPEncryptArg) e
 		NoSelf:       arg.Opts.NoSelf,
 		BinaryOutput: arg.Opts.BinaryOut,
 		KeyQuery:     arg.Opts.KeyQuery,
+		SkipTrack:    arg.Opts.SkipTrack,
 		TrackOptions: arg.Opts.TrackOptions,
 	}
 	ctx := &engine.Context{

--- a/go/service/pgp.go
+++ b/go/service/pgp.go
@@ -11,6 +11,22 @@ import (
 	"golang.org/x/net/context"
 )
 
+type RemotePgpUI struct {
+	sessionID int
+	cli       keybase1.PGPUiClient
+}
+
+func NewRemotePgpUI(sessionID int, c *rpc.Client) *RemotePgpUI {
+	return &RemotePgpUI{
+		sessionID: sessionID,
+		cli:       keybase1.PGPUiClient{Cli: c},
+	}
+}
+
+func (u *RemotePgpUI) OutputSignatureSuccess(ctx context.Context, arg keybase1.OutputSignatureSuccessArg) error {
+	return u.cli.OutputSignatureSuccess(ctx, arg)
+}
+
 type PGPHandler struct {
 	*BaseHandler
 	libkb.Contextified
@@ -77,12 +93,12 @@ func (h *PGPHandler) PGPDecrypt(_ context.Context, arg keybase1.PGPDecryptArg) (
 		Source:       src,
 		AssertSigned: arg.Opts.AssertSigned,
 		SignedBy:     arg.Opts.SignedBy,
-		TrackOptions: arg.Opts.TrackOptions,
 	}
 	ctx := &engine.Context{
 		SecretUI:   h.getSecretUI(arg.SessionID),
 		IdentifyUI: h.NewRemoteSkipPromptIdentifyUI(arg.SessionID, h.G()),
 		LogUI:      h.getLogUI(arg.SessionID),
+		PgpUI:      h.getPgpUI(arg.SessionID),
 	}
 	eng := engine.NewPGPDecrypt(earg, h.G())
 	err := engine.RunEngine(eng, ctx)
@@ -97,10 +113,9 @@ func (h *PGPHandler) PGPVerify(_ context.Context, arg keybase1.PGPVerifyArg) (ke
 	cli := h.getStreamUICli()
 	src := libkb.NewRemoteStreamBuffered(arg.Source, cli, arg.SessionID)
 	earg := &engine.PGPVerifyArg{
-		Source:       src,
-		Signature:    arg.Opts.Signature,
-		SignedBy:     arg.Opts.SignedBy,
-		TrackOptions: arg.Opts.TrackOptions,
+		Source:    src,
+		Signature: arg.Opts.Signature,
+		SignedBy:  arg.Opts.SignedBy,
 	}
 	ctx := &engine.Context{
 		SecretUI:   h.getSecretUI(arg.SessionID),

--- a/go/systests/common_test.go
+++ b/go/systests/common_test.go
@@ -52,6 +52,7 @@ func (n *baseNullUI) GetProveUI() libkb.ProveUI                       { return n
 func (n *baseNullUI) GetGPGUI() libkb.GPGUI                           { return nil }
 func (n *baseNullUI) GetLogUI() libkb.LogUI                           { return n.g.Log }
 func (n *baseNullUI) GetIdentifyLubaUI() libkb.IdentifyUI             { return nil }
+func (n *baseNullUI) GetPgpUI() libkb.PgpUI                           { return nil }
 func (n *baseNullUI) GetProvisionUI(libkb.KexRole) libkb.ProvisionUI  { return nil }
 
 func (n *baseNullUI) Configure() error { return nil }

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -134,6 +134,9 @@ func (n *signupTerminalUI) Write(b []byte) (int, error) {
 func (n *signupTerminalUI) OutputWriter() io.Writer {
 	return n
 }
+func (n *signupTerminalUI) ErrorWriter() io.Writer {
+	return n
+}
 
 func (n *signupTerminalUI) PromptYesNo(pd libkb.PromptDescriptor, s string, def libkb.PromptDefault) (ret bool, err error) {
 	switch pd {

--- a/go/vendor/github.com/keybase/go-crypto/openpgp/armor/encode.go
+++ b/go/vendor/github.com/keybase/go-crypto/openpgp/armor/encode.go
@@ -125,7 +125,7 @@ func (e *encoding) Close() (err error) {
 	var b64ChecksumBytes [4]byte
 	base64.StdEncoding.Encode(b64ChecksumBytes[:], checksumBytes[:])
 
-	return writeSlices(e.out, blockEnd, b64ChecksumBytes[:], newline, armorEnd, e.blockType, armorEndOfLine)
+	return writeSlices(e.out, blockEnd, b64ChecksumBytes[:], newline, armorEnd, e.blockType, armorEndOfLine, []byte{'\n'})
 }
 
 // Encode returns a WriteCloser which will encode the data written to it in

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -109,8 +109,8 @@
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp/armor",
-			"revision": "67d171e99a58463b40209d86a5438f5b708d8ad0",
-			"revisionTime": "2015-10-12T10:46:00-04:00"
+			"revision": "37775caa3ccd71d0bd7bab8bcd6af282b577dc22",
+			"revisionTime": "2015-12-04T17:01:02-05:00"
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp/clearsign",

--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -40,6 +40,7 @@ build-stamp: \
 	json/notify_session.json \
 	json/notify_users.json \
 	json/pgp.json \
+	json/pgp_ui.json \
 	json/prove.json \
 	json/prove_ui.json \
 	json/provision_ui.json \

--- a/protocol/avdl/pgp.avdl
+++ b/protocol/avdl/pgp.avdl
@@ -53,14 +53,12 @@ protocol pgp {
   record PGPDecryptOptions {
     boolean assertSigned;
     string signedBy; // assert that signature made by this user
-    TrackOptions trackOptions;
   }
 
   PGPSigVerification pgpDecrypt(int sessionID, Stream source, Stream sink, PGPDecryptOptions opts);
 
   record PGPVerifyOptions {
     string signedBy; // assert that signature made by this user
-    TrackOptions trackOptions;
     bytes signature; // detached signature data (binary or armored), can be empty
   }
 

--- a/protocol/avdl/pgp.avdl
+++ b/protocol/avdl/pgp.avdl
@@ -32,6 +32,7 @@ protocol pgp {
     boolean noSelf;
     boolean binaryOut;
     string keyQuery;
+    boolean skipTrack;
     TrackOptions trackOptions;
   }
 

--- a/protocol/avdl/pgp_ui.avdl
+++ b/protocol/avdl/pgp_ui.avdl
@@ -1,0 +1,7 @@
+@namespace("keybase.1")
+
+protocol pgpUi {
+  import idl "common.avdl";
+
+  void outputSignatureSuccess(int sessionID, string fingerprint, string username, Time signedAt);
+}

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2411,24 +2411,20 @@ export type PGPSigVerification = {
 export type pgp_PGPDecryptOptions = {
   assertSigned: boolean;
   signedBy: string;
-  trackOptions: TrackOptions;
 }
 
 export type PGPDecryptOptions = {
   assertSigned: boolean;
   signedBy: string;
-  trackOptions: TrackOptions;
 }
 
 export type pgp_PGPVerifyOptions = {
   signedBy: string;
-  trackOptions: TrackOptions;
   signature: bytes;
 }
 
 export type PGPVerifyOptions = {
   signedBy: string;
-  trackOptions: TrackOptions;
   signature: bytes;
 }
 

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2464,6 +2464,79 @@ export type PGPCreateUids = {
   ids: Array<PGPIdentity>;
 }
 
+export type pgpUi_Time = {
+}
+
+export type pgpUi_StringKVPair = {
+  key: string;
+  value: string;
+}
+
+export type pgpUi_Status = {
+  code: int;
+  name: string;
+  desc: string;
+  fields: Array<StringKVPair>;
+}
+
+export type pgpUi_UID = {
+}
+
+export type pgpUi_DeviceID = {
+}
+
+export type pgpUi_SigID = {
+}
+
+export type pgpUi_KID = {
+}
+
+export type pgpUi_Text = {
+  data: string;
+  markup: boolean;
+}
+
+export type pgpUi_PGPIdentity = {
+  username: string;
+  comment: string;
+  email: string;
+}
+
+export type pgpUi_PublicKey = {
+  KID: KID;
+  PGPFingerprint: string;
+  PGPIdentities: Array<PGPIdentity>;
+  isSibkey: boolean;
+  isEldest: boolean;
+  parentID: string;
+  deviceID: DeviceID;
+  deviceDescription: string;
+  deviceType: string;
+  cTime: Time;
+  eTime: Time;
+}
+
+export type pgpUi_User = {
+  uid: UID;
+  username: string;
+}
+
+export type pgpUi_Device = {
+  type: string;
+  name: string;
+  deviceID: DeviceID;
+  cTime: Time;
+  mTime: Time;
+}
+
+export type pgpUi_Stream = {
+  fd: int;
+}
+
+export type pgpUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
+
+export type pgpUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
 export type prove_Time = {
 }
 

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2380,6 +2380,7 @@ export type pgp_PGPEncryptOptions = {
   noSelf: boolean;
   binaryOut: boolean;
   keyQuery: string;
+  skipTrack: boolean;
   trackOptions: TrackOptions;
 }
 
@@ -2389,6 +2390,7 @@ export type PGPEncryptOptions = {
   noSelf: boolean;
   binaryOut: boolean;
   keyQuery: string;
+  skipTrack: boolean;
   trackOptions: TrackOptions;
 }
 

--- a/protocol/js/keybase_v1.js
+++ b/protocol/js/keybase_v1.js
@@ -705,6 +705,22 @@ export default {
       'clear': 2
     }
   },
+  'pgpUi': {
+    'LogLevel': {
+      'none': 0,
+      'debug': 1,
+      'info': 2,
+      'notice': 3,
+      'warn': 4,
+      'error': 5,
+      'critical': 6,
+      'fatal': 7
+    },
+    'ClientType': {
+      'cli': 0,
+      'gui': 1
+    }
+  },
   'prove': {
     'LogLevel': {
       'none': 0,

--- a/protocol/json/pgp.json
+++ b/protocol/json/pgp.json
@@ -391,9 +391,6 @@
     }, {
       "name" : "signedBy",
       "type" : "string"
-    }, {
-      "name" : "trackOptions",
-      "type" : "TrackOptions"
     } ]
   }, {
     "type" : "record",
@@ -401,9 +398,6 @@
     "fields" : [ {
       "name" : "signedBy",
       "type" : "string"
-    }, {
-      "name" : "trackOptions",
-      "type" : "TrackOptions"
     }, {
       "name" : "signature",
       "type" : "bytes"

--- a/protocol/json/pgp.json
+++ b/protocol/json/pgp.json
@@ -359,6 +359,9 @@
       "name" : "keyQuery",
       "type" : "string"
     }, {
+      "name" : "skipTrack",
+      "type" : "boolean"
+    }, {
       "name" : "trackOptions",
       "type" : "TrackOptions"
     } ]

--- a/protocol/json/pgp_ui.json
+++ b/protocol/json/pgp_ui.json
@@ -1,0 +1,184 @@
+{
+  "protocol" : "pgpUi",
+  "namespace" : "keybase.1",
+  "types" : [ {
+    "type" : "record",
+    "name" : "Time",
+    "fields" : [ ],
+    "typedef" : "long"
+  }, {
+    "type" : "record",
+    "name" : "StringKVPair",
+    "fields" : [ {
+      "name" : "key",
+      "type" : "string"
+    }, {
+      "name" : "value",
+      "type" : "string"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "Status",
+    "fields" : [ {
+      "name" : "code",
+      "type" : "int"
+    }, {
+      "name" : "name",
+      "type" : "string"
+    }, {
+      "name" : "desc",
+      "type" : "string"
+    }, {
+      "name" : "fields",
+      "type" : {
+        "type" : "array",
+        "items" : "StringKVPair"
+      }
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UID",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
+    "type" : "record",
+    "name" : "DeviceID",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
+    "type" : "record",
+    "name" : "SigID",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
+    "type" : "record",
+    "name" : "KID",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
+    "type" : "record",
+    "name" : "Text",
+    "fields" : [ {
+      "name" : "data",
+      "type" : "string"
+    }, {
+      "name" : "markup",
+      "type" : "boolean"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "PGPIdentity",
+    "fields" : [ {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "comment",
+      "type" : "string"
+    }, {
+      "name" : "email",
+      "type" : "string"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "PublicKey",
+    "fields" : [ {
+      "name" : "KID",
+      "type" : "KID"
+    }, {
+      "name" : "PGPFingerprint",
+      "type" : "string"
+    }, {
+      "name" : "PGPIdentities",
+      "type" : {
+        "type" : "array",
+        "items" : "PGPIdentity"
+      }
+    }, {
+      "name" : "isSibkey",
+      "type" : "boolean"
+    }, {
+      "name" : "isEldest",
+      "type" : "boolean"
+    }, {
+      "name" : "parentID",
+      "type" : "string"
+    }, {
+      "name" : "deviceID",
+      "type" : "DeviceID"
+    }, {
+      "name" : "deviceDescription",
+      "type" : "string"
+    }, {
+      "name" : "deviceType",
+      "type" : "string"
+    }, {
+      "name" : "cTime",
+      "type" : "Time"
+    }, {
+      "name" : "eTime",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "User",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "Device",
+    "fields" : [ {
+      "name" : "type",
+      "type" : "string"
+    }, {
+      "name" : "name",
+      "type" : "string"
+    }, {
+      "name" : "deviceID",
+      "type" : "DeviceID"
+    }, {
+      "name" : "cTime",
+      "type" : "Time"
+    }, {
+      "name" : "mTime",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "Stream",
+    "fields" : [ {
+      "name" : "fd",
+      "type" : "int"
+    } ]
+  }, {
+    "type" : "enum",
+    "name" : "LogLevel",
+    "symbols" : [ "NONE_0", "DEBUG_1", "INFO_2", "NOTICE_3", "WARN_4", "ERROR_5", "CRITICAL_6", "FATAL_7" ]
+  }, {
+    "type" : "enum",
+    "name" : "ClientType",
+    "symbols" : [ "CLI_0", "GUI_1" ]
+  } ],
+  "messages" : {
+    "outputSignatureSuccess" : {
+      "request" : [ {
+        "name" : "sessionID",
+        "type" : "int"
+      }, {
+        "name" : "fingerprint",
+        "type" : "string"
+      }, {
+        "name" : "username",
+        "type" : "string"
+      }, {
+        "name" : "signedAt",
+        "type" : "Time"
+      } ],
+      "response" : "null"
+    }
+  }
+}


### PR DESCRIPTION
Previously, Identify/Track was handled by PGPKeyfinder.  This led to some issues, especially on decrypt/verify of self-signed message.

I moved it out and encrypt/decrypt handle it.  Also cleaned up command line flags.  Some were not used, some were just wrong.

This behavior might change as the Identify system changes, but it should be more flexible in this state.

Also, created a PgpUI to output the signature success message instead of using LogUI.

There's a big test of the UI in engine/pgp_test.go, TestPGPUserInterface.