### PR TITLE
Fix rekeyself test in KBFS rekey notification popup

### DIFF
--- a/shared/util/kbfs-notifications.js
+++ b/shared/util/kbfs-notifications.js
@@ -35,7 +35,7 @@ export function decodeKBFSError (user: string, notification: FSNotification): De
       title: `Keybase: ${_.capitalize(notification.params.mode)} timeout in ${tlf}`,
       body: `The ${notification.params.mode} operation took too long and failed. Please run 'keybase log send' so our admins can review.`
     },
-    [enums.kbfs.FSErrorType.rekeyNeeded]: notification.rekeyself ? {
+    [enums.kbfs.FSErrorType.rekeyNeeded]: notification.params.rekeyself ? {
       title: 'Keybase: Files need to be rekeyed',
       body: `Please open one of your other computers to unlock ${tlf}`
     } : {


### PR DESCRIPTION
@strib r?  As seen in https://github.com/keybase/keybase-issues/issues/2204.  Haven't tested the fix yet.  Does it look correct?