### PR TITLE
fix the PrereleaseBuild ldflag in Linux and Windows builds

### DIFF
--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -27,7 +27,9 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol"
 )
 
-// PrereleaseBuild can be set at compile time for prerelease builds
+// PrereleaseBuild can be set at compile time for prerelease builds.
+// CAUTION: Don't change the name of this variable without grepping for
+// occurrences in shell scripts!
 var PrereleaseBuild string
 
 // VersionString returns semantic version string

--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -40,7 +40,7 @@ ldflags=""
 if [ "$mode" != "production" ] ; then
   # The non-production build number is everything in the version after the hyphen.
   build_number="$(echo -n "$version" | sed 's/.*-//')"
-  ldflags="-X github.com/keybase/client/go/libkb.CustomBuild=$build_number"
+  ldflags="-X github.com/keybase/client/go/libkb.PrereleaseBuild=$build_number"
 fi
 echo "-ldflags '$ldflags'"
 

--- a/packaging/windows/build_prerelease.cmd
+++ b/packaging/windows/build_prerelease.cmd
@@ -6,7 +6,7 @@ for /f %%i in ('winresource.exe -cv') do set KEYBASE_VERSION=%%i
 echo %KEYBASE_VERSION%
 for /f %%i in ('winresource.exe -cb') do set KEYBASE_BUILD=%%i
 echo %KEYBASE_BUILD%
-go build -a -tags "prerelease production" -ldflags="-X github.com/keybase/client/go/libkb.CustomBuild=%KEYBASE_BUILD%"
+go build -a -tags "prerelease production" -ldflags="-X github.com/keybase/client/go/libkb.PrereleaseBuild=%KEYBASE_BUILD%"
 
 :: Then build kbfsdokan
 pushd %GOPATH%\src\github.com\keybase\kbfs\kbfsdokan


### PR DESCRIPTION
https://github.com/keybase/client/pull/2230 changed the name of the
variable we use to store the prerelease build number, but shell scripts
were relying on the name of that variable, and I forgot to update them.

r? @gabriel @zanderz 