### PR TITLE
CLI to provision via pgp, signup push pgp

### DIFF
--- a/go/client/cmd_pgpprovision.go
+++ b/go/client/cmd_pgpprovision.go
@@ -4,28 +4,29 @@
 package client
 
 import (
-	//	"golang.org/x/net/context"
 	"fmt"
+
+	"golang.org/x/net/context"
 
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
-	//	keybase1 "github.com/keybase/client/go/protocol"
-	//	rpc "github.com/keybase/go-framed-msgpack-rpc"
+	keybase1 "github.com/keybase/client/go/protocol"
+	rpc "github.com/keybase/go-framed-msgpack-rpc"
 )
 
 type CmdPGPProvision struct {
 	libkb.Contextified
-	username       string
-	deviceName     string
-	pgpFingerprint string
+	username   string
+	deviceName string
+	passphrase string
 }
 
 func NewCmdPGPProvision(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:         "pgpprovision",
 		Usage:        "Provision a device via PGP",
-		ArgumentHelp: "[username] [devicename] [pgp fingerprint]",
+		ArgumentHelp: "[username] [passphrase] [devicename]",
 		Action: func(c *cli.Context) {
 			cmd := &CmdPGPProvision{Contextified: libkb.NewContextified(g)}
 			cl.ChooseCommand(cmd, "paper", c)
@@ -35,40 +36,35 @@ func NewCmdPGPProvision(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.
 
 func (c *CmdPGPProvision) ParseArgv(ctx *cli.Context) error {
 	if len(ctx.Args()) != 3 {
-		return fmt.Errorf("expected 3 args [username] [devicename] [pgp fingerprint]")
+		return fmt.Errorf("expected 3 args [username] [passphrase] [devicename]")
 	}
 
 	c.username = ctx.Args()[0]
-	c.deviceName = ctx.Args()[1]
-	c.pgpFingerprint = ctx.Args()[2]
+	c.passphrase = ctx.Args()[1]
+	c.deviceName = ctx.Args()[2]
 
 	return nil
 }
 
 func (c *CmdPGPProvision) Run() error {
-	/*
-		protocols := []rpc.Protocol{
-			NewSecretUIProtocol(c.G()),
-		}
-		if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
-			return err
-		}
+	protocols := []rpc.Protocol{
+		NewSecretUIProtocol(c.G()),
+		NewLoginUIProtocol(c.G()),
+	}
+	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
+		return err
+	}
 
-		phrase, err := PromptPaperPhrase(c.G())
-		if err != nil {
-			return err
-		}
-
-		cli, err := GetLoginClient(c.G())
-		if err != nil {
-			return err
-		}
-		arg := keybase1.PaperKeySubmitArg{
-			PaperPhrase: phrase,
-		}
-		return cli.PaperKeySubmit(context.Background(), arg)
-	*/
-	return nil
+	cli, err := GetLoginClient(c.G())
+	if err != nil {
+		return err
+	}
+	arg := keybase1.PGPProvisionArg{
+		Username:   c.username,
+		Passphrase: c.passphrase,
+		DeviceName: c.deviceName,
+	}
+	return cli.PGPProvision(context.Background(), arg)
 }
 
 func (c *CmdPGPProvision) GetUsage() libkb.Usage {

--- a/go/client/cmd_pgpprovision.go
+++ b/go/client/cmd_pgpprovision.go
@@ -1,0 +1,80 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	//	"golang.org/x/net/context"
+	"fmt"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	//	keybase1 "github.com/keybase/client/go/protocol"
+	//	rpc "github.com/keybase/go-framed-msgpack-rpc"
+)
+
+type CmdPGPProvision struct {
+	libkb.Contextified
+	username       string
+	deviceName     string
+	pgpFingerprint string
+}
+
+func NewCmdPGPProvision(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "pgpprovision",
+		Usage:        "Provision a device via PGP",
+		ArgumentHelp: "[username] [devicename] [pgp fingerprint]",
+		Action: func(c *cli.Context) {
+			cmd := &CmdPGPProvision{Contextified: libkb.NewContextified(g)}
+			cl.ChooseCommand(cmd, "paper", c)
+		},
+	}
+}
+
+func (c *CmdPGPProvision) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 3 {
+		return fmt.Errorf("expected 3 args [username] [devicename] [pgp fingerprint]")
+	}
+
+	c.username = ctx.Args()[0]
+	c.deviceName = ctx.Args()[1]
+	c.pgpFingerprint = ctx.Args()[2]
+
+	return nil
+}
+
+func (c *CmdPGPProvision) Run() error {
+	/*
+		protocols := []rpc.Protocol{
+			NewSecretUIProtocol(c.G()),
+		}
+		if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
+			return err
+		}
+
+		phrase, err := PromptPaperPhrase(c.G())
+		if err != nil {
+			return err
+		}
+
+		cli, err := GetLoginClient(c.G())
+		if err != nil {
+			return err
+		}
+		arg := keybase1.PaperKeySubmitArg{
+			PaperPhrase: phrase,
+		}
+		return cli.PaperKeySubmit(context.Background(), arg)
+	*/
+	return nil
+}
+
+func (c *CmdPGPProvision) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		API:       true,
+		KbKeyring: true,
+		Config:    true,
+	}
+}

