### PR TITLE
Send one min RPC while tracker popups are open, and close tracker popups on userChanged notification

### DIFF
--- a/desktop/app/window.js
+++ b/desktop/app/window.js
@@ -27,6 +27,16 @@ export default class Window {
         event.sender.send('remoteWindowClosed', remoteWindowId)
       })
     })
+
+    ipcMain.on('registerRemoteUnmount', (remoteComponentLoaderEvent, remoteWindowId) => {
+      const relayRemoteUnmount = (e, otherRemoteWindowId) => {
+        if (remoteWindowId === otherRemoteWindowId) {
+          remoteComponentLoaderEvent.sender.send('remoteUnmount')
+          ipcMain.removeListener('remoteUnmount', relayRemoteUnmount)
+        }
+      }
+      ipcMain.on('remoteUnmount', relayRemoteUnmount)
+    })
   }
 
   bindWindowListeners () {

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -342,6 +342,8 @@ const UserSummaryLimit = 500 // max number of user summaries in one request
 
 const MinPassphraseLength = 12
 
+const TrackingRateLimitSeconds = 50
+
 type KexRole int
 
 const (

--- a/go/service/track.go
+++ b/go/service/track.go
@@ -69,8 +69,8 @@ func (h *TrackHandler) Untrack(_ context.Context, arg keybase1.UntrackArg) error
 }
 
 func (h *TrackHandler) CheckTracking(_ context.Context, sessionID int) error {
-	// Rate-limited to once every thirty seconds.
-	if !h.G().RateLimits.GetPermission(libkb.CheckTrackingRateLimit, 30*time.Second) {
+	// Rate-limited to once every fifty seconds.
+	if !h.G().RateLimits.GetPermission(libkb.CheckTrackingRateLimit, 50*time.Second) {
 		h.G().Log.Debug("Skipping CheckTracking due to rate limit.")
 		return nil
 	}

--- a/go/service/track.go
+++ b/go/service/track.go
@@ -70,7 +70,6 @@ func (h *TrackHandler) Untrack(_ context.Context, arg keybase1.UntrackArg) error
 }
 
 func (h *TrackHandler) CheckTracking(_ context.Context, sessionID int) error {
-	// Rate-limited to once every fifty seconds.
 	if !h.G().RateLimits.GetPermission(libkb.CheckTrackingRateLimit, libkb.TrackingRateLimitSeconds * time.Second) {
 		h.G().Log.Debug("Skipping CheckTracking due to rate limit.")
 		return nil

--- a/go/service/track.go
+++ b/go/service/track.go
@@ -71,7 +71,7 @@ func (h *TrackHandler) Untrack(_ context.Context, arg keybase1.UntrackArg) error
 func (h *TrackHandler) CheckTracking(_ context.Context, sessionID int) error {
 	// Rate-limited to once every thirty seconds.
 	if !h.G().RateLimits.GetPermission(libkb.CheckTrackingRateLimit, 30*time.Second) {
-		h.G().Log.Warning("Skipping CheckTracking due to rate limit.")
+		h.G().Log.Debug("Skipping CheckTracking due to rate limit.")
 		return nil
 	}
 	return libkb.CheckTracking(h.G())

--- a/go/service/track.go
+++ b/go/service/track.go
@@ -4,12 +4,13 @@
 package service
 
 import (
+	"time"
+
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
 	rpc "github.com/keybase/go-framed-msgpack-rpc"
 	"golang.org/x/net/context"
-	"time"
 )
 
 // TrackHandler is the RPC handler for the track interface.
@@ -70,7 +71,7 @@ func (h *TrackHandler) Untrack(_ context.Context, arg keybase1.UntrackArg) error
 
 func (h *TrackHandler) CheckTracking(_ context.Context, sessionID int) error {
 	// Rate-limited to once every fifty seconds.
-	if !h.G().RateLimits.GetPermission(libkb.CheckTrackingRateLimit, 50*time.Second) {
+	if !h.G().RateLimits.GetPermission(libkb.CheckTrackingRateLimit, libkb.TrackingRateLimitSeconds * time.Second) {
 		h.G().Log.Debug("Skipping CheckTracking due to rate limit.")
 		return nil
 	}

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -18,7 +18,7 @@ type TrackerActionCreator = (dispatch: Dispatch, getState: () => {tracker: RootT
 
 // TODO make actions for all the call back stuff.
 
-export function startTimer (): (dispatch: Dispatch, getState: any) => void {
+export function startTimer (): TrackerActionCreator {
   return (dispatch, getState) => {
     // Increments timerActive as a count of open tracker popups.
     dispatch({type: Constants.startTimer})
@@ -43,7 +43,7 @@ export function stopTimer (): Action {
   }
 }
 
-export function registerTrackerChangeListener (): (dispatch: Dispatch) => void {
+export function registerTrackerChangeListener (): TrackerActionCreator {
   return dispatch => {
     const param = {
       channels: {

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -18,6 +18,30 @@ type TrackerActionCreator = (dispatch: Dispatch, getState: () => {tracker: RootT
 
 // TODO make actions for all the call back stuff.
 
+export function registerTrackerChangeListener (): (dispatch: Dispatch) => void {
+  return dispatch => {
+    const param = {
+      channels: {
+        tracking: true
+      }
+    }
+    engine.listenOnConnect(() => {
+      engine.rpc('notifyCtl.setNotifications', param, {}, (error, response) => {
+        if (error != null) {
+          console.error('error in toggling notifications: ', error)
+        }
+      })
+    })
+
+    engine.listenGeneralIncomingRpc('keybase.1.NotifyTracking.trackingChanged', function (args) {
+      dispatch({
+        type: Constants.userUpdated,
+        payload: args
+      })
+    })
+  }
+}
+
 export function registerIdentifyUi (): TrackerActionCreator {
   return (dispatch, getState) => {
     engine.rpc('delegateUiCtl.registerIdentifyUI', {}, {}, (error, response) => {

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -20,12 +20,15 @@ type TrackerActionCreator = (dispatch: Dispatch, getState: () => {tracker: RootT
 
 export function startTimer (): (dispatch: Dispatch, getState: any) => void {
   return (dispatch, getState) => {
+    // Increments timerActive as a count of open tracker popups.
     dispatch({type: Constants.startTimer})
     const timerActive = getState().tracker.timerActive
     if (timerActive === 1) {
+      // We're transitioning from 0->1, no tracker popups to one, start timer.
       const intervalId = setInterval(() => {
         const timerActive = getState().tracker.timerActive
         if (timerActive <= 0) {
+          // All popups are closed now.
           clearInterval(intervalId)
         }
         engine.rpc('track.checkTracking')

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -18,6 +18,28 @@ type TrackerActionCreator = (dispatch: Dispatch, getState: () => {tracker: RootT
 
 // TODO make actions for all the call back stuff.
 
+export function startTimer (): (dispatch: Dispatch, getState: any) => void {
+  return (dispatch, getState) => {
+    dispatch({type: Constants.startTimer})
+    const timerActive = getState().tracker.timerActive
+    if (timerActive === 1) {
+      const intervalId = setInterval(() => {
+        const timerActive = getState().tracker.timerActive
+        if (timerActive <= 0) {
+          clearInterval(intervalId)
+        }
+        engine.rpc('track.checkTracking')
+      }, 60000)
+    }
+  }
+}
+
+export function stopTimer (): Action {
+  return {
+    type: Constants.stopTimer
+  }
+}
+
 export function registerTrackerChangeListener (): (dispatch: Dispatch) => void {
   return dispatch => {
     const param = {

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -50,18 +50,18 @@ export function registerTrackerChangeListener (): (dispatch: Dispatch) => void {
         tracking: true
       }
     }
+    engine.listenGeneralIncomingRpc('keybase.1.NotifyTracking.trackingChanged', function (args) {
+      dispatch({
+        type: Constants.userUpdated,
+        payload: args
+      })
+    })
+
     engine.listenOnConnect(() => {
       engine.rpc('notifyCtl.setNotifications', param, {}, (error, response) => {
         if (error != null) {
           console.error('error in toggling notifications: ', error)
         }
-      })
-    })
-
-    engine.listenGeneralIncomingRpc('keybase.1.NotifyTracking.trackingChanged', function (args) {
-      dispatch({
-        type: Constants.userUpdated,
-        payload: args
       })
     })
   }

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -29,7 +29,7 @@ export function startTimer (): (dispatch: Dispatch, getState: any) => void {
           clearInterval(intervalId)
         }
         engine.rpc('track.checkTracking')
-      }, 60000)
+      }, Constants.rpcUpdateTimerSeconds)
     }
   }
 }

--- a/react-native/react/constants/tracker.js
+++ b/react-native/react/constants/tracker.js
@@ -44,3 +44,5 @@ export const userUpdated = 'tracker:userUpdated'
 
 export const startTimer = 'tracker:startTimer'
 export const stopTimer = 'tracker:stopTimer'
+
+export const rpcUpdateTimerSeconds = 60 * 1000

--- a/react-native/react/constants/tracker.js
+++ b/react-native/react/constants/tracker.js
@@ -41,3 +41,6 @@ export const decideToShowTracker = 'tracker:decideToShowTracker'
 export const updateTrackToken = 'tracker:updateTrackToken'
 
 export const userUpdated = 'tracker:userUpdated'
+
+export const startTimer = 'tracker:startTimer'
+export const stopTimer = 'tracker:stopTimer'

--- a/react-native/react/constants/tracker.js
+++ b/react-native/react/constants/tracker.js
@@ -39,3 +39,5 @@ export const onFollowChecked = 'tracker:onFollowChecked'
 export const decideToShowTracker = 'tracker:decideToShowTracker'
 
 export const updateTrackToken = 'tracker:updateTrackToken'
+
+export const userUpdated = 'tracker:userUpdated'

--- a/react-native/react/native/notification-listeners.desktop.js
+++ b/react-native/react/native/notification-listeners.desktop.js
@@ -51,7 +51,7 @@ export default function (notify) {
       }
       const body = `Files in ${tlf} ${notification.status}`
 
-      function rateLimitAllowsNotify(action, state, tlf) {
+      function rateLimitAllowsNotify (action, state, tlf) {
         if (!(action in sentNotifications)) {
           sentNotifications[action] = {}
         }

--- a/react-native/react/native/remote-component-loader.js
+++ b/react-native/react/native/remote-component-loader.js
@@ -78,7 +78,7 @@ class RemoteComponentLoader extends Component {
       if (props.waitForState &&
           // Make sure we only do this if we haven't loaded the state yet
           !this.state.loaded &&
-          // Only do this if the store hasn't been filled yet.
+          // Only do this if the store hasn't been filled yet
           Object.keys(this.store.getState()).length === 0) {
         const unsub = this.store.subscribe(() => {
           currentWindow.show()
@@ -86,8 +86,8 @@ class RemoteComponentLoader extends Component {
           unsub()
         })
       } else {
-        // If we've received props, and the loaded state was false
-        // That means we should show the window
+        // If we've received props, and the loaded state was false, that
+        // means we should show the window
         if (this.state.loaded === false) {
           currentWindow.show()
         }
@@ -97,7 +97,7 @@ class RemoteComponentLoader extends Component {
 
     ipcRenderer.on('remoteUnmount', () => {
       setImmediate(() => this.setState({unmounted: true}))
-      // Hide the window since we've effective told it to close
+      // Hide the window since we've effectively told it to close
       currentWindow.hide()
     })
     ipcRenderer.send('registerRemoteUnmount', currentWindow.id)
@@ -107,7 +107,8 @@ class RemoteComponentLoader extends Component {
 
   componentDidUpdate (prevProps, prevState) {
     if (!prevState.unmounted && this.state.unmounted) {
-      // Close the window now that the remote-components unmount lifecycle method has finished
+      // Close the window now that the remote-component's unmount
+      // lifecycle method has finished
       currentWindow.close()
     }
   }

--- a/react-native/react/native/remote-component.desktop.js
+++ b/react-native/react/native/remote-component.desktop.js
@@ -41,7 +41,7 @@ export default class RemoteComponent extends Component {
   componentWillUnmount () {
     if (!this.closed) {
       this.closed = true
-      this.remoteWindow.close()
+      ipcRenderer.send('remoteUnmount', this.remoteWindow.id)
     }
   }
 

--- a/react-native/react/native/remote-manager.desktop.js
+++ b/react-native/react/native/remote-manager.desktop.js
@@ -4,7 +4,7 @@ import React, {Component} from '../base-react'
 import {connect} from '../base-redux'
 
 import {bindActionCreators} from 'redux'
-import {registerIdentifyUi, onCloseFromHeader} from '../actions/tracker'
+import {registerIdentifyUi, onCloseFromHeader, startTimer, stopTimer} from '../actions/tracker'
 import {registerPinentryListener, onCancel as pinentryOnCancel, onSubmit as pinentryOnSubmit} from '../actions/pinentry'
 import {registerTrackerChangeListener} from '../actions/tracker'
 // $FlowIssue platform files
@@ -21,6 +21,8 @@ export type RemoteManagerProps = {
   registerIdentifyUi: () => void,
   onCloseFromHeader: () => void,
   trackerServerStarted: boolean,
+  startTimer: (dispatch: Dispatch, getState: any) => void,
+  stopTimer: () => Action,
   trackers: {[key: string]: TrackerState},
   pinentryStates: {[key: string]: PinentryState}
 }
@@ -81,6 +83,8 @@ class RemoteManager extends Component {
             component='tracker'
             username={username}
             substore='tracker'
+            startTimer={this.props.startTimer}
+            stopTimer={this.props.stopTimer}
             key={username}
             />
         )
@@ -139,6 +143,8 @@ RemoteManager.propTypes = {
   registerIdentifyUi: React.PropTypes.any,
   onCloseFromHeader: React.PropTypes.any,
   trackerServerStarted: React.PropTypes.bool,
+  startTimer: React.PropTypes.any,
+  stopTimer: React.PropTypes.any,
   trackers: React.PropTypes.any,
   pinentryStates: React.PropTypes.any
 }
@@ -151,5 +157,5 @@ export default connect(
       pinentryStates: state.pinentry.pinentryStates || {}
     }
   },
-  dispatch => bindActionCreators({registerIdentifyUi, onCloseFromHeader, registerPinentryListener, registerTrackerChangeListener, pinentryOnCancel, pinentryOnSubmit}, dispatch)
+  dispatch => bindActionCreators({registerIdentifyUi, startTimer, stopTimer, onCloseFromHeader, registerPinentryListener, registerTrackerChangeListener, pinentryOnCancel, pinentryOnSubmit}, dispatch)
 )(RemoteManager)

--- a/react-native/react/native/remote-manager.desktop.js
+++ b/react-native/react/native/remote-manager.desktop.js
@@ -6,6 +6,7 @@ import {connect} from '../base-redux'
 import {bindActionCreators} from 'redux'
 import {registerIdentifyUi, onCloseFromHeader} from '../actions/tracker'
 import {registerPinentryListener, onCancel as pinentryOnCancel, onSubmit as pinentryOnSubmit} from '../actions/pinentry'
+import {registerTrackerChangeListener} from '../actions/tracker'
 // $FlowIssue platform files
 import RemoteComponent from './remote-component'
 
@@ -39,6 +40,7 @@ class RemoteManager extends Component {
       console.log('starting identify ui server')
       this.props.registerIdentifyUi()
       this.props.registerPinentryListener()
+      this.props.registerTrackerChangeListener()
     }
   }
 
@@ -149,6 +151,5 @@ export default connect(
       pinentryStates: state.pinentry.pinentryStates || {}
     }
   },
-  dispatch => bindActionCreators({registerIdentifyUi, onCloseFromHeader, registerPinentryListener, pinentryOnCancel, pinentryOnSubmit}, dispatch)
+  dispatch => bindActionCreators({registerIdentifyUi, onCloseFromHeader, registerPinentryListener, registerTrackerChangeListener, pinentryOnCancel, pinentryOnSubmit}, dispatch)
 )(RemoteManager)
-

--- a/react-native/react/native/remote-manager.desktop.js
+++ b/react-native/react/native/remote-manager.desktop.js
@@ -10,7 +10,7 @@ import {registerTrackerChangeListener} from '../actions/tracker'
 // $FlowIssue platform files
 import RemoteComponent from './remote-component'
 
-import type {GUIEntryFeatures} from '../constants/types/flow-types'
+import type {GUIEntryFeatures, Action, Dispatch} from '../constants/types/flow-types'
 import type {TrackerState} from '../reducers/tracker'
 import type {PinentryState} from '../reducers/pinentry'
 
@@ -141,6 +141,7 @@ RemoteManager.propTypes = {
   pinentryOnSubmit: React.PropTypes.any,
   registerPinentryListener: React.PropTypes.any,
   registerIdentifyUi: React.PropTypes.any,
+  registerTrackerChangeListener: React.PropTypes.any,
   onCloseFromHeader: React.PropTypes.any,
   trackerServerStarted: React.PropTypes.bool,
   startTimer: React.PropTypes.any,

--- a/react-native/react/native/remote-manager.desktop.js
+++ b/react-native/react/native/remote-manager.desktop.js
@@ -10,7 +10,9 @@ import {registerTrackerChangeListener} from '../actions/tracker'
 // $FlowIssue platform files
 import RemoteComponent from './remote-component'
 
-import type {GUIEntryFeatures, Action, Dispatch} from '../constants/types/flow-types'
+import type {GUIEntryFeatures} from '../constants/types/flow-types'
+import type {Action, Dispatch} from '../constants/types/flux'
+
 import type {TrackerState} from '../reducers/tracker'
 import type {PinentryState} from '../reducers/pinentry'
 
@@ -19,6 +21,7 @@ export type RemoteManagerProps = {
   pinentryOnCancel: (sessionID: number) => void,
   pinentryOnSubmit: (sessionID: number, passphrase: string, features: GUIEntryFeatures) => void,
   registerIdentifyUi: () => void,
+  registerTrackerChangeListener: () => void,
   onCloseFromHeader: () => void,
   trackerServerStarted: boolean,
   startTimer: (dispatch: Dispatch, getState: any) => void,

--- a/react-native/react/reducers/pinentry.js
+++ b/react-native/react/reducers/pinentry.js
@@ -2,8 +2,8 @@
 
 import * as Constants from '../constants/pinentry'
 
-import type {Feature, GUIEntryFeatures, GUIEntryArg} from '../constants/types/flow-types'
-import type {PinentryActions, NewPinentryAction, RegisterPinentryListenerAction} from  '../constants/pinentry'
+import type {Feature, GUIEntryFeatures} from '../constants/types/flow-types'
+import type {PinentryActions} from '../constants/pinentry'
 
 // TODO: have a root state that maps session id to pinentry popup
 

--- a/react-native/react/reducers/tracker.js
+++ b/react-native/react/reducers/tracker.js
@@ -31,7 +31,8 @@ export type TrackerState = {
 
 export type State = {
   serverStarted: boolean,
-  trackers: {[key: string]: TrackerState}
+  trackers: {[key: string]: TrackerState},
+  timerActive: number
 }
 
 const initialProofState = checking

--- a/react-native/react/reducers/tracker.js
+++ b/react-native/react/reducers/tracker.js
@@ -80,6 +80,11 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
         ...state,
         trackToken: action.payload && action.payload.trackToken
       }
+    case Constants.userUpdated:
+      return {
+        ...state,
+        closed: true
+      }
     case Constants.onCloseFromActionBar:
       return {
         ...state,

--- a/react-native/react/reducers/tracker.js
+++ b/react-native/react/reducers/tracker.js
@@ -38,6 +38,7 @@ const initialProofState = checking
 
 const initialState: State = {
   serverStarted: false,
+  timerActive: 0,
   trackers: {}
 }
 
@@ -199,6 +200,18 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
 export default function (state: State = initialState, action: Action): State {
   const username: string = (action.payload && action.payload.username) ? action.payload.username : ''
   const trackerState = username ? state.trackers[username] : null
+  switch (action.type) {
+    case Constants.startTimer:
+      return {
+        ...state,
+        timerActive: state.timerActive + 1
+      }
+    case Constants.stopTimer:
+      return {
+        ...state,
+        timerActive: state.timerActive - 1
+      }
+  }
 
   if (trackerState) {
     const newTrackerState = updateUserState(trackerState, action)

--- a/react-native/react/tracker/action.render.desktop.js
+++ b/react-native/react/tracker/action.render.desktop.js
@@ -7,7 +7,6 @@ import commonStyles from '../styles/common'
 import type {Styled} from '../styles/common'
 
 import {normal, checking, warning} from '../constants/tracker'
-import type {SimpleProofState} from '../constants/tracker'
 
 import type {ActionProps} from './action.render.types'
 

--- a/react-native/react/tracker/index.js
+++ b/react-native/react/tracker/index.js
@@ -42,7 +42,6 @@ class Tracker extends Component {
   }
 
   componentWillUnmount () {
-    console.log('in ComponentWillUnmount')
     this.props.stopTimer()
   }
 

--- a/react-native/react/tracker/index.js
+++ b/react-native/react/tracker/index.js
@@ -4,7 +4,6 @@ import React, {Component} from '../base-react'
 import {connect} from '../base-redux'
 // $FlowIssue .desktop issue
 import Render from './render'
-import engine from '../engine'
 
 import * as trackerActions from '../actions/tracker'
 import {bindActionCreators} from 'redux'

--- a/react-native/react/tracker/index.js
+++ b/react-native/react/tracker/index.js
@@ -30,7 +30,10 @@ type TrackerProps = {
   onFollowHelp: () => void,
   onFollowChecked: () => void,
   registerIdentifyUi: () => void,
-  closed: boolean
+  registerTrackerChangeListener: () => void,
+  closed: boolean,
+  startTimer: () => void,
+  stopTimer: () => void
 }
 
 class Tracker extends Component {
@@ -139,6 +142,7 @@ Tracker.propTypes = {
   onFollowHelp: React.PropTypes.any,
   onFollowChecked: React.PropTypes.any,
   registerIdentifyUi: React.PropTypes.any,
+  registerTrackerChangeListener: React.PropTypes.any,
   closed: React.PropTypes.bool.isRequired,
   startTimer: React.PropTypes.any,
   stopTimer: React.PropTypes.any

--- a/react-native/react/tracker/index.js
+++ b/react-native/react/tracker/index.js
@@ -4,6 +4,7 @@ import React, {Component} from '../base-react'
 import {connect} from '../base-redux'
 // $FlowIssue .desktop issue
 import Render from './render'
+import engine from '../engine'
 
 import * as trackerActions from '../actions/tracker'
 import {bindActionCreators} from 'redux'
@@ -35,6 +36,18 @@ type TrackerProps = {
 
 class Tracker extends Component {
   props: TrackerProps;
+
+  componentWillMount () {
+    this.onemin = setInterval(function () {
+      engine.rpc('track.checkTracking')
+    }, 60000)
+  }
+
+  componentWillUnmount () {
+    if (this.onemin) {
+      clearInterval(this.onemin)
+    }
+  }
 
   render () {
     if (this.props.closed) {

--- a/react-native/react/tracker/index.js
+++ b/react-native/react/tracker/index.js
@@ -38,15 +38,12 @@ class Tracker extends Component {
   props: TrackerProps;
 
   componentWillMount () {
-    this.onemin = setInterval(function () {
-      engine.rpc('track.checkTracking')
-    }, 60000)
+    this.props.startTimer()
   }
 
   componentWillUnmount () {
-    if (this.onemin) {
-      clearInterval(this.onemin)
-    }
+    console.log('in ComponentWillUnmount')
+    this.props.stopTimer()
   }
 
   render () {

--- a/react-native/react/tracker/index.js
+++ b/react-native/react/tracker/index.js
@@ -139,7 +139,9 @@ Tracker.propTypes = {
   onFollowHelp: React.PropTypes.any,
   onFollowChecked: React.PropTypes.any,
   registerIdentifyUi: React.PropTypes.any,
-  closed: React.PropTypes.bool.isRequired
+  closed: React.PropTypes.bool.isRequired,
+  startTimer: React.PropTypes.any,
+  stopTimer: React.PropTypes.any
 }
 
 export default connect(


### PR DESCRIPTION
@keybase/react-hackers 

Two changes here:
* Whenever a tracker window's open, it sends the new `track.checkTracking` RPC to the service once every minute.  The service rate limits the RPCs itself (one check per 50 seconds).
* Listen to the new `tracking` notifications channel for a `NotifyTracking.trackingChanged` RPC that comes with a username/uid. When we get it, fire a `tracker:userUpdated` action on that user. In the reducer, set `closed` to true, which makes the tracker popup for that user go away.

I would have liked to use Redux to centralize the RPC sending and timers to one place, but actions aren't supposed to have side-effects (like firing RPCs) and reducers can't create actions, so I think Redux is incompatible with this particular flow.  Happy to hack together on it with someone if they can see a good way to do it, though!

CC @oconnor663 