### PR TITLE
Check assets after prompting (updater)

### DIFF
--- a/go/updater/updater.go
+++ b/go/updater/updater.go
@@ -437,17 +437,20 @@ func (u *Updater) update(ctx Context, force bool, requested bool) (update *keyba
 		// No update available
 		return
 	}
+
+	err = u.promptForUpdateAction(ctx, *update)
+	if err != nil {
+		return
+	}
+
+	// Linux updates don't have assets so it's ok to prompt for update before
+	// asset checks.
 	if update.Asset == nil {
 		u.log.Info("No update asset to apply")
 		return
 	}
 	if update.Asset.LocalPath == "" {
 		err = fmt.Errorf("No local asset path for update")
-		return
-	}
-
-	err = u.promptForUpdateAction(ctx, *update)
-	if err != nil {
 		return
 	}
 


### PR DESCRIPTION
@oconnor663 

I got a virtual box running linux and am using that to test updates daily and as I was doing some testing on linux and noticed the updater is returning with "No update asset to apply" before prompting. 

Because linux has no assets in an update, this is preventing the prompt from displaying (telling users to update).

This moves the asset check below the prompt and adds a comment.

If we want to resolve this for existing users we can add an dummy asset like "empty.txt" or something, but assuming it's ok, since people will eventually apt update...