### PR TITLE
Implement followee/follower badges on all avatars

### DIFF
--- a/shared/common-adapters/avatar.desktop.js
+++ b/shared/common-adapters/avatar.desktop.js
@@ -32,10 +32,11 @@ export default class Avatar extends Component {
   }
 
   render () {
-    const width = this.props.size
-    const height = this.props.size
+    const {size} = this.props
+    const width = size
+    const height = size
     const url = this._createUrl()
-    const avatarStyle = {width, height, borderRadius: this.props.size / 2, position: 'absolute'}
+    const avatarStyle = {width, height, borderRadius: size / 2, position: 'absolute'}
 
     return (
       <div onClick={this.props.onClick} style={{...globalStyles.noSelect, position: 'relative', width, height, ...this.props.style}}>
@@ -52,8 +53,50 @@ export default class Avatar extends Component {
             backgroundColor: globalColors.white
           }}
           onLoad={() => this.setState({avatarLoaded: true})} />
+        <div>
+        {size > 16 && (this.props.following || this.props.followsYou) &&
+          <div>
+            {this.props.followsYou && <div style={{...followTop(size, globalColors.green)}}> <div style={{...followInner(size, globalColors.white)}} /></div>}
+            <div style={{...followBottom(size, this.props.following ? globalColors.green : globalColors.grey)}} />
+          </div>
+        }
+        </div>
       </div>
     )
+  }
+}
+
+const followBadgeCommon = (size, color) => ({
+  position: 'absolute',
+  width: Math.round(size / 60 * 12),
+  height: Math.round(size / 60 * 12),
+  background: color,
+  borderRadius: '50%',
+  border: `${Math.round(size / 60 * 2)}px solid ${globalColors.white}`
+})
+
+const followTop = (size, color) => ({
+  ...followBadgeCommon(size, color),
+  bottom: Math.round(size / 60 * 5),
+  right: 0
+})
+
+const followBottom = (size, color) => ({
+  ...followBadgeCommon(size, color),
+  bottom: 0,
+  right: Math.round(size / 60 * 5)
+})
+
+const followInner = (size, color) => {
+  const padding = Math.round(size / 60 * 12 / 7)
+  return {
+    position: 'absolute',
+    background: color,
+    borderRadius: '50%',
+    top: padding,
+    right: padding,
+    bottom: padding,
+    left: padding
   }
 }
 

--- a/shared/common-adapters/avatar.js.flow
+++ b/shared/common-adapters/avatar.js.flow
@@ -5,7 +5,9 @@ import React, {Component} from 'react'
 type CommonProps = {
   size: 176 | 112 | 80 | 64 | 48 | 32 | 24 | 16,
   style?: ?Object,
-  onClick?: ?(() => void)
+  onClick?: ?(() => void),
+  following?: ?boolean,
+  followsYou?: ?boolean
 }
 
 export type Props = ({url: ?string} & CommonProps) | ({username: ?string} & CommonProps)

--- a/shared/common-adapters/dumb.desktop.js
+++ b/shared/common-adapters/dumb.desktop.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React from 'react'
+import _ from 'lodash'
 
 import Checkbox from './checkbox'
 import {Button, Box, TabBar, Text, Avatar, ListItem, PopupMenu} from './index'
@@ -142,9 +143,32 @@ const popupMenuMap: DumbComponentMap<PopupMenu> = {
   }
 }
 
+const mockAvatarSizes = (title, sizes, modifiers) => _.chain(sizes)
+  .map(size => ({size, username: 'awendland', ...modifiers}))
+  .keyBy(props => `${title} x${props.size}`)
+  .value()
+
+const avatarMap: DumbComponentMap<Avatar> = {
+  component: Avatar,
+  mocks: {
+    ...mockAvatarSizes('Normal', [32], {}),
+    ...mockAvatarSizes('Following', [48], {
+      following: true
+    }),
+    ...mockAvatarSizes('Follows You', [64], {
+      followsYou: true
+    }),
+    ...mockAvatarSizes('Mutual Follow', [112], {
+      following: true,
+      followsYou: true
+    })
+  }
+}
+
 export default {
   Checkbox: checkboxMap,
   TabBar: tabBarMap,
   ListItem: listItemMap,
-  PopupMenu: popupMenuMap
+  PopupMenu: popupMenuMap,
+  Avatar: avatarMap
 }

--- a/shared/common-adapters/user-bio.desktop.js
+++ b/shared/common-adapters/user-bio.desktop.js
@@ -52,15 +52,13 @@ export default class BioRender extends Component {
     return (
       <div style={stylesOuter}>
         <div style={stylesContainer}>
-          <div style={stylesAvatarOuter}>
-            <Avatar onClick={() => this._onClickAvatar()} style={globalStyles.clickable} url={userInfo.avatar} size={avatarSize} />
-            {(followsYou || currentlyFollowing) &&
-              <div>
-                {followsYou && <div style={followBadgeStyles.followsYou}> <div style={{...followBadgeCommon, height: 6, width: 6, top: 2, right: 2}} /></div>}
-                <div style={currentlyFollowing ? followBadgeStyles.following : followBadgeStyles.notFollowing} />
-              </div>
-            }
-          </div>
+          <Avatar
+            onClick={() => this._onClickAvatar()}
+            style={{...globalStyles.clickable, zIndex: 2}}
+            url={userInfo.avatar}
+            size={avatarSize}
+            following={currentlyFollowing}
+            followsYou={followsYou} />
           <div style={stylesContent}>
             <Text
               type='HeaderBig'
@@ -108,12 +106,6 @@ const stylesContainer = {
   width: 320,
   marginTop: -40
 }
-const stylesAvatarOuter = {
-  width: avatarSize,
-  height: avatarSize,
-  position: 'relative',
-  zIndex: 2
-}
 const stylesContent = {
   backgroundColor: globalColors.white,
   ...globalStyles.flexBoxColumn,
@@ -157,44 +149,4 @@ const stylesLocation = {
   paddingLeft: 30,
   paddingRight: 30,
   textAlign: 'center'
-}
-
-const followBadgeCommon = {
-  position: 'absolute',
-  background: globalColors.white,
-  width: 14,
-  height: 14,
-  borderRadius: '50%',
-  border: `2px solid ${globalColors.white}`
-}
-
-const followTop = {
-  ...followBadgeCommon,
-  bottom: 5,
-  right: 2
-}
-
-const followBottom = {
-  ...followBadgeCommon,
-  bottom: 0,
-  right: 8
-}
-
-const followBadgeStyles = {
-  followsYou: {
-    ...followTop,
-    background: globalColors.green
-  },
-  notFollowsYou: {
-    ...followTop,
-    background: globalColors.grey
-  },
-  following: {
-    ...followBottom,
-    background: globalColors.green
-  },
-  notFollowing: {
-    ...followBottom,
-    background: globalColors.grey
-  }
 }


### PR DESCRIPTION
This moves the avatar badging code from tracker/bio to the Avatar component and modifies it to scale with any avatar size (over 16 which is just too small). This is a desktop only implementation, mobile is blocking on #2949.

I'll let vissdiff fill in the screenshots. They should match the design and naming at [zpl.io/1GafG9](zpl.io/1GafG9).

@keybase/react-hackers 