### PR TITLE
env var for local debug stuff

### DIFF
--- a/shared/local-debug.desktop.js
+++ b/shared/local-debug.desktop.js
@@ -44,6 +44,15 @@ if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) {
   config.focusOnShow = false
   config.dumbFilter = ''
   config.printRoutes = true
+
+  let envJson = null
+  try {
+    envJson = JSON.parse(process.env.KEYBASE_LOCAL_DEBUG_JSON)
+  } catch (e) {
+    console.warn('Invalid KEYBASE_LOCAL_DEBUG_JSON:', e)
+  }
+
+  config = {...config, ...envJson}
 }
 
 config = updateConfig(config)


### PR DESCRIPTION
@keybase/react-hackers let's stop accidentally checking in the local-debug file. instead lets use an env var for our quick local changes:

```
KEYBASE_LOCAL_DEBUG_JSON="{\"dumbFilter\":\"folders\"}"
npm run start-hot
```