### PR TITLE
Make service restart (versionfix) safer (launchd)

### DIFF
--- a/go/client/commands_non_osx.go
+++ b/go/client/commands_non_osx.go
@@ -6,6 +6,8 @@
 package client
 
 import (
+	"fmt"
+
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
@@ -13,6 +15,10 @@ import (
 
 func getPlatformSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
 	return []cli.Command{}
+}
+
+func RestartLaunchdService(g *libkb.GlobalContext, label string) error {
+	return fmt.Errorf("Unsupported on this platform")
 }
 
 // DebugSocketError allows platforms to help the user diagnose and resolve

--- a/go/client/versionfix.go
+++ b/go/client/versionfix.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/keybase/client/go/launchd"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
 	rpc "github.com/keybase/go-framed-msgpack-rpc"
@@ -122,18 +121,7 @@ func FixVersionClash(g *libkb.GlobalContext, cl libkb.CommandLine) (err error) {
 	}
 
 	if serviceConfig.ForkType == keybase1.ForkType_LAUNCHD {
-		launchService := launchd.NewService(serviceConfig.Label)
-		launchService.SetLogger(g.Log)
-		err = launchService.Restart()
-		if err != nil {
-			return err
-		}
-		launchdStatus, err := launchService.LoadStatus()
-		if err != nil {
-			return err
-		}
-		_, err = libkb.WaitForServiceInfoFile(g, g.Env.GetServiceInfoPath(), launchdStatus.Label(), launchdStatus.Pid(), 25, 400*time.Millisecond, "version restart")
-		return err
+		return RestartLaunchdService(g, serviceConfig.Label)
 	}
 
 	ctlCli = keybase1.CtlClient{Cli: gcli}

--- a/go/install/install.go
+++ b/go/install/install.go
@@ -105,10 +105,6 @@ func ResolveInstallStatus(version string, bundleVersion string, lastExitStatus s
 	return
 }
 
-func serviceInfoPath(context Context) string {
-	return filepath.Join(context.GetRuntimeDir(), "keybased.info")
-}
-
 func KBFSBundleVersion(context Context, binPath string) (string, error) {
 	runMode := context.GetRunMode()
 	kbfsBinPath, err := kbfsBinPath(runMode, binPath)

--- a/go/install/install_osx.go
+++ b/go/install/install_osx.go
@@ -194,7 +194,7 @@ func installKeybaseService(g *libkb.GlobalContext, service launchd.Service, plis
 		return nil, err
 	}
 
-	st, err := serviceStatusFromLaunchd(g, service, serviceInfoPath(g))
+	st, err := serviceStatusFromLaunchd(g, service, g.Env.GetServiceInfoPath())
 	return &st, err
 }
 

--- a/go/launchd/launchd.go
+++ b/go/launchd/launchd.go
@@ -115,12 +115,17 @@ func (s Service) Stop(wait bool) error {
 		// it seems more like 5 seconds before it resorts to a SIGKILL.
 		// Because of the SIGKILL fallback we can use a large timeout here of 25
 		// seconds, which we'll likely never reach unless the process is zombied.
-		err = s.WaitForExit(time.Second * 2)
+		err = s.WaitForExit(time.Second * 5)
 		if err != nil {
 			return err
 		}
 	}
 	return err
+}
+
+// Restart a service.
+func (s Service) Restart() error {
+	return Restart(s.Label(), s.log)
 }
 
 // WaitForExit waits for service to exit

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -931,3 +931,7 @@ func (e *Env) GetMountDir() string {
 func (e *Env) GetAppStartMode() AppStartMode {
 	return e.config.GetAppStartMode()
 }
+
+func (e *Env) GetServiceInfoPath() string {
+	return filepath.Join(e.GetRuntimeDir(), "keybased.info")
+}


### PR DESCRIPTION
If fork type is launchd then after calling launchd restart, wait for
the service to startup and be ready before exiting.

Moves the service info path to Env (where it should be).

Also bumps the default timeout for service stop from 2 seconds to 5
seconds.