### PR TITLE
Popup error on quit

### DIFF
--- a/desktop/app/main.js
+++ b/desktop/app/main.js
@@ -67,7 +67,7 @@ ipc.on('console.log', (event, args) => {
   console.log.apply(console, args)
 })
 
-ipc.on('console.warn', (event, arg) => {
+ipc.on('console.warn', (event, args) => {
   console.log('From remote console.warn')
   console.log.apply(console, args)
 })

--- a/desktop/app/window.js
+++ b/desktop/app/window.js
@@ -1,6 +1,6 @@
 import BrowserWindow from 'browser-window'
 import showDockIcon from './dockIcon'
-import {app} from 'electron'
+import {app, ipcMain} from 'electron'
 
 export default class Window {
   constructor (filename, opts) {
@@ -15,6 +15,12 @@ export default class Window {
 
     app.on('ready', () => {
       this.createWindow()
+    })
+
+    ipcMain.on('listendForRemoteWindowClosed', (event, remoteWindowId) => {
+      BrowserWindow.fromId(remoteWindowId).on('close', () => {
+        event.sender.send('remoteWindowClosed', remoteWindowId)
+      })
     })
   }
 

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -15,6 +15,8 @@ import type {UserInfo} from '../tracker/bio.render.types'
 
 import type {Identity, IdentifyKey, TrackSummary, User, Cryptocurrency, IdentifyOutcome, RemoteProof, LinkCheckResult, TrackOptions} from '../constants/types/flow-types'
 
+type TrackerActionCreator = (dispatch: Dispatch, getState: () => {tracker: RootTrackerState}) => void
+
 // TODO make actions for all the call back stuff.
 
 export function registerIdentifyUi (): (dispatch: Dispatch) => void {
@@ -62,7 +64,7 @@ export function onFollowChecked (newFollowCheckedValue: boolean, username: strin
   }
 }
 
-export function onRefollow (username: string): Action {
+export function onRefollow (username: string): TrackerActionCreator {
   return (dispatch, getState) => {
     console.log('onRefollow')
     trackUser(username, getState())
@@ -73,7 +75,7 @@ export function onRefollow (username: string): Action {
   }
 }
 
-export function onUnfollow (username: string): (dispatch: Dispatch, getState: () => {tracker: RootTrackerState}) => void {
+export function onUnfollow (username: string): TrackerActionCreator {
   return (dispatch, getState) => {
     engine.rpc('track.untrack', {username}, {}, (err, response) => {
       if (err) {

--- a/react-native/react/native/remote-component.desktop.js
+++ b/react-native/react/native/remote-component.desktop.js
@@ -1,6 +1,7 @@
 import React, {Component} from '../base-react'
 import remote from 'remote'
 import {showDevTools} from '../local-debug'
+import {ipcRenderer} from 'electron'
 
 const BrowserWindow = remote.require('browser-window')
 
@@ -18,11 +19,15 @@ export default class RemoteComponent extends Component {
       this.remoteWindow.emit('hasProps', {...this.props})
     })
 
+    ipcRenderer.send('listenForRemoteWindowClosed', this.remoteWindow.id)
+
     // Remember if we close, it's an error to try to close an already closed window
-    this.remoteWindow.on('close', () => {
-      if (!this.closed) {
-        this.closed = true
-        this.props.onRemoteClose && this.props.onRemoteClose()
+    ipcRenderer.on('remoteWindowClosed', (event, remoteWindowId) => {
+      if (remoteWindowId === this.remoteWindow.id) {
+        if (!this.closed) {
+          this.closed = true
+          this.props.onRemoteClose && this.props.onRemoteClose()
+        }
       }
     })
 


### PR DESCRIPTION
@keybase/react-hackers 

Fixes the popup error you get when a remote component is alive and you quit.

It was because we registered a handler that we never cleared from the remote obj. at first I tried to simply clear the listener before we quit the main window, but it seems the window is quit before we have a chance to react to it.

This seems like this simplest and easiest approach. It replaces the registered remote handler with a handler that relies on ipc. Ipc won't give a popup error message (because it doesn't bind itself to a remote instance), so it something else down the line gives us a popup a similar approach to this would probably fix it.