### PR TITLE
stop stripping whitespace from the armored keys we hash

### DIFF
--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -95,6 +95,7 @@ type RawKeyFamily struct {
 // merged version of the key without revocations, and each individual version
 // of the key with revocations intact.
 type PGPKeySet struct {
+	Contextified
 	PermissivelyMergedKey *PGPKeyBundle
 	KeysByHash            map[string]*PGPKeyBundle
 }
@@ -125,6 +126,7 @@ func (s *PGPKeySet) addKey(key *PGPKeyBundle) error {
 	// behavior (for sigchains or sections of sigchains with no specific PGP
 	// key hash) and the new behavior.
 
+	s.G().Log.Debug("adding PGP kid %s with full hash %s", key.GetKID().String(), fullHash)
 	s.KeysByHash[fullHash] = key
 
 	strippedKey := key.StripRevocations()
@@ -352,7 +354,7 @@ func ParseKeyFamily(g *GlobalContext, jw *jsonw.Wrapper) (ret *KeyFamily, err er
 		if pgp, isPGP := newKey.(*PGPKeyBundle); isPGP {
 			ks, ok := kf.PGPKeySets[kid]
 			if !ok {
-				ks = &PGPKeySet{nil, make(map[string]*PGPKeyBundle)}
+				ks = &PGPKeySet{NewContextified(g), nil, make(map[string]*PGPKeyBundle)}
 				kf.PGPKeySets[kid] = ks
 
 				fp := pgp.GetFingerprint()

--- a/go/libkb/pgp_key.go
+++ b/go/libkb/pgp_key.go
@@ -288,11 +288,11 @@ func cleanPGPInput(s string) string {
 
 // note:  openpgp.ReadArmoredKeyRing only returns the first block.
 // It will never return multiple entities.
-func ReadOneKeyFromString(s string) (*PGPKeyBundle, error) {
-	s = cleanPGPInput(s)
-	reader := strings.NewReader(s)
+func ReadOneKeyFromString(originalArmor string) (*PGPKeyBundle, error) {
+	cleanArmor := cleanPGPInput(originalArmor)
+	reader := strings.NewReader(cleanArmor)
 	el, err := openpgp.ReadArmoredKeyRing(reader)
-	return finishReadOne(el, s, err)
+	return finishReadOne(el, originalArmor, err)
 }
 
 // firstPrivateKey scans s for a private key block.


### PR DESCRIPTION
@maxtaco This fixes https://github.com/keybase/client/issues/1908, but I'm going to need to do a lot of checking to make sure it doesn't fail anyone else's chain. In particular, any pgp_update link made with the Go client could be at risk, if client stripped any whitespace from the armored string before making it. Ultimately we might have to fix this by doctoring *the server's version* of some people's PGP keys to match what their clients actually signed.