### PR TITLE
Set the tab bar content container as display flex

### DIFF
--- a/shared/tab-bar/index.render.desktop.js
+++ b/shared/tab-bar/index.render.desktop.js
@@ -98,7 +98,7 @@ export default class Render extends Component<void, Props, void> {
         <TabBarItem
           key={t} tabBarButton={button}
           selected={this.props.selectedTab === t} onClick={onClick} containerStyle={{...stylesTabBarItem, ...(isProfile && {flex: 2, justifyContent: 'flex-end'})}}>
-          <Box style={{overflow: 'scroll', flex: 1}}>{this.props.tabContent[t]}</Box>
+          <Box style={{overflow: 'auto', flex: 1, ...globalStyles.flexBoxColumn}}>{this.props.tabContent[t]}</Box>
         </TabBarItem>
       )
     })


### PR DESCRIPTION
Set the tab bar content container to display flex so that it's children can properly fill up the entire view. Thanks @MarcoPolo.

Overflow:scroll was also changed to overflow: auto in order to ensure
that scroll bars are only shown on the tab content container when
necessary.

@keybase/react-hackers 

This is now possible:
![screen shot 2016-06-07 at 4 34 27 pm](https://cloud.githubusercontent.com/assets/1152104/15878171/c06cf1f4-2ccd-11e6-8042-3ec0e2133f6a.png)
