### PR TITLE
CLI: make self-encryption optional

### DIFF
--- a/go/client/cmd_encrypt.go
+++ b/go/client/cmd_encrypt.go
@@ -17,8 +17,9 @@ import (
 
 type CmdEncrypt struct {
 	libkb.Contextified
-	filter     UnixFilter
-	recipients []string
+	filter        UnixFilter
+	recipients    []string
+	noSelfEncrypt bool
 }
 
 func NewCmdEncrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -36,16 +37,9 @@ func NewCmdEncrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 			// https://keybase.atlassian.net/browse/CORE-2142
 			// .
 			//
-			// TODO: Make self-encryption optional:
-			// https://keybase.atlassian.net/browse/CORE-2143
-			// .
 			cli.StringFlag{
 				Name:  "i, infile",
 				Usage: "Specify an input file.",
-			},
-			cli.BoolFlag{
-				Name:  "l, local",
-				Usage: "Only track locally, don't send a statement to the server.",
 			},
 			cli.StringFlag{
 				Name:  "m, message",
@@ -56,8 +50,8 @@ func NewCmdEncrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 				Usage: "Specify an outfile (stdout by default).",
 			},
 			cli.BoolFlag{
-				Name:  "y",
-				Usage: "Approve remote tracking without prompting.",
+				Name:  "no-self",
+				Usage: "Don't encrypt for yourself",
 			},
 		},
 	}
@@ -84,7 +78,8 @@ func (c *CmdEncrypt) Run() error {
 	}
 
 	opts := keybase1.SaltPackEncryptOptions{
-		Recipients: c.recipients,
+		Recipients:    c.recipients,
+		NoSelfEncrypt: c.noSelfEncrypt,
 	}
 	arg := keybase1.SaltPackEncryptArg{Source: src, Sink: snk, Opts: opts}
 	err = cli.SaltPackEncrypt(context.TODO(), arg)
