### PR TITLE
<Input> errors should use DZ2 red, not DZ1 red

### DIFF
--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -335,7 +335,7 @@ type PassphraseError struct {
 func (p PassphraseError) Error() string {
 	msg := "Bad passphrase"
 	if len(p.Msg) != 0 {
-		msg = msg + ": " + p.Msg
+		msg = msg + ": " + p.Msg + "."
 	}
 	return msg
 }

--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -134,7 +134,7 @@ export const styles = {
   },
   errorStyle: {
     ...globalStyles.DZ2.fontRegular,
-    color: globalColors.highRiskWarning,
+    color: globalColorsDZ2.red,
     alignSelf: 'center',
     fontSize: 13,
     lineHeight: '17px',

--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -136,7 +136,7 @@ export const styles = {
     ...globalStyles.DZ2.fontRegular,
     color: globalColorsDZ2.red,
     alignSelf: 'center',
-    fontSize: 13,
+    fontSize: 14,
     lineHeight: '17px',
     position: 'initial',
     marginTop: 4

--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -139,7 +139,8 @@ export const styles = {
     fontSize: 14,
     lineHeight: '17px',
     position: 'initial',
-    marginTop: 4
+    marginTop: 4,
+    paddingTop: 4
   },
   hintStyle: {
     ...globalStyles.DZ2.fontRegular


### PR DESCRIPTION
@keybase/react-hackers