### PR TITLE
Install status should check plist (OS X)

### DIFF
--- a/go/client/cmd_launchd_osx.go
+++ b/go/client/cmd_launchd_osx.go
@@ -58,7 +58,7 @@ func NewCmdLaunchdInstall(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cl
 			plistArgs := args[3:]
 			envVars := install.DefaultLaunchdEnvVars(g, label)
 
-			plist := launchd.NewPlist(label, binPath, plistArgs, envVars, logFileName)
+			plist := launchd.NewPlist(label, binPath, plistArgs, envVars, logFileName, "")
 			err := launchd.Install(plist, g.Log)
 			if err != nil {
 				g.Log.Fatalf("%v", err)

--- a/go/launchd/launchd_test.go
+++ b/go/launchd/launchd_test.go
@@ -5,20 +5,94 @@ package launchd
 
 import (
 	"encoding/xml"
+	"os"
 	"testing"
+
+	"github.com/kardianos/osext"
 )
 
-func TestPlist(t *testing.T) {
-	envVars := make(map[string]string)
-	plist := NewPlist("keybase.testing", "/path/to/file", []string{"--flag=test", "testArg"}, envVars, "keybase.testing.log")
+func validExecutableForTest() (string, error) {
+	return osext.Executable()
+}
 
-	data := plist.plist()
+func TestPlist(t *testing.T) {
+	binPath, err := validExecutableForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	envVars := []EnvVar{
+		NewEnvVar("TESTVAR1", "1"),
+		NewEnvVar("TESTVAR2", "2"),
+	}
+	plist := NewPlist("keybase.testing", binPath, []string{"--flag=test", "testArg"}, envVars, "keybase.testing.log", "This is a comment")
+
+	data := plist.plistXML()
 	t.Logf("Plist: %s\n", data)
 
 	var i interface{}
 	// This tests valid XML but not actual values
-	err := xml.Unmarshal([]byte(data), &i)
+	err = xml.Unmarshal([]byte(data), &i)
 	if err != nil {
 		t.Errorf("Bad plist: %s", err)
+	}
+}
+
+func TestCheckPlist(t *testing.T) {
+	label := "keybase.testing.checkplist"
+	service := NewService(label)
+	defer os.Remove(service.plistDestination())
+
+	binPath, err := validExecutableForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	envVars := []EnvVar{
+		NewEnvVar("TESTVAR1", "1"),
+		NewEnvVar("TESTVAR2", "2"),
+	}
+	plist := NewPlist(label, binPath, []string{}, envVars, "keybase.testing.log", "")
+	plistIsValid, err := service.CheckPlist(plist)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plistIsValid {
+		t.Fatalf("We shouldn't have a plist")
+	}
+
+	err = service.Install(plist)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check valid plist after install
+	plistIsValidAfter, err := service.CheckPlist(plist)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !plistIsValidAfter {
+		t.Fatalf("Plist was invalid after install")
+	}
+
+	// Check a new plist
+	plistNew := NewPlist(label, binPath, []string{"differentArgs"}, envVars, "keybase.testing.log", "")
+	plistNewIsValid, err := service.CheckPlist(plistNew)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plistNewIsValid {
+		t.Fatal("New plist should be invalid")
+	}
+
+	err = service.Install(plistNew)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plistNewIsValidAfterInstall, err := service.CheckPlist(plistNew)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !plistNewIsValidAfterInstall {
+		t.Fatalf("New pist should be valid after install")
 	}
 }


### PR DESCRIPTION
Old installs may have invalid plists which causes problems after (brew) upgrades.

This checks to make sure the plist matches the one we generate on install. If invalid, it triggers the service install.