### PR TITLE
libkb: use correct convention for revoked last-writer-wins chainlinks

### DIFF
--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -101,6 +101,10 @@ func (g *GenericChainLink) extractPGPFullHash(loc string) string {
 
 func (g *GenericChainLink) DoOwnNewLinkFromServerNotifications(glob *GlobalContext) {}
 
+func CanonicalProofName(t TypedChainLink) string {
+	return strings.ToLower(t.ToDisplayString())
+}
+
 //
 //=========================================================================
 

--- a/go/libkb/remote_proof_links.go
+++ b/go/libkb/remote_proof_links.go
@@ -139,25 +139,20 @@ func AddToProofSetNoChecks(r RemoteProofChainLink, ps *ProofSet) {
 
 func (r *RemoteProofLinks) active() []ProofLinkWithState {
 	var links []ProofLinkWithState
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 	for _, list := range r.links {
 		for i := len(list) - 1; i >= 0; i-- {
 			both := list[i]
 			link := both.link
-			if link.IsRevoked() {
-				continue
+			if !link.IsRevoked() {
+				id := link.ToDisplayString()
+				// We only want to use the last proof in the list
+				// if we have several (like for dns://chriscoyne.com)
+				if _, ok := seen[id]; !ok {
+					links = append(links, both)
+					seen[id] = struct{}{}
+				}
 			}
-
-			// We only want to use the last proof in the list
-			// if we have several (like for dns://chriscoyne.com)
-			id := link.ToDisplayString()
-			if seen[id] {
-				continue
-			}
-
-			links = append(links, both)
-			seen[id] = true
-
 			// Things like Twitter, Github, etc, are last-writer wins.
 			// Things like dns/https can have multiples
 			if link.LastWriterWins() {

--- a/go/libkb/remote_proof_links.go
+++ b/go/libkb/remote_proof_links.go
@@ -140,12 +140,17 @@ func AddToProofSetNoChecks(r RemoteProofChainLink, ps *ProofSet) {
 func (r *RemoteProofLinks) active() []ProofLinkWithState {
 	var links []ProofLinkWithState
 	seen := make(map[string]struct{})
+
+	// Loop over all types of services
 	for _, list := range r.links {
+
+		// Loop over all proofs for that type, from most recent,
+		// to oldest.
 		for i := len(list) - 1; i >= 0; i-- {
 			both := list[i]
 			link := both.link
 			if !link.IsRevoked() {
-				id := link.ToDisplayString()
+				id := CanonicalProofName(link)
 				// We only want to use the last proof in the list
 				// if we have several (like for dns://chriscoyne.com)
 				if _, ok := seen[id]; !ok {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -148,7 +148,10 @@ func (d *Service) Run() (err error) {
 		}
 	}
 
-	// Explicitly set fork type here based on KEYBASE_LABEL
+	// Explicitly set fork type here based on KEYBASE_LABEL.
+	// This is for OSX-based Launchd implementations, which unfortunately
+	// don't obey the same command-line flag conventions as
+	// the other platforms.
 	if len(d.G().Env.GetLabel()) > 0 {
 		d.ForkType = keybase1.ForkType_LAUNCHD
 	}


### PR DESCRIPTION
Before if we had:

   bob@twitter -> alice@twitter -> revoke(alice@twitter)

We'd still check bob@twitter.  I think that's wrong, so fix it with this
commit