### PR TITLE
avoid undefined behavior in Go assignments

### DIFF
--- a/go/libkb/kbpackets.go
+++ b/go/libkb/kbpackets.go
@@ -72,8 +72,13 @@ func (p *KeybasePacket) hashToBytes() (ret []byte, err error) {
 }
 
 func (p *KeybasePacket) HashMe() error {
-	var err error
-	p.Hash.Value, err = p.hashToBytes()
+	// Don't assign directly to p.Hash.Value. The evaluation order of that
+	// assignment is undefined, and we can't rely on hashToBytes initializing
+	// p.Hash before that pointer gets dereferenced. This caused a crash that
+	// only repro'd in gcc-go:
+	// https://github.com/keybase/keybase-issues/issues/2083.
+	value, err := p.hashToBytes()
+	p.Hash.Value = value
 	return err
 }
 

--- a/go/libkb/naclwrap.go
+++ b/go/libkb/naclwrap.go
@@ -390,12 +390,7 @@ func (k NaclDHKeyPair) VerifyString(sig string, msg []byte) (id keybase1.SigID, 
 }
 
 func (s *NaclSigInfo) ToPacket() (ret *KeybasePacket, err error) {
-	ret = &KeybasePacket{
-		Version: KeybasePacketV1,
-		Tag:     TagSignature,
-	}
-	ret.Body = s
-	return
+	return NewKeybasePacket(s, TagSignature, KeybasePacketV1)
 }
 
 func (p KeybasePacket) ToNaclSigInfo() (*NaclSigInfo, error) {
@@ -647,12 +642,7 @@ func (k NaclDHKeyPair) EncryptToString(plaintext []byte, sender GenericKey) (str
 
 // ToPacket implements the Packetable interface.
 func (k *NaclEncryptionInfo) ToPacket() (ret *KeybasePacket, err error) {
-	ret = &KeybasePacket{
-		Version: KeybasePacketV1,
-		Tag:     TagEncryption,
-	}
-	ret.Body = k
-	return
+	return NewKeybasePacket(k, TagEncryption, KeybasePacketV1)
 }
 
 // DecryptFromString decrypts the output of EncryptToString above,

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -171,13 +171,7 @@ func (s *SKB) newLKSec(pps *PassphraseStream) *LKSec {
 }
 
 func (s *SKB) ToPacket() (ret *KeybasePacket, err error) {
-	ret = &KeybasePacket{
-		Version: KeybasePacketV1,
-		Tag:     TagP3skb,
-	}
-	ret.Body = s
-	err = ret.HashMe()
-	return
+	return NewKeybasePacket(s, TagP3skb, KeybasePacketV1)
 }
 
 func (s *SKB) ReadKey() (g GenericKey, err error) {


### PR DESCRIPTION
r? @maxtaco 

The behind-the-scenes initialization behavior of `hashToBytes` is kind of the real problem here, and we might want to clean that up rather than just making this minimal fix.