### PR TITLE
Fix typos

### DIFF
--- a/go/client/cmd_encrypt.go
+++ b/go/client/cmd_encrypt.go
@@ -53,7 +53,7 @@ func NewCmdEncrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 			},
 			cli.BoolFlag{
 				Name:  "hide-recipients",
-				Usage: "Don't include recepients in metadata",
+				Usage: "Don't include recipients in metadata",
 			},
 			cli.BoolFlag{
 				Name:  "no-self",

--- a/go/client/errors.go
+++ b/go/client/errors.go
@@ -68,5 +68,5 @@ func (e ProofNotYetAvailableError) Error() string {
 type UnexpectedArgsError string
 
 func (e UnexpectedArgsError) Error() string {
-	return fmt.Sprintf("Command `%s` doesn't talk any non-flag arugments", string(e))
+	return fmt.Sprintf("Command `%s` doesn't take any non-flag arguments", string(e))
 }

--- a/go/client/saltpack_ui.go
+++ b/go/client/saltpack_ui.go
@@ -43,7 +43,7 @@ func (s *SaltpackUI) doInteractive(arg keybase1.SaltpackPromptForDecryptArg) err
 	case keybase1.SaltpackSenderType_UNKNOWN:
 		why = "The sender of this message is unknown to Keybase"
 	case keybase1.SaltpackSenderType_ANONYMOUS:
-		why = "The sender of this message has choosen to remain anonymous"
+		why = "The sender of this message has chosen to remain anonymous"
 	case keybase1.SaltpackSenderType_TRACKING_BROKE:
 		why = "You track the sender of this message, but their tracking statement is broken"
 		def = libkb.PromptDefaultNo

--- a/go/keybase/main_test.go
+++ b/go/keybase/main_test.go
@@ -116,7 +116,7 @@ func (u user) newExpectCmd(t *testing.T, args ...string) *expectCmd {
 	cmd = append(cmd, args...)
 	es, err := gexpect.Spawn(strings.Join(cmd, " "))
 	if err != nil {
-		t.Fatalf("Error spwaning %v: %v", cmd, err)
+		t.Fatalf("Error spawning %v: %v", cmd, err)
 	}
 	return &expectCmd{es}
 }

--- a/go/launchd/launchd_test.go
+++ b/go/launchd/launchd_test.go
@@ -99,7 +99,7 @@ func todoTestCheckPlist(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !plistNewIsValidAfterInstall {
-		t.Fatalf("New pist should be valid after install")
+		t.Fatalf("New plist should be valid after install")
 	}
 }
 

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -166,7 +166,7 @@ func (a *Account) Logout() error {
 
 func (a *Account) CreateStreamCache(tsec *triplesec.Cipher, pps *PassphraseStream) {
 	if a.streamCache != nil {
-		a.G().Log.Warning("Account.CreateStreamCache overwriting exisitng StreamCache")
+		a.G().Log.Warning("Account.CreateStreamCache overwriting existing StreamCache")
 	}
 	a.streamCache = NewPassphraseStreamCache(tsec, pps)
 	a.SetLKSec(NewLKSec(pps, a.GetUID(), a.G()))

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -509,7 +509,7 @@ func (g *GlobalContext) GetUnforwardedLogger() *logger.UnforwardedLogger {
 	}
 	log, ok := g.Log.(*logger.Standard)
 	if !ok {
-		g.Log.Notice("Can't make Unforwaded logger from a non-standard logger")
+		g.Log.Notice("Can't make Unforwarded logger from a non-standard logger")
 		return nil
 	}
 	return (*logger.UnforwardedLogger)(log)

--- a/go/libkb/naclwrap_test.go
+++ b/go/libkb/naclwrap_test.go
@@ -92,7 +92,7 @@ func TestVerifyStringReject(t *testing.T) {
 
 	_, err = keyPair.VerifyString(sig2+sig, msg)
 	if err == nil {
-		t.Error("Signature with preprended invalid signature unexpectedly passes")
+		t.Error("Signature with prepended invalid signature unexpectedly passes")
 	}
 }
 

--- a/go/libkb/proof_support_twitter.go
+++ b/go/libkb/proof_support_twitter.go
@@ -155,7 +155,7 @@ func (t TwitterServiceType) GetTypeName() string          { return "twitter" }
 
 func (t TwitterServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *Markup, err error) {
 	if status == keybase1.ProofStatus_PERMISSION_DENIED {
-		warning = FmtMarkup("Permission denied! We can't suppport <strong>private</strong feeds.")
+		warning = FmtMarkup("Permission denied! We can't support <strong>private</strong> feeds.")
 	} else {
 		warning, err = t.BaseRecheckProofPosting(tryNumber, status)
 	}

--- a/go/libkb/resolve_test.go
+++ b/go/libkb/resolve_test.go
@@ -44,34 +44,34 @@ func TestResolveSimple(t *testing.T) {
 	}
 	goodResolve("eb72f49f2dde6429e5d78003dae0c919@uid")
 	if !r.stats.eq(0, 0, 0, 0, 0) {
-		t.Fatalf("Got bad cach stats: %+v\n", r.stats)
+		t.Fatalf("Got bad cache stats: %+v\n", r.stats)
 	}
 	goodResolve("t_tracy@keybase")
 	if !r.stats.eq(1, 0, 0, 0, 0) {
-		t.Fatalf("Got bad cach stats: %+v\n", r.stats)
+		t.Fatalf("Got bad cache stats: %+v\n", r.stats)
 	}
 	goodResolve("t_tracy@keybase")
 	if !r.stats.eq(1, 0, 0, 0, 1) {
-		t.Fatalf("Got bad cach stats: %+v\n", r.stats)
+		t.Fatalf("Got bad cache stats: %+v\n", r.stats)
 	}
 	clock.tick(resolveCacheMaxAge * 10)
 	goodResolve("t_tracy@keybase")
 	if !r.stats.eq(1, 1, 0, 0, 1) {
-		t.Fatalf("Got bad cach stats: %+v\n", r.stats)
+		t.Fatalf("Got bad cache stats: %+v\n", r.stats)
 	}
 	goodResolve("t_tracy@rooter")
 	if !r.stats.eq(2, 1, 0, 0, 1) {
-		t.Fatalf("Got bad cach stats: %+v\n", r.stats)
+		t.Fatalf("Got bad cache stats: %+v\n", r.stats)
 	}
 	clock.tick(resolveCacheMaxAgeMutable / 2)
 	goodResolve("t_tracy@rooter")
 	if !r.stats.eq(2, 1, 0, 0, 2) {
-		t.Fatalf("Got bad cach stats: %+v\n", r.stats)
+		t.Fatalf("Got bad cache stats: %+v\n", r.stats)
 	}
 	clock.tick(resolveCacheMaxAgeMutable * 2)
 	goodResolve("t_tracy@rooter")
 	if !r.stats.eq(2, 1, 1, 0, 2) {
-		t.Fatalf("Got bad cach stats: %+v\n", r.stats)
+		t.Fatalf("Got bad cache stats: %+v\n", r.stats)
 	}
 	res := r.Resolve("tacovontaco@twitter")
 	if err := res.GetError(); err == nil {

--- a/go/libkb/skb_test.go
+++ b/go/libkb/skb_test.go
@@ -283,7 +283,7 @@ func testErrUnlock(t *testing.T, skb *SKB, ui *TestCancelSecretUI) error {
 		t.Fatal("PromptAndUnlock returned nil error")
 	}
 	if key != nil {
-		t.Errorf("PromptAndUnlock eturned a key (%v)", key)
+		t.Errorf("PromptAndUnlock returned a key (%v)", key)
 	}
 	return err
 }

--- a/go/systests/rpc_test.go
+++ b/go/systests/rpc_test.go
@@ -59,14 +59,14 @@ func testIdentifyResolve2(t *testing.T, g *libkb.GlobalContext) {
 	}
 
 	if _, err := cli.Resolve(context.TODO(), "uid:eb72f49f2dde6429e5d78003dae0c919"); err != nil {
-		t.Fatalf("Resovle failed: %v\n", err)
+		t.Fatalf("Resolve failed: %v\n", err)
 	}
 
 	// We don't want to hit the cache, since the previous lookup never hit the
 	// server.  For Resolve2, we have to, since we need a username.  So test that
 	// here.
 	if res, err := cli.Resolve2(context.TODO(), "uid:eb72f49f2dde6429e5d78003dae0c919"); err != nil {
-		t.Fatalf("Resovle failed: %v\n", err)
+		t.Fatalf("Resolve failed: %v\n", err)
 	} else if res.Username != "t_tracy" {
 		t.Fatalf("Wrong username: %s != 't_tracy", res.Username)
 	}

--- a/go/vendor/h12.me/socks/socks.go
+++ b/go/vendor/h12.me/socks/socks.go
@@ -164,7 +164,7 @@ func dialSocks4(socksType int, proxy, targetAddr string) (conn net.Conn, err err
 	case 91:
 		err = errors.New("Socks connection request rejected or failed.")
 	case 92:
-		err = errors.New("Socks connection request rejected becasue SOCKS server cannot connect to identd on the client.")
+		err = errors.New("Socks connection request rejected because SOCKS server cannot connect to identd on the client.")
 	case 93:
 		err = errors.New("Socks connection request rejected because the client program and identd report different user-ids.")
 	default:

--- a/packaging/prerelease/s3_index.sh
+++ b/packaging/prerelease/s3_index.sh
@@ -35,7 +35,7 @@ elif [ "$platform" = "linux" ]; then
 elif [ "$platform" = "windows" ]; then
   "$release_bin" index-html --bucket-name="$bucket_name" --prefixes="windows/" --upload="windows/index.html"
 else
-  echo "Invalid platform: $paltform"
+  echo "Invalid platform: $platform"
   exit 1
 fi
 


### PR DESCRIPTION
While getting acquainted with the CLI application, I found a typo in the description of one of the switches.  To avoid creating a single-character pull request, I thought I'd follow up with a quick repository-wide review.  I'm pretty sure I haven't caught everything, but hopefully it's good enough for a 15-minute *aspell* session.

While we're at it, I found a minor mistake in the docs while skimming through the *[Meet your sigchain](https://keybase.io/docs/sigchain)* page:

> Your other devices will resume checking **the** their identity proofs and presenting them to you whenever you interact with them.