### PR TITLE
DZ2: Pinentry

### DIFF
--- a/desktop/renderer/remote-manager.js
+++ b/desktop/renderer/remote-manager.js
@@ -104,10 +104,13 @@ class RemoteManager extends Component {
       const sid = parseInt(pSessionID, 10)
       const onCancel = () => this.props.pinentryOnCancel(sid)
       const onSubmit = this.props.pinentryOnSubmit.bind(null, sid)
+      const windowsOpts = flags.dz2
+        ? {width: 500, height: 260}
+        : {width: 513, height: 260}
       return (
         <RemoteComponent
           title='Pinentry'
-          windowsOpts={{width: 500, height: 260}}
+          windowsOpts={windowsOpts}
           waitForState
           onRemoteClose={onCancel}
           component='pinentry'

--- a/desktop/renderer/remote-manager.js
+++ b/desktop/renderer/remote-manager.js
@@ -107,7 +107,7 @@ class RemoteManager extends Component {
       return (
         <RemoteComponent
           title='Pinentry'
-          windowsOpts={{width: 513, height: 260}}
+          windowsOpts={{width: 500, height: 260}}
           waitForState
           onRemoteClose={onCancel}
           component='pinentry'

--- a/go/libkb/passphrase_helper.go
+++ b/go/libkb/passphrase_helper.go
@@ -40,6 +40,8 @@ func GetPaperKeyPassphrase(ui SecretUI, username string) (string, error) {
 	arg.Prompt = fmt.Sprintf("Please enter a paper backup key passphrase for %s", username)
 	arg.Features.StoreSecret.Allow = false
 	arg.Features.StoreSecret.Readonly = true
+	arg.Features.ShowTyping.Allow = true
+	arg.Features.ShowTyping.DefaultValue = true
 	res, err := GetPassphraseUntilCheck(arg, newUIPrompter(ui), &CheckPassphraseSimple)
 	if err != nil {
 		return "", err

--- a/shared/common-adapters/form-with-checkbox.desktop.js
+++ b/shared/common-adapters/form-with-checkbox.desktop.js
@@ -15,7 +15,7 @@ export default class FormWithCheckbox extends Component {
 
     return (
       <div style={{...globalStyles.flexBoxColumn, marginBottom: 15, ...this.props.style}}>
-        <Input style={{marginBottom: 0}} errorStyle={{marginTop: 24, textAlign: 'center'}} {...inputProps}/>
+        <Input errorStyle={{marginTop: 24}} {...inputProps}/>
         <div style={{...styles.checkboxContainer, ...this.props.checkboxContainerStyle}}>
           {checkboxesProps.map(p => {
             const checkProps: CheckboxProps = {dz2: true, key: p.label, ...p}

--- a/shared/common-adapters/header.desktop.js
+++ b/shared/common-adapters/header.desktop.js
@@ -55,7 +55,7 @@ const styles = {
     color: globalColors.grey4,
     fontSize: 16,
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'flex-end',
     width: 30,
     height: 30
   }

--- a/shared/common-adapters/header.desktop.js
+++ b/shared/common-adapters/header.desktop.js
@@ -54,9 +54,9 @@ const styles = {
     ...globalStyles.windowDraggingClickable,
     color: globalColors.grey4,
     fontSize: 16,
-    alignItems: 'center',
+    alignItems: 'flex-start',
     justifyContent: 'flex-end',
     width: 30,
-    height: 30
+    height: 24
   }
 }

--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -83,7 +83,7 @@ export default class Input extends Component {
           autoFocus={this.props.autoFocus}
           errorText={this.props.errorText}
           floatingLabelText={this.props.small ? undefined : this.props.floatingLabelText}
-          floatingLabelStyle={{...styles.floatingLabelStyle, ...(this.state.focused ? {color: globalColorsDZ2.blue} : {})}}
+          floatingLabelStyle={{...styles.floatingLabelStyle, ...(this.state.focused ? {color: globalColorsDZ2.blue, transform: 'perspective(1px) scale(0.65) translate3d(2px, -28px, 0)', transformOrigin: 'center top'} : {transform: 'scale(1) translate3d(0, 0, 0)'})}}
           onFocus={() => this.setState({focused: true})}
           onBlur={() => this.setState({focused: false})}
           hintText={this.props.hintText}

--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -2,7 +2,7 @@
 import React, {Component} from 'react'
 import {TextField} from 'material-ui'
 import {globalStyles, globalColors, globalColorsDZ2} from '../styles/style-guide'
-import {styles as TextStyles} from './text'
+import {styles as TextStyles, specialStyles} from './text'
 import materialTheme from '../styles/material-theme.desktop'
 
 import InputOld from './input.old.desktop'
@@ -118,7 +118,7 @@ export const styles = {
     marginTop: 2
   },
   input: {
-    ...TextStyles.textBodyBigSemibold,
+    ...specialStyles.textInput,
     height: 80
   },
   inputSmall: {

--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -129,6 +129,7 @@ export const styles = {
   },
   underlineFocusStyle: {
     borderColor: globalColorsDZ2.blue,
+    borderBottom: 'solid 1px',
     transition: ''
   },
   errorStyle: {

--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -83,7 +83,7 @@ export default class Input extends Component {
           autoFocus={this.props.autoFocus}
           errorText={this.props.errorText}
           floatingLabelText={this.props.small ? undefined : this.props.floatingLabelText}
-          floatingLabelStyle={{...styles.floatingLabelStyle, ...(this.state.focused ? {color: globalColorsDZ2.blue, transform: 'perspective(1px) scale(0.65) translate3d(2px, -28px, 0)', transformOrigin: 'center top'} : {transform: 'scale(1) translate3d(0, 0, 0)'})}}
+          floatingLabelStyle={{...styles.floatingLabelStyle, ...(this.state.value || this.state.focused ? {color: globalColorsDZ2.blue, transform: 'perspective(1px) scale(0.65) translate3d(2px, -28px, 0)', transformOrigin: 'center top'} : {transform: 'scale(1) translate3d(0, 0, 0)'})}}
           onFocus={() => this.setState({focused: true})}
           onBlur={() => this.setState({focused: false})}
           hintText={this.props.hintText}

--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -76,7 +76,7 @@ export default class Input extends Component {
         <TextField
           ref={textField => (this._textField = textField)}
           fullWidth
-          inputStyle={inputStyle}
+          inputStyle={{...inputStyle, textAlign: 'center'}}
           underlineStyle={{bottom: 'auto'}}
           errorStyle={{...styles.errorStyle, ...this.props.errorStyle}}
           style={{...textStyle, ...globalStyles.flexBoxColumn}}
@@ -118,7 +118,8 @@ export const styles = {
     marginTop: 2
   },
   input: {
-    ...TextStyles.textBody
+    ...TextStyles.textBodyBigSemibold,
+    height: 80
   },
   inputSmall: {
     ...TextStyles.textBody,
@@ -149,4 +150,3 @@ export const styles = {
     top: 34
   }
 }
-

--- a/shared/common-adapters/text.desktop.js
+++ b/shared/common-adapters/text.desktop.js
@@ -175,6 +175,16 @@ const headerStyles = {
   }
 }
 
+export const specialStyles = {
+  textInput: {
+    ...textCommon,
+    ...globalStyles.DZ2.fontSemibold,
+    fontSize: 24,
+    lineHeight: '29px',
+    letterSpacing: '0.3px'
+  }
+}
+
 export const styles = {
   ...headerStyles,
   textBody: {
@@ -201,19 +211,6 @@ export const styles = {
     ...globalStyles.DZ2.fontSemibold,
     fontSize: 14,
     lineHeight: '19px',
-    letterSpacing: '0.3px'
-  },
-  textBodyBig: {
-    ...textCommon,
-    fontSize: 24,
-    lineHeight: '30px',
-    letterSpacing: '0.3px'
-  },
-  textBodyBigSemibold: {
-    ...textCommon,
-    ...globalStyles.DZ2.fontSemibold,
-    fontSize: 24,
-    lineHeight: '30px',
     letterSpacing: '0.3px'
   },
   textError: {

--- a/shared/common-adapters/text.desktop.js
+++ b/shared/common-adapters/text.desktop.js
@@ -203,6 +203,19 @@ export const styles = {
     lineHeight: '19px',
     letterSpacing: '0.3px'
   },
+  textBodyBig: {
+    ...textCommon,
+    fontSize: 24,
+    lineHeight: '30px',
+    letterSpacing: '0.3px'
+  },
+  textBodyBigSemibold: {
+    ...textCommon,
+    ...globalStyles.DZ2.fontSemibold,
+    fontSize: 24,
+    lineHeight: '30px',
+    letterSpacing: '0.3px'
+  },
   textError: {
     ...textCommon,
     color: globalColors.highRiskWarning,

--- a/shared/pinentry/index.render.desktop.js
+++ b/shared/pinentry/index.render.desktop.js
@@ -85,7 +85,7 @@ export default class PinentryRender extends Component {
             checkboxesProps={checkboxProps}
           />
         </div>
-        <div style={{...styles2.container, alignItems: 'flex-end', paddingRight: 40, paddingBottom: 20}}>
+        <div style={{...styles2.container, alignItems: 'flex-end', paddingRight: 20, paddingBottom: 20}}>
           <Button dz2 type='Primary' label='Continue' onClick={submitPassphrase} />
         </div>
       </div>

--- a/shared/pinentry/index.render.desktop.js
+++ b/shared/pinentry/index.render.desktop.js
@@ -77,7 +77,7 @@ export default class PinentryRender extends Component {
         <div style={{...styles2.container, alignItems: 'center', padding: 10}}>
           <Text type='Body'>{this.props.prompt}</Text>
         </div>
-        <div style={{...styles2.container, alignItems: 'center', padding: 10}}>
+        <div style={{...styles2.container, alignItems: 'center', padding: 10, paddingLeft: 30, paddingRight: 30}}>
           <FormWithCheckbox
             style={{alignSelf: 'stretch'}}
             inputProps={inputProps}

--- a/shared/pinentry/index.render.desktop.js
+++ b/shared/pinentry/index.render.desktop.js
@@ -80,10 +80,10 @@ export default class PinentryRender extends Component {
             onClose={() => this.props.onCancel()}
           />
         </div>
-        <div style={{...styles2.container, alignItems: 'center', padding: 30}}>
+        <div style={{...styles2.container, alignItems: 'center', padding: 10}}>
           <Text type='Body'>{this.props.prompt}</Text>
         </div>
-        <div style={{...styles2.container, alignItems: 'center', padding: 30}}>
+        <div style={{...styles2.container, alignItems: 'center', padding: 10}}>
           <FormWithCheckbox
             style={{alignSelf: 'stretch'}}
             inputProps={inputProps}
@@ -91,7 +91,7 @@ export default class PinentryRender extends Component {
             checkboxesProps={checkboxProps}
           />
         </div>
-        <div style={{...styles2.container, alignItems: 'flex-end', padding: 30}}>
+        <div style={{...styles2.container, alignItems: 'flex-end', paddingRight: 40, paddingBottom: 20}}>
           <Button dz2 type='Primary' label='Continue' onClick={submitPassphrase}
           />
         </div>

--- a/shared/pinentry/index.render.desktop.js
+++ b/shared/pinentry/index.render.desktop.js
@@ -86,8 +86,7 @@ export default class PinentryRender extends Component {
           />
         </div>
         <div style={{...styles2.container, alignItems: 'flex-end', paddingRight: 40, paddingBottom: 20}}>
-          <Button dz2 type='Primary' label='Continue' onClick={submitPassphrase}
-          />
+          <Button dz2 type='Primary' label='Continue' onClick={submitPassphrase} />
         </div>
       </div>
     )

--- a/shared/pinentry/index.render.desktop.js
+++ b/shared/pinentry/index.render.desktop.js
@@ -72,7 +72,7 @@ export default class PinentryRender extends Component {
     })
 
     return (
-      <div style={styles2.container}>
+      <div>
         <Header icon title='' onClose={() => this.props.onCancel()} />
         <div style={{...styles2.container, alignItems: 'center', padding: 10}}>
           <Text type='Body'>{this.props.prompt}</Text>

--- a/shared/pinentry/index.render.desktop.js
+++ b/shared/pinentry/index.render.desktop.js
@@ -57,13 +57,19 @@ export default class PinentryRender extends Component {
       onChange: event => this.setState({passphrase: event.target.value}),
       onEnterKeyDown: () => this.onSubmit(),
       type: this.state.showTyping ? 'text' : 'password',
-      errorText: this.state.error
+      errorText: this.props.retryLabel
     }
 
-    const checkboxProps = [
-      {label: 'Save in Keychain', checked: this.state.saveInKeychain, onCheck: check => { this.setState({saveInKeychain: check}) }},
-      {label: 'Show Typing', checked: this.state.showTyping, onCheck: check => { this.setState({showTyping: check}) }}
-    ]
+    const checkboxProps = Object.keys(this.props.features).map(feature => {
+      return ({
+        label: this.props.features[feature].label,
+        checked: this.state.features[feature],
+        key: feature,
+        name: feature,
+        style: styles.checkbox,
+        onCheck: checked => this.onCheck(feature, checked)
+      })
+    })
 
     return (
       <div style={styles2.container}>
@@ -86,7 +92,7 @@ export default class PinentryRender extends Component {
           />
         </div>
         <div style={{...styles2.container, alignItems: 'flex-end', padding: 30}}>
-          <Button dz2 type='Primary' label='Continue' onClick={() => this.onSubmit()}
+          <Button dz2 type='Primary' label='Continue' onClick={submitPassphrase}
           />
         </div>
       </div>

--- a/shared/pinentry/index.render.desktop.js
+++ b/shared/pinentry/index.render.desktop.js
@@ -55,7 +55,7 @@ export default class PinentryRender extends Component {
       floatingLabelText: 'Passphrase',
       style: {marginBottom: 0},
       onChange: event => this.setState({passphrase: event.target.value}),
-      onEnterKeyDown: () => this.onSubmit(),
+      onEnterKeyDown: () => submitPassphrase(),
       type: this.state.showTyping ? 'text' : 'password',
       errorText: this.props.retryLabel
     }

--- a/shared/pinentry/index.render.desktop.js
+++ b/shared/pinentry/index.render.desktop.js
@@ -73,13 +73,7 @@ export default class PinentryRender extends Component {
 
     return (
       <div style={styles2.container}>
-        <div style={styles2.container}>
-          <Header
-            icon
-            title=''
-            onClose={() => this.props.onCancel()}
-          />
-        </div>
+        <Header icon title='' onClose={() => this.props.onCancel()} />
         <div style={{...styles2.container, alignItems: 'center', padding: 10}}>
           <Text type='Body'>{this.props.prompt}</Text>
         </div>

--- a/shared/pinentry/index.render.desktop.js
+++ b/shared/pinentry/index.render.desktop.js
@@ -1,7 +1,8 @@
 import React, {Component} from 'react'
-import {globalStyles, globalColors} from '../styles/style-guide'
+import {globalStyles, globalColors, globalColorsDZ2} from '../styles/style-guide'
 import {autoResize} from '../../desktop/renderer/remote-component-helper'
-import {Checkbox, Header, Input, Text, Button} from '../common-adapters'
+import {Button, Checkbox, FormWithCheckbox, Header, Input, Text} from '../common-adapters'
+import flags from '../util/feature-flags'
 
 export default class PinentryRender extends Component {
   constructor (props) {
@@ -39,6 +40,60 @@ export default class PinentryRender extends Component {
   }
 
   render () {
+    if (flags.dz2) {
+      return this.render2()
+    } else {
+      return this.render1()
+    }
+  }
+
+  render2 () {
+    const submitPassphrase = () => this.props.onSubmit(this.state.passphrase, this.state.features)
+
+    const inputProps = {
+      dz2: true,
+      floatingLabelText: 'Passphrase',
+      style: {marginBottom: 0},
+      onChange: event => this.setState({passphrase: event.target.value}),
+      onEnterKeyDown: () => this.onSubmit(),
+      type: this.state.showTyping ? 'text' : 'password',
+      errorText: this.state.error
+    }
+
+    const checkboxProps = [
+      {label: 'Save in Keychain', checked: this.state.saveInKeychain, onCheck: check => { this.setState({saveInKeychain: check}) }},
+      {label: 'Show Typing', checked: this.state.showTyping, onCheck: check => { this.setState({showTyping: check}) }}
+    ]
+
+    return (
+      <div style={styles2.container}>
+        <div style={styles2.container}>
+          <Header
+            icon
+            title=''
+            onClose={() => this.props.onCancel()}
+          />
+        </div>
+        <div style={{...styles2.container, alignItems: 'center', padding: 30}}>
+          <Text type='Body'>{this.props.prompt}</Text>
+        </div>
+        <div style={{...styles2.container, alignItems: 'center', padding: 30}}>
+          <FormWithCheckbox
+            style={{alignSelf: 'stretch'}}
+            inputProps={inputProps}
+            checkboxContainerStyle={{paddingLeft: 60, paddingRight: 60}}
+            checkboxesProps={checkboxProps}
+          />
+        </div>
+        <div style={{...styles2.container, alignItems: 'flex-end', padding: 30}}>
+          <Button dz2 type='Primary' label='Continue' onClick={() => this.onSubmit()}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  render1 () {
     const submitPassphrase = () => this.props.onSubmit(this.state.passphrase, this.state.features)
 
     return (
@@ -94,6 +149,13 @@ PinentryRender.propTypes = {
   cancelLabel: React.PropTypes.string,
   submitLabel: React.PropTypes.string,
   windowTitle: React.PropTypes.string.isRequired
+}
+
+const styles2 = {
+  container: {
+    ...globalStyles.flexBoxColumn,
+    backgroundColor: globalColorsDZ2.white
+  }
 }
 
 const styles = {

--- a/shared/util/feature-flags.js
+++ b/shared/util/feature-flags.js
@@ -8,23 +8,28 @@ import getenv from 'getenv'
 const tracker2Key = 'tracker2'
 const loginKey = 'login'
 const mobileAppsExistKey = 'mobileAppsExist'
+const dz2Key = 'dz2'
 
 type FeatureFlags = {
   'tracker2': boolean,
   'login': boolean,
-  'mobileAppsExist': boolean
+  'mobileAppsExist': boolean,
+  'dz2': boolean
 }
 
 let features = getenv.array('KEYBASE_FEATURES', 'string', '')
 
-const tracker2 = features.includes(tracker2Key)
+// dz2 implies tracker2
+const tracker2 = features.includes(tracker2Key) || features.includes(dz2Key)
 const login = features.includes(loginKey)
 const mobileAppsExist = features.includes(mobileAppsExistKey)
+const dz2 = features.includes(dz2Key)
 
 const ff: FeatureFlags = {
   tracker2,
   login,
-  mobileAppsExist
+  mobileAppsExist,
+  dz2
 }
 
 if (__DEV__) {
@@ -35,5 +40,6 @@ export default ff
 export {
   tracker2,
   login,
-  mobileAppsExist
+  mobileAppsExist,
+  dz2
 }


### PR DESCRIPTION
@keybase/react-hackers New pinentry:

<img width="557" alt="screen shot 2016-03-01 at 11 28 33 am" src="https://cloud.githubusercontent.com/assets/21217/13433664/d682de9c-dfa0-11e5-8a23-0f318b11f7f1.png">

Also updates the login page to share the new larger text area for FormWithCheckbox, and sets the default on the Go side for paper keys to be "Show Typing" true. @patrickxb 