### PR TITLE
Add some Merkle tree RPC commands

### DIFF
--- a/go/protocol/extras.go
+++ b/go/protocol/extras.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"strconv"
 	"time"
 
 	jsonw "github.com/keybase/go-jsonw"
@@ -536,4 +537,12 @@ func (t ClientType) String() string {
 	default:
 		return "other"
 	}
+}
+
+func (m MerkleTreeID) Number() int {
+	return int(m)
+}
+
+func (m MerkleTreeID) String() string {
+	return strconv.Itoa(int(m))
 }

--- a/protocol/avdl/common.avdl
+++ b/protocol/avdl/common.avdl
@@ -114,4 +114,9 @@ protocol Common {
       UserVersionVector uvv;
   }
 
+  enum MerkleTreeID {
+       MASTER_0,
+       KBFS_PUBLIC_1,
+       KBFS_PRIVATE_2
+  }
 }

--- a/protocol/avdl/metadata.avdl
+++ b/protocol/avdl/metadata.avdl
@@ -11,12 +11,18 @@ protocol metadata {
 
   record MDBlock {
          int version;
+         Time timestamp;
          bytes block;
   }
 
   record MetadataResponse {
          string folderID;
          array<MDBlock> mdBlocks;
+  }
+
+  record MerkleRoot {
+         int version;
+         bytes root;
   }
 
   ChallengeInfo getChallenge();
@@ -33,4 +39,12 @@ protocol metadata {
   bytes getFolderHandle(string folderID, string signature, string challenge);
   void getFoldersForRekey(KID deviceKID);
   void ping();
+
+  // Merkle tree specific commands
+  // todo: we probably also want a method which will return a minmum set of interior nodes
+  // and a leaf node given a root node and a TLF ID.
+  MerkleRoot getMerkleRoot(MerkleTreeID treeID, long seqNo);
+  MerkleRoot getMerkleRootLatest(MerkleTreeID treeID);
+  MerkleRoot getMerkleRootSince(MerkleTreeID treeID, Time when);
+  bytes getMerkleNode(string hash);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -935,6 +935,44 @@ export type incomingCallMapType = {
       result: () => void
     }
   ) => void,
+  'keybase.1.metadata.getMerkleRoot'?: (
+    params: {
+      treeID: metadata_MerkleTreeID,
+      seqNo: long
+    },
+    response: {
+      error: (err: string) => void,
+      result: (result: metadata_getMerkleRoot_result) => void
+    }
+  ) => void,
+  'keybase.1.metadata.getMerkleRootLatest'?: (
+    params: {
+      treeID: metadata_MerkleTreeID
+    },
+    response: {
+      error: (err: string) => void,
+      result: (result: metadata_getMerkleRootLatest_result) => void
+    }
+  ) => void,
+  'keybase.1.metadata.getMerkleRootSince'?: (
+    params: {
+      treeID: metadata_MerkleTreeID,
+      when: metadata_Time
+    },
+    response: {
+      error: (err: string) => void,
+      result: (result: metadata_getMerkleRootSince_result) => void
+    }
+  ) => void,
+  'keybase.1.metadata.getMerkleNode'?: (
+    params: {
+      hash: string
+    },
+    response: {
+      error: (err: string) => void,
+      result: (result: metadata_getMerkleNode_result) => void
+    }
+  ) => void,
   'keybase.1.metadataUpdate.metadataUpdate'?: (
     params: {
       folderID: string,
@@ -5375,6 +5413,10 @@ export type metadata_UserPlusKeys = {
   uvv: UserVersionVector;
 }
 
+export type metadata_MerkleTreeID = 0 /* 'MASTER_0' */ | 1 /* 'KBFS_PUBLIC_1' */ | 2 /* 'KBFS_PRIVATE_2' */
+
+export type MerkleTreeID = 0 /* 'MASTER_0' */ | 1 /* 'KBFS_PUBLIC_1' */ | 2 /* 'KBFS_PRIVATE_2' */
+
 export type metadata_BlockIdCombo = {
   blockHash: string;
   chargedTo: UID;
@@ -5399,11 +5441,13 @@ export type KeyHalf = {
 
 export type metadata_MDBlock = {
   version: int;
+  timestamp: Time;
   block: bytes;
 }
 
 export type MDBlock = {
   version: int;
+  timestamp: Time;
   block: bytes;
 }
 
@@ -5415,6 +5459,16 @@ export type metadata_MetadataResponse = {
 export type MetadataResponse = {
   folderID: string;
   mdBlocks: Array<MDBlock>;
+}
+
+export type metadata_MerkleRoot = {
+  version: int;
+  root: bytes;
+}
+
+export type MerkleRoot = {
+  version: int;
+  root: bytes;
 }
 
 // metadata.getChallenge ////////////////////////////////////////
@@ -5612,6 +5666,60 @@ export type metadata_ping_rpc = {
   param: {},
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
+}
+
+// metadata.getMerkleRoot ////////////////////////////////////////
+
+export type metadata_getMerkleRoot_result = metadata_MerkleRoot
+
+export type metadata_getMerkleRoot_rpc = {
+  method: 'metadata.getMerkleRoot',
+  param: {
+    treeID: metadata_MerkleTreeID,
+    seqNo: long
+  },
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any, response: metadata_getMerkleRoot_result) => void)
+}
+
+// metadata.getMerkleRootLatest ////////////////////////////////////////
+
+export type metadata_getMerkleRootLatest_result = metadata_MerkleRoot
+
+export type metadata_getMerkleRootLatest_rpc = {
+  method: 'metadata.getMerkleRootLatest',
+  param: {
+    treeID: metadata_MerkleTreeID
+  },
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any, response: metadata_getMerkleRootLatest_result) => void)
+}
+
+// metadata.getMerkleRootSince ////////////////////////////////////////
+
+export type metadata_getMerkleRootSince_result = metadata_MerkleRoot
+
+export type metadata_getMerkleRootSince_rpc = {
+  method: 'metadata.getMerkleRootSince',
+  param: {
+    treeID: metadata_MerkleTreeID,
+    when: metadata_Time
+  },
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any, response: metadata_getMerkleRootSince_result) => void)
+}
+
+// metadata.getMerkleNode ////////////////////////////////////////
+
+export type metadata_getMerkleNode_result = bytes
+
+export type metadata_getMerkleNode_rpc = {
+  method: 'metadata.getMerkleNode',
+  param: {
+    hash: string
+  },
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any, response: metadata_getMerkleNode_result) => void)
 }
 
 export type metadataUpdate_Time = long
