### PR TITLE
Thunderbolt icon color folder DESKTOP-1090

### DIFF
--- a/shared/common-adapters/icon.desktop.js
+++ b/shared/common-adapters/icon.desktop.js
@@ -36,7 +36,7 @@ export default class Icon extends Component {
         title={this.props.hint}
         style={{...globalStyles.noSelect, ...styles.icon, ...this.props.style}}
         className={`fa ${iconType} ${this.props.className}`}
-        color={color}
+        color={color} // TODO (AW): this does nothing, color must be set in styles
         hoverColor={this.props.onClick ? hoverColor : null}
         onMouseEnter={this.props.onMouseEnter}
         onMouseLeave={this.props.onMouseLeave}

--- a/shared/common-adapters/text.desktop.js
+++ b/shared/common-adapters/text.desktop.js
@@ -29,7 +29,7 @@ export default class Text extends Component {
     }: {[key: string]: React$Element})[type]
   }
 
-  _inlineStyle (type: Props.type): Object {
+  static _inlineStyle (type: Props.type, context: Context): Object {
     switch (type) {
       case 'Terminal':
       case 'TerminalCommand':
@@ -38,13 +38,13 @@ export default class Text extends Component {
       case 'TerminalPublic':
       case 'TerminalPrivate':
       case 'TerminalSmall':
-        return this.context.inTerminal ? {} : styles.textTerminalInline
+        return context.inTerminal ? {} : styles.textTerminalInline
       default:
         return {}
     }
   }
 
-  _colorStyleBackgroundMode (backgroundMode: Background, type: Props.type): Object {
+  static _colorStyleBackgroundMode (backgroundMode: Background, type: Props.type): Object {
     if (backgroundMode === 'Information') {
       return {color: globalColors.brown_60}
     }
@@ -130,10 +130,10 @@ export default class Text extends Component {
     const style = {
       ...typeStyle,
       ...(LinkTypes[this.props.type] ? {cursor: 'pointer'} : {}),
-      ...this._colorStyleBackgroundMode(this.props.backgroundMode || 'Normal', this.props.type),
+      ...Text._colorStyleBackgroundMode(this.props.backgroundMode || 'Normal', this.props.type),
       ...(this.props.lineClamp ? lineClamp(this.props.lineClamp) : {}),
       ...(this.props.onClick ? globalStyles.clickable : {}),
-      ...(inline ? {...this._inlineStyle(this.props.type)} : {display: 'block'}),
+      ...(inline ? {...Text._inlineStyle(this.props.type, this.context)} : {display: 'block'}),
       ...this.props.style
     }
 

--- a/shared/common-adapters/text.js.flow
+++ b/shared/common-adapters/text.js.flow
@@ -1,6 +1,7 @@
 /* @flow */
 
 import React, {Component} from 'react'
+import type {Context} from './terminal'
 
 export type Background = 'Normal' | 'Announcements' | 'Success' | 'Information' | 'HighRisk' | 'Documentation' | 'Terminal'
 
@@ -35,6 +36,8 @@ export type Props = {
 
 declare export default class Text extends React.Component {
   props: Props;
+  static _colorStyleBackgroundMode: (backgroundMode: Background, type: Props.type) => {color?: string};
+  static _inlineStyle: (type: Props.type, context: Context) => Object;
 }
 
 declare export var styles: Object

--- a/shared/folders/files/file/render.desktop.js
+++ b/shared/folders/files/file/render.desktop.js
@@ -18,7 +18,8 @@ export default class Render extends Component<void, Props, void> {
           <Text type='BodySmall' style={pathStyleThemed[this.props.theme]}>{this.props.path}</Text>
           {!!this.props.lastModifiedBy && (<Box style={{display: 'inline'}}>
             <Text type='BodySmall' style={{...pathStyleThemed[this.props.theme], marginLeft: 4, marginRight: 4}} inline>·</Text>
-            {this.props.modifiedMarker && <Icon type='thunderbolt' style={{height: 12, alignSelf: 'center', marginRight: 6, ...pathStyleThemed[this.props.theme]}} />}
+            {this.props.modifiedMarker &&
+              <Icon type='fa-kb-iconfont-thunderbolt' style={{fontSize: 12, marginRight: 4, color: pathStyleThemed[this.props.theme].color}} />}
             <Text type='BodySmall' style={modifiedByStyleThemed[this.props.theme]} inline>{this.props.lastModifiedMeta}</Text>
             <Text type='BodySmall' style={modifiedByStyleThemed[this.props.theme]} inline> by </Text>
             <Text type='BodySmallLink' style={{...modifyingUserStyleThemed[this.props.theme], ...(this.props.lastModifiedBySelf ? globalStyles.italic : {})}} inline>{this.props.lastModifiedBy}</Text>

--- a/shared/folders/files/file/render.native.js
+++ b/shared/folders/files/file/render.native.js
@@ -18,7 +18,8 @@ export default class Render extends Component<void, Props, void> {
           <Text type='BodySmall' style={pathStyleThemed[this.props.theme]}>{this.props.path}</Text>
           {!!this.props.lastModifiedBy && (<Box style={{...globalStyles.flexBoxRow}}>
             <Text type='BodySmall' style={{...pathStyleThemed[this.props.theme], marginLeft: 4, marginRight: 4}} inline>·</Text>
-            {this.props.modifiedMarker && <Icon type='thunderbolt' style={{height: 12, alignSelf: 'center', marginRight: 6, ...pathStyleThemed[this.props.theme]}} />}
+            {this.props.modifiedMarker &&
+              <Icon type='fa-kb-iconfont-thunderbolt' style={{fontSize: 13, marginRight: 4, color: pathStyleThemed[this.props.theme].color}} />}
             <Text type='BodySmall' style={modifiedByStyleThemed[this.props.theme]} inline>{this.props.lastModifiedMeta}</Text>
             <Text type='BodySmall' style={modifiedByStyleThemed[this.props.theme]} inline> by </Text>
             <Text type='BodySmallLink' style={{...modifyingUserStyleThemed[this.props.theme], ...(this.props.lastModifiedBySelf ? globalStyles.italic : {})}} inline>{this.props.lastModifiedBy}</Text>

--- a/shared/folders/files/render.desktop.js
+++ b/shared/folders/files/render.desktop.js
@@ -11,7 +11,7 @@ const Section = ({section, theme}) => (
   <Box style={{...globalStyles.flexBoxColumn, backgroundColor: backgroundColorThemed[theme]}}>
     <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', height: 32}}>
       <Box key={section.name} style={{display: 'inline', marginLeft: 8}}>
-        {section.modifiedMarker && <Icon type='thunderbolt' style={{height: 12, alignSelf: 'center', marginRight: 6, ...styleSectionTextThemed[theme]}} />}
+        {section.modifiedMarker && <Icon type='fa-kb-iconfont-thunderbolt' style={{fontSize: 12, marginRight: 6, ...styleSectionTextThemed[theme]}} />}
         <Text type='BodySmallSemibold' style={{...styleSectionTextThemed[theme]}}>{section.name}</Text>
       </Box>
     </Box>

--- a/shared/folders/files/render.native.js
+++ b/shared/folders/files/render.native.js
@@ -13,7 +13,7 @@ export default class Render extends Component<void, Props, void> {
       <Box key={section.name} style={{...globalStyles.flexBoxColumn, backgroundColor: backgroundColorThemed[this.props.theme]}}>
         <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', height: 32}}>
           <Box key={section.name} style={{...globalStyles.flexBoxRow, marginLeft: 8}}>
-            {section.modifiedMarker && <Icon type='thunderbolt' style={{height: 12, alignSelf: 'center', marginRight: 6, ...styleSectionTextThemed[this.props.theme]}} />}
+            {section.modifiedMarker && <Icon type='fa-kb-iconfont-thunderbolt' style={{fontSize: 13, marginRight: 6, ...styleSectionTextThemed[this.props.theme]}} />}
             <Text type='BodySmallSemibold' style={{...styleSectionTextThemed[this.props.theme]}}>{section.name}</Text>
           </Box>
         </Box>

--- a/shared/folders/row.desktop.js
+++ b/shared/folders/row.desktop.js
@@ -18,13 +18,16 @@ const Avatars = ({styles, users, smallMode, groupAvatar, userAvatar}) => (
   </Box>
 )
 
-const Modified = ({styles, modified}) => (
-  <Box style={stylesModified}>
-    <Icon type='thunderbolt' style={{marginRight: 5}} />
-    <Text type='BodySmall' backgroundMode={styles.modifiedMode}>Modified {modified.when} by&nbsp;</Text>
-    <Text type='BodySmallLink' backgroundMode={styles.modifiedMode}>{modified.username}</Text>
-  </Box>
-)
+const Modified = ({styles, modified}) => {
+  const iconColor = Text._colorStyleBackgroundMode(styles.modifiedMode, 'BodySmallLink')
+  return (
+    <Box style={stylesModified}>
+      <Icon type='fa-kb-iconfont-thunderbolt' style={{fontSize: 12, alignSelf: 'center', marginLeft: -2, marginRight: 2, ...iconColor}} title='Modified' />
+      <Text type='BodySmall' backgroundMode={styles.modifiedMode}>Modified {modified.when} by&nbsp;</Text>
+      <Text type='BodySmallLink' backgroundMode={styles.modifiedMode}>{modified.username}</Text>
+    </Box>
+  )
+}
 
 const RowMeta = ({ignored, meta, styles}) => {
   const metaColors = {

--- a/shared/folders/row.native.js
+++ b/shared/folders/row.native.js
@@ -45,13 +45,16 @@ const Names = ({styles, users}) => {
   )
 }
 
-const Modified = ({styles, modified}) => (
-  <Box style={stylesModified}>
-    <Icon type='thunderbolt' style={{marginRight: 5}} />
-    <Text type='BodySmall' backgroundMode={styles.modifiedMode}>Modified {modified.when} by&nbsp;</Text>
-    <Text type='BodySmallLink' backgroundMode={styles.modifiedMode}>{modified.username}</Text>
-  </Box>
-)
+const Modified = ({styles, modified}) => {
+  const iconColor = Text._colorStyleBackgroundMode(styles.modifiedMode, 'BodySmallLink')
+  return (
+    <Box style={stylesModified}>
+      <Icon type='fa-kb-iconfont-thunderbolt' style={{fontSize: 13, alignSelf: 'center', marginLeft: -2, marginRight: 2, ...iconColor}} title='Modified' />
+      <Text type='BodySmall' backgroundMode={styles.modifiedMode}>Modified {modified.when} by&nbsp;</Text>
+      <Text type='BodySmallLink' backgroundMode={styles.modifiedMode}>{modified.username}</Text>
+    </Box>
+  )
+}
 
 const RowMeta = ({ignored, meta, styles}) => {
   const metaColors = {


### PR DESCRIPTION
Now the thunderbolt icon appropriately matches the text/desired color. This takes advantage of the new font icons implemented by @MarcoPolo.

**Look at these sweet examples of color matching:**

<img width="664" alt="screen shot 2016-06-03 at 4 47 23 pm" src="https://cloud.githubusercontent.com/assets/1152104/15795969/8196e1ee-29ab-11e6-82e1-09edeba4e270.png">

<img width="616" alt="screen shot 2016-06-03 at 4 47 40 pm" src="https://cloud.githubusercontent.com/assets/1152104/15795967/7f64b3e2-29ab-11e6-9c40-58ae39a8b9ec.png">

@keybase/react-hackers 