### PR TITLE
Add description of invalid phrase behavior

### DIFF
--- a/go/client/provision_ui.go
+++ b/go/client/provision_ui.go
@@ -291,7 +291,8 @@ func (p ProvisionUI) DisplaySecretExchanged(ctx context.Context, sessionID int) 
 	p.parent.Output("\n\nVerification code received.  On your new device, choose and save a public name for it.\n\n")
 	p.parent.Output("Note: if you do not see a prompt on your new device for a device name\n")
 	p.parent.Output("in a few seconds then the verification code entered above does not match the\n")
-	p.parent.Output("verification code provided on your new device.\n")
+	p.parent.Output("verification code provided on your new device. If that happens, quit\n")
+	p.parent.Output("this (ctrl-c) and try again.\n")
 	return nil
 }
 
@@ -309,6 +310,7 @@ func (p ProvisionUI) ProvisioneeSuccess(ctx context.Context, arg keybase1.Provis
 }
 
 func (p ProvisionUI) ProvisionerSuccess(ctx context.Context, arg keybase1.ProvisionerSuccessArg) error {
+	p.parent.Output("\n\n")
 	p.parent.Printf(CHECK + " Success! You added a new device named " + ColorString("bold", arg.DeviceName) + " to your account.\n\n")
 	return nil
 }

--- a/go/client/provision_ui.go
+++ b/go/client/provision_ui.go
@@ -288,7 +288,10 @@ func (p ProvisionUI) PromptNewDeviceName(ctx context.Context, arg keybase1.Promp
 }
 
 func (p ProvisionUI) DisplaySecretExchanged(ctx context.Context, sessionID int) error {
-	p.parent.Output("Secret successfully exchanged.  On your new device, choose and save a public name for it.\n\n")
+	p.parent.Output("\n\nVerification code received.  On your new device, choose and save a public name for it.\n\n")
+	p.parent.Output("Note: if you do not see a prompt on your new device for a device name\n")
+	p.parent.Output("in a few seconds then the verification code entered above does not match the\n")
+	p.parent.Output("verification code provided on your new device.\n")
 	return nil
 }
 


### PR DESCRIPTION
The reported bug in CORE-2925 is as follows:

1. `keybase device add`
2. enter a secret phrase with the correct number of words, and all words in the word list, but just doesn't match what `keybase login` on provisionee told you to enter.
3. nothing happens.  5m later, there is a timeout error.

It's asking API server for any messages, but none will come in because the secret is incorrect.  We do check that the words in the phrase are in the dictionary and that the number of words is correct.

We have yet to receive a report of this error in the wild.  For now, I changed the output to say that if they don't see a new device name prompt on their new device, then they typed the phrase incorrectly.

One other thing we could do is decrease the overall timeout so that it fails sooner.

I'm wary of making major changes here to fix this as it doesn't seem to be affecting real users.

r? @maxtaco 