### PR TITLE
pass --debug to autoforked daemons by default, and define --no-debug

### DIFF
--- a/go/client/fork_server.go
+++ b/go/client/fork_server.go
@@ -96,7 +96,7 @@ func makeServerCommandLine(cl libkb.CommandLine, forkType keybase1.ForkType) (ar
 	// we should automate the reconstruction of the argument vector.  Let's do
 	// this when we yank out keybase/cli
 	bools := []string{
-		"debug",
+		"no-debug",
 		"api-dump-unsafe",
 		"plain-logging",
 	}
@@ -122,6 +122,11 @@ func makeServerCommandLine(cl libkb.CommandLine, forkType keybase1.ForkType) (ar
 		"tor-hidden-address",
 	}
 	args = append(args, arg0)
+
+	// Always pass --debug to the server for more verbose logging, as other
+	// startup mechanisms do (launchd, run_keybase, etc). This can be
+	// overridden with --no-debug though.
+	args = append(args, "--debug")
 
 	for _, b := range bools {
 		if isSet, isTrue := cl.GetBool(b, true); isSet && isTrue {

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -80,6 +80,12 @@ func (p CommandLine) GetDbFilename() string {
 	return p.GetGString("db")
 }
 func (p CommandLine) GetDebug() (bool, bool) {
+	// --no-debug suppresses --debug. Note that although we don't define a
+	// separate GetNoDebug() accessor, fork_server.go still looks for
+	// --no-debug by name, to pass it along to an autoforked daemon.
+	if noDebug, _ := p.GetBool("no-debug", true); noDebug {
+		return false /* val */, true /* isSet */
+	}
 	return p.GetBool("debug", true)
 }
 func (p CommandLine) GetVDebugSetting() string {
@@ -328,6 +334,10 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 		cli.BoolFlag{
 			Name:  "debug, d",
 			Usage: "Enable debugging mode.",
+		},
+		cli.BoolFlag{
+			Name:  "no-debug",
+			Usage: "Suppress debugging mode; takes precedence over --debug.",
 		},
 		cli.StringFlag{
 			Name:  "vdebug",


### PR DESCRIPTION
r? @maxtaco 