### PR TITLE
Add Electron to Linux Debian packager

### DIFF
--- a/desktop/package.js
+++ b/desktop/package.js
@@ -13,6 +13,7 @@ const fs = require('fs-extra')
 const appName = 'Keybase'
 const shouldUseAsar = argv.asar || argv.a || false
 const shouldBuildAll = argv.all || false
+const shouldBuildArch = argv.arch || false
 const appVersion = argv.appVersion || '0.0.0'
 const comment = argv.comment || ''
 
@@ -94,6 +95,9 @@ function startPack () {
             pack(plat, arch, log(plat, arch))
           })
         })
+      } else if (shouldBuildArch) {
+        // build for specified arch on current platform only
+        pack(os.platform(), shouldBuildArch, log(os.platform(), shouldBuildArch))
       } else {
         // build for current platform only
         pack(os.platform(), os.arch(), log(os.platform(), os.arch()))

--- a/desktop/package.js
+++ b/desktop/package.js
@@ -13,7 +13,7 @@ const fs = require('fs-extra')
 const appName = 'Keybase'
 const shouldUseAsar = argv.asar || argv.a || false
 const shouldBuildAll = argv.all || false
-const shouldBuildArch = argv.arch || false
+const shouldBuildAnArch = argv.arch || false
 const appVersion = argv.appVersion || '0.0.0'
 const comment = argv.comment || ''
 
@@ -95,9 +95,9 @@ function startPack () {
             pack(plat, arch, log(plat, arch))
           })
         })
-      } else if (shouldBuildArch) {
-        // build for specified arch on current platform only
-        pack(os.platform(), shouldBuildArch, log(os.platform(), shouldBuildArch))
+      } else if (shouldBuildAnArch) {
+        // build for a specified arch on current platform only
+        pack(os.platform(), shouldBuildAnArch, log(os.platform(), shouldBuildAnArch))
       } else {
         // build for current platform only
         pack(os.platform(), os.arch(), log(os.platform(), os.arch()))

--- a/packaging/debian/build_debian.sh
+++ b/packaging/debian/build_debian.sh
@@ -67,7 +67,7 @@ build_one_architecture() {
   # Now the Electron build.
   echo "Building Electron client for $electron_arch"
   (cd ../../desktop && node package.js --platform linux --arch $electron_arch)
-  (cd ../../desktop && rsync -a release/linux-${electron_arch}/Keybase-linux-${electron_arch}/ "$dest/build/opt/keybase")
+  (cd ../../desktop && rsync -a "release/linux-${electron_arch}/Keybase-linux-${electron_arch}/" "$dest/build/opt/keybase")
 
   fakeroot dpkg-deb --build "$dest/build" "$dest/$binary_name.deb"
 

--- a/packaging/debian/build_debian.sh
+++ b/packaging/debian/build_debian.sh
@@ -27,11 +27,28 @@ build_root="${2:-$(mktemp -d)}"
 
 echo "Building $mode mode in $build_root"
 
+build_electron() {
+  echo "building Electron client"
+  # Remove the line below once this branch is in master.
+  git checkout cjb/DESKTOP-114-linux-electron-2
+  # Can't seem to get the right packages installed under NODE_ENV=production.
+  export NODE_ENV=development
+  backto=`pwd`
+  cd ../../
+  cd react-native
+  npm i
+  cd ../desktop
+  npm i
+  export NODE_ENV=production
+  cd $backto
+}
+
 build_one_architecture() {
   echo "building Go client for $GOARCH"
   dest="$build_root/$debian_arch"
   mkdir -p "$dest/build/usr/bin"
   mkdir -p "$dest/build/DEBIAN"
+  mkdir -p "$dest/build/opt/keybase"
 
   # `go build` reads $GOARCH
   # XXX: Go does not build tags reliably prior to 1.5 without -a. See:
@@ -52,18 +69,31 @@ build_one_architecture() {
     > "$dest/build/DEBIAN/control"
   cp "$here/postinst" "$dest/build/DEBIAN/"
 
+  # Now the Electron build.
+  echo "Building Electron client for $electron_arch"
+  backto=`pwd`
+  cd ../../desktop
+  node package.js --platform linux --arch $electron_arch
+  cp -r release/linux-${electron_arch}/Keybase-linux-${electron_arch}/* "$dest/build/opt/keybase"
+
   fakeroot dpkg-deb --build "$dest/build" "$dest/$binary_name.deb"
 
   # Write the version number to a file for the caller's convenience.
   echo -n "$version" > "$dest/VERSION"
+  cd $backto
 }
 
 # Note that Go names the x86 architecture differently than Debian does, which
 # is why we need these two variables.
-export GOARCH=386
-export debian_arch=i386
-build_one_architecture
+
+build_electron
 
 export GOARCH=amd64
 export debian_arch=amd64
+export electron_arch=x64
+build_one_architecture
+
+export GOARCH=386
+export debian_arch=i386
+export electron_arch=ia32
 build_one_architecture


### PR DESCRIPTION
@oconnor663 This adds Electron to your Debian build, putting the GUI binary at:

/opt/keybase/Keybase

It doesn't do autostart yet.  So to test it you run `keybase service &; /opt/keybase/Keybase`.