### PR TITLE
Pass onFolderClick to folder component

### DIFF
--- a/shared/menubar/dumb.desktop.js
+++ b/shared/menubar/dumb.desktop.js
@@ -9,6 +9,7 @@ const propsNormal = {
   folderProps: map.mocks['Normal Private'],
   username: 'max',
   showOpenApp: true,
+  onFolderClick: () => console.log('folder clicked'),
   openApp: () => console.log('open app'),
   showKBFS: () => console.log('show kbfs'),
   logIn: () => console.log('login'),

--- a/shared/menubar/index.js
+++ b/shared/menubar/index.js
@@ -164,7 +164,7 @@ class Menubar extends Component<void, Props, void> {
       quit={() => this._quit()}
       refresh={() => this._checkForFolders(true)}
       onRekey={(path: string) => this._onRekey(path)} // eslint-disable-line arrow-parens
-      onClick={(path: string) => this._openFolder(path)} // eslint-disable-line arrow-parens
+      onFolderClick={(path: string) => this._openFolder(path)} // eslint-disable-line arrow-parens
     />
   }
 }

--- a/shared/menubar/index.render.desktop.js
+++ b/shared/menubar/index.render.desktop.js
@@ -72,7 +72,7 @@ class Render extends Component<DefaultProps, Props, State> {
   }
 
   _onAdd (path: string) {
-    this.props.onClick && this.props.onClick(path)
+    this.props.onFolderClick(path)
     this.props.refresh()
   }
 
@@ -101,6 +101,7 @@ class Render extends Component<DefaultProps, Props, State> {
 
     const mergedProps = {
       ...this.props.folderProps,
+      onClick: this.props.onFolderClick,
       showComingSoon: false,
       smallMode: true,
       private: newPrivate,

--- a/shared/menubar/index.render.js.flow
+++ b/shared/menubar/index.render.js.flow
@@ -13,6 +13,7 @@ export type Props = {
   showKBFS: () => void,
   showBug: () => void,
   onRekey: (path: string) => void,
+  onFolderClick: (path: string) => void,
   refresh: () => void,
   quit: () => void,
   username: ?string,


### PR DESCRIPTION
@keybase/react-hackers 

Fixes bug where clicking on a folder doesn't open the folder.

We weren't passing in the onClick to the Folders component.

I think this is an example of when we should be more mindful about making a prop optional. Maybe in folder onClick should be mandatory like onRekey.

Not fixed here because it requires changing our notion of `FolderProps` as the thing the action, reducer and component knows about and uses into a `FolderData` type and `FolderProps` type which is just `FolderData` with onClick and onRekey and other non pure data. 