### PR TITLE
add an explicit prerelease dependency on fuse

### DIFF
--- a/packaging/linux/deb/package_binaries.sh
+++ b/packaging/linux/deb/package_binaries.sh
@@ -30,7 +30,7 @@ if [ "$mode" = "production" ] ; then
   repo_url="http://dist.keybase.io/linux/deb/repo"
 elif [ "$mode" = "prerelease" ] ; then
   repo_url="http://prerelease.keybase.io/deb"
-  dependencies="Depends: libappindicator1"
+  dependencies="Depends: libappindicator1, fuse"
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the
   # production URL, because we're moving to a model where we build a clean repo

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -26,10 +26,12 @@ mode="$(cat "$build_root/MODE")"
 
 name="$("$here/../../binary_name.sh" "$mode")"
 
+dependencies=""
 if [ "$mode" = "production" ] ; then
   repo_url="http://dist.keybase.io/linux/rpm/repo"
 elif [ "$mode" = "prerelease" ] ; then
   repo_url="http://prerelease.keybase.io/rpm"
+  dependencies="Requires: fuse"
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the
   # production URL, because we're moving to a model where we build a clean
@@ -82,6 +84,7 @@ build_one_architecture() {
     | sed "s/@@NAME@@/$name/g" \
     | sed "s/@@VERSION@@/$version/g" \
     | sed "s|@@COPIED_BINARIES@@|$copied_binaries|g" \
+    | sed "s|@@DEPENDENCIES@@|$dependencies|g" \
     > "$spec"
   # Append the files list to the spec.
   echo -e "\n%files\n$files" >> "$spec"

--- a/packaging/linux/rpm/spec.template
+++ b/packaging/linux/rpm/spec.template
@@ -4,6 +4,7 @@ Release: 1
 Summary: Keybase command line client
 License: BSD
 AutoReqProv: no
+@@DEPENDENCIES@@
 
 %description
 Keybase command line client


### PR DESCRIPTION
We left this out originally because it looked like mainstream Linux
distros always included FUSE. But inevitably we found out there were
some exceptions: https://github.com/keybase/client/issues/2368.

Note that the Arch PKGBUILD files (which build in prerelease mode, as
opposed to the community package that builds in prod mode) always
included this dependency.

r? @cjb 