### PR TITLE
Better UX for login from revoked device

### DIFF
--- a/shared/actions/devices.js
+++ b/shared/actions/devices.js
@@ -103,7 +103,7 @@ export function removeDevice (deviceID: string, name: string, currentDevice: boo
           if (!error) {
             dispatch(loadDevices())
             dispatch(setRevokedSelf(name))
-            dispatch(navigateTo('', loginTab))
+            dispatch(navigateTo([], loginTab))
             dispatch(switchTab(loginTab))
           }
         },

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -159,6 +159,10 @@ export function setRevokedSelf (revoked: string) {
   return {type: Constants.setRevokedSelf, payload: revoked}
 }
 
+export function setLoginFromRevokedDevice (error: string) {
+  return {type: Constants.setLoginFromRevokedDevice, payload: error}
+}
+
 export function doneRegistering (): TypedAction<'login:doneRegistering', void, void> {
   // this has to be undefined for flow to match it to void
   return {type: Constants.doneRegistering, payload: undefined}
@@ -293,6 +297,9 @@ export function relogin (user: string, passphrase: string, store: boolean) : Asy
             error: true,
             payload: {message},
           })
+          dispatch(setLoginFromRevokedDevice(message))
+          dispatch(navigateTo([], loginTab))
+          dispatch(switchTab(loginTab))
         },
       },
       callback: (error, status) => {

--- a/shared/constants/login.js
+++ b/shared/constants/login.js
@@ -27,6 +27,7 @@ export const doneRegistering = 'login:doneRegistering'
 export const configuredAccounts = 'login:configuredAccounts'
 export const waitingForResponse = 'login:waitingForResponse'
 export const setRevokedSelf = 'login:setRevokedSelf'
+export const setLoginFromRevokedDevice = 'login:setLoginFromRevokedDevice'
 
 export const actionUpdateForgotPasswordEmailAddress = 'login:actionUpdateForgotPasswordEmailAddress'
 export const actionSetForgotPasswordSubmitting = 'login:actionSetForgotPasswordSubmitting'

--- a/shared/login/forms/dumb.desktop.js
+++ b/shared/login/forms/dumb.desktop.js
@@ -8,6 +8,7 @@ const props: IntroProps = {
   onSignup: () => {},
   onLogin: () => {},
   justRevokedSelf: null,
+  justLoginFromRevokedDevice: null,
   loaded: false,
 }
 
@@ -17,6 +18,7 @@ export const dumbMap: DumbComponentMap<Intro> = {
     'Splash': props,
     'First time user': {...props, loaded: true},
     'User who just revoked device': {...props, loaded: true, justRevokedSelf: 'DEVICE_NAME'},
+    'User who tried to login from revoked device': {...props, loaded: true, justLoginFromRevokedDevice: 'DEVICE_NAME'},
   },
 }
 

