### PR TITLE
Dumb component widget DESKTOP-842

### DIFF
--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -66,6 +66,7 @@ const folderToProps = (dispatch: Dispatch, folders: Array<Folder>, username: str
 
   return {
     onRekey: () => {},
+    showingPrivate: true,
     smallMode: false,
     showComingSoon: !flags.tabFoldersEnabled,
     privateBadge,

--- a/shared/folders/dumb.js
+++ b/shared/folders/dumb.js
@@ -166,19 +166,29 @@ const parentProps = {
 export const map: DumbComponentMap<Folders> = {
   component: Folders,
   mocks: {
-    'Normal': {
+    'Normal Private': {
       smallMode: false,
       onRekey: path => console.log(`open rekey page: ${path}`),
       showComingSoon: false,
       private: {tlfs, ignored, isPublic: false, parentProps},
-      public: {tlfs: [f2, f3, f4, f5], ignored, isPublic: true, privateBadge: 1, publicBadge: 222, parentProps}
+      public: {tlfs: [f2, f3, f4, f5], ignored, isPublic: true, privateBadge: 1, publicBadge: 222, parentProps},
+      showingPrivate: true
+    },
+    'Normal Public': {
+      smallMode: false,
+      onRekey: path => console.log(`open rekey page: ${path}`),
+      showComingSoon: false,
+      private: {tlfs, ignored, isPublic: false, parentProps},
+      public: {tlfs: [f2, f3, f4, f5], ignored, isPublic: true, privateBadge: 1, publicBadge: 222, parentProps},
+      showingPrivate: false
     },
     'ComingSoon': {
       smallMode: false,
       onRekey: path => console.log(`open rekey page: ${path}`),
       showComingSoon: true,
       private: {tlfs, ignored, isPublic: false, parentProps},
-      public: {tlfs: [f2, f3, f4, f5], ignored, isPublic: true, privateBadge: 1, publicBadge: 222, parentProps}
+      public: {tlfs: [f2, f3, f4, f5], ignored, isPublic: true, privateBadge: 1, publicBadge: 222, parentProps},
+      showingPrivate: true
     }
   }
 }

--- a/shared/folders/index.js
+++ b/shared/folders/index.js
@@ -4,7 +4,22 @@ import {connect} from 'react-redux'
 import Render from './render'
 import flags from '../util/feature-flags'
 
-class Folders extends Component {
+type Props = {}
+
+type State = {
+  showingPrivate: boolean
+}
+
+class Folders extends Component<void, Props, State> {
+  state: State;
+
+  constructor (props: Props) {
+    super(props)
+    this.state = {
+      showingPrivate: true
+    }
+  }
+
   render () {
     return <Render
       onRekey={() => {}}
@@ -14,7 +29,8 @@ class Folders extends Component {
       private={{isPublic: false}}
       publicBadge={0}
       public={{isPublic: true}}
-      onSwitchTab={showingPublic => {}}
+      onSwitchTab={showingPrivate => this.setState({showingPrivate})}
+      showingPrivate={this.state.showingPrivate}
       />
   }
 

--- a/shared/folders/render.desktop.js
+++ b/shared/folders/render.desktop.js
@@ -6,26 +6,7 @@ import {TabBarItem, TabBarButton} from '../common-adapters/tab-bar'
 import List from './list'
 import {globalStyles, globalColors} from '../styles/style-guide'
 
-type State = {
-  showingPrivate: boolean
-}
-
-type DefaultProps = {
-  openToPrivate: boolean
-}
-
-class Render extends Component<DefaultProps, Props, State> {
-  static defaultProps: DefaultProps;
-  state: State;
-
-  constructor (props: Props & DefaultProps) {
-    super(props)
-
-    this.state = {
-      showingPrivate: props.openToPrivate
-    }
-  }
-
+class Render extends Component<void, Props, void> {
   _renderComingSoon () {
     return <ComingSoon />
   }
@@ -59,16 +40,13 @@ class Render extends Component<DefaultProps, Props, State> {
     }
 
     return (
-      <Box style={{...stylesContainer, backgroundColor: this.state.showingPrivate ? globalColors.darkBlue : globalColors.white}}>
+      <Box style={{...stylesContainer, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.white}}>
         <TabBar tabBarStyle={tabBarStyle}>
           <TabBarItem
-            selected={this.state.showingPrivate}
+            selected={this.props.showingPrivate}
             containerStyle={itemContainerStyle}
-            tabBarButton={this._makeItem(false, this.state.showingPrivate === true)}
-            onClick={() => {
-              this.setState({showingPrivate: true})
-              this.props.onSwitchTab && this.props.onSwitchTab(false)
-            }}>
+            tabBarButton={this._makeItem(false, this.props.showingPrivate === true)}
+            onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab(true) }}>
             <List
               {...this.props.private}
               style={this.props.listStyle}
@@ -77,13 +55,10 @@ class Render extends Component<DefaultProps, Props, State> {
               onClick={this.props.onClick} />
           </TabBarItem>
           <TabBarItem
-            selected={!this.state.showingPrivate}
+            selected={!this.props.showingPrivate}
             containerStyle={itemContainerStyle}
-            tabBarButton={this._makeItem(true, this.state.showingPrivate === false)}
-            onClick={() => {
-              this.setState({showingPrivate: false})
-              this.props.onSwitchTab && this.props.onSwitchTab(true)
-            }}>
+            tabBarButton={this._makeItem(true, this.props.showingPrivate === false)}
+            onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab(false) }}>
             <List
               {...this.props.public}
               style={this.props.listStyle}
@@ -95,10 +70,6 @@ class Render extends Component<DefaultProps, Props, State> {
       </Box>
     )
   }
-}
-
-Render.defaultProps = {
-  openToPrivate: true
 }
 
 const stylesContainer = {

--- a/shared/folders/render.desktop.js
+++ b/shared/folders/render.desktop.js
@@ -7,17 +7,22 @@ import List from './list'
 import {globalStyles, globalColors} from '../styles/style-guide'
 
 type State = {
-  showPrivate: boolean
+  showingPrivate: boolean
 }
 
-class Render extends Component<void, Props, State> {
+type DefaultProps = {
+  openToPrivate: boolean
+}
+
+class Render extends Component<DefaultProps, Props, State> {
+  static defaultProps: DefaultProps;
   state: State;
 
-  constructor (props: Props) {
+  constructor (props: Props & DefaultProps) {
     super(props)
 
     this.state = {
-      showPrivate: true
+      showingPrivate: props.openToPrivate
     }
   }
 
@@ -54,14 +59,14 @@ class Render extends Component<void, Props, State> {
     }
 
     return (
-      <Box style={{...stylesContainer, backgroundColor: this.state.showPrivate ? globalColors.darkBlue : globalColors.white}}>
+      <Box style={{...stylesContainer, backgroundColor: this.state.showingPrivate ? globalColors.darkBlue : globalColors.white}}>
         <TabBar tabBarStyle={tabBarStyle}>
           <TabBarItem
-            selected={this.state.showPrivate}
+            selected={this.state.showingPrivate}
             containerStyle={itemContainerStyle}
-            tabBarButton={this._makeItem(false, this.state.showPrivate === true)}
+            tabBarButton={this._makeItem(false, this.state.showingPrivate === true)}
             onClick={() => {
-              this.setState({showPrivate: true})
+              this.setState({showingPrivate: true})
               this.props.onSwitchTab && this.props.onSwitchTab(false)
             }}>
             <List
@@ -72,11 +77,11 @@ class Render extends Component<void, Props, State> {
               onClick={this.props.onClick} />
           </TabBarItem>
           <TabBarItem
-            selected={!this.state.showPrivate}
+            selected={!this.state.showingPrivate}
             containerStyle={itemContainerStyle}
-            tabBarButton={this._makeItem(true, this.state.showPrivate === false)}
+            tabBarButton={this._makeItem(true, this.state.showingPrivate === false)}
             onClick={() => {
-              this.setState({showPrivate: false})
+              this.setState({showingPrivate: false})
               this.props.onSwitchTab && this.props.onSwitchTab(true)
             }}>
             <List
@@ -90,6 +95,10 @@ class Render extends Component<void, Props, State> {
       </Box>
     )
   }
+}
+
+Render.defaultProps = {
+  openToPrivate: true
 }
 
 const stylesContainer = {

--- a/shared/folders/render.js.flow
+++ b/shared/folders/render.js.flow
@@ -11,8 +11,9 @@ export type Props = {
   public: ListProps,
   onSwitchTab?: (showingPublic: boolean) => void,
   listStyle?: any,
-  smallMode: boolean,
+  smallMode?: boolean,
   onClick?: (path: string) => void,
+  openToPrivate?: boolean,
   onRekey: (path: string) => void
 }
 

--- a/shared/folders/render.js.flow
+++ b/shared/folders/render.js.flow
@@ -9,11 +9,11 @@ export type Props = {
   private: ListProps,
   publicBadge?: number,
   public: ListProps,
-  onSwitchTab?: (showingPublic: boolean) => void,
+  showingPrivate: boolean,
+  onSwitchTab?: (showingPrivate: boolean) => void,
   listStyle?: any,
   smallMode?: boolean,
   onClick?: (path: string) => void,
-  openToPrivate?: boolean,
   onRekey: (path: string) => void
 }
 

--- a/shared/folders/render.native.js
+++ b/shared/folders/render.native.js
@@ -6,21 +6,7 @@ import {TabBarItem, TabBarButton} from '../common-adapters/tab-bar'
 import List from './list'
 import {globalStyles, globalColors} from '../styles/style-guide'
 
-type State = {
-  showPrivate: boolean
-}
-
-class Render extends Component<void, Props, State> {
-  state: State;
-
-  constructor (props: Props) {
-    super(props)
-
-    this.state = {
-      showPrivate: true
-    }
-  }
-
+class Render extends Component<void, Props, void> {
   _makeItem (isPublic: boolean, isSelected: boolean) {
     return <TabBarButton
       source={{type: 'icon', icon: `subnav-folders-${isPublic ? 'public' : 'private'}`}}
@@ -47,16 +33,13 @@ class Render extends Component<void, Props, State> {
 
   render () {
     return (
-      <Box style={{...stylesContainer, backgroundColor: this.state.showPrivate ? globalColors.darkBlue : globalColors.white}}>
+      <Box style={{...stylesContainer, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.white}}>
         <TabBar tabBarStyle={tabBarStyle}>
           <TabBarItem
-            selected={this.state.showPrivate}
+            selected={this.props.showingPrivate}
             containerStyle={itemContainerStyle}
-            tabBarButton={this._makeItem(false, this.state.showPrivate === true)}
-            onClick={() => {
-              this.setState({showPrivate: true})
-              this.props.onSwitchTab && this.props.onSwitchTab(false)
-            }}>
+            tabBarButton={this._makeItem(false, this.props.showingPrivate === true)}
+            onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab(true) }}>
             <List
               {...this.props.private}
               style={this.props.listStyle}
@@ -64,13 +47,10 @@ class Render extends Component<void, Props, State> {
               onClick={this.props.onClick} />
           </TabBarItem>
           <TabBarItem
-            selected={!this.state.showPrivate}
+            selected={!this.props.showingPrivate}
             containerStyle={itemContainerStyle}
-            tabBarButton={this._makeItem(true, this.state.showPrivate === false)}
-            onClick={() => {
-              this.setState({showPrivate: false})
-              this.props.onSwitchTab && this.props.onSwitchTab(true)
-            }}>
+            tabBarButton={this._makeItem(true, this.props.showingPrivate === false)}
+            onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab(false) }}>
             <List
               {...this.props.public}
               style={this.props.listStyle}

--- a/shared/menubar/dumb.desktop.js
+++ b/shared/menubar/dumb.desktop.js
@@ -6,7 +6,7 @@ import {map} from '../folders/dumb'
 import {globalStyles} from '../styles/style-guide'
 
 const propsNormal = {
-  folderProps: map.mocks.Normal,
+  folderProps: map.mocks['Normal Private'],
   username: 'max',
   showOpenApp: true,
   openApp: () => console.log('open app'),

--- a/shared/menubar/dumb.desktop.js
+++ b/shared/menubar/dumb.desktop.js
@@ -43,13 +43,17 @@ const propsTruncated = {
   }
 }
 
+const propsMenuShowing = {...propsNormal, openWithMenuShowing: true}
+
 const dumbComponentMap: DumbComponentMap<Menubar> = {
   component: Menubar,
   mocks: {
     'Private: Normal': propsNormal,
     'Private: Truncated': propsTruncated,
+    'Private: Menu Showing': propsMenuShowing,
     'Public: Normal': {...propsNormal, openToPrivate: false},
     'Public: Truncated': {...propsTruncated, openToPrivate: false},
+    'Public: Menu Showing': {...propsMenuShowing, openToPrivate: false},
     'LoggedOut': {
       ...propsNormal,
       loggedIn: false

--- a/shared/menubar/dumb.desktop.js
+++ b/shared/menubar/dumb.desktop.js
@@ -30,22 +30,26 @@ const propsNormal = {
   }
 }
 
+const propsTruncated = {
+  ...propsNormal,
+  parentProps: {
+    style: {
+      ...globalStyles.flexBoxColumn,
+      width: 325,
+      height: 200,
+      padding: 2,
+      backgroundColor: 'red'
+    }
+  }
+}
+
 const dumbComponentMap: DumbComponentMap<Menubar> = {
   component: Menubar,
   mocks: {
-    'Truncated': {
-      ...propsNormal,
-      parentProps: {
-        style: {
-          ...globalStyles.flexBoxColumn,
-          width: 325,
-          height: 200,
-          padding: 2,
-          backgroundColor: 'red'
-        }
-      }
-    },
-    'Normal': propsNormal,
+    'Private: Normal': propsNormal,
+    'Private: Truncated': propsTruncated,
+    'Public: Normal': {...propsNormal, openToPrivate: false},
+    'Public: Truncated': {...propsTruncated, openToPrivate: false},
     'LoggedOut': {
       ...propsNormal,
       loggedIn: false

--- a/shared/menubar/index.render.desktop.js
+++ b/shared/menubar/index.render.desktop.js
@@ -105,7 +105,8 @@ class Render extends Component<DefaultProps, Props, State> {
       smallMode: true,
       private: newPrivate,
       public: newPublic,
-      onSwitchTab: showingPublic => this.setState({showingPrivate: !showingPublic}),
+      onSwitchTab: showingPrivate => this.setState({showingPrivate}),
+      showingPrivate: this.state.showingPrivate,
       onRekey: this.props.onRekey
     }
 

--- a/shared/menubar/index.render.desktop.js
+++ b/shared/menubar/index.render.desktop.js
@@ -8,18 +8,23 @@ import type {Props} from './index.render'
 import UserAdd from './user-add'
 
 type State = {
-  showingPublic: boolean,
+  showingPrivate: boolean,
   showingMenu: boolean
 }
 
-class Render extends Component<void, Props, State> {
+type DefaultProps = {
+  openToPrivate: boolean
+}
+
+class Render extends Component<DefaultProps, Props, State> {
+  static defaultProps: DefaultProps;
   state: State;
 
-  constructor (props: Props) {
+  constructor (props: Props & DefaultProps) {
     super(props)
 
     this.state = {
-      showingPublic: false,
+      showingPrivate: props.openToPrivate,
       showingMenu: false
     }
   }
@@ -91,7 +96,7 @@ class Render extends Component<void, Props, State> {
         username={this.props.username} />]
     }
 
-    const styles = this.state.showingPublic ? stylesPublic : stylesPrivate
+    const styles = this.state.showingPrivate ? stylesPrivate : stylesPublic
 
     const mergedProps = {
       ...this.props.folderProps,
@@ -99,13 +104,13 @@ class Render extends Component<void, Props, State> {
       smallMode: true,
       private: newPrivate,
       public: newPublic,
-      onSwitchTab: showingPublic => this.setState({showingPublic}),
+      onSwitchTab: showingPublic => this.setState({showingPrivate: !showingPublic}),
       onRekey: this.props.onRekey
     }
 
-    const menuColor = this.state.showingPublic
-      ? (this.state.showingMenu ? globalColors.black : globalColors.black_40)
-      : (this.state.showingMenu ? globalColors.white : globalColors.blue3_40)
+    const menuColor = this.state.showingPrivate
+      ? (this.state.showingMenu ? globalColors.white : globalColors.blue3_40)
+      : (this.state.showingMenu ? globalColors.black : globalColors.black_40)
 
     const menuStyle = {...globalStyles.clickable, color: menuColor, hoverColor: menuColor, fontSize: 24}
 
@@ -122,6 +127,10 @@ class Render extends Component<void, Props, State> {
       </Box>
     )
   }
+}
+
+Render.defaultProps = {
+  openToPrivate: true
 }
 
 const stylesContainer = {

--- a/shared/menubar/index.render.desktop.js
+++ b/shared/menubar/index.render.desktop.js
@@ -13,7 +13,8 @@ type State = {
 }
 
 type DefaultProps = {
-  openToPrivate: boolean
+  openToPrivate: boolean,
+  openWithMenuShowing: boolean
 }
 
 class Render extends Component<DefaultProps, Props, State> {
@@ -25,7 +26,7 @@ class Render extends Component<DefaultProps, Props, State> {
 
     this.state = {
       showingPrivate: props.openToPrivate,
-      showingMenu: false
+      showingMenu: props.openWithMenuShowing
     }
   }
 
@@ -130,7 +131,8 @@ class Render extends Component<DefaultProps, Props, State> {
 }
 
 Render.defaultProps = {
-  openToPrivate: true
+  openToPrivate: true,
+  openWithMenuShowing: false
 }
 
 const stylesContainer = {

--- a/shared/menubar/index.render.js.flow
+++ b/shared/menubar/index.render.js.flow
@@ -19,7 +19,8 @@ export type Props = {
   debug?: boolean,
   loggedIn: boolean,
   folderProps: ?FolderProps,
-  openToPrivate?: boolean
+  openToPrivate?: boolean,
+  openWithMenuShowing?: boolean
 }
 
 export default class Render extends Component<void, Props, void> {}

--- a/shared/menubar/index.render.js.flow
+++ b/shared/menubar/index.render.js.flow
@@ -18,7 +18,8 @@ export type Props = {
   username: ?string,
   debug?: boolean,
   loggedIn: boolean,
-  folderProps: ?FolderProps
+  folderProps: ?FolderProps,
+  openToPrivate?: boolean
 }
 
 export default class Render extends Component<void, Props, void> {}


### PR DESCRIPTION
Expand on the dumb components for the menubar (AKA widget) to include both the public and private modes, as well as the open popup menu state. This will improve the ability for Viss Diff to track changes in the menu bar.

<img width="385" alt="screen shot 2016-06-02 at 5 49 52 pm" src="https://cloud.githubusercontent.com/assets/1152104/15765510/7080e60a-28ea-11e6-8613-321163d74bad.png">
<img width="383" alt="screen shot 2016-06-02 at 5 47 47 pm" src="https://cloud.githubusercontent.com/assets/1152104/15765506/64851fd8-28ea-11e6-97b9-7e79596e13db.png">
<img width="385" alt="screen shot 2016-06-02 at 5 47 56 pm" src="https://cloud.githubusercontent.com/assets/1152104/15765514/76d662dc-28ea-11e6-99e8-72e1361ede15.png">
