### PR TITLE
Add tool tip for linux, to see something when tray icon is clicked.

### DIFF
--- a/desktop/app/menu-bar.js
+++ b/desktop/app/menu-bar.js
@@ -55,6 +55,10 @@ export default function () {
       event.preventDefault()
     })
 
+    if (process.platform === 'linux') {
+      mb.tray.setToolTip('View Folders')
+    }
+
     mb.on('show', () => {
       menubarListeners.forEach(l => l.send('menubarShow'))
     })


### PR DESCRIPTION
Turns this:
![screen shot 2016-01-21 at 5 24 22 pm](https://cloud.githubusercontent.com/assets/594035/12571218/d0c4412c-c393-11e5-9661-6bc6c7712f1d.png)

into this:
![screen shot 2016-01-25 at 6 45 06 pm](https://cloud.githubusercontent.com/assets/594035/12571215/c6500050-c393-11e5-9704-4525b02cba22.png)
