### PR TITLE
Remote store with diffs

### DIFF
--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -8,6 +8,7 @@ import Nav from '../../react-native/react/nav'
 import injectTapEventPlugin from 'react-tap-event-plugin'
 import ListenForNotifications from '../../react-native/react/native/notifications'
 import ListenLogUi from '../../react-native/react/native/listen-log-ui'
+import {reduxDevToolsEnable} from '../../react-native/react/local-debug'
 
 // For Remote Components
 import {ipcRenderer} from 'electron'
@@ -99,7 +100,7 @@ class Keybase extends Component {
 
   render () {
     let dt = null
-    if (__DEV__) { // eslint-disable-line no-undef
+    if (__DEV__ && reduxDevToolsEnable) { // eslint-disable-line no-undef
       const DevTools = require('./redux-dev-tools')
       dt = <DevTools />
     }

--- a/react-native/react/local-debug.desktop.js
+++ b/react-native/react/local-debug.desktop.js
@@ -15,6 +15,8 @@ let config = {
   showDevTools: false,
   showAllTrackers: false,
   showMainWindow: false,
+  reduxDevToolsEnable: false,
+  redirectOnLogout: true,
   reduxDevToolsSelect: state => state // only watch a subset of the store
 }
 
@@ -24,9 +26,11 @@ if (__DEV__ && false) { // eslint-disable-line no-undef
   config.skipLoginRouteToRoot = true
   config.allowStartupFailure = true
   config.printRPC = true
-  config.showDevTools = true
+  config.showDevTools = false
   config.showMainWindow = true
   config.showAllTrackers = true
+  config.reduxDevToolsEnable = false
+  config.redirectOnLogout = false
   config.reduxDevToolsSelect = state => state.tracker
 }
 

--- a/react-native/react/native/remote-component-loader.js
+++ b/react-native/react/native/remote-component-loader.js
@@ -47,8 +47,7 @@ class RemoteComponentLoader extends Component {
       unmounted: false
     }
 
-    const substore = getQueryVariable('substore')
-    this.store = new RemoteStore({substore})
+    this.store = new RemoteStore({})
 
     const componentToLoad = getQueryVariable('component')
 

--- a/react-native/react/native/remote-component.desktop.js
+++ b/react-native/react/native/remote-component.desktop.js
@@ -45,8 +45,7 @@ export default class RemoteComponent extends Component {
     })
 
     const componentRequireName = this.props.component
-    const substore = this.props.substore
-    this.remoteWindow.loadUrl(`file://${resolveAssets('../react-native/react/native/remoteComponent.html')}?component=${componentRequireName || ''}&substore=${substore || ''}&src=${hotPath('remote-component-loader.bundle.js')}`)
+    this.remoteWindow.loadUrl(`file://${resolveAssets('../react-native/react/native/remoteComponent.html')}?component=${componentRequireName || ''}&src=${hotPath('remote-component-loader.bundle.js')}`)
   }
 
   componentWillUnmount () {
@@ -71,7 +70,6 @@ export default class RemoteComponent extends Component {
 
 RemoteComponent.propTypes = {
   component: React.PropTypes.string.isRequired,
-  substore: React.PropTypes.string,
   windowsOpts: React.PropTypes.object,
   onRemoteClose: React.PropTypes.func
 }

--- a/react-native/react/native/remote-manager.desktop.js
+++ b/react-native/react/native/remote-manager.desktop.js
@@ -138,7 +138,6 @@ class RemoteManager extends Component {
         windowsOpts={{width: 480, height: 430}}
         waitForState
         component='update'
-        substore='update'
         onCancel={() => this.props.updateOnCancel()}
         onSkip={() => this.props.updateOnSkip()}
         onSnooze={() => this.props.updateOnSnooze()}

--- a/react-native/react/native/remote-store.desktop.js
+++ b/react-native/react/native/remote-store.desktop.js
@@ -5,17 +5,17 @@ export default class RemoteStore {
   listeners: Array<Function>;
   internalState: any;
 
-  constructor (props: {substore?: ?string}) {
+  constructor (props: {}) {
     ipcRenderer.on('stateChange', (event, arg) => {
-      this.internalState = props.substore ? {[props.substore]: arg} : {...this.internalState, ...arg}
+      this.internalState = {...this.internalState, ...arg}
       this._publishChange()
     })
 
     ipcRenderer.on('resubscribeStore', () => {
-      ipcRenderer.send('subscribeStore', props.substore)
+      ipcRenderer.send('subscribeStore')
     })
 
-    ipcRenderer.send('subscribeStore', props.substore)
+    ipcRenderer.send('subscribeStore')
 
     this.listeners = []
     this.internalState = {}

--- a/react-native/react/native/remote-store.desktop.js
+++ b/react-native/react/native/remote-store.desktop.js
@@ -7,7 +7,7 @@ export default class RemoteStore {
 
   constructor (props: {substore?: ?string}) {
     ipcRenderer.on('stateChange', (event, arg) => {
-      this.internalState = props.substore ? {[props.substore]: arg} : arg
+      this.internalState = props.substore ? {[props.substore]: arg} : {...this.internalState, ...arg}
       this._publishChange()
     })
 

--- a/react-native/react/reducers/tabbed-router.js
+++ b/react-native/react/reducers/tabbed-router.js
@@ -42,7 +42,10 @@ export default function (state: TabbedRouterState = initialState, action: any): 
       }
       return state.set('activeTab', folderTab)
     case LoginConstants.logoutDone:
-      return state.set('activeTab', startupTab)
+      if (LocalDebug.redirectOnLogout) {
+        return state.set('activeTab', startupTab)
+      }
+      return
     case LoginConstants.needsLogin:
     case LoginConstants.needsRegistering:
       // TODO set the active tab to be startupTab here.


### PR DESCRIPTION
While working on #1707 I got tripped up by the substore business. This is implements a shallow diff between the old state we've sent and the new state, and only sends the diff.

This means we don't have two different code paths for remote stores depending on whether there is a substore argument.

This is consistent with how you'd expect a component to behave if it wasn't remote. (access to the full store)