### PR TITLE
Split NormalizeUsername into two functions

### DIFF
--- a/go/engine/prove.go
+++ b/go/engine/prove.go
@@ -23,8 +23,7 @@ type Prove struct {
 	postRes    *libkb.PostProofRes
 	signingKey libkb.GenericKey
 
-	username           string
-	usernameNormalized string
+	remoteNameNormalized string
 
 	libkb.Contextified
 }
@@ -87,30 +86,28 @@ func (p *Prove) checkExists1(ctx *Context) (err error) {
 }
 
 func (p *Prove) promptRemoteName(ctx *Context) (err error) {
-	p.username = p.arg.Username
-	if len(p.username) == 0 {
+	remoteName := p.arg.Username
+	if len(remoteName) == 0 {
 		var prevErr error
-		for len(p.username) == 0 && err == nil {
+		for len(remoteName) == 0 && err == nil {
 			var un string
 			un, err = ctx.ProveUI.PromptUsername(context.TODO(), keybase1.PromptUsernameArg{
 				Prompt:    p.st.GetPrompt(),
 				PrevError: libkb.ExportErrorAsStatus(prevErr),
 			})
 			if err == nil {
-				prevErr = p.st.CheckUsername(un)
+				remoteNameNormalized, prevErr := p.st.NormalizeRemoteName(un)
 				if prevErr == nil {
-					p.username = un
+					p.remoteNameNormalized = remoteNameNormalized
 				}
 			}
 		}
 	} else {
-		err = p.st.CheckUsername(p.username)
+		remoteNameNormalized, err := p.st.NormalizeRemoteName(remoteName)
+		if err == nil {
+			p.remoteNameNormalized = remoteNameNormalized
+		}
 	}
-	return
-}
-
-func (p *Prove) normalizeRemoteName() (err error) {
-	p.usernameNormalized, err = p.st.NormalizeUsername(p.username)
 	return
 }
 
@@ -121,7 +118,7 @@ func (p *Prove) checkExists2(ctx *Context) (err error) {
 		var found libkb.RemoteProofChainLink
 		for _, proof := range p.me.IDTable().GetActiveProofsFor(p.st) {
 			_, name := proof.ToKeyValuePair()
-			if libkb.Cicmp(name, p.usernameNormalized) {
+			if libkb.Cicmp(name, p.remoteNameNormalized) {
 				found = proof
 				break
 			}
@@ -147,7 +144,7 @@ func (p *Prove) checkExists2(ctx *Context) (err error) {
 
 func (p *Prove) doPrechecks(ctx *Context) (err error) {
 	var w *libkb.Markup
-	w, err = p.st.PreProofCheck(p.usernameNormalized)
+	w, err = p.st.PreProofCheck(p.remoteNameNormalized)
 	if w != nil {
 		if uierr := ctx.ProveUI.OutputPrechecks(context.TODO(), keybase1.OutputPrechecksArg{Text: w.Export()}); uierr != nil {
 			p.G().Log.Warning("prove ui OutputPrechecks call error: %s", uierr)
@@ -157,7 +154,7 @@ func (p *Prove) doPrechecks(ctx *Context) (err error) {
 }
 
 func (p *Prove) doWarnings(ctx *Context) (err error) {
-	if mu := p.st.PreProofWarning(p.usernameNormalized); mu != nil {
+	if mu := p.st.PreProofWarning(p.remoteNameNormalized); mu != nil {
 		var ok bool
 		arg := keybase1.PreProofWarningArg{Text: mu.Export()}
 		if ok, err = ctx.ProveUI.PreProofWarning(context.TODO(), arg); err == nil && !ok {
@@ -180,7 +177,7 @@ func (p *Prove) generateProof(ctx *Context) (err error) {
 	if p.signingKey, err = locked.GetPubKey(); err != nil {
 		return
 	}
-	if p.proof, err = p.me.ServiceProof(p.signingKey, p.st, p.usernameNormalized); err != nil {
+	if p.proof, err = p.me.ServiceProof(p.signingKey, p.st, p.remoteNameNormalized); err != nil {
 		return
 	}
 	if p.sig, p.sigID, _, err = libkb.SignJSON(p.proof, seckey); err != nil {
@@ -195,7 +192,7 @@ func (p *Prove) postProofToServer() (err error) {
 		ProofType:      p.st.GetProofType(),
 		ID:             p.sigID,
 		Supersede:      p.supersede,
-		RemoteUsername: p.usernameNormalized,
+		RemoteUsername: p.remoteNameNormalized,
 		RemoteKey:      p.st.GetAPIArgKey(),
 		SigningKey:     p.signingKey,
 	}
@@ -204,7 +201,7 @@ func (p *Prove) postProofToServer() (err error) {
 }
 
 func (p *Prove) instructAction(ctx *Context) (err error) {
-	mkp := p.st.PostInstructions(p.usernameNormalized)
+	mkp := p.st.PostInstructions(p.remoteNameNormalized)
 	var txt string
 	if txt, err = p.st.FormatProofText(p.postRes); err != nil {
 		return
@@ -223,7 +220,7 @@ func (p *Prove) promptPostedLoop(ctx *Context) (err error) {
 		var status keybase1.ProofStatus
 		var warn *libkb.Markup
 		retry, err = ctx.ProveUI.OkToCheck(context.TODO(), keybase1.OkToCheckArg{
-			Name:    p.st.DisplayName(p.usernameNormalized),
+			Name:    p.st.DisplayName(p.remoteNameNormalized),
 			Attempt: i,
 		})
 		if !retry || err != nil {
@@ -233,7 +230,7 @@ func (p *Prove) promptPostedLoop(ctx *Context) (err error) {
 		if found || err != nil {
 			break
 		}
-		warn, err = p.st.RecheckProofPosting(i, status, p.usernameNormalized)
+		warn, err = p.st.RecheckProofPosting(i, status, p.remoteNameNormalized)
 		if warn != nil {
 			uierr := ctx.ProveUI.DisplayRecheckWarning(context.TODO(), keybase1.DisplayRecheckWarningArg{
 				Text: warn.Export(),
@@ -297,10 +294,6 @@ func (p *Prove) Run(ctx *Context) (err error) {
 	}
 	stage("PromptRemoteName")
 	if err = p.promptRemoteName(ctx); err != nil {
-		return
-	}
-	stage("NormalizeRemoteName")
-	if err = p.normalizeRemoteName(); err != nil {
 		return
 	}
 	stage("CheckExists2")

--- a/go/libkb/proof_support_coinbase.go
+++ b/go/libkb/proof_support_coinbase.go
@@ -85,8 +85,10 @@ func coinbaseSettingsURL(s string) string {
 	return coinbaseUserURL(s) + "#settings"
 }
 
+var coinbaseUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_]{2,16})$`)
+
 func (t CoinbaseServiceType) NormalizeUsername(s string) (string, error) {
-	if !regexp.MustCompile(`^(?i:[a-z0-9_]{2,16})$`).MatchString(s) {
+	if !coinbaseUsernameRegexp.MatchString(s) {
 		return "", BadUsernameError{s}
 	}
 	return strings.ToLower(s), nil
@@ -94,10 +96,8 @@ func (t CoinbaseServiceType) NormalizeUsername(s string) (string, error) {
 
 func (t CoinbaseServiceType) NormalizeRemoteName(s string) (ret string, err error) {
 	// Allow a leading '@'.
-	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{2,16})$`).MatchString(s) {
-		return "", BadUsernameError{s}
-	}
-	return strings.ToLower(strings.TrimPrefix(s, "@")), nil
+	s = strings.TrimPrefix(s, "@")
+	return t.NormalizeUsername(s)
 }
 
 func (t CoinbaseServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_coinbase.go
+++ b/go/libkb/proof_support_coinbase.go
@@ -85,16 +85,15 @@ func coinbaseSettingsURL(s string) string {
 	return coinbaseUserURL(s) + "#settings"
 }
 
-func (t CoinbaseServiceType) NormalizeUsername(key, username string) (string, error) {
-	return t.NormalizeRemoteName(username)
-}
-
-func (t CoinbaseServiceType) NormalizeRemoteName(s string) (ret string, err error) {
+func (t CoinbaseServiceType) NormalizeUsername(s string) (string, error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{2,16})$`).MatchString(s) {
 		return "", BadUsernameError{s}
 	}
-	ret = strings.ToLower(s)
-	return ret, nil
+	return strings.ToLower(s), nil
+}
+
+func (t CoinbaseServiceType) NormalizeRemoteName(s string) (ret string, err error) {
+	return t.NormalizeUsername(s)
 }
 
 func (t CoinbaseServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_coinbase.go
+++ b/go/libkb/proof_support_coinbase.go
@@ -85,6 +85,10 @@ func coinbaseSettingsURL(s string) string {
 	return coinbaseUserURL(s) + "#settings"
 }
 
+func (t CoinbaseServiceType) NormalizeUsername(key, username string) (string, error) {
+	return t.NormalizeRemoteName(username)
+}
+
 func (t CoinbaseServiceType) NormalizeRemoteName(s string) (ret string, err error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{2,16})$`).MatchString(s) {
 		return "", BadUsernameError{s}

--- a/go/libkb/proof_support_coinbase.go
+++ b/go/libkb/proof_support_coinbase.go
@@ -77,13 +77,6 @@ type CoinbaseServiceType struct{ BaseServiceType }
 
 func (t CoinbaseServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-func (t CoinbaseServiceType) CheckUsername(s string) (err error) {
-	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{2,16})$`).MatchString(s) {
-		err = BadUsernameError{s}
-	}
-	return
-}
-
 func coinbaseUserURL(s string) string {
 	return "https://coinbase.com/" + s
 }
@@ -92,10 +85,9 @@ func coinbaseSettingsURL(s string) string {
 	return coinbaseUserURL(s) + "#settings"
 }
 
-func (t CoinbaseServiceType) NormalizeUsername(s string) (ret string, err error) {
-	err = t.CheckUsername(s)
-	if err != nil {
-		return "", err
+func (t CoinbaseServiceType) NormalizeRemoteName(s string) (ret string, err error) {
+	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{2,16})$`).MatchString(s) {
+		return "", BadUsernameError{s}
 	}
 	ret = strings.ToLower(s)
 	return ret, nil

--- a/go/libkb/proof_support_coinbase.go
+++ b/go/libkb/proof_support_coinbase.go
@@ -86,14 +86,18 @@ func coinbaseSettingsURL(s string) string {
 }
 
 func (t CoinbaseServiceType) NormalizeUsername(s string) (string, error) {
-	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{2,16})$`).MatchString(s) {
+	if !regexp.MustCompile(`^(?i:[a-z0-9_]{2,16})$`).MatchString(s) {
 		return "", BadUsernameError{s}
 	}
 	return strings.ToLower(s), nil
 }
 
 func (t CoinbaseServiceType) NormalizeRemoteName(s string) (ret string, err error) {
-	return t.NormalizeUsername(s)
+	// Allow a leading '@'.
+	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{2,16})$`).MatchString(s) {
+		return "", BadUsernameError{s}
+	}
+	return strings.ToLower(strings.TrimPrefix(s, "@")), nil
 }
 
 func (t CoinbaseServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_dns.go
+++ b/go/libkb/proof_support_dns.go
@@ -87,24 +87,20 @@ type DNSServiceType struct{ BaseServiceType }
 
 func (t DNSServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-func ParseDNS(s string) (ret string, err error) {
-	if strings.HasPrefix(s, "dns://") {
-		s = s[6:]
-	}
-	if !IsValidHostname(s) {
-		err = InvalidHostnameError{s}
-	} else {
-		ret = s
-	}
-	return
-}
-
 func (t DNSServiceType) NormalizeUsername(s string) (string, error) {
-	return ParseDNS(s)
+	if !IsValidHostname(s) {
+		return "", InvalidHostnameError{s}
+	}
+	return strings.ToLower(s), nil
 }
 
 func (t DNSServiceType) NormalizeRemoteName(s string) (string, error) {
-	return ParseDNS(s)
+	// Allow a leading 'dns://'.
+	s = strings.TrimPrefix(s, "dns://")
+	if !IsValidHostname(s) {
+		return "", InvalidHostnameError{s}
+	}
+	return strings.ToLower(s), nil
 }
 
 func (t DNSServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_dns.go
+++ b/go/libkb/proof_support_dns.go
@@ -95,12 +95,12 @@ func (t DNSServiceType) NormalizeUsername(s string) (string, error) {
 }
 
 func (t DNSServiceType) NormalizeRemoteName(s string) (string, error) {
-	// Allow a leading 'dns://'.
+	// Allow a leading 'dns://' and preserve case.
 	s = strings.TrimPrefix(s, "dns://")
 	if !IsValidHostname(s) {
 		return "", InvalidHostnameError{s}
 	}
-	return strings.ToLower(s), nil
+	return s, nil
 }
 
 func (t DNSServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_dns.go
+++ b/go/libkb/proof_support_dns.go
@@ -99,12 +99,7 @@ func ParseDNS(s string) (ret string, err error) {
 	return
 }
 
-func (t DNSServiceType) CheckUsername(s string) error {
-	_, e := ParseDNS(s)
-	return e
-}
-
-func (t DNSServiceType) NormalizeUsername(s string) (string, error) {
+func (t DNSServiceType) NormalizeRemoteName(s string) (string, error) {
 	return ParseDNS(s)
 }
 

--- a/go/libkb/proof_support_dns.go
+++ b/go/libkb/proof_support_dns.go
@@ -99,8 +99,8 @@ func ParseDNS(s string) (ret string, err error) {
 	return
 }
 
-func (t DNSServiceType) NormalizeUsername(key, username string) (string, error) {
-	return ParseDNS(username)
+func (t DNSServiceType) NormalizeUsername(s string) (string, error) {
+	return ParseDNS(s)
 }
 
 func (t DNSServiceType) NormalizeRemoteName(s string) (string, error) {

--- a/go/libkb/proof_support_dns.go
+++ b/go/libkb/proof_support_dns.go
@@ -99,6 +99,10 @@ func ParseDNS(s string) (ret string, err error) {
 	return
 }
 
+func (t DNSServiceType) NormalizeUsername(key, username string) (string, error) {
+	return ParseDNS(username)
+}
+
 func (t DNSServiceType) NormalizeRemoteName(s string) (string, error) {
 	return ParseDNS(s)
 }

--- a/go/libkb/proof_support_github.go
+++ b/go/libkb/proof_support_github.go
@@ -71,14 +71,18 @@ type GithubServiceType struct{ BaseServiceType }
 func (t GithubServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
 func (t GithubServiceType) NormalizeUsername(s string) (string, error) {
-	if !regexp.MustCompile(`^@?(?i:[a-z0-9][a-z0-9-]{0,38})$`).MatchString(s) {
+	if !regexp.MustCompile(`^(?i:[a-z0-9][a-z0-9-]{0,38})$`).MatchString(s) {
 		return "", BadUsernameError{s}
 	}
 	return strings.ToLower(s), nil
 }
 
 func (t GithubServiceType) NormalizeRemoteName(s string) (ret string, err error) {
-	return t.NormalizeUsername(s)
+	// Allow a leading '@'.
+	if !regexp.MustCompile(`^@?(?i:[a-z0-9][a-z0-9-]{0,38})$`).MatchString(s) {
+		return "", BadUsernameError{s}
+	}
+	return strings.ToLower(strings.TrimPrefix(s, "@")), nil
 }
 
 func (t GithubServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_github.go
+++ b/go/libkb/proof_support_github.go
@@ -70,8 +70,10 @@ type GithubServiceType struct{ BaseServiceType }
 
 func (t GithubServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
+var githubUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9][a-z0-9-]{0,38})$`)
+
 func (t GithubServiceType) NormalizeUsername(s string) (string, error) {
-	if !regexp.MustCompile(`^(?i:[a-z0-9][a-z0-9-]{0,38})$`).MatchString(s) {
+	if !githubUsernameRegexp.MatchString(s) {
 		return "", BadUsernameError{s}
 	}
 	return strings.ToLower(s), nil
@@ -79,10 +81,8 @@ func (t GithubServiceType) NormalizeUsername(s string) (string, error) {
 
 func (t GithubServiceType) NormalizeRemoteName(s string) (ret string, err error) {
 	// Allow a leading '@'.
-	if !regexp.MustCompile(`^@?(?i:[a-z0-9][a-z0-9-]{0,38})$`).MatchString(s) {
-		return "", BadUsernameError{s}
-	}
-	return strings.ToLower(strings.TrimPrefix(s, "@")), nil
+	s = strings.TrimPrefix(s, "@")
+	return t.NormalizeUsername(s)
 }
 
 func (t GithubServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_github.go
+++ b/go/libkb/proof_support_github.go
@@ -70,16 +70,15 @@ type GithubServiceType struct{ BaseServiceType }
 
 func (t GithubServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-func (t GithubServiceType) NormalizeUsername(key, username string) (string, error) {
-	return t.NormalizeRemoteName(username)
-}
-
-func (t GithubServiceType) NormalizeRemoteName(s string) (ret string, err error) {
+func (t GithubServiceType) NormalizeUsername(s string) (string, error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9][a-z0-9-]{0,38})$`).MatchString(s) {
 		return "", BadUsernameError{s}
 	}
-	ret = strings.ToLower(s)
-	return ret, nil
+	return strings.ToLower(s), nil
+}
+
+func (t GithubServiceType) NormalizeRemoteName(s string) (ret string, err error) {
+	return t.NormalizeUsername(s)
 }
 
 func (t GithubServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_github.go
+++ b/go/libkb/proof_support_github.go
@@ -70,6 +70,10 @@ type GithubServiceType struct{ BaseServiceType }
 
 func (t GithubServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
+func (t GithubServiceType) NormalizeUsername(key, username string) (string, error) {
+	return t.NormalizeRemoteName(username)
+}
+
 func (t GithubServiceType) NormalizeRemoteName(s string) (ret string, err error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9][a-z0-9-]{0,38})$`).MatchString(s) {
 		return "", BadUsernameError{s}

--- a/go/libkb/proof_support_github.go
+++ b/go/libkb/proof_support_github.go
@@ -70,11 +70,12 @@ type GithubServiceType struct{ BaseServiceType }
 
 func (t GithubServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-func (t GithubServiceType) CheckUsername(s string) (err error) {
+func (t GithubServiceType) NormalizeRemoteName(s string) (ret string, err error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9][a-z0-9-]{0,38})$`).MatchString(s) {
-		err = BadUsernameError{s}
+		return "", BadUsernameError{s}
 	}
-	return
+	ret = strings.ToLower(s)
+	return ret, nil
 }
 
 func (t GithubServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_hackernews.go
+++ b/go/libkb/proof_support_hackernews.go
@@ -100,15 +100,11 @@ type HackerNewsServiceType struct{ BaseServiceType }
 
 func (t HackerNewsServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-func (t HackerNewsServiceType) CheckUsername(s string) (err error) {
-	if !regexp.MustCompile(`^@?(?i:[a-z0-9_-]{2,15})$`).MatchString(s) {
-		err = BadUsernameError{s}
-	}
-	return
-}
-
 // HackerNews names are case-sensitive
-func (t HackerNewsServiceType) NormalizeUsername(s string) (string, error) {
+func (t HackerNewsServiceType) NormalizeRemoteName(s string) (string, error) {
+	if !regexp.MustCompile(`^@?(?i:[a-z0-9_-]{2,15})$`).MatchString(s) {
+		return "", BadUsernameError{s}
+	}
 	return s, nil
 }
 

--- a/go/libkb/proof_support_hackernews.go
+++ b/go/libkb/proof_support_hackernews.go
@@ -100,16 +100,21 @@ type HackerNewsServiceType struct{ BaseServiceType }
 
 func (t HackerNewsServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-// HackerNews names are case-sensitive
 func (t HackerNewsServiceType) NormalizeUsername(s string) (string, error) {
-	if !regexp.MustCompile(`^@?(?i:[a-z0-9_-]{2,15})$`).MatchString(s) {
+	if !regexp.MustCompile(`^(?i:[a-z0-9_-]{2,15})$`).MatchString(s) {
 		return "", BadUsernameError{s}
 	}
+	// HackerNews names are case-sensitive
 	return s, nil
 }
 
 func (t HackerNewsServiceType) NormalizeRemoteName(s string) (string, error) {
-	return t.NormalizeUsername(s)
+	// Allow a leading '@'.
+	if !regexp.MustCompile(`^@?(?i:[a-z0-9_-]{2,15})$`).MatchString(s) {
+		return "", BadUsernameError{s}
+	}
+	// HackerNews names are case-sensitive
+	return strings.TrimPrefix(s, "@"), nil
 }
 
 func (t HackerNewsServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_hackernews.go
+++ b/go/libkb/proof_support_hackernews.go
@@ -100,16 +100,16 @@ type HackerNewsServiceType struct{ BaseServiceType }
 
 func (t HackerNewsServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-func (t HackerNewsServiceType) NormalizeUsername(key, username string) (string, error) {
-	return t.NormalizeRemoteName(username)
-}
-
 // HackerNews names are case-sensitive
-func (t HackerNewsServiceType) NormalizeRemoteName(s string) (string, error) {
+func (t HackerNewsServiceType) NormalizeUsername(s string) (string, error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9_-]{2,15})$`).MatchString(s) {
 		return "", BadUsernameError{s}
 	}
 	return s, nil
+}
+
+func (t HackerNewsServiceType) NormalizeRemoteName(s string) (string, error) {
+	return t.NormalizeRemoteName(s)
 }
 
 func (t HackerNewsServiceType) CaseSensitiveUsername() bool {

--- a/go/libkb/proof_support_hackernews.go
+++ b/go/libkb/proof_support_hackernews.go
@@ -112,10 +112,6 @@ func (t HackerNewsServiceType) NormalizeRemoteName(s string) (string, error) {
 	return t.NormalizeRemoteName(s)
 }
 
-func (t HackerNewsServiceType) CaseSensitiveUsername() bool {
-	return true
-}
-
 func (t HackerNewsServiceType) ToChecker() Checker {
 	return t.BaseToChecker(t, "alphanumeric, 2 to 15 characters")
 }

--- a/go/libkb/proof_support_hackernews.go
+++ b/go/libkb/proof_support_hackernews.go
@@ -100,8 +100,10 @@ type HackerNewsServiceType struct{ BaseServiceType }
 
 func (t HackerNewsServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
+var hackerNewsUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_-]{2,15})$`)
+
 func (t HackerNewsServiceType) NormalizeUsername(s string) (string, error) {
-	if !regexp.MustCompile(`^(?i:[a-z0-9_-]{2,15})$`).MatchString(s) {
+	if !hackerNewsUsernameRegexp.MatchString(s) {
 		return "", BadUsernameError{s}
 	}
 	// HackerNews names are case-sensitive
@@ -110,11 +112,8 @@ func (t HackerNewsServiceType) NormalizeUsername(s string) (string, error) {
 
 func (t HackerNewsServiceType) NormalizeRemoteName(s string) (string, error) {
 	// Allow a leading '@'.
-	if !regexp.MustCompile(`^@?(?i:[a-z0-9_-]{2,15})$`).MatchString(s) {
-		return "", BadUsernameError{s}
-	}
-	// HackerNews names are case-sensitive
-	return strings.TrimPrefix(s, "@"), nil
+	s = strings.TrimPrefix(s, "@")
+	return t.NormalizeUsername(s)
 }
 
 func (t HackerNewsServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_hackernews.go
+++ b/go/libkb/proof_support_hackernews.go
@@ -109,7 +109,7 @@ func (t HackerNewsServiceType) NormalizeUsername(s string) (string, error) {
 }
 
 func (t HackerNewsServiceType) NormalizeRemoteName(s string) (string, error) {
-	return t.NormalizeRemoteName(s)
+	return t.NormalizeUsername(s)
 }
 
 func (t HackerNewsServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_hackernews.go
+++ b/go/libkb/proof_support_hackernews.go
@@ -100,6 +100,10 @@ type HackerNewsServiceType struct{ BaseServiceType }
 
 func (t HackerNewsServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
+func (t HackerNewsServiceType) NormalizeUsername(key, username string) (string, error) {
+	return t.NormalizeRemoteName(username)
+}
+
 // HackerNews names are case-sensitive
 func (t HackerNewsServiceType) NormalizeRemoteName(s string) (string, error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9_-]{2,15})$`).MatchString(s) {

--- a/go/libkb/proof_support_reddit.go
+++ b/go/libkb/proof_support_reddit.go
@@ -151,6 +151,10 @@ type RedditServiceType struct{ BaseServiceType }
 
 func (t RedditServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
+func (t RedditServiceType) NormalizeUsername(key, username string) (string, error) {
+	return t.NormalizeRemoteName(username)
+}
+
 func (t RedditServiceType) NormalizeRemoteName(s string) (ret string, err error) {
 	if !regexp.MustCompile(`^(?i:[a-z0-9_-]{3,20})$`).MatchString(s) {
 		return "", BadUsernameError{s}

--- a/go/libkb/proof_support_reddit.go
+++ b/go/libkb/proof_support_reddit.go
@@ -151,11 +151,12 @@ type RedditServiceType struct{ BaseServiceType }
 
 func (t RedditServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-func (t RedditServiceType) CheckUsername(s string) (err error) {
+func (t RedditServiceType) NormalizeRemoteName(s string) (ret string, err error) {
 	if !regexp.MustCompile(`^(?i:[a-z0-9_-]{3,20})$`).MatchString(s) {
-		err = BadUsernameError{s}
+		return "", BadUsernameError{s}
 	}
-	return
+	ret = strings.ToLower(s)
+	return ret, nil
 }
 
 func (t RedditServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_reddit.go
+++ b/go/libkb/proof_support_reddit.go
@@ -151,8 +151,10 @@ type RedditServiceType struct{ BaseServiceType }
 
 func (t RedditServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
+var redditUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_-]{3,20})$`)
+
 func (t RedditServiceType) NormalizeUsername(s string) (string, error) {
-	if !regexp.MustCompile(`^(?i:[a-z0-9_-]{3,20})$`).MatchString(s) {
+	if !redditUsernameRegexp.MatchString(s) {
 		return "", BadUsernameError{s}
 	}
 	return strings.ToLower(s), nil

--- a/go/libkb/proof_support_reddit.go
+++ b/go/libkb/proof_support_reddit.go
@@ -151,16 +151,15 @@ type RedditServiceType struct{ BaseServiceType }
 
 func (t RedditServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-func (t RedditServiceType) NormalizeUsername(key, username string) (string, error) {
-	return t.NormalizeRemoteName(username)
-}
-
-func (t RedditServiceType) NormalizeRemoteName(s string) (ret string, err error) {
+func (t RedditServiceType) NormalizeUsername(s string) (string, error) {
 	if !regexp.MustCompile(`^(?i:[a-z0-9_-]{3,20})$`).MatchString(s) {
 		return "", BadUsernameError{s}
 	}
-	ret = strings.ToLower(s)
-	return ret, nil
+	return strings.ToLower(s), nil
+}
+
+func (t RedditServiceType) NormalizeRemoteName(s string) (ret string, err error) {
+	return t.NormalizeUsername(s)
 }
 
 func (t RedditServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_rooter.go
+++ b/go/libkb/proof_support_rooter.go
@@ -161,14 +161,10 @@ type RooterServiceType struct{ BaseServiceType }
 
 func (t RooterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-func (t RooterServiceType) CheckUsername(s string) (err error) {
+func (t RooterServiceType) NormalizeRemoteName(s string) (string, error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
-		err = BadUsernameError{s}
+		return "", BadUsernameError{s}
 	}
-	return
-}
-
-func (t RooterServiceType) NormalizeUsername(s string) (string, error) {
 	if len(s) > 0 && s[0] == '@' {
 		s = s[1:]
 	}

--- a/go/libkb/proof_support_rooter.go
+++ b/go/libkb/proof_support_rooter.go
@@ -172,7 +172,7 @@ func (t RooterServiceType) NormalizeUsername(s string) (string, error) {
 }
 
 func (t RooterServiceType) NormalizeRemoteName(s string) (string, error) {
-	return t.NormalizeRemoteName(s)
+	return t.NormalizeUsername(s)
 }
 
 func (t RooterServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_rooter.go
+++ b/go/libkb/proof_support_rooter.go
@@ -173,10 +173,7 @@ func (t RooterServiceType) NormalizeRemoteName(s string) (string, error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
 		return "", BadUsernameError{s}
 	}
-	if len(s) > 0 && s[0] == '@' {
-		s = s[1:]
-	}
-	return strings.ToLower(s), nil
+	return strings.ToLower(strings.TrimPrefix(s, "@")), nil
 }
 
 func (t RooterServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_rooter.go
+++ b/go/libkb/proof_support_rooter.go
@@ -162,6 +162,14 @@ type RooterServiceType struct{ BaseServiceType }
 func (t RooterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
 func (t RooterServiceType) NormalizeUsername(s string) (string, error) {
+	if !regexp.MustCompile(`^(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
+		return "", BadUsernameError{s}
+	}
+	return strings.ToLower(s), nil
+}
+
+func (t RooterServiceType) NormalizeRemoteName(s string) (string, error) {
+	// Allow a leading '@'.
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
 		return "", BadUsernameError{s}
 	}
@@ -169,10 +177,6 @@ func (t RooterServiceType) NormalizeUsername(s string) (string, error) {
 		s = s[1:]
 	}
 	return strings.ToLower(s), nil
-}
-
-func (t RooterServiceType) NormalizeRemoteName(s string) (string, error) {
-	return t.NormalizeUsername(s)
 }
 
 func (t RooterServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_rooter.go
+++ b/go/libkb/proof_support_rooter.go
@@ -161,6 +161,10 @@ type RooterServiceType struct{ BaseServiceType }
 
 func (t RooterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
+func (t RooterServiceType) NormalizeUsername(key, username string) (string, error) {
+	return t.NormalizeRemoteName(username)
+}
+
 func (t RooterServiceType) NormalizeRemoteName(s string) (string, error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
 		return "", BadUsernameError{s}

--- a/go/libkb/proof_support_rooter.go
+++ b/go/libkb/proof_support_rooter.go
@@ -161,8 +161,10 @@ type RooterServiceType struct{ BaseServiceType }
 
 func (t RooterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
+var rooterUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_]{1,20})$`)
+
 func (t RooterServiceType) NormalizeUsername(s string) (string, error) {
-	if !regexp.MustCompile(`^(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
+	if !rooterUsernameRegexp.MatchString(s) {
 		return "", BadUsernameError{s}
 	}
 	return strings.ToLower(s), nil
@@ -170,10 +172,8 @@ func (t RooterServiceType) NormalizeUsername(s string) (string, error) {
 
 func (t RooterServiceType) NormalizeRemoteName(s string) (string, error) {
 	// Allow a leading '@'.
-	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
-		return "", BadUsernameError{s}
-	}
-	return strings.ToLower(strings.TrimPrefix(s, "@")), nil
+	s = strings.TrimPrefix(s, "@")
+	return t.NormalizeUsername(s)
 }
 
 func (t RooterServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_rooter.go
+++ b/go/libkb/proof_support_rooter.go
@@ -161,11 +161,7 @@ type RooterServiceType struct{ BaseServiceType }
 
 func (t RooterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-func (t RooterServiceType) NormalizeUsername(key, username string) (string, error) {
-	return t.NormalizeRemoteName(username)
-}
-
-func (t RooterServiceType) NormalizeRemoteName(s string) (string, error) {
+func (t RooterServiceType) NormalizeUsername(s string) (string, error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
 		return "", BadUsernameError{s}
 	}
@@ -173,6 +169,10 @@ func (t RooterServiceType) NormalizeRemoteName(s string) (string, error) {
 		s = s[1:]
 	}
 	return strings.ToLower(s), nil
+}
+
+func (t RooterServiceType) NormalizeRemoteName(s string) (string, error) {
+	return t.NormalizeRemoteName(s)
 }
 
 func (t RooterServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_twitter.go
+++ b/go/libkb/proof_support_twitter.go
@@ -120,11 +120,7 @@ type TwitterServiceType struct{ BaseServiceType }
 
 func (t TwitterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-func (t TwitterServiceType) NormalizeUsername(key, username string) (string, error) {
-	return t.NormalizeRemoteName(username)
-}
-
-func (t TwitterServiceType) NormalizeRemoteName(s string) (string, error) {
+func (t TwitterServiceType) NormalizeUsername(s string) (string, error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
 		return "", BadUsernameError{s}
 	}
@@ -132,6 +128,10 @@ func (t TwitterServiceType) NormalizeRemoteName(s string) (string, error) {
 		s = s[1:]
 	}
 	return strings.ToLower(s), nil
+}
+
+func (t TwitterServiceType) NormalizeRemoteName(s string) (string, error) {
+	return t.NormalizeRemoteName(s)
 }
 
 func (t TwitterServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_twitter.go
+++ b/go/libkb/proof_support_twitter.go
@@ -120,6 +120,10 @@ type TwitterServiceType struct{ BaseServiceType }
 
 func (t TwitterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
+func (t TwitterServiceType) NormalizeUsername(key, username string) (string, error) {
+	return t.NormalizeRemoteName(username)
+}
+
 func (t TwitterServiceType) NormalizeRemoteName(s string) (string, error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
 		return "", BadUsernameError{s}

--- a/go/libkb/proof_support_twitter.go
+++ b/go/libkb/proof_support_twitter.go
@@ -120,14 +120,10 @@ type TwitterServiceType struct{ BaseServiceType }
 
 func (t TwitterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-func (t TwitterServiceType) CheckUsername(s string) (err error) {
+func (t TwitterServiceType) NormalizeRemoteName(s string) (string, error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
-		err = BadUsernameError{s}
+		return "", BadUsernameError{s}
 	}
-	return
-}
-
-func (t TwitterServiceType) NormalizeUsername(s string) (string, error) {
 	if len(s) > 0 && s[0] == '@' {
 		s = s[1:]
 	}

--- a/go/libkb/proof_support_twitter.go
+++ b/go/libkb/proof_support_twitter.go
@@ -120,8 +120,10 @@ type TwitterServiceType struct{ BaseServiceType }
 
 func (t TwitterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
+var twitterUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_]{1,20})$`)
+
 func (t TwitterServiceType) NormalizeUsername(s string) (string, error) {
-	if !regexp.MustCompile(`^(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
+	if !twitterUsernameRegexp.MatchString(s) {
 		return "", BadUsernameError{s}
 	}
 	return strings.ToLower(s), nil
@@ -129,10 +131,8 @@ func (t TwitterServiceType) NormalizeUsername(s string) (string, error) {
 
 func (t TwitterServiceType) NormalizeRemoteName(s string) (string, error) {
 	// Allow a leading '@'.
-	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
-		return "", BadUsernameError{s}
-	}
-	return strings.ToLower(strings.TrimPrefix(s, "@")), nil
+	s = strings.TrimPrefix(s, "@")
+	return t.NormalizeUsername(s)
 }
 
 func (t TwitterServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_twitter.go
+++ b/go/libkb/proof_support_twitter.go
@@ -132,10 +132,7 @@ func (t TwitterServiceType) NormalizeRemoteName(s string) (string, error) {
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
 		return "", BadUsernameError{s}
 	}
-	if len(s) > 0 && s[0] == '@' {
-		s = s[1:]
-	}
-	return strings.ToLower(s), nil
+	return strings.ToLower(strings.TrimPrefix(s, "@")), nil
 }
 
 func (t TwitterServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_twitter.go
+++ b/go/libkb/proof_support_twitter.go
@@ -131,7 +131,7 @@ func (t TwitterServiceType) NormalizeUsername(s string) (string, error) {
 }
 
 func (t TwitterServiceType) NormalizeRemoteName(s string) (string, error) {
-	return t.NormalizeRemoteName(s)
+	return t.NormalizeUsername(s)
 }
 
 func (t TwitterServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_twitter.go
+++ b/go/libkb/proof_support_twitter.go
@@ -121,6 +121,14 @@ type TwitterServiceType struct{ BaseServiceType }
 func (t TwitterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
 func (t TwitterServiceType) NormalizeUsername(s string) (string, error) {
+	if !regexp.MustCompile(`^(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
+		return "", BadUsernameError{s}
+	}
+	return strings.ToLower(s), nil
+}
+
+func (t TwitterServiceType) NormalizeRemoteName(s string) (string, error) {
+	// Allow a leading '@'.
 	if !regexp.MustCompile(`^@?(?i:[a-z0-9_]{1,20})$`).MatchString(s) {
 		return "", BadUsernameError{s}
 	}
@@ -128,10 +136,6 @@ func (t TwitterServiceType) NormalizeUsername(s string) (string, error) {
 		s = s[1:]
 	}
 	return strings.ToLower(s), nil
-}
-
-func (t TwitterServiceType) NormalizeRemoteName(s string) (string, error) {
-	return t.NormalizeUsername(s)
 }
 
 func (t TwitterServiceType) ToChecker() Checker {

--- a/go/libkb/proof_support_web.go
+++ b/go/libkb/proof_support_web.go
@@ -92,7 +92,7 @@ func (t WebServiceType) AllStringKeys() []string     { return []string{"web", "h
 func (t WebServiceType) PrimaryStringKeys() []string { return []string{"https", "http"} }
 
 func (t WebServiceType) NormalizeUsername(s string) (ret string, err error) {
-	// The username is just the hostname.
+	// The username is just the (lowercased) hostname.
 	if !IsValidHostname(s) {
 		return "", InvalidHostnameError{s}
 	}
@@ -108,13 +108,13 @@ func ParseWeb(s string) (hostname string, prot string, err error) {
 	if !IsValidHostname(s) {
 		err = InvalidHostnameError{s}
 	} else {
-		hostname = strings.ToLower(s)
+		hostname = s
 	}
 	return
 }
 
 func (t WebServiceType) NormalizeRemoteName(s string) (ret string, err error) {
-	// The remote name is a full URL.
+	// The remote name is a full (case-preserved) URL.
 	var prot, host string
 	if host, prot, err = ParseWeb(s); err != nil {
 		return

--- a/go/libkb/proof_support_web.go
+++ b/go/libkb/proof_support_web.go
@@ -91,6 +91,10 @@ type WebServiceType struct{ BaseServiceType }
 func (t WebServiceType) AllStringKeys() []string     { return []string{"web", "http", "https"} }
 func (t WebServiceType) PrimaryStringKeys() []string { return []string{"https", "http"} }
 
+func (t WebServiceType) NormalizeUsername(key, s string) (ret string, err error) {
+	return strings.ToLower(s), nil
+}
+
 func ParseWeb(s string) (hostname string, prot string, err error) {
 	rxx := regexp.MustCompile("^(http(s?))://(.*)$")
 	if v := rxx.FindStringSubmatch(s); v != nil {
@@ -100,7 +104,7 @@ func ParseWeb(s string) (hostname string, prot string, err error) {
 	if !IsValidHostname(s) {
 		err = InvalidHostnameError{s}
 	} else {
-		hostname = s
+		hostname = strings.ToLower(s)
 	}
 	return
 }

--- a/go/libkb/proof_support_web.go
+++ b/go/libkb/proof_support_web.go
@@ -105,12 +105,7 @@ func ParseWeb(s string) (hostname string, prot string, err error) {
 	return
 }
 
-func (t WebServiceType) CheckUsername(s string) error {
-	_, _, e := ParseWeb(s)
-	return e
-}
-
-func (t WebServiceType) NormalizeUsername(s string) (ret string, err error) {
+func (t WebServiceType) NormalizeRemoteName(s string) (ret string, err error) {
 	var prot, host string
 	if host, prot, err = ParseWeb(s); err != nil {
 		return

--- a/go/libkb/proof_support_web.go
+++ b/go/libkb/proof_support_web.go
@@ -93,6 +93,9 @@ func (t WebServiceType) PrimaryStringKeys() []string { return []string{"https", 
 
 func (t WebServiceType) NormalizeUsername(s string) (ret string, err error) {
 	// The username is just the hostname.
+	if !IsValidHostname(s) {
+		return "", InvalidHostnameError{s}
+	}
 	return strings.ToLower(s), nil
 }
 

--- a/go/libkb/proof_support_web.go
+++ b/go/libkb/proof_support_web.go
@@ -91,7 +91,8 @@ type WebServiceType struct{ BaseServiceType }
 func (t WebServiceType) AllStringKeys() []string     { return []string{"web", "http", "https"} }
 func (t WebServiceType) PrimaryStringKeys() []string { return []string{"https", "http"} }
 
-func (t WebServiceType) NormalizeUsername(key, s string) (ret string, err error) {
+func (t WebServiceType) NormalizeUsername(s string) (ret string, err error) {
+	// The username is just the hostname.
 	return strings.ToLower(s), nil
 }
 
@@ -110,6 +111,7 @@ func ParseWeb(s string) (hostname string, prot string, err error) {
 }
 
 func (t WebServiceType) NormalizeRemoteName(s string) (ret string, err error) {
+	// The remote name is a full URL.
 	var prot, host string
 	if host, prot, err = ParseWeb(s); err != nil {
 		return

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -13,7 +13,7 @@ import (
 
 type ServiceType interface {
 	AllStringKeys() []string
-	NormalizeUsername(key, username string) (string, error)
+	NormalizeUsername(string) (string, error)
 	NormalizeRemoteName(string) (string, error)
 	CaseSensitiveUsername() bool
 	ToChecker() Checker

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -13,8 +13,16 @@ import (
 
 type ServiceType interface {
 	AllStringKeys() []string
+
+	// NormalizeUsername normalizes the given username, assuming
+	// that it's free of any leading strings like '@' or 'dns://'.
 	NormalizeUsername(string) (string, error)
+
+	// NormalizeRemote normalizes the given remote username, which
+	// is usually but not always the same as the username. It also
+	// allows leaders like '@' and 'dns://'.
 	NormalizeRemoteName(string) (string, error)
+
 	ToChecker() Checker
 	GetPrompt() string
 	LastWriterWins() bool

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -13,18 +13,17 @@ import (
 
 type ServiceType interface {
 	AllStringKeys() []string
-	CheckUsername(string) error
-	NormalizeUsername(string) (string, error)
+	NormalizeRemoteName(string) (string, error)
 	CaseSensitiveUsername() bool
 	ToChecker() Checker
 	GetPrompt() string
 	LastWriterWins() bool
-	PreProofCheck(username string) (*Markup, error)
+	PreProofCheck(remotename string) (*Markup, error)
 	PreProofWarning(remotename string) *Markup
 	ToServiceJSON(remotename string) *jsonw.Wrapper
 	PostInstructions(remotename string) *Markup
-	DisplayName(username string) string
-	RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, username string) (warning *Markup, err error)
+	DisplayName(remotename string) string
+	RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, remotename string) (warning *Markup, err error)
 	GetProofType() string
 	GetTypeName() string
 	CheckProofText(text string, id keybase1.SigID, sig string) error
@@ -87,7 +86,10 @@ func (t BaseServiceType) BaseGetProofType(st ServiceType) string {
 
 func (t BaseServiceType) BaseToChecker(st ServiceType, hint string) Checker {
 	return Checker{
-		F:             func(s string) bool { return (st.CheckUsername(s) == nil) },
+		F: func(s string) bool {
+			_, err := st.NormalizeRemoteName(s)
+			return (err == nil)
+		},
 		Hint:          hint,
 		PreserveSpace: false,
 	}
@@ -129,13 +131,13 @@ func (t BaseServiceType) BaseCheckProofTextFull(text string, id keybase1.SigID, 
 	return
 }
 
-func (t BaseServiceType) NormalizeUsername(s string) (string, error) {
+func (t BaseServiceType) NormalizeRemoteName(s string) (string, error) {
 	return strings.ToLower(s), nil
 }
 
-// Note: this is a bit of duplication of NormalizeUsername(), but
+// Note: this is a bit of duplication of NormalizeRemoteName(), but
 // there are some ServiceType implementations (coinbase) that do
-// more than username normalization in their NormalizeUsername()
+// more than username normalization in their NormalizeRemoteName()
 // function.
 func (t BaseServiceType) CaseSensitiveUsername() bool {
 	return false

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -131,10 +131,6 @@ func (t BaseServiceType) BaseCheckProofTextFull(text string, id keybase1.SigID, 
 	return
 }
 
-func (t BaseServiceType) NormalizeRemoteName(s string) (string, error) {
-	return strings.ToLower(s), nil
-}
-
 // Note: this is a bit of duplication of NormalizeRemoteName(), but
 // there are some ServiceType implementations (coinbase) that do
 // more than username normalization in their NormalizeRemoteName()

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -13,6 +13,7 @@ import (
 
 type ServiceType interface {
 	AllStringKeys() []string
+	NormalizeUsername(key, username string) (string, error)
 	NormalizeRemoteName(string) (string, error)
 	CaseSensitiveUsername() bool
 	ToChecker() Checker

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -15,7 +15,6 @@ type ServiceType interface {
 	AllStringKeys() []string
 	NormalizeUsername(string) (string, error)
 	NormalizeRemoteName(string) (string, error)
-	CaseSensitiveUsername() bool
 	ToChecker() Checker
 	GetPrompt() string
 	LastWriterWins() bool
@@ -130,14 +129,6 @@ func (t BaseServiceType) BaseCheckProofTextFull(text string, id keybase1.SigID, 
 		err = NotFoundError{"Couldn't find signature ID " + target + " in text"}
 	}
 	return
-}
-
-// Note: this is a bit of duplication of NormalizeRemoteName(), but
-// there are some ServiceType implementations (coinbase) that do
-// more than username normalization in their NormalizeRemoteName()
-// function.
-func (t BaseServiceType) CaseSensitiveUsername() bool {
-	return false
 }
 
 func (t BaseServiceType) BaseCheckProofForURL(text string, id keybase1.SigID) (err error) {

--- a/go/libkb/social_assertion.go
+++ b/go/libkb/social_assertion.go
@@ -4,7 +4,6 @@
 package libkb
 
 import (
-	"fmt"
 	"strings"
 
 	keybase1 "github.com/keybase/client/go/protocol"
@@ -57,9 +56,4 @@ func NormalizeSocialAssertion(s string) (keybase1.SocialAssertion, bool) {
 		User:    name,
 		Service: keybase1.SocialAssertionService(service),
 	}, true
-}
-
-// SocialAssertionToString returns a string that represents a social assertion.
-func SocialAssertionToString(assertion keybase1.SocialAssertion) string {
-	return fmt.Sprintf("%s@%s", assertion.User, assertion.Service)
 }

--- a/go/libkb/social_assertion.go
+++ b/go/libkb/social_assertion.go
@@ -48,8 +48,9 @@ func NormalizeSocialAssertion(s string) (keybase1.SocialAssertion, bool) {
 	}
 
 	st := GetServiceType(service)
-	if !st.CaseSensitiveUsername() {
-		name = strings.ToLower(name)
+	name, err := st.NormalizeUsername(name)
+	if err != nil {
+		return keybase1.SocialAssertion{}, false
 	}
 
 	return keybase1.SocialAssertion{

--- a/go/libkb/social_assertion_test.go
+++ b/go/libkb/social_assertion_test.go
@@ -22,6 +22,7 @@ var nsatests = []nsatest{
 	{in: "Twitter:alice", out: keybase1.SocialAssertion{User: "alice", Service: "twitter"}, ok: true},
 	{in: "twitter:Alice", out: keybase1.SocialAssertion{User: "alice", Service: "twitter"}, ok: true},
 	{in: "AlicE@twitter", out: keybase1.SocialAssertion{User: "alice", Service: "twitter"}, ok: true},
+	{in: "012345678901234567891@twitter", out: keybase1.SocialAssertion{}, ok: false},
 	{in: "bob@foo@bar", out: keybase1.SocialAssertion{}, ok: false},
 	{in: "foo:bar:bob", out: keybase1.SocialAssertion{}, ok: false},
 	{in: "foo:bob@bar", out: keybase1.SocialAssertion{}, ok: false},
@@ -31,6 +32,7 @@ var nsatests = []nsatest{
 	{in: "BOB@reddit", out: keybase1.SocialAssertion{User: "bob", Service: "reddit"}, ok: true},
 	{in: "BOB@rooter", out: keybase1.SocialAssertion{User: "bob", Service: "rooter"}, ok: true},
 	{in: "BOB@facebook", out: keybase1.SocialAssertion{}, ok: false},
+	{in: "Akalin.Com@web", out: keybase1.SocialAssertion{User: "akalin.com", Service: "web"}, ok: true},
 }
 
 func TestNormalizeSocialAssertion(t *testing.T) {

--- a/go/libkb/social_assertion_test.go
+++ b/go/libkb/social_assertion_test.go
@@ -18,6 +18,8 @@ type nsatest struct {
 var nsatests = []nsatest{
 	{in: "keybase", out: keybase1.SocialAssertion{}, ok: false},
 	{in: "alice@twitter", out: keybase1.SocialAssertion{User: "alice", Service: "twitter"}, ok: true},
+	{in: "alice@twitter+bob@twitter", out: keybase1.SocialAssertion{}, ok: false},
+	{in: "alice+bob@twitter", out: keybase1.SocialAssertion{}, ok: false},
 	{in: "twitter:alice", out: keybase1.SocialAssertion{User: "alice", Service: "twitter"}, ok: true},
 	{in: "Twitter:alice", out: keybase1.SocialAssertion{User: "alice", Service: "twitter"}, ok: true},
 	{in: "twitter:Alice", out: keybase1.SocialAssertion{User: "alice", Service: "twitter"}, ok: true},

--- a/go/protocol/extras.go
+++ b/go/protocol/extras.go
@@ -563,3 +563,7 @@ func (r BlockReference) String() string {
 func (r BlockReferenceCount) String() string {
 	return fmt.Sprintf("%s,%d", r.Ref.String(), r.LiveCount)
 }
+
+func (sa SocialAssertion) String() string {
+	return fmt.Sprintf("%s@%s", sa.User, sa.Service)
+}


### PR DESCRIPTION
Use NormalizeUsername for verifying social
assertion names, and NormalizeRemoteName
for the prove command.

Clean up the normalization for every service.

Also move SocialAssertion string method
into extras.go.