### PR TITLE
Add missing babel stage-2 preset npm module

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -60,6 +60,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-1": "^6.3.13",
+    "babel-preset-stage-2": "^6.3.13",
     "babel-runtime": "^6.3.19",
     "del": "^2.2.0",
     "electron-packager": "^5.1.0",


### PR DESCRIPTION
Couldn't build on Arch Linux without this.