### PR TITLE
Eof after retrack desktop 277

### DIFF
--- a/react-native/react/actions/notifications.js
+++ b/react-native/react/actions/notifications.js
@@ -11,7 +11,7 @@ import type {Text, LogLevel} from '../constants/types/flow-types'
 import type {LogAction} from '../constants/notifications'
 
 export function logUiLog ({text, level}: {text: Text, level: LogLevel}): LogAction {
-  console.log('fooo: keybase.1.logUi.log:', text.data)
+  console.log('keybase.1.logUi.log:', text.data)
   if (level >= logUi.LogLevel.error) {
     NotifyPopup(text.data, {})
   }

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -117,12 +117,20 @@ export function onRefollow (username: string): TrackerActionCreator {
       })
     }
 
+    dispatch(onUserTrackingLoading(username))
     trackUser(trackToken)
       .then(dispatchAction)
       .catch(err => {
         console.error('Couldn\'t track user:', err)
         dispatchAction()
       })
+  }
+}
+
+function onUserTrackingLoading (username: string): Action {
+  return {
+    type: Constants.onUserTrackingLoading,
+    payload: {username}
   }
 }
 
@@ -187,6 +195,7 @@ export function onCloseFromActionBar (username: string): (dispatch: Dispatch, ge
     const dispatchCloseAction = () => dispatch({type: Constants.onCloseFromActionBar, payload: {username}})
 
     if (shouldFollow) {
+      dispatch(onUserTrackingLoading(username))
       trackUser(trackToken)
         .then(dispatchCloseAction)
         .catch(err => {

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -121,7 +121,7 @@ export function onRefollow (username: string): TrackerActionCreator {
     trackUser(trackToken)
       .then(dispatchAction)
       .catch(err => {
-        console.error('Couldn\'t track user:', err)
+        console.error(`Couldn't track user:`, err)
         dispatchAction()
       })
   }

--- a/react-native/react/actions/tracker.js
+++ b/react-native/react/actions/tracker.js
@@ -110,11 +110,19 @@ export function onRefollow (username: string): TrackerActionCreator {
   return (dispatch, getState) => {
     console.log('onRefollow')
     const {trackToken} = (getState().tracker.trackers[username] || {})
+    const dispatchAction = () => {
+      dispatch({
+        type: Constants.onRefollow,
+        payload: {username}
+      })
+    }
+
     trackUser(trackToken)
-    dispatch({
-      type: Constants.onRefollow,
-      payload: {username}
-    })
+      .then(dispatchAction)
+      .catch(err => {
+        console.error('Couldn\'t track user:', err)
+        dispatchAction()
+      })
   }
 }
 
@@ -175,14 +183,19 @@ export function onCloseFromActionBar (username: string): (dispatch: Dispatch, ge
     const trackerState = getState().tracker.trackers[username]
     const {shouldFollow} = trackerState
     const {trackToken} = (trackerState || {})
+
+    const dispatchCloseAction = () => dispatch({type: Constants.onCloseFromActionBar, payload: {username}})
+
     if (shouldFollow) {
       trackUser(trackToken)
+        .then(dispatchCloseAction)
+        .catch(err => {
+          console.error('Couldn\'t track user:', err)
+          dispatchCloseAction()
+        })
+    } else {
+      dispatchCloseAction()
     }
-
-    dispatch({
-      type: Constants.onCloseFromActionBar,
-      payload: {username}
-    })
   }
 }
 

--- a/react-native/react/constants/tracker.js
+++ b/react-native/react/constants/tracker.js
@@ -32,6 +32,8 @@ export const updateProofState = 'tracker:updateProofState'
 
 export const reportLastTrack = 'tracker:reportLastTrack'
 
+export const onUserTrackingLoading = 'tracker:userTrackingLoading'
+
 export const onCloseFromActionBar = 'tracker:onCloseFromActionBar'
 export const onCloseFromHeader = 'tracker:onCloseFromHeader'
 

--- a/react-native/react/native/remote-component.desktop.js
+++ b/react-native/react/native/remote-component.desktop.js
@@ -67,7 +67,7 @@ export default class RemoteComponent extends Component {
       return false
     }
 
-    if (this.props !== nextProps) {
+    if (!this.props.ignoreNewProps && this.props !== nextProps) {
       this.remoteWindow.emit('hasProps', {...this.props})
     }
 
@@ -88,5 +88,6 @@ RemoteComponent.propTypes = {
   component: React.PropTypes.string.isRequired,
   windowsOpts: React.PropTypes.object,
   onRemoteClose: React.PropTypes.func,
-  hidden: React.PropTypes.bool
+  hidden: React.PropTypes.bool, // Hide the remote window (Does not close the window)
+  ignoreNewProps: React.PropTypes.bool // Do not send the remote window new props. Sometimes the remote component will have it's own store and can get it's own data. It doesn't need us to send it.
 }

--- a/react-native/react/native/remote-manager.desktop.js
+++ b/react-native/react/native/remote-manager.desktop.js
@@ -64,7 +64,7 @@ class RemoteManager extends Component {
 
   shouldComponentUpdate (nextProps, nextState) {
     // different window states
-    if (this.windowStates(nextProps.trackers) !== this.windowStates(this.props.trackers)) {
+    if (nextProps.trackers !== this.props.trackers) {
       return true
     }
 
@@ -83,22 +83,18 @@ class RemoteManager extends Component {
     let popups = {}
 
     Object.keys(nextProps.trackers).forEach(username => {
-      if (!this.state.popups[username]) {
-        popups[username] = (
-          <RemoteComponent
-            windowsOpts={{height: 339, width: 520}}
-            waitForState
-            onRemoteClose={() => this.props.trackerOnCloseFromHeader(username)}
-            component='tracker'
-            username={username}
-            startTimer={this.props.trackerStartTimer}
-            stopTimer={this.props.trackerStopTimer}
-            key={username} />
-        )
-      } else {
-        // keep existing ones
-        popups[username] = this.state.popups[username]
-      }
+      popups[username] = (
+        <RemoteComponent
+        windowsOpts={{height: 339, width: 520}}
+        waitForState
+        hidden={nextProps.trackers[username].hidden}
+        onRemoteClose={() => this.props.trackerOnCloseFromHeader(username)}
+        component='tracker'
+        username={username}
+        startTimer={this.props.trackerStartTimer}
+        stopTimer={this.props.trackerStopTimer}
+        key={username} />
+      )
     })
 
     this.setState({popups})

--- a/react-native/react/native/remote-manager.desktop.js
+++ b/react-native/react/native/remote-manager.desktop.js
@@ -85,15 +85,16 @@ class RemoteManager extends Component {
     Object.keys(nextProps.trackers).forEach(username => {
       popups[username] = (
         <RemoteComponent
-        windowsOpts={{height: 339, width: 520}}
-        waitForState
-        hidden={nextProps.trackers[username].hidden}
-        onRemoteClose={() => this.props.trackerOnCloseFromHeader(username)}
-        component='tracker'
-        username={username}
-        startTimer={this.props.trackerStartTimer}
-        stopTimer={this.props.trackerStopTimer}
-        key={username} />
+          windowsOpts={{height: 339, width: 520}}
+          waitForState
+          ignoreNewProps
+          hidden={nextProps.trackers[username].hidden}
+          onRemoteClose={() => this.props.trackerOnCloseFromHeader(username)}
+          component='tracker'
+          username={username}
+          startTimer={this.props.trackerStartTimer}
+          stopTimer={this.props.trackerStopTimer}
+          key={username} />
       )
     })
 

--- a/react-native/react/native/remote-manager.desktop.js
+++ b/react-native/react/native/remote-manager.desktop.js
@@ -42,24 +42,11 @@ export type RemoteManagerProps = {
 class RemoteManager extends Component {
   props: RemoteManagerProps;
 
-  constructor (props) {
-    super(props)
-    this.state = {
-      popups: {}
-    }
-  }
-
   componentWillMount () {
     this.props.registerIdentifyUi()
     this.props.registerPinentryListener()
     this.props.registerTrackerChangeListener()
     this.props.registerUpdateListener()
-  }
-
-  windowStates (trackers) {
-    return Object.keys(trackers).map(user => {
-      return `${user}:${trackers[user].closed ? 0 : 1}`
-    }).join(',')
   }
 
   shouldComponentUpdate (nextProps, nextState) {
@@ -79,26 +66,21 @@ class RemoteManager extends Component {
     return false
   }
 
-  componentWillReceiveProps (nextProps) {
-    let popups = {}
-
-    Object.keys(nextProps.trackers).forEach(username => {
-      popups[username] = (
-        <RemoteComponent
-          windowsOpts={{height: 339, width: 520}}
-          waitForState
-          ignoreNewProps
-          hidden={nextProps.trackers[username].hidden}
-          onRemoteClose={() => this.props.trackerOnCloseFromHeader(username)}
-          component='tracker'
-          username={username}
-          startTimer={this.props.trackerStartTimer}
-          stopTimer={this.props.trackerStopTimer}
-          key={username} />
-      )
-    })
-
-    this.setState({popups})
+  trackerRemoteComponents () {
+    const {trackers} = this.props
+    return Object.keys(trackers).filter(username => !trackers[username].closed).map(username => (
+      <RemoteComponent
+        windowsOpts={{height: 339, width: 520}}
+        waitForState
+        ignoreNewProps
+        hidden={trackers[username].hidden}
+        onRemoteClose={() => this.props.trackerOnCloseFromHeader(username)}
+        component='tracker'
+        username={username}
+        startTimer={this.props.trackerStartTimer}
+        stopTimer={this.props.trackerStopTimer}
+        key={username} />
+    ))
   }
 
   pinentryRemoteComponents () {
@@ -147,7 +129,7 @@ class RemoteManager extends Component {
   render () {
     return (
       <div style={{display: 'none'}}>
-        {Object.keys(this.state.popups).filter(username => !this.props.trackers[username].closed).map(username => this.state.popups[username])}
+        {this.trackerRemoteComponents()}
         {this.pinentryRemoteComponents()}
         {this.showUpdatePromptComponents()}
       </div>

--- a/react-native/react/reducers/tracker.js
+++ b/react-native/react/reducers/tracker.js
@@ -28,6 +28,7 @@ export type TrackerState = {
   userInfo: UserInfo,
   proofs: Array<Proof>,
   closed: boolean,
+  hidden: boolean,
   trackToken: ?string,
   lastTrack: ?TrackSummary
 }
@@ -56,6 +57,7 @@ function initialTrackerState (username: string): TrackerState {
     proofs: [],
     reason: '', // TODO: get the reason
     closed: true,
+    hidden: false,
     lastTrack: null,
     trackToken: null,
     userInfo: {
@@ -90,17 +92,20 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
     case Constants.userUpdated:
       return {
         ...state,
-        closed: true
+        closed: true,
+        hidden: false
       }
     case Constants.onCloseFromActionBar:
       return {
         ...state,
-        closed: true
+        closed: true,
+        hidden: false
       }
     case Constants.onCloseFromHeader:
       return {
         ...state,
         closed: true,
+        hidden: false,
         shouldFollow: false // don't follow if they close x out the window
       }
     case Constants.onRefollow:
@@ -173,7 +178,8 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
       return {
         ...state,
         serverActive,
-        closed
+        closed,
+        hidden: closed ? false : state.hidden
       }
 
     case Constants.reportLastTrack:
@@ -182,11 +188,18 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
         lastTrack: action.payload && action.payload.track
       }
 
+    case Constants.onUserTrackingLoading:
+      return {
+        ...state,
+        hidden: true
+      }
+
     case Constants.decideToShowTracker:
       if (showAllTrackers) {
         return {
           ...state,
-          closed: false
+          closed: false,
+          hidden: false
         }
       }
 
@@ -198,7 +211,8 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
       if (state.trackerState !== checking && (state.trackerState !== normal || !state.lastTrack)) {
         return {
           ...state,
-          closed: false
+          closed: false,
+          hidden: false
         }
       }
       return state


### PR DESCRIPTION
Currently we closed the tracker after starting the tracking request. But
that lead to errors like: https://keybase.atlassian.net/browse/DESKTOP-277
and possibly a race condition(?).

This will hide the window while we're making the request, and close it
when it's done or errors.

We can refine this later to have the same remote component come back up
with a helpful error message.

Also cleans up how remote trackers are made and cleans up remote-manager a bit.

@keybase/react-hackers 