### PR TITLE
Fix flow error

### DIFF
--- a/shared/folders/row.native.js
+++ b/shared/folders/row.native.js
@@ -7,9 +7,11 @@ import type {Props as IconProps} from '../common-adapters/icon'
 import {globalStyles, globalColors} from '../styles/style-guide'
 
 const Avatars = ({styles, users, isPublic}) => {
+  // TODO (MM) fix type
+  const groupIcon: any = styles.groupIcon
   const contents = users.length === 1 || users.length === 2
       ? <Avatar size={32} username={users[users.length - 1].username} />
-      : <Icon type={styles.groupIcon} />
+      : <Icon type={groupIcon} />
 
   if (isPublic) {
     return <Box style={styles.avatarContainer}>{contents}</Box>


### PR DESCRIPTION
@keybase/react-hackers 

quick fix to fix flow errors on master.

TODO fix this properly.

it also seems that with the new version of flow doing IconProps.type just turns into `any` so we should probably export a new `IconType`