### PR TITLE
stop treating eldest PGP keys as implicitly tracked

### DIFF
--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -439,7 +439,7 @@ func (ui BaseIdentifyUI) DisplayKey(key keybase1.IdentifyKey) {
 	}
 	if key.TrackDiff != nil {
 		mark := CHECK
-		if key.TrackDiff.Type == keybase1.TrackDiffType_NEW_ELDEST {
+		if key.TrackDiff.Type == keybase1.TrackDiffType_NEW_ELDEST || key.TrackDiff.Type == keybase1.TrackDiffType_REVOKED {
 			mark = BADX
 		}
 		msg := mark + " " + trackDiffToColoredString(*key.TrackDiff)

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -461,18 +461,6 @@ func (l *TrackChainLink) GetTrackedKeys() ([]TrackedKey, error) {
 
 	var res []TrackedKey
 
-	// If the eldest kid in this tracking statement is a PGP key, it's
-	// implicitly tracked, in addition to the "pgp_keys" section that follows.
-	// If there is no eldest kid tracked, just skip this step.
-	eldestKeyJSON := l.payloadJSON.AtPath("body.track.key")
-	eldestTrackedKey, err := trackedKeyFromJSON(eldestKeyJSON)
-	if err == nil {
-		if eldestTrackedKey.Fingerprint != nil {
-			res = append(res, eldestTrackedKey)
-			set[eldestTrackedKey.KID] = true
-		}
-	}
-
 	pgpKeysJSON := l.payloadJSON.AtPath("body.track.pgp_keys")
 	if !pgpKeysJSON.IsNil() {
 		n, err := pgpKeysJSON.Len()


### PR DESCRIPTION
I added this in e1132d7d80771786d733861ba0fa380c501cc79d, but it broke
the case where your eldest PGP key is in fact revoked. Rather than
trying to do whacky seqno tricks to figure out whether you "would've"
tracked the key, just revert the change. Users with old tracking
statements will continue to see not-strictly-necessary popups, but
that will gradually go away as all the old links get replaced.

r? @maxtaco @patrickxb 