### PR TITLE
Order matters when we reset the pinentry store

### DIFF
--- a/shared/reducers/pinentry.js
+++ b/shared/reducers/pinentry.js
@@ -40,8 +40,8 @@ export default function (state: RootPinentryState = initialState, action: Pinent
   switch (action.type) {
     case CommonConstants.resetStore:
       return {
-        started: state.started,
-        ...initialState
+        ...initialState,
+        started: state.started
       }
     case Constants.registerPinentryListener:
       if (action.payload && action.payload.started) {


### PR DESCRIPTION
@keybase/react-hackers 

We weren't persisting the started state properly