### PR TITLE
Vendored desktop dependencies

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,7 @@
 /desktop/release/**
 /desktop/node_modules
 /desktop/shared
+/desktop/js-vendor-desktop
 /react-native/node_modules
 /react-native/shared
 /shared/libs/immutable-interface.js

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ npm-debug.log
 node_modules
 
 Keybase.app.dSYM.zip
+
+js-vendor-desktop
+node_shrinkwrap

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,8 @@ node("ec2-fleet") {
             //],
     ])
 
-    env.GOPATH=pwd()
+    env.BASEDIR=pwd()
+    env.GOPATH="${env.BASEDIR}/go"
     def mysqlImage = docker.image("keybaseprivate/mysql")
     def gregorImage = docker.image("keybaseprivate/kbgregor")
     def kbwebImage = docker.image("keybaseprivate/kbweb")
@@ -171,7 +172,8 @@ node("ec2-fleet") {
                         test_windows: {
                             node('windows') {
                                 deleteDir()
-                                def GOPATH=pwd()
+                                def BASEDIR=pwd()
+                                def GOPATH="${BASEDIR}/go"
                                 withEnv([
                                     'GOROOT=C:\\tools\\go',
                                     "GOPATH=\"${GOPATH}\"",
@@ -239,7 +241,8 @@ node("ec2-fleet") {
                         test_osx: {
                             node('osx') {
                                 deleteDir()
-                                def GOPATH=pwd()
+                                def BASEDIR=pwd()
+                                def GOPATH="${BASEDIR}/go"
                                 withEnv([
                                     "GOPATH=${GOPATH}",
                                     "PATH=${env.PATH}:${GOPATH}/bin",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,8 +110,8 @@ node("ec2-fleet") {
                                 ]) {
                                     dir("desktop") {
                                         sh "npm run vendor-install"
-                                        sh "unzip ./js-vendor-desktop/flow/flow-linux64*.zip -d ${env.GOPATH}"
-                                        sh "${env.GOPATH}/flow/flow status shared"
+                                        sh "unzip ./js-vendor-desktop/flow/flow-linux64*.zip -d ${env.BASEDIR}"
+                                        sh "${env.BASEDIR}/flow/flow status shared"
                                     }
                                     sh "desktop/node_modules/.bin/eslint ."
                                     dir("protocol") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,23 +107,11 @@ node("ec2-fleet") {
                                     "PATH=${env.HOME}/.node/bin:${env.PATH}",
                                     "NODE_PATH=${env.HOME}/.node/lib/node_modules:${env.NODE_PATH}",
                                 ]) {
-                                    if (fileExists("desktop/npm-vendor.js")) {
-                                        dir("desktop") {
-                                            sh "npm run vendor-install"
-                                            sh "unzip ./js-vendor-desktop/flow/flow-linux64*.zip"
-                                            sh "./flow/flow"
-                                        }
-                                    } else {
-                                        dir("desktop") {
-                                            sh "../packaging/npm_mess.sh"
-                                        }
-                                        dir("shared") {
-                                            sh 'npm i -g flow-bin@$(tail -n1 .flowconfig)'
-                                            sh "flow"
-                                        }
+                                    dir("desktop") {
+                                        sh "npm run vendor-install"
+                                        sh "unzip ./js-vendor-desktop/flow/flow-linux64*.zip -d ${env.GOPATH}"
+                                        sh "${env.GOPATH}/flow/flow status shared"
                                     }
-                                    sh "npm ls"
-                                    sh "ls desktop/node_modules"
                                     sh "desktop/node_modules/.bin/eslint ."
                                     dir("protocol") {
                                         sh "./diff_test.sh"
@@ -142,20 +130,12 @@ node("ec2-fleet") {
                                         withEnv([
                                             "VISDIFF_PR_ID=${env.CHANGE_ID}",
                                         ]) {
-                                            if (fileExists("visdiff")) {
-                                                dir("visdiff") {
-                                                    sh "npm install"
-                                                }
-                                                sh "npm install ./visdiff"
-                                                dir("desktop") {
-                                                    sh "../node_modules/.bin/keybase-visdiff 'merge-base(origin/master, HEAD)...HEAD'"
-                                                }
-                                            } else {
-                                                dir("desktop") {
-                                                    sh 'echo -e "[default]\\naccess_key = $VISDIFF_AWS_ACCESS_KEY_ID\\nsecret_key = $VISDIFF_AWS_SECRET_ACCESS_KEY" > ~/.s3cfg;'
-                                                    sh "npm install octonode"
-                                                    sh "npm run visdiff -- \"`git merge-base origin/master HEAD`...`git rev-parse HEAD`\""
-                                                }
+                                            dir("visdiff") {
+                                                sh "npm install"
+                                            }
+                                            sh "npm install ./visdiff"
+                                            dir("desktop") {
+                                                sh "../node_modules/.bin/keybase-visdiff 'merge-base(origin/master, HEAD)...HEAD'"
                                             }
                                         }}}
                                     }
@@ -228,34 +208,28 @@ node("ec2-fleet") {
                                         if (false && env.CHANGE_ID) {
                                         wrap([$class: 'Xvfb']) {
                                             println "Test Windows JS"
-                                            if (fileExists("visdiff")) {
-                                                bat "choco install -y nodejs.install --allow-downgrade --version 6.1.0"
-                                                bat "choco install -y python --version 2.7.11"
-                                                bat "choco install -y graphicsmagick --version 1.3.24"
-                                                dir("visdiff") {
-                                                    bat "npm install"
-                                                }
-                                                bat "npm install .\\visdiff"
-                                                dir("desktop") {
-                                                    if (fileExists("npm-vendor.js")) {
-                                                        bat "npm run vendor-install"
-                                                    } else {
-                                                        bat "npm install"
-                                                    }
-                                                    withCredentials([[$class: 'UsernamePasswordMultiBinding',
-                                                            credentialsId: 'visdiff-aws-creds',
-                                                            usernameVariable: 'VISDIFF_AWS_ACCESS_KEY_ID',
-                                                            passwordVariable: 'VISDIFF_AWS_SECRET_ACCESS_KEY',
-                                                        ],[$class: 'StringBinding',
-                                                            credentialsId: 'visdiff-github-token',
-                                                            variable: 'VISDIFF_GH_TOKEN',
-                                                    ]]) {
-                                                    withEnv([
-                                                        "VISDIFF_PR_ID=${env.CHANGE_ID}",
-                                                    ]) {
-                                                        bat '..\\node_modules\\.bin\\keybase-visdiff "merge-base(origin/master, HEAD)...HEAD"'
-                                                    }}
-                                                }
+                                            bat "choco install -y nodejs.install --allow-downgrade --version 6.1.0"
+                                            bat "choco install -y python --version 2.7.11"
+                                            bat "choco install -y graphicsmagick --version 1.3.24"
+                                            dir("visdiff") {
+                                                bat "npm install"
+                                            }
+                                            bat "npm install .\\visdiff"
+                                            dir("desktop") {
+                                                bat "npm run vendor-install"
+                                                withCredentials([[$class: 'UsernamePasswordMultiBinding',
+                                                        credentialsId: 'visdiff-aws-creds',
+                                                        usernameVariable: 'VISDIFF_AWS_ACCESS_KEY_ID',
+                                                        passwordVariable: 'VISDIFF_AWS_SECRET_ACCESS_KEY',
+                                                    ],[$class: 'StringBinding',
+                                                        credentialsId: 'visdiff-github-token',
+                                                        variable: 'VISDIFF_GH_TOKEN',
+                                                ]]) {
+                                                withEnv([
+                                                    "VISDIFF_PR_ID=${env.CHANGE_ID}",
+                                                ]) {
+                                                    bat '..\\node_modules\\.bin\\keybase-visdiff "merge-base(origin/master, HEAD)...HEAD"'
+                                                }}
                                             }
                                         }}},
                                     )

--- a/desktop/npm-shrinkwrap.json
+++ b/desktop/npm-shrinkwrap.json
@@ -1080,8 +1080,8 @@
     },
     "electron-download": {
       "version": "2.1.2",
-      "from": "electron-download@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-2.1.2.tgz"
+      "from": "git://github.com/keybase/electron-download.git#5350b5a1bad8ba7bb8c7201abe59ae3a03c3d75d",
+      "resolved": "git://github.com/keybase/electron-download.git#5350b5a1bad8ba7bb8c7201abe59ae3a03c3d75d"
     },
     "electron-osx-sign": {
       "version": "0.3.1",

--- a/desktop/npm-vendor.js
+++ b/desktop/npm-vendor.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+var os = require('os')
+var path = require('path')
+var fs = require('fs')
+var spawnSync = require('child_process').spawnSync
+
+function ensureSymlink (target, dest) {
+  if (fs.existsSync(target)) {
+    console.log('Removing existing', target)
+    fs.unlinkSync(target)
+  }
+
+  var absDest = path.resolve(dest)
+  console.log('Linking', target, '->', absDest)
+  fs.symlinkSync(absDest, target)
+}
+
+function spawn (command, args, options) {
+  console.log('>', command, args.join(' '))
+  var res = spawnSync(command, args, Object.assign({stdio: 'inherit', encoding: 'utf8'}, options))
+  if (res.error) {
+    throw res.error
+  } else if (res.status !== 0) {
+    throw new Error('Unexpected exit code: ' + res.status)
+  }
+}
+
+function installVendored () {
+  var packageInfo = JSON.parse(fs.readFileSync('./package.json'))
+  var parts = packageInfo.keybaseVendoredDependencies.split('#')
+  var url = parts[0]
+  var commit = parts[1]
+
+  if (!fs.existsSync('./js-vendor-desktop')) {
+    spawn('git', ['clone', url, 'js-vendor-desktop'])
+  }
+  spawn('git', ['fetch', 'origin'], {cwd: './js-vendor-desktop'})
+  spawn('git', ['checkout', '-f', commit], {cwd: './js-vendor-desktop'})
+  console.log(`js-vendor-desktop: ${url} @ ${commit}`)
+
+  ensureSymlink('./npm-shrinkwrap.json', './js-vendor-desktop/npm-shrinkwrap.json')
+  ensureSymlink('./node_shrinkwrap', './js-vendor-desktop/node_shrinkwrap')
+  spawn(os.platform() === 'win32' ? 'npm.cmd' : 'npm', ['install', '--loglevel=http', '--no-optional'], {
+    env: Object.assign({}, process.env, {
+      ELECTRON_CACHE: path.resolve('./js-vendor-desktop/electron'),
+      ELECTRON_ONLY_CACHE: 1,
+    }),
+  })
+}
+
+installVendored()

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "./dist/main.bundle.js",
   "scripts": {
+    "vendor-install": "node npm-vendor.js",
     "start": "babel-node --presets es2015,stage-2 npm-helper.js start",
     "start-hot": "babel-node --presets es2015,stage-2 npm-helper.js start-hot",
     "start-cold": "babel-node --presets es2015,stage-2 npm-helper.js start-cold",
@@ -104,5 +105,6 @@
   },
   "optionalDependencies": {
     "fsevents": "1.0.12"
-  }
+  },
+  "keybaseVendoredDependencies": "git://github.com/keybase/js-vendor-desktop#65a74f32add51d5aba96d5d0ccb1cc6bd10d73c1"
 }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -71,6 +71,7 @@
     "devtron": "1.2.1",
     "electron-packager": "7.3.0",
     "electron-prebuilt": "1.2.6",
+    "electron-download": "git://github.com/keybase/electron-download#5350b5a1bad8ba7bb8c7201abe59ae3a03c3d75d",
     "eslint": "2.13.1",
     "eslint-config-standard": "5.3.1",
     "eslint-config-standard-jsx": "1.2.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -106,5 +106,5 @@
   "optionalDependencies": {
     "fsevents": "1.0.12"
   },
-  "keybaseVendoredDependencies": "git://github.com/keybase/js-vendor-desktop#65a74f32add51d5aba96d5d0ccb1cc6bd10d73c1"
+  "keybaseVendoredDependencies": "git://github.com/keybase/js-vendor-desktop#fec4c7b8f6c9be789cdcd085773e04ffaabf616e"
 }

--- a/protocol/diff_test.sh
+++ b/protocol/diff_test.sh
@@ -9,7 +9,14 @@ npm i
 make clean
 make
 
-if ! git diff --exit-code ; then
+# Protocol changes could create diffs in the following directories:
+#   protocol/
+#   go/
+#   shared/
+# This build process is idempotent. We expect there to be no changes after
+# re-running the protocol generation, because any changes should have been
+# checked in.
+if ! git diff --exit-code ./ ../go/ ../shared/; then
   echo 'ERROR: `git diff` detected changes. The generated protocol files are stale.'
   exit 1
 fi

--- a/visdiff/src/index.js
+++ b/visdiff/src/index.js
@@ -53,7 +53,13 @@ function checkout (commit) {
   } else {
     console.log(`Installing dependencies for package.json:${newPackageHash}...`)
   }
-  spawnSync(NPM_CMD, ['install'], {stdio: 'inherit'})
+
+  if (JSON.parse(fs.readFileSync('package.json')).keybaseVendoredDependencies) {
+    spawnSync(NPM_CMD, ['run', 'vendor-install'], {stdio: 'inherit'})
+  } else {
+    console.log('Warning: not using vendored dependencies')
+    spawnSync(NPM_CMD, ['install'], {stdio: 'inherit'})
+  }
 }
 
 function renderScreenshots (commitRange) {


### PR DESCRIPTION
## Try it out:

run `npm run vendor-install`.

It will clone the vendor repo and install the packages.

Note: `npm` between 3.8.6 and 3.10.4 will fail to install. This is caused by a regression in `npm` which ~~is hopefully being fixed in the next release~~ has been fixed in 3.10.4.

## Vendor ~~all~~ most of the things!

This vendors electron, flow, and the packages in `desktop/package.json` (minus `fsevents`). I believe this will enable us to do a release build of the desktop client without hitting npm. Also gets us close to being able to vendor CI, but there's still visdiff (`s3`, `octonode`, etc) and protocol generation (`activerecord` gem, npm install) outstanding.

This is passing CI with use of the vendored deps, and CI should fail if the vendoring repo falls out of sync somehow.

I've documented the flow for updating dependencies here: https://github.com/keybase/js-vendor-desktop. Basically, you update your packages, check in the `shrinkpack` results, and update the `keybaseVendoredDependencies` value in `package.json`.