### PR TITLE
Set myDeviceRole when starting login

### DIFF
--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -144,12 +144,16 @@ export function login (): AsyncAction {
         engine.rpc(params)
       }
     }
-    // We ask for user since the login will auto login with the last user which we don't always want
+    // We can either be a newDevice or an existingDevice.
+    // Here in the login flow, let's set ourselves to be
+    // a newDevice.  If we were in the Devices tab flow,
+    // we'd want the opposite.
     if (isMobile) {
       dispatch({type: Constants.setMyDeviceCodeState, payload: Constants.codePageDeviceRoleNewPhone})
     } else {
       dispatch({type: Constants.setMyDeviceCodeState, payload: Constants.codePageDeviceRoleNewComputer})
     }
+    // We ask for user since the login will auto login with the last user which we don't always want
     dispatch(routeAppend({parseRoute: {componentAtTop: {component: UsernameOrEmail, props}}}))
   }
 }

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -145,6 +145,11 @@ export function login (): AsyncAction {
       }
     }
     // We ask for user since the login will auto login with the last user which we don't always want
+    if (isMobile) {
+      dispatch({type: Constants.setMyDeviceCodeState, payload: Constants.codePageDeviceRoleNewPhone})
+    } else {
+      dispatch({type: Constants.setMyDeviceCodeState, payload: Constants.codePageDeviceRoleNewComputer})
+    }
     dispatch(routeAppend({parseRoute: {componentAtTop: {component: UsernameOrEmail, props}}}))
   }
 }

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -144,14 +144,19 @@ export function login (): AsyncAction {
         engine.rpc(params)
       }
     }
