### PR TITLE
visdiff: Use HEAD instead of $TRAVIS_COMMIT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
       cd ../desktop && npm run setup-ci-tools && npm run setup-dev-tools &&
       cd .. && eslint . &&
       if [ $TRAVIS_PULL_REQUEST != 'false' ]; then
-        cd desktop && ../packaging/npm_mess.sh && npm install octonode && npm run visdiff -- "`git rev-parse HEAD^1`...HEAD" && cd ..;
+        cd desktop && ../packaging/npm_mess.sh && npm install octonode && npm run visdiff -- "`git rev-parse HEAD^1`...`git rev-parse HEAD`" && cd ..;
       fi &&
       cd protocol && ./diff_test.sh &&
       docker login -e "$CI_EMAIL" -u "$CI_USER" -p "$CI_PASS" "$CI_HOST" &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
       cd ../desktop && npm run setup-ci-tools && npm run setup-dev-tools &&
       cd .. && eslint . &&
       if [ $TRAVIS_PULL_REQUEST != 'false' ]; then
-        cd desktop && ../packaging/npm_mess.sh && npm install octonode && npm run visdiff -- "`git rev-parse $TRAVIS_COMMIT^1`...$TRAVIS_COMMIT" && cd ..;
+        cd desktop && ../packaging/npm_mess.sh && npm install octonode && npm run visdiff -- "`git rev-parse HEAD^1`...HEAD" && cd ..;
       fi &&
       cd protocol && ./diff_test.sh &&
       docker login -e "$CI_EMAIL" -u "$CI_USER" -p "$CI_PASS" "$CI_HOST" &&


### PR DESCRIPTION
It seems that $TRAVIS_COMMIT can fall out of date wrt GitHub's merged PR
ref in some cases, which breaks visdiff because the commit it tries to
check out doesn't exist.

:eyeglasses: @keybase/react-hackers 