### PR TITLE
Add logsend bridge to ios

### DIFF
--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -896,11 +896,16 @@ func (e *Env) GetStoredSecretServiceName() string {
 type AppConfig struct {
 	NullConfiguration
 	HomeDir                     string
+	LogFile                     string
 	RunMode                     RunMode
 	Debug                       bool
 	LocalRPCDebug               string
 	ServerURI                   string
 	SecurityAccessGroupOverride bool
+}
+
+func (c AppConfig) GetLogFile() string {
+	return c.LogFile
 }
 
 func (c AppConfig) GetDebug() (bool, bool) {

--- a/go/loopback/main.go
+++ b/go/loopback/main.go
@@ -17,7 +17,7 @@ var con net.Conn
 var startOnce sync.Once
 
 // Init ServerURI should match run mode environment.
-func Init(homeDir string, runModeStr string, serverURI string, accessGroupOverride bool) {
+func Init(homeDir string, logFile string, runModeStr string, serverURI string, accessGroupOverride bool) {
 	startOnce.Do(func() {
 		g := libkb.G
 		g.Init()
@@ -30,7 +30,7 @@ func Init(homeDir string, runModeStr string, serverURI string, accessGroupOverri
 		if err != nil {
 			fmt.Println("Error decoding run mode", err, runModeStr)
 		}
-		config := libkb.AppConfig{HomeDir: homeDir, RunMode: runMode, Debug: true, LocalRPCDebug: "Acsvip", ServerURI: serverURI, SecurityAccessGroupOverride: accessGroupOverride}
+		config := libkb.AppConfig{HomeDir: homeDir, LogFile: logFile, RunMode: runMode, Debug: true, LocalRPCDebug: "Acsvip", ServerURI: serverURI, SecurityAccessGroupOverride: accessGroupOverride}
 		err = libkb.G.Configure(config, usage)
 		if err != nil {
 			panic(err)

--- a/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -66,7 +66,7 @@ public class MainActivity extends ReactActivity {
             startActivityForResult(intent, -1);
         }
 
-        Init(this.getFilesDir().getPath(), "staging", "", false);
+        Init(this.getFilesDir().getPath(), logFile.getAbsolutePath(), "staging", "", false);
 
         try {
             Keybase.SetGlobalExternalKeyStore(new KeyStore(this, getSharedPreferences("KeyStore", MODE_PRIVATE)));

--- a/react-native/ios/Keybase.xcodeproj/project.pbxproj
+++ b/react-native/ios/Keybase.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 139FDEF41B06529B00C62182 /* libRCTWebSocket.a */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
+		A969A40A1CF65C9C00F273F2 /* LogSend.m in Sources */ = {isa = PBXBuildFile; fileRef = A969A4091CF65C9C00F273F2 /* LogSend.m */; };
 		DB0846051BA75DC800F54960 /* keybase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB0846041BA75DC800F54960 /* keybase.framework */; };
 		DB1D5FEC1CA99E67006DC784 /* kb.ttf in Resources */ = {isa = PBXBuildFile; fileRef = DB1D5FE21CA99E67006DC784 /* kb.ttf */; };
 		DBC44FCE1CD3AF9400A226BC /* Lato_bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = DBC44FC71CD3AA1000A226BC /* Lato_bold.ttf */; };
@@ -145,6 +146,8 @@
 		29E8042104BFC61155FEE956 /* Pods-Keybase.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Keybase.release.xcconfig"; path = "Pods/Target Support Files/Pods-Keybase/Pods-Keybase.release.xcconfig"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
+		A969A4091CF65C9C00F273F2 /* LogSend.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LogSend.m; sourceTree = "<group>"; };
+		A969A4161CF65CB200F273F2 /* LogSend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LogSend.h; sourceTree = "<group>"; };
 		B01B0A0DD7B9A98B314CE2FB /* Pods-Keybase.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Keybase.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Keybase/Pods-Keybase.debug.xcconfig"; sourceTree = "<group>"; };
 		DB0846041BA75DC800F54960 /* keybase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = keybase.framework; sourceTree = "<group>"; };
 		DB1D5FE21CA99E67006DC784 /* kb.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = kb.ttf; path = ../../../desktop/renderer/fonts/kb.ttf; sourceTree = "<group>"; };
@@ -389,6 +392,8 @@
 				DBDCF3501B8D04FD00BA95D8 /* ObjcTest.m */,
 				DBDCF3511B8D04FD00BA95D8 /* ReactBridge.m */,
 				DBDCF3521B8D04FD00BA95D8 /* SwiftTest.swift */,
+				A969A4091CF65C9C00F273F2 /* LogSend.m */,
+				A969A4161CF65CB200F273F2 /* LogSend.h */,
 				DBDCF3441B8D04FC00BA95D8 /* Keybase-Bridging-Header.h */,
 				0044E59C1BCD7CEA008EF7EE /* LaunchScreen.storyboard */,
 			);
@@ -728,6 +733,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A969A40A1CF65C9C00F273F2 /* LogSend.m in Sources */,
 				DBDCF3531B8D04FD00BA95D8 /* ObjcTest.m in Sources */,
 				DBCE36251B90F14800ECADDE /* Engine.m in Sources */,
 				DBDCF3551B8D04FD00BA95D8 /* SwiftTest.swift in Sources */,

--- a/react-native/ios/Keybase/AppDelegate.swift
+++ b/react-native/ios/Keybase/AppDelegate.swift
@@ -10,6 +10,7 @@ class AppDelegate: UIResponder {
   
   var window: UIWindow?
   var engine: Engine!
+  var logSender: LogSend!
   
   private func setupReactWithOptions(launchOptions: [NSObject: AnyObject]?) -> RCTRootView {
     return RCTRootView(bundleURL: {
@@ -41,12 +42,17 @@ class AppDelegate: UIResponder {
       home = (root as NSString).stringByAppendingPathComponent(home)
     }
 
+    let logFile = (home as NSString).stringByAppendingPathComponent("ios.log");
+
     engine = Engine(settings: [
       "runmode": AppDefault.RunMode.stringValue!,
       "homedir": home,
+      "logFile": logFile,
       "serverURI": AppDefault.APIServer.stringValue ?? "",
       "SecurityAccessGroupOverride": SecurityAccessGroupOverride
     ])
+
+    logSender = LogSend(path: logFile);
   }
   
 }

--- a/react-native/ios/Keybase/Engine.m
+++ b/react-native/ios/Keybase/Engine.m
@@ -39,7 +39,7 @@ static NSString *const eventName = @"objc-engine-event";
 }
 
 - (void)setupKeybaseWithSettings:(NSDictionary *) settings {
-  GoKeybaseInit(settings[@"homedir"], settings[@"runmode"], settings[@"serverURI"], settings[@"SecurityAccessGroupOverride"]);
+  GoKeybaseInit(settings[@"homedir"], settings[@"logFile"], settings[@"runmode"], settings[@"serverURI"], settings[@"SecurityAccessGroupOverride"]);
 }
 
 - (void)setupQueues {

--- a/react-native/ios/Keybase/Keybase-Bridging-Header.h
+++ b/react-native/ios/Keybase/Keybase-Bridging-Header.h
@@ -5,5 +5,6 @@
 #import "RCTBridgeModule.h"
 #import "RCTEventDispatcher.h"
 #import "Engine.h"
+#import "LogSend.h"
 #import "RCTRootView.h"
 #import <keybase/keybase.h>

--- a/react-native/ios/Keybase/LogSend.h
+++ b/react-native/ios/Keybase/LogSend.h
@@ -1,0 +1,9 @@
+#import "RCTBridgeModule.h"
+#import <keybase/keybase.h>
+
+@interface LogSend : NSObject <RCTBridgeModule>
+- (instancetype)initWithPath:(NSString *)uiLogPath;
+
+@property NSString *uiLogPath;
+
+@end

--- a/react-native/ios/Keybase/LogSend.m
+++ b/react-native/ios/Keybase/LogSend.m
@@ -1,0 +1,29 @@
+#import "LogSend.h"
+
+@implementation LogSend
+
+- (instancetype)initWithPath:(NSString *)uiLogPath {
+  if ((self = [super init])) {
+    self.uiLogPath = uiLogPath;
+  }
+  return self;
+}
+
+RCT_EXPORT_MODULE();
+
+RCT_REMAP_METHOD(logSend,
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+
+  NSString *logId = nil;
+  NSError *err = nil;
+  GoKeybaseLogSend(self.uiLogPath, &logId, &err);
+  if (err == nil) {
+    resolve(logId);
+  } else {
+    reject(@"log_send_err", @"Error in sending log", err);
+  }
+}
+
+@end

--- a/shared/native/log-send.ios.js
+++ b/shared/native/log-send.ios.js
@@ -1,1 +1,2 @@
-export default function () { return Promise.resolve('none') }
+import {NativeModules} from 'react-native'
+export default NativeModules.LogSend.logSend


### PR DESCRIPTION
@keybase/react-hackers 

This adds the log send bridge to ios (already existed on android)


next step is to hook up the logsend on the Go side (separate PR).

You can verify it works by going into More -> Log send -> Press button -> It will say TODO (which comes from Go).

