### PR TITLE
correct our misuse of Poly1305

### DIFF
--- a/go/libkb/saltpack.go
+++ b/go/libkb/saltpack.go
@@ -52,9 +52,9 @@ func (k naclBoxPrecomputedSharedKey) Unbox(nonce *saltpack.Nonce, msg []byte) (
 	return ret, nil
 }
 
-func (k naclBoxPrecomputedSharedKey) Box(nonce *saltpack.Nonce, msg []byte) ([]byte, error) {
+func (k naclBoxPrecomputedSharedKey) Box(nonce *saltpack.Nonce, msg []byte) []byte {
 	ret := box.SealAfterPrecomputation([]byte{}, msg, (*[24]byte)(nonce), (*[32]byte)(&k))
-	return ret, nil
+	return ret
 }
 
 type naclBoxSecretKey NaclDHKeyPair

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -260,10 +260,7 @@ func (ds *decryptStream) processEncryptionBlock(bl *EncryptionBlock) ([]byte, er
 	ciphertext := bl.PayloadCiphertext
 	hash := sha512.Sum512(ciphertext)
 
-	hashBox, err := ds.tagKey.Box(nonce, hash[:])
-	if err != nil {
-		return nil, err
-	}
+	hashBox := ds.tagKey.Box(nonce, hash[:])
 	ourAuthenticator := hashBox[:secretbox.Overhead]
 
 	if !hmac.Equal(ourAuthenticator, bl.HashAuthenticators[ds.position]) {

--- a/go/saltpack/encrypt.go
+++ b/go/saltpack/encrypt.go
@@ -77,10 +77,7 @@ func (es *encryptStream) encryptBytes(b []byte) error {
 	}
 
 	for _, tagKey := range es.tagKeys {
-		hashBox, err := tagKey.Box(nonce, hash[:])
-		if err != nil {
-			return err
-		}
+		hashBox := tagKey.Box(nonce, hash[:])
 		authenticator := hashBox[:secretbox.Overhead]
 		block.HashAuthenticators = append(block.HashAuthenticators, authenticator)
 	}
@@ -174,7 +171,7 @@ func (es *encryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey) err
 
 		ephemeralShared := ephemeralKey.Precompute(receiver)
 
-		keys, err := ephemeralShared.Box(nonce, rkpPacked)
+		keys := ephemeralShared.Box(nonce, rkpPacked)
 		if err != nil {
 			return err
 		}

--- a/go/saltpack/encrypt.go
+++ b/go/saltpack/encrypt.go
@@ -5,6 +5,7 @@ package saltpack
 
 import (
 	"bytes"
+	"crypto/sha512"
 	"encoding/hex"
 	"golang.org/x/crypto/nacl/secretbox"
 	"io"
@@ -68,21 +69,20 @@ func (es *encryptStream) encryptBytes(b []byte) error {
 	}
 
 	nonce := es.nonce.ForPayloadBox(es.numBlocks)
-	raw := secretbox.Seal([]byte{}, b, (*[24]byte)(nonce), (*[32]byte)(&es.sessionKey))
-
-	tag := raw[0:secretbox.Overhead]
-	ciphertext := raw[secretbox.Overhead:]
+	ciphertext := secretbox.Seal([]byte{}, b, (*[24]byte)(nonce), (*[32]byte)(&es.sessionKey))
+	hash := sha512.Sum512(ciphertext)
 
 	block := EncryptionBlock{
 		PayloadCiphertext: ciphertext,
 	}
 
 	for _, tagKey := range es.tagKeys {
-		tag, err := tagKey.Box(nonce, tag)
+		hashBox, err := tagKey.Box(nonce, hash[:])
 		if err != nil {
 			return err
 		}
-		block.TagCiphertexts = append(block.TagCiphertexts, tag)
+		authenticator := hashBox[:secretbox.Overhead]
+		block.HashAuthenticators = append(block.HashAuthenticators, authenticator)
 	}
 
 	if err := es.encoder.Encode(block); err != nil {

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -763,7 +763,7 @@ func TestCorruptEncryption(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, _, err = Open(ciphertext, kr)
-	if mm, ok := err.(ErrBadCiphertext); !ok {
+	if mm, ok := err.(ErrBadTag); !ok {
 		t.Fatalf("Got wrong error; wanted 'Bad Ciphertext' but got %v", err)
 	} else if int(mm) != 3 {
 		t.Fatalf("Wanted a failure in packet %d but got %d", 3, mm)
@@ -774,7 +774,7 @@ func TestCorruptEncryption(t *testing.T) {
 		blockSize: 1024,
 		corruptEncryptionBlock: func(eb *EncryptionBlock, ebn encryptionBlockNumber) {
 			if ebn == 2 {
-				eb.TagCiphertexts[0][2] ^= 1
+				eb.HashAuthenticators[0][2] ^= 1
 			}
 		},
 	})

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -137,9 +137,9 @@ func (b boxPrecomputedSharedKey) Unbox(nonce *Nonce, msg []byte) ([]byte, error)
 	return out, nil
 }
 
-func (b boxPrecomputedSharedKey) Box(nonce *Nonce, msg []byte) ([]byte, error) {
+func (b boxPrecomputedSharedKey) Box(nonce *Nonce, msg []byte) []byte {
 	out := box.SealAfterPrecomputation([]byte{}, msg, (*[24]byte)(nonce), (*[32]byte)(&b))
-	return out, nil
+	return out
 }
 
 func (b boxSecretKey) Box(receiver BoxPublicKey, nonce *Nonce, msg []byte) ([]byte, error) {

--- a/go/saltpack/errors.go
+++ b/go/saltpack/errors.go
@@ -59,8 +59,9 @@ var (
 	ErrDetachedSignaturePresent = errors.New("detached signature present")
 )
 
-// ErrBadTag is generated when a Tag fails to Unbox properly. It specifies
-// which Packet sequence number the bad packet was in.
+// ErrBadTag is generated when a payload hash doesn't match the hash
+// authenticator. It specifies which Packet sequence number the bad packet was
+// in.
 type ErrBadTag PacketSeqno
 
 // ErrBadCiphertext is generated when decryption fails due to improper authentication. It specifies

--- a/go/saltpack/key.go
+++ b/go/saltpack/key.go
@@ -44,7 +44,7 @@ type BoxPublicKey interface {
 // BoxPrecomputedSharedKey results from a Precomputation below.
 type BoxPrecomputedSharedKey interface {
 	Unbox(nonce *Nonce, msg []byte) ([]byte, error)
-	Box(nonce *Nonce, msg []byte) ([]byte, error)
+	Box(nonce *Nonce, msg []byte) []byte
 }
 
 // BoxSecretKey is the secret key corresponding to a BoxPublicKey

--- a/go/saltpack/packets.go
+++ b/go/saltpack/packets.go
@@ -40,10 +40,10 @@ type EncryptionHeader struct {
 // EncryptionBlock contains a block of encrypted data. It contains
 // the ciphertext, and any necessary authentication Tags.
 type EncryptionBlock struct {
-	_struct           bool     `codec:",toarray"`
-	TagCiphertexts    [][]byte `codec:"tags"`
-	PayloadCiphertext []byte   `codec:"ctext"`
-	seqno             PacketSeqno
+	_struct            bool     `codec:",toarray"`
+	HashAuthenticators [][]byte `codec:"authenticators"`
+	PayloadCiphertext  []byte   `codec:"ctext"`
+	seqno              PacketSeqno
 }
 
 func verifyRawKey(k []byte) error {

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -182,7 +182,7 @@ to be the first 16 bytes of the SHA512 of the concatenation of these values:
 - `"encryption nonce prefix\0"`
 - the 32-byte **ephemeral_public** key
 
-The nonce for each box is the concatenation of `P` and a 64-bit big-endian
+The nonce for each box is then the concatenation of `P` and a 64-bit big-endian
 unsigned counter. For each **recipient_box** the counter is 0. For each payload
 packet we then increment the counter, so the first set of
 **hash_authenticators** is 1, the next is 2, and so on. For each
@@ -193,17 +193,17 @@ impossible to drop or reorder any payload packets.
 We might be concerned about reusing the same nonce for each recipient here. For
 example, a recipient key could show up more than once in the recipients list.
 However, note that all the recipient boxes contain the same keys, and all the
-authenticator boxes in a given payload packet contain the same hash. So if the
-same recipient shows up twice, we'll produce identical boxes for them the
-second time.
+authenticator boxes related to a given payload packet contain the same hash. So
+if the same recipient shows up twice, we'll produce identical boxes for them
+the second time.
 
 Besides avoiding nonce reuse, we also want to prevent abuse of the decryption
 key. Alice might use Bob's public key to encrypt many kinds of messages,
 besides just SaltPack messages. If Mallory intercepted one of these, she could
 assemble a fake SaltPack message using the intercepted box, in the hope that
 Bob might reveal something about its contents by decrypting it. If we used a
-random nonce transmitted in the message header, Mallory could pick the nonce to
-fit the intercepted box. Using the `P` prefix instead makes this attack
+random nonce transmitted in the message header, Mallory could choose the nonce
+to match an intercepted box. Using the `P` prefix instead makes this attack
 difficult. Unless Mallory can compute enough hashes to find one with a specific
 16-byte prefix, she can't control the nonce that Bob uses to decrypt.
 
@@ -227,16 +227,16 @@ place of `"SaltPack\0"`.
   0,
   # ephemeral public key
   LfqrHp8MXAjgaRgwDVc354+xT+KbCZaAgXXRL7bLWwI=,
-  # recipient tuples
+  # recipient pairs
   [
-    # the first recipient
+    # the first recipient pair
     [
       # recipient public key (null in this case, for an anonymous recipient)
       null,
       # recipient box
       yYTf3JDEYYxfKsHpF0yd5V4Ud7CAxFSJQCj5fV3x6WDGvxsmg/QQW6Qe3muB7uyg5PdlxEOg7fsmEXcFBEBDM9IzmvWsFZnqHk7yaLnkLd9mHeJLtw==,
     ],
-    # subsequent recipients...
+    # subsequent recipient pairs...
   ],
 ]
 

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -79,47 +79,49 @@ The header packet is a MessagePack list with these contents:
     format name,
     version,
     mode,
-    ephemeral public,
-    recipients,
+    ephemeral public key,
+    recipients list,
 ]
 ```
 
-- **format name** is the string "SaltPack".
-- **version** is a list of the major and minor versions, currently `[1, 0]`.
-- **mode** is the number 0, for encryption. (1 and 2 are attached and detached
-  signing.)
-- **ephemeral public** is an ephemeral NaCl public encryption key, 32 bytes.
-  The ephemeral keypair is generated at random by the sender and only used for
-  one message.
-- **recipients** is a list of pairs, one for each recipient key.
+- The **format name** is the string "SaltPack".
+- The **version** is a list of the major and minor versions, currently
+  `[1, 0]`.
+- The **mode** is the number 0, for encryption. (1 and 2 are attached and
+  detached signing.)
+- The **ephemeral public key** is an ephemeral NaCl public encryption key, 32
+  bytes. The ephemeral keypair is generated at random by the sender and only
+  used for one message.
+- The **recipients list** contains a recipient pair for each recipient key.
 
 A recipient pair is a two-element list:
 
 ```
 [
-    recipient public,
+    recipient public key,
     recipient box,
 ]
 ```
 
-- **recipient public** is the recipient's long-term NaCl public encryption key.
-  This field may be null, when the recipients are anonymous.
-- **recipient box** is a NaCl box encrypted with the recipient's public key and
-  the ephemeral private key.
+- The **recipient public key** is the recipient's long-term NaCl public
+  encryption key. This field may be null, when the recipients are anonymous.
+- The **recipient box** is a NaCl box encrypted with the recipient's public key
+  and the ephemeral private key.
 
 The the **recipient box** contains another two-element MessagePack list:
 
 ```
 [
-    sender public,
+    sender public key,
     message key,
 ]
 ```
 
-- **sender public** is the sender's long-term NaCl public encryption key.
-- **message key** is a NaCl symmetric key used to encrypt the payload packets.
-  The message key is generated at random by the sender and only used for one
-  message.
+- The **sender public key** is the sender's long-term NaCl public encryption
+  key.
+- The **message key** is a NaCl symmetric key used to encrypt the payload
+  packets. The message key is generated at random by the sender and only used
+  for one message.
 
 Putting the sender's key in the **recipient box** allows Alice to stay
 anonymous to Mallory. If Alice wants to be anonymous to Bob as well, she can
@@ -138,16 +140,16 @@ A payload packet is a MessagePack list with these contents:
 
 ```
 [
-    hash authenticators,
+    hash authenticators list,
     payload secretbox,
 ]
 ```
 
-- **hash authenticators** is a list of 16-byte Poly1305 tags, one for each
+- The **hash authenticators list** contains 16-byte Poly1305 tags, one for each
   recipient, which authenticate the hash of the **payload secretbox**.
-- **payload secretbox** is a NaCl secretbox containing a chunk of the plaintext
-  bytes, max size 1 MB. It's encrypted with the symmetric message key. See
-  [Nonces](#nonces) below.
+- The **payload secretbox** is a NaCl secretbox containing a chunk of the
+  plaintext bytes, max size 1 MB. It's encrypted with the symmetric message
+  key. See [Nonces](#nonces) below.
 
 We compute the authenticators in three steps:
 
@@ -156,13 +158,13 @@ We compute the authenticators in three steps:
   recipient's long-term keys. See [Nonces](#nonces) below.
 - Take the first 16 bytes of each box, which comprise the Poly1305 tag.
 
-The purpose of the **hash authenticators** is to prevent recipients from
-reusing the header packet and the symmetric message key to forge new messages
-that appear to be from the same sender to other recipients. (Recipients should
-be able to forge messages that appear to be sent to them only, not messages
-that appear to be sent to anyone else.) Before opening the
-**payload secretbox**, recipients must compute the authenticator and verify
-that it matches what's in the **hash authenticators** list.
+The purpose of the authenticators is to prevent recipients from reusing the
+header packet and the symmetric message key to forge new messages that appear
+to be from the same sender to other recipients. (Recipients should be able to
+forge messages that appear to be sent to them only, not messages that appear to
+be sent to anyone else.) Before opening the **payload secretbox**, recipients
+must compute the authenticator and verify that it matches what's in the **hash
+authenticators list**.
 
 Using NaCl's [`crypto_box`](http://nacl.cr.yp.to/box.html) to compute the
 authenticators takes more time than using
@@ -180,15 +182,14 @@ to be the first 16 bytes of the SHA512 of the concatenation of these values:
 - `"SaltPack\0"` (`\0` is a [null
   byte](https://www.ietf.org/mail-archive/web/tls/current/msg14734.html))
 - `"encryption nonce prefix\0"`
-- the 32-byte **ephemeral public** key
+- the 32-byte **ephemeral public key**
 
 The nonce for each box is then the concatenation of `P` and a 64-bit big-endian
 unsigned counter. For each **recipient box** the counter is 0. For each payload
-packet we then increment the counter, so the first set of
-**hash authenticators** is 1, the next is 2, and so on. For each
-**payload secretbox**, the nonce is the same as for the associated
-**hash authenticators**. The strict ordering of nonces should make it
-impossible to drop or reorder any payload packets.
+packet we then increment the counter, so the first set of hash authenticators
+is 1, the next is 2, and so on. For each **payload secretbox**, the nonce is
+the same as for the associated hash authenticators. The strict ordering of
+nonces should make it impossible to drop or reorder any payload packets.
 
 We might be concerned about reusing the same nonce for each recipient here. For
 example, a recipient key could show up more than once in the recipients list.
@@ -242,7 +243,7 @@ place of `"SaltPack\0"`.
 
 # payload packet
 [
-  # hash authenticators
+  # hash authenticators list
   [
     # the first recipient's authenticator
     Kf7jX3b41HUsMkBPPwITsw==,
@@ -254,7 +255,7 @@ place of `"SaltPack\0"`.
 
 # empty payload packet
 [
-  # hash authenticators
+  # hash authenticators list
   [
     # the first recipient's authenticator
     scFuUduo1tFLbWajQOXTzw==,

--- a/go/saltpack/tweakable_encryptor_test.go
+++ b/go/saltpack/tweakable_encryptor_test.go
@@ -109,10 +109,7 @@ func (pes *testEncryptStream) encryptBytes(b []byte) error {
 	}
 
 	for _, tagKey := range pes.tagKeys {
-		hashBox, err := tagKey.Box(nonce, hash[:])
-		if err != nil {
-			return err
-		}
+		hashBox := tagKey.Box(nonce, hash[:])
 		authenticator := hashBox[:secretbox.Overhead]
 		block.HashAuthenticators = append(block.HashAuthenticators, authenticator)
 	}


### PR DESCRIPTION
Spec changes in the first commit, Go implementation changes in the second. Compare to Python changes from https://github.com/oconnor663/crypto_format/commit/8a2f46345bae4cd90e3e9424b52275e3959acd97.

@maxtaco, this is the approach that I had in mind, where we authenticate a hash rather than a tag, a smaller change than a return to separate MAC keys would be. I still feel more comfortable with this way, probably we should schedule some time today or tomorrow to VC and bounce thoughts off each other?