### PR TITLE
Making scripts more platform independent

### DIFF
--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e -u -o pipefail # Fail on error
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+cd "$dir"
+
+GOPATH=${GOPATH:-}
+nopull=${NOPULL:-} # Don't check and pull repos
+nobuild=${NOBUILD:-}
+
+platform=${PLATFORM:-`uname`}
+
+if [ "$GOPATH" = "" ]; then
+  echo "No GOPATH"
+  exit 1
+fi
+
+build_dir_keybase="/tmp/build_keybase"
+build_dir_kbfs="/tmp/build_kbfs"
+client_dir="$GOPATH/src/github.com/keybase/client"
+bucket_name="prerelease.keybase.io"
+
+"$client_dir/packaging/slack/send.sh" "Starting build"
+
+if [ ! "$nopull" = "1" ]; then
+  "$client_dir/packaging/check_status_and_pull.sh" "$client_dir"
+  "$client_dir/packaging/check_status_and_pull.sh" "$GOPATH/src/github.com/keybase/kbfs"
+ else
+  # Save to alternate testing bucket if we are building local
+  bucket_name="prerelease-testing"
+fi
+
+if [ ! "$nobuild" = "1" ]; then
+  BUILD_DIR=$build_dir_keybase ./build_keybase.sh
+  BUILD_DIR=$build_dir_kbfs ./build_kbfs.sh
+fi
+
+cd $dir/../desktop
+save_dir="/tmp/build_desktop"
+rm -rf $save_dir
+
+if [ "$platform" = "Darwin" ]; then
+  SAVE_DIR=$save_dir KEYBASE_BINPATH="$build_dir_keybase/keybase" KBFS_BINPATH="$build_dir_kbfs/kbfs" BUCKET_NAME=$bucket_name ./package_darwin.sh
+elif [ "$platform" = "Linux" ]; then
+  SAVE_DIR=$save_dir KEYBASE_BINPATH="$build_dir_keybase/keybase" KBFS_BINPATH="$build_dir_kbfs/kbfs" BUCKET_NAME=$bucket_name ./package_linux.sh
+else
+  # TODO: Support linux build here?
+  echo "Unknown platform: $platform"
+  exit 1
+fi
+
+cd $dir
+SAVE_DIR=$save_dir BUCKET_NAME=$bucket_name ./s3_index.sh
+
+"$client_dir/packaging/slack/send.sh" "Finished build. See https://s3.amazonaws.com/$bucket_name/index.html"

--- a/packaging/prerelease/build_app_darwin.sh
+++ b/packaging/prerelease/build_app_darwin.sh
@@ -5,38 +5,4 @@ set -e -u -o pipefail # Fail on error
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 cd "$dir"
 
-GOPATH=${GOPATH:-}
-NOPULL=${NOPULL:-} # Don't check and pull repos
-
-if [ "$GOPATH" = "" ]; then
-  echo "No GOPATH"
-  exit 1
-fi
-
-build_dir_keybase="/tmp/build_keybase"
-build_dir_kbfs="/tmp/build_kbfs"
-client_dir="$GOPATH/src/github.com/keybase/client"
-bucket_name="prerelease.keybase.io"
-
-"$client_dir/packaging/slack/send.sh" "Starting build"
-
-if [ ! "$NOPULL" = "1" ]; then
-  "$client_dir/packaging/check_status_and_pull.sh" "$client_dir"
-  "$client_dir/packaging/check_status_and_pull.sh" "$GOPATH/src/github.com/keybase/kbfs"
- else
-  # Save to alternate testing bucket if we are building local
-  bucket_name="prerelease-testing"
-fi
-
-BUILD_DIR=$build_dir_keybase ./build_keybase.sh
-BUILD_DIR=$build_dir_kbfs ./build_kbfs.sh
-
-cd $dir/../desktop
-save_dir="/tmp/build_desktop"
-rm -rf $save_dir
-SAVE_DIR=$save_dir KEYBASE_BINPATH="$build_dir_keybase/keybase" KBFS_BINPATH="$build_dir_kbfs/kbfs" BUCKET_NAME=$bucket_name ./package_darwin.sh
-
-cd $dir
-SAVE_DIR=$save_dir BUCKET_NAME=$bucket_name ./s3_index.sh
-
-"$client_dir/packaging/slack/send.sh" "Finished build. See https://s3.amazonaws.com/$bucket_name/index.html"
+PLATFORM=Darwin ./build_app.sh

