### PR TITLE
Add CloneWithAddedFields method to logger

### DIFF
--- a/go/logger/logger.go
+++ b/go/logger/logger.go
@@ -12,6 +12,8 @@ type ExternalHandler interface {
 	Log(level keybase1.LogLevel, format string, args []interface{})
 }
 
+type Fields map[string]interface{}
+
 type Logger interface {
 	// Debug logs a message at debug level, with formatting args.
 	Debug(format string, args ...interface{})
@@ -61,6 +63,10 @@ type Logger interface {
 	// Returns a logger that is like the current one, except with
 	// more logging depth added on.
 	CloneWithAddedDepth(depth int) Logger
+
+	// Returns a logger that is like the current one, except with
+	// the given fields added.
+	CloneWithAddedFields(fields Fields) Logger
 
 	// SetExternalHandler sets a handler that will be called with every log message.
 	SetExternalHandler(handler ExternalHandler)

--- a/go/logger/null.go
+++ b/go/logger/null.go
@@ -35,5 +35,7 @@ func (l *Null) RotateLogFile() error                                           {
 
 func (l *Null) CloneWithAddedDepth(depth int) Logger { return l }
 
+func (l *Null) CloneWithAddedFields(fields Fields) Logger { return l }
+
 func (l *Null) SetExternalHandler(handler ExternalHandler) {}
 func (l *Null) Shutdown()                                  {}

--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -113,6 +113,8 @@ func (log *Standard) setLogLevelInfo() {
 	}
 }
 
+// TODO: Also print out fields, if we start using them in production.
+
 func (log *Standard) prepareString(
 	ctx context.Context, fmts string) string {
 	if ctx == nil {

--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -75,6 +75,7 @@ type Standard struct {
 	filename       string
 	configureMutex sync.Mutex
 	module         string
+	fields         Fields
 
 	externalHandler ExternalHandler
 }
@@ -337,18 +338,25 @@ func (log *Standard) clone() *Standard {
 	clone := *log
 	cloneInternal := *log.internal
 	clone.internal = &cloneInternal
+	clone.fields = make(Fields, len(log.fields))
+	for k, v := range log.fields {
+		clone.fields[k] = v
+	}
 	return &clone
 }
 
 func (log *Standard) CloneWithAddedDepth(depth int) Logger {
 	clone := log.clone()
-	clone.internal.ExtraCalldepth = log.internal.ExtraCalldepth + depth
+	clone.internal.ExtraCalldepth += depth
 	return clone
 }
 
 func (log *Standard) CloneWithAddedFields(fields Fields) Logger {
-	// TODO: Fix.
-	return log.clone()
+	clone := log.clone()
+	for k, v := range fields {
+		clone.fields[k] = v
+	}
+	return clone
 }
 
 func (log *Standard) SetExternalHandler(handler ExternalHandler) {

--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -333,12 +333,22 @@ func PickFirstError(errors ...error) error {
 	return nil
 }
 
-func (log *Standard) CloneWithAddedDepth(depth int) Logger {
+func (log *Standard) clone() *Standard {
 	clone := *log
 	cloneInternal := *log.internal
-	cloneInternal.ExtraCalldepth = log.internal.ExtraCalldepth + depth
 	clone.internal = &cloneInternal
 	return &clone
+}
+
+func (log *Standard) CloneWithAddedDepth(depth int) Logger {
+	clone := log.clone()
+	clone.internal.ExtraCalldepth = log.internal.ExtraCalldepth + depth
+	return clone
+}
+
+func (log *Standard) CloneWithAddedFields(fields Fields) Logger {
+	// TODO: Fix.
+	return log.clone()
 }
 
 func (log *Standard) SetExternalHandler(handler ExternalHandler) {

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -4,6 +4,7 @@
 package logger
 
 import (
+	"fmt"
 	"runtime"
 	"strings"
 
@@ -43,8 +44,12 @@ func (log *TestLogger) log(lvl logging.Level, format string, args ...interface{}
 	// it out (at least on a terminal) and do our own formatting.
 	_, file, line, _ := runtime.Caller(2 + log.extraDepth)
 	elements := strings.Split(file, "/")
-	log.backend.Logf("\r%s:%d: [%.1s] "+format,
-		append([]interface{}{elements[len(elements)-1], line, lvl}, args...)...)
+	var fieldsStr string
+	if len(log.fields) > 0 {
+		fieldsStr = fmt.Sprintf(" %v", log.fields)
+	}
+	log.backend.Logf("\r%s:%d: [%.1s]%s "+format,
+		append([]interface{}{elements[len(elements)-1], line, lvl, fieldsStr}, args...)...)
 }
 
 func (log *TestLogger) Debug(fmts string, arg ...interface{}) {

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -32,6 +32,7 @@ type TestLogBackend interface {
 type TestLogger struct {
 	log        TestLogBackend
 	extraDepth int
+	fields     Fields
 }
 
 func NewTestLogger(log TestLogBackend) *TestLogger {
@@ -132,18 +133,24 @@ func (log *TestLogger) RotateLogFile() error {
 
 func (log *TestLogger) clone() *TestLogger {
 	clone := *log
+	clone.fields = make(Fields, len(log.fields))
+	for k, v := range log.fields {
+		clone.fields[k] = v
+	}
 	return &clone
 }
 
 func (log *TestLogger) CloneWithAddedDepth(depth int) Logger {
-	// TODO: Fix.
 	clone := log.clone()
-	clone.extraDepth = log.extraDepth + depth
+	clone.extraDepth += depth
 	return clone
 }
 
 func (log *TestLogger) CloneWithAddedFields(fields Fields) Logger {
 	clone := log.clone()
+	for k, v := range fields {
+		clone.fields[k] = v
+	}
 	return clone
 }
 

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -130,10 +130,21 @@ func (log *TestLogger) RotateLogFile() error {
 	return nil
 }
 
-func (log *TestLogger) CloneWithAddedDepth(depth int) Logger {
+func (log *TestLogger) clone() *TestLogger {
 	clone := *log
-	clone.extraDepth += depth
 	return &clone
+}
+
+func (log *TestLogger) CloneWithAddedDepth(depth int) Logger {
+	// TODO: Fix.
+	clone := log.clone()
+	clone.extraDepth = log.extraDepth + depth
+	return clone
+}
+
+func (log *TestLogger) CloneWithAddedFields(fields Fields) Logger {
+	clone := log.clone()
+	return clone
 }
 
 // no-op stubs to fulfill the Logger interface

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -6,6 +6,7 @@ package logger
 import (
 	"fmt"
 	"runtime"
+	"sort"
 	"strings"
 
 	logging "github.com/keybase/go-logging"
@@ -46,9 +47,18 @@ func (log *TestLogger) log(lvl logging.Level, format string, args ...interface{}
 	elements := strings.Split(file, "/")
 	var fieldsStr string
 	if len(log.fields) > 0 {
-		fieldsStr = fmt.Sprintf(" %v", log.fields)
+		var keys []string
+		for k := range log.fields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var fields []string
+		for _, k := range keys {
+			fields = append(fields, fmt.Sprintf("%s:%v", k, log.fields[k]))
+		}
+		fieldsStr = ", " + strings.Join(fields, " ")
 	}
-	log.backend.Logf("\r%s:%d: [%.1s]%s "+format,
+	log.backend.Logf("\r%s:%d: [%.1s%s] "+format,
 		append([]interface{}{elements[len(elements)-1], line, lvl, fieldsStr}, args...)...)
 }
 

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -4,7 +4,6 @@
 package logger
 
 import (
-	"fmt"
 	"runtime"
 	"strings"
 
@@ -17,12 +16,8 @@ import (
 // a *testing.T).  We define this in order to avoid pulling in the
 // "testing" package in exported code.
 type TestLogBackend interface {
-	Error(args ...interface{})
-	Errorf(format string, args ...interface{})
-	Fatal(args ...interface{})
-	Fatalf(format string, args ...interface{})
-	Log(args ...interface{})
 	Logf(format string, args ...interface{})
+	FailNow()
 }
 
 // TestLogger is a Logger that writes to a TestLogBackend.  All
@@ -30,96 +25,99 @@ type TestLogBackend interface {
 // test that is trying to test an error condition.  No context tags
 // are logged.
 type TestLogger struct {
-	log        TestLogBackend
+	backend    TestLogBackend
 	extraDepth int
 	fields     Fields
 }
 
 func NewTestLogger(log TestLogBackend) *TestLogger {
-	return &TestLogger{log: log}
+	return &TestLogger{backend: log}
 }
 
 // Verify TestLogger fully implements the Logger interface.
 var _ Logger = (*TestLogger)(nil)
 
-func prefixCaller(extraDepth int, lvl logging.Level, fmts string) string {
+func (log *TestLogger) log(lvl logging.Level, format string, args ...interface{}) {
 	// The testing library doesn't let us control the stack depth,
 	// and it always prints out its own prefix, so use \r to clear
 	// it out (at least on a terminal) and do our own formatting.
-	_, file, line, _ := runtime.Caller(2 + extraDepth)
+	_, file, line, _ := runtime.Caller(2 + log.extraDepth)
 	elements := strings.Split(file, "/")
-	return fmt.Sprintf("\r%s:%d: [%.1s] %s", elements[len(elements)-1], line, lvl, fmts)
+	log.backend.Logf("\r%s:%d: [%.1s] "+format,
+		append([]interface{}{elements[len(elements)-1], line, lvl}, args...)...)
 }
 
 func (log *TestLogger) Debug(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.DEBUG, fmts), arg...)
+	log.log(logging.DEBUG, fmts, arg...)
 }
 
 func (log *TestLogger) CDebugf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.DEBUG, fmts), arg...)
+	log.log(logging.DEBUG, fmts, arg...)
 }
 
 func (log *TestLogger) Info(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.INFO, fmts), arg...)
+	log.log(logging.INFO, fmts, arg...)
 }
 
 func (log *TestLogger) CInfof(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.INFO, fmts), arg...)
+	log.log(logging.INFO, fmts, arg...)
 }
 
 func (log *TestLogger) Notice(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.NOTICE, fmts), arg...)
+	log.log(logging.NOTICE, fmts, arg...)
 }
 
 func (log *TestLogger) CNoticef(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.NOTICE, fmts), arg...)
+	log.log(logging.NOTICE, fmts, arg...)
 }
 
 func (log *TestLogger) Warning(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.WARNING, fmts), arg...)
+	log.log(logging.WARNING, fmts, arg...)
 }
 
 func (log *TestLogger) CWarningf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.WARNING, fmts), arg...)
+	log.log(logging.WARNING, fmts, arg...)
 }
 
 func (log *TestLogger) Error(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.ERROR, fmts), arg...)
