### PR TITLE
Add success/paperkey screen to native

### DIFF
--- a/shared/login/signup/success/index.render.js.flow
+++ b/shared/login/signup/success/index.render.js.flow
@@ -6,7 +6,7 @@ import HiddenString from '../../../util/hidden-string'
 export type Props = {
   paperkey: HiddenString,
   onFinish: () => void,
-  onBack: () => void,
+  onBack?: () => void,
   title?: ?string
 }
 

--- a/shared/login/signup/success/index.render.native.js
+++ b/shared/login/signup/success/index.render.native.js
@@ -2,15 +2,94 @@
 /* eslint-disable react/prop-types */
 
 import React, {Component} from 'react'
-import {View} from 'react-native'
+import {globalColors, globalStyles} from '../../../styles/style-guide'
+import {Box, Checkbox, Button, Text, Icon} from '../../../common-adapters'
+import {specialStyles} from '../../../common-adapters/text'
 
 import type {Props} from './index.render'
 
-export default class Render extends Component {
-  props: Props;
+/* types:
+  paperkey: HiddenString,
+  onFinish: () => void,
+  onBack: () => void,
+  title?: ?string
+  */
+
+type State = {
+  checked: boolean
+}
+
+export default class Render extends Component<void, Props, State> {
+  state: State;
+
+  constructor (props: Props) {
+    super(props)
+    this.state = {
+      checked: false
+    }
+  }
 
   render () {
-    return <View/>
+    return (
+      <Box style={{padding: 32, flex: 1}}>
+        <Text type='Header' style={textCenter}>{this.props.title || 'Congratulations, you’ve just joined Keybase!'}</Text>
+        <Text type='BodySmall' style={{...textCenter, marginTop: 7}}>Here is your unique paper key, it will allow you to perform important Keybase tasks in the future. This is the only time you’ll see this so be sure to write it down.</Text>
+
+        <Box style={paperKeyContainerStyle}>
+          <Text type='Body' style={paperkeyStyle}>{this.props.paperkey.stringValue()}</Text>
+          <Icon type='paper-key-corner' style={paperCornerStyle}/>
+        </Box>
+
+        <Box style={confirmCheckboxStyle}>
+          <Checkbox
+            label='Yes, I wrote this down.'
+            checked={this.state.checked}
+            onCheck={checked => this.setState({checked})}/>
+        </Box>
+
+        <Box style={{flex: 2, justifyContent: 'flex-end'}}>
+          <Button style={buttonStyle}
+            disabled={!this.state.checked}
+            onClick={this.props.onFinish}
+            label='Done'
+            type='Primary'/>
+        </Box>
+      </Box>
+    )
   }
 }
 
+const confirmCheckboxStyle = {
+  ...globalStyles.flexBoxRow,
+  alignSelf: 'center'
+}
+
+const buttonStyle = {
+}
+
+const textCenter = {
+  textAlign: 'center'
+}
+
+const paperKeyContainerStyle = {
+  position: 'relative',
+  alignSelf: 'center',
+  marginTop: 32,
+  marginBottom: 65,
+  padding: 32,
+  borderRadius: 1,
+  backgroundColor: globalColors.white,
+  borderStyle: 'solid',
+  borderWidth: 4,
+  borderColor: globalColors.darkBlue
+}
+
+const paperkeyStyle = {
+  ...specialStyles.paperKey
+}
+
+const paperCornerStyle = {
+  position: 'absolute',
+  right: 0,
+  top: -4
+}

--- a/shared/more/style-sheet.render.native.js
+++ b/shared/more/style-sheet.render.native.js
@@ -5,6 +5,9 @@ import {ScrollView} from 'react-native'
 import {globalStyles, globalColors} from '../styles/style-guide'
 import Container from './dev-container.native'
 import {Dropdown, Checkbox, Button, Box, Text, Terminal, Icon} from '../common-adapters'
+import HiddenString from '../util/hidden-string'
+
+import Success from '../login/signup/success/index.render'
 
 const Space = () => <Box style={{height: 20, width: 20}}/>
 
@@ -236,8 +239,14 @@ export default class Render extends Component {
   }
 
   render () {
+    // TODO: remove Success from here when dumb components sheet is in
     return (
       <ScrollView>
+        <Container title='Success signup paperkey'>
+          <Box style={{height: 660}}>
+            <Success onFinish={() => {}} paperkey={new HiddenString('elephant bag candy asteroid laptop mug second archive pizza ring fish bumpy down')}/>
+          </Box>
+        </Container>
         <Container title='Dropdown'><Dropdowns
           selectedUser={this.state.selectedUser}
           selectUser={(selectedUser, userIdx) => this.setState({selectedUser, userIdx})}


### PR DESCRIPTION
@keybase/react-hackers 

## Preview
<img width="487" alt="screen shot 2016-04-08 at 5 29 55 pm" src="https://cloud.githubusercontent.com/assets/594035/14400664/8319549c-fdb0-11e5-96a2-d47cfc3029f7.png">

## Zeplin
<img width="345" alt="screen shot 2016-04-08 at 5 30 02 pm" src="https://cloud.githubusercontent.com/assets/594035/14400665/8319e9de-fdb0-11e5-8e56-a7e688363db8.png">

I've left a not in zeplin that the mock uses 16px fonts where we aren't using that at all. I've gone ahead and used `BodySmall` (14px) in the mean time.

The height of the component is adjustable so the spacing is a bit different than zeplin, but as soon as we put it in the right height container it'll look the same