### PR TITLE
Fix commits checked out by visual diff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ script:
       cd shared && npm i -g flow-bin@`tail -n1 .flowconfig` && flow &&
       cd ../desktop && npm run setup-ci-tools && npm run setup-dev-tools &&
       cd .. && eslint . &&
+      if [ $TRAVIS_PULL_REQUEST != 'false' ]; then
+        cd desktop && ../packaging/npm_mess.sh && npm install octonode && npm run visdiff -- "$TRAVIS_COMMIT_RANGE" && cd ..;
+      fi &&
       cd protocol && ./diff_test.sh &&
       docker login -e "$CI_EMAIL" -u "$CI_USER" -p "$CI_PASS" "$CI_HOST" &&
       docker pull $CI_HOST/kbweb &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
       cd ../desktop && npm run setup-ci-tools && npm run setup-dev-tools &&
       cd .. && eslint . &&
       if [ $TRAVIS_PULL_REQUEST != 'false' ]; then
-        cd desktop && ../packaging/npm_mess.sh && npm install octonode && npm run visdiff -- "$TRAVIS_COMMIT_RANGE" && cd ..;
+        cd desktop && ../packaging/npm_mess.sh && npm install octonode && npm run visdiff -- "`git rev-parse $TRAVIS_COMMIT^1`...$TRAVIS_COMMIT" && cd ..;
       fi &&
       cd protocol && ./diff_test.sh &&
       docker login -e "$CI_EMAIL" -u "$CI_USER" -p "$CI_PASS" "$CI_HOST" &&


### PR DESCRIPTION
This incantation should select the correct before and after commits for visual diffing.

Before, I was using `$TRAVIS_COMMIT_RANGE`, which starts with the base of the merge (e.g. master) and ends with the last commit in the pull request. The `run-visdiff` script checks out each of these commits individually to render screenshots. The problem was that checking out the "last commit in the pull request" gives us the original un-merged history from the state of the pull requester's branch, rather than the result of merging the pull request for CI.

Now, we run: ```npm run visdiff -- "`git rev-parse $TRAVIS_COMMIT^1`...$TRAVIS_COMMIT"```

Breaking down what's going on here:

`$TRAVIS_COMMIT`: an automated merge commit for the pull request that CI is running against. The default state of `HEAD` when Travis is running.

`git rev-parse $TRAVIS_COMMIT^1`: the first parent of the merge commit (i.e. the commit from master branch that it is based on).

:eyeglasses: @keybase/react-hackers 