### PR TITLE
Allow sigs revoke to work with a SigID prefix

### DIFF
--- a/go/client/cmd_sigs_revoke.go
+++ b/go/client/cmd_sigs_revoke.go
@@ -16,7 +16,7 @@ import (
 )
 
 type CmdSigsRevoke struct {
-	sigIDs []keybase1.SigID
+	queries []string
 }
 
 func (c *CmdSigsRevoke) ParseArgv(ctx *cli.Context) error {
@@ -25,7 +25,10 @@ func (c *CmdSigsRevoke) ParseArgv(ctx *cli.Context) error {
 	}
 
 	for _, arg := range ctx.Args() {
-		c.sigIDs = append(c.sigIDs, keybase1.SigID(arg))
+		if len(arg) < keybase1.SigIDQueryMin {
+			return fmt.Errorf("sig id %q is too short; must be at least 16 characters long", arg)
+		}
+		c.queries = append(c.queries, arg)
 	}
 
 	return nil
@@ -45,7 +48,7 @@ func (c *CmdSigsRevoke) Run() error {
 	}
 
 	return cli.RevokeSigs(context.TODO(), keybase1.RevokeSigsArg{
-		SigIDs: c.sigIDs,
+		SigIDQueries: c.queries,
 	})
 }
 

--- a/go/engine/track_proof_test.go
+++ b/go/engine/track_proof_test.go
@@ -454,7 +454,7 @@ func TestTrackProofRooterRevoke(t *testing.T) {
 	// revoke the rooter proof
 	Logout(tc)
 	proofUser.LoginOrBust(tc)
-	revEng := NewRevokeSigsEngine([]keybase1.SigID{sigID}, tc.G)
+	revEng := NewRevokeSigsEngine([]string{sigID.ToString(true)}, tc.G)
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
 		SecretUI: proofUser.NewSecretUI(),

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -549,6 +549,17 @@ func (sc *SigChain) GetLinkFromSigID(id keybase1.SigID) *ChainLink {
 	return nil
 }
 
+// GetLinkFromSigIDQuery will return true if it finds a ChainLink
+// with a SigID that starts with query.
+func (sc *SigChain) GetLinkFromSigIDQuery(query string) *ChainLink {
+	for _, link := range sc.chainLinks {
+		if link.GetSigID().Match(query, false) {
+			return link
+		}
+	}
+	return nil
+}
+
 //========================================================================
 
 type ChainType struct {

--- a/go/protocol/extras.go
+++ b/go/protocol/extras.go
@@ -318,7 +318,7 @@ func (s SigID) ToDisplayString(verbose bool) string {
 	if verbose {
 		return string(s)
 	}
-	return fmt.Sprintf("%s...", s[0:16])
+	return fmt.Sprintf("%s...", s[0:SigIDQueryMin])
 }
 
 func (s SigID) ToString(suffix bool) string {

--- a/go/protocol/extras.go
+++ b/go/protocol/extras.go
@@ -30,6 +30,7 @@ const (
 	SIG_ID_LEN         = 32
 	SIG_ID_SUFFIX      = 0x0f
 	SIG_SHORT_ID_BYTES = 27
+	SigIDQueryMin      = 16
 )
 
 const (
@@ -293,6 +294,22 @@ func (s SigID) Equal(t SigID) bool {
 	return s == t
 }
 
+func (s SigID) Match(q string, exact bool) bool {
+	if s.IsNil() {
+		return false
+	}
+
+	if exact {
+		return strings.ToLower(s.ToString(true)) == strings.ToLower(q)
+	}
+
+	if strings.HasPrefix(s.ToString(true), strings.ToLower(q)) {
+		return true
+	}
+
+	return false
+}
+
 func (s SigID) NotEqual(t SigID) bool {
 	return !s.Equal(t)
 }
@@ -301,7 +318,7 @@ func (s SigID) ToDisplayString(verbose bool) string {
 	if verbose {
 		return string(s)
 	}
-	return fmt.Sprintf("%s...", s[0:6])
+	return fmt.Sprintf("%s...", s[0:16])
 }
 
 func (s SigID) ToString(suffix bool) string {

--- a/go/protocol/extras.go
+++ b/go/protocol/extras.go
@@ -30,7 +30,7 @@ const (
 	SIG_ID_LEN         = 32
 	SIG_ID_SUFFIX      = 0x0f
 	SIG_SHORT_ID_BYTES = 27
-	SigIDQueryMin      = 16
+	SigIDQueryMin      = 8
 )
 
 const (

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -4614,8 +4614,8 @@ type RevokeDeviceArg struct {
 }
 
 type RevokeSigsArg struct {
-	SessionID int     `codec:"sessionID" json:"sessionID"`
-	SigIDs    []SigID `codec:"sigIDs" json:"sigIDs"`
+	SessionID    int      `codec:"sessionID" json:"sessionID"`
+	SigIDQueries []string `codec:"sigIDQueries" json:"sigIDQueries"`
 }
 
 type RevokeInterface interface {

--- a/go/service/revoke.go
+++ b/go/service/revoke.go
@@ -48,6 +48,6 @@ func (h *RevokeHandler) RevokeSigs(_ context.Context, arg keybase1.RevokeSigsArg
 		LogUI:    h.getLogUI(arg.SessionID),
 		SecretUI: h.getSecretUI(arg.SessionID),
 	}
-	eng := engine.NewRevokeSigsEngine(arg.SigIDs, h.G())
+	eng := engine.NewRevokeSigsEngine(arg.SigIDQueries, h.G())
 	return engine.RunEngine(eng, &ctx)
 }

--- a/protocol/avdl/revoke.avdl
+++ b/protocol/avdl/revoke.avdl
@@ -5,5 +5,5 @@ protocol revoke {
 
   void revokeKey(int sessionID, KID keyID);
   void revokeDevice(int sessionID, DeviceID deviceID, boolean force);
-  void revokeSigs(int sessionID, array<SigID> sigIDs);
+  void revokeSigs(int sessionID, array<string> sigIDQueries);
 }

--- a/protocol/json/revoke.json
+++ b/protocol/json/revoke.json
@@ -242,10 +242,10 @@
         "name" : "sessionID",
         "type" : "int"
       }, {
-        "name" : "sigIDs",
+        "name" : "sigIDQueries",
         "type" : {
           "type" : "array",
-          "items" : "SigID"
+          "items" : "string"
         }
       } ],
       "response" : "null"


### PR DESCRIPTION
`sigs revoke` required full SigID, which by default was not output by website or `sigs list`.

Also changed SigID.ToDisplayString() to display a long-enough prefix for use with `sigs revoke`

r? @maxtaco 