### PR TITLE
Fix trackers from popping up if there is an error that you've already tracked

### DIFF
--- a/react-native/react/reducers/tracker.js
+++ b/react-native/react/reducers/tracker.js
@@ -282,7 +282,7 @@ function stateToColor (state: SimpleProofState): string {
 
 function proofStateToSimpleProofState (proofState: ProofState, diff: ?TrackDiff, remoteDiff: ?TrackDiff): SimpleProofState {
   // If there is no difference in what we've tracked from the server or remote resource it's good.
-  if (diff && remoteDiff && diff.type === identify.TrackDiffType.none && remoteDiff === identify.TrackDiffType.none) {
+  if (diff && remoteDiff && diff.type === identify.TrackDiffType.none && remoteDiff.type === identify.TrackDiffType.none) {
     return normal
   }
 
@@ -419,14 +419,14 @@ function deriveTrackerState (
   anyDeletedProofs : boolean,
   anyUnreachableProofs : boolean,
 ): SimpleProofState {
-  if (anyWarnings || anyUnreachableProofs) {
+  if (allOk) {
+    return normal
+  } else if (anyPending) {
+    return checking
+  } else if (anyWarnings || anyUnreachableProofs) {
     return warning
   } else if (anyError || anyDeletedProofs) {
     return error
-  } else if (anyPending) {
-    return checking
-  } else if (allOk) {
-    return normal
   }
 
   return error
@@ -440,14 +440,14 @@ function deriveTrackerMessage (
   anyUpgradedProofs : boolean,
   anyNewProofs: boolean
 ): ?string {
-  if (anyDeletedProofs) {
+  if (allOk) {
+    return null
+  } else if (anyDeletedProofs) {
     return `${username} deleted some proofs.`
   } else if (anyUnreachableProofs) {
     return `Some of ${username}’s proofs are compromised or have changed.`
   } else if (anyUpgradedProofs) {
     return `${username} added some identity proofs.`
-  } else if (allOk) {
-    return null
   }
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

Okay this actually fixes nojima's tracker popups :)

There were two problems: 

1) I forgot to add the `.type` at the end of remoteDiff. flow would have caught this if we typed `keybase_v1.js` so that may be useful if we run into stuff like this again.

2) The ordering of `deriveTrackerState` meant that if we had an Unreacabhle proof the tracker state would be warning, even if everything is `allOk`