### PR TITLE
UnboxBytes32Any working with device and paper keys

### DIFF
--- a/go/engine/crypto.go
+++ b/go/engine/crypto.go
@@ -119,5 +119,6 @@ func UnboxBytes32(g *libkb.GlobalContext, secretUI libkb.SecretUI,
 }
 
 func UnboxBytes32Any(g *libkb.GlobalContext, secretUI libkb.SecretUI, arg keybase1.UnboxBytes32AnyArg) (res keybase1.UnboxAnyRes, err error) {
+	defer g.Trace("UnboxBytes32Any", func() error { return err })
 	return
 }

--- a/go/engine/crypto.go
+++ b/go/engine/crypto.go
@@ -123,7 +123,7 @@ func UnboxBytes32Any(g *libkb.GlobalContext, secretUI libkb.SecretUI, arg keybas
 
 	key, err := getMatchingSecretKey(g, secretUI, arg)
 	if err != nil {
-		return bytes32, err
+		return res, err
 	}
 
 	g.Log.Debug("found key for unbox: %s", key.GetKID())

--- a/go/engine/paperkey.go
+++ b/go/engine/paperkey.go
@@ -20,6 +20,7 @@ import (
 // PaperKey is an engine.
 type PaperKey struct {
 	passphrase libkb.PaperKeyPhrase
+	gen        *PaperKeyGen
 	libkb.Contextified
 }
 
@@ -123,8 +124,8 @@ func (e *PaperKey) Run(ctx *Context) error {
 		Me:         me,
 		SigningKey: signingKey,
 	}
-	kgeng := NewPaperKeyGen(kgarg, e.G())
-	if err := RunEngine(kgeng, ctx); err != nil {
+	e.gen = NewPaperKeyGen(kgarg, e.G())
+	if err := RunEngine(e.gen, ctx); err != nil {
 		return err
 	}
 
@@ -134,4 +135,12 @@ func (e *PaperKey) Run(ctx *Context) error {
 
 func (e *PaperKey) Passphrase() string {
 	return e.passphrase.String()
+}
+
+func (e *PaperKey) SigKey() libkb.GenericKey {
+	return e.gen.SigKey()
+}
+
+func (e *PaperKey) EncKey() libkb.GenericKey {
+	return e.gen.EncKey()
 }

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -344,7 +344,6 @@ func (n *nullui) Shutdown() error {
 
 type TestSecretUI struct {
 	Passphrase          string
-	BackupPassphrase    string
 	StoreSecret         bool
 	CalledGetPassphrase bool
 }

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -684,6 +684,7 @@ type CiphertextKIDPair struct {
 type UnboxAnyRes struct {
 	Kid       KID     `codec:"kid" json:"kid"`
 	Plaintext Bytes32 `codec:"plaintext" json:"plaintext"`
+	Index     int     `codec:"index" json:"index"`
 }
 
 type SignED25519Arg struct {

--- a/protocol/avdl/crypto.avdl
+++ b/protocol/avdl/crypto.avdl
@@ -49,6 +49,7 @@ protocol crypto {
   record UnboxAnyRes {
     KID kid;                 // the KID that was used for decryption
     Bytes32 plaintext;       // decrypted data
+    int index;
   }
 
   UnboxAnyRes unboxBytes32Any(array<CiphertextKIDPair> pairs, BoxNonce nonce, BoxPublicKey peersPublicKey, string reason);

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -619,11 +619,13 @@ export type CiphertextKIDPair = {
 export type crypto_UnboxAnyRes = {
   kid: KID;
   plaintext: Bytes32;
+  index: int;
 }
 
 export type UnboxAnyRes = {
   kid: KID;
   plaintext: Bytes32;
+  index: int;
 }
 
 export type ctl_Time = {

--- a/protocol/json/crypto.json
+++ b/protocol/json/crypto.json
@@ -265,6 +265,9 @@
     }, {
       "name" : "plaintext",
       "type" : "Bytes32"
+    }, {
+      "name" : "index",
+      "type" : "int"
     } ]
   } ],
   "messages" : {

--- a/react-native/react/constants/types/flow-types.js
+++ b/react-native/react/constants/types/flow-types.js
@@ -619,11 +619,13 @@ export type CiphertextKIDPair = {
 export type crypto_UnboxAnyRes = {
   kid: KID;
   plaintext: Bytes32;
+  index: int;
 }
 
 export type UnboxAnyRes = {
   kid: KID;
   plaintext: Bytes32;
+  index: int;
 }
 
 export type ctl_Time = {


### PR DESCRIPTION
Cached and uncached.  When paper key is not cached, the prompt includes the descriptions of the set of paper keys that will work.

PTAL @maxtaco 

Also @jzila: note that the protocol response includes the index.  However, UnboxBytes32() as it stands only works with device keys, so subsequent calls should still use UnboxBytes32Any() with a single pair, if that is desired...

