### PR TITLE
Allow the entire app to quit on OSX through Quit

### DIFF
--- a/desktop/app/index.js
+++ b/desktop/app/index.js
@@ -74,16 +74,6 @@ if (shouldQuit) {
     }
   })
 
-  // Don't quit the app, instead try to close all windows
-  app.on('close-windows', event => {
-    const windows = BrowserWindow.getAllWindows()
-    windows.forEach(w => {
-      // We tell it to close, we can register handlers for the 'close' event if we want to
-      // keep this window alive or hide it instead.
-      w.close()
-    })
-  })
-
   app.on('before-quit', event => {
     const windows = BrowserWindow.getAllWindows()
     windows.forEach(w => {

--- a/desktop/app/menu-helper.js
+++ b/desktop/app/menu-helper.js
@@ -16,7 +16,7 @@ export default function makeMenu (window) {
         {label: 'Hide Others', accelerator: 'CmdOrCtrl+Shift+H', role: 'hideothers'},
         {label: 'Show All', role: 'unhide'},
         {type: 'separator'},
-        {label: 'Quit', accelerator: 'CmdOrCtrl+Q', role: 'quit'},
+        {label: 'Quit', accelerator: 'CmdOrCtrl+Q', click () { app.quit() }},
       ],
     }, {
       label: 'Edit',

--- a/desktop/app/menu-helper.js
+++ b/desktop/app/menu-helper.js
@@ -16,7 +16,7 @@ export default function makeMenu (window) {
         {label: 'Hide Others', accelerator: 'CmdOrCtrl+Shift+H', role: 'hideothers'},
         {label: 'Show All', role: 'unhide'},
         {type: 'separator'},
-        {label: 'Quit', accelerator: 'CmdOrCtrl+Q', click () { app.emit('close-windows') }},
+        {label: 'Quit', accelerator: 'CmdOrCtrl+Q', role: 'quit'},
       ],
     }, {
       label: 'Edit',


### PR DESCRIPTION
@keybase/react-hackers 

Opening this PR for discussion.  Leaving the menubar active but closing all other windows results in main thread exceptions, because we RPC to those other windows and get "Error: object has been destroyed", crashing the main thread.

To reproduce this on prod, click the menubar and then hit cmd-q.  The menubar icon stays there, and if you click it then you get a JS error.  There's no way to recover without killing Keybase and restarting.

@MarcoPolo I think you added this code originally, are you okay with it going away?