### PR TITLE
Change load user per sec from 8 to 4

### DIFF
--- a/go/engine/pgp_pull.go
+++ b/go/engine/pgp_pull.go
@@ -240,7 +240,7 @@ func (e *PGPPullEngine) exportKeysToGPG(ctx *Context, user *libkb.User, tfp map[
 
 func (e *PGPPullEngine) rateLimit(start time.Time, index int) time.Time {
 	// server currently limiting to 32 req/s, but there can be 4 requests for each loaduser call.
-	const loadUserPerSec = 8
+	const loadUserPerSec = 4
 	if index == 0 {
 		return start
 	}


### PR DESCRIPTION
I'm not 100% sure this will fix @malgorithms `pgp pull`, but it's worth a try as it is only a 1 byte change.

r? @maxtaco 