### PR TITLE
Don't ctl stop updater in Keybase.app quit

### DIFF
--- a/desktop/app/ctl.js
+++ b/desktop/app/ctl.js
@@ -4,7 +4,11 @@ import exec from './exec'
 
 export function ctlStop (callback) {
   const binPath = keybaseBinPath()
-  const args = ['ctl', 'stop', '--exclude=app', '--no-wait']
+  // Don't need to stop app, since we will quit ourselves
+  // We don't stop the updater either since quit may be triggered from the
+  // updater itself.
+  // See https://keybase.atlassian.net/browse/CORE-3418
+  const args = ['ctl', 'stop', '--exclude=app,updater', '--no-wait']
   exec(binPath, args, 'darwin', 'prod', false, callback)
 }
 

--- a/desktop/app/index.js
+++ b/desktop/app/index.js
@@ -105,9 +105,13 @@ function start () {
     })
   })
 
-  // quit through dock. only listen once
+  // This is called when there is any browser quit event such as,
+  // - Quit through dock
+  // - SIGINT and SIGTERM
+  // See https://keybase.atlassian.net/browse/CORE-3418
   app.once('before-quit', event => {
-    console.log('Quit through before-quit')
+    console.log('Quit through before-quit:', event)
+    // Prevent the default quit action, we'll do it ourselves
     event.preventDefault()
     executeActionsForContext('beforeQuit')
   })


### PR DESCRIPTION
See discussion here:
https://keybase.atlassian.net/browse/CORE-3418

With this change the updater would still be running if Keybase.app wasn't so
either this isn't the right solution or we need to address that too (as
mentioned in JIRA discussion), before merging this.