### PR TITLE
Show dock and menu for window when window is spawned.

### DIFF
--- a/desktop/app/main-window.js
+++ b/desktop/app/main-window.js
@@ -16,7 +16,6 @@ export default function () {
 
   ipcMain.on('showMain', () => {
     mainWindow.show(true)
-    menuHelper(mainWindow.window)
   })
 
   return mainWindow

--- a/desktop/app/window.js
+++ b/desktop/app/window.js
@@ -1,4 +1,5 @@
 import showDockIcon from './dockIcon'
+import menuHelper from './menu-helper'
 import {app, ipcMain, BrowserWindow} from 'electron'
 
 export default class Window {
@@ -67,7 +68,12 @@ export default class Window {
       return
     }
 
+    if (this.opts.show) {
+      this.releaseDockIcon = showDockIcon()
+    }
+
     this.window = new BrowserWindow({show: false, ...this.opts})
+    menuHelper(this.window)
     this.window.loadURL(`file://${this.filename}`)
     this.bindWindowListeners()
   }


### PR DESCRIPTION
@keybase/react-hackers @chrisnojima 

The dockIcon helper and menubar weren't being called correctly, so you couldn't open up devTools with the keyboard shortcut or have a dock icon.