### PR TITLE
Log send command

### DIFF
--- a/go/client/cmd_log.go
+++ b/go/client/cmd_log.go
@@ -1,0 +1,21 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+)
+
+func NewCmdLog(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "log",
+		Usage:        "Manage keybase logs",
+		ArgumentHelp: "[arguments...]",
+		Subcommands: []cli.Command{
+			NewCmdLogSend(cl, g),
+		},
+	}
+}

--- a/go/client/cmd_log_send.go
+++ b/go/client/cmd_log_send.go
@@ -85,7 +85,7 @@ func (c *CmdLogSend) post(status, kbfsLog, svcLog string) error {
 		return err
 	}
 
-	id, err := resp.Body.AtKey("id").GetString()
+	id, err := resp.Body.AtKey("logdump_id").GetString()
 	if err != nil {
 		return err
 	}

--- a/go/client/cmd_log_send.go
+++ b/go/client/cmd_log_send.go
@@ -77,9 +77,9 @@ func (c *CmdLogSend) confirm() error {
 	ui := c.G().UI.GetTerminalUI()
 	ui.Printf("This command will send recent keybase log entries to keybase.io\n")
 	ui.Printf("for debugging purposes only.\n\n")
-	ui.Printf("While we have made every attempt to keep sensitive information\n")
-	ui.Printf("out of the logs, we wanted to make sure you are ok with sending\n")
-	ui.Printf("your log files.\n\n")
+	ui.Printf("These logs don’t include your private keys or encrypted data,\n")
+	ui.Printf("but they will include filenames and other metadata keybase normally\n")
+	ui.Printf("can’t read, for debugging purposes.\n")
 	return ui.PromptForConfirmation("Continue sending logs to keybase.io?")
 }
 

--- a/go/client/cmd_log_send.go
+++ b/go/client/cmd_log_send.go
@@ -1,0 +1,102 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/rogpeppe/rog-go/reverse"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+)
+
+func NewCmdLogSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "send",
+		Usage: "Send recent debug logs to keybase",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdLogSend{Contextified: libkb.NewContextified(g)}, "send", c)
+		},
+		Flags: []cli.Flag{
+			cli.IntFlag{
+				Name:  "n",
+				Usage: "Number of lines in each log file",
+			},
+		},
+	}
+}
+
+type CmdLogSend struct {
+	libkb.Contextified
+	numLines int
+}
+
+func (c *CmdLogSend) Run() error {
+
+	// use status command to get status:
+	statusCmd := &CmdStatus{Contextified: libkb.NewContextified(c.G())}
+	status, err := statusCmd.load()
+	if err != nil {
+		return err
+	}
+	statusJSON, err := json.Marshal(status)
+	if err != nil {
+		return err
+	}
+	c.G().Log.Debug("status json: %s", statusJSON)
+
+	kbfsLog, err := tail(status.KBFS.Log, c.numLines)
+	if err != nil {
+		return err
+	}
+
+	svcLog, err := tail(status.Service.Log, c.numLines)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func tail(filename string, numLines int) (string, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+	b := reverse.NewScanner(f)
+	b.Split(bufio.ScanLines)
+
+	var lines []string
+	for b.Scan() {
+		lines = append(lines, b.Text())
+		if len(lines) == numLines {
+			break
+		}
+	}
+
+	return strings.Join(lines, "\n"), nil
+}
+
+func (c *CmdLogSend) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) > 0 {
+		return UnexpectedArgsError("log send")
+	}
+	c.numLines = ctx.Int("n")
+	if c.numLines < 1 {
+		c.numLines = 10000
+	}
+	return nil
+}
+
+func (c *CmdLogSend) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/cmd_status.go
+++ b/go/client/cmd_status.go
@@ -73,6 +73,7 @@ type fstatus struct {
 	}
 	Desktop struct {
 		Running bool
+		Log     string
 	}
 
 	DefaultUsername      string
