### PR TITLE
clean up gregor output CORE-3185

### DIFF
--- a/go/vendor/github.com/keybase/go-framed-msgpack-rpc/connection_test_util.go
+++ b/go/vendor/github.com/keybase/go-framed-msgpack-rpc/connection_test_util.go
@@ -1,0 +1,153 @@
+package rpc
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+type testConnectionHandler struct{}
+
+var _ ConnectionHandler = testConnectionHandler{}
+
+func (testConnectionHandler) OnConnect(context.Context, *Connection, GenericClient, *Server) error {
+	return nil
+}
+
+func (testConnectionHandler) OnConnectError(err error, reconnectThrottleDuration time.Duration) {
+}
+
+func (testConnectionHandler) OnDoCommandError(err error, nextTime time.Duration) {
+}
+
+func (testConnectionHandler) OnDisconnected(ctx context.Context, status DisconnectStatus) {
+}
+
+func (testConnectionHandler) ShouldRetry(name string, err error) bool {
+	return false
+}
+
+func (testConnectionHandler) ShouldRetryOnConnect(err error) bool {
+	return false
+}
+
+func (testConnectionHandler) HandlerName() string {
+	return "testConnectionHandler"
+}
+
+type singleTransport struct {
+	t Transporter
+}
+
+var _ ConnectionTransport = singleTransport{}
+
+// Dial is an implementation of the ConnectionTransport interface.
+func (st singleTransport) Dial(ctx context.Context) (Transporter, error) {
+	if !st.t.IsConnected() {
+		return nil, io.EOF
+	}
+	return st.t, nil
+}
+
+// IsConnected is an implementation of the ConnectionTransport interface.
+func (st singleTransport) IsConnected() bool {
+	return st.t.IsConnected()
+}
+
+// Finalize is an implementation of the ConnectionTransport interface.
+func (st singleTransport) Finalize() {}
+
+// Close is an implementation of the ConnectionTransport interface.
+func (st singleTransport) Close() {}
+
+type testStatus struct {
+	Code int
+}
+type testUnwrapper struct{}
+
+func testWrapError(err error) interface{} {
+	return &testStatus{}
+}
+
+func testLogTags(ctx context.Context) (map[interface{}]string, bool) {
+	return nil, false
+}
+
+type throttleError struct {
+	Err error
+}
+
+func (e throttleError) ToStatus() (s testStatus) {
+	s.Code = 15
+	return
+}
+
+func (e throttleError) Error() string {
+	return e.Err.Error()
+}
+
+type testErrorUnwrapper struct{}
+
+var _ ErrorUnwrapper = testErrorUnwrapper{}
+
+func (eu testErrorUnwrapper) MakeArg() interface{} {
+	return &testStatus{}
+}
+
+func (eu testErrorUnwrapper) UnwrapError(arg interface{}) (appError error, dispatchError error) {
+	s, ok := arg.(*testStatus)
+	if !ok {
+		return nil, errors.New("Error converting arg to testStatus object")
+	}
+	if s == nil || s.Code == 0 {
+		return nil, nil
+	}
+
+	switch s.Code {
+	case 15:
+		appError = throttleError{errors.New("throttle")}
+		break
+	default:
+		panic("Unknown testing error")
+	}
+	return appError, nil
+}
+
+// TestLogger is an interface for things, like *testing.T, that have a
+// Logf function.
+type TestLogger interface {
+	Logf(format string, args ...interface{})
+}
+
+type testLogOutput struct {
+	t TestLogger
+}
+
+func (t testLogOutput) log(ch string, fmts string, args []interface{}) {
+	fmts = fmt.Sprintf("[%s] %s", ch, fmts)
+	t.t.Logf(fmts, args...)
+}
+
+func (t testLogOutput) Info(fmt string, args ...interface{})    { t.log("I", fmt, args) }
+func (t testLogOutput) Error(fmt string, args ...interface{})   { t.log("E", fmt, args) }
+func (t testLogOutput) Debug(fmt string, args ...interface{})   { t.log("D", fmt, args) }
+func (t testLogOutput) Warning(fmt string, args ...interface{}) { t.log("W", fmt, args) }
+func (t testLogOutput) Profile(fmt string, args ...interface{}) { t.log("P", fmt, args) }
+
+// MakeConnectionForTest returns a Connection object, and a net.Conn
+// object representing the other end of that connection.
+func MakeConnectionForTest(t TestLogger) (net.Conn, *Connection) {
+	clientConn, serverConn := net.Pipe()
+	logOutput := testLogOutput{t}
+	logFactory := NewSimpleLogFactory(logOutput, nil)
+	transporter := NewTransport(clientConn, logFactory, testWrapError)
+	st := singleTransport{transporter}
+	conn := NewConnectionWithTransport(testConnectionHandler{}, st,
+		testErrorUnwrapper{}, true, testWrapError,
+		logOutput, testLogTags)
+	return serverConn, conn
+}

