### PR TITLE
Add UI RPC to display TLF create w/ invite for SBS

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -100,3 +100,5 @@ check_path_Join()
 check_go_fmt
 check_go_vet
 check_make_lint
+# removed call to check_path_Join here because path.Join is
+# completely valid and useful to make URL paths, for example.

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -100,4 +100,3 @@ check_path_Join()
 check_go_fmt
 check_go_vet
 check_make_lint
-check_path_Join

--- a/go/client/cmd_favorite.go
+++ b/go/client/cmd_favorite.go
@@ -9,16 +9,17 @@ import (
 
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
 )
 
-func NewCmdFavorite(cl *libcmdline.CommandLine) cli.Command {
+func NewCmdFavorite(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:         "favorite",
 		ArgumentHelp: "[arguments...]",
 		Usage:        "Manage favorites",
 		Subcommands: []cli.Command{
-			NewCmdFavoriteAdd(cl),
+			NewCmdFavoriteAdd(cl, g),
 			NewCmdFavoriteRemove(cl),
 			NewCmdFavoriteList(cl),
 		},

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -16,7 +16,7 @@ import (
 func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
 	return []cli.Command{
 		NewCmdCheckTracking(cl, g),
-		NewCmdFavorite(cl),
+		NewCmdFavorite(cl, g),
 		NewCmdFakeTrackingChanged(cl, g),
 		NewCmdSecretKey(cl, g),
 		NewCmdShowNotifications(cl, g),

--- a/go/client/identify_ui.go
+++ b/go/client/identify_ui.go
@@ -84,3 +84,7 @@ func (i *IdentifyUIServer) Finish(_ context.Context, sessionID int) error {
 	i.ui.Finish()
 	return nil
 }
+
+func (i *IdentifyUIServer) DisplayTLFCreateWithInvite(_ context.Context, arg keybase1.DisplayTLFCreateWithInviteArg) error {
+	return i.ui.DisplayTLFCreateWithInvite(arg)
+}

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -105,6 +105,23 @@ func (ui BaseIdentifyUI) ReportRevoked(del []keybase1.TrackDiff) {
 	}
 }
 
+func (ui BaseIdentifyUI) DisplayTLFCreateWithInvite(arg keybase1.DisplayTLFCreateWithInviteArg) error {
+	// this will only happen via `keybase favorite add` w/ no gui running:
+	if arg.IsPrivate {
+		ui.parent.Printf("Success! You created a private folder with %s\n", arg.Assertion)
+	} else {
+		ui.parent.Printf("Success! You created a public folder with %s\n", arg.Assertion)
+	}
+	if arg.Throttled {
+		ui.parent.Printf("Since you are out of invites, %s will need to request an invitation on keybase.io\n", arg.Assertion)
+	} else {
+		ui.parent.Printf("Here's an invitation link you can send to %s:\n", arg.Assertion)
+		ui.parent.Printf("\n   %s\n\nWith this link, they will be able to sign up immediately.\n", arg.InviteLink)
+	}
+
+	return nil
+}
+
 type IdentifyTrackUI struct {
 	BaseIdentifyUI
 }

--- a/go/engine/favorite_add.go
+++ b/go/engine/favorite_add.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
@@ -38,12 +39,22 @@ func (e *FavoriteAdd) Prereqs() Prereqs {
 
 // RequiredUIs returns the required UIs.
 func (e *FavoriteAdd) RequiredUIs() []libkb.UIKind {
-	return []libkb.UIKind{}
+	return []libkb.UIKind{
+		libkb.IdentifyUIKind,
+	}
 }
 
 // SubConsumers returns the other UI consumers for this engine.
 func (e *FavoriteAdd) SubConsumers() []libkb.UIConsumer {
 	return nil
+}
+
+func (e *FavoriteAdd) WantDelegate(kind libkb.UIKind) bool {
+	if kind == libkb.IdentifyUIKind {
+		return true
+	}
+
+	return false
 }
 
 // Run starts the engine.
@@ -60,5 +71,47 @@ func (e *FavoriteAdd) Run(ctx *Context) error {
 			"status":   libkb.S{Val: "favorite"},
 		},
 	})
-	return err
+	if err != nil {
+		return err
+	}
+
+	if e.arg.Folder.Created {
+		if err := e.checkInviteNeeded(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e *FavoriteAdd) checkInviteNeeded(ctx *Context) error {
+	for _, user := range strings.Split(e.arg.Folder.Name, ",") {
+		assertion, ok := libkb.NormalizeSocialAssertion(user)
+		if !ok {
+			e.G().Log.Debug("not a social assertion: %s", user)
+			continue
+		}
+
+		e.G().Log.Debug("social assertion found in FavoriteAdd folder name: %s", assertion)
+		e.G().Log.Debug("requesting an invitation for %s", assertion)
+
+		inv, err := libkb.GenerateInvitationCodeForAssertion(e.G(), assertion, libkb.InviteArg{})
+		if err != nil {
+			return err
+		}
+
+		e.G().Log.Debug("invitation requested, informing folder creator with result")
+		arg := keybase1.DisplayTLFCreateWithInviteArg{
+			FolderName: e.arg.Folder.Name,
+			Assertion:  assertion.String(),
+			IsPrivate:  e.arg.Folder.Private,
+			Throttled:  inv.Throttled,
+			InviteLink: inv.Link(),
+		}
+		if err := ctx.IdentifyUI.DisplayTLFCreateWithInvite(arg); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/go/engine/favorite_test.go
+++ b/go/engine/favorite_test.go
@@ -157,6 +157,7 @@ func addfav(name string, private, created bool, idUI libkb.IdentifyUI, tc libkb.
 	if err != nil {
 		tc.T.Fatal(err)
 	}
+	eng.Wait()
 }
 
 func rmfav(name string, private bool, tc libkb.TestContext) {

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -171,6 +171,8 @@ type FakeIdentifyUI struct {
 	StartCount      int
 	Token           keybase1.TrackToken
 	BrokenTracking  bool
+	DisplayTLFArg   keybase1.DisplayTLFCreateWithInviteArg
+	DisplayTLFCount int
 	sync.Mutex
 }
 
@@ -252,4 +254,9 @@ func (ui *FakeIdentifyUI) ReportTrackToken(tok keybase1.TrackToken) error {
 	return nil
 }
 func (ui *FakeIdentifyUI) SetStrict(b bool) {
+}
+func (ui *FakeIdentifyUI) DisplayTLFCreateWithInvite(arg keybase1.DisplayTLFCreateWithInviteArg) error {
+	ui.DisplayTLFCount++
+	ui.DisplayTLFArg = arg
+	return nil
 }

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -105,6 +105,10 @@ func (i *Identify2WithUIDTester) ReportTrackToken(keybase1.TrackToken) (err erro
 func (i *Identify2WithUIDTester) SetStrict(b bool)                                       { return }
 func (i *Identify2WithUIDTester) DisplayUserCard(keybase1.UserCard)                      { return }
 
+func (i *Identify2WithUIDTester) DisplayTLFCreateWithInvite(keybase1.DisplayTLFCreateWithInviteArg) error {
+	return nil
+}
+
 func (i *Identify2WithUIDTester) Finish() {
 	i.finishCh <- struct{}{}
 }

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -137,6 +137,7 @@ const (
 	SCBadLoginUserNotFound   = int(keybase1.StatusCode_SCBadLoginUserNotFound)
 	SCBadLoginPassword       = int(keybase1.StatusCode_SCBadLoginPassword)
 	SCNotFound               = int(keybase1.StatusCode_SCNotFound)
+	SCThrottleControl        = int(keybase1.StatusCode_SCThrottleControl)
 	SCGeneric                = int(keybase1.StatusCode_SCGeneric)
 	SCAlreadyLoggedIn        = int(keybase1.StatusCode_SCAlreadyLoggedIn)
 	SCCanceled               = int(keybase1.StatusCode_SCCanceled)

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -277,6 +277,7 @@ type IdentifyUI interface {
 	DisplayUserCard(keybase1.UserCard)
 	ReportTrackToken(keybase1.TrackToken) error
 	Finish()
+	DisplayTLFCreateWithInvite(keybase1.DisplayTLFCreateWithInviteArg) error
 }
 
 type Checker struct {

--- a/go/protocol/constants.go
+++ b/go/protocol/constants.go
@@ -16,6 +16,7 @@ const (
 	StatusCode_SCBadLoginUserNotFound   StatusCode = 203
 	StatusCode_SCBadLoginPassword       StatusCode = 204
 	StatusCode_SCNotFound               StatusCode = 205
+	StatusCode_SCThrottleControl        StatusCode = 210
 	StatusCode_SCGeneric                StatusCode = 218
 	StatusCode_SCAlreadyLoggedIn        StatusCode = 235
 	StatusCode_SCCanceled               StatusCode = 237

--- a/go/service/favorite.go
+++ b/go/service/favorite.go
@@ -29,7 +29,9 @@ func NewFavoriteHandler(xp rpc.Transporter, g *libkb.GlobalContext) *FavoriteHan
 // FavoriteAdd handles the favoriteAdd RPC.
 func (h *FavoriteHandler) FavoriteAdd(_ context.Context, arg keybase1.FavoriteAddArg) error {
 	eng := engine.NewFavoriteAdd(&arg, h.G())
-	ctx := &engine.Context{}
+	ctx := &engine.Context{
+		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
+	}
 	return engine.RunEngine(eng, ctx)
 }
 

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -251,3 +251,8 @@ func (u *RemoteIdentifyUI) Finish() {
 func (u *RemoteIdentifyUI) SetStrict(b bool) {
 	u.strict = b
 }
+
+func (u *RemoteIdentifyUI) DisplayTLFCreateWithInvite(arg keybase1.DisplayTLFCreateWithInviteArg) error {
+	arg.SessionID = u.sessionID
+	return u.uicli.DisplayTLFCreateWithInvite(context.TODO(), arg)
+}

--- a/go/systests/delegate_ui_test.go
+++ b/go/systests/delegate_ui_test.go
@@ -153,6 +153,10 @@ func (d *delegateUI) Finish(context.Context, int) error {
 	return nil
 }
 
+func (d *delegateUI) DisplayTLFCreateWithInvite(context.Context, keybase1.DisplayTLFCreateWithInviteArg) error {
+	return nil
+}
+
 func (d *delegateUI) checkSuccess() error {
 	if !d.launchedGithub || !d.foundGithub || !d.launchedTwitter || !d.foundTwitter || !d.finished {
 		return fmt.Errorf("Bad final state for delegate UI: %+v", d)

--- a/go/systests/tracking_test.go
+++ b/go/systests/tracking_test.go
@@ -44,6 +44,10 @@ func (*identifyUI) ReportTrackToken(keybase1.TrackToken) error                  
 func (*identifyUI) SetStrict(b bool)                                                      {}
 func (*identifyUI) Finish()                                                               {}
 
+func (*identifyUI) DisplayTLFCreateWithInvite(keybase1.DisplayTLFCreateWithInviteArg) error {
+	return nil
+}
+
 type trackingNotifyHandler struct {
 	trackingCh chan keybase1.TrackingChangedArg
 	errCh      chan error

--- a/protocol/avdl/constants.avdl
+++ b/protocol/avdl/constants.avdl
@@ -8,6 +8,7 @@ protocol constants {
     SCBadLoginUserNotFound_203,
     SCBadLoginPassword_204,
     SCNotFound_205,
+    SCThrottleControl_210,
     SCGeneric_218,
     SCAlreadyLoggedIn_235,
     SCCanceled_237,

--- a/protocol/avdl/identify_ui.avdl
+++ b/protocol/avdl/identify_ui.avdl
@@ -95,6 +95,8 @@ protocol identifyUi {
     boolean expiringLocal;   // true if the user answers yes to "Expire local tracking statement after X?"
   }
 
+  void displayTLFCreateWithInvite(int sessionID, string folderName, boolean isPrivate, string assertion, string inviteLink, boolean throttled);
+
   // The IdentifyUI can be delegated to another process.  Call this function
   // to initialize the delegated UI; it returns the sessionID to use in the
   // following exchange. Return 0 on failure.

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1004,6 +1004,7 @@ export type StatusCode =
   | 203 // SCBadLoginUserNotFound_203
   | 204 // SCBadLoginPassword_204
   | 205 // SCNotFound_205
+  | 210 // SCThrottleControl_210
   | 218 // SCGeneric_218
   | 235 // SCAlreadyLoggedIn_235
   | 237 // SCCanceled_237
@@ -1815,6 +1816,21 @@ export type identifyUi_displayKey_rpc = {
   method: 'identifyUi.displayKey',
   param: {
     key: IdentifyKey
+  },
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any) => void)
+}
+
+export type identifyUi_displayTLFCreateWithInvite_result = void
+
+export type identifyUi_displayTLFCreateWithInvite_rpc = {
+  method: 'identifyUi.displayTLFCreateWithInvite',
+  param: {
+    folderName: string,
+    isPrivate: boolean,
+    assertion: string,
+    inviteLink: string,
+    throttled: boolean
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -3386,6 +3402,7 @@ export type rpc =
   | identifyUi_delegateIdentifyUI_rpc
   | identifyUi_displayCryptocurrency_rpc
   | identifyUi_displayKey_rpc
+  | identifyUi_displayTLFCreateWithInvite_rpc
   | identifyUi_displayTrackStatement_rpc
   | identifyUi_displayUserCard_rpc
   | identifyUi_finishSocialProofCheck_rpc
@@ -4029,6 +4046,20 @@ export type incomingCallMapType = {
     response: {
       error: (err: RPCError) => void,
       result: (result: identify_identify2_result) => void
+    }
+  ) => void,
+  'keybase.1.identifyUi.displayTLFCreateWithInvite'?: (
+    params: {
+      sessionID: int,
+      folderName: string,
+      isPrivate: boolean,
+      assertion: string,
+      inviteLink: string,
+      throttled: boolean
+    },
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
     }
   ) => void,
   'keybase.1.identifyUi.delegateIdentifyUI'?: (

--- a/protocol/js/keybase-v1.js
+++ b/protocol/js/keybase-v1.js
@@ -93,6 +93,7 @@ export const constants = {
     'scbadloginusernotfound': 203,
     'scbadloginpassword': 204,
     'scnotfound': 205,
+    'scthrottlecontrol': 210,
     'scgeneric': 218,
     'scalreadyloggedin': 235,
     'sccanceled': 237,

--- a/protocol/json/constants.json
+++ b/protocol/json/constants.json
@@ -11,6 +11,7 @@
         "SCBadLoginUserNotFound_203",
         "SCBadLoginPassword_204",
         "SCNotFound_205",
+        "SCThrottleControl_210",
         "SCGeneric_218",
         "SCAlreadyLoggedIn_235",
         "SCCanceled_237",

--- a/protocol/json/identify_ui.json
+++ b/protocol/json/identify_ui.json
@@ -1024,6 +1024,35 @@
     }
   ],
   "messages": {
+    "displayTLFCreateWithInvite": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "folderName",
+          "type": "string"
+        },
+        {
+          "name": "isPrivate",
+          "type": "boolean"
+        },
+        {
+          "name": "assertion",
+          "type": "string"
+        },
+        {
+          "name": "inviteLink",
+          "type": "string"
+        },
+        {
+          "name": "throttled",
+          "type": "boolean"
+        }
+      ],
+      "response": "null"
+    },
     "delegateIdentifyUI": {
       "request": [],
       "response": "int"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1004,6 +1004,7 @@ export type StatusCode =
   | 203 // SCBadLoginUserNotFound_203
   | 204 // SCBadLoginPassword_204
   | 205 // SCNotFound_205
+  | 210 // SCThrottleControl_210
   | 218 // SCGeneric_218
   | 235 // SCAlreadyLoggedIn_235
   | 237 // SCCanceled_237
@@ -1815,6 +1816,21 @@ export type identifyUi_displayKey_rpc = {
   method: 'identifyUi.displayKey',
   param: {
     key: IdentifyKey
+  },
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any) => void)
+}
+
+export type identifyUi_displayTLFCreateWithInvite_result = void
+
+export type identifyUi_displayTLFCreateWithInvite_rpc = {
+  method: 'identifyUi.displayTLFCreateWithInvite',
+  param: {
+    folderName: string,
+    isPrivate: boolean,
+    assertion: string,
+    inviteLink: string,
+    throttled: boolean
   },
   incomingCallMap: ?incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -3386,6 +3402,7 @@ export type rpc =
   | identifyUi_delegateIdentifyUI_rpc
   | identifyUi_displayCryptocurrency_rpc
   | identifyUi_displayKey_rpc
+  | identifyUi_displayTLFCreateWithInvite_rpc
   | identifyUi_displayTrackStatement_rpc
   | identifyUi_displayUserCard_rpc
   | identifyUi_finishSocialProofCheck_rpc
@@ -4029,6 +4046,20 @@ export type incomingCallMapType = {
     response: {
       error: (err: RPCError) => void,
       result: (result: identify_identify2_result) => void
+    }
+  ) => void,
+  'keybase.1.identifyUi.displayTLFCreateWithInvite'?: (
+    params: {
+      sessionID: int,
+      folderName: string,
+      isPrivate: boolean,
+      assertion: string,
+      inviteLink: string,
+      throttled: boolean
+    },
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
     }
   ) => void,
   'keybase.1.identifyUi.delegateIdentifyUI'?: (

--- a/shared/constants/types/keybase-v1.js
+++ b/shared/constants/types/keybase-v1.js
@@ -93,6 +93,7 @@ export const constants = {
     'scbadloginusernotfound': 203,
     'scbadloginpassword': 204,
     'scnotfound': 205,
+    'scthrottlecontrol': 210,
     'scgeneric': 218,
     'scalreadyloggedin': 235,
     'sccanceled': 237,


### PR DESCRIPTION
When TLF created with sharing-before-signup user, create an invitation (if any remaining in account) and use UI to display that the TLF was created.

r? @maxtaco 

cc @strib @chrisnojima 
