### PR TITLE
prepare updater.go for running on Linux

### DIFF
--- a/go/updater/updater_test.go
+++ b/go/updater/updater_test.go
@@ -114,7 +114,7 @@ func TestUpdateCheckErrorIfLowerVersion(t *testing.T) {
 	u := NewTestUpdater(t, NewDefaultTestUpdateConfig())
 	u.options.Version = "100000000.0.0"
 
-	update, err := u.checkForUpdate(true, false, false)
+	update, err := u.checkForUpdate(false, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Restrict the file-downloading parts of the updater to Darwin-only.

@gabriel Is this a reasonable start? Can you think of other parts we're going to need to change? (cc @cjb)