### PR TITLE
update: new UI with routing and some basics RPCS

### DIFF
--- a/go/client/commands_common.go
+++ b/go/client/commands_common.go
@@ -42,6 +42,7 @@ func GetCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Comma
 		NewCmdTrack(cl, g),
 		NewCmdUnlock(cl),
 		NewCmdUntrack(cl, g),
+		NewCmdUpdate(cl, g),
 		NewCmdVersion(cl, g),
 	}
 	ret = append(ret, getBuildSpecificCommands(cl, g)...)

--- a/go/client/commands_osx.go
+++ b/go/client/commands_osx.go
@@ -17,6 +17,5 @@ func getPlatformSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalCont
 		NewCmdInstall(cl, g),
 		NewCmdLaunchd(cl, g),
 		NewCmdUninstall(cl, g),
-		NewCmdUpdate(cl, g),
 	}
 }

--- a/go/client/prompts.go
+++ b/go/client/prompts.go
@@ -42,4 +42,7 @@ const (
 	PromptDescriptorProvisionDeviceName
 	PromptDescriptorExportSecretKeyFromGPG
 	PromptDescriptorDeprovisionWhichUser
+	PromptDescriptorUpdateDo
+	PromptDescriptorUpdateAuto
+	PromptDescriptorUpdateSkipVersion
 )

