### PR TITLE
Check isatty for log format

### DIFF
--- a/go/libkb/output_windows.go
+++ b/go/libkb/output_windows.go
@@ -92,6 +92,12 @@ type ColorWriter struct {
 	mutex *sync.Mutex
 }
 
+// Fd returns the underlying file descriptor. This is mainly to
+// support checking whether it's a terminal or not.
+func (cw *ColorWriter) Fd() uintptr {
+	return cw.fd
+}
+
 // Rough emulation of Ansi terminal codes.
 // Parse the string, pick out the codes, and convert to
 // calls to SetConsoleTextAttribute.

--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -253,10 +253,14 @@ func (log *Standard) Configure(style string, debug bool, filename string) {
 	log.filename = filename
 
 	var logfmt string
-	if debug {
-		logfmt = fancyFormat
+	if log.isTerminal {
+		if debug {
+			logfmt = fancyFormat
+		} else {
+			logfmt = defaultFormat
+		}
 	} else {
-		logfmt = defaultFormat
+		logfmt = fileFormat
 	}
 
 	// Override the format above if an explicit style was specified.

--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -105,9 +105,10 @@ func NewWithCallDepth(module string, extraCallDepth int, iow io.Writer) *Standar
 }
 
 func (log *Standard) initLogging(iow io.Writer) {
-	// Logging is always done to stderr. It's the responsibility of the
-	// launcher (like launchd on OSX, or the autoforking code) to set up stderr
-	// to point to the appropriate log file.
+	// Logging is always done to the given io.Writer. It's the
+	// responsibility of the launcher (like launchd on OSX, or the
+	// autoforking code) to set it up to point to the appropriate
+	// log file.
 	initLoggingBackendOnce.Do(func() {
 		logBackend := logging.NewLogBackend(iow, "", 0)
 		logging.SetBackend(logBackend)

--- a/go/vendor/github.com/mattn/go-isatty/LICENSE
+++ b/go/vendor/github.com/mattn/go-isatty/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+
+MIT License (Expat)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/go/vendor/github.com/mattn/go-isatty/README.md
+++ b/go/vendor/github.com/mattn/go-isatty/README.md
@@ -1,0 +1,37 @@
+# go-isatty
+
+isatty for golang
+
+## Usage
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/mattn/go-isatty"
+	"os"
+)
+
+func main() {
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		fmt.Println("Is Terminal")
+	} else {
+		fmt.Println("Is Not Terminal")
+	}
+}
+```
+
+## Installation
+
+```
+$ go get github.com/mattn/go-isatty
+```
+
+# License
+
+MIT
+
+# Author
+
+Yasuhiro Matsumoto (a.k.a mattn)

--- a/go/vendor/github.com/mattn/go-isatty/doc.go
+++ b/go/vendor/github.com/mattn/go-isatty/doc.go
@@ -1,0 +1,2 @@
+// Package isatty implements interface to isatty
+package isatty

--- a/go/vendor/github.com/mattn/go-isatty/isatty_appengine.go
+++ b/go/vendor/github.com/mattn/go-isatty/isatty_appengine.go
@@ -1,0 +1,9 @@
+// +build appengine
+
+package isatty
+
+// IsTerminal returns true if the file descriptor is terminal which
+// is always false on on appengine classic which is a sandboxed PaaS.
+func IsTerminal(fd uintptr) bool {
+	return false
+}

--- a/go/vendor/github.com/mattn/go-isatty/isatty_bsd.go
+++ b/go/vendor/github.com/mattn/go-isatty/isatty_bsd.go
@@ -1,0 +1,18 @@
+// +build darwin freebsd openbsd netbsd
+// +build !appengine
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const ioctlReadTermios = syscall.TIOCGETA
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/go/vendor/github.com/mattn/go-isatty/isatty_linux.go
+++ b/go/vendor/github.com/mattn/go-isatty/isatty_linux.go
@@ -1,0 +1,18 @@
+// +build linux
+// +build !appengine
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const ioctlReadTermios = syscall.TCGETS
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/go/vendor/github.com/mattn/go-isatty/isatty_solaris.go
+++ b/go/vendor/github.com/mattn/go-isatty/isatty_solaris.go
@@ -1,0 +1,16 @@
+// +build solaris
+// +build !appengine
+
+package isatty
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+// see: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
+func IsTerminal(fd uintptr) bool {
+	var termio unix.Termio
+	err := unix.IoctlSetTermio(int(fd), unix.TCGETA, &termio)
+	return err == nil
+}

--- a/go/vendor/github.com/mattn/go-isatty/isatty_windows.go
+++ b/go/vendor/github.com/mattn/go-isatty/isatty_windows.go
@@ -1,0 +1,19 @@
+// +build windows
+// +build !appengine
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+var procGetConsoleMode = kernel32.NewProc("GetConsoleMode")
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var st uint32
+	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, fd, uintptr(unsafe.Pointer(&st)), 0)
+	return r != 0 && e == 0
+}

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -203,6 +203,11 @@
 			"revisionTime": "2015-05-20T12:37:12-04:00"
 		},
 		{
+			"path": "github.com/mattn/go-isatty",
+			"revision": "56b76bdf51f7708750eac80fa38b952bb9f32639",
+			"revisionTime": "2015-12-11T09:06:21+09:00"
+		},
+		{
 			"path": "github.com/natefinch/npipe",
 			"revision": "0938d701e50e580f5925c773055eb6d6b32a0cbc",
 			"revisionTime": "2014-10-08T16:43:58+02:00"


### PR DESCRIPTION
This makes it so that if you redirect output
to a file, you don't get color codes.

Of course, some other stuff might use
color codes (like the identify output),
but that can be taken care of later.