### PR TITLE
Identify sender even if self if there's a user assertion, add tests for SignedBy option

### DIFF
--- a/go/engine/saltpack_sender_identify.go
+++ b/go/engine/saltpack_sender_identify.go
@@ -86,9 +86,11 @@ func (e *SaltpackSenderIdentify) identifySender(ctx *Context) (err error) {
 	var lin bool
 	var uid keybase1.UID
 	if lin, uid, err = IsLoggedIn(e, ctx); err == nil && lin && uid.Equal(e.res.Uid) {
-		e.G().Log.Debug("| Sender is self")
-		e.res.SenderType = keybase1.SaltpackSenderType_SELF
-		return nil
+		if len(e.arg.userAssertion) == 0 {
+			e.G().Log.Debug("| Sender is self")
+			e.res.SenderType = keybase1.SaltpackSenderType_SELF
+			return nil
+		}
 	}
 
 	iarg := keybase1.Identify2Arg{

--- a/go/engine/saltpack_sender_identify.go
+++ b/go/engine/saltpack_sender_identify.go
@@ -86,9 +86,9 @@ func (e *SaltpackSenderIdentify) identifySender(ctx *Context) (err error) {
 	var lin bool
 	var uid keybase1.UID
 	if lin, uid, err = IsLoggedIn(e, ctx); err == nil && lin && uid.Equal(e.res.Uid) {
+		e.res.SenderType = keybase1.SaltpackSenderType_SELF
 		if len(e.arg.userAssertion) == 0 {
 			e.G().Log.Debug("| Sender is self")
-			e.res.SenderType = keybase1.SaltpackSenderType_SELF
 			return nil
 		}
 	}
@@ -106,6 +106,12 @@ func (e *SaltpackSenderIdentify) identifySender(ctx *Context) (err error) {
 	if err = RunEngine(eng, ctx); err != nil {
 		return err
 	}
+
+	if e.res.SenderType == keybase1.SaltpackSenderType_SELF {
+		// if we already know the sender type, then return now
+		return nil
+	}
+
 	switch eng.getTrackType() {
 	case identify2NoTrack:
 		e.res.SenderType = keybase1.SaltpackSenderType_NOT_TRACKED


### PR DESCRIPTION
There is a short-circuit for the identify call if the sender is self.  This makes sure that there isn't a user assertion before short-circuiting.  Fixes CORE-2451.

Also added tests for SignedBy option for self verify and non-self.

@maxtaco 