### PR TITLE
Change RekeyUI refresh protocol

### DIFF
--- a/go/libkb/device.go
+++ b/go/libkb/device.go
@@ -124,6 +124,9 @@ func (d *Device) ProtExport() *keybase1.Device {
 	if d.Status != nil {
 		ex.Status = *d.Status
 	}
+	if d.Kid.Exists() {
+		ex.VerifyKey = d.Kid
+	}
 	return ex
 }
 

--- a/go/protocol/rekey.go
+++ b/go/protocol/rekey.go
@@ -23,12 +23,6 @@ type ProblemTLF struct {
 	Solutions []KID `codec:"solutions" json:"solutions"`
 }
 
-type ProblemTLFDevices struct {
-	Tlf       TLF      `codec:"tlf" json:"tlf"`
-	Score     int      `codec:"score" json:"score"`
-	Solutions []Device `codec:"solutions" json:"solutions"`
-}
-
 // ProblemSet is for a particular (user,kid) that initiated a rekey problem.
 // This problem consists of one or more problem TLFs, which are individually scored
 // and have attendant solutions --- devices that if they came online can rekey and
@@ -40,9 +34,8 @@ type ProblemSet struct {
 }
 
 type ProblemSetDevices struct {
-	User User                `codec:"user" json:"user"`
-	Kid  KID                 `codec:"kid" json:"kid"`
-	Tlfs []ProblemTLFDevices `codec:"tlfs" json:"tlfs"`
+	ProblemSet ProblemSet `codec:"problemSet" json:"problemSet"`
+	Devices    []Device   `codec:"devices" json:"devices"`
 }
 
 type Outcome int

--- a/go/protocol/rekey.go
+++ b/go/protocol/rekey.go
@@ -23,6 +23,12 @@ type ProblemTLF struct {
 	Solutions []KID `codec:"solutions" json:"solutions"`
 }
 
+type ProblemTLFDevices struct {
+	Tlf       TLF      `codec:"tlf" json:"tlf"`
+	Score     int      `codec:"score" json:"score"`
+	Solutions []Device `codec:"solutions" json:"solutions"`
+}
+
 // ProblemSet is for a particular (user,kid) that initiated a rekey problem.
 // This problem consists of one or more problem TLFs, which are individually scored
 // and have attendant solutions --- devices that if they came online can rekey and
@@ -31,6 +37,12 @@ type ProblemSet struct {
 	User User         `codec:"user" json:"user"`
 	Kid  KID          `codec:"kid" json:"kid"`
 	Tlfs []ProblemTLF `codec:"tlfs" json:"tlfs"`
+}
+
+type ProblemSetDevices struct {
+	User User                `codec:"user" json:"user"`
+	Kid  KID                 `codec:"kid" json:"kid"`
+	Tlfs []ProblemTLFDevices `codec:"tlfs" json:"tlfs"`
 }
 
 type Outcome int
