### PR TITLE
thread incoming client through replay to be safe CORE-3136

### DIFF
--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -437,8 +437,8 @@ type GregorDismisser interface {
 type GregorInBandMessageHandler interface {
 	IsAlive() bool
 	Name() string
-	Create(ctx context.Context, category string, ibm gregor.Item) (bool, error)
-	Dismiss(ctx context.Context, category string, ibm gregor.Item) (bool, error)
+	Create(ctx context.Context, cli gregor1.IncomingInterface, category string, ibm gregor.Item) (bool, error)
+	Dismiss(ctx context.Context, cli gregor1.IncomingInterface, category string, ibm gregor.Item) (bool, error)
 }
 
 type GregorFirehoseHandler interface {

--- a/go/service/rekey_ui_handler.go
+++ b/go/service/rekey_ui_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
 	"github.com/keybase/gregor"
+	gregor1 "github.com/keybase/gregor/protocol/gregor1"
 )
 
 const rekeyHandlerName = "RekeyUIHandler"
@@ -39,7 +40,9 @@ func NewRekeyUIHandler(g *libkb.GlobalContext, connID libkb.ConnectionID) *Rekey
 	}
 }
 
-func (r *RekeyUIHandler) Create(ctx context.Context, category string, item gregor.Item) (bool, error) {
+func (r *RekeyUIHandler) Create(ctx context.Context, cli gregor1.IncomingInterface, category string,
+	item gregor.Item) (bool, error) {
+
 	switch category {
 	case "kbfs_tlf_rekey_needed":
 		return true, r.rekeyNeeded(ctx, item)
@@ -48,7 +51,8 @@ func (r *RekeyUIHandler) Create(ctx context.Context, category string, item grego
 	}
 }
 
-func (r *RekeyUIHandler) Dismiss(ctx context.Context, category string, item gregor.Item) (bool, error) {
+func (r *RekeyUIHandler) Dismiss(ctx context.Context, cli gregor1.IncomingInterface, category string,
+	item gregor.Item) (bool, error) {
 	return false, nil
 }
 


### PR DESCRIPTION
@maxtaco @oconnor663 This is for CORE-3136, and the point of it is to thread the client object passed into `OnConnect` through to the in-band messages handlers. Currently no handlers want to call back into Gregor for anything, but it could be possible (a message causes the client to Consume or Dismiss?). In the current setup they would need to use `g.cli`, which if used from `OnConnect` is trouble. This patch changes it so they should use the `cli` passed in as a parameter.