### PR TITLE
Fix for 2225: check username returned by pgpLookup

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -153,5 +153,5 @@ fi
 
 # checkLineLength
 check_go_fmt
-#check_go_vet
+check_go_vet
 check_make_lint

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -153,5 +153,5 @@ fi
 
 # checkLineLength
 check_go_fmt
-check_go_vet
+#check_go_vet
 check_make_lint

--- a/go/engine/gpg_test.go
+++ b/go/engine/gpg_test.go
@@ -80,3 +80,38 @@ func (g *gpgPubOnlyTestUI) SelectKeyAndPushOption(_ context.Context, arg keybase
 	key := arg.Keys[0]
 	return keybase1.SelectKeyRes{KeyID: key.KeyID, DoSecretPush: false}, nil
 }
+
+// selects a key by email address
+type gpgSelectEmailUI struct {
+	*gpgtestui
+	Email string
+}
+
+func newGPGSelectEmailUI(email string) *gpgSelectEmailUI {
+	return &gpgSelectEmailUI{
+		gpgtestui: &gpgtestui{},
+		Email:     email,
+	}
+}
+
+func (g *gpgSelectEmailUI) SelectKey(_ context.Context, arg keybase1.SelectKeyArg) (string, error) {
+	for _, key := range arg.Keys {
+		for _, id := range key.Identities {
+			if id.Email == g.Email {
+				return key.KeyID, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no keys found for email %q", g.Email)
+}
+
+func (g *gpgSelectEmailUI) SelectKeyAndPushOption(_ context.Context, arg keybase1.SelectKeyAndPushOptionArg) (keybase1.SelectKeyRes, error) {
+	for _, key := range arg.Keys {
+		for _, id := range key.Identities {
+			if id.Email == g.Email {
+				return keybase1.SelectKeyRes{KeyID: key.KeyID, DoSecretPush: false}, nil
+			}
+		}
+	}
+	return keybase1.SelectKeyRes{}, fmt.Errorf("no keys found for email %q", g.Email)
+}

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -533,9 +533,7 @@ func (e *LoginProvision) checkEmailOrUsername(ctx *Context, emailOrUsername stri
 // loadUser will load the user by name specified in e.username.
 func (e *LoginProvision) loadUser(ctx *Context) (*libkb.User, error) {
 	if len(e.username) == 0 {
-		// XXX temp:
-		// 		return nil, libkb.NoUsernameError{}
-		e.username = e.arg.Username
+		return nil, libkb.NoUsernameError{}
 	}
 	e.G().Log.Debug("LoginProvision: loading user %s", e.username)
 	arg := libkb.NewLoadUserByNameArg(e.G(), e.username)
@@ -792,7 +790,7 @@ func (e *LoginProvision) checkUserByPGPFingerprint(ctx *Context, fp *libkb.PGPFi
 		return libkb.NotFoundError{Msg: fmt.Sprintf("No keybase user found for PGP fingerprint %s; please try a different GPG key or another provisioning method", fp)}
 	}
 
-	e.G().Log.Debug("found user (%s, %s) for key %s", username, uid, fp)
+	e.G().Log.Debug("found user (%q, %q) for key %s", username, uid, fp)
 
 	// if so, will have username from that
 	e.username = username

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -533,7 +533,9 @@ func (e *LoginProvision) checkEmailOrUsername(ctx *Context, emailOrUsername stri
 // loadUser will load the user by name specified in e.username.
 func (e *LoginProvision) loadUser(ctx *Context) (*libkb.User, error) {
 	if len(e.username) == 0 {
-		return nil, libkb.NoUsernameError{}
+		// XXX temp:
+		// 		return nil, libkb.NoUsernameError{}
+		e.username = e.arg.Username
 	}
 	e.G().Log.Debug("LoginProvision: loading user %s", e.username)
 	arg := libkb.NewLoadUserByNameArg(e.G(), e.username)
@@ -784,6 +786,12 @@ func (e *LoginProvision) checkUserByPGPFingerprint(ctx *Context, fp *libkb.PGPFi
 		e.G().Log.Debug("error finding user for fp %s: %s", fp, err)
 		return err
 	}
+
+	// even if there was no error, make sure it found something
+	if len(username) == 0 {
+		return libkb.NotFoundError{Msg: fmt.Sprintf("No keybase user found for PGP fingerprint %s; please try a different GPG key or another provisioning method", fp)}
+	}
+
 	e.G().Log.Debug("found user (%s, %s) for key %s", username, uid, fp)
 
 	// if so, will have username from that

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -681,7 +681,11 @@ func (e *LoginProvision) chooseGPGKey(ctx *Context) (libkb.GenericKey, error) {
 	}
 
 	// get KID for the pgp key
-	kid, err := e.user.GetComputedKeyFamily().FindKIDFromFingerprint(*fp)
+	kf := e.user.GetComputedKeyFamily()
+	if kf == nil {
+		return nil, libkb.KeyFamilyError{Msg: "no key family for user"}
+	}
+	kid, err := kf.FindKIDFromFingerprint(*fp)
 	if err != nil {
 		return nil, err
 	}

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -526,7 +526,7 @@ func TestProvisionGPGSign(t *testing.T) {
 	}
 }
 
-// Provision device using a private GPG key that is not associated
+// Provision device first trying a private GPG key that is not associated
 // with a keybase account.
 func TestProvisionGPGUnknown(t *testing.T) {
 	tc := SetupEngineTest(t, "login")
@@ -562,10 +562,9 @@ func TestProvisionGPGUnknown(t *testing.T) {
 	if err == nil {
 		t.Fatalf("No provisioning error, expected an error using gpg key for %s", otherEmail)
 	}
-
-	config := tc2.G.Env.GetConfig()
-	fmt.Printf("config username: %s\n", config.GetUsername())
-	fmt.Printf("config device id: %s\n", config.GetDeviceID())
+	if _, ok := err.(libkb.NotFoundError); !ok {
+		t.Fatalf("provisioning error type: %T, expected libkb.NotFoundError", err)
+	}
 
 	// run login again, selecting the correct key
 	ctx.GPGUI = newGPGSelectEmailUI(u1.Email)
@@ -588,6 +587,72 @@ func TestProvisionGPGUnknown(t *testing.T) {
 	// since they *did not* import a pgp key, they should *not* be able to pgp sign something:
 	if err := signString(tc2, "sign me", u1.NewSecretUI()); err == nil {
 		t.Error("pgp sign worked after gpg provision w/o import")
+		t.Fatal(err)
+	}
+}
+
+// Provision device first trying a private GPG key that is not associated
+// with a keybase account, selecting the import private to kb
+// lksec option.
+func TestProvisionGPGImportUnknown(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	otherEmail := "gpg@gpg.com"
+	u1 := createFakeUserWithPGPMultSubset(t, tc, otherEmail)
+	Logout(tc)
+
+	// redo SetupEngineTest to get a new home directory...should look like a new device.
+	tc2 := SetupEngineTest(t, "login")
+	defer tc2.Cleanup()
+
+	// we need the gpg keyring that's in the first homedir
+	if err := tc.MoveGpgKeyringTo(tc2); err != nil {
+		t.Fatal(err)
+	}
+
+	// now safe to cleanup first home
+	tc.Cleanup()
+
+	// run login on new device, selecting the key for otherEmail for signing,
+	// which isn't associated with a keybase account.
+	ctx := &Context{
+		ProvisionUI: newTestProvisionUIGPGImport(),
+		LogUI:       tc2.G.UI.GetLogUI(),
+		SecretUI:    u1.NewSecretUI(),
+		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
+		GPGUI:       newGPGSelectEmailUI(otherEmail),
+	}
+	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, u1.Username, keybase1.ClientType_CLI)
+	err := RunEngine(eng, ctx)
+	if err == nil {
+		t.Fatalf("No provisioning error, expected an error using gpg key for %s", otherEmail)
+	}
+	if _, ok := err.(libkb.NotFoundError); !ok {
+		t.Fatalf("provisioning error type: %T, expected libkb.NotFoundError", err)
+	}
+
+	// run login again, selecting the correct key
+	ctx.GPGUI = newGPGSelectEmailUI(u1.Email)
+	eng = NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure everything is ok
+
+	testUserHasDeviceKey(tc2)
+
+	// highly possible they didn't have a paper key, so make sure they have one now:
+	hasOnePaperDev(tc2, u1)
+
+	if err := AssertProvisioned(tc2); err != nil {
+		t.Fatal(err)
+	}
+
+	// since they imported their pgp key, they should be able to pgp sign something:
+	if err := signString(tc2, "sign me", u1.NewSecretUI()); err != nil {
+		t.Error("pgp sign failed after gpg provision w/ import")
 		t.Fatal(err)
 	}
 }

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -526,6 +526,72 @@ func TestProvisionGPGSign(t *testing.T) {
 	}
 }
 
+// Provision device using a private GPG key that is not associated
+// with a keybase account.
+func TestProvisionGPGUnknown(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	otherEmail := "gpg@gpg.com"
+	u1 := createFakeUserWithPGPMultSubset(t, tc, otherEmail)
+	Logout(tc)
+
+	// redo SetupEngineTest to get a new home directory...should look like a new device.
+	tc2 := SetupEngineTest(t, "login")
+	defer tc2.Cleanup()
+
+	// we need the gpg keyring that's in the first homedir
+	if err := tc.MoveGpgKeyringTo(tc2); err != nil {
+		t.Fatal(err)
+	}
+
+	// now safe to cleanup first home
+	tc.Cleanup()
+
+	// run login on new device, selecting the key for otherEmail for signing,
+	// which isn't associated with a keybase account.
+	ctx := &Context{
+		ProvisionUI: newTestProvisionUIGPGSign(),
+		LogUI:       tc2.G.UI.GetLogUI(),
+		SecretUI:    u1.NewSecretUI(),
+		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
+		GPGUI:       newGPGSelectEmailUI(otherEmail),
+	}
+	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, u1.Username, keybase1.ClientType_CLI)
+	err := RunEngine(eng, ctx)
+	if err == nil {
+		t.Fatalf("No provisioning error, expected an error using gpg key for %s", otherEmail)
+	}
+
+	config := tc2.G.Env.GetConfig()
+	fmt.Printf("config username: %s\n", config.GetUsername())
+	fmt.Printf("config device id: %s\n", config.GetDeviceID())
+
+	// run login again, selecting the correct key
+	ctx.GPGUI = newGPGSelectEmailUI(u1.Email)
+	eng = NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure everything is ok
+
+	testUserHasDeviceKey(tc2)
+
+	// highly possible they didn't have a paper key, so make sure they have one now:
+	hasOnePaperDev(tc2, u1)
+
+	if err := AssertProvisioned(tc2); err != nil {
+		t.Fatal(err)
+	}
+
+	// since they *did not* import a pgp key, they should *not* be able to pgp sign something:
+	if err := signString(tc2, "sign me", u1.NewSecretUI()); err == nil {
+		t.Error("pgp sign worked after gpg provision w/o import")
+		t.Fatal(err)
+	}
+}
+
 func TestProvisionGPGSignFailedSign(t *testing.T) {
 	tc := SetupEngineTest(t, "login")
 	defer tc.Cleanup()

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -219,14 +219,14 @@ func (e BadSigError) Error() string {
 //=============================================================================
 
 type NotFoundError struct {
-	msg string
+	Msg string
 }
 
 func (e NotFoundError) Error() string {
-	if len(e.msg) == 0 {
+	if len(e.Msg) == 0 {
 		return "Not found"
 	}
-	return e.msg
+	return e.Msg
 }
 
 //=============================================================================


### PR DESCRIPTION
Also adds tests for users selecting gpg keys not associated with any keybase accounts.

r? @maxtaco 