### PR TITLE
Check for revoked device periodically

### DIFF
--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -176,3 +176,74 @@ func TestTrackAfterRevoke(t *testing.T) {
 		t.Errorf("expected libkb.KeyRevokedError, got %T", err)
 	}
 }
+
+func TestSignAfterRevoke(t *testing.T) {
+	tc1 := SetupEngineTest(t, "rev")
+	defer tc1.Cleanup()
+
+	// We need two devices.  Going to use GPG to sign second device.
+
+	// Sign up on tc1:
+	u := CreateAndSignupFakeUserGPG(tc1, "pgp")
+
+	// Redo SetupEngineTest to get a new home directory...should look like a new device.
+	tc2 := SetupEngineTest(t, "login")
+	defer tc2.Cleanup()
+
+	// We need the gpg keyring that's in the first device homedir:
+	if err := tc1.MoveGpgKeyringTo(tc2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Login on device tc2.  It will use gpg to sign the device.
+	ctx := &Context{
+		ProvisionUI: newTestProvisionUIGPGImport(),
+		LogUI:       tc2.G.UI.GetLogUI(),
+		SecretUI:    u.NewSecretUI(),
+		LoginUI:     &libkb.TestLoginUI{Username: u.Username},
+		GPGUI:       &gpgtestui{},
+	}
+	li := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
+	if err := RunEngine(li, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// tc2 revokes tc1 device:
+	err := doRevokeDevice(tc2, u, tc1.G.Env.GetDeviceID(), false)
+	if err != nil {
+		tc2.T.Fatal(err)
+	}
+
+	// Still logged in on tc1, a revoked device.
+
+	// Test signing with (revoked) device key on tc1, which works...
+	msg := []byte("test message")
+	ret, err := SignED25519(tc1.G, u.NewSecretUI(), keybase1.SignED25519Arg{
+		Msg: msg,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicKey := libkb.NaclSigningKeyPublic(ret.PublicKey)
+	if !publicKey.Verify(msg, (*libkb.NaclSignature)(&ret.Sig)) {
+		t.Error(libkb.VerificationError{})
+	}
+
+	// This should log out tc1:
+	if err := tc1.G.LogoutIfRevoked(); err != nil {
+		t.Fatal(err)
+	}
+
+	AssertLoggedOut(tc1)
+
+	// And now this should fail.
+	ret, err = SignED25519(tc1.G, u.NewSecretUI(), keybase1.SignED25519Arg{
+		Msg: msg,
+	})
+	if err == nil {
+		t.Fatal("nil error signing after LogoutIfRevoked")
+	}
+	if _, ok := err.(libkb.KeyRevokedError); !ok {
+		t.Errorf("error type: %T, expected libkb.KeyRevokedError", err)
+	}
+}

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -162,6 +162,7 @@ const (
 	SCKeyDuplicateUpdate     = int(keybase1.StatusCode_SCKeyDuplicateUpdate)
 	SCKeySyncedPGPNotFound   = int(keybase1.StatusCode_SCKeySyncedPGPNotFound)
 	SCKeyNoMatchingGPG       = int(keybase1.StatusCode_SCKeyNoMatchingGPG)
+	SCKeyRevoked             = int(keybase1.StatusCode_SCKeyRevoked)
 	SCSibkeyAlreadyExists    = int(keybase1.StatusCode_SCSibkeyAlreadyExists)
 	SCDecryptionKeyNotFound  = int(keybase1.StatusCode_SCDecryptionKeyNotFound)
 	SCBadTrackSession        = int(keybase1.StatusCode_SCBadTrackSession)

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -339,6 +339,8 @@ func ImportStatusAsError(s *keybase1.Status) error {
 		return NotFoundError{Msg: s.Desc}
 	case SCDecryptionError:
 		return DecryptionError{}
+	case SCKeyRevoked:
+		return KeyRevokedError{}
 	case SCGenericAPIError:
 		var code int
 		for _, field := range s.Fields {
@@ -1178,6 +1180,14 @@ func (e NoSigChainError) ToStatus() keybase1.Status {
 	return keybase1.Status{
 		Code: SCKeyNoEldest,
 		Name: "SC_KEY_NO_ELDEST",
+		Desc: e.Error(),
+	}
+}
+
+func (e KeyRevokedError) ToStatus() keybase1.Status {
+	return keybase1.Status{
+		Code: SCKeyRevoked,
+		Name: "SC_KEY_REVOKED_ERROR",
 		Desc: e.Error(),
 	}
 }

--- a/go/protocol/constants.go
+++ b/go/protocol/constants.go
@@ -48,6 +48,7 @@ const (
 	StatusCode_SCKeyNoNaClEncryption    StatusCode = 928
 	StatusCode_SCKeySyncedPGPNotFound   StatusCode = 929
 	StatusCode_SCKeyNoMatchingGPG       StatusCode = 930
+	StatusCode_SCKeyRevoked             StatusCode = 931
 	StatusCode_SCBadTrackSession        StatusCode = 1301
 	StatusCode_SCDeviceNotFound         StatusCode = 1409
 	StatusCode_SCDeviceMismatch         StatusCode = 1410

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -171,6 +171,7 @@ func (d *Service) Run() (err error) {
 	}
 
 	d.checkTrackingEveryHour()
+	d.checkRevokedPeriodic()
 	d.startupGregor()
 	d.configurePath()
 
@@ -238,6 +239,19 @@ func (d *Service) checkTrackingEveryHour() {
 			<-ticker.C
 			d.G().Log.Debug("Checking tracks on an hour timer.")
 			libkb.CheckTracking(d.G())
+		}
+	}()
+}
+
+func (d *Service) checkRevokedPeriodic() {
+	ticker := time.NewTicker(1 * time.Hour)
+	go func() {
+		for {
+			<-ticker.C
+			d.G().Log.Debug("Checking if current device revoked")
+			if err := d.G().LogoutIfRevoked(); err != nil {
+				d.G().Log.Debug("LogoutIfRevoked error: %s", err)
+			}
 		}
 	}()
 }

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -234,6 +234,11 @@ func (d *Service) writeServiceInfo() error {
 
 func (d *Service) checkTrackingEveryHour() {
 	ticker := time.NewTicker(1 * time.Hour)
+	d.G().PushShutdownHook(func() error {
+		d.G().Log.Debug("stopping checkTrackingEveryHour timer")
+		ticker.Stop()
+		return nil
+	})
 	go func() {
 		for {
 			<-ticker.C
@@ -245,6 +250,11 @@ func (d *Service) checkTrackingEveryHour() {
 
 func (d *Service) checkRevokedPeriodic() {
 	ticker := time.NewTicker(1 * time.Hour)
+	d.G().PushShutdownHook(func() error {
+		d.G().Log.Debug("stopping checkRevokedPeriodic timer")
+		ticker.Stop()
+		return nil
+	})
 	go func() {
 		for {
 			<-ticker.C

--- a/protocol/avdl/constants.avdl
+++ b/protocol/avdl/constants.avdl
@@ -40,6 +40,7 @@ protocol constants {
     SCKeyNoNaClEncryption_928,
     SCKeySyncedPGPNotFound_929,
     SCKeyNoMatchingGPG_930,
+    SCKeyRevoked_931,
     SCBadTrackSession_1301,
     SCDeviceNotFound_1409,
     SCDeviceMismatch_1410,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1158,6 +1158,7 @@ export type StatusCode =
   | 928 // SCKeyNoNaClEncryption_928
   | 929 // SCKeySyncedPGPNotFound_929
   | 930 // SCKeyNoMatchingGPG_930
+  | 931 // SCKeyRevoked_931
   | 1301 // SCBadTrackSession_1301
   | 1409 // SCDeviceNotFound_1409
   | 1410 // SCDeviceMismatch_1410

--- a/protocol/js/keybase-v1.js
+++ b/protocol/js/keybase-v1.js
@@ -85,6 +85,7 @@ export const constants = {
     'sckeynonaclencryption': 928,
     'sckeysyncedpgpnotfound': 929,
     'sckeynomatchinggpg': 930,
+    'sckeyrevoked': 931,
     'scbadtracksession': 1301,
     'scdevicenotfound': 1409,
     'scdevicemismatch': 1410,

--- a/protocol/json/constants.json
+++ b/protocol/json/constants.json
@@ -44,6 +44,7 @@
         "SCKeyNoNaClEncryption_928",
         "SCKeySyncedPGPNotFound_929",
         "SCKeyNoMatchingGPG_930",
+        "SCKeyRevoked_931",
         "SCBadTrackSession_1301",
         "SCDeviceNotFound_1409",
         "SCDeviceMismatch_1410",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1158,6 +1158,7 @@ export type StatusCode =
   | 928 // SCKeyNoNaClEncryption_928
   | 929 // SCKeySyncedPGPNotFound_929
   | 930 // SCKeyNoMatchingGPG_930
+  | 931 // SCKeyRevoked_931
   | 1301 // SCBadTrackSession_1301
   | 1409 // SCDeviceNotFound_1409
   | 1410 // SCDeviceMismatch_1410

--- a/shared/constants/types/keybase-v1.js
+++ b/shared/constants/types/keybase-v1.js
@@ -85,6 +85,7 @@ export const constants = {
     'sckeynonaclencryption': 928,
     'sckeysyncedpgpnotfound': 929,
     'sckeynomatchinggpg': 930,
+    'sckeyrevoked': 931,
     'scbadtracksession': 1301,
     'scdevicenotfound': 1409,
     'scdevicemismatch': 1410,


### PR DESCRIPTION
This checks periodically if the current device has been revoked.  If so, it logs the user out.

The other piece of this would be handling a push notification from the server that the user changed, then checking the current device status.

r? @maxtaco 