### PR TITLE
Fix ctl start on brew

### DIFF
--- a/go/client/cmd_ctl_start_osx.go
+++ b/go/client/cmd_ctl_start_osx.go
@@ -43,7 +43,7 @@ func (s *CmdCtlStart) Run() error {
 		return err
 	}
 
-	return StartLaunchdService(s.G(), string(install.AppServiceLabel), true)
+	return StartLaunchdService(s.G(), install.DefaultServiceLabel(), true)
 }
 
 func (s *CmdCtlStart) GetUsage() libkb.Usage {


### PR DESCRIPTION
`ctl start` was using wrong label for brew

@maxtaco or @patrickxb 