### PR TITLE
Unlock the stream cache on login instead of requiring a separate command

### DIFF
--- a/go/client/cmd_status.go
+++ b/go/client/cmd_status.go
@@ -53,6 +53,7 @@ type fstatus struct {
 	Device                 *keybase1.Device
 	LoggedInProvisioned    bool `json:"LoggedIn"`
 	PassphraseStreamCached bool `json:"KeychainUnlocked"`
+	SessionIsValid         bool `json:"SessionIsValid"`
 	SessionStatus          string
 	ConfigPath             string
 
@@ -117,6 +118,7 @@ func (c *CmdStatus) load() (*fstatus, error) {
 	}
 
 	status.LoggedInProvisioned = curStatus.LoggedIn
+	status.SessionIsValid = curStatus.SessionIsValid
 	if curStatus.User != nil {
 		status.Username = curStatus.User.Username
 		status.UserID = curStatus.User.Uid.String()
@@ -207,6 +209,7 @@ func (c *CmdStatus) outputTerminal(status *fstatus) error {
 		dui.Printf("    status:    %s\n\n", libkb.DeviceStatusToString(&status.Device.Status))
 	}
 	dui.Printf("Keybase keys:  %s\n", BoolString(status.PassphraseStreamCached, "unlocked", "locked"))
+	dui.Printf("    Session Is Valid: %s\n", BoolString(status.SessionIsValid, "yes", "no"))
 	dui.Printf("Session:       %s\n", status.SessionStatus)
 	dui.Printf("\nKBFS:\n")
 	dui.Printf("    status:    %s\n", BoolString(status.KBFS.Running, "running", "not running"))

--- a/go/client/commands_common.go
+++ b/go/client/commands_common.go
@@ -45,7 +45,6 @@ func GetCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Comma
 		NewCmdSignup(cl, g),
 		NewCmdStatus(cl, g),
 		NewCmdTrack(cl, g),
-		NewCmdUnlock(cl),
 		NewCmdUntrack(cl, g),
 		NewCmdUpdate(cl, g),
 		NewCmdVerify(cl, g),

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -23,6 +23,7 @@ func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext
 		NewCmdStress(cl),
 		NewCmdTestPassphrase(cl, g),
 		NewCmdTestFSNotify(cl, g),
+		NewCmdUnlock(cl),
 	}
 }
 

--- a/go/engine/login_current_device.go
+++ b/go/engine/login_current_device.go
@@ -45,12 +45,8 @@ func (e *LoginCurrentDevice) SubConsumers() []libkb.UIConsumer {
 	return nil
 }
 
