### PR TITLE
Taruti/windows nul open nonfatal

### DIFF
--- a/go/client/fork_server_nix.go
+++ b/go/client/fork_server_nix.go
@@ -19,16 +19,11 @@ func spawnServer(g *libkb.GlobalContext, cl libkb.CommandLine, forkType keybase1
 	var files []uintptr
 	var cmd string
 	var args []string
-	var devnull, log *os.File
+	var devnull *os.File
 
 	defer func() {
-		if err != nil {
-			if devnull != nil {
-				devnull.Close()
-			}
-			if log != nil {
-				log.Close()
-			}
+		if err != nil && devnull != nil {
+			devnull.Close()
 		}
 	}()
 

--- a/go/client/fork_server_windows.go
+++ b/go/client/fork_server_windows.go
@@ -19,24 +19,22 @@ func spawnServer(g *libkb.GlobalContext, cl libkb.CommandLine, forkType keybase1
 	var files []uintptr
 	var cmd string
 	var args []string
-	var devnull, log *os.File
+	var devnull *os.File
 
 	defer func() {
-		if err != nil {
-			if devnull != nil {
-				devnull.Close()
-			}
-			if log != nil {
-				log.Close()
-			}
+		if err != nil && devnull != nil {
+			devnull.Close()
 		}
 	}()
 
-	if devnull, err = os.OpenFile("nul", os.O_RDONLY, 0); err != nil {
-		return
+	// Failing to open nul is non-fatal here.
+	devnull, err = os.OpenFile("nul", os.O_RDONLY, 0)
+	if err != nil {
+		G.Log.Warning("Cannot open nul: %v", err)
+	} else {
+		nullfd := devnull.Fd()
+		files = append(files, nullfd, nullfd, nullfd)
 	}
-	nullfd := devnull.Fd()
-	files = append(files, nullfd, nullfd, nullfd)
 
 	// On 'nix this would include Setsid: true, which means
 	// the new process inherits the session/terminal from the parent.

--- a/go/client/fork_server_windows.go
+++ b/go/client/fork_server_windows.go
@@ -31,6 +31,11 @@ func spawnServer(g *libkb.GlobalContext, cl libkb.CommandLine, forkType keybase1
 	devnull, err = os.OpenFile("nul", os.O_RDONLY, 0)
 	if err != nil {
 		G.Log.Warning("Cannot open nul: %v", err)
+		// 0 is an invalid handle, but more importantly it will
+		// not be passed to DuplicateHandle by Go. This works
+		// with Go 1.6, but is hacky. This code path is taken
+		// only on systems that are broken to begin with...
+		files = append(files, 0, 0, 0)
 	} else {
 		nullfd := devnull.Fd()
 		files = append(files, nullfd, nullfd, nullfd)


### PR DESCRIPTION
Another go at this.

Passing 0 as the Handle is hacky, but this only done on machines that are somewhat broken to begin with. Go avoids calling DuplicateHandle on the 0 and it is an invalid handle (for most purposes). Tested this workaround on a few machines and it seems to work on them fine.