### PR TITLE
libkb: fix PGP update problem in jwives's sigchain

### DIFF
--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -434,6 +434,14 @@ func (sc *SigChain) verifySubchain(kf KeyFamily, links []*ChainLink) (cached boo
 		isModifyingKeys := isDelegating || tcl.Type() == PGPUpdateType
 		isFinalLink := (linkIndex == len(links)-1)
 		isLastLinkInSameKeyRun := (isFinalLink || newKID != links[linkIndex+1].GetKID())
+
+		if pgpcl, ok := tcl.(*PGPUpdateChainLink); ok {
+			if hash := pgpcl.GetPGPFullHash(); hash != "" {
+				sc.G().Log.Debug("| Setting active PGP hash for %s: %s", pgpcl.kid, hash)
+				ckf.SetActivePGPHash(pgpcl.kid, hash)
+			}
+		}
+
 		if isModifyingKeys || isFinalLink || isLastLinkInSameKeyRun {
 			_, err = link.VerifySigWithKeyFamily(ckf)
 			if err != nil {
@@ -447,13 +455,6 @@ func (sc *SigChain) verifySubchain(kf KeyFamily, links []*ChainLink) (cached boo
 			if err != nil {
 				sc.G().Log.Debug("| Failure in Delegate: %s", err)
 				return
-			}
-		}
-
-		if pgpcl, ok := tcl.(*PGPUpdateChainLink); ok {
-			if hash := pgpcl.GetPGPFullHash(); hash != "" {
-				sc.G().Log.Debug("| Setting active PGP hash for %s: %s", pgpcl.kid, hash)
-				ckf.SetActivePGPHash(pgpcl.kid, hash)
 			}
 		}
 


### PR DESCRIPTION
- the issue was that he's using a PGP update link to sign in a new signing subkey
- he's likely to use the new key and not the old when signing the PGP update link
- and therefore the old PGP update key won't work for verifying, since it lacks the
  proper subkeys that are being introduced in this signature.

We might eventually need to try both the new and the old, be on the lookout
for bugs as a result of this commit.