### PR TITLE
visdiff: Don't upload empty results folders to S3

### DIFF
--- a/desktop/test/run-visdiff.js
+++ b/desktop/test/run-visdiff.js
@@ -128,17 +128,6 @@ function processDiff (commitRange, results) {
     }
   })
 
-  if (!DRY_RUN) {
-    const s3Env = {
-      ...process.env,
-      AWS_ACCESS_KEY_ID: process.env['VISDIFF_AWS_ACCESS_KEY_ID'],
-      AWS_SECRET_ACCESS_KEY: process.env['VISDIFF_AWS_SECRET_ACCESS_KEY']
-    }
-    console.log(`Uploading ${diffDir} to ${BUCKET_S3}...`)
-    execSync(`s3cmd put --acl-public -r screenshots/${diffDir} ${BUCKET_S3}`, {env: s3Env})
-    console.log('Screenshots uploaded.')
-  }
-
   const commentLines = []
   let imageCount = 0
 
@@ -178,6 +167,15 @@ function processDiff (commitRange, results) {
     const commentBody = commentLines.join('\n')
 
     if (!DRY_RUN) {
+      const s3Env = {
+        ...process.env,
+        AWS_ACCESS_KEY_ID: process.env['VISDIFF_AWS_ACCESS_KEY_ID'],
+        AWS_SECRET_ACCESS_KEY: process.env['VISDIFF_AWS_SECRET_ACCESS_KEY']
+      }
+      console.log(`Uploading ${diffDir} to ${BUCKET_S3}...`)
+      execSync(`s3cmd put --acl-public -r screenshots/${diffDir} ${BUCKET_S3}`, {env: s3Env})
+      console.log('Screenshots uploaded.')
+
       var ghClient = github.client(process.env['VISDIFF_GH_TOKEN'])
       var ghIssue = ghClient.issue('keybase/client', process.env['TRAVIS_PULL_REQUEST'])
       ghIssue.createComment({body: commentBody}, (err, res) => {


### PR DESCRIPTION
These are causing s3cmd 1.6.1 to error, since it doesn't find anything to upload.

:eyeglasses: @cjb 