### PR TITLE
make DismissItem call ConsumeMessage properly

### DIFF
--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -529,6 +529,6 @@ func (e *Identify2WithUID) getTrackType() identify2TrackType {
 	}
 }
 
-func (e *Identify2WithUID) setResponsibleGregorItem(item gregor.Item) {
+func (e *Identify2WithUID) SetResponsibleGregorItem(item gregor.Item) {
 	e.responsibleGregorItem = item
 }

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -84,7 +84,7 @@ func (e *ResolveThenIdentify2) Run(ctx *Context) (err error) {
 
 	e.i2eng = NewIdentify2WithUID(e.G(), e.arg)
 	if e.responsibleGregorItem != nil {
-		e.i2eng.setResponsibleGregorItem(e.responsibleGregorItem)
+		e.i2eng.SetResponsibleGregorItem(e.responsibleGregorItem)
 	}
 
 	if err = e.resolveUID(ctx); err != nil {
@@ -104,6 +104,6 @@ func (e *ResolveThenIdentify2) Result() *keybase1.Identify2Res {
 	return e.i2eng.Result()
 }
 
-func (e *ResolveThenIdentify2) setResponsibleGregorItem(item gregor.Item) {
+func (e *ResolveThenIdentify2) SetResponsibleGregorItem(item gregor.Item) {
 	e.responsibleGregorItem = item
 }

--- a/go/engine/track_token_test.go
+++ b/go/engine/track_token_test.go
@@ -485,7 +485,7 @@ func TestTrackWithTokenDismissesGregor(t *testing.T) {
 		SecretUI:   fu.NewSecretUI(),
 	}
 	eng := NewResolveThenIdentify2(tc.G, arg)
-	eng.setResponsibleGregorItem(&responsibleGregorItem)
+	eng.SetResponsibleGregorItem(&responsibleGregorItem)
 	if err := RunEngine(eng, ctx); err != nil {
 		tc.T.Fatal(err)
 	}

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -645,28 +645,35 @@ func (g *gregorHandler) connectNoTLS(uri *rpc.FMPURI) error {
 }
 
 func (g *gregorHandler) DismissItem(id gregor.MsgID) error {
-	idStruct := gregor1.MsgID(id.Bytes())
+	g.G().Log.Debug("gregorHandler.DismissItem called with MsgID %s", id.String())
+
+	gregorMsgIDToDismiss := gregor1.MsgID(id.Bytes())
+
 	uid := g.G().Env.GetUID()
 	if uid.IsNil() {
 		return fmt.Errorf("Can't dismiss gregor items without a current UID.")
 	}
-	msgID, randErr := libkb.RandBytes(16) // TODO: Create a shared function for this.
+	gregorUID := gregor1.UID(uid.ToBytes())
+
+	newMsgID, randErr := libkb.RandBytes(16) // TODO: Create a shared function for this.
 	if randErr != nil {
 		return randErr
 	}
+
 	dismissal := gregor1.Message{
 		Ibm_: &gregor1.InBandMessage{
 			StateUpdate_: &gregor1.StateUpdateMessage{
 				Md_: gregor1.Metadata{
-					Uid_:   gregor1.UID(uid),
-					MsgID_: msgID,
+					Uid_:   gregorUID,
+					MsgID_: newMsgID,
 				},
 				Dismissal_: &gregor1.Dismissal{
-					MsgIDs_: []gregor1.MsgID{idStruct},
+					MsgIDs_: []gregor1.MsgID{gregorMsgIDToDismiss},
 				},
 			},
 		},
 	}
+	incomingClient := gregor1.IncomingClient{Cli: g.cli}
 	// TODO: Should the interface take a context from the caller?
-	return g.BroadcastMessage(context.TODO(), dismissal)
+	return incomingClient.ConsumeMessage(context.TODO(), dismissal)
 }

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -484,6 +484,7 @@ func (h IdentifyUIHandler) handleShowTrackerPopupCreate(ctx context.Context, ite
 	}
 	identifyArg := keybase1.Identify2Arg{Uid: uid, Reason: identifyReason}
 	identifyEng := engine.NewIdentify2WithUID(h.G(), &identifyArg)
+	identifyEng.SetResponsibleGregorItem(item)
 	return identifyEng.Run(&engineContext)
 }
 

--- a/go/service/track.go
+++ b/go/service/track.go
@@ -64,9 +64,11 @@ func (h *TrackHandler) TrackWithToken(_ context.Context, arg keybase1.TrackWithT
 func (h *TrackHandler) DismissWithToken(_ context.Context, arg keybase1.DismissWithTokenArg) error {
 	outcome, err := h.G().TrackCache.Get(arg.TrackToken)
 	if err != nil {
+		h.G().Log.Error("Failed to get track token", err)
 		return err
 	}
 	if outcome.ResponsibleGregorItem == nil {
+		h.G().Log.Info("No responsible gregor item found for track token %s", arg.TrackToken)
 		return nil
 	}
 


### PR DESCRIPTION
Previously we were calling the wrong end of the API. BroadcastMessage is
what is supposed to get called when the *server* informs us of a
message.

r? @maxtaco @mmaxim 

This is not yet working. The client RPC call seems to hang forever, and I can't see anything at all in the gregord logs. Probably something thinks it's not connected yet. I will debug with you guys tomorrow.