### PR TITLE
Let reducers decide how they want to reset themselves

### DIFF
--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -1,5 +1,6 @@
 /* @flow */
 import * as Constants from '../../constants/login'
+import * as CommonConstants from '../../constants/common'
 import {isMobile} from '../../constants/platform'
 import {navigateTo, routeAppend} from '../router'
 import engine from '../../engine'
@@ -276,6 +277,7 @@ export function logoutDone () : AsyncAction {
   // We've logged out, let's check our current status
   return (dispatch, getState) => {
     dispatch({type: Constants.logoutDone, payload: undefined})
+    dispatch({type: CommonConstants.resetStore, payload: undefined})
 
     dispatch(switchTab(loginTab))
     dispatch(navBasedOnLoginState())

--- a/shared/constants/common.js
+++ b/shared/constants/common.js
@@ -3,4 +3,4 @@
 import type {TypedAction} from '../constants/types/flux'
 
 export const resetStore = 'common:resetStore'
-export type CheckInviteCode = TypedAction< 'common:resetStore', void, void>
+export type ResetStore = TypedAction< 'common:resetStore', void, void>

--- a/shared/constants/common.js
+++ b/shared/constants/common.js
@@ -1,0 +1,6 @@
+/* @flow */
+
+import type {TypedAction} from '../constants/types/flux'
+
+export const resetStore = 'common:resetStore'
+export type CheckInviteCode = TypedAction< 'common:resetStore', void, void>

--- a/shared/reducers/config.js
+++ b/shared/reducers/config.js
@@ -27,7 +27,7 @@ const initialState: ConfigState = {
 export default function (state: ConfigState = initialState, action: Action): ConfigState {
   switch (action.type) {
     case CommonConstants.resetStore:
-      return initialState
+      return {...initialState}
 
     case Constants.startupLoading:
       return {

--- a/shared/reducers/config.js
+++ b/shared/reducers/config.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import * as Constants from '../constants/config'
+import * as CommonConstants from '../constants/common'
 
 import type {Action} from '../constants/types/flux'
 import type {Config, GetCurrentStatusRes, ExtendedStatus} from '../constants/types/flow-types'
@@ -25,6 +26,9 @@ const initialState: ConfigState = {
 
 export default function (state: ConfigState = initialState, action: Action): ConfigState {
   switch (action.type) {
+    case CommonConstants.resetStore:
+      return initialState
+
     case Constants.startupLoading:
       return {
         ...state,

--- a/shared/reducers/devices.js
+++ b/shared/reducers/devices.js
@@ -12,7 +12,7 @@ const initialState = {
 export default function (state = initialState, action) {
   switch (action.type) {
     case CommonConstants.resetStore:
-      return initialState
+      return {...initialState}
 
     case Constants.loadingDevices:
       return {

--- a/shared/reducers/devices.js
+++ b/shared/reducers/devices.js
@@ -1,4 +1,5 @@
 import * as Constants from '../constants/devices'
+import * as CommonConstants from '../constants/common'
 
 const initialState = {
   waitingForServer: false,
@@ -10,6 +11,9 @@ const initialState = {
 
 export default function (state = initialState, action) {
   switch (action.type) {
+    case CommonConstants.resetStore:
+      return initialState
+
     case Constants.loadingDevices:
       return {
         ...state,

--- a/shared/reducers/favorite.js
+++ b/shared/reducers/favorite.js
@@ -1,6 +1,8 @@
 /* @flow */
 
 import * as Constants from '../constants/favorite'
+import * as CommonConstants from '../constants/common'
+
 import type {FavoriteAction} from '../constants/favorite'
 import type {Folder} from '../constants/types/flow-types'
 
@@ -14,6 +16,9 @@ const initialState = {
 
 export default function (state: State = initialState, action: FavoriteAction): State {
   switch (action.type) {
+    case CommonConstants.resetStore:
+      return initialState
+
     case Constants.favoriteList:
       return {
         ...state,

--- a/shared/reducers/favorite.js
+++ b/shared/reducers/favorite.js
@@ -17,7 +17,7 @@ const initialState = {
 export default function (state: State = initialState, action: FavoriteAction): State {
   switch (action.type) {
     case CommonConstants.resetStore:
-      return initialState
+      return {...initialState}
 
     case Constants.favoriteList:
       return {

--- a/shared/reducers/index.js
+++ b/shared/reducers/index.js
@@ -16,7 +16,8 @@ import favorite from './favorite'
 import updateConfirm from './update-confirm'
 import updatePaused from './update-paused'
 import signup from './signup'
-import {logoutDone} from '../constants/login'
+
+import {resetStore} from '../constants/common.js'
 
 import devEdit from './dev-edit'
 
@@ -72,4 +73,12 @@ if (__DEV__) {
   reducer = combinedReducer
 }
 
-export default reducer
+export default function (state: State, action: any): State {
+  // Warn if any keys did not change after a resetStore action
+  if (action.type === resetStore) {
+    const nextState = reducer(state, action)
+    Object.keys(nextState).forEach(k => nextState[k] === state[k] && console.warn('Key %s did not change after resetStore action', k))
+    return nextState
+  }
+  return reducer(state, action)
+}

--- a/shared/reducers/index.js
+++ b/shared/reducers/index.js
@@ -75,7 +75,7 @@ if (__DEV__) {
 
 export default function (state: State, action: any): State {
   // Warn if any keys did not change after a resetStore action
-  if (action.type === resetStore) {
+  if (__DEV__ && action.type === resetStore) {
     const nextState = reducer(state, action)
     Object.keys(nextState).forEach(k => nextState[k] === state[k] && console.warn('Key %s did not change after resetStore action', k))
     return nextState

--- a/shared/reducers/index.js
+++ b/shared/reducers/index.js
@@ -72,10 +72,4 @@ if (__DEV__) {
   reducer = combinedReducer
 }
 
-export default function (state: Object = {}, action: any): State {
-  // Reset most of out state if we logout
-  if (action.type === logoutDone) {
-    state = {tracker: state.tracker, pinentry: state.pinentry, update: state.update}
-  }
-  return reducer(state, action)
-}
+export default reducer

--- a/shared/reducers/login.js
+++ b/shared/reducers/login.js
@@ -104,7 +104,7 @@ export default function (state: LoginState = initialState, action: any): LoginSt
 
   switch (action.type) {
     case CommonConstants.resetStore:
-      return initialState
+      return {...initialState}
 
     case ConfigConstants.statusLoaded:
       if (action.error || action.payload == null) {

--- a/shared/reducers/login.js
+++ b/shared/reducers/login.js
@@ -2,6 +2,7 @@
 
 import * as Constants from '../constants/login'
 import * as ConfigConstants from '../constants/config'
+import * as CommonConstants from '../constants/common'
 import Immutable from 'immutable'
 import HiddenString from '../util/hidden-string'
 import {isMobile} from '../constants/platform'
@@ -102,6 +103,9 @@ export default function (state: LoginState = initialState, action: any): LoginSt
   let toMerge = null
 
   switch (action.type) {
+    case CommonConstants.resetStore:
+      return initialState
+
     case ConfigConstants.statusLoaded:
       if (action.error || action.payload == null) {
         return state

--- a/shared/reducers/pinentry.js
+++ b/shared/reducers/pinentry.js
@@ -43,13 +43,12 @@ export default function (state: RootPinentryState = initialState, action: Pinent
     case CommonConstants.resetStore:
       if (state.started === 1) {
         return {
+          ...initialState,
           started: 1,
           pinentryStates: {}
         }
       } else {
-        return {
-          started: 0
-        }
+        return {...initialState}
       }
     case Constants.registerPinentryListener:
       if (action.payload && action.payload.started) {

--- a/shared/reducers/pinentry.js
+++ b/shared/reducers/pinentry.js
@@ -21,47 +21,38 @@ export type PinentryState = {
   retryLabel: ?string
 }
 
-// Hack until flow allows disjoint unions by boolean types: https://github.com/facebook/flow/issues/577
 export type RootPinentryState = {
-  started: 1,
+  started: boolean,
   pinentryStates: {
     [key: number]: PinentryState
   }
-} | {
-  started: 0
 }
 
 type EnabledFeatures = {[key: string]: Feature}
 
 const initialState: RootPinentryState = {
-  started: 0
+  started: false,
+  pinentryStates: {}
 }
 
 export default function (state: RootPinentryState = initialState, action: PinentryActions): RootPinentryState {
   const sessionID: ?number = (action.payload && action.payload.sessionID != null) ? action.payload.sessionID : null
   switch (action.type) {
     case CommonConstants.resetStore:
-      if (state.started === 1) {
-        return {
-          ...initialState,
-          started: 1,
-          pinentryStates: {}
-        }
-      } else {
-        return {...initialState}
+      return {
+        started: state.started,
+        ...initialState
       }
     case Constants.registerPinentryListener:
       if (action.payload && action.payload.started) {
         return {
-          started: 1,
+          started: true,
           pinentryStates: {}
         }
       }
-      return {
-        started: 0
-      }
+      return initialState
     case Constants.newPinentry:
-      if (state.started === 1 && action.payload && sessionID != null) {
+      if (state.started && action.payload && sessionID != null) {
         const features = action.payload.features
         // Long form function to add annotation to help flow
         const reducer = function (m, f): EnabledFeatures {
@@ -86,7 +77,7 @@ export default function (state: RootPinentryState = initialState, action: Pinent
       }
       return state
     default:
-      if (state.started === 1 && sessionID != null) {
+      if (state.started && sessionID != null) {
         return {
           ...state,
           pinentryStates: {

--- a/shared/reducers/pinentry.js
+++ b/shared/reducers/pinentry.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import * as Constants from '../constants/pinentry'
+import * as CommonConstants from '../constants/common'
 
 import type {Feature, GUIEntryFeatures} from '../constants/types/flow-types'
 import type {PinentryActions} from '../constants/pinentry'
@@ -39,6 +40,17 @@ const initialState: RootPinentryState = {
 export default function (state: RootPinentryState = initialState, action: PinentryActions): RootPinentryState {
   const sessionID: ?number = (action.payload && action.payload.sessionID != null) ? action.payload.sessionID : null
   switch (action.type) {
+    case CommonConstants.resetStore:
+      if (state.started === 1) {
+        return {
+          started: 1,
+          pinentryStates: {}
+        }
+      } else {
+        return {
+          started: 0
+        }
+      }
     case Constants.registerPinentryListener:
       if (action.payload && action.payload.started) {
         return {

--- a/shared/reducers/profile.js
+++ b/shared/reducers/profile.js
@@ -1,4 +1,5 @@
 import * as Constants from '../constants/profile'
+import * as CommonConstants from '../constants/common'
 import Immutable from 'immutable'
 
 const initialState = Immutable.Map()
@@ -7,6 +8,9 @@ export default function (state = initialState, action) {
   let update = null
 
   switch (action.type) {
+    case CommonConstants.resetStore:
+      return initialState
+
     case Constants.initProfile:
       update = {
         username: action.payload.username,

--- a/shared/reducers/profile.js
+++ b/shared/reducers/profile.js
@@ -9,7 +9,7 @@ export default function (state = initialState, action) {
 
   switch (action.type) {
     case CommonConstants.resetStore:
-      return initialState
+      return {...initialState}
 
     case Constants.initProfile:
       update = {

--- a/shared/reducers/search.js
+++ b/shared/reducers/search.js
@@ -1,6 +1,8 @@
 /* @flow */
 
 import * as Constants from '../constants/search'
+import * as CommonConstants from '../constants/common'
+
 import Immutable from 'immutable'
 
 import type {URI} from './router'
@@ -23,6 +25,8 @@ export default function (state: SearchState = initialState, action: any): Search
 
   return state.update(action.payload.base, oldValue => {
     switch (action.type) {
+      case CommonConstants.resetStore:
+        return initialState
       case Constants.initSearch:
         return Immutable.fromJS({
           base: action.payload.base,

--- a/shared/reducers/search.js
+++ b/shared/reducers/search.js
@@ -19,14 +19,16 @@ type SearchState = Immutable.Map<Base, SubSearchState>
 const initialState: SearchState = Immutable.Map()
 
 export default function (state: SearchState = initialState, action: any): SearchState {
+  if (action.type === CommonConstants.resetStore) {
+    return {...initialState}
+  }
+
   if (!action.payload || !action.payload.base) {
     return state
   }
 
   return state.update(action.payload.base, oldValue => {
     switch (action.type) {
-      case CommonConstants.resetStore:
-        return initialState
       case Constants.initSearch:
         return Immutable.fromJS({
           base: action.payload.base,

--- a/shared/reducers/signup.js
+++ b/shared/reducers/signup.js
@@ -43,7 +43,7 @@ const initialState: SignupState = {
 export default function (state: SignupState = initialState, action: SignupActions): SignupState {
   switch (action.type) {
     case CommonConstants.resetStore:
-      return initialState
+      return {...initialState}
 
     case Constants.checkInviteCode:
       if (action.error) {

--- a/shared/reducers/signup.js
+++ b/shared/reducers/signup.js
@@ -1,6 +1,8 @@
 /* @flow */
 
 import * as Constants from '../constants/signup'
+import * as CommonConstants from '../constants/common'
+
 import HiddenString from '../util/hidden-string'
 
 import type {SignupActions} from '../constants/signup'
@@ -40,6 +42,9 @@ const initialState: SignupState = {
 /* eslint-disable no-fallthrough */
 export default function (state: SignupState = initialState, action: SignupActions): SignupState {
   switch (action.type) {
+    case CommonConstants.resetStore:
+      return initialState
+
     case Constants.checkInviteCode:
       if (action.error) {
         return {

--- a/shared/reducers/tabbed-router.js
+++ b/shared/reducers/tabbed-router.js
@@ -18,24 +18,28 @@ type TabbedRouterState = MapADT2<'tabs', Immutable.Map<TabName, RouterState>, 'a
 
 const emptyRouterState: RouterState = createRouterState([], [])
 
-const initialState: TabbedRouterState = Immutable.fromJS(initTabbedRouterState({
-  // a map from tab name to router obj
-  tabs: {
-    [startupTab]: emptyRouterState,
-    [folderTab]: emptyRouterState,
-    [chatTab]: emptyRouterState,
-    [peopleTab]: emptyRouterState,
-    [devicesTab]: emptyRouterState,
-    [moreTab]: emptyRouterState,
-    [loginTab]: emptyRouterState
-  },
-  activeTab: loginTab
-}))
+function initialStateFn (): TabbedRouterState {
+  return Immutable.fromJS(initTabbedRouterState({
+    // a map from tab name to router obj
+    tabs: {
+      [startupTab]: emptyRouterState,
+      [folderTab]: emptyRouterState,
+      [chatTab]: emptyRouterState,
+      [peopleTab]: emptyRouterState,
+      [devicesTab]: emptyRouterState,
+      [moreTab]: emptyRouterState,
+      [loginTab]: emptyRouterState
+    },
+    activeTab: loginTab
+  }))
+}
+
+const initialState: TabbedRouterState = initialStateFn()
 
 export default function (state: TabbedRouterState = initialState, action: any): TabbedRouterState {
   switch (action.type) {
     case CommonConstants.resetStore:
-      return {...initialState}
+      return initialStateFn()
 
     case Constants.switchTab:
       return state.set('activeTab', action.payload)

--- a/shared/reducers/tabbed-router.js
+++ b/shared/reducers/tabbed-router.js
@@ -35,7 +35,7 @@ const initialState: TabbedRouterState = Immutable.fromJS(initTabbedRouterState({
 export default function (state: TabbedRouterState = initialState, action: any): TabbedRouterState {
   switch (action.type) {
     case CommonConstants.resetStore:
-      return initialState
+      return {...initialState}
 
     case Constants.switchTab:
       return state.set('activeTab', action.payload)

--- a/shared/reducers/tabbed-router.js
+++ b/shared/reducers/tabbed-router.js
@@ -8,6 +8,7 @@ import Immutable from 'immutable'
 import {subReducer as routerReducer, createRouterState} from './router'
 import {startupTab, folderTab, chatTab, peopleTab, devicesTab, moreTab, loginTab} from '../constants/tabs'
 import * as Constants from '../constants/tabbed-router'
+import * as CommonConstants from '../constants/common'
 import * as RouterConstants from '../constants/router'
 import {initTabbedRouterState} from '../local-debug'
 import type {RouterState} from './router'
@@ -33,6 +34,9 @@ const initialState: TabbedRouterState = Immutable.fromJS(initTabbedRouterState({
 
 export default function (state: TabbedRouterState = initialState, action: any): TabbedRouterState {
   switch (action.type) {
+    case CommonConstants.resetStore:
+      return initialState
+
     case Constants.switchTab:
       return state.set('activeTab', action.payload)
     case RouterConstants.navigateUp:

--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import * as Constants from '../constants/tracker'
+import * as CommonConstants from '../constants/common'
 
 import {normal, warning, error, checking} from '../constants/tracker'
 import {metaNew, metaUpgraded, metaUnreachable, metaDeleted} from '../constants/tracker'
@@ -250,6 +251,11 @@ export default function (state: State = initialState, action: Action): State {
   const username: string = (action.payload && action.payload.username) ? action.payload.username : ''
   const trackerState = username ? state.trackers[username] : null
   switch (action.type) {
+    case CommonConstants.resetStore:
+      return {
+        ...state,
+        trackers: {}
+      }
     case Constants.startTimer:
       return {
         ...state,

--- a/shared/reducers/unlock-folders.js
+++ b/shared/reducers/unlock-folders.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import * as Constants from '../constants/unlock-folders'
+import * as CommonConstants from '../constants/common'
 import HiddenString from '../util/hidden-string'
 
 import type {UnlockFolderActions, Device} from '../constants/unlock-folders'
@@ -22,6 +23,8 @@ const initialState: State = {
 export default function (state: State = initialState, action: UnlockFolderActions): State {
   // TODO: Fill out the rest of this reducer
   switch (action.type) {
+    case CommonConstants.resetStore:
+      return initialState
     case Constants.toPaperKeyInput:
       if (action.error) {
         return state

--- a/shared/reducers/unlock-folders.js
+++ b/shared/reducers/unlock-folders.js
@@ -24,7 +24,7 @@ export default function (state: State = initialState, action: UnlockFolderAction
   // TODO: Fill out the rest of this reducer
   switch (action.type) {
     case CommonConstants.resetStore:
-      return initialState
+      return {...initialState}
     case Constants.toPaperKeyInput:
       if (action.error) {
         return state

--- a/shared/reducers/update-confirm.js
+++ b/shared/reducers/update-confirm.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import * as Constants from '../constants/update'
+import * as CommonConstants from '../constants/common'
 
 import type {Asset, UpdateType} from '../constants/types/flow-types'
 import type {UpdateConfirmActions} from '../constants/update'
@@ -37,6 +38,11 @@ const initialState: UpdateConfirmState = {
 
 export default function (state: UpdateConfirmState = initialState, action: UpdateConfirmActions): UpdateConfirmState {
   switch (action.type) {
+    case CommonConstants.resetStore:
+      return {
+        ...initialState,
+        started: state.started
+      }
     case Constants.registerUpdateListener:
       return {
         ...state,

--- a/shared/reducers/update-paused.js
+++ b/shared/reducers/update-paused.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import * as Constants from '../constants/update'
+import * as CommonConstants from '../constants/common'
 
 import type {UpdatePausedActions} from '../constants/update'
 
@@ -14,6 +15,8 @@ const initialState: UpdatePausedState = {
 
 export default function (state: UpdatePausedState = initialState, action: UpdatePausedActions): UpdatePausedState {
   switch (action.type) {
+    case CommonConstants.resetStore:
+      return initialState
     case Constants.showUpdatePaused:
       return {
         ...state,

--- a/shared/reducers/update-paused.js
+++ b/shared/reducers/update-paused.js
@@ -16,7 +16,7 @@ const initialState: UpdatePausedState = {
 export default function (state: UpdatePausedState = initialState, action: UpdatePausedActions): UpdatePausedState {
   switch (action.type) {
     case CommonConstants.resetStore:
-      return initialState
+      return {...initialState}
     case Constants.showUpdatePaused:
       return {
         ...state,


### PR DESCRIPTION
Sequel to the critically acclaimed PR: https://github.com/keybase/client/pull/2278

Now with more resets!

@keybase/react-hackers 

The last solution was a bit brittle and not very flexible. Now we have the reducers decide how to reset their state. 

If a reducer doesn't explicitly reset its state on logout that state is persisted.