### PR TITLE
Fix provision via passphrase when logged in as another user

### DIFF
--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -310,6 +310,9 @@ func (e *LoginProvision) paper(ctx *Context) error {
 // synced pgp key.  Any other situations require different
 // provisioning methods.
 func (e *LoginProvision) passphrase(ctx *Context) error {
+	// clear out any existing session:
+	e.G().Logout()
+
 	// prompt for the email or username
 	emailOrUsername, err := e.promptEmailOrUsername(ctx)
 	if err != nil {


### PR DESCRIPTION
Fixes CORE-2605 (and https://github.com/keybase/client/issues/2104)

The test reproduces the error in #2104

@maxtaco 