### PR TITLE
Adding pre-commit support for running our global eslint/flow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+-   repo: git@github.com:keybase/pre-commit.git
+    sha: 'e56c58cc34b81fc814f10c5062c31c9db93376df'
+    hooks:
+    -   id: eslint
+-   repo: git@github.com:keybase/pre-commit.git
+    sha: 'e56c58cc34b81fc814f10c5062c31c9db93376df'
+    hooks:
+    -   id: flow

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,9 @@
     sha: 'e56c58cc34b81fc814f10c5062c31c9db93376df'
     hooks:
     -   id: flow
+-   repo: git@github.com:keybase/pre-commit-golang.git
+    sha: '04b422b4c7fabfcf586e563e54334c659e6fd189'
+    hooks:
+    -   id: go-fmt
+    -   id: go-vet
+    -   id: go-lint


### PR DESCRIPTION
@keybase/react-hackers 
This just points to our own hooks repo and runs eslint / flow using an assumed global install. to test this out

```
brew install pre-commit (or follow http://pre-commit.com/#install)
(cd into client root dir)
pre-commit install
```

then when you commit stuff it should eslint/flow check it