### PR TITLE
Incorrect names of functions. open logic incorrect on windows

### DIFF
--- a/shared/actions/kbfs/platform.desktop.js
+++ b/shared/actions/kbfs/platform.desktop.js
@@ -32,30 +32,33 @@ export function openInKBFS (path: string = Constants.defaultKBFSPath): AsyncActi
 
     // On windows the path isn't /keybase
     // We can figure it out by looking at the extendedConfig though
-    if (process.platform === 'win32' && kbfsPath === Constants.defaultKBFSPath) {
-      const extendedConfig = Promise.resolve(state.config.extendedConfig)
+    if (process.platform === 'win32') {
+      if (kbfsPath === Constants.defaultKBFSPath) {
+        const extendedConfig = Promise.resolve(state.config.extendedConfig)
 
-      extendedConfig.then(extendedConfig => {
-        const kbfsClients = extendedConfig.Clients.filter(c => c.clientType === Common.ClientType.kbfs)
-        if (kbfsClients.length !== 1) {
-          return Promise.reject("There isn't exactly one kbfs client")
-        }
+        extendedConfig.then(extendedConfig => {
+          const kbfsClients = extendedConfig.Clients.filter(c => c.clientType === Common.ClientType.kbfs)
+          if (kbfsClients.length !== 1) {
+            return Promise.reject("There isn't exactly one kbfs client")
+          }
 
-        // Hacky Regex to find a mount point on windows matches anything like foobar:\ or K:\
-        const kbfsPath = kbfsClients[0].argv.filter(arg => arg.search(/.*:\\?$/) === 0)[0]
+          // Hacky Regex to find a mount point on windows matches anything like foobar:\ or K:\
+          const kbfsPath = kbfsClients[0].argv.filter(arg => arg.search(/.*:\\?$/) === 0)[0]
 
-        if (!kbfsPath) {
-          return Promise.reject("Couldn't figure out kbfs path from argv")
-        }
+          if (!kbfsPath) {
+            return Promise.reject("Couldn't figure out kbfs path from argv")
+          }
 
-        return Promise.resolve(kbfsPath + '\\')
-      }).then(kbfsPath => {
-        dispatch({type: Constants.changeKBFSPath, payload: {path: kbfsPath}})
+          return Promise.resolve(kbfsPath + '\\')
+        }).then(kbfsPath => {
+          dispatch({type: Constants.changeKBFSPath, payload: {path: kbfsPath}})
+          open(kbfsPath, path)
+        }).catch(e => {
+          console.warn('Error in parsing kbfsPath: ', e)
+        })
+      } else {
         open(kbfsPath, path)
-        shell.openItem(`${kbfsPath}${path}`)
-      }).catch(e => {
-        console.warn('Error in parsing kbfsPath: ', e)
-      })
+      }
     } else {
       open(Constants.defaultKBFSPath, path)
     }

--- a/shared/actions/kbfs/platform.desktop.js
+++ b/shared/actions/kbfs/platform.desktop.js
@@ -19,7 +19,7 @@ const open = (kbfsPath: string, path: string = '') => { // eslint-disable-line s
 }
 
 // Paths MUST start with /keybase/
-export function platformOpenInKBFS (path: string = Constants.defaultKBFSPath): AsyncAction {
+export function openInKBFS (path: string = Constants.defaultKBFSPath): AsyncAction {
   if (!path.startsWith(Constants.defaultKBFSPath)) {
     console.warn(`ERROR: openInKBFS requires ${Constants.defaultKBFSPath} prefix`)
     return () => {}

--- a/shared/actions/kbfs/platform.native.js
+++ b/shared/actions/kbfs/platform.native.js
@@ -2,6 +2,6 @@
 
 import type {AsyncAction} from '../../constants/types/flux'
 
-export function platformOpenInKBFS (path: string = ''): AsyncAction {
+export function openInKBFS (path: string = ''): AsyncAction {
   return (dispatch, getState) => {}
 }


### PR DESCRIPTION
refactor to the kbfs actions caused this to not function on windows. unclear how it worked on osx (but it did). 

- [x] fixes exported names being incorrect
- [x] fixed borked windows open logic

@keybase/react-hackers 