### PR TITLE
git-hooks: don't go-fmt top-level vendor directories either

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -24,7 +24,7 @@
 # merged.
 
 check_go_fmt() {
-	gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '.go$' | grep -v go/vendor/)
+	gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '.go$' | grep -v go/vendor/ | grep -v vendor/)
 	[ -z "$gofiles" ] && return 0
 
 	unformatted=$(gofmt -l $gofiles)


### PR DESCRIPTION
We need this in order to vendor any other projects that use this git-hook, which have their go code in the top-level directory.

r @patrickxb @maxtaco?