### PR TITLE
Integrating rekey buttons

### DIFF
--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -144,14 +144,16 @@ const jsonToFolders = (json: Object, myKID: any) => {
         } else {
           folder.waitingForParticipantUnlock = Object.keys(solutions).map(userID => {
             const devices = solutions[userID].map(kid => json.devices[kid].name)
+            const numDevices = devices.length
+            let last
 
-            if (devices.length > 1) {
-              devices[devices.length - 1] = `or ${devices[devices.length - 1]}`
+            if (numDevices > 1) {
+              last = devices.pop()
             }
 
             return {
               name: json.users[userID],
-              devices: `Tell them to turn on${devices.length > 1 ? ':' : ' '} ${devices.join(', ')}`,
+              devices: `Tell them to turn on${numDevices > 1 ? ':' : ' '} ${devices.join(', ')}${last ? ` or ${last}` : ''}.`,
             }
           })
         }

--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -171,10 +171,18 @@ export function favoriteList (): (dispatch: Dispatch, getState: () => Object) =>
                   return {...device, deviceID: kid}
                 })
               } else {
-                folder.waitingForParticipantUnlock = Object.keys(solutions).map(userID => ({
-                  name: json.users[userID],
-                  devices: solutions[userID].map(kid => json.devices[kid].name).join(', '),
-                }))
+                folder.waitingForParticipantUnlock = Object.keys(solutions).map(userID => {
+                  const devices = solutions[userID].map(kid => json.devices[kid].name)
+
+                  if (devices.length > 1) {
+                    devices[devices.length - 1] = `or ${devices[devices.length - 1]}`
+                  }
+
+                  return {
+                    name: json.users[userID],
+                    devices: `Tell them to turn on${devices.length > 1 ? ':' : ' '} ${devices.join(', ')}`,
+                  }
+                })
               }
             }
           })

--- a/shared/constants/folders.js
+++ b/shared/constants/folders.js
@@ -3,8 +3,8 @@
 // TODO(mm) Everytype in this file should be pure...
 
 import type {UserList} from '../common-adapters/usernames'
-import type {IconType} from '../common-adapters/icon'
 import type {Props as FileProps} from '../folders/files/file/render'
