### PR TITLE
libkb: don't error out on PGP keys that don't import properly

### DIFF
--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -10,7 +10,7 @@
   - Don't error out on bad signatures in the PGP keys themselves
      (vendored PR: keybase/go-crypto#7)
   - Skip keys that don't import properly, rather than killing the whole
-     key family import ()
+     key family import (PR: keybase/client#1766)
 
 ## 1.0.8 (2016-01-13)
 - Do not use current keybase ID as default when generating PGP keys  (PR: keybase/client#1706)

--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Fix `pgp gen` export to gpg error if gpg doesn't exist (PR: keybase/client#1735)
 - Binary mode for all saltpack commands (PR: keybase/client#1727)
 - All config save operations use transactions (PR: keybase/client#1724)
+- More robust key-parsing on KeyFamily import. Fixed two ways:
+  - Don't error out on bad signatures in the PGP keys themselves
+     (vendored PR: keybase/go-crypto#7)
+  - Skip keys that don't import properly, rather than killing the whole
+     key family import ()
 
 ## 1.0.8 (2016-01-13)
 - Do not use current keybase ID as default when generating PGP keys  (PR: keybase/client#1706)

--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -28,6 +28,8 @@ type KeybaseTime struct {
 // Everything here has been checked by the client. Each ComputedKeyInfo
 // refers to exactly one ServerKeyInfo.
 type ComputedKeyInfo struct {
+	Contextified
+
 	Status KeyStatus
 	Eldest bool
 	Sibkey bool
@@ -52,8 +54,6 @@ type ComputedKeyInfo struct {
 	// legacy behavior of combining every instance of this key that we got from
 	// the server minus revocations.
 	ActivePGPHash string
-
-	Contextified
 }
 
 func (cki ComputedKeyInfo) GetCTime() time.Time {
@@ -68,6 +68,8 @@ func (cki ComputedKeyInfo) GetETime() time.Time {
 // store CKIs separately from the keys, since the server can clobber the
 // former.  We should rewrite CKIs every time we (re)check a user's SigChain
 type ComputedKeyInfos struct {
+	Contextified
+
 	dirty bool // whether it needs to be written to disk or not
 
 	// Map of KID to a computed info
@@ -157,9 +159,9 @@ type KeyFamily struct {
 // what the server returned and is not to be trusted; the ComputedKeyInfos
 // is what we compute as a result of playing the user's sigchain forward.
 type ComputedKeyFamily struct {
+	Contextified
 	kf  *KeyFamily
 	cki *ComputedKeyInfos
-	Contextified
 }
 
 // Insert inserts the given ComputedKeyInfo object 1 or 2 times,
@@ -216,8 +218,9 @@ func (cki ComputedKeyInfos) ShallowCopy() *ComputedKeyInfos {
 	return ret
 }
 
-func NewComputedKeyInfos() *ComputedKeyInfos {
+func NewComputedKeyInfos(g *GlobalContext) *ComputedKeyInfos {
 	return &ComputedKeyInfos{
+		Contextified:  NewContextified(g),
 		Infos:         make(map[keybase1.KID]*ComputedKeyInfo),
 		Sigs:          make(map[keybase1.SigID]*ComputedKeyInfo),
 		Devices:       make(map[keybase1.DeviceID]*Device),
@@ -305,11 +308,8 @@ func (ckf ComputedKeyFamily) InsertEldestLink(tcl TypedChainLink, username Norma
 
 // ParseKeyFamily takes as input a dictionary from a JSON file and returns
 // a parsed version for manipulation in the program.
-func ParseKeyFamily(jw *jsonw.Wrapper) (ret *KeyFamily, err error) {
-	G.Log.Debug("+ ParseKeyFamily")
-	defer func() {
-		G.Log.Debug("- ParseKeyFamily -> %s", ErrToOk(err))
-	}()
+func ParseKeyFamily(g *GlobalContext, jw *jsonw.Wrapper) (ret *KeyFamily, err error) {
+	g.Trace("ParseKeyFamily", func() error { return err })()
 
 	if jw == nil || jw.IsNil() {
 		err = KeyFamilyError{"nil record from server"}
@@ -317,9 +317,9 @@ func ParseKeyFamily(jw *jsonw.Wrapper) (ret *KeyFamily, err error) {
 	}
 
 	kf := KeyFamily{
+		Contextified: NewContextified(g),
 		pgp2kid:      make(map[PGPFingerprint]keybase1.KID),
 		kid2pgp:      make(map[keybase1.KID]PGPFingerprint),
-		Contextified: NewContextified(G),
 	}
 
 	// Fill in AllKeys. Somewhat wasteful but probably faster than
@@ -334,10 +334,17 @@ func ParseKeyFamily(jw *jsonw.Wrapper) (ret *KeyFamily, err error) {
 	kf.AllKIDs = make(map[keybase1.KID]bool)
 	kf.PGPKeySets = make(map[keybase1.KID]*PGPKeySet)
 	kf.SingleKeys = make(map[keybase1.KID]GenericKey)
-	for _, bundle := range rkf.AllBundles {
+	for i, bundle := range rkf.AllBundles {
 		newKey, err := ParseGenericKey(bundle)
+
+		// Some users have some historical bad keys, so no reason to crap
+		// out if we can't parse them, especially if there are others than
+		// can do just as well.
 		if err != nil {
-			return nil, err
+			g.Log.Notice("Failed to parse public key at position %d", i)
+			g.Log.Debug("Full key dump follows")
+			g.Log.Debug(bundle)
+			continue
 		}
 
 		kid := newKey.GetKID()
@@ -493,7 +500,7 @@ func (ckf *ComputedKeyFamily) Delegate(tcl TypedChainLink) (err error) {
 // Delegate marks the given ComputedKeyInfos object that the given kid is now
 // delegated, as of time tm, in sigid, as signed by signingKid, etc.
 func (cki *ComputedKeyInfos) Delegate(kid keybase1.KID, tm *KeybaseTime, sigid keybase1.SigID, signingKid, parentKID keybase1.KID, pgpHash string, isSibkey bool, ctime, etime time.Time) (err error) {
-	G.Log.Debug("ComputeKeyInfos::Delegate To %s with %s at sig %s", kid.String(), signingKid, sigid.ToDisplayString(true))
+	cki.G().Log.Debug("ComputeKeyInfos::Delegate To %s with %s at sig %s", kid.String(), signingKid, sigid.ToDisplayString(true))
 	info, found := cki.Infos[kid]
 	if !found {
 		newInfo := NewComputedKeyInfo(false, false, KeyUncancelled, ctime.Unix(), etime.Unix(), pgpHash)
@@ -595,7 +602,7 @@ func (ckf ComputedKeyFamily) FindKeybaseName(s string) bool {
 		}
 		pgp := ckf.kf.PGPKeySets[kid].PermissivelyMergedKey
 		if pgp.FindEmail(kem) {
-			G.Log.Debug("| Found self-sig for %s in key ID: %s", s, kid)
+			ckf.G().Log.Debug("| Found self-sig for %s in key ID: %s", s, kid)
 			return true
 		}
 	}
@@ -707,7 +714,7 @@ func (ckf ComputedKeyFamily) GetActivePGPKeys(sibkey bool) (ret []*PGPKeyBundle)
 			if key, err := ckf.FindKeyWithKIDUnsafe(kid); err == nil {
 				ret = append(ret, key.(*PGPKeyBundle))
 			} else {
-				G.Log.Errorf("KID %s was in a KeyFamily's list of PGP keys, but the key doesn't exist: %s", kid, err)
+				ckf.G().Log.Errorf("KID %s was in a KeyFamily's list of PGP keys, but the key doesn't exist: %s", kid, err)
 			}
 		}
 	}
@@ -717,11 +724,8 @@ func (ckf ComputedKeyFamily) GetActivePGPKeys(sibkey bool) (ret []*PGPKeyBundle)
 // UpdateDevices takes the Device object from the given ChainLink
 // and updates keys to reflects any device changes encoded therein.
 func (ckf *ComputedKeyFamily) UpdateDevices(tcl TypedChainLink) (err error) {
+	ckf.G().Trace("UpdateDevice", func() error { return err })()
 
-	G.Log.Debug("+ UpdateDevice")
-	defer func() {
-		G.Log.Debug("- UpdateDevice -> %s", ErrToOk(err))
-	}()
 	var dobj *Device
 	if dobj = tcl.GetDevice(); dobj == nil {
 		return
@@ -730,16 +734,16 @@ func (ckf *ComputedKeyFamily) UpdateDevices(tcl TypedChainLink) (err error) {
 	did := dobj.ID
 	kid := dobj.Kid
 
-	G.Log.Debug("| Device ID=%s; KID=%s", did, kid.String())
+	ckf.G().Log.Debug("| Device ID=%s; KID=%s", did, kid.String())
 
 	var prevKid keybase1.KID
 	if existing, found := ckf.cki.Devices[did]; found {
-		G.Log.Debug("| merge with existing")
+		ckf.G().Log.Debug("| merge with existing")
 		prevKid = existing.Kid
 		existing.Merge(dobj)
 		dobj = existing
 	} else {
-		G.Log.Debug("| New insert")
+		ckf.G().Log.Debug("| New insert")
 		ckf.cki.Devices[did] = dobj
 	}
 
@@ -747,7 +751,7 @@ func (ckf *ComputedKeyFamily) UpdateDevices(tcl TypedChainLink) (err error) {
 	// We might wind up just clobbering it with the same thing, but
 	// that's fine for now.
 	if prevKid.IsValid() {
-		G.Log.Debug("| Clear out old key")
+		ckf.G().Log.Debug("| Clear out old key")
 		delete(ckf.cki.KIDToDeviceID, prevKid)
 	}
 
@@ -759,21 +763,21 @@ func (ckf *ComputedKeyFamily) UpdateDevices(tcl TypedChainLink) (err error) {
 }
 
 func (ckf *ComputedKeyFamily) getSibkeyKidForDevice(did keybase1.DeviceID) (keybase1.KID, error) {
-	G.Log.Debug("+ getSibkeyKidForDevice(%v)", did)
-	G.Log.Debug("| Devices map: %+v", ckf.cki.Devices)
+	ckf.G().Log.Debug("+ getSibkeyKidForDevice(%v)", did)
+	ckf.G().Log.Debug("| Devices map: %+v", ckf.cki.Devices)
 
 	var kid keybase1.KID
 	device, found := ckf.cki.Devices[did]
 	if !found {
-		G.Log.Debug("device %s not found in cki.Devices", did)
+		ckf.G().Log.Debug("device %s not found in cki.Devices", did)
 		return kid, NoDeviceError{Reason: fmt.Sprintf("for device ID %s", did)}
 	}
 	if !device.Kid.IsValid() {
-		G.Log.Debug("device found, but Kid invalid")
+		ckf.G().Log.Debug("device found, but Kid invalid")
 		return kid, fmt.Errorf("invalid kid for device %s", did)
 	}
 
-	G.Log.Debug("device found, kid: %s", device.Kid.String())
+	ckf.G().Log.Debug("device found, kid: %s", device.Kid.String())
 	return device.Kid, nil
 }
 

--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -309,7 +309,7 @@ func (ckf ComputedKeyFamily) InsertEldestLink(tcl TypedChainLink, username Norma
 // ParseKeyFamily takes as input a dictionary from a JSON file and returns
 // a parsed version for manipulation in the program.
 func ParseKeyFamily(g *GlobalContext, jw *jsonw.Wrapper) (ret *KeyFamily, err error) {
-	g.Trace("ParseKeyFamily", func() error { return err })()
+	defer g.Trace("ParseKeyFamily", func() error { return err })()
 
 	if jw == nil || jw.IsNil() {
 		err = KeyFamilyError{"nil record from server"}
@@ -724,7 +724,7 @@ func (ckf ComputedKeyFamily) GetActivePGPKeys(sibkey bool) (ret []*PGPKeyBundle)
 // UpdateDevices takes the Device object from the given ChainLink
 // and updates keys to reflects any device changes encoded therein.
 func (ckf *ComputedKeyFamily) UpdateDevices(tcl TypedChainLink) (err error) {
-	ckf.G().Trace("UpdateDevice", func() error { return err })()
+	defer ckf.G().Trace("UpdateDevice", func() error { return err })()
 
 	var dobj *Device
 	if dobj = tcl.GetDevice(); dobj == nil {

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -50,7 +50,7 @@ func (sc *SigChain) LocalDelegate(kf *KeyFamily, key GenericKey, sigID keybase1.
 	}
 	if cki == nil {
 		sc.G().Log.Debug("LocalDelegate: creating new cki (signingKid: %s)", signingKid)
-		cki = NewComputedKeyInfos()
+		cki = NewComputedKeyInfos(sc.G())
 		cki.InsertLocalEldestKey(signingKid)
 	}
 
@@ -397,7 +397,7 @@ func (sc *SigChain) verifySubchain(kf KeyFamily, links []*ChainLink) (cached boo
 		return
 	}
 
-	cki = NewComputedKeyInfos()
+	cki = NewComputedKeyInfos(sc.G())
 	ckf := ComputedKeyFamily{kf: &kf, cki: cki, Contextified: sc.Contextified}
 
 	first := true
@@ -500,7 +500,7 @@ func (sc *SigChain) VerifySigsAndComputeKeys(eldest keybase1.KID, ckf *ComputedK
 
 	if ckf.kf == nil || eldest.IsNil() {
 		sc.G().Log.Debug("| VerifyWithKey short-circuit, since no Key available")
-		sc.localCki = NewComputedKeyInfos()
+		sc.localCki = NewComputedKeyInfos(sc.G())
 		ckf.cki = sc.localCki
 		return
 	}
@@ -512,7 +512,7 @@ func (sc *SigChain) VerifySigsAndComputeKeys(eldest keybase1.KID, ckf *ComputedK
 	if links == nil || len(links) == 0 {
 		sc.G().Log.Debug("| Empty chain after we limited to eldest %s", eldest)
 		eldestKey, _ := ckf.FindKeyWithKIDUnsafe(eldest)
-		sc.localCki = NewComputedKeyInfos()
+		sc.localCki = NewComputedKeyInfos(sc.G())
 		err = sc.localCki.InsertServerEldestKey(eldestKey, sc.username)
 		ckf.cki = sc.localCki
 		return

--- a/go/libkb/sig_chain_test.go
+++ b/go/libkb/sig_chain_test.go
@@ -257,7 +257,7 @@ func createKeyFamily(bundles []string) (*KeyFamily, error) {
 	}
 	publicKeys := jsonw.NewDictionary()
 	publicKeys.SetKey("all_bundles", allKeys)
-	return ParseKeyFamily(publicKeys)
+	return ParseKeyFamily(G, publicKeys)
 }
 
 func getCurrentTimeForTest(sigChain SigChain, keyFamily *KeyFamily) time.Time {

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -52,7 +52,7 @@ func NewUser(g *GlobalContext, o *jsonw.Wrapper) (*User, error) {
 		return nil, fmt.Errorf("user object for %s lacks a name", uid)
 	}
 
-	kf, err := ParseKeyFamily(o.AtKey("public_keys"))
+	kf, err := ParseKeyFamily(g, o.AtKey("public_keys"))
 	if err != nil {
 		return nil, err
 	}

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -109,8 +109,8 @@
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp",
-			"revision": "39cc7b45f0f73f46ec8472d841a6a119de13660c",
-			"revisionTime": "2016-01-12T17:43:46-05:00"
+			"revision": "aa981e6b0b1ceae926fb5de5bcae4ecf96053e6f",
+			"revisionTime": "2016-01-18T14:22:47-05:00"
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp/armor",


### PR DESCRIPTION
- Fix two ways:
  - don't error out on failed ParseGenericKey
  - don't error out on ReadKeyRing in OpenPGP (via vendored keybase/go-crypto#7)
- Also contextify more of keyfamily.go