### PR TITLE
libkb: updated Resolve machinery, for use with Resolve RPC

### DIFF
--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Installer tweak: don't prompt to start service (windows)
 - Ansi color code support for terminal (Windows)
 - EdDSA for OpenPGP support (PR: keybase/client#1519)
-- Resolve RPC support (PR: keybase/client#1498)
+- Resolve RPC support (PR: keybase/client#1520)
 
 ## 1.0.5-0 (2015-12-01)
 

--- a/go/engine/untrack.go
+++ b/go/engine/untrack.go
@@ -123,7 +123,7 @@ func (e *UntrackEngine) loadThem() (them *libkb.User, remoteLink, localLink *lib
 	}
 
 	if uid.IsNil() {
-		res := libkb.ResolveUID(e.arg.Username)
+		res := e.G().Resolver.Resolve(e.arg.Username)
 		if err = res.GetError(); err != nil {
 			return
 		}

--- a/go/libkb/assertion.go
+++ b/go/libkb/assertion.go
@@ -411,10 +411,10 @@ func RegisterSocialNetwork(s string) {
 	_socialNetworks[s] = true
 }
 
-func FindBestIdentifyComponent(e AssertionExpression) string {
+func FindBestIdentifyComponentURL(e AssertionExpression) AssertionURL {
 	urls := e.CollectUrls(nil)
 	if len(urls) == 0 {
-		return ""
+		return nil
 	}
 
 	var uid, kb, soc, fp AssertionURL
@@ -437,10 +437,18 @@ func FindBestIdentifyComponent(e AssertionExpression) string {
 	order := []AssertionURL{uid, kb, fp, soc, urls[0]}
 	for _, p := range order {
 		if p != nil {
-			return p.String()
+			return p
 		}
 	}
-	return ""
+	return nil
+}
+
+func FindBestIdentifyComponent(e AssertionExpression) string {
+	u := FindBestIdentifyComponentURL(e)
+	if u == nil {
+		return ""
+	}
+	return u.String()
 }
 
 func CollectAssertions(e AssertionExpression) (remotes AssertionAnd, locals AssertionAnd) {

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -110,6 +110,7 @@ const (
 	SCAlreadyLoggedIn        = 235
 	SCCanceled               = 237
 	SCReloginRequired        = 274
+	SCResolutionFailed       = 275
 	SCBadSignupUsernameTaken = 701
 	SCMissingResult          = 801
 	SCKeyNotFound            = 901

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1207,3 +1207,14 @@ func (e UnmetAssertionError) Error() string {
 	}
 	return fmt.Sprintf("Unmet %s assertions for user %q", which, e.User)
 }
+
+//=============================================================================
+
+type ResolutionError struct {
+	Input string
+	Msg   string
+}
+
+func (e ResolutionError) Error() string {
+	return fmt.Sprintf("In resolving '%s': %s", e.Input, e.Msg)
+}

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -34,7 +34,7 @@ type GlobalContext struct {
 	Env               *Env           // Env variables, cmdline args & config
 	Keyrings          *Keyrings      // Gpg Keychains holding keys
 	API               API            // How to make a REST call to the server
-	ResolveCache      *ResolveCache  // cache of resolve results
+	Resolver          *Resolver      // cache of resolve results
 	LocalDb           *JSONLocalDb   // Local DB for cache
 	MerkleClient      *MerkleClient  // client for querying server's merkle sig tree
 	XAPI              ExternalAPI    // for contacting Twitter, Github, etc.
@@ -85,6 +85,7 @@ func (g *GlobalContext) Init() {
 	g.Env = NewEnv(nil, nil)
 	g.Service = false
 	g.createLoginState()
+	g.Resolver = NewResolver(g)
 }
 
 func (g *GlobalContext) SetService() {
@@ -201,7 +202,7 @@ func (g *GlobalContext) ConfigureAPI() error {
 }
 
 func (g *GlobalContext) ConfigureCaches() error {
-	g.ResolveCache = NewResolveCache()
+	g.Resolver.EnableCaching()
 	g.TrackCache = NewTrackCache()
 	g.Identify2Cache = NewIdentify2Cache(g.Env.GetUserCacheMaxAge())
 	g.ProofCache = NewProofCache(g, g.Env.GetProofCacheSize())

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -81,7 +81,7 @@ func (arg *LoadUserArg) resolveUID() (ResolveResult, error) {
 		return rres, fmt.Errorf("resolveUID:  no uid or name")
 	}
 
-	if rres = ResolveUID(arg.Name); rres.err != nil {
+	if rres = arg.G().Resolver.Resolve(arg.Name); rres.err != nil {
 		return rres, rres.err
 	}
 

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -78,10 +78,10 @@ func (arg *LoadUserArg) resolveUID() (ResolveResult, error) {
 	if len(arg.Name) == 0 {
 		// this won't happen anymore because check moved to
 		// checkUIDName() func, but just in case
-		return rres, fmt.Errorf("resolveUID:  no uid or name")
+		return rres, fmt.Errorf("resolveUID: no uid or name")
 	}
 
-	if rres = arg.G().Resolver.Resolve(arg.Name); rres.err != nil {
+	if rres = arg.G().Resolver.ResolveWithBody(arg.Name); rres.err != nil {
 		return rres, rres.err
 	}
 

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -4,21 +4,27 @@
 package libkb
 
 import (
-	"fmt"
-	"sync"
-
 	keybase1 "github.com/keybase/client/go/protocol"
 	jsonw "github.com/keybase/go-jsonw"
+	"stathat.com/c/ramcache"
+	"time"
 )
-
-//==================================================================
 
 type ResolveResult struct {
 	uid        keybase1.UID
 	body       *jsonw.Wrapper
 	err        error
 	kbUsername string
+	cachedAt   time.Time
+	mutable    bool
 }
+
+const (
+	resolveCacheTTL           = 12 * time.Hour
+	resolveCacheMaxAge        = 12 * time.Hour
+	resolveCacheMaxAgeMutable = 20 * time.Minute
+	resolveCacheMaxAgeErrored = 5 * time.Second
+)
 
 func (res *ResolveResult) GetUID() keybase1.UID {
 	return res.uid
@@ -28,29 +34,31 @@ func (res *ResolveResult) GetError() error {
 	return res.err
 }
 
-func ResolveUID(input string) (res ResolveResult) {
-	G.Log.Debug("+ Resolving username %s", input)
+func (r *Resolver) Resolve(input string) (res ResolveResult) {
+	r.G().Log.Debug("+ Resolving username %s", input)
 	var au AssertionURL
 	if au, res.err = ParseAssertionURL(input, false); res.err != nil {
 		return
 	}
-	res = resolveUID(au)
+	res = r.resolveURL(au, input)
 	return
 }
 
-func ResolveUIDValuePair(key, value string) (res ResolveResult) {
-	G.Log.Debug("+ Resolve username (%s,%s)", key, value)
-
-	var au AssertionURL
-	if au, res.err = ParseAssertionURLKeyValue(key, value, false); res.err != nil {
-		res = resolveUID(au)
+func (r *Resolver) ResolveFullExpression(input string) (res ResolveResult) {
+	var expr AssertionExpression
+	expr, res.err = AssertionParseAndOnly(input)
+	if res.err != nil {
+		return res
 	}
-
-	G.Log.Debug("- Resolve username (%s,%s) -> %v", key, value, res.uid)
-	return
+	u := FindBestIdentifyComponentURL(expr)
+	if u == nil {
+		res.err = ResolutionError{Input: input, Msg: "Cannot find a resolvable factor"}
+		return res
+	}
+	return r.resolveURL(u, input)
 }
 
-func resolveUID(au AssertionURL) ResolveResult {
+func (r *Resolver) resolveURL(au AssertionURL, input string) ResolveResult {
 	// A standard keybase UID, so it's already resolved
 	if tmp := au.ToUID(); tmp.Exists() {
 		return ResolveResult{uid: tmp}
@@ -58,31 +66,20 @@ func resolveUID(au AssertionURL) ResolveResult {
 
 	ck := au.CacheKey()
 
-	if G.ResolveCache == nil {
-		return ResolveResult{}
-	}
-
-	if p := G.ResolveCache.Get(ck); p != nil {
+	if p := r.getCache(ck); p != nil {
 		return *p
 	}
 
-	r := resolveUsername(au)
+	res := r.resolveURLViaServerLookup(au, input)
 
-	if r.err != nil {
-		// Don't add to the cache if the resolve failed.
-		return r
-	}
+	// Cache for a shorter period of time if it's not a Keybase identity
+	res.mutable = !au.IsKeybase()
 
-	if !au.IsKeybase() {
-		// Don't add to the cache if it's a mutable identity.
-		return r
-	}
-
-	G.ResolveCache.Put(ck, r)
-	return r
+	r.putCache(ck, res)
+	return res
 }
 
-func resolveUsername(au AssertionURL) (res ResolveResult) {
+func (r *Resolver) resolveURLViaServerLookup(au AssertionURL, input string) (res ResolveResult) {
 
 	var key, val string
 	var ares *APIRes
@@ -99,7 +96,7 @@ func resolveUsername(au AssertionURL) (res ResolveResult) {
 	ha := HTTPArgsFromKeyValuePair(key, S{val})
 	ha.Add("multi", I{1})
 	ha.Add("fields", S{"basics,public_keys,pictures"})
-	ares, res.err = G.API.Get(APIArg{
+	ares, res.err = r.G().API.Get(APIArg{
 		Endpoint:    "user/lookup",
 		NeedSession: false,
 		Args:        ha,
@@ -119,9 +116,9 @@ func resolveUsername(au AssertionURL) (res ResolveResult) {
 	}
 
 	if l == 0 {
-		res.err = fmt.Errorf("No resolution found for %s", au)
+		res.err = ResolutionError{Input: input, Msg: "No resolution found"}
 	} else if l > 1 {
-		res.err = fmt.Errorf("Identity '%s' is ambiguous", au)
+		res.err = ResolutionError{Input: input, Msg: "Identify is ambiguous"}
 	} else {
 		res.body = them.AtIndex(0)
 		res.uid, res.err = GetUID(res.body.AtKey("id"))
@@ -130,31 +127,78 @@ func resolveUsername(au AssertionURL) (res ResolveResult) {
 	return
 }
 
-type ResolveCache struct {
-	results map[string]ResolveResult
-	sync.RWMutex
+type resolveCacheStats struct {
+	misses          int
+	timeouts        int
+	mutableTimeouts int
+	errorTimeouts   int
+	hits            int
 }
 
-func NewResolveCache() *ResolveCache {
-	return &ResolveCache{results: make(map[string]ResolveResult)}
+type Resolver struct {
+	Contextified
+	cache   *ramcache.Ramcache
+	stats   resolveCacheStats
+	nowFunc func() time.Time
 }
 
-// Get returns a ResolveResult, if present in the cache.
-func (c *ResolveCache) Get(key string) *ResolveResult {
-	c.RLock()
-	res, found := c.results[key]
-	c.RUnlock()
-	if found {
-		return &res
+func (s resolveCacheStats) eq(m, t, mt, et, h int) bool {
+	return (s.misses == m) && (s.timeouts == t) && (s.mutableTimeouts == mt) && (s.errorTimeouts == et) && (s.hits == h)
+}
+
+func NewResolver(g *GlobalContext) *Resolver {
+	return &Resolver{
+		Contextified: NewContextified(g),
+		cache:        nil,
+		nowFunc:      func() time.Time { return time.Now() },
 	}
-	return nil
+}
+
+func (r *Resolver) EnableCaching() {
+	cache := ramcache.New()
+	cache.MaxAge = resolveCacheMaxAge
+	cache.TTL = resolveCacheTTL
+	r.cache = cache
+}
+
+func (r *Resolver) getCache(key string) *ResolveResult {
+	if r.cache == nil {
+		return nil
+	}
+	res, _ := r.cache.Get(key)
+	if res == nil {
+		r.stats.misses++
+		return nil
+	}
+	rres, ok := res.(*ResolveResult)
+	if !ok {
+		r.stats.misses++
+		return nil
+	}
+	now := r.nowFunc()
+	if now.Sub(rres.cachedAt) > resolveCacheMaxAge {
+		r.stats.timeouts++
+		return nil
+	}
+	if rres.mutable && now.Sub(rres.cachedAt) > resolveCacheMaxAgeMutable {
+		r.stats.mutableTimeouts++
+		return nil
+	}
+	if rres.err != nil && now.Sub(rres.cachedAt) > resolveCacheMaxAgeErrored {
+		r.stats.errorTimeouts++
+		return nil
+	}
+	r.stats.hits++
+	return rres
 }
 
 // Put receives a copy of a ResolveResult, clears out the body
 // to avoid caching data that can go stale, and stores the result.
-func (c *ResolveCache) Put(key string, res ResolveResult) {
+func (r *Resolver) putCache(key string, res ResolveResult) {
+	if r.cache == nil {
+		return
+	}
 	res.body = nil
-	c.Lock()
-	c.results[key] = res
-	c.Unlock()
+	res.cachedAt = r.nowFunc()
+	r.cache.Set(key, &res)
 }

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -240,6 +240,12 @@ func ImportStatusAsError(s *keybase1.Status) error {
 		return SibkeyAlreadyExistsError{}
 	case SCNoUIDelegation:
 		return UIDelegationUnavailableError{}
+	case SCResolutionFailed:
+		var input string
+		if len(s.Fields) > 0 && s.Fields[0].Key == "input" {
+			input = s.Fields[0].Value
+		}
+		return ResolutionError{Msg: s.Desc, Input: input}
 	default:
 		ase := AppStatusError{
 			Code:   s.Code,
@@ -868,5 +874,16 @@ func (e UIDelegationUnavailableError) ToStatus() keybase1.Status {
 		Code: SCNoUIDelegation,
 		Name: "SC_UI_DELEGATION_UNAVAILABLE",
 		Desc: e.Error(),
+	}
+}
+
+func (e ResolutionError) ToStatus() keybase1.Status {
+	return keybase1.Status{
+		Code: SCResolutionFailed,
+		Name: "SC_RESOLUTION_FAILED",
+		Desc: e.Msg,
+		Fields: []keybase1.StringKVPair{
+			{"input", e.Input},
+		},
 	}
 }

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -50,6 +50,11 @@ func (h *IdentifyHandler) Identify2WithUID(_ context.Context, arg keybase1.Ident
 	return res, nil
 }
 
+func (h *IdentifyHandler) Resolve(_ context.Context, arg string) (keybase1.UID, error) {
+	rres := h.G().Resolver.ResolveFullExpression(arg)
+	return rres.GetUID(), rres.GetError()
+}
+
 func (h *IdentifyHandler) Identify(_ context.Context, arg keybase1.IdentifyArg) (keybase1.IdentifyRes, error) {
 	var do = func() (interface{}, error) {
 		if arg.Source == keybase1.IdentifySource_KBFS {

--- a/protocol/avdl/identify.avdl
+++ b/protocol/avdl/identify.avdl
@@ -10,6 +10,12 @@ protocol identify {
   }
 
   /**
+   * Resolve an assertion to a UID. On failure, resolves to an empty UID and returns
+   * an error.
+   */
+  UID Resolve(string assertion);
+
+  /**
     Identify a user from a username or assertion (e.g. kbuser, twuser@twitter).
     If trackStatement is true, we'll return a generated JSON tracking statement.
     If forceRemoteCheck is true, we force all remote proofs to be checked (otherwise a cache is used).

--- a/protocol/json/identify.json
+++ b/protocol/json/identify.json
@@ -379,6 +379,14 @@
     } ]
   } ],
   "messages" : {
+    "Resolve" : {
+      "doc" : "* Resolve an assertion to a UID. On failure, resolves to an empty UID and returns\n   * an error.",
+      "request" : [ {
+        "name" : "assertion",
+        "type" : "string"
+      } ],
+      "response" : "UID"
+    },
     "identify" : {
       "doc" : "Identify a user from a username or assertion (e.g. kbuser, twuser@twitter).\n    If trackStatement is true, we'll return a generated JSON tracking statement.\n    If forceRemoteCheck is true, we force all remote proofs to be checked (otherwise a cache is used).",
       "request" : [ {


### PR DESCRIPTION
- clean up the resolve cache machinery
      - enable failure caching for ~20 seconds
      - enable twitter/github caching for ~20 minutes
- make caching optional
- fully contextify the resolver
- stubs for the identify.Resolve RPC
- better error objects
- wire the RPC up to the service interface
- testing our resolve
- comments from review