### PR TITLE
SaltpackVerify: Remove unused global context

### DIFF
--- a/go/engine/saltpack_verify.go
+++ b/go/engine/saltpack_verify.go
@@ -20,6 +20,7 @@ type SaltpackVerify struct {
 	key libkb.NaclSigningKeyPair
 }
 
+// SaltpackVerifyArg are engine args.
 type SaltpackVerifyArg struct {
 	Sink   io.WriteCloser
 	Source io.Reader
@@ -39,7 +40,7 @@ func (e *SaltpackVerify) Name() string {
 	return "SaltpackVerify"
 }
 
-// GetPrereqs returns the engine prereqs.
+// Prereqs returns the engine prereqs.
 func (e *SaltpackVerify) Prereqs() Prereqs {
 	return Prereqs{}
 }

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -514,3 +514,7 @@ func (g *GlobalContext) GetUnforwardedLogger() *logger.UnforwardedLogger {
 	}
 	return (*logger.UnforwardedLogger)(log)
 }
+
+func (g *GlobalContext) GetLog() logger.Logger {
+	return g.Log
+}


### PR DESCRIPTION
Makes it easier to use these methods in other packages, like
go-updater. Since this stuff only has logging dependencies maybe we
could move it into the saltpack package.

FYI, we should be using GlobalContext infrequently if possible, and
instead use interfaces.