### PR TITLE
set PublicKeyOptional on LoadUser and LoadUserByName RPCs

### DIFF
--- a/go/service/user.go
+++ b/go/service/user.go
@@ -92,7 +92,9 @@ func (h *UserHandler) ListTrackingJSON(_ context.Context, arg keybase1.ListTrack
 }
 
 func (h *UserHandler) LoadUser(_ context.Context, arg keybase1.LoadUserArg) (user keybase1.User, err error) {
-	u, err := libkb.LoadUser(libkb.NewLoadUserByUIDArg(h.G(), arg.Uid))
+	loadUserArg := libkb.NewLoadUserByUIDArg(h.G(), arg.Uid)
+	loadUserArg.PublicKeyOptional = true
+	u, err := libkb.LoadUser(loadUserArg)
 	if err != nil {
 		return
 	}
@@ -102,7 +104,9 @@ func (h *UserHandler) LoadUser(_ context.Context, arg keybase1.LoadUserArg) (use
 }
 
 func (h *UserHandler) LoadUserByName(_ context.Context, arg keybase1.LoadUserByNameArg) (user keybase1.User, err error) {
-	u, err := libkb.LoadUser(libkb.NewLoadUserByNameArg(h.G(), arg.Username))
+	loadUserArg := libkb.NewLoadUserByNameArg(h.G(), arg.Username)
+	loadUserArg.PublicKeyOptional = true
+	u, err := libkb.LoadUser(loadUserArg)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Previously it was an error to try to load a user that didn't have any
keys. Since the interface provides separate RPCs to fetch a user along
with their keys, it makes sense for the simple RPCs to succeed by
default.

r? @maxtaco 