### PR TITLE
Mobile avatars w/o badging DESKTOP-1096

### DIFF
--- a/react-native/ios/Keybase/AppDelegate.swift
+++ b/react-native/ios/Keybase/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder {
 
       #if DEBUG
         if let reactHost = AppDefault.ReactHost.stringValue {
-          return NSURL(string: "http://\(reactHost)/shared/index.bundle?platform=ios&dev=true")
+          return NSURL(string: "http://\(reactHost)/index.ios.bundle?platform=ios&dev=true")
         } else {
           return NSBundle.mainBundle().URLForResource("main", withExtension: "jsbundle")
         }

--- a/shared/common-adapters/avatar.desktop.js
+++ b/shared/common-adapters/avatar.desktop.js
@@ -24,7 +24,7 @@ export default class Avatar extends Component {
     const {size} = this.props
     const width = size
     const height = size
-    const url = __SCREENSHOT__ ? noAvatar : shared.createAvatarUrl(this.props)
+    const url = shared.createAvatarUrl(this.props) || noAvatar
     const avatarStyle = {width, height, borderRadius: size / 2, position: 'absolute'}
 
     return (

--- a/shared/common-adapters/avatar.desktop.js
+++ b/shared/common-adapters/avatar.desktop.js
@@ -4,6 +4,7 @@ import React, {Component} from 'react'
 import {resolveImageAsURL} from '../../desktop/resolve-root'
 import {globalStyles, globalColors} from '../styles/style-guide'
 import type {Props} from './avatar'
+import * as shared from './avatar.shared'
 
 const noAvatar = resolveImageAsURL('icons', 'placeholder-avatar@2x.png')
 
@@ -19,23 +20,11 @@ export default class Avatar extends Component {
     this.state = {avatarLoaded: false}
   }
 
-  _createUrl (): ?string {
-    if (__SCREENSHOT__) {
-      return noAvatar
-    } else if (this.props.url) {
-      return this.props.url
-    } else if (this.props.username) {
-      return `https://keybase.io/${this.props.username}/picture`
-    }
-
-    return null
-  }
-
   render () {
     const {size} = this.props
     const width = size
     const height = size
-    const url = this._createUrl()
+    const url = __SCREENSHOT__ ? noAvatar : shared.createUrl(this.props)
     const avatarStyle = {width, height, borderRadius: size / 2, position: 'absolute'}
 
     return (

--- a/shared/common-adapters/avatar.desktop.js
+++ b/shared/common-adapters/avatar.desktop.js
@@ -24,7 +24,7 @@ export default class Avatar extends Component {
     const {size} = this.props
     const width = size
     const height = size
-    const url = __SCREENSHOT__ ? noAvatar : shared.createUrl(this.props)
+    const url = __SCREENSHOT__ ? noAvatar : shared.createAvatarUrl(this.props)
     const avatarStyle = {width, height, borderRadius: size / 2, position: 'absolute'}
 
     return (

--- a/shared/common-adapters/avatar.native.js
+++ b/shared/common-adapters/avatar.native.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, {Component} from 'react'
-import {Image, TouchableWithoutFeedback} from 'react-native'
+import {Image, TouchableOpacity, TouchableWithoutFeedback} from 'react-native'
 import type {Props} from './avatar'
 import {Box} from '../common-adapters'
 import {images} from './icon.paths.native'
@@ -13,7 +13,6 @@ type State = {
 }
 
 export default class Avatar extends Component<void, Props, State> {
-  props: Props;
   state: State;
 
   constructor (props: Props) {
@@ -24,30 +23,22 @@ export default class Avatar extends Component<void, Props, State> {
   render () {
     const {size} = this.props
     const uri = {uri: shared.createAvatarUrl(this.props)}
-    console.log('uri & state & props', uri, this.state, this.props)
 
-    const avatarImage =
-      <Box style={stylesContainer(size)}>
-        <Image
-          style={{...stylesImage(size), opacity: this.state.avatarLoaded ? 1 : 0}}
-          onLoad={() => this.setState({avatarLoaded: true})}
-          source={uri} />
-        {!this.state.avatarLoaded &&
+    const TouchWrapper = this.props.onClick ? TouchableOpacity : TouchableWithoutFeedback
+    return (
+      <TouchWrapper style={{...stylesContainer(size), ...this.props.style}} disabled={!this.props.onClick} onPress={this.props.onClick} {...(this.props.onClick ? {activeOpacity: 0.8} : {})}>
+        <Box style={stylesContainer(size)}>
           <Image
-            style={stylesPlaceholderImage(size)}
-            source={images['placeholder-avatar']} />}
-      </Box>
-
-    if (this.props.onClick) {
-      return (
-        <TouchableWithoutFeedback style={{...stylesContainer(size), ...this.props.style}} onPress={this.props.onClick}>
-          {avatarImage}
-        </TouchableWithoutFeedback>
-      )
-    } else {
-      Object.assign(avatarImage.props.style, this.props.style)
-      return avatarImage
-    }
+            style={{...stylesImage(size), opacity: this.state.avatarLoaded ? 1 : 0}}
+            onLoad={() => this.setState({avatarLoaded: true})}
+            source={uri} />
+          {!this.state.avatarLoaded &&
+            <Image
+              style={stylesPlaceholderImage(size)}
+              source={images['placeholder-avatar']} />}
+        </Box>
+      </TouchWrapper>
+    )
   }
 }
 

--- a/shared/common-adapters/avatar.native.js
+++ b/shared/common-adapters/avatar.native.js
@@ -1,36 +1,29 @@
 // @flow
 
 import React, {Component} from 'react'
+import {Image} from 'react-native'
 import type {Props} from './avatar'
 import {Box, Icon} from '../common-adapters'
+import {images} from './icon.paths.native'
+import * as shared from './avatar.shared'
 
 export default class Avatar extends Component {
   props: Props;
 
-  state: {
-    avatarLoaded: boolean
-  };
-
   constructor (props: Props) {
     super(props)
-    this.state = {avatarLoaded: false}
   }
 
   render () {
-    return (
-      <Box style={{justifyContent: 'flex-end', ...this.props.style}} onClick={this.props.onClick}>
-        <Icon style={{...avatarStyle(this.props.size - 2)}}
-          type='placeholder-avatar' />
-      </Box>
-    )
-  }
-}
+    const width = this.props.size
+    const height = this.props.size
+    const url = shared.createUrl(this.props)
 
-function avatarStyle (size: number): Object {
-  return {
-    width: size,
-    height: size,
-    borderRadius: size / 2,
-    alignSelf: 'center',
+    return (
+      <Image
+        style={{resizeMode: 'contain', width, height, borderRadius: width / 2}}
+        defaultSource={images['placeholder-avatar']}
+        source={{uri: url}} />
+    )
   }
 }

--- a/shared/common-adapters/avatar.native.js
+++ b/shared/common-adapters/avatar.native.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, {Component} from 'react'
-import {Image} from 'react-native'
+import {Image, PixelRatio, Platform} from 'react-native'
 import type {Props} from './avatar'
 import {Box, Icon} from '../common-adapters'
 import {images} from './icon.paths.native'
@@ -19,9 +19,14 @@ export default class Avatar extends Component {
     const height = this.props.size
     const uri = shared.createAvatarUrl(this.props)
 
+    // Hack AW: As of react-native 0.24.1, it appears that iOS takes in dp
+    //  for the borderRadius, while Android (incorrectly) takes in pixels. This
+    //  hack handles the conversion between pixels and dp on Android.
+    const borderRadius = width / 2 * (Platform.OS === 'android' ? PixelRatio.get() : 1);
+
     return (
       <Image
-        style={{resizeMode: 'contain', width, height, borderRadius: width / 2}}
+        style={{resizeMode: 'contain', width, height, borderRadius}}
         defaultSource={images['placeholder-avatar']}
         source={{uri}} />
     )

--- a/shared/common-adapters/avatar.native.js
+++ b/shared/common-adapters/avatar.native.js
@@ -17,13 +17,13 @@ export default class Avatar extends Component {
   render () {
     const width = this.props.size
     const height = this.props.size
-    const url = shared.createUrl(this.props)
+    const uri = shared.createAvatarUrl(this.props)
 
     return (
       <Image
         style={{resizeMode: 'contain', width, height, borderRadius: width / 2}}
         defaultSource={images['placeholder-avatar']}
-        source={{uri: url}} />
+        source={{uri}} />
     )
   }
 }

--- a/shared/common-adapters/avatar.native.js
+++ b/shared/common-adapters/avatar.native.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, {Component} from 'react'
-import {Image, TouchableOpacity, TouchableWithoutFeedback} from 'react-native'
+import {Image, TouchableOpacity} from 'react-native'
 import type {Props} from './avatar'
 import {Box} from '../common-adapters'
 import {images} from './icon.paths.native'
@@ -24,9 +24,8 @@ export default class Avatar extends Component<void, Props, State> {
     const {size} = this.props
     const uri = {uri: shared.createAvatarUrl(this.props)}
 
-    const TouchWrapper = this.props.onClick ? TouchableOpacity : TouchableWithoutFeedback
     return (
-      <TouchWrapper style={{...stylesContainer(size), ...this.props.style}} disabled={!this.props.onClick} onPress={this.props.onClick} {...(this.props.onClick ? {activeOpacity: 0.8} : {})}>
+      <TouchableOpacity style={{...stylesContainer(size), ...this.props.style}} disabled={!this.props.onClick} onPress={this.props.onClick} activeOpacity={0.8}>
         <Box style={stylesContainer(size)}>
           <Image
             style={{...stylesImage(size), opacity: this.state.avatarLoaded ? 1 : 0}}
@@ -37,7 +36,7 @@ export default class Avatar extends Component<void, Props, State> {
               style={stylesPlaceholderImage(size)}
               source={images['placeholder-avatar']} />}
         </Box>
-      </TouchWrapper>
+      </TouchableOpacity>
     )
   }
 }

--- a/shared/common-adapters/avatar.shared.js
+++ b/shared/common-adapters/avatar.shared.js
@@ -1,10 +1,8 @@
 // @flow
 
 export function createAvatarUrl (props: {url: ?string} | {username: ?string}): ?string {
-  if (props.url) {
-    return props.url
-  } else if (props.username) {
-    return `https://keybase.io/${props.username}/picture`
-  }
+  if (__SCREENSHOT__) return null
+  if (props.url) return props.url
+  if (props.username) return `https://keybase.io/${props.username}/picture`
   return null
 }

--- a/shared/common-adapters/avatar.shared.js
+++ b/shared/common-adapters/avatar.shared.js
@@ -1,0 +1,11 @@
+// @flow
+import type {Props} from './avatar'
+
+export function createUrl (props: Props): ?string {
+    if (props.url) {
+      return props.url
+    } else if (props.username) {
+      return `https://keybase.io/${props.username}/picture`
+    }
+    return null
+}

--- a/shared/common-adapters/avatar.shared.js
+++ b/shared/common-adapters/avatar.shared.js
@@ -1,11 +1,10 @@
 // @flow
-import type {Props} from './avatar'
 
 export function createAvatarUrl (props: {url: ?string} | {username: ?string}): ?string {
-    if (props.url) {
-      return props.url
-    } else if (props.username) {
-      return `https://keybase.io/${props.username}/picture`
-    }
-    return null
+  if (props.url) {
+    return props.url
+  } else if (props.username) {
+    return `https://keybase.io/${props.username}/picture`
+  }
+  return null
 }

--- a/shared/common-adapters/avatar.shared.js
+++ b/shared/common-adapters/avatar.shared.js
@@ -1,7 +1,7 @@
 // @flow
 import type {Props} from './avatar'
 
-export function createUrl (props: Props): ?string {
+export function createAvatarUrl (props: {url: ?string} | {username: ?string}): ?string {
     if (props.url) {
       return props.url
     } else if (props.username) {

--- a/shared/common-adapters/user-bio.native.js
+++ b/shared/common-adapters/user-bio.native.js
@@ -81,7 +81,7 @@ const stylesHeaderBar = (avatarSize: number, color: string) => ({
 })
 const stylesAvatarWrapper = (avatarSize: number) => ({ // eslint-disable-line arrow-parens
   ...globalStyles.flexBoxColumn,
-  justifyContent: 'center',
+  alignItems: 'center',
   flex: 1,
   height: avatarSize,
   marginTop: -avatarSize / 2,

--- a/shared/common-adapters/user-card.native.js
+++ b/shared/common-adapters/user-card.native.js
@@ -40,7 +40,7 @@ const styles = {
   avatar: {
     ...globalStyles.flexBoxColumn,
     marginTop: 0,
-    alignItems: 'stretch',
+    alignItems: 'center',
     alignSelf: 'stretch',
   },
   avatarBackground: {

--- a/shared/globals.native.js
+++ b/shared/globals.native.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-native-reassign */
+
+// __DEV__
+//  set by react-native to true if the app is being run in a simulator, false otherwise
+
+// __PROD__
+//  set opposite of __DEV__
+
+// __SCREENSHOT__
+//  indicates if the execution environment is visdiff
+//  set to false if it isn't already set
+if (typeof __SCREENSHOT__ === 'undefined') {
+  __SCREENSHOT__ = false
+}

--- a/shared/index.native.js
+++ b/shared/index.native.js
@@ -1,3 +1,4 @@
+import './globals'
 import React, {Component} from 'react'
 import {AppRegistry, NativeAppEventEmitter, AsyncStorage} from 'react-native'
 import {Provider} from 'react-redux'


### PR DESCRIPTION
Placeholder icons are used when no network is available. Attempts are made to keep the view hierarchy as simple as possible (and to avoid unexpected click interceptions), so a TouchableWithoutHighlight wrapper is only added if their is an onClick method supplied.

This fixes the issues mentioned in [PR #2949, WIP: Setup avatars on mobile DESKTOP-1096](https://github.com/keybase/client/pull/2949). Thanks @MarcoPolo for the update to RN 0.27!

A following PR will be necessary to bring avatar badging to mobile.

<img width="432" alt="screen shot 2016-06-27 at 5 46 03 pm" src="https://cloud.githubusercontent.com/assets/1152104/16400320/1c6f1be6-3c8f-11e6-8840-11baa2cbf22e.png">
<img width="418" alt="screen shot 2016-06-27 at 5 46 01 pm" src="https://cloud.githubusercontent.com/assets/1152104/16400321/1c7e04bc-3c8f-11e6-9949-ce5f1d82ca5f.png">

The problem of https://github.com/keybase/client/pull/2949 was that RN doesn't properly handle `borderRadius` on Android when the Image `resizeMode` is set to `contain`. This was an undocumented bug which has now been brought to light (but not yet fixed).

@keybase/react-hackers 