### PR TITLE
Add deviceHistoryList RPC

### DIFF
--- a/go/engine/device_history.go
+++ b/go/engine/device_history.go
@@ -1,0 +1,148 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
+)
+
+// DeviceHistory is an engine.
+type DeviceHistory struct {
+	libkb.Contextified
+	username string
+	user     *libkb.User
+	devices  []keybase1.DeviceDetail
+}
+
+// NewDeviceHistory creates a DeviceHistory engine to lookup the
+// device history for username.
+func NewDeviceHistory(g *libkb.GlobalContext, username string) *DeviceHistory {
+	return &DeviceHistory{
+		Contextified: libkb.NewContextified(g),
+		username:     username,
+	}
+}
+
+// NewDeviceHistorySelf creates a DeviceHistory engine to lookup
+// the device history of the current user.
+func NewDeviceHistorySelf(g *libkb.GlobalContext) *DeviceHistory {
+	return &DeviceHistory{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+// Name is the unique engine name.
+func (e *DeviceHistory) Name() string {
+	return "DeviceHistory"
+}
+
+// GetPrereqs returns the engine prereqs.
+func (e *DeviceHistory) Prereqs() Prereqs {
+	if len(e.username) > 0 {
+		return Prereqs{}
+	}
+	return Prereqs{Session: true}
+}
+
+// RequiredUIs returns the required UIs.
+func (e *DeviceHistory) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *DeviceHistory) SubConsumers() []libkb.UIConsumer {
+	return nil
+}
+
+// Run starts the engine.
+func (e *DeviceHistory) Run(ctx *Context) error {
+	if err := e.loadUser(); err != nil {
+		return err
+	}
+	if err := e.loadDevices(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *DeviceHistory) Devices() []keybase1.DeviceDetail {
+	return e.devices
+}
+
+func (e *DeviceHistory) loadUser() error {
+	arg := libkb.NewLoadUserPubOptionalArg(e.G())
+	if len(e.username) == 0 {
+		arg.Self = true
+	} else {
+		arg.Name = e.username
+	}
+	u, err := libkb.LoadUser(arg)
+	if err != nil {
+		return err
+	}
+	e.user = u
+	return nil
+}
+
+func (e *DeviceHistory) loadDevices() error {
+	ckf := e.user.GetComputedKeyFamily()
+	if ckf == nil {
+		return errors.New("nil ComputedKeyFamily for user")
+	}
+	ckis := e.user.GetComputedKeyInfos()
+	if ckis == nil {
+		return errors.New("nil ComputedKeyInfos for user")
+	}
+
+	for _, d := range ckf.GetAllDevices() {
+		exp := keybase1.DeviceDetail{Device: *(d.ProtExport())}
+		cki, ok := ckis.Infos[d.Kid]
+		if !ok {
+			return fmt.Errorf("no ComputedKeyInfo for device %s, kid %s", d.ID, d.Kid)
+		}
+
+		if cki.Eldest {
+			exp.Eldest = true
+		} else {
+			prov, err := e.provisioner(d, ckis, cki)
+			if err != nil {
+				return err
+			}
+			if prov != nil {
+				exp.Provisioner = prov.ProtExport()
+				t := keybase1.TimeFromSeconds(cki.DelegatedAt.Unix)
+				exp.ProvisionedAt = &t
+			}
+		}
+
+		if cki.RevokedAt != nil {
+			rt := keybase1.TimeFromSeconds(cki.RevokedAt.Unix)
+			exp.RevokedAt = &rt
+		}
+
+		e.devices = append(e.devices, exp)
+	}
+
+	return nil
+}
+
+func (e *DeviceHistory) provisioner(d *libkb.Device, ckis *libkb.ComputedKeyInfos, info *libkb.ComputedKeyInfo) (*libkb.Device, error) {
+	for _, v := range info.Delegations {
+		did, ok := ckis.KIDToDeviceID[v]
+		if !ok {
+			return nil, fmt.Errorf("device %s provisioned by kid %s, but couldn't find matching device ID in ComputedKeyInfos", d.ID, v)
+		}
+		prov, ok := ckis.Devices[did]
+		if !ok {
+			return nil, fmt.Errorf("device %s provisioned by device %s, but couldn't find matchind device in ComputedKeyInfos", d.ID, did)
+		}
+		return prov, nil
+	}
+
+	return nil, nil
+}

--- a/go/engine/device_history_test.go
+++ b/go/engine/device_history_test.go
@@ -1,0 +1,131 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
+)
+
+func TestDeviceHistoryBasic(t *testing.T) {
+	tc := SetupEngineTest(t, "devhist")
+	defer tc.Cleanup()
+
+	CreateAndSignupFakeUser(tc, "dhst")
+
+	ctx := &Context{}
+	eng := NewDeviceHistorySelf(tc.G)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+	devs := eng.Devices()
+	if len(devs) != 2 {
+		t.Errorf("num devices: %d, expected 2", len(devs))
+	}
+
+	var desktop keybase1.DeviceDetail
+	var paper keybase1.DeviceDetail
+
+	for _, d := range devs {
+		switch d.Device.Type {
+		case libkb.DeviceTypePaper:
+			paper = d
+		case libkb.DeviceTypeDesktop:
+			desktop = d
+		default:
+			t.Fatalf("unexpected device type %s", d.Device.Type)
+		}
+	}
+
+	// paper's provisioner should be desktop
+	if paper.Provisioner == nil {
+		t.Fatal("paper device has no provisioner")
+	}
+	if paper.Provisioner.DeviceID != desktop.Device.DeviceID {
+		t.Errorf("paper provisioned id: %s, expected %s", paper.Provisioner.DeviceID, desktop.Device.DeviceID)
+		t.Logf("desktop: %+v", desktop)
+		t.Logf("paper:   %+v", paper)
+	}
+}
+
+func TestDeviceHistoryRevoked(t *testing.T) {
+	tc := SetupEngineTest(t, "devhist")
+	defer tc.Cleanup()
+
+	u := CreateAndSignupFakeUser(tc, "dhst")
+
+	ctx := &Context{}
+	eng := NewDeviceHistorySelf(tc.G)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	var desktop keybase1.DeviceDetail
+	var paper keybase1.DeviceDetail
+
+	for _, d := range eng.Devices() {
+		switch d.Device.Type {
+		case libkb.DeviceTypePaper:
+			paper = d
+		case libkb.DeviceTypeDesktop:
+			desktop = d
+		default:
+			t.Fatalf("unexpected device type %s", d.Device.Type)
+		}
+	}
+
+	// paper's provisioner should be desktop
+	if paper.Provisioner == nil {
+		t.Fatal("paper device has no provisioner")
+	}
+	if paper.Provisioner.DeviceID != desktop.Device.DeviceID {
+		t.Errorf("paper provisioned id: %s, expected %s", paper.Provisioner.DeviceID, desktop.Device.DeviceID)
+		t.Logf("desktop: %+v", desktop)
+		t.Logf("paper:   %+v", paper)
+	}
+
+	// revoke the paper device
+	ctx.SecretUI = u.NewSecretUI()
+	ctx.LogUI = tc.G.UI.GetLogUI()
+	reng := NewRevokeDeviceEngine(RevokeDeviceEngineArgs{ID: paper.Device.DeviceID}, tc.G)
+	if err := RunEngine(reng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// get history after revoke
+	eng = NewDeviceHistorySelf(tc.G)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	var desktop2 keybase1.DeviceDetail
+	var paper2 keybase1.DeviceDetail
+
+	for _, d := range eng.Devices() {
+		switch d.Device.Type {
+		case libkb.DeviceTypePaper:
+			paper2 = d
+		case libkb.DeviceTypeDesktop:
+			desktop2 = d
+		default:
+			t.Fatalf("unexpected device type %s", d.Device.Type)
+		}
+	}
+
+	// paper's provisioner should (still) be desktop
+	if paper2.Provisioner == nil {
+		t.Fatal("paper device has no provisioner")
+	}
+	if paper2.Provisioner.DeviceID != desktop2.Device.DeviceID {
+		t.Errorf("paper provisioned id: %s, expected %s", paper2.Provisioner.DeviceID, desktop2.Device.DeviceID)
+		t.Logf("desktop: %+v", desktop2)
+		t.Logf("paper:   %+v", paper2)
+	}
+
+	if paper2.RevokedAt == nil {
+		t.Fatal("paper device RevokedAt is nil")
+	}
+}

--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -48,7 +48,13 @@ type ComputedKeyInfo struct {
 	// Map of SigID -> KID
 	Delegations map[keybase1.SigID]keybase1.KID
 	DelegatedAt *KeybaseTime
-	RevokedAt   *KeybaseTime
+
+	RevokedAt *KeybaseTime
+	// TODO:  would like to add this to support desktop's request
+	// to know who revoked a device, but changing this changes
+	// the sigchain stored on disk.  Putting off this change
+	// for now, so this is just a placeholder.  (PC)
+	// RevokedBy keybase1.KID
 
 	// For PGP keys, the active version of the key. If unspecified, use the
 	// legacy behavior of combining every instance of this key that we got from
@@ -588,6 +594,8 @@ func (ckf *ComputedKeyFamily) RevokeSig(sig keybase1.SigID, tcl TypedChainLink) 
 	} else {
 		info.Status = KeyRevoked
 		info.RevokedAt = TclToKeybaseTime(tcl)
+		// see comment in ComputedKeyInfo about this field
+		// info.RevokedBy = tcl.GetKID()
 	}
 	return
 }
@@ -596,6 +604,8 @@ func (ckf *ComputedKeyFamily) RevokeKid(kid keybase1.KID, tcl TypedChainLink) (e
 	if info, found := ckf.cki.Infos[kid]; found {
 		info.Status = KeyRevoked
 		info.RevokedAt = TclToKeybaseTime(tcl)
+		// see comment in ComputedKeyInfo about this field
+		// info.RevokedBy = tcl.GetKID()
 	}
 	return
 }

--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -54,6 +54,11 @@ type ComputedKeyInfo struct {
 	// to know who revoked a device, but changing this changes
 	// the sigchain stored on disk.  Putting off this change
 	// for now, so this is just a placeholder.  (PC)
+	//
+	// More details: adding this would work fine but would
+	// require handling the case where unmarshaling existing
+	// cki could have non-nil RevokedAt and empty RevokedBy.
+	//
 	// RevokedBy keybase1.KID
 
 	// For PGP keys, the active version of the key. If unspecified, use the

--- a/go/protocol/device.go
+++ b/go/protocol/device.go
@@ -9,18 +9,18 @@ import (
 )
 
 type DeviceDetail struct {
-	Device        Device `codec:"device" json:"device"`
-	Provisioner   Device `codec:"provisioner" json:"provisioner"`
-	ProvisionedAt Time   `codec:"provisionedAt" json:"provisionedAt"`
-	Revoker       Device `codec:"revoker" json:"revoker"`
-	RevokedAt     Time   `codec:"revokedAt" json:"revokedAt"`
+	Device        Device  `codec:"device" json:"device"`
+	Eldest        bool    `codec:"eldest" json:"eldest"`
+	Provisioner   *Device `codec:"provisioner,omitempty" json:"provisioner,omitempty"`
+	ProvisionedAt *Time   `codec:"provisionedAt,omitempty" json:"provisionedAt,omitempty"`
+	RevokedAt     *Time   `codec:"revokedAt,omitempty" json:"revokedAt,omitempty"`
 }
 
 type DeviceListArg struct {
 	SessionID int `codec:"sessionID" json:"sessionID"`
 }
 
-type DeviceDetailListArg struct {
+type DeviceHistoryListArg struct {
 	SessionID int `codec:"sessionID" json:"sessionID"`
 }
 
@@ -37,7 +37,7 @@ type DeviceInterface interface {
 	// List devices for the user.
 	DeviceList(context.Context, int) ([]Device, error)
 	// List all devices with detailed history and status information.
-	DeviceDetailList(context.Context, int) ([]DeviceDetail, error)
+	DeviceHistoryList(context.Context, int) ([]DeviceDetail, error)
 	// Starts the process of adding a new device using an existing
 	// device.  It is called on the existing device.
 	// This is for kex2.
@@ -66,18 +66,18 @@ func DeviceProtocol(i DeviceInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"deviceDetailList": {
+			"deviceHistoryList": {
 				MakeArg: func() interface{} {
-					ret := make([]DeviceDetailListArg, 1)
+					ret := make([]DeviceHistoryListArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]DeviceDetailListArg)
+					typedArgs, ok := args.(*[]DeviceHistoryListArg)
 					if !ok {
-						err = rpc.NewTypeError((*[]DeviceDetailListArg)(nil), args)
+						err = rpc.NewTypeError((*[]DeviceHistoryListArg)(nil), args)
 						return
 					}
-					ret, err = i.DeviceDetailList(ctx, (*typedArgs)[0].SessionID)
+					ret, err = i.DeviceHistoryList(ctx, (*typedArgs)[0].SessionID)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -130,9 +130,9 @@ func (c DeviceClient) DeviceList(ctx context.Context, sessionID int) (res []Devi
 }
 
 // List all devices with detailed history and status information.
-func (c DeviceClient) DeviceDetailList(ctx context.Context, sessionID int) (res []DeviceDetail, err error) {
-	__arg := DeviceDetailListArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.device.deviceDetailList", []interface{}{__arg}, &res)
+func (c DeviceClient) DeviceHistoryList(ctx context.Context, sessionID int) (res []DeviceDetail, err error) {
+	__arg := DeviceHistoryListArg{SessionID: sessionID}
+	err = c.Cli.Call(ctx, "keybase.1.device.deviceHistoryList", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/service/device.go
+++ b/go/service/device.go
@@ -40,6 +40,23 @@ func (h *DeviceHandler) DeviceList(_ context.Context, sessionID int) ([]keybase1
 	return eng.List(), nil
 }
 
+// DeviceDetailList returns a list of all the devices for a user,
+// with detailed provisioner, revoker information.
+func (h *DeviceHandler) DeviceDetailList(_ context.Context, sessionID int) ([]keybase1.DeviceDetail, error) {
+	/*
+		ctx := &engine.Context{
+			LogUI:     h.getLogUI(sessionID),
+			SessionID: sessionID,
+		}
+		eng := engine.NewDevList(h.G())
+		if err := engine.RunEngine(eng, ctx); err != nil {
+			return nil, err
+		}
+		return eng.List(), nil
+	*/
+	return nil, errors.New("not yet implemented")
+}
+
 // DeviceAdd starts the kex2 device provisioning on the
 // provisioner (device X/C1)
 func (h *DeviceHandler) DeviceAdd(_ context.Context, sessionID int) error {

--- a/go/service/device.go
+++ b/go/service/device.go
@@ -40,21 +40,19 @@ func (h *DeviceHandler) DeviceList(_ context.Context, sessionID int) ([]keybase1
 	return eng.List(), nil
 }
 
-// DeviceDetailList returns a list of all the devices for a user,
-// with detailed provisioner, revoker information.
-func (h *DeviceHandler) DeviceDetailList(_ context.Context, sessionID int) ([]keybase1.DeviceDetail, error) {
-	/*
-		ctx := &engine.Context{
-			LogUI:     h.getLogUI(sessionID),
-			SessionID: sessionID,
-		}
-		eng := engine.NewDevList(h.G())
-		if err := engine.RunEngine(eng, ctx); err != nil {
-			return nil, err
-		}
-		return eng.List(), nil
-	*/
-	return nil, errors.New("not yet implemented")
+// DeviceHistoryList returns a list of all the devices for a user,
+// with detailed history and provisioner, revoker information.
+func (h *DeviceHandler) DeviceHistoryList(nctx context.Context, sessionID int) ([]keybase1.DeviceDetail, error) {
+	ctx := &engine.Context{
+		LogUI:      h.getLogUI(sessionID),
+		NetContext: nctx,
+		SessionID:  sessionID,
+	}
+	eng := engine.NewDeviceHistorySelf(h.G())
+	if err := engine.RunEngine(eng, ctx); err != nil {
+		return nil, err
+	}
+	return eng.Devices(), nil
 }
 
 // DeviceAdd starts the kex2 device provisioning on the

--- a/protocol/avdl/device.avdl
+++ b/protocol/avdl/device.avdl
@@ -7,6 +7,19 @@ protocol device {
     List devices for the user.
     */
   array<Device> deviceList(int sessionID);
+ 
+  record DeviceDetail {
+    Device device;
+    Device provisioner;
+    Time provisionedAt;
+    Device revoker;
+    Time revokedAt;
+  }
+ 
+  /**
+    List all devices with detailed history and status information.
+    */
+  array<DeviceDetail> deviceDetailList(int sessionID);
 
   /**
     Starts the process of adding a new device using an existing

--- a/protocol/avdl/device.avdl
+++ b/protocol/avdl/device.avdl
@@ -10,16 +10,18 @@ protocol device {
  
   record DeviceDetail {
     Device device;
-    Device provisioner;
-    Time provisionedAt;
-    Device revoker;
-    Time revokedAt;
+    boolean eldest;
+    union {null, Device} provisioner;
+    union {null, Time} provisionedAt;
+    // not possible to determine revoker without major code change
+    // union {null, Device} revoker;
+    union {null, Time} revokedAt;
   }
  
   /**
     List all devices with detailed history and status information.
     */
-  array<DeviceDetail> deviceDetailList(int sessionID);
+  array<DeviceDetail> deviceHistoryList(int sessionID);
 
   /**
     Starts the process of adding a new device using an existing

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -157,10 +157,10 @@ export type Device = {
 
 export type DeviceDetail = {
   device: Device;
-  provisioner: Device;
-  provisionedAt: Time;
-  revoker: Device;
-  revokedAt: Time;
+  eldest: boolean;
+  provisioner?: ?Device;
+  provisionedAt?: ?Time;
+  revokedAt?: ?Time;
 }
 
 export type DeviceID = string
@@ -1675,13 +1675,13 @@ export type device_deviceAdd_rpc = {
   callback: (null | (err: ?any) => void)
 }
 
-export type device_deviceDetailList_result = Array<DeviceDetail>
+export type device_deviceHistoryList_result = Array<DeviceDetail>
 
-export type device_deviceDetailList_rpc = {
-  method: 'device.deviceDetailList',
+export type device_deviceHistoryList_rpc = {
+  method: 'device.deviceHistoryList',
   param: {},
   incomingCallMap: ?incomingCallMapType,
-  callback: (null | (err: ?any, response: device_deviceDetailList_result) => void)
+  callback: (null | (err: ?any, response: device_deviceHistoryList_result) => void)
 }
 
 export type device_deviceList_result = Array<Device>
@@ -3369,7 +3369,7 @@ export type rpc =
   | delegateUiCtl_registerUpdateUI_rpc
   | device_checkDeviceNameFormat_rpc
   | device_deviceAdd_rpc
-  | device_deviceDetailList_rpc
+  | device_deviceHistoryList_rpc
   | device_deviceList_rpc
   | favorite_favoriteAdd_rpc
   | favorite_favoriteDelete_rpc
@@ -3872,13 +3872,13 @@ export type incomingCallMapType = {
       result: (result: device_deviceList_result) => void
     }
   ) => void,
-  'keybase.1.device.deviceDetailList'?: (
+  'keybase.1.device.deviceHistoryList'?: (
     params: {
       sessionID: int
     },
     response: {
       error: (err: RPCError) => void,
-      result: (result: device_deviceDetailList_result) => void
+      result: (result: device_deviceHistoryList_result) => void
     }
   ) => void,
   'keybase.1.device.deviceAdd'?: (

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -155,6 +155,14 @@ export type Device = {
   status: int;
 }
 
+export type DeviceDetail = {
+  device: Device;
+  provisioner: Device;
+  provisionedAt: Time;
+  revoker: Device;
+  revokedAt: Time;
+}
+
 export type DeviceID = string
 
 export type DeviceType =
@@ -1665,6 +1673,15 @@ export type device_deviceAdd_rpc = {
   param: {},
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
+}
+
+export type device_deviceDetailList_result = Array<DeviceDetail>
+
+export type device_deviceDetailList_rpc = {
+  method: 'device.deviceDetailList',
+  param: {},
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any, response: device_deviceDetailList_result) => void)
 }
 
 export type device_deviceList_result = Array<Device>
@@ -3352,6 +3369,7 @@ export type rpc =
   | delegateUiCtl_registerUpdateUI_rpc
   | device_checkDeviceNameFormat_rpc
   | device_deviceAdd_rpc
+  | device_deviceDetailList_rpc
   | device_deviceList_rpc
   | favorite_favoriteAdd_rpc
   | favorite_favoriteDelete_rpc
@@ -3852,6 +3870,15 @@ export type incomingCallMapType = {
     response: {
       error: (err: RPCError) => void,
       result: (result: device_deviceList_result) => void
+    }
+  ) => void,
+  'keybase.1.device.deviceDetailList'?: (
+    params: {
+      sessionID: int
+    },
+    response: {
+      error: (err: RPCError) => void,
+      result: (result: device_deviceDetailList_result) => void
     }
   ) => void,
   'keybase.1.device.deviceAdd'?: (

--- a/protocol/json/device.json
+++ b/protocol/json/device.json
@@ -376,6 +376,32 @@
         }
       ],
       "doc": "UserResolution maps how an unresolved user assertion has been resolved."
+    },
+    {
+      "type": "record",
+      "name": "DeviceDetail",
+      "fields": [
+        {
+          "type": "Device",
+          "name": "device"
+        },
+        {
+          "type": "Device",
+          "name": "provisioner"
+        },
+        {
+          "type": "Time",
+          "name": "provisionedAt"
+        },
+        {
+          "type": "Device",
+          "name": "revoker"
+        },
+        {
+          "type": "Time",
+          "name": "revokedAt"
+        }
+      ]
     }
   ],
   "messages": {
@@ -391,6 +417,19 @@
         "items": "Device"
       },
       "doc": "List devices for the user."
+    },
+    "deviceDetailList": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        }
+      ],
+      "response": {
+        "type": "array",
+        "items": "DeviceDetail"
+      },
+      "doc": "List all devices with detailed history and status information."
     },
     "deviceAdd": {
       "request": [

--- a/protocol/json/device.json
+++ b/protocol/json/device.json
@@ -386,19 +386,28 @@
           "name": "device"
         },
         {
-          "type": "Device",
+          "type": "boolean",
+          "name": "eldest"
+        },
+        {
+          "type": [
+            "null",
+            "Device"
+          ],
           "name": "provisioner"
         },
         {
-          "type": "Time",
+          "type": [
+            "null",
+            "Time"
+          ],
           "name": "provisionedAt"
         },
         {
-          "type": "Device",
-          "name": "revoker"
-        },
-        {
-          "type": "Time",
+          "type": [
+            "null",
+            "Time"
+          ],
           "name": "revokedAt"
         }
       ]
@@ -418,7 +427,7 @@
       },
       "doc": "List devices for the user."
     },
-    "deviceDetailList": {
+    "deviceHistoryList": {
       "request": [
         {
           "name": "sessionID",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -157,10 +157,10 @@ export type Device = {
 
 export type DeviceDetail = {
   device: Device;
-  provisioner: Device;
-  provisionedAt: Time;
-  revoker: Device;
-  revokedAt: Time;
+  eldest: boolean;
+  provisioner?: ?Device;
+  provisionedAt?: ?Time;
+  revokedAt?: ?Time;
 }
 
 export type DeviceID = string
@@ -1675,13 +1675,13 @@ export type device_deviceAdd_rpc = {
   callback: (null | (err: ?any) => void)
 }
 
-export type device_deviceDetailList_result = Array<DeviceDetail>
+export type device_deviceHistoryList_result = Array<DeviceDetail>
 
-export type device_deviceDetailList_rpc = {
-  method: 'device.deviceDetailList',
+export type device_deviceHistoryList_rpc = {
+  method: 'device.deviceHistoryList',
   param: {},
   incomingCallMap: ?incomingCallMapType,
-  callback: (null | (err: ?any, response: device_deviceDetailList_result) => void)
+  callback: (null | (err: ?any, response: device_deviceHistoryList_result) => void)
 }
 
 export type device_deviceList_result = Array<Device>
@@ -3369,7 +3369,7 @@ export type rpc =
   | delegateUiCtl_registerUpdateUI_rpc
   | device_checkDeviceNameFormat_rpc
   | device_deviceAdd_rpc
-  | device_deviceDetailList_rpc
+  | device_deviceHistoryList_rpc
   | device_deviceList_rpc
   | favorite_favoriteAdd_rpc
   | favorite_favoriteDelete_rpc
@@ -3872,13 +3872,13 @@ export type incomingCallMapType = {
       result: (result: device_deviceList_result) => void
     }
   ) => void,
-  'keybase.1.device.deviceDetailList'?: (
+  'keybase.1.device.deviceHistoryList'?: (
     params: {
       sessionID: int
     },
     response: {
       error: (err: RPCError) => void,
-      result: (result: device_deviceDetailList_result) => void
+      result: (result: device_deviceHistoryList_result) => void
     }
   ) => void,
   'keybase.1.device.deviceAdd'?: (

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -155,6 +155,14 @@ export type Device = {
   status: int;
 }
 
+export type DeviceDetail = {
+  device: Device;
+  provisioner: Device;
+  provisionedAt: Time;
+  revoker: Device;
+  revokedAt: Time;
+}
+
 export type DeviceID = string
 
 export type DeviceType =
@@ -1665,6 +1673,15 @@ export type device_deviceAdd_rpc = {
   param: {},
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
+}
+
+export type device_deviceDetailList_result = Array<DeviceDetail>
+
+export type device_deviceDetailList_rpc = {
+  method: 'device.deviceDetailList',
+  param: {},
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any, response: device_deviceDetailList_result) => void)
 }
 
 export type device_deviceList_result = Array<Device>
@@ -3352,6 +3369,7 @@ export type rpc =
   | delegateUiCtl_registerUpdateUI_rpc
   | device_checkDeviceNameFormat_rpc
   | device_deviceAdd_rpc
+  | device_deviceDetailList_rpc
   | device_deviceList_rpc
   | favorite_favoriteAdd_rpc
   | favorite_favoriteDelete_rpc
@@ -3852,6 +3870,15 @@ export type incomingCallMapType = {
     response: {
       error: (err: RPCError) => void,
       result: (result: device_deviceList_result) => void
+    }
+  ) => void,
+  'keybase.1.device.deviceDetailList'?: (
+    params: {
+      sessionID: int
+    },
+    response: {
+      error: (err: RPCError) => void,
+      result: (result: device_deviceDetailList_result) => void
     }
   ) => void,
   'keybase.1.device.deviceAdd'?: (


### PR DESCRIPTION
This adds an RPC endpoint that contains all devices for a user including revoked devices.  It includes which device provisioned each device.  For revoked devices, it includes when they were revoked.

Adding which device revoked a device (as requested by @chrisnojima) would be a bigger change.  I wanted to add RevokedBy to ComputedKeyInfo, but that would change the sigchain data stored on disk.  As this is a 1pt ticket that has already gone over the time limit, putting off that change until M4.  Will add a ticket for it.

r? @oconnor663 or @maxtaco 

cc @chrisnojima 