### PR TITLE
use libkb constants for our log file names

### DIFF
--- a/go/client/cmd_launchd_osx.go
+++ b/go/client/cmd_launchd_osx.go
@@ -38,7 +38,7 @@ func NewCmdLaunchdInstall(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cl
 	return cli.Command{
 		Name:         "install",
 		Usage:        "Install a launchd service",
-		ArgumentHelp: "<label> <executable> <args>",
+		ArgumentHelp: "<label> <executable> <logfilename> <args>",
 		Action: func(c *cli.Context) {
 			// TODO: Use ChooseCommand
 			args := c.Args()
@@ -48,13 +48,17 @@ func NewCmdLaunchdInstall(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cl
 			if len(args) < 2 {
 				g.Log.Fatalf("No executable specified.")
 			}
+			if len(args) < 3 {
+				g.Log.Fatalf("No log file name specified.")
+			}
 
 			label := args[0]
 			binPath := args[1]
-			plistArgs := args[2:]
+			logFileName := args[2]
+			plistArgs := args[3:]
 			envVars := install.DefaultLaunchdEnvVars(g, label)
 
-			plist := launchd.NewPlist(label, binPath, plistArgs, envVars)
+			plist := launchd.NewPlist(label, binPath, plistArgs, envVars, logFileName)
 			err := launchd.Install(plist, g.Log)
 			if err != nil {
 				g.Log.Fatalf("%v", err)

--- a/go/client/cmd_status.go
+++ b/go/client/cmd_status.go
@@ -131,7 +131,7 @@ func (c *CmdStatus) load() (*fstatus, error) {
 		status.Service.Running = false
 	} else {
 		status.Service.Running = true
-		status.Service.Log = path.Join(extStatus.LogDir, c.serviceLogFilename())
+		status.Service.Log = path.Join(extStatus.LogDir, libkb.ServiceLogFileName)
 	}
 
 	status.SessionStatus = c.sessionStatus(extStatus.Session)
@@ -141,10 +141,10 @@ func (c *CmdStatus) load() (*fstatus, error) {
 	if err == nil {
 		status.KBFS.Version = kbfsVersion
 	}
-	status.KBFS.Log = path.Join(extStatus.LogDir, c.kbfsLogFilename())
+	status.KBFS.Log = path.Join(extStatus.LogDir, libkb.KBFSLogFileName)
 
 	status.Desktop.Running = extStatus.DesktopUIConnected
-	status.Desktop.Log = path.Join(extStatus.LogDir, c.desktopLogFilename())
+	status.Desktop.Log = path.Join(extStatus.LogDir, libkb.DesktopLogFileName)
 
 	status.DefaultUsername = extStatus.DefaultUsername
 	status.ProvisionedUsernames = extStatus.ProvisionedUsernames

--- a/go/client/cmd_status_nix.go
+++ b/go/client/cmd_status_nix.go
@@ -11,15 +11,3 @@ func (c *CmdStatus) osSpecific(status *fstatus) error {
 	// it.
 	return nil
 }
-
-func (c *CmdStatus) serviceLogFilename() string {
-	return "keybase.service.log"
-}
-
-func (c *CmdStatus) kbfsLogFilename() string {
-	return "keybase.kbfs.log"
-}
-
-func (c *CmdStatus) desktopLogFilename() string {
-	return "keybase.gui.log"
-}

--- a/go/client/cmd_status_osx.go
+++ b/go/client/cmd_status_osx.go
@@ -23,15 +23,3 @@ func (c *CmdStatus) osSpecific(status *fstatus) error {
 
 	return nil
 }
-
-func (c *CmdStatus) serviceLogFilename() string {
-	return "keybase.service.log"
-}
-
-func (c *CmdStatus) kbfsLogFilename() string {
-	return "keybase.kbfs.log"
-}
-
-func (c *CmdStatus) desktopLogFilename() string {
-	return "Keybase.app.log"
-}

--- a/go/client/cmd_status_windows.go
+++ b/go/client/cmd_status_windows.go
@@ -11,18 +11,3 @@ func (c *CmdStatus) osSpecific(status *fstatus) error {
 	// it.
 	return nil
 }
-
-// TODO: check with steve about this
-func (c *CmdStatus) serviceLogFilename() string {
-	return "keybase.service.log"
-}
-
-// TODO: check with steve about this
-func (c *CmdStatus) kbfsLogFilename() string {
-	return "keybase.kbfs.log"
-}
-
-// TODO: check with steve about this
-func (c *CmdStatus) desktopLogFilename() string {
-	return "keybase.gui.log"
-}

--- a/go/install/install_osx.go
+++ b/go/install/install_osx.go
@@ -184,7 +184,7 @@ func installKeybaseService(g *libkb.GlobalContext, binPath string) (*keybase1.Se
 	plistArgs := []string{"-d", "service"}
 	envVars := DefaultLaunchdEnvVars(g, label)
 
-	plist := launchd.NewPlist(label, binPath, plistArgs, envVars)
+	plist := launchd.NewPlist(label, binPath, plistArgs, envVars, libkb.ServiceLogFileName)
 	err := launchd.Install(plist, g.Log)
 	if err != nil {
 		return nil, err
@@ -220,7 +220,7 @@ func installKBFSService(g *libkb.GlobalContext, binPath string) (*keybase1.Servi
 	plistArgs := []string{"-debug", mountPath}
 	envVars := DefaultLaunchdEnvVars(g, label)
 
-	plist := launchd.NewPlist(label, kbfsBinPath, plistArgs, envVars)
+	plist := launchd.NewPlist(label, kbfsBinPath, plistArgs, envVars, libkb.KBFSLogFileName)
 	err = launchd.Install(plist, g.Log)
 	if err != nil {
 		return nil, err

--- a/go/launchd/launchd.go
+++ b/go/launchd/launchd.go
@@ -48,21 +48,23 @@ func (s Service) Label() string { return s.label }
 
 // Plist defines a launchd plist
 type Plist struct {
-	label     string
-	binPath   string
-	args      []string
-	envVars   map[string]string
-	keepAlive bool
+	label       string
+	binPath     string
+	args        []string
+	envVars     map[string]string
+	keepAlive   bool
+	logFileName string
 }
 
 // NewPlist constructs a launchd service.
-func NewPlist(label string, binPath string, args []string, envVars map[string]string) Plist {
+func NewPlist(label string, binPath string, args []string, envVars map[string]string, logFileName string) Plist {
 	return Plist{
-		label:     label,
-		binPath:   binPath,
-		args:      args,
-		envVars:   envVars,
-		keepAlive: true,
+		label:       label,
+		binPath:     binPath,
+		args:        args,
+		envVars:     envVars,
+		keepAlive:   true,
+		logFileName: logFileName,
 	}
 }
 
@@ -373,7 +375,7 @@ func ensureDirectoryExists(dir string) error {
 
 // TODO Use go-plist library
 func (p Plist) plist() string {
-	logFile := filepath.Join(launchdLogDir(), p.label+".log")
+	logFile := filepath.Join(launchdLogDir(), p.logFileName)
 
 	encodeTag := func(name, val string) string {
 		return fmt.Sprintf("<%s>%s</%s>", name, val, name)

--- a/go/launchd/launchd_test.go
+++ b/go/launchd/launchd_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestPlist(t *testing.T) {
 	envVars := make(map[string]string)
-	plist := NewPlist("keybase.testing", "/path/to/file", []string{"--flag=test", "testArg"}, envVars)
+	plist := NewPlist("keybase.testing", "/path/to/file", []string{"--flag=test", "testArg"}, envVars, "keybase.testing.log")
 
 	data := plist.plist()
 	t.Logf("Plist: %s\n", data)

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -58,9 +58,6 @@ func (p *CommandLine) GetLogForward() LogForward  { return p.logForward }
 func (p CommandLine) GetSplitLogOutput() (bool, bool) {
 	return p.GetBool("split-log-output", true)
 }
-func (p CommandLine) GetLogFile() string {
-	return p.GetGString("log-file")
-}
 func (p CommandLine) GetNoAutoFork() (bool, bool) {
 	return p.GetBool("no-auto-fork", true)
 }

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -376,3 +376,7 @@ const (
 const (
 	SecretPromptCancelDuration = 5 * time.Minute
 )
+
+const ServiceLogFileName = "keybase.service.log"
+const KBFSLogFileName = "keybase.kbfs.log"
+const DesktopLogFileName = "Keybase.app.log"

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -747,10 +747,7 @@ func (e *Env) GetSplitLogOutput() bool {
 
 func (e *Env) GetLogFile() string {
 	return e.GetString(
-		func() string { return e.cmd.GetLogFile() },
-		func() string { return os.Getenv("KEYBASE_LOG_FILE") },
-		func() string { return e.config.GetLogFile() },
-		func() string { return filepath.Join(e.GetLogDir(), "keybase.log") },
+		func() string { return filepath.Join(e.GetLogDir(), ServiceLogFileName) },
 	)
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -55,7 +55,6 @@ type CommandLine interface {
 	GetLocalRPCDebug() string
 	GetTimers() string
 	GetSplitLogOutput() (bool, bool)
-	GetLogFile() string
 	GetRunMode() (RunMode, error)
 
 	GetScraperTimeout() (time.Duration, bool)

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -47,7 +47,7 @@ echo Mounting /keybase...
 kbfsfuse -debug -mdserver mdserver.kbfs.keybase.io:443 \
   -bserver bserver.kbfs.keybase.io:443 /keybase &>> "$logdir/keybase.kbfs.log" &
 echo Launching Keybase GUI...
-/opt/keybase/Keybase &>> "$logdir/keybase.gui.log" &
+/opt/keybase/Keybase &>> "$logdir/Keybase.app.log" &
 
 echo 'Success!'
 # Magical squirrel produced by https://github.com/erkin/ponysay


### PR DESCRIPTION
Previously these were defined in several places, but it's important to
have them stay consistent. As part of deduplicating these, get rid of
the ability to configure them. We can add that back later if we decide
we need it, but using custom log paths is inevitably going to mess with
`keybase log send`, when someone runs that with a different config.

@gabriel I used the OSX names as the constants here, so nothing on
that platform should change. However, I didn't change the way install_osx.go
uses the different service labels as the name of the log file that launchd
gets configured to use. How would you feel about using the same constants
there? We would lose the distinction between the Brew log files and the regular
log files, but I don't know if we want to keep that distinction, since it's going
to confuse `keybase log send`. Let me know what you think.