### PR TITLE
Cache device keys after generating them

### DIFF
--- a/go/engine/device_wrap.go
+++ b/go/engine/device_wrap.go
@@ -97,6 +97,12 @@ func (e *DeviceWrap) Run(ctx *Context) error {
 	e.signingKey = kgEng.SigningKey()
 	e.encryptionKey = kgEng.EncryptionKey()
 
+	if ctx.LoginContext != nil {
+		// cache the secret keys
+		ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType}, e.signingKey)
+		ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceEncryptionKeyType}, e.encryptionKey)
+	}
+
 	return nil
 }
 

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -608,6 +608,25 @@ func TestProvisionPaper(t *testing.T) {
 	if key != nil {
 		t.Errorf("Got a non-null paper encryption key after timeout")
 	}
+
+	// should be able to sign something with new device keys without
+	// entering a passphrase
+	var sink bytes.Buffer
+
+	sarg := &SaltpackSignArg{
+		Sink:   libkb.NopWriteCloser{W: &sink},
+		Source: ioutil.NopCloser(bytes.NewBufferString("hello")),
+	}
+
+	signEng := NewSaltpackSign(sarg, tc2.G)
+	ctx = &Context{
+		IdentifyUI: &FakeIdentifyUI{},
+		SecretUI:   &libkb.TestSecretUI{}, // empty
+	}
+
+	if err := RunEngine(signEng, ctx); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestProvisionPaperCommandLine(t *testing.T) {

--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -199,10 +199,6 @@ func (s *SignupEngine) registerDevice(a libkb.LoginContext, ctx *Context, device
 		}
 	}
 
-	// is there any reason *not* to do this?
-	ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType}, s.signingKey)
-	ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceEncryptionKeyType}, eng.EncryptionKey())
-
 	s.G().Log.Debug("registered new device: %s", s.G().Env.GetDeviceID())
 	s.G().Log.Debug("eldest kid: %s", s.me.GetEldestKID())
 


### PR DESCRIPTION
Before they were only cached after signup.

Moved the caching to DeviceWrap, which is responsible
for generating device keys.

r? @maxtaco 

cc @malgorithms 