### PR TITLE
update the encryption spec to use HMAC and hash the entire header

### DIFF
--- a/go/saltpack/specs/saltpack.md
+++ b/go/saltpack/specs/saltpack.md
@@ -1,4 +1,4 @@
-# SaltPack
+# Saltpack
 ### An Alternative to the PGP Message Format
 
 Keybase today supports both PGP and NaCl keys. NaCl is the more modern of the
@@ -18,7 +18,7 @@ We start with some simplifying decisions:
 - We'll use [MessagePack](http://msgpack.org/index.html) for all the binary
   formatting.
 
-Thus, "SaltPack" (pronounced "NaCl pack"). The spec is in three parts:
+Thus, "saltpack" (pronounced "NaCl pack"). The spec is in three parts:
 
 - [a binary encryption format](saltpack_encryption.md)
 - [a binary signing format](saltpack_signing.md)

--- a/go/saltpack/specs/saltpack.md
+++ b/go/saltpack/specs/saltpack.md
@@ -18,7 +18,7 @@ We start with some simplifying decisions:
 - We'll use [MessagePack](http://msgpack.org/index.html) for all the binary
   formatting.
 
-Thus, "saltpack" (pronounced "NaCl pack"). The spec is in three parts:
+Thus, "saltpack". The spec is in three parts:
 
 - [a binary encryption format](saltpack_encryption.md)
 - [a binary signing format](saltpack_signing.md)

--- a/go/saltpack/specs/saltpack_armor.md
+++ b/go/saltpack/specs/saltpack_armor.md
@@ -1,6 +1,6 @@
-# SaltPack ASCII Armor Format
+# Saltpack ASCII Armor Format
 
-Like PGP, SaltPack encrypted and signed messages are binary formats. We need to
+Like PGP, saltpack encrypted and signed messages are binary formats. We need to
 wrap them in ASCII armor, to let people paste them into websites and apps that
 handle text.
 
@@ -13,13 +13,13 @@ where they interpret slashes and underscores as italics and strip them out.
 Even something as innocuous as `...` might turn into `…` and break decoding.
 
 We define the BaseX encoding scheme below, in a way that's independent of any
-particular alphabet or block size. For SaltPack we then select a 62-character
+particular alphabet or block size. For saltpack we then select a 62-character
 alphabet (all the digits and letters, in ASCII order) and a 32-byte input block
 size, which gives us 43-character output blocks and a packing efficiency of
 74.42%, compared to Base64's 75%. Finally we specify how the decoder recognizes
 the header and footer lines and strips whitespace.
 
-Here's the SaltPack armor encoding of the standard lorem ipsum paragraph:
+Here's the saltpack armor encoding of the standard lorem ipsum paragraph:
 
 > BEGIN SALTPACK MESSAGE.
 >
@@ -143,7 +143,7 @@ We can compare these efficiency figures to the theoretical maximum for a
                    = log_2(62) / 8
                    ≈ 0.7443
 
-The table above helped us pick the 32-byte block size for SaltPack. It hits an
+The table above helped us pick the 32-byte block size for saltpack. It hits an
 efficiency sweet spot without being absurdly large.
 
 ### Comparison to Base64
@@ -194,7 +194,7 @@ However, BaseX doesn't bother with this adjustment, for a few reasons:
 The last point is clear when we look at how single-byte blocks are encoded. In
 standard Base64, the bytes 0x00, 0x01, and 0x02 encode to `AA`, `AQ`, and `Ag`.
 In the same alphabet, BaseX would encodes those bytes as `AA`, `AB`, and `AC`.
