### PR TITLE
Fix wrapped Menubar items collapsing when out of space

### DIFF
--- a/shared/menubar/dumb.desktop.js
+++ b/shared/menubar/dumb.desktop.js
@@ -1,0 +1,60 @@
+// @flow
+
+import Menubar from './index.render'
+import type {RenderProps, FolderInfo} from './index.render'
+import type {DumbComponentMap} from '../constants/types/more'
+
+const folder1: FolderInfo = {
+  type: 'folder',
+  folderName: 'max,chris',
+  isPublic: true,
+  isEmpty: false,
+  openFolder: () => {}
+}
+
+const folderLong: FolderInfo = {
+  type: 'folder',
+  folderName: 'max,chris,marcopolo,patrick,strib,mgood,zanderz,gabrielh,chrisnojima,cbostrander,alness,akalin',
+  isPublic: true,
+  isEmpty: false,
+  openFolder: () => {}
+}
+
+const folder2: FolderInfo = {
+  type: 'folder',
+  folderName: 'mgood,strib,marcopolo',
+  isPublic: true,
+  isEmpty: false,
+  openFolder: () => {}
+}
+
+const propsNormal: RenderProps = {
+  username: 'max',
+  openKBFS: () => {},
+  openKBFSPublic: username => {},
+  logIn: () => {},
+  openKBFSPrivate: username => {},
+  showMain: () => {},
+  showHelp: () => {},
+  showUser: username => {},
+  quit: () => {},
+  folders: [
+    folder1,
+    folderLong,
+    folder2
+  ],
+  debug: false,
+  loading: false,
+  loggedIn: true
+}
+
+const dumbComponentMap: DumbComponentMap<Menubar> = {
+  component: Menubar,
+  mocks: {
+    'Normal': propsNormal,
+  }
+}
+
+export default {
+  'Menubar': dumbComponentMap
+}

--- a/shared/menubar/dumb.desktop.js
+++ b/shared/menubar/dumb.desktop.js
@@ -4,7 +4,7 @@ import Menubar from './index.render'
 import type {RenderProps, FolderInfo} from './index.render'
 import type {DumbComponentMap} from '../constants/types/more'
 
-const folder1: FolderInfo = {
+const folder1 = {
   type: 'folder',
   folderName: 'max,chris',
   isPublic: true,
@@ -12,7 +12,7 @@ const folder1: FolderInfo = {
   openFolder: () => {}
 }
 
-const folderLong: FolderInfo = {
+const folderLong = {
   type: 'folder',
   folderName: 'max,chris,marcopolo,patrick,strib,mgood,zanderz,gabrielh,chrisnojima,cbostrander,alness,akalin',
   isPublic: true,
@@ -20,7 +20,7 @@ const folderLong: FolderInfo = {
   openFolder: () => {}
 }
 
-const folder2: FolderInfo = {
+const folder2 = {
   type: 'folder',
   folderName: 'mgood,strib,marcopolo',
   isPublic: true,
@@ -28,7 +28,7 @@ const folder2: FolderInfo = {
   openFolder: () => {}
 }
 
-const propsNormal: RenderProps = {
+const propsNormal = {
   username: 'max',
   openKBFS: () => {},
   openKBFSPublic: username => {},

--- a/shared/menubar/index.render.desktop.js
+++ b/shared/menubar/index.render.desktop.js
@@ -106,6 +106,7 @@ const Row = props => {
   const containerStyle = {
     ...globalStyles.flexBoxRow,
     alignItems: 'flex-start',
+    flexShrink: 0,
     marginTop: 1,
     marginBottom: 1,
     minHeight: 25,

--- a/shared/menubar/index.render.js.flow
+++ b/shared/menubar/index.render.js.flow
@@ -17,9 +17,7 @@ export type RenderProps = {
   loggedIn: boolean
 }
 
-export default class Render extends Component {
-  props: RenderProps;
-}
+export default class Render extends Component<void, RenderProps, void> {}
 
 export type FolderInfo = {
     type: 'folder',

--- a/shared/more/dumb-sheet.render.desktop.js
+++ b/shared/more/dumb-sheet.render.desktop.js
@@ -8,6 +8,7 @@ import CommonMap from '../common-adapters/dumb.desktop'
 import DevicesMap from '../devices/dumb'
 import LoginMap from '../login/dumb.desktop'
 import SignupMap from '../login/signup/dumb.desktop'
+import MenubarMap from '../menubar/dumb.desktop'
 import TrackerMap from '../tracker/dumb.desktop'
 import PinentryMap from '../pinentry/dumb.desktop'
 import DevicePageMap from '../devices/device-page/dumb.desktop'
@@ -38,6 +39,7 @@ class Render extends Component<void, any, any> {
       ...DevicesMap,
       ...LoginMap,
       ...SignupMap,
+      ...MenubarMap,
       ...TrackerMap,
       ...PinentryMap,
       ...DevicePageMap,


### PR DESCRIPTION
Just needed to add `flex-shrink` to the menu items. And debug 9p/overlayfs kernel oops, set up file syncing, learn 100 things, etc etc...

:eyes: @keybase/react-hackers 