### PR TITLE
serialize access to pinentry across all kbfs-crypto calls

### DIFF
--- a/go/engine/crypto.go
+++ b/go/engine/crypto.go
@@ -11,7 +11,8 @@ import (
 	"golang.org/x/crypto/nacl/box"
 )
 
-// getMatchMu erializes calls to getMatchingSecretKey.
+// getKeyMu synchronizes all accesses to the need to pull in pinentries/secret keys
+// for this user.
 var getKeyMu sync.Mutex
 
 func getMySecretKey(
@@ -184,7 +185,7 @@ func getMatchingSecretKey(g *libkb.GlobalContext, secretUI libkb.SecretUI, arg k
 	g.Log.Debug("getMatchingSecretKey: acquiring lock")
 	getKeyMu.Lock()
 	defer func() {
-		getKeyhMu.Unlock()
+		getKeyMu.Unlock()
 		g.Log.Debug("getMatchingSecretKey: lock released")
 	}()
 	g.Log.Debug("getMatchingSecretKey: lock acquired")

--- a/go/engine/crypto.go
+++ b/go/engine/crypto.go
@@ -12,13 +12,22 @@ import (
 )
 
 // getMatchMu erializes calls to getMatchingSecretKey.
-var getMatchMu sync.Mutex
+var getKeyMu sync.Mutex
 
 func getMySecretKey(
 	g *libkb.GlobalContext, secretUI libkb.SecretUI,
 	secretKeyType libkb.SecretKeyType, reason string) (
 	libkb.GenericKey, error) {
 
+	g.Log.Debug("getMySecretKey: acquiring lock")
+	getKeyMu.Lock()
+	defer func() {
+		getKeyMu.Unlock()
+		g.Log.Debug("getMySecretKey: lock released")
+	}()
+	g.Log.Debug("getMySecretKey: lock acquired")
+
+	// check cache after acquiring lock
 	var key libkb.GenericKey
 	var err error
 	aerr := g.LoginState().Account(func(a *libkb.Account) {
@@ -173,9 +182,9 @@ func getMatchingSecretKey(g *libkb.GlobalContext, secretUI libkb.SecretUI, arg k
 	}
 
 	g.Log.Debug("getMatchingSecretKey: acquiring lock")
-	getMatchMu.Lock()
+	getKeyMu.Lock()
 	defer func() {
-		getMatchMu.Unlock()
+		getKeyhMu.Unlock()
 		g.Log.Debug("getMatchingSecretKey: lock released")
 	}()
 	g.Log.Debug("getMatchingSecretKey: lock acquired")


### PR DESCRIPTION
- can get a pinentry via getMySecretKey or getMatchingSecretKey on a paper rekey
- do a coarse-grained serialization here since the user doesn't want to see two overlapping
  pinentries anyways.