### PR TITLE
Add grey no avatar image

### DIFF
--- a/shared/common-adapters/avatar.desktop.js
+++ b/shared/common-adapters/avatar.desktop.js
@@ -4,7 +4,7 @@ import React, {Component} from 'react'
 import resolveRoot from '../../desktop/resolve-root'
 import type {Props} from './avatar'
 
-const noAvatar = `file:///${resolveRoot('shared/images/no-avatar@2x.png')}`
+const noAvatar = `file:///${resolveRoot('shared/images/icons/placeholder-avatar@2x.png')}`
 
 export default class Avatar extends Component {
   props: Props;

--- a/shared/common-adapters/avatar.desktop.js
+++ b/shared/common-adapters/avatar.desktop.js
@@ -2,6 +2,7 @@
 
 import React, {Component} from 'react'
 import resolveRoot from '../../desktop/resolve-root'
+import {globalColorsDZ2} from '../styles/style-guide'
 import type {Props} from './avatar'
 
 const noAvatar = `file:///${resolveRoot('shared/images/icons/placeholder-avatar@2x.png')}`
@@ -9,18 +10,43 @@ const noAvatar = `file:///${resolveRoot('shared/images/icons/placeholder-avatar@
 export default class Avatar extends Component {
   props: Props;
 
+  state: {
+    avatarLoaded: boolean
+  };
+
+  constructor (props: Props) {
+    super(props)
+    this.state = {avatarLoaded: false}
+  }
+
   render () {
     return (
-      <img
-        style={{width: this.props.size, height: this.props.size, borderRadius: this.props.size / 2, ...this.props.style}}
-        src={this.props.url}
-        onError={event => (event.target.src = noAvatar)}/>)
+      <div style={{position: 'relative'}}>
+        <div
+          style={{...avatarStyle(this.props.size),
+            backgroundImage: `url('${noAvatar}')`,
+            backgroundSize: 'cover',
+            ...this.props.style
+          }}/>
+        <img
+          src={this.props.url}
+          style={{...avatarStyle(this.props.size),
+            display: this.state.avatarLoaded ? 'block' : 'none',
+            backgroundColor: globalColorsDZ2.white,
+            ...this.props.style
+          }}
+          onLoad={() => this.setState({avatarLoaded: true})}/>
+      </div>
+    )
   }
 }
 
-Avatar.propTypes = {
-  size: React.PropTypes.number.isRequired,
-  url: React.PropTypes.string,
-  style: React.PropTypes.object
+function avatarStyle (size: number): Object {
+  return {
+    width: size,
+    height: size,
+    borderRadius: size / 2,
+    position: 'absolute'
+  }
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

This changes the default no-avatar on the avatar component to the new darker one.

Changes all instances of Avatar, not sure if we want that. If not I can make this just happen on the tracker popups.