### PR TITLE
Signup back button working

### DIFF
--- a/shared/actions/router.js
+++ b/shared/actions/router.js
@@ -9,10 +9,10 @@ export function getCurrentTab (state) {
   return state.tabbedRouter.get('activeTab')
 }
 
-export function navigateUp (tab) {
+export function navigateUp (tab, till) {
   return {
     type: Constants.navigateUp,
-    payload: {tab}
+    payload: {tab, till}
   }
 }
 

--- a/shared/actions/signup/index.js
+++ b/shared/actions/signup/index.js
@@ -2,10 +2,12 @@
 
 import _ from 'lodash'
 import * as Constants from '../../constants/signup'
+import {Map} from 'immutable'
 import HiddenString from '../../util/hidden-string'
 import engine from '../../engine'
+import {loginTab} from '../../constants/tabs'
 
-import {routeAppend} from '../../actions/router'
+import {routeAppend, navigateUp} from '../../actions/router'
 
 import type {TypedAsyncAction, AsyncAction} from '../../constants/types/flux'
 import type {RouteAppend} from '../../constants/router'
@@ -327,7 +329,8 @@ function signup (skipMail): TypedAsyncAction<Signup | ShowPaperKey | RouteAppend
 export function resetSignup (): TypedAsyncAction<ResetSignup | RouteAppend> {
   return dispatch => new Promise((resolve, reject) => {
     dispatch({type: Constants.resetSignup, payload: {}})
-    dispatch(nextPhase())
+    dispatch(navigateUp(loginTab, Map({path: 'signup'})))
+    dispatch(navigateUp())
     resolve()
   })
 }

--- a/shared/common-adapters/back-button.desktop.js
+++ b/shared/common-adapters/back-button.desktop.js
@@ -8,11 +8,19 @@ import type {Props} from './back-button'
 export default class BackButton extends Component {
   props: Props;
 
+  onClick (event: SyntheticEvent) {
+    event.preventDefault()
+    event.stopPropagation()
+    if (this.props.onClick) {
+      this.props.onClick()
+    }
+  }
+
   render () {
     return (
-      <div style={{...styles.container, ...this.props.style}} onClick={this.props.onClick}>
+      <div style={{...styles.container, ...this.props.style}} onClick={e => this.onClick(e)}>
         <Icon type='fa-arrow-left' style={styles.icon}/>
-        <Text type='BodyPrimaryLink' onClick={() => this.props.onClick()}>Back</Text>
+        <Text type='BodyPrimaryLink' onClick={e => this.onClick(e)}>Back</Text>
       </div>
     )
   }

--- a/shared/common-adapters/text.js.flow
+++ b/shared/common-adapters/text.js.flow
@@ -16,7 +16,7 @@ export type Props = {
   link?: boolean,
   small?: boolean,
   reversed?: boolean,
-  onClick?: () => void,
+  onClick?: (e: SyntheticEvent) => void,
   lineClamp?: number,
   style?: Object,
   children?: React$Element,

--- a/shared/login/login/index.js
+++ b/shared/login/login/index.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import {relogin} from '../../actions/login'
-import {navigateTo} from '../../actions/router'
+import {routeAppend} from '../../actions/router'
 import Render from './index.render'
 
 class Login extends Component {
@@ -42,7 +42,7 @@ export default connect(
   dispatch => {
     return {
       onLogin: (user, passphrase, store) => dispatch(relogin(user, passphrase, store)),
-      onSignup: () => dispatch(navigateTo(['signup']))
+      onSignup: () => dispatch(routeAppend(['signup']))
     }
   }
 )(Login)

--- a/shared/login/signup/invite-code.js
+++ b/shared/login/signup/invite-code.js
@@ -6,11 +6,17 @@ import {bindActionCreators} from 'redux'
 
 import Render from './invite-code.render'
 import * as signupActions from '../../actions/signup'
+import {navigateUp} from '../../actions/router'
 
 class InviteCode extends Component {
   render () {
     return (
-      <Render inviteCode={this.props.inviteCode} onRequestInvite={this.props.startRequestInvite} onInviteCodeSubmit={this.props.checkInviteCode} inviteCodeErrorText={this.props.errorText} onBack={this.props.resetSignup}/>
+      <Render
+        inviteCode={this.props.inviteCode}
+        onRequestInvite={this.props.startRequestInvite}
+        onInviteCodeSubmit={this.props.checkInviteCode}
+        inviteCodeErrorText={this.props.errorText}
+        onBack={this.props.navigateUp}/>
     )
   }
 }
@@ -22,5 +28,8 @@ InviteCode.propTypes = {
 
 export default connect(
   state => ({errorText: state.signup.inviteCodeError, inviteCode: state.signup.inviteCode}),
-  dispatch => bindActionCreators(signupActions, dispatch)
+    dispatch => bindActionCreators({
+      ...signupActions,
+      navigateUp
+    }, dispatch)
 )(InviteCode)

--- a/shared/login/signup/invite-code.render.desktop.js
+++ b/shared/login/signup/invite-code.render.desktop.js
@@ -30,7 +30,7 @@ export default class Render extends Component {
       <Container onBack={this.props.onBack} style={styles.container}>
         <Text style={styles.header} type='Header'>Type in your invite code:</Text>
         <Icon style={styles.icon} type='invite-code-m'/>
-        <Input style={styles.input} hintText='goddess brown result reject' value={this.state.inviteCode} errorText={this.props.inviteCodeErrorText} onEnterKeyDown={submitInviteCode} onChange={event => this.setState({inviteCode: event.target.value})}/>
+        <Input autoFocus style={styles.input} hintText='goddess brown result reject' value={this.state.inviteCode} errorText={this.props.inviteCodeErrorText} onEnterKeyDown={submitInviteCode} onChange={event => this.setState({inviteCode: event.target.value})}/>
         <Button style={styles.button} type='Primary' label='Continue' onClick={submitInviteCode} disabled={!this.state.inviteCode}/>
         <Text style={styles.text} type='Body'>Not invited?</Text>
         <Text type='BodyPrimaryLink' onClick={this.props.onRequestInvite}>Request an invite code</Text>

--- a/shared/login/signup/username-email-form.render.desktop.js
+++ b/shared/login/signup/username-email-form.render.desktop.js
@@ -21,7 +21,7 @@ export default class Render extends Component {
     return (
       <Container onBack={this.props.onBack} style={styles.container} outerStyle={styles.outer}>
         <UserCard style={styles.card}>
-          <Input style={styles.first} floatingLabelText='Create a username' value={this.props.username} ref={r => (usernameRef = r)} errorText={this.props.usernameErrorText}/>
+          <Input autoFocus style={styles.first} floatingLabelText='Create a username' value={this.props.username} ref={r => (usernameRef = r)} errorText={this.props.usernameErrorText}/>
           <Input floatingLabelText='Email address' value={this.props.email} ref={r => (emailRef = r)} errorText={this.props.emailErrorText}/>
           <Button fullWidth type='Primary' label='Continue' onClick={submitUserEmail}/>
         </UserCard>

--- a/shared/reducers/router.js
+++ b/shared/reducers/router.js
@@ -2,6 +2,7 @@
 
 import * as RouterConstants from '../constants/router'
 import Immutable, {List, Map} from 'immutable'
+import * as _ from 'lodash'
 export type URI = List<Map<string, string>>
 type History = List<URI>
 
@@ -53,7 +54,25 @@ export function subReducer (state: RouterState = initialState, action: any): Rou
     // or a child of it
     // we get rid of everything after it
     case RouterConstants.navigateUp:
-      return state.update('uri', uri => uri.count() > 1 ? uri.pop() : uri)
+      const uri = state.get('uri')
+      if (uri.count() > 1) {
+        if (action.payload.till) {
+          let current = uri
+          while (current.count() > 0 && !_.isEqual(current.last(), action.payload.till)) { // eslint-disable-line eqeqeq
+            current = current.pop()
+          }
+
+          if (current.count()) {
+            return state.set('uri', current)
+          } else {
+            console.error(`Navigate till unfound: ${action.payload.till}`)
+            return state
+          }
+        } else {
+          return state.set('uri', uri.pop())
+        }
+      }
+      return state
     case RouterConstants.navigateBack:
       const lastUri = state.get('history').last() || parseUri([])
       return state.update('history', history => history.count() > 1 ? history.pop() : parseUri([]))

--- a/shared/reducers/router.js
+++ b/shared/reducers/router.js
@@ -2,7 +2,6 @@
 
 import * as RouterConstants from '../constants/router'
 import Immutable, {List, Map} from 'immutable'
-import * as _ from 'lodash'
 export type URI = List<Map<string, string>>
 type History = List<URI>
 
@@ -58,7 +57,7 @@ export function subReducer (state: RouterState = initialState, action: any): Rou
       if (uri.count() > 1) {
         if (action.payload.till) {
           let current = uri
-          while (current.count() > 0 && !_.isEqual(current.last(), action.payload.till)) { // eslint-disable-line eqeqeq
+          while (current.count() > 0 && !Immutable.is(current.last(), action.payload.till)) {
             current = current.pop()
           }
 

--- a/shared/reducers/signup.js
+++ b/shared/reducers/signup.js
@@ -25,7 +25,7 @@ export type SignupState = {
 }
 
 const initialState: SignupState = {
-  inviteCode: '202020202020202020202020',
+  inviteCode: null,
   username: null,
   email: null,
   inviteCodeError: null,

--- a/shared/reducers/signup.js
+++ b/shared/reducers/signup.js
@@ -25,7 +25,7 @@ export type SignupState = {
 }
 
 const initialState: SignupState = {
-  inviteCode: null,
+  inviteCode: '202020202020202020202020',
   username: null,
   email: null,
   inviteCodeError: null,


### PR DESCRIPTION
Makes routing work more cleanly. when you reset signup you go back to the page before signup, instead of appending a new route forever

Added back autofocus to signup flow, not sure how that didn't get in before...

@keybase/react-hackers 