### PR TITLE
Cancel provisionee run when user cancels secret entry

### DIFF
--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -143,7 +143,8 @@ func (e *loginProvision) deviceWithType(ctx *Context, provisionerType keybase1.D
 		contxt, canceler = context.WithCancel(context.Background())
 		receivedSecret, err := ctx.ProvisionUI.DisplayAndPromptSecret(contxt, arg)
 		if err != nil {
-			// could cancel provisionee run here?
+			// cancel provisionee run:
+			provisionee.Cancel()
 			e.G().Log.Warning("DisplayAndPromptSecret error: %s", err)
 		} else if receivedSecret.Secret != nil && len(receivedSecret.Secret) > 0 {
 			e.G().Log.Debug("received secret, adding to provisionee")


### PR DESCRIPTION
This passes our local tests, but I wasn't able to get to the point in the desktop provisioning flow that makes this call with the desktop code that is in this branch (forked this morning).  I imagine @chrisnojima has it in a different branch.

So I'd like to wait to see if it works for @chrisnojima before merging.

r? @maxtaco and @chrisnojima 