### PR TITLE
report the full client version to the API

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -347,7 +348,8 @@ func (a *InternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
 	}
 	if a.G().Env.GetTorMode().UseHeaders() {
 		req.Header.Set("User-Agent", UserAgent)
-		req.Header.Set("X-Keybase-Client", IdentifyAs)
+		identifyAs := GoClientID + " v" + VersionString() + " " + runtime.GOOS
+		req.Header.Set("X-Keybase-Client", identifyAs)
 	}
 }
 

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -51,7 +51,6 @@ const (
 	APIURIPathPrefix     = "/_/api/" + APIVersion
 	DaemonPort           = 40933
 	GoClientID           = "keybase.io go client"
-	IdentifyAs           = GoClientID + " v" + Version + " " + runtime.GOOS
 	KeybaseSaltpackBrand = "KEYBASE"
 )
 


### PR DESCRIPTION
This lets us distinguish between prerelease and prod clients.

I tested this manually on my machine. The identity string should be the same except for the inclusion of the build number. Related to https://keybase.atlassian.net/browse/CORE-2677.

r? @maxtaco @cjb 