### PR TITLE
libkb: verbse debugging split out

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -10,12 +10,12 @@ import (
 	"time"
 )
 
-func importTrackingLink(t *testing.T) *libkb.TrackChainLink {
+func importTrackingLink(t *testing.T, g *libkb.GlobalContext) *libkb.TrackChainLink {
 	jw, err := jsonw.Unmarshal([]byte(trackingServerReply))
 	if err != nil {
 		t.Fatal(err)
 	}
-	cl, err := libkb.ImportLinkFromServer(nil, jw, trackingUID)
+	cl, err := libkb.ImportLinkFromServer(g, nil, jw, trackingUID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +28,7 @@ func importTrackingLink(t *testing.T) *libkb.TrackChainLink {
 }
 
 func TestIdentify2WithUIDImportTrackingLink(t *testing.T) {
-	link := importTrackingLink(t)
+	link := importTrackingLink(t, nil)
 	if link == nil {
 		t.Fatalf("link import failed")
 	}
@@ -179,7 +179,7 @@ func TestIdentify2WithUIDWithTrack(t *testing.T) {
 
 	eng.testArgs = &Identify2WithUIDTestArgs{
 		noMe: true,
-		tcl:  importTrackingLink(t),
+		tcl:  importTrackingLink(t, tc.G),
 	}
 
 	ctx := Context{IdentifyUI: i}
@@ -204,7 +204,7 @@ func TestIdentify2WithUIDWithBrokenTrack(t *testing.T) {
 
 	eng.testArgs = &Identify2WithUIDTestArgs{
 		noMe: true,
-		tcl:  importTrackingLink(t),
+		tcl:  importTrackingLink(t, tc.G),
 	}
 	i.checkStatusHook = func(l libkb.SigHint) libkb.ProofError {
 		if strings.Contains(l.GetHumanURL(), "twitter") {

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -85,6 +85,9 @@ func (p CommandLine) GetDbFilename() string {
 func (p CommandLine) GetDebug() (bool, bool) {
 	return p.GetBool("debug", true)
 }
+func (p CommandLine) GetVDebugSetting() string {
+	return p.GetGString("vdebug")
+}
 func (p CommandLine) GetPGPFingerprint() *libkb.PGPFingerprint {
 	return libkb.PGPFingerprintFromHexNoError(p.GetGString("fingerprint"))
 }
@@ -302,6 +305,10 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 		cli.BoolFlag{
 			Name:  "debug, d",
 			Usage: "Enable debugging mode.",
+		},
+		cli.StringFlag{
+			Name:  "vdebug",
+			Usage: "Verbose debugging; takes a comma-joined list of levels and tags",
 		},
 		cli.StringFlag{
 			Name:  "run-mode",

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -112,7 +112,7 @@ func (f JSONConfigFile) GetDurationAtPath(p string) (time.Duration, bool) {
 func (f JSONConfigFile) GetTopLevelString(s string) (ret string) {
 	var e error
 	f.jw.AtKey(s).GetStringVoid(&ret, &e)
-	f.G().Log.Debug("Config: mapping %s -> %s", s, ret)
+	f.G().VDL.Log(VLog1, "Config: mapping %q -> %q", s, ret)
 	return
 }
 
@@ -450,6 +450,9 @@ func (f JSONConfigFile) GetProxy() string {
 }
 func (f JSONConfigFile) GetDebug() (bool, bool) {
 	return f.GetTopLevelBool("debug")
+}
+func (f JSONConfigFile) GetVDebugSetting() string {
+	return f.GetTopLevelString("vdebug")
 }
 func (f JSONConfigFile) GetAutoFork() (bool, bool) {
 	return f.GetTopLevelBool("auto_fork")

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -62,6 +62,7 @@ func (n NullConfiguration) GetUpdatePreferenceAuto() (bool, bool)         { retu
 func (n NullConfiguration) GetUpdatePreferenceSnoozeUntil() keybase1.Time { return keybase1.Time(0) }
 func (n NullConfiguration) GetUpdateLastChecked() keybase1.Time           { return keybase1.Time(0) }
 func (n NullConfiguration) GetUpdatePreferenceSkip() string               { return "" }
+func (n NullConfiguration) GetVDebugSetting() string                      { return "" }
 
 func (n NullConfiguration) GetUserConfig() (*UserConfig, error) { return nil, nil }
 func (n NullConfiguration) GetUserConfigForUsername(s NormalizedUsername) (*UserConfig, error) {
@@ -840,4 +841,13 @@ func (e *Env) SetUpdatePreferenceSnoozeUntil(t keybase1.Time) error {
 
 func (e *Env) SetUpdateLastChecked(t keybase1.Time) error {
 	return e.GetConfigWriter().SetUpdateLastChecked(t)
+}
+
+func (e *Env) GetVDebugSetting() string {
+	return e.GetString(
+		func() string { return e.cmd.GetVDebugSetting() },
+		func() string { return os.Getenv("KEYBASE_VDEBUG") },
+		func() string { return e.config.GetVDebugSetting() },
+		func() string { return "" },
+	)
 }

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -31,6 +31,7 @@ type ShutdownHook func() error
 
 type GlobalContext struct {
 	Log               logger.Logger  // Handles all logging
+	VDL               *VDebugLog     // verbose debug log
 	Env               *Env           // Env variables, cmdline args & config
 	Keyrings          *Keyrings      // Gpg Keychains holding keys
 	API               API            // How to make a REST call to the server
@@ -67,8 +68,10 @@ type GlobalContext struct {
 }
 
 func NewGlobalContext() *GlobalContext {
+	log := logger.New("keybase", ErrorWriter())
 	return &GlobalContext{
-		Log:                 logger.New("keybase", ErrorWriter()),
+		Log:                 log,
+		VDL:                 NewVDebugLog(log),
 		ProofCheckerFactory: defaultProofCheckerFactory,
 		Clock:               clockwork.NewRealClock(),
 	}
@@ -155,6 +158,7 @@ func (g *GlobalContext) ConfigureLogging() error {
 	g.Log.Configure(g.Env.GetLogFormat(), g.Env.GetDebug(),
 		g.Env.GetLogFile())
 	g.Output = os.Stdout
+	g.VDL.Configure(g.Env.GetVDebugSetting())
 	return nil
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -32,6 +32,7 @@ type CommandLine interface {
 	GetSessionFilename() string
 	GetDbFilename() string
 	GetDebug() (bool, bool)
+	GetVDebugSetting() string
 	GetProxy() string
 	GetLogFormat() string
 	GetGpgHome() string
@@ -96,6 +97,7 @@ type ConfigReader interface {
 	GetSessionFilename() string
 	GetDbFilename() string
 	GetDebug() (bool, bool)
+	GetVDebugSetting() string
 	GetAutoFork() (bool, bool)
 	GetUserConfig() (*UserConfig, error)
 	GetUserConfigForUsername(s NormalizedUsername) (*UserConfig, error)

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -163,7 +163,7 @@ func (sc *SigChain) LoadFromServer(t *MerkleTriple, selfUID keybase1.UID) (dirty
 
 	for i := 0; i < lim; i++ {
 		var link *ChainLink
-		if link, err = ImportLinkFromServer(sc, v.AtIndex(i), selfUID); err != nil {
+		if link, err = ImportLinkFromServer(sc.G(), sc, v.AtIndex(i), selfUID); err != nil {
 			return
 		}
 		if link.GetSeqno() <= low {
@@ -659,7 +659,7 @@ func (l *SigChainLoader) LoadLinksFromStorage() (err error) {
 	suid := l.selfUID()
 
 	for curr != nil && goodKey {
-		l.G().Log.Debug("| loading link; curr=%s", curr)
+		l.G().VDL.Log(VLog1, "| loading link; curr=%s", curr)
 		if link, err = ImportLinkFromStorage(curr, suid, l.G()); err != nil {
 			return
 		}
@@ -680,6 +680,7 @@ func (l *SigChainLoader) LoadLinksFromStorage() (err error) {
 	}
 
 	reverse(links)
+	l.G().Log.Debug("| Loaded %d links", len(links))
 
 	l.links = links
 	return

--- a/go/libkb/sig_chain_test.go
+++ b/go/libkb/sig_chain_test.go
@@ -171,7 +171,7 @@ func doChainTest(t *testing.T, testCase TestCase) {
 	sigchain := SigChain{username: NewNormalizedUsername(input.Username), uid: uid, loadedFromLinkOne: true}
 	for i := 0; i < chainLen; i++ {
 		linkBlob := inputBlob.AtKey("chain").AtIndex(i)
-		link, err := ImportLinkFromServer(&sigchain, linkBlob, uid)
+		link, err := ImportLinkFromServer(nil, &sigchain, linkBlob, uid)
 		if err != nil {
 			sigchainErr = err
 			break

--- a/go/libkb/vdebug.go
+++ b/go/libkb/vdebug.go
@@ -1,0 +1,61 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package libkb
+
+import (
+	"fmt"
+	"github.com/keybase/client/go/logger"
+	"strings"
+)
+
+// VDebugLog is a "Verbose" debug logger; enable it if you really
+// want spam and/or minutiae
+type VDebugLog struct {
+	log logger.Logger
+	lev VDebugLevel
+}
+
+type VDebugLevel int
+
+func NewVDebugLog(l logger.Logger) *VDebugLog {
+	return &VDebugLog{log: l}
+}
+
+const (
+	VLog0 VDebugLevel = 0
+	VLog1 VDebugLevel = 1
+	VLog2 VDebugLevel = 2
+	VLog3 VDebugLevel = 3
+)
+
+func (v *VDebugLog) Log(lev VDebugLevel, fs string, args ...interface{}) {
+	if lev <= v.lev {
+		prfx := fmt.Sprintf("{VDL:%d} ", int(lev))
+		fs = prfx + fs
+		v.log.Debug(fs, args...)
+	}
+}
+
+func (v *VDebugLog) Configure(s string) {
+	if len(s) == 0 {
+		return
+	}
+	v.log.Debug("Setting Vdebug to %q", s)
+	parts := strings.Split(s, ",")
+	v.lev = VLog0
+	for _, s := range parts {
+		switch s {
+		case "vlog0":
+			v.lev = VLog0
+		case "vlog1":
+			v.lev = VLog1
+		case "vlog2":
+			v.lev = VLog2
+		case "vlog3":
+			v.lev = VLog3
+		default:
+			v.log.Warning("Ignoring Vdebug log directive: %q", s)
+		}
+	}
+}


### PR DESCRIPTION
- configure via command-line flags
- stub out the most noisy offenders

for the future:
- we need to get the correct line number (stack-off-by-one error in printf)
- we might want channels to split up logging further