### PR TITLE
command line verify was not working

### DIFF
--- a/go/client/cmd_pgp_verify.go
+++ b/go/client/cmd_pgp_verify.go
@@ -60,6 +60,7 @@ func (c *CmdPGPVerify) Run() error {
 		NewStreamUIProtocol(),
 		NewSecretUIProtocol(c.G()),
 		NewIdentifyTrackUIProtocol(c.G()),
+		NewPgpUIProtocol(c.G()),
 	}
 	if err := RegisterProtocols(protocols); err != nil {
 		return err

--- a/go/service/pgp.go
+++ b/go/service/pgp.go
@@ -121,6 +121,7 @@ func (h *PGPHandler) PGPVerify(_ context.Context, arg keybase1.PGPVerifyArg) (ke
 		SecretUI:   h.getSecretUI(arg.SessionID),
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
 		LogUI:      h.getLogUI(arg.SessionID),
+		PgpUI:      h.getPgpUI(arg.SessionID),
 	}
 	eng := engine.NewPGPVerify(earg, h.G())
 	err := engine.RunEngine(eng, ctx)


### PR DESCRIPTION
I am finally getting the hang of how the client works (I think - you guys tell me). Verify command wasn't working. 

It seems like the client requests the verify interface from the service, which in turn requires a remoted verifyUI interface to report the results?

@maxtaco @patrickxb 