### PR TITLE
Remove second on ready app listener

### DIFF
--- a/desktop/app/window.js
+++ b/desktop/app/window.js
@@ -1,6 +1,6 @@
 import showDockIcon from './dock-icon'
 import menuHelper from './menu-helper'
-import {app, ipcMain, BrowserWindow} from 'electron'
+import {ipcMain, BrowserWindow} from 'electron'
 import {focusOnShow} from '../shared/local-debug'
 
 export default class Window {
@@ -10,10 +10,7 @@ export default class Window {
     this.window = null
     this.initiallyVisible = this.opts.show || false
     this.releaseDockIcon = null
-
-    app.on('ready', () => {
-      this.createWindow()
-    })
+    this.createWindow()
 
     // Listen for remote windows to show a dock icon for, we'll bind the on close to
     // hide the dock icon too


### PR DESCRIPTION
Really tricky, there was a second on ready listener in our `Window` thing that didn't create the window until the app was ready.

But we had another bug where we used mainwindow.window before the app was ready, so we had wrap it in an `ready` listener.

So two `ready`'s do not work well together since the second one will never fire.