### PR TITLE
Fix retrack

### DIFF
--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -155,7 +155,7 @@ function trackUser (username: string, state: {tracker: RootTrackerState}): Promi
     bypassConfirm: false
   }
 
-  if (trackerState && trackToken && shouldFollow) {
+  if (trackerState && trackToken && (!(trackerState == Constants.normal) || shouldFollow)) {
     return new Promise((resolve, reject) => {
       engine.rpc('track.trackWithToken', {trackToken, options}, {}, (err, response) => {
         if (err) {

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -155,7 +155,7 @@ function trackUser (username: string, state: {tracker: RootTrackerState}): Promi
     bypassConfirm: false
   }
 
-  if (trackerState && trackToken && (!(trackerState == Constants.normal) || shouldFollow)) {
+  if (trackerState && trackToken && trackerState !== Constants.normal || shouldFollow) {
     return new Promise((resolve, reject) => {
       engine.rpc('track.trackWithToken', {trackToken, options}, {}, (err, response) => {
         if (err) {


### PR DESCRIPTION
@keybase/react-hackers

The Retrack button calls trackUser() immediately, which checks `trackerState && trackToken && shouldFollow` when deciding whether to perform a track.

`shouldFollow` is set by the Track checkbox that we show under trackerState == normal.  So in the Retrack/Untrack case, it's not true because it was never shown, and so we did nothing when you try to Retrack.

This PR fixes Retrack by only testing shouldFollow if we're showing a "normal" trackerState.  If we're showing a warning/error state, we don't need to test shouldFollow.