### PR TITLE
Basic native profile view

### DIFF
--- a/shared/common-adapters/button.native.js
+++ b/shared/common-adapters/button.native.js
@@ -149,10 +149,11 @@ const FollowingLabel = {
 const Unfollow = {
   ...common,
   ...followCommon,
-  backgroundColor: globalColors.blue,
+  backgroundColor: globalColors.lightGrey2,
 }
 const UnfollowLabel = {
   ...commonLabel,
+  color: globalColors.black_75,
 }
 
 const progress = {

--- a/shared/common-adapters/follow-button.native.js
+++ b/shared/common-adapters/follow-button.native.js
@@ -28,5 +28,5 @@ export default class FollowButton extends Component<void, Props, void> {
 }
 
 const styleButton = {
-  width: 125,
+  width: 140,
 }

--- a/shared/common-adapters/user-actions.native.js
+++ b/shared/common-adapters/user-actions.native.js
@@ -16,7 +16,7 @@ export default function UserActions ({trackerState, currentlyFollowing, style, o
     } else {
       return (
         <Box style={style}>
-          <Button type='Unfollow' label='Untrack' onClick={onUnfollow} style={{marginRight: globalMargins.xtiny}} />
+          <Button type='Unfollow' label='Untrack' onClick={onUnfollow} style={{marginRight: globalMargins.tiny}} />
           <Button type='Follow' label='Accept' onClick={onAcceptProofs} style={{marginRight: 0}} />
         </Box>
       )

--- a/shared/common-adapters/user-bio.native.js
+++ b/shared/common-adapters/user-bio.native.js
@@ -104,12 +104,10 @@ const stylesFullname = {
   ...globalStyles.selectable,
   textAlign: 'center',
   color: globalColors.black_75,
-  marginTop: globalMargins.xtiny,
 }
 const stylesFollowLabel = {
   fontSize: 12,
   color: globalColors.black_40,
-  marginTop: globalMargins.xtiny,
 }
 const stylesFollowing = {
   ...globalStyles.clickable,

--- a/shared/common-adapters/user-proofs.native.js
+++ b/shared/common-adapters/user-proofs.native.js
@@ -1,12 +1,10 @@
 /* @flow */
 
 import React, {Component} from 'react'
-import {View, Text} from 'react-native'
-
 import openUrl from '../util/open-url'
 import * as shared from './user-proofs.shared'
 import {metaNone} from '../constants/tracker'
-import {Icon, Meta} from '../common-adapters/index'
+import {Box, Icon, Meta, Text} from '../common-adapters/index'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import {checking as proofChecking} from '../constants/tracker'
 
@@ -42,27 +40,27 @@ export default class ProofsRender extends Component {
     const proofIcon = proofStatusIconType && <Icon type={proofStatusIconType} style={stylesStatusIcon} onClick={() => this._onClickProof(proof)} />
 
     return (
-      <View style={{...stylesRow, paddingTop: idx > 0 ? 8 : 0}} key={`${proof.id}${proof.type}`}>
+      <Box style={{...stylesRow, paddingTop: idx > 0 ? 8 : 0}} key={`${proof.id}${proof.type}`}>
         <Icon style={stylesService} type={shared.iconNameForProof(proof)} title={proof.type} onClick={onClickProfile} />
-        <View style={stylesProofNameSection}>
-          <View style={stylesProofNameLabelContainer}>
+        <Box style={stylesProofNameSection}>
+          <Box style={stylesProofNameLabelContainer}>
             <Text inline type='Body' onPress={onClickProfile} style={stylesProofName}>
               <Text inline type='Body' style={proofNameStyle}>{proof.name}</Text>
               <Text inline type='Body' style={stylesProofType}>@{proof.type}</Text>
             </Text>
             {meta}
-          </View>
-        </View>
+          </Box>
+        </Box>
         {proofIcon}
-      </View>
+      </Box>
     )
   }
 
   render () {
     return (
-      <View style={{...stylesContainer, ...this.props.style}}>
+      <Box style={{...stylesContainer, ...this.props.style}}>
         {this.props.proofs.map((p, idx) => this._renderProofRow(p, idx))}
-      </View>
+      </Box>
     )
   }
 }

--- a/shared/common-adapters/user-proofs.native.js
+++ b/shared/common-adapters/user-proofs.native.js
@@ -60,7 +60,7 @@ export default class ProofsRender extends Component {
 
   render () {
     return (
-      <View style={stylesContainer}>
+      <View style={{...stylesContainer, ...this.props.style}}>
         {this.props.proofs.map((p, idx) => this._renderProofRow(p, idx))}
       </View>
     )
@@ -70,11 +70,7 @@ export default class ProofsRender extends Component {
 const stylesContainer = {
   ...globalStyles.flexBoxColumn,
   backgroundColor: globalColors.white,
-  paddingTop: 16,
-  paddingBottom: 16,
   alignItems: 'stretch',
-  paddingLeft: globalMargins.medium,
-  paddingRight: globalMargins.medium,
 }
 const stylesRow = {
   ...globalStyles.flexBoxRow,

--- a/shared/common-adapters/user-proofs.native.js
+++ b/shared/common-adapters/user-proofs.native.js
@@ -46,9 +46,9 @@ export default class ProofsRender extends Component {
         <Icon style={stylesService} type={shared.iconNameForProof(proof)} title={proof.type} onClick={onClickProfile} />
         <View style={stylesProofNameSection}>
           <View style={stylesProofNameLabelContainer}>
-            <Text inline className='hover-underline-container' type='Body' onPress={onClickProfile} style={stylesProofName}>
-              <Text inline type='Body' className='underline' style={proofNameStyle}>{proof.name}</Text>
-              <Text className='no-underline' inline type='Body' style={stylesProofType}>@{proof.type}</Text>
+            <Text inline type='Body' onPress={onClickProfile} style={stylesProofName}>
+              <Text inline type='Body' style={proofNameStyle}>{proof.name}</Text>
+              <Text inline type='Body' style={stylesProofType}>@{proof.type}</Text>
             </Text>
             {meta}
           </View>

--- a/shared/common-adapters/usernames.js
+++ b/shared/common-adapters/usernames.js
@@ -2,14 +2,16 @@
 import React, {Component} from 'react'
 import {Box, Text} from './'
 import {globalStyles, globalColors} from '../styles/style-guide'
+import {isMobile} from '../constants/platform'
 
 import type {Props} from './usernames'
 
 export function usernameText ({type, users, style, inline}: Props) {
   return users.map((u, i) => {
-    const userStyle = {
-      textDecoration: 'inherit',
-      ...style,
+    const userStyle = {...style}
+
+    if (!isMobile) {
+      userStyle.textDecoration = 'inherit'
     }
 
     if (u.broken) {

--- a/shared/dev/dumb-component-map.native.js
+++ b/shared/dev/dumb-component-map.native.js
@@ -7,6 +7,7 @@ import QRMap from '../login/register/code-page/qr/dumb.native'
 import DevicePageMap from '../devices/device-page/dumb.native'
 import FoldersMap from '../folders/dumb'
 import FoldersConfirmMap from '../folders/confirm/dumb'
+import ProfileMap from '../profile/dumb'
 import SearchMap from '../search/dumb'
 import type {DumbComponentMap} from '../constants/types/more'
 import Tracker from '../tracker/dumb.native'
@@ -21,6 +22,7 @@ const map: DumbComponentMap = {
   ...DevicePageMap,
   ...FoldersMap,
   ...FoldersConfirmMap,
+  ...ProfileMap,
   ...SearchMap,
   ...Tracker,
 }

--- a/shared/profile/dumb.desktop.js
+++ b/shared/profile/dumb.desktop.js
@@ -46,16 +46,16 @@ const baseFolder = {
 const folders = [
   createFolder({
     users: [
-      {username: 'cecileb', you: true},
-      {username: 'chris'},
+      {username: 'chris', you: true},
+      {username: 'cecileb'},
     ],
     ...baseFolder,
     hasData: false,
   }),
   createFolder({
     users: [
-      {username: 'cecileb', you: true},
-      {username: 'chris'},
+      {username: 'chris', you: true},
+      {username: 'cecileb'},
     ],
     ...baseFolder,
     isPublic: false,
@@ -63,29 +63,29 @@ const folders = [
   }),
   createFolder({
     users: [
-      {username: 'cecileb', you: true},
-      {username: 'chris'},
+      {username: 'chris', you: true},
+      {username: 'cecileb'},
       {username: 'max'},
     ],
     ...baseFolder,
   }),
   createFolder({
     users: [
-      {username: 'cecileb', you: true},
+      {username: 'chris', you: true},
       {username: 'max'},
     ],
     ...baseFolder,
   }),
   createFolder({
     users: [
-      {username: 'cecileb', you: true},
+      {username: 'chris', you: true},
       {username: 'cjb'},
     ],
     ...baseFolder,
   }),
   createFolder({
     users: [
-      {username: 'cecileb', you: true},
+      {username: 'chris', you: true},
       {username: 'chrisnojima'},
       {username: 'marcopolo'},
       {username: 'zanderz'},
@@ -95,7 +95,7 @@ const folders = [
   }),
   createFolder({
     users: [
-      {username: 'cecileb', you: true},
+      {username: 'chris', you: true},
       {username: 'chrisnojima'},
       {username: 'marcopolo'},
     ],

--- a/shared/profile/dumb.js
+++ b/shared/profile/dumb.js
@@ -2,6 +2,7 @@
 import Profile from './render'
 import {normal, checking, revoked, error, metaNone} from '../constants/tracker'
 import {createFolder} from '../folders/dumb'
+import {isMobile} from '../constants/platform'
 import type {Props as RenderProps} from './render'
 import type {Proof} from '../common-adapters/user-proofs'
 import type {UserInfo} from '../common-adapters/user-bio'
@@ -136,7 +137,7 @@ const propsBase: RenderProps = {
   onAcceptProofs: () => console.log('onAcceptProofs'),
   onFolderClick: folder => { console.log('onFolderClick', folder) },
   onUserClick: username => { console.log('onUserClick', username) },
-  parentProps: {
+  parentProps: isMobile ? {} : {
     style: {
       width: 640,
       height: 578,

--- a/shared/profile/friendships.native.js
+++ b/shared/profile/friendships.native.js
@@ -6,6 +6,8 @@ import TabBar, {TabBarItem} from '../common-adapters/tab-bar'
 import {globalStyles, globalColors} from '../styles/style-guide'
 import type {Props, FriendshipUserInfo} from './friendships'
 
+const ITEM_WIDTH = 105
+
 type UserEntryProps = FriendshipUserInfo & {
   onClick?: (username: string) => void
 }
@@ -19,12 +21,20 @@ const UserEntry = ({onClick, username, followsYou, following}: UserEntryProps) =
   </TouchableHighlight>
 )
 
+// Pad an array of grid entries with enough placeholders to fill the final row
+function padGridEntries (entries, multiple) {
+  for (let i = 0; i < entries.length % multiple; i++) {
+    entries.push(<Box key={`pad${i}`} style={{width: ITEM_WIDTH, margin: 2}} />)
+  }
+  return entries
+}
+
 const userEntryContainerStyle = {
   ...globalStyles.clickable,
   ...globalStyles.flexBoxColumn,
   alignItems: 'center',
   justifyContent: 'flex-start',
-  width: 105,
+  width: ITEM_WIDTH,
   height: 108,
   margin: 2,
 }
@@ -51,7 +61,7 @@ class Render extends Component<void, Props, void> {
           <Box style={tabItemContainerStyle}>
             <Box style={tabItemContainerTopBorder} />
             <Box style={tabItemContainerUsers}>
-              {this.props.followers.map(user => <UserEntry key={user.username} {...user} onClick={this.props.onUserClick} />)}
+              {padGridEntries(this.props.followers.map(user => <UserEntry key={user.username} {...user} onClick={this.props.onUserClick} />), 3)}
             </Box>
           </Box>
         </TabBarItem>
@@ -63,7 +73,7 @@ class Render extends Component<void, Props, void> {
           <Box style={tabItemContainerStyle}>
             <Box style={tabItemContainerTopBorder} />
             <Box style={tabItemContainerUsers}>
-              {this.props.following.map(user => <UserEntry key={user.username} {...user} onClick={this.props.onUserClick} />)}
+              {padGridEntries(this.props.following.map(user => <UserEntry key={user.username} {...user} onClick={this.props.onUserClick} />), 3)}
             </Box>
           </Box>
         </TabBarItem>

--- a/shared/profile/render.desktop.js
+++ b/shared/profile/render.desktop.js
@@ -67,8 +67,8 @@ class Render extends Component<void, Props, State> {
         <Box key={folder.path} style={styleFolderLine} onClick={() => this.props.onFolderClick(folder)}>
           <Icon {...folderIconProps(folder, styleFolderIcon)} />
           <Box className='hover-underline'>
-            <Text type='Body'>{folder.isPublic ? 'public/' : 'private/'}</Text>
-            <Usernames inline users={folder.users} type='Body' />
+            <Text type='Body' style={{color: 'inherit'}}>{folder.isPublic ? 'public/' : 'private/'}</Text>
+            <Usernames inline users={folder.users} type='Body' style={{color: 'inherit'}} />
           </Box>
         </Box>
       ))

--- a/shared/profile/render.desktop.js
+++ b/shared/profile/render.desktop.js
@@ -16,7 +16,7 @@ export const HEADER_SIZE = AVATAR_SIZE / 2 + HEADER_TOP_SPACE
 
 type State = {
   currentFriendshipsTab: FriendshipsTab,
-  foldersExpanded: boolean
+  foldersExpanded: boolean,
 }
 
 function folderIconProps (folder, style) {

--- a/shared/profile/render.desktop.js
+++ b/shared/profile/render.desktop.js
@@ -7,6 +7,7 @@ import {headerColor as whichHeaderColor} from '../common-adapters/user-bio.share
 import Friendships from './friendships'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import ProfileHelp from './help.desktop'
+import {folderIconProps} from './render.shared'
 import type {Tab as FriendshipsTab} from './friendships'
 import type {Props} from './render'
 
@@ -17,21 +18,6 @@ export const HEADER_SIZE = AVATAR_SIZE / 2 + HEADER_TOP_SPACE
 type State = {
   currentFriendshipsTab: FriendshipsTab,
   foldersExpanded: boolean,
-}
-
-function folderIconProps (folder, style) {
-  const type = folder.isPublic
-    ? (folder.hasData ? 'fa-kb-iconfont-folder-public-has-files' : 'fa-kb-iconfont-folder-public')
-    : (folder.hasData ? 'fa-kb-iconfont-folder-private-has-files' : 'fa-kb-iconfont-folder-private')
-
-  const color = folder.isPublic
-    ? globalColors.yellowGreen
-    : globalColors.darkBlue2
-
-  return {
-    type,
-    style: {...style, color},
-  }
 }
 
 class Render extends Component<void, Props, State> {

--- a/shared/profile/render.native.js
+++ b/shared/profile/render.native.js
@@ -1,9 +1,35 @@
 // @flow
 import React, {Component} from 'react'
-import {Box, ComingSoon} from '../common-adapters'
+import _ from 'lodash'
+import {ScrollView} from 'react-native'
+import {normal as proofNormal} from '../constants/tracker'
+import {BackButton, Box, ComingSoon, Icon, Text, UserActions, UserBio, UserProofs} from '../common-adapters'
+import {usernameText} from '../common-adapters/usernames'
+import Friendships from './friendships'
+import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
+import {headerColor as whichHeaderColor} from '../common-adapters/user-bio.shared'
+import {folderIconProps} from './render.shared'
+import type {Tab as FriendshipsTab} from './friendships'
 import type {Props} from './render'
 
-class Render extends Component<void, Props, void> {
+export const AVATAR_SIZE = 112
+export const HEADER_TOP_SPACE = 48
+export const HEADER_SIZE = AVATAR_SIZE / 2 + HEADER_TOP_SPACE
+
+type State = {
+  currentFriendshipsTab: FriendshipsTab,
+}
+
+class Render extends Component<void, Props, State> {
+  state: State;
+
+  constructor (props: Props) {
+    super(props)
+    this.state = {
+      currentFriendshipsTab: 'Followers',
+    }
+  }
+
   _renderComingSoon () {
     return <ComingSoon />
   }
@@ -12,8 +38,120 @@ class Render extends Component<void, Props, void> {
     if (this.props.showComingSoon) {
       return this._renderComingSoon()
     }
-    return <Box />
+
+    const headerColor = whichHeaderColor(this.props)
+
+    let proofNotice
+    if (this.props.trackerState !== proofNormal) {
+      proofNotice = `Some of ${this.props.username}'s proofs are broken.`
+    }
+
+    let folders = _.chain(this.props.tlfs)
+      .orderBy('isPublic', 'asc')
+      .map(folder => (
+        <Box key={folder.path} style={styleFolderLine}>
+          <Icon {...folderIconProps(folder, styleFolderIcon)} onClick={() => this.props.onFolderClick(folder)} />
+          <Text type='Body' style={{...styleFolderTextLine, ...styleFolderText}} onClick={() => this.props.onFolderClick(folder)}>
+            {folder.isPublic ? 'public/' : 'private/'}
+            {usernameText({type: 'Body', users: folder.users, style: styleFolderText})}
+          </Text>
+        </Box>
+      ))
+      .value()
+
+    return (
+      <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
+        <Box style={{...styleHeader, backgroundColor: headerColor}}>
+          {this.props.onBack && <BackButton title={null} onClick={this.props.onBack} style={{marginLeft: 16}} iconStyle={{color: globalColors.white}} />}
+        </Box>
+        <ScrollView style={{flex: 1, backgroundColor: headerColor}} contentContainerStyle={{backgroundColor: globalColors.white}}>
+          {proofNotice && (
+            <Box style={{...styleProofNotice, backgroundColor: headerColor}}>
+              <Text type='BodySmallSemibold' style={{color: globalColors.white}}>{proofNotice}</Text>
+            </Box>
+          )}
+          <UserBio
+            type='Profile'
+            avatarSize={AVATAR_SIZE}
+            username={this.props.username}
+            userInfo={this.props.userInfo}
+            currentlyFollowing={this.props.currentlyFollowing}
+            trackerState={this.props.trackerState}
+          />
+          <UserActions
+            style={styleActions}
+            trackerState={this.props.trackerState}
+            currentlyFollowing={this.props.currentlyFollowing}
+            onFollow={this.props.onFollow}
+            onUnfollow={this.props.onUnfollow}
+            onAcceptProofs={this.props.onAcceptProofs}
+          />
+          <Box style={styleProofs}>
+            <UserProofs
+              username={this.props.username}
+              proofs={this.props.proofs}
+              currentlyFollowing={this.props.currentlyFollowing}
+            />
+            {folders}
+          </Box>
+          <Friendships
+            currentTab={this.state.currentFriendshipsTab}
+            onSwitchTab={currentFriendshipsTab => this.setState({currentFriendshipsTab})}
+            onUserClick={this.props.onUserClick}
+            followers={this.props.followers}
+            following={this.props.following}
+          />
+        </ScrollView>
+      </Box>
+    )
   }
+}
+
+const styleHeader = {
+  ...globalStyles.flexBoxRow,
+  height: HEADER_TOP_SPACE,
+  alignItems: 'center',
+}
+
+const styleProofNotice = {
+  ...globalStyles.flexBoxRow,
+  justifyContent: 'center',
+  paddingBottom: globalMargins.small,
+}
+
+const styleActions = {
+  ...globalStyles.flexBoxRow,
+  marginTop: globalMargins.small,
+  marginBottom: globalMargins.small,
+  justifyContent: 'center',
+}
+
+const styleProofs = {
+  paddingBottom: globalMargins.medium,
+  paddingLeft: globalMargins.medium,
+  paddingRight: globalMargins.medium,
+}
+
+const styleFolderLine = {
+  ...globalStyles.flexBoxRow,
+  marginTop: globalMargins.tiny,
+}
+
+const styleFolderTextLine = {
+  flex: 1,
+}
+
+const styleFolderText = {
+  color: globalColors.black_60,
+}
+
+const styleFolderIcon = {
+  ...globalStyles.clickable,
+  fontSize: 20,
+  width: 22,
+  textAlign: 'center',
+  color: globalColors.black_75,
+  marginRight: globalMargins.small,
 }
 
 export default Render

--- a/shared/profile/render.shared.js
+++ b/shared/profile/render.shared.js
@@ -1,0 +1,16 @@
+import {globalColors} from '../styles/style-guide'
+
+export function folderIconProps (folder, style = {}) {
+  const type = folder.isPublic
+    ? (folder.hasData ? 'fa-kb-iconfont-folder-public-has-files' : 'fa-kb-iconfont-folder-public')
+    : (folder.hasData ? 'fa-kb-iconfont-folder-private-has-files' : 'fa-kb-iconfont-folder-private')
+
+  const color = folder.isPublic
+    ? globalColors.yellowGreen
+    : globalColors.darkBlue2
+
+  return {
+    type,
+    style: {...style, color},
+  }
+}

--- a/shared/search/user-pane/dumb.desktop.js
+++ b/shared/search/user-pane/dumb.desktop.js
@@ -4,7 +4,7 @@ import NonUserPane from './non-user.render'
 import Help from './help'
 import Loading from './loading'
 import {normal, error} from '../../constants/tracker'
-import {proofsDefault, proofsTracked, proofsChanged, mockUserInfo} from '../../profile/dumb.desktop'
+import {proofsDefault, proofsTracked, proofsChanged, mockUserInfo} from '../../profile/dumb'
 import type {Props as UserRenderProps} from './user.render'
 import type {DumbComponentMap} from '../../constants/types/more'
 

--- a/shared/tracker/render.native.js
+++ b/shared/tracker/render.native.js
@@ -5,7 +5,7 @@ import {Box} from '../common-adapters'
 import Header from './header.render'
 import {UserBio, UserProofs} from '../common-adapters'
 import Action from './action.render'
-import {globalColors} from '../styles/style-guide'
+import {globalColors, globalMargins} from '../styles/style-guide'
 
 import type {RenderProps} from './render'
 
@@ -32,6 +32,7 @@ export default class Render extends Component<void, RenderProps, void> {
             trackerState={this.props.trackerState}
           />
           <UserProofs
+            style={stylesProofs}
             username={this.props.username}
             proofs={this.props.proofs}
             currentlyFollowing={this.props.currentlyFollowing}
@@ -61,4 +62,10 @@ const stylesContainer = {
 }
 const stylesContent = {
   backgroundColor: globalColors.white,
+}
+const stylesProofs = {
+  paddingTop: globalMargins.medium,
+  paddingBottom: globalMargins.medium,
+  paddingLeft: globalMargins.medium,
+  paddingRight: globalMargins.medium,
 }


### PR DESCRIPTION
:eyeglasses: @keybase/react-hackers 

This is roughly complete. Some visual / polish issues outstanding (deferred):
- Text wrapping on the folder names seems difficult to control. Haven't found a good solution for this yet.
- The "Tracking" button text is not vertically centered
- Switching between the friendships "Followers" / "Following" modes can scroll the view if the grid contents changes the container height.

<img src="https://cloud.githubusercontent.com/assets/16893/16627597/ca9a6c28-4362-11e6-9ad0-e87b69366b57.png" width="200"><img src="https://cloud.githubusercontent.com/assets/16893/16627596/ca99e74e-4362-11e6-9a1e-546942877b81.png" width="200"><img src="https://cloud.githubusercontent.com/assets/16893/16627593/ca97a4ac-4362-11e6-889a-e05f9703882d.png" width="200"><img src="https://cloud.githubusercontent.com/assets/16893/16627594/ca9840e2-4362-11e6-95a0-147185113a4d.png" width="200"><img src="https://cloud.githubusercontent.com/assets/16893/16627595/ca9877ec-4362-11e6-81cc-bf1d87a3a7fe.png" width="200"><img src="https://cloud.githubusercontent.com/assets/16893/16627598/caa0034a-4362-11e6-988a-75f7b50b2d94.png" width="200">