### PR TITLE
Move general logui handler outside of actions. Always respond to logui.

### DIFF
--- a/react-native/react/actions/notifications.js
+++ b/react-native/react/actions/notifications.js
@@ -1,20 +1,17 @@
 /* @flow */
 import engine from '../engine'
 import {NotifyPopup} from '../native/notifications'
-import {logUi} from '../constants/types/keybase_v1'
 import ListenerCreator from '../native/notification-listeners'
 import setNotifications from '../util/setNotifications'
 import * as Constants from '../constants/notifications'
+import {log} from '../native/log/logui'
 
 import type {Dispatch} from '../constants/types/flux'
-import type {Text, LogLevel} from '../constants/types/flow-types'
+import type {Text as KBText, LogLevel} from '../constants/types/flow-types'
 import type {LogAction} from '../constants/notifications'
 
-export function logUiLog ({text, level}: {text: Text, level: LogLevel}): LogAction {
-  console.log('keybase.1.logUi.log:', text.data)
-  if (level >= logUi.LogLevel.error) {
-    NotifyPopup(text.data, {})
-  }
+export function logUiLog ({text, level}: {text: KBText, level: LogLevel}, response: any): LogAction {
+  log({text, level}, response)
   return {type: Constants.log, payload: {text: text.data, level}}
 }
 

--- a/react-native/react/engine/index.js
+++ b/react-native/react/engine/index.js
@@ -9,6 +9,7 @@ const {client: {Client: RpcClient}} = rpc
 import {Buffer} from 'buffer'
 import NativeEventEmitter from '../common-adapters/native-event-emitter'
 import windowsHack from './windows-hack'
+import {log} from '../native/log/logui'
 
 class Engine {
   constructor () {
@@ -174,6 +175,14 @@ class Engine {
     listener(param, wrappedResponse)
   }
 
+  _hasNoHandler(method, callMap, generalIncomingRpcMap) {
+    if (!callMap) {
+      return generalIncomingRpcMap[method] == null
+    }
+
+    return callMap[method] == null
+  }
+
   _rpcIncoming (payload) {
     const {
       method: method,
@@ -189,8 +198,8 @@ class Engine {
       // make wrapper so we only call this once
       const wrappedResponse = this._wrapResponseOnceOnly(method, param, response)
       callMap[method](param, wrappedResponse)
-    } else if (callMap && method === 'keybase.1.logUi.log') {
-      logUiLog(param)
+    } else if (method === 'keybase.1.logUi.log' && this._hasNoHandler(method, callMap || {}, this._generalIncomingRpc)) {
+      log(param, response)
     } else if (!sessionID && this.generalListeners[method]) {
       this._generalIncomingRpc(method, param, response)
     } else if (!sessionID && this.serverListeners[method]) {

--- a/react-native/react/engine/index.js
+++ b/react-native/react/engine/index.js
@@ -199,7 +199,8 @@ class Engine {
       const wrappedResponse = this._wrapResponseOnceOnly(method, param, response)
       callMap[method](param, wrappedResponse)
     } else if (method === 'keybase.1.logUi.log' && this._hasNoHandler(method, callMap || {}, this._generalIncomingRpc)) {
-      log(param, response)
+      log(param)
+      response.result()
     } else if (!sessionID && this.generalListeners[method]) {
       this._generalIncomingRpc(method, param, response)
     } else if (!sessionID && this.serverListeners[method]) {

--- a/react-native/react/native/listen-log-ui.js
+++ b/react-native/react/native/listen-log-ui.js
@@ -7,7 +7,8 @@ import type {Text as KBText, LogLevel} from '../constants/types/flow-types'
 export default function ListenLogUi () {
   engine.listenOnConnect('ListenLogUi', () => {
     engine.listenGeneralIncomingRpc('keybase.1.logUi.log', (params: {text: KBText, level: LogLevel}, response: any) => {
-      log(params, response)
+      log(params)
+      response.result()
     })
     console.log('Registered Listener for logUi.log')
   })

--- a/react-native/react/native/listen-log-ui.js
+++ b/react-native/react/native/listen-log-ui.js
@@ -1,10 +1,13 @@
+/* @flow */
 import engine from '../engine'
-import {logUiLog} from '../actions/notifications'
+import {log} from './log/logui'
+
+import type {Text as KBText, LogLevel} from '../constants/types/flow-types'
 
 export default function ListenLogUi () {
   engine.listenOnConnect('ListenLogUi', () => {
-    engine.listenGeneralIncomingRpc('keybase.1.logUi.log', (params: {text: Text, level: LogLevel}) => {
-      logUiLog(params)
+    engine.listenGeneralIncomingRpc('keybase.1.logUi.log', (params: {text: KBText, level: LogLevel}, response: any) => {
+      log(params, response)
     })
     console.log('Registered Listener for logUi.log')
   })

--- a/react-native/react/native/log/logui.js
+++ b/react-native/react/native/log/logui.js
@@ -4,10 +4,9 @@ import type {Text as KBText, LogLevel} from '../../constants/types/flow-types'
 import {logUi} from '../../constants/types/keybase_v1'
 import {NotifyPopup} from '../../native/notifications'
 
-export function log ({text, level}: {text: KBText, level: LogLevel}, response: any): void {
+export function log ({text, level}: {text: KBText, level: LogLevel}): void {
   console.log('keybase.1.logUi.log:', text.data)
   if (level >= logUi.LogLevel.error) {
     NotifyPopup(text.data, {})
   }
-  response.result()
 }

--- a/react-native/react/native/log/logui.js
+++ b/react-native/react/native/log/logui.js
@@ -1,0 +1,13 @@
+/* @flow */
+
+import type {Text as KBText, LogLevel} from '../../constants/types/flow-types'
+import {logUi} from '../../constants/types/keybase_v1'
+import {NotifyPopup} from '../../native/notifications'
+
+export function log ({text, level}: {text: KBText, level: LogLevel}, response: any): void {
+  console.log('keybase.1.logUi.log:', text.data)
+  if (level >= logUi.LogLevel.error) {
+    NotifyPopup(text.data, {})
+  }
+  response.result()
+}


### PR DESCRIPTION
This prevents a circular dependency with actions <-> engine.
Now we always respond to the logui.

@keybase/react-hackers 

Fixes: https://keybase.atlassian.net/secure/RapidBoard.jspa?rapidView=8&projectKey=DESKTOP&view=detail&selectedIssue=DESKTOP-299
