### PR TITLE
Working component sheet and stylesheet

### DIFF
--- a/desktop/renderer/index.desktop.js
+++ b/desktop/renderer/index.desktop.js
@@ -30,6 +30,20 @@ class Keybase extends Component {
   constructor () {
     super()
 
+    this.state = {
+      panelShowing: false
+    }
+
+    if (isDev) {
+      if (typeof window !== 'undefined') {
+        window.addEventListener('keydown', event => {
+          if (event.ctrlKey && event.keyCode === 72) {
+            this.setState({panelShowing: !this.state.panelShowing})
+          }
+        })
+      }
+    }
+
     // Used by material-ui widgets.
     injectTapEventPlugin()
 
@@ -62,7 +76,7 @@ class Keybase extends Component {
   renderNav () {
     return (
       <Provider store={store}>
-        <div>
+        <div style={{display: 'flex', flex: 1}}>
           <RemoteManager />
           <Nav />
         </div>
@@ -73,11 +87,11 @@ class Keybase extends Component {
   render () {
     if (isDev) {
       return (
-        <div>
-          <DebugPanel top right bottom>
+        <div style={{position: 'absolute', width: '100%', height: '100%', display: 'flex'}}>
+          {this.renderNav()}
+          <DebugPanel style={{height: '100%', width: this.state.panelShowing ? '30%' : 0, position: 'relative', maxHeight: 'initial'}}>
             <DevTools store={store} monitor={LogMonitor} visibleOnLoad={false} select={reduxDevToolsSelect}/>
           </DebugPanel>
-          {this.renderNav()}
         </div>
       )
     } else {

--- a/react-native/react/more/component-sheet.js
+++ b/react-native/react/more/component-sheet.js
@@ -1,0 +1,14 @@
+import React, {Component} from '../base-react'
+import Render from './component-sheet.render'
+
+export default class ComponentSheet extends Component {
+  render () {
+    return <Render {...this.props}/>
+  }
+
+  static parseRoute () {
+    return {
+      componentAtTop: {title: 'Components'}
+    }
+  }
+}

--- a/react-native/react/more/component-sheet.render.desktop.js
+++ b/react-native/react/more/component-sheet.render.desktop.js
@@ -1,0 +1,43 @@
+import React, {Component} from '../base-react'
+import {Paper, AppBar, FlatButton} from 'material-ui'
+import commonStyles from '../styles/common'
+import Header from '../common-adapters/header'
+import path from 'path'
+
+const Container = props => {
+  return (
+    <Paper zDepth={5} style={{margin: 20}}>
+      <AppBar title={props.title}/>
+      <div style={{margin: 10}}>
+        {props.children}
+      </div>
+    </Paper>
+  )
+}
+
+Container.propTypes = {
+  title: React.PropTypes.string,
+  style: React.PropTypes.object,
+  children: React.PropTypes.node.isRequired
+}
+
+export default class Render extends Component {
+  render () {
+    return (
+      <div style={{...commonStyles.flexBoxColumn, flex: 1, overflowY: 'auto'}}>
+        <Container title='Header No Close'>
+          <Header icon={`file:///${path.resolve(__dirname, '../images/service/keybase.png')}`} title='Title'/>
+        </Container>
+        <Container title='Header' style={{backgroundColor: 'red'}}>
+          <Header icon={`file:///${path.resolve(__dirname, '../images/service/keybase.png')}`} title='Title' onClose={() => {}}/>
+        </Container>
+        <Container title='FlatButton Primary' style={{backgroundColor: 'red'}}>
+          <FlatButton style={commonStyles.primaryButton} label='Primary' primary />
+        </Container>
+        <Container title='FlatButton Secondary' style={{backgroundColor: 'red'}}>
+          <FlatButton style={commonStyles.secondaryButton} label='Secondary'/>
+        </Container>
+      </div>
+  )
+  }
+}

--- a/react-native/react/more/component-sheet.render.mobile.js
+++ b/react-native/react/more/component-sheet.render.mobile.js
@@ -1,0 +1,11 @@
+import React, {Component, View, Text} from '../base-react'
+
+export default class Render extends Component {
+  render () {
+    return (
+      <View>
+        <Text>TODO</Text>
+      </View>
+  )
+  }
+}

--- a/react-native/react/more/dev-menu.js
+++ b/react-native/react/more/dev-menu.js
@@ -66,6 +66,12 @@ class DevMenu extends Component {
       }},
       {name: 'Remote Window', hasChildren: true, onClick: () => {
         this.props.routeAppend([{parseRoute: {componentAtTop: {component: Foo}}}])
+      }},
+      {name: 'Components', hasChildren: true, onClick: () => {
+        this.props.routeAppend(['components'])
+      }},
+      {name: 'Stylesheet', hasChildren: true, onClick: () => {
+        this.props.routeAppend(['styleSheet'])
       }}
     ]
     return (
@@ -80,7 +86,9 @@ class DevMenu extends Component {
         developer: require('./developer'),
         login: require('../login'),
         pinentry: require('../pinentry'),
-        tracker: require('../tracker')
+        tracker: require('../tracker'),
+        components: require('./component-sheet'),
+        styleSheet: require('./style-sheet')
       }
     }
   }

--- a/react-native/react/more/style-sheet.js
+++ b/react-native/react/more/style-sheet.js
@@ -1,0 +1,19 @@
+import React, {Component} from '../base-react'
+import Render from './style-sheet.render'
+import {colors} from '../styles/common'
+
+export default class StyleSheet extends Component {
+  render () {
+    return <Render
+      {...this.props}
+      colors={colors}
+    />
+  }
+
+  static parseRoute () {
+    return {
+      componentAtTop: {title: 'Styleshet'}
+    }
+  }
+}
+

--- a/react-native/react/more/style-sheet.render.desktop.js
+++ b/react-native/react/more/style-sheet.render.desktop.js
@@ -1,0 +1,19 @@
+import React, {Component} from '../base-react'
+import commonStyles from '../styles/common'
+
+export default class Render extends Component {
+  render () {
+    return (
+      <div style={{...commonStyles.flexBoxRow, flexWrap: 'wrap'}}>
+        {Object.keys(this.props.colors).sort().map(c => {
+          return (
+            <p key={c} style={{backgroundColor: this.props.colors[c], margin: 5, padding: 20, minWidth: 100, textAlign: 'center', textShadow: '1px 1px 1px #FFF'}}>{c}</p>
+          ) }
+        )}
+      </div>)
+  }
+}
+
+Render.propTypes = {
+  colors: React.PropTypes.any
+}

--- a/react-native/react/more/style-sheet.render.mobile.js
+++ b/react-native/react/more/style-sheet.render.mobile.js
@@ -1,0 +1,11 @@
+import React, {Component, View, Text} from '../base-react'
+
+export default class Render extends Component {
+  render () {
+    return (
+      <View>
+        <Text>TODO</Text>
+      </View>
+  )
+  }
+}

--- a/react-native/react/nav.desktop.js
+++ b/react-native/react/nav.desktop.js
@@ -8,6 +8,7 @@ import People from './people'
 import Devices from './devices'
 import NoTab from './no-tab'
 import More from './more'
+import commonStyles from './styles/common'
 // TODO global routes
 // import globalRoutes from './router/global-routes'
 const globalRoutes = {}
@@ -16,8 +17,7 @@ import * as Constants from './constants/config'
 import {folderTab, chatTab, peopleTab, devicesTab, moreTab} from './constants/tabs'
 import {switchTab} from './actions/tabbed-router'
 import {startup} from './actions/config'
-import {Tab, Tabs, Styles} from 'material-ui'
-let {Colors, Typography} = Styles
+import {Tab, Tabs} from 'material-ui'
 
 const tabs = {
   [moreTab]: {module: More, name: 'More'},
@@ -25,6 +25,28 @@ const tabs = {
   [chatTab]: {module: Chat, name: 'Chat'},
   [peopleTab]: {module: People, name: 'People'},
   [devicesTab]: {module: Devices, name: 'Devices'}
+}
+
+class TabTemplate extends Component {
+  render () {
+    /* If we decide to show content for non-active tabs
+    if (this.props.selected) {
+      delete styles.height;
+      delete styles.overflow;
+    }
+    */
+
+    return (
+      <div style={styles.tabTemplate}>
+        {this.props.children}
+      </div>
+    )
+  }
+}
+
+TabTemplate.propTypes = {
+  children: React.PropTypes.node,
+  selected: React.PropTypes.bool
 }
 
 class Nav extends Component {
@@ -50,7 +72,11 @@ class Nav extends Component {
 
     return (
       <div style={styles.tabsContainer}>
-        <Tabs valueLink={{value: activeTab, requestChange: this._handleTabsChange.bind(this)}}>
+        <Tabs
+          style={styles.tabs}
+          valueLink={{value: activeTab, requestChange: this._handleTabsChange.bind(this)}}
+          contentContainerStyle={styles.tab}
+          tabTemplate={TabTemplate}>
           { Object.keys(tabs).map(tab => {
             const {module, name} = tabs[tab]
             return (
@@ -71,39 +97,27 @@ class Nav extends Component {
 }
 
 const styles = {
-  div: {
-    position: 'absolute',
-    left: 48,
-    backgroundColor: Colors.cyan500,
-    width: 0,
-    height: 48
-  },
-  headline: {
-    fontSize: 24,
-    lineHeight: '32px',
-    paddingTop: 16,
-    marginBottom: 12,
-    letterSpacing: 0,
-    fontWeight: Typography.fontWeightNormal,
-    color: Typography.textDarkBlack
-  },
-  iconButton: {
-    position: 'absolute',
-    left: 0,
-    backgroundColor: Colors.cyan500,
-    color: 'white',
-    marginRight: 0
-  },
-  iconStyle: {
-    color: Colors.white
-  },
-  tabs: {
+  tab: {
+    ...commonStyles.flexBoxColumn,
+    flex: 1,
     position: 'relative'
   },
+  tabs: {
+    ...commonStyles.flexBoxColumn,
+    flex: 1
+  },
   tabsContainer: {
-    position: 'relative',
-    paddingLeft: 0,
-    width: '70%'
+    ...commonStyles.flexBoxColumn,
+    flex: 1
+  },
+  tabTemplate: {
+    ...commonStyles.flexBoxColumn,
+    overflow: 'auto',
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0
   }
 }
 

--- a/react-native/react/router/meta-navigator.render.desktop.js
+++ b/react-native/react/router/meta-navigator.render.desktop.js
@@ -6,7 +6,9 @@ export default class MetaNavigatorRender extends Component {
     const {componentAtTop} = getComponentAtTop(rootComponent, uri)
     const Module = componentAtTop.component
 
-    return <Module {...componentAtTop.props} />
+    return (
+      <Module {...componentAtTop.props} />
+    )
   }
 }
 


### PR DESCRIPTION
In addition to the new screens under the devmenu this refactors some top level styling in the app.
Tab pages now take up the whole rest of the screen at the top level (you can overflow and get a scrollable region still) but this lets us act more like a desktop app vs being a web page. This does mess up the devices page styling as the parent wasn't actually flexbox before but i think this is likely an easier way to see the app. Also this makes the redux devtools actually go away and lets us reclaim that space vs it being 30% empty on the right even when its hidden.

@keybase/react-hackers 