### PR TITLE
Detached pgp verify was broken for messages shorter than 100 bytes

### DIFF
--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Detached pgp verify was broken for messages shorter than 100 bytes (PR: keybase/client#1862)
 - Only restart driver if necessary when upgrading on Windows (PR: keybase/client#1842)
 - Fix formatting for certain errors (PR: keybase/client#1830)
 - Cache InputCanceled from SecretUI from KBFS crypto ops (PR: keybase/client#1795)

--- a/go/engine/pgp_verify_test.go
+++ b/go/engine/pgp_verify_test.go
@@ -12,7 +12,7 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol"
 )
 
-func TestPGPVerify(t *testing.T) {
+func doVerify(t *testing.T, msg string) {
 	tc := SetupEngineTest(t, "PGPVerify")
 	defer tc.Cleanup()
 	fu := createFakeUserWithPGPSibkey(tc)
@@ -23,8 +23,6 @@ func TestPGPVerify(t *testing.T) {
 		LogUI:      tc.G.UI.GetLogUI(),
 		PgpUI:      &TestPgpUI{},
 	}
-
-	msg := "If you wish to stop receiving notifications from this topic, please click or visit the link below to unsubscribe:"
 
 	// create detached sig
 	detached := sign(ctx, tc, msg, keybase1.SignMode_DETACHED)
@@ -72,6 +70,16 @@ func TestPGPVerify(t *testing.T) {
 	// extra credit:
 	// encrypt a message for another user and sign it
 	// verify that attached signature
+}
+
+func TestPGPVerify(t *testing.T) {
+	msg := "If you wish to stop receiving notifications from this topic, please click or visit the link below to unsubscribe:"
+	doVerify(t, msg)
+}
+
+func TestPGPVerifyShortMsg(t *testing.T) {
+	msg := "less than 100 characters"
+	doVerify(t, msg)
 }
 
 func sign(ctx *Context, tc libkb.TestContext, msg string, mode keybase1.SignMode) string {

--- a/packaging/windows/build_prerelease.cmd
+++ b/packaging/windows/build_prerelease.cmd
@@ -1,4 +1,5 @@
 :: Build keybase.exe with prerelease options
+cd %GOPATH%\src\github.com\keybase\client\go\keybase
 set GOARCH=386
 go generate
 for /f %%i in ('winresource.exe -cb') do set KEYBASE_BUILD=%%i
@@ -6,12 +7,12 @@ echo %KEYBASE_BUILD%
 go build -a -tags "prerelease production" -ldflags="-X github.com/keybase/client/go/libkb.CustomBuild=%KEYBASE_BUILD%"
 
 :: Then build kbfsdokan
-cd %GOPATH%\src\github.com\keybase\kbfs\kbfsdokan
-go build -tags "production prerelease"
+::cd %GOPATH%\src\github.com\keybase\kbfs\kbfsdokan
+::go build -tags "production prerelease"
 
-Then the desktop:
-cd %GOPATH%\src\github.com\keybase\client\react-native\react
-npm i
-cd %GOPATH%\src\github.com\keybase\client\desktop
-npm i
-node package.js --arch ia32 --platform win32
+:: Then the desktop:
+::cd %GOPATH%\src\github.com\keybase\client\react-native\react
+::npm i
+::cd %GOPATH%\src\github.com\keybase\client\desktop
+::npm i
+::node package.js --arch ia32 --platform win32


### PR DESCRIPTION
As per https://keybase.atlassian.net/browse/CORE-2267
`C:\Program Files\Keybase>keybase pgp verify -d sig1.txt -i msg1.txt`
`   ERROR unexpected EOF`
@maxtaco @oconnor663 