### PR TITLE
have the client request out of date info

### DIFF
--- a/go/client/out_of_date.go
+++ b/go/client/out_of_date.go
@@ -1,0 +1,60 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"encoding/json"
+	"github.com/keybase/client/go/libkb"
+	context "golang.org/x/net/context"
+)
+
+func PrintOutOfDateWarnings(g *libkb.GlobalContext) {
+	g.Log.Debug("+ PrintOutOfDateWarnings")
+	defer g.Log.Debug("- PrintOutOfDateWarnings")
+
+	cli, err := GetConfigClient(g)
+	if err != nil {
+		g.Log.Debug("Ignoring error in printOutOfDateWarnings: %s", err)
+		return
+	}
+
+	info, err := cli.CheckAPIServerOutOfDateWarning(context.TODO())
+	if err != nil {
+		g.Log.Debug("Ignoring error in printOutOfDateWarnings: %s", err)
+		return
+	}
+	g.Log.Debug("Got OutOfDateInfo: %#v", info)
+
+	if info.CustomMessage != "" {
+		printCustomMessage(g, info.CustomMessage)
+	}
+	if info.UpgradeTo != "" {
+		g.Log.Warning("Upgrade recommended to client version %s or above (you have v%s)",
+			info.UpgradeTo, libkb.VersionString())
+	}
+	if info.UpgradeURI != "" {
+		libkb.PlatformSpecificUpgradeInstructions(g, info.UpgradeURI)
+	}
+}
+
+type ClientSpecificCustomMessage struct {
+	CliMessage string `json:"cli_message"`
+	// Ignore other fields.
+}
+
+func printCustomMessage(g *libkb.GlobalContext, message string) {
+	var parsedMessage ClientSpecificCustomMessage
+	err := json.Unmarshal([]byte(message), &parsedMessage)
+	if err != nil {
+		g.Log.Debug("Failed to unmarshall client-out-of-date JSON: %s", err)
+		g.Log.Warning(message)
+		return
+	}
+	if parsedMessage.CliMessage == "" {
+		g.Log.Debug("No CLI message after parsing client-out-of-date JSON.")
+		g.Log.Warning(message)
+		return
+	}
+	g.Log.Warning(parsedMessage.CliMessage)
+}

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -126,7 +126,7 @@ func mainInner(g *libkb.GlobalContext) error {
 	err = cmd.Run()
 	if !cl.IsService() {
 		// Errors that come up in printing this warning are logged but ignored.
-		printOutOfDateWarnings(g)
+		client.PrintOutOfDateWarnings(g)
 	}
 	return err
 }
@@ -308,34 +308,5 @@ func HandleSignals() {
 			G.Log.Error("interrupted")
 			os.Exit(3)
 		}
