### PR TITLE
Hot reloading extravaganza

### DIFF
--- a/desktop/npm-helper.js
+++ b/desktop/npm-helper.js
@@ -109,7 +109,7 @@ const commands = {
   },
   'hot-server': {
     env: {HOT: 'true', DEBUG: 'express:*'},
-    nodeEnv: 'production',
+    nodeEnv: 'development',
     nodePathDesktop: true,
     shell: 'node server.js',
     help: 'Start the webpack hot reloading code server (needed by npm run start-hot)',

--- a/desktop/npm-shrinkwrap.json
+++ b/desktop/npm-shrinkwrap.json
@@ -853,11 +853,6 @@
       "from": "concat-stream@1.5.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.0.6",
           "from": "readable-stream@>=2.0.0 <2.1.0",
@@ -1161,6 +1156,11 @@
       "version": "1.3.0",
       "from": "error-ex@^1.2.0",
       "resolved": "http://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
+    },
+    "error-stack-parser": {
+      "version": "1.3.6",
+      "from": "error-stack-parser@>=1.3.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz"
     },
     "es5-ext": {
       "version": "0.10.12",
@@ -2894,9 +2894,9 @@
       "resolved": "https://registry.npmjs.org/react-addons-transition-group/-/react-addons-transition-group-15.2.1.tgz"
     },
     "react-deep-force-update": {
-      "version": "1.0.1",
-      "from": "react-deep-force-update@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz"
+      "version": "2.0.1",
+      "from": "react-deep-force-update@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.0.1.tgz"
     },
     "react-dock": {
       "version": "0.2.3",
@@ -2912,6 +2912,18 @@
       "version": "0.2.1",
       "from": "react-event-listener@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.2.1.tgz"
+    },
+    "react-hot-loader": {
+      "version": "3.0.0-beta.2",
+      "from": "react-hot-loader@3.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-3.0.0-beta.2.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.4 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+        }
+      }
     },
     "react-json-tree": {
       "version": "0.6.8",
@@ -2931,9 +2943,9 @@
       }
     },
     "react-proxy": {
-      "version": "1.1.8",
-      "from": "react-proxy@>=1.1.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz"
+      "version": "3.0.0-alpha.1",
+      "from": "react-proxy@>=3.0.0-alpha.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz"
     },
     "react-pure-render": {
       "version": "1.0.2",
@@ -2961,16 +2973,6 @@
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
         }
       }
-    },
-    "react-transform-catch-errors": {
-      "version": "1.0.2",
-      "from": "react-transform-catch-errors@1.0.2",
-      "resolved": "https://registry.npmjs.org/react-transform-catch-errors/-/react-transform-catch-errors-1.0.2.tgz"
-    },
-    "react-transform-hmr": {
-      "version": "1.0.4",
-      "from": "react-transform-hmr@1.0.4",
-      "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz"
     },
     "read-json-sync": {
       "version": "1.1.1",
@@ -3006,6 +3008,11 @@
       "version": "0.20.2",
       "from": "recompose@>=0.20.2 <0.21.0",
       "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.20.2.tgz"
+    },
+    "redbox-react": {
+      "version": "1.2.10",
+      "from": "redbox-react@>=1.2.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.2.10.tgz"
     },
     "redent": {
       "version": "1.0.0",
@@ -3346,6 +3353,11 @@
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
+    },
+    "stackframe": {
+      "version": "0.3.1",
+      "from": "stackframe@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz"
     },
     "statuses": {
       "version": "1.3.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -93,8 +93,7 @@
     "mocha": "2.5.3",
     "null-loader": "0.1.1",
     "react-addons-perf": "15.2.1",
-    "react-transform-catch-errors": "1.0.2",
-    "react-transform-hmr": "1.0.4",
+    "react-hot-loader": "3.0.0-beta.2",
     "redux-devtools": "3.3.1",
     "redux-devtools-dock-monitor": "1.1.1",
     "redux-devtools-log-monitor": "1.0.11",
@@ -109,5 +108,5 @@
   "optionalDependencies": {
     "fsevents": "1.0.13"
   },
-  "keybaseVendoredDependencies": "https://github.com/keybase/js-vendor-desktop.git#9c409a258efe1b93a8d50bdab35a901a0991f85b"
+  "keybaseVendoredDependencies": "https://github.com/keybase/js-vendor-desktop.git#1b1170bd107681dd513bc8231869248da65bc127"
 }

