### PR TITLE
Fix hidden input invite code android

### DIFF
--- a/shared/login/signup/invite-code.render.native.js
+++ b/shared/login/signup/invite-code.render.native.js
@@ -16,7 +16,7 @@ export default class Render extends Component {
   constructor (props: Props) {
     super(props)
     this.state = {
-      inviteCode: this.props.inviteCode || ''
+      inviteCode: this.props.inviteCode
     }
   }
 
@@ -56,7 +56,8 @@ const styles = {
   },
   input: {
     alignSelf: 'stretch',
-    marginTop: 0
+    marginTop: 0,
+    flex: 0
   },
   text: {
     marginTop: 32


### PR DESCRIPTION
@keybase/react-hackers 
not sure if this is a react native problem, because flex: 1 would lead to a hidden input too.

### Before
![old](https://cloud.githubusercontent.com/assets/594035/14872349/3975238a-0ca0-11e6-985c-193fbdc48999.png)

### After
![new](https://cloud.githubusercontent.com/assets/594035/14872351/40ace1a6-0ca0-11e6-875a-74e6fc432aa7.png)


(also looks fine on ios)