### PR TITLE
Update check should be async

### DIFF
--- a/go/updater/update_checker.go
+++ b/go/updater/update_checker.go
@@ -12,17 +12,27 @@ import (
 )
 
 type UpdateChecker struct {
-	updater *Updater
-	ctx     Context
-	ticker  *time.Ticker
-	log     logger.Logger
+	updater       *Updater
+	ctx           Context
+	ticker        *time.Ticker
+	log           logger.Logger
+	tickDuration  time.Duration // tickDuration is the ticker delay
+	checkDuration time.Duration // checkDuration is how ofter to check for updates
+	count         int           // count is number of time we've checked
 }
 
+// NewUpdateChecker creates an update checker
 func NewUpdateChecker(updater *Updater, ctx Context, log logger.Logger) UpdateChecker {
+	return newUpdateChecker(updater, ctx, log, DefaultTickDuration(), DefaultCheckDuration())
+}
+
+func newUpdateChecker(updater *Updater, ctx Context, log logger.Logger, tickDuration time.Duration, checkDuration time.Duration) UpdateChecker {
 	return UpdateChecker{
-		updater: updater,
-		ctx:     ctx,
-		log:     log,
+		updater:       updater,
+		ctx:           ctx,
+		log:           log,
+		tickDuration:  tickDuration,
+		checkDuration: checkDuration,
 	}
 }
 
