### PR TITLE
Fix blue_30 RGB values

### DIFF
--- a/shared/styles/style-guide-colors.js
+++ b/shared/styles/style-guide-colors.js
@@ -11,7 +11,7 @@ export default {
   blue3_40: 'rgba(168, 215, 255, 0.4)',
   blue4: '#e6f3ff',
   blue: '#33a0ff',
-  blue_30: 'rgba(50, 159, 254, 0.3)',
+  blue_30: 'rgba(51, 160, 255, 0.3)',
   brown_60: 'rgba(71, 31, 17, 0.6)',
   darkBlue2: '#2470b3',
   darkBlue3: '#0a3052',


### PR DESCRIPTION
There's a slightly different variant of the color that slipped into some mockups. This is the correct value confirmed w/ Cecile.

:eyeglasses: @keybase/react-hackers 