### PR TITLE
libkb: fix for logUI recursive log explosion

### DIFF
--- a/go/client/versionfix.go
+++ b/go/client/versionfix.go
@@ -70,7 +70,7 @@ func FixVersionClash(g *libkb.GlobalContext, cl libkb.CommandLine) (err error) {
 	if err != nil {
 		return err
 	}
-	xp := libkb.NewTransportFromSocket(socket)
+	xp := libkb.NewTransportFromSocket(g, socket)
 	srv := rpc.NewServer(xp, libkb.WrapError)
 	gcli := rpc.NewClient(xp, libkb.ErrorUnwrapper{})
 	cli = keybase1.ConfigClient{Cli: gcli}

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -483,3 +483,15 @@ func (g *GlobalContext) GetMyClientDetails() keybase1.ClientDetails {
 		Version:    VersionString(),
 	}
 }
+
+func (g *GlobalContext) GetUnforwardedLogger() *logger.UnforwardedLogger {
+	if g.Log == nil {
+		return nil
+	}
+	log, ok := g.Log.(*logger.Standard)
+	if !ok {
+		g.Log.Notice("Can't make Unforwaded logger from a non-standard logger")
+		return nil
+	}
+	return (*logger.UnforwardedLogger)(log)
+}

--- a/go/libkb/rpc_log.go
+++ b/go/libkb/rpc_log.go
@@ -68,14 +68,16 @@ func getRPCLogOptions() *RPCLogOptions {
 	return rpcLogOptions
 }
 
-type RPCLogFactory struct{}
+type RPCLogFactory struct {
+	Contextified
+}
 
-func NewRPCLogFactory() *RPCLogFactory {
-	return &RPCLogFactory{}
+func NewRPCLogFactory(g *GlobalContext) *RPCLogFactory {
+	return &RPCLogFactory{Contextified: NewContextified(g)}
 }
 
 func (r *RPCLogFactory) NewLog(a net.Addr) rpc.LogInterface {
-	ret := rpc.SimpleLog{Addr: a, Out: G.Log, Opts: getRPCLogOptions()}
+	ret := rpc.SimpleLog{Addr: a, Out: r.G().GetUnforwardedLogger(), Opts: getRPCLogOptions()}
 	ret.TransportStart()
 	return ret
 }

--- a/go/libkb/socket.go
+++ b/go/libkb/socket.go
@@ -44,8 +44,8 @@ func (g *GlobalContext) BindToSocket() (net.Listener, error) {
 	return g.SocketInfo.BindToSocket()
 }
 
-func NewTransportFromSocket(s net.Conn) rpc.Transporter {
-	return rpc.NewTransport(s, NewRPCLogFactory(), WrapError)
+func NewTransportFromSocket(g *GlobalContext, s net.Conn) rpc.Transporter {
+	return rpc.NewTransport(s, NewRPCLogFactory(g), WrapError)
 }
 
 func (g *GlobalContext) GetSocket(clearError bool) (net.Conn, rpc.Transporter, bool, error) {
@@ -77,7 +77,7 @@ func (g *GlobalContext) GetSocket(clearError bool) (net.Conn, rpc.Transporter, b
 			isNew = true
 		}
 		if sw.err == nil {
-			sw.xp = NewTransportFromSocket(sw.conn)
+			sw.xp = NewTransportFromSocket(g, sw.conn)
 		}
 		g.SocketWrapper = &sw
 	}

--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -82,8 +82,7 @@ type Standard struct {
 	module         string
 	isTerminal     bool
 
-	shutdown bool
-
+	shutdown        bool
 	externalHandler ExternalHandler
 }
 
@@ -350,3 +349,15 @@ func PickFirstError(errors ...error) error {
 func (log *Standard) SetExternalHandler(handler ExternalHandler) {
 	log.externalHandler = handler
 }
+
+type UnforwardedLogger Standard
+
+func (log *Standard) GetUnforwardedLogger() *UnforwardedLogger {
+	return (*UnforwardedLogger)(log)
+}
+
+func (log *UnforwardedLogger) Debug(s string, args ...interface{})   { log.internal.Debug(s, args...) }
+func (log *UnforwardedLogger) Error(s string, args ...interface{})   { log.internal.Error(s, args...) }
+func (log *UnforwardedLogger) Warning(s string, args ...interface{}) { log.internal.Warning(s, args...) }
+func (log *UnforwardedLogger) Info(s string, args ...interface{})    { log.internal.Info(s, args...) }
+func (log *UnforwardedLogger) Profile(s string, args ...interface{}) { log.internal.Debug(s, args...) }

--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -358,6 +358,7 @@ func (log *Standard) GetUnforwardedLogger() *UnforwardedLogger {
 
 func (log *UnforwardedLogger) Debug(s string, args ...interface{})   { log.internal.Debug(s, args...) }
 func (log *UnforwardedLogger) Error(s string, args ...interface{})   { log.internal.Error(s, args...) }
+func (log *UnforwardedLogger) Errorf(s string, args ...interface{})  { log.internal.Error(s, args...) }
 func (log *UnforwardedLogger) Warning(s string, args ...interface{}) { log.internal.Warning(s, args...) }
 func (log *UnforwardedLogger) Info(s string, args ...interface{})    { log.internal.Info(s, args...) }
 func (log *UnforwardedLogger) Profile(s string, args ...interface{}) { log.internal.Debug(s, args...) }

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -84,7 +84,7 @@ func (d *Service) RegisterProtocols(srv *rpc.Server, xp rpc.Transporter, connID 
 }
 
 func (d *Service) Handle(c net.Conn) {
-	xp := rpc.NewTransport(c, libkb.NewRPCLogFactory(), libkb.WrapError)
+	xp := rpc.NewTransport(c, libkb.NewRPCLogFactory(d.G()), libkb.WrapError)
 
 	server := rpc.NewServer(xp, libkb.WrapError)
 


### PR DESCRIPTION
- make an `UnforwardedLogger` class, which ignores the external logger handler;
  pass this to RPC instead of the standard logger.
- Contextify the RPCLoggingFactory

Don't make any interface changes; this shouldn't affect other parts of the code
like KBFS.