### PR TITLE
WIP: Setup avatars on mobile DESKTOP-1096

### DIFF
--- a/shared/common-adapters/avatar.desktop.js
+++ b/shared/common-adapters/avatar.desktop.js
@@ -4,6 +4,7 @@ import React, {Component} from 'react'
 import {resolveImageAsURL} from '../../desktop/resolve-root'
 import {globalColors} from '../styles/style-guide'
 import type {Props} from './avatar'
+import * as shared from './avatar.shared'
 
 const noAvatar = resolveImageAsURL('icons', 'placeholder-avatar@2x.png')
 
@@ -19,22 +20,10 @@ export default class Avatar extends Component {
     this.state = {avatarLoaded: false}
   }
 
-  _createUrl (): ?string {
-    if (__SCREENSHOT__) {
-      return noAvatar
-    } else if (this.props.url) {
-      return this.props.url
-    } else if (this.props.username) {
-      return `https://keybase.io/${this.props.username}/picture`
-    }
-
-    return null
-  }
-
   render () {
     const width = this.props.size
     const height = this.props.size
-    const url = this._createUrl()
+    const url = __SCREENSHOT__ ? noAvatar : shared.createUrl(this.props)
 
     return (
       <div onClick={this.props.onClick} style={{position: 'relative', width, height, ...this.props.style}}>

--- a/shared/common-adapters/avatar.desktop.js
+++ b/shared/common-adapters/avatar.desktop.js
@@ -23,7 +23,7 @@ export default class Avatar extends Component {
   render () {
     const width = this.props.size
     const height = this.props.size
-    const url = __SCREENSHOT__ ? noAvatar : shared.createUrl(this.props)
+    const url = __SCREENSHOT__ ? noAvatar : shared.createAvatarUrl(this.props)
 
     return (
       <div onClick={this.props.onClick} style={{position: 'relative', width, height, ...this.props.style}}>

--- a/shared/common-adapters/avatar.native.js
+++ b/shared/common-adapters/avatar.native.js
@@ -1,36 +1,29 @@
 // @flow
 
 import React, {Component} from 'react'
+import {Image} from 'react-native'
 import type {Props} from './avatar'
 import {Box, Icon} from '../common-adapters'
+import {images} from './icon.paths.native'
+import * as shared from './avatar.shared'
 
 export default class Avatar extends Component {
   props: Props;
 
-  state: {
-    avatarLoaded: boolean
-  };
-
   constructor (props: Props) {
     super(props)
-    this.state = {avatarLoaded: false}
   }
 
   render () {
-    return (
-      <Box style={{justifyContent: 'flex-end', height: this.props.size, ...this.props.style}} onClick={this.props.onClick}>
-        <Icon style={{...avatarStyle(this.props.size - 2)}}
-          type='placeholder-avatar' />
-      </Box>
-    )
-  }
-}
+    const width = this.props.size
+    const height = this.props.size
+    const url = shared.createUrl(this.props)
 
-function avatarStyle (size: number): Object {
-  return {
-    width: size,
-    height: size,
-    borderRadius: size / 2,
-    alignSelf: 'center'
+    return (
+      <Image
+        style={{resizeMode: 'contain', width, height, borderRadius: width / 2}}
+        defaultSource={images['placeholder-avatar']}
+        source={{uri: url}} />
+    )
   }
 }

--- a/shared/common-adapters/avatar.native.js
+++ b/shared/common-adapters/avatar.native.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, {Component} from 'react'
-import {Image} from 'react-native'
+import {Image, PixelRatio, Platform} from 'react-native'
 import type {Props} from './avatar'
 import {Box, Icon} from '../common-adapters'
 import {images} from './icon.paths.native'
@@ -19,9 +19,14 @@ export default class Avatar extends Component {
     const height = this.props.size
     const uri = shared.createAvatarUrl(this.props)
 
+    // Hack AW: As of react-native 0.24.1, it appears that iOS takes in dp
+    //  for the borderRadius, while Android (incorrectly) takes in pixels. This
+    //  hack handles the conversion between pixels and dp on Android.
+    const borderRadius = width / 2 * (Platform.OS === 'android' ? PixelRatio.get() : 1);
+
     return (
       <Image
-        style={{resizeMode: 'contain', width, height, borderRadius: width / 2}}
+        style={{resizeMode: 'contain', width, height, borderRadius}}
         defaultSource={images['placeholder-avatar']}
         source={{uri}} />
     )

--- a/shared/common-adapters/avatar.native.js
+++ b/shared/common-adapters/avatar.native.js
@@ -17,13 +17,13 @@ export default class Avatar extends Component {
   render () {
     const width = this.props.size
     const height = this.props.size
-    const url = shared.createUrl(this.props)
+    const uri = shared.createAvatarUrl(this.props)
 
     return (
       <Image
         style={{resizeMode: 'contain', width, height, borderRadius: width / 2}}
         defaultSource={images['placeholder-avatar']}
-        source={{uri: url}} />
+        source={{uri}} />
     )
   }
 }

--- a/shared/common-adapters/avatar.shared.js
+++ b/shared/common-adapters/avatar.shared.js
@@ -1,0 +1,11 @@
+// @flow
+import type {Props} from './avatar'
+
+export function createUrl (props: Props): ?string {
+    if (props.url) {
+      return props.url
+    } else if (props.username) {
+      return `https://keybase.io/${props.username}/picture`
+    }
+    return null
+}

--- a/shared/common-adapters/avatar.shared.js
+++ b/shared/common-adapters/avatar.shared.js
@@ -1,7 +1,7 @@
 // @flow
 import type {Props} from './avatar'
 
-export function createUrl (props: Props): ?string {
+export function createAvatarUrl (props: {url: ?string} | {username: ?string}): ?string {
     if (props.url) {
       return props.url
     } else if (props.username) {


### PR DESCRIPTION
Avatars now display more than just the placeholder on mobile.

I condensed the mobile avatar representation down to a single element, an [Image](http://facebook.github.io/react-native/releases/0.24/docs/image.html), which was possible because Image has a property called [defaultSource](http://facebook.github.io/react-native/releases/0.24/docs/image.html#defaultsource) which displays until the image requested by uri in the `source` property is loaded.

I also factored out the shared `createUrl` code from .desktop and .native, and moved the desktop specific `__SCREENSHOT__` check to a higher level.

Notice the avatar in the bottom left 😄 

<img width="423" alt="screen shot 2016-06-01 at 4 44 28 pm" src="https://cloud.githubusercontent.com/assets/1152104/15729347/2da04f88-2818-11e6-8ceb-18c8a7785670.png">

⚠️ This still has issues