### PR TITLE
push kbfs-beta as part of the nightly build

### DIFF
--- a/packaging/export/export_kbfs.sh
+++ b/packaging/export/export_kbfs.sh
@@ -46,5 +46,8 @@ rm $src_dir/$name.tar
 cd $dest_dir
 echo "Committing"
 git add .
-git commit -m "Updating repo" --allow-empty
-git push
+if git commit -m "Updating repo" ; then
+  git push
+else
+  echo "Nothing to commit in kbfs-beta, skipping push."
+fi

--- a/packaging/export/export_kbfs.sh
+++ b/packaging/export/export_kbfs.sh
@@ -46,5 +46,5 @@ rm $src_dir/$name.tar
 cd $dest_dir
 echo "Committing"
 git add .
-git commit -m "Updating repo"
+git commit -m "Updating repo" --allow-empty
 git push


### PR DESCRIPTION
This helps the kbfs-git Arch package have roughly the same bits as the
Debian and RPM nightlies.

@gabriel this contains a tweak to `export_kbfs.sh`. Could you take a look?