### PR TITLE
accidentally logged an expected case as Error

### DIFF
--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -734,11 +734,14 @@ type RevokedKey struct {
 }
 
 func (ckf ComputedKeyFamily) GetRevokedKeys() []RevokedKey {
+	ckf.G().Log.Debug("+ GetRevokedKeys")
+	defer ckf.G().Log.Debug("- GetRevokedKeys")
+
 	var revokedKeys []RevokedKey
 	for kid := range ckf.kf.AllKIDs {
 		ki, ok := ckf.cki.Infos[kid]
 		if !ok || ki == nil {
-			ckf.G().Log.Errorf("KID %s not in cki.Infos", kid)
+			ckf.G().Log.Debug("KID %s not in cki.Infos (likely belongs to a previous subchain). Skipping.", kid)
 			continue
 		}
 		if ki.Status != KeyRevoked {


### PR DESCRIPTION
See https://github.com/keybase/client/issues/2240 and
https://github.com/keybase/client/pull/2212#discussion_r55236082.

I assumed that a KID in AllKIDs that didn't show up in cki.Infos was an
unexpected error. Turns out it's totally expected if you've ever done a
sigchain reset. Making this a Debug log instead of an Error.

r? @patrickxb 