### PR TITLE
Add missing native ProveEnterUsername component

### DIFF
--- a/shared/profile/edit-profile/render.native.js
+++ b/shared/profile/edit-profile/render.native.js
@@ -1,0 +1,11 @@
+// @flow
+import {Component} from 'react'
+import type {Props} from './render'
+
+class Render extends Component<void, Props, void> {
+  render () {
+    return null
+  }
+}
+
+export default Render

--- a/shared/profile/prove-enter-username.native.js
+++ b/shared/profile/prove-enter-username.native.js
@@ -1,0 +1,11 @@
+// @flow
+import {Component} from 'react'
+import type {Props} from './prove-enter-username'
+
+class Render extends Component<void, Props, void> {
+  render () {
+    return null
+  }
+}
+
+export default Render


### PR DESCRIPTION
I added a missing component to the native dumb sheet. Sorry about that!

:eyeglasses: @keybase/react-hackers 