### PR TITLE
Print s3 url apk

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -55,4 +55,4 @@ test:
     - (cd android && ./gradlew assembleDebug)
     # Upload it to appetize
     # And grep so we only reveal the public url in the CI logs
-    - PLATFORM=android PLATFORM_BUILD_PATH="android/app/build/outputs/apk/app-debug.apk" S3_URL="s3://kb-appbuilds/" BUILD_URL="https://s3-us-west-2.amazonaws.com/kb-appbuilds/" ./uploadApp.sh | grep -Eo "\"publicURL\":\"[^\"]*\""
+    - PLATFORM=android PLATFORM_BUILD_PATH="android/app/build/outputs/apk/app-debug.apk" S3_URL="s3://kb-appbuilds/" BUILD_URL="https://s3-us-west-2.amazonaws.com/kb-appbuilds/" ./uploadApp.sh | grep -Eo "\"publicURL\":\"[^\"]*\"|APK_URL:.*$"

--- a/circle.yml
+++ b/circle.yml
@@ -52,7 +52,7 @@ test:
     # copy the test results to the test results directory.
     # - cp -r android/app/build/outputs/androidTest-results/* $CIRCLE_TEST_REPORTS
     # Build a debug version of the app
-    - (cd android && ./gradlew assembleDebug)
+    - (cd android && ./gradlew assembleReleaseUnsigned)
     # Upload it to appetize
     # And grep so we only reveal the public url in the CI logs
-    - PLATFORM=android PLATFORM_BUILD_PATH="android/app/build/outputs/apk/app-debug.apk" S3_URL="s3://kb-appbuilds/" BUILD_URL="https://s3-us-west-2.amazonaws.com/kb-appbuilds/" ./uploadApp.sh | grep -Eo "\"publicURL\":\"[^\"]*\"|APK_URL:.*$"
+    - PLATFORM=android PLATFORM_BUILD_PATH="android/app/build/outputs/apk/app-releaseUnsigned.apk" S3_URL="s3://kb-appbuilds/" BUILD_URL="https://s3-us-west-2.amazonaws.com/kb-appbuilds/" ./uploadApp.sh | grep -Eo "\"publicURL\":\"[^\"]*\"|APK_URL:.*$"

--- a/react-native/android/app/build.gradle
+++ b/react-native/android/app/build.gradle
@@ -124,6 +124,12 @@ android {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
+
+        releaseUnsigned.initWith(buildTypes.release)
+        releaseUnsigned {
+            signingConfig buildTypes.debug.signingConfig
+        }
+
     }
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->

--- a/react-native/android/app/src/main/java/io/keybase/android/MainActivity.java
+++ b/react-native/android/app/src/main/java/io/keybase/android/MainActivity.java
@@ -50,26 +50,26 @@ public class MainActivity extends ReactActivity {
     }
 
 
-@Override
-@TargetApi(Build.VERSION_CODES.KITKAT)
-protected void onCreate(Bundle savedInstanceState) {
+    @Override
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    protected void onCreate(Bundle savedInstanceState) {
 
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M && !Settings.canDrawOverlays(this)) {
-        Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-          Uri.parse("package:" + getPackageName()));
-        startActivityForResult(intent, -1);
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M && !Settings.canDrawOverlays(this) && this.getUseDeveloperSupport()) {
+            Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+              Uri.parse("package:" + getPackageName()));
+            startActivityForResult(intent, -1);
+        }
+
+        Init(this.getFilesDir().getPath(), "staging", "", false);
+
+        try {
+            Keybase.SetGlobalExternalKeyStore(new KeyStore(this, getSharedPreferences("KeyStore", MODE_PRIVATE)));
+        } catch (KeyStoreException | CertificateException | IOException | NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+
+        super.onCreate(savedInstanceState);
     }
-
-    Init(this.getFilesDir().getPath(), "staging", "", false);
-
-    try {
-        Keybase.SetGlobalExternalKeyStore(new KeyStore(this, getSharedPreferences("KeyStore", MODE_PRIVATE)));
-    } catch (KeyStoreException | CertificateException | IOException | NoSuchAlgorithmException e) {
-        e.printStackTrace();
-    }
-
-    super.onCreate(savedInstanceState);
-}
 
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {

--- a/react-native/uploadApp.sh
+++ b/react-native/uploadApp.sh
@@ -43,6 +43,7 @@ fi
 
 aws s3 cp $PLATFORM_BUILD_PATH $S3_URL$BUILD_NAME
 
+echo "APK_URL: $BUILD_URL$BUILD_NAME"
 curl https://api.appetize.io/v1/app/update -H 'Content-Type: application/json' -d "$JSON_PAYLOAD"
 
 exit 0


### PR DESCRIPTION
@keybase/react-hackers 

This prints the APK Url that was uploaded to S3 so we can manually install it if something looks weird on appetize.

Also creates a new `buildType` called `releaseUnsigned` which should be effectively the same thing as `release`

This fixes the error were icons weren't showing up on appetize. That is because in debug mode the app looks for the packager to give it the assets instead of using the bundled ones.