### PR TITLE
Wait for NSTask to complete, prevent terminationHandler flakiness

### DIFF
--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.31</string>
+	<string>1.1.32</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.31</string>
+	<string>1.1.32</string>
 	<key>KBFuseBuild</key>
 	<string>3.2.0</string>
 	<key>KBFuseVersion</key>

--- a/osx/KBKit/KBKit/System/KBLaunchCtl.m
+++ b/osx/KBKit/KBKit/System/KBLaunchCtl.m
@@ -143,6 +143,7 @@
 
   @try {
     [task launch];
+    [task waitUntilExit];
   } @catch (NSException *e) {
     completion(KBMakeError(KBErrorCodeGeneric, @"%@", e.reason), nil);
   }

--- a/osx/KBKit/KBKit/System/KBTask.m
+++ b/osx/KBKit/KBKit/System/KBTask.m
@@ -43,6 +43,7 @@
   @try {
     DDLogDebug(@"Task: %@ %@", command, [args join:@" "]);
     [task launch];
+    [task waitUntilExit];
   } @catch (NSException *e) {
     NSString *errorMessage = NSStringWithFormat(@"%@ (%@ %@)", e.reason, command, [args join:@" "]);
     DDLogError(@"Error running task: %@", errorMessage);


### PR DESCRIPTION
Given some reports of installer hanging, I'm thinking due to the
terminationHandler not being called, due to maybe a race condition
where the NSTask is released before calling the termination handler
because it's being allocated statically and ARC might be releasing
it prematurely.

I'm seeing if a user can repro using build with this change:
https://github.com/keybase/client/issues/3369