### PR TITLE
Add debounced "as-you-type" search to Search tab DESKTOP-1331

### DIFF
--- a/shared/constants/search.js
+++ b/shared/constants/search.js
@@ -60,7 +60,7 @@ export const search = 'search:search'
 export type Search = TypedAction<'search:search', {term: string}, void>
 
 export const results = 'search:results'
-export type Results = TypedAction<'search:results', {term: string, results: Array<SearchResult>}, void>
+export type Results = TypedAction<'search:results', {term: string, results: Array<SearchResult>, requestTimestamp: Date}, void>
 
 export const selectPlatform = 'search:selectPlatform'
 export type SelectPlatform = TypedAction<'search:selectPlatform', {platform: SearchPlatforms}, void>

--- a/shared/reducers/search.js
+++ b/shared/reducers/search.js
@@ -13,6 +13,7 @@ export type State = {
   searchIcon: IconProps.type,
   searchPlatform: ?SearchPlatforms,
   results: Array<SearchResult>,
+  requestTimestamp: ?Date,
   selectedUsers: Array<SearchResult>,
   userForInfoPane: ?SearchResult,
   showUserGroup: boolean,
@@ -25,6 +26,7 @@ const initialState: State = {
   searchPlatform: 'Keybase',
   selectedUsers: [],
   results: [],
+  requestTimestamp: null,
   userForInfoPane: null,
   showUserGroup: false,
 }
@@ -105,9 +107,14 @@ export default function (state: State = initialState, action: SearchActions): St
           return state
         }
 
+        if (state.requestTimestamp && action.payload.requestTimestamp < state.requestTimestamp) {
+          return state
+        }
+
         return {
           ...state,
           results: action.payload.results,
+          requestTimestamp: action.payload.requestTimestamp,
         }
       }
       break

--- a/shared/search/user-search/render.desktop.js
+++ b/shared/search/user-search/render.desktop.js
@@ -1,5 +1,6 @@
 // @flow
 import React, {Component} from 'react'
+import _ from 'lodash'
 import {Text} from '../../common-adapters'
 
 import {Avatar, Box, Icon, Input} from '../../common-adapters'
@@ -143,13 +144,20 @@ function ServiceIcon ({serviceName, tooltip, iconType, selected, onClickService}
 
 export type SearchBarProps = {
   selectedService: ?SearchPlatforms,
-  onSearch: (term: string) => void,
+  onSearch: (term: string, platform?: ?SearchPlatforms) => void,
   searchText: ?string,
   searchHintText: string,
   onClickService: (service: SearchPlatforms) => void,
 }
 
 export class SearchBar extends Component<void, SearchBarProps, void> {
+  _onDebouncedSearch: (overridePlatform?: SearchPlatforms) => void;
+
+  constructor (props: SearchBarProps) {
+    super(props)
+    this._onDebouncedSearch = _.debounce(this._onSearch, 500)
+  }
+
   componentWillReceiveProps (nextProps: SearchBarProps) {
     if (nextProps.searchText === null && nextProps.searchText !== this.props.searchText) {
       this.refs && this.refs.searchBox && this.refs.searchBox.clearValue()
@@ -209,6 +217,7 @@ export class SearchBar extends Component<void, SearchBarProps, void> {
           type='text'
           ref='searchBox'
           onEnterKeyDown={() => this._onSearch()}
+          onChange={() => this._onDebouncedSearch()}
           value={this.props.searchText}
           hintText={this.props.searchHintText}
           style={styles.input}


### PR DESCRIPTION
Provides debounced (500 ms delay) searching to a user search as input is being typed. This also timestamps each search request to ensure that older, yet longer running, requests don't overwrite the data of more recent searches.

@keybase/react-hackers 