### PR TITLE
Update store logout and trackers desktop 260

### DIFF
--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -81,7 +81,7 @@ class Keybase extends Component {
     ipcRenderer.send('remoteStoreReady')
 
     // Handle notifications from the service
-    ListenForNotifications(NotifyPopup)
+    ListenForNotifications(store.dispatch, NotifyPopup)
 
     // Handle logUi.log
     ListenLogUi()

--- a/react-native/react/actions/login/index.js
+++ b/react-native/react/actions/login/index.js
@@ -12,6 +12,7 @@ import {switchTab} from '../tabbed-router'
 import {devicesTab} from '../../constants/tabs'
 import {loadDevices} from '../devices'
 import {defaultModeForDeviceRoles, qrGenerate} from './provision-helpers'
+import {getCurrentStatus} from '../config'
 
 export function login () {
   return (dispatch, getState) => {
@@ -99,9 +100,17 @@ export function logout () {
       if (error) {
         console.log(error)
       } else {
-        dispatch({type: Constants.logoutDone})
+        dispatch(logoutDone)
       }
     })
+  }
+}
+
+export function logoutDone () {
+  // We've logged out, let's check our current status
+  return dispatch => {
+    dispatch({type: Constants.logoutDone})
+    dispatch(getCurrentStatus())
   }
 }
 

--- a/react-native/react/constants/config.js
+++ b/react-native/react/constants/config.js
@@ -13,7 +13,10 @@ export const navErrorStartingUp = 'navErrorStartingUp'
 export const startupLoading = 'config:startupLoading'
 export const startupLoaded = 'config:startupLoaded'
 
-export const devConfigLoading = 'config:devConfigLoadin'
+export const statusLoaded = 'config:statusLoaded'
+export const configLoaded = 'config:configLoaded'
+
+export const devConfigLoading = 'config:devConfigLoading'
 export const devConfigLoaded = 'config:devConfigLoaded'
 export const devConfigUpdate = 'config:devConfigUpdate'
 export const devConfigSaved = 'config:devConfigSaved'

--- a/react-native/react/constants/tracker.js
+++ b/react-native/react/constants/tracker.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 // Simple state of the overall proof result
-export type SimpleProofState = 'normal' | 'warning' | 'error' | 'checking' | 'revoked' | 'loggedOut'
+export type SimpleProofState = 'normal' | 'warning' | 'error' | 'checking' | 'revoked'
 export type SimpleProofMeta = 'upgraded' | 'new' | 'unreachable' | 'pending' | 'deleted' | 'none'
 
 // Constants
@@ -10,7 +10,6 @@ export const warning: SimpleProofState = 'warning'
 export const error: SimpleProofState = 'error'
 export const checking: SimpleProofState = 'checking'
 export const revoked: SimpleProofState = 'revoked'
-export const loggedOut: SimpleProofState = 'loggedOut'
 
 export const metaNone: SimpleProofMeta = 'none'
 export const metaUpgraded: SimpleProofMeta = 'upgraded'

--- a/react-native/react/local-debug.desktop.js
+++ b/react-native/react/local-debug.desktop.js
@@ -15,6 +15,8 @@ let config = {
   showDevTools: false,
   showAllTrackers: false,
   showMainWindow: false,
+  reduxDevToolsEnable: false,
+  redirectOnLogout: true,
   reduxDevToolsSelect: state => state // only watch a subset of the store
 }
 
@@ -24,9 +26,11 @@ if (__DEV__ && false) { // eslint-disable-line no-undef
   config.skipLoginRouteToRoot = true
   config.allowStartupFailure = true
   config.printRPC = true
-  config.showDevTools = true
+  config.showDevTools = false
   config.showMainWindow = true
   config.showAllTrackers = true
+  config.reduxDevToolsEnable = false
+  config.redirectOnLogout = false
   config.reduxDevToolsSelect = state => state.tracker
 }
 

