### PR TITLE
Notify on startup error

### DIFF
--- a/shared/actions/startup.js
+++ b/shared/actions/startup.js
@@ -2,32 +2,28 @@ import * as ConfigConstants from '../constants/config'
 import {getConfig, getCurrentStatus} from './config'
 import {autoLogin} from './login'
 import engine from '../engine'
+import {NotifyPopup} from '../native/notifications'
 
 // This requires things across actions, so to avoid a circular dependency we'll pull this out
 // into it's own file
 export function startup () {
   return function (dispatch) {
-    // Also call getCurrentStatus if the service goes away/comes back.
+    dispatch({type: ConfigConstants.startupLoading})
+
     engine.listenOnConnect('getCurrentStatus', () => {
       return (
         Promise.all([dispatch(getCurrentStatus()), dispatch(getConfig())])
-          .then(() => dispatch({type: ConfigConstants.startupLoaded}))
-          .catch(error => dispatch({type: ConfigConstants.startupLoaded, payload: error, error: true}))
+          .then(() => {
+            dispatch({type: ConfigConstants.startupLoaded})
+            dispatch(autoLogin())
+          })
+          .catch(error => {
+            console.error('Error starting up:', error)
+            dispatch({type: ConfigConstants.startupLoaded, payload: error, error: true})
+            NotifyPopup('Startup Failed', {body: 'Run `keybase log send` to tell us why!'})
+          })
       )
     })
-
-    dispatch({type: ConfigConstants.startupLoading})
-
-    dispatch(getCurrentStatus())
-      .then(() => {
-        dispatch(autoLogin())
-        return dispatch(getConfig())
-      })
-      .then(() => dispatch({type: ConfigConstants.startupLoaded}))
-      .catch(error => {
-        console.error('Error starting up:', error)
-        dispatch({type: ConfigConstants.startupLoaded, payload: error, error: true})
-      })
   }
 }
 

--- a/shared/nav.desktop.js
+++ b/shared/nav.desktop.js
@@ -59,6 +59,10 @@ class Nav extends Component {
   constructor (props) {
     super(props)
     this.props.startup()
+
+    // Restartup when we connect online.
+    // If you startup while offline, you'll stay in an errored state
+    window.addEventListener('online', this.props.startup)
   }
 
   _handleTabsChange (e, key, payload) {


### PR DESCRIPTION
@keybase/react-hackers 

This will popup a notification that will tell the user the startup stuff failed.

Also re-starts up when connected to the internet. There was a bug where if you started keybase service offline and the app offline, when you got online you would be in a broken state since the startup never loaded properly.

Here's a preview of the notification.
<img width="334" alt="screen shot 2016-02-18 at 4 16 39 pm" src="https://cloud.githubusercontent.com/assets/594035/13163092/ec15e1be-d65e-11e5-9c2b-7c03b83a226a.png">


Look at https://github.com/keybase/client/pull/2051 first please!
