### PR TITLE
More signup fixes desktop 703

### DIFF
--- a/shared/common-adapters/button.desktop.js
+++ b/shared/common-adapters/button.desktop.js
@@ -121,12 +121,13 @@ class Button extends Component {
           label={label}
           primary={this.props.type === 'Primary'}
           secondary={this.props.type === 'Secondary'}
-          disabled={this.props.disabled || this.props.waiting}/>
-        {this.props.waiting && (
-          <ProgressIndicator
-            white={progressColor === globalColors.white}
-            style={{...stylesProgress}}
-          />)}
+          disabled={this.props.disabled || this.props.waiting}>
+          {this.props.waiting && (
+            <ProgressIndicator
+              white={progressColor === globalColors.white}
+              style={{...stylesProgress}}
+            />)}
+        </FlatButton>
       </div>
     )
   }

--- a/shared/constants/signup.js
+++ b/shared/constants/signup.js
@@ -33,4 +33,7 @@ export type ShowSuccess = TypedAction<'signup:showSuccess', {}, {}>
 export const resetSignup = 'signup:resetSignup'
 export type ResetSignup = TypedAction<'signup:resetSignup', {}, {}>
 
-export type SignupActions = CheckInviteCode | CheckUsernameEmail | CheckPassphrase | SubmitDeviceName | Signup | ShowPaperKey | ShowSuccess | ResetSignup
+export const signupWaiting = 'signup:waiting'
+export type SignupWaiting = TypedAction<'signup:waiting', boolean, void>
+
+export type SignupActions = CheckInviteCode | CheckUsernameEmail | CheckPassphrase | SubmitDeviceName | Signup | ShowPaperKey | ShowSuccess | ResetSignup | SignupWaiting

