### PR TITLE
have the linux build use $release_bin wait-ci

### DIFF
--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -90,6 +90,7 @@ if [ -n "$kbfs_commit" ]; then
   git checkout "$kbfs_commit"
 fi
 
+# NB: This is duplicated in packaging/linux/build_and_push_packages.sh.
 if [ ! "$nowait" = "1" ]; then
   echo "Checking client CI"
   "$release_bin" wait-ci --repo="client" --commit=`git -C $client_dir log -1 --pretty=format:%h` --context="client-windows-master-only/label=windows" --context="client-linux-master-only/label=master" --context="client-osx-master-only/label=osx" --context="ci/circleci"


### PR DESCRIPTION
r? @cjb @gabriel 

Please take a look in particular at whether I've done the right thing with the `--context` flags. I copied what was in the OSX build (minus the updater tests), but this stuff sounds like it's been changing recently?