### PR TITLE
periodically checking for new tracking statements

### DIFF
--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -1,4 +1,5 @@
 - Don't mask errors in PromptSeletion (Commit: 060ff319e6b50aad09fd0162e50a3212c4f7516d)
+- Periodic polling for new tracking statements (PR: keybase/client#1500)
 
 ## 1.0.6-1
 - Fix verify command (PR: keybase/client#1522)

--- a/go/client/cmd_check_tracking.go
+++ b/go/client/cmd_check_tracking.go
@@ -1,0 +1,60 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	rpc "github.com/keybase/go-framed-msgpack-rpc"
+	"golang.org/x/net/context"
+)
+
+type CmdCheckTracking struct {
+	libkb.Contextified
+}
+
+func (c *CmdCheckTracking) ParseArgv(ctx *cli.Context) error {
+	return nil
+}
+
+func (c *CmdCheckTracking) Run() (err error) {
+	cli, err := GetTrackClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	protocols := []rpc.Protocol{}
+	if err = RegisterProtocolsWithContext(protocols, c.G()); err != nil {
+		return err
+	}
+
+	err = cli.CheckTracking(context.TODO(), 0 /* session ID */)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func NewCmdCheckTracking(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "check-tracking",
+		Usage: "check for new tracking statements",
+		Flags: []cli.Flag{},
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdCheckTrackingRunner(g), "check-tracking", c)
+		},
+	}
+}
+
+func NewCmdCheckTrackingRunner(g *libkb.GlobalContext) *CmdCheckTracking {
+	return &CmdCheckTracking{Contextified: libkb.NewContextified(g)}
+}
+
+func (c *CmdCheckTracking) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/cmd_show_notifications.go
+++ b/go/client/cmd_show_notifications.go
@@ -31,11 +31,20 @@ func (c *CmdShowNotifications) Run() error {
 
 	display := newNotificationDisplay(c.G())
 
+	// NB: Make sure to edit both of these at the same time.
 	protocols := []rpc.Protocol{
 		keybase1.NotifySessionProtocol(display),
 		keybase1.NotifyUsersProtocol(display),
 		keybase1.NotifyFSProtocol(display),
+		keybase1.NotifyTrackingProtocol(display),
 	}
+	channels := keybase1.NotificationChannels{
+		Session:  true,
+		Users:    true,
+		Kbfs:     true,
+		Tracking: true,
+	}
+
 	if err := RegisterProtocols(protocols); err != nil {
 		return err
 	}
@@ -43,7 +52,7 @@ func (c *CmdShowNotifications) Run() error {
 	if err != nil {
 		return err
 	}
-	if err := cli.SetNotifications(context.TODO(), keybase1.NotificationChannels{Session: true, Users: true, Kbfs: true}); err != nil {
+	if err := cli.SetNotifications(context.TODO(), channels); err != nil {
 		return err
 	}
 
@@ -94,4 +103,8 @@ func (d *notificationDisplay) UserChanged(_ context.Context, uid keybase1.UID) e
 
 func (d *notificationDisplay) FSActivity(_ context.Context, notification keybase1.FSNotification) error {
 	return d.printf("KBFS notification: %+v\n", notification)
+}
+
+func (d *notificationDisplay) TrackingChanged(_ context.Context, uid keybase1.UID) error {
+	return d.printf("Tracking %s changed\n", uid)
 }

--- a/go/client/cmd_untrack.go
+++ b/go/client/cmd_untrack.go
@@ -17,15 +17,16 @@ import (
 
 type CmdUntrack struct {
 	user string
+	libkb.Contextified
 }
 
-func NewCmdUntrack(cl *libcmdline.CommandLine) cli.Command {
+func NewCmdUntrack(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:         "untrack",
 		ArgumentHelp: "<username>",
 		Usage:        "Untrack a user",
 		Action: func(c *cli.Context) {
-			cl.ChooseCommand(&CmdUntrack{}, "untrack", c)
+			cl.ChooseCommand(&CmdUntrack{Contextified: libkb.NewContextified(g)}, "untrack", c)
 		},
 	}
 }
@@ -39,7 +40,7 @@ func (v *CmdUntrack) ParseArgv(ctx *cli.Context) error {
 }
 
 func (v *CmdUntrack) Run() error {
-	cli, err := GetTrackClient()
+	cli, err := GetTrackClient(v.G())
 	if err != nil {
 		return err
 	}

--- a/go/client/commands_common.go
+++ b/go/client/commands_common.go
@@ -39,9 +39,9 @@ func GetCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Comma
 		NewCmdSigs(cl),
 		NewCmdSignup(cl, g),
 		NewCmdStatus(cl),
-		NewCmdTrack(cl),
+		NewCmdTrack(cl, g),
 		NewCmdUnlock(cl),
-		NewCmdUntrack(cl),
+		NewCmdUntrack(cl, g),
 		NewCmdVersion(cl, g),
 	}
 	ret = append(ret, getBuildSpecificCommands(cl, g)...)

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -15,6 +15,7 @@ import (
 
 func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
 	return []cli.Command{
+		NewCmdCheckTracking(cl, g),
 		NewCmdDecrypt(cl, g),
 		NewCmdEncrypt(cl, g),
 		NewCmdFavorite(cl),

--- a/go/client/rpc.go
+++ b/go/client/rpc.go
@@ -99,9 +99,9 @@ func GetProveClient() (cli keybase1.ProveClient, err error) {
 	return
 }
 
-func GetTrackClient() (cli keybase1.TrackClient, err error) {
+func GetTrackClient(g *libkb.GlobalContext) (cli keybase1.TrackClient, err error) {
 	var rcli *rpc.Client
-	if rcli, _, err = GetRPCClient(); err == nil {
+	if rcli, _, err = GetRPCClientWithContext(g); err == nil {
 		cli = keybase1.TrackClient{Cli: rcli}
 	}
 	return

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -182,7 +182,8 @@ type ChainLink struct {
 	unpacked    *ChainLinkUnpacked
 	cki         *ComputedKeyInfos
 
-	typed TypedChainLink
+	typed                  TypedChainLink
+	isOwnNewLinkFromServer bool
 }
 
 // Returns whether or not this chain link is bad, and if so, what the

--- a/go/libkb/check_tracking.go
+++ b/go/libkb/check_tracking.go
@@ -1,0 +1,13 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package libkb
+
+func CheckTracking(g *GlobalContext) error {
+	// LoadUser automatically fires off UserChanged notifications when it
+	// discovers new track or untrack chain links.
+	arg := NewLoadUserArg(g)
+	arg.AbortIfSigchainUnchanged = true
+	_, err := LoadMe(arg)
+	return err
+}

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -62,6 +62,7 @@ type GlobalContext struct {
 	UIRouter            UIRouter            // How to route UIs
 	ProofCheckerFactory ProofCheckerFactory // Makes new ProofCheckers
 	ExitCode            keybase1.ExitCode   // Value to return to OS on Exit()
+	RateLimits          *RateLimits         // tracks the last time certain actions were taken
 }
 
 func NewGlobalContext() *GlobalContext {
@@ -86,6 +87,7 @@ func (g *GlobalContext) Init() {
 	g.Service = false
 	g.createLoginState()
 	g.Resolver = NewResolver(g)
+	g.RateLimits = NewRateLimits(g)
 }
 
 func (g *GlobalContext) SetService() {

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -40,6 +40,7 @@ type TypedChainLink interface {
 	VerifyReverseSig(ckf ComputedKeyFamily) error
 	GetMerkleSeqno() int
 	GetDevice() *Device
+	DoOwnNewLinkFromServerNotifications(g *GlobalContext)
 }
 
 //=========================================================================
@@ -97,6 +98,8 @@ func (g *GenericChainLink) extractPGPFullHash(loc string) string {
 	}
 	return ""
 }
+
+func (g *GenericChainLink) DoOwnNewLinkFromServerNotifications(glob *GlobalContext) {}
 
 //
 //=========================================================================
@@ -379,9 +382,10 @@ func remoteProofInsertIntoTable(l RemoteProofChainLink, tab *IdentityTable) {
 //
 type TrackChainLink struct {
 	GenericChainLink
-	whom    string
-	untrack *UntrackChainLink
-	local   bool
+	whomUsername string
+	whomUID      keybase1.UID
+	untrack      *UntrackChainLink
+	local        bool
 }
 
 func (l TrackChainLink) IsRemote() bool {
@@ -389,25 +393,32 @@ func (l TrackChainLink) IsRemote() bool {
 }
 
 func ParseTrackChainLink(b GenericChainLink) (ret *TrackChainLink, err error) {
-	var whom string
-	whom, err = b.payloadJSON.AtPath("body.track.basics.username").GetString()
+	var whomUsername string
+	whomUsername, err = b.payloadJSON.AtPath("body.track.basics.username").GetString()
 	if err != nil {
 		err = fmt.Errorf("Bad track statement @%s: %s", b.ToDebugString(), err)
-	} else {
-		ret = &TrackChainLink{b, whom, nil, false}
+		return
 	}
+
+	whomUID, err := GetUID(b.payloadJSON.AtPath("body.track.id"))
+	if err != nil {
+		err = fmt.Errorf("Bad track statement @%s: %s", b.ToDebugString(), err)
+		return
+	}
+
+	ret = &TrackChainLink{b, whomUsername, whomUID, nil, false}
 	return
 }
 
 func (l *TrackChainLink) Type() string { return "track" }
 
 func (l *TrackChainLink) ToDisplayString() string {
-	return l.whom
+	return l.whomUsername
 }
 
 func (l *TrackChainLink) insertIntoTable(tab *IdentityTable) {
 	tab.insertLink(l)
-	tab.tracks[l.whom] = append(tab.tracks[l.whom], l)
+	tab.tracks[l.whomUsername] = append(tab.tracks[l.whomUsername], l)
 }
 
 type TrackedKey struct {
@@ -508,6 +519,11 @@ func (l *TrackChainLink) ToServiceBlocks() (ret []*ServiceBlock) {
 		}
 	}
 	return
+}
+
+func (l *TrackChainLink) DoOwnNewLinkFromServerNotifications(g *GlobalContext) {
+	g.Log.Debug("Post notification for new TrackChainLink")
+	g.NotifyRouter.HandleTrackingChanged(l.whomUID)
 }
 
 //
@@ -707,25 +723,33 @@ func (s *DeviceChainLink) insertIntoTable(tab *IdentityTable) {
 
 type UntrackChainLink struct {
 	GenericChainLink
-	whom string
+	whomUsername string
+	whomUID      keybase1.UID
 }
 
 func ParseUntrackChainLink(b GenericChainLink) (ret *UntrackChainLink, err error) {
-	var whom string
-	whom, err = b.payloadJSON.AtPath("body.untrack.basics.username").GetString()
+	var whomUsername string
+	whomUsername, err = b.payloadJSON.AtPath("body.untrack.basics.username").GetString()
 	if err != nil {
 		err = fmt.Errorf("Bad track statement @%s: %s", b.ToDebugString(), err)
-	} else {
-		ret = &UntrackChainLink{b, whom}
+		return
 	}
+
+	whomUID, err := GetUID(b.payloadJSON.AtPath("body.untrack.id"))
+	if err != nil {
+		err = fmt.Errorf("Bad track statement @%s: %s", b.ToDebugString(), err)
+		return
+	}
+
+	ret = &UntrackChainLink{b, whomUsername, whomUID}
 	return
 }
 
 func (u *UntrackChainLink) insertIntoTable(tab *IdentityTable) {
 	tab.insertLink(u)
-	if list, found := tab.tracks[u.whom]; !found {
+	if list, found := tab.tracks[u.whomUsername]; !found {
 		G.Log.Debug("| Useless untrack of %s; no previous tracking statement found",
-			u.whom)
+			u.whomUsername)
 	} else {
 		for _, obj := range list {
 			obj.untrack = u
@@ -734,12 +758,17 @@ func (u *UntrackChainLink) insertIntoTable(tab *IdentityTable) {
 }
 
 func (u *UntrackChainLink) ToDisplayString() string {
-	return u.whom
+	return u.whomUsername
 }
 
 func (u *UntrackChainLink) Type() string { return "untrack" }
 
 func (u *UntrackChainLink) IsRevocationIsh() bool { return true }
+
+func (u *UntrackChainLink) DoOwnNewLinkFromServerNotifications(g *GlobalContext) {
+	g.Log.Debug("Post notification for new UntrackChainLink")
+	g.NotifyRouter.HandleTrackingChanged(u.whomUID)
+}
 
 //
 //=========================================================================
@@ -1026,6 +1055,10 @@ func (idt *IdentityTable) populate() error {
 		tcl.insertIntoTable(idt)
 		if w != nil {
 			w.Warn()
+		}
+		if link.isOwnNewLinkFromServer {
+			link.isOwnNewLinkFromServer = false
+			tcl.DoOwnNewLinkFromServerNotifications(idt.G())
 		}
 	}
 	G.Log.Debug("- Populate ID Table")

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -11,14 +11,15 @@ import (
 )
 
 type LoadUserArg struct {
-	UID               keybase1.UID
-	Name              string // Can also be an assertion like foo@twitter
-	PublicKeyOptional bool
-	NoCacheResult     bool // currently ignore
-	Self              bool
-	ForceReload       bool
-	AllKeys           bool
-	LoginContext      LoginContext
+	UID                      keybase1.UID
+	Name                     string // Can also be an assertion like foo@twitter
+	PublicKeyOptional        bool
+	NoCacheResult            bool // currently ignore
+	Self                     bool
+	ForceReload              bool
+	AllKeys                  bool
+	LoginContext             LoginContext
+	AbortIfSigchainUnchanged bool
 	Contextified
 }
 
@@ -157,6 +158,10 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 
 	if err = ret.LoadSigChains(arg.AllKeys, &ret.leaf, arg.Self); err != nil {
 		return
+	}
+
+	if arg.AbortIfSigchainUnchanged && ret.sigChain().wasFullyCached {
+		return nil, nil
 	}
 
 	if ret.sigHints, err = LoadAndRefreshSigHints(ret.id, arg.G()); err != nil {

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -137,6 +137,29 @@ func (n *NotifyRouter) HandleUserChanged(uid keybase1.UID) {
 	})
 }
 
+// HandleTrackingChanged is called whenever we have a new tracking or
+// untracking chain link related to a given user. It will broadcast the
+// messages to all curious listeners.
+func (n *NotifyRouter) HandleTrackingChanged(uid keybase1.UID) {
+	if n == nil {
+		return
+	}
+	// For all connections we currently have open...
+	n.cm.ApplyAll(func(id ConnectionID, xp rpc.Transporter) bool {
+		// If the connection wants the `Tracking` notification type
+		if n.getNotificationChannels(id).Tracking {
+			// In the background do...
+			go func() {
+				// A send of a `TrackingChanged` RPC with the user's UID
+				(keybase1.NotifyTrackingClient{
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+				}).TrackingChanged(context.TODO(), uid)
+			}()
+		}
+		return true
+	})
+}
+
 // HandleFSActivity is called for any KBFS notification. It will broadcast the messages
 // to all curious listeners.
 func (n *NotifyRouter) HandleFSActivity(activity keybase1.FSNotification) {

--- a/go/libkb/ratelimit.go
+++ b/go/libkb/ratelimit.go
@@ -1,0 +1,49 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package libkb
+
+import (
+	"sync"
+	"time"
+)
+
+type RateLimitCategory string
+
+const (
+	CheckTrackingRateLimit RateLimitCategory = "CheckTrackingRateLimit"
+	TestEventRateLimit                       = "TestEventRateLimit"
+)
+
+type RateLimits struct {
+	Contextified
+	sync.Mutex
+	lastActionTimes map[RateLimitCategory]time.Time
+}
+
+func NewRateLimits(g *GlobalContext) *RateLimits {
+	return &RateLimits{
+		lastActionTimes: make(map[RateLimitCategory]time.Time),
+		Contextified:    NewContextified(g),
+	}
+}
+
+func (r *RateLimits) GetPermission(category RateLimitCategory, interval time.Duration) bool {
+	r.Lock()
+	defer r.Unlock()
+	now := time.Now()
+	last, exists := r.lastActionTimes[category]
+	if !exists {
+		r.G().Log.Debug("Rate limit %s checked for the first time.", category)
+		r.lastActionTimes[category] = now
+		return true
+	}
+	timeSince := now.Sub(last)
+	if timeSince >= interval {
+		r.G().Log.Debug("Rate limit %s passed.", category)
+		r.lastActionTimes[category] = now
+		return true
+	}
+	r.G().Log.Debug("Rate limit %s too recent.", category)
+	return false
+}

--- a/go/libkb/ratelimit_test.go
+++ b/go/libkb/ratelimit_test.go
@@ -1,0 +1,22 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package libkb
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRateLimit(t *testing.T) {
+	limits := NewRateLimits(G)
+	if !limits.GetPermission(TestEventRateLimit, 1*time.Minute) {
+		t.Fatal("expected to get permission")
+	}
+	if !limits.GetPermission(TestEventRateLimit, 0) {
+		t.Fatal("expected to get permission again with a zero interval")
+	}
+	if limits.GetPermission(TestEventRateLimit, 1*time.Minute) {
+		t.Fatal("expected not to get permission with a long interval")
+	}
+}

--- a/go/systests/tracking_test.go
+++ b/go/systests/tracking_test.go
@@ -1,0 +1,182 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package systests
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/client"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
+	"github.com/keybase/client/go/service"
+	rpc "github.com/keybase/go-framed-msgpack-rpc"
+	context "golang.org/x/net/context"
+)
+
+type trackingUI struct {
+	signupUI
+}
+
+func (n *trackingUI) GetIdentifyTrackUI(strict bool) libkb.IdentifyUI {
+	return &identifyUI{}
+}
+
+type identifyUI struct {
+}
+
+func (*identifyUI) Confirm(*keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
+	return keybase1.ConfirmResult{
+		IdentityConfirmed: true,
+		RemoteConfirmed:   true,
+	}, nil
+}
+func (*identifyUI) Start(string)                                                          {}
+func (*identifyUI) FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult)    {}
+func (*identifyUI) FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) {}
+func (*identifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency)                         {}
+func (*identifyUI) DisplayKey(keybase1.IdentifyKey)                                       {}
+func (*identifyUI) ReportLastTrack(*keybase1.TrackSummary)                                {}
+func (*identifyUI) LaunchNetworkChecks(*keybase1.Identity, *keybase1.User)                {}
+func (*identifyUI) DisplayTrackStatement(string) error                                    { return nil }
+func (*identifyUI) DisplayUserCard(keybase1.UserCard)                                     {}
+func (*identifyUI) ReportTrackToken(keybase1.TrackToken) error                            { return nil }
+func (*identifyUI) SetStrict(b bool)                                                      {}
+func (*identifyUI) Finish()                                                               {}
+
+type trackingNotifyHandler struct {
+	trackingCh chan keybase1.UID
+	errCh      chan error
+}
+
+func newTrackingNotifyHandler() *trackingNotifyHandler {
+	return &trackingNotifyHandler{
+		trackingCh: make(chan keybase1.UID),
+		errCh:      make(chan error),
+	}
+}
+
+func (h *trackingNotifyHandler) TrackingChanged(_ context.Context, uid keybase1.UID) error {
+	h.trackingCh <- uid
+	return nil
+}
+
+func TestTrackingNotifications(t *testing.T) {
+	tc := setupTest(t, "signup")
+	tc2 := cloneContext(tc)
+	tc5 := cloneContext(tc)
+
+	libkb.G.LocalDb = nil
+
+	// Hack the various portions of the service that aren't
+	// properly contextified.
+
+	defer tc.Cleanup()
+
+	stopCh := make(chan error)
+	svc := service.NewService(tc.G, false)
+	startCh := svc.GetStartChannel()
+	go func() {
+		err := svc.Run()
+		if err != nil {
+			t.Logf("Running the service produced an error: %v", err)
+		}
+		stopCh <- err
+	}()
+
+	userInfo := randomUser("sgnup")
+
+	tui := trackingUI{
+		signupUI: signupUI{
+			info:         userInfo,
+			Contextified: libkb.NewContextified(tc2.G),
+		},
+	}
+	tc2.G.SetUI(&tui)
+	signup := client.NewCmdSignupRunner(tc2.G)
+	signup.SetTest()
+
+	<-startCh
+
+	if err := signup.Run(); err != nil {
+		t.Fatal(err)
+	}
+	tc2.G.Log.Debug("Login State: %v", tc2.G.LoginState())
+
+	nh := newTrackingNotifyHandler()
+
+	// Launch the server that will listen for tracking notifications.
+	launchServer := func(nh *trackingNotifyHandler) error {
+		cli, xp, err := client.GetRPCClientWithContext(tc5.G)
+		if err != nil {
+			return err
+		}
+		srv := rpc.NewServer(xp, nil)
+		if err = srv.Register(keybase1.NotifyTrackingProtocol(nh)); err != nil {
+			return err
+		}
+		ncli := keybase1.NotifyCtlClient{Cli: cli}
+		if err = ncli.SetNotifications(context.TODO(), keybase1.NotificationChannels{
+			Tracking: true,
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// Actually launch it in the background
+	go func() {
+		err := launchServer(nh)
+		if err != nil {
+			nh.errCh <- err
+		}
+	}()
+
+	// Have our test user track t_alice.
+	trackCmd := client.NewCmdTrackRunner(tc2.G)
+	trackCmd.SetUser("t_alice")
+	trackCmd.SetOptions(keybase1.TrackOptions{BypassConfirm: true})
+	err := trackCmd.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Do a check for new tracking statements that should fire off a
+	// notification. Currently the TrackEngine above does not fetch the new
+	// chain link from the server, so this call is required. It's possible that
+	// TrackEngine (or our signature caching code) might change in the future,
+	// making this call unnecessary.
+	checkTrackingCmd := client.NewCmdCheckTrackingRunner(tc2.G)
+	err = checkTrackingCmd.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait to get a notification back as we expect.
+	// NOTE: If this test ever starts deadlocking here, it's possible that
+	// we've changed how we cache signatures that we make on the local client,
+	// in such a way that the fetch done by CheckTracking above doesn't find
+	// any "isOwnNewLinkFromServer" links. If so, one way to fix this test
+	// would be to blow away the local db before calling CheckTracking.
+	tc.G.Log.Debug("Waiting for tracking notification.")
+	select {
+	case err := <-nh.errCh:
+		t.Fatalf("Error before notify: %v", err)
+	case uid := <-nh.trackingCh:
+		tAliceUID := keybase1.UID("295a7eea607af32040647123732bc819")
+		tc.G.Log.Debug("Got tracking changed notification (%s)", uid)
+		if !tAliceUID.Equal(uid) {
+			t.Fatalf("Bad UID back: %s != %s", tAliceUID, uid)
+		}
+	}
+
+	stopper := client.NewCmdCtlStopRunner(tc2.G)
+	if err := stopper.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	// If the server failed, it's also an error
+	if err := <-stopCh; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -39,6 +39,7 @@ build-stamp: \
 	json/notify_ctl.json \
 	json/notify_fs.json \
 	json/notify_session.json \
+	json/notify_tracking.json \
 	json/notify_users.json \
 	json/pgp.json \
 	json/pgp_ui.json \

--- a/protocol/avdl/notify_ctl.avdl
+++ b/protocol/avdl/notify_ctl.avdl
@@ -5,9 +5,10 @@ protocol notifyCtl {
   import idl "common.avdl";
 
   record NotificationChannels {
-  	boolean session;
-  	boolean users;
-  	boolean kbfs;
+    boolean session;
+    boolean users;
+    boolean kbfs;
+    boolean tracking;
   }
 
   void setNotifications(NotificationChannels channels);

--- a/protocol/avdl/notify_tracking.avdl
+++ b/protocol/avdl/notify_tracking.avdl
@@ -1,0 +1,8 @@
+
+@namespace("keybase.1")
+protocol NotifyTracking {
+  import idl "common.avdl";
+
+  @notify("")
+  void trackingChanged(UID uid);
+}

--- a/protocol/avdl/track.avdl
+++ b/protocol/avdl/track.avdl
@@ -17,5 +17,7 @@ protocol track {
   void trackWithToken(int sessionID, TrackToken trackToken, TrackOptions options);
 
   void untrack(int sessionID, string username);
+
+  void checkTracking(int sessionID);
 }
 

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1552,6 +1552,22 @@ export type install_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO
 
 export type install_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type install_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type install_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type install_InstallStatus = 0 /* 'UNKNOWN_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'NOT_INSTALLED_2' */ | 3 /* 'INSTALLED_4' */
 
 export type InstallStatus = 0 /* 'UNKNOWN_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'NOT_INSTALLED_2' */ | 3 /* 'INSTALLED_4' */
@@ -2524,12 +2540,14 @@ export type notifyCtl_NotificationChannels = {
   session: boolean;
   users: boolean;
   kbfs: boolean;
+  tracking: boolean;
 }
 
 export type NotificationChannels = {
   session: boolean;
   users: boolean;
   kbfs: boolean;
+  tracking: boolean;
 }
 
 export type NotifyFS_FSStatusCode = 0 /* 'START_0' */ | 1 /* 'FINISH_1' */ | 2 /* 'ERROR_2' */
@@ -2542,6 +2560,95 @@ export type NotifyFS_FSNotification = {
   status: string;
   statusCode: FSStatusCode;
   notificationType: FSNotificationType;
+}
+
+export type NotifyTracking_Time = {
+}
+
+export type NotifyTracking_StringKVPair = {
+  key: string;
+  value: string;
+}
+
+export type NotifyTracking_Status = {
+  code: int;
+  name: string;
+  desc: string;
+  fields: Array<StringKVPair>;
+}
+
+export type NotifyTracking_UID = {
+}
+
+export type NotifyTracking_DeviceID = {
+}
+
+export type NotifyTracking_SigID = {
+}
+
+export type NotifyTracking_KID = {
+}
+
+export type NotifyTracking_Text = {
+  data: string;
+  markup: boolean;
+}
+
+export type NotifyTracking_PGPIdentity = {
+  username: string;
+  comment: string;
+  email: string;
+}
+
+export type NotifyTracking_PublicKey = {
+  KID: KID;
+  PGPFingerprint: string;
+  PGPIdentities: Array<PGPIdentity>;
+  isSibkey: boolean;
+  isEldest: boolean;
+  parentID: string;
+  deviceID: DeviceID;
+  deviceDescription: string;
+  deviceType: string;
+  cTime: Time;
+  eTime: Time;
+}
+
+export type NotifyTracking_User = {
+  uid: UID;
+  username: string;
+}
+
+export type NotifyTracking_Device = {
+  type: string;
+  name: string;
+  deviceID: DeviceID;
+  cTime: Time;
+  mTime: Time;
+}
+
+export type NotifyTracking_Stream = {
+  fd: int;
+}
+
+export type NotifyTracking_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
+
+export type NotifyTracking_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type NotifyTracking_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type NotifyTracking_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
 }
 
 export type NotifyUsers_Time = {
@@ -4497,6 +4604,22 @@ export type update_Stream = {
 export type update_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type update_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type update_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type update_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type update_Asset = {
   name: string;

--- a/protocol/js/keybase_v1.js
+++ b/protocol/js/keybase_v1.js
@@ -604,6 +604,22 @@ export default {
     }
   },
   'NotifySession': {},
+  'NotifyTracking': {
+    'LogLevel': {
+      'none': 0,
+      'debug': 1,
+      'info': 2,
+      'notice': 3,
+      'warn': 4,
+      'error': 5,
+      'critical': 6,
+      'fatal': 7
+    },
+    'ClientType': {
+      'cli': 0,
+      'gui': 1
+    }
+  },
   'NotifyUsers': {
     'LogLevel': {
       'none': 0,

--- a/protocol/json/notify_ctl.json
+++ b/protocol/json/notify_ctl.json
@@ -218,6 +218,9 @@
     }, {
       "name" : "kbfs",
       "type" : "boolean"
+    }, {
+      "name" : "tracking",
+      "type" : "boolean"
     } ]
   } ],
   "messages" : {

--- a/protocol/json/notify_tracking.json
+++ b/protocol/json/notify_tracking.json
@@ -1,5 +1,5 @@
 {
-  "protocol" : "install",
+  "protocol" : "NotifyTracking",
   "namespace" : "keybase.1",
   "types" : [ {
     "type" : "record",
@@ -206,117 +206,15 @@
       "name" : "uvv",
       "type" : "UserVersionVector"
     } ]
-  }, {
-    "type" : "enum",
-    "name" : "InstallStatus",
-    "doc" : "Install status describes state of install for a component or service.",
-    "symbols" : [ "UNKNOWN_0", "ERROR_1", "NOT_INSTALLED_2", "INSTALLED_4" ]
-  }, {
-    "type" : "enum",
-    "name" : "InstallAction",
-    "symbols" : [ "UNKNOWN_0", "NONE_1", "UPGRADE_2", "REINSTALL_3", "INSTALL_4" ]
-  }, {
-    "type" : "record",
-    "name" : "ServiceStatus",
-    "fields" : [ {
-      "name" : "version",
-      "type" : "string"
-    }, {
-      "name" : "label",
-      "type" : "string"
-    }, {
-      "name" : "pid",
-      "type" : "string"
-    }, {
-      "name" : "lastExitStatus",
-      "type" : "string"
-    }, {
-      "name" : "bundleVersion",
-      "type" : "string"
-    }, {
-      "name" : "installStatus",
-      "type" : "InstallStatus"
-    }, {
-      "name" : "installAction",
-      "type" : "InstallAction"
-    }, {
-      "name" : "status",
-      "type" : "Status"
-    } ]
-  }, {
-    "type" : "record",
-    "name" : "ServicesStatus",
-    "fields" : [ {
-      "name" : "service",
-      "type" : {
-        "type" : "array",
-        "items" : "ServiceStatus"
-      }
-    }, {
-      "name" : "kbfs",
-      "type" : {
-        "type" : "array",
-        "items" : "ServiceStatus"
-      }
-    } ]
-  }, {
-    "type" : "record",
-    "name" : "FuseMountInfo",
-    "fields" : [ {
-      "name" : "path",
-      "type" : "string"
-    }, {
-      "name" : "fstype",
-      "type" : "string"
-    }, {
-      "name" : "output",
-      "type" : "string"
-    } ]
-  }, {
-    "type" : "record",
-    "name" : "FuseStatus",
-    "fields" : [ {
-      "name" : "version",
-      "type" : "string"
-    }, {
-      "name" : "bundleVersion",
-      "type" : "string"
-    }, {
-      "name" : "kextID",
-      "type" : "string"
-    }, {
-      "name" : "path",
-      "type" : "string"
-    }, {
-      "name" : "kextStarted",
-      "type" : "boolean"
-    }, {
-      "name" : "installStatus",
-      "type" : "InstallStatus"
-    }, {
-      "name" : "installAction",
-      "type" : "InstallAction"
-    }, {
-      "name" : "mountInfos",
-      "type" : {
-        "type" : "array",
-        "items" : "FuseMountInfo"
-      }
-    }, {
-      "name" : "status",
-      "type" : "Status"
-    } ]
-  }, {
-    "type" : "record",
-    "name" : "ComponentStatus",
-    "doc" : "ComponentStatus defines a components status.\n    Names can be \"cli,\" \"service\", \"kbfs\".",
-    "fields" : [ {
-      "name" : "name",
-      "type" : "string"
-    }, {
-      "name" : "status",
-      "type" : "Status"
-    } ]
   } ],
-  "messages" : { }
+  "messages" : {
+    "trackingChanged" : {
+      "notify" : "",
+      "request" : [ {
+        "name" : "uid",
+        "type" : "UID"
+      } ],
+      "response" : "null"
+    }
+  }
 }

--- a/protocol/json/track.json
+++ b/protocol/json/track.json
@@ -408,6 +408,13 @@
         "type" : "string"
       } ],
       "response" : "null"
+    },
+    "checkTracking" : {
+      "request" : [ {
+        "name" : "sessionID",
+        "type" : "int"
+      } ],
+      "response" : "null"
     }
   }
 }

--- a/protocol/json/update.json
+++ b/protocol/json/update.json
@@ -164,6 +164,50 @@
     "symbols" : [ "CLI_0", "GUI_1" ]
   }, {
     "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "Asset",
     "doc" : "Asset describes a downloadable file.",
     "fields" : [ {

--- a/react-native/react/constants/types/flow-types.js
+++ b/react-native/react/constants/types/flow-types.js
@@ -1552,6 +1552,22 @@ export type install_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO
 
 export type install_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
 
+export type install_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type install_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
 export type install_InstallStatus = 0 /* 'UNKNOWN_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'NOT_INSTALLED_2' */ | 3 /* 'INSTALLED_4' */
 
 export type InstallStatus = 0 /* 'UNKNOWN_0' */ | 1 /* 'ERROR_1' */ | 2 /* 'NOT_INSTALLED_2' */ | 3 /* 'INSTALLED_4' */
@@ -2524,12 +2540,14 @@ export type notifyCtl_NotificationChannels = {
   session: boolean;
   users: boolean;
   kbfs: boolean;
+  tracking: boolean;
 }
 
 export type NotificationChannels = {
   session: boolean;
   users: boolean;
   kbfs: boolean;
+  tracking: boolean;
 }
 
 export type NotifyFS_FSStatusCode = 0 /* 'START_0' */ | 1 /* 'FINISH_1' */ | 2 /* 'ERROR_2' */
@@ -2542,6 +2560,95 @@ export type NotifyFS_FSNotification = {
   status: string;
   statusCode: FSStatusCode;
   notificationType: FSNotificationType;
+}
+
+export type NotifyTracking_Time = {
+}
+
+export type NotifyTracking_StringKVPair = {
+  key: string;
+  value: string;
+}
+
+export type NotifyTracking_Status = {
+  code: int;
+  name: string;
+  desc: string;
+  fields: Array<StringKVPair>;
+}
+
+export type NotifyTracking_UID = {
+}
+
+export type NotifyTracking_DeviceID = {
+}
+
+export type NotifyTracking_SigID = {
+}
+
+export type NotifyTracking_KID = {
+}
+
+export type NotifyTracking_Text = {
+  data: string;
+  markup: boolean;
+}
+
+export type NotifyTracking_PGPIdentity = {
+  username: string;
+  comment: string;
+  email: string;
+}
+
+export type NotifyTracking_PublicKey = {
+  KID: KID;
+  PGPFingerprint: string;
+  PGPIdentities: Array<PGPIdentity>;
+  isSibkey: boolean;
+  isEldest: boolean;
+  parentID: string;
+  deviceID: DeviceID;
+  deviceDescription: string;
+  deviceType: string;
+  cTime: Time;
+  eTime: Time;
+}
+
+export type NotifyTracking_User = {
+  uid: UID;
+  username: string;
+}
+
+export type NotifyTracking_Device = {
+  type: string;
+  name: string;
+  deviceID: DeviceID;
+  cTime: Time;
+  mTime: Time;
+}
+
+export type NotifyTracking_Stream = {
+  fd: int;
+}
+
+export type NotifyTracking_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
+
+export type NotifyTracking_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type NotifyTracking_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type NotifyTracking_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
 }
 
 export type NotifyUsers_Time = {
@@ -4497,6 +4604,22 @@ export type update_Stream = {
 export type update_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
 
 export type update_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type update_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type update_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
 
 export type update_Asset = {
   name: string;

--- a/react-native/react/constants/types/keybase_v1.js
+++ b/react-native/react/constants/types/keybase_v1.js
@@ -604,6 +604,22 @@ export default {
     }
   },
   'NotifySession': {},
+  'NotifyTracking': {
+    'LogLevel': {
+      'none': 0,
+      'debug': 1,
+      'info': 2,
+      'notice': 3,
+      'warn': 4,
+      'error': 5,
+      'critical': 6,
+      'fatal': 7
+    },
+    'ClientType': {
+      'cli': 0,
+      'gui': 1
+    }
+  },
   'NotifyUsers': {
     'LogLevel': {
       'none': 0,


### PR DESCRIPTION
I want to get comments from @maxtaco about whether this is a reasonable way to implement this feature:
1) we look for new tracking statements in every LoadMe call (so the check-tracks interface just calls LoadMe)
2) we store the last seen seqno in LevelDB

Also @chrisnojima mentioned that we want to check proof state in addition to new signatures. That could be expensive (because it's O(people you track) instead of O(1)), so I'll want to talk about that with @cjb and you guys.