### PR TITLE
vendor-update: Remove default repo path and add help when unset

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,10 +120,11 @@ if (env.CHANGE_TITLE && env.CHANGE_TITLE.contains('[ci-skip]')) {
                                     test_linux_js: { withEnv([
                                         "PATH=${env.HOME}/.node/bin:${env.PATH}",
                                         "NODE_PATH=${env.HOME}/.node/lib/node_modules:${env.NODE_PATH}",
+                                        "KEYBASE_JS_VENDOR_DIR=${env.BASEDIR}/js-vendor-desktop",
                                     ]) {
                                         dir("desktop") {
                                             sh "npm run vendor-install"
-                                            sh "unzip ./js-vendor-desktop/flow/flow-linux64*.zip -d ${env.BASEDIR}"
+                                            sh "unzip ${env.KEYBASE_JS_VENDOR_DIR}/flow/flow-linux64*.zip -d ${env.BASEDIR}"
                                             sh "${env.BASEDIR}/flow/flow status shared"
                                         }
                                         sh "desktop/node_modules/.bin/eslint ."
@@ -190,6 +191,7 @@ if (env.CHANGE_TITLE && env.CHANGE_TITLE.contains('[ci-skip]')) {
                                         'GOROOT=C:\\tools\\go',
                                         "GOPATH=\"${GOPATH}\"",
                                         "PATH=\"C:\\tools\\go\\bin\";\"C:\\Program Files (x86)\\GNU\\GnuPG\";\"C:\\Program Files\\nodejs\";\"C:\\tools\\python\";\"C:\\Program Files\\graphicsmagick-1.3.24-q8\";${env.PATH}",
+                                        "KEYBASE_JS_VENDOR_DIR=${env.BASEDIR}\\js-vendor-desktop",
                                         "KEYBASE_SERVER_URI=http://${kbwebNodePrivateIP}:3000",
                                         "KEYBASE_PUSH_SERVER_URI=fmprpc://${kbwebNodePrivateIP}:9911",
                                     ]) {

--- a/desktop/npm-vendor.js
+++ b/desktop/npm-vendor.js
@@ -5,7 +5,7 @@ var path = require('path')
 var fs = require('fs')
 var spawnSync = require('child_process').spawnSync
 
-var VENDOR_DIR = process.env.KEYBASE_JS_VENDOR_DIR || './js-vendor-desktop'
+var VENDOR_DIR = process.env.KEYBASE_JS_VENDOR_DIR
 const NPM_CMD = os.platform() === 'win32' ? 'npm.cmd' : 'npm'
 
 function ensureSymlink (target, dest) {
@@ -122,6 +122,11 @@ function installVendored () {
       ELECTRON_ONLY_CACHE: 1,
     }),
   })
+}
+
+if (!VENDOR_DIR) {
+  console.log('Error: KEYBASE_JS_VENDOR_DIR unset. Please specify a location for the vendoring repo.')
+  process.exit(1)
 }
 
 if (process.argv[process.argv.length - 1] === 'update') {


### PR DESCRIPTION
After talking to @chrisnojima we felt that having the script default to `./js-vendor-desktop` was confusing, and it was best to always explicitly take the vendor dir from an environment variable.

:eyeglasses: @keybase/react-hackers