### PR TITLE
Identify2 Engine

### DIFF
--- a/go/client/identify_ui.go
+++ b/go/client/identify_ui.go
@@ -66,7 +66,7 @@ func (i *IdentifyUIServer) DisplayTrackStatement(_ context.Context, arg keybase1
 }
 
 func (i *IdentifyUIServer) ReportTrackToken(_ context.Context, arg keybase1.ReportTrackTokenArg) error {
-	i.ui.ReportTrackToken(libkb.IdentifyCacheToken(arg.TrackToken))
+	i.ui.ReportTrackToken(arg.TrackToken)
 	return nil
 }
 

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -59,7 +59,7 @@ func (ui BaseIdentifyUI) DisplayTrackStatement(stmt string) error {
 	return ui.parent.Output(stmt)
 }
 
-func (ui BaseIdentifyUI) ReportTrackToken(_ libkb.IdentifyCacheToken) error {
+func (ui BaseIdentifyUI) ReportTrackToken(_ keybase1.TrackToken) error {
 	return nil
 }
 

--- a/go/engine/id.go
+++ b/go/engine/id.go
@@ -11,7 +11,7 @@ import (
 type IDRes struct {
 	Outcome           *libkb.IdentifyOutcome
 	User              *libkb.User
-	TrackToken        libkb.IdentifyCacheToken
+	TrackToken        keybase1.TrackToken
 	ComputedKeyFamily *libkb.ComputedKeyFamily
 }
 
@@ -118,7 +118,7 @@ func (ir *IDRes) Export() *keybase1.IdentifyRes {
 	return &keybase1.IdentifyRes{
 		Outcome:    *((*ir.Outcome).Export()),
 		User:       ir.User.Export(),
-		TrackToken: ir.TrackToken.Export(),
+		TrackToken: ir.TrackToken,
 		PublicKeys: ir.ComputedKeyFamily.Export(),
 	}
 }

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -235,7 +235,7 @@ func (ui *FakeIdentifyUI) DisplayTrackStatement(string) (err error) {
 }
 func (ui *FakeIdentifyUI) DisplayUserCard(keybase1.UserCard) {
 }
-func (ui *FakeIdentifyUI) ReportTrackToken(libkb.IdentifyCacheToken) error {
+func (ui *FakeIdentifyUI) ReportTrackToken(keybase1.TrackToken) error {
 	return nil
 }
 func (ui *FakeIdentifyUI) SetStrict(b bool) {

--- a/go/engine/identify.go
+++ b/go/engine/identify.go
@@ -19,7 +19,7 @@ type Identify struct {
 	userExpr         libkb.AssertionExpression
 	outcome          *libkb.IdentifyOutcome
 	trackInst        *libkb.TrackInstructions
-	trackToken       libkb.IdentifyCacheToken
+	trackToken       keybase1.TrackToken
 	selfShortCircuit bool
 	libkb.Contextified
 }
@@ -130,12 +130,12 @@ func (e *Identify) Run(ctx *Context) error {
 	// inform the ui what to do with the remote tracking prompt:
 	e.outcome.TrackOptions = e.arg.TrackOptions
 
-	e.G().Log.Debug("inserting identify outcome for %q in IdentifyCache", e.user.GetName())
-	key, err := e.G().IdentifyCache.Insert(e.outcome)
+	e.G().Log.Debug("inserting identify outcome for %q in TrackCache", e.user.GetName())
+	key, err := e.G().TrackCache.Insert(e.outcome)
 	if err != nil {
 		return err
 	}
-	e.G().Log.Debug("IdentifyCache key: %q", key)
+	e.G().Log.Debug("TrackCache key: %q", key)
 	e.trackToken = key
 
 	return nil
@@ -149,7 +149,7 @@ func (e *Identify) Outcome() *libkb.IdentifyOutcome {
 	return e.outcome
 }
 
-func (e *Identify) TrackToken() libkb.IdentifyCacheToken {
+func (e *Identify) TrackToken() keybase1.TrackToken {
 	return e.trackToken
 }
 

--- a/go/engine/identify.go
+++ b/go/engine/identify.go
@@ -158,7 +158,7 @@ func (e *Identify) TrackInstructions() *libkb.TrackInstructions {
 }
 
 func (e *Identify) run(ctx *Context) (*libkb.IdentifyOutcome, error) {
-	res := libkb.NewIdentifyOutcome(e.arg.WithTracking)
+	res := libkb.NewIdentifyOutcome()
 	res.Username = e.user.GetName()
 	is := libkb.NewIdentifyState(res, e.user)
 
@@ -176,8 +176,7 @@ func (e *Identify) run(ctx *Context) (*libkb.IdentifyOutcome, error) {
 			return nil, err
 		}
 		if tlink != nil {
-			is.CreateTrackLookup(tlink)
-			res.TrackUsed = is.TrackLookup()
+			is.SetTrackLookup(tlink)
 		}
 	}
 
@@ -189,10 +188,7 @@ func (e *Identify) run(ctx *Context) (*libkb.IdentifyOutcome, error) {
 
 	e.G().Log.Debug("+ Identify(%s)", e.user.GetName())
 
-	is.ComputeKeyDiffs(ctx.IdentifyUI.DisplayKey)
-	is.InitResultList()
-	is.ComputeTrackDiffs()
-	is.ComputeRevokedProofs()
+	is.Precompute(ctx.IdentifyUI.DisplayKey)
 
 	ctx.IdentifyUI.LaunchNetworkChecks(res.ExportToUncheckedIdentity(), e.user.Export())
 
@@ -203,12 +199,12 @@ func (e *Identify) run(ctx *Context) (*libkb.IdentifyOutcome, error) {
 		wg.Done()
 	}()
 
-	e.user.IDTable().Identify(is, e.arg.ForceRemoteCheck, ctx.IdentifyUI)
+	e.user.IDTable().Identify(is, e.arg.ForceRemoteCheck, ctx.IdentifyUI, nil)
 
 	wg.Wait()
 
 	base := e.user.BaseProofSet()
-	res.AddProofsToSet(base)
+	res.AddProofsToSet(base, []keybase1.ProofState{keybase1.ProofState_OK})
 	if !e.userExpr.MatchSet(*base) {
 		return nil, fmt.Errorf("User %s didn't match given assertion", e.user.GetName())
 	}
@@ -258,7 +254,7 @@ func (e *Identify) loadUserArg() (*libkb.LoadUserArg, error) {
 	// That is, it might be the keybase assertion (if there), or otherwise,
 	// something that's unique like Twitter or Github, and lastly,
 	// something like DNS that is more likely ambiguous...
-	b := e.findBestComponent(e.userExpr)
+	b := libkb.FindBestIdentifyComponent(e.userExpr)
 	if len(b) == 0 {
 		return nil, fmt.Errorf("Cannot lookup user with %q", e.arg.TargetUsername)
 	}
@@ -278,44 +274,12 @@ func (e *Identify) loadExpr(assertion string) error {
 	return nil
 }
 
-func (e *Identify) findBestComponent(expr libkb.AssertionExpression) string {
-	urls := expr.CollectUrls(nil)
-	if len(urls) == 0 {
-		return ""
-	}
-
-	var uid, kb, soc, fp libkb.AssertionURL
-
-	for _, u := range urls {
-		if u.IsUID() {
-			uid = u
-			break
-		}
-
-		if u.IsKeybase() {
-			kb = u
-		} else if u.IsFingerprint() && fp == nil {
-			fp = u
-		} else if u.IsSocial() && soc == nil {
-			soc = u
-		}
-	}
-
-	order := []libkb.AssertionURL{uid, kb, fp, soc, urls[0]}
-	for _, p := range order {
-		if p != nil {
-			return p.String()
-		}
-	}
-	return ""
-}
-
 func (e *Identify) shortCircuitSelfID(ctx *Context) error {
 	e.G().Log.Debug("Identify: short-circuiting self identification")
 	e.selfShortCircuit = true
 
 	// don't really need anything but username here
-	e.outcome = libkb.NewIdentifyOutcome(e.arg.WithTracking)
+	e.outcome = libkb.NewIdentifyOutcome()
 	e.outcome.Username = e.user.GetName()
 
 	return nil

--- a/go/engine/identify2.go
+++ b/go/engine/identify2.go
@@ -48,8 +48,6 @@ type Identify2 struct {
 	state        libkb.IdentifyState
 	useTracking  bool
 	identifyKeys []keybase1.IdentifyKey
-
-	ranAtTime time.Time
 }
 
 var _ (Engine) = (*Identify2)(nil)
@@ -125,7 +123,7 @@ func (e *Identify2) Run(ctx *Context) (err error) {
 	}
 
 	// First we check that all remote assertions as present for the user,
-	// whether or not the remote check actually suceeds (hnece the
+	// whether or not the remote check actually suceeds (hence the
 	// ProofState_NONE check).
 	okStates := []keybase1.ProofState{keybase1.ProofState_NONE, keybase1.ProofState_OK}
 	if err = e.checkRemoteAssertions(okStates); err != nil {
@@ -147,8 +145,6 @@ func (e *Identify2) Run(ctx *Context) (err error) {
 	if err = e.finishIdentify(ctx, l2); err != nil {
 		return err
 	}
-
-	e.ranAtTime = e.getNow()
 	return nil
 }
 
@@ -340,10 +336,6 @@ func (e *Identify2) useRemoteAssertions() bool {
 	return e.remoteAssertion.Len() > 0
 }
 
-func (e *Identify2) getIdentifyTime() keybase1.Time {
-	return keybase1.Time(e.ranAtTime.Unix())
-}
-
 func (e *Identify2) runIdentifyPrecomputation() (err error) {
 	f := func(k keybase1.IdentifyKey) {
 		e.identifyKeys = append(e.identifyKeys, k)
@@ -483,7 +475,7 @@ func (e *Identify2) Result() *keybase1.Identify2Res {
 }
 
 func (e *Identify2) toUserPlusKeys() keybase1.UserPlusKeys {
-	return e.them.ExportToUserPlusKeys(e.getIdentifyTime())
+	return e.them.ExportToUserPlusKeys(keybase1.ToTime(e.getNow()))
 }
 
 func (e *Identify2) getCache() libkb.Identify2Cacher {

--- a/go/engine/identify2.go
+++ b/go/engine/identify2.go
@@ -1,0 +1,428 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import (
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
+	"sync"
+	"time"
+)
+
+var locktab libkb.LockTable
+
+//
+// TODOs:
+//   - mocked out proof checkers for some sort of testing ability
+//     - this probably means something other than NewProofChecker() in ID table,
+//       and replacing it with a Mock instead.
+//   - think harder about what we're caching in failure cases; right now we're only
+//     caching full successes.
+//
+
+// Identify2 is the Identify engine used in KBFS and as a subroutine
+// of command-line crypto.
+type Identify2 struct {
+	libkb.Contextified
+
+	arg        *keybase1.Identify2Arg
+	trackToken keybase1.TrackToken
+	cachedRes  *keybase1.UserPlusKeys
+
+	me   *libkb.User
+	them *libkb.User
+
+	themAssertion   libkb.AssertionExpression
+	remoteAssertion libkb.AssertionAnd
+	localAssertion  libkb.AssertionAnd
+
+	state        libkb.IdentifyState
+	useTracking  bool
+	identifyKeys []keybase1.IdentifyKey
+
+	ranAtTime time.Time
+}
+
+var _ (Engine) = (*Identify2)(nil)
+
+// Name is the unique engine name.
+func (e *Identify2) Name() string {
+	return "Identify2"
+}
+
+func NewIdentify2(g *libkb.GlobalContext, arg *keybase1.Identify2Arg) *Identify2 {
+	return &Identify2{
+		Contextified: libkb.NewContextified(g),
+		arg:          arg,
+	}
+}
+
+// GetPrereqs returns the engine prereqs.
+func (e *Identify2) Prereqs() Prereqs {
+	return Prereqs{}
+}
+
+// Run then engine
+func (e *Identify2) Run(ctx *Context) (err error) {
+
+	e.G().Log.Debug("+ Identify2.runSingle(UID=%v, Assertion=%s)", e.arg.Uid, e.arg.UserAssertion)
+
+	e.G().Log.Debug("+ acquire singleflight lock")
+	lock := locktab.LockOnName(e.arg.Uid.String())
+	e.G().Log.Debug("- acquired")
+
+	defer func() {
+		if lock != nil {
+			lock.Unlock()
+		}
+		e.G().Log.Debug("- Identify2.Run -> %v", err)
+	}()
+
+	if e.loadAssertion(); err != nil {
+		return err
+	}
+
+	if !e.useAnyAssertions() && e.checkFastCacheHit() {
+		e.G().Log.Debug("| was a self load")
+		return nil
+	}
+
+	e.G().Log.Debug("| Identify2.loadUsers")
+	if err = e.loadUsers(ctx); err != nil {
+		return err
+	}
+
+	if err = e.checkLocalAssertions(); err != nil {
+		return err
+	}
+
+	if e.isSelfLoad() {
+		e.G().Log.Debug("| was a self load")
+		return nil
+	}
+
+	if !e.useRemoteAssertions() && e.checkSlowCacheHit() {
+		e.G().Log.Debug("| hit slow cache, first check")
+		return nil
+	}
+
+	e.G().Log.Debug("| Identify2.createIdentifyState")
+	if err = e.createIdentifyState(); err != nil {
+		return err
+	}
+
+	if err = e.runIdentifyPrecomputation(); err != nil {
+		return err
+	}
+
+	// First we check that all remote assertions as present for the user,
+	// whether or not the remote check actually suceeds (hnece the
+	// ProofState_NONE check).
+	if err = e.checkRemoteAssertions([]keybase1.ProofState{keybase1.ProofState_NONE}); err != nil {
+		e.G().Log.Debug("| Early fail due to missing remote assertions")
+		return err
+	}
+
+	if e.useRemoteAssertions() && e.checkSlowCacheHit() {
+		e.G().Log.Debug("| hit slow cache, second check")
+		return nil
+	}
+
+	if err = e.startIdentifyUI(ctx); err != nil {
+		return err
+	}
+
+	l2 := lock
+	lock = nil
+	if err = e.finishIdentify(ctx, l2); err != nil {
+		return err
+	}
+
+	e.ranAtTime = time.Now()
+	return nil
+}
+
+func (e *Identify2) runIDTableIdentify(ctx *Context, lock *libkb.NamedLock) (err error) {
+	e.them.IDTable().Identify(e.state, false /* ForceRemoteCheck */, ctx.IdentifyUI, nil)
+	e.insertTrackToken(ctx)
+	err = e.checkRemoteAssertions([]keybase1.ProofState{keybase1.ProofState_OK})
+	if err == nil {
+		e.maybeCacheResult()
+	}
+	lock.Unlock()
+	return err
+}
+
+func (e *Identify2) maybeCacheResult() {
+	if e.state.Result().IsOK() {
+		v := e.toUserPlusKeys()
+		e.G().UserCache.Insert(&v)
+	}
+}
+
+func (e *Identify2) insertTrackToken(ctx *Context) (err error) {
+	e.G().Log.Debug("+ insertTrackToken")
+	defer func() {
+		e.G().Log.Debug("- insertTrackToken -> %v", err)
+	}()
+	var ict libkb.IdentifyCacheToken
+	ict, err = e.G().IdentifyCache.Insert(e.state.Result())
+	if err != nil {
+		return err
+	}
+	if err = ctx.IdentifyUI.ReportTrackToken(ict); err != nil {
+		return err
+	}
+	return nil
+}
+
+type checkCompletedListener struct {
+	sync.Mutex
+	err       error
+	ch        chan error
+	needed    libkb.AssertionAnd
+	received  libkb.ProofSet
+	completed bool
+	responded bool
+}
+
+func newCheckCompletedListener(ch chan error, proofs libkb.AssertionAnd) *checkCompletedListener {
+	ret := &checkCompletedListener{
+		ch:     ch,
+		needed: proofs,
+	}
+	return ret
+}
+
+func (c *checkCompletedListener) CheckCompleted(lcr *libkb.LinkCheckResult) {
+	c.Lock()
+	defer c.Unlock()
+	libkb.AddToProofSetNoChecks(lcr.GetLink(), &c.received)
+
+	if err := lcr.GetError(); err != nil {
+		c.err = err
+	}
+
+	// note(maxtaco): this is a little ugly in that it's O(n^2) where n is the number
+	// of identities in the assertion. But I can't imagine n > 3, so this is fine
+	// for now.
+	c.completed = c.needed.MatchSet(c.received)
+
+	if c.err != nil || c.completed {
+		c.respond()
+	}
+}
+
+func (c *checkCompletedListener) Done() {
+	c.Lock()
+	defer c.Unlock()
+	c.respond()
+}
+
+func (c *checkCompletedListener) respond() {
+	if c.ch != nil {
+		if !c.completed && c.err == nil {
+			c.err = libkb.IdentifyDidNotCompleteError{}
+		}
+		c.ch <- c.err
+		c.ch = nil
+	}
+}
+
+func (e *Identify2) partiallyAsyncIdentify(ctx *Context, ch chan error, lock *libkb.NamedLock) {
+	ccl := newCheckCompletedListener(ch, e.remoteAssertion)
+	e.them.IDTable().Identify(e.state, false /* ForceRemoteCheck */, ctx.IdentifyUI, ccl)
+	e.insertTrackToken(ctx)
+	e.maybeCacheResult()
+	lock.Unlock()
+}
+
+func (e *Identify2) checkLocalAssertions() error {
+	if !e.localAssertion.MatchSet(*e.them.BaseProofSet()) {
+		return libkb.UnmetAssertionError{User: e.them.GetName(), Remote: false}
+	}
+	return nil
+}
+
+func (e *Identify2) checkRemoteAssertions(okStates []keybase1.ProofState) error {
+	var ps libkb.ProofSet
+	e.state.Result().AddProofsToSet(&ps, okStates)
+	if !e.remoteAssertion.MatchSet(ps) {
+		return libkb.UnmetAssertionError{User: e.them.GetName(), Remote: true}
+	}
+	return nil
+}
+
+func (e *Identify2) finishIdentify(ctx *Context, lock *libkb.NamedLock) (err error) {
+
+	e.G().Log.Debug("+ finishIdentify")
+	defer func() {
+		e.G().Log.Debug("- finishIdentify -> %v", err)
+	}()
+
+	ctx.IdentifyUI.LaunchNetworkChecks(e.state.ExportToUncheckedIdentity(), e.them.Export())
+
+	switch {
+	case e.useTracking:
+		e.G().Log.Debug("| Case 1: Using Tracking")
+		e.runIDTableIdentify(ctx, lock)
+	case !e.useRemoteAssertions():
+		e.G().Log.Debug("| Case 2: No tracking, without remote assertions")
+		go e.runIDTableIdentify(ctx, lock)
+	default:
+		e.G().Log.Debug("| Case 3: No tracking, with remote assertions")
+		ch := make(chan error)
+		go e.partiallyAsyncIdentify(ctx, ch, lock)
+		err = <-ch
+	}
+
+	return err
+}
+
+func (e *Identify2) loadAssertion() (err error) {
+	e.themAssertion, err = libkb.AssertionParseAndOnly(e.arg.UserAssertion)
+	if err == nil {
+		e.remoteAssertion, e.localAssertion = libkb.CollectAssertions(e.themAssertion)
+	}
+	return err
+}
+
+func (e *Identify2) useAnyAssertions() bool {
+	return e.useLocalAssertions() || e.useRemoteAssertions()
+}
+
+func (e *Identify2) useLocalAssertions() bool {
+	return e.localAssertion.Len() > 0
+}
+func (e *Identify2) useRemoteAssertions() bool {
+	return e.remoteAssertion.Len() > 0
+}
+
+func (e *Identify2) getIdentifyTime() keybase1.Time {
+	return keybase1.Time(e.ranAtTime.Unix())
+}
+
+func (e *Identify2) runIdentifyPrecomputation() (err error) {
+	f := func(k keybase1.IdentifyKey) {
+		e.identifyKeys = append(e.identifyKeys, k)
+	}
+	e.state.Precompute(f)
+	return nil
+}
+
+func (e *Identify2) startIdentifyUI(ctx *Context) (err error) {
+	e.G().Log.Debug("+ Identify(%s)", e.them.GetName())
+	ctx.IdentifyUI.Start(e.them.GetName())
+	for _, k := range e.identifyKeys {
+		ctx.IdentifyUI.DisplayKey(k)
+	}
+	ctx.IdentifyUI.ReportLastTrack(libkb.ExportTrackSummary(e.state.TrackLookup(), e.them.GetName()))
+	return nil
+}
+
+func (e *Identify2) createIdentifyState() (err error) {
+	e.state = libkb.NewIdentifyState(nil, e.them)
+	if e.me == nil {
+		return nil
+	}
+	tlink, err := e.me.TrackChainLinkFor(e.them.GetName(), e.them.GetUID())
+	if err != nil {
+		return nil
+	}
+	if tlink != nil {
+		e.useTracking = true
+		e.state.SetTrackLookup(tlink)
+	}
+	return nil
+}
+
+// RequiredUIs returns the required UIs.
+func (e *Identify2) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{
+		libkb.IdentifyUIKind,
+	}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *Identify2) SubConsumers() []libkb.UIConsumer {
+	return nil
+}
+
+func (e *Identify2) isSelfLoad() bool {
+	return e.me != nil && e.them != nil && e.me.Equal(e.them)
+}
+
+func (e *Identify2) loadMe(ctx *Context) (err error) {
+	var ok bool
+	ok, err = IsLoggedIn(e, ctx)
+	if err != nil || !ok {
+		return err
+	}
+	e.me, err = libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
+	return err
+}
+
+func (e *Identify2) loadThem(ctx *Context) (err error) {
+	arg := libkb.NewLoadUserArg(e.G())
+	arg.UID = e.arg.Uid
+	e.them, err = libkb.LoadUser(arg)
+	if e.them == nil {
+		panic("Expected e.them to be true after successful loadUser")
+	}
+	return err
+}
+
+func (e *Identify2) loadUsers(ctx *Context) (err error) {
+	if err = e.loadMe(ctx); err != nil {
+		return err
+	}
+	if err = e.loadThem(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *Identify2) checkFastCacheHit() bool {
+	u, _ := e.G().UserCache.Get(e.them.GetUID())
+	if u == nil {
+		return false
+	}
+	then := u.Uvv.CachedAt
+	if then == 0 {
+		return false
+	}
+	thenTime := time.Unix(int64(then), 0)
+	if time.Now().Sub(thenTime) > libkb.IdentifyCacheLongTimeout {
+		return false
+	}
+	e.cachedRes = u
+	return true
+}
+
+func (e *Identify2) checkSlowCacheHit() bool {
+
+	u, _ := e.G().UserCache.Get(e.them.GetUID())
+	if u == nil {
+		return false
+	}
+	if !e.them.IsCachedIdentifyFresh(u) {
+		return false
+	}
+	e.cachedRes = u
+	return true
+}
+
+func (e *Identify2) Result() *keybase1.Identify2Res {
+	res := &keybase1.Identify2Res{}
+	if e.cachedRes != nil {
+		res.Upk = *e.cachedRes
+	} else if e.them != nil {
+		res.Upk = e.toUserPlusKeys()
+	}
+	return res
+}
+
+func (e *Identify2) toUserPlusKeys() keybase1.UserPlusKeys {
+	return e.them.ExportToUserPlusKeys(e.getIdentifyTime())
+}

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -81,7 +81,7 @@ func (i *identify2Tester) DisplayKey(keybase1.IdentifyKey)                      
 func (i *identify2Tester) ReportLastTrack(*keybase1.TrackSummary)                 { return }
 func (i *identify2Tester) LaunchNetworkChecks(*keybase1.Identity, *keybase1.User) { return }
 func (i *identify2Tester) DisplayTrackStatement(string) (err error)               { return }
-func (i *identify2Tester) ReportTrackToken(libkb.IdentifyCacheToken) (err error)  { return }
+func (i *identify2Tester) ReportTrackToken(keybase1.TrackToken) (err error)       { return }
 func (i *identify2Tester) SetStrict(b bool)                                       { return }
 
 func (i *identify2Tester) Finish() {

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -101,6 +101,7 @@ func (i *identify2Tester) LaunchNetworkChecks(*keybase1.Identity, *keybase1.User
 func (i *identify2Tester) DisplayTrackStatement(string) (err error)               { return }
 func (i *identify2Tester) ReportTrackToken(keybase1.TrackToken) (err error)       { return }
 func (i *identify2Tester) SetStrict(b bool)                                       { return }
+func (i *identify2Tester) DisplayUserCard(keybase1.UserCard)                      { return }
 
 func (i *identify2Tester) Finish() {
 	i.finishCh <- struct{}{}

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -1,0 +1,389 @@
+package engine
+
+import (
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
+	jsonw "github.com/keybase/go-jsonw"
+	"strings"
+	"testing"
+)
+
+func importTrackingLink(t *testing.T) *libkb.TrackChainLink {
+	jw, err := jsonw.Unmarshal([]byte(trackingServerReply))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl, err := libkb.ImportLinkFromServer(nil, jw, trackingUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gl := libkb.GenericChainLink{ChainLink: cl}
+	tcl, err := libkb.ParseTrackChainLink(gl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tcl
+}
+
+func TestIdentify2ImportTrackingLink(t *testing.T) {
+	link := importTrackingLink(t)
+	if link == nil {
+		t.Fatalf("link import failed")
+	}
+}
+
+type identify2Tester struct {
+	libkb.Contextified
+	finishCh        chan struct{}
+	startCh         chan struct{}
+	checkStatusHook func(libkb.SigHint) libkb.ProofError
+}
+
+func newIdentify2Tester(g *libkb.GlobalContext) *identify2Tester {
+	return &identify2Tester{
+		Contextified: libkb.NewContextified(g),
+		finishCh:     make(chan struct{}),
+		startCh:      make(chan struct{}, 1),
+	}
+}
+
+func (i *identify2Tester) MakeProofChecker(_ libkb.RemoteProofChainLink) (libkb.ProofChecker, libkb.ProofError) {
+	return i, nil
+}
+
+func (i *identify2Tester) CheckHint(h libkb.SigHint) libkb.ProofError {
+	return nil
+}
+
+func (i *identify2Tester) CheckStatus(h libkb.SigHint) libkb.ProofError {
+	if i.checkStatusHook != nil {
+		return i.checkStatusHook(h)
+	}
+	i.G().Log.Debug("Check status rubber stamp: %+v", h)
+	return nil
+}
+
+func (i *identify2Tester) GetTorError() libkb.ProofError {
+	return nil
+}
+
+func (i *identify2Tester) FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) {
+	return
+}
+func (i *identify2Tester) Confirm(*keybase1.IdentifyOutcome) (res keybase1.ConfirmResult, err error) {
+	return
+}
+func (i *identify2Tester) FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) {
+	return
+}
+func (i *identify2Tester) DisplayCryptocurrency(keybase1.Cryptocurrency)          { return }
+func (i *identify2Tester) DisplayKey(keybase1.IdentifyKey)                        { return }
+func (i *identify2Tester) ReportLastTrack(*keybase1.TrackSummary)                 { return }
+func (i *identify2Tester) LaunchNetworkChecks(*keybase1.Identity, *keybase1.User) { return }
+func (i *identify2Tester) DisplayTrackStatement(string) (err error)               { return }
+func (i *identify2Tester) ReportTrackToken(libkb.IdentifyCacheToken) (err error)  { return }
+func (i *identify2Tester) SetStrict(b bool)                                       { return }
+
+func (i *identify2Tester) Finish() {
+	i.finishCh <- struct{}{}
+}
+
+func (i *identify2Tester) Start(string) {
+	i.startCh <- struct{}{}
+}
+
+func TestIdentify2WithoutTrack(t *testing.T) {
+	tc := SetupEngineTest(t, "identify2WithoutTrack")
+	i := newIdentify2Tester(tc.G)
+	tc.G.ProofCheckerFactory = i
+	arg := &keybase1.Identify2Arg{
+		Uid: tracyUID,
+	}
+	eng := NewIdentify2(tc.G, arg)
+	ctx := Context{IdentifyUI: i}
+
+	err := eng.Run(&ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-i.finishCh
+}
+
+func TestIdentify2WithTrack(t *testing.T) {
+	tc := SetupEngineTest(t, "identify2WithTrack")
+	i := newIdentify2Tester(tc.G)
+	tc.G.ProofCheckerFactory = i
+	arg := &keybase1.Identify2Arg{
+		Uid: tracyUID,
+	}
+	eng := NewIdentify2(tc.G, arg)
+
+	eng.testArgs = &identify2TestArgs{
+		noMe: true,
+		tcl:  importTrackingLink(t),
+	}
+
+	ctx := Context{IdentifyUI: i}
+	go func() {
+		<-i.finishCh
+	}()
+
+	err := eng.Run(&ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIdentify2WithBrokenTrack(t *testing.T) {
+	tc := SetupEngineTest(t, "TestIdentify2WithBrokenTrack")
+	i := newIdentify2Tester(tc.G)
+	tc.G.ProofCheckerFactory = i
+	arg := &keybase1.Identify2Arg{
+		Uid: tracyUID,
+	}
+	eng := NewIdentify2(tc.G, arg)
+
+	eng.testArgs = &identify2TestArgs{
+		noMe: true,
+		tcl:  importTrackingLink(t),
+	}
+	i.checkStatusHook = func(l libkb.SigHint) libkb.ProofError {
+		if strings.Contains(l.GetHumanURL(), "twitter") {
+			tc.G.Log.Debug("failing twitter proof %s", l.GetHumanURL())
+			return libkb.NewProofError(keybase1.ProofStatus_DELETED, "gone!")
+		}
+		return nil
+	}
+
+	ctx := Context{IdentifyUI: i}
+	go func() {
+		<-i.finishCh
+	}()
+
+	err := eng.Run(&ctx)
+	if err == nil {
+		t.Fatal("expected an ID2 error since twitter proof failed")
+	}
+}
+
+func TestIdentify2WithAssertion(t *testing.T) {
+	tc := SetupEngineTest(t, "identify2WithAssertion")
+	i := newIdentify2Tester(tc.G)
+	tc.G.ProofCheckerFactory = i
+	arg := &keybase1.Identify2Arg{
+		Uid:           tracyUID,
+		UserAssertion: "tacovontaco@twitter",
+	}
+	eng := NewIdentify2(tc.G, arg)
+
+	eng.testArgs = &identify2TestArgs{
+		noMe: true,
+	}
+
+	ctx := Context{IdentifyUI: i}
+
+	err := eng.Run(&ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	<-i.finishCh
+}
+
+func TestIdentify2WithNonExistentAssertion(t *testing.T) {
+	tc := SetupEngineTest(t, "identify2WithNonExistentAssertion")
+	i := newIdentify2Tester(tc.G)
+	tc.G.ProofCheckerFactory = i
+	arg := &keybase1.Identify2Arg{
+		Uid:           tracyUID,
+		UserAssertion: "beyonce@twitter",
+	}
+	eng := NewIdentify2(tc.G, arg)
+
+	eng.testArgs = &identify2TestArgs{
+		noMe: true,
+	}
+
+	ctx := Context{IdentifyUI: i}
+
+	starts := 0
+	go func() {
+		<-i.startCh
+		starts++
+	}()
+
+	err := eng.Run(&ctx)
+	if err == nil {
+		t.Fatal(err)
+	}
+	if _, ok := err.(libkb.UnmetAssertionError); !ok {
+		t.Fatalf("Wanted an error of type %T; got %T", libkb.UnmetAssertionError{}, err)
+	}
+	if starts > 0 {
+		t.Fatalf("Didn't expect the identify UI to start in this case")
+	}
+}
+
+func TestIdentify2WithFailedAssertion(t *testing.T) {
+	tc := SetupEngineTest(t, "TestIdentify2WithFailedAssertion")
+	i := newIdentify2Tester(tc.G)
+	tc.G.ProofCheckerFactory = i
+	arg := &keybase1.Identify2Arg{
+		Uid:           tracyUID,
+		UserAssertion: "tacovontaco@twitter",
+	}
+	eng := NewIdentify2(tc.G, arg)
+
+	eng.testArgs = &identify2TestArgs{
+		noMe: true,
+	}
+
+	ctx := Context{IdentifyUI: i}
+
+	starts := 0
+	go func() {
+		<-i.startCh
+		starts++
+	}()
+
+	i.checkStatusHook = func(l libkb.SigHint) libkb.ProofError {
+		if strings.Contains(l.GetHumanURL(), "twitter") {
+			tc.G.Log.Debug("failing twitter proof %s", l.GetHumanURL())
+			return libkb.NewProofError(keybase1.ProofStatus_DELETED, "gone!")
+		}
+		return nil
+	}
+
+	err := eng.Run(&ctx)
+
+	if err == nil {
+		t.Fatal(err)
+	}
+	if _, ok := err.(libkb.ProofError); !ok {
+		t.Fatalf("Wanted an error of type libkb.ProofError; got %T", err)
+	}
+	if starts != 1 {
+		t.Fatalf("Expected the UI to have started")
+	}
+}
+
+var tracyUID = keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")
+var trackingUID = keybase1.UID("92b3b3dbe457059f28c9f74e8e6b9419")
+var trackingServerReply = `{"seqno":3,"payload_hash":"c3ffe390e9c9dabdd5f7253b81e0a38fad2c17589a9c7fcd967958418055140a","sig_id":"4ec10665ad163d0aa419ce4eab8ff661429c9a3a32cd4978fdb8c6b5c6d047620f","sig_id_short":"TsEGZa0WPQqkGc5Oq4_2YUKcmjoyzUl4_bjG","kid":"0101f3b2f0e8c9d1f099db64cac366c6a9c1da63da624127b2f66a056acfa36834fe0a","sig":"-----BEGIN PGP MESSAGE-----\nVersion: Keybase OpenPGP v2.0.49\nComment: https://keybase.io/crypto\n\nyMWEAnictVZriF3VFZ7xVR1aDCqV0CbqqaDFG7vfj9FENJChFsUKWszD69p7rz1z\nk8ncm3vPZBxMQCytQjQEtQXBX42gJUgQ9U+1Jo2hVeID3wqKggoqiIiUtkLVtW+u\nyUxmwArpj8M97LPv2t/6vrW+vQ7+6MShkeEb7zjnd3fEcTt86NmvpoeuxzfOu6UK\n7TRbjd5SxckWTtXlbQo2YzVabcLZAD28uNU+dwZDtb1RVsp3nEzYq5ubWol2Mc54\nlkFkhi76xDPzPgWjIkRpTDTgI09gJD1CcWFppzHAtIGYQRonVUYGVaPKralx7Ha6\nrQKiAue8dhZ5RBuSxRRQIgaH2eXksg2SRwUi0x8n2r16Htyqj7TZh7fI/uOMe7of\nzosggySUSlumfRYUNFuFDk3wivuysYfdAbV1F+JsM3eJ8cQLs2VhU+GWUmjFXnlr\npeZW7PZa7alqlKtGNQnEOS3GCSCiyprymisr3PzQzX7wEvQwAcGKrAhQSmiU8KiT\ndYxRXsii7wMbyFo4my/CHLIE8yEJFFoLSY+PWZE81hoLyRlnk9OCMc0dpGiV9jox\n+q4Zimwh2MAYkUWYOuOdJh1EGa5b7ESVs2ZJO+YpPWEF8R64ik5wRtBFtDGzpJyb\nJyOi8YFrQ+k5zjxlrJVLHnyywlja7iWlC8pwlcEqGUs1QTQENhiTUkG2oVF1cXO7\nxman227nw/hi3dp8hGnhFGtUcbrbpWOpWqJTMULKznELCF4pLYyRDj2oyKSKnghJ\nybigQQpP2LPxyTsmPUuEHwfBvVbMuX7wThe3llpiPhsAowMjAqPWTmiu6SwlAQPP\nXliPKHgKXuuYs2QeqPAM1SA1DC9FOcilENzPp9/gExg3NRPU0NzYK1V1pNPrmVZd\nY/eYGoXY3tqeKj994UqYZj3boW+iUfVqqAt6+tLDLVPtalTTW2v8cNcZS12A3vKo\nA+XGSTXLLXWZswKcZEoQXuF0AOctuMxFihKpTShJdCyw0qcl2uC87Y0FYjh5RAyq\nORfRE+NJyCQMo7oTXvlSgRaJLlJJobXScO8KuTGgRWGTSTkoIxeKUYIPxDgOSn8/\nMcZb9cR0WKhFZ3K6V55jxZCLiWHmiBEyWgNCk3ExZciUiIlCEI8pceuQrI8JA+QR\nTlvqFG8jFyKAQgXUtvm7xfDFnwZiIOiAyC21pUXqV5dyslwJTvZB7ZZJWxCQlZXk\nqpF6NtPJSeooFSMwsECMfvCBGMdB6e8nBu1Y2BhHHXauDpy4YnwxMewcMVhUZEko\nBbWDDmSgAGRZ3GDwAI5rGXIGzY0MmllvqK6CTZpFUgKsVfw7xVBkxkfECDlJZQQI\n7iVZny/yZ8mRYquY6UKMhWNmHBNWJgzFw60DKoasY8j6GDE86wf/1qYAHe0zkUVD\n/evpjjCSgHtaY14oncvF58nNQYGMjMqCzDgEKjxFFNj/XYxywy8YSqo+/XU7tidp\nfaKuO73RxTRZTBE/RxEvEBHo6vY+Bs09pWmNjtzSIpmViOiCMyFApDmCRgO60ulC\nYZln8gKxiFdt6B/TrKE1WcB3YHayDak5Ab2J4yPJ/yeJ7WUM6acwmEYa1dH5g77N\nrzLryO/x5k6ri81W2aEtQe7TPSgPAmyNMeSPHBgNCHQ9SZc1GRF6lxwNS0w6IchM\nLWc2QPI8Z2rT5ERyKvmjiZLD1TBOISndKainu1htP7B//UlDwyNDp5x8Qhljh0ZO\nW/LtcHvjsz/4+jd3PvjW9b+c+Wu165rHX/z37/+w4qevrZr5hbj5oZ3m6i0zn709\n8vzaM+4be3THexufO/PzsRde+scPmxe8vORPo8s/vPhn+9/574p7bl9+w8lX7xz7\nci3fduDLu8ccDC9j7YevW7vi/aeePvE/ay7a9sm6Fz9fddnLl+45eOU/7ZZDa/bx\n19bA7jdXXfHzXR//Zf/eH7ceuOndjVvOXr2zXrbjzKVXfbB6RG5bsu+SB3cv3XvW\n5c+sfHfpXedf+/wrH+35+/1P7LhmaO/GJ9m9n35xq37zJ39++I0PP75t9SPPPXXP\nnuFTGvJVue+Zs/617PW/XX76JbuvHb7w16ctP9h97I+/XXn/Vzt/tf7Ahl3r3Ekr\nHzt0Q3P9OxPLmqeOPX3RVSPpG2YdtWQ=\n=h5Bq\n-----END PGP MESSAGE-----","payload_json":"{\"body\":{\"client\":{\"name\":\"keybase.io web\"},\"key\":{\"eldest_kid\":\"0101f3b2f0e8c9d1f099db64cac366c6a9c1da63da624127b2f66a056acfa36834fe0a\",\"fingerprint\":\"a889587e1ce7bd7edbe3eeb8ef8fd8f7b31c4a2f\",\"host\":\"keybase.io\",\"key_id\":\"ef8fd8f7b31c4a2f\",\"kid\":\"0101f3b2f0e8c9d1f099db64cac366c6a9c1da63da624127b2f66a056acfa36834fe0a\",\"uid\":\"92b3b3dbe457059f28c9f74e8e6b9419\",\"username\":\"tracy_friend1\"},\"track\":{\"basics\":{\"id_version\":14,\"last_id_change\":1449514728,\"username\":\"t_tracy\"},\"id\":\"eb72f49f2dde6429e5d78003dae0c919\",\"key\":{\"key_fingerprint\":\"\",\"kid\":\"01209bd2e255235529cf45877767ad8687d85200518adc74595d058750e2f7ab7b000a\"},\"pgp_keys\":[{\"key_fingerprint\":\"4ff50d580914427227bb14c821029e2c7cf0d488\",\"kid\":\"0101ee69b1566428109eb7548d9a9d7267d48933daa4614fa743cedbeac618ab66dd0a\"}],\"remote_proofs\":[{\"ctime\":1449512840,\"curr\":\"f09c84ccadf8817aea944526638e9a4c034c9200dd68b5a3292c7f69d980390d\",\"etime\":1954088840,\"prev\":\"909f6aa65b050ec5582515cad43aeb1f9279ee21db955cff309abe4692b7e11a\",\"remote_key_proof\":{\"check_data_json\":{\"name\":\"twitter\",\"username\":\"tacovontaco\"},\"proof_type\":2,\"state\":1},\"seqno\":5,\"sig_id\":\"67570e971c5b8881cf07179d1872a83042be4285ba897a8f12dc3e419cade80b0f\",\"sig_type\":2},{\"ctime\":1449512883,\"curr\":\"8ad8ce94c9d23d260750294905877ef92adf4e7736198909fcbe7e27d6dfb463\",\"etime\":1954088883,\"prev\":\"f09c84ccadf8817aea944526638e9a4c034c9200dd68b5a3292c7f69d980390d\",\"remote_key_proof\":{\"check_data_json\":{\"name\":\"github\",\"username\":\"tacoplusplus\"},\"proof_type\":3,\"state\":1},\"seqno\":6,\"sig_id\":\"bfe76a25acf046f7477350291cdd178e1f0026a49f85733d97c122ba4e4a000f0f\",\"sig_type\":2},{\"ctime\":1449512914,\"curr\":\"ea5bee1701e7ec7c8dfd71421bd2ab6fb0fa2af473412c664fa49d35c34078ea\",\"etime\":1954088914,\"prev\":\"8ad8ce94c9d23d260750294905877ef92adf4e7736198909fcbe7e27d6dfb463\",\"remote_key_proof\":{\"check_data_json\":{\"name\":\"rooter\",\"username\":\"t_tracy\"},\"proof_type\":100001,\"state\":1},\"seqno\":7,\"sig_id\":\"0c467de321795b777aa10916eb9aa8153bffa5163b5079600db7d50ca00a77410f\",\"sig_type\":2},{\"ctime\":1449514687,\"curr\":\"bfd3462a2193fa7946f7f31e5074cfc4ac95400680273deb520078a6a4f5cbf5\",\"etime\":1954090687,\"prev\":\"9ae84f56c0c62dc91206363b9f5609245f94199d58a4a3c0bee7d4bb91c47de7\",\"remote_key_proof\":{\"check_data_json\":{\"hostname\":\"keybase.io\",\"protocol\":\"https:\"},\"proof_type\":1000,\"state\":1},\"seqno\":9,\"sig_id\":\"92eeea3db99cb519409765c17ea32a82ce8b86bbacd8f366e8e8930f1faea20b0f\",\"sig_type\":2}],\"seq_tail\":{\"payload_hash\":\"bfd3462a2193fa7946f7f31e5074cfc4ac95400680273deb520078a6a4f5cbf5\",\"seqno\":9,\"sig_id\":\"92eeea3db99cb519409765c17ea32a82ce8b86bbacd8f366e8e8930f1faea20b0f\"}},\"type\":\"track\",\"version\":1},\"ctime\":1449514785,\"expire_in\":157680000,\"prev\":\"a4f76660341a087d69238f5a25e98d8b3d038224457107bad91ffdfbd82d84d9\",\"seqno\":3,\"tag\":\"signature\"}","sig_type":3,"ctime":1449514785,"etime":1607194785,"rtime":null,"sig_status":0,"prev":"a4f76660341a087d69238f5a25e98d8b3d038224457107bad91ffdfbd82d84d9","proof_id":null,"proof_type":null,"proof_text_check":null,"proof_text_full":null,"check_data_json":null,"remote_id":null,"api_url":null,"human_url":null,"proof_state":null,"proof_status":null,"retry_count":null,"hard_fail_count":null,"last_check":null,"last_success":null,"version":null,"fingerprint":"a889587e1ce7bd7edbe3eeb8ef8fd8f7b31c4a2f"}`
+
+var trackingStatementPayload = `{
+  "body": {
+    "client": {
+      "name": "keybase.io web"
+    },
+    "key": {
+      "eldest_kid": "0101f3b2f0e8c9d1f099db64cac366c6a9c1da63da624127b2f66a056acfa36834fe0a",
+      "fingerprint": "a889587e1ce7bd7edbe3eeb8ef8fd8f7b31c4a2f",
+      "host": "keybase.io",
+      "key_id": "ef8fd8f7b31c4a2f",
+      "kid": "0101f3b2f0e8c9d1f099db64cac366c6a9c1da63da624127b2f66a056acfa36834fe0a",
+      "uid": "92b3b3dbe457059f28c9f74e8e6b9419",
+      "username": "tracy_friend1"
+    },
+    "track": {
+      "basics": {
+        "id_version": 14,
+        "last_id_change": 1449514728,
+        "username": "t_tracy"
+      },
+      "id": "eb72f49f2dde6429e5d78003dae0c919",
+      "key": {
+        "key_fingerprint": "",
+        "kid": "01209bd2e255235529cf45877767ad8687d85200518adc74595d058750e2f7ab7b000a"
+      },
+      "pgp_keys": [
+        {
+          "key_fingerprint": "4ff50d580914427227bb14c821029e2c7cf0d488",
+          "kid": "0101ee69b1566428109eb7548d9a9d7267d48933daa4614fa743cedbeac618ab66dd0a"
+        }
+      ],
+      "remote_proofs": [
+        {
+          "ctime": 1449512840,
+          "curr": "f09c84ccadf8817aea944526638e9a4c034c9200dd68b5a3292c7f69d980390d",
+          "etime": 1954088840,
+          "prev": "909f6aa65b050ec5582515cad43aeb1f9279ee21db955cff309abe4692b7e11a",
+          "remote_key_proof": {
+            "check_data_json": {
+              "name": "twitter",
+              "username": "tacovontaco"
+            },
+            "proof_type": 2,
+            "state": 1
+          },
+          "seqno": 5,
+          "sig_id": "67570e971c5b8881cf07179d1872a83042be4285ba897a8f12dc3e419cade80b0f",
+          "sig_type": 2
+        },
+        {
+          "ctime": 1449512883,
+          "curr": "8ad8ce94c9d23d260750294905877ef92adf4e7736198909fcbe7e27d6dfb463",
+          "etime": 1954088883,
+          "prev": "f09c84ccadf8817aea944526638e9a4c034c9200dd68b5a3292c7f69d980390d",
+          "remote_key_proof": {
+            "check_data_json": {
+              "name": "github",
+              "username": "tacoplusplus"
+            },
+            "proof_type": 3,
+            "state": 1
+          },
+          "seqno": 6,
+          "sig_id": "bfe76a25acf046f7477350291cdd178e1f0026a49f85733d97c122ba4e4a000f0f",
+          "sig_type": 2
+        },
+        {
+          "ctime": 1449512914,
+          "curr": "ea5bee1701e7ec7c8dfd71421bd2ab6fb0fa2af473412c664fa49d35c34078ea",
+          "etime": 1954088914,
+          "prev": "8ad8ce94c9d23d260750294905877ef92adf4e7736198909fcbe7e27d6dfb463",
+          "remote_key_proof": {
+            "check_data_json": {
+              "name": "rooter",
+              "username": "t_tracy"
+            },
+            "proof_type": 100001,
+            "state": 1
+          },
+          "seqno": 7,
+          "sig_id": "0c467de321795b777aa10916eb9aa8153bffa5163b5079600db7d50ca00a77410f",
+          "sig_type": 2
+        },
+        {
+          "ctime": 1449514687,
+          "curr": "bfd3462a2193fa7946f7f31e5074cfc4ac95400680273deb520078a6a4f5cbf5",
+          "etime": 1954090687,
+          "prev": "9ae84f56c0c62dc91206363b9f5609245f94199d58a4a3c0bee7d4bb91c47de7",
+          "remote_key_proof": {
+            "check_data_json": {
+              "hostname": "keybase.io",
+              "protocol": "https:"
+            },
+            "proof_type": 1000,
+            "state": 1
+          },
+          "seqno": 9,
+          "sig_id": "92eeea3db99cb519409765c17ea32a82ce8b86bbacd8f366e8e8930f1faea20b0f",
+          "sig_type": 2
+        }
+      ],
+      "seq_tail": {
+        "payload_hash": "bfd3462a2193fa7946f7f31e5074cfc4ac95400680273deb520078a6a4f5cbf5",
+        "seqno": 9,
+        "sig_id": "92eeea3db99cb519409765c17ea32a82ce8b86bbacd8f366e8e8930f1faea20b0f"
+      }
+    },
+    "type": "track",
+    "version": 1
+  },
+  "ctime": 1449514785,
+  "expire_in": 157680000,
+  "prev": "a4f76660341a087d69238f5a25e98d8b3d038224457107bad91ffdfbd82d84d9",
+  "seqno": 3,
+  "tag": "signature"
+}`

--- a/go/engine/identify2_with_uid_test.go
+++ b/go/engine/identify2_with_uid_test.go
@@ -5,6 +5,7 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol"
 	jsonw "github.com/keybase/go-jsonw"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -26,7 +27,7 @@ func importTrackingLink(t *testing.T) *libkb.TrackChainLink {
 	return tcl
 }
 
-func TestIdentify2ImportTrackingLink(t *testing.T) {
+func TestIdentify2WithUIDImportTrackingLink(t *testing.T) {
 	link := importTrackingLink(t)
 	if link == nil {
 		t.Fatalf("link import failed")
@@ -44,7 +45,7 @@ func (c cacheStats) eq(h, t, m, n int) bool {
 	return h == c.hit && t == c.timeout && m == c.miss && n == c.notime
 }
 
-type identify2Tester struct {
+type Identify2WithUIDTester struct {
 	libkb.Contextified
 	finishCh        chan struct{}
 	startCh         chan struct{}
@@ -55,8 +56,8 @@ type identify2Tester struct {
 	now             time.Time
 }
 
-func newIdentify2Tester(g *libkb.GlobalContext) *identify2Tester {
-	return &identify2Tester{
+func newIdentify2WithUIDTester(g *libkb.GlobalContext) *Identify2WithUIDTester {
+	return &Identify2WithUIDTester{
 		Contextified: libkb.NewContextified(g),
 		finishCh:     make(chan struct{}),
 		startCh:      make(chan struct{}, 1),
@@ -65,15 +66,15 @@ func newIdentify2Tester(g *libkb.GlobalContext) *identify2Tester {
 	}
 }
 
-func (i *identify2Tester) MakeProofChecker(_ libkb.RemoteProofChainLink) (libkb.ProofChecker, libkb.ProofError) {
+func (i *Identify2WithUIDTester) MakeProofChecker(_ libkb.RemoteProofChainLink) (libkb.ProofChecker, libkb.ProofError) {
 	return i, nil
 }
 
-func (i *identify2Tester) CheckHint(h libkb.SigHint) libkb.ProofError {
+func (i *Identify2WithUIDTester) CheckHint(h libkb.SigHint) libkb.ProofError {
 	return nil
 }
 
-func (i *identify2Tester) CheckStatus(h libkb.SigHint) libkb.ProofError {
+func (i *Identify2WithUIDTester) CheckStatus(h libkb.SigHint) libkb.ProofError {
 	if i.checkStatusHook != nil {
 		return i.checkStatusHook(h)
 	}
@@ -81,37 +82,37 @@ func (i *identify2Tester) CheckStatus(h libkb.SigHint) libkb.ProofError {
 	return nil
 }
 
-func (i *identify2Tester) GetTorError() libkb.ProofError {
+func (i *Identify2WithUIDTester) GetTorError() libkb.ProofError {
 	return nil
 }
 
-func (i *identify2Tester) FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) {
+func (i *Identify2WithUIDTester) FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) {
 	return
 }
-func (i *identify2Tester) Confirm(*keybase1.IdentifyOutcome) (res keybase1.ConfirmResult, err error) {
+func (i *Identify2WithUIDTester) Confirm(*keybase1.IdentifyOutcome) (res keybase1.ConfirmResult, err error) {
 	return
 }
-func (i *identify2Tester) FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) {
+func (i *Identify2WithUIDTester) FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) {
 	return
 }
-func (i *identify2Tester) DisplayCryptocurrency(keybase1.Cryptocurrency)          { return }
-func (i *identify2Tester) DisplayKey(keybase1.IdentifyKey)                        { return }
-func (i *identify2Tester) ReportLastTrack(*keybase1.TrackSummary)                 { return }
-func (i *identify2Tester) LaunchNetworkChecks(*keybase1.Identity, *keybase1.User) { return }
-func (i *identify2Tester) DisplayTrackStatement(string) (err error)               { return }
-func (i *identify2Tester) ReportTrackToken(keybase1.TrackToken) (err error)       { return }
-func (i *identify2Tester) SetStrict(b bool)                                       { return }
-func (i *identify2Tester) DisplayUserCard(keybase1.UserCard)                      { return }
+func (i *Identify2WithUIDTester) DisplayCryptocurrency(keybase1.Cryptocurrency)          { return }
+func (i *Identify2WithUIDTester) DisplayKey(keybase1.IdentifyKey)                        { return }
+func (i *Identify2WithUIDTester) ReportLastTrack(*keybase1.TrackSummary)                 { return }
+func (i *Identify2WithUIDTester) LaunchNetworkChecks(*keybase1.Identity, *keybase1.User) { return }
+func (i *Identify2WithUIDTester) DisplayTrackStatement(string) (err error)               { return }
+func (i *Identify2WithUIDTester) ReportTrackToken(keybase1.TrackToken) (err error)       { return }
+func (i *Identify2WithUIDTester) SetStrict(b bool)                                       { return }
+func (i *Identify2WithUIDTester) DisplayUserCard(keybase1.UserCard)                      { return }
 
-func (i *identify2Tester) Finish() {
+func (i *Identify2WithUIDTester) Finish() {
 	i.finishCh <- struct{}{}
 }
 
-func (i *identify2Tester) Start(string) {
+func (i *Identify2WithUIDTester) Start(string) {
 	i.startCh <- struct{}{}
 }
 
-func (i *identify2Tester) Get(uid keybase1.UID, gctf libkb.GetCheckTimeFunc, timeout time.Duration) (*keybase1.UserPlusKeys, error) {
+func (i *Identify2WithUIDTester) Get(uid keybase1.UID, gctf libkb.GetCheckTimeFunc, timeout time.Duration) (*keybase1.UserPlusKeys, error) {
 	res := i.cache[uid]
 	stats := &i.slowStats
 	if timeout == libkb.Identify2CacheShortTimeout {
@@ -138,7 +139,7 @@ func (i *identify2Tester) Get(uid keybase1.UID, gctf libkb.GetCheckTimeFunc, tim
 	return res, nil
 }
 
-func (i *identify2Tester) Insert(up *keybase1.UserPlusKeys) error {
+func (i *Identify2WithUIDTester) Insert(up *keybase1.UserPlusKeys) error {
 	tmp := *up
 	copy := &tmp
 	copy.Uvv.CachedAt = keybase1.ToTime(i.now)
@@ -146,18 +147,18 @@ func (i *identify2Tester) Insert(up *keybase1.UserPlusKeys) error {
 	return nil
 }
 
-func (i *identify2Tester) Shutdown() {}
+func (i *Identify2WithUIDTester) Shutdown() {}
 
-var _ libkb.Identify2Cacher = (*identify2Tester)(nil)
+var _ libkb.Identify2Cacher = (*Identify2WithUIDTester)(nil)
 
-func TestIdentify2WithoutTrack(t *testing.T) {
-	tc := SetupEngineTest(t, "identify2WithoutTrack")
-	i := newIdentify2Tester(tc.G)
+func TestIdentify2WithUIDWithoutTrack(t *testing.T) {
+	tc := SetupEngineTest(t, "Identify2WithUIDWithoutTrack")
+	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.ProofCheckerFactory = i
-	arg := &keybase1.Identify2Arg{
+	arg := &keybase1.Identify2WithUIDArg{
 		Uid: tracyUID,
 	}
-	eng := NewIdentify2(tc.G, arg)
+	eng := NewIdentify2WithUID(tc.G, arg)
 	ctx := Context{IdentifyUI: i}
 
 	err := eng.Run(&ctx)
@@ -167,16 +168,16 @@ func TestIdentify2WithoutTrack(t *testing.T) {
 	<-i.finishCh
 }
 
-func TestIdentify2WithTrack(t *testing.T) {
-	tc := SetupEngineTest(t, "identify2WithTrack")
-	i := newIdentify2Tester(tc.G)
+func TestIdentify2WithUIDWithTrack(t *testing.T) {
+	tc := SetupEngineTest(t, "Identify2WithUIDWithTrack")
+	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.ProofCheckerFactory = i
-	arg := &keybase1.Identify2Arg{
+	arg := &keybase1.Identify2WithUIDArg{
 		Uid: tracyUID,
 	}
-	eng := NewIdentify2(tc.G, arg)
+	eng := NewIdentify2WithUID(tc.G, arg)
 
-	eng.testArgs = &identify2TestArgs{
+	eng.testArgs = &Identify2WithUIDTestArgs{
 		noMe: true,
 		tcl:  importTrackingLink(t),
 	}
@@ -192,16 +193,16 @@ func TestIdentify2WithTrack(t *testing.T) {
 	}
 }
 
-func TestIdentify2WithBrokenTrack(t *testing.T) {
-	tc := SetupEngineTest(t, "TestIdentify2WithBrokenTrack")
-	i := newIdentify2Tester(tc.G)
+func TestIdentify2WithUIDWithBrokenTrack(t *testing.T) {
+	tc := SetupEngineTest(t, "TestIdentify2WithUIDWithBrokenTrack")
+	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.ProofCheckerFactory = i
-	arg := &keybase1.Identify2Arg{
+	arg := &keybase1.Identify2WithUIDArg{
 		Uid: tracyUID,
 	}
-	eng := NewIdentify2(tc.G, arg)
+	eng := NewIdentify2WithUID(tc.G, arg)
 
-	eng.testArgs = &identify2TestArgs{
+	eng.testArgs = &Identify2WithUIDTestArgs{
 		noMe: true,
 		tcl:  importTrackingLink(t),
 	}
@@ -224,17 +225,17 @@ func TestIdentify2WithBrokenTrack(t *testing.T) {
 	}
 }
 
-func TestIdentify2WithAssertion(t *testing.T) {
-	tc := SetupEngineTest(t, "identify2WithAssertion")
-	i := newIdentify2Tester(tc.G)
+func TestIdentify2WithUIDWithAssertion(t *testing.T) {
+	tc := SetupEngineTest(t, "Identify2WithUIDWithAssertion")
+	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.ProofCheckerFactory = i
-	arg := &keybase1.Identify2Arg{
+	arg := &keybase1.Identify2WithUIDArg{
 		Uid:           tracyUID,
 		UserAssertion: "tacovontaco@twitter",
 	}
-	eng := NewIdentify2(tc.G, arg)
+	eng := NewIdentify2WithUID(tc.G, arg)
 
-	eng.testArgs = &identify2TestArgs{
+	eng.testArgs = &Identify2WithUIDTestArgs{
 		noMe: true,
 	}
 
@@ -248,17 +249,41 @@ func TestIdentify2WithAssertion(t *testing.T) {
 	<-i.finishCh
 }
 
-func TestIdentify2WithNonExistentAssertion(t *testing.T) {
-	tc := SetupEngineTest(t, "identify2WithNonExistentAssertion")
-	i := newIdentify2Tester(tc.G)
+func TestIdentify2WithUIDWithAssertions(t *testing.T) {
+	tc := SetupEngineTest(t, "Identify2WithUIDWithAssertion")
+	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.ProofCheckerFactory = i
-	arg := &keybase1.Identify2Arg{
+	arg := &keybase1.Identify2WithUIDArg{
+		Uid:           tracyUID,
+		UserAssertion: "tacovontaco@twitter+t_tracy@rooter",
+	}
+	eng := NewIdentify2WithUID(tc.G, arg)
+
+	eng.testArgs = &Identify2WithUIDTestArgs{
+		noMe: true,
+	}
+
+	ctx := Context{IdentifyUI: i}
+
+	err := eng.Run(&ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	<-i.finishCh
+}
+
+func TestIdentify2WithUIDWithNonExistentAssertion(t *testing.T) {
+	tc := SetupEngineTest(t, "Identify2WithUIDWithNonExistentAssertion")
+	i := newIdentify2WithUIDTester(tc.G)
+	tc.G.ProofCheckerFactory = i
+	arg := &keybase1.Identify2WithUIDArg{
 		Uid:           tracyUID,
 		UserAssertion: "beyonce@twitter",
 	}
-	eng := NewIdentify2(tc.G, arg)
+	eng := NewIdentify2WithUID(tc.G, arg)
 
-	eng.testArgs = &identify2TestArgs{
+	eng.testArgs = &Identify2WithUIDTestArgs{
 		noMe: true,
 	}
 
@@ -282,17 +307,17 @@ func TestIdentify2WithNonExistentAssertion(t *testing.T) {
 	}
 }
 
-func TestIdentify2WithFailedAssertion(t *testing.T) {
-	tc := SetupEngineTest(t, "TestIdentify2WithFailedAssertion")
-	i := newIdentify2Tester(tc.G)
+func TestIdentify2WithUIDWithFailedAssertion(t *testing.T) {
+	tc := SetupEngineTest(t, "TestIdentify2WithUIDWithFailedAssertion")
+	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.ProofCheckerFactory = i
-	arg := &keybase1.Identify2Arg{
+	arg := &keybase1.Identify2WithUIDArg{
 		Uid:           tracyUID,
 		UserAssertion: "tacovontaco@twitter",
 	}
-	eng := NewIdentify2(tc.G, arg)
+	eng := NewIdentify2WithUID(tc.G, arg)
 
-	eng.testArgs = &identify2TestArgs{
+	eng.testArgs = &Identify2WithUIDTestArgs{
 		noMe: true,
 	}
 
@@ -326,20 +351,65 @@ func TestIdentify2WithFailedAssertion(t *testing.T) {
 	<-i.finishCh
 }
 
-func (i *identify2Tester) incNow(d time.Duration) {
+func TestIdentify2WithUIDWithFailedAncillaryAssertion(t *testing.T) {
+	tc := SetupEngineTest(t, "TestIdentify2WithUIDWithFailedAncillaryAssertion")
+	i := newIdentify2WithUIDTester(tc.G)
+	tc.G.ProofCheckerFactory = i
+	arg := &keybase1.Identify2WithUIDArg{
+		Uid:           tracyUID,
+		UserAssertion: "tacoplusplus@github+t_tracy@rooter",
+	}
+	eng := NewIdentify2WithUID(tc.G, arg)
+
+	eng.testArgs = &Identify2WithUIDTestArgs{
+		noMe: true,
+	}
+
+	ctx := Context{IdentifyUI: i}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	i.checkStatusHook = func(l libkb.SigHint) libkb.ProofError {
+		switch {
+		case strings.Contains(l.GetHumanURL(), "twitter"):
+			wg.Done()
+			tc.G.Log.Debug("failing twitter proof %s", l.GetHumanURL())
+			return libkb.NewProofError(keybase1.ProofStatus_DELETED, "gone!")
+		case strings.Contains(l.GetHumanURL(), "github"):
+			wg.Wait()
+			return nil
+		case strings.Contains(l.GetHumanURL(), "rooter"):
+			wg.Wait()
+			return nil
+		default:
+			return nil
+		}
+	}
+
+	err := eng.Run(&ctx)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-i.startCh
+	<-i.finishCh
+}
+
+func (i *Identify2WithUIDTester) incNow(d time.Duration) {
 	i.now = i.now.Add(d)
 }
 
-func TestIdentify2Cache(t *testing.T) {
-	tc := SetupEngineTest(t, "identify2WithoutTrack")
-	i := newIdentify2Tester(tc.G)
+func TestIdentify2WithUIDCache(t *testing.T) {
+	tc := SetupEngineTest(t, "Identify2WithUIDWithoutTrack")
+	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.ProofCheckerFactory = i
-	arg := &keybase1.Identify2Arg{
+	arg := &keybase1.Identify2WithUIDArg{
 		Uid: tracyUID,
 	}
 	run := func() {
-		eng := NewIdentify2(tc.G, arg)
-		eng.testArgs = &identify2TestArgs{
+		eng := NewIdentify2WithUID(tc.G, arg)
+		eng.testArgs = &Identify2WithUIDTestArgs{
 			cache: i,
 			clock: func() time.Time { return i.now },
 		}
@@ -401,16 +471,16 @@ func TestIdentify2Cache(t *testing.T) {
 	}
 }
 
-func TestIdentify2LocalAssertions(t *testing.T) {
-	tc := SetupEngineTest(t, "TestIdentify2LocalAssertions")
-	i := newIdentify2Tester(tc.G)
+func TestIdentify2WithUIDLocalAssertions(t *testing.T) {
+	tc := SetupEngineTest(t, "TestIdentify2WithUIDLocalAssertions")
+	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.ProofCheckerFactory = i
-	arg := &keybase1.Identify2Arg{
+	arg := &keybase1.Identify2WithUIDArg{
 		Uid: tracyUID,
 	}
 	run := func() {
-		eng := NewIdentify2(tc.G, arg)
-		eng.testArgs = &identify2TestArgs{
+		eng := NewIdentify2WithUID(tc.G, arg)
+		eng.testArgs = &Identify2WithUIDTestArgs{
 			cache: i,
 			clock: func() time.Time { return i.now },
 		}
@@ -467,120 +537,3 @@ func TestIdentify2LocalAssertions(t *testing.T) {
 var tracyUID = keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")
 var trackingUID = keybase1.UID("92b3b3dbe457059f28c9f74e8e6b9419")
 var trackingServerReply = `{"seqno":3,"payload_hash":"c3ffe390e9c9dabdd5f7253b81e0a38fad2c17589a9c7fcd967958418055140a","sig_id":"4ec10665ad163d0aa419ce4eab8ff661429c9a3a32cd4978fdb8c6b5c6d047620f","sig_id_short":"TsEGZa0WPQqkGc5Oq4_2YUKcmjoyzUl4_bjG","kid":"0101f3b2f0e8c9d1f099db64cac366c6a9c1da63da624127b2f66a056acfa36834fe0a","sig":"-----BEGIN PGP MESSAGE-----\nVersion: Keybase OpenPGP v2.0.49\nComment: https://keybase.io/crypto\n\nyMWEAnictVZriF3VFZ7xVR1aDCqV0CbqqaDFG7vfj9FENJChFsUKWszD69p7rz1z\nk8ncm3vPZBxMQCytQjQEtQXBX42gJUgQ9U+1Jo2hVeID3wqKggoqiIiUtkLVtW+u\nyUxmwArpj8M97LPv2t/6vrW+vQ7+6MShkeEb7zjnd3fEcTt86NmvpoeuxzfOu6UK\n7TRbjd5SxckWTtXlbQo2YzVabcLZAD28uNU+dwZDtb1RVsp3nEzYq5ubWol2Mc54\nlkFkhi76xDPzPgWjIkRpTDTgI09gJD1CcWFppzHAtIGYQRonVUYGVaPKralx7Ha6\nrQKiAue8dhZ5RBuSxRRQIgaH2eXksg2SRwUi0x8n2r16Htyqj7TZh7fI/uOMe7of\nzosggySUSlumfRYUNFuFDk3wivuysYfdAbV1F+JsM3eJ8cQLs2VhU+GWUmjFXnlr\npeZW7PZa7alqlKtGNQnEOS3GCSCiyprymisr3PzQzX7wEvQwAcGKrAhQSmiU8KiT\ndYxRXsii7wMbyFo4my/CHLIE8yEJFFoLSY+PWZE81hoLyRlnk9OCMc0dpGiV9jox\n+q4Zimwh2MAYkUWYOuOdJh1EGa5b7ESVs2ZJO+YpPWEF8R64ik5wRtBFtDGzpJyb\nJyOi8YFrQ+k5zjxlrJVLHnyywlja7iWlC8pwlcEqGUs1QTQENhiTUkG2oVF1cXO7\nxman227nw/hi3dp8hGnhFGtUcbrbpWOpWqJTMULKznELCF4pLYyRDj2oyKSKnghJ\nybigQQpP2LPxyTsmPUuEHwfBvVbMuX7wThe3llpiPhsAowMjAqPWTmiu6SwlAQPP\nXliPKHgKXuuYs2QeqPAM1SA1DC9FOcilENzPp9/gExg3NRPU0NzYK1V1pNPrmVZd\nY/eYGoXY3tqeKj994UqYZj3boW+iUfVqqAt6+tLDLVPtalTTW2v8cNcZS12A3vKo\nA+XGSTXLLXWZswKcZEoQXuF0AOctuMxFihKpTShJdCyw0qcl2uC87Y0FYjh5RAyq\nORfRE+NJyCQMo7oTXvlSgRaJLlJJobXScO8KuTGgRWGTSTkoIxeKUYIPxDgOSn8/\nMcZb9cR0WKhFZ3K6V55jxZCLiWHmiBEyWgNCk3ExZciUiIlCEI8pceuQrI8JA+QR\nTlvqFG8jFyKAQgXUtvm7xfDFnwZiIOiAyC21pUXqV5dyslwJTvZB7ZZJWxCQlZXk\nqpF6NtPJSeooFSMwsECMfvCBGMdB6e8nBu1Y2BhHHXauDpy4YnwxMewcMVhUZEko\nBbWDDmSgAGRZ3GDwAI5rGXIGzY0MmllvqK6CTZpFUgKsVfw7xVBkxkfECDlJZQQI\n7iVZny/yZ8mRYquY6UKMhWNmHBNWJgzFw60DKoasY8j6GDE86wf/1qYAHe0zkUVD\n/evpjjCSgHtaY14oncvF58nNQYGMjMqCzDgEKjxFFNj/XYxywy8YSqo+/XU7tidp\nfaKuO73RxTRZTBE/RxEvEBHo6vY+Bs09pWmNjtzSIpmViOiCMyFApDmCRgO60ulC\nYZln8gKxiFdt6B/TrKE1WcB3YHayDak5Ab2J4yPJ/yeJ7WUM6acwmEYa1dH5g77N\nrzLryO/x5k6ri81W2aEtQe7TPSgPAmyNMeSPHBgNCHQ9SZc1GRF6lxwNS0w6IchM\nLWc2QPI8Z2rT5ERyKvmjiZLD1TBOISndKainu1htP7B//UlDwyNDp5x8Qhljh0ZO\nW/LtcHvjsz/4+jd3PvjW9b+c+Wu165rHX/z37/+w4qevrZr5hbj5oZ3m6i0zn709\n8vzaM+4be3THexufO/PzsRde+scPmxe8vORPo8s/vPhn+9/574p7bl9+w8lX7xz7\nci3fduDLu8ccDC9j7YevW7vi/aeePvE/ay7a9sm6Fz9fddnLl+45eOU/7ZZDa/bx\n19bA7jdXXfHzXR//Zf/eH7ceuOndjVvOXr2zXrbjzKVXfbB6RG5bsu+SB3cv3XvW\n5c+sfHfpXedf+/wrH+35+/1P7LhmaO/GJ9m9n35xq37zJ39++I0PP75t9SPPPXXP\nnuFTGvJVue+Zs/617PW/XX76JbuvHb7w16ctP9h97I+/XXn/Vzt/tf7Ahl3r3Ekr\nHzt0Q3P9OxPLmqeOPX3RVSPpG2YdtWQ=\n=h5Bq\n-----END PGP MESSAGE-----","payload_json":"{\"body\":{\"client\":{\"name\":\"keybase.io web\"},\"key\":{\"eldest_kid\":\"0101f3b2f0e8c9d1f099db64cac366c6a9c1da63da624127b2f66a056acfa36834fe0a\",\"fingerprint\":\"a889587e1ce7bd7edbe3eeb8ef8fd8f7b31c4a2f\",\"host\":\"keybase.io\",\"key_id\":\"ef8fd8f7b31c4a2f\",\"kid\":\"0101f3b2f0e8c9d1f099db64cac366c6a9c1da63da624127b2f66a056acfa36834fe0a\",\"uid\":\"92b3b3dbe457059f28c9f74e8e6b9419\",\"username\":\"tracy_friend1\"},\"track\":{\"basics\":{\"id_version\":14,\"last_id_change\":1449514728,\"username\":\"t_tracy\"},\"id\":\"eb72f49f2dde6429e5d78003dae0c919\",\"key\":{\"key_fingerprint\":\"\",\"kid\":\"01209bd2e255235529cf45877767ad8687d85200518adc74595d058750e2f7ab7b000a\"},\"pgp_keys\":[{\"key_fingerprint\":\"4ff50d580914427227bb14c821029e2c7cf0d488\",\"kid\":\"0101ee69b1566428109eb7548d9a9d7267d48933daa4614fa743cedbeac618ab66dd0a\"}],\"remote_proofs\":[{\"ctime\":1449512840,\"curr\":\"f09c84ccadf8817aea944526638e9a4c034c9200dd68b5a3292c7f69d980390d\",\"etime\":1954088840,\"prev\":\"909f6aa65b050ec5582515cad43aeb1f9279ee21db955cff309abe4692b7e11a\",\"remote_key_proof\":{\"check_data_json\":{\"name\":\"twitter\",\"username\":\"tacovontaco\"},\"proof_type\":2,\"state\":1},\"seqno\":5,\"sig_id\":\"67570e971c5b8881cf07179d1872a83042be4285ba897a8f12dc3e419cade80b0f\",\"sig_type\":2},{\"ctime\":1449512883,\"curr\":\"8ad8ce94c9d23d260750294905877ef92adf4e7736198909fcbe7e27d6dfb463\",\"etime\":1954088883,\"prev\":\"f09c84ccadf8817aea944526638e9a4c034c9200dd68b5a3292c7f69d980390d\",\"remote_key_proof\":{\"check_data_json\":{\"name\":\"github\",\"username\":\"tacoplusplus\"},\"proof_type\":3,\"state\":1},\"seqno\":6,\"sig_id\":\"bfe76a25acf046f7477350291cdd178e1f0026a49f85733d97c122ba4e4a000f0f\",\"sig_type\":2},{\"ctime\":1449512914,\"curr\":\"ea5bee1701e7ec7c8dfd71421bd2ab6fb0fa2af473412c664fa49d35c34078ea\",\"etime\":1954088914,\"prev\":\"8ad8ce94c9d23d260750294905877ef92adf4e7736198909fcbe7e27d6dfb463\",\"remote_key_proof\":{\"check_data_json\":{\"name\":\"rooter\",\"username\":\"t_tracy\"},\"proof_type\":100001,\"state\":1},\"seqno\":7,\"sig_id\":\"0c467de321795b777aa10916eb9aa8153bffa5163b5079600db7d50ca00a77410f\",\"sig_type\":2},{\"ctime\":1449514687,\"curr\":\"bfd3462a2193fa7946f7f31e5074cfc4ac95400680273deb520078a6a4f5cbf5\",\"etime\":1954090687,\"prev\":\"9ae84f56c0c62dc91206363b9f5609245f94199d58a4a3c0bee7d4bb91c47de7\",\"remote_key_proof\":{\"check_data_json\":{\"hostname\":\"keybase.io\",\"protocol\":\"https:\"},\"proof_type\":1000,\"state\":1},\"seqno\":9,\"sig_id\":\"92eeea3db99cb519409765c17ea32a82ce8b86bbacd8f366e8e8930f1faea20b0f\",\"sig_type\":2}],\"seq_tail\":{\"payload_hash\":\"bfd3462a2193fa7946f7f31e5074cfc4ac95400680273deb520078a6a4f5cbf5\",\"seqno\":9,\"sig_id\":\"92eeea3db99cb519409765c17ea32a82ce8b86bbacd8f366e8e8930f1faea20b0f\"}},\"type\":\"track\",\"version\":1},\"ctime\":1449514785,\"expire_in\":157680000,\"prev\":\"a4f76660341a087d69238f5a25e98d8b3d038224457107bad91ffdfbd82d84d9\",\"seqno\":3,\"tag\":\"signature\"}","sig_type":3,"ctime":1449514785,"etime":1607194785,"rtime":null,"sig_status":0,"prev":"a4f76660341a087d69238f5a25e98d8b3d038224457107bad91ffdfbd82d84d9","proof_id":null,"proof_type":null,"proof_text_check":null,"proof_text_full":null,"check_data_json":null,"remote_id":null,"api_url":null,"human_url":null,"proof_state":null,"proof_status":null,"retry_count":null,"hard_fail_count":null,"last_check":null,"last_success":null,"version":null,"fingerprint":"a889587e1ce7bd7edbe3eeb8ef8fd8f7b31c4a2f"}`
-
-var trackingStatementPayload = `{
-  "body": {
-    "client": {
-      "name": "keybase.io web"
-    },
-    "key": {
-      "eldest_kid": "0101f3b2f0e8c9d1f099db64cac366c6a9c1da63da624127b2f66a056acfa36834fe0a",
-      "fingerprint": "a889587e1ce7bd7edbe3eeb8ef8fd8f7b31c4a2f",
-      "host": "keybase.io",
-      "key_id": "ef8fd8f7b31c4a2f",
-      "kid": "0101f3b2f0e8c9d1f099db64cac366c6a9c1da63da624127b2f66a056acfa36834fe0a",
-      "uid": "92b3b3dbe457059f28c9f74e8e6b9419",
-      "username": "tracy_friend1"
-    },
-    "track": {
-      "basics": {
-        "id_version": 14,
-        "last_id_change": 1449514728,
-        "username": "t_tracy"
-      },
-      "id": "eb72f49f2dde6429e5d78003dae0c919",
-      "key": {
-        "key_fingerprint": "",
-        "kid": "01209bd2e255235529cf45877767ad8687d85200518adc74595d058750e2f7ab7b000a"
-      },
-      "pgp_keys": [
-        {
-          "key_fingerprint": "4ff50d580914427227bb14c821029e2c7cf0d488",
-          "kid": "0101ee69b1566428109eb7548d9a9d7267d48933daa4614fa743cedbeac618ab66dd0a"
-        }
-      ],
-      "remote_proofs": [
-        {
-          "ctime": 1449512840,
-          "curr": "f09c84ccadf8817aea944526638e9a4c034c9200dd68b5a3292c7f69d980390d",
-          "etime": 1954088840,
-          "prev": "909f6aa65b050ec5582515cad43aeb1f9279ee21db955cff309abe4692b7e11a",
-          "remote_key_proof": {
-            "check_data_json": {
-              "name": "twitter",
-              "username": "tacovontaco"
-            },
-            "proof_type": 2,
-            "state": 1
-          },
-          "seqno": 5,
-          "sig_id": "67570e971c5b8881cf07179d1872a83042be4285ba897a8f12dc3e419cade80b0f",
-          "sig_type": 2
-        },
-        {
-          "ctime": 1449512883,
-          "curr": "8ad8ce94c9d23d260750294905877ef92adf4e7736198909fcbe7e27d6dfb463",
-          "etime": 1954088883,
-          "prev": "f09c84ccadf8817aea944526638e9a4c034c9200dd68b5a3292c7f69d980390d",
-          "remote_key_proof": {
-            "check_data_json": {
-              "name": "github",
-              "username": "tacoplusplus"
-            },
-            "proof_type": 3,
-            "state": 1
-          },
-          "seqno": 6,
-          "sig_id": "bfe76a25acf046f7477350291cdd178e1f0026a49f85733d97c122ba4e4a000f0f",
-          "sig_type": 2
-        },
-        {
-          "ctime": 1449512914,
-          "curr": "ea5bee1701e7ec7c8dfd71421bd2ab6fb0fa2af473412c664fa49d35c34078ea",
-          "etime": 1954088914,
-          "prev": "8ad8ce94c9d23d260750294905877ef92adf4e7736198909fcbe7e27d6dfb463",
-          "remote_key_proof": {
-            "check_data_json": {
-              "name": "rooter",
-              "username": "t_tracy"
-            },
-            "proof_type": 100001,
-            "state": 1
-          },
-          "seqno": 7,
-          "sig_id": "0c467de321795b777aa10916eb9aa8153bffa5163b5079600db7d50ca00a77410f",
-          "sig_type": 2
-        },
-        {
-          "ctime": 1449514687,
-          "curr": "bfd3462a2193fa7946f7f31e5074cfc4ac95400680273deb520078a6a4f5cbf5",
-          "etime": 1954090687,
-          "prev": "9ae84f56c0c62dc91206363b9f5609245f94199d58a4a3c0bee7d4bb91c47de7",
-          "remote_key_proof": {
-            "check_data_json": {
-              "hostname": "keybase.io",
-              "protocol": "https:"
-            },
-            "proof_type": 1000,
-            "state": 1
-          },
-          "seqno": 9,
-          "sig_id": "92eeea3db99cb519409765c17ea32a82ce8b86bbacd8f366e8e8930f1faea20b0f",
-          "sig_type": 2
-        }
-      ],
-      "seq_tail": {
-        "payload_hash": "bfd3462a2193fa7946f7f31e5074cfc4ac95400680273deb520078a6a4f5cbf5",
-        "seqno": 9,
-        "sig_id": "92eeea3db99cb519409765c17ea32a82ce8b86bbacd8f366e8e8930f1faea20b0f"
-      }
-    },
-    "type": "track",
-    "version": 1
-  },
-  "ctime": 1449514785,
-  "expire_in": 157680000,
-  "prev": "a4f76660341a087d69238f5a25e98d8b3d038224457107bad91ffdfbd82d84d9",
-  "seqno": 3,
-  "tag": "signature"
-}`

--- a/go/engine/track_token.go
+++ b/go/engine/track_token.go
@@ -25,7 +25,7 @@ type TrackToken struct {
 }
 
 type TrackTokenArg struct {
-	Token   libkb.IdentifyCacheToken
+	Token   keybase1.TrackToken
 	Me      *libkb.User
 	Options keybase1.TrackOptions
 }
@@ -70,7 +70,7 @@ func (e *TrackToken) Run(ctx *Context) error {
 		return err
 	}
 
-	outcome, err := e.G().IdentifyCache.Get(e.arg.Token)
+	outcome, err := e.G().TrackCache.Get(e.arg.Token)
 	if err != nil {
 		return err
 	}

--- a/go/libkb/assertion.go
+++ b/go/libkb/assertion.go
@@ -81,6 +81,16 @@ func (a AssertionAnd) MatchSet(ps ProofSet) bool {
 	return true
 }
 
+func (a AssertionAnd) HasFactor(pf Proof) bool {
+	ps := NewProofSet([]Proof{pf})
+	for _, f := range a.factors {
+		if f.MatchSet(*ps) {
+			return true
+		}
+	}
+	return false
+}
+
 func (a AssertionAnd) String() string {
 	v := make([]string, len(a.factors))
 	for i, f := range a.factors {

--- a/go/libkb/assertion.go
+++ b/go/libkb/assertion.go
@@ -52,6 +52,10 @@ type AssertionAnd struct {
 	factors []AssertionExpression
 }
 
+func (a AssertionAnd) Len() int {
+	return len(a.factors)
+}
+
 func (a AssertionAnd) HasOr() bool {
 	for _, f := range a.factors {
 		if f.HasOr() {
@@ -93,6 +97,7 @@ type AssertionURL interface {
 	IsUID() bool
 	ToUID() keybase1.UID
 	IsSocial() bool
+	IsRemote() bool
 	IsFingerprint() bool
 	MatchProof(p Proof) bool
 	ToKeyValuePair() (string, string)
@@ -146,6 +151,7 @@ func (a AssertionHTTP) Keys() []string               { return []string{"http", "
 func (b AssertionURLBase) Keys() []string            { return []string{b.Key} }
 func (b AssertionURLBase) IsKeybase() bool           { return false }
 func (b AssertionURLBase) IsSocial() bool            { return false }
+func (b AssertionURLBase) IsRemote() bool            { return false }
 func (b AssertionURLBase) IsFingerprint() bool       { return false }
 func (b AssertionURLBase) IsUID() bool               { return false }
 func (b AssertionURLBase) ToUID() (ret keybase1.UID) { return ret }
@@ -269,6 +275,8 @@ func parseToKVPair(s string) (key string, value string, err error) {
 
 func (a AssertionKeybase) IsKeybase() bool         { return true }
 func (a AssertionSocial) IsSocial() bool           { return true }
+func (a AssertionSocial) IsRemote() bool           { return true }
+func (a AssertionWeb) IsRemote() bool              { return true }
 func (a AssertionFingerprint) IsFingerprint() bool { return true }
 func (a AssertionUID) IsUID() bool                 { return true }
 
@@ -391,4 +399,48 @@ func RegisterSocialNetwork(s string) {
 		_socialNetworks = make(map[string]bool)
 	}
 	_socialNetworks[s] = true
+}
+
+func FindBestIdentifyComponent(e AssertionExpression) string {
+	urls := e.CollectUrls(nil)
+	if len(urls) == 0 {
+		return ""
+	}
+
+	var uid, kb, soc, fp AssertionURL
+
+	for _, u := range urls {
+		if u.IsUID() {
+			uid = u
+			break
+		}
+
+		if u.IsKeybase() {
+			kb = u
+		} else if u.IsFingerprint() && fp == nil {
+			fp = u
+		} else if u.IsSocial() && soc == nil {
+			soc = u
+		}
+	}
+
+	order := []AssertionURL{uid, kb, fp, soc, urls[0]}
+	for _, p := range order {
+		if p != nil {
+			return p.String()
+		}
+	}
+	return ""
+}
+
+func CollectAssertions(e AssertionExpression) (remotes AssertionAnd, locals AssertionAnd) {
+	urls := e.CollectUrls(nil)
+	for _, u := range urls {
+		if u.IsRemote() {
+			remotes.factors = append(remotes.factors, u)
+		} else {
+			locals.factors = append(locals.factors, u)
+		}
+	}
+	return remotes, locals
 }

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -198,7 +198,7 @@ func (f *JSONConfigFile) SwitchUser(nu NormalizedUsername) error {
 	}
 
 	if f.jw.AtKey("users").AtKey(nu.String()).IsNil() {
-		return UserNotFoundError{msg: nu.String()}
+		return UserNotFoundError{Msg: nu.String()}
 	}
 
 	f.jw.SetKey("current_user", jsonw.NewString(nu.String()))

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -66,12 +66,12 @@ const (
 	UserCacheMaxAge      = 5 * time.Minute
 	PGPFingerprintHexLen = 40
 
-	ProofCacheSize            = 0x1000
-	ProofCacheLongDur         = 6 * time.Hour
-	ProofCacheMediumDur       = 30 * time.Minute
-	ProofCacheShortDur        = 1 * time.Minute
-	IdentifyCacheLongTimeout  = 6 * time.Hour
-	IdentifyCacheShortTimeout = 1 * time.Minute
+	ProofCacheSize             = 0x1000
+	ProofCacheLongDur          = 6 * time.Hour
+	ProofCacheMediumDur        = 30 * time.Minute
+	ProofCacheShortDur         = 1 * time.Minute
+	Identify2CacheLongTimeout  = 6 * time.Hour
+	Identify2CacheShortTimeout = 1 * time.Minute
 
 	SigShortIDBytes = 27
 )

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -66,10 +66,12 @@ const (
 	UserCacheMaxAge      = 5 * time.Minute
 	PGPFingerprintHexLen = 40
 
-	ProofCacheSize      = 0x1000
-	ProofCacheLongDur   = 6 * time.Hour
-	ProofCacheMediumDur = 30 * time.Minute
-	ProofCacheShortDur  = 1 * time.Minute
+	ProofCacheSize            = 0x1000
+	ProofCacheLongDur         = 6 * time.Hour
+	ProofCacheMediumDur       = 30 * time.Minute
+	ProofCacheShortDur        = 1 * time.Minute
+	IdentifyCacheLongTimeout  = 6 * time.Hour
+	IdentifyCacheShortTimeout = 1 * time.Minute
 
 	SigShortIDBytes = 27
 )
@@ -109,6 +111,7 @@ const (
 	SCCanceled               = 237
 	SCReloginRequired        = 274
 	SCBadSignupUsernameTaken = 701
+	SCMissingResult          = 801
 	SCKeyNotFound            = 901
 	SCKeyInUse               = 907
 	SCKeyBadGen              = 913

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -180,12 +180,12 @@ func (e UnexpectedKeyError) Error() string {
 //=============================================================================
 
 type UserNotFoundError struct {
-	uid keybase1.UID
-	msg string
+	UID keybase1.UID
+	Msg string
 }
 
 func (u UserNotFoundError) Error() string {
-	return fmt.Sprintf("User %s wasn't found (%s)", u.uid, u.msg)
+	return fmt.Sprintf("User %s wasn't found (%s)", u.UID, u.Msg)
 }
 
 //=============================================================================

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -23,7 +23,7 @@ type ProofError interface {
 
 func ProofErrorIsSoft(pe ProofError) bool {
 	s := pe.GetProofStatus()
-	return s >= keybase1.ProofStatus_BASE_ERROR && s < keybase1.ProofStatus_BASE_HARD_ERROR
+	return (s >= keybase1.ProofStatus_BASE_ERROR && s < keybase1.ProofStatus_BASE_HARD_ERROR)
 }
 
 func ProofErrorToState(pe ProofError) keybase1.ProofState {
@@ -766,6 +766,8 @@ func (e ProofNotFoundForUsernameError) Error() string {
 
 //=============================================================================
 
+//=============================================================================
+
 type KeyGenError struct {
 	Msg string
 }
@@ -1106,6 +1108,14 @@ func (e IdentifyTimeoutError) Error() string {
 
 //=============================================================================
 
+type IdentifyDidNotCompleteError struct{}
+
+func (e IdentifyDidNotCompleteError) Error() string {
+	return "Identification did not complete."
+}
+
+//=============================================================================
+
 type NotLatestSubchainError struct {
 	Msg string
 }
@@ -1181,4 +1191,19 @@ type UIDelegationUnavailableError struct{}
 
 func (e UIDelegationUnavailableError) Error() string {
 	return "This process does not support UI delegation"
+}
+
+//=============================================================================
+
+type UnmetAssertionError struct {
+	User   string
+	Remote bool
+}
+
+func (e UnmetAssertionError) Error() string {
+	which := "local"
+	if e.Remote {
+		which = "remote"
+	}
+	return fmt.Sprintf("Unmet %s assertions for user %q", which, e.User)
 }

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -68,7 +68,7 @@ type GlobalContext struct {
 
 func NewGlobalContext() *GlobalContext {
 	return &GlobalContext{
-		Log: logger.New("keybase", ErrorWriter()),
+		Log:                 logger.New("keybase", ErrorWriter()),
 		ProofCheckerFactory: defaultProofCheckerFactory,
 	}
 }

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -30,35 +30,33 @@ import (
 type ShutdownHook func() error
 
 type GlobalContext struct {
-	UIRouter UIRouter
-	ExitCode keybase1.ExitCode // Value to return to OS on Exit()
-	Log                 logger.Logger  // Handles all logging
-	Env                 *Env           // Env variables, cmdline args & config
-	Keyrings            *Keyrings      // Gpg Keychains holding keys
-	API                 API            // How to make a REST call to the server
-	ResolveCache        *ResolveCache  // cache of resolve results
-	LocalDb             *JSONLocalDb   // Local DB for cache
-	MerkleClient        *MerkleClient  // client for querying server's merkle sig tree
-	XAPI                ExternalAPI    // for contacting Twitter, Github, etc.
-	Output              io.Writer      // where 'Stdout'-style output goes
-	ProofCache          *ProofCache    // where to cache proof results
-	GpgClient           *GpgCLI        // A standard GPG-client (optional)
-	ShutdownHooks       []ShutdownHook // on shutdown, fire these...
-	SocketInfo          Socket         // which socket to bind/connect to
-	socketWrapperMu     sync.RWMutex
-	SocketWrapper       *SocketWrapper      // only need one connection per
-	LoopbackListener    *LoopbackListener   // If we're in loopback mode, we'll connect through here
-	XStreams            *ExportedStreams    // a table of streams we've exported to the daemon (or vice-versa)
-	Timers              *TimerSet           // Which timers are currently configured on
-	TrackCache          *TrackCache         // cache of IdentifyOutcomes for tracking purposes
-	Identify2Cache      Identify2Cacher     // cache of Identify2 results for fast-pathing identify2 RPCS
-	UI                  UI                  // Interact with the UI
-	Service             bool                // whether we're in server mode
-	shutdownOnce        sync.Once           // whether we've shut down or not
-	loginStateMu        sync.RWMutex        // protects loginState pointer, which gets destroyed on logout
-	loginState          *LoginState         // What phase of login the user's in
-	ConnectionManager   *ConnectionManager  // keep tabs on all active client connections
-	NotifyRouter        *NotifyRouter       // How to route notifications
+	Log               logger.Logger  // Handles all logging
+	Env               *Env           // Env variables, cmdline args & config
+	Keyrings          *Keyrings      // Gpg Keychains holding keys
+	API               API            // How to make a REST call to the server
+	ResolveCache      *ResolveCache  // cache of resolve results
+	LocalDb           *JSONLocalDb   // Local DB for cache
+	MerkleClient      *MerkleClient  // client for querying server's merkle sig tree
+	XAPI              ExternalAPI    // for contacting Twitter, Github, etc.
+	Output            io.Writer      // where 'Stdout'-style output goes
+	ProofCache        *ProofCache    // where to cache proof results
+	GpgClient         *GpgCLI        // A standard GPG-client (optional)
+	ShutdownHooks     []ShutdownHook // on shutdown, fire these...
+	SocketInfo        Socket         // which socket to bind/connect to
+	socketWrapperMu   sync.RWMutex
+	SocketWrapper     *SocketWrapper     // only need one connection per
+	LoopbackListener  *LoopbackListener  // If we're in loopback mode, we'll connect through here
+	XStreams          *ExportedStreams   // a table of streams we've exported to the daemon (or vice-versa)
+	Timers            *TimerSet          // Which timers are currently configured on
+	TrackCache        *TrackCache        // cache of IdentifyOutcomes for tracking purposes
+	Identify2Cache    Identify2Cacher    // cache of Identify2 results for fast-pathing identify2 RPCS
+	UI                UI                 // Interact with the UI
+	Service           bool               // whether we're in server mode
+	shutdownOnce      sync.Once          // whether we've shut down or not
+	loginStateMu      sync.RWMutex       // protects loginState pointer, which gets destroyed on logout
+	loginState        *LoginState        // What phase of login the user's in
+	ConnectionManager *ConnectionManager // keep tabs on all active client connections
+	NotifyRouter      *NotifyRouter      // How to route notifications
 	// How to route UIs. Nil if we're in standalone mode or in
 	// tests, and non-nil in service mode.
 	UIRouter            UIRouter            // How to route UIs

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1215,7 +1215,10 @@ func (idt *IdentityTable) proofRemoteCheck(hasPreviousTrack, forceRemoteCheck bo
 	}
 
 	var pc ProofChecker
-	pc, res.err = NewProofChecker(p)
+
+	// Call the Global context's version of what a proof checker is. We might want to stub it out
+	// for the purposes of testing.
+	pc, res.err = idt.G().NewProofChecker(p)
 
 	if res.err != nil {
 		return

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1118,8 +1118,7 @@ func (idt *IdentityTable) Len() int {
 }
 
 type CheckCompletedListener interface {
-	CheckCompleted(lcr *LinkCheckResult)
-	Done()
+	CCLCheckCompleted(lcr *LinkCheckResult)
 }
 
 func (idt *IdentityTable) Identify(is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener) {
@@ -1138,9 +1137,6 @@ func (idt *IdentityTable) Identify(is IdentifyState, forceRemoteCheck bool, ui I
 
 	// wait for all goroutines to complete before exiting
 	wg.Wait()
-	if ccl != nil {
-		ccl.Done()
-	}
 }
 
 //=========================================================================
@@ -1148,7 +1144,7 @@ func (idt *IdentityTable) Identify(is IdentifyState, forceRemoteCheck bool, ui I
 func (idt *IdentityTable) identifyActiveProof(lcr *LinkCheckResult, is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener) {
 	idt.proofRemoteCheck(is.HasPreviousTrack(), forceRemoteCheck, lcr)
 	if ccl != nil {
-		ccl.CheckCompleted(lcr)
+		ccl.CCLCheckCompleted(lcr)
 	}
 	lcr.link.DisplayCheck(ui, *lcr)
 }

--- a/go/libkb/identify2_cache.go
+++ b/go/libkb/identify2_cache.go
@@ -71,9 +71,6 @@ func (c *Identify2Cache) Insert(up *keybase1.UserPlusKeys) error {
 	tmp := *up
 	copy := &tmp
 	copy.Uvv.CachedAt = keybase1.Time(time.Now().Unix())
-
-	// TODO: Don't overwrite an existing entry that's just as fresh
-	// as the current entry, and that does have a `LastIdentifiedAt` time
 	return c.cache.Set(string(up.Uid), copy)
 }
 

--- a/go/libkb/identify2_cache.go
+++ b/go/libkb/identify2_cache.go
@@ -57,7 +57,7 @@ func (c *Identify2Cache) Get(uid keybase1.UID, gctf GetCheckTimeFunc, timeout ti
 			return nil, TimeoutError{}
 		}
 
-		thenTime := time.Unix(int64(then), 0)
+		thenTime := keybase1.FromTime(then)
 		if time.Now().Sub(thenTime) > timeout {
 			return nil, TimeoutError{}
 		}

--- a/go/libkb/identify_outcome.go
+++ b/go/libkb/identify_outcome.go
@@ -21,15 +21,12 @@ type IdentifyOutcome struct {
 	Warnings     []Warning
 	TrackUsed    *TrackLookup
 	TrackEqual   bool // Whether the track statement was equal to what we saw
-	MeSet        bool // whether me was set at the time
 	TrackOptions keybase1.TrackOptions
 	Reason       keybase1.IdentifyReason
 }
 
-func NewIdentifyOutcome(m bool) *IdentifyOutcome {
-	return &IdentifyOutcome{
-		MeSet: m,
-	}
+func NewIdentifyOutcome() *IdentifyOutcome {
+	return &IdentifyOutcome{}
 }
 
 func (i *IdentifyOutcome) remoteProofLinks() *RemoteProofLinks {
@@ -44,8 +41,8 @@ func (i *IdentifyOutcome) ActiveProofs() []RemoteProofChainLink {
 	return i.remoteProofLinks().Active()
 }
 
-func (i *IdentifyOutcome) AddProofsToSet(existing *ProofSet) {
-	i.remoteProofLinks().AddProofsToSet(existing)
+func (i *IdentifyOutcome) AddProofsToSet(existing *ProofSet, okStates []keybase1.ProofState) {
+	i.remoteProofLinks().AddProofsToSet(existing, okStates)
 }
 
 func (i *IdentifyOutcome) TrackSet() *TrackSet {
@@ -160,6 +157,21 @@ func (i IdentifyOutcome) TrackStatus() keybase1.TrackStatus {
 		return keybase1.TrackStatus_NEW_FAIL_PROOFS
 	}
 	return keybase1.TrackStatus_NEW_OK
+}
+
+func (i IdentifyOutcome) IsOK() bool {
+	switch i.TrackStatus() {
+	case keybase1.TrackStatus_UPDATE_NEW_PROOFS:
+		return true
+	case keybase1.TrackStatus_UPDATE_OK:
+		return true
+	case keybase1.TrackStatus_NEW_ZERO_PROOFS:
+		return true
+	case keybase1.TrackStatus_NEW_OK:
+		return true
+	default:
+		return false
+	}
 }
 
 func (i IdentifyOutcome) TrackingStatement() *jsonw.Wrapper {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -243,7 +243,7 @@ type IdentifyUI interface {
 	LaunchNetworkChecks(*keybase1.Identity, *keybase1.User)
 	DisplayTrackStatement(string) error
 	DisplayUserCard(keybase1.UserCard)
-	ReportTrackToken(IdentifyCacheToken) error
+	ReportTrackToken(keybase1.TrackToken) error
 	SetStrict(b bool)
 	Finish()
 }

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -322,19 +322,6 @@ func LoadUserPlusKeys(g *GlobalContext, uid keybase1.UID, cacheOK bool) (keybase
 		return up, fmt.Errorf("Nil UID")
 	}
 
-	if cacheOK {
-		up, err := g.UserCache.Get(uid)
-		if err == nil {
-			return *up, nil
-		}
-		if err != nil {
-			// not going to bail on cache error, just log it:
-			if _, ok := err.(NotFoundError); !ok {
-				g.Log.Debug("UserCache Get error: %s", err)
-			}
-		}
-	}
-
 	arg := NewLoadUserArg(g)
 	arg.UID = uid
 	arg.PublicKeyOptional = true
@@ -351,11 +338,6 @@ func LoadUserPlusKeys(g *GlobalContext, uid keybase1.UID, cacheOK bool) (keybase
 	up.Username = u.GetNormalizedName().String()
 	if u.GetComputedKeyFamily() != nil {
 		up.DeviceKeys = u.GetComputedKeyFamily().ExportDeviceKeys()
-	}
-
-	err = g.UserCache.Insert(&up)
-	if err != nil {
-		g.Log.Debug("UserCache Set error: %s", err)
 	}
 
 	return up, nil

--- a/go/libkb/locktab.go
+++ b/go/libkb/locktab.go
@@ -22,8 +22,8 @@ func (l *NamedLock) decref() {
 	l.refs--
 }
 
-func (l *NamedLock) Unlock() {
-	G.Log.Debug("+ LockTable.Unlock(%s)", l.name)
+func (l *NamedLock) Release() {
+	G.Log.Debug("+ LockTable.Release(%s)", l.name)
 	l.Unlock()
 	l.parent.Lock()
 	l.decref()
@@ -46,7 +46,7 @@ func (t *LockTable) init() {
 	}
 }
 
-func (t *LockTable) LockOnName(s string) (ret *NamedLock) {
+func (t *LockTable) AcquireOnName(s string) (ret *NamedLock) {
 	G.Log.Debug("+ LockTable.Lock(%s)", s)
 	t.Lock()
 	t.init()

--- a/go/libkb/proof_support_coinbase.go
+++ b/go/libkb/proof_support_coinbase.go
@@ -119,7 +119,7 @@ func (t CoinbaseServiceType) CheckProofText(text string, id keybase1.SigID, sig 
 func init() {
 	RegisterServiceType(CoinbaseServiceType{})
 	RegisterSocialNetwork("coinbase")
-	RegisterProofCheckHook("coinbase",
+	RegisterMakeProofCheckerFunc("coinbase",
 		func(l RemoteProofChainLink) (ProofChecker, ProofError) {
 			return NewCoinbaseChecker(l)
 		})

--- a/go/libkb/proof_support_dns.go
+++ b/go/libkb/proof_support_dns.go
@@ -155,7 +155,7 @@ func (t DNSServiceType) LastWriterWins() bool { return false }
 func init() {
 	RegisterServiceType(DNSServiceType{})
 	RegisterSocialNetwork("dns")
-	RegisterProofCheckHook("dns",
+	RegisterMakeProofCheckerFunc("dns",
 		func(l RemoteProofChainLink) (ProofChecker, ProofError) {
 			return NewDNSChecker(l)
 		})

--- a/go/libkb/proof_support_github.go
+++ b/go/libkb/proof_support_github.go
@@ -116,7 +116,7 @@ func (t GithubServiceType) CheckProofText(text string, id keybase1.SigID, sig st
 func init() {
 	RegisterServiceType(GithubServiceType{})
 	RegisterSocialNetwork("github")
-	RegisterProofCheckHook("github",
+	RegisterMakeProofCheckerFunc("github",
 		func(l RemoteProofChainLink) (ProofChecker, ProofError) {
 			return NewGithubChecker(l)
 		})

--- a/go/libkb/proof_support_hackernews.go
+++ b/go/libkb/proof_support_hackernews.go
@@ -167,7 +167,7 @@ func (t HackerNewsServiceType) PreProofCheck(un string) (markup *Markup, err err
 func init() {
 	RegisterServiceType(HackerNewsServiceType{})
 	RegisterSocialNetwork("hackernews")
-	RegisterProofCheckHook("hackernews",
+	RegisterMakeProofCheckerFunc("hackernews",
 		func(l RemoteProofChainLink) (ProofChecker, ProofError) {
 			return NewHackerNewsChecker(l)
 		})

--- a/go/libkb/proof_support_reddit.go
+++ b/go/libkb/proof_support_reddit.go
@@ -212,7 +212,7 @@ func (t RedditServiceType) CheckProofText(text string, id keybase1.SigID, sig st
 func init() {
 	RegisterServiceType(RedditServiceType{})
 	RegisterSocialNetwork("reddit")
-	RegisterProofCheckHook("reddit",
+	RegisterMakeProofCheckerFunc("reddit",
 		func(l RemoteProofChainLink) (ProofChecker, ProofError) {
 			return NewRedditChecker(l)
 		})

--- a/go/libkb/proof_support_rooter.go
+++ b/go/libkb/proof_support_rooter.go
@@ -207,7 +207,7 @@ func (t RooterServiceType) CheckProofText(text string, id keybase1.SigID, sig st
 func init() {
 	RegisterServiceType(RooterServiceType{})
 	RegisterSocialNetwork("rooter")
-	RegisterProofCheckHook("rooter",
+	RegisterMakeProofCheckerFunc("rooter",
 		func(l RemoteProofChainLink) (ProofChecker, ProofError) {
 			return NewRooterChecker(l)
 		})

--- a/go/libkb/proof_support_twitter.go
+++ b/go/libkb/proof_support_twitter.go
@@ -170,7 +170,7 @@ func (t TwitterServiceType) CheckProofText(text string, id keybase1.SigID, sig s
 func init() {
 	RegisterServiceType(TwitterServiceType{})
 	RegisterSocialNetwork("twitter")
-	RegisterProofCheckHook("twitter",
+	RegisterMakeProofCheckerFunc("twitter",
 		func(l RemoteProofChainLink) (ProofChecker, ProofError) {
 			return NewTwitterChecker(l)
 		})

--- a/go/libkb/proof_support_web.go
+++ b/go/libkb/proof_support_web.go
@@ -211,7 +211,7 @@ func (t WebServiceType) LastWriterWins() bool { return false }
 func init() {
 	RegisterServiceType(WebServiceType{})
 	RegisterSocialNetwork("web")
-	RegisterProofCheckHook("http",
+	RegisterMakeProofCheckerFunc("http",
 		func(l RemoteProofChainLink) (ProofChecker, ProofError) {
 			return NewWebChecker(l)
 		})

--- a/go/libkb/remote_proof_links.go
+++ b/go/libkb/remote_proof_links.go
@@ -128,9 +128,13 @@ func (r *RemoteProofLinks) AddProofsToSet(existing *ProofSet, okStates []keybase
 	}
 }
 
-func AddToProofSetNoChecks(r RemoteProofChainLink, ps *ProofSet) {
+func RemoteProofChainLinkToProof(r RemoteProofChainLink) Proof {
 	k, v := r.ToKeyValuePair()
-	ps.Add(Proof{Key: k, Value: v})
+	return Proof{Key: k, Value: v}
+}
+
+func AddToProofSetNoChecks(r RemoteProofChainLink, ps *ProofSet) {
+	ps.Add(RemoteProofChainLinkToProof(r))
 }
 
 func (r *RemoteProofLinks) active() []ProofLinkWithState {

--- a/go/libkb/track_cache.go
+++ b/go/libkb/track_cache.go
@@ -8,15 +8,16 @@ import (
 	"fmt"
 	"time"
 
+	keybase1 "github.com/keybase/client/go/protocol"
 	"stathat.com/c/ramcache"
 )
 
-type IdentifyCache struct {
+type TrackCache struct {
 	cache *ramcache.Ramcache
 }
 
-func NewIdentifyCache() *IdentifyCache {
-	res := &IdentifyCache{
+func NewTrackCache() *TrackCache {
+	res := &TrackCache{
 		cache: ramcache.New(),
 	}
 	res.cache.TTL = 10 * time.Minute
@@ -24,7 +25,7 @@ func NewIdentifyCache() *IdentifyCache {
 	return res
 }
 
-func (c *IdentifyCache) Get(key IdentifyCacheToken) (*IdentifyOutcome, error) {
+func (c *TrackCache) Get(key keybase1.TrackToken) (*IdentifyOutcome, error) {
 	v, err := c.cache.Get(string(key))
 	if err != nil {
 		if err == ramcache.ErrNotFound {
@@ -39,7 +40,7 @@ func (c *IdentifyCache) Get(key IdentifyCacheToken) (*IdentifyOutcome, error) {
 	return outcome, nil
 }
 
-func (c *IdentifyCache) Insert(outcome *IdentifyOutcome) (IdentifyCacheToken, error) {
+func (c *TrackCache) Insert(outcome *IdentifyOutcome) (keybase1.TrackToken, error) {
 	rb, err := RandBytes(16)
 	if err != nil {
 		return "", err
@@ -48,23 +49,13 @@ func (c *IdentifyCache) Insert(outcome *IdentifyOutcome) (IdentifyCacheToken, er
 	if err := c.cache.Set(key, outcome); err != nil {
 		return "", err
 	}
-	return IdentifyCacheToken(key), nil
+	return keybase1.TrackToken(key), nil
 }
 
-func (c *IdentifyCache) Delete(key IdentifyCacheToken) error {
+func (c *TrackCache) Delete(key keybase1.TrackToken) error {
 	return c.cache.Delete(string(key))
 }
 
-func (c *IdentifyCache) Shutdown() {
+func (c *TrackCache) Shutdown() {
 	c.cache.Shutdown()
-}
-
-type IdentifyCacheToken string
-
-func (t IdentifyCacheToken) Export() string {
-	return string(t)
-}
-
-func ImportIdentifyCacheToken(t string) IdentifyCacheToken {
-	return IdentifyCacheToken(t)
 }

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -5,11 +5,9 @@ package libkb
 
 import (
 	"fmt"
-	"io"
-	"time"
-
 	keybase1 "github.com/keybase/client/go/protocol"
 	jsonw "github.com/keybase/go-jsonw"
+	"io"
 )
 
 type UserBasic interface {
@@ -679,14 +677,6 @@ func (u *User) IsCachedIdentifyFresh(upk *keybase1.UserPlusKeys) bool {
 	}
 	scv := u.GetSigChainLastKnownSeqno()
 	if upk.Uvv.SigChain == 0 || int64(scv) != upk.Uvv.SigChain {
-		return false
-	}
-	then := upk.Uvv.LastIdentifiedAt
-	if then == 0 {
-		return false
-	}
-	thenTime := time.Unix(int64(then), 0)
-	if time.Now().Sub(thenTime) > IdentifyCacheLongTimeout {
 		return false
 	}
 	return true

--- a/go/libkb/user_cache.go
+++ b/go/libkb/user_cache.go
@@ -49,7 +49,13 @@ func (c *UserCache) Get(uid keybase1.UID) (*keybase1.UserPlusKeys, error) {
 
 // Insert adds a user to the cache, keyed on UID.
 func (c *UserCache) Insert(up *keybase1.UserPlusKeys) error {
-	return c.cache.Set(string(up.Uid), up)
+	tmp := *up
+	copy := &tmp
+	copy.Uvv.CachedAt = keybase1.Time(time.Now().Unix())
+
+	// TODO: Don't overwrite an existing entry that's just as fresh
+	// as the current entry, and that does have a `LastIdentifiedAt` time
+	return c.cache.Set(string(up.Uid), copy)
 }
 
 // Shutdown stops any goroutines in the cache.

--- a/go/protocol/extras.go
+++ b/go/protocol/extras.go
@@ -434,3 +434,7 @@ func (f Folder) ToString() string {
 	}
 	return prefix + f.Name
 }
+
+func (t TrackToken) String() string {
+	return string(t)
+}

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -1470,7 +1470,7 @@ type IdentifyArg struct {
 	Source           IdentifySource `codec:"source" json:"source"`
 }
 
-type Identify2Arg struct {
+type Identify2WithUIDArg struct {
 	SessionID     int            `codec:"sessionID" json:"sessionID"`
 	Uid           UID            `codec:"uid" json:"uid"`
 	UserAssertion string         `codec:"userAssertion" json:"userAssertion"`
@@ -1480,7 +1480,7 @@ type Identify2Arg struct {
 
 type IdentifyInterface interface {
 	Identify(context.Context, IdentifyArg) (IdentifyRes, error)
-	Identify2(context.Context, Identify2Arg) (Identify2Res, error)
+	Identify2WithUID(context.Context, Identify2WithUIDArg) (Identify2Res, error)
 }
 
 func IdentifyProtocol(i IdentifyInterface) rpc.Protocol {
@@ -1503,18 +1503,18 @@ func IdentifyProtocol(i IdentifyInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"identify2": {
+			"identify2WithUID": {
 				MakeArg: func() interface{} {
-					ret := make([]Identify2Arg, 1)
+					ret := make([]Identify2WithUIDArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]Identify2Arg)
+					typedArgs, ok := args.(*[]Identify2WithUIDArg)
 					if !ok {
-						err = rpc.NewTypeError((*[]Identify2Arg)(nil), args)
+						err = rpc.NewTypeError((*[]Identify2WithUIDArg)(nil), args)
 						return
 					}
-					ret, err = i.Identify2(ctx, (*typedArgs)[0])
+					ret, err = i.Identify2WithUID(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -1532,8 +1532,8 @@ func (c IdentifyClient) Identify(ctx context.Context, __arg IdentifyArg) (res Id
 	return
 }
 
-func (c IdentifyClient) Identify2(ctx context.Context, __arg Identify2Arg) (res Identify2Res, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.identify.identify2", []interface{}{__arg}, &res)
+func (c IdentifyClient) Identify2WithUID(ctx context.Context, __arg Identify2WithUIDArg) (res Identify2Res, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.identify.identify2WithUID", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -1369,6 +1369,7 @@ const (
 	ProofType_ROOTER           ProofType = 100001
 )
 
+type TrackToken string
 type TrackDiffType int
 
 const (
@@ -1436,7 +1437,7 @@ type IdentifyRes struct {
 	User       *User           `codec:"user,omitempty" json:"user,omitempty"`
 	PublicKeys []PublicKey     `codec:"publicKeys" json:"publicKeys"`
 	Outcome    IdentifyOutcome `codec:"outcome" json:"outcome"`
-	TrackToken string          `codec:"trackToken" json:"trackToken"`
+	TrackToken TrackToken      `codec:"trackToken" json:"trackToken"`
 }
 
 type RemoteProof struct {
@@ -1448,7 +1449,6 @@ type RemoteProof struct {
 	MTime         Time      `codec:"mTime" json:"mTime"`
 }
 
-type TrackToken string
 type IdentifySource int
 
 const (
@@ -1644,8 +1644,8 @@ type DisplayCryptocurrencyArg struct {
 }
 
 type ReportTrackTokenArg struct {
-	SessionID  int    `codec:"sessionID" json:"sessionID"`
-	TrackToken string `codec:"trackToken" json:"trackToken"`
+	SessionID  int        `codec:"sessionID" json:"sessionID"`
+	TrackToken TrackToken `codec:"trackToken" json:"trackToken"`
 }
 
 type ConfirmArg struct {
@@ -5011,7 +5011,7 @@ type TrackArg struct {
 
 type TrackWithTokenArg struct {
 	SessionID  int          `codec:"sessionID" json:"sessionID"`
-	TrackToken string       `codec:"trackToken" json:"trackToken"`
+	TrackToken TrackToken   `codec:"trackToken" json:"trackToken"`
 	Options    TrackOptions `codec:"options" json:"options"`
 }
 

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -198,8 +198,8 @@ func (u *RemoteIdentifyUI) DisplayTrackStatement(s string) error {
 	return u.uicli.DisplayTrackStatement(context.TODO(), keybase1.DisplayTrackStatementArg{Stmt: s, SessionID: u.sessionID})
 }
 
-func (u *RemoteIdentifyUI) ReportTrackToken(token libkb.IdentifyCacheToken) error {
-	return u.uicli.ReportTrackToken(context.TODO(), keybase1.ReportTrackTokenArg{TrackToken: string(token), SessionID: u.sessionID})
+func (u *RemoteIdentifyUI) ReportTrackToken(token keybase1.TrackToken) error {
+	return u.uicli.ReportTrackToken(context.TODO(), keybase1.ReportTrackTokenArg{TrackToken: token, SessionID: u.sessionID})
 }
 
 func (u *RemoteIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) {

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -46,6 +46,10 @@ func NewIdentifyHandler(xp rpc.Transporter, g *libkb.GlobalContext) *IdentifyHan
 	}
 }
 
+func (h *IdentifyHandler) Identify2(_ context.Context, arg keybase1.Identify2Arg) (res keybase1.Identify2Res, err error) {
+	return res, nil
+}
+
 func (h *IdentifyHandler) Identify(_ context.Context, arg keybase1.IdentifyArg) (keybase1.IdentifyRes, error) {
 	var do = func() (interface{}, error) {
 		if arg.Source == keybase1.IdentifySource_KBFS {

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -46,7 +46,7 @@ func NewIdentifyHandler(xp rpc.Transporter, g *libkb.GlobalContext) *IdentifyHan
 	}
 }
 
-func (h *IdentifyHandler) Identify2(_ context.Context, arg keybase1.Identify2Arg) (res keybase1.Identify2Res, err error) {
+func (h *IdentifyHandler) Identify2WithUID(_ context.Context, arg keybase1.Identify2WithUIDArg) (res keybase1.Identify2Res, err error) {
 	return res, nil
 }
 

--- a/go/service/track.go
+++ b/go/service/track.go
@@ -42,7 +42,7 @@ func (h *TrackHandler) Track(_ context.Context, arg keybase1.TrackArg) error {
 
 func (h *TrackHandler) TrackWithToken(_ context.Context, arg keybase1.TrackWithTokenArg) error {
 	earg := engine.TrackTokenArg{
-		Token:   libkb.ImportIdentifyCacheToken(arg.TrackToken),
+		Token:   arg.TrackToken,
 		Options: arg.Options,
 	}
 	ctx := engine.Context{

--- a/protocol/avdl/common.avdl
+++ b/protocol/avdl/common.avdl
@@ -86,4 +86,26 @@ protocol Common {
 		CLI_0,
 		GUI_1
 	}
+
+	record UserVersionVector {
+	    long id;
+	    int sigHints;
+	    long sigChain;
+	    Time cachedAt;
+	    Time lastIdentifiedAt;
+	}
+
+	record UserPlusKeys {
+	    UID uid;
+	    string username;
+
+	    // This is a misnomer; it's actually all keys, including PGP; let's deprecate
+	    // this field in a few versions
+	    array<PublicKey> deviceKeys;
+
+	    // A duplicate of deviceKeys above, but with a better name
+	    array<PublicKey> keys;
+
+	    UserVersionVector uvv;
+	}
 }

--- a/protocol/avdl/identify.avdl
+++ b/protocol/avdl/identify.avdl
@@ -16,4 +16,10 @@ protocol identify {
     */
   IdentifyRes identify(int sessionID, string userAssertion, boolean trackStatement=false, boolean forceRemoteCheck=false, boolean useDelegateUI=false, IdentifyReason reason, IdentifySource source);
 
+  record Identify2Res {
+    UserPlusKeys upk;
+  }
+
+  Identify2Res identify2(int sessionID, UID uid, string userAssertion, IdentifyReason reason, boolean useDelegateUI=false);
+
 }

--- a/protocol/avdl/identify.avdl
+++ b/protocol/avdl/identify.avdl
@@ -20,6 +20,6 @@ protocol identify {
     UserPlusKeys upk;
   }
 
-  Identify2Res identify2(int sessionID, UID uid, string userAssertion, IdentifyReason reason, boolean useDelegateUI=false);
+  Identify2Res identify2WithUID(int sessionID, UID uid, string userAssertion, IdentifyReason reason, boolean useDelegateUI=false);
 
 }

--- a/protocol/avdl/identify_common.avdl
+++ b/protocol/avdl/identify_common.avdl
@@ -90,4 +90,7 @@ protocol identifyCommon {
 		SigID sigID;
 		Time mTime;
 	}
+
+	@typedef("string")
+	record TrackToken {}
 }

--- a/protocol/avdl/identify_common.avdl
+++ b/protocol/avdl/identify_common.avdl
@@ -4,6 +4,9 @@ protocol identifyCommon {
 	import idl "common.avdl";
 	import idl "prove_common.avdl";
 
+	@typedef("string")
+	record TrackToken {}
+
 	enum TrackDiffType {
 		NONE_0,
 		ERROR_1,
@@ -79,7 +82,7 @@ protocol identifyCommon {
 		union { null, User } user;
 		array<PublicKey> publicKeys;
 		IdentifyOutcome outcome;
-		string trackToken;
+		TrackToken trackToken;
 	}
 
 	record RemoteProof {
@@ -90,7 +93,4 @@ protocol identifyCommon {
 		SigID sigID;
 		Time mTime;
 	}
-
-	@typedef("string")
-	record TrackToken {}
 }

--- a/protocol/avdl/identify_ui.avdl
+++ b/protocol/avdl/identify_ui.avdl
@@ -93,6 +93,7 @@ protocol identifyUi {
   void finishSocialProofCheck(int sessionID, RemoteProof rp, LinkCheckResult lcr);
   void displayCryptocurrency(int sessionID, Cryptocurrency c);
   void reportTrackToken(int sessionID, TrackToken trackToken);
+  void displayUserCard(int sessionID, UserCard card);
   ConfirmResult confirm(int sessionID, IdentifyOutcome outcome);
   void finish(int sessionID);
 }

--- a/protocol/avdl/identify_ui.avdl
+++ b/protocol/avdl/identify_ui.avdl
@@ -92,8 +92,7 @@ protocol identifyUi {
   void finishWebProofCheck(int sessionID, RemoteProof rp, LinkCheckResult lcr);
   void finishSocialProofCheck(int sessionID, RemoteProof rp, LinkCheckResult lcr);
   void displayCryptocurrency(int sessionID, Cryptocurrency c);
-  void reportTrackToken(int sessionID, string trackToken);
-  void displayUserCard(int sessionID, UserCard card);
+  void reportTrackToken(int sessionID, TrackToken trackToken);
   ConfirmResult confirm(int sessionID, IdentifyOutcome outcome);
   void finish(int sessionID);
 }

--- a/protocol/avdl/track.avdl
+++ b/protocol/avdl/track.avdl
@@ -14,7 +14,7 @@ protocol track {
   /**
     Track with token returned from identify.
     */
-  void trackWithToken(int sessionID, string trackToken, TrackOptions options);
+  void trackWithToken(int sessionID, TrackToken trackToken, TrackOptions options);
 
   void untrack(int sessionID, string username);
 }

--- a/protocol/avdl/user.avdl
+++ b/protocol/avdl/user.avdl
@@ -41,12 +41,6 @@ protocol user {
     Time trackTime;
   }
 
-  record UserPlusKeys {
-    UID uid;
-    string username;
-    array<PublicKey> deviceKeys;
-  }
-
   /**
     Load user summaries for the supplied uids.
     They are "unchecked" in that the client is not verifying the info from the server.

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1046,6 +1046,12 @@ export type identify_ProofType = 0 /* 'NONE_0' */ | 1 /* 'KEYBASE_1' */ | 2 /* '
 
 export type ProofType = 0 /* 'NONE_0' */ | 1 /* 'KEYBASE_1' */ | 2 /* 'TWITTER_2' */ | 3 /* 'GITHUB_3' */ | 4 /* 'REDDIT_4' */ | 5 /* 'COINBASE_5' */ | 6 /* 'HACKERNEWS_6' */ | 7 /* 'GENERIC_WEB_SITE_1000' */ | 8 /* 'DNS_1001' */ | 9 /* 'ROOTER_100001' */
 
+export type identify_TrackToken = {
+}
+
+export type TrackToken = {
+}
+
 export type identify_TrackDiffType = 0 /* 'NONE_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'CLASH_2' */ | 3 /* 'REVOKED_3' */ | 4 /* 'UPGRADED_4' */ | 5 /* 'NEW_5' */ | 6 /* 'REMOTE_FAIL_6' */ | 7 /* 'REMOTE_WORKING_7' */ | 8 /* 'REMOTE_CHANGED_8' */ | 9 /* 'NEW_ELDEST_9' */
 
 export type TrackDiffType = 0 /* 'NONE_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'CLASH_2' */ | 3 /* 'REVOKED_3' */ | 4 /* 'UPGRADED_4' */ | 5 /* 'NEW_5' */ | 6 /* 'REMOTE_FAIL_6' */ | 7 /* 'REMOTE_WORKING_7' */ | 8 /* 'REMOTE_CHANGED_8' */ | 9 /* 'NEW_ELDEST_9' */
@@ -1132,14 +1138,14 @@ export type identify_IdentifyRes = {
   user?: ?User;
   publicKeys: Array<PublicKey>;
   outcome: IdentifyOutcome;
-  trackToken: string;
+  trackToken: TrackToken;
 }
 
 export type IdentifyRes = {
   user?: ?User;
   publicKeys: Array<PublicKey>;
   outcome: IdentifyOutcome;
-  trackToken: string;
+  trackToken: TrackToken;
 }
 
 export type identify_RemoteProof = {
@@ -1158,12 +1164,6 @@ export type RemoteProof = {
   displayMarkup: string;
   sigID: SigID;
   mTime: Time;
-}
-
-export type identify_TrackToken = {
-}
-
-export type TrackToken = {
 }
 
 export type identify_IdentifySource = 0 /* 'CLI_0' */ | 1 /* 'KBFS_1' */
@@ -1273,6 +1273,9 @@ export type identifyUi_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'L
 
 export type identifyUi_ProofType = 0 /* 'NONE_0' */ | 1 /* 'KEYBASE_1' */ | 2 /* 'TWITTER_2' */ | 3 /* 'GITHUB_3' */ | 4 /* 'REDDIT_4' */ | 5 /* 'COINBASE_5' */ | 6 /* 'HACKERNEWS_6' */ | 7 /* 'GENERIC_WEB_SITE_1000' */ | 8 /* 'DNS_1001' */ | 9 /* 'ROOTER_100001' */
 
+export type identifyUi_TrackToken = {
+}
+
 export type identifyUi_TrackDiffType = 0 /* 'NONE_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'CLASH_2' */ | 3 /* 'REVOKED_3' */ | 4 /* 'UPGRADED_4' */ | 5 /* 'NEW_5' */ | 6 /* 'REMOTE_FAIL_6' */ | 7 /* 'REMOTE_WORKING_7' */ | 8 /* 'REMOTE_CHANGED_8' */ | 9 /* 'NEW_ELDEST_9' */
 
 export type identifyUi_TrackDiff = {
@@ -1318,7 +1321,7 @@ export type identifyUi_IdentifyRes = {
   user?: ?User;
   publicKeys: Array<PublicKey>;
   outcome: IdentifyOutcome;
-  trackToken: string;
+  trackToken: TrackToken;
 }
 
 export type identifyUi_RemoteProof = {
@@ -1328,9 +1331,6 @@ export type identifyUi_RemoteProof = {
   displayMarkup: string;
   sigID: SigID;
   mTime: Time;
-}
-
-export type identifyUi_TrackToken = {
 }
 
 export type identifyUi_ProofResult = {
@@ -1441,6 +1441,32 @@ export type LinkCheckResult = {
   diff?: ?TrackDiff;
   remoteDiff?: ?TrackDiff;
   hint?: ?SigHint;
+}
+
+export type identifyUi_UserCard = {
+  following: int;
+  followers: int;
+  uid: UID;
+  fullName: string;
+  location: string;
+  bio: string;
+  website: string;
+  twitter: string;
+  youFollowThem: boolean;
+  theyFollowYou: boolean;
+}
+
+export type UserCard = {
+  following: int;
+  followers: int;
+  uid: UID;
+  fullName: string;
+  location: string;
+  bio: string;
+  website: string;
+  twitter: string;
+  youFollowThem: boolean;
+  theyFollowYou: boolean;
 }
 
 export type identifyUi_ConfirmResult = {
@@ -1707,6 +1733,9 @@ export type kbcmf_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_
 
 export type kbcmf_ProofType = 0 /* 'NONE_0' */ | 1 /* 'KEYBASE_1' */ | 2 /* 'TWITTER_2' */ | 3 /* 'GITHUB_3' */ | 4 /* 'REDDIT_4' */ | 5 /* 'COINBASE_5' */ | 6 /* 'HACKERNEWS_6' */ | 7 /* 'GENERIC_WEB_SITE_1000' */ | 8 /* 'DNS_1001' */ | 9 /* 'ROOTER_100001' */
 
+export type kbcmf_TrackToken = {
+}
+
 export type kbcmf_TrackDiffType = 0 /* 'NONE_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'CLASH_2' */ | 3 /* 'REVOKED_3' */ | 4 /* 'UPGRADED_4' */ | 5 /* 'NEW_5' */ | 6 /* 'REMOTE_FAIL_6' */ | 7 /* 'REMOTE_WORKING_7' */ | 8 /* 'REMOTE_CHANGED_8' */ | 9 /* 'NEW_ELDEST_9' */
 
 export type kbcmf_TrackDiff = {
@@ -1752,7 +1781,7 @@ export type kbcmf_IdentifyRes = {
   user?: ?User;
   publicKeys: Array<PublicKey>;
   outcome: IdentifyOutcome;
-  trackToken: string;
+  trackToken: TrackToken;
 }
 
 export type kbcmf_RemoteProof = {
@@ -1762,9 +1791,6 @@ export type kbcmf_RemoteProof = {
   displayMarkup: string;
   sigID: SigID;
   mTime: Time;
-}
-
-export type kbcmf_TrackToken = {
 }
 
 export type kbcmf_KBCMFEncryptOptions = {
@@ -2702,6 +2728,9 @@ export type pgp_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_2'
 
 export type pgp_ProofType = 0 /* 'NONE_0' */ | 1 /* 'KEYBASE_1' */ | 2 /* 'TWITTER_2' */ | 3 /* 'GITHUB_3' */ | 4 /* 'REDDIT_4' */ | 5 /* 'COINBASE_5' */ | 6 /* 'HACKERNEWS_6' */ | 7 /* 'GENERIC_WEB_SITE_1000' */ | 8 /* 'DNS_1001' */ | 9 /* 'ROOTER_100001' */
 
+export type pgp_TrackToken = {
+}
+
 export type pgp_TrackDiffType = 0 /* 'NONE_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'CLASH_2' */ | 3 /* 'REVOKED_3' */ | 4 /* 'UPGRADED_4' */ | 5 /* 'NEW_5' */ | 6 /* 'REMOTE_FAIL_6' */ | 7 /* 'REMOTE_WORKING_7' */ | 8 /* 'REMOTE_CHANGED_8' */ | 9 /* 'NEW_ELDEST_9' */
 
 export type pgp_TrackDiff = {
@@ -2747,7 +2776,7 @@ export type pgp_IdentifyRes = {
   user?: ?User;
   publicKeys: Array<PublicKey>;
   outcome: IdentifyOutcome;
-  trackToken: string;
+  trackToken: TrackToken;
 }
 
 export type pgp_RemoteProof = {
@@ -2757,9 +2786,6 @@ export type pgp_RemoteProof = {
   displayMarkup: string;
   sigID: SigID;
   mTime: Time;
-}
-
-export type pgp_TrackToken = {
 }
 
 export type pgp_SignMode = 0 /* 'ATTACHED_0' */ | 1 /* 'DETACHED_1' */ | 2 /* 'CLEAR_2' */
@@ -2786,6 +2812,7 @@ export type pgp_PGPEncryptOptions = {
   noSelf: boolean;
   binaryOut: boolean;
   keyQuery: string;
+  skipTrack: boolean;
   trackOptions: TrackOptions;
 }
 
@@ -2795,6 +2822,7 @@ export type PGPEncryptOptions = {
   noSelf: boolean;
   binaryOut: boolean;
   keyQuery: string;
+  skipTrack: boolean;
   trackOptions: TrackOptions;
 }
 
@@ -2815,24 +2843,20 @@ export type PGPSigVerification = {
 export type pgp_PGPDecryptOptions = {
   assertSigned: boolean;
   signedBy: string;
-  trackOptions: TrackOptions;
 }
 
 export type PGPDecryptOptions = {
   assertSigned: boolean;
   signedBy: string;
-  trackOptions: TrackOptions;
 }
 
 export type pgp_PGPVerifyOptions = {
   signedBy: string;
-  trackOptions: TrackOptions;
   signature: bytes;
 }
 
 export type PGPVerifyOptions = {
   signedBy: string;
-  trackOptions: TrackOptions;
   signature: bytes;
 }
 
@@ -2868,6 +2892,95 @@ export type pgp_PGPCreateUids = {
 export type PGPCreateUids = {
   useDefault: boolean;
   ids: Array<PGPIdentity>;
+}
+
+export type pgpUi_Time = {
+}
+
+export type pgpUi_StringKVPair = {
+  key: string;
+  value: string;
+}
+
+export type pgpUi_Status = {
+  code: int;
+  name: string;
+  desc: string;
+  fields: Array<StringKVPair>;
+}
+
+export type pgpUi_UID = {
+}
+
+export type pgpUi_DeviceID = {
+}
+
+export type pgpUi_SigID = {
+}
+
+export type pgpUi_KID = {
+}
+
+export type pgpUi_Text = {
+  data: string;
+  markup: boolean;
+}
+
+export type pgpUi_PGPIdentity = {
+  username: string;
+  comment: string;
+  email: string;
+}
+
+export type pgpUi_PublicKey = {
+  KID: KID;
+  PGPFingerprint: string;
+  PGPIdentities: Array<PGPIdentity>;
+  isSibkey: boolean;
+  isEldest: boolean;
+  parentID: string;
+  deviceID: DeviceID;
+  deviceDescription: string;
+  deviceType: string;
+  cTime: Time;
+  eTime: Time;
+}
+
+export type pgpUi_User = {
+  uid: UID;
+  username: string;
+}
+
+export type pgpUi_Device = {
+  type: string;
+  name: string;
+  deviceID: DeviceID;
+  cTime: Time;
+  mTime: Time;
+}
+
+export type pgpUi_Stream = {
+  fd: int;
+}
+
+export type pgpUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
+
+export type pgpUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type pgpUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type pgpUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
 }
 
 export type prove_Time = {
@@ -2965,6 +3078,9 @@ export type prove_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_
 
 export type prove_ProofType = 0 /* 'NONE_0' */ | 1 /* 'KEYBASE_1' */ | 2 /* 'TWITTER_2' */ | 3 /* 'GITHUB_3' */ | 4 /* 'REDDIT_4' */ | 5 /* 'COINBASE_5' */ | 6 /* 'HACKERNEWS_6' */ | 7 /* 'GENERIC_WEB_SITE_1000' */ | 8 /* 'DNS_1001' */ | 9 /* 'ROOTER_100001' */
 
+export type prove_TrackToken = {
+}
+
 export type prove_TrackDiffType = 0 /* 'NONE_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'CLASH_2' */ | 3 /* 'REVOKED_3' */ | 4 /* 'UPGRADED_4' */ | 5 /* 'NEW_5' */ | 6 /* 'REMOTE_FAIL_6' */ | 7 /* 'REMOTE_WORKING_7' */ | 8 /* 'REMOTE_CHANGED_8' */ | 9 /* 'NEW_ELDEST_9' */
 
 export type prove_TrackDiff = {
@@ -3010,7 +3126,7 @@ export type prove_IdentifyRes = {
   user?: ?User;
   publicKeys: Array<PublicKey>;
   outcome: IdentifyOutcome;
-  trackToken: string;
+  trackToken: TrackToken;
 }
 
 export type prove_RemoteProof = {
@@ -3020,9 +3136,6 @@ export type prove_RemoteProof = {
   displayMarkup: string;
   sigID: SigID;
   mTime: Time;
-}
-
-export type prove_TrackToken = {
 }
 
 export type prove_CheckProofStatus = {
@@ -3572,27 +3685,35 @@ export type GetPassphraseRes = {
   storeSecret: boolean;
 }
 
-export type secretUi_SecretStorageFeature = {
+export type secretUi_Feature = {
   allow: boolean;
+  defaultValue: boolean;
+  readonly: boolean;
   label: string;
 }
 
-export type SecretStorageFeature = {
+export type Feature = {
   allow: boolean;
+  defaultValue: boolean;
+  readonly: boolean;
   label: string;
 }
 
 export type secretUi_GUIEntryFeatures = {
-  secretStorage: SecretStorageFeature;
+  storeSecret: Feature;
+  showTyping: Feature;
 }
 
 export type GUIEntryFeatures = {
-  secretStorage: SecretStorageFeature;
+  storeSecret: Feature;
+  showTyping: Feature;
 }
 
 export type secretUi_GUIEntryArg = {
   windowTitle: string;
   prompt: string;
+  submitLabel: string;
+  cancelLabel: string;
   retryLabel: string;
   features: GUIEntryFeatures;
 }
@@ -3600,6 +3721,8 @@ export type secretUi_GUIEntryArg = {
 export type GUIEntryArg = {
   windowTitle: string;
   prompt: string;
+  submitLabel: string;
+  cancelLabel: string;
   retryLabel: string;
   features: GUIEntryFeatures;
 }
@@ -4149,6 +4272,9 @@ export type track_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_
 
 export type track_ProofType = 0 /* 'NONE_0' */ | 1 /* 'KEYBASE_1' */ | 2 /* 'TWITTER_2' */ | 3 /* 'GITHUB_3' */ | 4 /* 'REDDIT_4' */ | 5 /* 'COINBASE_5' */ | 6 /* 'HACKERNEWS_6' */ | 7 /* 'GENERIC_WEB_SITE_1000' */ | 8 /* 'DNS_1001' */ | 9 /* 'ROOTER_100001' */
 
+export type track_TrackToken = {
+}
+
 export type track_TrackDiffType = 0 /* 'NONE_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'CLASH_2' */ | 3 /* 'REVOKED_3' */ | 4 /* 'UPGRADED_4' */ | 5 /* 'NEW_5' */ | 6 /* 'REMOTE_FAIL_6' */ | 7 /* 'REMOTE_WORKING_7' */ | 8 /* 'REMOTE_CHANGED_8' */ | 9 /* 'NEW_ELDEST_9' */
 
 export type track_TrackDiff = {
@@ -4194,7 +4320,7 @@ export type track_IdentifyRes = {
   user?: ?User;
   publicKeys: Array<PublicKey>;
   outcome: IdentifyOutcome;
-  trackToken: string;
+  trackToken: TrackToken;
 }
 
 export type track_RemoteProof = {
@@ -4204,9 +4330,6 @@ export type track_RemoteProof = {
   displayMarkup: string;
   sigID: SigID;
   mTime: Time;
-}
-
-export type track_TrackToken = {
 }
 
 export type ui_Time = {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -148,6 +148,38 @@ export type block_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
 export type ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type block_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type block_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
+export type UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type block_BlockIdCombo = {
   blockHash: string;
   chargedTo: UID;
@@ -253,6 +285,22 @@ export type BTC_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' 
 
 export type BTC_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type BTC_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type BTC_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type config_Time = {
 }
 
@@ -325,6 +373,22 @@ export type config_Stream = {
 export type config_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type config_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type config_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type config_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type config_GetCurrentStatusRes = {
   configured: boolean;
@@ -459,6 +523,22 @@ export type ctl_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' 
 
 export type ctl_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type ctl_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type ctl_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type ctl_ExitCode = 0 /* 'OK_0' */ | 1 /* 'NOTOK_2' */ | 2 /* 'RESTART_4' */
 
 export type ExitCode = 0 /* 'OK_0' */ | 1 /* 'NOTOK_2' */ | 2 /* 'RESTART_4' */
@@ -544,6 +624,22 @@ export type delegateUiCtl_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /*
 
 export type delegateUiCtl_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type delegateUiCtl_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type delegateUiCtl_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type device_Time = {
 }
 
@@ -617,6 +713,22 @@ export type device_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_
 
 export type device_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type device_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type device_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type favorite_Time = {
 }
 
@@ -689,6 +801,22 @@ export type favorite_Stream = {
 export type favorite_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type favorite_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type favorite_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type favorite_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type favorite_Folder = {
   name: string;
@@ -774,6 +902,22 @@ export type gpgUi_Stream = {
 export type gpgUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type gpgUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type gpgUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type gpgUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type gpgUi_GPGKey = {
   algorithm: string;
@@ -873,6 +1017,22 @@ export type identify_Stream = {
 export type identify_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type identify_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type identify_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type identify_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type identify_ProofState = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'TEMP_FAILURE_2' */ | 3 /* 'PERM_FAILURE_3' */ | 4 /* 'LOOKING_4' */ | 5 /* 'SUPERSEDED_5' */ | 6 /* 'POSTED_6' */ | 7 /* 'REVOKED_7' */
 
@@ -1000,9 +1160,23 @@ export type RemoteProof = {
   mTime: Time;
 }
 
+export type identify_TrackToken = {
+}
+
+export type TrackToken = {
+}
+
 export type identify_IdentifySource = 0 /* 'CLI_0' */ | 1 /* 'KBFS_1' */
 
 export type IdentifySource = 0 /* 'CLI_0' */ | 1 /* 'KBFS_1' */
+
+export type identify_Identify2Res = {
+  upk: UserPlusKeys;
+}
+
+export type Identify2Res = {
+  upk: UserPlusKeys;
+}
 
 export type identifyUi_Time = {
 }
@@ -1077,6 +1251,22 @@ export type identifyUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'I
 
 export type identifyUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type identifyUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type identifyUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type identifyUi_ProofState = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'TEMP_FAILURE_2' */ | 3 /* 'PERM_FAILURE_3' */ | 4 /* 'LOOKING_4' */ | 5 /* 'SUPERSEDED_5' */ | 6 /* 'POSTED_6' */ | 7 /* 'REVOKED_7' */
 
 export type identifyUi_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_2' */ | 3 /* 'FOUND_3' */ | 4 /* 'BASE_ERROR_100' */ | 5 /* 'HOST_UNREACHABLE_101' */ | 6 /* 'PERMISSION_DENIED_103' */ | 7 /* 'FAILED_PARSE_106' */ | 8 /* 'DNS_ERROR_107' */ | 9 /* 'AUTH_FAILED_108' */ | 10 /* 'HTTP_500_150' */ | 11 /* 'TIMEOUT_160' */ | 12 /* 'INTERNAL_ERROR_170' */ | 13 /* 'BASE_HARD_ERROR_200' */ | 14 /* 'NOT_FOUND_201' */ | 15 /* 'CONTENT_FAILURE_202' */ | 16 /* 'BAD_USERNAME_203' */ | 17 /* 'BAD_REMOTE_ID_204' */ | 18 /* 'TEXT_NOT_FOUND_205' */ | 19 /* 'BAD_ARGS_206' */ | 20 /* 'CONTENT_MISSING_207' */ | 21 /* 'TITLE_NOT_FOUND_208' */ | 22 /* 'SERVICE_ERROR_209' */ | 23 /* 'TOR_SKIPPED_210' */ | 24 /* 'TOR_INCOMPATIBLE_211' */ | 25 /* 'HTTP_300_230' */ | 26 /* 'HTTP_400_240' */ | 27 /* 'HTTP_OTHER_260' */ | 28 /* 'EMPTY_JSON_270' */ | 29 /* 'DELETED_301' */ | 30 /* 'SERVICE_DEAD_302' */ | 31 /* 'BAD_SIGNATURE_303' */ | 32 /* 'BAD_API_URL_304' */ | 33 /* 'UNKNOWN_TYPE_305' */ | 34 /* 'NO_HINT_306' */ | 35 /* 'BAD_HINT_TEXT_307' */
@@ -1138,6 +1328,9 @@ export type identifyUi_RemoteProof = {
   displayMarkup: string;
   sigID: SigID;
   mTime: Time;
+}
+
+export type identifyUi_TrackToken = {
 }
 
 export type identifyUi_ProofResult = {
@@ -1248,32 +1441,6 @@ export type LinkCheckResult = {
   diff?: ?TrackDiff;
   remoteDiff?: ?TrackDiff;
   hint?: ?SigHint;
-}
-
-export type identifyUi_UserCard = {
-  following: int;
-  followers: int;
-  uid: UID;
-  fullName: string;
-  location: string;
-  bio: string;
-  website: string;
-  twitter: string;
-  youFollowThem: boolean;
-  theyFollowYou: boolean;
-}
-
-export type UserCard = {
-  following: int;
-  followers: int;
-  uid: UID;
-  fullName: string;
-  location: string;
-  bio: string;
-  website: string;
-  twitter: string;
-  youFollowThem: boolean;
-  theyFollowYou: boolean;
 }
 
 export type identifyUi_ConfirmResult = {
@@ -1518,6 +1685,22 @@ export type kbcmf_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2
 
 export type kbcmf_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type kbcmf_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type kbcmf_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type kbcmf_ProofState = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'TEMP_FAILURE_2' */ | 3 /* 'PERM_FAILURE_3' */ | 4 /* 'LOOKING_4' */ | 5 /* 'SUPERSEDED_5' */ | 6 /* 'POSTED_6' */ | 7 /* 'REVOKED_7' */
 
 export type kbcmf_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_2' */ | 3 /* 'FOUND_3' */ | 4 /* 'BASE_ERROR_100' */ | 5 /* 'HOST_UNREACHABLE_101' */ | 6 /* 'PERMISSION_DENIED_103' */ | 7 /* 'FAILED_PARSE_106' */ | 8 /* 'DNS_ERROR_107' */ | 9 /* 'AUTH_FAILED_108' */ | 10 /* 'HTTP_500_150' */ | 11 /* 'TIMEOUT_160' */ | 12 /* 'INTERNAL_ERROR_170' */ | 13 /* 'BASE_HARD_ERROR_200' */ | 14 /* 'NOT_FOUND_201' */ | 15 /* 'CONTENT_FAILURE_202' */ | 16 /* 'BAD_USERNAME_203' */ | 17 /* 'BAD_REMOTE_ID_204' */ | 18 /* 'TEXT_NOT_FOUND_205' */ | 19 /* 'BAD_ARGS_206' */ | 20 /* 'CONTENT_MISSING_207' */ | 21 /* 'TITLE_NOT_FOUND_208' */ | 22 /* 'SERVICE_ERROR_209' */ | 23 /* 'TOR_SKIPPED_210' */ | 24 /* 'TOR_INCOMPATIBLE_211' */ | 25 /* 'HTTP_300_230' */ | 26 /* 'HTTP_400_240' */ | 27 /* 'HTTP_OTHER_260' */ | 28 /* 'EMPTY_JSON_270' */ | 29 /* 'DELETED_301' */ | 30 /* 'SERVICE_DEAD_302' */ | 31 /* 'BAD_SIGNATURE_303' */ | 32 /* 'BAD_API_URL_304' */ | 33 /* 'UNKNOWN_TYPE_305' */ | 34 /* 'NO_HINT_306' */ | 35 /* 'BAD_HINT_TEXT_307' */
@@ -1579,6 +1762,9 @@ export type kbcmf_RemoteProof = {
   displayMarkup: string;
   sigID: SigID;
   mTime: Time;
+}
+
+export type kbcmf_TrackToken = {
 }
 
 export type kbcmf_KBCMFEncryptOptions = {
@@ -1688,6 +1874,22 @@ export type Kex2Provisionee_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 
 
 export type Kex2Provisionee_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type Kex2Provisionee_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type Kex2Provisionee_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type Kex2Provisionee_PassphraseStream = {
   passphraseStream: bytes;
   generation: int;
@@ -1789,6 +1991,22 @@ export type logUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2
 
 export type logUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type logUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type logUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type login_Time = {
 }
 
@@ -1861,6 +2079,22 @@ export type login_Stream = {
 export type login_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type login_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type login_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type login_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type login_ConfiguredAccount = {
   username: string;
@@ -1945,6 +2179,22 @@ export type loginUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO
 
 export type loginUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type loginUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type loginUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type metadata_Time = {
 }
 
@@ -2017,6 +2267,22 @@ export type metadata_Stream = {
 export type metadata_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type metadata_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type metadata_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type metadata_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type metadata_BlockIdCombo = {
   blockHash: string;
@@ -2118,6 +2384,22 @@ export type metadataUpdate_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /
 
 export type metadataUpdate_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type metadataUpdate_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type metadataUpdate_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type metadataUpdate_BlockIdCombo = {
   blockHash: string;
   chargedTo: UID;
@@ -2195,6 +2477,22 @@ export type notifyCtl_Stream = {
 export type notifyCtl_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type notifyCtl_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type notifyCtl_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type notifyCtl_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type notifyCtl_NotificationChannels = {
   session: boolean;
@@ -2293,6 +2591,22 @@ export type NotifyUsers_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* '
 
 export type NotifyUsers_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type NotifyUsers_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type NotifyUsers_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type pgp_Time = {
 }
 
@@ -2366,6 +2680,22 @@ export type pgp_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' 
 
 export type pgp_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type pgp_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type pgp_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type pgp_ProofState = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'TEMP_FAILURE_2' */ | 3 /* 'PERM_FAILURE_3' */ | 4 /* 'LOOKING_4' */ | 5 /* 'SUPERSEDED_5' */ | 6 /* 'POSTED_6' */ | 7 /* 'REVOKED_7' */
 
 export type pgp_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_2' */ | 3 /* 'FOUND_3' */ | 4 /* 'BASE_ERROR_100' */ | 5 /* 'HOST_UNREACHABLE_101' */ | 6 /* 'PERMISSION_DENIED_103' */ | 7 /* 'FAILED_PARSE_106' */ | 8 /* 'DNS_ERROR_107' */ | 9 /* 'AUTH_FAILED_108' */ | 10 /* 'HTTP_500_150' */ | 11 /* 'TIMEOUT_160' */ | 12 /* 'INTERNAL_ERROR_170' */ | 13 /* 'BASE_HARD_ERROR_200' */ | 14 /* 'NOT_FOUND_201' */ | 15 /* 'CONTENT_FAILURE_202' */ | 16 /* 'BAD_USERNAME_203' */ | 17 /* 'BAD_REMOTE_ID_204' */ | 18 /* 'TEXT_NOT_FOUND_205' */ | 19 /* 'BAD_ARGS_206' */ | 20 /* 'CONTENT_MISSING_207' */ | 21 /* 'TITLE_NOT_FOUND_208' */ | 22 /* 'SERVICE_ERROR_209' */ | 23 /* 'TOR_SKIPPED_210' */ | 24 /* 'TOR_INCOMPATIBLE_211' */ | 25 /* 'HTTP_300_230' */ | 26 /* 'HTTP_400_240' */ | 27 /* 'HTTP_OTHER_260' */ | 28 /* 'EMPTY_JSON_270' */ | 29 /* 'DELETED_301' */ | 30 /* 'SERVICE_DEAD_302' */ | 31 /* 'BAD_SIGNATURE_303' */ | 32 /* 'BAD_API_URL_304' */ | 33 /* 'UNKNOWN_TYPE_305' */ | 34 /* 'NO_HINT_306' */ | 35 /* 'BAD_HINT_TEXT_307' */
@@ -2429,6 +2759,9 @@ export type pgp_RemoteProof = {
   mTime: Time;
 }
 
+export type pgp_TrackToken = {
+}
+
 export type pgp_SignMode = 0 /* 'ATTACHED_0' */ | 1 /* 'DETACHED_1' */ | 2 /* 'CLEAR_2' */
 
 export type SignMode = 0 /* 'ATTACHED_0' */ | 1 /* 'DETACHED_1' */ | 2 /* 'CLEAR_2' */
@@ -2453,7 +2786,6 @@ export type pgp_PGPEncryptOptions = {
   noSelf: boolean;
   binaryOut: boolean;
   keyQuery: string;
-  skipTrack: boolean;
   trackOptions: TrackOptions;
 }
 
@@ -2463,7 +2795,6 @@ export type PGPEncryptOptions = {
   noSelf: boolean;
   binaryOut: boolean;
   keyQuery: string;
-  skipTrack: boolean;
   trackOptions: TrackOptions;
 }
 
@@ -2484,20 +2815,24 @@ export type PGPSigVerification = {
 export type pgp_PGPDecryptOptions = {
   assertSigned: boolean;
   signedBy: string;
+  trackOptions: TrackOptions;
 }
 
 export type PGPDecryptOptions = {
   assertSigned: boolean;
   signedBy: string;
+  trackOptions: TrackOptions;
 }
 
 export type pgp_PGPVerifyOptions = {
   signedBy: string;
+  trackOptions: TrackOptions;
   signature: bytes;
 }
 
 export type PGPVerifyOptions = {
   signedBy: string;
+  trackOptions: TrackOptions;
   signature: bytes;
 }
 
@@ -2534,79 +2869,6 @@ export type PGPCreateUids = {
   useDefault: boolean;
   ids: Array<PGPIdentity>;
 }
-
-export type pgpUi_Time = {
-}
-
-export type pgpUi_StringKVPair = {
-  key: string;
-  value: string;
-}
-
-export type pgpUi_Status = {
-  code: int;
-  name: string;
-  desc: string;
-  fields: Array<StringKVPair>;
-}
-
-export type pgpUi_UID = {
-}
-
-export type pgpUi_DeviceID = {
-}
-
-export type pgpUi_SigID = {
-}
-
-export type pgpUi_KID = {
-}
-
-export type pgpUi_Text = {
-  data: string;
-  markup: boolean;
-}
-
-export type pgpUi_PGPIdentity = {
-  username: string;
-  comment: string;
-  email: string;
-}
-
-export type pgpUi_PublicKey = {
-  KID: KID;
-  PGPFingerprint: string;
-  PGPIdentities: Array<PGPIdentity>;
-  isSibkey: boolean;
-  isEldest: boolean;
-  parentID: string;
-  deviceID: DeviceID;
-  deviceDescription: string;
-  deviceType: string;
-  cTime: Time;
-  eTime: Time;
-}
-
-export type pgpUi_User = {
-  uid: UID;
-  username: string;
-}
-
-export type pgpUi_Device = {
-  type: string;
-  name: string;
-  deviceID: DeviceID;
-  cTime: Time;
-  mTime: Time;
-}
-
-export type pgpUi_Stream = {
-  fd: int;
-}
-
-export type pgpUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
-
-export type pgpUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
 export type prove_Time = {
 }
@@ -2681,6 +2943,22 @@ export type prove_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2
 
 export type prove_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type prove_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type prove_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type prove_ProofState = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'TEMP_FAILURE_2' */ | 3 /* 'PERM_FAILURE_3' */ | 4 /* 'LOOKING_4' */ | 5 /* 'SUPERSEDED_5' */ | 6 /* 'POSTED_6' */ | 7 /* 'REVOKED_7' */
 
 export type prove_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_2' */ | 3 /* 'FOUND_3' */ | 4 /* 'BASE_ERROR_100' */ | 5 /* 'HOST_UNREACHABLE_101' */ | 6 /* 'PERMISSION_DENIED_103' */ | 7 /* 'FAILED_PARSE_106' */ | 8 /* 'DNS_ERROR_107' */ | 9 /* 'AUTH_FAILED_108' */ | 10 /* 'HTTP_500_150' */ | 11 /* 'TIMEOUT_160' */ | 12 /* 'INTERNAL_ERROR_170' */ | 13 /* 'BASE_HARD_ERROR_200' */ | 14 /* 'NOT_FOUND_201' */ | 15 /* 'CONTENT_FAILURE_202' */ | 16 /* 'BAD_USERNAME_203' */ | 17 /* 'BAD_REMOTE_ID_204' */ | 18 /* 'TEXT_NOT_FOUND_205' */ | 19 /* 'BAD_ARGS_206' */ | 20 /* 'CONTENT_MISSING_207' */ | 21 /* 'TITLE_NOT_FOUND_208' */ | 22 /* 'SERVICE_ERROR_209' */ | 23 /* 'TOR_SKIPPED_210' */ | 24 /* 'TOR_INCOMPATIBLE_211' */ | 25 /* 'HTTP_300_230' */ | 26 /* 'HTTP_400_240' */ | 27 /* 'HTTP_OTHER_260' */ | 28 /* 'EMPTY_JSON_270' */ | 29 /* 'DELETED_301' */ | 30 /* 'SERVICE_DEAD_302' */ | 31 /* 'BAD_SIGNATURE_303' */ | 32 /* 'BAD_API_URL_304' */ | 33 /* 'UNKNOWN_TYPE_305' */ | 34 /* 'NO_HINT_306' */ | 35 /* 'BAD_HINT_TEXT_307' */
@@ -2742,6 +3020,9 @@ export type prove_RemoteProof = {
   displayMarkup: string;
   sigID: SigID;
   mTime: Time;
+}
+
+export type prove_TrackToken = {
 }
 
 export type prove_CheckProofStatus = {
@@ -2837,6 +3118,22 @@ export type proveUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO
 
 export type proveUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type proveUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type proveUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type proveUi_PromptOverwriteType = 0 /* 'SOCIAL_0' */ | 1 /* 'SITE_1' */
 
 export type PromptOverwriteType = 0 /* 'SOCIAL_0' */ | 1 /* 'SITE_1' */
@@ -2913,6 +3210,22 @@ export type provisionUi_Stream = {
 export type provisionUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type provisionUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type provisionUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type provisionUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type provisionUi_ProvisionMethod = 0 /* 'DEVICE_0' */ | 1 /* 'PAPER_KEY_1' */ | 2 /* 'PASSPHRASE_2' */ | 3 /* 'GPG_IMPORT_3' */ | 4 /* 'GPG_SIGN_4' */
 
@@ -3009,6 +3322,22 @@ export type quota_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2
 
 export type quota_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type quota_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type quota_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type quota_VerifySessionRes = {
   uid: UID;
   sid: string;
@@ -3096,6 +3425,22 @@ export type revoke_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_
 
 export type revoke_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type revoke_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type revoke_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type secretUi_Time = {
 }
 
@@ -3169,6 +3514,22 @@ export type secretUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INF
 
 export type secretUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type secretUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type secretUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type secretUi_SecretEntryArg = {
   desc: string;
   prompt: string;
@@ -3211,35 +3572,27 @@ export type GetPassphraseRes = {
   storeSecret: boolean;
 }
 
-export type secretUi_Feature = {
+export type secretUi_SecretStorageFeature = {
   allow: boolean;
-  defaultValue: boolean;
-  readonly: boolean;
   label: string;
 }
 
-export type Feature = {
+export type SecretStorageFeature = {
   allow: boolean;
-  defaultValue: boolean;
-  readonly: boolean;
   label: string;
 }
 
 export type secretUi_GUIEntryFeatures = {
-  storeSecret: Feature;
-  showTyping: Feature;
+  secretStorage: SecretStorageFeature;
 }
 
 export type GUIEntryFeatures = {
-  storeSecret: Feature;
-  showTyping: Feature;
+  secretStorage: SecretStorageFeature;
 }
 
 export type secretUi_GUIEntryArg = {
   windowTitle: string;
   prompt: string;
-  submitLabel: string;
-  cancelLabel: string;
   retryLabel: string;
   features: GUIEntryFeatures;
 }
@@ -3247,8 +3600,6 @@ export type secretUi_GUIEntryArg = {
 export type GUIEntryArg = {
   windowTitle: string;
   prompt: string;
-  submitLabel: string;
-  cancelLabel: string;
   retryLabel: string;
   features: GUIEntryFeatures;
 }
@@ -3325,6 +3676,22 @@ export type session_Stream = {
 export type session_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type session_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type session_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type session_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type session_Session = {
   uid: UID;
@@ -3415,6 +3782,22 @@ export type signup_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_
 
 export type signup_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type signup_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type signup_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type signup_SignupRes = {
   passphraseOk: boolean;
   postOk: boolean;
@@ -3499,6 +3882,22 @@ export type sigs_Stream = {
 export type sigs_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type sigs_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type sigs_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type sigs_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type sigs_Sig = {
   seqno: int;
@@ -3631,6 +4030,22 @@ export type streamUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INF
 
 export type streamUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type streamUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type streamUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type test_Test = {
   reply: string;
 }
@@ -3712,6 +4127,22 @@ export type track_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2
 
 export type track_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type track_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type track_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type track_ProofState = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'TEMP_FAILURE_2' */ | 3 /* 'PERM_FAILURE_3' */ | 4 /* 'LOOKING_4' */ | 5 /* 'SUPERSEDED_5' */ | 6 /* 'POSTED_6' */ | 7 /* 'REVOKED_7' */
 
 export type track_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_2' */ | 3 /* 'FOUND_3' */ | 4 /* 'BASE_ERROR_100' */ | 5 /* 'HOST_UNREACHABLE_101' */ | 6 /* 'PERMISSION_DENIED_103' */ | 7 /* 'FAILED_PARSE_106' */ | 8 /* 'DNS_ERROR_107' */ | 9 /* 'AUTH_FAILED_108' */ | 10 /* 'HTTP_500_150' */ | 11 /* 'TIMEOUT_160' */ | 12 /* 'INTERNAL_ERROR_170' */ | 13 /* 'BASE_HARD_ERROR_200' */ | 14 /* 'NOT_FOUND_201' */ | 15 /* 'CONTENT_FAILURE_202' */ | 16 /* 'BAD_USERNAME_203' */ | 17 /* 'BAD_REMOTE_ID_204' */ | 18 /* 'TEXT_NOT_FOUND_205' */ | 19 /* 'BAD_ARGS_206' */ | 20 /* 'CONTENT_MISSING_207' */ | 21 /* 'TITLE_NOT_FOUND_208' */ | 22 /* 'SERVICE_ERROR_209' */ | 23 /* 'TOR_SKIPPED_210' */ | 24 /* 'TOR_INCOMPATIBLE_211' */ | 25 /* 'HTTP_300_230' */ | 26 /* 'HTTP_400_240' */ | 27 /* 'HTTP_OTHER_260' */ | 28 /* 'EMPTY_JSON_270' */ | 29 /* 'DELETED_301' */ | 30 /* 'SERVICE_DEAD_302' */ | 31 /* 'BAD_SIGNATURE_303' */ | 32 /* 'BAD_API_URL_304' */ | 33 /* 'UNKNOWN_TYPE_305' */ | 34 /* 'NO_HINT_306' */ | 35 /* 'BAD_HINT_TEXT_307' */
@@ -3773,6 +4204,9 @@ export type track_RemoteProof = {
   displayMarkup: string;
   sigID: SigID;
   mTime: Time;
+}
+
+export type track_TrackToken = {
 }
 
 export type ui_Time = {
@@ -3847,6 +4281,22 @@ export type ui_Stream = {
 export type ui_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type ui_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type ui_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type ui_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type ui_PromptDefault = 0 /* 'NONE_0' */ | 1 /* 'YES_1' */ | 2 /* 'NO_2' */
 
@@ -4048,6 +4498,22 @@ export type user_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2'
 
 export type user_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type user_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type user_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type user_Tracker = {
   tracker: UID;
   status: int;
@@ -4116,18 +4582,6 @@ export type UserSummary = {
   proofs: Proofs;
   sigIDDisplay: string;
   trackTime: Time;
-}
-
-export type user_UserPlusKeys = {
-  uid: UID;
-  username: string;
-  deviceKeys: Array<PublicKey>;
-}
-
-export type UserPlusKeys = {
-  uid: UID;
-  username: string;
-  deviceKeys: Array<PublicKey>;
 }
 
 export type user_SearchComponent = {

--- a/protocol/json/block.json
+++ b/protocol/json/block.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "BlockIdCombo",
     "fields" : [ {
       "name" : "blockHash",

--- a/protocol/json/btc.json
+++ b/protocol/json/btc.json
@@ -162,6 +162,50 @@
     "type" : "enum",
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
+  }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
   } ],
   "messages" : {
     "registerBTC" : {

--- a/protocol/json/config.json
+++ b/protocol/json/config.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "GetCurrentStatusRes",
     "fields" : [ {
       "name" : "configured",

--- a/protocol/json/ctl.json
+++ b/protocol/json/ctl.json
@@ -163,6 +163,50 @@
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
     "type" : "enum",
     "name" : "ExitCode",
     "symbols" : [ "OK_0", "NOTOK_2", "RESTART_4" ]

--- a/protocol/json/delegate_ui_ctl.json
+++ b/protocol/json/delegate_ui_ctl.json
@@ -162,6 +162,50 @@
     "type" : "enum",
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
+  }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
   } ],
   "messages" : {
     "registerIdentifyUI" : {

--- a/protocol/json/device.json
+++ b/protocol/json/device.json
@@ -162,6 +162,50 @@
     "type" : "enum",
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
+  }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
   } ],
   "messages" : {
     "deviceList" : {

--- a/protocol/json/favorite.json
+++ b/protocol/json/favorite.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "Folder",
     "doc" : "Folder represents a favorite top-level folder in kbfs.\n    This type is likely to change significantly as all the various parts are\n    connected and tested.",
     "fields" : [ {

--- a/protocol/json/gpg_ui.json
+++ b/protocol/json/gpg_ui.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "GPGKey",
     "fields" : [ {
       "name" : "algorithm",

--- a/protocol/json/identify.json
+++ b/protocol/json/identify.json
@@ -408,7 +408,7 @@
       } ],
       "response" : "IdentifyRes"
     },
-    "identify2" : {
+    "identify2WithUID" : {
       "request" : [ {
         "name" : "sessionID",
         "type" : "int"

--- a/protocol/json/identify.json
+++ b/protocol/json/identify.json
@@ -220,6 +220,11 @@
     "name" : "ProofType",
     "symbols" : [ "NONE_0", "KEYBASE_1", "TWITTER_2", "GITHUB_3", "REDDIT_4", "COINBASE_5", "HACKERNEWS_6", "GENERIC_WEB_SITE_1000", "DNS_1001", "ROOTER_100001" ]
   }, {
+    "type" : "record",
+    "name" : "TrackToken",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
     "type" : "enum",
     "name" : "TrackDiffType",
     "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8", "NEW_ELDEST_9" ]
@@ -337,7 +342,7 @@
       "type" : "IdentifyOutcome"
     }, {
       "name" : "trackToken",
-      "type" : "string"
+      "type" : "TrackToken"
     } ]
   }, {
     "type" : "record",
@@ -361,11 +366,6 @@
       "name" : "mTime",
       "type" : "Time"
     } ]
-  }, {
-    "type" : "record",
-    "name" : "TrackToken",
-    "fields" : [ ],
-    "typedef" : "string"
   }, {
     "type" : "enum",
     "name" : "IdentifySource",

--- a/protocol/json/identify.json
+++ b/protocol/json/identify.json
@@ -163,6 +163,50 @@
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
     "type" : "enum",
     "name" : "ProofState",
     "symbols" : [ "NONE_0", "OK_1", "TEMP_FAILURE_2", "PERM_FAILURE_3", "LOOKING_4", "SUPERSEDED_5", "POSTED_6", "REVOKED_7" ]
@@ -318,9 +362,21 @@
       "type" : "Time"
     } ]
   }, {
+    "type" : "record",
+    "name" : "TrackToken",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
     "type" : "enum",
     "name" : "IdentifySource",
     "symbols" : [ "CLI_0", "KBFS_1" ]
+  }, {
+    "type" : "record",
+    "name" : "Identify2Res",
+    "fields" : [ {
+      "name" : "upk",
+      "type" : "UserPlusKeys"
+    } ]
   } ],
   "messages" : {
     "identify" : {
@@ -351,6 +407,26 @@
         "type" : "IdentifySource"
       } ],
       "response" : "IdentifyRes"
+    },
+    "identify2" : {
+      "request" : [ {
+        "name" : "sessionID",
+        "type" : "int"
+      }, {
+        "name" : "uid",
+        "type" : "UID"
+      }, {
+        "name" : "userAssertion",
+        "type" : "string"
+      }, {
+        "name" : "reason",
+        "type" : "IdentifyReason"
+      }, {
+        "name" : "useDelegateUI",
+        "type" : "boolean",
+        "default" : false
+      } ],
+      "response" : "Identify2Res"
     }
   }
 }

--- a/protocol/json/identify_ui.json
+++ b/protocol/json/identify_ui.json
@@ -502,6 +502,40 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "UserCard",
+    "fields" : [ {
+      "name" : "following",
+      "type" : "int"
+    }, {
+      "name" : "followers",
+      "type" : "int"
+    }, {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "fullName",
+      "type" : "string"
+    }, {
+      "name" : "location",
+      "type" : "string"
+    }, {
+      "name" : "bio",
+      "type" : "string"
+    }, {
+      "name" : "website",
+      "type" : "string"
+    }, {
+      "name" : "twitter",
+      "type" : "string"
+    }, {
+      "name" : "youFollowThem",
+      "type" : "boolean"
+    }, {
+      "name" : "theyFollowYou",
+      "type" : "boolean"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "ConfirmResult",
     "fields" : [ {
       "name" : "identityConfirmed",
@@ -612,6 +646,16 @@
       }, {
         "name" : "trackToken",
         "type" : "TrackToken"
+      } ],
+      "response" : "null"
+    },
+    "displayUserCard" : {
+      "request" : [ {
+        "name" : "sessionID",
+        "type" : "int"
+      }, {
+        "name" : "card",
+        "type" : "UserCard"
       } ],
       "response" : "null"
     },

--- a/protocol/json/identify_ui.json
+++ b/protocol/json/identify_ui.json
@@ -163,6 +163,50 @@
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
     "type" : "enum",
     "name" : "ProofState",
     "symbols" : [ "NONE_0", "OK_1", "TEMP_FAILURE_2", "PERM_FAILURE_3", "LOOKING_4", "SUPERSEDED_5", "POSTED_6", "REVOKED_7" ]
@@ -319,6 +363,11 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "TrackToken",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
+    "type" : "record",
     "name" : "ProofResult",
     "fields" : [ {
       "name" : "state",
@@ -453,40 +502,6 @@
     } ]
   }, {
     "type" : "record",
-    "name" : "UserCard",
-    "fields" : [ {
-      "name" : "following",
-      "type" : "int"
-    }, {
-      "name" : "followers",
-      "type" : "int"
-    }, {
-      "name" : "uid",
-      "type" : "UID"
-    }, {
-      "name" : "fullName",
-      "type" : "string"
-    }, {
-      "name" : "location",
-      "type" : "string"
-    }, {
-      "name" : "bio",
-      "type" : "string"
-    }, {
-      "name" : "website",
-      "type" : "string"
-    }, {
-      "name" : "twitter",
-      "type" : "string"
-    }, {
-      "name" : "youFollowThem",
-      "type" : "boolean"
-    }, {
-      "name" : "theyFollowYou",
-      "type" : "boolean"
-    } ]
-  }, {
-    "type" : "record",
     "name" : "ConfirmResult",
     "fields" : [ {
       "name" : "identityConfirmed",
@@ -597,16 +612,6 @@
       }, {
         "name" : "trackToken",
         "type" : "string"
-      } ],
-      "response" : "null"
-    },
-    "displayUserCard" : {
-      "request" : [ {
-        "name" : "sessionID",
-        "type" : "int"
-      }, {
-        "name" : "card",
-        "type" : "UserCard"
       } ],
       "response" : "null"
     },

--- a/protocol/json/identify_ui.json
+++ b/protocol/json/identify_ui.json
@@ -220,6 +220,11 @@
     "name" : "ProofType",
     "symbols" : [ "NONE_0", "KEYBASE_1", "TWITTER_2", "GITHUB_3", "REDDIT_4", "COINBASE_5", "HACKERNEWS_6", "GENERIC_WEB_SITE_1000", "DNS_1001", "ROOTER_100001" ]
   }, {
+    "type" : "record",
+    "name" : "TrackToken",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
     "type" : "enum",
     "name" : "TrackDiffType",
     "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8", "NEW_ELDEST_9" ]
@@ -337,7 +342,7 @@
       "type" : "IdentifyOutcome"
     }, {
       "name" : "trackToken",
-      "type" : "string"
+      "type" : "TrackToken"
     } ]
   }, {
     "type" : "record",
@@ -361,11 +366,6 @@
       "name" : "mTime",
       "type" : "Time"
     } ]
-  }, {
-    "type" : "record",
-    "name" : "TrackToken",
-    "fields" : [ ],
-    "typedef" : "string"
   }, {
     "type" : "record",
     "name" : "ProofResult",
@@ -611,7 +611,7 @@
         "type" : "int"
       }, {
         "name" : "trackToken",
-        "type" : "string"
+        "type" : "TrackToken"
       } ],
       "response" : "null"
     },

--- a/protocol/json/kbcmf.json
+++ b/protocol/json/kbcmf.json
@@ -220,6 +220,11 @@
     "name" : "ProofType",
     "symbols" : [ "NONE_0", "KEYBASE_1", "TWITTER_2", "GITHUB_3", "REDDIT_4", "COINBASE_5", "HACKERNEWS_6", "GENERIC_WEB_SITE_1000", "DNS_1001", "ROOTER_100001" ]
   }, {
+    "type" : "record",
+    "name" : "TrackToken",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
     "type" : "enum",
     "name" : "TrackDiffType",
     "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8", "NEW_ELDEST_9" ]
@@ -337,7 +342,7 @@
       "type" : "IdentifyOutcome"
     }, {
       "name" : "trackToken",
-      "type" : "string"
+      "type" : "TrackToken"
     } ]
   }, {
     "type" : "record",
@@ -361,11 +366,6 @@
       "name" : "mTime",
       "type" : "Time"
     } ]
-  }, {
-    "type" : "record",
-    "name" : "TrackToken",
-    "fields" : [ ],
-    "typedef" : "string"
   }, {
     "type" : "record",
     "name" : "KBCMFEncryptOptions",

--- a/protocol/json/kbcmf.json
+++ b/protocol/json/kbcmf.json
@@ -163,6 +163,50 @@
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
     "type" : "enum",
     "name" : "ProofState",
     "symbols" : [ "NONE_0", "OK_1", "TEMP_FAILURE_2", "PERM_FAILURE_3", "LOOKING_4", "SUPERSEDED_5", "POSTED_6", "REVOKED_7" ]
@@ -317,6 +361,11 @@
       "name" : "mTime",
       "type" : "Time"
     } ]
+  }, {
+    "type" : "record",
+    "name" : "TrackToken",
+    "fields" : [ ],
+    "typedef" : "string"
   }, {
     "type" : "record",
     "name" : "KBCMFEncryptOptions",

--- a/protocol/json/kex2provisionee.json
+++ b/protocol/json/kex2provisionee.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "PassphraseStream",
     "fields" : [ {
       "name" : "passphraseStream",

--- a/protocol/json/log_ui.json
+++ b/protocol/json/log_ui.json
@@ -162,6 +162,50 @@
     "type" : "enum",
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
+  }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
   } ],
   "messages" : {
     "log" : {

--- a/protocol/json/login.json
+++ b/protocol/json/login.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "ConfiguredAccount",
     "fields" : [ {
       "name" : "username",

--- a/protocol/json/login_ui.json
+++ b/protocol/json/login_ui.json
@@ -162,6 +162,50 @@
     "type" : "enum",
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
+  }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
   } ],
   "messages" : {
     "getEmailOrUsername" : {

--- a/protocol/json/metadata.json
+++ b/protocol/json/metadata.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "BlockIdCombo",
     "fields" : [ {
       "name" : "blockHash",

--- a/protocol/json/metadata_update.json
+++ b/protocol/json/metadata_update.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "BlockIdCombo",
     "fields" : [ {
       "name" : "blockHash",

--- a/protocol/json/notify_ctl.json
+++ b/protocol/json/notify_ctl.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "NotificationChannels",
     "fields" : [ {
       "name" : "session",

--- a/protocol/json/notify_users.json
+++ b/protocol/json/notify_users.json
@@ -162,6 +162,50 @@
     "type" : "enum",
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
+  }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
   } ],
   "messages" : {
     "userChanged" : {

--- a/protocol/json/pgp.json
+++ b/protocol/json/pgp.json
@@ -220,6 +220,11 @@
     "name" : "ProofType",
     "symbols" : [ "NONE_0", "KEYBASE_1", "TWITTER_2", "GITHUB_3", "REDDIT_4", "COINBASE_5", "HACKERNEWS_6", "GENERIC_WEB_SITE_1000", "DNS_1001", "ROOTER_100001" ]
   }, {
+    "type" : "record",
+    "name" : "TrackToken",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
     "type" : "enum",
     "name" : "TrackDiffType",
     "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8", "NEW_ELDEST_9" ]
@@ -337,7 +342,7 @@
       "type" : "IdentifyOutcome"
     }, {
       "name" : "trackToken",
-      "type" : "string"
+      "type" : "TrackToken"
     } ]
   }, {
     "type" : "record",
@@ -361,11 +366,6 @@
       "name" : "mTime",
       "type" : "Time"
     } ]
-  }, {
-    "type" : "record",
-    "name" : "TrackToken",
-    "fields" : [ ],
-    "typedef" : "string"
   }, {
     "type" : "enum",
     "name" : "SignMode",

--- a/protocol/json/pgp.json
+++ b/protocol/json/pgp.json
@@ -408,6 +408,9 @@
       "name" : "keyQuery",
       "type" : "string"
     }, {
+      "name" : "skipTrack",
+      "type" : "boolean"
+    }, {
       "name" : "trackOptions",
       "type" : "TrackOptions"
     } ]
@@ -437,9 +440,6 @@
     }, {
       "name" : "signedBy",
       "type" : "string"
-    }, {
-      "name" : "trackOptions",
-      "type" : "TrackOptions"
     } ]
   }, {
     "type" : "record",
@@ -447,9 +447,6 @@
     "fields" : [ {
       "name" : "signedBy",
       "type" : "string"
-    }, {
-      "name" : "trackOptions",
-      "type" : "TrackOptions"
     }, {
       "name" : "signature",
       "type" : "bytes"

--- a/protocol/json/pgp.json
+++ b/protocol/json/pgp.json
@@ -163,6 +163,50 @@
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
     "type" : "enum",
     "name" : "ProofState",
     "symbols" : [ "NONE_0", "OK_1", "TEMP_FAILURE_2", "PERM_FAILURE_3", "LOOKING_4", "SUPERSEDED_5", "POSTED_6", "REVOKED_7" ]
@@ -318,6 +362,11 @@
       "type" : "Time"
     } ]
   }, {
+    "type" : "record",
+    "name" : "TrackToken",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
     "type" : "enum",
     "name" : "SignMode",
     "symbols" : [ "ATTACHED_0", "DETACHED_1", "CLEAR_2" ]
@@ -359,9 +408,6 @@
       "name" : "keyQuery",
       "type" : "string"
     }, {
-      "name" : "skipTrack",
-      "type" : "boolean"
-    }, {
       "name" : "trackOptions",
       "type" : "TrackOptions"
     } ]
@@ -391,6 +437,9 @@
     }, {
       "name" : "signedBy",
       "type" : "string"
+    }, {
+      "name" : "trackOptions",
+      "type" : "TrackOptions"
     } ]
   }, {
     "type" : "record",
@@ -398,6 +447,9 @@
     "fields" : [ {
       "name" : "signedBy",
       "type" : "string"
+    }, {
+      "name" : "trackOptions",
+      "type" : "TrackOptions"
     }, {
       "name" : "signature",
       "type" : "bytes"

--- a/protocol/json/pgp_ui.json
+++ b/protocol/json/pgp_ui.json
@@ -162,6 +162,50 @@
     "type" : "enum",
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
+  }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
   } ],
   "messages" : {
     "outputSignatureSuccess" : {

--- a/protocol/json/prove.json
+++ b/protocol/json/prove.json
@@ -163,6 +163,50 @@
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
     "type" : "enum",
     "name" : "ProofState",
     "symbols" : [ "NONE_0", "OK_1", "TEMP_FAILURE_2", "PERM_FAILURE_3", "LOOKING_4", "SUPERSEDED_5", "POSTED_6", "REVOKED_7" ]
@@ -317,6 +361,11 @@
       "name" : "mTime",
       "type" : "Time"
     } ]
+  }, {
+    "type" : "record",
+    "name" : "TrackToken",
+    "fields" : [ ],
+    "typedef" : "string"
   }, {
     "type" : "record",
     "name" : "CheckProofStatus",

--- a/protocol/json/prove.json
+++ b/protocol/json/prove.json
@@ -220,6 +220,11 @@
     "name" : "ProofType",
     "symbols" : [ "NONE_0", "KEYBASE_1", "TWITTER_2", "GITHUB_3", "REDDIT_4", "COINBASE_5", "HACKERNEWS_6", "GENERIC_WEB_SITE_1000", "DNS_1001", "ROOTER_100001" ]
   }, {
+    "type" : "record",
+    "name" : "TrackToken",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
     "type" : "enum",
     "name" : "TrackDiffType",
     "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8", "NEW_ELDEST_9" ]
@@ -337,7 +342,7 @@
       "type" : "IdentifyOutcome"
     }, {
       "name" : "trackToken",
-      "type" : "string"
+      "type" : "TrackToken"
     } ]
   }, {
     "type" : "record",
@@ -361,11 +366,6 @@
       "name" : "mTime",
       "type" : "Time"
     } ]
-  }, {
-    "type" : "record",
-    "name" : "TrackToken",
-    "fields" : [ ],
-    "typedef" : "string"
   }, {
     "type" : "record",
     "name" : "CheckProofStatus",

--- a/protocol/json/prove_ui.json
+++ b/protocol/json/prove_ui.json
@@ -163,6 +163,50 @@
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
     "type" : "enum",
     "name" : "PromptOverwriteType",
     "symbols" : [ "SOCIAL_0", "SITE_1" ]

--- a/protocol/json/provision_ui.json
+++ b/protocol/json/provision_ui.json
@@ -163,6 +163,50 @@
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
     "type" : "enum",
     "name" : "ProvisionMethod",
     "symbols" : [ "DEVICE_0", "PAPER_KEY_1", "PASSPHRASE_2", "GPG_IMPORT_3", "GPG_SIGN_4" ]

--- a/protocol/json/quota.json
+++ b/protocol/json/quota.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "VerifySessionRes",
     "fields" : [ {
       "name" : "uid",

--- a/protocol/json/revoke.json
+++ b/protocol/json/revoke.json
@@ -162,6 +162,50 @@
     "type" : "enum",
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
+  }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
   } ],
   "messages" : {
     "revokeKey" : {

--- a/protocol/json/secret_ui.json
+++ b/protocol/json/secret_ui.json
@@ -256,9 +256,15 @@
     } ]
   }, {
     "type" : "record",
-    "name" : "SecretStorageFeature",
+    "name" : "Feature",
     "fields" : [ {
       "name" : "allow",
+      "type" : "boolean"
+    }, {
+      "name" : "defaultValue",
+      "type" : "boolean"
+    }, {
+      "name" : "readonly",
       "type" : "boolean"
     }, {
       "name" : "label",
@@ -268,8 +274,11 @@
     "type" : "record",
     "name" : "GUIEntryFeatures",
     "fields" : [ {
-      "name" : "secretStorage",
-      "type" : "SecretStorageFeature"
+      "name" : "storeSecret",
+      "type" : "Feature"
+    }, {
+      "name" : "showTyping",
+      "type" : "Feature"
     } ]
   }, {
     "type" : "record",
@@ -279,6 +288,12 @@
       "type" : "string"
     }, {
       "name" : "prompt",
+      "type" : "string"
+    }, {
+      "name" : "submitLabel",
+      "type" : "string"
+    }, {
+      "name" : "cancelLabel",
       "type" : "string"
     }, {
       "name" : "retryLabel",

--- a/protocol/json/secret_ui.json
+++ b/protocol/json/secret_ui.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "SecretEntryArg",
     "fields" : [ {
       "name" : "desc",
@@ -212,15 +256,9 @@
     } ]
   }, {
     "type" : "record",
-    "name" : "Feature",
+    "name" : "SecretStorageFeature",
     "fields" : [ {
       "name" : "allow",
-      "type" : "boolean"
-    }, {
-      "name" : "defaultValue",
-      "type" : "boolean"
-    }, {
-      "name" : "readonly",
       "type" : "boolean"
     }, {
       "name" : "label",
@@ -230,11 +268,8 @@
     "type" : "record",
     "name" : "GUIEntryFeatures",
     "fields" : [ {
-      "name" : "storeSecret",
-      "type" : "Feature"
-    }, {
-      "name" : "showTyping",
-      "type" : "Feature"
+      "name" : "secretStorage",
+      "type" : "SecretStorageFeature"
     } ]
   }, {
     "type" : "record",
@@ -244,12 +279,6 @@
       "type" : "string"
     }, {
       "name" : "prompt",
-      "type" : "string"
-    }, {
-      "name" : "submitLabel",
-      "type" : "string"
-    }, {
-      "name" : "cancelLabel",
       "type" : "string"
     }, {
       "name" : "retryLabel",

--- a/protocol/json/session.json
+++ b/protocol/json/session.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "Session",
     "fields" : [ {
       "name" : "uid",

--- a/protocol/json/signup.json
+++ b/protocol/json/signup.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "SignupRes",
     "fields" : [ {
       "name" : "passphraseOk",

--- a/protocol/json/sigs.json
+++ b/protocol/json/sigs.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "Sig",
     "fields" : [ {
       "name" : "seqno",

--- a/protocol/json/stream_ui.json
+++ b/protocol/json/stream_ui.json
@@ -162,6 +162,50 @@
     "type" : "enum",
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
+  }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
   } ],
   "messages" : {
     "close" : {

--- a/protocol/json/track.json
+++ b/protocol/json/track.json
@@ -163,6 +163,50 @@
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
     "type" : "enum",
     "name" : "ProofState",
     "symbols" : [ "NONE_0", "OK_1", "TEMP_FAILURE_2", "PERM_FAILURE_3", "LOOKING_4", "SUPERSEDED_5", "POSTED_6", "REVOKED_7" ]
@@ -317,6 +361,11 @@
       "name" : "mTime",
       "type" : "Time"
     } ]
+  }, {
+    "type" : "record",
+    "name" : "TrackToken",
+    "fields" : [ ],
+    "typedef" : "string"
   } ],
   "messages" : {
     "track" : {

--- a/protocol/json/track.json
+++ b/protocol/json/track.json
@@ -220,6 +220,11 @@
     "name" : "ProofType",
     "symbols" : [ "NONE_0", "KEYBASE_1", "TWITTER_2", "GITHUB_3", "REDDIT_4", "COINBASE_5", "HACKERNEWS_6", "GENERIC_WEB_SITE_1000", "DNS_1001", "ROOTER_100001" ]
   }, {
+    "type" : "record",
+    "name" : "TrackToken",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
     "type" : "enum",
     "name" : "TrackDiffType",
     "symbols" : [ "NONE_0", "ERROR_1", "CLASH_2", "REVOKED_3", "UPGRADED_4", "NEW_5", "REMOTE_FAIL_6", "REMOTE_WORKING_7", "REMOTE_CHANGED_8", "NEW_ELDEST_9" ]
@@ -337,7 +342,7 @@
       "type" : "IdentifyOutcome"
     }, {
       "name" : "trackToken",
-      "type" : "string"
+      "type" : "TrackToken"
     } ]
   }, {
     "type" : "record",
@@ -361,11 +366,6 @@
       "name" : "mTime",
       "type" : "Time"
     } ]
-  }, {
-    "type" : "record",
-    "name" : "TrackToken",
-    "fields" : [ ],
-    "typedef" : "string"
   } ],
   "messages" : {
     "track" : {
@@ -392,7 +392,7 @@
         "type" : "int"
       }, {
         "name" : "trackToken",
-        "type" : "string"
+        "type" : "TrackToken"
       }, {
         "name" : "options",
         "type" : "TrackOptions"

--- a/protocol/json/ui.json
+++ b/protocol/json/ui.json
@@ -163,6 +163,50 @@
     "name" : "ClientType",
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
     "type" : "enum",
     "name" : "PromptDefault",
     "symbols" : [ "NONE_0", "YES_1", "NO_2" ]

--- a/protocol/json/user.json
+++ b/protocol/json/user.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "Tracker",
     "fields" : [ {
       "name" : "tracker",
@@ -253,22 +297,6 @@
     }, {
       "name" : "trackTime",
       "type" : "Time"
-    } ]
-  }, {
-    "type" : "record",
-    "name" : "UserPlusKeys",
-    "fields" : [ {
-      "name" : "uid",
-      "type" : "UID"
-    }, {
-      "name" : "username",
-      "type" : "string"
-    }, {
-      "name" : "deviceKeys",
-      "type" : {
-        "type" : "array",
-        "items" : "PublicKey"
-      }
     } ]
   }, {
     "type" : "record",

--- a/react-native/react/constants/types/flow-types.js
+++ b/react-native/react/constants/types/flow-types.js
@@ -148,6 +148,38 @@ export type block_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
 export type ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type block_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type block_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
+export type UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type block_BlockIdCombo = {
   blockHash: string;
   chargedTo: UID;
@@ -253,6 +285,22 @@ export type BTC_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' 
 
 export type BTC_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type BTC_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type BTC_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type config_Time = {
 }
 
@@ -325,6 +373,22 @@ export type config_Stream = {
 export type config_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type config_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type config_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type config_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type config_GetCurrentStatusRes = {
   configured: boolean;
@@ -459,6 +523,22 @@ export type ctl_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' 
 
 export type ctl_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type ctl_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type ctl_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type ctl_ExitCode = 0 /* 'OK_0' */ | 1 /* 'NOTOK_2' */ | 2 /* 'RESTART_4' */
 
 export type ExitCode = 0 /* 'OK_0' */ | 1 /* 'NOTOK_2' */ | 2 /* 'RESTART_4' */
@@ -544,6 +624,22 @@ export type delegateUiCtl_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /*
 
 export type delegateUiCtl_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type delegateUiCtl_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type delegateUiCtl_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type device_Time = {
 }
 
@@ -617,6 +713,22 @@ export type device_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_
 
 export type device_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type device_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type device_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type favorite_Time = {
 }
 
@@ -689,6 +801,22 @@ export type favorite_Stream = {
 export type favorite_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type favorite_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type favorite_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type favorite_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type favorite_Folder = {
   name: string;
@@ -774,6 +902,22 @@ export type gpgUi_Stream = {
 export type gpgUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type gpgUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type gpgUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type gpgUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type gpgUi_GPGKey = {
   algorithm: string;
@@ -874,6 +1018,22 @@ export type identify_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INF
 
 export type identify_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type identify_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type identify_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type identify_ProofState = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'TEMP_FAILURE_2' */ | 3 /* 'PERM_FAILURE_3' */ | 4 /* 'LOOKING_4' */ | 5 /* 'SUPERSEDED_5' */ | 6 /* 'POSTED_6' */ | 7 /* 'REVOKED_7' */
 
 export type ProofState = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'TEMP_FAILURE_2' */ | 3 /* 'PERM_FAILURE_3' */ | 4 /* 'LOOKING_4' */ | 5 /* 'SUPERSEDED_5' */ | 6 /* 'POSTED_6' */ | 7 /* 'REVOKED_7' */
@@ -885,6 +1045,12 @@ export type ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_2' */ 
 export type identify_ProofType = 0 /* 'NONE_0' */ | 1 /* 'KEYBASE_1' */ | 2 /* 'TWITTER_2' */ | 3 /* 'GITHUB_3' */ | 4 /* 'REDDIT_4' */ | 5 /* 'COINBASE_5' */ | 6 /* 'HACKERNEWS_6' */ | 7 /* 'GENERIC_WEB_SITE_1000' */ | 8 /* 'DNS_1001' */ | 9 /* 'ROOTER_100001' */
 
 export type ProofType = 0 /* 'NONE_0' */ | 1 /* 'KEYBASE_1' */ | 2 /* 'TWITTER_2' */ | 3 /* 'GITHUB_3' */ | 4 /* 'REDDIT_4' */ | 5 /* 'COINBASE_5' */ | 6 /* 'HACKERNEWS_6' */ | 7 /* 'GENERIC_WEB_SITE_1000' */ | 8 /* 'DNS_1001' */ | 9 /* 'ROOTER_100001' */
+
+export type identify_TrackToken = {
+}
+
+export type TrackToken = {
+}
 
 export type identify_TrackDiffType = 0 /* 'NONE_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'CLASH_2' */ | 3 /* 'REVOKED_3' */ | 4 /* 'UPGRADED_4' */ | 5 /* 'NEW_5' */ | 6 /* 'REMOTE_FAIL_6' */ | 7 /* 'REMOTE_WORKING_7' */ | 8 /* 'REMOTE_CHANGED_8' */ | 9 /* 'NEW_ELDEST_9' */
 
@@ -972,14 +1138,14 @@ export type identify_IdentifyRes = {
   user?: ?User;
   publicKeys: Array<PublicKey>;
   outcome: IdentifyOutcome;
-  trackToken: string;
+  trackToken: TrackToken;
 }
 
 export type IdentifyRes = {
   user?: ?User;
   publicKeys: Array<PublicKey>;
   outcome: IdentifyOutcome;
-  trackToken: string;
+  trackToken: TrackToken;
 }
 
 export type identify_RemoteProof = {
@@ -1003,6 +1169,14 @@ export type RemoteProof = {
 export type identify_IdentifySource = 0 /* 'CLI_0' */ | 1 /* 'KBFS_1' */
 
 export type IdentifySource = 0 /* 'CLI_0' */ | 1 /* 'KBFS_1' */
+
+export type identify_Identify2Res = {
+  upk: UserPlusKeys;
+}
+
+export type Identify2Res = {
+  upk: UserPlusKeys;
+}
 
 export type identifyUi_Time = {
 }
@@ -1077,11 +1251,30 @@ export type identifyUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'I
 
 export type identifyUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type identifyUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type identifyUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type identifyUi_ProofState = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'TEMP_FAILURE_2' */ | 3 /* 'PERM_FAILURE_3' */ | 4 /* 'LOOKING_4' */ | 5 /* 'SUPERSEDED_5' */ | 6 /* 'POSTED_6' */ | 7 /* 'REVOKED_7' */
 
 export type identifyUi_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_2' */ | 3 /* 'FOUND_3' */ | 4 /* 'BASE_ERROR_100' */ | 5 /* 'HOST_UNREACHABLE_101' */ | 6 /* 'PERMISSION_DENIED_103' */ | 7 /* 'FAILED_PARSE_106' */ | 8 /* 'DNS_ERROR_107' */ | 9 /* 'AUTH_FAILED_108' */ | 10 /* 'HTTP_500_150' */ | 11 /* 'TIMEOUT_160' */ | 12 /* 'INTERNAL_ERROR_170' */ | 13 /* 'BASE_HARD_ERROR_200' */ | 14 /* 'NOT_FOUND_201' */ | 15 /* 'CONTENT_FAILURE_202' */ | 16 /* 'BAD_USERNAME_203' */ | 17 /* 'BAD_REMOTE_ID_204' */ | 18 /* 'TEXT_NOT_FOUND_205' */ | 19 /* 'BAD_ARGS_206' */ | 20 /* 'CONTENT_MISSING_207' */ | 21 /* 'TITLE_NOT_FOUND_208' */ | 22 /* 'SERVICE_ERROR_209' */ | 23 /* 'TOR_SKIPPED_210' */ | 24 /* 'TOR_INCOMPATIBLE_211' */ | 25 /* 'HTTP_300_230' */ | 26 /* 'HTTP_400_240' */ | 27 /* 'HTTP_OTHER_260' */ | 28 /* 'EMPTY_JSON_270' */ | 29 /* 'DELETED_301' */ | 30 /* 'SERVICE_DEAD_302' */ | 31 /* 'BAD_SIGNATURE_303' */ | 32 /* 'BAD_API_URL_304' */ | 33 /* 'UNKNOWN_TYPE_305' */ | 34 /* 'NO_HINT_306' */ | 35 /* 'BAD_HINT_TEXT_307' */
 
 export type identifyUi_ProofType = 0 /* 'NONE_0' */ | 1 /* 'KEYBASE_1' */ | 2 /* 'TWITTER_2' */ | 3 /* 'GITHUB_3' */ | 4 /* 'REDDIT_4' */ | 5 /* 'COINBASE_5' */ | 6 /* 'HACKERNEWS_6' */ | 7 /* 'GENERIC_WEB_SITE_1000' */ | 8 /* 'DNS_1001' */ | 9 /* 'ROOTER_100001' */
+
+export type identifyUi_TrackToken = {
+}
 
 export type identifyUi_TrackDiffType = 0 /* 'NONE_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'CLASH_2' */ | 3 /* 'REVOKED_3' */ | 4 /* 'UPGRADED_4' */ | 5 /* 'NEW_5' */ | 6 /* 'REMOTE_FAIL_6' */ | 7 /* 'REMOTE_WORKING_7' */ | 8 /* 'REMOTE_CHANGED_8' */ | 9 /* 'NEW_ELDEST_9' */
 
@@ -1128,7 +1321,7 @@ export type identifyUi_IdentifyRes = {
   user?: ?User;
   publicKeys: Array<PublicKey>;
   outcome: IdentifyOutcome;
-  trackToken: string;
+  trackToken: TrackToken;
 }
 
 export type identifyUi_RemoteProof = {
@@ -1518,11 +1711,30 @@ export type kbcmf_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2
 
 export type kbcmf_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type kbcmf_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type kbcmf_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type kbcmf_ProofState = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'TEMP_FAILURE_2' */ | 3 /* 'PERM_FAILURE_3' */ | 4 /* 'LOOKING_4' */ | 5 /* 'SUPERSEDED_5' */ | 6 /* 'POSTED_6' */ | 7 /* 'REVOKED_7' */
 
 export type kbcmf_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_2' */ | 3 /* 'FOUND_3' */ | 4 /* 'BASE_ERROR_100' */ | 5 /* 'HOST_UNREACHABLE_101' */ | 6 /* 'PERMISSION_DENIED_103' */ | 7 /* 'FAILED_PARSE_106' */ | 8 /* 'DNS_ERROR_107' */ | 9 /* 'AUTH_FAILED_108' */ | 10 /* 'HTTP_500_150' */ | 11 /* 'TIMEOUT_160' */ | 12 /* 'INTERNAL_ERROR_170' */ | 13 /* 'BASE_HARD_ERROR_200' */ | 14 /* 'NOT_FOUND_201' */ | 15 /* 'CONTENT_FAILURE_202' */ | 16 /* 'BAD_USERNAME_203' */ | 17 /* 'BAD_REMOTE_ID_204' */ | 18 /* 'TEXT_NOT_FOUND_205' */ | 19 /* 'BAD_ARGS_206' */ | 20 /* 'CONTENT_MISSING_207' */ | 21 /* 'TITLE_NOT_FOUND_208' */ | 22 /* 'SERVICE_ERROR_209' */ | 23 /* 'TOR_SKIPPED_210' */ | 24 /* 'TOR_INCOMPATIBLE_211' */ | 25 /* 'HTTP_300_230' */ | 26 /* 'HTTP_400_240' */ | 27 /* 'HTTP_OTHER_260' */ | 28 /* 'EMPTY_JSON_270' */ | 29 /* 'DELETED_301' */ | 30 /* 'SERVICE_DEAD_302' */ | 31 /* 'BAD_SIGNATURE_303' */ | 32 /* 'BAD_API_URL_304' */ | 33 /* 'UNKNOWN_TYPE_305' */ | 34 /* 'NO_HINT_306' */ | 35 /* 'BAD_HINT_TEXT_307' */
 
 export type kbcmf_ProofType = 0 /* 'NONE_0' */ | 1 /* 'KEYBASE_1' */ | 2 /* 'TWITTER_2' */ | 3 /* 'GITHUB_3' */ | 4 /* 'REDDIT_4' */ | 5 /* 'COINBASE_5' */ | 6 /* 'HACKERNEWS_6' */ | 7 /* 'GENERIC_WEB_SITE_1000' */ | 8 /* 'DNS_1001' */ | 9 /* 'ROOTER_100001' */
+
+export type kbcmf_TrackToken = {
+}
 
 export type kbcmf_TrackDiffType = 0 /* 'NONE_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'CLASH_2' */ | 3 /* 'REVOKED_3' */ | 4 /* 'UPGRADED_4' */ | 5 /* 'NEW_5' */ | 6 /* 'REMOTE_FAIL_6' */ | 7 /* 'REMOTE_WORKING_7' */ | 8 /* 'REMOTE_CHANGED_8' */ | 9 /* 'NEW_ELDEST_9' */
 
@@ -1569,7 +1781,7 @@ export type kbcmf_IdentifyRes = {
   user?: ?User;
   publicKeys: Array<PublicKey>;
   outcome: IdentifyOutcome;
-  trackToken: string;
+  trackToken: TrackToken;
 }
 
 export type kbcmf_RemoteProof = {
@@ -1688,6 +1900,22 @@ export type Kex2Provisionee_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 
 
 export type Kex2Provisionee_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type Kex2Provisionee_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type Kex2Provisionee_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type Kex2Provisionee_PassphraseStream = {
   passphraseStream: bytes;
   generation: int;
@@ -1789,6 +2017,22 @@ export type logUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2
 
 export type logUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type logUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type logUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type login_Time = {
 }
 
@@ -1861,6 +2105,22 @@ export type login_Stream = {
 export type login_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type login_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type login_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type login_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type login_ConfiguredAccount = {
   username: string;
@@ -1945,6 +2205,22 @@ export type loginUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO
 
 export type loginUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type loginUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type loginUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type metadata_Time = {
 }
 
@@ -2017,6 +2293,22 @@ export type metadata_Stream = {
 export type metadata_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type metadata_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type metadata_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type metadata_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type metadata_BlockIdCombo = {
   blockHash: string;
@@ -2118,6 +2410,22 @@ export type metadataUpdate_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /
 
 export type metadataUpdate_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type metadataUpdate_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type metadataUpdate_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type metadataUpdate_BlockIdCombo = {
   blockHash: string;
   chargedTo: UID;
@@ -2195,6 +2503,22 @@ export type notifyCtl_Stream = {
 export type notifyCtl_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type notifyCtl_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type notifyCtl_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type notifyCtl_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type notifyCtl_NotificationChannels = {
   session: boolean;
@@ -2293,6 +2617,22 @@ export type NotifyUsers_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* '
 
 export type NotifyUsers_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type NotifyUsers_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type NotifyUsers_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type pgp_Time = {
 }
 
@@ -2366,11 +2706,30 @@ export type pgp_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' 
 
 export type pgp_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type pgp_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type pgp_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type pgp_ProofState = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'TEMP_FAILURE_2' */ | 3 /* 'PERM_FAILURE_3' */ | 4 /* 'LOOKING_4' */ | 5 /* 'SUPERSEDED_5' */ | 6 /* 'POSTED_6' */ | 7 /* 'REVOKED_7' */
 
 export type pgp_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_2' */ | 3 /* 'FOUND_3' */ | 4 /* 'BASE_ERROR_100' */ | 5 /* 'HOST_UNREACHABLE_101' */ | 6 /* 'PERMISSION_DENIED_103' */ | 7 /* 'FAILED_PARSE_106' */ | 8 /* 'DNS_ERROR_107' */ | 9 /* 'AUTH_FAILED_108' */ | 10 /* 'HTTP_500_150' */ | 11 /* 'TIMEOUT_160' */ | 12 /* 'INTERNAL_ERROR_170' */ | 13 /* 'BASE_HARD_ERROR_200' */ | 14 /* 'NOT_FOUND_201' */ | 15 /* 'CONTENT_FAILURE_202' */ | 16 /* 'BAD_USERNAME_203' */ | 17 /* 'BAD_REMOTE_ID_204' */ | 18 /* 'TEXT_NOT_FOUND_205' */ | 19 /* 'BAD_ARGS_206' */ | 20 /* 'CONTENT_MISSING_207' */ | 21 /* 'TITLE_NOT_FOUND_208' */ | 22 /* 'SERVICE_ERROR_209' */ | 23 /* 'TOR_SKIPPED_210' */ | 24 /* 'TOR_INCOMPATIBLE_211' */ | 25 /* 'HTTP_300_230' */ | 26 /* 'HTTP_400_240' */ | 27 /* 'HTTP_OTHER_260' */ | 28 /* 'EMPTY_JSON_270' */ | 29 /* 'DELETED_301' */ | 30 /* 'SERVICE_DEAD_302' */ | 31 /* 'BAD_SIGNATURE_303' */ | 32 /* 'BAD_API_URL_304' */ | 33 /* 'UNKNOWN_TYPE_305' */ | 34 /* 'NO_HINT_306' */ | 35 /* 'BAD_HINT_TEXT_307' */
 
 export type pgp_ProofType = 0 /* 'NONE_0' */ | 1 /* 'KEYBASE_1' */ | 2 /* 'TWITTER_2' */ | 3 /* 'GITHUB_3' */ | 4 /* 'REDDIT_4' */ | 5 /* 'COINBASE_5' */ | 6 /* 'HACKERNEWS_6' */ | 7 /* 'GENERIC_WEB_SITE_1000' */ | 8 /* 'DNS_1001' */ | 9 /* 'ROOTER_100001' */
+
+export type pgp_TrackToken = {
+}
 
 export type pgp_TrackDiffType = 0 /* 'NONE_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'CLASH_2' */ | 3 /* 'REVOKED_3' */ | 4 /* 'UPGRADED_4' */ | 5 /* 'NEW_5' */ | 6 /* 'REMOTE_FAIL_6' */ | 7 /* 'REMOTE_WORKING_7' */ | 8 /* 'REMOTE_CHANGED_8' */ | 9 /* 'NEW_ELDEST_9' */
 
@@ -2417,7 +2776,7 @@ export type pgp_IdentifyRes = {
   user?: ?User;
   publicKeys: Array<PublicKey>;
   outcome: IdentifyOutcome;
-  trackToken: string;
+  trackToken: TrackToken;
 }
 
 export type pgp_RemoteProof = {
@@ -2608,6 +2967,22 @@ export type pgpUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2
 
 export type pgpUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type pgpUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type pgpUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type prove_Time = {
 }
 
@@ -2681,11 +3056,30 @@ export type prove_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2
 
 export type prove_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type prove_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type prove_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type prove_ProofState = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'TEMP_FAILURE_2' */ | 3 /* 'PERM_FAILURE_3' */ | 4 /* 'LOOKING_4' */ | 5 /* 'SUPERSEDED_5' */ | 6 /* 'POSTED_6' */ | 7 /* 'REVOKED_7' */
 
 export type prove_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_2' */ | 3 /* 'FOUND_3' */ | 4 /* 'BASE_ERROR_100' */ | 5 /* 'HOST_UNREACHABLE_101' */ | 6 /* 'PERMISSION_DENIED_103' */ | 7 /* 'FAILED_PARSE_106' */ | 8 /* 'DNS_ERROR_107' */ | 9 /* 'AUTH_FAILED_108' */ | 10 /* 'HTTP_500_150' */ | 11 /* 'TIMEOUT_160' */ | 12 /* 'INTERNAL_ERROR_170' */ | 13 /* 'BASE_HARD_ERROR_200' */ | 14 /* 'NOT_FOUND_201' */ | 15 /* 'CONTENT_FAILURE_202' */ | 16 /* 'BAD_USERNAME_203' */ | 17 /* 'BAD_REMOTE_ID_204' */ | 18 /* 'TEXT_NOT_FOUND_205' */ | 19 /* 'BAD_ARGS_206' */ | 20 /* 'CONTENT_MISSING_207' */ | 21 /* 'TITLE_NOT_FOUND_208' */ | 22 /* 'SERVICE_ERROR_209' */ | 23 /* 'TOR_SKIPPED_210' */ | 24 /* 'TOR_INCOMPATIBLE_211' */ | 25 /* 'HTTP_300_230' */ | 26 /* 'HTTP_400_240' */ | 27 /* 'HTTP_OTHER_260' */ | 28 /* 'EMPTY_JSON_270' */ | 29 /* 'DELETED_301' */ | 30 /* 'SERVICE_DEAD_302' */ | 31 /* 'BAD_SIGNATURE_303' */ | 32 /* 'BAD_API_URL_304' */ | 33 /* 'UNKNOWN_TYPE_305' */ | 34 /* 'NO_HINT_306' */ | 35 /* 'BAD_HINT_TEXT_307' */
 
 export type prove_ProofType = 0 /* 'NONE_0' */ | 1 /* 'KEYBASE_1' */ | 2 /* 'TWITTER_2' */ | 3 /* 'GITHUB_3' */ | 4 /* 'REDDIT_4' */ | 5 /* 'COINBASE_5' */ | 6 /* 'HACKERNEWS_6' */ | 7 /* 'GENERIC_WEB_SITE_1000' */ | 8 /* 'DNS_1001' */ | 9 /* 'ROOTER_100001' */
+
+export type prove_TrackToken = {
+}
 
 export type prove_TrackDiffType = 0 /* 'NONE_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'CLASH_2' */ | 3 /* 'REVOKED_3' */ | 4 /* 'UPGRADED_4' */ | 5 /* 'NEW_5' */ | 6 /* 'REMOTE_FAIL_6' */ | 7 /* 'REMOTE_WORKING_7' */ | 8 /* 'REMOTE_CHANGED_8' */ | 9 /* 'NEW_ELDEST_9' */
 
@@ -2732,7 +3126,7 @@ export type prove_IdentifyRes = {
   user?: ?User;
   publicKeys: Array<PublicKey>;
   outcome: IdentifyOutcome;
-  trackToken: string;
+  trackToken: TrackToken;
 }
 
 export type prove_RemoteProof = {
@@ -2837,6 +3231,22 @@ export type proveUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO
 
 export type proveUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type proveUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type proveUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type proveUi_PromptOverwriteType = 0 /* 'SOCIAL_0' */ | 1 /* 'SITE_1' */
 
 export type PromptOverwriteType = 0 /* 'SOCIAL_0' */ | 1 /* 'SITE_1' */
@@ -2913,6 +3323,22 @@ export type provisionUi_Stream = {
 export type provisionUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type provisionUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type provisionUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type provisionUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type provisionUi_ProvisionMethod = 0 /* 'DEVICE_0' */ | 1 /* 'PAPER_KEY_1' */ | 2 /* 'PASSPHRASE_2' */ | 3 /* 'GPG_IMPORT_3' */ | 4 /* 'GPG_SIGN_4' */
 
@@ -3009,6 +3435,22 @@ export type quota_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2
 
 export type quota_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type quota_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type quota_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type quota_VerifySessionRes = {
   uid: UID;
   sid: string;
@@ -3096,6 +3538,22 @@ export type revoke_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_
 
 export type revoke_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type revoke_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type revoke_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type secretUi_Time = {
 }
 
@@ -3168,6 +3626,22 @@ export type secretUi_Stream = {
 export type secretUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type secretUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type secretUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type secretUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type secretUi_SecretEntryArg = {
   desc: string;
@@ -3326,6 +3800,22 @@ export type session_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO
 
 export type session_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type session_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type session_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type session_Session = {
   uid: UID;
   username: string;
@@ -3415,6 +3905,22 @@ export type signup_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_
 
 export type signup_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type signup_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type signup_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type signup_SignupRes = {
   passphraseOk: boolean;
   postOk: boolean;
@@ -3499,6 +4005,22 @@ export type sigs_Stream = {
 export type sigs_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type sigs_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type sigs_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type sigs_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type sigs_Sig = {
   seqno: int;
@@ -3631,6 +4153,22 @@ export type streamUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INF
 
 export type streamUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type streamUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type streamUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type test_Test = {
   reply: string;
 }
@@ -3712,11 +4250,30 @@ export type track_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2
 
 export type track_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type track_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type track_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type track_ProofState = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'TEMP_FAILURE_2' */ | 3 /* 'PERM_FAILURE_3' */ | 4 /* 'LOOKING_4' */ | 5 /* 'SUPERSEDED_5' */ | 6 /* 'POSTED_6' */ | 7 /* 'REVOKED_7' */
 
 export type track_ProofStatus = 0 /* 'NONE_0' */ | 1 /* 'OK_1' */ | 2 /* 'LOCAL_2' */ | 3 /* 'FOUND_3' */ | 4 /* 'BASE_ERROR_100' */ | 5 /* 'HOST_UNREACHABLE_101' */ | 6 /* 'PERMISSION_DENIED_103' */ | 7 /* 'FAILED_PARSE_106' */ | 8 /* 'DNS_ERROR_107' */ | 9 /* 'AUTH_FAILED_108' */ | 10 /* 'HTTP_500_150' */ | 11 /* 'TIMEOUT_160' */ | 12 /* 'INTERNAL_ERROR_170' */ | 13 /* 'BASE_HARD_ERROR_200' */ | 14 /* 'NOT_FOUND_201' */ | 15 /* 'CONTENT_FAILURE_202' */ | 16 /* 'BAD_USERNAME_203' */ | 17 /* 'BAD_REMOTE_ID_204' */ | 18 /* 'TEXT_NOT_FOUND_205' */ | 19 /* 'BAD_ARGS_206' */ | 20 /* 'CONTENT_MISSING_207' */ | 21 /* 'TITLE_NOT_FOUND_208' */ | 22 /* 'SERVICE_ERROR_209' */ | 23 /* 'TOR_SKIPPED_210' */ | 24 /* 'TOR_INCOMPATIBLE_211' */ | 25 /* 'HTTP_300_230' */ | 26 /* 'HTTP_400_240' */ | 27 /* 'HTTP_OTHER_260' */ | 28 /* 'EMPTY_JSON_270' */ | 29 /* 'DELETED_301' */ | 30 /* 'SERVICE_DEAD_302' */ | 31 /* 'BAD_SIGNATURE_303' */ | 32 /* 'BAD_API_URL_304' */ | 33 /* 'UNKNOWN_TYPE_305' */ | 34 /* 'NO_HINT_306' */ | 35 /* 'BAD_HINT_TEXT_307' */
 
 export type track_ProofType = 0 /* 'NONE_0' */ | 1 /* 'KEYBASE_1' */ | 2 /* 'TWITTER_2' */ | 3 /* 'GITHUB_3' */ | 4 /* 'REDDIT_4' */ | 5 /* 'COINBASE_5' */ | 6 /* 'HACKERNEWS_6' */ | 7 /* 'GENERIC_WEB_SITE_1000' */ | 8 /* 'DNS_1001' */ | 9 /* 'ROOTER_100001' */
+
+export type track_TrackToken = {
+}
 
 export type track_TrackDiffType = 0 /* 'NONE_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'CLASH_2' */ | 3 /* 'REVOKED_3' */ | 4 /* 'UPGRADED_4' */ | 5 /* 'NEW_5' */ | 6 /* 'REMOTE_FAIL_6' */ | 7 /* 'REMOTE_WORKING_7' */ | 8 /* 'REMOTE_CHANGED_8' */ | 9 /* 'NEW_ELDEST_9' */
 
@@ -3763,7 +4320,7 @@ export type track_IdentifyRes = {
   user?: ?User;
   publicKeys: Array<PublicKey>;
   outcome: IdentifyOutcome;
-  trackToken: string;
+  trackToken: TrackToken;
 }
 
 export type track_RemoteProof = {
@@ -3847,6 +4404,22 @@ export type ui_Stream = {
 export type ui_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type ui_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type ui_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type ui_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type ui_PromptDefault = 0 /* 'NONE_0' */ | 1 /* 'YES_1' */ | 2 /* 'NO_2' */
 
@@ -4048,6 +4621,22 @@ export type user_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2'
 
 export type user_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type user_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type user_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type user_Tracker = {
   tracker: UID;
   status: int;
@@ -4116,18 +4705,6 @@ export type UserSummary = {
   proofs: Proofs;
   sigIDDisplay: string;
   trackTime: Time;
-}
-
-export type user_UserPlusKeys = {
-  uid: UID;
-  username: string;
-  deviceKeys: Array<PublicKey>;
-}
-
-export type UserPlusKeys = {
-  uid: UID;
-  username: string;
-  deviceKeys: Array<PublicKey>;
 }
 
 export type user_SearchComponent = {


### PR DESCRIPTION
This is the engine for the Identify2 RPC call.  This PR only contains the engine and tests.  It doesn't connect it into any working components just yet.

* Integrate a caching system
* Handle 3 cases of identify: (a) with tracking; (b) without tracking and with remote assertions; and (c) neither of the above.
* Closes CORE-2182, CORE-2171 and CORE-2204