### PR TITLE
only allow vertical scroll

### DIFF
--- a/shared/folders/list.desktop.js
+++ b/shared/folders/list.desktop.js
@@ -78,7 +78,8 @@ class Render extends Component<void, Props, State> {
 }
 
 const stylesScrollContainer = {
-  overflow: 'auto'
+  overflowY: 'auto',
+  overflowX: 'hidden'
 }
 
 const stylesContainer = {


### PR DESCRIPTION
Should fix the horizontal scrollbar showing up for ppl in the widget

@keybase/react-hackers 