### PR TITLE
Make CryptoHandler use UIRouter

### DIFF
--- a/go/engine/login_state_test.go
+++ b/go/engine/login_state_test.go
@@ -218,48 +218,6 @@ func (m *GetUsernameMock) CheckLastErr(t *testing.T) {
 	}
 }
 
-/*
-type GetKeybasePassphraseMock struct {
-	Passphrase  string
-	StoreSecret bool
-	Called      bool
-	LastErr     error
-}
-
-func (m *GetKeybasePassphraseMock) GetSecret(keybase1.SecretEntryArg, *keybase1.SecretEntryArg) (*keybase1.SecretEntryRes, error) {
-	return nil, errors.New("Fail pubkey login")
-}
-
-func (m *GetKeybasePassphraseMock) GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.GetPassphraseRes, error) {
-	m.LastErr = errors.New("GetNewPassphrase unexpectedly called")
-	return keybase1.GetPassphraseRes{Passphrase: "invalid passphrase"}, m.LastErr
-}
-
-func (m *GetKeybasePassphraseMock) GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (keybase1.GetPassphraseRes, error) {
-	if m.Called {
-		m.LastErr = errors.New("GetKeybasePassphrase unexpectedly called more than once")
-		return keybase1.GetPassphraseRes{Passphrase: "invalid passphrase"}, m.LastErr
-	}
-	m.Called = true
-	return keybase1.GetPassphraseRes{Passphrase: m.Passphrase, StoreSecret: m.StoreSecret}, nil
-}
-
-func (m *GetKeybasePassphraseMock) GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) (string, error) {
-	m.LastErr = errors.New("GetBackupPassphrase unexpectedly called")
-	return "invalid passphrase", m.LastErr
-}
-
-func (m *GetKeybasePassphraseMock) CheckLastErr(t *testing.T) {
-	if m.LastErr != nil {
-		t.Fatal(m.LastErr)
-	}
-}
-
-func (m *GetKeybasePassphraseMock) GetPassphrase(p keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (res keybase1.GetPassphraseRes, err error) {
-	return
-}
-*/
-
 // Test that the login falls back to a passphrase login if pubkey
 // login fails.
 func TestLoginWithPromptPassphrase(t *testing.T) {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -57,8 +57,10 @@ type GlobalContext struct {
 	loginState        *LoginState        // What phase of login the user's in
 	ConnectionManager *ConnectionManager // keep tabs on all active client connections
 	NotifyRouter      *NotifyRouter      // How to route notifications
-	UIRouter          UIRouter           // How to route UIs
-	ExitCode          keybase1.ExitCode  // Value to return to OS on Exit()
+	// How to route UIs. Nil if we're in standalone mode or in
+	// tests, and non-nil in service mode.
+	UIRouter UIRouter
+	ExitCode keybase1.ExitCode // Value to return to OS on Exit()
 }
 
 func NewGlobalContext() *GlobalContext {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -350,8 +350,12 @@ type UI interface {
 
 type UIRouter interface {
 	SetUI(ConnectionID, UIKind)
+
+	// Both of these are allowed to return nil for the UI even if
+	// error is nil.
 	GetIdentifyUI() (IdentifyUI, error)
 	GetSecretUI() (SecretUI, error)
+
 	Shutdown()
 }
 

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -540,19 +540,16 @@ type EncryptedBytes32 [48]byte
 type BoxNonce [24]byte
 type BoxPublicKey [32]byte
 type SignED25519Arg struct {
-	SessionID int    `codec:"sessionID" json:"sessionID"`
-	Msg       []byte `codec:"msg" json:"msg"`
-	Reason    string `codec:"reason" json:"reason"`
+	Msg    []byte `codec:"msg" json:"msg"`
+	Reason string `codec:"reason" json:"reason"`
 }
 
 type SignToStringArg struct {
-	SessionID int    `codec:"sessionID" json:"sessionID"`
-	Msg       []byte `codec:"msg" json:"msg"`
-	Reason    string `codec:"reason" json:"reason"`
+	Msg    []byte `codec:"msg" json:"msg"`
+	Reason string `codec:"reason" json:"reason"`
 }
 
 type UnboxBytes32Arg struct {
-	SessionID        int              `codec:"sessionID" json:"sessionID"`
 	EncryptedBytes32 EncryptedBytes32 `codec:"encryptedBytes32" json:"encryptedBytes32"`
 	Nonce            BoxNonce         `codec:"nonce" json:"nonce"`
 	PeersPublicKey   BoxPublicKey     `codec:"peersPublicKey" json:"peersPublicKey"`

--- a/go/service/crypto.go
+++ b/go/service/crypto.go
@@ -79,8 +79,6 @@ func (c *CryptoHandler) getSecretUI() libkb.SecretUI {
 	return errorSecretUI{}
 }
 
-// TODO: Remove sessionID from args.
-
 func (c *CryptoHandler) SignED25519(_ context.Context, arg keybase1.SignED25519Arg) (keybase1.ED25519SignatureInfo, error) {
 	return engine.SignED25519(c.G(), c.getSecretUI(), arg)
 }

--- a/go/service/crypto.go
+++ b/go/service/crypto.go
@@ -39,35 +39,29 @@ func (c *CryptoHandler) getDelegatedSecretUI() libkb.SecretUI {
 	return ui
 }
 
-type secretUIError struct{}
-
-func (secretUIError) Error() string {
-	return "Cannot fulfill SecretUI method"
-}
-
-// A libkb.SecretUI implementation that always returns an error.
+// A libkb.SecretUI implementation that always returns a LoginRequiredError.
 type errorSecretUI struct{}
 
 var _ libkb.SecretUI = errorSecretUI{}
 
 func (errorSecretUI) GetSecret(keybase1.SecretEntryArg, *keybase1.SecretEntryArg) (*keybase1.SecretEntryRes, error) {
-	return nil, secretUIError{}
+	return nil, libkb.LoginRequiredError{}
 }
 
 func (errorSecretUI) GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.GetPassphraseRes, error) {
-	return keybase1.GetPassphraseRes{}, secretUIError{}
+	return keybase1.GetPassphraseRes{}, libkb.LoginRequiredError{}
 }
 
 func (errorSecretUI) GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (keybase1.GetPassphraseRes, error) {
-	return keybase1.GetPassphraseRes{}, secretUIError{}
+	return keybase1.GetPassphraseRes{}, libkb.LoginRequiredError{}
 }
 
 func (errorSecretUI) GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) (string, error) {
-	return "", secretUIError{}
+	return "", libkb.LoginRequiredError{}
 }
 
 func (errorSecretUI) GetPassphrase(keybase1.GUIEntryArg, *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
-	return keybase1.GetPassphraseRes{}, secretUIError{}
+	return keybase1.GetPassphraseRes{}, libkb.LoginRequiredError{}
 }
 
 func (c *CryptoHandler) getSecretUI() libkb.SecretUI {

--- a/go/service/crypto.go
+++ b/go/service/crypto.go
@@ -25,7 +25,7 @@ func (c *CryptoHandler) getDelegatedSecretUI() libkb.SecretUI {
 	// should be non-nil.
 	ui, err := c.G().UIRouter.GetSecretUI()
 	if err != nil {
-		c.G().Log.Debug("UIRouter.GetSecretUI() returned %v", err)
+		c.G().Log.Debug("UIRouter.GetSecretUI() returned an error %v", err)
 		return nil
 	}
 

--- a/go/service/crypto.go
+++ b/go/service/crypto.go
@@ -7,7 +7,6 @@ import (
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
-	rpc "github.com/keybase/go-framed-msgpack-rpc"
 	"golang.org/x/net/context"
 )
 
@@ -15,7 +14,7 @@ type CryptoHandler struct {
 	libkb.Contextified
 }
 
-func NewCryptoHandler(xp rpc.Transporter, g *libkb.GlobalContext) *CryptoHandler {
+func NewCryptoHandler(g *libkb.GlobalContext) *CryptoHandler {
 	return &CryptoHandler{
 		Contextified: libkb.NewContextified(g),
 	}

--- a/go/service/crypto.go
+++ b/go/service/crypto.go
@@ -21,11 +21,8 @@ func NewCryptoHandler(g *libkb.GlobalContext) *CryptoHandler {
 }
 
 func (c *CryptoHandler) getDelegatedSecretUI() libkb.SecretUI {
-	if c.G().UIRouter == nil {
-		c.G().Log.Debug("no UIRouter to get SecretUI from")
-		return nil
-	}
-
+	// We should only ever be called in service mode, so UIRouter
+	// should be non-nil.
 	ui, err := c.G().UIRouter.GetSecretUI()
 	if err != nil {
 		c.G().Log.Debug("UIRouter.GetSecretUI() returned %v", err)

--- a/go/service/crypto.go
+++ b/go/service/crypto.go
@@ -12,25 +12,84 @@ import (
 )
 
 type CryptoHandler struct {
-	*BaseHandler
 	libkb.Contextified
 }
 
 func NewCryptoHandler(xp rpc.Transporter, g *libkb.GlobalContext) *CryptoHandler {
 	return &CryptoHandler{
-		BaseHandler:  NewBaseHandler(xp),
 		Contextified: libkb.NewContextified(g),
 	}
 }
 
+func (c *CryptoHandler) getDelegatedSecretUI() libkb.SecretUI {
+	if c.G().UIRouter == nil {
+		c.G().Log.Debug("no UIRouter to get SecretUI from")
+		return nil
+	}
+
+	ui, err := c.G().UIRouter.GetSecretUI()
+	if err != nil {
+		c.G().Log.Debug("UIRouter.GetSecretUI() returned %v", err)
+		return nil
+	}
+
+	if ui == nil {
+		c.G().Log.Debug("UIRouter.GetSecretUI() returned nil")
+	}
+
+	return ui
+}
+
+type secretUIError struct{}
+
+func (secretUIError) Error() string {
+	return "Cannot fulfill SecretUI method"
+}
+
+// A libkb.SecretUI implementation that always returns an error.
+type errorSecretUI struct{}
+
+var _ libkb.SecretUI = errorSecretUI{}
+
+func (errorSecretUI) GetSecret(keybase1.SecretEntryArg, *keybase1.SecretEntryArg) (*keybase1.SecretEntryRes, error) {
+	return nil, secretUIError{}
+}
+
+func (errorSecretUI) GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.GetPassphraseRes, error) {
+	return keybase1.GetPassphraseRes{}, secretUIError{}
+}
+
+func (errorSecretUI) GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (keybase1.GetPassphraseRes, error) {
+	return keybase1.GetPassphraseRes{}, secretUIError{}
+}
+
+func (errorSecretUI) GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) (string, error) {
+	return "", secretUIError{}
+}
+
+func (errorSecretUI) GetPassphrase(keybase1.GUIEntryArg, *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
+	return keybase1.GetPassphraseRes{}, secretUIError{}
+}
+
+func (c *CryptoHandler) getSecretUI() libkb.SecretUI {
+	secretUI := c.getDelegatedSecretUI()
+	if secretUI != nil {
+		return secretUI
+	}
+
+	return errorSecretUI{}
+}
+
+// TODO: Remove sessionID from args.
+
 func (c *CryptoHandler) SignED25519(_ context.Context, arg keybase1.SignED25519Arg) (keybase1.ED25519SignatureInfo, error) {
-	return engine.SignED25519(c.G(), c.getSecretUI(arg.SessionID), arg)
+	return engine.SignED25519(c.G(), c.getSecretUI(), arg)
 }
 
 func (c *CryptoHandler) SignToString(_ context.Context, arg keybase1.SignToStringArg) (string, error) {
-	return engine.SignToString(c.G(), c.getSecretUI(arg.SessionID), arg)
+	return engine.SignToString(c.G(), c.getSecretUI(), arg)
 }
 
 func (c *CryptoHandler) UnboxBytes32(_ context.Context, arg keybase1.UnboxBytes32Arg) (keybase1.Bytes32, error) {
-	return engine.UnboxBytes32(c.G(), c.getSecretUI(arg.SessionID), arg)
+	return engine.UnboxBytes32(c.G(), c.getSecretUI(), arg)
 }

--- a/go/service/crypto_test.go
+++ b/go/service/crypto_test.go
@@ -58,7 +58,7 @@ func TestCryptoSecretUI(t *testing.T) {
 	// Should return errorSecretUI because UIRouter returned an
 	// error.
 	tc.G.SetUIRouter(fakeUIRouter{secretUIErr: errors.New("fake error")})
-	secretUI = c.getSecretUI("")
+	secretUI := c.getSecretUI("")
 	if _, ok := secretUI.(errorSecretUI); !ok {
 		t.Error("secretUI %v is not an errorSecretUI", secretUI)
 	}

--- a/go/service/crypto_test.go
+++ b/go/service/crypto_test.go
@@ -55,12 +55,6 @@ func TestCryptoSecretUI(t *testing.T) {
 
 	c := NewCryptoHandler(tc.G)
 
-	// Should return errorSecretUI because there is no UIRouter.
-	secretUI := c.getSecretUI("")
-	if _, ok := secretUI.(errorSecretUI); !ok {
-		t.Error("secretUI %v is not an errorSecretUI", secretUI)
-	}
-
 	// Should return errorSecretUI because UIRouter returned an
 	// error.
 	tc.G.SetUIRouter(fakeUIRouter{secretUIErr: errors.New("fake error")})

--- a/go/service/crypto_test.go
+++ b/go/service/crypto_test.go
@@ -1,0 +1,18 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+)
+
+func TestCryptoErrorSecretUI(t *testing.T) {
+	tc := libkb.SetupTest(t, "crypto")
+	defer tc.Cleanup()
+
+	c := NewCryptoHandler(tc.G)
+	secretUI := c.getSecretUI("")
+	if _, ok := secretUI.(errorSecretUI); !ok {
+		t.Error("secretUI %v is not an errorSecretUI", secretUI)
+	}
+}

--- a/go/service/crypto_test.go
+++ b/go/service/crypto_test.go
@@ -1,18 +1,85 @@
 package service
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol"
 )
 
-func TestCryptoErrorSecretUI(t *testing.T) {
+type fakeUIRouter struct {
+	secretUI    libkb.SecretUI
+	secretUIErr error
+}
+
+var _ libkb.UIRouter = fakeUIRouter{}
+
+func (f fakeUIRouter) SetUI(libkb.ConnectionID, libkb.UIKind) {}
+
+func (f fakeUIRouter) GetIdentifyUI() (libkb.IdentifyUI, error) {
+	return nil, errors.New("Unexpected GetIdentifyUI call")
+}
+
+func (f fakeUIRouter) GetSecretUI() (libkb.SecretUI, error) {
+	return f.secretUI, f.secretUIErr
+}
+
+func (f fakeUIRouter) Shutdown() {}
+
+type nullSecretUI struct{}
+
+func (nullSecretUI) GetSecret(keybase1.SecretEntryArg, *keybase1.SecretEntryArg) (*keybase1.SecretEntryRes, error) {
+	return nil, nil
+}
+
+func (nullSecretUI) GetNewPassphrase(keybase1.GetNewPassphraseArg) (keybase1.GetPassphraseRes, error) {
+	return keybase1.GetPassphraseRes{}, nil
+}
+
+func (nullSecretUI) GetKeybasePassphrase(keybase1.GetKeybasePassphraseArg) (keybase1.GetPassphraseRes, error) {
+	return keybase1.GetPassphraseRes{}, nil
+}
+
+func (nullSecretUI) GetPaperKeyPassphrase(keybase1.GetPaperKeyPassphraseArg) (string, error) {
+	return "", nil
+}
+
+func (nullSecretUI) GetPassphrase(keybase1.GUIEntryArg, *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
+	return keybase1.GetPassphraseRes{}, nil
+}
+
+func TestCryptoSecretUI(t *testing.T) {
 	tc := libkb.SetupTest(t, "crypto")
 	defer tc.Cleanup()
 
 	c := NewCryptoHandler(tc.G)
+
+	// Should return errorSecretUI because there is no UIRouter.
 	secretUI := c.getSecretUI("")
 	if _, ok := secretUI.(errorSecretUI); !ok {
 		t.Error("secretUI %v is not an errorSecretUI", secretUI)
+	}
+
+	// Should return errorSecretUI because UIRouter returned an
+	// error.
+	tc.G.SetUIRouter(fakeUIRouter{secretUIErr: errors.New("fake error")})
+	secretUI = c.getSecretUI("")
+	if _, ok := secretUI.(errorSecretUI); !ok {
+		t.Error("secretUI %v is not an errorSecretUI", secretUI)
+	}
+
+	// Should return errorSecretUI because UIRouter returned nil.
+	tc.G.SetUIRouter(fakeUIRouter{})
+	secretUI = c.getSecretUI("")
+	if _, ok := secretUI.(errorSecretUI); !ok {
+		t.Error("secretUI %v is not an errorSecretUI", secretUI)
+	}
+
+	// Should return nullSecretUI..
+	tc.G.SetUIRouter(fakeUIRouter{secretUI: nullSecretUI{}})
+	secretUI = c.getSecretUI("")
+	if _, ok := secretUI.(nullSecretUI); !ok {
+		t.Error("secretUI %v is not a nullSecretUI", secretUI)
 	}
 }

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -46,7 +46,7 @@ func (d *Service) RegisterProtocols(srv *rpc.Server, xp rpc.Transporter, connID 
 		keybase1.AccountProtocol(NewAccountHandler(xp, g)),
 		keybase1.BTCProtocol(NewBTCHandler(xp, g)),
 		keybase1.ConfigProtocol(NewConfigHandler(xp, g, d)),
-		keybase1.CryptoProtocol(NewCryptoHandler(xp, g)),
+		keybase1.CryptoProtocol(NewCryptoHandler(g)),
 		keybase1.CtlProtocol(NewCtlHandler(xp, d, g)),
 		keybase1.DebuggingProtocol(NewDebuggingHandler(xp)),
 		keybase1.DeviceProtocol(NewDeviceHandler(xp, g)),

--- a/protocol/avdl/crypto.avdl
+++ b/protocol/avdl/crypto.avdl
@@ -18,12 +18,12 @@ protocol crypto {
     is used as part of the SecretEntryArg object passed into
     secretUi.getSecret().
     */
-  ED25519SignatureInfo signED25519(int sessionID, bytes msg, string reason);
+  ED25519SignatureInfo signED25519(bytes msg, string reason);
 
   /**
     Same as the above except the full marsheled and encoded NaclSigInfo.
     */
-  string signToString(int sessionID, bytes msg, string reason);
+  string signToString(bytes msg, string reason);
 
   fixed Bytes32(32);
   // 32 + fixed-size nacl/box overhead.
@@ -37,5 +37,5 @@ protocol crypto {
     decrypted data. The 'reason' parameter is used as part of the
     SecretEntryArg object passed into secretUi.getSecret().
     */
-  Bytes32 unboxBytes32(int sessionID, EncryptedBytes32 encryptedBytes32, BoxNonce nonce, BoxPublicKey peersPublicKey, string reason);
+  Bytes32 unboxBytes32(EncryptedBytes32 encryptedBytes32, BoxNonce nonce, BoxPublicKey peersPublicKey, string reason);
 }

--- a/protocol/json/crypto.json
+++ b/protocol/json/crypto.json
@@ -40,9 +40,6 @@
     "signED25519" : {
       "doc" : "Sign the given message (which should be small) using the device's private\n    signing ED25519 key, and return the signature as well as the corresponding\n    public key that can be used to verify the signature. The 'reason' parameter\n    is used as part of the SecretEntryArg object passed into\n    secretUi.getSecret().",
       "request" : [ {
-        "name" : "sessionID",
-        "type" : "int"
-      }, {
         "name" : "msg",
         "type" : "bytes"
       }, {
@@ -54,9 +51,6 @@
     "signToString" : {
       "doc" : "Same as the above except the full marsheled and encoded NaclSigInfo.",
       "request" : [ {
-        "name" : "sessionID",
-        "type" : "int"
-      }, {
         "name" : "msg",
         "type" : "bytes"
       }, {
@@ -68,9 +62,6 @@
     "unboxBytes32" : {
       "doc" : "Decrypt exactly 32 bytes using nacl/box with the given nonce, the given\n    peer's public key, and the device's private encryption key, and return the\n    decrypted data. The 'reason' parameter is used as part of the\n    SecretEntryArg object passed into secretUi.getSecret().",
       "request" : [ {
-        "name" : "sessionID",
-        "type" : "int"
-      }, {
         "name" : "encryptedBytes32",
         "type" : "EncryptedBytes32"
       }, {


### PR DESCRIPTION
Otherwise, have it use a SecretUI that always returns
an error.

This fixes a crash when there's no terminal available
for pinentry.