### PR TITLE
Add command for updating vendored dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,3 @@ npm-debug.log
 node_modules
 
 Keybase.app.dSYM.zip
-
-js-vendor-desktop
-node_shrinkwrap

--- a/desktop/npm-vendor.js
+++ b/desktop/npm-vendor.js
@@ -5,6 +5,8 @@ var path = require('path')
 var fs = require('fs')
 var spawnSync = require('child_process').spawnSync
 
+var VENDOR_DIR = process.env.KEYBASE_JS_VENDOR_DIR || './js-vendor-desktop'
+
 function ensureSymlink (target, dest) {
   if (fs.existsSync(target)) {
     console.log('Removing existing', target)
@@ -32,18 +34,18 @@ function installVendored () {
   var url = parts[0]
   var commit = parts[1]
 
-  if (!fs.existsSync('./js-vendor-desktop')) {
-    spawn('git', ['clone', url, 'js-vendor-desktop'])
+  if (!fs.existsSync(VENDOR_DIR)) {
+    spawn('git', ['clone', url, VENDOR_DIR])
   }
-  spawn('git', ['fetch', 'origin'], {cwd: './js-vendor-desktop'})
-  spawn('git', ['checkout', '-f', commit], {cwd: './js-vendor-desktop'})
+  spawn('git', ['fetch', 'origin'], {cwd: VENDOR_DIR})
+  spawn('git', ['checkout', '-f', commit], {cwd: VENDOR_DIR})
   console.log(`js-vendor-desktop: ${url} @ ${commit}`)
 
-  ensureSymlink('./npm-shrinkwrap.json', './js-vendor-desktop/npm-shrinkwrap.json')
-  ensureSymlink('./node_shrinkwrap', './js-vendor-desktop/node_shrinkwrap')
+  ensureSymlink('./npm-shrinkwrap.json', path.join(VENDOR_DIR, 'npm-shrinkwrap.json'))
+  ensureSymlink('./node_shrinkwrap', path.join(VENDOR_DIR, 'node_shrinkwrap'))
   spawn(os.platform() === 'win32' ? 'npm.cmd' : 'npm', ['install', '--loglevel=http', '--no-optional'], {
     env: Object.assign({}, process.env, {
-      ELECTRON_CACHE: path.resolve('./js-vendor-desktop/electron'),
+      ELECTRON_CACHE: path.resolve(path.join(VENDOR_DIR, 'electron')),
       ELECTRON_ONLY_CACHE: 1,
     }),
   })

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/main.bundle.js",
   "scripts": {
     "vendor-install": "node npm-vendor.js",
+    "vendor-update": "node npm-vendor.js update",
     "start": "babel-node --presets es2015,stage-2 npm-helper.js start",
     "start-hot": "babel-node --presets es2015,stage-2 npm-helper.js start-hot",
     "start-cold": "babel-node --presets es2015,stage-2 npm-helper.js start-cold",


### PR DESCRIPTION
:eyeglasses: @chrisnojima @keybase/react-hackers 

Here's a one-line utility to run to update the vendored deps. Invoke something like this:

```KEYBASE_JS_VENDOR_DIR=your-path-to/js-vendor-desktop/ npm run vendor-update```

This turned out a bit more complex than I hoped. I tried to reduce the likelihood of failure, but this whole process is fairly stateful, so if you start it from an unclean state, YMMV.