### PR TITLE
correct the Arch upgrade instructions for prerelease

### DIFF
--- a/go/libkb/upgrade_instructions.go
+++ b/go/libkb/upgrade_instructions.go
@@ -54,7 +54,11 @@ func linuxUpgradeInstructionsString() (string, error) {
 	} else if hasPackageManager("yum") {
 		start = "sudo yum upgrade " + packageName
 	} else if hasPackageManager("pacman") {
-		start = "sudo pacman -Syu"
+		if len(PrereleaseBuild) > 0 {
+			start = "yaourt -S keybase-git"
+		} else {
+			start = "sudo pacman -Syu"
+		}
 	} else {
 		return "", fmt.Errorf("Unhandled linux upgrade instruction.")
 	}


### PR DESCRIPTION
The `sudo pacman -Syu` command assumes that you're using the (official!)
Arch package, but if you're running prerelease that won't update you.
Suggest a more appropriate command if the current client is prerelease.

r? @cjb