### PR TITLE
Handle the case where there are warnings and we aren't already following

### DIFF
--- a/react-native/react/reducers/tracker.js
+++ b/react-native/react/reducers/tracker.js
@@ -71,7 +71,7 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
       if (action.payload == null) {
         return state
       }
-      const shouldFollow: boolean = action.payload.shouldFollow
+      let shouldFollow: boolean = action.payload.shouldFollow
 
       return {
         ...state,
@@ -115,8 +115,11 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
 
       let proofState: SimpleProofState = error
 
+      shouldFollow = false
+
       if (allOk) {
         proofState = normal
+        shouldFollow = true
       } else if (anyWarnings) {
         proofState = warning
       } else if (anyError) {
@@ -127,6 +130,7 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
 
       return {
         ...state,
+        shouldFollow,
         proofState
       }
 

--- a/react-native/react/tracker/action.render.desktop.js
+++ b/react-native/react/tracker/action.render.desktop.js
@@ -20,14 +20,35 @@ export default class ActionRender extends Component {
       return this.renderPending()
     } else if (this.props.state === normal) {
       return this.renderNormal(username)
-    } else {
+    } else if (this.props.currentlyFollowing) {
       return this.renderChanged()
+    } else {
+      return this.renderWarningNotFollowed()
     }
   }
 
   renderPending (): ReactElement {
     return (
       <div><p> Loading... </p></div>
+    )
+  }
+
+  renderWarningNotFollowed (): ReactElement {
+    const title = this.props.failedProofsNotFollowingText
+
+    return (
+      <div style={{...styles.normalContainer, ...this.props.style}}>
+        <i style={this.props.state === warning ? styles.flagWarning : styles.flagError} className='fa fa-flag'></i>
+        <div style={styles.textContainer}>
+          <span style={styles.changedMessage}>{title}</span>
+        </div>
+        <div style={styles.checkContainer} onClick={() => this.props.onFollowChecked(!this.props.shouldFollow)}>
+          <i style={styles.check} className={`fa ${this.props.shouldFollow ? 'fa-check-square-o' : 'fa-square-o'}`}></i>
+          <span style={styles.track}>Track</span>
+          <i style={styles.eye} className='fa fa-eye'></i>
+        </div>
+        <FlatButton style={commonStyles.primaryButton} label='Close' primary onClick={() => this.props.onClose()} />
+      </div>
     )
   }
 
@@ -72,6 +93,7 @@ ActionRender.propTypes = {
   onUnfollow: React.PropTypes.func.isRequired,
   onFollowChecked: React.PropTypes.func.isRequired,
   renderChangedTitle: React.PropTypes.string.isRequired,
+  failedProofsNotFollowingText: React.PropTypes.string.isRequired,
   style: React.PropTypes.object.isRequired
 }
 

--- a/react-native/react/tracker/action.render.types.js
+++ b/react-native/react/tracker/action.render.types.js
@@ -4,9 +4,11 @@ import type {SimpleProofState} from '../constants/tracker'
 
 export type ActionProps = {
   state: SimpleProofState,
+  currentlyFollowing: boolean,
   username: ?string,
   shouldFollow: ?boolean,
   renderChangedTitle: string,
+  failedProofsNotFollowingText: string,
   onClose: () => void,
   onRefollow: () => void,
   onUnfollow: () => void,

--- a/react-native/react/tracker/index.js
+++ b/react-native/react/tracker/index.js
@@ -9,14 +9,14 @@ import * as trackerActions from '../actions/tracker'
 import {bindActionCreators} from 'redux'
 import {warning} from '../constants/tracker'
 
-// TODO move these into render.type.js
 import type {RenderProps} from './render.types'
 import type {UserInfo} from './bio.render.types'
 import type {Proof} from './proofs.render.types'
 import type {SimpleProofState} from '../constants/tracker'
 
+import type {TrackSummary} from '../constants/types/flow-types'
+
 type TrackerProps = {
-  serverStarted: boolean,
   proofState: SimpleProofState,
   username: ?string,
   shouldFollow: ?boolean,
@@ -32,6 +32,7 @@ type TrackerProps = {
   registerIdentifyUi: () => void,
   registerTrackerChangeListener: () => void,
   closed: boolean,
+  lastTrack: ?TrackSummary,
   startTimer: () => void,
   stopTimer: () => void
 }
@@ -55,6 +56,8 @@ class Tracker extends Component {
     const renderChangedTitle = this.props.proofState === warning ? `${this.props.username} added some identity proofs.`
       : `Some of ${this.props.username}'s proofs are compromised or have changed.`
 
+    const failedProofsNotFollowingText = `Some of ${this.props.username}'s proofs couldn't be verified. Track the working proofs?`
+
     const renderProps: RenderProps = {
       bioProps: {
         username: this.props.username,
@@ -68,12 +71,14 @@ class Tracker extends Component {
         state: this.props.proofState,
         username: this.props.username,
         renderChangedTitle,
+        failedProofsNotFollowingText,
         shouldFollow: this.props.shouldFollow,
         onClose: () => this.props.onCloseFromActionBar(this.props.username),
         onRefollow: () => this.props.onRefollow(this.props.username),
         onUnfollow: () => this.props.onUnfollow(this.props.username),
         onFollowHelp: () => this.props.onFollowHelp(this.props.username),
-        onFollowChecked: checked => this.props.onFollowChecked(checked, this.props.username)
+        onFollowChecked: checked => this.props.onFollowChecked(checked, this.props.username),
+        currentlyFollowing: !!this.props.lastTrack
       },
       proofsProps: {
         username: this.props.username,
@@ -128,7 +133,6 @@ const mockData = {
 }
 
 Tracker.propTypes = {
-  serverStarted: React.PropTypes.any,
   proofState: React.PropTypes.any,
   username: React.PropTypes.any,
   shouldFollow: React.PropTypes.any,
@@ -144,6 +148,7 @@ Tracker.propTypes = {
   registerIdentifyUi: React.PropTypes.any,
   registerTrackerChangeListener: React.PropTypes.any,
   closed: React.PropTypes.bool.isRequired,
+  lastTrack: React.PropTypes.any,
   startTimer: React.PropTypes.any,
   stopTimer: React.PropTypes.any
 }


### PR DESCRIPTION
If you weren't following someone and their id had warnings you were given the option to untrack or retrack. Neither make sense if you aren't already following someone.

This changes the action bar to look like:
![screen shot 2015-12-17 at 4 31 51 pm](https://cloud.githubusercontent.com/assets/594035/11886141/d9dc8bc4-a4db-11e5-8388-489c8e9521c2.png)


and the auto track is unchecked since not everything looked good.

@keybase/react-hackers 

(From https://github.com/keybase/client/pull/1472, made a new PR that targets master)