### PR TITLE
remote manager WIP

### DIFF
--- a/desktop/renderer/remote-manager.js
+++ b/desktop/renderer/remote-manager.js
@@ -11,6 +11,7 @@ import {onForce as updateOnForce, onPauseCancel as updateOnPauseCancel} from '..
 // $FlowIssue platform files
 import RemoteComponent from './remote-component'
 import flags from '../shared/util/feature-flags'
+import {remoteComponentProps as trackerComponentProps} from '../shared/tracker'
 
 import type {GUIEntryFeatures} from '../shared/constants/types/flow-types'
 import type {Action, Dispatch} from '../shared/constants/types/flux'
@@ -77,23 +78,8 @@ class RemoteManager extends Component {
 
   trackerRemoteComponents () {
     const {trackers} = this.props
-    const windowsOpts = flags.tracker2
-      ? {height: 470, width: 320}
-      : {height: 339, width: 520}
     return Object.keys(trackers).filter(username => !trackers[username].closed).map(username => (
-      <RemoteComponent
-        windowsOpts={windowsOpts}
-        title={`tracker - ${username}`}
-        waitForState
-        ignoreNewProps
-        hidden={trackers[username].hidden}
-        onRemoteClose={() => this.props.trackerOnClose(username)}
-        component='tracker'
-        username={username}
-        startTimer={this.props.trackerStartTimer}
-        stopTimer={this.props.trackerStopTimer}
-        selectorParams={username}
-        key={username} />
+      <RemoteComponent {...trackerComponentProps(username, trackers[username], this.props)} waitForState ignoreNewProps />
     ))
   }
 

--- a/shared/pinentry/index.js
+++ b/shared/pinentry/index.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import PinentryRender from './index.render'
+import flags from '../util/feature-flags'
 
 class Pinentry extends Component {
   render () {
@@ -20,3 +21,18 @@ export default connect(
     return state.pinentry.pinentryStates[sessionID]
   }
 )(Pinentry)
+
+export function remoteComponentProps (pSessionID: string, managerProps: Object): Object {
+  const sid = parseInt(pSessionID, 10)
+  return {
+    component: 'pinentry',
+    key: 'pinentry:' + pSessionID,
+    onCancel: () => managerProps.pinentryOnCancel(sid),
+    onRemoteClose: () => managerProps.pinentryOnCancel(sid),
+    onSubmit: managerProps.pinentryOnSubmit.bind(null, sid),
+    sessionID: sid,
+    title: 'Pinentry',
+    waitForState: true,
+    windowsOpts: flags.dz2 ? {width: 500, height: 260} : {width: 513, height: 260}
+  }
+}

--- a/shared/tracker/index.js
+++ b/shared/tracker/index.js
@@ -154,3 +154,18 @@ export function selector (username: string): (store: Object) => Object {
     }
   }
 }
+
+export function remoteComponentProps (username: string, store: Object, managerProps: Object): Object {
+  return {
+    windowsOpts: flags.tracker2 ? {height: 470, width: 320} : {height: 339, width: 520},
+    title: `tracker - ${username}`,
+    hidden: store.hidden,
+    component: 'tracker',
+    username,
+    selectorParams: username,
+    key: username,
+    onRemoteClose: () => managerProps.trackerOnClose(username),
+    startTimer: managerProps.trackerStartTimer,
+    stopTimer: managerProps.trackerStopTimer
+  }
+}

--- a/shared/tracker/index.js
+++ b/shared/tracker/index.js
@@ -8,10 +8,13 @@ import * as trackerActions from '../actions/tracker'
 import {bindActionCreators} from 'redux'
 import {metaNone} from '../constants/tracker'
 
+import {onClose, startTimer, stopTimer} from '../actions/tracker'
+
 import type {RenderProps} from './render'
 import type {UserInfo} from './bio.render'
 import type {Proof} from './proofs.render'
 import type {SimpleProofState} from '../constants/tracker'
+import type {Dispatch} from '../constants/types/flux'
 
 import type {TrackSummary} from '../constants/types/flow-types'
 
@@ -155,16 +158,30 @@ export function selector (username: string): (store: Object) => Object {
   }
 }
 
