### PR TITLE
nuke session.json, standalone autologin, service start autologin

### DIFF
--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -236,9 +236,7 @@ func Logout(tc libkb.TestContext) {
 // testEngineWithSecretStore takes a given engine-running function and
 // makes sure that it works with the secret store, i.e. that it stores
 // data into it when told to and reads data out from it.
-func testEngineWithSecretStore(
-	t *testing.T,
-	runEngine func(libkb.TestContext, *FakeUser, libkb.SecretUI)) {
+func testEngineWithSecretStore(t *testing.T, runEngine func(libkb.TestContext, *FakeUser, libkb.SecretUI)) {
 	// TODO: Get this working on non-OS X platforms (by mocking
 	// out the SecretStore).
 	if !libkb.HasSecretStore() {
@@ -248,9 +246,12 @@ func testEngineWithSecretStore(
 	tc := SetupEngineTest(t, "wss")
 	defer tc.Cleanup()
 
+	t.Logf("testEngineWithSecretStore: creating fake user")
 	fu := CreateAndSignupFakeUser(tc, "wss")
-	tc.ResetLoginState()
+	t.Logf("testEngineWithSecretStore: clearing login state secret caches after signup")
+	tc.ClearLoginStateSecretCaches()
 
+	t.Logf("testEngineWithSecretStore: running engine first time, storing secret")
 	testSecretUI := libkb.TestSecretUI{
 		Passphrase:  fu.Passphrase,
 		StoreSecret: true,
@@ -261,8 +262,10 @@ func testEngineWithSecretStore(
 		t.Fatal("GetPassphrase() unexpectedly not called")
 	}
 
-	tc.ResetLoginState()
+	t.Logf("testEngineWithSecretStore: clearing login state secret caches after first engine run")
+	tc.ClearLoginStateSecretCaches()
 
+	t.Logf("testEngineWithSecretStore: running engine second time, using stored secret")
 	testSecretUI = libkb.TestSecretUI{}
 	runEngine(tc, fu, &testSecretUI)
 

--- a/go/engine/concurrency_test.go
+++ b/go/engine/concurrency_test.go
@@ -61,12 +61,8 @@ func TestConcurrentLogin(t *testing.T) {
 					tc.G.LoginState().LocalSession(func(s *libkb.Session) {
 						s.GetUID()
 					}, "GetUID")
-					tc.G.LoginState().LocalSession(func(s *libkb.Session) {
-						s.Load()
-					}, "session Load")
 					tc.G.LoginState().LoggedIn()
 					tc.G.LoginState().LoggedInLoad()
-					// tc.G.LoginState.Shutdown()
 				}
 			}
 		}(i)

--- a/go/engine/deprovision_test.go
+++ b/go/engine/deprovision_test.go
@@ -71,12 +71,10 @@ func TestDeprovision(t *testing.T) {
 	}
 
 	dbPath := tc.G.Env.GetDbFilename()
-	sessionPath := tc.G.Env.GetSessionFilename()
 	secretKeysPath := tc.G.SKBFilenameForUser(fu.NormalizedUsername())
 	numKeys := getNumKeys(tc, *fu)
 
 	assertFileExists(t, dbPath)
-	assertFileExists(t, sessionPath)
 	assertFileExists(t, secretKeysPath)
 	if !isUserInConfigFile(tc, *fu) {
 		t.Fatalf("User %s is not in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())
@@ -111,7 +109,6 @@ func TestDeprovision(t *testing.T) {
 	}
 
 	assertFileDoesNotExist(t, dbPath)
-	assertFileDoesNotExist(t, sessionPath)
 	assertFileDoesNotExist(t, secretKeysPath)
 	if isUserInConfigFile(tc, *fu) {
 		t.Fatalf("User %s is still in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())
@@ -156,12 +153,10 @@ func TestDeprovisionLoggedOut(t *testing.T) {
 	}
 
 	dbPath := tc.G.Env.GetDbFilename()
-	sessionPath := tc.G.Env.GetSessionFilename()
 	secretKeysPath := tc.G.SKBFilenameForUser(fu.NormalizedUsername())
 	numKeys := getNumKeys(tc, *fu)
 
 	assertFileExists(t, dbPath)
-	assertFileExists(t, sessionPath)
 	assertFileExists(t, secretKeysPath)
 	if !isUserInConfigFile(tc, *fu) {
 		t.Fatalf("User %s is not in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())
@@ -201,7 +196,6 @@ func TestDeprovisionLoggedOut(t *testing.T) {
 	}
 
 	assertFileDoesNotExist(t, dbPath)
-	assertFileDoesNotExist(t, sessionPath)
 	assertFileDoesNotExist(t, secretKeysPath)
 	if isUserInConfigFile(tc, *fu) {
 		t.Fatalf("User %s is still in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())
@@ -246,12 +240,10 @@ func TestCurrentDeviceRevoked(t *testing.T) {
 	}
 
 	dbPath := tc.G.Env.GetDbFilename()
-	sessionPath := tc.G.Env.GetSessionFilename()
 	secretKeysPath := tc.G.SKBFilenameForUser(fu.NormalizedUsername())
 	numKeys := getNumKeys(tc, *fu)
 
 	assertFileExists(t, dbPath)
-	assertFileExists(t, sessionPath)
 	assertFileExists(t, secretKeysPath)
 	if !isUserInConfigFile(tc, *fu) {
 		t.Fatalf("User %s is not in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())
@@ -293,7 +285,6 @@ func TestCurrentDeviceRevoked(t *testing.T) {
 	}
 
 	assertFileDoesNotExist(t, dbPath)
-	assertFileDoesNotExist(t, sessionPath)
 	assertFileDoesNotExist(t, secretKeysPath)
 	if isUserInConfigFile(tc, *fu) {
 		t.Fatalf("User %s is still in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())

--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -4,6 +4,7 @@
 package engine
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -30,25 +31,29 @@ func runPrereqs(e Engine, ctx *Context) (err error) {
 	prq := e.Prereqs()
 
 	// in standalone mode, try logging in if necessary:
-	if e.G().Env.GetStandalone() && (prq.Session || prq.Device) {
-		e.G().Log.Debug("standalone mode + session prereq = %v, device prereq = %v: attempting autologin", prq.Session, prq.Device)
-		eng := newLoginProvisionedDevice(e.G(), "")
-		if err = RunEngine(eng, ctx); err != nil {
-			e.G().Log.Debug("standalone mode autologin failed: %s", err)
-			return err
+	/*
+		if e.G().Env.GetStandalone() && (prq.Session || prq.Device) {
+			e.G().Log.Debug("standalone mode + session prereq = %v, device prereq = %v: attempting autologin", prq.Session, prq.Device)
+			eng := newLoginProvisionedDevice(e.G(), "")
+			if err = RunEngine(eng, ctx); err != nil {
+				e.G().Log.Debug("standalone mode autologin failed: %s", err)
+				return err
+			}
 		}
-	}
+	*/
 
 	if prq.Session {
 		var ok bool
 		ok, _, err = IsLoggedIn(e, ctx)
 		if !ok {
-			urlError, isURLError := err.(*url.Error)
-			context := ""
-			if isURLError {
-				context = fmt.Sprintf("Encountered a network error: %s", urlError.Err)
+			if serr := tryStandaloneLogin(e, ctx); serr != nil {
+				urlError, isURLError := err.(*url.Error)
+				context := ""
+				if isURLError {
+					context = fmt.Sprintf("Encountered a network error: %s", urlError.Err)
+				}
+				err = libkb.LoginRequiredError{Context: context}
 			}
-			err = libkb.LoginRequiredError{Context: context}
 		}
 		if err != nil {
 			return err
@@ -62,13 +67,29 @@ func runPrereqs(e Engine, ctx *Context) (err error) {
 			return err
 		}
 		if !ok {
-			err = libkb.DeviceRequiredError{}
-			return err
+			if serr := tryStandaloneLogin(e, ctx); serr != nil {
+				return libkb.DeviceRequiredError{}
+			}
 		}
 	}
 
 	return
 
+}
+
+func tryStandaloneLogin(e Engine, ctx *Context) error {
+	if !e.G().Env.GetStandalone() {
+		return errors.New("not standalone")
+	}
+
+	e.G().Log.Debug("standalone mode, attempting autologin")
+	eng := newLoginProvisionedDevice(e.G(), "")
+	if err := RunEngine(eng, ctx); err != nil {
+		e.G().Log.Debug("standalone mode autologin failed: %s", err)
+		return err
+	}
+	e.G().Log.Debug("standalone mode autologin success")
+	return nil
 }
 
 func RunEngine(e Engine, ctx *Context) (err error) {

--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -30,18 +30,6 @@ type UIDelegateWanter interface {
 func runPrereqs(e Engine, ctx *Context) (err error) {
 	prq := e.Prereqs()
 
-	// in standalone mode, try logging in if necessary:
-	/*
-		if e.G().Env.GetStandalone() && (prq.Session || prq.Device) {
-			e.G().Log.Debug("standalone mode + session prereq = %v, device prereq = %v: attempting autologin", prq.Session, prq.Device)
-			eng := newLoginProvisionedDevice(e.G(), "")
-			if err = RunEngine(eng, ctx); err != nil {
-				e.G().Log.Debug("standalone mode autologin failed: %s", err)
-				return err
-			}
-		}
-	*/
-
 	if prq.Session {
 		var ok bool
 		ok, _, err = IsLoggedIn(e, ctx)

--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -29,6 +29,16 @@ type UIDelegateWanter interface {
 func runPrereqs(e Engine, ctx *Context) (err error) {
 	prq := e.Prereqs()
 
+	// in standalone mode, try logging in if necessary:
+	if e.G().Env.GetStandalone() && (prq.Session || prq.Device) {
+		e.G().Log.Debug("standalone mode + session prereq = %v, device prereq = %v: attempting autologin", prq.Session, prq.Device)
+		eng := newLoginProvisionedDevice(e.G(), "")
+		if err = RunEngine(eng, ctx); err != nil {
+			e.G().Log.Debug("standalone mode autologin failed: %s", err)
+			return err
+		}
+	}
+
 	if prq.Session {
 		var ok bool
 		ok, _, err = IsLoggedIn(e, ctx)

--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -34,7 +34,11 @@ func runPrereqs(e Engine, ctx *Context) (err error) {
 		var ok bool
 		ok, _, err = IsLoggedIn(e, ctx)
 		if !ok {
-			if serr := tryStandaloneLogin(e, ctx); serr != nil {
+			if e.G().Env.GetStandalone() {
+				if serr := tryStandaloneLogin(e, ctx); serr == nil {
+					return nil
+				}
+			} else {
 				urlError, isURLError := err.(*url.Error)
 				context := ""
 				if isURLError {
@@ -55,9 +59,13 @@ func runPrereqs(e Engine, ctx *Context) (err error) {
 			return err
 		}
 		if !ok {
-			if serr := tryStandaloneLogin(e, ctx); serr != nil {
-				return libkb.DeviceRequiredError{}
+			if e.G().Env.GetStandalone() {
+				if serr := tryStandaloneLogin(e, ctx); serr == nil {
+					return nil
+				}
 			}
+
+			return libkb.DeviceRequiredError{}
 		}
 	}
 

--- a/go/engine/login.go
+++ b/go/engine/login.go
@@ -74,6 +74,7 @@ func (e *Login) Run(ctx *Context) error {
 			// login successful
 			e.G().Log.Debug("LoginProvisionedDevice.Run() was successful")
 			e.sendNotification()
+			e.G().Env.GetConfigWriter().SetLoggedIn(true)
 			return nil
 		}
 
@@ -127,6 +128,8 @@ func (e *Login) Run(ctx *Context) error {
 	if err = RunEngine(deng, ctx); err != nil {
 		return err
 	}
+
+	e.G().Env.GetConfigWriter().SetLoggedIn(true)
 
 	// commit the config changes
 	if err := tx.Commit(); err != nil {

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -281,7 +281,7 @@ func (e *loginProvision) pgpProvision(ctx *Context) error {
 	}
 
 	// need a session to try to get synced private key
-	return e.G().LoginState().LoginWithPrompt(e.arg.User.GetName(), ctx.LoginUI, ctx.SecretUI, afterLogin)
+	return e.G().LoginState().LoginWithPrompt(e.arg.User.GetName(), ctx.SecretUI, afterLogin)
 }
 
 // makeDeviceKeysWithSigner creates device keys given a signing
@@ -612,7 +612,7 @@ func (e *loginProvision) tryGPG(ctx *Context) error {
 	}
 
 	// need a session to continue to provision
-	return e.G().LoginState().LoginWithPrompt(e.arg.User.GetName(), ctx.LoginUI, ctx.SecretUI, afterLogin)
+	return e.G().LoginState().LoginWithPrompt(e.arg.User.GetName(), ctx.SecretUI, afterLogin)
 }
 
 func (e *loginProvision) chooseGPGKeyAndMethod(ctx *Context) (*libkb.GpgPrimaryKey, keybase1.GPGMethod, error) {

--- a/go/engine/login_provisioned_device.go
+++ b/go/engine/login_provisioned_device.go
@@ -35,7 +35,6 @@ func (e *loginProvisionedDevice) Prereqs() Prereqs {
 // RequiredUIs returns the required UIs.
 func (e *loginProvisionedDevice) RequiredUIs() []libkb.UIKind {
 	return []libkb.UIKind{
-		libkb.LoginUIKind,
 		libkb.SecretUIKind,
 	}
 }

--- a/go/engine/login_provisioned_device.go
+++ b/go/engine/login_provisioned_device.go
@@ -98,7 +98,7 @@ func (e *loginProvisionedDevice) Run(ctx *Context) error {
 	// and it has a device id, so this should be a provisioned device.  Thus, they should
 	// just login normally.
 
-	// set e.username so that LoginWithPrompt doesn't need LoginUI.
+	// set e.username for LoginWithPrompt
 	e.username = me.GetName()
 
 	var afterLogin = func(lctx libkb.LoginContext) error {
@@ -108,5 +108,5 @@ func (e *loginProvisionedDevice) Run(ctx *Context) error {
 		}
 		return nil
 	}
-	return e.G().LoginState().LoginWithPrompt(e.username, nil, ctx.SecretUI, afterLogin)
+	return e.G().LoginState().LoginWithPrompt(e.username, ctx.SecretUI, afterLogin)
 }

--- a/go/engine/login_provisioned_device.go
+++ b/go/engine/login_provisioned_device.go
@@ -98,6 +98,9 @@ func (e *loginProvisionedDevice) Run(ctx *Context) error {
 	// and it has a device id, so this should be a provisioned device.  Thus, they should
 	// just login normally.
 
+	// set e.username so that LoginWithPrompt doesn't need LoginUI.
+	e.username = me.GetName()
+
 	var afterLogin = func(lctx libkb.LoginContext) error {
 		if err := lctx.LocalSession().SetDeviceProvisioned(e.G().Env.GetDeviceID()); err != nil {
 			// not a fatal error, session will stay in memory
@@ -105,5 +108,5 @@ func (e *loginProvisionedDevice) Run(ctx *Context) error {
 		}
 		return nil
 	}
-	return e.G().LoginState().LoginWithPrompt(e.username, ctx.LoginUI, ctx.SecretUI, afterLogin)
+	return e.G().LoginState().LoginWithPrompt(e.username, nil, ctx.SecretUI, afterLogin)
 }

--- a/go/engine/login_state_test.go
+++ b/go/engine/login_state_test.go
@@ -61,7 +61,7 @@ func TestLoginLogout(t *testing.T) {
 	}
 
 	secretUI := &libkb.TestSecretUI{Passphrase: fu.Passphrase}
-	if err := tc.G.LoginState().LoginWithPrompt("", nil, secretUI, nil); err != nil {
+	if err := tc.G.LoginState().LoginWithPrompt("", secretUI, nil); err != nil {
 		t.Error(err)
 	}
 
@@ -111,11 +111,11 @@ func TestLoginWhileAlreadyLoggedIn(t *testing.T) {
 
 	// These should all work, since the username matches.
 
-	if err := tc.G.LoginState().LoginWithPrompt("", nil, nil, nil); err != nil {
+	if err := tc.G.LoginState().LoginWithPrompt("", nil, nil); err != nil {
 		t.Error(err)
 	}
 
-	if err := tc.G.LoginState().LoginWithPrompt(fu.Username, nil, nil, nil); err != nil {
+	if err := tc.G.LoginState().LoginWithPrompt(fu.Username, nil, nil); err != nil {
 		t.Error(err)
 	}
 
@@ -128,7 +128,7 @@ func TestLoginWhileAlreadyLoggedIn(t *testing.T) {
 	}
 
 	// This should fail.
-	if _, ok := tc.G.LoginState().LoginWithPrompt("other", nil, nil, nil).(libkb.LoggedInWrongUserError); !ok {
+	if _, ok := tc.G.LoginState().LoginWithPrompt("other", nil, nil).(libkb.LoggedInWrongUserError); !ok {
 		t.Fatal("Did not get expected LoggedIn error")
 	}
 }
@@ -144,7 +144,7 @@ func TestLoginAfterClearLoginStateSecretCaches(t *testing.T) {
 
 	tc.ClearLoginStateSecretCaches()
 
-	if err := tc.G.LoginState().LoginWithPrompt("", nil, nil, nil); err != nil {
+	if err := tc.G.LoginState().LoginWithPrompt("", nil, nil); err != nil {
 		t.Error(err)
 	}
 }
@@ -159,7 +159,7 @@ func TestLoginNonexistent(t *testing.T) {
 	Logout(tc)
 
 	secretUI := &libkb.TestSecretUI{Passphrase: "XXXXXXXXXXXX"}
-	err := tc.G.LoginState().LoginWithPrompt("nonexistent", nil, secretUI, nil)
+	err := tc.G.LoginState().LoginWithPrompt("nonexistent", secretUI, nil)
 	if _, ok := err.(libkb.AppStatusError); !ok {
 		t.Errorf("error type: %T, expected libkb.AppStatusError", err)
 	}
@@ -211,7 +211,7 @@ func TestLoginWithPromptPassphrase(t *testing.T) {
 	mockGetKeybasePassphrase := &GetPassphraseMock{
 		Passphrase: fu.Passphrase,
 	}
-	if err := tc.G.LoginState().LoginWithPrompt("", nil, mockGetKeybasePassphrase, nil); err != nil {
+	if err := tc.G.LoginState().LoginWithPrompt("", mockGetKeybasePassphrase, nil); err != nil {
 		t.Error(err)
 	}
 
@@ -222,35 +222,11 @@ func TestLoginWithPromptPassphrase(t *testing.T) {
 	Logout(tc)
 
 	mockGetKeybasePassphrase.Called = false
-	if err := tc.G.LoginState().LoginWithPrompt(fu.Username, nil, mockGetKeybasePassphrase, nil); err != nil {
+	if err := tc.G.LoginState().LoginWithPrompt(fu.Username, mockGetKeybasePassphrase, nil); err != nil {
 		t.Error(err)
 	}
 
 	mockGetKeybasePassphrase.CheckLastErr(t)
-
-	if !mockGetKeybasePassphrase.Called {
-		t.Errorf("secretUI.GetKeybasePassphrase() unexpectedly not called")
-	}
-
-	Logout(tc)
-
-	// Clear out the username stored in G.Env.
-	tc.G.Env.GetConfigWriter().SetUserConfig(nil, true)
-
-	mockGetUsername := &GetUsernameMock{
-		Username: fu.Username,
-	}
-	mockGetKeybasePassphrase.Called = false
-	if err := tc.G.LoginState().LoginWithPrompt("", mockGetUsername, mockGetKeybasePassphrase, nil); err != nil {
-		t.Error(err)
-	}
-
-	mockGetUsername.CheckLastErr(t)
-	mockGetKeybasePassphrase.CheckLastErr(t)
-
-	if !mockGetUsername.Called {
-		t.Errorf("loginUI.GetEmailOrUsername() unexpectedly not called")
-	}
 
 	if !mockGetKeybasePassphrase.Called {
 		t.Errorf("secretUI.GetKeybasePassphrase() unexpectedly not called")
@@ -315,7 +291,7 @@ func TestLoginWithStoredSecret(t *testing.T) {
 		Passphrase:  fu.Passphrase,
 		StoreSecret: true,
 	}
-	if err := tc.G.LoginState().LoginWithPrompt("", nil, mockGetPassphrase, nil); err != nil {
+	if err := tc.G.LoginState().LoginWithPrompt("", mockGetPassphrase, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/engine/login_state_test.go
+++ b/go/engine/login_state_test.go
@@ -135,14 +135,14 @@ func TestLoginWhileAlreadyLoggedIn(t *testing.T) {
 
 // Test that login works while already logged in and after a login
 // state reset.
-func TestLoginAfterLoginStateReset(t *testing.T) {
+func TestLoginAfterClearLoginStateSecretCaches(t *testing.T) {
 	tc := SetupEngineTest(t, "login while already logged in")
 	defer tc.Cleanup()
 
 	// Logs the user in.
 	_ = CreateAndSignupFakeUser(tc, "li")
 
-	tc.ResetLoginState()
+	tc.ClearLoginStateSecretCaches()
 
 	if err := tc.G.LoginState().LoginWithPrompt("", nil, nil, nil); err != nil {
 		t.Error(err)

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -550,7 +550,7 @@ func TestProvisionPaper(t *testing.T) {
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
 	tc2.G.Clock = fakeClock
 	// to pick up the new clock...
-	tc2.G.ResetLoginState()
+	tc2.ResetLoginState()
 	defer tc2.Cleanup()
 
 	secUI := fu.NewSecretUI()

--- a/go/engine/passphrase_change_test.go
+++ b/go/engine/passphrase_change_test.go
@@ -415,7 +415,7 @@ func TestPassphraseChangeLoggedOutBackupKeySecretStore(t *testing.T) {
 	// this call will cause the login state to be reloaded.
 	assertLoadSecretKeys(tc, u, "logged out w/ backup key, before passphrase change")
 
-	tc.ResetLoginState()
+	tc.ClearLoginStateSecretCaches()
 
 	secretUI := libkb.TestSecretUI{}
 	ctx := &Context{
@@ -612,7 +612,7 @@ func TestPassphraseChangeLoggedOutBackupKeySecretStorePGP(t *testing.T) {
 	// this call will cause the login state to be reloaded.
 	assertLoadSecretKeys(tc, u, "logged out w/ backup key, before passphrase change")
 
-	tc.ResetLoginState()
+	tc.ClearLoginStateSecretCaches()
 
 	secretUI := libkb.TestSecretUI{}
 	ctx = &Context{

--- a/go/engine/saltpack_encrypt.go
+++ b/go/engine/saltpack_encrypt.go
@@ -39,7 +39,10 @@ func (e *SaltpackEncrypt) Name() string {
 
 // GetPrereqs returns the engine prereqs.
 func (e *SaltpackEncrypt) Prereqs() Prereqs {
-	return Prereqs{}
+	if e.arg.Opts.NoSelfEncrypt {
+		return Prereqs{}
+	}
+	return Prereqs{Device: true}
 }
 
 // RequiredUIs returns the required UIs.

--- a/go/engine/saltpack_encrypt_test.go
+++ b/go/engine/saltpack_encrypt_test.go
@@ -132,8 +132,8 @@ func TestSaltpackEncryptSelfNoKey(t *testing.T) {
 
 	eng := NewSaltpackEncrypt(arg, tc.G)
 	err := RunEngine(eng, ctx)
-	if _, ok := err.(libkb.NoKeyError); !ok {
-		t.Fatalf("expected error type libkb.NoKeyError, got %T (%s)", err, err)
+	if _, ok := err.(libkb.DeviceRequiredError); !ok {
+		t.Fatalf("expected error type libkb.DeviceRequiredError, got %T (%s)", err, err)
 	}
 }
 

--- a/go/engine/saltpack_encrypt_test.go
+++ b/go/engine/saltpack_encrypt_test.go
@@ -149,7 +149,8 @@ func TestSaltpackEncryptLoggedOut(t *testing.T) {
 	sink := libkb.NewBufferCloser()
 	arg := &SaltpackEncryptArg{
 		Opts: keybase1.SaltpackEncryptOptions{
-			Recipients: []string{"t_tracy+t_tracy@rooter", "t_george", "t_kb+gbrltest@twitter"},
+			Recipients:    []string{"t_tracy+t_tracy@rooter", "t_george", "t_kb+gbrltest@twitter"},
+			NoSelfEncrypt: true,
 		},
 		Source: strings.NewReader("track and encrypt, track and encrypt"),
 		Sink:   sink,

--- a/go/engine/signup_join.go
+++ b/go/engine/signup_join.go
@@ -132,9 +132,6 @@ func (s *SignupJoinEngine) Run(lctx libkb.LoginContext, arg SignupJoinEngineRunA
 }
 
 func (s *SignupJoinEngine) WriteOut(lctx libkb.LoginContext, salt []byte) error {
-	if err := lctx.LocalSession().Load(); err != nil {
-		return err
-	}
 	if err := lctx.CreateLoginSessionWithSalt(s.username.String(), salt); err != nil {
 		return err
 	}

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -71,7 +71,7 @@ func TestSignupEngine(t *testing.T) {
 	mockGetPassphrase := &GetPassphraseMock{
 		Passphrase: fu.Passphrase,
 	}
-	if err = tc.G.LoginState().LoginWithPrompt(fu.Username, nil, mockGetPassphrase, nil); err != nil {
+	if err = tc.G.LoginState().LoginWithPrompt(fu.Username, mockGetPassphrase, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/engine/soft_snooze_test.go
+++ b/go/engine/soft_snooze_test.go
@@ -4,12 +4,13 @@
 package engine
 
 import (
-	"github.com/jonboulle/clockwork"
-	"github.com/keybase/client/go/libkb"
-	keybase1 "github.com/keybase/client/go/protocol"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
 )
 
 type flakeyRooterAPI struct {
@@ -61,12 +62,13 @@ func (e *flakeyRooterAPI) PostHTML(arg libkb.APIArg) (res *libkb.ExternalHTMLRes
 func TestSoftSnooze(t *testing.T) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
-	fu := CreateAndSignupFakeUser(tc, "track")
 
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
 	tc.G.Clock = fakeClock
 	// to pick up the new clock...
-	tc.G.ResetLoginState()
+	tc.ResetLoginState()
+
+	fu := CreateAndSignupFakeUser(tc, "track")
 
 	flakeyAPI := flakeyRooterAPI{orig: tc.G.XAPI, flakeOut: false, G: tc.G}
 	tc.G.XAPI = &flakeyAPI

--- a/go/engine/track_token_test.go
+++ b/go/engine/track_token_test.go
@@ -4,11 +4,12 @@
 package engine
 
 import (
+	"testing"
+	"time"
+
 	"github.com/jonboulle/clockwork"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
-	"testing"
-	"time"
 )
 
 func TestTrackToken(t *testing.T) {
@@ -82,12 +83,11 @@ func TestTrackTokenIdentify2(t *testing.T) {
 func TestTrackLocalThenLocalTemp(t *testing.T) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	fakeClock := clockwork.NewFakeClock()
 	tc.G.Clock = fakeClock
-	// to pick up the new clock...
-	tc.G.ResetLoginState()
 
 	flakeyAPI := flakeyRooterAPI{orig: tc.G.XAPI, flakeOut: false, G: tc.G}
 	tc.G.XAPI = &flakeyAPI
@@ -207,13 +207,14 @@ func TestTrackLocalThenLocalTemp(t *testing.T) {
 func TestTrackRemoteThenLocalTemp(t *testing.T) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
-	fu := CreateAndSignupFakeUser(tc, "track")
 
 	// Tracking remote means we have to agree what time it is
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
 	tc.G.Clock = fakeClock
 	// to pick up the new clock...
-	tc.G.ResetLoginState()
+	tc.ResetLoginState()
+
+	fu := CreateAndSignupFakeUser(tc, "track")
 
 	flakeyAPI := flakeyRooterAPI{orig: tc.G.XAPI, flakeOut: false, G: tc.G}
 	tc.G.XAPI = &flakeyAPI
@@ -329,12 +330,11 @@ func TestTrackRemoteThenLocalTemp(t *testing.T) {
 func TestTrackFailTempRecover(t *testing.T) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
+
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	fakeClock := clockwork.NewFakeClock()
 	tc.G.Clock = fakeClock
-	// to pick up the new clock...
-	tc.G.ResetLoginState()
 
 	flakeyAPI := flakeyRooterAPI{orig: tc.G.XAPI, flakeOut: false, G: tc.G}
 	tc.G.XAPI = &flakeyAPI

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -14,6 +14,13 @@ import (
 	jsonw "github.com/keybase/go-jsonw"
 )
 
+// Top-level key names
+const (
+	currentUserKey = "current_user"
+	loggedInKey    = "logged_in"
+	usersKey       = "users"
+)
+
 type UserConfigWrapper struct {
 	userConfig *UserConfig
 	sync.Mutex
@@ -182,8 +189,6 @@ func (f JSONConfigFile) GetUserConfig() (*UserConfig, error) {
 	return f.getUserConfigWithLock()
 }
 
-const currentUser = "current_user"
-
 // GetUserConfig looks for the `current_user` field to see if there's
 // a corresponding user object in the `users` table. There really should be.
 func (f JSONConfigFile) getUserConfigWithLock() (ret *UserConfig, err error) {
@@ -192,7 +197,7 @@ func (f JSONConfigFile) getUserConfigWithLock() (ret *UserConfig, err error) {
 	if ret = f.userConfigWrapper.userConfig; ret != nil {
 		return
 	}
-	if s, err = f.jw.AtKey(currentUser).GetString(); err != nil {
+	if s, err = f.jw.AtKey(currentUserKey).GetString(); err != nil {
 		return
 	}
 	nu := NewNormalizedUsername(s)
@@ -216,11 +221,11 @@ func (f *JSONConfigFile) SwitchUser(nu NormalizedUsername) error {
 		return nil
 	}
 
-	if f.jw.AtKey("users").AtKey(nu.String()).IsNil() {
+	if f.jw.AtKey(usersKey).AtKey(nu.String()).IsNil() {
 		return UserNotFoundError{Msg: nu.String()}
 	}
 
-	f.jw.SetKey(currentUser, jsonw.NewString(nu.String()))
+	f.jw.SetKey(currentUserKey, jsonw.NewString(nu.String()))
 	f.userConfigWrapper.userConfig = nil
 	return f.Save()
 }
@@ -230,14 +235,14 @@ func (f *JSONConfigFile) NukeUser(nu NormalizedUsername) error {
 	defer f.userConfigWrapper.Unlock()
 
 	if cu := f.getCurrentUser(); cu.Eq(nu) {
-		err := f.jw.DeleteValueAtPath(currentUser)
+		err := f.jw.DeleteValueAtPath(currentUserKey)
 		if err != nil {
 			return err
 		}
 	}
 
-	if !f.jw.AtKey("users").AtKey(nu.String()).IsNil() {
-		err := f.jw.DeleteValueAtPath("users." + nu.String())
+	if !f.jw.AtKey(usersKey).AtKey(nu.String()).IsNil() {
+		err := f.jw.DeleteValueAtPath(usersKey + "." + nu.String())
 		if err != nil {
 			return err
 		}
@@ -249,12 +254,12 @@ func (f *JSONConfigFile) NukeUser(nu NormalizedUsername) error {
 // GetUserConfigForUsername sees if there's a UserConfig object for the given
 // username previously stored.
 func (f JSONConfigFile) GetUserConfigForUsername(nu NormalizedUsername) (*UserConfig, error) {
-	return ImportUserConfigFromJSONWrapper(f.jw.AtKey("users").AtKey(nu.String()))
+	return ImportUserConfigFromJSONWrapper(f.jw.AtKey(usersKey).AtKey(nu.String()))
 }
 
 func (f JSONConfigFile) GetAllUsernames() (current NormalizedUsername, others []NormalizedUsername, err error) {
 	current = f.getCurrentUser()
-	uw := f.jw.AtKey("users")
+	uw := f.jw.AtKey(usersKey)
 	if uw.IsNil() {
 		return
 	}
@@ -299,7 +304,7 @@ func (f *JSONConfigFile) SetDeviceID(did keybase1.DeviceID) (err error) {
 }
 
 func (f JSONConfigFile) GetLoggedIn() bool {
-	x := f.jw.AtKey("logged_in")
+	x := f.jw.AtKey(loggedInKey)
 	if x.IsNil() {
 		return false
 	}
@@ -312,12 +317,12 @@ func (f JSONConfigFile) GetLoggedIn() bool {
 }
 
 func (f *JSONConfigFile) SetLoggedIn(loggedIn bool) error {
-	f.jw.SetKey("logged_in", jsonw.NewBool(loggedIn))
+	f.jw.SetKey(loggedInKey, jsonw.NewBool(loggedIn))
 	return f.Save()
 }
 
 func (f *JSONConfigFile) getCurrentUser() NormalizedUsername {
-	s, _ := f.jw.AtKey(currentUser).GetString()
+	s, _ := f.jw.AtKey(currentUserKey).GetString()
 	return NormalizedUsername(s)
 }
 
@@ -336,17 +341,17 @@ func (f *JSONConfigFile) setUserConfigWithLock(u *UserConfig, overwrite bool) er
 
 	if u == nil {
 		f.G().Log.Debug("| SetUserConfig(nil)")
-		f.jw.DeleteKey(currentUser)
+		f.jw.DeleteKey(currentUserKey)
 		f.userConfigWrapper.userConfig = nil
 		return f.Save()
 	}
 
-	parent := f.jw.AtKey("users")
+	parent := f.jw.AtKey(usersKey)
 	un := u.GetUsername()
 	f.G().Log.Debug("| SetUserConfig(%s)", un)
 	if parent.IsNil() {
 		parent = jsonw.NewDictionary()
-		f.jw.SetKey("users", parent)
+		f.jw.SetKey(usersKey, parent)
 	}
 	if parent.AtKey(un.String()).IsNil() || overwrite {
 		uWrapper, err := jsonw.NewObjectWrapper(*u)
@@ -358,7 +363,7 @@ func (f *JSONConfigFile) setUserConfigWithLock(u *UserConfig, overwrite bool) er
 	}
 
 	if !f.getCurrentUser().Eq(un) {
-		f.jw.SetKey(currentUser, jsonw.NewString(un.String()))
+		f.jw.SetKey(currentUserKey, jsonw.NewString(un.String()))
 		f.userConfigWrapper.userConfig = nil
 	}
 

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -116,6 +116,7 @@ func (n NullConfiguration) GetNullAtPath(string) bool {
 func (n NullConfiguration) GetSecurityAccessGroupOverride() (bool, bool) {
 	return false, false
 }
+func (n NullConfiguration) GetLoggedIn() bool { return false }
 
 type TestParameters struct {
 	ConfigFilename string

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -150,6 +150,8 @@ func (g *GlobalContext) Logout() error {
 	g.TrackCache = NewTrackCache()
 	g.Identify2Cache = NewIdentify2Cache(g.Env.GetUserCacheMaxAge())
 
+	g.Env.GetConfigWriter().SetLoggedIn(false)
+
 	// get a clean LoginState:
 	g.createLoginStateLocked()
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -134,11 +134,6 @@ func (g *GlobalContext) LoginState() *LoginState {
 	return g.loginState
 }
 
-// ResetLoginState is mainly used for testing...
-func (g *GlobalContext) ResetLoginState() {
-	g.createLoginStateLocked()
-}
-
 func (g *GlobalContext) Logout() error {
 	g.loginStateMu.Lock()
 	defer g.loginStateMu.Unlock()

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -142,6 +142,7 @@ type ConfigReader interface {
 	GetScraperTimeout() (time.Duration, bool)
 	GetAPITimeout() (time.Duration, bool)
 	GetSecurityAccessGroupOverride() (bool, bool)
+	GetLoggedIn() bool
 
 	GetUpdatePreferenceAuto() (bool, bool)
 	GetUpdatePreferenceSkip() string
@@ -176,6 +177,7 @@ type ConfigWriter interface {
 	SetUpdatePreferenceSkip(string) error
 	SetUpdatePreferenceSnoozeUntil(keybase1.Time) error
 	SetUpdateLastChecked(keybase1.Time) error
+	SetLoggedIn(bool) error
 	Reset()
 	BeginTransaction() (ConfigWriterTransacter, error)
 }

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -12,8 +12,6 @@ import (
 	"runtime/debug"
 	"time"
 
-	"golang.org/x/net/context"
-
 	keybase1 "github.com/keybase/client/go/protocol"
 	triplesec "github.com/keybase/go-triplesec"
 )
@@ -114,12 +112,12 @@ func NewLoginState(g *GlobalContext) *LoginState {
 	return res
 }
 
-func (s *LoginState) LoginWithPrompt(username string, loginUI LoginUI, secretUI SecretUI, after afterFn) (err error) {
+func (s *LoginState) LoginWithPrompt(username string, secretUI SecretUI, after afterFn) (err error) {
 	s.G().Log.Debug("+ LoginWithPrompt(%s) called", username)
 	defer func() { s.G().Log.Debug("- LoginWithPrompt -> %s", ErrToOk(err)) }()
 
 	err = s.loginHandle(func(lctx LoginContext) error {
-		return s.loginWithPromptHelper(lctx, username, loginUI, secretUI, false)
+		return s.loginWithPromptHelper(lctx, username, secretUI, false)
 	}, after, "loginWithPromptHelper")
 	return
 }
@@ -226,7 +224,7 @@ func (s *LoginState) GetPassphraseStreamForUser(ui SecretUI, username string) (p
 		return pps, nil
 	}
 	err = s.loginHandle(func(lctx LoginContext) error {
-		return s.loginWithPromptHelper(lctx, username, nil, ui, true)
+		return s.loginWithPromptHelper(lctx, username, ui, true)
 	}, nil, "LoginState - GetPassphraseStreamForUser")
 	if err != nil {
 		return nil, err
@@ -571,36 +569,16 @@ func (s *LoginState) tryPassphrasePromptLogin(lctx LoginContext, username string
 	return
 }
 
-func (s *LoginState) getEmailOrUsername(lctx LoginContext, username *string, loginUI LoginUI) (err error) {
+func (s *LoginState) getEmailOrUsername(lctx LoginContext, username *string) error {
 	if len(*username) != 0 {
-		return
+		return nil
 	}
 
 	*username = s.G().Env.GetEmailOrUsername()
-	if len(*username) != 0 {
-		return
-	}
-
-	if loginUI != nil {
-		if *username, err = loginUI.GetEmailOrUsername(context.TODO(), 0); err != nil {
-			*username = ""
-			return
-		}
-	}
-
 	if len(*username) == 0 {
-		err = NoUsernameError{}
+		return NoUsernameError{}
 	}
-
-	if err != nil {
-		return err
-	}
-
-	// username set, so redo config
-	if err = s.G().ConfigureConfig(); err != nil {
-		return
-	}
-	return s.switchUser(lctx, *username)
+	return nil
 }
 
 func (s *LoginState) verifyPlaintextPassphraseForLoggedInUser(lctx LoginContext, passphrase string) (err error) {
@@ -610,7 +588,7 @@ func (s *LoginState) verifyPlaintextPassphraseForLoggedInUser(lctx LoginContext,
 	}()
 
 	var username string
-	if err = s.getEmailOrUsername(lctx, &username, nil); err != nil {
+	if err = s.getEmailOrUsername(lctx, &username); err != nil {
 		return
 	}
 
@@ -725,21 +703,21 @@ func (s *LoginState) stretchPassphraseIfNecessary(lctx LoginContext, un string, 
 
 func (s *LoginState) verifyPassphraseWithServer(ui SecretUI) error {
 	return s.loginHandle(func(lctx LoginContext) error {
-		return s.loginWithPromptHelper(lctx, s.G().Env.GetUsername().String(), nil, ui, true)
+		return s.loginWithPromptHelper(lctx, s.G().Env.GetUsername().String(), ui, true)
 	}, nil, "LoginState - verifyPassphrase")
 }
 
-func (s *LoginState) loginWithPromptHelper(lctx LoginContext, username string, loginUI LoginUI, secretUI SecretUI, force bool) (err error) {
+func (s *LoginState) loginWithPromptHelper(lctx LoginContext, username string, secretUI SecretUI, force bool) (err error) {
 	var loggedIn bool
 	if loggedIn, err = s.checkLoggedIn(lctx, username, force); err != nil || loggedIn {
 		return
 	}
 
-	if err = s.switchUser(lctx, username); err != nil {
+	if err = s.getEmailOrUsername(lctx, &username); err != nil {
 		return
 	}
 
-	if err = s.getEmailOrUsername(lctx, &username, loginUI); err != nil {
+	if err = s.switchUser(lctx, username); err != nil {
 		return
 	}
 

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -974,11 +974,6 @@ func (s *LoginState) LoginSession(h func(*LoginSession), name string) error {
 func (s *LoginState) SecretSyncer(h func(*SecretSyncer), name string) error {
 	var err error
 	aerr := s.Account(func(a *Account) {
-		// SecretSyncer needs session loaded:
-		err = a.localSession.Load()
-		if err != nil {
-			return
-		}
 		h(a.SecretSyncer())
 	}, name)
 	if aerr != nil {

--- a/go/libkb/session.go
+++ b/go/libkb/session.go
@@ -4,13 +4,11 @@
 package libkb
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"time"
 
 	keybase1 "github.com/keybase/client/go/protocol"
-	jsonw "github.com/keybase/go-jsonw"
 )
 
 type SessionReader interface {
@@ -21,7 +19,6 @@ type SessionReader interface {
 
 type Session struct {
 	Contextified
-	file     *JSONFile
 	token    string
 	csrf     string
 	inFile   bool
@@ -101,53 +98,21 @@ func (s *Session) SetLoggedIn(sessionID, csrfToken string, username NormalizedUs
 	s.uid = uid
 	s.username = &username
 	s.token = sessionID
-	if s.file == nil {
-		if err := s.Load(); err != nil {
-			return err
-		}
-	}
-	if s.GetDictionary() == nil {
-		G.Log.Warning("s.GetDict() == nil")
-	}
-	s.GetDictionary().SetKey("session", jsonw.NewString(sessionID))
-
 	s.SetCsrf(csrfToken)
-
 	s.deviceID = deviceID
-	if s.file == nil {
-		return errors.New("no session file")
-	}
-	s.GetDictionary().SetKey("device_provisioned", jsonw.NewString(deviceID.String()))
+	s.mtime = time.Now()
 
-	return s.save()
-}
-
-func (s *Session) save() error {
-	mtime := time.Now()
-	s.GetDictionary().SetKey("mtime", jsonw.NewInt64(mtime.Unix()))
-	if err := s.file.Save(); err != nil {
-		return err
-	}
-	s.mtime = mtime
 	return nil
 }
 
 func (s *Session) SetCsrf(t string) {
 	s.csrf = t
-	if s.file == nil {
-		return
-	}
-	s.GetDictionary().SetKey("csrf", jsonw.NewString(t))
 }
 
 func (s *Session) SetDeviceProvisioned(devid keybase1.DeviceID) error {
 	s.G().Log.Debug("Local Session:  setting provisioned device id: %s", devid)
 	s.deviceID = devid
-	if s.file == nil {
-		return errors.New("no session file")
-	}
-	s.GetDictionary().SetKey("device_provisioned", jsonw.NewString(devid.String()))
-	return s.save()
+	return nil
 }
 
 func (s *Session) isConfigLoggedIn() bool {
@@ -166,74 +131,6 @@ func (s *Session) nukeSessionFileIfOutOfSync() error {
 		return os.Remove(sessionFile)
 	}
 	return nil
-}
-
-func (s *Session) Load() error {
-	s.G().Log.Debug("+ Loading session")
-	if s.loaded {
-		s.G().Log.Debug("- Skipped; already loaded")
-		return nil
-	}
-
-	err := s.nukeSessionFileIfOutOfSync()
-	if err != nil {
-		return err
-	}
-
-	s.file = NewJSONFile(s.G(), s.G().Env.GetSessionFilename(), "session")
-	err = s.file.Load(false)
-	s.loaded = true
-
-	if err != nil {
-		s.G().Log.Error("Failed to load session file")
-		return err
-	}
-
-	if s.file.Exists() {
-		var tmp error
-		var token, csrf, devid string
-		ok := true
-		s.file.jw.AtKey("session").GetStringVoid(&token, &tmp)
-		if tmp != nil {
-			s.G().Log.Warning("Bad 'session' value in session file %s: %s",
-				s.file.filename, tmp)
-			ok = false
-		}
-		s.file.jw.AtKey("csrf").GetStringVoid(&csrf, &tmp)
-		if tmp != nil {
-			s.G().Log.Warning("Bad 'csrf' value in session file %s: %s",
-				s.file.filename, tmp)
-			ok = false
-		}
-		var did keybase1.DeviceID
-		s.file.jw.AtKey("device_provisioned").GetStringVoid(&devid, &tmp)
-		if tmp != nil {
-			s.G().Log.Debug("Bad 'device_provisioned' value in session file %s: %s", s.file.filename, tmp)
-			ok = false
-		} else {
-			var err error
-			did, err = keybase1.DeviceIDFromString(devid)
-			if err != nil {
-				s.G().Log.Debug("Bad 'device_provisioned' value in session file %s: %s (%s)", s.file.filename, err, devid)
-				ok = false
-
-			}
-		}
-		mtime, _ := s.file.jw.AtKey("mtime").GetInt64()
-		if ok {
-			s.token = token
-			s.csrf = csrf
-			s.inFile = true
-			s.deviceID = did
-			s.mtime = time.Unix(mtime, 0)
-		}
-	}
-	s.G().Log.Debug("- Loaded session")
-	return nil
-}
-
-func (s *Session) GetDictionary() *jsonw.Wrapper {
-	return s.file.jw
 }
 
 func (s *Session) IsRecent() bool {
@@ -281,9 +178,6 @@ func (s *Session) check() error {
 		nu := NewNormalizedUsername(username)
 		s.username = &nu
 		s.SetCsrf(csrf)
-		if err = s.save(); err != nil {
-			return err
-		}
 	} else {
 		s.G().Log.Notice("Stored session expired")
 		s.Invalidate()
@@ -329,26 +223,14 @@ func (s *Session) postLogout() error {
 }
 
 func (s *Session) Logout() error {
-	err := s.Load()
-	var e2 error
-	if err == nil && s.HasSessionToken() {
-		e2 = s.postLogout()
-		if e3 := s.file.Nuke(); e3 != nil {
-			s.inFile = false
-			s.G().Log.Warning("Failed to remove session file: %s", e3)
-		}
+	if s.HasSessionToken() {
+		return s.postLogout()
 	}
-	if err == nil && e2 != nil {
-		err = e2
-	}
-	return err
+	return nil
 }
 
 func (s *Session) loadAndCheck() (bool, error) {
-	err := s.Load()
-	if err != nil {
-		return false, err
-	}
+	var err error
 	if s.HasSessionToken() {
 		err = s.check()
 	}

--- a/go/libkb/session.go
+++ b/go/libkb/session.go
@@ -5,7 +5,6 @@ package libkb
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	keybase1 "github.com/keybase/client/go/protocol"
@@ -21,8 +20,6 @@ type Session struct {
 	Contextified
 	token    string
 	csrf     string
-	inFile   bool
-	loaded   bool
 	deviceID keybase1.DeviceID
 	valid    bool
 	uid      keybase1.UID
@@ -33,14 +30,6 @@ type Session struct {
 
 func newSession(g *GlobalContext) *Session {
 	return &Session{Contextified: Contextified{g}}
-}
-
-// NewSessionThin creates a minimal (thin) session of just the uid and username.
-// Clients of the daemon that use the session protocol need this.
-func NewSessionThin(uid keybase1.UID, username NormalizedUsername, token string) *Session {
-	// XXX should this set valid to true?  daemon won't return a
-	// session unless valid is true, so...
-	return &Session{uid: uid, username: &username, token: token, valid: true}
 }
 
 func (s *Session) IsLoggedIn() bool {
@@ -81,10 +70,6 @@ func (s *Session) GetToken() string {
 	return s.token
 }
 
-func (s *Session) GetCsrf() string {
-	return s.csrf
-}
-
 func (s *Session) APIArgs() (token, csrf string) {
 	return s.token, s.csrf
 }
@@ -98,15 +83,11 @@ func (s *Session) SetLoggedIn(sessionID, csrfToken string, username NormalizedUs
 	s.uid = uid
 	s.username = &username
 	s.token = sessionID
-	s.SetCsrf(csrfToken)
+	s.csrf = csrfToken
 	s.deviceID = deviceID
 	s.mtime = time.Now()
 
 	return nil
-}
-
-func (s *Session) SetCsrf(t string) {
-	s.csrf = t
 }
 
 func (s *Session) SetDeviceProvisioned(devid keybase1.DeviceID) error {
@@ -115,25 +96,7 @@ func (s *Session) SetDeviceProvisioned(devid keybase1.DeviceID) error {
 	return nil
 }
 
-func (s *Session) isConfigLoggedIn() bool {
-	reader := s.G().Env.GetConfig()
-	return reader.GetUsername() != "" && reader.GetDeviceID().Exists() && reader.GetUID().Exists()
-}
-
-// The session file can be out of sync with the config file, particularly when
-// switching between the node and go clients.
-func (s *Session) nukeSessionFileIfOutOfSync() error {
-	sessionFile := s.G().Env.GetSessionFilename()
-	// Use stat to check existence.
-	_, statErr := os.Lstat(sessionFile)
-	if statErr == nil && !s.isConfigLoggedIn() {
-		s.G().Log.Warning("Session file found but user is not logged in. Deleting session file.")
-		return os.Remove(sessionFile)
-	}
-	return nil
-}
-
-func (s *Session) IsRecent() bool {
+func (s *Session) isRecent() bool {
 	if s.mtime.IsZero() {
 		return false
 	}
@@ -142,7 +105,7 @@ func (s *Session) IsRecent() bool {
 
 func (s *Session) check() error {
 	s.G().Log.Debug("+ Checking session")
-	if s.IsRecent() && s.checked {
+	if s.isRecent() && s.checked {
 		s.G().Log.Debug("- session is recent, short-circuiting")
 		s.valid = true
 		return nil
@@ -177,7 +140,7 @@ func (s *Session) check() error {
 		s.uid = uid
 		nu := NewNormalizedUsername(username)
 		s.username = &nu
-		s.SetCsrf(csrf)
+		s.csrf = csrf
 	} else {
 		s.G().Log.Notice("Stored session expired")
 		s.Invalidate()
@@ -204,12 +167,7 @@ func (s *Session) HasSessionToken() bool {
 	return len(s.token) > 0
 }
 
-func (s *Session) IsValid() bool {
-	return s.valid
-}
-
 func (s *Session) postLogout() error {
-
 	_, err := s.G().API.Post(APIArg{
 		SessionR:    s,
 		Endpoint:    "logout",
@@ -234,7 +192,7 @@ func (s *Session) loadAndCheck() (bool, error) {
 	if s.HasSessionToken() {
 		err = s.check()
 	}
-	return s.IsValid(), err
+	return s.valid, err
 }
 
 func (s *Session) loadAndCheckProvisioned() (bool, error) {

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -252,8 +252,8 @@ func (s *SKB) RawUnlockedKey() []byte {
 }
 
 func (s *SKB) unlockSecretKeyFromSecretRetriever(secretRetriever SecretRetriever) (key GenericKey, err error) {
-	if key = s.decryptedSecret; key != nil {
-		return
+	if s.decryptedSecret != nil {
+		return s.decryptedSecret, nil
 	}
 
 	var unlocked []byte
@@ -262,14 +262,14 @@ func (s *SKB) unlockSecretKeyFromSecretRetriever(secretRetriever SecretRetriever
 		unlocked = s.Priv.Data
 	case LKSecVersion:
 		unlocked, err = s.lksUnlockWithSecretRetriever(secretRetriever)
+		if err != nil {
+			return nil, err
+		}
 	default:
-		err = BadKeyError{fmt.Sprintf("Can't unlock secret from secret retriever with protection type %d", int(s.Priv.Encryption))}
+		return nil, BadKeyError{fmt.Sprintf("Can't unlock secret from secret retriever with protection type %d", int(s.Priv.Encryption))}
 	}
 
-	if err == nil {
-		key, err = s.parseUnlocked(unlocked)
-	}
-	return
+	return s.parseUnlocked(unlocked)
 }
 
 // unverifiedPassphraseStream takes a passphrase as a parameter and
@@ -438,7 +438,7 @@ func (s *SKB) lksUnlockWithSecretRetriever(secretRetriever SecretRetriever) (unl
 	}
 	lks := NewLKSecWithFullSecret(secret, s.uid, s.G())
 	unlocked, _, err = lks.Decrypt(nil, s.Priv.Data)
-	return
+	return unlocked, err
 }
 
 func (s *SKB) SetUID(uid keybase1.UID) {
@@ -663,8 +663,8 @@ func (s *SKB) UnlockWithStoredSecret(secretRetriever SecretRetriever) (ret Gener
 		s.G().Log.Debug("- UnlockWithStoredSecret -> %s", ErrToOk(err))
 	}()
 
-	if ret = s.decryptedSecret; ret != nil {
-		return
+	if s.decryptedSecret != nil {
+		return s.decryptedSecret, nil
 	}
 
 	return s.unlockSecretKeyFromSecretRetriever(secretRetriever)
@@ -779,6 +779,7 @@ func (s *SKB) PromptAndUnlock(arg SecretKeyPromptArg, which string, secretStore 
 	// First try to unlock without prompting the user.
 	ret, err = s.UnlockNoPrompt(arg.LoginContext, secretStore, lksPreload)
 	if err == nil {
+		s.G().Log.Debug("| PromptAndUnlock: UnlockNoPrompt success")
 		return
 	}
 	if err != errUnlockNotPossible {

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -158,11 +158,20 @@ func (tc *TestContext) MakePGPKey(id string) (*PGPKeyBundle, error) {
 	return GeneratePGPKeyBundle(arg, tc.G.UI.GetLogUI())
 }
 
-// ResetLoginStateForTest simulates a shutdown and restart (for client
-// state). Used by tests that need to clear out cached login state
-// without logging out.
+// ResetLoginState simulates a shutdown and restart (for client
+// state). Used by tests that need to clear out cached login
+// state.
 func (tc *TestContext) ResetLoginState() {
 	tc.G.createLoginState()
+}
+
+// ClearLoginStateSecretCaches removes the stream cache and the cached
+// secret keys.
+func (tc *TestContext) ClearLoginStateSecretCaches() {
+	tc.G.LoginState().Account(func(a *Account) {
+		a.ClearStreamCache()
+		a.ClearCachedSecretKeys()
+	}, "TestContext - ClearLoginStateSecretCaches")
 }
 
 func (tc TestContext) ClearAllStoredSecrets() error {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -181,13 +181,16 @@ func (d *Service) Run() (err error) {
 	// If daemon and they were logged in before, then try logging in
 	// automatically.
 	if d.isDaemon {
-		in := d.G().Env.GetConfig().GetLoggedIn()
-		if in {
+		if d.G().Env.GetConfig().GetLoggedIn() {
 			un := d.G().Env.GetUsername()
-			d.G().Log.Debug("user %q was previously logged in, trying autologin", un)
+			d.G().Log.Debug("autologin: user %q was previously logged in, trying autologin", un)
 			if err := d.G().LoginState().LoginWithStoredSecret(un.String(), nil); err != nil {
-				d.G().Log.Debug("autologin %q failed: %s", un, err)
+				d.G().Log.Debug("autologin: %q failed: %s", un, err)
+			} else {
+				d.G().Log.Debug("autologin: success")
 			}
+		} else {
+			d.G().Log.Debug("autologin: logged_in config flag not set, skipping autologin")
 		}
 	}
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -178,6 +178,19 @@ func (d *Service) Run() (err error) {
 		}
 	}
 
+	// If daemon and they were logged in before, then try logging in
+	// automatically.
+	if d.isDaemon {
+		in := d.G().Env.GetConfig().GetLoggedIn()
+		if in {
+			un := d.G().Env.GetUsername()
+			d.G().Log.Debug("user %q was previously logged in, trying autologin", un)
+			if err := d.G().LoginState().LoginWithStoredSecret(un.String(), nil); err != nil {
+				d.G().Log.Debug("autologin %q failed: %s", un, err)
+			}
+		}
+	}
+
 	d.checkTrackingEveryHour()
 
 	d.G().ExitCode, err = d.ListenLoopWithStopper(l)


### PR DESCRIPTION
Here are the three parts of CORE-2640:

1. session.json is gone, session only stays in memory.
2. in standalone mode, autologin in engine if session or device prereq (to get session in memory)
3. when service starts, attempt to autologin with stored secret.

There are some tickets after this (CORE-2635, CORE-2638) that will clean up the logged in state confusion as well as the Device/Session engine prereqs.

r? @maxtaco 