### PR TITLE
using merge and not clone deep to fix action isPlainObject issues

### DIFF
--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -60,7 +60,8 @@ class Keybase extends Component {
     ipcMain.on('dispatchAction', (event, action) => {
       // we MUST clone this else we'll run into issues with redux. See https://github.com/rackt/redux/issues/830
       // This is because we get a remote proxy object, instead of a normal object
-      setImmediate(() => store.dispatch(_.cloneDeep(action)))
+      // Using _.cloneDeep() creates a non-plain object
+      setImmediate(() => store.dispatch(_.merge({}, action)))
     })
 
     ipcMain.on('subscribeStore', event => {


### PR DESCRIPTION
@keybase/react-hackers @maxtaco 