### PR TITLE
let `keybase device remove` accept names, not just ids

### DIFF
--- a/go/client/cmd_device_remove.go
+++ b/go/client/cmd_device_remove.go
@@ -31,6 +31,13 @@ func (c *CmdDeviceRemove) ParseArgv(ctx *cli.Context) error {
 }
 
 func (c *CmdDeviceRemove) Run() (err error) {
+	protocols := []rpc.Protocol{
+		NewSecretUIProtocol(c.G()),
+	}
+	if err = RegisterProtocolsWithContext(protocols, c.G()); err != nil {
+		return err
+	}
+
 	var id keybase1.DeviceID
 	id, err = keybase1.DeviceIDFromString(c.idOrName)
 	if err != nil {
@@ -45,13 +52,6 @@ func (c *CmdDeviceRemove) Run() (err error) {
 		return err
 	}
 
-	protocols := []rpc.Protocol{
-		NewSecretUIProtocol(c.G()),
-	}
-	if err = RegisterProtocols(protocols); err != nil {
-		return err
-	}
-
 	return cli.RevokeDevice(context.TODO(), keybase1.RevokeDeviceArg{
 		Force:    c.force,
 		DeviceID: id,
@@ -61,9 +61,6 @@ func (c *CmdDeviceRemove) Run() (err error) {
 func (c *CmdDeviceRemove) lookup(name string) (keybase1.DeviceID, error) {
 	cli, err := GetDeviceClient()
 	if err != nil {
-		return "", err
-	}
-	if err := RegisterProtocols(nil); err != nil {
 		return "", err
 	}
 	devs, err := cli.DeviceList(context.TODO(), 0)

--- a/go/client/cmd_device_remove.go
+++ b/go/client/cmd_device_remove.go
@@ -16,25 +16,29 @@ import (
 )
 
 type CmdDeviceRemove struct {
-	id    keybase1.DeviceID
+	id    string
 	force bool
 	libkb.Contextified
 }
 
 func (c *CmdDeviceRemove) ParseArgv(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
-		return fmt.Errorf("Device remove only takes one argument, the device ID.")
+		return fmt.Errorf("Device remove only takes one argument: the device ID or name.")
 	}
-	id, err := keybase1.DeviceIDFromString(ctx.Args()[0])
-	if err != nil {
-		return err
-	}
-	c.id = id
+	c.id = ctx.Args()[0]
 	c.force = ctx.Bool("force")
 	return nil
 }
 
 func (c *CmdDeviceRemove) Run() (err error) {
+	id, err := keybase1.DeviceIDFromString(c.id)
+	if err != nil {
+		id, err = c.lookup(c.id)
+		if err != nil {
+			return err
+		}
+	}
+
 	cli, err := GetRevokeClient()
 	if err != nil {
 		return err
@@ -49,14 +53,35 @@ func (c *CmdDeviceRemove) Run() (err error) {
 
 	return cli.RevokeDevice(context.TODO(), keybase1.RevokeDeviceArg{
 		Force:    c.force,
-		DeviceID: c.id,
+		DeviceID: id,
 	})
+}
+
+func (c *CmdDeviceRemove) lookup(name string) (keybase1.DeviceID, error) {
+	cli, err := GetDeviceClient()
+	if err != nil {
+		return "", err
+	}
+	if err := RegisterProtocols(nil); err != nil {
+		return "", err
+	}
+	devs, err := cli.DeviceList(context.TODO(), 0)
+	if err != nil {
+		return "", err
+	}
+
+	for _, dev := range devs {
+		if dev.Name == name {
+			return dev.DeviceID, nil
+		}
+	}
+	return "", fmt.Errorf("Unknown Device ID or Name")
 }
 
 func NewCmdDeviceRemove(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:         "remove",
-		ArgumentHelp: "<id>",
+		ArgumentHelp: "<id|name>",
 		Usage:        "Remove a device",
 		Flags: []cli.Flag{
 			cli.BoolFlag{

--- a/go/client/cmd_device_remove.go
+++ b/go/client/cmd_device_remove.go
@@ -16,8 +16,8 @@ import (
 )
 
 type CmdDeviceRemove struct {
-	id    string
-	force bool
+	idOrName string
+	force    bool
 	libkb.Contextified
 }
 
@@ -25,15 +25,16 @@ func (c *CmdDeviceRemove) ParseArgv(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
 		return fmt.Errorf("Device remove only takes one argument: the device ID or name.")
 	}
-	c.id = ctx.Args()[0]
+	c.idOrName = ctx.Args()[0]
 	c.force = ctx.Bool("force")
 	return nil
 }
 
 func (c *CmdDeviceRemove) Run() (err error) {
-	id, err := keybase1.DeviceIDFromString(c.id)
+	var id keybase1.DeviceID
+	id, err = keybase1.DeviceIDFromString(c.idOrName)
 	if err != nil {
-		id, err = c.lookup(c.id)
+		id, err = c.lookup(c.idOrName)
 		if err != nil {
 			return err
 		}

--- a/go/client/cmd_device_remove.go
+++ b/go/client/cmd_device_remove.go
@@ -73,7 +73,7 @@ func (c *CmdDeviceRemove) lookup(name string) (keybase1.DeviceID, error) {
 			return dev.DeviceID, nil
 		}
 	}
-	return "", fmt.Errorf("Unknown Device ID or Name")
+	return "", fmt.Errorf("Invalid Device ID or Unknown Device Name")
 }
 
 func NewCmdDeviceRemove(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {


### PR DESCRIPTION
As per https://keybase.atlassian.net/browse/CORE-2321

A potential downside is that you get less specific error messages if you pass a badly-formatted ID.
E.g. you used to get `Bad Device ID length: 7` but now you'll just get `Unknown Device ID or Name`.

Alternatives that come to mind:
- Return more verbose error messages (though I don't actually know how to concatenate go `error` objects) for example `Unknown Device Name or Bad Device ID length: 7`
- Require a flag `-n`/`--name` to do name lookups, in which case the errors could be simple in both cases.

/cc @oconnor663 