### PR TITLE
Implement correct dock icon behavior

### DIFF
--- a/desktop/app/dock-icon.js
+++ b/desktop/app/dock-icon.js
@@ -1,24 +1,19 @@
+// @flow
+
 import {app} from 'electron'
 
-var visibleCount = 0
+let isDockVisible = false
 
-export default (() => {
-  if (!app.dock) {
-    return () => () => {}
+export function showDockIcon () {
+  if (!isDockVisible) {
+    isDockVisible = true
+    app.dock && app.dock.show()
   }
-  return function () {
-    if (++visibleCount === 1) {
-      app.dock.show()
-    }
-    let alreadyHidden = false
-    return () => {
-      if (alreadyHidden) {
-        throw new Error('Tried to hide the dock icon twice')
-      }
-      alreadyHidden = true
-      if (--visibleCount === 0) {
-        app.dock.hide()
-      }
-    }
+}
+
+export function hideDockIcon () {
+  if (isDockVisible) {
+    isDockVisible = false
+    app.dock && app.dock.hide()
   }
-})()
+}

--- a/desktop/app/index.js
+++ b/desktop/app/index.js
@@ -2,7 +2,6 @@ import {BrowserWindow, app, dialog} from 'electron'
 import splash from './splash'
 import installer from './installer'
 import ListenLogUi from '../shared/native/listen-log-ui'
-import menuHelper from './menu-helper'
 import consoleHelper, {ipcLogs} from './console-helper'
 import devTools from './dev-tools'
 import menuBar from './menu-bar'
@@ -14,6 +13,7 @@ import hello from '../shared/util/hello'
 import semver from 'semver'
 import os from 'os'
 import {setupExecuteActionsListener} from '../shared/util/quit-helper.desktop'
+import {hideDockIcon} from './dock-icon'
 
 let mainWindow = null
 
@@ -21,7 +21,6 @@ function start () {
   // Only one app per app in osx...
   const shouldQuit = app.makeSingleInstance(() => {
     if (mainWindow) {
-      mainWindow.show()
       mainWindow.show(true)
       mainWindow.window.focus()
     }
@@ -67,10 +66,6 @@ function start () {
   ListenLogUi()
   windowHelper(app)
 
-  if (process.platform === 'darwin') {
-    menuHelper()
-  }
-
   installer(err => {
     if (err) {
       console.log('Error: ', err)
@@ -81,9 +76,16 @@ function start () {
   app.once('ready', () => {
     mainWindow = MainWindow()
     storeHelper(mainWindow)
-    if (app.dock && !mainWindow.initiallyVisible) {
-      app.dock.hide()
+    if (!mainWindow.initiallyVisible) {
+      hideDockIcon()
     }
+  })
+
+  // Called when the user clicks the dock icon
+  // We'll show the main window if there are no visible
+  // windows
+  app.on('activate', (e, hasVisibleWindows) => {
+    mainWindow.show(true)
   })
 
   // Don't quit the app, instead try to close all windows

--- a/desktop/app/index.js
+++ b/desktop/app/index.js
@@ -82,9 +82,7 @@ function start () {
   })
 
   // Called when the user clicks the dock icon
-  // We'll show the main window if there are no visible
-  // windows
-  app.on('activate', (e, hasVisibleWindows) => {
+  app.on('activate', () => {
     mainWindow.show(true)
   })
 

--- a/shared/util/quit-helper.desktop.js
+++ b/shared/util/quit-helper.desktop.js
@@ -1,16 +1,17 @@
 // @flow
 import {ipcRenderer, ipcMain, app} from 'electron'
 import {quit} from '../../desktop/app/ctl'
+import {hideDockIcon} from '../../desktop/app/dock-icon'
 
 export type Context = {type: 'uiWindow'} | {type: 'mainThread'} | {type: 'quitButton'}
 
-export type Action = {type: 'closePopups'} | {type: 'hideMainWindow'} | {type: 'quitApp'}
+export type Action = {type: 'closePopups'} | {type: 'quitMainWindow'} | {type: 'quitApp'}
 
 // Logic to figure out what to do given your context
 export function quitOnContext (context: Context): Array<Action> {
   switch (context.type) {
     case 'uiWindow':
-      return [{type: 'closePopups'}, {type: 'hideMainWindow'}]
+      return [{type: 'closePopups'}, {type: 'quitMainWindow'}]
     case 'mainThread':
     case 'quitButton':
       return [{type: 'quitApp'}]
@@ -28,7 +29,9 @@ function isMainThread () {
 function _executeActions (actions: Array<Action>) {
   actions.forEach(a => {
     switch (a.type) {
-      case 'hideMainWindow':
+      case 'quitMainWindow':
+        hideDockIcon()
+        return
       case 'closePopups':
         app.emit('close-windows')
         return


### PR DESCRIPTION
If you close all windows the dock icon will stay (clicking it will bring
the main window back).

If you hide windows cmd-tabbing or clicking the dock icon will bring
back the windows.

If you cmd-q all windows will close and the dock icon will disappear.
You can get to the main window from the menubar.

Also fixes a bug that prevented us from hiding the main window. We have
to build the application menu while the dock icon is visible, otherwise
we can't hide the window.

@keybase/react-hackers 