### PR TITLE
libkb: handle multiple sigs for a UID

### DIFF
--- a/go/libkb/keymerge.go
+++ b/go/libkb/keymerge.go
@@ -31,6 +31,15 @@ func (to *PGPKeyBundle) MergeKey(from *PGPKeyBundle) {
 	for name, fromIdentity := range from.Identities {
 		if toIdentity, ok := to.Identities[name]; ok {
 			to.Identities[name].Signatures = combineSignatures(toIdentity.Signatures, fromIdentity.Signatures)
+
+			// There's a primary self-signature that we use. Always take the later
+			// of the two.
+			ssTo := to.Identities[name].SelfSignature
+			ssFrom := fromIdentity.SelfSignature
+			if ssFrom.CreationTime.After(ssTo.CreationTime) {
+				to.Identities[name].SelfSignature = ssFrom
+			}
+
 		} else {
 			to.Identities[fromIdentity.Name] = fromIdentity
 		}

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -109,8 +109,8 @@
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp",
-			"revision": "f36281eca125933db34a24b47c61d11fd9540c4a",
-			"revisionTime": "2016-01-11T17:04:01-05:00"
+			"revision": "39cc7b45f0f73f46ec8472d841a6a119de13660c",
+			"revisionTime": "2016-01-12T17:43:46-05:00"
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp/armor",


### PR DESCRIPTION
- Use RFC 4880 Section 5.2.3.3's recommendation of taking the later signature
- Vendor in keybase/go-crypto#6, for the OpenPGP side of these changes