### PR TITLE
Support Fuse upgrades

### DIFF
--- a/go/client/cmd_fuse_osx.go
+++ b/go/client/cmd_fuse_osx.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/keybase/cli"
+	"github.com/keybase/client/go/install"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 )
@@ -62,7 +63,7 @@ func (v *CmdFuseStatus) ParseArgv(ctx *cli.Context) error {
 }
 
 func (v *CmdFuseStatus) Run() error {
-	status := KeybaseFuseStatus(v.G(), v.bundleVersion)
+	status := install.KeybaseFuseStatus(v.bundleVersion, v.G().Log)
 	out, err := json.MarshalIndent(status, "", "  ")
 	if err != nil {
 		return err

--- a/go/client/cmd_update.go
+++ b/go/client/cmd_update.go
@@ -198,6 +198,10 @@ func (v *CmdUpdateRunLocal) GetUpdateUI() (libkb.UpdateUI, error) {
 	return v.G().UI.GetUpdateUI(), nil
 }
 
+func (v *CmdUpdateRunLocal) AfterUpdateApply() error {
+	return nil
+}
+
 func (v *CmdUpdateRunLocal) Run() error {
 	source, err := engine.NewUpdateSourceFromString(v.G(), v.options.Source)
 	if err != nil {

--- a/go/engine/update_default.go
+++ b/go/engine/update_default.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build !darwin
+
+package engine
+
+func (u *UpdateEngine) AfterUpdateApply() error {
+	return nil
+}

--- a/go/engine/update_osx.go
+++ b/go/engine/update_osx.go
@@ -1,0 +1,35 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build darwin
+
+package engine
+
+import (
+	"github.com/keybase/client/go/install"
+	"github.com/keybase/client/go/protocol"
+)
+
+func (u *UpdateEngine) AfterUpdateApply() error {
+	fuseStatus, err := install.KeybaseFuseStatusForAppBundle("/Applications/Keybase.app", u.G().Log)
+	if err != nil {
+		return err
+	}
+
+	u.G().Log.Debug("Fuse status: %s", fuseStatus)
+
+	hasKBFuseMounts := false
+	for _, mountInfo := range fuseStatus.MountInfos {
+		if mountInfo.Fstype == "kbfuse" {
+			hasKBFuseMounts = true
+			break
+		}
+	}
+
+	if fuseStatus.InstallAction == keybase1.InstallAction_UPGRADE && hasKBFuseMounts {
+		u.G().Log.Info("Fuse needs upgrade and we have mounts, let's uninstall KBFS so the installer can upgrade after app restart")
+		install.Uninstall(u.G(), []string{"kbfs"})
+	}
+
+	return nil
+}

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -172,7 +172,7 @@ func (d *Service) Run() (err error) {
 		updater.CleanupFix() // TODO(gabriel): Remove anytime after March 2016
 		updr := engine.NewDefaultUpdater(d.G())
 		if updr != nil {
-			updateChecker := updater.NewUpdateChecker(updr, d.G().UIRouter, d.G().Log)
+			updateChecker := updater.NewUpdateChecker(updr, d, d.G().Log)
 			d.updateChecker = &updateChecker
 			d.updateChecker.Start()
 		}
@@ -392,4 +392,12 @@ func GetCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Comma
 	return []cli.Command{
 		NewCmdService(cl, g),
 	}
+}
+
+func (d *Service) GetUpdateUI() (libkb.UpdateUI, error) {
+	return d.G().UIRouter.GetUpdateUI()
+}
+
+func (d *Service) AfterUpdateApply() error {
+	return nil
 }

--- a/go/updater/sources/local.go
+++ b/go/updater/sources/local.go
@@ -1,0 +1,61 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package sources
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/keybase/client/go/logger"
+	keybase1 "github.com/keybase/client/go/protocol"
+)
+
+// LocalUpdateSource finds releases/updates from custom url feed (used primarily for testing)
+type LocalUpdateSource struct {
+	log logger.Logger
+}
+
+func NewLocalUpdateSource(log logger.Logger) LocalUpdateSource {
+	return LocalUpdateSource{
+		log: log,
+	}
+}
+
+func (k LocalUpdateSource) Description() string {
+	return "Local"
+}
+
+func digest(URL string) (digest string, err error) {
+	f, err := os.Open(URL[7:]) // Remove file:// prefix
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	hasher := sha256.New()
+	if _, ioerr := io.Copy(hasher, f); ioerr != nil {
+		err = ioerr
+		return
+	}
+	digest = hex.EncodeToString(hasher.Sum(nil))
+	return
+}
+
+func (k LocalUpdateSource) FindUpdate(options keybase1.UpdateOptions) (update *keybase1.Update, err error) {
+	digest, err := digest(options.URL)
+	if err != nil {
+		return nil, err
+	}
+	return &keybase1.Update{
+		Version: options.Version,
+		Name:    fmt.Sprintf("v%s", options.Version),
+		Asset: &keybase1.Asset{
+			Name:   fmt.Sprintf("Keybase-%s.zip", options.Version),
+			Url:    options.URL,
+			Digest: digest,
+		},
+	}, nil
+}

--- a/go/updater/sources/sources.go
+++ b/go/updater/sources/sources.go
@@ -16,11 +16,12 @@ type UpdateSourceName string
 const (
 	KeybaseSource    UpdateSourceName = "keybase"
 	RemoteSource                      = "remote"
+	LocalSource                       = "local"
 	PrereleaseSource                  = "prerelease"
 	ErrorSource                       = "error"
 )
 
-var UpdateSourceNames = []UpdateSourceName{KeybaseSource, RemoteSource, PrereleaseSource}
+var UpdateSourceNames = []UpdateSourceName{KeybaseSource, RemoteSource, PrereleaseSource, LocalSource}
 
 func DefaultUpdateSourceName() UpdateSourceName {
 	if IsPrerelease {
@@ -47,6 +48,8 @@ func UpdateSourceNameFromString(name string, defaultSourceName UpdateSourceName)
 		return RemoteSource
 	case string(PrereleaseSource):
 		return PrereleaseSource
+	case string(LocalSource):
+		return LocalSource
 	default:
 		return defaultSourceName
 	}

--- a/go/updater/update_checker.go
+++ b/go/updater/update_checker.go
@@ -13,15 +13,15 @@ import (
 
 type UpdateChecker struct {
 	updater *Updater
-	ui      UI
+	ctx     Context
 	ticker  *time.Ticker
 	log     logger.Logger
 }
 
-func NewUpdateChecker(updater *Updater, ui UI, log logger.Logger) UpdateChecker {
+func NewUpdateChecker(updater *Updater, ctx Context, log logger.Logger) UpdateChecker {
 	return UpdateChecker{
 		updater: updater,
-		ui:      ui,
+		ctx:     ctx,
 		log:     log,
 	}
 }
@@ -40,7 +40,7 @@ func (u *UpdateChecker) Check(force bool, requested bool) error {
 	}
 
 	checkTime := time.Now()
-	_, err := u.updater.Update(u.ui, force, requested)
+	_, err := u.updater.Update(u.ctx, force, requested)
 	if err != nil {
 		return err
 	}

--- a/go/updater/updater_test.go
+++ b/go/updater/updater_test.go
@@ -34,6 +34,10 @@ func (u testUpdateUI) GetUpdateUI() (libkb.UpdateUI, error) {
 	return u, nil
 }
 
+func (u testUpdateUI) AfterUpdateApply() error {
+	return nil
+}
+
 func (u testUpdateUI) UpdateAppInUse(context.Context, keybase1.UpdateAppInUseArg) (keybase1.UpdateAppInUseRes, error) {
 	return keybase1.UpdateAppInUseRes{Action: keybase1.UpdateAppInUseAction_CANCEL}, nil
 }

--- a/osx/Fuse/README.md
+++ b/osx/Fuse/README.md
@@ -6,7 +6,7 @@ of relying on 3rd party binaries from other developers.
 
 ### Building KBFuse from OSXFuse
 
-    build.sh
+    ./build.sh
 
 ### Manual Install
 
@@ -14,8 +14,7 @@ If you are upgrading you should uninstall the kext first (see below).
 
 To install:
 
-    sudo /bin/cp -RfX kbfuse.bundle /Library/Filesystems/kbfuse.fs
-    sudo chmod +s /Library/Filesystems/kbfuse.fs/Contents/Resources/load_kbfuse
+    ./install.sh
 
 ### Uninstall
 

--- a/osx/Fuse/build.sh
+++ b/osx/Fuse/build.sh
@@ -5,9 +5,11 @@ set -e -u -o pipefail # Fail on error
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 cd "$dir"
 
+version=${VERSION:-"3.2.0"}
+
 # Checkout
 rm -rf osxfuse
-git clone --recursive -b osxfuse-3.2.0 git://github.com/osxfuse/osxfuse.git osxfuse
+git clone --recursive -b osxfuse-$version git://github.com/osxfuse/osxfuse.git osxfuse
 
 # Rename osxfuse to kbfuse
 # Run multiple times to workaround dir renames (TODO: Fix hack)

--- a/osx/Fuse/install.sh
+++ b/osx/Fuse/install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail # Fail on error
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+cd "$dir"
+
+bundle=${BUNDLE:-"kbfuse.bundle"}
+
+echo "Using bundle: $bundle"
+
+sudo /bin/cp -RfX $bundle /Library/Filesystems/kbfuse.fs
+sudo chmod +s /Library/Filesystems/kbfuse.fs/Contents/Resources/load_kbfuse
+/Library/Filesystems/kbfuse.fs/Contents/Resources/load_kbfuse
+
+kextstat | grep kbfuse

--- a/packaging/prerelease/README.md
+++ b/packaging/prerelease/README.md
@@ -56,3 +56,12 @@ To build the app and services from a local copy (for testing):
 ```
 TEST=1 NOSIGN=1 ./build_app.sh
 ```
+
+### Testing Updates
+
+To store current install, to re-apply as an update:
+
+```
+ditto -c -k --keepParent -rsrc /Applications/Keybase.app /tmp/Keybase.zip
+keybase update run --source=local --url=file:///tmp/Keybase.zip
+```


### PR DESCRIPTION
After updates, we check to see if there is a new fuse version.
If so we uninstall KBFS before we restart. This stops KBFS and
unmounts, allowing Fuse to upgrade on next restart.