### PR TITLE
Login holder

### DIFF
--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -10,9 +10,11 @@ import configureStore from '../../react-native/react/store/configure-store'
 import Nav from '../../react-native/react/nav'
 import injectTapEventPlugin from 'react-tap-event-plugin'
 import ListenLogUi from '../../react-native/react/native/listen-log-ui'
-import {reduxDevToolsEnable} from '../../react-native/react/local-debug'
+import {reduxDevToolsEnable, devStoreChangingFunctions} from '../../react-native/react/local-debug'
 import {listenForNotifications} from '../../react-native/react/actions/notifications'
 import hello from '../../react-native/react/util/hello'
+
+import {devEditAction} from '../../react-native/react/reducers/devEdit'
 
 // For Remote Components
 import {ipcRenderer} from 'electron'
@@ -27,6 +29,10 @@ if (module.hot) {
 }
 
 const store = configureStore()
+
+if (devStoreChangingFunctions) {
+  window.devEdit = (path, value) => store.dispatch(devEditAction(path, value))
+}
 
 class Keybase extends Component {
   constructor () {

--- a/react-native/.flowconfig
+++ b/react-native/.flowconfig
@@ -8,7 +8,6 @@
 .*/react/router/global-routes.js
 .*/react/nav.android.js
 .*/react/nav.ios.js
-.*/react/login/.*
 .*/react/login2/.*
 .*/react/profile/.*
 .*/react/search/.*

--- a/react-native/.flowconfig
+++ b/react-native/.flowconfig
@@ -11,7 +11,6 @@
 .*/react/login2/.*
 .*/react/profile/.*
 .*/react/search/.*
-.*/react/local-debug.js
 
 # Ignoring these for now
 .*/desktop/.*

--- a/react-native/react/actions/login/index.js
+++ b/react-native/react/actions/login/index.js
@@ -4,15 +4,10 @@ import {isMobile} from '../../constants/platform'
 import {navigateTo, routeAppend, getCurrentURI, getCurrentTab} from '../router'
 import engine from '../../engine'
 import enums from '../../constants/types/keybase_v1'
-// $FlowIssue TODO
 import UserPass from '../../login/register/user-pass'
-// $FlowIssue TODO
 import PaperKey from '../../login/register/paper-key'
-// $FlowIssue TODO
 import CodePage from '../../login/register/code-page'
-// $FlowIssue TODO
 import ExistingDevice from '../../login/register/existing-device'
-// $FlowIssue TODO
 import SetPublicName from '../../login/register/set-public-name'
 import {switchTab} from '../tabbed-router'
 import {devicesTab} from '../../constants/tabs'

--- a/react-native/react/common-adapters/header.js.flow
+++ b/react-native/react/common-adapters/header.js.flow
@@ -3,10 +3,10 @@
 import React, {Component} from '../base-react'
 
 export type Props = {
-  icon: ?string,
+  icon?: ?string,
   title: string,
   onClose: () => void,
-  style: Object,
+  style?: Object,
   children?: ?Object
 }
 

--- a/react-native/react/constants/tabs.js
+++ b/react-native/react/constants/tabs.js
@@ -4,6 +4,7 @@ export const chatTab = 'tabs:chatTab'
 export const peopleTab = 'tabs:peopleTab'
 export const devicesTab = 'tabs:devicesTab'
 export const moreTab = 'tabs:moreTab'
+export const loginTab = 'tabs:loginTab'
 
 const prettyNames = {
   [startupTab]: null,
@@ -11,7 +12,8 @@ const prettyNames = {
   [chatTab]: 'Chat',
   [peopleTab]: 'People',
   [devicesTab]: 'Devices',
-  [moreTab]: 'More'
+  [moreTab]: 'More',
+  [loginTab]: 'Login'
 }
 
 export function prettify (tabName) {

--- a/react-native/react/local-debug.desktop.js
+++ b/react-native/react/local-debug.desktop.js
@@ -21,7 +21,8 @@ let config = {
   enableStoreLogging: false,
   enableActionLogging: true,
   forwardLogs: true,
-  devStoreChangingFunctions: false
+  devStoreChangingFunctions: false,
+  resizeLoginForm: true
 }
 
 if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) { // eslint-disable-line no-undef
@@ -40,6 +41,7 @@ if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) { // eslint-disable-line no-unde
   config.enableActionLogging = false
   config.forwardLogs = true
   config.devStoreChangingFunctions = true
+  config.resizeLoginForm = false
 }
 
 config = updateConfig(config)
@@ -57,5 +59,6 @@ export const {
   reduxDevToolsSelect,
   enableStoreLogging,
   forwardLogs,
-  devStoreChangingFunctions
+  devStoreChangingFunctions,
+  resizeLoginForm
 } = config

--- a/react-native/react/local-debug.desktop.js
+++ b/react-native/react/local-debug.desktop.js
@@ -20,7 +20,8 @@ let config = {
   reduxDevToolsSelect: state => state, // only watch a subset of the store
   enableStoreLogging: false,
   enableActionLogging: true,
-  forwardLogs: true
+  forwardLogs: true,
+  devStoreChangingFunctions: false
 }
 
 if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) { // eslint-disable-line no-undef
@@ -38,6 +39,7 @@ if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) { // eslint-disable-line no-unde
   config.enableStoreLogging = true
   config.enableActionLogging = false
   config.forwardLogs = true
+  config.devStoreChangingFunctions = true
 }
 
 config = updateConfig(config)
@@ -54,5 +56,6 @@ export const {
   showAllTrackers,
   reduxDevToolsSelect,
   enableStoreLogging,
-  forwardLogs
+  forwardLogs,
+  devStoreChangingFunctions
 } = config

--- a/react-native/react/local-debug.js.flow
+++ b/react-native/react/local-debug.js.flow
@@ -1,0 +1,1 @@
+declare var exports: any;

--- a/react-native/react/login/forms/intro.js
+++ b/react-native/react/login/forms/intro.js
@@ -1,0 +1,26 @@
+/* @flow */
+
+import React, {Component} from '../../base-react'
+import {connect} from 'react-redux'
+import Render from './intro.render'
+
+class Intro extends Component {
+  render (): ReactElement {
+    return (
+      <Render onSignup={this.props.onSignup} onLogin={this.props.onLogin}/>
+    )
+  }
+}
+
+Intro.propTypes = {
+  onLogin: React.PropTypes.func.isRequired,
+  onSignup: React.PropTypes.func.isRequired
+}
+
+export default connect(
+  state => ({}),
+  dispatch => ({
+    onSignup: () => {},
+    onLogin: () => {}
+  })
+)(Intro)

--- a/react-native/react/login/forms/intro.render.desktop.js
+++ b/react-native/react/login/forms/intro.render.desktop.js
@@ -1,0 +1,34 @@
+/* @flow */
+/* eslint-disable react/prop-types */
+
+import React, {Component} from '../../base-react'
+import {globalStyles} from '../../styles/style-guide'
+import {Text} from '../../common-adapters'
+
+import type {IntroProps} from './intro.render'
+
+export default class Intro extends Component {
+  props: IntroProps;
+
+  render (): ReactElement {
+    return (
+      <div style={styles.loginForm}>
+        <Text style={styles.topMargin} type='Header'>Welcome to Keybase!</Text>
+        <Text style={styles.topMargin} type='Body'>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sagittis lacus vel augue laoreet.</Text>
+        <Text style={styles.topMargin} type='Body' link onClick={this.props.onSignup}>Create Account</Text>
+        <Text style={styles.topMargin} type='Body' link onClick={this.props.onLogin}>Log In</Text>
+      </div>
+    )
+  }
+}
+
+const styles = {
+  loginForm: {
+    ...globalStyles.flexBoxColumn,
+    flex: 1
+  },
+
+  topMargin: {
+    marginTop: 20
+  }
+}

--- a/react-native/react/login/forms/intro.render.js.flow
+++ b/react-native/react/login/forms/intro.render.js.flow
@@ -1,0 +1,11 @@
+/* @flow */
+import React, {Component} from '../base-react'
+
+export type IntroProps = {
+  onSignup: () => void,
+  onLogin: () => void
+}
+
+export default class Intro extends Component {
+  props: IntroProps;
+}

--- a/react-native/react/login/index.js
+++ b/react-native/react/login/index.js
@@ -1,16 +1,17 @@
+/* @flow */
+
 import React, {Component} from '../base-react'
 import Welcome from './welcome'
 import Register from './register'
 import Render from './index.render'
 
 export default class Login extends Component {
-  constructor (props) {
-    super(props)
-  }
-
   render () {
     return (
-      <Render />
+      // TODO: hook this up
+      <Render
+        onSignup={() => {}}
+        onLogin={() => {}}/>
     )
   }
 

--- a/react-native/react/login/index.js
+++ b/react-native/react/login/index.js
@@ -1,28 +1,37 @@
 /* @flow */
 
 import React, {Component} from '../base-react'
-import Welcome from './welcome'
-import Register from './register'
 import Render from './index.render'
+import Intro from './forms/intro'
+import {Text} from '../common-adapters'
 
 export default class Login extends Component {
   render () {
-    return (
-      // TODO: hook this up
-      <Render
-        onSignup={() => {}}
-        onLogin={() => {}}/>
-    )
+    return <Render formComponent={this.props.formComponent}/>
   }
 
-  static parseRoute (store, currentPath, nextPath) {
+  static parseRoute (currentPath, uri) {
+    // Fallback (for debugging)
+    let Form = () => <Text type='Body'>Error loading component {JSON.stringify(currentPath.toJS())}</Text>
+
+    switch (currentPath.get('path')) {
+      case 'root':
+        Form = () => <Intro/>
+        break
+    }
+
     return {
-      subRoutes: {
-        welcome: Welcome,
-        register: Register
-      }
+      componentAtTop: {
+        component: Login,
+        props: {
+          formComponent: Form
+        }
+      },
+      parseNextRoute: Login.parseRoute
     }
   }
 }
 
-Login.propTypes = {}
+Login.propTypes = {
+  formComponent: React.PropTypes.any.isRequired
+}

--- a/react-native/react/login/index.render.desktop.js
+++ b/react-native/react/login/index.render.desktop.js
@@ -3,37 +3,12 @@
 
 import React, {Component} from '../base-react'
 import {globalStyles} from '../styles/style-guide'
-import {resizeLoginForm} from '../local-debug'
-
-import {remote} from 'electron'
-
 import Carousel from '../util/carousel.desktop'
 
 import type {LoginRenderProps} from './index.render'
 
 export default class LoginRender extends Component {
   props: LoginRenderProps;
-
-  window: ?any;
-  originalSize: ?{width: number, height: number};
-
-  componentWillMount () {
-    if (resizeLoginForm) {
-      this.window = remote.getCurrentWindow()
-      const [width, height] = this.window.getSize()
-      this.originalSize = {width, height}
-      this.window && this.window.setSize(styles.container.width, styles.container.height + 20 /* for frame */, true)
-      this.window && this.window.setResizable(false)
-    }
-  }
-
-  componentWillUnmount () {
-    if (this.originalSize) {
-      const {width, height} = this.originalSize
-      this.window && this.window.setSize(width, height, true)
-    }
-    this.window && this.window.setResizable(true)
-  }
 
   render (): ReactElement {
     const FormComponent = this.props.formComponent
@@ -48,10 +23,12 @@ export default class LoginRender extends Component {
   }
 }
 
+export const loginResizeTo = {width: 700, height: 500}
+
 const styles = {
   container: {
-    height: 500,
-    width: 700,
+    height: loginResizeTo.height,
+    width: loginResizeTo.width,
     overflow: 'hidden'
   },
 

--- a/react-native/react/login/index.render.desktop.js
+++ b/react-native/react/login/index.render.desktop.js
@@ -1,12 +1,54 @@
+/* @flow */
+/* eslint-disable react/prop-types */
+
 import React, {Component} from '../base-react'
+import {globalStyles} from '../styles/style-guide'
+
+import {Text} from '../common-adapters'
+import Carousel from '../util/carousel.desktop'
+
+import type {LoginRenderProps} from './index.render'
 
 export default class LoginRender extends Component {
-  render () {
+  props: LoginRenderProps;
+
+  render (): ReactElement {
     return (
-      <div style={{display: 'flex', flex: 1, alignItems: 'center', justifyContent: 'center'}}>
+      <div style={{...globalStyles.flexBoxRow, ...styles.container, ...styles.demo}}>
+        <Carousel style={{width: 400}} itemWidth={340}/>
+        <div style={styles.loginForm}>
+          <Text style={styles.topMargin} type='Header'>Welcome to Keybase!</Text>
+          <Text style={styles.topMargin} type='Body'>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sagittis lacus vel augue laoreet.</Text>
+          <Text style={styles.topMargin} type='Body' link onClick={this.props.onSignup}>Create Account</Text>
+          <Text style={styles.topMargin} type='Body' link onClick={this.props.onLogin}>Log In</Text>
+        </div>
       </div>
     )
   }
 }
 
-LoginRender.propTypes = { }
+const styles = {
+  demo: {
+    marginTop: 20,
+    marginLeft: 20,
+    boxShadow: '10px 10px 40px black'
+  },
+
+  container: {
+    height: 500,
+    width: 700,
+    overflow: 'hidden'
+  },
+
+  loginForm: {
+    ...globalStyles.flexBoxColumn,
+    flex: 1,
+    paddingRight: 20,
+    paddingLeft: 20,
+    boxShadow: `-2px 0px 2px rgba(0, 0, 0, 0.12)`
+  },
+
+  topMargin: {
+    marginTop: 20
+  }
+}

--- a/react-native/react/login/index.render.desktop.js
+++ b/react-native/react/login/index.render.desktop.js
@@ -3,10 +3,10 @@
 
 import React, {Component} from '../base-react'
 import {globalStyles} from '../styles/style-guide'
+import {resizeLoginForm} from '../local-debug'
 
 import {remote} from 'electron'
 
-import {Text} from '../common-adapters'
 import Carousel from '../util/carousel.desktop'
 
 import type {LoginRenderProps} from './index.render'
@@ -18,11 +18,13 @@ export default class LoginRender extends Component {
   originalSize: ?{width: number, height: number};
 
   componentWillMount () {
-    this.window = remote.getCurrentWindow()
-    const [width, height] = this.window.getSize()
-    this.originalSize = {width, height}
-    this.window && this.window.setSize(styles.container.width, styles.container.height + 20 /* for frame */, true)
-    this.window && this.window.setResizable(false)
+    if (resizeLoginForm) {
+      this.window = remote.getCurrentWindow()
+      const [width, height] = this.window.getSize()
+      this.originalSize = {width, height}
+      this.window && this.window.setSize(styles.container.width, styles.container.height + 20 /* for frame */, true)
+      this.window && this.window.setResizable(false)
+    }
   }
 
   componentWillUnmount () {
@@ -34,14 +36,12 @@ export default class LoginRender extends Component {
   }
 
   render (): ReactElement {
+    const FormComponent = this.props.formComponent
     return (
       <div style={{...globalStyles.flexBoxRow, ...styles.container}}>
         <Carousel style={{width: 400}} itemWidth={340}/>
         <div style={styles.loginForm}>
-          <Text style={styles.topMargin} type='Header'>Welcome to Keybase!</Text>
-          <Text style={styles.topMargin} type='Body'>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sagittis lacus vel augue laoreet.</Text>
-          <Text style={styles.topMargin} type='Body' link onClick={this.props.onSignup}>Create Account</Text>
-          <Text style={styles.topMargin} type='Body' link onClick={this.props.onLogin}>Log In</Text>
+          <FormComponent/>
         </div>
       </div>
     )

--- a/react-native/react/login/index.render.desktop.js
+++ b/react-native/react/login/index.render.desktop.js
@@ -4,6 +4,8 @@
 import React, {Component} from '../base-react'
 import {globalStyles} from '../styles/style-guide'
 
+import {remote} from 'electron'
+
 import {Text} from '../common-adapters'
 import Carousel from '../util/carousel.desktop'
 
@@ -12,9 +14,28 @@ import type {LoginRenderProps} from './index.render'
 export default class LoginRender extends Component {
   props: LoginRenderProps;
 
+  window: ?any;
+  originalSize: ?{width: number, height: number};
+
+  componentWillMount () {
+    this.window = remote.getCurrentWindow()
+    const [width, height] = this.window.getSize()
+    this.originalSize = {width, height}
+    this.window && this.window.setSize(styles.container.width, styles.container.height + 20 /* for frame */, true)
+    this.window && this.window.setResizable(false)
+  }
+
+  componentWillUnmount () {
+    if (this.originalSize) {
+      const {width, height} = this.originalSize
+      this.window && this.window.setSize(width, height, true)
+    }
+    this.window && this.window.setResizable(true)
+  }
+
   render (): ReactElement {
     return (
-      <div style={{...globalStyles.flexBoxRow, ...styles.container, ...styles.demo}}>
+      <div style={{...globalStyles.flexBoxRow, ...styles.container}}>
         <Carousel style={{width: 400}} itemWidth={340}/>
         <div style={styles.loginForm}>
           <Text style={styles.topMargin} type='Header'>Welcome to Keybase!</Text>
@@ -28,12 +49,6 @@ export default class LoginRender extends Component {
 }
 
 const styles = {
-  demo: {
-    marginTop: 20,
-    marginLeft: 20,
-    boxShadow: '10px 10px 40px black'
-  },
-
   container: {
     height: 500,
     width: 700,

--- a/react-native/react/login/index.render.js.flow
+++ b/react-native/react/login/index.render.js.flow
@@ -1,0 +1,11 @@
+/* @flow */
+import React, {Component} from '../base-react'
+
+export type LoginRenderProps = {
+  onSignup: () => void,
+  onLogin: () => void
+}
+
+export default class LoginRender extends Component {
+  props: LoginRenderProps;
+}

--- a/react-native/react/login/index.render.js.flow
+++ b/react-native/react/login/index.render.js.flow
@@ -2,8 +2,7 @@
 import React, {Component} from '../base-react'
 
 export type LoginRenderProps = {
-  onSignup: () => void,
-  onLogin: () => void
+  formComponent: ReactClass
 }
 
 export default class LoginRender extends Component {

--- a/react-native/react/more/dev-menu.js
+++ b/react-native/react/more/dev-menu.js
@@ -1,12 +1,15 @@
 import React, {Component} from '../base-react'
 import {connect} from '../base-redux'
 import {routeAppend} from '../actions/router'
+import {switchTab} from '../actions/tabbed-router'
 import {pushNewProfile} from '../actions/profile'
 import {pushNewSearch} from '../actions/search'
 import {logout} from '../actions/login'
 import {pushDebugTracker} from '../actions/tracker'
 import MenuList from './menu-list'
 import RemoteComponent from '../native/remote-component'
+
+import {loginTab} from '../constants/tabs'
 
 class Foo extends Component {
   render () {
@@ -28,7 +31,7 @@ class DevMenu extends Component {
   render () {
     const menuItems = [
       {name: 'Login', onClick: () => {
-        this.props.routeAppend(['login', {path: 'welcome', upLink: ['about'], upTitle: 'About'}])
+        this.props.switchTab(loginTab)
       }},
       {name: 'Register', onClick: () => {
         this.props.routeAppend(['login', {path: 'register', upLink: ['']}])
@@ -107,6 +110,7 @@ export default connect(
   dispatch => {
     return {
       routeAppend: uri => dispatch(routeAppend(uri)),
+      switchTab: tabName => dispatch(switchTab(tabName)),
       logout: () => dispatch(logout()),
       pushNewSearch: () => dispatch(pushNewSearch()),
       pushNewProfile: username => dispatch(pushNewProfile(username)),

--- a/react-native/react/nav.desktop.js
+++ b/react-native/react/nav.desktop.js
@@ -8,13 +8,14 @@ import People from './people'
 import Devices from './devices'
 import NoTab from './no-tab'
 import More from './more'
+import Login from './login'
 import commonStyles from './styles/common'
 // TODO global routes
 // import globalRoutes from './router/global-routes'
 const globalRoutes = {}
 
 import * as Constants from './constants/config'
-import {folderTab, chatTab, peopleTab, devicesTab, moreTab} from './constants/tabs'
+import {folderTab, chatTab, peopleTab, devicesTab, moreTab, loginTab} from './constants/tabs'
 import {switchTab} from './actions/tabbed-router'
 import {startup} from './actions/startup'
 import {Tab, Tabs} from 'material-ui'
@@ -66,6 +67,17 @@ class Nav extends Component {
       return (
         <div style={{display: 'flex', flexDirection: 'column', flex: 1, alignItems: 'center', justifyContent: 'center'}}>
           <h1>Loading...</h1>
+        </div>
+      )
+    }
+
+    if (activeTab === loginTab) {
+      return (
+        <div style={styles.tabsContainer}>
+          <MetaNavigator
+            tab={loginTab}
+            globalRoutes={globalRoutes}
+            rootComponent={Login} />
         </div>
       )
     }

--- a/react-native/react/nav.desktop.js
+++ b/react-native/react/nav.desktop.js
@@ -1,3 +1,5 @@
+import {remote} from 'electron'
+
 import {Component} from './base-react'
 import {connect} from './base-redux'
 import MetaNavigator from './router/meta-navigator'
@@ -10,6 +12,9 @@ import NoTab from './no-tab'
 import More from './more'
 import Login from './login'
 import commonStyles from './styles/common'
+
+import {resizeLoginForm} from './local-debug'
+
 // TODO global routes
 // import globalRoutes from './router/global-routes'
 const globalRoutes = {}
@@ -19,6 +24,8 @@ import {folderTab, chatTab, peopleTab, devicesTab, moreTab, loginTab} from './co
 import {switchTab} from './actions/tabbed-router'
 import {startup} from './actions/startup'
 import {Tab, Tabs} from 'material-ui'
+
+import {loginResizeTo} from './login/index.render'
 
 const tabs = {
   [moreTab]: {module: More, name: 'More'},
@@ -58,6 +65,30 @@ class Nav extends Component {
 
   _handleTabsChange (e, key, payload) {
     this.props.switchTab(e)
+  }
+
+  componentWillReceiveProps (nextProps) {
+    const activeTab = this.props.tabbedRouter.get('activeTab')
+    const nextActiveTab = nextProps.tabbedRouter.get('activeTab')
+
+    // Transistioning into the login tab
+    if (resizeLoginForm && activeTab !== loginTab && nextActiveTab === loginTab) {
+      this.window = remote.getCurrentWindow()
+      const [width, height] = this.window.getSize()
+      this.originalSize = {width, height}
+
+      this.window && this.window.setContentSize(loginResizeTo.width, loginResizeTo.height, true)
+      this.window && this.window.setResizable(false)
+    }
+
+    // Transistioning out of the login tab
+    if (resizeLoginForm && activeTab === loginTab && nextActiveTab !== loginTab) {
+      if (this.originalSize) {
+        const {width, height} = this.originalSize
+        this.window && this.window.setSize(width, height, true)
+      }
+      this.window && this.window.setResizable(true)
+    }
   }
 
   render () {

--- a/react-native/react/reducers/devEdit.js
+++ b/react-native/react/reducers/devEdit.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import Immutable from 'immutable'
 import type {State} from '../constants/reducer'
 import type {Action} from '../constants/types/flux'
 
@@ -15,7 +16,10 @@ function updateInKeypath (map: any, keyPath: Array<String | number>, v: any): an
         console.error('Accessing an array without a number')
       }
       return copy
+    } else if (Immutable.Iterable.isIterable(map)) {
+      return map.set(frontKey, v)
     }
+
     return {...map, [frontKey]: v}
   }
 
@@ -27,7 +31,10 @@ function updateInKeypath (map: any, keyPath: Array<String | number>, v: any): an
       console.error('Accessing an array without a number')
     }
     return copy
+  } else if (Immutable.Iterable.isIterable(map)) {
+    return map.setIn(keyPath, v)
   }
+
   return {...map, [frontKey]: updateInKeypath(map[frontKey], keyPath.slice(1), v)}
 }
 

--- a/react-native/react/reducers/tabbed-router.js
+++ b/react-native/react/reducers/tabbed-router.js
@@ -8,7 +8,6 @@ import Immutable from 'immutable'
 import routerReducer, {createRouterState} from './router'
 import {startupTab, folderTab, chatTab, peopleTab, devicesTab, moreTab, loginTab} from '../constants/tabs'
 import * as Constants from '../constants/tabbed-router'
-// $FlowFixMe ignore this import for now
 import * as LocalDebug from '../local-debug'
 import * as LoginConstants from '../constants/login'
 

--- a/react-native/react/reducers/tabbed-router.js
+++ b/react-native/react/reducers/tabbed-router.js
@@ -6,7 +6,7 @@
 
 import Immutable from 'immutable'
 import routerReducer, {createRouterState} from './router'
-import {startupTab, folderTab, chatTab, peopleTab, devicesTab, moreTab} from '../constants/tabs'
+import {startupTab, folderTab, chatTab, peopleTab, devicesTab, moreTab, loginTab} from '../constants/tabs'
 import * as Constants from '../constants/tabbed-router'
 // $FlowFixMe ignore this import for now
 import * as LocalDebug from '../local-debug'
@@ -14,7 +14,7 @@ import * as LoginConstants from '../constants/login'
 
 import type {RouterState} from './router'
 
-type TabName = startupTab | folderTab | chatTab | peopleTab | devicesTab | moreTab
+type TabName = startupTab | folderTab | chatTab | peopleTab | devicesTab | moreTab | loginTab
 type TabbedRouterState = MapADT2<'tabs', Immutable.Map<TabName, RouterState>, 'activeTab', TabName> // eslint-disable-line no-undef
 
 const emptyRouterState: RouterState = LocalDebug.overrideRouterState ? LocalDebug.overrideRouterState : createRouterState([], [])
@@ -27,7 +27,8 @@ const initialState: TabbedRouterState = Immutable.fromJS({
     [chatTab]: emptyRouterState,
     [peopleTab]: emptyRouterState,
     [devicesTab]: emptyRouterState,
-    [moreTab]: emptyRouterState
+    [moreTab]: emptyRouterState,
+    [loginTab]: emptyRouterState
   },
   activeTab: LocalDebug.overrideActiveTab ? LocalDebug.overrideActiveTab : moreTab
 })

--- a/react-native/react/reducers/tracker.js
+++ b/react-native/react/reducers/tracker.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-// $FlowIssue platform files
 import {showAllTrackers} from '../local-debug'
 
 import * as Constants from '../constants/tracker'

--- a/react-native/react/router/meta-navigator.js
+++ b/react-native/react/router/meta-navigator.js
@@ -61,7 +61,7 @@ class MetaNavigator extends Component {
 
   getComponentAtTop (rootComponent, uri) {
     let currentPath = uri.first() || Immutable.Map()
-    let nextPath = uri.rest().first() || Immutable.Map()
+    let nextPath = uri.rest().first()
     let restPath = uri.rest().rest()
     let routeStack = Immutable.List()
 
@@ -69,7 +69,7 @@ class MetaNavigator extends Component {
     let parseNextRoute = rootComponent.parseRoute
     let componentAtTop = null
 
-    while (parseNextRoute) {
+    while (parseNextRoute && currentPath) {
       const t = parseNextRoute(currentPath, uri)
       componentAtTop = {
         ...t.componentAtTop,
@@ -93,14 +93,14 @@ class MetaNavigator extends Component {
           ...t.subRoutes
         }
 
-        if (subRoutes[nextPath.get('path')]) {
+        if (nextPath && subRoutes[nextPath.get('path')]) {
           nextComponent = subRoutes[nextPath.get('path')]
           parseNextRoute = nextComponent.parseRoute
         }
       }
 
       // See if they're using an embedded parseRoute
-      if (!parseNextRoute && nextPath.get('parseRoute')) {
+      if (!parseNextRoute && nextPath && nextPath.get('parseRoute')) {
         const result = nextPath.get('parseRoute')
         parseNextRoute = () => result
       }
@@ -108,7 +108,7 @@ class MetaNavigator extends Component {
       routeStack = routeStack.push(componentAtTop)
 
       currentPath = nextPath
-      nextPath = restPath.first() || Immutable.Map()
+      nextPath = restPath.first()
       restPath = restPath.rest()
     }
 

--- a/react-native/react/util/carousel.desktop.js
+++ b/react-native/react/util/carousel.desktop.js
@@ -1,0 +1,116 @@
+/* @flow */
+/* eslint-disable react/prop-types */
+
+import React from 'react'
+import _ from 'lodash'
+
+import {Component} from '../base-react'
+import {globalStyles, globalColors} from '../styles/style-guide'
+import {Text} from '../common-adapters'
+
+export type CarouselProps = {
+  style?: ?Object,
+  itemWidth: number
+}
+
+class CarouselThing extends Component {
+  render (): ReactElement {
+    return (
+      <div style={{...this.props.style}}>
+          <Text style={{margin: 20}} type='Body'>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sagittis lacus vel augue laoreet.</Text>
+      </div>
+    )
+  }
+}
+
+function PageIndicator ({selectedIndex, itemCount, style, onClickPage}: {selectedIndex: number, itemCount: number, style: Object, onClickPage: (i: number) => void}): ReactElement {
+  const marks = _.range(itemCount).map(n => {
+    const color = (n === selectedIndex) ? globalColors.white : globalColors.lightBlue
+    return (<i className='fa fa-circle' style={{color, ...styles.pageIndicator}} onClick={() => onClickPage(n)} key={n}/>)
+  })
+  return (
+    <div style={style}>{marks}</div>
+  )
+}
+
+export default class Carousel extends Component {
+  props: CarouselProps;
+  state: {selectedIndex: number, itemCount: number};
+
+  interval: number;
+  timeout: number;
+
+  constructor (props: CarouselProps) {
+    super(props)
+    this.state = {selectedIndex: 0, itemCount: 4}
+    this.timeout = 5e3
+  }
+
+  incrementIndex () {
+    this.setState({selectedIndex: (this.state.selectedIndex + 1) % this.state.itemCount})
+  }
+
+  componentDidMount () {
+    // timer to change the state
+    this.interval = setInterval(() => this.incrementIndex(), this.timeout)
+  }
+
+  componentWillUnmount () {
+    clearInterval(this.interval)
+  }
+
+  resetIndex (i: number) {
+    this.setState({selectedIndex: i})
+    // Reset the timer so we don't change index as soon as the user clicks a page.
+    clearInterval(this.interval)
+    this.interval = setInterval(() => this.incrementIndex(), this.timeout)
+  }
+
+  render (): ReactElement {
+    const marginLeft = this.state.selectedIndex * -(this.props.itemWidth + 20)
+    const itemWidth = this.props.itemWidth
+    return (
+      <div style={{...styles.carousel, ...this.props.style}}>
+        <div style={{...globalStyles.flexBoxRow, width: itemWidth, overflow: 'visible'}}>
+          <div style={{...styles.carouselWrapper, marginLeft}}>
+            <CarouselThing style={{...styles.carouselThing, ...globalStyles.rounded, width: itemWidth}}/>
+            <CarouselThing style={{...styles.carouselThing, ...globalStyles.rounded, width: itemWidth}}/>
+            <CarouselThing style={{...styles.carouselThing, ...globalStyles.rounded, width: itemWidth}}/>
+            <CarouselThing style={{...styles.carouselThing, ...globalStyles.rounded, width: itemWidth}}/>
+          </div>
+        </div>
+        <PageIndicator style={{alignSelf: 'center'}} selectedIndex={this.state.selectedIndex} itemCount={this.state.itemCount} onClickPage={i => this.resetIndex(i)}/>
+      </div>
+    )
+  }
+}
+
+const styles = {
+  carousel: {
+    ...globalStyles.flexBoxColumn,
+    backgroundColor: globalColors.blue,
+    alignItems: 'center',
+    overflow: 'hidden'
+  },
+
+  carouselWrapper: {
+    ...globalStyles.flexBoxRow,
+    transition: 'margin-left 1s ease-in-out'
+  },
+
+  carouselThing: {
+    height: 431,
+    marginTop: 20,
+    marginBottom: 20,
+    marginRight: 20,
+    backgroundColor: globalColors.white
+  },
+
+  pageIndicator: {
+    ...globalStyles.clickable,
+    transition: 'color 1s ease-in-out',
+    fontSize: 10,
+    marginLeft: 4,
+    marginRight: 4
+  }
+}

--- a/react-native/react/util/carousel.desktop.js
+++ b/react-native/react/util/carousel.desktop.js
@@ -73,10 +73,8 @@ export default class Carousel extends Component {
       <div style={{...styles.carousel, ...this.props.style}}>
         <div style={{...globalStyles.flexBoxRow, width: itemWidth, overflow: 'visible'}}>
           <div style={{...styles.carouselWrapper, marginLeft}}>
-            <CarouselThing style={{...styles.carouselThing, ...globalStyles.rounded, width: itemWidth}}/>
-            <CarouselThing style={{...styles.carouselThing, ...globalStyles.rounded, width: itemWidth}}/>
-            <CarouselThing style={{...styles.carouselThing, ...globalStyles.rounded, width: itemWidth}}/>
-            <CarouselThing style={{...styles.carouselThing, ...globalStyles.rounded, width: itemWidth}}/>
+            {_.range(this.state.itemCount)
+              .map(i => <CarouselThing style={{...styles.carouselThing, ...globalStyles.rounded, width: itemWidth}} key={i}/>)}
           </div>
         </div>
         <PageIndicator style={{alignSelf: 'center'}} selectedIndex={this.state.selectedIndex} itemCount={this.state.itemCount} onClickPage={i => this.resetIndex(i)}/>

--- a/react-native/react/util/carousel.desktop.js
+++ b/react-native/react/util/carousel.desktop.js
@@ -6,7 +6,7 @@ import _ from 'lodash'
 
 import {Component} from '../base-react'
 import {globalStyles, globalColors} from '../styles/style-guide'
-import {Text} from '../common-adapters'
+import {Text, Icon} from '../common-adapters'
 
 export type CarouselProps = {
   style?: ?Object,
@@ -26,7 +26,7 @@ class CarouselThing extends Component {
 function PageIndicator ({selectedIndex, itemCount, style, onClickPage}: {selectedIndex: number, itemCount: number, style: Object, onClickPage: (i: number) => void}): ReactElement {
   const marks = _.range(itemCount).map(n => {
     const color = (n === selectedIndex) ? globalColors.white : globalColors.lightBlue
-    return (<i className='fa fa-circle' style={{color, ...styles.pageIndicator}} onClick={() => onClickPage(n)} key={n}/>)
+    return (<Icon type='fa-circle' style={{color, ...styles.pageIndicator}} onClick={() => onClickPage(n)} key={n}/>)
   })
   return (
     <div style={style}>{marks}</div>
@@ -111,6 +111,8 @@ const styles = {
     transition: 'color 1s ease-in-out',
     fontSize: 10,
     marginLeft: 4,
+    width: 8,
+    height: 8,
     marginRight: 4
   }
 }


### PR DESCRIPTION
## Preview
![loginform](https://cloud.githubusercontent.com/assets/594035/12684252/b402ecdc-c672-11e5-9af2-f984690e9613.gif)


This makes the boiler plate for the login page.

Basically there is a new tab called login, it doesn't show up in the top tabs on the main part of the app.

When you go there you have a carousel, and a form container. You can put anything in the form container by registering a new path for it under login/index.js (see the `intro` component for an example).

This means that do switch between pages in the login/signup form you just have to dispatch an action to update the navState.

## Dev Stuff

I added a global function to dispatch the `devEdit` function, so know you can change the store arbitrarily from the console. You can do things like:
```
devEdit(['tabbedRouter','tabs', 'tabs:loginTab', 'uri'], Immutable.List([Immutable.Map({path: 'root'}), Immutable.Map({path: 'foo'})])))
devEdit(['tabbedRouter','activeTab'], 'tabs:moreTab')
```

@keybase/react-hackers 