### PR TITLE
Devices: Fix revoked color

### DIFF
--- a/shared/devices/render.desktop.js
+++ b/shared/devices/render.desktop.js
@@ -56,7 +56,7 @@ const DeviceRow = ({device, revoked, showRemoveDevicePage, showExistingDevicePag
     <Box
       className='existing-device-container'
       key={device.name}
-      style={{...stylesCommonRow, backgroundColor: revoked ? globalColors.lightGrey : globalColors.white}}>
+      style={{...stylesCommonRow, backgroundColor: revoked ? globalColors.white_40 : globalColors.white}}>
       <Box style={revoked ? stylesRevokedIconColumn : stylesIconColumn}>
         <Icon type={icon} />
       </Box>

--- a/shared/devices/render.desktop.js
+++ b/shared/devices/render.desktop.js
@@ -89,7 +89,7 @@ const RevokedDevices = ({revokedDevices, showExistingDevicePage}) => (
 )
 
 const DeviceHeader = ({addNewDevice, showingMenu, onHidden, menuItems}) => (
-  <Box style={{...stylesCommonRow, ...globalStyles.clickable}} onClick={addNewDevice}>
+  <Box style={{...stylesCommonRow, ...globalStyles.clickable, backgroundColor: globalColors.white}} onClick={addNewDevice}>
     <Box style={stylesCommonColumn}>
       <Icon type='devices-add-s' />
     </Box>
@@ -133,7 +133,7 @@ class Render extends Component<void, Props, State> {
     }
     `
     return (
-      <Box style={stylesContainer}>
+      <Box style={{stylesContainer, backgroundColor: globalColors.lightGrey}}>
         <DeviceHeader
           menuItems={this._items()}
           addNewDevice={() => this.setState({showingMenu: true})}

--- a/shared/devices/render.desktop.js
+++ b/shared/devices/render.desktop.js
@@ -133,7 +133,7 @@ class Render extends Component<void, Props, State> {
     }
     `
     return (
-      <Box style={{stylesContainer, backgroundColor: globalColors.lightGrey}}>
+      <Box style={stylesContainer}>
         <DeviceHeader
           menuItems={this._items()}
           addNewDevice={() => this.setState({showingMenu: true})}
@@ -149,6 +149,8 @@ class Render extends Component<void, Props, State> {
 
 const stylesContainer = {
   ...globalStyles.scrollable,
+  backgroundColor: globalColors.lightGrey,
+  flexGrow: 1,
 }
 
 const stylesCommonRow = {

--- a/shared/devices/render.native.js
+++ b/shared/devices/render.native.js
@@ -59,7 +59,7 @@ const DeviceRow = ({device, revoked, showRemoveDevicePage, showExistingDevicePag
   }
 
   return (
-    <Box key={device.name} style={{...stylesCommonRow, backgroundColor: revoked ? globalColors.lightGrey : globalColors.white}}>
+    <Box key={device.name} style={{...stylesCommonRow, backgroundColor: revoked ? globalColors.white_40 : globalColors.white}}>
       <Box style={revoked ? stylesRevokedIconColumn : stylesIconColumn}>
         <Icon type={icon} />
       </Box>

--- a/shared/folders/list.native.js
+++ b/shared/folders/list.native.js
@@ -76,6 +76,7 @@ const stylesContainer = {
 
 const stylesIgnoreContainer = {
   ...globalStyles.flexBoxColumn,
+  backgroundColor: globalColors.white_40
 }
 
 const stylesIgnoreDesc = {

--- a/shared/folders/list.native.js
+++ b/shared/folders/list.native.js
@@ -76,7 +76,6 @@ const stylesContainer = {
 
 const stylesIgnoreContainer = {
   ...globalStyles.flexBoxColumn,
-  backgroundColor: globalColors.white_40
 }
 
 const stylesIgnoreDesc = {

--- a/shared/folders/render.desktop.js
+++ b/shared/folders/render.desktop.js
@@ -41,8 +41,8 @@ class Render extends Component<void, Props, void> {
     }
 
     return (
-      <Box style={{...stylesContainer, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.white, paddingTop: this.props.smallMode ? 0 : 45}}>
-        <TabBar styleTabBar={tabBarStyle}>
+      <Box style={{...stylesContainer, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.lightGrey, paddingTop: 0, minHeight: 32}}>
+        <TabBar styleTabBar={{...tabBarStyle, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.white}}>
           <TabBarItem
             selected={this.props.showingPrivate}
             styleContainer={itemContainerStyle}
@@ -118,7 +118,8 @@ const itemContainerStyle = {
 
 const tabBarStyle = {
   ...globalStyles.flexBoxRow,
-  minHeight: 32,
+  minHeight: 64,
+  paddingTop: 32,
 }
 
 export default Render

--- a/shared/folders/render.desktop.js
+++ b/shared/folders/render.desktop.js
@@ -42,7 +42,7 @@ class Render extends Component<void, Props, void> {
 
     return (
       <Box style={{...stylesContainer, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.lightGrey, paddingTop: 0, minHeight: 32}}>
-        <TabBar styleTabBar={{...tabBarStyle, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.white}}>
+        <TabBar styleTabBar={{...tabBarStyle, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.white, minHeight: this.props.smallMode ? 32 : 64, paddingTop: this.props.smallMode ? 0 : 32}}>
           <TabBarItem
             selected={this.props.showingPrivate}
             styleContainer={itemContainerStyle}
@@ -118,8 +118,6 @@ const itemContainerStyle = {
 
 const tabBarStyle = {
   ...globalStyles.flexBoxRow,
-  minHeight: 64,
-  paddingTop: 32,
 }
 
 export default Render

--- a/shared/folders/render.native.js
+++ b/shared/folders/render.native.js
@@ -34,8 +34,8 @@ class Render extends Component<void, Props, void> {
 
   render () {
     return (
-      <Box style={{...stylesContainer, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.white}}>
-        <TabBar styleTabBar={tabBarStyle}>
+      <Box style={{...stylesContainer, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.lightGrey}}>
+        <TabBar styleTabBar={{...tabBarStyle, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.white}}>
           <TabBarItem
             selected={this.props.showingPrivate}
             styleContainer={itemContainerStyle}

--- a/shared/folders/row.desktop.js
+++ b/shared/folders/row.desktop.js
@@ -66,11 +66,20 @@ const Row = ({users, isPublic, ignored, meta, modified, hasData, smallMode, onOp
 
   const styles = isPublic ? stylesPublic : stylesPrivate
 
+  let backgroundColor = styles.rowContainer.backgroundColor
+  if (isPublic && ignored) {
+    backgroundColor = globalColors.white_40
+  }
+
   const containerStyle = {
     ...styles.rowContainer,
     minHeight: smallMode ? 40 : 48,
+    backgroundColor,
   }
 
+  console.log('CONTAINERSTYLE')
+  console.log(containerStyle)
+  console.table(containerStyle)
   const icon: IconProps.type = smallMode ? styles.hasStuffIcon.small : styles.hasStuffIcon.normal
 
   return (

--- a/shared/folders/row.desktop.js
+++ b/shared/folders/row.desktop.js
@@ -77,9 +77,6 @@ const Row = ({users, isPublic, ignored, meta, modified, hasData, smallMode, onOp
     backgroundColor,
   }
 
-  console.log('CONTAINERSTYLE')
-  console.log(containerStyle)
-  console.table(containerStyle)
   const icon: IconProps.type = smallMode ? styles.hasStuffIcon.small : styles.hasStuffIcon.normal
 
   return (

--- a/shared/folders/row.native.js
+++ b/shared/folders/row.native.js
@@ -89,10 +89,6 @@ const Row = ({users, isPublic, ignored, isFirst, meta, modified, hasData, path, 
     backgroundColor,
   }
 
-  console.log('CONTAINERSTYLE')
-  console.log(containerStyle)
-  console.log(backgroundColor)
-
   const icon: IconProps.type = styles.hasStuffIcon
 
   return (

--- a/shared/folders/row.native.js
+++ b/shared/folders/row.native.js
@@ -79,9 +79,19 @@ const RowMeta = ({ignored, meta, styles}) => {
 const Row = ({users, isPublic, ignored, isFirst, meta, modified, hasData, path, onClick}: Folder & {isFirst: boolean, onClick: (path: string) => void}) => {
   const styles = isPublic ? stylesPublic : stylesPrivate
 
+  let backgroundColor = styles.rowContainer.backgroundColor
+  if (isPublic && ignored) {
+    backgroundColor = globalColors.white_40
+  }
+
   const containerStyle = {
     ...styles.rowContainer,
+    backgroundColor,
   }
+
+  console.log('CONTAINERSTYLE')
+  console.log(containerStyle)
+  console.log(backgroundColor)
 
   const icon: IconProps.type = styles.hasStuffIcon
 


### PR DESCRIPTION
@keybase/react-hackers 

This ended up being a larger change, after talking to Cecile.  The revoked devices and ignored public folders had the wrong color, as a symptom of a larger problem: the background color for the entire of each tab was white100, but the background color for tabs with a list (devices, public folders) should be lightGrey, and then each element on top of that background should be set to white100, so that we can then use white40 for greyed out elements, and also have the background outside the list elements be lightGrey rather than white.  The devices tab matches up with Zeplin colors now.

Feel free to ask for a more coherent explanation!