### PR TITLE
Don't reset the close state when we get another identify call.

### DIFF
--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -78,7 +78,6 @@ class Keybase extends Component {
       sender.send('stateChange', getStore())
       store.subscribe(() => {
         const diffState = getStore()
-        console.log('Sending state change!', diffState)
         if (Object.keys(diffState).length !== 0) {
           sender.send('stateChange', diffState)
         }

--- a/react-native/react/reducers/tracker.js
+++ b/react-native/react/reducers/tracker.js
@@ -177,13 +177,9 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
 
     case Constants.markActiveIdentifyUi:
       const serverActive = action.payload && !!action.payload.active || false
-      // The server wasn't active and now it is, we reset closed state
-      const closed = !state.serverActive && serverActive ? true : state.closed
       return {
         ...state,
-        serverActive,
-        closed,
-        hidden: closed ? false : state.hidden
+        serverActive
       }
 
     case Constants.reportLastTrack:
@@ -314,9 +310,9 @@ function proofStateToSimpleProofState (proofState: ProofState, diff: ?TrackDiff,
       return warning
     case 'revoked':
     case 'permFailure':
+    case 'none':
       return error
     case 'looking':
-    case 'none':
     default:
       return checking
   }


### PR DESCRIPTION
The service can make multiply identify calls to the app for the same
user. For example when the user goes to `private/user,foo` and `private/user,foo,bar`
That will yield two identify calls to `foo`. So instead of closing the
tracker popup and reopening it when we've decided to show it again,
let's just leave it open.

This will mean that the tracker popup will update to say "Checking" if
we get a launchNetworkCheck or finishProof from the service.

Ideally the service would only send updates, and not reset the state
with launchNetworkChecks, but that might be hard to do because the
service would have to keep track whether it's already started an identify,
and that the client hasn't cleared it's state. So this is okay for now since it's 
simple and has fewer edge cases.

Doesn't completely fix: https://keybase.atlassian.net/browse/DESKTOP-280
but makes it a lot less ugly and painful. 

@keybase/react-hackers 