### PR TITLE
despam sigchain device objects

### DIFF
--- a/go/libkb/device.go
+++ b/go/libkb/device.go
@@ -104,6 +104,10 @@ func (d *Device) Export(lt LinkType) (*jsonw.Wrapper, error) {
 		}
 	}
 
+	// These were being set to 0, so don't include them
+	dw.DeleteKey("mtime")
+	dw.DeleteKey("ctime")
+
 	return dw, nil
 }
 


### PR DESCRIPTION
- don't print 0s for mtime or ctime