### PR TITLE
Updater without global context

### DIFF
--- a/go/client/cmd_update.go
+++ b/go/client/cmd_update.go
@@ -8,10 +8,10 @@ import (
 	"runtime"
 
 	"github.com/keybase/cli"
+	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol"
-	"github.com/keybase/client/go/updater"
 	"github.com/keybase/client/go/updater/sources"
 	"github.com/keybase/go-framed-msgpack-rpc"
 	"golang.org/x/net/context"
@@ -134,7 +134,7 @@ type CmdUpdateCustom struct {
 func NewCmdUpdateCustomRunner(g *libkb.GlobalContext) *CmdUpdateCustom {
 	return &CmdUpdateCustom{
 		Contextified: libkb.NewContextified(g),
-		options:      updater.DefaultUpdaterOptions(g),
+		options:      engine.DefaultUpdaterOptions(g),
 	}
 }
 

--- a/go/engine/update.go
+++ b/go/engine/update.go
@@ -4,6 +4,9 @@
 package engine
 
 import (
+	"fmt"
+	"runtime"
+
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol"
 	"github.com/keybase/client/go/updater"
@@ -47,16 +50,70 @@ func (u *UpdateEngine) Run(ctx *Context) (err error) {
 		u.G().Log.Debug("- UpdateEngine Run")
 	}()
 
-	source, err := sources.NewUpdateSourceFromString(u.G(), u.options.Source)
+	source, err := NewUpdateSourceFromString(u.G(), u.options.Source)
 	if err != nil {
 		return
 	}
 
-	updr := updater.NewUpdater(u.G(), u.options, source)
+	updr := updater.NewUpdater(u.options, source, u.G().Env, u.G().Log)
 	update, err := updr.Update(ctx.UpdateUI, u.options.Force, true)
 	if err != nil {
 		return
 	}
 	u.Result = update
 	return
+}
+
+func NewDefaultUpdater(g *libkb.GlobalContext) *updater.Updater {
+	options := DefaultUpdaterOptions(g)
+	if options == nil {
+		g.Log.Info("No updater available for this environment")
+		return nil
+	}
+	source := DefaultUpdateSource(g)
+	if source == nil {
+		g.Log.Info("No updater source available for this environment")
+		return nil
+	}
+	updr := updater.NewUpdater(*options, source, g.Env, g.Log)
+	return &updr
+}
+
+func DefaultUpdateSource(g *libkb.GlobalContext) sources.UpdateSource {
+	u, _ := NewUpdateSource(g, sources.DefaultUpdateSourceName())
+	return u
+}
+
+func NewUpdateSourceFromString(g *libkb.GlobalContext, name string) (sources.UpdateSource, error) {
+	sourceName := sources.UpdateSourceNameFromString(name, sources.ErrorSource)
+	return NewUpdateSource(g, sourceName)
+}
+
+// The https cert won't work with dots (.) in bucket name, so use alternate URI
+const PrereleaseURI = "https://s3.amazonaws.com/prerelease.keybase.io"
+
+func NewUpdateSource(g *libkb.GlobalContext, sourceName sources.UpdateSourceName) (sources.UpdateSource, error) {
+	switch sourceName {
+	case sources.KeybaseSource:
+		return sources.NewKeybaseUpdateSource(g.Log, g.API, g.Env.GetRunMode()), nil
+	case sources.RemoteSource:
+		return sources.NewRemoteUpdateSource(g.Log, g.Env.GetRunMode(), ""), nil
+	case sources.PrereleaseSource:
+		return sources.NewRemoteUpdateSource(g.Log, g.Env.GetRunMode(), PrereleaseURI), nil
+	}
+	return nil, fmt.Errorf("Invalid update source: %s", string(sourceName))
+}
+
+// DefaultUpdaterOptions returns update config for this environment
+func DefaultUpdaterOptions(g *libkb.GlobalContext) *keybase1.UpdateOptions {
+	ret := &keybase1.UpdateOptions{
+		Version:  libkb.VersionString(),
+		Channel:  "main", // The default channel
+		Platform: runtime.GOOS,
+	}
+	switch {
+	case runtime.GOOS == "darwin" && g.Env.GetRunMode() == libkb.ProductionRunMode:
+		ret.DestinationPath = "/Applications/Keybase.app"
+	}
+	return ret
 }

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -820,3 +820,15 @@ func (e *Env) GetUpdatePreferenceSkip() string {
 func (e *Env) GetUpdatePreferenceSnoozeUntil() keybase1.Time {
 	return e.config.GetUpdatePreferenceSnoozeUntil()
 }
+
+func (e *Env) SetUpdatePreferenceAuto(b bool) error {
+	return e.GetConfigWriter().SetUpdatePreferenceAuto(b)
+}
+
+func (e *Env) SetUpdatePreferenceSkip(v string) error {
+	return e.GetConfigWriter().SetUpdatePreferenceSkip(v)
+}
+
+func (e *Env) SetUpdatePreferenceSnoozeUntil(t keybase1.Time) error {
+	return e.GetConfigWriter().SetUpdatePreferenceSnoozeUntil(t)
+}

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/keybase/cli"
+	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
@@ -149,9 +150,9 @@ func (d *Service) Run() (err error) {
 	}
 
 	if sources.IsPrerelease {
-		updr := updater.NewDefaultUpdater(d.G())
+		updr := engine.NewDefaultUpdater(d.G())
 		if updr != nil {
-			updateChecker := updater.NewUpdateChecker(*updr)
+			updateChecker := updater.NewUpdateChecker(*updr, d.G().UIRouter, d.G().Log)
 			d.updateChecker = &updateChecker
 			d.updateChecker.Start()
 		}

--- a/go/updater/sources/keybase.go
+++ b/go/updater/sources/keybase.go
@@ -5,6 +5,7 @@ package sources
 
 import (
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol"
 )
 
@@ -19,12 +20,16 @@ func (k *updateResponse) GetAppStatus() *libkb.AppStatus {
 
 // KeybaseUpdateSource finds releases/updates from custom url (used primarily for testing)
 type KeybaseUpdateSource struct {
-	libkb.Contextified
+	log     logger.Logger
+	api     libkb.API
+	runMode libkb.RunMode
 }
 
-func NewKeybaseUpdateSource(g *libkb.GlobalContext) KeybaseUpdateSource {
+func NewKeybaseUpdateSource(log logger.Logger, api libkb.API, runMode libkb.RunMode) KeybaseUpdateSource {
 	return KeybaseUpdateSource{
-		Contextified: libkb.NewContextified(g),
+		log:     log,
+		api:     api,
+		runMode: runMode,
 	}
 }
 
@@ -36,12 +41,12 @@ func (k KeybaseUpdateSource) FindUpdate(options keybase1.UpdateOptions) (update 
 	APIArgs := libkb.HTTPArgs{
 		"version":  libkb.S{Val: options.Version},
 		"platform": libkb.S{Val: options.Platform},
-		"run_mode": libkb.S{Val: string(k.G().Env.GetRunMode())},
+		"run_mode": libkb.S{Val: string(k.runMode)},
 		"channel":  libkb.S{Val: options.Channel},
 	}
 
 	var res updateResponse
-	err = k.G().API.GetDecode(libkb.APIArg{
+	err = k.api.GetDecode(libkb.APIArg{
 		Endpoint: "pkg/update",
 		Args:     APIArgs,
 	}, &res)

--- a/go/updater/sources/sources.go
+++ b/go/updater/sources/sources.go
@@ -1,10 +1,8 @@
 package sources
 
 import (
-	"fmt"
 	"strings"
 
-	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
 )
 
@@ -24,19 +22,11 @@ const (
 
 var UpdateSourceNames = []UpdateSourceName{KeybaseSource, RemoteSource, PrereleaseSource}
 
-// The https cert won't work with dots (.) in bucket name, so use alternate URI
-const PrereleaseURI = "https://s3.amazonaws.com/prerelease.keybase.io"
-
 func DefaultUpdateSourceName() UpdateSourceName {
 	if IsPrerelease {
 		return PrereleaseSource
 	}
 	return KeybaseSource
-}
-
-func DefaultUpdateSource(g *libkb.GlobalContext) UpdateSource {
-	u, _ := NewUpdateSource(g, DefaultUpdateSourceName())
-	return u
 }
 
 func UpdateSourcesDescription(delimeter string) string {
@@ -60,21 +50,4 @@ func UpdateSourceNameFromString(name string, defaultSourceName UpdateSourceName)
 	default:
 		return defaultSourceName
 	}
-}
-
-func NewUpdateSourceFromString(g *libkb.GlobalContext, name string) (UpdateSource, error) {
-	sourceName := UpdateSourceNameFromString(name, ErrorSource)
-	return NewUpdateSource(g, sourceName)
-}
-
-func NewUpdateSource(g *libkb.GlobalContext, sourceName UpdateSourceName) (UpdateSource, error) {
-	switch sourceName {
-	case KeybaseSource:
-		return NewKeybaseUpdateSource(g), nil
-	case RemoteSource:
-		return NewRemoteUpdateSource(g, ""), nil
-	case PrereleaseSource:
-		return NewRemoteUpdateSource(g, PrereleaseURI), nil
-	}
-	return nil, fmt.Errorf("Invalid update source: %s", string(sourceName))
 }

--- a/go/updater/update_checker.go
+++ b/go/updater/update_checker.go
@@ -6,23 +6,34 @@ package updater
 import (
 	"fmt"
 	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
 )
 
 type UpdateChecker struct {
 	updater Updater
+	ui      UI
 	ticker  *time.Ticker
+	log     logger.Logger
+}
+
+type UI interface {
+	GetUpdateUI() (libkb.UpdateUI, error)
 }
 
 var UpdateCheckDuration = (24 * time.Hour)
 
-func NewUpdateChecker(updater Updater) UpdateChecker {
+func NewUpdateChecker(updater Updater, ui UI, log logger.Logger) UpdateChecker {
 	return UpdateChecker{
 		updater: updater,
+		ui:      ui,
+		log:     log,
 	}
 }
 
 func (u *UpdateChecker) Check(force bool, requested bool) error {
-	ui, _ := u.updater.G().UIRouter.GetUpdateUI()
+	ui, _ := u.ui.GetUpdateUI()
 	if ui == nil && !force {
 		return fmt.Errorf("No UI for update check")
 	}
@@ -40,7 +51,7 @@ func (u *UpdateChecker) Start() {
 	u.ticker = time.NewTicker(UpdateCheckDuration)
 	go func() {
 		for _ = range u.ticker.C {
-			u.updater.G().Log.Info("Checking for update (ticker)")
+			u.log.Info("Checking for update (ticker)")
 			u.Check(false, false)
 		}
 	}()

--- a/go/updater/updater_osx.go
+++ b/go/updater/updater_osx.go
@@ -34,7 +34,7 @@ func (u *Updater) checkPlatformSpecificUpdate(sourcePath string, destinationPath
 	// Get uid, gid of destination
 	uid := destFileInfo.Sys().(*syscall.Stat_t).Uid
 	gid := destFileInfo.Sys().(*syscall.Stat_t).Gid
-	u.G().Log.Info("Destination: %s, Uid: %d, Gid: %d", destinationPath, uid, gid)
+	u.log.Info("Destination: %s, Uid: %d, Gid: %d", destinationPath, uid, gid)
 
 	walk := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -52,7 +52,7 @@ func (u *Updater) checkPlatformSpecificUpdate(sourcePath string, destinationPath
 		return nil
 	}
 
-	u.G().Log.Info("Touching, chowning files in %s", sourcePath)
+	u.log.Info("Touching, chowning files in %s", sourcePath)
 	err = filepath.Walk(sourcePath, walk)
 	if err != nil {
 		return err

--- a/go/updater/updater_test.go
+++ b/go/updater/updater_test.go
@@ -11,17 +11,13 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol"
 	"golang.org/x/net/context"
 )
 
-func NewTestUpdater(t *testing.T, config keybase1.UpdateOptions) Updater {
-	context := libkb.NewGlobalContext()
-	context.Init()
-	context.Log = logger.NewTestLogger(t)
-	return NewUpdater(context, config, testUpdateSource{})
+func NewTestUpdater(t *testing.T, options keybase1.UpdateOptions) Updater {
+	return NewUpdater(options, testUpdateSource{}, testConfig{}, logger.NewTestLogger(t))
 }
 
 type testUpdateSource struct{}
@@ -54,6 +50,32 @@ func (u testUpdateSource) FindUpdate(config keybase1.UpdateOptions) (release *ke
 			Name: "Test-1.0.1.zip",
 			Url:  fmt.Sprintf("file://%s", path),
 		}}, nil
+}
+
+type testConfig struct{}
+
+func (c testConfig) GetUpdatePreferenceAuto() bool {
+	return false
+}
+
+func (c testConfig) GetUpdatePreferenceSnoozeUntil() keybase1.Time {
+	return keybase1.Time(0)
+}
+
+func (c testConfig) GetUpdatePreferenceSkip() string {
+	return ""
+}
+
+func (c testConfig) SetUpdatePreferenceAuto(b bool) error {
+	panic("Unsupported")
+}
+
+func (c testConfig) SetUpdatePreferenceSkip(v string) error {
+	panic("Unsupported")
+}
+
+func (c testConfig) SetUpdatePreferenceSnoozeUntil(t keybase1.Time) error {
+	panic("Unsupported")
 }
 
 func NewDefaultTestUpdateConfig() keybase1.UpdateOptions {


### PR DESCRIPTION
The updater seems like it should be able to be a more independent/portable thing that other projects could use. So I set out to decouple it from GlobalContext.

An issue with GlobalContext is it is so huge that the only code that will ever implement it is us. That makes it hard for other projects to use any code that uses GlobalContext cause then they have to either use our GlobalContext which has a ton of dependencies or come up with their own.

GlobalContext make sense in our main packages since it is capturing our app state and is great especially cause it fixes using globals. (So not saying GlobalContext is bad, just that it can make packages less independent/portable.)

One thing that we might want to consider is moving GlobalContext into a separate package (like `app`) and maybe change the name GlobalContext to just Context (e.g. `app.Context`) but that's probably a different discussion.