-    // We can either be a newDevice or an existingDevice.
-    // Here in the login flow, let's set ourselves to be
-    // a newDevice.  If we were in the Devices tab flow,
-    // we'd want the opposite.
+    // We can either be a newDevice or an existingDevice.  Here in the login
+    // flow, let's set ourselves to be a newDevice.  If we were in the Devices
+    // tab flow, we'd want the opposite.
     if (isMobile) {
-      dispatch({type: Constants.setMyDeviceCodeState, payload: Constants.codePageDeviceRoleNewPhone})
+      dispatch({
+        type: Constants.setMyDeviceCodeState,
+        payload: Constants.codePageDeviceRoleNewPhon
+      })
     } else {
-      dispatch({type: Constants.setMyDeviceCodeState, payload: Constants.codePageDeviceRoleNewComputer})
+      dispatch({
+        type: Constants.setMyDeviceCodeState,
+        payload: Constants.codePageDeviceRoleNewComputer
+      })
     }
     // We ask for user since the login will auto login with the last user which we don't always want
     dispatch(routeAppend({parseRoute: {componentAtTop: {component: UsernameOrEmail, props}}}))

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -150,7 +150,7 @@ export function login (): AsyncAction {
     if (isMobile) {
       dispatch({
         type: Constants.setMyDeviceCodeState,
-        payload: Constants.codePageDeviceRoleNewPhon
+        payload: Constants.codePageDeviceRoleNewPhone
       })
     } else {
       dispatch({

--- a/shared/constants/login.js
+++ b/shared/constants/login.js
@@ -16,6 +16,7 @@ export const countDownTime = 5 * 60
 export const login = 'login:login'
 export const loginDone = 'login:loginDone'
 export const logoutDone = 'login:logoutDone'
+export const setMyDeviceCodeState = 'login:setMyDeviceCodeState'
 export const setOtherDeviceCodeState = 'login:setOtherDeviceCodeState'
 export const setCodeMode = 'login:setCodeMode'
 export const setTextCode = 'login:setTextCode'

--- a/shared/login/register/code-page/index.render.desktop.js
+++ b/shared/login/register/code-page/index.render.desktop.js
@@ -97,6 +97,7 @@ export default class CodePageRender extends Component {
       case codePageModeShowText:
         return this.renderText()
     }
+    console.error(`No mode prop passed! Mode: ${this.props.mode}`)
     return (<div/>)
   }
 }

--- a/shared/login/register/code-page/index.render.desktop.js
+++ b/shared/login/register/code-page/index.render.desktop.js
@@ -32,7 +32,7 @@ export default class CodePageRender extends Component {
         onBack={this.props.onBack}>
 
         <Text type='Header' style={{marginTop: 60}}>Type in text code</Text>
-        <Text type='BodySmall'>Type this code on your other device</Text>
+        <Text type='BodySmall'>Run&nbsp;</Text><Text type='TerminalSmall'>keybase device add</Text><Text type='BodySmall'>&nbsp;on your other device and type this code there: </Text>
         <Icon type='computer-bw-m' style={{marginTop: 28}}/>
 
         <Text type='Body' style={styles.paperkey}>{this.props.textCode}</Text>

--- a/shared/login/register/code-page/index.render.desktop.js
+++ b/shared/login/register/code-page/index.render.desktop.js
@@ -32,7 +32,7 @@ export default class CodePageRender extends Component {
         onBack={this.props.onBack}>
 
         <Text type='Header' style={{marginTop: 60}}>Type in text code</Text>
-        <Text type='BodySmall'>Run&nbsp;</Text><Text type='TerminalSmall'>keybase device add</Text><Text type='BodySmall'>&nbsp;on your other device and type this code there: </Text>
+        <Text type='BodySmall'>Type this code on your other device</Text>
         <Icon type='computer-bw-m' style={{marginTop: 28}}/>
 
         <Text type='Body' style={styles.paperkey}>{this.props.textCode}</Text>

--- a/shared/reducers/login.js
+++ b/shared/reducers/login.js
@@ -4,12 +4,6 @@ import * as Constants from '../constants/login'
 import * as ConfigConstants from '../constants/config'
 import * as CommonConstants from '../constants/common'
 import Immutable from 'immutable'
-import {isMobile} from '../constants/platform'
-import {
-  codePageDeviceRoleNewPhone,
-  codePageDeviceRoleNewComputer,
-  codePageDeviceRoleExistingPhone,
-  codePageDeviceRoleExistingComputer} from '../constants/login'
 
 export type DeviceRole = 'codePageDeviceRoleExistingPhone' | 'codePageDeviceRoleNewPhone' | 'codePageDeviceRoleExistingComputer' | 'codePageDeviceRoleNewComputer'
 export type Mode = 'codePageModeScanCode' | 'codePageModeShowCode' | 'codePageModeEnterText' | 'codePageModeShowText'

--- a/shared/reducers/login.js
+++ b/shared/reducers/login.js
@@ -79,15 +79,6 @@ export default function (state: LoginState = initialState, action: any): LoginSt
       if (action.error || action.payload == null) {
         return state
       }
-      let myDeviceRole = null
-
-      if (action.payload.status.registered) {
-        myDeviceRole = isMobile ? codePageDeviceRoleExistingPhone : codePageDeviceRoleExistingComputer
-      } else {
-        myDeviceRole = isMobile ? codePageDeviceRoleNewPhone : codePageDeviceRoleNewComputer
-      }
-
-      toMerge = {codePage: {myDeviceRole}}
       break
     case Constants.setMyDeviceCodeState:
       toMerge = {codePage: {myDeviceRole: action.payload}}

--- a/shared/reducers/login.js
+++ b/shared/reducers/login.js
@@ -89,6 +89,9 @@ export default function (state: LoginState = initialState, action: any): LoginSt
 
       toMerge = {codePage: {myDeviceRole}}
       break
+    case Constants.setMyDeviceCodeState:
+      toMerge = {codePage: {myDeviceRole: action.payload}}
+      break
     case Constants.setOtherDeviceCodeState:
       toMerge = {codePage: {otherDeviceRole: action.payload}}
       break


### PR DESCRIPTION
@keybase/react-hackers 

We were using whether the service was "registered" to determine if provisioning is happening with a NewComputer or ExistingComputer. But someone could be registered under one username, and trying to log in under a different one.  In that case, they should be a NewComputer, not an ExistingComputer.

This PR sets myDeviceRole to NewComputer at the start of the login flow.