### PR TITLE
Add search dumb component for mobile

### DIFF
--- a/shared/common-adapters/avatar.js.flow
+++ b/shared/common-adapters/avatar.js.flow
@@ -4,7 +4,7 @@ import React, {Component} from 'react'
 
 type CommonProps = {
   size: 176 | 112 | 80 | 64 | 48 | 32 | 24
-| 180 | 110 | 75 | 60 | 45 | 32, // TODO old sizes: remove this line and clean up globally
+| 180 | 110 | 75 | 60 | 45 | 32 | 16, // TODO old sizes: remove this line and clean up globally
   style?: ?Object,
   onClick?: ?(() => void)
 }

--- a/shared/common-adapters/input.js.flow
+++ b/shared/common-adapters/input.js.flow
@@ -17,6 +17,7 @@ export type Props = $Shape<{
   rowsMax?: number,
   style?: Object,
   inputStyle?: Object,
+  iosOmitUnderline?: boolean,
   underlineStyle?: Object,
   type?: 'password' | 'text' | 'passwordVisible',
   autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters',

--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -67,7 +67,7 @@ class Input extends Component<void, Props, State> {
           onSubmitEditing={this.props.onEnterKeyDown}
           onChange={this.props.onChange}
           onChangeText={text => { this.setState({text}); this.props.onChangeText && this.props.onChangeText(text) }} />
-        {IOS && <HorizontalLine focused={this.state.inputFocused} />}
+        {IOS && !this.props.iosOmitUnderline && <HorizontalLine focused={this.state.inputFocused} />}
         {!!(this.props.errorText) && <Text type='Error' style={{...errorText, ...this.props.errorStyle}}>{this.props.errorText}</Text>}
       </Box>
     )

--- a/shared/common-adapters/list-item.js.flow
+++ b/shared/common-adapters/list-item.js.flow
@@ -15,6 +15,7 @@ export type Props = {
   extraRightMarginAction?: boolean, // Spacing is different if the action is just text (for example)
   onClick?: () => void,
   containerStyle?: Object,
+  bodyContainerStyle?: Object,
   swipeToAction?: boolean // Do you have to swipe the list item to reveal an action?
 }
 

--- a/shared/common-adapters/list-item.native.js
+++ b/shared/common-adapters/list-item.native.js
@@ -18,7 +18,7 @@ export default class ListItem extends Component<void, Props, void> {
             {this.props.icon}
           </Box>
         </Box>
-        <Box style={{...globalStyles.flexBoxColumn, ...bodyContainerStyle(this.props.swipeToAction)}}>
+        <Box style={{...globalStyles.flexBoxColumn, ...bodyContainerStyle(this.props.swipeToAction), ...this.props.bodyContainerStyle}}>
           {this.props.body}
         </Box>
         {!this.props.swipeToAction && (<Box style={{...globalStyles.flexBoxColumn, ...actionStyle(!!this.props.extraRightMarginAction), justifyContent: 'center'}}>

--- a/shared/common-adapters/text.native.js
+++ b/shared/common-adapters/text.native.js
@@ -158,7 +158,7 @@ Text.contextTypes = {
   inTerminal: React.PropTypes.bool
 }
 
-const sizeGroups: { [key: '40' | '30' | '22' | '18' | '15' | '14']: Object } = {
+const sizeGroups: { [key: '40' | '30' | '22' | '18' | '15' | '13']: Object } = {
   '40': {
     fontSize: 40,
     lineHeight: 46
@@ -179,8 +179,8 @@ const sizeGroups: { [key: '40' | '30' | '22' | '18' | '15' | '14']: Object } = {
     fontSize: 15,
     lineHeight: 20
   },
-  '14': {
-    fontSize: 14,
+  '13': {
+    fontSize: 13,
     lineHeight: 18
   }
 }
@@ -301,11 +301,11 @@ export const styles = {
   },
   textBodyXSmall: {
     ...textCommon,
-    ...sizeGroups['14']
+    ...sizeGroups['13']
   },
   textBodyXSmallLink: {
     ...textCommon,
-    ...sizeGroups['14']
+    ...sizeGroups['13']
   },
   textError: {
     ...textCommon,

--- a/shared/constants/types/more.js
+++ b/shared/constants/types/more.js
@@ -38,3 +38,7 @@ export type DumbComponentMap<C: Component<*, *, *>> = {
     [key: string]: PropsOf<C>
   }
 }
+
+export type Combo<A, B> = {
+  combo: [A, B]
+}

--- a/shared/constants/types/more.js
+++ b/shared/constants/types/more.js
@@ -38,7 +38,3 @@ export type DumbComponentMap<C: Component<*, *, *>> = {
     [key: string]: PropsOf<C>
   }
 }
-
-export type Combo<A, B> = {
-  combo: [A, B]
-}

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -19,6 +19,7 @@ let config = {
   overrideLoggedInTab: null,
   dumbFilter: '',
   dumbIndex: 0,
+  dumbFullscreen: false,
   printRoutes: false
 }
 
@@ -36,6 +37,7 @@ if (__DEV__ && true) {
   config.overrideLoggedInTab = Tabs.moreTab
   config.dumbFilter = ''
   config.dumbIndex = 0
+  config.dumbFullscreen = false
   config.printRoutes = true
 }
 
@@ -54,6 +56,7 @@ export const {
   overrideLoggedInTab,
   dumbFilter,
   dumbIndex,
+  dumbFullscreen,
   printRoutes
 } = config
 

--- a/shared/more/dumb-component-map.native.js
+++ b/shared/more/dumb-component-map.native.js
@@ -6,6 +6,8 @@ import DeviceRevokeMap from '../devices/device-revoke/dumb.native'
 import QRMap from '../login/register/code-page/qr/dumb.native'
 import DevicePageMap from '../devices/device-page/dumb.native'
 import FoldersMap from '../folders/dumb'
+import SearchMap from '../search/dumb'
+
 import type {DumbComponentMap} from './dumb'
 
 const map: DumbComponentMap = {
@@ -16,7 +18,8 @@ const map: DumbComponentMap = {
   ...DevicesMap,
   ...DeviceRevokeMap,
   ...DevicePageMap,
-  ...FoldersMap
+  ...FoldersMap,
+  ...SearchMap
 }
 
 export default map

--- a/shared/more/dumb-sheet.render.native.js
+++ b/shared/more/dumb-sheet.render.native.js
@@ -4,7 +4,7 @@ import {ScrollView} from 'react-native'
 import {Box, Text, Input, Button} from '../common-adapters'
 import {globalStyles} from '../styles/style-guide'
 import dumbComponentMap from './dumb-component-map.native'
-import {dumbFilter, dumbIndex} from '../local-debug'
+import {dumbFilter, dumbIndex, dumbFullscreen} from '../local-debug'
 import debounce from 'lodash/debounce'
 
 class Render extends Component<void, any, any> {
@@ -27,6 +27,7 @@ class Render extends Component<void, any, any> {
 
   render () {
     const components = []
+    const componentsOnly = []
 
     Object.keys(dumbComponentMap).forEach(key => {
       if (this.state.filter && key.toLowerCase().indexOf(this.state.filter) === -1) {
@@ -48,10 +49,19 @@ class Render extends Component<void, any, any> {
             </Box>
           </Box>
         )
+        componentsOnly.push(<Component key={mockKey} {...mock} />)
       })
     })
 
     const ToShow = components[this.state.index % components.length]
+
+    if (dumbFullscreen) {
+      return (
+        <Box style={{flex: 1}}>
+          {componentsOnly[this.state.index % components.length]}
+        </Box>
+      )
+    }
 
     return (
       <Box style={{flex: 1}}>

--- a/shared/search/dumb.js
+++ b/shared/search/dumb.js
@@ -1,0 +1,63 @@
+// @flow
+
+import UserSearch from './user-search/render'
+import type {DumbComponentMap} from '../constants/types/more'
+
+const userSearchMap: DumbComponentMap<UserSearch> = {
+  component: UserSearch,
+  mocks: {
+    'Normal': {
+      searchHintText: 'Search Keybase',
+      searchText: 'malg',
+      searchIcon: 'logo-32',
+      results: [
+        {
+          service: 'external',
+          icon: 'fa-twitter',
+          username: 'malgorithms',
+          extraInfo: {
+            service: 'keybase',
+            username: 'chris',
+            fullName: 'Chris Coyne',
+            isFollowing: true
+          }
+        },
+        {
+          service: 'keybase',
+          username: 'malg',
+          isFollowing: false,
+          extraInfo: {
+            service: 'none',
+            fullName: 'John Malg'
+          }
+        },
+        {
+          service: 'keybase',
+          username: 'chris',
+          isFollowing: true,
+          extraInfo: {
+            service: 'external',
+            icon: 'fa-twitter',
+            serviceUsername: 'malgorithms',
+            fullNameOnService: 'Chris Coyne'
+          }
+        },
+        {
+          service: 'keybase',
+          username: 'chris2',
+          isFollowing: true,
+          extraInfo: {
+            service: 'keybase',
+            username: 'chris',
+            fullName: 'Chris Coyne',
+            isFollowing: true
+          }
+        }
+      ]
+    }
+  }
+}
+
+export default {
+  'user search': userSearchMap
+}

--- a/shared/search/dumb.js
+++ b/shared/search/dumb.js
@@ -33,6 +33,15 @@ const userSearchMap: DumbComponentMap<UserSearch> = {
         },
         {
           service: 'keybase',
+          username: 'malgomalg',
+          isFollowing: false,
+          extraInfo: {
+            service: 'none',
+            fullName: 'Malgo Malg'
+          }
+        },
+        {
+          service: 'keybase',
           username: 'chris',
           isFollowing: true,
           extraInfo: {

--- a/shared/search/user-search/render.desktop.js
+++ b/shared/search/user-search/render.desktop.js
@@ -1,0 +1,10 @@
+// @flow
+import React, {Component} from 'react'
+import {Text} from '../../common-adapters'
+import type {Props} from './render'
+
+export default class Render extends Component<void, Props, void> {
+  render () {
+    return (<Text type='Body'>todo</Text>)
+  }
+}

--- a/shared/search/user-search/render.js.flow
+++ b/shared/search/user-search/render.js.flow
@@ -1,0 +1,42 @@
+/* @flow */
+
+import React, {Component} from 'react'
+
+import type {Props as IconProps} from '../../common-adapters/icon'
+
+export type ExtraInfo = {
+  service: 'external',
+  icon: IconProps.type,
+  serviceUsername: string, // i.e. with twitter it would be malgorithms
+  fullNameOnService: ?string // Say with twitter we know malgorithms is "Chris Coyne"
+} | {
+  service: 'keybase',
+  username: string,
+  fullName: string,
+  isFollowing: boolean
+} | {
+  service: 'none',
+  fullName: string
+}
+
+export type SearchResult = {
+  service: 'keybase',
+  username: string,
+  isFollowing: boolean,
+  extraInfo: ExtraInfo
+} | {
+  service: 'external',
+  icon: IconProps.type,
+  username: string,
+  extraInfo: ExtraInfo
+}
+
+export type Props = {
+  searchHintText: string,
+  searchText: ?string,
+  searchIcon: IconProps.type,
+  results: Array<SearchResult>
+}
+
+export default class Render extends Component<void, Props, void> { }
+

--- a/shared/search/user-search/render.native.js
+++ b/shared/search/user-search/render.native.js
@@ -88,7 +88,7 @@ function Result ({result, searchText}: {result: SearchResult, searchText: string
       extraInfo = <KeybaseExtraInfo {...result.extraInfo} searchText={searchText} />
       break
     case 'none':
-      extraInfo = <Text type='BodyXSmall' style={{color: globalColors.black_40}}>{result.extraInfo.fullName}</Text>
+      extraInfo = <Text type='BodyXSmall' style={{color: globalColors.black_40, alignSelf: 'center'}}>{result.extraInfo.fullName}</Text>
       break
   }
 

--- a/shared/search/user-search/render.native.js
+++ b/shared/search/user-search/render.native.js
@@ -4,7 +4,6 @@ import {Avatar, Box, Icon, Input, Text, ListItem} from '../../common-adapters'
 import {globalStyles, globalColors} from '../../styles/style-guide'
 
 import type {Props, SearchResult} from './render'
-import type {Combo} from '../../constants/types/more'
 import type {Props as TextProps} from '../../common-adapters/text'
 
 function EmboldenTextMatch ({text, match, style, textType, emboldenStyle}: {text: string, match: string, emboldenStyle: Object, style: Object, textType: TextProps.type}) {
@@ -54,7 +53,7 @@ function ExternalExtraInfo ({serviceUsername, fullNameOnService, icon, searchTex
   )
 }
 
-function Result ({combo: [result, {searchText}]}: Combo<SearchResult, {searchText: string}>) {
+function Result ({result, searchText}: {result: SearchResult, searchText: string}) {
   const iconStyle = {height: 32, width: 32}
 
   let icon
@@ -116,7 +115,7 @@ export default class Render extends Component<void, Props, void> {
             <Input type='text' autoCapitalize='none' value={this.props.searchText} hintText={this.props.searchHintText} iosOmitUnderline style={{marginTop: 0, height: 32}} />
           </Box>}
           action={<Box />} />
-        {this.props.results.map(r => <Result key={r.service + (r.icon || '') + r.username} combo={[r, {searchText: this.props.searchText}]} />)}
+        {this.props.results.map(r => <Result key={r.service + (r.icon || '') + r.username} result={r} searchText={this.props.searchText} />)}
       </Box>
     )
   }

--- a/shared/search/user-search/render.native.js
+++ b/shared/search/user-search/render.native.js
@@ -71,7 +71,7 @@ function Result ({result, searchText}: {result: SearchResult, searchText: string
 
   // Align the body to the middle of the original 32 row so the extra info doesn't push the username down
   const alignedBody = (
-    <Box style={{flex: 2}}>
+    <Box style={{flex: 1}}>
       <Box style={{...globalStyles.flexBoxRow, alignItems: 'center'}}>
         <Box style={{height: 32, width: 0}} />
         {body}

--- a/shared/search/user-search/render.native.js
+++ b/shared/search/user-search/render.native.js
@@ -13,7 +13,7 @@ function EmboldenTextMatch ({text, match, style, textType, emboldenStyle}: {text
       <Box style={globalStyles.flexBoxRow}>
         <Text type={textType} style={style}>{text.substring(0, indexOfMatch)}</Text>
         <Text type={textType} style={{...globalStyles.fontBold, ...style, ...emboldenStyle}}>{match}</Text>
-        <Text type={textType} style={style}>{text.substring(indexOfMatch + match.length)}</Text>
+        <EmboldenTextMatch style={style} text={text.substring(indexOfMatch + match.length)} match={match} textType={textType} emboldenStyle={emboldenStyle} />
       </Box>
     )
   }

--- a/shared/search/user-search/render.native.js
+++ b/shared/search/user-search/render.native.js
@@ -1,0 +1,123 @@
+// @flow
+import React, {Component} from 'react'
+import {Avatar, Box, Icon, Input, Text, ListItem} from '../../common-adapters'
+import {globalStyles, globalColors} from '../../styles/style-guide'
+
+import type {Props, SearchResult} from './render'
+import type {Combo} from '../../constants/types/more'
+import type {Props as TextProps} from '../../common-adapters/text'
+
+function EmboldenTextMatch ({text, match, style, textType, emboldenStyle}: {text: string, match: string, emboldenStyle: Object, style: Object, textType: TextProps.type}) {
+  const indexOfMatch = text.indexOf(match)
+  if (indexOfMatch > -1) {
+    return (
+      <Box style={globalStyles.flexBoxRow}>
+        <Text type={textType} style={style}>{text.substring(0, indexOfMatch)}</Text>
+        <Text type={textType} style={{...globalStyles.fontBold, ...style, ...emboldenStyle}}>{match}</Text>
+        <Text type={textType} style={style}>{text.substring(indexOfMatch + match.length)}</Text>
+      </Box>
+    )
+  }
+
+  return <Text type={textType} style={style}>{text}</Text>
+}
+
+function KeybaseResultBody ({username, searchText, isFollowing}) {
+  return <EmboldenTextMatch text={username} match={searchText} textType={'Body'} style={{color: isFollowing ? globalColors.green2 : globalColors.orange}} />
+}
+
+function ExternalResultBody ({username, searchText}) {
+  return <EmboldenTextMatch text={username} match={searchText} textType={'Body'} style={{color: globalColors.black_75}} />
+}
+
+function KeybaseExtraInfo ({username, fullName, isFollowing, searchText}) {
+  return (
+    <Box style={{...globalStyles.flexBoxColumn, alignItems: 'flex-end'}}>
+      <Box style={{...globalStyles.flexBoxRow, alignItems: 'center'}}>
+        <Avatar size={16} style={{width: 16, marginRight: 4}} username={username} />
+        <EmboldenTextMatch text={username} match={searchText} textType={'BodySmall'} style={{color: isFollowing ? globalColors.green2 : globalColors.orange}} />
+      </Box>
+      {!!fullName && <Text type='BodyXSmall' style={{color: globalColors.black_40}}>{fullName}</Text>}
+    </Box>
+  )
+}
+
+function ExternalExtraInfo ({serviceUsername, fullNameOnService, icon, searchText}) {
+  return (
+    <Box style={{...globalStyles.flexBoxColumn, alignItems: 'flex-end'}}>
+      <Box style={{...globalStyles.flexBoxRow, alignItems: 'center'}}>
+        <Icon type={icon} style={{width: 17, marginRight: 4}} />
+        <EmboldenTextMatch text={serviceUsername} match={searchText} textType={'BodySmall'} emboldenStyle={{color: globalColors.black_75}} />
+      </Box>
+      {!!fullNameOnService && <Text type='BodyXSmall' style={{color: globalColors.black_40}}>{fullNameOnService}</Text>}
+    </Box>
+  )
+}
+
+function Result ({combo: [result, {searchText}]}: Combo<SearchResult, {searchText: string}>) {
+  const iconStyle = {height: 32, width: 32}
+
+  let icon
+  let body = <Box />
+  switch (result.service) {
+    case 'keybase':
+      icon = <Avatar size={32} username={result.username} style={iconStyle} />
+      body = <KeybaseResultBody username={result.username} searchText={searchText} isFollowing={result.isFollowing} />
+      break
+    case 'external':
+      icon = <Icon type={result.icon} style={iconStyle} />
+      body = <ExternalResultBody username={result.username} searchText={searchText} />
+      break
+  }
+
+  // Align the body to the middle of the original 32 row so the extra info doesn't push the username down
+  const alignedBody = (
+    <Box style={{flex: 2}}>
+      <Box style={{...globalStyles.flexBoxRow, alignItems: 'center'}}>
+        <Box style={{height: 32, width: 0}} />
+        {body}
+      </Box>
+    </Box>
+  )
+
+  let extraInfo = <Box />
+  switch (result.extraInfo.service) {
+    case 'external':
+      extraInfo = <ExternalExtraInfo {...result.extraInfo} searchText={searchText} />
+      break
+    case 'keybase':
+      extraInfo = <KeybaseExtraInfo {...result.extraInfo} searchText={searchText} />
+      break
+    case 'none':
+      extraInfo = <Text type='BodyXSmall' style={{color: globalColors.black_40}}>{result.extraInfo.fullName}</Text>
+      break
+  }
+
+  return (
+    <ListItem
+      type='Small'
+      icon={icon}
+      body={<Box style={{...globalStyles.flexBoxRow}}>{alignedBody}{extraInfo}</Box>}
+      action={<Box />}
+      bodyContainerStyle={{marginBottom: 0, marginTop: 0}}
+      />
+  )
+}
+
+export default class Render extends Component<void, Props, void> {
+  render () {
+    return (
+      <Box style={globalStyles.flexBoxColumn}>
+        <ListItem
+          type='Small'
+          containerStyle={{backgroundColor: globalColors.blue4}}
+          icon={<Icon type={this.props.searchIcon} style={{width: 32, height: 32}} />}
+          body={<Box style={{flex: 2, height: 32}}>
+            <Input type='text' autoCapitalize='none' value={this.props.searchText} hintText={this.props.searchHintText} iosOmitUnderline style={{marginTop: 0, height: 32}} />
+          </Box>}
+          action={<Box />} />
+        {this.props.results.map(r => <Result key={r.service + (r.icon || '') + r.username} combo={[r, {searchText: this.props.searchText}]} />)}
+      </Box>
+    )
+  }
+}


### PR DESCRIPTION
@keybase/react-hackers 

Search screen for mobile

The preview is showing some states that don't make sense together, but just there to show how different rows would look without having a bunch of different mocks.

Also the twitter icon is not colored. Not sure if we want to make a separate image icon for these services that are colored correctly or try to color the font icons ourselves. I'm leaning towards using images because that'll keep our colors separate from service colors and it'll work for multicolor logos (e.g. reddit).

![image](https://cloud.githubusercontent.com/assets/594035/15617847/8bdeaa1c-23ff-11e6-91e1-d95ad379d82c.png)

![image](https://cloud.githubusercontent.com/assets/594035/15617837/7e99e57e-23ff-11e6-972c-b082d77fdf38.png)


## Todo:
Service images or colored icons
