### PR TITLE
Bump flow version

### DIFF
--- a/shared/.flowconfig
+++ b/shared/.flowconfig
@@ -48,4 +48,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
 
 [version]
-0.24
+0.24.1


### PR DESCRIPTION
@keybase/react-hackers 

Build was failing because we didn't say `0.24.0` so flow was installing `0.24.1` while the config said it expects flow `0.24` so flow would fail.

In the future we should add the `.0` so npm doesn't get ahead of itself