### PR TITLE
Electron menubar shadow instead of arrow

### DIFF
--- a/desktop/app/menu-bar.js
+++ b/desktop/app/menu-bar.js
@@ -11,8 +11,8 @@ export default function () {
   const mb = menubar({
     index: `file://${resolveAssets('./renderer/launcher.html')}?src=${hotPath('launcher.bundle.js')}&selectorParams=menubar`,
     width: 320,
-    height: 364 + 10, // size plus gap to deal with deadzone
-    transparent: true,
+    height: 364,
+    frame: false,
     resizable: false,
     preloadWindow: true,
     icon: menubarIconPath,

--- a/react-native/react/menubar/index.render.desktop.js
+++ b/react-native/react/menubar/index.render.desktop.js
@@ -98,7 +98,6 @@ export default class Render extends Component {
 
     return (
       <div style={styles.container}>
-        <div style={styles.arrow}/>
         <div style={styles.body}>
           <Header openKBFS={openKBFS} showUser={() => showUser(username)}/>
           {!loggedIn && <LoggedoutMessage />}
@@ -331,25 +330,12 @@ const styles = {
   },
   body: {
     ...globalStyles.flexBoxColumn,
-    ...globalStyles.rounded,
-    ...globalStyles.windowBorder,
     position: 'relative',
     overflow: 'hidden',
     height: 364,
     minHeight: 364,
     maxHeight: 364,
-    marginTop: -1, // let arrow not have a border below it
     flex: 1
-  },
-  arrow: {
-    ...globalStyles.topMost,
-    width: 0,
-    height: 10,
-    minHeight: 10,
-    borderLeft: '7px solid transparent',
-    borderRight: '7px solid transparent',
-    borderBottom: `5px solid ${globalColors.grey5}`,
-    alignSelf: 'center'
   },
   header: {
     ...globalStyles.flexBoxRow,


### PR DESCRIPTION
What do you think about bringing back the menubar drop shadow, and ditching the arrow (which isn't really visible)?

@keybase/react-hackers 

![2016-01-12 at 3 18 pm](https://cloud.githubusercontent.com/assets/2669/12280017/d14af8c4-b93f-11e5-857a-4c5fed316147.png)

vs

![2016-01-12 at 3 19 pm](https://cloud.githubusercontent.com/assets/2669/12280023/e22717d6-b93f-11e5-8ddb-e468adc4e635.png)


