### PR TITLE
fix hot reload

### DIFF
--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -60,7 +60,14 @@ class Keybase extends Component {
     setupContextMenu(electron.remote.getCurrentWindow())
 
     // Used by material-ui widgets.
-    injectTapEventPlugin()
+    if (module.hot) {
+      // Don't reload this thing if we're hot reloading
+      if (module.hot.data === undefined) {
+        injectTapEventPlugin()
+      }
+    } else {
+      injectTapEventPlugin()
+    }
 
     this.setupDispatchAction()
     this.setupStoreSubscriptions()


### PR DESCRIPTION
so this broke with some new updates. the tap even plugin doesn't like to be loaded multiple times so this just stops that. when hot loading module.hot.data will have stuff in it on subsequent loads so we can use this to load once

@keybase/react-hackers 