### PR TITLE
saltpack: apply new version of spec

### DIFF
--- a/go/engine/kbcmf_encrypt.go
+++ b/go/engine/kbcmf_encrypt.go
@@ -77,7 +77,7 @@ func (e *KBCMFEncrypt) Run(ctx *Context) (err error) {
 	}
 
 	uplus := kf.UsersPlusDeviceKeys()
-	receivers := make([]libkb.NaclDHKeyPublic, len(uplus))
+	var receivers []libkb.NaclDHKeyPublic
 	for _, up := range uplus {
 		for _, k := range up.Keys {
 			if !k.IsSibkey {
@@ -89,7 +89,6 @@ func (e *KBCMFEncrypt) Run(ctx *Context) (err error) {
 				if !ok {
 					return libkb.KeyCannotEncryptError{}
 				}
-
 				receivers = append(receivers, kp.Public)
 			}
 		}

--- a/go/engine/kbcmf_encrypt.go
+++ b/go/engine/kbcmf_encrypt.go
@@ -77,9 +77,8 @@ func (e *KBCMFEncrypt) Run(ctx *Context) (err error) {
 	}
 
 	uplus := kf.UsersPlusDeviceKeys()
-	receivers := make([][]libkb.NaclDHKeyPublic, len(uplus))
+	receivers := make([]libkb.NaclDHKeyPublic, len(uplus))
 	for _, up := range uplus {
-		var receiver []libkb.NaclDHKeyPublic
 		for _, k := range up.Keys {
 			if !k.IsSibkey {
 				gk, err := libkb.ImportKeypairFromKID(k.KID)
@@ -91,10 +90,9 @@ func (e *KBCMFEncrypt) Run(ctx *Context) (err error) {
 					return libkb.KeyCannotEncryptError{}
 				}
 
-				receiver = append(receiver, kp.Public)
+				receivers = append(receivers, kp.Public)
 			}
 		}
-		receivers[up.Index] = receiver
 	}
 
 	ska := libkb.SecretKeyArg{

--- a/go/kbcmf/armor62_encrypt.go
+++ b/go/kbcmf/armor62_encrypt.go
@@ -26,17 +26,13 @@ func (c closeForwarder) Close() error {
 // NewEncryptArmor62Stream creates a stream that consumes plaintext data.
 // It will write out encrypted data to the io.Writer passed in as ciphertext.
 // The encryption is from the specified sender, and is encrypted for the
-// given receivers.  Note that receivers as specified as two-dimensional array.
-// Each inner group of receivers shares the same pairwise MAC-key, so should
-// represent a logic receiver split across multiple devices.  Each group of
-// receivers represents a mutually distrustful set of receivers, and will each
-// get their own pairwise-MAC keys.
+// given receivers.
 //
 // The ciphertext is additionally armored with the recommended armor62-style format.
 //
 // Returns an io.WriteCloser that accepts plaintext data to be encrypted; and
 // also returns an error if initialization failed.
-func NewEncryptArmor62Stream(ciphertext io.Writer, sender BoxSecretKey, receivers [][]BoxPublicKey) (plaintext io.WriteCloser, err error) {
+func NewEncryptArmor62Stream(ciphertext io.Writer, sender BoxSecretKey, receivers []BoxPublicKey) (plaintext io.WriteCloser, err error) {
 	enc, err := NewArmor62EncoderStream(ciphertext, EncryptionArmorHeader, EncryptionArmorFooter)
 	if err != nil {
 		return nil, err
@@ -50,7 +46,7 @@ func NewEncryptArmor62Stream(ciphertext io.Writer, sender BoxSecretKey, receiver
 
 // EncryptArmor62Seal is the non-streaming version of NewEncryptArmor62Stream, which
 // inputs a plaintext (in bytes) and output a ciphertext (as a string).
-func EncryptArmor62Seal(plaintext []byte, sender BoxSecretKey, receivers [][]BoxPublicKey) (string, error) {
+func EncryptArmor62Seal(plaintext []byte, sender BoxSecretKey, receivers []BoxPublicKey) (string, error) {
 	var buf bytes.Buffer
 	enc, err := NewEncryptArmor62Stream(&buf, sender, receivers)
 	if err != nil {

--- a/go/kbcmf/armor62_encrypt_test.go
+++ b/go/kbcmf/armor62_encrypt_test.go
@@ -18,7 +18,7 @@ func encryptArmor62RandomData(t *testing.T, sz int) ([]byte, string) {
 		t.Fatal(err)
 	}
 	sndr := newBoxKey(t)
-	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 
 	ciphertext, err := EncryptArmor62Seal(msg, sndr, receivers)
 	if err != nil {
@@ -45,7 +45,7 @@ func TestDearmor62DecryptSlowReader(t *testing.T) {
 		t.Fatal(err)
 	}
 	sndr := newBoxKey(t)
-	receivers := [][]BoxPublicKey{{newBoxKey(t).GetPublicKey()}}
+	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 
 	ciphertext, err := EncryptArmor62Seal(msg, sndr, receivers)
 	if err != nil {

--- a/go/kbcmf/common.go
+++ b/go/kbcmf/common.go
@@ -5,9 +5,7 @@ package kbcmf
 
 import (
 	"bytes"
-	"crypto/hmac"
 	"crypto/rand"
-	"crypto/sha512"
 	"github.com/ugorji/go/codec"
 	"golang.org/x/crypto/poly1305"
 )
@@ -39,12 +37,6 @@ func (e encryptionBlockNumber) check() error {
 		return ErrPacketOverflow
 	}
 	return nil
-}
-
-func hmacSHA512(key []byte, data []byte) []byte {
-	hasher := hmac.New(sha512.New, key)
-	hasher.Write(data)
-	return hasher.Sum(nil)[0:32]
 }
 
 func hashNonceAndAuthTag(nonce *Nonce, ciphertext []byte) []byte {

--- a/go/kbcmf/common.go
+++ b/go/kbcmf/common.go
@@ -8,7 +8,6 @@ import (
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha512"
-	"encoding/binary"
 	"github.com/ugorji/go/codec"
 	"golang.org/x/crypto/poly1305"
 )
@@ -35,20 +34,6 @@ func randomFill(b []byte) (err error) {
 	return nil
 }
 
-func (n *Nonce) writeCounter(i uint64) {
-	binary.BigEndian.PutUint64((*n)[16:], i)
-}
-
-func (n *Nonce) writeCounter32(i uint32) {
-	binary.BigEndian.PutUint32((*n)[20:], i)
-}
-
-func (e encryptionBlockNumber) newCounterNonce() *Nonce {
-	var ret Nonce
-	ret.writeCounter(uint64(e))
-	return &ret
-}
-
 func (e encryptionBlockNumber) check() error {
 	if e >= encryptionBlockNumber(0xffffffffffffffff) {
 		return ErrPacketOverflow
@@ -60,15 +45,6 @@ func hmacSHA512(key []byte, data []byte) []byte {
 	hasher := hmac.New(sha512.New, key)
 	hasher.Write(data)
 	return hasher.Sum(nil)[0:32]
-}
-
-func keyToNonce(nonce *Nonce, pk BoxPublicKey) {
-	raw := *pk.ToRawBoxKeyPointer()
-	nonceRandLen := 20
-	hasher := sha512.New()
-	hasher.Write(raw[:])
-	res := hasher.Sum(nil)
-	copy((*nonce)[0:nonceRandLen], res)
 }
 
 func hashNonceAndAuthTag(nonce *Nonce, ciphertext []byte) []byte {

--- a/go/kbcmf/const.go
+++ b/go/kbcmf/const.go
@@ -3,31 +3,23 @@
 
 package kbcmf
 
-// PacketTag is an int used to describe what "tag" or "type" of packet it is.
-type PacketTag int
-
-// PacketVersion is an int used to capture the packet version. Right now, only
-// Version=1 is supported
-type PacketVersion int
+// PacketType is an int used to describe what "type" of packet it is.
+type PacketType int
 
 // PacketSeqno is a special int type used to describe which packet in the
 // sequence we're dealing with.  The header is always at seqno=0. Other packets
 // follow. Note that there is a distinction between PacketSeqno and EncryptionBlockNumber.
 // In general, the former is one more than the latter.
-type PacketSeqno int
+type PacketSeqno uint64
 
-// PacketTagEncryptionHeader is a packet tag to describe the first packet
-// in an encryption message.
-const PacketTagEncryptionHeader PacketTag = 1
+// PacketTypeEncryptionHeader is a packet type to describe an encryption message
+const PacketTypeEncryption PacketType = 0
 
-// PacketTagEncryptionBlock is a packet tag to describe the body of an encryption.
-const PacketTagEncryptionBlock PacketTag = 2
-
-// PacketTagSignature is a packet tag for describing a signature packet
-const PacketTagSignature PacketTag = 3
+// PacketTypeAttachedSignature is a packet type to describe an attached signature
+const PacketTypeAttachedSignature PacketType = 1
 
 // PacketVersion1 is currently the only supported packet version
-const PacketVersion1 PacketVersion = 1
+var SaltPackCurrentVersion = Version{Major: 1, Minor: 0}
 
 // EncryptionBlockSize is by default 1MB and can't currently be tweaked.
 const EncryptionBlockSize int = 1048576
@@ -40,6 +32,6 @@ const EncryptionArmorHeader = "BEGIN KEYBASE ENCRYPTED MESSAGE"
 // armored KB message
 const EncryptionArmorFooter = "END KEYBASE ENCRYPTED MESSAGE"
 
-// groupIDMask is OR'ed into group IDs, so that they all are encoded as full
-// 32-bit integers
-const groupIDMask uint32 = 0x80000000
+const SaltPackFormatName = "SaltPack"
+
+const NoncePrefixEncryption = "encryption nonce prefix"

--- a/go/kbcmf/const.go
+++ b/go/kbcmf/const.go
@@ -3,8 +3,8 @@
 
 package kbcmf
 
-// PacketType is an int used to describe what "type" of packet it is.
-type PacketType int
+// MessageType is an int used to describe what "type" of message it is.
+type MessageType int
 
 // PacketSeqno is a special int type used to describe which packet in the
 // sequence we're dealing with.  The header is always at seqno=0. Other packets
@@ -12,13 +12,13 @@ type PacketType int
 // In general, the former is one more than the latter.
 type PacketSeqno uint64
 
-// PacketTypeEncryptionHeader is a packet type to describe an encryption message
-const PacketTypeEncryption PacketType = 0
+// MessageTypeEncryption is a packet type to describe an encryption message
+const MessageTypeEncryption MessageType = 0
 
-// PacketTypeAttachedSignature is a packet type to describe an attached signature
-const PacketTypeAttachedSignature PacketType = 1
+// MessageTypeAttachedSignature is a packet type to describe an attached signature
+const MessageTypeAttachedSignature MessageType = 1
 
-// PacketVersion1 is currently the only supported packet version
+// SaltPackCurrentVersion is currently the only supported packet version, 1.0
 var SaltPackCurrentVersion = Version{Major: 1, Minor: 0}
 
 // EncryptionBlockSize is by default 1MB and can't currently be tweaked.
@@ -32,6 +32,10 @@ const EncryptionArmorHeader = "BEGIN KEYBASE ENCRYPTED MESSAGE"
 // armored KB message
 const EncryptionArmorFooter = "END KEYBASE ENCRYPTED MESSAGE"
 
+// SaltPackFormatName is the publicly advertised name of the format,
+// used in the header of the message and also in Nonce creation.
 const SaltPackFormatName = "SaltPack"
 
+// NoncePrefixEncryption is the prefix used to create the nonce when
+// using the nonce for encryption.
 const NoncePrefixEncryption = "encryption nonce prefix"

--- a/go/kbcmf/encrypt.go
+++ b/go/kbcmf/encrypt.go
@@ -16,8 +16,9 @@ type encryptStream struct {
 	header     *EncryptionHeader
 	sessionKey SymmetricKey
 	buffer     bytes.Buffer
+	nonce      *Nonce
 	inblock    []byte
-	macGroups  []SymmetricKey
+	macKeys    []BoxPrecomputedSharedKey
 
 	numBlocks encryptionBlockNumber // the lower 64 bits of the nonce
 
@@ -50,15 +51,6 @@ func (es *encryptStream) Write(plaintext []byte) (int, error) {
 	return ret, nil
 }
 
-func (es *encryptStream) macForAllGroups(b []byte) [][]byte {
-	var macs [][]byte
-	for _, key := range es.macGroups {
-		mac := hmacSHA512(key[:], b)
-		macs = append(macs, mac)
-	}
-	return macs
-}
-
 func (es *encryptStream) encryptBlock() error {
 	var n int
 	var err error
@@ -75,32 +67,37 @@ func (es *encryptStream) encryptBytes(b []byte) error {
 		return err
 	}
 
-	nonce := es.numBlocks.newCounterNonce()
-	ciphertext := secretbox.Seal([]byte{}, b, (*[24]byte)(nonce), (*[32]byte)(&es.sessionKey))
-	// Compute the MAC over the nonce and the ciphertext
-	sum := hashNonceAndAuthTag(nonce, ciphertext)
-	macs := es.macForAllGroups(sum)
+	nonce := es.nonce.ForPayloadBox(es.numBlocks)
+	raw := secretbox.Seal([]byte{}, b, (*[24]byte)(nonce), (*[32]byte)(&es.sessionKey))
+
+	tag := raw[0:secretbox.Overhead]
+	ciphertext := raw[secretbox.Overhead:]
+
 	block := EncryptionBlock{
-		Version:    PacketVersion1,
-		Tag:        PacketTagEncryptionBlock,
 		Ciphertext: ciphertext,
-		MACs:       macs,
+	}
+
+	for _, macKey := range es.macKeys {
+		tag, err := macKey.Box(nonce, tag)
+		if err != nil {
+			return err
+		}
+		block.Tags = append(block.Tags, tag)
 	}
 
 	if err := es.encoder.Encode(block); err != nil {
-		return nil
+		return err
 	}
 
 	es.numBlocks++
 	return nil
 }
 
-// Do some sanity checking on the receiver group. Check that receivers
-// aren't sent to twice; check that there aren't any empty receiver
-// groups. In particular, we need r[0][0] to be a valid PublicKey.
-func (es *encryptStream) checkReceivers(r [][]BoxPublicKey) error {
+// Do some sanity checking on the receivers. Check that receivers
+// aren't sent to twice; check that there's at least one receiver.
+func (es *encryptStream) checkReceivers(v []BoxPublicKey) error {
 
-	if len(r) == 0 {
+	if len(v) == 0 {
 		return ErrBadReceivers
 	}
 
@@ -109,27 +106,18 @@ func (es *encryptStream) checkReceivers(r [][]BoxPublicKey) error {
 	// Make sure that each receiver only shows up in the set once.
 	receiversAsSet := make(map[string]struct{})
 
-	for _, g := range r {
-
-		if len(g) == 0 {
-			return ErrBadReceivers
+	for _, receiver := range v {
+		// Make sure this key hasn't been used before
+		kid := receiver.ToKID()
+		kidString := hex.EncodeToString(kid)
+		if _, found := receiversAsSet[kidString]; found {
+			return ErrRepeatedKey(kid)
 		}
-
-		for _, receiver := range g {
-
-			// Make sure this key hasn't been used before
-			kid := receiver.ToKID()
-			kidString := hex.EncodeToString(kid)
-			if _, found := receiversAsSet[kidString]; found {
-				return ErrRepeatedKey(kid)
-			}
-			receiversAsSet[kidString] = struct{}{}
-			tot++
-		}
+		receiversAsSet[kidString] = struct{}{}
+		tot++
 	}
 
-	// Don't allow more than 2^31 receivers. This also means BTW we can
-	// only have at most (2^31-1) receiver groups.
+	// Don't allow more than 2^31 receivers.
 	if tot >= 0x7fffffff {
 		return ErrBadReceivers
 	}
@@ -137,85 +125,74 @@ func (es *encryptStream) checkReceivers(r [][]BoxPublicKey) error {
 	return nil
 }
 
-func (es *encryptStream) init(sender BoxSecretKey, receivers [][]BoxPublicKey) error {
+func (es *encryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey) error {
 
 	if err := es.checkReceivers(receivers); err != nil {
 		return err
 	}
 
-	ephemeralKey, err := receivers[0][0].CreateEphemeralKey()
+	ephemeralKey, err := receivers[0].CreateEphemeralKey()
 	if err != nil {
 		return err
 	}
 
 	// If we have a nil Sender key, then we really want the ephemeral key
 	// as the main encryption key.
+	senderAnon := false
 	if sender == nil {
 		sender = ephemeralKey
+		senderAnon = true
 	}
 
 	eh := &EncryptionHeader{
-		Version:   PacketVersion1,
-		Tag:       PacketTagEncryptionHeader,
-		Sender:    ephemeralKey.GetPublicKey().ToKID(),
-		Receivers: make([]receiverKeysCiphertexts, 0, len(receivers)),
+		FormatName: SaltPackFormatName,
+		Version:    SaltPackCurrentVersion,
+		Type:       PacketTypeEncryption,
+		Sender:     ephemeralKey.GetPublicKey().ToKID(),
+		Receivers:  make([]receiverKeysCiphertexts, 0, len(receivers)),
 	}
 	es.header = eh
 	if err := randomFill(es.sessionKey[:]); err != nil {
 		return err
 	}
 
-	var nonce Nonce
-	keyToNonce(&nonce, ephemeralKey.GetPublicKey())
+	es.nonce = NewNonceForEncryption(ephemeralKey.GetPublicKey())
 
-	var i uint32
+	rkp := receiverKeysPlaintext{
+		Sender:     sender.GetPublicKey().ToKID(),
+		SessionKey: es.sessionKey[:],
+	}
 
-	for gid, group := range receivers {
-		var macKey SymmetricKey
-		if err := randomFill(macKey[:]); err != nil {
+	rkpPacked, err := encodeToBytes(rkp)
+	if err != nil {
+		return err
+	}
+
+	nonce := es.nonce.ForKeyBox()
+
+	for _, receiver := range receivers {
+
+		emphemeralShared := ephemeralKey.Precompute(receiver)
+
+		keys, err := emphemeralShared.Box(nonce, rkpPacked)
+		if err != nil {
 			return err
 		}
-		es.macGroups = append(es.macGroups, macKey)
 
-		for _, receiver := range group {
+		rkc := receiverKeysCiphertexts{Keys: keys}
 
-			// Next encode the ultimate sender key for the receiver,
-			// using the ephemeral key.
-			nonce.writeCounter32(i)
-			i++
-			ske, err := ephemeralKey.Box(receiver, &nonce, sender.GetPublicKey().ToKID())
-			if err != nil {
-				return err
-			}
-
-			pt := receiverKeysPlaintext{
-				GroupID:    (uint32(gid) | groupIDMask),
-				SessionKey: es.sessionKey[:],
-				MACKey:     macKey[:],
-			}
-			pte, err := encodeToBytes(pt)
-			if err != nil {
-				return err
-			}
-			nonce.writeCounter32(i)
-			i++
-			ptec, err := sender.Box(receiver, &nonce, pte)
-			if err != nil {
-				return err
-			}
-
-			rkc := receiverKeysCiphertexts{
-				Keys:   ptec,
-				Sender: ske,
-			}
-
-			// Don't specify the receivers if this public key wants to hide
-			if !receiver.HideIdentity() {
-				rkc.KID = receiver.ToKID()
-			}
-
-			eh.Receivers = append(eh.Receivers, rkc)
+		// Don't specify the receivers if this public key wants to hide
+		if !receiver.HideIdentity() {
+			rkc.ReceiverKID = receiver.ToKID()
 		}
+
+		eh.Receivers = append(eh.Receivers, rkc)
+
+		macKey := emphemeralShared
+		if !senderAnon {
+			macKey = sender.Precompute(receiver)
+		}
+		es.macKeys = append(es.macKeys, macKey)
 	}
 	return nil
 }
@@ -237,15 +214,11 @@ func (es *encryptStream) writeFooter() error {
 // NewEncryptStream creates a stream that consumes plaintext data.
 // It will write out encrypted data to the io.Writer passed in as ciphertext.
 // The encryption is from the specified sender, and is encrypted for the
-// given receivers.  Note that receivers as specified as two-dimensional array.
-// Each inner group of receivers shares the same pairwise MAC-key, so should
-// represent a logic receiver split across multiple devices.  Each group of
-// receivers represents a mutually distrustful set of receivers, and will each
-// get their own pairwise-MAC keys.
+// given receivers.
 //
 // Returns an io.WriteClose that accepts plaintext data to be encrypted; and
 // also returns an error if initialization failed.
-func NewEncryptStream(ciphertext io.Writer, sender BoxSecretKey, receivers [][]BoxPublicKey) (plaintext io.WriteCloser, err error) {
+func NewEncryptStream(ciphertext io.Writer, sender BoxSecretKey, receivers []BoxPublicKey) (plaintext io.WriteCloser, err error) {
 	es := &encryptStream{
 		output:  ciphertext,
 		encoder: newEncoder(ciphertext),
@@ -259,7 +232,7 @@ func NewEncryptStream(ciphertext io.Writer, sender BoxSecretKey, receivers [][]B
 
 // Seal a plaintext from the given sender, for the specified receiver groups.
 // Returns a ciphertext, or an error if something bad happened.
-func Seal(plaintext []byte, sender BoxSecretKey, receivers [][]BoxPublicKey) (out []byte, err error) {
+func Seal(plaintext []byte, sender BoxSecretKey, receivers []BoxPublicKey) (out []byte, err error) {
 	var buf bytes.Buffer
 	es, err := NewEncryptStream(&buf, sender, receivers)
 	if err != nil {

--- a/go/kbcmf/errors.go
+++ b/go/kbcmf/errors.go
@@ -58,12 +58,11 @@ type ErrBadCiphertext PacketSeqno
 // unique.
 type ErrRepeatedKey []byte
 
-// ErrWrongPacketTag is produced if one packet tag was expected, but a packet
+// ErrWrongMessageType is produced if one packet tag was expected, but a packet
 // of another tag was found.
-type ErrWrongPacketType struct {
-	seqno    PacketSeqno
-	wanted   PacketType
-	received PacketType
+type ErrWrongMessageType struct {
+	wanted   MessageType
+	received MessageType
 }
 
 // ErrBadVersion is returned if a packet of an unsupported version is found.
@@ -95,8 +94,8 @@ func (e ErrBadArmorHeader) Error() string {
 		e.wanted, e.received)
 }
 
-func (e ErrWrongPacketType) Error() string {
-	return fmt.Sprintf("In packet %d: wanted type=%d; got type=%d", e.seqno, e.wanted, e.received)
+func (e ErrWrongMessageType) Error() string {
+	return fmt.Sprintf("Wanted type=%d; got type=%d", e.wanted, e.received)
 }
 func (e ErrBadVersion) Error() string {
 	return fmt.Sprintf("In packet %d: unsupported version (%v)", e.seqno, e.received)
@@ -108,5 +107,5 @@ func (e ErrBadTag) Error() string {
 	return fmt.Sprintf("In packet %d: bad Poly1305 tag; data was corrupted in transit", e)
 }
 func (e ErrRepeatedKey) Error() string {
-	return fmt.Sprintf("Repeated recipient key: %x", e)
+	return fmt.Sprintf("Repeated recipient key: %x", []byte(e))
 }

--- a/go/kbcmf/key.go
+++ b/go/kbcmf/key.go
@@ -34,13 +34,10 @@ type BoxPublicKey interface {
 	HideIdentity() bool
 }
 
-// Nonce is a NaCl-style nonce, with 24 bytes of data, some of which can be
-// counter values, and some of which can be truly random values.
-type Nonce [24]byte
-
 // BoxPrecomputedSharedKey results from a Precomputation below.
 type BoxPrecomputedSharedKey interface {
 	Unbox(nonce *Nonce, msg []byte) ([]byte, error)
+	Box(nonce *Nonce, msg []byte) ([]byte, error)
 }
 
 // BoxSecretKey is the secret key corresponding to a BoxPublicKey

--- a/go/kbcmf/key.go
+++ b/go/kbcmf/key.go
@@ -10,7 +10,7 @@ import ()
 type RawBoxKey [32]byte
 
 // SymmetricKey is a template for a symmetric key, a 32-byte static
-// buffer.  Used for both NaCl SecretBox and also HMAC keys.
+// buffer.  Used for both NaCl SecretBox.
 type SymmetricKey [32]byte
 
 // BoxPublicKey is an generic interface to NaCl's public key Box function.

--- a/go/kbcmf/nonce.go
+++ b/go/kbcmf/nonce.go
@@ -7,16 +7,21 @@ import (
 )
 
 // Nonce is a NaCl-style nonce, with 24 bytes of data, some of which can be
-// counter values, and some of which can be truly random values.
+// counter values, and some of which can be random-ish values.
 type Nonce [24]byte
 
+// NonceType is different for the different type of usages of the nonce.
 type NonceType int
 
 const (
-	NonceTypeEncryptionKeyBox     NonceType = 0
+	// NonceTypeEncryptionKeyBox is used for the header of an encrypted message
+	NonceTypeEncryptionKeyBox NonceType = 0
+
+	// NonceTypeEncryptionPayloadBox is used for the payload of an encrypted message
 	NonceTypeEncryptionPayloadBox NonceType = 1
 )
 
+// ForPayloadBox formats this nonce for the ith block of payload.
 func (n *Nonce) ForPayloadBox(i encryptionBlockNumber) *Nonce {
 	n.mutate(uint64(NonceTypeEncryptionPayloadBox) + uint64(i))
 	return n
@@ -26,6 +31,7 @@ func (n *Nonce) mutate(i uint64) {
 	binary.BigEndian.PutUint64((*n)[16:], i)
 }
 
+// ForKeyBox formats the nonce for use the KeyBox in a message header.
 func (n *Nonce) ForKeyBox() *Nonce {
 	n.mutate(uint64(NonceTypeEncryptionKeyBox))
 	return n
@@ -36,8 +42,15 @@ func writeStringToHash(h hash.Hash, s string) {
 	h.Write([]byte{0})
 }
 
-func NewNonceForEncryption(pk BoxPublicKey) *Nonce {
-	raw := *pk.ToRawBoxKeyPointer()
+// NewNonceForEncryption creates a new nonce for the purposes of an encrypted
+// message. It is a deterministic function of the ephemeral public key used
+// for this encrypted message.
+//
+// **DO NOT** pass a long-live public key here, as you might lose the guarantee
+// that each (nonce,key) pair must be unique over the lifetime of the universe.
+//
+func NewNonceForEncryption(ephemeralPublicKey BoxPublicKey) *Nonce {
+	raw := *ephemeralPublicKey.ToRawBoxKeyPointer()
 	hasher := sha512.New()
 	writeStringToHash(hasher, SaltPackFormatName)
 	writeStringToHash(hasher, NoncePrefixEncryption)

--- a/go/kbcmf/nonce.go
+++ b/go/kbcmf/nonce.go
@@ -1,0 +1,49 @@
+package kbcmf
+
+import (
+	"crypto/sha512"
+	"encoding/binary"
+	"hash"
+)
+
+// Nonce is a NaCl-style nonce, with 24 bytes of data, some of which can be
+// counter values, and some of which can be truly random values.
+type Nonce [24]byte
+
+type NonceType int
+
+const (
+	NonceTypeEncryptionKeyBox     NonceType = 0
+	NonceTypeEncryptionPayloadBox NonceType = 1
+)
+
+func (n *Nonce) ForPayloadBox(i encryptionBlockNumber) *Nonce {
+	n.mutate(uint64(NonceTypeEncryptionPayloadBox) + uint64(i))
+	return n
+}
+
+func (n *Nonce) mutate(i uint64) {
+	binary.BigEndian.PutUint64((*n)[16:], i)
+}
+
+func (n *Nonce) ForKeyBox() *Nonce {
+	n.mutate(uint64(NonceTypeEncryptionKeyBox))
+	return n
+}
+
+func writeStringToHash(h hash.Hash, s string) {
+	h.Write([]byte(s))
+	h.Write([]byte{0})
+}
+
+func NewNonceForEncryption(pk BoxPublicKey) *Nonce {
+	raw := *pk.ToRawBoxKeyPointer()
+	hasher := sha512.New()
+	writeStringToHash(hasher, SaltPackFormatName)
+	writeStringToHash(hasher, NoncePrefixEncryption)
+	hasher.Write(raw[:])
+	res := hasher.Sum(nil)
+	var out Nonce
+	copy(out[0:16], res)
+	return &out
+}

--- a/go/kbcmf/packets.go
+++ b/go/kbcmf/packets.go
@@ -31,19 +31,19 @@ type EncryptionHeader struct {
 	_struct    bool                      `codec:",toarray"`
 	FormatName string                    `codec:"format_name"`
 	Version    Version                   `codec:"vers"`
-	Type       PacketType                `codec:"type"`
+	Type       MessageType               `codec:"type"`
 	Sender     []byte                    `codec:"sender"`
 	Receivers  []receiverKeysCiphertexts `codec:"rcvrs"`
 	seqno      PacketSeqno
 }
 
 // EncryptionBlock contains a block of encrypted data. It cointains
-// the ciphertext, and any necessary MACs.
+// the ciphertext, and any necessary authentication Tags.
 type EncryptionBlock struct {
-	_struct    bool     `codec:",toarray"`
-	Tags       [][]byte `codec:"tags"`
-	Ciphertext []byte   `codec:"ctext"`
-	seqno      PacketSeqno
+	_struct           bool     `codec:",toarray"`
+	TagCiphertexts    [][]byte `codec:"tags"`
+	PayloadCiphertext []byte   `codec:"ctext"`
+	seqno             PacketSeqno
 }
 
 func verifyRawKey(k []byte) error {
@@ -54,8 +54,8 @@ func verifyRawKey(k []byte) error {
 }
 
 func (h *EncryptionHeader) validate() error {
-	if h.Type != PacketTypeEncryption {
-		return ErrWrongPacketType{h.seqno, PacketTypeEncryption, h.Type}
+	if h.Type != MessageTypeEncryption {
+		return ErrWrongMessageType{MessageTypeEncryption, h.Type}
 	}
 	if h.Version.Major != SaltPackCurrentVersion.Major {
 		return ErrBadVersion{h.seqno, h.Version}

--- a/go/kbcmf/tweakable_encryptor_test.go
+++ b/go/kbcmf/tweakable_encryptor_test.go
@@ -5,7 +5,6 @@ package kbcmf
 
 import (
 	"bytes"
-	"encoding/hex"
 	"golang.org/x/crypto/nacl/secretbox"
 	"io"
 )
@@ -14,14 +13,12 @@ type testEncryptionOptions struct {
 	blockSize                          int
 	skipFooter                         bool
 	corruptEncryptionBlock             func(bl *EncryptionBlock, ebn encryptionBlockNumber)
-	corruptNonce                       func(n *Nonce, ebn encryptionBlockNumber)
-	corruptMacKey                      func(k *SymmetricKey, i int)
-	corruptReceiverKeysPlaintext       func(rk *receiverKeysPlaintext, gid int, rid int)
-	corruptReceiverKeysPlaintextPacked func(b []byte, gid int, rid int)
-	corruptReceiverKeysCiphertext      func(rk *receiverKeysCiphertexts, gid int, rid int)
-	corruptHeaderNonce                 func(n *Nonce, gid int, rid int, slot int)
+	corruptPayloadNonce                func(n *Nonce, ebn encryptionBlockNumber) *Nonce
+	corruptKeysNonce                   func(n *Nonce, rid int) *Nonce
+	corruptReceiverKeysPlaintext       func(rk *receiverKeysPlaintext, rid int)
+	corruptReceiverKeysPlaintextPacked func(b []byte, rid int)
+	corruptReceiverKeysCiphertext      func(rk *receiverKeysCiphertexts, rid int)
 	corruptHeader                      func(eh *EncryptionHeader)
-	corruptHeaderSenderKey             func(sk []byte, git int, rid int) []byte
 	corruptHeaderPacked                func(b []byte)
 }
 
@@ -39,8 +36,9 @@ type testEncryptStream struct {
 	sessionKey SymmetricKey
 	buffer     bytes.Buffer
 	inblock    []byte
-	macGroups  []SymmetricKey
 	options    testEncryptionOptions
+	macKeys    []BoxPrecomputedSharedKey
+	nonce      *Nonce
 
 	numBlocks encryptionBlockNumber // the lower 64 bits of the nonce
 
@@ -80,15 +78,6 @@ func (pes *testEncryptStream) Write(plaintext []byte) (int, error) {
 	return ret, nil
 }
 
-func (pes *testEncryptStream) macForAllGroups(b []byte) [][]byte {
-	var macs [][]byte
-	for _, key := range pes.macGroups {
-		mac := hmacSHA512(key[:], b)
-		macs = append(macs, mac)
-	}
-	return macs
-}
-
 func (pes *testEncryptStream) encryptBlock() error {
 	var n int
 	var err error
@@ -105,21 +94,27 @@ func (pes *testEncryptStream) encryptBytes(b []byte) error {
 		return err
 	}
 
-	nonce := pes.numBlocks.newCounterNonce()
+	nonce := pes.nonce.ForPayloadBox(pes.numBlocks)
 
-	if pes.options.corruptNonce != nil {
-		pes.options.corruptNonce(nonce, pes.numBlocks)
+	if pes.options.corruptPayloadNonce != nil {
+		nonce = pes.options.corruptPayloadNonce(nonce, pes.numBlocks)
 	}
 
-	ciphertext := secretbox.Seal([]byte{}, b, (*[24]byte)(nonce), (*[32]byte)(&pes.sessionKey))
-	// Compute the MAC over the nonce and the ciphertext
-	sum := hashNonceAndAuthTag(nonce, ciphertext)
-	macs := pes.macForAllGroups(sum)
+	raw := secretbox.Seal([]byte{}, b, (*[24]byte)(nonce), (*[32]byte)(&pes.sessionKey))
+
+	tag := raw[0:secretbox.Overhead]
+	ciphertext := raw[secretbox.Overhead:]
+
 	block := EncryptionBlock{
-		Version:    PacketVersion1,
-		Tag:        PacketTagEncryptionBlock,
 		Ciphertext: ciphertext,
-		MACs:       macs,
+	}
+
+	for _, macKey := range pes.macKeys {
+		tag, err := macKey.Box(nonce, tag)
+		if err != nil {
+			return err
+		}
+		block.Tags = append(block.Tags, tag)
 	}
 
 	if pes.options.corruptEncryptionBlock != nil {
@@ -127,122 +122,97 @@ func (pes *testEncryptStream) encryptBytes(b []byte) error {
 	}
 
 	if err := pes.encoder.Encode(block); err != nil {
-		return nil
+		return err
 	}
 
 	pes.numBlocks++
 	return nil
 }
 
-func (pes *testEncryptStream) init(sender BoxSecretKey, receivers [][]BoxPublicKey) error {
+func (pes *testEncryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey) error {
 
-	ephemeralKey, err := receivers[0][0].CreateEphemeralKey()
+	ephemeralKey, err := receivers[0].CreateEphemeralKey()
 	if err != nil {
 		return err
 	}
 
 	// If we have a NULL Sender key, then we really want an ephemeral key
 	// as the main encryption key.
+	senderAnon := false
 	if sender == nil {
 		sender = ephemeralKey
+		senderAnon = true
 	}
 
 	eh := &EncryptionHeader{
-		Version:   PacketVersion1,
-		Tag:       PacketTagEncryptionHeader,
-		Sender:    ephemeralKey.GetPublicKey().ToKID(),
-		Receivers: make([]receiverKeysCiphertexts, 0, len(receivers)),
+		FormatName: SaltPackFormatName,
+		Version:    SaltPackCurrentVersion,
+		Type:       PacketTypeEncryption,
+		Sender:     ephemeralKey.GetPublicKey().ToKID(),
+		Receivers:  make([]receiverKeysCiphertexts, 0, len(receivers)),
 	}
 	pes.header = eh
 	if err := randomFill(pes.sessionKey[:]); err != nil {
 		return err
 	}
 
-	var nonce Nonce
-	keyToNonce(&nonce, ephemeralKey.GetPublicKey())
+	pes.nonce = NewNonceForEncryption(ephemeralKey.GetPublicKey())
+	nonce := pes.nonce.ForKeyBox()
 
-	d := make(map[string]struct{})
+	for rid, receiver := range receivers {
 
-	var i uint32
+		rkp := receiverKeysPlaintext{
+			Sender:     sender.GetPublicKey().ToKID(),
+			SessionKey: pes.sessionKey[:],
+		}
 
-	for gid, group := range receivers {
-		var macKey SymmetricKey
-		if err := randomFill(macKey[:]); err != nil {
+		if pes.options.corruptReceiverKeysPlaintext != nil {
+			pes.options.corruptReceiverKeysPlaintext(&rkp, rid)
+		}
+
+		rkpPacked, err := encodeToBytes(rkp)
+		if err != nil {
 			return err
 		}
-		pes.macGroups = append(pes.macGroups, macKey)
-
-		if pes.options.corruptMacKey != nil {
-			pes.options.corruptMacKey(&macKey, gid)
+		if pes.options.corruptReceiverKeysPlaintextPacked != nil {
+			pes.options.corruptReceiverKeysPlaintextPacked(rkpPacked, rid)
 		}
 
-		for rid, receiver := range group {
-			kid := receiver.ToKID()
-			kidString := hex.EncodeToString(kid)
-			if _, found := d[kidString]; found {
-				return ErrRepeatedKey(kid)
-			}
-			d[kidString] = struct{}{}
-
-			pt := receiverKeysPlaintext{
-				GroupID:    (uint32(gid) | groupIDMask),
-				SessionKey: pes.sessionKey[:],
-				MACKey:     macKey[:],
-			}
-
-			if pes.options.corruptReceiverKeysPlaintext != nil {
-				pes.options.corruptReceiverKeysPlaintext(&pt, gid, rid)
-			}
-
-			pte, err := encodeToBytes(pt)
-			if pes.options.corruptReceiverKeysPlaintextPacked != nil {
-				pes.options.corruptReceiverKeysPlaintextPacked(pte, gid, rid)
-			}
-			if err != nil {
-				return err
-			}
-			nonce.writeCounter32(i)
-			i++
-
-			if pes.options.corruptHeaderNonce != nil {
-				pes.options.corruptHeaderNonce(&nonce, gid, rid, 0)
-			}
-
-			skp := sender.GetPublicKey().ToKID()
-			if pes.options.corruptHeaderSenderKey != nil {
-				skp = pes.options.corruptHeaderSenderKey(skp, gid, rid)
-			}
-
-			ske, err := ephemeralKey.Box(receiver, &nonce, skp)
-			if err != nil {
-				return err
-			}
-
-			if pes.options.corruptHeaderNonce != nil {
-				pes.options.corruptHeaderNonce(&nonce, gid, rid, 1)
-			}
-
-			nonce.writeCounter32(i)
-			i++
-
-			ptec, err := sender.Box(receiver, &nonce, pte)
-			if err != nil {
-				return err
-			}
-
-			rkc := receiverKeysCiphertexts{
-				KID:    kid,
-				Keys:   ptec,
-				Sender: ske,
-			}
-
-			if pes.options.corruptReceiverKeysCiphertext != nil {
-				pes.options.corruptReceiverKeysCiphertext(&rkc, gid, rid)
-			}
-
-			eh.Receivers = append(eh.Receivers, rkc)
+		if err != nil {
+			return err
 		}
+
+		nonceTmp := nonce
+		if pes.options.corruptKeysNonce != nil {
+			nonceTmp = pes.options.corruptKeysNonce(nonceTmp, rid)
+		}
+
+		keys, err := ephemeralKey.Box(receiver, nonceTmp, rkpPacked)
+		if err != nil {
+			return err
+		}
+
+		rkc := receiverKeysCiphertexts{
+			ReceiverKID: receiver.ToKID(),
+			Keys:        keys,
+		}
+
+		if pes.options.corruptReceiverKeysCiphertext != nil {
+			pes.options.corruptReceiverKeysCiphertext(&rkc, rid)
+		}
+
+		eh.Receivers = append(eh.Receivers, rkc)
+
+		var macKey BoxPrecomputedSharedKey
+		if !senderAnon {
+			macKey = sender.Precompute(receiver)
+		} else {
+			macKey = ephemeralKey.Precompute(receiver)
+		}
+
+		pes.macKeys = append(pes.macKeys, macKey)
 	}
+
 	if pes.options.corruptHeader != nil {
 		pes.options.corruptHeader(eh)
 	}
@@ -269,7 +239,7 @@ func (pes *testEncryptStream) writeFooter() error {
 
 // Options are available mainly for testing.  Can't think of a good reason for
 // end-users to have to specify options.
-func newTestEncryptStream(ciphertext io.Writer, sender BoxSecretKey, receivers [][]BoxPublicKey, options testEncryptionOptions) (plaintext io.WriteCloser, err error) {
+func newTestEncryptStream(ciphertext io.Writer, sender BoxSecretKey, receivers []BoxPublicKey, options testEncryptionOptions) (plaintext io.WriteCloser, err error) {
 	pes := &testEncryptStream{
 		output:  ciphertext,
 		encoder: newEncoder(ciphertext),
@@ -282,7 +252,7 @@ func newTestEncryptStream(ciphertext io.Writer, sender BoxSecretKey, receivers [
 	return pes, nil
 }
 
-func testSeal(plaintext []byte, sender BoxSecretKey, receivers [][]BoxPublicKey, options testEncryptionOptions) (out []byte, err error) {
+func testSeal(plaintext []byte, sender BoxSecretKey, receivers []BoxPublicKey, options testEncryptionOptions) (out []byte, err error) {
 	var buf bytes.Buffer
 	es, err := newTestEncryptStream(&buf, sender, receivers, options)
 	if err != nil {

--- a/go/libkb/kbcmf.go
+++ b/go/libkb/kbcmf.go
@@ -51,6 +51,11 @@ func (k naclBoxPrecomputedSharedKey) Unbox(nonce *kbcmf.Nonce, msg []byte) (
 	return ret, nil
 }
 
+func (k naclBoxPrecomputedSharedKey) Box(nonce *kbcmf.Nonce, msg []byte) ([]byte, error) {
+	ret := box.SealAfterPrecomputation([]byte{}, msg, (*[24]byte)(nonce), (*[32]byte)(&k))
+	return ret, nil
+}
+
 type naclBoxSecretKey NaclDHKeyPair
 
 var _ kbcmf.BoxSecretKey = naclBoxSecretKey{}

--- a/go/libkb/kbcmf_enc.go
+++ b/go/libkb/kbcmf_enc.go
@@ -13,14 +13,10 @@ import (
 // receivers from the given sender, armors it, and writes it to sink.
 func KBCMFEncrypt(
 	source io.Reader, sink io.WriteCloser,
-	receivers [][]NaclDHKeyPublic, sender NaclDHKeyPair) error {
-	var receiverBoxKeys [][]kbcmf.BoxPublicKey
-	for _, receiverPublicKeys := range receivers {
-		var t []kbcmf.BoxPublicKey
-		for _, k := range receiverPublicKeys {
-			t = append(t, naclBoxPublicKey(k))
-		}
-		receiverBoxKeys = append(receiverBoxKeys, t)
+	receivers []NaclDHKeyPublic, sender NaclDHKeyPair) error {
+	var receiverBoxKeys []kbcmf.BoxPublicKey
+	for _, k := range receivers {
+		receiverBoxKeys = append(receiverBoxKeys, naclBoxPublicKey(k))
 	}
 	plainsink, err := kbcmf.NewEncryptArmor62Stream(
 		sink, naclBoxSecretKey(sender), receiverBoxKeys)

--- a/go/libkb/kbcmf_test.go
+++ b/go/libkb/kbcmf_test.go
@@ -27,21 +27,15 @@ func TestKbcmfEncDec(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var receiverKPs [][]NaclDHKeyPair
-	var receiverPKs [][]NaclDHKeyPublic
-	for i := 0; i < 4; i++ {
-		var tKP []NaclDHKeyPair
-		var tPK []NaclDHKeyPublic
-		for j := 0; j < 3; j++ {
-			kp, err := GenerateNaclDHKeyPair()
-			if err != nil {
-				t.Fatal(err)
-			}
-			tKP = append(tKP, kp)
-			tPK = append(tPK, kp.Public)
+	var receiverKPs []NaclDHKeyPair
+	var receiverPKs []NaclDHKeyPublic
+	for i := 0; i < 12; i++ {
+		kp, err := GenerateNaclDHKeyPair()
+		if err != nil {
+			t.Fatal(err)
 		}
-		receiverKPs = append(receiverKPs, tKP)
-		receiverPKs = append(receiverPKs, tPK)
+		receiverKPs = append(receiverKPs, kp)
+		receiverPKs = append(receiverPKs, kp.Public)
 	}
 
 	nonReceiverKP, err := GenerateNaclDHKeyPair()
@@ -68,22 +62,19 @@ func TestKbcmfEncDec(t *testing.T) {
 		t.Errorf("ciphertext doesn't have footer: %s", ciphertext)
 	}
 
-	for i := 0; i < len(receiverKPs); i++ {
-		for j := 0; j < len(receiverKPs[i]); j++ {
-			buf.Reset()
-			err = KBCMFDecrypt(
-				strings.NewReader(ciphertext),
-				&buf, receiverKPs[i][j])
-			if err != nil {
-				t.Fatal(err)
-			}
+	for _, key := range receiverKPs {
+		buf.Reset()
+		err = KBCMFDecrypt(
+			strings.NewReader(ciphertext),
+			&buf, key)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-			plaintext := buf.String()
-			if plaintext != message {
-				t.Errorf("expected %s, got %s",
-					message, plaintext)
-			}
-
+		plaintext := buf.String()
+		if plaintext != message {
+			t.Errorf("expected %s, got %s",
+				message, plaintext)
 		}
 	}
 

--- a/go/service/track.go
+++ b/go/service/track.go
@@ -70,7 +70,7 @@ func (h *TrackHandler) Untrack(_ context.Context, arg keybase1.UntrackArg) error
 }
 
 func (h *TrackHandler) CheckTracking(_ context.Context, sessionID int) error {
-	if !h.G().RateLimits.GetPermission(libkb.CheckTrackingRateLimit, libkb.TrackingRateLimitSeconds * time.Second) {
+	if !h.G().RateLimits.GetPermission(libkb.CheckTrackingRateLimit, libkb.TrackingRateLimitSeconds*time.Second) {
 		h.G().Log.Debug("Skipping CheckTracking due to rate limit.")
 		return nil
 	}


### PR DESCRIPTION
- no more MAC groups
- clever box(tag) per recipient trick
- all tests now work with > 95% coverage in decrypt
- version pairs/prefix strings
- strip down payload packets
- use @oconnor663's nonce scheme