### PR TITLE
Add Invite Code component and Signup boilerplate.

### DIFF
--- a/shared/actions/signup/index.js
+++ b/shared/actions/signup/index.js
@@ -1,0 +1,12 @@
+/* @flow */
+
+import * as Constants from '../../constants/signup'
+
+import type {CheckInviteCodeCreator} from '../../constants/signup'
+
+export function checkInviteCode (inviteCode: string): CheckInviteCodeCreator {
+  return dispatch => {
+    // TODO make service call
+    dispatch({type: Constants.checkInviteCode, payload: {valid: true}})
+  }
+}

--- a/shared/constants/signup.js
+++ b/shared/constants/signup.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+import type {TypedAsyncAction, TypedAction} from '../constants/types/flux'
+
+export const checkInviteCode = 'signup:checkInviteCode'
+export type CheckInviteCode = TypedAction<'signup:checkInviteCode', {valid: true}, {errorText: string}>
+export type CheckInviteCodeCreator = TypedAsyncAction<CheckInviteCode>
+
+export type SignupActions = CheckInviteCode
+

--- a/shared/constants/types/flux.js
+++ b/shared/constants/types/flux.js
@@ -15,5 +15,5 @@ export type GetState = () => Object
 export type AsyncAction = (dispatch: Dispatch, getState: GetState) => ?Promise
 export type Dispatch = (action: TypedAction | AsyncAction) => ?Promise
 
-export type TypedAsyncAction<T, P, E> = (dispatch: TypedDispatch<T, P, E>, getState: GetState) => ?Promise
-export type TypedDispatch<T, P, E> = (action: TypedAction<T, P, E> | AsyncAction<T, P, E>) => ?Promise
+export type TypedAsyncAction<A> = (dispatch: TypedDispatch<A>, getState: GetState) => ?Promise
+export type TypedDispatch<A> = (action: A | TypedAsyncAction<A>) => ?Promise

--- a/shared/login/error.render.desktop.js
+++ b/shared/login/error.render.desktop.js
@@ -1,3 +1,4 @@
+import React, {Component} from 'react'
 import {Text} from '../common-adapters'
 
 export default props => <Text type='Body'>Error loading component {JSON.stringify(props.currentPath.toJS())}</Text>

