### PR TITLE
Skip GPG sign tests if version < 2.0.29

### DIFF
--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -2360,6 +2360,9 @@ func (g *gpgImportFailer) Index(secret bool, query string) (ki *libkb.GpgKeyInde
 
 func skipOldGPG(tc libkb.TestContext) {
 	gpg := tc.G.GetGpgClient()
+	if err := gpg.Configure(); err != nil {
+		tc.T.Skip(fmt.Sprintf("skipping test due to gpg configure error: %s", err))
+	}
 	ok, err := gpg.VersionAtLeast("2.0.29")
 	if err != nil {
 		tc.T.Fatal(err)

--- a/go/libkb/gpg_cli.go
+++ b/go/libkb/gpg_cli.go
@@ -235,7 +235,7 @@ func (g *GpgCLI) SemanticVersion() (*semver.Version, error) {
 	}
 	parts := strings.Fields(lines[0])
 	if len(parts) != 3 {
-		return nil, errors.New("unhandled gpg version output")
+		return nil, fmt.Errorf("unhandled gpg version output %q full: %q", lines[0], lines)
 	}
 	return semver.New(parts[2])
 }

--- a/go/libkb/gpg_cli.go
+++ b/go/libkb/gpg_cli.go
@@ -234,7 +234,7 @@ func (g *GpgCLI) SemanticVersion() (*semver.Version, error) {
 		return nil, errors.New("empty gpg version")
 	}
 	parts := strings.Fields(lines[0])
-	if len(parts) != 3 {
+	if len(parts) < 3 {
 		return nil, fmt.Errorf("unhandled gpg version output %q full: %q", lines[0], lines)
 	}
 	return semver.New(parts[2])

--- a/go/libkb/gpg_cli_test.go
+++ b/go/libkb/gpg_cli_test.go
@@ -60,3 +60,34 @@ func TestGPGImportSecret(t *testing.T) {
 		t.Fatal("bundle can't sign")
 	}
 }
+
+// Useful to track down signing errors in GPG < 2.0.29
+func TestGPGSign(t *testing.T) {
+	t.Skip("skipping GPG Sign test")
+	tc := SetupTest(t, "gpg_cli", 1)
+	defer tc.Cleanup()
+	err := tc.GenerateGPGKeyring("no@no.no")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cli := NewGpgCLI(tc.G, nil)
+	if err := cli.Configure(); err != nil {
+		t.Fatal(err)
+	}
+	index, _, err := cli.Index(true, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fps := index.AllFingerprints()
+	if len(fps) != 1 {
+		t.Fatalf("num fingerprints: %d, expected 1", len(fps))
+	}
+	fp := fps[0]
+
+	for i := 0; i < 1000; i++ {
+		_, err = cli.Sign(fp, []byte("hello"))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
There's a bug with gpg versions < 2.0.29 where they can sometimes fail to sign a message.  This makes the tests not run unless gpg is 2.0.29 or higher, which should fix the CI errors we sometimes see.

r? @maxtaco 

@cjb we should upgrade CI server gpg versions to 2.0.29 or 2.0.30 if possible.