### PR TITLE
Fix go vet in git hooks

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -44,7 +44,7 @@ check_go_vet() {
 	gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '.go$' | grep -v go/vendor/)
 	[ -z "$gofiles" ] && return 0
 
-	warnings=$(go vet $(go list ./... 2>&1 | grep -v vendor))
+	warnings=$(go vet $(go list ./... 2>/dev/null | grep -v vendor) 2>&1)
 	[ -z "$warnings" ] && return 0
 
 	# go vet found issues

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -40,7 +40,7 @@ check_go_fmt() {
 }
 
 check_go_vet() {
-	warnings=$(go vet $(go list ./... 2>&1 | grep -v vendor))
+    	warnings=$(go vet $(go list ./... 2>/dev/null | grep -v vendor) 2>&1)
 	[ -z "$warnings" ] && return 0
 
 	# go vet found issues


### PR DESCRIPTION
In my previous change, I messed up the go vet
command line. This un-messes it up.

We want the (harmless) errors from go list to go to /dev/null,
but we want the errors from go vet to go to stdout so
it can get captured.