### PR TITLE
protocol: add an OVER_QUOTA fs error type

### DIFF
--- a/go/protocol/kbfs_common.go
+++ b/go/protocol/kbfs_common.go
@@ -39,6 +39,7 @@ const (
 	FSErrorType_BAD_FOLDER            FSErrorType = 6
 	FSErrorType_NOT_IMPLEMENTED       FSErrorType = 7
 	FSErrorType_OLD_VERSION           FSErrorType = 8
+	FSErrorType_OVER_QUOTA            FSErrorType = 9
 )
 
 type FSNotification struct {

--- a/protocol/avdl/kbfs_common.avdl
+++ b/protocol/avdl/kbfs_common.avdl
@@ -26,7 +26,8 @@ protocol kbfsCommon {
     REKEY_NEEDED_5,
     BAD_FOLDER_6,
     NOT_IMPLEMENTED_7,
-    OLD_VERSION_8
+    OLD_VERSION_8,
+    OVER_QUOTA_9
   }
 
   record FSNotification {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -229,6 +229,7 @@ export type FSErrorType =
   | 6 // BAD_FOLDER_6
   | 7 // NOT_IMPLEMENTED_7
   | 8 // OLD_VERSION_8
+  | 9 // OVER_QUOTA_9
 
 export type FSNotification = {
   publicTopLevelFolder: boolean;

--- a/protocol/js/keybase-v1.js
+++ b/protocol/js/keybase-v1.js
@@ -236,6 +236,7 @@ export const kbfsCommon = {
     'badFolder': 6,
     'notImplemented': 7,
     'oldVersion': 8,
+    'overQuota': 9,
   },
 }
 

--- a/protocol/json/kbfs_common.json
+++ b/protocol/json/kbfs_common.json
@@ -36,7 +36,8 @@
         "REKEY_NEEDED_5",
         "BAD_FOLDER_6",
         "NOT_IMPLEMENTED_7",
-        "OLD_VERSION_8"
+        "OLD_VERSION_8",
+        "OVER_QUOTA_9"
       ]
     },
     {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -229,6 +229,7 @@ export type FSErrorType =
   | 6 // BAD_FOLDER_6
   | 7 // NOT_IMPLEMENTED_7
   | 8 // OLD_VERSION_8
+  | 9 // OVER_QUOTA_9
 
 export type FSNotification = {
   publicTopLevelFolder: boolean;

--- a/shared/constants/types/keybase-v1.js
+++ b/shared/constants/types/keybase-v1.js
@@ -236,6 +236,7 @@ export const kbfsCommon = {
     'badFolder': 6,
     'notImplemented': 7,
     'oldVersion': 8,
+    'overQuota': 9,
   },
 }
 


### PR DESCRIPTION
r @cjb @chrisnojima?

Context: 
For KBFS-1110 we will add an "error" notification for being over quota.  This is not truly an error, since the writes still succeed, but the user is slowed down until they free enough data to get them back under the quota.

We might want @malgorithms to write a better user-facing error message that the UI can substitute in.  Right now I have `fmt.Sprintf("You are using %d bytes, and your plan limits you to %d bytes.  Please delete some data.", w.UsageBytes, w.LimitBytes)` in my KBFS branch.

Let me know if you want me to make a JIRA issue for handling this in the UI.

Issue: KBFS-1110