### PR TITLE
search last minute tweaks

### DIFF
--- a/shared/actions/search.js
+++ b/shared/actions/search.js
@@ -34,15 +34,23 @@ type RawResult = {
 
 function parseExtraInfo (platform: SearchPlatforms, rr: RawResult, isFollowing: (username: string) => boolean): ExtraInfo {
   const serviceName = rr.service && capitalize(rr.service.service_name || '')
+  let userName = ''
+  if (rr.service) {
+    userName = rr.service.username || ''
+    if (rr.service.service_name === 'key_fingerprint') {
+      const parts = [4, 8].map(idx => userName.slice(-16 - idx, -16 - idx + 4))
+      userName = `...${parts.join(' ')}`
+    }
+  }
 
   if (platform === 'Keybase') {
     if (rr.service) {
       return {
         service: 'external',
         icon: serviceName && platformToLogo16(serviceName),
-        serviceUsername: rr.service.username || '',
+        serviceUsername: userName,
         serviceAvatar: '',
-        fullNameOnService: rr.service.full_name || '',
+        fullNameOnService: rr.service.full_name || (rr.keybase && rr.keybase.full_name) || '',
       }
     } else if (rr.keybase) {
       return {
@@ -62,7 +70,7 @@ function parseExtraInfo (platform: SearchPlatforms, rr: RawResult, isFollowing: 
       return {
         service: 'external',
         icon: null,
-        serviceUsername: rr.service.username || '',
+        serviceUsername: userName,
         serviceAvatar: rr.service.picture_url || '',
         fullNameOnService: rr.service.full_name || '',
       }

--- a/shared/constants/search.js
+++ b/shared/constants/search.js
@@ -36,6 +36,21 @@ export type SearchResult = {
   keybaseSearchResult: ?SearchResult, // If we want to grab the keybase version of a search result
 }
 
+// Keys for service+username to use in cross referencing things
+export function searchResultKeys (result: SearchResult) : Array<string> {
+  const results = []
+  if (result.service === 'keybase') {
+    results.push('Keybase' + result.username)
+  } else if (result.service === 'external') {
+    if (result.keybaseSearchResult) {
+      results.push('Keybase' + result.keybaseSearchResult.username)
+    }
+    results.push(result.serviceName + result.username)
+  }
+
+  return results
+}
+
 export function fullName (extraInfo: ExtraInfo): string {
   switch (extraInfo.service) {
     case 'keybase':

--- a/shared/constants/search.js
+++ b/shared/constants/search.js
@@ -133,6 +133,14 @@ export function platformToLogo16 (platform: SearchPlatforms): IconType {
   }[platform]
 }
 
+export function platformToNiceName (platform: SearchPlatforms): string {
+  const niceNames: {[key: SearchPlatforms]: ?string} = {
+    'Hackernews': 'Hacker News',
+  }
+
+  return niceNames[platform] || platform
+}
+
 export function equalSearchResult (a: SearchResult, b: SearchResult): boolean {
   return a.service === b.service && a.username === b.username
 }

--- a/shared/reducers/search.js
+++ b/shared/reducers/search.js
@@ -5,7 +5,7 @@ import * as CommonConstants from '../constants/common'
 import type {IconType} from '../common-adapters/icon'
 import type {SearchResult, SearchActions, SearchPlatforms} from '../constants/search'
 
-const {equalSearchResult} = Constants
+const {equalSearchResult, platformToNiceName} = Constants
 
 export type State = {
   searchHintText: string,
@@ -20,9 +20,10 @@ export type State = {
   waiting: boolean,
 }
 
-const searchHintText = (searchPlatform: SearchPlatforms, selectedUsers: Array<SearchResult>): string => (
-  `${selectedUsers.length ? `Add a ${searchPlatform} user` : `Search ${searchPlatform}`}`
-)
+const searchHintText = (searchPlatform: SearchPlatforms, selectedUsers: Array<SearchResult>): string => {
+  const name = platformToNiceName(searchPlatform)
+  return `${selectedUsers.length ? `Add a ${name} user` : `Search ${name}`}`
+}
 
 const showUserGroup = (searchText: ?string, selectedUsers: Array<SearchResult>): boolean => (
   !searchText && !!selectedUsers.length

--- a/shared/search/render.desktop.js
+++ b/shared/search/render.desktop.js
@@ -13,7 +13,7 @@ import type {Props as UserGroupProps} from './user-search/user-group'
 import type {Props as SearchBarProps} from './user-search/search-bar'
 
 const ClearSearch = ({onReset, showUserGroup}) => (
-  <Box style={{...globalStyles.flexBoxColumn, height: 48, justifyContent: 'center', alignItems: 'flex-end', paddingRight: 16}}>
+  <Box style={{...globalStyles.flexBoxColumn, height: 40, justifyContent: 'center', alignItems: 'flex-end', paddingRight: 16, flexShrink: 0}}>
     {showUserGroup && <Text type='BodySmallSecondaryLink' onClick={onReset}>Clear search</Text>}
   </Box>
 )
@@ -39,7 +39,7 @@ class Render extends Component<void, Props, void> {
         <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
           <ClearSearch {...this.props} />
           <SearchBar {...searchBarProps} />
-          <Box style={{overflowY: 'auto', height: 'calc(100% - 96px)'}}>
+          <Box style={{overflowY: 'auto'}}>
             {this.props.showUserGroup ? <UserGroup {...userGroupProps} /> : <UserSearch {...userSearchProps} />}
           </Box>
         </Box>

--- a/shared/search/user-search/render.desktop.js
+++ b/shared/search/user-search/render.desktop.js
@@ -9,19 +9,20 @@ import type {Props, SearchResultFn} from './render'
 import type {Props as TextProps} from '../../common-adapters/text'
 
 function EmboldenTextMatch ({text, match, style, textType, emboldenStyle}: {text: string, match: string, emboldenStyle?: Object, style?: Object, textType: TextProps.type}) {
-  const indexOfMatch = text.toLowerCase().indexOf(match.toLowerCase())
-  if (indexOfMatch > -1) {
-    const left = text.substring(0, indexOfMatch)
-    const middle = text.substring(indexOfMatch, indexOfMatch + match.length)
-    const right = text.substring(indexOfMatch + match.length)
-    return (
-      <Box style={globalStyles.flexBoxRow}>
-        {!!left && <Text type={textType} style={style}>{left}</Text>}
-        <Text type={textType} style={{...globalStyles.fontBold, ...style, ...emboldenStyle}}>{middle}</Text>
-        {!!right && <EmboldenTextMatch style={style} text={right} match={match} textType={textType} emboldenStyle={emboldenStyle} />}
-      </Box>
-    )
-  }
+  // TEMP leaving this out while we dicuss with design. i think the bold is actually harder to parse visually so we might tear this all out
+  // const indexOfMatch = text.toLowerCase().indexOf(match.toLowerCase())
+  // if (indexOfMatch > -1) {
+    // const left = text.substring(0, indexOfMatch)
+    // const middle = text.substring(indexOfMatch, indexOfMatch + match.length)
+    // const right = text.substring(indexOfMatch + match.length)
+    // return (
+      // <Box style={globalStyles.flexBoxRow}>
+        // {!!left && <Text type={textType} style={style}>{left}</Text>}
+        // <Text type={textType} style={{...globalStyles.fontBold, ...style, ...emboldenStyle}}>{middle}</Text>
+        // {!!right && <EmboldenTextMatch style={style} text={right} match={match} textType={textType} emboldenStyle={emboldenStyle} />}
+      // </Box>
+    // )
+  // }
 
   return <Text type={textType} style={style}>{text}</Text>
 }

--- a/shared/search/user-search/render.desktop.js
+++ b/shared/search/user-search/render.desktop.js
@@ -41,7 +41,7 @@ function KeybaseExtraInfo ({username, fullName, isFollowing, searchText}) {
         <Avatar size={16} style={{width: 16, marginRight: 4}} username={username} />
         <EmboldenTextMatch text={username} match={searchText} textType={'BodySmall'} style={{color: isFollowing ? globalColors.green2 : globalColors.orange}} />
       </Box>
-      {!!fullName && <Text type='BodyXSmall' style={{color: globalColors.black_40}}>{fullName}</Text>}
+      {!!fullName && <Text type='BodyXSmall' style={{...fullNameStyle, color: globalColors.black_40}}>{fullName}</Text>}
     </Box>
   )
 }
@@ -54,7 +54,7 @@ function ExternalExtraInfo ({fullNameOnService, icon, serviceAvatar, serviceUser
         {!icon && <Avatar size={16} url={serviceAvatar} style={{marginRight: 4}} />}
         {!!serviceUsername && <EmboldenTextMatch text={serviceUsername} match={searchText} textType={'BodySmall'} emboldenStyle={{color: globalColors.black_75}} />}
       </Box>
-      {!!fullNameOnService && <Text type='BodyXSmall' style={{color: globalColors.black_40}}>{fullNameOnService}</Text>}
+      {!!fullNameOnService && <Text type='BodyXSmall' style={{...fullNameStyle, color: globalColors.black_40}}>{fullNameOnService}</Text>}
     </Box>
   )
 }
@@ -94,7 +94,7 @@ export function Result ({result, searchText, onClickResult}: {result: SearchResu
       extraInfo = <KeybaseExtraInfo {...result.extraInfo} searchText={searchText} />
       break
     case 'none':
-      extraInfo = <Text type='BodyXSmall' style={{color: globalColors.black_40, alignSelf: 'center'}}>{result.extraInfo.fullName}</Text>
+      extraInfo = <Text type='BodyXSmall' style={{...fullNameStyle, color: globalColors.black_40, alignSelf: 'center'}}>{result.extraInfo.fullName}</Text>
       break
   }
 
@@ -132,6 +132,14 @@ class Render extends Component<void, Props, void> {
       </Box>
     )
   }
+}
+
+const fullNameStyle = {
+  whiteSpace: 'nowrap',
+  width: 130,
+  textOverflow: 'ellipsis',
+  overflow: 'auto',
+  textAlign: 'right',
 }
 
 export default Render

--- a/shared/search/user-search/render.desktop.js
+++ b/shared/search/user-search/render.desktop.js
@@ -6,33 +6,15 @@ import {globalStyles, globalColors} from '../../styles/style-guide'
 
 import type {SearchResult} from '../../constants/search'
 import type {Props, SearchResultFn} from './render'
-import type {Props as TextProps} from '../../common-adapters/text'
-
-function EmboldenTextMatch ({text, match, style, textType, emboldenStyle}: {text: string, match: string, emboldenStyle?: Object, style?: Object, textType: TextProps.type}) {
-  // TEMP leaving this out while we dicuss with design. i think the bold is actually harder to parse visually so we might tear this all out
-  // const indexOfMatch = text.toLowerCase().indexOf(match.toLowerCase())
-  // if (indexOfMatch > -1) {
-    // const left = text.substring(0, indexOfMatch)
-    // const middle = text.substring(indexOfMatch, indexOfMatch + match.length)
-    // const right = text.substring(indexOfMatch + match.length)
-    // return (
-      // <Box style={globalStyles.flexBoxRow}>
-        // {!!left && <Text type={textType} style={style}>{left}</Text>}
-        // <Text type={textType} style={{...globalStyles.fontBold, ...style, ...emboldenStyle}}>{middle}</Text>
-        // {!!right && <EmboldenTextMatch style={style} text={right} match={match} textType={textType} emboldenStyle={emboldenStyle} />}
-      // </Box>
-    // )
-  // }
-
-  return <Text type={textType} style={style}>{text}</Text>
-}
 
 function KeybaseResultBody ({username, searchText, isFollowing}) {
-  return <EmboldenTextMatch text={username} match={searchText} textType={'Body'} style={{color: isFollowing ? globalColors.green2 : globalColors.orange}} />
+  return <Text type='Body'
+    style={{color: isFollowing ? globalColors.green2 : globalColors.orange}}>{username}</Text>
 }
 
 function ExternalResultBody ({username, searchText}) {
-  return <EmboldenTextMatch text={username} match={searchText} textType={'Body'} style={{color: globalColors.black_75}} />
+  return <Text type='Body'
+    style={{color: globalColors.black_75}}>{username}</Text>
 }
 
 function KeybaseExtraInfo ({username, fullName, isFollowing, searchText}) {
@@ -40,7 +22,8 @@ function KeybaseExtraInfo ({username, fullName, isFollowing, searchText}) {
     <Box style={{...globalStyles.flexBoxColumn, alignItems: 'flex-end', justifyContent: 'center'}}>
       <Box style={{...globalStyles.flexBoxRow, alignItems: 'center'}}>
         <Avatar size={16} style={{width: 16, marginRight: 4}} username={username} />
-        <EmboldenTextMatch text={username} match={searchText} textType={'BodySmall'} style={{color: isFollowing ? globalColors.green2 : globalColors.orange}} />
+        <Text type='BodySmall'
+          style={{color: isFollowing ? globalColors.green2 : globalColors.orange}}>{username}</Text>
       </Box>
       {!!fullName && <Text type='BodyXSmall' style={{...fullNameStyle, color: globalColors.black_40}}>{fullName}</Text>}
     </Box>
@@ -53,9 +36,10 @@ function ExternalExtraInfo ({fullNameOnService, icon, serviceAvatar, serviceUser
       <Box style={{...globalStyles.flexBoxRow, alignItems: 'center'}}>
         {!!icon && <Icon type={icon} style={{width: 17, marginRight: 4}} />}
         {!icon && <Avatar size={16} url={serviceAvatar} style={{marginRight: 4}} />}
-        {!!serviceUsername && <EmboldenTextMatch text={serviceUsername} match={searchText} textType={'BodySmall'} emboldenStyle={{color: globalColors.black_75}} />}
+        {!!serviceUsername && <Text type='BodySmall'>{serviceUsername}</Text>}
       </Box>
-      {!!fullNameOnService && <Text type='BodyXSmall' style={{...fullNameStyle, color: globalColors.black_40}}>{fullNameOnService}</Text>}
+      {!!fullNameOnService && <Text type='BodyXSmall'
+        style={{...fullNameStyle, color: globalColors.black_40}}>{fullNameOnService}</Text>}
     </Box>
   )
 }

--- a/shared/search/user-search/render.desktop.js
+++ b/shared/search/user-search/render.desktop.js
@@ -105,8 +105,8 @@ export function Result ({result, searchText, onClickResult}: {result: SearchResu
     paddingBottom: 8,
     paddingRight: 8,
     paddingLeft: 8,
-    borderBottom: 'solid 1px',
-    borderBottomColor: globalColors.black_10,
+    borderTop: 'solid 1px',
+    borderTopColor: globalColors.black_10,
   }
 
   return (

--- a/shared/search/user-search/render.native.js
+++ b/shared/search/user-search/render.native.js
@@ -5,32 +5,15 @@ import {globalStyles, globalColors} from '../../styles/style-guide'
 
 import type {Props} from './render'
 import type {SearchResult} from '../../constants/search'
-import type {Props as TextProps} from '../../common-adapters/text'
-
-function EmboldenTextMatch ({text, match, style, textType, emboldenStyle}: {text: string, match: string, emboldenStyle?: Object, style?: Object, textType: TextProps.type}) {
-  const indexOfMatch = text.indexOf(match)
-  if (indexOfMatch > -1) {
-    const left = text.substring(0, indexOfMatch)
-    const middle = text.substring(indexOfMatch, indexOfMatch + match.length)
-    const right = text.substring(indexOfMatch + match.length)
-    return (
-      <Box style={globalStyles.flexBoxRow}>
-        {!!left && <Text type={textType} style={style}>{left}</Text>}
-        <Text type={textType} style={{...globalStyles.fontBold, ...style, ...emboldenStyle}}>{middle}</Text>
-        {!!right && <EmboldenTextMatch style={style} text={right} match={match} textType={textType} emboldenStyle={emboldenStyle} />}
-      </Box>
-    )
-  }
-
-  return <Text type={textType} style={style}>{text}</Text>
-}
 
 function KeybaseResultBody ({username, searchText, isFollowing}) {
-  return <EmboldenTextMatch text={username} match={searchText} textType={'Body'} style={{color: isFollowing ? globalColors.green2 : globalColors.orange}} />
+  return <Text type='Body'
+    style={{color: isFollowing ? globalColors.green2 : globalColors.orange}}>{username}</Text>
 }
 
 function ExternalResultBody ({username, searchText}) {
-  return <EmboldenTextMatch text={username} match={searchText} textType={'Body'} style={{color: globalColors.black_75}} />
+  return <Text type='Body'
+    style={{color: globalColors.black_75}}>{username}</Text>
 }
 
 function KeybaseExtraInfo ({username, fullName, isFollowing, searchText}) {
@@ -38,7 +21,8 @@ function KeybaseExtraInfo ({username, fullName, isFollowing, searchText}) {
     <Box style={{...globalStyles.flexBoxColumn, alignItems: 'flex-end', justifyContent: 'center'}}>
       <Box style={{...globalStyles.flexBoxRow, alignItems: 'center'}}>
         <Avatar size={16} style={{width: 16, marginRight: 4}} username={username} />
-        <EmboldenTextMatch text={username} match={searchText} textType={'BodySmall'} style={{color: isFollowing ? globalColors.green2 : globalColors.orange}} />
+        <Text type='BodySmall'
+          style={{color: isFollowing ? globalColors.green2 : globalColors.orange}}>{username}</Text>
       </Box>
       {!!fullName && <Text type='BodyXSmall' style={{color: globalColors.black_40}}>{fullName}</Text>}
     </Box>
@@ -51,7 +35,7 @@ function ExternalExtraInfo ({fullNameOnService, icon, serviceAvatar, serviceUser
       <Box style={{...globalStyles.flexBoxRow, alignItems: 'center'}}>
         {!!icon && <Icon type={icon} style={{width: 17, marginRight: 4}} />}
         {!icon && <Avatar size={16} url={serviceAvatar} style={{marginRight: 4}} />}
-        {!!serviceUsername && <EmboldenTextMatch text={serviceUsername} match={searchText} textType={'BodySmall'} emboldenStyle={{color: globalColors.black_75}} />}
+        {!!serviceUsername && <Text type='BodySmall'>{serviceUsername}</Text>}
       </Box>
       {!!fullNameOnService && <Text type='BodyXSmall' style={{color: globalColors.black_40}}>{fullNameOnService}</Text>}
     </Box>

--- a/shared/search/user-search/search-bar.desktop.js
+++ b/shared/search/user-search/search-bar.desktop.js
@@ -116,7 +116,6 @@ const stylesServicesContainer = {
 const stylesInputContainer = {
   ...globalStyles.flexBoxRow,
   height: 48,
-  borderBottom: `solid 1px ${globalColors.black_10}`,
   alignItems: 'center',
   marginBottom: 8,
 }

--- a/shared/search/user-search/search-bar.desktop.js
+++ b/shared/search/user-search/search-bar.desktop.js
@@ -110,7 +110,8 @@ class SearchBar extends Component<void, Props, void> {
 
 const stylesServicesContainer = {
   ...globalStyles.flexBoxRow,
-  height: 48,
+  height: 64,
+  alignItems: 'center',
   paddingLeft: 16,
 }
 const stylesInputContainer = {

--- a/shared/search/user-search/search-bar.desktop.js
+++ b/shared/search/user-search/search-bar.desktop.js
@@ -100,8 +100,8 @@ class SearchBar extends Component<void, Props, void> {
             underlineShow={false}
             style={stylesInput}
             textStyle={{height: 31}} />
-          <Icon type='iconfont-remove' style={{marginRight: 16, opacity: this.props.searchText ? 1 : 0}}
-            onClick={() => this.refs.searchBox.clearValue()} />
+          {this.props.searchText && <Icon type='iconfont-remove' style={{marginRight: 16}}
+            onClick={() => this.refs.searchBox.clearValue()} />}
         </Box>
       </Box>
     )


### PR DESCRIPTION
- [x] At min window size: names that are longer than one line get cut off ('full-name-wrapping.png' / 'full-name-wrapping2.png') + full name should be right-aligned, now it's left aligned
- [x] Remove extra 8px margin below the search field - you can see it when you mouse over 1st list item and it also makes things look cut off when scrolling
- [x] Our text field at min size is still wrapping. Unsure why though since it looks like it should actually fit ('input-wrapping.png') + Hacker News should be in 2 words (currently it says "Hackernews")
- [x] In the search input: Can we highlight the full word + double clicking at the end of the text input to highlight? That way it's not really annoying to delete something you typed that's really long.
- [x] Hovering on a new social tab scrolls up the current set of results to the top, lets have it stay in its scrolled position until click ('hover-jump.png')
- [x] pgp key result is shifting the window size a lot, see attached 'php-key-shift.png'
- [x] I search "chris" looking for Chris Coyne and click him to add him to a group. Then, If I search "chris" again looking for cjb but see the same "chris" that I just added, it feels a little weird, like I didn't successfully add him (especially because I can't get back to the group view while seeing search results). This is more of an open question - should we surface them again once we've added them? cecileboucheronchrisnojimaChris Coyne 
- [x] Edit Cecile] We decided to exclude people you already added in the search results, see https://keybase.atlassian.net/browse/DESIGN-682
