### PR TITLE
Distinguish broken/failed proofs. Add --skip-proof-cache to track com…

### DIFF
--- a/go/client/cmd_track.go
+++ b/go/client/cmd_track.go
@@ -16,8 +16,9 @@ import (
 )
 
 type CmdTrack struct {
-	user    string
-	options keybase1.TrackOptions
+	user           string
+	skipProofCache bool
+	options        keybase1.TrackOptions
 	libkb.Contextified
 }
 
@@ -34,6 +35,10 @@ func NewCmdTrack(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command
 			cli.BoolFlag{
 				Name:  "y",
 				Usage: "Approve remote tracking without prompting.",
+			},
+			cli.BoolFlag{
+				Name:  "s, skip-proof-cache",
+				Usage: "Skip cached proofs, force re-check",
 			},
 		},
 		Action: func(c *cli.Context) {
@@ -60,6 +65,7 @@ func (v *CmdTrack) ParseArgv(ctx *cli.Context) error {
 	}
 	v.user = ctx.Args()[0]
 	v.options = keybase1.TrackOptions{LocalOnly: ctx.Bool("local"), BypassConfirm: ctx.Bool("y")}
+	v.skipProofCache = ctx.Bool("skip-proof-cache")
 	return nil
 }
 
@@ -78,8 +84,9 @@ func (v *CmdTrack) Run() error {
 	}
 
 	return cli.Track(context.TODO(), keybase1.TrackArg{
-		UserAssertion: v.user,
-		Options:       v.options,
+		UserAssertion:    v.user,
+		Options:          v.options,
+		ForceRemoteCheck: v.skipProofCache,
 	})
 }
 

--- a/go/engine/track_proof_test.go
+++ b/go/engine/track_proof_test.go
@@ -399,7 +399,7 @@ func TestTrackProofRooterRemove(t *testing.T) {
 		NumTrackFailures: 1,
 		NumTrackChanges:  1,
 		NumProofFailures: 1,
-		TrackStatus:      keybase1.TrackStatus_UPDATE_BROKEN,
+		TrackStatus:      keybase1.TrackStatus_UPDATE_BROKEN_FAILED_PROOFS,
 	}
 	// use checkTrackForce to skip any proof cache results
 	err = checkTrackForce(tc, trackUser, proofUser.Username, []sb{rbl}, &outcome)
