### PR TITLE
Strip extra characters from visdiff output filenames

### DIFF
--- a/desktop/test/render-visdiff.js
+++ b/desktop/test/render-visdiff.js
@@ -37,7 +37,7 @@ app.on('ready', () => {
 
   ipcMain.on('display-done', (ev, msg) => {
     win.capturePage(msg.rect, img => {
-      const filenameParts = [msg.key, msg.mockKey].map(s => _.words(s).join('_'))
+      const filenameParts = [msg.key, msg.mockKey].map(s => _.words(s).join('_').replace(/[^\w_-]/g, ''))
       const filename = filenameParts.join('-') + '.png'
       fs.writeFileSync(path.join(outputDir, filename), img.toPng())
       console.log('wrote', filename)

--- a/desktop/test/render-visdiff.js
+++ b/desktop/test/render-visdiff.js
@@ -37,7 +37,7 @@ app.on('ready', () => {
 
   ipcMain.on('display-done', (ev, msg) => {
     win.capturePage(msg.rect, img => {
-      const filenameParts = [msg.key, msg.mockKey].map(s => _.words(s).join('_').replace(/[^\w_-]/g, ''))
+      const filenameParts = [msg.key, msg.mockKey].map(s => _.words(s).join('_').replace(/[^\w_]/g, ''))
       const filename = filenameParts.join('-') + '.png'
       fs.writeFileSync(path.join(outputDir, filename), img.toPng())
       console.log('wrote', filename)


### PR DESCRIPTION
:eyeglasses: @keybase/react-hackers 

`_.words` doesn't account for the possibility of single quote characters inside words.