### PR TITLE
Folders: Smart component integration with RPC

### DIFF
--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -98,8 +98,8 @@ const folderToProps = (folders: Array<FolderWithMeta>, username: string = ''): F
   })
 
   const [priFolders, pubFolders] = _.partition(converted, {isPublic: false})
-  let [privIgnored, priv] = _.partition(priFolders, {ignored: true})
-  let [pubIgnored, pub] = _.partition(pubFolders, {ignored: true})
+  const [privIgnored, priv] = _.partition(priFolders, {ignored: true})
+  const [pubIgnored, pub] = _.partition(pubFolders, {ignored: true})
   return {
     onRekey: () => {},
     showingPrivate: true,
@@ -198,7 +198,7 @@ export function ignoreFolder (path: string): (dispatch: Dispatch) => void {
   return (dispatch, getState) => {
     const folder = folderFromPath(path)
     if (!folder) {
-      const action: FavoriteIgnore = {type: Constants.favoriteIgnore, payload: {error: 'no folder'}}
+      const action: FavoriteIgnore = {type: Constants.favoriteIgnore, payload: {error: true}}
       dispatch(action)
       return
     }
@@ -212,7 +212,7 @@ export function ignoreFolder (path: string): (dispatch: Dispatch) => void {
           console.warn('Err in favorite.favoriteIgnore', error)
           return
         }
-        const action: FavoriteIgnore = {type: Constants.favoriteIgnore, payload: {error: null}}
+        const action: FavoriteIgnore = {type: Constants.favoriteIgnore, payload: {}}
         dispatch(action)
         dispatch(favoriteList())
         dispatch(navigateBack())

--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import engine from '../engine'
+import {navigateBack} from '../actions/router'
 import * as Constants from '../constants/favorite'
 import {badgeApp} from './notifications'
 import {canonicalizeUsernames, parseFolderNameToUsers} from '../util/kbfs'
@@ -213,6 +214,8 @@ export function ignoreFolder (path: string): (dispatch: Dispatch) => void {
         }
         const action: FavoriteIgnore = {type: Constants.favoriteIgnore, payload: {error: null}}
         dispatch(action)
+        dispatch(favoriteList())
+        dispatch(navigateBack())
       }
     }
     engine.rpc(params)

--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -20,7 +20,7 @@ export function pathFromFolder ({isPublic, users}: {isPublic: boolean, users: Us
   return {sortName, path}
 }
 
-export function folderFromPath (path: string): ?Folder {
+function folderFromPath (path: string): ?Folder {
   if (path.startsWith('/keybase/private/')) {
     return {
       name: path.replace('/keybase/private/', ''),
@@ -198,7 +198,7 @@ export function ignoreFolder (path: string): (dispatch: Dispatch) => void {
   return (dispatch, getState) => {
     const folder = folderFromPath(path)
     if (!folder) {
-      const action: FavoriteIgnore = {type: Constants.favoriteIgnore, payload: {error: true}}
+      const action: FavoriteIgnore = {type: Constants.favoriteIgnore, error: true, payload: {errorText: 'No folder specified'}}
       dispatch(action)
       return
     }
@@ -210,11 +210,11 @@ export function ignoreFolder (path: string): (dispatch: Dispatch) => void {
       callback: error => {
         if (error) {
           console.warn('Err in favorite.favoriteIgnore', error)
+          dispatch(navigateBack())
           return
         }
-        const action: FavoriteIgnore = {type: Constants.favoriteIgnore, payload: {}}
+        const action: FavoriteIgnore = {type: Constants.favoriteIgnore, payload: undefined}
         dispatch(action)
-        dispatch(favoriteList())
         dispatch(navigateBack())
       }
     }

--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -15,8 +15,28 @@ import {NotifyPopup} from '../native/notifications'
 
 export function pathFromFolder ({isPublic, users}: {isPublic: boolean, users: UserList}) {
   const sortName = users.map(u => u.username).join(',')
-  const path = `/keybase/${isPublic ? 'private' : 'public'}/${sortName}`
+  const path = `/keybase/${isPublic ? 'public' : 'private'}/${sortName}`
   return {sortName, path}
+}
+
+export function folderFromPath (path: string): ?Folder {
+  if (path.startsWith('/keybase/private/')) {
+    return {
+      name: path.replace('/keybase/private/', ''),
+      private: true,
+      notificationsOn: false,
+      created: false
+    }
+  } else if (path.startsWith('/keybase/public/')) {
+    return {
+      name: path.replace('/keybase/public/', ''),
+      private: false,
+      notificationsOn: false,
+      created: false
+    }
+  } else {
+    return null
+  }
 }
 
 type FolderWithMeta = {

--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -5,9 +5,9 @@ import * as Constants from '../constants/favorite'
 import {badgeApp} from './notifications'
 import {canonicalizeUsernames, parseFolderNameToUsers} from '../util/kbfs'
 import _ from 'lodash'
-import type {Folder, favoriteGetFavoritesRpc, FavoritesResult} from '../constants/types/flow-types'
+import type {Folder, favoriteGetFavoritesRpc, favoriteFavoriteIgnoreRpc, FavoritesResult} from '../constants/types/flow-types'
 import type {Dispatch} from '../constants/types/flux'
-import type {FavoriteList} from '../constants/favorite'
+import type {FavoriteList, FavoriteIgnore} from '../constants/favorite'
 import type {Props as FolderProps} from '../folders/render'
 import type {UserList} from '../common-adapters/usernames'
 import flags from '../util/feature-flags'
@@ -193,6 +193,28 @@ export function favoriteList (): (dispatch: Dispatch) => void {
   }
 }
 
-export function ignoreFolder (path: string) {
-  return () => console.log('TODO: implement ignore folder action')
+export function ignoreFolder (path: string): (dispatch: Dispatch) => void {
+  return (dispatch, getState) => {
+    const folder = folderFromPath(path)
+    if (!folder) {
+      const action: FavoriteIgnore = {type: Constants.favoriteIgnore, payload: {error: 'no folder'}}
+      dispatch(action)
+      return
+    }
+
+    const params : favoriteFavoriteIgnoreRpc = {
+      param: {folder},
+      incomingCallMap: {},
+      method: 'favorite.favoriteIgnore',
+      callback: error => {
+        if (error) {
+          console.warn('Err in favorite.favoriteIgnore', error)
+          return
+        }
+        const action: FavoriteIgnore = {type: Constants.favoriteIgnore, payload: {}}
+        dispatch(action)
+      }
+    }
+    engine.rpc(params)
+  }
 }

--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -6,9 +6,9 @@ import * as Constants from '../constants/favorite'
 import {badgeApp} from './notifications'
 import {canonicalizeUsernames, parseFolderNameToUsers} from '../util/kbfs'
 import _ from 'lodash'
-import type {Folder, favoriteGetFavoritesRpc, favoriteFavoriteIgnoreRpc, FavoritesResult} from '../constants/types/flow-types'
+import type {Folder, favoriteGetFavoritesRpc, favoriteFavoriteAddRpc, favoriteFavoriteIgnoreRpc, FavoritesResult} from '../constants/types/flow-types'
 import type {Dispatch} from '../constants/types/flux'
-import type {FavoriteList, FavoriteIgnore} from '../constants/favorite'
+import type {FavoriteAdd, FavoriteList, FavoriteIgnore} from '../constants/favorite'
 import type {Props as FolderProps} from '../folders/render'
 import type {UserList} from '../common-adapters/usernames'
 import flags from '../util/feature-flags'
@@ -214,6 +214,34 @@ export function ignoreFolder (path: string): (dispatch: Dispatch) => void {
           return
         }
         const action: FavoriteIgnore = {type: Constants.favoriteIgnore, payload: undefined}
+        dispatch(action)
+        dispatch(navigateBack())
+      }
+    }
+    engine.rpc(params)
+  }
+}
+
+export function favoriteFolder (path: string): (dispatch: Dispatch) => void {
+  return (dispatch, getState) => {
+    const folder = folderFromPath(path)
+    if (!folder) {
+      const action: FavoriteAdd = {type: Constants.favoriteAdd, error: true, payload: {errorText: 'No folder specified'}}
+      dispatch(action)
+      return
+    }
+
+    const params : favoriteFavoriteAddRpc = {
+      param: {folder},
+      incomingCallMap: {},
+      method: 'favorite.favoriteAdd',
+      callback: error => {
+        if (error) {
+          console.warn('Err in favorite.favoriteAdd', error)
+          dispatch(navigateBack())
+          return
+        }
+        const action: FavoriteAdd = {type: Constants.favoriteAdd, payload: undefined}
         dispatch(action)
         dispatch(navigateBack())
       }

--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -211,7 +211,7 @@ export function ignoreFolder (path: string): (dispatch: Dispatch) => void {
           console.warn('Err in favorite.favoriteIgnore', error)
           return
         }
-        const action: FavoriteIgnore = {type: Constants.favoriteIgnore, payload: {}}
+        const action: FavoriteIgnore = {type: Constants.favoriteIgnore, payload: {error: null}}
         dispatch(action)
       }
     }

--- a/shared/constants/favorite.js
+++ b/shared/constants/favorite.js
@@ -7,6 +7,6 @@ export const favoriteList = 'favorite:favoriteList'
 export type FavoriteList = TypedAction<'favorite:favoriteList', {folders: FolderProps}, void>
 
 export const favoriteIgnore = 'favorite:favoriteIgnore'
-export type FavoriteIgnore = TypedAction<'favorite:favoriteIgnore', {error: ?string}, void>
+export type FavoriteIgnore = TypedAction<'favorite:favoriteIgnore', {error?: true}, void>
 
 export type FavoriteAction = FavoriteList | FavoriteIgnore

--- a/shared/constants/favorite.js
+++ b/shared/constants/favorite.js
@@ -7,6 +7,6 @@ export const favoriteList = 'favorite:favoriteList'
 export type FavoriteList = TypedAction<'favorite:favoriteList', {folders: FolderProps}, void>
 
 export const favoriteIgnore = 'favorite:favoriteIgnore'
-export type FavoriteIgnore = TypedAction<'favorite:favoriteIgnore', {error?: true}, void>
+export type FavoriteIgnore = TypedAction<'favorite:favoriteIgnore', void, {errorText: string}>
 
 export type FavoriteAction = FavoriteList | FavoriteIgnore

--- a/shared/constants/favorite.js
+++ b/shared/constants/favorite.js
@@ -2,8 +2,12 @@
 
 import type {TypedAction} from '../constants/types/flux'
 import type {Props as FolderProps} from '../folders/render'
+import type {Folder} from '../constants/types/flow-types'
 
 export const favoriteList = 'favorite:favoriteList'
 export type FavoriteList = TypedAction<'favorite:favoriteList', {folders: FolderProps}, void>
 
-export type FavoriteAction = FavoriteList
+export const favoriteIgnore = 'favorite:favoriteIgnore'
+export type FavoriteIgnore = TypedAction<'favorite:favoriteIgnore', {folder: Folder}, void>
+
+export type FavoriteAction = FavoriteList | FavoriteIgnore

--- a/shared/constants/favorite.js
+++ b/shared/constants/favorite.js
@@ -2,7 +2,6 @@
 
 import type {TypedAction} from '../constants/types/flux'
 import type {Props as FolderProps} from '../folders/render'
-import type {Folder} from '../constants/types/flow-types'
 
 export const favoriteList = 'favorite:favoriteList'
 export type FavoriteList = TypedAction<'favorite:favoriteList', {folders: FolderProps}, void>

--- a/shared/constants/favorite.js
+++ b/shared/constants/favorite.js
@@ -3,10 +3,13 @@
 import type {TypedAction} from '../constants/types/flux'
 import type {Props as FolderProps} from '../folders/render'
 
+export const favoriteAdd = 'favorite:favoriteAdd'
+export type FavoriteAdd = TypedAction<'favorite:favoriteAdd', void, {errorText: string}>
+
 export const favoriteList = 'favorite:favoriteList'
 export type FavoriteList = TypedAction<'favorite:favoriteList', {folders: FolderProps}, void>
 
 export const favoriteIgnore = 'favorite:favoriteIgnore'
 export type FavoriteIgnore = TypedAction<'favorite:favoriteIgnore', void, {errorText: string}>
 
-export type FavoriteAction = FavoriteList | FavoriteIgnore
+export type FavoriteAction = FavoriteAdd | FavoriteList | FavoriteIgnore

--- a/shared/constants/favorite.js
+++ b/shared/constants/favorite.js
@@ -8,6 +8,6 @@ export const favoriteList = 'favorite:favoriteList'
 export type FavoriteList = TypedAction<'favorite:favoriteList', {folders: FolderProps}, void>
 
 export const favoriteIgnore = 'favorite:favoriteIgnore'
-export type FavoriteIgnore = TypedAction<'favorite:favoriteIgnore', {folder: Folder}, void>
+export type FavoriteIgnore = TypedAction<'favorite:favoriteIgnore', {error: ?string}, void>
 
 export type FavoriteAction = FavoriteList | FavoriteIgnore

--- a/shared/folders/dumb.js
+++ b/shared/folders/dumb.js
@@ -293,6 +293,7 @@ const filesMenuItems = [
 
 const commonFiles = (isPrivate): FilesProps => ({ // eslint-disable-line arrow-parens
   theme: isPrivate ? 'private' : 'public',
+  ignored: false,
   visiblePopupMenu: false,
   popupMenuItems: filesMenuItems,
   selfUsername: 'cecileb',

--- a/shared/folders/dumb.js
+++ b/shared/folders/dumb.js
@@ -305,6 +305,7 @@ const commonFiles = (isPrivate): FilesProps => ({ // eslint-disable-line arrow-p
   onBack: () => console.log('onBack:files'),
   openCurrentFolder: () => console.log('open current folder'),
   ignoreCurrentFolder: () => console.log('ignore current folder'),
+  unIgnoreCurrentFolder: () => console.log('unignore current folder'),
   onTogglePopupMenu: () => console.log('onTogglePopupMenu'),
   recentFilesSection: [
     {name: 'Today', modifiedMarker: true, files: genFiles(0, 4, isPrivate)},

--- a/shared/folders/files/index.js
+++ b/shared/folders/files/index.js
@@ -3,7 +3,7 @@ import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
 import {openInKBFS} from '../../actions/kbfs'
-import {ignoreFolder} from '../../actions/favorite'
+import {favoriteFolder, ignoreFolder} from '../../actions/favorite'
 import {navigateBack} from '../../actions/router'
 import flags from '../../util/feature-flags'
 import Render from './render'
@@ -17,6 +17,7 @@ type Props = $Shape<{
   username: string,
   navigateBack: () => void,
   ignoreFolder: (path: string) => void,
+  favoriteFolder: (path: string) => void,
   openInKBFS: (path: string) => void
 }>
 
@@ -51,6 +52,7 @@ class Files extends Component<void, Props, State> {
     if (!folder) return null // Protect from state where the folder to be displayed was removed
     const openCurrentFolder = () => { this.props.openInKBFS(this.props.path) }
     const ignoreCurrentFolder = () => { this.props.ignoreFolder(this.props.path) }
+    const unIgnoreCurrentFolder = () => { this.props.favoriteFolder(this.props.path) }
     return (
       <Render
         ignored={folder.ignored}
@@ -68,6 +70,7 @@ class Files extends Component<void, Props, State> {
         onBack={() => this.props.navigateBack()}
         openCurrentFolder={openCurrentFolder}
         ignoreCurrentFolder={ignoreCurrentFolder}
+        unIgnoreCurrentFolder={unIgnoreCurrentFolder}
         recentFilesSection={folder.recentFiles} // TODO (AW): integrate recent files once the service provides this data
         recentFilesEnabled={flags.recentFilesEnabled}
       />
@@ -98,7 +101,7 @@ const ConnectedFiles = connect(
       username: state.config && state.config.username
     }
   },
-  dispatch => bindActionCreators({openInKBFS, ignoreFolder, navigateBack}, dispatch)
+  dispatch => bindActionCreators({favoriteFolder, ignoreFolder, navigateBack, openInKBFS}, dispatch)
 )(Files)
 
 export default ConnectedFiles

--- a/shared/folders/files/index.js
+++ b/shared/folders/files/index.js
@@ -53,6 +53,7 @@ class Files extends Component<void, Props, State> {
     const ignoreCurrentFolder = () => { this.props.ignoreFolder(this.props.path) }
     return (
       <Render
+        ignored={folder.ignored}
         theme={folder.isPublic ? 'public' : 'private'}
         popupMenuItems={[
           {onClick: openCurrentFolder, title: 'Open folder'},
@@ -85,7 +86,12 @@ class Files extends Component<void, Props, State> {
 
 const ConnectedFiles = connect(
   (state, ownProps) => {
-    const folders: Array<Folder> = [].concat(_.get(state, 'favorite.folders.private.tlfs'), _.get(state, 'favorite.folders.public.tlfs'))
+    const folders: Array<Folder> = [].concat(
+      _.get(state, 'favorite.folders.private.tlfs'),
+      _.get(state, 'favorite.folders.public.tlfs'),
+      _.get(state, 'favorite.folders.private.ignored'),
+      _.get(state, 'favorite.folders.public.ignored')
+    )
     const folder = folders.find(f => f.path === ownProps.path)
     return {
       folder,

--- a/shared/folders/files/render.desktop.js
+++ b/shared/folders/files/render.desktop.js
@@ -71,9 +71,10 @@ export default class Render extends Component<void, Props, void> {
     if (!this.props.recentFilesEnabled) {
       return (
         <Box style={{...styleRecentFilesNotEnabled}}>
-          {ignored ? <Button type='Primary' onClick={this.props.openCurrentFolder} label='Open and unignore folder' /> : [
-            <Button key='ignore' type='Secondary' onClick={this.props.ignoreCurrentFolder} label='Ignore folder' />,
-            <Button key='open' type='Primary' onClick={this.props.openCurrentFolder} label='Open folder' />
+          {ignored
+          ? <Button type='Secondary' onClick={this.props.unIgnoreCurrentFolder} label='Unignore folder' />
+          : <Button type='Secondary' onClick={this.props.ignoreCurrentFolder} label='Ignore folder' />}
+          <Button key='open' type='Primary' onClick={this.props.openCurrentFolder} label='Open folder' />
           ]}
         </Box>
       )
@@ -114,10 +115,12 @@ export default class Render extends Component<void, Props, void> {
         <Box style={{...globalStyles.flexBoxRow, ...styleHeaderThemed[this.props.theme], height: 48}}>
           <BackButton onClick={this.props.onBack} style={{marginLeft: 16}}
             iconStyle={{color: backButtonColor}} textStyle={{color: backButtonColor}} />
-          <Icon
-            style={{...styleMenu, color: menuColor, hoverColor: menuColor, marginRight: 16, position: 'relative', top: 14}}
-            type='fa-kb-iconfont-hamburger'
-            onClick={this.props.onTogglePopupMenu} />
+          {this.props.recentFilesEnabled &&
+            <Icon
+              style={{...styleMenu, color: menuColor, hoverColor: menuColor, marginRight: 16, position: 'relative', top: 14}}
+              type='fa-kb-iconfont-hamburger'
+              onClick={this.props.onTogglePopupMenu} />
+          }
         </Box>
         <Box style={{...globalStyles.flexBoxColumn, ...styleTLFHeader, ...styleTLFHeaderThemed[this.props.theme]}}>
           <Box style={{...globalStyles.flexBoxRow, height: 0, justifyContent: 'center', position: 'relative', bottom: 16}}>

--- a/shared/folders/files/render.desktop.js
+++ b/shared/folders/files/render.desktop.js
@@ -75,7 +75,6 @@ export default class Render extends Component<void, Props, void> {
           ? <Button type='Secondary' onClick={this.props.unIgnoreCurrentFolder} label='Unignore folder' />
           : <Button type='Secondary' onClick={this.props.ignoreCurrentFolder} label='Ignore folder' />}
           <Button key='open' type='Primary' onClick={this.props.openCurrentFolder} label='Open folder' />
-          ]}
         </Box>
       )
     }

--- a/shared/folders/files/render.desktop.js
+++ b/shared/folders/files/render.desktop.js
@@ -65,14 +65,16 @@ const YouCanUnlock = ({youCanUnlock, isPrivate, backgroundMode}) => {
 
 export default class Render extends Component<void, Props, void> {
 
-  _renderContents (isPrivate: boolean) {
+  _renderContents (isPrivate: boolean, ignored: boolean) {
     const backgroundMode = isPrivate ? 'Terminal' : 'Normal'
 
     if (!this.props.recentFilesEnabled) {
       return (
         <Box style={{...styleRecentFilesNotEnabled}}>
-          <Button type='Secondary' onClick={this.props.ignoreCurrentFolder} label='Ignore folder' />
-          <Button type='Primary' onClick={this.props.openCurrentFolder} label='Open folder' />
+          {ignored ? <Button type='Primary' onClick={this.props.openCurrentFolder} label='Open and unignore folder' /> : [
+            <Button key='ignore' type='Secondary' onClick={this.props.ignoreCurrentFolder} label='Ignore folder' />,
+            <Button key='open' type='Primary' onClick={this.props.openCurrentFolder} label='Open folder' />
+          ]}
         </Box>
       )
     }
@@ -127,7 +129,7 @@ export default class Render extends Component<void, Props, void> {
           </Box>
         </Box>
         <PopupMenu style={{marginLeft: 'auto', marginRight: 8, marginTop: 36, width: 320}} items={this.props.popupMenuItems} visible={this.props.visiblePopupMenu} onHidden={this.props.onTogglePopupMenu} />
-        {this._renderContents(isPrivate)}
+        {this._renderContents(isPrivate, this.props.ignored)}
       </Box>
     )
   }

--- a/shared/folders/files/render.js.flow
+++ b/shared/folders/files/render.js.flow
@@ -25,6 +25,7 @@ export type UnlockDevice = {
 
 export type Props = {
   theme: 'public' | 'private',
+  ignored: boolean,
   visiblePopupMenu: boolean,
   popupMenuItems: MenuProps.items,
   selfUsername: string,

--- a/shared/folders/files/render.js.flow
+++ b/shared/folders/files/render.js.flow
@@ -37,6 +37,7 @@ export type Props = {
   recentFilesEnabled: boolean, // TODO (AW): remove when recentFiles feature is finished
   openCurrentFolder: () => void,
   ignoreCurrentFolder: () => void,
+  unIgnoreCurrentFolder: () => void,
   waitingForParticipantUnlock: Array<ParticipantUnlock>,
   youCanUnlock: Array<UnlockDevice>
 }

--- a/shared/folders/index.js
+++ b/shared/folders/index.js
@@ -2,6 +2,7 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import Render from './render'
+import {openInKBFS} from '../actions/kbfs'
 import {bindActionCreators} from 'redux'
 import {routeAppend} from '../actions/router'
 import Files from './files'
@@ -9,6 +10,7 @@ import type {Props as RenderProps} from './render'
 
 export type Props = {
   folderProps: ?RenderProps,
+  openInKBFS: (path: string) => void,
   routeAppend: (path: any) => void
 }
 
@@ -31,6 +33,7 @@ class Folders extends Component<void, Props, State> {
       <Render
         {...this.props.folderProps}
         onClick={path => this.props.routeAppend(path)}
+        onOpen={path => this.props.openInKBFS(path)}
         onSwitchTab={showingPrivate => this.setState({showingPrivate})}
         showingPrivate={this.state.showingPrivate}
       />
@@ -49,5 +52,5 @@ export default connect(
   state => ({
     folderProps: state.favorite && state.favorite.folders
   }),
-  dispatch => bindActionCreators({routeAppend}, dispatch)
+  dispatch => bindActionCreators({routeAppend, openInKBFS}, dispatch)
 )(Folders)

--- a/shared/folders/list.desktop.js
+++ b/shared/folders/list.desktop.js
@@ -74,7 +74,7 @@ class Render extends Component<void, Props, State> {
               isFirst={!idx} />
             ))}
             {this.props.ignored && this.props.ignored.length > 0 && <Ignored
-              ignored={this.props.ignored} showIgnored={this.state.showIgnored} styles={styles} onOpen={this.props.onOpen} onRekey={this.props.onRekey}
+              ignored={this.props.ignored} showIgnored={this.state.showIgnored} styles={styles} onOpen={this.props.onOpen} onClick={this.props.onClick} onRekey={this.props.onRekey}
               isPublic={this.props.isPublic} onToggle={() => this.setState({showIgnored: !this.state.showIgnored})} />}
         </Box>
       </Box>

--- a/shared/folders/list.desktop.js
+++ b/shared/folders/list.desktop.js
@@ -11,7 +11,7 @@ type State = {
 
 const rowKey = users => users && users.map(u => u.username).join('-')
 
-const Ignored = ({showIgnored, ignored, styles, onToggle, isPublic, onClick, onRekey}) => {
+const Ignored = ({showIgnored, ignored, styles, onToggle, isPublic, onOpen, onClick, onRekey}) => {
   return (
     <Box style={stylesIgnoreContainer}>
       <Box style={styles.topBox} onClick={onToggle}>
@@ -30,6 +30,7 @@ const Ignored = ({showIgnored, ignored, styles, onToggle, isPublic, onClick, onR
           ignored={true} // eslint-disable-line
           onClick={onClick}
           onRekey={onRekey}
+          onOpen={onOpen}
           isFirst={!idx} />
         ))}
     </Box>
@@ -67,12 +68,13 @@ class Render extends Component<void, Props, State> {
               isPublic={this.props.isPublic}
               ignored={false}
               onClick={this.props.onClick}
+              onOpen={this.props.onOpen}
               onRekey={this.props.onRekey}
               smallMode={this.props.smallMode}
               isFirst={!idx} />
             ))}
             {this.props.ignored && this.props.ignored.length > 0 && <Ignored
-              ignored={this.props.ignored} showIgnored={this.state.showIgnored} styles={styles} onRekey={this.props.onRekey}
+              ignored={this.props.ignored} showIgnored={this.state.showIgnored} styles={styles} onOpen={this.props.onOpen} onRekey={this.props.onRekey}
               isPublic={this.props.isPublic} onToggle={() => this.setState({showIgnored: !this.state.showIgnored})} />}
         </Box>
       </Box>

--- a/shared/folders/list.js.flow
+++ b/shared/folders/list.js.flow
@@ -30,6 +30,7 @@ export type Props = {
   smallMode?: boolean,
   onClick?: (path: string) => void,
   onRekey?: (path: string) => void,
+  onOpen?: (path: string) => void,
   extraRows?: Array<React$Element>
 }
 

--- a/shared/folders/render.desktop.js
+++ b/shared/folders/render.desktop.js
@@ -52,6 +52,7 @@ class Render extends Component<void, Props, void> {
               style={this.props.listStyle}
               smallMode={this.props.smallMode}
               onRekey={this.props.onRekey}
+              onOpen={this.props.onOpen}
               onClick={this.props.onClick} />
           </TabBarItem>
           <TabBarItem
@@ -64,6 +65,7 @@ class Render extends Component<void, Props, void> {
               style={this.props.listStyle}
               smallMode={this.props.smallMode}
               onRekey={this.props.onRekey}
+              onOpen={this.props.onOpen}
               onClick={this.props.onClick} />
           </TabBarItem>
         </TabBar>

--- a/shared/folders/render.desktop.js
+++ b/shared/folders/render.desktop.js
@@ -76,7 +76,8 @@ class Render extends Component<void, Props, void> {
 
 const stylesContainer = {
   ...globalStyles.flexBoxColumn,
-  flex: 1
+  flex: 1,
+  paddingTop: 45
 }
 
 const styleBadge = {

--- a/shared/folders/render.js.flow
+++ b/shared/folders/render.js.flow
@@ -14,6 +14,7 @@ export type Props = {
   listStyle?: any,
   smallMode?: boolean,
   onClick?: (path: string) => void,
+  onOpen?: (path: string) => void,
   onRekey: (path: string) => void
 }
 

--- a/shared/folders/row.desktop.js
+++ b/shared/folders/row.desktop.js
@@ -54,8 +54,16 @@ const RowMeta = ({ignored, meta, styles}) => {
   return <Meta {...metaProps} />
 }
 
-const Row = ({users, isPublic, ignored, meta, modified, hasData, smallMode, onClick, groupAvatar, userAvatar, onRekey, path}:
-  {smallMode: boolean, onClick: (path: string) => void, onRekey: (path: string) => void} & Folder) => {
+const Row = ({users, isPublic, ignored, meta, modified, hasData, smallMode, onOpen, onClick, groupAvatar, userAvatar, onRekey, path}:
+  {smallMode: boolean, onOpen: (path: string) => void, onClick: (path: string) => void, onRekey: (path: string) => void} & Folder) => {
+  const onOpenClick = event => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (onOpen) {
+      onOpen(path)
+    }
+  }
+
   const styles = isPublic ? stylesPublic : stylesPrivate
 
   const containerStyle = {
@@ -77,7 +85,7 @@ const Row = ({users, isPublic, ignored, meta, modified, hasData, smallMode, onCl
         </Box>
         <Box style={{...stylesActionContainer, width: smallMode ? undefined : 112}}>
           {!smallMode && meta !== 'rekey' && <Text
-            type='BodySmall' className='folder-row-hover-action' style={stylesAction}>Open</Text>}
+            type='BodySmall' className='folder-row-hover-action' onClick={onOpenClick} style={stylesAction}>Open</Text>}
           {meta === 'rekey' && <Button
             backgroundMode={styles.modifiedMode} small={smallMode} type='Secondary'
             onClick={() => onRekey && onRekey(path)} label='Rekey' style={stylesAction} />}
@@ -182,4 +190,3 @@ const stylesModified = {
 }
 
 export default Row
-


### PR DESCRIPTION
@keybase/react-hackers 

This PR:

* sets the 'new' and 'ignored' metas on folders coming in from the favoriteList RPC, so that our dumb component (which already knew what to do with those) badges them appropriately

* makes the "Ignore folder" button perform a favoriteIgnore RPC on that folder

* after a favoriteIgnore RPC, go back to the folders list and refresh the favorites list

No visdiff changes expected, since it's all data integration on the smart component.