### PR TITLE
Add multiline implementation.

### DIFF
--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -53,7 +53,7 @@ class Input extends Component<void, Props, State> {
       <Box style={{...containerStyle, ...this.props.style}}>
         {this.state.text.length > 0 && <Text type='BodySmall' style={{...floatingLabelStyle}}>{this.props.floatingLabelText}</Text>}
         <TextInput
-          style={{...inputStyle, ...textInputStyle}}
+          style={{...inputStyle, ...textInputStyle, ...(IOS && this.props.multiLine && IOSMultilineTextInputStyle || {})}}
           ref={component => { this._textInput = component }}
           autoCorrect={!(password || passwordVisible)}
           defaultValue={this.props.value}
@@ -62,6 +62,8 @@ class Input extends Component<void, Props, State> {
           placeholder={this.props.hintText}
           placeholderColor={globalColors.black10}
           underlineColorAndroid={this.state.inputFocused ? globalColors.blue : globalColors.black10}
+          multiline={this.props.multiLine}
+          numberOfLines={this.props.rows}
           onFocus={() => this.setState({inputFocused: true})}
           onBlur={() => this.setState({inputFocused: false})}
           onSubmitEditing={this.props.onEnterKeyDown}
@@ -93,11 +95,16 @@ const containerStyle = {
 
 const textInputStyle = {
   textAlign: 'center',
+  textAlignVertical: 'bottom',
   position: 'absolute',
   top: 0,
   bottom: -8,
   left: -4,
   right: -4
+}
+
+const IOSMultilineTextInputStyle = {
+  bottom: 0
 }
 
 const floatingLabelStyle = {

--- a/shared/more/style-sheet.render.native.js
+++ b/shared/more/style-sheet.render.native.js
@@ -57,6 +57,8 @@ const Inputs = () => (
       <Input type='password' hintText='Secure Passphrase Input' floatingLabelText='Passphrase'/>
     </Row>
 
+    <Input multiLine type='passwordVisible' floatingLabelText='Multiline' style={{height: 80}} hintText='opp blezzard tofi pando agg whi pany yaga jocket daubt bruwnstane hubit yas'/>
+
     <ShowTypingDemo/>
 
     <ShowTypingDemo initialShowTyping/>

--- a/shared/more/style-sheet.render.native.js
+++ b/shared/more/style-sheet.render.native.js
@@ -293,11 +293,9 @@ export default class Render extends Component {
         <Container title='Inputs'><Inputs/></Container>
         <Container title='Checkboxes'><Checkboxes flip={idx => this.flip(idx)} check={this.state.check}/></Container>
         <Container title='Icons'><Icons/></Container>
-        <Container title='Inputs'><Inputs/></Container>
         <Container title='Buttons'><Buttons/></Container>
         <Container title='Text'><Fonts/></Container>
         <Container title='Colors'><Colors/></Container>
-        <Container title='Inputs'><Inputs/></Container>
       </ScrollView>
     )
   }


### PR DESCRIPTION
Based off: https://github.com/keybase/client/pull/2535, so take a look at that first

### Preview

<img width="487" alt="screen shot 2016-04-06 at 4 32 50 pm" src="https://cloud.githubusercontent.com/assets/594035/14336114/d5ac5f34-fc15-11e5-80da-784ba4887fba.png">
<img width="515" alt="screen shot 2016-04-06 at 4 33 25 pm" src="https://cloud.githubusercontent.com/assets/594035/14336115/d5ad0632-fc15-11e5-88b1-1b373a84e147.png">


### Quirks
I can't seem to figure out how to align the ios text vertically
downwards. Android does not have this problem.