### PR TITLE
Properly hide the dock icon

### DIFF
--- a/desktop/app/main.js
+++ b/desktop/app/main.js
@@ -69,6 +69,8 @@ installer(err => {
   splash()
 })
 
+app.dock.hide()
+
 // Don't quit the app, instead try to close all windows
 app.on('before-quit', event => {
   const windows = BrowserWindow.getAllWindows()

--- a/desktop/app/window.js
+++ b/desktop/app/window.js
@@ -53,6 +53,8 @@ export default class Window {
   }
 
   show (shouldShowDockIcon) {
+    this.releaseDockIcon = shouldShowDockIcon ? showDockIcon() : null
+
     if (this.window) {
       if (!this.window.isVisible()) {
         this.window.show()
@@ -64,7 +66,6 @@ export default class Window {
     }
 
     this.createWindow()
-    this.releaseDockIcon = shouldShowDockIcon ? showDockIcon() : null
 
     if (this.opts.openDevTools) {
       this.window.openDevTools()

--- a/desktop/app/window.js
+++ b/desktop/app/window.js
@@ -13,6 +13,15 @@ export default class Window {
       this.createWindow()
     })
 
+    // Listen for remote windows to show a dock icon for, we'll bind the on close to
+    // hide the dock icon too
+    ipcMain.on('showDockIconForRemoteWindow', (event, remoteWindowId) => {
+      const remoteReleaseDockIcon = showDockIcon()
+      BrowserWindow.fromId(remoteWindowId).on('close', () => {
+        remoteReleaseDockIcon()
+      })
+    })
+
     ipcMain.on('listendForRemoteWindowClosed', (event, remoteWindowId) => {
       BrowserWindow.fromId(remoteWindowId).on('close', () => {
         event.sender.send('remoteWindowClosed', remoteWindowId)

--- a/react-native/react/native/remote-component.desktop.js
+++ b/react-native/react/native/remote-component.desktop.js
@@ -19,6 +19,7 @@ export default class RemoteComponent extends Component {
       this.remoteWindow.emit('hasProps', {...this.props})
     })
 
+    ipcRenderer.send('showDockIconForRemoteWindow', this.remoteWindow.id)
     ipcRenderer.send('listenForRemoteWindowClosed', this.remoteWindow.id)
 
     // Remember if we close, it's an error to try to close an already closed window


### PR DESCRIPTION
@keybase/react-hackers 

Fixes the dock icon to only show up when there is an active window (e.g. the main window is open)

~~Edit: This needs to include remote components, so I'm changing this to a WIP for now~~

Edit: Fixed for remote components