### PR TITLE
Revert back to Dokan 0.8 drivers.

### DIFF
--- a/go/winresource/main.go
+++ b/go/winresource/main.go
@@ -53,13 +53,6 @@ func main() {
 		os.Exit(3)
 	}
 
-	// Ugly special case hack: fv.Build went from 1 to 0 at 1.0.14, which makes Windows
-	// think it's a downgrade (1.0.14.1 -> 1.0.14.0), so artificially bump build until we
-	// get past 1.0.14
-	if fv.Major == 1 && fv.Minor == 0 && fv.Patch == 14 {
-		fv.Build = 1
-	}
-
 	semVer := fmt.Sprintf("%d.%d.%d-%d", fv.Major, fv.Minor, fv.Patch, fv.Build)
 
 	if *printverPtr {

--- a/packaging/windows/build_prerelease.cmd
+++ b/packaging/windows/build_prerelease.cmd
@@ -18,10 +18,14 @@ for /f %%i in ('winresource.exe -cb') do set KEYBASE_BUILD=%%i
 echo %KEYBASE_BUILD%
 go build -a -tags "prerelease production" -ldflags="-X github.com/keybase/client/go/libkb.PrereleaseBuild=%KEYBASE_BUILD%"
 
-:: Then build kbfsdokan
-if NOT EXIST %GOPATH%\src\github.com\keybase\kbfs\dokan\dokan1.lib copy %GOPATH%\bin\dokan-dev\dokan-v1.0.0-RC2\Win32\Release\dokan1.lib %GOPATH%\src\github.com\keybase\kbfs\dokan
-for /f "usebackq tokens=2*" %%i in (`powershell Get-FileHash -Algorithm sha1 %GOPATH%\src\github.com\keybase\kbfs\dokan\dokan1.lib`) do set DOKANLIBHASH=%%i
-if NOT %DOKANLIBHASH%==8FCFE265C5558FBA9FC6BFF4AF8BB0B83A159611 exit /B 1
+:: Then build kbfsdokan.
+:: First, sanity-check the hashes
+if NOT EXIST %GOPATH%\src\github.com\keybase\kbfs\dokan\dokan.lib copy %GOPATH%\bin\dokan-dev\dokan-v0.8.0\Win32\Release\dokan.lib %GOPATH%\src\github.com\keybase\kbfs\dokan
+for /f "usebackq tokens=2*" %%i in (`powershell Get-FileHash -Algorithm sha1 %GOPATH%\src\github.com\keybase\kbfs\dokan\dokan.lib`) do set DOKANLIBHASH=%%i
+if NOT %DOKANLIBHASH%==1C9316A567B805C4A6ADAF0ABE1424FFFB36A3BD exit /B 1
+for /f "usebackq tokens=2*" %%i in (`powershell Get-FileHash -Algorithm sha1 %GOPATH%\bin\dokan-dev\dokan-v0.8.0\Win32\Release\dokan.dll`) do set DOKANDLLHASH=%%i
+if NOT %DOKANDLLHASH%==5C4FC6B6E3083E575EED06DE3115A6D05B30DB02 exit /B 1
+
 pushd %GOPATH%\src\github.com\keybase\kbfs\kbfsdokan
 :: winresource invokes git to get the current revision
 for /f %%i in ('git -C %GOPATH%\src\github.com\keybase\kbfs rev-parse --short HEAD') do set KBFS_HASH=%%i

--- a/packaging/windows/doinstaller_gui.cmd
+++ b/packaging/windows/doinstaller_gui.cmd
@@ -23,7 +23,7 @@ echo %SEMVER%
 
 :: dokan source binaries.
 :: There are 8 (4 windows versions times 32/64 bit) but they all seem to have the same version.
-for /f %%i in ('PowerShell "(Get-Item %GOPATH%\bin\dokan-dev\dokan-v1.0.0-RC2\Win32\Win10Release\dokan1.sys).VersionInfo.FileVersion"') do set DOKANVER=%%i
+for /f %%i in ('PowerShell "(Get-Item %GOPATH%\bin\dokan-dev\dokan-v0.8.0\Win32\Win10Release\dokan.sys).VersionInfo.FileVersion"') do set DOKANVER=%%i
 echo %DOKANVER%
 IF %DOKANVER%=="" (
   EXIT /B 1

--- a/packaging/windows/setup_windows_gui.iss
+++ b/packaging/windows/setup_windows_gui.iss
@@ -28,7 +28,7 @@
 ; NOTE: The value of AppId uniquely identifies this application.
 ; Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-AppId={{1B2672D9-2BAD-4C11-BA53-A75AF6FD7789}
+AppId={{357F272E-BE0E-409F-8E39-0BB9827F5716}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 ;AppVerName={#MyAppName} {#MyAppVersion}
@@ -58,7 +58,7 @@ SignTool=SignCommand
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
-; Unpack the dokan components in $GOPATH\bin\dokan-dev\dokan-v1.0.0-RC2
+; Unpack the dokan components in $GOPATH\bin\dokan-dev\dokan-v0.8.0
 ; Download the Visuap Studio 2015 redistributable to $GOPATH\bin
 
 [Files]
@@ -66,26 +66,27 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Source: "{#MyExePathName}"; DestDir: "{app}"; Flags: ignoreversion
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 Source: "..\..\desktop\release\win32-ia32\Keybase-win32-ia32\*"; DestDir: "{app}\gui"; Flags: createallsubdirs recursesubdirs replacesameversion
-Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v1.0.0-RC2\Win32\Win7Release\dokan1.sys"; DestDir: "{sys}\drivers"; Check: IsOtherArch and IsWindows7 and IsDokanBeingUpdated
-Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v1.0.0-RC2\Win32\Win8Release\dokan1.sys"; DestDir: "{sys}\drivers"; Check: IsOtherArch and IsWindows8 and IsDokanBeingUpdated
-Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v1.0.0-RC2\Win32\Win8.1Release\dokan1.sys"; DestDir: "{sys}\drivers"; Check: IsOtherArch and IsWindows8_1 and IsDokanBeingUpdated
-Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v1.0.0-RC2\Win32\Win10Release\dokan1.sys"; DestDir: "{sys}\drivers"; Check: IsOtherArch and IsWindows10 and IsDokanBeingUpdated
-Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v1.0.0-RC2\Win32\Release\dokan1.dll"; DestDir: "{sys}"; Flags: 32bit
-Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v1.0.0-RC2\Win32\Release\dokannp1.dll"; DestDir: "{sys}"; Flags: 32bit
-Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v1.0.0-RC2\x64\Win7Release\dokan1.sys"; DestDir: "{sys}\drivers"; Check: IsX64 and IsWindows7 and IsDokanBeingUpdated
-Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v1.0.0-RC2\x64\Win8Release\dokan1.sys"; DestDir: "{sys}\drivers"; Check: IsX64 and IsWindows8 and IsDokanBeingUpdated
-Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v1.0.0-RC2\x64\Win8.1Release\dokan1.sys"; DestDir: "{sys}\drivers"; Check: IsX64 and IsWindows8_1 and IsDokanBeingUpdated
-Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v1.0.0-RC2\x64\Win10Release\dokan1.sys"; DestDir: "{sys}\drivers"; Check: IsX64 and IsWindows10 and IsDokanBeingUpdated
-Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v1.0.0-RC2\x64\Release\dokan1.dll"; DestDir: "{sys}"; Flags: 64bit; Check: IsX64
-Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v1.0.0-RC2\x64\Release\dokannp1.dll"; DestDir: "{sys}"; Flags: 64bit; Check: IsX64
-Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v1.0.0-RC2\Win32\Release\dokanctl.exe"; DestDir: "{pf32}\Dokan\DokanLibrary"
+Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v0.8.0\Win32\Win7Release\dokan.sys"; DestDir: "{sys}\drivers"; Check: IsOtherArch and IsWindows7 and IsDokanBeingInstalled
+Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v0.8.0\Win32\Win8Release\dokan.sys"; DestDir: "{sys}\drivers"; Check: IsOtherArch and IsWindows8 and IsDokanBeingInstalled
+Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v0.8.0\Win32\Win8.1Release\dokan.sys"; DestDir: "{sys}\drivers"; Check: IsOtherArch and IsWindows8_1 and IsDokanBeingInstalled
+Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v0.8.0\Win32\Win10Release\dokan.sys"; DestDir: "{sys}\drivers"; Check: IsOtherArch and IsWindows10 and IsDokanBeingInstalled
+Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v0.8.0\Win32\Release\dokan.dll"; DestDir: "{sys}"; Flags: 32bit; Check: IsDokanBeingInstalled
+Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v0.8.0\Win32\Release\dokannp.dll"; DestDir: "{sys}"; Flags: 32bit; Check: IsDokanBeingInstalled
+Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v0.8.0\x64\Win7Release\dokan.sys"; DestDir: "{sys}\drivers"; Check: IsX64 and IsWindows7 and IsDokanBeingInstalled
+Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v0.8.0\x64\Win8Release\dokan.sys"; DestDir: "{sys}\drivers"; Check: IsX64 and IsWindows8 and IsDokanBeingInstalled
+Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v0.8.0\x64\Win8.1Release\dokan.sys"; DestDir: "{sys}\drivers"; Check: IsX64 and IsWindows8_1 and IsDokanBeingInstalled
+Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v0.8.0\x64\Win10Release\dokan.sys"; DestDir: "{sys}\drivers"; Check: IsX64 and IsWindows10 and IsDokanBeingInstalled
+Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v0.8.0\x64\Release\dokan.dll"; DestDir: "{sys}"; Flags: 64bit; Check: IsX64 and IsDokanBeingInstalled
+Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v0.8.0\x64\Release\dokannp.dll"; DestDir: "{sys}"; Flags: 64bit; Check: IsX64 and IsDokanBeingInstalled
+; install only 32 bit versions of dokanctl and mounter, otherwise we need 64 bit redistributables too
+Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v0.8.0\Win32\Release\dokanctl.exe"; DestDir: "{pf32}\Dokan\DokanLibrary"; Check: IsDokanBeingInstalled
+Source: "..\..\..\..\..\..\bin\dokan-dev\dokan-v0.8.0\Win32\Release\mounter.exe"; DestDir: "{pf32}\Dokan\DokanLibrary"; Check:  IsDokanBeingInstalled
 Source: "..\..\..\..\..\..\bin\vc_redist.x86.exe"; DestDir: "{tmp}"
 Source: "..\..\..\kbfs\kbfsdokan\kbfsdokan.exe"; DestDir: "{app}"; Flags: replacesameversion
 
 [Icons]
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 Name: "{group}\{#MyAppName} CMD"; Filename: "cmd.exe"; WorkingDir: "{app}"; IconFilename: "{app}\{#MyExeName}"; Parameters: "/K ""set PATH=%PATH%;{app}"""
-Name: "{userstartup}\Keybase UI"; Filename: "{app}\gui\Keybase.exe"
 Name: "{group}\Keybase UI"; Filename: "{app}\gui\Keybase.exe"
 
 [Registry]
@@ -97,7 +98,7 @@ WelcomeLabel2=This will install [name/ver] on your computer.
 [Run]
 Filename: "{tmp}\vc_redist.x86.exe"; Parameters: "/quiet /Q:a /c:""msiexec /qb /i vcredist.msi"""; StatusMsg: "Installing VisualStudio 2015 RunTime..."
 Filename: "{app}\{#MyExeName}"; Parameters: "ctl watchdog"; Flags: runasoriginaluser runhidden nowait
-Filename: "{pf32}\Dokan\DokanLibrary\dokanctl.exe"; Parameters: "/i d"; WorkingDir: "{pf32}\Dokan\DokanLibrary"; Flags: runhidden; Description: "Install Dokan Service"; Check: IsDokanBeingUpdated
+Filename: "{pf32}\Dokan\DokanLibrary\dokanctl.exe"; Parameters: "/i a"; WorkingDir: "{pf32}\Dokan\DokanLibrary"; Flags: runhidden; Description: "Install Dokan Service"; Check: IsDokanBeingInstalled
 Filename: "{app}\gui\Keybase.exe"; WorkingDir: "{app}\gui"; Flags: nowait runasoriginaluser
 Filename: "{app}\kbfsdokan.exe"; Parameters: "-log-to-file -debug k:"; Flags: runasoriginaluser runhidden nowait
 
@@ -112,7 +113,6 @@ Filename: "taskkill"; Parameters: "/f /im Keybase.exe"; Flags: runhidden
 Filename: "taskkill"; Parameters: "/f /im kbfsdokan.exe"; Flags: runhidden
 Filename: "{app}\{#MyExeName}"; Parameters: "ctl stop"; WorkingDir: "{app}"; Flags: skipifdoesntexist runhidden
 Filename: "{pf32}\Dokan\DokanLibrary\dokanctl.exe"; Parameters: "/u k /f"; Flags: runhidden
-; Legacy Dokan
 Filename: "{pf32}\Dokan\DokanLibrary\dokanctl.exe"; Parameters: "/r a"; Flags: runhidden
 Filename: "{pf32}\Dokan\DokanLibrary\dokanctl.exe"; Parameters: "/r d"; Flags: runhidden
 
@@ -147,7 +147,7 @@ var
 begin
   // Default is hardcoded to match AppId, above
   if AppIdString = '' then
-    AppIdString := '{1B2672D9-2BAD-4C11-BA53-A75AF6FD7789}';
+    AppIdString := '{357F272E-BE0E-409F-8E39-0BB9827F5716}';
   sUnInstPath := 'Software\Microsoft\Windows\CurrentVersion\Uninstall\' + AppIdString + '_is1';
   sUnInstallString := '';
   
@@ -165,9 +165,15 @@ var
   AppIdString: String;
 
 begin
+  // Hardcoded app IDs from previous installers:
+  // Old Dokan 0.8 based client
   AppIdString := '{DEB2E54C-C39F-4DC8-93A7-ABE0AB91DDCA}';
-  // Hardcoded app ID from previous installers
   Result := GetUninstallString(AppIdString);
+  if Result = '' then begin
+    // Ill fated Dokan 1.0.0 RC2
+    AppIdString := '{1B2672D9-2BAD-4C11-BA53-A75AF6FD7789}';
+    Result := GetUninstallString(AppIdString);  
+  end
   // Add more as we change the appId
 end;
 
@@ -242,13 +248,14 @@ begin
   Result := true;
   fileName := ExpandConstant('{userstartup}\{#MyAppName}.vbs');
   Log('Created ' + fileName);
-  SetArrayLength(lines, 5);
+  SetArrayLength(lines, 6);
 
   lines[0] := 'Dim WinScriptHost';
   lines[1] := 'Set WinScriptHost = CreateObject("WScript.Shell")';
   lines[2] := ExpandConstant('WinScriptHost.Run Chr(34) & "{app}\{#MyExeName}" & Chr(34) & " ctl watchdog", 0');
   lines[3] := ExpandConstant('WinScriptHost.Run Chr(34) & "{app}\kbfsdokan.exe" & Chr(34) & " -log-to-file -debug k:", 0');
-  lines[4] := 'Set WinScriptHost = Nothing';
+  lines[4] := ExpandConstant('WinScriptHost.Run Chr(34) & "{app}\gui\Keybase.exe" & Chr(34), 0');
+  lines[5] := 'Set WinScriptHost = Nothing';
 
   Result := SaveStringsToFile(filename,lines,true);
   exit;
@@ -267,7 +274,7 @@ begin
 end;
 
 
-function IsDokanBeingUpdated(): Boolean;
+function IsDokanBeingInstalled(): Boolean;
 var
   newVer: String;
 
@@ -278,10 +285,10 @@ begin
   Result := not (CompareStr(g_currentDokanVer, newVer) = 0)
 end;
 
-// Restart if the driver got changed
+// Assume if the driver is being updated, we've already rebooted
 function NeedRestart(): Boolean;
 begin
-  Result := (Length(g_currentDokanVer) > 0) and IsDokanBeingUpdated();
+  Result := false
 end;
 
 procedure StopKeybaseService();
@@ -300,13 +307,6 @@ begin
     ewWaitUntilTerminated, ResultCode);
   Exec('taskkill.exe', '/f /im kbfsdokan.exe', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
   Sleep(100);
-  if IsDokanBeingUpdated() then
-  begin
-    Exec(ExpandConstant('{pf32}\Dokan\DokanLibrary\dokanctl.exe'), '/u k /f', '', SW_HIDE,
-      ewWaitUntilTerminated, ResultCode);
-    Exec(ExpandConstant('{pf32}\Dokan\DokanLibrary\dokanctl.exe'), '/r d', '', SW_HIDE,
-      ewWaitUntilTerminated, ResultCode);
-  end
 end;
 
 function UninstallNeedRestart(): Boolean;
@@ -364,7 +364,9 @@ begin
           Log('Restarted, removing legacy stuff');
           DeleteFile(dokanCtlName);
           DeleteFile(ExpandConstant('{pf32}\Dokan\DokanLibrary\mounter.exe'));
+          DeleteFile(ExpandConstant('{pf32}\Dokan\DokanLibrary\dokanctl.exe'));
           DeleteFile(ExpandConstant('{sys}\drivers\dokan.sys'));
+          DeleteFile(ExpandConstant('{sys}\drivers\dokan1.sys'));
     end else begin
       CheckAndUninstallCLI
       if IsUpgradeFromPrevious then
@@ -387,9 +389,17 @@ var
     ResultCode: Integer;
 
 begin
-    fileName := ExpandConstant('{sys}\drivers\dokan1.sys');
+    fileName := ExpandConstant('{sys}\drivers\dokan.sys');
     GetVersionNumbersString(fileName, g_currentDokanVer);
-    // overwrite old dokan components
+
+    // The problem here is that no dokan components except the driver have
+    // version information, but the driver can't be deleted by normal 
+    // uninstall. So we have to assume that we're installing if dokanctl.exe
+    // is not already there - dokan.sys could be a leftover.
+    if not FileExists(ExpandConstant('{pf32}\Dokan\DokanLibrary\dokanctl.exe')) then
+       g_currentDokanVer :=  '';
+    
+    // Overall product upgrade also equals driver install
     if IsUpgradeFromPrevious() then
        g_currentDokanVer := '';
 
@@ -411,6 +421,7 @@ begin
     end else begin
       Result := true;
       DeleteFile(ExpandConstant('{sys}\drivers\dokan.sys'));
+      DeleteFile(ExpandConstant('{sys}\drivers\dokan1.sys'));
     end;
 end;
 


### PR DESCRIPTION
Give up on updating drivers without uninstall.

I tried the following:
- upgrading from an install containing dokan 1.0.0RC2 drivers
- upgrading from an install containing dokan 0.8 drivers
- installing on a clean machine
- installing on a clean machine except leftover dokan.sys file
- 32 bit Windows 7

With Marco's pending fix we may be close to back in biz.
@maxtaco @taruti 