### PR TITLE
Skip primary paper key generation by default

### DIFF
--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -83,6 +83,7 @@ func MakeTestSignupEngineRunArg(fu *FakeUser) SignupEngineRunArg {
 		DeviceName:  defaultDeviceName,
 		SkipGPG:     true,
 		SkipMail:    true,
+		SkipPaper:   true,
 	}
 }
 
@@ -106,6 +107,15 @@ func CreateAndSignupFakeUser(tc libkb.TestContext, prefix string) *FakeUser {
 	fu := NewFakeUserOrBust(tc.T, prefix)
 	tc.G.Log.Debug("New test user: %s / %s", fu.Username, fu.Email)
 	arg := MakeTestSignupEngineRunArg(fu)
+	_ = SignupFakeUserWithArg(tc, fu, arg)
+	return fu
+}
+
+func CreateAndSignupFakeUserPaper(tc libkb.TestContext, prefix string) *FakeUser {
+	fu := NewFakeUserOrBust(tc.T, prefix)
+	tc.G.Log.Debug("New test user: %s / %s", fu.Username, fu.Email)
+	arg := MakeTestSignupEngineRunArg(fu)
+	arg.SkipPaper = false
 	_ = SignupFakeUserWithArg(tc, fu, arg)
 	return fu
 }
