### PR TITLE
Tracker update states

### DIFF
--- a/shared/constants/tracker.js
+++ b/shared/constants/tracker.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 // Simple state of the overall proof result
-export type SimpleProofState = 'normal' | 'warning' | 'error' | 'checking' | 'revoked' | 'followed' | 'unfollowed' | 'refollowed' | 'proofsAdded'
+export type SimpleProofState = 'normal' | 'warning' | 'error' | 'checking' | 'revoked' | 'followed' | 'refollowed' | 'proofsAdded'
 export type SimpleProofMeta = 'upgraded' | 'new' | 'unreachable' | 'pending' | 'deleted' | 'none'
 
 // Constants
@@ -11,7 +11,6 @@ export const error: SimpleProofState = 'error'
 export const checking: SimpleProofState = 'checking'
 export const revoked: SimpleProofState = 'revoked'
 export const followed: SimpleProofState = 'followed'
-export const unfollowed: SimpleProofState = 'unfollowed'
 export const refollowed: SimpleProofState = 'refollowed'
 export const proofsAdded: SimpleProofState = 'proofsAdded'
 

--- a/shared/constants/tracker.js
+++ b/shared/constants/tracker.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 // Simple state of the overall proof result
-export type SimpleProofState = 'normal' | 'warning' | 'error' | 'checking' | 'revoked'
+export type SimpleProofState = 'normal' | 'warning' | 'error' | 'checking' | 'revoked' | 'followed' | 'unfollowed' | 'refollowed' | 'proofsAdded'
 export type SimpleProofMeta = 'upgraded' | 'new' | 'unreachable' | 'pending' | 'deleted' | 'none'
 
 // Constants
@@ -10,6 +10,10 @@ export const warning: SimpleProofState = 'warning'
 export const error: SimpleProofState = 'error'
 export const checking: SimpleProofState = 'checking'
 export const revoked: SimpleProofState = 'revoked'
+export const followed: SimpleProofState = 'followed'
+export const unfollowed: SimpleProofState = 'unfollowed'
+export const refollowed: SimpleProofState = 'refollowed'
+export const proofsAdded: SimpleProofState = 'proofsAdded'
 
 export const metaNone: SimpleProofMeta = 'none'
 export const metaUpgraded: SimpleProofMeta = 'upgraded'

--- a/shared/constants/tracker.js
+++ b/shared/constants/tracker.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 // Simple state of the overall proof result
-export type SimpleProofState = 'normal' | 'warning' | 'error' | 'checking' | 'revoked' | 'followed' | 'refollowed' | 'proofsAdded'
+export type SimpleProofState = 'normal' | 'warning' | 'error' | 'checking' | 'revoked' | 'followed' | 'refollowed' | 'followedProofsAdded'
 export type SimpleProofMeta = 'upgraded' | 'new' | 'unreachable' | 'pending' | 'deleted' | 'none'
 
 // Constants
@@ -12,7 +12,7 @@ export const checking: SimpleProofState = 'checking'
 export const revoked: SimpleProofState = 'revoked'
 export const followed: SimpleProofState = 'followed'
 export const refollowed: SimpleProofState = 'refollowed'
-export const proofsAdded: SimpleProofState = 'proofsAdded'
+export const followedProofsAdded: SimpleProofState = 'followedProofsAdded'
 
 export const metaNone: SimpleProofMeta = 'none'
 export const metaUpgraded: SimpleProofMeta = 'upgraded'

--- a/shared/tracker/proofs.render.desktop.js
+++ b/shared/tracker/proofs.render.desktop.js
@@ -70,7 +70,7 @@ export default class ProofsRender extends Component {
       followed: colors.lightBlue,
       unfollowed: colors.lightBlue,
       refollowed: colors.lightBlue,
-      proofsAdded: colors.lightBlue
+      followedProofsAdded: colors.lightBlue
     }[proof.state]
 
     return (

--- a/shared/tracker/proofs.render.desktop.js
+++ b/shared/tracker/proofs.render.desktop.js
@@ -64,7 +64,13 @@ export default class ProofsRender extends Component {
       checking: colors.grey,
       revoked: colors.orange,
       warning: colors.orange,
-      error: colors.red
+      error: colors.red,
+      // Note the four below states will never be rendered; this is a hack
+      // to keep flow happy.  Will go away when tracker v1 goes away.
+      followed: colors.lightBlue,
+      unfollowed: colors.lightBlue,
+      refollowed: colors.lightBlue,
+      proofsAdded: colors.lightBlue
     }[proof.state]
 
     return (

--- a/shared/tracker/proofs.render.desktop.js
+++ b/shared/tracker/proofs.render.desktop.js
@@ -65,7 +65,7 @@ export default class ProofsRender extends Component {
       revoked: colors.orange,
       warning: colors.orange,
       error: colors.red,
-      // Note the four below states will never be rendered; this is a hack
+      // FIXME: the four below states will never be rendered; this is a hack
       // to keep flow happy.  Will go away when tracker v1 goes away.
       followed: colors.lightBlue,
       unfollowed: colors.lightBlue,


### PR DESCRIPTION
@keybase/react-hackers

I wanted to add some new trackerStates that @gabriel and I can each start using in trackerv2 straight away.  "followed" and "refollowed" correspond to states where you've performed some action and now the tracker popup just needs to say "Close".  There's also a "followedProofsAdded" state -- for when someone you follow added new proofs -- which we won't use immediately because we don't plan to do a popup for that yet.

The additions to trackerv1's `statusColor` map are necessary because it (and maybe other parts of the code!) makes the mistake of thinking that `SimpleProofState` is a *per-proof* state that it should make per-proof rendering decisions based on.  But `SimpleProofState` is actually the same thing as the "global" trackerState -- we probably should've called it `SimpleTrackerState` instead.

I think that the `revoked` entry in `SimpleProofState` is actually a per-proof state that snuck in to our global tracker states.  But I guess I can re-use it for `unfollowed` without harm?