### PR TITLE
Remove notification that startup failed and send log

### DIFF
--- a/shared/actions/startup.js
+++ b/shared/actions/startup.js
@@ -20,7 +20,6 @@ export function startup () {
           .catch(error => {
             console.error('Error starting up:', error)
             dispatch({type: ConfigConstants.startupLoaded, payload: error, error: true})
-            NotifyPopup('Startup Failed', {body: 'Run `keybase log send` to tell us why!'})
           })
       )
     })


### PR DESCRIPTION
@keybase/react-hackers 

This was firing quite often, so let's remove this.