### PR TITLE
Set signup state to waiting after successful signup & friends

### DIFF
--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -3,6 +3,7 @@ import * as Constants from '../../constants/config'
 import engine from '../../engine'
 
 import {navBasedOnLoginState} from '../../actions/login'
+import {resetSignup} from '../../actions/signup'
 
 // $FlowFixMe
 import * as native from './index.native'
@@ -141,6 +142,7 @@ export function bootstrap (): AsyncAction {
           }
           dispatch({type: Constants.bootstrapped, payload: null})
           dispatch(navBasedOnLoginState())
+          dispatch(resetSignup())
         }).catch(error => {
           console.warn('Error bootstrapping: ', error)
         })

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -566,6 +566,7 @@ function makeKex2IncomingMap (dispatch, getState, onBack: SimpleCB, onProvisione
       appendRouteElement((
         <SuccessRender
           paperkey={new HiddenString(phrase)}
+          waiting={false}
           onFinish={() => { response.result() }}
           onBack={() => onBack(response)}
           title={"Your new paper key!"} />))

--- a/shared/actions/signup/index.js
+++ b/shared/actions/signup/index.js
@@ -11,7 +11,7 @@ import {routeAppend, navigateUp} from '../../actions/router'
 
 import type {TypedAsyncAction, AsyncAction} from '../../constants/types/flux'
 import type {RouteAppend} from '../../constants/router'
-import type {CheckInviteCode, CheckUsernameEmail, CheckPassphrase, SubmitDeviceName, Signup, ShowPaperKey, ShowSuccess, ResetSignup, RequestInvite, StartRequestInvite, SignupWaiting} from '../../constants/signup'
+import type {CheckInviteCode, CheckUsernameEmail, CheckPassphrase, SubmitDeviceName, Signup, ShowPaperKey, ShowSuccess, RestartSignup, RequestInvite, StartRequestInvite, SignupWaiting} from '../../constants/signup'
 import type {signupSignupRpc, signupCheckInvitationCodeRpc, signupCheckUsernameAvailableRpc,
   signupInviteRequestRpc, deviceCheckDeviceNameFormatRpc} from '../../constants/types/flow-types'
 
@@ -359,9 +359,9 @@ function waiting (isWaiting: boolean): SignupWaiting {
   }
 }
 