@@ -32,7 +42,7 @@ func (u *UpdateChecker) Check(force bool, requested bool) error {
 	if !requested && !force {
 		if lastCheckedPTime := u.updater.config.GetUpdateLastChecked(); lastCheckedPTime > 0 {
 			lastChecked := keybase1.FromTime(lastCheckedPTime)
-			if time.Now().Before(lastChecked.Add(checkDuration())) {
+			if time.Now().Before(lastChecked.Add(u.checkDuration)) {
 				u.log.Debug("Already checked: %s", lastChecked)
 				return nil
 			}
@@ -40,6 +50,7 @@ func (u *UpdateChecker) Check(force bool, requested bool) error {
 	}
 
 	checkTime := time.Now()
+	u.count++
 	_, err := u.updater.Update(u.ctx, force, requested)
 	if err != nil {
 		return err
@@ -50,11 +61,12 @@ func (u *UpdateChecker) Check(force bool, requested bool) error {
 	return nil
 }
 
+// Start starts the update checker
 func (u *UpdateChecker) Start() {
 	if u.ticker != nil {
 		return
 	}
-	u.ticker = time.NewTicker(tickDuration())
+	u.ticker = time.NewTicker(u.tickDuration)
 	go func() {
 		for _ = range u.ticker.C {
 			go func() {
@@ -68,21 +80,27 @@ func (u *UpdateChecker) Start() {
 	}()
 }
 
+// Stop stops the update checker
 func (u *UpdateChecker) Stop() {
 	u.ticker.Stop()
 	u.ticker = nil
 }
 
-// checkDuration is how often to check for updates
-func checkDuration() time.Duration {
+// Count is number of times the check has been called
+func (u UpdateChecker) Count() int {
+	return u.count
+}
+
+// DefaultCheckDuration is default for how often to check for updates (e.g. daily)
+func DefaultCheckDuration() time.Duration {
 	if sources.IsPrerelease {
 		return time.Hour
 	}
 	return 24 * time.Hour
 }
 
-// tickDuration is how often to call check (should be less than checkDuration or snooze min)
-func tickDuration() time.Duration {
+// DefaultTickDuration is how often to call check (should be less than checkDuration or snooze min)
+func DefaultTickDuration() time.Duration {
 	if sources.IsPrerelease {
 		return 15 * time.Minute
 	}

--- a/go/updater/update_checker.go
+++ b/go/updater/update_checker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/client/go/updater/sources"
 )
 
+// UpdateChecker runs updates checks every check duration
 type UpdateChecker struct {
 	updater       *Updater
 	ctx           Context
@@ -18,7 +19,7 @@ type UpdateChecker struct {
 	log           logger.Logger
 	tickDuration  time.Duration // tickDuration is the ticker delay
 	checkDuration time.Duration // checkDuration is how ofter to check for updates
-	count         int           // count is number of time we've checked
+	count         int           // count is number of times we've checked
 }
 
 // NewUpdateChecker creates an update checker
@@ -42,7 +43,7 @@ func (u *UpdateChecker) Check(force bool, requested bool) error {
 	if !requested && !force {
 		if lastCheckedPTime := u.updater.config.GetUpdateLastChecked(); lastCheckedPTime > 0 {
 			lastChecked := keybase1.FromTime(lastCheckedPTime)
-			if time.Now().Before(lastChecked.Add(u.checkDuration)) {
+			if time.Since(lastChecked) > u.checkDuration {
 				u.log.Debug("Already checked: %s", lastChecked)
 				return nil
 			}

--- a/go/updater/update_checker.go
+++ b/go/updater/update_checker.go
@@ -56,12 +56,14 @@ func (u *UpdateChecker) Start() {
 	}
 	u.ticker = time.NewTicker(tickDuration())
 	go func() {
-		for range u.ticker.C {
-			u.log.Debug("Checking for update (ticker)")
-			err := u.Check(false, false)
-			if err != nil {
-				u.log.Errorf("Error in update: %s", err)
-			}
+		for _ = range u.ticker.C {
+			go func() {
+				u.log.Debug("Checking for update (ticker)")
+				err := u.Check(false, false)
+				if err != nil {
+					u.log.Errorf("Error in update: %s", err)
+				}
+			}()
 		}
 	}()
 }

--- a/go/updater/update_checker_test.go
+++ b/go/updater/update_checker_test.go
@@ -1,0 +1,62 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package updater
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol"
+	"golang.org/x/net/context"
+)
+
+// TestUpdateCheckerIsAsync checks to make sure if the updater is blocked in a
+// prompt that checks continue. This is safe because the updater is
+// singleflighted.
+func TestUpdateCheckerIsAsync(t *testing.T) {
+	updater, err := NewTestUpdater(t, NewDefaultTestUpdateConfig(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checker := newUpdateChecker(updater, testUpdateCheckUI{}, logger.NewTestLogger(t), 50*time.Millisecond, 100*time.Millisecond)
+	defer checker.Stop()
+	checker.Start()
+
+	time.Sleep(400 * time.Millisecond)
+
+	if checker.Count() <= 2 {
+		t.Fatal("Checker should have checked more than once")
+	}
+}
+
+type testUpdateCheckUI struct{}
+
+func (u testUpdateCheckUI) UpdatePrompt(_ context.Context, _ keybase1.UpdatePromptArg) (keybase1.UpdatePromptRes, error) {
+	time.Sleep(400 * time.Millisecond)
+	return keybase1.UpdatePromptRes{Action: keybase1.UpdateAction_UPDATE}, nil
+}
+
+func (u testUpdateCheckUI) UpdateQuit(_ context.Context) (keybase1.UpdateQuitRes, error) {
+	return keybase1.UpdateQuitRes{Quit: false}, nil
+}
+
+func (u testUpdateCheckUI) GetUpdateUI() (libkb.UpdateUI, error) {
+	return u, nil
+}
+
+func (u testUpdateCheckUI) AfterUpdateApply(willRestart bool) error {
+	return nil
+}
+
+func (u testUpdateCheckUI) Verify(r io.Reader, signature string) error {
+	return nil
+}
+
+func (u testUpdateCheckUI) UpdateAppInUse(context.Context, keybase1.UpdateAppInUseArg) (keybase1.UpdateAppInUseRes, error) {
+	return keybase1.UpdateAppInUseRes{Action: keybase1.UpdateAppInUseAction_CANCEL}, nil
+}


### PR DESCRIPTION
The updater is single flighted so we want the ticker to be async. If an
old update is blocked (a prompt is up and you are away from computer
for a long time), this allows the update check to keep occurring.

This fixes the issue where coyne came into work on Monday and still had
an old update prompt.