### PR TITLE
Make sure to clone deep actions we receive from remote processes

### DIFF
--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -17,6 +17,7 @@ import {ipcRenderer} from 'electron'
 import RemoteManager from '../../react-native/react/native/remote-manager'
 import {ipcMain} from 'remote'
 import consoleHack from '../app/console-hack'
+import _ from 'lodash'
 
 consoleHack()
 
@@ -67,10 +68,10 @@ class Keybase extends Component {
     ipcMain.removeAllListeners('stateChange')
     ipcMain.removeAllListeners('subscribeStore')
 
-    ipcMain.on('dispatchAction', (event, incomingAction) => {
-      // we MUST convert this else we'll run into issues with redux. See https://github.com/rackt/redux/issues/830
-      const action = {...incomingAction}
-      setImmediate(() => store.dispatch(action))
+    ipcMain.on('dispatchAction', (event, action) => {
+      // we MUST clone this else we'll run into issues with redux. See https://github.com/rackt/redux/issues/830
+      // This is because we get a remote proxy object, instead of a normal object
+      setImmediate(() => store.dispatch(_.cloneDeep(action)))
     })
 
     ipcMain.on('subscribeStore', (event, substore) => {


### PR DESCRIPTION
@chrisnojima Had the original fix to this, but this makes sure that if we have nested objects we don't run into even more subtle bugs.

bugs like: remote process A sends an action with payload {foo: {nested: objData}}. Then remoteProc A is killed and now when we try to access objData we get a nasty, not very helpful, error telling us the object is dead.

@keybase/react-hackers 