--- a/go/vendor/github.com/keybase/go-framed-msgpack-rpc/server.go
+++ b/go/vendor/github.com/keybase/go-framed-msgpack-rpc/server.go
@@ -15,20 +15,21 @@ func (s *Server) Register(p Protocol) error {
 }
 
 // Run starts processing incoming RPC messages asynchronously, if it
-// hasn't been started already. Returns a channel that's closed when
-// incoming frames have finished processing, either due to an error or
-// the underlying connection being closed. Successive calls to Run()
-// return the same value.
-//
-// If you want to know when said processing is done, and any
-// associated error, use Transport.Done() and Transport.Err().
+// hasn't been started already. Returns the result of Done(), for
+// convenience.
 func (s *Server) Run() <-chan struct{} {
 	return s.xp.receiveFrames()
 }
 
-// Err returns a non-nil error value after the channel returned by Run
-// is closed.  After that channel is closed, successive calls to Err
-// return the same value.
+// Returns a channel that's closed when incoming frames have finished
+// processing, either due to an error or the underlying connection
+// being closed. Successive calls to Done() return the same value.
+func (s *Server) Done() <-chan struct{} {
+	return s.xp.done()
+}
+
+// Err returns a non-nil error value after Done() is closed.  After
+// Done() is closed, successive calls to Err return the same value.
 func (s *Server) Err() error {
 	return s.xp.err()
 }

--- a/go/vendor/github.com/keybase/go-framed-msgpack-rpc/transport.go
+++ b/go/vendor/github.com/keybase/go-framed-msgpack-rpc/transport.go
@@ -24,15 +24,17 @@ type Transporter interface {
 
 	// receiveFrames starts processing incoming frames in a
 	// background goroutine, if it's not already happening.
-	//
+	// Returns the result of done(), for convenience.
+	receiveFrames() <-chan struct{}
+
 	// Returns a channel that's closed when incoming frames have
 	// finished processing, either due to an error or the
 	// underlying connection being closed. Successive calls to
-	// receiveFrames return the same value.
-	receiveFrames() <-chan struct{}
+	// done() return the same value.
+	done() <-chan struct{}
 
-	// err returns a non-nil error value after done is closed.
-	// After done is closed, successive calls to err return the
+	// err returns a non-nil error value after done() is closed.
+	// After done() is closed, successive calls to err return the
 	// same value.
 	err() error
 }
@@ -119,6 +121,10 @@ func (t *transport) receiveFrames() <-chan struct{} {
 		// Subsequent times -- do nothing.
 	}
 
+	return t.stopCh
+}
+
+func (t *transport) done() <-chan struct{} {
 	return t.stopCh
 }
 

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -178,10 +178,10 @@
 			"revisionTime": "2016-03-19T10:18:54-07:00"
 		},
 		{
-			"checksumSHA1": "jpUqeZQ0mjQc5tN4Ecr+A12M2VA=",
+			"checksumSHA1": "bQYKzjpfY6drHZIr7jncJHAh8BQ=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc",
-			"revision": "2a4cdfc4f2ce5894aef188818ec5f03ed3ea9614",
-			"revisionTime": "2016-05-16T17:05:43-05:00"
+			"revision": "090895b12240aa18b8d6a759a2638f0c1065c7d0",
+			"revisionTime": "2016-06-15T14:04:14Z"
 		},
 		{
 			"path": "github.com/keybase/go-jsonw",


### PR DESCRIPTION
@maxtaco This demotes a bunch of prints to Debug, as well as converting all the prefixes to "push handler". There is also a change from the rpc library vendored in to reduce client spam.