### PR TITLE
protocol change for TLF representation

### DIFF
--- a/go/protocol/rekey.go
+++ b/go/protocol/rekey.go
@@ -10,7 +10,7 @@ import (
 
 type TLFID string
 type TLF struct {
-	Tlfid     TLFID    `codec:"tlfid" json:"tlfid"`
+	Id        TLFID    `codec:"id" json:"id"`
 	Name      string   `codec:"name" json:"name"`
 	Writers   []string `codec:"writers" json:"writers"`
 	Readers   []string `codec:"readers" json:"readers"`

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -491,13 +491,20 @@ func (d *Service) SimulateGregorCrashForTesting() {
 	}
 }
 
+// configurePath is a somewhat unfortunate hack, but as it currently stands,
+// when the keybase service is run out of launchd, its path is minimal and
+// often can't find the GPG location. We have hacks around this for CLI operation,
+// in which the CLI forwards its path to the service, and the service enlarges
+// its path accordingly. In this way, the service can get access to path additions
+// inserted by the user's shell startup scripts. However the same mechanism doesn't
+// apply to a GUI-driven workload, since the Electron GUI, like the Go service, is
+// launched from launchd and therefore has the wrong path. This function currently
+// noops on all platforms aside from macOS, but we can expand it later as needs be.
 func (d *Service) configurePath() {
 	defer d.G().Trace("Service#configurePath", func() error { return nil })()
 
 	var newDirs string
 	switch runtime.GOOS {
-	case "linux":
-		newDirs = "/usr/local/bin"
 	case "darwin":
 		newDirs = "/usr/local/bin:/usr/local/MacGPG2/bin"
 	default:

--- a/go/service/rekey_ui_handler.go
+++ b/go/service/rekey_ui_handler.go
@@ -166,7 +166,7 @@ func (s *scoreResult) GetAppStatus() *libkb.AppStatus {
 func scoreProblemFolders(g *libkb.GlobalContext, existing keybase1.ProblemSet) (keybase1.ProblemSet, error) {
 	tlfIDs := make([]string, len(existing.Tlfs))
 	for i, v := range existing.Tlfs {
-		tlfIDs[i] = v.Tlf.Tlfid.String()
+		tlfIDs[i] = v.Tlf.Id.String()
 	}
 	args := libkb.HTTPArgs{
 		"tlfs": libkb.S{Val: strings.Join(tlfIDs, ",")},

--- a/protocol/avdl/rekey.avdl
+++ b/protocol/avdl/rekey.avdl
@@ -7,7 +7,7 @@ protocol rekey {
   record TLFID {}
 
   record TLF {
-    TLFID tlfid;
+    TLFID id;
     string name;
     array<string> writers;
     array<string> readers;

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1194,7 +1194,7 @@ export type StringKVPair = {
 }
 
 export type TLF = {
-  tlfid: TLFID;
+  id: TLFID;
   name: string;
   writers?: ?Array<string>;
   readers?: ?Array<string>;

--- a/protocol/json/rekey.json
+++ b/protocol/json/rekey.json
@@ -19,7 +19,7 @@
       "fields": [
         {
           "type": "TLFID",
-          "name": "tlfid"
+          "name": "id"
         },
         {
           "type": "string",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1194,7 +1194,7 @@ export type StringKVPair = {
 }
 
 export type TLF = {
-  tlfid: TLFID;
+  id: TLFID;
   name: string;
   writers?: ?Array<string>;
   readers?: ?Array<string>;


### PR DESCRIPTION
Rename to `id`

Also a forgotten commit from the previous PR.