### PR TITLE
Return EOF if conn closed and 0 msgs

### DIFF
--- a/go/kex2/transport.go
+++ b/go/kex2/transport.go
@@ -435,12 +435,12 @@ func (c *Conn) Read(out []byte) (n int, err error) {
 	}
 
 	if n == 0 {
-		if c.getClosed() {
-			return 0, io.EOF
-		}
-		if poll > 0 {
+		switch {
+		case c.getClosed():
+			err = io.EOF
+		case poll > 0:
 			err = ErrTimedOut
-		} else {
+		default:
 			err = ErrAgain
 		}
 	}

--- a/go/kex2/transport.go
+++ b/go/kex2/transport.go
@@ -435,6 +435,9 @@ func (c *Conn) Read(out []byte) (n int, err error) {
 	}
 
 	if n == 0 {
+		if c.getClosed() {
+			return 0, io.EOF
+		}
 		if poll > 0 {
 			err = ErrTimedOut
 		} else {


### PR DESCRIPTION
This was causing an errant timed out error during `keybase device add` when actually the connection was just closed.