### PR TITLE
Fix getenv

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -24,7 +24,7 @@
     "babel-runtime": "^5.8.34",
     "font-awesome": "^4.4.0",
     "framed-msgpack-rpc": "keybase/node-framed-msgpack-rpc#nojima/keybase-client-changes",
-    "getenv": "keybase/node-getenv",
+    "getenv": "^0.6.0",
     "immutable": "^3.7.5",
     "lodash": "^3.10.1",
     "marked": "^0.3.5",

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "buffer": "^3.5.4",
     "framed-msgpack-rpc": "keybase/node-framed-msgpack-rpc#nojima/keybase-client-changes",
-    "getenv": "^0.5.0",
+    "getenv": "^0.6.0",
     "iced-runtime": "^1.0.3",
     "immutable": "^3.7.5",
     "lodash": "^3.10.1",


### PR DESCRIPTION
@chrisnojima @oconnor663 

We were importing different versions of getenv in react-native/ and desktop/.  Webpack was choosing the older react-native one and ignoring the desktop one, leading to:

TypeError: _getenv2.default.boolish is not a function

While we're at it, move both dependencies to the latest upstream version which has incorporated @chrisnojima's addition of boolish, instead of our fork.