### PR TITLE
Add Dialog box, and use the dialog box to show startup error

### DIFF
--- a/shared/actions/startup.js
+++ b/shared/actions/startup.js
@@ -2,7 +2,7 @@ import * as ConfigConstants from '../constants/config'
 import {getConfig, getCurrentStatus} from './config'
 import {autoLogin} from './login'
 import engine from '../engine'
-import {NotifyPopup} from '../native/notifications'
+import dialog from '../native/dialog'
 
 // This requires things across actions, so to avoid a circular dependency we'll pull this out
 // into it's own file
@@ -20,7 +20,7 @@ export function startup () {
           .catch(error => {
             console.error('Error starting up:', error)
             dispatch({type: ConfigConstants.startupLoaded, payload: error, error: true})
-            NotifyPopup('Startup Failed', {body: 'Run `keybase log send` to tell us why!'})
+            dialog.showErrorBox('Startup Failed', `Run \`keybase log send\` to tell us why!\nError Message: ${error}`)
           })
       )
     })

--- a/shared/native/dialog.desktop.js
+++ b/shared/native/dialog.desktop.js
@@ -1,0 +1,6 @@
+// @flow
+import {remote} from 'electron'
+
+const {dialog} = remote
+
+export default dialog

--- a/shared/native/dialog.js.flow
+++ b/shared/native/dialog.js.flow
@@ -1,0 +1,7 @@
+// @ flow
+
+declare var exports: {
+  default:  {
+    showErrorBox: (title: string, body: string) => void
+  }
+}

--- a/shared/native/dialog.native.js
+++ b/shared/native/dialog.native.js
@@ -1,0 +1,7 @@
+// @flow
+
+const dialog = {
+  showErrorBox: (title: string, body: string) => {}
+}
+
+export default dialog


### PR DESCRIPTION
@keybase/react-hackers 

This changes the notification to be a dialog box.

Preview:
<img width="532" alt="screen shot 2016-02-18 at 5 13 27 pm" src="https://cloud.githubusercontent.com/assets/594035/13163737/4bfde9fa-d664-11e5-853c-5ea84ec4052b.png">

The benefits of this is that:
 * It's isn't easy to ignore.
 * More room for the error message.

The cons are:
 * Poor ux - What does "Ok" do? does it send the log, or does it do nothing?
 * Sometimes we can recover from a startup error (e.g. we reconnect to the internet), so this isn't as dire as it seems

If we want to have this dialog box we should invest a bit more time in making better options for the user in the dialog box

Thoughts on this before investing any more time on it?