### PR TITLE
Comment out libkbfs.Init in mobile due to RPC issue

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -77,11 +77,15 @@ func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride
 		Logs:         logs,
 	}
 
-	kbfsParams := libkbfs.DefaultInitParams(kbCtx)
-	kbfsConfig, err = libkbfs.Init(kbCtx, kbfsParams, newKeybaseDaemon, func() {}, kbCtx.Log)
-	if err != nil {
-		return err
-	}
+	// FIXME (MBG): This is causing RPC responses to sometimes not be recieved
+	// on iOS. Repro by hooking up getExtendedStatus to a button in the iOS
+	// client and watching JS logs. Disabling until we have a root cause / fix.
+	//
+	//kbfsParams := libkbfs.DefaultInitParams(kbCtx)
+	//kbfsConfig, err = libkbfs.Init(kbCtx, kbfsParams, newKeybaseDaemon, func() {}, kbCtx.Log)
+	//if err != nil {
+	//	return err
+	//}
 
 	return Reset()
 }


### PR DESCRIPTION
:eyeglasses: @keybase/react-hackers especially @chrisnojima @gabriel 

This appears to have been introduced in https://github.com/keybase/client/commit/0b2e640709f506a29daa2e62e192bc47565d8774

Opening a ticket to dig into this further, for the time being commenting it out since I've been informed it's pretty experimental.