### PR TITLE
Friendships list desktop dumb component DESKTOP-1166

### DIFF
--- a/shared/common-adapters/dumb.desktop.js
+++ b/shared/common-adapters/dumb.desktop.js
@@ -57,7 +57,7 @@ const tabBarCustomButtons = selectedIndex => ({
       : <IconButton icon={buttonInfo.icon} label={buttonInfo.label} badgeNumber={buttonInfo.badgeNumber} selected={selectedIndex === i} />
 
     return (
-      <TabBarItem tabBarButton={button} containerStyle={{display: 'flex'}} selected={selectedIndex === i} onClick={() => console.log('TabBaritem:onClick')}>
+      <TabBarItem tabBarButton={button} styleContainer={{display: 'flex'}} selected={selectedIndex === i} onClick={() => console.log('TabBaritem:onClick')}>
         <Text type='Header' style={{flex: 1}}>Content here at: {i}</Text>
       </TabBarItem>
     )

--- a/shared/common-adapters/dumb.native.js
+++ b/shared/common-adapters/dumb.native.js
@@ -51,7 +51,7 @@ const tabBarCustomButtons = selectedIndex => ({
       : <IconButton icon={buttonInfo.icon} badgeNumber={buttonInfo.badgeNumber} selected={selectedIndex === i} />
 
     return (
-      <TabBarItem tabBarButton={button} containerStyle={{flex: 1}} selected={selectedIndex === i} onClick={() => console.log('TabBaritem:onClick')}>
+      <TabBarItem tabBarButton={button} styleContainer={{flex: 1}} selected={selectedIndex === i} onClick={() => console.log('TabBaritem:onClick')}>
         <Text type='Header' style={{flex: 2}}>Content here at: {i}</Text>
       </TabBarItem>
     )

--- a/shared/common-adapters/tab-bar.desktop.js
+++ b/shared/common-adapters/tab-bar.desktop.js
@@ -16,15 +16,40 @@ export class TabBarItem extends Component {
 }
 
 type SimpleTabBarButtonProps = {
-  selected: boolean,
   label: string,
-  tabWidth?: ?number,
-  style?: Object
+  selected: boolean,
+  selectedColor?: string,
+  underlined?: boolean,
+  onBottom?: boolean,
+  styleContainer?: Object,
+  styleLabel?: Object
 }
 
 class SimpleTabBarButton extends Component<void, SimpleTabBarButtonProps, void> {
   render () {
-    return <Text type='BodySemibold'>Not implemented, use tab bar button</Text>
+    const selectedColor = this.props.selectedColor || globalColors.blue
+    const borderLocation = this.props.onBottom ? 'borderTop' : 'borderBottom'
+    const underlineStyle = this.props.underlined ? {textDecoration: 'underlined'} : {}
+    return (
+      <Box
+        style={{
+          [borderLocation]: this.props.selected
+            ? `solid 2px ${selectedColor}`
+            : 'solid 2px transparent',
+          padding: '4px 12px',
+          ...this.props.styleContainer
+        }}>
+        <Text
+          type='BodySmall'
+          style={{
+            color: this.props.selected ? globalColors.black_75 : globalColors.black_60,
+            ...underlineStyle,
+            ...this.props.styleLabel
+          }}>
+          {this.props.label}
+        </Text>
+      </Box>
+    )
   }
 }
 
@@ -108,7 +133,16 @@ class TabBar extends Component {
     // TODO: Not sure why I have to wrap the child in a box, but otherwise touches won't work
     return (this.props.children || []).map((item, i) => (
       <Box key={item.props.label || i} style={item.props.containerStyle} onClick={item.props.onClick}>
-        {item.props.tabBarButton || <SimpleTabBarButton label={item.props.label} selected={item.props.selected} underlined={this.props.underlined} />}
+        {item.props.tabBarButton ||
+          <SimpleTabBarButton
+            label={item.props.label}
+            selected={item.props.selected}
+            selectedColor={item.props.selectedColor}
+            underlined={this.props.underlined}
+            onBottom={this.props.tabBarOnBottom}
+            styleContainer={item.props.styleContainer}
+            styleLabel={item.props.styleLabel}
+          />}
       </Box>
     ))
   }

--- a/shared/common-adapters/tab-bar.desktop.js
+++ b/shared/common-adapters/tab-bar.desktop.js
@@ -33,9 +33,7 @@ class SimpleTabBarButton extends Component<void, SimpleTabBarButtonProps, void> 
     return (
       <Box
         style={{
-          [borderLocation]: this.props.selected
-            ? `solid 2px ${selectedColor}`
-            : 'solid 2px transparent',
+          [borderLocation]: `solid 2px ${this.props.selected ? selectedColor : 'transparent'}`,
           padding: '4px 12px',
           ...this.props.styleContainer
         }}>

--- a/shared/common-adapters/tab-bar.js.flow
+++ b/shared/common-adapters/tab-bar.js.flow
@@ -9,8 +9,10 @@ export type ItemProps = {
   label?: string,
   style?: Object,
   selected?: boolean,
+  selectedColor?: string,
   onClick?: () => void,
-  containerStyle?: Object,
+  styleContainer?: Object,
+  styleLabel?: Object,
   children?: React$Element
 }
 

--- a/shared/dev/dumb-component-map.desktop.js
+++ b/shared/dev/dumb-component-map.desktop.js
@@ -13,6 +13,7 @@ import FoldersConfirmMap from '../folders/confirm/dumb'
 import ProfileMap from '../profile/dumb'
 import SearchMap from '../search/dumb'
 import SearchUserPaneMap from '../search/user-pane/dumb'
+import FriendshipsMap from '../profile/friendships.dumb' // TODO (AW): remove once chromakode is done working on profile stuff
 import type {DumbComponentMap} from './dumb'
 
 const map : DumbComponentMap = {
@@ -30,7 +31,8 @@ const map : DumbComponentMap = {
   ...FoldersConfirmMap,
   ...ProfileMap,
   ...SearchMap,
-  ...SearchUserPaneMap
+  ...SearchUserPaneMap,
+  ...FriendshipsMap
 }
 
 export default map

--- a/shared/dev/dumb-sheet.render.native.js
+++ b/shared/dev/dumb-sheet.render.native.js
@@ -44,7 +44,7 @@ class Render extends Component<void, any, any> {
 
         components.push(
           <Box key={mockKey} style={styleBox}>
-            <Text type='Body' style={{marginBottom: 5}}>{mockKey}</Text>
+            <Text type='Body' style={{marginBottom: 5}}>{key}: {mockKey}</Text>
             <Box style={{flex: 1}} {...parentProps}>
               <Component key={mockKey} {...mock} />
             </Box>

--- a/shared/profile/friendships.desktop.js
+++ b/shared/profile/friendships.desktop.js
@@ -1,0 +1,86 @@
+/* @flow */
+import React, {Component} from 'react'
+import {Box, Avatar, Text} from '../common-adapters'
+import TabBar, {TabBarItem} from '../common-adapters/tab-bar'
+import {globalStyles, globalColors} from '../styles/style-guide'
+import type {Props, UserInfo} from './friendships'
+
+type UserEntryProps = UserInfo & {
+  onClick?: (username: string) => void
+};
+
+class RenderUserEntry extends Component<void, UserEntryProps, void> {
+  render () {
+    return (
+      <Box
+        style={userEntryContainerStyle}
+        onClick={() => { this.props.onClick && this.props.onClick(this.props.username) }}>
+        <Avatar
+          style={userEntryAvatarStyle}
+          size={48}
+          username={this.props.username}
+          followsYou={this.props.followsYou}
+          following={this.props.following} />
+        <Text type='BodySmall' style={userEntryUsernameStyle(this.props.followsYou)}>{this.props.username}</Text>
+        <Text type='BodySmall' style={userEntryFullnameStyle}>{this.props.fullname}</Text>
+      </Box>
+    )
+  }
+}
+
+const userEntryContainerStyle = {
+  ...globalStyles.clickable,
+  ...globalStyles.flexBoxColumn,
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 130,
+  height: 130
+}
+
+const userEntryAvatarStyle = {
+  marginBottom: 2
+}
+
+const userEntryUsernameStyle = followsYou => ({
+  color: followsYou ? globalColors.green : globalColors.blue
+})
+
+const userEntryFullnameStyle = {
+  color: globalColors.black_40
+}
+
+class Render extends Component<void, Props, void> {
+  render () {
+    return (
+      <Box>
+        <TabBar>
+          <TabBarItem
+            selected={this.props.currentTab === 'FOLLOWERS'}
+            label={`FOLLOWERS (${this.props.followers.length})`}
+            onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab('FOLLOWERS') }}>
+            <Box style={tabItemContainerStyle}>
+              {this.props.followers.map(user => <RenderUserEntry key={user.username} {...user} />)}
+            </Box>
+          </TabBarItem>
+          <TabBarItem
+            selected={this.props.currentTab === 'FOLLOWING'}
+            label={`FOLLOWING (${this.props.following.length})`}
+            onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab('FOLLOWING') }}>
+            <Box style={tabItemContainerStyle}>
+              {this.props.following.map(user => <RenderUserEntry key={user.username} {...user} />)}
+            </Box>
+          </TabBarItem>
+        </TabBar>
+      </Box>
+    )
+  }
+}
+
+const tabItemContainerStyle = {
+  ...globalStyles.flexBoxRow,
+  flex: 1,
+  flexWrap: 'wrap',
+  borderTop: `solid 1px ${globalColors.black_10}`
+}
+
+export default Render

--- a/shared/profile/friendships.desktop.js
+++ b/shared/profile/friendships.desktop.js
@@ -9,24 +9,13 @@ type UserEntryProps = UserInfo & {
   onClick?: (username: string) => void
 };
 
-class RenderUserEntry extends Component<void, UserEntryProps, void> {
-  render () {
-    return (
-      <Box
-        style={userEntryContainerStyle}
-        onClick={() => { this.props.onClick && this.props.onClick(this.props.username) }}>
-        <Avatar
-          style={userEntryAvatarStyle}
-          size={48}
-          username={this.props.username}
-          followsYou={this.props.followsYou}
-          following={this.props.following} />
-        <Text type='BodySmall' style={userEntryUsernameStyle(this.props.followsYou)}>{this.props.username}</Text>
-        <Text type='BodySmall' style={userEntryFullnameStyle}>{this.props.fullname}</Text>
-      </Box>
-    )
-  }
-}
+const UserEntry = ({onClick, username, followsYou, following, fullname}: UserEntryProps) => (
+  <Box style={userEntryContainerStyle} onClick={() => { onClick && onClick(username) }}>
+    <Avatar style={userEntryAvatarStyle} size={48} username={username} followsYou={followsYou} following={following} />
+    <Text type='BodySmall' style={userEntryUsernameStyle(followsYou)}>{username}</Text>
+    <Text type='BodySmall' style={userEntryFullnameStyle}>{fullname}</Text>
+  </Box>
+)
 
 const userEntryContainerStyle = {
   ...globalStyles.clickable,
@@ -52,26 +41,24 @@ const userEntryFullnameStyle = {
 class Render extends Component<void, Props, void> {
   render () {
     return (
-      <Box>
-        <TabBar>
-          <TabBarItem
-            selected={this.props.currentTab === 'FOLLOWERS'}
-            label={`FOLLOWERS (${this.props.followers.length})`}
-            onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab('FOLLOWERS') }}>
-            <Box style={tabItemContainerStyle}>
-              {this.props.followers.map(user => <RenderUserEntry key={user.username} {...user} />)}
-            </Box>
-          </TabBarItem>
-          <TabBarItem
-            selected={this.props.currentTab === 'FOLLOWING'}
-            label={`FOLLOWING (${this.props.following.length})`}
-            onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab('FOLLOWING') }}>
-            <Box style={tabItemContainerStyle}>
-              {this.props.following.map(user => <RenderUserEntry key={user.username} {...user} />)}
-            </Box>
-          </TabBarItem>
-        </TabBar>
-      </Box>
+      <TabBar>
+        <TabBarItem
+          selected={this.props.currentTab === 'FOLLOWERS'}
+          label={`FOLLOWERS (${this.props.followers.length})`}
+          onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab('FOLLOWERS') }}>
+          <Box style={tabItemContainerStyle}>
+            {this.props.followers.map(user => <UserEntry key={user.username} {...user} onClick={this.props.onUserClick} />)}
+          </Box>
+        </TabBarItem>
+        <TabBarItem
+          selected={this.props.currentTab === 'FOLLOWING'}
+          label={`FOLLOWING (${this.props.following.length})`}
+          onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab('FOLLOWING') }}>
+          <Box style={tabItemContainerStyle}>
+            {this.props.following.map(user => <UserEntry key={user.username} {...user} onClick={this.props.onUserClick} />)}
+          </Box>
+        </TabBarItem>
+      </TabBar>
     )
   }
 }

