### PR TITLE
more forgiving timeouts for Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,18 @@
-install:
 
 environment:
   global:
     GOPATH: c:\work\
     GO15VENDOREXPERIMENT: 1
     KEYBASE_SERVER_URI: https://ci1.keybase.io
-
+    GOVERSION: 1.5.3
 # clone directory
 clone_folder: c:\work\src\github.com\keybase\client
+  
+install:
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.zip
+  - ps: rmdir C:\go -Force -Recurse -Confirm:$false
+  - 7z x go%GOVERSION%.windows-amd64.zip -o"C:\" -y > nul
+  - set Path=c:\go\bin;%Path%  
 
 #---------------------------------#
 #       build configuration       #

--- a/go/kex2/rpc_test.go
+++ b/go/kex2/rpc_test.go
@@ -97,7 +97,7 @@ func (mp *mockProvisionee) GetLogFactory() rpc.LogFactory {
 
 var ErrHandleHello = errors.New("handle hello failure")
 var ErrHandleDidCounterSign = errors.New("handle didCounterSign failure")
-var testTimeout = time.Duration(10) * time.Millisecond
+var testTimeout = time.Duration(20) * time.Millisecond
 
 func (mp *mockProvisionee) HandleHello(arg keybase1.HelloArg) (res keybase1.HelloRes, err error) {
 	if (mp.behavior & BadProvisioneeSlowHello) != 0 {

--- a/go/kex2/transport_test.go
+++ b/go/kex2/transport_test.go
@@ -307,7 +307,7 @@ func TestReadTimeout(t *testing.T) {
 
 func TestReadDelayedWrite(t *testing.T) {
 	c1, c2, _, _ := genConnPair(t, GoodRouter, time.Duration(0))
-	wait := time.Duration(10) * time.Millisecond
+	wait := time.Duration(20) * time.Millisecond
 	c2.SetReadDeadline(time.Now().Add(wait))
 	text := "hello friend"
 	go func() {
@@ -462,7 +462,7 @@ func TestErrAgain(t *testing.T) {
 
 func TestPollLoopSuccess(t *testing.T) {
 
-	wait := time.Duration(8) * time.Millisecond
+	wait := time.Duration(16) * time.Millisecond
 	r := newMockRouterWithBehaviorAndMaxPoll(GoodRouter, wait/32)
 	s := genSecret(t)
 	d1 := genDeviceID(t)


### PR DESCRIPTION
use go 1.5.3 on AppVeyor

Whoops, I closed the other pull request by mistake.