### PR TITLE
Never popup login screen automatically

### DIFF
--- a/shared/nav.desktop.js
+++ b/shared/nav.desktop.js
@@ -39,7 +39,6 @@ const tabs = {
 class Nav extends Component {
   constructor (props) {
     super(props)
-    this._checkedBootstrap = false
     this.props.bootstrap()
 
     this.state = {searchActive: false}
@@ -120,16 +119,6 @@ class Nav extends Component {
   shouldComponentUpdate (nextProps, nextState) {
     if (this.state.searchActive !== nextState.searchActive) {
       return true
-    }
-
-    if (!this._checkedBootstrap) {
-      if (nextProps.bootstrapped > 0) {
-        this._checkedBootstrap = true
-
-        if (!nextProps.provisioned) {
-          ipcRenderer.send('showMain')
-        }
-      }
     }
 
     return (nextProps.tabbedRouter.get('activeTab') !== this._activeTab())


### PR DESCRIPTION
@keybase/react-hackers 

This changes our logic to never show the popup screen automatically. Before we had some possibly fault logic to show it once. See the issue for [more info](https://keybase.atlassian.net/secure/RapidBoard.jspa?rapidView=8&projectKey=DESKTOP&view=detail&selectedIssue=DESKTOP-1014)


This is one option to fix another option is to make it only show up once per lifetime of the app (which was the old intended behavior).

Not sure which is better, but @malgorithms and @gabriel probably have opinions