### PR TITLE
Go install script, can pull repo, or update but doesn't do go get -u

### DIFF
--- a/packaging/goinstall.sh
+++ b/packaging/goinstall.sh
@@ -5,12 +5,17 @@ set -e -u -o pipefail # Fail on error
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 cd $dir
 
-istest=${TEST:-}
+package="$1"
 nopull=${NOPULL:-}
+src_dir="$GOPATH/src/$package"
 
-if [ ! "$istest" = "1" ] && [ ! "$nopull" = "1" ]; then
-  go get -u -f $1
-else
-  go get $1
+if [ ! -d "$GOPATH/src/$package" ]; then
+  git clone "https://$package" "$src_dir"
+elif [ ! -n "$nopull" ]; then
+  "$dir/check_status_and_pull.sh" "$src_dir"
 fi
-go install $1
+
+# We don't go get -u for dependencies since we assume this is used on vendored
+# packages, or dependencies are updated manually.
+
+go install "$package"


### PR DESCRIPTION
The release tool is now vendored so we don't need to do `go get`. goinstall.sh was only being used on this package (keybase/release), so I updated it to pull if not found, or use the check and pull script to update.