### PR TITLE
Always pass in a function or touchables get mad

### DIFF
--- a/shared/common-adapters/button.native.js
+++ b/shared/common-adapters/button.native.js
@@ -49,7 +49,8 @@ class Button extends Component {
     // Need this nested view to get around this RN issue: https://github.com/facebook/react-native/issues/1040
     return (
       <TouchableHighlight
-        onPress={onPress}
+        disabled={!onPress}
+        onPress={onPress || (() => {})}
         activeOpacity={0.2}
         underlayColor={style.backgroundColor}
         style={{...style, ...this.props.style}}>

--- a/shared/common-adapters/icon.native.js
+++ b/shared/common-adapters/icon.native.js
@@ -39,7 +39,7 @@ export default class Icon extends Component {
       <TouchableHighlight
         activeOpacity={0.8}
         underlayColor={globalColors.white}
-        onPress={this.props.onClick}
+        onPress={this.props.onClick || (() => {})}
         disabled={!(this.props.onClick)}
         style={containerProps}>
         {icon}

--- a/shared/common-adapters/tab-bar.native.js
+++ b/shared/common-adapters/tab-bar.native.js
@@ -86,7 +86,7 @@ class TabBar extends Component {
   _labels (): Array<React$Element> {
     // TODO: Not sure why I have to wrap the child in a box, but otherwise touches won't work
     return (this.props.children || []).map((item, i) => (
-      <TouchableWithoutFeedback key={item.props.label || i} onPress={item.props.onPress}>
+      <TouchableWithoutFeedback key={item.props.label || i} onPress={item.props.onPress || (() => {})}>
         <Box style={item.props.containerStyle}>
           {item.props.tabBarButton || <SimpleTabBarButton label={item.props.label} selected={item.props.selected} underlined={this.props.underlined}/>}
         </Box>

--- a/shared/common-adapters/user-card.native.js
+++ b/shared/common-adapters/user-card.native.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, {Component} from 'react-native'
+import React, {Component} from 'react'
 import {globalStyles, globalColors} from '../styles/style-guide'
 import type {Props} from './user-card'
 import Avatar from './avatar'

--- a/shared/devices/index.render.native.js
+++ b/shared/devices/index.render.native.js
@@ -19,7 +19,7 @@ export default class DevicesRender extends Component {
 
   renderAction (headerText, subText, onPress) {
     return (
-      <TouchableHighlight onPress={onPress} style={{flex: 1}}>
+      <TouchableHighlight onPress={onPress || (() => {})} style={{flex: 1}}>
         <View style={[styles.outlineBox, styles.innerAction, {marginRight: 10}]}>
           <View style={{flex: 1}}>
             <Text style={[commonStyles.greyText, commonStyles.centerText]}>ICON</Text>

--- a/shared/login/register/select-other-device/index.render.native.js
+++ b/shared/login/register/select-other-device/index.render.native.js
@@ -21,7 +21,7 @@ const Row = ({deviceID, name, type, onSelect}) => {
   }
 
   return (
-    <TouchableHighlight style={stylesRow} onPress={onPress}>
+    <TouchableHighlight style={stylesRow} onPress={onPress || (() => {})}>
       <View style={stylesIconName}>
         <View style={stylesIconContainer}>
           <Icon style={stylesIcon} type={iconType} onPress={onPress}/>

--- a/shared/more/menu-list.native.js
+++ b/shared/more/menu-list.native.js
@@ -13,7 +13,7 @@ export default class MenuList extends Component {
 
   renderRow (rowData, sectionID, rowID) {
     return (
-      <TouchableWithoutFeedback onPress={rowData.onClick}>
+      <TouchableWithoutFeedback onPress={rowData.onClick || (() => {})}>
         <Box style={{margin: 10, ...globalStyles.flexBoxRow, flex: 1}}>
           <Text type='BodySmall'>{rowData.name}</Text>
           <Text type='BodySmall' style={{flex: 1}}>{rowData.hasChildren ? '>' : ''}</Text>


### PR DESCRIPTION
@keybase/react-hackers 

Fixes: https://keybase.atlassian.net/browse/DESKTOP-953

Which happened on ios too. Turns out if you don't pass a function into the touchables they do some weird behavior.

The docs also say you have to pass in a function, bools won't work.