@@ -294,6 +304,7 @@ func SetupTwoDevices(t *testing.T, nm string) (user *FakeUser, dev1 libkb.TestCo
 
 	user = NewFakeUserOrBust(t, nm)
 	arg := MakeTestSignupEngineRunArg(user)
+	arg.SkipPaper = false
 	loginUI := &paperLoginUI{Username: user.Username}
 	ctx := &Context{
 		LogUI:    dev1.G.UI.GetLogUI(),

--- a/go/engine/deprovision_test.go
+++ b/go/engine/deprovision_test.go
@@ -46,7 +46,7 @@ func assertDeprovisionWithSetup(tc libkb.TestContext) {
 	// secret store (if possible).
 	fu := NewFakeUserOrBust(tc.T, "dpr")
 	arg := MakeTestSignupEngineRunArg(fu)
-
+	arg.SkipPaper = false
 	arg.StoreSecret = tc.G.SecretStoreAll != nil
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
@@ -245,6 +245,7 @@ func assertCurrentDeviceRevoked(tc libkb.TestContext) {
 	// secret store (if possible).
 	fu := NewFakeUserOrBust(tc.T, "dpr")
 	arg := MakeTestSignupEngineRunArg(fu)
+	arg.SkipPaper = false
 	arg.StoreSecret = tc.G.SecretStoreAll != nil
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),

--- a/go/engine/device_history_test.go
+++ b/go/engine/device_history_test.go
@@ -14,7 +14,7 @@ func TestDeviceHistoryBasic(t *testing.T) {
 	tc := SetupEngineTest(t, "devhist")
 	defer tc.Cleanup()
 
-	CreateAndSignupFakeUser(tc, "dhst")
+	CreateAndSignupFakeUserPaper(tc, "dhst")
 
 	ctx := &Context{}
 	eng := NewDeviceHistorySelf(tc.G)
@@ -62,7 +62,7 @@ func TestDeviceHistoryRevoked(t *testing.T) {
 	tc := SetupEngineTest(t, "devhist")
 	defer tc.Cleanup()
 
-	u := CreateAndSignupFakeUser(tc, "dhst")
+	u := CreateAndSignupFakeUserPaper(tc, "dhst")
 
 	ctx := &Context{}
 	eng := NewDeviceHistorySelf(tc.G)

--- a/go/engine/devlist_test.go
+++ b/go/engine/devlist_test.go
@@ -9,7 +9,7 @@ func TestDeviceList(t *testing.T) {
 	tc := SetupEngineTest(t, "devicelist")
 	defer tc.Cleanup()
 
-	CreateAndSignupFakeUser(tc, "login")
+	CreateAndSignupFakeUserPaper(tc, "login")
 
 	ctx := &Context{LogUI: tc.G.UI.GetLogUI()}
 	eng := NewDevList(tc.G)

--- a/go/engine/fakeusers_test.go
+++ b/go/engine/fakeusers_test.go
@@ -256,8 +256,55 @@ func createFakeUserWithPGPSibkey(tc libkb.TestContext) *FakeUser {
 	return fu
 }
 
+func createFakeUserWithPGPSibkeyPaper(tc libkb.TestContext) *FakeUser {
+	fu := CreateAndSignupFakeUserPaper(tc, "pgp")
+
+	arg := PGPKeyImportEngineArg{
+		Gen: &libkb.PGPGenArg{
+			PrimaryBits: 768,
+			SubkeyBits:  768,
+		},
+	}
+	arg.Gen.MakeAllIds()
+	ctx := Context{
+		LogUI:    tc.G.UI.GetLogUI(),
+		SecretUI: fu.NewSecretUI(),
+	}
+	eng := NewPGPKeyImportEngine(arg)
+	err := RunEngine(eng, &ctx)
+	if err != nil {
+		tc.T.Fatal(err)
+	}
+	return fu
+}
+
 func createFakeUserWithPGPSibkeyPushed(tc libkb.TestContext) *FakeUser {
 	fu := CreateAndSignupFakeUser(tc, "pgp")
+
+	arg := PGPKeyImportEngineArg{
+		Gen: &libkb.PGPGenArg{
+			PrimaryBits: 768,
+			SubkeyBits:  768,
+		},
+		PushSecret: true,
+		NoSave:     true,
+		Ctx:        tc.G,
+	}
+	arg.Gen.MakeAllIds()
+	ctx := Context{
+		LogUI:    tc.G.UI.GetLogUI(),
+		SecretUI: fu.NewSecretUI(),
+	}
+	eng := NewPGPKeyImportEngine(arg)
+	err := RunEngine(eng, &ctx)
+	if err != nil {
+		tc.T.Fatal(err)
+	}
+	return fu
+}
+
+func createFakeUserWithPGPSibkeyPushedPaper(tc libkb.TestContext) *FakeUser {
+	fu := CreateAndSignupFakeUserPaper(tc, "pgp")
 
 	arg := PGPKeyImportEngineArg{
 		Gen: &libkb.PGPGenArg{

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -155,7 +155,7 @@ func TestProvisionDesktop(t *testing.T) {
 	defer tcY.Cleanup()
 
 	// provisioner needs to be logged in
-	userX := CreateAndSignupFakeUser(tcX, "login")
+	userX := CreateAndSignupFakeUserPaper(tcX, "login")
 	var secretX kex2.Secret
 	if _, err := rand.Read(secretX[:]); err != nil {
 		t.Fatal(err)
@@ -244,7 +244,7 @@ func TestProvisionMobile(t *testing.T) {
 	defer tcY.Cleanup()
 
 	// provisioner needs to be logged in
-	userX := CreateAndSignupFakeUser(tcX, "login")
+	userX := CreateAndSignupFakeUserPaper(tcX, "login")
 	var secretX kex2.Secret
 	if _, err := rand.Read(secretX[:]); err != nil {
 		t.Fatal(err)
@@ -546,6 +546,7 @@ func TestProvisionPaper(t *testing.T) {
 	defer tc.Cleanup()
 	fu := NewFakeUserOrBust(t, "paper")
 	arg := MakeTestSignupEngineRunArg(fu)
+	arg.SkipPaper = false
 	loginUI := &paperLoginUI{Username: fu.Username}
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
@@ -655,6 +656,7 @@ func TestProvisionPaperCommandLine(t *testing.T) {
 	defer tc.Cleanup()
 	fu := NewFakeUserOrBust(t, "paper")
 	arg := MakeTestSignupEngineRunArg(fu)
+	arg.SkipPaper = false
 	loginUI := &paperLoginUI{Username: fu.Username}
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
@@ -1402,6 +1404,7 @@ func userPlusPaper(t *testing.T) (*FakeUser, string) {
 	defer tc.Cleanup()
 	fu := NewFakeUserOrBust(t, "fake")
 	arg := MakeTestSignupEngineRunArg(fu)
+	arg.SkipPaper = false
 	loginUI := &paperLoginUI{Username: fu.Username}
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
@@ -1535,7 +1538,7 @@ func TestProvisionKexUseSyncPGP(t *testing.T) {
 	defer tcY.Cleanup()
 
 	// create provisioner with synced pgp key
-	userX := createFakeUserWithPGPSibkeyPushed(tcX)
+	userX := createFakeUserWithPGPSibkeyPushedPaper(tcX)
 	var secretX kex2.Secret
 	if _, err := rand.Read(secretX[:]); err != nil {
 		t.Fatal(err)
@@ -2037,7 +2040,7 @@ func TestProvisionWithBadConfig(t *testing.T) {
 	defer tcY.Cleanup()
 
 	// provisioner needs to be logged in
-	userX := CreateAndSignupFakeUser(tcX, "login")
+	userX := CreateAndSignupFakeUserPaper(tcX, "login")
 	var secretX kex2.Secret
 	if _, err := rand.Read(secretX[:]); err != nil {
 		t.Fatal(err)

--- a/go/engine/paperkey_submit_test.go
+++ b/go/engine/paperkey_submit_test.go
@@ -21,6 +21,7 @@ func TestPaperKeySubmit(t *testing.T) {
 	// signup and get the paper key
 	fu := NewFakeUserOrBust(t, "paper")
 	arg := MakeTestSignupEngineRunArg(fu)
+	arg.SkipPaper = false
 	loginUI := &paperLoginUI{Username: fu.Username}
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),

--- a/go/engine/paperkey_test.go
+++ b/go/engine/paperkey_test.go
@@ -154,7 +154,7 @@ func TestPaperKeyNoRevoke(t *testing.T) {
 	tc := SetupEngineTest(t, "backup")
 	defer tc.Cleanup()
 
-	fu := CreateAndSignupFakeUser(tc, "login")
+	fu := CreateAndSignupFakeUserPaper(tc, "login")
 
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),

--- a/go/engine/revoke_sigs_test.go
+++ b/go/engine/revoke_sigs_test.go
@@ -15,7 +15,7 @@ func TestRevokeSig(t *testing.T) {
 	defer tc.Cleanup()
 
 	// The PGP key is the 5th signature in the user's chain.
-	u := createFakeUserWithPGPSibkey(tc)
+	u := createFakeUserWithPGPSibkeyPaper(tc)
 	assertNumDevicesAndKeys(tc, u, 2, 5)
 
 	secui := &libkb.TestSecretUI{Passphrase: u.Passphrase}

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -69,7 +69,7 @@ func TestRevokeDevice(t *testing.T) {
 	tc := SetupEngineTest(t, "rev")
 	defer tc.Cleanup()
 
-	u := CreateAndSignupFakeUser(tc, "rev")
+	u := CreateAndSignupFakeUserPaper(tc, "rev")
 
 	assertNumDevicesAndKeys(tc, u, 2, 4)
 
@@ -102,7 +102,7 @@ func TestRevokeKey(t *testing.T) {
 	tc := SetupEngineTest(t, "rev")
 	defer tc.Cleanup()
 
-	u := createFakeUserWithPGPSibkey(tc)
+	u := createFakeUserWithPGPSibkeyPaper(tc)
 
 	assertNumDevicesAndKeys(tc, u, 2, 5)
 

--- a/go/engine/saltpack_decrypt_test.go
+++ b/go/engine/saltpack_decrypt_test.go
@@ -275,7 +275,7 @@ func TestSaltpackNoEncryptionForDevice(t *testing.T) {
 	defer tcZ.Cleanup()
 
 	// provisioner needs to be logged in
-	userX := CreateAndSignupFakeUser(tcX, "naclp")
+	userX := CreateAndSignupFakeUserPaper(tcX, "naclp")
 	var secretX kex2.Secret
 	if _, err := rand.Read(secretX[:]); err != nil {
 		t.Fatal(err)

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -240,6 +240,6 @@ func TestSignupGeneratesPaperKey(t *testing.T) {
 	tc := SetupEngineTest(t, "signup")
 	defer tc.Cleanup()
 
-	fu := CreateAndSignupFakeUser(tc, "se")
+	fu := CreateAndSignupFakeUserPaper(tc, "se")
 	hasOnePaperDev(tc, fu)
 }

--- a/go/engine/user_test.go
+++ b/go/engine/user_test.go
@@ -13,7 +13,7 @@ func TestLoadUserPlusKeysHasKeys(t *testing.T) {
 	tc := SetupEngineTest(t, "user")
 	defer tc.Cleanup()
 
-	CreateAndSignupFakeUser(tc, "login")
+	CreateAndSignupFakeUserPaper(tc, "login")
 	me, err := libkb.LoadMe(libkb.NewLoadUserArg(tc.G))
 	if err != nil {
 		t.Fatal(err)
@@ -31,7 +31,7 @@ func TestLoadUserPlusKeysRevoked(t *testing.T) {
 	tc := SetupEngineTest(t, "login")
 	defer tc.Cleanup()
 
-	fu := CreateAndSignupFakeUser(tc, "login")
+	fu := CreateAndSignupFakeUserPaper(tc, "login")
 	me, err := libkb.LoadMe(libkb.NewLoadUserArg(tc.G))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
To speed up tests.  20% reduction in overall engine test time with this.

r? @maxtaco 