### PR TITLE
visdiff: Print message on the console when no changes detected

### DIFF
--- a/desktop/test/run-visdiff.js
+++ b/desktop/test/run-visdiff.js
@@ -159,6 +159,8 @@ function processDiff (commitRange, results) {
       }
       console.log('Posted visual diff on GitHub:', res.html_url)
     })
+  } else {
+    console.log('No visual changes found as a result of these commits.')
   }
 }
 


### PR DESCRIPTION
Tiny change -- now that visdiff doesn't post comments on no changes, it's useful to be able to find this message in the log to affirm that nothing changed.

:eyeglasses: @keybase/react-hackers 