### PR TITLE
Protect G.Clock to fix race, add Clock(), SetClock()

### DIFF
--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -550,7 +550,7 @@ func TestProvisionPaper(t *testing.T) {
 	// redo SetupEngineTest to get a new home directory...should look like a new device.
 	tc2 := SetupEngineTest(t, "login")
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
-	tc2.G.Clock = fakeClock
+	tc2.G.SetClock(fakeClock)
 	// to pick up the new clock...
 	tc2.G.ResetLoginState()
 	defer tc2.Cleanup()

--- a/go/engine/soft_snooze_test.go
+++ b/go/engine/soft_snooze_test.go
@@ -4,12 +4,13 @@
 package engine
 
 import (
-	"github.com/jonboulle/clockwork"
-	"github.com/keybase/client/go/libkb"
-	keybase1 "github.com/keybase/client/go/protocol"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
 )
 
 type flakeyRooterAPI struct {
@@ -64,7 +65,7 @@ func TestSoftSnooze(t *testing.T) {
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
-	tc.G.Clock = fakeClock
+	tc.G.SetClock(fakeClock)
 	// to pick up the new clock...
 	tc.G.ResetLoginState()
 

--- a/go/engine/track_token_test.go
+++ b/go/engine/track_token_test.go
@@ -4,13 +4,14 @@
 package engine
 
 import (
+	"testing"
+	"time"
+
 	"github.com/jonboulle/clockwork"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
 	"github.com/keybase/gregor"
 	gregor1 "github.com/keybase/gregor/protocol/gregor1"
-	"testing"
-	"time"
 )
 
 func TestTrackToken(t *testing.T) {
@@ -87,7 +88,7 @@ func TestTrackLocalThenLocalTemp(t *testing.T) {
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	fakeClock := clockwork.NewFakeClock()
-	tc.G.Clock = fakeClock
+	tc.G.SetClock(fakeClock)
 	// to pick up the new clock...
 	tc.G.ResetLoginState()
 
@@ -213,7 +214,7 @@ func TestTrackRemoteThenLocalTemp(t *testing.T) {
 
 	// Tracking remote means we have to agree what time it is
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
-	tc.G.Clock = fakeClock
+	tc.G.SetClock(fakeClock)
 	// to pick up the new clock...
 	tc.G.ResetLoginState()
 
@@ -334,7 +335,7 @@ func TestTrackFailTempRecover(t *testing.T) {
 	fu := CreateAndSignupFakeUser(tc, "track")
 
 	fakeClock := clockwork.NewFakeClock()
-	tc.G.Clock = fakeClock
+	tc.G.SetClock(fakeClock)
 	// to pick up the new clock...
 	tc.G.ResetLoginState()
 

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -537,7 +537,7 @@ func (a *Account) SkipSecretPrompt() bool {
 		return false
 	}
 
-	if a.G().Clock.Now().Sub(a.secretPromptCanceledAt) < SecretPromptCancelDuration {
+	if a.G().GetClock().Now().Sub(a.secretPromptCanceledAt) < SecretPromptCancelDuration {
 		return true
 	}
 
@@ -546,5 +546,5 @@ func (a *Account) SkipSecretPrompt() bool {
 }
 
 func (a *Account) SecretPromptCanceled() {
-	a.secretPromptCanceledAt = a.G().Clock.Now()
+	a.secretPromptCanceledAt = a.G().GetClock().Now()
 }

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -23,18 +23,18 @@ func newTimedGenericKey(g *GlobalContext, k GenericKey, w string) *timedGenericK
 	return &timedGenericKey{
 		Contextified: NewContextified(g),
 		key:          k,
-		atime:        g.GetClock().Now(),
+		atime:        g.Clock().Now(),
 		which:        w,
 	}
 }
 
 func (t *timedGenericKey) getKey() GenericKey {
-	t.atime = t.G().GetClock().Now()
+	t.atime = t.G().Clock().Now()
 	return t.key
 }
 
 func (t *timedGenericKey) clean() {
-	now := t.G().GetClock().Now()
+	now := t.G().Clock().Now()
 	if t.key != nil && (now.Sub(t.atime) > PaperKeyMemoryTimeout) {
 		t.G().Log.Debug("Cleaned out key %q at %s", t.which, now)
 		t.key = nil
@@ -537,7 +537,7 @@ func (a *Account) SkipSecretPrompt() bool {
 		return false
 	}
 
-	if a.G().GetClock().Now().Sub(a.secretPromptCanceledAt) < SecretPromptCancelDuration {
+	if a.G().Clock().Now().Sub(a.secretPromptCanceledAt) < SecretPromptCancelDuration {
 		return true
 	}
 
@@ -546,5 +546,5 @@ func (a *Account) SkipSecretPrompt() bool {
 }
 
 func (a *Account) SecretPromptCanceled() {
-	a.secretPromptCanceledAt = a.G().GetClock().Now()
+	a.secretPromptCanceledAt = a.G().Clock().Now()
 }

--- a/go/libkb/delegatekey.go
+++ b/go/libkb/delegatekey.go
@@ -166,7 +166,7 @@ func (d *Delegator) Run(lctx LoginContext) (err error) {
 
 	// We'll need to generate two proofs, so set the Ctime
 	// so that we get the same time both times
-	d.Ctime = d.G().Clock.Now().Unix()
+	d.Ctime = d.G().GetClock().Now().Unix()
 
 	// For a sibkey signature, we first sign the blob with the
 	// sibkey, and then embed that signature for the delegating key

--- a/go/libkb/delegatekey.go
+++ b/go/libkb/delegatekey.go
@@ -166,7 +166,7 @@ func (d *Delegator) Run(lctx LoginContext) (err error) {
 
 	// We'll need to generate two proofs, so set the Ctime
 	// so that we get the same time both times
-	d.Ctime = d.G().GetClock().Now().Unix()
+	d.Ctime = d.G().Clock().Now().Unix()
 
 	// For a sibkey signature, we first sign the blob with the
 	// sibkey, and then embed that signature for the delegating key

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -74,7 +74,7 @@ type GlobalContext struct {
 	ProofCheckerFactory ProofCheckerFactory // Makes new ProofCheckers
 	ExitCode            keybase1.ExitCode   // Value to return to OS on Exit()
 	RateLimits          *RateLimits         // tracks the last time certain actions were taken
-	clockMu             sync.RWMutex        // protects Clock
+	clockMu             sync.Mutex          // protects Clock
 	clock               clockwork.Clock     // RealClock unless we're testing
 	SecretStoreAll      SecretStoreAll      // nil except for tests and supported platforms
 	hookMu              sync.RWMutex        // protects loginHooks, logoutHooks

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -74,7 +74,8 @@ type GlobalContext struct {
 	ProofCheckerFactory ProofCheckerFactory // Makes new ProofCheckers
 	ExitCode            keybase1.ExitCode   // Value to return to OS on Exit()
 	RateLimits          *RateLimits         // tracks the last time certain actions were taken
-	Clock               clockwork.Clock     // RealClock unless we're testing
+	clockMu             sync.RWMutex        // protects Clock
+	clock               clockwork.Clock     // RealClock unless we're testing
 	SecretStoreAll      SecretStoreAll      // nil except for tests and supported platforms
 	hookMu              sync.RWMutex        // protects loginHooks, logoutHooks
 	loginHooks          []LoginHook         // call these on login
@@ -89,7 +90,7 @@ func NewGlobalContext() *GlobalContext {
 		Log:                 log,
 		VDL:                 NewVDebugLog(log),
 		ProofCheckerFactory: defaultProofCheckerFactory,
-		Clock:               clockwork.NewRealClock(),
+		clock:               clockwork.NewRealClock(),
 	}
 }
 
@@ -516,10 +517,18 @@ func (g *GlobalContext) GetRunMode() RunMode {
 }
 
 func (g *GlobalContext) GetClock() clockwork.Clock {
-	if g.Clock == nil {
-		return clockwork.NewRealClock()
+	g.clockMu.Lock()
+	defer g.clockMu.Unlock()
+	if g.clock == nil {
+		g.clock = clockwork.NewRealClock()
 	}
-	return g.Clock
+	return g.clock
+}
+
+func (g *GlobalContext) SetClock(c clockwork.Clock) {
+	g.clockMu.Lock()
+	defer g.clockMu.Unlock()
+	g.clock = c
 }
 
 func (g *GlobalContext) GetMyClientDetails() keybase1.ClientDetails {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -516,7 +516,7 @@ func (g *GlobalContext) GetRunMode() RunMode {
 	return g.Env.GetRunMode()
 }
 
-func (g *GlobalContext) GetClock() clockwork.Clock {
+func (g *GlobalContext) Clock() clockwork.Clock {
 	g.clockMu.Lock()
 	defer g.clockMu.Unlock()
 	if g.clock == nil {

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -266,7 +266,7 @@ func (arg ProofMetadata) ToJSON(g *GlobalContext) (ret *jsonw.Wrapper, err error
 
 	ctime := arg.CreationTime
 	if ctime == 0 {
-		ctime = g.Clock.Now().Unix()
+		ctime = g.GetClock().Now().Unix()
 	}
 
 	ei := arg.ExpireIn

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -266,7 +266,7 @@ func (arg ProofMetadata) ToJSON(g *GlobalContext) (ret *jsonw.Wrapper, err error
 
 	ctime := arg.CreationTime
 	if ctime == 0 {
-		ctime = g.GetClock().Now().Unix()
+		ctime = g.Clock().Now().Unix()
 	}
 
 	ei := arg.ExpireIn

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -123,7 +123,7 @@ func LoadMeByUID(g *GlobalContext, uid keybase1.UID) (*User, error) {
 }
 
 func LoadUser(arg LoadUserArg) (ret *User, err error) {
-	defer TimeLog(fmt.Sprintf("LoadUser: %+v", arg), arg.G().Clock.Now(), arg.G().Log.Debug)
+	defer TimeLog(fmt.Sprintf("LoadUser: %+v", arg), arg.G().GetClock().Now(), arg.G().Log.Debug)
 	arg.G().Log.Debug("LoadUser: %+v", arg)
 	var refresh bool
 

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -123,7 +123,7 @@ func LoadMeByUID(g *GlobalContext, uid keybase1.UID) (*User, error) {
 }
 
 func LoadUser(arg LoadUserArg) (ret *User, err error) {
-	defer TimeLog(fmt.Sprintf("LoadUser: %+v", arg), arg.G().GetClock().Now(), arg.G().Log.Debug)
+	defer TimeLog(fmt.Sprintf("LoadUser: %+v", arg), arg.G().Clock().Now(), arg.G().Log.Debug)
 	arg.G().Log.Debug("LoadUser: %+v", arg)
 	var refresh bool
 

--- a/go/libkb/login_session.go
+++ b/go/libkb/login_session.go
@@ -99,7 +99,7 @@ func (s *LoginSession) ExistsFor(emailOrUsername string) bool {
 }
 
 func (s *LoginSession) NotExpired() bool {
-	now := s.G().GetClock().Now()
+	now := s.G().Clock().Now()
 
 	if now.Sub(s.createTime) < LoginSessionMemoryTimeout {
 		return true
@@ -187,7 +187,7 @@ func (s *LoginSession) Load() error {
 	s.loginSession = ls
 	s.loaded = true
 	s.cleared = false
-	s.createTime = s.G().GetClock().Now()
+	s.createTime = s.G().Clock().Now()
 
 	return nil
 }

--- a/go/libkb/login_session_test.go
+++ b/go/libkb/login_session_test.go
@@ -85,7 +85,7 @@ func TestLoginSessionTimeout(t *testing.T) {
 	tc := SetupTest(t, "login_session_test", 1)
 	tc.G.API = &FakeAPI{}
 	c := clockwork.NewFakeClock()
-	tc.G.Clock = c
+	tc.G.SetClock(c)
 	defer tc.Cleanup()
 
 	sesh := NewLoginSession("logintest", tc.G)
@@ -97,7 +97,7 @@ func TestLoginSessionTimeout(t *testing.T) {
 		t.Fatal("Fresh LoginSession says expired")
 	}
 	c.Advance(LoginSessionMemoryTimeout + 1*time.Second)
-	tc.G.Clock = c // ??
+	tc.G.SetClock(c) // ??
 	if sesh.NotExpired() {
 		t.Fatal("Stale LoginSession says not expired")
 	}

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -828,7 +828,7 @@ func (s *LoginState) requests() {
 
 	// Run a cleanup routine on the Account object every minute.
 	// We're supposed to timeout & cleanup Paper Keys after an hour of inactivity.
-	maketimer := func() <-chan time.Time { return s.G().GetClock().After(1 * time.Minute) }
+	maketimer := func() <-chan time.Time { return s.G().Clock().After(1 * time.Minute) }
 	timer := maketimer()
 	s.G().Log.Debug("LoginState: Running request loop")
 

--- a/go/libkb/proof_cache.go
+++ b/go/libkb/proof_cache.go
@@ -208,7 +208,7 @@ func (pc *ProofCache) Put(sid keybase1.SigID, pe ProofError) error {
 	cr := CheckResult{
 		Contextified: pc.Contextified,
 		Status:       pe,
-		Time:         pc.G().Clock.Now(),
+		Time:         pc.G().GetClock().Now(),
 	}
 	pc.memPut(sid, cr)
 	return pc.dbPut(sid, cr)

--- a/go/libkb/proof_cache.go
+++ b/go/libkb/proof_cache.go
@@ -31,7 +31,7 @@ func (cr CheckResult) Pack() *jsonw.Wrapper {
 }
 
 func (cr CheckResult) Freshness() keybase1.CheckResultFreshness {
-	now := cr.G().GetClock().Now()
+	now := cr.G().Clock().Now()
 	age := now.Sub(cr.Time)
 	switch {
 	case cr.Status == nil:
@@ -56,7 +56,7 @@ func NewNowCheckResult(g *GlobalContext, pe ProofError) *CheckResult {
 	return &CheckResult{
 		Contextified: NewContextified(g),
 		Status:       pe,
-		Time:         g.GetClock().Now(),
+		Time:         g.Clock().Now(),
 	}
 }
 
@@ -208,7 +208,7 @@ func (pc *ProofCache) Put(sid keybase1.SigID, pe ProofError) error {
 	cr := CheckResult{
 		Contextified: pc.Contextified,
 		Status:       pe,
-		Time:         pc.G().GetClock().Now(),
+		Time:         pc.G().Clock().Now(),
 	}
 	pc.memPut(sid, cr)
 	return pc.dbPut(sid, cr)

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -79,7 +79,7 @@ func (sc SigChain) GetComputedKeyInfos() (cki *ComputedKeyInfos) {
 }
 
 func (sc SigChain) GetFutureChainTail() (ret *MerkleTriple) {
-	now := sc.G().GetClock().Now()
+	now := sc.G().Clock().Now()
 	if sc.localChainTail != nil && now.Sub(sc.localChainUpdateTime) < ServerUpdateLag {
 		ret = sc.localChainTail
 	}
@@ -125,7 +125,7 @@ func (sc *SigChain) Bump(mt MerkleTriple) {
 	mt.Seqno = sc.GetLastKnownSeqno() + 1
 	sc.G().Log.Debug("| Bumping SigChain LastKnownSeqno to %d", mt.Seqno)
 	sc.localChainTail = &mt
-	sc.localChainUpdateTime = sc.G().GetClock().Now()
+	sc.localChainUpdateTime = sc.G().Clock().Now()
 }
 
 func (sc *SigChain) LoadFromServer(t *MerkleTriple, selfUID keybase1.UID) (dirtyTail *MerkleTriple, err error) {
@@ -860,7 +860,7 @@ func (l *SigChainLoader) merkleTreeEldestMatchesLastLinkEldest() bool {
 // all of the steps to load a chain in from storage, to refresh it against
 // the server, and to verify its integrity.
 func (l *SigChainLoader) Load() (ret *SigChain, err error) {
-	defer TimeLog(fmt.Sprintf("SigChainLoader.Load: %s", l.user.GetName()), l.G().GetClock().Now(), l.G().Log.Debug)
+	defer TimeLog(fmt.Sprintf("SigChainLoader.Load: %s", l.user.GetName()), l.G().Clock().Now(), l.G().Log.Debug)
 	var current bool
 	var preload bool
 

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -79,7 +79,7 @@ func (sc SigChain) GetComputedKeyInfos() (cki *ComputedKeyInfos) {
 }
 
 func (sc SigChain) GetFutureChainTail() (ret *MerkleTriple) {
-	now := sc.G().Clock.Now()
+	now := sc.G().GetClock().Now()
 	if sc.localChainTail != nil && now.Sub(sc.localChainUpdateTime) < ServerUpdateLag {
 		ret = sc.localChainTail
 	}
@@ -125,7 +125,7 @@ func (sc *SigChain) Bump(mt MerkleTriple) {
 	mt.Seqno = sc.GetLastKnownSeqno() + 1
 	sc.G().Log.Debug("| Bumping SigChain LastKnownSeqno to %d", mt.Seqno)
 	sc.localChainTail = &mt
-	sc.localChainUpdateTime = sc.G().Clock.Now()
+	sc.localChainUpdateTime = sc.G().GetClock().Now()
 }
 
 func (sc *SigChain) LoadFromServer(t *MerkleTriple, selfUID keybase1.UID) (dirtyTail *MerkleTriple, err error) {
@@ -860,7 +860,7 @@ func (l *SigChainLoader) merkleTreeEldestMatchesLastLinkEldest() bool {
 // all of the steps to load a chain in from storage, to refresh it against
 // the server, and to verify its integrity.
 func (l *SigChainLoader) Load() (ret *SigChain, err error) {
-	defer TimeLog(fmt.Sprintf("SigChainLoader.Load: %s", l.user.GetName()), l.G().Clock.Now(), l.G().Log.Debug)
+	defer TimeLog(fmt.Sprintf("SigChainLoader.Load: %s", l.user.GetName()), l.G().GetClock().Now(), l.G().Log.Debug)
 	var current bool
 	var preload bool
 

--- a/go/libkb/skb_test.go
+++ b/go/libkb/skb_test.go
@@ -212,7 +212,7 @@ func TestPromptCancelCache(t *testing.T) {
 	defer tc.Cleanup()
 
 	fakeClock := clockwork.NewFakeClock()
-	tc.G.Clock = fakeClock
+	tc.G.SetClock(fakeClock)
 
 	lks := makeTestLKSec(t, tc.G)
 	skb := makeTestSKB(t, lks, tc.G)

--- a/go/libkb/track.go
+++ b/go/libkb/track.go
@@ -401,9 +401,9 @@ func localTrackChainLinkFor(tracker, trackee keybase1.UID, localExpires bool, g 
 	if localExpires {
 		linkETime = cl.GetCTime().Add(g.Env.GetLocalTrackMaxAge())
 
-		g.Log.Debug("| := local track created %s, expires: %s, it is now %s", cl.GetCTime(), linkETime.String(), g.Clock.Now())
+		g.Log.Debug("| := local track created %s, expires: %s, it is now %s", cl.GetCTime(), linkETime.String(), g.GetClock().Now())
 
-		if linkETime.Before(g.Clock.Now()) {
+		if linkETime.Before(g.GetClock().Now()) {
 			g.Log.Debug("| expired local track, deleting")
 			removeLocalTrack(tracker, trackee, true, g)
 			ret = nil

--- a/go/libkb/track.go
+++ b/go/libkb/track.go
@@ -401,9 +401,9 @@ func localTrackChainLinkFor(tracker, trackee keybase1.UID, localExpires bool, g 
 	if localExpires {
 		linkETime = cl.GetCTime().Add(g.Env.GetLocalTrackMaxAge())
 
-		g.Log.Debug("| := local track created %s, expires: %s, it is now %s", cl.GetCTime(), linkETime.String(), g.GetClock().Now())
+		g.Log.Debug("| := local track created %s, expires: %s, it is now %s", cl.GetCTime(), linkETime.String(), g.Clock().Now())
 
-		if linkETime.Before(g.GetClock().Now()) {
+		if linkETime.Before(g.Clock().Now()) {
 			g.Log.Debug("| expired local track, deleting")
 			removeLocalTrack(tracker, trackee, true, g)
 			ret = nil

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -221,7 +221,7 @@ func (u *User) StoreSigChain() error {
 }
 
 func (u *User) LoadSigChains(allKeys bool, f *MerkleUserLeaf, self bool) (err error) {
-	defer TimeLog(fmt.Sprintf("LoadSigChains: %s", u.name), u.G().GetClock().Now(), u.G().Log.Debug)
+	defer TimeLog(fmt.Sprintf("LoadSigChains: %s", u.name), u.G().Clock().Now(), u.G().Log.Debug)
 
 	loader := SigChainLoader{
 		user:         u,

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -221,7 +221,7 @@ func (u *User) StoreSigChain() error {
 }
 
 func (u *User) LoadSigChains(allKeys bool, f *MerkleUserLeaf, self bool) (err error) {
-	defer TimeLog(fmt.Sprintf("LoadSigChains: %s", u.name), u.G().Clock.Now(), u.G().Log.Debug)
+	defer TimeLog(fmt.Sprintf("LoadSigChains: %s", u.name), u.G().GetClock().Now(), u.G().Log.Debug)
 
 	loader := SigChainLoader{
 		user:         u,

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -644,7 +644,7 @@ func (g *gregorHandler) pingLoop() {
 			g.G().Log.Errorf("gregor handler: error in ping loop: %s", err)
 		}
 
-		g.G().GetClock().Sleep(g.G().Env.GetGregorPingInterval())
+		g.G().Clock().Sleep(g.G().Env.GetGregorPingInterval())
 	}
 }
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -644,7 +644,7 @@ func (g *gregorHandler) pingLoop() {
 			g.G().Log.Errorf("gregor handler: error in ping loop: %s", err)
 		}
 
-		g.G().Clock.Sleep(g.G().Env.GetGregorPingInterval())
+		g.G().GetClock().Sleep(g.G().Env.GetGregorPingInterval())
 	}
 }
 

--- a/go/service/rekey_test.go
+++ b/go/service/rekey_test.go
@@ -45,7 +45,7 @@ func rekeyBroadcast(tc libkb.TestContext, gUID gregor1.UID, h *gregorHandler, bo
 			StateUpdate_: &gregor1.StateUpdateMessage{
 				Md_: gregor1.Metadata{
 					MsgID_: msgID,
-					Ctime_: gregor1.ToTime(tc.G.GetClock().Now()),
+					Ctime_: gregor1.ToTime(tc.G.Clock().Now()),
 					Uid_:   gUID,
 				},
 				Creation_: &gregor1.Item{

--- a/go/service/rekey_test.go
+++ b/go/service/rekey_test.go
@@ -45,7 +45,7 @@ func rekeyBroadcast(tc libkb.TestContext, gUID gregor1.UID, h *gregorHandler, bo
 			StateUpdate_: &gregor1.StateUpdateMessage{
 				Md_: gregor1.Metadata{
 					MsgID_: msgID,
-					Ctime_: gregor1.ToTime(tc.G.Clock.Now()),
+					Ctime_: gregor1.ToTime(tc.G.GetClock().Now()),
 					Uid_:   gUID,
 				},
 				Creation_: &gregor1.Item{
@@ -105,7 +105,7 @@ func TestRekeyNeededMessageWithScores(t *testing.T) {
 	tc.G.SetUIRouter(&router)
 
 	clock := clockwork.NewFakeClock()
-	tc.G.Clock = clock
+	tc.G.SetClock(clock)
 
 	gUID, h, rekeyHandler := rekeySetup(tc)
 
@@ -170,7 +170,7 @@ func TestRekeyNeededUserClose(t *testing.T) {
 	tc.G.SetUIRouter(&router)
 
 	clock := clockwork.NewFakeClock()
-	tc.G.Clock = clock
+	tc.G.SetClock(clock)
 
 	gUID, h, rekeyHandler := rekeySetup(tc)
 

--- a/go/service/rekey_ui_handler.go
+++ b/go/service/rekey_ui_handler.go
@@ -71,7 +71,7 @@ func (r *RekeyUIHandler) rekeyNeeded(ctx context.Context, item gregor.Item) erro
 		return err
 	}
 
-	if r.G().GetClock().Now().Sub(item.Metadata().CTime()) > 10*time.Second {
+	if r.G().Clock().Now().Sub(item.Metadata().CTime()) > 10*time.Second {
 		// if the message isn't fresh, get:
 		var err error
 		problemSet, err = r.scorer(r.G(), problemSet)
@@ -244,7 +244,7 @@ func (u *rekeyStatusUpdater) update() {
 		case <-u.done:
 			u.G().Log.Debug("rekeyStatusUpdater done chan closed, terminating update loop")
 			return
-		case <-u.G().GetClock().After(1 * time.Second):
+		case <-u.G().Clock().After(1 * time.Second):
 		}
 
 		u.problemSet, err = u.scorer(u.G(), u.problemSet)

--- a/go/service/rekey_ui_handler.go
+++ b/go/service/rekey_ui_handler.go
@@ -71,7 +71,7 @@ func (r *RekeyUIHandler) rekeyNeeded(ctx context.Context, item gregor.Item) erro
 		return err
 	}
 
-	if r.G().Clock.Now().Sub(item.Metadata().CTime()) > 10*time.Second {
+	if r.G().GetClock().Now().Sub(item.Metadata().CTime()) > 10*time.Second {
 		// if the message isn't fresh, get:
 		var err error
 		problemSet, err = r.scorer(r.G(), problemSet)
@@ -244,7 +244,7 @@ func (u *rekeyStatusUpdater) update() {
 		case <-u.done:
 			u.G().Log.Debug("rekeyStatusUpdater done chan closed, terminating update loop")
 			return
-		case <-u.G().Clock.After(1 * time.Second):
+		case <-u.G().GetClock().After(1 * time.Second):
 		}
 
 		u.problemSet, err = u.scorer(u.G(), u.problemSet)


### PR DESCRIPTION
I found a race with the use of GlobalContext.Clock, and then found some inconsistent usage of G.GetClock() vs. G.Clock.

This fixes it all up, protects the clock member, and standardizes on G.Clock(), G.SetClock(...).

There is a slight chance this would have fixed the issue with fakeClock.BlockUntil(1) that we experienced in the rekey tests.

r? @maxtaco 