### PR TITLE
Don't warn about invalid local debug JSON if it's unset

### DIFF
--- a/shared/local-debug.desktop.js
+++ b/shared/local-debug.desktop.js
@@ -46,10 +46,12 @@ if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) {
   config.printRoutes = true
 
   let envJson = null
-  try {
-    envJson = JSON.parse(process.env.KEYBASE_LOCAL_DEBUG_JSON)
-  } catch (e) {
-    console.warn('Invalid KEYBASE_LOCAL_DEBUG_JSON:', e)
+  if (process.env.KEYBASE_LOCAL_DEBUG_JSON) {
+    try {
+      envJson = JSON.parse(process.env.KEYBASE_LOCAL_DEBUG_JSON)
+    } catch (e) {
+      console.warn('Invalid KEYBASE_LOCAL_DEBUG_JSON:', e)
+    }
   }
 
   config = {...config, ...envJson}


### PR DESCRIPTION
@keybase/react-hackers 

Silences:
```
Invalid KEYBASE_LOCAL_DEBUG_JSON: SyntaxError: Unexpected token u in JSON at position 0
    at Object.parse (native)
    at eval (eval at <anonymous> (/home/cjb/go/src/github.com/keybase/client/desktop/dist/main.hot.bundle.js:918:2), <anonymous>:77:20)
    at Object.<anonymous> (/home/cjb/go/src/github.com/keybase/client/desktop/dist/main.hot.bundle.js:918:2)
    at __webpack_require__ (/home/cjb/go/src/github.com/keybase/client/desktop/dist/main.hot.bundle.js:557:30)
    at fn (/home/cjb/go/src/github.com/keybase/client/desktop/dist/main.hot.bundle.js:88:20)
    at eval (eval at <anonymous> (/home/cjb/go/src/github.com/keybase/client/desktop/dist/main.hot.bundle.js:798:2), <anonymous>:45:19)
    at Object.<anonymous> (/home/cjb/go/src/github.com/keybase/client/desktop/dist/main.hot.bundle.js:798:2)
    at __webpack_require__ (/home/cjb/go/src/github.com/keybase/client/desktop/dist/main.hot.bundle.js:557:30)
    at fn (/home/cjb/go/src/github.com/keybase/client/desktop/dist/main.hot.bundle.js:88:20)
    at eval (eval at <anonymous> (/home/cjb/go/src/github.com/keybase/client/desktop/dist/main.hot.bundle.js:10940:2), <anonymous>:8:15)
```
when not setting $KEYBASE_LOCAL_DEBUG_JSON.