### PR TITLE
handle gregor show_tracker_popup notifications in the client

### DIFF
--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -64,5 +64,9 @@ func CreateAndSignupFakeUser(prefix string, g *libkb.GlobalContext) (*FakeUser, 
 	if err := engine.RunEngine(s, ctx); err != nil {
 		return nil, err
 	}
+	fu.User, err = libkb.LoadUser(libkb.NewLoadUserByNameArg(g, fu.Username))
+	if err != nil {
+		return nil, err
+	}
 	return fu, nil
 }

--- a/go/service/crypto_test.go
+++ b/go/service/crypto_test.go
@@ -10,6 +10,7 @@ import (
 
 type fakeUIRouter struct {
 	secretUI    libkb.SecretUI
+	identifyUI  libkb.IdentifyUI
 	secretUIErr error
 }
 
@@ -18,7 +19,7 @@ var _ libkb.UIRouter = fakeUIRouter{}
 func (f fakeUIRouter) SetUI(libkb.ConnectionID, libkb.UIKind) {}
 
 func (f fakeUIRouter) GetIdentifyUI() (libkb.IdentifyUI, error) {
-	return nil, errors.New("Unexpected GetIdentifyUI call")
+	return f.identifyUI, nil
 }
 
 func (f fakeUIRouter) GetSecretUI(int) (libkb.SecretUI, error) {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
 	rpc "github.com/keybase/go-framed-msgpack-rpc"
@@ -91,11 +92,110 @@ func (g *gregorHandler) ShouldRetryOnConnect(err error) bool {
 func (g *gregorHandler) BroadcastMessage(ctx context.Context, m gregor1.Message) error {
 	g.G().Log.Debug("gregor handler: broadcast: %+v", m)
 
-	obm := m.ToOutOfBandMessage()
-	if obm == nil {
-		return fmt.Errorf("gregor handler: out-of-band message nil")
+	ibm := m.ToInBandMessage()
+	if ibm != nil {
+		return g.handleInBandMessage(ctx, ibm)
 	}
 
+	obm := m.ToOutOfBandMessage()
+	if obm != nil {
+		return g.handleOutOfBandMessage(ctx, obm)
+	}
+
+	return fmt.Errorf("gregor handler: both in-band and out-of-band message nil")
+}
+
+func (g *gregorHandler) handleInBandMessage(ctx context.Context, ibm gregor.InBandMessage) error {
+	g.G().Log.Debug("gregor handler: handleInBand: %+v", ibm)
+
+	sync := ibm.ToStateSyncMessage()
+	if sync != nil {
+		g.G().Log.Debug("gregor handler: state sync message")
+		return nil
+	}
+
+	update := ibm.ToStateUpdateMessage()
+	if update != nil {
+		g.G().Log.Debug("gregor handler: state update message")
+
+		item := update.Creation()
+		if item != nil {
+			g.G().Log.Debug("gregor handler: item created")
+
+			category := ""
+			if item.Category() != nil {
+				category = item.Category().String()
+			}
+			if category == "show_tracker_popup" {
+				return g.handleShowTrackerPopup(ctx, item)
+			}
+			g.G().Log.Errorf("Unrecognized item category: %s", item.Category())
+		}
+
+		dismissal := update.Dismissal()
+		if dismissal != nil {
+			g.G().Log.Debug("gregor handler: dismissal!!!")
+			return nil
+		}
+	}
+
+	g.G().Log.Errorf("InBandMessage unexpectedly not handled")
+	return nil
+}
+
+func (g *gregorHandler) handleShowTrackerPopup(ctx context.Context, item gregor.Item) error {
+	g.G().Log.Debug("gregor handler: handleShowTrackerPopup: %+v", item)
+	if item.Body() == nil {
+		return errors.New("gregor handler for show_tracker_popup: nil message body")
+	}
+	body, err := jsonw.Unmarshal(item.Body().Bytes())
+	if err != nil {
+		g.G().Log.Error("body failed to unmarshal", err)
+		return err
+	}
+	uid, err := body.AtPath("uid").GetString()
+	if err != nil {
+		g.G().Log.Error("failed to extract uid", err)
+		return err
+	}
+
+	// Load the user with that UID, to get a username.
+	user, err := libkb.LoadUser(libkb.NewLoadUserByUIDArg(g.G(), keybase1.UID(uid)))
+	if err != nil {
+		g.G().Log.Errorf("failed to load user %s", uid)
+		return err
+	}
+
+	identifyUI, err := g.G().UIRouter.GetIdentifyUI()
+	if err != nil {
+		g.G().Log.Error("failed to get IdentifyUI", err)
+		return err
+	}
+	if identifyUI == nil {
+		g.G().Log.Error("got nil IdentifyUI")
+		return errors.New("got nil IdentifyUI")
+	}
+	secretUI, err := g.G().UIRouter.GetSecretUI(0)
+	if err != nil {
+		g.G().Log.Error("failed to get SecretUI", err)
+		return err
+	}
+	if secretUI == nil {
+		g.G().Log.Error("got nil SecretUI")
+		return errors.New("got nil SecretUI")
+	}
+	engineContext := engine.Context{
+		IdentifyUI: identifyUI,
+		SecretUI:   secretUI,
+	}
+
+	trackArg := engine.TrackEngineArg{UserAssertion: user.GetName()}
+	trackEng := engine.NewTrackEngine(&trackArg, g.G())
+	return trackEng.Run(&engineContext)
+}
+
+func (g *gregorHandler) handleOutOfBandMessage(ctx context.Context, obm gregor.OutOfBandMessage) error {
+	g.G().Log.Debug("gregor handler: handleOutOfBand: %+v", obm)
 	if obm.System() == nil {
 		return errors.New("nil system in out of band message")
 	}

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -1,10 +1,12 @@
 package service
 
 import (
+	"fmt"
 	"testing"
 
 	"golang.org/x/net/context"
 
+	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
 	"github.com/keybase/gregor/protocol/gregor1"
@@ -58,4 +60,72 @@ func (n *nlistener) TrackingChanged(uid keybase1.UID, username string) {}
 func (n *nlistener) FSActivity(activity keybase1.FSNotification)       {}
 func (n *nlistener) FavoritesChanged(uid keybase1.UID) {
 	n.favoritesChanged = append(n.favoritesChanged, uid)
+}
+
+type showTrackerIdentifyUI struct {
+	kbtest.FakeIdentifyUI
+	confirmedUsername string
+}
+
+// Overriding the Confirm method does two things: 1) it lets is unconditionally
+// approve the track, so that we don't get a "track not confirmed" error, and
+// 2) it lets us check that the track went through by setting the confirmed
+// flag on the UI.
+func (ui *showTrackerIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
+	ui.confirmedUsername = outcome.Username
+	result := keybase1.ConfirmResult{
+		IdentityConfirmed: true,
+		RemoteConfirmed:   true,
+	}
+	return result, nil
+}
+
+// Test that when we inject a gregor "show_tracker_popup" message containing a
+// given UID into a gregorHandler, the result is that a TrackEngine gets run
+// for that user.
+func TestShowTrackerPopupMessage(t *testing.T) {
+	tc := libkb.SetupTest(t, "gregor")
+	defer tc.Cleanup()
+
+	tc.G.SetService()
+
+	identifyUI := &showTrackerIdentifyUI{}
+	router := fakeUIRouter{
+		secretUI:   &libkb.TestSecretUI{},
+		identifyUI: identifyUI,
+	}
+	tc.G.SetUIRouter(&router)
+
+	trackee, err := kbtest.CreateAndSignupFakeUser("gregr", tc.G)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create another test user to actually perform the track, because we can't track ourselves.
+	_, err = kbtest.CreateAndSignupFakeUser("gregr", tc.G)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := newGregorHandler(tc.G)
+
+	m := gregor1.Message{
+		Ibm_: &gregor1.InBandMessage{
+			StateUpdate_: &gregor1.StateUpdateMessage{
+				Creation_: &gregor1.Item{
+					Category_: gregor1.Category("show_tracker_popup"),
+					Body_:     gregor1.Body(fmt.Sprintf(`{"uid": "%s"}`, trackee.User.GetUID())),
+				},
+			},
+		},
+	}
+
+	err = h.BroadcastMessage(context.Background(), m)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if identifyUI.confirmedUsername != trackee.Username {
+		t.Fatalf("Expected test user %#v to be tracked. Saw %#v. Did the track not happen?", trackee.Username, identifyUI.confirmedUsername)
+	}
 }

--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -5,6 +5,8 @@ ICED=node_modules/.bin/iced
 AVDL2JSON=node_modules/.bin/avdl2json
 AVDLC=node_modules/.bin/avdlc
 
+$(AVDL2JSON): config
+
 json/%.json: avdl/%.avdl
 	$(AVDL2JSON) -i $< -o $@~ && mv $@~ $@
 


### PR DESCRIPTION
This is my first time using `UIRouter`, so there's a good chance I've put this together incorrectly. Also please let me know if there's a better way to kick off a track from the service, other than using `TrackEngine`. I was able to see a tracker popup on my machine using `gregor_inject.iced`.

r? @maxtaco @patrickxb 