### PR TITLE
add more debugging to places where PGP keys might be expired

### DIFF
--- a/go/libkb/gpg_index_test.go
+++ b/go/libkb/gpg_index_test.go
@@ -11,7 +11,7 @@ import (
 
 func parse(t *testing.T, kr string) *GpgKeyIndex {
 	buf := bytes.NewBufferString(kr)
-	i, w, e := ParseGpgIndexStream(buf)
+	i, w, e := ParseGpgIndexStream(G, buf)
 	if e != nil {
 		t.Fatalf("failure in parse: %s", e)
 	}

--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -401,6 +401,9 @@ func (ckf ComputedKeyFamily) getCkiIfActiveAtTime(kid keybase1.KID, t time.Time)
 	} else if ki.Status != KeyUncancelled {
 		err = KeyRevokedError{fmt.Sprintf("The key '%s' is no longer active", kid)}
 	} else if ki.ETime > 0 && unixTime > ki.ETime {
+		formatStr := "Mon Jan 2 15:04:05 -0700 MST 2006"
+		ckf.G().Log.Warning("Checking status of key %s\n    with respect to time [%s],\n    found it had expired at [%s].",
+			kid, t.Format(formatStr), time.Unix(ki.ETime, 0).Format(formatStr))
 		err = KeyExpiredError{fmt.Sprintf("The key '%s' expired at %s", kid, time.Unix(ki.ETime, 0))}
 	} else {
 		ret = ki


### PR DESCRIPTION
r? @maxtaco

Tested `getCkiIfActiveAtTime` by hacking that branch in keyfamily.go to be `else if true ...`, and then doing `keybase id max`. (I haven't thought of a condition where this branch would normally be hit.)

Tested gpg_index.go by hacking my computer's clock to be a year ago, adding a short-lived PGP key to a test user's account, putting the clock back to normal, exporting the expired PGP private key to a new device, and then trying to login that new device using that PGP key.

There are still several scenarios where subkeys get dropped inside of go-crypto, which we're not currently warning. For example, trying to encrypt a PGP message to someone whose only PGP key is expired.