### PR TITLE
Qr new mobile flow desktop 942

### DIFF
--- a/shared/actions/login/provision-helpers.js
+++ b/shared/actions/login/provision-helpers.js
@@ -1,7 +1,7 @@
 // @flow
 import * as Constants from '../../constants/login'
 import QRCodeGen from 'qrcode-generator'
-import type {DeviceRole, Mode} from '../../reducers/login'
+import type {DeviceRole, Mode} from '../../constants/login'
 
 export function defaultModeForDeviceRoles (myDeviceRole: DeviceRole, otherDeviceRole: DeviceRole, brokenMode: boolean): ?Mode {
   switch (myDeviceRole + otherDeviceRole) {

--- a/shared/common-adapters/tab-bar.native.js
+++ b/shared/common-adapters/tab-bar.native.js
@@ -88,7 +88,7 @@ class TabBar extends Component {
     return (this.props.children || []).map((item, i) => (
       <TouchableWithoutFeedback key={item.props.label || i} onPress={item.props.onPress || (() => {})}>
         <Box style={item.props.containerStyle}>
-          {item.props.tabBarButton || <SimpleTabBarButton label={item.props.label} selected={item.props.selected} underlined={this.props.underlined} />}
+          {item.props.tabBarButton || <SimpleTabBarButton tabWidth={this.props.tabWidth} label={item.props.label} selected={item.props.selected} underlined={this.props.underlined} />}
         </Box>
       </TouchableWithoutFeedback>
     ))

--- a/shared/constants/login.js
+++ b/shared/constants/login.js
@@ -37,3 +37,4 @@ export const actionRegisteredWithPaperKey = 'login:actionRegisteredWithPaperKey'
 export const actionRegisteredWithExistingDevice = 'login:actionRegisteredWithExistingDevice'
 
 export type DeviceRole = 'codePageDeviceRoleExistingPhone' | 'codePageDeviceRoleNewPhone' | 'codePageDeviceRoleExistingComputer' | 'codePageDeviceRoleNewComputer'
+export type Mode = 'codePageModeScanCode' | 'codePageModeShowCode' | 'codePageModeEnterText' | 'codePageModeShowText'

--- a/shared/login/register/code-page/dumb.js
+++ b/shared/login/register/code-page/dumb.js
@@ -1,0 +1,30 @@
+// @flow
+
+import Render from './index.render'
+import type {DumbComponentMap} from '../../../constants/types/more'
+
+export type Mode = 'codePageModeScanCode' | 'codePageModeShowCode' | 'codePageModeEnterText' | 'codePageModeShowText'
+const baseMock = {
+  mode: 'codePageModeScanCode',
+  textCode: 'go hammer go hammer go hammer go stop hammer time',
+  qrCode: 'go hammer go hammer go hammer go stop hammer time',
+  myDeviceRole: 'codePageDeviceRoleNewPhone',
+  otherDeviceRole: 'codePageDeviceRoleExistingComputer',
+  cameraBrokenMode: false,
+  setCodePageMode: () => {},
+  qrScanned: data => console.log('QR Scanned:', data),
+  setCameraBrokenMode: () => {},
+  textEntered: () => console.log('textEntered'),
+  onChangeText: () => console.log('onChangeText'),
+  onBack: () => console.log('onBack'),
+  enterText: 'Foo Enter Text'
+}
+
+const dumbComponentMap: DumbComponentMap<Render> = {
+  component: Render,
+  mocks: {
+    'Normal': baseMock
+  }
+}
+
+export default dumbComponentMap

--- a/shared/login/register/code-page/index.render.js.flow
+++ b/shared/login/register/code-page/index.render.js.flow
@@ -1,7 +1,7 @@
 /* @flow */
 
 import {Component} from 'react'
-import type {Mode, DeviceRole} from '../../../reducers/login'
+import type {Mode, DeviceRole} from '../../../constants/login'
 
 export type Props = {
   mode: Mode,
@@ -10,7 +10,7 @@ export type Props = {
   myDeviceRole: DeviceRole,
   otherDeviceRole: DeviceRole,
   cameraBrokenMode: boolean,
-  setCodePageMode: Function,
+  setCodePageMode: (requestedMode: Mode) => void,
   qrScanned: Function,
   setCameraBrokenMode: Function,
   textEntered: Function,
@@ -19,6 +19,4 @@ export type Props = {
   enterText: string
 }
 
-export default class CodePageRender extends Component {
-  props: Props;
-}
+export default class CodePageRender extends Component<void, Props, void> {}

--- a/shared/login/register/code-page/index.render.native.js
+++ b/shared/login/register/code-page/index.render.native.js
@@ -110,22 +110,44 @@ export default class CodePageRender extends Component<void, Props, void> {
     )
   }
 
-  renderIntro () {
-    const headerTextMap: {[key: Mode]: string} = {
-      codePageModeScanCode: 'Scan QR code',
-      codePageModeShowCode: 'Scan this QR code',
-      codePageModeShowText: 'Type in text code'
-    }
-
-    const headerText: string = headerTextMap[this.props.mode] || 'Good luck'
+  renderIntroTextCode () {
     return (
       <Box style={stylesIntro}>
-        <Text type='Header' style={{marginBottom: 10}} inline>{headerText}</Text>
+        <Text type='Header' style={{marginBottom: 10}} inline>Type in text code</Text>
         <Text type='BodySmall' inline>Please run </Text>
         <Text type='TerminalSmall' inline>keybase device add</Text>
         <Text type='BodySmall' inline> in the terminal on your computer.</Text>
       </Box>
     )
+  }
+
+  renderIntroScanQR () {
+    return (
+      <Box style={stylesIntro}>
+        <Text type='Header' style={{marginBottom: 10}} inline>Scan QR code</Text>
+        <Text type='BodySmall' inline>In the Keybase App</Text>
+        <Text type='BodySmall' inline>{'go to Devices > Add a new device'}</Text>
+      </Box>
+    )
+  }
+
+  renderIntroShowQR () {
+    return (
+      <Box style={stylesIntro}>
+        <Text type='Header' style={{marginBottom: 10}} inline>Scan this QR code</Text>
+        <Text type='BodySmall' inline>{'When adding a new mobile device'}</Text>
+      </Box>
+    )
+  }
+
+  renderIntro () {
+    const headerTextMap: {[key: Mode]: React$Element} = {
+      codePageModeScanCode: this.renderIntroScanQR(),
+      codePageModeShowCode: this.renderIntroShowQR(),
+      codePageModeShowText: this.renderIntroTextCode()
+    }
+
+    return headerTextMap[this.props.mode] || <Text type='BodySmall'>Good luck</Text>
   }
 
   renderText () {

--- a/shared/login/register/code-page/qr/index.android.js
+++ b/shared/login/register/code-page/qr/index.android.js
@@ -33,7 +33,7 @@ export default class QR extends Component<void, Props, State> {
       return (
         <BarcodeScanner
           onBarCodeRead={this.props.onBarCodeRead}
-          style={{flex: 1}}
+          style={this.props.style || {flex: 1}}
           torchMode={'off'}
           cameraType='back' />
       )

--- a/shared/login/register/dumb.js
+++ b/shared/login/register/dumb.js
@@ -1,8 +1,10 @@
 // @flow
 import Passphrase from './passphrase/dumb'
 import PaperKey from './paper-key/dumb'
+import CodePage from './code-page/dumb'
 
 export default {
   Passphrase,
-  PaperKey
+  PaperKey,
+  CodePage
 }

--- a/shared/reducers/login.js
+++ b/shared/reducers/login.js
@@ -5,8 +5,7 @@ import * as ConfigConstants from '../constants/config'
 import * as CommonConstants from '../constants/common'
 import Immutable from 'immutable'
 
-export type DeviceRole = 'codePageDeviceRoleExistingPhone' | 'codePageDeviceRoleNewPhone' | 'codePageDeviceRoleExistingComputer' | 'codePageDeviceRoleNewComputer'
-export type Mode = 'codePageModeScanCode' | 'codePageModeShowCode' | 'codePageModeEnterText' | 'codePageModeShowText'
+import type {DeviceRole, Mode} from '../constants/login'
 
 // It's the b64 encoded value used to render the image
 type QRCode = string


### PR DESCRIPTION
@keybase/react-hackers 

This cleans up the code page to make it look like the mocks, and tests it to make sure it works on android.

I don't have a physical ios device yet so I cannot test qr code flow, maybe @chrisnojima can help? but no real changes to the qr stuff happened so if it worked before it should still work.

### Screenshots from android

![screenshot_20160503-184338](https://cloud.githubusercontent.com/assets/594035/15003264/0735abc4-115f-11e6-9c14-8b536a839098.png)

![screenshot_20160503-182657](https://cloud.githubusercontent.com/assets/594035/15003141/92099e38-115d-11e6-927d-11e3b2befbb0.png)

### Zeplin

<img width="340" alt="screen shot 2016-05-03 at 6 34 23 pm" src="https://cloud.githubusercontent.com/assets/594035/15003156/b5357eae-115d-11e6-965c-447df6705254.png">
<img width="341" alt="screen shot 2016-05-03 at 6 34 28 pm" src="https://cloud.githubusercontent.com/assets/594035/15003157/b5379f9a-115d-11e6-90a8-cc84c95be2b5.png">



### Quirks

The aspect ratio of the image is a bit off, haven't spent any time on that.

There is a padding that is from the container that the mocks do not have.