### PR TITLE
logger: print times and debug tags in test logs

### DIFF
--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -113,7 +113,7 @@ func (log *Standard) setLogLevelInfo() {
 	}
 }
 
-func (log *Standard) prepareString(
+func prepareString(
 	ctx context.Context, fmts string) string {
 	if ctx == nil {
 		return fmts
@@ -141,7 +141,7 @@ func (log *Standard) Debug(fmt string, arg ...interface{}) {
 func (log *Standard) CDebugf(ctx context.Context, fmt string,
 	arg ...interface{}) {
 	if log.internal.IsEnabledFor(logging.DEBUG) {
-		log.Debug(log.prepareString(ctx, fmt), arg...)
+		log.Debug(prepareString(ctx, fmt), arg...)
 	}
 }
 
@@ -155,7 +155,7 @@ func (log *Standard) Info(fmt string, arg ...interface{}) {
 func (log *Standard) CInfof(ctx context.Context, fmt string,
 	arg ...interface{}) {
 	if log.internal.IsEnabledFor(logging.INFO) {
-		log.Info(log.prepareString(ctx, fmt), arg...)
+		log.Info(prepareString(ctx, fmt), arg...)
 	}
 }
 
@@ -169,7 +169,7 @@ func (log *Standard) Notice(fmt string, arg ...interface{}) {
 func (log *Standard) CNoticef(ctx context.Context, fmt string,
 	arg ...interface{}) {
 	if log.internal.IsEnabledFor(logging.NOTICE) {
-		log.Notice(log.prepareString(ctx, fmt), arg...)
+		log.Notice(prepareString(ctx, fmt), arg...)
 	}
 }
 
@@ -183,7 +183,7 @@ func (log *Standard) Warning(fmt string, arg ...interface{}) {
 func (log *Standard) CWarningf(ctx context.Context, fmt string,
 	arg ...interface{}) {
 	if log.internal.IsEnabledFor(logging.WARNING) {
-		log.Warning(log.prepareString(ctx, fmt), arg...)
+		log.Warning(prepareString(ctx, fmt), arg...)
 	}
 }
 
@@ -201,7 +201,7 @@ func (log *Standard) Errorf(fmt string, arg ...interface{}) {
 func (log *Standard) CErrorf(ctx context.Context, fmt string,
 	arg ...interface{}) {
 	if log.internal.IsEnabledFor(logging.ERROR) {
-		log.Error(log.prepareString(ctx, fmt), arg...)
+		log.Error(prepareString(ctx, fmt), arg...)
 	}
 }
 
@@ -215,7 +215,7 @@ func (log *Standard) Critical(fmt string, arg ...interface{}) {
 func (log *Standard) CCriticalf(ctx context.Context, fmt string,
 	arg ...interface{}) {
 	if log.internal.IsEnabledFor(logging.CRITICAL) {
-		log.Critical(log.prepareString(ctx, fmt), arg...)
+		log.Critical(prepareString(ctx, fmt), arg...)
 	}
 }
 
@@ -228,7 +228,7 @@ func (log *Standard) Fatalf(fmt string, arg ...interface{}) {
 
 func (log *Standard) CFatalf(ctx context.Context, fmt string,
 	arg ...interface{}) {
-	log.Fatalf(log.prepareString(ctx, fmt), arg...)
+	log.Fatalf(prepareString(ctx, fmt), arg...)
 }
 
 func (log *Standard) Profile(fmts string, arg ...interface{}) {

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"time"
 
 	logging "github.com/keybase/go-logging"
 
@@ -47,7 +48,8 @@ func prefixCaller(extraDepth int, lvl logging.Level, fmts string) string {
 	// it out (at least on a terminal) and do our own formatting.
 	_, file, line, _ := runtime.Caller(2 + extraDepth)
 	elements := strings.Split(file, "/")
-	return fmt.Sprintf("\r%s:%d: [%.1s] %s", elements[len(elements)-1], line, lvl, fmts)
+	return fmt.Sprintf("%s \r%s:%d: [%.1s] %s", time.Now(),
+		elements[len(elements)-1], line, lvl, fmts)
 }
 
 func (log *TestLogger) Debug(fmts string, arg ...interface{}) {
@@ -56,7 +58,8 @@ func (log *TestLogger) Debug(fmts string, arg ...interface{}) {
 
 func (log *TestLogger) CDebugf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.DEBUG, fmts), arg...)
+	log.log.Logf(prepareString(ctx,
+		prefixCaller(log.extraDepth, logging.DEBUG, fmts)), arg...)
 }
 
 func (log *TestLogger) Info(fmts string, arg ...interface{}) {
@@ -65,7 +68,8 @@ func (log *TestLogger) Info(fmts string, arg ...interface{}) {
 
 func (log *TestLogger) CInfof(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.INFO, fmts), arg...)
+	log.log.Logf(prepareString(ctx,
+		prefixCaller(log.extraDepth, logging.INFO, fmts)), arg...)
 }
 
 func (log *TestLogger) Notice(fmts string, arg ...interface{}) {
@@ -74,7 +78,8 @@ func (log *TestLogger) Notice(fmts string, arg ...interface{}) {
 
 func (log *TestLogger) CNoticef(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.NOTICE, fmts), arg...)
+	log.log.Logf(prepareString(ctx,
+		prefixCaller(log.extraDepth, logging.NOTICE, fmts)), arg...)
 }
 
 func (log *TestLogger) Warning(fmts string, arg ...interface{}) {
@@ -83,7 +88,8 @@ func (log *TestLogger) Warning(fmts string, arg ...interface{}) {
 
 func (log *TestLogger) CWarningf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.WARNING, fmts), arg...)
+	log.log.Logf(prepareString(ctx,
+		prefixCaller(log.extraDepth, logging.WARNING, fmts)), arg...)
 }
 
 func (log *TestLogger) Error(fmts string, arg ...interface{}) {
@@ -96,7 +102,8 @@ func (log *TestLogger) Errorf(fmts string, arg ...interface{}) {
 
 func (log *TestLogger) CErrorf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.ERROR, fmts), arg...)
+	log.log.Logf(prepareString(ctx,
+		prefixCaller(log.extraDepth, logging.ERROR, fmts)), arg...)
 }
 
 func (log *TestLogger) Critical(fmts string, arg ...interface{}) {
@@ -105,7 +112,8 @@ func (log *TestLogger) Critical(fmts string, arg ...interface{}) {
 
 func (log *TestLogger) CCriticalf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.log.Logf(prepareString(ctx,
+		prefixCaller(log.extraDepth, logging.CRITICAL, fmts)), arg...)
 }
 
 func (log *TestLogger) Fatalf(fmts string, arg ...interface{}) {
@@ -114,7 +122,8 @@ func (log *TestLogger) Fatalf(fmts string, arg ...interface{}) {
 
 func (log *TestLogger) CFatalf(ctx context.Context, fmts string,
 	arg ...interface{}) {
-	log.log.Fatalf(prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.log.Fatalf(prepareString(ctx,
+		prefixCaller(log.extraDepth, logging.CRITICAL, fmts)), arg...)
 }
 
 func (log *TestLogger) Profile(fmts string, arg ...interface{}) {


### PR DESCRIPTION
@akalin-keybase I know you started on other more general logging fixes, but these changes really helped me debug timing problems in the face of concurrency in the tests, so this seems worth doing to me.  I don't think it precludes your other eventual changes.
