### PR TITLE
Always use transaction in JSONFile.Save()

### DIFF
--- a/go/engine/device_register.go
+++ b/go/engine/device_register.go
@@ -66,9 +66,6 @@ func (d *DeviceRegister) Run(ctx *Context) error {
 		if err := wr.SetDeviceID(d.deviceID); err != nil {
 			return err
 		}
-		if err := wr.Save(); err != nil {
-			return err
-		}
 		ctx.LogUI.Debug("Setting Device ID to %s", d.deviceID)
 	}
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -166,7 +166,6 @@ type ConfigWriter interface {
 	SetUpdatePreferenceSnoozeUntil(keybase1.Time) error
 	SetUpdateLastChecked(keybase1.Time) error
 	Reset()
-	Save() error
 	BeginTransaction() (ConfigWriterTransacter, error)
 }
 

--- a/go/libkb/json.go
+++ b/go/libkb/json.go
@@ -5,6 +5,7 @@ package libkb
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -85,14 +86,6 @@ func (f *JSONFile) Nuke() error {
 	return err
 }
 
-func (f *JSONFile) getFilename() string {
-	tx := f.getTx()
-	if tx != nil {
-		return tx.tmpname
-	}
-	return f.filename
-}
-
 func (f *JSONFile) BeginTransaction() (ConfigWriterTransacter, error) {
 	tx, err := newJSONFileTransaction(f)
 	if err != nil {
@@ -113,12 +106,6 @@ func (f *JSONFile) setTx(tx *jsonFileTransaction) error {
 	}
 	f.tx = tx
 	return nil
-}
-
-func (f *JSONFile) getTx() *jsonFileTransaction {
-	f.txMutex.Lock()
-	defer f.txMutex.Unlock()
-	return f.tx
 }
 
 func (f *JSONFile) getOrMakeTx() (*jsonFileTransaction, bool, error) {
@@ -167,7 +154,7 @@ func (f *JSONFile) Save() error {
 		}()
 	}
 
-	if err := f.save(f.getFilename(), true, 0); err != nil {
+	if err := f.save(); err != nil {
 		return err
 	}
 
@@ -185,7 +172,11 @@ func (f *JSONFile) Save() error {
 	return nil
 }
 
-func (f *JSONFile) save(filename string, pretty bool, mode os.FileMode) (err error) {
+func (f *JSONFile) save() (err error) {
+	if f.tx == nil {
+		return errors.New("save() called with nil transaction")
+	}
+	filename := f.tx.tmpname
 	f.G().Log.Debug("+ saving %s file %s", f.which, filename)
 
 	err = MakeParentDirs(filename)
@@ -210,10 +201,7 @@ func (f *JSONFile) save(filename string, pretty bool, mode os.FileMode) (err err
 	}
 	var writer *os.File
 	flags := (os.O_WRONLY | os.O_CREATE | os.O_TRUNC)
-	if mode == 0 {
-		mode = PermFile // By default, secrecy
-	}
-	writer, err = os.OpenFile(filename, flags, mode)
+	writer, err = os.OpenFile(filename, flags, PermFile)
 	if err != nil {
 		f.G().Log.Errorf("Failed to open %s file %s for writing: %s",
 			f.which, filename, err)
@@ -221,14 +209,9 @@ func (f *JSONFile) save(filename string, pretty bool, mode os.FileMode) (err err
 	}
 	defer writer.Close()
 
-	if pretty {
-		encoded, err := json.MarshalIndent(dat, "", "    ")
-		if err == nil {
-			_, err = writer.Write(encoded)
-		}
-	} else {
-		encoder := json.NewEncoder(writer)
-		err = encoder.Encode(dat)
+	encoded, err := json.MarshalIndent(dat, "", "    ")
+	if err == nil {
+		_, err = writer.Write(encoded)
 	}
 
 	if err != nil {


### PR DESCRIPTION
If one exists, it will be used, otherwise a transaction
will be created and used around the save() call.

Also, this removes Save() from ConfigWriter interface
and cleans up unnecessary usage of Save() outside config.go.

PTAL @maxtaco 