### PR TITLE
Don't offer to add pgp key if none available

### DIFF
--- a/go/client/cmd_signup.go
+++ b/go/client/cmd_signup.go
@@ -132,7 +132,6 @@ Welcome to keybase.io!
    - you are now logged in as %s
    - your profile on keybase is https://keybase.io/%s
    - type 'keybase help' for more instructions
-   - type 'keybase pgp gen' if you'd like to create a PGP key
 
 Keybase is in alpha and we'll be rolling out new features soon. Report bugs
 to us at https://github.com/keybase/keybase-issues

--- a/go/engine/gpg_import_key.go
+++ b/go/engine/gpg_import_key.go
@@ -12,6 +12,7 @@ package engine
 
 import (
 	"fmt"
+
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/libkb"
@@ -77,6 +78,16 @@ func (e *GPGImportKeyEngine) WantsGPG(ctx *Context) (bool, error) {
 	}
 
 	// they have gpg
+
+	// get an index of all the secret keys
+	index, _, err := gpg.Index(true, "")
+	if err != nil {
+		return false, err
+	}
+	if index.Len() == 0 {
+		// no private keys available, so don't offer
+		return false, nil
+	}
 
 	res, err := ctx.GPGUI.WantToAddGPGKey(context.TODO(), 0)
 	if err != nil {


### PR DESCRIPTION
This is for `signup`.  At the end there is a prompt for adding a gpg key.

Previously, it checked if the gpg executable existed.

This adds a check for no private keys, and skips the prompt if there aren't any.

r? @oconnor663 or @mmaxim 