### PR TITLE
Connect files to store & feature flag recent files DESKTOP-1131

### DIFF
--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -9,9 +9,16 @@ import type {Folder, favoriteFavoriteListRpc} from '../constants/types/flow-type
 import type {Dispatch} from '../constants/types/flux'
 import type {FavoriteList} from '../constants/favorite'
 import type {Props as FolderProps} from '../folders/render'
+import type {UserList} from '../common-adapters/usernames'
 import flags from '../util/feature-flags'
 
-const folderToProps = (dispatch: Dispatch, folders: Array<Folder>, username: string = ''): FolderProps => { // eslint-disable-line space-infix-ops
+export function pathFromFolder ({isPublic, users}: {isPublic: boolean, users: UserList}) {
+  const sortName = users.map(u => u.username).join(',')
+  const path = `/keybase/${isPublic ? 'private' : 'public'}/${sortName}`
+  return {sortName, path}
+}
+
+const folderToProps = (folders: Array<Folder>, username: string = ''): FolderProps => { // eslint-disable-line space-infix-ops
   let privateBadge = 0
   let publicBadge = 0
 
@@ -22,9 +29,8 @@ const folderToProps = (dispatch: Dispatch, folders: Array<Folder>, username: str
         you: u === username,
         broken: false
       }))
-    const sortName = users.map(u => u.username).join(',')
-    const path = `/keybase/${f.private ? 'private' : 'public'}/${sortName}`
 
+    const {sortName, path} = pathFromFolder({users, isPublic: !f.private})
     const groupAvatar = f.private ? (users.length > 2) : (users.length > 1)
     const userAvatar = groupAvatar ? null : users[users.length - 1].username
     const meta = null
@@ -45,8 +51,11 @@ const folderToProps = (dispatch: Dispatch, folders: Array<Folder>, username: str
       isPublic: !f.private,
       groupAvatar,
       userAvatar,
+      meta,
       onRekey: null,
-      meta
+      recentFiles: [],
+      waitingForParticipationUnlock: [],
+      youCanUnlock: []
     }
   }).sort((a, b) => {
     // New first
@@ -117,7 +126,7 @@ export function favoriteList (): (dispatch: Dispatch) => void {
           })
         }
 
-        const folderProps = folderToProps(dispatch, folders, currentUser)
+        const folderProps = folderToProps(folders, currentUser)
         const action: FavoriteList = {type: Constants.favoriteList, payload: {folders: folderProps}}
         dispatch(action)
         dispatch(badgeApp('newTLFs', !!(folderProps.publicBadge || folderProps.privateBadge)))
@@ -125,4 +134,8 @@ export function favoriteList (): (dispatch: Dispatch) => void {
     }
     engine.rpc(params)
   }
+}
+
+export function ignoreFolder (path: string) {
+  return () => console.log('TODO: implement ignore folder action')
 }

--- a/shared/folders/dumb.js
+++ b/shared/folders/dumb.js
@@ -4,11 +4,16 @@ import Files from './files/render'
 import File from './files/file/render'
 import type {PropsOf} from '../constants/types/more'
 import type {Folder} from './list'
+import type {Props as FilesProps} from './files/render'
 import type {DumbComponentMap} from '../constants/types/more'
 import {globalStyles} from '../styles/style-guide'
+import {pathFromFolder} from '../actions/favorite'
 
