### PR TITLE
add a ClientOutOfDate to notify_session.avdl

### DIFF
--- a/go/client/cmd_show_notifications.go
+++ b/go/client/cmd_show_notifications.go
@@ -99,6 +99,9 @@ func (d *notificationDisplay) LoggedOut(_ context.Context) error {
 func (d *notificationDisplay) LoggedIn(_ context.Context, un string) error {
 	return d.printf("Logged in as %q\n", un)
 }
+func (d *notificationDisplay) ClientOutOfDate(_ context.Context, arg keybase1.ClientOutOfDateArg) error {
+	return d.printf("Client out of date, upgrade to \"%s\", uri \"%s\"\n", arg.UpgradeTo, arg.UpgradeURI)
+}
 
 func (d *notificationDisplay) UserChanged(_ context.Context, uid keybase1.UID) error {
 	return d.printf("User %s changed\n", uid)

--- a/go/client/cmd_update.go
+++ b/go/client/cmd_update.go
@@ -11,9 +11,9 @@ import (
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
+	"github.com/keybase/go-framed-msgpack-rpc"
 	"github.com/keybase/go-updater"
 	"github.com/keybase/go-updater/sources"
-	"github.com/keybase/go-framed-msgpack-rpc"
 	"golang.org/x/net/context"
 )
 

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -323,6 +323,7 @@ func (a *InternalAPIEngine) consumeHeaders(resp *http.Response) error {
 	u := resp.Header.Get("X-Keybase-Client-Upgrade-To")
 	p := resp.Header.Get("X-Keybase-Upgrade-URI")
 	if len(u) > 0 {
+		a.G().NotifyRouter.HandleClientOutOfDate(u, p)
 		now := time.Now()
 		lastUpgradeWarningMu.Lock()
 		if lastUpgradeWarning == nil || now.Sub(*lastUpgradeWarning) > 3*time.Minute {

--- a/go/protocol/notify_session.go
+++ b/go/protocol/notify_session.go
@@ -15,9 +15,15 @@ type LoggedInArg struct {
 	Username string `codec:"username" json:"username"`
 }
 
+type ClientOutOfDateArg struct {
+	UpgradeTo  string `codec:"upgradeTo" json:"upgradeTo"`
+	UpgradeURI string `codec:"upgradeURI" json:"upgradeURI"`
+}
+
 type NotifySessionInterface interface {
 	LoggedOut(context.Context) error
 	LoggedIn(context.Context, string) error
+	ClientOutOfDate(context.Context, ClientOutOfDateArg) error
 }
 
 func NotifySessionProtocol(i NotifySessionInterface) rpc.Protocol {
@@ -51,6 +57,22 @@ func NotifySessionProtocol(i NotifySessionInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"clientOutOfDate": {
+				MakeArg: func() interface{} {
+					ret := make([]ClientOutOfDateArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ClientOutOfDateArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ClientOutOfDateArg)(nil), args)
+						return
+					}
+					err = i.ClientOutOfDate(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -67,5 +89,10 @@ func (c NotifySessionClient) LoggedOut(ctx context.Context) (err error) {
 func (c NotifySessionClient) LoggedIn(ctx context.Context, username string) (err error) {
 	__arg := LoggedInArg{Username: username}
 	err = c.Cli.Call(ctx, "keybase.1.NotifySession.loggedIn", []interface{}{__arg}, nil)
+	return
+}
+
+func (c NotifySessionClient) ClientOutOfDate(ctx context.Context, __arg ClientOutOfDateArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.NotifySession.clientOutOfDate", []interface{}{__arg}, nil)
 	return
 }

--- a/go/service/update.go
+++ b/go/service/update.go
@@ -9,8 +9,8 @@ import (
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
-	"github.com/keybase/go-updater"
 	rpc "github.com/keybase/go-framed-msgpack-rpc"
+	"github.com/keybase/go-updater"
 	"golang.org/x/net/context"
 )
 

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -165,18 +165,20 @@ func randomUser(prefix string) *signupInfo {
 }
 
 type notifyHandler struct {
-	logoutCh chan struct{}
-	loginCh  chan string
-	userCh   chan keybase1.UID
-	errCh    chan error
+	logoutCh    chan struct{}
+	loginCh     chan string
+	outOfDateCh chan keybase1.ClientOutOfDateArg
+	userCh      chan keybase1.UID
+	errCh       chan error
 }
 
 func newNotifyHandler() *notifyHandler {
 	return &notifyHandler{
-		logoutCh: make(chan struct{}),
-		loginCh:  make(chan string),
-		userCh:   make(chan keybase1.UID),
-		errCh:    make(chan error),
+		logoutCh:    make(chan struct{}),
+		loginCh:     make(chan string),
+		outOfDateCh: make(chan keybase1.ClientOutOfDateArg),
+		userCh:      make(chan keybase1.UID),
+		errCh:       make(chan error),
 	}
 }
 
@@ -187,6 +189,11 @@ func (h *notifyHandler) LoggedOut(_ context.Context) error {
 
 func (h *notifyHandler) LoggedIn(_ context.Context, un string) error {
 	h.loginCh <- un
+	return nil
+}
+
+func (h *notifyHandler) ClientOutOfDate(_ context.Context, arg keybase1.ClientOutOfDateArg) error {
+	h.outOfDateCh <- arg
 	return nil
 }
 

--- a/protocol/avdl/notify_session.avdl
+++ b/protocol/avdl/notify_session.avdl
@@ -5,4 +5,5 @@ protocol NotifySession {
   @notify("")
   void loggedOut();
   void loggedIn(string username);
+  void clientOutOfDate(string upgradeTo, string upgradeURI);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -536,6 +536,18 @@ export type NotifyFS_FSActivity_rpc = {
   callback: (null | (err: ?any) => void)
 }
 
+export type NotifySession_clientOutOfDate_result = void
+
+export type NotifySession_clientOutOfDate_rpc = {
+  method: 'NotifySession.clientOutOfDate',
+  param: {
+    upgradeTo: string,
+    upgradeURI: string
+  },
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any) => void)
+}
+
 export type NotifySession_loggedIn_result = void
 
 export type NotifySession_loggedIn_rpc = {
@@ -3265,6 +3277,7 @@ export type rpc =
   | Kex2Provisionee_hello_rpc
   | Kex2Provisioner_kexStart_rpc
   | NotifyFS_FSActivity_rpc
+  | NotifySession_clientOutOfDate_rpc
   | NotifySession_loggedIn_rpc
   | NotifySession_loggedOut_rpc
   | NotifyTracking_trackingChanged_rpc
@@ -4493,6 +4506,16 @@ export type incomingCallMapType = {
   'keybase.1.NotifySession.loggedIn'?: (
     params: {
       username: string
+    },
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
+    }
+  ) => void,
+  'keybase.1.NotifySession.clientOutOfDate'?: (
+    params: {
+      upgradeTo: string,
+      upgradeURI: string
     },
     response: {
       error: (err: RPCError) => void,

--- a/protocol/json/notify_session.json
+++ b/protocol/json/notify_session.json
@@ -15,6 +15,19 @@
         }
       ],
       "response": "null"
+    },
+    "clientOutOfDate": {
+      "request": [
+        {
+          "name": "upgradeTo",
+          "type": "string"
+        },
+        {
+          "name": "upgradeURI",
+          "type": "string"
+        }
+      ],
+      "response": "null"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -536,6 +536,18 @@ export type NotifyFS_FSActivity_rpc = {
   callback: (null | (err: ?any) => void)
 }
 
+export type NotifySession_clientOutOfDate_result = void
+
+export type NotifySession_clientOutOfDate_rpc = {
+  method: 'NotifySession.clientOutOfDate',
+  param: {
+    upgradeTo: string,
+    upgradeURI: string
+  },
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any) => void)
+}
+
 export type NotifySession_loggedIn_result = void
 
 export type NotifySession_loggedIn_rpc = {
@@ -3265,6 +3277,7 @@ export type rpc =
   | Kex2Provisionee_hello_rpc
   | Kex2Provisioner_kexStart_rpc
   | NotifyFS_FSActivity_rpc
+  | NotifySession_clientOutOfDate_rpc
   | NotifySession_loggedIn_rpc
   | NotifySession_loggedOut_rpc
   | NotifyTracking_trackingChanged_rpc
@@ -4493,6 +4506,16 @@ export type incomingCallMapType = {
   'keybase.1.NotifySession.loggedIn'?: (
     params: {
       username: string
+    },
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
+    }
+  ) => void,
+  'keybase.1.NotifySession.clientOutOfDate'?: (
+    params: {
+      upgradeTo: string,
+      upgradeURI: string
     },
     response: {
       error: (err: RPCError) => void,


### PR DESCRIPTION
This will allow the GUI to alert the user when they're on a bad version,
without waiting for / relying on the regular update loop.

r? @cjb 

This will break KBFS when it lands. @strib, what's the preferred workflow
for that sort of thing? Should I make a KBFS PR with a vendor bump and
fixes after this goes in, or do you like to review those first?