### PR TITLE
make GlobalContext.GetUnforwardedLogger work with *logger.TestLogger

### DIFF
--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -355,37 +355,25 @@ func (log *Standard) GetUnforwardedLogger() *UnforwardedLogger {
 }
 
 func (log *UnforwardedLogger) Debug(s string, args ...interface{}) {
-	if log != nil && log.internal != nil {
-		log.internal.Debugf(s, args...)
-	}
+	log.internal.Debugf(s, args...)
 }
 
 func (log *UnforwardedLogger) Error(s string, args ...interface{}) {
-	if log != nil && log.internal != nil {
-		log.internal.Errorf(s, args...)
-	}
+	log.internal.Errorf(s, args...)
 }
 
 func (log *UnforwardedLogger) Errorf(s string, args ...interface{}) {
-	if log != nil && log.internal != nil {
-		log.internal.Errorf(s, args...)
-	}
+	log.internal.Errorf(s, args...)
 }
 
 func (log *UnforwardedLogger) Warning(s string, args ...interface{}) {
-	if log != nil && log.internal != nil {
-		log.internal.Warningf(s, args...)
-	}
+	log.internal.Warningf(s, args...)
 }
 
 func (log *UnforwardedLogger) Info(s string, args ...interface{}) {
-	if log != nil && log.internal != nil {
-		log.internal.Infof(s, args...)
-	}
+	log.internal.Infof(s, args...)
 }
 
 func (log *UnforwardedLogger) Profile(s string, args ...interface{}) {
-	if log != nil && log.internal != nil {
-		log.internal.Debugf(s, args...)
-	}
+	log.internal.Debugf(s, args...)
 }


### PR DESCRIPTION
This hopefully fixes `nil` logger issues. The problem was that, when `KEYBASE_DEBUG` was not present, `libkb.SetupTest` returned a `*logger.TestLogger`, which broke `GlobalContext.GetUnforwardedLogger()` since it did a type assertion to `*logger.Standard` which `*logger.TestLogger` is not.

Eventually we should probably move to a much cleaner and simpler logger interface in a big refactoring or something. But for now, let `GetUnforwardedLogger()` panic if it fails to return a proper logger?