### PR TITLE
Only quit app in dev mode

### DIFF
--- a/desktop/app/ctl.js
+++ b/desktop/app/ctl.js
@@ -9,6 +9,13 @@ export function ctlStop (callback) {
 }
 
 export function quit () {
+  // Only quit the app in dev mode
+  if (__DEV__) {
+    console.log('Only quiting app in dev mode')
+    app.quit()
+    return
+  }
+
   console.log('Quit the app')
   ctlStop(function (stopErr) {
     if (stopErr) {


### PR DESCRIPTION
Otherwise the world gets stopped and we don't run installer on start in dev mode
so there is a mismatch in behavior there.