### PR TITLE
Clear node_modules before packaging

### DIFF
--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -130,6 +130,7 @@ package_electron() {
   cd $client_dir
   cd desktop
 
+  rm -rf node_modules
   npm install
   npm run package -- --appVersion="$app_version" --comment="$comment"
   rsync -av release/darwin-x64/Keybase-darwin-x64 $build_dir


### PR DESCRIPTION
npm can get confused if packages get left in node_modules, so need to clear before re-packaging