--- a/desktop/renderer/container.js
+++ b/desktop/renderer/container.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react'
+import React from 'react'
 import {Provider} from 'react-redux'
 import Nav from '../shared/nav.desktop'
 import RemoteManager from './remote-manager'
@@ -6,46 +6,22 @@ import {MuiThemeProvider} from 'material-ui/styles'
 import materialTheme from '../shared/styles/material-theme.desktop'
 import {reduxDevToolsEnable} from '../shared/local-debug.desktop'
 
-export default class Root extends Component {
-  state: {
-    panelShowing: boolean
-  };
-
-  constructor () {
-    super()
-
-    this.state = {
-      panelShowing: false,
-    }
-
-    if (__DEV__) { // eslint-disable-line no-undef
-      window.addEventListener('keydown', event => {
-        if (event.ctrlKey && event.keyCode === 72) {
-          this.setState({panelShowing: !this.state.panelShowing})
-        }
-      })
-    }
+export default function Root ({store}) {
+  let dt = null
+  if (__DEV__ && reduxDevToolsEnable) { // eslint-disable-line no-undef
+    const DevTools = require('./redux-dev-tools').default
+    dt = <DevTools />
   }
 
-  render () {
-    let dt = null
-    if (__DEV__ && reduxDevToolsEnable) { // eslint-disable-line no-undef
-      const DevTools = require('./redux-dev-tools').default
-      dt = <DevTools />
-    }
-
-    const {store} = this.props
-
-    return (
-      <MuiThemeProvider muiTheme={materialTheme}>
-        <Provider store={store}>
-          <div style={{display: 'flex', flex: 1}}>
-            <RemoteManager />
-            <Nav />
-            {dt}
-          </div>
-        </Provider>
-      </MuiThemeProvider>
-    )
-  }
+  return (
+    <MuiThemeProvider muiTheme={materialTheme}>
+      <Provider store={store}>
+        <div style={{display: 'flex', flex: 1}}>
+          <RemoteManager />
+          <Nav />
+          {dt}
+        </div>
+      </Provider>
+    </MuiThemeProvider>
+  )
 }

--- a/desktop/renderer/container.js
+++ b/desktop/renderer/container.js
@@ -1,0 +1,51 @@
+import React, {Component} from 'react'
+import {Provider} from 'react-redux'
+import Nav from '../shared/nav.desktop'
+import RemoteManager from './remote-manager'
+import {MuiThemeProvider} from 'material-ui/styles'
+import materialTheme from '../shared/styles/material-theme.desktop'
+import {reduxDevToolsEnable} from '../shared/local-debug.desktop'
+
+export default class Root extends Component {
+  state: {
+    panelShowing: boolean
+  };
+
+  constructor () {
+    super()
+
+    this.state = {
+      panelShowing: false,
+    }
+
+    if (__DEV__) { // eslint-disable-line no-undef
+      window.addEventListener('keydown', event => {
+        if (event.ctrlKey && event.keyCode === 72) {
+          this.setState({panelShowing: !this.state.panelShowing})
+        }
+      })
+    }
+  }
+
+  render () {
+    let dt = null
+    if (__DEV__ && reduxDevToolsEnable) { // eslint-disable-line no-undef
+      const DevTools = require('./redux-dev-tools').default
+      dt = <DevTools />
+    }
+
+    const {store} = this.props
+
+    return (
+      <MuiThemeProvider muiTheme={materialTheme}>
+        <Provider store={store}>
+          <div style={{display: 'flex', flex: 1}}>
+            <RemoteManager />
+            <Nav />
+            {dt}
+          </div>
+        </Provider>
+      </MuiThemeProvider>
+    )
+  }
+}

--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -3,131 +3,100 @@
  * The main renderer. Holds the global store. When it changes we send it to the main thread which then sends it out to subscribers
  */
 
-import React, {Component} from 'react'
+import React from 'react'
 import ReactDOM from 'react-dom'
-import {Provider} from 'react-redux'
+import {AppContainer} from 'react-hot-loader'
 import configureStore from '../shared/store/configure-store'
-import Nav from '../shared/nav.desktop'
 import injectTapEventPlugin from 'react-tap-event-plugin'
 import ListenLogUi from '../shared/native/listen-log-ui'
-import {reduxDevToolsEnable, devStoreChangingFunctions, setup as setupLocalDebug} from '../shared/local-debug.desktop'
+import {devStoreChangingFunctions} from '../shared/local-debug.desktop'
 import {listenForNotifications} from '../shared/actions/notifications'
+import {bootstrap} from '../shared/actions/config'
 import hello from '../shared/util/hello'
 
+import Root from './container'
 import {devEditAction} from '../shared/reducers/dev-edit'
 import {setupContextMenu} from '../app/menu-helper'
 
 // For Remote Components
 import electron, {ipcRenderer} from 'electron'
-import RemoteManager from './remote-manager'
 import {ipcLogsRenderer} from '../app/console-helper'
 import loadPerf from '../shared/util/load-perf'
 import merge from 'lodash/merge'
-import {MuiThemeProvider} from 'material-ui/styles'
-import materialTheme from '../shared/styles/material-theme.desktop'
 
-ipcLogsRenderer()
+function setupApp (store) {
+  ipcLogsRenderer()
 
-if (module.hot) {
-  module.hot.accept()
+  loadPerf()
+
+  if (devStoreChangingFunctions) {
+    window.devEdit = (path, value) => store.dispatch(devEditAction(path, value))
+  }
+
+  if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) {
+    require('devtron').install()
+  }
+
+  setupContextMenu(electron.remote.getCurrentWindow())
+
+  // Used by material-ui widgets.
+  if (module.hot) {
+    // Don't reload this thing if we're hot reloading
+    if (module.hot.data === undefined) {
+      injectTapEventPlugin()
+    }
+  } else {
+    injectTapEventPlugin()
+  }
+
+  ipcRenderer.on('dispatchAction', (event, action) => {
+    // we MUST convert this else we'll run into issues with redux. See https://github.com/rackt/redux/issues/830
+    // This is because this is touched due to the remote proxying. We get a __proto__ which causes the _.isPlainObject check to fail. We use
+    // _.merge() to get a plain object back out which we can send
+    setImmediate(() => {
+      try {
+        store.dispatch(merge({}, action))
+      } catch (_) {
+      }
+    })
+  })
+
+  store.subscribe(() => {
+    ipcRenderer.send('stateChange', store.getState())
+  })
+
+  // Handle notifications from the service
+  store.dispatch(listenForNotifications())
+
+  // Handle logUi.log
+  ListenLogUi()
+
+  // Introduce ourselves to the service
+  hello(process.pid, 'Main Renderer', process.argv, __VERSION__) // eslint-disable-line no-undef
+
+  store.dispatch(bootstrap())
+  // Restartup when we connect online.
+  // If you startup while offline, you'll stay in an errored state
+  window.addEventListener('online', () => store.dispatch(bootstrap()))
 }
 
 const store = configureStore()
 
-setupLocalDebug(store)
+setupApp(store)
 
-if (devStoreChangingFunctions) {
-  window.devEdit = (path, value) => store.dispatch(devEditAction(path, value))
-}
+const appEl = document.getElementById('app')
 
-class Keybase extends Component {
-  state: {
-    panelShowing: boolean
-  };
+ReactDOM.render(
+  <AppContainer><Root store={store} /></AppContainer>,
+  appEl,
+)
 
-  constructor () {
-    super()
-
-    loadPerf()
-
-    this.state = {
-      panelShowing: false,
-    }
-
-    if (__DEV__) { // eslint-disable-line no-undef
-      if (typeof window !== 'undefined') {
-        window.addEventListener('keydown', event => {
-          if (event.ctrlKey && event.keyCode === 72) {
-            this.setState({panelShowing: !this.state.panelShowing})
-          }
-        })
-      }
-    }
-
-    setupContextMenu(electron.remote.getCurrentWindow())
-
-    // Used by material-ui widgets.
-    if (module.hot) {
-      // Don't reload this thing if we're hot reloading
-      if (module.hot.data === undefined) {
-        injectTapEventPlugin()
-      }
-    } else {
-      injectTapEventPlugin()
-    }
-
-    this.setupDispatchAction()
-    this.setupStoreSubscriptions()
-
-    // Handle notifications from the service
-    store.dispatch(listenForNotifications())
-
-    // Handle logUi.log
-    ListenLogUi()
-
-    // Introduce ourselves to the service
-    hello(process.pid, 'Main Renderer', process.argv, __VERSION__) // eslint-disable-line no-undef
-  }
-
-  setupDispatchAction () {
-    ipcRenderer.on('dispatchAction', (event, action) => {
-      // we MUST convert this else we'll run into issues with redux. See https://github.com/rackt/redux/issues/830
-      // This is because this is touched due to the remote proxying. We get a __proto__ which causes the _.isPlainObject check to fail. We use
-      // _.merge() to get a plain object back out which we can send
-      setImmediate(() => {
-        try {
-          store.dispatch(merge({}, action))
-        } catch (_) {
-        }
-      })
-    })
-  }
-
-  setupStoreSubscriptions () {
-    store.subscribe(() => {
-      ipcRenderer.send('stateChange', store.getState())
-    })
-  }
-
-  render () {
-    let dt = null
-    if (__DEV__ && reduxDevToolsEnable) { // eslint-disable-line no-undef
-      const DevTools = require('./redux-dev-tools').default
-      dt = <DevTools />
-    }
-
-    return (
-      <MuiThemeProvider muiTheme={materialTheme}>
-        <Provider store={store}>
-          <div style={{display: 'flex', flex: 1}}>
-            <RemoteManager />
-            <Nav />
-            {dt}
-          </div>
-        </Provider>
-      </MuiThemeProvider>
+if (module.hot) {
+  module.hot.accept('./container', () => {
+    const NewRoot = require('./container').default
+    ReactDOM.render(
+      <AppContainer><NewRoot store={store} /></AppContainer>,
+      appEl,
     )
-  }
+  })
 }
-
-ReactDOM.render(<Keybase />, document.getElementById('app'))

--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -12,6 +12,7 @@ import ListenLogUi from '../shared/native/listen-log-ui'
 import {devStoreChangingFunctions} from '../shared/local-debug.desktop'
 import {listenForNotifications} from '../shared/actions/notifications'
 import {bootstrap} from '../shared/actions/config'
+import {updateDebugConfig} from '../shared/actions/dev'
 import hello from '../shared/util/hello'
 
 import Root from './container'
@@ -74,6 +75,8 @@ function setupApp (store) {
   // Introduce ourselves to the service
   hello(process.pid, 'Main Renderer', process.argv, __VERSION__) // eslint-disable-line no-undef
 
+  store.dispatch(updateDebugConfig(require('../shared/local-debug-live')))
+
   store.dispatch(bootstrap())
   // Restartup when we connect online.
   // If you startup while offline, you'll stay in an errored state
@@ -98,5 +101,12 @@ if (module.hot) {
       <AppContainer><NewRoot store={store} /></AppContainer>,
       appEl,
     )
+  })
+}
+
+// flowtype requires this to be a separate if statement
+if (module.hot) {
+  module.hot.accept('../shared/local-debug-live', () => {
+    store.dispatch(updateDebugConfig(require('../shared/local-debug-live')))
   })
 }

--- a/desktop/webpack.config.base.js
+++ b/desktop/webpack.config.base.js
@@ -16,7 +16,7 @@ module.exports = {
       exclude: /(node_modules|\/dist\/)/,
       query: {
         cacheDirectory: true,
-        plugins: ['transform-runtime'],
+        plugins: ['transform-runtime', 'react-hot-loader/babel'],
         presets: ['es2015', 'stage-1', 'react'],
       },
     }, {

--- a/desktop/webpack.config.development.js
+++ b/desktop/webpack.config.development.js
@@ -34,6 +34,8 @@ config.plugins.push(
 )
 
 if (getenv.boolish('HOT', false)) {
+  config.entry.index = ['react-hot-loader/patch'].concat(config.entry.index)
+
   const HMR = 'webpack-hot-middleware/client?path=http://localhost:4000/__webpack_hmr'
 
   Object.keys(config.entry).forEach(k => {

--- a/shared/common-adapters/dumb.desktop.js
+++ b/shared/common-adapters/dumb.desktop.js
@@ -69,29 +69,31 @@ const iconMap: DumbComponentMap<IconHolder> = {
   },
 }
 
-const IconButton = ({selected, icon, badgeNumber, label}: any) => <TabBarButton label={label} source={{type: 'icon', icon}} selected={selected} badgeNumber={badgeNumber} style={{height: 40}} />
-const AvatarButton = ({selected, avatar, badgeNumber}: any) => <TabBarButton source={{type: 'avatar', avatar}} selected={selected} badgeNumber={badgeNumber} style={{flex: 1}} styleContainer={{height: 40}} />
+const tabBarCustomButtons = selectedIndex => {
+  const IconButton = ({selected, icon, badgeNumber, label}: any) => <TabBarButton label={label} source={{type: 'icon', icon}} selected={selected} badgeNumber={badgeNumber} style={{height: 40}} />
+  const AvatarButton = ({selected, avatar, badgeNumber}: any) => <TabBarButton source={{type: 'avatar', avatar}} selected={selected} badgeNumber={badgeNumber} style={{flex: 1}} styleContainer={{height: 40}} />
 
-const tabBarCustomButtons = selectedIndex => ({
-  style: {flex: 1, display: 'flex', ...globalStyles.flexBoxRow, height: 580},
-  styleTabBar: {justifyContent: 'flex-start', width: 160, backgroundColor: globalColors.midnightBlue, ...globalStyles.flexBoxColumn},
-  children: [
-    {avatar: <Avatar size={32} onClick={null} username='max' />},
-    {icon: 'iconfont-people', label: 'PEOPLE', badgeNumber: 3},
-    {icon: 'iconfont-folder', label: 'FOLDERS'},
-    {icon: 'iconfont-device', label: 'DEVICES', badgeNumber: 12},
-    {icon: 'iconfont-settings', label: 'SETTINGS'},
-  ].map((buttonInfo: any, i) => {
-    const button = buttonInfo.avatar
-      ? <AvatarButton badgeNumber={buttonInfo.badgeNumber} selected={selectedIndex === i} avatar={buttonInfo.avatar} />
-      : <IconButton icon={buttonInfo.icon} label={buttonInfo.label} badgeNumber={buttonInfo.badgeNumber} selected={selectedIndex === i} />
-    return (
-      <TabBarItem key={i} tabBarButton={button} styleContainer={{display: 'flex'}} selected={selectedIndex === i} onClick={() => console.log('TabBaritem:onClick')}>
-        <Text type='Header' style={{flex: 1}}>Content here at: {i}</Text>
-      </TabBarItem>
-    )
-  }),
-})
+  return {
+    style: {flex: 1, display: 'flex', ...globalStyles.flexBoxRow, height: 580},
+    styleTabBar: {justifyContent: 'flex-start', width: 160, backgroundColor: globalColors.midnightBlue, ...globalStyles.flexBoxColumn},
+    children: [
+      {avatar: <Avatar size={32} onClick={null} username='max' />},
+      {icon: 'iconfont-people', label: 'PEOPLE', badgeNumber: 3},
+      {icon: 'iconfont-folder', label: 'FOLDERS'},
+      {icon: 'iconfont-device', label: 'DEVICES', badgeNumber: 12},
+      {icon: 'iconfont-settings', label: 'SETTINGS'},
+    ].map((buttonInfo: any, i) => {
+      const button = buttonInfo.avatar
+        ? <AvatarButton badgeNumber={buttonInfo.badgeNumber} selected={selectedIndex === i} avatar={buttonInfo.avatar} />
+        : <IconButton icon={buttonInfo.icon} label={buttonInfo.label} badgeNumber={buttonInfo.badgeNumber} selected={selectedIndex === i} />
+      return (
+        <TabBarItem key={i} tabBarButton={button} styleContainer={{display: 'flex'}} selected={selectedIndex === i} onClick={() => console.log('TabBaritem:onClick')}>
+          <Text type='Header' style={{flex: 1}}>Content here at: {i}</Text>
+        </TabBarItem>
+      )
+    }),
+  }
+}
 
 const tabBarMap: DumbComponentMap<TabBar> = {
   component: TabBar,

--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -19,8 +19,13 @@ export default class Input extends Component {
       focused: false,
     }
   }
+
   getValue (): ?string {
     return this.state.value
+  }
+
+  setValue (value: string) {
+    this.setState({value})
   }
 
   clearValue () {

--- a/shared/dev/dumb-sheet.render.desktop.js
+++ b/shared/dev/dumb-sheet.render.desktop.js
@@ -26,6 +26,11 @@ class Render extends Component<void, any, any> {
     ReactDOM.findDOMNode(this.refs.filterInput).querySelector('input').focus()
   }
 
+  componentWillReceiveProps (nextProps: any) {
+    // FIXME: desktop <Input> element keeps internal state, need to set its value manually
+    this.refs.filterInput.setValue(nextProps.dumbFilter)
+  }
+
   render () {
     const filter = this.props.dumbFilter.toLowerCase()
 

--- a/shared/local-debug-live.js
+++ b/shared/local-debug-live.js
@@ -1,0 +1,5 @@
+export const dumbFilter = ''
+
+// the following only apply to mobile:
+export const dumbIndex = 0
+export const dumbFullscreen = false

--- a/shared/local-debug.desktop.js
+++ b/shared/local-debug.desktop.js
@@ -3,7 +3,6 @@
  */
 
 import {createRouterState} from './reducers/router'
-import {updateDebugConfig} from './actions/dev'
 import * as Tabs from './constants/tabs'
 import {updateConfig} from './command-line.desktop.js'
 
@@ -23,7 +22,6 @@ let config = {
   reactPerf: false,
   overrideLoggedInTab: null,
   focusOnShow: true,
-  dumbFilter: '',
   printRoutes: false,
   skipLauncherDevtools: true,
   initialTabState: {},
@@ -50,7 +48,6 @@ if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) {
   config.reactPerf = false
   config.overrideLoggedInTab = Tabs.settingsTab
   config.focusOnShow = false
-  config.dumbFilter = ''
   config.printRoutes = true
   config.initialTabState = {
     [Tabs.loginTab]: [],
@@ -88,7 +85,6 @@ export const {
   reactPerf,
   overrideLoggedInTab,
   focusOnShow,
-  dumbFilter,
   printRoutes,
   skipLauncherDevtools,
   forceMainWindowPosition,
@@ -114,21 +110,4 @@ export function initTabbedRouterState (state) {
       ...tabState,
     },
   }
-}
-
-function updateStore (store, config) {
-  store.dispatch(updateDebugConfig({
-    dumbFilter: config.dumbFilter,
-    dumbIndex: config.dumbIndex,
-    dumbFullscreen: config.dumbFullscreen,
-  }))
-}
-
-export function setup (store) {
-  if (module.hot) {
-    module.hot.accept('./local-debug.desktop', () => {
-      updateStore(store, require('./local-debug.desktop'))
-    })
-  }
-  updateStore(store, config)
 }

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -18,9 +18,6 @@ let config = {
   printOutstandingRPCs: false,
   reactPerf: false,
   overrideLoggedInTab: null,
-  dumbFilter: '',
-  dumbIndex: 0,
-  dumbFullscreen: false,
   printRoutes: false,
   logStatFrequency: 0,
   actionStatFrequency: 0,
@@ -57,9 +54,6 @@ export const {
   printOutstandingRPCs,
   reactPerf,
   overrideLoggedInTab,
-  dumbFilter,
-  dumbIndex,
-  dumbFullscreen,
   printRoutes,
   logStatFrequency,
   actionStatFrequency,
@@ -81,19 +75,11 @@ export function initTabbedRouterState (state) {
   }
 }
 
-function updateStore (store, config) {
-  store.dispatch(updateDebugConfig({
-    dumbFilter: config.dumbFilter,
-    dumbIndex: config.dumbIndex,
-    dumbFullscreen: config.dumbFullscreen,
-  }))
-}
-
 export function setup (store) {
+  const updateLiveConfig = () => store.dispatch(updateDebugConfig(require('./local-debug-live')))
+
   if (module.hot) {
-    module.hot.accept(() => {
-      updateStore(store, require('./local-debug.native'))
-    })
+    module.hot.accept(() => updateLiveConfig())
   }
-  updateStore(store, config)
+  updateLiveConfig()
 }

--- a/shared/nav.desktop.js
+++ b/shared/nav.desktop.js
@@ -25,8 +25,6 @@ import {switchTab} from './actions/tabbed-router'
 import {navigateBack, navigateUp} from './actions/router'
 import TabBar from './tab-bar/index.render'
 
-import {bootstrap} from './actions/config'
-
 const tabs = {
   [settingsTab]: {module: Settings, name: 'Settings'},
   [profileTab]: {module: Profile, name: 'Profile'},
@@ -42,10 +40,8 @@ type State = {
 
 type Props = {
   menuBadge: boolean,
-  bootstrap: () => void,
   switchTab: (tab: Tabs) => void,
   tabbedRouter: Object,
-  bootstrapped: boolean,
   provisioned: boolean,
   username: string,
   navigateBack: () => void,
@@ -62,23 +58,11 @@ class Nav extends Component<void, Props, State> {
 
   constructor (props) {
     super(props)
-    this._setupDebug()
-    this.props.bootstrap()
     this._handleKeyDown = this._handleKeyDown.bind(this)
 
     this.state = {searchActive}
 
-    // Restartup when we connect online.
-    // If you startup while offline, you'll stay in an errored state
-    window.addEventListener('online', () => this.props.bootstrap())
-
     this._lastCheckedTab = null // the last tab we resized for
-  }
-
-  _setupDebug () {
-    if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) {
-      require('devtron').install()
-    }
   }
 
   _handleTabsChange (e, key, payload) {
@@ -206,11 +190,10 @@ const stylesTabsContainer = {
 
 export default connect(
   ({tabbedRouter,
-    config: {bootstrapped, extendedConfig, username},
+    config: {extendedConfig, username},
     favorite: {publicBadge, privateBadge},
     notifications: {menuBadge}}) => ({
       tabbedRouter,
-      bootstrapped,
       provisioned: extendedConfig && !!extendedConfig.device,
       username,
       menuBadge,
@@ -219,7 +202,6 @@ export default connect(
   dispatch => {
     return {
       switchTab: tab => dispatch(switchTab(tab)),
-      bootstrap: () => dispatch(bootstrap()),
       navigateBack: () => dispatch(navigateBack()),
       navigateUp: () => dispatch(navigateUp()),
     }

--- a/shared/tab-bar/dumb.desktop.js
+++ b/shared/tab-bar/dumb.desktop.js
@@ -16,15 +16,17 @@ const badgeNumbers = {
   [settingsTab]: 0,
 }
 
-const DummyContent = ({text}) => <Text type='Body'>Filler: {text}</Text>
+const tabContent = (() => {  // wrapped in a self-calling function to prevent React Hot Loader
+  const DummyContent = ({text}) => <Text type='Body'>Filler: {text}</Text>
 
-const tabContent = {
-  [profileTab]: <DummyContent text='profile' />,
-  [peopleTab]: <DummyContent text='people' />,
-  [folderTab]: <DummyContent text='folder' />,
-  [devicesTab]: <DummyContent text='devicees' />,
-  [settingsTab]: <DummyContent text='settings' />,
-}
+  return {
+    [profileTab]: <DummyContent text='profile' />,
+    [peopleTab]: <DummyContent text='people' />,
+    [folderTab]: <DummyContent text='folder' />,
+    [devicesTab]: <DummyContent text='devicees' />,
+    [settingsTab]: <DummyContent text='settings' />,
+  }
+})()
 
 const map: DumbComponentMap<TabBar> = {
   component: TabBar,


### PR DESCRIPTION
:eyeglasses: @keybase/react-hackers 

:fire: Hot reloading in the desktop client using react-hot-loader 3.0.0 beta
:fire: Live local-debug filter for twiddling the dumb sheet from your editor
:sparkle: Cleaned up desktop entry point setup
:one: Moved `bootstrap` action out of component so it only runs on startup 
:left_right_arrow: Unified live local debug properties into a single file

Deps: https://github.com/keybase/js-vendor-desktop/pull/3

![:fire:](http://i0.kym-cdn.com/entries/icons/original/000/018/012/Screen_Shot_2015-05-12_at_3.31.31_PM.png)