### PR TITLE
Provisioner use secret store if available

### DIFF
--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -162,6 +162,16 @@ func CreateAndSignupFakeUserGPG(tc libkb.TestContext, prefix string) *FakeUser {
 	return fu
 }
 
+func SignupFakeUserStoreSecret(tc libkb.TestContext, prefix string) *FakeUser {
+	fu := NewFakeUserOrBust(tc.T, prefix)
+	tc.G.Log.Debug("New test user: %s / %s", fu.Username, fu.Email)
+	arg := MakeTestSignupEngineRunArg(fu)
+	arg.SkipPaper = false
+	arg.StoreSecret = true
+	_ = SignupFakeUserWithArg(tc, fu, arg)
+	return fu
+}
+
 func CreateAndSignupFakeUserCustomArg(tc libkb.TestContext, prefix string, fmod func(*SignupEngineRunArg)) (*FakeUser, libkb.GenericKey) {
 	fu := NewFakeUserOrBust(tc.T, prefix)
 	arg := MakeTestSignupEngineRunArg(fu)

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -503,7 +503,10 @@ func (e *Kex2Provisionee) pushLKSServerHalf() error {
 	}
 
 	// Cache the passphrase stream.  Note that we don't have the triplesec
-	// portion of the stream cache.
+	// portion of the stream cache, and that the only bytes in ppstream
+	// are the lksec portion (no pwhash, eddsa, dh).  Currently passes
+	// all tests with this situation and code that uses those portions
+	// looks to be ok.
 	e.ctx.LoginContext.CreateStreamCache(nil, ppstream)
 
 	return nil

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -280,6 +280,56 @@ func (s *LoginState) GetPassphraseStreamWithPassphrase(passphrase string) (pps *
 	return nil, err
 }
 
+// GetPassphraseStreamExport either returns a cached, verified passphrase stream
+// export, or generates a new one via login.
+func (s *LoginState) GetPassphraseStreamExport(ui SecretUI) (pps keybase1.PassphraseStream, err error) {
+	s.G().Log.Debug("+ GetPassphraseStreamExport() called")
+	defer func() { s.G().Log.Debug("- GetPassphraseStreamExport() -> %s", ErrToOk(err)) }()
+
+	// 1. try cached
+	s.G().Log.Debug("| trying cached passphrase stream")
+	full, err := s.PassphraseStream()
+	if err != nil {
+		return pps, err
+	}
+	if full != nil {
+		s.G().Log.Debug("| cached passphrase stream ok, using it")
+		return full.Export(), nil
+	}
+
+	// 2. try from secret store
+	if s.G().SecretStoreAll != nil {
+		s.G().Log.Debug("| trying to get passphrase stream from secret store")
+		secret, err := s.G().SecretStoreAll.RetrieveSecret(s.G().Env.GetUsername())
+		if err != nil {
+			return pps, err
+		}
+		lks := NewLKSecWithFullSecret(secret, s.G().Env.GetUID(), s.G())
+		if err = lks.LoadServerHalf(nil); err != nil {
+			return pps, err
+		}
+		stream, err := NewPassphraseStreamLKSecOnly(secret)
+		if err != nil {
+			return pps, err
+		}
+		stream.SetGeneration(lks.Generation())
+		return stream.Export(), nil
+	}
+	s.G().Log.Debug("| no secret store available")
+
+	// 3. login and get it
+	s.G().Log.Debug("| using full GetPassphraseStream")
+	full, err = s.GetPassphraseStream(ui)
+	if err != nil {
+		return pps, err
+	}
+	if full != nil {
+		s.G().Log.Debug("| success using full GetPassphraseStream")
+		return full.Export(), nil
+	}
+	return pps, nil
+}
+
 // GetVerifiedTripleSec either returns a cached, verified Triplesec
 // or generates a new one that's verified via Login.
 func (s *LoginState) GetVerifiedTriplesec(ui SecretUI) (ret Triplesec, gen PassphraseGeneration, err error) {

--- a/go/libkb/passphrase_stream.go
+++ b/go/libkb/passphrase_stream.go
@@ -64,6 +64,19 @@ func NewPassphraseStream(s []byte) *PassphraseStream {
 	}
 }
 
+func NewPassphraseStreamLKSecOnly(s []byte) (*PassphraseStream, error) {
+	if len(s) != lksLen {
+		return nil, fmt.Errorf("invalid lksec stream length %d (expected %d)", len(s), lksLen)
+	}
+	stream := make([]byte, extraLen)
+	copy(stream[lksIndex:], s)
+	ps := &PassphraseStream{
+		stream: stream,
+		gen:    PassphraseGeneration(0),
+	}
+	return ps, nil
+}
+
 func (ps *PassphraseStream) SetGeneration(gen PassphraseGeneration) {
 	ps.gen = gen
 }


### PR DESCRIPTION
Before did a brute-force login to get full passphrase stream.  This tries the cache, secret store before potentially bothering the user with a passphrase prompt.

r? @maxtaco 

cc @malgorithms 