### PR TITLE
Add prerelease build number to kbfsdokan

### DIFF
--- a/packaging/windows/build_prerelease.cmd
+++ b/packaging/windows/build_prerelease.cmd
@@ -23,7 +23,10 @@ if NOT EXIST %GOPATH%\src\github.com\keybase\kbfs\dokan\dokan1.lib copy %GOPATH%
 for /f "usebackq tokens=2*" %%i in (`powershell Get-FileHash -Algorithm sha1 %GOPATH%\src\github.com\keybase\kbfs\dokan\dokan1.lib`) do set DOKANLIBHASH=%%i
 if NOT %DOKANLIBHASH%==8FCFE265C5558FBA9FC6BFF4AF8BB0B83A159611 exit /B 1
 pushd %GOPATH%\src\github.com\keybase\kbfs\kbfsdokan
-go build -tags "production prerelease"
+:: winresource invokes git to get the current revision
+for /f %%i in ('%GOPATH%\src\github.com\keybase\client\go\keybase\winresource.exe -cb') do set KBFS_BUILD=%%i
+echo %KBFS_BUILD%
+go build -a -tags "prerelease production" -ldflags="-X github.com/keybase/kbfs/libkbfs.PrereleaseBuild=%KBFS_BUILD%"
 popd
 
 :: Then the desktop:


### PR DESCRIPTION
KBFS:
    status:    running
    version:   1.0.2-20160406180908+a245428
    log:       C:\Users\IEUser\AppData\Roaming\Keybase\keybase.kbfs.log

@maxtaco @cjb 