### PR TITLE
fixes electron-prebuilt version finding being broken

### DIFF
--- a/desktop/package.js
+++ b/desktop/package.js
@@ -66,31 +66,24 @@ if (icon) {
   DEFAULT_OPTS.icon = icon
 }
 
-const version = argv.version || argv.v
-
-if (version) {
-  console.log('Using passed in version of electron-prebuild: ', version)
-  DEFAULT_OPTS.version = version
-  startPack()
-} else {
-  // use the same version as the currently-installed electron-prebuilt
-  console.log('Finding electron version')
-  exec('npm list --dev electron-prebuilt', (err, stdout, stderr) => {
-    DEFAULT_OPTS.version = '0.36.3'
-    if (!err) {
-      try {
-        DEFAULT_OPTS.version = stdout.match(/electron-prebuilt@([0-9.]+)/)[1]
-        console.log("Found electron-prebuilt version: ", DEFAULT_OPTS.version)
-      } catch (err) {
-        console.log("Couldn't parse npm list to find electron: ", err)
-      }
-    } else {
-        console.log("Couldn't list npm to find electron: ", err)
+// use the same version as the currently-installed electron-prebuilt
+console.log('Finding electron version')
+exec('npm list --dev electron-prebuilt', (err, stdout, stderr) => {
+  if (!err) {
+    try {
+      DEFAULT_OPTS.version = stdout.match(/electron-prebuilt@([0-9.]+)/)[1]
+      console.log("Found electron-prebuilt version: ", DEFAULT_OPTS.version)
+    } catch (err) {
+      console.log("Couldn't parse npm list to find electron: ", err)
+      process.exit(1)
     }
+  } else {
+      console.log("Couldn't list npm to find electron: ", err)
+      process.exit(1)
+  }
 
-    startPack()
-  })
-}
+  startPack()
+})
 
 function startPack () {
   console.log('start pack...')

--- a/desktop/package.js
+++ b/desktop/package.js
@@ -69,6 +69,7 @@ if (icon) {
 const version = argv.version || argv.v
 
 if (version) {
+  console.log('Using passed in version of electron-prebuild: ', version)
   DEFAULT_OPTS.version = version
   startPack()
 } else {
@@ -76,12 +77,17 @@ if (version) {
   console.log('Finding electron version')
   exec('npm list --dev electron-prebuilt', (err, stdout, stderr) => {
     DEFAULT_OPTS.version = '0.36.3'
-
     if (!err) {
       try {
-        DEFAULT_OPTS.version = stdout.match(/electron-prebuilt@([0-9.]+)\n/)[1]
-      } catch (ignore) { }
+        DEFAULT_OPTS.version = stdout.match(/electron-prebuilt@([0-9.]+)/)[1]
+        console.log("Found electron-prebuilt version: ", DEFAULT_OPTS.version)
+      } catch (err) {
+        console.log("Couldn't parse npm list to find electron: ", err)
+      }
+    } else {
+        console.log("Couldn't list npm to find electron: ", err)
     }
+
     startPack()
   })
 }


### PR DESCRIPTION
@keybase/react-hackers for some reason npm's output changed so the old regexp broke.
i also added more logging so we can tell wtf is going on in the future

@gabriel let's do a test build when this is merged