### PR TITLE
Add debug flag to prevent window stealing focus on refresh

### DIFF
--- a/desktop/app/window.js
+++ b/desktop/app/window.js
@@ -1,6 +1,7 @@
 import showDockIcon from './dock-icon'
 import menuHelper from './menu-helper'
 import {app, ipcMain, BrowserWindow} from 'electron'
+import {focusOnShow} from '../shared/local-debug'
 
 export default class Window {
   constructor (filename, opts) {
@@ -86,7 +87,7 @@ export default class Window {
       if (!this.window.isVisible()) {
         this.window.show()
       }
-      if (!this.window.isFocused()) {
+      if (!this.window.isFocused() && focusOnShow) {
         this.window.focus()
       }
       return

--- a/shared/local-debug.desktop.js
+++ b/shared/local-debug.desktop.js
@@ -20,7 +20,8 @@ let config = {
   devStoreChangingFunctions: false,
   printOutstandingRPCs: false,
   reactPerf: false,
-  overrideLoggedInTab: null
+  overrideLoggedInTab: null,
+  focusOnShow: true
 }
 
 if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) {
@@ -38,6 +39,7 @@ if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) {
   config.printOutstandingRPCs = true
   config.reactPerf = false
   config.overrideLoggedInTab = Tabs.moreTab
+  config.focusOnShow = false
 }
 
 config = updateConfig(config)
@@ -54,7 +56,8 @@ export const {
   devStoreChangingFunctions,
   printOutstandingRPCs,
   reactPerf,
-  overrideLoggedInTab
+  overrideLoggedInTab,
+  focusOnShow
 } = config
 
 export function initTabbedRouterState (state) {


### PR DESCRIPTION
@keybase/react-hackers 

It was getting annoying having the window steal focus every time you save a file.