### PR TITLE
protocol: add an "oldVersion" KBFS error type

### DIFF
--- a/go/protocol/kbfs_common.go
+++ b/go/protocol/kbfs_common.go
@@ -37,6 +37,7 @@ const (
 	FSErrorType_REKEY_NEEDED          FSErrorType = 5
 	FSErrorType_BAD_FOLDER            FSErrorType = 6
 	FSErrorType_NOT_IMPLEMENTED       FSErrorType = 7
+	FSErrorType_OLD_VERSION           FSErrorType = 8
 )
 
 type FSNotification struct {

--- a/protocol/avdl/kbfs_common.avdl
+++ b/protocol/avdl/kbfs_common.avdl
@@ -24,7 +24,8 @@ protocol kbfsCommon {
     TIMEOUT_4,
     REKEY_NEEDED_5,
     BAD_FOLDER_6,
-    NOT_IMPLEMENTED_7
+    NOT_IMPLEMENTED_7,
+    OLD_VERSION_8
   }
 
   record FSNotification {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -204,6 +204,7 @@ export type FSErrorType =
   | 5 // REKEY_NEEDED_5
   | 6 // BAD_FOLDER_6
   | 7 // NOT_IMPLEMENTED_7
+  | 8 // OLD_VERSION_8
 
 export type FSNotification = {
   publicTopLevelFolder: boolean;

--- a/protocol/js/keybase-v1.js
+++ b/protocol/js/keybase-v1.js
@@ -596,7 +596,8 @@ export const kbfs = {
     'timeout': 4,
     'rekeyNeeded': 5,
     'badFolder': 6,
-    'notImplemented': 7
+    'notImplemented': 7,
+    'oldVersion': 8
   }
 }
 
@@ -816,7 +817,8 @@ export const NotifyFS = {
     'timeout': 4,
     'rekeyNeeded': 5,
     'badFolder': 6,
-    'notImplemented': 7
+    'notImplemented': 7,
+    'oldVersion': 8
   }
 }
 

--- a/protocol/json/kbfs.json
+++ b/protocol/json/kbfs.json
@@ -33,7 +33,8 @@
         "TIMEOUT_4",
         "REKEY_NEEDED_5",
         "BAD_FOLDER_6",
-        "NOT_IMPLEMENTED_7"
+        "NOT_IMPLEMENTED_7",
+        "OLD_VERSION_8"
       ]
     },
     {

--- a/protocol/json/notify_fs.json
+++ b/protocol/json/notify_fs.json
@@ -33,7 +33,8 @@
         "TIMEOUT_4",
         "REKEY_NEEDED_5",
         "BAD_FOLDER_6",
-        "NOT_IMPLEMENTED_7"
+        "NOT_IMPLEMENTED_7",
+        "OLD_VERSION_8"
       ]
     },
     {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -204,6 +204,7 @@ export type FSErrorType =
   | 5 // REKEY_NEEDED_5
   | 6 // BAD_FOLDER_6
   | 7 // NOT_IMPLEMENTED_7
+  | 8 // OLD_VERSION_8
 
 export type FSNotification = {
   publicTopLevelFolder: boolean;

--- a/shared/constants/types/keybase-v1.js
+++ b/shared/constants/types/keybase-v1.js
@@ -596,7 +596,8 @@ export const kbfs = {
     'timeout': 4,
     'rekeyNeeded': 5,
     'badFolder': 6,
-    'notImplemented': 7
+    'notImplemented': 7,
+    'oldVersion': 8
   }
 }
 
@@ -816,7 +817,8 @@ export const NotifyFS = {
     'timeout': 4,
     'rekeyNeeded': 5,
     'badFolder': 6,
-    'notImplemented': 7
+    'notImplemented': 7,
+    'oldVersion': 8
   }
 }
 


### PR DESCRIPTION
To be used when KBFS encounters data in a folder, formatted in a version that's too new for this client.

Issue: KBFS-915