--- a/go/client/prompts.go
+++ b/go/client/prompts.go
@@ -44,5 +44,5 @@ const (
 	PromptDescriptorDeprovisionWhichUser
 	PromptDescriptorUpdateDo
 	PromptDescriptorUpdateAuto
-	PromptDescriptorUpdateSkipVersion
+	PromptDescriptorUpdateSnooze
 )

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -528,24 +529,33 @@ type UpdateUI struct {
 
 func (u UpdateUI) UpdatePrompt(_ context.Context, arg keybase1.UpdatePromptArg) (res keybase1.UpdatePromptRes, err error) {
 	if u.noPrompt {
-		res.DoInstall = true
+		res.Action = keybase1.UpdateAction_UPDATE
 		return res, err
 	}
-	u.terminal.Printf("There is a new update available (version %s)\n", arg.Version)
-	if len(arg.Desc) != 0 {
-		u.terminal.Printf("  %s\n", arg.Desc)
+	u.terminal.Printf("There is a new update available (version %s)\n", arg.Update.Version)
+	if len(arg.Update.Description) != 0 {
+		u.terminal.Printf("  %s\n", arg.Update.Description)
 	}
 	prompt := "Install update?"
-	res.DoInstall, err = u.terminal.PromptYesNo(PromptDescriptorUpdateDo, prompt, libkb.PromptDefaultYes)
+	var doUpdate bool
+	doUpdate, err = u.terminal.PromptYesNo(PromptDescriptorUpdateDo, prompt, libkb.PromptDefaultYes)
 	if err != nil {
 		return res, err
 	}
-	if res.DoInstall {
+	if doUpdate {
+		res.Action = keybase1.UpdateAction_UPDATE
 		prompt = "Auto-update in the future?"
 		res.AlwaysAutoInstall, err = u.terminal.PromptYesNo(PromptDescriptorUpdateAuto, prompt, libkb.PromptDefaultYes)
 	} else {
-		prompt = "Skip this version entirely?"
-		res.SkipVersion, err = u.terminal.PromptYesNo(PromptDescriptorUpdateSkipVersion, prompt, libkb.PromptDefaultYes)
+		prompt = "Snooze for one day?"
+		var snooze bool
+		snooze, err = u.terminal.PromptYesNo(PromptDescriptorUpdateSnooze, prompt, libkb.PromptDefaultYes)
+		if snooze {
+			res.Action = keybase1.UpdateAction_SNOOZE
+			res.SnoozeUntil = keybase1.ToTime(time.Now().Add(time.Hour * 24))
+		} else {
+			res.Action = keybase1.UpdateAction_CANCEL
+		}
 	}
 	return res, err
 }

--- a/go/engine/context.go
+++ b/go/engine/context.go
@@ -18,6 +18,7 @@ type Context struct {
 	PgpUI       libkb.PgpUI
 	ProveUI     libkb.ProveUI
 	ProvisionUI libkb.ProvisionUI
+	UpdateUI    libkb.UpdateUI
 
 	LoginContext libkb.LoginContext
 }
@@ -40,6 +41,8 @@ func (c *Context) HasUI(kind libkb.UIKind) bool {
 		return c.ProveUI != nil
 	case libkb.ProvisionUIKind:
 		return c.ProvisionUI != nil
+	case libkb.UpdateUIKind:
+		return c.UpdateUI != nil
 	}
 	panic(fmt.Sprintf("unhandled kind:  %d", kind))
 }

--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -83,18 +83,22 @@ func delegateUIs(e Engine, ctx *Context) error {
 	// currently, only doing this for SecretUI, but in future,
 	// perhaps should iterate over all registered UIs in UIRouter.
 
-	if !requiresUI(e, ctx, libkb.SecretUIKind) {
-		return nil
+	if requiresUI(e, ctx, libkb.SecretUIKind) {
+		if ui, err := e.G().UIRouter.GetSecretUI(); err != nil {
+			return err
+		} else if ui != nil {
+			e.G().Log.Debug("using delegated secret UI for engine %q", e.Name())
+			ctx.SecretUI = ui
+		}
 	}
 
-	ui, err := e.G().UIRouter.GetSecretUI()
-	if err != nil {
-		return err
-	}
-
-	if ui != nil {
-		e.G().Log.Debug("using delegated secret UI for engine %q", e.Name())
-		ctx.SecretUI = ui
+	if requiresUI(e, ctx, libkb.UpdateUIKind) {
+		if ui, err := e.G().UIRouter.GetUpdateUI(); err != nil {
+			return err
+		} else if ui != nil {
+			e.G().Log.Debug("using delegated update UI for engine %q", e.Name())
+			ctx.UpdateUI = ui
+		}
 	}
 
 	return nil

--- a/go/engine/update.go
+++ b/go/engine/update.go
@@ -34,7 +34,9 @@ func (u *UpdateEngine) Prereqs() Prereqs {
 }
 
 func (u *UpdateEngine) RequiredUIs() []libkb.UIKind {
-	return []libkb.UIKind{}
+	return []libkb.UIKind{
+		libkb.UpdateUIKind,
+	}
 }
 
 func (u *UpdateEngine) SubConsumers() []libkb.UIConsumer {
@@ -57,7 +59,7 @@ func (u *UpdateEngine) Run(ctx *Context) (err error) {
 	if u.checkOnly {
 		update, err = updater.CheckForUpdate()
 	} else {
-		update, err = updater.Update()
+		update, err = updater.Update(ctx.UpdateUI)
 	}
 	if err != nil {
 		return

--- a/go/install/sources/keybase.go
+++ b/go/install/sources/keybase.go
@@ -27,16 +27,16 @@ func NewKeybaseUpdateSource(g *libkb.GlobalContext) KeybaseUpdateSource {
 func (k KeybaseUpdateSource) FindUpdate(config keybase1.UpdateConfig) (update *keybase1.Update, err error) {
 	APIArgs := libkb.HTTPArgs{
 		"version":  libkb.S{Val: config.Version},
-		"os_name":  libkb.S{Val: config.OsName},
+		"platform": libkb.S{Val: config.OsName},
 		"run_mode": libkb.S{Val: string(k.G().Env.GetRunMode())},
 		"channel":  libkb.S{Val: config.Channel},
 	}
 
 	var res updateResponse
 	err = k.G().API.GetDecode(libkb.APIArg{
-		Endpoint: "update.json",
+		Endpoint: "pkg/update",
 		Args:     APIArgs,
-	}, res)
+	}, &res)
 	if err != nil {
 		return
 	}

--- a/go/install/update_test.go
+++ b/go/install/update_test.go
@@ -12,15 +12,23 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol"
+	"golang.org/x/net/context"
 )
 
 func NewTestUpdater(t *testing.T, config keybase1.UpdateConfig) Updater {
 	context := libkb.NewGlobalContext()
+	context.Init()
 	context.Log = logger.NewTestLogger(t)
 	return NewUpdater(context, config, testUpdateSource{})
 }
 
 type testUpdateSource struct{}
+
+type nullUpdateUI struct{}
+
+func (u nullUpdateUI) UpdatePrompt(_ context.Context, _ keybase1.UpdatePromptArg) (keybase1.UpdatePromptRes, error) {
+	return keybase1.UpdatePromptRes{DoInstall: true}, nil
+}
 
 func (u testUpdateSource) FindUpdate(config keybase1.UpdateConfig) (release *keybase1.Update, err error) {
 	return &keybase1.Update{
@@ -44,7 +52,7 @@ func NewDefaultTestUpdateConfig() keybase1.UpdateConfig {
 
 func TestUpdater(t *testing.T) {
 	u := NewTestUpdater(t, NewDefaultTestUpdateConfig())
-	update, err := u.Update()
+	update, err := u.Update(nullUpdateUI{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -567,3 +567,24 @@ func (f JSONConfigFile) GetSplitLogOutput() (bool, bool) {
 func (f JSONConfigFile) GetSecurityAccessGroupOverride() (bool, bool) {
 	return false, false
 }
+
+func (f JSONConfigFile) GetUpdatePreferences() *keybase1.UpdatePreferences {
+	jw := f.jw.AtKey("updates")
+	if jw.IsNil() {
+		return nil
+	}
+	var ret keybase1.UpdatePreferences
+	if err := jw.UnmarshalAgain(&ret); err != nil {
+		f.G().Log.Warning("Bad config value for 'updates': %s", jw.MarshalToDebug())
+		return nil
+	}
+	return &ret
+}
+
+func (f *JSONConfigFile) SetUpdatePreferenceAuto(b bool) error {
+	return f.SetBoolAtPath("updates.auto", b)
+}
+
+func (f *JSONConfigFile) SetUpdatePreferenceSkip(v string) error {
+	return f.SetStringAtPath("updates.skip", v)
+}

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -58,9 +58,9 @@ func (n NullConfiguration) GetAPITimeout() (time.Duration, bool)          { retu
 func (n NullConfiguration) GetTorMode() (TorMode, error)                  { return TorNone, nil }
 func (n NullConfiguration) GetTorHiddenAddress() string                   { return "" }
 func (n NullConfiguration) GetTorProxy() string                           { return "" }
-func (n NullConfiguration) GetUpdatePreferences() *keybase1.UpdatePreferences {
-	return nil
-}
+func (n NullConfiguration) GetUpdatePreferenceAuto() (bool, bool)         { return false, false }
+func (n NullConfiguration) GetUpdatePreferenceSnoozeUntil() keybase1.Time { return keybase1.Time(0) }
+func (n NullConfiguration) GetUpdatePreferenceSkip() string               { return "" }
 
 func (n NullConfiguration) GetUserConfig() (*UserConfig, error) { return nil, nil }
 func (n NullConfiguration) GetUserConfigForUsername(s NormalizedUsername) (*UserConfig, error) {
@@ -808,6 +808,15 @@ func (c AppConfig) GetSecurityAccessGroupOverride() (bool, bool) {
 	return c.SecurityAccessGroupOverride, c.SecurityAccessGroupOverride
 }
 
-func (e *Env) GetUpdatePreferences() *keybase1.UpdatePreferences {
-	return e.config.GetUpdatePreferences()
+func (e *Env) GetUpdatePreferenceAuto() bool {
+	a, _ := e.config.GetUpdatePreferenceAuto()
+	return a
+}
+
+func (e *Env) GetUpdatePreferenceSkip() string {
+	return e.config.GetUpdatePreferenceSkip()
+}
+
+func (e *Env) GetUpdatePreferenceSnoozeUntil() keybase1.Time {
+	return e.config.GetUpdatePreferenceSnoozeUntil()
 }

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -58,6 +58,9 @@ func (n NullConfiguration) GetAPITimeout() (time.Duration, bool)          { retu
 func (n NullConfiguration) GetTorMode() (TorMode, error)                  { return TorNone, nil }
 func (n NullConfiguration) GetTorHiddenAddress() string                   { return "" }
 func (n NullConfiguration) GetTorProxy() string                           { return "" }
+func (n NullConfiguration) GetUpdatePreferences() *keybase1.UpdatePreferences {
+	return nil
+}
 
 func (n NullConfiguration) GetUserConfig() (*UserConfig, error) { return nil, nil }
 func (n NullConfiguration) GetUserConfigForUsername(s NormalizedUsername) (*UserConfig, error) {
@@ -803,4 +806,8 @@ func (c AppConfig) GetServerURI() string {
 
 func (c AppConfig) GetSecurityAccessGroupOverride() (bool, bool) {
 	return c.SecurityAccessGroupOverride, c.SecurityAccessGroupOverride
+}
+
+func (e *Env) GetUpdatePreferences() *keybase1.UpdatePreferences {
+	return e.config.GetUpdatePreferences()
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -135,7 +135,10 @@ type ConfigReader interface {
 	GetScraperTimeout() (time.Duration, bool)
 	GetAPITimeout() (time.Duration, bool)
 	GetSecurityAccessGroupOverride() (bool, bool)
-	GetUpdatePreferences() *keybase1.UpdatePreferences
+
+	GetUpdatePreferenceAuto() (bool, bool)
+	GetUpdatePreferenceSkip() string
+	GetUpdatePreferenceSnoozeUntil() keybase1.Time
 
 	GetTorMode() (TorMode, error)
 	GetTorHiddenAddress() string
@@ -159,6 +162,7 @@ type ConfigWriter interface {
 	DeleteAtPath(string)
 	SetUpdatePreferenceAuto(bool) error
 	SetUpdatePreferenceSkip(string) error
+	SetUpdatePreferenceSnoozeUntil(keybase1.Time) error
 	Reset()
 	Save() error
 	BeginTransaction() (ConfigWriterTransacter, error)

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -135,6 +135,7 @@ type ConfigReader interface {
 	GetScraperTimeout() (time.Duration, bool)
 	GetAPITimeout() (time.Duration, bool)
 	GetSecurityAccessGroupOverride() (bool, bool)
+	GetUpdatePreferences() *keybase1.UpdatePreferences
 
 	GetTorMode() (TorMode, error)
 	GetTorHiddenAddress() string
@@ -156,6 +157,8 @@ type ConfigWriter interface {
 	SetIntAtPath(string, int) error
 	SetNullAtPath(string) error
 	DeleteAtPath(string)
+	SetUpdatePreferenceAuto(bool) error
+	SetUpdatePreferenceSkip(string) error
 	Reset()
 	Save() error
 	BeginTransaction() (ConfigWriterTransacter, error)
@@ -306,6 +309,10 @@ type ProvisionUI interface {
 	keybase1.ProvisionUiInterface
 }
 
+type UpdateUI interface {
+	keybase1.UpdateUiInterface
+}
+
 type PromptDefault int
 
 const (
@@ -344,6 +351,7 @@ type UI interface {
 	GetGPGUI() GPGUI
 	GetProvisionUI(role KexRole) ProvisionUI
 	GetPgpUI() PgpUI
+	GetUpdateUI() UpdateUI
 	Configure() error
 	Shutdown() error
 }
@@ -355,6 +363,7 @@ type UIRouter interface {
 	// error is nil.
 	GetIdentifyUI() (IdentifyUI, error)
 	GetSecretUI() (SecretUI, error)
+	GetUpdateUI() (UpdateUI, error)
 
 	Shutdown()
 }

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -326,6 +326,9 @@ func (n *nullui) GetLogUI() LogUI {
 func (n *nullui) GetPgpUI() PgpUI {
 	return nil
 }
+func (n *nullui) GetUpdateUI() UpdateUI {
+	return nil
+}
 func (n *nullui) GetProvisionUI(KexRole) ProvisionUI {
 	return nil
 }

--- a/go/libkb/uigroup.go
+++ b/go/libkb/uigroup.go
@@ -16,6 +16,7 @@ const (
 	SecretUIKind
 	ProvisionUIKind
 	PgpUIKind
+	UpdateUIKind
 )
 
 func (u UIKind) String() string {
@@ -36,6 +37,8 @@ func (u UIKind) String() string {
 		return "ProvisionUI"
 	case PgpUIKind:
 		return "PgpUI"
+	case UpdateUIKind:
+		return "UpdateUI"
 	}
 	panic(fmt.Sprintf("unhandled uikind: %d", u))
 }

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -5422,11 +5422,20 @@ type Asset struct {
 	Url  string `codec:"url" json:"url"`
 }
 
+type UpdateType int
+
+const (
+	UpdateType_NORMAL   UpdateType = 0
+	UpdateType_BUGFIX   UpdateType = 1
+	UpdateType_CRITICAL UpdateType = 2
+)
+
 type Update struct {
-	Version     string `codec:"version" json:"version"`
-	Name        string `codec:"name" json:"name"`
-	Description string `codec:"description" json:"description"`
-	Asset       Asset  `codec:"asset" json:"asset"`
+	Version     string     `codec:"version" json:"version"`
+	Name        string     `codec:"name" json:"name"`
+	Description string     `codec:"description" json:"description"`
+	Type        UpdateType `codec:"type" json:"type"`
+	Asset       Asset      `codec:"asset" json:"asset"`
 }
 
 type UpdateConfig struct {
@@ -5436,11 +5445,6 @@ type UpdateConfig struct {
 	Source          string `codec:"source" json:"source"`
 	URL             string `codec:"URL" json:"URL"`
 	Channel         string `codec:"channel" json:"channel"`
-}
-
-type UpdatePreferences struct {
-	Auto bool   `codec:"auto" json:"auto"`
-	Skip string `codec:"skip" json:"skip"`
 }
 
 type UpdateResult struct {
@@ -5516,17 +5520,24 @@ func (c UpdateClient) UpdateNotification(ctx context.Context, update Update) (er
 	return
 }
 
+type UpdateAction int
+
+const (
+	UpdateAction_UPDATE UpdateAction = 0
+	UpdateAction_SKIP   UpdateAction = 1
+	UpdateAction_SNOOZE UpdateAction = 2
+	UpdateAction_CANCEL UpdateAction = 3
+)
+
 type UpdatePromptRes struct {
-	DoInstall         bool `codec:"doInstall" json:"doInstall"`
-	AlwaysAutoInstall bool `codec:"alwaysAutoInstall" json:"alwaysAutoInstall"`
-	SkipVersion       bool `codec:"skipVersion" json:"skipVersion"`
-	RepromptInSeconds int  `codec:"repromptInSeconds" json:"repromptInSeconds"`
+	Action            UpdateAction `codec:"action" json:"action"`
+	AlwaysAutoInstall bool         `codec:"alwaysAutoInstall" json:"alwaysAutoInstall"`
+	SnoozeUntil       Time         `codec:"snoozeUntil" json:"snoozeUntil"`
 }
 
 type UpdatePromptArg struct {
 	SessionID int    `codec:"sessionID" json:"sessionID"`
-	Desc      string `codec:"desc" json:"desc"`
-	Version   string `codec:"version" json:"version"`
+	Update    Update `codec:"update" json:"update"`
 }
 
 type UpdateUiInterface interface {

--- a/go/service/crypto_test.go
+++ b/go/service/crypto_test.go
@@ -25,6 +25,10 @@ func (f fakeUIRouter) GetSecretUI() (libkb.SecretUI, error) {
 	return f.secretUI, f.secretUIErr
 }
 
+func (f fakeUIRouter) GetUpdateUI() (libkb.UpdateUI, error) {
+	return nil, errors.New("Unexpected GetUpdateUI call")
+}
+
 func (f fakeUIRouter) Shutdown() {}
 
 type nullSecretUI struct{}

--- a/go/service/delegate_ui.go
+++ b/go/service/delegate_ui.go
@@ -35,3 +35,8 @@ func (d *DelegateUICtlHandler) RegisterSecretUI(_ context.Context) error {
 	d.G().UIRouter.SetUI(d.id, libkb.SecretUIKind)
 	return nil
 }
+
+func (d *DelegateUICtlHandler) RegisterUpdateUI(_ context.Context) error {
+	d.G().UIRouter.SetUI(d.id, libkb.UpdateUIKind)
+	return nil
+}

--- a/go/service/handler.go
+++ b/go/service/handler.go
@@ -103,6 +103,10 @@ func (h *BaseHandler) getGPGUI(sessionID int) libkb.GPGUI {
 	return NewRemoteGPGUI(sessionID, h.rpcClient())
 }
 
+func (h *BaseHandler) getUpdateUI() libkb.UpdateUI {
+	return keybase1.UpdateUiClient{Cli: h.rpcClient()}
+}
+
 func (h *BaseHandler) getSecretUICli() *keybase1.SecretUiClient {
 	return h.secretCli
 }
@@ -145,4 +149,13 @@ func (h *BaseHandler) NewRemoteSkipPromptIdentifyUI(sessionID int, g *libkb.Glob
 	c := h.NewRemoteIdentifyUI(sessionID, g)
 	c.skipPrompt = true
 	return c
+}
+
+type UpdateUI struct {
+	sessionID int
+	cli       *keybase1.UpdateUiClient
+}
+
+func (u *UpdateUI) UpdatePrompt(ctx context.Context, arg keybase1.UpdatePromptArg) (res keybase1.UpdatePromptRes, err error) {
+	return u.cli.UpdatePrompt(ctx, arg)
 }

--- a/go/service/ui_router.go
+++ b/go/service/ui_router.go
@@ -112,3 +112,13 @@ func (u *UIRouter) GetSecretUI() (libkb.SecretUI, error) {
 	scli := keybase1.SecretUiClient{Cli: cli}
 	return &SecretUI{cli: &scli}, nil
 }
+
+func (u *UIRouter) GetUpdateUI() (libkb.UpdateUI, error) {
+	x := u.getUI(libkb.UpdateUIKind)
+	if x == nil {
+		return nil, nil
+	}
+	cli := rpc.NewClient(x, libkb.ErrorUnwrapper{})
+	scli := keybase1.UpdateUiClient{Cli: cli}
+	return &UpdateUI{cli: &scli}, nil
+}

--- a/go/service/update.go
+++ b/go/service/update.go
@@ -26,7 +26,9 @@ func NewUpdateHandler(xp rpc.Transporter, g *libkb.GlobalContext) *UpdateHandler
 }
 
 func (h *UpdateHandler) Update(_ context.Context, arg keybase1.UpdateArg) (result keybase1.UpdateResult, err error) {
-	ctx := engine.Context{}
+	ctx := engine.Context{
+		UpdateUI: h.getUpdateUI(),
+	}
 	eng := engine.NewUpdateEngine(h.G(), arg.Config, arg.CheckOnly)
 	err = engine.RunEngine(eng, &ctx)
 	if err != nil {

--- a/go/systests/common_test.go
+++ b/go/systests/common_test.go
@@ -53,6 +53,7 @@ func (n *baseNullUI) GetGPGUI() libkb.GPGUI                           { return n
 func (n *baseNullUI) GetLogUI() libkb.LogUI                           { return n.g.Log }
 func (n *baseNullUI) GetIdentifyLubaUI() libkb.IdentifyUI             { return nil }
 func (n *baseNullUI) GetPgpUI() libkb.PgpUI                           { return nil }
+func (n *baseNullUI) GetUpdateUI() libkb.UpdateUI                     { return nil }
 func (n *baseNullUI) GetProvisionUI(libkb.KexRole) libkb.ProvisionUI  { return nil }
 
 func (n *baseNullUI) Configure() error { return nil }

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -70,6 +70,8 @@ func (n *signupUI) GetGPGUI() libkb.GPGUI {
 	return client.NewGPGUI(n.G(), n.GetTerminalUI(), false, "")
 }
 
+func (n *signupUI) GetUpdateUI() libkb.UpdateUI { return nil }
+
 func (n *signupSecretUI) GetNewPassphrase(arg keybase1.GetNewPassphraseArg) (res keybase1.GetPassphraseRes, err error) {
 	res.Passphrase = n.info.passphrase
 	n.G().Log.Debug("| GetNewPassphrase: %v -> %v", arg, res)

--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -58,6 +58,7 @@ build-stamp: \
 	json/track.json \
 	json/ui.json \
 	json/update.json \
+	json/update_ui.json \
 	json/user.json
 	@mkdir -p json
 	date > $@

--- a/protocol/avdl/common.avdl
+++ b/protocol/avdl/common.avdl
@@ -108,4 +108,26 @@ protocol Common {
 
 	    UserVersionVector uvv;
 	}
+
+	/**
+     Asset describes a downloadable file.
+     */
+	record Asset {
+		string name;
+		string url;
+	}
+
+	enum UpdateType {
+		NORMAL_0,
+		BUGFIX_1,
+		CRITICAL_2
+	}
+
+	record Update {
+		string version; // Sematic version, e.g. 1.2.3-400
+		string name;
+		string description;
+		UpdateType type;
+		Asset asset;
+	}
 }

--- a/protocol/avdl/delegate_ui_ctl.avdl
+++ b/protocol/avdl/delegate_ui_ctl.avdl
@@ -5,4 +5,5 @@ protocol delegateUiCtl {
 
   void registerIdentifyUI();
   void registerSecretUI();
+  void registerUpdateUI();
 }

--- a/protocol/avdl/update.avdl
+++ b/protocol/avdl/update.avdl
@@ -31,6 +31,11 @@ protocol update {
     string channel; // Update channel, empty string for default
   }
 
+  record UpdatePreferences {
+    boolean auto;
+    string skip; // As a semantic version to skip
+  }
+
   record UpdateResult {
     union { null, Update } update;
   }

--- a/protocol/avdl/update.avdl
+++ b/protocol/avdl/update.avdl
@@ -5,21 +5,6 @@ protocol update {
   import idl "common.avdl";
 
   /**
-   Asset describes a downloadable file.
-   */
-  record Asset {
-    string name;
-    string url;
-  }
-
-  record Update {
-    string version; // Sematic version, e.g. 1.2.3-400
-    string name;
-    string description;
-    Asset asset;
-  }
-
-  /**
     Configuration for checking and applying updates.
     */
   record UpdateConfig {
@@ -29,11 +14,6 @@ protocol update {
     string source; // Source to check, empty string for default
     string URL; // Custom source URL
     string channel; // Update channel, empty string for default
-  }
-
-  record UpdatePreferences {
-    boolean auto;
-    string skip; // As a semantic version to skip
   }
 
   record UpdateResult {

--- a/protocol/avdl/update_ui.avdl
+++ b/protocol/avdl/update_ui.avdl
@@ -1,0 +1,13 @@
+
+@namespace("keybase.1")
+protocol updateUi {
+
+	record UpdatePromptRes {
+		boolean doInstall;
+		boolean alwaysAutoInstall;
+		boolean skipVersion;
+		int repromptInSeconds;
+	}
+
+	UpdatePromptRes updatePrompt(int sessionID, string desc, string version);
+}

--- a/protocol/avdl/update_ui.avdl
+++ b/protocol/avdl/update_ui.avdl
@@ -2,12 +2,20 @@
 @namespace("keybase.1")
 protocol updateUi {
 
-	record UpdatePromptRes {
-		boolean doInstall;
-		boolean alwaysAutoInstall;
-		boolean skipVersion;
-		int repromptInSeconds;
+	import idl "common.avdl";
+
+	enum UpdateAction {
+		UPDATE_0,
+		SKIP_1,
+		SNOOZE_2,
+		CANCEL_3
 	}
 
-	UpdatePromptRes updatePrompt(int sessionID, string desc, string version);
+	record UpdatePromptRes {
+		UpdateAction action;
+		boolean alwaysAutoInstall;
+		Time snoozeUntil;
+	}
+
+	UpdatePromptRes updatePrompt(int sessionID, Update update);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4668,12 +4668,36 @@ export type UpdateConfig = {
   channel: string;
 }
 
+export type update_UpdatePreferences = {
+  auto: boolean;
+  skip: string;
+}
+
+export type UpdatePreferences = {
+  auto: boolean;
+  skip: string;
+}
+
 export type update_UpdateResult = {
   update?: ?Update;
 }
 
 export type UpdateResult = {
   update?: ?Update;
+}
+
+export type updateUi_UpdatePromptRes = {
+  doInstall: boolean;
+  alwaysAutoInstall: boolean;
+  skipVersion: boolean;
+  repromptInSeconds: int;
+}
+
+export type UpdatePromptRes = {
+  doInstall: boolean;
+  alwaysAutoInstall: boolean;
+  skipVersion: boolean;
+  repromptInSeconds: int;
 }
 
 export type user_Time = {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4636,10 +4636,15 @@ export type Asset = {
   url: string;
 }
 
+export type update_UpdateType = 0 /* 'NORMAL_0' */ | 1 /* 'BUGFIX_1' */ | 2 /* 'CRITICAL_2' */
+
+export type UpdateType = 0 /* 'NORMAL_0' */ | 1 /* 'BUGFIX_1' */ | 2 /* 'CRITICAL_2' */
+
 export type update_Update = {
   version: string;
   name: string;
   description: string;
+  type: UpdateType;
   asset: Asset;
 }
 
@@ -4647,6 +4652,7 @@ export type Update = {
   version: string;
   name: string;
   description: string;
+  type: UpdateType;
   asset: Asset;
 }
 
@@ -4668,16 +4674,6 @@ export type UpdateConfig = {
   channel: string;
 }
 
-export type update_UpdatePreferences = {
-  auto: boolean;
-  skip: string;
-}
-
-export type UpdatePreferences = {
-  auto: boolean;
-  skip: string;
-}
-
 export type update_UpdateResult = {
   update?: ?Update;
 }
@@ -4686,18 +4682,124 @@ export type UpdateResult = {
   update?: ?Update;
 }
 
+export type updateUi_Time = {
+}
+
+export type updateUi_StringKVPair = {
+  key: string;
+  value: string;
+}
+
+export type updateUi_Status = {
+  code: int;
+  name: string;
+  desc: string;
+  fields: Array<StringKVPair>;
+}
+
+export type updateUi_UID = {
+}
+
+export type updateUi_DeviceID = {
+}
+
+export type updateUi_SigID = {
+}
+
+export type updateUi_KID = {
+}
+
+export type updateUi_Text = {
+  data: string;
+  markup: boolean;
+}
+
+export type updateUi_PGPIdentity = {
+  username: string;
+  comment: string;
+  email: string;
+}
+
+export type updateUi_PublicKey = {
+  KID: KID;
+  PGPFingerprint: string;
+  PGPIdentities: Array<PGPIdentity>;
+  isSibkey: boolean;
+  isEldest: boolean;
+  parentID: string;
+  deviceID: DeviceID;
+  deviceDescription: string;
+  deviceType: string;
+  cTime: Time;
+  eTime: Time;
+}
+
+export type updateUi_User = {
+  uid: UID;
+  username: string;
+}
+
+export type updateUi_Device = {
+  type: string;
+  name: string;
+  deviceID: DeviceID;
+  cTime: Time;
+  mTime: Time;
+}
+
+export type updateUi_Stream = {
+  fd: int;
+}
+
+export type updateUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
+
+export type updateUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type updateUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type updateUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
+export type updateUi_Asset = {
+  name: string;
+  url: string;
+}
+
+export type updateUi_UpdateType = 0 /* 'NORMAL_0' */ | 1 /* 'BUGFIX_1' */ | 2 /* 'CRITICAL_2' */
+
+export type updateUi_Update = {
+  version: string;
+  name: string;
+  description: string;
+  type: UpdateType;
+  asset: Asset;
+}
+
+export type updateUi_UpdateAction = 0 /* 'UPDATE_0' */ | 1 /* 'SKIP_1' */ | 2 /* 'SNOOZE_2' */ | 3 /* 'CANCEL_3' */
+
+export type UpdateAction = 0 /* 'UPDATE_0' */ | 1 /* 'SKIP_1' */ | 2 /* 'SNOOZE_2' */ | 3 /* 'CANCEL_3' */
+
 export type updateUi_UpdatePromptRes = {
-  doInstall: boolean;
+  action: UpdateAction;
   alwaysAutoInstall: boolean;
-  skipVersion: boolean;
-  repromptInSeconds: int;
+  snoozeUntil: Time;
 }
 
 export type UpdatePromptRes = {
-  doInstall: boolean;
+  action: UpdateAction;
   alwaysAutoInstall: boolean;
-  skipVersion: boolean;
-  repromptInSeconds: int;
+  snoozeUntil: Time;
 }
 
 export type user_Time = {

--- a/protocol/js/keybase_v1.js
+++ b/protocol/js/keybase_v1.js
@@ -1191,6 +1191,7 @@ export default {
       'gui': 1
     }
   },
+  'updateUi': {},
   'user': {
     'LogLevel': {
       'none': 0,

--- a/protocol/js/keybase_v1.js
+++ b/protocol/js/keybase_v1.js
@@ -1189,9 +1189,40 @@ export default {
     'ClientType': {
       'cli': 0,
       'gui': 1
+    },
+    'UpdateType': {
+      'normal': 0,
+      'bugfix': 1,
+      'critical': 2
     }
   },
-  'updateUi': {},
+  'updateUi': {
+    'LogLevel': {
+      'none': 0,
+      'debug': 1,
+      'info': 2,
+      'notice': 3,
+      'warn': 4,
+      'error': 5,
+      'critical': 6,
+      'fatal': 7
+    },
+    'ClientType': {
+      'cli': 0,
+      'gui': 1
+    },
+    'UpdateType': {
+      'normal': 0,
+      'bugfix': 1,
+      'critical': 2
+    },
+    'UpdateAction': {
+      'update': 0,
+      'skip': 1,
+      'snooze': 2,
+      'cancel': 3
+    }
+  },
   'user': {
     'LogLevel': {
       'none': 0,

--- a/protocol/json/delegate_ui_ctl.json
+++ b/protocol/json/delegate_ui_ctl.json
@@ -215,6 +215,10 @@
     "registerSecretUI" : {
       "request" : [ ],
       "response" : "null"
+    },
+    "registerUpdateUI" : {
+      "request" : [ ],
+      "response" : "null"
     }
   }
 }

--- a/protocol/json/update.json
+++ b/protocol/json/update.json
@@ -258,6 +258,16 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "UpdatePreferences",
+    "fields" : [ {
+      "name" : "auto",
+      "type" : "boolean"
+    }, {
+      "name" : "skip",
+      "type" : "string"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "UpdateResult",
     "fields" : [ {
       "name" : "update",

--- a/protocol/json/update.json
+++ b/protocol/json/update.json
@@ -218,6 +218,10 @@
       "type" : "string"
     } ]
   }, {
+    "type" : "enum",
+    "name" : "UpdateType",
+    "symbols" : [ "NORMAL_0", "BUGFIX_1", "CRITICAL_2" ]
+  }, {
     "type" : "record",
     "name" : "Update",
     "fields" : [ {
@@ -229,6 +233,9 @@
     }, {
       "name" : "description",
       "type" : "string"
+    }, {
+      "name" : "type",
+      "type" : "UpdateType"
     }, {
       "name" : "asset",
       "type" : "Asset"
@@ -254,16 +261,6 @@
       "type" : "string"
     }, {
       "name" : "channel",
-      "type" : "string"
-    } ]
-  }, {
-    "type" : "record",
-    "name" : "UpdatePreferences",
-    "fields" : [ {
-      "name" : "auto",
-      "type" : "boolean"
-    }, {
-      "name" : "skip",
       "type" : "string"
     } ]
   }, {

--- a/protocol/json/update_ui.json
+++ b/protocol/json/update_ui.json
@@ -3,19 +3,259 @@
   "namespace" : "keybase.1",
   "types" : [ {
     "type" : "record",
+    "name" : "Time",
+    "fields" : [ ],
+    "typedef" : "long"
+  }, {
+    "type" : "record",
+    "name" : "StringKVPair",
+    "fields" : [ {
+      "name" : "key",
+      "type" : "string"
+    }, {
+      "name" : "value",
+      "type" : "string"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "Status",
+    "fields" : [ {
+      "name" : "code",
+      "type" : "int"
+    }, {
+      "name" : "name",
+      "type" : "string"
+    }, {
+      "name" : "desc",
+      "type" : "string"
+    }, {
+      "name" : "fields",
+      "type" : {
+        "type" : "array",
+        "items" : "StringKVPair"
+      }
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UID",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
+    "type" : "record",
+    "name" : "DeviceID",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
+    "type" : "record",
+    "name" : "SigID",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
+    "type" : "record",
+    "name" : "KID",
+    "fields" : [ ],
+    "typedef" : "string"
+  }, {
+    "type" : "record",
+    "name" : "Text",
+    "fields" : [ {
+      "name" : "data",
+      "type" : "string"
+    }, {
+      "name" : "markup",
+      "type" : "boolean"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "PGPIdentity",
+    "fields" : [ {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "comment",
+      "type" : "string"
+    }, {
+      "name" : "email",
+      "type" : "string"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "PublicKey",
+    "fields" : [ {
+      "name" : "KID",
+      "type" : "KID"
+    }, {
+      "name" : "PGPFingerprint",
+      "type" : "string"
+    }, {
+      "name" : "PGPIdentities",
+      "type" : {
+        "type" : "array",
+        "items" : "PGPIdentity"
+      }
+    }, {
+      "name" : "isSibkey",
+      "type" : "boolean"
+    }, {
+      "name" : "isEldest",
+      "type" : "boolean"
+    }, {
+      "name" : "parentID",
+      "type" : "string"
+    }, {
+      "name" : "deviceID",
+      "type" : "DeviceID"
+    }, {
+      "name" : "deviceDescription",
+      "type" : "string"
+    }, {
+      "name" : "deviceType",
+      "type" : "string"
+    }, {
+      "name" : "cTime",
+      "type" : "Time"
+    }, {
+      "name" : "eTime",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "User",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "Device",
+    "fields" : [ {
+      "name" : "type",
+      "type" : "string"
+    }, {
+      "name" : "name",
+      "type" : "string"
+    }, {
+      "name" : "deviceID",
+      "type" : "DeviceID"
+    }, {
+      "name" : "cTime",
+      "type" : "Time"
+    }, {
+      "name" : "mTime",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "Stream",
+    "fields" : [ {
+      "name" : "fd",
+      "type" : "int"
+    } ]
+  }, {
+    "type" : "enum",
+    "name" : "LogLevel",
+    "symbols" : [ "NONE_0", "DEBUG_1", "INFO_2", "NOTICE_3", "WARN_4", "ERROR_5", "CRITICAL_6", "FATAL_7" ]
+  }, {
+    "type" : "enum",
+    "name" : "ClientType",
+    "symbols" : [ "CLI_0", "GUI_1" ]
+  }, {
+    "type" : "record",
+    "name" : "UserVersionVector",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "long"
+    }, {
+      "name" : "sigHints",
+      "type" : "int"
+    }, {
+      "name" : "sigChain",
+      "type" : "long"
+    }, {
+      "name" : "cachedAt",
+      "type" : "Time"
+    }, {
+      "name" : "lastIdentifiedAt",
+      "type" : "Time"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "UserPlusKeys",
+    "fields" : [ {
+      "name" : "uid",
+      "type" : "UID"
+    }, {
+      "name" : "username",
+      "type" : "string"
+    }, {
+      "name" : "deviceKeys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "keys",
+      "type" : {
+        "type" : "array",
+        "items" : "PublicKey"
+      }
+    }, {
+      "name" : "uvv",
+      "type" : "UserVersionVector"
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "Asset",
+    "doc" : "Asset describes a downloadable file.",
+    "fields" : [ {
+      "name" : "name",
+      "type" : "string"
+    }, {
+      "name" : "url",
+      "type" : "string"
+    } ]
+  }, {
+    "type" : "enum",
+    "name" : "UpdateType",
+    "symbols" : [ "NORMAL_0", "BUGFIX_1", "CRITICAL_2" ]
+  }, {
+    "type" : "record",
+    "name" : "Update",
+    "fields" : [ {
+      "name" : "version",
+      "type" : "string"
+    }, {
+      "name" : "name",
+      "type" : "string"
+    }, {
+      "name" : "description",
+      "type" : "string"
+    }, {
+      "name" : "type",
+      "type" : "UpdateType"
+    }, {
+      "name" : "asset",
+      "type" : "Asset"
+    } ]
+  }, {
+    "type" : "enum",
+    "name" : "UpdateAction",
+    "symbols" : [ "UPDATE_0", "SKIP_1", "SNOOZE_2", "CANCEL_3" ]
+  }, {
+    "type" : "record",
     "name" : "UpdatePromptRes",
     "fields" : [ {
-      "name" : "doInstall",
-      "type" : "boolean"
+      "name" : "action",
+      "type" : "UpdateAction"
     }, {
       "name" : "alwaysAutoInstall",
       "type" : "boolean"
     }, {
-      "name" : "skipVersion",
-      "type" : "boolean"
-    }, {
-      "name" : "repromptInSeconds",
-      "type" : "int"
+      "name" : "snoozeUntil",
+      "type" : "Time"
     } ]
   } ],
   "messages" : {
@@ -24,11 +264,8 @@
         "name" : "sessionID",
         "type" : "int"
       }, {
-        "name" : "desc",
-        "type" : "string"
-      }, {
-        "name" : "version",
-        "type" : "string"
+        "name" : "update",
+        "type" : "Update"
       } ],
       "response" : "UpdatePromptRes"
     }

--- a/protocol/json/update_ui.json
+++ b/protocol/json/update_ui.json
@@ -1,0 +1,36 @@
+{
+  "protocol" : "updateUi",
+  "namespace" : "keybase.1",
+  "types" : [ {
+    "type" : "record",
+    "name" : "UpdatePromptRes",
+    "fields" : [ {
+      "name" : "doInstall",
+      "type" : "boolean"
+    }, {
+      "name" : "alwaysAutoInstall",
+      "type" : "boolean"
+    }, {
+      "name" : "skipVersion",
+      "type" : "boolean"
+    }, {
+      "name" : "repromptInSeconds",
+      "type" : "int"
+    } ]
+  } ],
+  "messages" : {
+    "updatePrompt" : {
+      "request" : [ {
+        "name" : "sessionID",
+        "type" : "int"
+      }, {
+        "name" : "desc",
+        "type" : "string"
+      }, {
+        "name" : "version",
+        "type" : "string"
+      } ],
+      "response" : "UpdatePromptRes"
+    }
+  }
+}

--- a/react-native/react/constants/types/flow-types.js
+++ b/react-native/react/constants/types/flow-types.js
@@ -4668,12 +4668,36 @@ export type UpdateConfig = {
   channel: string;
 }
 
+export type update_UpdatePreferences = {
+  auto: boolean;
+  skip: string;
+}
+
+export type UpdatePreferences = {
+  auto: boolean;
+  skip: string;
+}
+
 export type update_UpdateResult = {
   update?: ?Update;
 }
 
 export type UpdateResult = {
   update?: ?Update;
+}
+
+export type updateUi_UpdatePromptRes = {
+  doInstall: boolean;
+  alwaysAutoInstall: boolean;
+  skipVersion: boolean;
+  repromptInSeconds: int;
+}
+
+export type UpdatePromptRes = {
+  doInstall: boolean;
+  alwaysAutoInstall: boolean;
+  skipVersion: boolean;
+  repromptInSeconds: int;
 }
 
 export type user_Time = {

--- a/react-native/react/constants/types/flow-types.js
+++ b/react-native/react/constants/types/flow-types.js
@@ -4636,10 +4636,15 @@ export type Asset = {
   url: string;
 }
 
+export type update_UpdateType = 0 /* 'NORMAL_0' */ | 1 /* 'BUGFIX_1' */ | 2 /* 'CRITICAL_2' */
+
+export type UpdateType = 0 /* 'NORMAL_0' */ | 1 /* 'BUGFIX_1' */ | 2 /* 'CRITICAL_2' */
+
 export type update_Update = {
   version: string;
   name: string;
   description: string;
+  type: UpdateType;
   asset: Asset;
 }
 
@@ -4647,6 +4652,7 @@ export type Update = {
   version: string;
   name: string;
   description: string;
+  type: UpdateType;
   asset: Asset;
 }
 
@@ -4668,16 +4674,6 @@ export type UpdateConfig = {
   channel: string;
 }
 
-export type update_UpdatePreferences = {
-  auto: boolean;
-  skip: string;
-}
-
-export type UpdatePreferences = {
-  auto: boolean;
-  skip: string;
-}
-
 export type update_UpdateResult = {
   update?: ?Update;
 }
@@ -4686,18 +4682,124 @@ export type UpdateResult = {
   update?: ?Update;
 }
 
+export type updateUi_Time = {
+}
+
+export type updateUi_StringKVPair = {
+  key: string;
+  value: string;
+}
+
+export type updateUi_Status = {
+  code: int;
+  name: string;
+  desc: string;
+  fields: Array<StringKVPair>;
+}
+
+export type updateUi_UID = {
+}
+
+export type updateUi_DeviceID = {
+}
+
+export type updateUi_SigID = {
+}
+
+export type updateUi_KID = {
+}
+
+export type updateUi_Text = {
+  data: string;
+  markup: boolean;
+}
+
+export type updateUi_PGPIdentity = {
+  username: string;
+  comment: string;
+  email: string;
+}
+
+export type updateUi_PublicKey = {
+  KID: KID;
+  PGPFingerprint: string;
+  PGPIdentities: Array<PGPIdentity>;
+  isSibkey: boolean;
+  isEldest: boolean;
+  parentID: string;
+  deviceID: DeviceID;
+  deviceDescription: string;
+  deviceType: string;
+  cTime: Time;
+  eTime: Time;
+}
+
+export type updateUi_User = {
+  uid: UID;
+  username: string;
+}
+
+export type updateUi_Device = {
+  type: string;
+  name: string;
+  deviceID: DeviceID;
+  cTime: Time;
+  mTime: Time;
+}
+
+export type updateUi_Stream = {
+  fd: int;
+}
+
+export type updateUi_LogLevel = 0 /* 'NONE_0' */ | 1 /* 'DEBUG_1' */ | 2 /* 'INFO_2' */ | 3 /* 'NOTICE_3' */ | 4 /* 'WARN_4' */ | 5 /* 'ERROR_5' */ | 6 /* 'CRITICAL_6' */ | 7 /* 'FATAL_7' */
+
+export type updateUi_ClientType = 0 /* 'CLI_0' */ | 1 /* 'GUI_1' */
+
+export type updateUi_UserVersionVector = {
+  id: long;
+  sigHints: int;
+  sigChain: long;
+  cachedAt: Time;
+  lastIdentifiedAt: Time;
+}
+
+export type updateUi_UserPlusKeys = {
+  uid: UID;
+  username: string;
+  deviceKeys: Array<PublicKey>;
+  keys: Array<PublicKey>;
+  uvv: UserVersionVector;
+}
+
+export type updateUi_Asset = {
+  name: string;
+  url: string;
+}
+
+export type updateUi_UpdateType = 0 /* 'NORMAL_0' */ | 1 /* 'BUGFIX_1' */ | 2 /* 'CRITICAL_2' */
+
+export type updateUi_Update = {
+  version: string;
+  name: string;
+  description: string;
+  type: UpdateType;
+  asset: Asset;
+}
+
+export type updateUi_UpdateAction = 0 /* 'UPDATE_0' */ | 1 /* 'SKIP_1' */ | 2 /* 'SNOOZE_2' */ | 3 /* 'CANCEL_3' */
+
+export type UpdateAction = 0 /* 'UPDATE_0' */ | 1 /* 'SKIP_1' */ | 2 /* 'SNOOZE_2' */ | 3 /* 'CANCEL_3' */
+
 export type updateUi_UpdatePromptRes = {
-  doInstall: boolean;
+  action: UpdateAction;
   alwaysAutoInstall: boolean;
-  skipVersion: boolean;
-  repromptInSeconds: int;
+  snoozeUntil: Time;
 }
 
 export type UpdatePromptRes = {
-  doInstall: boolean;
+  action: UpdateAction;
   alwaysAutoInstall: boolean;
-  skipVersion: boolean;
-  repromptInSeconds: int;
+  snoozeUntil: Time;
 }
 
 export type user_Time = {

--- a/react-native/react/constants/types/keybase_v1.js
+++ b/react-native/react/constants/types/keybase_v1.js
@@ -1191,6 +1191,7 @@ export default {
       'gui': 1
     }
   },
+  'updateUi': {},
   'user': {
     'LogLevel': {
       'none': 0,

--- a/react-native/react/constants/types/keybase_v1.js
+++ b/react-native/react/constants/types/keybase_v1.js
@@ -1189,9 +1189,40 @@ export default {
     'ClientType': {
       'cli': 0,
       'gui': 1
+    },
+    'UpdateType': {
+      'normal': 0,
+      'bugfix': 1,
+      'critical': 2
     }
   },
-  'updateUi': {},
+  'updateUi': {
+    'LogLevel': {
+      'none': 0,
+      'debug': 1,
+      'info': 2,
+      'notice': 3,
+      'warn': 4,
+      'error': 5,
+      'critical': 6,
+      'fatal': 7
+    },
+    'ClientType': {
+      'cli': 0,
+      'gui': 1
+    },
+    'UpdateType': {
+      'normal': 0,
+      'bugfix': 1,
+      'critical': 2
+    },
+    'UpdateAction': {
+      'update': 0,
+      'skip': 1,
+      'snooze': 2,
+      'cancel': 3
+    }
+  },
   'user': {
     'LogLevel': {
       'none': 0,


### PR DESCRIPTION
- set up new AVDL for updateUI
- set up routing and delegation possibilities
- debug the update flow, get it working with the KB source
- knobs for reading/writing config file for update preferences
- make update run on all platforms
- cobble together some install location for development mode
- fix update.json call to at least hit the right endpoint