### PR TITLE
Fix status and waiting on install

### DIFF
--- a/go/client/cmd_ctl_start_osx.go
+++ b/go/client/cmd_ctl_start_osx.go
@@ -7,7 +7,6 @@ package client
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/install"
@@ -77,7 +76,7 @@ func ctlStart(g *libkb.GlobalContext, components map[string]bool) error {
 		}
 	}
 	if ok := components[install.ComponentNameUpdater.String()]; ok {
-		if err := launchd.Start(install.DefaultUpdaterLabel(), 5*time.Second, g.Log); err != nil {
+		if err := launchd.Start(install.DefaultUpdaterLabel(), defaultLaunchdWait, g.Log); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/go/client/cmd_log_send.go
+++ b/go/client/cmd_log_send.go
@@ -8,10 +8,11 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"os"
+
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
-	"os"
 )
 
 const (

--- a/go/install/install_osx.go
+++ b/go/install/install_osx.go
@@ -24,7 +24,7 @@ import (
 )
 
 // defaultLaunchdWait is how long we should wait after install, start, etc
-const defaultLaunchdWait = 5 * time.Second
+const defaultLaunchdWait = 10 * time.Second
 
 // ServiceLabel is an identifier string for a service
 type ServiceLabel string


### PR DESCRIPTION
This fixes the bug where it thought the services weren't running after reboot.

This bug is also related:
https://keybase.atlassian.net/browse/CORE-2649

I was able to reproduce the bug by having tons of apps running before rebooting (causing resource contention at boot). 

-  WaitForStatus should keep waiting if no pid and no exit status (main fix)
- Fix updater status potentially hitting null pointer panic
- launchd use CombinedOutput() for debug log
- Use defaultLaunchdWait instead of hardcoded seconds