### PR TITLE
Logger (internal) can be nil in RPC somehow

### DIFF
--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -354,11 +354,38 @@ func (log *Standard) GetUnforwardedLogger() *UnforwardedLogger {
 	return (*UnforwardedLogger)(log)
 }
 
-func (log *UnforwardedLogger) Debug(s string, args ...interface{})  { log.internal.Debugf(s, args...) }
-func (log *UnforwardedLogger) Error(s string, args ...interface{})  { log.internal.Errorf(s, args...) }
-func (log *UnforwardedLogger) Errorf(s string, args ...interface{}) { log.internal.Errorf(s, args...) }
-func (log *UnforwardedLogger) Warning(s string, args ...interface{}) {
-	log.internal.Warningf(s, args...)
+func (log *UnforwardedLogger) Debug(s string, args ...interface{}) {
+	if log.internal != nil {
+		log.internal.Debugf(s, args...)
+	}
 }
-func (log *UnforwardedLogger) Info(s string, args ...interface{})    { log.internal.Infof(s, args...) }
-func (log *UnforwardedLogger) Profile(s string, args ...interface{}) { log.internal.Debugf(s, args...) }
+
+func (log *UnforwardedLogger) Error(s string, args ...interface{}) {
+	if log.internal != nil {
+		log.internal.Errorf(s, args...)
+	}
+}
+
+func (log *UnforwardedLogger) Errorf(s string, args ...interface{}) {
+	if log.internal != nil {
+		log.internal.Errorf(s, args...)
+	}
+}
+
+func (log *UnforwardedLogger) Warning(s string, args ...interface{}) {
+	if log.internal != nil {
+		log.internal.Warningf(s, args...)
+	}
+}
+
+func (log *UnforwardedLogger) Info(s string, args ...interface{}) {
+	if log.internal != nil {
+		log.internal.Infof(s, args...)
+	}
+}
+
+func (log *UnforwardedLogger) Profile(s string, args ...interface{}) {
+	if log.internal != nil {
+		log.internal.Debugf(s, args...)
+	}
+}


### PR DESCRIPTION
This is a temporary fix that kind of sucks cause internal log shouldn't be nil... e.g. the constructor should return error and the thing calling the constructor should check for that etc etc, so I'll leave that original jira issue open.

See https://keybase.atlassian.net/browse/KBFS-1279

