### PR TITLE
Refactor API error conversion

### DIFF
--- a/go/engine/login_load_user.go
+++ b/go/engine/login_load_user.go
@@ -65,7 +65,7 @@ func (e *loginLoadUser) Run(ctx *Context) error {
 	arg.PublicKeyOptional = true
 	user, err := libkb.LoadUser(arg)
 	if err != nil {
-		return e.convertNotFound(err)
+		return err
 	}
 	e.user = user
 
@@ -106,7 +106,7 @@ func (e *loginLoadUser) findUsername(ctx *Context) (string, error) {
 		return nil
 	}
 	if err := e.G().LoginState().VerifyEmailAddress(e.usernameOrEmail, ctx.SecretUI, afterLogin); err != nil {
-		return "", e.convertNotFound(err)
+		return "", err
 	}
 
 	e.G().Log.Debug("VerifyEmailAddress %q => %q", e.usernameOrEmail, username)
@@ -121,15 +121,4 @@ func (e *loginLoadUser) prompt(ctx *Context) error {
 	}
 	e.usernameOrEmail = res
 	return nil
-}
-
-// LoadUser and VerifyEmailAddress can return an AppStatusError when a user isn't found.
-// Convert that to a libkb.NotFoundError.
-func (e *loginLoadUser) convertNotFound(in error) error {
-	if aerr, ok := in.(libkb.AppStatusError); ok {
-		if aerr.Code == libkb.SCNotFound || aerr.Code == libkb.SCBadLoginUserNotFound {
-			return libkb.NotFoundError{}
-		}
-	}
-	return in
 }

--- a/go/engine/login_state_test.go
+++ b/go/engine/login_state_test.go
@@ -160,8 +160,8 @@ func TestLoginNonexistent(t *testing.T) {
 
 	secretUI := &libkb.TestSecretUI{Passphrase: "XXXXXXXXXXXX"}
 	err := tc.G.LoginState().LoginWithPrompt("nonexistent", nil, secretUI, nil)
-	if _, ok := err.(libkb.AppStatusError); !ok {
-		t.Errorf("error type: %T, expected libkb.AppStatusError", err)
+	if _, ok := err.(libkb.NotFoundError); !ok {
+		t.Errorf("error type: %T, expected libkb.NotFoundError", err)
 	}
 }
 

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -354,7 +354,7 @@ func (s *LoginState) postLoginToServer(lctx LoginContext, eOu string, lgpw []byt
 			"hmac_pwh":          S{hex.EncodeToString(lgpw)},
 			"login_session":     S{loginSessionEncoded},
 		},
-		AppStatusCodes: []int{SCOk, SCBadLoginPassword},
+		AppStatusCodes: []int{SCOk, SCBadLoginPassword, SCBadLoginUserNotFound},
 	})
 	if err != nil {
 		return nil, err
@@ -362,6 +362,9 @@ func (s *LoginState) postLoginToServer(lctx LoginContext, eOu string, lgpw []byt
 	if res.AppStatus.Code == SCBadLoginPassword {
 		err = PassphraseError{"server rejected login attempt"}
 		return nil, err
+	}
+	if res.AppStatus.Code == SCBadLoginUserNotFound {
+		return nil, NotFoundError{}
 	}
 
 	b := res.Body

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -4,10 +4,11 @@
 package libkb
 
 import (
+	"time"
+
 	keybase1 "github.com/keybase/client/go/protocol"
 	jsonw "github.com/keybase/go-jsonw"
 	"stathat.com/c/ramcache"
-	"time"
 )
 
 type ResolveResult struct {
@@ -140,12 +141,17 @@ func (r *Resolver) resolveURLViaServerLookup(au AssertionURL, input string, with
 	}
 	ha.Add("fields", S{fields})
 	ares, res.err = r.G().API.Get(APIArg{
-		Endpoint:    "user/lookup",
-		NeedSession: false,
-		Args:        ha,
+		Endpoint:       "user/lookup",
+		NeedSession:    false,
+		Args:           ha,
+		AppStatusCodes: []int{SCOk, SCNotFound},
 	})
 
 	if res.err != nil {
+		return
+	}
+	if ares.AppStatus.Code == SCNotFound {
+		res.err = NotFoundError{}
 		return
 	}
 


### PR DESCRIPTION
LoginLoadUser was doing some AppStatusError -> libkb error conversion.  

This fixes it so the errors are translated when the API call is processed.

r? @maxtaco 