### PR TITLE
Remove LocalRPCDebug flags from keybase loopback

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -54,7 +54,7 @@ func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride
 		LogFile:                     logFile,
 		RunMode:                     runMode,
 		Debug:                       true,
-		LocalRPCDebug:               "Acsvip",
+		LocalRPCDebug:               "",
 		SecurityAccessGroupOverride: accessGroupOverride,
 	}
 	err = kbCtx.Configure(config, usage)


### PR DESCRIPTION
I'm afraid we'll forget about these things and put things in logs we shouldn't when we start shipping this.

@gabriel 
