### PR TITLE
force only our node_modules in webpack

### DIFF
--- a/desktop/webpack.config.base.js
+++ b/desktop/webpack.config.base.js
@@ -30,9 +30,10 @@ module.exports = {
     libraryTarget: 'commonjs2'
   },
   resolve: {
+    modulesDirectories: [path.join(__dirname, 'node_modules')],
+    root: [path.join(__dirname)],
     extensions: ['', '.desktop.js', '.js', '.jsx', '.json'],
-    packageMains: ['webpack', 'browser', 'web', 'browserify', ['jam', 'main'], 'main'],
-    fallback: path.join(__dirname, 'node_modules')
+    packageMains: ['webpack', 'browser', 'web', 'browserify', ['jam', 'main'], 'main']
   },
   resolveLoader: {
     modulesDirectories: ['web_loaders', 'web_modules', 'node_loaders', 'node_modules', path.join(__dirname, 'node_modules')],


### PR DESCRIPTION
@cjb @keybase/react-hackers 
Webpack by default will try and resolve node_modules under ~/node_modules, which is annoying. It actually prefers this over where our modules were stored, but i think due to us exposing it as a fallback. This overwrites the node_modules with just our own