### PR TITLE
Store LKSec in Account

### DIFF
--- a/go/client/cmd_status.go
+++ b/go/client/cmd_status.go
@@ -53,6 +53,7 @@ type fstatus struct {
 	Device                 *keybase1.Device
 	LoggedInProvisioned    bool `json:"LoggedIn"`
 	PassphraseStreamCached bool `json:"KeychainUnlocked"`
+	LKSecLoaded            bool `json:"LocalKeySecurityLoaded"`
 	SessionIsValid         bool `json:"SessionIsValid"`
 	SessionStatus          string
 	ConfigPath             string
@@ -148,6 +149,7 @@ func (c *CmdStatus) load() (*fstatus, error) {
 
 	status.SessionStatus = c.sessionStatus(extStatus.Session)
 	status.PassphraseStreamCached = extStatus.PassphraseStreamCached
+	status.LKSecLoaded = extStatus.LksecLoaded
 
 	if kbfs := getFirstClient(extStatus.Clients, keybase1.ClientType_KBFS); kbfs != nil {
 		status.KBFS.Version = kbfs.Version
@@ -211,6 +213,7 @@ func (c *CmdStatus) outputTerminal(status *fstatus) error {
 	dui.Printf("Session:       %s\n", status.SessionStatus)
 	dui.Printf("    is valid:  %s\n", BoolString(status.SessionIsValid, "yes", "no"))
 	dui.Printf("    keys:      %s\n", BoolString(status.PassphraseStreamCached, "unlocked", "locked"))
+	dui.Printf("    lksec:     %s\n", BoolString(status.LKSecLoaded, "loaded", "not loaded"))
 	dui.Printf("\nKBFS:\n")
 	dui.Printf("    status:    %s\n", BoolString(status.KBFS.Running, "running", "not running"))
 	dui.Printf("    version:   %s\n", status.KBFS.Version)

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -418,7 +418,7 @@ func (e *loginProvision) syncedPGPKey(ctx *Context) (libkb.GenericKey, error) {
 	// unlock it
 	// XXX improve this prompt
 	parg := ctx.SecretKeyPromptArg(libkb.SecretKeyArg{}, "sign new device")
-	unlocked, err := key.PromptAndUnlock(parg, "keybase", nil, e.lks, e.arg.User)
+	unlocked, err := key.PromptAndUnlock(parg, "keybase", nil, e.arg.User)
 	if err != nil {
 		return nil, err
 	}

--- a/go/engine/login_provisioned_device.go
+++ b/go/engine/login_provisioned_device.go
@@ -94,6 +94,9 @@ func (e *loginProvisionedDevice) Run(ctx *Context) error {
 		return errNoDevice
 	}
 
+	// set e.username so that LoginUI never needs to ask for it
+	e.username = me.GetName()
+
 	// at this point, there is a user config either for the current user or for e.username
 	// and it has a device id, so this should be a provisioned device.  Thus, they should
 	// just login normally.

--- a/go/engine/passphrase_change.go
+++ b/go/engine/passphrase_change.go
@@ -397,7 +397,7 @@ func (c *PassphraseChange) findAndDecryptPrivatePGPKeys(ctx *Context) ([]libkb.G
 
 	for _, block := range blocks {
 		parg := ctx.SecretKeyPromptArg(libkb.SecretKeyArg{}, "passphrase change")
-		key, err := block.PromptAndUnlock(parg, "your keybase passphrase", secretRetriever, nil, c.me)
+		key, err := block.PromptAndUnlock(parg, "your keybase passphrase", secretRetriever, c.me)
 		if err != nil {
 			return nil, err
 		}

--- a/go/engine/passphrase_change_test.go
+++ b/go/engine/passphrase_change_test.go
@@ -713,7 +713,7 @@ func TestPassphraseChangePGP3SecMultiple(t *testing.T) {
 		parg := libkb.SecretKeyPromptArg{
 			SecretUI: u.NewSecretUI(),
 		}
-		unlocked, err := key.PromptAndUnlock(parg, "", nil, nil, me)
+		unlocked, err := key.PromptAndUnlock(parg, "", nil, me)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -102,7 +102,7 @@ func (e *PGPKeyImportEngine) saveLKS(ctx *Context) (err error) {
 
 	lks := e.arg.Lks
 	if lks == nil {
-		lks, err = libkb.NewLKSForEncrypt(ctx.SecretUI, e.me.GetUID(), e.G())
+		lks, err = libkb.NewLKSecForEncrypt(ctx.SecretUI, e.me.GetUID(), e.G())
 		if err != nil {
 			return err
 		}

--- a/go/engine/scankeys.go
+++ b/go/engine/scankeys.go
@@ -286,7 +286,7 @@ func (s *ScanKeys) unlockByID(id uint64) openpgp.EntityList {
 			Reason:   unlockReason,
 			SecretUI: s.secui,
 		}
-		unlocked, err := skb.PromptAndUnlock(parg, "", nil, nil, s.me)
+		unlocked, err := skb.PromptAndUnlock(parg, "", nil, s.me)
 		if err != nil {
 			s.G().Log.Warning("error unlocking key: %s", err)
 			continue
@@ -308,7 +308,7 @@ func (s *ScanKeys) unlockAll() openpgp.EntityList {
 			Reason:   unlockReason,
 			SecretUI: s.secui,
 		}
-		unlocked, err := skb.PromptAndUnlock(parg, "", nil, nil, s.me)
+		unlocked, err := skb.PromptAndUnlock(parg, "", nil, s.me)
 		if err != nil {
 			s.G().Log.Warning("error unlocking key: %s", err)
 			continue

--- a/go/engine/track_token.go
+++ b/go/engine/track_token.go
@@ -206,7 +206,7 @@ func (e *TrackToken) storeRemoteTrack(ctx *Context) (err error) {
 	}
 	// need to unlock private key
 	parg := ctx.SecretKeyPromptArg(libkb.SecretKeyArg{}, "tracking signature")
-	e.signingKeyPriv, err = e.lockedKey.PromptAndUnlock(parg, e.lockedWhich, secretStore, nil, e.arg.Me)
+	e.signingKeyPriv, err = e.lockedKey.PromptAndUnlock(parg, e.lockedWhich, secretStore, e.arg.Me)
 	if err != nil {
 		return err
 	}

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -255,6 +255,13 @@ func (a *Account) LKSec() *LKSec {
 	return a.lksec
 }
 
+func (a *Account) LKSecUnlock(locked []byte) ([]byte, PassphraseGeneration, error) {
+	if a.lksec == nil {
+		return nil, 0, errors.New("LKSecUnlock: no lksec in account")
+	}
+	return a.lksec.Decrypt(a, locked)
+}
+
 func (a *Account) SecretSyncer() *SecretSyncer {
 	return a.secretSyncer
 }

--- a/go/libkb/keyring.go
+++ b/go/libkb/keyring.go
@@ -356,7 +356,7 @@ func (k *Keyrings) GetSecretKeyWithoutPrompt(lctx LoginContext, ska SecretKeyArg
 		return nil, err
 	}
 
-	key, err = skb.UnlockNoPrompt(lctx, secretStore, nil)
+	key, err = skb.UnlockNoPrompt(lctx, secretStore)
 	if key != nil && err == nil {
 		k.setCachedSecretKey(lctx, ska, key)
 	}
@@ -379,7 +379,7 @@ func (k *Keyrings) GetSecretKeyAndSKBWithPrompt(arg SecretKeyPromptArg) (key Gen
 		skb.SetUID(arg.Ska.Me.GetUID())
 		secretStore = NewSecretStore(k.G(), arg.Ska.Me.GetNormalizedName())
 	}
-	if key, err = skb.PromptAndUnlock(arg, which, secretStore, nil, arg.Ska.Me); err != nil {
+	if key, err = skb.PromptAndUnlock(arg, which, secretStore, arg.Ska.Me); err != nil {
 		key = nil
 		skb = nil
 		return
@@ -427,7 +427,7 @@ func (k *Keyrings) GetSecretKeyWithPassphrase(lctx LoginContext, me *User, passp
 			pps = sc.PassphraseStream()
 		}, "StreamCache - tsec, pps")
 	}
-	return skb.UnlockSecretKey(lctx, passphrase, tsec, pps, secretStorer, nil)
+	return skb.UnlockSecretKey(lctx, passphrase, tsec, pps, secretStorer)
 }
 
 type EmptyKeyRing struct{}

--- a/go/libkb/keyring.go
+++ b/go/libkb/keyring.go
@@ -398,7 +398,7 @@ func (k *Keyrings) GetSecretKeyWithStoredSecret(lctx LoginContext, ska SecretKey
 		return
 	}
 	skb.SetUID(me.GetUID())
-	return skb.UnlockWithStoredSecret(secretRetriever)
+	return skb.UnlockWithStoredSecret(lctx, secretRetriever)
 }
 
 func (k *Keyrings) GetSecretKeyWithPassphrase(lctx LoginContext, me *User, passphrase string, secretStorer SecretStorer) (key GenericKey, err error) {

--- a/go/libkb/lksec.go
+++ b/go/libkb/lksec.go
@@ -234,7 +234,7 @@ func (s *LKSec) apiServerHalf(lctx LoginContext, devid keybase1.DeviceID) error 
 
 // NewLKSForEncrypt gets a verified passphrase stream, and returns
 // an LKS that works for encryption.
-func NewLKSForEncrypt(ui SecretUI, uid keybase1.UID, gc *GlobalContext) (ret *LKSec, err error) {
+func NewLKSecForEncrypt(ui SecretUI, uid keybase1.UID, gc *GlobalContext) (ret *LKSec, err error) {
 	var pps *PassphraseStream
 	if pps, err = gc.LoginState().GetPassphraseStream(ui); err != nil {
 		return
@@ -244,7 +244,7 @@ func NewLKSForEncrypt(ui SecretUI, uid keybase1.UID, gc *GlobalContext) (ret *LK
 }
 
 // EncryptClientHalfRecovery takes the client half of the LKS secret
-// and ecrypts it for the given key.  This is for recovery of passphrases
+// and encrypts it for the given key.  This is for recovery of passphrases
 // on device recovery operations.
 func (s *LKSec) EncryptClientHalfRecovery(key GenericKey) (string, error) {
 	return key.EncryptToString(s.clientHalf, nil)

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -68,6 +68,8 @@ type LoginContext interface {
 
 	CachedSecretKey(ska SecretKeyArg) (GenericKey, error)
 	SetCachedSecretKey(ska SecretKeyArg, key GenericKey) error
+
+	SetLKSec(lksec *LKSec)
 }
 
 type LoggedInHelper interface {

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -331,7 +331,8 @@ func (s *SKB) UnlockSecretKey(lctx LoginContext, passphrase string, tsec *triple
 				return nil, fmt.Errorf("UnlockSecretKey: %s", err)
 			}
 		}
-		if unlocked, err = s.lksUnlock(lctx, pps, secretStorer); err == nil && ppsIn == nil {
+		unlocked, err = s.lksUnlock(lctx, pps, secretStorer)
+		if err == nil && ppsIn == nil {
 			// the unverified tsec, pps has been verified, so cache it:
 			if lctx != nil {
 				lctx.CreateStreamCache(tsec, pps)
@@ -344,7 +345,7 @@ func (s *SKB) UnlockSecretKey(lctx LoginContext, passphrase string, tsec *triple
 				}
 			}
 		} else {
-			s.G().Log.Debug("| not caching passphrase stream: err = %v", err)
+			s.G().Log.Debug("| not caching passphrase stream: err = %v, ppsIn == nil? %v", err, ppsIn == nil)
 		}
 	default:
 		err = BadKeyError{fmt.Sprintf("Can't unlock secret with protection type %d", int(s.Priv.Encryption))}

--- a/go/libkb/skb_test.go
+++ b/go/libkb/skb_test.go
@@ -120,7 +120,7 @@ func testPromptAndUnlock(t *testing.T, skb *SKB) {
 		Reason:   "test reason",
 		SecretUI: &TestSecretUI{Passphrase: "test passphrase", StoreSecret: true},
 	}
-	key, err := skb.PromptAndUnlock(parg, "test which", NewSecretStore(skb.G(), "testusername"), nil, nil)
+	key, err := skb.PromptAndUnlock(parg, "test which", NewSecretStore(skb.G(), "testusername"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +263,7 @@ func TestPromptCancelCache(t *testing.T) {
 		Reason:   "test reason",
 		SecretUI: &TestSecretUI{Passphrase: "passphrase"},
 	}
-	key, err := skb.PromptAndUnlock(parg, "test which", NewSecretStore(tc.G, "testusername"), nil, nil)
+	key, err := skb.PromptAndUnlock(parg, "test which", NewSecretStore(tc.G, "testusername"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +278,7 @@ func testErrUnlock(t *testing.T, skb *SKB, ui *TestCancelSecretUI) error {
 		SecretUI:       ui,
 		UseCancelCache: true,
 	}
-	key, err := skb.PromptAndUnlock(parg, "test which", NewSecretStore(skb.G(), "testusername"), nil, nil)
+	key, err := skb.PromptAndUnlock(parg, "test which", NewSecretStore(skb.G(), "testusername"), nil)
 	if err == nil {
 		t.Fatal("PromptAndUnlock returned nil error")
 	}

--- a/go/protocol/config.go
+++ b/go/protocol/config.go
@@ -41,6 +41,7 @@ type PlatformInfo struct {
 type ExtendedStatus struct {
 	Standalone             bool            `codec:"standalone" json:"standalone"`
 	PassphraseStreamCached bool            `codec:"passphraseStreamCached" json:"passphraseStreamCached"`
+	LksecLoaded            bool            `codec:"lksecLoaded" json:"lksecLoaded"`
 	Device                 *Device         `codec:"device,omitempty" json:"device,omitempty"`
 	LogDir                 string          `codec:"logDir" json:"logDir"`
 	Session                *SessionStatus  `codec:"session,omitempty" json:"session,omitempty"`

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -144,6 +144,7 @@ func (h ConfigHandler) GetExtendedStatus(_ context.Context, sessionID int) (res 
 
 	h.G().LoginState().Account(func(a *libkb.Account) {
 		res.PassphraseStreamCached = a.PassphraseStreamCache().Valid()
+		res.LksecLoaded = a.LKSec() != nil
 		if a.LoginSession() != nil {
 			res.Session = a.LoginSession().Status()
 		}

--- a/protocol/avdl/config.avdl
+++ b/protocol/avdl/config.avdl
@@ -39,6 +39,7 @@ protocol config {
   record ExtendedStatus {
     boolean standalone;
     boolean passphraseStreamCached;
+    boolean lksecLoaded;
     union { null, Device } device;
     string logDir;
     union { null, SessionStatus } session;

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -185,6 +185,7 @@ export type ExitCode =
 export type ExtendedStatus = {
   standalone: boolean;
   passphraseStreamCached: boolean;
+  lksecLoaded: boolean;
   device?: ?Device;
   logDir: string;
   session?: ?SessionStatus;

--- a/protocol/json/config.json
+++ b/protocol/json/config.json
@@ -456,6 +456,10 @@
           "name": "passphraseStreamCached"
         },
         {
+          "type": "boolean",
+          "name": "lksecLoaded"
+        },
+        {
           "type": [
             "null",
             "Device"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -185,6 +185,7 @@ export type ExitCode =
 export type ExtendedStatus = {
   standalone: boolean;
   passphraseStreamCached: boolean;
+  lksecLoaded: boolean;
   device?: ?Device;
   logDir: string;
   session?: ?SessionStatus;


### PR DESCRIPTION
After logging in, we have access to the LKSec object for a user, but always discard it.  It is then recreated through a variety of methods when it is needed in the future.

Instead of discarding it, store it in the Account object.  This LKSec could be used to simplify the unlocking of local device keys.  Currently, there are no changes to any Unlock code to use this.

This does provide correct information about if the local keys are unlockable after logging in via secret store.

Some other cleanup in this PR:  lksPreload argument was not used.  Pass (known) username in to LoginWithPrompt during LoginProvisionedDevice.

This code was originally in the Login3 login state PRs that got abandoned/rolled back.

r? @maxtaco 

