### PR TITLE
Make tab content flex styled & views manage scroll

### DIFF
--- a/shared/dev/dumb-sheet.render.desktop.js
+++ b/shared/dev/dumb-sheet.render.desktop.js
@@ -31,7 +31,7 @@ class Render extends Component<void, any, any> {
 
   render () {
     return (
-      <Box style={{flex: 1, padding: 20}}>
+      <Box style={{...globalStyles.scrollable, padding: 20}}>
         <Box style={{...globalStyles.flexBoxRow}}>
           <Text type='Header'>Filter:</Text>
           <Input

--- a/shared/dev/style-sheet.render.desktop.js
+++ b/shared/dev/style-sheet.render.desktop.js
@@ -262,7 +262,7 @@ const Inputs = () => (
 export default class Render extends Component {
   render () {
     return (
-      <Box style={{flex: 1, overflow: 'auto', margin: 20}}>
+      <Box style={{flex: 1, ...globalStyles.scrollable, padding: 20}}>
         <Container title='Text'><Fonts /></Container>
         <Container title='Icons'><Icons /></Container>
         <Container title='Buttons'><Buttons /></Container>

--- a/shared/devices/render.desktop.js
+++ b/shared/devices/render.desktop.js
@@ -148,8 +148,7 @@ class Render extends Component<void, Props, State> {
 }
 
 const stylesContainer = {
-  ...globalStyles.flexBoxColumn,
-  position: 'relative'
+  ...globalStyles.scrollable
 }
 
 const stylesCommonRow = {

--- a/shared/folders/list.desktop.js
+++ b/shared/folders/list.desktop.js
@@ -81,8 +81,7 @@ class Render extends Component<void, Props, State> {
 }
 
 const stylesScrollContainer = {
-  overflowY: 'auto',
-  overflowX: 'hidden'
+  ...globalStyles.scrollable
 }
 
 const stylesContainer = {

--- a/shared/folders/list.desktop.js
+++ b/shared/folders/list.desktop.js
@@ -56,36 +56,31 @@ class Render extends Component<void, Props, State> {
     const styles = this.props.isPublic ? stylesPublic : stylesPrivate
 
     return (
-      <Box style={{...stylesScrollContainer, ...this.props.style}}>
-        <Box style={stylesContainer}>
-          <style>{realCSS}</style>
-          {this.props.extraRows}
-          {this.props.tlfs && this.props.tlfs.map((t, idx) => (
-            <Row
-              key={rowKey(t.users)}
-              {...t}
-              isPublic={this.props.isPublic}
-              ignored={false}
-              onClick={this.props.onClick}
-              onRekey={this.props.onRekey}
-              smallMode={this.props.smallMode}
-              isFirst={!idx} />
-            ))}
-            {this.props.ignored && this.props.ignored.length > 0 && <Ignored
-              ignored={this.props.ignored} showIgnored={this.state.showIgnored} styles={styles} onRekey={this.props.onRekey}
-              isPublic={this.props.isPublic} onToggle={() => this.setState({showIgnored: !this.state.showIgnored})} />}
-        </Box>
+      <Box style={{...stylesContainer, ...this.props.style}}>
+        <style>{realCSS}</style>
+        {this.props.extraRows}
+        {this.props.tlfs && this.props.tlfs.map((t, idx) => (
+          <Row
+            key={rowKey(t.users)}
+            {...t}
+            isPublic={this.props.isPublic}
+            ignored={false}
+            onClick={this.props.onClick}
+            onRekey={this.props.onRekey}
+            smallMode={this.props.smallMode}
+            isFirst={!idx} />
+          ))}
+          {this.props.ignored && this.props.ignored.length > 0 && <Ignored
+            ignored={this.props.ignored} showIgnored={this.state.showIgnored} styles={styles} onRekey={this.props.onRekey}
+            isPublic={this.props.isPublic} onToggle={() => this.setState({showIgnored: !this.state.showIgnored})} />}
       </Box>
     )
   }
 }
 
-const stylesScrollContainer = {
-  ...globalStyles.scrollable
-}
-
 const stylesContainer = {
-  ...globalStyles.flexBoxColumn
+  ...globalStyles.scrollable,
+  overflowX: 'hidden'
 }
 
 const stylesIgnoreContainer = {

--- a/shared/folders/render.desktop.js
+++ b/shared/folders/render.desktop.js
@@ -73,6 +73,7 @@ class Render extends Component<void, Props, void> {
 }
 
 const stylesContainer = {
+  ...globalStyles.flexBoxColumn,
   flexGrow: 1
 }
 

--- a/shared/folders/render.desktop.js
+++ b/shared/folders/render.desktop.js
@@ -73,8 +73,7 @@ class Render extends Component<void, Props, void> {
 }
 
 const stylesContainer = {
-  ...globalStyles.flexBoxColumn,
-  flex: 1
+  flexGrow: 1
 }
 
 const styleBadge = {

--- a/shared/settings/menu-list.desktop.js
+++ b/shared/settings/menu-list.desktop.js
@@ -1,14 +1,18 @@
 import React, {Component} from 'react'
 import {List, ListItem} from 'material-ui'
+import {Box} from '../common-adapters'
+import {globalStyles} from '../styles/style-guide'
 
 export default class MenuList extends Component {
   render () {
     return (
-      <List>
-        {this.props.items.map(title => {
-          return <ListItem key={title.name} onClick={title.onClick}>{title.name}</ListItem>
-        })}
-      </List>
+      <Box style={{...globalStyles.scrollable}}>
+        <List>
+          {this.props.items.map(title => {
+            return <ListItem key={title.name} onClick={title.onClick}>{title.name}</ListItem>
+          })}
+        </List>
+      </Box>
     )
   }
 }

--- a/shared/styles/style-guide.desktop.js
+++ b/shared/styles/style-guide.desktop.js
@@ -63,7 +63,7 @@ const util = {
     alignItems: 'center'
   },
   scrollable: {
-    overflow: 'auto'
+    overflowY: 'auto'
   },
   selectable: {
     WebkitUserSelect: 'initial'

--- a/shared/styles/style-guide.desktop.js
+++ b/shared/styles/style-guide.desktop.js
@@ -62,6 +62,9 @@ const util = {
     justifyContent: 'center',
     alignItems: 'center'
   },
+  scrollable: {
+    overflow: 'auto'
+  },
   selectable: {
     WebkitUserSelect: 'initial'
   },

--- a/shared/tab-bar/index.render.desktop.js
+++ b/shared/tab-bar/index.render.desktop.js
@@ -98,7 +98,7 @@ export default class Render extends Component<void, Props, void> {
         <TabBarItem
           key={t} tabBarButton={button}
           selected={this.props.selectedTab === t} onClick={onClick} containerStyle={{...stylesTabBarItem, ...(isProfile && {flex: 1, justifyContent: 'flex-end'})}}>
-          <Box style={{overflow: 'auto', flex: 1, ...globalStyles.flexBoxColumn}}>{this.props.tabContent[t]}</Box>
+          <Box style={{flex: 1, ...globalStyles.flexBoxColumn}}>{this.props.tabContent[t]}</Box>
         </TabBarItem>
       )
     })


### PR DESCRIPTION
Apply only `display: flex` and `flex: 1` (therefore, remove `overflow: auto`) to containers in meta navigator and tab-bar. This will expose a view to the child that is the full, available screen size that they can play with, no extra overflow attached. If the child needs to overflow, it can wrap it's contents in a normal Box/Div that has `scrollable: auto` (provided as `globalStyles.scrollable`). This separates the concerns of child overflow management away from the tab bar and meta navigator and provides more power to the children to maintain their scroll behavior/layout behavior in a marginally impactful SLOC manner. This also brings parity to how layouts are handled on native.

I attempted to fix all views that would be impacted by this change, the main ones being the dumb sheet, settings page, and devices list.

This arose out of a conversation with @MarcoPolo around layout goals and isolation of tab bar and meta navigator.

Ideally there would be no visual diffs, looking forward to what visdiff has to bring us.

@keybase/react-hackers 