### PR TITLE
allow app-startup-mode to be specified on CLI or in env

### DIFF
--- a/go/client/fork_server.go
+++ b/go/client/fork_server.go
@@ -18,12 +18,12 @@ import (
 func GetExtraFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.BoolFlag{
-			Name:  "no-auto-fork, F",
-			Usage: "Disable auto-fork of background service.",
-		},
-		cli.BoolFlag{
 			Name:  "auto-fork",
 			Usage: "Enable auto-fork of background service.",
+		},
+		cli.BoolFlag{
+			Name:  "no-auto-fork, F",
+			Usage: "Disable auto-fork of background service.",
 		},
 	}
 }

--- a/go/install/install.go
+++ b/go/install/install.go
@@ -34,7 +34,7 @@ type Context interface {
 	GetMountDir() (string, error)
 	GetRunMode() libkb.RunMode
 	GetServiceInfoPath() string
-	GetAppStartMode() libkb.AppStartMode
+	GetAppStartMode() (libkb.AppStartMode, error)
 }
 
 // ComponentName defines a component name

--- a/go/install/install_osx.go
+++ b/go/install/install_osx.go
@@ -784,8 +784,12 @@ func RunAfterStartup(context Context, isService bool, log Log) error {
 	if context.GetRunMode() != libkb.ProductionRunMode {
 		return nil
 	}
-	log.Debug("App start mode: %s", context.GetAppStartMode())
-	switch context.GetAppStartMode() {
+	mode, err := context.GetAppStartMode()
+	if err != nil {
+		log.Errorf("Error getting app start mode: %s", err)
+	}
+	log.Debug("App start mode: %s", mode)
+	switch mode {
 	case libkb.AppStartModeService:
 		if !isService {
 			return nil

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -260,6 +260,10 @@ func (p CommandLine) GetMountDir() string {
 	return p.GetGString("mountdir")
 }
 
+func (p CommandLine) GetAppStartMode() libkb.AppStartMode {
+	return libkb.ParseAppStartMode(p.GetGString("app-start-mode"))
+}
+
 func (p CommandLine) GetBool(s string, glbl bool) (bool, bool) {
 	var v bool
 	if glbl {
@@ -341,6 +345,10 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 		cli.StringFlag{
 			Name:  "api-uri-path-prefix",
 			Usage: "Specify an alternate API URI path prefix.",
+		},
+		cli.StringFlag{
+			Name:  "app-start-mode",
+			Usage: "specify 'service' to auto-start UI app, or anything else to disable",
 		},
 		cli.StringFlag{
 			Name:  "push-server-uri",

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -260,8 +260,8 @@ func (p CommandLine) GetMountDir() string {
 	return p.GetGString("mountdir")
 }
 
-func (p CommandLine) GetAppStartMode() libkb.AppStartMode {
-	return libkb.ParseAppStartMode(p.GetGString("app-start-mode"))
+func (p CommandLine) GetAppStartMode() string {
+	return p.GetGString("app-start-mode")
 }
 
 func (p CommandLine) GetBool(s string, glbl bool) (bool, bool) {
@@ -318,29 +318,13 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 	app.Usage = "Keybase command line client."
 
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:  "home, H",
-			Usage: "Specify an (alternate) home directory.",
+		cli.BoolFlag{
+			Name:  "api-dump-unsafe",
+			Usage: "Dump API call internals (may leak secrets).",
 		},
 		cli.StringFlag{
-			Name:  "server, s",
-			Usage: "Specify server API.",
-		},
-		cli.StringFlag{
-			Name:  "config-file, c",
-			Usage: "Specify an (alternate) master config file.",
-		},
-		cli.StringFlag{
-			Name:  "updater-config-file",
-			Usage: "Specify a path to the updater config file",
-		},
-		cli.StringFlag{
-			Name:  "session-file",
-			Usage: "Specify an alternate session data file.",
-		},
-		cli.StringFlag{
-			Name:  "db",
-			Usage: "Specify an alternate local DB location.",
+			Name:  "api-timeout",
+			Usage: "set the HTTP timeout for API calls to the keybase API server",
 		},
 		cli.StringFlag{
 			Name:  "api-uri-path-prefix",
@@ -348,83 +332,23 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 		},
 		cli.StringFlag{
 			Name:  "app-start-mode",
-			Usage: "specify 'service' to auto-start UI app, or anything else to disable",
-		},
-		cli.StringFlag{
-			Name:  "push-server-uri",
-			Usage: "specify a URI for contacting the Keybase push server",
-		},
-		cli.BoolFlag{
-			Name:  "push-disabled",
-			Usage: "disable push server connection (which is on by default)",
-		},
-		cli.IntFlag{
-			Name:  "push-save-interval",
-			Usage: "set the interval between saves of the push cache (in seconds)",
-		},
-		cli.StringFlag{
-			Name:  "pinentry",
-			Usage: "Specify a path to find a pinentry program.",
-		},
-		cli.StringFlag{
-			Name:  "secret-keyring",
-			Usage: "Location of the Keybase secret-keyring (P3SKB-encoded).",
-		},
-		cli.StringFlag{
-			Name:  "socket-file",
-			Usage: "Location of the keybased socket-file.",
-		},
-		cli.StringFlag{
-			Name:  "pid-file",
-			Usage: "Location of the keybased pid-file (to ensure only one running daemon).",
-		},
-		cli.StringFlag{
-			Name:  "proxy",
-			Usage: "Specify an HTTP(s) proxy to ship all Web requests over.",
-		},
-		cli.BoolFlag{
-			Name:  "debug, d",
-			Usage: "Enable debugging mode.",
-		},
-		cli.BoolFlag{
-			Name:  "no-debug",
-			Usage: "Suppress debugging mode; takes precedence over --debug.",
-		},
-		cli.StringFlag{
-			Name:  "vdebug",
-			Usage: "Verbose debugging; takes a comma-joined list of levels and tags",
-		},
-		cli.StringFlag{
-			Name:  "run-mode",
-			Usage: "Run mode (devel, staging, prod).", // These are defined in libkb/constants.go
-		},
-		cli.StringFlag{
-			Name:  "log-format",
-			Usage: "Log format (default, plain, file, fancy).",
-		},
-		cli.StringFlag{
-			Name:  "pgpdir, gpgdir",
-			Usage: "Specify a PGP directory (default is ~/.gnupg).",
-		},
-		cli.BoolFlag{
-			Name:  "api-dump-unsafe",
-			Usage: "Dump API call internals (may leak secrets).",
-		},
-		cli.StringFlag{
-			Name:  "merkle-kids",
-			Usage: "Set of admissable Merkle Tree fingerprints (colon-separated).",
+			Usage: "Specify 'service' to auto-start UI app, or anything else to disable",
 		},
 		cli.StringFlag{
 			Name:  "code-signing-kids",
 			Usage: "Set of code signing key IDs (colon-separated).",
 		},
-		cli.IntFlag{
-			Name:  "user-cache-size",
-			Usage: "Number of User entries to cache.",
+		cli.StringFlag{
+			Name:  "config-file, c",
+			Usage: "Specify an (alternate) master config file.",
 		},
-		cli.IntFlag{
-			Name:  "proof-cache-size",
-			Usage: "Number of proof entries to cache.",
+		cli.StringFlag{
+			Name:  "db",
+			Usage: "Specify an alternate local DB location.",
+		},
+		cli.BoolFlag{
+			Name:  "debug, d",
+			Usage: "Enable debugging mode.",
 		},
 		cli.StringFlag{
 			Name:  "gpg",
@@ -434,9 +358,9 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 			Name:  "gpg-options",
 			Usage: "Options to use when calling GPG.",
 		},
-		cli.BoolFlag{
-			Name:  "standalone",
-			Usage: "Use the client without any daemon support.",
+		cli.StringFlag{
+			Name:  "home, H",
+			Usage: "Specify an (alternate) home directory.",
 		},
 		cli.StringFlag{
 			Name:  "local-rpc-debug-unsafe",
@@ -447,16 +371,84 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 			Usage: "Specify a log file for the keybase service.",
 		},
 		cli.StringFlag{
-			Name:  "timers",
-			Usage: "Specify 'a' for API; 'r' for RPCs; and 'x' for eXternal API calls",
+			Name:  "log-format",
+			Usage: "Log format (default, plain, file, fancy).",
+		},
+		cli.StringFlag{
+			Name:  "merkle-kids",
+			Usage: "Set of admissable Merkle Tree fingerprints (colon-separated).",
+		},
+		cli.BoolFlag{
+			Name:  "no-debug",
+			Usage: "Suppress debugging mode; takes precedence over --debug.",
+		},
+		cli.StringFlag{
+			Name:  "pgpdir, gpgdir",
+			Usage: "Specify a PGP directory (default is ~/.gnupg).",
+		},
+		cli.StringFlag{
+			Name:  "pinentry",
+			Usage: "Specify a path to find a pinentry program.",
+		},
+		cli.StringFlag{
+			Name:  "pid-file",
+			Usage: "Location of the keybased pid-file (to ensure only one running daemon).",
+		},
+		cli.IntFlag{
+			Name:  "proof-cache-size",
+			Usage: "Number of proof entries to cache.",
+		},
+		cli.StringFlag{
+			Name:  "proxy",
+			Usage: "Specify an HTTP(s) proxy to ship all Web requests over.",
+		},
+		cli.BoolFlag{
+			Name:  "push-disabled",
+			Usage: "Disable push server connection (which is on by default)",
+		},
+		cli.IntFlag{
+			Name:  "push-save-interval",
+			Usage: "Set the interval between saves of the push cache (in seconds)",
+		},
+		cli.StringFlag{
+			Name:  "push-server-uri",
+			Usage: "Specify a URI for contacting the Keybase push server",
+		},
+		cli.StringFlag{
+			Name:  "run-mode",
+			Usage: "Run mode (devel, staging, prod).", // These are defined in libkb/constants.go
 		},
 		cli.StringFlag{
 			Name:  "scraper-timeout",
 			Usage: "set the HTTP timeout for external proof scrapers",
 		},
 		cli.StringFlag{
-			Name:  "api-timeout",
-			Usage: "set the HTTP timeout for API calls to the keybase API server",
+			Name:  "secret-keyring",
+			Usage: "Location of the Keybase secret-keyring (P3SKB-encoded).",
+		},
+		cli.StringFlag{
+			Name:  "server, s",
+			Usage: "Specify server API.",
+		},
+		cli.StringFlag{
+			Name:  "session-file",
+			Usage: "Specify an alternate session data file.",
+		},
+		cli.StringFlag{
+			Name:  "socket-file",
+			Usage: "Location of the keybased socket-file.",
+		},
+		cli.BoolFlag{
+			Name:  "standalone",
+			Usage: "Use the client without any daemon support.",
+		},
+		cli.StringFlag{
+			Name:  "timers",
+			Usage: "Specify 'a' for API; 'r' for RPCs; and 'x' for eXternal API calls",
+		},
+		cli.StringFlag{
+			Name:  "tor-hidden-address",
+			Usage: fmt.Sprintf("set TOR address of keybase server; defaults to %s", libkb.TorServerURI),
 		},
 		cli.StringFlag{
 			Name:  "tor-mode",
@@ -467,8 +459,16 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 			Usage: fmt.Sprintf("set TOR proxy; when Tor mode is on; defaults to %s when TOR is enabled", libkb.TorProxy),
 		},
 		cli.StringFlag{
-			Name:  "tor-hidden-address",
-			Usage: fmt.Sprintf("set TOR address of keybase server; defaults to %s", libkb.TorServerURI),
+			Name:  "updater-config-file",
+			Usage: "Specify a path to the updater config file",
+		},
+		cli.IntFlag{
+			Name:  "user-cache-size",
+			Usage: "Number of User entries to cache.",
+		},
+		cli.StringFlag{
+			Name:  "vdebug",
+			Usage: "Verbose debugging; takes a comma-joined list of levels and tags",
 		},
 	}
 	if extraFlags != nil {

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -676,10 +676,10 @@ func (f JSONConfigFile) IsAdmin() (bool, bool) {
 
 func (f JSONConfigFile) GetAppStartMode() AppStartMode {
 	s, isSet := f.GetStringAtPath("app_start_mode")
-	if s == "service" || !isSet {
-		return AppStartModeService
+	if !isSet {
+		return AppStartModeDefault
 	}
-	return AppStartModeDisabled
+	return ParseAppStartMode(s)
 }
 
 func (f JSONConfigFile) GetTimeAtPath(path string) keybase1.Time {

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -674,12 +674,9 @@ func (f JSONConfigFile) IsAdmin() (bool, bool) {
 	return f.GetBoolAtPath("is_admin")
 }
 
-func (f JSONConfigFile) GetAppStartMode() AppStartMode {
-	s, isSet := f.GetStringAtPath("app_start_mode")
-	if !isSet {
-		return AppStartModeDefault
-	}
-	return ParseAppStartMode(s)
+func (f JSONConfigFile) GetAppStartMode() string {
+	s, _ := f.GetStringAtPath("app_start_mode")
+	return s
 }
 
 func (f JSONConfigFile) GetTimeAtPath(path string) keybase1.Time {

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -428,6 +428,7 @@ const (
 type AppStartMode string
 
 const (
+	AppStartModeError    AppStartMode = "error"
 	AppStartModeDefault  AppStartMode = "default" // It will be "service" in most cases
 	AppStartModeDisabled AppStartMode = "disabled"
 	AppStartModeService  AppStartMode = "service" // Open app after service start

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -428,6 +428,7 @@ const (
 type AppStartMode string
 
 const (
-	AppStartModeDisabled AppStartMode = ""
+	AppStartModeDefault  AppStartMode = "default" // It will be "service" in most cases
+	AppStartModeDisabled AppStartMode = "disabled"
 	AppStartModeService  AppStartMode = "service" // Open app after service start
 )

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -69,7 +69,7 @@ func (n NullConfiguration) GetUpdateURL() string                          { retu
 func (n NullConfiguration) GetUpdateDisabled() (bool, bool)               { return false, false }
 func (n NullConfiguration) GetVDebugSetting() string                      { return "" }
 func (n NullConfiguration) GetLocalTrackMaxAge() (time.Duration, bool)    { return 0, false }
-func (n NullConfiguration) GetAppStartMode() AppStartMode                 { return AppStartModeDisabled }
+func (n NullConfiguration) GetAppStartMode() AppStartMode                 { return AppStartModeDefault }
 func (n NullConfiguration) GetGregorURI() string                          { return "" }
 func (n NullConfiguration) GetGregorSaveInterval() (time.Duration, bool)  { return 0, false }
 func (n NullConfiguration) GetGregorPingInterval() (time.Duration, bool)  { return 0, false }
@@ -1040,8 +1040,29 @@ func (e *Env) GetMountDir() (string, error) {
 	}
 }
 
+func ParseAppStartMode(s string) AppStartMode {
+	switch s {
+	case "":
+		return AppStartModeDefault
+	case "service":
+		return AppStartModeService
+	default:
+		return AppStartModeDisabled
+	}
+}
+
 func (e *Env) GetAppStartMode() AppStartMode {
-	return e.config.GetAppStartMode()
+	mode := e.cmd.GetAppStartMode()
+	if mode == AppStartModeDefault {
+		mode = ParseAppStartMode(os.Getenv("KEYBASE_APP_START_MODE"))
+		if mode == AppStartModeDefault {
+			mode = e.config.GetAppStartMode()
+		}
+	}
+	if mode == AppStartModeDefault {
+		mode = AppStartModeService
+	}
+	return mode
 }
 
 func (e *Env) GetServiceInfoPath() string {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -592,7 +592,7 @@ func (g *GlobalContext) CallLogoutHooks() {
 	}
 }
 
-func (g *GlobalContext) GetAppStartMode() AppStartMode {
+func (g *GlobalContext) GetAppStartMode() (AppStartMode, error) {
 	return g.Env.GetAppStartMode()
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -63,6 +63,7 @@ type CommandLine interface {
 	GetLocalRPCDebug() string
 	GetTimers() string
 	GetRunMode() (RunMode, error)
+	GetAppStartMode() AppStartMode
 
 	GetScraperTimeout() (time.Duration, bool)
 	GetAPITimeout() (time.Duration, bool)

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -63,7 +63,7 @@ type CommandLine interface {
 	GetLocalRPCDebug() string
 	GetTimers() string
 	GetRunMode() (RunMode, error)
-	GetAppStartMode() AppStartMode
+	GetAppStartMode() string
 
 	GetScraperTimeout() (time.Duration, bool)
 	GetAPITimeout() (time.Duration, bool)
@@ -166,7 +166,7 @@ type ConfigReader interface {
 	GetUpdateURL() string
 	GetUpdateDisabled() (bool, bool)
 	GetLocalTrackMaxAge() (time.Duration, bool)
-	GetAppStartMode() AppStartMode
+	GetAppStartMode() string
 	IsAdmin() (bool, bool)
 
 	GetTorMode() (TorMode, error)


### PR DESCRIPTION
- also change semantics, so that in a config file, `app_status_mode : ""` now means "default"
  which is "service"