### PR TITLE
Add timeouts to RemoteIdentifyUI calls, check errors

### DIFF
--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -42,13 +42,15 @@ type BaseIdentifyUI struct {
 	parent *UI
 }
 
-func (ui BaseIdentifyUI) DisplayUserCard(keybase1.UserCard) {}
+func (ui BaseIdentifyUI) DisplayUserCard(keybase1.UserCard) error {
+	return nil
+}
 
 type IdentifyUI struct {
 	BaseIdentifyUI
 }
 
-func (ui BaseIdentifyUI) Start(username string, reason keybase1.IdentifyReason) {
+func (ui BaseIdentifyUI) Start(username string, reason keybase1.IdentifyReason) error {
 	msg := "Identifying "
 	switch reason.Type {
 	case keybase1.IdentifyReasonType_TRACK:
@@ -57,9 +59,10 @@ func (ui BaseIdentifyUI) Start(username string, reason keybase1.IdentifyReason) 
 		msg = "Identifying recipient "
 	case keybase1.IdentifyReasonType_DECRYPT:
 		ui.G().Log.Info("Message authored by " + ColorString("bold", username) + "; identifying...")
-		return
+		return nil
 	}
 	ui.G().Log.Info(msg + ColorString("bold", username))
+	return nil
 }
 
 func (ui BaseIdentifyUI) DisplayTrackStatement(stmt string) error {
@@ -70,10 +73,12 @@ func (ui BaseIdentifyUI) ReportTrackToken(_ keybase1.TrackToken) error {
 	return nil
 }
 
-func (ui BaseIdentifyUI) Finish() {
+func (ui BaseIdentifyUI) Finish() error {
+	return nil
 }
 
-func (ui BaseIdentifyUI) Dismiss(_ string, _ keybase1.DismissReason) {
+func (ui BaseIdentifyUI) Dismiss(_ string, _ keybase1.DismissReason) error {
+	return nil
 }
 
 func (ui BaseIdentifyUI) Confirm(o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
@@ -94,8 +99,8 @@ func (ui BaseIdentifyUI) Confirm(o *keybase1.IdentifyOutcome) (keybase1.ConfirmR
 	return keybase1.ConfirmResult{IdentityConfirmed: false, RemoteConfirmed: false}, nil
 }
 
-func (ui BaseIdentifyUI) LaunchNetworkChecks(i *keybase1.Identity, u *keybase1.User) {
-	return
+func (ui BaseIdentifyUI) LaunchNetworkChecks(i *keybase1.Identity, u *keybase1.User) error {
+	return nil
 }
 
 func (ui BaseIdentifyUI) ReportRevoked(del []keybase1.TrackDiff) {
@@ -345,7 +350,7 @@ func (w LinkCheckResultWrapper) GetCachedMsg() string {
 	return msg
 }
 
-func (ui BaseIdentifyUI) FinishSocialProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) {
+func (ui BaseIdentifyUI) FinishSocialProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
 	var msg, lcrs string
 
 	s := RemoteProofWrapper{p}
@@ -374,6 +379,8 @@ func (ui BaseIdentifyUI) FinishSocialProofCheck(p keybase1.RemoteProof, l keybas
 		msg += " " + ColorString("magenta", cachedMsg)
 	}
 	ui.ReportHook(msg)
+
+	return nil
 }
 
 func trackDiffToColor(typ keybase1.TrackDiffType) string {
@@ -403,7 +410,7 @@ func (ui BaseIdentifyUI) TrackDiffUpgradedToString(t libkb.TrackDiffUpgraded) st
 	return ColorString("orange", "<Upgraded from "+t.GetPrev()+" to "+t.GetCurr()+">")
 }
 
-func (ui BaseIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) {
+func (ui BaseIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
 	var msg, lcrs string
 
 	s := RemoteProofWrapper{p}
@@ -451,14 +458,17 @@ func (ui BaseIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, l keybase1.
 		msg += " " + ColorString("magenta", cachedMsg)
 	}
 	ui.ReportHook(msg)
+
+	return nil
 }
 
-func (ui BaseIdentifyUI) DisplayCryptocurrency(l keybase1.Cryptocurrency) {
+func (ui BaseIdentifyUI) DisplayCryptocurrency(l keybase1.Cryptocurrency) error {
 	msg := (BTC + " bitcoin " + ColorString("green", l.Address))
 	ui.ReportHook(msg)
+	return nil
 }
 
-func (ui BaseIdentifyUI) DisplayKey(key keybase1.IdentifyKey) {
+func (ui BaseIdentifyUI) DisplayKey(key keybase1.IdentifyKey) error {
 	var fpq string
 	if fp := libkb.ImportPGPFingerprintSlice(key.PGPFingerprint); fp != nil {
 		fpq = fp.ToQuads()
@@ -477,9 +487,11 @@ func (ui BaseIdentifyUI) DisplayKey(key keybase1.IdentifyKey) {
 		msg := CHECK + " " + ColorString("green", "public key fingerprint: "+fpq)
 		ui.ReportHook(msg)
 	}
+
+	return nil
 }
 
-func (ui BaseIdentifyUI) ReportLastTrack(tl *keybase1.TrackSummary) {
+func (ui BaseIdentifyUI) ReportLastTrack(tl *keybase1.TrackSummary) error {
 	if t := libkb.ImportTrackSummary(tl); t != nil {
 		locally := ""
 		if !t.IsRemote() {
@@ -489,6 +501,8 @@ func (ui BaseIdentifyUI) ReportLastTrack(tl *keybase1.TrackSummary) {
 			locally, t.Username(), libkb.FormatTime(t.GetCTime())))
 		ui.ReportHook(msg)
 	}
+
+	return nil
 }
 
 func (ui BaseIdentifyUI) Warning(m string) {

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -176,7 +176,7 @@ type FakeIdentifyUI struct {
 	sync.Mutex
 }
 
-func (ui *FakeIdentifyUI) FinishWebProofCheck(proof keybase1.RemoteProof, result keybase1.LinkCheckResult) {
+func (ui *FakeIdentifyUI) FinishWebProofCheck(proof keybase1.RemoteProof, result keybase1.LinkCheckResult) error {
 	ui.Lock()
 	defer ui.Unlock()
 	if ui.Proofs == nil {
@@ -191,9 +191,10 @@ func (ui *FakeIdentifyUI) FinishWebProofCheck(proof keybase1.RemoteProof, result
 	if result.BreaksTracking {
 		ui.BrokenTracking = true
 	}
+	return nil
 }
 
-func (ui *FakeIdentifyUI) FinishSocialProofCheck(proof keybase1.RemoteProof, result keybase1.LinkCheckResult) {
+func (ui *FakeIdentifyUI) FinishSocialProofCheck(proof keybase1.RemoteProof, result keybase1.LinkCheckResult) error {
 	ui.Lock()
 	defer ui.Unlock()
 	if ui.Proofs == nil {
@@ -207,6 +208,7 @@ func (ui *FakeIdentifyUI) FinishSocialProofCheck(proof keybase1.RemoteProof, res
 	if result.BreaksTracking {
 		ui.BrokenTracking = true
 	}
+	return nil
 }
 
 func (ui *FakeIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (result keybase1.ConfirmResult, err error) {
@@ -217,10 +219,11 @@ func (ui *FakeIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (result key
 	result.RemoteConfirmed = outcome.TrackOptions.BypassConfirm && !outcome.TrackOptions.ExpiringLocal
 	return
 }
-func (ui *FakeIdentifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency) {
+func (ui *FakeIdentifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency) error {
+	return nil
 }
 
-func (ui *FakeIdentifyUI) DisplayKey(ik keybase1.IdentifyKey) {
+func (ui *FakeIdentifyUI) DisplayKey(ik keybase1.IdentifyKey) error {
 	ui.Lock()
 	defer ui.Unlock()
 	if ui.Keys == nil {
@@ -230,32 +233,50 @@ func (ui *FakeIdentifyUI) DisplayKey(ik keybase1.IdentifyKey) {
 
 	ui.Keys[*fp] = ik.TrackDiff
 	ui.DisplayKeyCalls++
+	return nil
 }
-func (ui *FakeIdentifyUI) ReportLastTrack(*keybase1.TrackSummary) {
+func (ui *FakeIdentifyUI) ReportLastTrack(*keybase1.TrackSummary) error {
+	return nil
 }
-func (ui *FakeIdentifyUI) Start(username string, _ keybase1.IdentifyReason) {
+
+func (ui *FakeIdentifyUI) Start(username string, _ keybase1.IdentifyReason) error {
 	ui.Lock()
 	defer ui.Unlock()
 	ui.StartCount++
+	return nil
 }
-func (ui *FakeIdentifyUI) Finish()                                    {}
-func (ui *FakeIdentifyUI) Dismiss(_ string, _ keybase1.DismissReason) {}
-func (ui *FakeIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) {
+
+func (ui *FakeIdentifyUI) Finish() error {
+	return nil
+}
+
+func (ui *FakeIdentifyUI) Dismiss(_ string, _ keybase1.DismissReason) error {
+	return nil
+}
+
+func (ui *FakeIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) error {
 	ui.Lock()
 	defer ui.Unlock()
 	ui.User = user
+	return nil
 }
-func (ui *FakeIdentifyUI) DisplayTrackStatement(string) (err error) {
-	return
+
+func (ui *FakeIdentifyUI) DisplayTrackStatement(string) error {
+	return nil
 }
-func (ui *FakeIdentifyUI) DisplayUserCard(keybase1.UserCard) {
+
+func (ui *FakeIdentifyUI) DisplayUserCard(keybase1.UserCard) error {
+	return nil
 }
+
 func (ui *FakeIdentifyUI) ReportTrackToken(tok keybase1.TrackToken) error {
 	ui.Token = tok
 	return nil
 }
+
 func (ui *FakeIdentifyUI) SetStrict(b bool) {
 }
+
 func (ui *FakeIdentifyUI) DisplayTLFCreateWithInvite(arg keybase1.DisplayTLFCreateWithInviteArg) error {
 	ui.DisplayTLFCount++
 	ui.DisplayTLFArg = arg

--- a/go/engine/identify.go
+++ b/go/engine/identify.go
@@ -196,7 +196,9 @@ func (e *Identify) run(ctx *Context) (*libkb.IdentifyOutcome, error) {
 	ctx.IdentifyUI.LaunchNetworkChecks(res.ExportToUncheckedIdentity(), e.user.Export())
 	waiter := e.displayUserCardAsync(ctx)
 
-	e.user.IDTable().Identify(is, e.arg.ForceRemoteCheck, ctx.IdentifyUI, nil)
+	if err := e.user.IDTable().Identify(is, e.arg.ForceRemoteCheck, ctx.IdentifyUI, nil); err != nil {
+		return nil, err
+	}
 
 	if err := <-waiter; err != nil {
 		return nil, err

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -87,37 +87,56 @@ func (i *Identify2WithUIDTester) GetTorError() libkb.ProofError {
 	return nil
 }
 
-func (i *Identify2WithUIDTester) FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) {
-	return
+func (i *Identify2WithUIDTester) FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error {
+	return nil
 }
 func (i *Identify2WithUIDTester) Confirm(*keybase1.IdentifyOutcome) (res keybase1.ConfirmResult, err error) {
 	return
 }
-func (i *Identify2WithUIDTester) FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) {
-	return
+func (i *Identify2WithUIDTester) FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error {
+	return nil
 }
-func (i *Identify2WithUIDTester) DisplayCryptocurrency(keybase1.Cryptocurrency)          { return }
-func (i *Identify2WithUIDTester) DisplayKey(keybase1.IdentifyKey)                        { return }
-func (i *Identify2WithUIDTester) ReportLastTrack(*keybase1.TrackSummary)                 { return }
-func (i *Identify2WithUIDTester) LaunchNetworkChecks(*keybase1.Identity, *keybase1.User) { return }
-func (i *Identify2WithUIDTester) DisplayTrackStatement(string) (err error)               { return }
-func (i *Identify2WithUIDTester) ReportTrackToken(keybase1.TrackToken) (err error)       { return }
-func (i *Identify2WithUIDTester) SetStrict(b bool)                                       { return }
-func (i *Identify2WithUIDTester) DisplayUserCard(keybase1.UserCard)                      { return }
+func (i *Identify2WithUIDTester) DisplayCryptocurrency(keybase1.Cryptocurrency) error {
+	return nil
+}
+func (i *Identify2WithUIDTester) DisplayKey(keybase1.IdentifyKey) error {
+	return nil
+}
+func (i *Identify2WithUIDTester) ReportLastTrack(*keybase1.TrackSummary) error {
+	return nil
+}
+func (i *Identify2WithUIDTester) LaunchNetworkChecks(*keybase1.Identity, *keybase1.User) error {
+	return nil
+}
+func (i *Identify2WithUIDTester) DisplayTrackStatement(string) error {
+	return nil
+}
+func (i *Identify2WithUIDTester) ReportTrackToken(keybase1.TrackToken) (err error) {
+	return nil
+}
+func (i *Identify2WithUIDTester) SetStrict(b bool) error {
+	return nil
+}
+func (i *Identify2WithUIDTester) DisplayUserCard(keybase1.UserCard) error {
+	return nil
+}
 
 func (i *Identify2WithUIDTester) DisplayTLFCreateWithInvite(keybase1.DisplayTLFCreateWithInviteArg) error {
 	return nil
 }
 
-func (i *Identify2WithUIDTester) Finish() {
+func (i *Identify2WithUIDTester) Finish() error {
 	i.finishCh <- struct{}{}
+	return nil
 }
 
-func (i *Identify2WithUIDTester) Dismiss(_ string, _ keybase1.DismissReason) {
+func (i *Identify2WithUIDTester) Dismiss(_ string, _ keybase1.DismissReason) error {
+	return nil
 }
 
-func (i *Identify2WithUIDTester) Start(string, keybase1.IdentifyReason) {
+func (i *Identify2WithUIDTester) Start(string, keybase1.IdentifyReason) error {
 	i.startCh <- struct{}{}
+	return nil
 }
 
 func (i *Identify2WithUIDTester) Get(uid keybase1.UID, gctf libkb.GetCheckTimeFunc, timeout time.Duration) (*keybase1.UserPlusKeys, error) {

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -364,7 +364,9 @@ func (e *Identify2WithUID) runIdentifyUI(ctx *Context) (err error) {
 
 	waiter := displayUserCardAsync(e.G(), ctx, e.them.GetUID(), (e.me != nil))
 	e.G().Log.Debug("| IdentifyUI.Identify(%s)", e.them.GetName())
-	e.them.IDTable().Identify(e.state, e.arg.ForceRemoteCheck, ctx.IdentifyUI, e)
+	if err = e.them.IDTable().Identify(e.state, e.arg.ForceRemoteCheck, ctx.IdentifyUI, e); err != nil {
+		return err
+	}
 
 	if err = <-waiter; err != nil {
 		return err

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -329,8 +329,9 @@ func (e *Identify2WithUID) useRemoteAssertions() bool {
 }
 
 func (e *Identify2WithUID) runIdentifyPrecomputation() (err error) {
-	f := func(k keybase1.IdentifyKey) {
+	f := func(k keybase1.IdentifyKey) error {
 		e.identifyKeys = append(e.identifyKeys, k)
+		return nil
 	}
 	e.state.Precompute(f)
 	return nil
@@ -344,27 +345,39 @@ func (e *Identify2WithUID) runIdentifyUI(ctx *Context) (err error) {
 	e.remotesReceived = e.them.BaseProofSet()
 
 	e.G().Log.Debug("| IdentifyUI.Start(%s)", e.them.GetName())
-	ctx.IdentifyUI.Start(e.them.GetName(), e.arg.Reason)
+	if err = ctx.IdentifyUI.Start(e.them.GetName(), e.arg.Reason); err != nil {
+		return err
+	}
 	for _, k := range e.identifyKeys {
-		ctx.IdentifyUI.DisplayKey(k)
+		if err = ctx.IdentifyUI.DisplayKey(k); err != nil {
+			return err
+		}
 	}
 	e.G().Log.Debug("| IdentifyUI.ReportLastTrack(%s)", e.them.GetName())
-	ctx.IdentifyUI.ReportLastTrack(libkb.ExportTrackSummary(e.state.TrackLookup(), e.them.GetName()))
+	if err = ctx.IdentifyUI.ReportLastTrack(libkb.ExportTrackSummary(e.state.TrackLookup(), e.them.GetName())); err != nil {
+		return err
+	}
 	e.G().Log.Debug("| IdentifyUI.LaunchNetworkChecks(%s)", e.them.GetName())
-	ctx.IdentifyUI.LaunchNetworkChecks(e.state.ExportToUncheckedIdentity(), e.them.Export())
+	if err = ctx.IdentifyUI.LaunchNetworkChecks(e.state.ExportToUncheckedIdentity(), e.them.Export()); err != nil {
+		return err
+	}
 
 	waiter := displayUserCardAsync(e.G(), ctx, e.them.GetUID(), (e.me != nil))
 	e.G().Log.Debug("| IdentifyUI.Identify(%s)", e.them.GetName())
 	e.them.IDTable().Identify(e.state, e.arg.ForceRemoteCheck, ctx.IdentifyUI, e)
 
-	waiter()
+	if err = <-waiter; err != nil {
+		return err
+	}
 	e.G().Log.Debug("| IdentifyUI waited for waiter (%s)", e.them.GetName())
 
 	// use Confirm to display the IdentifyOutcome
 	ctx.IdentifyUI.Confirm(e.state.Result().Export())
 
 	e.insertTrackToken(ctx)
-	ctx.IdentifyUI.Finish()
+	if err = ctx.IdentifyUI.Finish(); err != nil {
+		return err
+	}
 	e.G().Log.Debug("| IdentifyUI.Finished(%s)", e.them.GetName())
 
 	err = e.checkRemoteAssertions([]keybase1.ProofState{keybase1.ProofState_OK})

--- a/go/kbtest/ui.go
+++ b/go/kbtest/ui.go
@@ -73,7 +73,7 @@ type FakeIdentifyUI struct {
 
 var _ libkb.IdentifyUI = (*FakeIdentifyUI)(nil)
 
-func (ui *FakeIdentifyUI) FinishWebProofCheck(proof keybase1.RemoteProof, result keybase1.LinkCheckResult) {
+func (ui *FakeIdentifyUI) FinishWebProofCheck(proof keybase1.RemoteProof, result keybase1.LinkCheckResult) error {
 	ui.Lock()
 	defer ui.Unlock()
 	if ui.Proofs == nil {
@@ -88,9 +88,10 @@ func (ui *FakeIdentifyUI) FinishWebProofCheck(proof keybase1.RemoteProof, result
 	if result.BreaksTracking {
 		ui.BrokenTracking = true
 	}
+	return nil
 }
 
-func (ui *FakeIdentifyUI) FinishSocialProofCheck(proof keybase1.RemoteProof, result keybase1.LinkCheckResult) {
+func (ui *FakeIdentifyUI) FinishSocialProofCheck(proof keybase1.RemoteProof, result keybase1.LinkCheckResult) error {
 	ui.Lock()
 	defer ui.Unlock()
 	if ui.Proofs == nil {
@@ -104,6 +105,7 @@ func (ui *FakeIdentifyUI) FinishSocialProofCheck(proof keybase1.RemoteProof, res
 	if result.BreaksTracking {
 		ui.BrokenTracking = true
 	}
+	return nil
 }
 
 func (ui *FakeIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (result keybase1.ConfirmResult, err error) {
@@ -115,10 +117,11 @@ func (ui *FakeIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (result key
 	return
 }
 
-func (ui *FakeIdentifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency) {
+func (ui *FakeIdentifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency) error {
+	return nil
 }
 
-func (ui *FakeIdentifyUI) DisplayKey(ik keybase1.IdentifyKey) {
+func (ui *FakeIdentifyUI) DisplayKey(ik keybase1.IdentifyKey) error {
 	ui.Lock()
 	defer ui.Unlock()
 	if ui.Keys == nil {
@@ -128,25 +131,34 @@ func (ui *FakeIdentifyUI) DisplayKey(ik keybase1.IdentifyKey) {
 
 	ui.Keys[*fp] = ik.TrackDiff
 	ui.DisplayKeyCalls++
+	return nil
 }
-func (ui *FakeIdentifyUI) ReportLastTrack(*keybase1.TrackSummary) {
+func (ui *FakeIdentifyUI) ReportLastTrack(*keybase1.TrackSummary) error {
+	return nil
 }
-func (ui *FakeIdentifyUI) Start(username string, _ keybase1.IdentifyReason) {
+func (ui *FakeIdentifyUI) Start(username string, _ keybase1.IdentifyReason) error {
 	ui.Lock()
 	defer ui.Unlock()
 	ui.StartCount++
+	return nil
 }
-func (ui *FakeIdentifyUI) Finish()                                    {}
-func (ui *FakeIdentifyUI) Dismiss(_ string, _ keybase1.DismissReason) {}
-func (ui *FakeIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) {
+func (ui *FakeIdentifyUI) Finish() error {
+	return nil
+}
+func (ui *FakeIdentifyUI) Dismiss(_ string, _ keybase1.DismissReason) error {
+	return nil
+}
+func (ui *FakeIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) error {
 	ui.Lock()
 	defer ui.Unlock()
 	ui.User = user
+	return nil
 }
-func (ui *FakeIdentifyUI) DisplayTrackStatement(string) (err error) {
-	return
+func (ui *FakeIdentifyUI) DisplayTrackStatement(string) error {
+	return nil
 }
-func (ui *FakeIdentifyUI) DisplayUserCard(keybase1.UserCard) {
+func (ui *FakeIdentifyUI) DisplayUserCard(keybase1.UserCard) error {
+	return nil
 }
 func (ui *FakeIdentifyUI) ReportTrackToken(tok keybase1.TrackToken) error {
 	ui.Token = tok

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -95,6 +95,8 @@ const (
 	LocalTrackMaxAge = 48 * time.Hour
 )
 
+const RemoteIdentifyUITimeout = 5 * time.Second
+
 var MerkleProdKIDs = []string{
 	"010159baae6c7d43c66adf8fb7bb2b8b4cbe408c062cfc369e693ccb18f85631dbcd0a",
 }

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -6,7 +6,6 @@ package libkb
 import (
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	keybase1 "github.com/keybase/client/go/protocol"
@@ -118,7 +117,7 @@ type RemoteProofChainLink interface {
 	GetRemoteUsername() string
 	GetHostname() string
 	GetProtocol() string
-	DisplayCheck(ui IdentifyUI, lcr LinkCheckResult)
+	DisplayCheck(ui IdentifyUI, lcr LinkCheckResult) error
 	ToTrackingStatement(keybase1.ProofState) (*jsonw.Wrapper, error)
 	CheckDataJSON() *jsonw.Wrapper
 	ToIDString() string
@@ -165,8 +164,8 @@ func (w *WebProofChainLink) ToTrackingStatement(state keybase1.ProofState) (*jso
 	return ret, err
 }
 
-func (w *WebProofChainLink) DisplayCheck(ui IdentifyUI, lcr LinkCheckResult) {
-	ui.FinishWebProofCheck(ExportRemoteProof(w), lcr.Export())
+func (w *WebProofChainLink) DisplayCheck(ui IdentifyUI, lcr LinkCheckResult) error {
+	return ui.FinishWebProofCheck(ExportRemoteProof(w), lcr.Export())
 }
 
 func (w *WebProofChainLink) Type() string { return "proof" }
@@ -261,8 +260,8 @@ func (s *SocialProofChainLink) ComputeTrackDiff(tl *TrackLookup) TrackDiff {
 	}
 }
 
-func (s *SocialProofChainLink) DisplayCheck(ui IdentifyUI, lcr LinkCheckResult) {
-	ui.FinishSocialProofCheck(ExportRemoteProof(s), lcr.Export())
+func (s *SocialProofChainLink) DisplayCheck(ui IdentifyUI, lcr LinkCheckResult) error {
+	return ui.FinishSocialProofCheck(ExportRemoteProof(s), lcr.Export())
 }
 
 func (s *SocialProofChainLink) CheckDataJSON() *jsonw.Wrapper {
@@ -840,8 +839,8 @@ func (c *CryptocurrencyChainLink) insertIntoTable(tab *IdentityTable) {
 	tab.cryptocurrency = append(tab.cryptocurrency, c)
 }
 
-func (c CryptocurrencyChainLink) Display(ui IdentifyUI) {
-	ui.DisplayCryptocurrency(c.Export())
+func (c CryptocurrencyChainLink) Display(ui IdentifyUI) error {
+	return ui.DisplayCryptocurrency(c.Export())
 }
 
 //
@@ -912,7 +911,9 @@ func (s *SelfSigChainLink) ProofText() string         { return "" }
 
 func (s *SelfSigChainLink) GetPGPFullHash() string { return s.extractPGPFullHash("key") }
 
-func (s *SelfSigChainLink) DisplayCheck(ui IdentifyUI, lcr LinkCheckResult) {}
+func (s *SelfSigChainLink) DisplayCheck(ui IdentifyUI, lcr LinkCheckResult) error {
+	return nil
+}
 
 func (s *SelfSigChainLink) CheckDataJSON() *jsonw.Wrapper { return nil }
 
@@ -1172,32 +1173,38 @@ type CheckCompletedListener interface {
 	CCLCheckCompleted(lcr *LinkCheckResult)
 }
 
-func (idt *IdentityTable) Identify(is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener) {
-	var wg sync.WaitGroup
+func (idt *IdentityTable) Identify(is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener) error {
+	errs := make(chan error, len(is.res.ProofChecks))
 	for _, lcr := range is.res.ProofChecks {
-		wg.Add(1)
 		go func(l *LinkCheckResult) {
-			defer wg.Done()
-			idt.identifyActiveProof(l, is, forceRemoteCheck, ui, ccl)
+			errs <- idt.identifyActiveProof(l, is, forceRemoteCheck, ui, ccl)
 		}(lcr)
 	}
 
 	if acc := idt.ActiveCryptocurrency(); acc != nil {
-		acc.Display(ui)
+		if err := acc.Display(ui); err != nil {
+			return err
+		}
 	}
 
-	// wait for all goroutines to complete before exiting
-	wg.Wait()
+	for i := 0; i < len(is.res.ProofChecks); i++ {
+		err := <-errs
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 //=========================================================================
 
-func (idt *IdentityTable) identifyActiveProof(lcr *LinkCheckResult, is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener) {
+func (idt *IdentityTable) identifyActiveProof(lcr *LinkCheckResult, is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener) error {
 	idt.proofRemoteCheck(is.HasPreviousTrack(), forceRemoteCheck, lcr)
 	if ccl != nil {
 		ccl.CCLCheckCompleted(lcr)
 	}
-	lcr.link.DisplayCheck(ui, *lcr)
+	return lcr.link.DisplayCheck(ui, *lcr)
 }
 
 type LinkCheckResult struct {
@@ -1332,7 +1339,7 @@ func (idt *IdentityTable) proofRemoteCheck(hasPreviousTrack, forceRemoteCheck bo
 		return
 	}
 
-	idt.G().Log.Warning("| Check status failed with error: %s", res.err.Error())
+	idt.G().Log.Warning("| Check status (%s) failed with error: %s", p.ToDebugString(), res.err.Error())
 
 	return
 }

--- a/go/libkb/identify_state.go
+++ b/go/libkb/identify_state.go
@@ -118,14 +118,14 @@ func (s *IdentifyState) computeTrackDiffs() {
 	}
 }
 
-func (s *IdentifyState) Precompute(dhook func(keybase1.IdentifyKey)) {
+func (s *IdentifyState) Precompute(dhook func(keybase1.IdentifyKey) error) {
 	s.computeKeyDiffs(dhook)
 	s.initResultList()
 	s.computeTrackDiffs()
 	s.computeRevokedProofs()
 }
 
-func (s *IdentifyState) computeKeyDiffs(dhook func(keybase1.IdentifyKey)) {
+func (s *IdentifyState) computeKeyDiffs(dhook func(keybase1.IdentifyKey) error) {
 	mapify := func(v []keybase1.KID) map[keybase1.KID]bool {
 		ret := make(map[keybase1.KID]bool)
 		for _, k := range v {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -285,20 +285,20 @@ type ExternalAPI interface {
 }
 
 type IdentifyUI interface {
-	Start(string, keybase1.IdentifyReason)
-	FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult)
-	FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult)
+	Start(string, keybase1.IdentifyReason) error
+	FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error
+	FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error
 	Confirm(*keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error)
-	DisplayCryptocurrency(keybase1.Cryptocurrency)
-	DisplayKey(keybase1.IdentifyKey)
-	ReportLastTrack(*keybase1.TrackSummary)
-	LaunchNetworkChecks(*keybase1.Identity, *keybase1.User)
+	DisplayCryptocurrency(keybase1.Cryptocurrency) error
+	DisplayKey(keybase1.IdentifyKey) error
+	ReportLastTrack(*keybase1.TrackSummary) error
+	LaunchNetworkChecks(*keybase1.Identity, *keybase1.User) error
 	DisplayTrackStatement(string) error
-	DisplayUserCard(keybase1.UserCard)
+	DisplayUserCard(keybase1.UserCard) error
 	ReportTrackToken(keybase1.TrackToken) error
-	Finish()
+	Finish() error
 	DisplayTLFCreateWithInvite(keybase1.DisplayTLFCreateWithInviteArg) error
-	Dismiss(string, keybase1.DismissReason)
+	Dismiss(string, keybase1.DismissReason) error
 }
 
 type Checker struct {

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -90,13 +90,15 @@ type showTrackerPopupIdentifyUI struct {
 
 var _ libkb.IdentifyUI = (*showTrackerPopupIdentifyUI)(nil)
 
-func (ui *showTrackerPopupIdentifyUI) Start(name string, reason keybase1.IdentifyReason) {
+func (ui *showTrackerPopupIdentifyUI) Start(name string, reason keybase1.IdentifyReason) error {
 	ui.startedUsername = name
+	return nil
 }
 
 // Overriding the Dismiss method lets us test that it gets called.
-func (ui *showTrackerPopupIdentifyUI) Dismiss(username string, _ keybase1.DismissReason) {
+func (ui *showTrackerPopupIdentifyUI) Dismiss(username string, _ keybase1.DismissReason) error {
 	ui.dismissedUsername = username
+	return nil
 }
 
 // Test that when we inject a gregor "show_tracker_popup" message containing a

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -181,22 +181,28 @@ func (h *IdentifyHandler) identify(sessionID int, arg keybase1.IdentifyArg) (res
 	return res, err
 }
 
-func (u *RemoteIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, lcr keybase1.LinkCheckResult) {
-	u.uicli.FinishWebProofCheck(context.TODO(), keybase1.FinishWebProofCheckArg{
-		SessionID: u.sessionID,
-		Rp:        p,
-		Lcr:       lcr,
-	})
-	return
+func (u *RemoteIdentifyUI) newContext() (context.Context, func()) {
+	return context.WithTimeout(context.Background(), libkb.RemoteIdentifyUITimeout)
 }
 
-func (u *RemoteIdentifyUI) FinishSocialProofCheck(p keybase1.RemoteProof, lcr keybase1.LinkCheckResult) {
-	u.uicli.FinishSocialProofCheck(context.TODO(), keybase1.FinishSocialProofCheckArg{
+func (u *RemoteIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, lcr keybase1.LinkCheckResult) error {
+	ctx, cancel := u.newContext()
+	defer cancel()
+	return u.uicli.FinishWebProofCheck(ctx, keybase1.FinishWebProofCheckArg{
 		SessionID: u.sessionID,
 		Rp:        p,
 		Lcr:       lcr,
 	})
-	return
+}
+
+func (u *RemoteIdentifyUI) FinishSocialProofCheck(p keybase1.RemoteProof, lcr keybase1.LinkCheckResult) error {
+	ctx, cancel := u.newContext()
+	defer cancel()
+	return u.uicli.FinishSocialProofCheck(ctx, keybase1.FinishSocialProofCheckArg{
+		SessionID: u.sessionID,
+		Rp:        p,
+		Lcr:       lcr,
+	})
 }
 
 func (u *RemoteIdentifyUI) Confirm(io *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
@@ -207,53 +213,68 @@ func (u *RemoteIdentifyUI) Confirm(io *keybase1.IdentifyOutcome) (keybase1.Confi
 	return u.uicli.Confirm(context.TODO(), keybase1.ConfirmArg{SessionID: u.sessionID, Outcome: *io})
 }
 
-func (u *RemoteIdentifyUI) DisplayCryptocurrency(c keybase1.Cryptocurrency) {
-	u.uicli.DisplayCryptocurrency(context.TODO(), keybase1.DisplayCryptocurrencyArg{SessionID: u.sessionID, C: c})
-	return
+func (u *RemoteIdentifyUI) DisplayCryptocurrency(c keybase1.Cryptocurrency) error {
+	ctx, cancel := u.newContext()
+	defer cancel()
+	return u.uicli.DisplayCryptocurrency(ctx, keybase1.DisplayCryptocurrencyArg{SessionID: u.sessionID, C: c})
 }
 
-func (u *RemoteIdentifyUI) DisplayKey(key keybase1.IdentifyKey) {
-	u.uicli.DisplayKey(context.TODO(), keybase1.DisplayKeyArg{SessionID: u.sessionID, Key: key})
-	return
+func (u *RemoteIdentifyUI) DisplayKey(key keybase1.IdentifyKey) error {
+	ctx, cancel := u.newContext()
+	defer cancel()
+	return u.uicli.DisplayKey(ctx, keybase1.DisplayKeyArg{SessionID: u.sessionID, Key: key})
 }
 
-func (u *RemoteIdentifyUI) ReportLastTrack(t *keybase1.TrackSummary) {
-	u.uicli.ReportLastTrack(context.TODO(), keybase1.ReportLastTrackArg{SessionID: u.sessionID, Track: t})
-	return
+func (u *RemoteIdentifyUI) ReportLastTrack(t *keybase1.TrackSummary) error {
+	ctx, cancel := u.newContext()
+	defer cancel()
+	return u.uicli.ReportLastTrack(ctx, keybase1.ReportLastTrackArg{SessionID: u.sessionID, Track: t})
 }
 
 func (u *RemoteIdentifyUI) DisplayTrackStatement(s string) error {
-	return u.uicli.DisplayTrackStatement(context.TODO(), keybase1.DisplayTrackStatementArg{Stmt: s, SessionID: u.sessionID})
+	ctx, cancel := u.newContext()
+	defer cancel()
+	return u.uicli.DisplayTrackStatement(ctx, keybase1.DisplayTrackStatementArg{Stmt: s, SessionID: u.sessionID})
 }
 
 func (u *RemoteIdentifyUI) ReportTrackToken(token keybase1.TrackToken) error {
-	return u.uicli.ReportTrackToken(context.TODO(), keybase1.ReportTrackTokenArg{TrackToken: token, SessionID: u.sessionID})
+	ctx, cancel := u.newContext()
+	defer cancel()
+	return u.uicli.ReportTrackToken(ctx, keybase1.ReportTrackTokenArg{TrackToken: token, SessionID: u.sessionID})
 }
 
-func (u *RemoteIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) {
-	u.uicli.LaunchNetworkChecks(context.TODO(), keybase1.LaunchNetworkChecksArg{
+func (u *RemoteIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) error {
+	ctx, cancel := u.newContext()
+	defer cancel()
+	return u.uicli.LaunchNetworkChecks(ctx, keybase1.LaunchNetworkChecksArg{
 		SessionID: u.sessionID,
 		Identity:  *id,
 		User:      *user,
 	})
-	return
 }
 
-func (u *RemoteIdentifyUI) DisplayUserCard(card keybase1.UserCard) {
-	u.uicli.DisplayUserCard(context.TODO(), keybase1.DisplayUserCardArg{SessionID: u.sessionID, Card: card})
-	return
+func (u *RemoteIdentifyUI) DisplayUserCard(card keybase1.UserCard) error {
+	ctx, cancel := u.newContext()
+	defer cancel()
+	return u.uicli.DisplayUserCard(ctx, keybase1.DisplayUserCardArg{SessionID: u.sessionID, Card: card})
 }
 
-func (u *RemoteIdentifyUI) Start(username string, reason keybase1.IdentifyReason) {
-	u.uicli.Start(context.TODO(), keybase1.StartArg{SessionID: u.sessionID, Username: username, Reason: reason})
+func (u *RemoteIdentifyUI) Start(username string, reason keybase1.IdentifyReason) error {
+	ctx, cancel := u.newContext()
+	defer cancel()
+	return u.uicli.Start(ctx, keybase1.StartArg{SessionID: u.sessionID, Username: username, Reason: reason})
 }
 
-func (u *RemoteIdentifyUI) Finish() {
-	u.uicli.Finish(context.TODO(), u.sessionID)
+func (u *RemoteIdentifyUI) Finish() error {
+	ctx, cancel := u.newContext()
+	defer cancel()
+	return u.uicli.Finish(ctx, u.sessionID)
 }
 
-func (u *RemoteIdentifyUI) Dismiss(username string, reason keybase1.DismissReason) {
-	u.uicli.Dismiss(context.TODO(), keybase1.DismissArg{
+func (u *RemoteIdentifyUI) Dismiss(username string, reason keybase1.DismissReason) error {
+	ctx, cancel := u.newContext()
+	defer cancel()
+	return u.uicli.Dismiss(ctx, keybase1.DismissArg{
 		SessionID: u.sessionID,
 		Username:  username,
 		Reason:    reason,
@@ -265,6 +286,8 @@ func (u *RemoteIdentifyUI) SetStrict(b bool) {
 }
 
 func (u *RemoteIdentifyUI) DisplayTLFCreateWithInvite(arg keybase1.DisplayTLFCreateWithInviteArg) error {
+	ctx, cancel := u.newContext()
+	defer cancel()
 	arg.SessionID = u.sessionID
-	return u.uicli.DisplayTLFCreateWithInvite(context.TODO(), arg)
+	return u.uicli.DisplayTLFCreateWithInvite(ctx, arg)
 }

--- a/go/systests/tracking_test.go
+++ b/go/systests/tracking_test.go
@@ -31,19 +31,43 @@ func (*identifyUI) Confirm(*keybase1.IdentifyOutcome) (keybase1.ConfirmResult, e
 		RemoteConfirmed:   true,
 	}, nil
 }
-func (*identifyUI) Start(string, keybase1.IdentifyReason)                                 {}
-func (*identifyUI) FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult)    {}
-func (*identifyUI) FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) {}
-func (*identifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency)                         {}
-func (*identifyUI) DisplayKey(keybase1.IdentifyKey)                                       {}
-func (*identifyUI) ReportLastTrack(*keybase1.TrackSummary)                                {}
-func (*identifyUI) LaunchNetworkChecks(*keybase1.Identity, *keybase1.User)                {}
-func (*identifyUI) DisplayTrackStatement(string) error                                    { return nil }
-func (*identifyUI) DisplayUserCard(keybase1.UserCard)                                     {}
-func (*identifyUI) ReportTrackToken(keybase1.TrackToken) error                            { return nil }
-func (*identifyUI) SetStrict(b bool)                                                      {}
-func (*identifyUI) Finish()                                                               {}
-func (*identifyUI) Dismiss(string, keybase1.DismissReason)                                {}
+func (*identifyUI) Start(string, keybase1.IdentifyReason) error {
+	return nil
+}
+func (*identifyUI) FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error {
+	return nil
+}
+func (*identifyUI) FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error {
+	return nil
+}
+func (*identifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency) error {
+	return nil
+}
+func (*identifyUI) DisplayKey(keybase1.IdentifyKey) error {
+	return nil
+}
+func (*identifyUI) ReportLastTrack(*keybase1.TrackSummary) error {
+	return nil
+}
+func (*identifyUI) LaunchNetworkChecks(*keybase1.Identity, *keybase1.User) error {
+	return nil
+}
+func (*identifyUI) DisplayTrackStatement(string) error {
+	return nil
+}
+func (*identifyUI) DisplayUserCard(keybase1.UserCard) error {
+	return nil
+}
+func (*identifyUI) ReportTrackToken(keybase1.TrackToken) error {
+	return nil
+}
+func (*identifyUI) SetStrict(b bool) {}
+func (*identifyUI) Finish() error {
+	return nil
+}
+func (*identifyUI) Dismiss(string, keybase1.DismissReason) error {
+	return nil
+}
 
 func (*identifyUI) DisplayTLFCreateWithInvite(keybase1.DisplayTLFCreateWithInviteArg) error {
 	return nil


### PR DESCRIPTION
This PR adds timeouts to RemoteIdentifyUI calls (except for Confirm).  The purpose of this is to allow  identify pipeline to finish in a timely manner in the event of an electron crash/failure.

Also, before, all errors returned from the identify ui calls were dropped.  This changes that so they are checked and they will stop an identify pipeline.

I tested this with CLI and desktop.  Everything worked, but it would be nice to have some more hands-on testing of id, track.  @keybase/react-hackers could one of you try out this branch and see if tracker popups work well?

r? @maxtaco, @oconnor663, or @mmaxim 