### PR TITLE
more windows terminal fixes, especially backspace

### DIFF
--- a/go/minterm/minterm.go
+++ b/go/minterm/minterm.go
@@ -55,7 +55,7 @@ func (m *MinTerm) Size() (int, int) {
 
 // Write writes a string to the terminal.
 func (m *MinTerm) Write(s string) error {
-	_, err := fmt.Fprint(m.termOut, s)
+	_, err := fmt.Fprint(m.getReadWriter(), s)
 	return err
 }
 

--- a/go/minterm/minterm_windows.go
+++ b/go/minterm/minterm_windows.go
@@ -6,6 +6,7 @@
 package minterm
 
 import (
+	"github.com/keybase/client/go/logger"
 	"golang.org/x/crypto/ssh/terminal"
 	"io"
 	"os"
@@ -50,6 +51,8 @@ func (m *MinTerm) open() error {
 	return nil
 }
 
+// Use a Windows output writer to eat control codes that look ugly on legacy terminals.
+// As a bonus, we can do color prompts this way.
 func (m *MinTerm) getReadWriter() io.ReadWriter {
-	return WindowsReadWriter{r: m.termIn, w: m.termOut}
+	return WindowsReadWriter{r: m.termIn, w: logger.OutputWriterFromFile(m.termOut)}
 }


### PR DESCRIPTION
I tested various scenarios with old and new terminals, and the colors work better and the Ctrl-C notification comes back and backspace appears normally too. @maxtaco @oconnor663 