### PR TITLE
Announce once CI has passed

### DIFF
--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -100,6 +100,8 @@ if [ ! "$nowait" = "1" ]; then
   "$release_bin" wait-ci --repo="go-updater" --commit=`git -C $updater_dir log -1 --pretty=format:%h` --context="continuous-integration/travis-ci/push"
 fi
 
+"$client_dir/packaging/slack/send.sh" "CI tests passed! Starting build and release for $platform."
+
 if [ ! "$nobuild" = "1" ]; then
   BUILD_DIR=$build_dir_keybase "$dir/build_keybase.sh"
   BUILD_DIR=$build_dir_kbfs "$dir/build_kbfs.sh"


### PR DESCRIPTION
@gabriel r? This way I'll at least know whether a build is spinning waiting for CI or not..