### PR TITLE
Set run mode on launchd plist install

### DIFF
--- a/go/install/install_osx.go
+++ b/go/install/install_osx.go
@@ -193,6 +193,7 @@ func keybasePlist(g *libkb.GlobalContext, binPath string, label string) launchd.
 	logFile := filepath.Join(launchd.LogDir(), libkb.ServiceLogFileName)
 	plistArgs := []string{"-d", fmt.Sprintf("--log-file=%s", logFile), "service"}
 	envVars := DefaultLaunchdEnvVars(label)
+	envVars = append(envVars, launchd.NewEnvVar("KEYBASE_RUN_MODE", g.Env.GetRunModeAsString()))
 	comment := "It's not advisable to edit this plist, it may be overwritten"
 	return launchd.NewPlist(label, binPath, plistArgs, envVars, libkb.StartLogFileName, comment)
 }
@@ -225,6 +226,7 @@ func kbfsPlist(g *libkb.GlobalContext, kbfsBinPath string, label string) (plist 
 		mountDir,
 	}
 	envVars := DefaultLaunchdEnvVars(label)
+	envVars = append(envVars, launchd.NewEnvVar("KEYBASE_RUN_MODE", g.Env.GetRunModeAsString()))
 	comment := "It's not advisable to edit this plist, it may be overwritten"
 	plist = launchd.NewPlist(label, kbfsBinPath, plistArgs, envVars, libkb.StartLogFileName, comment)
 


### PR DESCRIPTION
This is important if you run install from prod but from a binary that defaults to devel,
or vice versa.

So

```
KEYBASE_RUN_MODE=prod ./keybase install
```

will install keybase.service.plist that runs as prod.

```
KEYBASE_RUN_MODE=devel ./keybase install
```

will install keybase.service.devel.plist that runs as devel no matter what the default runmode is for that binary.

This isn't a huge issue, because we only run install for prod run mode right now, but @cjb ran an install manually with KEYBASE_RUN_MODE overridden and then had problems cause of services conflicting.

cc @maxtaco 