### PR TITLE
Fix merkle tree path mismatch bug when level > 0

### DIFF
--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -634,7 +634,6 @@ func (vp *VerificationPath) VerifyUser() (user *MerkleUserLeaf, err error) {
 func (path PathSteps) VerifyPath(curr NodeHash, uidS string) (juser *jsonw.Wrapper, err error) {
 
 	bpath := uidS
-	pos := 0
 	lastTyp := 0
 
 	for i, step := range path {
@@ -652,14 +651,10 @@ func (path PathSteps) VerifyPath(curr NodeHash, uidS string) (juser *jsonw.Wrapp
 		}
 
 		plen := len(step.prefix)
-
-		epos := pos + plen
-		if bpath[pos:epos] != step.prefix {
-			err = fmt.Errorf("Path mismatch at level %d: %s != %s",
-				i, bpath[pos:epos], step.prefix)
+		if plen > 0 && bpath[:plen] != step.prefix {
+			err = fmt.Errorf("Path mismatch at level %d: %s != %s", i, bpath[:plen], step.prefix)
 			break
 		}
-		pos = epos
 
 		lastTyp, err = jw.AtKey("type").GetInt()
 		if err != nil {


### PR DESCRIPTION
API server creates prefix_through_level, but this was
checking prefix at level.  Now this code checks prefix
through level.

Nothing showed up before because there was only data at
level 0 of the merkle tree.  My dev db has 62k+ users in
it now, so the merkle tree started having data at level
1 and I was getting Path mismatch errors during tests.

r? @maxtaco 