### PR TITLE
Call LoggedInProvisionedLoad before UserInfo

### DIFF
--- a/go/service/session.go
+++ b/go/service/session.go
@@ -40,6 +40,10 @@ func (h *SessionHandler) CurrentSession(_ context.Context, sessionID int) (keyba
 	var err error
 
 	aerr := h.G().LoginState().Account(func(a *libkb.Account) {
+		_, err = a.LoggedInProvisionedLoad()
+		if err != nil {
+			return
+		}
 		uid, username, token, deviceSubkey, deviceSibkey, err = a.UserInfo()
 	}, "Service - SessionHandler - UserInfo")
 	if aerr != nil {


### PR DESCRIPTION
This fixes a bug where if the daemon restarts
CurrentSession would return ErrNoSession when there
actually was one, it just wasn't loaded.

It's fine to do this now because kbfs caching the
result, so the slow performance isn't an issue.

r? @cjb @maxtaco 

In relation to https://keybase.atlassian.net/browse/CORE-2317