### PR TITLE
Unify tab bar props

### DIFF
--- a/shared/common-adapters/dumb.desktop.js
+++ b/shared/common-adapters/dumb.desktop.js
@@ -41,11 +41,11 @@ const checkboxMap: DumbComponentMap<Checkbox> = {
 }
 
 const IconButton = ({selected, icon, badgeNumber, label}: any) => <TabBarButton label={label} source={{type: 'icon', icon}} selected={selected} badgeNumber={badgeNumber} style={{height: 40}} />
-const AvatarButton = ({selected, avatar, badgeNumber}: any) => <TabBarButton source={{type: 'avatar', avatar}} selected={selected} badgeNumber={badgeNumber} style={{height: 40}} />
+const AvatarButton = ({selected, avatar, badgeNumber}: any) => <TabBarButton source={{type: 'avatar', avatar}} selected={selected} badgeNumber={badgeNumber} style={{flex: 1}} styleContainer={{height: 40}} />
 
 const tabBarCustomButtons = selectedIndex => ({
   style: {flex: 1, display: 'flex', ...globalStyles.flexBoxRow, height: 580},
-  tabBarStyle: {justifyContent: 'flex-start', width: 160, backgroundColor: globalColors.midnightBlue, ...globalStyles.flexBoxColumn},
+  styleTabBar: {justifyContent: 'flex-start', width: 160, backgroundColor: globalColors.midnightBlue, ...globalStyles.flexBoxColumn},
   children: [
     {avatar: <Avatar size={32} onClick={null} username='max' />},
     {icon: 'fa-kb-iconfont-people', label: 'PEOPLE', badgeNumber: 3},
@@ -53,9 +53,9 @@ const tabBarCustomButtons = selectedIndex => ({
     {icon: 'fa-kb-iconfont-device', label: 'DEVICES', badgeNumber: 12},
     {icon: 'fa-kb-iconfont-settings', label: 'SETTINGS'},
   ].map((buttonInfo: any, i) => {
-    const button = buttonInfo.avatar ? <AvatarButton badgeNumber={buttonInfo.badgeNumber} selected={selectedIndex === i} avatar={buttonInfo.avatar} />
+    const button = buttonInfo.avatar
+      ? <AvatarButton badgeNumber={buttonInfo.badgeNumber} selected={selectedIndex === i} avatar={buttonInfo.avatar} />
       : <IconButton icon={buttonInfo.icon} label={buttonInfo.label} badgeNumber={buttonInfo.badgeNumber} selected={selectedIndex === i} />
-
     return (
       <TabBarItem tabBarButton={button} styleContainer={{display: 'flex'}} selected={selectedIndex === i} onClick={() => console.log('TabBaritem:onClick')}>
         <Text type='Header' style={{flex: 1}}>Content here at: {i}</Text>

--- a/shared/common-adapters/dumb.native.js
+++ b/shared/common-adapters/dumb.native.js
@@ -22,7 +22,8 @@ const tabBarButtonMap: DumbComponentMap<TabBarButton> = {
 const tabBarBaseMock = {
   style: {flex: 1},
   children: [
-    (<TabBarItem label='One' selected onClick={() => {}}>
+    // eslint-disable-next-line react/jsx-boolean-value
+    (<TabBarItem label='One' selected={true} onClick={() => {}}>
       <Text type='Header' style={{flex: 2}}>One</Text>
     </TabBarItem>),
     (<TabBarItem label='Two' selected={false} onClick={() => {}}>
@@ -39,7 +40,7 @@ const AvatarButton = ({selected, avatar, badgeNumber}: any) => <TabBarButton sou
 
 const tabBarCustomButtons = selectedIndex => ({
   style: {flex: 1},
-  tabBarStyle: {justifyContent: 'space-between', height: 56},
+  styleTabBar: {justifyContent: 'space-between', height: 56},
   children: [
     {avatar: <Avatar size={32} onClick={null} username='max' />},
     {icon: 'fa-users', badgeNumber: 3},
@@ -47,11 +48,12 @@ const tabBarCustomButtons = selectedIndex => ({
     {icon: 'phone-bw-m', badgeNumber: 12},
     {icon: 'fa-cog'},
   ].map((buttonInfo: any, i) => {
-    const button = buttonInfo.avatar ? <AvatarButton badgeNumber={buttonInfo.badgeNumber} selected={selectedIndex === i} avatar={buttonInfo.avatar} />
+    const button = buttonInfo.avatar
+      ? <AvatarButton badgeNumber={buttonInfo.badgeNumber} selected={selectedIndex === i} avatar={buttonInfo.avatar} />
       : <IconButton icon={buttonInfo.icon} badgeNumber={buttonInfo.badgeNumber} selected={selectedIndex === i} />
 
     return (
-      <TabBarItem tabBarButton={button} styleContainer={{flex: 1}} selected={selectedIndex === i} onClick={() => console.log('TabBaritem:onClick')}>
+      <TabBarItem tabBarButton={button} style={{flex: 1}} selected={selectedIndex === i} onClick={() => console.log('TabBaritem:onClick')}>
         <Text type='Header' style={{flex: 2}}>Content here at: {i}</Text>
       </TabBarItem>
     )

--- a/shared/common-adapters/tab-bar.desktop.js
+++ b/shared/common-adapters/tab-bar.desktop.js
@@ -15,17 +15,7 @@ export class TabBarItem extends Component {
   }
 }
 
-type SimpleTabBarButtonProps = {
-  label: string,
-  selected: boolean,
-  selectedColor?: string,
-  underlined?: boolean,
-  onBottom?: boolean,
-  styleContainer?: Object,
-  styleLabel?: Object
-}
-
-class SimpleTabBarButton extends Component<void, SimpleTabBarButtonProps, void> {
+class SimpleTabBarButton extends Component<void, ItemProps, void> {
   render () {
     const selectedColor = this.props.selectedColor || globalColors.blue
     const borderLocation = this.props.onBottom ? 'borderTop' : 'borderBottom'
@@ -35,14 +25,13 @@ class SimpleTabBarButton extends Component<void, SimpleTabBarButtonProps, void> 
         style={{
           [borderLocation]: `solid 2px ${this.props.selected ? selectedColor : 'transparent'}`,
           padding: '4px 12px',
-          ...this.props.styleContainer,
+          ...this.props.style,
         }}>
         <Text
           type='BodySmall'
           style={{
             color: this.props.selected ? globalColors.black_75 : globalColors.black_60,
             ...underlineStyle,
-            ...this.props.styleLabel,
           }}>
           {this.props.label}
         </Text>
@@ -55,8 +44,8 @@ export class TabBarButton extends Component<void, TabBarButtonProps, void> {
   _renderAvatar (backgroundColor: string, color: string, badgeNumber: number) {
     if (this.props.source.type !== 'avatar') return // needed to make flow happy
     return (
-      <Box style={{...globalStyles.flexBoxColumn, backgroundColor, paddingBottom: 21, paddingTop: 21}}>
-        <Box style={{...stylesTabBarButtonIcon, paddingLeft: 0, height: undefined, justifyContent: 'center', ...this.props.style}}>
+      <Box style={{...globalStyles.flexBoxColumn, backgroundColor, paddingBottom: 21, paddingTop: 21, ...this.props.style}}>
+        <Box style={{...stylesTabBarButtonIcon, paddingLeft: 0, height: undefined, justifyContent: 'center', ...this.props.styleContainer}}>
           {this.props.source.avatar}
           {badgeNumber > 0 &&
             <Box style={{width: 0, display: 'flex'}}>
@@ -129,18 +118,9 @@ class TabBar extends Component {
 
   _labels (): Array<React$Element> {
     // TODO: Not sure why I have to wrap the child in a box, but otherwise touches won't work
-    return (this.props.children || []).map((item, i) => (
-      <Box key={item.props.label || i} style={item.props.containerStyle} onClick={item.props.onClick}>
-        {item.props.tabBarButton ||
-          <SimpleTabBarButton
-            label={item.props.label}
-            selected={item.props.selected}
-            selectedColor={item.props.selectedColor}
-            underlined={this.props.underlined}
-            onBottom={this.props.tabBarOnBottom}
-            styleContainer={item.props.styleContainer}
-            styleLabel={item.props.styleLabel}
-          />}
+    return (this.props.children || []).map((item: {props: ItemProps}, i) => (
+      <Box key={`${i}-${item.props.label}`} style={item.props.styleContainer} onClick={item.props.onClick}>
+        {item.props.tabBarButton || <SimpleTabBarButton {...item.props} />}
       </Box>
     ))
   }
@@ -151,7 +131,7 @@ class TabBar extends Component {
 
   render () {
     const tabBarButtons = (
-      <Box style={{...globalStyles.flexBoxRow, ...this.props.tabBarStyle}}>
+      <Box style={{...globalStyles.flexBoxRow, ...this.props.styleTabBar}}>
         {this._labels()}
       </Box>
     )

--- a/shared/common-adapters/tab-bar.desktop.js
+++ b/shared/common-adapters/tab-bar.desktop.js
@@ -1,5 +1,6 @@
 // @flow
 import React, {Component} from 'react'
+import _ from 'lodash'
 import {globalStyles, globalColors} from '../styles/style-guide'
 import Box from './box'
 import Text from './text'
@@ -118,11 +119,14 @@ class TabBar extends Component {
 
   _labels (): Array<React$Element> {
     // TODO: Not sure why I have to wrap the child in a box, but otherwise touches won't work
-    return (this.props.children || []).map((item: {props: ItemProps}, i) => (
-      <Box key={`${i}-${item.props.label}`} style={item.props.styleContainer} onClick={item.props.onClick}>
-        {item.props.tabBarButton || <SimpleTabBarButton {...item.props} />}
-      </Box>
-    ))
+    return (this.props.children || []).map((item: {props: ItemProps}, i) => {
+      const key = item.props.label || _.get(item, 'props.tabBarButton.props.label') || i
+      return (
+        <Box key={key} style={item.props.styleContainer} onClick={item.props.onClick}>
+          {item.props.tabBarButton || <SimpleTabBarButton {...item.props} />}
+        </Box>
+      )
+    })
   }
 
   _content (): any {

--- a/shared/common-adapters/tab-bar.js.flow
+++ b/shared/common-adapters/tab-bar.js.flow
@@ -4,41 +4,40 @@ import React, {Component} from 'react'
 import Avatar from './avatar'
 import type {Props as IconProps} from './icon'
 
-export type ItemProps = {
-  tabBarButton?: React$Element,
-  label?: string,
+export type Props = $Shape<{
   style?: Object,
-  selected?: boolean,
-  selectedColor?: string,
-  onClick?: () => void,
-  styleContainer?: Object,
-  styleLabel?: Object,
-  children?: React$Element
-}
-
-export class TabBarItem extends Component<void, ItemProps, void> {
-}
-
-export type Props = {
-  style?: Object,
-  tabBarStyle?: Object,
+  styleTabBar?: Object,
   children?: Array<React$Element<ItemProps>>,
   tabBarOnBottom?: boolean,
-  tabWidth?: number,
   underlined?: boolean
-}
-
-export type TabBarButtonProps = {
-  selected?: boolean,
-  source: {type: 'icon', icon: IconProps.type, label?: string} | {type: 'avatar', avatar: Avatar},
-  badgeNumber?: ?number,
-  style?: Object,
-  styleBadge?: Object,
-  styleIcon?: Object,
-  styleLabel?: Object,
-  styleBadgeNumber?: Object
-}
-
-export class TabBarButton extends Component<void, TabBarButtonProps, void> { }
+}>
 
 export default class TabBar extends Component<void, Props, void> { }
+
+export type ItemProps = $Shape<{
+  tabBarButton: React$Element,
+  label: string,
+  selected: boolean,
+  selectedColor: string,
+  onClick: () => void,
+  style: Object,
+  styleContainer: Object,
+  children: React$Element
+}>
+
+export class TabBarItem extends Component<void, ItemProps, void> { }
+
+export type TabBarButtonProps = $Shape<{
+  selected?: boolean,
+  source: {type: 'icon', icon: IconProps.type} | {type: 'avatar', avatar: Avatar},
+  label?: string,
+  badgeNumber?: ?number,
+  style?: Object,
+  styleContainer?: Object,
+  styleBadge?: Object,
+  styleIcon?: Object,
+  styleBadgeNumber?: Object,
+  styleLabel?: Object
+}>
+
+export class TabBarButton extends Component<void, TabBarButtonProps, void> { }

--- a/shared/common-adapters/tab-bar.js.flow
+++ b/shared/common-adapters/tab-bar.js.flow
@@ -3,7 +3,7 @@
 import React, {Component} from 'react'
 import Avatar from './avatar'
 import type {$Exact} from '../constants/types/more'
-import type {Props as IconProps} from './icon'
+import type {IconType} from './icon'
 
 export type Props = $Exact<{
   style?: Object,
@@ -30,7 +30,7 @@ export class TabBarItem extends Component<void, ItemProps, void> { }
 
 export type TabBarButtonProps = $Exact<{
   selected?: boolean,
-  source: {type: 'icon', icon: IconProps.type} | {type: 'avatar', avatar: Avatar},
+  source: {type: 'icon', icon: IconType} | {type: 'avatar', avatar: Avatar},
   label?: string,
   badgeNumber?: ?number,
   style?: Object,

--- a/shared/common-adapters/tab-bar.js.flow
+++ b/shared/common-adapters/tab-bar.js.flow
@@ -2,32 +2,33 @@
 
 import React, {Component} from 'react'
 import Avatar from './avatar'
+import type {$Exact} from '../constants/types/more'
 import type {Props as IconProps} from './icon'
 
-export type Props = $Shape<{
+export type Props = $Exact<{
   style?: Object,
   styleTabBar?: Object,
   children?: Array<React$Element<ItemProps>>,
   tabBarOnBottom?: boolean,
-  underlined?: boolean
+  underlined?: boolean,
 }>
 
 export default class TabBar extends Component<void, Props, void> { }
 
-export type ItemProps = $Shape<{
-  tabBarButton: React$Element,
-  label: string,
+export type ItemProps = $Exact<{
+  tabBarButton?: React$Element,
+  label?: string,
   selected: boolean,
-  selectedColor: string,
-  onClick: () => void,
-  style: Object,
-  styleContainer: Object,
-  children: React$Element
+  selectedColor?: string,
+  onClick?: () => void,
+  style?: Object,
+  styleContainer?: Object,
+  children?: React$Element,
 }>
 
 export class TabBarItem extends Component<void, ItemProps, void> { }
 
-export type TabBarButtonProps = $Shape<{
+export type TabBarButtonProps = $Exact<{
   selected?: boolean,
   source: {type: 'icon', icon: IconProps.type} | {type: 'avatar', avatar: Avatar},
   label?: string,
@@ -37,7 +38,7 @@ export type TabBarButtonProps = $Shape<{
   styleBadge?: Object,
   styleIcon?: Object,
   styleBadgeNumber?: Object,
-  styleLabel?: Object
+  styleLabel?: Object,
 }>
 
 export class TabBarButton extends Component<void, TabBarButtonProps, void> { }

--- a/shared/common-adapters/tab-bar.native.js
+++ b/shared/common-adapters/tab-bar.native.js
@@ -1,6 +1,7 @@
 // @flow
 import React, {Component} from 'react'
 import {TouchableWithoutFeedback} from 'react-native'
+import _ from 'lodash'
 import {globalStyles, globalColors} from '../styles/style-guide'
 import Box from './box'
 import Text from './text'
@@ -78,13 +79,16 @@ class TabBar extends Component {
 
   _labels (): Array<React$Element> {
     // TODO: Not sure why I have to wrap the child in a box, but otherwise touches won't work
-    return (this.props.children || []).map((item: {props: ItemProps}, i) => (
-      <TouchableWithoutFeedback key={`${i}-${item.props.label}`} onPress={item.props.onClick || (() => {})}>
-        <Box style={item.props.styleContainer}>
-          {item.props.tabBarButton || <SimpleTabBarButton {...item.props} />}
-        </Box>
-      </TouchableWithoutFeedback>
-    ))
+    return (this.props.children || []).map((item: {props: ItemProps}, i) => {
+      const key = item.props.label || _.get(item, 'props.tabBarButton.props.label') || i
+      return (
+        <TouchableWithoutFeedback key={key} onPress={item.props.onClick || (() => {})}>
+          <Box style={item.props.styleContainer}>
+            {item.props.tabBarButton || <SimpleTabBarButton {...item.props} />}
+          </Box>
+        </TouchableWithoutFeedback>
+      )
+    })
   }
 
   _content (): any {

--- a/shared/common-adapters/tab-bar.native.js
+++ b/shared/common-adapters/tab-bar.native.js
@@ -133,8 +133,8 @@ const stylesTabBarButtonIcon = {
 const stylesLabel = {
   fontSize: 14,
   lineHeight: 20,
-  marginTop: 5,
-  marginBottom: 5,
+  marginTop: 11,
+  marginBottom: 11,
 }
 
 const stylesSelectedUnderline = color => ({

--- a/shared/common-adapters/tab-bar.native.js
+++ b/shared/common-adapters/tab-bar.native.js
@@ -16,22 +16,15 @@ export class TabBarItem extends Component {
   }
 }
 
-type SimpleTabBarButtonProps = {
-  selected: boolean,
-  label: string,
-  tabWidth?: ?number,
-  style?: Object
-}
-
-class SimpleTabBarButton extends Component<void, SimpleTabBarButtonProps, void> {
+class SimpleTabBarButton extends Component<void, ItemProps, void> {
   render () {
-    const tabWidth = this.props.tabWidth || 93
+    const selectedColor = this.props.selectedColor || globalColors.blue
     return (
-      <Box style={{...stylesTab, width: tabWidth}}>
+      <Box style={{...stylesTab, ...this.props.style}}>
         <Text type='BodySemibold' style={{...stylesLabel, color: this.props.selected ? globalColors.black_75 : globalColors.black_60}}>
           {this.props.label.toUpperCase()}
         </Text>
-        {this.props.selected && <Box style={stylesSelectedUnderline} />}
+        {(!this.props.underlined || this.props.selected) && <Box style={stylesSelectedUnderline(this.props.selected ? selectedColor : 'transparent')} />}
         {!this.props.selected && this.props.underlined && <Box style={stylesUnselectedUnderline} />}
       </Box>
     )
@@ -85,10 +78,10 @@ class TabBar extends Component {
 
   _labels (): Array<React$Element> {
     // TODO: Not sure why I have to wrap the child in a box, but otherwise touches won't work
-    return (this.props.children || []).map((item, i) => (
-      <TouchableWithoutFeedback key={item.props.label || i} onPress={item.props.onClick || (() => {})}>
-        <Box style={item.props.containerStyle}>
-          {item.props.tabBarButton || <SimpleTabBarButton tabWidth={this.props.tabWidth} label={item.props.label} selected={item.props.selected} underlined={this.props.underlined} />}
+    return (this.props.children || []).map((item: {props: ItemProps}, i) => (
+      <TouchableWithoutFeedback key={`${i}-${item.props.label}`} onPress={item.props.onClick || (() => {})}>
+        <Box style={item.props.styleContainer}>
+          {item.props.tabBarButton || <SimpleTabBarButton {...item.props} />}
         </Box>
       </TouchableWithoutFeedback>
     ))
@@ -100,7 +93,7 @@ class TabBar extends Component {
 
   render () {
     const tabBarButtons = (
-      <Box style={{...globalStyles.flexBoxRow, ...this.props.tabBarStyle}}>
+      <Box style={{...globalStyles.flexBoxRow, ...this.props.styleTabBar}}>
         {this._labels()}
       </Box>
     )
@@ -140,11 +133,11 @@ const stylesLabel = {
   marginBottom: 5,
 }
 
-const stylesSelectedUnderline = {
+const stylesSelectedUnderline = color => ({
   height: 3,
-  backgroundColor: globalColors.blue,
   alignSelf: 'stretch',
-}
+  backgroundColor: color,
+})
 
 const stylesUnselectedUnderline = {
   height: 2,

--- a/shared/constants/types/more.js
+++ b/shared/constants/types/more.js
@@ -5,6 +5,8 @@ import {Component} from 'react' // eslint-disable-line
 export type DeviceType = 'mobile' | 'desktop' | 'backup'
 import type {Device as _Device, DeviceID, Time} from './flow-types'
 
+export type $Exact<X> = $Shape<X> & X
+
 export type Device = {
   name: string;
   deviceID: DeviceID;

--- a/shared/folders/render.desktop.js
+++ b/shared/folders/render.desktop.js
@@ -41,10 +41,10 @@ class Render extends Component<void, Props, void> {
 
     return (
       <Box style={{...stylesContainer, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.white, paddingTop: this.props.smallMode ? 0 : 45}}>
-        <TabBar tabBarStyle={tabBarStyle}>
+        <TabBar styleTabBar={tabBarStyle}>
           <TabBarItem
             selected={this.props.showingPrivate}
-            containerStyle={itemContainerStyle}
+            styleContainer={itemContainerStyle}
             tabBarButton={this._makeItem(false, this.props.showingPrivate === true)}
             onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab(true) }}>
             <List
@@ -57,7 +57,7 @@ class Render extends Component<void, Props, void> {
           </TabBarItem>
           <TabBarItem
             selected={!this.props.showingPrivate}
-            containerStyle={itemContainerStyle}
+            styleContainer={itemContainerStyle}
             tabBarButton={this._makeItem(true, this.props.showingPrivate === false)}
             onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab(false) }}>
             <List

--- a/shared/folders/render.desktop.js
+++ b/shared/folders/render.desktop.js
@@ -12,8 +12,9 @@ class Render extends Component<void, Props, void> {
   }
 
   _makeItem (isPublic: boolean, isSelected: boolean) {
+    const icon = isPublic ? 'subnav-folders-public' : 'subnav-folders-private'
     return <TabBarButton
-      source={{type: 'icon', icon: `subnav-folders-${isPublic ? 'public' : 'private'}`}}
+      source={{type: 'icon', icon}}
       style={{
         ...styleItem,
         borderBottom: isSelected

--- a/shared/folders/render.desktop.js
+++ b/shared/folders/render.desktop.js
@@ -13,13 +13,12 @@ class Render extends Component<void, Props, void> {
 
   _makeItem (isPublic: boolean, isSelected: boolean) {
     const icon = isPublic ? 'subnav-folders-public' : 'subnav-folders-private'
+    const selectedColor = isPublic ? globalColors.yellowGreen : globalColors.darkBlue2
     return <TabBarButton
       source={{type: 'icon', icon}}
       style={{
         ...styleItem,
-        borderBottom: isSelected
-          ? `solid 2px ${isPublic ? globalColors.yellowGreen : globalColors.darkBlue2}`
-          : 'none',
+        borderBottom: `solid 2px ${isSelected ? selectedColor : 'transparent'}`,
       }}
       styleBadge={styleBadge}
       styleIcon={styleIcon}

--- a/shared/folders/render.native.js
+++ b/shared/folders/render.native.js
@@ -34,10 +34,10 @@ class Render extends Component<void, Props, void> {
   render () {
     return (
       <Box style={{...stylesContainer, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.white}}>
-        <TabBar tabBarStyle={tabBarStyle}>
+        <TabBar styleTabBar={tabBarStyle}>
           <TabBarItem
             selected={this.props.showingPrivate}
-            containerStyle={itemContainerStyle}
+            styleContainer={itemContainerStyle}
             tabBarButton={this._makeItem(false, this.props.showingPrivate === true)}
             onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab(true) }}>
             <List
@@ -48,7 +48,7 @@ class Render extends Component<void, Props, void> {
           </TabBarItem>
           <TabBarItem
             selected={!this.props.showingPrivate}
-            containerStyle={itemContainerStyle}
+            styleContainer={itemContainerStyle}
             tabBarButton={this._makeItem(true, this.props.showingPrivate === false)}
             onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab(false) }}>
             <List

--- a/shared/folders/render.native.js
+++ b/shared/folders/render.native.js
@@ -8,8 +8,9 @@ import {globalStyles, globalColors} from '../styles/style-guide'
 
 class Render extends Component<void, Props, void> {
   _makeItem (isPublic: boolean, isSelected: boolean) {
+    const icon = isPublic ? 'subnav-folders-public' : 'subnav-folders-private'
     return <TabBarButton
-      source={{type: 'icon', icon: `subnav-folders-${isPublic ? 'public' : 'private'}`}}
+      source={{type: 'icon', icon}}
       style={{
         ...styleItem,
         borderBottomWidth: 2,

--- a/shared/tab-bar/index.render.desktop.js
+++ b/shared/tab-bar/index.render.desktop.js
@@ -49,9 +49,12 @@ export default class Render extends Component<void, Props, void> {
 
     return (
       <TabBarItem
-        key='search' tabBarButton={button}
+        key='search'
+        tabBarButton={button}
         selected={searchActive}
-        onClick={onClick} containerStyle={{...stylesTabBarItem}}>
+        onClick={onClick}
+        style={{...stylesTabBarItem}}
+      >
         {this.props.searchContent || <Box />}
       </TabBarItem>
     )
@@ -64,7 +67,6 @@ export default class Render extends Component<void, Props, void> {
     const label = this.props.username
     return (
       <TabBarButton
-        style={{flex: 0}}
         label={label}
         selected={this.props.selectedTab === tab}
         badgeNumber={this.props.badgeNumbers[tab]}
@@ -96,8 +98,13 @@ export default class Render extends Component<void, Props, void> {
 
       return (
         <TabBarItem
-          key={t} tabBarButton={button}
-          selected={this.props.selectedTab === t} onClick={onClick} containerStyle={{...stylesTabBarItem, ...(isProfile && {flex: 1, justifyContent: 'flex-end'})}}>
+          key={t}
+          tabBarButton={button}
+          selected={this.props.selectedTab === t}
+          onClick={onClick}
+          style={{...stylesTabBarItem}}
+          styleContainer={{...(isProfile ? {flex: 1, ...globalStyles.flexBoxColumn, justifyContent: 'flex-end'} : {})}}
+        >
           <Box style={{flex: 1, ...globalStyles.flexBoxColumn}}>{this.props.tabContent[t]}</Box>
         </TabBarItem>
       )
@@ -116,7 +123,7 @@ export default class Render extends Component<void, Props, void> {
 
     return (
       <TabBar style={stylesTabBarContainer}
-        tabBarStyle={{...stylesTabBar, backgroundColor}}>
+        styleTabBar={{...stylesTabBar, backgroundColor}}>
         {tabItems}
       </TabBar>
     )

--- a/shared/tab-bar/index.render.native.js
+++ b/shared/tab-bar/index.render.native.js
@@ -29,7 +29,7 @@ export default class Render extends Component<void, Props, void> {
     return (
       <TabBar style={{flex: 1}}
         tabBarOnBottom
-        tabBarStyle={stylesTabBar}>
+        styleTabBar={stylesTabBar}>
 
         {tabs.map(t => {
           const onPress = () => this.props.onTabClick(t)
@@ -47,7 +47,7 @@ export default class Render extends Component<void, Props, void> {
 
           return (
             <TabBarItem
-              key={t} tabBarButton={button} selected={this.props.selectedTab === t} onClick={onPress} containerStyle={{flex: 1}}>
+              key={t} tabBarButton={button} selected={this.props.selectedTab === t} onClick={onPress} styleContainer={{flex: 1}}>
               {this.props.tabContent[t]}
             </TabBarItem>
           )


### PR DESCRIPTION
- Standardize tab bar props for various tab bar button types (simple,
  avatar, icon)
- Use one set of props for mobile and desktop
- Ensure that all tab bar use cases are providing properly typed props