### PR TITLE
Fix "Close" on tracker logged out popup causing track to happen

### DIFF
--- a/desktop/renderer/remote-manager.js
+++ b/desktop/renderer/remote-manager.js
@@ -3,7 +3,7 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
-import {registerIdentifyUi, onCloseFromHeader as trackerOnCloseFromHeader, startTimer as trackerStartTimer, stopTimer as trackerStopTimer} from '../shared/actions/tracker'
+import {registerIdentifyUi, onClose as trackerOnClose, startTimer as trackerStartTimer, stopTimer as trackerStopTimer} from '../shared/actions/tracker'
 import {registerPinentryListener, onCancel as pinentryOnCancel, onSubmit as pinentryOnSubmit} from '../shared/actions/pinentry'
 import {registerTrackerChangeListener} from '../shared/actions/tracker'
 import {registerUpdateListener, onCancel as updateOnCancel, onSkip as updateOnSkip, onSnooze as updateOnSnooze, onUpdate as updateOnUpdate, setAlwaysUpdate} from '../shared/actions/update'
@@ -24,7 +24,7 @@ export type RemoteManagerProps = {
   pinentryOnSubmit: (sessionID: number, passphrase: string, features: GUIEntryFeatures) => void,
   registerIdentifyUi: () => void,
   registerTrackerChangeListener: () => void,
-  trackerOnCloseFromHeader: () => void,
+  trackerOnClose: () => void,
   trackerServerStarted: boolean,
   trackerStartTimer: (dispatch: Dispatch, getState: any) => void,
   trackerStopTimer: () => Action,
@@ -74,7 +74,7 @@ class RemoteManager extends Component {
         waitForState
         ignoreNewProps
         hidden={trackers[username].hidden}
-        onRemoteClose={() => this.props.trackerOnCloseFromHeader(username)}
+        onRemoteClose={() => this.props.trackerOnClose(username)}
         component='tracker'
         username={username}
         startTimer={this.props.trackerStartTimer}
@@ -147,7 +147,7 @@ RemoteManager.propTypes = {
   registerUpdateListener: React.PropTypes.func,
   registerIdentifyUi: React.PropTypes.func,
   registerTrackerChangeListener: React.PropTypes.any,
-  trackerOnCloseFromHeader: React.PropTypes.func,
+  trackerOnClose: React.PropTypes.func,
   trackerServerStarted: React.PropTypes.bool,
   trackerStartTimer: React.PropTypes.func,
   trackerStopTimer: React.PropTypes.func,
@@ -174,7 +174,7 @@ export default connect(
     registerIdentifyUi,
     trackerStartTimer,
     trackerStopTimer,
-    trackerOnCloseFromHeader,
+    trackerOnClose,
     registerPinentryListener,
     registerTrackerChangeListener,
     pinentryOnCancel,

--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -223,13 +223,13 @@ function trackUser (trackToken: ?string): Promise<boolean> {
   })
 }
 
-export function onCloseFromActionBar (username: string): (dispatch: Dispatch, getState: () => {tracker: RootTrackerState}) => void {
+export function onMaybeTrack (username: string): (dispatch: Dispatch, getState: () => {tracker: RootTrackerState}) => void {
   return (dispatch, getState) => {
     const trackerState = getState().tracker.trackers[username]
     const {shouldFollow} = trackerState
     const {trackToken} = (trackerState || {})
 
-    const dispatchCloseAction = () => dispatch({type: Constants.onCloseFromActionBar, payload: {username}})
+    const dispatchCloseAction = () => dispatch({type: Constants.onMaybeTrack, payload: {username}})
 
     if (shouldFollow) {
       dispatch(onUserTrackingLoading(username))
@@ -245,9 +245,9 @@ export function onCloseFromActionBar (username: string): (dispatch: Dispatch, ge
   }
 }
 
-export function onCloseFromHeader (username: string): Action {
+export function onClose (username: string): Action {
   return {
-    type: Constants.onCloseFromHeader,
+    type: Constants.onClose,
     payload: {username}
   }
 }

--- a/shared/constants/tracker.js
+++ b/shared/constants/tracker.js
@@ -35,8 +35,8 @@ export const reportLastTrack = 'tracker:reportLastTrack'
 
 export const onUserTrackingLoading = 'tracker:userTrackingLoading'
 
-export const onCloseFromActionBar = 'tracker:onCloseFromActionBar'
-export const onCloseFromHeader = 'tracker:onCloseFromHeader'
+export const onMaybeTrack = 'tracker:onMaybeTrack'
+export const onClose = 'tracker:onClose'
 
 export const onRefollow = 'tracker:onRefollow'
 export const onUnfollow = 'tracker:onUnfollow'

--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -98,13 +98,13 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
         closed: true,
         hidden: false
       }
-    case Constants.onCloseFromActionBar:
+    case Constants.onMaybeTrack:
       return {
         ...state,
         closed: true,
         hidden: false
       }
-    case Constants.onCloseFromHeader:
+    case Constants.onClose:
       return {
         ...state,
         closed: true,

--- a/shared/tracker/action.render.desktop.js
+++ b/shared/tracker/action.render.desktop.js
@@ -47,7 +47,7 @@ export default class ActionRender extends Component {
           <span style={styles.track}>Track</span>
           <i style={styles.eye} className='fa fa-eye'></i>
         </div>
-        <FlatButton style={commonStyles.primaryButton} label='Close' primary onClick={() => this.props.onClose()} />
+        <FlatButton style={commonStyles.primaryButton} label='Close' primary onClick={() => this.props.onMaybeTrack()} />
       </div>
     )
   }
@@ -79,7 +79,7 @@ export default class ActionRender extends Component {
           <span style={styles.track}>Track</span>
           <i style={styles.eye} className='fa fa-eye'></i>
         </div>
-        <FlatButton style={commonStyles.primaryButton} label='Close' primary onClick={() => this.props.onClose()} />
+        <FlatButton style={commonStyles.primaryButton} label='Close' primary onClick={() => this.props.onMaybeTrack()} />
       </div>
     )
   }
@@ -104,6 +104,7 @@ ActionRender.propTypes = {
   username: React.PropTypes.string,
   shouldFollow: React.PropTypes.bool.isRequired,
   onClose: React.PropTypes.func.isRequired,
+  onMaybeTrack: React.PropTypes.func.isRequired,
   onRefollow: React.PropTypes.func.isRequired,
   onUnfollow: React.PropTypes.func.isRequired,
   onFollowChecked: React.PropTypes.func.isRequired,

--- a/shared/tracker/action.render.js.flow
+++ b/shared/tracker/action.render.js.flow
@@ -11,9 +11,9 @@ export type ActionProps = {
   renderChangedTitle: ?string,
   failedProofsNotFollowingText: string,
   onClose: () => void,
+  onMaybeTrack: () => void,
   onRefollow: () => void,
   onUnfollow: () => void,
   onFollowHelp: () => void,
   onFollowChecked: () => void
 }
-

--- a/shared/tracker/index.js
+++ b/shared/tracker/index.js
@@ -23,8 +23,8 @@ type TrackerProps = {
   reason: string,
   userInfo: UserInfo,
   proofs: Array<Proof>,
-  onCloseFromHeader: () => void,
-  onCloseFromActionBar: () => void,
+  onClose: () => void,
+  onMaybeTrack: () => void,
   onRefollow: () => void,
   onUnfollow: () => void,
   onFollowHelp: () => void,
@@ -63,7 +63,7 @@ class Tracker extends Component {
       },
       headerProps: {
         reason: this.props.reason,
-        onClose: () => this.props.onCloseFromHeader(this.props.username)
+        onClose: () => this.props.onClose(this.props.username)
       },
       actionProps: {
         loggedIn: this.props.loggedIn,
@@ -72,7 +72,8 @@ class Tracker extends Component {
         renderChangedTitle,
         failedProofsNotFollowingText,
         shouldFollow: this.props.shouldFollow,
-        onClose: () => this.props.onCloseFromActionBar(this.props.username),
+        onClose: () => this.props.onClose(this.props.username),
+        onMaybeTrack: () => this.props.onMaybeTrack(this.props.username),
         onRefollow: () => this.props.onRefollow(this.props.username),
         onUnfollow: () => this.props.onUnfollow(this.props.username),
         onFollowHelp: () => this.props.onFollowHelp(this.props.username),
@@ -140,8 +141,8 @@ Tracker.propTypes = {
   reason: React.PropTypes.any,
   userInfo: React.PropTypes.any,
   proofs: React.PropTypes.any,
-  onCloseFromHeader: React.PropTypes.any,
-  onCloseFromActionBar: React.PropTypes.any,
+  onClose: React.PropTypes.any,
+  onMaybeTrack: React.PropTypes.any,
   onRefollow: React.PropTypes.any,
   onUnfollow: React.PropTypes.any,
   onFollowHelp: React.PropTypes.any,

--- a/shared/tracker/proofs.render.desktop.js
+++ b/shared/tracker/proofs.render.desktop.js
@@ -166,4 +166,3 @@ const styles = {
     ...commonStyles.clickable
   }
 }
-


### PR DESCRIPTION
@keybase/react-hackers 

We have a "Close" button appear on different types of tracker popup, and then convoluted logic for working out which type of "close" this is and whether it should result in a track.  This causes a bug where
the "logged out" tracker popup would track people when closed (in combination with a Core bug that left you logged in when the UI thought you were logged out).

This PR fixes that situation by switching to a "tracker:onClose" (which closes the popup without taking any action) -- which is now used both on the header component and the action bar component in the logged out case -- and a "tracker:maybeTrack" action, which triggers the convoluted logic I mentioned earlier.  We only call maybeTrack when tracking is a possible outcome of the button click.

This whole flow is going to be thrown out and replaced by simpler callbacks as part of the DZ2 rework, so we don't need to get too caught up in this, but this seems like a simplifying fix until we get to DZ2.

Tested on stage0 using signup of real accounts, in the logged out and logged in cases.  But please review carefully anyway, since it's important to get this right.