### PR TITLE
Set default colors for fa-close to match style guide

### DIFF
--- a/shared/common-adapters/icon.desktop.js
+++ b/shared/common-adapters/icon.desktop.js
@@ -17,6 +17,8 @@ export default class Icon extends Component {
         return globalColorsDZ2.green
       case 'fa-custom-icon-proof-good-new':
         return globalColorsDZ2.blue2
+      case 'fa-close':
+        return globalColorsDZ2.black20
       default:
         return null
     }
@@ -28,8 +30,19 @@ export default class Icon extends Component {
       case 'fa-custom-icon-proof-good-followed':
       case 'fa-custom-icon-proof-good-new':
         return this._defaultColor(type)
+      case 'fa-close':
+        return globalColorsDZ2.black60
       default:
         return null
+    }
+  }
+
+  _defaultOpacity (type: Props.type): ?string {
+    switch (type) {
+      case 'fa-close':
+        return 1.0
+      default:
+        return 0.35
     }
   }
 
@@ -47,6 +60,7 @@ export default class Icon extends Component {
   render () {
     let color = this._defaultColor(this.props.type)
     let hoverColor = this._defaultHoverColor(this.props.type)
+    let defaultOpacity = this._defaultOpacity(this.props.type)
     let iconType = this._typeToIconMapper(this.props.type)
 
     if (this.props.inheritColor) {
@@ -62,7 +76,7 @@ export default class Icon extends Component {
     if (isFontIcon) {
       return <FontIcon
         title={this.props.hint}
-        style={{...styles.icon, opacity: this.props.opacity ? 0.35 : 1.0, ...this.props.style}}
+        style={{...styles.icon, opacity: this.props.opacity ? defaultOpacity : 1.0, ...this.props.style}}
         className={`fa ${iconType}`}
         color={color}
         hoverColor={this.props.onClick ? hoverColor : null}

--- a/shared/tracker/header.render.desktop.js
+++ b/shared/tracker/header.render.desktop.js
@@ -77,7 +77,7 @@ export default class HeaderRender extends Component {
         <div style={{...styles.header, ...headerStyle}}>
           <div style={{...styles.header, ...headerStyle, height: 54, zIndex: 2, opacity: isWarning ? 1 : 0, backgroundColor: globalColorsDZ2.yellow}}/>
           <Text type='BodySemibold' dz2 lineClamp={2} style={{...styles.text, ...headerTextStyle, flex: 1, zIndex: isWarning ? 2 : 'inherit'}}>{headerText}</Text>
-          <Icon type='fa-times' opacity style={styles.close}
+          <Icon type='fa-close' opacity style={styles.close}
             onClick={() => this.props.onClose()}
             onMouseEnter={() => this.closeMouseEnter()}
             onMouseLeave={() => this.closeMouseLeave()} />


### PR DESCRIPTION
@keybase/react-hackers 

The close icons weren't the right color.

Should have looked like:
<img width="83" alt="screen shot 2016-03-04 at 11 25 51 am" src="https://cloud.githubusercontent.com/assets/594035/13537841/ecc9c366-e1fb-11e5-8296-6710eeee6093.png">

and now they do automatically anytime you use the `fa-close` icon. (if you don't want it you can use the general `fa-times` icon)