### PR TITLE
Fix Linux bringing up the splash screen at every boot

### DIFF
--- a/react-native/react/constants/platform.native.desktop.js
+++ b/react-native/react/constants/platform.native.desktop.js
@@ -12,6 +12,12 @@ if (__DEV__) { // eslint-disable-line no-undef
   console.log(`Run mode: ${runMode}`)
 }
 
+const envedPathLinux = {
+  staging: 'keybase.staging',
+  devel: 'keybase.devel',
+  prod: 'keybase'
+}
+
 const envedPathOSX = {
   staging: 'KeybaseStaging',
   devel: 'KeybaseDevel',
@@ -44,9 +50,10 @@ function findSocketRoot () {
 }
 
 function findDataRoot () {
+  linuxDefaultRoot = `${getenv('HOME', '')}/.local/share`
   const paths = {
     'darwin': `${getenv('HOME', '')}/Library/Application Support/${envedPathOSX[runMode]}/`,
-    'linux': `${getenv('XDG_DATA_DIR', '')}/keybase.${runMode}/`,
+    'linux': `${getenv('XDG_DATA_HOME', linuxDefaultRoot)}/${envedPathLinux[runMode]}/`,
     'win32': `${getenv('APPDATA', '')}\\Keybase\\`
   }
 

--- a/react-native/react/constants/platform.native.desktop.js
+++ b/react-native/react/constants/platform.native.desktop.js
@@ -57,4 +57,4 @@ export const socketRoot = findSocketRoot()
 export const socketName = 'keybased.sock'
 export const socketPath = path.join(socketRoot, socketName)
 export const dataRoot = findDataRoot()
-export const splashRoot = process.platform === 'win32' ? dataRoot : socketRoot
+export const splashRoot = process.platform === 'darwin' ? socketRoot : dataRoot


### PR DESCRIPTION
@keybase/react-hackers @oconnor663 

On Linux, we want to store the started.txt file in the data dir because the socket dir is ephemeral.

On Windows, we want to store the started.txt in the data dir because the socket dir isn't actually a filesystem.

On OS X, we want to store the started.txt in the socket dir, which launchd manages for it.