### PR TITLE
Wait for CI to finish

### DIFF
--- a/packaging/desktop/package.json
+++ b/packaging/desktop/package.json
@@ -10,7 +10,6 @@
   "license": "ISC",
   "dependencies": {
     "appdmg": "^0.3.5",
-    "electron-packager": "^5.1.1",
-    "github-ci-status": "1.0.0"
+    "electron-packager": "^5.1.1"
   }
 }

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -143,10 +143,6 @@ get_deps() {(
   curl -J -L -Ss "$updater_url" | tar zx
 )}
 
-check_ci() {
-  $node_bin/ci --required-tests 3
-}
-
 # Build Keybase.app
 package_electron() {(
   cd "$client_dir/desktop"
@@ -280,7 +276,6 @@ s3sync() {
 
 clean
 get_deps
-check_ci
 package_electron
 package_app
 update_plist

--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -67,8 +67,9 @@ echo "Loading release tool"
 "$client_dir/packaging/goinstall.sh" "github.com/keybase/release"
 release_bin="$GOPATH/bin/release"
 
-client_commit=`$release_bin latest-commit --repo=client`
-kbfs_commit=`$release_bin latest-commit --repo=kbfs`
+# Wait for CI
+"$release_bin" wait-ci --repo=client
+"$release_bin" wait-ci --repo=kbfs
 
 if [ -n "$client_commit" ]; then
   (cd "$client_dir"

--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -67,9 +67,9 @@ echo "Loading release tool"
 "$client_dir/packaging/goinstall.sh" "github.com/keybase/release"
 release_bin="$GOPATH/bin/release"
 
-# Wait for CI
-"$release_bin" wait-ci --repo=client
-"$release_bin" wait-ci --repo=kbfs
+echo "Wait for CI"
+"$release_bin" wait-ci --repo=client --commit=`git -C $client_dir log -1 --pretty=format:%h`
+"$release_bin" wait-ci --repo=kbfs --commit=`git -C $kbfs_dir log -1 --pretty=format:%h`
 
 if [ -n "$client_commit" ]; then
   (cd "$client_dir"

--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -67,35 +67,32 @@ echo "Loading release tool"
 "$client_dir/packaging/goinstall.sh" "github.com/keybase/release"
 release_bin="$GOPATH/bin/release"
 
-echo "Wait for CI"
-"$release_bin" wait-ci --repo=client --commit=`git -C $client_dir log -1 --pretty=format:%h`
-"$release_bin" wait-ci --repo=kbfs --commit=`git -C $kbfs_dir log -1 --pretty=format:%h`
-
 if [ -n "$client_commit" ]; then
-  (
-    cd "$client_dir"
-    client_branch=`git rev-parse --abbrev-ref HEAD`
-    function reset_client {
-      (cd "$client_dir" && git checkout $client_branch)
-    }
-    trap reset_client EXIT
-    echo "Checking out $client_commit on client"
-    git checkout "$client_commit"
-  )
+  cd "$client_dir"
+  client_branch=`git rev-parse --abbrev-ref HEAD`
+  function reset_client {
+    (cd "$client_dir" && git checkout $client_branch)
+  }
+  trap reset_client EXIT
+  echo "Checking out $client_commit on client"
+  git checkout "$client_commit"
 fi
 
 if [ -n "$kbfs_commit" ]; then
-  (
-    cd "$kbfs_dir"
-    kbfs_branch=`git rev-parse --abbrev-ref HEAD`
-    function reset_kbfs {
-      (cd "$kbfs_dir" && git checkout $kbfs_branch)
-    }
-    trap reset_kbfs EXIT
-    echo "Checking out $kbfs_commit on kbfs"
-    git checkout "$kbfs_commit"
-  )
+  cd "$kbfs_dir"
+  kbfs_branch=`git rev-parse --abbrev-ref HEAD`
+  function reset_kbfs {
+    (cd "$kbfs_dir" && git checkout $kbfs_branch)
+  }
+  trap reset_kbfs EXIT
+  echo "Checking out $kbfs_commit on kbfs"
+  git checkout "$kbfs_commit"
 fi
+
+echo "Checking client CI"
+"$release_bin" wait-ci --repo=client --commit=`git -C $client_dir log -1 --pretty=format:%h`
+echo "Checking kbfs CI"
+"$release_bin" wait-ci --repo=client --commit=`git -C $kbfs_dir log -1 --pretty=format:%h`
 
 if [ ! "$nobuild" = "1" ]; then
   BUILD_DIR=$build_dir_keybase "$dir/build_keybase.sh"

--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -72,25 +72,29 @@ echo "Wait for CI"
 "$release_bin" wait-ci --repo=kbfs --commit=`git -C $kbfs_dir log -1 --pretty=format:%h`
 
 if [ -n "$client_commit" ]; then
-  (cd "$client_dir"
-  client_branch=`git rev-parse --abbrev-ref HEAD`
-  function reset_client {
-    (cd "$client_dir" && git checkout $client_branch)
-  }
-  trap reset_client EXIT
-  echo "Checking out $client_commit on client"
-  git checkout "$client_commit")
+  (
+    cd "$client_dir"
+    client_branch=`git rev-parse --abbrev-ref HEAD`
+    function reset_client {
+      (cd "$client_dir" && git checkout $client_branch)
+    }
+    trap reset_client EXIT
+    echo "Checking out $client_commit on client"
+    git checkout "$client_commit"
+  )
 fi
 
 if [ -n "$kbfs_commit" ]; then
-  (cd "$kbfs_dir"
-  kbfs_branch=`git rev-parse --abbrev-ref HEAD`
-  function reset_kbfs {
-    (cd "$kbfs_dir" && git checkout $kbfs_branch)
-  }
-  trap reset_kbfs EXIT
-  echo "Checking out $kbfs_commit on kbfs"
-  git checkout "$kbfs_commit")
+  (
+    cd "$kbfs_dir"
+    kbfs_branch=`git rev-parse --abbrev-ref HEAD`
+    function reset_kbfs {
+      (cd "$kbfs_dir" && git checkout $kbfs_branch)
+    }
+    trap reset_kbfs EXIT
+    echo "Checking out $kbfs_commit on kbfs"
+    git checkout "$kbfs_commit"
+  )
 fi
 
 if [ ! "$nobuild" = "1" ]; then

--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -63,26 +63,33 @@ if [ ! "$nopull" = "1" ]; then
   "$client_dir/packaging/check_status_and_pull.sh" "$updater_dir"
 fi
 
+echo "Loading release tool"
+"$client_dir/packaging/goinstall.sh" "github.com/keybase/release"
+release_bin="$GOPATH/bin/release"
+
+client_commit=`$release_bin latest-commit --repo=client`
+kbfs_commit=`$release_bin latest-commit --repo=kbfs`
+
 if [ -n "$client_commit" ]; then
-  cd "$client_dir"
+  (cd "$client_dir"
   client_branch=`git rev-parse --abbrev-ref HEAD`
   function reset_client {
     (cd "$client_dir" && git checkout $client_branch)
   }
   trap reset_client EXIT
   echo "Checking out $client_commit on client"
-  git checkout "$client_commit"
+  git checkout "$client_commit")
 fi
 
 if [ -n "$kbfs_commit" ]; then
-  cd "$kbfs_dir"
+  (cd "$kbfs_dir"
   kbfs_branch=`git rev-parse --abbrev-ref HEAD`
   function reset_kbfs {
     (cd "$kbfs_dir" && git checkout $kbfs_branch)
   }
   trap reset_kbfs EXIT
   echo "Checking out $kbfs_commit on kbfs"
-  git checkout "$kbfs_commit"
+  git checkout "$kbfs_commit")
 fi
 
 if [ ! "$nobuild" = "1" ]; then


### PR DESCRIPTION
See https://github.com/keybase/release/pull/9 for "latest-commit" command added to release tool.

This builds from the latest commit passing tests:
```
"continuous-integration/travis-ci/push":  "success",
"continuous-integration/appveyor/branch": "success",
```

An added benefit of this, is it checks for latest safe kbfs commit too.. Something the `check_ci` thing wasn't doing.