### PR TITLE
implement header hashing in the encryption format

### DIFF
--- a/go/libkb/saltpack.go
+++ b/go/libkb/saltpack.go
@@ -62,12 +62,11 @@ type naclBoxSecretKey NaclDHKeyPair
 var _ saltpack.BoxSecretKey = naclBoxSecretKey{}
 
 func (n naclBoxSecretKey) Box(
-	receiver saltpack.BoxPublicKey, nonce *saltpack.Nonce, msg []byte) (
-	[]byte, error) {
+	receiver saltpack.BoxPublicKey, nonce *saltpack.Nonce, msg []byte) []byte {
 	ret := box.Seal([]byte{}, msg, (*[24]byte)(nonce),
 		(*[32]byte)(receiver.ToRawBoxKeyPointer()),
 		(*[32]byte)(n.Private))
-	return ret, nil
+	return ret
 }
 
 func (n naclBoxSecretKey) Unbox(

--- a/go/saltpack/common.go
+++ b/go/saltpack/common.go
@@ -107,3 +107,11 @@ func computeMACKey(secret BoxSecretKey, public BoxPublicKey, headerHash []byte) 
 	macKey := macKeyBox[poly1305.TagSize : poly1305.TagSize+CryptoAuthKeyBytes]
 	return macKey
 }
+
+func computePayloadHash(headerHash []byte, nonce *Nonce, payloadCiphertext []byte) []byte {
+	payloadDigest := sha512.New()
+	payloadDigest.Write(headerHash)
+	payloadDigest.Write(nonce[:])
+	payloadDigest.Write(payloadCiphertext)
+	return payloadDigest.Sum(nil)
+}

