### PR TITLE
implement the sender secretbox

### DIFF
--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Preserve external log message order (PR: keybase/client#1641)
 - SaltPack: implement sign/verify commands (PR: keybase/client#1635)
 - SaltPack: implement sign/verify package (PRs: keybase/client#1596, keybase/client#1612, keybase/client#1614)
+- SaltPack: implement the sender secretbox (PR: keybase/client#1645)
 - Fix merkle tree path mismatch bug (PR: keybase/client#1621)
 - encoding: Speed up B62 decoder (PRs: keybase/client#1644, keybase/client#1640)
 

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -160,9 +160,9 @@ func (ds *decryptStream) tryVisibleReceivers(hdr *EncryptionHeader, ephemeralKey
 		return nil, nil, nil, -1, err
 	}
 
-	payloadKey := symmetricKeyFromSlice(payloadKeySlice)
-	if payloadKey == nil {
-		return nil, nil, nil, -1, ErrBadPayloadKey
+	payloadKey, err := symmetricKeyFromSlice(payloadKeySlice)
+	if err != nil {
+		return nil, nil, nil, -1, err
 	}
 
 	return sk, shared, payloadKey, orig, err
@@ -187,9 +187,9 @@ func (ds *decryptStream) tryHiddenReceivers(hdr *EncryptionHeader, ephemeralKey 
 				if err != nil {
 					continue
 				}
-				payloadKey := symmetricKeyFromSlice(payloadKeySlice)
-				if payloadKey == nil {
-					return nil, nil, nil, -1, ErrBadPayloadKey
+				payloadKey, err := symmetricKeyFromSlice(payloadKeySlice)
+				if err != nil {
+					return nil, nil, nil, -1, err
 				}
 				return secretKey, shared, payloadKey, i, nil
 			}
@@ -235,9 +235,9 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 	if !ok {
 		return ErrBadSenderKeySecretbox
 	}
-	ds.senderKey = rawBoxKeyFromSlice(senderKeySlice)
-	if ds.senderKey == nil {
-		return ErrBadSenderKey
+	ds.senderKey, err = rawBoxKeyFromSlice(senderKeySlice)
+	if err != nil {
+		return err
 	}
 
 	// Lookup the sender's public key in our keyring, and import

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -1126,9 +1126,9 @@ func TestCorruptEmpheralKey(t *testing.T) {
 
 func TestCiphertextSwapKeys(t *testing.T) {
 	receivers := []BoxPublicKey{
-		newHiddenBoxKeyNoInsert(t).GetPublicKey(),
-		newHiddenBoxKey(t).GetPublicKey(),
-		newHiddenBoxKeyNoInsert(t).GetPublicKey(),
+		newBoxKeyNoInsert(t).GetPublicKey(),
+		newBoxKey(t).GetPublicKey(),
+		newBoxKeyNoInsert(t).GetPublicKey(),
 	}
 	plaintext := randomMsg(t, 1024*3)
 	teo := testEncryptionOptions{

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -702,15 +702,19 @@ func TestCorruptPayloadKeyPlaintext(t *testing.T) {
 		t.Fatalf("Got wrong error; wanted 'Bad Symmetric Key' but got %v", err)
 	}
 
-	// Finally, do the above test again with a hidden receiver.
+	// Finally, do the above test again with a hidden receiver. The default
+	// testing keyring is not iterable, so we need to make a new one.
+	iterableKeyring := newKeyring().makeIterable()
+	sender = newHiddenBoxKeyNoInsert(t)
+	iterableKeyring.insert(sender)
 	receivers = []BoxPublicKey{
-		newHiddenBoxKey(t).GetPublicKey(),
+		sender.GetPublicKey(),
 	}
 	ciphertext, err = testSeal(msg, sender, receivers, teo)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = Open(ciphertext, kr)
+	_, _, err = Open(ciphertext, iterableKeyring)
 	if err != ErrBadSymmetricKey {
 		t.Fatalf("Got wrong error; wanted 'Bad Symmetric Key' but got %v", err)
 	}

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -606,12 +606,12 @@ func TestCorruptHeaderNonceR5(t *testing.T) {
 	}
 }
 
-func TestCorruptReceiverKeysCiphertextR5(t *testing.T) {
+func TestCorruptPayloadKeyBoxR5(t *testing.T) {
 	msg := randomMsg(t, 129)
 	teo := testEncryptionOptions{
-		corruptReceiverKeysCiphertext: func(rkc *receiverKeysCiphertexts, rid int) {
+		corruptReceiverKeys: func(keys *receiverKeys, rid int) {
 			if rid == 5 {
-				rkc.Keys[35] ^= 1
+				keys.PayloadKeyBox[35] ^= 1
 			}
 		},
 	}
@@ -638,9 +638,9 @@ func TestCorruptReceiverKeysCiphertextR5(t *testing.T) {
 	// If someone else's encryption was tampered with, we don't care and
 	// shouldn't get an error.
 	teo = testEncryptionOptions{
-		corruptReceiverKeysCiphertext: func(rkc *receiverKeysCiphertexts, rid int) {
+		corruptReceiverKeys: func(keys *receiverKeys, rid int) {
 			if rid != 5 {
-				rkc.Keys[35] ^= 1
+				keys.PayloadKeyBox[35] ^= 1
 			}
 		},
 	}
@@ -654,17 +654,14 @@ func TestCorruptReceiverKeysCiphertextR5(t *testing.T) {
 	}
 }
 
-// TestCorruptRewceiverKeys tests what happens if the encryptor messes up in
-// formulating the **plaintext** input of the encrypted session keys.  We try
-// fiddling all of the keys below, in the case of multiple receivers.
-func TestCorruptReceiverKeysPlaintext(t *testing.T) {
+func TestCorruptPayloadKeyPlaintext(t *testing.T) {
 	msg := randomMsg(t, 129)
 
-	// First try to supply a bogus group ID that's out of bounds.
+	// Corrupt the payload key.
 	teo := testEncryptionOptions{
-		corruptReceiverKeysPlaintext: func(rkp *receiverKeysPlaintext, rid int) {
+		corruptPayloadKey: func(pk []byte, rid int) {
 			if rid == 2 {
-				rkp.Sender[3] ^= 1
+				pk[3] ^= 1
 			}
 		},
 	}
@@ -681,41 +678,48 @@ func TestCorruptReceiverKeysPlaintext(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// If we've corrupted the sender key, the first thing that will fail is the
-	// Tag check for this receiver on packet #1.
+	// If we've corrupted the payload key, the first thing that will fail is
+	// opening the sender secretbox.
 	_, _, err = Open(ciphertext, kr)
-	if ebt, ok := err.(ErrBadTag); !ok || int(ebt) != 1 {
-		t.Fatalf("Got wrong error; wanted %v but got %v", ErrNoSenderKey, ErrBadTag(1))
+	if err != ErrBadSenderKeySecretbox {
+		t.Fatalf("Got wrong error; wanted %v but got %v", ErrNoSenderKey, ErrBadSenderKeySecretbox)
 	}
+}
 
-	// Finally let's corrupt the session key
-	teo = testEncryptionOptions{
-		corruptReceiverKeysPlaintext: func(rkp *receiverKeysPlaintext, rid int) {
-			if rid == 2 {
-				sk := make([]byte, len(rkp.SessionKey))
-				copy(sk, rkp.SessionKey)
-				sk[3] ^= 1
-				rkp.SessionKey = sk
-			}
+func TestCorruptSenderSecretboxPlaintext(t *testing.T) {
+	msg := randomMsg(t, 129)
+
+	// First try flipping a bit. This should break the first payload packet.
+	teo := testEncryptionOptions{
+		corruptSenderKeyPlaintext: func(pk *[]byte) {
+			(*pk)[3] ^= 1
 		},
 	}
-	ciphertext, err = testSeal(msg, sender, receivers, teo)
+	sender := newBoxKey(t)
+	receivers := []BoxPublicKey{
+		newBoxKeyNoInsert(t).GetPublicKey(),
+		newBoxKeyNoInsert(t).GetPublicKey(),
+		newBoxKey(t).GetPublicKey(),
+		newBoxKeyNoInsert(t).GetPublicKey(),
+	}
+	ciphertext, err := testSeal(msg, sender, receivers, teo)
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, _, err = Open(ciphertext, kr)
-	if mm, ok := err.(ErrBadCiphertext); !ok {
-		t.Fatalf("Got wrong error; wanted 'Bad Ciphertext' but got %v", err)
+	if mm, ok := err.(ErrBadTag); !ok {
+		t.Fatalf("Got wrong error; wanted 'Bad Tag' but got %v", err)
 	} else if int(mm) != 1 {
 		t.Fatalf("Wanted a failure in packet %d but got %d", 1, mm)
 	}
 
-	// Test Bad Sender Key
+	// Also try truncating the sender key. This should hit the bad length
+	// check.
 	teo = testEncryptionOptions{
-		corruptReceiverKeysPlaintext: func(rkp *receiverKeysPlaintext, rid int) {
-			if rid == 2 {
-				rkp.Sender = rkp.Sender[0 : len(rkp.Sender)-1]
-			}
+		corruptSenderKeyPlaintext: func(pk *[]byte) {
+			var shortKey [31]byte
+			copy(shortKey[:], *pk)
+			*pk = shortKey[:]
 		},
 	}
 	ciphertext, err = testSeal(msg, sender, receivers, teo)
@@ -724,7 +728,32 @@ func TestCorruptReceiverKeysPlaintext(t *testing.T) {
 	}
 	_, _, err = Open(ciphertext, kr)
 	if err != ErrBadSenderKey {
-		t.Fatalf("Bad error: wanted %v but got %v", ErrBadSenderKey, err)
+		t.Fatalf("Got wrong error; wanted 'Bad Sender Key' but got %v", err)
+	}
+}
+
+func TestCorruptSenderSecretboxCiphertext(t *testing.T) {
+	msg := randomMsg(t, 129)
+
+	teo := testEncryptionOptions{
+		corruptSenderKeyCiphertext: func(pk []byte) {
+			pk[3] ^= 1
+		},
+	}
+	sender := newBoxKey(t)
+	receivers := []BoxPublicKey{
+		newBoxKeyNoInsert(t).GetPublicKey(),
+		newBoxKeyNoInsert(t).GetPublicKey(),
+		newBoxKey(t).GetPublicKey(),
+		newBoxKeyNoInsert(t).GetPublicKey(),
+	}
+	ciphertext, err := testSeal(msg, sender, receivers, teo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = Open(ciphertext, kr)
+	if err != ErrBadSenderKeySecretbox {
+		t.Fatalf("Got wrong error; wanted 'Bad Sender Key Secretbox' but got %v", err)
 	}
 }
 
@@ -887,23 +916,6 @@ func TestCorruptHeader(t *testing.T) {
 		t.Fatalf("got wrong received in error message: %d", ebv.received)
 	}
 
-	// Corrupt Plaintext Keys after packing
-	teo = testEncryptionOptions{
-		blockSize: 1024,
-		corruptReceiverKeysPlaintextPacked: func(b []byte, rid int) {
-			b[0] = 0xff
-			b[1] = 0xff
-		},
-	}
-	ciphertext, err = testSeal(msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, _, err = Open(ciphertext, kr)
-	if err == nil || err.Error() != "only encoded map or array can be decoded into a struct" {
-		t.Fatalf("wanted a msgpack decode error")
-	}
-
 	// Corrupt Header after packing
 	teo = testEncryptionOptions{
 		blockSize: 1024,
@@ -1043,7 +1055,7 @@ func TestCorruptEmpheralKey(t *testing.T) {
 	plaintext := randomMsg(t, 1024*3)
 	teo := testEncryptionOptions{
 		corruptHeader: func(eh *EncryptionHeader) {
-			eh.Sender = eh.Sender[0 : len(eh.Sender)-1]
+			eh.Ephemeral = eh.Ephemeral[0 : len(eh.Ephemeral)-1]
 		},
 	}
 	ciphertext, err := testSeal(plaintext, nil, receivers, teo)
@@ -1065,7 +1077,7 @@ func TestCiphertextSwapKeys(t *testing.T) {
 	plaintext := randomMsg(t, 1024*3)
 	teo := testEncryptionOptions{
 		corruptHeader: func(h *EncryptionHeader) {
-			h.Receivers[1].Keys, h.Receivers[0].Keys = h.Receivers[0].Keys, h.Receivers[1].Keys
+			h.Receivers[1].PayloadKeyBox, h.Receivers[0].PayloadKeyBox = h.Receivers[0].PayloadKeyBox, h.Receivers[1].PayloadKeyBox
 		},
 	}
 	ciphertext, err := testSeal(plaintext, nil, receivers, teo)
@@ -1086,8 +1098,8 @@ func TestEmptyReceiverKID(t *testing.T) {
 	}
 	plaintext := randomMsg(t, 1024*3)
 	teo := testEncryptionOptions{
-		corruptReceiverKeysCiphertext: func(rkc *receiverKeysCiphertexts, rid int) {
-			rkc.ReceiverKID = []byte{}
+		corruptReceiverKeys: func(keys *receiverKeys, rid int) {
+			keys.ReceiverKID = []byte{}
 		},
 	}
 	ciphertext, err := testSeal(plaintext, nil, receivers, teo)

--- a/go/saltpack/errors.go
+++ b/go/saltpack/errors.go
@@ -45,6 +45,10 @@ var (
 	// open.
 	ErrBadSenderKeySecretbox = errors.New("sender secretbox failed to open")
 
+	// ErrBadPayloadKey is returned if a key with the wrong number of bytes
+	// is discovered in the encryption header.
+	ErrBadPayloadKey = errors.New("bad payload key; must be 32 bytes")
+
 	// ErrBadSenderKey is returned if a key with the wrong number of bytes
 	// is discovered in the encryption header.
 	ErrBadSenderKey = errors.New("bad sender key; must be 32 bytes")

--- a/go/saltpack/errors.go
+++ b/go/saltpack/errors.go
@@ -45,13 +45,13 @@ var (
 	// open.
 	ErrBadSenderKeySecretbox = errors.New("sender secretbox failed to open")
 
-	// ErrBadPayloadKey is returned if a key with the wrong number of bytes
+	// ErrBadSymmetricKey is returned if a key with the wrong number of bytes
 	// is discovered in the encryption header.
-	ErrBadPayloadKey = errors.New("bad payload key; must be 32 bytes")
+	ErrBadSymmetricKey = errors.New("bad symmetric key; must be 32 bytes")
 
-	// ErrBadSenderKey is returned if a key with the wrong number of bytes
+	// ErrBadBoxKey is returned if a key with the wrong number of bytes
 	// is discovered in the encryption header.
-	ErrBadSenderKey = errors.New("bad sender key; must be 32 bytes")
+	ErrBadBoxKey = errors.New("bad box key; must be 32 bytes")
 
 	// ErrBadLookup is when the user-provided key lookup gives a bad value
 	ErrBadLookup = errors.New("bad key lookup")

--- a/go/saltpack/errors.go
+++ b/go/saltpack/errors.go
@@ -41,6 +41,10 @@ var (
 	// ErrBadReceivers shows up when you pass a bad receivers vector
 	ErrBadReceivers = errors.New("bad receivers argument")
 
+	// ErrBadSenderKeySecretbox is returned if the sender secretbox fails to
+	// open.
+	ErrBadSenderKeySecretbox = errors.New("sender secretbox failed to open")
+
 	// ErrBadSenderKey is returned if a key with the wrong number of bytes
 	// is discovered in the encryption header.
 	ErrBadSenderKey = errors.New("bad sender key; must be 32 bytes")

--- a/go/saltpack/key.go
+++ b/go/saltpack/key.go
@@ -8,12 +8,30 @@ import (
 )
 
 // RawBoxKey is the raw byte-representation of what a box key should
-// look like --- a static 32-byte buffer
+// look like, a static 32-byte buffer. Used for NaCl Box.
 type RawBoxKey [32]byte
 
+func rawBoxKeyFromSlice(slice []byte) *RawBoxKey {
+	var result RawBoxKey
+	if len(slice) != len(result) {
+		return nil
+	}
+	copy(result[:], slice)
+	return &result
+}
+
 // SymmetricKey is a template for a symmetric key, a 32-byte static
-// buffer.  Used for both NaCl SecretBox.
+// buffer. Used for NaCl SecretBox.
 type SymmetricKey [32]byte
+
+func symmetricKeyFromSlice(slice []byte) *SymmetricKey {
+	var result SymmetricKey
+	if len(slice) != len(result) {
+		return nil
+	}
+	copy(result[:], slice)
+	return &result
+}
 
 // KIDExtractor key types can output a key ID corresponding to the
 // key.

--- a/go/saltpack/key.go
+++ b/go/saltpack/key.go
@@ -11,26 +11,26 @@ import (
 // look like, a static 32-byte buffer. Used for NaCl Box.
 type RawBoxKey [32]byte
 
-func rawBoxKeyFromSlice(slice []byte) *RawBoxKey {
+func rawBoxKeyFromSlice(slice []byte) (*RawBoxKey, error) {
 	var result RawBoxKey
 	if len(slice) != len(result) {
-		return nil
+		return nil, ErrBadBoxKey
 	}
 	copy(result[:], slice)
-	return &result
+	return &result, nil
 }
 
 // SymmetricKey is a template for a symmetric key, a 32-byte static
 // buffer. Used for NaCl SecretBox.
 type SymmetricKey [32]byte
 
-func symmetricKeyFromSlice(slice []byte) *SymmetricKey {
+func symmetricKeyFromSlice(slice []byte) (*SymmetricKey, error) {
 	var result SymmetricKey
 	if len(slice) != len(result) {
-		return nil
+		return nil, ErrBadSymmetricKey
 	}
 	copy(result[:], slice)
-	return &result
+	return &result, nil
 }
 
 // KIDExtractor key types can output a key ID corresponding to the

--- a/go/saltpack/packets.go
+++ b/go/saltpack/packets.go
@@ -41,13 +41,6 @@ type EncryptionBlock struct {
 	seqno              PacketSeqno
 }
 
-func verifyRawKey(k []byte) error {
-	if len(k) != len(RawBoxKey{}) {
-		return ErrBadSenderKey
-	}
-	return nil
-}
-
 func (h *EncryptionHeader) validate() error {
 	if h.Type != MessageTypeEncryption {
 		return ErrWrongMessageType{MessageTypeEncryption, h.Type}

--- a/go/saltpack/packets.go
+++ b/go/saltpack/packets.go
@@ -5,16 +5,10 @@ package saltpack
 
 import "fmt"
 
-type receiverKeysPlaintext struct {
-	_struct    bool   `codec:",toarray"`
-	Sender     []byte `codec:"sender"`
-	SessionKey []byte `codec:"session_key"`
-}
-
-type receiverKeysCiphertexts struct {
-	_struct     bool   `codec:",toarray"`
-	ReceiverKID []byte `codec:"receiver_key_id"`
-	Keys        []byte `codec:"keys"`
+type receiverKeys struct {
+	_struct       bool   `codec:",toarray"`
+	ReceiverKID   []byte `codec:"receiver_key_id"`
+	PayloadKeyBox []byte `codec:"payloadkey"`
 }
 
 // Version is a major.minor pair that shows the version of the whole file
@@ -28,13 +22,14 @@ type Version struct {
 // It contains the encryptions of the session keys, and various
 // message metadata.
 type EncryptionHeader struct {
-	_struct    bool                      `codec:",toarray"`
-	FormatName string                    `codec:"format_name"`
-	Version    Version                   `codec:"vers"`
-	Type       MessageType               `codec:"type"`
-	Sender     []byte                    `codec:"sender"`
-	Receivers  []receiverKeysCiphertexts `codec:"rcvrs"`
-	seqno      PacketSeqno
+	_struct         bool           `codec:",toarray"`
+	FormatName      string         `codec:"format_name"`
+	Version         Version        `codec:"vers"`
+	Type            MessageType    `codec:"type"`
+	Ephemeral       []byte         `codec:"ephemeral"`
+	SenderSecretbox []byte         `codec:"sendersecretbox"`
+	Receivers       []receiverKeys `codec:"rcvrs"`
+	seqno           PacketSeqno
 }
 
 // EncryptionBlock contains a block of encrypted data. It contains

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -1,6 +1,10 @@
 # SaltPack Binary Encryption Format
 
 **Changelog**
+- 5 Jan 2015
+  - Move the sender's public key out of the recipient box and into a separate
+    secretbox with its own field in the header. That saves us the overhead of
+    encrypting it for every recipient.
 - 29 Dec 2015
   - We had incorrectly assumed it was hard for other recipients to find a
     Poly1305 collision. Use a hash instead, where we need preimage resistance.
@@ -60,7 +64,7 @@ or twenty recipients with one key each.
 Finally, the scheme accommodates anonymous receivers and anonymous senders. Thus,
 each message needs an ephemeral sender public key, used only for this one message,
 to hide the sender's true identity. Some implementations of the scheme can
-choose to reveal the keys of the receivers to make user-friendlier errors
+choose to reveal the keys of the receivers to make user-friendlier error
 messages on decryption failures (e.g., "Can't decrypt this message on your
 phone, but try your laptop.")  If the sender wants to decrypt the message
 at a later date, she simply adds her public keys to the list of recipients.
@@ -80,6 +84,7 @@ The header packet is a MessagePack list with these contents:
     version,
     mode,
     ephemeral public key,
+    sender public key secretbox,
     recipients list,
 ]
 ```
@@ -89,52 +94,45 @@ The header packet is a MessagePack list with these contents:
   `[1, 0]`.
 - The **mode** is the number 0, for encryption. (1 and 2 are attached and
   detached signing.)
-- The **ephemeral public key** is an ephemeral NaCl public encryption key, 32
-  bytes. The ephemeral keypair is generated at random by the sender and only
-  used for one message.
-- The **recipients list** contains a recipient pair for each recipient key.
+- The **ephemeral public key** is a NaCl public encryption key, 32 bytes. The
+  ephemeral keypair is generated at random by the sender and only used for one
+  message.
+- The **sender public key secretbox** is a NaCl secretbox containing the
+  sender's long-term public key, encrypted with the **payload key**.
+- The **recipients list** contains a recipient pair for each recipient key,
+  including an encrypted copy of the **payload key**. See below.
 
 A recipient pair is a two-element list:
 
 ```
 [
     recipient public key,
-    recipient box,
+    payload key box,
 ]
 ```
 
 - The **recipient public key** is the recipient's long-term NaCl public
   encryption key. This field may be null, when the recipients are anonymous.
-- The **recipient box** is a NaCl box encrypted with the recipient's public key
-  and the ephemeral private key.
+- The **payload key box** is a NaCl box encrypted with the recipient's public
+  key and the ephemeral private key. It contains the **payload key**, a 32-byte
+  NaCl symmetric encryption key used to encrypt the **sender public key
+  secretbox** above that the **payload secretbox** in each payload packet
+  below. The sender generates a random payload key for each message.
 
-The **recipient box** contains another two-element MessagePack list:
+Recipients should compute the ephemeral shared secret and then try to open each
+of the **payload key boxes**. In the NaCl interface, computing a shared secret
+is done with the [`crypto_box_beforenm`](http://nacl.cr.yp.to/box.html)
+function, which does a Curve25519 multiplication and an HSalsa20 key
+derivation, to avoid repeating those steps in
+[`crypto_box_open`](http://nacl.cr.yp.to/box.html). After obtaining the
+**payload key**, clients open the **sender public key secretbox** and obtain
+the sender's public key. Both keys are used to decrypt payload packets below.
 
-```
-[
-    sender public key,
-    message key,
-]
-```
-
-- The **sender public key** is the sender's long-term NaCl public encryption
-  key.
-- The **message key** is a NaCl symmetric key used to encrypt the payload
-  packets. This key is generated at random by the sender and only used for one
-  message.
-
-Putting the sender's key in the **recipient box** allows Alice to stay
-anonymous to Mallory. If Alice wants to be anonymous to Bob as well, she can
-reuse the ephemeral key as her sender key. When the ephemeral key and the
-sender key are the same, clients may indicate that a message is "intentionally
-anonymous" as opposed to "from an unknown sender".
-
-When decrypting, clients should compute the ephemeral shared secret and then
-try to open each of the recipient boxes. In the NaCl interface, computing the
-shared secret is done with the
-[`crypto_box_beforenm`](http://nacl.cr.yp.to/box.html) function, which does a
-Curve25519 multiplication and an HSalsa20 key derivation, to avoid repeating
-those steps in [`crypto_box_open`](http://nacl.cr.yp.to/box.html).
+Encrypting the sender's long-term public key allows Alice to stay anonymous to
+Mallory. If Alice wants to be anonymous to Bob as well, she can reuse the
+ephemeral key as her sender key. When the ephemeral key and the sender key are
+the same, clients may indicate that a message is "intentionally anonymous" as
+opposed to "from an unknown sender".
 
 Note that when parsing lists in general, if a list is longer than expected,
 clients should allow the extra fields and ignore them. That flexibility allows
@@ -153,10 +151,10 @@ A payload packet is a MessagePack list with these contents:
 - The **authenticators list** contains 16-byte Poly1305 tags, one for each
   recipient, which authenticate the **payload secretbox**.
 - The **payload secretbox** is a NaCl secretbox containing a chunk of the
-  plaintext bytes, max size 1 MB. It's encrypted with the symmetric message
-  key. See [Nonces](#nonces) below.
+  plaintext bytes, max size 1 MB. It's encrypted with the **payload key**. See
+  [Nonces](#nonces) below.
 
-If Mallory doesn't have the **message key**, she can't modify the **payload
+If Mallory doesn't have the **payload key**, she can't modify the **payload
 secretbox** without breaking authentication. However, if Mallory is one of the
 recipients, then she will have the key, and she could modify the payload. The
 **authenticators list** is there to prevent this attack, protecting the
@@ -165,8 +163,8 @@ recipients from each other.
 We compute each recipient's authenticator in three steps:
 
 - Compute the SHA512 of the **payload secretbox**.
-- Encrypt that hash in a NaCl box, using the sender's and the recipient's
-  long-term keys. See [Nonces](#nonces) below.
+- Encrypt that hash in a NaCl box, using the sender and recipient's long-term
+  keys. See [Nonces](#nonces) below.
 - The authenticator is the first 16 bytes of that box.
 
 The index of each authenticator in the list corresponds to the index of that

--- a/go/saltpack/tweakable_encryptor_test.go
+++ b/go/saltpack/tweakable_encryptor_test.go
@@ -11,16 +11,17 @@ import (
 )
 
 type testEncryptionOptions struct {
-	blockSize                          int
-	skipFooter                         bool
-	corruptEncryptionBlock             func(bl *EncryptionBlock, ebn encryptionBlockNumber)
-	corruptPayloadNonce                func(n *Nonce, ebn encryptionBlockNumber) *Nonce
-	corruptKeysNonce                   func(n *Nonce, rid int) *Nonce
-	corruptReceiverKeysPlaintext       func(rk *receiverKeysPlaintext, rid int)
-	corruptReceiverKeysPlaintextPacked func(b []byte, rid int)
-	corruptReceiverKeysCiphertext      func(rk *receiverKeysCiphertexts, rid int)
-	corruptHeader                      func(eh *EncryptionHeader)
-	corruptHeaderPacked                func(b []byte)
+	blockSize                  int
+	skipFooter                 bool
+	corruptEncryptionBlock     func(bl *EncryptionBlock, ebn encryptionBlockNumber)
+	corruptPayloadNonce        func(n *Nonce, ebn encryptionBlockNumber) *Nonce
+	corruptKeysNonce           func(n *Nonce, rid int) *Nonce
+	corruptPayloadKey          func(pk []byte, rid int)
+	corruptReceiverKeys        func(rk *receiverKeys, rid int)
+	corruptSenderKeyPlaintext  func(pk *[]byte)
+	corruptSenderKeyCiphertext func(pk []byte)
+	corruptHeader              func(eh *EncryptionHeader)
+	corruptHeaderPacked        func(b []byte)
 }
 
 func (eo testEncryptionOptions) getBlockSize() int {
@@ -34,7 +35,7 @@ type testEncryptStream struct {
 	output     io.Writer
 	encoder    encoder
 	header     *EncryptionHeader
-	sessionKey SymmetricKey
+	payloadKey SymmetricKey
 	buffer     bytes.Buffer
 	inblock    []byte
 	options    testEncryptionOptions
@@ -101,7 +102,7 @@ func (pes *testEncryptStream) encryptBytes(b []byte) error {
 		nonce = pes.options.corruptPayloadNonce(nonce, pes.numBlocks)
 	}
 
-	ciphertext := secretbox.Seal([]byte{}, b, (*[24]byte)(nonce), (*[32]byte)(&pes.sessionKey))
+	ciphertext := secretbox.Seal([]byte{}, b, (*[24]byte)(nonce), (*[32]byte)(&pes.payloadKey))
 	hash := sha512.Sum512(ciphertext)
 
 	block := EncryptionBlock{
@@ -145,38 +146,32 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey
 		FormatName: SaltPackFormatName,
 		Version:    SaltPackCurrentVersion,
 		Type:       MessageTypeEncryption,
-		Sender:     ephemeralKey.GetPublicKey().ToKID(),
-		Receivers:  make([]receiverKeysCiphertexts, 0, len(receivers)),
+		Ephemeral:  ephemeralKey.GetPublicKey().ToKID(),
+		Receivers:  make([]receiverKeys, 0, len(receivers)),
 	}
 	pes.header = eh
-	if err := randomFill(pes.sessionKey[:]); err != nil {
+	if err := randomFill(pes.payloadKey[:]); err != nil {
 		return err
 	}
 
 	pes.nonce = NewNonceForEncryption(ephemeralKey.GetPublicKey())
 	nonce := pes.nonce.ForKeyBox()
 
+	var senderPlaintext [32]byte
+	copy(senderPlaintext[:], sender.GetPublicKey().ToKID())
+	senderPlaintextSlice := senderPlaintext[:]
+	if pes.options.corruptSenderKeyPlaintext != nil {
+		pes.options.corruptSenderKeyPlaintext(&senderPlaintextSlice)
+	}
+	eh.SenderSecretbox = secretbox.Seal([]byte{}, senderPlaintextSlice, (*[24]byte)(nonce), (*[32]byte)(&pes.payloadKey))
+	if pes.options.corruptSenderKeyCiphertext != nil {
+		pes.options.corruptSenderKeyCiphertext(eh.SenderSecretbox)
+	}
+
 	for rid, receiver := range receivers {
 
-		rkp := receiverKeysPlaintext{
-			Sender:     sender.GetPublicKey().ToKID(),
-			SessionKey: pes.sessionKey[:],
-		}
-
-		if pes.options.corruptReceiverKeysPlaintext != nil {
-			pes.options.corruptReceiverKeysPlaintext(&rkp, rid)
-		}
-
-		rkpPacked, err := encodeToBytes(rkp)
-		if err != nil {
-			return err
-		}
-		if pes.options.corruptReceiverKeysPlaintextPacked != nil {
-			pes.options.corruptReceiverKeysPlaintextPacked(rkpPacked, rid)
-		}
-
-		if err != nil {
-			return err
+		if pes.options.corruptPayloadKey != nil {
+			pes.options.corruptPayloadKey(pes.payloadKey[:], rid)
 		}
 
 		nonceTmp := nonce
@@ -184,21 +179,21 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey
 			nonceTmp = pes.options.corruptKeysNonce(nonceTmp, rid)
 		}
 
-		keys, err := ephemeralKey.Box(receiver, nonceTmp, rkpPacked)
+		payloadKeyBox, err := ephemeralKey.Box(receiver, nonceTmp, pes.payloadKey[:])
 		if err != nil {
 			return err
 		}
 
-		rkc := receiverKeysCiphertexts{
-			ReceiverKID: receiver.ToKID(),
-			Keys:        keys,
+		keys := receiverKeys{
+			ReceiverKID:   receiver.ToKID(),
+			PayloadKeyBox: payloadKeyBox,
 		}
 
-		if pes.options.corruptReceiverKeysCiphertext != nil {
-			pes.options.corruptReceiverKeysCiphertext(&rkc, rid)
+		if pes.options.corruptReceiverKeys != nil {
+			pes.options.corruptReceiverKeys(&keys, rid)
 		}
 
-		eh.Receivers = append(eh.Receivers, rkc)
+		eh.Receivers = append(eh.Receivers, keys)
 
 		var tagKey BoxPrecomputedSharedKey
 		if !senderAnon {

--- a/go/saltpack/tweakable_encryptor_test.go
+++ b/go/saltpack/tweakable_encryptor_test.go
@@ -186,8 +186,12 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey
 		}
 
 		keys := receiverKeys{
-			ReceiverKID:   receiver.ToKID(),
 			PayloadKeyBox: payloadKeyBox,
+		}
+
+		// Don't specify the receivers if this public key wants to hide
+		if !receiver.HideIdentity() {
+			keys.ReceiverKID = receiver.ToKID()
 		}
 
 		if pes.options.corruptReceiverKeys != nil {

--- a/go/saltpack/tweakable_encryptor_test.go
+++ b/go/saltpack/tweakable_encryptor_test.go
@@ -16,7 +16,7 @@ type testEncryptionOptions struct {
 	corruptEncryptionBlock     func(bl *EncryptionBlock, ebn encryptionBlockNumber)
 	corruptPayloadNonce        func(n *Nonce, ebn encryptionBlockNumber) *Nonce
 	corruptKeysNonce           func(n *Nonce, rid int) *Nonce
-	corruptPayloadKey          func(pk []byte, rid int)
+	corruptPayloadKey          func(pk *[]byte, rid int)
 	corruptReceiverKeys        func(rk *receiverKeys, rid int)
 	corruptSenderKeyPlaintext  func(pk *[]byte)
 	corruptSenderKeyCiphertext func(pk []byte)
@@ -170,8 +170,9 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey
 
 	for rid, receiver := range receivers {
 
+		payloadKeySlice := pes.payloadKey[:]
 		if pes.options.corruptPayloadKey != nil {
-			pes.options.corruptPayloadKey(pes.payloadKey[:], rid)
+			pes.options.corruptPayloadKey(&payloadKeySlice, rid)
 		}
 
 		nonceTmp := nonce
@@ -179,7 +180,7 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey
 			nonceTmp = pes.options.corruptKeysNonce(nonceTmp, rid)
 		}
 
-		payloadKeyBox, err := ephemeralKey.Box(receiver, nonceTmp, pes.payloadKey[:])
+		payloadKeyBox, err := ephemeralKey.Box(receiver, nonceTmp, payloadKeySlice)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
@maxtaco 

This saves us 37 bytes per-recipient-after-the-first, (32 for the repeated sender key, and 5 more in overhead since we no longer encrypt a MessagePack structure), at cost of 48 bytes in the new encrypted sender field. In theory we could chop off another 16 by omitting the Poly1305 tag for the sender's key (because the payload will fail to decrypt if it's modified), but we're avoiding the lower-level NaCl functions. Not a big deal.