### PR TITLE
Profile proofs display tweaks

### DIFF
--- a/shared/profile/dumb.js
+++ b/shared/profile/dumb.js
@@ -3,7 +3,7 @@ import Profile from './render'
 import ConfirmOrPending from './confirm-or-pending'
 import ProveEnterUsername from './prove-enter-username'
 import EditAvatar from './edit-avatar'
-import {normal, checking, revoked, error, metaNone} from '../constants/tracker'
+import {normal, checking, revoked, error, metaNone, metaNew} from '../constants/tracker'
 import {createFolder} from '../folders/dumb'
 import {globalColors} from '../styles/style-guide'
 import {isMobile} from '../constants/platform'
@@ -14,7 +14,7 @@ import type {DumbComponentMap} from '../constants/types/more'
 
 export const proofsDefault: Array<Proof> = [
   {name: 'malgorithms', type: 'twitter', id: 'twitterId', state: normal, meta: metaNone, humanUrl: 'twitter.com', profileUrl: 'http://twitter.com', isTracked: false},
-  {name: 'malgorithms', type: 'github', id: 'githubId', state: normal, meta: metaNone, humanUrl: 'github.com', profileUrl: 'http://github.com', isTracked: false},
+  {name: 'malgorithms', type: 'github', id: 'githubId', state: normal, meta: metaNew, humanUrl: 'github.com', profileUrl: 'http://github.com', isTracked: false},
   {name: 'malgorithms', type: 'reddit', id: 'redditId', state: normal, meta: metaNone, humanUrl: 'reddit.com', profileUrl: 'http://reddit.com', isTracked: false},
   {name: 'keybase.io', type: 'dns', id: 'dnsId', state: normal, meta: metaNone, humanUrl: 'keybase.io', profileUrl: 'http://keybase.io', isTracked: false},
   {name: 'keybase.pub', type: 'dns', id: 'dns2Id', state: normal, meta: metaNone, humanUrl: 'keybase.pub', profileUrl: 'http://keybase.pub', isTracked: false},

--- a/shared/profile/dumb.js
+++ b/shared/profile/dumb.js
@@ -3,7 +3,7 @@ import Profile from './render'
 import ConfirmOrPending from './confirm-or-pending'
 import ProveEnterUsername from './prove-enter-username'
 import EditAvatar from './edit-avatar'
-import {normal, checking, revoked, error, metaNone, metaNew} from '../constants/tracker'
+import {normal, checking, revoked, error, metaNone, metaNew, metaDeleted} from '../constants/tracker'
 import {createFolder} from '../folders/dumb'
 import {globalColors} from '../styles/style-guide'
 import {isMobile} from '../constants/platform'
@@ -22,7 +22,7 @@ export const proofsDefault: Array<Proof> = [
 
 export const proofsTracked = proofsDefault.map(proof => ({...proof, isTracked: true}))
 
-export const proofsChanged = proofsDefault.map((proof, idx) => ({...proof, state: idx % 2 ? checking : revoked}))
+export const proofsDeleted = proofsDefault.map((proof, idx) => ({...proof, state: idx % 2 ? checking : revoked, meta: idx % 2 ? metaNone : metaDeleted}))
 
 export const mockUserInfo: {username: string, userInfo: UserInfo} = {
   username: 'chris',
@@ -202,13 +202,13 @@ const dumbMap: DumbComponentMap<Profile> = {
     },
     'Changed': {
       ...propsBase,
-      proofs: proofsChanged,
+      proofs: proofsDeleted,
       trackerState: error,
       currentlyFollowing: true,
     },
     'Changed - Scrolled': {
       ...propsBase,
-      proofs: proofsChanged,
+      proofs: proofsDeleted,
       trackerState: error,
       currentlyFollowing: true,
       afterMount: (c, node) => { node.querySelector('.scroll-container').scrollTop = 50 },

--- a/shared/profile/dumb.js
+++ b/shared/profile/dumb.js
@@ -3,7 +3,7 @@ import Profile from './render'
 import ConfirmOrPending from './confirm-or-pending'
 import ProveEnterUsername from './prove-enter-username'
 import EditAvatar from './edit-avatar'
-import {normal, checking, revoked, error, metaNone, metaNew, metaDeleted} from '../constants/tracker'
+import {normal, checking, revoked, error, metaNone, metaNew, metaDeleted, metaUnreachable} from '../constants/tracker'
 import {createFolder} from '../folders/dumb'
 import {globalColors} from '../styles/style-guide'
 import {isMobile} from '../constants/platform'
@@ -23,6 +23,8 @@ export const proofsDefault: Array<Proof> = [
 export const proofsTracked = proofsDefault.map(proof => ({...proof, isTracked: true}))
 
 export const proofsDeleted = proofsDefault.map((proof, idx) => ({...proof, state: idx % 2 ? checking : revoked, meta: idx % 2 ? metaNone : metaDeleted}))
+
+export const proofsChanged = proofsDefault.map((proof, idx) => ({...proof, state: idx === 0 ? error : checking, meta: idx === 0 ? metaUnreachable : metaNone}))
 
 export const mockUserInfo: {username: string, userInfo: UserInfo} = {
   username: 'chris',
@@ -177,6 +179,13 @@ const dumbMap: DumbComponentMap<Profile> = {
         location: '',
         bio: '',
       },
+    },
+    'Your Profile - Broken': {
+      ...propsBase,
+      bioEditFns,
+      isYou: true,
+      proofs: proofsChanged,
+      trackerState: error,
     },
     'Unfollowed': propsBase,
     'Unfollowed - Profile page': {

--- a/shared/profile/render.desktop.js
+++ b/shared/profile/render.desktop.js
@@ -1,7 +1,7 @@
 /* @flow */
 import React, {Component} from 'react'
 import _ from 'lodash'
-import {normal as proofNormal} from '../constants/tracker'
+import {normal as proofNormal, metaUnreachable} from '../constants/tracker'
 import {Box, Icon, Text, UserBio, UserActions, UserProofs, Usernames, BackButton} from '../common-adapters'
 import {headerColor as whichHeaderColor} from '../common-adapters/user-bio.shared'
 import Friendships from './friendships'
@@ -44,7 +44,13 @@ class Render extends Component<void, Props, State> {
 
     let proofNotice
     if (this.props.trackerState !== proofNormal) {
-      proofNotice = `Some of ${this.props.username}'s proofs have changed since you last tracked them.`
+      if (this.props.isYou) {
+        if (this.props.proofs.some(proof => proof.meta === metaUnreachable)) {
+          proofNotice = 'Some of your proofs are unreachable.'
+        }
+      } else {
+        proofNotice = `Some of ${this.props.username}'s proofs have changed since you last tracked them.`
+      }
     }
 
     let folders = _.chain(this.props.tlfs)


### PR DESCRIPTION
:eyeglasses: @keybase/react-hackers 

A small precursor to DESKTOP-1422. Noticed some discrepancies vs. the mockups and wanted to discuss them in a separate PR. I added a `metaRevoked` constant since we didn't seem to have a way to display the "REVOKED" badge as pictured in mockups.