### PR TITLE
Log actions and next state for mac and windows. Log into file

### DIFF
--- a/desktop/app/console-helper.js
+++ b/desktop/app/console-helper.js
@@ -1,6 +1,8 @@
 import {ipcMain, ipcRenderer} from 'electron'
 import util from 'util'
 import {forwardLogs} from '../../react-native/react/local-debug'
+import fs from 'fs'
+import {logFileName} from '../../react-native/react/constants/platform.native.desktop.js'
 
 const methods = ['log', 'error', 'info']
 const originalConsole = {}
@@ -8,9 +10,37 @@ methods.forEach(k => {
   originalConsole[k] = console[k]
 })
 
+const logLimit = 5e6
+const logFile = logFileName()
+let fileWritable = null
+// If the file is too big, let's reset the log
+if (logFile) {
+  fs.stat(logFile, (err, stat) => {
+    if (err != null) {
+      fileWritable = fs.createWriteStream(logFile)
+    }
+
+    if (stat.size > logLimit) {
+      fileWritable = fs.createWriteStream(logFile)
+    }
+
+    fileWritable = fs.createWriteStream(logFile, {flags: 'a'})
+  })
+}
+
+function tee (...writeFns) {
+  return t => writeFns.forEach(w => w(t))
+}
+
+const stdErrWriter = t => process.stderr.write(t)
+const stdOutWriter = t => process.stdout.write(t)
+const logFileWriter = t => fileWritable && fileWritable.write(t + '\n')
+
 // override console logging to also go to stdout
 const output = {
-  error: process.stderr
+  error: tee(stdErrWriter, logFileWriter),
+  log: tee(stdOutWriter, logFileWriter),
+  warn: tee(stdOutWriter, logFileWriter)
 }
 
 export default function pipeLogs () {
@@ -22,8 +52,8 @@ export default function pipeLogs () {
     console[k] = (...args) => {
       originalConsole[k].apply(console, args)
       if (args.length) {
-        const out = output[k] || process.stdout
-        out.write(k + ': ' + util.format.apply(util, args))
+        const out = output[k] || (t => process.stdout.write(t))
+        out(k + `: ${Date()} (${Date.now()}): ` + util.format.apply(util, args))
       }
     }
   })

--- a/react-native/react/constants/platform.native.desktop.js
+++ b/react-native/react/constants/platform.native.desktop.js
@@ -50,11 +50,21 @@ function findSocketRoot () {
 }
 
 function findDataRoot () {
-  linuxDefaultRoot = `${getenv('HOME', '')}/.local/share`
+  const linuxDefaultRoot = `${getenv('HOME', '')}/.local/share`
   const paths = {
     'darwin': `${getenv('HOME', '')}/Library/Application Support/${envedPathOSX[runMode]}/`,
     'linux': `${getenv('XDG_DATA_HOME', linuxDefaultRoot)}/${envedPathLinux[runMode]}/`,
     'win32': `${getenv('APPDATA', '')}\\Keybase\\`
+  }
+
+  return paths[process.platform]
+}
+
+export function logFileName () {
+  const paths = {
+    'darwin': `${getenv('HOME', '')}/Library/Logs/${envedPathOSX[runMode]}.app.log`,
+    'linux': null, // linux is null because we can redirect stdout
+    'win32': `${getenv('APPDATA', '')}\\Keybase\\keybase.${runMode}.app.log`
   }
 
   return paths[process.platform]

--- a/react-native/react/local-debug.desktop.js
+++ b/react-native/react/local-debug.desktop.js
@@ -19,7 +19,8 @@ let config = {
   redirectOnLogout: true,
   reduxDevToolsSelect: state => state, // only watch a subset of the store
   enableStoreLogging: false,
-  forwardLogs: false
+  enableActionLogging: true,
+  forwardLogs: true
 }
 
 if (__DEV__ && false) { // eslint-disable-line no-undef
@@ -35,6 +36,7 @@ if (__DEV__ && false) { // eslint-disable-line no-undef
   config.redirectOnLogout = false
   config.reduxDevToolsSelect = state => state.tracker
   config.enableStoreLogging = true
+  config.enableActionLogging = false
   config.forwardLogs = true
 }
 

--- a/react-native/react/store/actionLogger.js
+++ b/react-native/react/store/actionLogger.js
@@ -1,0 +1,27 @@
+import Immutable from 'immutable'
+
+// Transform objects from Immutable on printing
+const objToJS = state => {
+  var newState = {}
+
+  Object.keys(state).forEach(i => {
+    if (Immutable.Iterable.isIterable(state[i])) {
+      newState[i] = state[i].toJS()
+    } else {
+      newState[i] = state[i]
+    }
+  })
+
+  return newState
+}
+
+export const actionLogger = store => next => action => {
+  console.groupCollapsed(`Dispatching action: ${action.type}`)
+
+  console.log(`Dispatching action: ${action.type}: ${JSON.stringify(action)} `)
+  let result = next(action)
+
+  console.log('Next state:', JSON.stringify(objToJS(store.getState())))
+  console.groupEnd()
+  return result
+}

--- a/react-native/react/store/configure-store.js
+++ b/react-native/react/store/configure-store.js
@@ -4,7 +4,8 @@ import thunkMiddleware from 'redux-thunk'
 import createLogger from 'redux-logger'
 import rootReducer from '../reducers'
 import Immutable from 'immutable'
-import {enableStoreLogging} from '../local-debug'
+import {enableStoreLogging, enableActionLogging} from '../local-debug'
+import {actionLogger} from './actionLogger'
 
 // Transform objects from Immutable on printing
 const objToJS = state => {
@@ -31,7 +32,9 @@ const loggerMiddleware = enableStoreLogging ? createLogger({
 
 const createStoreWithMiddleware = enableStoreLogging
   ? applyMiddleware(thunkMiddleware, loggerMiddleware)
-  : applyMiddleware(thunkMiddleware)
+  : (enableActionLogging
+    ? applyMiddleware(thunkMiddleware, actionLogger)
+    : applyMiddleware(thunkMiddleware))
 
 export default function configureStore (initialState: ?any) {
   return configureStoreNative(createStoreWithMiddleware)(rootReducer, initialState)


### PR DESCRIPTION
@keybase/react-hackers 

On linux we can redirect stdout/stderr to a logfile. But we can't do that on mac (afaik). This implements a simple logger that appends to a file, and resets when starting up and the file is > 5mb.

We can do more complex log rotating stuff later.

Also adds a smaller action/state logger that logs the current action and the next state. It outputs this in a single line JSON string so it'll be easy to parse from the logs.