### PR TITLE
Prompt for uninstalling old CLI instead of doing so automatically wit…

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -1,31 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-	<Product Id="*" Name="Keybase Update" Language="1033" Version="$(env.KEYBASE_WINVER)" Manufacturer="Keybase, Inc." UpgradeCode="c118f7ec-9a1d-4ff1-91f5-15d208499d7b">
+	<Product Id="*" Name="Keybase Apps" Language="1033" Version="$(env.KEYBASE_WINVER)" Manufacturer="Keybase, Inc." UpgradeCode="c118f7ec-9a1d-4ff1-91f5-15d208499d7b">
 		<Package InstallerVersion="500" Compressed="yes" InstallPrivileges="limited" InstallScope="perUser" />
     <MediaTemplate EmbedCab="yes"/>
     <Icon Id="ProductIcon" SourceFile="$(env.GOPATH)\src\github.com\keybase\client\packaging\windows\keybase.ico"/>
     <Property Id="ARPPRODUCTICON" Value="ProductIcon"/>
     <Property Id="ARPHELPLINK" Value="https://www.keybase.io"/>
     <Property Id="ARPURLINFOABOUT" Value="https://www.keybase.io"/>
-    <Property Id="INNOCLIUNINSTALL">
-      <RegistrySearch Id="InnoCLIUninstall"
-                      Root="HKLM"
-                      Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\{70E747DE-4E09-44B0-ACAD-784AA9D79C02}_is1"
-                      Name="UninstallString"
-                      Type="raw" />
-    </Property>
-    <Property Id="DOKANUNINSTALL">
-      <RegistrySearch Id="DokanUninstall86"
-                      Root="HKLM"
-                      Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\{65A3A986-3DC3-0100-0000-160310102248}"
-                      Name="UninstallString"
-                      Type="raw" />
-      <RegistrySearch Id="DokanUninstall64"
-                      Root="HKLM"
-                      Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\{65A3A964-3DC3-0100-0000-160310102248}"
-                      Name="UninstallString"
-                      Type="raw" />
-    </Property>
+
     
     <MajorUpgrade DowngradeErrorMessage="A newer version of Keybase is already installed." AllowSameVersionUpgrades="yes"  />		
 
@@ -48,29 +30,6 @@
       <Custom Action="RunGUI" Before="InstallFinalize">NOT (REMOVE ~= "ALL")</Custom>
     </InstallExecuteSequence>
 
-    <UI>
-      <Property Id="DefaultUIFont">DlgFont8</Property>
-      
-      <Dialog Id="MyCancelDlg" Width="260" Height="85" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="No" Type="PushButton" X="132" Y="57" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_No]">
-          <Publish Event="EndDialog" Value="Exit">1</Publish>
-        </Control>
-        <Control Id="Yes" Type="PushButton" X="72" Y="57" Width="56" Height="17" Text="[ButtonText_Yes]">
-          <Publish Event="EndDialog" Value="Return">1</Publish>
-        </Control>
-        <Control Id="Text" Type="Text" X="48" Y="15" Width="194" Height="30">
-          <Text>Previous [ProductName] components need to be uninstalled before proceeding. Continue?</Text>
-        </Control>
-        <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="Information icon" FixedSize="yes" IconSize="32" Text="[InfoIcon]" />
-      </Dialog>
-
-      <TextStyle Id="DlgFont8" FaceName="Tahoma" Size="8" />
-      <TextStyle Id="DlgTitleFont" FaceName="Tahoma" Size="8" Bold="yes" />
-
-      <InstallUISequence>
-        <Show Dialog="MyCancelDlg" After="CostFinalize">(NOT Installed) AND INNOCLIUNINSTALL</Show>
-      </InstallUISequence>
-    </UI>
 
     <Property Id="Setup">Setup</Property>
     <Property Id="ButtonText_No">&amp;No</Property>

--- a/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
@@ -7,6 +7,8 @@
     <Variable Name="DokanProduct86" Type="string" Value="{65A3A986-3DC3-0100-0000-160621082245}" />
     <Log PathVariable="LOGPATH_PROP"/>
     <util:FileSearchRef Id='WINTRUST_FileSearch' />
