### PR TITLE
Does more signing checks (including spctl assess)

### DIFF
--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -190,16 +190,16 @@ sign() {(
   codesign --verbose --force --deep --sign "$code_sign_identity" "$app_name.app"
 
   echo "Verify codesigning..."
-  codesign -v "$app_name.app"
+  codesign --verify --verbose=4 "$app_name.app"
   spctl --assess --verbose=4 "$app_name.app"
-  codesign -v "$app_name.app/Contents/SharedSupport/bin/keybase"
-  codesign -v "$app_name.app/Contents/SharedSupport/bin/kbfs"
-  codesign -v "$app_name.app/Contents/SharedSupport/bin/updater"
+  codesign --verify --verbose=4 "$app_name.app/Contents/SharedSupport/bin/keybase"
+  codesign --verify --verbose=4 "$app_name.app/Contents/SharedSupport/bin/kbfs"
+  codesign --verify --verbose=4 "$app_name.app/Contents/SharedSupport/bin/updater"
   bundle_installer_app="$app_name.app/Contents/Resources/KeybaseInstaller.app"
-  codesign -v "$bundle_installer_app"
+  codesign --verify --verbose=4 "$bundle_installer_app"
   spctl --assess --verbose=4  "$bundle_installer_app"
   bundle_updater_app="$app_name.app/Contents/Resources/KeybaseUpdater.app"
-  codesign -v "$bundle_updater_app"
+  codesign --verify --verbose=4 "$bundle_updater_app"
   spctl --assess --verbose=4 "$bundle_updater_app"
 )}
 

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -191,8 +191,15 @@ sign() {(
 
   echo "Verify codesigning..."
   codesign -v "$app_name.app"
+  spctl --assess --verbose=4 "$app_name.app"
   codesign -v "$app_name.app/Contents/SharedSupport/bin/keybase"
   codesign -v "$app_name.app/Contents/SharedSupport/bin/kbfs"
+  bundle_installer_app="$app_name.app/Contents/Resources/KeybaseInstaller.app"
+  codesign -v "$bundle_installer_app"
+  spctl --assess --verbose=4  "$bundle_installer_app"
+  bundle_updater_app="$app_name.app/Contents/Resources/KeybaseUpdater.app"
+  codesign -v "$bundle_updater_app"
+  spctl --assess --verbose=4 "$bundle_updater_app"
 )}
 
 # Create dmg from Keybase.app

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -194,6 +194,7 @@ sign() {(
   spctl --assess --verbose=4 "$app_name.app"
   codesign -v "$app_name.app/Contents/SharedSupport/bin/keybase"
   codesign -v "$app_name.app/Contents/SharedSupport/bin/kbfs"
+  codesign -v "$app_name.app/Contents/SharedSupport/bin/updater"
   bundle_installer_app="$app_name.app/Contents/Resources/KeybaseInstaller.app"
   codesign -v "$bundle_installer_app"
   spctl --assess --verbose=4  "$bundle_installer_app"


### PR DESCRIPTION
There weren't any issues, just making it safer

Note you can't `spctl --assess` binaries (which is why keybase and kbfs don't have that, only codesign verify) 

> Please know that our engineering team has determined that this issue behaves as intended based on the information provided.
> Gatekeeper (as of 10.11.4) rejects anything that isn’t an app (or “like” an app, such a widget). This is part of a general hardening effort.
- http://www.openradar.me/25618668