### PR TITLE
Switch global dev tools installation from default on to default off

### DIFF
--- a/desktop/npm-helper.js
+++ b/desktop/npm-helper.js
@@ -158,7 +158,7 @@ function postInstall () {
     fixupSymlinks()
   }
 
-  if (!process.env.KEYBASE_SKIP_DEV_TOOLS) {
+  if (process.env.KEYBASE_INSTALL_DEV_TOOLS) {
     const modules = Object.keys(postinstallGlobals).map(k => `${k}${postinstallGlobals[k]}`).join(' ')
     exec(`npm install -g -E ${modules}`)
   }

--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -59,10 +59,8 @@ if should_build_kbfs ; then
   echo "Installing Node modules for Electron"
   # Can't seem to get the right packages installed under NODE_ENV=production.
   export NODE_ENV=development
-  export KEYBASE_SKIP_DEV_TOOLS=1
   npm cache clean
   (cd "$this_repo/desktop" && npm i)
-  unset KEYBASE_SKIP_DEV_TOOLS
   export NODE_ENV=production
 fi
 


### PR DESCRIPTION
This has hit me a couple times: since I typically run `npm install` unprivileged, the install fails in the postinstall phase when it doesn't have permissions to install these packages globally. What do you think of making this behavior opt-in rather than opt-out?

:eyeglasses: @keybase/react-hackers 