--- a/go/client/cmd_signup.go
+++ b/go/client/cmd_signup.go
@@ -70,6 +70,7 @@ type CmdSignup struct {
 	defaultDevice     string
 	doPrompt          bool
 	skipMail          bool
+	genPGP            bool
 }
 
 func NewCmdSignupRunner(g *libkb.GlobalContext) *CmdSignup {
@@ -111,6 +112,7 @@ func (s *CmdSignup) ParseArgv(ctx *cli.Context) error {
 		}
 
 		s.passphrase = s.defaultPassphrase
+		s.genPGP = ctx.Bool("pgp")
 		s.doPrompt = false
 	} else {
 		s.doPrompt = true
@@ -242,6 +244,7 @@ func (s *CmdSignup) runEngine() (retry bool, err error) {
 		StoreSecret: s.storeSecret,
 		DeviceName:  s.fields.deviceName.GetValue(),
 		SkipMail:    s.skipMail,
+		GenPGPBatch: s.genPGP,
 	}
 	res, err := s.scli.Signup(context.TODO(), rarg)
 	if err == nil {

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -24,6 +24,7 @@ func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext
 		NewCmdTestPassphrase(cl, g),
 		NewCmdTestFSNotify(cl, g),
 		NewCmdPaperProvision(cl, g),
+		NewCmdPGPProvision(cl, g),
 	}
 }
 
@@ -41,8 +42,8 @@ var restrictedSignupFlags = []cli.Flag{
 		Usage: "Batch mode (don't prompt, use all defaults)",
 	},
 	cli.BoolFlag{
-		Name:  "devel",
-		Usage: "Run the client in development mode",
+		Name:  "pgp",
+		Usage: "Add a server-synced pgp key",
 	},
 }
 

--- a/go/engine/paperprovision.go
+++ b/go/engine/paperprovision.go
@@ -21,12 +21,12 @@ type PaperProvisionEngine struct {
 	User       *libkb.User
 }
 
