### PR TITLE
have build_and_push_packages.sh also upload packages for friend-of-keybase

### DIFF
--- a/packaging/linux/build_and_push_packages.sh
+++ b/packaging/linux/build_and_push_packages.sh
@@ -105,6 +105,13 @@ release_prerelease() {
     s3cmd cp "$blob" "s3://$BUCKET_NAME/linux_binaries/rpm/"
   done
 
+  # Make yet another copy of the .deb and .rpm packages we just made, in a
+  # constant location for the friend-of-keybase instructions.
+  s3cmd put --follow-symlinks "$build_dir/deb_repo/keybase-latest-amd64.deb" "s3://$BUCKET_NAME/keybase_amd64.deb"
+  s3cmd put --follow-symlinks "$build_dir/deb_repo/keybase-latest-i386.deb" "s3://$BUCKET_NAME/keybase_i386.deb"
+  s3cmd put --follow-symlinks "$build_dir/rpm_repo/keybase-latest-x86_64.rpm" "s3://$BUCKET_NAME/keybase_amd64.rpm"
+  s3cmd put --follow-symlinks "$build_dir/rpm_repo/keybase-latest-i386.rpm" "s3://$BUCKET_NAME/keybase_i386.rpm"
+
   json_tmp=`mktemp`
   echo "Writing version into JSON to $json_tmp"
 


### PR DESCRIPTION
Previously we depended on s3_index.sh and the release tool to perform
this step, but that got broken in
https://github.com/keybase/client/pull/2743, and it took us a few weeks
to notice. This change fixes that break, and keeps all our Linux file
uploading in one place.

r? @gabriel @MarcoPolo 