+import type {DeviceType} from '../constants/types/more'
 
 export type FileSection = {
   name: string,
@@ -15,19 +15,20 @@ export type FileSection = {
 export type ParticipantUnlock = {
   name: string,
   devices: string,
-  onClick: () => void
 }
 
-export type UnlockDevice = {
+export type Device = {
+  type: DeviceType,
   name: string,
-  icon: IconType,
-  onClickPaperkey?: () => void
+  deviceID: string,
 }
+
+export type MetaType = 'new' | 'rekey' | 'ignored' | null
 
 export type Folder = {
   users: UserList,
   path: string,
-  meta?: 'new' | 'rekey' | null,
+  meta?: MetaType,
   modified?: {
     when: string,
     username: string
@@ -38,6 +39,6 @@ export type Folder = {
   groupAvatar: boolean,
   userAvatar: ?string,
   recentFiles: Array<FileSection>, // TODO make pure
-  waitingForParticipantUnlock: Array<ParticipantUnlock>, // TODO make pure
-  youCanUnlock: Array<UnlockDevice> // TODO make pure
+  waitingForParticipantUnlock: Array<ParticipantUnlock>,
+  youCanUnlock: Array<Device>,
 }

--- a/shared/constants/unlock-folders.js
+++ b/shared/constants/unlock-folders.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import type {TypedAction} from '../constants/types/flux'
-import type {DeviceID, Device as ServiceDevice} from '../constants/types/flow-types'
+import type {DeviceID, Device as ServiceDevice, ProblemSet} from '../constants/types/flow-types'
 import type {DeviceType} from '../constants/types/more'
 
 export type Device = {
@@ -32,7 +32,10 @@ export type Waiting = TypedAction<'unlockFolders:waiting', boolean, {}>
 export type RegisterRekeyListenerAction = TypedAction<'notifications:registerRekeyListener', any, any>
 export const registerRekeyListener = 'notifications:registerRekeyListener'
 
-export type NewRekeyPopupAction = TypedAction<'notifications:newRekeyPopup', {sessionID: number, devices: Array<ServiceDevice>}, void>
+export type NewRekeyPopupAction = TypedAction<'notifications:newRekeyPopup', {
+  sessionID: number,
+  devices: Array<ServiceDevice>,
+  problemSet: ProblemSet}, void>
 export const newRekeyPopup = 'notifications:newRekeyPopup'
 
 export type UnlockFolderActions = ToPaperKeyInput | OnBackFromPaperKey | CheckPaperKey | Finish

--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -166,7 +166,7 @@ class Engine {
         delete this.sessionIDToIncomingCall[sid]
       },
     }
-    this.serverListeners[method](param, cbs)
+    this.serverListeners[method](param, cbs, sid)
   }
 
   _rpcWrite (data) {
@@ -335,7 +335,8 @@ class Engine {
       param = {}
     }
 
-    const sessionID = param.sessionID = this.getSessionID()
+    // allow overwriting of sessionID with param.sessionID
+    const sessionID = param.sessionID = param.sessionID || this.getSessionID()
     this.sessionIDToIncomingCall[sessionID] = {incomingCallMap, waitingHandler}
     this.sessionIDToResponse[sessionID] = null
 

--- a/shared/engine/server.js
+++ b/shared/engine/server.js
@@ -47,6 +47,7 @@ type Engine = any
 export default class Server {
   startMethodName: string;
   engine: Engine;
+  sessionID: ?number; // if you want to make a call with the same sessionID as this server
   endpointsFn: (params: any, end: () => void) => CallMap;
 
   constructor (engine: Engine, startMethodName: string, endMethodName: ?string, endpointMapFn: (params: any) => CallMap) {
@@ -73,15 +74,17 @@ export default class Server {
   }
 
   listen () {
-    this.engine.listenServerInit(this.startMethodName, (param, cbs) => this.init(param, cbs))
+    this.engine.listenServerInit(this.startMethodName, (param, cbs, sessionID) => this.init(param, cbs, sessionID))
   }
 
-  init (params: any, {start, end}: {start: (endpoints: CallMap) => void, end: () => void}) {
+  init (params: any, {start, end}: {start: (endpoints: CallMap) => void, end: () => void}, sessionID: number) {
+    this.sessionID = sessionID
     start(this.endpointsFn(params, end))
   }
 }
 
-export function createServer (engine: Engine, startMethodName: string, endMethodName: ?string, endpointMapFn: (params: any) => CallMap): void {
+export function createServer (engine: Engine, startMethodName: string, endMethodName: ?string, endpointMapFn: (params: any) => CallMap): Server {
   const s = new Server(engine, startMethodName, endMethodName, endpointMapFn)
   s.listen()
+  return s
 }

--- a/shared/folders/dumb.js
+++ b/shared/folders/dumb.js
@@ -315,13 +315,14 @@ const commonFiles = (isPrivate): FilesProps => ({ // eslint-disable-line arrow-p
     {name: 'Yesterday', modifiedMarker: false, files: genFiles(4, 4, isPrivate)},
   ],
   recentFilesEnabled: true,
+  onClickPaperkey: device => console.log('on click paperkey ', device),
 })
 
 const commonParticipant = {
   recentFilesSection: [],
   waitingForParticipantUnlock: [
-    {name: 'throughnothing', devices: 'Tell them to turn on: Home Computer, ben\'s iPhone or Work laptop.', onClick: () => console.log('clicked throughnothing')},
-    {name: 'bob', devices: 'Tell them to turn on bob\'s Android phone', onClick: () => console.log('clicked bob')},
+    {name: 'throughnothing', devices: 'Tell them to turn on: Home Computer, ben\'s iPhone or Work laptop.'},
+    {name: 'bob', devices: 'Tell them to turn on bob\'s Android phone'},
   ],
 }
 
@@ -329,11 +330,11 @@ const commonUnlock = {
   recentFilesSection: [],
   waitingForParticipantUnlock: [],
   youCanUnlock: [
-    {name: 'Work Computer', icon: 'icon-computer-bw-32'},
-    {name: 'Home Computer', icon: 'icon-computer-bw-32'},
-    {name: 'Cecil\'s iPhone', icon: 'icon-phone-bw-48'},
-    {name: 'project green...', icon: 'icon-paper-key-32', onClickPaperkey: () => console.log('clicked on project green')},
-    {name: 'gumball sparkles...', icon: 'icon-paper-key-32', onClickPaperkey: () => console.log('clicked on gumball sparkles')},
+    {name: 'Work Computer', type: 'desktop', deviceID: '1'},
+    {name: 'Home Computer', type: 'desktop', deviceID: '2'},
+    {name: 'Cecil\'s iPhone', type: 'mobile', deviceID: '3'},
+    {name: 'project green...', type: 'backup', deviceID: '4'},
+    {name: 'gumball sparkles...', type: 'backup', deviceID: '5'},
   ],
 }
 

--- a/shared/folders/files/index.js
+++ b/shared/folders/files/index.js
@@ -4,7 +4,8 @@ import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
 import {openInKBFS} from '../../actions/kbfs'
 import {favoriteFolder, ignoreFolder} from '../../actions/favorite'
-import {navigateBack} from '../../actions/router'
+import {navigateBack, routeAppend} from '../../actions/router'
+import paperkey from './paperkey'
 import flags from '../../util/feature-flags'
 import Render from './render'
 import _ from 'lodash'
@@ -16,6 +17,7 @@ type Props = $Shape<{
   path: string,
   username: string,
   navigateBack: () => void,
+  routeAppend: (route: any) => void,
   ignoreFolder: (path: string) => void,
   favoriteFolder: (path: string) => void,
   openInKBFS: (path: string) => void
@@ -53,6 +55,7 @@ class Files extends Component<void, Props, State> {
     const openCurrentFolder = () => { this.props.openInKBFS(this.props.path) }
     const ignoreCurrentFolder = () => { this.props.ignoreFolder(this.props.path) }
     const unIgnoreCurrentFolder = () => { this.props.favoriteFolder(this.props.path) }
+
     return (
       <Render
         ignored={folder.ignored}
@@ -69,6 +72,7 @@ class Files extends Component<void, Props, State> {
         youCanUnlock={folder.youCanUnlock}
         onBack={() => this.props.navigateBack()}
         openCurrentFolder={openCurrentFolder}
+        onClickPaperkey={device => this.props.routeAppend({path: 'paperkey', name: device.name})}
         ignoreCurrentFolder={ignoreCurrentFolder}
         unIgnoreCurrentFolder={unIgnoreCurrentFolder}
         recentFilesSection={folder.recentFiles} // TODO (AW): integrate recent files once the service provides this data
@@ -83,6 +87,7 @@ class Files extends Component<void, Props, State> {
         title: 'Files',
         element: <ConnectedFiles path={currentPath.get('path')} />,
       },
+      subRoutes: {paperkey},
     }
   }
 }
@@ -95,13 +100,15 @@ const ConnectedFiles = connect(
       _.get(state, 'favorite.private.ignored', []),
       _.get(state, 'favorite.public.ignored', [])
     )
+
     const folder = folders.find(f => f.path === ownProps.path)
+
     return {
       folder,
       username: state.config && state.config.username,
     }
   },
-  dispatch => bindActionCreators({favoriteFolder, ignoreFolder, navigateBack, openInKBFS}, dispatch)
+  dispatch => bindActionCreators({favoriteFolder, ignoreFolder, navigateBack, openInKBFS, routeAppend}, dispatch)
 )(Files)
 
 export default ConnectedFiles

--- a/shared/folders/files/paperkey.js
+++ b/shared/folders/files/paperkey.js
@@ -1,0 +1,79 @@
+// @flow
+import React, {Component} from 'react'
+import {connect} from 'react-redux'
+import {bindActionCreators} from 'redux'
+import {navigateUp} from '../../actions/router'
+import {checkPaperKey, toPaperKeyInput, onBackFromPaperKey} from '../../actions/unlock-folders'
+import HiddenString from '../../util/hidden-string'
+import Render from '../../login/register/paper-key/index.render'
+import type {State as StoreState} from '../../reducers/unlock-folders'
+
+type Props = $Shape<{
+  error: string,
+  waiting: boolean,
+  onBack: () => void,
+  onBackFromPaperKey: () => void,
+  toPaperKeyInput: () => void,
+  phase: StoreState.phase,
+  checkPaperKey: (paperKey: HiddenString) => void,
+}>
+
+type State = {
+  paperKey: string,
+}
+
+class PaperKey extends Component<void, Props, State> {
+  state: State;
+
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      paperKey: '',
+    }
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.phase === 'success') {
+      this._onBack()
+    }
+  }
+
+  _onBack () {
+    this.props.onBackFromPaperKey()
+    this.props.onBack()
+  }
+
+  render () {
+    return <Render
+      onSubmit={() => {
+        this.props.toPaperKeyInput()
+        this.props.checkPaperKey(new HiddenString(this.state.paperKey))
+      }}
+      error={this.props.error}
+      onChangePaperKey={paperKey => this.setState({paperKey})}
+      onBack={() => this._onBack()}
+      paperKey={this.state.paperKey}
+      waitingForResponse={this.props.waiting}
+    />
+  }
+
+  static parseRoute (currentPath, uri) {
+    return {
+      componentAtTop: {
+        title: 'Paperkey',
+      },
+    }
+  }
+}
+
+export default connect(
+  (state, ownProps) => {
+    return {
+      waiting: state.unlockFolders.waiting,
+      error: state.unlockFolders.paperkeyError || '',
+      phase: state.unlockFolders.phase,
+    }
+  },
+  dispatch => bindActionCreators({onBack: navigateUp, checkPaperKey, toPaperKeyInput, onBackFromPaperKey}, dispatch),
+)(PaperKey)

--- a/shared/folders/files/paperkey.js
+++ b/shared/folders/files/paperkey.js
@@ -8,7 +8,7 @@ import HiddenString from '../../util/hidden-string'
 import Render from '../../login/register/paper-key/index.render'
 import type {State as StoreState} from '../../reducers/unlock-folders'
 
-type Props = $Shape<{
+type Props = {
   error: string,
   waiting: boolean,
   onBack: () => void,
@@ -16,7 +16,7 @@ type Props = $Shape<{
   toPaperKeyInput: () => void,
   phase: StoreState.phase,
   checkPaperKey: (paperKey: HiddenString) => void,
-}>
+}
 
 type State = {
   paperKey: string,

--- a/shared/folders/files/render.js.flow
+++ b/shared/folders/files/render.js.flow
@@ -3,7 +3,7 @@
 import type {Props as FileProps} from './file/render'
 import type {UserList} from '../../common-adapters/usernames'
 import type {MenuItem, Props as MenuProps} from '../../common-adapters/popup-menu'
-import type {FileSection, ParticipantUnlock, UnlockDevice} from '../../constants/folders'
+import type {FileSection, Device, ParticipantUnlock} from '../../constants/folders'
 
 export type Props = {
   theme: 'public' | 'private',
@@ -21,7 +21,8 @@ export type Props = {
   ignoreCurrentFolder: () => void,
   unIgnoreCurrentFolder: () => void,
   waitingForParticipantUnlock: Array<ParticipantUnlock>,
-  youCanUnlock: Array<UnlockDevice>
+  youCanUnlock: Array<Device>,
+  onClickPaperkey: (device: Device) => void,
 }
 
 export default class Render extends React$Component<void, Props, void> { }

--- a/shared/folders/index.js
+++ b/shared/folders/index.js
@@ -15,7 +15,7 @@ export type Props = {
   folderProps: ?RenderProps,
   openInKBFS: (path: string) => void,
   username: string,
-  routeAppend: (path: any) => void
+  routeAppend: (path: any) => void,
 }
 
 type State = {
@@ -41,6 +41,7 @@ class Folders extends Component<void, Props, State> {
       <Render
         {...this.props.folderProps}
         onClick={path => this.props.routeAppend(path)}
+        onRekey={path => this.props.routeAppend(path)}
         onOpen={path => this.props.openInKBFS(path)}
         onSwitchTab={showingPrivate => this.setState({showingPrivate})}
         showingPrivate={this.state.showingPrivate}

--- a/shared/folders/list.desktop.js
+++ b/shared/folders/list.desktop.js
@@ -65,29 +65,30 @@ class Render extends Component<void, Props, State> {
 
     const styles = this.props.isPublic ? stylesPublic : stylesPrivate
 
+    const sharedProps = {
+      onOpen: this.props.onOpen,
+      onClick: this.props.onClick,
+      onRekey: this.props.onRekey,
+      isPublic: this.props.isPublic,
+      smallMode: this.props.smallMode,
+    }
+
     return (
       <Box style={{...stylesContainer, ...this.props.style}}>
         <style>{realCSS}</style>
         {this.props.extraRows}
         <Rows
-          rows={this.props.tlfs}
-          onOpen={this.props.onOpen}
-          onClick={this.props.onClick}
-          onRekey={this.props.onRekey}
-          isPublic={this.props.isPublic}
-          smallMode={this.props.smallMode}
           ignored={false}
+          rows={this.props.tlfs}
+          {...sharedProps}
         />
           {this.props.ignored && this.props.ignored.length > 0 && <Ignored
             ignored={this.props.ignored}
             showIgnored={this.state.showIgnored}
             styles={styles}
-            onOpen={this.props.onOpen}
-            onClick={this.props.onClick}
-            onRekey={this.props.onRekey}
-            isPublic={this.props.isPublic}
-            smallMode={this.props.smallMode}
-            onToggle={() => this.setState({showIgnored: !this.state.showIgnored})} />}
+            onToggle={() => this.setState({showIgnored: !this.state.showIgnored})}
+            {...sharedProps}
+          />}
       </Box>
     )
   }

--- a/shared/folders/list.js.flow
+++ b/shared/folders/list.js.flow
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {FileSection, ParticipantUnlock, UnlockDevice, Folder as ConstantsFolder} from '../constants/folders'
+import type {FileSection, ParticipantUnlock, Folder as ConstantsFolder} from '../constants/folders'
 
 export type Folder = ConstantsFolder
 
@@ -16,5 +16,4 @@ export type Props = {
   extraRows?: Array<React$Element>
 }
 
-export default class Render extends React$Component<void, Props, void> {
-}
+export default class Render extends React$Component<void, Props, void> { }

--- a/shared/folders/render.desktop.js
+++ b/shared/folders/render.desktop.js
@@ -45,6 +45,14 @@ class Render extends Component<void, Props, void> {
       return this._renderComingSoon()
     }
 
+    const sharedListProps = {
+      style: this.props.listStyle,
+      smallMode: this.props.smallMode,
+      onRekey: this.props.onRekey,
+      onOpen: this.props.onOpen,
+      onClick: this.props.onClick,
+    }
+
     return (
       <Box style={{...stylesContainer, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.lightGrey, paddingTop: 0, minHeight: 32}}>
         <TabBar styleTabBar={{...tabBarStyle, backgroundColor: this.props.showingPrivate ? globalColors.darkBlue : globalColors.white, minHeight: this.props.smallMode ? 32 : 64, paddingTop: this.props.smallMode ? 0 : 32}}>
@@ -53,13 +61,7 @@ class Render extends Component<void, Props, void> {
             styleContainer={itemContainerStyle}
             tabBarButton={this._makeItem(false, this.props.showingPrivate === true)}
             onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab(true) }}>
-            <List
-              {...this.props.private}
-              style={this.props.listStyle}
-              smallMode={this.props.smallMode}
-              onRekey={this.props.onRekey}
-              onOpen={this.props.onOpen}
-              onClick={this.props.onClick} />
+            <List {...this.props.private} {...sharedListProps} isPublic={false} />
           </TabBarItem>
           <TabBarItem
             selected={!this.props.showingPrivate}
@@ -68,11 +70,9 @@ class Render extends Component<void, Props, void> {
             onClick={() => { this.props.onSwitchTab && this.props.onSwitchTab(false) }}>
             <List
               {...this.props.public}
-              style={this.props.listStyle}
-              smallMode={this.props.smallMode}
-              onRekey={this.props.onRekey}
-              onOpen={this.props.onOpen}
-              onClick={this.props.onClick} />
+              {...sharedListProps}
+              isPublic={true} // eslint-disable-line
+            />
           </TabBarItem>
         </TabBar>
       </Box>

--- a/shared/folders/row.desktop.js
+++ b/shared/folders/row.desktop.js
@@ -49,7 +49,7 @@ const RowMeta = ({ignored, meta, styles}) => {
     'rekey': globalColors.red,
   }
 
-  const metaProps = ignored
+  const metaProps = meta === 'ignored'
     ? {title: 'ignored', style: styles.ignored}
     : {title: meta || '', style: meta ? {color: metaColors[meta], backgroundColor: metaBGColors[meta]} : {}}
 
@@ -96,7 +96,11 @@ const Row = ({users, isPublic, ignored, meta, modified, hasData, smallMode, onOp
             type='BodySmall' className='folder-row-hover-action' onClick={onOpenClick} style={stylesAction}>Open</Text>}
           {meta === 'rekey' && <Button
             backgroundMode={styles.modifiedMode} small={smallMode} type='Secondary'
-            onClick={() => onRekey && onRekey(path)} label='Rekey' style={stylesAction} />}
+            onClick={e => {
+              if (onRekey) {
+                e.stopPropagation()
+                onRekey(path)
+              } }} label='Rekey' style={stylesAction} />}
           <Icon type={icon} style={{visibility: hasData ? 'visible' : 'hidden', ...(smallMode && !hasData ? {display: 'none'} : {})}} />
         </Box>
       </Box>

--- a/shared/folders/row.native.js
+++ b/shared/folders/row.native.js
@@ -69,7 +69,7 @@ const RowMeta = ({ignored, meta, styles}) => {
     'rekey': globalColors.red,
   }
 
-  const metaProps = ignored
+  const metaProps = meta === 'ignored'
     ? {title: 'ignored', style: styles.ignored}
     : {title: meta || '', style: meta ? {color: metaColors[meta], backgroundColor: metaBGColors[meta]} : {}}
 

--- a/shared/menubar/index.js
+++ b/shared/menubar/index.js
@@ -8,6 +8,7 @@ import {shell} from 'electron'
 
 import * as favoriteAction from '../actions/favorite'
 import {openInKBFS} from '../actions/kbfs'
+import {openDialog as openRekeyDialog} from '../actions/unlock-folders'
 import {switchTab} from '../actions/tabbed-router'
 
 import {ipcRenderer} from 'electron'
@@ -19,6 +20,7 @@ import type {Props as FolderProps} from '../folders/render'
 
 export type Props = $Shape<{
   username: ?string,
+  openRekeyDialog: () => void,
   favoriteList: () => void,
   openInKBFS: (target?: any) => void,
   loggedIn: ?boolean,
@@ -111,7 +113,7 @@ class Menubar extends Component<void, Props, void> {
   }
 
   _onRekey (path: ?string) {
-    console.log(`TODO show rekey popup ${path}`)
+    this.props.openRekeyDialog()
     this._closeMenubar()
   }
 
@@ -174,7 +176,7 @@ export default connect(
     loggedIn: state.config && state.config.loggedIn,
     folderProps: state.favorite,
   }),
-  dispatch => bindActionCreators({...favoriteAction, openInKBFS, switchTab}, dispatch)
+  dispatch => bindActionCreators({...favoriteAction, openInKBFS, switchTab, openRekeyDialog}, dispatch)
 )(Menubar)
 
 export function selector (): (store: Object) => Object {

--- a/shared/reducers/favorite.js
+++ b/shared/reducers/favorite.js
@@ -24,6 +24,7 @@ export default function (state: State = initialState, action: FavoriteAction): S
         ...state,
         ...(action.payload && action.payload.folders),
       }
+
     default:
       return state
   }

--- a/shared/reducers/unlock-folders.js
+++ b/shared/reducers/unlock-folders.js
@@ -9,7 +9,7 @@ export type State = {
   started: boolean,
   closed: boolean,
   phase: 'dead' | 'promptOtherDevice' | 'paperKeyInput' | 'success',
-  devices: Array<Device>,
+  devices: ?Array<Device>,
   waiting: boolean,
   paperkeyError: ?string,
   sessionID: ?number
@@ -20,7 +20,7 @@ const initialState: State = {
   closed: true,
   phase: 'dead',
   waiting: false,
-  devices: [],
+  devices: null,
   paperkeyError: null,
   sessionID: null,
 }

--- a/shared/reducers/unlock-folders.js
+++ b/shared/reducers/unlock-folders.js
@@ -9,7 +9,7 @@ export type State = {
   started: boolean,
   closed: boolean,
   phase: 'dead' | 'promptOtherDevice' | 'paperKeyInput' | 'success',
-  devices: ?Array<Device>,
+  devices: Array<Device>,
   waiting: boolean,
   paperkeyError: ?string,
   sessionID: ?number
@@ -20,7 +20,7 @@ const initialState: State = {
   closed: true,
   phase: 'dead',
   waiting: false,
-  devices: null,
+  devices: [],
   paperkeyError: null,
   sessionID: null,
 }
@@ -52,6 +52,7 @@ export default function (state: State = initialState, action: UnlockFolderAction
       return {
         ...state,
         phase: 'promptOtherDevice',
+        paperkeyError: '',
       }
 
     case Constants.toPaperKeyInput:
@@ -94,15 +95,11 @@ export default function (state: State = initialState, action: UnlockFolderAction
           name, deviceID,
         }))
 
-        if (devices.length) {
-          return {
-            ...state, devices, closed: false,
-            sessionID: action.payload.sessionID,
-          }
-        } else { // close as its all fixed
-          return {...state, devices, closed: true,
-            sessionID: action.payload.sessionID,
-          }
+        return {
+          ...state,
+          devices,
+          closed: !devices.length,
+          sessionID: action.payload.sessionID,
         }
       }
       return state


### PR DESCRIPTION
This makes rekey buttons work. To test

1. Make an account and have it generate a pgp key
1. Provision a device
1. Write some data to your private folder
1. Turn off device (or move config folder)
1. Provision a new device with user/pass

You'll now be in a rekey needed state
You can see rekey buttons in the widget / folders screen.
Clicking the rekey button in the widget brings up the rekey dialog
Clicking the x on the rekey widget snoozes it (quit/restart the gui to get it again)
Clicking on a folder in folders screen with rekey shows you/other participant rekey screen
You can enter a paper key in the dialog or files screen
