### PR TITLE
Fix tracker closing on follow and checking jankiness

### DIFF
--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -230,18 +230,21 @@ export function onRefollow (username: string): TrackerActionCreator {
     const trackToken = _getTrackToken(getState(), username)
 
     const dispatchRefollowAction = () => {
+      dispatch(onWaiting(username, false))
       dispatch({
         type: Constants.onRefollow,
         payload: {username},
       })
     }
     const dispatchErrorAction = () => {
+      dispatch(onWaiting(username, false))
       dispatch({
         type: Constants.onError,
         payload: {username},
       })
     }
 
+    dispatch(onWaiting(username, true))
     trackUser(trackToken, false)
       .then(dispatchRefollowAction)
       .catch(err => {
@@ -256,6 +259,7 @@ export function onUnfollow (username: string): TrackerActionCreator {
       method: 'track.untrack',
       param: {username},
       callback: (err, response) => {
+        dispatch(onWaiting(username, false))
         if (err) {
           console.log('err untracking', err)
         } else {
@@ -268,6 +272,7 @@ export function onUnfollow (username: string): TrackerActionCreator {
       },
     }
 
+    dispatch(onWaiting(username, true))
     engine.rpc(params)
 
     dispatch({


### PR DESCRIPTION
@keybase/react-hackers 

This fixes https://keybase.atlassian.net/browse/DESKTOP-1378

Which was caused by a race condition where we get a userUpdated action *before* we get a on(Re)Follow action.

This causes the app to think that you tracked from somewhere else and closes that window.

(We might want to discuss if that logic even makes sense, removing it would mean the only way to close a tracker is to manually close it)

This also fixes the jankiness you get with mutliple identifies and flashing windows.

The problem is we defaulted to `checking` if we couldn't parse the proofstate, that meant that if we knew something was broken, if we got another proof update that didn't make sense we would change it to checking. Now we keep the old proof state until told otherwise. A much smoother experience.