### PR TITLE
Show error text in main login screen

### DIFF
--- a/shared/login/login/index.render.desktop.js
+++ b/shared/login/login/index.render.desktop.js
@@ -6,7 +6,6 @@ import type {Props} from './index.render'
 
 type State = {
   selectedUser: ?string,
-  error: ?string,
   saveInKeychain: boolean,
   showTyping: boolean,
   passphrase: string
@@ -20,7 +19,6 @@ export default class LoginRender extends Component<void, Props, State> {
 
     this.state = {
       selectedUser: props.lastUser,
-      error: props.error,
       saveInKeychain: true,
       showTyping: false,
       passphrase: ''
@@ -40,7 +38,7 @@ export default class LoginRender extends Component<void, Props, State> {
       onChange: event => this.setState({passphrase: event.target.value}),
       onEnterKeyDown: () => this.onSubmit(),
       type: this.state.showTyping ? 'text' : 'password',
-      errorText: this.state.error
+      errorText: this.props.error
     }
 
     const checkboxProps = [


### PR DESCRIPTION
@keybase/react-hackers Any idea why this was using `state.error`?  We need `error` to propagate updates after each login attempt, not just be set once in the constructor.  But maybe there's some good reason to use state that I'm not thinking of.

Before:
![screenshot from 2016-03-29 11-14-57](https://cloud.githubusercontent.com/assets/21217/14114748/45476c74-f5a6-11e5-8d46-c47c3b3c0eb5.png)

After:
![screenshot from 2016-03-29 12-08-16](https://cloud.githubusercontent.com/assets/21217/14114915/fdea04f8-f5a6-11e5-9f85-2ae0736864f9.png)
