### PR TITLE
privatize lots of stuff

### DIFF
--- a/go/saltpack/armor.go
+++ b/go/saltpack/armor.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 )
 
-// ArmorParams specify armor formatting, encoding and punctuation.
-type ArmorParams struct {
+// armorParams specify armor formatting, encoding and punctuation.
+type armorParams struct {
 	// BytesPerWord is the number of characters in each "word" of output.
 	// We'll put spaces between words.
 	BytesPerWord int
@@ -33,7 +33,7 @@ type armorEncoderStream struct {
 	encoded io.Writer
 	encoder io.WriteCloser
 	nWords  int
-	params  ArmorParams
+	params  armorParams
 }
 
 func (s *armorEncoderStream) Write(b []byte) (n int, err error) {
@@ -97,7 +97,7 @@ func (s *armorEncoderStream) Close() (err error) {
 //
 // To make the output look pretty, a space is inserted every 15 characters of output,
 // and a newline is inserted every 200 words.
-func NewArmorEncoderStream(encoded io.Writer, header string, footer string, params ArmorParams) (io.WriteCloser, error) {
+func NewArmorEncoderStream(encoded io.Writer, header string, footer string, params armorParams) (io.WriteCloser, error) {
 	ret := &armorEncoderStream{
 		buf:     new(bytes.Buffer),
 		encoded: encoded,
@@ -111,10 +111,10 @@ func NewArmorEncoderStream(encoded io.Writer, header string, footer string, para
 	return ret, nil
 }
 
-// ArmorSeal takes an input plaintext and returns and output armor encoding
+// armorSeal takes an input plaintext and returns and output armor encoding
 // as a string, or an error if a problem was encountered. Also provide a header
 // and a footer to frame the message.
-func ArmorSeal(plaintext []byte, header string, footer string, params ArmorParams) (string, error) {
+func armorSeal(plaintext []byte, header string, footer string, params armorParams) (string, error) {
 	var buf bytes.Buffer
 	enc, err := NewArmorEncoderStream(&buf, header, footer, params)
 	if err != nil {
@@ -150,7 +150,7 @@ type framedDecoderStream struct {
 	header []byte
 	footer []byte
 	state  fdsState
-	params ArmorParams
+	params armorParams
 	r      *punctuatedReader
 }
 
@@ -246,14 +246,14 @@ func (s *framedDecoderStream) GetHeader() (string, error) { return s.toASCII(s.h
 // NewArmorDecoderStream is used to decode armored encoding. It returns a stream you
 // can read from, and also a Frame you can query to see what the open/close
 // frame markers were.
-func NewArmorDecoderStream(r io.Reader, params ArmorParams) (io.Reader, Frame, error) {
+func NewArmorDecoderStream(r io.Reader, params armorParams) (io.Reader, Frame, error) {
 	fds := &framedDecoderStream{r: newPunctuatedReader(r, params.Punctuation), params: params}
 	ret := basex.NewDecoder(params.Encoding, fds)
 	return ret, fds, nil
 }
 
-// ArmorOpen runs armor stream decoding, but on a string, and it outputs a string.
-func ArmorOpen(msg string, params ArmorParams) (body []byte, header string, footer string, err error) {
+// armorOpen runs armor stream decoding, but on a string, and it outputs a string.
+func armorOpen(msg string, params armorParams) (body []byte, header string, footer string, err error) {
 	var dec io.Reader
 	var frame Frame
 	buf := bytes.NewBufferString(msg)

--- a/go/saltpack/armor.go
+++ b/go/saltpack/armor.go
@@ -151,7 +151,7 @@ type framedDecoderStream struct {
 	footer []byte
 	state  fdsState
 	params ArmorParams
-	r      *PunctuatedReader
+	r      *punctuatedReader
 }
 
 // Read from a framedDeecoderStream. The frame is the "BEGIN FOO." block
@@ -247,7 +247,7 @@ func (s *framedDecoderStream) GetHeader() (string, error) { return s.toASCII(s.h
 // can read from, and also a Frame you can query to see what the open/close
 // frame markers were.
 func NewArmorDecoderStream(r io.Reader, params ArmorParams) (io.Reader, Frame, error) {
-	fds := &framedDecoderStream{r: NewPunctuatedReader(r, params.Punctuation), params: params}
+	fds := &framedDecoderStream{r: newPunctuatedReader(r, params.Punctuation), params: params}
 	ret := basex.NewDecoder(params.Encoding, fds)
 	return ret, fds, nil
 }

--- a/go/saltpack/armor.go
+++ b/go/saltpack/armor.go
@@ -89,7 +89,7 @@ func (s *armorEncoderStream) Close() (err error) {
 	return nil
 }
 
-// NewArmorEncoderStream makes a new Armor encoding stream, using the given encoding
+// newArmorEncoderStream makes a new Armor encoding stream, using the given encoding
 // Pass it an `encoded` stream writer to write the
 // encoded stream to.  Also pass a header, and a footer string.  It will
 // return an io.WriteCloser on success, that you can write raw (unencoded) data to.
@@ -97,7 +97,7 @@ func (s *armorEncoderStream) Close() (err error) {
 //
 // To make the output look pretty, a space is inserted every 15 characters of output,
 // and a newline is inserted every 200 words.
-func NewArmorEncoderStream(encoded io.Writer, header string, footer string, params armorParams) (io.WriteCloser, error) {
+func newArmorEncoderStream(encoded io.Writer, header string, footer string, params armorParams) (io.WriteCloser, error) {
 	ret := &armorEncoderStream{
 		buf:     new(bytes.Buffer),
 		encoded: encoded,
@@ -116,7 +116,7 @@ func NewArmorEncoderStream(encoded io.Writer, header string, footer string, para
 // and a footer to frame the message.
 func armorSeal(plaintext []byte, header string, footer string, params armorParams) (string, error) {
 	var buf bytes.Buffer
-	enc, err := NewArmorEncoderStream(&buf, header, footer, params)
+	enc, err := newArmorEncoderStream(&buf, header, footer, params)
 	if err != nil {
 		return "", err
 	}
@@ -243,10 +243,10 @@ func (s *framedDecoderStream) toASCII(buf []byte) (string, error) {
 func (s *framedDecoderStream) GetFooter() (string, error) { return s.toASCII(s.footer) }
 func (s *framedDecoderStream) GetHeader() (string, error) { return s.toASCII(s.header) }
 
-// NewArmorDecoderStream is used to decode armored encoding. It returns a stream you
+// newArmorDecoderStream is used to decode armored encoding. It returns a stream you
 // can read from, and also a Frame you can query to see what the open/close
 // frame markers were.
-func NewArmorDecoderStream(r io.Reader, params armorParams) (io.Reader, Frame, error) {
+func newArmorDecoderStream(r io.Reader, params armorParams) (io.Reader, Frame, error) {
 	fds := &framedDecoderStream{r: newPunctuatedReader(r, params.Punctuation), params: params}
 	ret := basex.NewDecoder(params.Encoding, fds)
 	return ret, fds, nil
@@ -257,7 +257,7 @@ func armorOpen(msg string, params armorParams) (body []byte, header string, foot
 	var dec io.Reader
 	var frame Frame
 	buf := bytes.NewBufferString(msg)
-	dec, frame, err = NewArmorDecoderStream(buf, params)
+	dec, frame, err = newArmorDecoderStream(buf, params)
 	if err != nil {
 		return
 	}

--- a/go/saltpack/armor62.go
+++ b/go/saltpack/armor62.go
@@ -11,7 +11,7 @@ import (
 // Armor62Params are the armoring parameters we recommend for use with
 // a generic armorer.  It specifies the spaces between words, the spacing
 // between lines, some simple punctuation, and an encoding alphabet.
-var Armor62Params = ArmorParams{
+var Armor62Params = armorParams{
 	BytesPerWord: 15,
 	WordsPerLine: 200,
 	Punctuation:  byte('.'),
@@ -38,7 +38,7 @@ func NewArmor62EncoderStream(encoded io.Writer, typ MessageType, brand string) (
 func Armor62Seal(plaintext []byte, typ MessageType, brand string) (string, error) {
 	hdr := makeFrame(headerMarker, typ, brand)
 	ftr := makeFrame(footerMarker, typ, brand)
-	return ArmorSeal(plaintext, hdr, ftr, Armor62Params)
+	return armorSeal(plaintext, hdr, ftr, Armor62Params)
 }
 
 // NewArmor62DecoderStream is used to decode input base62-armoring format. It returns
@@ -51,7 +51,7 @@ func NewArmor62DecoderStream(r io.Reader) (io.Reader, Frame, error) {
 // Armor62Open runs armor stream decoding, but on a string, and it outputs
 // a string.
 func Armor62Open(msg string) (body []byte, header string, footer string, err error) {
-	return ArmorOpen(msg, Armor62Params)
+	return armorOpen(msg, Armor62Params)
 }
 
 // CheckArmor62Frame checks that the frame matches our standard

--- a/go/saltpack/armor62.go
+++ b/go/saltpack/armor62.go
@@ -29,7 +29,7 @@ var Armor62Params = armorParams{
 func NewArmor62EncoderStream(encoded io.Writer, typ MessageType, brand string) (io.WriteCloser, error) {
 	hdr := makeFrame(headerMarker, typ, brand)
 	ftr := makeFrame(footerMarker, typ, brand)
-	return NewArmorEncoderStream(encoded, hdr, ftr, Armor62Params)
+	return newArmorEncoderStream(encoded, hdr, ftr, Armor62Params)
 }
 
 // Armor62Seal takes an input plaintext and returns and output armor encoding
@@ -45,7 +45,7 @@ func Armor62Seal(plaintext []byte, typ MessageType, brand string) (string, error
 // a stream you can read from, and also a Frame you can query to see what the open/close
 // frame markers were.
 func NewArmor62DecoderStream(r io.Reader) (io.Reader, Frame, error) {
-	return NewArmorDecoderStream(r, Armor62Params)
+	return newArmorDecoderStream(r, Armor62Params)
 }
 
 // Armor62Open runs armor stream decoding, but on a string, and it outputs

--- a/go/saltpack/armor62_sign_test.go
+++ b/go/saltpack/armor62_sign_test.go
@@ -24,7 +24,7 @@ func TestSignArmor62(t *testing.T) {
 		t.Fatal(err)
 	}
 	brandCheck(t, brand)
-	if !KIDEqual(skey, key.PublicKey()) {
+	if !kidEqual(skey, key.PublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
 	}
 	if !bytes.Equal(vmsg, msg) {
@@ -48,7 +48,7 @@ func TestSignDetachedArmor62(t *testing.T) {
 		t.Fatal(err)
 	}
 	brandCheck(t, brand)
-	if !KIDEqual(skey, key.PublicKey()) {
+	if !kidEqual(skey, key.PublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
 	}
 }

--- a/go/saltpack/common.go
+++ b/go/saltpack/common.go
@@ -59,7 +59,7 @@ func attachedSignatureInput(headerHash []byte, block *signatureBlock) []byte {
 	hasher.Write(block.PayloadChunk)
 
 	var buf bytes.Buffer
-	buf.Write([]byte(SignatureAttachedString))
+	buf.Write([]byte(signatureAttachedString))
 	buf.Write(hasher.Sum(nil))
 
 	return buf.Bytes()
@@ -75,7 +75,7 @@ func detachedSignatureInput(headerHash []byte, plaintext []byte) []byte {
 
 func detachedSignatureInputFromHash(plaintextAndHeaderHash []byte) []byte {
 	var buf bytes.Buffer
-	buf.Write([]byte(SignatureDetachedString))
+	buf.Write([]byte(signatureDetachedString))
 	buf.Write(plaintextAndHeaderHash)
 
 	return buf.Bytes()
@@ -84,19 +84,19 @@ func detachedSignatureInputFromHash(plaintextAndHeaderHash []byte) []byte {
 func hmacSHA512256(key []byte, input []byte) []byte {
 	// Equivalent to crypto_auth, but using Go's builtin HMAC. Truncates
 	// SHA512, instead of actually calling SHA512/256.
-	if len(key) != CryptoAuthKeyBytes {
+	if len(key) != cryptoAuthKeyBytes {
 		panic("Bad crypto_auth key length")
 	}
 	authenticatorDigest := hmac.New(sha512.New, key)
 	authenticatorDigest.Write(input)
 	fullMAC := authenticatorDigest.Sum(nil)
-	return fullMAC[:CryptoAuthBytes]
+	return fullMAC[:cryptoAuthBytes]
 }
 
 func computeMACKey(secret BoxSecretKey, public BoxPublicKey, headerHash []byte) []byte {
 	nonce := nonceForMACKeyBox(headerHash)
-	macKeyBox := secret.Box(public, nonce, make([]byte, CryptoAuthKeyBytes))
-	macKey := macKeyBox[poly1305.TagSize : poly1305.TagSize+CryptoAuthKeyBytes]
+	macKeyBox := secret.Box(public, nonce, make([]byte, cryptoAuthKeyBytes))
+	macKey := macKeyBox[poly1305.TagSize : poly1305.TagSize+cryptoAuthKeyBytes]
 	return macKey
 }
 

--- a/go/saltpack/common.go
+++ b/go/saltpack/common.go
@@ -52,7 +52,7 @@ func assertEndOfStream(stream *msgpackStream) error {
 	return err
 }
 
-func attachedSignatureInput(headerHash []byte, block *SignatureBlock) []byte {
+func attachedSignatureInput(headerHash []byte, block *signatureBlock) []byte {
 	hasher := sha512.New()
 	hasher.Write(headerHash)
 	binary.Write(hasher, binary.BigEndian, block.seqno)

--- a/go/saltpack/const.go
+++ b/go/saltpack/const.go
@@ -6,11 +6,11 @@ package saltpack
 // MessageType is an int used to describe what "type" of message it is.
 type MessageType int
 
-// PacketSeqno is a special int type used to describe which packet in the
+// packetSeqno is a special int type used to describe which packet in the
 // sequence we're dealing with.  The header is always at seqno=0. Other packets
-// follow. Note that there is a distinction between PacketSeqno and EncryptionBlockNumber.
+// follow. Note that there is a distinction between packetSeqno and EncryptionBlockNumber.
 // In general, the former is one more than the latter.
-type PacketSeqno uint64
+type packetSeqno uint64
 
 // MessageTypeEncryption is a packet type to describe an
 // encryption message.

--- a/go/saltpack/const.go
+++ b/go/saltpack/const.go
@@ -8,7 +8,7 @@ type MessageType int
 
 // packetSeqno is a special int type used to describe which packet in the
 // sequence we're dealing with.  The header is always at seqno=0. Other packets
-// follow. Note that there is a distinction between packetSeqno and EncryptionBlockNumber.
+// follow. Note that there is a distinction between packetSeqno and encryptionBlockNumber.
 // In general, the former is one more than the latter.
 type packetSeqno uint64
 
@@ -28,8 +28,8 @@ const MessageTypeDetachedSignature MessageType = 2
 // version, 1.0.
 var SaltpackCurrentVersion = Version{Major: 1, Minor: 0}
 
-// EncryptionBlockSize is by default 1MB and can't currently be tweaked.
-const EncryptionBlockSize int = 1048576
+// encryptionBlockSize is by default 1MB and can't currently be tweaked.
+const encryptionBlockSize int = 1048576
 
 const EncryptionArmorString = "ENCRYPTED MESSAGE"
 const SignedArmorString = "SIGNED MESSAGE"

--- a/go/saltpack/const.go
+++ b/go/saltpack/const.go
@@ -46,18 +46,18 @@ const NoncePrefixEncryption = "encryption nonce prefix"
 // signatureBlockSize is by default 1MB and can't currently be tweaked.
 const signatureBlockSize int = 1048576
 
-// SignatureAttachedString is part of the data that is signed in
+// signatureAttachedString is part of the data that is signed in
 // each payload packet.
-const SignatureAttachedString = "saltpack attached signature\x00"
+const signatureAttachedString = "saltpack attached signature\x00"
 
-// SignatureDetachedString is part of the data that is signed in
+// signatureDetachedString is part of the data that is signed in
 // a detached signature.
-const SignatureDetachedString = "saltpack detached signature\x00"
+const signatureDetachedString = "saltpack detached signature\x00"
 
 // We truncate HMAC512 to the same link that NaCl's crypto_auth function does.
-const CryptoAuthBytes = 32
+const cryptoAuthBytes = 32
 
-const CryptoAuthKeyBytes = 32
+const cryptoAuthKeyBytes = 32
 
 type readState int
 

--- a/go/saltpack/const.go
+++ b/go/saltpack/const.go
@@ -43,8 +43,8 @@ const SaltpackFormatName = "saltpack"
 // using the nonce for encryption.
 const NoncePrefixEncryption = "encryption nonce prefix"
 
-// SignatureBlockSize is by default 1MB and can't currently be tweaked.
-const SignatureBlockSize int = 1048576
+// signatureBlockSize is by default 1MB and can't currently be tweaked.
+const signatureBlockSize int = 1048576
 
 // SignatureAttachedString is part of the data that is signed in
 // each payload packet.

--- a/go/saltpack/const.go
+++ b/go/saltpack/const.go
@@ -39,10 +39,6 @@ const DetachedSignatureArmorString = "DETACHED SIGNATURE"
 // used in the header of the message and also in Nonce creation.
 const SaltpackFormatName = "saltpack"
 
-// NoncePrefixEncryption is the prefix used to create the nonce when
-// using the nonce for encryption.
-const NoncePrefixEncryption = "encryption nonce prefix"
-
 // signatureBlockSize is by default 1MB and can't currently be tweaked.
 const signatureBlockSize int = 1048576
 

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -103,7 +103,7 @@ func (ds *decryptStream) readHeader(rawReader io.Reader) error {
 	headerHash := sha512.Sum512(headerBytes)
 	ds.headerHash = headerHash[:]
 	// Parse the header bytes.
-	var header EncryptionHeader
+	var header encryptionHeader
 	err = decodeFromBytes(&header, headerBytes)
 	if err != nil {
 		return err
@@ -142,7 +142,7 @@ func (ds *decryptStream) readBlock(b []byte) (n int, lastBlock bool, err error) 
 	return n, false, err
 }
 
-func (ds *decryptStream) tryVisibleReceivers(hdr *EncryptionHeader, ephemeralKey BoxPublicKey) (BoxSecretKey, *SymmetricKey, int, error) {
+func (ds *decryptStream) tryVisibleReceivers(hdr *encryptionHeader, ephemeralKey BoxPublicKey) (BoxSecretKey, *SymmetricKey, int, error) {
 	var kids [][]byte
 	tab := make(map[int]int)
 	for i, r := range hdr.Receivers {
@@ -176,7 +176,7 @@ func (ds *decryptStream) tryVisibleReceivers(hdr *EncryptionHeader, ephemeralKey
 	return sk, payloadKey, orig, err
 }
 
-func (ds *decryptStream) tryHiddenReceivers(hdr *EncryptionHeader, ephemeralKey BoxPublicKey) (BoxSecretKey, *SymmetricKey, int, error) {
+func (ds *decryptStream) tryHiddenReceivers(hdr *encryptionHeader, ephemeralKey BoxPublicKey) (BoxSecretKey, *SymmetricKey, int, error) {
 	secretKeys := ds.ring.GetAllSecretKeys()
 
 	for _, r := range hdr.Receivers {
@@ -207,7 +207,7 @@ func (ds *decryptStream) tryHiddenReceivers(hdr *EncryptionHeader, ephemeralKey 
 	return nil, nil, -1, nil
 }
 
-func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
+func (ds *decryptStream) processEncryptionHeader(hdr *encryptionHeader) error {
 	if err := hdr.validate(); err != nil {
 		return err
 	}

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -119,7 +119,7 @@ func (ds *decryptStream) readHeader(rawReader io.Reader) error {
 
 func (ds *decryptStream) readBlock(b []byte) (n int, lastBlock bool, err error) {
 	var eb EncryptionBlock
-	var seqno PacketSeqno
+	var seqno packetSeqno
 	seqno, err = ds.mps.Read(&eb)
 	if err != nil {
 		return 0, false, err

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -118,7 +118,7 @@ func (ds *decryptStream) readHeader(rawReader io.Reader) error {
 }
 
 func (ds *decryptStream) readBlock(b []byte) (n int, lastBlock bool, err error) {
-	var eb EncryptionBlock
+	var eb encryptionBlock
 	var seqno packetSeqno
 	seqno, err = ds.mps.Read(&eb)
 	if err != nil {
@@ -267,7 +267,7 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 	return nil
 }
 
-func (ds *decryptStream) processEncryptionBlock(bl *EncryptionBlock) ([]byte, error) {
+func (ds *decryptStream) processEncryptionBlock(bl *encryptionBlock) ([]byte, error) {
 
 	blockNum := encryptionBlockNumber(bl.seqno - 1)
 

--- a/go/saltpack/encrypt.go
+++ b/go/saltpack/encrypt.go
@@ -14,7 +14,7 @@ import (
 type encryptStream struct {
 	output     io.Writer
 	encoder    encoder
-	header     *EncryptionHeader
+	header     *encryptionHeader
 	payloadKey SymmetricKey
 	buffer     bytes.Buffer
 	inblock    []byte
@@ -135,7 +135,7 @@ func (es *encryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey) err
 		sender = ephemeralKey
 	}
 
-	eh := &EncryptionHeader{
+	eh := &encryptionHeader{
 		FormatName: SaltpackFormatName,
 		Version:    SaltpackCurrentVersion,
 		Type:       MessageTypeEncryption,

--- a/go/saltpack/encrypt.go
+++ b/go/saltpack/encrypt.go
@@ -38,7 +38,7 @@ func (es *encryptStream) Write(plaintext []byte) (int, error) {
 	if ret, es.err = es.buffer.Write(plaintext); es.err != nil {
 		return 0, es.err
 	}
-	for es.buffer.Len() >= EncryptionBlockSize {
+	for es.buffer.Len() >= encryptionBlockSize {
 		es.err = es.encryptBlock()
 		if es.err != nil {
 			return 0, es.err
@@ -66,7 +66,7 @@ func (es *encryptStream) encryptBytes(b []byte) error {
 	nonce := nonceForChunkSecretBox(es.numBlocks)
 	ciphertext := secretbox.Seal([]byte{}, b, (*[24]byte)(nonce), (*[32]byte)(&es.payloadKey))
 
-	block := EncryptionBlock{
+	block := encryptionBlock{
 		PayloadCiphertext: ciphertext,
 	}
 
@@ -212,7 +212,7 @@ func NewEncryptStream(ciphertext io.Writer, sender BoxSecretKey, receivers []Box
 	es := &encryptStream{
 		output:  ciphertext,
 		encoder: newEncoder(ciphertext),
-		inblock: make([]byte, EncryptionBlockSize),
+		inblock: make([]byte, encryptionBlockSize),
 	}
 	err := es.init(sender, receivers)
 	return es, err

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -821,7 +821,7 @@ func TestCorruptEncryption(t *testing.T) {
 	// First check that a corrupted ciphertext fails the Poly1305
 	ciphertext, err := testSeal(msg, sender, receivers, testEncryptionOptions{
 		blockSize: 1024,
-		corruptEncryptionBlock: func(eb *EncryptionBlock, ebn encryptionBlockNumber) {
+		corruptEncryptionBlock: func(eb *encryptionBlock, ebn encryptionBlockNumber) {
 			if ebn == 2 {
 				eb.PayloadCiphertext[8] ^= 1
 			}
@@ -840,7 +840,7 @@ func TestCorruptEncryption(t *testing.T) {
 	// Next check that a corruption of the Poly1305 tags causes a failure
 	ciphertext, err = testSeal(msg, sender, receivers, testEncryptionOptions{
 		blockSize: 1024,
-		corruptEncryptionBlock: func(eb *EncryptionBlock, ebn encryptionBlockNumber) {
+		corruptEncryptionBlock: func(eb *encryptionBlock, ebn encryptionBlockNumber) {
 			if ebn == 2 {
 				eb.HashAuthenticators[0][2] ^= 1
 			}

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -936,7 +936,7 @@ func TestCorruptHeader(t *testing.T) {
 	// Test bad Header version
 	teo := testEncryptionOptions{
 		blockSize: 1024,
-		corruptHeader: func(eh *EncryptionHeader) {
+		corruptHeader: func(eh *encryptionHeader) {
 			eh.Version.Major = 2
 		},
 	}
@@ -956,7 +956,7 @@ func TestCorruptHeader(t *testing.T) {
 	// Test bad header Tag
 	teo = testEncryptionOptions{
 		blockSize: 1024,
-		corruptHeader: func(eh *EncryptionHeader) {
+		corruptHeader: func(eh *encryptionHeader) {
 			eh.Type = MessageTypeAttachedSignature
 		},
 	}
@@ -1111,7 +1111,7 @@ func TestCorruptEmpheralKey(t *testing.T) {
 	receivers := []BoxPublicKey{newHiddenBoxKey(t).GetPublicKey()}
 	plaintext := randomMsg(t, 1024*3)
 	teo := testEncryptionOptions{
-		corruptHeader: func(eh *EncryptionHeader) {
+		corruptHeader: func(eh *encryptionHeader) {
 			eh.Ephemeral = eh.Ephemeral[0 : len(eh.Ephemeral)-1]
 		},
 	}
@@ -1133,7 +1133,7 @@ func TestCiphertextSwapKeys(t *testing.T) {
 	}
 	plaintext := randomMsg(t, 1024*3)
 	teo := testEncryptionOptions{
-		corruptHeader: func(h *EncryptionHeader) {
+		corruptHeader: func(h *encryptionHeader) {
 			h.Receivers[1].PayloadKeyBox, h.Receivers[0].PayloadKeyBox = h.Receivers[0].PayloadKeyBox, h.Receivers[1].PayloadKeyBox
 		},
 	}

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -334,10 +334,10 @@ func testRealEncryptor(t *testing.T, sz int) {
 	if mki.ReceiverIsAnon {
 		t.Fatal("receiver shouldn't be anon")
 	}
-	if !PublicKeyEqual(sndr.GetPublicKey(), mki.SenderKey) {
+	if !publicKeyEqual(sndr.GetPublicKey(), mki.SenderKey) {
 		t.Fatal("got wrong sender key")
 	}
-	if !PublicKeyEqual(receivers[0], mki.ReceiverKey.GetPublicKey()) {
+	if !publicKeyEqual(receivers[0], mki.ReceiverKey.GetPublicKey()) {
 		t.Fatal("wrong receiver key")
 	}
 	if mki.NumAnonReceivers != 0 {
@@ -1071,7 +1071,7 @@ func TestAllAnonymous(t *testing.T) {
 	if !mki.ReceiverIsAnon {
 		t.Fatal("receiver should be anon")
 	}
-	if !PublicKeyEqual(receivers[5], mki.ReceiverKey.GetPublicKey()) {
+	if !publicKeyEqual(receivers[5], mki.ReceiverKey.GetPublicKey()) {
 		t.Fatal("wrong receiver key")
 	}
 	if mki.NumAnonReceivers != 8 {

--- a/go/saltpack/errors.go
+++ b/go/saltpack/errors.go
@@ -64,11 +64,11 @@ var (
 // ErrBadTag is generated when a payload hash doesn't match the hash
 // authenticator. It specifies which Packet sequence number the bad packet was
 // in.
-type ErrBadTag PacketSeqno
+type ErrBadTag packetSeqno
 
 // ErrBadCiphertext is generated when decryption fails due to improper authentication. It specifies
 // which Packet sequence number the bad packet was in.
-type ErrBadCiphertext PacketSeqno
+type ErrBadCiphertext packetSeqno
 
 // ErrRepeatedKey is produced during encryption if a key is repeated; keys must be
 // unique.

--- a/go/saltpack/key.go
+++ b/go/saltpack/key.go
@@ -132,8 +132,8 @@ type SigKeyring interface {
 	LookupSigningPublicKey(kid []byte) SigningPublicKey
 }
 
-// PublicKeyEqual returns true if the two public keys are equal.
-func PublicKeyEqual(pk1, pk2 BoxPublicKey) bool {
+// publicKeyEqual returns true if the two public keys are equal.
+func publicKeyEqual(pk1, pk2 BoxPublicKey) bool {
 	return KIDEqual(pk1, pk2)
 }
 

--- a/go/saltpack/key.go
+++ b/go/saltpack/key.go
@@ -132,11 +132,6 @@ type SigKeyring interface {
 	LookupSigningPublicKey(kid []byte) SigningPublicKey
 }
 
-// SecretKeyEqual returns true if the two secret keys are equal.
-func SecretKeyEqual(sk1, sk2 BoxSecretKey) bool {
-	return PublicKeyEqual(sk1.GetPublicKey(), sk2.GetPublicKey())
-}
-
 // PublicKeyEqual returns true if the two public keys are equal.
 func PublicKeyEqual(pk1, pk2 BoxPublicKey) bool {
 	return KIDEqual(pk1, pk2)

--- a/go/saltpack/key.go
+++ b/go/saltpack/key.go
@@ -134,10 +134,10 @@ type SigKeyring interface {
 
 // publicKeyEqual returns true if the two public keys are equal.
 func publicKeyEqual(pk1, pk2 BoxPublicKey) bool {
-	return KIDEqual(pk1, pk2)
+	return kidEqual(pk1, pk2)
 }
 
-// KIDEqual return true if the KIDs for two keys are equal.
-func KIDEqual(k1, k2 KIDExtractor) bool {
+// kidEqual return true if the KIDs for two keys are equal.
+func kidEqual(k1, k2 KIDExtractor) bool {
 	return hmac.Equal(k1.ToKID(), k2.ToKID())
 }

--- a/go/saltpack/key.go
+++ b/go/saltpack/key.go
@@ -33,9 +33,9 @@ func symmetricKeyFromSlice(slice []byte) (*SymmetricKey, error) {
 	return &result, nil
 }
 
-// KIDExtractor key types can output a key ID corresponding to the
+// kidExtractor key types can output a key ID corresponding to the
 // key.
-type KIDExtractor interface {
+type kidExtractor interface {
 	// ToKID outputs the "key ID" that corresponds to this key.
 	// You can do whatever you'd like here, but probably it makes sense just
 	// to output the public key as is.
@@ -44,7 +44,7 @@ type KIDExtractor interface {
 
 // BoxPublicKey is an generic interface to NaCl's public key Box function.
 type BoxPublicKey interface {
-	KIDExtractor
+	kidExtractor
 
 	// ToRawBoxKeyPointer returns this public key as a *[32]byte,
 	// for use with nacl.box.Seal
@@ -95,7 +95,7 @@ type SigningSecretKey interface {
 // SigningPublicKey is a public NaCl key that can verify
 // signatures.
 type SigningPublicKey interface {
-	KIDExtractor
+	kidExtractor
 
 	// Verify verifies that signature is a valid signature of message for
 	// this public key.
@@ -138,6 +138,6 @@ func publicKeyEqual(pk1, pk2 BoxPublicKey) bool {
 }
 
 // kidEqual return true if the KIDs for two keys are equal.
-func kidEqual(k1, k2 KIDExtractor) bool {
+func kidEqual(k1, k2 kidExtractor) bool {
 	return hmac.Equal(k1.ToKID(), k2.ToKID())
 }

--- a/go/saltpack/msgpack.go
+++ b/go/saltpack/msgpack.go
@@ -29,14 +29,14 @@ func decodeFromBytes(p interface{}, b []byte) error {
 
 type msgpackStream struct {
 	decoder *codec.Decoder
-	seqno   PacketSeqno
+	seqno   packetSeqno
 }
 
 func newMsgpackStream(r io.Reader) *msgpackStream {
 	return &msgpackStream{decoder: codec.NewDecoder(r, codecHandle())}
 }
 
-func (r *msgpackStream) Read(i interface{}) (ret PacketSeqno, err error) {
+func (r *msgpackStream) Read(i interface{}) (ret packetSeqno, err error) {
 	if err = r.decoder.Decode(i); err != nil {
 		return ret, err
 	}

--- a/go/saltpack/nonce.go
+++ b/go/saltpack/nonce.go
@@ -5,11 +5,11 @@ import (
 	"encoding/binary"
 )
 
-const NonceBytes = 24
+const nonceBytes = 24
 
 // Nonce is a NaCl-style nonce, with 24 bytes of data, some of which can be
 // counter values, and some of which can be random-ish values.
-type Nonce [NonceBytes]byte
+type Nonce [nonceBytes]byte
 
 func nonceForSenderKeySecretBox() *Nonce {
 	var n Nonce
@@ -28,7 +28,7 @@ func nonceForMACKeyBox(headerHash []byte) *Nonce {
 		panic("Header hash shorter than expected.")
 	}
 	var n Nonce
-	copy(n[:], headerHash[:NonceBytes])
+	copy(n[:], headerHash[:nonceBytes])
 	return &n
 }
 

--- a/go/saltpack/nonce.go
+++ b/go/saltpack/nonce.go
@@ -40,14 +40,14 @@ func nonceForChunkSecretBox(i encryptionBlockNumber) *Nonce {
 	return &n
 }
 
-// SigNonce is a nonce for signatures.
-type SigNonce [16]byte
+// sigNonce is a nonce for signatures.
+type sigNonce [16]byte
 
-// NewSigNonce creates a SigNonce with random bytes.
-func NewSigNonce() (SigNonce, error) {
-	var n SigNonce
+// newSigNonce creates a sigNonce with random bytes.
+func newSigNonce() (sigNonce, error) {
+	var n sigNonce
 	if _, err := rand.Read(n[:]); err != nil {
-		return SigNonce{}, err
+		return sigNonce{}, err
 	}
 	return n, nil
 }

--- a/go/saltpack/packets.go
+++ b/go/saltpack/packets.go
@@ -18,10 +18,10 @@ type Version struct {
 	Minor   int  `codec:"minor"`
 }
 
-// EncryptionHeader is the first packet in an encrypted message.
+// encryptionHeader is the first packet in an encrypted message.
 // It contains the encryptions of the session keys, and various
 // message metadata.
-type EncryptionHeader struct {
+type encryptionHeader struct {
 	_struct         bool           `codec:",toarray"`
 	FormatName      string         `codec:"format_name"`
 	Version         Version        `codec:"vers"`
@@ -41,7 +41,7 @@ type encryptionBlock struct {
 	seqno              packetSeqno
 }
 
-func (h *EncryptionHeader) validate() error {
+func (h *encryptionHeader) validate() error {
 	if h.Type != MessageTypeEncryption {
 		return ErrWrongMessageType{MessageTypeEncryption, h.Type}
 	}

--- a/go/saltpack/packets.go
+++ b/go/saltpack/packets.go
@@ -29,7 +29,7 @@ type EncryptionHeader struct {
 	Ephemeral       []byte         `codec:"ephemeral"`
 	SenderSecretbox []byte         `codec:"sendersecretbox"`
 	Receivers       []receiverKeys `codec:"rcvrs"`
-	seqno           PacketSeqno
+	seqno           packetSeqno
 }
 
 // EncryptionBlock contains a block of encrypted data. It contains
@@ -38,7 +38,7 @@ type EncryptionBlock struct {
 	_struct            bool     `codec:",toarray"`
 	HashAuthenticators [][]byte `codec:"authenticators"`
 	PayloadCiphertext  []byte   `codec:"ctext"`
-	seqno              PacketSeqno
+	seqno              packetSeqno
 }
 
 func (h *EncryptionHeader) validate() error {
@@ -104,5 +104,5 @@ type SignatureBlock struct {
 	_struct      bool   `codec:",toarray"`
 	Signature    []byte `codec:"signature"`
 	PayloadChunk []byte `codec:"payload_chunk"`
-	seqno        PacketSeqno
+	seqno        packetSeqno
 }

--- a/go/saltpack/packets.go
+++ b/go/saltpack/packets.go
@@ -65,7 +65,7 @@ func newSignatureHeader(sender SigningPublicKey, msgType MessageType) (*Signatur
 	if sender == nil {
 		return nil, ErrInvalidParameter{message: "no public signing key provided"}
 	}
-	nonce, err := NewSigNonce()
+	nonce, err := newSigNonce()
 	if err != nil {
 		return nil, err
 	}

--- a/go/saltpack/packets.go
+++ b/go/saltpack/packets.go
@@ -99,8 +99,8 @@ func (h *SignatureHeader) validate(msgType MessageType) error {
 	return nil
 }
 
-// SignatureBlock contains a block of signed data.
-type SignatureBlock struct {
+// signatureBlock contains a block of signed data.
+type signatureBlock struct {
 	_struct      bool   `codec:",toarray"`
 	Signature    []byte `codec:"signature"`
 	PayloadChunk []byte `codec:"payload_chunk"`

--- a/go/saltpack/packets.go
+++ b/go/saltpack/packets.go
@@ -32,9 +32,9 @@ type EncryptionHeader struct {
 	seqno           packetSeqno
 }
 
-// EncryptionBlock contains a block of encrypted data. It contains
+// encryptionBlock contains a block of encrypted data. It contains
 // the ciphertext, and any necessary authentication Tags.
-type EncryptionBlock struct {
+type encryptionBlock struct {
 	_struct            bool     `codec:",toarray"`
 	HashAuthenticators [][]byte `codec:"authenticators"`
 	PayloadCiphertext  []byte   `codec:"ctext"`

--- a/go/saltpack/punctuated_reader.go
+++ b/go/saltpack/punctuated_reader.go
@@ -9,11 +9,11 @@ import (
 	"io"
 )
 
-// PunctuatedReader is a stream reader that reads until it hits a usual
+// punctuatedReader is a stream reader that reads until it hits a usual
 // error OR until it hits a punctuation character. In that latter case
 // it returns an `ErrPunctuation` "error" so that way callers can tell
 // the difference between a normal EOF and a "punctuated" EOF.
-type PunctuatedReader struct {
+type punctuatedReader struct {
 	r              io.Reader
 	punctuation    [1]byte
 	nextSegment    []byte
@@ -30,9 +30,9 @@ var ErrPunctuated = errors.New("found punctuation in stream")
 // overflowed before we found the needed character.
 var ErrOverflow = errors.New("buffer was overflowed before we found punctuation")
 
-// Read from the PunctuatedReader, potentially returning an `ErrPunctuation`
+// Read from the punctuatedReader, potentially returning an `ErrPunctuation`
 // if a punctuation character was found.
-func (p *PunctuatedReader) Read(out []byte) (n int, err error) {
+func (p *punctuatedReader) Read(out []byte) (n int, err error) {
 
 	// First deal with the case that we had a "short copy" to our target buffer
 	// in a previous call of the read function.
@@ -100,7 +100,7 @@ func (p *PunctuatedReader) Read(out []byte) (n int, err error) {
 // ReadUntilPunctuation reads from the stream until it find a desired
 // punctuation byte. If it wasn't found before EOF, it will return io.ErrUnexpectedEOF.
 // If it wasn't found before lim bytes are consumed, then it will return ErrOverflow.
-func (p *PunctuatedReader) ReadUntilPunctuation(lim int) (res []byte, err error) {
+func (p *punctuatedReader) ReadUntilPunctuation(lim int) (res []byte, err error) {
 	for {
 		var n int
 		n, err = p.Read(p.buf[:])
@@ -124,10 +124,10 @@ func (p *PunctuatedReader) ReadUntilPunctuation(lim int) (res []byte, err error)
 	}
 }
 
-// NewPunctuatedReader returns a new PunctuatedReader given an underlying
+// newPunctuatedReader returns a new punctuatedReader given an underlying
 // read stream and a punctuation byte.
-func NewPunctuatedReader(r io.Reader, p byte) *PunctuatedReader {
-	ret := &PunctuatedReader{r: r}
+func newPunctuatedReader(r io.Reader, p byte) *punctuatedReader {
+	ret := &punctuatedReader{r: r}
 	ret.punctuation[0] = p
 	return ret
 }

--- a/go/saltpack/punctuated_reader_test.go
+++ b/go/saltpack/punctuated_reader_test.go
@@ -42,7 +42,7 @@ My Muse said to me ‘Fool, look in your heart and write.’
 
 func TestPunctuatedReaderRegularReads(t *testing.T) {
 	buf := bytes.NewBufferString(testText)
-	r := NewPunctuatedReader(buf, '.')
+	r := newPunctuatedReader(buf, '.')
 	for i := 0; i < 6; i++ {
 		_, err := r.ReadUntilPunctuation(1024)
 		if err != nil {
@@ -56,7 +56,7 @@ func TestPunctuatedReaderRegularReads(t *testing.T) {
 }
 
 func TestPunctuatedReaderSlowReads(t *testing.T) {
-	r := NewPunctuatedReader(&slowReader{[]byte(testText)}, '.')
+	r := newPunctuatedReader(&slowReader{[]byte(testText)}, '.')
 	for i := 0; i < 6; i++ {
 		_, err := r.ReadUntilPunctuation(1024)
 		if err != nil {
@@ -70,7 +70,7 @@ func TestPunctuatedReaderSlowReads(t *testing.T) {
 }
 
 func TestPunctuatedReaderSlowReadsOverflow(t *testing.T) {
-	r := NewPunctuatedReader(&slowReader{[]byte(testText)}, '.')
+	r := newPunctuatedReader(&slowReader{[]byte(testText)}, '.')
 	_, err := r.ReadUntilPunctuation(20)
 	if err != ErrOverflow {
 		t.Fatalf("Wrong error; wanted %v but got %v", ErrOverflow, err)

--- a/go/saltpack/sign_stream.go
+++ b/go/saltpack/sign_stream.go
@@ -42,7 +42,7 @@ func newSignAttachedStream(w io.Writer, signer SigningSecretKey) (*signAttachedS
 	stream := &signAttachedStream{
 		headerHash: headerHash,
 		encoder:    newEncoder(w),
-		block:      make([]byte, SignatureBlockSize),
+		block:      make([]byte, signatureBlockSize),
 		secretKey:  signer,
 	}
 
@@ -61,7 +61,7 @@ func (s *signAttachedStream) Write(p []byte) (int, error) {
 		return 0, err
 	}
 
-	for s.buffer.Len() >= SignatureBlockSize {
+	for s.buffer.Len() >= signatureBlockSize {
 		if err := s.signBlock(); err != nil {
 			return 0, err
 		}
@@ -88,7 +88,7 @@ func (s *signAttachedStream) signBlock() error {
 }
 
 func (s *signAttachedStream) signBytes(b []byte) error {
-	block := SignatureBlock{
+	block := signatureBlock{
 		PayloadChunk: b,
 		seqno:        s.seqno,
 	}
@@ -110,7 +110,7 @@ func (s *signAttachedStream) writeFooter() error {
 	return s.signBytes([]byte{})
 }
 
-func (s *signAttachedStream) computeSig(block *SignatureBlock) ([]byte, error) {
+func (s *signAttachedStream) computeSig(block *signatureBlock) ([]byte, error) {
 	return s.secretKey.Sign(attachedSignatureInput(s.headerHash, block))
 }
 

--- a/go/saltpack/sign_stream.go
+++ b/go/saltpack/sign_stream.go
@@ -15,7 +15,7 @@ type signAttachedStream struct {
 	encoder    encoder
 	buffer     bytes.Buffer
 	block      []byte
-	seqno      PacketSeqno
+	seqno      packetSeqno
 	secretKey  SigningSecretKey
 }
 

--- a/go/saltpack/sign_test.go
+++ b/go/saltpack/sign_test.go
@@ -122,7 +122,7 @@ func testSignAndVerify(t *testing.T, message []byte) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !KIDEqual(skey, key.PublicKey()) {
+	if !kidEqual(skey, key.PublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
 	}
 	if !bytes.Equal(vmsg, message) {
@@ -155,7 +155,7 @@ func TestSignEmptyStream(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !KIDEqual(skey, key.PublicKey()) {
+	if !kidEqual(skey, key.PublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
 	}
 	if len(vmsg) != 0 {
@@ -270,7 +270,7 @@ func TestSignDetached(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !KIDEqual(skey, key.PublicKey()) {
+	if !kidEqual(skey, key.PublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
 	}
 }
@@ -427,7 +427,7 @@ func TestSignCorruptHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !KIDEqual(skey, key.PublicKey()) {
+	if !kidEqual(skey, key.PublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
 	}
 	if !bytes.Equal(vmsg, msg) {
@@ -516,7 +516,7 @@ func TestSignDetachedCorruptHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !KIDEqual(skey, key.PublicKey()) {
+	if !kidEqual(skey, key.PublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
 	}
 

--- a/go/saltpack/sign_test.go
+++ b/go/saltpack/sign_test.go
@@ -198,7 +198,7 @@ func TestSignSkipBlock(t *testing.T) {
 	key := newSigPrivKey(t)
 	var opts testSignOptions
 	numBlocks := 10
-	opts.skipBlock = func(n PacketSeqno) bool {
+	opts.skipBlock = func(n packetSeqno) bool {
 		return int(n) == numBlocks-1
 	}
 	smsg, err := testTweakSign(randomMsg(t, numBlocks*1024*1024), key, opts)

--- a/go/saltpack/tweakable_encryptor_test.go
+++ b/go/saltpack/tweakable_encryptor_test.go
@@ -21,7 +21,7 @@ type testEncryptionOptions struct {
 	corruptReceiverKeys         func(rk *receiverKeys, rid int)
 	corruptSenderKeyPlaintext   func(pk *[]byte)
 	corruptSenderKeyCiphertext  func(pk []byte)
-	corruptHeader               func(eh *EncryptionHeader)
+	corruptHeader               func(eh *encryptionHeader)
 	corruptHeaderPacked         func(b []byte)
 }
 
@@ -35,7 +35,7 @@ func (eo testEncryptionOptions) getBlockSize() int {
 type testEncryptStream struct {
 	output     io.Writer
 	encoder    encoder
-	header     *EncryptionHeader
+	header     *encryptionHeader
 	payloadKey SymmetricKey
 	buffer     bytes.Buffer
 	inblock    []byte
@@ -134,7 +134,7 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey
 		sender = ephemeralKey
 	}
 
-	eh := &EncryptionHeader{
+	eh := &encryptionHeader{
 		FormatName: SaltpackFormatName,
 		Version:    SaltpackCurrentVersion,
 		Type:       MessageTypeEncryption,

--- a/go/saltpack/tweakable_encryptor_test.go
+++ b/go/saltpack/tweakable_encryptor_test.go
@@ -13,7 +13,7 @@ import (
 type testEncryptionOptions struct {
 	blockSize                   int
 	skipFooter                  bool
-	corruptEncryptionBlock      func(bl *EncryptionBlock, ebn encryptionBlockNumber)
+	corruptEncryptionBlock      func(bl *encryptionBlock, ebn encryptionBlockNumber)
 	corruptCiphertextBeforeHash func(c []byte, ebn encryptionBlockNumber)
 	corruptPayloadNonce         func(n *Nonce, ebn encryptionBlockNumber) *Nonce
 	corruptKeysNonce            func(n *Nonce, rid int) *Nonce
@@ -27,7 +27,7 @@ type testEncryptionOptions struct {
 
 func (eo testEncryptionOptions) getBlockSize() int {
 	if eo.blockSize == 0 {
-		return EncryptionBlockSize
+		return encryptionBlockSize
 	}
 	return eo.blockSize
 }
@@ -97,7 +97,7 @@ func (pes *testEncryptStream) encryptBytes(b []byte) error {
 		pes.options.corruptCiphertextBeforeHash(ciphertext, pes.numBlocks)
 	}
 
-	block := EncryptionBlock{
+	block := encryptionBlock{
 		PayloadCiphertext: ciphertext,
 	}
 

--- a/go/saltpack/tweakable_signer_test.go
+++ b/go/saltpack/tweakable_signer_test.go
@@ -12,7 +12,7 @@ type testSignOptions struct {
 	corruptHeader      func(sh *SignatureHeader)
 	corruptHeaderBytes func(bytes *[]byte)
 	swapBlock          bool
-	skipBlock          func(blockNum PacketSeqno) bool
+	skipBlock          func(blockNum packetSeqno) bool
 	skipFooter         bool
 }
 
@@ -21,7 +21,7 @@ type testSignStream struct {
 	encoder    encoder
 	buffer     bytes.Buffer
 	block      []byte
-	seqno      PacketSeqno
+	seqno      packetSeqno
 	secretKey  SigningSecretKey
 	options    testSignOptions
 	savedBlock *SignatureBlock

--- a/go/saltpack/tweakable_signer_test.go
+++ b/go/saltpack/tweakable_signer_test.go
@@ -24,7 +24,7 @@ type testSignStream struct {
 	seqno      packetSeqno
 	secretKey  SigningSecretKey
 	options    testSignOptions
-	savedBlock *SignatureBlock
+	savedBlock *signatureBlock
 }
 
 func newTestSignStream(w io.Writer, signer SigningSecretKey, opts testSignOptions) (*testSignStream, error) {
@@ -55,7 +55,7 @@ func newTestSignStream(w io.Writer, signer SigningSecretKey, opts testSignOption
 	stream := &testSignStream{
 		headerHash: headerHash,
 		encoder:    newEncoder(w),
-		block:      make([]byte, SignatureBlockSize),
+		block:      make([]byte, signatureBlockSize),
 		secretKey:  signer,
 		options:    opts,
 	}
@@ -75,7 +75,7 @@ func (s *testSignStream) Write(p []byte) (int, error) {
 		return 0, err
 	}
 
-	for s.buffer.Len() >= SignatureBlockSize {
+	for s.buffer.Len() >= signatureBlockSize {
 		if err := s.signBlock(); err != nil {
 			return 0, err
 		}
@@ -107,7 +107,7 @@ func (s *testSignStream) signBlock() error {
 }
 
 func (s *testSignStream) signBytes(b []byte) error {
-	block := SignatureBlock{
+	block := signatureBlock{
 		PayloadChunk: b,
 		seqno:        s.seqno,
 	}
@@ -149,7 +149,7 @@ func (s *testSignStream) writeFooter() error {
 	return s.signBytes([]byte{})
 }
 
-func (s *testSignStream) computeSig(block *SignatureBlock) ([]byte, error) {
+func (s *testSignStream) computeSig(block *signatureBlock) ([]byte, error) {
 	return s.secretKey.Sign(attachedSignatureInput(s.headerHash, block))
 }
 

--- a/go/saltpack/verify_stream.go
+++ b/go/saltpack/verify_stream.go
@@ -88,7 +88,7 @@ func (v *verifyStream) readHeader(msgType MessageType) error {
 }
 
 func (v *verifyStream) readBlock(p []byte) (int, bool, error) {
-	var block SignatureBlock
+	var block signatureBlock
 	_, err := v.stream.Read(&block)
 	if err != nil {
 		return 0, false, err
@@ -110,7 +110,7 @@ func (v *verifyStream) readBlock(p []byte) (int, bool, error) {
 	return n, false, err
 }
 
-func (v *verifyStream) processBlock(block *SignatureBlock) ([]byte, error) {
+func (v *verifyStream) processBlock(block *signatureBlock) ([]byte, error) {
 	if err := v.publicKey.Verify(attachedSignatureInput(v.headerHash, block), block.Signature); err != nil {
 		return nil, err
 	}

--- a/go/saltpack/verify_stream.go
+++ b/go/saltpack/verify_stream.go
@@ -14,7 +14,7 @@ type verifyStream struct {
 	header     *SignatureHeader
 	headerHash []byte
 	publicKey  SigningPublicKey
-	seqno      PacketSeqno
+	seqno      packetSeqno
 }
 
 func newVerifyStream(r io.Reader, msgType MessageType) (*verifyStream, error) {

--- a/go/saltpack/verify_test.go
+++ b/go/saltpack/verify_test.go
@@ -22,7 +22,7 @@ func TestVerify(t *testing.T) {
 		t.Logf("signed msg: %x", smsg)
 		t.Fatal(err)
 	}
-	if !KIDEqual(skey, key.PublicKey()) {
+	if !kidEqual(skey, key.PublicKey()) {
 		t.Errorf("sender key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
 	}
 	if !bytes.Equal(msg, in) {
@@ -48,7 +48,7 @@ func TestVerifyConcurrent(t *testing.T) {
 				t.Logf("signed msg: %x", smsg)
 				t.Error(err)
 			}
-			if !KIDEqual(skey, key.PublicKey()) {
+			if !kidEqual(skey, key.PublicKey()) {
 				t.Errorf("sender key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
 			}
 			if !bytes.Equal(msg, in) {


### PR DESCRIPTION
The goal here is to reduce the amount of noise in https://godoc.org/github.com/keybase/client/go/saltpack.

I think I caught most of the functions that we don't actually use in libkb. @maxtaco I'd like to sit down with you for 5 minutes tomorrow and think about how we'd like this to look in a perfect world. For example, interfaces like `SigKeyring` make it easy for us to adapt our own libkb code, but 3rd party callers might prefer to just give us a list of keys.