-const f1: Folder = {
-  path: '/keybase/private/cecileb,jeresig,throughnothing,cdixon,bob,aliceb,lmorchard,chris,chris1,chris2,chris3,chris4,chris5,chris6,chris7,chris8,chris9,chris10,chris11,chris12,chris13',
+function createFolder (partialFolder: $Shape<Folder>) {
+  return {...partialFolder, path: pathFromFolder(partialFolder).path}
+}
+
+const f1: Folder = createFolder({
   users: [
     {username: 'cecileb', you: true},
     {username: 'jeresig', broken: true},
@@ -35,14 +40,15 @@ const f1: Folder = {
   meta: 'new',
   ignored: false,
   isPublic: false,
-  isFirst: true,
   hasData: true,
   groupAvatar: true,
-  userAvatar: null
-}
+  userAvatar: null,
+  recentFiles: [],
+  waitingForParticipantUnlock: [],
+  youCanUnlock: []
+})
 
-const f2: Folder = {
-  path: '/keybase/private/cecileb,jeresig,throughnothing',
+const f2: Folder = createFolder({
   users: [
     {username: 'cecileb', you: true},
     {username: 'jeresig', broken: true},
@@ -54,14 +60,15 @@ const f2: Folder = {
   },
   ignored: false,
   isPublic: false,
-  isFirst: false,
   hasData: true,
   groupAvatar: true,
-  userAvatar: null
-}
+  userAvatar: null,
+  recentFiles: [],
+  waitingForParticipantUnlock: [],
+  youCanUnlock: []
+})
 
-const f3: Folder = {
-  path: '/keybase/private/cecileb,bob',
+const f3: Folder = createFolder({
   users: [
     {username: 'cecileb', you: true},
     {username: 'bob'}
@@ -72,38 +79,42 @@ const f3: Folder = {
   },
   ignored: false,
   isPublic: false,
-  isFirst: false,
   hasData: true,
   groupAvatar: false,
-  userAvatar: 'bob'
-}
+  userAvatar: 'bob',
+  recentFiles: [],
+  waitingForParticipantUnlock: [],
+  youCanUnlock: []
+})
 
-const f4: Folder = {
-  path: '/keybase/private/cecileb,jenbee',
+const f4: Folder = createFolder({
   users: [
     {username: 'cecileb', you: true},
     {username: 'jenbee'}
   ],
   ignored: false,
   isPublic: false,
-  isFirst: false,
   hasData: false,
   groupAvatar: false,
-  userAvatar: 'jenbee'
-}
+  userAvatar: 'jenbee',
+  recentFiles: [],
+  waitingForParticipantUnlock: [],
+  youCanUnlock: []
+})
 
-const f5: Folder = {
-  path: '/keybase/private/cecileb',
+const f5: Folder = createFolder({
   users: [
     {username: 'cecileb', you: true}
   ],
   ignored: false,
   isPublic: false,
-  isFirst: false,
   hasData: true,
   groupAvatar: false,
-  userAvatar: 'cecileb'
-}
+  userAvatar: 'cecileb',
+  recentFiles: [],
+  waitingForParticipantUnlock: [],
+  youCanUnlock: []
+})
 
 const f6: Folder = {
   path: '/keybase/private/cecileb,jenbeeb',
@@ -117,13 +128,15 @@ const f6: Folder = {
   isFirst: false,
   hasData: false,
   groupAvatar: false,
-  userAvatar: 'jenbee'
+  userAvatar: 'jenbee',
+  recentFiles: [],
+  waitingForParticipantUnlock: [],
+  youCanUnlock: []
 }
 
 const tlfs: Array<Folder> = [f1, f2, f3, f4, f5, f6]
 
-const i1: Folder = {
-  path: '/keybase/private/cecileb,jeresig,cdixon',
+const i1: Folder = createFolder({
   users: [
     {username: 'cecileb', you: true},
     {username: 'jeresig', broken: true},
@@ -131,25 +144,28 @@ const i1: Folder = {
   ],
   ignored: true,
   isPublic: false,
-  isFirst: true,
   hasData: true,
   groupAvatar: true,
-  userAvatar: null
-}
+  userAvatar: null,
+  recentFiles: [],
+  waitingForParticipantUnlock: [],
+  youCanUnlock: []
+})
 
-const i2: Folder = {
-  path: '/keybase/private/cecileb,jeresig',
+const i2: Folder = createFolder({
   users: [
     {username: 'cecileb', you: true},
     {username: 'jeresig', broken: true}
   ],
   ignored: true,
   isPublic: false,
-  isFirst: true,
   hasData: false,
   groupAvatar: false,
-  userAvatar: 'jeresig'
-}
+  userAvatar: 'jeresig',
+  recentFiles: [],
+  waitingForParticipantUnlock: [],
+  youCanUnlock: []
+})
 
 const ignored: Array<Folder> = [i1, i2]
 
@@ -275,7 +291,7 @@ const filesMenuItems = [
   {...popupItemCommon, title: 'Delete files and clear history (5.17GB)', subTitle: 'Deletes everything in this folder, including its backup versions', danger: true}
 ]
 
-const commonFiles = isPrivate => ({
+const commonFiles = (isPrivate): FilesProps => ({ // eslint-disable-line arrow-parens
   theme: isPrivate ? 'private' : 'public',
   visiblePopupMenu: false,
   popupMenuItems: filesMenuItems,
@@ -287,11 +303,13 @@ const commonFiles = isPrivate => ({
   youCanUnlock: [],
   onBack: () => console.log('onBack:files'),
   openCurrentFolder: () => console.log('open current folder'),
+  ignoreCurrentFolder: () => console.log('ignore current folder'),
   onTogglePopupMenu: () => console.log('onTogglePopupMenu'),
   recentFilesSection: [
     {name: 'Today', modifiedMarker: true, files: genFiles(0, 4, isPrivate)},
     {name: 'Yesterday', modifiedMarker: false, files: genFiles(4, 4, isPrivate)}
-  ]
+  ],
+  recentFilesEnabled: true
 })
 
 const commonParticipant = {
@@ -354,6 +372,16 @@ export const files: DumbComponentMap<Files> = {
     'You can unlock - Private': {
       ...commonFiles(true),
       ...commonUnlock
+    },
+    'Recent Files Disabled - Private': {
+      ...commonFiles(true),
+      recentFilesSection: undefined,
+      recentFilesEnabled: false
+    },
+    'Recent Files Disabled - Public': {
+      ...commonFiles(false),
+      recentFilesSection: undefined,
+      recentFilesEnabled: false
     }
   }
 }

--- a/shared/folders/files/index.js
+++ b/shared/folders/files/index.js
@@ -1,14 +1,98 @@
 // @flow
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
-import {Text} from '../../common-adapters'
+import {bindActionCreators} from 'redux'
+import {openInKBFS} from '../../actions/kbfs'
+import {ignoreFolder} from '../../actions/favorite'
+import {navigateBack} from '../../actions/router'
+import flags from '../../util/feature-flags'
+import Render from './render'
+import _ from 'lodash'
 
-// import Render from './render'
+import type {Folder} from '../list'
 
-class Files extends Component {
+type Props = $Shape<{
+  folder: ?Folder,
+  path: string,
+  username: string,
+  navigateBack: () => void,
+  ignoreFolder: (path: string) => void,
+  openInKBFS: (path: string) => void
+}>
+
+type State = {
+  visiblePopupMenu: boolean
+};
+
+class Files extends Component<void, Props, State> {
+  state: State;
+
+  _checkFolderExistence (props) {
+    // TODO (AW): make a more user friendly response for when the folder they were hoping to look at
+    // has been removed/defavorited in the time between them clicking it in the Folders view and the
+    // loading of this component
+    if (!props.folder) props.navigateBack()
+  }
+
+  constructor (props) {
+    super(props)
+    this.state = {
+      visiblePopupMenu: false
+    }
+    this._checkFolderExistence(props)
+  }
+
+  componentWillReceiveProps (nextProps) {
+    this._checkFolderExistence(nextProps)
+  }
+
   render () {
-    return <Text type='Body'>TODO</Text>
+    const {folder, username} = this.props
+    if (!folder) return null // Protect from state where the folder to be displayed was removed
+    const openCurrentFolder = () => { this.props.openInKBFS(this.props.path) }
+    const ignoreCurrentFolder = () => { this.props.ignoreFolder(this.props.path) }
+    return (
+      <Render
+        theme={folder.isPublic ? 'public' : 'private'}
+        popupMenuItems={[
+          {onClick: openCurrentFolder, title: 'Open folder'},
+          {onClick: ignoreCurrentFolder, title: 'Ignore'}
+        ]}
+        visiblePopupMenu={this.state.visiblePopupMenu}
+        onTogglePopupMenu={() => this.setState({visiblePopupMenu: !this.state.visiblePopupMenu})}
+        selfUsername={username}
+        users={folder.users}
+        waitingForParticipantUnlock={folder.waitingForParticipantUnlock}
+        youCanUnlock={folder.youCanUnlock}
+        onBack={() => this.props.navigateBack()}
+        openCurrentFolder={openCurrentFolder}
+        ignoreCurrentFolder={ignoreCurrentFolder}
+        recentFilesSection={folder.recentFiles} // TODO (AW): integrate recent files once the service provides this data
+        recentFilesEnabled={flags.recentFilesEnabled}
+      />
+    )
+  }
+
+  static parseRoute (currentPath, uri) {
+    return {
+      componentAtTop: {
+        title: 'Files',
+        element: <ConnectedFiles path={currentPath.get('path')} />
+      }
+    }
   }
 }
 
-export default connect()(Files)
+const ConnectedFiles = connect(
+  (state, ownProps) => {
+    const folders: Array<Folder> = [].concat(_.get(state, 'favorite.folders.private.tlfs'), _.get(state, 'favorite.folders.public.tlfs'))
+    const folder = folders.find(f => f.path === ownProps.path)
+    return {
+      folder,
+      username: state.config && state.config.username
+    }
+  },
+  dispatch => bindActionCreators({openInKBFS, ignoreFolder, navigateBack}, dispatch)
+)(Files)
+
+export default ConnectedFiles

--- a/shared/folders/files/render.desktop.js
+++ b/shared/folders/files/render.desktop.js
@@ -64,8 +64,18 @@ const YouCanUnlock = ({youCanUnlock, isPrivate, backgroundMode}) => {
 }
 
 export default class Render extends Component<void, Props, void> {
+
   _renderContents (isPrivate: boolean) {
     const backgroundMode = isPrivate ? 'Terminal' : 'Normal'
+
+    if (!this.props.recentFilesEnabled) {
+      return (
+        <Box style={{...styleRecentFilesNotEnabled}}>
+          <Button type='Secondary' onClick={this.props.ignoreCurrentFolder} label='Ignore folder' />
+          <Button type='Primary' onClick={this.props.openCurrentFolder} label='Open folder' />
+        </Box>
+      )
+    }
 
     if (this.props.youCanUnlock.length) {
       return <YouCanUnlock youCanUnlock={this.props.youCanUnlock} isPrivate={isPrivate} backgroundMode={backgroundMode} />
@@ -98,7 +108,7 @@ export default class Render extends Component<void, Props, void> {
     const tlfTextStyle = styleTLFTextThemed[this.props.theme]
 
     return (
-      <Box style={{...globalStyles.flexBoxColumn, position: 'relative', backgroundColor: backgroundColorThemed[this.props.theme]}}>
+      <Box style={{...globalStyles.flexBoxColumn, flex: 1, position: 'relative', backgroundColor: backgroundColorThemed[this.props.theme]}}>
         <Box style={{...globalStyles.flexBoxRow, ...styleHeaderThemed[this.props.theme], height: 48}}>
           <BackButton onClick={this.props.onBack} style={{marginLeft: 16}}
             iconStyle={{color: backButtonColor}} textStyle={{color: backButtonColor}} />
@@ -183,6 +193,14 @@ const styleMenu = {
 const backButtonColorThemed = {
   'private': globalColors.white,
   'public': globalColors.white
+}
+
+const styleRecentFilesNotEnabled = {
+  ...globalStyles.flexBoxRow,
+  flex: 1,
+  justifyContent: 'center',
+  alignItems: 'center',
+  padding: 64
 }
 
 const styleNoFiles = {

--- a/shared/folders/files/render.js.flow
+++ b/shared/folders/files/render.js.flow
@@ -33,7 +33,9 @@ export type Props = {
   onBack: () => void,
   onTogglePopupMenu: () => void,
   recentFilesSection: Array<FileSection>,
+  recentFilesEnabled: boolean, // TODO (AW): remove when recentFiles feature is finished
   openCurrentFolder: () => void,
+  ignoreCurrentFolder: () => void,
   waitingForParticipantUnlock: Array<ParticipantUnlock>,
   youCanUnlock: Array<UnlockDevice>
 }

--- a/shared/folders/files/render.native.js
+++ b/shared/folders/files/render.native.js
@@ -42,12 +42,24 @@ export default class Render extends Component<void, Props, void> {
     return contents
   }
 
+  _renderContents (isPrivate: boolean) {
+    if (!this.props.recentFilesEnabled) {
+      return (
+        <Box style={{...globalStyles.flexBoxColumn, flex: 1, justifyContent: 'center', alignItems: 'center', padding: 8}}>
+          <Text type='BodySmall' backgroundMode={isPrivate ? 'Terminal' : 'Normal'}>File History has not been implemented yet.</Text>
+        </Box>
+      )
+    } else {
+      return <ScrollView>{this.props.recentFilesSection.map(s => this._renderSection(s))}</ScrollView>
+    }
+  }
+
   render () {
     const isPrivate = this.props.theme === 'private'
     const tlfTextStyle = styleTLFTextThemed[this.props.theme]
 
     return (
-      <Box style={{...globalStyles.flexBoxColumn, position: 'relative', backgroundColor: backgroundColorThemed[this.props.theme]}}>
+      <Box style={{...globalStyles.flexBoxColumn, flex: 1, position: 'relative', backgroundColor: backgroundColorThemed[this.props.theme]}}>
         {this._renderHeader()}
         <Box style={{...globalStyles.flexBoxColumn, ...styleTLFHeader, ...styleTLFHeaderThemed[this.props.theme]}}>
           <Box style={{...globalStyles.flexBoxRow, height: 0, justifyContent: 'center', position: 'relative', bottom: 16}}>
@@ -58,12 +70,8 @@ export default class Render extends Component<void, Props, void> {
             <Usernames users={this.props.users} type='BodySemibold' style={tlfTextStyle} />
           </Box>
         </Box>
-        <ScrollView>
-            {this.props.recentFilesSection.map(s => this._renderSection(s))}
-        </ScrollView>
-
+        {this._renderContents(isPrivate)}
       </Box>
-
     )
   }
 }

--- a/shared/folders/index.js
+++ b/shared/folders/index.js
@@ -2,9 +2,15 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import Render from './render'
-import flags from '../util/feature-flags'
+import {bindActionCreators} from 'redux'
+import {routeAppend} from '../actions/router'
+import Files from './files'
+import type {Props as RenderProps} from './render'
 
-type Props = {}
+export type Props = {
+  folderProps: ?RenderProps,
+  routeAppend: (path: any) => void
+}
 
 type State = {
   showingPrivate: boolean
@@ -21,22 +27,27 @@ class Folders extends Component<void, Props, State> {
   }
 
   render () {
-    return <Render
-      onRekey={() => {}}
-      smallMode={false}
-      showComingSoon={!flags.tabFoldersEnabled}
-      privateBadge={0}
-      private={{isPublic: false}}
-      publicBadge={0}
-      public={{isPublic: true}}
-      onSwitchTab={showingPrivate => this.setState({showingPrivate})}
-      showingPrivate={this.state.showingPrivate}
+    return (
+      <Render
+        {...this.props.folderProps}
+        onClick={path => this.props.routeAppend(path)}
+        onSwitchTab={showingPrivate => this.setState({showingPrivate})}
+        showingPrivate={this.state.showingPrivate}
       />
+    )
   }
 
   static parseRoute () {
-    return {componentAtTop: {title: 'Folders'}}
+    return {
+      componentAtTop: {title: 'Folders'},
+      parseNextRoute: Files.parseRoute
+    }
   }
 }
 
-export default connect()(Folders)
+export default connect(
+  state => ({
+    folderProps: state.favorite && state.favorite.folders
+  }),
+  dispatch => bindActionCreators({routeAppend}, dispatch)
+)(Folders)

--- a/shared/folders/list.js.flow
+++ b/shared/folders/list.js.flow
@@ -1,6 +1,7 @@
 /* @flow */
 
 import type {UserList} from '../common-adapters/usernames'
+import type {FileSection, ParticipantUnlock, UnlockDevice} from './files/render'
 
 export type Folder = {
   users: UserList,
@@ -12,10 +13,13 @@ export type Folder = {
   },
   isPublic: boolean,
   ignored: boolean,
-  isFirst: boolean,
   hasData: boolean,
   groupAvatar: boolean,
-  userAvatar: ?string
+  userAvatar: ?string,
+  path: string,
+  recentFiles: Array<FileSection>, // TODO make pure
+  waitingForParticipantUnlock: Array<ParticipantUnlock>, // TODO make pure
+  youCanUnlock: Array<UnlockDevice> // TODO make pure
 }
 
 export type Props = {

--- a/shared/folders/row.native.js
+++ b/shared/folders/row.native.js
@@ -76,7 +76,7 @@ const RowMeta = ({ignored, meta, styles}) => {
   return <Meta {...metaProps} />
 }
 
-const Row = ({users, isPublic, ignored, isFirst, meta, modified, hasData}: Folder) => {
+const Row = ({users, isPublic, ignored, isFirst, meta, modified, hasData, path}: Folder & {isFirst: boolean}) => {
   const styles = isPublic ? stylesPublic : stylesPrivate
 
   const containerStyle = {

--- a/shared/util/feature-flags.desktop.js
+++ b/shared/util/feature-flags.desktop.js
@@ -20,7 +20,8 @@ const ff: FeatureFlags = {
   tabFoldersEnabled: featureOn('tabFoldersEnabled'),
   tabSettingsEnabled: featureOn('tabSettingsEnabled'),
   tabProfileEnabled: featureOn('tabProfileEnabled'),
-  searchEnabled: featureOn('searchEnabled')
+  searchEnabled: featureOn('searchEnabled'),
+  recentFilesEnabled: featureOn('recentFilesEnabled')
 }
 
 if (__DEV__) {

--- a/shared/util/feature-flags.js.flow
+++ b/shared/util/feature-flags.js.flow
@@ -1,7 +1,7 @@
 /* @flow */
 
 export type FeatureKeys = 'admin' | 'mainWindow' | 'mobileAppsExist' | 'tabPeopleEnabled' | 'tabFoldersEnabled'
-| 'tabSettingsEnabled' | 'tabProfileEnabled' | 'searchEnabled'
+| 'tabSettingsEnabled' | 'tabProfileEnabled' | 'searchEnabled' | 'recentFilesEnabled'
 
 export type FeatureFlags = {[key: FeatureKeys]: boolean}
 


### PR DESCRIPTION
Connect the Files and Folders component to the favorite store, with some props refactoring to fix hidden flow errors that lodash methods were silencing (thanks @MarcoPolo).

Implement a feature flag for displaying recentFiles in the File component. If the feature flag is turned off then two buttons are shown: 'Open folder' and 'Ignore folder'. Open folder will launch a Finder/Explorer/Linux-thing window to browse the folder, and Ignore folder currently just prints a todo statement to the console.

![screen shot 2016-06-07 at 2 40 58 pm](https://cloud.githubusercontent.com/assets/1152104/15875653/f40d9096-2cbd-11e6-959d-849047e20b27.png)
![screen shot 2016-06-07 at 2 41 03 pm](https://cloud.githubusercontent.com/assets/1152104/15875659/fe8400aa-2cbd-11e6-98d3-a2d81f531cad.png)
![screen shot 2016-06-07 at 2 41 15 pm](https://cloud.githubusercontent.com/assets/1152104/15875661/02244b66-2cbe-11e6-81b7-166474d7ad13.png)
![screen shot 2016-06-07 at 2 41 19 pm](https://cloud.githubusercontent.com/assets/1152104/15875664/04736046-2cbe-11e6-8774-c334929d19e6.png)
