### PR TITLE
add a NoSkipSelf flag to identify2

### DIFF
--- a/go/client/cmd_id.go
+++ b/go/client/cmd_id.go
@@ -45,6 +45,7 @@ func (v *CmdID) makeArg() keybase1.Identify2Arg {
 		AlwaysBlock:      true,
 		NeedProofSet:     true,
 		AllowEmptySelfID: true,
+		NoSkipSelf:       true,
 	}
 }
 

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -152,8 +152,8 @@ func (e *Identify2WithUID) runReturnError(ctx *Context) (err error) {
 		return err
 	}
 
-	if e.isSelfLoad() {
-		e.G().Log.Debug("| was a self load")
+	if e.isSelfLoad() && !e.arg.NoSkipSelf {
+		e.G().Log.Debug("| was a self load, short-circuiting")
 		return nil
 	}
 

--- a/go/protocol/identify.go
+++ b/go/protocol/identify.go
@@ -40,6 +40,7 @@ type Identify2Arg struct {
 	ForceRemoteCheck      bool           `codec:"forceRemoteCheck" json:"forceRemoteCheck"`
 	NeedProofSet          bool           `codec:"needProofSet" json:"needProofSet"`
 	AllowEmptySelfID      bool           `codec:"allowEmptySelfID" json:"allowEmptySelfID"`
+	NoSkipSelf            bool           `codec:"noSkipSelf" json:"noSkipSelf"`
 }
 
 type IdentifyInterface interface {

--- a/protocol/avdl/identify.avdl
+++ b/protocol/avdl/identify.avdl
@@ -29,6 +29,6 @@ protocol identify {
   /*
    * Note that UID can be empty, in which case a resolution is also forced.
    */
-  Identify2Res identify2(int sessionID, UID uid, string userAssertion, IdentifyReason reason, boolean useDelegateUI=false, boolean alwaysBlock=false, boolean noErrorOnTrackFailure=false, boolean forceRemoteCheck=false, boolean needProofSet=false, boolean allowEmptySelfID=false);
+  Identify2Res identify2(int sessionID, UID uid, string userAssertion, IdentifyReason reason, boolean useDelegateUI=false, boolean alwaysBlock=false, boolean noErrorOnTrackFailure=false, boolean forceRemoteCheck=false, boolean needProofSet=false, boolean allowEmptySelfID=false, boolean noSkipSelf=true);
 
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1919,7 +1919,8 @@ export type identify_identify2_rpc = {
     noErrorOnTrackFailure?: boolean,
     forceRemoteCheck?: boolean,
     needProofSet?: boolean,
-    allowEmptySelfID?: boolean
+    allowEmptySelfID?: boolean,
+    noSkipSelf?: boolean
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any, response: identify_identify2_result) => void)
@@ -3960,7 +3961,8 @@ export type incomingCallMapType = {
       noErrorOnTrackFailure?: boolean,
       forceRemoteCheck?: boolean,
       needProofSet?: boolean,
-      allowEmptySelfID?: boolean
+      allowEmptySelfID?: boolean,
+      noSkipSelf?: boolean
     },
     response: {
       error: (err: RPCError) => void,

--- a/protocol/json/identify.json
+++ b/protocol/json/identify.json
@@ -779,6 +779,11 @@
           "name": "allowEmptySelfID",
           "type": "boolean",
           "default": false
+        },
+        {
+          "name": "noSkipSelf",
+          "type": "boolean",
+          "default": true
         }
       ],
       "response": "Identify2Res"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1919,7 +1919,8 @@ export type identify_identify2_rpc = {
     noErrorOnTrackFailure?: boolean,
     forceRemoteCheck?: boolean,
     needProofSet?: boolean,
-    allowEmptySelfID?: boolean
+    allowEmptySelfID?: boolean,
+    noSkipSelf?: boolean
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any, response: identify_identify2_result) => void)
@@ -3960,7 +3961,8 @@ export type incomingCallMapType = {
       noErrorOnTrackFailure?: boolean,
       forceRemoteCheck?: boolean,
       needProofSet?: boolean,
-      allowEmptySelfID?: boolean
+      allowEmptySelfID?: boolean,
+      noSkipSelf?: boolean
     },
     response: {
       error: (err: RPCError) => void,


### PR DESCRIPTION
Setting this prevents `keybase id` from short-circuiting and failing to
show your own proofs.

r? @maxtaco 