### PR TITLE
Update fix to remove existing unzip directory if interrupted

### DIFF
--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -891,3 +891,7 @@ func (e *Env) GetVDebugSetting() string {
 		func() string { return "" },
 	)
 }
+
+func (e *Env) GetRunModeAsString() string {
+	return string(e.GetRunMode())
+}

--- a/go/updater/updater_osx.go
+++ b/go/updater/updater_osx.go
@@ -8,19 +8,15 @@ package updater
 import (
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
-	"syscall"
+	"strconv"
 	"time"
 )
 
 func (u *Updater) checkPlatformSpecificUpdate(sourcePath string, destinationPath string) error {
-	destFileInfo, err := os.Lstat(destinationPath)
-	if err != nil {
-		return err
-	}
-
 	//
-	// Get the uid, gid of the destination and make sure our src matches.
+	// Get the uid, gid of the current user and make sure our src matches.
 	//
 	// Updating the modification time of the application is important because the
 	// system will be aware a new version of your app is available.
@@ -31,16 +27,27 @@ func (u *Updater) checkPlatformSpecificUpdate(sourcePath string, destinationPath
 	// get the priviledged helper tool involved.
 	//
 
-	// Get uid, gid of destination
-	uid := destFileInfo.Sys().(*syscall.Stat_t).Uid
-	gid := destFileInfo.Sys().(*syscall.Stat_t).Gid
-	u.log.Info("Destination: %s, Uid: %d, Gid: %d", destinationPath, uid, gid)
+	// Get uid, gid of current user
+	currentUser, err := user.Current()
+	if err != nil {
+		return err
+	}
+	uid, err := strconv.Atoi(currentUser.Uid)
+	if err != nil {
+		return err
+	}
+	gid, err := strconv.Atoi(currentUser.Gid)
+	if err != nil {
+		return err
+	}
+
+	u.log.Info("Current user uid: %d, gid: %d", uid, gid)
 
 	walk := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		err = os.Chown(path, int(uid), int(gid))
+		err = os.Chown(path, uid, gid)
 		if err != nil {
 			return err
 		}
@@ -67,7 +74,17 @@ func openApplication(applicationPath string) error {
 }
 
 func (u *Updater) applyUpdate(localPath string) (tmpPath string, err error) {
-	// TODO: On OSX call mdimport so Spotlight knows it changed?
+	destinationPath := u.options.DestinationPath
+	tmpPath, err = u.applyZip(localPath, destinationPath)
+	if err != nil {
+		return
+	}
 
-	return u.applyZip(localPath)
+	// Update spotlight, ignore (but log) errors
+	u.log.Debug("Updating spotlight: %s", destinationPath)
+	mdimportOut, mdierr := exec.Command("/usr/bin/mdimport", destinationPath).Output()
+	if mdierr != nil {
+		u.log.Errorf("Error trying to update spotlight: %s; %s", mdierr, mdimportOut)
+	}
+	return
 }

--- a/go/updater/updater_test.go
+++ b/go/updater/updater_test.go
@@ -106,6 +106,10 @@ func (c testConfig) SetUpdateLastChecked(t keybase1.Time) error {
 	return nil
 }
 
+func (c testConfig) GetRunModeAsString() string {
+	return "test"
+}
+
 func NewDefaultTestUpdateConfig() keybase1.UpdateOptions {
 	return keybase1.UpdateOptions{
 		Version:             "1.0.0",


### PR DESCRIPTION
Also updating spotlight after update on OS X. This was from a really old PR I forgot to commit, that had conflicts so committing here now.