### PR TITLE
Small consistency tweak of dumb sheet capitalization

### DIFF
--- a/shared/profile/dumb.js
+++ b/shared/profile/dumb.js
@@ -173,13 +173,13 @@ const dumbMap: DumbComponentMap<Profile> = {
       bioEditFns,
       isYou: true,
     },
-    'Your Profile - loading': {
+    'Your Profile - Loading': {
       ...propsBase,
       loading: true,
       bioEditFns,
       isYou: true,
     },
-    'Your Profile - empty': {
+    'Your Profile - Empty': {
       ...propsBase,
       bioEditFns,
       isYou: true,


### PR DESCRIPTION
Fiddled with this in another PR, but wanted to separate it so that the rename doesn't obscure a visdiff.

:eyeglasses: @keybase/react-hackers 