### PR TITLE
Update upstream dependency paths

### DIFF
--- a/go/qrcode/qrcode.go
+++ b/go/qrcode/qrcode.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"strings"
 
-	"code.google.com/p/rsc/qr"
+	"github.com/rsc/rsc/qr"
 )
 
 // Encodings is the result of QR encoding.  It has three different

--- a/go/vendor/code.google.com/p/rsc/qr/coding/qr.go
+++ b/go/vendor/code.google.com/p/rsc/qr/coding/qr.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"code.google.com/p/rsc/gf256"
+	"github.com/rsc/rsc/gf256"
 )
 
 // Field is the field for QR error correction.

--- a/go/vendor/code.google.com/p/rsc/qr/qr.go
+++ b/go/vendor/code.google.com/p/rsc/qr/qr.go
@@ -12,7 +12,7 @@ import (
 	"image"
 	"image/color"
 
-	"code.google.com/p/rsc/qr/coding"
+	"github.com/rsc/rsc/qr/coding"
 )
 
 // A Level denotes a QR error correction level.

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -8,17 +8,17 @@
 			"revisionTime": "2015-09-10T16:50:43-07:00"
 		},
 		{
-			"path": "code.google.com/p/rsc/gf256",
+			"path": "github.com/rsc/rsc/gf256",
 			"revision": "2d8aa6027fab",
 			"revisionTime": "2014-11-30T16:07:12-05:00"
 		},
 		{
-			"path": "code.google.com/p/rsc/qr",
+			"path": "github.com/rsc/rsc/qr",
 			"revision": "2d8aa6027fab",
 			"revisionTime": "2014-11-30T16:07:12-05:00"
 		},
 		{
-			"path": "code.google.com/p/rsc/qr/coding",
+			"path": "github.com/rsc/rsc/qr/coding",
 			"revision": "2d8aa6027fab",
 			"revisionTime": "2014-11-30T16:07:12-05:00"
 		},


### PR DESCRIPTION
code.google.com no longer exists. Use the rsc repository on github
instead.