### PR TITLE
saltpack: a signing example

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -9,6 +9,8 @@ vet:
 
 lint:
 	golint ./... | grep -v ^vendor | grep -v ^protocol | grep -v comment | grep -v KeysById | grep -v "error should be the last type" || echo "Lint-free!"
+	# Strict linting on saltpack
+	golint saltpack/...
 
 # to run splint, first do this:  go get stathat.com/c/splint
 splint:

--- a/go/saltpack/armor62_sign_test.go
+++ b/go/saltpack/armor62_sign_test.go
@@ -24,7 +24,7 @@ func TestSignArmor62(t *testing.T) {
 		t.Fatal(err)
 	}
 	brandCheck(t, brand)
-	if !kidEqual(skey, key.GetPublicKey()) {
+	if !PublicKeyEqual(skey, key.GetPublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 	if !bytes.Equal(vmsg, msg) {
@@ -48,7 +48,7 @@ func TestSignDetachedArmor62(t *testing.T) {
 		t.Fatal(err)
 	}
 	brandCheck(t, brand)
-	if !kidEqual(skey, key.GetPublicKey()) {
+	if !PublicKeyEqual(skey, key.GetPublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 }

--- a/go/saltpack/basic/doc.go
+++ b/go/saltpack/basic/doc.go
@@ -1,4 +1,4 @@
 /*
-package basic is a basic implementation of a saltpack key/keyring configuration.
+Package basic is a basic implementation of a saltpack key/keyring configuration.
 */
 package basic

--- a/go/saltpack/basic/key_test.go
+++ b/go/saltpack/basic/key_test.go
@@ -57,7 +57,7 @@ func TestBasicSign(t *testing.T) {
 	if !bytes.Equal(msg, msg2) {
 		t.Fatal("msg payload mismatch")
 	}
-	if !saltpack.PublicSigningKeyEqual(k1.GetPublicKey(), pk) {
+	if !saltpack.PublicKeyEqual(k1.GetPublicKey(), pk) {
 		t.Fatal("public signing key wasn't right")
 	}
 }

--- a/go/saltpack/const.go
+++ b/go/saltpack/const.go
@@ -37,7 +37,7 @@ const EncryptionArmorString = "ENCRYPTED MESSAGE"
 // SignedArmorString is included in armor headers for signed messages
 const SignedArmorString = "SIGNED MESSAGE"
 
-// DetachedArmorString is included in armor headers for detached signatures.
+// DetachedSignatureArmorString is included in armor headers for detached signatures.
 const DetachedSignatureArmorString = "DETACHED SIGNATURE"
 
 // SaltpackFormatName is the publicly advertised name of the format,

--- a/go/saltpack/key.go
+++ b/go/saltpack/key.go
@@ -33,9 +33,8 @@ func symmetricKeyFromSlice(slice []byte) (*SymmetricKey, error) {
 	return &result, nil
 }
 
-// kidExtractor key types can output a key ID corresponding to the
-// key.
-type kidExtractor interface {
+// BasePublicKey types can output a key ID corresponding to the key.
+type BasePublicKey interface {
 	// ToKID outputs the "key ID" that corresponds to this key.
 	// You can do whatever you'd like here, but probably it makes sense just
 	// to output the public key as is.
@@ -44,7 +43,7 @@ type kidExtractor interface {
 
 // BoxPublicKey is an generic interface to NaCl's public key Box function.
 type BoxPublicKey interface {
-	kidExtractor
+	BasePublicKey
 
 	// ToRawBoxKeyPointer returns this public key as a *[32]byte,
 	// for use with nacl.box.Seal
@@ -95,7 +94,7 @@ type SigningSecretKey interface {
 // SigningPublicKey is a public NaCl key that can verify
 // signatures.
 type SigningPublicKey interface {
-	kidExtractor
+	BasePublicKey
 
 	// Verify verifies that signature is a valid signature of message for
 	// this public key.
@@ -133,16 +132,6 @@ type SigKeyring interface {
 }
 
 // PublicKeyEqual returns true if the two public keys are equal.
-func PublicKeyEqual(pk1, pk2 BoxPublicKey) bool {
-	return kidEqual(pk1, pk2)
-}
-
-// PublicSigningKeyEqual returns true if the two public signing keys are equal
-func PublicSigningKeyEqual(pk1, pk2 SigningPublicKey) bool {
-	return kidEqual(pk1, pk2)
-}
-
-// kidEqual return true if the KIDs for two keys are equal.
-func kidEqual(k1, k2 kidExtractor) bool {
+func PublicKeyEqual(k1, k2 BasePublicKey) bool {
 	return hmac.Equal(k1.ToKID(), k2.ToKID())
 }

--- a/go/saltpack/sign_test.go
+++ b/go/saltpack/sign_test.go
@@ -122,7 +122,7 @@ func testSignAndVerify(t *testing.T, message []byte) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !kidEqual(skey, key.GetPublicKey()) {
+	if !PublicKeyEqual(skey, key.GetPublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 	if !bytes.Equal(vmsg, message) {
@@ -155,7 +155,7 @@ func TestSignEmptyStream(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !kidEqual(skey, key.GetPublicKey()) {
+	if !PublicKeyEqual(skey, key.GetPublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 	if len(vmsg) != 0 {
@@ -270,7 +270,7 @@ func TestSignDetached(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !kidEqual(skey, key.GetPublicKey()) {
+	if !PublicKeyEqual(skey, key.GetPublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 }
@@ -427,7 +427,7 @@ func TestSignCorruptHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !kidEqual(skey, key.GetPublicKey()) {
+	if !PublicKeyEqual(skey, key.GetPublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 	if !bytes.Equal(vmsg, msg) {
@@ -516,7 +516,7 @@ func TestSignDetachedCorruptHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !kidEqual(skey, key.GetPublicKey()) {
+	if !PublicKeyEqual(skey, key.GetPublicKey()) {
 		t.Errorf("signer key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 

--- a/go/saltpack/verify_test.go
+++ b/go/saltpack/verify_test.go
@@ -22,7 +22,7 @@ func TestVerify(t *testing.T) {
 		t.Logf("signed msg: %x", smsg)
 		t.Fatal(err)
 	}
-	if !kidEqual(skey, key.GetPublicKey()) {
+	if !PublicKeyEqual(skey, key.GetPublicKey()) {
 		t.Errorf("sender key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 	}
 	if !bytes.Equal(msg, in) {
@@ -48,7 +48,7 @@ func TestVerifyConcurrent(t *testing.T) {
 				t.Logf("signed msg: %x", smsg)
 				t.Error(err)
 			}
-			if !kidEqual(skey, key.GetPublicKey()) {
+			if !PublicKeyEqual(skey, key.GetPublicKey()) {
 				t.Errorf("sender key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
 			}
 			if !bytes.Equal(msg, in) {


### PR DESCRIPTION
- also fix PublicKeyEqual() so that it works with either key
- fixup comments
- enforce strict linting for saltpack
- fix strict linting for saltpack