### PR TITLE
Add tests for provisioning after account reset

### DIFF
--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -348,4 +348,5 @@ func ResetAccount(tc libkb.TestContext, u *FakeUser) {
 		tc.T.Fatal(err)
 	}
 	tc.T.Logf("nuke api result: %+v", res)
+	Logout(tc)
 }

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -330,3 +330,22 @@ func SetupTwoDevices(t *testing.T, nm string) (user *FakeUser, dev1 libkb.TestCo
 
 	return user, dev1, dev2, cleanup
 }
+
+func ResetAccount(tc libkb.TestContext, u *FakeUser) {
+	pps, err := tc.G.LoginState().GetPassphraseStreamWithPassphrase(u.Passphrase)
+	if err != nil {
+		tc.T.Fatal(err)
+	}
+	arg := libkb.APIArg{
+		Endpoint:    "nuke",
+		NeedSession: true,
+		Args: libkb.HTTPArgs{
+			"pwh": libkb.HexArg(pps.PWHash()),
+		},
+	}
+	res, err := tc.G.API.Post(arg)
+	if err != nil {
+		tc.T.Fatal(err)
+	}
+	tc.T.Logf("nuke api result: %+v", res)
+}

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -1794,10 +1794,6 @@ func TestResetAccountLikeNistur(t *testing.T) {
 	// now reset account
 	ResetAccount(tc, u)
 
-	// without this sleep, get
-	// ERROR: can't find a race-free state for 98ef54a78e482ae8be06f254fa4f9d19 (error 236)
-	time.Sleep(time.Second)
-
 	// create provisioner device
 	tcX := SetupEngineTest(t, "login")
 	defer tcX.Cleanup()
@@ -1880,55 +1876,6 @@ func TestResetAccountLikeNistur(t *testing.T) {
 	if err := RunEngine(teng, ctx); err != nil {
 		t.Fatal(err)
 	}
-}
-
-func TestResetAccountRaceFreeState(t *testing.T) {
-	// max: here's a test that generates error 236 reliably
-	t.Skip()
-	tc := SetupEngineTest(t, "login")
-	defer tc.Cleanup()
-
-	// user with synced pgp key
-	u := createFakeUserWithPGPOnly(t, tc)
-	Logout(tc)
-	tc.Cleanup()
-
-	// provision a device with that key
-	tc = SetupEngineTest(t, "login")
-	defer tc.Cleanup()
-
-	ctx := &Context{
-		ProvisionUI: newTestProvisionUIPassphrase(),
-		LoginUI:     &libkb.TestLoginUI{Username: u.Username},
-		LogUI:       tc.G.UI.GetLogUI(),
-		SecretUI:    u.NewSecretUI(),
-		GPGUI:       &gpgtestui{},
-	}
-	eng := NewLogin(tc.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
-	if err := RunEngine(eng, ctx); err != nil {
-		t.Fatal(err)
-	}
-
-	// since this user didn't have any device keys, login should have fixed that:
-	testUserHasDeviceKey(tc)
-
-	// now reset account
-	ResetAccount(tc, u)
-
-	// without this sleep, get
-	// ERROR: can't find a race-free state for 98ef54a78e482ae8be06f254fa4f9d19 (error 236)
-	// time.Sleep(time.Second)
-
-	// create provisioner device
-	tcX := SetupEngineTest(t, "login")
-	defer tcX.Cleanup()
-
-	// this will reprovision as an eldest device:
-	u.LoginOrBust(tcX)
-	if err := AssertProvisioned(tcX); err != nil {
-		t.Fatal(err)
-	}
-	testUserHasDeviceKey(tcX)
 }
 
 type testProvisionUI struct {

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -1574,7 +1574,22 @@ func TestResetAccount(t *testing.T) {
 	defer tc.Cleanup()
 
 	u := CreateAndSignupFakeUser(tc, "login")
+	originalDevice := tc.G.Env.GetDeviceID()
 	ResetAccount(tc, u)
+
+	Logout(tc)
+
+	// this will reprovision as an eldest device:
+	u.LoginOrBust(tc)
+	if err := AssertProvisioned(tc); err != nil {
+		t.Fatal(err)
+	}
+
+	newDevice := tc.G.Env.GetDeviceID()
+
+	if newDevice == originalDevice {
+		t.Errorf("device id did not change: %s", newDevice)
+	}
 }
 
 type testProvisionUI struct {

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -1569,6 +1569,14 @@ func TestProvisionMultipleUsers(t *testing.T) {
 	}
 }
 
+func TestResetAccount(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	u := CreateAndSignupFakeUser(tc, "login")
+	ResetAccount(tc, u)
+}
+
 type testProvisionUI struct {
 	secretCh               chan kex2.Secret
 	method                 keybase1.ProvisionMethod

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -1569,6 +1569,7 @@ func TestProvisionMultipleUsers(t *testing.T) {
 	}
 }
 
+// create a standard user with device keys, reset account, login.
 func TestResetAccount(t *testing.T) {
 	tc := SetupEngineTest(t, "login")
 	defer tc.Cleanup()
@@ -1576,8 +1577,6 @@ func TestResetAccount(t *testing.T) {
 	u := CreateAndSignupFakeUser(tc, "login")
 	originalDevice := tc.G.Env.GetDeviceID()
 	ResetAccount(tc, u)
-
-	Logout(tc)
 
 	// this will reprovision as an eldest device:
 	u.LoginOrBust(tc)
@@ -1590,6 +1589,346 @@ func TestResetAccount(t *testing.T) {
 	if newDevice == originalDevice {
 		t.Errorf("device id did not change: %s", newDevice)
 	}
+
+	testUserHasDeviceKey(tc)
+}
+
+// After resetting account, try provisioning in a clean home dir.
+func TestResetAccountNewHome(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	u := CreateAndSignupFakeUser(tc, "login")
+	originalDevice := tc.G.Env.GetDeviceID()
+	ResetAccount(tc, u)
+
+	tcp := SetupEngineTest(t, "login")
+	// this will reprovision as an eldest device:
+	u.LoginOrBust(tcp)
+	if err := AssertProvisioned(tcp); err != nil {
+		t.Fatal(err)
+	}
+
+	newDevice := tcp.G.Env.GetDeviceID()
+
+	if newDevice == originalDevice {
+		t.Errorf("device id did not change: %s", newDevice)
+	}
+
+	testUserHasDeviceKey(tcp)
+}
+
+// After account reset, establish new eldest keys, paper key.
+// Provision another device with paper key.
+func TestResetAccountPaper(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	u := CreateAndSignupFakeUser(tc, "login")
+	ResetAccount(tc, u)
+
+	// login, creating new eldest key, new paper keys
+	loginUI := &paperLoginUI{Username: u.Username}
+	ctx := &Context{
+		ProvisionUI: newTestProvisionUI(),
+		LogUI:       tc.G.UI.GetLogUI(),
+		GPGUI:       &gpgtestui{},
+		SecretUI:    u.NewSecretUI(),
+		LoginUI:     loginUI,
+	}
+	li := NewLogin(tc.G, libkb.DeviceTypeDesktop, u.Username, keybase1.ClientType_CLI)
+	if err := RunEngine(li, ctx); err != nil {
+		t.Fatal(err)
+	}
+	paper := loginUI.PaperPhrase
+	if len(paper) == 0 {
+		t.Fatal("no paper phrase in login ui")
+	}
+	testUserHasDeviceKey(tc)
+
+	// provision on new device with paper key
+	tcp := SetupEngineTest(t, "login")
+	defer tcp.Cleanup()
+
+	secUI := u.NewSecretUI()
+	secUI.Passphrase = paper
+	provUI := newTestProvisionUIPaper()
+	provLoginUI := &libkb.TestLoginUI{Username: u.Username}
+	ctx = &Context{
+		ProvisionUI: provUI,
+		LogUI:       tcp.G.UI.GetLogUI(),
+		SecretUI:    secUI,
+		LoginUI:     provLoginUI,
+		GPGUI:       &gpgtestui{},
+	}
+	eng := NewLogin(tcp.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	testUserHasDeviceKey(tcp)
+}
+
+// After resetting account, try kex2 provisioning.
+func TestResetAccountKexProvision(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	u := CreateAndSignupFakeUser(tc, "login")
+
+	ResetAccount(tc, u)
+
+	// create provisioner device
+	tcX := SetupEngineTest(t, "login")
+	defer tcX.Cleanup()
+	// this will reprovision as an eldest device:
+	u.LoginOrBust(tcX)
+	if err := AssertProvisioned(tcX); err != nil {
+		t.Fatal(err)
+	}
+	testUserHasDeviceKey(tcX)
+	var secretX kex2.Secret
+	if _, err := rand.Read(secretX[:]); err != nil {
+		t.Fatal(err)
+	}
+	secretCh := make(chan kex2.Secret)
+
+	// provisionee context:
+	tcY := SetupEngineTest(t, "template")
+	defer tcY.Cleanup()
+
+	// provisionee calls login:
+	ctx := &Context{
+		ProvisionUI: newTestProvisionUISecretCh(secretCh),
+		LoginUI:     &libkb.TestLoginUI{Username: u.Username},
+		LogUI:       tcY.G.UI.GetLogUI(),
+		SecretUI:    &libkb.TestSecretUI{},
+		GPGUI:       &gpgtestui{},
+	}
+	eng := NewLogin(tcY.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
+
+	var wg sync.WaitGroup
+
+	// start provisionee
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := RunEngine(eng, ctx); err != nil {
+			t.Errorf("login error: %s", err)
+			return
+		}
+	}()
+
+	// start provisioner
+	provisioner := NewKex2Provisioner(tcX.G, secretX, nil)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		ctx := &Context{
+			SecretUI:    u.NewSecretUI(),
+			ProvisionUI: newTestProvisionUI(),
+		}
+		if err := RunEngine(provisioner, ctx); err != nil {
+			t.Errorf("provisioner error: %s", err)
+			return
+		}
+	}()
+	secretFromY := <-secretCh
+	provisioner.AddSecret(secretFromY)
+
+	wg.Wait()
+
+	if err := AssertProvisioned(tcY); err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure that the provisioned device can use
+	// the passphrase stream cache (use an empty secret ui)
+	arg := &TrackEngineArg{
+		UserAssertion: "t_alice",
+		Options:       keybase1.TrackOptions{BypassConfirm: true},
+	}
+	ctx = &Context{
+		LogUI:      tcY.G.UI.GetLogUI(),
+		IdentifyUI: &FakeIdentifyUI{},
+		SecretUI:   &libkb.TestSecretUI{},
+	}
+
+	teng := NewTrackEngine(arg, tcY.G)
+	if err := RunEngine(teng, ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Try to replicate @nistur sigchain.
+// github issue: https://github.com/keybase/client/issues/2356
+func TestResetAccountLikeNistur(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	// user with synced pgp key
+	u := createFakeUserWithPGPOnly(t, tc)
+	Logout(tc)
+	tc.Cleanup()
+
+	// provision a device with that key
+	tc = SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	ctx := &Context{
+		ProvisionUI: newTestProvisionUIPassphrase(),
+		LoginUI:     &libkb.TestLoginUI{Username: u.Username},
+		LogUI:       tc.G.UI.GetLogUI(),
+		SecretUI:    u.NewSecretUI(),
+		GPGUI:       &gpgtestui{},
+	}
+	eng := NewLogin(tc.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// since this user didn't have any device keys, login should have fixed that:
+	testUserHasDeviceKey(tc)
+
+	// now reset account
+	ResetAccount(tc, u)
+
+	// without this sleep, get
+	// ERROR: can't find a race-free state for 98ef54a78e482ae8be06f254fa4f9d19 (error 236)
+	time.Sleep(time.Second)
+
+	// create provisioner device
+	tcX := SetupEngineTest(t, "login")
+	defer tcX.Cleanup()
+
+	// this will reprovision as an eldest device:
+	u.LoginOrBust(tcX)
+	if err := AssertProvisioned(tcX); err != nil {
+		t.Fatal(err)
+	}
+	testUserHasDeviceKey(tcX)
+	var secretX kex2.Secret
+	if _, err := rand.Read(secretX[:]); err != nil {
+		t.Fatal(err)
+	}
+	secretCh := make(chan kex2.Secret)
+
+	// provisionee context:
+	tcY := SetupEngineTest(t, "template")
+	defer tcY.Cleanup()
+
+	// provisionee calls login:
+	ctx = &Context{
+		ProvisionUI: newTestProvisionUISecretCh(secretCh),
+		LoginUI:     &libkb.TestLoginUI{Username: u.Username},
+		LogUI:       tcY.G.UI.GetLogUI(),
+		SecretUI:    &libkb.TestSecretUI{},
+		GPGUI:       &gpgtestui{},
+	}
+	eng = NewLogin(tcY.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
+
+	var wg sync.WaitGroup
+
+	// start provisionee
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := RunEngine(eng, ctx); err != nil {
+			t.Errorf("login error: %s", err)
+			return
+		}
+	}()
+
+	// start provisioner
+	provisioner := NewKex2Provisioner(tcX.G, secretX, nil)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		ctx := &Context{
+			SecretUI:    u.NewSecretUI(),
+			ProvisionUI: newTestProvisionUI(),
+		}
+		if err := RunEngine(provisioner, ctx); err != nil {
+			t.Errorf("provisioner error: %s", err)
+			return
+		}
+	}()
+	secretFromY := <-secretCh
+	provisioner.AddSecret(secretFromY)
+
+	wg.Wait()
+
+	if err := AssertProvisioned(tcY); err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure that the provisioned device can use
+	// the passphrase stream cache (use an empty secret ui)
+	arg := &TrackEngineArg{
+		UserAssertion: "t_alice",
+		Options:       keybase1.TrackOptions{BypassConfirm: true},
+	}
+	ctx = &Context{
+		LogUI:      tcY.G.UI.GetLogUI(),
+		IdentifyUI: &FakeIdentifyUI{},
+		SecretUI:   &libkb.TestSecretUI{},
+	}
+
+	teng := NewTrackEngine(arg, tcY.G)
+	if err := RunEngine(teng, ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResetAccountRaceFreeState(t *testing.T) {
+	// max: here's a test that generates error 236 reliably
+	t.Skip()
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	// user with synced pgp key
+	u := createFakeUserWithPGPOnly(t, tc)
+	Logout(tc)
+	tc.Cleanup()
+
+	// provision a device with that key
+	tc = SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	ctx := &Context{
+		ProvisionUI: newTestProvisionUIPassphrase(),
+		LoginUI:     &libkb.TestLoginUI{Username: u.Username},
+		LogUI:       tc.G.UI.GetLogUI(),
+		SecretUI:    u.NewSecretUI(),
+		GPGUI:       &gpgtestui{},
+	}
+	eng := NewLogin(tc.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// since this user didn't have any device keys, login should have fixed that:
+	testUserHasDeviceKey(tc)
+
+	// now reset account
+	ResetAccount(tc, u)
+
+	// without this sleep, get
+	// ERROR: can't find a race-free state for 98ef54a78e482ae8be06f254fa4f9d19 (error 236)
+	// time.Sleep(time.Second)
+
+	// create provisioner device
+	tcX := SetupEngineTest(t, "login")
+	defer tcX.Cleanup()
+
+	// this will reprovision as an eldest device:
+	u.LoginOrBust(tcX)
+	if err := AssertProvisioned(tcX); err != nil {
+		t.Fatal(err)
+	}
+	testUserHasDeviceKey(tcX)
 }
 
 type testProvisionUI struct {

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -242,6 +242,7 @@ func (a *Account) ClearStreamCache() {
 // object
 func (a *Account) ClearLoginSession() {
 	if a.loginSession != nil {
+		// calling this is pointless since setting to nil next:
 		a.loginSession.Clear()
 		a.loginSession = nil
 	}
@@ -427,6 +428,9 @@ func (a *Account) saveUserConfig(username NormalizedUsername, uid keybase1.UID, 
 		return NoConfigWriterError{}
 	}
 
+	// XXX I don't understand the intent of clearing the login session here.
+	// All tests pass with this removed, but I'm wary of making any changes.
+	// The git history didn't help, and this is the
 	if err := a.LoginSession().Clear(); err != nil {
 		return err
 	}

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -430,7 +430,8 @@ func (a *Account) saveUserConfig(username NormalizedUsername, uid keybase1.UID, 
 
 	// XXX I don't understand the intent of clearing the login session here.
 	// All tests pass with this removed, but I'm wary of making any changes.
-	// The git history didn't help, and this is the
+	// The git history didn't help, and this is the only place this function
+	// is used (where it matters).
 	if err := a.LoginSession().Clear(); err != nil {
 		return err
 	}

--- a/go/libkb/login_session.go
+++ b/go/libkb/login_session.go
@@ -108,6 +108,8 @@ func (s *LoginSession) NotExpired() bool {
 	return false
 }
 
+// Clear removes the loginSession value from s. It does not
+// clear the salt. Unclear how this is useful.
 func (s *LoginSession) Clear() error {
 	if s == nil {
 		return nil

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -275,6 +275,9 @@ func (s *SKB) unlockSecretKeyFromSecretRetriever(lctx LoginContext, secretRetrie
 // unverifiedPassphraseStream takes a passphrase as a parameter and
 // also the salt from the Account and computes a Triplesec and
 // a passphrase stream.  It's not verified through a Login.
+//
+// question: why is this a member of SKB?
+//
 func (s *SKB) unverifiedPassphraseStream(lctx LoginContext, passphrase string) (tsec *triplesec.Cipher, ret *PassphraseStream, err error) {
 	var salt []byte
 	username := s.G().Env.GetUsername().String()


### PR DESCRIPTION
They all passed, so no issues were found, except the merkled poke issue which only affects single-run tests.

r? @maxtaco 