### PR TITLE
Dont log env

### DIFF
--- a/desktop/npm-helper.js
+++ b/desktop/npm-helper.js
@@ -224,11 +224,9 @@ if (!info) {
 info = inject(info)
 
 if (info.shell) {
-  console.log(`Calling: ${JSON.stringify(info, null, 2)}`)
   exec(info.shell, info.env)
 }
 
 if (info.code) {
   info.code()
 }
-


### PR DESCRIPTION
@keybase/react-hackers 

Not a good idea to log env since it can contain secrets.... Not a huge deal, just to be safe.

If you need to print out env you should print specific env values instead of the whole env.