### PR TITLE
Fix status commands to wait

### DIFF
--- a/go/client/cmd_ctl_start_osx.go
+++ b/go/client/cmd_ctl_start_osx.go
@@ -56,7 +56,7 @@ func (s *cmdCtlStart) ParseArgv(ctx *cli.Context) error {
 }
 
 func ctlBrewStart(g *libkb.GlobalContext) error {
-	return StartLaunchdService(g, install.DefaultServiceLabel(g.Env.GetRunMode()), g.Env.GetServiceInfoPath(), true)
+	return startLaunchdService(g, install.DefaultServiceLabel(g.Env.GetRunMode()), g.Env.GetServiceInfoPath(), true)
 }
 
 func ctlStart(g *libkb.GlobalContext, components map[string]bool) error {
@@ -67,23 +67,27 @@ func ctlStart(g *libkb.GlobalContext, components map[string]bool) error {
 	g.Log.Debug("Components: %v", components)
 	errs := []error{}
 	if ok := components[install.ComponentNameService.String()]; ok {
-		if err := StartLaunchdService(g, install.DefaultServiceLabel(runMode), g.Env.GetServiceInfoPath(), true); err != nil {
+		if err := startLaunchdService(g, install.DefaultServiceLabel(runMode), g.Env.GetServiceInfoPath(), true); err != nil {
 			errs = append(errs, err)
+			g.Log.Errorf("%s", err)
 		}
 	}
 	if ok := components[install.ComponentNameKBFS.String()]; ok {
-		if err := StartLaunchdService(g, install.DefaultKBFSLabel(runMode), g.Env.GetKBFSInfoPath(), true); err != nil {
+		if err := startLaunchdService(g, install.DefaultKBFSLabel(runMode), g.Env.GetKBFSInfoPath(), true); err != nil {
 			errs = append(errs, err)
+			g.Log.Errorf("%s", err)
 		}
 	}
 	if ok := components[install.ComponentNameUpdater.String()]; ok {
 		if err := launchd.Start(install.DefaultUpdaterLabel(runMode), defaultLaunchdWait, g.Log); err != nil {
 			errs = append(errs, err)
+			g.Log.Errorf("%s", err)
 		}
 	}
 	if ok := components[install.ComponentNameApp.String()]; ok {
 		if err := install.RunApp(g, g.Log); err != nil {
 			errs = append(errs, err)
+			g.Log.Errorf("%s", err)
 		}
 	}
 	return libkb.CombineErrors(errs...)

--- a/go/client/cmd_ctl_stop_osx.go
+++ b/go/client/cmd_ctl_stop_osx.go
@@ -63,7 +63,8 @@ func (s *CmdCtlStop) ParseArgv(ctx *cli.Context) error {
 }
 
 func ctlBrewStop(g *libkb.GlobalContext) error {
-	return launchd.Stop(install.DefaultServiceLabel(g.Env.GetRunMode()), defaultLaunchdWait, g.Log)
+	_, err := launchd.Stop(install.DefaultServiceLabel(g.Env.GetRunMode()), defaultLaunchdWait, g.Log)
+	return err
 }
 
 func ctlStop(g *libkb.GlobalContext, components map[string]bool, wait time.Duration) error {
@@ -79,17 +80,17 @@ func ctlStop(g *libkb.GlobalContext, components map[string]bool, wait time.Durat
 		}
 	}
 	if ok := components[install.ComponentNameService.String()]; ok {
-		if err := launchd.Stop(install.DefaultServiceLabel(runMode), wait, g.Log); err != nil {
+		if _, err := launchd.Stop(install.DefaultServiceLabel(runMode), wait, g.Log); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	if ok := components[install.ComponentNameKBFS.String()]; ok {
-		if err := launchd.Stop(install.DefaultKBFSLabel(runMode), wait, g.Log); err != nil {
+		if _, err := launchd.Stop(install.DefaultKBFSLabel(runMode), wait, g.Log); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	if ok := components[install.ComponentNameUpdater.String()]; ok {
-		if err := launchd.Stop(install.DefaultUpdaterLabel(runMode), wait, g.Log); err != nil {
+		if _, err := launchd.Stop(install.DefaultUpdaterLabel(runMode), wait, g.Log); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/go/client/cmd_status_osx.go
+++ b/go/client/cmd_status_osx.go
@@ -8,8 +8,8 @@ package client
 import "github.com/keybase/client/go/install"
 
 func (c *CmdStatus) osSpecific(status *fstatus) error {
-	serviceStatus := install.KeybaseServiceStatus(c.G(), "service", c.G().Log)
-	kbfsStatus := install.KeybaseServiceStatus(c.G(), "kbfs", c.G().Log)
+	serviceStatus := install.KeybaseServiceStatus(c.G(), "service", 0, c.G().Log)
+	kbfsStatus := install.KeybaseServiceStatus(c.G(), "kbfs", 0, c.G().Log)
 
 	if len(serviceStatus.Pid) > 0 {
 		status.Service.Running = true

--- a/go/client/commands_non_osx.go
+++ b/go/client/commands_non_osx.go
@@ -21,7 +21,7 @@ func StopLaunchdService(g *libkb.GlobalContext, label string, wait bool) error {
 	return fmt.Errorf("Unsupported on this platform")
 }
 
-func RestartLaunchdService(g *libkb.GlobalContext, label string, serviceInfoPath string) error {
+func restartLaunchdService(g *libkb.GlobalContext, label string, serviceInfoPath string) error {
 	return fmt.Errorf("Unsupported on this platform")
 }
 

--- a/go/client/versionfix.go
+++ b/go/client/versionfix.go
@@ -121,7 +121,7 @@ func FixVersionClash(g *libkb.GlobalContext, cl libkb.CommandLine) (err error) {
 	}
 
 	if serviceConfig.ForkType == keybase1.ForkType_LAUNCHD {
-		return RestartLaunchdService(g, serviceConfig.Label, g.Env.GetServiceInfoPath())
+		return restartLaunchdService(g, serviceConfig.Label, g.Env.GetServiceInfoPath())
 	}
 
 	ctlCli = keybase1.CtlClient{Cli: gcli}


### PR DESCRIPTION
Not all status commands need to wait for launchctl, things around install should,
but things reporting status on command line don't.

Also fixes some error handling and reporting, nothing of which was critical.