### PR TITLE
Remove default keybase id from pgp generate

### DIFF
--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Do not use current keybase ID as default when generating PGP keys
+- Rename SaltPack to saltpack
 - Fix hang in auth C/I tests (commit: 0a30c4ca47bd4d7b936f8bccf46afc00b143d5a7)
 - Better `keybase exp encrypt`/identification interaction (PR: keybase/client#1577)
 - Allow disabling self-encryption in `keybase exp encrypt` (PR: keybase/client#1606)

--- a/go/client/cmd_pgp.go
+++ b/go/client/cmd_pgp.go
@@ -15,7 +15,7 @@ func NewCmdPGP(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 		Usage:        "Manage keybase PGP keys",
 		ArgumentHelp: "[arguments...]",
 		Subcommands: []cli.Command{
-			NewCmdPGPGen(cl),
+			NewCmdPGPGen(cl, g),
 			NewCmdPGPPull(cl, g),
 			NewCmdPGPUpdate(cl),
 			NewCmdPGPSelect(cl),

--- a/go/client/prompts.go
+++ b/go/client/prompts.go
@@ -46,4 +46,5 @@ const (
 	PromptDescriptorUpdateAuto
 	PromptDescriptorUpdateSnooze
 	PromptDescriptorDecryptInteractive
+	PromptDescriptorPGPGenEnterID
 )

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -297,6 +297,7 @@ func TestProvisionPassphraseBadName(t *testing.T) {
 func TestProvisionPassphraseSyncedPGP(t *testing.T) {
 	tc := SetupEngineTest(t, "login")
 	u1 := createFakeUserWithPGPOnly(t, tc)
+	t.Log("Created fake user")
 	Logout(tc)
 	tc.Cleanup()
 

--- a/go/libkb/keygen_test.go
+++ b/go/libkb/keygen_test.go
@@ -11,45 +11,54 @@ import (
 
 type cidTest struct {
 	name      string
-	noDefArg  bool
 	pgpUIDArg []string
 	errOut    error
 	idsOut    []Identity
 }
 
 var cidTests = []cidTest{
-	{"empty", false, []string{}, nil, []Identity{
-		{Username: "keybase.io/foo", Email: "foo@keybase.io"},
-	}},
-	{"no default, no custom", true, []string{}, nil, []Identity{}},
-	{"no default", true, []string{"pc@pc.com"}, nil, []Identity{
+	{"empty", []string{}, nil, []Identity{}},
+	{"no custom", []string{}, nil, []Identity{}},
+	{"one ID", []string{"pc@pc.com"}, nil, []Identity{
 		{Email: "pc@pc.com"},
 	}},
-	{"default + custom", false, []string{"pc@pc.com"}, nil, []Identity{
-		{Email: "pc@pc.com"},
-		{Username: "keybase.io/foo", Email: "foo@keybase.io"},
+	{"one ID with comment", []string{"non_email_name (test comment)"}, nil, []Identity{
+		{Username: "non_email_name", Comment: "test comment"},
 	}},
-	{"default + many custom", false, []string{"pc@pc.com", "ab@ab.com", "cd@cd.com"}, nil, []Identity{
+	{"one email with comment", []string{"(test comment) <pc@pc.com>"}, nil, []Identity{
+		{Email: "pc@pc.com", Comment: "test comment"},
+	}},
+	{"custom", []string{"pc@pc.com"}, nil, []Identity{
+		{Email: "pc@pc.com"},
+	}},
+	{"many custom", []string{"pc@pc.com", "ab@ab.com", "cd@cd.com"}, nil, []Identity{
 		{Email: "pc@pc.com"},
 		{Email: "ab@ab.com"},
 		{Email: "cd@cd.com"},
-		{Username: "keybase.io/foo", Email: "foo@keybase.io"},
 	}},
-	{"pgp uid", true, []string{"Patrick Crosby <pc@pc.com>"}, nil, []Identity{
+	{"pgp uid", []string{"Patrick Crosby <pc@pc.com>"}, nil, []Identity{
 		{Username: "Patrick Crosby", Email: "pc@pc.com"},
 	}},
-	{"pgp uid no email", true, []string{"Patrick Crosby"}, nil, []Identity{
+	{"pgp uid no email", []string{"Patrick Crosby"}, nil, []Identity{
 		{Username: "Patrick Crosby"},
 	}},
-	{"brackets", true, []string{"<xyz@xyz.com>"}, nil, []Identity{
+	{"brackets", []string{"<xyz@xyz.com>"}, nil, []Identity{
 		{Email: "xyz@xyz.com"},
 	}},
-	{"mixture", false, []string{"Patrick Crosby", "pc@pc.com", "<ab@ab.com>", "CD <cd@cd.com>"}, nil, []Identity{
+	{"brackets with comment", []string{"(test comment) <xyz@xyz.com>"}, nil, []Identity{
+		{Email: "xyz@xyz.com", Comment: "test comment"},
+	}},
+	{"mixture", []string{"Patrick Crosby", "pc@pc.com", "<ab@ab.com>", "CD <cd@cd.com>"}, nil, []Identity{
 		{Username: "Patrick Crosby"},
 		{Email: "pc@pc.com"},
 		{Email: "ab@ab.com"},
 		{Username: "CD", Email: "cd@cd.com"},
-		{Username: "keybase.io/foo", Email: "foo@keybase.io"},
+	}},
+	// Note that we can parse an email by itself without brackets, but can't support a comment in that case
+	{"mixture2", []string{"Patrick Crosby (test comment1)", "(test comment3) <ab@ab.com>", "CD (test comment4) <cd@cd.com>"}, nil, []Identity{
+		{Username: "Patrick Crosby", Comment: "test comment1"},
+		{Email: "ab@ab.com", Comment: "test comment3"},
+		{Username: "CD", Comment: "test comment4", Email: "cd@cd.com"},
 	}},
 }
 
@@ -65,7 +74,7 @@ func TestCreateIds(t *testing.T) {
 	G.Env.GetConfigWriter().SetUserConfig(NewUserConfig(uid, "foo", []byte{}, nilDeviceID), true)
 
 	for _, test := range cidTests {
-		arg := &PGPGenArg{PrimaryBits: 1024, SubkeyBits: 1024, PGPUids: test.pgpUIDArg, NoDefPGPUid: test.noDefArg}
+		arg := &PGPGenArg{PrimaryBits: 1024, SubkeyBits: 1024, PGPUids: test.pgpUIDArg}
 		if err := arg.Init(); err != nil {
 			t.Errorf("%s: arg init err: %s", test.name, err)
 			continue
@@ -79,7 +88,6 @@ func TestCreateIds(t *testing.T) {
 			// this is an error test, no need to do anything else
 			continue
 		}
-		arg.AddDefaultUID()
 		if len(arg.Ids) != len(test.idsOut) {
 			t.Errorf("%s: %d IDs, expected %d.", test.name, len(arg.Ids), len(test.idsOut))
 			continue

--- a/go/libkb/pgp_gen.go
+++ b/go/libkb/pgp_gen.go
@@ -21,7 +21,6 @@ type PGPGenArg struct {
 	Ids             Identities
 	Config          *packet.Config
 	PGPUids         []string
-	NoDefPGPUid     bool
 	PrimaryLifetime int
 	SubkeyLifetime  int
 }
@@ -156,13 +155,12 @@ func (a *PGPGenArg) CreatePGPIDs() error {
 	return nil
 }
 
+// Just for testing
 func (a *PGPGenArg) AddDefaultUID() {
-	if a.NoDefPGPUid {
-		return
-	}
 	a.Ids = append(a.Ids, KeybaseIdentity(""))
 }
 
+// Just for testing
 func (a *PGPGenArg) MakeAllIds() error {
 	if err := a.CreatePGPIDs(); err != nil {
 		return err

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -751,7 +751,7 @@ func (u *User) ExportToUserPlusKeys(idTime keybase1.Time) keybase1.UserPlusKeys 
 func (a PGPGenArg) ExportTo(ret *keybase1.PGPKeyGenArg) {
 	ret.PrimaryBits = a.PrimaryBits
 	ret.SubkeyBits = a.SubkeyBits
-	ret.CreateUids = keybase1.PGPCreateUids{UseDefault: !a.NoDefPGPUid, Ids: a.Ids.Export()}
+	ret.CreateUids = keybase1.PGPCreateUids{Ids: a.Ids.Export()}
 	return
 }
 
@@ -760,7 +760,6 @@ func (a PGPGenArg) ExportTo(ret *keybase1.PGPKeyGenArg) {
 func ImportKeyGenArg(a keybase1.PGPKeyGenArg) (ret PGPGenArg) {
 	ret.PrimaryBits = a.PrimaryBits
 	ret.SubkeyBits = a.SubkeyBits
-	ret.NoDefPGPUid = !a.CreateUids.UseDefault
 	ret.Ids = ImportPGPIdentities(a.CreateUids.Ids)
 	return
 }

--- a/go/service/pgp.go
+++ b/go/service/pgp.go
@@ -194,7 +194,6 @@ func (h *PGPHandler) PGPExportByFingerprint(_ context.Context, arg keybase1.PGPE
 func (h *PGPHandler) PGPKeyGen(_ context.Context, arg keybase1.PGPKeyGenArg) error {
 	ctx := &engine.Context{LogUI: h.getLogUI(arg.SessionID), SecretUI: h.getSecretUI(arg.SessionID)}
 	earg := engine.ImportPGPKeyImportEngineArg(arg)
-	earg.Gen.AddDefaultUID()
 	eng := engine.NewPGPKeyImportEngine(earg)
 	return engine.RunEngine(eng, ctx)
 }


### PR DESCRIPTION
Support interactive userID input

@maxtaco @patrickxb 
@malgorithms wanted interactive userIds; both are supported with this change.

(replaces https://github.com/keybase/client/pull/1703, closed due to test failures)