### PR TITLE
Fix KBFS not spawning pinentry

### DIFF
--- a/react-native/react/actions/config/index.js
+++ b/react-native/react/actions/config/index.js
@@ -19,29 +19,27 @@ export function startup () {
         dispatch({type: Constants.startupLoaded, payload: error, error: true})
         return
       }
-      engine.rpc('config.getCurrentStatus', {}, incomingMap, (error, status) => {
-        if (error) {
-          dispatch({type: Constants.startupLoaded, payload: error, error: true})
-          return
-        }
-        dispatch({
-          type: Constants.startupLoaded,
-          payload: {config, status}
+
+      function getCurrentStatus () {
+        engine.rpc('config.getCurrentStatus', {}, incomingMap, (error, status) => {
+          if (error) {
+            dispatch({type: Constants.startupLoaded, payload: error, error: true})
+            return
+          }
+          dispatch({
+            type: Constants.startupLoaded,
+            payload: {config, status}
+          })
+
+          if (status.loggedIn) {
+            dispatch(autoLogin())
+          }
         })
+      }
 
-        if (status.loggedIn) {
-          dispatch(autoLogin())
-        }
-      })
-    })
-
-    // Also call getCurrentStatus if the service goes away/comes back.
-    engine.listenOnConnect(() => {
-      engine.rpc('config.getCurrentStatus', {}, incomingMap, (error, status) => {
-        if (error) {
-          console.log(`Error calling getCurrentStatus: ${error}`)
-        }
-      })
+      getCurrentStatus()
+      // Also call getCurrentStatus if the service goes away/comes back.
+      engine.listenOnConnect(getCurrentStatus)
     })
   }
 }

--- a/react-native/react/actions/config/index.js
+++ b/react-native/react/actions/config/index.js
@@ -34,6 +34,15 @@ export function startup () {
         }
       })
     })
+
+    // Also call getCurrentStatus if the service goes away/comes back.
+    engine.listenOnConnect(() => {
+      engine.rpc('config.getCurrentStatus', {}, incomingMap, (error, status) => {
+        if (error) {
+          console.log(`Error calling getCurrentStatus: ${error}`)
+        }
+      })
+    })
   }
 }
 


### PR DESCRIPTION
@keybase/react-hackers

We were seeing something strange:

  start service -> start electron -> start kbfsfuse

caused a pinentry popup asking for your Keybase login for KBFS, which is good, but:

  start service -> start electron -> restart service -> start kbfsfuse

did not cause any popup, and KBFS sat failing silently.  It turns out that the difference was the config.getCurrentStatus() RPC that we called only once at Electron startup time.

We will fix the core bug in a separate PR too, but Patrick says that having us reissue the getCurrentStatus RPC when we reconnect to the service is orthogonally a good idea.