### PR TITLE
use the client that reconnects

### DIFF
--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -51,7 +51,7 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection, cli
 		return err
 	}
 
-	g.cli = cli
+	g.cli = conn.GetClient()
 
 	return g.auth(ctx)
 }


### PR DESCRIPTION
@patrickxb I don't think the client is properly reconnecting to gregord in its current state. The following change should make this work. The `GenericClient` that comes back from `GetClient` has all the reconnect machinery in it. Let me know what you think!