### PR TITLE
Replace nslog with console.log everywhere

### DIFF
--- a/desktop/app/installer.js
+++ b/desktop/app/installer.js
@@ -1,5 +1,4 @@
 import {app} from 'electron';
-import nslog from 'nslog';
 import {exec} from 'child_process';
 import path from 'path';
 import fs from 'fs';
@@ -15,21 +14,21 @@ export default (callback) => {
   fs.access(installerExec, fs.X_OK , function (err) {
     if (runMode != "prod") {
       // Only run in prod
-      nslog("Installer not available (runMode=%s)", runMode)
+      console.log("Installer not available (runMode=%s)", runMode)
       callback(null);
       return
     }
 
     if (err) {
       // Installer is not accessible
-      nslog("Installer not available (not found)")
+      console.log("Installer not available (not found)")
       callback(null);
       return
     }
 
     var cmd = [installerExec, "--app-path="+appBundlePath, "--run-mode=prod"].join(" ");
     exec(cmd, function(err, stdout, stderr) {
-      nslog("Installer: ", err, stdout, stderr);
+      console.log("Installer: ", err, stdout, stderr);
       callback(err);
     });
   });

--- a/desktop/package.js
+++ b/desktop/package.js
@@ -25,18 +25,12 @@ fs.copySync('../react-native/react/native', 'build/react-native/react/native', {
 fs.copySync('../react-native/react/images', 'build/react-native/react/images')
 fs.copySync('./node_modules/font-awesome/css/font-awesome.min.css', 'build/desktop/node_modules/font-awesome/css/font-awesome.min.css')
 fs.copySync('./node_modules/font-awesome/fonts/fontawesome-webfont.woff2', 'build/desktop/node_modules/font-awesome/fonts/fontawesome-webfont.woff2')
-fs.copySync('./node_modules/nslog/package.json', 'build/desktop/node_modules/nslog/package.json')
-fs.copySync('./node_modules/nslog/lib/nslog.js', 'build/desktop/node_modules/nslog/lib/nslog.js')
-fs.copySync('./node_modules/nslog/build/Release/nslog.node', 'build/desktop/node_modules/nslog/build/Release/nslog.node')
 fs.copySync('./renderer', 'build/desktop/renderer', {filter: f => !f.endsWith('.js')})
 
 fs.writeJsonSync('build/package.json', {
   name: appName,
   version: appVersion,
-  main: 'desktop/dist/main.bundle.js',
-  dependencies: {
-    'nslog': '^3.0.0'
-  }
+  main: 'desktop/dist/main.bundle.js'
 })
 
 const DEFAULT_OPTS = {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -31,7 +31,6 @@
     "material-ui": "^0.13.3",
     "menubar": "keybase/menubar",
     "moment": "^2.10.6",
-    "nslog": "^3.0.0",
     "purepack": "keybase/purepack#nojima/keybase-client-changes",
     "qrcode-generator": "^1.0.0",
     "react": "^0.14.3",

--- a/desktop/webpack.config.base.js
+++ b/desktop/webpack.config.base.js
@@ -39,9 +39,6 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin(defines)
   ],
-  externals: [
-    'nslog'
-  ],
   node: {
     __dirname: true
   },


### PR DESCRIPTION
@keybase/react-hackers 

We can't get nslog to build and package properly on Windows.  But @gabriel says we don't need it anymore and can just remove it, so this PR does that.  This puts us in the nice place of not having to ship any native modules at the moment, which means we can make Linux/Win/OSX packages all from the same machine.

(Gabriel also suggests moving to a proper logger with loglevels at some point, but let's get this blocker out of the way first.)