### PR TITLE
Fix button letter spacing to match style guide

### DIFF
--- a/shared/common-adapters/button.desktop.js
+++ b/shared/common-adapters/button.desktop.js
@@ -170,6 +170,7 @@ const buttonCommon2 = {
   fontSize: 16,
   height: 32,
   lineHeight: '24px',
+  letterSpacing: '0.3px',
   textTransform: 'none',
   minWidth: 10
 }

--- a/shared/common-adapters/button.desktop.js
+++ b/shared/common-adapters/button.desktop.js
@@ -170,7 +170,6 @@ const buttonCommon2 = {
   fontSize: 16,
   height: 32,
   lineHeight: '24px',
-  letterSpacing: '0.3px',
   textTransform: 'none',
   minWidth: 10
 }

--- a/shared/styles/style-guide.desktop.js
+++ b/shared/styles/style-guide.desktop.js
@@ -68,7 +68,8 @@ export const globalResizing = {
 
 const fontCommon = {
   WebkitFontSmoothing: 'antialiased',
-  textRendering: 'optimizeLegibility'
+  textRendering: 'optimizeLegibility',
+  letterSpacing: '0.3px'
 }
 
 const font = {


### PR DESCRIPTION
@keybase/react-hackers @cecileboucheron

Before and after:

![screenshot from 2016-03-04 16-24-19](https://cloud.githubusercontent.com/assets/21217/13540728/398e5156-e226-11e5-8fc1-29a9b70e39b9.png)

![screenshot from 2016-03-04 16-26-26](https://cloud.githubusercontent.com/assets/21217/13540732/3cee042c-e226-11e5-9e33-0f7c8f82a199.png)
