### PR TITLE
Unregister listeners desktop 221

### DIFF
--- a/react-native/react/actions/pinentry.js
+++ b/react-native/react/actions/pinentry.js
@@ -14,7 +14,7 @@ const uglySessionIDResponseMapper: {[key: number]: Function} = {}
 
 export function registerPinentryListener (): (dispatch: Dispatch) => void {
   return dispatch => {
-    engine.listenOnConnect(() => {
+    engine.listenOnConnect('registerSecretUI', () => {
       engine.rpc('delegateUiCtl.registerSecretUI', {}, {}, (error, response) => {
         if (error != null) {
           console.error('error in registering secret ui: ', error)

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -54,18 +54,18 @@ export function registerTrackerChangeListener (): TrackerActionCreator {
       })
     })
 
-    engine.listenOnConnect(() => {
-      setNotifications({tracking: true})
-    })
+    setNotifications({tracking: true})
   }
 }
 
 export function registerIdentifyUi (): TrackerActionCreator {
   return (dispatch, getState) => {
-    engine.rpc('delegateUiCtl.registerIdentifyUI', {}, {}, (error, response) => {
-      if (error != null) {
-        console.error('error in registering identify ui: ', error)
-      }
+    engine.listenOnConnect('registerIdentifyUi', () => {
+      engine.rpc('delegateUiCtl.registerIdentifyUI', {}, {}, (error, response) => {
+        if (error != null) {
+          console.error('error in registering identify ui: ', error)
+        }
+      })
     })
 
     createServer(
@@ -74,6 +74,7 @@ export function registerIdentifyUi (): TrackerActionCreator {
       'keybase.1.identifyUi.finish',
       () => serverCallMap(dispatch, getState)
     )
+
     dispatch({
       type: Constants.registerIdentifyUi,
       payload: {

--- a/react-native/react/actions/update.js
+++ b/react-native/react/actions/update.js
@@ -19,7 +19,7 @@ let updatePromptResponse: ?{result: (payload: any) => void}
 export function registerUpdateListener (): (dispatch: Dispatch, getState: () => {config: ConfigState}) => void {
   updatePromptResponse = null
   return (dispatch, getState) => {
-    engine.listenOnConnect(() => {
+    engine.listenOnConnect('registerUpdateUI', () => {
       engine.rpc('delegateUiCtl.registerUpdateUI', {}, {}, (error, response) => {
         if (error != null) {
           console.error('error in registering update ui: ', error)

--- a/react-native/react/native/listen-log-ui.js
+++ b/react-native/react/native/listen-log-ui.js
@@ -3,7 +3,7 @@ import engine from '../engine'
 import type {Text} from '../constants/types/flow-types'
 
 export default function ListenLogUi () {
-  engine.listenOnConnect(() => {
+  engine.listenOnConnect('ListenLogUi', () => {
     engine.listenGeneralIncomingRpc('keybase.1.logUi.log', (params: {text: Text}) => {
       console.log('keybase.1.logUi.log:', params.text.data)
     })

--- a/react-native/react/native/notifications.js
+++ b/react-native/react/native/notifications.js
@@ -15,12 +15,10 @@ export default function (notify: NotifyFn) {
     return
   }
 
-  engine.listenOnConnect(() => {
-    setNotifications({
-      session: true,
-      users: true,
-      kbfs: true
-    })
+  setNotifications({
+    session: true,
+    users: true,
+    kbfs: true
   })
 
   const listeners = ListenerCreator(notify)

--- a/react-native/react/native/remote-manager.desktop.js
+++ b/react-native/react/native/remote-manager.desktop.js
@@ -3,8 +3,6 @@
 import React, {Component} from '../base-react'
 import {connect} from '../base-redux'
 
-import engine from '../engine'
-
 import {bindActionCreators} from 'redux'
 import {registerIdentifyUi, onCloseFromHeader as trackerOnCloseFromHeader, startTimer as trackerStartTimer, stopTimer as trackerStopTimer} from '../actions/tracker'
 import {registerPinentryListener, onCancel as pinentryOnCancel, onSubmit as pinentryOnSubmit} from '../actions/pinentry'
@@ -52,12 +50,10 @@ class RemoteManager extends Component {
   }
 
   componentWillMount () {
-    engine.listenOnConnect(() => {
-      this.props.registerIdentifyUi()
-      this.props.registerPinentryListener()
-      this.props.registerTrackerChangeListener()
-      this.props.registerUpdateListener()
-    })
+    this.props.registerIdentifyUi()
+    this.props.registerPinentryListener()
+    this.props.registerTrackerChangeListener()
+    this.props.registerUpdateListener()
   }
 
   windowStates (trackers) {

--- a/react-native/react/util/setNotifications.js
+++ b/react-native/react/util/setNotifications.js
@@ -14,13 +14,15 @@ let channelsSet = {}
 export default function (channels: NotificationChannels): Promise<void> {
   return new Promise((resolve, reject) => {
     channelsSet = {...channelsSet, ...channels}
-    engine.rpc('notifyCtl.setNotifications', {channels: channelsSet}, {}, (error, response) => {
-      if (error != null) {
-        console.error('error in toggling notifications: ', error)
-        reject(error)
-      } else {
-        resolve()
-      }
+    engine.listenOnConnect('setNotifications', () => {
+      engine.rpc('notifyCtl.setNotifications', {channels: channelsSet}, {}, (error, response) => {
+        if (error != null) {
+          console.error('error in toggling notifications: ', error)
+          reject(error)
+        } else {
+          resolve()
+        }
+      })
     })
   })
 }


### PR DESCRIPTION
Fixes: https://keybase.atlassian.net/browse/DESKTOP-221

There are a couple subtle issues that came up here, and I think they are all fixed by treating `listenOnConnect` (and `listenGeneralIncomingRPC`) as idempotent.

The bug was that a `listenOnConnect` was calling a function that itself had `listenOnConnect`. Since `listenOnConnect` used to take a function and add it to a list of callbacks, it would register multiple callbacks that did the same thing. This lead to the multiple console logs showing registered secret UI (as seen in the ticket).

Now `listenOnConnect` will error if you call nested `listenOnConnect`s.

@keybase/react-hackers 