### PR TITLE
New updater service (installer)

### DIFF
--- a/go/client/cmd_install_osx.go
+++ b/go/client/cmd_install_osx.go
@@ -79,6 +79,8 @@ func (v *CmdInstall) ParseArgv(ctx *cli.Context) error {
 	v.binPath = ctx.String("bin-path")
 	v.installer = ctx.String("installer")
 	if ctx.String("components") == "" {
+		// To enable udpater install use:
+		// v.components = []string{"updater", "service", "kbfs"}
 		v.components = []string{"service", "kbfs"}
 	} else {
 		v.components = strings.Split(ctx.String("components"), ",")
@@ -167,6 +169,8 @@ func (v *CmdUninstall) ParseArgv(ctx *cli.Context) error {
 		if libkb.IsBrewBuild {
 			v.components = []string{"service"}
 		} else {
+			// To enable updater use:
+			//v.components = []string{"service", "kbfs", "updater"}
 			v.components = []string{"service", "kbfs"}
 		}
 	} else {

--- a/go/client/cmd_launchd_osx.go
+++ b/go/client/cmd_launchd_osx.go
@@ -57,7 +57,7 @@ func NewCmdLaunchdInstall(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cl
 			binPath := args[1]
 			logFileName := args[2]
 			plistArgs := args[3:]
-			envVars := install.DefaultLaunchdEnvVars(g, label)
+			envVars := install.DefaultLaunchdEnvVars(label)
 
 			plist := launchd.NewPlist(label, binPath, plistArgs, envVars, logFileName, "")
 			err := launchd.Install(plist, g.Log)
@@ -365,6 +365,6 @@ func WaitForService(g *libkb.GlobalContext, launchService launchd.Service) error
 	if launchdStatus == nil {
 		return fmt.Errorf("%s was not found", launchService.Label())
 	}
-	_, err = libkb.WaitForServiceInfoFile(g, g.Env.GetServiceInfoPath(), launchService.Label(), launchdStatus.Pid(), 25, 400*time.Millisecond, "restart")
+	_, err = libkb.WaitForServiceInfoFile(g.Env.GetServiceInfoPath(), launchdStatus.Label(), launchdStatus.Pid(), 25, 400*time.Millisecond, "restart", g.Log)
 	return err
 }

--- a/go/client/cmd_status.go
+++ b/go/client/cmd_status.go
@@ -78,6 +78,9 @@ type fstatus struct {
 		Running bool
 		Log     string
 	}
+	Updater struct {
+		Log string
+	}
 	Start struct {
 		Log string
 	}
@@ -171,6 +174,7 @@ func (c *CmdStatus) load() (*fstatus, error) {
 
 	status.KBFS.Log = filepath.Join(extStatus.LogDir, libkb.KBFSLogFileName)
 	status.Desktop.Log = filepath.Join(extStatus.LogDir, libkb.DesktopLogFileName)
+	status.Updater.Log = filepath.Join(extStatus.LogDir, libkb.UpdaterLogFileName)
 
 	status.Start.Log = filepath.Join(extStatus.LogDir, libkb.StartLogFileName)
 
@@ -227,6 +231,8 @@ func (c *CmdStatus) outputTerminal(status *fstatus) error {
 	dui.Printf("    status:    %s\n", BoolString(status.Service.Running, "running", "not running"))
 	dui.Printf("    version:   %s\n", status.Service.Version)
 	dui.Printf("    log:       %s\n", status.Service.Log)
+	dui.Printf("\nUpdater:\n")
+	dui.Printf("    log:       %s\n", status.Updater.Log)
 	dui.Printf("\nPlatform Information:\n")
 	dui.Printf("    OS:        %s\n", status.PlatformInfo.Os)
 	dui.Printf("    Runtime:   %s\n", status.PlatformInfo.GoVersion)

--- a/go/engine/update_osx.go
+++ b/go/engine/update_osx.go
@@ -8,20 +8,29 @@ package engine
 import (
 	"github.com/keybase/client/go/install"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol"
 )
 
+// AfterUpdateApply runs after an update has been applied
 func AfterUpdateApply(g *libkb.GlobalContext, willRestart bool) error {
-	if !willRestart {
-		return nil
+	if willRestart {
+		return UninstallForFuseUpgrade("/Applications/Keybase.app", g.Env.GetRunMode(), g.Env.GetMountDir(), g.Log)
 	}
+	return nil
+}
 
-	fuseStatus, err := install.KeybaseFuseStatusForAppBundle("/Applications/Keybase.app", g.Log)
+// UninstallForFuseUpgrade will see if the Fuse version in the Keybase.app
+// bundle matches whats currently installed, and if not, will uninstall KBFS so
+// that on the next restart, Fuse can be upgraded.
+func UninstallForFuseUpgrade(appPath string, runMode libkb.RunMode, mountDir string, log logger.Logger) error {
+	log.Debug("Checking Fuse status")
+	fuseStatus, err := install.KeybaseFuseStatusForAppBundle(appPath, log)
 	if err != nil {
 		return err
 	}
 
-	g.Log.Debug("Fuse status: %s", fuseStatus)
+	log.Debug("Fuse status: %s", fuseStatus)
 
 	hasKBFuseMounts := false
 	for _, mountInfo := range fuseStatus.MountInfos {
@@ -32,8 +41,8 @@ func AfterUpdateApply(g *libkb.GlobalContext, willRestart bool) error {
 	}
 
 	if fuseStatus.InstallAction == keybase1.InstallAction_UPGRADE && hasKBFuseMounts {
-		g.Log.Info("Fuse needs upgrade and we have mounts, let's uninstall KBFS so the installer can upgrade after app restart")
-		install.Uninstall(g, []string{"kbfs"})
+		log.Info("Fuse needs upgrade and we have mounts, let's uninstall KBFS so the installer can upgrade after app restart")
+		return install.UninstallKBFS(runMode, mountDir, log)
 	}
 
 	return nil

--- a/go/install/install_osx.go
+++ b/go/install/install_osx.go
@@ -23,14 +23,22 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol"
 )
 
+// ServiceLabel is an identifier string for a service
 type ServiceLabel string
 
 const (
-	AppServiceLabel  ServiceLabel = "keybase.service"
-	AppKBFSLabel     ServiceLabel = "keybase.kbfs"
+	// AppServiceLabel is the service label for the keybase launchd service in Keybase.app
+	AppServiceLabel ServiceLabel = "keybase.service"
+	// AppKBFSLabel is the service label for the kbfs launchd service in Keybase.app
+	AppKBFSLabel ServiceLabel = "keybase.kbfs"
+	// AppUpdaterLabel is the service label for the updater launchd service in Keybase.app
+	AppUpdaterLabel ServiceLabel = "keybase.updater"
+	// BrewServiceLabel is the service label for the updater launchd service in homebrew
 	BrewServiceLabel ServiceLabel = "homebrew.mxcl.keybase"
-	BrewKBFSLabel    ServiceLabel = "homebrew.mxcl.kbfs"
-	UnknownLabel     ServiceLabel = ""
+	// BrewKBFSLabel is the service label for the kbfs launchd service in homebrew
+	BrewKBFSLabel ServiceLabel = "homebrew.mxcl.kbfs"
+	// UnknownLabel is an empty/unknown label
+	UnknownLabel ServiceLabel = ""
 )
 
 func KeybaseServiceStatus(g *libkb.GlobalContext, label string) (status keybase1.ServiceStatus) {
@@ -39,7 +47,7 @@ func KeybaseServiceStatus(g *libkb.GlobalContext, label string) (status keybase1
 	}
 	kbService := launchd.NewService(label)
 
-	status, err := serviceStatusFromLaunchd(g, kbService, path.Join(g.Env.GetRuntimeDir(), "keybased.info"))
+	status, err := serviceStatusFromLaunchd(kbService, path.Join(g.Env.GetRuntimeDir(), "keybased.info"), g.Log)
 	status.BundleVersion = libkb.VersionString()
 	if err != nil {
 		return
@@ -61,7 +69,7 @@ func KBFSServiceStatus(g *libkb.GlobalContext, label string) (status keybase1.Se
 	}
 	kbfsService := launchd.NewService(label)
 
-	status, err := serviceStatusFromLaunchd(g, kbfsService, path.Join(g.Env.GetRuntimeDir(), "kbfs.info"))
+	status, err := serviceStatusFromLaunchd(kbfsService, path.Join(g.Env.GetRuntimeDir(), "kbfs.info"), g.Log)
 	if err != nil {
 		return
 	}
@@ -82,7 +90,7 @@ func KBFSServiceStatus(g *libkb.GlobalContext, label string) (status keybase1.Se
 	return
 }
 
-func serviceStatusFromLaunchd(g *libkb.GlobalContext, ls launchd.Service, infoPath string) (status keybase1.ServiceStatus, err error) {
+func serviceStatusFromLaunchd(ls launchd.Service, infoPath string, log logger.Logger) (status keybase1.ServiceStatus, err error) {
 	status = keybase1.ServiceStatus{
 		Label: ls.Label(),
 	}
@@ -110,7 +118,7 @@ func serviceStatusFromLaunchd(g *libkb.GlobalContext, ls launchd.Service, infoPa
 	var serviceInfo *libkb.ServiceInfo
 	if infoPath != "" {
 		if status.Pid != "" {
-			serviceInfo, err = libkb.WaitForServiceInfoFile(g, infoPath, status.Label, status.Pid, 40, 500*time.Millisecond, "service status")
+			serviceInfo, err = libkb.WaitForServiceInfoFile(infoPath, status.Label, status.Pid, 40, 500*time.Millisecond, "service status", log)
 			if err != nil {
 				status.InstallStatus = keybase1.InstallStatus_ERROR
 				status.InstallAction = keybase1.InstallAction_REINSTALL
@@ -138,7 +146,7 @@ func serviceStatusFromLaunchd(g *libkb.GlobalContext, ls launchd.Service, infoPa
 func serviceStatusesFromLaunchd(g *libkb.GlobalContext, ls []launchd.Service) []keybase1.ServiceStatus {
 	c := []keybase1.ServiceStatus{}
 	for _, l := range ls {
-		s, _ := serviceStatusFromLaunchd(g, l, "")
+		s, _ := serviceStatusFromLaunchd(l, "", g.Log)
 		c = append(c, s)
 	}
 	return c
@@ -159,7 +167,7 @@ func ListServices(g *libkb.GlobalContext) (*keybase1.ServicesStatus, error) {
 		Kbfs:    serviceStatusesFromLaunchd(g, kbfs)}, nil
 }
 
-func DefaultLaunchdEnvVars(g *libkb.GlobalContext, label string) []launchd.EnvVar {
+func DefaultLaunchdEnvVars(label string) []launchd.EnvVar {
 	return []launchd.EnvVar{
 		launchd.NewEnvVar("KEYBASE_LABEL", label),
 		launchd.NewEnvVar("KEYBASE_SERVICE_TYPE", "launchd"),
@@ -184,7 +192,7 @@ func keybasePlist(g *libkb.GlobalContext, binPath string, label string) launchd.
 	// TODO: Remove -d when doing real release
 	logFile := filepath.Join(launchd.LogDir(), libkb.ServiceLogFileName)
 	plistArgs := []string{"-d", fmt.Sprintf("--log-file=%s", logFile), "service"}
-	envVars := DefaultLaunchdEnvVars(g, label)
+	envVars := DefaultLaunchdEnvVars(label)
 	comment := "It's not advisable to edit this plist, it may be overwritten"
 	return launchd.NewPlist(label, binPath, plistArgs, envVars, libkb.StartLogFileName, comment)
 }
@@ -195,7 +203,7 @@ func installKeybaseService(g *libkb.GlobalContext, service launchd.Service, plis
 		return nil, err
 	}
 
-	st, err := serviceStatusFromLaunchd(g, service, g.Env.GetServiceInfoPath())
+	st, err := serviceStatusFromLaunchd(service, g.Env.GetServiceInfoPath(), g.Log)
 	return &st, err
 }
 
@@ -216,7 +224,7 @@ func kbfsPlist(g *libkb.GlobalContext, kbfsBinPath string, label string) (plist 
 		fmt.Sprintf("-runtime-dir=%s", g.Env.GetRuntimeDir()),
 		mountDir,
 	}
-	envVars := DefaultLaunchdEnvVars(g, label)
+	envVars := DefaultLaunchdEnvVars(label)
 	comment := "It's not advisable to edit this plist, it may be overwritten"
 	plist = launchd.NewPlist(label, kbfsBinPath, plistArgs, envVars, libkb.StartLogFileName, comment)
 
@@ -234,7 +242,7 @@ func installKBFSService(g *libkb.GlobalContext, service launchd.Service, plist l
 		return nil, err
 	}
 
-	st, err := serviceStatusFromLaunchd(g, service, "")
+	st, err := serviceStatusFromLaunchd(service, "", g.Log)
 	return &st, err
 }
 
@@ -300,6 +308,11 @@ func Install(g *libkb.GlobalContext, binPath string, components []string, force 
 	componentResults := []keybase1.ComponentResult{}
 
 	g.Log.Debug("Installing components: %s", components)
+
+	if libkb.IsIn(string(ComponentNameUpdater), components, false) {
+		err = installUpdater(binPath, force, libkb.VersionString(), g.Log)
+		componentResults = append(componentResults, componentResult(string(ComponentNameUpdater), err))
+	}
 
 	if libkb.IsIn(string(ComponentNameCLI), components, false) {
 		err = installCommandLine(g, binPath, true) // Always force CLI install
@@ -463,6 +476,11 @@ func Uninstall(g *libkb.GlobalContext, components []string) keybase1.UninstallRe
 	if libkb.IsIn(string(ComponentNameService), components, false) {
 		err = uninstallKeybaseServices(g.Env.GetRunMode())
 		componentResults = append(componentResults, componentResult(string(ComponentNameService), err))
+	}
+
+	if libkb.IsIn(string(ComponentNameUpdater), components, false) {
+		err = uninstallUpdater()
+		componentResults = append(componentResults, componentResult(string(ComponentNameUpdater), err))
 	}
 
 	return NewUninstallResult(componentResults)
@@ -723,4 +741,75 @@ func RunAfterStartup(g *libkb.GlobalContext, isService bool) error {
 		g.Log.Errorf("Error trying to open Keybase.app; %s; %s", err, out)
 	}
 	return nil
+}
+
+func installUpdater(keybaseBinPath string, force bool, keybaseVersion string, log logger.Logger) error {
+	keybaseBinPath, err := chooseBinPath(keybaseBinPath)
+	if err != nil {
+		return err
+	}
+	updaterBinPath := filepath.Join(filepath.Dir(keybaseBinPath), "updater")
+	if err != nil {
+		return err
+	}
+	log.Debug("Using updater path: %s", updaterBinPath)
+
+	label := string(AppUpdaterLabel)
+	service := launchd.NewService(label)
+	plist := keybaseUpdaterPlist(label, updaterBinPath, keybaseBinPath, keybaseVersion)
+
+	launchdStatus, err := service.LoadStatus()
+	if err != nil {
+		return err
+	}
+
+	needsInstall := false
+	if launchdStatus == nil {
+		log.Debug("No status, needs install")
+		needsInstall = true
+	}
+
+	if !needsInstall {
+		plistValid, err := service.CheckPlist(plist)
+		if err != nil {
+			return err
+		}
+		if !plistValid {
+			log.Debug("Plist needs update: %s", service.PlistDestination())
+			needsInstall = true
+		}
+	}
+
+	if needsInstall || force {
+		uninstallUpdater()
+		log.Debug("Installing updater service")
+		_, err := installUpdaterService(service, plist, log)
+		if err != nil {
+			log.Errorf("Error installing updater service: %s", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func keybaseUpdaterPlist(label string, serviceBinPath string, keybaseBinPath string, keybaseVersion string) launchd.Plist {
+	plistArgs := []string{fmt.Sprintf("-path-to-keybase=%s", keybaseBinPath)}
+	envVars := DefaultLaunchdEnvVars(label)
+	comment := fmt.Sprintf("It's not advisable to edit this plist, it may be overwritten. This was installed by keybase version %s.", keybaseVersion)
+	return launchd.NewPlist(label, serviceBinPath, plistArgs, envVars, libkb.UpdaterLogFileName, comment)
+}
+
+func installUpdaterService(service launchd.Service, plist launchd.Plist, log logger.Logger) (*keybase1.ServiceStatus, error) {
+	err := launchd.Install(plist, log)
+	if err != nil {
+		return nil, err
+	}
+
+	st, err := serviceStatusFromLaunchd(service, "", log)
+	return &st, err
+}
+
+func uninstallUpdater() error {
+	return launchd.Uninstall(string(AppUpdaterLabel), true, nil)
 }

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -407,6 +407,7 @@ const (
 const (
 	ServiceLogFileName = "keybase.service.log"
 	KBFSLogFileName    = "keybase.kbfs.log"
+	UpdaterLogFileName = "keybase.updater.log"
 	DesktopLogFileName = "Keybase.app.log"
 	// StartLogFileName is where services can log to (on startup) before they handle their own logging
 	StartLogFileName = "keybase.start.log"

--- a/go/libkb/service_info.go
+++ b/go/libkb/service_info.go
@@ -9,6 +9,8 @@ import (
 	"io/ioutil"
 	"os"
 	"time"
+
+	"github.com/keybase/client/go/logger"
 )
 
 // ServiceInfo describes runtime info for a service.
@@ -51,7 +53,7 @@ func (s ServiceInfo) WriteFile(path string) error {
 
 // WaitForServiceInfoFile tries to wait for a service info file, which should be
 // written on successful service startup.
-func WaitForServiceInfoFile(g *GlobalContext, path string, label string, pid string, maxAttempts int, wait time.Duration, reason string) (*ServiceInfo, error) {
+func WaitForServiceInfoFile(path string, label string, pid string, maxAttempts int, wait time.Duration, reason string, log logger.Logger) (*ServiceInfo, error) {
 	if pid == "" {
 		return nil, fmt.Errorf("No pid to wait for")
 	}
@@ -84,7 +86,7 @@ func WaitForServiceInfoFile(g *GlobalContext, path string, label string, pid str
 	serviceInfo, lookErr := lookForServiceInfo()
 	for attempt < maxAttempts && serviceInfo == nil {
 		attempt++
-		g.Log.Debug("Waiting for service info file...")
+		log.Debug("Waiting for service info file...")
 		time.Sleep(wait)
 		serviceInfo, lookErr = lookForServiceInfo()
 	}
@@ -98,6 +100,6 @@ func WaitForServiceInfoFile(g *GlobalContext, path string, label string, pid str
 	}
 
 	// We succeeded in finding service info
-	g.Log.Debug("Found service info: %#v", *serviceInfo)
+	log.Debug("Found service info: %#v", *serviceInfo)
 	return serviceInfo, nil
 }

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -30,6 +30,9 @@ comment=""
 
 keybase_binpath=${KEYBASE_BINPATH:-}
 kbfs_binpath=${KBFS_BINPATH:-}
+updater_binpath=${UPDATER_BINPATH:-}
+
+updater_version=`$updater_binpath -version`
 
 icon_path="$client_dir/media/icons/Keybase.icns"
 
@@ -76,6 +79,7 @@ installer_url="https://github.com/keybase/client/releases/download/v1.0.14-0/Key
 
 keybase_bin="$tmp_dir/keybase"
 kbfs_bin="$tmp_dir/kbfs"
+updater_bin="$tmp_dir/updater"
 installer_app="$tmp_dir/KeybaseInstaller.app"
 
 app_version="$keybase_version"
@@ -126,6 +130,10 @@ get_deps() {(
     ensure_url $kbfs_url "You need to build the binary for this Github release/version. See packaging/github to create/build a release."
     curl -J -L -Ss "$kbfs_url" | tar zx
   fi
+
+  echo "Using local updater binpath: $updater_binpath"
+  cp "$updater_binpath" .
+
   echo "Using installer from $installer_url"
   curl -J -L -Ss "$installer_url" | tar zx
 )}
@@ -156,6 +164,7 @@ package_app() {(
   mkdir -p "$shared_support_dir/bin"
   cp "$keybase_bin" "$shared_support_dir/bin"
   cp "$kbfs_bin" "$shared_support_dir/bin"
+  cp "$updater_bin" "$shared_support_dir/bin"
   echo "Copying installer"
   mkdir -p "$resources_dir"
   cp -R "$installer_app" "$resources_dir/KeybaseInstaller.app"

--- a/packaging/prerelease/README.md
+++ b/packaging/prerelease/README.md
@@ -53,16 +53,6 @@ To test a local build (using test bucket):
 NOPULL=1 TEST=1 PLATFORM=darwin ./build_app.sh
 ```
 
-### Testing Updates
-
-To store current install, to re-apply as an update:
-
-```
-ditto -c -k --keepParent -rsrc /Applications/Keybase.app /tmp/Keybase.zip
-keybase sign -d -i /tmp/Keybase.zip -o /tmp/keybase.sig
-keybase -d update run --source=local --url=file:///tmp/Keybase.zip --signature=/tmp/keybase.sig --force
-```
-
 ### Updating from Test Builds
 
 ```

--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -49,14 +49,17 @@ fi
 
 build_dir_keybase="/tmp/build_keybase"
 build_dir_kbfs="/tmp/build_kbfs"
+build_dir_updater="/tmp/build_updater"
 client_dir="$gopath/src/github.com/keybase/client"
 kbfs_dir="$gopath/src/github.com/keybase/kbfs"
+updater_dir="$gopath/src/github.com/keybase/go-updater"
 
 "$client_dir/packaging/slack/send.sh" "Starting $platform $build_desc"
 
 if [ ! "$nopull" = "1" ]; then
   "$client_dir/packaging/check_status_and_pull.sh" "$client_dir"
   "$client_dir/packaging/check_status_and_pull.sh" "$kbfs_dir"
+  "$client_dir/packaging/check_status_and_pull.sh" "$updater_dir"
 fi
 
 if [ -n "$client_commit" ]; then
@@ -84,16 +87,20 @@ fi
 if [ ! "$nobuild" = "1" ]; then
   BUILD_DIR=$build_dir_keybase "$dir/build_keybase.sh"
   BUILD_DIR=$build_dir_kbfs "$dir/build_kbfs.sh"
+  BUILD_DIR=$build_dir_updater "$dir/build_updater.sh"
 fi
 
 version=`$build_dir_keybase/keybase version -S`
 kbfs_version=`$build_dir_kbfs/kbfs -version`
+updater_version=`$build_dir_updater/updater -version`
 
 save_dir="/tmp/build_desktop"
 rm -rf $save_dir
 
 if [ "$platform" = "darwin" ]; then
-  SAVE_DIR="$save_dir" KEYBASE_BINPATH="$build_dir_keybase/keybase" KBFS_BINPATH="$build_dir_kbfs/kbfs" BUCKET_NAME="$bucket_name" S3HOST="$s3host" "$dir/../desktop/package_darwin.sh"
+  SAVE_DIR="$save_dir" KEYBASE_BINPATH="$build_dir_keybase/keybase" KBFS_BINPATH="$build_dir_kbfs/kbfs" \
+    UPDATER_BINPATH="$build_dir_updater/updater" BUCKET_NAME="$bucket_name" S3HOST="$s3host" \
+    "$dir/../desktop/package_darwin.sh"
 else
   # TODO: Support linux build here?
   echo "Unknown platform: $platform"

--- a/packaging/prerelease/build_updater.sh
+++ b/packaging/prerelease/build_updater.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail # Fail on error
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+cd "$dir"
+
+build_dir=${BUILD_DIR:-/tmp/build_updater}
+gopath=${GOPATH:-}
+package="github.com/keybase/go-updater/service"
+dest="$build_dir/updater"
+
+src_dir="$gopath/src/$package"
+cd $src_dir
+
+mkdir -p $build_dir
+
+ldflags=""
+
+if [ "$PLATFORM" = "darwin" ]; then
+  # To get codesign to work you have to use -ldflags "-s ...", see https://github.com/golang/go/issues/11887
+  ldflags="-s $ldflags"
+fi
+
+echo "Building $build_dir/updater"
+GO15VENDOREXPERIMENT=1 go build -a -ldflags "$ldflags" -o "$dest" "$package"
+
+if [ "$PLATFORM" = "darwin" ]; then
+  code_sign_identity="Developer ID Application: Keybase, Inc. (99229SGT5K)"
+  codesign --verbose --force --deep --sign "$code_sign_identity" "$dest"
+elif [ "$PLATFORM" = "linux" ]; then
+  echo "No codesigning for linux"
+else
+  echo "Invalid PLATFORM"
+  exit 1
+fi
+
+updater_version=`$build_dir/updater -version`
+echo "Updater version: $updater_version"


### PR DESCRIPTION
Installs the updater service (a new component in the installer). Includes build scripts, and log send as well. This has the default install of "updater" component commented out, so this is safe to merge.

When enabled (in a later PR), the result of `keybase install` would be:

```
keybase install
▶ INFO Saving /Users/gabe/Library/LaunchAgents/keybase.updater.plist
▶ INFO Starting keybase.updater
▶ INFO Saving /Users/gabe/Library/LaunchAgents/keybase.service.plist
▶ INFO Starting keybase.service
▶ INFO Saving /Users/gabe/Library/LaunchAgents/keybase.kbfs.plist
▶ INFO Starting keybase.kbfs
Install Updater: OK
Install Service: OK
Install KBFS: OK
```

The updater binary is built, signed and included in the Keybase.app bundle, for example, at /Applications/Keybase.app/Contents/SharedSupport/bin/updater. The binary that is build is just a placeholder that doesn't do anything for now.

This also adds the following endpoints which will be called by the updater in the future:

- `keybase update check-in-use`: Returns non-zero exit code if keybase is currently in use
- `keybase update notify after-apply`: Called after the update is applied

