### PR TITLE
logger: include year-month-day in log messages

### DIFF
--- a/go/logger/formats_nix.go
+++ b/go/logger/formats_nix.go
@@ -6,8 +6,8 @@
 package logger
 
 const (
-	fancyFormat   = "%{color}%{time:15:04:05.000000} ▶ [%{level:.4s} %{module} %{shortfile}] %{id:03x}%{color:reset} %{message}"
+	fancyFormat   = "%{color}%{time:2006-01-02T15:04:05.000000} ▶ [%{level:.4s} %{module} %{shortfile}] %{id:03x}%{color:reset} %{message}"
 	plainFormat   = "[%{level:.4s}] %{id:03x} %{message}"
-	fileFormat    = "%{time:15:04:05.000000} ▶ [%{level:.4s} %{module} %{shortfile}] %{id:03x} %{message}"
+	fileFormat    = "%{time:2006-01-02T15:04:05.000000} ▶ [%{level:.4s} %{module} %{shortfile}] %{id:03x} %{message}"
 	defaultFormat = "%{color}▶ %{level} %{message}%{color:reset}"
 )


### PR DESCRIPTION
Otherwise the logs are useless for long-running processes.

Issue: CORE-2377