### PR TITLE
Fix TrackToken, Prove engines to use cached keys

### DIFF
--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -540,7 +540,7 @@ func TestProvisionPassphraseNoKeysSwitchUser(t *testing.T) {
 	}
 }
 
-func TestProvisionPaper(t *testing.T) {
+func TestProvisionPaperOnly(t *testing.T) {
 	tc := SetupEngineTest(t, "login")
 	defer tc.Cleanup()
 	fu := NewFakeUserOrBust(t, "paper")
@@ -646,6 +646,22 @@ func TestProvisionPaper(t *testing.T) {
 	}
 
 	if err := RunEngine(signEng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// should be able to track someone (no passphrase prompt)
+	targ := &TrackEngineArg{
+		UserAssertion: "t_alice",
+		Options:       keybase1.TrackOptions{BypassConfirm: true},
+	}
+	ctx = &Context{
+		LogUI:      tc2.G.UI.GetLogUI(),
+		IdentifyUI: &FakeIdentifyUI{},
+		SecretUI:   &libkb.TestSecretUI{},
+	}
+
+	teng := NewTrackEngine(targ, tc2.G)
+	if err := RunEngine(teng, ctx); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/go/engine/prove.go
+++ b/go/engine/prove.go
@@ -173,18 +173,16 @@ func (p *Prove) generateProof(ctx *Context) (err error) {
 		Me:      p.me,
 		KeyType: libkb.DeviceSigningKeyType,
 	}
-	seckey, locked, err := p.G().Keyrings.GetSecretKeyAndSKBWithPrompt(ctx.SecretKeyPromptArg(ska, "proof signature"))
+
+	p.signingKey, err = p.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "tracking signature"))
 	if err != nil {
-		return
+		return err
 	}
 
-	if p.signingKey, err = locked.GetPubKey(); err != nil {
-		return
-	}
 	if p.proof, err = p.me.ServiceProof(p.signingKey, p.st, p.remoteNameNormalized); err != nil {
 		return
 	}
-	if p.sig, p.sigID, _, err = libkb.SignJSON(p.proof, seckey); err != nil {
+	if p.sig, p.sigID, _, err = libkb.SignJSON(p.proof, p.signingKey); err != nil {
 		return
 	}
 	return

--- a/go/engine/prove_test.go
+++ b/go/engine/prove_test.go
@@ -44,3 +44,19 @@ func TestProveRooterWithSecretStore(t *testing.T) {
 		}
 	})
 }
+
+// When device keys are cached, proofs shouldn't require passphrase prompt.
+func TestProveRooterCachedKeys(t *testing.T) {
+	tc := SetupEngineTest(t, "prove")
+	defer tc.Cleanup()
+
+	fu := CreateAndSignupFakeUser(tc, "prove")
+	tc.G.LoginState().Account(func(a *libkb.Account) {
+		a.ClearStreamCache()
+	}, "clear stream cache")
+
+	_, _, err := proveRooterWithSecretUI(tc.G, fu, &libkb.TestSecretUI{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -173,6 +173,7 @@ func TestTrackRetrack(t *testing.T) {
 
 	tc.G.LoginState().Account(func(a *libkb.Account) {
 		a.ClearStreamCache()
+		a.ClearCachedSecretKeys()
 	}, "clear stream cache")
 
 	idUI := &FakeIdentifyUI{}
@@ -220,6 +221,7 @@ func TestTrackRetrack(t *testing.T) {
 	// clear out the passphrase cache
 	tc.G.LoginState().Account(func(a *libkb.Account) {
 		a.ClearStreamCache()
+		a.ClearCachedSecretKeys()
 	}, "clear stream cache")
 
 	// reset the flag


### PR DESCRIPTION
After paper provision, tracking works without passphrase
prompt.   Proofs should work too.

r? @maxtaco 