### PR TITLE
use a UserAgent that reddit likes

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -532,7 +532,15 @@ const (
 )
 
 func (api *ExternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
-	// noop for now
+	// TODO (here and in the internal API engine implementation): If we don't
+	// set the User-Agent, it will default to http.defaultUserAgent
+	// ("Go-http-client/1.1"). We should think about whether that's what we
+	// want in Tor mode. Clients that are actually using Tor will always be
+	// distinguishable from the rest, insofar as their originating IP will be a
+	// Tor exit node, but there may be other use cases where this matters more?
+	if api.G().Env.GetTorMode().UseHeaders() {
+		req.Header.Set("User-Agent", UserAgent)
+	}
 }
 
 func (api *ExternalAPIEngine) consumeHeaders(resp *http.Response) error {

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -538,9 +538,19 @@ func (api *ExternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
 	// want in Tor mode. Clients that are actually using Tor will always be
 	// distinguishable from the rest, insofar as their originating IP will be a
 	// Tor exit node, but there may be other use cases where this matters more?
-	if api.G().Env.GetTorMode().UseHeaders() {
-		req.Header.Set("User-Agent", UserAgent)
+	userAgent := UserAgent
+	// Awful hack to make reddit as happy as possible.
+	if isReddit(req) {
+		userAgent += " (by /u/oconnor663)"
 	}
+	if api.G().Env.GetTorMode().UseHeaders() {
+		req.Header.Set("User-Agent", userAgent)
+	}
+}
+
+func isReddit(req *http.Request) bool {
+	host := req.URL.Host
+	return host == "reddit.com" || strings.HasSuffix(host, ".reddit.com")
 }
 
 func (api *ExternalAPIEngine) consumeHeaders(resp *http.Response) error {

--- a/go/libkb/api_test.go
+++ b/go/libkb/api_test.go
@@ -1,0 +1,26 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package libkb
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestIsReddit(t *testing.T) {
+	// Test both with and without a subdomain.
+	req, _ := http.NewRequest("GET", "http://reddit.com", nil)
+	if !isReddit(req) {
+		t.Fatal("should be a reddit URL")
+	}
+	req, _ = http.NewRequest("GET", "http://www.reddit.com", nil)
+	if !isReddit(req) {
+		t.Fatal("should be a reddit URL")
+	}
+	// Test a non-reddit URL.
+	req, _ = http.NewRequest("GET", "http://github.com", nil)
+	if isReddit(req) {
+		t.Fatal("should NOT be a reddit URL")
+	}
+}

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -55,7 +55,10 @@ const (
 	KeybaseSaltpackBrand = "KEYBASE"
 )
 
-var UserAgent = "Keybase/" + Version + " (" + runtime.Version() + " on " + runtime.GOOS + ")"
+// Right now reddit is the only site that seems to have any requirements for
+// our User-Agent string. (See https://github.com/reddit/reddit/wiki/API.)If
+// something else comes up, we'll want to make this more configurable.
+var UserAgent = runtime.GOOS + ":" + "Keybase CLI (" + runtime.Version() + "):" + Version + " (by /u/oconnor663)"
 
 const (
 	PermFile          os.FileMode = 0600

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -58,7 +58,7 @@ const (
 // Right now reddit is the only site that seems to have any requirements for
 // our User-Agent string. (See https://github.com/reddit/reddit/wiki/API.)If
 // something else comes up, we'll want to make this more configurable.
-var UserAgent = runtime.GOOS + ":" + "Keybase CLI (" + runtime.Version() + "):" + Version + " (by /u/oconnor663)"
+var UserAgent = runtime.GOOS + ":" + "Keybase CLI (" + runtime.Version() + "):" + Version
 
 const (
 	PermFile          os.FileMode = 0600


### PR DESCRIPTION
When I looked into this, it turned out we weren't setting a User-Agent
at all for non-Keybase APIs, and instead we just fell back to Go's
default. Oops.

@maxtaco, any suggestions on how to test this sort of thing? I wasn't able to repro any reddit 429's today, though I only id'd a handful of people.