### PR TITLE
kex2 provisioner now stops properly

### DIFF
--- a/go/kex2/transport.go
+++ b/go/kex2/transport.go
@@ -371,9 +371,7 @@ func (c *Conn) pollLoop(poll time.Duration) (msgs [][]byte, err error) {
 	var totalWaitTime time.Duration
 
 	c.setPollLoopRunning(true)
-	defer func() {
-		c.setPollLoopRunning(false)
-	}()
+	defer c.setPollLoopRunning(false)
 
 	start := time.Now()
 	for {


### PR DESCRIPTION
- previously the kex2 provisioner would leave one of its connections continuing to poll
- the bug was in Conn.Close, which wasn't telling the poll loop to stop
- a test is really needed, but i have to move on