### PR TITLE
replay gregor state on UI connect CORE-3120

### DIFF
--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -80,6 +80,7 @@ type GlobalContext struct {
 	loginHooks          []LoginHook         // call these on login
 	logoutHooks         []LogoutHook        // call these on logout
 	GregorDismisser     GregorDismisser     // for dismissing gregor items that we've handled
+	GregorListener      GregorListener      // for alerting about clients connecting and registering UI protocols
 }
 
 func NewGlobalContext() *GlobalContext {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -424,6 +424,14 @@ type GregorDismisser interface {
 	DismissItem(id gregor.MsgID) error
 }
 
+type GregorInBandMessageHandler interface {
+	IsAlive() bool
+	Name() string
+	HandlesCategory(category string) bool
+	Create(ctx context.Context, category string, ibm gregor.Item) error
+	Dismiss(ctx context.Context, category string, ibm gregor.Item) error
+}
+
 type GregorListener interface {
-	ConnectIdentifyUI() error
+	PushHandler(handler GregorInBandMessageHandler)
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -427,7 +427,6 @@ type GregorDismisser interface {
 type GregorInBandMessageHandler interface {
 	IsAlive() bool
 	Name() string
-	HandlesCategory(category string) bool
 	Create(ctx context.Context, category string, ibm gregor.Item) error
 	Dismiss(ctx context.Context, category string, ibm gregor.Item) error
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -423,3 +423,7 @@ type Clock interface {
 type GregorDismisser interface {
 	DismissItem(id gregor.MsgID) error
 }
+
+type GregorListener interface {
+	ConnectIdentifyUI() error
+}

--- a/go/service/delegate_ui.go
+++ b/go/service/delegate_ui.go
@@ -28,6 +28,11 @@ func NewDelegateUICtlHandler(xp rpc.Transporter, id libkb.ConnectionID, g *libkb
 
 func (d *DelegateUICtlHandler) RegisterIdentifyUI(_ context.Context) error {
 	d.G().UIRouter.SetUI(d.id, libkb.IdentifyUIKind)
+
+	// Let Gregor related code know that a IdentifyUI client
+	// (probably Electron) has connected, and to sync out state to it
+	d.G().GregorListener.ConnectIdentifyUI()
+
 	return nil
 }
 

--- a/go/service/delegate_ui.go
+++ b/go/service/delegate_ui.go
@@ -31,7 +31,9 @@ func (d *DelegateUICtlHandler) RegisterIdentifyUI(_ context.Context) error {
 
 	// Let Gregor related code know that a IdentifyUI client
 	// (probably Electron) has connected, and to sync out state to it
-	d.G().GregorListener.ConnectIdentifyUI()
+	if d.G().GregorListener != nil {
+		d.G().GregorListener.PushHandler(NewIdentifyUIHandler(d.G(), d.id))
+	}
 
 	return nil
 }

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -51,7 +51,7 @@ func (h *identifyUIHandler) toggleAlwaysAlive(alive bool) {
 }
 
 type gregorHandler struct {
-	libkb.Contextifie
+	libkb.Contextified
 
 	// This lock is to protect ibmHandlers and gregorCli. Only public methods
 	// should grab it.

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -435,7 +435,7 @@ func (h identifyUIHandler) Dismiss(ctx context.Context, category string, item gr
 }
 
 func (h identifyUIHandler) handleShowTrackerPopupCreate(ctx context.Context, item gregor.Item) error {
-	h.G().Log.Debug("gregor handler: handleShowTrackerPopup: %+v", item)
+	h.G().Log.Debug("gregor handler: handleShowTrackerPopupCreate: %+v", item)
 	if item.Body() == nil {
 		return errors.New("gregor handler for show_tracker_popup: nil message body")
 	}
@@ -488,7 +488,7 @@ func (h identifyUIHandler) handleShowTrackerPopupCreate(ctx context.Context, ite
 }
 
 func (h identifyUIHandler) handleShowTrackerPopupDismiss(ctx context.Context, item gregor.Item) error {
-	g.G().Log.Debug("gregor handler: handleDismissTrackerPopup: %+v", item)
+	h.G().Log.Debug("gregor handler: handleShowTrackerPopupDismiss: %+v", item)
 	if item.Body() == nil {
 		return errors.New("gregor dismissal for show_tracker_popup: nil message body")
 	}

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -242,6 +242,8 @@ func (g *gregorHandler) serverSync(ctx context.Context, cli gregor1.IncomingInte
 	return nil
 }
 
+// OnConnect is called by the rpc library to indicate we have connected to
+// gregord
 func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 	cli rpc.GenericClient, srv *rpc.Server) error {
 	g.Lock()
@@ -301,6 +303,8 @@ func (g *gregorHandler) ShouldRetryOnConnect(err error) bool {
 	return true
 }
 
+// BroadcastMessage is called when we receive a new messages from gregord. Grabs
+// the lock protect the state machine and handleInBandMessage
 func (g *gregorHandler) BroadcastMessage(ctx context.Context, m gregor1.Message) error {
 	g.Lock()
 	defer g.Unlock()
@@ -345,6 +349,7 @@ func (g *gregorHandler) handleInBandMessage(ctx context.Context, ibm gregor.InBa
 	return nil
 }
 
+// handleInBandMessageWithHandler runs a message against the specified handler
 func (g *gregorHandler) handleInBandMessageWithHandler(ctx context.Context,
 	ibm gregor.InBandMessage, handler libkb.GregorInBandMessageHandler) error {
 	g.G().Log.Debug("gregor handler: handleInBand: %+v", ibm)

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -46,10 +46,6 @@ func (h identifyUIHandler) Name() string {
 	return "identifyUIHandler"
 }
 
-func (h identifyUIHandler) HandlesCategory(category string) bool {
-	return category == "show_tracker_popup"
-}
-
 func (h *identifyUIHandler) toggleAlwaysAlive(alive bool) {
 	h.alwaysAlive = alive
 }
@@ -366,10 +362,7 @@ func (g *gregorHandler) handleInBandMessageWithHandler(ctx context.Context,
 				g.G().Log.Debug("gregor handler: item %s has category %s", id, category)
 			}
 
-			// Run handler for the category if it handles it
-			if handler.HandlesCategory(category) {
-				handler.Create(ctx, category, item)
-			}
+			handler.Create(ctx, category, item)
 		}
 
 		dismissal := update.Dismissal()
@@ -389,10 +382,7 @@ func (g *gregorHandler) handleInBandMessageWithHandler(ctx context.Context,
 					g.G().Log.Debug("gregor handler: dismissal %s has category %s", id, category)
 				}
 
-				// Run handler for the category if it handles it
-				if handler.HandlesCategory(category) {
-					handler.Dismiss(ctx, category, item)
-				}
+				handler.Dismiss(ctx, category, item)
 
 				// Clear the item out of items map.
 				delete(g.itemsByID, id.String())
@@ -414,9 +404,7 @@ func (h identifyUIHandler) Create(ctx context.Context, category string, item gre
 		return h.handleShowTrackerPopupCreate(ctx, item)
 	}
 
-	errmsg := "identifyUIHandler: create() on unhandled category"
-	h.G().Log.Error(errmsg)
-	return errors.New(errmsg)
+	return nil
 }
 
 func (h identifyUIHandler) Dismiss(ctx context.Context, category string, item gregor.Item) error {
@@ -425,9 +413,7 @@ func (h identifyUIHandler) Dismiss(ctx context.Context, category string, item gr
 		return h.handleShowTrackerPopupDismiss(ctx, item)
 	}
 
-	errmsg := "identifyUIHandler: dismiss() on unhandled category"
-	h.G().Log.Error(errmsg)
-	return errors.New(errmsg)
+	return nil
 }
 
 func (h identifyUIHandler) handleShowTrackerPopupCreate(ctx context.Context, item gregor.Item) error {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -317,11 +317,13 @@ func (g *gregorHandler) handleInBandMessage(ctx context.Context, ibm gregor.InBa
 			// Run handler for the category, and if a UIKind is specified, check
 			// to see if the handler cares about it
 			handler, present := g.ibmHandlers[category]
-			if present && (uik == nil || handler.needsUI(*uik)) {
-				handler.create(ctx, item)
+			if present {
+				if uik == nil || handler.needsUI(*uik) {
+					handler.create(ctx, item)
+				}
+			} else {
+				g.G().Log.Errorf("Unrecognized item category: %s", item.Category())
 			}
-
-			g.G().Log.Errorf("Unrecognized item category: %s", item.Category())
 		}
 
 		dismissal := update.Dismissal()
@@ -344,8 +346,12 @@ func (g *gregorHandler) handleInBandMessage(ctx context.Context, ibm gregor.InBa
 				// Run handler for the category, and if a UIKind is specified,
 				// check to see if the handler cares about it
 				handler, present := g.ibmHandlers[category]
-				if present && (uik == nil || handler.needsUI(*uik)) {
-					handler.dismiss(ctx, item)
+				if present {
+					if uik == nil || handler.needsUI(*uik) {
+						handler.dismiss(ctx, item)
+					}
+				} else {
+					g.G().Log.Errorf("Unrecognized item category: %s", item.Category())
 				}
 
 				// Clear the item out of items map.

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -103,6 +103,9 @@ func TestShowTrackerPopupMessage(t *testing.T) {
 	}
 	tc.G.SetUIRouter(&router)
 
+	idhandler := NewIdentifyUIHandler(tc.G, 0)
+	idhandler.toggleAlwaysAlive(true)
+
 	trackee, err := kbtest.CreateAndSignupFakeUser("gregr", tc.G)
 	if err != nil {
 		t.Fatal(err)
@@ -118,6 +121,8 @@ func TestShowTrackerPopupMessage(t *testing.T) {
 	if h, err = newGregorHandler(tc.G); err != nil {
 		t.Fatal(err)
 	}
+
+	h.PushHandler(idhandler)
 
 	msgID := gregor1.MsgID("my_random_id")
 	m := gregor1.Message{

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -292,6 +292,7 @@ func (d *Service) gregordConnect() (err error) {
 		return err
 	}
 	d.G().GregorDismisser = d.gregor
+	d.G().GregorListener = d.gregor
 
 	if err = d.gregor.Connect(uri); err != nil {
 		return err


### PR DESCRIPTION
@maxtaco @oconnor663 @patrickxb this is an attempt at getting the `gregorHandler` to respond to Electron connecting and needing to replay the state to it. The basic idea is similar to what we talked about today:

* When Electron registers the IdentifyUI protocol, then alert `gregorHandler` that it happened.
* `gregorHandler` will then replay all the messages from its current state.
* Bonus addition of in-band message handlers being able to declare if they care about the UI replay or not.

Anyway, I just hacked this together tonight, and I'm curious if you all think this is the right path to be going down.