### PR TITLE
Latest should be after promote

### DIFF
--- a/packaging/prerelease/s3_index.sh
+++ b/packaging/prerelease/s3_index.sh
@@ -39,11 +39,11 @@ else
   exit 1
 fi
 
-echo "Linking latest ($platform)"
-"$release_bin" latest --bucket-name="$bucket_name" --platform="$platform"
-
 echo "Checking if we need to promote a release for testing ($platform)"
 "$release_bin" promote-test-releases --bucket-name="$bucket_name" --platform="$platform"
 
 echo "Checking if we need to promote a release ($platform)"
 "$release_bin" promote-releases --bucket-name="$bucket_name" --platform="$platform"
+
+echo "Linking latest ($platform)"
+"$release_bin" latest --bucket-name="$bucket_name" --platform="$platform"


### PR DESCRIPTION
@cjb 

Because we removed update.json to stop updates, the copy latest breaks... if we move it to after the promote then it will be ok... this is also desirable behavior