### PR TITLE
setup dev tools command

### DIFF
--- a/desktop/npm-helper.js
+++ b/desktop/npm-helper.js
@@ -167,7 +167,7 @@ function postInstall () {
       childProcess.exec(`npm -g ls ${k}${postinstallGlobals[k]}`, {},
         err => {
           if (err) {
-            console.log('>>>>> Missing dev tooling ', k, postinstallGlobals[k], 'please run "npm run setup-dev-tools"')
+            console.log('>>>>> Missing dev tooling', k, postinstallGlobals[k], 'please run "npm run setup-dev-tools"')
           }
         })
     })

--- a/desktop/npm-helper.js
+++ b/desktop/npm-helper.js
@@ -150,6 +150,10 @@ const commands = {
   'postinstall': {
     help: 'Window: fixup symlinks, all: install global eslint',
     code: postInstall
+  },
+  'setup-dev-tools': {
+    help: 'Install dev tooling (linters, etc)',
+    code: installDevTools
   }
 }
 
@@ -159,9 +163,20 @@ function postInstall () {
   }
 
   if (!process.env.KEYBASE_SKIP_DEV_TOOLS) {
-    const modules = Object.keys(postinstallGlobals).map(k => `${k}${postinstallGlobals[k]}`).join(' ')
-    exec(`npm install -g -E ${modules}`)
+    Object.keys(postinstallGlobals).forEach(k => {
+      childProcess.exec(`npm -g ls ${k}${postinstallGlobals[k]}`, {},
+        err => {
+          if (err) {
+            console.log('>>>>> Missing dev tooling ', k, postinstallGlobals[k], 'please run "npm run setup-dev-tools"')
+          }
+        })
+    })
   }
+}
+
+function installDevTools () {
+  const modules = Object.keys(postinstallGlobals).map(k => `${k}${postinstallGlobals[k]}`).join(' ')
+  exec(`npm install -g -E ${modules}`)
 }
 
 function setupDebugMain () {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -19,6 +19,7 @@
     "debug-main": "babel-node --presets es2015,stage-2 npm-helper.js debug-main",
     "setup-debug-main": "babel-node --presets es2015,stage-2 npm-helper.js setup-debug-main",
     "postinstall": "babel-node --presets es2015,stage-2 npm-helper.js postinstall",
+    "setup-dev-tools": "babel-node --presets es2015,stage-2 npm-helper.js setup-dev-tools",
     "help": "babel-node --presets es2015,stage-2 npm-helper.js help",
     "watch-test-file": "KEYBASE_RUN_MODE=devel babel-node --presets es2015,stage-2 npm-helper.js watch-test-file",
     "mocha": "KEYBASE_RUN_MODE=devel node_modules/mocha/bin/mocha --require source-map-support/register dist/test.bundle.js",


### PR DESCRIPTION
@keybase/react-hackers 
This makes npm install's postinstall hook not install your deps but instead just checks and complains if you don't have them installed. If you get that message just do npm run setup-dev-tools to install it