### PR TITLE
☠ Unify react-native Android and iOS bundles

### DIFF
--- a/react-native/android/app/react.gradle
+++ b/react-native/android/app/react.gradle
@@ -2,8 +2,8 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 def config = project.hasProperty("react") ? project.react : [];
 
-def bundleAssetName = config.bundleAssetName ?: "index.android.bundle"
-def entryFile = config.entryFile ?: "index.android.js"
+def bundleAssetName = config.bundleAssetName ?: "index.native.bundle"
+def entryFile = config.entryFile ?: "shared/index.native.js"
 
 // because elvis operator
 def elvisFile(thing) {

--- a/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -55,6 +55,17 @@ public class MainActivity extends ReactActivity {
     }
 
     /**
+     * Returns the name of the bundle in assets. If this is null, and no file path is specified for
+     * the bundle, the app will only work with {@code getUseDeveloperSupport} enabled and will
+     * always try to load the JS bundle from the packager server.
+     * e.g. "index.android.bundle"
+     */
+    @Override
+    protected String getBundleAssetName() {
+        return "index.native.bundle";
+    }
+
+    /**
      * Returns whether dev mode should be enabled.
      * This enables e.g. the dev menu.
      */

--- a/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -47,6 +47,14 @@ public class MainActivity extends ReactActivity {
     }
 
     /**
+     * Returns the location of the JavaScript entry file.
+     */
+    @Override
+    protected String getJSMainModuleName() {
+        return "shared/index.native";
+    }
+
+    /**
      * Returns whether dev mode should be enabled.
      * This enables e.g. the dev menu.
      */

--- a/react-native/index.android.js
+++ b/react-native/index.android.js
@@ -1,2 +1,0 @@
-// React-native tooling assumes this file is here, so we just require our real entry point
-require('./shared')

--- a/react-native/index.ios.js
+++ b/react-native/index.ios.js
@@ -1,2 +1,0 @@
-// React-native tooling assumes this file is here, so we just require our real entry point
-require('./shared')

--- a/react-native/ios/Keybase.xcodeproj/project.pbxproj
+++ b/react-native/ios/Keybase.xcodeproj/project.pbxproj
@@ -716,7 +716,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/packager/react-native-xcode.sh";
+			shellScript = "export NODE_BINARY=node\n../react-native-xcode.sh";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/react-native/ios/Keybase/AppDelegate.swift
+++ b/react-native/ios/Keybase/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder {
 
       #if DEBUG
         if let reactHost = AppDefault.ReactHost.stringValue {
-          return NSURL(string: "http://\(reactHost)/shared/index.bundle?platform=ios&dev=true")
+          return NSURL(string: "http://\(reactHost)/shared/index.native.bundle?platform=ios&dev=true")
         } else {
           return NSBundle.mainBundle().URLForResource("main", withExtension: "jsbundle")
         }

--- a/react-native/react-native-xcode.sh
+++ b/react-native/react-native-xcode.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+# Bundle React Native app's code and image assets.
+# This script is supposed to be invoked as part of Xcode build process
+# and relies on environment variables (including PWD) set by Xcode
+
+case "$CONFIGURATION" in
+  Debug)
+    # Speed up build times by skipping the creation of the offline package for debug
+    # builds on the simulator since the packager is supposed to be running anyways.
+    if [[ "$PLATFORM_NAME" = "iphonesimulator" ]]; then
+      echo "Skipping bundling for Simulator platform"
+      exit 0;
+    fi
+
+    DEV=true
+    ;;
+  "")
+    echo "$0 must be invoked by Xcode"
+    exit 1
+    ;;
+  *)
+    DEV=false
+    ;;
+esac
+
+# Path to react-native folder inside node_modules
+REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Xcode project file for React Native apps is located in ios/ subfolder
+cd ..
+
+# Define NVM_DIR and source the nvm.sh setup script
+[ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
+
+if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+  . "$HOME/.nvm/nvm.sh"
+elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
+  . "$(brew --prefix nvm)/nvm.sh"
+fi
+
+# Set up the nodenv node version manager if present
+if [[ -x "$HOME/.nodenv/bin/nodenv" ]]; then
+  eval "$($HOME/.nodenv/bin/nodenv init -)"
+fi
+
+[ -z "$NODE_BINARY" ] && export NODE_BINARY="node"
+
+nodejs_not_found()
+{
+  echo "error: Can't find '$NODE_BINARY' binary to build React Native bundle" >&2
+  echo "If you have non-standard nodejs installation, select your project in Xcode," >&2
+  echo "find 'Build Phases' - 'Bundle React Native code and images'" >&2
+  echo "and change NODE_BINARY to absolute path to your node executable" >&2
+  echo "(you can find it by invoking 'which node' in the terminal)" >&2
+  exit 2
+}
+
+type $NODE_BINARY >/dev/null 2>&1 || nodejs_not_found
+
+# Print commands before executing them (useful for troubleshooting)
+set -x
+DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
+
+$NODE_BINARY "$REACT_NATIVE_DIR/local-cli/cli.js" bundle \
+  --entry-file shared/index.native.js \
+  --platform ios \
+  --dev $DEV \
+  --reset-cache true \
+  --bundle-output "$DEST/main.jsbundle" \
+  --assets-dest "$DEST"

--- a/shared/globals.native.js
+++ b/shared/globals.native.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-native-reassign */
+
+// __DEV__
+//  set by react-native to true if the app is being run in a simulator, false otherwise
+
+// __PROD__
+//  set opposite of __DEV__
+
+// __SCREENSHOT__
+//  indicates if the execution environment is visdiff
+//  set to false if it isn't already set
+if (typeof __SCREENSHOT__ === 'undefined') {
+  __SCREENSHOT__ = false
+}

--- a/shared/index.native.js
+++ b/shared/index.native.js
@@ -1,3 +1,4 @@
+import './globals'
 import React, {Component} from 'react'
 import {AppRegistry, NativeAppEventEmitter, AsyncStorage} from 'react-native'
 import {Provider} from 'react-redux'


### PR DESCRIPTION
- Directly use shared/index.native.js for both OSs
- Add shared/globals.native to provide expected global values (such as __SCREENSHOT__)