### PR TITLE
govendor update bazil.org/fuse

### DIFF
--- a/go/vendor/bazil.org/fuse/fuse_kernel.go
+++ b/go/vendor/bazil.org/fuse/fuse_kernel.go
@@ -489,6 +489,7 @@ type exchangeIn struct {
 	Olddir  uint64
 	Newdir  uint64
 	Options uint64
+	// "oldname\x00newname\x00" follows
 }
 
 type linkIn struct {

--- a/go/vendor/bazil.org/fuse/mount_darwin.go
+++ b/go/vendor/bazil.org/fuse/mount_darwin.go
@@ -91,7 +91,7 @@ func isBoringMountOSXFUSEError(err error) bool {
 	return false
 }
 
-func callMount(bin string, dir string, conf *mountConfig, f *os.File, ready chan<- struct{}, errp *error) error {
+func callMount(bin string, daemonVar string, dir string, conf *mountConfig, f *os.File, ready chan<- struct{}, errp *error) error {
 	for k, v := range conf.options {
 		if strings.Contains(k, ",") || strings.Contains(v, ",") {
 			// Silly limitation but the mount helper does not
@@ -116,12 +116,10 @@ func callMount(bin string, dir string, conf *mountConfig, f *os.File, ready chan
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "MOUNT_FUSEFS_CALL_BY_LIB=")
 
-	// TODO this is used for fs typenames etc, let app influence it
-
-	// for OSXFUSE 2.x
-	cmd.Env = append(cmd.Env, "MOUNT_FUSEFS_DAEMON_PATH="+bin)
-	// for OSXFUSE 3.x
-	cmd.Env = append(cmd.Env, "MOUNT_OSXFUSE_DAEMON_PATH="+bin)
+	daemon := os.Args[0]
+	if daemonVar != "" {
+		cmd.Env = append(cmd.Env, daemonVar+"="+daemon)
+	}
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -197,7 +195,7 @@ func mount(dir string, conf *mountConfig, ready chan<- struct{}, errp *error) (*
 		if err != nil {
 			return nil, err
 		}
-		err = callMount(loc.Mount, dir, conf, f, ready, errp)
+		err = callMount(loc.Mount, loc.DaemonVar, dir, conf, f, ready, errp)
 		if err != nil {
 			f.Close()
 			return nil, err

--- a/go/vendor/bazil.org/fuse/options.go
+++ b/go/vendor/bazil.org/fuse/options.go
@@ -181,6 +181,9 @@ type OSXFUSEPaths struct {
 	Load string
 	// Path of the mount helper, used for the actual mount operation.
 	Mount string
+	// Environment variable used to pass the path to the executable
+	// calling the mount helper.
+	DaemonVar string
 }
 
 // Default paths for OSXFUSE. See OSXFUSELocations.
@@ -189,11 +192,13 @@ var (
 		DevicePrefix: "/dev/osxfuse",
 		Load:         "/Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse",
 		Mount:        "/Library/Filesystems/osxfuse.fs/Contents/Resources/mount_osxfuse",
+		DaemonVar:    "MOUNT_OSXFUSE_DAEMON_PATH",
 	}
 	OSXFUSELocationV2 = OSXFUSEPaths{
 		DevicePrefix: "/dev/osxfuse",
 		Load:         "/Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs",
 		Mount:        "/Library/Filesystems/osxfusefs.fs/Support/mount_osxfusefs",
+		DaemonVar:    "MOUNT_FUSEFS_DAEMON_PATH",
 	}
 )
 

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -4,8 +4,8 @@
 	"package": [
 		{
 			"path": "bazil.org/fuse",
-			"revision": "70f2bea820ccbf0b4e72e44dbcb28fe333635085",
-			"revisionTime": "2015-09-10T16:50:43-07:00"
+			"revision": "a8bc3b86317dc95ed28fdefcebc1dbce8baa88e9",
+			"revisionTime": "2015-12-02T10:18:56-08:00"
 		},
 		{
 			"path": "code.google.com/p/rsc/gf256",


### PR DESCRIPTION
Uninstaller uses the unmounter in this package, and want to keep it same
as kbfs.