### PR TITLE
specify that whitespace should be stripped before checking the header

### DIFF
--- a/go/saltpack/specs/saltpack_armor.md
+++ b/go/saltpack/specs/saltpack_armor.md
@@ -257,23 +257,22 @@ ipsum](https://twitter.com/oconnor663/status/680171387353448448).
 
 Before getting to the BaseX payload, the decoder parses the header and footer:
 
-1. Collect input up to the first period, stripping any leading whitespace and
-   `>` characters (for compatibility with email clients that use `>` for
-   quoting). This is the header.
-2. Assert that the header matches
+1. Strip all whitespace and `>` characters from the message. (`>` is for
+   compatibility with email clients that use it for quoting.)
+2. Collect input up to the first period. This is the header.
+3. Assert that the header (with its whitespace stripped in step 1) matches
 
    ```
-   BEGIN ([a-zA-Z0-9]+ )?SALTPACK (ENCRYPTED MESSAGE)|(SIGNED MESSAGE)|(DETACHED SIGNATURE)
+   BEGIN([a-zA-Z0-9]+ )?SALTPACK(ENCRYPTEDMESSAGE)|(SIGNEDMESSAGE)|(DETACHEDSIGNATURE)
    ```
 
    The optional word is for an application name (like `KEYBASE`). The last two
    words give the mode of the message.
-3. Collect input up to the second period, stripping all whitespace and `>`
-   characters. This is the payload. If the implementation is streaming, it may
-   decode the payload before the following steps.
-4. Collect input up to the third period, stripping any leading whitespace and
-   `>` characters. This is the footer.
-5. Assert that the footer matches the header, with `END` instead of `BEGIN`.
+4. Collect input up to the second period. This is the payload. If the
+   implementation is streaming, it may decode the payload before the following
+   steps.
+5. Collect input up to the third period. This is the footer.
+6. Assert that the footer matches the header, with `END` instead of `BEGIN`.
 
 We use periods to delimit the header and footer to make parsing easier.
 Although we've been careful to avoid special characters in the payload, we're


### PR DESCRIPTION
@maxtaco small change to how we spec verifying armor headers and
footers, that occurred to me while I was reviewing saltpack.org.

Now that we have inline headers and footers, it's possible that an
application that inserts newlines in our messages will put one right in
the middle of the footer. (The same might've been a problem even before
inline headers, e.g. for very small column widths.) If we require that
words in the header and footer are separated by exactly one space, we're
going to break on this case.

The simplest fix seems to be stripping whitespace first, and then
matching against an expression that has no spaces. I don't think there's
any rush to change our implementation, since this is unlikely to come up
in practice, but it would be nice to spec the right thing.