### PR TITLE
Add helpers for invitation endpoints

### DIFF
--- a/go/libkb/api_mock_test.go
+++ b/go/libkb/api_mock_test.go
@@ -1,0 +1,40 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package libkb
+
+import (
+	"io"
+	"net/http"
+)
+
+type NullMockAPI struct{}
+
+var _ API = (*NullMockAPI)(nil)
+
+func (n *NullMockAPI) Get(APIArg) (*APIRes, error)                        { return nil, nil }
+func (n *NullMockAPI) GetResp(APIArg) (*http.Response, error)             { return nil, nil }
+func (n *NullMockAPI) GetDecode(APIArg, APIResponseWrapper) error         { return nil }
+func (n *NullMockAPI) Post(APIArg) (*APIRes, error)                       { return nil, nil }
+func (n *NullMockAPI) PostJSON(APIArg) (*APIRes, error)                   { return nil, nil }
+func (n *NullMockAPI) PostResp(APIArg) (*http.Response, error)            { return nil, nil }
+func (n *NullMockAPI) PostDecode(APIArg, APIResponseWrapper) error        { return nil }
+func (n *NullMockAPI) PostRaw(APIArg, string, io.Reader) (*APIRes, error) { return nil, nil }
+
+type APIArgRecorder struct {
+	*NullMockAPI
+	Args []APIArg
+}
+
+func NewAPIArgRecorder() *APIArgRecorder {
+	return &APIArgRecorder{NullMockAPI: &NullMockAPI{}}
+}
+
+func (a *APIArgRecorder) Post(arg APIArg) (*APIRes, error) {
+	a.Args = append(a.Args, arg)
+	return nil, nil
+}
+
+func (a *APIArgRecorder) Reset() {
+	a.Args = nil
+}

--- a/go/libkb/invite.go
+++ b/go/libkb/invite.go
@@ -1,0 +1,64 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package libkb
+
+import keybase1 "github.com/keybase/client/go/protocol"
+
+// InviteArg contains optional invitation arguments.
+type InviteArg struct {
+	Message    string
+	NoteToSelf string
+}
+
+type Invitation struct {
+	ID        string
+	ShortCode string
+}
+
+func (i InviteArg) ToHTTPArgs() HTTPArgs {
+	return HTTPArgs{
+		"invitation_message": S{Val: i.Message},
+		"note_to_self":       S{Val: i.NoteToSelf},
+	}
+}
+
+func SendInvitation(g *GlobalContext, email string, arg InviteArg) (*Invitation, error) {
+	hargs := arg.ToHTTPArgs()
+	hargs["email"] = S{Val: email}
+	return callSendInvitation(g, hargs)
+}
+
+func GenerateInvitationCode(g *GlobalContext, arg InviteArg) (*Invitation, error) {
+	return callSendInvitation(g, arg.ToHTTPArgs())
+}
+
+func GenerateInvitationCodeForAssertion(g *GlobalContext, assertion keybase1.SocialAssertion, arg InviteArg) (*Invitation, error) {
+	hargs := arg.ToHTTPArgs()
+	hargs["assertion"] = S{Val: assertion.String()}
+	return callSendInvitation(g, hargs)
+}
+
+func callSendInvitation(g *GlobalContext, params HTTPArgs) (*Invitation, error) {
+	arg := APIArg{
+		Endpoint:     "send_invitation",
+		NeedSession:  true,
+		Contextified: NewContextified(g),
+		Args:         params,
+	}
+	res, err := g.API.Post(arg)
+	if err != nil {
+		return nil, err
+	}
+
+	var inv Invitation
+	inv.ID, err = res.Body.AtKey("invitation_id").GetString()
+	if err != nil {
+		return nil, err
+	}
+	inv.ShortCode, err = res.Body.AtKey("short_code").GetString()
+	if err != nil {
+		return nil, err
+	}
+	return &inv, nil
+}

