### PR TITLE
Include revoked keys in IdentifyOutcome

### DIFF
--- a/go/libkb/identify_state.go
+++ b/go/libkb/identify_state.go
@@ -163,6 +163,10 @@ func (s *IdentifyState) computeKeyDiffs(dhook func(keybase1.IdentifyKey)) {
 			fp := s.u.GetKeyFamily().kid2pgp[kid]
 			diff := TrackDiffRevoked{fp}
 			s.res.KeyDiffs = append(s.res.KeyDiffs, diff)
+			// the identify outcome should know that this
+			// key was revoked, as well as there being
+			// a KeyDiff:
+			s.res.Revoked = append(s.res.Revoked, diff)
 			display(kid, diff)
 		}
 	}


### PR DESCRIPTION
This fixes CORE-2693, where an ignore temporarily option was available to the user for revoked keys.

r? @oconnor663 