-	}
-}
-
-func printOutOfDateWarnings(g *libkb.GlobalContext) {
-	g.Log.Debug("+ printOutOfDateWarnings")
-	defer g.Log.Debug("- printOutOfDateWarnings")
-
-	cli, err := client.GetConfigClient(g)
-	if err != nil {
-		g.Log.Debug("Ignoring error in printOutOfDateWarnings: %s", err)
-		return
-	}
-
-	info, err := cli.CheckAPIServerOutOfDateWarning(context.TODO())
-	if err != nil {
-		g.Log.Debug("Ignoring error in printOutOfDateWarnings: %s", err)
-		return
-	}
-	g.Log.Debug("Got OutOfDateInfo: %#v", info)
-
-	if info.CustomMessage != "" {
-		g.Log.Warning("%s", info.CustomMessage)
-	}
-	if info.UpgradeTo != "" {
-		g.Log.Warning("Upgrade recommended to client version %s or above (you have v%s)",
-			info.UpgradeTo, libkb.VersionString())
-	}
-	if info.UpgradeURI != "" {
-		libkb.PlatformSpecificUpgradeInstructions(g, info.UpgradeURI)
 	}
 }

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -344,19 +344,12 @@ func (a *InternalAPIEngine) consumeHeaders(resp *http.Response) (err error) {
 	if len(upgradeTo) > 0 || len(customMessage) > 0 {
 		now := time.Now()
 		lastUpgradeWarningMu.Lock()
+		a.G().OutOfDateInfo.UpgradeTo = upgradeTo
+		a.G().OutOfDateInfo.UpgradeURI = upgradeURI
+		a.G().OutOfDateInfo.CustomMessage = customMessage
 		if lastUpgradeWarning == nil || now.Sub(*lastUpgradeWarning) > 3*time.Minute {
 			// Send the notification after we unlock
 			defer a.G().NotifyRouter.HandleClientOutOfDate(upgradeTo, upgradeURI, customMessage)
-			if customMessage != "" {
-				a.G().Log.Warning("%s", customMessage)
-			}
-			if upgradeTo != "" {
-				a.G().Log.Warning("Upgrade recommended to client version %s or above (you have v%s)",
-					upgradeTo, VersionString())
-			}
-			if upgradeURI != "" {
-				platformSpecificUpgradeInstructions(a.G(), upgradeURI)
-			}
 			lastUpgradeWarning = &now
 		}
 		lastUpgradeWarningMu.Unlock()

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -174,6 +174,7 @@ const (
 	SCStreamNotFound         = int(keybase1.StatusCode_SCStreamNotFound)
 	SCStreamWrongKind        = int(keybase1.StatusCode_SCStreamWrongKind)
 	SCStreamEOF              = int(keybase1.StatusCode_SCStreamEOF)
+	SCGenericAPIError        = int(keybase1.StatusCode_SCGenericAPIError)
 	SCAPINetworkError        = int(keybase1.StatusCode_SCAPINetworkError)
 	SCTimeout                = int(keybase1.StatusCode_SCTimeout)
 	SCProofError             = int(keybase1.StatusCode_SCProofError)

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -70,18 +70,19 @@ type GlobalContext struct {
 	NotifyRouter      *NotifyRouter      // How to route notifications
 	// How to route UIs. Nil if we're in standalone mode or in
 	// tests, and non-nil in service mode.
-	UIRouter            UIRouter            // How to route UIs
-	ProofCheckerFactory ProofCheckerFactory // Makes new ProofCheckers
-	ExitCode            keybase1.ExitCode   // Value to return to OS on Exit()
-	RateLimits          *RateLimits         // tracks the last time certain actions were taken
-	clockMu             sync.Mutex          // protects Clock
-	clock               clockwork.Clock     // RealClock unless we're testing
-	SecretStoreAll      SecretStoreAll      // nil except for tests and supported platforms
-	hookMu              sync.RWMutex        // protects loginHooks, logoutHooks
-	loginHooks          []LoginHook         // call these on login
-	logoutHooks         []LogoutHook        // call these on logout
-	GregorDismisser     GregorDismisser     // for dismissing gregor items that we've handled
-	GregorListener      GregorListener      // for alerting about clients connecting and registering UI protocols
+	UIRouter            UIRouter               // How to route UIs
+	ProofCheckerFactory ProofCheckerFactory    // Makes new ProofCheckers
+	ExitCode            keybase1.ExitCode      // Value to return to OS on Exit()
+	RateLimits          *RateLimits            // tracks the last time certain actions were taken
+	clockMu             sync.Mutex             // protects Clock
+	clock               clockwork.Clock        // RealClock unless we're testing
+	SecretStoreAll      SecretStoreAll         // nil except for tests and supported platforms
+	hookMu              sync.RWMutex           // protects loginHooks, logoutHooks
+	loginHooks          []LoginHook            // call these on login
+	logoutHooks         []LogoutHook           // call these on logout
+	GregorDismisser     GregorDismisser        // for dismissing gregor items that we've handled
+	GregorListener      GregorListener         // for alerting about clients connecting and registering UI protocols
+	OutOfDateInfo       keybase1.OutOfDateInfo // Stores out of date messages we got from API server headers.
 }
 
 func NewGlobalContext() *GlobalContext {

--- a/go/libkb/upgrade_instructions.go
+++ b/go/libkb/upgrade_instructions.go
@@ -17,7 +17,7 @@ func PlatformSpecificUpgradeInstructionsString() (string, error) {
 	return "", nil
 }
 
-func platformSpecificUpgradeInstructions(g *GlobalContext, upgradeURI string) {
+func PlatformSpecificUpgradeInstructions(g *GlobalContext, upgradeURI string) {
 	switch runtime.GOOS {
 	case "linux":
 		linuxUpgradeInstructions(g)

--- a/go/protocol/constants.go
+++ b/go/protocol/constants.go
@@ -58,6 +58,7 @@ const (
 	StatusCode_SCStreamNotFound         StatusCode = 1502
 	StatusCode_SCStreamWrongKind        StatusCode = 1503
 	StatusCode_SCStreamEOF              StatusCode = 1504
+	StatusCode_SCGenericAPIError        StatusCode = 1600
 	StatusCode_SCAPINetworkError        StatusCode = 1601
 	StatusCode_SCTimeout                StatusCode = 1602
 	StatusCode_SCProofError             StatusCode = 1701

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -27,6 +27,8 @@ type ConfigHandler struct {
 	connID libkb.ConnectionID
 }
 
+var _ keybase1.ConfigInterface = (*ConfigHandler)(nil)
+
 func NewConfigHandler(xp rpc.Transporter, i libkb.ConnectionID, g *libkb.GlobalContext, svc *Service) *ConfigHandler {
 	return &ConfigHandler{
 		Contextified: libkb.NewContextified(g),
@@ -284,4 +286,8 @@ func (h ConfigHandler) SetPath(_ context.Context, arg keybase1.SetPathArg) error
 
 func (h ConfigHandler) HelloIAm(_ context.Context, arg keybase1.ClientDetails) error {
 	return h.G().ConnectionManager.Label(h.connID, arg)
+}
+
+func (h ConfigHandler) CheckAPIServerOutOfDateWarning(_ context.Context) (keybase1.OutOfDateInfo, error) {
+	return h.G().OutOfDateInfo, nil
 }

--- a/protocol/avdl/config.avdl
+++ b/protocol/avdl/config.avdl
@@ -107,4 +107,14 @@ protocol config {
   void clearValue(string path);
   ConfigValue getValue(string path);
 
+  record OutOfDateInfo {
+    string upgradeTo;
+    string upgradeURI;
+    string customMessage;
+  }
+
+  /**
+    Check whether the API server has told us we're out of date.
+    */
+  OutOfDateInfo checkAPIServerOutOfDateWarning();
 }

--- a/protocol/avdl/constants.avdl
+++ b/protocol/avdl/constants.avdl
@@ -50,6 +50,7 @@ protocol constants {
     SCStreamNotFound_1502,
     SCStreamWrongKind_1503,
     SCStreamEOF_1504,
+    SCGenericAPIError_1600,
     SCAPINetworkError_1601,
     SCTimeout_1602,
     SCProofError_1701,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -654,6 +654,12 @@ export type NotifyUsersUserChangedRpc = {
   callback: (null | (err: ?any) => void)
 }
 
+export type OutOfDateInfo = {
+  upgradeTo: string;
+  upgradeURI: string;
+  customMessage: string;
+}
+
 export type Outcome =
     0 // NONE_0
   | 1 // FIXED_1
@@ -1494,6 +1500,14 @@ export type blockPutBlockRpc = {
   },
   incomingCallMap?: incomingCallMapType,
   callback: (null | (err: ?any) => void)
+}
+
+export type configCheckAPIServerOutOfDateWarningResult = OutOfDateInfo
+
+export type configCheckAPIServerOutOfDateWarningRpc = {
+  method: 'config.checkAPIServerOutOfDateWarning',
+  incomingCallMap?: incomingCallMapType,
+  callback: (null | (err: ?any, response: configCheckAPIServerOutOfDateWarningResult) => void)
 }
 
 export type configClearValueResult = void
@@ -3569,6 +3583,7 @@ export type rpc =
   | blockGetSessionChallengeRpc
   | blockGetUserQuotaInfoRpc
   | blockPutBlockRpc
+  | configCheckAPIServerOutOfDateWarningRpc
   | configClearValueRpc
   | configGetConfigRpc
   | configGetCurrentStatusRpc
@@ -3967,6 +3982,13 @@ export type incomingCallMapType = {
     response: {
       error: (err: RPCError) => void,
       result: (result: configGetValueResult) => void
+    }
+  ) => void,
+  'keybase.1.config.checkAPIServerOutOfDateWarning'?: (
+    params: {},
+    response: {
+      error: (err: RPCError) => void,
+      result: (result: configCheckAPIServerOutOfDateWarningResult) => void
     }
   ) => void,
   'keybase.1.crypto.signED25519'?: (

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1126,6 +1126,7 @@ export type StatusCode =
   | 1502 // SCStreamNotFound_1502
   | 1503 // SCStreamWrongKind_1503
   | 1504 // SCStreamEOF_1504
+  | 1600 // SCGenericAPIError_1600
   | 1601 // SCAPINetworkError_1601
   | 1602 // SCTimeout_1602
   | 1701 // SCProofError_1701

--- a/protocol/js/keybase-v1.js
+++ b/protocol/js/keybase-v1.js
@@ -93,6 +93,7 @@ export const constants = {
     'scstreamnotfound': 1502,
     'scstreamwrongkind': 1503,
     'scstreameof': 1504,
+    'scgenericapierror': 1600,
     'scapinetworkerror': 1601,
     'sctimeout': 1602,
     'scprooferror': 1701,

--- a/protocol/json/config.json
+++ b/protocol/json/config.json
@@ -296,6 +296,24 @@
           "name": "o"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "OutOfDateInfo",
+      "fields": [
+        {
+          "type": "string",
+          "name": "upgradeTo"
+        },
+        {
+          "type": "string",
+          "name": "upgradeURI"
+        },
+        {
+          "type": "string",
+          "name": "customMessage"
+        }
+      ]
     }
   ],
   "messages": {
@@ -400,6 +418,11 @@
         }
       ],
       "response": "ConfigValue"
+    },
+    "checkAPIServerOutOfDateWarning": {
+      "request": [],
+      "response": "OutOfDateInfo",
+      "doc": "Check whether the API server has told us we're out of date."
     }
   },
   "namespace": "keybase.1"

--- a/protocol/json/constants.json
+++ b/protocol/json/constants.json
@@ -54,6 +54,7 @@
         "SCStreamNotFound_1502",
         "SCStreamWrongKind_1503",
         "SCStreamEOF_1504",
+        "SCGenericAPIError_1600",
         "SCAPINetworkError_1601",
         "SCTimeout_1602",
         "SCProofError_1701",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -654,6 +654,12 @@ export type NotifyUsersUserChangedRpc = {
   callback: (null | (err: ?any) => void)
 }
 
+export type OutOfDateInfo = {
+  upgradeTo: string;
+  upgradeURI: string;
+  customMessage: string;
+}
+
 export type Outcome =
     0 // NONE_0
   | 1 // FIXED_1
@@ -1494,6 +1500,14 @@ export type blockPutBlockRpc = {
   },
   incomingCallMap?: incomingCallMapType,
   callback: (null | (err: ?any) => void)
+}
+
+export type configCheckAPIServerOutOfDateWarningResult = OutOfDateInfo
+
+export type configCheckAPIServerOutOfDateWarningRpc = {
+  method: 'config.checkAPIServerOutOfDateWarning',
+  incomingCallMap?: incomingCallMapType,
+  callback: (null | (err: ?any, response: configCheckAPIServerOutOfDateWarningResult) => void)
 }
 
 export type configClearValueResult = void
@@ -3569,6 +3583,7 @@ export type rpc =
   | blockGetSessionChallengeRpc
   | blockGetUserQuotaInfoRpc
   | blockPutBlockRpc
+  | configCheckAPIServerOutOfDateWarningRpc
   | configClearValueRpc
   | configGetConfigRpc
   | configGetCurrentStatusRpc
@@ -3967,6 +3982,13 @@ export type incomingCallMapType = {
     response: {
       error: (err: RPCError) => void,
       result: (result: configGetValueResult) => void
+    }
+  ) => void,
+  'keybase.1.config.checkAPIServerOutOfDateWarning'?: (
+    params: {},
+    response: {
+      error: (err: RPCError) => void,
+      result: (result: configCheckAPIServerOutOfDateWarningResult) => void
     }
   ) => void,
   'keybase.1.crypto.signED25519'?: (

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1126,6 +1126,7 @@ export type StatusCode =
   | 1502 // SCStreamNotFound_1502
   | 1503 // SCStreamWrongKind_1503
   | 1504 // SCStreamEOF_1504
+  | 1600 // SCGenericAPIError_1600
   | 1601 // SCAPINetworkError_1601
   | 1602 // SCTimeout_1602
   | 1701 // SCProofError_1701

--- a/shared/constants/types/keybase-v1.js
+++ b/shared/constants/types/keybase-v1.js
@@ -93,6 +93,7 @@ export const constants = {
     'scstreamnotfound': 1502,
     'scstreamwrongkind': 1503,
     'scstreameof': 1504,
+    'scgenericapierror': 1600,
     'scapinetworkerror': 1601,
     'sctimeout': 1602,
     'scprooferror': 1701,


### PR DESCRIPTION
Previously we used a 3 minute rate limit to avoid spamming multiple
warnings per command. With this change the client asks for out-of-date
info at the end of every command, and prints it from the client side.
This avoids some problems:
- If the service makes an API requests before the client connects, we
  still show the warning.
- If a client command doesn't hit the network, we still show the
  warning, if the service has seen out-of-date headers before.

r? @maxtaco