@@ -109,6 +104,7 @@ func (c *CmdEncrypt) ParseArgv(ctx *cli.Context) error {
 	msg := ctx.String("message")
 	outfile := ctx.String("outfile")
 	infile := ctx.String("infile")
+	c.noSelfEncrypt = ctx.Bool("no-self")
 	if err := c.filter.FilterInit(msg, infile, outfile); err != nil {
 		return err
 	}

--- a/go/engine/saltpack_decrypt.go
+++ b/go/engine/saltpack_decrypt.go
@@ -51,10 +51,7 @@ func (e *SaltPackDecrypt) SubConsumers() []libkb.UIConsumer {
 // Run starts the engine.
 func (e *SaltPackDecrypt) Run(ctx *Context) (err error) {
 
-	e.G().Log.Debug("+ SaltPackDecrypt::Run")
-	defer func() {
-		e.G().Log.Debug("- SaltPackDecrypt::Run -> %v", err)
-	}()
+	defer libkb.Trace(e.G().Log, "SaltPackDecrypt::Run", func() error { return err })()
 
 	var me *libkb.User
 	me, err = libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
@@ -66,6 +63,7 @@ func (e *SaltPackDecrypt) Run(ctx *Context) (err error) {
 		Me:      me,
 		KeyType: libkb.DeviceEncryptionKeyType,
 	}
+	e.G().Log.Debug("| GetSecretKeyWithPrompt")
 	key, err := e.G().Keyrings.GetSecretKeyWithPrompt(
 		ctx.LoginContext, ska, ctx.SecretUI,
 		"decrypting a message/file")
@@ -78,8 +76,7 @@ func (e *SaltPackDecrypt) Run(ctx *Context) (err error) {
 		return libkb.KeyCannotDecryptError{}
 	}
 
-	e.G().Log.Debug("| run SaltPackDecrypt")
+	e.G().Log.Debug("| SaltPackDecrypt")
 	err = libkb.SaltPackDecrypt(e.arg.Source, e.arg.Sink, kp)
-	e.G().Log.Debug("| SaltPackDecrypt -> %v", err)
 	return err
 }

--- a/go/engine/saltpack_decrypt.go
+++ b/go/engine/saltpack_decrypt.go
@@ -50,7 +50,14 @@ func (e *SaltPackDecrypt) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *SaltPackDecrypt) Run(ctx *Context) (err error) {
-	me, err := libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
+
+	e.G().Log.Debug("+ SaltPackDecrypt::Run")
+	defer func() {
+		e.G().Log.Debug("- SaltPackDecrypt::Run -> %v", err)
+	}()
+
+	var me *libkb.User
+	me, err = libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
 	if err != nil {
 		return err
 	}
@@ -71,5 +78,8 @@ func (e *SaltPackDecrypt) Run(ctx *Context) (err error) {
 		return libkb.KeyCannotDecryptError{}
 	}
 
-	return libkb.SaltPackDecrypt(e.arg.Source, e.arg.Sink, kp)
+	e.G().Log.Debug("| run SaltPackDecrypt")
+	err = libkb.SaltPackDecrypt(e.arg.Source, e.arg.Sink, kp)
+	e.G().Log.Debug("| SaltPackDecrypt -> %v", err)
+	return err
 }

--- a/go/engine/saltpack_decrypt_test.go
+++ b/go/engine/saltpack_decrypt_test.go
@@ -25,7 +25,6 @@ func TestSaltPackDecrypt(t *testing.T) {
 	}
 	// Should encrypt for self, too.
 	arg := &SaltPackEncryptArg{
-		Recips: []string{},
 		Source: strings.NewReader(msg),
 		Sink:   sink,
 	}

--- a/go/engine/saltpack_encrypt_test.go
+++ b/go/engine/saltpack_encrypt_test.go
@@ -4,10 +4,11 @@
 package engine
 
 import (
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
+	saltpack "github.com/keybase/client/go/saltpack"
 	"strings"
 	"testing"
-
-	"github.com/keybase/client/go/libkb"
 )
 
 func TestSaltPackEncrypt(t *testing.T) {
@@ -26,7 +27,7 @@ func TestSaltPackEncrypt(t *testing.T) {
 	run := func(Recips []string) {
 		sink := libkb.NewBufferCloser()
 		arg := &SaltPackEncryptArg{
-			Recips: Recips,
+			Opts:   keybase1.SaltPackEncryptOptions{Recipients: Recips},
 			Source: strings.NewReader("id2 and encrypt, id2 and encrypt"),
 			Sink:   sink,
 		}
@@ -60,7 +61,9 @@ func TestSaltPackEncryptSelfNoKey(t *testing.T) {
 
 	sink := libkb.NewBufferCloser()
 	arg := &SaltPackEncryptArg{
-		Recips: []string{"t_tracy+t_tracy@rooter", "t_george", "t_kb+gbrltest@twitter"},
+		Opts: keybase1.SaltPackEncryptOptions{
+			Recipients: []string{"t_tracy+t_tracy@rooter", "t_george", "t_kb+gbrltest@twitter"},
+		},
 		Source: strings.NewReader("track and encrypt, track and encrypt"),
 		Sink:   sink,
 	}
@@ -83,7 +86,9 @@ func TestSaltPackEncryptLoggedOut(t *testing.T) {
 
 	sink := libkb.NewBufferCloser()
 	arg := &SaltPackEncryptArg{
-		Recips: []string{"t_tracy+t_tracy@rooter", "t_george", "t_kb+gbrltest@twitter"},
+		Opts: keybase1.SaltPackEncryptOptions{
+			Recipients: []string{"t_tracy+t_tracy@rooter", "t_george", "t_kb+gbrltest@twitter"},
+		},
 		Source: strings.NewReader("track and encrypt, track and encrypt"),
 		Sink:   sink,
 	}
@@ -92,5 +97,67 @@ func TestSaltPackEncryptLoggedOut(t *testing.T) {
 	err := RunEngine(eng, ctx)
 	if err != nil {
 		t.Fatalf("Got unexpected error: %s", err)
+	}
+}
+
+func TestSaltPackEncryptNoSelf(t *testing.T) {
+	tc := SetupEngineTest(t, "SaltPackEncrypt")
+	defer tc.Cleanup()
+
+	u1 := CreateAndSignupFakeUser(tc, "nalcp")
+	u2 := CreateAndSignupFakeUser(tc, "nalcp")
+
+	msg := "for your eyes only (not even mine!)"
+
+	trackUI := &FakeIdentifyUI{
+		Proofs: make(map[string]string),
+	}
+	ctx := &Context{IdentifyUI: trackUI, SecretUI: u2.NewSecretUI()}
+
+	sink := libkb.NewBufferCloser()
+	arg := &SaltPackEncryptArg{
+		Opts: keybase1.SaltPackEncryptOptions{
+			Recipients:    []string{u1.Username},
+			NoSelfEncrypt: true,
+		},
+		Source: strings.NewReader(msg),
+		Sink:   sink,
+	}
+
+	eng := NewSaltPackEncrypt(arg, tc.G)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	out := sink.Bytes()
+	if len(out) == 0 {
+		t.Fatal("no output")
+	}
+
+	// decrypt it
+	decoded := libkb.NewBufferCloser()
+	decarg := &SaltPackDecryptArg{
+		Source: strings.NewReader(string(out)),
+		Sink:   decoded,
+	}
+	dec := NewSaltPackDecrypt(decarg, tc.G)
+	err := RunEngine(dec, ctx)
+	if err != saltpack.ErrNoDecryptionKey {
+		t.Fatalf("Expected err=%v, but got %v", saltpack.ErrNoDecryptionKey, err)
+	}
+
+	Logout(tc)
+	u1.Login(tc.G)
+
+	ctx = &Context{IdentifyUI: trackUI, SecretUI: u1.NewSecretUI()}
+	decarg.Source = strings.NewReader(string(out))
+	dec = NewSaltPackDecrypt(decarg, tc.G)
+	err = RunEngine(dec, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decmsg := decoded.String()
+	if decmsg != msg {
+		t.Errorf("decoded: %s, expected: %s", decmsg, msg)
 	}
 }

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -4606,9 +4606,9 @@ func (c RevokeClient) RevokeSigs(ctx context.Context, __arg RevokeSigsArg) (err 
 }
 
 type SaltPackEncryptOptions struct {
-	Recipients     []string `codec:"recipients" json:"recipients"`
-	HideSelf       bool     `codec:"hideSelf" json:"hideSelf"`
-	EncryptForSelf bool     `codec:"encryptForSelf" json:"encryptForSelf"`
+	Recipients    []string `codec:"recipients" json:"recipients"`
+	HideSelf      bool     `codec:"hideSelf" json:"hideSelf"`
+	NoSelfEncrypt bool     `codec:"noSelfEncrypt" json:"noSelfEncrypt"`
 }
 
 type SaltPackEncryptArg struct {

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -242,7 +242,6 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 		ds.mki.SenderIsAnon = true
 		ds.mki.SenderKey = ephemeralKey
 	}
-
 	copy(ds.sessionKey[:], keys.SessionKey)
 
 	return nil

--- a/go/service/saltpack.go
+++ b/go/service/saltpack.go
@@ -45,7 +45,7 @@ func (h *SaltPackHandler) SaltPackEncrypt(_ context.Context, arg keybase1.SaltPa
 	src := libkb.NewRemoteStreamBuffered(arg.Source, cli, arg.SessionID)
 	snk := libkb.NewRemoteStreamBuffered(arg.Sink, cli, arg.SessionID)
 	earg := &engine.SaltPackEncryptArg{
-		Recips: arg.Opts.Recipients,
+		Opts:   arg.Opts,
 		Sink:   snk,
 		Source: src,
 	}

--- a/protocol/avdl/saltpack.avdl
+++ b/protocol/avdl/saltpack.avdl
@@ -7,7 +7,7 @@ protocol saltPack {
   record SaltPackEncryptOptions {
     array<string> recipients; // user assertions
     boolean hideSelf;
-    boolean encryptForSelf;
+    boolean noSelfEncrypt;
   }
 
   void saltPackEncrypt(int sessionID, Stream source, Stream sink, SaltPackEncryptOptions opts);

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4175,13 +4175,13 @@ export type saltPack_RemoteProof = {
 export type saltPack_SaltPackEncryptOptions = {
   recipients: Array<string>;
   hideSelf: boolean;
-  encryptForSelf: boolean;
+  noSelfEncrypt: boolean;
 }
 
 export type SaltPackEncryptOptions = {
   recipients: Array<string>;
   hideSelf: boolean;
-  encryptForSelf: boolean;
+  noSelfEncrypt: boolean;
 }
 
 export type secretUi_Feature = {

--- a/protocol/json/saltpack.json
+++ b/protocol/json/saltpack.json
@@ -416,7 +416,7 @@
       "name" : "hideSelf",
       "type" : "boolean"
     }, {
-      "name" : "encryptForSelf",
+      "name" : "noSelfEncrypt",
       "type" : "boolean"
     } ]
   } ],

--- a/react-native/react/constants/types/flow-types.js
+++ b/react-native/react/constants/types/flow-types.js
@@ -4175,13 +4175,13 @@ export type saltPack_RemoteProof = {
 export type saltPack_SaltPackEncryptOptions = {
   recipients: Array<string>;
   hideSelf: boolean;
-  encryptForSelf: boolean;
+  noSelfEncrypt: boolean;
 }
 
 export type SaltPackEncryptOptions = {
   recipients: Array<string>;
   hideSelf: boolean;
-  encryptForSelf: boolean;
+  noSelfEncrypt: boolean;
 }
 
 export type secretUi_Feature = {


### PR DESCRIPTION
- plumb options through to engine
- tested successfully via the command line
- test in engine/
- fix C/I tests for new encryption arg format