### PR TITLE
Bump up connection attempts for Helper tool (macOS)

### DIFF
--- a/osx/KBKit/KBKit/Component/KBHelperTool.m
+++ b/osx/KBKit/KBKit/Component/KBHelperTool.m
@@ -77,7 +77,7 @@
     return;
   }
 
-  [self.helper sendRequest:@"version" params:nil completion:^(NSError *error, NSDictionary *versions) {
+  [self.helper sendRequest:@"version" params:nil maxAttempts:4 completion:^(NSError *error, NSDictionary *versions) {
     if (error) {
       self.componentStatus = [KBComponentStatus componentStatusWithInstallStatus:KBRInstallStatusError installAction:KBRInstallActionReinstall info:info error:error];
       completion(self.componentStatus);

--- a/osx/Keybase.xcodeproj/project.pbxproj
+++ b/osx/Keybase.xcodeproj/project.pbxproj
@@ -1349,7 +1349,7 @@
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Installer/Installer.entitlements;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Developer ID Application: Keybase, Inc. (99229SGT5K)";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Installer/Info.plist";
@@ -1357,7 +1357,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = keybase.Installer;
 				PRODUCT_NAME = Keybase;
-				PROVISIONING_PROFILE = "7cc30809-4a30-4fd1-b973-355c84bd6fcf";
 				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -1371,7 +1370,7 @@
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Installer/Installer.entitlements;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Developer ID Application: Keybase, Inc. (99229SGT5K)";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -1380,7 +1379,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = keybase.Installer;
 				PRODUCT_NAME = Keybase;
-				PROVISIONING_PROFILE = "7cc30809-4a30-4fd1-b973-355c84bd6fcf";
 				STRIP_INSTALLED_PRODUCT = NO;
 			};
 			name = Release;

--- a/osx/Podfile.lock
+++ b/osx/Podfile.lock
@@ -45,7 +45,7 @@ PODS:
     - Mantle/extobjc (= 2.0.7)
   - Mantle/extobjc (2.0.7)
   - MDPSplitView (1.0.2)
-  - MPMessagePack (1.3.5):
+  - MPMessagePack (1.3.8):
     - GHODictionary
   - ObjectiveSugar (1.1.0)
   - Slash (0.1.4)
@@ -79,7 +79,7 @@ SPEC CHECKSUMS:
   KBKit: 9f139696e2cd916f05ee603e33aabfd558ac8ccd
   Mantle: bc40bb061d8c2c6fb48d5083e04d928c3b7f73d9
   MDPSplitView: 127b4b371e813ec29333e515fb1c057126a75671
-  MPMessagePack: 7c9c9cdee049b62e3578ee423ba451fa406bbd08
+  MPMessagePack: 7744c19284340b5f24986d581c0f21076461fbef
   ObjectiveSugar: a6a25f23d657c19df0a0b972466d5b5ca9f5295c
   Slash: 7184f2a98e13ad62303037db3a706c88e98b197e
   Tikppa: 5174130e6bae70e8b2b0c93bc2efca4927d34ac6


### PR DESCRIPTION
Patrick experienced a invalid connection after a helper tool upgrade
where the install retried. This is cool because it meant the retry
worked and overcame the flakiness of helper tool upgrades. Though it
seems under this scenario (which is rare) we need to bump up the
retries on the status request after upgrade.