### PR TITLE
Catch SIGTERM and safe launchd stop

### DIFF
--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"syscall"
 
 	"golang.org/x/net/context"
 
@@ -239,7 +240,7 @@ func registerGlobalLogUI(g *libkb.GlobalContext) error {
 
 func HandleSignals() {
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, os.Kill)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM, os.Kill)
 	for {
 		s := <-c
 		if s != nil {


### PR DESCRIPTION
`launchctl unload` uses SIGKILL (for fast termination)... and changing to use `launchctl remove` which uses SIGTERM.

Also fixed use of logger and using terminal UI for launchd command output.

Also see https://keybase.atlassian.net/browse/DESKTOP-285

