### PR TITLE
Dumb component login DESKTOP-840

### DIFF
--- a/shared/login/dumb.desktop.js
+++ b/shared/login/dumb.desktop.js
@@ -1,6 +1,8 @@
 // @flow
 import LoginError, {Mocks as loginErrorMocks} from './error.render'
+import IntroMap from './forms/dumb'
 
 export default {
-  'Login: Error': {component: LoginError, mocks: loginErrorMocks}
+  'Login: Error': {component: LoginError, mocks: loginErrorMocks},
+  ...IntroMap
 }

--- a/shared/login/dumb.desktop.js
+++ b/shared/login/dumb.desktop.js
@@ -1,8 +1,10 @@
 // @flow
 import LoginError, {Mocks as loginErrorMocks} from './error.render'
-import IntroMap from './forms/dumb'
+import IntroMap from './forms/dumb.desktop'
+import LoginMap from './login/dumb.desktop'
 
 export default {
   'Login: Error': {component: LoginError, mocks: loginErrorMocks},
-  ...IntroMap
+  ...IntroMap,
+  ...LoginMap
 }

--- a/shared/login/forms/dumb.desktop.js
+++ b/shared/login/forms/dumb.desktop.js
@@ -1,0 +1,24 @@
+// @flow
+import Intro from './intro.render'
+
+import type IntroProps from './intro';
+
+const props: IntroProps = {
+  onSignup: () => {},
+  onLogin: () => {},
+  justRevokedSelf: null
+}
+
+export const dumbMap: DumbComponentMap<Intro> = {
+  component: Intro,
+  mocks: {
+    'First time user': props,
+    'User who just revoked device': Object.assign({}, props, {
+      justRevokedSelf: 'DEVICE_NAME'
+    })
+  }
+}
+
+export default {
+  'Intro': dumbMap
+}

--- a/shared/login/forms/dumb.desktop.js
+++ b/shared/login/forms/dumb.desktop.js
@@ -2,7 +2,7 @@
 import Intro from './intro.render'
 import type {DumbComponentMap} from '../../constants/types/more'
 
-import type IntroProps from './intro';
+import type IntroProps from './intro'
 
 const props: IntroProps = {
   onSignup: () => {},

--- a/shared/login/forms/dumb.desktop.js
+++ b/shared/login/forms/dumb.desktop.js
@@ -1,5 +1,6 @@
 // @flow
 import Intro from './intro.render'
+import type {DumbComponentMap} from '../../constants/types/more'
 
 import type IntroProps from './intro';
 

--- a/shared/login/login/dumb.desktop.js
+++ b/shared/login/login/dumb.desktop.js
@@ -1,0 +1,46 @@
+// @flow
+import Login from './index.render'
+import type {DumbComponentMap} from '../../constants/types/more'
+
+import type LoginProps from './';
+
+function createLogger(event) {
+  return function () {
+    console.log(`login/login => ${event}`, arguments);
+  };
+}
+
+const props: LoginProps = {
+  users: ['awendland'],
+  onForgotPassphrase: createLogger('onForgotPassphrase'),
+  onSignup: createLogger('onSignup'),
+  onBack: createLogger('onBack'),
+  onSomeoneElse: createLogger('onSomeoneElse'),
+  error: null,
+  waitingForResponse: false,
+  showTyping: false,
+  saveInKeychain: false,
+  selectedUser: null,
+  selectedUserChange: createLogger('selectedUserChange'),
+  passphraseChange: createLogger('passphraseChange'),
+  showTypingChange: createLogger('showTypingChange'),
+  saveInKeychainChange: createLogger('saveInKeychainChange'),
+  onSubmit: createLogger('onSubmit')
+}
+
+export const dumbMap: DumbComponentMap<Login> = {
+  component: Login,
+  mocks: {
+    'Single previous user': props,
+    'Error': Object.assign({}, props, {
+      error: 'Oh, no! What a mess!'
+    }),
+    'Multiple previous users': Object.assign({}, props, {
+      users: ['awendland', 'mgood', 'marcopolo']
+    })
+  }
+}
+
+export default {
+  'Login: Signed Out': dumbMap
+}

--- a/shared/login/login/dumb.desktop.js
+++ b/shared/login/login/dumb.desktop.js
@@ -2,12 +2,12 @@
 import Login from './index.render'
 import type {DumbComponentMap} from '../../constants/types/more'
 
-import type LoginProps from './';
+import type LoginProps from './'
 
-function createLogger(event) {
+function createLogger (event) {
   return function () {
-    console.log(`login/login => ${event}`, arguments);
-  };
+    console.log(`login/login => ${event}`, arguments)
+  }
 }
 
 const props: LoginProps = {
@@ -32,12 +32,14 @@ export const dumbMap: DumbComponentMap<Login> = {
   component: Login,
   mocks: {
     'Single previous user': props,
-    'Error': Object.assign({}, props, {
+    'Error': {
+      ...props,
       error: 'Oh, no! What a mess!'
-    }),
-    'Multiple previous users': Object.assign({}, props, {
+    },
+    'Multiple previous users': {
+      ...props,
       users: ['awendland', 'mgood', 'marcopolo']
-    })
+    }
   }
 }
 

--- a/shared/login/login/index.render.js.flow
+++ b/shared/login/login/index.render.js.flow
@@ -2,16 +2,12 @@
 import type {Component} from 'react'
 
 export type Props = {
-  lastUser: ?string,
-  serverURI: string,
   users: Array<string>,
   onForgotPassphrase: () => void,
   onSignup: () => void,
-  onBack: () => void,
   onSomeoneElse: () => void,
   error: ?string,
   waitingForResponse: boolean,
-  passphrase: string,
   showTyping: boolean,
   saveInKeychain: boolean,
   selectedUser: ?string,

--- a/shared/login/signup/dumb.desktop.js
+++ b/shared/login/signup/dumb.desktop.js
@@ -136,7 +136,7 @@ export default {
       }
     }
   },
-  'UsernameEmail': {
+  'UsernameEmail (Login)': {
     component: usernameEmail,
     mocks: {
       'Start': {


### PR DESCRIPTION
Added dumb components for shared/login/intro and for shared/login/login.

The file/component names in shared/login is a tad confusing, but I tried to guess at the use cases by looking at import statements and walking through the app registration process. I've renamed "UsernameEmail" to "UsernameEmail (Login)" to reflect that it seems to only be used in the login process (when the app is first installed), not in the signup process as denoted by the folder it's located in and the method it's loaded by (some injection through actions/dispatch).

@keybase/react-hackers 