### PR TITLE
Pass username through from the service for passphrase pinentry and use it

### DIFF
--- a/go/libkb/passphrase_helper.go
+++ b/go/libkb/passphrase_helper.go
@@ -12,6 +12,7 @@ func GetKeybasePassphrase(ui SecretUI, username, retryMsg string, allowSecretSto
 	arg := DefaultPassphraseArg(allowSecretStore)
 	arg.WindowTitle = "Keybase passphrase"
 	arg.Type = keybase1.PassphraseType_PASS_PHRASE
+	arg.Username = username
 	arg.Prompt = fmt.Sprintf("Please enter the Keybase passphrase for %s (12+ characters)", username)
 	arg.RetryLabel = retryMsg
 	return GetPassphraseUntilCheck(arg, newUIPrompter(ui), &CheckPassphraseSimple)
@@ -38,6 +39,7 @@ func GetPaperKeyPassphrase(ui SecretUI, username string) (string, error) {
 		username = "your account"
 	}
 	arg.Prompt = fmt.Sprintf("Please enter a paper backup key passphrase for %s", username)
+	arg.Username = username
 	arg.Features.StoreSecret.Allow = false
 	arg.Features.StoreSecret.Readonly = true
 	arg.Features.ShowTyping.Allow = true

--- a/go/protocol/passphrase_common.go
+++ b/go/protocol/passphrase_common.go
@@ -31,6 +31,7 @@ const (
 type GUIEntryArg struct {
 	WindowTitle string           `codec:"windowTitle" json:"windowTitle"`
 	Prompt      string           `codec:"prompt" json:"prompt"`
+	Username    string           `codec:"username" json:"username"`
 	SubmitLabel string           `codec:"submitLabel" json:"submitLabel"`
 	CancelLabel string           `codec:"cancelLabel" json:"cancelLabel"`
 	RetryLabel  string           `codec:"retryLabel" json:"retryLabel"`

--- a/protocol/avdl/passphrase_common.avdl
+++ b/protocol/avdl/passphrase_common.avdl
@@ -23,6 +23,7 @@ protocol passphraseCommon {
   record GUIEntryArg {
     string windowTitle;
     string prompt;
+    string username;
     string submitLabel;
     string cancelLabel;
     string retryLabel;

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -295,6 +295,7 @@ export type GPGMethod =
 export type GUIEntryArg = {
   windowTitle: string;
   prompt: string;
+  username: string;
   submitLabel: string;
   cancelLabel: string;
   retryLabel: string;

--- a/protocol/json/account.json
+++ b/protocol/json/account.json
@@ -61,6 +61,10 @@
         },
         {
           "type": "string",
+          "name": "username"
+        },
+        {
+          "type": "string",
           "name": "submitLabel"
         },
         {

--- a/protocol/json/secret_ui.json
+++ b/protocol/json/secret_ui.json
@@ -61,6 +61,10 @@
         },
         {
           "type": "string",
+          "name": "username"
+        },
+        {
+          "type": "string",
           "name": "submitLabel"
         },
         {

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -423,7 +423,7 @@ function makeKex2IncomingMap (dispatch, getState) : incomingCallMapType {
           onWont={() => response.result('')}
           onBack={() => dispatch(cancelLogin(response))}/>))
     },
-    'keybase.1.secretUi.getPassphrase': ({pinentry: {type, prompt, retryLabel}}, response) => {
+    'keybase.1.secretUi.getPassphrase': ({pinentry: {type, prompt, username, retryLabel}}, response) => {
       switch (type) {
         case enums.secretUi.PassphraseType.paperKey:
           appendRouteElement((

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -295,6 +295,7 @@ export type GPGMethod =
 export type GUIEntryArg = {
   windowTitle: string;
   prompt: string;
+  username: string;
   submitLabel: string;
   cancelLabel: string;
   retryLabel: string;


### PR DESCRIPTION
@keybase/react-hackers @patrickxb 

Prior to this PR, the only access we had to the username being asked for during `secretUi.getPassphrase` was inside the `prompt` parameter (`Please enter the Keybase passphrase for cjb..`).  This PR adds it to the protocol and sends it through when it's known for use during kex2.

Before:
![screenshot from 2016-03-29 10-26-43](https://cloud.githubusercontent.com/assets/21217/14111573/429e7682-f599-11e5-9a92-852629b4cf72.png)

After:
![screenshot from 2016-03-29 10-27-02](https://cloud.githubusercontent.com/assets/21217/14111592/4780a38c-f599-11e5-89ec-151c94eea88f.png)
