### PR TITLE
Improve danger button rippleColor DESKTOP-1098

### DIFF
--- a/shared/common-adapters/button.desktop.js
+++ b/shared/common-adapters/button.desktop.js
@@ -13,6 +13,9 @@ class Button extends Component {
     let backgroundStyle = {}
     let labelStyle = {}
     let progressColor = globalColors.white
+    let rippleStyle: {rippleColor: string} = {}
+    // Set all button ripples to be more prominent
+    rippleStyle = {rippleColor: 'rgba(0, 0, 0, 0.3)'}
 
     const disabled = this.props.disabled || this.props.waiting
 
@@ -63,12 +66,12 @@ class Button extends Component {
         }
         progressColor = globalColors.black_75
     }
-    return {backgroundStyle, labelStyle, progressColor}
+    return {backgroundStyle, labelStyle, progressColor, rippleStyle}
   }
 
   render () {
     // First apply styles for the main button types.
-    let {backgroundStyle, labelStyle, progressColor} = this._styles(this.props.type)
+    let {backgroundStyle, labelStyle, progressColor, rippleStyle} = this._styles(this.props.type)
     let smallStyle = {}
 
     // Then some overrides that apply to all button types.
@@ -119,6 +122,7 @@ class Button extends Component {
           onClick={this.props.onClick}
           style={{...backgroundStyle, ...smallStyle, ...this.props.style}}
           labelStyle={{...stylesButtonLabel, ...labelStyle, ...this.props.labelStyle}}
+          {...rippleStyle}
           label={label}
           primary={this.props.type === 'Primary'}
           secondary={this.props.type === 'Secondary'}


### PR DESCRIPTION
The ripple that when clicking buttons with Danger styling is poorly distinguished. This started out improving the ripple on Danger buttons, but I then expanded to improve it on Follow (Green) buttons as well, and eventually just darkened the ripple on all buttons. It's a subtle change, but should make feedback on button interaction more apparent.

I've setup a simple framework (3 SLOC) to change rippleColor on a per-button type level, if that's desirable for future visual tweaks to the buttons.

@keybase/react-hackers 

Requested by @chromakode 