### PR TITLE
Android nightlies

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ dependencies:
     - mkdir -p $GOPATH/src/github.com/keybase
     - ln -s $HOME/client $GOPATH/src/github.com/keybase/client
     - npm run gobuild-android
-    - echo y | android update sdk --all --no-ui --filter "build-tools-23.0.1,android-23,extra-android-support"
+    - echo y | android update sdk --all --no-ui --filter "build-tools-23.0.2,android-23,extra-android-support,extra-android-m2repository"
 test:
   override:
     # TODO(mm) uncomment these device tests (see todo above)

--- a/packaging/android/build_and_publish.sh
+++ b/packaging/android/build_and_publish.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail # Fail on error
+
+gopath=${GOPATH:-}
+rn_dir="$gopath/src/github.com/keybase/client/react-native"
+android_dir="$gopath/src/github.com/keybase/client/react-native/android"
+client_dir="$gopath/src/github.com/keybase/client"
+cache_npm=${CACHE_NPM:-}
+cache_go_lib=${CACHE_GO_LIB:-}
+
+cd $rn_dir
+
+if [ ! "$cache_npm" = "1" ]; then
+  echo "Clearing old node_modules in react-native"
+  rm -r node_modules
+  # Install npm
+  npm install
+  npm install -g react-native-cli
+fi
+
+
+if [ ! "$cache_go_lib" = "1" ]; then
+  echo "Building Go library"
+  npm run gobuild-android
+fi
+
+# We can't currently automate this :(, we used to be able to `echo y | android update ...` but that no longer works
+# android update sdk --all --no-ui --filter "build-tools-23.0.2,android-23,extra-android-support,extra-android-m2repository"
+
+# Build and publish the apk
+cd $android_dir
+
+./gradlew publishApkRelease
+
+"$client_dir/packaging/slack/send.sh" "Finished releasing android"
+
+

--- a/react-native/android/app/build.gradle
+++ b/react-native/android/app/build.gradle
@@ -65,12 +65,21 @@ apply from: "react.gradle"
  * Upload all the APKs to the Play Store and people will download
  * the correct one based on the CPU architecture of their device.
  */
-def enableSeparateBuildPerCPUArchitecture = true
+// Disabling for now since it makes automating the builds a little trickier
+def enableSeparateBuildPerCPUArchitecture = false
 
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
  */
 def enableProguardInReleaseBuilds = false
+
+// Returns minutes from January 1 2016
+def Integer timestamp() {
+    def date = new Date()
+    def minutesSinceEpoch = date.getTime()/(1000 * 60)
+    def minutesJan2016 = 1451606400/60
+    return minutesSinceEpoch - minutesJan2016
+}
 
 android {
     compileSdkVersion 23
@@ -80,7 +89,9 @@ android {
         applicationId "io.keybase.android"
         minSdkVersion 16
         targetSdkVersion 23
-        versionCode 4
+        // Marco messed up the version code originally, so now we have to set the 2nd and 3rd msb
+        // The top one would make the number negative
+        versionCode (timestamp() | (1 << 30) | (1 << 29))
         versionName "1.0.0-alpha-2"
         ndk {
             abiFilters "armeabi-v7a", "x86"

--- a/react-native/android/app/build.gradle
+++ b/react-native/android/app/build.gradle
@@ -80,8 +80,8 @@ android {
         applicationId "io.keybase.android"
         minSdkVersion 16
         targetSdkVersion 23
-        versionCode 2
-        versionName "1.0.0-alpha-1"
+        versionCode 3
+        versionName "1.0.0-alpha-2"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/react-native/android/app/build.gradle
+++ b/react-native/android/app/build.gradle
@@ -80,7 +80,7 @@ android {
         applicationId "io.keybase.android"
         minSdkVersion 16
         targetSdkVersion 23
-        versionCode 3
+        versionCode 4
         versionName "1.0.0-alpha-2"
         ndk {
             abiFilters "armeabi-v7a", "x86"

--- a/react-native/android/app/build.gradle
+++ b/react-native/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: 'com.github.triplet.play'
 
 import com.android.build.OutputFile
 
@@ -85,6 +86,16 @@ android {
             abiFilters "armeabi-v7a", "x86"
         }
     }
+
+    signingConfigs {
+        release {
+            storeFile file(KB_RELEASE_STORE_FILE)
+            storePassword KB_RELEASE_STORE_PASSWORD
+            keyAlias KB_RELEASE_KEY_ALIAS
+            keyPassword KB_RELEASE_KEY_PASSWORD
+        }
+    }
+
     splits {
         abi {
             reset()
@@ -95,6 +106,7 @@ android {
     }
     buildTypes {
         release {
+            signingConfig signingConfigs.release
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
@@ -112,6 +124,11 @@ android {
             }
         }
     }
+}
+
+play {
+    track = 'alpha'
+    jsonFile = file(KB_SERVICE_ACCT_JSON)
 }
 
 dependencies {

--- a/react-native/android/app/build.gradle
+++ b/react-native/android/app/build.gradle
@@ -75,9 +75,12 @@ def enableProguardInReleaseBuilds = false
 
 // Returns minutes from January 1 2016
 def Integer timestamp() {
-    def date = new Date()
-    def minutesSinceEpoch = date.getTime()/(1000 * 60)
-    def minutesJan2016 = 1451606400/60
+    def minutesSinceEpoch = (new Date()).getTime()/(1000 * 60)
+    def cal = new GregorianCalendar()
+    cal.clear()
+    cal.set(2016,0,1)
+    def minutesJan2016 = cal.getTimeInMillis()/(1000 * 60)
+
     return minutesSinceEpoch - minutesJan2016
 }
 

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.github.triplet.gradle:play-publisher:1.1.4' // To publish from gradle
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
@keybase/react-hackers 

Code for building and publishing in one step.

Originally I was building a split APK (one for x86 and another for arm) but that might it a little more complicated with the gradle publish plugin, it's not setup for that. So I disabled that for now. Splitting them saved around 10mb on the apk. (~17mb instead of ~27 mb)