### PR TITLE
Ported tracker bio avatar to use avatar helper and cleaned up css

### DIFF
--- a/shared/styles/style-guide.desktop.js
+++ b/shared/styles/style-guide.desktop.js
@@ -44,6 +44,7 @@ export const globalColorsDZ2 = {
 
   lightGrey: '#ebebeb',
   lightGrey2: '#f6f6f6',
+  lightGrey3: '#e0e0e0',
 
   white: '#ffffff',
   white75: 'rgba(255, 255, 255, 0.75)',

--- a/shared/tracker/bio.render.desktop.js
+++ b/shared/tracker/bio.render.desktop.js
@@ -2,7 +2,7 @@
 
 import React, {Component} from 'react'
 import {Paper} from 'material-ui'
-import {Text} from '../common-adapters'
+import {Text, Avatar} from '../common-adapters'
 import commonStyles, {colors} from '../styles/common'
 import {globalStyles, globalColorsDZ2} from '../styles/style-guide'
 import resolveRoot from '../../desktop/resolve-root'
@@ -12,8 +12,6 @@ import flags from '../util/feature-flags'
 const shell = electron.shell || electron.remote.shell
 
 import type {BioProps} from './bio.render'
-
-const noAvatar = `file:///${resolveRoot('shared/images/no-avatar@2x.png')}`
 
 export default class BioRender extends Component {
   props: BioProps;
@@ -39,6 +37,7 @@ export default class BioRender extends Component {
 
   renderDefault (styles: Object) {
     const {userInfo} = this.props
+    const noAvatar = `file:///${resolveRoot('shared/images/no-avatar@2x.png')}`
 
     return (
       <div style={styles.container}>
@@ -76,13 +75,11 @@ export default class BioRender extends Component {
       <div style={styles.outer}>
         <div style={styles.container}>
           <div style={styles.avatarOuter}>
-            <Paper onClick={() => this.onClickAvatar()} style={styles.avatarContainer} zDepth={1} circle>
-              <img src={(userInfo.avatar) || noAvatar} style={styles.avatar}/>
-            </Paper>
+            <Avatar onClick={() => this.onClickAvatar()} url={userInfo.avatar} size={75} />
             {(followsYou || currentlyFollowing) &&
               <div>
-                <div style={followsYou ? {...followBadgeStyles.followBadge, ...followBadgeStyles.followsYou} : {...followBadgeStyles.followBadge, ...followBadgeStyles.notFollowsYou}} />
-                <div style={currentlyFollowing ? {...followBadgeStyles.followBadge, ...followBadgeStyles.following} : {...followBadgeStyles.followBadge, ...followBadgeStyles.notFollowing}} />
+                <div style={followsYou ? followBadgeStyles.followsYou : followBadgeStyles.notFollowsYou} />
+                <div style={currentlyFollowing ? followBadgeStyles.following : followBadgeStyles.notFollowing} />
               </div>
             }
           </div>
@@ -195,17 +192,10 @@ const styles2 = {
     marginTop: -35
   },
   avatarOuter: {
-    width: 70,
-    height: 70,
+    width: 75,
+    height: 75,
     position: 'relative',
     zIndex: 2
-  },
-  avatarContainer: {
-    width: 70,
-    height: 70,
-    minHeight: 70,
-    overflow: 'hidden',
-    boxSizing: 'content-box'
   },
   avatar: {
     ...globalStyles.clickable,
@@ -255,34 +245,42 @@ const styles2 = {
   }
 }
 
+const followBadgeCommon = {
+  position: 'absolute',
+  background: globalColorsDZ2.white,
+  width: 14,
+  height: 14,
+  borderRadius: '50%',
+  border: `2px solid ${globalColorsDZ2.white}`
+}
+
+const followTop = {
+  ...followBadgeCommon,
+  bottom: 5,
+  right: 2
+}
+
+const followBottom = {
+  ...followBadgeCommon,
+  bottom: 0,
+  right: 8
+}
+
 const followBadgeStyles = {
-  followBadge: {
-    position: 'absolute',
-    background: '#fff',
-    width: 14,
-    height: 14,
-    borderRadius: '50%',
-    border: '2px solid #fff',
-    boxShadow: '0px 3px 3px rgba(0,0,0,0.1)'
-  },
   followsYou: {
-    top: 52,
-    left: 55,
+    ...followTop,
     background: globalColorsDZ2.green2
   },
   notFollowsYou: {
-    top: 52,
-    left: 55,
-    background: '#ccc'
+    ...followTop,
+    background: globalColorsDZ2.lightGrey3
   },
   following: {
-    top: 57,
-    left: 48,
+    ...followBottom,
     background: globalColorsDZ2.green2
   },
   notFollowing: {
-    top: 57,
-    left: 48,
-    background: '#ccc'
+    ...followBottom,
+    background: globalColorsDZ2.lightGrey3
   }
 }


### PR DESCRIPTION
@keybase/react-hackers This uses the shared avatar component for the avatar in the tracker
@gabriel i changed the css a little bit, we should discuss. In general we should design our css so that when we are resizing various elements the logical layout will still 'hold'. For example the grey/green follow/following circles on the avatar were using position absolute with a top/left. But really they're bottom /right aligned so it's better to define them that way. Then if we make the avatar larger they'll still 'work' instead of being in the middle of the avatar.  I also moved the merging of some props out of the component and into the css. I think this is a little cleaner of a pattern.