### PR TITLE
Semantic version doesn't work with installer tool after all

### DIFF
--- a/go/winresource/main.go
+++ b/go/winresource/main.go
@@ -24,6 +24,7 @@ func main() {
 
 	outPtr := flag.String("o", "rsrc_windows.syso", "resource output pathname")
 	printverPtr := flag.Bool("v", false, "print version to console (no .syso output)")
+	printWinVerPtr := flag.Bool("w", false, "print windows format version to console (no .syso output)")
 	iconPtr := flag.String("i", "../../../keybase/public/images/favicon.ico", "icon pathname")
 
 	flag.Parse()
@@ -41,7 +42,11 @@ func main() {
 
 	if *printverPtr {
 		fmt.Printf("%d.%d.%d-%d", fv.Major, fv.Minor, fv.Patch, fv.Build)
-		//		fmt.Printf("%s", libkb.VersionString())
+		return
+	}
+
+	if *printWinVerPtr {
+		fmt.Printf("%d.%d.%d.%d", fv.Major, fv.Minor, fv.Patch, fv.Build)
 		return
 	}
 

--- a/packaging/windows/doinstaller.cmd
+++ b/packaging/windows/doinstaller.cmd
@@ -5,10 +5,13 @@
 :: get the target build folder. Assume winresource.exe has been built.
 :: If not, go there and do "go generate"
 For %%A in ("%1") do Set Folder=%%~dpA
-:: Capture the version - this is the only way to store it in a .cmd variable
-for /f %%i in ('%Folder%winresource.exe -v') do set BUILDVER=%%i
+:: Capture the windows style version - this is the only way to store it in a .cmd variable
+for /f %%i in ('%Folder%winresource.exe -w') do set BUILDVER=%%i
 echo %BUILDVER%
 
+:: Capture the semantic version - this is the only way to store it in a .cmd variable
+for /f %%i in ('%Folder%winresource.exe -v') do set SEMVER=%%i
+echo %SEMVER%
 
 :: Other alternate time servers:
 ::   http://timestamp.verisign.com/scripts/timstamp.dll
@@ -20,4 +23,4 @@ SignTool.exe sign /a /tr http://timestamp.digicert.com %1
 IF %ERRORLEVEL% NEQ 0 (
   EXIT /B 1
 )
-"%ProgramFiles(x86)%\Inno Setup 5\iscc.exe" /DMyExePathName=%1 /DMyAppVersion=%BUILDVER% "/sSignCommand=signtool.exe sign /tr http://timestamp.digicert.com $f" setup_windows.iss
+"%ProgramFiles(x86)%\Inno Setup 5\iscc.exe" /DMyExePathName=%1 /DMyAppVersion=%BUILDVER% /DMySemVersion=%SEMVER% "/sSignCommand=signtool.exe sign /tr http://timestamp.digicert.com $f" setup_windows.iss

--- a/packaging/windows/setup_windows.iss
+++ b/packaging/windows/setup_windows.iss
@@ -5,6 +5,11 @@
 #ifndef MyAppVersion
 #define MyAppVersion "1.0"
 #endif
+; Use semantic version to name the installer,
+; but we still need the x.x.x.x version because Windows.
+#ifndef MySemVersion
+#define MySemVersion MyAppVersion
+#endif
 #define MyAppPublisher "Keybase, Inc."
 #define MyAppURL "http://www.keybase.io/"
 #define MyExeName "keybase.exe"
@@ -36,7 +41,7 @@ AppCopyright=Copyright (c) 2015, Keybase
 DefaultDirName={pf}\{#MyAppName}
 DefaultGroupName={#MyAppName}
 AllowNoIcons=yes
-OutputBaseFilename=keybase_setup_{#MyAppVersion}_{#MyGoArch}
+OutputBaseFilename=keybase_setup_{#MySemVersion}_{#MyGoArch}
 SetupIconFile={#MyGoPath}\src\github.com\keybase\keybase\public\images\favicon.ico
 Compression=lzma
 SolidCompression=yes


### PR DESCRIPTION
I knew that Windows file versions must be in the x.x.x.x format, but I had forgotten that the installer files also get versioned according the current application version. So now we are maintaining two formats and the only way to use the semantic one in Windows is the filename of the installer. I don't think this makes sense but it is certainly possible. I thought I would double check before pushing a signed release to the production server.  
BTW, should these kinds of minor tweaks always have a matching Jira story?  
![image](https://cloud.githubusercontent.com/assets/862397/11818914/d14cfe42-a311-11e5-8671-9ed14156b5ee.png)
@maxtaco 