-export function resetSignup (): TypedAsyncAction<ResetSignup | RouteAppend> {
+export function restartSignup (): TypedAsyncAction<RestartSignup | RouteAppend> {
   return dispatch => new Promise((resolve, reject) => {
-    dispatch({type: Constants.resetSignup, payload: {}})
+    dispatch({type: Constants.restartSignup, payload: {}})
     dispatch(navigateUp(loginTab, Map({path: 'signup'})))
     dispatch(navigateUp())
     resolve()

--- a/shared/actions/signup/index.js
+++ b/shared/actions/signup/index.js
@@ -11,7 +11,7 @@ import {routeAppend, navigateUp} from '../../actions/router'
 
 import type {TypedAsyncAction, AsyncAction} from '../../constants/types/flux'
 import type {RouteAppend} from '../../constants/router'
-import type {CheckInviteCode, CheckUsernameEmail, CheckPassphrase, SubmitDeviceName, Signup, ShowPaperKey, ShowSuccess, RestartSignup, RequestInvite, StartRequestInvite, SignupWaiting} from '../../constants/signup'
+import type {CheckInviteCode, CheckUsernameEmail, CheckPassphrase, SubmitDeviceName, Signup, ShowPaperKey, ShowSuccess, ResetSignup, RestartSignup, RequestInvite, StartRequestInvite, SignupWaiting} from '../../constants/signup'
 import type {signupSignupRpc, signupCheckInvitationCodeRpc, signupCheckUsernameAvailableRpc,
   signupInviteRequestRpc, deviceCheckDeviceNameFormatRpc} from '../../constants/types/flow-types'
 
@@ -356,6 +356,13 @@ function waiting (isWaiting: boolean): SignupWaiting {
   return {
     type: Constants.signupWaiting,
     payload: isWaiting,
+  }
+}
+
+export function resetSignup (): ResetSignup {
+  return {
+    type: Constants.resetSignup,
+    payload: undefined,
   }
 }
 

--- a/shared/actions/signup/index.js
+++ b/shared/actions/signup/index.js
@@ -338,6 +338,7 @@ function signup (skipMail: boolean, onDisplayPaperKey?: () => void): TypedAsyncA
             reject()
           } else {
             console.log('Successful signup', passphraseOk, postOk, writeOk)
+            dispatch(waiting(true))
             resolve()
           }
         },

--- a/shared/actions/signup/index.js
+++ b/shared/actions/signup/index.js
@@ -269,7 +269,7 @@ export function submitDeviceName (deviceName: string, skipMail?: boolean, onDisp
 
               const signupPromise = dispatch(signup(skipMail || false, onDisplayPaperKey))
               if (signupPromise) {
-                resolve(signupPromise.then(() => dispatch(nextPhase()) || Promise.resolve()))
+                signupPromise.then(resolve, reject)
               } else {
                 throw new Error('did not get promise from signup')
               }

--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -33,6 +33,10 @@ export default class Input extends Component {
     this.props.onChangeText && this.props.onChangeText(event.target.value || '')
   }
 
+  focus () {
+    this._textField && this._textField.focus()
+  }
+
   blur () {
     this._textField && this._textField.blur()
   }

--- a/shared/constants/signup.js
+++ b/shared/constants/signup.js
@@ -30,10 +30,10 @@ export type ShowPaperKey = TypedAction<'signup:showPaperKey', {paperkey: HiddenS
 export const showSuccess = 'signup:showSuccess'
 export type ShowSuccess = TypedAction<'signup:showSuccess', {}, {}>
 
-export const resetSignup = 'signup:resetSignup'
-export type ResetSignup = TypedAction<'signup:resetSignup', {}, {}>
+export const restartSignup = 'signup:restartSignup'
+export type RestartSignup = TypedAction<'signup:restartSignup', {}, {}>
 
 export const signupWaiting = 'signup:waiting'
 export type SignupWaiting = TypedAction<'signup:waiting', boolean, void>
 
-export type SignupActions = CheckInviteCode | CheckUsernameEmail | CheckPassphrase | SubmitDeviceName | Signup | ShowPaperKey | ShowSuccess | ResetSignup | SignupWaiting
+export type SignupActions = CheckInviteCode | CheckUsernameEmail | CheckPassphrase | SubmitDeviceName | Signup | ShowPaperKey | ShowSuccess | RestartSignup | SignupWaiting

--- a/shared/constants/signup.js
+++ b/shared/constants/signup.js
@@ -30,6 +30,9 @@ export type ShowPaperKey = TypedAction<'signup:showPaperKey', {paperkey: HiddenS
 export const showSuccess = 'signup:showSuccess'
 export type ShowSuccess = TypedAction<'signup:showSuccess', {}, {}>
 
+export const resetSignup = 'signup:resetSignup'
+export type ResetSignup = TypedAction<'signup:resetSignup', void, void>
+
 export const restartSignup = 'signup:restartSignup'
 export type RestartSignup = TypedAction<'signup:restartSignup', {}, {}>
 

--- a/shared/devices/gen-paper-key/index.js
+++ b/shared/devices/gen-paper-key/index.js
@@ -43,6 +43,7 @@ class GenPaperKey extends Component<void, Props, State> {
     return (
       <Render
         paperkey={this.props.paperKey}
+        waiting={false}
         onBack={this.props.onBack}
         title='Paper key generated!'
       />

--- a/shared/login/signup/device-name.js
+++ b/shared/login/signup/device-name.js
@@ -23,7 +23,7 @@ class DeviceName extends Component {
         deviceNameError={this.props.deviceNameError}
         onChange={deviceName => this.setState({deviceName})}
         onSubmit={() => this.props.submitDeviceName(this.state.deviceName || '')}
-        onBack={this.props.resetSignup}
+        onBack={this.props.restartSignup}
         waiting={this.props.waiting} />
     )
   }

--- a/shared/login/signup/dumb.desktop.js
+++ b/shared/login/signup/dumb.desktop.js
@@ -179,7 +179,7 @@ export default {
       'Start': {
         ...signupShared,
         errorText: new HiddenString('This is an error'),
-        resetSignup: nullFunc,
+        restartSignup: nullFunc,
       },
     },
   },

--- a/shared/login/signup/error/index.js
+++ b/shared/login/signup/error/index.js
@@ -3,7 +3,7 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import HiddenString from '../../../util/hidden-string'
-import {resetSignup} from '../../../actions/signup'
+import {restartSignup} from '../../../actions/signup'
 
 import Render from './index.render'
 
@@ -12,17 +12,17 @@ class SignupError extends Component {
     return (
       <Render
         errorText={this.props.errorText}
-        resetSignup={this.props.resetSignup} />
+        restartSignup={this.props.restartSignup} />
     )
   }
 }
 
 SignupError.propTypes = {
   errorText: React.PropTypes.instanceOf(HiddenString).isRequired,
-  resetSignup: React.PropTypes.func.isRequired,
+  restartSignup: React.PropTypes.func.isRequired,
 }
 
 export default connect(
   state => ({errorText: state.signup.signupError}),
-  dispatch => ({resetSignup: () => dispatch(resetSignup())})
+  dispatch => ({restartSignup: () => dispatch(restartSignup())})
 )(SignupError)

--- a/shared/login/signup/error/index.render.desktop.js
+++ b/shared/login/signup/error/index.render.desktop.js
@@ -10,10 +10,10 @@ import type {Props} from './index.render'
 class Render extends Component<void, Props, void> {
   render () {
     return (
-      <Container onBack={this.props.resetSignup} style={container}>
+      <Container onBack={this.props.restartSignup} style={container}>
         <Text type='Header' style={topMargin}>Ah Shoot! Something went wrong, wanna try again?</Text>
         <Text type='Error' style={topMargin}>{this.props.errorText.stringValue()}</Text>
-        <Button style={topMargin} type='Secondary' label='Try Again' onClick={() => this.props.resetSignup()} />
+        <Button style={topMargin} type='Secondary' label='Try Again' onClick={() => this.props.restartSignup()} />
       </Container>
     )
   }

--- a/shared/login/signup/error/index.render.js.flow
+++ b/shared/login/signup/error/index.render.js.flow
@@ -5,7 +5,7 @@ import HiddenString from '../../../util/hidden-string'
 
 export type Props = {
   errorText: HiddenString,
-  resetSignup: () => void
+  restartSignup: () => void
 }
 
 export default class Render extends Component {

--- a/shared/login/signup/passphrase/index.js
+++ b/shared/login/signup/passphrase/index.js
@@ -6,7 +6,7 @@ import {bindActionCreators} from 'redux'
 import HiddenString from '../../../util/hidden-string'
 
 import Render from './index.render'
-import {checkPassphrase, resetSignup} from '../../../actions/signup'
+import {checkPassphrase, restartSignup} from '../../../actions/signup'
 import type {Props} from './index.render'
 
 type State = {
@@ -35,7 +35,7 @@ class PassphraseForm extends Component {
         pass2={this.state.pass2}
         pass2Update={pass2 => this.setState({pass2})}
         onSubmit={() => this.props.checkPassphrase(this.state.pass1, this.state.pass2)}
-        onBack={this.props.resetSignup}
+        onBack={this.props.restartSignup}
         />
     )
   }
@@ -50,5 +50,5 @@ export default connect(
   state => ({
     passphraseError: state.signup.passphraseError,
   }),
-  dispatch => bindActionCreators({checkPassphrase, resetSignup}, dispatch)
+  dispatch => bindActionCreators({checkPassphrase, restartSignup}, dispatch)
 )(PassphraseForm)

--- a/shared/login/signup/passphrase/index.render.desktop.js
+++ b/shared/login/signup/passphrase/index.render.desktop.js
@@ -12,13 +12,16 @@ class Render extends Component<void, Props, void> {
   render () {
     const passphraseError = this.props.passphraseError && this.props.passphraseError.stringValue()
 
+    let confirmInput
     return (
       <Container onBack={this.props.onBack} style={stylesContainer} outerStyle={stylesOuter}>
         <UserCard style={stylesCard}>
           <Input autoFocus style={stylesFirst} type='password'
             onChangeText={pass1 => this.props.pass1Update(pass1)}
+            onEnterKeyDown={() => confirmInput.focus()}
             hintText='Create a passphrase' errorText={passphraseError} />
           <Input type='password' hintText='Confirm passphrase' onEnterKeyDown={this.props.onSubmit}
+            ref={input => { confirmInput = input }}
             onChangeText={pass2 => this.props.pass2Update(pass2)} />
           <Button fullWidth type='Primary' label='Continue' onClick={this.props.onSubmit} />
         </UserCard>

--- a/shared/login/signup/request-invite-success.js
+++ b/shared/login/signup/request-invite-success.js
@@ -11,7 +11,7 @@ class RequestInviteSuccess extends Component {
   render () {
     return (
       <Render
-        onBack={this.props.resetSignup}
+        onBack={this.props.restartSignup}
       />
     )
   }

--- a/shared/login/signup/request-invite.js
+++ b/shared/login/signup/request-invite.js
@@ -32,7 +32,7 @@ class RequestInvite extends Component {
         emailChange={email => this.setState({email})}
         emailErrorText={this.props.emailErrorText}
         nameErrorText={this.props.nameErrorText}
-        onBack={this.props.resetSignup}
+        onBack={this.props.restartSignup}
         onSubmit={() => this.props.requestInvite(this.state.email, this.state.name)}
         waiting={this.props.waiting} />
     )

--- a/shared/login/signup/success/index.js
+++ b/shared/login/signup/success/index.js
@@ -13,6 +13,7 @@ class Success extends Component {
       <Render
         title={this.props.title}
         paperkey={this.props.paperkey}
+        waiting={this.props.waiting}
         onFinish={this.props.onFinish}
         onBack={this.props.onBack}
         />
@@ -26,7 +27,10 @@ Success.propTypes = {
 }
 
 export default connect(
-  state => ({paperkey: state.signup.paperkey}),
+  state => ({
+    paperkey: state.signup.paperkey,
+    waiting: state.signup.waiting,
+  }),
   dispatch => ({
     onFinish: () => dispatch(sawPaperKey()),
     onBack: () => {},

--- a/shared/login/signup/success/index.render.desktop.js
+++ b/shared/login/signup/success/index.render.desktop.js
@@ -30,7 +30,7 @@ class Render extends Component<void, Props, State> {
           <Icon type='icon-paper-key-corner' style={stylesPaperCorner} />
         </Box>
         {this.props.onFinish && <Checkbox style={stylesCheck} label='Yes, I wrote this down.' checked={this.state.inWallet} onCheck={inWallet => this.setState({inWallet})} />}
-        {this.props.onFinish && <Button style={stylesButton} type='Primary' label='Done' onClick={this.props.onFinish} disabled={!this.state.inWallet} />}
+        {this.props.onFinish && <Button style={stylesButton} waiting={this.props.waiting} type='Primary' label='Done' onClick={this.props.onFinish} disabled={!this.state.inWallet} />}
       </Container>
     )
   }

--- a/shared/login/signup/success/index.render.js.flow
+++ b/shared/login/signup/success/index.render.js.flow
@@ -5,6 +5,7 @@ import HiddenString from '../../../util/hidden-string'
 
 export type Props = {
   paperkey: HiddenString,
+  waiting: boolean,
   onFinish?: () => void,
   onBack?: () => void,
   title?: ?string

--- a/shared/login/signup/success/index.render.native.js
+++ b/shared/login/signup/success/index.render.native.js
@@ -50,6 +50,7 @@ export default class Render extends Component<void, Props, State> {
         <Box style={{flex: 2, justifyContent: 'flex-end'}}>
           <Button style={buttonStyle}
             disabled={!this.state.checked}
+            waiting={this.props.waiting}
             onClick={this.props.onFinish}
             label='Done'
             type='Primary' />

--- a/shared/login/signup/username-email-form.js
+++ b/shared/login/signup/username-email-form.js
@@ -35,7 +35,7 @@ class UsernameEmailForm extends Component {
         onSubmit={() => this.props.checkUsernameEmail(this.state.username, this.state.email)}
         usernameErrorText={this.props.usernameErrorText}
         emailErrorText={this.props.emailErrorText}
-        onBack={this.props.resetSignup}
+        onBack={this.props.restartSignup}
         waiting={this.props.waiting} />
     )
   }

--- a/shared/reducers/signup.js
+++ b/shared/reducers/signup.js
@@ -49,6 +49,7 @@ const initialState: SignupState = {
 export default function (state: SignupState = initialState, action: SignupActions): SignupState {
   switch (action.type) {
     case CommonConstants.resetStore:
+    case Constants.resetSignup:
       return {...initialState}
 
     case Constants.signupWaiting:

--- a/shared/reducers/signup.js
+++ b/shared/reducers/signup.js
@@ -189,7 +189,7 @@ export default function (state: SignupState = initialState, action: SignupAction
         return state
       }
 
-    case Constants.resetSignup:
+    case Constants.restartSignup:
       return {
         ...state,
         phase: 'inviteCode',

--- a/shared/test/actions/signup.js
+++ b/shared/test/actions/signup.js
@@ -104,7 +104,7 @@ describe('Signup', function () {
 
   describe('Reset signup', () => {
     it('should reset the phase to inviteCode', () => {
-      store.dispatch(signupActions.resetSignup())
+      store.dispatch(signupActions.restartSignup())
       assert(store.getState().signup.phase === 'inviteCode', 'Resets the phase to inviteCode')
     })
   })


### PR DESCRIPTION
:eyeglasses: @keybase/react-hackers 

We now set the signup reducer state to waiting when the user confirms the final signup step, because the UI will linger for a few seconds on this dialog while the login and bootstrapping process occurs. Once the bootstrap finishes, we reset the signup reducer state.

I've tested this on desktop, iOS, and Android. On iOS I discovered some flakiness in the final signup screen closing that seems to be unrelated to these changes.