### PR TITLE
Show item in folder instead of open

### DIFF
--- a/desktop/app/kbfs-helper.js
+++ b/desktop/app/kbfs-helper.js
@@ -4,7 +4,6 @@ import {ipcMain, shell} from 'electron'
 
 export default function () {
   ipcMain.on('openInKBFS', (e, path) => {
-    // We do the `shell.openItem` here to not block the ui thread
-    shell.openItem(path)
+    shell.showItemInFolder(path)
   })
 }


### PR DESCRIPTION
It looks like `shell.openItem` won't focus the Finder. The Electron people say this is due to the Finder not grabbing focus?

There is another method which might be more what we want which is `shell.showItemInFolder`. It opens the Finder and takes focus and selects the file.

This slightly changes behavior... instead of opening into the folder, it opens to the parent dir and selects the folder. So this:
![2016-07-29 at 11 50 am](https://cloud.githubusercontent.com/assets/2669/17259955/a15563c2-5582-11e6-8d39-8a7da5aaa9bb.png)

instead of in the folder:
![2016-07-29 at 11 50 am](https://cloud.githubusercontent.com/assets/2669/17259966/ae307cee-5582-11e6-9c56-a2b34f546212.png)

There is a 3rd option which is to use `shell.openExternal` which takes an url and it does open Finder into the folder and is focused. I tried that in this branch: https://github.com/keybase/client/blob/openurl/desktop/app/kbfs-helper.js
The problem is that it's flakey and doesn't seem to work sometimes. I did try the usual suspects (escaping URI components, etc), but appears to be something breaking and then openExternal stops working altogether.

So the options are:
- Leave as is with `shell.openItem` (and not have focus)
- Use `shell.showItemInFolder` which works but shows item selected in finder (which we may want?)
- Investigate why `shell.openExternal` is flakey.

I think `shell.showItemInFolder` is probably ok? Which is what this PR does.
