### PR TITLE
Register: Make paper key errors work

### DIFF
--- a/shared/login/register/paper-key/dumb.js
+++ b/shared/login/register/paper-key/dumb.js
@@ -9,7 +9,7 @@ const baseMock = {
   onChangePaperKey: () => console.log('onBack'),
   paperKey: '',
   waitingForResponse: false,
-  error: ''
+  error: '',
 }
 
 const dumbComponentMap: DumbComponentMap<Render> = {

--- a/shared/login/register/paper-key/dumb.js
+++ b/shared/login/register/paper-key/dumb.js
@@ -9,6 +9,7 @@ const baseMock = {
   onChangePaperKey: () => console.log('onBack'),
   paperKey: '',
   waitingForResponse: false,
+  error: ''
 }
 
 const dumbComponentMap: DumbComponentMap<Render> = {

--- a/shared/login/register/paper-key/index.js
+++ b/shared/login/register/paper-key/index.js
@@ -23,6 +23,7 @@ class PaperKey extends Component<void, Props, State> {
         onChangePaperKey={paperKey => this.setState({paperKey})}
         onBack={this.props.onBack}
         paperKey={this.state.paperKey}
+        error={this.props.error}
         waitingForResponse={this.props.waitingForResponse}
       />
     )

--- a/shared/login/register/paper-key/index.js.flow
+++ b/shared/login/register/paper-key/index.js.flow
@@ -4,7 +4,8 @@ import React, {Component} from 'react'
 export type Props = {
   onSubmit: (paperKey: string) => void,
   onBack: () => void,
-  waitingForResponse?: boolean
+  waitingForResponse?: boolean,
+  error: string
 }
 
 export type State = {

--- a/shared/login/register/paper-key/index.render.desktop.js
+++ b/shared/login/register/paper-key/index.render.desktop.js
@@ -4,7 +4,7 @@ import {Text, Icon, Input, Button} from '../../../common-adapters'
 import Container from '../../forms/container.desktop'
 import type {Props} from './index.render'
 
-const Render = ({onBack, onSubmit, onChangePaperKey, paperKey, waitingForResponse}: Props) => {
+const Render = ({onBack, onSubmit, onChangePaperKey, error, paperKey, waitingForResponse}: Props) => {
   return (
     <Container
       style={styles.container}
@@ -15,6 +15,7 @@ const Render = ({onBack, onSubmit, onChangePaperKey, paperKey, waitingForRespons
         autoFocus
         multiLine
         style={styles.input}
+        errorText={error}
         hintText='opp blezzard tofi pando agg whi pany yaga jocket daubt bruwnstane hubit yas'
         onEnterKeyDown={() => onSubmit()}
         onChange={event => onChangePaperKey(event.target.value)}

--- a/shared/login/register/paper-key/index.render.js.flow
+++ b/shared/login/register/paper-key/index.render.js.flow
@@ -6,6 +6,7 @@ export type Props = {
   onSubmit: () => void,
   onChangePaperKey: (val: string) => void,
   paperKey: string,
+  error: string,
   waitingForResponse?: ?boolean
 }
 

--- a/shared/login/register/paper-key/index.render.native.js
+++ b/shared/login/register/paper-key/index.render.native.js
@@ -21,6 +21,7 @@ class PaperKeyRender extends Component<void, Props, void> {
             style={stylesInput}
             floatingLabelText='Paper key'
             hintText='opp blezzard tofi pando'
+            errorText={this.props.error}
             onEnterKeyDown={() => this.props.onSubmit()}
             onChangeText={paperKey => this.props.onChangePaperKey(paperKey)}
             type='passwordVisible'


### PR DESCRIPTION
@keybase/react-hackers 

We already had the data in props, but it never got plumbed through to the input component.

![screenshot from 2016-07-11 11-11-58](https://cloud.githubusercontent.com/assets/21217/16735804/582e3648-4758-11e6-81a8-39b9d09c424c.png)