--- a/go/saltpack/common.go
+++ b/go/saltpack/common.go
@@ -5,6 +5,7 @@ package saltpack
 
 import (
 	"bytes"
+	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha512"
 	"encoding/binary"
@@ -93,4 +94,16 @@ func detachedDigest(sum []byte) []byte {
 	buf.Write(sum)
 
 	return buf.Bytes()
+}
+
+func hmacSHA512256(key []byte, input []byte) []byte {
+	// Equivalent to crypto_auth, but using Go's builtin HMAC. Truncates
+	// SHA512, instead of actually calling SHA512/256.
+	if len(key) != CryptoAuthKeyBytes {
+		panic("Bad crypto_auth key length")
+	}
+	authenticatorDigest := hmac.New(sha512.New, key)
+	authenticatorDigest.Write(input)
+	fullMAC := authenticatorDigest.Sum(nil)
+	return fullMAC[:CryptoAuthBytes]
 }

--- a/go/saltpack/const.go
+++ b/go/saltpack/const.go
@@ -54,6 +54,9 @@ const SignatureAttachedString = "attached signature"
 // a detached signature.
 const SignatureDetachedString = "detached signature"
 
+// We truncate HMAC512 to the same link that NaCl's crypto_auth function does.
+const CryptoAuthLength = 32
+
 type readState int
 
 const (

--- a/go/saltpack/const.go
+++ b/go/saltpack/const.go
@@ -55,7 +55,9 @@ const SignatureAttachedString = "attached signature"
 const SignatureDetachedString = "detached signature"
 
 // We truncate HMAC512 to the same link that NaCl's crypto_auth function does.
-const CryptoAuthLength = 32
+const CryptoAuthBytes = 32
+
+const CryptoAuthKeyBytes = 32
 
 type readState int
 

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -97,13 +97,13 @@ func (ds *decryptStream) readHeader(rawReader io.Reader) error {
 	var headerLength int
 	seqno, err := ds.mps.Read(&headerLength)
 	if err != nil {
-		return err
+		return ErrFailedToDecodeHeaderLength
 	}
 	// Read the header bytes.
 	headerBytes := make([]byte, headerLength)
 	_, err = io.ReadFull(rawReader, headerBytes)
 	if err != nil {
-		return err
+		return ErrFailedToReadHeaderBytes
 	}
 	// Compute the header hash.
 	headerHash := sha512.Sum512(headerBytes)

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -294,7 +294,7 @@ func (ds *decryptStream) processEncryptionBlock(bl *EncryptionBlock) ([]byte, er
 	authenticatorDigest := hmac.New(sha512.New, ds.macKey)
 	authenticatorDigest.Write(hashToAuthenticate)
 	fullMAC := authenticatorDigest.Sum(nil)
-	ourAuthenticator := fullMAC[:32]
+	ourAuthenticator := fullMAC[:CryptoAuthLength]
 	if !hmac.Equal(ourAuthenticator, bl.HashAuthenticators[ds.position]) {
 		return nil, ErrBadTag(bl.seqno)
 	}

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -93,15 +93,9 @@ func (ds *decryptStream) read(b []byte) (n int, err error) {
 }
 
 func (ds *decryptStream) readHeader(rawReader io.Reader) error {
-	// Parse the length of the header.
-	var headerLength int
-	seqno, err := ds.mps.Read(&headerLength)
-	if err != nil {
-		return ErrFailedToDecodeHeaderLength
-	}
 	// Read the header bytes.
-	headerBytes := make([]byte, headerLength)
-	_, err = io.ReadFull(rawReader, headerBytes)
+	headerBytes := []byte{}
+	seqno, err := ds.mps.Read(&headerBytes)
 	if err != nil {
 		return ErrFailedToReadHeaderBytes
 	}

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -67,7 +67,7 @@ func (ds *decryptStream) read(b []byte) (n int, err error) {
 		return n, nil
 	}
 
-	// We have three states we can be in, but we can definitely
+	// We have two states we can be in, but we can definitely
 	// fall through during one read, so be careful.
 
 	if ds.state == stateBody {

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -285,10 +285,7 @@ func (ds *decryptStream) processEncryptionBlock(bl *EncryptionBlock) ([]byte, er
 	ciphertextDigest.Write(nonce[:])
 	ciphertextDigest.Write(ciphertext)
 	hashToAuthenticate := ciphertextDigest.Sum(nil)
-	authenticatorDigest := hmac.New(sha512.New, ds.macKey)
-	authenticatorDigest.Write(hashToAuthenticate)
-	fullMAC := authenticatorDigest.Sum(nil)
-	ourAuthenticator := fullMAC[:CryptoAuthLength]
+	ourAuthenticator := hmacSHA512256(ds.macKey, hashToAuthenticate)
 	if !hmac.Equal(ourAuthenticator, bl.HashAuthenticators[ds.position]) {
 		return nil, ErrBadTag(bl.seqno)
 	}

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -262,8 +262,7 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 	}
 
 	// Compute the MAC key.
-	macKeyBox := secretKey.Box(ds.mki.SenderKey, nonceForMACKeyBox(ds.headerHash[:]), make([]byte, 32))
-	ds.macKey = macKeyBox[16:48]
+	ds.macKey = computeMACKey(secretKey, ds.mki.SenderKey, ds.headerHash)
 
 	return nil
 }

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -279,11 +279,7 @@ func (ds *decryptStream) processEncryptionBlock(bl *EncryptionBlock) ([]byte, er
 	ciphertext := bl.PayloadCiphertext
 
 	// Check the authenticator.
-	ciphertextDigest := sha512.New()
-	ciphertextDigest.Write(ds.headerHash)
-	ciphertextDigest.Write(nonce[:])
-	ciphertextDigest.Write(ciphertext)
-	hashToAuthenticate := ciphertextDigest.Sum(nil)
+	hashToAuthenticate := computePayloadHash(ds.headerHash, nonce, ciphertext)
 	ourAuthenticator := hmacSHA512256(ds.macKey, hashToAuthenticate)
 	if !hmac.Equal(ourAuthenticator, bl.HashAuthenticators[ds.position]) {
 		return nil, ErrBadTag(bl.seqno)

--- a/go/saltpack/encrypt.go
+++ b/go/saltpack/encrypt.go
@@ -82,7 +82,7 @@ func (es *encryptStream) encryptBytes(b []byte) error {
 		authenticatorDigest := hmac.New(sha512.New, macKey)
 		authenticatorDigest.Write(hashToAuthenticate)
 		fullMAC := authenticatorDigest.Sum(nil)
-		truncatedMAC := fullMAC[:32]
+		truncatedMAC := fullMAC[:CryptoAuthLength]
 		block.HashAuthenticators = append(block.HashAuthenticators, truncatedMAC)
 	}
 

--- a/go/saltpack/encrypt.go
+++ b/go/saltpack/encrypt.go
@@ -170,22 +170,14 @@ func (es *encryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey) err
 		eh.Receivers = append(eh.Receivers, keys)
 	}
 
-	// Encode the header and the header length, and write them out immediately.
+	// Encode the header to bytes, hash it, then double encode it.
 	headerBytes, err := encodeToBytes(es.header)
-	if err != nil {
-		return err
-	}
-	headerLen, err := encodeToBytes(len(headerBytes))
 	if err != nil {
 		return err
 	}
 	headerHash := sha512.Sum512(headerBytes)
 	es.headerHash = headerHash[:]
-	_, err = es.output.Write(headerLen)
-	if err != nil {
-		return err
-	}
-	_, err = es.output.Write(headerBytes)
+	err = es.encoder.Encode(headerBytes)
 	if err != nil {
 		return err
 	}

--- a/go/saltpack/encrypt.go
+++ b/go/saltpack/encrypt.go
@@ -30,11 +30,6 @@ type encryptStream struct {
 
 func (es *encryptStream) Write(plaintext []byte) (int, error) {
 
-	if !es.didHeader {
-		es.didHeader = true
-		es.err = es.encoder.Encode(es.header)
-	}
-
 	if es.err != nil {
 		return 0, es.err
 	}
@@ -216,7 +211,8 @@ func NewEncryptStream(ciphertext io.Writer, sender BoxSecretKey, receivers []Box
 	if err := es.init(sender, receivers); err != nil {
 		return nil, err
 	}
-	return es, nil
+	err = es.encoder.Encode(es.header)
+	return es, err
 }
 
 // Seal a plaintext from the given sender, for the specified receiver groups.

--- a/go/saltpack/encrypt.go
+++ b/go/saltpack/encrypt.go
@@ -211,7 +211,20 @@ func NewEncryptStream(ciphertext io.Writer, sender BoxSecretKey, receivers []Box
 	if err := es.init(sender, receivers); err != nil {
 		return nil, err
 	}
-	err = es.encoder.Encode(es.header)
+	// Encode the header and the header length, and write them out immediately.
+	headerBytes, err := encodeToBytes(es.header)
+	if err != nil {
+		return nil, err
+	}
+	headerLen, err := encodeToBytes(len(headerBytes))
+	if err != nil {
+		return nil, err
+	}
+	_, err = es.output.Write(headerLen)
+	if err != nil {
+		return nil, err
+	}
+	_, err = es.output.Write(headerBytes)
 	return es, err
 }
 

--- a/go/saltpack/encrypt.go
+++ b/go/saltpack/encrypt.go
@@ -186,8 +186,8 @@ func (es *encryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey) err
 
 func (es *encryptStream) computeMACKeys(sender BoxSecretKey, receivers []BoxPublicKey) {
 	for _, receiver := range receivers {
-		macKeyBox := sender.Box(receiver, nonceForMACKeyBox(es.headerHash[:]), make([]byte, 32))
-		es.macKeys = append(es.macKeys, macKeyBox[16:48])
+		macKey := computeMACKey(sender, receiver, es.headerHash)
+		es.macKeys = append(es.macKeys, macKey)
 	}
 }
 

--- a/go/saltpack/encrypt.go
+++ b/go/saltpack/encrypt.go
@@ -72,11 +72,7 @@ func (es *encryptStream) encryptBytes(b []byte) error {
 
 	// Compute the digest to authenticate, and authenticate it for each
 	// recipient.
-	ciphertextDigest := sha512.New()
-	ciphertextDigest.Write(es.headerHash)
-	ciphertextDigest.Write(nonce[:])
-	ciphertextDigest.Write(ciphertext)
-	hashToAuthenticate := ciphertextDigest.Sum(nil)
+	hashToAuthenticate := computePayloadHash(es.headerHash, nonce, ciphertext)
 	for _, macKey := range es.macKeys {
 		authenticator := hmacSHA512256(macKey, hashToAuthenticate)
 		block.HashAuthenticators = append(block.HashAuthenticators, authenticator)

--- a/go/saltpack/encrypt.go
+++ b/go/saltpack/encrypt.go
@@ -5,7 +5,6 @@ package saltpack
 
 import (
 	"bytes"
-	"crypto/hmac"
 	"crypto/sha512"
 	"encoding/hex"
 	"golang.org/x/crypto/nacl/secretbox"
@@ -79,11 +78,8 @@ func (es *encryptStream) encryptBytes(b []byte) error {
 	ciphertextDigest.Write(ciphertext)
 	hashToAuthenticate := ciphertextDigest.Sum(nil)
 	for _, macKey := range es.macKeys {
-		authenticatorDigest := hmac.New(sha512.New, macKey)
-		authenticatorDigest.Write(hashToAuthenticate)
-		fullMAC := authenticatorDigest.Sum(nil)
-		truncatedMAC := fullMAC[:CryptoAuthLength]
-		block.HashAuthenticators = append(block.HashAuthenticators, truncatedMAC)
+		authenticator := hmacSHA512256(macKey, hashToAuthenticate)
+		block.HashAuthenticators = append(block.HashAuthenticators, authenticator)
 	}
 
 	if err := es.encoder.Encode(block); err != nil {

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -1209,22 +1209,12 @@ func TestBadKeyLookup(t *testing.T) {
 }
 
 func TestCorruptFraming(t *testing.T) {
-	// Create a "ciphertext" where payload length isn't an integer.
-	nonInteger, err := encodeToBytes("I'm a string")
+	// Create a "ciphertext" where header packet is a type other than bytes.
+	nonInteger, err := encodeToBytes(42)
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, _, err = Open(nonInteger, kr)
-	if err != ErrFailedToDecodeHeaderLength {
-		t.Fatal(err)
-	}
-
-	// Create a "ciphertext" where the payload length is a valid integer, but
-	// it's not followed by the promised number of bytes.
-	integer, err := encodeToBytes(1000)
-	tooFewBytes, err := encodeToBytes("less than a thousand bytes")
-	ciphertext := append(integer, tooFewBytes...)
-	_, _, err = Open(ciphertext, kr)
 	if err != ErrFailedToReadHeaderBytes {
 		t.Fatal(err)
 	}

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -858,11 +858,9 @@ func TestCorruptEncryption(t *testing.T) {
 		corruptPayloadNonce: func(n *Nonce, ebn encryptionBlockNumber) *Nonce {
 			switch ebn {
 			case 1:
-				tmp := *n
-				return tmp.ForPayloadBox(encryptionBlockNumber(0))
+				return nonceForChunkSecretBox(encryptionBlockNumber(0))
 			case 0:
-				tmp := *n
-				return tmp.ForPayloadBox(encryptionBlockNumber(1))
+				return nonceForChunkSecretBox(encryptionBlockNumber(1))
 			}
 			return n
 		},

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -142,10 +142,10 @@ func (b boxPrecomputedSharedKey) Box(nonce *Nonce, msg []byte) []byte {
 	return out
 }
 
-func (b boxSecretKey) Box(receiver BoxPublicKey, nonce *Nonce, msg []byte) ([]byte, error) {
+func (b boxSecretKey) Box(receiver BoxPublicKey, nonce *Nonce, msg []byte) []byte {
 	ret := box.Seal([]byte{}, msg, (*[24]byte)(nonce),
 		(*[32]byte)(receiver.ToRawBoxKeyPointer()), (*[32]byte)(&b.key))
-	return ret, nil
+	return ret
 }
 
 var errPublicKeyDecryptionFailed = errors.New("public key decryption failed")

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -1207,3 +1207,25 @@ func TestBadKeyLookup(t *testing.T) {
 	}
 	kr.bad = false
 }
+
+func TestCorruptFraming(t *testing.T) {
+	// Create a "ciphertext" where payload length isn't an integer.
+	nonInteger, err := encodeToBytes("I'm a string")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = Open(nonInteger, kr)
+	if err != ErrFailedToDecodeHeaderLength {
+		t.Fatal(err)
+	}
+
+	// Create a "ciphertext" where the payload length is a valid integer, but
+	// it's not followed by the promised number of bytes.
+	integer, err := encodeToBytes(1000)
+	tooFewBytes, err := encodeToBytes("less than a thousand bytes")
+	ciphertext := append(integer, tooFewBytes...)
+	_, _, err = Open(ciphertext, kr)
+	if err != ErrFailedToReadHeaderBytes {
+		t.Fatal(err)
+	}
+}

--- a/go/saltpack/errors.go
+++ b/go/saltpack/errors.go
@@ -22,14 +22,9 @@ var (
 	// end of the encryption stream.
 	ErrTrailingGarbage = errors.New("trailing garbage found at end of message")
 
-	// ErrFailedToDecodeHeaderLength indicates that we hit an error in the very
-	// first step of decoding the header, where we expect to read an integer
-	// from the message stream.
-	ErrFailedToDecodeHeaderLength = errors.New("failed to decode header length")
-
-	// ErrFailedToReadHeaderBytes indicates that we failed to read all the
-	// bytes that the header length suggested we should be able to read.
-	ErrFailedToReadHeaderBytes = errors.New("failed to read header bytes promised by the header length")
+	// ErrFailedToReadHeaderBytes indicates that we failed to read the
+	// doubly-encoded header bytes object from the input stream.
+	ErrFailedToReadHeaderBytes = errors.New("failed to read header bytes")
 
 	// ErrPacketOverflow indicates that more than (2^64-2) packets were found in an encryption
 	// stream.  This would indicate a very big message, and results in an error here.

--- a/go/saltpack/errors.go
+++ b/go/saltpack/errors.go
@@ -22,6 +22,15 @@ var (
 	// end of the encryption stream.
 	ErrTrailingGarbage = errors.New("trailing garbage found at end of message")
 
+	// ErrFailedToDecodeHeaderLength indicates that we hit an error in the very
+	// first step of decoding the header, where we expect to read an integer
+	// from the message stream.
+	ErrFailedToDecodeHeaderLength = errors.New("failed to decode header length")
+
+	// ErrFailedToReadHeaderBytes indicates that we failed to read all the
+	// bytes that the header length suggested we should be able to read.
+	ErrFailedToReadHeaderBytes = errors.New("failed to read header bytes promised by the header length")
+
 	// ErrPacketOverflow indicates that more than (2^64-2) packets were found in an encryption
 	// stream.  This would indicate a very big message, and results in an error here.
 	ErrPacketOverflow = errors.New("no more than 2^32 packets in a message are supported")

--- a/go/saltpack/key.go
+++ b/go/saltpack/key.go
@@ -70,7 +70,7 @@ type BoxSecretKey interface {
 
 	// Box boxes up data, sent from this secret key, and to the receiver
 	// specified.
-	Box(receiver BoxPublicKey, nonce *Nonce, msg []byte) ([]byte, error)
+	Box(receiver BoxPublicKey, nonce *Nonce, msg []byte) []byte
 
 	// Unobx opens up the box, using this secret key as the receiver key
 	// abd the give public key as the sender key.

--- a/go/saltpack/nonce.go
+++ b/go/saltpack/nonce.go
@@ -11,13 +11,13 @@ type Nonce [24]byte
 
 func nonceForSenderKeySecretBox() *Nonce {
 	var n Nonce
-	copy(n[:], "saltpack_sender_key\x00\x00\x00\x00\x00")
+	copy(n[:], "saltpack_sender_secbox\x00\x00")
 	return &n
 }
 
 func nonceForPayloadKeyBox() *Nonce {
 	var n Nonce
-	copy(n[:], "saltpack_payload_key\x00\x00\x00\x00")
+	copy(n[:], "saltpack_payload_key_box")
 	return &n
 }
 
@@ -30,7 +30,7 @@ func nonceForMACKeyBox(headerHash []byte) *Nonce {
 // Construct the nonce for the ith block of payload.
 func nonceForChunkSecretBox(i encryptionBlockNumber) *Nonce {
 	var n Nonce
-	copy(n[0:16], "saltpack_payload")
+	copy(n[0:16], "saltpack_ploadsb")
 	binary.BigEndian.PutUint64(n[16:], uint64(i))
 	return &n
 }

--- a/go/saltpack/nonce.go
+++ b/go/saltpack/nonce.go
@@ -2,7 +2,6 @@ package saltpack
 
 import (
 	"crypto/rand"
-	"crypto/sha512"
 	"encoding/binary"
 )
 
@@ -10,50 +9,30 @@ import (
 // counter values, and some of which can be random-ish values.
 type Nonce [24]byte
 
-// NonceType is different for the different type of usages of the nonce.
-type NonceType int
-
-const (
-	// NonceTypeEncryptionKeyBox is used for the header of an encrypted message
-	NonceTypeEncryptionKeyBox NonceType = 0
-
-	// NonceTypeEncryptionPayloadBox is used for the payload of an encrypted message
-	NonceTypeEncryptionPayloadBox NonceType = 1
-)
-
-// ForPayloadBox formats this nonce for the ith block of payload.
-func (n *Nonce) ForPayloadBox(i encryptionBlockNumber) *Nonce {
-	n.mutate(uint64(NonceTypeEncryptionPayloadBox) + uint64(i))
-	return n
+func nonceForSenderKeySecretBox() *Nonce {
+	var n Nonce
+	copy(n[:], "saltpack_sender_key\x00\x00\x00\x00\x00")
+	return &n
 }
 
-func (n *Nonce) mutate(i uint64) {
-	binary.BigEndian.PutUint64((*n)[16:], i)
+func nonceForPayloadKeyBox() *Nonce {
+	var n Nonce
+	copy(n[:], "saltpack_payload_key\x00\x00\x00\x00")
+	return &n
 }
 
-// ForKeyBox formats the nonce for use the KeyBox in a message header.
-func (n *Nonce) ForKeyBox() *Nonce {
-	n.mutate(uint64(NonceTypeEncryptionKeyBox))
-	return n
+func nonceForMACKeyBox(headerHash []byte) *Nonce {
+	var n Nonce
+	copy(n[:], headerHash[:24])
+	return &n
 }
 
-// NewNonceForEncryption creates a new nonce for the purposes of an encrypted
-// message. It is a deterministic function of the ephemeral public key used
-// for this encrypted message.
-//
-// **DO NOT** pass a long-live public key here, as you might lose the guarantee
-// that each (nonce,key) pair must be unique over the lifetime of the universe.
-//
-func NewNonceForEncryption(ephemeralPublicKey BoxPublicKey) *Nonce {
-	raw := *ephemeralPublicKey.ToRawBoxKeyPointer()
-	hasher := sha512.New()
-	writeNullTerminatedString(hasher, SaltpackFormatName)
-	writeNullTerminatedString(hasher, NoncePrefixEncryption)
-	hasher.Write(raw[:])
-	res := hasher.Sum(nil)
-	var out Nonce
-	copy(out[0:16], res)
-	return &out
+// Construct the nonce for the ith block of payload.
+func nonceForChunkSecretBox(i encryptionBlockNumber) *Nonce {
+	var n Nonce
+	copy(n[0:16], "saltpack_payload")
+	binary.BigEndian.PutUint64(n[16:], uint64(i))
+	return &n
 }
 
 // SigNonce is a nonce for signatures.

--- a/go/saltpack/nonce.go
+++ b/go/saltpack/nonce.go
@@ -5,9 +5,11 @@ import (
 	"encoding/binary"
 )
 
+const NonceBytes = 24
+
 // Nonce is a NaCl-style nonce, with 24 bytes of data, some of which can be
 // counter values, and some of which can be random-ish values.
-type Nonce [24]byte
+type Nonce [NonceBytes]byte
 
 func nonceForSenderKeySecretBox() *Nonce {
 	var n Nonce
@@ -23,7 +25,7 @@ func nonceForPayloadKeyBox() *Nonce {
 
 func nonceForMACKeyBox(headerHash []byte) *Nonce {
 	var n Nonce
-	copy(n[:], headerHash[:24])
+	copy(n[:], headerHash[:NonceBytes])
 	return &n
 }
 

--- a/go/saltpack/nonce.go
+++ b/go/saltpack/nonce.go
@@ -13,7 +13,7 @@ type Nonce [NonceBytes]byte
 
 func nonceForSenderKeySecretBox() *Nonce {
 	var n Nonce
-	copy(n[:], "saltpack_sender_secbox\x00\x00")
+	copy(n[:], "saltpack_sender_key_sbox")
 	return &n
 }
 

--- a/go/saltpack/nonce.go
+++ b/go/saltpack/nonce.go
@@ -24,6 +24,9 @@ func nonceForPayloadKeyBox() *Nonce {
 }
 
 func nonceForMACKeyBox(headerHash []byte) *Nonce {
+	if len(headerHash) != 64 {
+		panic("Header hash shorter than expected.")
+	}
 	var n Nonce
 	copy(n[:], headerHash[:NonceBytes])
 	return &n

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -251,6 +251,9 @@ index of that recipient's **payload key box** in the header. Before opening the
 authenticator by repeating steps #1 and #2 and then calling
 [`crypto_auth_verify`](http://nacl.cr.yp.to/auth.html).
 
+Unlike the twice-encoded header above, payload packets are once-encoded
+directly to the output stream.
+
 After encrypting the entire message, the sender adds an extra payload packet
 with an empty payload to signify the end. If a message doesn't end with an
 empty payload packet, the receiving client should report an error that the

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -134,12 +134,12 @@ header:
    [`crypto_box_keypair`](http://nacl.cr.yp.to/box.html).
 3. Encrypt the sender's long-term public key using
    [`crypto_secretbox`](http://nacl.cr.yp.to/secretbox.html) with the **payload
-   key** and the nonce `saltpack_sender_key\0\0\0\0\0`, to create the **sender
+   key** and the nonce `saltpack_sender_secbox\0\0`, to create the **sender
    secretbox**. (`\0` is a null byte.)
 4. For each recipient, encrypt the **payload key** using
    [`crypto_box`](http://nacl.cr.yp.to/box.html) with the recipient's public
    key, the ephemeral private key, and the nonce
-   `saltpack_payload_key\0\0\0\0`. Pair these with the recipients' public keys,
+   `saltpack_payload_key_box`. Pair these with the recipients' public keys,
    or `null` for anonymous recipients, and collect the pairs into the
    **recipients list**.
 5. Collect the **format name**, **version**, and **mode** into a list, followed
@@ -190,12 +190,12 @@ Recipients parse the header of a message using the following steps:
    public key** and the sender's private key.
 7. Try to open each of the **payload key boxes** in the recipients list using
    [`crypto_box_afternm`](http://nacl.cr.yp.to/box.html), the shared secret
-   from #6, and the nonce `saltpack_payload_key\0\0\0\0`. Successfully opening
+   from #6, and the nonce `saltpack_payload_key_box`. Successfully opening
    one gives the **payload key**, and the index of the box that worked is the
    **recipient index**.
 8. Open the **sender secretbox** using
    [`crypto_secretbox_open`](http://nacl.cr.yp.to/secretbox.html) with the
-   **payload key** from #7 and the nonce `saltpack_sender_key\0\0\0\0\0`
+   **payload key** from #7 and the nonce `saltpack_sender_secbox\0\0`
 9. Compute the recipient's **MAC key** by encrypting 32 zero bytes using
    [`crypto_box`](http://nacl.cr.yp.to/box.html) with the recipient's private
    key, the sender's public key from #8, and the first 24 bytes of the hash
@@ -231,7 +231,7 @@ A payload packet is a MessagePack list with these contents:
   message header. See below.
 - The **payload secretbox** is a NaCl secretbox containing a chunk of the
   plaintext bytes, max size 1 MB. It's encrypted with the **payload key**. The
-  nonce is `saltpack_payloadNNNNNNNN` where `NNNNNNNN` is the packet numer as
+  nonce is `saltpack_ploadsbNNNNNNNN` where `NNNNNNNN` is the packet numer as
   an 8-byte big-endian unsigned integer. The first payload packet is number 0.
 
 If Mallory doesn't have the **payload key**, she can't modify the **payload

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -18,7 +18,7 @@
 - 15 Dec 2015
   - Initial version.
 
-The main building block of our encrypted message format will be NaCl's
+The main building block of our encrypted message format is NaCl's
 [box](http://nacl.cr.yp.to/box.html) and
 [secretbox](http://nacl.cr.yp.to/secretbox.html) constructions. These have
 several properties that we'll want to keep:

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -233,7 +233,9 @@ A payload packet is a MessagePack list with these contents:
 
 Computing the **MAC keys** is the only step of encrypting a message that
 requires the sender's private key. Thus it's the **authenticators list**,
-generated from those keys, that proves the sender is authentic.
+generated from those keys, that proves the sender is authentic. We also include
+the hash of the entire header as an input to the authenticators, to prevent an
+attacker from modifying the format version or any other header fields.
 
 We compute the authenticators in three steps:
 

--- a/go/saltpack/specs/saltpack_encryption.md
+++ b/go/saltpack/specs/saltpack_encryption.md
@@ -131,8 +131,8 @@ header:
    [`crypto_box_keypair`](http://nacl.cr.yp.to/box.html).
 3. Encrypt the sender's long-term public key using
    [`crypto_secretbox`](http://nacl.cr.yp.to/secretbox.html) with the **payload
-   key** and the nonce `saltpack_sender_secbox\0\0`, to create the **sender
-   secretbox**. (`\0` is a null byte.)
+   key** and the nonce `saltpack_sender_key_sbox`, to create the **sender
+   secretbox**.
 4. For each recipient, encrypt the **payload key** using
    [`crypto_box`](http://nacl.cr.yp.to/box.html) with the recipient's public
    key, the ephemeral private key, and the nonce
@@ -191,7 +191,7 @@ Recipients parse the header of a message using the following steps:
    is the **recipient index**.
 7. Open the **sender secretbox** using
    [`crypto_secretbox_open`](http://nacl.cr.yp.to/secretbox.html) with the
-   **payload key** from #7 and the nonce `saltpack_sender_secbox\0\0`
+   **payload key** from #7 and the nonce `saltpack_sender_key_sbox`
 8. Compute the recipient's **MAC key** by encrypting 32 zero bytes using
    [`crypto_box`](http://nacl.cr.yp.to/box.html) with the recipient's private
    key, the sender's public key from #8, and the first 24 bytes of the hash

--- a/go/saltpack/tweakable_encryptor_test.go
+++ b/go/saltpack/tweakable_encryptor_test.go
@@ -240,12 +240,21 @@ func newTestEncryptStream(ciphertext io.Writer, sender BoxSecretKey, receivers [
 	if err := pes.init(sender, receivers); err != nil {
 		return nil, err
 	}
+	// Encode the header and the header length, and write them out immediately.
 	headerBytes, err := encodeToBytes(pes.header)
+	if err != nil {
+		return nil, err
+	}
+	headerLen, err := encodeToBytes(len(headerBytes))
 	if err != nil {
 		return nil, err
 	}
 	if pes.options.corruptHeaderPacked != nil {
 		pes.options.corruptHeaderPacked(headerBytes)
+	}
+	_, err = pes.output.Write(headerLen)
+	if err != nil {
+		return nil, err
 	}
 	_, err = pes.output.Write(headerBytes)
 	return pes, err

--- a/go/saltpack/tweakable_encryptor_test.go
+++ b/go/saltpack/tweakable_encryptor_test.go
@@ -207,20 +207,15 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey
 	if err != nil {
 		return err
 	}
-	headerLen, err := encodeToBytes(len(headerBytes))
-	if err != nil {
-		return err
-	}
 	if pes.options.corruptHeaderPacked != nil {
 		pes.options.corruptHeaderPacked(headerBytes)
 	}
 	headerHash := sha512.Sum512(headerBytes)
 	pes.headerHash = headerHash[:]
-	_, err = pes.output.Write(headerLen)
+	err = pes.encoder.Encode(headerBytes)
 	if err != nil {
 		return err
 	}
-	_, err = pes.output.Write(headerBytes)
 
 	// Use the header hash to compute the MAC keys.
 	pes.computeMACKeys(sender, receivers)

--- a/go/saltpack/tweakable_encryptor_test.go
+++ b/go/saltpack/tweakable_encryptor_test.go
@@ -221,8 +221,8 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey
 
 func (pes *testEncryptStream) computeMACKeys(sender BoxSecretKey, receivers []BoxPublicKey) {
 	for _, receiver := range receivers {
-		macKeyBox := sender.Box(receiver, nonceForMACKeyBox(pes.headerHash[:]), make([]byte, 32))
-		pes.macKeys = append(pes.macKeys, macKeyBox[16:48])
+		macKey := computeMACKey(sender, receiver, pes.headerHash)
+		pes.macKeys = append(pes.macKeys, macKey)
 	}
 }
 

--- a/go/saltpack/tweakable_encryptor_test.go
+++ b/go/saltpack/tweakable_encryptor_test.go
@@ -103,11 +103,7 @@ func (pes *testEncryptStream) encryptBytes(b []byte) error {
 
 	// Compute the digest to authenticate, and authenticate it for each
 	// recipient.
-	ciphertextDigest := sha512.New()
-	ciphertextDigest.Write(pes.headerHash)
-	ciphertextDigest.Write(nonce[:])
-	ciphertextDigest.Write(ciphertext)
-	hashToAuthenticate := ciphertextDigest.Sum(nil)
+	hashToAuthenticate := computePayloadHash(pes.headerHash, nonce, ciphertext)
 	for _, macKey := range pes.macKeys {
 		authenticator := hmacSHA512256(macKey, hashToAuthenticate)
 		block.HashAuthenticators = append(block.HashAuthenticators, authenticator)

--- a/go/saltpack/tweakable_encryptor_test.go
+++ b/go/saltpack/tweakable_encryptor_test.go
@@ -5,7 +5,6 @@ package saltpack
 
 import (
 	"bytes"
-	"crypto/hmac"
 	"crypto/sha512"
 	"golang.org/x/crypto/nacl/secretbox"
 	"io"
@@ -110,11 +109,8 @@ func (pes *testEncryptStream) encryptBytes(b []byte) error {
 	ciphertextDigest.Write(ciphertext)
 	hashToAuthenticate := ciphertextDigest.Sum(nil)
 	for _, macKey := range pes.macKeys {
-		authenticatorDigest := hmac.New(sha512.New, macKey)
-		authenticatorDigest.Write(hashToAuthenticate)
-		fullMAC := authenticatorDigest.Sum(nil)
-		truncatedMAC := fullMAC[:32]
-		block.HashAuthenticators = append(block.HashAuthenticators, truncatedMAC)
+		authenticator := hmacSHA512256(macKey, hashToAuthenticate)
+		block.HashAuthenticators = append(block.HashAuthenticators, authenticator)
 	}
 
 	if pes.options.corruptEncryptionBlock != nil {


### PR DESCRIPTION
Use the hash of the entire header to authenticate the payload chunks. Use HMAC instead of our Box hack to construct these authenticators.

Doing that meant we had two important hashes to keep in mind: the hash of the ephemeral key and the hash of the entire header. We no longer have to use the hash of the ephemeral key though, since the MAC keys (the only thing that actually requires a random nonce) are computed after the whole header is processed. Stop using the hash of the ephemeral key, by hardcoding more of our nonces. This has the nice effect of bringing us closer to https://curvecp.org/nonces.html.

@maxtaco 