### PR TITLE
Handle the relogin() case with an unprovisioned device

### DIFF
--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -282,6 +282,18 @@ export function relogin (user: string, passphrase: string, store: boolean) : Asy
             storeSecret: store,
           })
         },
+        'keybase.1.provisionUi.chooseDevice': ({devices}, response) => {
+          const message = 'This device is no longer provisioned.'
+          response.error({
+            code: constants.StatusCode.scgeneric,
+            desc: message,
+          })
+          dispatch({
+            type: Constants.loginDone,
+            error: true,
+            payload: {message},
+          })
+        },
       },
       callback: (error, status) => {
         if (error) {


### PR DESCRIPTION
@keybase/react-hackers 

The dialog in the screenshot below is the "Relogin" dialog -- when you click Login it emits the Relogin action, and in turn that calls the `loginLoginRPC()`.  But it does so with only one entry in its `incomingCallMap`, for `getPassphrase`.  The usual login flow would have a whole `makeKex2IncomingMap()` of handlers defined.  If your device has been revoked *but* your device doesn't know about that yet, the service will send us a `provisionUi.chooseDevice()` in response to our relogin attempt, which will fail with an unhandled RPC.

Since this is an edge case and it would feel weird to silently punt people into the provisioning flow when they're just trying to login, let's just tell them what's going on in an error message.

<img width="797" alt="screen shot 2016-07-18 at 11 42 40 am" src="https://cloud.githubusercontent.com/assets/21217/16920729/ce56225c-4cdc-11e6-8f1f-5a6903b86ce5.png">
