### PR TITLE
Fix alignment of tracker icons

### DIFF
--- a/shared/common-adapters/user-proofs.desktop.js
+++ b/shared/common-adapters/user-proofs.desktop.js
@@ -168,6 +168,9 @@ const styleRow = {
 const styleService = {
   ...globalStyles.clickable,
   fontSize: 15,
+  width: 15,
+  flexShrink: 0,
+  textAlign: 'center',
   color: globalColors.black_75,
   hoverColor: globalColors.black_75,
   marginRight: 9,


### PR DESCRIPTION
There's variance in the size of the font icons being used for services in the tracker windows, which is causing the alignment of the lines to vary. Hopefully visdiff will confirm this fix.