### PR TITLE
Updater will attempt privileged remove (on OS X)

### DIFF
--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -850,3 +850,7 @@ func (e *Env) GetVDebugSetting() string {
 		func() string { return "" },
 	)
 }
+
+func (e *Env) GetRunModeAsString() string {
+	return string(e.GetRunMode())
+}

--- a/go/updater/updater.go
+++ b/go/updater/updater.go
@@ -46,6 +46,7 @@ type Config interface {
 	SetUpdatePreferenceSkip(v string) error
 	SetUpdatePreferenceSnoozeUntil(t keybase1.Time) error
 	SetUpdateLastChecked(t keybase1.Time) error
+	GetRunModeAsString() string
 }
 
 func NewUpdater(options keybase1.UpdateOptions, source sources.UpdateSource, config Config, log logger.Logger) *Updater {
@@ -257,7 +258,7 @@ func (u *Updater) downloadAsset(asset keybase1.Asset) (fpath string, cached bool
 	}
 
 	savePath := fmt.Sprintf("%s.download", fpath)
-	if _, err = os.Stat(savePath); err == nil {
+	if _, ferr := os.Stat(savePath); ferr == nil {
 		u.log.Info("Removing existing partial download: %s", savePath)
 		err = os.Remove(savePath)
 		if err != nil {
@@ -305,13 +306,21 @@ func (u *Updater) save(savePath string, resp http.Response) error {
 }
 
 func (u *Updater) unpack(filename string) (string, error) {
-	u.log.Debug("unpack %s", filename)
+	u.log.Debug("Unpack %s", filename)
 	if !strings.HasSuffix(filename, ".zip") {
-		u.log.Debug("File isn't compressed, so won't unzip: %q", filename)
-		return filename, nil
+		u.log.Errorf("Don't know how to unpack: %s", filename)
+		return "", nil
 	}
 
 	unzipDestination := unzipDestination(filename)
+	if _, ferr := os.Stat(unzipDestination); ferr == nil {
+		u.log.Info("Removing existing unzip destination: %s", unzipDestination)
+		err := os.RemoveAll(unzipDestination)
+		if err != nil {
+			return "", nil
+		}
+	}
+
 	u.log.Info("Unzipping %q -> %q", filename, unzipDestination)
 	err := zip.Unzip(filename, unzipDestination)
 	if err != nil {
@@ -360,9 +369,18 @@ func (u *Updater) apply(src string, dest string) (tmpPath string, err error) {
 			return
 		}
 		u.log.Info("Moving (existing) %s to %s", dest, tmpPath)
+
 		err = os.Rename(dest, tmpPath)
+		// If we error trying to remove existing destination, let's try using
+		// a platform dependent (privileged) way.
+		// To test this (on OS X), chown -R root:admin /Applications/Keybase and
+		// perform an update.
 		if err != nil {
-			return
+			platformRemoveErr := u.removeApp(dest)
+			if platformRemoveErr != nil {
+				// We failed to remove via platform too, return (original) err
+				return
+			}
 		}
 	}
 
@@ -504,21 +522,21 @@ func (u *Updater) promptForUpdateAction(ui UI, update keybase1.Update) (err erro
 	return
 }
 
-func (u *Updater) applyZip(localPath string) (tmpPath string, err error) {
+func (u *Updater) applyZip(localPath string, destinationPath string) (tmpPath string, err error) {
 	unzipPath, err := u.unpack(localPath)
 	if err != nil {
 		return
 	}
 	u.log.Info("Unzip path: %s", unzipPath)
 
-	baseName := filepath.Base(u.options.DestinationPath)
+	baseName := filepath.Base(destinationPath)
 	sourcePath := filepath.Join(unzipPath, baseName)
-	err = u.checkUpdate(sourcePath, u.options.DestinationPath)
+	err = u.checkUpdate(sourcePath, destinationPath)
 	if err != nil {
 		return
 	}
 
-	tmpPath, err = u.apply(sourcePath, u.options.DestinationPath)
+	tmpPath, err = u.apply(sourcePath, destinationPath)
 	if err != nil {
 		return
 	}

--- a/go/updater/updater_default.go
+++ b/go/updater/updater_default.go
@@ -18,3 +18,7 @@ func openApplication(applicationPath string) error {
 func (u *Updater) applyUpdate(localPath string) (string, error) {
 	return "", nil
 }
+
+func (u *Updater) removeApp(appPath string) error {
+	return fmt.Errorf("Remove app is unsupported on this platform")
+}

--- a/go/updater/updater_osx.go
+++ b/go/updater/updater_osx.go
@@ -6,21 +6,18 @@
 package updater
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
-	"syscall"
+	"strconv"
 	"time"
 )
 
 func (u *Updater) checkPlatformSpecificUpdate(sourcePath string, destinationPath string) error {
-	destFileInfo, err := os.Lstat(destinationPath)
-	if err != nil {
-		return err
-	}
-
 	//
-	// Get the uid, gid of the destination and make sure our src matches.
+	// Get the uid, gid of the current user and make sure our src matches.
 	//
 	// Updating the modification time of the application is important because the
 	// system will be aware a new version of your app is available.
@@ -31,16 +28,27 @@ func (u *Updater) checkPlatformSpecificUpdate(sourcePath string, destinationPath
 	// get the priviledged helper tool involved.
 	//
 
-	// Get uid, gid of destination
-	uid := destFileInfo.Sys().(*syscall.Stat_t).Uid
-	gid := destFileInfo.Sys().(*syscall.Stat_t).Gid
-	u.log.Info("Destination: %s, Uid: %d, Gid: %d", destinationPath, uid, gid)
+	// Get uid, gid of current user
+	currentUser, err := user.Current()
+	if err != nil {
+		return err
+	}
+	uid, err := strconv.Atoi(currentUser.Uid)
+	if err != nil {
+		return err
+	}
+	gid, err := strconv.Atoi(currentUser.Gid)
+	if err != nil {
+		return err
+	}
+
+	u.log.Info("Current user uid: %d, gid: %d", uid, gid)
 
 	walk := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		err = os.Chown(path, int(uid), int(gid))
+		err = os.Chown(path, uid, gid)
 		if err != nil {
 			return err
 		}
@@ -67,7 +75,32 @@ func openApplication(applicationPath string) error {
 }
 
 func (u *Updater) applyUpdate(localPath string) (tmpPath string, err error) {
-	// TODO: On OSX call mdimport so Spotlight knows it changed?
+	destinationPath := u.options.DestinationPath
+	tmpPath, err = u.applyZip(localPath, destinationPath)
+	if err != nil {
+		return
+	}
 
-	return u.applyZip(localPath)
+	// Update spotlight, ignore (log) errors
+	u.log.Debug("Updating spotlight: %s", destinationPath)
+	mdimportOut, mdierr := exec.Command("/usr/bin/mdimport", destinationPath).Output()
+	if mdierr != nil {
+		u.log.Errorf("Error trying to update spotlight: %s; %s", mdierr, mdimportOut)
+	}
+
+	return
+}
+
+func (u *Updater) removeApp(appPath string) error {
+	// TODO: Move this Keybase specific logic outside of updater package since it
+	// only applies to our app
+	uninstaller := filepath.Join(appPath, "Contents", "Resources", "KeybaseInstaller.app", "Contents", "MacOS", "Keybase")
+	if _, err := os.Stat(uninstaller); os.IsNotExist(err) {
+		return fmt.Errorf("Remove app (privileged) is unavailable")
+	}
+
+	u.log.Debug("Using uninstaller: %s", uninstaller)
+	uninstallOutput, err := exec.Command(uninstaller, "--uninstall-app", fmt.Sprintf("--app-path=%s", appPath), fmt.Sprintf("--run-mode=%s", u.config.GetRunModeAsString())).Output()
+	u.log.Debug("Uninstaller: %s", uninstallOutput)
+	return err
 }

--- a/go/updater/updater_test.go
+++ b/go/updater/updater_test.go
@@ -106,6 +106,10 @@ func (c testConfig) SetUpdateLastChecked(t keybase1.Time) error {
 	return nil
 }
 
+func (c testConfig) GetRunModeAsString() string {
+	return "test"
+}
+
 func NewDefaultTestUpdateConfig() keybase1.UpdateOptions {
 	return keybase1.UpdateOptions{
 		Version:             "1.0.0",

--- a/go/updater/updater_windows.go
+++ b/go/updater/updater_windows.go
@@ -27,3 +27,7 @@ func (u *Updater) applyUpdate(localPath string) (tmpPath string, err error) {
 	}
 	return
 }
+
+func (u *Updater) removeApp(appPath string) error {
+	return fmt.Errorf("Remove app is unsupported on this platform")
+}

--- a/osx/Helper/Info.plist
+++ b/osx/Helper/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleName</key>
 	<string>Helper</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.26</string>
+	<string>1.0.27</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.26</string>
+	<string>1.0.27</string>
 	<key>SMAuthorizedClients</key>
 	<array>
 		<string>anchor apple generic and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = &quot;99229SGT5K&quot;) and (identifier &quot;keybase.Installer&quot; or identifier &quot;keybase.Keybase&quot;)</string>

--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,19 +15,19 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.20</string>
+	<string>1.1.21</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.20</string>
+	<string>1.1.21</string>
 	<key>KBFuseBuild</key>
 	<string>3.1.0</string>
 	<key>KBFuseVersion</key>
 	<string>3.1.0</string>
 	<key>KBHelperBuild</key>
-	<string>1.0.26</string>
+	<string>1.0.27</string>
 	<key>KBHelperVersion</key>
-	<string>1.0.26</string>
+	<string>1.0.27</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/osx/KBKit/KBKit/Component/KBAppBundle.m
+++ b/osx/KBKit/KBKit/Component/KBAppBundle.m
@@ -25,19 +25,18 @@
 
 - (void)uninstall:(KBCompletion)completion {
   MPXPCClient *helper = [KBHelperTool helper];
-  // Only uninstall from approved locations
+  // Only remove from approved locations
   if (![_path isEqualToString:@"/Applications/Keybase.app"]) {
     completion(KBMakeError(-1, @"Not approved to uninstall: %@", _path));
     return;
   }
   if (![NSFileManager.defaultManager fileExistsAtPath:_path]) {
-    DDLogInfo(@"No app to trash");
+    DDLogInfo(@"No app to uninstall");
     completion(nil);
     return;
   }
-  NSDictionary *params = @{@"path": _path};
-  [helper sendRequest:@"trash" params:@[params] completion:^(NSError *error, id value) {
-    DDLogDebug(@"Trash: %@", value);
+  NSDictionary *params = @{@"source": _path, @"destination": @"/tmp/Keybase.app"};
+  [helper sendRequest:@"move" params:@[params] completion:^(NSError *error, id value) {
     completion(error);
   }];
 }

--- a/osx/KBKit/KBKit/Component/KBInstallable.m
+++ b/osx/KBKit/KBKit/Component/KBInstallable.m
@@ -104,19 +104,32 @@
 }
 
 + (NSError *)combineErrors:(NSArray *)installables ignoreWarnings:(BOOL)ignoreWarnings {
-  NSMutableArray *errorMessages = [NSMutableArray array];
+  NSMutableArray *errors = [NSMutableArray array];
   for (KBInstallable *installable in installables) {
     NSError *error = installable.error;
     if (!error) error = installable.componentStatus.error;
+    if (!error) continue;
 
     // Ignore warnings
-    if (ignoreWarnings && error && KBIsWarning(error)) {
+    if (ignoreWarnings && KBIsWarning(error)) {
       continue;
     }
 
+    [errors addObject:error];
+  }
+
+  if ([errors count] == 0) {
+    return nil;
+  }
+  if ([errors count] == 1) {
+    return errors[0];
+  }
+
+  NSMutableArray *errorMessages = [NSMutableArray array];
+  for (NSError *error in errors) {
     NSString *errorMessage = nil;
     if (error) {
-      errorMessage = NSStringWithFormat(@"%@ (%@)", installable.componentStatus.error.localizedDescription, @(installable.componentStatus.error.code));
+      errorMessage = NSStringWithFormat(@"%@ (%@)", error.localizedDescription, @(error.code));
     }
     if (errorMessage && ![errorMessages containsObject:errorMessage]) [errorMessages addObject:errorMessage];
   }

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -31,6 +31,7 @@ comment=""
 
 keybase_binpath=${KEYBASE_BINPATH:-}
 kbfs_binpath=${KBFS_BINPATH:-}
+installer_bundle_path=${INSTALLER_BUNDLE_PATH:-}
 
 echo "Loading release tool"
 "$client_dir/packaging/goinstall.sh" "github.com/keybase/release"
@@ -70,7 +71,7 @@ out_dir="$build_dir/Keybase-darwin-x64"
 shared_support_dir="$out_dir/Keybase.app/Contents/SharedSupport"
 resources_dir="$out_dir/Keybase.app/Contents/Resources/"
 
-installer_url="https://github.com/keybase/client/releases/download/v1.0.9-0/KeybaseInstaller-1.1.20-darwin.tgz"
+installer_url="https://github.com/keybase/client/releases/download/v1.0.9-0/KeybaseInstaller-1.1.21-darwin.tgz"
 
 keybase_bin="$tmp_dir/keybase"
 kbfs_bin="$tmp_dir/kbfs"
@@ -122,7 +123,12 @@ get_deps() {
     ensure_url $kbfs_url "You need to build the binary for this Github release/version. See packaging/github to create/build a release."
     curl -J -L -Ss $kbfs_url | tar zx
   fi
-  curl -J -L -Ss $installer_url | tar zx
+  if [ ! "$installer_bundle_path" = "" ]; then
+    echo "Using local installer bundle path: $installer_bundle_path"
+    cp -R $installer_bundle_path .
+  else
+    curl -J -L -Ss $installer_url | tar zx
+  fi
 }
 
 # Build Keybase.app


### PR DESCRIPTION
This can occur if the /Applications/Keybase.app is owned by another user. Uses privileged helper tool to move existing install out of the way so an update can occur.

Some bug fixes:
- Remove partial unzip (if unzip failed previously)
- Update spotlight after update on OSX.