### PR TITLE
Put SetLogLevel outside once

### DIFF
--- a/go/logger/log_test.go
+++ b/go/logger/log_test.go
@@ -1,0 +1,41 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package logger
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	logging "github.com/keybase/go-logging"
+)
+
+func TestInitLogging(t *testing.T) {
+	var l1, l2 *Standard
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// New must be race-free.
+	go func() {
+		defer wg.Done()
+		l1 = New("l1", os.Stderr)
+	}()
+	go func() {
+		defer wg.Done()
+		l2 = New("l2", os.Stderr)
+	}()
+
+	wg.Wait()
+
+	// New must also initialize the level correctly.
+	l1Level := logging.GetLevel("l1")
+	if l1Level != logging.INFO {
+		t.Errorf("l1 level=%s is unexpectedly not INFO", l1Level)
+	}
+	l2Level := logging.GetLevel("l2")
+	if l2Level != logging.INFO {
+		t.Errorf("l2 level=%s is unexpectedly not INFO", l2Level)
+	}
+}

--- a/go/logger/log_test.go
+++ b/go/logger/log_test.go
@@ -11,6 +11,7 @@ import (
 	logging "github.com/keybase/go-logging"
 )
 
+// This test must pass with -race.
 func TestInitLogging(t *testing.T) {
 	var l1, l2 *Standard
 

--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -103,8 +103,8 @@ func (log *Standard) initLogging(iow io.Writer) {
 	initLoggingBackendOnce.Do(func() {
 		logBackend := logging.NewLogBackend(iow, "", 0)
 		logging.SetBackend(logBackend)
-		logging.SetLevel(logging.INFO, log.module)
 	})
+	logging.SetLevel(logging.INFO, log.module)
 }
 
 func (log *Standard) prepareString(


### PR DESCRIPTION
If it's inside, then calls to initLogging from
everything but the first module won't set the
log level correctly.

Do this in a race-free way, and add a test for that.

This will fix KBFS-572.