### PR TITLE
make deprovision keep working if revoke fails

### DIFF
--- a/go/engine/deprovision.go
+++ b/go/engine/deprovision.go
@@ -44,6 +44,62 @@ func (e *DeprovisionEngine) SubConsumers() []libkb.UIConsumer {
 	}
 }
 
+// This function anticipates some error cases, but it will still return an
+// error if something unexpected goes wrong.
+func (e *DeprovisionEngine) attemptRevoke(ctx *Context) error {
+	isLoggedIn, _, err := IsLoggedIn(e, ctx)
+	if err != nil {
+		e.G().Log.Debug("DeprovisionEngine error checking login status: %s", err)
+		return err
+	}
+
+	// If the user we're deprovisioning isn't logged in, short-circuit the
+	// revoke and continue deprovision.
+	if !isLoggedIn || !e.G().Env.GetUsername().Eq(e.username) {
+		ctx.LogUI.Warning("User %s is not logged in, so we aren't revoking their keys on the server.", e.username)
+		ctx.LogUI.Warning("To do that yourself, run `keybase device remove %s`", e.G().Env.GetDeviceID())
+		ctx.LogUI.Warning("from another device.")
+		return nil
+	}
+
+	me, err := libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
+	if err != nil {
+		e.G().Log.Debug("DeprovisionEngine error loading current user: %s", err)
+		return err
+	}
+
+	keys, err := me.GetComputedKeyFamily().GetAllActiveKeysForDevice(e.G().Env.GetDeviceID())
+	if err != nil {
+		e.G().Log.Debug("DeprovisionEngine error loading keys for current device: %s", err)
+		return err
+	}
+	// If there are no keys to revoke, it's likely the device has already been
+	// revoked. We still need to log out below though.
+	if len(keys) == 0 {
+		ctx.LogUI.Warning("No active keys to revoke.")
+	} else {
+		// Do the revoke. We expect this to succeed.
+		revokeArg := RevokeDeviceEngineArgs{
+			ID:    e.G().Env.GetDeviceID(),
+			Force: true,
+		}
+		revokeEng := NewRevokeDeviceEngine(revokeArg, e.G())
+		err = revokeEng.Run(ctx)
+		if err != nil {
+			e.G().Log.Debug("DeprovisionEngine error during revoke: %s", err)
+			return err
+		}
+	}
+
+	ctx.LogUI.Info("Logging out...")
+	if err = e.G().Logout(); err != nil {
+		e.G().Log.Debug("DeprovisionEngine error during logout: %s", err)
+		return err
+	}
+
+	return nil
+}
+
 func (e *DeprovisionEngine) Run(ctx *Context) (err error) {
 	// Deprovision steps
 	// =================
@@ -56,28 +112,9 @@ func (e *DeprovisionEngine) Run(ctx *Context) (err error) {
 
 	// If the user to deprovision is currently logged in, we need to revoke
 	// their keys and then log out.
-	isLoggedIn, _, err := IsLoggedIn(e, ctx)
+	err = e.attemptRevoke(ctx)
 	if err != nil {
-		return err
-	}
-	if e.G().Env.GetUsername().Eq(e.username) && isLoggedIn {
-		revokeArg := RevokeDeviceEngineArgs{
-			ID:    e.G().Env.GetDeviceID(),
-			Force: true,
-		}
-		revokeEng := NewRevokeDeviceEngine(revokeArg, e.G())
-		err = revokeEng.Run(ctx)
-		if err != nil {
-			return err
-		}
-
-		ctx.LogUI.Info("Logging out...")
-		if err = e.G().Logout(); err != nil {
-			return
-		}
-	} else {
-		ctx.LogUI.Warning("User %s is not logged in, so we aren't revoking their keys on the server.", e.username)
-		ctx.LogUI.Warning("To do that yourself, use `keybase device remove` from a logged in device.")
+		return
 	}
 
 	if clearSecretErr := libkb.ClearStoredSecret(e.G(), e.username); clearSecretErr != nil {

--- a/go/engine/deprovision.go
+++ b/go/engine/deprovision.go
@@ -47,7 +47,7 @@ func (e *DeprovisionEngine) SubConsumers() []libkb.UIConsumer {
 // This function anticipates some error cases, but it will still return an
 // error if something unexpected goes wrong.
 func (e *DeprovisionEngine) attemptRevoke(ctx *Context) error {
-	isLoggedIn, _, err := IsLoggedIn(e, ctx)
+	isLoggedIn, uid, err := IsLoggedIn(e, ctx)
 	if err != nil {
 		e.G().Log.Debug("DeprovisionEngine error checking login status: %s", err)
 		return err
@@ -62,7 +62,7 @@ func (e *DeprovisionEngine) attemptRevoke(ctx *Context) error {
 		return nil
 	}
 
-	me, err := libkb.LoadMe(libkb.NewLoadUserArg(e.G()))
+	me, err := libkb.LoadMeByUID(e.G(), uid)
 	if err != nil {
 		e.G().Log.Debug("DeprovisionEngine error loading current user: %s", err)
 		return err

--- a/go/engine/deprovision_test.go
+++ b/go/engine/deprovision_test.go
@@ -215,3 +215,95 @@ func TestDeprovisionLoggedOut(t *testing.T) {
 		t.Fatalf("expected the same number of device keys, before: %d, after: %d", numKeys, newNumKeys)
 	}
 }
+
+func TestCurrentDeviceRevoked(t *testing.T) {
+	tc := SetupEngineTest(t, "deprovision")
+	defer tc.Cleanup()
+
+	// Sign up a new user and have it store its secret in the
+	// secret store (if possible).
+	fu := NewFakeUserOrBust(tc.T, "dpr")
+	arg := MakeTestSignupEngineRunArg(fu)
+	arg.StoreSecret = libkb.HasSecretStore()
+	ctx := &Context{
+		LogUI:    tc.G.UI.GetLogUI(),
+		GPGUI:    &gpgtestui{},
+		SecretUI: fu.NewSecretUI(),
+		LoginUI:  &libkb.TestLoginUI{Username: fu.Username},
+	}
+	s := NewSignupEngine(&arg, tc.G)
+	err := RunEngine(s, ctx)
+	if err != nil {
+		tc.T.Fatal(err)
+	}
+
+	if libkb.HasSecretStore() {
+		secretStore := libkb.NewSecretStore(tc.G, fu.NormalizedUsername())
+		_, err := secretStore.RetrieveSecret()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dbPath := tc.G.Env.GetDbFilename()
+	sessionPath := tc.G.Env.GetSessionFilename()
+	secretKeysPath := tc.G.SKBFilenameForUser(fu.NormalizedUsername())
+	numKeys := getNumKeys(tc, *fu)
+
+	assertFileExists(t, dbPath)
+	assertFileExists(t, sessionPath)
+	assertFileExists(t, secretKeysPath)
+	if !isUserInConfigFile(tc, *fu) {
+		t.Fatalf("User %s is not in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())
+	}
+	if !isUserConfigInMemory(tc) {
+		t.Fatalf("user config is not in memory")
+	}
+
+	if !LoggedIn(tc) {
+		t.Fatal("Unexpectedly logged out")
+	}
+
+	// Revoke the current device! This will cause an error when deprovision
+	// tries to revoke the device again, but deprovision should carry on.
+	err = doRevokeDevice(tc, fu, tc.G.Env.GetDeviceID(), true /* force */)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := NewDeprovisionEngine(tc.G, fu.Username)
+	ctx = &Context{
+		LogUI:    tc.G.UI.GetLogUI(),
+		SecretUI: fu.NewSecretUI(),
+	}
+	if err := RunEngine(e, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if LoggedIn(tc) {
+		t.Error("Unexpectedly still logged in")
+	}
+
+	if libkb.HasSecretStore() {
+		secretStore := libkb.NewSecretStore(tc.G, fu.NormalizedUsername())
+		secret, err := secretStore.RetrieveSecret()
+		if err == nil {
+			t.Errorf("Unexpectedly got secret %v", secret)
+		}
+	}
+
+	assertFileDoesNotExist(t, dbPath)
+	assertFileDoesNotExist(t, sessionPath)
+	assertFileDoesNotExist(t, secretKeysPath)
+	if isUserInConfigFile(tc, *fu) {
+		t.Fatalf("User %s is still in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())
+	}
+	if isUserConfigInMemory(tc) {
+		t.Fatalf("user config is still in memory")
+	}
+
+	newNumKeys := getNumKeys(tc, *fu)
+	if newNumKeys != numKeys-2 {
+		t.Fatalf("failed to revoke device keys, before: %d, after: %d", numKeys, newNumKeys)
+	}
+}

--- a/go/engine/deprovision_test.go
+++ b/go/engine/deprovision_test.go
@@ -89,7 +89,7 @@ func TestDeprovision(t *testing.T) {
 		t.Fatal("Unexpectedly logged out")
 	}
 
-	e := NewDeprovisionEngine(tc.G, fu.Username)
+	e := NewDeprovisionEngine(tc.G, fu.Username, true /* doRevoke */)
 	ctx = &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
 		SecretUI: fu.NewSecretUI(),
@@ -175,11 +175,11 @@ func TestDeprovisionLoggedOut(t *testing.T) {
 	}
 
 	// Unlike the first test, this time we log out before we run the
-	// deprovision. That should mean that no keys get revoked, but everything
-	// else should be the same.
+	// deprovision. We should be able to do a deprovision with revocation
+	// disabled.
 	tc.G.Logout()
 
-	e := NewDeprovisionEngine(tc.G, fu.Username)
+	e := NewDeprovisionEngine(tc.G, fu.Username, false /* doRevoke */)
 	ctx = &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
 		SecretUI: fu.NewSecretUI(),
@@ -271,7 +271,7 @@ func TestCurrentDeviceRevoked(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	e := NewDeprovisionEngine(tc.G, fu.Username)
+	e := NewDeprovisionEngine(tc.G, fu.Username, true /* doRevoke */)
 	ctx = &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
 		SecretUI: fu.NewSecretUI(),

--- a/go/engine/revoke.go
+++ b/go/engine/revoke.go
@@ -74,6 +74,9 @@ func (e *RevokeEngine) getKIDsToRevoke(me *libkb.User) ([]keybase1.KID, error) {
 		if err != nil {
 			return nil, err
 		}
+		if len(deviceKeys) == 0 {
+			return nil, fmt.Errorf("No active keys to revoke for device %s.", e.deviceID)
+		}
 		return deviceKeys, nil
 	} else if e.mode == RevokeKey {
 		kid := e.kid

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -2744,6 +2744,7 @@ type LogoutArg struct {
 type DeprovisionArg struct {
 	SessionID int    `codec:"sessionID" json:"sessionID"`
 	Username  string `codec:"username" json:"username"`
+	DoRevoke  bool   `codec:"doRevoke" json:"doRevoke"`
 }
 
 type RecoverAccountFromEmailAddressArg struct {

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -33,7 +33,7 @@ func (h *LoginHandler) Logout(_ context.Context, sessionID int) error {
 }
 
 func (h *LoginHandler) Deprovision(_ context.Context, arg keybase1.DeprovisionArg) error {
-	eng := engine.NewDeprovisionEngine(h.G(), arg.Username)
+	eng := engine.NewDeprovisionEngine(h.G(), arg.Username, arg.DoRevoke)
 	ctx := engine.Context{
 		LogUI:     h.getLogUI(arg.SessionID),
 		SecretUI:  h.getSecretUI(arg.SessionID, h.G()),

--- a/protocol/avdl/login.avdl
+++ b/protocol/avdl/login.avdl
@@ -31,7 +31,7 @@ protocol login {
   void clearStoredSecret(int sessionID, string username);
 
   void logout(int sessionID);
-  void deprovision(int sessionID, string username);
+  void deprovision(int sessionID, string username, boolean doRevoke);
 
   void recoverAccountFromEmailAddress(string email);
 

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -681,7 +681,8 @@ export type incomingCallMapType = {
   'keybase.1.login.deprovision'?: (
     params: {
       sessionID: int,
-      username: string
+      username: string,
+      doRevoke: boolean
     },
     response: {
       error: (err: string) => void,
@@ -4994,7 +4995,8 @@ export type login_logout_rpc = {
 export type login_deprovision_rpc = {
   method: 'login.deprovision',
   param: {
-    username: string
+    username: string,
+    doRevoke: boolean
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)

--- a/protocol/json/login.json
+++ b/protocol/json/login.json
@@ -280,6 +280,9 @@
       }, {
         "name" : "username",
         "type" : "string"
+      }, {
+        "name" : "doRevoke",
+        "type" : "boolean"
       } ],
       "response" : "null"
     },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -681,7 +681,8 @@ export type incomingCallMapType = {
   'keybase.1.login.deprovision'?: (
     params: {
       sessionID: int,
-      username: string
+      username: string,
+      doRevoke: boolean
     },
     response: {
       error: (err: string) => void,
@@ -4994,7 +4995,8 @@ export type login_logout_rpc = {
 export type login_deprovision_rpc = {
   method: 'login.deprovision',
   param: {
-    username: string
+    username: string,
+    doRevoke: boolean
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)


### PR DESCRIPTION
@maxtaco 

The original design was that deprovision would check the current login state before trying to revoke, and just skip that step if the device was not logged in. That fails if you've just revoked the device from another device, which @malgorithms probably did in his testing. My first thought was to invalidate the login session cache to force that check to hit the server, but in fact revoking a device isn't expected to log you out in any case -- my original design was wrong. Instead, handle this case explicitly by checking for active keys with the current device ID, and skipping the revoke if none are found.

Note that there are other plausible error cases a user could run into here. For example, they might not have an internet connection at all. We might want to think about handling cases like that in the future, but it's more complicated than just skipping the revoke. (Before we even get to DeprovisionEngine, for example, CmdDeprovision calls GetCurrentStatus, and that makes network calls. Quite a lot will fail if we can't talk to the server at all.)