### PR TITLE
Fix textAlign check on <Input/>

### DIFF
--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -54,7 +54,7 @@ export default class Input extends Component {
       marginTop: 6
     }
     const inputStyle = this.props.multiLine ? multiLineStyleFix : {height: 'auto'}
-    const alignStyle = {textAlign: 'center', ...{textAlign: this.props.style && this.props.style.textAlign}}
+    const alignStyle = this.props.style && this.props.style.textAlign ? this.props.style.textAlign : {textAlign: 'center'}
     return (
       <div style={{...style, ...this.props.style}} onClick={() => { this._textField && this._textField.focus() }}>
         <TextField

--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -54,7 +54,7 @@ export default class Input extends Component {
       marginTop: 6
     }
     const inputStyle = this.props.multiLine ? multiLineStyleFix : {height: 'auto'}
-    const alignStyle = this.props.style && this.props.style.textAlign ? this.props.style.textAlign : {textAlign: 'center'}
+    const alignStyle = this.props.style && this.props.style.textAlign ? {textAlign: this.props.style.textAlign} : {textAlign: 'center'}
     return (
       <div style={{...style, ...this.props.style}} onClick={() => { this._textField && this._textField.focus() }}>
         <TextField


### PR DESCRIPTION
@keybase/react-hackers 

Oops -- I added a commit to allow both left-aligned (for the menubar widget) and center-aligned (for pinentry) <input/> text fields, but the syntax doesn't do what I thought it did, and it made everything left-aligned.  I'll use the verbose syntax since I've tested that.  Please could I get a thumb tonight, since the bug's in master now?  Sorry for the hassle!