### PR TITLE
Switch to personal fork of menubar until fix is merged

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -23,7 +23,7 @@
     "immutable": "^3.7.5",
     "lodash": "^3.10.1",
     "material-ui": "^0.13.3",
-    "menubar": "^2.3.0",
+    "menubar": "keybase/menubar",
     "moment": "^2.10.6",
     "nslog": "^3.0.0",
     "purepack": "keybase/purepack#nojima/keybase-client-changes",


### PR DESCRIPTION
@keybase/react-hackers 

Fixes: 
![2015-12-01 at 5 34 pm](https://cloud.githubusercontent.com/assets/594035/11732975/4cc5b5c6-9f5e-11e5-9d4a-dea113e3fd91.png)

Into:
<img width="99" alt="screen shot 2015-12-10 at 4 35 23 pm" src="https://cloud.githubusercontent.com/assets/594035/11732979/53bfb6ce-9f5e-11e5-89c0-1619d81e298c.png">

I'll be PR'ing this change to menubar & electron-positioner so we can get off my fork eventually.