-func NewPaperProvisionEngine(g *libkb.GlobalContext, Username string, DeviceName string, PaperKey string) *PaperProvisionEngine {
+func NewPaperProvisionEngine(g *libkb.GlobalContext, username, deviceName, paperKey string) *PaperProvisionEngine {
 	return &PaperProvisionEngine{
 		Contextified: libkb.NewContextified(g),
-		Username:     Username,
-		DeviceName:   DeviceName,
-		PaperKey:     PaperKey,
+		Username:     username,
+		DeviceName:   deviceName,
+		PaperKey:     paperKey,
 	}
 }
 
@@ -178,7 +178,9 @@ func (e *PaperProvisionEngine) sendNotification() {
 }
 
 func (e *PaperProvisionEngine) SubConsumers() []libkb.UIConsumer {
-	return []libkb.UIConsumer{}
+	return []libkb.UIConsumer{
+		&loginLoadUser{},
+	}
 }
 
 func (e *PaperProvisionEngine) Result() error {

--- a/go/engine/pgpprovision.go
+++ b/go/engine/pgpprovision.go
@@ -10,18 +10,19 @@ import (
 // PGPProvision is an engine.
 type PGPProvision struct {
 	libkb.Contextified
-	username    string
-	deviceName  string
-	fingerprint string
+	username   string
+	deviceName string
+	passphrase string
+	user       *libkb.User
 }
 
 // NewPGPProvision creates a PGPProvision engine.
-func NewPGPProvision(g *libkb.GlobalContext, username, deviceName, fingerprint string) *PGPProvision {
+func NewPGPProvision(g *libkb.GlobalContext, username, deviceName, passphrase string) *PGPProvision {
 	return &PGPProvision{
 		Contextified: libkb.NewContextified(g),
 		username:     username,
 		deviceName:   deviceName,
-		fingerprint:  fingerprint,
+		passphrase:   passphrase,
 	}
 }
 
@@ -44,6 +45,7 @@ func (e *PGPProvision) RequiredUIs() []libkb.UIKind {
 func (e *PGPProvision) SubConsumers() []libkb.UIConsumer {
 	return []libkb.UIConsumer{
 		&loginLoadUser{},
+		&DeviceWrap{},
 	}
 }
 
@@ -78,6 +80,103 @@ func (e *PGPProvision) Run(ctx *Context) error {
 	if ueng.User().HasCurrentDeviceInCurrentInstall() {
 		return libkb.DeviceAlreadyProvisionedError{}
 	}
-	// e.User = ueng.User()
+	e.user = ueng.User()
+
+	return e.provision(ctx)
+}
+
+// provision attempts to provision with a synced pgp key.  It
+// needs to get a session first to look for a synced pgp key.
+func (e *PGPProvision) provision(ctx *Context) error {
+	// After obtaining login session, this will be called before the login state is released.
+	// It tries to get the pgp key and uses it to provision new device keys for this device.
+	var afterLogin = func(lctx libkb.LoginContext) error {
+		ctx.LoginContext = lctx
+		signer, err := e.syncedPGPKey(ctx)
+		if err != nil {
+			return err
+		}
+
+		if err := e.makeDeviceKeysWithSigner(ctx, signer); err != nil {
+			return err
+		}
+		if err := lctx.LocalSession().SetDeviceProvisioned(e.G().Env.GetDeviceID()); err != nil {
+			// not a fatal error, session will stay in memory
+			e.G().Log.Warning("error saving session file: %s", err)
+		}
+		return nil
+	}
+
+	// need a session to try to get synced private key
+	return e.G().LoginState().LoginWithPassphrase(e.user.GetName(), e.passphrase, false, afterLogin)
+}
+
+// syncedPGPKey looks for a synced pgp key for e.user.  If found,
+// it unlocks it.
+func (e *PGPProvision) syncedPGPKey(ctx *Context) (libkb.GenericKey, error) {
+	key, err := e.user.SyncedSecretKey(ctx.LoginContext)
+	if err != nil {
+		return nil, err
+	}
+	if key == nil {
+		return nil, libkb.NoSyncedPGPKeyError{}
+	}
+
+	e.G().Log.Debug("got synced secret key")
+
+	// unlock it
+	parg := ctx.SecretKeyPromptArg(libkb.SecretKeyArg{}, "sign new device")
+	unlocked, err := key.PromptAndUnlock(parg, nil, e.user)
+	if err != nil {
+		return nil, err
+	}
+
+	e.G().Log.Debug("unlocked secret key")
+	return unlocked, nil
+}
+
+// makeDeviceKeysWithSigner creates device keys given a signing
+// key.
+func (e *PGPProvision) makeDeviceKeysWithSigner(ctx *Context, signer libkb.GenericKey) error {
+	args, err := e.makeDeviceWrapArgs(ctx)
+	if err != nil {
+		return err
+	}
+	args.Signer = signer
+	args.IsEldest = false // just to be explicit
+	args.EldestKID = e.user.GetEldestKID()
+
+	return e.makeDeviceKeys(ctx, args)
+}
+
+// makeDeviceWrapArgs creates a base set of args for DeviceWrap.
+func (e *PGPProvision) makeDeviceWrapArgs(ctx *Context) (*DeviceWrapArgs, error) {
+	// generate lks
+	salt, err := ctx.LoginContext.LoginSession().Salt()
+	if err != nil {
+		return nil, err
+	}
+	_, pps, err := libkb.StretchPassphrase(e.passphrase, salt)
+	if err != nil {
+		return nil, err
+	}
+	// since this is just for testing, ok to set this explicitly
+	pps.SetGeneration(1)
+	lks := libkb.NewLKSec(pps, e.user.GetUID(), e.G())
+
+	return &DeviceWrapArgs{
+		Me:         e.user,
+		DeviceName: e.deviceName,
+		DeviceType: libkb.DeviceTypeDesktop,
+		Lks:        lks,
+	}, nil
+}
+
+// makeDeviceKeys uses DeviceWrap to generate device keys.
+func (e *PGPProvision) makeDeviceKeys(ctx *Context, args *DeviceWrapArgs) error {
+	eng := NewDeviceWrap(args, e.G())
+	if err := RunEngine(eng, ctx); err != nil {
+		return err
+	}
 	return nil
 }

--- a/go/engine/pgpprovision.go
+++ b/go/engine/pgpprovision.go
@@ -1,0 +1,83 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import (
+	"github.com/keybase/client/go/libkb"
+)
+
+// PGPProvision is an engine.
+type PGPProvision struct {
+	libkb.Contextified
+	username    string
+	deviceName  string
+	fingerprint string
+}
+
+// NewPGPProvision creates a PGPProvision engine.
+func NewPGPProvision(g *libkb.GlobalContext, username, deviceName, fingerprint string) *PGPProvision {
+	return &PGPProvision{
+		Contextified: libkb.NewContextified(g),
+		username:     username,
+		deviceName:   deviceName,
+		fingerprint:  fingerprint,
+	}
+}
+
+// Name is the unique engine name.
+func (e *PGPProvision) Name() string {
+	return "PGPProvision"
+}
+
+// GetPrereqs returns the engine prereqs.
+func (e *PGPProvision) Prereqs() Prereqs {
+	return Prereqs{}
+}
+
+// RequiredUIs returns the required UIs.
+func (e *PGPProvision) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *PGPProvision) SubConsumers() []libkb.UIConsumer {
+	return []libkb.UIConsumer{
+		&loginLoadUser{},
+	}
+}
+
+// Run starts the engine.
+func (e *PGPProvision) Run(ctx *Context) error {
+	// clear out any existing session:
+	e.G().Logout()
+
+	// transaction around config file
+	tx, err := e.G().Env.GetConfigWriter().BeginTransaction()
+	if err != nil {
+		return err
+	}
+
+	// From this point on, if there's an error, we abort the
+	// transaction.
+	defer func() {
+		if tx != nil {
+			tx.Abort()
+		}
+	}()
+
+	// run the LoginLoadUser sub-engine to load a user
+	ueng := newLoginLoadUser(e.G(), e.username)
+	if err = RunEngine(ueng, ctx); err != nil {
+		return err
+	}
+
+	// make sure the user isn't already provisioned (can
+	// get here if usernameOrEmail is an email address
+	// for an already provisioned on this device user).
+	if ueng.User().HasCurrentDeviceInCurrentInstall() {
+		return libkb.DeviceAlreadyProvisionedError{}
+	}
+	// e.User = ueng.User()
+	return nil
+}

--- a/go/engine/pgpprovision_test.go
+++ b/go/engine/pgpprovision_test.go
@@ -1,0 +1,69 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+)
+
+// Provision device using PGPProvision engine.
+func TestPGPProvision(t *testing.T) {
+	tc := SetupEngineTest(t, "pgpprov")
+	defer tc.Cleanup()
+
+	u1 := createFakeUserWithPGPPubOnly(t, tc)
+	Logout(tc)
+
+	// redo SetupEngineTest to get a new home directory...should look like a new device.
+	tc2 := SetupEngineTest(t, "pgpprov")
+	defer tc2.Cleanup()
+
+	// we need the gpg keyring that's in the first homedir
+	if err := tc.MoveGpgKeyringTo(tc2); err != nil {
+		t.Fatal(err)
+	}
+
+	// now safe to cleanup first home
+	tc.Cleanup()
+
+	// run PGPProvision on new device
+	ctx := &Context{
+		LoginUI:  &libkb.TestLoginUI{Username: u1.Username},
+		SecretUI: u1.NewSecretUI(),
+	}
+	eng := NewPGPProvision(tc2.G, u1.Username, "new device", "xxx")
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+	/*
+		ctx := &Context{
+			ProvisionUI: newTestProvisionUIGPGImport(),
+			LogUI:       tc2.G.UI.GetLogUI(),
+			SecretUI:    u1.NewSecretUI(),
+			LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
+			GPGUI:       &gpgtestui{},
+		}
+		eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
+		if err := RunEngine(eng, ctx); err != nil {
+			t.Fatal(err)
+		}
+	*/
+
+	testUserHasDeviceKey(tc2)
+
+	// highly possible they didn't have a paper key, so make sure they have one now:
+	hasOnePaperDev(tc2, u1)
+
+	if err := AssertProvisioned(tc2); err != nil {
+		t.Fatal(err)
+	}
+
+	// since they imported their pgp key, they should be able to pgp sign something:
+	if err := signString(tc2, "sign me", u1.NewSecretUI()); err != nil {
+		t.Error("pgp sign failed after gpg provision w/ import")
+		t.Fatal(err)
+	}
+}

--- a/go/engine/pgpprovision_test.go
+++ b/go/engine/pgpprovision_test.go
@@ -14,56 +14,29 @@ func TestPGPProvision(t *testing.T) {
 	tc := SetupEngineTest(t, "pgpprov")
 	defer tc.Cleanup()
 
-	u1 := createFakeUserWithPGPPubOnly(t, tc)
+	// create a user w/ a synced pgp key
+	u1 := createFakeUserWithPGPOnly(t, tc)
+	t.Log("Created fake user")
 	Logout(tc)
 
 	// redo SetupEngineTest to get a new home directory...should look like a new device.
 	tc2 := SetupEngineTest(t, "pgpprov")
 	defer tc2.Cleanup()
 
-	// we need the gpg keyring that's in the first homedir
-	if err := tc.MoveGpgKeyringTo(tc2); err != nil {
-		t.Fatal(err)
-	}
-
-	// now safe to cleanup first home
-	tc.Cleanup()
-
 	// run PGPProvision on new device
 	ctx := &Context{
 		LoginUI:  &libkb.TestLoginUI{Username: u1.Username},
-		SecretUI: u1.NewSecretUI(),
+		SecretUI: &libkb.TestSecretUI{},
+		LogUI:    tc2.G.UI.GetLogUI(),
 	}
-	eng := NewPGPProvision(tc2.G, u1.Username, "new device", "xxx")
+	eng := NewPGPProvision(tc2.G, u1.Username, "new device", u1.Passphrase)
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
-	/*
-		ctx := &Context{
-			ProvisionUI: newTestProvisionUIGPGImport(),
-			LogUI:       tc2.G.UI.GetLogUI(),
-			SecretUI:    u1.NewSecretUI(),
-			LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-			GPGUI:       &gpgtestui{},
-		}
-		eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
-		if err := RunEngine(eng, ctx); err != nil {
-			t.Fatal(err)
-		}
-	*/
 
 	testUserHasDeviceKey(tc2)
 
-	// highly possible they didn't have a paper key, so make sure they have one now:
-	hasOnePaperDev(tc2, u1)
-
 	if err := AssertProvisioned(tc2); err != nil {
-		t.Fatal(err)
-	}
-
-	// since they imported their pgp key, they should be able to pgp sign something:
-	if err := signString(tc2, "sign me", u1.NewSecretUI()); err != nil {
-		t.Error("pgp sign failed after gpg provision w/ import")
 		t.Fatal(err)
 	}
 }

--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -34,6 +34,7 @@ type SignupEngineRunArg struct {
 	SkipGPG     bool
 	SkipMail    bool
 	SkipPaper   bool
+	GenPGPBatch bool // if true, generate and push a pgp key to the server (no interaction)
 }
 
 func NewSignupEngine(arg *SignupEngineRunArg, g *libkb.GlobalContext) *SignupEngine {
@@ -86,6 +87,15 @@ func (s *SignupEngine) Run(ctx *Context) error {
 
 		if !s.arg.SkipPaper {
 			if err := s.genPaperKeys(ctx); err != nil {
+				return err
+			}
+		}
+
+		// GenPGPBatch can be set in devel CLI to generate
+		// a pgp key and push it to the server without any
+		// user interaction to make testing easier.
+		if s.arg.GenPGPBatch {
+			if err := s.genPGPBatch(ctx); err != nil {
 				return err
 			}
 		}
@@ -235,4 +245,26 @@ func (s *SignupEngine) addGPG(lctx libkb.LoginContext, ctx *Context, allowMulti 
 		s.signingKey = eng.LastKey()
 	}
 	return nil
+}
+
+func (s *SignupEngine) genPGPBatch(ctx *Context) error {
+	gen := libkb.PGPGenArg{
+		PrimaryBits: 1024,
+		SubkeyBits:  1024,
+	}
+	gen.AddDefaultUID()
+
+	tsec := ctx.LoginContext.PassphraseStreamCache().Triplesec()
+	sgen := ctx.LoginContext.GetStreamGeneration()
+
+	eng := NewPGPKeyImportEngine(PGPKeyImportEngineArg{
+		Gen:              &gen,
+		PushSecret:       true,
+		Lks:              s.lks,
+		NoSave:           true,
+		PreloadTsec:      tsec,
+		PreloadStreamGen: sgen,
+	})
+
+	return RunEngine(eng, ctx)
 }

--- a/go/protocol/login.go
+++ b/go/protocol/login.go
@@ -62,10 +62,10 @@ type UnlockWithPassphraseArg struct {
 }
 
 type PGPProvisionArg struct {
-	SessionID      int    `codec:"sessionID" json:"sessionID"`
-	Username       string `codec:"username" json:"username"`
-	DeviceName     string `codec:"deviceName" json:"deviceName"`
-	PGPFingerprint string `codec:"pgpFingerprint" json:"pgpFingerprint"`
+	SessionID  int    `codec:"sessionID" json:"sessionID"`
+	Username   string `codec:"username" json:"username"`
+	Passphrase string `codec:"passphrase" json:"passphrase"`
+	DeviceName string `codec:"deviceName" json:"deviceName"`
 }
 
 type LoginInterface interface {

--- a/go/protocol/login.go
+++ b/go/protocol/login.go
@@ -61,6 +61,13 @@ type UnlockWithPassphraseArg struct {
 	Passphrase string `codec:"passphrase" json:"passphrase"`
 }
 
+type PGPProvisionArg struct {
+	SessionID      int    `codec:"sessionID" json:"sessionID"`
+	Username       string `codec:"username" json:"username"`
+	DeviceName     string `codec:"deviceName" json:"deviceName"`
+	PGPFingerprint string `codec:"pgpFingerprint" json:"pgpFingerprint"`
+}
+
 type LoginInterface interface {
 	// Returns an array of information about accounts configured on the local
 	// machine. Currently configured accounts are defined as those that have stored
@@ -90,6 +97,9 @@ type LoginInterface interface {
 	// Unlock restores access to local key store by priming passphrase stream cache.
 	Unlock(context.Context, int) error
 	UnlockWithPassphrase(context.Context, UnlockWithPassphraseArg) error
+	// pgpProvision is for devel/testing to provision a device via pgp using CLI
+	// with no user interaction.
+	PGPProvision(context.Context, PGPProvisionArg) error
 }
 
 func LoginProtocol(i LoginInterface) rpc.Protocol {
@@ -256,6 +266,22 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"pgpProvision": {
+				MakeArg: func() interface{} {
+					ret := make([]PGPProvisionArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]PGPProvisionArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]PGPProvisionArg)(nil), args)
+						return
+					}
+					err = i.PGPProvision(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -334,5 +360,12 @@ func (c LoginClient) Unlock(ctx context.Context, sessionID int) (err error) {
 
 func (c LoginClient) UnlockWithPassphrase(ctx context.Context, __arg UnlockWithPassphraseArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.login.unlockWithPassphrase", []interface{}{__arg}, nil)
+	return
+}
+
+// pgpProvision is for devel/testing to provision a device via pgp using CLI
+// with no user interaction.
+func (c LoginClient) PGPProvision(ctx context.Context, __arg PGPProvisionArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.login.pgpProvision", []interface{}{__arg}, nil)
 	return
 }

--- a/go/protocol/signup.go
+++ b/go/protocol/signup.go
@@ -28,6 +28,7 @@ type SignupArg struct {
 	DeviceName  string `codec:"deviceName" json:"deviceName"`
 	StoreSecret bool   `codec:"storeSecret" json:"storeSecret"`
 	SkipMail    bool   `codec:"skipMail" json:"skipMail"`
+	GenPGPBatch bool   `codec:"genPGPBatch" json:"genPGPBatch"`
 }
 
 type InviteRequestArg struct {

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -117,3 +117,7 @@ func (h *LoginHandler) Login(ctx context.Context, arg keybase1.LoginArg) error {
 	eng := engine.NewLogin(h.G(), arg.DeviceType, arg.UsernameOrEmail, arg.ClientType)
 	return engine.RunEngine(eng, ectx)
 }
+
+func (h *LoginHandler) PGPProvision(ctx context.Context, arg keybase1.PGPProvisionArg) error {
+	return nil
+}

--- a/go/service/signup.go
+++ b/go/service/signup.go
@@ -43,6 +43,7 @@ func (h *SignupHandler) Signup(_ context.Context, arg keybase1.SignupArg) (res k
 		StoreSecret: arg.StoreSecret,
 		DeviceName:  arg.DeviceName,
 		SkipMail:    arg.SkipMail,
+		GenPGPBatch: arg.GenPGPBatch,
 	}
 	eng := engine.NewSignupEngine(&runarg, h.G())
 	err = engine.RunEngine(eng, ctx)

--- a/protocol/avdl/login.avdl
+++ b/protocol/avdl/login.avdl
@@ -61,5 +61,5 @@ protocol login {
     pgpProvision is for devel/testing to provision a device via pgp using CLI
     with no user interaction.
     */
-  void pgpProvision(int sessionID, string username, string deviceName, string pgpFingerprint);
+  void pgpProvision(int sessionID, string username, string passphrase, string deviceName);
 }

--- a/protocol/avdl/login.avdl
+++ b/protocol/avdl/login.avdl
@@ -57,4 +57,9 @@ protocol login {
   void unlock(int sessionID);
   void unlockWithPassphrase(int sessionID, string passphrase);
 
+  /**
+    pgpProvision is for devel/testing to provision a device via pgp using CLI
+    with no user interaction.
+    */
+  void pgpProvision(int sessionID, string username, string deviceName, string pgpFingerprint);
 }

--- a/protocol/avdl/signup.avdl
+++ b/protocol/avdl/signup.avdl
@@ -11,7 +11,7 @@ protocol signup {
   }
 
   void checkUsernameAvailable(int sessionID, string username);
-  SignupRes signup(int sessionID, string email, string inviteCode, string passphrase, string username, string deviceName, boolean storeSecret, boolean skipMail);
+  SignupRes signup(int sessionID, string email, string inviteCode, string passphrase, string username, string deviceName, boolean storeSecret, boolean skipMail, boolean genPGPBatch);
   void inviteRequest(int sessionID, string email, string fullname, string notes);
   void checkInvitationCode(int sessionID, string invitationCode);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2195,6 +2195,19 @@ export type loginPaperKeySubmitRpc = {
   callback: (null | (err: ?any) => void)
 }
 
+export type loginPgpProvisionResult = void
+
+export type loginPgpProvisionRpc = {
+  method: 'login.pgpProvision',
+  param: {
+    username: string,
+    deviceName: string,
+    pgpFingerprint: string
+  },
+  incomingCallMap?: incomingCallMapType,
+  callback: (null | (err: ?any) => void)
+}
+
 export type loginRecoverAccountFromEmailAddressResult = void
 
 export type loginRecoverAccountFromEmailAddressRpc = {
@@ -3167,7 +3180,8 @@ export type signupSignupRpc = {
     username: string,
     deviceName: string,
     storeSecret: boolean,
-    skipMail: boolean
+    skipMail: boolean,
+    genPGPBatch: boolean
   },
   incomingCallMap?: incomingCallMapType,
   callback: (null | (err: ?any, response: signupSignupResult) => void)
@@ -3621,6 +3635,7 @@ export type rpc =
   | loginLogoutRpc
   | loginPaperKeyRpc
   | loginPaperKeySubmitRpc
+  | loginPgpProvisionRpc
   | loginRecoverAccountFromEmailAddressRpc
   | loginUiDisplayPaperKeyPhraseRpc
   | loginUiDisplayPrimaryPaperKeyRpc
@@ -4580,6 +4595,18 @@ export type incomingCallMapType = {
       result: () => void
     }
   ) => void,
+  'keybase.1.login.pgpProvision'?: (
+    params: {
+      sessionID: int,
+      username: string,
+      deviceName: string,
+      pgpFingerprint: string
+    },
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
+    }
+  ) => void,
   'keybase.1.loginUi.getEmailOrUsername'?: (
     params: {
       sessionID: int
@@ -5486,7 +5513,8 @@ export type incomingCallMapType = {
       username: string,
       deviceName: string,
       storeSecret: boolean,
-      skipMail: boolean
+      skipMail: boolean,
+      genPGPBatch: boolean
     },
     response: {
       error: (err: RPCError) => void,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2201,8 +2201,8 @@ export type loginPgpProvisionRpc = {
   method: 'login.pgpProvision',
   param: {
     username: string,
-    deviceName: string,
-    pgpFingerprint: string
+    passphrase: string,
+    deviceName: string
   },
   incomingCallMap?: incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -4599,8 +4599,8 @@ export type incomingCallMapType = {
     params: {
       sessionID: int,
       username: string,
-      deviceName: string,
-      pgpFingerprint: string
+      passphrase: string,
+      deviceName: string
     },
     response: {
       error: (err: RPCError) => void,

--- a/protocol/json/login.json
+++ b/protocol/json/login.json
@@ -153,6 +153,28 @@
         }
       ],
       "response": null
+    },
+    "pgpProvision": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "name": "deviceName",
+          "type": "string"
+        },
+        {
+          "name": "pgpFingerprint",
+          "type": "string"
+        }
+      ],
+      "response": null,
+      "doc": "pgpProvision is for devel/testing to provision a device via pgp using CLI\n    with no user interaction."
     }
   },
   "namespace": "keybase.1"

--- a/protocol/json/login.json
+++ b/protocol/json/login.json
@@ -165,11 +165,11 @@
           "type": "string"
         },
         {
-          "name": "deviceName",
+          "name": "passphrase",
           "type": "string"
         },
         {
-          "name": "pgpFingerprint",
+          "name": "deviceName",
           "type": "string"
         }
       ],

--- a/protocol/json/signup.json
+++ b/protocol/json/signup.json
@@ -73,6 +73,10 @@
         {
           "name": "skipMail",
           "type": "boolean"
+        },
+        {
+          "name": "genPGPBatch",
+          "type": "boolean"
         }
       ],
       "response": "SignupRes"

--- a/shared/actions/signup/index.js
+++ b/shared/actions/signup/index.js
@@ -306,13 +306,14 @@ function signup (skipMail: boolean, onDisplayPaperKey?: () => void): TypedAsyncA
         method: 'signup.signup',
         waitingHandler: isWaiting => dispatch(waiting(isWaiting)),
         param: {
-          email,
-          inviteCode,
-          username,
           deviceName,
+          email,
+          genPGPBatch: false,
+          inviteCode,
           passphrase: passphrase.stringValue(),
-          storeSecret: false,
           skipMail,
+          storeSecret: false,
+          username,
         },
         incomingCallMap: {
           'keybase.1.loginUi.displayPrimaryPaperKey': ({sessionID, phrase}, response) => {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2195,6 +2195,19 @@ export type loginPaperKeySubmitRpc = {
   callback: (null | (err: ?any) => void)
 }
 
+export type loginPgpProvisionResult = void
+
+export type loginPgpProvisionRpc = {
+  method: 'login.pgpProvision',
+  param: {
+    username: string,
+    deviceName: string,
+    pgpFingerprint: string
+  },
+  incomingCallMap?: incomingCallMapType,
+  callback: (null | (err: ?any) => void)
+}
+
 export type loginRecoverAccountFromEmailAddressResult = void
 
 export type loginRecoverAccountFromEmailAddressRpc = {
@@ -3167,7 +3180,8 @@ export type signupSignupRpc = {
     username: string,
     deviceName: string,
     storeSecret: boolean,
-    skipMail: boolean
+    skipMail: boolean,
+    genPGPBatch: boolean
   },
   incomingCallMap?: incomingCallMapType,
   callback: (null | (err: ?any, response: signupSignupResult) => void)
@@ -3621,6 +3635,7 @@ export type rpc =
   | loginLogoutRpc
   | loginPaperKeyRpc
   | loginPaperKeySubmitRpc
+  | loginPgpProvisionRpc
   | loginRecoverAccountFromEmailAddressRpc
   | loginUiDisplayPaperKeyPhraseRpc
   | loginUiDisplayPrimaryPaperKeyRpc
@@ -4580,6 +4595,18 @@ export type incomingCallMapType = {
       result: () => void
     }
   ) => void,
+  'keybase.1.login.pgpProvision'?: (
+    params: {
+      sessionID: int,
+      username: string,
+      deviceName: string,
+      pgpFingerprint: string
+    },
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
+    }
+  ) => void,
   'keybase.1.loginUi.getEmailOrUsername'?: (
     params: {
       sessionID: int
@@ -5486,7 +5513,8 @@ export type incomingCallMapType = {
       username: string,
       deviceName: string,
       storeSecret: boolean,
-      skipMail: boolean
+      skipMail: boolean,
+      genPGPBatch: boolean
     },
     response: {
       error: (err: RPCError) => void,

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2201,8 +2201,8 @@ export type loginPgpProvisionRpc = {
   method: 'login.pgpProvision',
   param: {
     username: string,
-    deviceName: string,
-    pgpFingerprint: string
+    passphrase: string,
+    deviceName: string
   },
   incomingCallMap?: incomingCallMapType,
   callback: (null | (err: ?any) => void)
@@ -4599,8 +4599,8 @@ export type incomingCallMapType = {
     params: {
       sessionID: int,
       username: string,
-      deviceName: string,
-      pgpFingerprint: string
+      passphrase: string,
+      deviceName: string
     },
     response: {
       error: (err: RPCError) => void,


### PR DESCRIPTION
1. Add `--pgp` flag to devel `signup` command that pushes a PGP key to API server
2. Add devel command `pgpprovision` that will provision a new device with synced PGP key

r? @maxtaco 