### PR TITLE
Nudge initial login screen up to match subsequent steps

### DIFF
--- a/shared/login/login/index.render.desktop.js
+++ b/shared/login/login/index.render.desktop.js
@@ -58,6 +58,6 @@ const styles = {
     backgroundColor: globalColors.lightGrey
   },
   card: {
-    marginTop: 115
+    marginTop: 100
   }
 }


### PR DESCRIPTION
Before:

![screen shot 2016-05-04 at 5 27 51 pm](https://cloud.githubusercontent.com/assets/16893/15033258/a0783216-121d-11e6-8a64-1e24fa4fd7d5.png)

Here's the two screens now:

![screen shot 2016-05-04 at 5 19 58 pm](https://cloud.githubusercontent.com/assets/16893/15033166/dd405210-121c-11e6-9dcc-4a838d5788ef.png)

![screen shot 2016-05-04 at 5 19 52 pm](https://cloud.githubusercontent.com/assets/16893/15033167/dffa7df0-121c-11e6-91b6-b8fac3eaaca6.png)

Note: there is a similar `115px` offset in the mobile version of this view. I looked into it a little bit and noticed that the padding for the subsequent steps is different from on desktop, so not sure if it needs to be adjusted as well. I don't have a mobile test env set up, but can look into this further if desired.

@keybase/react-hackers 