### PR TITLE
Pass elements around instead of components : fixes thrashing

### DIFF
--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -1,4 +1,5 @@
 /* @flow */
+import React from 'react'
 import * as Constants from '../../constants/login'
 import * as CommonConstants from '../../constants/common'
 import {bindActionCreators} from 'redux'
@@ -375,71 +376,60 @@ export function openAccountResetPage () : AsyncAction {
 }
 
 function makeKex2IncomingMap (dispatch, getState) : incomingCallMapType {
-  function appendRoute (component: any, props: Object) {
-    dispatch(routeAppend({
-      parseRoute: {
-        componentAtTop: {
-          component, props
-        }
-      }
-    }))
+  function appendRouteElement (element: React$Element) {
+    dispatch(routeAppend({parseRoute: {componentAtTop: {element}}}))
   }
 
   let username = null
 
   return {
     'keybase.1.loginUi.getEmailOrUsername': (param, response) => {
-      appendRoute(UsernameOrEmail, {
-        onSubmit: usernameOrEmail => {
-          username = usernameOrEmail
-          response.result(usernameOrEmail)
-        },
-        onBack: () => dispatch(cancelLogin(response))
-      })
+      appendRouteElement((
+        <UsernameOrEmail
+          onSubmit={usernameOrEmail => {
+            username = usernameOrEmail
+            response.result(usernameOrEmail)
+          }}
+          onBack={() => dispatch(cancelLogin(response))} />))
     },
     'keybase.1.provisionUi.chooseDevice': ({devices}, response) => {
-      appendRoute(SelectOtherDevice, {
-        devices,
-        onSelect: deviceID => {
-          const type: DeviceRole = devices[devices.findIndex(d => d.deviceID === deviceID)].type
-          const role = {
-            mobile: Constants.codePageDeviceRoleExistingPhone,
-            computer: Constants.codePageDeviceRoleExistingComputer
-          }[type]
-          dispatch(setCodePageOtherDeviceRole(role))
-          response.result(deviceID)
-        },
-        onWont: () => response.result(''),
-        onBack: () => dispatch(cancelLogin(response))
-      })
+      appendRouteElement((
+        <SelectOtherDevice
+          devices={devices}
+          onSelect={deviceID => {
+            const type: DeviceRole = devices[devices.findIndex(d => d.deviceID === deviceID)].type
+            const role = {
+              mobile: Constants.codePageDeviceRoleExistingPhone,
+              computer: Constants.codePageDeviceRoleExistingComputer
+            }[type]
+            dispatch(setCodePageOtherDeviceRole(role))
+            response.result(deviceID)
+          }}
+          onWont={() => response.result('')}
+          onBack={() => dispatch(cancelLogin(response))}/>))
     },
     'keybase.1.secretUi.getPassphrase': ({pinentry: {type, prompt, retryLabel}}, response) => {
       switch (type) {
-        case enums.secretUi.PassphraseType.paperKey: {
-          appendRoute(PaperKey, {
-            mapStateToProps: state => state.login,
-            onSubmit: passphrase => response.result({
-              passphrase,
-              storeSecret: false
-            }),
-            onBack: () => dispatch(cancelLogin(response)),
-            error: retryLabel
-          })
+        case enums.secretUi.PassphraseType.paperKey:
+          appendRouteElement((
+            <PaperKey
+              mapStateToProps={state => state.login}
+              onSubmit={(passphrase: string) => { response.result({passphrase, storeSecret: false}) }} // eslint-disable-line arrow-parens
+              onBack={() => { dispatch(cancelLogin(response)) }}
+              error={retryLabel}/>))
           break
-        }
-        case enums.secretUi.PassphraseType.passPhrase: {
-          appendRoute(Passphrase, {
-            prompt,
-            onSubmit: passphrase => response.result({
-              passphrase,
-              storeSecret: false
-            }),
-            onBack: () => dispatch(cancelLogin(response)),
-            error: retryLabel,
-            username
-          })
+        case enums.secretUi.PassphraseType.passPhrase:
+          appendRouteElement((
+            <Passphrase
+              prompt={prompt}
+              onSubmit={passphrase => response.result({
+                passphrase,
+                storeSecret: false
+              })}
+              onBack={() => dispatch(cancelLogin(response))}
+              error={retryLabel}
+              username={username} />))
           break
-        }
         default:
           response.error({
             code: enums.constants.StatusCode.scnotfound,
@@ -453,18 +443,18 @@ function makeKex2IncomingMap (dispatch, getState) : incomingCallMapType {
       dispatch(askForCodePage(phrase => { response.result({phrase, secret: null}) }, response))
     },
     'keybase.1.provisionUi.PromptNewDeviceName': ({existingDevices, errorMessage}, response) => {
-      appendRoute(SetPublicName, {
-        existingDevices,
-        deviceNameError: errorMessage,
-        onSubmit: deviceName => { response.result(deviceName) },
-        onBack: () => dispatch(cancelLogin(response))
-      })
+      appendRouteElement((
+        <SetPublicName
+          existingDevices={existingDevices}
+          deviceNameError={errorMessage}
+          onSubmit={deviceName => { response.result(deviceName) }}
+          onBack={() => dispatch(cancelLogin(response))} />))
     },
     'keybase.1.provisionUi.chooseGPGMethod': (param, response) => {
-      appendRoute(GPGSign, {
-        onSubmit: exportKey => response.result(exportKey ? enums.provisionUi.GPGMethod.gpgImport : enums.provisionUi.GPGMethod.gpgSign),
-        onBack: () => dispatch(cancelLogin(response))
-      })
+      appendRouteElement((
+        <GPGSign
+          onSubmit={exportKey => response.result(exportKey ? enums.provisionUi.GPGMethod.gpgImport : enums.provisionUi.GPGMethod.gpgSign)}
+          onBack={() => dispatch(cancelLogin(response))} />))
     },
     'keybase.1.provisionUi.ProvisioneeSuccess': (param, response) => {
       response.result()

--- a/shared/libs/flow-interface.js
+++ b/shared/libs/flow-interface.js
@@ -1,3 +1,4 @@
+/*eslint-disable */
 declare module 'electron' {
   declare var exports: any;
 }
@@ -65,10 +66,11 @@ declare module 'react-addons-perf' {
   declare var exports: {
     start: () => void,
     stop: () => void,
-    getLastMeasurements: () => void,
-    printInclusive: () => void,
-    printExclusive: () => void,
-    printWasted: () => void
+    getLastMeasurements: () => Object,
+    printInclusive: (measurements: Object) => void,
+    printExclusive: (measurements: Object) => void,
+    printWasted: (measurements: Object) => void,
+    printDOM: (measurements: Object) => void
   };
 }
 

--- a/shared/login/index.js
+++ b/shared/login/index.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React, {Component} from 'react'
+import React from 'react'
 import Intro from './forms/intro'
 import ErrorText from './error.render'
 
@@ -12,29 +12,31 @@ import type {URI} from '../reducers/router'
 
 function loginRouter (currentPath: Map<string, string>, uri: URI): any {
   // Fallback (for debugging)
-  let form = <ErrorText currentPath={currentPath}/>
+  let element = <ErrorText currentPath={currentPath}/>
 
   const path = currentPath.get('path')
+  let {componentAtTop: {component: Component, props, element: dynamicElement}} = currentPath.get('parseRoute') || {componentAtTop: {}}
 
-  const {componentAtTop: {component: Component, props}} = currentPath.get('parseRoute') || {componentAtTop: {}}
-  if (Component) {
-    form = <Component {...props}/>
+  if (dynamicElement) {
+    element = dynamicElement
+  } else if (Component) {
+    element = <Component {...props} />
   } else {
     switch (path) {
       case 'root':
-        form = <Intro/>
+        element = <Intro />
         break
       case 'signup':
         return signupRouter(currentPath, uri)
       case 'login':
-        form = <Login />
+        element = <Login />
         break
     }
   }
 
   return {
     componentAtTop: {
-      component: () => form,
+      element,
       hideBack: true
     },
     parseNextRoute: loginRouter

--- a/shared/login/register/paper-key/index.js.flow
+++ b/shared/login/register/paper-key/index.js.flow
@@ -2,7 +2,7 @@
 import React, {Component} from 'react'
 
 export type Props = {
-  onSubmit: () => void,
+  onSubmit: (paperKey: string) => void,
   onBack: () => void
 }
 

--- a/shared/login/signup/index.js
+++ b/shared/login/signup/index.js
@@ -18,47 +18,47 @@ import type {URI} from '../../reducers/router'
 
 export default function signupRouter (currentPath: Map<string, string>, uri: URI): any {
   // Fallback (for debugging)
-  let form = <ErrorText currentPath={currentPath} />
+  let element = <ErrorText currentPath={currentPath} />
 
   const path = currentPath.get('path')
 
   const {component: Component, props} = currentPath.get('parseRoute') || {}
   if (Component) {
-    form = <Component {...props}/>
+    element = <Component {...props}/>
   } else {
     switch (path) {
       case 'signup':
       case 'inviteCode':
-        form = <InviteCode/>
+        element = <InviteCode />
         break
       case 'requestInvite':
-        form = <RequestInvite/>
+        element = <RequestInvite />
         break
       case 'requestInviteSuccess':
-        form = <RequestInviteSuccess/>
+        element = <RequestInviteSuccess />
         break
       case 'usernameAndEmail':
-        form = <UsernameEmailForm/>
+        element = <UsernameEmailForm />
         break
       case 'passphraseSignup':
-        form = <PassphraseSignup/>
+        element = <PassphraseSignup />
         break
       case 'deviceName':
-        form = <DeviceName/>
+        element = <DeviceName />
         break
       case 'paperkey':
       case 'success':
-        form = <Success/>
+        element = <Success />
         break
       case 'signupError':
-        form = <SignupError/>
+        element = <SignupError />
         break
     }
   }
 
   return {
     componentAtTop: {
-      component: () => form,
+      element,
       hideBack: true
     },
     parseNextRoute: signupRouter

--- a/shared/router/meta-navigator.render.desktop.js
+++ b/shared/router/meta-navigator.render.desktop.js
@@ -15,11 +15,13 @@ class MetaNavigatorRender extends Component {
     const {rootComponent, uri, getComponentAtTop} = this.props
     const {componentAtTop} = getComponentAtTop(rootComponent, uri)
     const Module = componentAtTop.component
+    const element = componentAtTop.element
     const hideBack = !!componentAtTop.hideBack
 
     return (
       <div style={{...globalStyles.flexBoxColumn, flex: 1}}>
-        <Module {...componentAtTop.props} />
+        {element}
+        {!element && Module && <Module {...componentAtTop.props}/>}
         {!hideBack && uri && uri.count() > 1 && <BackButton onClick={() => this.onBack()} style={styles.backButton}/>}
       </div>
     )

--- a/shared/util/load-perf.js
+++ b/shared/util/load-perf.js
@@ -7,7 +7,7 @@ function print (...rest) {
 
 export default function () {
   let start = false
-  const onPerf = () => {
+  const onPerf = showDom => {
     setImmediate(() => {
       const Perf = require('react-addons-perf')
 
@@ -24,6 +24,10 @@ export default function () {
         Perf.printExclusive(measurements)
         print('Wasted')
         Perf.printWasted(measurements)
+        if (showDom) {
+          print('DOM')
+          Perf.printDOM(measurements)
+        }
       }
 
       start = !start
@@ -31,7 +35,7 @@ export default function () {
   }
 
   if (reactPerf) {
-    onPerf()
+    onPerf(false)
   }
 
   window.KBPERF = onPerf


### PR DESCRIPTION
We had an existing pattern where we would pass around a component + its props so that eventually something (like the meta navigator) will build the react element and return. This allows code that injects this to make simple mistakes which causes consistency thrashing. for example in the master code if you provision and go to enter the public name you'll see the public name field will thrash as its making rpc calls. This is due to us passing a closure to the meta navigator which is anonymous and causes the root component to be entirely replaces with every action. Passing a simple react element will make this flow a lot harder to accidentally do. It also allows the props to correctly be checked!

@keybase/react-hackers 