### PR TITLE
IdentifyUI: display user card

### DIFF
--- a/go/client/identify_ui.go
+++ b/go/client/identify_ui.go
@@ -70,6 +70,11 @@ func (i *IdentifyUIServer) ReportTrackToken(_ context.Context, arg keybase1.Repo
 	return nil
 }
 
+func (i *IdentifyUIServer) DisplayUserCard(_ context.Context, arg keybase1.DisplayUserCardArg) error {
+	i.ui.DisplayUserCard(arg.Card)
+	return nil
+}
+
 func (i *IdentifyUIServer) Start(_ context.Context, arg keybase1.StartArg) error {
 	i.ui.Start(arg.Username)
 	return nil

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -12,11 +12,12 @@ import (
 
 	"golang.org/x/net/context"
 
+	"sync"
+
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
 	"github.com/keybase/client/go/spotty"
 	rpc "github.com/keybase/go-framed-msgpack-rpc"
-	"sync"
 )
 
 type UI struct {
@@ -38,6 +39,8 @@ type BaseIdentifyUI struct {
 }
 
 func (ui BaseIdentifyUI) SetStrict(b bool) {}
+
+func (ui BaseIdentifyUI) DisplayUserCard(keybase1.UserCard) {}
 
 type IdentifyUI struct {
 	BaseIdentifyUI

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -229,6 +229,8 @@ func (ui *FakeIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keyba
 func (ui *FakeIdentifyUI) DisplayTrackStatement(string) (err error) {
 	return
 }
+func (ui *FakeIdentifyUI) DisplayUserCard(keybase1.UserCard) {
+}
 func (ui *FakeIdentifyUI) ReportTrackToken(libkb.IdentifyCacheToken) error {
 	return nil
 }

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1127,12 +1127,12 @@ func (idt *IdentityTable) Identify(is IdentifyState, forceRemoteCheck bool, ui I
 		}(lcr)
 	}
 
-	// wait for all goroutines to complete before exiting
-	wg.Wait()
-
 	if acc := idt.ActiveCryptocurrency(); acc != nil {
 		acc.Display(ui)
 	}
+
+	// wait for all goroutines to complete before exiting
+	wg.Wait()
 }
 
 //=========================================================================

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -242,6 +242,7 @@ type IdentifyUI interface {
 	ReportLastTrack(*keybase1.TrackSummary)
 	LaunchNetworkChecks(*keybase1.Identity, *keybase1.User)
 	DisplayTrackStatement(string) error
+	DisplayUserCard(keybase1.UserCard)
 	ReportTrackToken(IdentifyCacheToken) error
 	SetStrict(b bool)
 	Finish()

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -1602,6 +1602,17 @@ type LinkCheckResult struct {
 	Hint        *SigHint     `codec:"hint,omitempty" json:"hint,omitempty"`
 }
 
+type UserCard struct {
+	Following int    `codec:"following" json:"following"`
+	Followers int    `codec:"followers" json:"followers"`
+	Uid       UID    `codec:"uid" json:"uid"`
+	FullName  string `codec:"fullName" json:"fullName"`
+	Location  string `codec:"location" json:"location"`
+	Bio       string `codec:"bio" json:"bio"`
+	Website   string `codec:"website" json:"website"`
+	Twitter   string `codec:"twitter" json:"twitter"`
+}
+
 type ConfirmResult struct {
 	IdentityConfirmed bool `codec:"identityConfirmed" json:"identityConfirmed"`
 	RemoteConfirmed   bool `codec:"remoteConfirmed" json:"remoteConfirmed"`
@@ -1658,6 +1669,11 @@ type ReportTrackTokenArg struct {
 	TrackToken string `codec:"trackToken" json:"trackToken"`
 }
 
+type DisplayUserCardArg struct {
+	SessionID int      `codec:"sessionID" json:"sessionID"`
+	Card      UserCard `codec:"card" json:"card"`
+}
+
 type ConfirmArg struct {
 	SessionID int             `codec:"sessionID" json:"sessionID"`
 	Outcome   IdentifyOutcome `codec:"outcome" json:"outcome"`
@@ -1678,6 +1694,7 @@ type IdentifyUiInterface interface {
 	FinishSocialProofCheck(context.Context, FinishSocialProofCheckArg) error
 	DisplayCryptocurrency(context.Context, DisplayCryptocurrencyArg) error
 	ReportTrackToken(context.Context, ReportTrackTokenArg) error
+	DisplayUserCard(context.Context, DisplayUserCardArg) error
 	Confirm(context.Context, ConfirmArg) (ConfirmResult, error)
 	Finish(context.Context, int) error
 }
@@ -1841,6 +1858,22 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"displayUserCard": {
+				MakeArg: func() interface{} {
+					ret := make([]DisplayUserCardArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]DisplayUserCardArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]DisplayUserCardArg)(nil), args)
+						return
+					}
+					err = i.DisplayUserCard(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 			"confirm": {
 				MakeArg: func() interface{} {
 					ret := make([]ConfirmArg, 1)
@@ -1928,6 +1961,11 @@ func (c IdentifyUiClient) DisplayCryptocurrency(ctx context.Context, __arg Displ
 
 func (c IdentifyUiClient) ReportTrackToken(ctx context.Context, __arg ReportTrackTokenArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.identifyUi.reportTrackToken", []interface{}{__arg}, nil)
+	return
+}
+
+func (c IdentifyUiClient) DisplayUserCard(ctx context.Context, __arg DisplayUserCardArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.displayUserCard", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -1603,14 +1603,16 @@ type LinkCheckResult struct {
 }
 
 type UserCard struct {
-	Following int    `codec:"following" json:"following"`
-	Followers int    `codec:"followers" json:"followers"`
-	Uid       UID    `codec:"uid" json:"uid"`
-	FullName  string `codec:"fullName" json:"fullName"`
-	Location  string `codec:"location" json:"location"`
-	Bio       string `codec:"bio" json:"bio"`
-	Website   string `codec:"website" json:"website"`
-	Twitter   string `codec:"twitter" json:"twitter"`
+	Following     int    `codec:"following" json:"following"`
+	Followers     int    `codec:"followers" json:"followers"`
+	Uid           UID    `codec:"uid" json:"uid"`
+	FullName      string `codec:"fullName" json:"fullName"`
+	Location      string `codec:"location" json:"location"`
+	Bio           string `codec:"bio" json:"bio"`
+	Website       string `codec:"website" json:"website"`
+	Twitter       string `codec:"twitter" json:"twitter"`
+	YouFollowThem bool   `codec:"youFollowThem" json:"youFollowThem"`
+	TheyFollowYou bool   `codec:"theyFollowYou" json:"theyFollowYou"`
 }
 
 type ConfirmResult struct {

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -207,6 +207,11 @@ func (u *RemoteIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keyb
 	return
 }
 
+func (u *RemoteIdentifyUI) DisplayUserCard(card keybase1.UserCard) {
+	u.uicli.DisplayUserCard(context.TODO(), keybase1.DisplayUserCardArg{SessionID: u.sessionID, Card: card})
+	return
+}
+
 func (u *RemoteIdentifyUI) Start(username string) {
 	u.uicli.Start(context.TODO(), keybase1.StartArg{SessionID: u.sessionID, Username: username})
 }

--- a/go/systests/delegate_ui_test.go
+++ b/go/systests/delegate_ui_test.go
@@ -130,6 +130,12 @@ func (d *delegateUI) DisplayCryptocurrency(context.Context, keybase1.DisplayCryp
 	}
 	return nil
 }
+func (d *delegateUI) DisplayUserCard(context.Context, keybase1.DisplayUserCardArg) error {
+	if err := d.checkStarted(); err != nil {
+		return err
+	}
+	return nil
+}
 func (d *delegateUI) Confirm(context.Context, keybase1.ConfirmArg) (res keybase1.ConfirmResult, err error) {
 	if err = d.checkStarted(); err != nil {
 		return res, err

--- a/protocol/avdl/identify_ui.avdl
+++ b/protocol/avdl/identify_ui.avdl
@@ -69,6 +69,8 @@ protocol identifyUi {
     string bio;
     string website;
     string twitter;
+    boolean youFollowThem;
+    boolean theyFollowYou;
   }
 
   record ConfirmResult {

--- a/protocol/avdl/identify_ui.avdl
+++ b/protocol/avdl/identify_ui.avdl
@@ -60,6 +60,17 @@ protocol identifyUi {
     union { null, SigHint } hint;
   }
 
+  record UserCard {
+    int following;
+    int followers;
+    UID uid;
+    string fullName;
+    string location;
+    string bio;
+    string website;
+    string twitter;
+  }
+
   record ConfirmResult {
     boolean identityConfirmed; // true if the user answers yes to "Is this the user you wanted?"
     boolean remoteConfirmed;   // true if the user answers yes to "Publicly write tracking statement to server?"
@@ -80,6 +91,7 @@ protocol identifyUi {
   void finishSocialProofCheck(int sessionID, RemoteProof rp, LinkCheckResult lcr);
   void displayCryptocurrency(int sessionID, Cryptocurrency c);
   void reportTrackToken(int sessionID, string trackToken);
+  void displayUserCard(int sessionID, UserCard card);
   ConfirmResult confirm(int sessionID, IdentifyOutcome outcome);
   void finish(int sessionID);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1345,6 +1345,8 @@ export type identifyUi_UserCard = {
   bio: string;
   website: string;
   twitter: string;
+  youFollowThem: boolean;
+  theyFollowYou: boolean;
 }
 
 export type UserCard = {
@@ -1356,6 +1358,8 @@ export type UserCard = {
   bio: string;
   website: string;
   twitter: string;
+  youFollowThem: boolean;
+  theyFollowYou: boolean;
 }
 
 export type identifyUi_ConfirmResult = {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1336,6 +1336,28 @@ export type LinkCheckResult = {
   hint?: ?SigHint;
 }
 
+export type identifyUi_UserCard = {
+  following: int;
+  followers: int;
+  uid: UID;
+  fullName: string;
+  location: string;
+  bio: string;
+  website: string;
+  twitter: string;
+}
+
+export type UserCard = {
+  following: int;
+  followers: int;
+  uid: UID;
+  fullName: string;
+  location: string;
+  bio: string;
+  website: string;
+  twitter: string;
+}
+
 export type identifyUi_ConfirmResult = {
   identityConfirmed: boolean;
   remoteConfirmed: boolean;

--- a/protocol/json/identify_ui.json
+++ b/protocol/json/identify_ui.json
@@ -478,6 +478,12 @@
     }, {
       "name" : "twitter",
       "type" : "string"
+    }, {
+      "name" : "youFollowThem",
+      "type" : "boolean"
+    }, {
+      "name" : "theyFollowYou",
+      "type" : "boolean"
     } ]
   }, {
     "type" : "record",

--- a/protocol/json/identify_ui.json
+++ b/protocol/json/identify_ui.json
@@ -453,6 +453,34 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "UserCard",
+    "fields" : [ {
+      "name" : "following",
+      "type" : "int"
+    }, {
+      "name" : "followers",
+      "type" : "int"
+    }, {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "fullName",
+      "type" : "string"
+    }, {
+      "name" : "location",
+      "type" : "string"
+    }, {
+      "name" : "bio",
+      "type" : "string"
+    }, {
+      "name" : "website",
+      "type" : "string"
+    }, {
+      "name" : "twitter",
+      "type" : "string"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "ConfirmResult",
     "fields" : [ {
       "name" : "identityConfirmed",
@@ -563,6 +591,16 @@
       }, {
         "name" : "trackToken",
         "type" : "string"
+      } ],
+      "response" : "null"
+    },
+    "displayUserCard" : {
+      "request" : [ {
+        "name" : "sessionID",
+        "type" : "int"
+      }, {
+        "name" : "card",
+        "type" : "UserCard"
       } ],
       "response" : "null"
     },


### PR DESCRIPTION
Completes CORE-2181

As part of the identify process, the daemon will look up extended user info via user/card and send it to the UI async via DisplayUserCard().

@maxtaco @chrisnojima 