### PR TITLE
Updater check-in-use command should output JSON instead of exit code

### DIFF
--- a/go/client/cmd_update.go
+++ b/go/client/cmd_update.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -301,11 +302,18 @@ func (v *CmdUpdateCheckInUse) ParseArgv(ctx *cli.Context) error {
 	return nil
 }
 
+type checkInUseResult struct {
+	InUse bool `json:"in_use"`
+}
+
 func (v *CmdUpdateCheckInUse) Run() error {
 	inUse := install.IsInUse(v.G().Env.GetMountDir(), G.Log)
-	if inUse {
-		os.Exit(100)
+	result := checkInUseResult{InUse: inUse}
+	out, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
 	}
+	fmt.Fprintf(os.Stdout, "%s\n", out)
 	return nil
 }
 


### PR DESCRIPTION
Instead of using a weird exit code. Exit code is hard to determine cross platform and JSON is more helpful. Also is probably a good idea to avoid exit codes unless there was a real error.