### PR TITLE
Enable anonymous sender with --anonymous

### DIFF
--- a/go/client/cmd_encrypt.go
+++ b/go/client/cmd_encrypt.go
@@ -57,8 +57,9 @@ func NewCmdEncrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 				Usage: "Don't include recipients in metadata",
 			},
 			cli.BoolFlag{
-				Name:  "hide-self",
-				Usage: "Don't include sender in metadata",
+				Name: "anonymous",
+				Usage: "Don't include sender or recipients in metadata. " +
+					"Implies --hide-recipients.",
 			},
 			cli.BoolFlag{
 				Name:  "no-self",
@@ -120,8 +121,9 @@ func (c *CmdEncrypt) ParseArgv(ctx *cli.Context) error {
 	infile := ctx.String("infile")
 	c.noSelfEncrypt = ctx.Bool("no-self")
 	c.binary = ctx.Bool("binary")
-	c.hideRecipients = ctx.Bool("hide-recipients")
-	c.hideSelf = ctx.Bool("hide-self")
+	// --anonymous means hide both self and recipients.
+	c.hideSelf = ctx.Bool("anonymous")
+	c.hideRecipients = ctx.Bool("hide-recipients") || ctx.Bool("anonymous")
 	if err := c.filter.FilterInit(msg, infile, outfile); err != nil {
 		return err
 	}

--- a/go/client/cmd_encrypt.go
+++ b/go/client/cmd_encrypt.go
@@ -22,6 +22,7 @@ type CmdEncrypt struct {
 	noSelfEncrypt  bool
 	binary         bool
 	hideRecipients bool
+	hideSelf       bool
 }
 
 func NewCmdEncrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -56,6 +57,10 @@ func NewCmdEncrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 				Usage: "Don't include recipients in metadata",
 			},
 			cli.BoolFlag{
+				Name:  "hide-self",
+				Usage: "Don't include sender in metadata",
+			},
+			cli.BoolFlag{
 				Name:  "no-self",
 				Usage: "Don't encrypt for yourself",
 			},
@@ -88,6 +93,7 @@ func (c *CmdEncrypt) Run() error {
 		NoSelfEncrypt:  c.noSelfEncrypt,
 		Binary:         c.binary,
 		HideRecipients: c.hideRecipients,
+		HideSelf:       c.hideSelf,
 	}
 	arg := keybase1.SaltpackEncryptArg{Source: src, Sink: snk, Opts: opts}
 	err = cli.SaltpackEncrypt(context.TODO(), arg)
@@ -115,6 +121,7 @@ func (c *CmdEncrypt) ParseArgv(ctx *cli.Context) error {
 	c.noSelfEncrypt = ctx.Bool("no-self")
 	c.binary = ctx.Bool("binary")
 	c.hideRecipients = ctx.Bool("hide-recipients")
+	c.hideSelf = ctx.Bool("hide-self")
 	if err := c.filter.FilterInit(msg, infile, outfile); err != nil {
 		return err
 	}


### PR DESCRIPTION
Hooks up anonymous sender to the CLI.
Functionality already existed in the engine, this just adds a flag to use it.
keybase encrypt bob -i ~/.sample --hide-self
The ephemeral key is used as the sender key.