### PR TITLE
service: new RPC: identify.Resolve2

### DIFF
--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -160,7 +160,7 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 	// Match the returned User object to the Merkle tree. Also make sure
 	// that the username queried for matches the User returned (if it
 	// was indeed queried for)
-	if err = ret.leaf.MatchUser(ret, arg.UID, rres.kbUsername); err != nil {
+	if err = ret.leaf.MatchUser(ret, arg.UID, rres.GetNormalizedQueriedUsername()); err != nil {
 		return
 	}
 

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -742,13 +742,13 @@ func (mc *MerkleClient) LastRootToSigJSON() (ret *jsonw.Wrapper, err error) {
 	return
 }
 
-func (mul *MerkleUserLeaf) MatchUser(u *User, uid keybase1.UID, un string) (err error) {
+func (mul *MerkleUserLeaf) MatchUser(u *User, uid keybase1.UID, nun NormalizedUsername) (err error) {
 	if mul.username != u.GetName() {
 		err = MerkleClashError{fmt.Sprintf("vs loaded object: username %s != %s", mul.username, u.GetName())}
 	} else if mul.uid.NotEqual(u.GetUID()) {
 		err = MerkleClientError{fmt.Sprintf("vs loaded object: UID %s != %s", mul.uid, u.GetUID())}
-	} else if len(un) > 0 && mul.username != un {
-		err = MerkleClashError{fmt.Sprintf("vs given arg: username %s != %s", mul.username, un)}
+	} else if !nun.IsNil() && !NewNormalizedUsername(mul.username).Eq(nun) {
+		err = MerkleClashError{fmt.Sprintf("vs given arg: username %s != %s", mul.username, nun)}
 	} else if uid.NotEqual(mul.uid) {
 		err = MerkleClashError{fmt.Sprintf("vs given arg: UID %s != %s", uid, mul.uid)}
 	}

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -1746,6 +1746,10 @@ type ResolveArg struct {
 	Assertion string `codec:"assertion" json:"assertion"`
 }
 
+type Resolve2Arg struct {
+	Assertion string `codec:"assertion" json:"assertion"`
+}
+
 type IdentifyArg struct {
 	SessionID        int            `codec:"sessionID" json:"sessionID"`
 	UserAssertion    string         `codec:"userAssertion" json:"userAssertion"`
@@ -1770,6 +1774,7 @@ type Identify2Arg struct {
 
 type IdentifyInterface interface {
 	Resolve(context.Context, string) (UID, error)
+	Resolve2(context.Context, string) (User, error)
 	Identify(context.Context, IdentifyArg) (IdentifyRes, error)
 	Identify2(context.Context, Identify2Arg) (Identify2Res, error)
 }
@@ -1790,6 +1795,22 @@ func IdentifyProtocol(i IdentifyInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.Resolve(ctx, (*typedArgs)[0].Assertion)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"Resolve2": {
+				MakeArg: func() interface{} {
+					ret := make([]Resolve2Arg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]Resolve2Arg)
+					if !ok {
+						err = rpc.NewTypeError((*[]Resolve2Arg)(nil), args)
+						return
+					}
+					ret, err = i.Resolve2(ctx, (*typedArgs)[0].Assertion)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -1837,6 +1858,12 @@ type IdentifyClient struct {
 func (c IdentifyClient) Resolve(ctx context.Context, assertion string) (res UID, err error) {
 	__arg := ResolveArg{Assertion: assertion}
 	err = c.Cli.Call(ctx, "keybase.1.identify.Resolve", []interface{}{__arg}, &res)
+	return
+}
+
+func (c IdentifyClient) Resolve2(ctx context.Context, assertion string) (res User, err error) {
+	__arg := Resolve2Arg{Assertion: assertion}
+	err = c.Cli.Call(ctx, "keybase.1.identify.Resolve2", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -67,6 +67,15 @@ func (h *IdentifyHandler) Resolve(_ context.Context, arg string) (keybase1.UID, 
 	return rres.GetUID(), rres.GetError()
 }
 
+func (h *IdentifyHandler) Resolve2(_ context.Context, arg string) (u keybase1.User, err error) {
+	rres := h.G().Resolver.ResolveFullExpression(arg)
+	err = rres.GetError()
+	if err == nil {
+		u.Uid, u.Username = rres.GetUID(), rres.GetNormalizedUsername().String()
+	}
+	return u, err
+}
+
 func (h *IdentifyHandler) Identify(_ context.Context, arg keybase1.IdentifyArg) (keybase1.IdentifyRes, error) {
 	var do = func() (interface{}, error) {
 		if arg.Source == keybase1.ClientType_KBFS {

--- a/go/systests/rpc_test.go
+++ b/go/systests/rpc_test.go
@@ -1,0 +1,73 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package systests
+
+// Test various RPCs that are used mainly in other clients but not by the CLI.
+
+import (
+	"github.com/keybase/client/go/client"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
+	"github.com/keybase/client/go/service"
+	context "golang.org/x/net/context"
+	"testing"
+)
+
+func TestRPCs(t *testing.T) {
+	tc := setupTest(t, "resolve2")
+	tc2 := cloneContext(tc)
+
+	libkb.G.LocalDb = nil
+
+	defer tc.Cleanup()
+
+	stopCh := make(chan error)
+	svc := service.NewService(tc.G, false)
+	startCh := svc.GetStartChannel()
+	go func() {
+		err := svc.Run()
+		if err != nil {
+			t.Logf("Running the service produced an error: %v", err)
+		}
+		stopCh <- err
+	}()
+
+	stopper := client.NewCmdCtlStopRunner(tc2.G)
+
+	<-startCh
+
+	// Add test RPC methods here.
+	testIdentifyResolve2(t, tc2.G)
+
+	if err := stopper.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	// If the server failed, it's also an error
+	if err := <-stopCh; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testIdentifyResolve2(t *testing.T, g *libkb.GlobalContext) {
+
+	cli, err := client.GetIdentifyClient(g)
+	if err != nil {
+		t.Fatalf("failed to get new identifyclient: %v", err)
+	}
+
+	if res, err := cli.Resolve2(context.TODO(), "t_tracy@rooter"); err != nil {
+		t.Fatalf("Resolve2 failed: %v\n", err)
+	} else if res.Username != "t_tracy" {
+		t.Fatalf("Wrong name: %s != 't_tracy", res.Username)
+	} else if !res.Uid.Equal(keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")) {
+		t.Fatalf("Wrong uid for tracy: %s\n", res.Uid)
+	}
+
+	if _, err := cli.Resolve2(context.TODO(), "foobag@rooter"); err == nil {
+		t.Fatalf("expected an error on a bad resolve, but got none")
+	} else if _, ok := err.(libkb.ResolutionError); !ok {
+		t.Fatalf("Wrong error: wanted type %T but got (%v, %T)", libkb.ResolutionError{}, err, err)
+	}
+}

--- a/protocol/avdl/identify.avdl
+++ b/protocol/avdl/identify.avdl
@@ -12,6 +12,11 @@ protocol identify {
   UID Resolve(string assertion);
 
   /**
+    Resolve an assertion to a (UID,username). On failure, returns an error.
+   */
+  User Resolve2(string assertion);
+
+  /**
     Identify a user from a username or assertion (e.g. kbuser, twuser@twitter).
     If trackStatement is true, we'll return a generated JSON tracking statement.
     If forceRemoteCheck is true, we force all remote proofs to be checked (otherwise a cache is used).

--- a/protocol/json/identify.json
+++ b/protocol/json/identify.json
@@ -405,6 +405,14 @@
       } ],
       "response" : "UID"
     },
+    "Resolve2" : {
+      "doc" : "Resolve an assertion to a (UID,username). On failure, returns an error.",
+      "request" : [ {
+        "name" : "assertion",
+        "type" : "string"
+      } ],
+      "response" : "User"
+    },
     "identify" : {
       "doc" : "Identify a user from a username or assertion (e.g. kbuser, twuser@twitter).\n    If trackStatement is true, we'll return a generated JSON tracking statement.\n    If forceRemoteCheck is true, we force all remote proofs to be checked (otherwise a cache is used).",
       "request" : [ {


### PR DESCRIPTION
KBFS needs an RPC that resolves from social assertion to <UID, username> pair.
Add a new RPC rather than breaking the old AVDL protocol for Resolve()