### PR TITLE
saltpack: factor out "branding"

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -47,11 +47,12 @@ const (
 
 	SecretKeyringTemplate = "secretkeys.%u.mpack"
 
-	APIVersion       = "1.0"
-	APIURIPathPrefix = "/_/api/" + APIVersion
-	DaemonPort       = 40933
-	GoClientID       = "keybase.io go client"
-	IdentifyAs       = GoClientID + " v" + Version + " " + runtime.GOOS
+	APIVersion           = "1.0"
+	APIURIPathPrefix     = "/_/api/" + APIVersion
+	DaemonPort           = 40933
+	GoClientID           = "keybase.io go client"
+	IdentifyAs           = GoClientID + " v" + Version + " " + runtime.GOOS
+	KeybaseSaltpackBrand = "KEYBASE"
 )
 
 var UserAgent = "Keybase/" + Version + " (" + runtime.Version() + " on " + runtime.GOOS + ")"

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1289,6 +1289,14 @@ func (e TrackingBrokeError) Error() string {
 
 //=============================================================================
 
+type KeybaseSaltpackError struct{}
+
+func (e KeybaseSaltpackError) Error() string {
+	return "Bad use of saltpack for Keybase"
+}
+
+//=============================================================================
+
 type UnknownStreamError struct{}
 
 func (e UnknownStreamError) Error() string {

--- a/go/libkb/saltpack.go
+++ b/go/libkb/saltpack.go
@@ -137,3 +137,10 @@ func BoxPublicKeyToKeybaseKID(k saltpack.BoxPublicKey) (ret keybase1.KID) {
 	p := k.ToKID()
 	return keybase1.KIDFromRawKey(p, KIDNaclDH)
 }
+
+func checkSaltpackBrand(b string) error {
+	if b != KeybaseSaltpackBrand {
+		return KeybaseSaltpackError{}
+	}
+	return nil
+}

--- a/go/libkb/saltpack_dec.go
+++ b/go/libkb/saltpack_dec.go
@@ -44,8 +44,12 @@ func SaltpackDecrypt(
 
 	// TODO: Check header inline, and only warn if the footer
 	// doesn't match.
-	err = saltpack.CheckArmor62Frame(frame, saltpack.EncryptionArmorHeader, saltpack.EncryptionArmorFooter)
+	var brand string
+	brand, err = saltpack.CheckArmor62Frame(frame, saltpack.MessageTypeEncryption)
 	if err != nil {
+		return mki, err
+	}
+	if err = checkSaltpackBrand(brand); err != nil {
 		return mki, err
 	}
 

--- a/go/libkb/saltpack_enc.go
+++ b/go/libkb/saltpack_enc.go
@@ -23,7 +23,7 @@ func SaltpackEncrypt(
 		bsk = naclBoxSecretKey(sender)
 	}
 
-	plainsink, err := saltpack.NewEncryptArmor62Stream(sink, bsk, receiverBoxKeys)
+	plainsink, err := saltpack.NewEncryptArmor62Stream(sink, bsk, receiverBoxKeys, KeybaseSaltpackBrand)
 	if err != nil {
 		return err
 	}

--- a/go/libkb/saltpack_sign.go
+++ b/go/libkb/saltpack_sign.go
@@ -21,7 +21,7 @@ func SaltpackSignDetached(g *GlobalContext, source io.ReadCloser, sink io.WriteC
 	return saltpackSign(g, source, sink, key, saltpack.NewSignDetachedArmor62Stream)
 }
 
-func saltpackSign(g *GlobalContext, source io.ReadCloser, sink io.WriteCloser, key NaclSigningKeyPair, streamer func(io.Writer, saltpack.SigningSecretKey) (io.WriteCloser, error)) error {
+func saltpackSign(g *GlobalContext, source io.ReadCloser, sink io.WriteCloser, key NaclSigningKeyPair, streamer func(io.Writer, saltpack.SigningSecretKey, string) (io.WriteCloser, error)) error {
 	defer func() {
 		if err := source.Close(); err != nil {
 			g.Log.Warning("error closing source: %s", err)
@@ -31,7 +31,7 @@ func saltpackSign(g *GlobalContext, source io.ReadCloser, sink io.WriteCloser, k
 		}
 	}()
 
-	stream, err := streamer(sink, saltSigner{key})
+	stream, err := streamer(sink, saltSigner{key}, KeybaseSaltpackBrand)
 	if err != nil {
 		return err
 	}

--- a/go/libkb/saltpack_test.go
+++ b/go/libkb/saltpack_test.go
@@ -54,11 +54,11 @@ func TestSaltpackEncDec(t *testing.T) {
 	}
 
 	ciphertext := buf.String()
-	if !strings.HasPrefix(ciphertext, saltpack.EncryptionArmorHeader) {
+	if !strings.HasPrefix(ciphertext, saltpack.MakeArmorHeader(saltpack.MessageTypeEncryption, KeybaseSaltpackBrand)) {
 		t.Errorf("ciphertext doesn't have header: %s", ciphertext)
 	}
 
-	if !strings.HasSuffix(ciphertext, saltpack.EncryptionArmorFooter+".\n") {
+	if !strings.HasSuffix(ciphertext, saltpack.MakeArmorFooter(saltpack.MessageTypeEncryption, KeybaseSaltpackBrand)+".\n") {
 		t.Errorf("ciphertext doesn't have footer: %s", ciphertext)
 	}
 

--- a/go/libkb/stream_classifier.go
+++ b/go/libkb/stream_classifier.go
@@ -196,6 +196,9 @@ func isPGPBinary(b []byte, sc *StreamClassification) bool {
 	return true
 }
 
+var encryptionArmorHeader = saltpack.MakeArmorHeader(saltpack.MessageTypeEncryption, KeybaseSaltpackBrand)
+var signedArmorHeader = saltpack.MakeArmorHeader(saltpack.MessageTypeAttachedSignature, KeybaseSaltpackBrand)
+
 // ClassifyStream takes a stream reader in, and returns a likely classification
 // of that stream without consuming any data from it. It returns a reader that you
 // should read from instead, in addition to the classification. If classification
@@ -222,11 +225,11 @@ func ClassifyStream(r io.Reader) (sc StreamClassification, out io.Reader, err er
 		sc.Format = CryptoMessageFormatPGP
 		sc.Armored = true
 		sc.Type = CryptoMessageTypeClearSignature
-	case strings.HasPrefix(sb, saltpack.EncryptionArmorHeader+"."):
+	case strings.HasPrefix(sb, encryptionArmorHeader+"."):
 		sc.Format = CryptoMessageFormatSaltpack
 		sc.Armored = true
 		sc.Type = CryptoMessageTypeEncryption
-	case strings.HasPrefix(sb, saltpack.SignedArmorHeader+"."):
+	case strings.HasPrefix(sb, signedArmorHeader+"."):
 		sc.Format = CryptoMessageFormatSaltpack
 		sc.Armored = true
 		sc.Type = CryptoMessageTypeSignature

--- a/go/saltpack/armor.go
+++ b/go/saltpack/armor.go
@@ -235,7 +235,7 @@ func (s *framedDecoderStream) isValidByteSequence(p []byte) bool {
 
 func (s *framedDecoderStream) toASCII(buf []byte) (string, error) {
 	if !s.isValidByteSequence(buf) {
-		return "", ErrBadArmorFrame
+		return "", makeErrBadFrame("invalid ASCII sequence")
 	}
 	return strings.TrimSpace(string(buf)), nil
 }

--- a/go/saltpack/armor62.go
+++ b/go/saltpack/armor62.go
@@ -20,21 +20,25 @@ var Armor62Params = ArmorParams{
 
 // NewArmor62EncoderStream makes a new Armor 62 encoding stream, using the base62-alphabet
 // and a 32/43 encoding rate strategy. Pass it an `encoded` stream writer to write the
-// encoded stream to.  Also pass a header, and a footer string.  It will
+// encoded stream to.  Also pass an optional "brand" .  It will
 // return an io.WriteCloser on success, that you can write raw (unencoded) data to.
 // An error will be returned if there is trouble writing the header to encoded.
 //
 // To make the output look pretty, a space is inserted every 15 characters of output,
 // and a newline is inserted every 200 words.
-func NewArmor62EncoderStream(encoded io.Writer, header string, footer string) (io.WriteCloser, error) {
-	return NewArmorEncoderStream(encoded, header, footer, Armor62Params)
+func NewArmor62EncoderStream(encoded io.Writer, typ MessageType, brand string) (io.WriteCloser, error) {
+	hdr := makeFrame(headerMarker, typ, brand)
+	ftr := makeFrame(footerMarker, typ, brand)
+	return NewArmorEncoderStream(encoded, hdr, ftr, Armor62Params)
 }
 
 // Armor62Seal takes an input plaintext and returns and output armor encoding
 // as a string, or an error if a problem was encountered. Also provide a header
 // and a footer to frame the message. Uses Base62 encoding scheme
-func Armor62Seal(plaintext []byte, header string, footer string) (string, error) {
-	return ArmorSeal(plaintext, header, footer, Armor62Params)
+func Armor62Seal(plaintext []byte, typ MessageType, brand string) (string, error) {
+	hdr := makeFrame(headerMarker, typ, brand)
+	ftr := makeFrame(footerMarker, typ, brand)
+	return ArmorSeal(plaintext, hdr, ftr, Armor62Params)
 }
 
 // NewArmor62DecoderStream is used to decode input base62-armoring format. It returns
@@ -48,4 +52,36 @@ func NewArmor62DecoderStream(r io.Reader) (io.Reader, Frame, error) {
 // a string.
 func Armor62Open(msg string) (body []byte, header string, footer string, err error) {
 	return ArmorOpen(msg, Armor62Params)
+}
+
+// CheckArmor62Frame checks that the frame matches our standard
+// begin/end frame
+func CheckArmor62Frame(frame Frame, typ MessageType) (brand string, err error) {
+	var hdr, ftr string
+	if hdr, err = frame.GetHeader(); err != nil {
+		return "", err
+	}
+	if ftr, err = frame.GetFooter(); err != nil {
+		return "", err
+	}
+	return CheckArmor62(hdr, ftr, typ)
+}
+
+// CheckArmor62Frame checks that the frame matches our standard
+// begin/end frame
+func CheckArmor62(hdr string, ftr string, typ MessageType) (brand string, err error) {
+	brand, err = parseFrame(hdr, typ, headerMarker)
+	if err != nil {
+		return "", err
+	}
+	var b2 string
+	b2, err = parseFrame(ftr, typ, footerMarker)
+	if err != nil {
+		return "", err
+	}
+
+	if b2 != brand {
+		return "", makeErrBadFrame("brand mismatch: %q != %q", brand, b2)
+	}
+	return brand, nil
 }

--- a/go/saltpack/armor62_encrypt.go
+++ b/go/saltpack/armor62_encrypt.go
@@ -28,12 +28,15 @@ func (c closeForwarder) Close() error {
 // The encryption is from the specified sender, and is encrypted for the
 // given receivers.
 //
+// The "brand" is the optional "brand" string to put into the header
+// and footer.
+//
 // The ciphertext is additionally armored with the recommended armor62-style format.
 //
 // Returns an io.WriteCloser that accepts plaintext data to be encrypted; and
 // also returns an error if initialization failed.
-func NewEncryptArmor62Stream(ciphertext io.Writer, sender BoxSecretKey, receivers []BoxPublicKey) (plaintext io.WriteCloser, err error) {
-	enc, err := NewArmor62EncoderStream(ciphertext, EncryptionArmorHeader, EncryptionArmorFooter)
+func NewEncryptArmor62Stream(ciphertext io.Writer, sender BoxSecretKey, receivers []BoxPublicKey, brand string) (plaintext io.WriteCloser, err error) {
+	enc, err := NewArmor62EncoderStream(ciphertext, MessageTypeEncryption, brand)
 	if err != nil {
 		return nil, err
 	}
@@ -46,9 +49,9 @@ func NewEncryptArmor62Stream(ciphertext io.Writer, sender BoxSecretKey, receiver
 
 // EncryptArmor62Seal is the non-streaming version of NewEncryptArmor62Stream, which
 // inputs a plaintext (in bytes) and output a ciphertext (as a string).
-func EncryptArmor62Seal(plaintext []byte, sender BoxSecretKey, receivers []BoxPublicKey) (string, error) {
+func EncryptArmor62Seal(plaintext []byte, sender BoxSecretKey, receivers []BoxPublicKey, brand string) (string, error) {
 	var buf bytes.Buffer
-	enc, err := NewEncryptArmor62Stream(&buf, sender, receivers)
+	enc, err := NewEncryptArmor62Stream(&buf, sender, receivers, brand)
 	if err != nil {
 		return "", err
 	}

--- a/go/saltpack/armor62_encrypt_test.go
+++ b/go/saltpack/armor62_encrypt_test.go
@@ -20,7 +20,7 @@ func encryptArmor62RandomData(t *testing.T, sz int) ([]byte, string) {
 	sndr := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 
-	ciphertext, err := EncryptArmor62Seal(msg, sndr, receivers)
+	ciphertext, err := EncryptArmor62Seal(msg, sndr, receivers, ourBrand)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,13 +29,14 @@ func encryptArmor62RandomData(t *testing.T, sz int) ([]byte, string) {
 
 func TestEncryptArmor62(t *testing.T) {
 	plaintext, ciphertext := encryptArmor62RandomData(t, 1024)
-	_, plaintext2, err := Dearmor62DecryptOpen(ciphertext, kr)
+	_, plaintext2, brand, err := Dearmor62DecryptOpen(ciphertext, kr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(plaintext, plaintext2) {
 		t.Fatalf("bad message back out")
 	}
+	brandCheck(t, brand)
 }
 
 func TestDearmor62DecryptSlowReader(t *testing.T) {
@@ -47,7 +48,7 @@ func TestDearmor62DecryptSlowReader(t *testing.T) {
 	sndr := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 
-	ciphertext, err := EncryptArmor62Seal(msg, sndr, receivers)
+	ciphertext, err := EncryptArmor62Seal(msg, sndr, receivers, ourBrand)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,8 +62,10 @@ func TestDearmor62DecryptSlowReader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := CheckArmor62Frame(frame, EncryptionArmorHeader, EncryptionArmorFooter); err != nil {
+	if brand, err := CheckArmor62Frame(frame, MessageTypeEncryption); err != nil {
 		t.Fatal(err)
+	} else {
+		brandCheck(t, brand)
 	}
 
 	if !bytes.Equal(plaintext, msg) {
@@ -73,35 +76,38 @@ func TestDearmor62DecryptSlowReader(t *testing.T) {
 func TestBadArmor62(t *testing.T) {
 	_, ciphertext := encryptArmor62RandomData(t, 24)
 	bad1 := ciphertext[0:2] + "䁕" + ciphertext[2:]
-	if _, _, err := Dearmor62DecryptOpen(bad1, kr); err != ErrBadArmorFrame {
-		t.Fatalf("Wanted error %v but got %v", ErrBadArmorFrame, err)
+	_, _, _, err := Dearmor62DecryptOpen(bad1, kr)
+	if _, ok := err.(ErrBadFrame); !ok {
+		t.Fatalf("Wanted error type %T but got type %T", ErrBadFrame{}, err)
 	}
-	if _, _, _, err := Armor62Open(bad1); err != ErrBadArmorFrame {
-		t.Fatalf("Wanted error %v but got %v", ErrBadArmorFrame, err)
+	_, _, _, err = Armor62Open(bad1)
+	if _, ok := err.(ErrBadFrame); !ok {
+		t.Fatalf("Wanted error type %T but got type %T", ErrBadFrame{}, err)
 	}
 
 	bad2 := ciphertext[0:1] + "z" + ciphertext[2:]
-	_, _, err := Dearmor62DecryptOpen(bad2, kr)
-	if _, ok := err.(ErrBadArmorHeader); !ok {
-		t.Fatalf("Wanted of type ErrBadArmorHeader; got %v", err)
+	_, _, _, err = Dearmor62DecryptOpen(bad2, kr)
+	if _, ok := err.(ErrBadFrame); !ok {
+		t.Fatalf("Wanted of type ErrBadFrame; got %v", err)
 	}
 
 	l := len(ciphertext)
 	bad3 := ciphertext[0:(l-8)] + "z" + ciphertext[(l-7):]
-	_, _, err = Dearmor62DecryptOpen(bad3, kr)
-	if _, ok := err.(ErrBadArmorFooter); !ok {
-		t.Fatalf("Wanted of type ErrBadArmorFooter; got %v", err)
+	_, _, _, err = Dearmor62DecryptOpen(bad3, kr)
+	if _, ok := err.(ErrBadFrame); !ok {
+		t.Fatalf("Wanted of type ErrBadFrmae; got %v", err)
 	}
 
 	bad4 := ciphertext + "䁕"
-	_, _, err = Dearmor62DecryptOpen(bad4, kr)
+	_, _, _, err = Dearmor62DecryptOpen(bad4, kr)
 	if err != ErrTrailingGarbage {
 		t.Fatalf("Wanted error %v but got %v", ErrTrailingGarbage, err)
 	}
 
 	bad5 := ciphertext[0:(l-8)] + "䁕" + ciphertext[(l-7):]
-	if _, _, _, err := Armor62Open(bad5); err != ErrBadArmorFrame {
-		t.Fatalf("Wanted error %v but got %v", ErrBadArmorFrame, err)
+	_, _, _, err = Armor62Open(bad5)
+	if _, ok := err.(ErrBadFrame); !ok {
+		t.Fatalf("Wanted error type %T but got type %T", ErrBadFrame{}, err)
 	}
 	half := l >> 1
 	bad6 := ciphertext[0:half] + "䁕" + ciphertext[(half+1):]

--- a/go/saltpack/armor62_sign.go
+++ b/go/saltpack/armor62_sign.go
@@ -5,14 +5,22 @@ package saltpack
 
 import "io"
 
+func curry(f func(signedtext io.Writer, signer SigningSecretKey, brand string) (io.WriteCloser, error), brand string) func(io.Writer, SigningSecretKey) (io.WriteCloser, error) {
+	return func(signedtext io.Writer, signer SigningSecretKey) (io.WriteCloser, error) {
+		return f(signedtext, signer, brand)
+	}
+}
+
 // NewSignArmor62Stream creates a stream that consumes plaintext data.
 // It will write out signed data to the io.Writer passed in as
-// signedtext.  NewSignArmor62Stream only generates attached signatures.
+// signedtext. The `brand` is optional, and allows you to specify
+// your "white label" brand to this signature. NewSignArmor62Stream only
+// generates attached signatures.
 //
 // The signed data is armored with the recommended armor62-style
 // format.
-func NewSignArmor62Stream(signedtext io.Writer, signer SigningSecretKey) (stream io.WriteCloser, err error) {
-	enc, err := NewArmor62EncoderStream(signedtext, SignedArmorHeader, SignedArmorFooter)
+func NewSignArmor62Stream(signedtext io.Writer, signer SigningSecretKey, brand string) (stream io.WriteCloser, err error) {
+	enc, err := NewArmor62EncoderStream(signedtext, MessageTypeAttachedSignature, brand)
 	if err != nil {
 		return nil, err
 	}
@@ -24,8 +32,8 @@ func NewSignArmor62Stream(signedtext io.Writer, signer SigningSecretKey) (stream
 }
 
 // SignArmor62 creates an attached armored signature message of plaintext from signer.
-func SignArmor62(plaintext []byte, signer SigningSecretKey) (string, error) {
-	buf, err := signToStream(plaintext, signer, NewSignArmor62Stream)
+func SignArmor62(plaintext []byte, signer SigningSecretKey, brand string) (string, error) {
+	buf, err := signToStream(plaintext, signer, curry(NewSignArmor62Stream, brand))
 	if err != nil {
 		return "", err
 	}
@@ -34,12 +42,16 @@ func SignArmor62(plaintext []byte, signer SigningSecretKey) (string, error) {
 
 // NewSignDetachedArmor62Stream creates a stream that consumes plaintext data.
 // It will write out the detached signature to the io.Writer passed in as
-// detachedsig.  NewSignDetachedArmor62Stream only generates detached signatures.
+// detachedsig. The `brand` is optional, and allows you to specify
+// your "white label" brand to this signature.
+//
+// The signed data is armored with the recommended armor62-style
+// NewSignDetachedArmor62Stream only generates detached signatures.
 //
 // The signature is armored with the recommended armor62-style
 // format.
-func NewSignDetachedArmor62Stream(detachedsig io.Writer, signer SigningSecretKey) (stream io.WriteCloser, err error) {
-	enc, err := NewArmor62EncoderStream(detachedsig, DetachedSignatureArmorHeader, DetachedSignatureArmorFooter)
+func NewSignDetachedArmor62Stream(detachedsig io.Writer, signer SigningSecretKey, brand string) (stream io.WriteCloser, err error) {
+	enc, err := NewArmor62EncoderStream(detachedsig, MessageTypeDetachedSignature, brand)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +64,8 @@ func NewSignDetachedArmor62Stream(detachedsig io.Writer, signer SigningSecretKey
 }
 
 // SignDetachedArmor62 returns a detached armored signature of plaintext from signer.
-func SignDetachedArmor62(plaintext []byte, signer SigningSecretKey) (string, error) {
-	buf, err := signToStream(plaintext, signer, NewSignDetachedArmor62Stream)
+func SignDetachedArmor62(plaintext []byte, signer SigningSecretKey, brand string) (string, error) {
+	buf, err := signToStream(plaintext, signer, curry(NewSignDetachedArmor62Stream, brand))
 	if err != nil {
 		return "", err
 	}

--- a/go/saltpack/armor62_sign_test.go
+++ b/go/saltpack/armor62_sign_test.go
@@ -11,7 +11,7 @@ import (
 func TestSignArmor62(t *testing.T) {
 	msg := randomMsg(t, 128)
 	key := newSigPrivKey(t)
-	smsg, err := SignArmor62(msg, key)
+	smsg, err := SignArmor62(msg, key, ourBrand)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -19,10 +19,11 @@ func TestSignArmor62(t *testing.T) {
 		t.Fatal("SignArmor62 returned no error and no output")
 	}
 
-	skey, vmsg, err := Dearmor62Verify(smsg, kr)
+	skey, vmsg, brand, err := Dearmor62Verify(smsg, kr)
 	if err != nil {
 		t.Fatal(err)
 	}
+	brandCheck(t, brand)
 	if !KIDEqual(skey, key.PublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
 	}
@@ -34,7 +35,7 @@ func TestSignArmor62(t *testing.T) {
 func TestSignDetachedArmor62(t *testing.T) {
 	msg := randomMsg(t, 128)
 	key := newSigPrivKey(t)
-	sig, err := SignDetachedArmor62(msg, key)
+	sig, err := SignDetachedArmor62(msg, key, ourBrand)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,10 +43,11 @@ func TestSignDetachedArmor62(t *testing.T) {
 		t.Fatal("empty sig and no error from SignDetachedArmor62")
 	}
 
-	skey, err := Dearmor62VerifyDetached(msg, sig, kr)
+	skey, brand, err := Dearmor62VerifyDetached(msg, sig, kr)
 	if err != nil {
 		t.Fatal(err)
 	}
+	brandCheck(t, brand)
 	if !KIDEqual(skey, key.PublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
 	}

--- a/go/saltpack/armor_test.go
+++ b/go/saltpack/armor_test.go
@@ -18,12 +18,20 @@ func msg(sz int) []byte {
 	return res
 }
 
-const hdr = "BEGIN KBr ENCRYPTED MESSAGE"
-const ftr = "END KBr ENCRYPTED MESSAGE"
+const ourBrand = "ACME"
+
+func brandCheck(t *testing.T, received string) {
+	if received != ourBrand {
+		t.Fatalf("brand mismatch; wanted %q but got %q", ourBrand, received)
+	}
+}
+
+const hdr = "BEGIN ACME SALTPACK ENCRYPTED MESSAGE"
+const ftr = "END ACME SALTPACK ENCRYPTED MESSAGE"
 
 func testArmor(t *testing.T, sz int) {
 	m := msg(sz)
-	a, e := Armor62Seal(m, hdr, ftr)
+	a, e := Armor62Seal(m, MessageTypeEncryption, ourBrand)
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -64,7 +72,7 @@ func TestArmor65536(t *testing.T) {
 func TestSlowWriter(t *testing.T) {
 	m := msg(1024 * 16)
 	var out bytes.Buffer
-	enc, err := NewArmor62EncoderStream(&out, hdr, ftr)
+	enc, err := NewArmor62EncoderStream(&out, MessageTypeEncryption, ourBrand)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +115,7 @@ func (sr *slowReader) Read(b []byte) (int, error) {
 func TestSlowReader(t *testing.T) {
 	var sr slowReader
 	m := msg(1024 * 32)
-	a, err := Armor62Seal(m, hdr, ftr)
+	a, err := Armor62Seal(m, MessageTypeEncryption, ourBrand)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/saltpack/const.go
+++ b/go/saltpack/const.go
@@ -31,29 +31,9 @@ var SaltpackCurrentVersion = Version{Major: 1, Minor: 0}
 // EncryptionBlockSize is by default 1MB and can't currently be tweaked.
 const EncryptionBlockSize int = 1048576
 
-// EncryptionArmorHeader is the header that marks the start of an encrypted
-// armored KB message.
-const EncryptionArmorHeader = "BEGIN KEYBASE SALTPACK ENCRYPTED MESSAGE"
-
-// EncryptionArmorFooter is the footer that marks the end of an encrypted
-// armored KB message.
-const EncryptionArmorFooter = "END KEYBASE SALTPACK ENCRYPTED MESSAGE"
-
-// SignedArmorHeader is the header that marks the start of signed
-// armored KB message.
-const SignedArmorHeader = "BEGIN KEYBASE SALTPACK SIGNED MESSAGE"
-
-// SignedArmorFooter is the footer that marks the end of signed
-// armored KB message.
-const SignedArmorFooter = "END KEYBASE SALTPACK SIGNED MESSAGE"
-
-// DetachedSignatureArmorHeader is the header that marks the start of
-// a detached armored KB signature.
-const DetachedSignatureArmorHeader = "BEGIN KEYBASE SALTPACK DETACHED SIGNATURE"
-
-// DetachedSignatureArmorFooter is the footer that marks the end of
-// a detached armored KB signature.
-const DetachedSignatureArmorFooter = "END KEYBASE SALTPACK DETACHED SIGNATURE"
+const encryptionArmorString = "ENCRYPTED MESSAGE"
+const signedArmorString = "SIGNED MESSAGE"
+const detachedSignatureArmorString = "DETACHED SIGNATURE"
 
 // SaltpackFormatName is the publicly advertised name of the format,
 // used in the header of the message and also in Nonce creation.

--- a/go/saltpack/errors.go
+++ b/go/saltpack/errors.go
@@ -31,9 +31,6 @@ var (
 	// of randomness, so this should never happen
 	ErrInsufficientRandomness = errors.New("could not collect enough randomness")
 
-	// ErrBadArmorFrame shows up when the ASCII armor frame has non-ASCII
-	ErrBadArmorFrame = errors.New("bad frame found; had non-ASCII")
-
 	// ErrBadEphemeralKey is for when an ephemeral key fails to be properly
 	// imported.
 	ErrBadEphemeralKey = errors.New("bad ephermal key in header")
@@ -94,26 +91,17 @@ type ErrBadVersion struct {
 	received Version
 }
 
-// ErrBadArmorHeader shows up when we get the wrong value for our header
-type ErrBadArmorHeader struct {
-	wanted   string
-	received string
+// ErrBadFrame shows up when the BEGIN or END frames have issues
+type ErrBadFrame struct {
+	msg string
 }
 
-// ErrBadArmorFooter shows up when we get the wrong value for our header
-type ErrBadArmorFooter struct {
-	wanted   string
-	received string
+func (e ErrBadFrame) Error() string {
+	return fmt.Sprintf("Error in framing: %s", e.msg)
 }
 
-func (e ErrBadArmorFooter) Error() string {
-	return fmt.Sprintf("Bad encryption armor footer; wanted '%s' but got '%s'",
-		e.wanted, e.received)
-}
-
-func (e ErrBadArmorHeader) Error() string {
-	return fmt.Sprintf("Bad encryption armor header; wanted '%s' but got '%s'",
-		e.wanted, e.received)
+func makeErrBadFrame(format string, args ...interface{}) error {
+	return ErrBadFrame{fmt.Sprintf(format, args...)}
 }
 
 func (e ErrWrongMessageType) Error() string {

--- a/go/saltpack/frame.go
+++ b/go/saltpack/frame.go
@@ -1,0 +1,99 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package saltpack
+
+import (
+	"strings"
+)
+
+type headerOrFooterMarker string
+
+const (
+	headerMarker headerOrFooterMarker = "BEGIN"
+	footerMarker headerOrFooterMarker = "END"
+)
+
+func pop(v *([]string), n int) (ret []string) {
+	ret = (*v)[(len(*v) - n):]
+	*v = (*v)[0:(len(*v) - n)]
+	return
+}
+
+func shift(v *([]string), n int) (ret []string) {
+	ret = (*v)[0:n]
+	*v = (*v)[n:]
+	return
+}
+
+func makeFrame(which headerOrFooterMarker, typ MessageType, brand string) string {
+	sffx := getStringForType(typ)
+	if len(sffx) == 0 {
+		return sffx
+	}
+	words := []string{string(which)}
+	if len(brand) > 0 {
+		words = append(words, brand)
+		brand += " "
+	}
+	words = append(words, strings.ToUpper(SaltpackFormatName))
+	words = append(words, sffx)
+	return strings.Join(words, " ")
+}
+
+func MakeArmorHeader(typ MessageType, brand string) string {
+	return makeFrame(headerMarker, typ, brand)
+}
+func MakeArmorFooter(typ MessageType, brand string) string {
+	return makeFrame(footerMarker, typ, brand)
+}
+
+func getStringForType(typ MessageType) string {
+	switch typ {
+	case MessageTypeEncryption:
+		return encryptionArmorString
+	case MessageTypeAttachedSignature:
+		return signedArmorString
+	case MessageTypeDetachedSignature:
+		return detachedSignatureArmorString
+	default:
+		return ""
+	}
+}
+
+func parseFrame(m string, typ MessageType, hof headerOrFooterMarker) (brand string, err error) {
+
+	sffx := getStringForType(typ)
+	if len(sffx) == 0 {
+		err = makeErrBadFrame("Message type %v not found", typ)
+		return
+	}
+	v := strings.Split(m, " ")
+	if len(v) != 4 && len(v) != 5 {
+		err = makeErrBadFrame("wrong number of words (%d)", len(v))
+		return
+	}
+
+	front := shift(&v, 1)
+	if front[0] != string(hof) {
+		err = makeErrBadFrame("Bad prefix: %s (wanted %s)", front[0], string(hof))
+		return
+	}
+
+	expected := getStringForType(typ)
+	tmp := pop(&v, 2)
+	received := strings.Join(tmp, " ")
+	if received != expected {
+		err = makeErrBadFrame("wanted %q but got %q", expected, received)
+		return
+	}
+	spfn := pop(&v, 1)
+	if spfn[0] != strings.ToUpper(SaltpackFormatName) {
+		err = makeErrBadFrame("bad format name (%s)", spfn[0])
+		return
+	}
+	if len(v) > 0 {
+		brand = v[0]
+	}
+	return brand, err
+}


### PR DESCRIPTION
- the word "KEYBASE" doesn't appear in code in the saltpack/ library
- it's supplied as a parameter to encryption, and a return value from decryption
  (and similarly for signing/verifying)
- should make it easy to adopt for other uses
- add more tests for bad frames