-// Run starts the engine.
-func (e *LoginCurrentDevice) Run(ctx *Context) error {
-	e.G().Log.Debug("+- LoginCurrentDevice.Run")
-	defer func() {
-		e.G().Log.Debug("- LoginCurrentDevice.Run")
-	}()
+func (e *LoginCurrentDevice) doLogin(ctx *Context) error {
+
 	// already logged in?
 	in, err := e.G().LoginState().LoggedInProvisionedLoad()
 	if err == nil && in {
@@ -111,4 +107,21 @@ func (e *LoginCurrentDevice) Run(ctx *Context) error {
 		return nil
 	}
 	return e.G().LoginState().LoginWithPrompt(e.username, ctx.LoginUI, ctx.SecretUI, afterLogin)
+}
+
+// Run starts the engine.
+func (e *LoginCurrentDevice) Run(ctx *Context) error {
+	e.G().Log.Debug("+- LoginCurrentDevice.Run")
+	defer func() {
+		e.G().Log.Debug("- LoginCurrentDevice.Run")
+	}()
+
+	ret := e.doLogin(ctx)
+
+	// Unlock the passphrase stream here so the user won't have to
+	// separately
+	if ret == nil {
+		_, ret = e.G().LoginState().GetPassphraseStream(ctx.SecretUI)
+	}
+	return ret
 }

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -988,6 +988,33 @@ func TestProvisionPassphraseNoKeysMultipleAccounts(t *testing.T) {
 	}
 }
 
+// We have obviated the unlock command by combining it with login.
+func TestLoginStreamCache(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	u1 := CreateAndSignupFakeUser(tc, "login")
+
+	if !assertStreamCache(tc, true) {
+		t.Fatal("expected valid stream cache after signup")
+	}
+
+	tc.G.LoginState().Account(func(a *libkb.Account) {
+		a.ClearStreamCache()
+	}, "clear stream cache")
+
+	if !assertStreamCache(tc, false) {
+		t.Fatal("expected invalid stream cache after clear")
+	}
+
+	// This should now unlock the stream cache too
+	u1.LoginOrBust(tc)
+
+	if !assertStreamCache(tc, true) {
+		t.Fatal("expected valid stream cache after login")
+	}
+}
+
 type testProvisionUI struct {
 	secretCh               chan kex2.Secret
 	method                 keybase1.ProvisionMethod

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -446,6 +446,7 @@ func (c CurrentStatus) Export() (ret keybase1.GetCurrentStatusRes) {
 	ret.Configured = c.Configured
 	ret.Registered = c.Registered
 	ret.LoggedIn = c.LoggedIn
+	ret.SessionIsValid = c.SessionIsValid
 	if c.User != nil {
 		ret.User = c.User.Export()
 	}

--- a/go/libkb/status.go
+++ b/go/libkb/status.go
@@ -13,10 +13,11 @@ type UserInfo struct {
 }
 
 type CurrentStatus struct {
-	Configured bool
-	Registered bool
-	LoggedIn   bool
-	User       *User
+	Configured     bool
+	Registered     bool
+	LoggedIn       bool
+	SessionIsValid bool
+	User           *User
 }
 
 func GetCurrentStatus(g *GlobalContext) (res CurrentStatus, err error) {
@@ -29,6 +30,11 @@ func GetCurrentStatus(g *GlobalContext) (res CurrentStatus, err error) {
 		res.Registered = true
 		res.User = NewUserThin(cr.GetUsername().String(), uid)
 	}
-	res.LoggedIn, err = g.LoginState().LoggedInProvisionedLoad()
+	res.SessionIsValid, err = g.LoginState().LoggedInProvisionedLoad()
+	if err == nil {
+		if pps, err := g.LoginState().PassphraseStream(); err == nil {
+			res.LoggedIn = res.SessionIsValid && (pps != nil)
+		}
+	}
 	return
 }

--- a/go/protocol/keybase_v1.go
+++ b/go/protocol/keybase_v1.go
@@ -510,10 +510,11 @@ func (c BTCClient) RegisterBTC(ctx context.Context, __arg RegisterBTCArg) (err e
 }
 
 type GetCurrentStatusRes struct {
-	Configured bool  `codec:"configured" json:"configured"`
-	Registered bool  `codec:"registered" json:"registered"`
-	LoggedIn   bool  `codec:"loggedIn" json:"loggedIn"`
-	User       *User `codec:"user,omitempty" json:"user,omitempty"`
+	Configured     bool  `codec:"configured" json:"configured"`
+	Registered     bool  `codec:"registered" json:"registered"`
+	LoggedIn       bool  `codec:"loggedIn" json:"loggedIn"`
+	SessionIsValid bool  `codec:"sessionIsValid" json:"sessionIsValid"`
+	User           *User `codec:"user,omitempty" json:"user,omitempty"`
 }
 
 type SessionStatus struct {

--- a/protocol/avdl/config.avdl
+++ b/protocol/avdl/config.avdl
@@ -8,6 +8,7 @@ protocol config {
     boolean configured;
     boolean registered;
     boolean loggedIn;
+    boolean sessionIsValid;
     union { null, User } user;
   }
 

--- a/protocol/json/config.json
+++ b/protocol/json/config.json
@@ -326,6 +326,10 @@
           "name": "loggedIn"
         },
         {
+          "type": "boolean",
+          "name": "loggedInSession"
+        },
+        {
           "type": [
             "null",
             "User"


### PR DESCRIPTION
Make Unlock a devel command.
Don't show logged in when unlocked in status command.
(may have more work getting the Electron UI to match)
@maxtaco @patrickxb 