### PR TITLE
Add a show-paper-key path to provisioning flow

### DIFF
--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -17,7 +17,7 @@ import PaperKey from '../../login/register/paper-key'
 import CodePage from '../../login/register/code-page'
 import Error from '../../login/register/error'
 import SetPublicName from '../../login/register/set-public-name'
-import Success from '../../login/signup/success'
+import SuccessRender from '../../login/signup/success/index.render'
 import {switchTab} from '../tabbed-router'
 import {devicesTab, loginTab} from '../../constants/tabs'
 import {loadDevices} from '../devices'
@@ -313,7 +313,9 @@ export function logout () : AsyncAction {
 
 let paperKeyResponse = null
 export function sawPaperKey (): AsyncAction {
+  console.log('in login -> sawPaperKey')
   return () => {
+    console.log('in login2 -> sawPaperKey')
     if (paperKeyResponse) {
       paperKeyResponse.result()
       paperKeyResponse = null
@@ -482,8 +484,9 @@ function makeKex2IncomingMap (dispatch, getState) : incomingCallMapType {
     'keybase.1.loginUi.displayPrimaryPaperKey': ({sessionID, phrase}, response) => {
       paperKeyResponse = response
       let hiddenphrase = new HiddenString(phrase)
+      console.log('in displayPrimaryPaperKey')
       appendRouteElement((
-        <Success
+        <SuccessRender
           paperkey={hiddenphrase}
           onFinish={() => dispatch(sawPaperKey())}
           onBack={() => dispatch(cancelLogin(response))}

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -313,16 +313,6 @@ export function logout () : AsyncAction {
   }
 }
 
-let paperKeyResponse = null
-export function sawPaperKey (): AsyncAction {
-  return () => {
-    if (paperKeyResponse) {
-      paperKeyResponse.result()
-      paperKeyResponse = null
-    }
-  }
-}
-
 export function logoutDone () : AsyncAction {
   // We've logged out, let's check our current status
   return (dispatch, getState) => {
@@ -482,12 +472,10 @@ function makeKex2IncomingMap (dispatch, getState) : incomingCallMapType {
           onBack={() => dispatch(cancelLogin(response))} />))
     },
     'keybase.1.loginUi.displayPrimaryPaperKey': ({sessionID, phrase}, response) => {
-      paperKeyResponse = response
-      let hiddenphrase = new HiddenString(phrase)
       appendRouteElement((
         <SuccessRender
-          paperkey={hiddenphrase}
-          onFinish={() => { dispatch(sawPaperKey()) }}
+          paperkey={new HiddenString(phrase)}
+          onFinish={() => { response.result() }}
           onBack={() => { dispatch(cancelLogin(response)) }}
           title={"Your new paper key!"} />))
     },

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -313,9 +313,7 @@ export function logout () : AsyncAction {
 
 let paperKeyResponse = null
 export function sawPaperKey (): AsyncAction {
-  console.log('in login -> sawPaperKey')
   return () => {
-    console.log('in login2 -> sawPaperKey')
     if (paperKeyResponse) {
       paperKeyResponse.result()
       paperKeyResponse = null
@@ -484,12 +482,11 @@ function makeKex2IncomingMap (dispatch, getState) : incomingCallMapType {
     'keybase.1.loginUi.displayPrimaryPaperKey': ({sessionID, phrase}, response) => {
       paperKeyResponse = response
       let hiddenphrase = new HiddenString(phrase)
-      console.log('in displayPrimaryPaperKey')
       appendRouteElement((
         <SuccessRender
           paperkey={hiddenphrase}
-          onFinish={() => dispatch(sawPaperKey())}
-          onBack={() => dispatch(cancelLogin(response))}
+          onFinish={() => { dispatch(sawPaperKey()) }}
+          onBack={() => { dispatch(cancelLogin(response)) }}
           title={"Your new paper key!"} />))
     },
     'keybase.1.provisionUi.ProvisioneeSuccess': (param, response) => {

--- a/shared/actions/signup/index.js
+++ b/shared/actions/signup/index.js
@@ -285,7 +285,6 @@ let paperKeyResponse = null
 export function sawPaperKey (): AsyncAction {
   return () => {
     if (paperKeyResponse) {
-      console.log('in signup -> sawPaperKey')
       paperKeyResponse.result()
       paperKeyResponse = null
     }

--- a/shared/actions/signup/index.js
+++ b/shared/actions/signup/index.js
@@ -285,6 +285,7 @@ let paperKeyResponse = null
 export function sawPaperKey (): AsyncAction {
   return () => {
     if (paperKeyResponse) {
+      console.log('in signup -> sawPaperKey')
       paperKeyResponse.result()
       paperKeyResponse = null
     }

--- a/shared/login/signup/success/index.js
+++ b/shared/login/signup/success/index.js
@@ -3,7 +3,6 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import HiddenString from '../../../util/hidden-string'
-import {sawPaperKey} from '../../../actions/signup'
 
 import Render from './index.render'
 
@@ -11,6 +10,7 @@ class Success extends Component {
   render () {
     return (
       <Render
+        title={this.props.title}
         paperkey={this.props.paperkey}
         onFinish={this.props.onFinish}
         onBack={this.props.onBack}
@@ -25,9 +25,10 @@ Success.propTypes = {
 }
 
 export default connect(
-  state => ({paperkey: state.signup.paperkey}),
+  (state, ownProps) => ({
+    paperkey: ownProps.paperkey || state.signup.paperkey,
+    title: ownProps.title || state.signup.successTitle
+  }),
   dispatch => ({
-    onFinish: () => dispatch(sawPaperKey()),
-    onBack: () => {}
   })
 )(Success)

--- a/shared/login/signup/success/index.js
+++ b/shared/login/signup/success/index.js
@@ -3,6 +3,7 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import HiddenString from '../../../util/hidden-string'
+import {sawPaperKey} from '../../../actions/signup'
 
 import Render from './index.render'
 
@@ -25,10 +26,9 @@ Success.propTypes = {
 }
 
 export default connect(
-  (state, ownProps) => ({
-    paperkey: ownProps.paperkey || state.signup.paperkey,
-    title: ownProps.title || state.signup.successTitle
-  }),
+  state => ({paperkey: state.signup.paperkey}),
   dispatch => ({
+    onFinish: dispatch(sawPaperKey()),
+    onBack: () => {}
   })
 )(Success)

--- a/shared/login/signup/success/index.js
+++ b/shared/login/signup/success/index.js
@@ -28,7 +28,7 @@ Success.propTypes = {
 export default connect(
   state => ({paperkey: state.signup.paperkey}),
   dispatch => ({
-    onFinish: dispatch(sawPaperKey()),
+    onFinish: () => dispatch(sawPaperKey()),
     onBack: () => {}
   })
 )(Success)

--- a/shared/login/signup/success/index.render.desktop.js
+++ b/shared/login/signup/success/index.render.desktop.js
@@ -23,7 +23,7 @@ export default class Render extends Component {
   render () {
     return (
       <Container onBack={this.props.onBack} style={styles.container}>
-        <Text type='Header' style={styles.header}>{this.props.title ? this.props.title : 'Congratulations, you’ve just joined Keybase!'}</Text>
+        <Text type='Header' style={styles.header}>{this.props.title || 'Congratulations, you’ve just joined Keybase!'}</Text>
         <Text type='Body' style={styles.body}>Here is your unique paper key, it will allow you to perform important Keybase tasks in the future. This is the only time you’ll see this so be sure to write it down.</Text>
         <div style={styles.paperKeyContainer}>
           <Text type='Body' style={styles.paperkey}>{this.props.paperkey.stringValue()}</Text>

--- a/shared/login/signup/success/index.render.desktop.js
+++ b/shared/login/signup/success/index.render.desktop.js
@@ -23,7 +23,7 @@ export default class Render extends Component {
   render () {
     return (
       <Container onBack={this.props.onBack} style={styles.container}>
-        <Text type='Header' style={styles.header}>Congratulations, you’ve just joined Keybase!</Text>
+        <Text type='Header' style={styles.header}>{this.props.title ? this.props.title : 'Congratulations, you’ve just joined Keybase!'}</Text>
         <Text type='Body' style={styles.body}>Here is your unique paper key, it will allow you to perform important Keybase tasks in the future. This is the only time you’ll see this so be sure to write it down.</Text>
         <div style={styles.paperKeyContainer}>
           <Text type='Body' style={styles.paperkey}>{this.props.paperkey.stringValue()}</Text>

--- a/shared/login/signup/success/index.render.js.flow
+++ b/shared/login/signup/success/index.render.js.flow
@@ -6,7 +6,8 @@ import HiddenString from '../../../util/hidden-string'
 export type Props = {
   paperkey: HiddenString,
   onFinish: () => void,
-  onBack: () => void
+  onBack: () => void,
+  title?: ?string
 }
 
 export default class Render extends Component {


### PR DESCRIPTION
@keybase/react-hackers 

There's a (fairly common) provisioning path that was missing the show-paper-key stage -- when you have a keybase account with no device keys and login through the GUI app.  Before this PR, the `displayPrimaryPaperKey` RPC is unhandled and we just move to being logged in without ever showing the user their new paper key.

After this PR, we go to the same show-paper-key screen that signup uses as its Success page, but now parameterized to say appropriate things for our case.

I'm not going to merge this until I see whether this breaks the signup flow; I can test that once DESKTOP-818 is fixed.