### PR TITLE
Add windows hack into critical connect section

### DIFF
--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -10,7 +10,6 @@ import setupLocalLogs, {logLocal} from '../util/local-log'
 
 import {Buffer} from 'buffer'
 import NativeEventEmitter from '../common-adapters/native-event-emitter'
-import windowsHack from './windows-hack'
 import {log} from '../native/log/logui'
 
 import {constants} from '../constants/types/keybase-v1'
@@ -18,7 +17,6 @@ import {printOutstandingRPCs} from '../local-debug'
 
 class Engine {
   constructor () {
-    windowsHack()
     setupLocalLogs()
 
     // Keep some meta data from session ID to response meta

--- a/shared/engine/rpc.js
+++ b/shared/engine/rpc.js
@@ -1,5 +1,6 @@
 import EngineError from './errors'
 import rpc from 'framed-msgpack-rpc'
+import windowsHack from './windows-hack'
 
 const {
   transport: {RobustTransport}
@@ -27,6 +28,11 @@ class BaseTransport extends RobustTransport {
     } else {
       return new Error(JSON.stringify(err))
     }
+  }
+
+  _connect_critical_section (cb) {
+    super._connect_critical_section(cb)
+    windowsHack()
   }
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

This takes @cjb windows hack and calls it everytime we connect.

We weren't able to reconnect to the service because we weren't doing this hack on reconnect.

Minimal repro case here: https://github.com/MarcoPolo/electron-quick-start/tree/net-fail-windows

I'll create an electron issue too.