### PR TITLE
Add SessionID to delegated SecretUI

### DIFF
--- a/go/client/cmd_login.go
+++ b/go/client/cmd_login.go
@@ -42,6 +42,7 @@ type CmdLogin struct {
 	clientType keybase1.ClientType
 	cancel     func()
 	done       chan struct{}
+	SessionID  int
 }
 
 func NewCmdLoginRunner(g *libkb.GlobalContext) *CmdLogin {
@@ -82,6 +83,7 @@ func (c *CmdLogin) Run() error {
 			Username:   c.username,
 			DeviceType: libkb.DeviceTypeDesktop,
 			ClientType: c.clientType,
+			SessionID:  c.SessionID,
 		})
 	c.done <- struct{}{}
 

--- a/go/engine/context.go
+++ b/go/engine/context.go
@@ -25,6 +25,8 @@ type Context struct {
 	LoginContext libkb.LoginContext
 	NetContext   context.Context
 	SaltpackUI   libkb.SaltpackUI
+
+	SessionID int
 }
 
 func (c *Context) HasUI(kind libkb.UIKind) bool {

--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -88,7 +88,7 @@ func delegateUIs(e Engine, ctx *Context) error {
 	// perhaps should iterate over all registered UIs in UIRouter.
 
 	if requiresUI(e, libkb.SecretUIKind) {
-		if ui, err := e.G().UIRouter.GetSecretUI(); err != nil {
+		if ui, err := e.G().UIRouter.GetSecretUI(ctx.SessionID); err != nil {
 			return err
 		} else if ui != nil {
 			e.G().Log.Debug("using delegated secret UI for engine %q", e.Name())

--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -91,7 +91,7 @@ func delegateUIs(e Engine, ctx *Context) error {
 		if ui, err := e.G().UIRouter.GetSecretUI(ctx.SessionID); err != nil {
 			return err
 		} else if ui != nil {
-			e.G().Log.Debug("using delegated secret UI for engine %q", e.Name())
+			e.G().Log.Debug("using delegated secret UI for engine %q (session id = %d)", e.Name(), ctx.SessionID)
 			ctx.SecretUI = ui
 		}
 	}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -385,7 +385,7 @@ type UIRouter interface {
 	// Both of these are allowed to return nil for the UI even if
 	// error is nil.
 	GetIdentifyUI() (IdentifyUI, error)
-	GetSecretUI() (SecretUI, error)
+	GetSecretUI(sessionID int) (SecretUI, error)
 	GetUpdateUI() (UpdateUI, error)
 
 	Shutdown()

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -836,16 +836,19 @@ type UnboxAnyRes struct {
 }
 
 type SignED25519Arg struct {
-	Msg    []byte `codec:"msg" json:"msg"`
-	Reason string `codec:"reason" json:"reason"`
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	Msg       []byte `codec:"msg" json:"msg"`
+	Reason    string `codec:"reason" json:"reason"`
 }
 
 type SignToStringArg struct {
-	Msg    []byte `codec:"msg" json:"msg"`
-	Reason string `codec:"reason" json:"reason"`
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	Msg       []byte `codec:"msg" json:"msg"`
+	Reason    string `codec:"reason" json:"reason"`
 }
 
 type UnboxBytes32Arg struct {
+	SessionID        int              `codec:"sessionID" json:"sessionID"`
 	EncryptedBytes32 EncryptedBytes32 `codec:"encryptedBytes32" json:"encryptedBytes32"`
 	Nonce            BoxNonce         `codec:"nonce" json:"nonce"`
 	PeersPublicKey   BoxPublicKey     `codec:"peersPublicKey" json:"peersPublicKey"`
@@ -853,6 +856,7 @@ type UnboxBytes32Arg struct {
 }
 
 type UnboxBytes32AnyArg struct {
+	SessionID   int                `codec:"sessionID" json:"sessionID"`
 	Bundles     []CiphertextBundle `codec:"bundles" json:"bundles"`
 	Reason      string             `codec:"reason" json:"reason"`
 	PromptPaper bool               `codec:"promptPaper" json:"promptPaper"`

--- a/go/service/account.go
+++ b/go/service/account.go
@@ -26,7 +26,8 @@ func NewAccountHandler(xp rpc.Transporter, g *libkb.GlobalContext) *AccountHandl
 func (h *AccountHandler) PassphraseChange(_ context.Context, arg keybase1.PassphraseChangeArg) error {
 	eng := engine.NewPassphraseChange(&arg, h.G())
 	ctx := &engine.Context{
-		SecretUI: h.getSecretUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID),
+		SessionID: arg.SessionID,
 	}
 	return engine.RunEngine(eng, ctx)
 }
@@ -34,7 +35,7 @@ func (h *AccountHandler) PassphraseChange(_ context.Context, arg keybase1.Passph
 func (h *AccountHandler) PassphrasePrompt(_ context.Context, arg keybase1.PassphrasePromptArg) (keybase1.GetPassphraseRes, error) {
 	ui := h.getSecretUI(arg.SessionID)
 	if h.G().UIRouter != nil {
-		delegateUI, err := h.G().UIRouter.GetSecretUI()
+		delegateUI, err := h.G().UIRouter.GetSecretUI(arg.SessionID)
 		if err != nil {
 			return keybase1.GetPassphraseRes{}, err
 		}

--- a/go/service/account.go
+++ b/go/service/account.go
@@ -26,14 +26,14 @@ func NewAccountHandler(xp rpc.Transporter, g *libkb.GlobalContext) *AccountHandl
 func (h *AccountHandler) PassphraseChange(_ context.Context, arg keybase1.PassphraseChangeArg) error {
 	eng := engine.NewPassphraseChange(&arg, h.G())
 	ctx := &engine.Context{
-		SecretUI:  h.getSecretUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID, h.G()),
 		SessionID: arg.SessionID,
 	}
 	return engine.RunEngine(eng, ctx)
 }
 
 func (h *AccountHandler) PassphrasePrompt(_ context.Context, arg keybase1.PassphrasePromptArg) (keybase1.GetPassphraseRes, error) {
-	ui := h.getSecretUI(arg.SessionID)
+	ui := h.getSecretUI(arg.SessionID, h.G())
 	if h.G().UIRouter != nil {
 		delegateUI, err := h.G().UIRouter.GetSecretUI(arg.SessionID)
 		if err != nil {

--- a/go/service/btc.go
+++ b/go/service/btc.go
@@ -26,8 +26,9 @@ func NewBTCHandler(xp rpc.Transporter, g *libkb.GlobalContext) *BTCHandler {
 // BTC creates a BTCEngine and runs it.
 func (h *BTCHandler) RegisterBTC(_ context.Context, arg keybase1.RegisterBTCArg) error {
 	ctx := engine.Context{
-		LogUI:    h.getLogUI(arg.SessionID),
-		SecretUI: h.getSecretUI(arg.SessionID),
+		LogUI:     h.getLogUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID),
+		SessionID: arg.SessionID,
 	}
 	eng := engine.NewBTCEngine(arg.Address, arg.Force, h.G())
 	return engine.RunEngine(eng, &ctx)

--- a/go/service/btc.go
+++ b/go/service/btc.go
@@ -27,7 +27,7 @@ func NewBTCHandler(xp rpc.Transporter, g *libkb.GlobalContext) *BTCHandler {
 func (h *BTCHandler) RegisterBTC(_ context.Context, arg keybase1.RegisterBTCArg) error {
 	ctx := engine.Context{
 		LogUI:     h.getLogUI(arg.SessionID),
-		SecretUI:  h.getSecretUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID, h.G()),
 		SessionID: arg.SessionID,
 	}
 	eng := engine.NewBTCEngine(arg.Address, arg.Force, h.G())

--- a/go/service/crypto.go
+++ b/go/service/crypto.go
@@ -20,10 +20,10 @@ func NewCryptoHandler(g *libkb.GlobalContext) *CryptoHandler {
 	}
 }
 
-func (c *CryptoHandler) getDelegatedSecretUI() libkb.SecretUI {
+func (c *CryptoHandler) getDelegatedSecretUI(sessionID int) libkb.SecretUI {
 	// We should only ever be called in service mode, so UIRouter
 	// should be non-nil.
-	ui, err := c.G().UIRouter.GetSecretUI()
+	ui, err := c.G().UIRouter.GetSecretUI(sessionID)
 	if err != nil {
 		c.G().Log.Debug("UIRouter.GetSecretUI() returned an error %v", err)
 		return nil
@@ -49,8 +49,8 @@ func (e errorSecretUI) GetPassphrase(keybase1.GUIEntryArg, *keybase1.SecretEntry
 	return keybase1.GetPassphraseRes{}, libkb.LoginRequiredError{Context: e.reason}
 }
 
-func (c *CryptoHandler) getSecretUI(reason string) libkb.SecretUI {
-	secretUI := c.getDelegatedSecretUI()
+func (c *CryptoHandler) getSecretUI(sessionID int, reason string) libkb.SecretUI {
+	secretUI := c.getDelegatedSecretUI(sessionID)
 	if secretUI != nil {
 		return secretUI
 	}
@@ -61,17 +61,17 @@ func (c *CryptoHandler) getSecretUI(reason string) libkb.SecretUI {
 }
 
 func (c *CryptoHandler) SignED25519(_ context.Context, arg keybase1.SignED25519Arg) (keybase1.ED25519SignatureInfo, error) {
-	return engine.SignED25519(c.G(), c.getSecretUI(arg.Reason), arg)
+	return engine.SignED25519(c.G(), c.getSecretUI(arg.SessionID, arg.Reason), arg)
 }
 
 func (c *CryptoHandler) SignToString(_ context.Context, arg keybase1.SignToStringArg) (string, error) {
-	return engine.SignToString(c.G(), c.getSecretUI(arg.Reason), arg)
+	return engine.SignToString(c.G(), c.getSecretUI(arg.SessionID, arg.Reason), arg)
 }
 
 func (c *CryptoHandler) UnboxBytes32(_ context.Context, arg keybase1.UnboxBytes32Arg) (keybase1.Bytes32, error) {
-	return engine.UnboxBytes32(c.G(), c.getSecretUI(arg.Reason), arg)
+	return engine.UnboxBytes32(c.G(), c.getSecretUI(arg.SessionID, arg.Reason), arg)
 }
 
 func (c *CryptoHandler) UnboxBytes32Any(_ context.Context, arg keybase1.UnboxBytes32AnyArg) (keybase1.UnboxAnyRes, error) {
-	return engine.UnboxBytes32Any(c.G(), c.getSecretUI(arg.Reason), arg)
+	return engine.UnboxBytes32Any(c.G(), c.getSecretUI(arg.SessionID, arg.Reason), arg)
 }

--- a/go/service/crypto_test.go
+++ b/go/service/crypto_test.go
@@ -21,7 +21,7 @@ func (f fakeUIRouter) GetIdentifyUI() (libkb.IdentifyUI, error) {
 	return nil, errors.New("Unexpected GetIdentifyUI call")
 }
 
-func (f fakeUIRouter) GetSecretUI() (libkb.SecretUI, error) {
+func (f fakeUIRouter) GetSecretUI(int) (libkb.SecretUI, error) {
 	return f.secretUI, f.secretUIErr
 }
 
@@ -46,21 +46,21 @@ func TestCryptoSecretUI(t *testing.T) {
 	// Should return errorSecretUI because UIRouter returned an
 	// error.
 	tc.G.SetUIRouter(fakeUIRouter{secretUIErr: errors.New("fake error")})
-	secretUI := c.getSecretUI("")
+	secretUI := c.getSecretUI(0, "")
 	if _, ok := secretUI.(errorSecretUI); !ok {
 		t.Errorf("secretUI %v is not an errorSecretUI", secretUI)
 	}
 
 	// Should return errorSecretUI because UIRouter returned nil.
 	tc.G.SetUIRouter(fakeUIRouter{})
-	secretUI = c.getSecretUI("")
+	secretUI = c.getSecretUI(0, "")
 	if _, ok := secretUI.(errorSecretUI); !ok {
 		t.Errorf("secretUI %v is not an errorSecretUI", secretUI)
 	}
 
 	// Should return nullSecretUI..
 	tc.G.SetUIRouter(fakeUIRouter{secretUI: nullSecretUI{}})
-	secretUI = c.getSecretUI("")
+	secretUI = c.getSecretUI(0, "")
 	if _, ok := secretUI.(nullSecretUI); !ok {
 		t.Errorf("secretUI %v is not a nullSecretUI", secretUI)
 	}

--- a/go/service/ctl.go
+++ b/go/service/ctl.go
@@ -45,7 +45,8 @@ func (c *CtlHandler) Reload(_ context.Context, sessionID int) error {
 
 func (c *CtlHandler) DbNuke(_ context.Context, sessionID int) error {
 	ctx := engine.Context{
-		LogUI: c.getLogUI(sessionID),
+		LogUI:     c.getLogUI(sessionID),
+		SessionID: sessionID,
 	}
 
 	fn, err := c.G().LocalDb.Nuke()

--- a/go/service/device.go
+++ b/go/service/device.go
@@ -27,7 +27,10 @@ func NewDeviceHandler(xp rpc.Transporter, g *libkb.GlobalContext) *DeviceHandler
 
 // DeviceList returns a list of all the devices for a user.
 func (h *DeviceHandler) DeviceList(_ context.Context, sessionID int) ([]keybase1.Device, error) {
-	ctx := &engine.Context{LogUI: h.getLogUI(sessionID)}
+	ctx := &engine.Context{
+		LogUI:     h.getLogUI(sessionID),
+		SessionID: sessionID,
+	}
 	eng := engine.NewDevList(h.G())
 	if err := engine.RunEngine(eng, ctx); err != nil {
 		return nil, err
@@ -41,6 +44,7 @@ func (h *DeviceHandler) DeviceAdd(_ context.Context, sessionID int) error {
 	ctx := &engine.Context{
 		ProvisionUI: h.getProvisionUI(sessionID),
 		SecretUI:    h.getSecretUI(sessionID),
+		SessionID:   sessionID,
 	}
 	eng := engine.NewDeviceAdd(h.G())
 	return engine.RunEngine(eng, ctx)

--- a/go/service/device.go
+++ b/go/service/device.go
@@ -43,7 +43,7 @@ func (h *DeviceHandler) DeviceList(_ context.Context, sessionID int) ([]keybase1
 func (h *DeviceHandler) DeviceAdd(_ context.Context, sessionID int) error {
 	ctx := &engine.Context{
 		ProvisionUI: h.getProvisionUI(sessionID),
-		SecretUI:    h.getSecretUI(sessionID),
+		SecretUI:    h.getSecretUI(sessionID, h.G()),
 		SessionID:   sessionID,
 	}
 	eng := engine.NewDeviceAdd(h.G())

--- a/go/service/handler.go
+++ b/go/service/handler.go
@@ -55,11 +55,13 @@ func (u *LoginUI) DisplayPrimaryPaperKey(ctx context.Context, arg keybase1.Displ
 type SecretUI struct {
 	sessionID int
 	cli       *keybase1.SecretUiClient
+	libkb.Contextified
 }
 
 // GetPassphrase gets the current keybase passphrase from delegated pinentry.
-func (l *SecretUI) GetPassphrase(pinentry keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
-	return l.cli.GetPassphrase(context.TODO(), keybase1.GetPassphraseArg{SessionID: l.sessionID, Pinentry: pinentry, Terminal: terminal})
+func (u *SecretUI) GetPassphrase(pinentry keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
+	u.G().Log.Debug("SecretUI:GetPassphrase, sessionID = %d", u.sessionID)
+	return u.cli.GetPassphrase(context.TODO(), keybase1.GetPassphraseArg{SessionID: u.sessionID, Pinentry: pinentry, Terminal: terminal})
 }
 
 func (h *BaseHandler) rpcClient() *rpc.Client {
@@ -86,8 +88,12 @@ func (h *BaseHandler) getSecretUICli() *keybase1.SecretUiClient {
 	return h.secretCli
 }
 
-func (h *BaseHandler) getSecretUI(sessionID int) libkb.SecretUI {
-	return &SecretUI{sessionID, h.getSecretUICli()}
+func (h *BaseHandler) getSecretUI(sessionID int, g *libkb.GlobalContext) libkb.SecretUI {
+	return &SecretUI{
+		sessionID:    sessionID,
+		cli:          h.getSecretUICli(),
+		Contextified: libkb.NewContextified(g),
+	}
 }
 
 func (h *BaseHandler) getLogUICli() *keybase1.LogUiClient {

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -52,6 +52,7 @@ func (h *IdentifyHandler) Identify2(_ context.Context, arg keybase1.Identify2Arg
 	ctx := engine.Context{
 		LogUI:      logui,
 		IdentifyUI: iui,
+		SessionID:  arg.SessionID,
 	}
 	eng := engine.NewResolveThenIdentify2(h.G(), &arg)
 	err = engine.RunEngine(eng, &ctx)
@@ -163,6 +164,7 @@ func (h *IdentifyHandler) makeContext(sessionID int, arg keybase1.IdentifyArg) (
 	ctx := engine.Context{
 		LogUI:      logui,
 		IdentifyUI: iui,
+		SessionID:  sessionID,
 	}
 	return &ctx, nil
 }

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -35,8 +35,9 @@ func (h *LoginHandler) Logout(_ context.Context, sessionID int) error {
 func (h *LoginHandler) Deprovision(_ context.Context, arg keybase1.DeprovisionArg) error {
 	eng := engine.NewDeprovisionEngine(h.G(), arg.Username)
 	ctx := engine.Context{
-		LogUI:    h.getLogUI(arg.SessionID),
-		SecretUI: h.getSecretUI(arg.SessionID),
+		LogUI:     h.getLogUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID),
+		SessionID: arg.SessionID,
 	}
 	return engine.RunEngine(eng, &ctx)
 }
@@ -65,9 +66,10 @@ func (h *LoginHandler) ClearStoredSecret(_ context.Context, arg keybase1.ClearSt
 
 func (h *LoginHandler) PaperKey(_ context.Context, sessionID int) error {
 	ctx := &engine.Context{
-		LogUI:    h.getLogUI(sessionID),
-		LoginUI:  h.getLoginUI(sessionID),
-		SecretUI: h.getSecretUI(sessionID),
+		LogUI:     h.getLogUI(sessionID),
+		LoginUI:   h.getLoginUI(sessionID),
+		SecretUI:  h.getSecretUI(sessionID),
+		SessionID: sessionID,
 	}
 	eng := engine.NewPaperKey(h.G())
 	return engine.RunEngine(eng, ctx)
@@ -75,8 +77,9 @@ func (h *LoginHandler) PaperKey(_ context.Context, sessionID int) error {
 
 func (h *LoginHandler) Unlock(_ context.Context, sessionID int) error {
 	ctx := &engine.Context{
-		LogUI:    h.getLogUI(sessionID),
-		SecretUI: h.getSecretUI(sessionID),
+		LogUI:     h.getLogUI(sessionID),
+		SecretUI:  h.getSecretUI(sessionID),
+		SessionID: sessionID,
 	}
 	eng := engine.NewUnlock(h.G())
 	return engine.RunEngine(eng, ctx)
@@ -84,8 +87,9 @@ func (h *LoginHandler) Unlock(_ context.Context, sessionID int) error {
 
 func (h *LoginHandler) UnlockWithPassphrase(_ context.Context, arg keybase1.UnlockWithPassphraseArg) error {
 	ctx := &engine.Context{
-		LogUI:    h.getLogUI(arg.SessionID),
-		SecretUI: h.getSecretUI(arg.SessionID),
+		LogUI:     h.getLogUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID),
+		SessionID: arg.SessionID,
 	}
 	eng := engine.NewUnlockWithPassphrase(h.G(), arg.Passphrase)
 	return engine.RunEngine(eng, ctx)
@@ -99,6 +103,7 @@ func (h *LoginHandler) Login(ctx context.Context, arg keybase1.LoginArg) error {
 		SecretUI:    h.getSecretUI(arg.SessionID),
 		GPGUI:       h.getGPGUI(arg.SessionID),
 		NetContext:  ctx,
+		SessionID:   arg.SessionID,
 	}
 	eng := engine.NewLogin(h.G(), arg.DeviceType, arg.Username, arg.ClientType)
 	return engine.RunEngine(eng, ectx)

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -36,7 +36,7 @@ func (h *LoginHandler) Deprovision(_ context.Context, arg keybase1.DeprovisionAr
 	eng := engine.NewDeprovisionEngine(h.G(), arg.Username)
 	ctx := engine.Context{
 		LogUI:     h.getLogUI(arg.SessionID),
-		SecretUI:  h.getSecretUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID, h.G()),
 		SessionID: arg.SessionID,
 	}
 	return engine.RunEngine(eng, &ctx)
@@ -68,7 +68,7 @@ func (h *LoginHandler) PaperKey(_ context.Context, sessionID int) error {
 	ctx := &engine.Context{
 		LogUI:     h.getLogUI(sessionID),
 		LoginUI:   h.getLoginUI(sessionID),
-		SecretUI:  h.getSecretUI(sessionID),
+		SecretUI:  h.getSecretUI(sessionID, h.G()),
 		SessionID: sessionID,
 	}
 	eng := engine.NewPaperKey(h.G())
@@ -78,7 +78,7 @@ func (h *LoginHandler) PaperKey(_ context.Context, sessionID int) error {
 func (h *LoginHandler) Unlock(_ context.Context, sessionID int) error {
 	ctx := &engine.Context{
 		LogUI:     h.getLogUI(sessionID),
-		SecretUI:  h.getSecretUI(sessionID),
+		SecretUI:  h.getSecretUI(sessionID, h.G()),
 		SessionID: sessionID,
 	}
 	eng := engine.NewUnlock(h.G())
@@ -88,7 +88,7 @@ func (h *LoginHandler) Unlock(_ context.Context, sessionID int) error {
 func (h *LoginHandler) UnlockWithPassphrase(_ context.Context, arg keybase1.UnlockWithPassphraseArg) error {
 	ctx := &engine.Context{
 		LogUI:     h.getLogUI(arg.SessionID),
-		SecretUI:  h.getSecretUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID, h.G()),
 		SessionID: arg.SessionID,
 	}
 	eng := engine.NewUnlockWithPassphrase(h.G(), arg.Passphrase)
@@ -100,7 +100,7 @@ func (h *LoginHandler) Login(ctx context.Context, arg keybase1.LoginArg) error {
 		LogUI:       h.getLogUI(arg.SessionID),
 		LoginUI:     h.getLoginUI(arg.SessionID),
 		ProvisionUI: h.getProvisionUI(arg.SessionID),
-		SecretUI:    h.getSecretUI(arg.SessionID),
+		SecretUI:    h.getSecretUI(arg.SessionID, h.G()),
 		GPGUI:       h.getGPGUI(arg.SessionID),
 		NetContext:  ctx,
 		SessionID:   arg.SessionID,

--- a/go/service/pgp.go
+++ b/go/service/pgp.go
@@ -45,7 +45,7 @@ func (h *PGPHandler) PGPSign(_ context.Context, arg keybase1.PGPSignArg) (err er
 	snk := libkb.NewRemoteStreamBuffered(arg.Sink, cli, arg.SessionID)
 	earg := engine.PGPSignArg{Sink: snk, Source: src, Opts: arg.Opts}
 	ctx := engine.Context{
-		SecretUI:  h.getSecretUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID, h.G()),
 		SessionID: arg.SessionID,
 	}
 	eng := engine.NewPGPSignEngine(&earg, h.G())
@@ -82,7 +82,7 @@ func (h *PGPHandler) PGPEncrypt(_ context.Context, arg keybase1.PGPEncryptArg) e
 	}
 	ctx := &engine.Context{
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
-		SecretUI:   h.getSecretUI(arg.SessionID),
+		SecretUI:   h.getSecretUI(arg.SessionID, h.G()),
 		SessionID:  arg.SessionID,
 	}
 	eng := engine.NewPGPEncrypt(earg, h.G())
@@ -100,7 +100,7 @@ func (h *PGPHandler) PGPDecrypt(_ context.Context, arg keybase1.PGPDecryptArg) (
 		SignedBy:     arg.Opts.SignedBy,
 	}
 	ctx := &engine.Context{
-		SecretUI:   h.getSecretUI(arg.SessionID),
+		SecretUI:   h.getSecretUI(arg.SessionID, h.G()),
 		IdentifyUI: h.NewRemoteSkipPromptIdentifyUI(arg.SessionID, h.G()),
 		LogUI:      h.getLogUI(arg.SessionID),
 		PgpUI:      h.getPgpUI(arg.SessionID),
@@ -124,7 +124,7 @@ func (h *PGPHandler) PGPVerify(_ context.Context, arg keybase1.PGPVerifyArg) (ke
 		SignedBy:  arg.Opts.SignedBy,
 	}
 	ctx := &engine.Context{
-		SecretUI:   h.getSecretUI(arg.SessionID),
+		SecretUI:   h.getSecretUI(arg.SessionID, h.G()),
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
 		LogUI:      h.getLogUI(arg.SessionID),
 		PgpUI:      h.getPgpUI(arg.SessionID),
@@ -160,7 +160,7 @@ func sigVer(ss *libkb.SignatureStatus, owner *libkb.User) keybase1.PGPSigVerific
 
 func (h *PGPHandler) PGPImport(_ context.Context, arg keybase1.PGPImportArg) error {
 	ctx := &engine.Context{
-		SecretUI:  h.getSecretUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID, h.G()),
 		LogUI:     h.getLogUI(arg.SessionID),
 		SessionID: arg.SessionID,
 	}
@@ -179,7 +179,7 @@ type exporter interface {
 
 func (h *PGPHandler) export(sessionID int, ex exporter) ([]keybase1.KeyInfo, error) {
 	ctx := &engine.Context{
-		SecretUI:  h.getSecretUI(sessionID),
+		SecretUI:  h.getSecretUI(sessionID, h.G()),
 		LogUI:     h.getLogUI(sessionID),
 		SessionID: sessionID,
 	}
@@ -203,7 +203,7 @@ func (h *PGPHandler) PGPExportByFingerprint(_ context.Context, arg keybase1.PGPE
 func (h *PGPHandler) PGPKeyGen(_ context.Context, arg keybase1.PGPKeyGenArg) error {
 	ctx := &engine.Context{
 		LogUI:     h.getLogUI(arg.SessionID),
-		SecretUI:  h.getSecretUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID, h.G()),
 		SessionID: arg.SessionID,
 	}
 	earg := engine.ImportPGPKeyImportEngineArg(arg)
@@ -225,7 +225,7 @@ func (h *PGPHandler) PGPSelect(_ context.Context, sarg keybase1.PGPSelectArg) er
 	gpg := engine.NewGPGImportKeyEngine(&arg, h.G())
 	ctx := &engine.Context{
 		GPGUI:     h.getGPGUI(sarg.SessionID),
-		SecretUI:  h.getSecretUI(sarg.SessionID),
+		SecretUI:  h.getSecretUI(sarg.SessionID, h.G()),
 		LogUI:     h.getLogUI(sarg.SessionID),
 		LoginUI:   h.getLoginUI(sarg.SessionID),
 		SessionID: sarg.SessionID,
@@ -236,7 +236,7 @@ func (h *PGPHandler) PGPSelect(_ context.Context, sarg keybase1.PGPSelectArg) er
 func (h *PGPHandler) PGPUpdate(_ context.Context, arg keybase1.PGPUpdateArg) error {
 	ctx := engine.Context{
 		LogUI:     h.getLogUI(arg.SessionID),
-		SecretUI:  h.getSecretUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID, h.G()),
 		SessionID: arg.SessionID,
 	}
 	eng := engine.NewPGPUpdateEngine(arg.Fingerprints, arg.All, h.G())

--- a/go/service/prove.go
+++ b/go/service/prove.go
@@ -69,7 +69,7 @@ func (ph *ProveHandler) StartProof(_ context.Context, arg keybase1.StartProofArg
 	eng := engine.NewProve(&arg, ph.G())
 	ctx := engine.Context{
 		ProveUI:   ph.getProveUI(arg.SessionID),
-		SecretUI:  ph.getSecretUI(arg.SessionID),
+		SecretUI:  ph.getSecretUI(arg.SessionID, ph.G()),
 		LogUI:     ph.getLogUI(arg.SessionID),
 		SessionID: arg.SessionID,
 	}

--- a/go/service/prove.go
+++ b/go/service/prove.go
@@ -68,9 +68,10 @@ func (ph *ProveHandler) getProveUI(sessionID int) libkb.ProveUI {
 func (ph *ProveHandler) StartProof(_ context.Context, arg keybase1.StartProofArg) (res keybase1.StartProofResult, err error) {
 	eng := engine.NewProve(&arg, ph.G())
 	ctx := engine.Context{
-		ProveUI:  ph.getProveUI(arg.SessionID),
-		SecretUI: ph.getSecretUI(arg.SessionID),
-		LogUI:    ph.getLogUI(arg.SessionID),
+		ProveUI:   ph.getProveUI(arg.SessionID),
+		SecretUI:  ph.getSecretUI(arg.SessionID),
+		LogUI:     ph.getLogUI(arg.SessionID),
+		SessionID: arg.SessionID,
 	}
 	err = engine.RunEngine(eng, &ctx)
 	if err != nil {

--- a/go/service/revoke.go
+++ b/go/service/revoke.go
@@ -27,7 +27,7 @@ func (h *RevokeHandler) RevokeKey(_ context.Context, arg keybase1.RevokeKeyArg) 
 	sessionID := arg.SessionID
 	ctx := engine.Context{
 		LogUI:     h.getLogUI(sessionID),
-		SecretUI:  h.getSecretUI(sessionID),
+		SecretUI:  h.getSecretUI(sessionID, h.G()),
 		SessionID: arg.SessionID,
 	}
 	eng := engine.NewRevokeKeyEngine(arg.KeyID, h.G())
@@ -38,7 +38,7 @@ func (h *RevokeHandler) RevokeDevice(_ context.Context, arg keybase1.RevokeDevic
 	sessionID := arg.SessionID
 	ctx := engine.Context{
 		LogUI:     h.getLogUI(sessionID),
-		SecretUI:  h.getSecretUI(sessionID),
+		SecretUI:  h.getSecretUI(sessionID, h.G()),
 		SessionID: arg.SessionID,
 	}
 	eng := engine.NewRevokeDeviceEngine(engine.RevokeDeviceEngineArgs{ID: arg.DeviceID, Force: arg.Force}, h.G())
@@ -48,7 +48,7 @@ func (h *RevokeHandler) RevokeDevice(_ context.Context, arg keybase1.RevokeDevic
 func (h *RevokeHandler) RevokeSigs(_ context.Context, arg keybase1.RevokeSigsArg) error {
 	ctx := engine.Context{
 		LogUI:     h.getLogUI(arg.SessionID),
-		SecretUI:  h.getSecretUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID, h.G()),
 		SessionID: arg.SessionID,
 	}
 	eng := engine.NewRevokeSigsEngine(arg.SigIDQueries, h.G())

--- a/go/service/revoke.go
+++ b/go/service/revoke.go
@@ -26,8 +26,9 @@ func NewRevokeHandler(xp rpc.Transporter, g *libkb.GlobalContext) *RevokeHandler
 func (h *RevokeHandler) RevokeKey(_ context.Context, arg keybase1.RevokeKeyArg) error {
 	sessionID := arg.SessionID
 	ctx := engine.Context{
-		LogUI:    h.getLogUI(sessionID),
-		SecretUI: h.getSecretUI(sessionID),
+		LogUI:     h.getLogUI(sessionID),
+		SecretUI:  h.getSecretUI(sessionID),
+		SessionID: arg.SessionID,
 	}
 	eng := engine.NewRevokeKeyEngine(arg.KeyID, h.G())
 	return engine.RunEngine(eng, &ctx)
@@ -36,8 +37,9 @@ func (h *RevokeHandler) RevokeKey(_ context.Context, arg keybase1.RevokeKeyArg) 
 func (h *RevokeHandler) RevokeDevice(_ context.Context, arg keybase1.RevokeDeviceArg) error {
 	sessionID := arg.SessionID
 	ctx := engine.Context{
-		LogUI:    h.getLogUI(sessionID),
-		SecretUI: h.getSecretUI(sessionID),
+		LogUI:     h.getLogUI(sessionID),
+		SecretUI:  h.getSecretUI(sessionID),
+		SessionID: arg.SessionID,
 	}
 	eng := engine.NewRevokeDeviceEngine(engine.RevokeDeviceEngineArgs{ID: arg.DeviceID, Force: arg.Force}, h.G())
 	return engine.RunEngine(eng, &ctx)
@@ -45,8 +47,9 @@ func (h *RevokeHandler) RevokeDevice(_ context.Context, arg keybase1.RevokeDevic
 
 func (h *RevokeHandler) RevokeSigs(_ context.Context, arg keybase1.RevokeSigsArg) error {
 	ctx := engine.Context{
-		LogUI:    h.getLogUI(arg.SessionID),
-		SecretUI: h.getSecretUI(arg.SessionID),
+		LogUI:     h.getLogUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID),
+		SessionID: arg.SessionID,
 	}
 	eng := engine.NewRevokeSigsEngine(arg.SigIDQueries, h.G())
 	return engine.RunEngine(eng, &ctx)

--- a/go/service/saltpack.go
+++ b/go/service/saltpack.go
@@ -59,6 +59,7 @@ func (h *SaltpackHandler) SaltpackDecrypt(_ context.Context, arg keybase1.Saltpa
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
 		SecretUI:   h.getSecretUI(arg.SessionID),
 		SaltpackUI: h.getSaltpackUI(arg.SessionID),
+		SessionID:  arg.SessionID,
 	}
 	eng := engine.NewSaltpackDecrypt(earg, h.G())
 	err = engine.RunEngine(eng, ctx)
@@ -79,6 +80,7 @@ func (h *SaltpackHandler) SaltpackEncrypt(_ context.Context, arg keybase1.Saltpa
 	ctx := &engine.Context{
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
 		SecretUI:   h.getSecretUI(arg.SessionID),
+		SessionID:  arg.SessionID,
 	}
 	eng := engine.NewSaltpackEncrypt(earg, h.G())
 	return engine.RunEngine(eng, ctx)
@@ -97,6 +99,7 @@ func (h *SaltpackHandler) SaltpackSign(_ context.Context, arg keybase1.SaltpackS
 	ctx := &engine.Context{
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
 		SecretUI:   h.getSecretUI(arg.SessionID),
+		SessionID:  arg.SessionID,
 	}
 	eng := engine.NewSaltpackSign(earg, h.G())
 	return engine.RunEngine(eng, ctx)
@@ -116,6 +119,7 @@ func (h *SaltpackHandler) SaltpackVerify(_ context.Context, arg keybase1.Saltpac
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
 		SecretUI:   h.getSecretUI(arg.SessionID),
 		SaltpackUI: h.getSaltpackUI(arg.SessionID),
+		SessionID:  arg.SessionID,
 	}
 	eng := engine.NewSaltpackVerify(earg, h.G())
 	return engine.RunEngine(eng, ctx)

--- a/go/service/saltpack.go
+++ b/go/service/saltpack.go
@@ -57,7 +57,7 @@ func (h *SaltpackHandler) SaltpackDecrypt(_ context.Context, arg keybase1.Saltpa
 
 	ctx := &engine.Context{
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
-		SecretUI:   h.getSecretUI(arg.SessionID),
+		SecretUI:   h.getSecretUI(arg.SessionID, h.G()),
 		SaltpackUI: h.getSaltpackUI(arg.SessionID),
 		SessionID:  arg.SessionID,
 	}
@@ -79,7 +79,7 @@ func (h *SaltpackHandler) SaltpackEncrypt(_ context.Context, arg keybase1.Saltpa
 
 	ctx := &engine.Context{
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
-		SecretUI:   h.getSecretUI(arg.SessionID),
+		SecretUI:   h.getSecretUI(arg.SessionID, h.G()),
 		SessionID:  arg.SessionID,
 	}
 	eng := engine.NewSaltpackEncrypt(earg, h.G())
@@ -98,7 +98,7 @@ func (h *SaltpackHandler) SaltpackSign(_ context.Context, arg keybase1.SaltpackS
 
 	ctx := &engine.Context{
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
-		SecretUI:   h.getSecretUI(arg.SessionID),
+		SecretUI:   h.getSecretUI(arg.SessionID, h.G()),
 		SessionID:  arg.SessionID,
 	}
 	eng := engine.NewSaltpackSign(earg, h.G())
@@ -117,7 +117,7 @@ func (h *SaltpackHandler) SaltpackVerify(_ context.Context, arg keybase1.Saltpac
 
 	ctx := &engine.Context{
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
-		SecretUI:   h.getSecretUI(arg.SessionID),
+		SecretUI:   h.getSecretUI(arg.SessionID, h.G()),
 		SaltpackUI: h.getSaltpackUI(arg.SessionID),
 		SessionID:  arg.SessionID,
 	}

--- a/go/service/secretkeys.go
+++ b/go/service/secretkeys.go
@@ -25,8 +25,9 @@ func NewSecretKeysHandler(xp rpc.Transporter, g *libkb.GlobalContext) *SecretKey
 
 func (h *SecretKeysHandler) GetSecretKeys(_ context.Context, sessionID int) (keybase1.SecretKeys, error) {
 	ctx := engine.Context{
-		LogUI:    h.getLogUI(sessionID),
-		SecretUI: h.getSecretUI(sessionID),
+		LogUI:     h.getLogUI(sessionID),
+		SecretUI:  h.getSecretUI(sessionID),
+		SessionID: sessionID,
 	}
 	eng := engine.NewSecretKeysEngine(h.G())
 	err := engine.RunEngine(eng, &ctx)

--- a/go/service/secretkeys.go
+++ b/go/service/secretkeys.go
@@ -26,7 +26,7 @@ func NewSecretKeysHandler(xp rpc.Transporter, g *libkb.GlobalContext) *SecretKey
 func (h *SecretKeysHandler) GetSecretKeys(_ context.Context, sessionID int) (keybase1.SecretKeys, error) {
 	ctx := engine.Context{
 		LogUI:     h.getLogUI(sessionID),
-		SecretUI:  h.getSecretUI(sessionID),
+		SecretUI:  h.getSecretUI(sessionID, h.G()),
 		SessionID: sessionID,
 	}
 	eng := engine.NewSecretKeysEngine(h.G())

--- a/go/service/signup.go
+++ b/go/service/signup.go
@@ -29,10 +29,11 @@ func (h *SignupHandler) CheckUsernameAvailable(_ context.Context, arg keybase1.C
 
 func (h *SignupHandler) Signup(_ context.Context, arg keybase1.SignupArg) (res keybase1.SignupRes, err error) {
 	ctx := &engine.Context{
-		LogUI:    h.getLogUI(arg.SessionID),
-		GPGUI:    h.getGPGUI(arg.SessionID),
-		SecretUI: h.getSecretUI(arg.SessionID),
-		LoginUI:  h.getLoginUI(arg.SessionID),
+		LogUI:     h.getLogUI(arg.SessionID),
+		GPGUI:     h.getGPGUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID),
+		LoginUI:   h.getLoginUI(arg.SessionID),
+		SessionID: arg.SessionID,
 	}
 	runarg := engine.SignupEngineRunArg{
 		Username:    arg.Username,

--- a/go/service/signup.go
+++ b/go/service/signup.go
@@ -31,7 +31,7 @@ func (h *SignupHandler) Signup(_ context.Context, arg keybase1.SignupArg) (res k
 	ctx := &engine.Context{
 		LogUI:     h.getLogUI(arg.SessionID),
 		GPGUI:     h.getGPGUI(arg.SessionID),
-		SecretUI:  h.getSecretUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID, h.G()),
 		LoginUI:   h.getLoginUI(arg.SessionID),
 		SessionID: arg.SessionID,
 	}

--- a/go/service/track.go
+++ b/go/service/track.go
@@ -39,6 +39,7 @@ func (h *TrackHandler) Track(_ context.Context, arg keybase1.TrackArg) error {
 	ctx := engine.Context{
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
 		SecretUI:   h.getSecretUI(arg.SessionID),
+		SessionID:  arg.SessionID,
 	}
 	eng := engine.NewTrackEngine(&earg, h.G())
 	return engine.RunEngine(eng, &ctx)
@@ -52,6 +53,7 @@ func (h *TrackHandler) TrackWithToken(_ context.Context, arg keybase1.TrackWithT
 	ctx := engine.Context{
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
 		SecretUI:   h.getSecretUI(arg.SessionID),
+		SessionID:  arg.SessionID,
 	}
 	eng := engine.NewTrackToken(&earg, h.G())
 	return engine.RunEngine(eng, &ctx)
@@ -63,7 +65,8 @@ func (h *TrackHandler) Untrack(_ context.Context, arg keybase1.UntrackArg) error
 		Username: arg.Username,
 	}
 	ctx := engine.Context{
-		SecretUI: h.getSecretUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID),
+		SessionID: arg.SessionID,
 	}
 	eng := engine.NewUntrackEngine(&earg, h.G())
 	return engine.RunEngine(eng, &ctx)

--- a/go/service/track.go
+++ b/go/service/track.go
@@ -38,7 +38,7 @@ func (h *TrackHandler) Track(_ context.Context, arg keybase1.TrackArg) error {
 	}
 	ctx := engine.Context{
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
-		SecretUI:   h.getSecretUI(arg.SessionID),
+		SecretUI:   h.getSecretUI(arg.SessionID, h.G()),
 		SessionID:  arg.SessionID,
 	}
 	eng := engine.NewTrackEngine(&earg, h.G())
@@ -52,7 +52,7 @@ func (h *TrackHandler) TrackWithToken(_ context.Context, arg keybase1.TrackWithT
 	}
 	ctx := engine.Context{
 		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
-		SecretUI:   h.getSecretUI(arg.SessionID),
+		SecretUI:   h.getSecretUI(arg.SessionID, h.G()),
 		SessionID:  arg.SessionID,
 	}
 	eng := engine.NewTrackToken(&earg, h.G())
@@ -65,7 +65,7 @@ func (h *TrackHandler) Untrack(_ context.Context, arg keybase1.UntrackArg) error
 		Username: arg.Username,
 	}
 	ctx := engine.Context{
-		SecretUI:  h.getSecretUI(arg.SessionID),
+		SecretUI:  h.getSecretUI(arg.SessionID, h.G()),
 		SessionID: arg.SessionID,
 	}
 	eng := engine.NewUntrackEngine(&earg, h.G())

--- a/go/service/ui_router.go
+++ b/go/service/ui_router.go
@@ -105,7 +105,7 @@ func (u *UIRouter) GetIdentifyUI() (libkb.IdentifyUI, error) {
 	return ret, nil
 }
 
-func (u *UIRouter) GetSecretUI() (ui libkb.SecretUI, err error) {
+func (u *UIRouter) GetSecretUI(sessionID int) (ui libkb.SecretUI, err error) {
 	defer u.G().Trace("UIRouter.GetSecretUI", func() error { return err })
 	x := u.getUI(libkb.SecretUIKind)
 	if x == nil {
@@ -115,7 +115,7 @@ func (u *UIRouter) GetSecretUI() (ui libkb.SecretUI, err error) {
 	cli := rpc.NewClient(x, libkb.ErrorUnwrapper{})
 	scli := keybase1.SecretUiClient{Cli: cli}
 	u.G().Log.Debug("| returning delegated SecretUI")
-	return &SecretUI{cli: &scli}, nil
+	return &SecretUI{cli: &scli, sessionID: sessionID}, nil
 }
 
 func (u *UIRouter) GetUpdateUI() (libkb.UpdateUI, error) {

--- a/go/service/ui_router.go
+++ b/go/service/ui_router.go
@@ -115,7 +115,12 @@ func (u *UIRouter) GetSecretUI(sessionID int) (ui libkb.SecretUI, err error) {
 	cli := rpc.NewClient(x, libkb.ErrorUnwrapper{})
 	scli := keybase1.SecretUiClient{Cli: cli}
 	u.G().Log.Debug("| returning delegated SecretUI with sessionID = %d", sessionID)
-	return &SecretUI{cli: &scli, sessionID: sessionID}, nil
+	ret := &SecretUI{
+		cli:          &scli,
+		sessionID:    sessionID,
+		Contextified: libkb.NewContextified(u.G()),
+	}
+	return ret, nil
 }
 
 func (u *UIRouter) GetUpdateUI() (libkb.UpdateUI, error) {

--- a/go/service/ui_router.go
+++ b/go/service/ui_router.go
@@ -114,7 +114,7 @@ func (u *UIRouter) GetSecretUI(sessionID int) (ui libkb.SecretUI, err error) {
 	}
 	cli := rpc.NewClient(x, libkb.ErrorUnwrapper{})
 	scli := keybase1.SecretUiClient{Cli: cli}
-	u.G().Log.Debug("| returning delegated SecretUI")
+	u.G().Log.Debug("| returning delegated SecretUI with sessionID = %d", sessionID)
 	return &SecretUI{cli: &scli, sessionID: sessionID}, nil
 }
 

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -46,7 +46,10 @@ func (h *UserHandler) ListTrackersSelf(_ context.Context, sessionID int) ([]keyb
 }
 
 func (h *UserHandler) listTrackers(sessionID int, eng *engine.ListTrackersEngine) ([]keybase1.Tracker, error) {
-	ctx := &engine.Context{LogUI: h.getLogUI(sessionID)}
+	ctx := &engine.Context{
+		LogUI:     h.getLogUI(sessionID),
+		SessionID: sessionID,
+	}
 	if err := engine.RunEngine(eng, ctx); err != nil {
 		return nil, err
 	}
@@ -104,7 +107,10 @@ func (h *UserHandler) Search(_ context.Context, arg keybase1.SearchArg) (results
 	eng := engine.NewSearchEngine(engine.SearchEngineArgs{
 		Query: arg.Query,
 	}, h.G())
-	ctx := &engine.Context{LogUI: h.getLogUI(arg.SessionID)}
+	ctx := &engine.Context{
+		LogUI:     h.getLogUI(arg.SessionID),
+		SessionID: arg.SessionID,
+	}
 	err = engine.RunEngine(eng, ctx)
 	if err == nil {
 		results = eng.GetResults()

--- a/protocol/avdl/crypto.avdl
+++ b/protocol/avdl/crypto.avdl
@@ -20,12 +20,12 @@ protocol crypto {
     is used as part of the SecretEntryArg object passed into
     secretUi.getSecret().
     */
-  ED25519SignatureInfo signED25519(bytes msg, string reason);
+  ED25519SignatureInfo signED25519(int sessionID, bytes msg, string reason);
 
   /**
     Same as the above except the full marsheled and encoded NaclSigInfo.
     */
-  string signToString(bytes msg, string reason);
+  string signToString(int sessionID, bytes msg, string reason);
 
   fixed Bytes32(32);
   // 32 + fixed-size nacl/box overhead.
@@ -39,7 +39,7 @@ protocol crypto {
     decrypted data. The 'reason' parameter is used as part of the
     SecretEntryArg object passed into secretUi.getSecret().
     */
-  Bytes32 unboxBytes32(EncryptedBytes32 encryptedBytes32, BoxNonce nonce, BoxPublicKey peersPublicKey, string reason);
+  Bytes32 unboxBytes32(int sessionID, EncryptedBytes32 encryptedBytes32, BoxNonce nonce, BoxPublicKey peersPublicKey, string reason);
  
   record CiphertextBundle {
     KID kid;
@@ -57,5 +57,5 @@ protocol crypto {
   // if promptPaper is set to true and a paper key would work for one of the bundles, 
   // then there will be a prompt for the user to enter it.  If false, no paper key 
   // prompts will happen.
-  UnboxAnyRes unboxBytes32Any(array<CiphertextBundle> bundles, string reason, boolean promptPaper);
+  UnboxAnyRes unboxBytes32Any(int sessionID, array<CiphertextBundle> bundles, string reason, boolean promptPaper);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -174,6 +174,7 @@ export type incomingCallMapType = {
   ) => void,
   'keybase.1.crypto.signED25519'?: (
     params: {
+      sessionID: int,
       msg: bytes,
       reason: string
     },
@@ -184,6 +185,7 @@ export type incomingCallMapType = {
   ) => void,
   'keybase.1.crypto.signToString'?: (
     params: {
+      sessionID: int,
       msg: bytes,
       reason: string
     },
@@ -194,6 +196,7 @@ export type incomingCallMapType = {
   ) => void,
   'keybase.1.crypto.unboxBytes32'?: (
     params: {
+      sessionID: int,
       encryptedBytes32: crypto_EncryptedBytes32,
       nonce: crypto_BoxNonce,
       peersPublicKey: crypto_BoxPublicKey,
@@ -206,6 +209,7 @@ export type incomingCallMapType = {
   ) => void,
   'keybase.1.crypto.unboxBytes32Any'?: (
     params: {
+      sessionID: int,
       bundles: Array<crypto_CiphertextBundle>,
       reason: string,
       promptPaper: boolean

--- a/protocol/json/crypto.json
+++ b/protocol/json/crypto.json
@@ -283,6 +283,9 @@
     "signED25519" : {
       "doc" : "Sign the given message (which should be small) using the device's private\n    signing ED25519 key, and return the signature as well as the corresponding\n    public key that can be used to verify the signature. The 'reason' parameter\n    is used as part of the SecretEntryArg object passed into\n    secretUi.getSecret().",
       "request" : [ {
+        "name" : "sessionID",
+        "type" : "int"
+      }, {
         "name" : "msg",
         "type" : "bytes"
       }, {
@@ -294,6 +297,9 @@
     "signToString" : {
       "doc" : "Same as the above except the full marsheled and encoded NaclSigInfo.",
       "request" : [ {
+        "name" : "sessionID",
+        "type" : "int"
+      }, {
         "name" : "msg",
         "type" : "bytes"
       }, {
@@ -305,6 +311,9 @@
     "unboxBytes32" : {
       "doc" : "Decrypt exactly 32 bytes using nacl/box with the given nonce, the given\n    peer's public key, and the device's private encryption key, and return the\n    decrypted data. The 'reason' parameter is used as part of the\n    SecretEntryArg object passed into secretUi.getSecret().",
       "request" : [ {
+        "name" : "sessionID",
+        "type" : "int"
+      }, {
         "name" : "encryptedBytes32",
         "type" : "EncryptedBytes32"
       }, {
@@ -321,6 +330,9 @@
     },
     "unboxBytes32Any" : {
       "request" : [ {
+        "name" : "sessionID",
+        "type" : "int"
+      }, {
         "name" : "bundles",
         "type" : {
           "type" : "array",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -174,6 +174,7 @@ export type incomingCallMapType = {
   ) => void,
   'keybase.1.crypto.signED25519'?: (
     params: {
+      sessionID: int,
       msg: bytes,
       reason: string
     },
@@ -184,6 +185,7 @@ export type incomingCallMapType = {
   ) => void,
   'keybase.1.crypto.signToString'?: (
     params: {
+      sessionID: int,
       msg: bytes,
       reason: string
     },
@@ -194,6 +196,7 @@ export type incomingCallMapType = {
   ) => void,
   'keybase.1.crypto.unboxBytes32'?: (
     params: {
+      sessionID: int,
       encryptedBytes32: crypto_EncryptedBytes32,
       nonce: crypto_BoxNonce,
       peersPublicKey: crypto_BoxPublicKey,
@@ -206,6 +209,7 @@ export type incomingCallMapType = {
   ) => void,
   'keybase.1.crypto.unboxBytes32Any'?: (
     params: {
+      sessionID: int,
       bundles: Array<crypto_CiphertextBundle>,
       reason: string,
       promptPaper: boolean


### PR DESCRIPTION
systest/secret_ui_test includes test for this plumbing.

SessionID now a field of engine.Context
Updated all the services with non-empty engine.Contexts
to include SessionID.

@chrisnojima can you verify that this fixes your desktop integration issue?

cc @maxtaco 