### PR TITLE
filepath.Join instead of path.Join on windows

### DIFF
--- a/go/client/cmd_status.go
+++ b/go/client/cmd_status.go
@@ -6,7 +6,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/net/context"
@@ -143,7 +143,7 @@ func (c *CmdStatus) load() (*fstatus, error) {
 		status.Service.Running = false
 	} else {
 		status.Service.Running = true
-		status.Service.Log = path.Join(extStatus.LogDir, libkb.ServiceLogFileName)
+		status.Service.Log = filepath.Join(extStatus.LogDir, libkb.ServiceLogFileName)
 	}
 
 	status.SessionStatus = c.sessionStatus(extStatus.Session)
@@ -164,8 +164,8 @@ func (c *CmdStatus) load() (*fstatus, error) {
 		status.Desktop.Version = desktop.Version
 	}
 
-	status.KBFS.Log = path.Join(extStatus.LogDir, libkb.KBFSLogFileName)
-	status.Desktop.Log = path.Join(extStatus.LogDir, libkb.DesktopLogFileName)
+	status.KBFS.Log = filepath.Join(extStatus.LogDir, libkb.KBFSLogFileName)
+	status.Desktop.Log = filepath.Join(extStatus.LogDir, libkb.DesktopLogFileName)
 
 	status.DefaultUsername = extStatus.DefaultUsername
 	status.ProvisionedUsernames = extStatus.ProvisionedUsernames

--- a/go/client/provision_ui.go
+++ b/go/client/provision_ui.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/net/context"
@@ -220,7 +220,7 @@ func (p ProvisionUI) DisplayAndPromptSecret(ctx context.Context, arg keybase1.Di
 			if err == nil {
 				p.parent.Output("Or, scan this QR Code with the keybase app on your mobile phone:\n\n")
 				p.parent.Output(encodings.Terminal)
-				fname := path.Join(os.TempDir(), "keybase_qr.png")
+				fname := filepath.Join(os.TempDir(), "keybase_qr.png")
 				f, ferr := os.Create(fname)
 				if ferr == nil {
 					f.Write(encodings.PNG)

--- a/go/install/install.go
+++ b/go/install/install.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -107,7 +106,7 @@ func ResolveInstallStatus(version string, bundleVersion string, lastExitStatus s
 }
 
 func serviceInfoPath(context Context) string {
-	return path.Join(context.GetRuntimeDir(), "keybased.info")
+	return filepath.Join(context.GetRuntimeDir(), "keybased.info")
 }
 
 func KBFSBundleVersion(context Context, binPath string) (string, error) {

--- a/go/keybase/main_test.go
+++ b/go/keybase/main_test.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -38,7 +38,7 @@ func compileBinary() error {
 // keybase binary.
 func keybaseBinaryPath() string {
 	gopath := os.Getenv("GOPATH")
-	binpath := path.Join(gopath, "bin", "keybase")
+	binpath := filepath.Join(gopath, "bin", "keybase")
 	return binpath
 }
 
@@ -87,7 +87,7 @@ func newUser(t *testing.T) *user {
 // makeHome creates a new home directory for this user, and returns where
 // it is, so that our keybase command-line can use it during tests.
 func (u user) makeHome(t *testing.T) string {
-	p := path.Join(".", "scratch", "home", u.name)
+	p := filepath.Join(".", "scratch", "home", u.name)
 	err := os.MkdirAll(p, 0755)
 	if err != nil {
 		t.Fatalf("Error in MkdirAll %s: %v", p, err)

--- a/go/libkb/gpg_cli_test.go
+++ b/go/libkb/gpg_cli_test.go
@@ -4,7 +4,7 @@
 package libkb
 
 import (
-	"path"
+	"path/filepath"
 	"testing"
 )
 
@@ -17,7 +17,7 @@ func TestGPGKeyring(t *testing.T) {
 	}
 
 	for _, fn := range []string{"secring.gpg", "pubring.gpg"} {
-		p := path.Join(tc.Tp.GPGHome, fn)
+		p := filepath.Join(tc.Tp.GPGHome, fn)
 		ok, err := FileExists(p)
 		if err != nil {
 			t.Fatal(err)

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -101,7 +102,7 @@ func (tc *TestContext) Cleanup() {
 func (tc TestContext) MoveGpgKeyringTo(dst TestContext) error {
 
 	mv := func(f string) (err error) {
-		return os.Rename(path.Join(tc.Tp.GPGHome, f), path.Join(dst.Tp.GPGHome, f))
+		return os.Rename(path.Join(tc.Tp.GPGHome, f), filepath.Join(dst.Tp.GPGHome, f))
 	}
 
 	if err := mv("secring.gpg"); err != nil {

--- a/go/libkb/tmpfile.go
+++ b/go/libkb/tmpfile.go
@@ -6,7 +6,7 @@ package libkb
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 )
 
 // OpenTempFile creates an opened termporary file. Use mode=0 for default
@@ -46,5 +46,5 @@ func TempFile(prefix string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return path.Join(os.TempDir(), tmp), nil
+	return filepath.Join(os.TempDir(), tmp), nil
 }


### PR DESCRIPTION
This broke log uploads, possibly. Anyway, path.Join doesn't work on Windows. Thanks Golang!
@maxtaco @patrickxb 