### PR TITLE
Fix status for passphrase stream cached, cache device keys after kex provision

### DIFF
--- a/go/client/cmd_status.go
+++ b/go/client/cmd_status.go
@@ -53,6 +53,7 @@ type fstatus struct {
 	Device                 *keybase1.Device
 	LoggedInProvisioned    bool `json:"LoggedIn"`
 	PassphraseStreamCached bool
+	TsecCached             bool
 	DeviceSigKeyCached     bool
 	DeviceEncKeyCached     bool
 	PaperSigKeyCached      bool
@@ -160,6 +161,7 @@ func (c *CmdStatus) load() (*fstatus, error) {
 
 	status.SessionStatus = c.sessionStatus(extStatus.Session)
 	status.PassphraseStreamCached = extStatus.PassphraseStreamCached
+	status.TsecCached = extStatus.TsecCached
 	status.DeviceSigKeyCached = extStatus.DeviceSigKeyCached
 	status.DeviceEncKeyCached = extStatus.DeviceEncKeyCached
 	status.PaperSigKeyCached = extStatus.PaperSigKeyCached
@@ -257,6 +259,7 @@ func (c *CmdStatus) outputTerminal(status *fstatus) error {
 	dui.Printf("    paper sig: %s\n", BoolString(status.PaperSigKeyCached, "cached", "not cached"))
 	dui.Printf("    paper enc: %s\n", BoolString(status.PaperEncKeyCached, "cached", "not cached"))
 	dui.Printf("    prompt:    %s\n", BoolString(status.SecretPromptSkip, "skip", "show"))
+	dui.Printf("    tsec:      %s\n", BoolString(status.TsecCached, "cached", "not cached"))
 
 	dui.Printf("\nKBFS:\n")
 	dui.Printf("    status:    %s\n", BoolString(status.KBFS.Running, "running", "not running"))

--- a/go/engine/crypto.go
+++ b/go/engine/crypto.go
@@ -198,6 +198,7 @@ func getMatchingSecretKey(g *libkb.GlobalContext, secretUI libkb.SecretUI, arg k
 	if key != nil {
 		return key, index, nil
 	}
+	g.Log.Debug("getMatchingSecretKey: no matching cached device key found")
 
 	// load the user
 	me, err := libkb.LoadMe(libkb.NewLoadUserArg(g))
@@ -213,6 +214,7 @@ func getMatchingSecretKey(g *libkb.GlobalContext, secretUI libkb.SecretUI, arg k
 	if key != nil {
 		return key, index, nil
 	}
+	g.Log.Debug("getMatchingSecretKey: no matching device key found")
 
 	if !arg.PromptPaper {
 		g.Log.Debug("UnboxBytes32Any/getMatchingSecretKey: not checking paper keys (promptPaper == false)")
@@ -283,6 +285,11 @@ func matchingDeviceKey(g *libkb.GlobalContext, secretUI libkb.SecretUI, arg keyb
 			}
 			return key, n, nil
 		}
+
+		g.Log.Debug("matchingDeviceKey: no match found for ekey in arg.Bundles")
+		logNoMatch(g, ekey, arg.Bundles)
+	} else {
+		g.Log.Debug("matchingDeviceKey: ignoring error getting device subkey: %s", err)
 	}
 
 	return nil, 0, nil
@@ -355,4 +362,16 @@ func kidMatch(key libkb.GenericKey, bundles []keybase1.CiphertextBundle) (int, b
 		}
 	}
 	return -1, false
+}
+
+func logNoMatch(g *libkb.GlobalContext, key libkb.GenericKey, bundles []keybase1.CiphertextBundle) {
+	if key == nil {
+		g.Log.Debug("logNoMatch: key is nil")
+		return
+	}
+	kid := key.GetKID()
+	g.Log.Debug("logNoMatch: desired kid: %s", kid)
+	for i, bundle := range bundles {
+		g.Log.Debug("logNoMatch: kid %d: %s (%v)", i, bundle.Kid, kid.Equal(bundle.Kid))
+	}
 }

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -114,9 +114,6 @@ func (e *Kex2Provisionee) Run(ctx *Context) error {
 		return err
 	}
 
-	// cache the device keys after successful provision
-	e.cacheKeys()
-
 	return nil
 }
 
@@ -242,6 +239,11 @@ func (e *Kex2Provisionee) HandleDidCounterSign(sig []byte) (err error) {
 
 	// post the key sigs to the api server
 	if err = e.postSigs(eddsaArgs, dhArgs); err != nil {
+		return err
+	}
+
+	// cache the device keys in memory
+	if err = e.cacheKeys(); err != nil {
 		return err
 	}
 

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -114,6 +114,9 @@ func (e *Kex2Provisionee) Run(ctx *Context) error {
 		return err
 	}
 
+	// cache the device keys after successful provision
+	e.cacheKeys()
+
 	return nil
 }
 
@@ -514,6 +517,26 @@ func (e *Kex2Provisionee) saveKeys() error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+// cacheKeys caches the device keys in the Account object.
+func (e *Kex2Provisionee) cacheKeys() error {
+	if e.eddsa == nil {
+		return errors.New("cacheKeys called, but eddsa key is nil")
+	}
+	if e.dh == nil {
+		return errors.New("cacheKeys called, but dh key is nil")
+	}
+
+	if err := e.ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType}, e.eddsa); err != nil {
+		return err
+	}
+
+	if err := e.ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceEncryptionKeyType}, e.dh); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/go/libkb/passphrase_stream_cache.go
+++ b/go/libkb/passphrase_stream_cache.go
@@ -53,10 +53,21 @@ func (s *PassphraseStreamCache) PassphraseStreamRef() *PassphraseStream {
 }
 
 func (s *PassphraseStreamCache) Valid() bool {
+	return s.ValidPassphraseStream() && s.ValidTsec()
+}
+
+func (s *PassphraseStreamCache) ValidPassphraseStream() bool {
 	if s == nil {
 		return false
 	}
-	return s.tsec != nil && s.passphraseStream != nil
+	return s.passphraseStream != nil
+}
+
+func (s *PassphraseStreamCache) ValidTsec() bool {
+	if s == nil {
+		return false
+	}
+	return s.tsec != nil
 }
 
 func (s *PassphraseStreamCache) Clear() {

--- a/go/protocol/config.go
+++ b/go/protocol/config.go
@@ -41,6 +41,7 @@ type PlatformInfo struct {
 type ExtendedStatus struct {
 	Standalone             bool            `codec:"standalone" json:"standalone"`
 	PassphraseStreamCached bool            `codec:"passphraseStreamCached" json:"passphraseStreamCached"`
+	TsecCached             bool            `codec:"tsecCached" json:"tsecCached"`
 	DeviceSigKeyCached     bool            `codec:"deviceSigKeyCached" json:"deviceSigKeyCached"`
 	DeviceEncKeyCached     bool            `codec:"deviceEncKeyCached" json:"deviceEncKeyCached"`
 	PaperSigKeyCached      bool            `codec:"paperSigKeyCached" json:"paperSigKeyCached"`

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -143,7 +143,8 @@ func (h ConfigHandler) GetExtendedStatus(_ context.Context, sessionID int) (res 
 	}
 
 	h.G().LoginState().Account(func(a *libkb.Account) {
-		res.PassphraseStreamCached = a.PassphraseStreamCache().Valid()
+		res.PassphraseStreamCached = a.PassphraseStreamCache().ValidPassphraseStream()
+		res.TsecCached = a.PassphraseStreamCache().ValidTsec()
 
 		// cached keys status
 		sk, err := a.CachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType})

--- a/protocol/avdl/config.avdl
+++ b/protocol/avdl/config.avdl
@@ -39,6 +39,7 @@ protocol config {
   record ExtendedStatus {
     boolean standalone;
     boolean passphraseStreamCached;
+    boolean tsecCached;
     boolean deviceSigKeyCached;
     boolean deviceEncKeyCached;
     boolean paperSigKeyCached;

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -207,6 +207,7 @@ export type ExitCode =
 export type ExtendedStatus = {
   standalone: boolean;
   passphraseStreamCached: boolean;
+  tsecCached: boolean;
   deviceSigKeyCached: boolean;
   deviceEncKeyCached: boolean;
   paperSigKeyCached: boolean;

--- a/protocol/json/config.json
+++ b/protocol/json/config.json
@@ -497,6 +497,10 @@
         },
         {
           "type": "boolean",
+          "name": "tsecCached"
+        },
+        {
+          "type": "boolean",
           "name": "deviceSigKeyCached"
         },
         {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -207,6 +207,7 @@ export type ExitCode =
 export type ExtendedStatus = {
   standalone: boolean;
   passphraseStreamCached: boolean;
+  tsecCached: boolean;
   deviceSigKeyCached: boolean;
   deviceEncKeyCached: boolean;
   paperSigKeyCached: boolean;


### PR DESCRIPTION
`keybase status` was still incorrect about passphrase stream cache.

Also, device keys weren't cached after kex2 provisioning.

r? @maxtaco 