### PR TITLE
More Ansi color support for Windows

### DIFF
--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -178,7 +178,7 @@ func (ui IdentifyTrackUI) Confirm(o *keybase1.IdentifyOutcome) (result keybase1.
 }
 
 func (ui BaseIdentifyUI) ReportHook(s string) {
-	os.Stderr.Write([]byte(s + "\n"))
+	ui.parent.ErrorWriter().Write([]byte(s + "\n"))
 }
 
 func (ui BaseIdentifyUI) ShowWarnings(w libkb.Warnings) {

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -159,8 +159,8 @@
 		},
 		{
 			"path": "github.com/keybase/go-logging",
-			"revision": "2da2aba05a96db6143502dd25a69f828034613e8",
-			"revisionTime": "2015-12-07T11:02:23-08:00"
+			"revision": "d7b8c00ee8a21d4cfe58c75c0f09c6d3d030d80f",
+			"revisionTime": "2015-12-09T11:25:47-08:00"
 		},
 		{
 			"path": "github.com/keybase/go-osxkeychain",


### PR DESCRIPTION
This was really hard to figure out because, while it seems that "keybase id" never had the proper ansi color treatment, Windows 10 has a console than can handle them. Chris Coyne and I just switched to Windows 10 at the same time, so this was invisible until I tried it on 7, then was able to repro on 10 by explicitly switching to legacy terminal mode:
![image](https://cloud.githubusercontent.com/assets/862397/11675073/90cdcd28-9ddb-11e5-9938-294a5f5e7254.png)
After:
![image](https://cloud.githubusercontent.com/assets/862397/11675089/b39ac3c4-9ddb-11e5-964e-4c51b95e0793.png)

@maxtaco @patrickxb 