### PR TITLE
Fix tracker2 popup styling and dragging.

### DIFF
--- a/desktop/renderer/remote-manager.js
+++ b/desktop/renderer/remote-manager.js
@@ -78,7 +78,7 @@ class RemoteManager extends Component {
   trackerRemoteComponents () {
     const {trackers} = this.props
     const windowsOpts = flags.tracker2
-      ? {height: 539, width: 320}
+      ? {height: 470, width: 320}
       : {height: 339, width: 520}
     return Object.keys(trackers).filter(username => !trackers[username].closed).map(username => (
       <RemoteComponent

--- a/shared/styles/style-guide.desktop.js
+++ b/shared/styles/style-guide.desktop.js
@@ -47,6 +47,7 @@ export const globalColorsDZ2 = {
   lightGrey3: '#e0e0e0',
 
   white: '#ffffff',
+  white90: 'rgba(255, 255, 255, 0.90)',
   white75: 'rgba(255, 255, 255, 0.75)',
   white40: 'rgba(255, 255, 255, 0.40)',
 

--- a/shared/tracker/action.render.desktop.js
+++ b/shared/tracker/action.render.desktop.js
@@ -4,7 +4,7 @@ import React, {Component} from 'react'
 import {FlatButton} from 'material-ui'
 import {Button} from '../common-adapters'
 import commonStyles from '../styles/common'
-import {globalColors} from '../styles/style-guide'
+import {globalColors, globalColorsDZ2} from '../styles/style-guide'
 import {normal, checking, warning} from '../constants/tracker'
 import flags from '../util/feature-flags'
 import {Text} from '../common-adapters'
@@ -221,8 +221,7 @@ const styles2 = {
   container: {
     ...commonStyles.flexBoxRow,
     ...commonStyles.noSelect,
-    backgroundColor: globalColors.white,
-    opacity: 0.9,
+    backgroundColor: globalColorsDZ2.white90,
     width: '100%',
     height: 61,
     boxShadow: '0px 0px 3px rgba(0, 0, 0, 0.15)',

--- a/shared/tracker/header.render.desktop.js
+++ b/shared/tracker/header.render.desktop.js
@@ -99,6 +99,8 @@ const styles2 = {
     position: 'relative'
   },
   header: {
+    ...globalStyles.windowDragging,
+    cursor: 'default',
     position: 'absolute',
     top: 0,
     ...globalStyles.flexBoxRow,
@@ -130,6 +132,8 @@ const styles2 = {
     backgroundColor: globalColorsDZ2.red
   },
   close: {
+    ...globalStyles.clickable,
+    zIndex: 2,
     position: 'absolute',
     top: 7,
     right: 4

--- a/shared/tracker/proofs.render.desktop.js
+++ b/shared/tracker/proofs.render.desktop.js
@@ -127,7 +127,8 @@ export class ProofsRender2 extends Component {
 
 const styles2 = {
   container: {
-    ...globalStyles.flexBoxColumn
+    ...globalStyles.flexBoxColumn,
+    backgroundColor: globalColorsDZ2.white
   },
   row: {
     ...globalStyles.flexBoxRow,
@@ -136,8 +137,6 @@ const styles2 = {
     paddingRight: 30,
     alignItems: 'flex-start',
     justifyContent: 'flex-start',
-    backgroundColor: globalColorsDZ2.orange.white,
-    zIndex: 1
   },
   service: {
     height: 14,

--- a/shared/tracker/render.desktop.js
+++ b/shared/tracker/render.desktop.js
@@ -84,7 +84,8 @@ const styles2 = {
   content: {
     overflowY: 'auto',
     overflowX: 'hidden',
-    paddingBottom: 120
+    paddingBottom: 120,
+    zIndex: 1
   },
   footer: {
     position: 'absolute',


### PR DESCRIPTION
@keybase/react-hackers 

part of DESKTOP-556, this lets you drag windows around and fixes the scroll background jank.

A future PR will include:
- [ ] s/follow/track
- [ ] make clickable proofs
- [ ] change unfollow to ignore for 24 hrs
- [ ] Check loading states
- [ ] Check unreachable new tags
- [ ] check logged out state

lmk if there I should add for dz2 tracker end to end.  