### PR TITLE
use a single signing prefix string, instead of a pair

### DIFF
--- a/go/saltpack/common.go
+++ b/go/saltpack/common.go
@@ -9,7 +9,6 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"encoding/binary"
-	"io"
 
 	"github.com/ugorji/go/codec"
 	"golang.org/x/crypto/poly1305"
@@ -44,11 +43,6 @@ func (e encryptionBlockNumber) check() error {
 	return nil
 }
 
-func writeNullTerminatedString(w io.Writer, s string) {
-	w.Write([]byte(s))
-	w.Write([]byte{0})
-}
-
 func assertEndOfStream(stream *msgpackStream) error {
 	var i interface{}
 	_, err := stream.Read(&i)
@@ -65,8 +59,7 @@ func attachedSignatureInput(headerHash []byte, block *SignatureBlock) []byte {
 	hasher.Write(block.PayloadChunk)
 
 	var buf bytes.Buffer
-	writeNullTerminatedString(&buf, SaltpackFormatName)
-	writeNullTerminatedString(&buf, SignatureAttachedString)
+	buf.Write([]byte(SignatureAttachedString))
 	buf.Write(hasher.Sum(nil))
 
 	return buf.Bytes()
@@ -82,8 +75,7 @@ func detachedSignatureInput(headerHash []byte, plaintext []byte) []byte {
 
 func detachedSignatureInputFromHash(plaintextAndHeaderHash []byte) []byte {
 	var buf bytes.Buffer
-	writeNullTerminatedString(&buf, SaltpackFormatName)
-	writeNullTerminatedString(&buf, SignatureDetachedString)
+	buf.Write([]byte(SignatureDetachedString))
 	buf.Write(plaintextAndHeaderHash)
 
 	return buf.Bytes()

--- a/go/saltpack/const.go
+++ b/go/saltpack/const.go
@@ -48,11 +48,11 @@ const SignatureBlockSize int = 1048576
 
 // SignatureAttachedString is part of the data that is signed in
 // each payload packet.
-const SignatureAttachedString = "attached signature"
+const SignatureAttachedString = "saltpack attached signature\x00"
 
 // SignatureDetachedString is part of the data that is signed in
 // a detached signature.
-const SignatureDetachedString = "detached signature"
+const SignatureDetachedString = "saltpack detached signature\x00"
 
 // We truncate HMAC512 to the same link that NaCl's crypto_auth function does.
 const CryptoAuthBytes = 32

--- a/go/saltpack/specs/saltpack_signing.md
+++ b/go/saltpack/specs/saltpack_signing.md
@@ -76,22 +76,14 @@ concatenation of three values:
   the first payload packet is zero
 - the **payload chunk**
 
-The sender then signs the concatenation of three values:
-- `"saltpack\0"`
-- `"attached signature\0"`
+The sender then signs the concatenation of two values:
+- `"saltpack attached signature\0"`
 - the SHA512 hash above
 
 As in the [encryption spec](saltpack_encryption.md), after encrypting the
 entire message, the sender adds an extra payload packet with an empty payload
 to signify the end. If a message doesn't end with an empty payload packet, the
 receiving client should report an error that the message has been truncated.
-
-Some applications might use the saltpack format, but don't want signature
-compatibility with other saltpack applications. In addition to changing the
-format name at the start of the header, these applications should use a
-[different null-terminated context
-string](https://www.ietf.org/mail-archive/web/tls/current/msg14734.html) in
-place of `"saltpack\0"`.
 
 ## Detached Implementation
 
@@ -118,9 +110,8 @@ concatenation of two values::
 - the **header hash** from above
 - the entire plaintext
 
-The sender then signs the concatenation of three values:
-- `"saltpack\0"`
-- `"detached signature\0"`
+The sender then signs the concatenation of two values:
+- `"saltpack detached signature\0"`
 - the SHA512 hash above
 
 ## Examples


### PR DESCRIPTION
Not much reason to have two moving parts in the spec, when one will do.

We used to talk more about what implementations should do if they don't
want decryption/verification compatibility with saltpack. We've already
removed those suggestions from the encryption spec, mainly because it
adds words to the document without meaning anything to most people. Go
ahead and remove them from the signing side too.

@maxtaco 