### PR TITLE
Don't reset the whole state.

### DIFF
--- a/shared/reducers/index.js
+++ b/shared/reducers/index.js
@@ -73,9 +73,9 @@ if (__DEV__) {
 }
 
 export default function (state: Object = {}, action: any): State {
-  // Reset our state if we logout
+  // Reset most of out state if we logout
   if (action.type === logoutDone) {
-    state = {}
+    state = {tracker: state.tracker, pinentry: state.pinentry, update: state.update}
   }
   return reducer(state, action)
 }


### PR DESCRIPTION
@keybase/react-hackers 
We keep track of whether we've registered listeners in the store, when we
log out those listeners are still active, so we shouldn't forget about
them.

We wiped the store on logout in this commit: https://github.com/keybase/client/commit/b1711c2bbc99df036b03563c510de4f7befec262

That led to the pinentry reducer thinking it hadn't registered a listener and not acting on the `newPinentry` action.


This is one solution that's kinda brittle. If we add something else to the store that registers listeners we have to remember to add it here so that it doesn't get wiped.