### PR TITLE
moving margin to the status icon. reducing to 10

### DIFF
--- a/shared/tracker/header.render.desktop.js
+++ b/shared/tracker/header.render.desktop.js
@@ -3,7 +3,7 @@
 import React, {Component} from 'react'
 import {Header} from '../common-adapters'
 import {Icon, Text} from '../common-adapters/index'
-import {globalStyles, globalColorsDZ2, transitionColor} from '../styles/style-guide'
+import {globalStyles, globalColorsDZ2} from '../styles/style-guide'
 import flags from '../util/feature-flags'
 
 import type {HeaderProps} from './header.render'

--- a/shared/tracker/proofs.render.desktop.js
+++ b/shared/tracker/proofs.render.desktop.js
@@ -131,7 +131,7 @@ export class ProofsRender2 extends Component {
           <CircularProgress style={styles.loader} mode='indeterminate' color='#999' size={0.2} />
         }
         {!isChecking && proofStatusIcon &&
-          <Icon type={proofStatusIcon} style={{...globalStyles.clickable, fontSize: 20}} onClick={onClickProfile} />
+          <Icon type={proofStatusIcon} style={styles.statusIcon} onClick={onClickProfile} />
         }
       </div>
     )
@@ -167,6 +167,11 @@ const styles2 = {
     marginRight: 9,
     marginTop: 4
   },
+  statusIcon: {
+    ...globalStyles.clickable,
+    fontSize: 20,
+    marginLeft: 10
+  },
   proofNameSection: {
     ...globalStyles.flexBoxRow,
     alignItems: 'flex-start',
@@ -178,7 +183,6 @@ const styles2 = {
   },
   proofNameContainer: {
     wordWrap: 'break-word',
-    marginRight: 15,
     flex: 1
   },
   proofName: {


### PR DESCRIPTION
also fixes eslint error

@keybase/react-hackers 