### PR TITLE
Tweak npm wrap script for use with vendoring

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -20,7 +20,7 @@
     "postinstall": "babel-node --presets es2015,stage-2 npm-helper.js postinstall",
     "render-screenshots": "babel-node --presets es2015,stage-2 npm-helper.js render-screenshots",
     "updated-fonts": "babel-node --presets es2015,stage-2 npm-helper.js updated-fonts",
-    "wrap": "rm -rf node_modules/msgpack && npm shrinkwrap --dev",
+    "wrap": "npm uninstall fsevents && npm prune && npm shrinkwrap --dev",
     "help": "babel-node --presets es2015,stage-2 npm-helper.js help",
     "watch-test-file": "KEYBASE_RUN_MODE=devel babel-node --presets es2015,stage-2 npm-helper.js watch-test-file",
     "mocha": "KEYBASE_RUN_MODE=devel node_modules/mocha/bin/mocha --require source-map-support/register dist/test.bundle.js",


### PR DESCRIPTION
`npm prune` will remove the extraneous `msgpack` module that is created by our postinstall script, and also cleans up any extra packages the user has installed that will prevent shrinkwrapping. Also need to get rid of `fsevents` here before if it gets added to the shrinkwrap. We don't need `fsevents` for a production build or CI (it's only useful for dev) and it invokes an unnecessary node-gyp build process.

@keybase/react-hackers 