### PR TITLE
fix static path to bash

### DIFF
--- a/packaging/binary_name.sh
+++ b/packaging/binary_name.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # Prints out the binary name ("keybase", "kbstage", or "kbdev") that
 # corresponds to the current bulid mode. This script helps us avoid duplicating

--- a/packaging/brew/brew.sh
+++ b/packaging/brew/brew.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Note:  this script isn't bulletproof, and you have to kind of know what you
 # are doing (editing the formula by hand, etc.), but it saves some time.

--- a/packaging/build_mode.sh
+++ b/packaging/build_mode.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # Prints out the current build mode ("production", "prerelease", "staging", or
 # "devel") as determined from the first command line arg. This script enforces

--- a/packaging/check_status_and_pull.sh
+++ b/packaging/check_status_and_pull.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # There are lots of places where we need to check stuff like:
 #   1) Does repo X exist?

--- a/packaging/clean_build_kbstage.sh
+++ b/packaging/clean_build_kbstage.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # This script is for users who want make staging builds from source. See
 # https://keybase.io/docs/client/client_architecture. We don't use it

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -u -o pipefail # Fail on error
 

--- a/packaging/export/export_kbfs.sh
+++ b/packaging/export/export_kbfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -u -o pipefail # Fail on error
 

--- a/packaging/github/kbfs.sh
+++ b/packaging/github/kbfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This creates a KBFS (beta) release on github from the current source/tagged version.
 

--- a/packaging/github/keybase.sh
+++ b/packaging/github/keybase.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This creates a Keybase release on github from the current source/tagged version.
 

--- a/packaging/goinstall.sh
+++ b/packaging/goinstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -u -o pipefail # Fail on error
 

--- a/packaging/linux/arch/package_here.sh
+++ b/packaging/linux/arch/package_here.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 set -e -u -o pipefail
 

--- a/packaging/linux/build_and_push_packages.sh
+++ b/packaging/linux/build_and_push_packages.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # This script does a complete Linux build and publishes the results:
 #   1) Build Linux binaries with Go and Electron

--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 set -e -u -o pipefail
 

--- a/packaging/linux/deb/layout_repo.sh
+++ b/packaging/linux/deb/layout_repo.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # Given a build root, invokes package_binaries.sh and then lays out the
 # resulting packages as they would be in a debian package server.

--- a/packaging/linux/deb/package_binaries.sh
+++ b/packaging/linux/deb/package_binaries.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # Builds the keybase binary and packages it into two ".deb" files, one for i386
 # and one for amd64. The argument to this script is the output directory of a

--- a/packaging/linux/docker_build.sh
+++ b/packaging/linux/docker_build.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # This script is the starting point for linux packaging builds. Here's what it
 # does:

--- a/packaging/linux/inside_docker_main.sh
+++ b/packaging/linux/inside_docker_main.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # This script is the starting point for everything that happens inside our
 # packaging docker. It expects to be invoked like this:

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # This script handles distro-independent Linux post-install tasks. Currently
 # that means creating the /keybase directory and making it writable. The deb-

--- a/packaging/linux/rpm/layout_repo.sh
+++ b/packaging/linux/rpm/layout_repo.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # Invokes the build_rpm.sh script in the Go client repo, copies the resulting
 # package here, and then updates the RPM repo hierarchy. Does not check for

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # Builds the keybase binary and packages it into two ".rpm" files, one for i386
 # and one for amd64. The argument to this script is the output directory of a

--- a/packaging/linux/tmux_nightly.sh
+++ b/packaging/linux/tmux_nightly.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # This is a script that you can run on boot to kick off a nightly build loop.
 # It requires tmux and gnome-terminal. One way to make it autostart, if you're

--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -u -o pipefail # Fail on error
 

--- a/packaging/prerelease/build_app_darwin.sh
+++ b/packaging/prerelease/build_app_darwin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -u -o pipefail # Fail on error
 

--- a/packaging/prerelease/build_kbfs.sh
+++ b/packaging/prerelease/build_kbfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -u -o pipefail # Fail on error
 

--- a/packaging/prerelease/build_keybase.sh
+++ b/packaging/prerelease/build_keybase.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -u -o pipefail # Fail on error
 

--- a/packaging/prerelease/s3_index.sh
+++ b/packaging/prerelease/s3_index.sh
@@ -1,5 +1,5 @@
 
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -u -o pipefail # Fail on error
 

--- a/packaging/release/kbfsstage_release.sh
+++ b/packaging/release/kbfsstage_release.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 #
 # kbfsstage_release.sh creates kbfsstage releases.

--- a/packaging/release/release.sh
+++ b/packaging/release/release.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 #
 # release.sh creates keybase releases.

--- a/packaging/slack/send.sh
+++ b/packaging/slack/send.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -u -o pipefail # Fail on error
 

--- a/packaging/version.sh
+++ b/packaging/version.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # Parse the version number out of our codebase and print it. This script exists
 # because our packaging process needs the version number in a lot of places,


### PR DESCRIPTION
On systems like OpenBSD and FreeBSD `bash` is not installed in /bin. This PR switches scripts to use the POSIX `env` to determine the location of `bash`

More info on [env](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/env.html).

I didn't change scripts outside of the `packaging` directory, but I can if needed. Here is a snip from the script I used to fix this:

```
find . -name \*.sh -exec sed -i 's$#!/bin/bash$#!/usr/bin/env bash$g' {} \;
```