### PR TITLE
Allow bundled versions less than installed

### DIFF
--- a/go/install/fuse_status_osx.go
+++ b/go/install/fuse_status_osx.go
@@ -73,7 +73,7 @@ func KeybaseFuseStatus(bundleVersion string, log Log) keybase1.FuseStatus {
 	st.Version = kextInfo.Version
 	st.KextStarted = kextInfo.Started
 
-	installStatus, installAction, status := ResolveInstallStatus(st.Version, st.BundleVersion, "")
+	installStatus, installAction, status := ResolveInstallStatus(st.Version, st.BundleVersion, "", log)
 	st.InstallStatus = installStatus
 	st.InstallAction = installAction
 	st.Status = status

--- a/go/install/install.go
+++ b/go/install/install.go
@@ -103,7 +103,7 @@ func ComponentNameFromString(s string) ComponentName {
 }
 
 // ResolveInstallStatus will determine necessary install actions for the current environment
-func ResolveInstallStatus(version string, bundleVersion string, lastExitStatus string) (installStatus keybase1.InstallStatus, installAction keybase1.InstallAction, status keybase1.Status) {
+func ResolveInstallStatus(version string, bundleVersion string, lastExitStatus string, log Log) (installStatus keybase1.InstallStatus, installAction keybase1.InstallAction, status keybase1.Status) {
 	installStatus = keybase1.InstallStatus_UNKNOWN
 	installAction = keybase1.InstallAction_UNKNOWN
 	if version != "" && bundleVersion != "" {
@@ -129,10 +129,10 @@ func ResolveInstallStatus(version string, bundleVersion string, lastExitStatus s
 			installStatus = keybase1.InstallStatus_INSTALLED
 			installAction = keybase1.InstallAction_NONE
 		} else if bsv.LT(sv) {
-			installStatus = keybase1.InstallStatus_ERROR
+			// It's ok if we have a bundled version less than what was installed
+			log.Warning("Bundle version (%s) is less than installed version (%s)", bundleVersion, version)
+			installStatus = keybase1.InstallStatus_INSTALLED
 			installAction = keybase1.InstallAction_NONE
-			status = keybase1.StatusFromCode(keybase1.StatusCode_SCOldVersionError, fmt.Sprintf("Bundle version (%s) is less than installed version (%s)", bundleVersion, version))
-			return
 		}
 	} else if version != "" && bundleVersion == "" {
 		installStatus = keybase1.InstallStatus_INSTALLED

--- a/go/install/install_osx.go
+++ b/go/install/install_osx.go
@@ -61,7 +61,7 @@ func KeybaseServiceStatus(context Context, label string, wait time.Duration, log
 		return
 	}
 
-	installStatus, installAction, kbStatus := ResolveInstallStatus(status.Version, status.BundleVersion, status.LastExitStatus)
+	installStatus, installAction, kbStatus := ResolveInstallStatus(status.Version, status.BundleVersion, status.LastExitStatus, log)
 	status.InstallStatus = installStatus
 	status.InstallAction = installAction
 	status.Status = kbStatus
@@ -90,7 +90,7 @@ func KBFSServiceStatus(context Context, label string, wait time.Duration, log Lo
 		return
 	}
 
-	installStatus, installAction, kbStatus := ResolveInstallStatus(status.Version, status.BundleVersion, status.LastExitStatus)
+	installStatus, installAction, kbStatus := ResolveInstallStatus(status.Version, status.BundleVersion, status.LastExitStatus, log)
 	status.InstallStatus = installStatus
 	status.InstallAction = installAction
 	status.Status = kbStatus


### PR DESCRIPTION
It's not really an error and means you have a component installed thats newer than what
we have bundled. It's a warning at most.