--- a/shared/login/forms/intro.js
+++ b/shared/login/forms/intro.js
@@ -3,6 +3,7 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import Render from './intro.render'
+import {routeAppend} from '../../actions/router'
 
 class Intro extends Component {
   render (): ReactElement {
@@ -20,7 +21,7 @@ Intro.propTypes = {
 export default connect(
   state => ({}),
   dispatch => ({
-    onSignup: () => {},
-    onLogin: () => {}
+    onSignup: () => { dispatch(routeAppend('signup')) },
+    onLogin: () => { dispatch(routeAppend('login')) }
   })
 )(Intro)

--- a/shared/login/index.js
+++ b/shared/login/index.js
@@ -5,6 +5,9 @@ import Render from './index.render'
 import Intro from './forms/intro'
 import ErrorText from './error.render'
 
+// Signup Components
+import InviteCode from './signup/inviteCode'
+
 export default class Login extends Component {
   render () {
     return <Render formComponent={this.props.formComponent}/>
@@ -17,6 +20,9 @@ export default class Login extends Component {
     switch (currentPath.get('path')) {
       case 'root':
         Form = () => <Intro/>
+        break
+      case 'signup':
+        Form = () => <InviteCode/>
         break
     }
 

--- a/shared/login/signup/inviteCode.js
+++ b/shared/login/signup/inviteCode.js
@@ -1,0 +1,26 @@
+/* @flow */
+
+import React, {Component} from 'react'
+import {connect} from 'react-redux'
+import {bindActionCreators} from 'redux'
+
+import Render from './inviteCode.render'
+import * as signupActions from '../../actions/signup'
+
+class InviteCode extends Component {
+  render (): ReactElement {
+    return (
+      <Render onInviteCodeSubmit={this.props.checkInviteCode} inviteCodeErrorText={this.props.errorText}/>
+    )
+  }
+}
+
+InviteCode.propTypes = {
+  checkInviteCode: React.PropTypes.func,
+  errorText: React.PropTypes.string
+}
+
+export default connect(
+  state => ({}),
+  dispatch => bindActionCreators(signupActions, dispatch)
+)(InviteCode)

--- a/shared/login/signup/inviteCode.render.desktop.js
+++ b/shared/login/signup/inviteCode.render.desktop.js
@@ -1,0 +1,33 @@
+/* @flow */
+/* eslint-disable react/prop-types */
+
+import React, {Component} from 'react'
+import {globalStyles} from '../../styles/style-guide'
+import {Text, Input, Button} from '../../common-adapters'
+
+import type {Props} from './inviteCode.render'
+
+export default class Render extends Component {
+  props: Props;
+
+  render (): ReactElement {
+    return (
+      <div style={styles.form}>
+        <Text style={styles.topMargin} type='Header'>Enter your special invite code</Text>
+        <Input hintText='Invite Code' errorText={this.props.inviteCodeErrorText} onEnterKeyDown={this.props.onInviteCodeSubmit}/>
+        <Button label='Check' onClick={this.props.onInviteCodeSubmit}/>
+      </div>
+    )
+  }
+}
+
+const styles = {
+  form: {
+    ...globalStyles.flexBoxColumn,
+    flex: 1
+  },
+
+  topMargin: {
+    marginTop: 20
+  }
+}

--- a/shared/login/signup/inviteCode.render.js.flow
+++ b/shared/login/signup/inviteCode.render.js.flow
@@ -1,0 +1,13 @@
+/* @flow */
+/* eslint-disable react/prop-types */
+
+import React, {Component} from 'react'
+
+export type Props = {
+  onInviteCodeSubmit: () => void,
+  inviteCodeErrorText: ?string
+}
+
+export default class Render extends Component {
+  props: Props;
+}

--- a/shared/more/dev-menu.desktop.js
+++ b/shared/more/dev-menu.desktop.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import {routeAppend} from '../actions/router'
+import {switchTab} from '../actions/tabbed-router'
 import {pushNewProfile} from '../actions/profile'
 import {pushNewSearch} from '../actions/search'
 import {logout} from '../actions/login'

--- a/shared/reducers/signup.js
+++ b/shared/reducers/signup.js
@@ -1,0 +1,30 @@
+/* @flow */
+
+import * as Constants from '../constants/signup'
+
+import type {SignupActions, CheckInviteCode} from '../constants/signup'
+
+export type SignupState = {
+  inviteCodeError: ?string,
+}
+
+const initialState: SignupState = {
+  inviteCodeError: null
+}
+
+export default function (state: SignupState = initialState, action: SignupActions): SignupState {
+  switch (action.type) {
+    case Constants.checkInviteCode:
+      // Assert this is the type we're looking at
+      var _t: CheckInviteCode = action
+      if (action.error && action.error === true) {
+        return {
+          ...state,
+          inviteCodeError: action.payload.errorText
+        }
+      }
+      return state
+    default:
+      return state
+  }
+}

--- a/shared/reducers/signup.js
+++ b/shared/reducers/signup.js
@@ -16,7 +16,7 @@ export default function (state: SignupState = initialState, action: SignupAction
   switch (action.type) {
     case Constants.checkInviteCode:
       // Assert this is the type we're looking at
-      var _t: CheckInviteCode = action
+      var action: CheckInviteCode = action
       if (action.error && action.error === true) {
         return {
           ...state,


### PR DESCRIPTION
@keybase/react-hackers 

Check out https://github.com/keybase/client/pull/1881 first since it adds some type stuff this relies on. 

Here we introduce the actions, reducers, constants for signup. and introduce the invite code component.

A new thing here is `TypedAsyncAction` which allows you to specify the types of async actions and what the dispatch will receive. So for example you could do `TypedAsyncAction<SignupActions>` and that means flow will not allow you to dispatch anything that doesn't match a SignupAction. If you need to dispatch another type of action you can do that too by making a union like `TypedAsyncAction<SignupActions | RouteAppend>`, not only do you get type guarantees you also document what the code will dispatch too!


Currently we don't have a service call we can make to check if an invite code is valid, but we probably want one. so this is left as a TODO for now.

@maxtaco should I make a core ticket for the `isValidInviteCode` call?