### PR TITLE
client: better U/X for changed eldest key

### DIFF
--- a/go/libkb/identify_state.go
+++ b/go/libkb/identify_state.go
@@ -3,7 +3,9 @@
 
 package libkb
 
-import keybase1 "github.com/keybase/client/go/protocol"
+import (
+	keybase1 "github.com/keybase/client/go/protocol"
+)
 
 type IdentifyState struct {
 	res   *IdentifyOutcome
@@ -103,8 +105,9 @@ func (s *IdentifyState) computeKeyDiffs(dhook func(keybase1.IdentifyKey)) {
 			TrackDiff: ExportTrackDiff(diff),
 		}
 		k.KID = kid
-		fp := s.u.GetKeyFamily().kid2pgp[kid]
-		k.PGPFingerprint = fp[:]
+		if fp, ok := s.u.GetKeyFamily().kid2pgp[kid]; ok {
+			k.PGPFingerprint = fp[:]
+		}
 		dhook(k)
 	}
 

--- a/go/libkb/track.go
+++ b/go/libkb/track.go
@@ -324,7 +324,7 @@ func (t TrackDiffNewEldest) GetTrackDiffType() keybase1.TrackDiffType {
 	return keybase1.TrackDiffType_NEW_ELDEST
 }
 func (t TrackDiffNewEldest) ToDisplayString() string {
-	return fmt.Sprintf("Eldest key changed from %s to %s", t.tracked, t.observed)
+	return fmt.Sprintf("Account reset! Old key was %s; new key is %s", t.tracked, t.observed)
 }
 func (t TrackDiffNewEldest) ToDisplayMarkup() *Markup {
 	return NewMarkup(t.ToDisplayString())

--- a/go/libkb/track.go
+++ b/go/libkb/track.go
@@ -324,7 +324,7 @@ func (t TrackDiffNewEldest) GetTrackDiffType() keybase1.TrackDiffType {
 	return keybase1.TrackDiffType_NEW_ELDEST
 }
 func (t TrackDiffNewEldest) ToDisplayString() string {
-	return fmt.Sprintf("Changed from %s to %s", t.tracked, t.observed)
+	return fmt.Sprintf("Eldest key changed from %s to %s", t.tracked, t.observed)
 }
 func (t TrackDiffNewEldest) ToDisplayMarkup() *Markup {
 	return NewMarkup(t.ToDisplayString())


### PR DESCRIPTION
- Also deal with erroneous `0000 0000`-style PGP fingerprint output
  for NaCl keys, as per CORE-2327