### PR TITLE
changes the favorites API to return favorites+ignored+new

### DIFF
--- a/go/client/cmd_favorite_list.go
+++ b/go/client/cmd_favorite_list.go
@@ -47,7 +47,7 @@ func (c *CmdFavoriteList) Run() error {
 	if err != nil {
 		return err
 	}
-	for _, f := range result.Favorites {
+	for _, f := range result.FavoriteFolders {
 		acc := "public"
 		if f.Private {
 			acc = "private"

--- a/go/client/cmd_favorite_list.go
+++ b/go/client/cmd_favorite_list.go
@@ -42,12 +42,12 @@ func (c *CmdFavoriteList) GetUsage() libkb.Usage {
 }
 
 func (c *CmdFavoriteList) Run() error {
-	arg := keybase1.FavoriteListArg{}
-	folders, err := list(arg)
+	arg := keybase1.GetFavoritesArg{}
+	result, err := list(arg)
 	if err != nil {
 		return err
 	}
-	for _, f := range folders {
+	for _, f := range result.Favorites {
 		acc := "public"
 		if f.Private {
 			acc = "private"
@@ -57,10 +57,10 @@ func (c *CmdFavoriteList) Run() error {
 	return nil
 }
 
-func list(arg keybase1.FavoriteListArg) ([]keybase1.Folder, error) {
+func list(arg keybase1.GetFavoritesArg) (keybase1.FavoritesResult, error) {
 	cli, err := GetFavoriteClient()
 	if err != nil {
-		return nil, err
+		return keybase1.FavoritesResult{}, err
 	}
-	return cli.FavoriteList(context.TODO(), 0)
+	return cli.GetFavorites(context.TODO(), 0)
 }

--- a/go/client/cmd_favorite_remove.go
+++ b/go/client/cmd_favorite_remove.go
@@ -14,7 +14,7 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol"
 )
 
-type CmdFavoriteDelete struct {
+type CmdFavoriteRemove struct {
 	folder keybase1.Folder
 }
 
@@ -24,23 +24,26 @@ func NewCmdFavoriteRemove(cl *libcmdline.CommandLine) cli.Command {
 		ArgumentHelp: "<folder-name>",
 		Usage:        "Remove a favorite",
 		Action: func(c *cli.Context) {
-			cl.ChooseCommand(&CmdFavoriteDelete{}, "remove", c)
+			cl.ChooseCommand(&CmdFavoriteRemove{}, "remove", c)
 		},
 	}
 }
 
-func (c *CmdFavoriteDelete) Run() error {
-	arg := keybase1.FavoriteDeleteArg{
+func (c *CmdFavoriteRemove) Run() error {
+	arg := keybase1.FavoriteIgnoreArg{
 		Folder: c.folder,
 	}
 	cli, err := GetFavoriteClient()
 	if err != nil {
 		return err
 	}
-	return cli.FavoriteDelete(context.TODO(), arg)
+	// The "remove" command becomes an "ignore" row in the database. If we
+	// actually deleted the row, it would make the folder in question appear
+	// "new" instead.
+	return cli.FavoriteIgnore(context.TODO(), arg)
 }
 
-func (c *CmdFavoriteDelete) ParseArgv(ctx *cli.Context) error {
+func (c *CmdFavoriteRemove) ParseArgv(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
 		return errors.New("Favorite remove only takes one argument, the folder name.")
 	}
@@ -52,7 +55,7 @@ func (c *CmdFavoriteDelete) ParseArgv(ctx *cli.Context) error {
 	return nil
 }
 
-func (c *CmdFavoriteDelete) GetUsage() libkb.Usage {
+func (c *CmdFavoriteRemove) GetUsage() libkb.Usage {
 	return libkb.Usage{
 		Config: true,
 		API:    true,

--- a/go/engine/favorite_ignore.go
+++ b/go/engine/favorite_ignore.go
@@ -10,53 +10,54 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol"
 )
 
-// FavoriteDelete is an engine.
-type FavoriteDelete struct {
-	arg *keybase1.FavoriteDeleteArg
+// FavoriteIgnore is an engine.
+type FavoriteIgnore struct {
+	arg *keybase1.FavoriteIgnoreArg
 	libkb.Contextified
 }
 
-// NewFavoriteDelete creates a FavoriteDelete engine.
-func NewFavoriteDelete(arg *keybase1.FavoriteDeleteArg, g *libkb.GlobalContext) *FavoriteDelete {
-	return &FavoriteDelete{
+// NewFavoriteIgnore creates a FavoriteIgnore engine.
+func NewFavoriteIgnore(arg *keybase1.FavoriteIgnoreArg, g *libkb.GlobalContext) *FavoriteIgnore {
+	return &FavoriteIgnore{
 		arg:          arg,
 		Contextified: libkb.NewContextified(g),
 	}
 }
 
 // Name is the unique engine name.
-func (e *FavoriteDelete) Name() string {
-	return "FavoriteDelete"
+func (e *FavoriteIgnore) Name() string {
+	return "FavoriteIgnore"
 }
 
 // GetPrereqs returns the engine prereqs.
-func (e *FavoriteDelete) Prereqs() Prereqs {
+func (e *FavoriteIgnore) Prereqs() Prereqs {
 	return Prereqs{
 		Device: true,
 	}
 }
 
 // RequiredUIs returns the required UIs.
-func (e *FavoriteDelete) RequiredUIs() []libkb.UIKind {
+func (e *FavoriteIgnore) RequiredUIs() []libkb.UIKind {
 	return []libkb.UIKind{}
 }
 
 // SubConsumers returns the other UI consumers for this engine.
-func (e *FavoriteDelete) SubConsumers() []libkb.UIConsumer {
+func (e *FavoriteIgnore) SubConsumers() []libkb.UIConsumer {
 	return nil
 }
 
 // Run starts the engine.
-func (e *FavoriteDelete) Run(ctx *Context) error {
+func (e *FavoriteIgnore) Run(ctx *Context) error {
 	if e.arg == nil {
-		return fmt.Errorf("FavoriteDelete arg is nil")
+		return fmt.Errorf("FavoriteIgnore arg is nil")
 	}
 	_, err := e.G().API.Post(libkb.APIArg{
-		Endpoint:    "kbfs/favorite/delete",
+		Endpoint:    "kbfs/favorite/add",
 		NeedSession: true,
 		Args: libkb.HTTPArgs{
 			"tlf_name": libkb.S{Val: e.arg.Folder.Name},
 			"private":  libkb.B{Val: e.arg.Folder.Private},
+			"status":   libkb.S{Val: "ignored"},
 		},
 	})
 	return err

--- a/go/engine/favorite_list.go
+++ b/go/engine/favorite_list.go
@@ -66,9 +66,8 @@ func (e *FavoriteList) Run(ctx *Context) error {
 // Favorites returns the list of favorites that Run generated.
 func (e *FavoriteList) Result() keybase1.FavoritesResult {
 	return keybase1.FavoritesResult{
-		Favorites: e.result.Favorites,
-		Ignored:   e.result.Ignored,
-		// The name "new" is illegal in ObjC. "X" is just a filler character.
-		Xnew: e.result.New,
+		FavoriteFolders: e.result.Favorites,
+		IgnoredFolders:  e.result.Ignored,
+		NewFolders:      e.result.New,
 	}
 }

--- a/go/engine/favorite_list.go
+++ b/go/engine/favorite_list.go
@@ -11,7 +11,7 @@ import (
 // FavoriteList is an engine.
 type FavoriteList struct {
 	libkb.Contextified
-	result FavoritesResult
+	result FavoritesAPIResult
 }
 
 // NewFavoriteList creates a FavoriteList engine.
@@ -43,13 +43,14 @@ func (e *FavoriteList) SubConsumers() []libkb.UIConsumer {
 	return nil
 }
 
-type FavoritesResult struct {
+type FavoritesAPIResult struct {
 	Status    libkb.AppStatus   `json:"status"`
 	Favorites []keybase1.Folder `json:"favorites"`
 	Ignored   []keybase1.Folder `json:"ignored"`
+	New       []keybase1.Folder `json:"new"`
 }
 
-func (f *FavoritesResult) GetAppStatus() *libkb.AppStatus {
+func (f *FavoritesAPIResult) GetAppStatus() *libkb.AppStatus {
 	return &f.Status
 }
 
@@ -63,6 +64,11 @@ func (e *FavoriteList) Run(ctx *Context) error {
 }
 
 // Favorites returns the list of favorites that Run generated.
-func (e *FavoriteList) Favorites() []keybase1.Folder {
-	return e.result.Favorites
+func (e *FavoriteList) Result() keybase1.FavoritesResult {
+	return keybase1.FavoritesResult{
+		Favorites: e.result.Favorites,
+		Ignored:   e.result.Ignored,
+		// The name "new" is illegal in ObjC. "X" is just a filler character.
+		Xnew: e.result.New,
+	}
 }

--- a/go/engine/favorite_test.go
+++ b/go/engine/favorite_test.go
@@ -133,7 +133,7 @@ func TestFavoriteList(t *testing.T) {
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
-	favs := eng.Result().Favorites
+	favs := eng.Result().FavoriteFolders
 	if len(favs) != 2 {
 		t.Fatalf("num favs: %d, expected 2", len(favs))
 	}
@@ -179,5 +179,5 @@ func listfav(tc libkb.TestContext) []keybase1.Folder {
 	if err != nil {
 		tc.T.Fatal(err)
 	}
-	return eng.Result().Favorites
+	return eng.Result().FavoriteFolders
 }

--- a/go/engine/favorite_test.go
+++ b/go/engine/favorite_test.go
@@ -99,7 +99,7 @@ func TestFavoriteAddSocial(t *testing.T) {
 	}
 }
 
-func TestFavoriteDelete(t *testing.T) {
+func TestFavoriteIgnore(t *testing.T) {
 	tc := SetupEngineTest(t, "template")
 	defer tc.Cleanup()
 	CreateAndSignupFakeUser(tc, "fav")
@@ -133,7 +133,7 @@ func TestFavoriteList(t *testing.T) {
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
-	favs := eng.Favorites()
+	favs := eng.Result().Favorites
 	if len(favs) != 2 {
 		t.Fatalf("num favs: %d, expected 2", len(favs))
 	}
@@ -162,10 +162,10 @@ func addfav(name string, private, created bool, idUI libkb.IdentifyUI, tc libkb.
 
 func rmfav(name string, private bool, tc libkb.TestContext) {
 	ctx := &Context{}
-	arg := keybase1.FavoriteDeleteArg{
+	arg := keybase1.FavoriteIgnoreArg{
 		Folder: keybase1.Folder{Name: name, Private: private},
 	}
-	eng := NewFavoriteDelete(&arg, tc.G)
+	eng := NewFavoriteIgnore(&arg, tc.G)
 	err := RunEngine(eng, ctx)
 	if err != nil {
 		tc.T.Fatal(err)
@@ -179,5 +179,5 @@ func listfav(tc libkb.TestContext) []keybase1.Folder {
 	if err != nil {
 		tc.T.Fatal(err)
 	}
-	return eng.Favorites()
+	return eng.Result().Favorites
 }

--- a/go/protocol/favorite.go
+++ b/go/protocol/favorite.go
@@ -19,9 +19,9 @@ type Folder struct {
 }
 
 type FavoritesResult struct {
-	Favorites []Folder `codec:"favorites" json:"favorites"`
-	Ignored   []Folder `codec:"ignored" json:"ignored"`
-	Xnew      []Folder `codec:"xnew" json:"xnew"`
+	FavoriteFolders []Folder `codec:"favoriteFolders" json:"favoriteFolders"`
+	IgnoredFolders  []Folder `codec:"ignoredFolders" json:"ignoredFolders"`
+	NewFolders      []Folder `codec:"newFolders" json:"newFolders"`
 }
 
 type FavoriteAddArg struct {

--- a/go/protocol/favorite.go
+++ b/go/protocol/favorite.go
@@ -18,17 +18,23 @@ type Folder struct {
 	Created         bool   `codec:"created" json:"created"`
 }
 
+type FavoritesResult struct {
+	Favorites []Folder `codec:"favorites" json:"favorites"`
+	Ignored   []Folder `codec:"ignored" json:"ignored"`
+	Xnew      []Folder `codec:"xnew" json:"xnew"`
+}
+
 type FavoriteAddArg struct {
 	SessionID int    `codec:"sessionID" json:"sessionID"`
 	Folder    Folder `codec:"folder" json:"folder"`
 }
 
-type FavoriteDeleteArg struct {
+type FavoriteIgnoreArg struct {
 	SessionID int    `codec:"sessionID" json:"sessionID"`
 	Folder    Folder `codec:"folder" json:"folder"`
 }
 
-type FavoriteListArg struct {
+type GetFavoritesArg struct {
 	SessionID int `codec:"sessionID" json:"sessionID"`
 }
 
@@ -36,9 +42,9 @@ type FavoriteInterface interface {
 	// Adds a folder to a user's list of favorite folders.
 	FavoriteAdd(context.Context, FavoriteAddArg) error
 	// Removes a folder from a user's list of favorite folders.
-	FavoriteDelete(context.Context, FavoriteDeleteArg) error
+	FavoriteIgnore(context.Context, FavoriteIgnoreArg) error
 	// Returns all of a user's favorite folders.
-	FavoriteList(context.Context, int) ([]Folder, error)
+	GetFavorites(context.Context, int) (FavoritesResult, error)
 }
 
 func FavoriteProtocol(i FavoriteInterface) rpc.Protocol {
@@ -61,34 +67,34 @@ func FavoriteProtocol(i FavoriteInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"favoriteDelete": {
+			"favoriteIgnore": {
 				MakeArg: func() interface{} {
-					ret := make([]FavoriteDeleteArg, 1)
+					ret := make([]FavoriteIgnoreArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]FavoriteDeleteArg)
+					typedArgs, ok := args.(*[]FavoriteIgnoreArg)
 					if !ok {
-						err = rpc.NewTypeError((*[]FavoriteDeleteArg)(nil), args)
+						err = rpc.NewTypeError((*[]FavoriteIgnoreArg)(nil), args)
 						return
 					}
-					err = i.FavoriteDelete(ctx, (*typedArgs)[0])
+					err = i.FavoriteIgnore(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"favoriteList": {
+			"getFavorites": {
 				MakeArg: func() interface{} {
-					ret := make([]FavoriteListArg, 1)
+					ret := make([]GetFavoritesArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]FavoriteListArg)
+					typedArgs, ok := args.(*[]GetFavoritesArg)
 					if !ok {
-						err = rpc.NewTypeError((*[]FavoriteListArg)(nil), args)
+						err = rpc.NewTypeError((*[]GetFavoritesArg)(nil), args)
 						return
 					}
-					ret, err = i.FavoriteList(ctx, (*typedArgs)[0].SessionID)
+					ret, err = i.GetFavorites(ctx, (*typedArgs)[0].SessionID)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -108,14 +114,14 @@ func (c FavoriteClient) FavoriteAdd(ctx context.Context, __arg FavoriteAddArg) (
 }
 
 // Removes a folder from a user's list of favorite folders.
-func (c FavoriteClient) FavoriteDelete(ctx context.Context, __arg FavoriteDeleteArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.favorite.favoriteDelete", []interface{}{__arg}, nil)
+func (c FavoriteClient) FavoriteIgnore(ctx context.Context, __arg FavoriteIgnoreArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.favorite.favoriteIgnore", []interface{}{__arg}, nil)
 	return
 }
 
 // Returns all of a user's favorite folders.
-func (c FavoriteClient) FavoriteList(ctx context.Context, sessionID int) (res []Folder, err error) {
-	__arg := FavoriteListArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.favorite.favoriteList", []interface{}{__arg}, &res)
+func (c FavoriteClient) GetFavorites(ctx context.Context, sessionID int) (res FavoritesResult, err error) {
+	__arg := GetFavoritesArg{SessionID: sessionID}
+	err = c.Cli.Call(ctx, "keybase.1.favorite.getFavorites", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/favorite.go
+++ b/go/service/favorite.go
@@ -35,19 +35,19 @@ func (h *FavoriteHandler) FavoriteAdd(_ context.Context, arg keybase1.FavoriteAd
 	return engine.RunEngine(eng, ctx)
 }
 
-// FavoriteDelete handles the favoriteDelete RPC.
-func (h *FavoriteHandler) FavoriteDelete(_ context.Context, arg keybase1.FavoriteDeleteArg) error {
-	eng := engine.NewFavoriteDelete(&arg, h.G())
+// FavoriteIgnore handles the favoriteIgnore RPC.
+func (h *FavoriteHandler) FavoriteIgnore(_ context.Context, arg keybase1.FavoriteIgnoreArg) error {
+	eng := engine.NewFavoriteIgnore(&arg, h.G())
 	ctx := &engine.Context{}
 	return engine.RunEngine(eng, ctx)
 }
 
 // FavoriteList handles the favoriteList RPC.
-func (h *FavoriteHandler) FavoriteList(_ context.Context, sessionID int) ([]keybase1.Folder, error) {
+func (h *FavoriteHandler) GetFavorites(_ context.Context, sessionID int) (keybase1.FavoritesResult, error) {
 	eng := engine.NewFavoriteList(h.G())
 	ctx := &engine.Context{}
 	if err := engine.RunEngine(eng, ctx); err != nil {
-		return nil, err
+		return keybase1.FavoritesResult{}, err
 	}
-	return eng.Favorites(), nil
+	return eng.Result(), nil
 }

--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -28,10 +28,11 @@ go-build-stamp: avdl/*.avdl $(AVDLC) | config
 	(cd ../go/protocol && go fmt ./...)
 	date > $@
 
-objc-build-stamp: build-stamp | config
-	@ # Runs without generating files (to validate)
-	ruby ./bin/objc.rb
-	date > $@
+# We no longer build an objc client
+# objc-build-stamp: build-stamp | config
+	# @ # Runs without generating files (to validate)
+	# ruby ./bin/objc.rb
+	# date > $@
 
 js/flow-types.js: build-stamp | config
 	@mkdir -p js/
@@ -55,6 +56,6 @@ clean:
 fmt:
 	@./fmt.sh
 
-build: fmt build-stamp go-build-stamp js/keybase_v1.js js/flow-types.js objc-build-stamp swift-build-stamp
+build: fmt build-stamp go-build-stamp js/keybase_v1.js js/flow-types.js swift-build-stamp
 
 .PHONY: test config

--- a/protocol/avdl/favorite.avdl
+++ b/protocol/avdl/favorite.avdl
@@ -15,6 +15,17 @@ protocol favorite {
     boolean created;          // this folder was just created by this user
   }
 
+  // Each of your TLFs is in one of 3 states with respect to favoriting. Either
+  // you've favorited it, or you've ignored it, or you haven't done either of
+  // those things yet ("new"). The favorite/list endpoint returns 3 lists,
+  // representing all the TLFs you have in each of those 3 states, and we
+  // marshall that result into this struct.
+  record FavoritesResult {
+    array<Folder> favorites;
+    array<Folder> ignored;
+    array<Folder> xnew;  // "new" is an illegal variable prefix in ObjC :p
+  }
+
   /**
     Adds a folder to a user's list of favorite folders.
     */
@@ -23,10 +34,10 @@ protocol favorite {
   /**
     Removes a folder from a user's list of favorite folders.
     */
-  void favoriteDelete(int sessionID, Folder folder);
+  void favoriteIgnore(int sessionID, Folder folder);
 
   /**
     Returns all of a user's favorite folders.
     */
-  array<Folder> favoriteList(int sessionID);
+  FavoritesResult getFavorites(int sessionID);
 }

--- a/protocol/avdl/favorite.avdl
+++ b/protocol/avdl/favorite.avdl
@@ -21,9 +21,9 @@ protocol favorite {
   // representing all the TLFs you have in each of those 3 states, and we
   // marshall that result into this struct.
   record FavoritesResult {
-    array<Folder> favorites;
-    array<Folder> ignored;
-    array<Folder> xnew;  // "new" is an illegal variable prefix in ObjC :p
+    array<Folder> favoriteFolders;
+    array<Folder> ignoredFolders;
+    array<Folder> newFolders;
   }
 
   /**

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -252,6 +252,12 @@ export type FSStatusCode =
   | 1 // FINISH_1
   | 2 // ERROR_2
 
+export type FavoritesResult = {
+  favorites: Array<Folder>;
+  ignored: Array<Folder>;
+  xnew: Array<Folder>;
+}
+
 export type Feature = {
   allow: boolean;
   defaultValue: boolean;
@@ -1758,10 +1764,10 @@ export type favoriteFavoriteAddRpc = {
   callback: (null | (err: ?any) => void)
 }
 
-export type favoriteFavoriteDeleteResult = void
+export type favoriteFavoriteIgnoreResult = void
 
-export type favoriteFavoriteDeleteRpc = {
-  method: 'favorite.favoriteDelete',
+export type favoriteFavoriteIgnoreRpc = {
+  method: 'favorite.favoriteIgnore',
   param: {
     folder: Folder
   },
@@ -1769,12 +1775,12 @@ export type favoriteFavoriteDeleteRpc = {
   callback: (null | (err: ?any) => void)
 }
 
-export type favoriteFavoriteListResult = Array<Folder>
+export type favoriteGetFavoritesResult = FavoritesResult
 
-export type favoriteFavoriteListRpc = {
-  method: 'favorite.favoriteList',
+export type favoriteGetFavoritesRpc = {
+  method: 'favorite.getFavorites',
   incomingCallMap?: incomingCallMapType,
-  callback: (null | (err: ?any, response: favoriteFavoriteListResult) => void)
+  callback: (null | (err: ?any, response: favoriteGetFavoritesResult) => void)
 }
 
 export type gpgUiConfirmDuplicateKeyChosenResult = boolean
@@ -3518,8 +3524,8 @@ export type rpc =
   | deviceDeviceHistoryListRpc
   | deviceDeviceListRpc
   | favoriteFavoriteAddRpc
-  | favoriteFavoriteDeleteRpc
-  | favoriteFavoriteListRpc
+  | favoriteFavoriteIgnoreRpc
+  | favoriteGetFavoritesRpc
   | gpgUiConfirmDuplicateKeyChosenRpc
   | gpgUiSelectKeyAndPushOptionRpc
   | gpgUiSelectKeyRpc
@@ -4073,7 +4079,7 @@ export type incomingCallMapType = {
       result: () => void
     }
   ) => void,
-  'keybase.1.favorite.favoriteDelete'?: (
+  'keybase.1.favorite.favoriteIgnore'?: (
     params: {
       sessionID: int,
       folder: Folder
@@ -4083,13 +4089,13 @@ export type incomingCallMapType = {
       result: () => void
     }
   ) => void,
-  'keybase.1.favorite.favoriteList'?: (
+  'keybase.1.favorite.getFavorites'?: (
     params: {
       sessionID: int
     },
     response: {
       error: (err: RPCError) => void,
-      result: (result: favoriteFavoriteListResult) => void
+      result: (result: favoriteGetFavoritesResult) => void
     }
   ) => void,
   'keybase.1.gpgUi.wantToAddGPGKey'?: (

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -253,9 +253,9 @@ export type FSStatusCode =
   | 2 // ERROR_2
 
 export type FavoritesResult = {
-  favorites: Array<Folder>;
-  ignored: Array<Folder>;
-  xnew: Array<Folder>;
+  favoriteFolders: Array<Folder>;
+  ignoredFolders: Array<Folder>;
+  newFolders: Array<Folder>;
 }
 
 export type Feature = {

--- a/protocol/json/favorite.json
+++ b/protocol/json/favorite.json
@@ -403,6 +403,33 @@
         }
       ],
       "doc": "Folder represents a favorite top-level folder in kbfs.\n    This type is likely to change significantly as all the various parts are\n    connected and tested."
+    },
+    {
+      "type": "record",
+      "name": "FavoritesResult",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "Folder"
+          },
+          "name": "favorites"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "Folder"
+          },
+          "name": "ignored"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "Folder"
+          },
+          "name": "xnew"
+        }
+      ]
     }
   ],
   "messages": {
@@ -420,7 +447,7 @@
       "response": "null",
       "doc": "Adds a folder to a user's list of favorite folders."
     },
-    "favoriteDelete": {
+    "favoriteIgnore": {
       "request": [
         {
           "name": "sessionID",
@@ -434,17 +461,14 @@
       "response": "null",
       "doc": "Removes a folder from a user's list of favorite folders."
     },
-    "favoriteList": {
+    "getFavorites": {
       "request": [
         {
           "name": "sessionID",
           "type": "int"
         }
       ],
-      "response": {
-        "type": "array",
-        "items": "Folder"
-      },
+      "response": "FavoritesResult",
       "doc": "Returns all of a user's favorite folders."
     }
   },

--- a/protocol/json/favorite.json
+++ b/protocol/json/favorite.json
@@ -413,21 +413,21 @@
             "type": "array",
             "items": "Folder"
           },
-          "name": "favorites"
+          "name": "favoriteFolders"
         },
         {
           "type": {
             "type": "array",
             "items": "Folder"
           },
-          "name": "ignored"
+          "name": "ignoredFolders"
         },
         {
           "type": {
             "type": "array",
             "items": "Folder"
           },
-          "name": "xnew"
+          "name": "newFolders"
         }
       ]
     }

--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -5,7 +5,7 @@ import * as Constants from '../constants/favorite'
 import {badgeApp} from './notifications'
 import {canonicalizeUsernames, parseFolderNameToUsers} from '../util/kbfs'
 import _ from 'lodash'
-import type {Folder, favoriteFavoriteListRpc} from '../constants/types/flow-types'
+import type {Folder, favoriteGetFavoritesRpc, FavoritesResult} from '../constants/types/flow-types'
 import type {Dispatch} from '../constants/types/flux'
 import type {FavoriteList} from '../constants/favorite'
 import type {Props as FolderProps} from '../folders/render'
@@ -84,15 +84,17 @@ const folderToProps = (dispatch: Dispatch, folders: Array<Folder>, username: str
 
 export function favoriteList (): (dispatch: Dispatch) => void {
   return (dispatch, getState) => {
-    const params : favoriteFavoriteListRpc = {
+    const params : favoriteGetFavoritesRpc = {
       param: {},
       incomingCallMap: {},
-      method: 'favorite.favoriteList',
-      callback: (error, folders: Array<Folder>) => {
+      method: 'favorite.getFavorites',
+      callback: (error, favorites: FavoritesResult) => {
         if (error) {
-          console.warn('Err in favorite.favoriteList', error)
+          console.warn('Err in favorite.getFavorites', error)
           return
         }
+
+        let folders = favorites.favoriteFolders
 
         if (!folders) {
           folders = []

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -252,6 +252,12 @@ export type FSStatusCode =
   | 1 // FINISH_1
   | 2 // ERROR_2
 
+export type FavoritesResult = {
+  favorites: Array<Folder>;
+  ignored: Array<Folder>;
+  xnew: Array<Folder>;
+}
+
 export type Feature = {
   allow: boolean;
   defaultValue: boolean;
@@ -1758,10 +1764,10 @@ export type favoriteFavoriteAddRpc = {
   callback: (null | (err: ?any) => void)
 }
 
-export type favoriteFavoriteDeleteResult = void
+export type favoriteFavoriteIgnoreResult = void
 
-export type favoriteFavoriteDeleteRpc = {
-  method: 'favorite.favoriteDelete',
+export type favoriteFavoriteIgnoreRpc = {
+  method: 'favorite.favoriteIgnore',
   param: {
     folder: Folder
   },
@@ -1769,12 +1775,12 @@ export type favoriteFavoriteDeleteRpc = {
   callback: (null | (err: ?any) => void)
 }
 
-export type favoriteFavoriteListResult = Array<Folder>
+export type favoriteGetFavoritesResult = FavoritesResult
 
-export type favoriteFavoriteListRpc = {
-  method: 'favorite.favoriteList',
+export type favoriteGetFavoritesRpc = {
+  method: 'favorite.getFavorites',
   incomingCallMap?: incomingCallMapType,
-  callback: (null | (err: ?any, response: favoriteFavoriteListResult) => void)
+  callback: (null | (err: ?any, response: favoriteGetFavoritesResult) => void)
 }
 
 export type gpgUiConfirmDuplicateKeyChosenResult = boolean
@@ -3518,8 +3524,8 @@ export type rpc =
   | deviceDeviceHistoryListRpc
   | deviceDeviceListRpc
   | favoriteFavoriteAddRpc
-  | favoriteFavoriteDeleteRpc
-  | favoriteFavoriteListRpc
+  | favoriteFavoriteIgnoreRpc
+  | favoriteGetFavoritesRpc
   | gpgUiConfirmDuplicateKeyChosenRpc
   | gpgUiSelectKeyAndPushOptionRpc
   | gpgUiSelectKeyRpc
@@ -4073,7 +4079,7 @@ export type incomingCallMapType = {
       result: () => void
     }
   ) => void,
-  'keybase.1.favorite.favoriteDelete'?: (
+  'keybase.1.favorite.favoriteIgnore'?: (
     params: {
       sessionID: int,
       folder: Folder
@@ -4083,13 +4089,13 @@ export type incomingCallMapType = {
       result: () => void
     }
   ) => void,
-  'keybase.1.favorite.favoriteList'?: (
+  'keybase.1.favorite.getFavorites'?: (
     params: {
       sessionID: int
     },
     response: {
       error: (err: RPCError) => void,
-      result: (result: favoriteFavoriteListResult) => void
+      result: (result: favoriteGetFavoritesResult) => void
     }
   ) => void,
   'keybase.1.gpgUi.wantToAddGPGKey'?: (

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -253,9 +253,9 @@ export type FSStatusCode =
   | 2 // ERROR_2
 
 export type FavoritesResult = {
-  favorites: Array<Folder>;
-  ignored: Array<Folder>;
-  xnew: Array<Folder>;
+  favoriteFolders: Array<Folder>;
+  ignoredFolders: Array<Folder>;
+  newFolders: Array<Folder>;
 }
 
 export type Feature = {


### PR DESCRIPTION
As part of this, replace the FavoriteDelete engine with FavoriteIgnore.
In all our current use cases, it's more appropriate to set a folder
"ignored" than to delete its row and make it "new" again.

r? @patrickxb 

@chrisnojima you can build on this branch if you want, to see whether the API works for you?