### PR TITLE
Mounter/Uninstall: Remove some global context usage

### DIFF
--- a/go/mounter/mounter_non_osx.go
+++ b/go/mounter/mounter_non_osx.go
@@ -8,9 +8,10 @@ package mounter
 import (
 	"fmt"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
 )
 
-func IsMounted(g *libkb.GlobalContext, dir string) (bool, error) {
+// IsMounted returns true if directory is mounted (by kbfuse)
+func IsMounted(dir string, log logger.Logger) (bool, error) {
 	return false, fmt.Errorf("IsMounted unsupported on this platform")
 }

--- a/go/mounter/mounter_osx.go
+++ b/go/mounter/mounter_osx.go
@@ -10,16 +10,17 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
 )
 
-func IsMounted(g *libkb.GlobalContext, dir string) (bool, error) {
+// IsMounted returns true if directory is mounted (by kbfuse)
+func IsMounted(dir string, log logger.Logger) (bool, error) {
 	mountInfo, err := getMountInfo(dir)
 	if err != nil {
 		return false, err
 	}
 
-	g.Log.Debug("Mount info: %s", mountInfo)
+	log.Debug("Mount info: %s", mountInfo)
 	if strings.Contains(mountInfo, "@kbfuse") {
 		return true, nil
 	}

--- a/go/mounter/mounter_windows.go
+++ b/go/mounter/mounter_windows.go
@@ -8,14 +8,15 @@ package mounter
 import (
 	"fmt"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
 )
 
 // Unmount tries to unmount normally and then if force if unsuccessful.
-func Unmount(g *libkb.GlobalContext, dir string, force bool) error {
+func Unmount(dir string, force bool, log logger.Logger) error {
 	return fmt.Errorf("Unmount unsupported on this platform")
 }
 
-func ForceUnmount(g *libkb.GlobalContext, dir string) (err error) {
+// ForceUnmount tries to forceably unmount a directory
+func ForceUnmount(dir string, log logger.Logger) (err error) {
 	return fmt.Errorf("ForceUnmount unsupported on this platform")
 }


### PR DESCRIPTION
Reducing some dependencies for the go updater when it needs to perform
special actions for fuse upgrades.

Should be relatively benign, trading GlobalContext references for runMode, mountDir and log.