### PR TITLE
Fix remote-window sizing

### DIFF
--- a/desktop/renderer/remote-component-helper.js
+++ b/desktop/renderer/remote-component-helper.js
@@ -1,5 +1,4 @@
 import electron from 'electron'
-import {globalStyles} from '../shared/styles/style-guide'
 
 const remote = electron.remote
 
@@ -17,7 +16,7 @@ export function autoResize () {
           // Height of remote component + offset from parent + top/bottom border
           const originalResizableState = browserWindow.isResizable()
           browserWindow.setResizable(true)
-          browserWindow.setContentSize(browserWindow.getSize()[0], element.scrollHeight + 2 * element.offsetTop + 2 * globalStyles.windowBorder.borderWidth)
+          browserWindow.setContentSize(browserWindow.getSize()[0], element.scrollHeight + 2 * element.offsetTop + 2)
           browserWindow.setResizable(originalResizableState)
         })
       }


### PR DESCRIPTION
@keybase/react-hackers 

Commit cdad99c21 removed globalStyles.windowBorder, but it was still being used by `desktop/renderer/remote-component-helper.js` to set window height, with the result that we crash while trying to set height.  On Linux this gave me an updater dialog that wasn't tall enough to contain the update buttons, and couldn't be resized to include them.

Because of this I paused the build bot, but I think this actually went out to users already yesterday.

This PR fixes it by cherry-picking in a fix (to just not use windowBorder anymore) from @chrisnojima's  #2428 PR.