### PR TITLE
fix forward-compatibility problems with new RPCs unhandled by old services

### DIFF
--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -119,7 +119,10 @@ func mainInner(g *libkb.GlobalContext) error {
 	// its PATH if necessary. This is called after FixVersionClash(), which
 	// happens above in configureProcesses().
 	if err = configurePath(g, cl); err != nil {
-		return err
+		// Further note -- don't die here.  It could be we're calling this method
+		// against an earlier version of the service that doesn't support it.
+		// It's not critical that it succeed, so continue on.
+		g.Log.Notice("Configure path failed: %v\n", err)
 	}
 
 	return cmd.Run()

--- a/go/vendor/github.com/keybase/go-framed-msgpack-rpc/dispatch.go
+++ b/go/vendor/github.com/keybase/go-framed-msgpack-rpc/dispatch.go
@@ -80,7 +80,11 @@ func (d *dispatch) Call(ctx context.Context, name string, arg interface{}, res i
 
 func (d *dispatch) Notify(ctx context.Context, name string, arg interface{}) error {
 	rpcTags, _ := RpcTagsFromContext(ctx)
-	errCh := d.writer.EncodeAndWrite(ctx, []interface{}{MethodNotify, name, arg, rpcTags})
+	v := []interface{}{MethodNotify, name, arg}
+	if len(rpcTags) > 0 {
+		v = append(v, rpcTags)
+	}
+	errCh := d.writer.EncodeAndWrite(ctx, v)
 	select {
 	case err := <-errCh:
 		if err == nil {

--- a/go/vendor/github.com/keybase/go-framed-msgpack-rpc/receiver.go
+++ b/go/vendor/github.com/keybase/go-framed-msgpack-rpc/receiver.go
@@ -112,7 +112,7 @@ func (r *receiveHandler) receiveCancel(rpc *rpcCancelMessage) error {
 func (r *receiveHandler) handleReceiveDispatch(req request) error {
 	if req.Err() != nil {
 		req.LogInvocation(req.Err())
-		return req.Reply(r.writer, nil, wrapError(nil, req.Err()))
+		return req.Reply(r.writer, nil, wrapError(r.protHandler.wef, req.Err()))
 	}
 	serveHandler, wrapErrorFunc, se := r.protHandler.findServeHandler(req.Name())
 	if se != nil {

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -149,8 +149,8 @@
 		},
 		{
 			"path": "github.com/keybase/go-framed-msgpack-rpc",
-			"revision": "0d22f1a7bfb5638724d7ca7e32b0be220d4ace93",
-			"revisionTime": "2016-02-05T14:35:36-05:00"
+			"revision": "8290ec13128f8375b58c7ff301b8de8775725e13",
+			"revisionTime": "2016-02-05T19:42:04-06:00"
 		},
 		{
 			"path": "github.com/keybase/go-jsonw",


### PR DESCRIPTION
- vendor in new RPC library
- no fail-stop errors if `configPath` fails