### PR TITLE
Wait for updater UI (in case of app/service restarts)

### DIFF
--- a/go/engine/context.go
+++ b/go/engine/context.go
@@ -59,3 +59,7 @@ func (c *Context) GetNetContext() context.Context {
 	}
 	return c.NetContext
 }
+
+func (c *Context) GetUpdateUI() (libkb.UpdateUI, error) {
+	return c.UpdateUI, nil
+}

--- a/go/engine/update.go
+++ b/go/engine/update.go
@@ -56,7 +56,7 @@ func (u *UpdateEngine) Run(ctx *Context) (err error) {
 	}
 
 	updr := updater.NewUpdater(u.options, source, u.G().Env, u.G().Log)
-	update, err := updr.Update(ctx.UpdateUI, u.options.Force, true)
+	update, err := updr.Update(ctx, u.options.Force, true)
 	if err != nil {
 		return
 	}

--- a/go/updater/update_checker.go
+++ b/go/updater/update_checker.go
@@ -4,10 +4,8 @@
 package updater
 
 import (
-	"fmt"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol"
 	"github.com/keybase/client/go/updater/sources"
@@ -20,10 +18,6 @@ type UpdateChecker struct {
 	log     logger.Logger
 }
 
-type UI interface {
-	GetUpdateUI() (libkb.UpdateUI, error)
-}
-
 func NewUpdateChecker(updater *Updater, ui UI, log logger.Logger) UpdateChecker {
 	return UpdateChecker{
 		updater: updater,
@@ -33,11 +27,6 @@ func NewUpdateChecker(updater *Updater, ui UI, log logger.Logger) UpdateChecker 
 }
 
 func (u *UpdateChecker) Check(force bool, requested bool) error {
-	ui, _ := u.ui.GetUpdateUI()
-	if ui == nil && !force {
-		return fmt.Errorf("No UI for update check")
-	}
-
 	if !requested && !force {
 		if lastCheckedPTime := u.updater.config.GetUpdateLastChecked(); lastCheckedPTime > 0 {
 			lastChecked := keybase1.FromTime(lastCheckedPTime)
@@ -48,7 +37,7 @@ func (u *UpdateChecker) Check(force bool, requested bool) error {
 		}
 	}
 
-	_, err := u.updater.Update(ui, force, requested)
+	_, err := u.updater.Update(u.ui, force, requested)
 	if err != nil {
 		return err
 	}

--- a/go/updater/updater_test.go
+++ b/go/updater/updater_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol"
 	"golang.org/x/net/context"
@@ -30,6 +31,10 @@ func (u nullUpdateUI) UpdatePrompt(_ context.Context, _ keybase1.UpdatePromptArg
 
 func (u nullUpdateUI) UpdateQuit(_ context.Context) (keybase1.UpdateQuitRes, error) {
 	return keybase1.UpdateQuitRes{Quit: false}, nil
+}
+
+func (u nullUpdateUI) GetUpdateUI() (libkb.UpdateUI, error) {
+	return u, nil
 }
 
 func (u testUpdateSource) Description() string {


### PR DESCRIPTION
I think this will resolve:
https://keybase.atlassian.net/browse/DESKTOP-211
https://keybase.atlassian.net/browse/DESKTOP-290

Getting the update UI is now lazier (waits until needed), and when it requests it, it will wait for up to 5 seconds, in case the app or service are restarting.
