### PR TITLE
Add FS notification for successful MD reads, and don't popup notifications for unknown types.

### DIFF
--- a/go/protocol/kbfs_common.go
+++ b/go/protocol/kbfs_common.go
@@ -18,12 +18,13 @@ const (
 type FSNotificationType int
 
 const (
-	FSNotificationType_ENCRYPTING FSNotificationType = 0
-	FSNotificationType_DECRYPTING FSNotificationType = 1
-	FSNotificationType_SIGNING    FSNotificationType = 2
-	FSNotificationType_VERIFYING  FSNotificationType = 3
-	FSNotificationType_REKEYING   FSNotificationType = 4
-	FSNotificationType_CONNECTION FSNotificationType = 5
+	FSNotificationType_ENCRYPTING      FSNotificationType = 0
+	FSNotificationType_DECRYPTING      FSNotificationType = 1
+	FSNotificationType_SIGNING         FSNotificationType = 2
+	FSNotificationType_VERIFYING       FSNotificationType = 3
+	FSNotificationType_REKEYING        FSNotificationType = 4
+	FSNotificationType_CONNECTION      FSNotificationType = 5
+	FSNotificationType_MD_READ_SUCCESS FSNotificationType = 6
 )
 
 type FSErrorType int

--- a/protocol/avdl/kbfs_common.avdl
+++ b/protocol/avdl/kbfs_common.avdl
@@ -13,7 +13,8 @@ protocol kbfsCommon {
     SIGNING_2,
     VERIFYING_3,
     REKEYING_4,
-    CONNECTION_5
+    CONNECTION_5,
+    MD_READ_SUCCESS_6
   }
 
   enum FSErrorType {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -231,6 +231,7 @@ export type FSNotificationType =
   | 3 // VERIFYING_3
   | 4 // REKEYING_4
   | 5 // CONNECTION_5
+  | 6 // MD_READ_SUCCESS_6
 
 export type FSStatusCode =
     0 // START_0

--- a/protocol/js/keybase-v1.js
+++ b/protocol/js/keybase-v1.js
@@ -590,7 +590,8 @@ export const kbfs = {
     'signing': 2,
     'verifying': 3,
     'rekeying': 4,
-    'connection': 5
+    'connection': 5,
+    'mdReadSuccess': 6
   },
   'FSErrorType': {
     'accessDenied': 0,
@@ -811,7 +812,8 @@ export const NotifyFS = {
     'signing': 2,
     'verifying': 3,
     'rekeying': 4,
-    'connection': 5
+    'connection': 5,
+    'mdReadSuccess': 6
   },
   'FSErrorType': {
     'accessDenied': 0,

--- a/protocol/json/kbfs.json
+++ b/protocol/json/kbfs.json
@@ -19,7 +19,8 @@
         "SIGNING_2",
         "VERIFYING_3",
         "REKEYING_4",
-        "CONNECTION_5"
+        "CONNECTION_5",
+        "MD_READ_SUCCESS_6"
       ]
     },
     {

--- a/protocol/json/notify_fs.json
+++ b/protocol/json/notify_fs.json
@@ -19,7 +19,8 @@
         "SIGNING_2",
         "VERIFYING_3",
         "REKEYING_4",
-        "CONNECTION_5"
+        "CONNECTION_5",
+        "MD_READ_SUCCESS_6"
       ]
     },
     {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -231,6 +231,7 @@ export type FSNotificationType =
   | 3 // VERIFYING_3
   | 4 // REKEYING_4
   | 5 // CONNECTION_5
+  | 6 // MD_READ_SUCCESS_6
 
 export type FSStatusCode =
     0 // START_0

--- a/shared/constants/types/keybase-v1.js
+++ b/shared/constants/types/keybase-v1.js
@@ -590,7 +590,8 @@ export const kbfs = {
     'signing': 2,
     'verifying': 3,
     'rekeying': 4,
-    'connection': 5
+    'connection': 5,
+    'mdReadSuccess': 6
   },
   'FSErrorType': {
     'accessDenied': 0,
@@ -811,7 +812,8 @@ export const NotifyFS = {
     'signing': 2,
     'verifying': 3,
     'rekeying': 4,
-    'connection': 5
+    'connection': 5,
+    'mdReadSuccess': 6
   },
   'FSErrorType': {
     'accessDenied': 0,

--- a/shared/util/kbfs-notifications.js
+++ b/shared/util/kbfs-notifications.js
@@ -90,6 +90,11 @@ export function kbfsNotification (notification: FSNotification, notify: any, get
     [enums.kbfs.FSNotificationType.rekeying]: 'Rekeying'
   }[notification.notificationType]
 
+  if (action === undefined) {
+    // Ignore notification types we don't care about.
+    return
+  }
+
   const state = {
     [enums.kbfs.FSStatusCode.start]: 'starting',
     [enums.kbfs.FSStatusCode.finish]: 'finished',


### PR DESCRIPTION
The new MD_READ_SUCCESS notification allows the service to keep state about which TLFs need to be rekeyed.  This notification is not intended for the UI, so make sure the UI ignores notification types it doesn't care about.

Issue: KBFS-935