### PR TITLE
Windows pinentry fix desktop 991

### DIFF
--- a/desktop/renderer/remote-component-loader.js
+++ b/desktop/renderer/remote-component-loader.js
@@ -34,6 +34,18 @@ const getCurrentWindow = (function () {
   }
 })()
 
+// Will keep trying to show a window until it is visible
+const showStubbornly = (currentWindow, delay) => {
+  const id = setInterval(() => {
+    if (currentWindow.isVisible()) {
+      clearInterval(id)
+    } else {
+      currentWindow.show()
+    }
+  }, delay)
+  return () => { clearInterval(id) }
+}
+
 function getQueryVariable (variable) {
   var query = window.location.search.substring(1)
   var vars = query.split('&')
@@ -91,14 +103,14 @@ class RemoteComponentLoader extends Component {
           Object.keys(this.store.getState()).length === 0) {
         const unsub = this.store.subscribe(() => {
           unsub()
-          getCurrentWindow().show()
+          showStubbornly(getCurrentWindow(), 1e3)
           this.setState({props: props, loaded: true})
         })
       } else {
         // If we've received props, and the loaded state was false, that
         // means we should show the window
         if (this.state.loaded === false) {
-          currentWindow.show()
+          showStubbornly(getCurrentWindow(), 1e3)
         }
         setImmediate(() => this.setState({props: props, loaded: true}))
       }

--- a/desktop/renderer/remote-component-loader.js
+++ b/desktop/renderer/remote-component-loader.js
@@ -41,6 +41,7 @@ const showStubbornly = (currentWindow, delay) => {
       clearInterval(id)
     } else {
       currentWindow.show()
+      currentWindow.isVisible() && clearInterval(id)
     }
   }, delay)
   return () => { clearInterval(id) }


### PR DESCRIPTION
@keybase/react-hackers 

On Windows, when booting, we get to the code path that calls `.show()` on the pinentry window before Windows lets us actually show windows, so the call to `.show()` fails.

`isVisible` is correct though, so this creates a new function that will call `.show` every `delay` ms, and stop after the window is visible.

We use that new function on windows to make sure the pinentry (and any other remote components) get shown properly on startup.

@zanderz  