### PR TITLE
Add DiscardAndCloseBody utility function

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -181,7 +181,7 @@ func (api *BaseAPIEngine) PreparePost(url url.URL, arg APIArg, sendJSON bool) (*
 // The returned response, if non-nil, should have
 // DiscardAndCloseBody() called on it.
 func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes bool) (
-	resp *http.Response, jw *jsonw.Wrapper, err error) {
+	_ *http.Response, jw *jsonw.Wrapper, err error) {
 	if !arg.G().Env.GetTorMode().UseSession() && arg.NeedSession {
 		err = TorSessionRequiredError{}
 		return
@@ -215,21 +215,21 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 	if err != nil {
 		return nil, nil, APINetError{err: err}
 	}
-	arg.G().Log.Debug(fmt.Sprintf("| Result is: %s", resp.Status))
+	arg.G().Log.Debug(fmt.Sprintf("| Result is: %s", internalResp.Status))
 
 	// Check for a code 200 or rather which codes were allowed in arg.HttpStatus
-	err = checkHTTPStatus(arg, resp)
+	err = checkHTTPStatus(arg, internalResp)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = api.consumeHeaders(resp)
+	err = api.consumeHeaders(internalResp)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	if wantJSONRes {
-		decoder := json.NewDecoder(resp.Body)
+		decoder := json.NewDecoder(internalResp.Body)
 		var obj interface{}
 		decoder.UseNumber()
 		err = decoder.Decode(&obj)

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -436,8 +436,8 @@ func (a *InternalAPIEngine) GetDecode(arg APIArg, v APIResponseWrapper) error {
 	if err != nil {
 		return err
 	}
+	defer DiscardAndCloseBody(resp)
 	dec := json.NewDecoder(resp.Body)
-	defer resp.Body.Close()
 	if err = dec.Decode(&v); err != nil {
 		return err
 	}
@@ -485,8 +485,8 @@ func (a *InternalAPIEngine) PostDecode(arg APIArg, v APIResponseWrapper) error {
 	if err != nil {
 		return err
 	}
+	defer DiscardAndCloseBody(resp)
 	dec := json.NewDecoder(resp.Body)
-	defer resp.Body.Close()
 	if err = dec.Decode(&v); err != nil {
 		return err
 	}
@@ -595,7 +595,6 @@ func (api *ExternalAPIEngine) DoRequest(
 	case XAPIResText:
 		var buf bytes.Buffer
 		_, err = buf.ReadFrom(resp.Body)
-		defer resp.Body.Close()
 		if err == nil {
 			tr = &ExternalTextRes{resp.StatusCode, string(buf.Bytes())}
 		}

--- a/go/libkb/httputil.go
+++ b/go/libkb/httputil.go
@@ -1,0 +1,34 @@
+package libkb
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+func discardAndClose(rc io.ReadCloser) error {
+	_, _ = io.Copy(ioutil.Discard, rc)
+	return rc.Close()
+}
+
+// DiscardAndCloseBody reads as much as possible from the body of the
+// given response, and then closes it.
+//
+// This is because, in order to free up the current connection for
+// re-use, a response body must be read from before being closed; see
+// http://stackoverflow.com/a/17953506 .
+//
+// Instead of doing:
+//
+//   res, _ := ...
+//   defer res.Body.Close()
+//
+// do
+//
+//   res, _ := ...
+//   defer DiscardAndCloseBody(res)
+//
+// instead.
+func DiscardAndCloseBody(resp *http.Response) error {
+	return discardAndClose(resp.Body)
+}

--- a/go/updater/sources/remote.go
+++ b/go/updater/sources/remote.go
@@ -49,7 +49,7 @@ func (k RemoteUpdateSource) FindUpdate(options keybase1.UpdateOptions) (update *
 	k.log.Info("Request %#v", sourceURL)
 	resp, err := client.Do(req)
 	if resp != nil {
-		defer resp.Body.Close()
+		defer libkb.DiscardAndCloseBody(resp)
 	}
 	if err != nil {
 		return

--- a/go/updater/updater.go
+++ b/go/updater/updater.go
@@ -250,7 +250,7 @@ func (u *Updater) downloadAsset(asset keybase1.Asset) (fpath string, cached bool
 		err = fmt.Errorf("No response")
 		return
 	}
-	defer resp.Body.Close()
+	defer libkb.DiscardAndCloseBody(resp)
 	if resp.StatusCode == http.StatusNotModified {
 		u.log.Info("Using cached file: %s", fpath)
 		cached = true


### PR DESCRIPTION
Use it to avoid unnecessary new
connections.

Also clean up cleanup flow a bit in
api.go.