### PR TITLE
Use the proper coinbase icon for coinbase DESKTOP-1088

### DIFF
--- a/shared/tracker/proofs.render.desktop.js
+++ b/shared/tracker/proofs.render.desktop.js
@@ -40,7 +40,7 @@ class ProofsRender extends Component {
       'github': 'fa-github',
       'reddit': 'fa-reddit',
       'pgp': 'fa-key',
-      'coinbase': 'fa-btc',
+      'coinbase': 'fa-kb-iconfont-coinbase',
       'hackernews': 'fa-hacker-news',
       'rooter': 'fa-shopping-basket',
       'http': 'fa-globe',


### PR DESCRIPTION
This replaced the BTC icon that was being used for coinbase with the actual coinbase logo