### PR TITLE
Clean up trackers to use dumb components

### DIFF
--- a/shared/tracker/dumb.desktop.js
+++ b/shared/tracker/dumb.desktop.js
@@ -1,5 +1,6 @@
 /* @flow */
-import Tracker from './index'
+import Tracker from './render'
+import {trackerPropsToRenderProps} from './index'
 import {normal, checking, revoked, error} from '../constants/tracker'
 import {metaUpgraded, metaUnreachable, metaPending, metaDeleted, metaNone, metaIgnored} from '../constants/tracker'
 import type {TrackerProps} from '../tracker'
@@ -214,21 +215,21 @@ const propsFiveProof: TrackerProps = {
 const dumbMap: DumbComponentMap<Tracker> = {
   component: Tracker,
   mocks: {
-    'NonuserNoLinkPrivate': {...propsNonUser, inviteLink: null, isPrivate: true},
-    'NonuserLink': propsNonUser,
-    'NonuserNoLinkPublic': {...propsNonUser, inviteLink: null},
-    'Logged out': propsLoggedOut,
-    'Only one proof': propsOneProof,
-    '5 proofs': propsFiveProof,
-    'New user': propsNewUser,
-    'New user, follows me': propsNewUserFollowsYou,
-    'Followed': propsFollowing,
-    'Changed/Broken proofs user you dont follow': {...propsChangedProofs, lastTrack: false},
-    'Changed/Broken proofs': propsChangedProofs,
-    'You track them': {...propsFollowing, userInfo: {...propsNewUser.userInfo, followsYou: false}},
-    'Unfollowed': propsUnfollowed,
-    'Barely there': propsLessData,
-    'Whatevz': propsWhatevz
+    'NonuserNoLinkPrivate': trackerPropsToRenderProps({...propsNonUser, inviteLink: null, isPrivate: true}),
+    'NonuserLink': trackerPropsToRenderProps(propsNonUser),
+    'NonuserNoLinkPublic': trackerPropsToRenderProps({...propsNonUser, inviteLink: null}),
+    'Logged out': trackerPropsToRenderProps(propsLoggedOut),
+    'Only one proof': trackerPropsToRenderProps(propsOneProof),
+    '5 proofs': trackerPropsToRenderProps(propsFiveProof),
+    'New user': trackerPropsToRenderProps(propsNewUser),
+    'New user, follows me': trackerPropsToRenderProps(propsNewUserFollowsYou),
+    'Followed': trackerPropsToRenderProps(propsFollowing),
+    'Changed/Broken proofs user you dont follow': trackerPropsToRenderProps({...propsChangedProofs, lastTrack: null}),
+    'Changed/Broken proofs': trackerPropsToRenderProps(propsChangedProofs),
+    'You track them': trackerPropsToRenderProps({...propsFollowing, userInfo: {...propsNewUser.userInfo, followsYou: false}}),
+    'Unfollowed': trackerPropsToRenderProps(propsUnfollowed),
+    'Barely there': trackerPropsToRenderProps(propsLessData),
+    'Whatevz': trackerPropsToRenderProps(propsWhatevz)
   }
 }
 

--- a/shared/tracker/index.js
+++ b/shared/tracker/index.js
@@ -38,8 +38,63 @@ export type TrackerProps = {
   currentlyFollowing: boolean,
   lastAction: ?('followed' | 'refollowed' | 'unfollowed' | 'error'),
   name?: string,
-  inviteLink?: string,
+  inviteLink?: ?string,
   isPrivate?: boolean
+}
+
+export function trackerPropsToRenderProps (props: TrackerProps): RenderProps {
+  const renderChangedTitle = props.trackerMessage
+  const failedProofsNotFollowingText = `Some of ${props.username}'s proofs couldn't be verified. Track the working proofs?`
+  const currentlyFollowing = !!props.lastTrack
+
+  const changed = !(props.proofs || []).every(function (proof, index, ar) {
+    return (!proof.meta || proof.meta === metaNone)
+  })
+
+  const reason = currentlyFollowing && renderChangedTitle ? renderChangedTitle : props.reason
+
+  return {
+    bioProps: {
+      username: props.username,
+      userInfo: props.userInfo,
+      currentlyFollowing
+    },
+    headerProps: {
+      reason: reason,
+      onClose: () => props.onClose(props.username),
+      trackerState: props.trackerState,
+      currentlyFollowing,
+      changed,
+      lastAction: props.lastAction,
+      loggedIn: props.loggedIn
+    },
+    actionProps: {
+      loggedIn: props.loggedIn,
+      state: props.trackerState,
+      username: props.username,
+      waiting: props.waiting,
+      renderChangedTitle,
+      failedProofsNotFollowingText,
+      shouldFollow: props.shouldFollow,
+      onClose: () => props.onClose(props.username),
+      onRefollow: () => props.onRefollow(props.username),
+      onIgnore: () => props.onIgnore(props.username),
+      onUnfollow: () => props.onUnfollow(props.username),
+      onFollow: () => props.onFollow(props.username),
+      currentlyFollowing,
+      lastAction: props.lastAction
+    },
+    proofsProps: {
+      username: props.username,
+      proofs: props.proofs,
+      currentlyFollowing
+    },
+    nonUser: props.nonUser,
+    name: props.name,
+    reason: props.reason,
+    inviteLink: props.inviteLink,
+    isPrivate: props.isPrivate
+  }
 }
 
 class Tracker extends Component {
@@ -58,58 +113,7 @@ class Tracker extends Component {
       return <div />
     }
 
-    const renderChangedTitle = this.props.trackerMessage
-    const failedProofsNotFollowingText = `Some of ${this.props.username}'s proofs couldn't be verified. Track the working proofs?`
-    const currentlyFollowing = !!this.props.lastTrack
-
-    const changed = !(this.props.proofs || []).every(function (proof, index, ar) {
-      return (!proof.meta || proof.meta === metaNone)
-    })
-
-    const reason = currentlyFollowing && renderChangedTitle ? renderChangedTitle : this.props.reason
-
-    const renderProps: RenderProps = {
-      bioProps: {
-        username: this.props.username,
-        userInfo: this.props.userInfo,
-        currentlyFollowing
-      },
-      headerProps: {
-        reason: reason,
-        onClose: () => this.props.onClose(this.props.username),
-        trackerState: this.props.trackerState,
-        currentlyFollowing,
-        changed,
-        lastAction: this.props.lastAction,
-        loggedIn: this.props.loggedIn
-      },
-      actionProps: {
-        loggedIn: this.props.loggedIn,
-        state: this.props.trackerState,
-        username: this.props.username,
-        waiting: this.props.waiting,
-        renderChangedTitle,
-        failedProofsNotFollowingText,
-        shouldFollow: this.props.shouldFollow,
-        onClose: () => this.props.onClose(this.props.username),
-        onRefollow: () => this.props.onRefollow(this.props.username),
-        onIgnore: () => this.props.onIgnore(this.props.username),
-        onUnfollow: () => this.props.onUnfollow(this.props.username),
-        onFollow: () => this.props.onFollow(this.props.username),
-        currentlyFollowing,
-        lastAction: this.props.lastAction
-      },
-      proofsProps: {
-        username: this.props.username,
-        proofs: this.props.proofs,
-        currentlyFollowing
-      },
-      nonUser: this.props.nonUser,
-      name: this.props.name,
-      reason: this.props.reason,
-      inviteLink: this.props.inviteLink,
-      isPrivate: this.props.isPrivate
-    }
+    const renderProps = trackerPropsToRenderProps(this.props)
 
     return <Render {...renderProps} />
   }

--- a/shared/tracker/render.js.flow
+++ b/shared/tracker/render.js.flow
@@ -15,7 +15,7 @@ export type RenderProps = $Shape<{
   name?: string,
   nonUser?: ?boolean,
   reason?: string,
-  inviteLink?: string,
+  inviteLink?: ?string,
   isPrivate?: boolean
 }>
 


### PR DESCRIPTION
@keybase/react-hackers 

Nice and easy one :) uses the dumb components instead of the smart component so no more connect calls that start up tracker timers!