### PR TITLE
service: fix resolver to always return a username in Resolve2

### DIFF
--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -68,7 +68,7 @@ func (h *IdentifyHandler) Resolve(_ context.Context, arg string) (keybase1.UID, 
 }
 
 func (h *IdentifyHandler) Resolve2(_ context.Context, arg string) (u keybase1.User, err error) {
-	rres := h.G().Resolver.ResolveFullExpression(arg)
+	rres := h.G().Resolver.ResolveFullExpressionNeedUsername(arg)
 	err = rres.GetError()
 	if err == nil {
 		u.Uid, u.Username = rres.GetUID(), rres.GetNormalizedUsername().String()

--- a/go/systests/rpc_test.go
+++ b/go/systests/rpc_test.go
@@ -57,6 +57,19 @@ func testIdentifyResolve2(t *testing.T, g *libkb.GlobalContext) {
 		t.Fatalf("failed to get new identifyclient: %v", err)
 	}
 
+	if _, err := cli.Resolve(context.TODO(), "uid:eb72f49f2dde6429e5d78003dae0c919"); err != nil {
+		t.Fatalf("Resovle failed: %v\n", err)
+	}
+
+	// We don't want to hit the cache, since the previous lookup never hit the
+	// server.  For Resolve2, we have to, since we need a username.  So test that
+	// here.
+	if res, err := cli.Resolve2(context.TODO(), "uid:eb72f49f2dde6429e5d78003dae0c919"); err != nil {
+		t.Fatalf("Resovle failed: %v\n", err)
+	} else if res.Username != "t_tracy" {
+		t.Fatalf("Wrong username: %s != 't_tracy", res.Username)
+	}
+
 	if res, err := cli.Resolve2(context.TODO(), "t_tracy@rooter"); err != nil {
 		t.Fatalf("Resolve2 failed: %v\n", err)
 	} else if res.Username != "t_tracy" {


### PR DESCRIPTION
- still not required in Resolve(), but we can change that.
- add RPC-tests to make sure that we don't get messed up w/r/t cross-caching
  with the two RPCs.