### PR TITLE
Timeout logui requests and remove external loggers

### DIFF
--- a/react-native/react/native/listen-log-ui.js
+++ b/react-native/react/native/listen-log-ui.js
@@ -3,8 +3,9 @@ import {logUiLog} from '../actions/notifications'
 
 export default function ListenLogUi () {
   engine.listenOnConnect('ListenLogUi', () => {
-    engine.listenGeneralIncomingRpc('keybase.1.logUi.log', (params: {text: Text, level: LogLevel}) => {
+    engine.listenGeneralIncomingRpc('keybase.1.logUi.log', (params: {text: Text, level: LogLevel}, response:any) => {
       logUiLog(params)
+      response.result()
     })
     console.log('Registered Listener for logUi.log')
   })


### PR DESCRIPTION
So we have an issue that any connection to the daemon gets registered as an external log handler and receives logui calls for all daemon log messages.

With the desktop app, there can be multiple connections to the daemon, one for each window.  Only one of the connections handled logui calls, but it never returned a response.  While it looks like there is a fix for all connections to handle logui calls (https://github.com/keybase/client/pull/1756), it does seem wasteful to spam a tracker window with a litany of log messages.

This fix was made to handle the case of a client that does not handle logui calls.  With the current WaitGroup, the daemon is waiting for all external log requests to finish before proceeding.  This code checks for a call timing out.  If it does time out, it is removed as an external logger.  It fixes CORE-2360, but I'm not super happy with it.

A better long term fix would be to have any client that wants log messages to register for them instead of making each connection an external logger.  Only the CLI really needs log forwarding...

So if it is urgent to get a fix in, this will work ok, but I'm fine ditching this and working on a better solution.

r? @maxtaco 

cc @keybase/react-hackers 