### PR TITLE
Script to install KBFuse from installer

### DIFF
--- a/osx/Fuse/README.md
+++ b/osx/Fuse/README.md
@@ -35,3 +35,8 @@ After install if you are having problems loading the kext:
 View kext status:
 
     sudo kextstat -b com.github.kbfuse.filesystems.kbfuse
+
+### Release
+
+The Fuse bundle is included in the KeybaseInstaller.app.
+Building a new installer will automatically pick up the kbfuse.bundle checked in here.

--- a/osx/Fuse/install.sh
+++ b/osx/Fuse/install.sh
@@ -6,11 +6,20 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 cd "$dir"
 
 bundle=${BUNDLE:-"kbfuse.bundle"}
+dest="/Library/Filesystems/kbfuse.fs"
 
 echo "Using bundle: $bundle"
 
-sudo /bin/cp -RfX $bundle /Library/Filesystems/kbfuse.fs
-sudo chmod +s /Library/Filesystems/kbfuse.fs/Contents/Resources/load_kbfuse
+# Uninstall if present. This will fail if there are current kbfuse mounts.
+if [ -d "$dest" ]; then
+  echo "Uninstalling $dest..."
+  "$dir/uninstall.sh"
+fi
+
+echo "Installing $dest..."
+sudo /bin/cp -RfX "$bundle" "$dest"
+sudo chmod +s "/Library/Filesystems/kbfuse.fs/Contents/Resources/load_kbfuse"
+echo "Loading kext..."
 /Library/Filesystems/kbfuse.fs/Contents/Resources/load_kbfuse
 
 kextstat | grep kbfuse

--- a/osx/Fuse/uninstall.sh
+++ b/osx/Fuse/uninstall.sh
@@ -5,6 +5,8 @@ set -e -u -o pipefail # Fail on error
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 cd "$dir"
 
+dest="/Library/Filesystems/kbfuse.fs"
+
 echo "Checking for mounts..."
 mounts=`mount -t kbfuse`
 if [[ $mounts = *[!\ ]* ]]; then
@@ -14,6 +16,9 @@ if [[ $mounts = *[!\ ]* ]]; then
 fi
 
 echo "Unloading kext..."
-sudo kextunload -b "com.github.kbfuse.filesystems.kbfuse"
-echo "Removing bundle..."
-sudo rm -rf "/Library/Filesystems/kbfuse.fs"
+sudo kextunload -b "com.github.kbfuse.filesystems.kbfuse" || true
+
+if [ -d "$dest" ]; then
+  echo "Removing bundle..."
+  sudo rm -rf "$dest"
+fi

--- a/osx/Fuse/uninstall.sh
+++ b/osx/Fuse/uninstall.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail # Fail on error
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+cd "$dir"
+
+echo "Checking for mounts..."
+mounts=`mount -t kbfuse`
+if [[ $mounts = *[!\ ]* ]]; then
+  echo "There are mounts, please unmount before uninstalling."
+  echo "\t$mounts"
+  exit 1
+fi
+
+echo "Unloading kext..."
+sudo kextunload -b "com.github.kbfuse.filesystems.kbfuse"
+echo "Removing bundle..."
+sudo rm -rf "/Library/Filesystems/kbfuse.fs"

--- a/osx/Helper/uninstall_fuse.sh
+++ b/osx/Helper/uninstall_fuse.sh
@@ -1,2 +1,0 @@
-sudo kextunload -b com.github.kbfuse.filesystems.kbfuse
-sudo rm -rf /Library/Filesystems/kbfuse.fs

--- a/osx/Scripts/README.md
+++ b/osx/Scripts/README.md
@@ -18,7 +18,7 @@
 
 ### Releasing Installer
 
-Upload the build KeybaseInstaller-x.y.z-darwin.tgz to the latest release downlods at https://github.com/keybase/client/releases.
+Upload the build KeybaseInstaller-x.y.z-darwin.tgz to the latest release downloads at https://github.com/keybase/client/releases.
 
 Update the scripts that reference the older version such to include this version:
 - `packaging/desktop/package_darwin.sh`

--- a/osx/Scripts/README.md
+++ b/osx/Scripts/README.md
@@ -16,6 +16,14 @@
 
 ./build/KeybaseInstaller.app/Contents/MacOS/Keybase --app-path=/Applications/Keybase.app --run-mode=prod
 
+### Releasing Installer
+
+Upload the build KeybaseInstaller-x.y.z-darwin.tgz to the latest release downlods at https://github.com/keybase/client/releases.
+
+Update the scripts that reference the older version such to include this version:
+- `packaging/desktop/package_darwin.sh`
+- `packaging/desktop/kbfuse.sh`
+
 ## Overview
 
 When the Keybase.app runs it checks for the following components and compares the bundled version with the installed and running versions to make sure it's installed and up to date:

--- a/packaging/desktop/kbfuse.sh
+++ b/packaging/desktop/kbfuse.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail # Fail on error
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+cd $dir
+
+client_dir="$dir/../.."
+fuse_dir="$client_dir/osx/Fuse"
+tmp_dir="/tmp/desktop-kbfuse"
+installer_url="https://github.com/keybase/client/releases/download/v1.0.16/KeybaseInstaller-1.1.32-darwin.tgz"
+
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run as root"
+fi
+
+# Clear tmp
+rm -rf "$tmp_dir"
+mkdir -p "$tmp_dir"
+cd "$tmp_dir"
+
+echo "Downloading installer from $installer_url"
+curl -J -L -Ss "$installer_url" | tar zx
+
+echo "Installing KBFuse..."
+bundle="$tmp_dir/KeybaseInstaller.app/Contents/Resources/kbfuse.bundle"
+BUNDLE="$bundle" "$fuse_dir/install.sh"

--- a/packaging/desktop/kbfuse.sh
+++ b/packaging/desktop/kbfuse.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+#
+# This is a script to install KBFuse fsbundle and load the kext.
+# It is likely used by build or test machines since it requires
+# root permissions. Our end users have this installed via a
+# privileged helper tool in the Installer app.
+#
+
 set -e -u -o pipefail # Fail on error
 
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )

--- a/packaging/desktop/kbfuse.sh
+++ b/packaging/desktop/kbfuse.sh
@@ -19,6 +19,7 @@ installer_url="https://github.com/keybase/client/releases/download/v1.0.16/Keyba
 
 if [ "$EUID" -ne 0 ]; then
   echo "Please run as root"
+  exit 1
 fi
 
 # Clear tmp


### PR DESCRIPTION
Run `packaging/desktop/kbfuse.sh` as root (via sudo?), since installing the kext requires root access.

We use a OS level privileged helper tool to do this in the real app but this script can be used for build or test machines.