### PR TITLE
'Ignore for 24 hours' -> close instead of unfollow

### DIFF
--- a/shared/tracker/action.render.desktop.js
+++ b/shared/tracker/action.render.desktop.js
@@ -73,7 +73,7 @@ export default class ActionRender extends Component {
   renderChanged (styles: Object, username: string) {
     return (
       <div style={{...styles.container}}>
-        <Button waiting={this.props.waiting} type='Unfollow' label='Ignore for 24 hrs' onClick={() => this.props.onUnfollow(username)} />
+        <Button waiting={this.props.waiting} type='Unfollow' label='Ignore for 24 hrs' onClick={() => this.props.onClose(username)} />
         <Button waiting={this.props.waiting} style={styles.actionButton} type='Follow' label='Accept' onClick={() => this.props.onRefollow(username)} />
       </div>
     )


### PR DESCRIPTION
@keybase/react-hackers 

Looks like getting "Ignore for 24 hours" working properly involves a new RPC flow (we receive an identifyUi.Confirm RPC and reply to it with `expiringLocal: true`), so in the interest of getting a fix out faster, let's start by making 'Ignore for 24 hours' do the same thing as just closing the tracker popup, which is pretty close.