### PR TITLE
include the port with stringing an fmpURI

### DIFF
--- a/go/service/rpc.go
+++ b/go/service/rpc.go
@@ -61,7 +61,7 @@ func (f *fmpURI) UseTLS() bool {
 }
 
 func (f *fmpURI) String() string {
-	return fmt.Sprintf("%s://%s", f.Scheme, f.Host)
+	return fmt.Sprintf("%s://%s", f.Scheme, f.HostPort)
 }
 
 // connTransport implements rpc.ConnectionTransport


### PR DESCRIPTION
Tiny review for @patrickxb, just to make sure we don't rely on leaving out the port anywhere.