### PR TITLE
Mobile dumb proofs DESKTOP-1171

### DIFF
--- a/shared/common-adapters/icon.native.js
+++ b/shared/common-adapters/icon.native.js
@@ -26,7 +26,6 @@ export default class Icon extends Component {
 
     const fontSize = this.props.style && (this.props.style.fontSize || this.props.style.width)
     const textAlign = this.props.style && this.props.style.textAlign
-    const fontWidth = this.props.style && this.props.style.fontWidth
 
     // Color is for our fontIcon and not the container
     let containerProps = {...this.props.style}
@@ -34,11 +33,10 @@ export default class Icon extends Component {
     delete containerProps.width
     delete containerProps.height
     delete containerProps.textAlign
-    delete containerProps.fontWidth
     delete containerProps.fontSize
 
     const icon = fontIcons[iconType]
-      ? <Text style={{color, textAlign, fontFamily: 'kb', fontSize: fontSize, width: fontWidth}}>{fontIcons[iconType]}</Text>
+      ? <Text style={{color, textAlign, fontFamily: 'kb', fontSize: fontSize, ...width}}>{fontIcons[iconType]}</Text>
       : <Image source={images[this.props.type]} style={{resizeMode: 'contain', ...width, ...height}} />
 
     return (

--- a/shared/common-adapters/meta.native.js
+++ b/shared/common-adapters/meta.native.js
@@ -9,7 +9,7 @@ const Meta = ({title, style}: Props) => (
     color: globalColors.white,
     borderRadius: 1,
     fontSize: 10,
-    height: 11,
+    height: 12,
     lineHeight: 11,
     paddingLeft: 2,
     paddingRight: 2,

--- a/shared/common-adapters/meta.native.js
+++ b/shared/common-adapters/meta.native.js
@@ -1,22 +1,30 @@
 // @flow
 import React from 'react'
+import {View} from 'react-native'
 import Text from './text'
 import type {Props} from './meta'
 import {globalColors} from '../styles/style-guide'
+import Platform, {OS} from '../constants/platform'
+
+const isAndroid = Platform.OS_ANDROID === OS
 
 const Meta = ({title, style}: Props) => (
-  <Text type='Header' style={{
-    color: globalColors.white,
+  <View style={{
     borderRadius: 1,
-    fontSize: 10,
-    height: 12,
-    lineHeight: 11,
     paddingLeft: 2,
     paddingRight: 2,
-    paddingTop: 1,
+    paddingTop: isAndroid ? 1 : 2,
+    paddingBottom: 1,
     alignSelf: 'flex-start',
     ...style,
-  }}>{title && title.toUpperCase()}</Text>
+  }}>
+    <Text type='Header' style={{
+      color: globalColors.white,
+      fontSize: 10,
+      height: 11,
+      lineHeight: 11,
+    }}>{title && title.toUpperCase()}</Text>
+  </View>
 )
 
 export default Meta

--- a/shared/common-adapters/tab-bar.native.js
+++ b/shared/common-adapters/tab-bar.native.js
@@ -40,7 +40,7 @@ export class TabBarButton extends Component<void, TabBarButtonProps, void> {
     return (
       <Box style={{...globalStyles.flexBoxColumn, backgroundColor, ...stylesTabBarButtonIcon, ...this.props.style}}>
         {this.props.source.type === 'icon'
-          ? <Icon type={this.props.source.icon} style={{fontSize: 48, fontWidth: 80, textAlign: 'center', color: this.props.selected ? globalColors.blue3 : globalColors.blue3_40, ...this.props.styleIcon}} />
+          ? <Icon type={this.props.source.icon} style={{fontSize: 48, width: 80, textAlign: 'center', color: this.props.selected ? globalColors.blue3 : globalColors.blue3_40, ...this.props.styleIcon}} />
           : this.props.source.avatar}
         {badgeNumber > 0 &&
           <Box style={{...styleBadgeOuter, borderColor: backgroundColor, backgroundColor}}>

--- a/shared/common-adapters/text.native.js
+++ b/shared/common-adapters/text.native.js
@@ -2,8 +2,7 @@
 /* eslint-disable react/prop-types */
 
 import React, {Component} from 'react'
-import {Text as RNText, TouchableHighlight as RNTouchableWithoutFeedback} from 'react-native'
-import * as _ from 'lodash'
+import {Text as RNText} from 'react-native'
 import {globalStyles, globalColors} from '../styles/style-guide'
 import Platform, {OS} from '../constants/platform'
 
@@ -143,27 +142,6 @@ export default class Text extends Component {
           onKeyUp={this.props.onKeyUp}
           onKeyDown={this.props.onKeyDown}
           onPress={this.props.onClick} />)
-    }
-
-    // RN-BUG: Handle React-Native incompatibility in which Android doesn't properly
-    // pad text inputs.
-    const isPaddingProp = key => key.indexOf('padding') === 0
-    if (Object.keys(style).some(isPaddingProp)) {
-      const isWrapperStyle = (val, key) =>
-        !['font', 'letter', 'lineHeight', 'text', 'color', 'writingDirection', 'padding']
-          .some(start => key.indexOf(start) === 0)
-      const styleWrapper = _.pickBy(style, isWrapperStyle)
-      const styleChild = _.mapKeys(
-        _.omitBy(style, isWrapperStyle),
-        (val, key) => isPaddingProp(key) ? key.replace('padding', 'margin') : key
-      )
-      return (
-        <RNTouchableWithoutFeedback
-          style={styleWrapper}
-          onPress={this.props.onClick}>
-          <RNText style={styleChild}>{terminalPrefix}{this.props.children}</RNText>
-        </RNTouchableWithoutFeedback>
-      )
     }
 
     return (

--- a/shared/common-adapters/user-bio.native.js
+++ b/shared/common-adapters/user-bio.native.js
@@ -1,11 +1,12 @@
 import React, {Component} from 'react'
 import {View, Text} from 'react-native'
+import {Avatar} from './'
 
 export default class BioRender extends Component {
   render () {
     return (
-      <View style={{display: 'flex', flexDirection: 'column', alignItems: 'center', marginRight: 40}}>
-        <Text style={{backgroundColor: 'blue', width: 100, height: 100}}>Image</Text>
+      <View style={styles.container}>
+        <Avatar size={this.props.avatarSize} />
         <Text>Username</Text>
         <Text>Full Name</Text>
         <Text>Followers stuff</Text>
@@ -14,4 +15,11 @@ export default class BioRender extends Component {
       </View>
     )
   }
+}
+
+const styles = {
+  container: {
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
 }

--- a/shared/common-adapters/user-proofs.desktop.js
+++ b/shared/common-adapters/user-proofs.desktop.js
@@ -1,110 +1,35 @@
 /* @flow */
 
 import React, {Component} from 'react'
-import commonStyles from '../styles/common'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import {Icon, Text, Meta} from '../common-adapters/index'
-import {normal as proofNormal, checking as proofChecking, revoked as proofRevoked, error as proofError, warning as proofWarning} from '../constants/tracker'
-import {metaNew, metaUpgraded, metaUnreachable, metaPending, metaDeleted, metaNone, metaIgnored} from '../constants/tracker'
-import electron from 'electron'
-
-import type {Props as IconProps} from '../common-adapters/icon'
-
-const shell = electron.shell || electron.remote.shell
+import openUrl from '../util/open-url'
+import * as shared from './user-proofs.shared'
+import {metaNone} from '../constants/tracker'
+import {checking as proofChecking} from '../constants/tracker'
 
 import type {Proof, Props} from './user-proofs'
 
 class ProofsRender extends Component {
   props: Props;
 
-  _openLink (url: string): void {
-    shell.openExternal(url)
-  }
-
   _onClickProof (proof: Proof): void {
     if (proof.state !== proofChecking) {
-      proof.humanUrl && this._openLink(proof.humanUrl)
+      proof.humanUrl && openUrl(proof.humanUrl)
     }
   }
 
   _onClickProfile (proof: Proof): void {
     console.log('Opening profile link:', proof)
     if (proof.state !== proofChecking) {
-      proof.profileUrl && this._openLink(proof.profileUrl)
-    }
-  }
-
-  _iconNameForProof (proof: Proof): IconProps.type {
-    return {
-      'twitter': 'fa-twitter',
-      'github': 'fa-github',
-      'reddit': 'fa-reddit',
-      'pgp': 'fa-key',
-      'coinbase': 'fa-kb-iconfont-coinbase',
-      'hackernews': 'fa-hacker-news',
-      'rooter': 'fa-shopping-basket',
-      'http': 'fa-globe',
-      'https': 'fa-globe',
-      'dns': 'fa-globe',
-    }[proof.type]
-  }
-
-  _metaColor (proof: Proof): string {
-    let color = globalColors.blue
-    switch (proof.meta) {
-      case metaNew: color = globalColors.blue; break
-      case metaUpgraded: color = globalColors.blue; break
-      case metaUnreachable: color = globalColors.red; break
-      case metaPending: color = globalColors.black_40; break
-      case metaDeleted: color = globalColors.red; break
-      case metaIgnored: color = globalColors.green; break
-    }
-    return color
-  }
-
-  _proofColor (proof: Proof): string {
-    let color = globalColors.blue
-    switch (proof.state) {
-      case proofNormal: {
-        color = proof.isTracked ? globalColors.green2 : globalColors.blue
-        break
-      }
-      case proofChecking:
-        color = globalColors.black_20
-        break
-      case proofRevoked:
-      case proofWarning:
-      case proofError:
-        color = globalColors.red
-        break
-    }
-
-    if (proof.state === proofChecking) color = globalColors.black_20
-
-    return color
-  }
-
-  _proofStatusIcon (proof: Proof): ?IconProps.type {
-    switch (proof.state) {
-      case proofChecking:
-        return 'fa-kb-iconfont-proof-pending'
-
-      case proofNormal:
-        return proof.isTracked ? 'fa-kb-iconfont-proof-followed' : 'fa-kb-iconfont-proof-new'
-
-      case proofWarning:
-      case proofError:
-      case proofRevoked:
-        return 'fa-kb-iconfont-proof-broken'
-      default:
-        return null
+      proof.profileUrl && openUrl(proof.profileUrl)
     }
   }
 
   _renderProofRow (proof: Proof, idx: number) {
-    const metaColor = this._metaColor(proof)
-    const proofNameColor = this._proofColor(proof)
-    const proofStatusIcon = this._proofStatusIcon(proof)
+    const metaBackgroundColor = shared.metaColor(proof)
+    const proofStatusIconType = shared.proofStatusIcon(proof)
+    const proofNameStyle = shared.proofNameStyle(proof)
     const onClickProfile = () => { this._onClickProfile(proof) }
 
     const proofStyle = {
@@ -115,19 +40,13 @@ class ProofsRender extends Component {
       ...styleProofName,
     }
 
-    const proofNameStyle = {
-      color: proofNameColor,
-      ...(proof.meta === metaDeleted ? {textDecoration: 'line-through'} : {}),
-    }
+    const meta = proof.meta && proof.meta !== metaNone && <Meta title={proof.meta} style={{backgroundColor: metaBackgroundColor}} />
 
-    const meta = proof.meta &&
-      proof.meta !== metaNone &&
-      <Meta title={proof.meta} style={{backgroundColor: metaColor}} />
-    const proofIcon = proofStatusIcon && <Icon type={proofStatusIcon} style={styleStatusIcon} onClick={() => this._onClickProof(proof)} />
+    const proofIcon = proofStatusIconType && <Icon type={proofStatusIconType} style={styleStatusIcon} onClick={() => this._onClickProof(proof)} />
 
     return (
       <p style={{...styleRow, paddingTop: idx > 0 ? 8 : 0}} key={`${proof.id}${proof.type}`}>
-        <Icon style={styleService} type={this._iconNameForProof(proof)} title={proof.type} onClick={onClickProfile} />
+        <Icon style={styleService} type={shared.iconNameForProof(proof)} title={proof.type} onClick={onClickProfile} />
         <span style={styleProofNameSection}>
           <span style={styleProofNameLabelContainer}>
             <Text inline className='hover-underline-container' type='Body' onClick={onClickProfile} style={proofStyle}>
@@ -193,7 +112,7 @@ const styleProofNameLabelContainer = {
 }
 
 const styleProofName = {
-  ...commonStyles.clickable,
+  ...globalStyles.clickable,
   flex: 1,
 }
 

--- a/shared/common-adapters/user-proofs.native.js
+++ b/shared/common-adapters/user-proofs.native.js
@@ -1,32 +1,117 @@
+/* @flow */
+
 import React, {Component} from 'react'
 import {View, Text} from 'react-native'
 
+import openUrl from '../util/open-url'
+import * as shared from './user-proofs.shared'
+import {metaNone} from '../constants/tracker'
+import {Icon, Meta} from '../common-adapters/index'
+import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
+import {checking as proofChecking} from '../constants/tracker'
+
+import type {Props, Proof} from './user-proofs'
+
 export default class ProofsRender extends Component {
-  render () {
+  props: Props;
+
+  _onClickProof (proof: Proof): void {
+    if (proof.state !== proofChecking) {
+      proof.humanUrl && openUrl(proof.humanUrl)
+    }
+  }
+
+  _onClickProfile (proof: Proof): void {
+    console.log('Opening profile link:', proof)
+    if (proof.state !== proofChecking) {
+      proof.profileUrl && openUrl(proof.profileUrl)
+    }
+  }
+
+  _renderProofRow (proof: Proof, idx: number) {
+    const metaBackgroundColor = shared.metaColor(proof)
+    const proofStatusIconType = shared.proofStatusIcon(proof)
+    const proofNameStyle = shared.proofNameStyle(proof)
+    const onClickProfile = () => { this._onClickProfile(proof) }
+
+    const proofStyle = {
+      ...globalStyles.selectable,
+      width: 208,
+      ...styles.proofName,
+    }
+
+    const meta = proof.meta && proof.meta !== metaNone && <Meta title={proof.meta} style={{backgroundColor: metaBackgroundColor}} />
+
+    const proofIcon = proofStatusIconType && <Icon type={proofStatusIconType} style={styles.statusIcon} onClick={() => this._onClickProof(proof)} />
+
     return (
-      <View style={{backgroundColor: 'green', display: 'flex', flex: 1, flexDirection: 'column', overflowY: 'auto'}}>
-        <Text>Proof1</Text>
-        <Text>Proof2</Text>
-        <Text>Proof3</Text>
-        <Text>Proof4</Text>
-        <Text>Proof5</Text>
-        <Text>Proof6</Text>
-        <Text>Proof7</Text>
-        <Text>Proof8</Text>
-        <Text>Proof9</Text>
-        <Text>Proof10</Text>
-        <Text>Proof11</Text>
-        <Text>Proof12</Text>
-        <Text>Proof13</Text>
-        <Text>Proof14</Text>
-        <Text>Proof15</Text>
-        <Text>Proof16</Text>
-        <Text>Proof17</Text>
-        <Text>Proof18</Text>
-        <Text>Proof19</Text>
-        <Text>Proof20</Text>
-        <Text>Proof21</Text>
+      <View style={{...styles.row, paddingTop: idx > 0 ? 8 : 0}} key={`${proof.id}${proof.type}`}>
+        <Icon style={styles.service} type={shared.iconNameForProof(proof)} title={proof.type} onClick={onClickProfile} />
+        <View style={styles.proofNameSection}>
+          <View style={styles.proofNameLabelContainer}>
+            <Text inline className='hover-underline-container' type='Body' onClick={onClickProfile} style={proofStyle}>
+              <Text inline type='Body' className='underline' style={proofNameStyle}>{proof.name}</Text>
+              <Text className='no-underline' inline type='Body' style={styles.proofType}>@{proof.type}</Text>
+            </Text>
+            {meta}
+          </View>
+        </View>
+        {proofIcon}
       </View>
     )
   }
+
+  render () {
+    return (
+      <View style={styles.container}>
+        {this.props.proofs.map((p, idx) => this._renderProofRow(p, idx))}
+      </View>
+    )
+  }
+}
+
+const styles = {
+  container: {
+    ...globalStyles.flexBoxColumn,
+    backgroundColor: globalColors.white,
+    paddingTop: 16,
+    paddingBottom: 16,
+    alignItems: 'center',
+  },
+  row: {
+    ...globalStyles.flexBoxRow,
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+  },
+  service: {
+    ...globalStyles.clickable,
+    fontSize: 15,
+    marginTop: 2,
+    width: 15,
+    textAlign: 'center',
+    color: globalColors.black_75,
+    marginRight: globalMargins.tiny,
+  },
+  statusIcon: {
+    ...globalStyles.clickable,
+    fontSize: 20,
+    marginLeft: 10,
+    marginTop: 1,
+  },
+  proofNameSection: {
+    ...globalStyles.flexBoxRow,
+    alignItems: 'flex-start',
+    flex: 1,
+  },
+  proofNameLabelContainer: {
+    ...globalStyles.flexBoxColumn,
+    flex: 1,
+  },
+  proofName: {
+    ...globalStyles.clickable,
+    flex: 1,
+  },
+  proofType: {
+    color: globalColors.black_10,
+  },
 }

--- a/shared/common-adapters/user-proofs.native.js
+++ b/shared/common-adapters/user-proofs.native.js
@@ -15,16 +15,19 @@ import type {Props, Proof} from './user-proofs'
 export default class ProofsRender extends Component {
   props: Props;
 
+  _ensureUrlProtocal (url: string): string {
+    return url && (url.indexOf('://') === -1 ? 'http://' : '') + url
+  }
+
   _onClickProof (proof: Proof): void {
-    if (proof.state !== proofChecking) {
-      proof.humanUrl && openUrl(proof.humanUrl)
+    if (proof.state !== proofChecking && proof.humanUrl) {
+      openUrl(this._ensureUrlProtocal(proof.humanUrl))
     }
   }
 
   _onClickProfile (proof: Proof): void {
-    console.log('Opening profile link:', proof)
-    if (proof.state !== proofChecking) {
-      proof.profileUrl && openUrl(proof.profileUrl)
+    if (proof.state !== proofChecking && proof.profileUrl) {
+      openUrl(this._ensureUrlProtocal(proof.profileUrl))
     }
   }
 
@@ -33,12 +36,6 @@ export default class ProofsRender extends Component {
     const proofStatusIconType = shared.proofStatusIcon(proof)
     const proofNameStyle = shared.proofNameStyle(proof)
     const onClickProfile = () => { this._onClickProfile(proof) }
-
-    const proofStyle = {
-      ...globalStyles.selectable,
-      width: 208,
-      ...styles.proofName,
-    }
 
     const meta = proof.meta && proof.meta !== metaNone && <Meta title={proof.meta} style={{backgroundColor: metaBackgroundColor}} />
 
@@ -49,7 +46,7 @@ export default class ProofsRender extends Component {
         <Icon style={styles.service} type={shared.iconNameForProof(proof)} title={proof.type} onClick={onClickProfile} />
         <View style={styles.proofNameSection}>
           <View style={styles.proofNameLabelContainer}>
-            <Text inline className='hover-underline-container' type='Body' onClick={onClickProfile} style={proofStyle}>
+            <Text inline className='hover-underline-container' type='Body' onPress={onClickProfile} style={styles.proofName}>
               <Text inline type='Body' className='underline' style={proofNameStyle}>{proof.name}</Text>
               <Text className='no-underline' inline type='Body' style={styles.proofType}>@{proof.type}</Text>
             </Text>
@@ -76,27 +73,28 @@ const styles = {
     backgroundColor: globalColors.white,
     paddingTop: 16,
     paddingBottom: 16,
-    alignItems: 'center',
+    alignItems: 'stretch',
+    paddingLeft: globalMargins.medium,
+    paddingRight: globalMargins.medium,
   },
   row: {
     ...globalStyles.flexBoxRow,
     alignItems: 'flex-start',
     justifyContent: 'flex-start',
+    // RN-BUG: set maxWidth once that prop is supported
   },
   service: {
     ...globalStyles.clickable,
-    fontSize: 15,
-    marginTop: 2,
-    width: 15,
+    fontSize: 20,
+    width: 22,
     textAlign: 'center',
     color: globalColors.black_75,
-    marginRight: globalMargins.tiny,
+    marginRight: globalMargins.small,
   },
   statusIcon: {
     ...globalStyles.clickable,
-    fontSize: 20,
-    marginLeft: 10,
-    marginTop: 1,
+    fontSize: 24,
+    marginLeft: globalMargins.small,
   },
   proofNameSection: {
     ...globalStyles.flexBoxRow,

--- a/shared/common-adapters/user-proofs.native.js
+++ b/shared/common-adapters/user-proofs.native.js
@@ -39,16 +39,16 @@ export default class ProofsRender extends Component {
 
     const meta = proof.meta && proof.meta !== metaNone && <Meta title={proof.meta} style={{backgroundColor: metaBackgroundColor}} />
 
-    const proofIcon = proofStatusIconType && <Icon type={proofStatusIconType} style={styles.statusIcon} onClick={() => this._onClickProof(proof)} />
+    const proofIcon = proofStatusIconType && <Icon type={proofStatusIconType} style={stylesStatusIcon} onClick={() => this._onClickProof(proof)} />
 
     return (
-      <View style={{...styles.row, paddingTop: idx > 0 ? 8 : 0}} key={`${proof.id}${proof.type}`}>
-        <Icon style={styles.service} type={shared.iconNameForProof(proof)} title={proof.type} onClick={onClickProfile} />
-        <View style={styles.proofNameSection}>
-          <View style={styles.proofNameLabelContainer}>
-            <Text inline className='hover-underline-container' type='Body' onPress={onClickProfile} style={styles.proofName}>
+      <View style={{...stylesRow, paddingTop: idx > 0 ? 8 : 0}} key={`${proof.id}${proof.type}`}>
+        <Icon style={stylesService} type={shared.iconNameForProof(proof)} title={proof.type} onClick={onClickProfile} />
+        <View style={stylesProofNameSection}>
+          <View style={stylesProofNameLabelContainer}>
+            <Text inline className='hover-underline-container' type='Body' onPress={onClickProfile} style={stylesProofName}>
               <Text inline type='Body' className='underline' style={proofNameStyle}>{proof.name}</Text>
-              <Text className='no-underline' inline type='Body' style={styles.proofType}>@{proof.type}</Text>
+              <Text className='no-underline' inline type='Body' style={stylesProofType}>@{proof.type}</Text>
             </Text>
             {meta}
           </View>
@@ -60,56 +60,54 @@ export default class ProofsRender extends Component {
 
   render () {
     return (
-      <View style={styles.container}>
+      <View style={stylesContainer}>
         {this.props.proofs.map((p, idx) => this._renderProofRow(p, idx))}
       </View>
     )
   }
 }
 
-const styles = {
-  container: {
-    ...globalStyles.flexBoxColumn,
-    backgroundColor: globalColors.white,
-    paddingTop: 16,
-    paddingBottom: 16,
-    alignItems: 'stretch',
-    paddingLeft: globalMargins.medium,
-    paddingRight: globalMargins.medium,
-  },
-  row: {
-    ...globalStyles.flexBoxRow,
-    alignItems: 'flex-start',
-    justifyContent: 'flex-start',
-    // RN-BUG: set maxWidth once that prop is supported
-  },
-  service: {
-    ...globalStyles.clickable,
-    fontSize: 20,
-    width: 22,
-    textAlign: 'center',
-    color: globalColors.black_75,
-    marginRight: globalMargins.small,
-  },
-  statusIcon: {
-    ...globalStyles.clickable,
-    fontSize: 24,
-    marginLeft: globalMargins.small,
-  },
-  proofNameSection: {
-    ...globalStyles.flexBoxRow,
-    alignItems: 'flex-start',
-    flex: 1,
-  },
-  proofNameLabelContainer: {
-    ...globalStyles.flexBoxColumn,
-    flex: 1,
-  },
-  proofName: {
-    ...globalStyles.clickable,
-    flex: 1,
-  },
-  proofType: {
-    color: globalColors.black_10,
-  },
+const stylesContainer = {
+  ...globalStyles.flexBoxColumn,
+  backgroundColor: globalColors.white,
+  paddingTop: 16,
+  paddingBottom: 16,
+  alignItems: 'stretch',
+  paddingLeft: globalMargins.medium,
+  paddingRight: globalMargins.medium,
+}
+const stylesRow = {
+  ...globalStyles.flexBoxRow,
+  alignItems: 'flex-start',
+  justifyContent: 'flex-start',
+  // RN-BUG: set maxWidth once that prop is supported
+}
+const stylesService = {
+  ...globalStyles.clickable,
+  fontSize: 20,
+  width: 22,
+  textAlign: 'center',
+  color: globalColors.black_75,
+  marginRight: globalMargins.small,
+}
+const stylesStatusIcon = {
+  ...globalStyles.clickable,
+  fontSize: 24,
+  marginLeft: globalMargins.small,
+}
+const stylesProofNameSection = {
+  ...globalStyles.flexBoxRow,
+  alignItems: 'flex-start',
+  flex: 1,
+}
+const stylesProofNameLabelContainer = {
+  ...globalStyles.flexBoxColumn,
+  flex: 1,
+}
+const stylesProofName = {
+  ...globalStyles.clickable,
+  flex: 1,
+}
+const stylesProofType = {
+  color: globalColors.black_10,
 }

--- a/shared/common-adapters/user-proofs.shared.js
+++ b/shared/common-adapters/user-proofs.shared.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {globalColors} from '../styles/style-guide'
+import {globalColors, globalStyles} from '../styles/style-guide'
 import {normal as proofNormal, checking as proofChecking, revoked as proofRevoked, error as proofError, warning as proofWarning} from '../constants/tracker'
 import {metaNew, metaUpgraded, metaUnreachable, metaPending, metaDeleted, metaIgnored} from '../constants/tracker'
 
@@ -76,6 +76,6 @@ export function proofStatusIcon (proof: Proof): ?IconProps.type {
 export function proofNameStyle (proof: Proof) {
   return {
     color: proofColor(proof),
-    ...(proof.meta === metaDeleted ? {textDecorationLine: 'line-through'} : {}),
+    ...(proof.meta === metaDeleted ? globalStyles.textDecoration('line-through') : {}),
   }
 }

--- a/shared/common-adapters/user-proofs.shared.js
+++ b/shared/common-adapters/user-proofs.shared.js
@@ -1,0 +1,81 @@
+/* @flow */
+
+import {globalColors} from '../styles/style-guide'
+import {normal as proofNormal, checking as proofChecking, revoked as proofRevoked, error as proofError, warning as proofWarning} from '../constants/tracker'
+import {metaNew, metaUpgraded, metaUnreachable, metaPending, metaDeleted, metaIgnored} from '../constants/tracker'
+
+import type {Props as IconProps} from '../common-adapters/icon'
+import type {Proof} from './user-proofs'
+
+export function metaColor (proof: Proof): string {
+  let color = globalColors.blue
+  switch (proof.meta) {
+    case metaNew: color = globalColors.blue; break
+    case metaUpgraded: color = globalColors.blue; break
+    case metaUnreachable: color = globalColors.red; break
+    case metaPending: color = globalColors.black_40; break
+    case metaDeleted: color = globalColors.red; break
+    case metaIgnored: color = globalColors.green; break
+  }
+  return color
+}
+
+export function proofColor (proof: Proof): string {
+  let color = globalColors.blue
+  switch (proof.state) {
+    case proofNormal: {
+      color = proof.isTracked ? globalColors.green2 : globalColors.blue
+      break
+    }
+    case proofChecking:
+      color = globalColors.black_20
+      break
+    case proofRevoked:
+    case proofWarning:
+    case proofError:
+      color = globalColors.red
+      break
+  }
+  if (proof.state === proofChecking) color = globalColors.black_20
+  return color
+}
+
+export function iconNameForProof (proof: Proof): IconProps.type {
+  return {
+    'twitter': 'fa-twitter',
+    'github': 'fa-github',
+    'reddit': 'fa-reddit',
+    'pgp': 'fa-key',
+    'coinbase': 'fa-kb-iconfont-coinbase',
+    'hackernews': 'fa-hacker-news',
+    'rooter': 'fa-shopping-basket',
+    'http': 'fa-globe',
+    'https': 'fa-globe',
+    'dns': 'fa-globe',
+  }[proof.type]
+}
+
+export function proofStatusIcon (proof: Proof): ?IconProps.type {
+  switch (proof.state) {
+    case proofChecking:
+      return 'fa-kb-iconfont-proof-pending'
+
+    case proofNormal:
+      return proof.isTracked ? 'fa-kb-iconfont-proof-followed' : 'fa-kb-iconfont-proof-new'
+
+    case proofWarning:
+    case proofError:
+    case proofRevoked:
+      return 'fa-kb-iconfont-proof-broken'
+
+    default:
+      return null
+  }
+}
+
+export function proofNameStyle (proof: Proof) {
+  return {
+    color: proofColor(proof),
+    ...(proof.meta === metaDeleted ? {textDecorationLine: 'line-through'} : {}),
+  }
+}

--- a/shared/dev/dev-menu.native.js
+++ b/shared/dev/dev-menu.native.js
@@ -1,7 +1,6 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import {routeAppend} from '../actions/router'
-import {pushNewProfile} from '../actions/profile'
 import {switchTab} from '../actions/tabbed-router'
 import {pushNewSearch} from '../actions/search'
 import {logout} from '../actions/login'
@@ -39,9 +38,6 @@ class DevMenu extends Component {
       {name: 'Search', hasChildren: true, onClick: () => {
         this.props.pushNewSearch()
       }},
-      {name: 'Profile', hasChildren: true, onClick: () => {
-        this.props.pushNewProfile('test12')
-      }},
       {name: 'Components', hasChildren: true, onClick: () => {
         this.props.routeAppend('components')
       }},
@@ -69,7 +65,6 @@ DevMenu.propTypes = {
   routeAppend: React.PropTypes.func.isRequired,
   logout: React.PropTypes.func.isRequired,
   pushNewSearch: React.PropTypes.func.isRequired,
-  pushNewProfile: React.PropTypes.func.isRequired,
   showTrackerListener: React.PropTypes.func.isRequired,
   switchTab: React.PropTypes.func.isRequired,
 }
@@ -82,7 +77,6 @@ export default connect(
       switchTab: tabName => dispatch(switchTab(tabName)),
       logout: () => dispatch(logout()),
       pushNewSearch: () => dispatch(pushNewSearch()),
-      pushNewProfile: username => dispatch(pushNewProfile(username)),
       showTrackerListener: username => dispatch(pushDebugTracker(username)),
     }
   }

--- a/shared/dev/dumb-component-map.native.js
+++ b/shared/dev/dumb-component-map.native.js
@@ -8,7 +8,6 @@ import DevicePageMap from '../devices/device-page/dumb.native'
 import FoldersMap from '../folders/dumb'
 import FoldersConfirmMap from '../folders/confirm/dumb'
 import SearchMap from '../search/dumb'
-import Friendships from '../profile/friendships.dumb'
 import type {DumbComponentMap} from '../constants/types/more'
 import Tracker from '../tracker/dumb.native'
 
@@ -24,7 +23,6 @@ const map: DumbComponentMap = {
   ...FoldersConfirmMap,
   ...SearchMap,
   ...Tracker,
-  ...Friendships,
 }
 
 export default map

--- a/shared/dev/dumb-component-map.native.js
+++ b/shared/dev/dumb-component-map.native.js
@@ -10,6 +10,7 @@ import FoldersConfirmMap from '../folders/confirm/dumb'
 import SearchMap from '../search/dumb'
 import Friendships from '../profile/friendships.dumb'
 import type {DumbComponentMap} from '../constants/types/more'
+import Tracker from '../tracker/dumb.native'
 
 const map: DumbComponentMap = {
   ...CommonMap,
@@ -22,6 +23,7 @@ const map: DumbComponentMap = {
   ...FoldersMap,
   ...FoldersConfirmMap,
   ...SearchMap,
+  ...Tracker,
   ...Friendships,
 }
 

--- a/shared/styles/style-guide.desktop.js
+++ b/shared/styles/style-guide.desktop.js
@@ -86,6 +86,9 @@ const util = {
   topMost: {
     zIndex: 9999,
   },
+  textDecoration: (type: string) => ({ // eslint-disable-line arrow-parens
+    textDecoration: type,
+  }),
 }
 
 export const globalStyles = {

--- a/shared/styles/style-guide.native.js
+++ b/shared/styles/style-guide.native.js
@@ -92,3 +92,12 @@ export const globalStyles = {
   ...font,
   ...util,
 }
+
+export const globalMargins = {
+  xtiny: 4,
+  tiny: 8,
+  small: 16,
+  medium: 32,
+  large: 48,
+  xlarge: 64,
+}

--- a/shared/styles/style-guide.native.js
+++ b/shared/styles/style-guide.native.js
@@ -86,6 +86,9 @@ const util = {
   rounded: {
     borderRadius: 3,
   },
+  textDecoration: (type: string) => ({ // eslint-disable-line arrow-parens
+    textDecorationLine: type,
+  }),
 }
 
 export const globalStyles = {

--- a/shared/tracker/action.render.js.flow
+++ b/shared/tracker/action.render.js.flow
@@ -1,4 +1,5 @@
 /* @flow */
+import {Component} from 'react'
 
 import type {SimpleProofState} from '../constants/tracker'
 
@@ -13,5 +14,7 @@ export type ActionProps = {
   onIgnore: () => void,
   onFollow: () => void,
   onRefollow: () => void,
-  onUnfollow: () => void
+  onUnfollow: () => void,
 }
+
+export default class ActionRender extends Component<void, ActionProps, void> { }

--- a/shared/tracker/dumb.native.js
+++ b/shared/tracker/dumb.native.js
@@ -5,7 +5,6 @@ import {normal, checking, revoked, error} from '../constants/tracker'
 import {metaUpgraded, metaUnreachable, metaPending, metaDeleted, metaNone, metaIgnored} from '../constants/tracker'
 import type {TrackerProps} from '../tracker'
 import type {Proof} from '../common-adapters/user-proofs'
-import type {TrackSummary} from '../constants/types/flow-types'
 
 import type {DumbComponentMap} from '../constants/types/more'
 
@@ -41,7 +40,6 @@ const proofsChanged: Array<Proof> = [
 
 const propsBase = {
   closed: false,
-  lastTrack: null,
   currentlyFollowing: false,
   onFollow: () => {},
   onRefollow: () => {},
@@ -52,7 +50,6 @@ const propsBase = {
   onIgnore: () => {},
   waiting: false,
   loggedIn: true,
-  trackerMessage: null,
   lastAction: null,
 }
 
@@ -70,7 +67,6 @@ const propsDefault: TrackerProps = {
     avatar: 'https://keybase.io/darksim905/picture',
     followsYou: false,
   },
-  shouldFollow: true,
   trackerState: normal,
   proofs: proofsDefault,
 
@@ -80,12 +76,6 @@ const propsDefault: TrackerProps = {
       console.log('Close')
     },
   },
-}
-
-const lastTrackMax: TrackSummary = {
-  username: 'max',
-  time: 0,
-  isRemote: true,
 }
 
 const propsNewUser: TrackerProps = {
@@ -123,12 +113,12 @@ function setFollow (source: TrackerProps, filter: setFollowFilter): TrackerProps
 
 const propsFollowing: TrackerProps = setFollow({
   ...propsNewUser,
+  currentlyFollowing: true,
   reason: 'You have tracked gabrielh.',
   userInfo: {
     ...propsNewUser.userInfo,
     followsYou: true,
   },
-  lastTrack: lastTrackMax,
   proofs: proofsDefault,
   lastAction: 'followed',
 }, () => true)
@@ -144,12 +134,12 @@ const propsWhatevz: TrackerProps = setFollow({
 
 const propsChangedProofs: TrackerProps = {
   ...propsDefault,
+  currentlyFollowing: true,
   reason: 'Some of gabrielh\'s proofs have changed since you last tracked them.',
   userInfo: {
     ...propsNewUser.userInfo,
     followsYou: true,
   },
-  lastTrack: lastTrackMax,
   trackerState: error,
   proofs: proofsChanged,
 }
@@ -178,7 +168,6 @@ const propsLessData: TrackerProps = {
     avatar: 'http://placehold.it/140x140/ffffff/000000',
     location: '',
   },
-  shouldFollow: true,
   currentlyFollowing: false,
   trackerState: normal,
   proofs: [
@@ -206,7 +195,7 @@ const dumbMap: DumbComponentMap<Tracker> = {
     'Only one proof': trackerPropsToRenderProps(propsOneProof),
     '5 proofs': trackerPropsToRenderProps(propsFiveProof),
     'Followed': trackerPropsToRenderProps(propsFollowing),
-    'Changed/Broken proofs user you dont follow': trackerPropsToRenderProps({...propsChangedProofs, lastTrack: null}),
+    'Changed/Broken proofs user you dont follow': trackerPropsToRenderProps({...propsChangedProofs, currentlyFollowing: false}),
     'Changed/Broken proofs': trackerPropsToRenderProps(propsChangedProofs),
     'You track them': trackerPropsToRenderProps({...propsFollowing, userInfo: {...propsNewUser.userInfo, followsYou: false}}),
     'Unfollowed': trackerPropsToRenderProps(propsUnfollowed),

--- a/shared/tracker/dumb.native.js
+++ b/shared/tracker/dumb.native.js
@@ -1,0 +1,225 @@
+/* @flow */
+import Tracker from './render'
+import {trackerPropsToRenderProps} from './index'
+import {normal, checking, revoked, error} from '../constants/tracker'
+import {metaUpgraded, metaUnreachable, metaPending, metaDeleted, metaNone, metaIgnored} from '../constants/tracker'
+import type {TrackerProps} from '../tracker'
+import type {Proof} from '../common-adapters/user-proofs'
+import type {TrackSummary} from '../constants/types/flow-types'
+
+import type {DumbComponentMap} from '../constants/types/more'
+
+function proofGithubMaker (name): Proof {
+  return {name: 'githubuser' + name, type: 'github', id: 'githubId' + name, state: normal, meta: metaNone, humanUrl: 'github.com', profileUrl: 'http://github.com', isTracked: false}
+}
+
+const proofGithub = proofGithubMaker('')
+
+const proofTwitter: Proof = {name: 'twitteruser', type: 'twitter', id: 'twitterId', state: normal, meta: metaNone, humanUrl: 'twitter.com', profileUrl: 'http://twitter.com', isTracked: false}
+const proofHN: Proof = {name: 'pg', type: 'hackernews', id: 'hnId', state: normal, meta: metaNone, humanUrl: 'news.ycombinator.com', profileUrl: 'http://news.ycombinator.com', isTracked: false}
+const longDomainName = 'thelongestdomainnameintheworldandthensomeandthensomemoreandmore.com'
+const proofWeb1: Proof = {name: longDomainName, type: 'http', id: 'webId', state: normal, meta: metaNone, humanUrl: longDomainName, profileUrl: '', isTracked: false}
+const proofWeb2: Proof = {name: longDomainName.substring(1), type: 'http', id: 'webId1', state: normal, meta: metaNone, humanUrl: longDomainName, profileUrl: '', isTracked: false}
+const proofRooter: Proof = {name: 'roooooooter', type: 'rooter', state: normal, meta: metaNone, id: 'rooterId', humanUrl: '', profileUrl: '', isTracked: false}
+
+const proofsDefault: Array<Proof> = [
+  proofGithub,
+  proofTwitter,
+  proofHN,
+  proofWeb1,
+  proofWeb2,
+  proofRooter,
+]
+
+const proofsChanged: Array<Proof> = [
+  {name: 'deleted', type: 'github', id: 'warningId', state: revoked, meta: metaDeleted, humanUrl: '', profileUrl: '', isTracked: false},
+  {name: 'unreachable', type: 'twitter', id: 'unreachableId', state: error, meta: metaUnreachable, humanUrl: '', profileUrl: '', isTracked: false},
+  {name: 'checking', type: 'twitter', id: 'checkingId', state: checking, meta: metaNone, humanUrl: '', profileUrl: '', isTracked: false},
+  {name: 'pending', type: 'https', id: 'pendingId', state: normal, meta: metaPending, humanUrl: '', profileUrl: '', isTracked: false},
+  {name: 'upgraded', type: 'rooter', id: 'upgradedId', state: normal, meta: metaUpgraded, humanUrl: '', profileUrl: '', isTracked: false},
+]
+
+const propsBase = {
+  closed: false,
+  lastTrack: null,
+  currentlyFollowing: false,
+  onFollow: () => {},
+  onRefollow: () => {},
+  onUnfollow: () => {},
+  onClose: () => {},
+  startTimer: () => {},
+  stopTimer: () => {},
+  onIgnore: () => {},
+  waiting: false,
+  loggedIn: true,
+  trackerMessage: null,
+  lastAction: null,
+}
+
+const propsDefault: TrackerProps = {
+  ...propsBase,
+  nonUser: false,
+  username: 'darksim905',
+  reason: 'You accessed a private folder with gabrielh.',
+  userInfo: {
+    fullname: 'Gabriel Handford',
+    followersCount: 1871,
+    followingCount: 356,
+    location: 'San Francisco, California, USA, Earth, Milky Way',
+    bio: 'Etsy photo booth mlkshk semiotics, 8-bit literally slow-carb keytar bushwick +1. Plaid migas etsy yuccie, locavore street art mlkshk lumbersexual. Literally microdosing pug disrupt iPhone raw denim, quinoa meggings kitsch. ',
+    avatar: 'https://keybase.io/darksim905/picture',
+    followsYou: false,
+  },
+  shouldFollow: true,
+  trackerState: normal,
+  proofs: proofsDefault,
+
+  // For hover
+  headerProps: {
+    onClose: () => {
+      console.log('Close')
+    },
+  },
+}
+
+const lastTrackMax: TrackSummary = {
+  username: 'max',
+  time: 0,
+  isRemote: true,
+}
+
+const propsNewUser: TrackerProps = {
+  ...propsDefault,
+}
+
+const propsNonUser: TrackerProps = {
+  ...propsDefault,
+  userInfo: null,
+  isPrivate: false,
+  proofs: [],
+  nonUser: true,
+  name: 'aliceb@reddit',
+  serviceName: 'reddit',
+  reason: 'Success! You opened a private folder with aliceb@twitter.',
+  inviteLink: 'keybase.io/inv/9999999999',
+}
+
+const propsNewUserFollowsYou: TrackerProps = {
+  ...propsDefault,
+  userInfo: {
+    ...propsNewUser.userInfo,
+    followsYou: true,
+  },
+}
+
+type setFollowFilter = (p: Proof) => bool;
+function setFollow (source: TrackerProps, filter: setFollowFilter): TrackerProps {
+  source.proofs = source.proofs.map(p => filter(p) ? {
+    ...p,
+    isTracked: true,
+  } : p)
+  return source
+}
+
+const propsFollowing: TrackerProps = setFollow({
+  ...propsNewUser,
+  reason: 'You have tracked gabrielh.',
+  userInfo: {
+    ...propsNewUser.userInfo,
+    followsYou: true,
+  },
+  lastTrack: lastTrackMax,
+  proofs: proofsDefault,
+  lastAction: 'followed',
+}, () => true)
+
+const propsWhatevz: TrackerProps = setFollow({
+  ...propsFollowing,
+  reason: 'You have tracked gabrielh',
+  proofs: [
+    proofGithub,
+    {...proofTwitter, meta: metaIgnored},
+  ],
+}, () => true)
+
+const propsChangedProofs: TrackerProps = {
+  ...propsDefault,
+  reason: 'Some of gabrielh\'s proofs have changed since you last tracked them.',
+  userInfo: {
+    ...propsNewUser.userInfo,
+    followsYou: true,
+  },
+  lastTrack: lastTrackMax,
+  trackerState: error,
+  proofs: proofsChanged,
+}
+
+const propsUnfollowed: TrackerProps = {
+  ...propsDefault,
+  reason: 'You have untracked gabrielh.',
+  userInfo: {
+    ...propsNewUser.userInfo,
+    followsYou: true,
+  },
+  lastAction: 'unfollowed',
+}
+
+const propsLessData: TrackerProps = {
+  ...propsBase,
+  nonUser: false,
+  username: '00',
+  reason: 'I\'m a user with not much data.',
+  userInfo: {
+    fullname: 'Hi',
+    bio: '',
+    followersCount: 1,
+    followingCount: 0,
+    followsYou: false,
+    avatar: 'http://placehold.it/140x140/ffffff/000000',
+    location: '',
+  },
+  shouldFollow: true,
+  currentlyFollowing: false,
+  trackerState: normal,
+  proofs: [
+    proofGithub,
+  ],
+}
+
+const propsLoggedOut: TrackerProps = {...propsDefault, loggedIn: false, reason: 'You accessed a public folder with gabrielh.'}
+const propsOneProof: TrackerProps = {...propsDefault, proofs: [proofsDefault[0]]}
+const propsFiveProof: TrackerProps = {
+  ...propsDefault,
+  userInfo: {
+    ...propsDefault.userInfo,
+    bio: 'bio',
+    location: '',
+  },
+  proofs: [0, 1, 2, 3, 4].map(proofGithubMaker),
+}
+
+const dumbMap: DumbComponentMap<Tracker> = {
+  component: Tracker,
+  mocks: {
+    'New user': trackerPropsToRenderProps(propsNewUser),
+    'New user, follows me': trackerPropsToRenderProps(propsNewUserFollowsYou),
+    'Only one proof': trackerPropsToRenderProps(propsOneProof),
+    '5 proofs': trackerPropsToRenderProps(propsFiveProof),
+    'Followed': trackerPropsToRenderProps(propsFollowing),
+    'Changed/Broken proofs user you dont follow': trackerPropsToRenderProps({...propsChangedProofs, lastTrack: null}),
+    'Changed/Broken proofs': trackerPropsToRenderProps(propsChangedProofs),
+    'You track them': trackerPropsToRenderProps({...propsFollowing, userInfo: {...propsNewUser.userInfo, followsYou: false}}),
+    'Unfollowed': trackerPropsToRenderProps(propsUnfollowed),
+    'Barely there': trackerPropsToRenderProps(propsLessData),
+    'Whatevz': trackerPropsToRenderProps(propsWhatevz),
+    'NonuserNoLinkPrivate': trackerPropsToRenderProps({...propsNonUser, inviteLink: null, isPrivate: true}),
+    'NonuserLink': trackerPropsToRenderProps(propsNonUser),
+    'NonuserNoLinkPublic': trackerPropsToRenderProps({...propsNonUser, inviteLink: null}),
+    'Logged out': trackerPropsToRenderProps(propsLoggedOut),
+  },
+}
+
+export default {
+  'Tracker': dumbMap,
+}
+

--- a/shared/tracker/header.render.js.flow
+++ b/shared/tracker/header.render.js.flow
@@ -1,4 +1,5 @@
 /* @flow */
+import {Component} from 'react'
 
 import type {SimpleProofState} from '../constants/tracker'
 
@@ -8,5 +9,7 @@ export type HeaderProps = {
   trackerState: SimpleProofState,
   currentlyFollowing: boolean,
   lastAction: ?string,
-  loggedIn: boolean
+  loggedIn: boolean,
 }
+
+export default class HeaderRender extends Component<void, HeaderProps, void> { }

--- a/shared/tracker/header.render.native.js
+++ b/shared/tracker/header.render.native.js
@@ -4,7 +4,7 @@ import {View, Text} from 'react-native'
 export default class HeaderRender extends Component {
   render () {
     return (
-      <View style={{flex: 1, flexDirection: 'row'}}>
+      <View style={{flexDirection: 'row'}}>
         <Text>You accessed /private/cecile</Text>
       </View>
     )

--- a/shared/tracker/index.js
+++ b/shared/tracker/index.js
@@ -21,7 +21,7 @@ export type TrackerProps = {
   waiting: boolean,
   userInfo: ?UserInfo,
   nonUser: ?boolean,
-  parentProps: ?Object,
+  parentProps?: Object,
   proofs: Array<Proof>,
   onClose: () => void,
   onRefollow: () => void,

--- a/shared/tracker/render.js.flow
+++ b/shared/tracker/render.js.flow
@@ -5,6 +5,7 @@ import {Component} from 'react'
 import type {SimpleProofState} from '../constants/tracker'
 import type {UserInfo} from '../common-adapters/user-bio'
 import type {Proof} from '../common-adapters/user-proofs'
+import type {$Exact} from '../constants/types/more'
 
 export type RenderPropsUnshaped = {
   currentlyFollowing: boolean,
@@ -28,6 +29,6 @@ export type RenderPropsUnshaped = {
   waiting: boolean,
 }
 
-export type RenderProps = $Shape<RenderPropsUnshaped>
+export type RenderProps = $Exact<RenderPropsUnshaped>
 
 export default class Render extends Component<void, RenderProps, void> { }

--- a/shared/tracker/render.native.js
+++ b/shared/tracker/render.native.js
@@ -1,3 +1,4 @@
+/* @flow */
 import React, {Component} from 'react'
 import {View} from 'react-native'
 
@@ -5,17 +6,31 @@ import Header from './header.render'
 import {UserBio, UserProofs} from '../common-adapters'
 import Action from './action.render'
 
-export default class Render extends Component {
+import type {RenderProps} from './render'
+
+export default class Render extends Component<void, RenderProps, void> {
+  props: RenderProps;
+
   render () {
     return (
-      <View style={{backgroundColor: 'red', display: 'flex', flex: 1, flexDirection: 'column'}}>
-        <Header />
-        <View style={{backgroundColor: 'green', display: 'flex', flex: 1, flexDirection: 'row', height: 480}}>
-          <UserBio />
-          <UserProofs />
+      <View style={styles.container}>
+        <Header {...this.props.headerProps} />
+        <View style={styles.content}>
+          <UserBio type='Tracker' {...this.props.bioProps} avatarSize={80} />
+          <UserProofs {...this.props.proofsProps} />
         </View>
-        <Action />
+        <Action {...this.props.actionProps} />
       </View>
     )
   }
+}
+
+const styles = {
+  container: {
+    backgroundColor: 'red',
+    flexDirection: 'column',
+  },
+  content: {
+    backgroundColor: 'green',
+  },
 }

--- a/shared/tracker/render.native.js
+++ b/shared/tracker/render.native.js
@@ -13,24 +13,51 @@ export default class Render extends Component<void, RenderProps, void> {
 
   render () {
     return (
-      <View style={styles.container}>
-        <Header {...this.props.headerProps} />
-        <View style={styles.content}>
-          <UserBio type='Tracker' {...this.props.bioProps} avatarSize={80} />
-          <UserProofs {...this.props.proofsProps} />
+      <View style={stylesContainer}>
+        <Header
+          reason={this.props.reason}
+          onClose={this.props.onClose}
+          trackerState={this.props.trackerState}
+          currentlyFollowing={this.props.currentlyFollowing}
+          lastAction={this.props.lastAction}
+          loggedIn={this.props.loggedIn}
+        />
+        <View style={stylesContent}>
+          <UserBio type='Tracker'
+            avatarSize={80}
+            username={this.props.username}
+            userInfo={this.props.userInfo}
+            currentlyFollowing={this.props.currentlyFollowing}
+            trackerState={this.props.trackerState}
+          />
+          <UserProofs
+            username={this.props.username}
+            proofs={this.props.proofs}
+            currentlyFollowing={this.props.currentlyFollowing}
+          />
         </View>
-        <Action {...this.props.actionProps} />
+        <Action
+          loggedIn={this.props.loggedIn}
+          waiting={this.props.waiting}
+          state={this.props.trackerState}
+          currentlyFollowing={this.props.currentlyFollowing}
+          username={this.props.username}
+          lastAction={this.props.lastAction}
+          onClose={this.props.onClose}
+          onIgnore={this.props.onIgnore}
+          onFollow={this.props.onFollow}
+          onRefollow={this.props.onRefollow}
+          onUnfollow={this.props.onUnfollow}
+        />
       </View>
     )
   }
 }
 
-const styles = {
-  container: {
-    backgroundColor: 'red',
-    flexDirection: 'column',
-  },
-  content: {
-    backgroundColor: 'green',
-  },
+const stylesContainer = {
+  backgroundColor: 'red',
+  flexDirection: 'column',
+}
+const stylesContent = {
+  backgroundColor: 'green',
 }


### PR DESCRIPTION
This mostly takes advantage of the desktop proofs code, and simply modifies it to be mobile appropriate. Shared code is extracted and placed in `user-proofs.shared.js`. Some cleanup was done around the mobile tracker and user-bio so that this component could be tested. The cleanup is minimal and expected to be changed by proper implementations of those components.

An attempt was made at shimming padding on Text elements so that it worked on Android as well as iOS, but this resulted in unideal looking visual output because there are other inconsistencies in how view sizes/margins are calculated. This was reverted, and a wrapper was manually created around the Text view instead. This wrapper has special values applied for iOS vs. Android because of discrepancies that arose.

External linking should work. Because the links are based on the Android intent system (and the iOS equivalent) the URLs sometimes have to be modified to contain protocols if they are not otherwise present so that the OS knows to use a browser to view them.

### Example valid proofs on both mobile OSs:

iOS:
<img width="432" alt="screen shot 2016-06-22 at 4 07 09 pm" src="https://cloud.githubusercontent.com/assets/1152104/16287203/5038bd4e-3896-11e6-98a3-2ddd87e11355.png">
Android:
<img width="418" alt="screen shot 2016-06-22 at 4 07 16 pm" src="https://cloud.githubusercontent.com/assets/1152104/16287208/5357c72c-3896-11e6-9149-7a776f0c09e5.png">

### Example meta tags on Android (looks the same on iOS)
<img width="418" alt="screen shot 2016-06-23 at 12 52 21 pm" src="https://cloud.githubusercontent.com/assets/1152104/16317721/596371f6-3941-11e6-8ae1-aa8ad4502619.png">


### Example you track them on Android (looks the same on iOS)
<img width="418" alt="screen shot 2016-06-22 at 4 25 21 pm" src="https://cloud.githubusercontent.com/assets/1152104/16287212/57008404-3896-11e6-8c42-58ad2ecbea02.png">

@keybase/react-hackers 