### PR TITLE
Have watchdog check if service is already running. Change pipe timeou…

### DIFF
--- a/go/libkb/socket_windows.go
+++ b/go/libkb/socket_windows.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/natefinch/npipe"
 )
@@ -38,7 +39,7 @@ func (s SocketInfo) BindToSocket() (ret net.Listener, err error) {
 }
 
 func (s SocketInfo) DialSocket() (ret net.Conn, err error) {
-	pipe, err := npipe.DialTimeout(s.file, 10)
+	pipe, err := npipe.DialTimeout(s.file, time.Duration(1)*time.Second)
 	if err != nil {
 		// Be sure to return a nil interface, and not a nil npipe.PipeConn
 		// See https://keybase.atlassian.net/browse/CORE-2675 for when this


### PR DESCRIPTION
…t from 10 nanoseconds to 1 second.

This may help with the NULL handle errors, because according to the named pipe source files, there can be a delay between one client connecting and the pipe server being ready for the next.

At the very least, the error is not so ugly when the watchdog finds the server already running.
@maxtaco @patrickxb 