### PR TITLE
Service info lookup better logging and error messages

### DIFF
--- a/go/client/cmd_launchd_osx.go
+++ b/go/client/cmd_launchd_osx.go
@@ -183,7 +183,7 @@ func (v *CmdLaunchdList) ParseArgv(ctx *cli.Context) error {
 
 func (v *CmdLaunchdList) Run() error {
 	if v.format == "json" {
-		servicesStatus, err := install.ListServices()
+		servicesStatus, err := install.ListServices(v.G())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
In response to https://keybase.atlassian.net/browse/DESKTOP-282

Basically if the service is borked and not running, it can report a pid mismatch since the old pid info remained around.

This cleans up a bunch of stuff and makes the error message better (reports that the service isn't running).

Also added some debug logging.