### PR TITLE
Fixes for favorites rpc

### DIFF
--- a/go/client/cmd_favorite_list.go
+++ b/go/client/cmd_favorite_list.go
@@ -47,7 +47,7 @@ func (c *CmdFavoriteList) Run() error {
 	if err != nil {
 		return err
 	}
-	for _, f := range result.Favorites {
+	for _, f := range result.FavoriteFolders {
 		acc := "public"
 		if f.Private {
 			acc = "private"

--- a/go/engine/favorite_list.go
+++ b/go/engine/favorite_list.go
@@ -66,9 +66,8 @@ func (e *FavoriteList) Run(ctx *Context) error {
 // Favorites returns the list of favorites that Run generated.
 func (e *FavoriteList) Result() keybase1.FavoritesResult {
 	return keybase1.FavoritesResult{
-		Favorites: e.result.Favorites,
-		Ignored:   e.result.Ignored,
-		// The name "new" is illegal in ObjC. "X" is just a filler character.
-		Xnew: e.result.New,
+		FavoriteFolders: e.result.Favorites,
+		IgnoredFolders:  e.result.Ignored,
+		NewFolders:      e.result.New,
 	}
 }

--- a/go/engine/favorite_test.go
+++ b/go/engine/favorite_test.go
@@ -133,7 +133,7 @@ func TestFavoriteList(t *testing.T) {
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
-	favs := eng.Result().Favorites
+	favs := eng.Result().FavoriteFolders
 	if len(favs) != 2 {
 		t.Fatalf("num favs: %d, expected 2", len(favs))
 	}
@@ -179,5 +179,5 @@ func listfav(tc libkb.TestContext) []keybase1.Folder {
 	if err != nil {
 		tc.T.Fatal(err)
 	}
-	return eng.Result().Favorites
+	return eng.Result().FavoriteFolders
 }

--- a/go/protocol/favorite.go
+++ b/go/protocol/favorite.go
@@ -19,9 +19,9 @@ type Folder struct {
 }
 
 type FavoritesResult struct {
-	Favorites []Folder `codec:"favorites" json:"favorites"`
-	Ignored   []Folder `codec:"ignored" json:"ignored"`
-	Xnew      []Folder `codec:"xnew" json:"xnew"`
+	FavoriteFolders []Folder `codec:"favoriteFolders" json:"favoriteFolders"`
+	IgnoredFolders  []Folder `codec:"ignoredFolders" json:"ignoredFolders"`
+	NewFolders      []Folder `codec:"newFolders" json:"newFolders"`
 }
 
 type FavoriteAddArg struct {

--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -28,10 +28,11 @@ go-build-stamp: avdl/*.avdl $(AVDLC) | config
 	(cd ../go/protocol && go fmt ./...)
 	date > $@
 
-objc-build-stamp: build-stamp | config
-	@ # Runs without generating files (to validate)
-	ruby ./bin/objc.rb
-	date > $@
+# We no longer build an objc client
+# objc-build-stamp: build-stamp | config
+	# @ # Runs without generating files (to validate)
+	# ruby ./bin/objc.rb
+	# date > $@
 
 js/flow-types.js: build-stamp | config
 	@mkdir -p js/
@@ -55,6 +56,6 @@ clean:
 fmt:
 	@./fmt.sh
 
-build: fmt build-stamp go-build-stamp js/keybase_v1.js js/flow-types.js objc-build-stamp swift-build-stamp
+build: fmt build-stamp go-build-stamp js/keybase_v1.js js/flow-types.js swift-build-stamp
 
 .PHONY: test config

--- a/protocol/avdl/favorite.avdl
+++ b/protocol/avdl/favorite.avdl
@@ -21,9 +21,9 @@ protocol favorite {
   // representing all the TLFs you have in each of those 3 states, and we
   // marshall that result into this struct.
   record FavoritesResult {
-    array<Folder> favorites;
-    array<Folder> ignored;
-    array<Folder> xnew;  // "new" is an illegal variable prefix in ObjC :p
+    array<Folder> favoriteFolders;
+    array<Folder> ignoredFolders;
+    array<Folder> newFolders;
   }
 
   /**

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -253,9 +253,9 @@ export type FSStatusCode =
   | 2 // ERROR_2
 
 export type FavoritesResult = {
-  favorites: Array<Folder>;
-  ignored: Array<Folder>;
-  xnew: Array<Folder>;
+  favoriteFolders: Array<Folder>;
+  ignoredFolders: Array<Folder>;
+  newFolders: Array<Folder>;
 }
 
 export type Feature = {

--- a/protocol/json/favorite.json
+++ b/protocol/json/favorite.json
@@ -413,21 +413,21 @@
             "type": "array",
             "items": "Folder"
           },
-          "name": "favorites"
+          "name": "favoriteFolders"
         },
         {
           "type": {
             "type": "array",
             "items": "Folder"
           },
-          "name": "ignored"
+          "name": "ignoredFolders"
         },
         {
           "type": {
             "type": "array",
             "items": "Folder"
           },
-          "name": "xnew"
+          "name": "newFolders"
         }
       ]
     }

--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -5,7 +5,7 @@ import * as Constants from '../constants/favorite'
 import {badgeApp} from './notifications'
 import {canonicalizeUsernames, parseFolderNameToUsers} from '../util/kbfs'
 import _ from 'lodash'
-import type {Folder, favoriteFavoriteListRpc} from '../constants/types/flow-types'
+import type {Folder, favoriteGetFavoritesRpc, FavoritesResult} from '../constants/types/flow-types'
 import type {Dispatch} from '../constants/types/flux'
 import type {FavoriteList} from '../constants/favorite'
 import type {Props as FolderProps} from '../folders/render'
@@ -84,15 +84,17 @@ const folderToProps = (dispatch: Dispatch, folders: Array<Folder>, username: str
 
 export function favoriteList (): (dispatch: Dispatch) => void {
   return (dispatch, getState) => {
-    const params : favoriteFavoriteListRpc = {
+    const params : favoriteGetFavoritesRpc = {
       param: {},
       incomingCallMap: {},
-      method: 'favorite.favoriteList',
-      callback: (error, folders: Array<Folder>) => {
+      method: 'favorite.getFavorites',
+      callback: (error, favorites: FavoritesResult) => {
         if (error) {
-          console.warn('Err in favorite.favoriteList', error)
+          console.warn('Err in favorite.getFavorites', error)
           return
         }
+
+        let folders = favorites.favoriteFolders
 
         if (!folders) {
           folders = []

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -253,9 +253,9 @@ export type FSStatusCode =
   | 2 // ERROR_2
 
 export type FavoritesResult = {
-  favorites: Array<Folder>;
-  ignored: Array<Folder>;
-  xnew: Array<Folder>;
+  favoriteFolders: Array<Folder>;
+  ignoredFolders: Array<Folder>;
+  newFolders: Array<Folder>;
 }
 
 export type Feature = {


### PR DESCRIPTION
- [x] xnew -> new. 
- [x] stopping objc code gen. 
- [x] pulling favorites out of new property. fixing flow

@oconnor663 : note: this has go lint problems

```
go/protocol/favorite.go:21:6: exported type FavoritesResult should have comment or be unexported
go/protocol/favorite.go:27:6: exported type FavoriteAddArg should have comment or be unexported
go/protocol/favorite.go:32:6: exported type FavoriteIgnoreArg should have comment or be unexported
go/protocol/favorite.go:37:6: exported type GetFavoritesArg should have comment or be unexported
go/protocol/favorite.go:41:6: exported type FavoriteInterface should have comment or be unexported
go/protocol/favorite.go:50:1: exported function FavoriteProtocol should have comment or be unexported
go/protocol/favorite.go:106:6: exported type FavoriteClient should have comment or be unexported
go/protocol/favorite.go:110:1: comment on exported method FavoriteClient.FavoriteAdd should be of the form "FavoriteAdd ..."
go/protocol/favorite.go:111:58: don't use underscores in Go names; method parameter __arg should be _Arg
go/protocol/favorite.go:116:1: comment on exported method FavoriteClient.FavoriteIgnore should be of the form "FavoriteIgnore ..."
go/protocol/favorite.go:117:61: don't use underscores in Go names; method parameter __arg should be _Arg
go/protocol/favorite.go:122:1: comment on exported method FavoriteClient.GetFavorites should be of the form "GetFavorites ..."
go/protocol/favorite.go:124:2: don't use underscores in Go names; var __arg should be _Arg
go/engine/favorite_list.go:29:1: comment on exported method FavoriteList.Prereqs should be of the form "Prereqs ..."
go/engine/favorite_list.go:46:6: exported type FavoritesAPIResult should have comment or be unexported
go/engine/favorite_list.go:53:1: exported method FavoritesAPIResult.GetAppStatus should have comment or be unexported
go/engine/favorite_list.go:66:1: comment on exported method FavoriteList.Result should be of the form "Result ..."
go/client/cmd_favorite_list.go:18:6: exported type CmdFavoriteList should have comment or be unexported
go/client/cmd_favorite_list.go:20:1: exported function NewCmdFavoriteList should have comment or be unexported
go/client/cmd_favorite_list.go:30:1: exported method CmdFavoriteList.ParseArgv should have comment or be unexported
go/client/cmd_favorite_list.go:37:1: exported method CmdFavoriteList.GetUsage should have comment or be unexported
go/client/cmd_favorite_list.go:44:1: exported method CmdFavoriteList.Run should have comment or be unexported
```