### PR TITLE
Delete Circle CI's installation of an older go.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,6 @@ machine:
   node:
     version: 5.7.0
   environment:
-    GOROOT: $HOME/go
     GOPATH: $HOME/go-path
     PATH: $GOROOT/bin:$PATH
     # Limit memory usage of gradle
@@ -16,6 +15,13 @@ general:
   build_dir: react-native
 dependencies:
   pre:
+    - sudo rm -rf $HOME/go* # Remove old go installation
+    - sudo rm -rf /usr/local/go* # Remove old go installation
+    - wget https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz -O $HOME/go.tar.gz
+    - mkdir $HOME/go-path
+    - (cd $HOME; tar -xzvf go.tar.gz)
+    - sudo mv $HOME/go /usr/local
+    - go get golang.org/x/mobile/cmd/gomobile
     - if ! $(grep -q "Revision=24.4.1" $ANDROID_HOME/tools/source.properties); then echo y | android update sdk -u -a -t "tools"; fi
     - if [ ! -e $ANDROID_HOME/build-tools/23.0.2 ]; then echo y | android update sdk -u -a -t "build-tools-23.0.2"; fi
   cache_directories:
@@ -28,10 +34,6 @@ dependencies:
     #    parallel: true
     - npm install
     - npm install -g react-native-cli
-    - wget https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz -O $HOME/go.tar.gz
-    - (cd $HOME; tar -xzvf go.tar.gz)
-    - mkdir $HOME/go-path
-    - go get golang.org/x/mobile/cmd/gomobile
     - $GOPATH/bin/gomobile init
     - mkdir -p $GOPATH/src/github.com/keybase
     - ln -s $HOME/client $GOPATH/src/github.com/keybase/client


### PR DESCRIPTION
Was causing problems when you `go get` `gomobile` in Circle CI.

@keybase/react-hackers 