### PR TITLE
Hot load local debug dumb sheet config

### DIFF
--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -6,6 +6,7 @@
 import React, {Component} from 'react'
 import ReactDOM from 'react-dom'
 import {Provider} from 'react-redux'
+import {setup as setupLocalDebug} from '../shared/local-debug.desktop'
 import configureStore from '../shared/store/configure-store'
 import Nav from '../shared/nav.desktop'
 import injectTapEventPlugin from 'react-tap-event-plugin'
@@ -33,6 +34,8 @@ if (module.hot) {
 }
 
 const store = configureStore()
+
+setupLocalDebug(store)
 
 if (devStoreChangingFunctions) {
   window.devEdit = (path, value) => store.dispatch(devEditAction(path, value))

--- a/shared/actions/dev.js
+++ b/shared/actions/dev.js
@@ -1,0 +1,7 @@
+// @flow
+import * as Constants from '../constants/dev'
+import type {DebugConfig, DevAction} from '../constants/dev'
+
+export function updateDebugConfig (value: DebugConfig): DevAction {
+  return {type: Constants.updateDebugConfig, value: value}
+}

--- a/shared/constants/dev.js
+++ b/shared/constants/dev.js
@@ -1,6 +1,18 @@
-// Actions
+// @flow
 export const serializeRestore = 'dev:restoreState'
 export const serializeSave = 'dev:saveState'
 export const timeTravel = 'dev:timetravel'
 export const timeTravelBack = 'dev:back'
 export const timeTravelForward = 'dev:forward'
+
+export type DebugConfig = {
+  dumbFilter: string,
+  dumbIndex: number,
+  dumbFullscreen: boolean,
+}
+
+export type DevAction = {
+  type: 'dev:updateDebugConfig',
+  value: $Shape<DebugConfig>,
+}
+export const updateDebugConfig = 'dev:updateDebugConfig'

--- a/shared/dev/dumb-sheet.js
+++ b/shared/dev/dumb-sheet.js
@@ -1,11 +1,18 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import Render from './dumb-sheet.render'
+import {updateDebugConfig} from '../actions/dev'
 import {navigateUp} from '../actions/router'
 
 class DumbSheet extends Component {
   render () {
-    return <Render onBack={this.props.onBack} />
+    return <Render
+      onBack={this.props.onBack}
+      onDebugConfigChange={this.props.onDebugConfigChange}
+      dumbIndex={this.props.dumbIndex}
+      dumbFilter={this.props.dumbFilter}
+      dumbFullscreen={this.props.dumbFullscreen}
+    />
   }
 
   static parseRoute () {
@@ -16,7 +23,12 @@ class DumbSheet extends Component {
 }
 
 export default connect(
-  state => ({}),
+  state => ({
+    dumbIndex: state.dev.debugConfig.dumbIndex,
+    dumbFilter: state.dev.debugConfig.dumbFilter,
+    dumbFullscreen: state.dev.debugConfig.dumbFullscreen,
+  }),
   dispatch => ({
     onBack: () => dispatch(navigateUp()),
+    onDebugConfigChange: value => dispatch(updateDebugConfig(value)),
   }))(DumbSheet)

--- a/shared/dev/dumb-sheet.render.desktop.js
+++ b/shared/dev/dumb-sheet.render.desktop.js
@@ -5,22 +5,18 @@ import {Box, Text, Input, BackButton} from '../common-adapters'
 import {globalStyles} from '../styles/style-guide'
 import dumbComponentMap from './dumb-component-map.desktop'
 import DumbSheetItem from './dumb-sheet-item'
-import {dumbFilter} from '../local-debug'
 import debounce from 'lodash/debounce'
 
 class Render extends Component<void, any, any> {
-  state: any;
   _onFilterChange: (a: any) => void;
 
   constructor (props: any) {
     super(props)
 
-    this.state = {
-      filter: (dumbFilter && dumbFilter.toLowerCase()) || '',
-    }
-
     this._onFilterChange = debounce(filter => {
-      this.setState({filter})
+      this.props.onDebugConfigChange({
+        dumbFilter: filter,
+      })
     }, 300)
   }
 
@@ -31,6 +27,8 @@ class Render extends Component<void, any, any> {
   }
 
   render () {
+    const filter = this.props.dumbFilter.toLowerCase()
+
     return (
       <Box style={{...globalStyles.scrollable, padding: 20}}>
         <BackButton onClick={this.props.onBack} />
@@ -38,15 +36,15 @@ class Render extends Component<void, any, any> {
           <Text type='Header'>Filter:</Text>
           <Input
             ref='filterInput'
-            value={this.state.filter}
+            value={filter}
             onChange={event => this._onFilterChange(event.target.value.toLowerCase())}
           />
         </Box>
         {Object.keys(dumbComponentMap).map(key => {
           const map = dumbComponentMap[key]
-          const includeAllChildren = !this.state.filter || key.toLowerCase().indexOf(this.state.filter) !== -1
+          const includeAllChildren = !filter || key.toLowerCase().indexOf(filter) !== -1
           const items = Object.keys(map.mocks)
-            .filter(mockKey => !this.state.filter || includeAllChildren || mockKey.toLowerCase().indexOf(this.state.filter) !== -1)
+            .filter(mockKey => !filter || includeAllChildren || mockKey.toLowerCase().indexOf(filter) !== -1)
             .map((mockKey, idx) => {
               return (
                 <DumbSheetItem

--- a/shared/dev/dumb-sheet.render.native.js
+++ b/shared/dev/dumb-sheet.render.native.js
@@ -4,7 +4,6 @@ import {ScrollView} from 'react-native'
 import {Box, Text, Input, Button} from '../common-adapters'
 import {globalStyles} from '../styles/style-guide'
 import dumbComponentMap from './dumb-component-map.native'
-import {dumbFilter, dumbIndex, dumbFullscreen} from '../local-debug'
 import debounce from 'lodash/debounce'
 
 class Render extends Component<void, any, any> {
@@ -15,23 +14,24 @@ class Render extends Component<void, any, any> {
     super(props)
 
     this.state = {
-      filter: (dumbFilter && dumbFilter.toLowerCase()) || '',
       filterShow: false,
-      index: dumbIndex || 0,
     }
 
     this._onFilterChange = debounce(filter => {
-      this.setState({filter})
+      this.props.onDebugConfigChange({
+        dumbFilter: filter,
+      })
     }, 300)
   }
 
   render () {
+    const filter = this.props.dumbFilter.toLowerCase()
     const components = []
     const componentsOnly = []
     const parentPropsOnly = []
 
     Object.keys(dumbComponentMap).forEach(key => {
-      if (this.state.filter && key.toLowerCase().indexOf(this.state.filter) === -1) {
+      if (filter && key.toLowerCase().indexOf(filter) === -1) {
         return
       }
 
@@ -55,12 +55,12 @@ class Render extends Component<void, any, any> {
       })
     })
 
-    const ToShow = components[this.state.index % components.length]
+    const ToShow = components[this.props.dumbIndex % components.length]
 
-    if (dumbFullscreen) {
+    if (this.props.dumbFullscreen) {
       return (
-        <Box style={{flex: 1}} {...parentPropsOnly[this.state.index % components.length]}>
-          {componentsOnly[this.state.index % components.length]}
+        <Box style={{flex: 1}} {...parentPropsOnly[this.props.dumbIndex % components.length]}>
+          {componentsOnly[this.props.dumbIndex % components.length]}
         </Box>
       )
     }
@@ -71,8 +71,8 @@ class Render extends Component<void, any, any> {
           {ToShow}
         </ScrollView>
         <Box style={stylesControls}>
-          <Text type='BodySmall'>{this.state.index}</Text>
-          {this.state.filterShow && <Box style={{...globalStyles.flexBoxColumn, backgroundColor: 'red', width: 200}}><Input style={inputStyle} value={this.state.filter} onChangeText={filter => this._onFilterChange(filter.toLowerCase())} /></Box>}
+          <Text type='BodySmall'>{this.props.dumbIndex}</Text>
+          {this.state.filterShow && <Box style={{...globalStyles.flexBoxColumn, backgroundColor: 'red', width: 200}}><Input style={inputStyle} value={filter} onChangeText={filter => this._onFilterChange(filter.toLowerCase())} /></Box>}
           <Button type='Primary' style={stylesButton} label='...' onClick={() => { this.setState({filterShow: !this.state.filterShow}) }} />
           <Button type='Primary' style={stylesButton} label='<' onClick={() => { this._incremement(false) }} />
           <Button type='Primary' style={stylesButton} label='>' onClick={() => { this._incremement(true) }} />
@@ -82,8 +82,10 @@ class Render extends Component<void, any, any> {
   }
 
   _incremement (up: boolean) {
-    let next = Math.max(0, this.state.index + (up ? 1 : -1))
-    this.setState({index: next})
+    let next = Math.max(0, this.props.dumbIndex + (up ? 1 : -1))
+    this.props.onDebugConfigChange({
+      dumbIndex: next,
+    })
   }
 }
 

--- a/shared/index.native.js
+++ b/shared/index.native.js
@@ -1,4 +1,5 @@
 import './globals'
+import {setup as setupLocalDebug} from './local-debug'
 import React, {Component} from 'react'
 import {AppRegistry, NativeAppEventEmitter, AsyncStorage} from 'react-native'
 import {Provider} from 'react-redux'
@@ -9,6 +10,8 @@ import {stateKey} from './constants/reducer'
 import {serializeRestore, serializeSave, timeTravel, timeTravelForward, timeTravelBack} from './constants/dev'
 
 const store = configureStore()
+
+setupLocalDebug(store)
 
 class Keybase extends Component {
   componentWillMount () {

--- a/shared/local-debug.desktop.js
+++ b/shared/local-debug.desktop.js
@@ -3,6 +3,7 @@
  */
 
 import {createRouterState} from './reducers/router'
+import {updateDebugConfig} from './actions/dev'
 import * as Tabs from './constants/tabs'
 import {updateConfig} from './command-line.desktop.js'
 
@@ -104,4 +105,21 @@ export function initTabbedRouterState (state) {
       ...tabState,
     },
   }
+}
+
+function updateStore (store, config) {
+  store.dispatch(updateDebugConfig({
+    dumbFilter: config.dumbFilter,
+    dumbIndex: config.dumbIndex,
+    dumbFullscreen: config.dumbFullscreen,
+  }))
+}
+
+export function setup (store) {
+  if (module.hot) {
+    module.hot.accept('./local-debug.desktop', () => {
+      updateStore(store, require('./local-debug.desktop'))
+    })
+  }
+  updateStore(store, config)
 }

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -3,6 +3,7 @@
  */
 
 import {createRouterState} from './reducers/router'
+import {updateDebugConfig} from './actions/dev'
 import * as Tabs from './constants/tabs'
 
 let config = {
@@ -74,4 +75,21 @@ export function initTabbedRouterState (state) {
     },
     activeTab: Tabs.settingsTab,
   }
+}
+
+function updateStore (store, config) {
+  store.dispatch(updateDebugConfig({
+    dumbFilter: config.dumbFilter,
+    dumbIndex: config.dumbIndex,
+    dumbFullscreen: config.dumbFullscreen,
+  }))
+}
+
+export function setup (store) {
+  if (module.hot) {
+    module.hot.accept(() => {
+      updateStore(store, require('./local-debug.native'))
+    })
+  }
+  updateStore(store, config)
 }

--- a/shared/nav.android.js
+++ b/shared/nav.android.js
@@ -15,7 +15,6 @@ import Profile from './profile'
 import Login from './login'
 import {mapValues} from 'lodash'
 
-import {dumbFullscreen} from './local-debug'
 import DumbSheet from './dev/dumb-sheet'
 
 import {profileTab, folderTab, chatTab, peopleTab, devicesTab, settingsTab, loginTab, prettify} from './constants/tabs'
@@ -109,7 +108,7 @@ class Nav extends Component {
   }
 
   render () {
-    if (dumbFullscreen) {
+    if (this.props.dev.debugConfig.dumbFullscreen) {
       return <DumbSheet />
     }
 

--- a/shared/nav.ios.js
+++ b/shared/nav.ios.js
@@ -24,7 +24,6 @@ import {bootstrap} from './actions/config'
 
 import {navBarHeight, tabBarHeight} from './styles/style-guide'
 
-import {dumbFullscreen} from './local-debug'
 import DumbSheet from './dev/dumb-sheet'
 
 import {startupTab, profileTab, folderTab, chatTab, peopleTab, devicesTab, settingsTab, loginTab} from './constants/tabs'
@@ -138,11 +137,12 @@ class Nav extends Component {
   }
 
   shouldComponentUpdate (nextProps, nextState) {
-    return (nextProps.tabbedRouter.get('activeTab') !== this._activeTab())
+    return (nextProps.tabbedRouter.get('activeTab') !== this._activeTab() ||
+            nextProps.dumbFullscreen !== this.props.dumbFullscreen)
   }
 
   render () {
-    if (dumbFullscreen) {
+    if (this.props.dumbFullscreen) {
       return <DumbSheet />
     }
 
@@ -192,11 +192,12 @@ const styles = StyleSheet.create({
 })
 
 export default connect(
-  ({tabbedRouter, config: {bootstrapped, extendedConfig, username}}) => ({
+  ({tabbedRouter, config: {bootstrapped, extendedConfig, username}, dev: {debugConfig: {dumbFullscreen}}}) => ({
     tabbedRouter,
     bootstrapped,
     provisioned: extendedConfig && !!extendedConfig.device,
     username,
+    dumbFullscreen,
   }),
   dispatch => {
     return {

--- a/shared/reducers/dev.js
+++ b/shared/reducers/dev.js
@@ -1,0 +1,27 @@
+/* @flow */
+
+import {updateDebugConfig} from '../constants/dev'
+import type {State} from '../constants/reducer'
+import type {DebugConfig, DevAction} from '../constants/dev'
+
+type DevState = {
+  debugConfig: DebugConfig,
+}
+
+const initialState: DevState = {
+  debugConfig: {
+    dumbFilter: '',
+    dumbIndex: 0,
+    dumbFullscreen: false,
+  },
+}
+
+export default function (state: DevState = initialState, action: DevAction): State {
+  if (action.type === updateDebugConfig) {
+    return {
+      ...state,
+      debugConfig: {...state.debugConfig, ...action.value},
+    }
+  }
+  return state
+}

--- a/shared/reducers/index.js
+++ b/shared/reducers/index.js
@@ -19,6 +19,7 @@ import tabbedRouter from './tabbed-router'
 import tracker from './tracker'
 import unlockFolders from './unlock-folders'
 import devEdit from './dev-edit'
+import dev from './dev'
 
 let history = List()
 let index = 0
@@ -50,6 +51,7 @@ const combinedReducer = combineReducers({
   signup,
   unlockFolders,
   notifications,
+  dev,
 })
 
 let reducer


### PR DESCRIPTION
This changeset facilitates hot updating the dumb sheet parameters (filter, index, fullscreen) via `local-debug.desktop` and `local-debug.native`. The state is now stored in a redux store/reducer named "dev". When the `local-debug` file updates, its value will be assigned to the live application state, which can also still be manipulated via the UI.

On mobile particularly, this makes it convenient to work with the dumb sheet without reloading the app.

![](http://66.media.tumblr.com/0ceabee4aac4aa970023f328261a633b/tumblr_n30ix6QVHV1rm3aawo1_500.gif)