@@ -9700,5 +9808,5 @@ export type user_search_rpc = {
   callback: (null | (err: ?any, response: user_search_result) => void)
 }
 
-export type rpc = account_passphraseChange_rpc | account_passphrasePrompt_rpc | block_getSessionChallenge_rpc | block_authenticateSession_rpc | block_putBlock_rpc | block_getBlock_rpc | block_addReference_rpc | block_delReference_rpc | block_archiveReference_rpc | block_getUserQuotaInfo_rpc | BTC_registerBTC_rpc | config_getCurrentStatus_rpc | config_getExtendedStatus_rpc | config_getConfig_rpc | config_setUserConfig_rpc | config_setPath_rpc | config_helloIAm_rpc | config_setValue_rpc | config_clearValue_rpc | config_getValue_rpc | crypto_signED25519_rpc | crypto_signToString_rpc | crypto_unboxBytes32_rpc | crypto_unboxBytes32Any_rpc | ctl_stop_rpc | ctl_logRotate_rpc | ctl_reload_rpc | ctl_dbNuke_rpc | debugging_firstStep_rpc | debugging_secondStep_rpc | debugging_increment_rpc | delegateUiCtl_registerIdentifyUI_rpc | delegateUiCtl_registerSecretUI_rpc | delegateUiCtl_registerUpdateUI_rpc | device_deviceList_rpc | device_deviceAdd_rpc | favorite_favoriteAdd_rpc | favorite_favoriteDelete_rpc | favorite_favoriteList_rpc | gpgUi_wantToAddGPGKey_rpc | gpgUi_confirmDuplicateKeyChosen_rpc | gpgUi_selectKeyAndPushOption_rpc | gpgUi_selectKey_rpc | gpgUi_sign_rpc | identify_Resolve_rpc | identify_Resolve2_rpc | identify_identify_rpc | identify_identify2_rpc | identifyUi_delegateIdentifyUI_rpc | identifyUi_start_rpc | identifyUi_displayKey_rpc | identifyUi_reportLastTrack_rpc | identifyUi_launchNetworkChecks_rpc | identifyUi_displayTrackStatement_rpc | identifyUi_finishWebProofCheck_rpc | identifyUi_finishSocialProofCheck_rpc | identifyUi_displayCryptocurrency_rpc | identifyUi_reportTrackToken_rpc | identifyUi_displayUserCard_rpc | identifyUi_confirm_rpc | identifyUi_finish_rpc | kbfs_FSEvent_rpc | Kex2Provisionee_hello_rpc | Kex2Provisionee_didCounterSign_rpc | Kex2Provisioner_kexStart_rpc | log_registerLogger_rpc | logUi_log_rpc | login_getConfiguredAccounts_rpc | login_login_rpc | login_clearStoredSecret_rpc | login_logout_rpc | login_deprovision_rpc | login_recoverAccountFromEmailAddress_rpc | login_paperKey_rpc | login_unlock_rpc | login_unlockWithPassphrase_rpc | loginUi_getEmailOrUsername_rpc | loginUi_promptRevokePaperKeys_rpc | loginUi_displayPaperKeyPhrase_rpc | loginUi_displayPrimaryPaperKey_rpc | metadata_getChallenge_rpc | metadata_authenticate_rpc | metadata_putMetadata_rpc | metadata_getMetadata_rpc | metadata_registerForUpdates_rpc | metadata_pruneBranch_rpc | metadata_putKeys_rpc | metadata_getKey_rpc | metadata_deleteKey_rpc | metadata_truncateLock_rpc | metadata_truncateUnlock_rpc | metadata_getFolderHandle_rpc | metadata_getFoldersForRekey_rpc | metadata_ping_rpc | metadataUpdate_metadataUpdate_rpc | metadataUpdate_folderNeedsRekey_rpc | notifyCtl_setNotifications_rpc | NotifyFS_FSActivity_rpc | NotifySession_loggedOut_rpc | NotifySession_loggedIn_rpc | NotifyTracking_trackingChanged_rpc | NotifyUsers_userChanged_rpc | pgp_pgpSign_rpc | pgp_pgpPull_rpc | pgp_pgpEncrypt_rpc | pgp_pgpDecrypt_rpc | pgp_pgpVerify_rpc | pgp_pgpImport_rpc | pgp_pgpExport_rpc | pgp_pgpExportByFingerprint_rpc | pgp_pgpExportByKID_rpc | pgp_pgpKeyGen_rpc | pgp_pgpDeletePrimary_rpc | pgp_pgpSelect_rpc | pgp_pgpUpdate_rpc | pgpUi_outputSignatureSuccess_rpc | prove_startProof_rpc | prove_checkProof_rpc | proveUi_promptOverwrite_rpc | proveUi_promptUsername_rpc | proveUi_outputPrechecks_rpc | proveUi_preProofWarning_rpc | proveUi_outputInstructions_rpc | proveUi_okToCheck_rpc | proveUi_displayRecheckWarning_rpc | provisionUi_chooseProvisioningMethod_rpc | provisionUi_chooseDeviceType_rpc | provisionUi_DisplayAndPromptSecret_rpc | provisionUi_DisplaySecretExchanged_rpc | provisionUi_PromptNewDeviceName_rpc | provisionUi_ProvisioneeSuccess_rpc | provisionUi_ProvisionerSuccess_rpc | quota_verifySession_rpc | revoke_revokeKey_rpc | revoke_revokeDevice_rpc | revoke_revokeSigs_rpc | saltpack_saltpackEncrypt_rpc | saltpack_saltpackDecrypt_rpc | saltpack_saltpackSign_rpc | saltpack_saltpackVerify_rpc | saltpackUi_saltpackPromptForDecrypt_rpc | saltpackUi_saltpackVerifySuccess_rpc | secretUi_getPassphrase_rpc | SecretKeys_getSecretKeys_rpc | session_currentSession_rpc | signup_checkUsernameAvailable_rpc | signup_signup_rpc | signup_inviteRequest_rpc | signup_checkInvitationCode_rpc | sigs_sigList_rpc | sigs_sigListJSON_rpc | streamUi_close_rpc | streamUi_read_rpc | streamUi_write_rpc | test_test_rpc | test_testCallback_rpc | test_panic_rpc | track_track_rpc | track_trackWithToken_rpc | track_untrack_rpc | track_checkTracking_rpc | track_fakeTrackingChanged_rpc | ui_promptYesNo_rpc | update_update_rpc | update_updateCheck_rpc | updateUi_updatePrompt_rpc | updateUi_updateQuit_rpc | user_listTrackers_rpc | user_listTrackersByName_rpc | user_listTrackersSelf_rpc | user_loadUncheckedUserSummaries_rpc | user_loadUser_rpc | user_loadUserPlusKeys_rpc | user_loadPublicKeys_rpc | user_listTracking_rpc | user_listTrackingJSON_rpc | user_search_rpc
+export type rpc = account_passphraseChange_rpc | account_passphrasePrompt_rpc | block_getSessionChallenge_rpc | block_authenticateSession_rpc | block_putBlock_rpc | block_getBlock_rpc | block_addReference_rpc | block_delReference_rpc | block_archiveReference_rpc | block_getUserQuotaInfo_rpc | BTC_registerBTC_rpc | config_getCurrentStatus_rpc | config_getExtendedStatus_rpc | config_getConfig_rpc | config_setUserConfig_rpc | config_setPath_rpc | config_helloIAm_rpc | config_setValue_rpc | config_clearValue_rpc | config_getValue_rpc | crypto_signED25519_rpc | crypto_signToString_rpc | crypto_unboxBytes32_rpc | crypto_unboxBytes32Any_rpc | ctl_stop_rpc | ctl_logRotate_rpc | ctl_reload_rpc | ctl_dbNuke_rpc | debugging_firstStep_rpc | debugging_secondStep_rpc | debugging_increment_rpc | delegateUiCtl_registerIdentifyUI_rpc | delegateUiCtl_registerSecretUI_rpc | delegateUiCtl_registerUpdateUI_rpc | device_deviceList_rpc | device_deviceAdd_rpc | favorite_favoriteAdd_rpc | favorite_favoriteDelete_rpc | favorite_favoriteList_rpc | gpgUi_wantToAddGPGKey_rpc | gpgUi_confirmDuplicateKeyChosen_rpc | gpgUi_selectKeyAndPushOption_rpc | gpgUi_selectKey_rpc | gpgUi_sign_rpc | identify_Resolve_rpc | identify_Resolve2_rpc | identify_identify_rpc | identify_identify2_rpc | identifyUi_delegateIdentifyUI_rpc | identifyUi_start_rpc | identifyUi_displayKey_rpc | identifyUi_reportLastTrack_rpc | identifyUi_launchNetworkChecks_rpc | identifyUi_displayTrackStatement_rpc | identifyUi_finishWebProofCheck_rpc | identifyUi_finishSocialProofCheck_rpc | identifyUi_displayCryptocurrency_rpc | identifyUi_reportTrackToken_rpc | identifyUi_displayUserCard_rpc | identifyUi_confirm_rpc | identifyUi_finish_rpc | kbfs_FSEvent_rpc | Kex2Provisionee_hello_rpc | Kex2Provisionee_didCounterSign_rpc | Kex2Provisioner_kexStart_rpc | log_registerLogger_rpc | logUi_log_rpc | login_getConfiguredAccounts_rpc | login_login_rpc | login_clearStoredSecret_rpc | login_logout_rpc | login_deprovision_rpc | login_recoverAccountFromEmailAddress_rpc | login_paperKey_rpc | login_unlock_rpc | login_unlockWithPassphrase_rpc | loginUi_getEmailOrUsername_rpc | loginUi_promptRevokePaperKeys_rpc | loginUi_displayPaperKeyPhrase_rpc | loginUi_displayPrimaryPaperKey_rpc | metadata_getChallenge_rpc | metadata_authenticate_rpc | metadata_putMetadata_rpc | metadata_getMetadata_rpc | metadata_registerForUpdates_rpc | metadata_pruneBranch_rpc | metadata_putKeys_rpc | metadata_getKey_rpc | metadata_deleteKey_rpc | metadata_truncateLock_rpc | metadata_truncateUnlock_rpc | metadata_getFolderHandle_rpc | metadata_getFoldersForRekey_rpc | metadata_ping_rpc | metadata_getMerkleRoot_rpc | metadata_getMerkleRootLatest_rpc | metadata_getMerkleRootSince_rpc | metadata_getMerkleNode_rpc | metadataUpdate_metadataUpdate_rpc | metadataUpdate_folderNeedsRekey_rpc | notifyCtl_setNotifications_rpc | NotifyFS_FSActivity_rpc | NotifySession_loggedOut_rpc | NotifySession_loggedIn_rpc | NotifyTracking_trackingChanged_rpc | NotifyUsers_userChanged_rpc | pgp_pgpSign_rpc | pgp_pgpPull_rpc | pgp_pgpEncrypt_rpc | pgp_pgpDecrypt_rpc | pgp_pgpVerify_rpc | pgp_pgpImport_rpc | pgp_pgpExport_rpc | pgp_pgpExportByFingerprint_rpc | pgp_pgpExportByKID_rpc | pgp_pgpKeyGen_rpc | pgp_pgpDeletePrimary_rpc | pgp_pgpSelect_rpc | pgp_pgpUpdate_rpc | pgpUi_outputSignatureSuccess_rpc | prove_startProof_rpc | prove_checkProof_rpc | proveUi_promptOverwrite_rpc | proveUi_promptUsername_rpc | proveUi_outputPrechecks_rpc | proveUi_preProofWarning_rpc | proveUi_outputInstructions_rpc | proveUi_okToCheck_rpc | proveUi_displayRecheckWarning_rpc | provisionUi_chooseProvisioningMethod_rpc | provisionUi_chooseDeviceType_rpc | provisionUi_DisplayAndPromptSecret_rpc | provisionUi_DisplaySecretExchanged_rpc | provisionUi_PromptNewDeviceName_rpc | provisionUi_ProvisioneeSuccess_rpc | provisionUi_ProvisionerSuccess_rpc | quota_verifySession_rpc | revoke_revokeKey_rpc | revoke_revokeDevice_rpc | revoke_revokeSigs_rpc | saltpack_saltpackEncrypt_rpc | saltpack_saltpackDecrypt_rpc | saltpack_saltpackSign_rpc | saltpack_saltpackVerify_rpc | saltpackUi_saltpackPromptForDecrypt_rpc | saltpackUi_saltpackVerifySuccess_rpc | secretUi_getPassphrase_rpc | SecretKeys_getSecretKeys_rpc | session_currentSession_rpc | signup_checkUsernameAvailable_rpc | signup_signup_rpc | signup_inviteRequest_rpc | signup_checkInvitationCode_rpc | sigs_sigList_rpc | sigs_sigListJSON_rpc | streamUi_close_rpc | streamUi_read_rpc | streamUi_write_rpc | test_test_rpc | test_testCallback_rpc | test_panic_rpc | track_track_rpc | track_trackWithToken_rpc | track_untrack_rpc | track_checkTracking_rpc | track_fakeTrackingChanged_rpc | ui_promptYesNo_rpc | update_update_rpc | update_updateCheck_rpc | updateUi_updatePrompt_rpc | updateUi_updateQuit_rpc | user_listTrackers_rpc | user_listTrackersByName_rpc | user_listTrackersSelf_rpc | user_loadUncheckedUserSummaries_rpc | user_loadUser_rpc | user_loadUserPlusKeys_rpc | user_loadPublicKeys_rpc | user_listTracking_rpc | user_listTrackingJSON_rpc | user_search_rpc
 

