### PR TITLE
use `npm install --no-shrinkwrap` to unbreak the Linux build

### DIFF
--- a/packaging/linux/Dockerfile
+++ b/packaging/linux/Dockerfile
@@ -23,7 +23,6 @@ RUN curl -sL https://deb.nodesource.com/setup_5.x | bash -
 RUN apt-get update
 RUN apt-get install -y nodejs
 RUN npm install -g npm
-RUN npm cache clean
 
 # Install Go directly from Google, because the Debian repos tend to be behind.
 RUN wget https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz -O /root/go.tar

--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -54,8 +54,9 @@ if should_build_kbfs ; then
   # Can't seem to get the right packages installed under NODE_ENV=production.
   export NODE_ENV=development
   export KEYBASE_SKIP_DEV_TOOLS=1
-  npm cache clean
-  (cd "$this_repo/desktop" && npm i)
+  # --no-shrinkwrap is needed to avoid crashing `npm install` with Z_BUF_ERROR.
+  # Not sure why.
+  (cd "$this_repo/desktop" && npm i --no-shrinkwrap)
   unset KEYBASE_SKIP_DEV_TOOLS
   export NODE_ENV=production
 fi


### PR DESCRIPTION
The following intermittent error has become consistent in my Linux
builds:

```
npm ERR! tar.unpack unzip error /tmp/npm-28814-d055d95c/registry.npmjs.org/fsevents/-/fsevents-1.0.8.tgz
npm ERR! Linux 4.4.5-1-ARCH
npm ERR! argv "/usr/bin/node" "/usr/bin/npm" "install"
npm ERR! node v5.9.0
npm ERR! npm  v3.8.2
npm ERR! code Z_BUF_ERROR
npm ERR! errno -5

npm ERR! unexpected end of file
```

It looks like disabling shrinkwrap fixes this problem. This is an
example PR to do it. But we probably don't want to disable shrinkwrap...

Thoughts, @chrisnojima and @cjb?