### PR TITLE
saltpack: improvement documentation via live examples

### DIFF
--- a/go/libkb/saltpack.go
+++ b/go/libkb/saltpack.go
@@ -121,11 +121,11 @@ func (n naclKeyring) LookupBoxPublicKey(kid []byte) saltpack.BoxPublicKey {
 	return pk
 }
 
-func (n naclKeyring) GetAllSecretKeys() []saltpack.BoxSecretKey {
+func (n naclKeyring) GetAllBoxSecretKeys() []saltpack.BoxSecretKey {
 	return []saltpack.BoxSecretKey{naclBoxSecretKey(n)}
 }
 
-func (n naclKeyring) ImportEphemeralKey(kid []byte) saltpack.BoxPublicKey {
+func (n naclKeyring) ImportBoxEphemeralKey(kid []byte) saltpack.BoxPublicKey {
 	return n.LookupBoxPublicKey(kid)
 }
 

--- a/go/libkb/saltpack_sign.go
+++ b/go/libkb/saltpack_sign.go
@@ -69,7 +69,7 @@ type saltSigner struct {
 	NaclSigningKeyPair
 }
 
-func (s saltSigner) PublicKey() saltpack.SigningPublicKey {
+func (s saltSigner) GetPublicKey() saltpack.SigningPublicKey {
 	return saltSignerPublic{key: s.Public}
 }
 

--- a/go/libkb/saltpack_verify.go
+++ b/go/libkb/saltpack_verify.go
@@ -126,12 +126,12 @@ type sigKeyring struct {
 }
 
 func (s sigKeyring) LookupSigningPublicKey(kid []byte) saltpack.SigningPublicKey {
-	if s.PublicKey() == nil {
+	if s.GetPublicKey() == nil {
 		return nil
 	}
 
-	if hmac.Equal(s.PublicKey().ToKID(), kid) {
-		return s.PublicKey()
+	if hmac.Equal(s.GetPublicKey().ToKID(), kid) {
+		return s.GetPublicKey()
 	}
 
 	return nil

--- a/go/saltpack/armor62.go
+++ b/go/saltpack/armor62.go
@@ -67,7 +67,7 @@ func CheckArmor62Frame(frame Frame, typ MessageType) (brand string, err error) {
 	return CheckArmor62(hdr, ftr, typ)
 }
 
-// CheckArmor62Frame checks that the frame matches our standard
+// CheckArmor62 checks that the frame matches our standard
 // begin/end frame
 func CheckArmor62(hdr string, ftr string, typ MessageType) (brand string, err error) {
 	brand, err = parseFrame(hdr, typ, headerMarker)

--- a/go/saltpack/armor62_decrypt.go
+++ b/go/saltpack/armor62_decrypt.go
@@ -26,7 +26,9 @@ func NewDearmor62DecryptStream(ciphertext io.Reader, kr Keyring) (*MessageKeyInf
 
 // Dearmor62DecryptOpen takes an armor62'ed, encrypted ciphertext and attempts to
 // dearmor and decrypt it, using the provided keyring. Checks that the frames in the
-// armor are as expected.
+// armor are as expected. Returns the MessageKeyInfo recovered during message
+// processing, the plaintext (if decryption succeeded), the armor branding, and
+// maybe an error if there was a failure.
 func Dearmor62DecryptOpen(ciphertext string, kr Keyring) (*MessageKeyInfo, []byte, string, error) {
 	buf := bytes.NewBufferString(ciphertext)
 	mki, s, frame, err := NewDearmor62DecryptStream(buf, kr)

--- a/go/saltpack/armor62_sign_test.go
+++ b/go/saltpack/armor62_sign_test.go
@@ -24,8 +24,8 @@ func TestSignArmor62(t *testing.T) {
 		t.Fatal(err)
 	}
 	brandCheck(t, brand)
-	if !kidEqual(skey, key.PublicKey()) {
-		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
+	if !kidEqual(skey, key.GetPublicKey()) {
+		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 	if !bytes.Equal(vmsg, msg) {
 		t.Errorf("verified msg '%x', expected '%x'", vmsg, msg)
@@ -48,7 +48,7 @@ func TestSignDetachedArmor62(t *testing.T) {
 		t.Fatal(err)
 	}
 	brandCheck(t, brand)
-	if !kidEqual(skey, key.PublicKey()) {
-		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
+	if !kidEqual(skey, key.GetPublicKey()) {
+		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 }

--- a/go/saltpack/basic/doc.go
+++ b/go/saltpack/basic/doc.go
@@ -1,0 +1,4 @@
+/*
+package basic is a basic implementation of a saltpack key/keyring configuration.
+*/
+package basic

--- a/go/saltpack/basic/key.go
+++ b/go/saltpack/basic/key.go
@@ -1,0 +1,279 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package basic
+
+import (
+	"crypto/rand"
+	"github.com/agl/ed25519"
+	"github.com/keybase/client/go/saltpack"
+	"golang.org/x/crypto/nacl/box"
+)
+
+// PublicKey is a basic implementation of a saltpack public key
+type PublicKey saltpack.RawBoxKey
+
+// SecretKey is a basic implementation of a saltpack private key
+type SecretKey struct {
+	sec saltpack.RawBoxKey
+	pub PublicKey
+}
+
+// PrecomputedSharedKey is a basic implementation of a saltpack
+// precomputed shared key, computed from a BasicPublicKey and a BasicPrivateKey
+type PrecomputedSharedKey saltpack.RawBoxKey
+
+// ToKID takes a Publickey and returns a "key ID" or a KID, which is
+// just the key itself in this implementation. It can be used to identify
+// the key.
+func (k PublicKey) ToKID() []byte {
+	return k[:]
+}
+
+// ToRawBoxKeyPointer returns a RawBoxKey from a given public key.
+// A RawBoxKey is just a bunch of bytes that can be used in
+// the lower-level Box libraries.
+func (k PublicKey) ToRawBoxKeyPointer() *saltpack.RawBoxKey {
+	ret := saltpack.RawBoxKey(k)
+	return &ret
+}
+
+// HideIdentity says not to hide the identity of this key.
+func (k PublicKey) HideIdentity() bool { return false }
+
+func generateBoxKey() (*SecretKey, error) {
+	pub, priv, err := box.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	ret := NewSecretKey(pub, priv)
+	return &ret, nil
+}
+
+// CreateEphemeralKey takes a PublicKey and returns a new ephemeral
+// secret key of the same type.
+func (k PublicKey) CreateEphemeralKey() (saltpack.BoxSecretKey, error) {
+	ret, err := generateBoxKey()
+	if err != nil {
+		return nil, err
+	}
+	return *ret, nil
+}
+
+var _ saltpack.BoxPublicKey = PublicKey{}
+
+// Box runs the NaCl box for the given sender and receiver key.
+func (k SecretKey) Box(receiver saltpack.BoxPublicKey, nonce *saltpack.Nonce, msg []byte) []byte {
+	ret := box.Seal([]byte{}, msg, (*[24]byte)(nonce), (*[32]byte)(receiver.ToRawBoxKeyPointer()), (*[32]byte)(&k.sec))
+	return ret
+}
+
+// Unbox runs the NaCl unbox operation on the given ciphertext and nonce,
+// using the receiver as the secret key.
+func (k SecretKey) Unbox(sender saltpack.BoxPublicKey, nonce *saltpack.Nonce, msg []byte) ([]byte, error) {
+	ret, ok := box.Open([]byte{}, msg, (*[24]byte)(nonce), (*[32]byte)(sender.ToRawBoxKeyPointer()), (*[32]byte)(&k.sec))
+	if !ok {
+		return nil, saltpack.ErrDecryptionFailed
+	}
+	return ret, nil
+}
+
+// GetPublicKey returns the public key that corresponds to this secret key.
+func (k SecretKey) GetPublicKey() saltpack.BoxPublicKey {
+	return k.pub
+}
+
+// Precompute computes a shared key with the passed public key.
+func (k SecretKey) Precompute(sender saltpack.BoxPublicKey) saltpack.BoxPrecomputedSharedKey {
+	var res PrecomputedSharedKey
+	box.Precompute((*[32]byte)(&res), (*[32]byte)(sender.ToRawBoxKeyPointer()), (*[32]byte)(&k.sec))
+	return res
+}
+
+// NewSecretKey makes a new SecretKey from the raw 32-byte arrays
+// the represent Box public and secret keys.
+func NewSecretKey(pub, sec *[32]byte) SecretKey {
+	return SecretKey{
+		sec: saltpack.RawBoxKey(*sec),
+		pub: PublicKey(*pub),
+	}
+}
+
+var _ saltpack.BoxSecretKey = SecretKey{}
+
+// Box runs the box computation given a precomputed key.
+func (k PrecomputedSharedKey) Box(nonce *saltpack.Nonce, msg []byte) []byte {
+	ret := box.SealAfterPrecomputation([]byte{}, msg, (*[24]byte)(nonce), (*[32]byte)(&k))
+	return ret
+}
+
+// Unbox runs the unbox computation given a precomputed key.
+func (k PrecomputedSharedKey) Unbox(nonce *saltpack.Nonce, msg []byte) ([]byte, error) {
+	ret, ok := box.OpenAfterPrecomputation([]byte{}, msg, (*[24]byte)(nonce), (*[32]byte)(&k))
+	if !ok {
+		return nil, saltpack.ErrDecryptionFailed
+	}
+	return ret, nil
+}
+
+var _ saltpack.BoxPrecomputedSharedKey = PrecomputedSharedKey{}
+
+// Keyring holds signing and box secret/public keypairs.
+type Keyring struct {
+	encKeys map[PublicKey]SecretKey
+	sigKeys map[SigningPublicKey]SigningSecretKey
+}
+
+// NewKeyring makes an empty new basic keyring.
+func NewKeyring() *Keyring {
+	return &Keyring{
+		encKeys: make(map[PublicKey]SecretKey),
+		sigKeys: make(map[SigningPublicKey]SigningSecretKey),
+	}
+}
+
+// ImportBoxKey imports an existing Box key into this keyring, from a raw byte arrays,
+// first the public, and then the secret key halves.
+func (k *Keyring) ImportBoxKey(pub, sec *[32]byte) {
+	nk := NewSecretKey(pub, sec)
+	k.encKeys[nk.pub] = nk
+}
+
+// GenerateBoxKey generates a new Box secret key and imports it into the keyring.
+func (k *Keyring) GenerateBoxKey() (*SecretKey, error) {
+	ret, err := generateBoxKey()
+	if err != nil {
+		return nil, err
+	}
+	k.encKeys[ret.pub] = *ret
+	return ret, nil
+}
+
+// GenerateSigningKey generates a signing key and import it into the keyring.
+func (k *Keyring) GenerateSigningKey() (*SigningSecretKey, error) {
+	pub, sec, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	ret := NewSigningSecretKey(pub, sec)
+	return &ret, nil
+}
+
+// ImportSigningKey imports the raw signing key into the keyring.
+func (k *Keyring) ImportSigningKey(pub *[ed25519.PublicKeySize]byte, sec *[ed25519.PrivateKeySize]byte) {
+	nk := NewSigningSecretKey(pub, sec)
+	k.sigKeys[nk.pub] = nk
+}
+
+func kidToPublicKey(kid []byte) PublicKey {
+	var tmp PublicKey
+	copy(tmp[:], kid)
+	return tmp
+}
+
+// LookupBoxSecretKey tries to find one of the secret keys in its keyring
+// given the possible key IDs. It returns the index and the key, if found, and -1
+// and nil otherwise.
+func (k *Keyring) LookupBoxSecretKey(kids [][]byte) (int, saltpack.BoxSecretKey) {
+	for i, kid := range kids {
+		if sk, ok := k.encKeys[kidToPublicKey(kid)]; ok {
+			return i, sk
+		}
+	}
+	return -1, nil
+}
+
+// LookupBoxPublicKey returns the public key that corresponds to the
+// given key ID (or "kid")
+func (k *Keyring) LookupBoxPublicKey(kid []byte) saltpack.BoxPublicKey {
+	return kidToPublicKey(kid)
+}
+
+// GetAllBoxSecretKeys returns all secret Box keys in the keyring.
+func (k *Keyring) GetAllBoxSecretKeys() []saltpack.BoxSecretKey {
+	var out []saltpack.BoxSecretKey
+	for _, v := range k.encKeys {
+		out = append(out, v)
+	}
+	return out
+}
+
+// ImportBoxEphemeralKey takes a key ID and returns a public key
+// useful for encryption/decryption.
+func (k *Keyring) ImportBoxEphemeralKey(kid []byte) saltpack.BoxPublicKey {
+	return kidToPublicKey(kid)
+}
+
+var _ saltpack.Keyring = (*Keyring)(nil)
+
+// SigningPublicKey is a basic public key used for verifying signatures.
+// It's just a wrapper around an array of bytes.
+type SigningPublicKey saltpack.RawBoxKey
+
+type rawSigningSecretKey [ed25519.PrivateKeySize]byte
+
+// SigningSecretKey is a basic secret key used for creating signatures
+// and also for verifying signatures. It's a wrapper around an array of bytes
+// and also the corresponding public key.
+type SigningSecretKey struct {
+	pub SigningPublicKey
+	sec rawSigningSecretKey
+}
+
+// Sign runs the NaCl signature scheme on the input message, returning
+// a signature.
+func (k SigningSecretKey) Sign(msg []byte) (ret []byte, err error) {
+	tmp := ed25519.Sign((*[ed25519.PrivateKeySize]byte)(&k.sec), msg)
+	return (*tmp)[:], nil
+}
+
+var _ saltpack.SigningSecretKey = SigningSecretKey{}
+
+// ToKID returns the key id for this signing key. It just returns
+// the key itself.
+func (k SigningPublicKey) ToKID() []byte {
+	return k[:]
+}
+
+// GetPublicKey gets the public key that corresponds to this
+// secret signing key
+func (k SigningSecretKey) GetPublicKey() saltpack.SigningPublicKey {
+	return k.pub
+}
+
+// Verify runs the NaCl verification routine on the given msg / sig
+// input.
+func (k SigningPublicKey) Verify(msg []byte, sig []byte) error {
+	var tmp [ed25519.SignatureSize]byte
+	copy(tmp[:], sig)
+	ok := ed25519.Verify((*[ed25519.PublicKeySize]byte)(&k), msg, &tmp)
+	if !ok {
+		return saltpack.ErrBadSignature
+	}
+	return nil
+}
+
+var _ saltpack.SigningPublicKey = SigningPublicKey{}
+
+// NewSigningSecretKey creates a new baisic signing key fromm the
+// input raw byte arrays.
+func NewSigningSecretKey(pub *[ed25519.PublicKeySize]byte, sec *[ed25519.PrivateKeySize]byte) SigningSecretKey {
+	return SigningSecretKey{
+		sec: rawSigningSecretKey(*sec),
+		pub: SigningPublicKey(*pub),
+	}
+}
+
+func kidToSigningPublicKey(kid []byte) SigningPublicKey {
+	var tmp SigningPublicKey
+	copy(tmp[:], kid)
+	return tmp
+}
+
+// LookupSigningPublicKey turns the given key ID ("kid") into a corresponding
+// signing public key.
+func (k *Keyring) LookupSigningPublicKey(kid []byte) saltpack.SigningPublicKey {
+	return kidToSigningPublicKey(kid)
+}
+
+var _ saltpack.SigKeyring = (*Keyring)(nil)

--- a/go/saltpack/basic/key_test.go
+++ b/go/saltpack/basic/key_test.go
@@ -1,0 +1,63 @@
+package basic
+
+import (
+	"bytes"
+	"crypto/rand"
+	"github.com/keybase/client/go/saltpack"
+	"testing"
+)
+
+func randomMsg(t *testing.T, sz int) []byte {
+	out := make([]byte, sz)
+	if _, err := rand.Read(out); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func TestBasicBox(t *testing.T) {
+	kr := NewKeyring()
+	k1, err := kr.GenerateBoxKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	k2, err := kr.GenerateBoxKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := randomMsg(t, 1024)
+	text, err := saltpack.EncryptArmor62Seal(msg, k1, []saltpack.BoxPublicKey{k2.GetPublicKey()}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, msg2, _, err := saltpack.Dearmor62DecryptOpen(text, kr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(msg, msg2) {
+		t.Fatal("failed to recover message")
+	}
+}
+
+func TestBasicSign(t *testing.T) {
+	kr := NewKeyring()
+	k1, err := kr.GenerateSigningKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := randomMsg(t, 1024)
+	sig, err := saltpack.SignArmor62(msg, k1, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pk, msg2, _, err := saltpack.Dearmor62Verify(sig, kr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(msg, msg2) {
+		t.Fatal("msg payload mismatch")
+	}
+	if !saltpack.PublicSigningKeyEqual(k1.GetPublicKey(), pk) {
+		t.Fatal("public signing key wasn't right")
+	}
+}

--- a/go/saltpack/const.go
+++ b/go/saltpack/const.go
@@ -31,8 +31,13 @@ var SaltpackCurrentVersion = Version{Major: 1, Minor: 0}
 // encryptionBlockSize is by default 1MB and can't currently be tweaked.
 const encryptionBlockSize int = 1048576
 
+// EncryptionArmorString is included in armor headers for encrypted messages.
 const EncryptionArmorString = "ENCRYPTED MESSAGE"
+
+// SignedArmorString is included in armor headers for signed messages
 const SignedArmorString = "SIGNED MESSAGE"
+
+// DetachedArmorString is included in armor headers for detached signatures.
 const DetachedSignatureArmorString = "DETACHED SIGNATURE"
 
 // SaltpackFormatName is the publicly advertised name of the format,

--- a/go/saltpack/decrypt.go
+++ b/go/saltpack/decrypt.go
@@ -177,7 +177,7 @@ func (ds *decryptStream) tryVisibleReceivers(hdr *encryptionHeader, ephemeralKey
 }
 
 func (ds *decryptStream) tryHiddenReceivers(hdr *encryptionHeader, ephemeralKey BoxPublicKey) (BoxSecretKey, *SymmetricKey, int, error) {
-	secretKeys := ds.ring.GetAllSecretKeys()
+	secretKeys := ds.ring.GetAllBoxSecretKeys()
 
 	for _, r := range hdr.Receivers {
 		if len(r.ReceiverKID) == 0 {
@@ -212,7 +212,7 @@ func (ds *decryptStream) processEncryptionHeader(hdr *encryptionHeader) error {
 		return err
 	}
 
-	ephemeralKey := ds.ring.ImportEphemeralKey(hdr.Ephemeral)
+	ephemeralKey := ds.ring.ImportBoxEphemeralKey(hdr.Ephemeral)
 	if ephemeralKey == nil {
 		return ErrBadEphemeralKey
 	}

--- a/go/saltpack/encrypt_test.go
+++ b/go/saltpack/encrypt_test.go
@@ -48,7 +48,7 @@ func (r *keyring) insert(k BoxSecretKey) {
 }
 
 func (r *keyring) insertSigningKey(k SigningSecretKey) {
-	r.sigKeys[hex.EncodeToString(k.PublicKey().ToKID())] = k
+	r.sigKeys[hex.EncodeToString(k.GetPublicKey().ToKID())] = k
 }
 
 func (r *keyring) LookupBoxPublicKey(kid []byte) BoxPublicKey {
@@ -65,10 +65,10 @@ func (r *keyring) LookupSigningPublicKey(kid []byte) SigningPublicKey {
 	if !ok {
 		return nil
 	}
-	return key.PublicKey()
+	return key.GetPublicKey()
 }
 
-func (r *keyring) ImportEphemeralKey(kid []byte) BoxPublicKey {
+func (r *keyring) ImportBoxEphemeralKey(kid []byte) BoxPublicKey {
 	ret := &boxPublicKey{}
 	if len(kid) != len(ret.key) {
 		return nil
@@ -77,7 +77,7 @@ func (r *keyring) ImportEphemeralKey(kid []byte) BoxPublicKey {
 	return ret
 }
 
-func (r *keyring) GetAllSecretKeys() (ret []BoxSecretKey) {
+func (r *keyring) GetAllBoxSecretKeys() (ret []BoxSecretKey) {
 	if r.iterable {
 		for _, v := range r.keys {
 			ret = append(ret, v)
@@ -334,10 +334,10 @@ func testRealEncryptor(t *testing.T, sz int) {
 	if mki.ReceiverIsAnon {
 		t.Fatal("receiver shouldn't be anon")
 	}
-	if !publicKeyEqual(sndr.GetPublicKey(), mki.SenderKey) {
+	if !PublicKeyEqual(sndr.GetPublicKey(), mki.SenderKey) {
 		t.Fatal("got wrong sender key")
 	}
-	if !publicKeyEqual(receivers[0], mki.ReceiverKey.GetPublicKey()) {
+	if !PublicKeyEqual(receivers[0], mki.ReceiverKey.GetPublicKey()) {
 		t.Fatal("wrong receiver key")
 	}
 	if mki.NumAnonReceivers != 0 {
@@ -1071,7 +1071,7 @@ func TestAllAnonymous(t *testing.T) {
 	if !mki.ReceiverIsAnon {
 		t.Fatal("receiver should be anon")
 	}
-	if !publicKeyEqual(receivers[5], mki.ReceiverKey.GetPublicKey()) {
+	if !PublicKeyEqual(receivers[5], mki.ReceiverKey.GetPublicKey()) {
 		t.Fatal("wrong receiver key")
 	}
 	if mki.NumAnonReceivers != 8 {

--- a/go/saltpack/errors.go
+++ b/go/saltpack/errors.go
@@ -59,6 +59,9 @@ var (
 
 	// ErrBadSignature is returned when verification of a block fails.
 	ErrBadSignature = errors.New("invalid signature")
+
+	// ErrDecryptionFailed is returned when a decryption fails
+	ErrDecryptionFailed = errors.New("decryption failed")
 )
 
 // ErrBadTag is generated when a payload hash doesn't match the hash

--- a/go/saltpack/example_test.go
+++ b/go/saltpack/example_test.go
@@ -1,0 +1,114 @@
+package saltpack_test
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/keybase/client/go/saltpack"
+	"github.com/keybase/client/go/saltpack/basic"
+	"io"
+	"os"
+)
+
+func ExampleEncryptArmor62Seal() {
+
+	var err error
+
+	// Make a new Keyring, initialized to be empty
+	basicKeyring := basic.NewKeyring()
+	var keyring saltpack.Keyring
+	keyring = basicKeyring
+
+	// The test message
+	msg := []byte("The Magic Words are Squeamish Ossifrage")
+
+	// Make a secret key for the sender
+	var sender saltpack.BoxSecretKey
+	sender, err = basicKeyring.GenerateBoxKey()
+	if err != nil {
+		return
+	}
+
+	// And one for the receiver
+	var receiver saltpack.BoxSecretKey
+	receiver, err = basicKeyring.GenerateBoxKey()
+	if err != nil {
+		return
+	}
+
+	// AllReceivers can contain more receivers (like the sender)
+	// but for now, just the one.
+	var ciphertext string
+	allReceivers := []saltpack.BoxPublicKey{receiver.GetPublicKey()}
+	ciphertext, err = saltpack.EncryptArmor62Seal(msg, sender, allReceivers, "")
+	if err != nil {
+		return
+	}
+
+	// The decrypted message
+	var msg2 []byte
+	_, msg2, _, err = saltpack.Dearmor62DecryptOpen(ciphertext, keyring)
+	if err != nil {
+		return
+	}
+
+	fmt.Println(string(msg2))
+
+	// Output:
+	// The Magic Words are Squeamish Ossifrage
+}
+
+func ExampleNewEncryptArmor62Stream() {
+
+	var err error
+
+	// Make a new Keyring, initialized to be empty
+	basicKeyring := basic.NewKeyring()
+	var keyring saltpack.Keyring
+	keyring = basicKeyring
+
+	// The test message
+	plaintext := "The Magic Words are Squeamish Ossifrage"
+
+	// Make a secret key for the sender
+	var sender saltpack.BoxSecretKey
+	sender, err = basicKeyring.GenerateBoxKey()
+	if err != nil {
+		return
+	}
+
+	// And one for the receiver
+	var receiver saltpack.BoxSecretKey
+	receiver, err = basicKeyring.GenerateBoxKey()
+	if err != nil {
+		return
+	}
+
+	// AllReceivers can contain more receivers (like the sender)
+	// but for now, just the one.
+	var output bytes.Buffer
+	allReceivers := []saltpack.BoxPublicKey{receiver.GetPublicKey()}
+	var input io.WriteCloser
+	input, err = saltpack.NewEncryptArmor62Stream(&output, sender, allReceivers, "")
+	if err != nil {
+		return
+	}
+	// Write plaintext into the returned WriteCloser stream
+	input.Write([]byte(plaintext))
+	// And close when we're done
+	input.Close()
+
+	// The decrypted message
+	var plaintextOutput io.Reader
+	_, plaintextOutput, _, err = saltpack.NewDearmor62DecryptStream(&output, keyring)
+	if err != nil {
+		return
+	}
+
+	// Copy all of the data out of the output decrypted stream, and into standard
+	// output, here for testing / comparison purposes.
+	io.Copy(os.Stdout, plaintextOutput)
+	os.Stdout.Write([]byte{'\n'})
+
+	// Output:
+	// The Magic Words are Squeamish Ossifrage
+}

--- a/go/saltpack/frame.go
+++ b/go/saltpack/frame.go
@@ -41,9 +41,12 @@ func makeFrame(which headerOrFooterMarker, typ MessageType, brand string) string
 	return strings.Join(words, " ")
 }
 
+// MakeArmorHeader makes the armor header for the message type for the given "brand"
 func MakeArmorHeader(typ MessageType, brand string) string {
 	return makeFrame(headerMarker, typ, brand)
 }
+
+// MakeArmorFooter makes the armor footer for the message type for the given "brand"
 func MakeArmorFooter(typ MessageType, brand string) string {
 	return makeFrame(footerMarker, typ, brand)
 }

--- a/go/saltpack/key.go
+++ b/go/saltpack/key.go
@@ -88,8 +88,8 @@ type SigningSecretKey interface {
 	// Sign signs message with this secret key.
 	Sign(message []byte) ([]byte, error)
 
-	// PublicKey gets the public key associated with this secret key.
-	PublicKey() SigningPublicKey
+	// GetPublicKey gets the public key associated with this secret key.
+	GetPublicKey() SigningPublicKey
 }
 
 // SigningPublicKey is a public NaCl key that can verify
@@ -117,12 +117,12 @@ type Keyring interface {
 
 	// GetAllSecretKeys returns all keys, needed if we want to support
 	// "hidden" receivers via trial and error
-	GetAllSecretKeys() []BoxSecretKey
+	GetAllBoxSecretKeys() []BoxSecretKey
 
 	// ImportEphemeralKey imports the ephemeral key into
 	// BoxPublicKey format. This key has never been seen before, so
 	// will be ephemeral.
-	ImportEphemeralKey(kid []byte) BoxPublicKey
+	ImportBoxEphemeralKey(kid []byte) BoxPublicKey
 }
 
 // SigKeyring is an interface used during verification to find
@@ -132,8 +132,13 @@ type SigKeyring interface {
 	LookupSigningPublicKey(kid []byte) SigningPublicKey
 }
 
-// publicKeyEqual returns true if the two public keys are equal.
-func publicKeyEqual(pk1, pk2 BoxPublicKey) bool {
+// PublicKeyEqual returns true if the two public keys are equal.
+func PublicKeyEqual(pk1, pk2 BoxPublicKey) bool {
+	return kidEqual(pk1, pk2)
+}
+
+// PublicSigningKeyEqual returns true if the two public signing keys are equal
+func PublicSigningKeyEqual(pk1, pk2 SigningPublicKey) bool {
 	return kidEqual(pk1, pk2)
 }
 

--- a/go/saltpack/sign_stream.go
+++ b/go/saltpack/sign_stream.go
@@ -24,7 +24,7 @@ func newSignAttachedStream(w io.Writer, signer SigningSecretKey) (*signAttachedS
 		return nil, ErrInvalidParameter{message: "no signing key provided"}
 	}
 
-	header, err := newSignatureHeader(signer.PublicKey(), MessageTypeAttachedSignature)
+	header, err := newSignatureHeader(signer.GetPublicKey(), MessageTypeAttachedSignature)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func newSignDetachedStream(w io.Writer, signer SigningSecretKey) (*signDetachedS
 		return nil, ErrInvalidParameter{message: "no signing key provided"}
 	}
 
-	header, err := newSignatureHeader(signer.PublicKey(), MessageTypeDetachedSignature)
+	header, err := newSignatureHeader(signer.GetPublicKey(), MessageTypeDetachedSignature)
 	if err != nil {
 		return nil, err
 	}

--- a/go/saltpack/sign_test.go
+++ b/go/saltpack/sign_test.go
@@ -63,19 +63,19 @@ func (s *sigPrivKey) Sign(message []byte) ([]byte, error) {
 	return sig[:], nil
 }
 
-func (s *sigPrivKey) PublicKey() SigningPublicKey {
+func (s *sigPrivKey) GetPublicKey() SigningPublicKey {
 	return s.public
 }
 
 type sigErrKey struct{}
 
 func (s *sigErrKey) Sign(message []byte) ([]byte, error) { return nil, errors.New("sign error") }
-func (s *sigErrKey) PublicKey() SigningPublicKey         { return &sigPubKey{} }
+func (s *sigErrKey) GetPublicKey() SigningPublicKey      { return &sigPubKey{} }
 
 type sigNilPubKey struct{}
 
 func (s *sigNilPubKey) Sign(message []byte) ([]byte, error) { return nil, errors.New("sign error") }
-func (s *sigNilPubKey) PublicKey() SigningPublicKey         { return nil }
+func (s *sigNilPubKey) GetPublicKey() SigningPublicKey      { return nil }
 
 func TestSign(t *testing.T) {
 	msg := randomMsg(t, 128)
@@ -122,8 +122,8 @@ func testSignAndVerify(t *testing.T, message []byte) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !kidEqual(skey, key.PublicKey()) {
-		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
+	if !kidEqual(skey, key.GetPublicKey()) {
+		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 	if !bytes.Equal(vmsg, message) {
 		t.Errorf("verified msg '%x', expected '%x'", vmsg, message)
@@ -155,8 +155,8 @@ func TestSignEmptyStream(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !kidEqual(skey, key.PublicKey()) {
-		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
+	if !kidEqual(skey, key.GetPublicKey()) {
+		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 	if len(vmsg) != 0 {
 		t.Errorf("verified msg '%x', expected empty", vmsg)
@@ -270,8 +270,8 @@ func TestSignDetached(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !kidEqual(skey, key.PublicKey()) {
-		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
+	if !kidEqual(skey, key.GetPublicKey()) {
+		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 }
 
@@ -427,8 +427,8 @@ func TestSignCorruptHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !kidEqual(skey, key.PublicKey()) {
-		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
+	if !kidEqual(skey, key.GetPublicKey()) {
+		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 	if !bytes.Equal(vmsg, msg) {
 		t.Errorf("verified msg '%x', expected '%x'", vmsg, msg)
@@ -516,8 +516,8 @@ func TestSignDetachedCorruptHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !kidEqual(skey, key.PublicKey()) {
-		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
+	if !kidEqual(skey, key.GetPublicKey()) {
+		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 
 	// change the message type to attached

--- a/go/saltpack/tweakable_signer_test.go
+++ b/go/saltpack/tweakable_signer_test.go
@@ -32,7 +32,7 @@ func newTestSignStream(w io.Writer, signer SigningSecretKey, opts testSignOption
 		return nil, ErrInvalidParameter{message: "no signing key provided"}
 	}
 
-	header, err := newSignatureHeader(signer.PublicKey(), MessageTypeAttachedSignature)
+	header, err := newSignatureHeader(signer.GetPublicKey(), MessageTypeAttachedSignature)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func testTweakSignDetached(plaintext []byte, signer SigningSecretKey, opts testS
 	if signer == nil {
 		return nil, ErrInvalidParameter{message: "no signing key provided"}
 	}
-	header, err := newSignatureHeader(signer.PublicKey(), MessageTypeDetachedSignature)
+	header, err := newSignatureHeader(signer.GetPublicKey(), MessageTypeDetachedSignature)
 	if err != nil {
 		return nil, err
 	}

--- a/go/saltpack/verify_test.go
+++ b/go/saltpack/verify_test.go
@@ -22,8 +22,8 @@ func TestVerify(t *testing.T) {
 		t.Logf("signed msg: %x", smsg)
 		t.Fatal(err)
 	}
-	if !kidEqual(skey, key.PublicKey()) {
-		t.Errorf("sender key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
+	if !kidEqual(skey, key.GetPublicKey()) {
+		t.Errorf("sender key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 	if !bytes.Equal(msg, in) {
 		t.Errorf("verified msg '%x', expected '%x'", msg, in)
@@ -48,8 +48,8 @@ func TestVerifyConcurrent(t *testing.T) {
 				t.Logf("signed msg: %x", smsg)
 				t.Error(err)
 			}
-			if !kidEqual(skey, key.PublicKey()) {
-				t.Errorf("sender key %x, expected %x", skey.ToKID(), key.PublicKey().ToKID())
+			if !kidEqual(skey, key.GetPublicKey()) {
+				t.Errorf("sender key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 			}
 			if !bytes.Equal(msg, in) {
 				t.Errorf("verified msg '%x', expected '%x'", msg, in)


### PR DESCRIPTION
- live examples for encrypt/decrypt in stream/fixed
- make a new "basic" key/keyring implementation
- fix some doc/style issues with existig saltpack
  - golint again
  - republicize PublicKeyEqual
  - Rename SigningSecretKey PublicKey() -> GetPublicKey(), to be consistent with BoxSecretKey