### PR TITLE
auth+mdserver: add rekeying protocol methods

### DIFF
--- a/go/auth/errors.go
+++ b/go/auth/errors.go
@@ -34,6 +34,14 @@ func (e BadKeyError) Error() string {
 	return fmt.Sprintf("Bad key error: %s not active for %s", e.kid, e.uid)
 }
 
+// KeysNotEqualError is raised when compared keys sets aren't equal.
+type KeysNotEqualError struct {
+}
+
+func (e KeysNotEqualError) Error() string {
+	return "Keys not equal"
+}
+
 // InvalidTokenTypeError is raised when the given token is not of the expected type.
 type InvalidTokenTypeError struct {
 	expected string

--- a/go/auth/user_keys_api.go
+++ b/go/auth/user_keys_api.go
@@ -60,7 +60,8 @@ type userKeyAPI struct {
 	instanceID    string
 }
 
-func (u *userKeyAPI) GetUser(ctx context.Context, uid keybase1.UID) (un libkb.NormalizedUsername, kids []keybase1.KID, err error) {
+func (u *userKeyAPI) GetUser(ctx context.Context, uid keybase1.UID) (
+	un libkb.NormalizedUsername, sibkeys, subkeys []keybase1.KID, err error) {
 	u.log.Debug("+ GetUser")
 	defer func() {
 		u.log.Debug("- GetUser -> %v", err)
@@ -73,17 +74,10 @@ func (u *userKeyAPI) GetUser(ctx context.Context, uid keybase1.UID) (un libkb.No
 		},
 	}, &ukr)
 	if err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 	un = libkb.NewNormalizedUsername(ukr.Username)
-	for _, k := range ukr.PublicKeys.Sibkeys {
-		kids = append(kids, k)
-	}
-	for _, k := range ukr.PublicKeys.Subkeys {
-		kids = append(kids, k)
-	}
-
-	return un, kids, nil
+	return un, ukr.PublicKeys.Sibkeys, ukr.PublicKeys.Subkeys, nil
 }
 
 func (u *userKeyAPI) PollForChanges(ctx context.Context) (uids []keybase1.UID, err error) {

--- a/protocol/avdl/metadata.avdl
+++ b/protocol/avdl/metadata.avdl
@@ -24,5 +24,6 @@ protocol metadata {
   boolean truncateLock(string folderID);
   boolean truncateUnlock(string folderID);
   bytes getFolderHandle(string folderID, string signature);
+  void getFoldersForRekey(KID deviceKID);
   void ping();
 }

--- a/protocol/avdl/metadata_update.avdl
+++ b/protocol/avdl/metadata_update.avdl
@@ -4,4 +4,5 @@ protocol metadataUpdate {
   import idl "backend_common.avdl";
 
   void metadataUpdate(string folderID, long revision);
+  void folderNeedsRekey(string folderID, long revision);
 }

--- a/protocol/json/metadata.json
+++ b/protocol/json/metadata.json
@@ -417,6 +417,13 @@
       } ],
       "response" : "bytes"
     },
+    "getFoldersForRekey" : {
+      "request" : [ {
+        "name" : "deviceKID",
+        "type" : "KID"
+      } ],
+      "response" : "null"
+    },
     "ping" : {
       "request" : [ ],
       "response" : "null"

--- a/protocol/json/metadata_update.json
+++ b/protocol/json/metadata_update.json
@@ -264,6 +264,16 @@
         "type" : "long"
       } ],
       "response" : "null"
+    },
+    "folderNeedsRekey" : {
+      "request" : [ {
+        "name" : "folderID",
+        "type" : "string"
+      }, {
+        "name" : "revision",
+        "type" : "long"
+      } ],
+      "response" : "null"
     }
   }
 }


### PR DESCRIPTION
Most of this is to add a key comparison method used by the mdserver.

KBFS side: https://github.com/keybase/kbfs/pull/508