--- a/shared/profile/friendships.desktop.js
+++ b/shared/profile/friendships.desktop.js
@@ -21,9 +21,9 @@ const userEntryContainerStyle = {
   ...globalStyles.clickable,
   ...globalStyles.flexBoxColumn,
   alignItems: 'center',
-  justifyContent: 'center',
+  justifyContent: 'flex-start',
   width: 130,
-  height: 130
+  padding: '10px 5px'
 }
 
 const userEntryAvatarStyle = {
@@ -31,11 +31,13 @@ const userEntryAvatarStyle = {
 }
 
 const userEntryUsernameStyle = followsYou => ({
-  color: followsYou ? globalColors.green : globalColors.blue
+  color: followsYou ? globalColors.green : globalColors.blue,
+  textAlign: 'center'
 })
 
 const userEntryFullnameStyle = {
-  color: globalColors.black_40
+  color: globalColors.black_40,
+  textAlign: 'center'
 }
 
 class Render extends Component<void, Props, void> {

--- a/shared/profile/friendships.dumb.js
+++ b/shared/profile/friendships.dumb.js
@@ -1,0 +1,41 @@
+// @flow
+
+import Friendships from './friendships'
+import type {DumbComponentMap} from '../constants/types/more'
+import type {Props} from './friendships'
+
+const propsNormal: Props = {
+  currentTab: 'FOLLOWERS',
+  onSwitchTab: selected => { console.log('friendships:onSwitchTab', selected) },
+  onUserClick: username => { console.log('friendships:onUserClick', username) },
+  followers: [
+    {username: 'awendland', fullname: 'Alex Wendland', followsYou: true, following: false},
+    {username: 'marcopolo', fullname: 'Marco Munizaga', followsYou: false, following: false},
+    {username: 'chromakode', fullname: 'Max Goodman', followsYou: true, following: true},
+    {username: 'strib', fullname: 'Jeremy Stribling', followsYou: false, following: true},
+    {username: 'chris', fullname: 'Chris Vendle', followsYou: false, following: false},
+    {username: 'thor', fullname: 'Thor Asgard', followsYou: false, following: true},
+    {username: 'alex', fullname: 'Alexander The-Gret', followsYou: true, following: false},
+    {username: 'daniel', fullname: 'Daniel Steven', followsYou: true, following: true}
+  ],
+  following: [
+    {username: 'zanderz', fullname: 'Steve Sanders', followsYou: false, following: false},
+    {username: 'awendland', fullname: 'Alex Wendland', followsYou: true, following: false},
+    {username: 'strib', fullname: 'Jeremy Stribling', followsYou: false, following: true}
+  ]
+}
+
+const dumbComponentMap: DumbComponentMap<Friendships> = {
+  component: Friendships,
+  mocks: {
+    'Followers': propsNormal,
+    'Following': {
+      ...propsNormal,
+      currentTab: 'FOLLOWING'
+    }
+  }
+}
+
+export default {
+  'Friendships': dumbComponentMap
+}

--- a/shared/profile/friendships.js.flow
+++ b/shared/profile/friendships.js.flow
@@ -1,0 +1,21 @@
+/* @flow */
+
+export type UserInfo = { // TODO (AW): replace with reference to bio's/profile's UserInfo
+  username: string,
+  fullname: string,
+  followsYou: boolean,
+  following: boolean
+}
+
+export type Tab = 'FOLLOWERS' | 'FOLLOWING'
+
+export type Props = {
+  currentTab: Tab,
+  onSwitchTab?: (selected: Tab) => void,
+  onUserClick?: (username: string) => void,
+  followers: Array<any>,
+  following: Array<any>
+}
+
+export default class Render extends React$Component<void, Props, void> {
+}

--- a/shared/profile/friendships.native.js
+++ b/shared/profile/friendships.native.js
@@ -1,0 +1,19 @@
+// @flow
+import React, {Component} from 'react'
+import {Box, ComingSoon} from '../common-adapters'
+import type {Props} from './render'
+
+class Render extends Component<void, Props, void> {
+  _renderComingSoon () {
+    return <ComingSoon />
+  }
+
+  render () {
+    if (this.props.showComingSoon) {
+      return this._renderComingSoon()
+    }
+    return <Box />
+  }
+}
+
+export default Render


### PR DESCRIPTION
Creates a dumb component for the followers/following component at the bottom of the profiles screen @ [zpl.io/1rwApg](zpl.io/1rwApg). I've named the intersection of these followers/following as "friendships" out of inspiration from Twitter—see [`GET /friendships/lookup`](https://dev.twitter.com/rest/reference/get/friendships/lookup).

The avatars are arranged in rows which overflow to new rows when they run out of space. Padding is constant (no justify-content: space-around) because the design doc appears to take this approach (look at the extra margin on the right side).

Here're some dumb component demos:

![screen shot 2016-06-10 at 3 56 18 pm](https://cloud.githubusercontent.com/assets/1152104/15980926/1cb2fab4-2f24-11e6-9837-a4d881adf6b2.png)

@keybase/react-hackers 
