### PR TITLE
Fix installer/updater duplicate process issues

### DIFF
--- a/desktop/app/installer.js
+++ b/desktop/app/installer.js
@@ -32,7 +32,7 @@ export default (callback) => {
     }
 
     var cmd = [installerExec, "--app-path="+appBundlePath, "--run-mode="+runMode].join(" ")
-    exec(cmd, function(execErr, stdout, stderr) {
+    var installerProcess = exec(cmd, function(execErr, stdout, stderr) {
       if (execErr) {
         console.log("Installer (err):", execErr)
         if (execErr.code == 1) {
@@ -48,6 +48,11 @@ export default (callback) => {
       console.log("Installer (stdout):", stdout)
       console.log("Installer (stderr):", stderr)
       callback(null)
+    });
+
+    // Kill the installer process if parent process exits
+    process.on('exit', function () {
+      installerProcess.kill();
     });
   });
 

--- a/go/updater/singleflight.go
+++ b/go/updater/singleflight.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2012 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is a copy of https://github.com/golang/groupcache with a minor change
+// being discussed here: https://github.com/golang/groupcache/issues/61
+// This is temporary!
+
+package updater
+
+import "sync"
+
+// call is an in-flight or completed Do call
+type call struct {
+	wg  sync.WaitGroup
+	val interface{}
+	err error
+}
+
+// Group represents a class of work and forms a namespace in which
+// units of work can be executed with duplicate suppression.
+type Group struct {
+	mu sync.Mutex       // protects m
+	m  map[string]*call // lazily initialized
+}
+
+// Do executes and returns the results of the given function, making
+// sure that only one execution is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
+func (g *Group) Do(key string, fn func() (interface{}, error)) (interface{}, bool, error) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		g.mu.Unlock()
+		c.wg.Wait()
+		return c.val, true, c.err
+	}
+	c := new(call)
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	c.val, c.err = fn()
+	c.wg.Done()
+
+	g.mu.Lock()
+	delete(g.m, key)
+	g.mu.Unlock()
+
+	return c.val, false, c.err
+}


### PR DESCRIPTION
Skip cached updater singleflight result:
    
    We don't want to re-apply the previous singleflighted update.
    Temporarily copying singleflight.go here until we add in behavior to the
    golang package: https://github.com/golang/groupcache/issues/61

And installer process should be killed if parent process exits