### PR TITLE
Error strings accidentally used as format strings when logging

### DIFF
--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -55,7 +55,12 @@ func main() {
 		err = e2
 	}
 	if err != nil {
-		g.Log.Error(err.Error())
+		// Note that logger.Error and logger.Errorf are the same, which causes problems
+		// trying to print percent signs, which are used in environment variables
+		// in Windows.
+		// Had to change from Error to Errorf because of go vet because of:
+		// https://github.com/golang/go/issues/6407
+		g.Log.Errorf("%s", err.Error())
 	}
 	if g.ExitCode != keybase1.ExitCode_OK {
 		os.Exit(int(g.ExitCode))

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -7,7 +7,6 @@ package libkb
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"sort"
 
@@ -193,7 +192,7 @@ func ImportStatusAsError(s *keybase1.Status) error {
 	case SCOk:
 		return nil
 	case SCGeneric:
-		return fmt.Errorf(s.Desc)
+		return errors.New(s.Desc)
 	case SCBadLoginPassword:
 		return PassphraseError{s.Desc}
 	case SCKeyBadGen:


### PR DESCRIPTION
This took me a really long time to find.

An example of the yucky output this caused:
`- ERROR exec: "gpg": executable file not found in %!P(MISSING)ATH%!(NOVERB)`

After this change:
`- ERROR exec: "gpg": executable file not found in %PATH%`

@maxtaco @patrickxb 