### PR TITLE
Log debug webpack config messages to stderr

### DIFF
--- a/desktop/webpack.config.base.js
+++ b/desktop/webpack.config.base.js
@@ -6,7 +6,7 @@ const defines = {
   '__HOT__': JSON.stringify(getenv.boolish('HOT', false)),
 }
 
-console.log('Injecting defines: ', defines)
+console.warn('Injecting defines: ', defines)
 
 module.exports = {
   module: {

--- a/desktop/webpack.config.development.js
+++ b/desktop/webpack.config.development.js
@@ -12,7 +12,7 @@ const defines = {
   '__VERSION__': JSON.stringify('Development'),
 }
 
-console.log('Injecting dev defines: ', defines)
+console.warn('Injecting dev defines: ', defines)
 
 config.debug = true
 config.devtool = NO_SOURCE_MAPS ? undefined : 'cheap-module-eval-source-map'

--- a/desktop/webpack.config.production.js
+++ b/desktop/webpack.config.production.js
@@ -11,7 +11,7 @@ const defines = {
   'process.env.NODE_ENV': JSON.stringify('production'),
 }
 
-console.log('Injecting production defines: ', defines)
+console.warn('Injecting production defines: ', defines)
 
 config.devtool = 'source-map'
 config.output.publicPath = '/dist/'


### PR DESCRIPTION
This gets them out of the way of --profile --json output.

There's a cool visualizer you can use this data with: https://github.com/webpack/webpack/issues/690

:eyeglasses: @keybase/react-hackers 