### PR TITLE
Add social assertion info to displayTLFCreateWithInvite

### DIFF
--- a/go/engine/favorite_add.go
+++ b/go/engine/favorite_add.go
@@ -116,11 +116,12 @@ func (e *FavoriteAdd) checkInviteNeeded(ctx *Context) error {
 
 		e.G().Log.Debug("invitation requested, informing folder creator with result")
 		arg := keybase1.DisplayTLFCreateWithInviteArg{
-			FolderName: e.arg.Folder.Name,
-			Assertion:  assertion.String(),
-			IsPrivate:  e.arg.Folder.Private,
-			Throttled:  inv.Throttled,
-			InviteLink: inv.Link(),
+			FolderName:      e.arg.Folder.Name,
+			Assertion:       assertion.String(),
+			SocialAssertion: assertion,
+			IsPrivate:       e.arg.Folder.Private,
+			Throttled:       inv.Throttled,
+			InviteLink:      inv.Link(),
 		}
 		if err := ctx.IdentifyUI.DisplayTLFCreateWithInvite(arg); err != nil {
 			return err

--- a/go/protocol/identify_ui.go
+++ b/go/protocol/identify_ui.go
@@ -115,12 +115,13 @@ type DismissReason struct {
 }
 
 type DisplayTLFCreateWithInviteArg struct {
-	SessionID  int    `codec:"sessionID" json:"sessionID"`
-	FolderName string `codec:"folderName" json:"folderName"`
-	IsPrivate  bool   `codec:"isPrivate" json:"isPrivate"`
-	Assertion  string `codec:"assertion" json:"assertion"`
-	InviteLink string `codec:"inviteLink" json:"inviteLink"`
-	Throttled  bool   `codec:"throttled" json:"throttled"`
+	SessionID       int             `codec:"sessionID" json:"sessionID"`
+	FolderName      string          `codec:"folderName" json:"folderName"`
+	IsPrivate       bool            `codec:"isPrivate" json:"isPrivate"`
+	Assertion       string          `codec:"assertion" json:"assertion"`
+	SocialAssertion SocialAssertion `codec:"socialAssertion" json:"socialAssertion"`
+	InviteLink      string          `codec:"inviteLink" json:"inviteLink"`
+	Throttled       bool            `codec:"throttled" json:"throttled"`
 }
 
 type DelegateIdentifyUIArg struct {

--- a/protocol/avdl/identify_ui.avdl
+++ b/protocol/avdl/identify_ui.avdl
@@ -106,7 +106,7 @@ protocol identifyUi {
     string resource;
   }
 
-  void displayTLFCreateWithInvite(int sessionID, string folderName, boolean isPrivate, string assertion, string inviteLink, boolean throttled);
+  void displayTLFCreateWithInvite(int sessionID, string folderName, boolean isPrivate, string assertion, SocialAssertion socialAssertion, string inviteLink, boolean throttled);
 
   // The IdentifyUI can be delegated to another process.  Call this function
   // to initialize the delegated UI; it returns the sessionID to use in the

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1894,6 +1894,7 @@ export type identifyUi_displayTLFCreateWithInvite_rpc = {
     folderName: string,
     isPrivate: boolean,
     assertion: string,
+    socialAssertion: SocialAssertion,
     inviteLink: string,
     throttled: boolean
   },
@@ -4211,6 +4212,7 @@ export type incomingCallMapType = {
       folderName: string,
       isPrivate: boolean,
       assertion: string,
+      socialAssertion: SocialAssertion,
       inviteLink: string,
       throttled: boolean
     },

--- a/protocol/json/identify_ui.json
+++ b/protocol/json/identify_ui.json
@@ -1073,6 +1073,10 @@
           "type": "string"
         },
         {
+          "name": "socialAssertion",
+          "type": "SocialAssertion"
+        },
+        {
           "name": "inviteLink",
           "type": "string"
         },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1894,6 +1894,7 @@ export type identifyUi_displayTLFCreateWithInvite_rpc = {
     folderName: string,
     isPrivate: boolean,
     assertion: string,
+    socialAssertion: SocialAssertion,
     inviteLink: string,
     throttled: boolean
   },
@@ -4211,6 +4212,7 @@ export type incomingCallMapType = {
       folderName: string,
       isPrivate: boolean,
       assertion: string,
+      socialAssertion: SocialAssertion,
       inviteLink: string,
       throttled: boolean
     },

--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -114,6 +114,7 @@ function updateNonUserState (state: NonUserState, action: NonUserActions): NonUs
         closed: false,
         hidden: false,
         name: action.payload.assertion,
+        serviceName: action.payload.socialAssertion.service,
         reason: `You tried to access ${action.payload.folderName}`,
         isPrivate: action.payload.isPrivate,
         inviteLink: action.payload.throttled ? null : action.payload.inviteLink

--- a/shared/tracker/dumb.desktop.js
+++ b/shared/tracker/dumb.desktop.js
@@ -106,7 +106,8 @@ const propsNonUser: TrackerProps = {
   isPrivate: false,
   proofs: [],
   nonUser: true,
-  name: '@aliceb',
+  name: 'aliceb@reddit',
+  serviceName: 'reddit',
   reason: 'Success! You opened a private folder with aliceb@twitter.',
   inviteLink: 'keybase.io/inv/9999999999',
   parentProps: {

--- a/shared/tracker/index.js
+++ b/shared/tracker/index.js
@@ -38,6 +38,7 @@ export type TrackerProps = {
   currentlyFollowing: boolean,
   lastAction: ?('followed' | 'refollowed' | 'unfollowed' | 'error'),
   name?: string,
+  serviceName?: string,
   inviteLink?: ?string,
   isPrivate?: boolean
 }
@@ -91,6 +92,7 @@ export function trackerPropsToRenderProps (props: TrackerProps): RenderProps {
     },
     nonUser: props.nonUser,
     name: props.name,
+    serviceName: props.serviceName,
     reason: props.reason,
     inviteLink: props.inviteLink,
     isPrivate: props.isPrivate

--- a/shared/tracker/non-user.desktop.js
+++ b/shared/tracker/non-user.desktop.js
@@ -25,12 +25,12 @@ const Top = ({onClose, reason, inviteLink, name, isPrivate}) => {
   )
 }
 
-const Bottom = ({onClose, name}) => (
+const Bottom = ({onClose, name, serviceName}) => (
   <Box style={stylesNext}>
     <Text style={{marginBottom: 16}} type='Header'>What's next?</Text>
     <Box style={stylesBullet}>
       <Text type='BodySmall' style={{marginRight: 8}}>•</Text>
-      <Text type='BodySmall'>When {name} connects Keybase and their Twitter account, your computer will verify them and rekey the folder.</Text>
+      <Text type='BodySmall'>When {name} connects Keybase and their {serviceName || 'other'} account, your computer will verify them and rekey the folder.</Text>
     </Box>
     <Box style={{...stylesBullet, marginTop: 5}}>
       <Text type='BodySmall' style={{marginRight: 8}}>•</Text>
@@ -41,10 +41,10 @@ const Bottom = ({onClose, name}) => (
   </Box>
 )
 
-const Render = ({name, reason, inviteLink, onClose, isPrivate}: Props) => (
+const Render = ({name, reason, inviteLink, onClose, isPrivate, serviceName}: Props) => (
   <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
     <Top reason={reason} isPrivate={isPrivate} inviteLink={inviteLink} name={name} />
-    <Bottom onClose={onClose} name={name} />
+    <Bottom onClose={onClose} name={name} serviceName={serviceName} />
   </Box>
 )
 

--- a/shared/tracker/non-user.js.flow
+++ b/shared/tracker/non-user.js.flow
@@ -8,6 +8,7 @@ import {globalColors, globalStyles} from '../styles/style-guide'
 
 export type Props = $Shape<{
   name: string,
+  serviceName: string,
   reason: string,
   isPrivate: boolean,
   inviteLink: ?string,

--- a/shared/tracker/render.desktop.js
+++ b/shared/tracker/render.desktop.js
@@ -11,7 +11,7 @@ import NonUser from './non-user'
 
 import type {RenderProps} from './render'
 
-export default class Render extends Component {
+export default class Render extends Component<void, RenderProps, void> {
   props: RenderProps;
 
   render () {
@@ -19,6 +19,7 @@ export default class Render extends Component {
       return <NonUser
         onClose={this.props.headerProps.onClose}
         name={this.props.name}
+        serviceName={this.props.serviceName}
         reason={this.props.reason}
         inviteLink={this.props.inviteLink}
         isPrivate={this.props.isPrivate} />

--- a/shared/tracker/render.js.flow
+++ b/shared/tracker/render.js.flow
@@ -14,6 +14,7 @@ export type RenderProps = $Shape<{
   proofsProps: ProofsProps,
   name?: string,
   nonUser?: ?boolean,
+  serviceName?: string,
   reason?: string,
   inviteLink?: ?string,
   isPrivate?: boolean


### PR DESCRIPTION
@patrickxb 

Just added the social assertion info to be passed into the UI so we can be smart about the service name.