### PR TITLE
upgrades to assertion parsing code

### DIFF
--- a/go/libkb/assertion_test.go
+++ b/go/libkb/assertion_test.go
@@ -143,3 +143,27 @@ func TestAssertions3(t *testing.T) {
 		}
 	}
 }
+
+func TestNeedsParans(t *testing.T) {
+	tests := []struct {
+		expr        string
+		needsParens bool
+	}{
+		{"max+foo@twitter,chris+chris@keybase", false},
+		{"max+foo@twitter+(chris,bob)", true},
+		{"max+foo@twitter+(chris)", false},
+		{"max+foo@twitter+((chris))", false},
+		{"max+foo@twitter+(chris+sam)", false},
+		{"max", false},
+	}
+
+	for _, test := range tests {
+		expr, err := AssertionParse(test.expr)
+		if err != nil {
+			t.Errorf("Error parsing %s: %s", test.expr, err)
+		} else if expr.NeedsParens() != test.needsParens {
+			t.Errorf("On expresssion %s: didn't agree on needing parens", test.expr)
+		}
+	}
+
+}

--- a/go/libkb/social_assertion.go
+++ b/go/libkb/social_assertion.go
@@ -4,8 +4,6 @@
 package libkb
 
 import (
-	"strings"
-
 	keybase1 "github.com/keybase/client/go/protocol"
 )
 
@@ -25,35 +23,12 @@ func IsSocialAssertion(s string) bool {
 // transformed to the user@twitter format.  Only registered
 // services are allowed.
 func NormalizeSocialAssertion(s string) (keybase1.SocialAssertion, bool) {
-	if strings.Count(s, ":")+strings.Count(s, "@") != 1 {
+	url, err := ParseAssertionURL(s, true)
+	if err != nil || !url.IsRemote() {
 		return keybase1.SocialAssertion{}, false
 	}
-
-	var name, service string
-
-	if strings.Contains(s, ":") {
-		pieces := strings.Split(s, ":")
-		service = pieces[0]
-		name = pieces[1]
-	} else {
-		pieces := strings.Split(s, "@")
-		name = pieces[0]
-		service = pieces[1]
-	}
-
-	service = strings.ToLower(service)
-	if !ValidSocialNetwork(service) {
-		return keybase1.SocialAssertion{}, false
-	}
-
-	st := GetServiceType(service)
-	name, err := st.NormalizeUsername(name)
-	if err != nil {
-		return keybase1.SocialAssertion{}, false
-	}
-
 	return keybase1.SocialAssertion{
-		User:    name,
-		Service: keybase1.SocialAssertionService(service),
+		User:    url.GetValue(),
+		Service: keybase1.SocialAssertionService(url.GetKey()),
 	}, true
 }


### PR DESCRIPTION
- better, more robust checking and normalization
- output in KBFS-style expressions
- consolidate code and use assertion-parsing machinery everywhere
- moar tests
- only admit `Remote()` assertions for NormalizeSocialAssertions
- test UIDs, and normalize them to lowercase too