### PR TITLE
Include HasActiveDevice flag in NoMatchingGPGKeysError

### DIFF
--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -27,6 +27,8 @@ type loginProvision struct {
 	username      string
 	devname       string
 	cleanupOnErr  bool
+	hasPGP        bool
+	hasDevice     bool
 }
 
 // gpgInterface defines the portions of gpg client that provision
@@ -470,19 +472,17 @@ func (e *loginProvision) checkArg() error {
 
 func (e *loginProvision) route(ctx *Context) error {
 	// check if User has any pgp keys, active devices
-	pgp := false
-	device := false
 	ckf := e.arg.User.GetComputedKeyFamily()
 	if ckf != nil {
-		pgp = len(ckf.GetActivePGPKeys(false)) > 0
-		device = ckf.HasActiveDevice()
+		e.hasPGP = len(ckf.GetActivePGPKeys(false)) > 0
+		e.hasDevice = ckf.HasActiveDevice()
 	}
 
-	if device {
-		return e.chooseDevice(ctx, pgp)
+	if e.hasDevice {
+		return e.chooseDevice(ctx, e.hasPGP)
 	}
 
-	if pgp {
+	if e.hasPGP {
 		return e.tryPGP(ctx)
 	}
 
@@ -741,7 +741,7 @@ func (e *loginProvision) newGPGMatchErr(keys []*libkb.PGPKeyBundle) error {
 	for i, k := range keys {
 		fps[i] = k.GetFingerprint().ToQuads()
 	}
-	return libkb.NoMatchingGPGKeysError{Fingerprints: fps}
+	return libkb.NoMatchingGPGKeysError{Fingerprints: fps, HasActiveDevice: e.hasDevice}
 }
 
 func (e *loginProvision) gpgSignKey(ctx *Context, fp *libkb.PGPFingerprint) (libkb.GenericKey, error) {

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1360,7 +1360,8 @@ func (e BadInvitationCodeError) Error() string {
 }
 
 type NoMatchingGPGKeysError struct {
-	Fingerprints []string
+	Fingerprints    []string
+	HasActiveDevice bool // true if the user has an active device that they chose not to use
 }
 
 func (e NoMatchingGPGKeysError) Error() string {

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -312,6 +312,8 @@ func ImportStatusAsError(s *keybase1.Status) error {
 			switch field.Key {
 			case "fingerprints":
 				ret.Fingerprints = strings.Split(field.Value, ",")
+			case "has_active_device":
+				ret.HasActiveDevice = true
 			}
 		}
 		return ret
@@ -1059,13 +1061,17 @@ func (e WrongCryptoFormatError) ToStatus() keybase1.Status {
 }
 
 func (e NoMatchingGPGKeysError) ToStatus() keybase1.Status {
-	return keybase1.Status{
+	s := keybase1.Status{
 		Code: SCKeyNoMatchingGPG,
 		Name: "SC_KEY_NO_MATCHING_GPG",
 		Fields: []keybase1.StringKVPair{
 			{"fingerprints", strings.Join(e.Fingerprints, ",")},
 		},
 	}
+	if e.HasActiveDevice {
+		s.Fields = append(s.Fields, keybase1.StringKVPair{Key: "has_active_device", Value: "1"})
+	}
+	return s
 }
 
 func (e DeviceAlreadyProvisionedError) ToStatus() keybase1.Status {


### PR DESCRIPTION
r? @chrisnojima 

cc: @malgorithms 

(what we discussed yesterday afternoon:  error now includes "has_active_device" so clients can give better user message)