### PR TITLE
return non-zero when exiting with an error

### DIFF
--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -61,6 +61,9 @@ func main() {
 		// Had to change from Error to Errorf because of go vet because of:
 		// https://github.com/golang/go/issues/6407
 		g.Log.Errorf("%s", err.Error())
+		if g.ExitCode == keybase1.ExitCode_OK {
+			g.ExitCode = keybase1.ExitCode_NOTOK
+		}
 	}
 	if g.ExitCode != keybase1.ExitCode_OK {
 		os.Exit(int(g.ExitCode))


### PR DESCRIPTION
Previously we just returned zero, which made it hard for shell scripts to tell that an error had happened.

@patrickxb do you know if there's a reason we didn't do this before? I'm surprised it didn't come up.