### PR TITLE
create gregor handler regardless of logged in status CORE-3364

### DIFF
--- a/go/service/main.go
+++ b/go/service/main.go
@@ -188,6 +188,22 @@ func (d *Service) startupGregor() {
 		g.Log.Debug("Gregor disabled in Tor mode")
 	} else {
 		g.Log.Debug("connecting to gregord for push notifications")
+
+		// Create gregorHandler instance first so any handlers can connect
+		// to it before we actually connect to gregor (either gregor is down
+		// or we aren't logged in)
+		var err error
+		if d.gregor, err = newGregorHandler(d.G()); err != nil {
+			d.G().Log.Warning("failed to create push service handler: %s", err)
+			return
+		}
+		d.G().GregorDismisser = d.gregor
+		d.G().GregorListener = d.gregor
+
+		// Add default handlers
+		d.gregor.PushHandler(newUserHandler(d.G()))
+
+		// Connect to gregord
 		if gcErr := d.tryGregordConnect(); gcErr != nil {
 			g.Log.Debug("error connecting to gregord: %s", gcErr)
 		}
@@ -301,20 +317,15 @@ func (d *Service) gregordConnect() (err error) {
 	}
 	d.G().Log.Debug("| gregor URI: %s", uri)
 
-	if d.gregor == nil {
-		if d.gregor, err = newGregorHandler(d.G()); err != nil {
-			return err
-		}
-		d.G().GregorDismisser = d.gregor
-		d.G().GregorListener = d.gregor
-
-		d.gregor.PushHandler(newUserHandler(d.G()))
-	} else {
+	// If we are already connected, then shutdown and reset the gregor
+	// handler
+	if d.gregor.IsConnected() {
 		if d.gregor.Reset(); err != nil {
 			return err
 		}
 	}
 
+	// Connect to gregord
 	if err = d.gregor.Connect(uri); err != nil {
 		return err
 	}


### PR DESCRIPTION
@maxtaco @patrickxb r?

This patch makes it so that the `gregorHandler` object is always created when the service starts up. It solves the problem of the service starting logged out and having a ibm handler fail to get pushed.