### PR TITLE
Don't read the id from a possibly dead window

### DIFF
--- a/react-native/react/native/remote-component.desktop.js
+++ b/react-native/react/native/remote-component.desktop.js
@@ -10,6 +10,7 @@ export default class RemoteComponent extends Component {
   componentWillMount () {
     const windowsOpts = {width: 500, height: 300, fullscreen: false, show: false, ...this.props.windowsOpts}
     this.remoteWindow = new BrowserWindow(windowsOpts)
+    const myRemoteWindowId = this.remoteWindow.id
 
     menuHelper(this.remoteWindow)
     this.closed = false
@@ -23,7 +24,7 @@ export default class RemoteComponent extends Component {
 
     // Remember if we close, it's an error to try to close an already closed window
     ipcRenderer.on('remoteWindowClosed', (event, remoteWindowId) => {
-      if (remoteWindowId === this.remoteWindow.id) {
+      if (remoteWindowId === myRemoteWindowId) {
         if (!this.closed) {
           this.closed = true
           this.props.onRemoteClose && this.props.onRemoteClose()


### PR DESCRIPTION
@keybase/react-hackers 

This fixes an error where we were trying to deref an id from a possibly dead window. Caused errors when you closed popups.