### PR TITLE
Clean up engine listeners after a js-reload

### DIFF
--- a/react-native/android/app/src/main/java/io/keybase/android/KBReactPackage.java
+++ b/react-native/android/app/src/main/java/io/keybase/android/KBReactPackage.java
@@ -11,13 +11,23 @@ import java.util.List;
 
 import io.keybase.android.components.VisiblePassReactEditTextManager;
 import io.keybase.android.modules.KeybaseEngine;
+import io.keybase.android.modules.KillableModule;
 
-public class ReactPackage implements com.facebook.react.ReactPackage {
+public class KBReactPackage implements com.facebook.react.ReactPackage {
+    private List<KillableModule> killableModules = new ArrayList<>();
+
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
-        List<NativeModule> modules = new ArrayList<>();
+        for (final KillableModule killableModule : killableModules) {
+            killableModule.destroy();
+            killableModules.remove(killableModule);
+        }
 
-        modules.add(new KeybaseEngine(reactApplicationContext));
+        final KeybaseEngine kbEngine = new KeybaseEngine(reactApplicationContext);
+        killableModules.add(kbEngine);
+
+        List<NativeModule> modules = new ArrayList<>();
+        modules.add(kbEngine);
 
         return modules;
     }

--- a/react-native/android/app/src/main/java/io/keybase/android/KBReactPackage.java
+++ b/react-native/android/app/src/main/java/io/keybase/android/KBReactPackage.java
@@ -7,6 +7,7 @@ import com.facebook.react.uimanager.ViewManager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 
 import io.keybase.android.components.VisiblePassReactEditTextManager;
@@ -18,9 +19,11 @@ public class KBReactPackage implements com.facebook.react.ReactPackage {
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
-        for (final KillableModule killableModule : killableModules) {
+        final Iterator<KillableModule> i = killableModules.iterator();
+        while (i.hasNext()) {
+            final KillableModule killableModule = i.next();
             killableModule.destroy();
-            killableModules.remove(killableModule);
+            i.remove();
         }
 
         final KeybaseEngine kbEngine = new KeybaseEngine(reactApplicationContext);

--- a/react-native/android/app/src/main/java/io/keybase/android/MainActivity.java
+++ b/react-native/android/app/src/main/java/io/keybase/android/MainActivity.java
@@ -83,7 +83,7 @@ public class MainActivity extends ReactActivity {
     protected List<com.facebook.react.ReactPackage> getPackages() {
         return Arrays.asList(
           new MainReactPackage(),
-          new ReactPackage());
+          new KBReactPackage());
     }
 
 

--- a/react-native/android/app/src/main/java/io/keybase/android/modules/KeybaseEngine.java
+++ b/react-native/android/app/src/main/java/io/keybase/android/modules/KeybaseEngine.java
@@ -1,5 +1,7 @@
 package io.keybase.android.modules;
 
+import android.util.Log;
+
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -16,7 +18,7 @@ import static go.keybase.Keybase.ReadB64;
 import static go.keybase.Keybase.Reset;
 import static go.keybase.Keybase.WriteB64;
 
-public class KeybaseEngine extends ReactContextBaseJavaModule {
+public class KeybaseEngine extends ReactContextBaseJavaModule implements KillableModule {
 
     private static final String NAME = "KeybaseEngine";
     private static final String RPC_EVENT_NAME = "RPC";
@@ -31,17 +33,17 @@ public class KeybaseEngine extends ReactContextBaseJavaModule {
 
         @Override
         public void run() {
-            // TODO: There may be a race condition here...
-            // It will fail if you try to run .getJSModule
-            // before react has loaded.
-
-            while (!Thread.currentThread().isInterrupted()) {
+            do {
                 final String data = ReadB64();
+
+                if (!reactContext.hasActiveCatalystInstance()) {
+                    Log.e(NAME, "JS Bridge is dead, dropping engine message: " + data);
+                }
 
                 reactContext
                   .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                   .emit(KeybaseEngine.RPC_EVENT_NAME, data);
-            }
+            } while (!Thread.currentThread().isInterrupted() && reactContext.hasActiveCatalystInstance());
         }
     }
 

--- a/react-native/android/app/src/main/java/io/keybase/android/modules/KillableModule.java
+++ b/react-native/android/app/src/main/java/io/keybase/android/modules/KillableModule.java
@@ -1,0 +1,5 @@
+package io.keybase.android.modules;
+
+public interface KillableModule {
+    void destroy ();
+}


### PR DESCRIPTION
@keybase/react-hackers 

We weren't killing old engine listeners when you reloaded js while devving so a bunch of unexpected stuff was happening including all of @chrisnojima "Calling JS func after bridge has been destroyed". 

rpc messages were mostly going to old engines that couldn't communicate with the js bridge because their bridge was killed in the js reload.


This keeps track of killable modules, and kills them before recreating new versions.