### PR TITLE
Fix logic in user actions for broken tracker

### DIFF
--- a/shared/common-adapters/user-actions.desktop.js
+++ b/shared/common-adapters/user-actions.desktop.js
@@ -6,8 +6,8 @@ import {globalMargins} from '../styles/style-guide'
 import type {Props} from './user-actions'
 
 export default function UserActions ({trackerState, currentlyFollowing, style, onFollow, onUnfollow, onAcceptProofs}: Props) {
-  if (trackerState === proofNormal) {
-    if (currentlyFollowing) {
+  if (currentlyFollowing) {
+    if (trackerState === proofNormal) {
       return (
         <Box style={style}>
           <FollowButton following onUnfollow={onUnfollow} style={{marginRight: 0}} />
@@ -16,15 +16,15 @@ export default function UserActions ({trackerState, currentlyFollowing, style, o
     } else {
       return (
         <Box style={style}>
-          <FollowButton following={false} onFollow={onFollow} style={{marginRight: 0}} />
+          <Button type='Unfollow' label='Untrack' onClick={onUnfollow} style={{marginRight: globalMargins.xtiny}} />
+          <Button type='Follow' label='Accept' onClick={onAcceptProofs} style={{marginRight: 0}} />
         </Box>
       )
     }
   } else {
     return (
       <Box style={style}>
-        <Button type='Unfollow' label='Untrack' onClick={onUnfollow} style={{marginRight: globalMargins.xtiny}} />
-        <Button type='Follow' label='Accept' onClick={onAcceptProofs} style={{marginRight: 0}} />
+        <FollowButton following={false} onFollow={onFollow} style={{marginRight: 0}} />
       </Box>
     )
   }

--- a/shared/common-adapters/user-actions.native.js
+++ b/shared/common-adapters/user-actions.native.js
@@ -6,8 +6,8 @@ import {globalMargins} from '../styles/style-guide'
 import type {Props} from './user-actions'
 
 export default function UserActions ({trackerState, currentlyFollowing, style, onFollow, onUnfollow, onAcceptProofs}: Props) {
-  if (trackerState === proofNormal) {
-    if (currentlyFollowing) {
+  if (currentlyFollowing) {
+    if (trackerState === proofNormal) {
       return (
         <Box style={style}>
           <FollowButton following onUnfollow={onUnfollow} style={{marginRight: 0}} />
@@ -16,15 +16,15 @@ export default function UserActions ({trackerState, currentlyFollowing, style, o
     } else {
       return (
         <Box style={style}>
-          <FollowButton following={false} onFollow={onFollow} style={{marginRight: 0}} />
+          <Button type='Unfollow' label='Untrack' onClick={onUnfollow} style={{marginRight: globalMargins.xtiny}} />
+          <Button type='Follow' label='Accept' onClick={onAcceptProofs} style={{marginRight: 0}} />
         </Box>
       )
     }
   } else {
     return (
       <Box style={style}>
-        <Button type='Unfollow' label='Untrack' onClick={onUnfollow} style={{marginRight: globalMargins.xtiny}} />
-        <Button type='Follow' label='Accept' onClick={onAcceptProofs} style={{marginRight: 0}} />
+        <FollowButton following={false} onFollow={onFollow} style={{marginRight: 0}} />
       </Box>
     )
   }

--- a/shared/search/user-pane/dumb.desktop.js
+++ b/shared/search/user-pane/dumb.desktop.js
@@ -37,6 +37,18 @@ const dumbMapUser: DumbComponentMap<UserPane> = {
         },
       },
     },
+    'Broken tracker, not following': {
+      ...userPaneBase,
+      proofs: proofsChanged,
+      trackerState: error,
+      currentlyFollowing: false,
+      parentProps: {
+        style: {
+          width: 320,
+          height: 420,
+        },
+      },
+    },
     'Followed': {
       ...userPaneBase,
       proofs: proofsTracked,


### PR DESCRIPTION
@keybase/react-hackers 

Fixes logic in user actions.

We used to show the option to untrack or accept a broken tracker statement even if you weren't following them.

Now we show the follow prompt always if you aren't following them already, and the untrack/accept only if you are following them.