+    <util:RegistrySearchRef Id='InnoCLIUninstall' />
+    <util:RegistrySearchRef Id='InnoCLIUninstall64' />
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
       <bal:WixStandardBootstrapperApplication
             LicenseUrl="https://keybase.io/docs/terms"
@@ -76,26 +78,6 @@
                  Format="raw"
                  Win64="yes"
                  />
-    <!-- For the Inno command line client -->
-    <util:RegistrySearch Id="InnoCLIUninstall"
-                 After="InnoUninstall364"                         
-                 Variable="InnoUninstallString"
-                 Condition="NOT InnoUninstallString"
-                 Root="HKLM"
-                 Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{70E747DE-4E09-44B0-ACAD-784AA9D79C02}_is1"
-                 Value="QuietUninstallString"
-                 Format="raw"
-                 />
-    <util:RegistrySearch Id="InnoCLIUninstall64"
-                 After="InnoCLIUninstall"
-                 Condition="NOT InnoUninstallString"
-                 Variable="InnoUninstallString"
-                 Root="HKLM"
-                 Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{70E747DE-4E09-44B0-ACAD-784AA9D79C02}_is1"
-                 Value="QuietUninstallString"
-                 Format="raw"
-                 Win64="yes"
-                 />
 
     <!-- Dokany Product Codes: v1.0.0-RC4.2 -->
     
@@ -157,9 +139,7 @@
 
 
     <Chain>
-      <!-- Run whatever quiet uninstaller we detected. With this hack, we can't distinguish
-           between CLI and KBFS, and must reboot regardless - another, custom MSI for cleanup
-           could get around this possibly. -->
+      <!-- Run whatever quiet uninstaller we detected. -->
       <ExePackage
         SourceFile="$(env.GOPATH)\src\github.com\keybase\client\go\tools\runquiet\runquiet.exe"
           InstallCommand="-wait [InnoUninstallString] /NORESTART"
@@ -188,19 +168,12 @@
       
       <MsiPackage Id="KeybasePrograms" 
                   SourceFile="$(var.KeybaseApps.TargetPath)" 
-                  DisplayInternalUI='yes'
+                  DisplayInternalUI='no'
                   Permanent="no">
       </MsiPackage>
 		</Chain>
 	</Bundle>
-  <Fragment>
-    <util:RegistrySearch
-          Id='SearchForThirdParty'
-          Variable="ThirdPartyCOMLibraryInstalled"
-          Result="exists"
-          Root="HKLM"
-          Key="SOFTWARE\Classes\ThirdPartyId.Server\CLSID" />
-    
+  <Fragment>    
     <util:FileSearch Id="WINTRUST_FileSearch"
                      Path="[SystemFolder]Wintrust.dll"
                      Variable="WINTRUSTVERSION"
@@ -211,4 +184,28 @@
       <![CDATA[Installed OR VersionNT > v6.1 OR (VersionNT = v6.1 AND WINTRUSTVERSION >= v6.1.7601.18741)]]>
     </bal:Condition>
   </Fragment>
+  <Fragment>
+    <util:RegistrySearch
+          Id='InnoCLIUninstall'
+          Variable="InnoCLIInstalled"
+          Result="exists"
+          Root="HKLM"
+          Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\{70E747DE-4E09-44B0-ACAD-784AA9D79C02}_is1"
+          Value="UninstallString" />
+
+    <util:RegistrySearch
+          Id='InnoCLIUninstall64'
+          Variable="InnoCLIInstalled64"
+          Result="exists"
+          Root="HKLM"
+          Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\{70E747DE-4E09-44B0-ACAD-784AA9D79C02}_is1"
+          Value="UninstallString" 
+          Win64="yes"/>
+
+    <bal:Condition
+      Message="Please uninstall any previous Keybase versions before continuing.">
+      <![CDATA[NOT InnoCLIInstalled AND NOT InnoCLIInstalled64]]>
+    </bal:Condition>
+  </Fragment>
+
 </Wix>


### PR DESCRIPTION
…h reboot

This case was covered before, or so I thought, with a rule requiring reboot, but there are reports of messed up installs where the CLI isn't removed properly. This way is more explicit and less error prone, and doesn't add the extra reboot.

I've been testing this all day so if someone wants to give thumbs I can put it out there @maxtaco @gabriel 