--- a/shared/login/forms/intro.js
+++ b/shared/login/forms/intro.js
@@ -23,7 +23,7 @@ export default connect(
   state => ({
     justLoginFromRevokedDevice: state.login.justLoginFromRevokedDevice,
     justRevokedSelf: state.login.justRevokedSelf,
-    loaded: state.login.loaded
+    loaded: state.login.loaded,
   }),
   dispatch => ({
     onSignup: () => {

--- a/shared/login/forms/intro.js
+++ b/shared/login/forms/intro.js
@@ -4,12 +4,12 @@ import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import Render from './intro.render'
 import {routeAppend} from '../../actions/router'
-import {setRevokedSelf, login} from '../../actions/login'
+import {setRevokedSelf, setLoginFromRevokedDevice, login} from '../../actions/login'
 
 class Intro extends Component {
   render () {
     return (
-      <Render onSignup={this.props.onSignup} onLogin={this.props.onLogin} loaded={this.props.loaded} justRevokedSelf={this.props.justRevokedSelf} />
+      <Render onSignup={this.props.onSignup} onLogin={this.props.onLogin} loaded={this.props.loaded} justLoginFromRevokedDevice={this.props.justLoginFromRevokedDevice} justRevokedSelf={this.props.justRevokedSelf} />
     )
   }
 }
@@ -20,13 +20,19 @@ Intro.propTypes = {
 }
 
 export default connect(
-  state => ({justRevokedSelf: state.login.justRevokedSelf, loaded: state.login.loaded}),
+  state => ({
+    justLoginFromRevokedDevice: state.login.justLoginFromRevokedDevice,
+    justRevokedSelf: state.login.justRevokedSelf,
+    loaded: state.login.loaded
+  }),
   dispatch => ({
     onSignup: () => {
+      dispatch(setLoginFromRevokedDevice(''))
       dispatch(setRevokedSelf(''))
       dispatch(routeAppend('signup'))
     },
     onLogin: () => {
+      dispatch(setLoginFromRevokedDevice(''))
       dispatch(setRevokedSelf(''))
       dispatch(login())
     },

--- a/shared/login/forms/intro.render.desktop.js
+++ b/shared/login/forms/intro.render.desktop.js
@@ -19,10 +19,13 @@ export default class Intro extends Component<void, IntroProps, void> {
 
   _render () {
     return (
-      <Box style={{...stylesLoginForm, marginTop: this.props.justRevokedSelf ? 0 : 45}}>
+      <Box style={{...stylesLoginForm, marginTop: this.props.justRevokedSelf || this.props.justLoginFromRevokedDevice ? 0 : 45}}>
         {!!this.props.justRevokedSelf && <Box style={stylesRevoked}>
           <Text type='BodySemiboldItalic' style={{color: globalColors.white}}>{this.props.justRevokedSelf}</Text>
           <Text type='BodySemiboldItalic' style={{color: globalColors.white}}>&nbsp;was revoked successfully</Text>
+        </Box>}
+        {!!this.props.justLoginFromRevokedDevice && <Box style={stylesRevoked}>
+          <Text type='BodySemiboldItalic' style={{color: globalColors.white}}>This device has been revoked, please log in again.</Text>
         </Box>}
         <Icon type='icon-keybase-logo-160' />
         <Text style={stylesHeader} type='HeaderJumbo'>Join Keybase</Text>

--- a/shared/login/forms/intro.render.native.js
+++ b/shared/login/forms/intro.render.native.js
@@ -9,6 +9,9 @@ export default class Render extends Component {
         {!!this.props.justRevokedSelf &&
           <Text type='BodySemiboldItalic' style={{...stylesRevoked}}>{this.props.justRevokedSelf}<Text type='BodySemiboldItalic' style={{color: globalColors.white}}>&nbsp;was revoked successfully</Text></Text>
         }
+        {!!this.props.justLoginFromRevokedDevice &&
+          <Text type='BodySemiboldItalic' style={{color: globalColors.white}}>This device has been revoked, please log in again.</Text>
+        }
         <Icon type='icon-keybase-logo-160' />
         <Text style={stylesHeader} type='HeaderJumbo'>Join Keybase</Text>
         <Text style={stylesHeaderSub} type='Body'>Folders for anyone in the world.</Text>

--- a/shared/reducers/login.js
+++ b/shared/reducers/login.js
@@ -155,6 +155,9 @@ export default function (state: LoginState = initialState, action: any): LoginSt
     case Constants.setRevokedSelf:
       toMerge = {justRevokedSelf: action.payload}
       break
+    case Constants.setLoginFromRevokedDevice:
+      toMerge = {justLoginFromRevokedDevice: action.payload}
+      break
     default:
       return state
   }


### PR DESCRIPTION
@keybase/react-hackers 

This is mostly a copy-paste of the setRevokedSelf/justRevokedSelf code paths, changed to setLoginFromRevokedDevice and called on relogin errors due to unprovisioned device.  There should be a visdiff showing the new screen.