### PR TITLE
KBFS errors

### DIFF
--- a/protocol/bin/flow.js
+++ b/protocol/bin/flow.js
@@ -57,7 +57,7 @@ function figureType (type) {
       case 'array':
         return `Array<${type.items}>`
       case 'map':
-        return `{string: ${type.values}}`
+        return `{[key: string]: ${type.values}}`
       default:
         console.log(`Unknown type: ${type}`)
         return 'unknown'

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -213,7 +213,7 @@ export type FSNotification = {
   statusCode: FSStatusCode;
   notificationType: FSNotificationType;
   errorType: FSErrorType;
-  params: {string: string};
+  params: {[key: string]: string};
 }
 
 export type FSNotificationType =
@@ -2158,7 +2158,7 @@ export type metadata_deleteKey_rpc = {
     uid: UID,
     deviceKID: KID,
     keyHalfID: bytes,
-    logTags: {string: string}
+    logTags: {[key: string]: string}
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -2204,7 +2204,7 @@ export type metadata_getKey_rpc = {
   param: {
     keyHalfID: bytes,
     deviceKID: string,
-    logTags: {string: string}
+    logTags: {[key: string]: string}
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any, response: metadata_getKey_result) => void)
@@ -2267,7 +2267,7 @@ export type metadata_getMetadata_rpc = {
     unmerged: boolean,
     startRevision: long,
     stopRevision: long,
-    logTags: {string: string}
+    logTags: {[key: string]: string}
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any, response: metadata_getMetadata_result) => void)
@@ -2289,7 +2289,7 @@ export type metadata_pruneBranch_rpc = {
   param: {
     folderID: string,
     branchID: string,
-    logTags: {string: string}
+    logTags: {[key: string]: string}
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -2301,7 +2301,7 @@ export type metadata_putKeys_rpc = {
   method: 'metadata.putKeys',
   param: {
     keyHalves: Array<KeyHalf>,
-    logTags: {string: string}
+    logTags: {[key: string]: string}
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -2313,7 +2313,7 @@ export type metadata_putMetadata_rpc = {
   method: 'metadata.putMetadata',
   param: {
     mdBlock: MDBlock,
-    logTags: {string: string}
+    logTags: {[key: string]: string}
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -2326,7 +2326,7 @@ export type metadata_registerForUpdates_rpc = {
   param: {
     folderID: string,
     currRevision: long,
-    logTags: {string: string}
+    logTags: {[key: string]: string}
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -4306,7 +4306,7 @@ export type incomingCallMapType = {
   'keybase.1.metadata.putMetadata'?: (
     params: {
       mdBlock: MDBlock,
-      logTags: {string: string}
+      logTags: {[key: string]: string}
     },
     response: {
       error: (err: RPCError) => void,
@@ -4321,7 +4321,7 @@ export type incomingCallMapType = {
       unmerged: boolean,
       startRevision: long,
       stopRevision: long,
-      logTags: {string: string}
+      logTags: {[key: string]: string}
     },
     response: {
       error: (err: RPCError) => void,
@@ -4332,7 +4332,7 @@ export type incomingCallMapType = {
     params: {
       folderID: string,
       currRevision: long,
-      logTags: {string: string}
+      logTags: {[key: string]: string}
     },
     response: {
       error: (err: RPCError) => void,
@@ -4343,7 +4343,7 @@ export type incomingCallMapType = {
     params: {
       folderID: string,
       branchID: string,
-      logTags: {string: string}
+      logTags: {[key: string]: string}
     },
     response: {
       error: (err: RPCError) => void,
@@ -4353,7 +4353,7 @@ export type incomingCallMapType = {
   'keybase.1.metadata.putKeys'?: (
     params: {
       keyHalves: Array<KeyHalf>,
-      logTags: {string: string}
+      logTags: {[key: string]: string}
     },
     response: {
       error: (err: RPCError) => void,
@@ -4364,7 +4364,7 @@ export type incomingCallMapType = {
     params: {
       keyHalfID: bytes,
       deviceKID: string,
-      logTags: {string: string}
+      logTags: {[key: string]: string}
     },
     response: {
       error: (err: RPCError) => void,
@@ -4376,7 +4376,7 @@ export type incomingCallMapType = {
       uid: UID,
       deviceKID: KID,
       keyHalfID: bytes,
-      logTags: {string: string}
+      logTags: {[key: string]: string}
     },
     response: {
       error: (err: RPCError) => void,

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -213,7 +213,7 @@ export type FSNotification = {
   statusCode: FSStatusCode;
   notificationType: FSNotificationType;
   errorType: FSErrorType;
-  params: {string: string};
+  params: {[key: string]: string};
 }
 
 export type FSNotificationType =
@@ -2158,7 +2158,7 @@ export type metadata_deleteKey_rpc = {
     uid: UID,
     deviceKID: KID,
     keyHalfID: bytes,
-    logTags: {string: string}
+    logTags: {[key: string]: string}
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -2204,7 +2204,7 @@ export type metadata_getKey_rpc = {
   param: {
     keyHalfID: bytes,
     deviceKID: string,
-    logTags: {string: string}
+    logTags: {[key: string]: string}
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any, response: metadata_getKey_result) => void)
@@ -2267,7 +2267,7 @@ export type metadata_getMetadata_rpc = {
     unmerged: boolean,
     startRevision: long,
     stopRevision: long,
-    logTags: {string: string}
+    logTags: {[key: string]: string}
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any, response: metadata_getMetadata_result) => void)
@@ -2289,7 +2289,7 @@ export type metadata_pruneBranch_rpc = {
   param: {
     folderID: string,
     branchID: string,
-    logTags: {string: string}
+    logTags: {[key: string]: string}
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -2301,7 +2301,7 @@ export type metadata_putKeys_rpc = {
   method: 'metadata.putKeys',
   param: {
     keyHalves: Array<KeyHalf>,
-    logTags: {string: string}
+    logTags: {[key: string]: string}
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -2313,7 +2313,7 @@ export type metadata_putMetadata_rpc = {
   method: 'metadata.putMetadata',
   param: {
     mdBlock: MDBlock,
-    logTags: {string: string}
+    logTags: {[key: string]: string}
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -2326,7 +2326,7 @@ export type metadata_registerForUpdates_rpc = {
   param: {
     folderID: string,
     currRevision: long,
-    logTags: {string: string}
+    logTags: {[key: string]: string}
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -4306,7 +4306,7 @@ export type incomingCallMapType = {
   'keybase.1.metadata.putMetadata'?: (
     params: {
       mdBlock: MDBlock,
-      logTags: {string: string}
+      logTags: {[key: string]: string}
     },
     response: {
       error: (err: RPCError) => void,
@@ -4321,7 +4321,7 @@ export type incomingCallMapType = {
       unmerged: boolean,
       startRevision: long,
       stopRevision: long,
-      logTags: {string: string}
+      logTags: {[key: string]: string}
     },
     response: {
       error: (err: RPCError) => void,
@@ -4332,7 +4332,7 @@ export type incomingCallMapType = {
     params: {
       folderID: string,
       currRevision: long,
-      logTags: {string: string}
+      logTags: {[key: string]: string}
     },
     response: {
       error: (err: RPCError) => void,
@@ -4343,7 +4343,7 @@ export type incomingCallMapType = {
     params: {
       folderID: string,
       branchID: string,
-      logTags: {string: string}
+      logTags: {[key: string]: string}
     },
     response: {
       error: (err: RPCError) => void,
@@ -4353,7 +4353,7 @@ export type incomingCallMapType = {
   'keybase.1.metadata.putKeys'?: (
     params: {
       keyHalves: Array<KeyHalf>,
-      logTags: {string: string}
+      logTags: {[key: string]: string}
     },
     response: {
       error: (err: RPCError) => void,
@@ -4364,7 +4364,7 @@ export type incomingCallMapType = {
     params: {
       keyHalfID: bytes,
       deviceKID: string,
-      logTags: {string: string}
+      logTags: {[key: string]: string}
     },
     response: {
       error: (err: RPCError) => void,
@@ -4376,7 +4376,7 @@ export type incomingCallMapType = {
       uid: UID,
       deviceKID: KID,
       keyHalfID: bytes,
-      logTags: {string: string}
+      logTags: {[key: string]: string}
     },
     response: {
       error: (err: RPCError) => void,

--- a/shared/native/notification-listeners.desktop.js
+++ b/shared/native/notification-listeners.desktop.js
@@ -3,7 +3,7 @@
 import enums from '../constants/types/keybase-v1'
 import type {incomingCallMapType} from '../constants/types/flow-types'
 import path from 'path'
-import {getTLF} from '../util/kbfs'
+import {getTLF, decodeKBFSError} from '../util/kbfs'
 
 import {bootstrap} from '../actions/config'
 import {logoutDone} from '../actions/login'
@@ -74,11 +74,13 @@ export default function (dispatch: Dispatch, getState: () => Object, notify: any
 
       let title = `KBFS: ${action}`
       let body = `Files in ${tlf} ${notification.status}`
-
+      let user = 'You'
+      if (getState().config && getState().config.status && getState().config.status.user && getState().config.status.user.username) {
+        user = getState().config.status.user.username
+      }
       // Don't show starting or finished, but do show error.
       if (notification.statusCode === enums.kbfs.FSStatusCode.error) {
-        title += ` ${state}`
-        body = notification.status
+        [title, body] = decodeKBFSError(user, notification)
       }
 
       function rateLimitAllowsNotify (action, state, tlf) {
@@ -103,6 +105,7 @@ export default function (dispatch: Dispatch, getState: () => Object, notify: any
         return false
       }
 
+       console.log(title, body)
       if (rateLimitAllowsNotify(action, state, tlf)) {
         notify(title, {body})
       }

--- a/shared/native/notification-listeners.desktop.js
+++ b/shared/native/notification-listeners.desktop.js
@@ -105,7 +105,6 @@ export default function (dispatch: Dispatch, getState: () => Object, notify: any
         return false
       }
 
-       console.log(title, body)
       if (rateLimitAllowsNotify(action, state, tlf)) {
         notify(title, {body})
       }

--- a/shared/native/notification-listeners.desktop.js
+++ b/shared/native/notification-listeners.desktop.js
@@ -1,18 +1,10 @@
 /* @flow */
 
-import enums from '../constants/types/keybase-v1'
-import type {incomingCallMapType} from '../constants/types/flow-types'
-import path from 'path'
-import {getTLF, decodeKBFSError} from '../util/kbfs'
-
 import {bootstrap} from '../actions/config'
 import {logoutDone} from '../actions/login'
-
+import {kbfsNotification} from '../util/kbfs-notifications'
 import type {Dispatch} from '../constants/types/flux'
-
-// TODO: Once we have access to the Redux store from the thread running
-// notification listeners, store the sentNotifications map in it.
-var sentNotifications = {}
+import type {incomingCallMapType} from '../constants/types/flow-types'
 
 // Keep track of the last time we notified and ignore if its the same
 let lastLoggedInNotifyUsername = null
@@ -41,73 +33,7 @@ export default function (dispatch: Dispatch, getState: () => Object, notify: any
       response.result()
     },
     'keybase.1.NotifyFS.FSActivity': ({notification}) => {
-      const action = {
-        [enums.kbfs.FSNotificationType.encrypting]: 'Encrypting and uploading',
-        [enums.kbfs.FSNotificationType.decrypting]: 'Decrypting, verifying, and downloading',
-        [enums.kbfs.FSNotificationType.signing]: 'Signing and uploading',
-        [enums.kbfs.FSNotificationType.verifying]: 'Verifying and downloading',
-        [enums.kbfs.FSNotificationType.rekeying]: 'Rekeying'
-      }[notification.notificationType]
-
-      const state = {
-        [enums.kbfs.FSStatusCode.start]: 'starting',
-        [enums.kbfs.FSStatusCode.finish]: 'finished',
-        [enums.kbfs.FSStatusCode.error]: 'errored'
-      }[notification.statusCode]
-
-      // KBFS fires a notification when it changes state between connected
-      // and disconnected (to the mdserver).  For now we just log it.
-      if (notification.notificationType === enums.kbfs.FSNotificationType.connection) {
-        const state = (notification.statusCode === enums.kbfs.FSStatusCode.start) ? 'connected' : 'disconnected'
-        console.log(`KBFS is ${state}`)
-        return
-      }
-
-      if (notification.statusCode === enums.kbfs.FSStatusCode.finish) {
-        // Since we're aggregating dir operations and not showing state,
-        // let's ignore file-finished notifications.
-        return
-      }
-
-      const basedir = notification.filename.split(path.sep)[0]
-      const tlf = getTLF(notification.publicTopLevelFolder, basedir)
-
-      let title = `KBFS: ${action}`
-      let body = `Files in ${tlf} ${notification.status}`
-      let user = 'You'
-      if (getState().config && getState().config.status && getState().config.status.user && getState().config.status.user.username) {
-        user = getState().config.status.user.username
-      }
-      // Don't show starting or finished, but do show error.
-      if (notification.statusCode === enums.kbfs.FSStatusCode.error) {
-        [title, body] = decodeKBFSError(user, notification)
-      }
-
-      function rateLimitAllowsNotify (action, state, tlf) {
-        if (!(action in sentNotifications)) {
-          sentNotifications[action] = {}
-        }
-        if (!(state in sentNotifications[action])) {
-          sentNotifications[action][state] = {}
-        }
-
-        // 20s in msec
-        const delay = 20000
-        const now = new Date()
-
-        // If we haven't notified for {action,state,tlf} or it was >20s ago, do it.
-        if (!(tlf in sentNotifications[action][state]) || now - sentNotifications[action][state][tlf] > delay) {
-          sentNotifications[action][state][tlf] = now
-          return true
-        }
-
-        // We've already notified recently, ignore this one.
-        return false
-      }
-
-      if (rateLimitAllowsNotify(action, state, tlf)) {
-        notify(title, {body})
-      }
+      kbfsNotification(notification, notify, getState)
     }
   }
 }

--- a/shared/util/kbfs-notifications.js
+++ b/shared/util/kbfs-notifications.js
@@ -1,0 +1,152 @@
+/* @flow */
+
+import _ from 'lodash'
+import enums from '../constants/types/keybase-v1'
+import {getTLF} from '../util/kbfs'
+import path from 'path'
+import type {FSNotification} from '../constants/types/flow-types'
+
+type DecodedKBFSError = {
+  'title': string;
+  'body': string;
+}
+
+export function decodeKBFSError (user: string, notification: FSNotification): DecodedKBFSError {
+  const basedir = notification.filename.split(path.sep)[0]
+  const tlf = `/keybase${getTLF(notification.publicTopLevelFolder, basedir)}`
+  const errors = {
+    [enums.kbfs.FSErrorType.accessDenied]: {
+      title: 'Keybase: Access denied',
+      body: `${user} does not have ${notification.params.mode} access to ${tlf}`
+    },
+    [enums.kbfs.FSErrorType.userNotFound]: {
+      title: 'Keybase: User not found',
+      body: `${notification.params.username} is not a Keybase user`
+    },
+    [enums.kbfs.FSErrorType.revokedDataDetected]: {
+      title: 'Keybase: Possibly revoked data detected',
+      body: `${tlf} was modified by a revoked or bad device. Use 'keybase log send' to file an issue with the Keybase admins.`
+    },
+    [enums.kbfs.FSErrorType.notLoggedIn]: {
+      title: `Keybase: Permission denied in ${tlf}`,
+      body: "You are not logged into Keybase. Try 'keybase login'."
+    },
+    [enums.kbfs.FSErrorType.timeout]: {
+      title: `Keybase: ${_.capitalize(notification.params.mode)} timeout in ${tlf}`,
+      body: `The ${notification.params.mode} operation took too long and failed. Please run 'keybase log send' so our admins can review.`
+    },
+    [enums.kbfs.FSErrorType.rekeyNeeded]: notification.rekeyself ? {
+      title: 'Keybase: Files need to be rekeyed',
+      body: `Please open one of your other computers to unlock ${tlf}`
+    } : {
+      title: 'Keybase: Friends needed',
+      body: `Please ask another member of ${tlf} to open Keybase on one of their computers to unlock it for you.`
+    },
+    [enums.kbfs.FSErrorType.badFolder]: {
+      title: 'Keybase: Bad folder',
+      body: `${tlf} is not a Keybase folder. All folders begin with /keybase/private or /keybase/public.`
+    }
+  }
+
+  if (notification.errorType in errors) {
+    return errors[notification.errorType]
+  }
+
+  if (notification.errorType === enums.kbfs.FSErrorType.notImplemented) {
+    if (notification.feature === '2gbFileLimit') {
+      return ({
+        title: 'Keybase: Not yet implemented',
+        body: `You just tried to write a file larger than 2GB in ${tlf}. This limitation will be removed soon.`
+      })
+    } else if (notification.feature === '512kbDirLimit') {
+      return ({
+        title: 'Keybase: Not yet implemented',
+        body: `You just tried to write too many files into ${tlf}. This limitation will be removed soon.`
+      })
+    } else {
+      return ({
+        title: 'Keybase: Not yet implemented',
+        body: `You just hit a ${notification.feature} limitation in KBFS. It will be fixed soon.`
+      })
+    }
+  } else {
+    return ({
+      title: 'Keybase: KBFS error',
+      body: `${notification.status}`
+    })
+  }
+}
+
+// TODO: Once we have access to the Redux store from the thread running
+// notification listeners, store the sentNotifications map in it.
+var sentNotifications = {}
+
+export function kbfsNotification (notification: FSNotification, notify: any, getState: any) {
+  const action = {
+    [enums.kbfs.FSNotificationType.encrypting]: 'Encrypting and uploading',
+    [enums.kbfs.FSNotificationType.decrypting]: 'Decrypting, verifying, and downloading',
+    [enums.kbfs.FSNotificationType.signing]: 'Signing and uploading',
+    [enums.kbfs.FSNotificationType.verifying]: 'Verifying and downloading',
+    [enums.kbfs.FSNotificationType.rekeying]: 'Rekeying'
+  }[notification.notificationType]
+
+  const state = {
+    [enums.kbfs.FSStatusCode.start]: 'starting',
+    [enums.kbfs.FSStatusCode.finish]: 'finished',
+    [enums.kbfs.FSStatusCode.error]: 'errored'
+  }[notification.statusCode]
+
+  // KBFS fires a notification when it changes state between connected
+  // and disconnected (to the mdserver).  For now we just log it.
+  if (notification.notificationType === enums.kbfs.FSNotificationType.connection) {
+    const state = (notification.statusCode === enums.kbfs.FSStatusCode.start) ? 'connected' : 'disconnected'
+    console.log(`KBFS is ${state}`)
+    return
+  }
+
+  if (notification.statusCode === enums.kbfs.FSStatusCode.finish) {
+    // Since we're aggregating dir operations and not showing state,
+    // let's ignore file-finished notifications.
+    return
+  }
+
+  const basedir = notification.filename.split(path.sep)[0]
+  const tlf = getTLF(notification.publicTopLevelFolder, basedir)
+
+  let title = `KBFS: ${action}`
+  let body = `Files in ${tlf} ${notification.status}`
+  let user = 'You'
+  try {
+    user = getState().config.status.user.username
+  } catch (e) {}
+  // Don't show starting or finished, but do show error.
+  if (notification.statusCode === enums.kbfs.FSStatusCode.error) {
+    ({title, body} = decodeKBFSError(user, notification))
+  }
+
+  function rateLimitAllowsNotify (action, state, tlf) {
+    if (!(action in sentNotifications)) {
+      sentNotifications[action] = {}
+    }
+    if (!(state in sentNotifications[action])) {
+      sentNotifications[action][state] = {}
+    }
+
+    // 20s in msec
+    const delay = 20000
+    const now = new Date()
+
+    // If we haven't notified for {action,state,tlf} or it was >20s ago, do it.
+    if (!(tlf in sentNotifications[action][state]) || now - sentNotifications[action][state][tlf] > delay) {
+      sentNotifications[action][state][tlf] = now
+      return true
+    }
+
+    // We've already notified recently, ignore this one.
+    return false
+  }
+
+  if (rateLimitAllowsNotify(action, state, tlf)) {
+    notify(title, {body})
+  }
+}

--- a/shared/util/kbfs.js
+++ b/shared/util/kbfs.js
@@ -1,10 +1,5 @@
 /* @flow */
 
-import _ from 'lodash'
-import enums from '../constants/types/keybase-v1'
-import path from 'path'
-import type {FSNotification} from '../constants/types/flow-types'
-
 // Parses the folder name and returns an array of usernames (TODO: handle read only-ers)
 export function parseFolderNameToUsers (folderName: string): Array<string> {
   return folderName.split(',')
@@ -36,70 +31,4 @@ export function cleanup (folderName: string): string {
   }
 
   return folderName.replace(/\s/g, '').replace(/\.\./g, '').replace(/\//g, '').replace(/\\/g, '')
-}
-
-export function decodeKBFSError (user: string, notification: FSNotification): Array<string> {
-  const basedir = notification.filename.split(path.sep)[0]
-  const tlf = `/keybase${getTLF(notification.publicTopLevelFolder, basedir)}`
-  const errors = {
-    [enums.kbfs.FSErrorType.accessDenied]: [
-      'Keybase: Access denied',
-      `${user} does not have ${notification.params.mode} access to ${tlf}`
-    ],
-    [enums.kbfs.FSErrorType.userNotFound]: [
-      'Keybase: User not found',
-      `${notification.params.username} is not a Keybase user`
-    ],
-    [enums.kbfs.FSErrorType.revokedDataDetected]: [
-      'Keybase: Possibly revoked data detected',
-      `${tlf} was modified by a revoked or bad device. Use 'keybase log send' to file an issue with the Keybase admins.`
-    ],
-    [enums.kbfs.FSErrorType.notLoggedIn]: [
-      `Keybase: Permission denied in ${tlf}`,
-      "You are not logged into Keybase. Try 'keybase login'."
-    ],
-    [enums.kbfs.FSErrorType.timeout]: [
-      `Keybase: ${_.capitalize(notification.params.mode)} timeout in ${tlf}`,
-      `The ${notification.params.mode} operation took too long and failed. Please run 'keybase log send' so our admins can review.`
-    ],
-    [enums.kbfs.FSErrorType.rekeyNeeded]: notification.rekeyself ? [
-      'Keybase: Files need to be rekeyed',
-      `Please open one of your other computers to unlock ${tlf}`
-    ] : [
-      'Keybase: Friends needed',
-      `Please ask another member of ${tlf} to open Keybase on one of their computers to unlock it for you.`
-    ],
-    [enums.kbfs.FSErrorType.badFolder]: [
-      'Keybase: Bad folder',
-      `${tlf} is not a Keybase folder. All folders begin with /keybase/private or /keybase/public.`
-    ]
-  }
-
-  if (notification.errorType in errors) {
-    return errors[notification.errorType]
-  }
-
-  if (notification.errorType === enums.kbfs.FSErrorType.notImplemented) {
-    if (notification.feature === '2gbFileLimit') {
-      return ([
-        'Keybase: Not yet implemented',
-        `You just tried to write a file larger than 2GB in ${tlf}. This limitation will be removed soon.`
-      ])
-    } else if (notification.feature === '512kbDirLimit') {
-      return ([
-        'Keybase: Not yet implemented',
-        `You just tried to write too many files into ${tlf}. This limitation will be removed soon.`
-      ])
-    } else {
-      return ([
-        'Keybase: Not yet implemented',
-        `You just hit a ${notification.feature} limitation in KBFS. It will be fixed soon.`
-      ])
-    }
-  } else {
-    return ([
-      'Keybase: KBFS error',
-      `${notification.status}`
-    ])
-  }
 }

--- a/shared/util/kbfs.js
+++ b/shared/util/kbfs.js
@@ -41,75 +41,65 @@ export function cleanup (folderName: string): string {
 export function decodeKBFSError (user: string, notification: FSNotification): Array<string> {
   const basedir = notification.filename.split(path.sep)[0]
   const tlf = `/keybase${getTLF(notification.publicTopLevelFolder, basedir)}`
-  switch (notification.errorType) {
-    case enums.kbfs.FSErrorType.accessDenied:
+  const errors = {
+    [enums.kbfs.FSErrorType.accessDenied]: [
+      'Keybase: Access denied',
+      `${user} does not have ${notification.params.mode} access to ${tlf}`
+    ],
+    [enums.kbfs.FSErrorType.userNotFound]: [
+      'Keybase: User not found',
+      `${notification.params.username} is not a Keybase user`
+    ],
+    [enums.kbfs.FSErrorType.revokedDataDetected]: [
+      'Keybase: Possibly revoked data detected',
+      `${tlf} was modified by a revoked or bad device. Use 'keybase log send' to file an issue with the Keybase admins.`
+    ],
+    [enums.kbfs.FSErrorType.notLoggedIn]: [
+      `Keybase: Permission denied in ${tlf}`,
+      "You are not logged into Keybase. Try 'keybase login'."
+    ],
+    [enums.kbfs.FSErrorType.timeout]: [
+      `Keybase: ${_.capitalize(notification.params.mode)} timeout in ${tlf}`,
+      `The ${notification.params.mode} operation took too long and failed. Please run 'keybase log send' so our admins can review.`
+    ],
+    [enums.kbfs.FSErrorType.rekeyNeeded]: notification.rekeyself ? [
+      'Keybase: Files need to be rekeyed',
+      `Please open one of your other computers to unlock ${tlf}`
+    ] : [
+      'Keybase: Friends needed',
+      `Please ask another member of ${tlf} to open Keybase on one of their computers to unlock it for you.`
+    ],
+    [enums.kbfs.FSErrorType.badFolder]: [
+      'Keybase: Bad folder',
+      `${tlf} is not a Keybase folder. All folders begin with /keybase/private or /keybase/public.`
+    ]
+  }
+
+  if (notification.errorType in errors) {
+    return errors[notification.errorType]
+  }
+
+  if (notification.errorType === enums.kbfs.FSErrorType.notImplemented) {
+    if (notification.feature === '2gbFileLimit') {
       return ([
-        'Keybase: Access denied',
-        `${user} does not have ${notification.params.mode} access to ${tlf}`
+        'Keybase: Not yet implemented',
+        `You just tried to write a file larger than 2GB in ${tlf}. This limitation will be removed soon.`
       ])
-    case enums.kbfs.FSErrorType.userNotFound:
+    } else if (notification.feature === '512kbDirLimit') {
       return ([
-        'Keybase: User not found',
-        `${notification.username} is not a Keybase user`
+        'Keybase: Not yet implemented',
+        `You just tried to write too many files into ${tlf}. This limitation will be removed soon.`
       ])
-    case enums.kbfs.FSErrorType.revokedDataDetected:
+    } else {
       return ([
-        'Keybase: Possibly revoked data detected',
-        `${tlf} was modified by a revoked or bad device. Use 'keybase log send' to file an issue with the Keybase admins.`
+        'Keybase: Not yet implemented',
+        `You just hit a ${notification.feature} limitation in KBFS. It will be fixed soon.`
       ])
-    case enums.kbfs.FSErrorType.notLoggedIn:
-      return ([
-        `Keybase: Permission denied in ${tlf}`,
-        "You are not logged into Keybase. Try 'keybase login'."
-      ])
-    case enums.kbfs.FSErrorType.timeout:
-      return ([
-        `Keybase: ${_.capitalize(notification.params.mode)} timeout in ${tlf}`,
-        `The ${notification.params.mode} operation took too long and failed. Please run 'keybase log send' so our admins can review.`
-      ])
-    case enums.kbfs.FSErrorType.rekeyNeeded:
-      if (notification.rekeyself) {
-        return ([
-          'Keybase: Files need to be rekeyed',
-          `Please open one of your other computers to unlock ${tlf}`
-        ])
-      } else {
-        return ([
-          'Keybase: Friends needed',
-          `Please ask another member of ${tlf} to open Keybase on one of their computers to unlock it for you.`
-        ])
-      }
-    case enums.kbfs.FSErrorType.badFolder:
-      return ([
-        'Keybase: Bad folder',
-        `${tlf} is not a Keybase folder. All folders begin with /keybase/private or /keybase/public.`
-      ])
-    case enums.kbfs.FSErrorType.notImplemented:
-      if (notification.feature === '2gbFileLimit') {
-        return ([
-          'Keybase: Not yet implemented',
-          `You just tried to write a file larger than 2GB in ${tlf}. This limitation will be removed soon.`
-        ])
-      } else if (notification.feature === '512kbDirLimit') {
-        return ([
-          'Keybase: Not yet implemented',
-          `You just tried to write too many files into ${tlf}. This limitation will be removed soon.`
-        ])
-      } else {
-        return ([
-          'Keybase: Not yet implemented',
-          `You just hit a ${notification.feature} limitation in KBFS. It will be fixed soon.`
-        ])
-      }
-    case enums.kbfs.FSErrorType.oldVersion:
-      return ([
-        'Keybase: Old version found',
-        'Please upgrade your Keybase app!'
-      ])
-    default:
-      return ([
-        'Keybase: KBFS error',
-        `${notification.status}`
-      ])
+    }
+  } else {
+    return ([
+      'Keybase: KBFS error',
+      `${notification.status}`
+    ])
   }
 }

--- a/shared/util/kbfs.js
+++ b/shared/util/kbfs.js
@@ -1,5 +1,10 @@
 /* @flow */
 
+import _ from 'lodash'
+import enums from '../constants/types/keybase-v1'
+import path from 'path'
+import type {FSNotification} from '../constants/types/flow-types'
+
 // Parses the folder name and returns an array of usernames (TODO: handle read only-ers)
 export function parseFolderNameToUsers (folderName: string): Array<string> {
   return folderName.split(',')
@@ -31,4 +36,80 @@ export function cleanup (folderName: string): string {
   }
 
   return folderName.replace(/\s/g, '').replace(/\.\./g, '').replace(/\//g, '').replace(/\\/g, '')
+}
+
+export function decodeKBFSError (user: string, notification: FSNotification): Array<string> {
+  const basedir = notification.filename.split(path.sep)[0]
+  const tlf = `/keybase${getTLF(notification.publicTopLevelFolder, basedir)}`
+  switch (notification.errorType) {
+    case enums.kbfs.FSErrorType.accessDenied:
+      return ([
+        'Keybase: Access denied',
+        `${user} does not have ${notification.params.mode} access to ${tlf}`
+      ])
+    case enums.kbfs.FSErrorType.userNotFound:
+      return ([
+        'Keybase: User not found',
+        `${notification.username} is not a Keybase user`
+      ])
+    case enums.kbfs.FSErrorType.revokedDataDetected:
+      return ([
+        'Keybase: Possibly revoked data detected',
+        `${tlf} was modified by a revoked or bad device. Use 'keybase log send' to file an issue with the Keybase admins.`
+      ])
+    case enums.kbfs.FSErrorType.notLoggedIn:
+      return ([
+        `Keybase: Permission denied in ${tlf}`,
+        "You are not logged into Keybase. Try 'keybase login'."
+      ])
+    case enums.kbfs.FSErrorType.timeout:
+      return ([
+        `Keybase: ${_.capitalize(notification.params.mode)} timeout in ${tlf}`,
+        `The ${notification.params.mode} operation took too long and failed. Please run 'keybase log send' so our admins can review.`
+      ])
+    case enums.kbfs.FSErrorType.rekeyNeeded:
+      if (notification.rekeyself) {
+        return ([
+          'Keybase: Files need to be rekeyed',
+          `Please open one of your other computers to unlock ${tlf}`
+        ])
+      } else {
+        return ([
+          'Keybase: Friends needed',
+          `Please ask another member of ${tlf} to open Keybase on one of their computers to unlock it for you.`
+        ])
+      }
+    case enums.kbfs.FSErrorType.badFolder:
+      return ([
+        'Keybase: Bad folder',
+        `${tlf} is not a Keybase folder. All folders begin with /keybase/private or /keybase/public.`
+      ])
+    case enums.kbfs.FSErrorType.notImplemented:
+      if (notification.feature === '2gbFileLimit') {
+        return ([
+          'Keybase: Not yet implemented',
+          `You just tried to write a file larger than 2GB in ${tlf}. This limitation will be removed soon.`
+        ])
+      } else if (notification.feature === '512kbDirLimit') {
+        return ([
+          'Keybase: Not yet implemented',
+          `You just tried to write too many files into ${tlf}. This limitation will be removed soon.`
+        ])
+      } else {
+        return ([
+          'Keybase: Not yet implemented',
+          `You just hit a ${notification.feature} limitation in KBFS. It will be fixed soon.`
+        ])
+      }
+    case enums.kbfs.FSErrorType.oldVersion:
+      return ([
+        'Keybase: Old version found',
+        'Please upgrade your Keybase app!'
+      ])
+    default:
+      return ([
+        'Keybase: KBFS error',
+        `${notification.status}`
+      ])
+  }
 }


### PR DESCRIPTION
@keybase/react-hackers 

This PR takes us from using notification strings that we receive from KBFS to using semantic descriptions of errors that we convert to strings ourselves.  This makes it easier for us to change the strings in future, etc.

There's a flow error here around this type:
```js
export type FSNotification = {
  publicTopLevelFolder: boolean;
  filename: string;
  status: string;
  statusCode: FSStatusCode;
  notificationType: FSNotificationType;
  errorType: FSErrorType;
  params: {string: string};
}
```
because `params` has many possible values, not just the key 'string'.  Maybe a problem with our type generator?
