### PR TITLE
Fix resize issue in pinentry on linux.

### DIFF
--- a/react-native/react/more/component-sheet.render.desktop.js
+++ b/react-native/react/more/component-sheet.render.desktop.js
@@ -2,11 +2,14 @@ import React, {Component} from '../base-react'
 import {FlatButton} from 'material-ui'
 import {connect} from '../base-redux'
 import commonStyles from '../styles/common'
-import {Header} from '../common-adapters'
+import {Header, Button} from '../common-adapters'
 import Tracker from '../tracker'
 import Menubar from '../menubar'
 import Container from './dev-container'
 import Update from '../update/index.js'
+
+// $FlowIssue platform files
+import RemoteComponent from '../native/remote-component'
 
 import {devEditAction} from '../reducers/devEdit'
 
@@ -45,6 +48,9 @@ export default class Render extends Component {
         <Container title='Tracker'>
           <ConnectedTrackerDev/>
         </Container>
+        <Container title='Popup'>
+          <PopupDemo/>
+        </Container>
         <Container title='Header No Close'>
           <Header icon title='Title'/>
         </Container>
@@ -55,6 +61,64 @@ export default class Render extends Component {
   )
   }
 }
+class PopupDemo_ extends Component {
+  componentWillMount () {
+    const demoState = {
+      closed: true,
+      sessionID: -1,
+      features: {},
+      prompt: 'Demo Pinentry',
+      windowTitle: 'demo window title',
+      canceled: false,
+      submitted: false,
+      submitLabel: 'submit',
+      cancelLabel: 'cancel',
+      retryLabel: 'retry'
+    }
+
+    const trackerDemoState = {
+      serverActive: true,
+      trackerState: 'metaNew',
+      trackerMessage: 'stuff',
+      username: 'Demo',
+      shouldFollow: false,
+      reason: 'Reason here',
+      userInfo: {
+        fullname: 'sir demo',
+        followersCount: 1337,
+        followingCount: 1337,
+        followsYou: false,
+        avatar: null,
+        location: 'Planet Earth'
+      },
+      proofs: [],
+      closed: true,
+      hidden: false,
+      trackToken: null,
+      lastTrack: null
+    }
+
+    this.props.dispatch(devEditAction(['pinentry', 'pinentryStates', -1], demoState))
+    this.props.dispatch(devEditAction(['tracker', 'trackers', '::demo'], trackerDemoState))
+  }
+
+  render () {
+    const togglePinentry = () => {
+      this.props.dispatch(devEditAction(['pinentry', 'pinentryStates', -1, 'closed'], false))
+    }
+    const toggleTracker = () => {
+      this.props.dispatch(devEditAction(['tracker', 'trackers', '::demo', 'closed'], false))
+    }
+    return (
+      <div>
+      <Header title='Pinentry'/>
+        <Button label='toggle popup pinentry' onClick={togglePinentry} />
+        <Button label='toggle popup tracker' onClick={toggleTracker} />
+      </div>
+    )
+  }
+}
+const PopupDemo = connect(state => ({}), dispatch => ({dispatch}))(PopupDemo_)
 
 class TrackerDev extends Component {
   constructor (props) {

--- a/react-native/react/native/remote-component-helper.js
+++ b/react-native/react/native/remote-component-helper.js
@@ -9,9 +9,15 @@ export function autoResize () {
     try {
       const element = window.document.getElementById('remoteComponent')
       const browserWindow = remote.getCurrentWindow()
-      // Height of remote component + offset from parent + top/bottom border
-      browserWindow.setSize(browserWindow.getSize()[0], element.scrollHeight + 2 * element.offsetTop + 2 * globalStyles.windowBorder.borderWidth)
-    } catch (i) {
+      if (element && (element.scrollHeight != null) && (element.offsetTop != null) && !browserWindow.isDestroyed()) {
+        // Height of remote component + offset from parent + top/bottom border
+        const originalResizableState = browserWindow.isResizable()
+        browserWindow.setResizable(true)
+        browserWindow.setSize(browserWindow.getSize()[0], element.scrollHeight + 2 * element.offsetTop + 2 * globalStyles.windowBorder.borderWidth)
+        browserWindow.setResizable(originalResizableState)
+      }
+    } catch (e) {
+      console.error('error in resizing frame', e)
     }
   }, 1)
 }

--- a/react-native/react/reducers/pinentry.js
+++ b/react-native/react/reducers/pinentry.js
@@ -68,6 +68,7 @@ export default function (state: RootPinentryState = initialState, action: Pinent
         return {
           ...state,
           pinentryStates: {
+            ...state.pinentryStates,
             [sessionID]: newPinentryState
           }
         }
@@ -78,6 +79,7 @@ export default function (state: RootPinentryState = initialState, action: Pinent
         return {
           ...state,
           pinentryStates: {
+            ...state.pinentryStates,
             [sessionID]: updatePinentryState(state.pinentryStates[sessionID] || {}, action)
           }
         }


### PR DESCRIPTION
The problem came from the autoResize fn.
Apparently when you programatically resize a window when it's set as non
resizable it unsets the unresizable attribute on the window, and the
user can resize. Fix is to enable resize, programatically resize, then
set resize to the original state.

@keybase/react-hackers 

Fixes https://keybase.atlassian.net/browse/DESKTOP-351