### PR TITLE
Fix updater checker bug

### DIFF
--- a/go/service/update.go
+++ b/go/service/update.go
@@ -45,5 +45,6 @@ func (h *UpdateHandler) UpdateCheck(_ context.Context, force bool) error {
 	if h.updateChecker == nil {
 		return fmt.Errorf("No updater available")
 	}
-	return h.updateChecker.Check(force, true)
+	_, err := h.updateChecker.Check(force, true)
+	return err
 }

--- a/go/updater/updater_test.go
+++ b/go/updater/updater_test.go
@@ -25,7 +25,7 @@ func NewTestUpdater(t *testing.T, options keybase1.UpdateOptions, p processUpdat
 	if err != nil {
 		return nil, err
 	}
-	config := testConfig{}
+	config := &testConfig{}
 	return NewUpdater(options, updateSource, config, logger.NewTestLogger(t)), nil
 }
 
@@ -130,19 +130,19 @@ func (c testConfig) GetUpdatePreferenceSkip() string {
 	return ""
 }
 
-func (c testConfig) SetUpdatePreferenceAuto(b bool) error {
+func (c *testConfig) SetUpdatePreferenceAuto(b bool) error {
 	return nil
 }
 
-func (c testConfig) SetUpdatePreferenceSkip(v string) error {
+func (c *testConfig) SetUpdatePreferenceSkip(v string) error {
 	return nil
 }
 
-func (c testConfig) SetUpdatePreferenceSnoozeUntil(t keybase1.Time) error {
+func (c *testConfig) SetUpdatePreferenceSnoozeUntil(t keybase1.Time) error {
 	return nil
 }
 
-func (c testConfig) SetUpdateLastChecked(t keybase1.Time) error {
+func (c *testConfig) SetUpdateLastChecked(t keybase1.Time) error {
 	c.lastChecked = t
 	return nil
 }


### PR DESCRIPTION
I introduced a bug 5 days ago, which causes the update checker to stop checking:
https://github.com/keybase/client/pull/2251

cc @cjb @patrickxb 

What happened is I flipped the condition and I didn't have test coverage for it. This fixes bug and adds a test.

keybase update check/run still work ok, so people will be able update manually but this will stops periodic update check from occurring :(

Created an issue here to discuss how best to notify users who have old versions that they need to update: https://keybase.atlassian.net/browse/CORE-2736