### PR TITLE
Create a folder name with unique users (never dupe users)

### DIFF
--- a/shared/constants/config.js
+++ b/shared/constants/config.js
@@ -1,4 +1,5 @@
 /* @flow */
+import {uniq} from 'lodash'
 
 // Constants
 export const defaultKBFSPath = '/keybase'
@@ -21,9 +22,9 @@ export const devConfigUpdate = 'config:devConfigUpdate'
 export const devConfigSaved = 'config:devConfigSaved'
 
 export function privateFolderWithUsers (users: Array<string>): string {
-  return `${defaultKBFSPath}${defaultPrivatePrefix}${users.join(',')}`
+  return `${defaultKBFSPath}${defaultPrivatePrefix}${uniq(users).join(',')}`
 }
 
 export function publicFolderWithUsers (users: Array<string>): string {
-  return `${defaultKBFSPath}${defaultPublicPrefix}${users.join(',')}`
+  return `${defaultKBFSPath}${defaultPublicPrefix}${uniq(users).join(',')}`
 }


### PR DESCRIPTION
@keybase/react-hackers 

This is useful as an extra safety check to make sure we don't accidentally try to open `marcopolo,marcopolo,cjb`

Also simplifies logic for opening shared private folders in search.

#### Example:
Say they select cjb in search and hit open shared private folder, that turns into open `/keybase/private/cjb,marcopolo`.

If they select cjb in search and themselves and then hit open shared private folder we have to either:

1. Always remove ourself from the selected users list, and add ourselves back in.

1. Conditionally add/remove ourself from selected users list.

1. Or just not worry about it and let the transformation of `users -> path` function handle it (selected choice).