### PR TITLE
add a new client header that includes the device ID

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -354,6 +354,9 @@ func (a *InternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
 		req.Header.Set("User-Agent", UserAgent)
 		identifyAs := GoClientID + " v" + VersionString() + " " + runtime.GOOS
 		req.Header.Set("X-Keybase-Client", identifyAs)
+		if a.G().Env.GetDeviceID().Exists() {
+			req.Header.Set("X-Keybase-Device-ID", a.G().Env.GetDeviceID().String())
+		}
 	}
 }
 


### PR DESCRIPTION
r? @maxtaco 

We could consider using empty string or something if the device ID isn't present (i.e. if the device isn't provisioned)? Not sure what the best practice is there. Also feel free to bikeshed the name :)