@@ -71,7 +83,7 @@ type RekeyInterface interface {
 	// getProblemSet is called by the UI to render which TLFs need to be fixed.
 	// The UI will repeatedly poll this RPC when it gets a `rekeyChanged` notice
 	// below
-	GetProblemSet(context.Context, int) (ProblemSet, error)
+	GetProblemSet(context.Context, int) (ProblemSetDevices, error)
 	// rekeyStatusFinish is called when work is completed on a given RekeyStatus window. The Outcome
 	// can be Fixed or Ignored.
 	RekeyStatusFinish(context.Context, int) (Outcome, error)
@@ -172,7 +184,7 @@ func (c RekeyClient) ShowRekeyStatus(ctx context.Context, __arg ShowRekeyStatusA
 // getProblemSet is called by the UI to render which TLFs need to be fixed.
 // The UI will repeatedly poll this RPC when it gets a `rekeyChanged` notice
 // below
-func (c RekeyClient) GetProblemSet(ctx context.Context, sessionID int) (res ProblemSet, err error) {
+func (c RekeyClient) GetProblemSet(ctx context.Context, sessionID int) (res ProblemSetDevices, err error) {
 	__arg := GetProblemSetArg{SessionID: sessionID}
 	err = c.Cli.Call(ctx, "keybase.1.rekey.getProblemSet", []interface{}{__arg}, &res)
 	return

--- a/go/protocol/rekey_ui.go
+++ b/go/protocol/rekey_ui.go
@@ -12,8 +12,8 @@ type DelegateRekeyUIArg struct {
 }
 
 type RefreshArg struct {
-	SessionID int          `codec:"sessionID" json:"sessionID"`
-	Tlfs      []ProblemTLF `codec:"tlfs" json:"tlfs"`
+	SessionID int                 `codec:"sessionID" json:"sessionID"`
+	Tlfs      []ProblemTLFDevices `codec:"tlfs" json:"tlfs"`
 }
 
 type RekeyUIInterface interface {

--- a/go/protocol/rekey_ui.go
+++ b/go/protocol/rekey_ui.go
@@ -12,8 +12,8 @@ type DelegateRekeyUIArg struct {
 }
 
 type RefreshArg struct {
-	SessionID int                 `codec:"sessionID" json:"sessionID"`
-	Tlfs      []ProblemTLFDevices `codec:"tlfs" json:"tlfs"`
+	SessionID         int               `codec:"sessionID" json:"sessionID"`
+	ProblemSetDevices ProblemSetDevices `codec:"problemSetDevices" json:"problemSetDevices"`
 }
 
 type RekeyUIInterface interface {

--- a/go/service/rekey.go
+++ b/go/service/rekey.go
@@ -33,8 +33,8 @@ func (h *RekeyHandler) ShowRekeyStatus(ctx context.Context, arg keybase1.ShowRek
 	return nil
 }
 
-func (h *RekeyHandler) GetProblemSet(ctx context.Context, sessionID int) (keybase1.ProblemSet, error) {
-	return keybase1.ProblemSet{}, nil
+func (h *RekeyHandler) GetProblemSet(ctx context.Context, sessionID int) (keybase1.ProblemSetDevices, error) {
+	return keybase1.ProblemSetDevices{}, nil
 }
 
 func (h *RekeyHandler) RekeyStatusFinish(ctx context.Context, sessionID int) (keybase1.Outcome, error) {

--- a/go/service/rekey_test.go
+++ b/go/service/rekey_test.go
@@ -15,7 +15,10 @@ import (
 func rekeySetup(tc libkb.TestContext) (gregor1.UID, *gregorHandler, *RekeyUIHandler) {
 	tc.G.SetService()
 
-	kbUID := keybase1.MakeTestUID(1)
+	kbUID, err := keybase1.UIDFromString("9f9611a4b7920637b1c2a839b2a0e119")
+	if err != nil {
+		tc.T.Fatal(err)
+	}
 	gUID := gregor1.UID(kbUID.ToBytes())
 	did, err := libkb.NewDeviceID()
 	if err != nil {
@@ -75,21 +78,21 @@ func TestRekeyNeededMessageNoScores(t *testing.T) {
 
 const problemSet = `{ 
 	"user": {
-		"uid": "295a7eea607af32040647123732bc819",
-		"username": "t_alice"
+		"uid": "9f9611a4b7920637b1c2a839b2a0e119",
+		"username": "t_frank"
 	},
-	"kid": "011212121212121212121212121212121212121212121212121212121212121212120a",
+	"kid": "01206f31b54690a95a1a60a0d8861c8ec27c322b49a93b475a631ee6a676018bfd140a",
 	"tlfs": [
 		{
 			"tlf": {
 				"tlfid": "folder", 
 				"name": "folder name", 
-				"writers": ["t_alice"], 
+				"writers": ["t_frank","t_george"], 
 				"readers": ["t_alice"], 
 				"isPrivate": true
 			},
 			"score": 300,
-			"solutions": ["011313131313131313131313131313131313131313131313131313131313131313130a"]
+			"solutions": ["01206f31b54690a95a1a60a0d8861c8ec27c322b49a93b475a631ee6a676018bfd140a"]
 		}
 	]
 }`

--- a/go/service/rekey_test.go
+++ b/go/service/rekey_test.go
@@ -145,12 +145,24 @@ func TestRekeyNeededMessageWithScores(t *testing.T) {
 	}
 
 	// the first call should contain a TLF
-	if len(rkeyui.refreshArgs[0].Tlfs) != 1 {
-		t.Errorf("first refresh call, tlf count = %d, expected 1", len(rkeyui.refreshArgs[0].Tlfs))
+	if len(rkeyui.refreshArgs[0].ProblemSetDevices.ProblemSet.Tlfs) != 1 {
+		t.Errorf("first refresh call, tlf count = %d, expected 1", len(rkeyui.refreshArgs[0].ProblemSetDevices.ProblemSet.Tlfs))
 	}
 	// the second call should have updated the scores, and have no more TLFs in it.
-	if len(rkeyui.refreshArgs[1].Tlfs) != 0 {
-		t.Errorf("second/final refresh call, tlf count = %d, expected 0", len(rkeyui.refreshArgs[1].Tlfs))
+	if len(rkeyui.refreshArgs[1].ProblemSetDevices.ProblemSet.Tlfs) != 0 {
+		t.Errorf("second/final refresh call, tlf count = %d, expected 0", len(rkeyui.refreshArgs[1].ProblemSetDevices.ProblemSet.Tlfs))
+	}
+
+	// check the devices field
+	if len(rkeyui.refreshArgs[0].ProblemSetDevices.Devices) != 1 {
+		t.Fatalf("num devices: %d, expected 1", len(rkeyui.refreshArgs[0].ProblemSetDevices.Devices))
+	}
+	d := rkeyui.refreshArgs[0].ProblemSetDevices.Devices[0]
+	if d.DeviceID != "640ee4f517c2a0ff190456952df26e18" {
+		t.Errorf("device id: %v, expected 640ee4f517c2a0ff190456952df26e18", d.DeviceID)
+	}
+	if d.VerifyKey != "01206f31b54690a95a1a60a0d8861c8ec27c322b49a93b475a631ee6a676018bfd140a" {
+		t.Errorf("device verify key: %v, expected 01206f31b54690a95a1a60a0d8861c8ec27c322b49a93b475a631ee6a676018bfd140a", d.VerifyKey)
 	}
 }
 
@@ -216,8 +228,8 @@ func TestRekeyNeededUserClose(t *testing.T) {
 		t.Fatalf("rkeyui refresh calls: %d, expected 1", len(rkeyui.refreshArgs))
 	}
 
-	if len(rkeyui.refreshArgs[0].Tlfs) != 1 {
-		t.Errorf("first refresh call, tlf count = %d, expected 1", len(rkeyui.refreshArgs[0].Tlfs))
+	if len(rkeyui.refreshArgs[0].ProblemSetDevices.ProblemSet.Tlfs) != 1 {
+		t.Errorf("first refresh call, tlf count = %d, expected 1", len(rkeyui.refreshArgs[0].ProblemSetDevices.ProblemSet.Tlfs))
 	}
 }
 

--- a/protocol/avdl/rekey.avdl
+++ b/protocol/avdl/rekey.avdl
@@ -20,6 +20,12 @@ protocol rekey {
     array<KID> solutions;
   }
 
+  record ProblemTLFDevices {
+    TLF tlf;
+    int score;
+    array<Device> solutions;
+  }
+
   /**
    ProblemSet is for a particular (user,kid) that initiated a rekey problem.
    This problem consists of one or more problem TLFs, which are individually scored
@@ -30,6 +36,12 @@ protocol rekey {
     User user;
     KID kid;
     array<ProblemTLF> tlfs;
+  }
+
+  record ProblemSetDevices {
+    User user;
+    KID kid;
+    array<ProblemTLFDevices> tlfs;
   }
 
   enum Outcome {
@@ -57,7 +69,7 @@ protocol rekey {
    The UI will repeatedly poll this RPC when it gets a `rekeyChanged` notice
    below
    */
-  ProblemSet getProblemSet(int sessionID);
+  ProblemSetDevices getProblemSet(int sessionID);
 
   /**
    rekeyStatusFinish is called when work is completed on a given RekeyStatus window. The Outcome

--- a/protocol/avdl/rekey.avdl
+++ b/protocol/avdl/rekey.avdl
@@ -20,12 +20,6 @@ protocol rekey {
     array<KID> solutions;
   }
 
-  record ProblemTLFDevices {
-    TLF tlf;
-    int score;
-    array<Device> solutions;
-  }
-
   /**
    ProblemSet is for a particular (user,kid) that initiated a rekey problem.
    This problem consists of one or more problem TLFs, which are individually scored
@@ -39,9 +33,8 @@ protocol rekey {
   }
 
   record ProblemSetDevices {
-    User user;
-    KID kid;
-    array<ProblemTLFDevices> tlfs;
+    ProblemSet problemSet;
+    array<Device> devices;
   }
 
   enum Outcome {

--- a/protocol/avdl/rekey_ui.avdl
+++ b/protocol/avdl/rekey_ui.avdl
@@ -7,5 +7,5 @@ protocol rekeyUI {
   /** refresh is called whenever Electron should refresh the UI, either
    * because a change came in, or because there was a timeout poll.
    */
-  void refresh(int sessionID, array<ProblemTLFDevices> tlfs);
+  void refresh(int sessionID, ProblemSetDevices problemSetDevices);
 }

--- a/protocol/avdl/rekey_ui.avdl
+++ b/protocol/avdl/rekey_ui.avdl
@@ -7,5 +7,5 @@ protocol rekeyUI {
   /** refresh is called whenever Electron should refresh the UI, either
    * because a change came in, or because there was a timeout poll.
    */
-  void refresh(int sessionID, array<ProblemTLF> tlfs);
+  void refresh(int sessionID, array<ProblemTLFDevices> tlfs);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -706,21 +706,14 @@ export type ProblemSet = {
 }
 
 export type ProblemSetDevices = {
-  user: User;
-  kid: KID;
-  tlfs: Array<ProblemTLFDevices>;
+  problemSet: ProblemSet;
+  devices: Array<Device>;
 }
 
 export type ProblemTLF = {
   tlf: TLF;
   score: int;
   solutions: Array<KID>;
-}
-
-export type ProblemTLFDevices = {
-  tlf: TLF;
-  score: int;
-  solutions: Array<Device>;
 }
 
 export type Process = {
@@ -2950,7 +2943,7 @@ export type rekeyUIRefreshResult = void
 export type rekeyUIRefreshRpc = {
   method: 'rekeyUI.refresh',
   param: {
-    tlfs: Array<ProblemTLFDevices>
+    problemSetDevices: ProblemSetDevices
   },
   incomingCallMap?: incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -5242,7 +5235,7 @@ export type incomingCallMapType = {
   'keybase.1.rekeyUI.refresh'?: (
     params: {
       sessionID: int,
-      tlfs: Array<ProblemTLFDevices>
+      problemSetDevices: ProblemSetDevices
     },
     response: {
       error: (err: RPCError) => void,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -705,10 +705,22 @@ export type ProblemSet = {
   tlfs: Array<ProblemTLF>;
 }
 
+export type ProblemSetDevices = {
+  user: User;
+  kid: KID;
+  tlfs: Array<ProblemTLFDevices>;
+}
+
 export type ProblemTLF = {
   tlf: TLF;
   score: int;
   solutions: Array<KID>;
+}
+
+export type ProblemTLFDevices = {
+  tlf: TLF;
+  score: int;
+  solutions: Array<Device>;
 }
 
 export type Process = {
@@ -2888,7 +2900,7 @@ export type quotaVerifySessionRpc = {
   callback: (null | (err: ?any, response: quotaVerifySessionResult) => void)
 }
 
-export type rekeyGetProblemSetResult = ProblemSet
+export type rekeyGetProblemSetResult = ProblemSetDevices
 
 export type rekeyGetProblemSetRpc = {
   method: 'rekey.getProblemSet',
@@ -2938,7 +2950,7 @@ export type rekeyUIRefreshResult = void
 export type rekeyUIRefreshRpc = {
   method: 'rekeyUI.refresh',
   param: {
-    tlfs: Array<ProblemTLF>
+    tlfs: Array<ProblemTLFDevices>
   },
   incomingCallMap?: incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -5230,7 +5242,7 @@ export type incomingCallMapType = {
   'keybase.1.rekeyUI.refresh'?: (
     params: {
       sessionID: int,
-      tlfs: Array<ProblemTLF>
+      tlfs: Array<ProblemTLFDevices>
     },
     response: {
       error: (err: RPCError) => void,

--- a/protocol/json/rekey.json
+++ b/protocol/json/rekey.json
@@ -442,27 +442,6 @@
     },
     {
       "type": "record",
-      "name": "ProblemTLFDevices",
-      "fields": [
-        {
-          "type": "TLF",
-          "name": "tlf"
-        },
-        {
-          "type": "int",
-          "name": "score"
-        },
-        {
-          "type": {
-            "type": "array",
-            "items": "Device"
-          },
-          "name": "solutions"
-        }
-      ]
-    },
-    {
-      "type": "record",
       "name": "ProblemSet",
       "fields": [
         {
@@ -488,19 +467,15 @@
       "name": "ProblemSetDevices",
       "fields": [
         {
-          "type": "User",
-          "name": "user"
-        },
-        {
-          "type": "KID",
-          "name": "kid"
+          "type": "ProblemSet",
+          "name": "problemSet"
         },
         {
           "type": {
             "type": "array",
-            "items": "ProblemTLFDevices"
+            "items": "Device"
           },
-          "name": "tlfs"
+          "name": "devices"
         }
       ]
     },

--- a/protocol/json/rekey.json
+++ b/protocol/json/rekey.json
@@ -442,6 +442,27 @@
     },
     {
       "type": "record",
+      "name": "ProblemTLFDevices",
+      "fields": [
+        {
+          "type": "TLF",
+          "name": "tlf"
+        },
+        {
+          "type": "int",
+          "name": "score"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "Device"
+          },
+          "name": "solutions"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "ProblemSet",
       "fields": [
         {
@@ -461,6 +482,27 @@
         }
       ],
       "doc": "ProblemSet is for a particular (user,kid) that initiated a rekey problem.\n   This problem consists of one or more problem TLFs, which are individually scored\n   and have attendant solutions --- devices that if they came online can rekey and\n   solve the ProblemTLF."
+    },
+    {
+      "type": "record",
+      "name": "ProblemSetDevices",
+      "fields": [
+        {
+          "type": "User",
+          "name": "user"
+        },
+        {
+          "type": "KID",
+          "name": "kid"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "ProblemTLFDevices"
+          },
+          "name": "tlfs"
+        }
+      ]
     },
     {
       "type": "enum",
@@ -521,7 +563,7 @@
           "type": "int"
         }
       ],
-      "response": "ProblemSet",
+      "response": "ProblemSetDevices",
       "doc": "getProblemSet is called by the UI to render which TLFs need to be fixed.\n   The UI will repeatedly poll this RPC when it gets a `rekeyChanged` notice\n   below"
     },
     "rekeyStatusFinish": {

--- a/protocol/json/rekey_ui.json
+++ b/protocol/json/rekey_ui.json
@@ -16,7 +16,7 @@
           "name": "tlfs",
           "type": {
             "type": "array",
-            "items": "ProblemTLF"
+            "items": "ProblemTLFDevices"
           }
         }
       ],

--- a/protocol/json/rekey_ui.json
+++ b/protocol/json/rekey_ui.json
@@ -13,11 +13,8 @@
           "type": "int"
         },
         {
-          "name": "tlfs",
-          "type": {
-            "type": "array",
-            "items": "ProblemTLFDevices"
-          }
+          "name": "problemSetDevices",
+          "type": "ProblemSetDevices"
         }
       ],
       "response": "null",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -706,21 +706,14 @@ export type ProblemSet = {
 }
 
 export type ProblemSetDevices = {
-  user: User;
-  kid: KID;
-  tlfs: Array<ProblemTLFDevices>;
+  problemSet: ProblemSet;
+  devices: Array<Device>;
 }
 
 export type ProblemTLF = {
   tlf: TLF;
   score: int;
   solutions: Array<KID>;
-}
-
-export type ProblemTLFDevices = {
-  tlf: TLF;
-  score: int;
-  solutions: Array<Device>;
 }
 
 export type Process = {
@@ -2950,7 +2943,7 @@ export type rekeyUIRefreshResult = void
 export type rekeyUIRefreshRpc = {
   method: 'rekeyUI.refresh',
   param: {
-    tlfs: Array<ProblemTLFDevices>
+    problemSetDevices: ProblemSetDevices
   },
   incomingCallMap?: incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -5242,7 +5235,7 @@ export type incomingCallMapType = {
   'keybase.1.rekeyUI.refresh'?: (
     params: {
       sessionID: int,
-      tlfs: Array<ProblemTLFDevices>
+      problemSetDevices: ProblemSetDevices
     },
     response: {
       error: (err: RPCError) => void,

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -705,10 +705,22 @@ export type ProblemSet = {
   tlfs: Array<ProblemTLF>;
 }
 
+export type ProblemSetDevices = {
+  user: User;
+  kid: KID;
+  tlfs: Array<ProblemTLFDevices>;
+}
+
 export type ProblemTLF = {
   tlf: TLF;
   score: int;
   solutions: Array<KID>;
+}
+
+export type ProblemTLFDevices = {
+  tlf: TLF;
+  score: int;
+  solutions: Array<Device>;
 }
 
 export type Process = {
@@ -2888,7 +2900,7 @@ export type quotaVerifySessionRpc = {
   callback: (null | (err: ?any, response: quotaVerifySessionResult) => void)
 }
 
-export type rekeyGetProblemSetResult = ProblemSet
+export type rekeyGetProblemSetResult = ProblemSetDevices
 
 export type rekeyGetProblemSetRpc = {
   method: 'rekey.getProblemSet',
@@ -2938,7 +2950,7 @@ export type rekeyUIRefreshResult = void
 export type rekeyUIRefreshRpc = {
   method: 'rekeyUI.refresh',
   param: {
-    tlfs: Array<ProblemTLF>
+    tlfs: Array<ProblemTLFDevices>
   },
   incomingCallMap?: incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -5230,7 +5242,7 @@ export type incomingCallMapType = {
   'keybase.1.rekeyUI.refresh'?: (
     params: {
       sessionID: int,
-      tlfs: Array<ProblemTLF>
+      tlfs: Array<ProblemTLFDevices>
     },
     response: {
       error: (err: RPCError) => void,


### PR DESCRIPTION
Instead of sending KIDs to RekeyUI clients, send Devices.

Updated problemSet in tests to use t_frank, t_george UIDs, KIDs.

r? @maxtaco 
cc: @chrisnojima 

Note that this doesn't close 3100, but @chrisnojima said updated protocol would be useful.