### PR TITLE
handling notify rpcs with wrapped response. adding in some missing response calls

### DIFF
--- a/react-native/react/engine/index.js
+++ b/react-native/react/engine/index.js
@@ -145,7 +145,7 @@ class Engine {
         if (response) {
           response.result(...args)
         } else if (__DEV__){ // eslint-disable-line no-undef
-          console.log('Calling response.result on non-response object: ', method)
+          console.warn('Calling response.result on non-response object: ', method)
         }
       },
       error: (...args) => {
@@ -164,7 +164,7 @@ class Engine {
         if (response) {
           response.error(...args)
         } else if (__DEV__){ // eslint-disable-line no-undef
-          console.log('Calling response.error on non-response object: ', method)
+          console.warn('Calling response.error on non-response object: ', method)
         }
       }
     }

--- a/react-native/react/engine/index.js
+++ b/react-native/react/engine/index.js
@@ -142,7 +142,11 @@ class Engine {
           console.log('RPC ▼ result: ', method, param, ...args)
         }
 
-        response.result(...args)
+        if (response) {
+          response.result(...args)
+        } else if (__DEV__){ // eslint-disable-line no-undef
+          console.log('Calling response.result on non-response object: ', method)
+        }
       },
       error: (...args) => {
         if (once) {
@@ -157,7 +161,11 @@ class Engine {
           console.log('RPC ▼ error: ', method, param, ...args)
         }
 
-        response.error(...args)
+        if (response) {
+          response.error(...args)
+        } else if (__DEV__){ // eslint-disable-line no-undef
+          console.log('Calling response.error on non-response object: ', method)
+        }
       }
     }
     return wrappedResponse

--- a/react-native/react/native/notification-listeners.desktop.js
+++ b/react-native/react/native/notification-listeners.desktop.js
@@ -13,13 +13,15 @@ var sentNotifications = {}
 // TODO(mm) Move these to their own actions
 export default function (dispatch, notify) {
   return {
-    'keybase.1.NotifySession.loggedOut': () => {
+    'keybase.1.NotifySession.loggedOut': (params, response) => {
       notify('Logged out of Keybase')
       dispatch(logoutDone())
+      response.result()
     },
-    'keybase.1.NotifySession.loggedIn': ({username}: {username: string}) => {
+    'keybase.1.NotifySession.loggedIn': ({username}: {username: string}, response) => {
       notify('Logged in to Keybase as: ' + username)
       dispatch(getCurrentStatus())
+      response.result()
     },
     'keybase.1.NotifyFS.FSActivity': params => {
       const notification: FSNotification = params.notification


### PR DESCRIPTION
@keybase/react-hackers 
We can get rpc calls that are of the 'notify' type and not the 'invoke' type. Notify are fire and forget so there is no response object. I added a helper to the response wrapper that'll tell us in __DEV__ if we accidentally call it. I'll make a ticket to investigate generating some flow stuff for all the calls so we can know what params we get and be more safe