### PR TITLE
Limit react-native workers

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ machine:
     # Limit memory usage of gradle
     _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
     GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m -XX:+HeapDumpOnOutOfMemoryError"'
+    REACT_NATIVE_MAX_WORKERS: 1
     # Some node dependencies break without this
     CXX: g++-4.8
 general:


### PR DESCRIPTION
The workers react native spawns to package are pretty aggressive. This tones that down so we don't get Out of Memory errors on the CI.

@keybase/react-hackers 