### PR TITLE
Desktop: getenv instead of process.env

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -39,7 +39,8 @@ Environment variables:
 
  - $HOME: Home dir to use. Useful for multiple parallel installs
  - $KEYBASE_RUN_MODE: production | devel. Which server to hit
- - $KEYBASE_APP_DEBUG: Debug settings. Devtools, extra logging
+ - $KEYBASE_APP_DEBUG: Debug settings, extra logging
+ - $KEYBASE_SHOW_DEVTOOLS: Show devtools
 
 Use
 ```

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -25,6 +25,7 @@
     "core-decorators": "^0.9.1",
     "font-awesome": "^4.4.0",
     "framed-msgpack-rpc": "keybase/node-framed-msgpack-rpc#nojima/keybase-client-changes",
+    "getenv": "^0.5.0",
     "immutable": "^3.7.5",
     "lodash": "^3.10.1",
     "marked": "^0.3.5",

--- a/desktop/server.js
+++ b/desktop/server.js
@@ -2,12 +2,13 @@
 const express = require('express')
 const webpack = require('webpack')
 const config = Object.assign({}, require('./webpack.config.development'))
+const getenv = require('getenv')
 
 const PORT = 4000
 const compiler = webpack(config)
 
 // Just build output files and don't run a hot server
-const NO_SERVER = (process.env.NO_SERVER && process.env.NO_SERVER === 'true') || false
+const NO_SERVER = getenv.bool('NO_SERVER', false)
 
 if (NO_SERVER) {
   console.log('Starting local file build')

--- a/desktop/webpack.config.base.js
+++ b/desktop/webpack.config.base.js
@@ -1,10 +1,11 @@
 const webpack = require('webpack')
 const path = require('path')
+const getenv = require('getenv')
 
 const defines = {
-  '__HOT__': JSON.stringify(process.env.HOT === 'true'),
-  '__DEV__': JSON.stringify(process.env.NODE_ENV !== 'production'),
-  'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+  '__HOT__': JSON.stringify(getenv.bool('HOT', false)),
+  '__DEV__': JSON.stringify(getenv('NODE_ENV') !== 'production'),
+  'process.env.NODE_ENV': JSON.stringify(getenv('NODE_ENV'))
 }
 
 console.log('Injecting defines: ', defines)

--- a/desktop/webpack.config.development.js
+++ b/desktop/webpack.config.development.js
@@ -2,8 +2,9 @@ const webpack = require('webpack')
 const webpackTargetElectronRenderer = require('webpack-target-electron-renderer')
 const baseConfig = require('./webpack.config.base')
 const config = Object.assign({}, baseConfig)
+const getenv = require('getenv')
 
-const NO_SOURCE_MAPS = process.env.NO_SOURCE_MAPS === 'true'
+const NO_SOURCE_MAPS = getenv.bool('NO_SOURCE_MAPS', false)
 
 config.debug = true
 config.devtool = NO_SOURCE_MAPS ? undefined : 'cheap-module-eval-source-map'
@@ -15,7 +16,7 @@ config.output.publicPath = 'http://localhost:4000/dist/'
 
 config.plugins.push(new webpack.optimize.OccurenceOrderPlugin())
 
-if (process.env.HOT === 'true') {
+if (getenv.bool('HOT', false)) {
   config.plugins.push(new webpack.HotModuleReplacementPlugin())
 }
 
@@ -26,7 +27,7 @@ config.plugins.push(
   })
 )
 
-if (process.env.HOT === 'true') {
+if (getenv.bool('HOT', false)) {
   const HMR = 'webpack-hot-middleware/client?path=http://localhost:4000/__webpack_hmr'
 
   Object.keys(config.entry).forEach(k => {

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "buffer": "^3.5.4",
     "framed-msgpack-rpc": "keybase/node-framed-msgpack-rpc#nojima/keybase-client-changes",
+    "getenv": "^0.5.0",
     "iced-runtime": "^1.0.3",
     "immutable": "^3.7.5",
     "lodash": "^3.10.1",
@@ -36,7 +37,9 @@
       "immutable-interface.js",
       "flow-types.js"
     ],
-    "globals": ["ReactElement"]
+    "globals": [
+      "ReactElement"
+    ]
   },
   "devDependencies": {
     "babel-eslint": "^4.1.6",

--- a/react-native/react/command-line.desktop.js
+++ b/react-native/react/command-line.desktop.js
@@ -4,8 +4,11 @@ export function updateConfig (config) {
   let newConfig = {...config}
 
   if (getenv.bool('KEYBASE_APP_DEBUG', false)) {
-    newConfig.showDevTools = true
     newConfig.showMainWindow = true
+  }
+
+  if (getenv.bool('KEYBASE_SHOW_DEVTOOLS', false)) {
+    newConfig.showDevTools = true
   }
 
   return newConfig

--- a/react-native/react/command-line.desktop.js
+++ b/react-native/react/command-line.desktop.js
@@ -1,7 +1,9 @@
+import getenv from 'getenv'
+
 export function updateConfig (config) {
   let newConfig = {...config}
 
-  if (process.env.KEYBASE_APP_DEBUG === 'true') {
+  if (getenv.bool('KEYBASE_APP_DEBUG', false)) {
     newConfig.showDevTools = true
     newConfig.showMainWindow = true
   }

--- a/react-native/react/constants/platform.native.desktop.js
+++ b/react-native/react/constants/platform.native.desktop.js
@@ -1,11 +1,12 @@
 import {OS_DESKTOP} from './platform.shared'
 import path from 'path'
+import getenv from 'getenv'
 
 export const OS = OS_DESKTOP
 export const isMobile = false
 export const kbfsPath = `/keybase`
 
-export const runMode = process.env.KEYBASE_RUN_MODE || 'prod'
+export const runMode = getenv('KEYBASE_RUN_MODE', 'prod')
 
 if (__DEV__) { // eslint-disable-line no-undef
   console.log(`Run mode: ${runMode}`)
@@ -18,7 +19,7 @@ const envedPathOSX = {
 }
 
 function buildWin32SocketRoot () {
-  let appdata = process.env.APPDATA
+  let appdata = getenv('APPDATA', '')
   // Remove leading drive letter e.g. C:
   if (/^[a-zA-Z]:/.test(appdata)) {
     appdata = appdata.slice(2)
@@ -34,8 +35,8 @@ function buildWin32SocketRoot () {
 
 function findSocketRoot () {
   const paths = {
-    'darwin': `${process.env.HOME}/Library/Caches/${envedPathOSX[runMode]}/`,
-    'linux': runMode === 'prod' ? `${process.env.XDG_RUNTIME_DIR}/keybase/` : `${process.env.XDG_RUNTIME_DIR}/keybase.${runMode}/`,
+    'darwin': `${getenv('HOME', '')}/Library/Caches/${envedPathOSX[runMode]}/`,
+    'linux': runMode === 'prod' ? `${getenv('XDG_RUNTIME_DIR', '')}/keybase/` : `${getenv('XDG_RUNTIME_DIR', '')}/keybase.${runMode}/`,
     'win32': buildWin32SocketRoot()
   }
 
@@ -44,9 +45,9 @@ function findSocketRoot () {
 
 function findDataRoot () {
   const paths = {
-    'darwin': `${process.env.HOME}/Library/Application Support/${envedPathOSX[runMode]}/`,
-    'linux': `${process.env.XDG_DATA_DIR}/keybase.${runMode}/`,
-    'win32': `${process.env.APPDATA}\\Keybase\\`
+    'darwin': `${getenv('HOME', '')}/Library/Application Support/${envedPathOSX[runMode]}/`,
+    'linux': `${getenv('XDG_DATA_DIR', '')}/keybase.${runMode}/`,
+    'win32': `${getenv('APPDATA', '')}\\Keybase\\`
   }
 
   return paths[process.platform]


### PR DESCRIPTION
So I set an env var to "1" and it silently failed. I found this getenv package which is tiny and allows you to get envvars by int, float, bool etc and errors nicely if a var is invalid or not set at all (required).

Basically if you mess up env vars at all this will catch it.

Also changing showDevTools to use different env var KEYBASE_SHOW_DEVTOOLS