### PR TITLE
Dumb file list desktop 977 part 3

### DIFF
--- a/shared/common-adapters/back-button.desktop.js
+++ b/shared/common-adapters/back-button.desktop.js
@@ -19,8 +19,8 @@ export default class BackButton extends Component {
   render () {
     return (
       <div style={{...styles.container, ...this.props.style}} onClick={e => this.onClick(e)}>
-        <Icon type='fa-arrow-left' style={styles.icon} />
-        <Text type='BodyPrimaryLink' onClick={e => this.onClick(e)}>Back</Text>
+        <Icon type='fa-arrow-left' style={{...styles.icon, ...this.props.iconStyle}} />
+        {!this.props.iconOnly && <Text type='BodyPrimaryLink' style={this.props.textStyle} onClick={e => this.onClick(e)}>Back</Text>}
       </div>
     )
   }

--- a/shared/common-adapters/back-button.js.flow
+++ b/shared/common-adapters/back-button.js.flow
@@ -4,7 +4,10 @@ import React, {Component} from 'react'
 
 export type Props = {
   onClick: Function,
-  style?: ?Object
+  iconOnly?: boolean,
+  style?: ?Object,
+  iconStyle?: Object,
+  textStyle?: Object
 }
 
 declare export default class BackButton extends Component {

--- a/shared/common-adapters/back-button.native.js
+++ b/shared/common-adapters/back-button.native.js
@@ -22,8 +22,8 @@ export default class BackButton extends Component {
     return (
       <TouchableWithoutFeedback onPress={e => this.onClick(e)}>
         <Box style={{...styles.container, ...this.props.style}} >
-          <Icon type='fa-arrow-left' style={styles.icon} />
-          <Text type='BodyPrimaryLink'>Back</Text>
+          <Icon type='fa-arrow-left' style={{...styles.icon, ...this.props.iconStyle}} />
+          {!this.props.iconOnly && <Text type='BodyPrimaryLink' style={this.props.textStyle}>Back</Text>}
         </Box>
       </TouchableWithoutFeedback>
     )

--- a/shared/common-adapters/icon.js.flow
+++ b/shared/common-adapters/icon.js.flow
@@ -80,6 +80,7 @@ export type Props = {
   onMouseLeave?: () => void,
   style?: Object,
   inheritColor?: boolean,
+  underlayColor?: string,
   className?: string
 }
 

--- a/shared/common-adapters/icon.native.js
+++ b/shared/common-adapters/icon.native.js
@@ -23,8 +23,8 @@ export default class Icon extends Component {
 
     const width = this.props.style && this.props.style.width && {width: this.props.style.width}
     const height = this.props.style && this.props.style.height && {height: this.props.style.height}
-    const fontSize = this.props.style && this.props.style.width && {fontSize: this.props.style.width}
 
+    const fontSize = this.props.style && (this.props.style.fontSize || this.props.style.width)
     const textAlign = this.props.style && this.props.style.textAlign
     const fontWidth = this.props.style && this.props.style.fontWidth
 
@@ -35,15 +35,16 @@ export default class Icon extends Component {
     delete containerProps.height
     delete containerProps.textAlign
     delete containerProps.fontWidth
+    delete containerProps.fontSize
 
     const icon = fontIcons[iconType]
-      ? <Text style={{color, textAlign, fontFamily: 'kb', ...fontSize, width: fontWidth}}>{fontIcons[iconType]}</Text>
+      ? <Text style={{color, textAlign, fontFamily: 'kb', fontSize: fontSize, width: fontWidth}}>{fontIcons[iconType]}</Text>
       : <Image source={images[this.props.type]} style={{resizeMode: 'contain', ...width, ...height}} />
 
     return (
       <TouchableHighlight
         activeOpacity={0.8}
-        underlayColor={globalColors.white}
+        underlayColor={this.props.underlayColor || globalColors.white}
         onPress={this.props.onClick || (() => {})}
         disabled={!(this.props.onClick)}
         style={{...containerProps}}>

--- a/shared/common-adapters/list-item.desktop.js
+++ b/shared/common-adapters/list-item.desktop.js
@@ -6,9 +6,9 @@ import type {Props} from './list-item'
 
 export default class ListItem extends Component<void, Props, void> {
   render () {
-    const clickable = this.props.clickable === undefined ? true : !!this.props.clickable
+    const clickable = !!this.props.onClick
     return (
-      <Box style={{...globalStyles.flexBoxRow, ...containerStyle(this.props.type, clickable), ...this.props.containerStyle}}>
+      <Box style={{...globalStyles.flexBoxRow, ...containerStyle(this.props.type, clickable), ...this.props.containerStyle}} onClick={this.props.onClick}>
         <Box style={{...globalStyles.flexBoxColumn, ...iconContainerThemed[this.props.type], alignItems: 'center', justifyContent: 'center'}}>
           {this.props.icon}
         </Box>

--- a/shared/common-adapters/list-item.js.flow
+++ b/shared/common-adapters/list-item.js.flow
@@ -13,7 +13,7 @@ export type Props = {
   body: React$Element,
   action: React$Element,
   extraRightMarginAction?: boolean, // Spacing is different if the action is just text (for example)
-  clickable?: boolean, // defaults to true
+  onClick?: () => void,
   containerStyle?: Object,
   swipeToAction?: boolean // Do you have to swipe the list item to reveal an action?
 }

--- a/shared/common-adapters/list-item.native.js
+++ b/shared/common-adapters/list-item.native.js
@@ -1,14 +1,15 @@
 // @flow
 import React, {Component} from 'react'
+import {TouchableHighlight} from 'react-native'
 import Box from './box'
-import {globalStyles} from '../styles/style-guide'
+import {globalStyles, globalColors} from '../styles/style-guide'
 import type {Props} from './list-item'
 
 // TODO Add swipe for action
 export default class ListItem extends Component<void, Props, void> {
   render () {
-    const clickable = this.props.clickable === undefined ? true : !!this.props.clickable
-    return (
+    const clickable = !!this.props.onClick
+    const listItem = (
       <Box style={{...globalStyles.flexBoxRow, ...containerStyle(this.props.type, clickable), ...this.props.containerStyle}}>
         <Box style={{...globalStyles.flexBoxColumn, ...iconContainerThemed[this.props.type], alignItems: 'center', justifyContent: 'center'}}>
           {this.props.icon}
@@ -20,6 +21,17 @@ export default class ListItem extends Component<void, Props, void> {
           {this.props.action}
         </Box>)}
       </Box>
+    )
+
+    return (
+      <TouchableHighlight
+        activeOpacity={0.8}
+        underlayColor={globalColors.white}
+        onPress={this.props.onClick || (() => {})}
+        disabled={!(this.props.onClick)}>
+        {listItem}
+      </TouchableHighlight>
+
     )
   }
 }

--- a/shared/common-adapters/popup-menu.desktop.js
+++ b/shared/common-adapters/popup-menu.desktop.js
@@ -17,7 +17,7 @@ class Menu extends Component<void, Props, void> {
     `
 
     return (
-      <Box style={stylesMenuCatcher} onClick={() => this.props.onHidden()}>
+      <Box style={{...stylesMenuCatcher, ...this.props.menuCatcherStyle}} onClick={() => this.props.onHidden()}>
         <style>{realCSS}</style>
         <Box style={stylesMenu}>
           {this.props.items.map(i => (

--- a/shared/common-adapters/popup-menu.js.flow
+++ b/shared/common-adapters/popup-menu.js.flow
@@ -12,7 +12,8 @@ export type Props = {
   items: Array<MenuItem>,
   onHidden: () => void,
   visible: boolean,
-  style?: Object
+  style?: Object,
+  menuCatcherStyle?: Object
 }
 
 declare export default class PopupMenu extends React.Component<void, Props, void> {

--- a/shared/folders/dumb.js
+++ b/shared/folders/dumb.js
@@ -213,25 +213,71 @@ function genFiles (offsetNumber: number, fileCount: number, isPrivate: boolean):
       path: 'pics/',
       modifiedMarker: false,
       fileIcon: 'logo-128',
-      onClick: () => console.log('onClick:file')
+      onClick: () => console.log('onClick:file', wordGen(i))
     })
   }
 
   return results
 }
 
+const filesMenuItems = [
+  {title: 'Item 1', onClick: () => {}},
+  {title: 'Item 2', onClick: () => {}}
+]
+
 export const files: DumbComponentMap<Files> = {
   component: Files,
   mocks: {
+    'Normal - Public': {
+      theme: 'public',
+      visiblePopupMenu: false,
+      popupMenuItems: filesMenuItems,
+      selfUsername: 'cecileb',
+      users: ['cecileb', 'aliceb'],
+      onBack: () => console.log('onBack:files'),
+      onTogglePopupMenu: () => console.log('onTogglePopupMenu'),
+      recentFilesSection: [
+        {name: 'Today', modifiedMarker: true, files: genFiles(0, 4, false)},
+        {name: 'Yesterday', modifiedMarker: false, files: genFiles(4, 4, false)}
+      ]
+    },
+    'Popup - Public': {
+      theme: 'public',
+      visiblePopupMenu: true,
+      popupMenuItems: filesMenuItems,
+      selfUsername: 'cecileb',
+      users: ['cecileb', 'aliceb'],
+      onBack: () => console.log('onBack:files'),
+      onTogglePopupMenu: () => console.log('onTogglePopupMenu'),
+      recentFilesSection: [
+        {name: 'Today', modifiedMarker: true, files: genFiles(0, 4, false)},
+        {name: 'Yesterday', modifiedMarker: false, files: genFiles(4, 4, false)}
+      ]
+    },
     'Normal - Private': {
+      theme: 'private',
+      visiblePopupMenu: false,
+      popupMenuItems: filesMenuItems,
+      selfUsername: 'cecileb',
+      users: ['cecileb', 'aliceb'],
+      onBack: () => console.log('onBack:files'),
+      onTogglePopupMenu: () => console.log('onTogglePopupMenu'),
+      recentFilesSection: [
+        {name: 'Today', modifiedMarker: true, files: genFiles(0, 4, true)},
+        {name: 'Yesterday', modifiedMarker: false, files: genFiles(4, 4, true)}
+      ]
+    },
+    'Popup - Private': {
       theme: 'private',
       selfUsername: 'cecileb',
       users: ['cecileb', 'aliceb'],
       onBack: () => console.log('onBack:files'),
-      onOptions: () => console.log('onOptions'),
+      onTogglePopupMenu: () => console.log('onTogglePopupMenu'),
+      visiblePopupMenu: true,
+      popupMenuItems: filesMenuItems,
       recentFilesSection: [
         {name: 'Today', modifiedMarker: true, files: genFiles(0, 4, true)},
-        {name: 'Yesterday', modifiedMarker: true, files: genFiles(4, 8, true)}
+        {name: 'Yesterday', modifiedMarker: false, files: genFiles(4, 4, true)}
       ]
     }
   }
@@ -239,5 +285,6 @@ export const files: DumbComponentMap<Files> = {
 
 export default {
   'Folders TLF': map,
+  'Files': files,
   'File': file
 }

--- a/shared/folders/files/file/render.desktop.js
+++ b/shared/folders/files/file/render.desktop.js
@@ -40,7 +40,7 @@ export default class Render extends Component<void, Props, void> {
         body={this._renderBody()}
         action={this._renderAction()}
         containerStyle={fileContainerStyleThemed[this.props.theme]}
-        clickable />
+        onClick={this.props.onClick} />
     )
   }
 }
@@ -58,6 +58,7 @@ const filenameStyleThemed = {
 
 const fileContainerStyleThemed = {
   'public': {
+    backgroundColor: globalColors.white
   },
   'private': {
     backgroundColor: globalColors.darkBlue

--- a/shared/folders/files/file/render.native.js
+++ b/shared/folders/files/file/render.native.js
@@ -40,7 +40,7 @@ export default class Render extends Component<void, Props, void> {
         body={this._renderBody()}
         action={this._renderAction()}
         containerStyle={fileContainerStyleThemed[this.props.theme]}
-        clickable />
+        onClick={this.props.onClick} />
     )
   }
 }
@@ -58,6 +58,7 @@ const filenameStyleThemed = {
 
 const fileContainerStyleThemed = {
   'public': {
+    backgroundColor: globalColors.white
   },
   'private': {
     backgroundColor: globalColors.darkBlue

--- a/shared/folders/files/render.desktop.js
+++ b/shared/folders/files/render.desktop.js
@@ -1,30 +1,129 @@
 // @flow
 import React, {Component} from 'react'
-import {Box, Text, BackButton, Avatar, PopupMenu} from '../../common-adapters'
-import {globalStyles} from '../../styles/style-guide'
+import {Box, Text, BackButton, Avatar, PopupMenu, Icon} from '../../common-adapters'
+import File from './file/render'
+import {globalStyles, globalColors} from '../../styles/style-guide'
+import {resolveImageAsURL} from '../../../desktop/resolve-root'
 import {intersperseFn} from '../../util/arrays'
+import type {Props, FileSection} from './render'
 
-export default class Render extends Component {
+export default class Render extends Component<void, Props, void> {
+  _renderSection (section: FileSection) {
+    return (
+      <Box key={section.name} style={{...globalStyles.flexBoxColumn, backgroundColor: backgroundColorThemed[this.props.theme]}}>
+        <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', height: 32}}>
+          <Box key={section.name} style={{display: 'inline', marginLeft: 8}}>
+            {section.modifiedMarker && <Icon type='thunderbolt' style={{height: 12, alignSelf: 'center', marginRight: 6, ...styleSectionTextThemed[this.props.theme]}} />}
+            <Text type='BodySmallSemibold' style={{...styleSectionTextThemed[this.props.theme]}}>{section.name}</Text>
+          </Box>
+        </Box>
+        {intersperseFn(i => <Box key={i} style={{height: 1, backgroundColor: globalColors.black_10}} />,
+                       section.files.map(f => <File key={f.name} {...f} />))}
+      </Box>
+    )
+  }
+
   render () {
     const isPrivate = this.props.theme === 'private'
+    const menuColor = styleMenuColorThemed(this.props.theme, this.props.visiblePopupMenu)
+    const backButtonColor = backButtonColorThemed[this.props.theme]
+    const tlfTextStyle = styleTLFTextThemed[this.props.theme]
+
     return (
-      <Box style={{...globalStyles.flexBoxColumn}}>
-        <Box style={{...globalStyles.flexBoxRow}}>
-          <BackButton onClick={this.props.onBack} />
-          <Box style={{...globalStyles.flexBoxRow, flex: 2}}>
-            {this.props.users.map(u => <Avatar key={u} username={u} size={32} />)}
-          </Box>
-          <PopupMenu visible={false} items={[]} onHidden={() => {}} />
+      <Box style={{...globalStyles.flexBoxColumn, position: 'relative', backgroundColor: backgroundColorThemed[this.props.theme]}}>
+        <Box style={{...globalStyles.flexBoxRow, ...styleHeaderThemed[this.props.theme], height: 48}}>
+          <BackButton onClick={this.props.onBack} style={{marginLeft: 16}} iconStyle={{color: backButtonColor}} textStyle={{color: backButtonColor}} />
+          <Icon
+            style={{...styleMenu, color: menuColor, hoverColor: menuColor, marginRight: 16, position: 'relative', top: 18}}
+            type='fa-custom-icon-hamburger'
+            onClick={this.props.onTogglePopupMenu} />
         </Box>
-        <Box style={{display: 'inline'}}>
-          <Text type='BodySmall'>{isPrivate ? 'private/' : 'public/'}</Text>
-          {intersperseFn(i => (<Text key={i} type='BodySmallSemibold'>,</Text>), this.props.users.map(u => (
-            <Text key={u} type='BodySmallSemibold' style={this.props.selfUsename === u ? globalStyles.italic : {}}>{u}</Text>
-          )))}
+        <Box style={{...globalStyles.flexBoxColumn, ...styleTLFHeader, ...styleTLFHeaderThemed[this.props.theme]}}>
+          <Box style={{...globalStyles.flexBoxRow, height: 0, justifyContent: 'center', position: 'relative', bottom: 16}}>
+            {this.props.users.map(u => <Box key={u} style={{height: 32, width: 28}}><Avatar username={u} size={32} /></Box>)}
+          </Box>
+          <Box style={{display: 'inline', marginBottom: 'auto', marginTop: 'auto'}}>
+            <Text type='BodySmallSemibold' style={tlfTextStyle}>{isPrivate ? 'private/' : 'public/'}</Text>
+            {intersperseFn(i => (<Text key={i} style={tlfTextStyle} type='BodySemibold'>,</Text>), this.props.users.map(u => (
+              <Text key={u} type='BodySemibold' style={{...tlfTextStyle, ...(this.props.selfUsername === u ? globalStyles.italic : {})}}>{u}</Text>
+            )))}
+          </Box>
+        </Box>
+        <PopupMenu menuCatcherStyle={{alignItems: 'flex-end', top: 12, right: 12}} items={this.props.popupMenuItems} visible={this.props.visiblePopupMenu} onHidden={this.props.onTogglePopupMenu} />
+        <Box style={{...globalStyles.flexBoxColumn}}>
+          {this.props.recentFilesSection.map(s => this._renderSection(s))}
         </Box>
 
       </Box>
 
     )
   }
+}
+
+const styleHeaderThemed = {
+  'private': {
+    backgroundColor: globalColors.darkBlue3,
+    backgroundImage: `url(${resolveImageAsURL('icons', 'damier-pattern-good-open.png')})`,
+    backgroundRepeat: 'repeat'
+  },
+
+  'public': {
+    backgroundColor: globalColors.yellowGreen
+  }
+}
+
+const styleTLFHeader = {
+  height: 64,
+  alignItems: 'center'
+}
+
+const styleTLFHeaderThemed = {
+  'private': {
+    backgroundColor: globalColors.darkBlue
+  },
+
+  'public': {
+    backgroundColor: globalColors.white
+  }
+}
+
+const styleTLFTextThemed = {
+  'private': {
+    color: globalColors.white
+  },
+
+  'public': {
+    color: globalColors.yellowGreen
+  }
+}
+
+const styleSectionTextThemed = {
+  'public': {
+    color: globalColors.black_60
+  },
+  'private': {
+    color: globalColors.blue3_40
+  }
+}
+
+const backgroundColorThemed = {
+  'public': globalColors.lightGrey,
+  'private': globalColors.darkBlue3
+}
+
+const styleMenu = {
+  ...globalStyles.clickable,
+  marginLeft: 'auto',
+  fontSize: 12
+}
+
+const backButtonColorThemed = {
+  'private': globalColors.white,
+  'public': globalColors.white
+}
+
+function styleMenuColorThemed (theme, showingMenu): string {
+  return theme === 'public'
+    ? (showingMenu ? globalColors.black_40 : globalColors.white)
+    : (showingMenu ? globalColors.blue3 : globalColors.white)
 }

--- a/shared/folders/files/render.desktop.js
+++ b/shared/folders/files/render.desktop.js
@@ -53,9 +53,7 @@ export default class Render extends Component<void, Props, void> {
         <Box style={{...globalStyles.flexBoxColumn}}>
           {this.props.recentFilesSection.map(s => this._renderSection(s))}
         </Box>
-
       </Box>
-
     )
   }
 }

--- a/shared/folders/files/render.js.flow
+++ b/shared/folders/files/render.js.flow
@@ -15,7 +15,7 @@ export type Props = {
   popupMenuItems: Array<MenuItem>,
   selfUsername: string,
   users: Array<string>,
-  showGroupIcon?: boolean,
+  showGroupIcon?: boolean, // TODO (this is not implemented, but this will show the group icon instead of user avatars)
   onBack: () => void,
   onTogglePopupMenu: () => void,
   recentFilesSection: Array<FileSection>

--- a/shared/folders/files/render.js.flow
+++ b/shared/folders/files/render.js.flow
@@ -1,6 +1,7 @@
 // @flow
 
 import type {Props as FileProps} from './file/render'
+import type {MenuItem} from '../../common-adapters/popup-menu'
 
 export type FileSection = {
   name: string,
@@ -10,10 +11,13 @@ export type FileSection = {
 
 export type Props = {
   theme: 'public' | 'private',
+  visiblePopupMenu: boolean,
+  popupMenuItems: Array<MenuItem>,
   selfUsername: string,
   users: Array<string>,
+  showGroupIcon?: boolean,
   onBack: () => void,
-  onOptions: () => void,
+  onTogglePopupMenu: () => void,
   recentFilesSection: Array<FileSection>
 }
 

--- a/shared/folders/files/render.native.js
+++ b/shared/folders/files/render.native.js
@@ -1,5 +1,6 @@
 // @flow
 import React, {Component} from 'react'
+import {ScrollView} from 'react-native'
 import {Box, Text, BackButton, Avatar, Icon} from '../../common-adapters'
 import File from './file/render'
 import {globalStyles, globalColors} from '../../styles/style-guide'
@@ -22,22 +23,32 @@ export default class Render extends Component<void, Props, void> {
     )
   }
 
-  render () {
-    const isPrivate = this.props.theme === 'private'
+  // TODO render checkerboard pattern for private mode
+  _renderHeader () {
     const menuColor = styleMenuColorThemed(this.props.theme, this.props.visiblePopupMenu)
     const backButtonColor = backButtonColorThemed[this.props.theme]
+
+    const contents = (
+      <Box style={{...globalStyles.flexBoxRow, justifyContent: 'space-between', ...styleHeaderThemed[this.props.theme], height: 48}}>
+        <BackButton iconOnly onClick={this.props.onBack} style={{marginLeft: 16}} iconStyle={{color: backButtonColor}} textStyle={{color: backButtonColor}} />
+        <Icon
+          underlayColor={'transparent'}
+          style={{...styleMenu, color: menuColor, marginRight: 16}}
+          type='fa-custom-icon-hamburger'
+          onClick={this.props.onTogglePopupMenu} />
+      </Box>
+    )
+
+    return contents
+  }
+
+  render () {
+    const isPrivate = this.props.theme === 'private'
     const tlfTextStyle = styleTLFTextThemed[this.props.theme]
 
     return (
       <Box style={{...globalStyles.flexBoxColumn, position: 'relative', backgroundColor: backgroundColorThemed[this.props.theme]}}>
-        <Box style={{...globalStyles.flexBoxRow, justifyContent: 'space-between', ...styleHeaderThemed[this.props.theme], height: 48}}>
-          <BackButton iconOnly onClick={this.props.onBack} style={{marginLeft: 16}} iconStyle={{color: backButtonColor}} textStyle={{color: backButtonColor}} />
-          <Icon
-            underlayColor={'transparent'}
-            style={{...styleMenu, color: menuColor, marginRight: 16}}
-            type='fa-custom-icon-hamburger'
-            onClick={this.props.onTogglePopupMenu} />
-        </Box>
+        {this._renderHeader()}
         <Box style={{...globalStyles.flexBoxColumn, ...styleTLFHeader, ...styleTLFHeaderThemed[this.props.theme]}}>
           <Box style={{...globalStyles.flexBoxRow, height: 0, justifyContent: 'center', position: 'relative', bottom: 16}}>
             {this.props.users.map(u => <Box key={u} style={{height: 32, width: 28}}><Avatar username={u} size={32} /></Box>)}
@@ -49,9 +60,9 @@ export default class Render extends Component<void, Props, void> {
             )))}
           </Box>
         </Box>
-        <Box style={{...globalStyles.flexBoxColumn}}>
-          {this.props.recentFilesSection.map(s => this._renderSection(s))}
-        </Box>
+        <ScrollView>
+            {this.props.recentFilesSection.map(s => this._renderSection(s))}
+        </ScrollView>
 
       </Box>
 
@@ -61,8 +72,7 @@ export default class Render extends Component<void, Props, void> {
 
 const styleHeaderThemed = {
   'private': {
-    backgroundColor: globalColors.darkBlue3,
-    backgroundRepeat: 'repeat'
+    backgroundColor: globalColors.darkBlue3
   },
 
   'public': {

--- a/shared/folders/files/render.native.js
+++ b/shared/folders/files/render.native.js
@@ -1,0 +1,126 @@
+// @flow
+import React, {Component} from 'react'
+import {Box, Text, BackButton, Avatar, Icon} from '../../common-adapters'
+import File from './file/render'
+import {globalStyles, globalColors} from '../../styles/style-guide'
+import {intersperseFn} from '../../util/arrays'
+import type {Props, FileSection} from './render'
+
+export default class Render extends Component<void, Props, void> {
+  _renderSection (section: FileSection) {
+    return (
+      <Box key={section.name} style={{...globalStyles.flexBoxColumn, backgroundColor: backgroundColorThemed[this.props.theme]}}>
+        <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', height: 32}}>
+          <Box key={section.name} style={{...globalStyles.flexBoxRow, marginLeft: 8}}>
+            {section.modifiedMarker && <Icon type='thunderbolt' style={{height: 12, alignSelf: 'center', marginRight: 6, ...styleSectionTextThemed[this.props.theme]}} />}
+            <Text type='BodySmallSemibold' style={{...styleSectionTextThemed[this.props.theme]}}>{section.name}</Text>
+          </Box>
+        </Box>
+        {intersperseFn(i => <Box key={i} style={{height: 0.5, backgroundColor: globalColors.black_10}} />,
+                       section.files.map(f => <File key={f.name} {...f} />))}
+      </Box>
+    )
+  }
+
+  render () {
+    const isPrivate = this.props.theme === 'private'
+    const menuColor = styleMenuColorThemed(this.props.theme, this.props.visiblePopupMenu)
+    const backButtonColor = backButtonColorThemed[this.props.theme]
+    const tlfTextStyle = styleTLFTextThemed[this.props.theme]
+
+    return (
+      <Box style={{...globalStyles.flexBoxColumn, position: 'relative', backgroundColor: backgroundColorThemed[this.props.theme]}}>
+        <Box style={{...globalStyles.flexBoxRow, justifyContent: 'space-between', ...styleHeaderThemed[this.props.theme], height: 48}}>
+          <BackButton iconOnly onClick={this.props.onBack} style={{marginLeft: 16}} iconStyle={{color: backButtonColor}} textStyle={{color: backButtonColor}} />
+          <Icon
+            underlayColor={'transparent'}
+            style={{...styleMenu, color: menuColor, marginRight: 16}}
+            type='fa-custom-icon-hamburger'
+            onClick={this.props.onTogglePopupMenu} />
+        </Box>
+        <Box style={{...globalStyles.flexBoxColumn, ...styleTLFHeader, ...styleTLFHeaderThemed[this.props.theme]}}>
+          <Box style={{...globalStyles.flexBoxRow, height: 0, justifyContent: 'center', position: 'relative', bottom: 16}}>
+            {this.props.users.map(u => <Box key={u} style={{height: 32, width: 28}}><Avatar username={u} size={32} /></Box>)}
+          </Box>
+          <Box style={{...globalStyles.flexBoxRow, alignItems: 'flex-end', justifyContent: 'center', marginTop: 20, marginBottom: 20}}>
+            <Text type='BodySmallSemibold' style={tlfTextStyle}>{isPrivate ? 'private/' : 'public/'}</Text>
+            {intersperseFn(i => (<Text key={i} style={tlfTextStyle} type='BodySemibold'>,</Text>), this.props.users.map(u => (
+              <Text key={u} type='BodySemibold' style={{...tlfTextStyle, ...(this.props.selfUsername === u ? globalStyles.italic : {})}}>{u}</Text>
+            )))}
+          </Box>
+        </Box>
+        <Box style={{...globalStyles.flexBoxColumn}}>
+          {this.props.recentFilesSection.map(s => this._renderSection(s))}
+        </Box>
+
+      </Box>
+
+    )
+  }
+}
+
+const styleHeaderThemed = {
+  'private': {
+    backgroundColor: globalColors.darkBlue3,
+    backgroundRepeat: 'repeat'
+  },
+
+  'public': {
+    backgroundColor: globalColors.yellowGreen
+  }
+}
+
+const styleTLFHeader = {
+  height: 64
+}
+
+const styleTLFHeaderThemed = {
+  'private': {
+    backgroundColor: globalColors.darkBlue
+  },
+
+  'public': {
+    backgroundColor: globalColors.white
+  }
+}
+
+const styleTLFTextThemed = {
+  'private': {
+    color: globalColors.white
+  },
+
+  'public': {
+    color: globalColors.yellowGreen
+  }
+}
+
+const styleSectionTextThemed = {
+  'public': {
+    color: globalColors.black_60
+  },
+  'private': {
+    color: globalColors.blue3_40
+  }
+}
+
+const backgroundColorThemed = {
+  'public': globalColors.lightGrey,
+  'private': globalColors.darkBlue3
+}
+
+const styleMenu = {
+  ...globalStyles.clickable,
+  alignSelf: 'center',
+  fontSize: 12
+}
+
+const backButtonColorThemed = {
+  'private': globalColors.white,
+  'public': globalColors.white
+}
+
+function styleMenuColorThemed (theme, showingMenu): string {
+  return theme === 'public'
+    ? (showingMenu ? globalColors.black_40 : globalColors.white)
+    : (showingMenu ? globalColors.blue3 : globalColors.white)
+}


### PR DESCRIPTION
@keybase/react-hackers 

part 3! This adds the files view to the folders.

## Preview 

#### Mobile
<img width="733" alt="screen shot 2016-05-24 at 4 46 50 pm" src="https://cloud.githubusercontent.com/assets/594035/15523488/9c9846b0-21cf-11e6-9036-10972a31301c.png">

<img width="733" alt="screen shot 2016-05-24 at 4 46 55 pm" src="https://cloud.githubusercontent.com/assets/594035/15523490/9c9aaa04-21cf-11e6-822e-6ed97d50bf69.png">

#### Desktop
<img width="672" alt="screen shot 2016-05-24 at 4 47 54 pm" src="https://cloud.githubusercontent.com/assets/594035/15523489/9c9a6364-21cf-11e6-983e-0ddf46dab971.png">

![image](https://cloud.githubusercontent.com/assets/594035/15523509/c1c28ee6-21cf-11e6-9311-dd5cbb227408.png)

## Left todo (maybe in another PR):
Add thunderbolt into our font icon.
Use group avatar icon.
Use pattern in header for private (mobile)