-The 62-character SaltPack alphabet starts with the ASCII numerals, so those
+The 62-character saltpack alphabet starts with the ASCII numerals, so those
 bytes encode to `00`, `01`, and `02`, which is even nicer.
 
 ### Comparison to Base85

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -139,7 +139,8 @@ header:
 4. For each recipient, encrypt the **payload key** using
    [`crypto_box`](http://nacl.cr.yp.to/box.html) with the recipient's public
    key and the ephemeral private key. (See [Nonces](#nonces).) Assemble these
-   into the **recipients list**.
+   into the **recipients list**. Pair these with the recipients' public keys,
+   or `null` for anonymous recipients.
 5. Collect the **format name**, **version**, and **mode** into a list, followed
    by the **ephemeral public key**, the **sender secretbox**, and the nested
    **recipients list**.

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -106,7 +106,6 @@ header length
 - The **sender secretbox** is a
   [`crypto_secretbox`](http://nacl.cr.yp.to/secretbox.html) containing the
   sender's long-term public key, encrypted with the **payload key** from below.
-  (See [Nonces](#nonces).)
 - The **recipients list** contains a recipient pair for each recipient key,
   including an encrypted copy of the **payload key**. See below.
 
@@ -122,8 +121,8 @@ A recipient pair is a two-element list:
 - The **recipient public key** is the recipient's long-term NaCl public
   encryption key. This field may be null, when the recipients are anonymous.
 - The **payload key box** is a [`crypto_box`](http://nacl.cr.yp.to/box.html)
-  containing a copy of the **payload key**. It's encrypted with the recipient's
-  public key and the ephemeral private key. (See [Nonces](#nonces).)
+  containing a copy of the **payload key**, encrypted with the recipient's
+  public key and the ephemeral private key.
 
 ### Generating a Header Packet
 
@@ -135,7 +134,8 @@ header:
    [`crypto_box_keypair`](http://nacl.cr.yp.to/box.html).
 3. Encrypt the sender's long-term public key using
    [`crypto_secretbox`](http://nacl.cr.yp.to/secretbox.html) with the **payload
-   key**, to create the **sender secretbox**. (See [Nonces](#nonces).)
+   key**, to create the **sender secretbox**. (The [Nonces](#nonces) section
+   below specifies what nonce to use.)
 4. For each recipient, encrypt the **payload key** using
    [`crypto_box`](http://nacl.cr.yp.to/box.html) with the recipient's public
    key and the ephemeral private key. (See [Nonces](#nonces).) Assemble these

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -1,4 +1,4 @@
-# SaltPack Binary Encryption Format
+# Saltpack Binary Encryption Format
 
 **Changelog**
 - 5 Jan 2015
@@ -35,10 +35,10 @@ our messages to have:
   without needing to fit the whole thing in RAM. At the same time, decryption
   should never output any unauthenticated bytes.
 - Abuse resistance. Alice might use the same encryption key for many
-  applications besides SaltPack. If Mallory intercepts some of these other
+  applications besides saltpack. If Mallory intercepts some of these other
   ciphertexts, she could [try to trick Alice into decrypting
   them](https://blog.sandstorm.io/news/2015-05-01-is-that-ascii-or-protobuf.html)
-  by formatting them as a SaltPack message. Alice's SaltPack client should fail
+  by formatting them as a saltpack message. Alice's saltpack client should fail
   to decrypt these forgeries.
 
 ## Design
@@ -89,7 +89,7 @@ The header packet is a MessagePack list with these contents:
 ]
 ```
 
-- The **format name** is the string "SaltPack".
+- The **format name** is the string "saltpack".
 - The **version** is a list of the major and minor versions, currently
   `[1, 0]`.
 - The **mode** is the number 0, for encryption. (1 and 2 are attached and
@@ -190,7 +190,7 @@ NaCl libraries that only expose these higher-level constructions.
 
 We use a pseudorandom prefix to avoid nonce reuse. Define the nonce prefix `P`
 to be the first 16 bytes of the SHA512 of the concatenation of these values:
-- `"SaltPack\0"` (`\0` is a [null
+- `"saltpack\0"` (`\0` is a [null
   byte](https://www.ietf.org/mail-archive/web/tls/current/msg14734.html))
 - `"encryption nonce prefix\0"`
 - the 32-byte **ephemeral public key**
@@ -211,8 +211,8 @@ the second time.
 
 Besides avoiding nonce reuse and enforcing the packet order, we also want to
 prevent abuse of the decryption key. Alice might use Bob's public key to
-encrypt many kinds of messages, besides just SaltPack messages. If Mallory
-intercepted one of these, she could assemble a fake SaltPack message using the
+encrypt many kinds of messages, besides just saltpack messages. If Mallory
+intercepted one of these, she could assemble a fake saltpack message using the
 intercepted box, in the hope that Bob might reveal something about its contents
 by decrypting it. If we used a random nonce transmitted in the message header,
 Mallory could choose the nonce to match an intercepted box. Using the `P`
@@ -220,12 +220,12 @@ prefix instead makes this attack difficult. Unless Mallory can compute enough
 hashes to find one with a specific 16-byte prefix, she can't control the nonce
 that Bob uses to decrypt.
 
-Some applications might use the SaltPack format, but don't want decryption
-compatibility with other SaltPack applications. In addition to changing the
+Some applications might use the saltpack format, but don't want decryption
+compatibility with other saltpack applications. In addition to changing the
 format name at the start of the header, these applications should use a
 [different null-terminated context
 string](https://www.ietf.org/mail-archive/web/tls/current/msg14734.html) in
-place of `"SaltPack\0"`.
+place of `"saltpack\0"`.
 
 ## Example
 
@@ -233,7 +233,7 @@ place of `"SaltPack\0"`.
 # header packet
 [
   # format name
-  "SaltPack",
+  "saltpack",
   # major and minor version
   [1, 0],
   # mode (0 = encryption)

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -294,6 +294,8 @@ place of `"saltpack\0"` above.
 ## Example
 
 ```yaml
+# header length
+150
 # header packet
 [
   # format name
@@ -303,9 +305,9 @@ place of `"saltpack\0"` above.
   # mode (0 = encryption)
   0,
   # ephemeral public key
-  e1c7c20fc7ac2012fe4066f5350ae3bbcdb1d243a6ae9706710727611e6efa65,
+  895e690ba0fd8d15f51adf59e161af3f67518fa6e2eaadd8a666b8a1629c2349,
   # sender secretbox
-  86eb1d6032e9a199ecbf844b8d0bb0cde096f84c08a07960f1ea929cee907df5b5e7757ca612a121a7927ffd0cf8fcde,
+  b49c4c8791cd97f2c244c637df90e343eda4aaa56e37d975d2b7c81d36f44850d77706a51e2ccd57e7f7606565db4b1e,
   # recipient pairs
   [
     # the first recipient pair
@@ -313,7 +315,7 @@ place of `"saltpack\0"` above.
       # recipient public key (null in this case, for an anonymous recipient)
       null,
       # payload key box
-      36b1d43f73660961bb8033ad880db2b4b5b00b7a08908cb00551de07719a9455f48672eae697ea0270be6ffe1d3740da,
+      c16b6126d155d7a39db20825d6c43f856689d0f8665a8da803270e0106ed91a90ef599961492bd6e49c69b43adc22724,
     ],
     # subsequent recipient pairs...
   ],
@@ -324,11 +326,11 @@ place of `"saltpack\0"` above.
   # authenticators list
   [
     # the first recipient's authenticator
-    c84eafa03ede35d527b24785ca8b722c84eafa03ede35d527b24785ca8b72266,
+    f90b04186d599b42779564fc93535e1de486de5fbb98e8a987487799910c10c8,
     # subsequent authenticators...
   ],
   # payload secretbox
-  b3f359cfaa303a6f38378b2525d0f731911dd8d73af53f,
+  f991dbe030e2cfa00a640376f956c68b2d113ec6384441a1834e455acbb046ead9389826e92cb7f91cc7ab30c3d4d38ef5e84d12617f37,
 ]
 
 # empty payload packet
@@ -336,10 +338,10 @@ place of `"saltpack\0"` above.
   # authenticators list
   [
     # the first recipient's authenticator
-    c556aade21fd10054603560faa6ce53c556aade21fd10054603560faa6ce5355,
+    0bd743eb8b9c48ba1888d265cd90dedcc3d56b0a003ef99763af224c1a6501db,
     # subsequent authenticators...
   ],
   # the empty payload secretbox
-  16585d2741f0be03882d8df76905535a,
+  481ef99b4f0d0f918edd82e9f5619a41,
 ]
 ```

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -104,7 +104,7 @@ header length
   ephemeral keypair is generated at random by the sender and only used for one
   message.
 - The **sender secretbox** is a NaCl secretbox containing the sender's
-  long-term public key, encrypted with the **payload key**. (See
+  long-term public key, encrypted with the **payload key** from below. (See
   [Nonces](#nonces).)
 - The **recipients list** contains a recipient pair for each recipient key,
   including an encrypted copy of the **payload key**. See below.
@@ -188,6 +188,10 @@ Recipients parse the header of a message using the following steps:
    key and the sender's public key from #8. (See [Nonces](#nonces).) The **MAC
    key** is the last 32 bytes of the resulting box.
 
+If the recipient's public key is shown in the **recipients list** (that is, if
+the recipient is not anonymous), clients may skip all the other **payload key
+boxes** in step #7.
+
 Note that when parsing lists in general, if a list is longer than expected,
 clients should allow the extra fields and ignore them. That allows us to make
 future additions to the format without breaking backward compatibility.
@@ -203,7 +207,8 @@ A payload packet is a MessagePack list with these contents:
 ```
 
 - The **authenticators list** contains 32-byte HMAC tags, one for each
-  recipient, which authenticate the **payload secretbox**.
+  recipient, which authenticate the **payload secretbox** together with the
+  message header.
 - The **payload secretbox** is a NaCl secretbox containing a chunk of the
   plaintext bytes, max size 1 MB. It's encrypted with the **payload key**. (See
   [Nonces](#nonces).)

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -103,9 +103,10 @@ header length
 - The **ephemeral public key** is a NaCl public encryption key, 32 bytes. The
   ephemeral keypair is generated at random by the sender and only used for one
   message.
-- The **sender secretbox** is a NaCl secretbox containing the sender's
-  long-term public key, encrypted with the **payload key** from below. (See
-  [Nonces](#nonces).)
+- The **sender secretbox** is a
+  [`crypto_secretbox`](http://nacl.cr.yp.to/secretbox.html) containing the
+  sender's long-term public key, encrypted with the **payload key** from below.
+  (See [Nonces](#nonces).)
 - The **recipients list** contains a recipient pair for each recipient key,
   including an encrypted copy of the **payload key**. See below.
 
@@ -120,9 +121,9 @@ A recipient pair is a two-element list:
 
 - The **recipient public key** is the recipient's long-term NaCl public
   encryption key. This field may be null, when the recipients are anonymous.
-- The **payload key box** is a NaCl box containing a copy of the **payload
-  key**. It's encrypted with the recipient's public key and the ephemeral
-  private key. (See [Nonces](#nonces).)
+- The **payload key box** is a [`crypto_box`](http://nacl.cr.yp.to/box.html)
+  containing a copy of the **payload key**. It's encrypted with the recipient's
+  public key and the ephemeral private key. (See [Nonces](#nonces).)
 
 ### Generating a Header Packet
 
@@ -208,7 +209,7 @@ A payload packet is a MessagePack list with these contents:
 
 - The **authenticators list** contains 32-byte HMAC tags, one for each
   recipient, which authenticate the **payload secretbox** together with the
-  message header.
+  message header. See below.
 - The **payload secretbox** is a NaCl secretbox containing a chunk of the
   plaintext bytes, max size 1 MB. It's encrypted with the **payload key**. (See
   [Nonces](#nonces).)

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -178,9 +178,10 @@ Recipients parse the header of a message using the following steps:
    [`crypto_box_beforenm`](http://nacl.cr.yp.to/box.html) with the **ephemeral
    public key** and the sender's private key.
 7. Try to open each of the **payload key boxes** in the recipients list using
-   [`crypto_box_afternm`] and the shared secret from #6. (See
-   [Nonces](#nonces).) Successfully opening one gives the **payload key**, and
-   the index of the box that opened is the **recipient index**.
+   [`crypto_box_afternm`](http://nacl.cr.yp.to/box.html) and the shared secret
+   from #6. (See [Nonces](#nonces).) Successfully opening one gives the
+   **payload key**, and the index of the box that opened is the **recipient
+   index**.
 8. Open the **sender secretbox** using
    [`crypto_secretbox_open`](http://nacl.cr.yp.to/secretbox.html) and the
    **payload key** from #7. (See [Nonces](#nonces).)

--- a/go/saltpack/specs/saltpack_signing.md
+++ b/go/saltpack/specs/saltpack_signing.md
@@ -1,4 +1,4 @@
-# SaltPack Binary Signing Format
+# Saltpack Binary Signing Format
 
 As with the [encryption format](saltpack_encryption.md), we want our signing
 format to have some properties on top of a standard NaCl signature:
@@ -6,7 +6,7 @@ format to have some properties on top of a standard NaCl signature:
   fitting the whole thing in RAM, and without requiring a second pass to output
   attached plaintext. But we should only ever output verified data.
 - Abuse resistance. Alice might use the same signing key for many applications
-  besides SaltPack. Mallory (an attacker) could [try to trick Alice into
+  besides saltpack. Mallory (an attacker) could [try to trick Alice into
   signing
   messages](https://blog.sandstorm.io/news/2015-05-01-is-that-ascii-or-protobuf.html)
   that are meaningful to other applications. Alice should avoid signing bytes
@@ -42,7 +42,7 @@ header packet is a MessagePack array that looks like this:
 ]
 ```
 
-- **format_name** is the string "SaltPack".
+- **format_name** is the string "saltpack".
 - **version** is a list of the major and minor versions, currently `[1, 0]`.
 - **mode** is the number 1, for attached signing. (0 is encryption, and 2 is
   detached signing.)
@@ -69,16 +69,16 @@ concatenation of three values:
 - the **payload_chunk**
 
 The sender then signs the concatenation of three values:
-- `"SaltPack\0"`
+- `"saltpack\0"`
 - `"attached signature\0"`
 - the SHA512 hash above
 
-Some applications might use the SaltPack format, but don't want signature
-compatibility with other SaltPack applications. In addition to changing the
+Some applications might use the saltpack format, but don't want signature
+compatibility with other saltpack applications. In addition to changing the
 format name at the start of the header, these applications should use a
 [different null-terminated context
 string](https://www.ietf.org/mail-archive/web/tls/current/msg14734.html) in
-place of `"SaltPack\0"`.
+place of `"saltpack\0"`.
 
 ## Detached Implementation
 
@@ -96,7 +96,7 @@ itself, with an extra signature field at the end.
 ]
 ```
 
-- **format_name** is the string "SaltPack".
+- **format_name** is the string "saltpack".
 - **version** is a list of the major and minor versions, currently `[1, 0]`.
 - **mode** is the number 2, for attached signing. (0 is encryption, and 1 is
   attached signing.)
@@ -111,7 +111,7 @@ concatenation of two values:
 - the entire plaintext
 
 The sender then signs the concatenation of three values:
-- `"SaltPack\0"`
+- `"saltpack\0"`
 - `"detached signature\0"`
 - the SHA512 hash above
 
@@ -123,7 +123,7 @@ An attached signature:
 # header packet
 [
   # format name
-  "SaltPack",
+  "saltpack",
   # major and minor version
   [1, 0],
   # mode (1 = attached signing)
@@ -157,7 +157,7 @@ A detached signature:
 # header packet (the only packet)
 [
   # format name
-  "SaltPack",
+  "saltpack",
   # major and minor version
   [1, 0],
   # mode (2 = detached signing)


### PR DESCRIPTION
I ended up going with the "reserializing the header is allowed approach" rather than framing, but we can go the other way if you prefer. I didn't try to truncate the 32-byte `crypto_auth` output, though that's an option too.

@maxtaco 