### PR TITLE
Move DLL loading code from client to libkb for kbfs

### DIFF
--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -37,7 +37,7 @@ type Stopper interface {
 }
 
 func main() {
-	err := client.SaferDLLLoading()
+	err := libkb.SaferDLLLoading()
 
 	g := G
 	g.Init()

--- a/go/libkb/saferdllloading_dummy.go
+++ b/go/libkb/saferdllloading_dummy.go
@@ -3,7 +3,7 @@
 // Copyright 2016 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
-package client
+package libkb
 
 // SaferDLLLoading dummy for platforms not needing this.
 func SaferDLLLoading() error { return nil }

--- a/go/libkb/saferdllloading_test.go
+++ b/go/libkb/saferdllloading_test.go
@@ -1,4 +1,4 @@
-package client
+package libkb
 
 import "testing"
 

--- a/go/libkb/saferdllloading_windows.go
+++ b/go/libkb/saferdllloading_windows.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
-package client
+package libkb
 
 import (
 	"errors"


### PR DESCRIPTION
I noticed we only vendor few packages from client to kbfs, this should thus be in libkb.

Sorry for the duplicate work. This changes functionally nothing.