### PR TITLE
Merge own props in the dispatch connect fn

### DIFF
--- a/shared/tracker/index.js
+++ b/shared/tracker/index.js
@@ -128,9 +128,10 @@ export default connect(
     ...state.tracker.trackers[ownProps.username],
     ...ownProps
   }),
-  dispatch => {
-    return bindActionCreators(trackerActions, dispatch)
-  })(Tracker)
+  (dispatch, ownProps) => ({
+    ...bindActionCreators(trackerActions, dispatch),
+    ...ownProps
+  }))(Tracker)
 
 export function selector (username: string): (store: Object) => ?Object {
   return store => {


### PR DESCRIPTION
This allows the dumb screen to not make real calls like
startTrackerTimer (which is was doing before)

@keybase/react-hackers 