### PR TITLE
Add Disjoint Typed Actions

### DIFF
--- a/go/engine/unlock.go
+++ b/go/engine/unlock.go
@@ -10,12 +10,21 @@ import (
 // Unlock is an engine.
 type Unlock struct {
 	libkb.Contextified
+	passphrase string
 }
 
 // NewUnlock creates a Unlock engine.
 func NewUnlock(g *libkb.GlobalContext) *Unlock {
 	return &Unlock{
 		Contextified: libkb.NewContextified(g),
+	}
+}
+
+// NewUnlock creates a Unlock engine.
+func NewUnlockWithPassphrase(g *libkb.GlobalContext, passphrase string) *Unlock {
+	return &Unlock{
+		Contextified: libkb.NewContextified(g),
+		passphrase:   passphrase,
 	}
 }
 
@@ -31,6 +40,9 @@ func (e *Unlock) Prereqs() Prereqs {
 
 // RequiredUIs returns the required UIs.
 func (e *Unlock) RequiredUIs() []libkb.UIKind {
+	if e.passphrase != "" {
+		return nil
+	}
 	return []libkb.UIKind{libkb.SecretUIKind}
 }
 
@@ -41,6 +53,10 @@ func (e *Unlock) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *Unlock) Run(ctx *Context) error {
+	if e.passphrase != "" {
+		_, err := e.G().LoginState().GetPassphraseStreamWithPassphrase(e.passphrase)
+		return err
+	}
 	_, err := e.G().LoginState().GetPassphraseStream(ctx.SecretUI)
 	return err
 }

--- a/go/engine/unlock_test.go
+++ b/go/engine/unlock_test.go
@@ -77,3 +77,37 @@ func TestUnlockNoop(t *testing.T) {
 		t.Fatal("expected valid stream cache after unlock")
 	}
 }
+
+func TestUnlockWithPassphrase(t *testing.T) {
+	tc := SetupEngineTest(t, "template")
+	defer tc.Cleanup()
+
+	fu := CreateAndSignupFakeUser(tc, "login")
+
+	if !assertStreamCache(tc, true) {
+		t.Fatal("expected valid stream cache after sign up")
+	}
+
+	ctx := &Context{
+		LogUI:   tc.G.UI.GetLogUI(),
+		LoginUI: &libkb.TestLoginUI{},
+		// No SecretUI here!
+	}
+
+	tc.G.LoginState().Account(func(a *libkb.Account) {
+		a.ClearStreamCache()
+	}, "clear stream cache")
+
+	if !assertStreamCache(tc, false) {
+		t.Fatal("expected invalid stream cache after clear")
+	}
+
+	eng := NewUnlockWithPassphrase(tc.G, fu.Passphrase)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if !assertStreamCache(tc, true) {
+		t.Fatal("expected valid stream cache after unlock")
+	}
+}

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -82,6 +82,15 @@ func (h *LoginHandler) Unlock(_ context.Context, sessionID int) error {
 	return engine.RunEngine(eng, ctx)
 }
 
+func (h *LoginHandler) UnlockWithPassphrase(_ context.Context, arg keybase1.UnlockWithPassphraseArg) error {
+	ctx := &engine.Context{
+		LogUI:    h.getLogUI(arg.SessionID),
+		SecretUI: h.getSecretUI(arg.SessionID),
+	}
+	eng := engine.NewUnlockWithPassphrase(h.G(), arg.Passphrase)
+	return engine.RunEngine(eng, ctx)
+}
+
 func (h *LoginHandler) Login(ctx context.Context, arg keybase1.LoginArg) error {
 	ectx := &engine.Context{
 		LogUI:       h.getLogUI(arg.SessionID),

--- a/protocol/avdl/login.avdl
+++ b/protocol/avdl/login.avdl
@@ -45,5 +45,6 @@ protocol login {
     Unlock restores access to local key store by priming passphrase stream cache.
     */
   void unlock(int sessionID);
+  void unlockWithPassphrase(int sessionID, string passphrase);
 
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -700,6 +700,16 @@ export type incomingCallMapType = {
       result: () => void
     }
   ) => void,
+  'keybase.1.login.unlockWithPassphrase'?: (
+    params: {
+      sessionID: int,
+      passphrase: string
+    },
+    response: {
+      error: (err: string) => void,
+      result: () => void
+    }
+  ) => void,
   'keybase.1.loginUi.getEmailOrUsername'?: (
     params: {
       sessionID: int
@@ -4986,6 +4996,19 @@ export type login_paperKey_rpc = {
 export type login_unlock_rpc = {
   method: 'login.unlock',
   param: {},
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any) => void)
+}
+
+// login.unlockWithPassphrase ////////////////////////////////////////
+
+/* void response */
+
+export type login_unlockWithPassphrase_rpc = {
+  method: 'login.unlockWithPassphrase',
+  param: {
+    passphrase: string
+  },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
 }

--- a/protocol/json/login.json
+++ b/protocol/json/login.json
@@ -305,6 +305,16 @@
         "type" : "int"
       } ],
       "response" : "null"
+    },
+    "unlockWithPassphrase" : {
+      "request" : [ {
+        "name" : "sessionID",
+        "type" : "int"
+      }, {
+        "name" : "passphrase",
+        "type" : "string"
+      } ],
+      "response" : "null"
     }
   }
 }

