### PR TITLE
hide the launcher devtools most of the time

### DIFF
--- a/desktop/app/dev-tools.js
+++ b/desktop/app/dev-tools.js
@@ -1,5 +1,5 @@
 import {BrowserWindow, app, globalShortcut} from 'electron'
-import {showDevTools} from '../shared/local-debug.desktop'
+import {showDevTools, skipLauncherDevtools} from '../shared/local-debug.desktop'
 
 function setupDevToolsExtensions () {
   if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) {
@@ -41,6 +41,13 @@ export default function () {
     win = win || BrowserWindow.getFocusedWindow()
 
     if (win) {
+      if (skipLauncherDevtools) {
+        win.webContents.addListener('did-finish-load', () => {
+          if (win.webContents.getURL().indexOf('launcher.') !== -1) {
+            win.closeDevTools()
+          }
+        })
+      }
       win.openDevTools()
     }
   })

--- a/shared/local-debug.desktop.js
+++ b/shared/local-debug.desktop.js
@@ -24,6 +24,7 @@ let config = {
   focusOnShow: true,
   dumbFilter: '',
   printRoutes: false,
+  skipLauncherDevtools: true,
 }
 
 if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) {
@@ -75,6 +76,7 @@ export const {
   focusOnShow,
   dumbFilter,
   printRoutes,
+  skipLauncherDevtools,
 } = config
 
 export function initTabbedRouterState (state) {


### PR DESCRIPTION
@keybase/react-hackers usually we want the main devtools and not the menu widget