### PR TITLE
add the libXScrnSaver dependency on RPM distros

### DIFF
--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -31,7 +31,7 @@ if [ "$mode" = "production" ] ; then
   repo_url="http://dist.keybase.io/linux/rpm/repo"
 elif [ "$mode" = "prerelease" ] ; then
   repo_url="http://prerelease.keybase.io/rpm"
-  dependencies="Requires: fuse"
+  dependencies="Requires: fuse, libXScrnSaver"
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the
   # production URL, because we're moving to a model where we build a clean


### PR DESCRIPTION
This prevents Electron from crashing with:

    libXss.so.1: cannot open shared object file: No such file or directory

r? @cjb 