-export function remoteComponentProps (username: string, store: Object, managerProps: Object): Object {
+export type RemoteActions = {
+  onClose: (username: string) => void,
+  startTimer: () => void,
+  stopTimer: () => void
+}
+
+export function remoteComponentActions (dispatch: Dispatch) : RemoteActions {
+  return bindActionCreators({
+    onClose,
+    startTimer,
+    stopTimer
+  })
+}
+
+export function remoteComponentProps (username: string, store: Object, remoteActions: RemoteActions): Object {
   return {
     component: 'tracker',
     hidden: store.hidden,
     ignoreNewProps: true,
     key: username,
-    onRemoteClose: () => managerProps.trackerOnClose(username),
+    onRemoteClose: () => remoteActions.onClose(username),
     selectorParams: username,
-    startTimer: managerProps.trackerStartTimer,
-    stopTimer: managerProps.trackerStopTimer,
+    startTimer: remoteActions.startTimer,
+    stopTimer: remoteActions.stopTimer,
     title: `tracker - ${username}`,
     username,
     waitForState: true,

--- a/shared/tracker/index.js
+++ b/shared/tracker/index.js
@@ -169,7 +169,7 @@ export function remoteComponentActions (dispatch: Dispatch) : RemoteActions {
     onClose,
     startTimer,
     stopTimer
-  })
+  }, dispatch)
 }
 
 export function remoteComponentProps (username: string, store: Object, remoteActions: RemoteActions): Object {

--- a/shared/tracker/index.js
+++ b/shared/tracker/index.js
@@ -157,15 +157,17 @@ export function selector (username: string): (store: Object) => Object {
 
 export function remoteComponentProps (username: string, store: Object, managerProps: Object): Object {
   return {
-    windowsOpts: flags.tracker2 ? {height: 470, width: 320} : {height: 339, width: 520},
-    title: `tracker - ${username}`,
-    hidden: store.hidden,
     component: 'tracker',
-    username,
-    selectorParams: username,
+    hidden: store.hidden,
+    ignoreNewProps: true,
     key: username,
     onRemoteClose: () => managerProps.trackerOnClose(username),
+    selectorParams: username,
     startTimer: managerProps.trackerStartTimer,
-    stopTimer: managerProps.trackerStopTimer
+    stopTimer: managerProps.trackerStopTimer,
+    title: `tracker - ${username}`,
+    username,
+    waitForState: true,
+    windowsOpts: flags.tracker2 ? {height: 470, width: 320} : {height: 339, width: 520}
   }
 }

--- a/shared/update/index.js
+++ b/shared/update/index.js
@@ -22,3 +22,36 @@ Update.propTypes = {
   type: React.PropTypes.oneOf(['confirm', 'paused']).isRequired,
   options: React.PropTypes.any
 }
+
+export function remoteComponentPropsUpdate (managerProps: Object): Object {
+  return {
+    component: 'update',
+    onRemoteClose: () => managerProps.updateOnCancel(),
+    options: {
+      onCancel: () => managerProps.updateOnCancel(),
+      onSkip: () => managerProps.updateOnSkip(),
+      onSnooze: () => managerProps.updateOnSnooze(),
+      onUpdate: () => managerProps.updateOnUpdate(),
+      setAlwaysUpdate: alwaysUpdate => managerProps.setAlwaysUpdate(alwaysUpdate)
+    },
+    title: 'Update',
+    type: 'confirm',
+    waitForState: true,
+    windowsOpts: {width: 480, height: 430}
+  }
+}
+
+export function remoteComponentPropsPaused (managerProps: Object): Object {
+  return {
+    component: 'update',
+    onRemoteClose: () => managerProps.updateOnPauseCancel(),
+    title: 'Update',
+    waitForState: true,
+    windowsOpts: {width: 500, height: 309},
+    type: 'paused',
+    options: {
+      onCancel: () => managerProps.updateOnPauseCancel(),
+      onForce: () => managerProps.updateOnForce()
+    }
+  }
+}


### PR DESCRIPTION
@MarcoPolo let's discuss. the idea is to move all this component specific stuff out of remote-manager and into the smart components themselves. i've exported 2 functions, one to get the props, and one to get the actions since those are created in 2 different places. let's discuss

Focus on the tracker component, ignore update/pinenentry/etc