--- a/protocol/js/keybase-v1.js
+++ b/protocol/js/keybase-v1.js
@@ -637,6 +637,11 @@ export const metadata = {
     'cli': 1,
     'gui': 2,
     'kbfs': 3
+  },
+  'MerkleTreeID': {
+    'master': 0,
+    'kbfsPublic': 1,
+    'kbfsPrivate': 2
   }
 }
 

--- a/protocol/json/metadata.json
+++ b/protocol/json/metadata.json
@@ -216,6 +216,10 @@
       "type" : "UserVersionVector"
     } ]
   }, {
+    "type" : "enum",
+    "name" : "MerkleTreeID",
+    "symbols" : [ "MASTER_0", "KBFS_PUBLIC_1", "KBFS_PRIVATE_2" ]
+  }, {
     "type" : "record",
     "name" : "BlockIdCombo",
     "fields" : [ {
@@ -255,6 +259,9 @@
       "name" : "version",
       "type" : "int"
     }, {
+      "name" : "timestamp",
+      "type" : "Time"
+    }, {
       "name" : "block",
       "type" : "bytes"
     } ]
@@ -270,6 +277,16 @@
         "type" : "array",
         "items" : "MDBlock"
       }
+    } ]
+  }, {
+    "type" : "record",
+    "name" : "MerkleRoot",
+    "fields" : [ {
+      "name" : "version",
+      "type" : "int"
+    }, {
+      "name" : "root",
+      "type" : "bytes"
     } ]
   } ],
   "messages" : {
@@ -445,6 +462,40 @@
     "ping" : {
       "request" : [ ],
       "response" : "null"
+    },
+    "getMerkleRoot" : {
+      "request" : [ {
+        "name" : "treeID",
+        "type" : "MerkleTreeID"
+      }, {
+        "name" : "seqNo",
+        "type" : "long"
+      } ],
+      "response" : "MerkleRoot"
+    },
+    "getMerkleRootLatest" : {
+      "request" : [ {
+        "name" : "treeID",
+        "type" : "MerkleTreeID"
+      } ],
+      "response" : "MerkleRoot"
+    },
+    "getMerkleRootSince" : {
+      "request" : [ {
+        "name" : "treeID",
+        "type" : "MerkleTreeID"
+      }, {
+        "name" : "when",
+        "type" : "Time"
+      } ],
+      "response" : "MerkleRoot"
+    },
+    "getMerkleNode" : {
+      "request" : [ {
+        "name" : "hash",
+        "type" : "string"
+      } ],
+      "response" : "bytes"
     }
   }
 }

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -935,6 +935,44 @@ export type incomingCallMapType = {
       result: () => void
     }
   ) => void,
