### PR TITLE
Ios builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ build
 
 npm-debug.log
 node_modules
+
+Keybase.app.dSYM.zip

--- a/packaging/android/build_and_publish.sh
+++ b/packaging/android/build_and_publish.sh
@@ -14,7 +14,7 @@ cd $rn_dir
 if [ ! "$cache_npm" = "1" ]; then
   echo "Clearing old node_modules in react-native"
   npm cache clean
-  rm -r node_modules
+  rm -r node_modules || true
   # Install npm
   npm install
   npm install -g react-native-cli

--- a/packaging/android/build_and_publish.sh
+++ b/packaging/android/build_and_publish.sh
@@ -15,6 +15,7 @@ if [ ! "$cache_npm" = "1" ]; then
   echo "Clearing old node_modules in react-native"
   npm cache clean
   rm -r node_modules || true
+  npm cache clean
   # Install npm
   npm install
   npm install -g react-native-cli

--- a/packaging/ios/build_and_publish.sh
+++ b/packaging/ios/build_and_publish.sh
@@ -14,7 +14,7 @@ cd $rn_dir
 if [ ! "$cache_npm" = "1" ]; then
   echo "Clearing old node_modules in react-native"
   npm cache clean
-  rm -r node_modules
+  rm -r node_modules || true
   # Install npm
   npm install
   npm install -g react-native-cli

--- a/packaging/ios/build_and_publish.sh
+++ b/packaging/ios/build_and_publish.sh
@@ -4,7 +4,7 @@ set -e -u -o pipefail # Fail on error
 
 gopath=${GOPATH:-}
 rn_dir="$gopath/src/github.com/keybase/client/react-native"
-android_dir="$gopath/src/github.com/keybase/client/react-native/android"
+ios_dir="$gopath/src/github.com/keybase/client/react-native/ios"
 client_dir="$gopath/src/github.com/keybase/client"
 cache_npm=${CACHE_NPM:-}
 cache_go_lib=${CACHE_GO_LIB:-}
@@ -23,17 +23,12 @@ fi
 
 if [ ! "$cache_go_lib" = "1" ]; then
   echo "Building Go library"
-  npm run gobuild-android
+  npm run gobuild-ios
 fi
 
-# We can't currently automate this :(, we used to be able to `echo y | android update ...` but that no longer works
-# android update sdk --all --no-ui --filter "build-tools-23.0.2,android-23,extra-android-support,extra-android-m2repository"
-
 # Build and publish the apk
-cd $android_dir
+cd $ios_dir
 
-./gradlew publishApkRelease
+fastlane ios beta
 
-"$client_dir/packaging/slack/send.sh" "Finished releasing android"
-
-
+"$client_dir/packaging/slack/send.sh" "Finished releasing ios"

--- a/packaging/ios/build_and_publish.sh
+++ b/packaging/ios/build_and_publish.sh
@@ -15,6 +15,7 @@ if [ ! "$cache_npm" = "1" ]; then
   echo "Clearing old node_modules in react-native"
   npm cache clean
   rm -r node_modules || true
+  npm cache clean
   # Install npm
   npm install
   npm install -g react-native-cli

--- a/react-native/ios/Keybase.xcodeproj/project.pbxproj
+++ b/react-native/ios/Keybase.xcodeproj/project.pbxproj
@@ -815,6 +815,7 @@
 				CODE_SIGN_ENTITLEMENTS = Keybase/Keybase.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 4;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -826,7 +827,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/KeybaseGo",
 				);
-				INFOPLIST_FILE = "$(SRCROOT)/Keybase/Info.plist";
+				INFOPLIST_FILE = Keybase/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -850,6 +851,7 @@
 				CODE_SIGN_ENTITLEMENTS = Keybase/Keybase.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Keybase, Inc. (99229SGT5K)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: Keybase, Inc. (99229SGT5K)";
+				CURRENT_PROJECT_VERSION = 4;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -861,7 +863,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/KeybaseGo",
 				);