--- a/shared/actions/devices.js
+++ b/shared/actions/devices.js
@@ -2,13 +2,14 @@
 import * as Constants from '../constants/devices'
 import engine from '../engine'
 import {navigateUpOnUnchanged} from './router'
-import type {AsyncAction} from '../constants/types/flux'
+import type {AsyncAction, TypedAction} from '../constants/types/flux'
 import type {incomingCallMapType, revoke_revokeDevice_rpc, device_deviceList_rpc, login_paperKey_rpc} from '../constants/types/flow-types'
 
 export function loadDevices () : AsyncAction {
   return function (dispatch) {
     dispatch({
-      type: Constants.loadingDevices
+      type: Constants.loadingDevices,
+      payload: null
     })
 
     const params : device_deviceList_rpc = {
@@ -16,11 +17,21 @@ export function loadDevices () : AsyncAction {
       param: {},
       incomingCallMap: {},
       callback: (error, devices) => {
-        dispatch({
-          type: Constants.showDevices,
-          payload: error || devices,
-          error: !!error
-        })
+        // Flow is weird here, we have to give it true or false directly instead of just giving it !!error
+        if (error) {
+          dispatch({
+            type: Constants.showDevices,
+            payload: error,
+            error: true
+          })
+        } else {
+          dispatch({
+            type: Constants.showDevices,
+            payload: devices,
+            error: false
+          })
+        }
+        // dispatch()
       }
     }
 
@@ -31,7 +42,8 @@ export function loadDevices () : AsyncAction {
 export function generatePaperKey () : AsyncAction {
   return function (dispatch) {
     dispatch({
-      type: Constants.paperKeyLoading
+      type: Constants.paperKeyLoading,
+      payload: null
     })
 
     const incomingMap : incomingCallMapType = {

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -25,7 +25,8 @@ export function login (): AsyncAction {
 }
 
 export function doneRegistering (): TypedAction<'login:doneRegistering', void, void> {
-  return {type: Constants.doneRegistering}
+  // this has to be undefined for flow to match it to void
+  return {type: Constants.doneRegistering, payload: undefined}
 }
 
 function setCodePageOtherDeviceRole (otherDeviceRole) : AsyncAction {
@@ -74,18 +75,26 @@ export function updateForgotPasswordEmail (email: string) : TypedAction<'login:a
 
 export function submitForgotPassword () : AsyncAction {
   return (dispatch, getState) => {
-    dispatch({type: Constants.actionSetForgotPasswordSubmitting})
+    dispatch({type: Constants.actionSetForgotPasswordSubmitting, payload: undefined})
 
     const params : login_recoverAccountFromEmailAddress_rpc = {
       method: 'login.recoverAccountFromEmailAddress',
       param: {email: getState().login.forgotPasswordEmailAddress},
       incomingCallMap: {},
       callback: (error, response) => {
-        dispatch({
-          type: Constants.actionForgotPasswordDone,
-          payload: error,
-          error: !!error
-        })
+        if (error) {
+          dispatch({
+            type: Constants.actionForgotPasswordDone,
+            payload: error,
+            error: true
+          })
+        } else {
+          dispatch({
+            type: Constants.actionForgotPasswordDone,
+            payload: undefined,
+            error: false
+          })
+        }
       }
     }
 
@@ -137,7 +146,7 @@ export function logout () : AsyncAction {
 export function logoutDone () : AsyncAction {
   // We've logged out, let's check our current status
   return dispatch => {
-    dispatch({type: Constants.logoutDone})
+    dispatch({type: Constants.logoutDone, payload: undefined})
     dispatch(getCurrentStatus())
   }
 }
@@ -294,13 +303,19 @@ function startLoginFlow (dispatch, getState, provisionMethod, userPassTitle, use
     },
     incomingCallMap: incomingMap,
     callback: (error, response) => {
-      dispatch({
-        type: successType,
-        error: !!error,
-        payload: error || null
-      })
+      if (error) {
+        dispatch({
+          type: successType,
+          error: true,
+          payload: error
+        })
+      } else {
+        dispatch({
+          type: successType,
+          error: false,
+          payload: undefined
+        })
 
-      if (!error) {
         dispatch(navigateTo([]))
         dispatch(loadDevices())
         dispatch(switchTab(devicesTab))

--- a/shared/actions/profile.js
+++ b/shared/actions/profile.js
@@ -3,8 +3,8 @@ import * as Constants from '../constants/profile'
 import {routeAppend} from './router'
 import engine from '../engine'
 import {identify} from '../constants/types/keybase_v1'
-import type {incomingCallMapType, user_loadUncheckedUserSummaries_rpc, identify_identify_rpc} from '../constants/types/flow-types'
-import type {AsyncAction} from '../constants/types/flux'
+import type {incomingCallMapType, user_loadUncheckedUserSummaries_rpc, identify_identify_rpc, user_UserSummary} from '../constants/types/flow-types'
+import type {AsyncAction, TypedAction} from '../constants/types/flux'
 const enums = identify
 
 export function pushNewProfile (username: string) : AsyncAction {
@@ -145,6 +145,7 @@ export function refreshProfile (username: string) : AsyncAction {
   }
 }
 
+type Summaries = {[key: string]: user_UserSummary}
 export function loadSummaries (uids: Array<string>) : AsyncAction {
   return function (dispatch) {
     dispatch({
@@ -167,11 +168,19 @@ export function loadSummaries (uids: Array<string>) : AsyncAction {
           summaries[r.username] = {summary: r}
         })
 
-        dispatch({
-          type: Constants.profileSummaryLoaded,
-          payload: error || summaries,
-          error: !!error
-        })
+        if (error) {
+          dispatch(({
+            type: Constants.profileSummaryLoaded,
+            payload: error,
+            error: true
+          }: TypedAction<'profile:profileSummaryLoaded', Summaries, any>))
+        } else {
+          dispatch(({
+            type: Constants.profileSummaryLoaded,
+            payload: summaries,
+            error: false
+          }: TypedAction<'profile:profileSummaryLoaded', Summaries, any>))
+        }
       }
     }
 

--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -24,7 +24,7 @@ type TrackerActionCreator = (dispatch: Dispatch, getState: () => {tracker: RootT
 export function startTimer (): TrackerActionCreator {
   return (dispatch, getState) => {
     // Increments timerActive as a count of open tracker popups.
-    dispatch({type: Constants.startTimer})
+    dispatch({type: Constants.startTimer, payload: undefined})
     const timerActive = getState().tracker.timerActive
     if (timerActive === 1) {
       // We're transitioning from 0->1, no tracker popups to one, start timer.
@@ -50,7 +50,8 @@ export function startTimer (): TrackerActionCreator {
 
 export function stopTimer (): Action {
   return {
-    type: Constants.stopTimer
+    type: Constants.stopTimer,
+    payload: null
   }
 }
 

--- a/shared/actions/update.js
+++ b/shared/actions/update.js
@@ -75,7 +75,8 @@ function updateListenersCreator (dispatch: Dispatch, getState: () => {config: Co
 
       // Cancel any existing update prompts; this will trigger a new focused window
       dispatch({
-        type: Constants.onCancel
+        type: Constants.onCancel,
+        payload: null
       })
 
       dispatch(({
@@ -128,21 +129,21 @@ function sendUpdatePromptResponse (payload: any /* UpdatePromptRes */): void {
 
 export function onCancel (): (dispatch: Dispatch) => void {
   return dispatch => {
-    dispatch(({type: Constants.onCancel}: OnCancelAction))
+    dispatch(({type: Constants.onCancel, payload: null}: OnCancelAction))
     sendUpdatePromptResponse({action: updateUi.UpdateAction.cancel})
   }
 }
 
 export function onSkip (): (dispatch: Dispatch) => void {
   return dispatch => {
-    dispatch(({type: Constants.onSkip}: OnSkipAction))
+    dispatch(({type: Constants.onSkip, payload: null}: OnSkipAction))
     sendUpdatePromptResponse({action: updateUi.UpdateAction.skip})
   }
 }
 
 export function onSnooze (): (dispatch: Dispatch) => void {
   return dispatch => {
-    dispatch(({type: Constants.onSnooze}: OnSnoozeAction))
+    dispatch(({type: Constants.onSnooze, payload: null}: OnSnoozeAction))
     sendUpdatePromptResponse({
       action: updateUi.UpdateAction.snooze,
       snoozeUntil: Date.now() + snoozeTimeSecs * 1000
@@ -152,7 +153,7 @@ export function onSnooze (): (dispatch: Dispatch) => void {
 
 export function onUpdate (): (dispatch: Dispatch, getState: () => {update: ShowUpdateState}) => void {
   return (dispatch, getState) => {
-    dispatch(({type: Constants.onUpdate}: OnUpdateAction))
+    dispatch(({type: Constants.onUpdate, payload: null}: OnUpdateAction))
     sendUpdatePromptResponse({
       action: updateUi.UpdateAction.update,
       alwaysAutoInstall: getState().update.alwaysUpdate

--- a/shared/common-adapters/button.js.flow
+++ b/shared/common-adapters/button.js.flow
@@ -5,10 +5,10 @@ import React, {Component} from 'react'
 export type Props = {
   onClick: ?Function,
   label: ?string,
-  style: ?Object,
-  primary: ?bool,
-  small: ?bool,
-  more: ?bool
+  style?: ?Object,
+  primary?: ?bool,
+  small?: ?bool,
+  more?: ?bool
 }
 
 declare export default class Button extends Component {

--- a/shared/common-adapters/input.js.flow
+++ b/shared/common-adapters/input.js.flow
@@ -4,7 +4,7 @@ import React, {Component} from 'react'
 
 export type Props = {
   autoFocus?: bool,
-  errorText?: string,
+  errorText?: ?string,
   floatingLabelText?: string,
   hintText?: string,
   multiLine?: bool,

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -700,6 +700,16 @@ export type incomingCallMapType = {
       result: () => void
     }
   ) => void,
+  'keybase.1.login.unlockWithPassphrase'?: (
+    params: {
+      sessionID: int,
+      passphrase: string
+    },
+    response: {
+      error: (err: string) => void,
+      result: () => void
+    }
+  ) => void,
   'keybase.1.loginUi.getEmailOrUsername'?: (
     params: {
       sessionID: int
@@ -4986,6 +4996,19 @@ export type login_paperKey_rpc = {
 export type login_unlock_rpc = {
   method: 'login.unlock',
   param: {},
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any) => void)
+}
+
+// login.unlockWithPassphrase ////////////////////////////////////////
+
+/* void response */
+
+export type login_unlockWithPassphrase_rpc = {
+  method: 'login.unlockWithPassphrase',
+  param: {
+    passphrase: string
+  },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
 }

--- a/shared/constants/types/flux.js
+++ b/shared/constants/types/flux.js
@@ -1,15 +1,19 @@
 /* @flow */
 
-// This should really be a disjoint union, but union of unions doesn't quite work yet:
-// and we need that to make a Actions union over different types of actions
-// https://github.com/facebook/flow/issues/582
 export type TypedAction<T, P, E> = {
+  error?: false,
   type: T,
-  payload?: ?P,
-  error?: boolean
+  payload: P
+} | {
+  error: true,
+  type: T,
+  payload: E
 }
 
 export type Action = TypedAction<string, any, any>
 export type GetState = () => Object
 export type AsyncAction = (dispatch: Dispatch, getState: GetState) => ?Promise
 export type Dispatch = (action: TypedAction | AsyncAction) => ?Promise
+
+export type TypedAsyncAction<T, P, E> = (dispatch: TypedDispatch<T, P, E>, getState: GetState) => ?Promise
+export type TypedDispatch<T, P, E> = (action: TypedAction<T, P, E> | AsyncAction<T, P, E>) => ?Promise

--- a/shared/login/error.render.js.flow
+++ b/shared/login/error.render.js.flow
@@ -1,0 +1,5 @@
+/* @flow */
+
+export default class ErrorRender extends ReactComponent {
+  props: {currentPath: any};
+}


### PR DESCRIPTION
@keybase/react-hackers 

This adds support for disjoin unions on booleans so now you can do:

```
type Foo = {error: true, payload: {error: string}} | {error: false, payload: {username: string}}

const something: Foo ...

if (something.error === true) {
 console.error(something.payload.error) 
} else {
 console.log(something.payload.username)
}
```

This means we can take better advantage of our typed actions!

A couple caveats:

* We have to check it against `=== true` just `if (something.error)` isn't good enough
* I made action.payload a non optional key, so if payload is void we have to pass in `payload: undefined`. But this means when we specify what the payload should look like we can just reach in with `action.payload.foo.bar` instead of spreading nullables with `const foo: ?Bar = action.payload && action.payload.foo.bar` 