+  'keybase.1.metadata.getMerkleRoot'?: (
+    params: {
+      treeID: metadata_MerkleTreeID,
+      seqNo: long
+    },
+    response: {
+      error: (err: string) => void,
+      result: (result: metadata_getMerkleRoot_result) => void
+    }
+  ) => void,
+  'keybase.1.metadata.getMerkleRootLatest'?: (
+    params: {
+      treeID: metadata_MerkleTreeID
+    },
+    response: {
+      error: (err: string) => void,
+      result: (result: metadata_getMerkleRootLatest_result) => void
+    }
+  ) => void,
+  'keybase.1.metadata.getMerkleRootSince'?: (
+    params: {
+      treeID: metadata_MerkleTreeID,
+      when: metadata_Time
+    },
+    response: {
+      error: (err: string) => void,
+      result: (result: metadata_getMerkleRootSince_result) => void
+    }
+  ) => void,
+  'keybase.1.metadata.getMerkleNode'?: (
+    params: {
+      hash: string
+    },
+    response: {
+      error: (err: string) => void,
+      result: (result: metadata_getMerkleNode_result) => void
+    }
+  ) => void,
   'keybase.1.metadataUpdate.metadataUpdate'?: (
     params: {
       folderID: string,
@@ -5375,6 +5413,10 @@ export type metadata_UserPlusKeys = {
   uvv: UserVersionVector;
 }
 
+export type metadata_MerkleTreeID = 0 /* 'MASTER_0' */ | 1 /* 'KBFS_PUBLIC_1' */ | 2 /* 'KBFS_PRIVATE_2' */
+
+export type MerkleTreeID = 0 /* 'MASTER_0' */ | 1 /* 'KBFS_PUBLIC_1' */ | 2 /* 'KBFS_PRIVATE_2' */
+
 export type metadata_BlockIdCombo = {
   blockHash: string;
   chargedTo: UID;
@@ -5399,11 +5441,13 @@ export type KeyHalf = {
 
 export type metadata_MDBlock = {
   version: int;
+  timestamp: Time;
   block: bytes;
 }
 
 export type MDBlock = {
   version: int;
+  timestamp: Time;
   block: bytes;
 }
 
@@ -5415,6 +5459,16 @@ export type metadata_MetadataResponse = {
 export type MetadataResponse = {
   folderID: string;
   mdBlocks: Array<MDBlock>;
+}
+
+export type metadata_MerkleRoot = {
+  version: int;
+  root: bytes;
+}
+
+export type MerkleRoot = {
+  version: int;
+  root: bytes;
 }
 
 // metadata.getChallenge ////////////////////////////////////////
@@ -5612,6 +5666,60 @@ export type metadata_ping_rpc = {
   param: {},
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
+}
+
+// metadata.getMerkleRoot ////////////////////////////////////////
+
+export type metadata_getMerkleRoot_result = metadata_MerkleRoot
+
+export type metadata_getMerkleRoot_rpc = {
+  method: 'metadata.getMerkleRoot',
+  param: {
+    treeID: metadata_MerkleTreeID,
+    seqNo: long
+  },
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any, response: metadata_getMerkleRoot_result) => void)
+}
+
+// metadata.getMerkleRootLatest ////////////////////////////////////////
+
+export type metadata_getMerkleRootLatest_result = metadata_MerkleRoot
+
+export type metadata_getMerkleRootLatest_rpc = {
+  method: 'metadata.getMerkleRootLatest',
+  param: {
+    treeID: metadata_MerkleTreeID
+  },
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any, response: metadata_getMerkleRootLatest_result) => void)
+}
+
+// metadata.getMerkleRootSince ////////////////////////////////////////
+
+export type metadata_getMerkleRootSince_result = metadata_MerkleRoot
+
+export type metadata_getMerkleRootSince_rpc = {
+  method: 'metadata.getMerkleRootSince',
+  param: {
+    treeID: metadata_MerkleTreeID,
+    when: metadata_Time
+  },
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any, response: metadata_getMerkleRootSince_result) => void)
+}
+
+// metadata.getMerkleNode ////////////////////////////////////////
+
+export type metadata_getMerkleNode_result = bytes
+
+export type metadata_getMerkleNode_rpc = {
+  method: 'metadata.getMerkleNode',
+  param: {
+    hash: string
+  },
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any, response: metadata_getMerkleNode_result) => void)
 }
 
 export type metadataUpdate_Time = long
