### PR TITLE
implement `keybase decrypt --paperkey`

### DIFF
--- a/go/client/cmd_decrypt.go
+++ b/go/client/cmd_decrypt.go
@@ -52,6 +52,10 @@ func NewCmdDecrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 				Name:  "f, force",
 				Usage: "Force unprompted decryption, even on an identify failure",
 			},
+			cli.BoolFlag{
+				Name:  "paperkey",
+				Usage: "Use a paper key for decryption",
+			},
 		},
 	}
 }
@@ -82,7 +86,7 @@ func (c *CmdDecrypt) explainDecryptionFailure(info *keybase1.SaltpackEncryptedMe
 			prnt("Additionally, there were %d hidden receivers for this message\n", info.NumAnonReceivers)
 		}
 	} else if info.NumAnonReceivers > 0 {
-		prnt("Decryption failed; it was encrypted for %d hidden receivers, which may or may not you\n", info.NumAnonReceivers)
+		prnt("Decryption failed; it was encrypted for %d hidden receivers, which may or may not be you\n", info.NumAnonReceivers)
 	} else {
 		prnt("Decryption failed; message wasn't encrypted for any of your known keys\n")
 	}
@@ -147,6 +151,7 @@ func (c *CmdDecrypt) ParseArgv(ctx *cli.Context) error {
 		force:        ctx.Bool("force"),
 	}
 	c.opts.Interactive = interactive
+	c.opts.UsePaperKey = ctx.Bool("paperkey")
 	msg := ctx.String("message")
 	outfile := ctx.String("outfile")
 	infile := ctx.String("infile")

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -231,7 +231,7 @@ func (e *loginProvision) getValidPaperKey(ctx *Context) (*keypair, error) {
 	var lastErr error
 	for i := 0; i < 10; i++ {
 		// get the paper key from the user
-		kp, err := e.getPaperKey(ctx)
+		kp, err := getPaperKey(e.G(), ctx)
 		if err != nil {
 			e.G().Log.Debug("getValidPaperKey attempt %d: %s", i, err)
 			if _, ok := err.(libkb.InputCanceledError); ok {
@@ -825,13 +825,14 @@ func (e *loginProvision) ensurePaperKey(ctx *Context) error {
 	return RunEngine(eng, ctx)
 }
 
-func (e *loginProvision) getPaperKey(ctx *Context) (*keypair, error) {
+// This is used by SaltpackDecrypt as well.
+func getPaperKey(g *libkb.GlobalContext, ctx *Context) (*keypair, error) {
 	passphrase, err := libkb.GetPaperKeyPassphrase(ctx.SecretUI, "")
 	if err != nil {
 		return nil, err
 	}
 
-	paperPhrase, err := libkb.NewPaperKeyPhraseCheckVersion(e.G(), passphrase)
+	paperPhrase, err := libkb.NewPaperKeyPhraseCheckVersion(g, passphrase)
 	if err != nil {
 		return nil, err
 	}
@@ -840,13 +841,13 @@ func (e *loginProvision) getPaperKey(ctx *Context) (*keypair, error) {
 		Passphrase: paperPhrase,
 		SkipPush:   true,
 	}
-	bkeng := NewPaperKeyGen(bkarg, e.G())
+	bkeng := NewPaperKeyGen(bkarg, g)
 	if err := RunEngine(bkeng, ctx); err != nil {
 		return nil, err
 	}
 
 	kp := &keypair{sigKey: bkeng.SigKey(), encKey: bkeng.EncKey()}
-	if err := e.G().LoginState().Account(func(a *libkb.Account) {
+	if err := g.LoginState().Account(func(a *libkb.Account) {
 		a.SetUnlockedPaperKey(kp.sigKey, kp.encKey)
 	}, "UnlockedPaperKey"); err != nil {
 		return nil, err

--- a/go/protocol/saltpack.go
+++ b/go/protocol/saltpack.go
@@ -19,6 +19,7 @@ type SaltpackEncryptOptions struct {
 type SaltpackDecryptOptions struct {
 	Interactive      bool `codec:"interactive" json:"interactive"`
 	ForceRemoteCheck bool `codec:"forceRemoteCheck" json:"forceRemoteCheck"`
+	UsePaperKey      bool `codec:"usePaperKey" json:"usePaperKey"`
 }
 
 type SaltpackSignOptions struct {

--- a/protocol/avdl/saltpack.avdl
+++ b/protocol/avdl/saltpack.avdl
@@ -15,6 +15,7 @@ protocol saltpack {
   record SaltpackDecryptOptions {
     boolean interactive;
     boolean forceRemoteCheck;
+    boolean usePaperKey;
   }
 
   record SaltpackSignOptions {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -791,6 +791,7 @@ export type RevokedProof = {
 export type SaltpackDecryptOptions = {
   interactive: boolean;
   forceRemoteCheck: boolean;
+  usePaperKey: boolean;
 }
 
 export type SaltpackEncryptOptions = {

--- a/protocol/json/saltpack.json
+++ b/protocol/json/saltpack.json
@@ -746,6 +746,10 @@
         {
           "type": "boolean",
           "name": "forceRemoteCheck"
+        },
+        {
+          "type": "boolean",
+          "name": "usePaperKey"
         }
       ]
     },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -791,6 +791,7 @@ export type RevokedProof = {
 export type SaltpackDecryptOptions = {
   interactive: boolean;
   forceRemoteCheck: boolean;
+  usePaperKey: boolean;
 }
 
 export type SaltpackEncryptOptions = {


### PR DESCRIPTION
The new flag causes the decrypt command to prompt you for a paper key,
and then it uses that instead of your regular device keys to try to
decrypt the message. If your paper key doesn't actually work, it should
give you the same errors as if your device didn't work.

r? @maxtaco @patrickxb 