### PR TITLE
Fix index gen for windows

### DIFF
--- a/packaging/windows/doinstaller_gui.cmd
+++ b/packaging/windows/doinstaller_gui.cmd
@@ -96,5 +96,4 @@ IF %ERRORLEVEL% NEQ 0 (
 :: After sanity checking, do:
 ::"%ProgramFiles%\S3 Browser\s3browser-con.exe" upload keybase update-windows-prod.json prerelease.keybase.io
 :: popd
-::%GOPATH%\bin\windows_386\release index-html --bucket-name=prerelease.keybase.io --prefixes="darwin/,linux_binaries/deb/,linux_binaries/rpm/,windows/" --dest=index.html
-::"%ProgramFiles%\S3 Browser\s3browser-con.exe" upload keybase index.html prerelease.keybase.io
+::%GOPATH%\bin\windows_386\release index-html --bucket-name=prerelease.keybase.io --prefixes="windows/" --upload="windows/index.html"

--- a/packaging/windows/s3_prerelease.cmd
+++ b/packaging/windows/s3_prerelease.cmd
@@ -10,7 +10,7 @@ go install github.com/keybase/release
 set release_bin=%GOPATH%\bin\windows_386\release.exe
 
 echo "Creating index files"
-%release_bin% index-html --bucket-name=%BUCKET_NAME% --prefixes="darwin/,linux_binaries/deb/,linux_binaries/rpm/,windows/" --upload=index.html
+%release_bin% index-html --bucket-name=%BUCKET_NAME% --prefixes="windows/" --upload="windows/index.html"
 
 echo "Linking latest"
 %release_bin% latest --bucket-name=%BUCKET_NAME% --platform=windows


### PR DESCRIPTION
We changed index.html files to be in darwin/index.html, windows/index.html etc.. The top level is static and links to all the platforms

@zanderz @oconnor663 