### PR TITLE
Move winresource into tools, fix linter errors

### DIFF
--- a/go/keybase/generate_windows.go
+++ b/go/keybase/generate_windows.go
@@ -2,7 +2,7 @@
 
 package main
 
-//go:generate go build ../winresource
+//go:generate go build ../tools/winresource
 //go:generate ./winresource.exe
 
 func noOp() {

--- a/go/tools/winresource/main.go
+++ b/go/tools/winresource/main.go
@@ -3,7 +3,7 @@
 
 // This is a utility which binds to libkb to get the correct version
 // for printing out or generating compiled resources for the windows
-// executlable.
+// executable.
 
 // +build windows
 
@@ -17,12 +17,13 @@ import (
 	"os/exec"
 	"time"
 
+	"strconv"
+
 	"github.com/josephspurrier/goversioninfo"
 	"github.com/keybase/client/go/libkb"
-	"strconv"
 )
 
-func GetBuildName() string {
+func getBuildName() string {
 	// Todo: use regular build number when not doing prerelease
 
 	gitHash, err := exec.Command("cmd", "/C", "git", "log", "-1", "--pretty=format:%h").Output()
@@ -72,13 +73,13 @@ func main() {
 	}
 
 	if *printCustomVerPtr {
-		customVer := fmt.Sprintf("%d.%d.%d-%s", fv.Major, fv.Minor, fv.Patch, GetBuildName())
+		customVer := fmt.Sprintf("%d.%d.%d-%s", fv.Major, fv.Minor, fv.Patch, getBuildName())
 		fmt.Print(customVer)
 		return
 	}
 
 	if *printCustomBuildPtr {
-		fmt.Printf("%s", GetBuildName())
+		fmt.Printf("%s", getBuildName())
 		return
 	}
 


### PR DESCRIPTION
If this is a keybase specific tool, we should put it in tools package @zanderz 