--- a/react-native/react/menubar/index.js
+++ b/react-native/react/menubar/index.js
@@ -109,7 +109,7 @@ class Menubar extends Component {
   }
 
   render () {
-    const openingMessage = this.props.username ? 'Keybase Alpha' : 'Looks like you aren\'t logged in. Try running `keybase login`'
+    const openingMessage = this.props.loggedIn ? 'Keybase Alpha' : 'Looks like you aren\'t logged in. Try running `keybase login`'
 
     const openingButtonInfo = this.props.username && {text: 'WTF?', onClick: this.showHelp}
     const folders = (this.props.folders || []).map(function (f: Folder): FolderInfo {

--- a/react-native/react/native/notification-listeners.desktop.js
+++ b/react-native/react/native/notification-listeners.desktop.js
@@ -3,14 +3,18 @@ import path from 'path'
 import type {FSNotification} from '../../react/constants/types/flow-types'
 import {getTLF} from '../util/kbfs'
 
+import {logoutDone} from '../actions/login'
+
 // TODO: Once we have access to the Redux store from the thread running
 // notification listeners, store the sentNotifications map in it.
 var sentNotifications = {}
 
-export default function (notify) {
+// TODO(mm) Move these to their own actions
+export default function (dispatch, notify) {
   return {
     'keybase.1.NotifySession.loggedOut': () => {
       notify('Logged Out')
+      dispatch(logoutDone())
     },
     'keybase.1.NotifyFS.FSActivity': params => {
       const notification: FSNotification = params.notification

--- a/react-native/react/native/notifications.js
+++ b/react-native/react/native/notifications.js
@@ -5,12 +5,14 @@ import engine from '../engine'
 import ListenerCreator from './notification-listeners'
 import setNotifications from '../util/setNotifications'
 
+import type {Dispatch} from '../constants/types/flux'
+
 var initialized = false
 
 // A function that can display a notification
 type NotifyFn = (title: string, opts: Object) => void
 
-export default function (notify: NotifyFn) {
+export default function (dispatch: Dispatch, notify: NotifyFn) {
   if (initialized) {
     return
   }
@@ -21,7 +23,7 @@ export default function (notify: NotifyFn) {
     kbfs: true
   })
 
-  const listeners = ListenerCreator(notify)
+  const listeners = ListenerCreator(dispatch, notify)
   Object.keys(listeners).forEach(k => engine.listenGeneralIncomingRpc(k, listeners[k]))
   initialized = true
 }

--- a/react-native/react/native/remote-component-loader.js
+++ b/react-native/react/native/remote-component-loader.js
@@ -47,8 +47,7 @@ class RemoteComponentLoader extends Component {
       unmounted: false
     }
 
-    const substore = getQueryVariable('substore')
-    this.store = new RemoteStore({substore})
+    this.store = new RemoteStore({})
 
     const componentToLoad = getQueryVariable('component')
 

--- a/react-native/react/native/remote-component.desktop.js
+++ b/react-native/react/native/remote-component.desktop.js
@@ -45,8 +45,7 @@ export default class RemoteComponent extends Component {
     })
 
     const componentRequireName = this.props.component
-    const substore = this.props.substore
-    this.remoteWindow.loadUrl(`file://${resolveAssets('../react-native/react/native/remoteComponent.html')}?component=${componentRequireName || ''}&substore=${substore || ''}&src=${hotPath('remote-component-loader.bundle.js')}`)
+    this.remoteWindow.loadUrl(`file://${resolveAssets('../react-native/react/native/remoteComponent.html')}?component=${componentRequireName || ''}&src=${hotPath('remote-component-loader.bundle.js')}`)
   }
 
   componentWillUnmount () {
@@ -71,7 +70,6 @@ export default class RemoteComponent extends Component {
 
 RemoteComponent.propTypes = {
   component: React.PropTypes.string.isRequired,
-  substore: React.PropTypes.string,
   windowsOpts: React.PropTypes.object,
   onRemoteClose: React.PropTypes.func
 }

--- a/react-native/react/native/remote-manager.desktop.js
+++ b/react-native/react/native/remote-manager.desktop.js
@@ -91,7 +91,6 @@ class RemoteManager extends Component {
             onRemoteClose={() => this.props.onCloseFromHeader(username)}
             component='tracker'
             username={username}
-            substore='tracker'
             startTimer={this.props.trackerStartTimer}
             stopTimer={this.props.trackerStopTimer}
             key={username}

--- a/react-native/react/native/remote-manager.desktop.js
+++ b/react-native/react/native/remote-manager.desktop.js
@@ -138,7 +138,6 @@ class RemoteManager extends Component {
         windowsOpts={{width: 480, height: 430}}
         waitForState
         component='update'
-        substore='update'
         onCancel={() => this.props.updateOnCancel()}
         onSkip={() => this.props.updateOnSkip()}
         onSnooze={() => this.props.updateOnSnooze()}

--- a/react-native/react/native/remote-store.desktop.js
+++ b/react-native/react/native/remote-store.desktop.js
@@ -5,17 +5,17 @@ export default class RemoteStore {
   listeners: Array<Function>;
   internalState: any;
 
-  constructor (props: {substore?: ?string}) {
+  constructor (props: {}) {
     ipcRenderer.on('stateChange', (event, arg) => {
-      this.internalState = props.substore ? {[props.substore]: arg} : arg
+      this.internalState = {...this.internalState, ...arg}
       this._publishChange()
     })
 
     ipcRenderer.on('resubscribeStore', () => {
-      ipcRenderer.send('subscribeStore', props.substore)
+      ipcRenderer.send('subscribeStore')
     })
 
-    ipcRenderer.send('subscribeStore', props.substore)
+    ipcRenderer.send('subscribeStore')
 
     this.listeners = []
     this.internalState = {}

--- a/react-native/react/reducers/config.js
+++ b/react-native/react/reducers/config.js
@@ -2,12 +2,15 @@
 
 import * as Constants from '../constants/config'
 import * as LoginConstants from '../constants/login'
+
+import type {Action} from '../constants/types/flux'
 import type {NavState} from '../constants/config'
+import type {Config, GetCurrentStatusRes} from '../constants/types/flow-types'
 
 export type ConfigState = {
   navState: NavState;
-  status: ?any;
-  config: ?any;
+  status: ?GetCurrentStatusRes;
+  config: ?Config;
   error: ?any;
   devConfig: ?any;
 }
@@ -20,7 +23,7 @@ const initialState: ConfigState = {
   devConfig: null
 }
 
-export default function (state: ConfigState = initialState, action: any): ConfigState {
+export default function (state: ConfigState = initialState, action: Action): ConfigState {
   switch (action.type) {
     case Constants.startupLoading:
       return {
@@ -30,13 +33,32 @@ export default function (state: ConfigState = initialState, action: any): Config
         status: null,
         error: null
       }
+
+    case Constants.configLoaded:
+      if (action.payload && action.payload.config) {
+        return {
+          ...state,
+          config: action.payload.config
+        }
+      }
+      return state
+
+    case Constants.statusLoaded:
+      if (action.payload && action.payload.status) {
+        return {
+          ...state,
+          status: action.payload.status
+        }
+      }
+      return state
+
     case Constants.startupLoaded:
       let navState = Constants.navStartingUp
 
       if (!action.error) {
-        if (!action.payload.status.registered) {
+        if (state.status && state.status.registered) {
           navState = Constants.navNeedsRegistration
-        } else if (!action.payload.status.loggedIn) {
+        } else if (state.status && state.status.loggedIn) {
           navState = Constants.navNeedsLogin
         }
       } else {
@@ -45,8 +67,6 @@ export default function (state: ConfigState = initialState, action: any): Config
 
       return {
         ...state,
-        config: action.error ? null : action.payload.config,
-        status: action.error ? null : action.payload.status,
         error: action.error ? action.payload : null,
         navState
       }

--- a/react-native/react/reducers/login.js
+++ b/react-native/react/reducers/login.js
@@ -79,8 +79,8 @@ export default function (state: LoginState = initialState, action: any): LoginSt
   let toMerge = null
 
   switch (action.type) {
-    case ConfigConstants.startupLoaded:
-      if (action.error) {
+    case ConfigConstants.statusLoaded:
+      if (action.error || action.payload == null) {
         return state
       }
       let myDeviceRole = null

--- a/react-native/react/reducers/tabbed-router.js
+++ b/react-native/react/reducers/tabbed-router.js
@@ -42,7 +42,10 @@ export default function (state: TabbedRouterState = initialState, action: any): 
       }
       return state.set('activeTab', folderTab)
     case LoginConstants.logoutDone:
-      return state.set('activeTab', startupTab)
+      if (LocalDebug.redirectOnLogout) {
+        return state.set('activeTab', startupTab)
+      }
+      return
     case LoginConstants.needsLogin:
     case LoginConstants.needsRegistering:
       // TODO set the active tab to be startupTab here.

--- a/react-native/react/reducers/tracker.js
+++ b/react-native/react/reducers/tracker.js
@@ -6,7 +6,7 @@ import {showAllTrackers} from '../local-debug'
 import * as Constants from '../constants/tracker'
 import * as ConfigConstants from '../constants/config'
 
-import {normal, warning, error, checking, loggedOut} from '../constants/tracker'
+import {normal, warning, error, checking} from '../constants/tracker'
 import {metaNew, metaUpgraded, metaUnreachable, metaDeleted} from '../constants/tracker'
 
 import {identify} from '../constants/types/keybase_v1'
@@ -33,7 +33,6 @@ export type TrackerState = {
 }
 
 export type State = {
-  loggedIn: boolean,
   serverStarted: boolean,
   trackers: {[key: string]: TrackerState},
   timerActive: number
@@ -42,7 +41,6 @@ export type State = {
 const initialProofState = checking
 
 const initialState: State = {
-  loggedIn: false,
   serverStarted: false,
   timerActive: 0,
   trackers: {}
@@ -71,7 +69,7 @@ function initialTrackerState (username: string): TrackerState {
   }
 }
 
-function updateUserState (state: TrackerState, action: Action, loggedIn: boolean): TrackerState {
+function updateUserState (state: TrackerState, action: Action): TrackerState {
   let shouldFollow: boolean
   switch (action.type) {
     case Constants.onFollowChecked:
@@ -131,7 +129,7 @@ function updateUserState (state: TrackerState, action: Action, loggedIn: boolean
       return {
         ...state,
         shouldFollow: deriveShouldFollow(allOk),
-        trackerState: deriveTrackerState(allOk, anyWarnings, anyError, anyPending, anyDeletedProofs, anyUnreachableProofs, loggedIn),
+        trackerState: deriveTrackerState(allOk, anyWarnings, anyError, anyPending, anyDeletedProofs, anyUnreachableProofs),
         trackerMessage: deriveTrackerMessage(state.username, allOk, anyDeletedProofs, anyUnreachableProofs, anyUpgradedProofs, anyNewProofs)
       }
 
@@ -207,11 +205,6 @@ export default function (state: State = initialState, action: Action): State {
   const username: string = (action.payload && action.payload.username) ? action.payload.username : ''
   const trackerState = username ? state.trackers[username] : null
   switch (action.type) {
-    case ConfigConstants.statusLoaded:
-      return {
-        ...state,
-        loggedIn: action.payload && action.payload.status.loggedIn
-      }
     case Constants.startTimer:
       return {
         ...state,
@@ -225,7 +218,7 @@ export default function (state: State = initialState, action: Action): State {
   }
 
   if (trackerState) {
-    const newTrackerState = updateUserState(trackerState, action, state.loggedIn)
+    const newTrackerState = updateUserState(trackerState, action)
     if (newTrackerState === trackerState) {
       return state
     }
@@ -413,11 +406,8 @@ function deriveTrackerState (
   anyPending: boolean,
   anyDeletedProofs : boolean,
   anyUnreachableProofs : boolean,
-  loggedIn : boolean
 ): SimpleProofState {
-  if (!loggedIn) {
-    return loggedOut
-  } else if (anyWarnings || anyUnreachableProofs) {
+  if (anyWarnings || anyUnreachableProofs) {
     return warning
   } else if (anyError || anyDeletedProofs) {
     return error

--- a/react-native/react/reducers/tracker.js
+++ b/react-native/react/reducers/tracker.js
@@ -207,7 +207,7 @@ export default function (state: State = initialState, action: Action): State {
   const username: string = (action.payload && action.payload.username) ? action.payload.username : ''
   const trackerState = username ? state.trackers[username] : null
   switch (action.type) {
-    case ConfigConstants.startupLoaded:
+    case ConfigConstants.statusLoaded:
       return {
         ...state,
         loggedIn: action.payload && action.payload.status.loggedIn

--- a/react-native/react/tracker/action.render.desktop.js
+++ b/react-native/react/tracker/action.render.desktop.js
@@ -3,7 +3,7 @@
 import React, {Component} from '../base-react'
 import {FlatButton} from 'material-ui'
 import commonStyles from '../styles/common'
-import {normal, checking, warning, loggedOut} from '../constants/tracker'
+import {normal, checking, warning} from '../constants/tracker'
 
 import type {Styled} from '../styles/common'
 import type {ActionProps} from './action.render'
@@ -12,9 +12,9 @@ export default class ActionRender extends Component {
   props: ActionProps & Styled;
 
   render (): ReactElement {
-    const {username, state} = this.props
+    const {username, state, loggedIn} = this.props
 
-    if (state === loggedOut) {
+    if (!loggedIn) {
       return this.renderLoggedOut()
     } else if (state === checking || !username) {
       return this.renderPending()
@@ -100,6 +100,7 @@ export default class ActionRender extends Component {
 
 ActionRender.propTypes = {
   state: React.PropTypes.any.isRequired,
+  loggedIn: React.PropTypes.bool.isRequired,
   username: React.PropTypes.string,
   shouldFollow: React.PropTypes.bool.isRequired,
   onClose: React.PropTypes.func.isRequired,

--- a/react-native/react/tracker/action.render.js.flow
+++ b/react-native/react/tracker/action.render.js.flow
@@ -3,6 +3,7 @@
 import type {SimpleProofState} from '../constants/tracker'
 
 export type ActionProps = {
+  loggedIn: boolean,
   state: SimpleProofState,
   currentlyFollowing: boolean,
   username: ?string,

--- a/react-native/react/tracker/index.js
+++ b/react-native/react/tracker/index.js
@@ -7,7 +7,6 @@ import Render from './render'
 
 import * as trackerActions from '../actions/tracker'
 import {bindActionCreators} from 'redux'
-import {warning} from '../constants/tracker'
 
 import type {RenderProps} from './render'
 import type {UserInfo} from './bio.render'
@@ -17,6 +16,7 @@ import type {SimpleProofState} from '../constants/tracker'
 import type {TrackSummary} from '../constants/types/flow-types'
 
 type TrackerProps = {
+  loggedIn: boolean,
   trackerState: SimpleProofState,
   trackerMessage: ?string,
   username: ?string,
@@ -67,6 +67,7 @@ class Tracker extends Component {
         onClose: () => this.props.onCloseFromHeader(this.props.username)
       },
       actionProps: {
+        loggedIn: this.props.loggedIn,
         state: this.props.trackerState,
         username: this.props.username,
         renderChangedTitle,
@@ -132,6 +133,7 @@ const mockData = {
 }
 
 Tracker.propTypes = {
+  loggedIn: React.PropTypes.bool.isRequired,
   trackerState: React.PropTypes.any,
   trackerMessage: React.PropTypes.any,
   username: React.PropTypes.any,
@@ -154,12 +156,13 @@ Tracker.propTypes = {
 }
 
 export default connect(
-  state => state.tracker,
+  state => ({...state.tracker, loggedIn: state.config.status.loggedIn}),
   dispatch => {
     return bindActionCreators(trackerActions, dispatch)
   },
   (stateProps, dispatchProps, ownProps) => {
     return {
+      loggedIn: stateProps.loggedIn,
       ...stateProps.trackers[ownProps.username],
       ...dispatchProps,
       ...ownProps


### PR DESCRIPTION
We now dispatch an action when we logout. This action currently causes us to refetch our status from the service (and update the config substore).

Some code was refactored to avoid duplicating state across stores. Tracker store no longer has logged out state, and loggedOut is no longer a ProofState.

The startup loading action was broken up into smaller pieces (and composed with promises and thunks, which is kinda neat)

for: https://keybase.atlassian.net/browse/DESKTOP-260

@keybase/react-hackers 