--- a/go/libkb/invite_test.go
+++ b/go/libkb/invite_test.go
@@ -1,0 +1,118 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package libkb
+
+import (
+	"testing"
+
+	jsonw "github.com/keybase/go-jsonw"
+)
+
+func TestInvitationArgs(t *testing.T) {
+	tc := SetupTest(t, "invite")
+	defer tc.Cleanup()
+
+	rec := newSendInvitationMock()
+	tc.G.API = rec
+
+	email := "email@nomail.keybase.io"
+	inv, err := SendInvitation(tc.G, email, InviteArg{Message: "message", NoteToSelf: "note"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rec.Args) != 1 {
+		t.Fatalf("recorded args: %d, expected 1", len(rec.Args))
+	}
+	checkArg(t, rec.Args[0])
+	checkHTTPArg(t, rec.Args[0], "email", email)
+	checkHTTPArg(t, rec.Args[0], "invitation_message", "message")
+	checkHTTPArg(t, rec.Args[0], "note_to_self", "note")
+	checkInvitation(t, inv)
+
+	rec.Reset()
+
+	inv, err = GenerateInvitationCode(tc.G, InviteArg{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rec.Args) != 1 {
+		t.Fatalf("recorded args: %d, expected 1", len(rec.Args))
+	}
+	checkArg(t, rec.Args[0])
+	checkHTTPArg(t, rec.Args[0], "invitation_message", "")
+	checkHTTPArg(t, rec.Args[0], "note_to_self", "")
+	checkInvitation(t, inv)
+
+	rec.Reset()
+
+	assertion, ok := NormalizeSocialAssertion("twitter:KeyBase")
+	if !ok {
+		t.Fatal("invalid social assertion")
+	}
+	inv, err = GenerateInvitationCodeForAssertion(tc.G, assertion, InviteArg{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rec.Args) != 1 {
+		t.Fatalf("recorded args: %d, expected 1", len(rec.Args))
+	}
+	checkArg(t, rec.Args[0])
+	checkHTTPArg(t, rec.Args[0], "assertion", "keybase@twitter")
+	checkHTTPArg(t, rec.Args[0], "invitation_message", "")
+	checkHTTPArg(t, rec.Args[0], "note_to_self", "")
+	checkInvitation(t, inv)
+}
+
+func checkArg(t *testing.T, arg APIArg) {
+	if arg.Endpoint != "send_invitation" {
+		t.Errorf("endpoint: %s, expected send_invitation", arg.Endpoint)
+	}
+	if !arg.NeedSession {
+		t.Errorf("NeedSession false, should be true")
+	}
+}
+
+func checkHTTPArg(t *testing.T, arg APIArg, key, value string) {
+	if arg.Args[key].String() != value {
+		t.Errorf("%s parameter: %q, expected %q", key, arg.Args[key], value)
+	}
+
+}
+
+func checkInvitation(t *testing.T, inv *Invitation) {
+	if inv.ID != "2b25175f6da1d9155f23800d" {
+		t.Errorf("invitation id: %q, expected 2b25175f6da1d9155f23800d", inv.ID)
+	}
+	if inv.ShortCode != "clip outside broccoli culture" {
+		t.Errorf("short code: %q, expected clip outside broccoli culture", inv.ShortCode)
+	}
+}
+
+type sendInvitationMock struct {
+	*APIArgRecorder
+}
+
+func newSendInvitationMock() *sendInvitationMock {
+	return &sendInvitationMock{NewAPIArgRecorder()}
+}
+
+func (s *sendInvitationMock) Post(arg APIArg) (*APIRes, error) {
+	if _, err := s.APIArgRecorder.Post(arg); err != nil {
+		return nil, err
+	}
+	jw, err := jsonw.Unmarshal([]byte(`{"status":{"code":0,"name":"OK"},"short_code":"clip outside broccoli culture","invitation_id":"2b25175f6da1d9155f23800d","csrf_token":"lgHZIDBlNjRhNDBhOTQ3ZWYyMTMxOWQ4MzM1Y2M4YjQ1YjE5zlcVNMHOAAFRgMDEIFyHOIg/AetihKRvVMNT2NoBNNG1QoCVxtDfzEK7/rdF"}`))
+	if err != nil {
+		return nil, err
+	}
+	return &APIRes{
+		Status:     jw.AtKey("status"),
+		Body:       jw,
+		HTTPStatus: 200,
+		AppStatus: &AppStatus{
+			Code: SCOk,
+			Name: "OK",
+			Desc: "Ok",
+		},
+	}, nil
+}


### PR DESCRIPTION
r? @maxtaco 

There is no way to grant invitations to a user via API, so there was no way to test this against the API server.  However, I added tests for the arguments and made a mock response that came from the API server.

cc @malgorithms 