### PR TITLE
Add DZ2 Dropdown

### DIFF
--- a/shared/common-adapters/dropdown/index.desktop.js
+++ b/shared/common-adapters/dropdown/index.desktop.js
@@ -1,0 +1,203 @@
+// @flow
+import React, {Component} from 'react'
+
+import Icon from '../icon'
+import Text from '../text'
+
+import {transition, globalColorsDZ2, globalStyles} from '../../styles/style-guide'
+import {intersperse} from '../../util/arrays'
+
+import type {Props, MenuItemProps} from './index'
+import type {Props as TextProps} from '../text'
+
+import Popover from 'material-ui/lib/popover/popover'
+import PopoverAnimationFromTop from 'material-ui/lib/popover/popover-animation-from-top'
+import DropDownArrow from 'material-ui/lib/svg-icons/navigation/arrow-drop-down'
+
+export default class Dropdown extends Component {
+  props: Props;
+
+  state: {
+    popoverOpen: boolean
+  };
+
+  _dropdownRef: any;
+
+  constructor (props: Props) {
+    super(props)
+    this.state = {
+      popoverOpen: false
+    }
+  }
+
+  _clickItemFromList (index: ?number) {
+    // Use != null because 0 is false
+    if (index != null) {
+      this.props.onClick(this.props.options[index], index)
+    }
+
+    this.setState({popoverOpen: false})
+  }
+
+  render () {
+    const realCSS = `
+      .kbdropdown { color: ${globalColorsDZ2.black10}; }
+      .kbdropdown:hover { color: ${globalColorsDZ2.blue}; }
+
+      .kbdropdown svg { fill: ${globalColorsDZ2.black10} !important; }
+      .kbdropdown:hover svg { fill: ${globalColorsDZ2.blue} !important; }
+
+      .popover .kbmenuitem:hover { background-color: ${globalColorsDZ2.blue4}; }
+      .popover .kbmenuitem+.kbmenuitem { border-top: 1px solid ${globalColorsDZ2.black10}; }
+    `
+
+    let list: ReactElement
+    let selectedValue: ReactElement
+
+    const onOther = this.props.onOther && (() => {this.setState({popoverOpen: false}); this.props.onOther()})
+
+    switch (this.props.type) {
+      case 'Username':
+        list = <UsernameList options={this.props.options} onClick={i => this._clickItemFromList(i)} onOther={onOther}/>
+        selectedValue = <MenuItem type='Username' style={{height: 'initial'}} textStyle={{...styles.labelStyle}}>{this.props.value || this.props.options[0]}</MenuItem>
+        break;
+      case 'General':
+        list = <GeneralList options={this.props.options} onClick={i => this._clickItemFromList(i)} onOther={onOther}/>
+        selectedValue = <MenuItem type='Pick' style={{height: 'initial'}} textStyle={{...styles.labelStyle}}>{this.props.value || 'Pick an option'}</MenuItem>
+        break;
+    }
+
+    return (
+      <div>
+        <style>{realCSS}</style>
+        <div
+          ref={r => (this._dropdownRef = r)}
+          style={{...styles.dropdown, ...this.props.style}}
+          onClick={() => this.setState({popoverOpen: true})}
+          className={'kbdropdown'}>
+          <Popover
+            className={'popover'}
+            anchorOrigin={{horizontal: 'middle', vertical: 'top'}}
+            targetOrigin={{horizontal: 'middle', vertical: 'top'}}
+            anchorEl={this._dropdownRef}
+            style={styles.menuStyle}
+            animation={PopoverAnimationFromTop}
+            open={this.state.popoverOpen}
+            onRequestClose={() => this.setState({popoverOpen: false})}>
+            {list}
+          </Popover>
+          {selectedValue}
+          <DropDownArrow style={styles.iconStyle}/>
+        </div>
+      </div>
+    )
+  }
+}
+
+class MenuItem extends Component<void, MenuItemProps, void> {
+  props: MenuItemProps;
+
+  render () {
+    let textStyle : Object = {}
+    let textType: TextProps.type = 'HeaderBig'
+
+    switch (this.props.type || 'Normal') {
+      case 'Normal':
+        break
+      case 'Username':
+        textStyle = {color: globalColorsDZ2.orange}
+        break
+      case 'Other':
+      case 'Pick':
+        textType = 'Header'
+        textStyle = globalStyles.DZ2.fontSemibold
+        break
+    }
+
+    return (
+      <div className="kbmenuitem" style={{...styles.menuItem, ...this.props.style}} onClick={this.props.onClick}>
+        <Text dz2 style={{...textStyle, ...this.props.textStyle}} type={textType}>{this.props.children}</Text>
+      </div>
+    )
+  }
+}
+
+type OptionsListProps = {
+  options: Array<string>,
+  onClick: (i: ?number) => void,
+  onOther?: () => void,
+  username?: true
+}
+
+const optionsList = ({options, onClick, username}: OptionsListProps) => {
+  return options.map((o, i) => <MenuItem onClick={() => onClick(i)} key={o} type={username ? 'Username' : 'Normal'}>{o}</MenuItem>)
+}
+
+const UsernameList = ({options, onClick, onOther}: OptionsListProps) => {
+  return (
+    <div style={styles.popover}>
+      {optionsList({onClick, options, username: true})}
+      {onOther && <MenuItem onClick={onOther} type='Other'>someone else...</MenuItem>}
+    </div>
+  )
+}
+
+const GeneralList = ({options, onClick, onOther}: OptionsListProps) => {
+  return (
+    <div style={styles.popover}>
+      <MenuItem onClick={() => onClick()} type='Pick'>Pick an option</MenuItem>
+      {optionsList({onClick, options})}
+      {onOther && <MenuItem onClick={onOther} type='Other'>Or something else</MenuItem>}
+    </div>
+  )
+}
+
+const styles = {
+  dropdown: {
+    ...globalStyles.flexBoxRow,
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderRadius: 100,
+    position: 'relative',
+    height: 36,
+    ...transition('color')
+  },
+
+  labelStyle: {
+    lineHeight: '36px',
+    paddingLeft: 15,
+    paddingRight: 30,
+    minWidth: 268,
+    textAlign: 'center',
+    alignItems: 'initial'
+  },
+
+  iconStyle: {
+    position: 'absolute',
+    top: 5,
+    right: 8,
+  },
+
+  menuStyle: {
+    ...globalStyles.rounded,
+    borderColor: globalColorsDZ2.blue,
+    transformOrigin: 'center top',
+    borderStyle: 'solid',
+    borderWidth: 1,
+  },
+
+  popover: {
+    ...globalStyles.flexBoxColumn,
+    width: 290
+  },
+
+  menuItem: {
+    ...globalStyles.clickable,
+    height: 50,
+    textAlign: 'center',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+}

--- a/shared/common-adapters/dropdown/index.js.flow
+++ b/shared/common-adapters/dropdown/index.js.flow
@@ -1,0 +1,29 @@
+/* @flow */
+
+import React, {Component} from 'react'
+
+export type Props = {
+  type: 'Username' | 'General',
+  options: Array<string>,
+  onClick: (option: string, index: number) => void,
+  onOther: () => void,
+  value?: string,
+  style?: Object
+}
+
+declare export default class Dropdown extends Component {
+  props: Props;
+}
+
+export type MenuItemProps = {
+  value?: any, // The value of the menu item.
+  type?: 'Normal' | 'Username' | 'Other' | 'Pick',
+  onClick: () => void,
+  style?: Object,
+  textStyle?: Object,
+  children?: any
+}
+
+export class MenuItem extends Component {
+  props: MenuItemProps;
+}

--- a/shared/common-adapters/dropdown/index.native.js
+++ b/shared/common-adapters/dropdown/index.native.js
@@ -1,0 +1,9 @@
+// @flow
+import React, {Component} from 'react'
+import {View} from 'react-native'
+
+export default class Dropdown extends Component {
+  render () {
+    return <View />
+  }
+}

--- a/shared/more/components/dropdown.desktop.js
+++ b/shared/more/components/dropdown.desktop.js
@@ -1,0 +1,35 @@
+// @flow
+import React, {Component} from 'react'
+
+import Dropdown, {MenuItem} from '../../common-adapters/dropdown'
+import {Text} from '../../common-adapters'
+
+export default class DropdownDemo extends Component {
+  state: any;
+
+  constructor (props: {}) {
+    super(props)
+    this.state = {selectedUser: 'marcopolo', selectedOption: null}
+  }
+
+  render () {
+    return (
+      <div style={{display: 'flex', justifyContent: 'space-around'}}>
+        <Dropdown type={'Username'}
+          value={this.state.selectedUser}
+          options={['marcopolo', 'chris', 'cjb', 'bbbbbbbbbbbbbbbb']}
+          onOther={() => console.log('Clicked on other')}
+          onClick={selectedUser => this.setState({selectedUser})}/>
+        <Dropdown type={'General'}
+          options={['one', 'two', 'three']}
+          value={this.state.selectedOption}
+          onOther={() => console.log('Clicked on other')}
+          onClick={selectedOption => this.setState({selectedOption})}/>
+        <Dropdown type={'General'}
+          options={['one', 'two', 'three']}
+          value={this.state.selectedOption}
+          onClick={selectedOption => this.setState({selectedOption})}/>
+      </div>
+    )
+  }
+}

--- a/shared/more/style-sheet.render.desktop.js
+++ b/shared/more/style-sheet.render.desktop.js
@@ -3,10 +3,15 @@ import {globalStyles, globalColors, globalColorsDZ2} from '../styles/style-guide
 import Container from './dev-container'
 import {Button, Input, Text, Terminal, FormWithCheckbox} from '../common-adapters'
 
+import DropdownDemo from './components/dropdown'
+
 export default class Render extends Component {
   render () {
     return (
       <div style={{...globalStyles.flexBoxColumn, margin: 20}}>
+        <Container title='Dropdown - DZ2'>
+          <DropdownDemo/>
+        </Container>
         <Container title='Text - DZ2'>
           <DZ2Font/>
         </Container>


### PR DESCRIPTION
## Preview: 

<img width="1052" alt="screen shot 2016-02-23 at 11 16 10 am" src="https://cloud.githubusercontent.com/assets/594035/13263561/e1e486dc-da1e-11e5-901c-92eb99d449d5.png">

## Api

The api is a bit different than the material ui's one. Namely you pass in an array of strings that are the options. and you can specify which one should be selected in the `value` field.

There are 2 types of drop downs, `Username` and `General`, they each have their own slightly different styles.

You pass in an onClick which will get called when one of the options is chosen. It calls the function with the string value and index of the option.

You pass in an onOther which is called when the other option is picked ("someone else" for usernames and "Or something else" for general)

If you don't pass in an onOther, the other option won't show up.

------

This was hacked together quickly so it's probably missing something we'll want later in the future, but I vote that we pay that cost when we need it. This should be what we need for now, let me know if I'm wrong.

@keybase/react-hackers 


TODO:

- [x] Open the animation from the top down instead of the middle. This seems like a bug in the material-ui popover component.