### PR TITLE
implement dismissals for show_tracker_popup gregor notifications

### DIFF
--- a/go/client/identify_ui.go
+++ b/go/client/identify_ui.go
@@ -85,6 +85,11 @@ func (i *IdentifyUIServer) Finish(_ context.Context, sessionID int) error {
 	return nil
 }
 
+func (i *IdentifyUIServer) Dismiss(_ context.Context, arg keybase1.DismissArg) error {
+	i.ui.Dismiss(arg.Uid, arg.Reason)
+	return nil
+}
+
 func (i *IdentifyUIServer) DisplayTLFCreateWithInvite(_ context.Context, arg keybase1.DisplayTLFCreateWithInviteArg) error {
 	return i.ui.DisplayTLFCreateWithInvite(arg)
 }

--- a/go/client/identify_ui.go
+++ b/go/client/identify_ui.go
@@ -86,7 +86,7 @@ func (i *IdentifyUIServer) Finish(_ context.Context, sessionID int) error {
 }
 
 func (i *IdentifyUIServer) Dismiss(_ context.Context, arg keybase1.DismissArg) error {
-	i.ui.Dismiss(arg.Uid, arg.Reason)
+	i.ui.Dismiss(arg.Username, arg.Reason)
 	return nil
 }
 

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -73,6 +73,9 @@ func (ui BaseIdentifyUI) ReportTrackToken(_ keybase1.TrackToken) error {
 func (ui BaseIdentifyUI) Finish() {
 }
 
+func (ui BaseIdentifyUI) Dismiss(_ keybase1.UID, _ keybase1.DismissReason) {
+}
+
 func (ui BaseIdentifyUI) Confirm(o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
 	warnings := libkb.ImportWarnings(o.Warnings)
 	if !warnings.IsEmpty() {

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -73,7 +73,7 @@ func (ui BaseIdentifyUI) ReportTrackToken(_ keybase1.TrackToken) error {
 func (ui BaseIdentifyUI) Finish() {
 }
 
-func (ui BaseIdentifyUI) Dismiss(_ keybase1.UID, _ keybase1.DismissReason) {
+func (ui BaseIdentifyUI) Dismiss(_ string, _ keybase1.DismissReason) {
 }
 
 func (ui BaseIdentifyUI) Confirm(o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -238,7 +238,8 @@ func (ui *FakeIdentifyUI) Start(username string, _ keybase1.IdentifyReason) {
 	defer ui.Unlock()
 	ui.StartCount++
 }
-func (ui *FakeIdentifyUI) Finish() {}
+func (ui *FakeIdentifyUI) Finish()                                          {}
+func (ui *FakeIdentifyUI) Dismiss(_ keybase1.UID, _ keybase1.DismissReason) {}
 func (ui *FakeIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) {
 	ui.Lock()
 	defer ui.Unlock()

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -238,8 +238,8 @@ func (ui *FakeIdentifyUI) Start(username string, _ keybase1.IdentifyReason) {
 	defer ui.Unlock()
 	ui.StartCount++
 }
-func (ui *FakeIdentifyUI) Finish()                                          {}
-func (ui *FakeIdentifyUI) Dismiss(_ keybase1.UID, _ keybase1.DismissReason) {}
+func (ui *FakeIdentifyUI) Finish()                                    {}
+func (ui *FakeIdentifyUI) Dismiss(_ string, _ keybase1.DismissReason) {}
 func (ui *FakeIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) {
 	ui.Lock()
 	defer ui.Unlock()

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -113,6 +113,9 @@ func (i *Identify2WithUIDTester) Finish() {
 	i.finishCh <- struct{}{}
 }
 
+func (i *Identify2WithUIDTester) Dismiss(_ keybase1.UID, _ keybase1.DismissReason) {
+}
+
 func (i *Identify2WithUIDTester) Start(string, keybase1.IdentifyReason) {
 	i.startCh <- struct{}{}
 }

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -113,7 +113,7 @@ func (i *Identify2WithUIDTester) Finish() {
 	i.finishCh <- struct{}{}
 }
 
-func (i *Identify2WithUIDTester) Dismiss(_ keybase1.UID, _ keybase1.DismissReason) {
+func (i *Identify2WithUIDTester) Dismiss(_ string, _ keybase1.DismissReason) {
 }
 
 func (i *Identify2WithUIDTester) Start(string, keybase1.IdentifyReason) {

--- a/go/kbtest/ui.go
+++ b/go/kbtest/ui.go
@@ -136,7 +136,8 @@ func (ui *FakeIdentifyUI) Start(username string, _ keybase1.IdentifyReason) {
 	defer ui.Unlock()
 	ui.StartCount++
 }
-func (ui *FakeIdentifyUI) Finish() {}
+func (ui *FakeIdentifyUI) Finish()                                          {}
+func (ui *FakeIdentifyUI) Dismiss(_ keybase1.UID, _ keybase1.DismissReason) {}
 func (ui *FakeIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) {
 	ui.Lock()
 	defer ui.Unlock()

--- a/go/kbtest/ui.go
+++ b/go/kbtest/ui.go
@@ -136,8 +136,8 @@ func (ui *FakeIdentifyUI) Start(username string, _ keybase1.IdentifyReason) {
 	defer ui.Unlock()
 	ui.StartCount++
 }
-func (ui *FakeIdentifyUI) Finish()                                          {}
-func (ui *FakeIdentifyUI) Dismiss(_ keybase1.UID, _ keybase1.DismissReason) {}
+func (ui *FakeIdentifyUI) Finish()                                    {}
+func (ui *FakeIdentifyUI) Dismiss(_ string, _ keybase1.DismissReason) {}
 func (ui *FakeIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) {
 	ui.Lock()
 	defer ui.Unlock()

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -285,6 +285,7 @@ type IdentifyUI interface {
 	ReportTrackToken(keybase1.TrackToken) error
 	Finish()
 	DisplayTLFCreateWithInvite(keybase1.DisplayTLFCreateWithInviteArg) error
+	Dismiss(keybase1.UID, keybase1.DismissReason)
 }
 
 type Checker struct {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -285,7 +285,7 @@ type IdentifyUI interface {
 	ReportTrackToken(keybase1.TrackToken) error
 	Finish()
 	DisplayTLFCreateWithInvite(keybase1.DisplayTLFCreateWithInviteArg) error
-	Dismiss(keybase1.UID, keybase1.DismissReason)
+	Dismiss(string, keybase1.DismissReason)
 }
 
 type Checker struct {

--- a/go/protocol/identify_ui.go
+++ b/go/protocol/identify_ui.go
@@ -101,6 +101,19 @@ type ConfirmResult struct {
 	ExpiringLocal     bool `codec:"expiringLocal" json:"expiringLocal"`
 }
 
+type DismissReasonType int
+
+const (
+	DismissReasonType_NONE              DismissReasonType = 0
+	DismissReasonType_HANDLED_ELSEWHERE DismissReasonType = 1
+)
+
+type DismissReason struct {
+	Type     DismissReasonType `codec:"type" json:"type"`
+	Reason   string            `codec:"reason" json:"reason"`
+	Resource string            `codec:"resource" json:"resource"`
+}
+
 type DisplayTLFCreateWithInviteArg struct {
 	SessionID  int    `codec:"sessionID" json:"sessionID"`
 	FolderName string `codec:"folderName" json:"folderName"`
@@ -176,6 +189,12 @@ type FinishArg struct {
 	SessionID int `codec:"sessionID" json:"sessionID"`
 }
 
+type DismissArg struct {
+	SessionID int           `codec:"sessionID" json:"sessionID"`
+	Uid       UID           `codec:"uid" json:"uid"`
+	Reason    DismissReason `codec:"reason" json:"reason"`
+}
+
 type IdentifyUiInterface interface {
 	DisplayTLFCreateWithInvite(context.Context, DisplayTLFCreateWithInviteArg) error
 	DelegateIdentifyUI(context.Context) (int, error)
@@ -191,6 +210,7 @@ type IdentifyUiInterface interface {
 	DisplayUserCard(context.Context, DisplayUserCardArg) error
 	Confirm(context.Context, ConfirmArg) (ConfirmResult, error)
 	Finish(context.Context, int) error
+	Dismiss(context.Context, DismissArg) error
 }
 
 func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
@@ -416,6 +436,22 @@ func IdentifyUiProtocol(i IdentifyUiInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"dismiss": {
+				MakeArg: func() interface{} {
+					ret := make([]DismissArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]DismissArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]DismissArg)(nil), args)
+						return
+					}
+					err = i.Dismiss(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -492,5 +528,10 @@ func (c IdentifyUiClient) Confirm(ctx context.Context, __arg ConfirmArg) (res Co
 func (c IdentifyUiClient) Finish(ctx context.Context, sessionID int) (err error) {
 	__arg := FinishArg{SessionID: sessionID}
 	err = c.Cli.Call(ctx, "keybase.1.identifyUi.finish", []interface{}{__arg}, nil)
+	return
+}
+
+func (c IdentifyUiClient) Dismiss(ctx context.Context, __arg DismissArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.identifyUi.dismiss", []interface{}{__arg}, nil)
 	return
 }

--- a/go/protocol/identify_ui.go
+++ b/go/protocol/identify_ui.go
@@ -191,7 +191,7 @@ type FinishArg struct {
 
 type DismissArg struct {
 	SessionID int           `codec:"sessionID" json:"sessionID"`
-	Uid       UID           `codec:"uid" json:"uid"`
+	Username  string        `codec:"username" json:"username"`
 	Reason    DismissReason `codec:"reason" json:"reason"`
 }
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -249,6 +249,11 @@ func (g *gregorHandler) handleDismissTrackerPopup(ctx context.Context, item greg
 		g.G().Log.Error("failed to convert UID from string", err)
 		return err
 	}
+	user, err := libkb.LoadUser(libkb.NewLoadUserByUIDArg(g.G(), uid))
+	if err != nil {
+		g.G().Log.Error("failed to load user from UID", err)
+		return err
+	}
 
 	identifyUI, err := g.G().UIRouter.GetIdentifyUI()
 	if err != nil {
@@ -263,7 +268,7 @@ func (g *gregorHandler) handleDismissTrackerPopup(ctx context.Context, item greg
 	reason := keybase1.DismissReason{
 		Type: keybase1.DismissReasonType_HANDLED_ELSEWHERE,
 	}
-	identifyUI.Dismiss(uid, reason)
+	identifyUI.Dismiss(user.GetName(), reason)
 
 	return nil
 }

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -252,6 +252,14 @@ func (u *RemoteIdentifyUI) Finish() {
 	u.uicli.Finish(context.TODO(), u.sessionID)
 }
 
+func (u *RemoteIdentifyUI) Dismiss(uid keybase1.UID, reason keybase1.DismissReason) {
+	u.uicli.Dismiss(context.TODO(), keybase1.DismissArg{
+		SessionID: u.sessionID,
+		Uid:       uid,
+		Reason:    reason,
+	})
+}
+
 func (u *RemoteIdentifyUI) SetStrict(b bool) {
 	u.strict = b
 }

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -252,10 +252,10 @@ func (u *RemoteIdentifyUI) Finish() {
 	u.uicli.Finish(context.TODO(), u.sessionID)
 }
 
-func (u *RemoteIdentifyUI) Dismiss(uid keybase1.UID, reason keybase1.DismissReason) {
+func (u *RemoteIdentifyUI) Dismiss(username string, reason keybase1.DismissReason) {
 	u.uicli.Dismiss(context.TODO(), keybase1.DismissArg{
 		SessionID: u.sessionID,
-		Uid:       uid,
+		Username:  username,
 		Reason:    reason,
 	})
 }

--- a/go/systests/delegate_ui_test.go
+++ b/go/systests/delegate_ui_test.go
@@ -152,6 +152,12 @@ func (d *delegateUI) Finish(context.Context, int) error {
 	close(d.ch)
 	return nil
 }
+func (d *delegateUI) Dismiss(context.Context, keybase1.DismissArg) error {
+	if err := d.checkStarted(); err != nil {
+		return err
+	}
+	return nil
+}
 
 func (d *delegateUI) DisplayTLFCreateWithInvite(context.Context, keybase1.DisplayTLFCreateWithInviteArg) error {
 	return nil

--- a/go/systests/tracking_test.go
+++ b/go/systests/tracking_test.go
@@ -43,6 +43,7 @@ func (*identifyUI) DisplayUserCard(keybase1.UserCard)                           
 func (*identifyUI) ReportTrackToken(keybase1.TrackToken) error                            { return nil }
 func (*identifyUI) SetStrict(b bool)                                                      {}
 func (*identifyUI) Finish()                                                               {}
+func (*identifyUI) Dismiss(keybase1.UID, keybase1.DismissReason)                          {}
 
 func (*identifyUI) DisplayTLFCreateWithInvite(keybase1.DisplayTLFCreateWithInviteArg) error {
 	return nil

--- a/go/systests/tracking_test.go
+++ b/go/systests/tracking_test.go
@@ -43,7 +43,7 @@ func (*identifyUI) DisplayUserCard(keybase1.UserCard)                           
 func (*identifyUI) ReportTrackToken(keybase1.TrackToken) error                            { return nil }
 func (*identifyUI) SetStrict(b bool)                                                      {}
 func (*identifyUI) Finish()                                                               {}
-func (*identifyUI) Dismiss(keybase1.UID, keybase1.DismissReason)                          {}
+func (*identifyUI) Dismiss(string, keybase1.DismissReason)                                {}
 
 func (*identifyUI) DisplayTLFCreateWithInvite(keybase1.DisplayTLFCreateWithInviteArg) error {
 	return nil

--- a/go/vendor/github.com/keybase/gregor/interface.go
+++ b/go/vendor/github.com/keybase/gregor/interface.go
@@ -17,14 +17,17 @@ const (
 
 type UID interface {
 	Bytes() []byte
+	String() string
 }
 
 type MsgID interface {
 	Bytes() []byte
+	String() string
 }
 
 type DeviceID interface {
 	Bytes() []byte
+	String() string
 }
 
 type System interface {
@@ -43,7 +46,6 @@ type Metadata interface {
 	UID() UID
 	MsgID() MsgID
 	CTime() time.Time
-	SetCTime(time.Time)
 	DeviceID() DeviceID
 	InBandMsgType() InBandMsgType
 }

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -222,15 +222,15 @@
 			"checksumSHA1": "vYGpKgcvBhYyZkvNd6WDSSlUTVM=",
 			"origin": "github.com/keybase/client/go/vendor/github.com/keybase/gregor",
 			"path": "github.com/keybase/gregor",
-			"revision": "e273bc87efb4f99ecf7c3bac919c6b5b32b049ee",
-			"revisionTime": "2016-05-02T13:52:31-04:00"
+			"revision": "41dc0cce10c8f5a8c33af009d275b5f06569d4cc",
+			"revisionTime": "2016-05-12T15:42:36-04:00"
 		},
 		{
 			"checksumSHA1": "olxyKjwg4+HWaaaaEQaylm5jJLE=",
 			"origin": "github.com/keybase/client/go/vendor/github.com/keybase/gregor/protocol/gregor1",
 			"path": "github.com/keybase/gregor/protocol/gregor1",
-			"revision": "e273bc87efb4f99ecf7c3bac919c6b5b32b049ee",
-			"revisionTime": "2016-05-02T13:52:31-04:00"
+			"revision": "41dc0cce10c8f5a8c33af009d275b5f06569d4cc",
+			"revisionTime": "2016-05-12T15:42:36-04:00"
 		},
 		{
 			"path": "github.com/keybase/keybase-test-vectors/go",

--- a/protocol/avdl/identify_ui.avdl
+++ b/protocol/avdl/identify_ui.avdl
@@ -127,5 +127,5 @@ protocol identifyUi {
   ConfirmResult confirm(int sessionID, IdentifyOutcome outcome);
   void finish(int sessionID);
 
-  void dismiss(int sessionID, UID uid, DismissReason reason);
+  void dismiss(int sessionID, string username, DismissReason reason);
 }

--- a/protocol/avdl/identify_ui.avdl
+++ b/protocol/avdl/identify_ui.avdl
@@ -95,6 +95,17 @@ protocol identifyUi {
     boolean expiringLocal;   // true if the user answers yes to "Expire local tracking statement after X?"
   }
 
+  enum DismissReasonType {
+    NONE_0,
+    HANDLED_ELSEWHERE_1
+  }
+
+  record DismissReason {
+    DismissReasonType type;
+    string reason;
+    string resource;
+  }
+
   void displayTLFCreateWithInvite(int sessionID, string folderName, boolean isPrivate, string assertion, string inviteLink, boolean throttled);
 
   // The IdentifyUI can be delegated to another process.  Call this function
@@ -115,4 +126,6 @@ protocol identifyUi {
   void displayUserCard(int sessionID, UserCard card);
   ConfirmResult confirm(int sessionID, IdentifyOutcome outcome);
   void finish(int sessionID);
+
+  void dismiss(int sessionID, UID uid, DismissReason reason);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1828,7 +1828,7 @@ export type identifyUi_dismiss_result = void
 export type identifyUi_dismiss_rpc = {
   method: 'identifyUi.dismiss',
   param: {
-    uid: UID,
+    username: string,
     reason: DismissReason
   },
   incomingCallMap: ?incomingCallMapType,
@@ -4245,7 +4245,7 @@ export type incomingCallMapType = {
   'keybase.1.identifyUi.dismiss'?: (
     params: {
       sessionID: int,
-      uid: UID,
+      username: string,
       reason: DismissReason
     },
     response: {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -170,6 +170,16 @@ export type DeviceType =
     0 // DESKTOP_0
   | 1 // MOBILE_1
 
+export type DismissReason = {
+  type: DismissReasonType;
+  reason: string;
+  resource: string;
+}
+
+export type DismissReasonType =
+    0 // NONE_0
+  | 1 // HANDLED_ELSEWHERE_1
+
 export type DowngradeReferenceRes = {
   completed: Array<BlockReferenceCount>;
   failed: BlockReference;
@@ -1813,6 +1823,18 @@ export type identifyUi_delegateIdentifyUI_rpc = {
   callback: (null | (err: ?any, response: identifyUi_delegateIdentifyUI_result) => void)
 }
 
+export type identifyUi_dismiss_result = void
+
+export type identifyUi_dismiss_rpc = {
+  method: 'identifyUi.dismiss',
+  param: {
+    uid: UID,
+    reason: DismissReason
+  },
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any) => void)
+}
+
 export type identifyUi_displayCryptocurrency_result = void
 
 export type identifyUi_displayCryptocurrency_rpc = {
@@ -3426,6 +3448,7 @@ export type rpc =
   | gpgUi_wantToAddGPGKey_rpc
   | identifyUi_confirm_rpc
   | identifyUi_delegateIdentifyUI_rpc
+  | identifyUi_dismiss_rpc
   | identifyUi_displayCryptocurrency_rpc
   | identifyUi_displayKey_rpc
   | identifyUi_displayTLFCreateWithInvite_rpc
@@ -4213,6 +4236,17 @@ export type incomingCallMapType = {
   'keybase.1.identifyUi.finish'?: (
     params: {
       sessionID: int
+    },
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
+    }
+  ) => void,
+  'keybase.1.identifyUi.dismiss'?: (
+    params: {
+      sessionID: int,
+      uid: UID,
+      reason: DismissReason
     },
     response: {
       error: (err: RPCError) => void,

--- a/protocol/js/keybase-v1.js
+++ b/protocol/js/keybase-v1.js
@@ -538,6 +538,10 @@ export const identifyUi = {
     'fresh': 0,
     'aged': 1,
     'rancid': 2
+  },
+  'DismissReasonType': {
+    'none': 0,
+    'handledElsewhere': 1
   }
 }
 

--- a/protocol/json/identify_ui.json
+++ b/protocol/json/identify_ui.json
@@ -1021,6 +1021,32 @@
           "name": "expiringLocal"
         }
       ]
+    },
+    {
+      "type": "enum",
+      "name": "DismissReasonType",
+      "symbols": [
+        "NONE_0",
+        "HANDLED_ELSEWHERE_1"
+      ]
+    },
+    {
+      "type": "record",
+      "name": "DismissReason",
+      "fields": [
+        {
+          "type": "DismissReasonType",
+          "name": "type"
+        },
+        {
+          "type": "string",
+          "name": "reason"
+        },
+        {
+          "type": "string",
+          "name": "resource"
+        }
+      ]
     }
   ],
   "messages": {
@@ -1224,6 +1250,23 @@
         {
           "name": "sessionID",
           "type": "int"
+        }
+      ],
+      "response": "null"
+    },
+    "dismiss": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "uid",
+          "type": "UID"
+        },
+        {
+          "name": "reason",
+          "type": "DismissReason"
         }
       ],
       "response": "null"

--- a/protocol/json/identify_ui.json
+++ b/protocol/json/identify_ui.json
@@ -1261,8 +1261,8 @@
           "type": "int"
         },
         {
-          "name": "uid",
-          "type": "UID"
+          "name": "username",
+          "type": "string"
         },
         {
           "name": "reason",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1828,7 +1828,7 @@ export type identifyUi_dismiss_result = void
 export type identifyUi_dismiss_rpc = {
   method: 'identifyUi.dismiss',
   param: {
-    uid: UID,
+    username: string,
     reason: DismissReason
   },
   incomingCallMap: ?incomingCallMapType,
@@ -4245,7 +4245,7 @@ export type incomingCallMapType = {
   'keybase.1.identifyUi.dismiss'?: (
     params: {
       sessionID: int,
-      uid: UID,
+      username: string,
       reason: DismissReason
     },
     response: {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -170,6 +170,16 @@ export type DeviceType =
     0 // DESKTOP_0
   | 1 // MOBILE_1
 
+export type DismissReason = {
+  type: DismissReasonType;
+  reason: string;
+  resource: string;
+}
+
+export type DismissReasonType =
+    0 // NONE_0
+  | 1 // HANDLED_ELSEWHERE_1
+
 export type DowngradeReferenceRes = {
   completed: Array<BlockReferenceCount>;
   failed: BlockReference;
@@ -1813,6 +1823,18 @@ export type identifyUi_delegateIdentifyUI_rpc = {
   callback: (null | (err: ?any, response: identifyUi_delegateIdentifyUI_result) => void)
 }
 
+export type identifyUi_dismiss_result = void
+
+export type identifyUi_dismiss_rpc = {
+  method: 'identifyUi.dismiss',
+  param: {
+    uid: UID,
+    reason: DismissReason
+  },
+  incomingCallMap: ?incomingCallMapType,
+  callback: (null | (err: ?any) => void)
+}
+
 export type identifyUi_displayCryptocurrency_result = void
 
 export type identifyUi_displayCryptocurrency_rpc = {
@@ -3426,6 +3448,7 @@ export type rpc =
   | gpgUi_wantToAddGPGKey_rpc
   | identifyUi_confirm_rpc
   | identifyUi_delegateIdentifyUI_rpc
+  | identifyUi_dismiss_rpc
   | identifyUi_displayCryptocurrency_rpc
   | identifyUi_displayKey_rpc
   | identifyUi_displayTLFCreateWithInvite_rpc
@@ -4213,6 +4236,17 @@ export type incomingCallMapType = {
   'keybase.1.identifyUi.finish'?: (
     params: {
       sessionID: int
+    },
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
+    }
+  ) => void,
+  'keybase.1.identifyUi.dismiss'?: (
+    params: {
+      sessionID: int,
+      uid: UID,
+      reason: DismissReason
     },
     response: {
       error: (err: RPCError) => void,

--- a/shared/constants/types/keybase-v1.js
+++ b/shared/constants/types/keybase-v1.js
@@ -538,6 +538,10 @@ export const identifyUi = {
     'fresh': 0,
     'aged': 1,
     'rancid': 2
+  },
+  'DismissReasonType': {
+    'none': 0,
+    'handledElsewhere': 1
   }
 }
 


### PR DESCRIPTION
This creates a new `Dismiss()` function as part of the IdentifyUI
protocol, which Electron will need to implement. That RPC will tell
Electron to close existing track windows for a given user.

This PR implements receiving dismissals, but what remains to be done is
*sending* dismissals. This will require another new RPC, maybe called
`DismissWithToken()`, as a counterpart to `TrackWithToken()` in
`track.avdl`. This will be called by Electron when a track window is
dismissed without tracking. Both of those RPC will be used to send out
gregor dismissals in a subsequent PR.