### PR TITLE
Fixes npm run start-hot if npm run hot-server is cold started

### DIFF
--- a/desktop/client.js
+++ b/desktop/client.js
@@ -13,12 +13,10 @@ const name = 'dist/main.hot.bundle.js'
 const file = fs.createWriteStream(name)
 http.get('http://localhost:4000/dist/main.bundle.js', function (response) {
   response.pipe(file)
-  const e = spawn(electron, [name])
-  e.stdout.on('data', function (data) {
-    console.log(data.toString())
-  })
-
-  e.stderr.on('data', function (data) {
-    console.log('E: ' + data)
+  file.on('finish', function() {
+    file.close(function () {
+      const e = spawn(electron, [name], {stdio: 'inherit'})
+      e.on('close', function () {})
+    })
   })
 })


### PR DESCRIPTION
Fixes this timing issue, pipe wasn't necessarily written out before electron was spawned

@keybase/react-hackers 