### PR TITLE
Concurrent visdiff rendering

### DIFF
--- a/desktop/test/render-visdiff.js
+++ b/desktop/test/render-visdiff.js
@@ -29,6 +29,8 @@ Object.keys(dumbComponentMap).forEach(key => {
 
 app.on('ready', () => {
   let rendering = 0
+  const total = toRender.length
+  let count = 0
 
   function renderNext (target) {
     if (!toRender.length) {
@@ -51,7 +53,8 @@ app.on('ready', () => {
           console.log('Error writing image', err)
           app.exit(1)
         }
-        console.log('wrote', filename)
+        count++
+        console.log(`[${count} / ${total}] wrote ${filename}`)
         rendering--
         renderNext(sender)
       })

--- a/desktop/test/render-visdiff.js
+++ b/desktop/test/render-visdiff.js
@@ -67,6 +67,8 @@ app.on('ready', () => {
   for (let i = 0; i < WORKER_COUNT; i++) {
     setTimeout(() => {
       const workerWin = new BrowserWindow({show: false, width: CANVAS_SIZE, height: CANVAS_SIZE})
+      // TODO: once we're on electron v1.2.3, try ready-to-show event.
+      workerWin.webContents.once('did-finish-load', () => renderNext(workerWin.webContents))
       workerWin.loadURL(resolveRootAsURL('renderer', `index.html?src=${scriptPath}`))
     }, i * 150)
   }

--- a/shared/test/render-dumb-sheet.js
+++ b/shared/test/render-dumb-sheet.js
@@ -48,7 +48,7 @@ ipcRenderer.on('display', (ev, msg) => {
       }
 
       ev.sender.send('display-done', {rect, ...msg})
-    }, 250)
+    }, 1000)
   })
 })
 

--- a/shared/test/render-dumb-sheet.js
+++ b/shared/test/render-dumb-sheet.js
@@ -31,7 +31,7 @@ ipcRenderer.on('display', (ev, msg) => {
   ReactDOM.render(displayTree, appEl, () => {
     // Remove pesky blinking cursors
     if (document.activeElement.tagName === 'INPUT') {
-      window.blur()
+      document.activeElement.blur()
     }
 
     // Unfortunately some resources lazy load after they're rendered.  We need

--- a/shared/test/render-dumb-sheet.js
+++ b/shared/test/render-dumb-sheet.js
@@ -51,16 +51,3 @@ ipcRenderer.on('display', (ev, msg) => {
     }, 1000)
   })
 })
-
-declare class ExtendedDocument extends Document {
-  fonts: {
-    ready: Promise
-  }
-}
-declare var document: ExtendedDocument
-
-window.addEventListener('load', () =>
-  document.fonts.ready.then(() =>
-    ipcRenderer.send('visdiff-ready')
-  )
-)

--- a/visdiff/src/index.js
+++ b/visdiff/src/index.js
@@ -61,7 +61,9 @@ function renderScreenshots (commitRange) {
     checkout(commit)
     console.log(`Rendering screenshots of ${commit}`)
     mkdirp.sync(`screenshots/${commit}`)
+    const startTime = Date.now()
     spawnSync(NPM_CMD, ['run', 'render-screenshots', '--', `screenshots/${commit}`], {stdio: 'inherit'})
+    console.log(`Rendered in ${(Date.now() - startTime) / 1000}s.`)
   }
 }
 

--- a/visdiff/src/index.js
+++ b/visdiff/src/index.js
@@ -28,7 +28,7 @@ const DIFF_SAME = 'same'
 const DRY_RUN = !!process.env['VISDIFF_DRY_RUN']
 
 function packageHash () {
-  return crypto.createHash('sha1').update(fs.readFileSync('package.json')).digest('hex')
+  return crypto.createHash('sha1').update(fs.readFileSync('package.json')).digest('hex').substr(0, 12)
 }
 
 function checkout (commit) {


### PR DESCRIPTION
I've tried a lot of things to fix the intermittent missing images issue, and the only thing that has worked so far is increasing the timeout length.

The idea here is to saturate all available CPUs with concurrently rendering browser windows, so that even if there's a sleep fudge factor for images/fonts/etc to load, we're still maximizing the throughput of the visdiff. Higher concurrency doesn't seem to negate the effect of the sleep fudge factor. From my experimentation, this is a pretty big win -- over 2x rendering speed on my dev machine, and the CPU utilization is much higher.

The only visdiff here should be input components being defocused, since it turns out my previous fix for that wasn't working. Increasing the concurrency made this inconsistency more apparent. :disappointed: 