### PR TITLE
Fix builds on FreeBSD using build_binaries.sh.

### DIFF
--- a/go/logger/redirect_stderr_nix.go
+++ b/go/logger/redirect_stderr_nix.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
-// +build linux,!android darwin
+// +build linux,!android darwin freebsd
 
 package logger
 

--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -13,8 +13,8 @@ binary_name="$("$here/../binary_name.sh" "$@")"
 # second argument. Absolutify the build root, because we cd around in this
 # script, and also because GOPATH is not allowed to be relative.
 build_root="${2:-/tmp/keybase_build_$(date +%Y_%m_%d_%H%M%S)}"
-build_root="$(realpath "$build_root")"
 mkdir -p "$build_root"
+build_root="$(realpath "$build_root")"
 
 # Record the version now, and write it to the build root. Because it uses a
 # timestamp in prerelease mode, it's important that other scripts use this file


### PR DESCRIPTION
`realpath` on FreeBSD requires the path exist first, so mkdir it first.  Also, `logger/redirect_stderr_nix.go` compiles unchanged.