--- a/packaging/prerelease/build_kbfs.sh
+++ b/packaging/prerelease/build_kbfs.sh
@@ -13,13 +13,21 @@ commit_short=`git log -1 --pretty=format:%h`
 build="$current_date+$commit_short"
 kbfs_build=${KBFS_BUILD:-$build}
 tags=${TAGS:-"prerelease production"}
+platform=${PLATFORM:-`uname`}
+ldflags="-X github.com/keybase/kbfs/libkbfs.CustomBuild=$kbfs_build"
+
+if [ "$platform" = "Darwin" ]; then
+  # To get codesign to work you have to use -ldflags "-s ...", see https://github.com/golang/go/issues/11887
+  ldflags="-s $ldflags"
+fi
 
 echo "Building $build_dir/kbfs ($kbfs_build)"
-# To get codesign to work you have to use -ldflags "-s ...", see https://github.com/golang/go/issues/11887
-GO15VENDOREXPERIMENT=1 go build -a -tags "$tags" -ldflags "-s -X github.com/keybase/kbfs/libkbfs.CustomBuild=$kbfs_build" -o $build_dir/kbfs github.com/keybase/kbfs/kbfsfuse
+GO15VENDOREXPERIMENT=1 go build -a -tags "$tags" -ldflags "$ldflags" -o $build_dir/kbfs github.com/keybase/kbfs/kbfsfuse
 
-code_sign_identity="Developer ID Application: Keybase, Inc. (99229SGT5K)"
-codesign --verbose --force --deep --timestamp=none --sign "$code_sign_identity" $build_dir/kbfs
+if [ "$platform" = "Darwin" ]; then
+  code_sign_identity="Developer ID Application: Keybase, Inc. (99229SGT5K)"
+  codesign --verbose --force --deep --timestamp=none --sign "$code_sign_identity" $build_dir/kbfs
+fi
 
 kbfs_version=`$build_dir/kbfs -version`
 echo "KBFS version: $kbfs_version"

--- a/packaging/prerelease/build_keybase.sh
+++ b/packaging/prerelease/build_keybase.sh
@@ -13,13 +13,21 @@ commit_short=`git log -1 --pretty=format:%h`
 build="$current_date+$commit_short"
 keybase_build=${KEYBASE_BUILD:-$build}
 tags=${TAGS:-"prerelease production"}
+platform=${PLATFORM:-`uname`}
+ldflags="-X github.com/keybase/client/go/libkb.CustomBuild=$keybase_build"
+
+if [ "$platform" = "Darwin" ]; then
+  # To get codesign to work you have to use -ldflags "-s ...", see https://github.com/golang/go/issues/11887
+  ldflags="-s $ldflags"
+fi
 
 echo "Building $build_dir/keybase ($keybase_build)"
-# To get codesign to work you have to use -ldflags "-s ...", see https://github.com/golang/go/issues/11887
-GO15VENDOREXPERIMENT=1 go build -a -tags "$tags" -ldflags "-s -X github.com/keybase/client/go/libkb.CustomBuild=$keybase_build" -o $build_dir/keybase github.com/keybase/client/go/keybase
+GO15VENDOREXPERIMENT=1 go build -a -tags "$tags" -ldflags "$ldflags" -o $build_dir/keybase github.com/keybase/client/go/keybase
 
-code_sign_identity="Developer ID Application: Keybase, Inc. (99229SGT5K)"
-codesign --verbose --force --deep --timestamp=none --sign "$code_sign_identity" $build_dir/keybase
+if [ "$platform" = "Darwin" ]; then
+  code_sign_identity="Developer ID Application: Keybase, Inc. (99229SGT5K)"
+  codesign --verbose --force --deep --timestamp=none --sign "$code_sign_identity" $build_dir/keybase
+fi
 
 version=`$build_dir/keybase version -S`
 echo "Keybase version: $version"


### PR DESCRIPTION
Renamed `prerelease/build_app_darwin.sh` to `prerelease/build_app.sh` and can be run from non-darwin platforms.

Linux can use `prerelease/build_keybase.sh` and `prerelease/build_kbfs.sh` to make go binaries with the prerelease versioning e.g. "1.2.3-201601110234+deadbeef".  (Now only does codesigning if darwin build.)

Created a `package_linux.sh` file in `desktop` placeholder with the update json creation and s3 sync at the end.

If you run `PLATFORM=Linux ./build_app.sh`, it should theoretically do the right stuff...