@@ -469,7 +469,7 @@ func TestTrackProofRooterRevoke(t *testing.T) {
 	trackUser.LoginOrBust(tc)
 	outcome = keybase1.IdentifyOutcome{
 		NumRevoked:  1,
-		TrackStatus: keybase1.TrackStatus_UPDATE_BROKEN,
+		TrackStatus: keybase1.TrackStatus_UPDATE_BROKEN_REVOKED,
 	}
 	err = checkTrack(tc, trackUser, proofUser.Username, nil, &outcome)
 	if err != nil {
@@ -579,7 +579,7 @@ func TestTrackProofRooterChange(t *testing.T) {
 		NumTrackChanges:   1,
 		NumTrackFailures:  1,
 		NumProofSuccesses: 1,
-		TrackStatus:       keybase1.TrackStatus_UPDATE_BROKEN,
+		TrackStatus:       keybase1.TrackStatus_UPDATE_BROKEN_FAILED_PROOFS,
 	}
 	err = checkTrack(tc, trackUser, proofUser.Username, []sb{rbl}, &outcome)
 	if err != nil {

--- a/go/libkb/identify_outcome.go
+++ b/go/libkb/identify_outcome.go
@@ -144,8 +144,11 @@ func (i IdentifyOutcome) NumTrackChanges() int {
 }
 
 func (i IdentifyOutcome) TrackStatus() keybase1.TrackStatus {
-	if i.NumTrackFailures() > 0 || i.NumRevoked() > 0 {
-		return keybase1.TrackStatus_UPDATE_BROKEN
+	if i.NumRevoked() > 0 {
+		return keybase1.TrackStatus_UPDATE_BROKEN_REVOKED
+	}
+	if i.NumTrackFailures() > 0 {
+		return keybase1.TrackStatus_UPDATE_BROKEN_FAILED_PROOFS
 	}
 	if i.TrackUsed != nil {
 		if i.NumTrackChanges() > 0 {

--- a/go/protocol/identify_common.go
+++ b/go/protocol/identify_common.go
@@ -48,12 +48,13 @@ type TrackSummary struct {
 type TrackStatus int
 
 const (
-	TrackStatus_NEW_OK            TrackStatus = 1
-	TrackStatus_NEW_ZERO_PROOFS   TrackStatus = 2
-	TrackStatus_NEW_FAIL_PROOFS   TrackStatus = 3
-	TrackStatus_UPDATE_BROKEN     TrackStatus = 4
-	TrackStatus_UPDATE_NEW_PROOFS TrackStatus = 5
-	TrackStatus_UPDATE_OK         TrackStatus = 6
+	TrackStatus_NEW_OK                      TrackStatus = 1
+	TrackStatus_NEW_ZERO_PROOFS             TrackStatus = 2
+	TrackStatus_NEW_FAIL_PROOFS             TrackStatus = 3
+	TrackStatus_UPDATE_BROKEN_FAILED_PROOFS TrackStatus = 4
+	TrackStatus_UPDATE_NEW_PROOFS           TrackStatus = 5
+	TrackStatus_UPDATE_OK                   TrackStatus = 6
+	TrackStatus_UPDATE_BROKEN_REVOKED       TrackStatus = 7
 )
 
 type TrackOptions struct {

--- a/protocol/avdl/identify_common.avdl
+++ b/protocol/avdl/identify_common.avdl
@@ -48,9 +48,10 @@ protocol identifyCommon {
     NEW_OK_1,
     NEW_ZERO_PROOFS_2,
     NEW_FAIL_PROOFS_3,
-    UPDATE_BROKEN_4,
+    UPDATE_BROKEN_FAILED_PROOFS_4,
     UPDATE_NEW_PROOFS_5,
-    UPDATE_OK_6
+    UPDATE_OK_6,
+    UPDATE_BROKEN_REVOKED_7
   }
 
   record TrackOptions {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1094,9 +1094,10 @@ export type TrackStatus =
     1 // NEW_OK_1
   | 2 // NEW_ZERO_PROOFS_2
   | 3 // NEW_FAIL_PROOFS_3
-  | 4 // UPDATE_BROKEN_4
+  | 4 // UPDATE_BROKEN_FAILED_PROOFS_4
   | 5 // UPDATE_NEW_PROOFS_5
   | 6 // UPDATE_OK_6
+  | 7 // UPDATE_BROKEN_REVOKED_7
 
 export type TrackSummary = {
   username: string;

--- a/protocol/js/keybase-v1.js
+++ b/protocol/js/keybase-v1.js
@@ -401,9 +401,10 @@ export const identify = {
     'newOk': 1,
     'newZeroProofs': 2,
     'newFailProofs': 3,
-    'updateBroken': 4,
+    'updateBrokenFailedProofs': 4,
     'updateNewProofs': 5,
-    'updateOk': 6
+    'updateOk': 6,
+    'updateBrokenRevoked': 7
   },
   'IdentifyReasonType': {
     'none': 0,
@@ -517,9 +518,10 @@ export const identifyUi = {
     'newOk': 1,
     'newZeroProofs': 2,
     'newFailProofs': 3,
-    'updateBroken': 4,
+    'updateBrokenFailedProofs': 4,
     'updateNewProofs': 5,
-    'updateOk': 6
+    'updateOk': 6,
+    'updateBrokenRevoked': 7
   },
   'IdentifyReasonType': {
     'none': 0,
@@ -973,9 +975,10 @@ export const pgp = {
     'newOk': 1,
     'newZeroProofs': 2,
     'newFailProofs': 3,
-    'updateBroken': 4,
+    'updateBrokenFailedProofs': 4,
     'updateNewProofs': 5,
-    'updateOk': 6
+    'updateOk': 6,
+    'updateBrokenRevoked': 7
   },
   'IdentifyReasonType': {
     'none': 0,
@@ -1118,9 +1121,10 @@ export const prove = {
     'newOk': 1,
     'newZeroProofs': 2,
     'newFailProofs': 3,
-    'updateBroken': 4,
+    'updateBrokenFailedProofs': 4,
     'updateNewProofs': 5,
-    'updateOk': 6
+    'updateOk': 6,
+    'updateBrokenRevoked': 7
   },
   'IdentifyReasonType': {
     'none': 0,
@@ -1354,9 +1358,10 @@ export const saltpack = {
     'newOk': 1,
     'newZeroProofs': 2,
     'newFailProofs': 3,
-    'updateBroken': 4,
+    'updateBrokenFailedProofs': 4,
     'updateNewProofs': 5,
-    'updateOk': 6
+    'updateOk': 6,
+    'updateBrokenRevoked': 7
   },
   'IdentifyReasonType': {
     'none': 0,
@@ -1633,9 +1638,10 @@ export const track = {
     'newOk': 1,
     'newZeroProofs': 2,
     'newFailProofs': 3,
-    'updateBroken': 4,
+    'updateBrokenFailedProofs': 4,
     'updateNewProofs': 5,
-    'updateOk': 6
+    'updateOk': 6,
+    'updateBrokenRevoked': 7
   },
   'IdentifyReasonType': {
     'none': 0,

--- a/protocol/json/identify.json
+++ b/protocol/json/identify.json
@@ -477,9 +477,10 @@
         "NEW_OK_1",
         "NEW_ZERO_PROOFS_2",
         "NEW_FAIL_PROOFS_3",
-        "UPDATE_BROKEN_4",
+        "UPDATE_BROKEN_FAILED_PROOFS_4",
         "UPDATE_NEW_PROOFS_5",
-        "UPDATE_OK_6"
+        "UPDATE_OK_6",
+        "UPDATE_BROKEN_REVOKED_7"
       ],
       "doc": "TrackStatus is a summary of this track before the track is approved by the\n    user.\n    NEW_*: New tracks\n    UPDATE_*: Update to an existing track\n    NEW_OK: Everything ok\n    NEW_ZERO_PROOFS: User being tracked has no proofs\n    NEW_FAIL_PROOFS: User being tracked has some failed proofs\n    UPDATE_BROKEN: Previous tracking statement broken, this one will fix it.\n    UPDATE_NEW_PROOFS: Previous tracking statement ok, but there are new proofs since previous tracking statement generated\n    UPDATE_OK: No changes to previous tracking statement"
     },

--- a/protocol/json/identify_ui.json
+++ b/protocol/json/identify_ui.json
@@ -477,9 +477,10 @@
         "NEW_OK_1",
         "NEW_ZERO_PROOFS_2",
         "NEW_FAIL_PROOFS_3",
-        "UPDATE_BROKEN_4",
+        "UPDATE_BROKEN_FAILED_PROOFS_4",
         "UPDATE_NEW_PROOFS_5",
-        "UPDATE_OK_6"
+        "UPDATE_OK_6",
+        "UPDATE_BROKEN_REVOKED_7"
       ],
       "doc": "TrackStatus is a summary of this track before the track is approved by the\n    user.\n    NEW_*: New tracks\n    UPDATE_*: Update to an existing track\n    NEW_OK: Everything ok\n    NEW_ZERO_PROOFS: User being tracked has no proofs\n    NEW_FAIL_PROOFS: User being tracked has some failed proofs\n    UPDATE_BROKEN: Previous tracking statement broken, this one will fix it.\n    UPDATE_NEW_PROOFS: Previous tracking statement ok, but there are new proofs since previous tracking statement generated\n    UPDATE_OK: No changes to previous tracking statement"
     },

--- a/protocol/json/pgp.json
+++ b/protocol/json/pgp.json
@@ -477,9 +477,10 @@
         "NEW_OK_1",
         "NEW_ZERO_PROOFS_2",
         "NEW_FAIL_PROOFS_3",
-        "UPDATE_BROKEN_4",
+        "UPDATE_BROKEN_FAILED_PROOFS_4",
         "UPDATE_NEW_PROOFS_5",
-        "UPDATE_OK_6"
+        "UPDATE_OK_6",
+        "UPDATE_BROKEN_REVOKED_7"
       ],
       "doc": "TrackStatus is a summary of this track before the track is approved by the\n    user.\n    NEW_*: New tracks\n    UPDATE_*: Update to an existing track\n    NEW_OK: Everything ok\n    NEW_ZERO_PROOFS: User being tracked has no proofs\n    NEW_FAIL_PROOFS: User being tracked has some failed proofs\n    UPDATE_BROKEN: Previous tracking statement broken, this one will fix it.\n    UPDATE_NEW_PROOFS: Previous tracking statement ok, but there are new proofs since previous tracking statement generated\n    UPDATE_OK: No changes to previous tracking statement"
     },

--- a/protocol/json/prove.json
+++ b/protocol/json/prove.json
@@ -477,9 +477,10 @@
         "NEW_OK_1",
         "NEW_ZERO_PROOFS_2",
         "NEW_FAIL_PROOFS_3",
-        "UPDATE_BROKEN_4",
+        "UPDATE_BROKEN_FAILED_PROOFS_4",
         "UPDATE_NEW_PROOFS_5",
-        "UPDATE_OK_6"
+        "UPDATE_OK_6",
+        "UPDATE_BROKEN_REVOKED_7"
       ],
       "doc": "TrackStatus is a summary of this track before the track is approved by the\n    user.\n    NEW_*: New tracks\n    UPDATE_*: Update to an existing track\n    NEW_OK: Everything ok\n    NEW_ZERO_PROOFS: User being tracked has no proofs\n    NEW_FAIL_PROOFS: User being tracked has some failed proofs\n    UPDATE_BROKEN: Previous tracking statement broken, this one will fix it.\n    UPDATE_NEW_PROOFS: Previous tracking statement ok, but there are new proofs since previous tracking statement generated\n    UPDATE_OK: No changes to previous tracking statement"
     },

--- a/protocol/json/saltpack.json
+++ b/protocol/json/saltpack.json
@@ -477,9 +477,10 @@
         "NEW_OK_1",
         "NEW_ZERO_PROOFS_2",
         "NEW_FAIL_PROOFS_3",
-        "UPDATE_BROKEN_4",
+        "UPDATE_BROKEN_FAILED_PROOFS_4",
         "UPDATE_NEW_PROOFS_5",
-        "UPDATE_OK_6"
+        "UPDATE_OK_6",
+        "UPDATE_BROKEN_REVOKED_7"
       ],
       "doc": "TrackStatus is a summary of this track before the track is approved by the\n    user.\n    NEW_*: New tracks\n    UPDATE_*: Update to an existing track\n    NEW_OK: Everything ok\n    NEW_ZERO_PROOFS: User being tracked has no proofs\n    NEW_FAIL_PROOFS: User being tracked has some failed proofs\n    UPDATE_BROKEN: Previous tracking statement broken, this one will fix it.\n    UPDATE_NEW_PROOFS: Previous tracking statement ok, but there are new proofs since previous tracking statement generated\n    UPDATE_OK: No changes to previous tracking statement"
     },

--- a/protocol/json/track.json
+++ b/protocol/json/track.json
@@ -477,9 +477,10 @@
         "NEW_OK_1",
         "NEW_ZERO_PROOFS_2",
         "NEW_FAIL_PROOFS_3",
-        "UPDATE_BROKEN_4",
+        "UPDATE_BROKEN_FAILED_PROOFS_4",
         "UPDATE_NEW_PROOFS_5",
-        "UPDATE_OK_6"
+        "UPDATE_OK_6",
+        "UPDATE_BROKEN_REVOKED_7"
       ],
       "doc": "TrackStatus is a summary of this track before the track is approved by the\n    user.\n    NEW_*: New tracks\n    UPDATE_*: Update to an existing track\n    NEW_OK: Everything ok\n    NEW_ZERO_PROOFS: User being tracked has no proofs\n    NEW_FAIL_PROOFS: User being tracked has some failed proofs\n    UPDATE_BROKEN: Previous tracking statement broken, this one will fix it.\n    UPDATE_NEW_PROOFS: Previous tracking statement ok, but there are new proofs since previous tracking statement generated\n    UPDATE_OK: No changes to previous tracking statement"
     },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1094,9 +1094,10 @@ export type TrackStatus =
     1 // NEW_OK_1
   | 2 // NEW_ZERO_PROOFS_2
   | 3 // NEW_FAIL_PROOFS_3
-  | 4 // UPDATE_BROKEN_4
+  | 4 // UPDATE_BROKEN_FAILED_PROOFS_4
   | 5 // UPDATE_NEW_PROOFS_5
   | 6 // UPDATE_OK_6
+  | 7 // UPDATE_BROKEN_REVOKED_7
 
 export type TrackSummary = {
   username: string;

--- a/shared/constants/types/keybase-v1.js
+++ b/shared/constants/types/keybase-v1.js
@@ -401,9 +401,10 @@ export const identify = {
     'newOk': 1,
     'newZeroProofs': 2,
     'newFailProofs': 3,
-    'updateBroken': 4,
+    'updateBrokenFailedProofs': 4,
     'updateNewProofs': 5,
-    'updateOk': 6
+    'updateOk': 6,
+    'updateBrokenRevoked': 7
   },
   'IdentifyReasonType': {
     'none': 0,
@@ -517,9 +518,10 @@ export const identifyUi = {
     'newOk': 1,
     'newZeroProofs': 2,
     'newFailProofs': 3,
-    'updateBroken': 4,
+    'updateBrokenFailedProofs': 4,
     'updateNewProofs': 5,
-    'updateOk': 6
+    'updateOk': 6,
+    'updateBrokenRevoked': 7
   },
   'IdentifyReasonType': {
     'none': 0,
@@ -973,9 +975,10 @@ export const pgp = {
     'newOk': 1,
     'newZeroProofs': 2,
     'newFailProofs': 3,
-    'updateBroken': 4,
+    'updateBrokenFailedProofs': 4,
     'updateNewProofs': 5,
-    'updateOk': 6
+    'updateOk': 6,
+    'updateBrokenRevoked': 7
   },
   'IdentifyReasonType': {
     'none': 0,
@@ -1118,9 +1121,10 @@ export const prove = {
     'newOk': 1,
     'newZeroProofs': 2,
     'newFailProofs': 3,
-    'updateBroken': 4,
+    'updateBrokenFailedProofs': 4,
     'updateNewProofs': 5,
-    'updateOk': 6
+    'updateOk': 6,
+    'updateBrokenRevoked': 7
   },
   'IdentifyReasonType': {
     'none': 0,
@@ -1354,9 +1358,10 @@ export const saltpack = {
     'newOk': 1,
     'newZeroProofs': 2,
     'newFailProofs': 3,
-    'updateBroken': 4,
+    'updateBrokenFailedProofs': 4,
     'updateNewProofs': 5,
-    'updateOk': 6
+    'updateOk': 6,
+    'updateBrokenRevoked': 7
   },
   'IdentifyReasonType': {
     'none': 0,
@@ -1633,9 +1638,10 @@ export const track = {
     'newOk': 1,
     'newZeroProofs': 2,
     'newFailProofs': 3,
-    'updateBroken': 4,
+    'updateBrokenFailedProofs': 4,
     'updateNewProofs': 5,
-    'updateOk': 6
+    'updateOk': 6,
+    'updateBrokenRevoked': 7
   },
   'IdentifyReasonType': {
     'none': 0,


### PR DESCRIPTION
…mand. 

Note that Max says it's ok to just not present the snooze ("[I]gnore") option for revoked proofs.

I could take a crack at changing the gui if someone gives me a hint.

@maxtaco @cjb 