### PR TITLE
Add clickable styles to dropdown arrow

### DIFF
--- a/shared/common-adapters/dropdown.desktop.js
+++ b/shared/common-adapters/dropdown.desktop.js
@@ -84,7 +84,7 @@ export default class Dropdown extends Component {
             {list}
           </Popover>
           {selectedValue}
-          <DropDownArrow style={styles.iconStyle} />
+          <DropDownArrow style={{...styles.iconStyle, ...globalStyles.clickable}} />
         </div>
       </div>
     )

--- a/shared/common-adapters/dropdown.desktop.js
+++ b/shared/common-adapters/dropdown.desktop.js
@@ -84,7 +84,7 @@ export default class Dropdown extends Component {
             {list}
           </Popover>
           {selectedValue}
-          <DropDownArrow style={{...styles.iconStyle, ...globalStyles.clickable}} />
+          <DropDownArrow style={styles.iconStyle} />
         </div>
       </div>
     )
@@ -171,6 +171,7 @@ const styles = {
   },
 
   iconStyle: {
+    ...globalStyles.clickable,
     position: 'absolute',
     top: 5,
     right: 8


### PR DESCRIPTION
The selected menu item has `globalStyles.clickable`, but the `DropDownArrow` was covering it w/ unset cursor styles.

Fixes DESKTOP-794.