@@ -9700,5 +9808,5 @@ export type user_search_rpc = {
   callback: (null | (err: ?any, response: user_search_result) => void)
 }
 
-export type rpc = account_passphraseChange_rpc | account_passphrasePrompt_rpc | block_getSessionChallenge_rpc | block_authenticateSession_rpc | block_putBlock_rpc | block_getBlock_rpc | block_addReference_rpc | block_delReference_rpc | block_archiveReference_rpc | block_getUserQuotaInfo_rpc | BTC_registerBTC_rpc | config_getCurrentStatus_rpc | config_getExtendedStatus_rpc | config_getConfig_rpc | config_setUserConfig_rpc | config_setPath_rpc | config_helloIAm_rpc | config_setValue_rpc | config_clearValue_rpc | config_getValue_rpc | crypto_signED25519_rpc | crypto_signToString_rpc | crypto_unboxBytes32_rpc | crypto_unboxBytes32Any_rpc | ctl_stop_rpc | ctl_logRotate_rpc | ctl_reload_rpc | ctl_dbNuke_rpc | debugging_firstStep_rpc | debugging_secondStep_rpc | debugging_increment_rpc | delegateUiCtl_registerIdentifyUI_rpc | delegateUiCtl_registerSecretUI_rpc | delegateUiCtl_registerUpdateUI_rpc | device_deviceList_rpc | device_deviceAdd_rpc | favorite_favoriteAdd_rpc | favorite_favoriteDelete_rpc | favorite_favoriteList_rpc | gpgUi_wantToAddGPGKey_rpc | gpgUi_confirmDuplicateKeyChosen_rpc | gpgUi_selectKeyAndPushOption_rpc | gpgUi_selectKey_rpc | gpgUi_sign_rpc | identify_Resolve_rpc | identify_Resolve2_rpc | identify_identify_rpc | identify_identify2_rpc | identifyUi_delegateIdentifyUI_rpc | identifyUi_start_rpc | identifyUi_displayKey_rpc | identifyUi_reportLastTrack_rpc | identifyUi_launchNetworkChecks_rpc | identifyUi_displayTrackStatement_rpc | identifyUi_finishWebProofCheck_rpc | identifyUi_finishSocialProofCheck_rpc | identifyUi_displayCryptocurrency_rpc | identifyUi_reportTrackToken_rpc | identifyUi_displayUserCard_rpc | identifyUi_confirm_rpc | identifyUi_finish_rpc | kbfs_FSEvent_rpc | Kex2Provisionee_hello_rpc | Kex2Provisionee_didCounterSign_rpc | Kex2Provisioner_kexStart_rpc | log_registerLogger_rpc | logUi_log_rpc | login_getConfiguredAccounts_rpc | login_login_rpc | login_clearStoredSecret_rpc | login_logout_rpc | login_deprovision_rpc | login_recoverAccountFromEmailAddress_rpc | login_paperKey_rpc | login_unlock_rpc | login_unlockWithPassphrase_rpc | loginUi_getEmailOrUsername_rpc | loginUi_promptRevokePaperKeys_rpc | loginUi_displayPaperKeyPhrase_rpc | loginUi_displayPrimaryPaperKey_rpc | metadata_getChallenge_rpc | metadata_authenticate_rpc | metadata_putMetadata_rpc | metadata_getMetadata_rpc | metadata_registerForUpdates_rpc | metadata_pruneBranch_rpc | metadata_putKeys_rpc | metadata_getKey_rpc | metadata_deleteKey_rpc | metadata_truncateLock_rpc | metadata_truncateUnlock_rpc | metadata_getFolderHandle_rpc | metadata_getFoldersForRekey_rpc | metadata_ping_rpc | metadataUpdate_metadataUpdate_rpc | metadataUpdate_folderNeedsRekey_rpc | notifyCtl_setNotifications_rpc | NotifyFS_FSActivity_rpc | NotifySession_loggedOut_rpc | NotifySession_loggedIn_rpc | NotifyTracking_trackingChanged_rpc | NotifyUsers_userChanged_rpc | pgp_pgpSign_rpc | pgp_pgpPull_rpc | pgp_pgpEncrypt_rpc | pgp_pgpDecrypt_rpc | pgp_pgpVerify_rpc | pgp_pgpImport_rpc | pgp_pgpExport_rpc | pgp_pgpExportByFingerprint_rpc | pgp_pgpExportByKID_rpc | pgp_pgpKeyGen_rpc | pgp_pgpDeletePrimary_rpc | pgp_pgpSelect_rpc | pgp_pgpUpdate_rpc | pgpUi_outputSignatureSuccess_rpc | prove_startProof_rpc | prove_checkProof_rpc | proveUi_promptOverwrite_rpc | proveUi_promptUsername_rpc | proveUi_outputPrechecks_rpc | proveUi_preProofWarning_rpc | proveUi_outputInstructions_rpc | proveUi_okToCheck_rpc | proveUi_displayRecheckWarning_rpc | provisionUi_chooseProvisioningMethod_rpc | provisionUi_chooseDeviceType_rpc | provisionUi_DisplayAndPromptSecret_rpc | provisionUi_DisplaySecretExchanged_rpc | provisionUi_PromptNewDeviceName_rpc | provisionUi_ProvisioneeSuccess_rpc | provisionUi_ProvisionerSuccess_rpc | quota_verifySession_rpc | revoke_revokeKey_rpc | revoke_revokeDevice_rpc | revoke_revokeSigs_rpc | saltpack_saltpackEncrypt_rpc | saltpack_saltpackDecrypt_rpc | saltpack_saltpackSign_rpc | saltpack_saltpackVerify_rpc | saltpackUi_saltpackPromptForDecrypt_rpc | saltpackUi_saltpackVerifySuccess_rpc | secretUi_getPassphrase_rpc | SecretKeys_getSecretKeys_rpc | session_currentSession_rpc | signup_checkUsernameAvailable_rpc | signup_signup_rpc | signup_inviteRequest_rpc | signup_checkInvitationCode_rpc | sigs_sigList_rpc | sigs_sigListJSON_rpc | streamUi_close_rpc | streamUi_read_rpc | streamUi_write_rpc | test_test_rpc | test_testCallback_rpc | test_panic_rpc | track_track_rpc | track_trackWithToken_rpc | track_untrack_rpc | track_checkTracking_rpc | track_fakeTrackingChanged_rpc | ui_promptYesNo_rpc | update_update_rpc | update_updateCheck_rpc | updateUi_updatePrompt_rpc | updateUi_updateQuit_rpc | user_listTrackers_rpc | user_listTrackersByName_rpc | user_listTrackersSelf_rpc | user_loadUncheckedUserSummaries_rpc | user_loadUser_rpc | user_loadUserPlusKeys_rpc | user_loadPublicKeys_rpc | user_listTracking_rpc | user_listTrackingJSON_rpc | user_search_rpc
+export type rpc = account_passphraseChange_rpc | account_passphrasePrompt_rpc | block_getSessionChallenge_rpc | block_authenticateSession_rpc | block_putBlock_rpc | block_getBlock_rpc | block_addReference_rpc | block_delReference_rpc | block_archiveReference_rpc | block_getUserQuotaInfo_rpc | BTC_registerBTC_rpc | config_getCurrentStatus_rpc | config_getExtendedStatus_rpc | config_getConfig_rpc | config_setUserConfig_rpc | config_setPath_rpc | config_helloIAm_rpc | config_setValue_rpc | config_clearValue_rpc | config_getValue_rpc | crypto_signED25519_rpc | crypto_signToString_rpc | crypto_unboxBytes32_rpc | crypto_unboxBytes32Any_rpc | ctl_stop_rpc | ctl_logRotate_rpc | ctl_reload_rpc | ctl_dbNuke_rpc | debugging_firstStep_rpc | debugging_secondStep_rpc | debugging_increment_rpc | delegateUiCtl_registerIdentifyUI_rpc | delegateUiCtl_registerSecretUI_rpc | delegateUiCtl_registerUpdateUI_rpc | device_deviceList_rpc | device_deviceAdd_rpc | favorite_favoriteAdd_rpc | favorite_favoriteDelete_rpc | favorite_favoriteList_rpc | gpgUi_wantToAddGPGKey_rpc | gpgUi_confirmDuplicateKeyChosen_rpc | gpgUi_selectKeyAndPushOption_rpc | gpgUi_selectKey_rpc | gpgUi_sign_rpc | identify_Resolve_rpc | identify_Resolve2_rpc | identify_identify_rpc | identify_identify2_rpc | identifyUi_delegateIdentifyUI_rpc | identifyUi_start_rpc | identifyUi_displayKey_rpc | identifyUi_reportLastTrack_rpc | identifyUi_launchNetworkChecks_rpc | identifyUi_displayTrackStatement_rpc | identifyUi_finishWebProofCheck_rpc | identifyUi_finishSocialProofCheck_rpc | identifyUi_displayCryptocurrency_rpc | identifyUi_reportTrackToken_rpc | identifyUi_displayUserCard_rpc | identifyUi_confirm_rpc | identifyUi_finish_rpc | kbfs_FSEvent_rpc | Kex2Provisionee_hello_rpc | Kex2Provisionee_didCounterSign_rpc | Kex2Provisioner_kexStart_rpc | log_registerLogger_rpc | logUi_log_rpc | login_getConfiguredAccounts_rpc | login_login_rpc | login_clearStoredSecret_rpc | login_logout_rpc | login_deprovision_rpc | login_recoverAccountFromEmailAddress_rpc | login_paperKey_rpc | login_unlock_rpc | login_unlockWithPassphrase_rpc | loginUi_getEmailOrUsername_rpc | loginUi_promptRevokePaperKeys_rpc | loginUi_displayPaperKeyPhrase_rpc | loginUi_displayPrimaryPaperKey_rpc | metadata_getChallenge_rpc | metadata_authenticate_rpc | metadata_putMetadata_rpc | metadata_getMetadata_rpc | metadata_registerForUpdates_rpc | metadata_pruneBranch_rpc | metadata_putKeys_rpc | metadata_getKey_rpc | metadata_deleteKey_rpc | metadata_truncateLock_rpc | metadata_truncateUnlock_rpc | metadata_getFolderHandle_rpc | metadata_getFoldersForRekey_rpc | metadata_ping_rpc | metadata_getMerkleRoot_rpc | metadata_getMerkleRootLatest_rpc | metadata_getMerkleRootSince_rpc | metadata_getMerkleNode_rpc | metadataUpdate_metadataUpdate_rpc | metadataUpdate_folderNeedsRekey_rpc | notifyCtl_setNotifications_rpc | NotifyFS_FSActivity_rpc | NotifySession_loggedOut_rpc | NotifySession_loggedIn_rpc | NotifyTracking_trackingChanged_rpc | NotifyUsers_userChanged_rpc | pgp_pgpSign_rpc | pgp_pgpPull_rpc | pgp_pgpEncrypt_rpc | pgp_pgpDecrypt_rpc | pgp_pgpVerify_rpc | pgp_pgpImport_rpc | pgp_pgpExport_rpc | pgp_pgpExportByFingerprint_rpc | pgp_pgpExportByKID_rpc | pgp_pgpKeyGen_rpc | pgp_pgpDeletePrimary_rpc | pgp_pgpSelect_rpc | pgp_pgpUpdate_rpc | pgpUi_outputSignatureSuccess_rpc | prove_startProof_rpc | prove_checkProof_rpc | proveUi_promptOverwrite_rpc | proveUi_promptUsername_rpc | proveUi_outputPrechecks_rpc | proveUi_preProofWarning_rpc | proveUi_outputInstructions_rpc | proveUi_okToCheck_rpc | proveUi_displayRecheckWarning_rpc | provisionUi_chooseProvisioningMethod_rpc | provisionUi_chooseDeviceType_rpc | provisionUi_DisplayAndPromptSecret_rpc | provisionUi_DisplaySecretExchanged_rpc | provisionUi_PromptNewDeviceName_rpc | provisionUi_ProvisioneeSuccess_rpc | provisionUi_ProvisionerSuccess_rpc | quota_verifySession_rpc | revoke_revokeKey_rpc | revoke_revokeDevice_rpc | revoke_revokeSigs_rpc | saltpack_saltpackEncrypt_rpc | saltpack_saltpackDecrypt_rpc | saltpack_saltpackSign_rpc | saltpack_saltpackVerify_rpc | saltpackUi_saltpackPromptForDecrypt_rpc | saltpackUi_saltpackVerifySuccess_rpc | secretUi_getPassphrase_rpc | SecretKeys_getSecretKeys_rpc | session_currentSession_rpc | signup_checkUsernameAvailable_rpc | signup_signup_rpc | signup_inviteRequest_rpc | signup_checkInvitationCode_rpc | sigs_sigList_rpc | sigs_sigListJSON_rpc | streamUi_close_rpc | streamUi_read_rpc | streamUi_write_rpc | test_test_rpc | test_testCallback_rpc | test_panic_rpc | track_track_rpc | track_trackWithToken_rpc | track_untrack_rpc | track_checkTracking_rpc | track_fakeTrackingChanged_rpc | ui_promptYesNo_rpc | update_update_rpc | update_updateCheck_rpc | updateUi_updatePrompt_rpc | updateUi_updateQuit_rpc | user_listTrackers_rpc | user_listTrackersByName_rpc | user_listTrackersSelf_rpc | user_loadUncheckedUserSummaries_rpc | user_loadUser_rpc | user_loadUserPlusKeys_rpc | user_loadPublicKeys_rpc | user_listTracking_rpc | user_listTrackingJSON_rpc | user_search_rpc
 

--- a/shared/constants/types/keybase-v1.js
+++ b/shared/constants/types/keybase-v1.js
@@ -637,6 +637,11 @@ export const metadata = {
     'cli': 1,
     'gui': 2,
     'kbfs': 3
+  },
+  'MerkleTreeID': {
+    'master': 0,
+    'kbfsPublic': 1,
+    'kbfsPrivate': 2
   }
 }
 


### PR DESCRIPTION
@maxtaco These are some initial RPC methods I plan to expose from the mdserver primarily so the site can add the latest KBFS roots to its Merkle tree (and so intrepid programmers can verify folder state by hand if they want to.) I didn't yet include a method to gather the leaf node and minimum set of interior nodes required to verify a folder's state in a single response. I figure I'll do that when implementing the client-side verification logic.