### PR TITLE
libkb: keep unlocked paper key in memory for rekeying purposes

### DIFF
--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -812,18 +812,14 @@ func (e *LoginProvision) getPaperKey(ctx *Context) (*keypair, error) {
 	if err != nil {
 		return nil, err
 	}
-	paperPhrase := libkb.NewPaperKeyPhrase(passphrase)
-	version, err := paperPhrase.Version()
+
+	paperPhrase, err := libkb.NewPaperKeyPhraseCheckVersion(e.G(), passphrase)
 	if err != nil {
 		return nil, err
 	}
-	if version != libkb.PaperKeyVersion {
-		e.G().Log.Debug("paper version mismatch: generated paper key version = %d, libkb version = %d", version, libkb.PaperKeyVersion)
-		return nil, libkb.KeyVersionError{}
-	}
 
 	bkarg := &PaperKeyGenArg{
-		Passphrase: libkb.NewPaperKeyPhrase(passphrase),
+		Passphrase: paperPhrase,
 		SkipPush:   true,
 	}
 	bkeng := NewPaperKeyGen(bkarg, e.G())
@@ -831,7 +827,14 @@ func (e *LoginProvision) getPaperKey(ctx *Context) (*keypair, error) {
 		return nil, err
 	}
 
-	return &keypair{sigKey: bkeng.SigKey(), encKey: bkeng.EncKey()}, nil
+	kp := &keypair{sigKey: bkeng.SigKey(), encKey: bkeng.EncKey()}
+	if err := e.G().LoginState().Account(func(a *libkb.Account) {
+		a.SetUnlockedPaperKey(kp.sigKey, kp.encKey)
+	}, "UnlockedPaperKey"); err != nil {
+		return nil, err
+	}
+
+	return kp, nil
 }
 
 func (e *LoginProvision) loadUserByKID(kid keybase1.KID) (*libkb.User, error) {

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -7,13 +7,14 @@ import (
 	"bytes"
 	"crypto/rand"
 	"fmt"
+	"github.com/jonboulle/clockwork"
+	"golang.org/x/net/context"
 	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
 	"testing"
-
-	"golang.org/x/net/context"
+	"time"
 
 	"github.com/keybase/client/go/kex2"
 	"github.com/keybase/client/go/libkb"
@@ -389,6 +390,10 @@ func TestProvisionPaper(t *testing.T) {
 
 	// redo SetupEngineTest to get a new home directory...should look like a new device.
 	tc2 := SetupEngineTest(t, "login")
+	fakeClock := clockwork.NewFakeClock()
+	tc2.G.Clock = fakeClock
+	// to pick up the new clock...
+	tc2.G.ResetLoginState()
 	defer tc2.Cleanup()
 
 	secUI := fu.NewSecretUI()
@@ -420,6 +425,24 @@ func TestProvisionPaper(t *testing.T) {
 	}
 	if provLoginUI.CalledGetEmailOrUsername != 0 {
 		t.Errorf("expected 0 calls to GetEmailOrUsername, got %d", provLoginUI.CalledGetEmailOrUsername)
+	}
+	var key libkb.GenericKey
+	tc2.G.LoginState().Account(func(a *libkb.Account) {
+		key = a.GetUnlockedPaperEncKey()
+	}, "GetUnlockedPaperEncKey")
+	if key == nil {
+		t.Errorf("Got a null paper encryption key")
+	}
+
+	wait := tc2.G.LoginState().GetTimerCompletionWaiter()
+	fakeClock.Advance(libkb.PaperKeyMemoryTimeout + 1*time.Minute)
+	wait()
+
+	tc2.G.LoginState().Account(func(a *libkb.Account) {
+		key = a.GetUnlockedPaperEncKey()
+	}, "GetUnlockedPaperEncKey")
+	if key != nil {
+		t.Errorf("Got a non-null paper encryption key after timeout")
 	}
 }
 

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -52,6 +52,8 @@ type Account struct {
 
 	paperSigKey *timedGenericKey // cached, unlocked paper signing key
 	paperEncKey *timedGenericKey // cached, unlocked paper encryption key
+
+	testPostCleanHook func() // for testing, call this hook after cleaning
 }
 
 func NewAccount(g *GlobalContext) *Account {
@@ -478,6 +480,10 @@ func (a *Account) ClearCachedSecretKeys() {
 	a.paperSigKey = nil
 }
 
+func (a *Account) SetTestPostCleanHook(f func()) {
+	a.testPostCleanHook = f
+}
+
 func (a *Account) clean() {
 	a.G().Log.Debug("Running Account::clean")
 	if a.paperEncKey != nil {
@@ -485,6 +491,9 @@ func (a *Account) clean() {
 	}
 	if a.paperSigKey != nil {
 		a.paperSigKey.clean()
+	}
+	if a.testPostCleanHook != nil {
+		a.testPostCleanHook()
 	}
 }
 

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -22,18 +22,18 @@ func newTimedGenericKey(g *GlobalContext, k GenericKey, w string) *timedGenericK
 	return &timedGenericKey{
 		Contextified: NewContextified(g),
 		key:          k,
-		atime:        g.Now(),
+		atime:        g.GetClock().Now(),
 		which:        w,
 	}
 }
 
 func (t *timedGenericKey) getKey() GenericKey {
-	t.atime = t.G().Now()
+	t.atime = t.G().GetClock().Now()
 	return t.key
 }
 
 func (t *timedGenericKey) clean() {
-	now := t.G().Now()
+	now := t.G().GetClock().Now()
 	if t.key != nil && (now.Sub(t.atime) > PaperKeyMemoryTimeout) {
 		t.G().Log.Debug("Cleaned out key %q at %s", t.which, now)
 		t.key = nil

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -8,7 +8,37 @@ import (
 	"fmt"
 	keybase1 "github.com/keybase/client/go/protocol"
 	triplesec "github.com/keybase/go-triplesec"
+	"time"
 )
+
+type timedGenericKey struct {
+	Contextified
+	key   GenericKey
+	which string
+	atime time.Time
+}
+
+func newTimedGenericKey(g *GlobalContext, k GenericKey, w string) *timedGenericKey {
+	return &timedGenericKey{
+		Contextified: NewContextified(g),
+		key:          k,
+		atime:        g.Now(),
+		which:        w,
+	}
+}
+
+func (t *timedGenericKey) getKey() GenericKey {
+	t.atime = t.G().Now()
+	return t.key
+}
+
+func (t *timedGenericKey) clean() {
+	now := t.G().Now()
+	if t.key != nil && (now.Sub(t.atime) > PaperKeyMemoryTimeout) {
+		t.G().Log.Debug("Cleaned out key %q at %s", t.which, now)
+		t.key = nil
+	}
+}
 
 type Account struct {
 	Contextified
@@ -19,6 +49,9 @@ type Account struct {
 	skbKeyring   *SKBKeyringFile
 	secSigKey    GenericKey // cached secret signing key
 	secEncKey    GenericKey // cache secret encryption key
+
+	paperSigKey *timedGenericKey // cached, unlocked paper signing key
+	paperEncKey *timedGenericKey // cached, unlocked paper encryption key
 }
 
 func NewAccount(g *GlobalContext) *Account {
@@ -417,10 +450,42 @@ func (a *Account) SetCachedSecretKey(ska SecretKeyArg, key GenericKey) error {
 	return fmt.Errorf("attempt to cache invalid key type: %d", ska.KeyType)
 }
 
+func (a *Account) SetUnlockedPaperKey(sig GenericKey, enc GenericKey) error {
+	a.paperSigKey = newTimedGenericKey(a.G(), sig, "paper signing key")
+	a.paperEncKey = newTimedGenericKey(a.G(), enc, "paper encryption key")
+	return nil
+}
+
+func (a *Account) GetUnlockedPaperSigKey() GenericKey {
+	if a.paperSigKey == nil {
+		return nil
+	}
+	return a.paperSigKey.getKey()
+}
+
+func (a *Account) GetUnlockedPaperEncKey() GenericKey {
+	if a.paperEncKey == nil {
+		return nil
+	}
+	return a.paperEncKey.getKey()
+}
+
 func (a *Account) ClearCachedSecretKeys() {
 	a.G().Log.Debug("clearing cached secret keys")
 	a.secSigKey = nil
 	a.secEncKey = nil
+	a.paperEncKey = nil
+	a.paperSigKey = nil
+}
+
+func (a *Account) clean() {
+	a.G().Log.Debug("Running Account::clean")
+	if a.paperEncKey != nil {
+		a.paperEncKey.clean()
+	}
+	if a.paperSigKey != nil {
+		a.paperSigKey.clean()
+	}
 }
 
 func (a *Account) ClearKeyring() {

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -97,6 +97,8 @@ const (
 	KeyExpireIn       = OneYearInSeconds * 16 // 16 years
 	SubkeyExpireIn    = OneYearInSeconds * 16 // 16 years
 	AuthExpireIn      = OneYearInSeconds      // 1 year
+
+	PaperKeyMemoryTimeout = time.Hour
 )
 
 // Status codes.  This list should match keybase/lib/constants.iced.

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -18,13 +18,14 @@ package libkb
 
 import (
 	"fmt"
+	"github.com/jonboulle/clockwork"
+	"github.com/keybase/client/go/logger"
+	keybase1 "github.com/keybase/client/go/protocol"
 	"io"
 	"os"
 	"runtime"
 	"sync"
-
-	"github.com/keybase/client/go/logger"
-	keybase1 "github.com/keybase/client/go/protocol"
+	"time"
 )
 
 type ShutdownHook func() error
@@ -63,12 +64,14 @@ type GlobalContext struct {
 	ProofCheckerFactory ProofCheckerFactory // Makes new ProofCheckers
 	ExitCode            keybase1.ExitCode   // Value to return to OS on Exit()
 	RateLimits          *RateLimits         // tracks the last time certain actions were taken
+	Clock               clockwork.Clock     // RealClock unless we're testing
 }
 
 func NewGlobalContext() *GlobalContext {
 	return &GlobalContext{
 		Log:                 logger.New("keybase", ErrorWriter()),
 		ProofCheckerFactory: defaultProofCheckerFactory,
+		Clock:               clockwork.NewRealClock(),
 	}
 }
 
@@ -120,6 +123,11 @@ func (g *GlobalContext) LoginState() *LoginState {
 	defer g.loginStateMu.RUnlock()
 
 	return g.loginState
+}
+
+// ResetLoginState is mainly used for testing...
+func (g *GlobalContext) ResetLoginState() {
+	g.createLoginStateLocked()
 }
 
 func (g *GlobalContext) Logout() error {
@@ -450,4 +458,18 @@ func (g *GlobalContext) GetRuntimeDir() string {
 
 func (g *GlobalContext) GetRunMode() RunMode {
 	return g.Env.GetRunMode()
+}
+
+func (g *GlobalContext) Now() time.Time {
+	if g.Clock == nil {
+		return time.Now()
+	}
+	return g.Clock.Now()
+}
+
+func (g *GlobalContext) After(d time.Duration) <-chan time.Time {
+	if g.Clock == nil {
+		return time.After(d)
+	}
+	return g.Clock.After(d)
 }

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"runtime"
 	"sync"
-	"time"
 )
 
 type ShutdownHook func() error
@@ -460,16 +459,9 @@ func (g *GlobalContext) GetRunMode() RunMode {
 	return g.Env.GetRunMode()
 }
 
-func (g *GlobalContext) Now() time.Time {
+func (g *GlobalContext) GetClock() clockwork.Clock {
 	if g.Clock == nil {
-		return time.Now()
+		return clockwork.NewRealClock()
 	}
-	return g.Clock.Now()
-}
-
-func (g *GlobalContext) After(d time.Duration) <-chan time.Time {
-	if g.Clock == nil {
-		return time.After(d)
-	}
-	return g.Clock.After(d)
+	return g.Clock
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -390,3 +390,7 @@ type UIConsumer interface {
 	RequiredUIs() []UIKind
 	SubConsumers() []UIConsumer
 }
+
+type Clock interface {
+	Now() time.Time
+}

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -772,7 +772,7 @@ func (s *LoginState) requests() {
 
 	// Run a cleanup routine on the Account object every minute.
 	// We're supposed to timeout & cleanup Paper Keys after an hour of inactivity.
-	maketimer := func() <-chan time.Time { return s.G().After(1 * time.Minute) }
+	maketimer := func() <-chan time.Time { return s.G().GetClock().After(1 * time.Minute) }
 	timer := maketimer()
 	s.G().Log.Debug("LoginState: Running request loop")
 

--- a/go/libkb/paperkey_phrase.go
+++ b/go/libkb/paperkey_phrase.go
@@ -76,3 +76,16 @@ func wordVersion(word string) uint8 {
 	}
 	return h[len(h)-1] & ((1 << PaperKeyVersionBits) - 1)
 }
+
+func NewPaperKeyPhraseCheckVersion(g *GlobalContext, passphrase string) (ret PaperKeyPhrase, err error) {
+	paperPhrase := NewPaperKeyPhrase(passphrase)
+	version, err := paperPhrase.Version()
+	if err != nil {
+		return ret, err
+	}
+	if version != PaperKeyVersion {
+		g.Log.Debug("paper version mismatch: generated paper key version = %d, libkb version = %d", version, PaperKeyVersion)
+		return ret, KeyVersionError{}
+	}
+	return paperPhrase, nil
+}

--- a/go/vendor/github.com/jonboulle/clockwork/LICENSE
+++ b/go/vendor/github.com/jonboulle/clockwork/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/go/vendor/github.com/jonboulle/clockwork/README.md
+++ b/go/vendor/github.com/jonboulle/clockwork/README.md
@@ -1,0 +1,61 @@
+clockwork
+=========
+
+[![Build Status](https://travis-ci.org/jonboulle/clockwork.png?branch=master)](https://travis-ci.org/jonboulle/clockwork)
+[![godoc](https://godoc.org/github.com/jonboulle/clockwork?status.svg)](http://godoc.org/github.com/jonboulle/clockwork) 
+
+a simple fake clock for golang
+
+# Usage
+
+Replace uses of the `time` package with the `clockwork.Clock` interface instead.
+
+For example, instead of using `time.Sleep` directly:
+
+```
+func my_func() {
+	time.Sleep(3 * time.Second)
+	do_something()
+}
+```
+
+inject a clock and use its `Sleep` method instead:
+
+```
+func my_func(clock clockwork.Clock) {
+	clock.Sleep(3 * time.Second)
+	do_something()
+}
+```
+
+Now you can easily test `my_func` with a `FakeClock`:
+
+```
+func TestMyFunc(t *testing.T) {
+	c := clockwork.NewFakeClock()
+
+	// Start our sleepy function
+	my_func(c)
+
+	// Ensure we wait until my_func is sleeping
+	c.BlockUntil(1)
+
+	assert_state()
+
+	// Advance the FakeClock forward in time
+	c.Advance(3)
+
+	assert_state()
+}
+```
+
+and in production builds, simply inject the real clock instead:
+```
+my_func(clockwork.NewRealClock())
+```
+
+See [example_test.go](example_test.go) for a full example.
+
+# Credits
+
+clockwork is inspired by @wickman's [threaded fake clock](https://gist.github.com/wickman/3840816), and the [Golang playground](http://blog.golang.org/playground#Faking time)

--- a/go/vendor/github.com/jonboulle/clockwork/clockwork.go
+++ b/go/vendor/github.com/jonboulle/clockwork/clockwork.go
@@ -1,0 +1,169 @@
+package clockwork
+
+import (
+	"sync"
+	"time"
+)
+
+// Clock provides an interface that packages can use instead of directly
+// using the time module, so that chronology-related behavior can be tested
+type Clock interface {
+	After(d time.Duration) <-chan time.Time
+	Sleep(d time.Duration)
+	Now() time.Time
+}
+
+// FakeClock provides an interface for a clock which can be
+// manually advanced through time
+type FakeClock interface {
+	Clock
+	// Advance advances the FakeClock to a new point in time, ensuring any existing
+	// sleepers are notified appropriately before returning
+	Advance(d time.Duration)
+	// BlockUntil will block until the FakeClock has the given number of
+	// sleepers (callers of Sleep or After)
+	BlockUntil(n int)
+}
+
+// NewRealClock returns a Clock which simply delegates calls to the actual time
+// package; it should be used by packages in production.
+func NewRealClock() Clock {
+	return &realClock{}
+}
+
+// NewFakeClock returns a FakeClock implementation which can be
+// manually advanced through time for testing. The initial time of the
+// FakeClock will be an arbitrary non-zero time.
+func NewFakeClock() FakeClock {
+	// use a fixture that does not fulfill Time.IsZero()
+	return NewFakeClockAt(time.Date(1984, time.April, 4, 0, 0, 0, 0, time.UTC))
+}
+
+// NewFakeClock returns a FakeClock initialised at the given time.Time.
+func NewFakeClockAt(t time.Time) FakeClock {
+	return &fakeClock{
+		time: t,
+	}
+}
+
+type realClock struct{}
+
+func (rc *realClock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}
+
+func (rc *realClock) Sleep(d time.Duration) {
+	time.Sleep(d)
+}
+
+func (rc *realClock) Now() time.Time {
+	return time.Now()
+}
+
+type fakeClock struct {
+	sleepers []*sleeper
+	blockers []*blocker
+	time     time.Time
+
+	l sync.RWMutex
+}
+
+// sleeper represents a caller of After or Sleep
+type sleeper struct {
+	until time.Time
+	done  chan time.Time
+}
+
+// blocker represents a caller of BlockUntil
+type blocker struct {
+	count int
+	ch    chan struct{}
+}
+
+// After mimics time.After; it waits for the given duration to elapse on the
+// fakeClock, then sends the current time on the returned channel.
+func (fc *fakeClock) After(d time.Duration) <-chan time.Time {
+	fc.l.Lock()
+	defer fc.l.Unlock()
+	now := fc.time
+	done := make(chan time.Time, 1)
+	if d.Nanoseconds() == 0 {
+		// special case - trigger immediately
+		done <- now
+	} else {
+		// otherwise, add to the set of sleepers
+		s := &sleeper{
+			until: now.Add(d),
+			done:  done,
+		}
+		fc.sleepers = append(fc.sleepers, s)
+		// and notify any blockers
+		fc.blockers = notifyBlockers(fc.blockers, len(fc.sleepers))
+	}
+	return done
+}
+
+// notifyBlockers notifies all the blockers waiting until the
+// given number of sleepers are waiting on the fakeClock. It
+// returns an updated slice of blockers (i.e. those still waiting)
+func notifyBlockers(blockers []*blocker, count int) (newBlockers []*blocker) {
+	for _, b := range blockers {
+		if b.count == count {
+			close(b.ch)
+		} else {
+			newBlockers = append(newBlockers, b)
+		}
+	}
+	return
+}
+
+// Sleep blocks until the given duration has passed on the fakeClock
+func (fc *fakeClock) Sleep(d time.Duration) {
+	<-fc.After(d)
+}
+
+// Time returns the current time of the fakeClock
+func (fc *fakeClock) Now() time.Time {
+	fc.l.RLock()
+	t := fc.time
+	fc.l.RUnlock()
+	return t
+}
+
+// Advance advances fakeClock to a new point in time, ensuring channels from any
+// previous invocations of After are notified appropriately before returning
+func (fc *fakeClock) Advance(d time.Duration) {
+	fc.l.Lock()
+	defer fc.l.Unlock()
+	end := fc.time.Add(d)
+	var newSleepers []*sleeper
+	for _, s := range fc.sleepers {
+		if end.Sub(s.until) >= 0 {
+			s.done <- end
+		} else {
+			newSleepers = append(newSleepers, s)
+		}
+	}
+	fc.sleepers = newSleepers
+	fc.blockers = notifyBlockers(fc.blockers, len(fc.sleepers))
+	fc.time = end
+}
+
+// BlockUntil will block until the fakeClock has the given number of sleepers
+// (callers of Sleep or After)
+func (fc *fakeClock) BlockUntil(n int) {
+	fc.l.Lock()
+	// Fast path: current number of sleepers is what we're looking for
+	if len(fc.sleepers) == n {
+		fc.l.Unlock()
+		return
+	}
+	// Otherwise, set up a new blocker
+	b := &blocker{
+		count: n,
+		ch:    make(chan struct{}),
+	}
+	fc.blockers = append(fc.blockers, b)
+	fc.l.Unlock()
+	<-b.ch
+}

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -88,6 +88,11 @@
 			"revisionTime": "2015-05-12T11:15:40-07:00"
 		},
 		{
+			"path": "github.com/jonboulle/clockwork",
+			"revision": "ed104f61ea4877bea08af6f759805674861e968d",
+			"revisionTime": "2015-11-20T16:16:58-08:00"
+		},
+		{
 			"path": "github.com/josephspurrier/goversioninfo",
 			"revision": "0ec0f16b6f6fd29a6ef146fddab80417dbcfa7e8",
 			"revisionTime": "2015-09-01T19:20:23-04:00"


### PR DESCRIPTION
- make a cleaner process to clear it out after an hour of inactivity
- introduce a global fake clock for testing purposes
- unfortunately, make LoginState more complicated so our tests can know
  when cleanup completes.