### PR TITLE
Fix new passphrase confirmation logic

### DIFF
--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fix passphrase confirmation logic (PR: keybase/client#1752)
 - Fix `keybase passphrase recover` SecretUI, LoginSession issues (PR: keybase/client#1750)
 - Allow `keybase sigs revoke` to work with a prefix, and
   have `keybase sigs list` display Sig IDs that will


### PR DESCRIPTION
If match fails, enter a new first passphrase and a new
confirmation passphrase.

Previously, it just kept trying to match the first
passphrase.

r? @maxtaco 