### PR TITLE
Add hotkeys triggering navigateUp & navigateBack

### DIFF
--- a/shared/nav.desktop.js
+++ b/shared/nav.desktop.js
@@ -147,12 +147,12 @@ class Nav extends Component<void, Props, State> {
 
   _handleKeyDown (e: SyntheticKeyboardEvent) {
     const modKey = process.platform === 'darwin' ? e.metaKey : e.ctrlKey
-    if (modKey && e.keyCode === 37 /* left arrow */) {
+    if (modKey && e.key === 'ArrowLeft') {
       e.preventDefault()
       this.props.navigateBack()
       return
     }
-    if (modKey && e.keyCode === 38 /* up arrow */) {
+    if (modKey && e.key === 'ArrowUp') {
       e.preventDefault()
       this.props.navigateUp()
       return
@@ -173,7 +173,7 @@ class Nav extends Component<void, Props, State> {
 
   componentDidMount () {
     this._checkTabChanged()
-    window.addEventListener('keydown', this._handleKeyDown)
+    if (flags.admin) window.addEventListener('keydown', this._handleKeyDown)
   }
 
   componentDidUpdate () {
@@ -181,7 +181,7 @@ class Nav extends Component<void, Props, State> {
   }
 
   componentWillUnmount () {
-    window.removeEventListener('keydown', this._handleKeyDown)
+    if (flags.admin) window.removeEventListener('keydown', this._handleKeyDown)
   }
 
   _renderContent (tab, module) {


### PR DESCRIPTION
This places a keyDown listener on the main window (and ties it to the component lifecycle to make sure that it has access to the component's props without leaking them). The listener can handle two hotkeys:

- `ctrl/cmd + left_arrow` *(Windows/Linux is ctrl, macOs is cmd)* to trigger navigateBack
- `ctrl/cmd + up_arrow` *(Windows/Linux is ctrl, macOs is cmd)* to trigger navigateUp

This complements @chrisnojima's change in #3117 which removes the debug back button