### PR TITLE
Integrate new DeviceHistoryRPC

### DIFF
--- a/shared/actions/devices.js
+++ b/shared/actions/devices.js
@@ -3,7 +3,7 @@ import * as Constants from '../constants/devices'
 import engine from '../engine'
 import {navigateUpOnUnchanged} from './router'
 import type {AsyncAction} from '../constants/types/flux'
-import type {incomingCallMapType, revoke_revokeDevice_rpc, device_deviceList_rpc, login_paperKey_rpc} from '../constants/types/flow-types'
+import type {incomingCallMapType, revoke_revokeDevice_rpc, device_deviceHistoryList_rpc, login_paperKey_rpc} from '../constants/types/flow-types'
 // import {loginTab} from '../constants/tabs'
 
 export function loadDevices () : AsyncAction {
@@ -13,8 +13,8 @@ export function loadDevices () : AsyncAction {
       payload: null
     })
 
-    const params : device_deviceList_rpc = {
-      method: 'device.deviceList',
+    const params : device_deviceHistoryList_rpc = {
+      method: 'device.deviceHistoryList',
       param: {},
       incomingCallMap: {},
       callback: (error, devices) => {

--- a/shared/constants/types/more.js
+++ b/shared/constants/types/more.js
@@ -1,10 +1,20 @@
 // @flow
 
 import {Component} from 'react' // eslint-disable-line
-import type {Device as _Device} from './flow-types'
 
 export type DeviceType = 'mobile' | 'desktop' | 'backup'
-export type Device = {type: DeviceType} & _Device
+import type {Device as _Device, DeviceID, Time} from './flow-types'
+
+export type Device = {
+  name: string;
+  deviceID: DeviceID;
+  type: DeviceType;
+  created: Time;
+  currentDevice: boolean;
+  provisioner: ?_Device;
+  provisionedAt: ?Time;
+  revokedAt: ?Time;
+}
 
 // Converts a string to the DeviceType enum, logging an error if it doesn't match
 export function toDeviceType (s: string): DeviceType {

--- a/shared/devices/dumb.js
+++ b/shared/devices/dumb.js
@@ -1,57 +1,57 @@
 /* @flow */
 import Devices from './render'
-import type {Device} from '../constants/types/flow-types'
+import type {Device} from '../constants/types/more'
 
 const dev1: Device = {
-  cTime: 1444423192000,
-  deviceID: '3d2e716574f68fb4eb5b56a5ec8eeeee',
-  encryptKey: '',
-  mTime: 1444423192000,
   name: 'Paper Key (lorem ipsum...)',
-  status: 0,
+  deviceID: '3d2e716574f68fb4eb5b56a5ec8eeeee',
   type: 'backup',
-  verifyKey: '',
-  isCurrent: false
+  created: 1444423192000,
+  currentDevice: false,
+  provisioner: null,
+  provisionedAt: 1444423192000,
+  revokedAt: null
 }
 
 const dev2: Device = {
-  cTime: 1444423193000,
-  deviceID: '7289c92083fc6a2b6d46e26212e00000',
-  encryptKey: '',
-  mTime: 1444423194000,
   name: 'My Desktop',
-  status: 0,
+  deviceID: '7289c92083fc6a2b6d46e26212e00000',
   type: 'desktop',
-  verifyKey: '',
-  isCurrent: true
+  created: 1444423193000,
+  currentDevice: true,
+  provisioner: null,
+  provisionedAt: 1444423193000,
+  revokedAt: null
 }
 
 const dev3: Device = {
-  cTime: 1450305567000,
-  deviceID: '729cb1b72ebadafee219759c33399999',
-  encryptKey: '',
-  mTime: 1450305567000,
   name: 'My Phone',
-  status: 0,
+  deviceID: '729cb1b72ebadafee219759c33399999',
   type: 'mobile',
-  verifyKey: '',
-  isCurrent: false
+  created: 1450305567000,
+  currentDevice: false,
+  provisioner: null,
+  provisionedAt: 1450305567000,
+  revokedAt: null
 }
 
 const rev1: Device = {
   ...dev1,
-  name: 'Paper Key (revo ked...)'
+  name: 'Paper Key (revo ked...)',
+  revokedAt: 1444423192000
 }
 
 const rev2: Device = {
   ...dev2,
   name: 'My Revoked Desktop',
-  isCurrent: false
+  currentDevice: false,
+  revokedAt: 1444423193000
 }
 
 const rev3: Device = {
   ...dev3,
-  name: 'My Revoked Phone'
+  name: 'My Revoked Phone',
+  revokedAt: 1444423193000
 }
 
 const devices: Array<Device> = [

--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -35,7 +35,8 @@ class Devices extends Component {
   render () {
     return (
       <Render
-        devices={this.props.devices}
+        devices={this.props.devices && this.props.devices.filter(dev => !dev.revokedAt)}
+        revokedDevices={this.props.devices && this.props.devices.filter(dev => dev.revokedAt)}
         waitingForServer={this.props.waitingForServer}
         addNewDevice={this.props.addNewDevice}
         showRemoveDevicePage={this.props.showRemoveDevicePage}

--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
+import _ from 'lodash'
 
 import CodePage from '../login/register/code-page'
 import GenPaperKey from './gen-paper-key'
@@ -33,10 +34,13 @@ class Devices extends Component {
   }
 
   render () {
+    // Divide the devices array into not-revoked and revoked.
+    const [devices, revokedDevices] = _.partition(this.props.devices, dev => !dev.revokedAt)
+
     return (
       <Render
-        devices={this.props.devices && this.props.devices.filter(dev => !dev.revokedAt)}
-        revokedDevices={this.props.devices && this.props.devices.filter(dev => dev.revokedAt)}
+        devices={devices}
+        revokedDevices={revokedDevices}
         waitingForServer={this.props.waitingForServer}
         addNewDevice={this.props.addNewDevice}
         showRemoveDevicePage={this.props.showRemoveDevicePage}

--- a/shared/devices/render.desktop.js
+++ b/shared/devices/render.desktop.js
@@ -5,6 +5,7 @@ import {globalStyles, globalColors} from '../styles/style-guide'
 import type {Props as IconProps} from '../common-adapters/icon'
 
 import type {Props} from './index'
+import type {Device as DeviceType} from '../constants/types/flow-types'
 
 type RevokedHeaderState = {expanded: boolean}
 
@@ -65,7 +66,7 @@ const DeviceRow = ({device, revoked, showRemoveDevicePage, showExistingDevicePag
           <Text style={textStyle} type='Header'>{device.name}</Text>
         </Box>
         <Box style={{...globalStyles.flexBoxRow}}>
-          {device.isCurrent && <Text type='BodySmall'>Current device</Text>}
+          {device.currentDevice && <Text type='BodySmall'>Current device</Text>}
         </Box>
       </Box>
       <Box style={{...stylesRevokedColumn}}>
@@ -83,8 +84,8 @@ const RevokedDescription = () => (
 
 const RevokedDevices = ({revokedDevices}) => (
   <RevokedHeader>
-    <RevokedDescription />
-    {revokedDevices.map(device => <DeviceRow key={device.name} device={device} revoked />)}
+    <RevokedDescription/>
+    {revokedDevices.map(device => <DeviceRow key={device.name} device={device} revoked/>)}
   </RevokedHeader>
 )
 

--- a/shared/devices/render.desktop.js
+++ b/shared/devices/render.desktop.js
@@ -5,7 +5,6 @@ import {globalStyles, globalColors} from '../styles/style-guide'
 import type {Props as IconProps} from '../common-adapters/icon'
 
 import type {Props} from './index'
-import type {Device as DeviceType} from '../constants/types/flow-types'
 
 type RevokedHeaderState = {expanded: boolean}
 
@@ -84,8 +83,8 @@ const RevokedDescription = () => (
 
 const RevokedDevices = ({revokedDevices}) => (
   <RevokedHeader>
-    <RevokedDescription/>
-    {revokedDevices.map(device => <DeviceRow key={device.name} device={device} revoked/>)}
+    <RevokedDescription />
+    {revokedDevices.map(device => <DeviceRow key={device.name} device={device} revoked />)}
   </RevokedHeader>
 )
 

--- a/shared/devices/render.native.js
+++ b/shared/devices/render.native.js
@@ -67,7 +67,7 @@ const DeviceRow = ({device, revoked, showRemoveDevicePage, showExistingDevicePag
           <Text style={textStyle} type='BodySemibold'>{device.name}</Text>
         </Box>
         <Box style={{...globalStyles.flexBoxRow}}>
-          {device.isCurrent && <Text type='BodySmall'>Current device</Text>}
+          {device.currentDevice && <Text type='BodySmall'>Current device</Text>}
         </Box>
       </Box>
       <Box style={stylesRevokedColumn}>

--- a/shared/reducers/devices.js
+++ b/shared/reducers/devices.js
@@ -24,7 +24,16 @@ export default function (state = initialState, action) {
       return {
         ...state,
         error: action.error && action.payload,
-        devices: action.error ? [] : action.payload,
+        devices: action.error ? [] : action.payload.map(dev => ({
+          name: dev.device.name,
+          deviceID: dev.device.deviceID,
+          type: dev.device.type,
+          created: dev.device.created,
+          currentDevice: dev.currentDevice,
+          provisioner: dev.provisioner,
+          provisionedAt: dev.provisionedAt,
+          revokedAt: dev.revokedAt
+        })),
         waitingForServer: false
       }
     case Constants.deviceRemoved:


### PR DESCRIPTION
@keybase/react-hackers 

This PR switches to using the new DeviceHistoryListRPC, which contains extra information about provisioning and revocation.

Previously we were passing the RPC payload directly to our components, so this also specifies a new Device type and uses it in the reducer, and updates the render components and dumb-sheet component's mock data to use it.

No visible UI changes.