### PR TITLE
Add some more fields to the electron .exe for Windows

### DIFF
--- a/desktop/package.js
+++ b/desktop/package.js
@@ -123,12 +123,22 @@ function pack (plat, arch, cb) {
   // there is no darwin ia32 electron
   if (plat === 'darwin' && arch === 'ia32') return
 
-  const opts = Object.assign({}, DEFAULT_OPTS, {
+  var opts = Object.assign({}, DEFAULT_OPTS, {
     platform: plat,
     arch: arch,
     prune: true,
     out: `release/${plat}-${arch}`,
   })
+
+  if (plat === 'win32') {
+    opts = Object.assign(opts, {
+      'version-string': {
+        'OriginalFilename': appName + '.exe',
+        'FileDescription': appName,
+        'ProductName': appName,
+      },
+    })
+  }
 
   packager(opts, cb)
 }


### PR DESCRIPTION
The icon and window name was fixed before; this addresses some properties of the .exe
@marco @chrisnojima 