-				INFOPLIST_FILE = "$(SRCROOT)/Keybase/Info.plist";
+				INFOPLIST_FILE = Keybase/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (

--- a/react-native/ios/Keybase.xcodeproj/project.pbxproj
+++ b/react-native/ios/Keybase.xcodeproj/project.pbxproj
@@ -848,8 +848,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Keybase/Keybase.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution: Keybase, Inc. (99229SGT5K)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: Keybase, Inc. (99229SGT5K)";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/react-native/ios/Keybase/Info.plist
+++ b/react-native/ios/Keybase/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/react-native/ios/Keybase/Info.plist
+++ b/react-native/ios/Keybase/Info.plist
@@ -2,17 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIAppFonts</key>
-	<array>
-		<string>kb.ttf</string>
-		<string>Lato-Bold.ttf</string>
-		<string>Lato-Italic.ttf</string>
-		<string>Lato-Regular.ttf</string>
-		<string>Lato-Semibold.ttf</string>
-		<string>Lato-SemiboldItalic.ttf</string>
-		<string>SourceCodePro-Regular.ttf</string>
-		<string>SourceCodePro-Semibold.ttf</string>
-	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -40,6 +29,17 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>UIAppFonts</key>
+	<array>
+		<string>kb.ttf</string>
+		<string>Lato-Bold.ttf</string>
+		<string>Lato-Italic.ttf</string>
+		<string>Lato-Regular.ttf</string>
+		<string>Lato-Semibold.ttf</string>
+		<string>Lato-SemiboldItalic.ttf</string>
+		<string>SourceCodePro-Regular.ttf</string>
+		<string>SourceCodePro-Semibold.ttf</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/react-native/ios/KeybaseTests/Info.plist
+++ b/react-native/ios/KeybaseTests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>4</string>
 </dict>
 </plist>

--- a/react-native/ios/fastlane/.gitignore
+++ b/react-native/ios/fastlane/.gitignore
@@ -1,0 +1,3 @@
+report.xml
+metadata/*
+screenshots/*

--- a/react-native/ios/fastlane/Appfile
+++ b/react-native/ios/fastlane/Appfile
@@ -1,0 +1,7 @@
+app_identifier "keybase.ios" # The bundle identifier of your app
+apple_id "android+ios@keyba.se" # Your Apple email address
+
+team_id "99229SGT5K"  # Developer Portal Team ID
+
+# you can even provide different app identifiers, Apple IDs and team names per lane:
+# More information: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Appfile.md

--- a/react-native/ios/fastlane/Deliverfile
+++ b/react-native/ios/fastlane/Deliverfile
@@ -1,0 +1,10 @@
+###################### More Options ######################
+# If you want to have even more control, check out the documentation
+# https://github.com/fastlane/fastlane/blob/master/deliver/Deliverfile.md
+
+
+###################### Automatically generated ######################
+# Feel free to remove the following line if you use fastlane (which you should)
+
+app_identifier "keybase.ios" # The bundle identifier of your app
+username "android+ios@keyba.se" # your Apple ID user

--- a/react-native/ios/fastlane/Fastfile
+++ b/react-native/ios/fastlane/Fastfile
@@ -1,0 +1,77 @@
+# Customise this file, documentation can be found here:
+# https://github.com/fastlane/fastlane/tree/master/docs
+# All available actions: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Actions.md
+# can also be listed using the `fastlane actions` command
+
+# Change the syntax highlighting to Ruby
+# All lines starting with a # are ignored when running `fastlane`
+
+# If you want to automatically update fastlane if a new version is available:
+# update_fastlane
+
+# This is the minimum version number required.
+# Update this, if you use features of a newer version
+fastlane_version "1.81.0"
+
+default_platform :ios
+
+platform :ios do
+  before_all do
+    # ENV["SLACK_URL"] = "https://hooks.slack.com/services/..."
+    cocoapods
+  end
+
+  desc "Runs all the tests"
+  lane :test do
+    scan
+  end
+
+  desc "Submit a new Beta Build to Apple TestFlight"
+  desc "This will also make sure the profile is up to date"
+  lane :beta do
+  version = get_version_number
+    increment_build_number({
+      build_number: latest_testflight_build_number(version: version) + 1
+    })
+
+    # match(type: "appstore") # more information: https://codesigning.guide
+    gym(scheme: "Keybase") # Build your app - more options available
+    pilot
+
+    # sh "your_script.sh"
+    # You can also use other beta testing services here (run `fastlane actions`)
+  end
+
+  desc "Deploy a new version to the App Store"
+  lane :appstore do
+    # match(type: "appstore")
+    # snapshot
+    gym(scheme: "Keybase") # Build your app - more options available
+    deliver(force: true)
+    # frameit
+  end
+
+  # You can define as many lanes as you want
+
+  after_all do |lane|
+    # This block is called, only if the executed lane was successful
+
+    # slack(
+    #   message: "Successfully deployed new App Update."
+    # )
+  end
+
+  error do |lane, exception|
+    # slack(
+    #   message: exception.message,
+    #   success: false
+    # )
+  end
+end
+
+
+# More information about multiple platforms in fastlane: https://github.com/fastlane/fastlane/blob/master/docs/Platforms.md
+# All available actions: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Actions.md
+
+# fastlane reports which actions are used
+# No personal data is recorded. Learn more at https://github.com/fastlane/enhancer

--- a/react-native/ios/fastlane/README.md
+++ b/react-native/ios/fastlane/README.md
@@ -1,0 +1,31 @@
+fastlane documentation
+================
+# Installation
+```
+sudo gem install fastlane
+```
+# Available Actions
+## iOS
+### ios test
+```
+fastlane ios test
+```
+Runs all the tests
+### ios beta
+```
+fastlane ios beta
+```
+Submit a new Beta Build to Apple TestFlight
+
+This will also make sure the profile is up to date
+### ios appstore
+```
+fastlane ios appstore
+```
+Deploy a new version to the App Store
+
+----
+
+This README.md is auto-generated and will be re-generated every time to run [fastlane](https://fastlane.tools).
+More information about fastlane can be found on [https://fastlane.tools](https://fastlane.tools).
+The documentation of fastlane can be found on [GitHub](https://github.com/fastlane/fastlane/tree/master/fastlane).

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -11,7 +11,8 @@
     "build-ios": "npm run pod-install && npm run gobuild-ios",
     "watch": "npm run sync && cd ../shared && watchman-make -p '**' --make 'cd ../react-native && npm run sync && cd ../shared' -t all",
     "sync": "rsync -avhW --delete --exclude='*.desktop.js' ../shared/ ./shared/",
-    "update-font-icon": "babel-node update-font-icon.js"
+    "update-font-icon": "babel-node update-font-icon.js",
+    "postinstall": "mkdir -p node_modules/net; echo 'exports = {}' > node_modules/net/index.js; echo '{\"main\": \"index.js\"}' > node_modules/net/package.json"
   },
   "dependencies": {
     "buffer": "4.5.1",

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -12,7 +12,7 @@
     "watch": "npm run sync && cd ../shared && watchman-make -p '**' --make 'cd ../react-native && npm run sync && cd ../shared' -t all",
     "sync": "rsync -avhW --delete --exclude='*.desktop.js' ../shared/ ./shared/",
     "update-font-icon": "babel-node update-font-icon.js",
-    "postinstall": "mkdir -p node_modules/net; echo 'exports = {}' > node_modules/net/index.js; echo '{\"main\": \"index.js\"}' > node_modules/net/package.json"
+    "postinstall": "npm run sync; mkdir -p node_modules/net; echo 'exports = {}' > node_modules/net/index.js; echo '{\"main\": \"index.js\"}' > node_modules/net/package.json"
   },
   "dependencies": {
     "buffer": "4.5.1",


### PR DESCRIPTION
@keybase/react-hackers 

This adds the build script for the ios testflight nightlies.

Pretty simple and pretty magical.

We're using https://fastlane.tools/ for everything. It also let's query itunes connect for the version number and simply increment it instead of having to do what we do android with timestamps.

After this is merged nightlies should work for internal testflight users (which are limited to 25). We'll have to submit the app for prelim review to hit our external testflight users limit of 2k.

Currently it is mostly working, but I get a forbidden error which is related to not setting the right role for the build bot. Just fixed this and will test that tomorrow. In the mean time feel free to review this.