### PR TITLE
Ensure go binaries are codesigned

### DIFF
--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -12,7 +12,6 @@ tmp_dir="/tmp/package_darwin/tmp"
 bucket_name=${BUCKET_NAME:-}
 run_mode="prod"
 platform="darwin"
-nosign=${NOSIGN:-}
 
 s3host=""
 if [ ! "$bucket_name" = "" ]; then
@@ -161,12 +160,13 @@ update_plist() {(
 
 sign() {(
   cd "$out_dir"
-  if [ "$nosign" = "1" ]; then
-    echo "Skipping signing (OS X)"
-    return
-  fi
   code_sign_identity="Developer ID Application: Keybase, Inc. (99229SGT5K)"
-  codesign --verbose --force --deep --timestamp=none --sign "$code_sign_identity" "$app_name.app"
+  codesign --verbose --force --deep --sign "$code_sign_identity" "$app_name.app"
+
+  echo "Verify codesigning..."
+  codesign -v "$app_name.app"
+  codesign -v "$app_name.app/Contents/SharedSupport/bin/keybase"
+  codesign -v "$app_name.app/Contents/SharedSupport/bin/kbfs"
 )}
 
 # Create dmg from Keybase.app

--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -46,7 +46,7 @@ build_dir_kbfs="/tmp/build_kbfs"
 client_dir="$gopath/src/github.com/keybase/client"
 kbfs_dir="$gopath/src/github.com/keybase/kbfs"
 
-"$client_dir/packaging/slack/send.sh" "Starting $build_desc"
+"$client_dir/packaging/slack/send.sh" "Starting $platform $build_desc"
 
 if [ ! "$nopull" = "1" ]; then
   "$client_dir/packaging/check_status_and_pull.sh" "$client_dir"
@@ -87,7 +87,7 @@ save_dir="/tmp/build_desktop"
 rm -rf $save_dir
 
 if [ "$platform" = "darwin" ]; then
-  SAVE_DIR=$save_dir KEYBASE_BINPATH="$build_dir_keybase/keybase" KBFS_BINPATH="$build_dir_kbfs/kbfs" BUCKET_NAME=$bucket_name "$dir/../desktop/package_darwin.sh"
+  SAVE_DIR="$save_dir" KEYBASE_BINPATH="$build_dir_keybase/keybase" KBFS_BINPATH="$build_dir_kbfs/kbfs" BUCKET_NAME=$bucket_name "$dir/../desktop/package_darwin.sh"  
 else
   # TODO: Support linux build here?
   echo "Unknown platform: $platform"


### PR DESCRIPTION
- Removing NOSIGN option
- Checking that a valid PLATFORM is set
- Verifying the codesign after the build
- Removing timestamp=none from codesign. This allows the codesign to sign with timestamp so that builds signed with old (but valid) cert will still work. FYI our cert expires in 2020, so this change probably is meaningless.