### PR TITLE
Don't use the ID cache for decrypt command

### DIFF
--- a/go/client/cmd_decrypt.go
+++ b/go/client/cmd_decrypt.go
@@ -59,6 +59,7 @@ func NewCmdDecrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 func NewCmdDecryptRunner(g *libkb.GlobalContext) *CmdDecrypt {
 	return &CmdDecrypt{
 		Contextified: libkb.NewContextified(g),
+		opts:         keybase1.SaltpackDecryptOptions{ForceRemoteCheck: true},
 	}
 }
 

--- a/go/engine/saltpack_sender_identify.go
+++ b/go/engine/saltpack_sender_identify.go
@@ -99,6 +99,7 @@ func (e *SaltpackSenderIdentify) identifySender(ctx *Context) (err error) {
 		UseDelegateUI:         !e.arg.interactive,
 		AlwaysBlock:           e.arg.interactive,
 		ForceRemoteCheck:      e.arg.forceRemoteCheck,
+		NeedProofSet:          e.arg.forceRemoteCheck,
 		NoErrorOnTrackFailure: true,
 		Reason:                e.arg.reason,
 		UserAssertion:         e.arg.userAssertion,


### PR DESCRIPTION
Pretty self explanatory. I needed to set NeedProofSet also to avoid using the cache.
@maxtaco @patrickxb 