--- a/shared/login/forms/container.desktop.js
+++ b/shared/login/forms/container.desktop.js
@@ -7,7 +7,7 @@ import type {Props} from './container'
 export default ({children, onBack, style, outerStyle}: Props) => {
   return (
     <div style={{...styles.container, ...outerStyle}}>
-      <BackButton style={styles.button} onClick={onBack}/>
+      {onBack && <BackButton style={styles.button} onClick={onBack}/>}
       <div style={{...styles.innerContainer, ...style}}>
         {children}
       </div>

--- a/shared/login/forms/container.js.flow
+++ b/shared/login/forms/container.js.flow
@@ -2,7 +2,7 @@
 import React from 'react'
 
 export type Props = {
-    onBack: () => void,
+    onBack?: () => void,
     children?: ?Array<any>,
     style?: ?Object,
     outerStyle?: ?Object

--- a/shared/login/register/set-public-name/index.render.desktop.js
+++ b/shared/login/register/set-public-name/index.render.desktop.js
@@ -4,7 +4,7 @@ import {Text, Button, Input, Icon} from '../../../common-adapters'
 import Container from '../../forms/container.desktop'
 import type {Props} from './index.render'
 
-const SetPublicName = ({onBack, onSubmit, onChange, deviceNameError, deviceName}: Props) => (
+const SetPublicName = ({onBack, onSubmit, onChange, deviceNameError, deviceName, waiting}: Props) => (
   <Container style={styles.container} onBack={onBack}>
     <Text type='Header' style={styles.header}>Set a public name for this device:</Text>
     <Icon type='computer-color-m' style={styles.icon}/>
@@ -19,6 +19,7 @@ const SetPublicName = ({onBack, onSubmit, onChange, deviceNameError, deviceName}
     <Button
       type='Primary'
       style={styles.button}
+      waiting={waiting}
       label='Continue'
       onClick={() => onSubmit()} />
   </Container>

--- a/shared/login/register/set-public-name/index.render.js.flow
+++ b/shared/login/register/set-public-name/index.render.js.flow
@@ -7,6 +7,7 @@ export type Props = {
   onSubmit: () => void,
   deviceName: ?string,
   deviceNameError?: ?string,
+  waiting?: ?boolean
 }
 
 declare export default class SetPublicName extends Component<void, Props, void> { }

--- a/shared/login/signup/device-name.js
+++ b/shared/login/signup/device-name.js
@@ -23,7 +23,8 @@ class DeviceName extends Component {
         deviceNameError={this.props.deviceNameError}
         onChange={deviceName => this.setState({deviceName})}
         onSubmit={() => this.props.submitDeviceName(this.state.deviceName || '')}
-        onBack={this.props.resetSignup} />
+        onBack={this.props.resetSignup}
+        waiting={this.props.waiting}/>
     )
   }
 }
@@ -31,7 +32,8 @@ class DeviceName extends Component {
 export default connect(
   state => ({
     deviceNameError: state.signup.deviceNameError,
-    deviceName: state.signup.deviceName
+    deviceName: state.signup.deviceName,
+    waiting: state.signup.waiting
   }),
   dispatch => bindActionCreators(signupActions, dispatch)
 )(DeviceName)

--- a/shared/login/signup/invite-code.js
+++ b/shared/login/signup/invite-code.js
@@ -16,7 +16,8 @@ class InviteCode extends Component {
         onRequestInvite={this.props.startRequestInvite}
         onInviteCodeSubmit={this.props.checkInviteCode}
         inviteCodeErrorText={this.props.errorText}
-        onBack={this.props.navigateUp}/>
+        onBack={this.props.navigateUp}
+        waiting={this.props.waiting}/>
     )
   }
 }
@@ -27,7 +28,11 @@ InviteCode.propTypes = {
 }
 
 export default connect(
-  state => ({errorText: state.signup.inviteCodeError, inviteCode: state.signup.inviteCode}),
+  state => ({
+    errorText: state.signup.inviteCodeError,
+    inviteCode: state.signup.inviteCode,
+    waiting: state.signup.waiting
+  }),
     dispatch => bindActionCreators({
       ...signupActions,
       navigateUp

--- a/shared/login/signup/invite-code.render.desktop.js
+++ b/shared/login/signup/invite-code.render.desktop.js
@@ -31,7 +31,7 @@ export default class Render extends Component {
         <Text style={styles.header} type='Header'>Type in your invite code:</Text>
         <Icon style={styles.icon} type='invite-code-m'/>
         <Input autoFocus style={styles.input} hintText='goddess brown result reject' value={this.state.inviteCode} errorText={this.props.inviteCodeErrorText} onEnterKeyDown={submitInviteCode} onChange={event => this.setState({inviteCode: event.target.value})}/>
-        <Button style={styles.button} type='Primary' label='Continue' onClick={submitInviteCode} disabled={!this.state.inviteCode}/>
+        <Button style={styles.button} waiting={this.props.waiting} type='Primary' label='Continue' onClick={submitInviteCode} disabled={!this.state.inviteCode}/>
         <Text style={styles.text} type='Body'>Not invited?</Text>
         <Text type='BodyPrimaryLink' onClick={this.props.onRequestInvite}>Request an invite code</Text>
       </Container>

--- a/shared/login/signup/invite-code.render.js.flow
+++ b/shared/login/signup/invite-code.render.js.flow
@@ -8,7 +8,8 @@ export type Props = {
   onInviteCodeSubmit: () => void,
   onRequestInvite: () => void,
   inviteCode: ?string,
-  inviteCodeErrorText: ?string
+  inviteCodeErrorText: ?string,
+  waiting: boolean
 }
 
 export default class Render extends Component {

--- a/shared/login/signup/request-invite.js
+++ b/shared/login/signup/request-invite.js
@@ -17,7 +17,7 @@ class RequestInvite extends Component {
         nameErrorText={this.props.nameErrorText}
         onBack={this.props.resetSignup}
         onRequestInvite={this.props.requestInvite}
-      />
+        waiting={this.props.waiting}/>
     )
   }
 }
@@ -25,7 +25,8 @@ class RequestInvite extends Component {
 export default connect(
   state => ({
     emailErrorText: state.signup.emailError,
-    nameErrorText: state.signup.nameError
+    nameErrorText: state.signup.nameError,
+    waiting: state.signup.waiting
   }),
   dispatch => bindActionCreators(signupActions, dispatch)
 )(RequestInvite)

--- a/shared/login/signup/request-invite.render.desktop.js
+++ b/shared/login/signup/request-invite.render.desktop.js
@@ -50,6 +50,7 @@ export default class Render extends Component {
         />
         <Button
           style={styles.button}
+          waiting={this.props.waiting}
           type='Primary'
           label='Request'
           onClick={submitRequestInvite}

--- a/shared/login/signup/request-invite.render.js.flow
+++ b/shared/login/signup/request-invite.render.js.flow
@@ -9,7 +9,8 @@ export type Props = {
   nameErrorText: ?string,
   emailErrorText: ?string,
   onRequestInvite: () => void,
-  onBack: () => void
+  onBack: () => void,
+  waiting: boolean
 }
 
 export default class Render extends Component {

--- a/shared/login/signup/success/index.render.desktop.js
+++ b/shared/login/signup/success/index.render.desktop.js
@@ -22,7 +22,7 @@ export default class Render extends Component {
 
   render () {
     return (
-      <Container onBack={this.props.onBack} style={styles.container}>
+      <div style={styles.container}>
         <Text type='Header' style={styles.header}>Congratulations, you’ve just joined Keybase!</Text>
         <Text type='Body' style={styles.body}>Here is your unique paper key, it will allow you to perform important Keybase tasks in the future. This is the only time you’ll see this so be sure to write it down.</Text>
         <div style={styles.paperKeyContainer}>
@@ -31,7 +31,7 @@ export default class Render extends Component {
         </div>
         <Checkbox style={styles.check} label='Yes, I wrote this down.' checked={this.state.inWallet} onCheck={inWallet => this.setState({inWallet})} />
         <Button style={styles.button} type='Primary' label='Done' onClick={() => this.props.onFinish()} disabled={!this.state.inWallet} />
-      </Container>
+      </div>
     )
   }
 }
@@ -40,10 +40,10 @@ const styles = {
   container: {
     ...globalStyles.flexBoxColumn,
     alignItems: 'center',
-    marginTop: 15
+    padding: 60
   },
   header: {
-    marginTop: 22,
+    marginTop: 60,
     marginBottom: 5
   },
   body: {

--- a/shared/login/signup/success/index.render.desktop.js
+++ b/shared/login/signup/success/index.render.desktop.js
@@ -22,7 +22,7 @@ export default class Render extends Component {
 
   render () {
     return (
-      <div style={styles.container}>
+      <Container style={styles.container}>
         <Text type='Header' style={styles.header}>Congratulations, you’ve just joined Keybase!</Text>
         <Text type='Body' style={styles.body}>Here is your unique paper key, it will allow you to perform important Keybase tasks in the future. This is the only time you’ll see this so be sure to write it down.</Text>
         <div style={styles.paperKeyContainer}>
@@ -31,16 +31,14 @@ export default class Render extends Component {
         </div>
         <Checkbox style={styles.check} label='Yes, I wrote this down.' checked={this.state.inWallet} onCheck={inWallet => this.setState({inWallet})} />
         <Button style={styles.button} type='Primary' label='Done' onClick={() => this.props.onFinish()} disabled={!this.state.inWallet} />
-      </div>
+      </Container>
     )
   }
 }
 
 const styles = {
   container: {
-    ...globalStyles.flexBoxColumn,
-    alignItems: 'center',
-    padding: 60
+    alignItems: 'center'
   },
   header: {
     marginTop: 60,

--- a/shared/login/signup/username-email-form.js
+++ b/shared/login/signup/username-email-form.js
@@ -16,7 +16,8 @@ class UsernameEmailForm extends Component {
         submitUserEmail={this.props.checkUsernameEmail}
         usernameErrorText={this.props.usernameErrorText}
         emailErrorText={this.props.emailErrorText}
-        onBack={this.props.resetSignup}/>
+        onBack={this.props.resetSignup}
+        waiting={this.props.waiting}/>
     )
   }
 }
@@ -34,7 +35,8 @@ export default connect(
     usernameErrorText: state.signup.usernameError,
     emailErrorText: state.signup.emailError,
     username: state.signup.username,
-    email: state.signup.email
+    email: state.signup.email,
+    waiting: state.signup.waiting
   }),
   dispatch => bindActionCreators(signupActions, dispatch)
 )(UsernameEmailForm)

--- a/shared/login/signup/username-email-form.render.desktop.js
+++ b/shared/login/signup/username-email-form.render.desktop.js
@@ -23,7 +23,7 @@ class Render extends Component {
         <UserCard style={stylesCard}>
           <Input autoFocus floatingLabelText='Create a username' value={this.props.username} ref={r => (usernameRef = r)} errorText={this.props.usernameErrorText}/>
           <Input floatingLabelText='Email address' value={this.props.email} ref={r => (emailRef = r)} errorText={this.props.emailErrorText} onEnterKeyDown={submitUserEmail}/>
-          <Button style={{marginTop: 40}} fullWidth type='Primary' label='Continue' onClick={submitUserEmail}/>
+          <Button waiting={this.props.waiting} style={{marginTop: 40}} fullWidth type='Primary' label='Continue' onClick={submitUserEmail}/>
         </UserCard>
       </Container>
     )

--- a/shared/login/signup/username-email-form.render.js.flow
+++ b/shared/login/signup/username-email-form.render.js.flow
@@ -9,7 +9,8 @@ export type Props = {
   usernameErrorText: ?string,
   emailErrorText: ?string,
   submitUserEmail: () => void,
-  onBack: () => void
+  onBack: () => void,
+  waiting: boolean
 }
 
 export default class Render extends Component {

--- a/shared/more/style-sheet.render.desktop.js
+++ b/shared/more/style-sheet.render.desktop.js
@@ -56,7 +56,9 @@ export default class Render extends Component {
                 <Button onClick={() => {}} type='Follow' disabled label='Follow disabled'/><Space/>
               </div>
               <div style={{...globalStyles.flexBoxColumn, alignItems: 'flex-start', justifyContents: 'flex-start', padding: 10, paddingRight: 100}}>
-                <Button onClick={() => {}} type='Primary' label='Primary' waiting/><Space/>
+                <div>
+                  <Button style={{alignSelf: 'flex-end', marginTop: 40}} onClick={() => {}} type='Primary' label='Primary' waiting/><Space/>
+                </div>
                 <Button onClick={() => {}} type='Secondary' label='Secondary' waiting/><Space/>
                 <Button onClick={() => {}} type='Danger' danger label='Danger' waiting/><Space/>
                 <Space/>

--- a/shared/reducers/signup.js
+++ b/shared/reducers/signup.js
@@ -21,6 +21,7 @@ export type SignupState = {
   deviceName: ?string,
   paperkey: ?HiddenString,
   signupError: ?HiddenString,
+  waiting: boolean,
   phase: 'inviteCode' | 'usernameAndEmail' | 'passphraseSignup' | 'deviceName' | 'signupLoading' | 'paperkey' | 'success' | 'signupError' | 'requestInvite' | 'requestInviteSuccess'
 }
 
@@ -38,6 +39,7 @@ const initialState: SignupState = {
   paperkey: null,
   signupError: null,
   deviceName: 'Home Computer',
+  waiting: false,
   phase: 'inviteCode'
 }
 
@@ -46,6 +48,12 @@ export default function (state: SignupState = initialState, action: SignupAction
   switch (action.type) {
     case CommonConstants.resetStore:
       return {...initialState}
+
+    case Constants.signupWaiting:
+      if (action.error) {
+        return state
+      }
+      return {...state, waiting: action.payload}
 
     case Constants.checkInviteCode:
       if (action.error) {


### PR DESCRIPTION
@keybase/react-hackers 

More fixes for signup flow.

* Remove back from the success screen
* Add waiting states to signup buttons
* fix waiting styles for buttons (not signup specific)

### Waiting styles
Before
<img width="144" alt="screen shot 2016-03-23 at 5 28 27 pm" src="https://cloud.githubusercontent.com/assets/594035/14004231/7b6ade50-f126-11e5-982d-99d2ca799ee4.png">
After
<img width="113" alt="screen shot 2016-03-23 at 6 39 06 pm" src="https://cloud.githubusercontent.com/assets/594035/14004241/90cd7c80-f126-11e5-832b-b24f7fc00424.png">


### A couple other potential bugs

We should discuss if we should invest time fixing these now

* Clear error fields when the user starts typing in the input boxes
  * We could fix this at the component level or parent level.

* Possible to create an account without seeing the paperkey
  * If there are certain errors in signup (like network timeout) it will retry later, but the gui doesn't get updated (it stays on the error screen) so the account is created in the service side, but the gui isn't notified about this. This will lead to outstanding rpcs too. 