### PR TITLE
Unlock folders paper key desktop 584

### DIFF
--- a/shared/actions/unlock-folders.js
+++ b/shared/actions/unlock-folders.js
@@ -1,10 +1,11 @@
 /* @flow */
 
 import engine from '../engine'
+import HiddenString from '../util/hidden-string'
 import * as Constants from '../constants/unlock-folders'
 
 import type {TypedAsyncAction} from '../constants/types/flux'
-import type {LoadDevices, ToPaperKeyInput, CheckPaperKey, Finish, Close} from '../constants/unlock-folders'
+import type {LoadDevices, ToPaperKeyInput, OnBackFromPaperKey, CheckPaperKey, Finish, Close, Waiting} from '../constants/unlock-folders'
 import type {device_deviceList_rpc} from '../constants/types/flow-types'
 
 export function loadDevice (): TypedAsyncAction<LoadDevices> {
@@ -38,10 +39,23 @@ export function toPaperKeyInput (): ToPaperKeyInput {
   return {type: Constants.toPaperKeyInput, payload: {}}
 }
 
-export function checkPaperKey (): TypedAsyncAction<CheckPaperKey> {
+export function onBackFromPaperKey (): OnBackFromPaperKey {
+  return {type: Constants.onBackFromPaperKey, payload: {}}
+}
+
+function waiting (currentlyWaiting: boolean): Waiting {
+  return {type: Constants.waiting, payload: currentlyWaiting}
+}
+
+export function checkPaperKey (paperKey: HiddenString): TypedAsyncAction<CheckPaperKey | Waiting> {
   return dispatch => {
     // TODO figure out what service request to ask for
-    dispatch({type: Constants.checkPaperKey, payload: {success: true}})
+
+    dispatch(waiting(true))
+    setTimeout(() => {
+      dispatch(waiting(false))
+      dispatch({type: Constants.checkPaperKey, payload: {success: true}})
+    }, 1e3)
   }
 }
 

--- a/shared/actions/unlock-folders.js
+++ b/shared/actions/unlock-folders.js
@@ -50,6 +50,7 @@ function waiting (currentlyWaiting: boolean): Waiting {
 export function checkPaperKey (paperKey: HiddenString): TypedAsyncAction<CheckPaperKey | Waiting> {
   return dispatch => {
     // TODO figure out what service request to ask for
+    // TODO Use the waiting ability of the engine instead of manually dispatching
 
     dispatch(waiting(true))
     setTimeout(() => {

--- a/shared/common-adapters/button.js.flow
+++ b/shared/common-adapters/button.js.flow
@@ -7,10 +7,10 @@ export type Props = {
   label: ?string,
   style?: ?Object,
   type: 'Primary' | 'Secondary' | 'Danger' | 'Follow' | 'Following' | 'Unfollow',
-  disabled?: bool,
-  waiting?: bool,
-  small?: bool,
-  fullWidth?: bool
+  disabled?: ?boolean,
+  waiting?: ?boolean,
+  small?: boolean,
+  fullWidth?: boolean
 }
 
 declare export default class Button extends Component {

--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -4,6 +4,7 @@ import {TextField} from 'material-ui'
 import {globalStyles, globalColors} from '../styles/style-guide'
 import {styles as TextStyles, specialStyles} from './text'
 import materialTheme from '../styles/material-theme.desktop'
+import MultiLineInput from './multi-line-input.desktop'
 
 import type {Props} from './input'
 
@@ -43,6 +44,18 @@ export default class Input extends Component {
   }
 
   render () {
+    if (this.props.multiLine) {
+      return (
+        <MultiLineInput
+          autoFocus={this.props.autoFocus}
+          errorText={this.props.errorText}
+          onChange={this.props.onChange}
+          onEnterKeyDown={this.props.onEnterKeyDown}
+          hintText={this.props.hintText}
+          style={this.props.style}/>
+      )
+    }
+
     const style = this.props.small ? styles.containerSmall : styles.container
     const textStyle = this.props.small ? styles.inputSmall : styles.input
 

--- a/shared/common-adapters/input.js.flow
+++ b/shared/common-adapters/input.js.flow
@@ -2,7 +2,7 @@
 
 import React, {Component} from 'react'
 
-export type Props = {
+export type Props = $Shape<{
   autoFocus?: bool,
   errorText?: ?string,
   floatingLabelText?: string,
@@ -18,7 +18,7 @@ export type Props = {
   value?: ?string,
   small?: bool,
   errorStyle?: Object
-}
+}>
 
 declare export default class Input extends React.Component {
   props: Props;

--- a/shared/common-adapters/multi-line-input.desktop.js
+++ b/shared/common-adapters/multi-line-input.desktop.js
@@ -59,6 +59,7 @@ const containerStyle = {
 
 const hintTextStyle = {
   ...transition('opacity'),
+  cursor: 'text',
   color: globalColors.black10,
   textAlign: 'center'
 }

--- a/shared/common-adapters/multi-line-input.desktop.js
+++ b/shared/common-adapters/multi-line-input.desktop.js
@@ -1,0 +1,88 @@
+// @flow
+import React, {Component} from 'react'
+import {globalStyles, globalColors, transition} from '../styles/style-guide'
+import Text from './text'
+import type {Props} from './multi-line-input'
+
+type State = {textContent: string}
+
+export default class MultiLineInput extends Component<void, Props, State> {
+  state: State;
+
+  constructor (props: Props) {
+    super(props)
+    this.state = {textContent: ''}
+  }
+
+  _handleKeyUp (e: SyntheticEvent) {
+    // $FlowIssue
+    this.setState({textContent: e.target.textContent})
+    this.props.onChange && this.props.onChange(e)
+  }
+
+  _handleKeyDown (e: any) {
+    // Check enter
+    if (e.keyCode === 13 && this.props.onEnterKeyDown) {
+      this.props.onEnterKeyDown(e)
+    }
+  }
+
+  _focusTextBox () {
+    if (this.refs && this.refs.textBox) {
+      this.refs.textBox.focus()
+    }
+  }
+
+  render () {
+    return (
+      <div style={{...containerStyle, ...this.props.style}}>
+        <Text
+          style={{...hintTextStyle, ...(this.state.textContent.length > 0 ? {opacity: 0} : {opacity: 1})}}
+          onClick={() => this._focusTextBox()} type='HeaderBig'>{this.props.hintText}</Text>
+        <Text style={inputStyle}
+          contentEditable
+          ref='textBox'
+          onKeyUp={e => this._handleKeyUp(e)}
+          onKeyDown={e => this._handleKeyDown(e)}
+          type='HeaderBig'>type</Text>
+        {this.props.errorText && <Text style={errorTextStyle} type='Error'>{this.props.errorText}</Text>}
+        <div style={underlineStyle}></div>
+      </div>
+    )
+  }
+}
+
+const containerStyle = {
+  ...globalStyles.flexBoxColumn,
+  position: 'relative'
+}
+
+const hintTextStyle = {
+  ...transition('opacity'),
+  color: globalColors.black10,
+  textAlign: 'center'
+}
+
+const inputStyle = {
+  position: 'absolute',
+  bottom: 2, // To align it perfectly with the hintText
+  left: 0,
+  right: 0,
+  outline: 'none',
+  textAlign: 'center'
+}
+
+const underlineStyle = {
+  border: 'solid',
+  borderWidth: 1,
+  borderColor: 'rgba(0, 0, 0, 0.08)'
+}
+
+const errorTextStyle = {
+  position: 'absolute',
+  bottom: -18,
+  left: 0,
+  right: 0,
+  outline: 'none',
+  textAlign: 'center'
+}

--- a/shared/common-adapters/multi-line-input.js.flow
+++ b/shared/common-adapters/multi-line-input.js.flow
@@ -1,0 +1,14 @@
+/* @flow */
+
+import React, {Component} from 'react'
+
+export type Props = $Shape<{
+  autoFocus?: bool,
+  errorText?: ?string,
+  onChange?: (event: Object) => void,
+  onEnterKeyDown?: (event: Object) => void,
+  hintText: ?string,
+  style?: Object
+}>
+
+declare export default class Input extends React.Component<void, Props, void> {}

--- a/shared/common-adapters/text.desktop.js
+++ b/shared/common-adapters/text.desktop.js
@@ -58,6 +58,12 @@ export default class Text extends Component {
     }
   }
 
+  focus () {
+    if (this.refs && this.refs.text) {
+      this.refs.text.focus()
+    }
+  }
+
   render () {
     const typeStyle = {
       'HeaderJumbo': styles.textHeaderJumbo,
@@ -112,6 +118,18 @@ export default class Text extends Component {
 
     const terminalPrefix = this._terminalPrefix(this.props.type)
     const className = (this.props.className || '') + ' ' + (linkClassname || '')
+
+    if (this.props.contentEditable) {
+      return (
+        <span
+          ref='text'
+          className={className}
+          style={style}
+          contentEditable
+          onKeyUp={this.props.onKeyUp}
+          onKeyDown={this.props.onKeyDown}
+          onClick={this.props.onClick}/>)
+    }
 
     return (
       <span
@@ -230,7 +248,7 @@ export const styles = {
   textError: {
     ...textCommon,
     color: globalColors.red,
-    fontSize: 13,
+    fontSize: 14,
     lineHeight: '17px',
     letterSpacing: '0.2px'
   },

--- a/shared/common-adapters/text.js.flow
+++ b/shared/common-adapters/text.js.flow
@@ -20,7 +20,10 @@ export type Props = {
   lineClamp?: number,
   style?: Object,
   children?: React$Element,
-  className?: string
+  className?: string,
+  contentEditable?: boolean,
+  onKeyDown?: (e: SyntheticEvent) => void,
+  onKeyUp?: (e: SyntheticEvent) => void
 }
 
 declare export default class Text extends React.Component {

--- a/shared/constants/unlock-folders.js
+++ b/shared/constants/unlock-folders.js
@@ -19,6 +19,9 @@ export type LoadDevices = TypedAction<'unlockFolders:loadDevices', {devices: Arr
 export const toPaperKeyInput = 'unlockFolders:toPaperKeyInput'
 export type ToPaperKeyInput = TypedAction<'unlockFolders:toPaperKeyInput', {}, {}>
 
+export const onBackFromPaperKey = 'unlockFolders:onBackFromPaperKey'
+export type OnBackFromPaperKey = TypedAction<'unlockFolders:onBackFromPaperKey', {}, {}>
+
 export const checkPaperKey = 'unlockFolders:checkPaperKey'
 export type CheckPaperKey = TypedAction<'unlockFolders:checkPaperKey', {success: true}, {error: HiddenString}>
 
@@ -28,4 +31,7 @@ export type Finish = TypedAction<'unlockFolders:finish', {}, {}>
 export const close = 'unlockFolders:close'
 export type Close = TypedAction<'unlockFolders:close', {}, {}>
 
-export type UnlockFolderActions = LoadDevices | ToPaperKeyInput | CheckPaperKey | Finish | Close
+export const waiting = 'unlockFolders:waiting'
+export type Waiting = TypedAction<'unlockFolders:waiting', boolean, {}>
+
+export type UnlockFolderActions = LoadDevices | ToPaperKeyInput | OnBackFromPaperKey | CheckPaperKey | Finish | Close | Waiting

--- a/shared/login/register/code-page/index.render.desktop.js
+++ b/shared/login/register/code-page/index.render.desktop.js
@@ -66,7 +66,6 @@ export default class CodePageRender extends Component {
         <Icon style={{marginTop: 30, marginBottom: 40}} type='phone-text-code' />
         <Input
           style={{alignSelf: 'stretch'}}
-          fullWidth
           hintText='opp blezzard tofi pando agg whi pany yaga jocket daubt bruwnstane hubit yas'
           floatingLabelText='Text code'
           multiLine

--- a/shared/more/style-sheet.render.desktop.js
+++ b/shared/more/style-sheet.render.desktop.js
@@ -104,7 +104,7 @@ export default class Render extends Component {
             <Input floatingLabelText='Label' errorText='Error lorem ipsum dolor sit amet.'/>
             <Input multiLine floatingLabelText='Multiline'/>
             <Input multiLine floatingLabelText='Multiline' errorText='Error lorem ipsum dolor sit amet.'/>
-            <Input floatingLabelText='Label' defaultValue='Blah'/>
+            <Input floatingLabelText='Label'/>
             <Input floatingLabelText='foo' rows={1} rowsMax={3} multiLine />
             <Input hintText='foo' rows={1} rowsMax={3} multiLine />
             <Input multiLine hintText='opp blezzard tofi pando agg whi pany yaga jocket daubt bruwnstane hubit yas' style={{marginTop: 30}} />

--- a/shared/reducers/unlock-folders.js
+++ b/shared/reducers/unlock-folders.js
@@ -10,11 +10,13 @@ import type {UnlockFolderActions, Device} from '../constants/unlock-folders'
 export type State = {
   phase: 'dead' | 'promptOtherDevice' | 'paperKeyInput' | 'success',
   devices: ?Array<Device>,
+  waiting: boolean,
   paperkeyError: ?HiddenString
 }
 
 const initialState: State = {
   phase: 'dead',
+  waiting: false,
   devices: null,
   paperkeyError: null
 }
@@ -37,6 +39,22 @@ export default function (state: State = initialState, action: UnlockFolderAction
           ...state,
           devices
         }
+      }
+
+    case Constants.waiting:
+      if (action.error) {
+        return state
+      }
+
+      return {
+        ...state,
+        waiting: action.payload
+      }
+
+    case Constants.onBackFromPaperKey:
+      return {
+        ...state,
+        phase: 'promptOtherDevice'
       }
 
     case Constants.toPaperKeyInput:
@@ -71,11 +89,13 @@ export default function (state: State = initialState, action: UnlockFolderAction
 export const mocks: {[key: string]: State} = {
   promptOtherSingleDevice: {
     phase: 'promptOtherDevice',
+    waiting: false,
     devices: [{type: 'desktop', name: 'Cray', deviceID: 'bada55'}],
     paperkeyError: null
   },
   promptOtherMultiDevice: {
     phase: 'promptOtherDevice',
+    waiting: false,
     devices: [
       {type: 'desktop', name: 'Cray', deviceID: 'c0ffee'},
       {type: 'desktop', name: 'Watson', deviceID: 'beef'},
@@ -85,6 +105,7 @@ export const mocks: {[key: string]: State} = {
   },
   promptOtherLotsaDevice: {
     phase: 'promptOtherDevice',
+    waiting: false,
     devices: [
       {type: 'desktop', name: 'Cray', deviceID: 'c0ffee'},
       {type: 'desktop', name: 'Watson', deviceID: 'beef1'},
@@ -107,16 +128,25 @@ export const mocks: {[key: string]: State} = {
   },
   paperKeyInput: {
     phase: 'paperKeyInput',
+    waiting: false,
     devices: [],
     paperkeyError: null
   },
   paperKeyInputWithError: {
     phase: 'paperKeyInput',
+    waiting: false,
+    devices: [],
+    paperkeyError: new HiddenString('Invalid paper key')
+  },
+  paperKeyInputWithErrorWaiting: {
+    phase: 'paperKeyInput',
+    waiting: true,
     devices: [],
     paperkeyError: new HiddenString('Invalid paper key')
   },
   success: {
     phase: 'success',
+    waiting: false,
     devices: [],
     paperkeyError: null
   }

--- a/shared/unlock-folders/device-list.desktop.js
+++ b/shared/unlock-folders/device-list.desktop.js
@@ -36,8 +36,6 @@ export default class DeviceList extends Component<void, Props, void> {
         <div style={styles.buttonsContainer}>
           <Button type='Secondary' label='Enter a paper key instead' style={styles.enterPaperKey}
             onClick={this.props.toPaperKeyInput}/>
-          <Button type='Primary' label='Access my folders' disabled style={styles.accessFolders}
-            onClick={() => {}}/>
         </div>
       </div>
     )

--- a/shared/unlock-folders/index.js
+++ b/shared/unlock-folders/index.js
@@ -23,7 +23,8 @@ export type Props = {
   onBackFromPaperKey: () => void,
   onContinueFromPaperKey: (paperkey: HiddenString) => void,
   paperkeyError: ?HiddenString,
-  waiting: boolean
+  waiting: boolean,
+  onFinish: () => void
 }
 
 class UnlockFolders extends Component<void, Props, void> {
@@ -38,7 +39,7 @@ class UnlockFolders extends Component<void, Props, void> {
         onContinueFromPaperKey={this.props.onContinueFromPaperKey}
         paperkeyError={this.props.paperkeyError}
         waiting={this.props.waiting}
-        />
+        onFinish={this.props.onFinish}/>
     )
   }
 }
@@ -53,6 +54,7 @@ const Connected: Class<ConnectedComponent<OwnProps>> = typedConnect(
     toPaperKeyInput: () => { dispatch(actions.toPaperKeyInput()) },
     onBackFromPaperKey: () => { dispatch(actions.onBackFromPaperKey()) },
     onContinueFromPaperKey: pk => { dispatch(actions.checkPaperKey(pk)) },
+    onFinish: () => { dispatch(actions.finish()) },
     paperkeyError,
     waiting,
     devices,

--- a/shared/unlock-folders/index.js
+++ b/shared/unlock-folders/index.js
@@ -2,13 +2,14 @@
 
 import React, {Component} from 'react'
 import typedConnect, {ConnectedComponent} from '../util/typed-connect'
+import HiddenString from '../util/hidden-string'
 
 import type {State as UnlockFoldersState} from '../reducers/unlock-folders'
 import type {Device, UnlockFolderActions} from '../constants/unlock-folders'
 import type {TypedState} from '../constants/reducer'
 import type {TypedDispatch} from '../constants/types/flux'
 
-import {close, toPaperKeyInput} from '../actions/unlock-folders'
+import * as actions from '../actions/unlock-folders'
 
 import Render from './render'
 
@@ -18,16 +19,26 @@ export type Props = {
   devices: ?Array<Device>,
   phase: UnlockFoldersState.phase,
   close: () => void,
-  toPaperKeyInput: () => void
+  toPaperKeyInput: () => void,
+  onBackFromPaperKey: () => void,
+  onContinueFromPaperKey: (paperkey: HiddenString) => void,
+  paperkeyError: ?HiddenString,
+  waiting: boolean
 }
 
 class UnlockFolders extends Component<void, Props, void> {
   render () {
     return (
       <Render
-        devices={this.props.devices} phase={this.props.phase}
+        phase={this.props.phase}
+        devices={this.props.devices}
         onClose={this.props.close}
-        toPaperKeyInput={this.props.toPaperKeyInput}/>
+        toPaperKeyInput={this.props.toPaperKeyInput}
+        onBackFromPaperKey={this.props.onBackFromPaperKey}
+        onContinueFromPaperKey={this.props.onContinueFromPaperKey}
+        paperkeyError={this.props.paperkeyError}
+        waiting={this.props.waiting}
+        />
     )
   }
 }
@@ -37,9 +48,13 @@ type Dispatch = TypedDispatch<UnlockFolderActions>
 // otherwise flow doesn't type it quite correctly and you loose OwnProps checking
 // Luckily if this declared type is wrong, flow will tell us.
 const Connected: Class<ConnectedComponent<OwnProps>> = typedConnect(
-  ({unlockFolders: {devices, phase}}: TypedState, dispatch: Dispatch, ownProps: OwnProps): Props => ({
-    close: () => { dispatch(close()) },
-    toPaperKeyInput: () => { dispatch(toPaperKeyInput()) },
+  ({unlockFolders: {devices, phase, paperkeyError, waiting}}: TypedState, dispatch: Dispatch, ownProps: OwnProps): Props => ({
+    close: () => { dispatch(actions.close()) },
+    toPaperKeyInput: () => { dispatch(actions.toPaperKeyInput()) },
+    onBackFromPaperKey: () => { dispatch(actions.onBackFromPaperKey()) },
+    onContinueFromPaperKey: pk => { dispatch(actions.checkPaperKey(pk)) },
+    paperkeyError,
+    waiting,
     devices,
     phase
   })

--- a/shared/unlock-folders/paper-key-input.desktop.js
+++ b/shared/unlock-folders/paper-key-input.desktop.js
@@ -1,0 +1,72 @@
+// @flow
+
+import React, {Component} from 'react'
+import {globalStyles} from '../styles/style-guide'
+import {Text, Button, BackButton, Icon} from '../common-adapters'
+import MultiLineInput from '../common-adapters/multi-line-input.desktop'
+import HiddenString from '../util/hidden-string'
+
+export type Props = {
+  onBack: () => void,
+  onContinue: (paperkey: HiddenString) => void,
+  paperkeyError: ?HiddenString,
+  waiting: ?boolean
+}
+
+type State = {
+  paperkey: string
+}
+
+export default class PaperKeyInput extends Component<void, Props, State> {
+  state: State;
+
+  constructor (props: Props) {
+    super(props)
+    this.state = {paperkey: ''}
+  }
+
+  render () {
+    const errorText = this.props.paperkeyError && this.props.paperkeyError.stringValue()
+
+    return (
+      <div style={{...globalStyles.flexBoxColumn, alignItems: 'center'}}>
+        <BackButton onClick={this.props.onBack} style={backStyle}/>
+        <Text style={headerTextStyle} type='Body'>Type in your paper key:</Text>
+        <Icon style={paperKeyIconStyle} type='paper-key-m'/>
+        <MultiLineInput style={paperKeyInputStyle}
+          onChange={e => this.setState({paperkey: e.target.textContent})}
+          errorText={errorText}
+          hintText='elephont sturm cectus opp blezzard tofi pando agg whi pany yaga jocket daubt ruril globil cose'/>
+        <Button type='Primary' label='Continue' style={continueStyle}
+          waiting={this.props.waiting}
+          onClick={this.props.onContinue}/>
+      </div>
+    )
+  }
+}
+
+const headerTextStyle = {
+  marginTop: 30
+}
+
+const paperKeyIconStyle = {
+  marginTop: 17
+}
+
+const paperKeyInputStyle = {
+  marginTop: 18,
+  width: 440
+}
+
+const backStyle = {
+  position: 'absolute',
+  top: 30,
+  left: 30
+}
+
+const continueStyle = {
+  marginTop: 38,
+  height: 32,
+  width: 116,
+  alignSelf: 'flex-end'
+}

--- a/shared/unlock-folders/paper-key-input.desktop.js
+++ b/shared/unlock-folders/paper-key-input.desktop.js
@@ -65,6 +65,7 @@ const backStyle = {
 }
 
 const continueStyle = {
+  marginRight: 30,
   marginTop: 38,
   height: 32,
   width: 116,

--- a/shared/unlock-folders/paper-key-input.desktop.js
+++ b/shared/unlock-folders/paper-key-input.desktop.js
@@ -2,8 +2,7 @@
 
 import React, {Component} from 'react'
 import {globalStyles} from '../styles/style-guide'
-import {Text, Button, BackButton, Icon} from '../common-adapters'
-import MultiLineInput from '../common-adapters/multi-line-input.desktop'
+import {Text, Button, BackButton, Icon, Input} from '../common-adapters'
 import HiddenString from '../util/hidden-string'
 
 export type Props = {
@@ -33,7 +32,7 @@ export default class PaperKeyInput extends Component<void, Props, State> {
         <BackButton onClick={this.props.onBack} style={backStyle}/>
         <Text style={headerTextStyle} type='Body'>Type in your paper key:</Text>
         <Icon style={paperKeyIconStyle} type='paper-key-m'/>
-        <MultiLineInput style={paperKeyInputStyle}
+        <Input multiLine style={paperKeyInputStyle}
           onChange={e => this.setState({paperkey: e.target.textContent})}
           errorText={errorText}
           hintText='elephont sturm cectus opp blezzard tofi pando agg whi pany yaga jocket daubt ruril globil cose'/>

--- a/shared/unlock-folders/render.desktop.js
+++ b/shared/unlock-folders/render.desktop.js
@@ -3,6 +3,7 @@
 import React, {Component} from 'react'
 
 import DeviceList from './device-list.desktop'
+import PaperKeyInput from './paper-key-input.desktop'
 import {Header} from '../common-adapters'
 
 import type {Props} from './render'
@@ -17,6 +18,15 @@ export default class Render extends Component<void, Props, void> {
         innerComponent = <DeviceList devices={this.props.devices} toPaperKeyInput={this.props.toPaperKeyInput}/>
         break
       case 'paperKeyInput':
+        innerComponent = (
+          <PaperKeyInput
+            toPaperKeyInput={this.props.toPaperKeyInput}
+            onBack={this.props.onBackFromPaperKey}
+            onContinue={this.props.onContinueFromPaperKey}
+            paperkeyError={this.props.paperkeyError}
+            waiting={this.props.waiting}/>
+        )
+        break
       case 'success':
         innerComponent = (<div>todo</div>)
     }

--- a/shared/unlock-folders/render.desktop.js
+++ b/shared/unlock-folders/render.desktop.js
@@ -4,6 +4,7 @@ import React, {Component} from 'react'
 
 import DeviceList from './device-list.desktop'
 import PaperKeyInput from './paper-key-input.desktop'
+import Success from './success.desktop'
 import {Header} from '../common-adapters'
 
 import type {Props} from './render'
@@ -28,7 +29,10 @@ export default class Render extends Component<void, Props, void> {
         )
         break
       case 'success':
-        innerComponent = (<div>todo</div>)
+        innerComponent = (
+          <Success onAccessFolders={this.props.onFinish}/>
+        )
+        break
     }
 
     return (

--- a/shared/unlock-folders/render.js.flow
+++ b/shared/unlock-folders/render.js.flow
@@ -3,12 +3,17 @@
 import {Component} from 'react'
 import type {State} from '../reducers/unlock-folders'
 import type {Device} from '../constants/unlock-folders'
+import HiddenString from '../util/hidden-string'
 
 export type Props = {
   phase: State.phase,
   devices: ?Array<Device>,
   onClose: () => void,
-  toPaperKeyInput: () => void
+  toPaperKeyInput: () => void,
+  onBackFromPaperKey: () => void,
+  onContinueFromPaperKey: (paperkey: HiddenString) => void,
+  paperkeyError: ?HiddenString,
+  waiting: boolean
 }
 
 export default class Render extends Component<void, Props, void> {}

--- a/shared/unlock-folders/render.js.flow
+++ b/shared/unlock-folders/render.js.flow
@@ -13,7 +13,8 @@ export type Props = {
   onBackFromPaperKey: () => void,
   onContinueFromPaperKey: (paperkey: HiddenString) => void,
   paperkeyError: ?HiddenString,
-  waiting: boolean
+  waiting: boolean,
+  onFinish: () => void
 }
 
 export default class Render extends Component<void, Props, void> {}

--- a/shared/unlock-folders/success.desktop.js
+++ b/shared/unlock-folders/success.desktop.js
@@ -1,0 +1,40 @@
+// @flow
+
+import React, {Component} from 'react'
+import {globalStyles} from '../styles/style-guide'
+import {Text, Button, Icon} from '../common-adapters'
+
+export type Props = {
+  onAccessFolders: () => void,
+}
+
+export default class PaperKeyInput extends Component<void, Props, void> {
+
+  render () {
+    return (
+      <div style={{...globalStyles.flexBoxColumn, alignItems: 'center'}}>
+        <Icon style={foldersUnlockedStyle} type='folders-unlocked-m'/>
+        <Text style={successStyle} type='Body'>Success</Text>
+        <Text style={{textAlign: 'center'}} type='Body'>You have unlocked your folders on this computer.</Text>
+        <Button type='Primary' label='Access my folders' style={finishStyle} onClick={this.props.onAccessFolders}/>
+      </div>
+    )
+  }
+}
+
+const foldersUnlockedStyle = {
+  marginTop: 72
+}
+
+const successStyle = {
+  marginTop: 28,
+  textAlign: 'center'
+}
+
+const finishStyle = {
+  marginTop: 56,
+  marginRight: 30,
+  height: 32,
+  width: 181,
+  alignSelf: 'flex-end'
+}


### PR DESCRIPTION
@keybase/react-hackers 

This adds 3 things

#### Multi line input for paper keys, we had a hacked version of this, but:
* it was really hard to style (the content inside overflowed the bounds)
* The text grew downward

#### Paper key input screen for the unlock folders flow

#### Success screen for the unlock folders flow


## Preview
@keybase/design 

<img width="559" alt="screen shot 2016-03-21 at 6 57 57 pm" src="https://cloud.githubusercontent.com/assets/594035/13940146/0bfca696-ef98-11e5-8c53-f4e67d90194d.png">

## TODO (possibly in a future PR)

The waiting state looks weird on the button, the spinner is too big?
