### PR TITLE
Make non user popup a little taller

### DIFF
--- a/shared/tracker/index.js
+++ b/shared/tracker/index.js
@@ -8,7 +8,7 @@ import * as trackerActions from '../actions/tracker'
 import {bindActionCreators} from 'redux'
 import {metaNone} from '../constants/tracker'
 
-import type {RenderProps} from './render'
+import type {RenderPropsUnshaped} from './render'
 import type {UserInfo} from './bio.render'
 import type {Proof} from './proofs.render'
 import type {SimpleProofState} from '../constants/tracker'
@@ -42,7 +42,7 @@ export type TrackerProps = {
   isPrivate?: boolean
 }
 
-export function trackerPropsToRenderProps (props: TrackerProps): RenderProps {
+export function trackerPropsToRenderProps (props: TrackerProps): RenderPropsUnshaped {
   const renderChangedTitle = props.trackerMessage
   const failedProofsNotFollowingText = `Some of ${props.username}'s proofs couldn't be verified. Track the working proofs?`
   const currentlyFollowing = !!props.lastTrack
@@ -54,6 +54,7 @@ export function trackerPropsToRenderProps (props: TrackerProps): RenderProps {
   const reason = currentlyFollowing && renderChangedTitle ? renderChangedTitle : props.reason
 
   return {
+    parentProps: props.parentProps || {},
     bioProps: {
       username: props.username,
       userInfo: props.userInfo,

--- a/shared/tracker/render.desktop.js
+++ b/shared/tracker/render.desktop.js
@@ -8,11 +8,16 @@ import Bio from './bio.render.desktop'
 import ProofsRender from './proofs.render.desktop'
 import commonStyles from '../styles/common'
 import NonUser from './non-user'
+import {autoResize} from '../../desktop/renderer/remote-component-helper'
 
 import type {RenderProps} from './render'
 
 export default class Render extends Component {
   props: RenderProps;
+
+  componentDidMount () {
+    autoResize()
+  }
 
   render () {
     if (this.props.nonUser) {

--- a/shared/tracker/render.js.flow
+++ b/shared/tracker/render.js.flow
@@ -7,7 +7,7 @@ import type {ActionProps} from './action.render'
 import type {HeaderProps} from './header.render'
 import type {ProofsProps} from './proofs.render'
 
-export type RenderProps = $Shape<{
+export type RenderPropsUnshaped = {
   bioProps: BioProps,
   actionProps: ActionProps,
   headerProps: HeaderProps,
@@ -17,6 +17,8 @@ export type RenderProps = $Shape<{
   reason?: string,
   inviteLink?: ?string,
   isPrivate?: boolean
-}>
+}
+
+export type RenderProps = $Shape<RenderPropsUnshaped>
 
 export default class Render extends Component<void, RenderProps, void> { }


### PR DESCRIPTION
@keybase/react-hackers 

The close button was really close to the edge, this makes the popup for sharing before signup a little taller so that shouldn't happen.


Also makes remote components use up the whole available size, instead of limiting to be as tall as the child is.