### PR TITLE
saltpack: collect MessageKeyInfo on decryption

### DIFF
--- a/go/libkb/saltpack_dec.go
+++ b/go/libkb/saltpack_dec.go
@@ -12,7 +12,7 @@ import (
 func SaltPackDecrypt(
 	source io.Reader, sink io.WriteCloser,
 	deviceEncryptionKey NaclDHKeyPair) error {
-	plainsource, frame, err := saltpack.NewDearmor62DecryptStream(
+	_, plainsource, frame, err := saltpack.NewDearmor62DecryptStream(
 		source, naclKeyring(deviceEncryptionKey))
 	if err != nil {
 		return err

--- a/go/saltpack/armor62_decrypt.go
+++ b/go/saltpack/armor62_decrypt.go
@@ -12,35 +12,35 @@ import (
 // NewDearmor62DecryptStream makes a new stream that dearmors and decrypts the given
 // Reader stream. Pass it a keyring so that it can lookup private and public keys
 // as necessary
-func NewDearmor62DecryptStream(ciphertext io.Reader, kr Keyring) (plaintext io.Reader, frame Frame, err error) {
+func NewDearmor62DecryptStream(ciphertext io.Reader, kr Keyring) (*MessageKeyInfo, io.Reader, Frame, error) {
 	dearmored, frame, err := NewArmor62DecoderStream(ciphertext)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	r, err := NewDecryptStream(dearmored, kr)
+	mki, r, err := NewDecryptStream(dearmored, kr)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return r, frame, nil
+	return mki, r, frame, nil
 }
 
 // Dearmor62DecryptOpen takes an armor62'ed, encrypted ciphertext and attempts to
 // dearmor and decrypt it, using the provided keyring. Checks that the frames in the
 // armor are as expected.
-func Dearmor62DecryptOpen(ciphertext string, kr Keyring) (plaintext []byte, err error) {
+func Dearmor62DecryptOpen(ciphertext string, kr Keyring) (*MessageKeyInfo, []byte, error) {
 	buf := bytes.NewBufferString(ciphertext)
-	s, frame, err := NewDearmor62DecryptStream(buf, kr)
+	mki, s, frame, err := NewDearmor62DecryptStream(buf, kr)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	out, err := ioutil.ReadAll(s)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err = CheckArmor62Frame(frame); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return out, nil
+	return mki, out, nil
 }
 
 // CheckArmor62Frame checks that the frame matches our standard

--- a/go/saltpack/armor62_encrypt_test.go
+++ b/go/saltpack/armor62_encrypt_test.go
@@ -29,7 +29,7 @@ func encryptArmor62RandomData(t *testing.T, sz int) ([]byte, string) {
 
 func TestEncryptArmor62(t *testing.T) {
 	plaintext, ciphertext := encryptArmor62RandomData(t, 1024)
-	plaintext2, err := Dearmor62DecryptOpen(ciphertext, kr)
+	_, plaintext2, err := Dearmor62DecryptOpen(ciphertext, kr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestDearmor62DecryptSlowReader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dec, frame, err := NewDearmor62DecryptStream(&slowReader{[]byte(ciphertext)}, kr)
+	_, dec, frame, err := NewDearmor62DecryptStream(&slowReader{[]byte(ciphertext)}, kr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestDearmor62DecryptSlowReader(t *testing.T) {
 func TestBadArmor62(t *testing.T) {
 	_, ciphertext := encryptArmor62RandomData(t, 24)
 	bad1 := ciphertext[0:2] + "䁕" + ciphertext[2:]
-	if _, err := Dearmor62DecryptOpen(bad1, kr); err != ErrBadArmorFrame {
+	if _, _, err := Dearmor62DecryptOpen(bad1, kr); err != ErrBadArmorFrame {
 		t.Fatalf("Wanted error %v but got %v", ErrBadArmorFrame, err)
 	}
 	if _, _, _, err := Armor62Open(bad1); err != ErrBadArmorFrame {
@@ -81,20 +81,20 @@ func TestBadArmor62(t *testing.T) {
 	}
 
 	bad2 := ciphertext[0:1] + "z" + ciphertext[2:]
-	_, err := Dearmor62DecryptOpen(bad2, kr)
+	_, _, err := Dearmor62DecryptOpen(bad2, kr)
 	if _, ok := err.(ErrBadArmorHeader); !ok {
 		t.Fatalf("Wanted of type ErrBadArmorHeader; got %v", err)
 	}
 
 	l := len(ciphertext)
 	bad3 := ciphertext[0:(l-8)] + "z" + ciphertext[(l-7):]
-	_, err = Dearmor62DecryptOpen(bad3, kr)
+	_, _, err = Dearmor62DecryptOpen(bad3, kr)
 	if _, ok := err.(ErrBadArmorFooter); !ok {
 		t.Fatalf("Wanted of type ErrBadArmorFooter; got %v", err)
 	}
 
 	bad4 := ciphertext + "䁕"
-	_, err = Dearmor62DecryptOpen(bad4, kr)
+	_, _, err = Dearmor62DecryptOpen(bad4, kr)
 	if err != ErrTrailingGarbage {
 		t.Fatalf("Wanted error %v but got %v", ErrTrailingGarbage, err)
 	}

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -34,10 +34,14 @@ type decryptStream struct {
 
 // MessageKeyInfo conveys all of the data about the keys used in this encrypted message.
 type MessageKeyInfo struct {
-	SenderKey        BoxPublicKey
-	SenderIsAnon     bool
-	ReceiverKey      BoxSecretKey
-	ReceiverIsAnon   bool
+	// These fields are cryptographically verified
+	SenderKey      BoxPublicKey
+	SenderIsAnon   bool
+	ReceiverKey    BoxSecretKey
+	ReceiverIsAnon bool
+
+	// These fields are not cryptographically verified, and are just repeated from what
+	// we saw in the incoming message.
 	NamedReceivers   [][]byte
 	NumAnonReceivers int
 }

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -1081,3 +1081,23 @@ func TestEmptyReceiverKID(t *testing.T) {
 		t.Fatalf("Got %v but wanted %v", err, ErrNoDecryptionKey)
 	}
 }
+
+func TestAnonymousThenNamed(t *testing.T) {
+	receivers := []BoxPublicKey{
+		newHiddenBoxKeyNoInsert(t).GetPublicKey(),
+		newHiddenBoxKeyNoInsert(t).GetPublicKey(),
+		newHiddenBoxKeyNoInsert(t).GetPublicKey(),
+		newHiddenBoxKeyNoInsert(t).GetPublicKey(),
+		newHiddenBoxKeyNoInsert(t).GetPublicKey(),
+		newBoxKey(t).GetPublicKey(),
+	}
+	plaintext := randomMsg(t, 1024*3)
+	ciphertext, err := Seal(plaintext, nil, receivers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = Open(ciphertext, kr)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -1010,7 +1010,7 @@ func TestAllAnonymous(t *testing.T) {
 	}
 
 	if mki.SenderIsAnon {
-		t.Fatal("that the sender is anon isn't known!")
+		t.Fatal("that the sender shouldn't be anonymous")
 	}
 	if mki.ReceiverKey != nil {
 		t.Fatal("non-nil receiver key")

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -239,7 +239,7 @@ func testRoundTrip(t *testing.T, msg []byte, receivers []BoxPublicKey, opts *opt
 		t.Fatal(err)
 	}
 
-	plaintextStream, err := NewDecryptStream(&ciphertext, kr)
+	_, plaintextStream, err := NewDecryptStream(&ciphertext, kr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -298,12 +298,27 @@ func testRealEncryptor(t *testing.T, sz int) {
 		t.Fatal(err)
 	}
 
-	msg2, err := Open(ciphertext.Bytes(), kr)
+	mki, msg2, err := Open(ciphertext.Bytes(), kr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(msg2, msg) {
 		t.Fatal("decryption mismatch")
+	}
+	if mki.SenderIsAnon {
+		t.Fatal("sender should't be anon")
+	}
+	if mki.ReceiverIsAnon {
+		t.Fatal("receiver shouldn't be anon")
+	}
+	if !PublicKeyEqual(sndr.GetPublicKey(), mki.SenderKey) {
+		t.Fatal("got wrong sender key")
+	}
+	if !PublicKeyEqual(receivers[0], mki.ReceiverKey.GetPublicKey()) {
+		t.Fatal("wrong receiver key")
+	}
+	if mki.NumAnonReceivers != 0 {
+		t.Fatal("wrong number of anon receivers")
 	}
 }
 
@@ -371,7 +386,7 @@ func TestReceiverNotFound(t *testing.T) {
 	if err := strm.Close(); err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(out.Bytes(), kr)
+	_, _, err = Open(out.Bytes(), kr)
 	if err != ErrNoDecryptionKey {
 		t.Fatalf("expected an ErrNoDecryptionkey; got %v", err)
 	}
@@ -396,7 +411,7 @@ func TestTruncation(t *testing.T) {
 
 	ciphertext := out.Bytes()
 	trunced1 := ciphertext[0 : len(ciphertext)-51]
-	_, err = Open(trunced1, kr)
+	_, _, err = Open(trunced1, kr)
 	if err != io.ErrUnexpectedEOF {
 		t.Fatalf("Wanted an %v; but got %v\n", io.ErrUnexpectedEOF, err)
 	}
@@ -437,7 +452,7 @@ func testSealAndOpen(t *testing.T, sz int) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	plaintext2, err := Open(ciphertext, kr)
+	_, plaintext2, err := Open(ciphertext, kr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -468,7 +483,7 @@ func TestSealAndOpenTwoReceivers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	plaintext2, err := Open(ciphertext, kr)
+	_, plaintext2, err := Open(ciphertext, kr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -513,7 +528,7 @@ func TestCorruptHeaderNonce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err != errPublicKeyDecryptionFailed {
 		t.Fatalf("Wanted an error %v; got %v", errPublicKeyDecryptionFailed, err)
 	}
@@ -546,7 +561,7 @@ func TestCorruptHeaderNonceR5(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err != errPublicKeyDecryptionFailed {
 		t.Fatalf("Wanted an error %v; got %v", errPublicKeyDecryptionFailed, err)
 	}
@@ -567,7 +582,7 @@ func TestCorruptHeaderNonceR5(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -597,7 +612,7 @@ func TestCorruptReceiverKeysCiphertextR5(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err != errPublicKeyDecryptionFailed {
 		t.Fatalf("Wanted an error %v; got %v", errPublicKeyDecryptionFailed, err)
 	}
@@ -615,7 +630,7 @@ func TestCorruptReceiverKeysCiphertextR5(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -650,7 +665,7 @@ func TestCorruptReceiverKeysPlaintext(t *testing.T) {
 
 	// If we've corrupted the sender key, the first thing that will fail is the
 	// Tag check for this receiver on packet #1.
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if ebt, ok := err.(ErrBadTag); !ok || int(ebt) != 1 {
 		t.Fatalf("Got wrong error; wanted %v but got %v", ErrNoSenderKey, ErrBadTag(1))
 	}
@@ -670,7 +685,7 @@ func TestCorruptReceiverKeysPlaintext(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if mm, ok := err.(ErrBadCiphertext); !ok {
 		t.Fatalf("Got wrong error; wanted 'Bad Ciphertext' but got %v", err)
 	} else if int(mm) != 1 {
@@ -689,7 +704,7 @@ func TestCorruptReceiverKeysPlaintext(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err != ErrBadSenderKey {
 		t.Fatalf("Bad error: wanted %v but got %v", ErrBadSenderKey, err)
 	}
@@ -706,7 +721,7 @@ func TestMissingFooter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err != io.ErrUnexpectedEOF {
 		t.Fatalf("Wanted %v but got %v", io.ErrUnexpectedEOF, err)
 	}
@@ -729,7 +744,7 @@ func TestCorruptEncryption(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if mm, ok := err.(ErrBadCiphertext); !ok {
 		t.Fatalf("Got wrong error; wanted 'Bad Ciphertext' but got %v", err)
 	} else if int(mm) != 3 {
@@ -748,7 +763,7 @@ func TestCorruptEncryption(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if mm, ok := err.(ErrBadTag); !ok {
 		t.Fatalf("Got wrong error; wanted 'Bad Tag; failed Poly1305' but got %v", err)
 	} else if int(mm) != 3 {
@@ -774,7 +789,7 @@ func TestCorruptEncryption(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if emm, ok := err.(ErrBadTag); !ok {
 		t.Fatalf("Expected a 'bad tag' error but got %v", err)
 	} else if int(emm) != 1 {
@@ -801,7 +816,7 @@ func TestCorruptNonce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if bcte, ok := err.(ErrBadTag); !ok {
 		t.Fatalf("Wanted error 'ErrBadTag' but got %v", err)
 	} else if int(bcte) != 3 {
@@ -825,7 +840,7 @@ func TestCorruptHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if ebv, ok := err.(ErrBadVersion); !ok {
 		t.Fatalf("Got wrong error; wanted 'Bad Version' but got %v", err)
 	} else if int(ebv.seqno) != 0 {
@@ -845,7 +860,7 @@ func TestCorruptHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if ebv, ok := err.(ErrWrongMessageType); !ok {
 		t.Fatalf("Got wrong error; wanted 'Bad Type' but got %v", err)
 	} else if ebv.wanted != MessageTypeEncryption {
@@ -866,7 +881,7 @@ func TestCorruptHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err == nil || err.Error() != "only encoded map or array can be decoded into a struct" {
 		t.Fatalf("wanted a msgpack decode error")
 	}
@@ -885,7 +900,7 @@ func TestCorruptHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err == nil || err.Error() != "only encoded map or array can be decoded into a struct" {
 		t.Fatalf("wanted a msgpack decode error")
 	}
@@ -901,7 +916,7 @@ func TestNoSenderKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err != ErrNoSenderKey {
 		t.Fatalf("Wanted %v but got %v", ErrNoSenderKey, err)
 	}
@@ -918,7 +933,7 @@ func TestSealAndOpenTrailingGarbage(t *testing.T) {
 	var buf bytes.Buffer
 	buf.Write(ciphertext)
 	newEncoder(&buf).Encode(randomMsg(t, 14))
-	_, err = Open(buf.Bytes(), kr)
+	_, _, err = Open(buf.Bytes(), kr)
 	if err != ErrTrailingGarbage {
 		t.Fatalf("Wanted 'ErrTrailingGarbage' but got %v", err)
 	}
@@ -931,7 +946,7 @@ func TestAnonymousSender(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -953,13 +968,30 @@ func TestAllAnonymous(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err != ErrNoDecryptionKey {
 		t.Fatalf("Got %v but wanted %v", err, ErrNoDecryptionKey)
 	}
-	_, err = Open(ciphertext, kr.makeIterable())
+
+	var mki *MessageKeyInfo
+	mki, _, err = Open(ciphertext, kr.makeIterable())
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !mki.SenderIsAnon {
+		t.Fatal("sender should be anon")
+	}
+	if !mki.ReceiverIsAnon {
+		t.Fatal("receiver should be anon")
+	}
+	if !PublicKeyEqual(receivers[5], mki.ReceiverKey.GetPublicKey()) {
+		t.Fatal("wrong receiver key")
+	}
+	if mki.NumAnonReceivers != 8 {
+		t.Fatal("wrong number of anon receivers")
+	}
+	if len(mki.NamedReceivers) > 0 {
+		t.Fatal("got named receivers")
 	}
 
 	receivers[5] = newHiddenBoxKeyNoInsert(t).GetPublicKey()
@@ -967,10 +999,25 @@ func TestAllAnonymous(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr.makeIterable())
+
+	mki, _, err = Open(ciphertext, kr.makeIterable())
 	if err != ErrNoDecryptionKey {
 		t.Fatalf("Got %v but wanted %v", err, ErrNoDecryptionKey)
 	}
+
+	if mki.SenderIsAnon {
+		t.Fatal("that the sender is anon isn't known!")
+	}
+	if mki.ReceiverKey != nil {
+		t.Fatal("non-nil receiver key")
+	}
+	if mki.NumAnonReceivers != 8 {
+		t.Fatal("wrong number of anon receivers")
+	}
+	if len(mki.NamedReceivers) > 0 {
+		t.Fatal("got named receivers")
+	}
+
 }
 
 func TestCorruptEmpheralKey(t *testing.T) {
@@ -985,7 +1032,7 @@ func TestCorruptEmpheralKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err != ErrBadEphemeralKey {
 		t.Fatalf("Got %v but wanted %v", err, ErrBadEphemeralKey)
 	}
@@ -1007,7 +1054,7 @@ func TestCiphertextSwapKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err != errPublicKeyDecryptionFailed {
 		t.Fatalf("Got %v but wanted %v", err, errPublicKeyDecryptionFailed)
 	}
@@ -1029,7 +1076,7 @@ func TestEmptyReceiverKID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, kr)
 	if err != ErrNoDecryptionKey {
 		t.Fatalf("Got %v but wanted %v", err, ErrNoDecryptionKey)
 	}

--- a/go/saltpack/errors.go
+++ b/go/saltpack/errors.go
@@ -44,6 +44,9 @@ var (
 	// ErrBadSenderKey is returned if a key with the wrong number of bytes
 	// is discovered in the encryption header.
 	ErrBadSenderKey = errors.New("bad sender key; must be 32 bytes")
+
+	// ErrBadLookup is when the user-provided key lookup gives a bad value
+	ErrBadLookup = errors.New("bad key lookup")
 )
 
 // ErrBadTag is generated when a Tag fails to Unbox properly. It specifies

--- a/go/saltpack/key.go
+++ b/go/saltpack/key.go
@@ -3,7 +3,9 @@
 
 package saltpack
 
-import ()
+import (
+	"crypto/hmac"
+)
 
 // RawBoxKey is the raw byte-representation of what a box key should
 // look like --- a static 32-byte buffer
@@ -79,4 +81,14 @@ type Keyring interface {
 	// BoxPublicKey format. This key has never been seen before, so
 	// will be ephemeral.
 	ImportEphemeralKey(kid []byte) BoxPublicKey
+}
+
+// SecretKeyEqual returns true if the two secret keys are equal.
+func SecretKeyEqual(sk1, sk2 BoxSecretKey) bool {
+	return PublicKeyEqual(sk1.GetPublicKey(), sk2.GetPublicKey())
+}
+
+// PublicKeyEqual returns true if the two public keys are equal.
+func PublicKeyEqual(pk1, pk2 BoxPublicKey) bool {
+	return hmac.Equal(pk1.ToKID(), pk2.ToKID())
 }


### PR DESCRIPTION
- return MessageKeyInfo, read header in constructor..
- only return a readable stream if the header processing succeeds
- all tests pass
- plumb through MessageKeyInfo to all downstream func's
- commentary clean up
- tests that test the MessageKeyInfo use
- and bugfixes for bugs we found