### PR TITLE
Reduce loggin while showing devtools

### DIFF
--- a/desktop/app/console-helper.js
+++ b/desktop/app/console-helper.js
@@ -1,8 +1,9 @@
 import {ipcMain, ipcRenderer} from 'electron'
 import util from 'util'
+import getenv from 'getenv'
 
 export default function pipeLogs () {
-  if (!__DEV__) { // eslint-disable-line no-undef
+  if (!__DEV__ || getenv.boolish('KEYBASE_SHOW_DEVTOOLS', true)) { // eslint-disable-line no-undef
     return
   }
 


### PR DESCRIPTION
This should reduce the dupe logging we mostly see while we're devving
Let me know if ppl have other ideas
@keybase/react-hackers 