### PR TITLE
Move login resizing info to style-guide

### DIFF
--- a/shared/nav.desktop.js
+++ b/shared/nav.desktop.js
@@ -25,7 +25,7 @@ import {switchTab} from './actions/tabbed-router'
 import {startup} from './actions/startup'
 import {Tab, Tabs} from 'material-ui'
 
-import {formResizeTo as loginResizeTo} from './login/form.render'
+import {globalResizing} from './styles/style-guide'
 
 const tabs = {
   [moreTab]: {module: More, name: 'More'},
@@ -77,7 +77,7 @@ class Nav extends Component {
       const [width, height] = this.window.getSize()
       this.originalSize = {width, height}
 
-      this.window && this.window.setContentSize(loginResizeTo.width, loginResizeTo.height, true)
+      this.window && this.window.setContentSize(globalResizing.login.width, globalResizing.login.height, true)
       this.window && this.window.setResizable(false)
     }
 

--- a/shared/styles/style-guide.desktop.js
+++ b/shared/styles/style-guide.desktop.js
@@ -17,6 +17,10 @@ export const globalColors = {
   white: '#ffffff'
 }
 
+export const globalResizing = {
+  login: {width: 550, height: 605}
+}
+
 const fontCommon = {
   WebkitFontSmoothing: 'antialiased',
   textRendering: 'optimizeLegibility'

--- a/shared/styles/style-guide.js.flow
+++ b/shared/styles/style-guide.js.flow
@@ -1,2 +1,3 @@
 declare export var globalColors: Object
 declare export var globalStyles: Object
+declare export var globalResizing: Object


### PR DESCRIPTION
@keybase/react-hackers @chrisnojima 

Fixes the thing I broke because I deleted the form.render file. 

I wonder if webpack cached the form file and that's why I didn't notice?