### PR TITLE
Installer (OS X) CLI option to install/upgrade Fuse only

### DIFF
--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.28</string>
+	<string>1.1.29</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.28</string>
+	<string>1.1.29</string>
 	<key>KBFuseBuild</key>
 	<string>3.2.0</string>
 	<key>KBFuseVersion</key>
@@ -41,7 +41,7 @@
 	<key>SMPrivilegedExecutables</key>
 	<dict>
 		<key>keybase.Helper</key>
-		<string>anchor apple generic and identifier "keybase.Helper" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "99229SGT5K")</string>
+		<string>anchor apple generic and identifier &quot;keybase.Helper&quot; and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = &quot;99229SGT5K&quot;)</string>
 	</dict>
 </dict>
 </plist>

--- a/osx/KBKit/KBKit/App/KBApp.m
+++ b/osx/KBKit/KBKit/App/KBApp.m
@@ -96,18 +96,18 @@
   NSString *runMode = NSBundle.mainBundle.infoDictionary[@"KBRunMode"];
   NSString *servicePath = [KBPath pathInDir:NSBundle.mainBundle.sharedSupportPath path:@"bin" options:0];
   if ([runMode isEqualToString:@"prod"]) {
-    [self openWithEnvironment:[[KBEnvironment alloc] initWithConfig:[KBEnvConfig envConfigWithRunMode:KBRunModeProd] servicePath:servicePath]];
+    [self openWithEnvironment:[[KBEnvironment alloc] initWithConfig:[KBEnvConfig envConfigWithRunMode:KBRunModeProd] servicePath:servicePath options:KBInstallOptionAll]];
   } else if ([runMode isEqualToString:@"staging"]) {
-    [self openWithEnvironment:[[KBEnvironment alloc] initWithConfig:[KBEnvConfig envConfigWithRunMode:KBRunModeStaging] servicePath:servicePath]];
+    [self openWithEnvironment:[[KBEnvironment alloc] initWithConfig:[KBEnvConfig envConfigWithRunMode:KBRunModeStaging] servicePath:servicePath options:KBInstallOptionAll]];
   } else if ([runMode isEqualToString:@"devel"]) {
-    [self openWithEnvironment:[[KBEnvironment alloc] initWithConfig:[KBEnvConfig envConfigWithRunMode:KBRunModeDevel] servicePath:servicePath]];
+    [self openWithEnvironment:[[KBEnvironment alloc] initWithConfig:[KBEnvConfig envConfigWithRunMode:KBRunModeDevel] servicePath:servicePath options:KBInstallOptionAll]];
   } else {
     KBEnvSelectView *envSelectView = [[KBEnvSelectView alloc] init];
     KBNavigationView *navigation = [[KBNavigationView alloc] initWithView:envSelectView title:@"Keybase"];
     KBWindow *window = [KBWindow windowWithContentView:navigation size:CGSizeMake(900, 600) retain:YES];
     envSelectView.onSelect = ^(KBEnvConfig *envConfig) {
       [window close];
-      KBEnvironment *environment = [[KBEnvironment alloc] initWithConfig:envConfig servicePath:servicePath];
+      KBEnvironment *environment = [[KBEnvironment alloc] initWithConfig:envConfig servicePath:servicePath options:KBInstallOptionAll];
       [self openWithEnvironment:environment];
     };
     window.styleMask = NSFullSizeContentViewWindowMask | NSTitledWindowMask | NSResizableWindowMask;

--- a/osx/KBKit/KBKit/System/KBEnvironment.h
+++ b/osx/KBKit/KBKit/System/KBEnvironment.h
@@ -13,6 +13,17 @@
 #import "KBFSService.h"
 #import "KBFuseComponent.h"
 
+typedef NS_OPTIONS (NSUInteger, KBInstallOptions) {
+  KBInstallOptionNone = 0,
+  KBInstallOptionService = 1 << 1,
+  KBInstallOptionHelper = 2 << 1,
+  KBInstallOptionFuse = 3 << 1,
+  KBInstallOptionKBFS = 4 << 1,
+  KBInstallOptionCLI = 10 << 1,
+
+  KBInstallOptionAll = KBInstallOptionService | KBInstallOptionHelper | KBInstallOptionKBFS | KBInstallOptionFuse | KBInstallOptionCLI,
+};
+
 @interface KBEnvironment : NSObject
 
 @property (readonly) KBEnvConfig *config;
@@ -21,7 +32,9 @@
 @property (readonly) KBFuseComponent *fuse;
 @property (readonly) NSArray */*of KBInstallable*/installables;
 
-- (instancetype)initWithConfig:(KBEnvConfig *)config servicePath:(NSString *)servicePath;
+- (instancetype)initWithConfig:(KBEnvConfig *)config servicePath:(NSString *)servicePath options:(KBInstallOptions)options;
+
++ (instancetype)environmentForRunModeString:(NSString *)runModeString servicePath:(NSString *)servicePath options:(KBInstallOptions)options;
 
 - (NSArray *)componentsForControlPanel;
 

--- a/osx/KBKit/KBKit/System/KBEnvironment.m
+++ b/osx/KBKit/KBKit/System/KBEnvironment.m
@@ -22,26 +22,43 @@
 @property KBFSService *kbfs;
 @property KBFuseComponent *fuse;
 @property NSMutableArray */*of id<KBComponent>*/components;
-@property NSArray */*of KBInstallable*/installables;
+@property NSMutableArray */*of KBInstallable*/installables;
 @property NSArray *services;
 @property (nonatomic) NSDictionary *appConfig;
 @end
 
-
 @implementation KBEnvironment
 
-- (instancetype)initWithConfig:(KBEnvConfig *)config servicePath:(NSString *)servicePath {
+- (instancetype)initWithConfig:(KBEnvConfig *)config servicePath:(NSString *)servicePath options:(KBInstallOptions)options {
   if ((self = [super init])) {
     _config = config;
+
+    _installables = [NSMutableArray array];
+
     KBHelperTool *helperTool = [[KBHelperTool alloc] initWithConfig:config];
+    if (options&KBInstallOptionHelper) {
+      [_installables addObject:helperTool];
+    }
 
     _service = [[KBService alloc] initWithConfig:config label:[config launchdServiceLabel] servicePath:servicePath];
-    _kbfs = [[KBFSService alloc] initWithConfig:config helperTool:helperTool label:[config launchdKBFSLabel] servicePath:servicePath];
+    if (options&KBInstallOptionService) {
+      [_installables addObject:_service];
+    }
 
     _fuse = [[KBFuseComponent alloc] initWithConfig:config helperTool:helperTool servicePath:servicePath];
-    KBCommandLine *cli = [[KBCommandLine alloc] initWithConfig:config helperTool:helperTool servicePath:servicePath];
+    if (options&KBInstallOptionFuse) {
+      [_installables addObject:_fuse];
+    }
 
-    _installables = [NSArray arrayWithObjects:helperTool, _service, _fuse, _kbfs, cli, nil];
+    _kbfs = [[KBFSService alloc] initWithConfig:config helperTool:helperTool label:[config launchdKBFSLabel] servicePath:servicePath];
+    if (options&KBInstallOptionKBFS) {
+      [_installables addObject:_kbfs];
+    }
+
+    if (options&KBInstallOptionCLI) {
+      KBCommandLine *cli = [[KBCommandLine alloc] initWithConfig:config helperTool:helperTool servicePath:servicePath];
+      [_installables addObject:cli];
+    }
 
     _services = [NSArray arrayWithObjects:_service, _kbfs, nil];
     _components = [NSMutableArray arrayWithObjects:_service, _kbfs, helperTool, _fuse, nil];
@@ -53,13 +70,13 @@
   return _components;
 }
 
-+ (instancetype)environmentForRunModeString:(NSString *)runModeString servicePath:(NSString *)servicePath {
++ (instancetype)environmentForRunModeString:(NSString *)runModeString servicePath:(NSString *)servicePath options:(KBInstallOptions)options {
   if ([runModeString isEqualToString:@"prod"]) {
-    return [[KBEnvironment alloc] initWithConfig:[KBEnvConfig envConfigWithRunMode:KBRunModeProd] servicePath:servicePath];
+    return [[KBEnvironment alloc] initWithConfig:[KBEnvConfig envConfigWithRunMode:KBRunModeProd] servicePath:servicePath options:options];
   } else if ([runModeString isEqualToString:@"staging"]) {
-    return [[KBEnvironment alloc] initWithConfig:[KBEnvConfig envConfigWithRunMode:KBRunModeStaging] servicePath:servicePath];
+    return [[KBEnvironment alloc] initWithConfig:[KBEnvConfig envConfigWithRunMode:KBRunModeStaging] servicePath:servicePath options:options];
   } else if ([runModeString isEqualToString:@"devel"]) {
-    return [[KBEnvironment alloc] initWithConfig:[KBEnvConfig envConfigWithRunMode:KBRunModeDevel] servicePath:servicePath];
+    return [[KBEnvironment alloc] initWithConfig:[KBEnvConfig envConfigWithRunMode:KBRunModeDevel] servicePath:servicePath options:options];
   }
   return nil;
 }

--- a/osx/Keybase.xcodeproj/project.pbxproj
+++ b/osx/Keybase.xcodeproj/project.pbxproj
@@ -1126,8 +1126,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DF54D7C94B2D7756B784F46B /* Pods-keybase.Helper.debug.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application: Keybase, Inc. (99229SGT5K)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1155,8 +1154,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 50CECECF69AD315C4D376EB8 /* Pods-keybase.Helper.release.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Developer ID Application: Keybase, Inc. (99229SGT5K)";
 				COPY_PHASE_STRIP = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
 				OTHER_LDFLAGS = (

--- a/osx/Utils/Settings.m
+++ b/osx/Utils/Settings.m
@@ -12,6 +12,7 @@
 @property NSString *appPath;
 @property NSString *runMode;
 @property UninstallOptions uninstallOptions;
+@property KBInstallOptions installOptions;
 @property GBSettings *settings;
 @end
 
@@ -32,6 +33,7 @@
     [parser registerOption:@"run-mode" shortcut:'r' requirement:GBValueRequired];
     [parser registerSwitch:@"uninstall-app"];
     [parser registerSwitch:@"uninstall-kext"];
+    [parser registerSwitch:@"install-fuse"];
     [parser registerSettings:self.settings];
     NSArray *subargs = [args subarrayWithRange:NSMakeRange(1, args.count-1)];
     [parser parseOptionsWithArguments:subargs commandLine:args[0]];
@@ -45,6 +47,12 @@
     if ([[self.settings objectForKey:@"uninstall-kext"] boolValue]) {
       self.uninstallOptions |= UninstallOptionKext;
     }
+    if ([[self.settings objectForKey:@"install-fuse"] boolValue]) {
+      self.installOptions |= KBInstallOptionFuse;
+    }
+    if (self.installOptions == 0) {
+      self.installOptions = KBInstallOptionAll;
+    }
   }
   return self;
 }
@@ -52,7 +60,7 @@
 - (KBEnvironment *)environment {
   NSAssert(self.runMode, @"No run mode");
   NSString *servicePath = [self.appPath stringByAppendingPathComponent:@"Contents/SharedSupport/bin"];
-  KBEnvironment *environment = [KBEnvironment environmentForRunModeString:self.runMode servicePath:servicePath];
+  KBEnvironment *environment = [KBEnvironment environmentForRunModeString:self.runMode servicePath:servicePath options:self.installOptions];
   return environment;
 }
 


### PR DESCRIPTION
This allows us to upgrade Fuse after an update (in `keybase update notify`) directly.

Currently, we do something a little hacky:
On `keybase update notify`:
- After update, check if new Fuse version
- If so, uninstall KBFS and unmount /keybase
- Exit
- When Keybase.app restarts it installs the new Fuse and then starts KBFS.

If there is a problem restarting the Keybase.app, KBFS is left uninstalled. This happened to max.

The better solution I think is to:
On `keybase update notify`:
- After update, check if new Fuse version
- If so, uninstall KBFS and unmount /keybase
- Call KeybaseUpdater --install-fuse
- Restart KBFS

