### PR TITLE
fix "inappropriate ioctl" bug

### DIFF
--- a/go/minterm/minterm_nix.go
+++ b/go/minterm/minterm_nix.go
@@ -15,8 +15,8 @@ func (m *MinTerm) open() error {
 	if err != nil {
 		return err
 	}
-	m.out = f
-	fd := int(m.out.Fd())
+	m.termFile = f
+	fd := int(m.termFile.Fd())
 	w, h, err := terminal.GetSize(fd)
 	if err != nil {
 		return err

--- a/go/minterm/minterm_nix.go
+++ b/go/minterm/minterm_nix.go
@@ -15,8 +15,9 @@ func (m *MinTerm) open() error {
 	if err != nil {
 		return err
 	}
-	m.termFile = f
-	fd := int(m.termFile.Fd())
+	m.termIn = f
+	m.termOut = f
+	fd := int(f.Fd())
 	w, h, err := terminal.GetSize(fd)
 	if err != nil {
 		return err

--- a/go/minterm/minterm_windows.go
+++ b/go/minterm/minterm_windows.go
@@ -11,14 +11,21 @@ import (
 )
 
 func (m *MinTerm) open() error {
+	// Must be O_RDWR, or we can't mask the password as the user types it.
+	fin, err := os.OpenFile("CONIN$", os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	// Must be O_RDWR, or else GetSize below breaks.
 	fout, err := os.OpenFile("CONOUT$", os.O_RDWR, 0)
 	if err != nil {
 		return err
 	}
 
-	m.termFile = fout
-	fd := int(m.termFile.Fd())
-	w, h, err := terminal.GetSize(fd)
+	m.termIn = fin
+	m.termOut = fout
+	fdout := int(fout.Fd())
+	w, h, err := terminal.GetSize(fdout)
 	if err != nil {
 		return err
 	}

--- a/go/minterm/minterm_windows.go
+++ b/go/minterm/minterm_windows.go
@@ -16,8 +16,8 @@ func (m *MinTerm) open() error {
 		return err
 	}
 
-	m.out = fout
-	fd := int(m.out.Fd())
+	m.termFile = fout
+	fd := int(m.termFile.Fd())
 	w, h, err := terminal.GetSize(fd)
 	if err != nil {
 		return err

--- a/go/vendor/github.com/keybase/gopass/bsd.go
+++ b/go/vendor/github.com/keybase/gopass/bsd.go
@@ -7,23 +7,28 @@ package gopass
 #include <unistd.h>
 #include <stdio.h>
 
-int getch() {
-        int ch;
+int getch(int termDescriptor) {
+        char ch;
         struct termios t_old, t_new;
 
-        tcgetattr(STDIN_FILENO, &t_old);
+        tcgetattr(termDescriptor, &t_old);
         t_new = t_old;
         t_new.c_lflag &= ~(ICANON | ECHO);
-        tcsetattr(STDIN_FILENO, TCSANOW, &t_new);
+        tcsetattr(termDescriptor, TCSANOW, &t_new);
 
-        ch = getchar();
+        ssize_t size = read(termDescriptor, &ch, sizeof(ch));
 
-        tcsetattr(STDIN_FILENO, TCSANOW, &t_old);
-        return ch;
+        tcsetattr(termDescriptor, TCSANOW, &t_old);
+
+        if (size == 0) {
+            return -1;
+        } else {
+            return ch;
+        }
 }
 */
 import "C"
 
-func getch() byte {
-	return byte(C.getch())
+func getch(termDescriptor int) byte {
+	return byte(C.getch(C.int(termDescriptor)))
 }

--- a/go/vendor/github.com/keybase/gopass/nix.go
+++ b/go/vendor/github.com/keybase/gopass/nix.go
@@ -8,15 +8,15 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-func getch() byte {
-	if oldState, err := terminal.MakeRaw(0); err != nil {
+func getch(termDescriptor int) byte {
+	if oldState, err := terminal.MakeRaw(termDescriptor); err != nil {
 		panic(err)
 	} else {
-		defer terminal.Restore(0, oldState)
+		defer terminal.Restore(termDescriptor, oldState)
 	}
 
 	var buf [1]byte
-	if n, err := syscall.Read(0, buf[:]); n == 0 || err != nil {
+	if n, err := syscall.Read(termDescriptor, buf[:]); n == 0 || err != nil {
 		panic(err)
 	}
 	return buf[0]

--- a/go/vendor/github.com/keybase/gopass/pass.go
+++ b/go/vendor/github.com/keybase/gopass/pass.go
@@ -10,7 +10,7 @@ var ErrInterrupted = errors.New("Interrupted")
 // getPasswd returns the input read from terminal.
 // If masked is true, typing will be matched by asterisks on the screen.
 // Otherwise, typing will echo nothing.
-func getPasswd(masked bool) ([]byte, error) {
+func getPasswd(termDescriptor int, masked bool) ([]byte, error) {
 	var pass, bs, mask []byte
 	if masked {
 		bs = []byte("\b \b")
@@ -19,7 +19,7 @@ func getPasswd(masked bool) ([]byte, error) {
 
 	var err error
 	for {
-		if v := getch(); v == 127 || v == 8 {
+		if v := getch(termDescriptor); v == 127 || v == 8 {
 			if l := len(pass); l > 0 {
 				pass = pass[:l-1]
 				os.Stdout.Write(bs)
@@ -43,12 +43,12 @@ func getPasswd(masked bool) ([]byte, error) {
 
 // GetPasswd returns the password read from the terminal without echoing input.
 // The returned byte array does not include end-of-line characters.
-func GetPasswd() ([]byte, error) {
-	return getPasswd(false)
+func GetPasswd(termDescriptor int) ([]byte, error) {
+	return getPasswd(termDescriptor, false)
 }
 
 // GetPasswdMasked returns the password read from the terminal, echoing asterisks.
 // The returned byte array does not include end-of-line characters.
-func GetPasswdMasked() ([]byte, error) {
-	return getPasswd(true)
+func GetPasswdMasked(termDescriptor int) ([]byte, error) {
+	return getPasswd(termDescriptor, true)
 }

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -179,8 +179,8 @@
 		},
 		{
 			"path": "github.com/keybase/gopass",
-			"revision": "af52fa39b72c0515bd730d2edbfd3d842253dc17",
-			"revisionTime": "2015-06-04T16:15:13-05:00"
+			"revision": "8cb3611ab4d378cb4ff58ed723a4ea0557f81adb",
+			"revisionTime": "2016-01-05T18:46:37-05:00"
 		},
 		{
 			"path": "github.com/keybase/keybase-test-vectors/go",


### PR DESCRIPTION
https://github.com/keybase/keybase-issues/issues/1712

This PR imports changes for Linux, BSD, and Windows. When I test it on Linux, it fixes the panic from the issue above. On Windows, it builds, but I don't know what the equivalent of `unset DISPLAY` would be. On BSD, it builds, but password entry seems to be broken both before and after this change, both with and without `DISPLAY` set (but in different ways). Not sure how much time we want to spend on that one.