### PR TITLE
Change the layout of the tracker popup

### DIFF
--- a/desktop/app/store-helper.js
+++ b/desktop/app/store-helper.js
@@ -20,7 +20,10 @@ export default function (mainWindow) {
     subscribeStoreSubscribers.push({sender, selector})
 
     try {
-      sender.send('stateChange', selector ? selector(store) : store)
+      const newStore = selector ? selector(store) : store
+      if (newStore) {
+        sender.send('stateChange', newStore)
+      }
     } catch (_) { }
   })
 
@@ -30,7 +33,10 @@ export default function (mainWindow) {
     let dead = []
     subscribeStoreSubscribers.forEach((sub, idx) => {
       try {
-        sub.sender.send('stateChange', sub.selector ? sub.selector(store) : store)
+        const newStore = sub.selector ? sub.selector(store) : store
+        if (newStore) {
+          sub.sender.send('stateChange', newStore)
+        }
       } catch (_) {
         dead.push(idx)
       }

--- a/desktop/renderer/remote-component-helper.js
+++ b/desktop/renderer/remote-component-helper.js
@@ -1,5 +1,4 @@
 import electron from 'electron'
-import {globalStyles} from '../shared/styles/style-guide'
 
 const remote = electron.remote
 
@@ -17,7 +16,7 @@ export function autoResize () {
           // Height of remote component + offset from parent + top/bottom border
           const originalResizableState = browserWindow.isResizable()
           browserWindow.setResizable(true)
-          browserWindow.setContentSize(browserWindow.getSize()[0], element.scrollHeight + 2 * element.offsetTop + 2 * globalStyles.windowBorder.borderWidth)
+          browserWindow.setContentSize(browserWindow.getSize()[0], element.scrollHeight + 2 * element.offsetTop + 2)
           browserWindow.setResizable(originalResizableState)
         })
       }

--- a/desktop/renderer/style.css
+++ b/desktop/renderer/style.css
@@ -150,8 +150,3 @@ body {
 .hover-underline:hover {
   text-decoration: underline;
 }
-
-.hide-scrollbar::-webkit-scrollbar {
-	display: none;
-	width: 0;
-}

--- a/shared/tracker/bio.render.desktop.js
+++ b/shared/tracker/bio.render.desktop.js
@@ -48,70 +48,74 @@ export default class BioRender extends Component {
     const followsYou = userInfo.followsYou
     const followLabel = this._followLabel()
 
+    // $FlowFixMe we need to change how the props work in these components
+    const backgroundStyle = this.props.backgroundStyle
+
     return (
-      <div style={stylesOuter}>
-        <div style={stylesContainer}>
-          <div style={stylesAvatarOuter}>
-            <Avatar onClick={() => this._onClickAvatar()} style={globalStyles.clickable} url={userInfo.avatar} size={75} />
-            {(followsYou || currentlyFollowing) &&
-              <div>
-                {followsYou && <div style={followBadgeStyles.followsYou}> <div style={{...followBadgeCommon, height: 6, width: 6, top: 2, right: 2}}/></div>}
-                <div style={currentlyFollowing ? followBadgeStyles.following : followBadgeStyles.notFollowing} />
-              </div>
-            }
-          </div>
-          <div style={stylesContent}>
-            <Text
-              type='HeaderBig'
-              style={{...stylesUsername, ...(currentlyFollowing ? stylesUsernameFollowing : stylesUsernameNotFollowing)}}
-              onClick={() => this._onClickAvatar()}>
-              {username}
+      <div style={stylesContainer}>
+        <div style={{...headerBackground, ...backgroundStyle}} />
+        <div style={stylesAvatarOuter}>
+          <Avatar onClick={() => this._onClickAvatar()} style={globalStyles.clickable} url={userInfo.avatar} size={75} />
+          {(followsYou || currentlyFollowing) &&
+            <div>
+              {followsYou && <div style={followBadgeStyles.followsYou}> <div style={{...followBadgeCommon, height: 6, width: 6, top: 2, right: 2}}/></div>}
+              <div style={currentlyFollowing ? followBadgeStyles.following : followBadgeStyles.notFollowing} />
+            </div>
+          }
+        </div>
+        <div style={stylesContent}>
+          <Text
+            type='HeaderBig'
+            style={{...stylesUsername, ...(currentlyFollowing ? stylesUsernameFollowing : stylesUsernameNotFollowing)}}
+            onClick={() => this._onClickAvatar()}>
+            {username}
+          </Text>
+          <Text type='BodySemibold' style={stylesFullname}>{userInfo.fullname}</Text>
+          {followLabel &&
+            <Text type='BodySmall' style={stylesFollowLabel}>{followLabel}</Text>
+          }
+          <Text type='BodySmall' style={stylesFollowing}>
+            <span className='hover-underline' onClick={() => this._onClickFollowers()}>
+              <Text type='BodySmall' style={{...globalStyles.fontBold}}>{userInfo.followersCount}</Text> {userInfo.followersCount === 1 ? 'Tracker' : 'Trackers'}
+            </span>
+            &nbsp;
+            &middot;
+            &nbsp;
+            <span className='hover-underline' onClick={() => this._onClickFollowing()}>
+              Tracking <Text type='BodySmall' style={{...globalStyles.fontBold}}>{userInfo.followingCount}</Text>
+            </span>
+          </Text>
+          {userInfo.bio &&
+            <Text type='BodySmall' style={stylesBio} lineClamp={userInfo.location ? 2 : 3}>
+              {userInfo.bio}
             </Text>
-            <Text type='BodySemibold' style={stylesFullname}>{userInfo.fullname}</Text>
-            {followLabel &&
-              <Text type='BodySmall' style={stylesFollowLabel}>{followLabel}</Text>
-            }
-            <Text type='BodySmall' style={stylesFollowing}>
-              <span className='hover-underline' onClick={() => this._onClickFollowers()}>
-                <Text type='BodySmall' style={{...globalStyles.fontBold}}>{userInfo.followersCount}</Text> {userInfo.followersCount === 1 ? 'Tracker' : 'Trackers'}
-              </span>
-              &nbsp;
-              &middot;
-              &nbsp;
-              <span className='hover-underline' onClick={() => this._onClickFollowing()}>
-                Tracking <Text type='BodySmall' style={{...globalStyles.fontBold}}>{userInfo.followingCount}</Text>
-              </span>
-            </Text>
-            {userInfo.bio &&
-              <Text type='BodySmall' style={stylesBio} lineClamp={userInfo.location ? 2 : 3}>
-                {userInfo.bio}
-              </Text>
-            }
-            {userInfo.location &&
-              <Text type='BodySmall' style={stylesLocation} lineClamp={1}>{userInfo.location}</Text>
-            }
-          </div>
+          }
+          {userInfo.location &&
+            <Text type='BodySmall' style={stylesLocation} lineClamp={1}>{userInfo.location}</Text>
+          }
         </div>
       </div>
     )
   }
 }
 
-const stylesOuter = {
-  marginTop: 90
-}
+const avatarSize = 75
+
 const stylesContainer = {
   ...globalStyles.flexBoxColumn,
   alignItems: 'center',
   justifyContent: 'center',
-  width: 320,
-  marginTop: -40
+  width: 320
+}
+const headerBackground = {
+  height: avatarSize / 2,
+  width: '100%'
 }
 const stylesAvatarOuter = {
-  width: 75,
-  height: 75,
+  width: avatarSize,
+  height: avatarSize,
   position: 'relative',
-  zIndex: 2
+  marginTop: -avatarSize / 2
 }
 const stylesContent = {
   backgroundColor: globalColors.white,
@@ -120,8 +124,7 @@ const stylesContent = {
   justifyContent: 'center',
   width: 320,
   marginTop: -35,
-  paddingTop: 35,
-  zIndex: 1
+  paddingTop: 35
 }
 const stylesUsername = {
   ...globalStyles.selectable,

--- a/shared/tracker/bio.render.js.flow
+++ b/shared/tracker/bio.render.js.flow
@@ -13,5 +13,6 @@ export type UserInfo = {
 export type BioProps = {
   username: ?string,
   userInfo: ?UserInfo,
-  currentlyFollowing: boolean
+  currentlyFollowing: boolean,
+  style?: ?Object
 }

--- a/shared/tracker/header.render.desktop.js
+++ b/shared/tracker/header.render.desktop.js
@@ -8,32 +8,22 @@ import type {HeaderProps} from './header.render'
 
 export default class HeaderRender extends Component {
   props: HeaderProps;
-  state: {showCloseWarning: boolean};
-
-  constructor (props: HeaderProps) {
-    super(props)
-    this.state = {showCloseWarning: false}
-  }
 
   render () {
-    let headerStyle = (this.props.currentlyFollowing && !this.props.changed) ? styles.headerSuccess : styles.headerNormal
+    // $FlowFixMe // how we split these props needs to change
+    let headerStyle = this.props.backgroundStyle
     let headerTextStyle = styles.headerTextNormal
 
     if (this.props.currentlyFollowing) {
       switch (this.props.trackerState) {
         case 'warning':
-          headerStyle = styles.headerWarning
           headerTextStyle = styles.headerTextWarning
           break
-        case 'error': headerStyle = styles.headerError; break
       }
     }
 
     let headerText: string = this.props.reason
-    let isWarning = false
-    if (!this.props.currentlyFollowing && this.state.showCloseWarning) {
-      isWarning = true
-      headerStyle = styles.headerWarning
+    if (!this.props.currentlyFollowing && this.props.showCloseWarning) {
       headerTextStyle = styles.headerTextWarning
       headerText = 'You will see this window every time you access this folder.'
     }
@@ -43,79 +33,53 @@ export default class HeaderRender extends Component {
       case 'followed':
       case 'refollowed':
       case 'unfollowed':
-        headerStyle = styles.headerSuccess
         headerTextStyle = styles.headerTextNormal
         headerText = this.props.reason
         break
       case 'error':
-        headerStyle = styles.headerWarning
         headerTextStyle = styles.headerTextWarning
     }
 
     return (
-      <div style={styles.outer}>
-        <div style={{...styles.header, ...headerStyle}}>
-          <div style={{...styles.header, ...headerStyle, height: 48, zIndex: 2, opacity: isWarning ? 1 : 0, backgroundColor: globalColors.yellow}}/>
-          <Text type='BodySemibold' lineClamp={2} style={{...styles.text, ...headerTextStyle, flex: 1, zIndex: isWarning ? 2 : 'inherit'}}>{headerText}</Text>
-          <Icon type='fa-close' style={styles.close}
-            onClick={() => this.props.onClose()}
-            onMouseEnter={() => this.closeMouseEnter()}
-            onMouseLeave={() => this.closeMouseLeave()} />
-        </div>
+      <div style={{...styles.header, ...headerStyle}}>
+        <Text type='BodySemibold' style={{...styles.text, ...headerTextStyle}}>{headerText}</Text>
+        <Icon type='fa-close' style={styles.close}
+          onClick={() => this.props.onClose()}
+          onMouseEnter={() => this.closeMouseEnter()}
+          onMouseLeave={() => this.closeMouseLeave()} />
       </div>
     )
   }
 
   closeMouseEnter () {
-    this.setState({showCloseWarning: true})
+    // $FlowFixMe // how we split these props needs to change
+    this.props.onShowCloseWarning(true)
   }
 
   closeMouseLeave () {
-    this.setState({showCloseWarning: false})
+    // $FlowFixMe // how we split these props needs to change
+    this.props.onShowCloseWarning(false)
   }
 }
 
 const styles = {
-  outer: {
-    position: 'relative'
-  },
   header: {
     ...globalStyles.windowDragging,
-    cursor: 'default',
-    position: 'absolute',
-    top: 0,
-    ...globalStyles.flexBoxRow,
-    height: 90,
-    width: 320
-  },
-  headerNormal: {
-    backgroundColor: globalColors.blue
-  },
-  headerSuccess: {
-    backgroundColor: globalColors.green
-  },
-  headerWarning: {
-    backgroundColor: globalColors.yellow
+    cursor: 'default'
   },
   headerTextNormal: {
     color: globalColors.white,
     fontSize: 14,
-    lineHeight: 'normal',
-    opacity: 1
+    lineHeight: 'normal'
   },
   headerTextWarning: {
     color: globalColors.brown60,
     fontSize: 14,
-    lineHeight: 'normal',
-    opacity: 1
-  },
-  headerError: {
-    backgroundColor: globalColors.red
+    lineHeight: 'normal'
   },
   close: {
     ...globalStyles.clickable,
     ...globalStyles.windowDraggingClickable,
-    zIndex: 2,
     position: 'absolute',
     top: 7,
     right: 9
@@ -125,10 +89,9 @@ const styles = {
     alignItems: 'center',
     justifyContent: 'center',
     color: globalColors.white,
-    marginLeft: 30,
-    marginRight: 30,
-    marginBottom: 32,
     fontSize: 14,
-    textAlign: 'center'
+    textAlign: 'center',
+    padding: '10px 30px',
+    minHeight: 54
   }
 }

--- a/shared/tracker/index.js
+++ b/shared/tracker/index.js
@@ -131,15 +131,19 @@ export default connect(
     return bindActionCreators(trackerActions, dispatch)
   })(Tracker)
 
-export function selector (username: string): (store: Object) => Object {
+export function selector (username: string): (store: Object) => ?Object {
   return store => {
-    return {
-      tracker: {
-        trackers: {
-          [username]: store.tracker.trackers[username]
-        }
-      },
-      config: store.config
+    if (store.tracker.trackers[username]) {
+      return {
+        tracker: {
+          trackers: {
+            [username]: store.tracker.trackers[username]
+          }
+        },
+        config: store.config
+      }
     }
+
+    return null
   }
 }

--- a/shared/tracker/render.desktop.js
+++ b/shared/tracker/render.desktop.js
@@ -7,11 +7,23 @@ import Action, {calcFooterHeight} from './action.render.desktop'
 import Bio from './bio.render.desktop'
 import {ProofsRender} from './proofs.render.desktop'
 import commonStyles from '../styles/common'
+import {globalColors} from '../styles/style-guide'
 
 import type {RenderProps} from './render'
 
 export default class Render extends Component {
   props: RenderProps;
+  state: {showCloseWarning: boolean};
+
+  constructor (props: RenderProps) {
+    super(props)
+
+    this.state = {showCloseWarning: false}
+  }
+
+  onShowCloseWarning (showCloseWarning: boolean): void {
+    this.setState({showCloseWarning})
+  }
 
   render () {
     // We have to calculate the height of the footer.
@@ -20,11 +32,40 @@ export default class Render extends Component {
     // So we use the existing paddingBottom and add the height of the footer
     const footerHeight = calcFooterHeight(this.props.actionProps.loggedIn)
     const calculatedPadding = styles.content.paddingBottom + footerHeight
+
+    let backgroundStyle = (this.props.headerProps.currentlyFollowing && !this.props.headerProps.changed) ? styles.headerSuccess : styles.headerNormal
+
+    if (this.props.headerProps.currentlyFollowing) {
+      switch (this.props.headerProps.trackerState) {
+        case 'warning': backgroundStyle = styles.headerWarning; break
+        case 'error': backgroundStyle = styles.headerError; break
+      }
+    }
+
+    if (this.props.actionProps.loggedIn && !this.props.headerProps.currentlyFollowing && this.state.showCloseWarning) {
+      backgroundStyle = styles.headerWarning
+    }
+
+    // If there's a lastAction, it overrides everything else.
+    switch (this.props.headerProps.lastAction) {
+      case 'followed':
+      case 'refollowed':
+      case 'unfollowed':
+        backgroundStyle = styles.headerSuccess
+        break
+      case 'error':
+        backgroundStyle = styles.headerWarning
+    }
+
     return (
       <div style={styles.container}>
-        <Header {...this.props.headerProps} />
+        <Header {...this.props.headerProps}
+          backgroundStyle={backgroundStyle}
+          headerWarning={styles.headerWarning}
+          showCloseWarning={this.state.showCloseWarning}
+          onShowCloseWarning={show => this.onShowCloseWarning(show)}/>
         <div style={{...styles.content, paddingBottom: calculatedPadding}}>
-          <Bio {...this.props.bioProps} />
+          <Bio {...this.props.bioProps} backgroundStyle={backgroundStyle} />
           <ProofsRender {...this.props.proofsProps} />
         </div>
         <div style={styles.footer}>
@@ -53,13 +94,24 @@ const styles = {
     overflowY: 'scroll',
     overflowX: 'hidden',
     // This value is added to the footer height to set the actual paddingBottom
-    paddingBottom: 12,
-    zIndex: 1
+    paddingBottom: 12
   },
   footer: {
     position: 'absolute',
     bottom: 0,
     left: 0,
     right: 0
+  },
+  headerNormal: {
+    backgroundColor: globalColors.blue
+  },
+  headerSuccess: {
+    backgroundColor: globalColors.green
+  },
+  headerWarning: {
+    backgroundColor: globalColors.yellow
+  },
+  headerError: {
+    backgroundColor: globalColors.red
   }
 }

--- a/shared/tracker/render.desktop.js
+++ b/shared/tracker/render.desktop.js
@@ -23,7 +23,7 @@ export default class Render extends Component {
     return (
       <div style={styles.container}>
         <Header {...this.props.headerProps} />
-        <div style={{...styles.content, paddingBottom: calculatedPadding}} className='hide-scrollbar'>
+        <div style={{...styles.content, paddingBottom: calculatedPadding}}>
           <Bio {...this.props.bioProps} />
           <ProofsRender {...this.props.proofsProps} />
         </div>
@@ -50,7 +50,7 @@ const styles = {
     position: 'relative'
   },
   content: {
-    overflowY: 'auto',
+    overflowY: 'scroll',
     overflowX: 'hidden',
     // This value is added to the footer height to set the actual paddingBottom
     paddingBottom: 12,


### PR DESCRIPTION
@keybase/react-hackers let's discuss this.

I was working with @cecileboucheron about all the issues we have with the tracker and we landed on just making the header fixed and the scrolling start below it. This also simplifies our code a ton (on hover we'd dynamically inject a yellow background in case you'd scrolled up, etc).

Along the way i also was debugging a race where you'd get an empty store sometimes which would cause the tracker to die.

We've violated how smart our dumb components are in tracker, which makes some of the hoisting kinda painful. Due to this the flow typing is kinda jacked up. Really the business logic of which state we're in (red/blue/green/etc) should be some abstract concept that's figured out by the smart component and turned into some enum. That should be translated into something like a background color.

The division of props into the specific action/bio/header/etc also seems like an abstraction violation, esp. if we're sharing pieces between them. If we're moving this information around the smart component shouldn't have to be refactored to allow this, a flat map of all the props required I think would be cleaner. The renderer would then parcel out the subsets