### PR TITLE
Fix track happening even when checkbox was unset

### DIFF
--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -149,14 +149,14 @@ export function onFollowHelp (username: string): Action {
 function trackUser (username: string, state: {tracker: RootTrackerState}): Promise<boolean> {
   const trackers = state.tracker.trackers
   const trackerState = trackers[username]
-  const {shouldFollow, trackToken} = (trackerState || {})
+  const {trackToken} = (trackerState || {})
 
   const options: TrackOptions = {
     localOnly: false,
     bypassConfirm: false
   }
 
-  if (trackerState && trackToken && trackerState !== Constants.normal || shouldFollow) {
+  if (trackerState && trackToken) {
     return new Promise((resolve, reject) => {
       engine.rpc('track.trackWithToken', {trackToken, options}, {}, (err, response) => {
         if (err) {
@@ -175,7 +175,10 @@ function trackUser (username: string, state: {tracker: RootTrackerState}): Promi
 
 export function onCloseFromActionBar (username: string): (dispatch: Dispatch, getState: () => {tracker: RootTrackerState}) => void {
   return (dispatch, getState) => {
-    trackUser(username, getState())
+    const {shouldFollow} = getState().tracker.trackers[username].trackerState
+    if (shouldFollow) {
+      trackUser(username, trackerState)
+    }
 
     dispatch({
       type: Constants.onCloseFromActionBar,

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -147,7 +147,7 @@ export function onFollowHelp (username: string): Action {
   }
 }
 
-function trackUser (trackToken: string): Promise<boolean> {
+function trackUser (trackToken: ?string): Promise<boolean> {
   const options: TrackOptions = {
     localOnly: false,
     bypassConfirm: false


### PR DESCRIPTION
@keybase/react-hackers 

We were trying to work out whether the user intended to track inside `trackUser()`, but that's too late to figure it out reliably.  `onRefollow()` is only called when you click Refollow, so that definitely intends to track.  And `onCloseFromActionBar` should always have shown a checkbox to the user, so that's the right place to investigate the checkbox's value and decide whether to track.

This PR also follows a @MarcoPolo suggestion to simplify `trackUser()`'s prototype from `(username: string, state: {tracker: RootTrackerState})` to `(trackToken: string)`, now that it doesn't have to concern itself with poking around in the store.