### PR TITLE
Spring cleanup, no functional changes

### DIFF
--- a/go/client/cmd_dump_keyfamily.go
+++ b/go/client/cmd_dump_keyfamily.go
@@ -161,7 +161,7 @@ func (v *CmdDumpKeyfamily) printKey(key keybase1.PublicKey, subkeys []keybase1.P
 	dui.Printf("%sCreated: %s\n", indentSpace(indent+1), keybase1.FromTime(key.CTime))
 	dui.Printf("%sExpires: %s\n", indentSpace(indent+1), keybase1.FromTime(key.ETime))
 
-	if subkeys != nil && len(subkeys) > 0 {
+	if len(subkeys) > 0 {
 		dui.Printf("%sSubkeys:\n", indentSpace(indent+1))
 		for _, subkey := range subkeys {
 			v.printKey(subkey, nil, indent+2)

--- a/go/libkb/base64_finder.go
+++ b/go/libkb/base64_finder.go
@@ -103,7 +103,7 @@ func FindBase64Blocks(s string) []string {
 
 func FindFirstBase64Block(s string) string {
 	v := FindBase64Blocks(s)
-	if v != nil && len(v) > 0 {
+	if len(v) > 0 {
 		return v[0]
 	}
 	return ""

--- a/go/libkb/identify2_cache.go
+++ b/go/libkb/identify2_cache.go
@@ -58,7 +58,7 @@ func (c *Identify2Cache) Get(uid keybase1.UID, gctf GetCheckTimeFunc, timeout ti
 		}
 
 		thenTime := keybase1.FromTime(then)
-		if time.Now().Sub(thenTime) > timeout {
+		if time.Since(thenTime) > timeout {
 			return nil, TimeoutError{}
 		}
 	}

--- a/go/libkb/pgp_enc_test.go
+++ b/go/libkb/pgp_enc_test.go
@@ -133,7 +133,7 @@ func TestPGPEncryptQuick(t *testing.T) {
 			if err != nil {
 				return false
 			}
-			if bytes.Compare(data, msg) != 0 {
+			if !bytes.Equal(data, msg) {
 				return false
 			}
 		}

--- a/go/libkb/saltpack.go
+++ b/go/libkb/saltpack.go
@@ -127,7 +127,7 @@ func (n naclKeyring) LookupBoxSecretKey(
 	sk := (naclBoxSecretKey)(n)
 	pkKid := sk.GetPublicKey().ToKID()
 	for i, kid := range kids {
-		if bytes.Compare(pkKid, kid) == 0 {
+		if bytes.Equal(pkKid, kid) {
 			return i, sk
 		}
 	}

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -385,7 +385,7 @@ func (sc *SigChain) verifySubchain(kf KeyFamily, links []*ChainLink) (cached boo
 		sc.G().Log.Debug("- verifySubchain -> %v, %s", cached, ErrToOk(err))
 	}()
 
-	if links == nil || len(links) == 0 {
+	if len(links) == 0 {
 		err = InternalError{"verifySubchain should never get an empty chain."}
 		return
 	}
@@ -510,7 +510,7 @@ func (sc *SigChain) VerifySigsAndComputeKeys(eldest keybase1.KID, ckf *ComputedK
 		return
 	}
 
-	if links == nil || len(links) == 0 {
+	if len(links) == 0 {
 		sc.G().Log.Debug("| Empty chain after we limited to eldest %s", eldest)
 		eldestKey, _ := ckf.FindKeyWithKIDUnsafe(eldest)
 		sc.localCki = NewComputedKeyInfos(sc.G())

--- a/go/libkb/sig_chain_test.go
+++ b/go/libkb/sig_chain_test.go
@@ -190,7 +190,7 @@ func doChainTest(t *testing.T, testCase TestCase) {
 		}
 		foundType := reflect.TypeOf(sigchainErr)
 		expectedTypes := getErrorTypesMap()[testCase.ErrType]
-		if expectedTypes == nil || len(expectedTypes) == 0 {
+		if len(expectedTypes) == 0 {
 			msg := "No Go error types defined for expected failure %s.\n" +
 				"This could be because of new test cases in github.com/keybase/keybase-test-vectors.\n" +
 				"Go error returned: %s"

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -452,7 +452,7 @@ func TimeLog(name string, start time.Time, out func(string, ...interface{})) {
 }
 
 func WhitespaceNormalize(s string) string {
-	v := regexp.MustCompile("\\s+").Split(s, -1)
+	v := regexp.MustCompile(`\s+`).Split(s, -1)
 	if len(v) > 0 && len(v[0]) == 0 {
 		v = v[1:]
 	}


### PR DESCRIPTION
+ x!=nil && len(x)>0 => len(x)>0, len works fine on nil
+ bytes.Equal instead of bytes.Compare
+ time.Since
+ regexps are nicer with raw strings