### PR TITLE
Don't require default destination (it's not required for windows and linux)

### DIFF
--- a/go/client/cmd_update.go
+++ b/go/client/cmd_update.go
@@ -225,9 +225,6 @@ func parseOptions(ctx *cli.Context, options *keybase1.UpdateOptions) error {
 	options.Force = ctx.Bool("force")
 	options.SignaturePath = ctx.String("signature")
 
-	if options.DestinationPath == "" {
-		return fmt.Errorf("No default destination path for this environment")
-	}
 	return nil
 }
 


### PR DESCRIPTION
See https://github.com/keybase/keybase-issues/issues/2055