### PR TITLE
Don't delete kids from ComputedKeyInfos on revoke

### DIFF
--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -814,12 +814,11 @@ func (ckf *ComputedKeyFamily) UpdateDevices(tcl TypedChainLink) (err error) {
 	// Clear out the old Key that this device used to refer to.
 	// We might wind up just clobbering it with the same thing, but
 	// that's fine for now.
-	if prevKid.IsValid() {
-		ckf.G().Log.Debug("| Clear out old key")
-		delete(ckf.cki.KIDToDeviceID, prevKid)
-	}
-
 	if kid.IsValid() {
+		if prevKid.IsValid() {
+			ckf.G().Log.Debug("| Clear out old key")
+			delete(ckf.cki.KIDToDeviceID, prevKid)
+		}
 		ckf.cki.KIDToDeviceID[kid] = did
 	}
 

--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -811,9 +811,9 @@ func (ckf *ComputedKeyFamily) UpdateDevices(tcl TypedChainLink) (err error) {
 		ckf.cki.Devices[did] = dobj
 	}
 
-	// Clear out the old Key that this device used to refer to.
-	// We might wind up just clobbering it with the same thing, but
-	// that's fine for now.
+	// If a KID is specified, we should clear out any previous KID from the
+	// KID->Device map. But if not, leave the map as it is. Later "device"
+	// blobs in the sigchain aren't required to repeat the KID every time.
 	if kid.IsValid() {
 		if prevKid.IsValid() {
 			ckf.G().Log.Debug("| Clear out old key")


### PR DESCRIPTION
Before this PR, if you do the following:

* sign up a new user
* provision a device1
* deprovision the device1
* login again and create a device2

Then the deviceHistoryRPC will fail with:
```
2016-05-06T11:35:12.255571 ▶ [WARN keybase rpc_exim.go:167] b28 not exportable error: device 6876a9ddda60b262f031d101ae094318 provisioned by kid 012039c68fe20ef741cf443ebde3ca8b9b3f229908e399f220293376b66c6ee8c8dc0a, but couldn't find matching device ID in ComputedKeyInfos (*errors.errorString)
```

It's true, device1's kid is no longer in ComputedKeyInfos.  It was removed by this code, added in de8686bde07:
```go
	// Clear out the old Key that this device used to refer to.
	// We might wind up just clobbering it with the same thing, but
	// that's fine for now.
	if prevKid.IsValid() {
		ckf.G().Log.Debug("| Clear out old key")
		delete(ckf.cki.KIDToDeviceID, prevKid)
	}

	if kid.IsValid() {
		ckf.cki.KIDToDeviceID[kid] = did
	}
```
.. because "kid" is null in this case.  You can see that it's null in the sigchain by looking here:

https://stage0.keybase.io/cjbrev2/chain (#5)

@oconnor663 proposes this change to make both conditions (prevKid && kid) necessary to perform the delete.

r? @patrickxb || @maxtaco