### PR TITLE
remove store dumping in action logger

### DIFF
--- a/desktop/npm-shrinkwrap.json
+++ b/desktop/npm-shrinkwrap.json
@@ -67,6 +67,16 @@
       "from": "array-flatten@1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
     },
+    "array-parallel": {
+      "version": "0.1.3",
+      "from": "array-parallel@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz"
+    },
+    "array-series": {
+      "version": "0.1.5",
+      "from": "array-series@>=0.1.5 <0.2.0",
+      "resolved": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz"
+    },
     "array-union": {
       "version": "1.0.1",
       "from": "array-union@>=1.0.1 <2.0.0",
@@ -999,7 +1009,8 @@
           "dependencies": {
             "core-js": {
               "version": "1.2.6",
-              "from": "core-js@>=1.0.0 <2.0.0"
+              "from": "core-js@1.2.6",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
             }
           }
         },
@@ -1052,7 +1063,8 @@
           "dependencies": {
             "core-js": {
               "version": "1.2.6",
-              "from": "core-js@>=1.0.0 <2.0.0"
+              "from": "core-js@1.2.6",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
             }
           }
         },
@@ -1745,7 +1757,8 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "from": "minimist@0.0.8"
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
@@ -2576,6 +2589,11 @@
         }
       }
     },
+    "gm": {
+      "version": "1.22.0",
+      "from": "gm@1.22.0",
+      "resolved": "https://registry.npmjs.org/gm/-/gm-1.22.0.tgz"
+    },
     "graceful-fs": {
       "version": "4.1.3",
       "from": "graceful-fs@>=4.1.2 <5.0.0",
@@ -2930,6 +2948,43 @@
       "from": "json5@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
     },
+    "jsondiffpatch": {
+      "version": "0.1.43",
+      "from": "jsondiffpatch@0.1.43",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.1.43.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "from": "ansi-regex@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "from": "ansi-styles@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "from": "has-ansi@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "from": "strip-ansi@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "from": "supports-color@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+        }
+      }
+    },
     "jsonfile": {
       "version": "2.3.0",
       "from": "jsonfile@>=2.1.0 <3.0.0",
@@ -3225,7 +3280,14 @@
     "mkdirp": {
       "version": "0.5.1",
       "from": "mkdirp@0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        }
+      }
     },
     "mkpath": {
       "version": "0.1.0",
@@ -5815,7 +5877,8 @@
       "dependencies": {
         "esprima": {
           "version": "2.7.2",
-          "from": "esprima@>=2.5.0 <3.0.0"
+          "from": "esprima@2.7.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
         },
         "supports-color": {
           "version": "3.1.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -36,6 +36,7 @@
     "framed-msgpack-rpc": "keybase/node-framed-msgpack-rpc#nojima/keybase-client-changes",
     "getenv": "0.6.0",
     "immutable": "3.7.6",
+    "jsondiffpatch": "0.1.43",
     "lodash": "4.6.1",
     "marked": "0.3.5",
     "material-ui": "0.14.4",

--- a/shared/store/action-logger.js
+++ b/shared/store/action-logger.js
@@ -1,6 +1,41 @@
+import Immutable from 'immutable'
+import jsondiffpatch from 'jsondiffpatch'
+
+// Transform objects from Immutable on printing
+const objToJS = state => {
+  var newState = {}
+
+  Object.keys(state).forEach(i => {
+    if (Immutable.Iterable.isIterable(state[i])) {
+      newState[i] = state[i].toJS()
+    } else {
+      newState[i] = state[i]
+    }
+  })
+
+  return newState
+}
+
+let logs = []
+let startedLoop = false
+
 export const actionLogger = store => next => action => {
-  console.groupCollapsed && console.groupCollapsed(`Dispatching action: ${action.type}`)
-  console.log(`Dispatching action: ${action.type}: ${JSON.stringify(action)} `)
-  console.groupEnd && console.groupEnd()
-  return next(action)
+  if (!startedLoop) {
+    startedLoop = true
+    setInterval(() => {
+      if (!logs.length) return
+      console.groupCollapsed && console.groupCollapsed('Actions: ' + logs.length)
+      console.log(logs.join('\n'))
+      logs = []
+      console.groupEnd && console.groupEnd()
+    }, 2000)
+  }
+  const old = objToJS(store.getState())
+
+  let result = next(action)
+
+  logs.push('Dispatching action: ' + action.type + ': ', JSON.stringify(action) + '\n' +
+    'State diff: ' + JSON.stringify(jsondiffpatch.diff(old, objToJS(store.getState()))))
+
+  return result
 }

--- a/shared/store/action-logger.js
+++ b/shared/store/action-logger.js
@@ -1,27 +1,6 @@
-import Immutable from 'immutable'
-
-// Transform objects from Immutable on printing
-const objToJS = state => {
-  var newState = {}
-
-  Object.keys(state).forEach(i => {
-    if (Immutable.Iterable.isIterable(state[i])) {
-      newState[i] = state[i].toJS()
-    } else {
-      newState[i] = state[i]
-    }
-  })
-
-  return newState
-}
-
 export const actionLogger = store => next => action => {
   console.groupCollapsed && console.groupCollapsed(`Dispatching action: ${action.type}`)
-
   console.log(`Dispatching action: ${action.type}: ${JSON.stringify(action)} `)
-  let result = next(action)
-
-  console.log('Next state:', JSON.stringify(objToJS(store.getState())))
   console.groupEnd && console.groupEnd()
-  return result
+  return next(action)
 }


### PR DESCRIPTION
@keybase/react-hackers @MarcoPolo our logging really lags out the electron process since its all async. we have action logging turned on for everyone always, let's make this lighter weight. i think we can see whats going on with just the actions for most cases so i'm whittling this down to just that for now. thoughts?