+	log.log(logging.ERROR, fmts, arg...)
 }
 
 func (log *TestLogger) Errorf(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.ERROR, fmts), arg...)
+	log.log(logging.ERROR, fmts, arg...)
 }
 
 func (log *TestLogger) CErrorf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.ERROR, fmts), arg...)
+	log.log(logging.ERROR, fmts, arg...)
 }
 
 func (log *TestLogger) Critical(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.log(logging.CRITICAL, fmts, arg...)
 }
 
 func (log *TestLogger) CCriticalf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.log(logging.CRITICAL, fmts, arg...)
 }
 
 func (log *TestLogger) Fatalf(fmts string, arg ...interface{}) {
-	log.log.Fatalf(prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.log(logging.CRITICAL, fmts, arg...)
+	log.backend.FailNow()
 }
 
 func (log *TestLogger) CFatalf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Fatalf(prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.log(logging.CRITICAL, fmts, arg...)
+	log.backend.FailNow()
 }
 
 func (log *TestLogger) Profile(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.log(logging.CRITICAL, fmts, arg...)
 }
 
 func (log *TestLogger) Configure(style string, debug bool, filename string) {


### PR DESCRIPTION
This lets us use structured logging.
For now, just use these fields in TestLogger,
as they'll be used in tests.

Also pare down TestLogBackend interface.
