### PR TITLE
Remove link latest command

### DIFF
--- a/packaging/prerelease/s3_index.sh
+++ b/packaging/prerelease/s3_index.sh
@@ -44,6 +44,3 @@ echo "Checking if we need to promote a release for testing ($platform)"
 
 echo "Checking if we need to promote a release ($platform)"
 "$release_bin" promote-releases --bucket-name="$bucket_name" --platform="$platform"
-
-echo "Linking latest ($platform)"
-"$release_bin" latest --bucket-name="$bucket_name" --platform="$platform"

--- a/packaging/windows/s3_prerelease.cmd
+++ b/packaging/windows/s3_prerelease.cmd
@@ -12,9 +12,6 @@ set release_bin=%GOPATH%\bin\windows_386\release.exe
 echo "Creating index files"
 %release_bin% index-html --bucket-name=%BUCKET_NAME% --prefixes="windows/" --upload="windows/index.html"
 
-echo "Linking latest"
-%release_bin% latest --bucket-name=%BUCKET_NAME% --platform=windows
-
 echo "Checking if we need to promote a release for testing"
 %release_bin% promote-test-releases --bucket-name=%BUCKET_NAME% --platform=windows
 


### PR DESCRIPTION
Works alongside this PR: https://github.com/keybase/release/pull/8

@gabriel 
@zanderz You'll have to update the release_bin you're using. 

@oconnor663 (I don't think linux used this command, right?)