### PR TITLE
:wrench: Call the old class methods when using the old input component

### DIFF
--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -29,10 +29,17 @@ export default class Input extends Component {
   }
 
   getValue (): ?string {
+    if (!this.props.dz2) {
+      return this.refs.inputOld && this.refs.inputOld.getValue()
+    }
     return this.state.value
   }
 
   clearValue () {
+    if (!this.props.dz2) {
+      this.refs.inputOld && this.refs.inputOld.clearValue()
+      return
+    }
     this.setState({value: null})
   }
 
@@ -41,12 +48,16 @@ export default class Input extends Component {
   }
 
   blur () {
+    if (!this.props.dz2) {
+      return this.refs.inputOld && this.refs.inputOld.blur()
+    }
+
     this._textField && this._textField.blur()
   }
 
   render () {
     if (!this.props.dz2) {
-      return <InputOld {...this.props}/>
+      return <InputOld ref="inputOld" {...this.props}/>
     }
 
     const style = this.props.small ? styles.containerSmall : styles.container


### PR DESCRIPTION
@keybase/react-hackers 

The menubar text input was broken before this, this fixes it.

The problem is the `ref` references the new component and isn't forwarded to the old Input component. 