### PR TITLE
If we close the window, we also release the dock icon

### DIFF
--- a/shared/nav.desktop.js
+++ b/shared/nav.desktop.js
@@ -105,7 +105,8 @@ class Nav extends Component {
         }
       } else if (oldWasLogin) {
         if (!flags.mainWindow) {
-          currentWindow.hide()
+          // We close since that will hide the window and release the dock icon
+          currentWindow.close()
         }
 
         if (this._originalSize) {


### PR DESCRIPTION
@keybase/react-hackers 

Fixes: https://keybase.atlassian.net/browse/DESKTOP-846

We listen for the `close` event on the main window to hide it and release the dock icon, this was calling close and circumventing that.