### PR TITLE
Reuse search right pane components to fill out profile view

### DIFF
--- a/shared/common-adapters/user-bio.desktop.js
+++ b/shared/common-adapters/user-bio.desktop.js
@@ -3,7 +3,7 @@
 import React, {Component} from 'react'
 import {Text, Avatar} from '../common-adapters'
 import {error as proofError} from '../constants/tracker'
-import {globalStyles, globalColors} from '../styles/style-guide'
+import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import electron from 'electron'
 
 const shell = electron.shell || electron.remote.shell
@@ -89,7 +89,7 @@ export default class BioRender extends Component {
               </span>
             </Text>
             {userInfo.bio &&
-              <Text type='BodySmall' style={stylesBio} lineClamp={userInfo.location ? 2 : 3}>
+              <Text type={this.props.type === 'Profile' ? 'Body' : 'BodySmall'} style={{...stylesBio, ...stylesBioType[this.props.type]}} lineClamp={userInfo.location ? 2 : 3}>
                 {userInfo.bio}
               </Text>
             }
@@ -149,6 +149,12 @@ const stylesBio = {
   paddingLeft: 30,
   paddingRight: 30,
   textAlign: 'center'
+}
+const stylesBioType = {
+  Profile: {
+    marginTop: globalMargins.tiny
+  },
+  Tracker: {}
 }
 const stylesLocation = {
   ...globalStyles.selectable,

--- a/shared/common-adapters/user-bio.js.flow
+++ b/shared/common-adapters/user-bio.js.flow
@@ -14,6 +14,7 @@ export type UserInfo = {
 }
 
 export type Props = {
+  type: 'Tracker' | 'Profile',
   avatarSize: AvatarSize,
   style?: Object,
   username: ?string,

--- a/shared/common-adapters/user-proofs.desktop.js
+++ b/shared/common-adapters/user-proofs.desktop.js
@@ -2,7 +2,7 @@
 
 import React, {Component} from 'react'
 import commonStyles from '../styles/common'
-import {globalStyles, globalColors} from '../styles/style-guide'
+import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import {Icon, Text, Meta} from '../common-adapters/index'
 import {normal as proofNormal, checking as proofChecking, revoked as proofRevoked, error as proofError, warning as proofWarning} from '../constants/tracker'
 import {metaNew, metaUpgraded, metaUnreachable, metaPending, metaDeleted, metaNone, metaIgnored} from '../constants/tracker'
@@ -170,7 +170,7 @@ const styleService = {
   textAlign: 'center',
   color: globalColors.black_75,
   hoverColor: globalColors.black_75,
-  marginRight: 9,
+  marginRight: globalMargins.tiny,
   marginTop: 5
 }
 

--- a/shared/folders/dumb.js
+++ b/shared/folders/dumb.js
@@ -9,7 +9,7 @@ import type {DumbComponentMap} from '../constants/types/more'
 import {globalStyles} from '../styles/style-guide'
 import {pathFromFolder} from '../actions/favorite'
 
-function createFolder (partialFolder: $Shape<Folder>) {
+export function createFolder (partialFolder: $Shape<Folder>) {
   return {...partialFolder, path: pathFromFolder(partialFolder).path}
 }
 

--- a/shared/profile/common.desktop.js
+++ b/shared/profile/common.desktop.js
@@ -1,0 +1,46 @@
+// @flow
+import React from 'react'
+import {normal as proofNormal} from '../constants/tracker'
+import {Box, Button, FollowButton} from '../common-adapters'
+import {globalColors, globalMargins} from '../styles/style-guide'
+import type {SimpleProofState} from '../constants/tracker'
+
+export function userHeaderColor (trackerState: SimpleProofState, currentlyFollowing: boolean) {
+  if (trackerState === proofNormal) {
+    return currentlyFollowing ? globalColors.green : globalColors.blue
+  } else {
+    return globalColors.red
+  }
+}
+
+export function UserActions ({trackerState, currentlyFollowing, style, onFollow, onUnfollow, onAcceptProofs}: {
+  trackerState: SimpleProofState,
+  currentlyFollowing: boolean,
+  style: Object,
+  onFollow: () => void,
+  onUnfollow: () => void,
+  onAcceptProofs: () => void
+}) {
+  if (trackerState === proofNormal) {
+    if (currentlyFollowing) {
+      return (
+        <Box style={style}>
+          <FollowButton following onUnfollow={onUnfollow} style={{marginRight: 0}} />
+        </Box>
+      )
+    } else {
+      return (
+        <Box style={style}>
+          <FollowButton following={false} onFollow={onFollow} style={{marginRight: 0}} />
+        </Box>
+      )
+    }
+  } else {
+    return (
+      <Box style={style}>
+        <Button type='Unfollow' label='Untrack' onClick={onUnfollow} style={{marginRight: globalMargins.xtiny}} />
+        <Button type='Follow' label='Accept' onClick={onAcceptProofs} style={{marginRight: 0}} />
+      </Box>
+    )
+  }
+}

--- a/shared/profile/dumb.desktop.js
+++ b/shared/profile/dumb.desktop.js
@@ -1,6 +1,7 @@
 /* @flow */
 import Profile from './render'
 import {normal, checking, revoked, error, metaNone} from '../constants/tracker'
+import {createFolder} from '../folders/dumb'
 import type {Props as RenderProps} from './render'
 import type {Proof} from '../common-adapters/user-proofs'
 import type {UserInfo} from '../common-adapters/user-bio'
@@ -31,9 +32,56 @@ export const mockUserInfo: {username: string, userInfo: UserInfo} = {
   }
 }
 
+const baseFolder = {
+  ignored: false,
+  hasData: true,
+  groupAvatar: true,
+  userAvatar: null,
+  recentFiles: [],
+  waitingForParticipantUnlock: [],
+  youCanUnlock: []
+}
+
+const folders = [
+  createFolder({
+    users: [
+      {username: 'cecileb', you: true},
+      {username: 'chris'}
+    ],
+    isPublic: true,
+    ...baseFolder
+  }),
+  createFolder({
+    users: [
+      {username: 'cecileb', you: true},
+      {username: 'chris'}
+    ],
+    isPublic: false,
+    ...baseFolder
+  }),
+  createFolder({
+    users: [
+      {username: 'cecileb', you: true},
+      {username: 'chris'},
+      {username: 'max'}
+    ],
+    isPublic: false,
+    ...baseFolder
+  }),
+  createFolder({
+    users: [
+      {username: 'cecileb', you: true},
+      {username: 'max'}
+    ],
+    isPublic: true,
+    ...baseFolder
+  })
+]
+
 const propsBase: RenderProps = {
   ...mockUserInfo,
   proofs: proofsDefault,
+  tlfs: folders,
   trackerState: normal,
   currentlyFollowing: false,
   onFollow: () => console.log('onFollow'),

--- a/shared/profile/dumb.desktop.js
+++ b/shared/profile/dumb.desktop.js
@@ -27,7 +27,7 @@ export const mockUserInfo: {username: string, userInfo: UserInfo} = {
     location: 'NYC & Maine',
     bio: 'Co-founder of Keybase, OkCupid, SparkNotes, and some random other junk. I like making things.',
     avatar: 'https://keybase.io/chris/picture',
-    followsYou: false
+    followsYou: true
   }
 }
 

--- a/shared/profile/dumb.desktop.js
+++ b/shared/profile/dumb.desktop.js
@@ -1,51 +1,67 @@
 /* @flow */
 import Profile from './render'
-import {normal} from '../constants/tracker'
-import {metaNone} from '../constants/tracker'
+import {normal, checking, revoked, error, metaNone} from '../constants/tracker'
 import type {Props as RenderProps} from './render'
 import type {Proof} from '../common-adapters/user-proofs'
 import type {UserInfo} from '../common-adapters/user-bio'
 import type {DumbComponentMap} from '../constants/types/more'
 
-const proofTwitter: Proof = {name: 'twitteruser', type: 'twitter', id: 'twitterId', state: normal, meta: metaNone, humanUrl: 'twitter.com', profileUrl: 'http://twitter.com', isTracked: false}
-const proofWeb: Proof = {name: 'thelongestdomainnameintheworldandthensomeandthensomemoreandmore.com', type: 'http', id: 'webId', state: normal, meta: metaNone, humanUrl: 'thelongestdomainnameintheworldandthensomeandthensomemoreandmore.com', profileUrl: '', isTracked: false}
-const proofHN: Proof = {name: 'pg', type: 'hackernews', id: 'hnId', state: normal, meta: metaNone, humanUrl: 'news.ycombinator.com', profileUrl: 'http://news.ycombinator.com', isTracked: false}
-const proofRooter: Proof = {name: 'roooooooter', type: 'rooter', state: normal, meta: metaNone, id: 'rooterId', humanUrl: '', profileUrl: '', isTracked: false}
-
-const proofsDefault: Array<Proof> = [
-  proofTwitter,
-  proofWeb,
-  proofHN,
-  proofRooter
+export const proofsDefault: Array<Proof> = [
+  {name: 'malgorithms', type: 'twitter', id: 'twitterId', state: normal, meta: metaNone, humanUrl: 'twitter.com', profileUrl: 'http://twitter.com', isTracked: false},
+  {name: 'malgorithms', type: 'github', id: 'githubId', state: normal, meta: metaNone, humanUrl: 'github.com', profileUrl: 'http://github.com', isTracked: false},
+  {name: 'malgorithms', type: 'reddit', id: 'redditId', state: normal, meta: metaNone, humanUrl: 'reddit.com', profileUrl: 'http://reddit.com', isTracked: false},
+  {name: 'keybase.io', type: 'dns', id: 'dnsId', state: normal, meta: metaNone, humanUrl: 'keybase.io', profileUrl: 'http://keybase.io', isTracked: false},
+  {name: 'keybase.pub', type: 'dns', id: 'dns2Id', state: normal, meta: metaNone, humanUrl: 'keybase.pub', profileUrl: 'http://keybase.pub', isTracked: false}
 ]
 
-const userBase: {username: string, userInfo: UserInfo} = {
-  username: 'darksim905',
+export const proofsTracked = proofsDefault.map(proof => ({...proof, isTracked: true}))
+
+export const proofsChanged = proofsDefault.map((proof, idx) => ({...proof, state: idx % 2 ? checking : revoked}))
+
+export const mockUserInfo: {username: string, userInfo: UserInfo} = {
+  username: 'chris',
   userInfo: {
-    fullname: 'Gabriel Handford',
+    fullname: 'Chris Coyne',
     followersCount: 1871,
     followingCount: 356,
-    location: 'San Francisco, California, USA, Earth, Milky Way',
-    bio: 'Etsy photo booth mlkshk semiotics, 8-bit literally slow-carb keytar bushwick +1. Plaid migas etsy yuccie, locavore street art mlkshk lumbersexual. Literally microdosing pug disrupt iPhone raw denim, quinoa meggings kitsch.',
-    avatar: 'https://keybase.io/darksim905/picture',
+    location: 'NYC & Maine',
+    bio: 'Co-founder of Keybase, OkCupid, SparkNotes, and some random other junk. I like making things.',
+    avatar: 'https://keybase.io/chris/picture',
     followsYou: false
   }
 }
 
 const propsBase: RenderProps = {
-  ...userBase,
+  ...mockUserInfo,
   proofs: proofsDefault,
-  currentlyFollowing: false,
   trackerState: normal,
-  onFollow: () => {},
-  onUnfollow: () => {}
+  currentlyFollowing: false,
+  onFollow: () => console.log('onFollow'),
+  onUnfollow: () => console.log('onUnfollow'),
+  onAcceptProofs: () => console.log('onAcceptProofs'),
+  parentProps: {
+    style: {
+      width: 640,
+      height: 578
+    }
+  }
 }
 
 const dumbMap: DumbComponentMap<Profile> = {
   component: Profile,
   mocks: {
     'Unfollowed': propsBase,
-    'Followed': {...propsBase, currentlyFollowing: true}
+    'Followed': {
+      ...propsBase,
+      proofs: proofsTracked,
+      currentlyFollowing: true
+    },
+    'Changed': {
+      ...propsBase,
+      proofs: proofsChanged,
+      trackerState: error,
+      currentlyFollowing: true
+    }
   }
 }
 

--- a/shared/profile/render.desktop.js
+++ b/shared/profile/render.desktop.js
@@ -1,8 +1,12 @@
 /* @flow */
 import React, {Component} from 'react'
-import {Box, ComingSoon, UserBio, UserProofs} from '../common-adapters'
-import {globalStyles, globalColors} from '../styles/style-guide'
+import {normal as proofNormal} from '../constants/tracker'
+import {Box, Text, ComingSoon, UserBio, UserProofs} from '../common-adapters'
+import {userHeaderColor, UserActions} from './common.desktop'
+import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import type {Props} from './render'
+
+const HEADER_SIZE = 96
 
 class Render extends Component<void, Props, void> {
   _renderComingSoon () {
@@ -14,33 +18,93 @@ class Render extends Component<void, Props, void> {
       return this._renderComingSoon()
     }
 
-    // TODO: Work in progress demo of composition structure
-    const headerColor = this.props.currentlyFollowing ? globalColors.green : globalColors.blue
+    const headerColor = userHeaderColor(this.props.trackerState, this.props.currentlyFollowing)
+
+    let proofNotice
+    if (this.props.trackerState !== proofNormal) {
+      proofNotice = `Some of ${this.props.username}'s proofs have changed since you last tracked them.`
+    }
+
     return (
-      <Box>
+      <Box style={styleContainer}>
         <Box style={{...styleHeader, backgroundColor: headerColor}} />
         <Box style={globalStyles.flexBoxRow}>
-          <UserBio
-            avatarSize={112}
-            username={this.props.username}
-            userInfo={this.props.userInfo}
-            currentlyFollowing={this.props.currentlyFollowing}
-            trackerState={this.props.trackerState}
-          />
-          <UserProofs
-            username={this.props.username}
-            proofs={this.props.proofs}
-            currentlyFollowing={this.props.currentlyFollowing}
-          />
+          <Box style={styleBioColumn}>
+            <UserBio
+              avatarSize={112}
+              style={{marginTop: 39}}
+              username={this.props.username}
+              userInfo={this.props.userInfo}
+              currentlyFollowing={this.props.currentlyFollowing}
+              trackerState={this.props.trackerState}
+            />
+            <UserActions
+              style={styleActions}
+              trackerState={this.props.trackerState}
+              currentlyFollowing={this.props.currentlyFollowing}
+              onFollow={this.props.onFollow}
+              onUnfollow={this.props.onUnfollow}
+              onAcceptProofs={this.props.onAcceptProofs}
+            />
+          </Box>
+          <Box style={styleProofColumn}>
+            <Box style={styleProofNoticeBox}>
+              {proofNotice && <Text type='BodySmallSemibold' style={{color: globalColors.white}}>{proofNotice}</Text>}
+            </Box>
+            <UserProofs
+              style={styleProofs}
+              username={this.props.username}
+              proofs={this.props.proofs}
+              currentlyFollowing={this.props.currentlyFollowing}
+            />
+          </Box>
         </Box>
       </Box>
     )
   }
 }
 
+const styleContainer = {
+  ...globalStyles.flexBoxColumn,
+  position: 'relative'
+}
+
 const styleHeader = {
-  flex: 1,
-  height: 96
+  position: 'absolute',
+  width: '100%',
+  height: HEADER_SIZE
+}
+
+const styleBioColumn = {
+  ...globalStyles.flexBoxColumn,
+  alignItems: 'center'
+}
+
+const styleActions = {
+  ...globalStyles.flexBoxRow,
+  marginTop: globalMargins.small
+}
+
+const styleProofColumn = {
+  ...globalStyles.flexBoxColumn,
+  width: 320,
+  zIndex: 2
+}
+
+const styleProofNoticeBox = {
+  ...globalStyles.flexBoxRow,
+  height: HEADER_SIZE,
+  marginLeft: globalMargins.medium,
+  marginRight: globalMargins.medium,
+  alignItems: 'center',
+  textAlign: 'center'
+}
+
+const styleProofs = {
+  // header + small space from top of header + tiny space to pad top of first item
+  marginTop: globalMargins.small + globalMargins.tiny,
+  marginLeft: globalMargins.medium,
+  marginRight: globalMargins.medium
 }
 
 export default Render

--- a/shared/profile/render.desktop.js
+++ b/shared/profile/render.desktop.js
@@ -31,6 +31,7 @@ class Render extends Component<void, Props, void> {
         <Box style={globalStyles.flexBoxRow}>
           <Box style={styleBioColumn}>
             <UserBio
+              type='Profile'
               avatarSize={112}
               style={{marginTop: 39}}
               username={this.props.username}

--- a/shared/profile/render.desktop.js
+++ b/shared/profile/render.desktop.js
@@ -1,7 +1,8 @@
 /* @flow */
 import React, {Component} from 'react'
+import _ from 'lodash'
 import {normal as proofNormal} from '../constants/tracker'
-import {Box, Text, ComingSoon, UserBio, UserProofs} from '../common-adapters'
+import {Box, Icon, Text, ComingSoon, UserBio, UserProofs, Usernames} from '../common-adapters'
 import {userHeaderColor, UserActions} from './common.desktop'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import type {Props} from './render'
@@ -24,6 +25,16 @@ class Render extends Component<void, Props, void> {
     if (this.props.trackerState !== proofNormal) {
       proofNotice = `Some of ${this.props.username}'s proofs have changed since you last tracked them.`
     }
+
+    const folders = _.chain(this.props.tlfs)
+      .sortBy('isPublic')
+      .map(folder => (
+        <Box style={styleFolderLine}>
+          <Icon type={folder.isPublic ? 'icon-folder-public-32' : 'icon-folder-private-32'} style={styleFolderIcon} />
+          <Usernames users={folder.users} type={'Body'} />
+        </Box>
+      ))
+      .value()
 
     return (
       <Box style={styleContainer}>
@@ -58,6 +69,7 @@ class Render extends Component<void, Props, void> {
               proofs={this.props.proofs}
               currentlyFollowing={this.props.currentlyFollowing}
             />
+            {folders}
           </Box>
         </Box>
       </Box>
@@ -89,23 +101,36 @@ const styleActions = {
 const styleProofColumn = {
   ...globalStyles.flexBoxColumn,
   width: 320,
+  marginLeft: globalMargins.medium,
+  marginRight: globalMargins.medium,
   zIndex: 2
 }
 
 const styleProofNoticeBox = {
   ...globalStyles.flexBoxRow,
   height: HEADER_SIZE,
-  marginLeft: globalMargins.medium,
-  marginRight: globalMargins.medium,
   alignItems: 'center',
+  justifyContent: 'center',
   textAlign: 'center'
 }
 
 const styleProofs = {
   // header + small space from top of header + tiny space to pad top of first item
-  marginTop: globalMargins.small + globalMargins.tiny,
-  marginLeft: globalMargins.medium,
-  marginRight: globalMargins.medium
+  marginTop: globalMargins.small + globalMargins.tiny
+}
+
+const styleFolderLine = {
+  ...globalStyles.flexBoxRow,
+  ...globalStyles.clickable,
+  alignItems: 'center',
+  marginTop: globalMargins.tiny,
+  color: globalColors.black_60
+}
+
+const styleFolderIcon = {
+  width: 16,
+  height: 16,
+  marginRight: globalMargins.tiny
 }
 
 export default Render

--- a/shared/profile/render.js.flow
+++ b/shared/profile/render.js.flow
@@ -11,6 +11,7 @@ export type Props = {
   currentlyFollowing: boolean,
   onFollow: () => void,
   onUnfollow: () => void,
+  onAcceptProofs: () => void,
   username: string,
   userInfo: UserInfo,
   proofs: Array<Proof>

--- a/shared/profile/render.js.flow
+++ b/shared/profile/render.js.flow
@@ -5,6 +5,7 @@ import {Component} from 'react'
 import type {SimpleProofState} from '../constants/tracker'
 import type {UserInfo} from '../common-adapters/user-bio'
 import type {Proof} from '../common-adapters/user-proofs'
+import type {Folder} from '../folders/list'
 
 export type Props = {
   trackerState: SimpleProofState,
@@ -14,7 +15,8 @@ export type Props = {
   onAcceptProofs: () => void,
   username: string,
   userInfo: UserInfo,
-  proofs: Array<Proof>
+  proofs: Array<Proof>,
+  tlfs?: Array<Folder>
 }
 
 export default class Render extends Component<void, Props, void> { }

--- a/shared/search/user-pane/dumb.desktop.js
+++ b/shared/search/user-pane/dumb.desktop.js
@@ -1,22 +1,10 @@
 /* @flow */
 import UserPane from './user.render'
 import NonUserPane from './non-user.render'
-import {normal, checking, revoked, error, metaNone} from '../../constants/tracker'
+import {normal, error} from '../../constants/tracker'
+import {proofsDefault, proofsTracked, proofsChanged, mockUserInfo} from '../../profile/dumb.desktop'
 import type {Props as UserRenderProps} from './user.render'
-import type {Proof} from '../../common-adapters/user-proofs'
 import type {DumbComponentMap} from '../../constants/types/more'
-
-const proofsDefault: Array<Proof> = [
-  {name: 'malgorithms', type: 'twitter', id: 'twitterId', state: normal, meta: metaNone, humanUrl: 'twitter.com', profileUrl: 'http://twitter.com', isTracked: false},
-  {name: 'malgorithms', type: 'github', id: 'githubId', state: normal, meta: metaNone, humanUrl: 'github.com', profileUrl: 'http://github.com', isTracked: false},
-  {name: 'malgorithms', type: 'reddit', id: 'redditId', state: normal, meta: metaNone, humanUrl: 'reddit.com', profileUrl: 'http://reddit.com', isTracked: false},
-  {name: 'keybase.io', type: 'dns', id: 'dnsId', state: normal, meta: metaNone, humanUrl: 'keybase.io', profileUrl: 'http://keybase.io', isTracked: false},
-  {name: 'keybase.pub', type: 'dns', id: 'dns2Id', state: normal, meta: metaNone, humanUrl: 'keybase.pub', profileUrl: 'http://keybase.pub', isTracked: false}
-]
-
-const proofsTracked = proofsDefault.map(proof => ({...proof, isTracked: true}))
-
-const proofsChanged = proofsDefault.map((proof, idx) => ({...proof, state: idx % 2 ? checking : revoked}))
 
 const defaultParentProps = {
   style: {
@@ -26,16 +14,7 @@ const defaultParentProps = {
 }
 
 const userPaneBase: UserRenderProps = {
-  username: 'chris',
-  userInfo: {
-    fullname: 'Chris Coyne',
-    followersCount: 1871,
-    followingCount: 356,
-    location: 'NYC & Maine',
-    bio: 'Co-founder of Keybase, OkCupid, SparkNotes, and some random other junk. I like making things.',
-    avatar: 'https://keybase.io/chris/picture',
-    followsYou: false
-  },
+  ...mockUserInfo,
   proofs: proofsDefault,
   trackerState: normal,
   currentlyFollowing: false,

--- a/shared/search/user-pane/user.render.desktop.js
+++ b/shared/search/user-pane/user.render.desktop.js
@@ -1,43 +1,14 @@
 /* @flow */
 
 import React, {Component} from 'react'
-import {normal as proofNormal} from '../../constants/tracker'
-import {Box, Button, FollowButton, UserProofs, UserBio} from '../../common-adapters'
+import {Box, UserProofs, UserBio} from '../../common-adapters'
+import {userHeaderColor, UserActions} from '../../profile/common.desktop'
 import {globalColors, globalStyles, globalMargins} from '../../styles/style-guide'
 import type {Props} from './user.render'
 
 export default class Render extends Component<void, Props, void> {
   render () {
-    let headerColor
-    if (this.props.trackerState === proofNormal) {
-      headerColor = this.props.currentlyFollowing ? globalColors.green : globalColors.blue
-    } else {
-      headerColor = globalColors.red
-    }
-
-    let actions
-    if (this.props.trackerState === proofNormal) {
-      if (this.props.currentlyFollowing) {
-        actions = (
-          <Box style={styleActionBox}>
-            <FollowButton following onUnfollow={this.props.onUnfollow} style={styleFollowButton} />
-          </Box>
-        )
-      } else {
-        actions = (
-          <Box style={styleActionBox}>
-            <FollowButton following={false} onFollow={this.props.onFollow} style={styleFollowButton} />
-          </Box>
-        )
-      }
-    } else {
-      actions = (
-        <Box style={styleActionBox}>
-          <Button type='Unfollow' label='Untrack' onClick={this.props.onUnfollow} />
-          <Button type='Follow' label='Accept' onClick={this.props.onAcceptProofs} style={styleFollowButton} />
-        </Box>
-      )
-    }
+    const headerColor = userHeaderColor(this.props.trackerState, this.props.currentlyFollowing)
 
     return (
       <Box style={styleContainer}>
@@ -58,7 +29,14 @@ export default class Render extends Component<void, Props, void> {
             currentlyFollowing={this.props.currentlyFollowing}
           />
         </Box>
-        {actions}
+        <UserActions
+          style={styleActionBox}
+          trackerState={this.props.trackerState}
+          currentlyFollowing={this.props.currentlyFollowing}
+          onFollow={this.props.onFollow}
+          onUnfollow={this.props.onUnfollow}
+          onAcceptProofs={this.props.onAcceptProofs}
+        />
       </Box>
     )
   }
@@ -90,8 +68,4 @@ const styleActionBox = {
   padding: globalMargins.small,
   boxShadow: `0 0 5px ${globalColors.black_20}`,
   zIndex: 1
-}
-
-const styleFollowButton = {
-  marginRight: 0
 }

--- a/shared/search/user-pane/user.render.desktop.js
+++ b/shared/search/user-pane/user.render.desktop.js
@@ -15,6 +15,7 @@ export default class Render extends Component<void, Props, void> {
         <Box style={styleScroller} className='hide-scrollbar'>
           <Box style={{...styleHeader, backgroundColor: headerColor}} />
           <UserBio
+            type='Tracker'
             avatarSize={112}
             style={{marginTop: 39}}
             username={this.props.username}

--- a/shared/styles/style-guide.js.flow
+++ b/shared/styles/style-guide.js.flow
@@ -5,5 +5,12 @@ export {default as globalColors} from './style-guide-colors'
 
 declare export var transition: (...properties: Array<string>) => Object
 declare export var globalStyles: Object
-declare export var globalMargins: Object
+declare export var globalMargins: {
+  xtiny: number,
+  tiny: number,
+  small: number,
+  medium: number,
+  large: number,
+  xlarge: number
+}
 declare export var globalResizing: Object

--- a/shared/tracker/render.desktop.js
+++ b/shared/tracker/render.desktop.js
@@ -39,7 +39,7 @@ export default class Render extends Component<void, RenderProps, void> {
       <div style={styles.container}>
         <Header {...this.props.headerProps} />
         <div style={{...styles.content, paddingBottom: calculatedPadding}} className='hide-scrollbar'>
-          <UserBio {...this.props.bioProps} style={{marginTop: 50}} avatarSize={80} />
+          <UserBio type='Tracker' {...this.props.bioProps} style={{marginTop: 50}} avatarSize={80} />
           <UserProofs {...this.props.proofsProps} style={{paddingTop: 8, paddingLeft: 30, paddingRight: 30}} />
         </div>
         <div style={styles.footer}>


### PR DESCRIPTION
Here's the top bits of the profile page, without the folders list or back button / fancy scrolling behavior. I'll add in the friendships view once https://github.com/keybase/client/pull/3060 merges.

:eyeglasses: @keybase/react-hackers 