### PR TITLE
nav pixel fixes

### DIFF
--- a/shared/common-adapters/tab-bar.desktop.js
+++ b/shared/common-adapters/tab-bar.desktop.js
@@ -59,7 +59,7 @@ export class TabBarButton extends Component<void, TabBarButtonProps, void> {
               </Box>
             </Box>}
         </Box>
-        {!!this.props.label && <Text type='BodySemiboldItalic' style={{color, textAlign: 'center'}}>{this.props.label}</Text>}
+        {!!this.props.label && <Text type='BodySemiboldItalic' style={{color, textAlign: 'center', ...this.props.styleLabel}}>{this.props.label}</Text>}
       </Box>
     )
   }
@@ -69,7 +69,7 @@ export class TabBarButton extends Component<void, TabBarButtonProps, void> {
     return (
       <Box style={{...stylesTabBarButtonIcon, backgroundColor, ...this.props.style}}>
         <Icon type={this.props.source.icon} style={{...stylesIcon, color, ...this.props.styleIcon}} />
-        {!!this.props.label && <Text type='Body' style={{color, ...this.props.styleLabel}}>{this.props.label}</Text>}
+        {!!this.props.label && <Text type={this.props.styleLabelType || 'Body'} style={{color, ...this.props.styleLabel}}>{this.props.label}</Text>}
         {badgeNumber > 0 &&
           <Box style={{...styleBadge, ...this.props.styleBadge}}>
             <Text style={{flex: 0, ...this.props.styleBadgeNumber}} type='BadgeNumber'>{badgeNumber}</Text>
@@ -80,7 +80,7 @@ export class TabBarButton extends Component<void, TabBarButtonProps, void> {
 
   render () {
     const backgroundColor = this.props.selected ? globalColors.darkBlue4 : globalColors.midnightBlue
-    const color = this.props.selected ? globalColors.blue3 : globalColors.blue3_40
+    const color = this.props.selected ? globalColors.white : globalColors.blue3_40
     const badgeNumber = this.props.badgeNumber || 0
 
     switch (this.props.source.type) {

--- a/shared/common-adapters/tab-bar.js.flow
+++ b/shared/common-adapters/tab-bar.js.flow
@@ -4,6 +4,7 @@ import React, {Component} from 'react'
 import Avatar from './avatar'
 import type {$Exact} from '../constants/types/more'
 import type {IconType} from './icon'
+import type {TextType} from './text'
 
 export type Props = $Exact<{
   style?: Object,
@@ -39,6 +40,7 @@ export type TabBarButtonProps = $Exact<{
   styleIcon?: Object,
   styleBadgeNumber?: Object,
   styleLabel?: Object,
+  styleLabelType?: ?TextType
 }>
 
 export class TabBarButton extends Component<void, TabBarButtonProps, void> { }

--- a/shared/tab-bar/index.render.desktop.js
+++ b/shared/tab-bar/index.render.desktop.js
@@ -69,6 +69,7 @@ export default class Render extends Component<void, Props, void> {
     return (
       <TabBarButton
         label={label}
+        styleLabel={{fontSize: 14, marginTop: 4}}
         selected={this.props.selectedTab === tab}
         badgeNumber={this.props.badgeNumbers[tab]}
         source={source} />
@@ -81,6 +82,8 @@ export default class Render extends Component<void, Props, void> {
     return (
       <TabBarButton
         style={stylesTabButton}
+        styleLabel={{fontSize: 13}}
+        styleLabelType='BodySemibold'
         label={label}
         selected={this.props.selectedTab === tab}
         badgeNumber={this.props.badgeNumbers[tab]}


### PR DESCRIPTION
- [x] main menu labels should be 13px semibold (now they're 16 regular)
- [x] active item should be white, with the icon white (now it's blue4)
- [x] my own username should be 14px (currently 16), get pushed down to 4px away from the avatar and turn white when active.

@keybase/react-hackers 