### PR TITLE
Bump fsevents due to unpublished 1.0.13

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -107,7 +107,7 @@
     "webpack-target-electron-renderer": "0.4.0"
   },
   "optionalDependencies": {
-    "fsevents": "1.0.13"
+    "fsevents": "1.0.14"
   },
   "keybaseVendoredDependencies": "https://github.com/keybase/js-vendor-desktop.git#9c409a258efe1b93a8d50bdab35a901a0991f85b"
 }


### PR DESCRIPTION
:eyeglasses: @keybase/react-hackers 

See https://github.com/strongloop/fsevents/issues/141