### PR TITLE
Revert "ctl stop on app quit (#3469)"

### DIFF
--- a/desktop/app/ctl.js
+++ b/desktop/app/ctl.js
@@ -11,14 +11,13 @@ export function ctlStop (callback) {
 export function quit () {
   // Only quit the app in dev mode
   if (__DEV__) {
-    console.log('Only quiting gui in dev mode')
+    console.log('Only quiting app in dev mode')
     app.quit()
     return
   }
 
   console.log('Quit the app')
   ctlStop(function (stopErr) {
-    console.log('Done with ctlstop')
     if (stopErr) {
       console.log('Error in ctl stop, when quiting:', stopErr)
     }

--- a/desktop/app/index.js
+++ b/desktop/app/index.js
@@ -13,7 +13,7 @@ import urlHelper from './url-helper'
 import hello from '../shared/util/hello'
 import semver from 'semver'
 import os from 'os'
-import {setupExecuteActionsListener, executeActionsForContext} from '../shared/util/quit-helper.desktop'
+import {setupExecuteActionsListener} from '../shared/util/quit-helper.desktop'
 import {hideDockIcon} from './dock-icon'
 
 let mainWindow = null
@@ -103,13 +103,6 @@ function start () {
     windows.forEach(w => {
       w.destroy()
     })
-  })
-
-  // quit through dock. only listen once
-  app.once('before-quit', event => {
-    console.log('Quit through before-quit')
-    event.preventDefault()
-    executeActionsForContext('beforeQuit')
   })
 }
 

--- a/desktop/app/menu-helper.js
+++ b/desktop/app/menu-helper.js
@@ -1,7 +1,7 @@
 // Can't tell which thread we're in so let's try both
 import electron from 'electron'
 
-import {executeActionsForContext} from '../shared/util/quit-helper.desktop'
+import {executeActions, quitOnContext} from '../shared/util/quit-helper.desktop'
 
 const Menu = electron.Menu || electron.remote.Menu
 const shell = electron.shell || electron.remote.shell
@@ -52,7 +52,7 @@ export default function makeMenu (window) {
         {label: 'Hide Others', accelerator: 'CmdOrCtrl+Shift+H', role: 'hideothers'},
         {label: 'Show All', role: 'unhide'},
         {type: 'separator'},
-        {label: 'Quit', accelerator: 'CmdOrCtrl+Q', click () { executeActionsForContext('uiWindow') }},
+        {label: 'Quit', accelerator: 'CmdOrCtrl+Q', click () { executeActions(quitOnContext({type: 'uiWindow'})) }},
       ],
     }, {
       ...editMenu,
@@ -68,7 +68,7 @@ export default function makeMenu (window) {
       label: '&File',
       submenu: [
        {label: '&Close', accelerator: 'CmdOrCtrl+W', role: 'close'},
-       {label: '&Quit', accelerator: 'CmdOrCtrl+Q', click () { executeActionsForContext('uiWindow') }},
+       {label: '&Quit', accelerator: 'CmdOrCtrl+Q', click () { executeActions(quitOnContext({type: 'uiWindow'})) }},
       ],
     }, {
       ...editMenu,

--- a/shared/menubar/index.js
+++ b/shared/menubar/index.js
@@ -10,7 +10,7 @@ import {openInKBFS} from '../actions/kbfs'
 import {openDialog as openRekeyDialog} from '../actions/unlock-folders'
 import {switchTab} from '../actions/tabbed-router'
 import {loginTab} from '../constants/tabs'
-import {executeActionsForContext} from '../util/quit-helper.desktop'
+import {executeActions, quitOnContext} from '../util/quit-helper.desktop'
 
 import type {Props as FolderProps} from '../folders/render'
 
@@ -139,7 +139,7 @@ class Menubar extends Component<void, Props, void> {
   }
 
   _quit () {
-    executeActionsForContext('quitButton')
+    executeActions(quitOnContext({type: 'quitButton'}))
   }
 
   _showBug () {


### PR DESCRIPTION
This reverts commit 567cfe55382e8ad4a01dbc6bbf8ad10acb00f0d8.

This fixes the issue where SIGTERM/INT/HUP was triggering our custom before-quit handling (which was meant to be handling quit from dock) which was calling ctl stop.

See https://keybase.atlassian.net/browse/CORE-3418

This means calling Quit from dock icon quits the app without ctl stop, which we'll have to figure out how to address. Unfortunately I don't see an easy way to detect dock quit.