@@ -143,6 +144,7 @@ func (c *CmdStatus) load() (*fstatus, error) {
 	status.KBFS.Log = path.Join(extStatus.LogDir, c.kbfsLogFilename())
 
 	status.Desktop.Running = extStatus.DesktopUIConnected
+	status.Desktop.Log = path.Join(extStatus.LogDir, c.desktopLogFilename())
 
 	status.DefaultUsername = extStatus.DefaultUsername
 	status.ProvisionedUsernames = extStatus.ProvisionedUsernames
@@ -203,6 +205,7 @@ func (c *CmdStatus) outputTerminal(status *fstatus) error {
 	dui.Printf("    version:   %s\n", status.Client.Version)
 	dui.Printf("\nDesktop app:\n")
 	dui.Printf("    status:    %s\n\n", BoolString(status.Desktop.Running, "running", "not running"))
+	dui.Printf("    log:       %s\n", status.Desktop.Log)
 	dui.Printf("Config path:        %s\n", status.ConfigPath)
 	dui.Printf("Default user:       %s\n", status.DefaultUsername)
 	dui.Printf("Provisioned users:  %s\n", strings.Join(status.ProvisionedUsernames, ", "))

--- a/go/client/cmd_status_nix.go
+++ b/go/client/cmd_status_nix.go
@@ -19,3 +19,7 @@ func (c *CmdStatus) serviceLogFilename() string {
 func (c *CmdStatus) kbfsLogFilename() string {
 	return "keybase.kbfs.log"
 }
+
+func (c *CmdStatus) desktopLogFilename() string {
+	return "keybase.gui.log"
+}

--- a/go/client/cmd_status_osx.go
+++ b/go/client/cmd_status_osx.go
@@ -31,3 +31,7 @@ func (c *CmdStatus) serviceLogFilename() string {
 func (c *CmdStatus) kbfsLogFilename() string {
 	return "keybase.kbfs.log"
 }
+
+func (c *CmdStatus) desktopLogFilename() string {
+	return "Keybase.app.log"
+}

--- a/go/client/cmd_status_windows.go
+++ b/go/client/cmd_status_windows.go
@@ -21,3 +21,8 @@ func (c *CmdStatus) serviceLogFilename() string {
 func (c *CmdStatus) kbfsLogFilename() string {
 	return "keybase.kbfs.log"
 }
+
+// TODO: check with steve about this
+func (c *CmdStatus) desktopLogFilename() string {
+	return "keybase.gui.log"
+}

--- a/go/client/commands_common.go
+++ b/go/client/commands_common.go
@@ -31,6 +31,7 @@ func GetCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Comma
 		NewCmdID(cl, g),
 		NewCmdListTracking(cl),
 		NewCmdListTrackers(cl),
+		NewCmdLog(cl, g),
 		NewCmdLogin(cl, g),
 		NewCmdLogout(cl, g),
 		NewCmdPaperKey(cl),

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -483,6 +483,18 @@ func (a *InternalAPIEngine) PostDecode(arg APIArg, v APIResponseWrapper) error {
 	return a.checkAppStatus(arg, v.GetAppStatus())
 }
 
+func (a *InternalAPIEngine) PostRaw(arg APIArg, ctype string, r io.Reader) (*APIRes, error) {
+	url := a.getURL(arg)
+	req, err := http.NewRequest("POST", url.String(), r)
+	if len(ctype) > 0 {
+		req.Header.Set("Content-Type", ctype)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return a.DoRequest(arg, req)
+}
+
 func (a *InternalAPIEngine) DoRequest(arg APIArg, req *http.Request) (*APIRes, error) {
 	resp, jw, err := doRequestShared(a, arg, req, true)
 	if err != nil {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -242,6 +242,7 @@ type API interface {
 	PostJSON(APIArg) (*APIRes, error)
 	PostResp(APIArg) (*http.Response, error)
 	PostDecode(APIArg, APIResponseWrapper) error
+	PostRaw(APIArg, string, io.Reader) (*APIRes, error)
 }
 
 type ExternalAPI interface {

--- a/go/libkb/login_session_test.go
+++ b/go/libkb/login_session_test.go
@@ -7,11 +7,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/jonboulle/clockwork"
-	jsonw "github.com/keybase/go-jsonw"
+	"io"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/jonboulle/clockwork"
+	jsonw "github.com/keybase/go-jsonw"
 )
 
 const fakeResponse = `{
@@ -69,6 +71,10 @@ func (a *FakeAPI) PostJSON(APIArg) (*APIRes, error) {
 
 func (a *FakeAPI) PostResp(APIArg) (*http.Response, error) {
 	return nil, fmt.Errorf("PostResp is phony")
+}
+
+func (a *FakeAPI) PostRaw(APIArg, string, io.Reader) (*APIRes, error) {
+	return nil, fmt.Errorf("PostRaw is phony")
 }
 
 func (a *FakeAPI) PostDecode(APIArg, APIResponseWrapper) error {

--- a/go/vendor/github.com/rogpeppe/rog-go/reverse/scan.go
+++ b/go/vendor/github.com/rogpeppe/rog-go/reverse/scan.go
@@ -1,0 +1,212 @@
+package reverse
+
+import (
+	"bufio"
+	"errors"
+	"io"
+)
+
+const maxBufSize = 64 * 1024
+
+// Scanner presents the same interface as bufio.Scanner
+// except it scans tokens in reverse from the end of
+// a file instead of forwards from the beginning.
+//
+// It may not work correctly if the split function can return an
+// error from reading half way through a token.
+// That is not the case for any of the Scan* functions
+// in bufio.
+type Scanner struct {
+	r io.ReadSeeker
+
+	split bufio.SplitFunc
+
+	// buf holds currently buffered data.
+	buf []byte
+
+	// offset holds the file offset of the data
+	// in buf.
+	offset int64
+
+	// atEOF reports whether the buffer
+	// is located at the end of the file.
+	atEOF bool
+
+	// tokens holds any currently unscanned
+	// tokens in buf.
+	tokens [][]byte
+
+	// partialToken holds the size of the partial
+	// token at the start of buf.
+	partialToken int
+
+	// err holds any error encountered.
+	err error
+}
+
+// TODO make NewScanner take a ReaderAt rather
+// than a ReadSeeker.
+
+// TODO provide a FileOffset method that returns
+// the offset of the token in the file.
+
+// NewScanner returns a new Scanner to read tokens
+// in reverse from r. The split function defaults to bufio.ScanLines.
+func NewScanner(r io.ReadSeeker) *Scanner {
+	b := &Scanner{
+		r:     r,
+		buf:   make([]byte, 4096),
+		atEOF: true,
+		split: bufio.ScanLines,
+	}
+	b.offset, b.err = r.Seek(0, 2)
+	return b
+}
+
+func (b *Scanner) fillbuf() error {
+	b.tokens = b.tokens[:0]
+	if b.offset == 0 {
+		return io.EOF
+	}
+	space := len(b.buf) - b.partialToken
+	if space == 0 {
+		// Partial token fills the buffer, so expand it.
+		if len(b.buf) >= maxBufSize {
+			return errors.New("token too long")
+		}
+		n := len(b.buf) * 2
+		if n > maxBufSize {
+			n = maxBufSize
+		}
+		newBuf := make([]byte, n)
+		copy(newBuf, b.buf[0:b.partialToken])
+		b.buf = newBuf
+		space = len(b.buf) - b.partialToken
+	}
+	if int64(space) > b.offset {
+		// We have less than the given buffer's space
+		// left to read, so shrink the buffer to simplify
+		// the remaining logic by preserving the
+		// invariants that b.partialToken + space == len(buf)
+		// and the data is read into the start of buf.
+		b.buf = b.buf[0 : b.partialToken+int(b.offset)]
+		space = len(b.buf) - b.partialToken
+	}
+	newOffset := b.offset - int64(space)
+	// Copy old partial token to end of buffer.
+	copy(b.buf[space:], b.buf[0:b.partialToken])
+	_, err := b.r.Seek(newOffset, 0)
+	if err != nil {
+		return err
+	}
+	b.offset = newOffset
+	if _, err := io.ReadFull(b.r, b.buf[0:space]); err != nil {
+		// TODO Cope better with io.UnexpectedEOF at the
+		// end of a file - historically some versions of NFS
+		// can report a file size that's larger than the actual
+		// file size.
+		return err
+	}
+	// Populate b.tokens with the tokens in the buffer.
+	if b.offset > 0 {
+		// We're not at the start of the file - read the first
+		// token to find out where the token boundary is, but
+		// don't treat it as an actual token, because we're
+		// probably not at its start.
+		advance, _, err := b.split(b.buf, b.atEOF)
+		if err != nil {
+			// If the split function can return an error
+			// when starting at a non-token boundary, this
+			// will happen and there's not much we can do
+			// about it other than scanning forward a byte
+			// at a time in a horribly inefficient manner,
+			// so just return the error.
+			return err
+		}
+		b.partialToken = advance
+		if advance == 0 || advance == len(b.buf) {
+			// There are no more tokens in the buffer,
+			// or the single token fills the entire buffer
+			// so try again (the buffer will expand if
+			// necessary)
+			return b.fillbuf()
+		}
+	} else {
+		b.partialToken = 0
+	}
+	for i := b.partialToken; i < len(b.buf); {
+		advance, token, err := b.split(b.buf[i:], b.atEOF)
+		if err != nil {
+			// We've got an error - avoid returning
+			// any tokens encountered earlier in this
+			// buffer scan, otherwise we risk skipping
+			// tokens before returning the error.
+			b.tokens = b.tokens[:0]
+			return err
+		}
+		if advance == 0 {
+			// There's no remaining token in the buffer.
+			break
+		}
+		b.tokens = append(b.tokens, token)
+		i += advance
+	}
+	b.atEOF = false
+	if len(b.tokens) == 0 {
+		// There were no tokens found - that means that
+		// although we did find a partial token at the start,
+		// there were no other tokens, so we need
+		// to scan back further.
+		return b.fillbuf()
+	}
+	return nil
+}
+
+// Scan advances the Scanner to the next token, which will then be
+// available through the Bytes or Text method. It returns false when the
+// scan stops, either by reaching the end of the input or an error.
+// After Scan returns false, the Err method will return any error that
+// occurred during scanning, except that if it was io.EOF, Err
+// will return nil.
+func (b *Scanner) Scan() bool {
+	if len(b.tokens) > 0 {
+		b.tokens = b.tokens[0 : len(b.tokens)-1]
+	}
+	if len(b.tokens) > 0 {
+		return true
+	}
+	if b.err != nil {
+		return false
+	}
+	b.err = b.fillbuf()
+	return len(b.tokens) > 0
+}
+
+// Split sets the split function for the Scanner. If called, it must be
+// called before Scan. The default split function is bufio.ScanLines.
+func (b *Scanner) Split(split bufio.SplitFunc) {
+	b.split = split
+}
+
+// Bytes returns the most recent token generated by a call to Scan.
+// The underlying array may point to data that will be overwritten
+// by a subsequent call to Scan. It does no allocation.
+func (b *Scanner) Bytes() []byte {
+	return b.tokens[len(b.tokens)-1]
+}
+
+// Text returns the most recent token generated by a call to Scan
+// as a newly allocated string holding its bytes.
+func (b *Scanner) Text() string {
+	return string(b.Bytes())
+}
+
+func (b *Scanner) Err() error {
+	if len(b.tokens) > 0 {
+		return nil
+	}
+	if b.err == io.EOF {
+		return nil
+	}
+	return b.err
+}

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -218,6 +218,11 @@
 			"revisionTime": "2014-10-08T16:43:58+02:00"
 		},
 		{
+			"path": "github.com/rogpeppe/rog-go/reverse",
+			"revision": "f57ad5e24ab7813942c045f86eda1066eb969e98",
+			"revisionTime": "2015-01-10T16:24:53Z"
+		},
+		{
 			"path": "github.com/syndtr/goleveldb/leveldb",
 			"revision": "a06509502ca32565bdf74afc1e573050023f261c",
 			"revisionTime": "2015-06-10T06:54:26+07:00"


### PR DESCRIPTION
This adds `keyabse log send`.

It works with keybase/keybase#coyne/CORE-2423.

r? @malgorithms @maxtaco 

(for testing with devel build, I linked my production log files to the devel home directory locations reported by `status` command, since with devel the stdout isn't saved to files.)