### PR TITLE
KEYBASE_DRIVE_LETTER environment

### DIFF
--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -256,6 +256,10 @@ func (p CommandLine) GetTorProxy() string {
 	return p.GetGString("tor-proxy")
 }
 
+func (p CommandLine) GetMountDir() string {
+	return p.GetGString("mountdir")
+}
+
 func (p CommandLine) GetBool(s string, glbl bool) (bool, bool) {
 	var v bool
 	if glbl {

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -706,3 +706,7 @@ func (f *JSONConfigFile) SetTimeAtPath(path string, t keybase1.Time) error {
 func (f JSONConfigFile) GetLocalTrackMaxAge() (time.Duration, bool) {
 	return f.GetDurationAtPath("local_track_max_age")
 }
+
+func (f JSONConfigFile) GetMountDir() string {
+	return f.GetTopLevelString("mountdir")
+}

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -75,6 +75,7 @@ func (n NullConfiguration) GetGregorSaveInterval() (time.Duration, bool)  { retu
 func (n NullConfiguration) GetGregorPingInterval() (time.Duration, bool)  { return 0, false }
 func (n NullConfiguration) IsAdmin() (bool, bool)                         { return false, false }
 func (n NullConfiguration) GetGregorDisabled() (bool, bool)               { return false, false }
+func (n NullConfiguration) GetMountDir() string                           { return "" }
 
 func (n NullConfiguration) GetUserConfig() (*UserConfig, error) { return nil, nil }
 func (n NullConfiguration) GetUserConfigForUsername(s NormalizedUsername) (*UserConfig, error) {
@@ -1016,7 +1017,12 @@ func (e *Env) GetMountDir() (string, error) {
 		if runMode != ProductionRunMode {
 			return "", fmt.Errorf("KBFS is currently only supported in production mode on Windows")
 		}
-		return "k:", nil
+		return e.GetString(
+			func() string { return e.cmd.GetMountDir() },
+			func() string { return os.Getenv("KEYBASE_DRIVE_LETTER") },
+			func() string { return e.config.GetMountDir() },
+			func() string { return "k:" },
+		), nil
 	}
 
 	switch runMode {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -72,6 +72,8 @@ type CommandLine interface {
 	GetTorProxy() string
 	GetLocalTrackMaxAge() (time.Duration, bool)
 
+	GetMountDir() string
+
 	// Lower-level functions
 	GetGString(string) string
 	GetString(string) string
@@ -154,6 +156,7 @@ type ConfigReader interface {
 	GetGregorSaveInterval() (time.Duration, bool)
 	GetGregorDisabled() (bool, bool)
 	GetGregorPingInterval() (time.Duration, bool)
+	GetMountDir() string
 
 	GetUpdatePreferenceAuto() (bool, bool)
 	GetUpdatePreferenceSkip() string


### PR DESCRIPTION
Otherwise users are stuck with hardcoded k:, whereas before watchdog2 they could at least modify the shortcut. @maxtaco @gabriel 

BTW I built + tested this and it works for changing the drive letter.