### PR TITLE
Unify tracker state colors DESKTOP-1535

### DIFF
--- a/shared/common-adapters/user-bio.desktop.js
+++ b/shared/common-adapters/user-bio.desktop.js
@@ -4,6 +4,7 @@ import React, {Component} from 'react'
 import {Avatar, Box, Button, Icon, Text} from '../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import * as shared from './user-bio.shared'
+import {stateColors} from '../util/tracker'
 
 import type {Props} from './user-bio'
 import type {AvatarSize} from './avatar'
@@ -44,6 +45,8 @@ export default class BioRender extends Component<void, Props, void> {
     const {followsYou} = userInfo
     const followLabel = shared.followLabel(userInfo, currentlyFollowing)
 
+    const trackerStateColors = stateColors(this.props)
+
     let [bioLineClamp, locationLineClamp] = [{}, {}]
     if (this.props.type === 'Tracker') {
       bioLineClamp = {lineClamp: userInfo.location ? 2 : 3}
@@ -80,7 +83,7 @@ export default class BioRender extends Component<void, Props, void> {
           <Box style={{...stylesContent, ...globalStyles.fadeOpacity, opacity: loading ? 0 : 1}}>
             <Text
               type='HeaderBig'
-              style={{...stylesUsername, ...shared.usernameStyle(this.props)}}
+              style={{...stylesUsername, color: trackerStateColors.username}}
               onClick={() => shared.onClickAvatar(username)}>
               {username}
             </Text>

--- a/shared/common-adapters/user-bio.native.js
+++ b/shared/common-adapters/user-bio.native.js
@@ -5,6 +5,7 @@ import React, {Component} from 'react'
 import {Box, Avatar, Text} from './'
 import * as shared from './user-bio.shared'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
+import {stateColors} from '../util/tracker'
 
 import type {Props} from './user-bio'
 
@@ -19,7 +20,7 @@ export default class BioRender extends Component {
 
     const {followsYou} = userInfo
     const followLabel = shared.followLabel(userInfo, currentlyFollowing)
-    const headerColor = shared.headerColor(this.props)
+    const trackerStateColors = stateColors(this.props)
 
     let [bioLineClamp, locationLineClamp] = [{}, {}]
     if (this.props.type === 'Tracker') {
@@ -29,7 +30,7 @@ export default class BioRender extends Component {
 
     return (
       <Box style={{...stylesContainer, ...this.props.style}}>
-        <Box style={stylesHeaderBar(avatarSize, headerColor)} />
+        <Box style={stylesHeaderBar(avatarSize, trackerStateColors.header.background)} />
         <Box style={stylesAvatarWrapper(avatarSize)}>
           <Avatar
             style={stylesAvatar}
@@ -42,7 +43,7 @@ export default class BioRender extends Component {
         <Box style={stylesContent}>
           <Text
             type='HeaderBig'
-            style={{...stylesUsername, ...shared.usernameStyle(this.props)}}
+            style={{...stylesUsername, color: trackerStateColors.username}}
             onClick={() => shared.onClickAvatar(username)}>
             {username}
           </Text>

--- a/shared/common-adapters/user-bio.shared.js
+++ b/shared/common-adapters/user-bio.shared.js
@@ -2,11 +2,8 @@
 
 import keybaseUrl from '../constants/urls'
 import openUrl from '../util/open-url'
-import {globalColors} from '../styles/style-guide'
-import {error as proofError} from '../constants/tracker'
 
 import type {UserInfo} from './user-bio'
-import type {SimpleProofState} from '../constants/tracker'
 
 export function onClickAvatar (username: ?string) {
   username && openUrl(`${keybaseUrl}/${username}`)
@@ -29,18 +26,3 @@ export function followLabel (userInfo: UserInfo, currentlyFollowing: boolean): ?
   return null
 }
 
-export function usernameStyle ({currentlyFollowing, trackerState}: {currentlyFollowing: boolean, trackerState: SimpleProofState}): Object {
-  if (trackerState === proofError) {
-    return {color: globalColors.red}
-  }
-  if (currentlyFollowing) {
-    return {color: globalColors.green2}
-  }
-  return {color: globalColors.orange}
-}
-
-export function headerColor ({currentlyFollowing, trackerState}: {currentlyFollowing: boolean, trackerState: SimpleProofState}): string {
-  if (trackerState === proofError) return globalColors.red
-  if (currentlyFollowing) return globalColors.green
-  return globalColors.blue
-}

--- a/shared/common-adapters/user-proofs.desktop.js
+++ b/shared/common-adapters/user-proofs.desktop.js
@@ -8,7 +8,8 @@ import openUrl from '../util/open-url'
 import * as shared from './user-proofs.shared'
 import {metaNone, checking as proofChecking} from '../constants/tracker'
 
-import type {Proof, Props, MissingProof} from './user-proofs'
+import type {Props, MissingProof} from './user-proofs'
+import type {Proof} from '../constants/tracker'
 
 function MissingProofRow ({missingProof, style}: {missingProof: MissingProof, style: Object}): React$Element<*> {
   const missingColor = globalColors.black_20

--- a/shared/common-adapters/user-proofs.js.flow
+++ b/shared/common-adapters/user-proofs.js.flow
@@ -1,25 +1,12 @@
 /* @flow */
 
-import type {SimpleProofState, SimpleProofMeta} from '../constants/tracker'
+import type {Proof, SimpleProofState, SimpleProofMeta} from '../constants/tracker'
 import type {PlatformsExpanded} from '../constants/types/more'
-import type {Time} from '../constants/types/flow-types'
 
 export type MissingProof = {
   type: PlatformsExpanded,
   message: string,
   onClick: (missingProof: MissingProof) => void,
-}
-
-export type Proof = {
-  id: string,
-  type: PlatformsExpanded,
-  mTime: Time,
-  meta: ?SimpleProofMeta,
-  humanUrl: ?string,
-  profileUrl: ?string,
-  name: string,
-  state: SimpleProofState,
-  isTracked: bool,
 }
 
 type CommonProps = {

--- a/shared/common-adapters/user-proofs.native.js
+++ b/shared/common-adapters/user-proofs.native.js
@@ -8,7 +8,8 @@ import {metaNone, checking as proofChecking} from '../constants/tracker'
 import {Box, Icon, Meta, Text} from '../common-adapters/index'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 
-import type {Props, Proof, MissingProof} from './user-proofs'
+import type {Props, MissingProof} from './user-proofs'
+import type {Proof} from '../constants/tracker'
 
 function MissingProofRow ({missingProof, style}: {missingProof: MissingProof, style: Object}): React$Element<*> {
   const missingColor = globalColors.black_20

--- a/shared/common-adapters/user-proofs.shared.js
+++ b/shared/common-adapters/user-proofs.shared.js
@@ -6,7 +6,7 @@ import {normal as proofNormal, checking as proofChecking, revoked as proofRevoke
 import type {PlatformsExpanded} from '../constants/types/more.js'
 
 import type {IconType} from '../common-adapters/icon'
-import type {Proof} from './user-proofs'
+import type {Proof} from '../constants/tracker'
 
 export function metaColor (proof: Proof): string {
   switch (proof.meta) {

--- a/shared/constants/profile.js
+++ b/shared/constants/profile.js
@@ -1,4 +1,5 @@
 /* @flow */
+
 // Actions
 export const editingProfile = 'devices:editingProfile'
 export const editedProfile = 'devices:editedProfile'

--- a/shared/constants/tracker.js
+++ b/shared/constants/tracker.js
@@ -4,7 +4,33 @@ import type {identifyUiDisplayTLFCreateWithInviteRpcParam} from './types/flow-ty
 import type {TypedAction} from './types/flux'
 import type {Folder} from '../folders/list'
 import type {UserInfo} from '../common-adapters/user-bio'
-import type {Proof} from '../common-adapters/user-proofs'
+import type {PlatformsExpanded} from '../constants/types/more'
+import type {Time} from '../constants/types/flow-types'
+
+// Types
+export type Proof = {
+  id: string,
+  type: PlatformsExpanded,
+  mTime: Time,
+  meta: ?SimpleProofMeta,
+  humanUrl: ?string,
+  profileUrl: ?string,
+  name: string,
+  state: SimpleProofState,
+  isTracked: bool,
+}
+
+export type OverviewProofState = {
+  allOk: boolean,
+  anyWarnings: boolean,
+  anyError: boolean,
+  anyPending: boolean,
+  anyDeletedProofs: boolean,
+  anyUnreachableProofs: boolean,
+  anyUpgradedProofs: boolean,
+  anyNewProofs: boolean,
+  anyChanged: boolean,
+}
 
 // Simple state of the overall proof result
 export type SimpleProofState = 'normal' | 'warning' | 'error' | 'checking' | 'revoked'

--- a/shared/profile/dumb.js
+++ b/shared/profile/dumb.js
@@ -10,7 +10,7 @@ import {createFolder} from '../folders/dumb'
 import {isMobile} from '../constants/platform'
 import {globalColors} from '../styles/style-guide'
 import type {Props as RenderProps} from './render'
-import type {Proof} from '../common-adapters/user-proofs'
+import type {Proof} from '../constants/tracker'
 import type {UserInfo} from '../common-adapters/user-bio'
 import type {DumbComponentMap} from '../constants/types/more'
 

--- a/shared/profile/render.desktop.js
+++ b/shared/profile/render.desktop.js
@@ -5,13 +5,13 @@ import _ from 'lodash'
 import moment from 'moment'
 import {normal as proofNormal, checking as proofChecking, metaUnreachable, metaPending} from '../constants/tracker'
 import {Box, Icon, PlatformIcon, PopupMenu, Text, UserBio, UserActions, UserProofs, Usernames, BackButton} from '../common-adapters'
-import {headerColor as whichHeaderColor} from '../common-adapters/user-bio.shared'
+import {stateColors} from '../util/tracker'
 import Friendships from './friendships'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import ProfileHelp from './help.desktop'
 import * as shared from './render.shared'
 import type {Tab as FriendshipsTab} from './friendships'
-import type {Proof} from '../common-adapters/user-proofs'
+import type {Proof} from '../constants/tracker'
 import type {Props} from './render'
 
 export const AVATAR_SIZE = 112
@@ -160,7 +160,7 @@ class Render extends Component<void, Props, State> {
       return this._renderComingSoon()
     }
 
-    const headerColor = whichHeaderColor(this.props)
+    const trackerStateColors = stateColors(this.props)
 
     let proofNotice
     if (this.props.trackerState !== proofNormal && this.props.trackerState !== proofChecking && !loading) {
@@ -201,12 +201,12 @@ class Render extends Component<void, Props, State> {
 
     return (
       <Box style={styleOuterContainer}>
-        <Box style={{...styleScrollHeaderBg, backgroundColor: headerColor}} />
-        <Box style={{...styleScrollHeaderCover, backgroundColor: headerColor}} />
+        <Box style={{...styleScrollHeaderBg, backgroundColor: trackerStateColors.header.background}} />
+        <Box style={{...styleScrollHeaderCover, backgroundColor: trackerStateColors.header.background}} />
         {this.props.onBack && <BackButton onClick={this.props.onBack} style={{position: 'absolute', left: 10, top: 10, zIndex: 12}}
           textStyle={{color: globalColors.white}} iconStyle={{color: globalColors.white}} />}
         <Box ref={c => { this._scrollContainer = c }} className='scroll-container' style={styleContainer}>
-          <Box style={{...styleHeader, backgroundColor: headerColor}} />
+          <Box style={{...styleHeader, backgroundColor: trackerStateColors.header.background}} />
           <Box style={{...globalStyles.flexBoxRow, minHeight: 300}}>
             <Box style={styleBioColumn}>
               <UserBio

--- a/shared/profile/render.js.flow
+++ b/shared/profile/render.js.flow
@@ -5,7 +5,8 @@ import {Component} from 'react'
 import type {SimpleProofState} from '../constants/tracker'
 import type {UserInfo, BioEditFns} from '../common-adapters/user-bio'
 import type {FriendshipUserInfo} from './friendships'
-import type {Proof, MissingProof} from '../common-adapters/user-proofs'
+import type {MissingProof} from '../common-adapters/user-proofs'
+import type {Proof} from '../constants/tracker'
 import type {Folder} from '../folders/list'
 
 export type Props = {

--- a/shared/profile/render.native.js
+++ b/shared/profile/render.native.js
@@ -7,7 +7,7 @@ import {BackButton, Box, ComingSoon, Icon, Text, UserActions, UserBio, UserProof
 import {usernameText} from '../common-adapters/usernames'
 import Friendships from './friendships'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
-import {headerColor as whichHeaderColor} from '../common-adapters/user-bio.shared'
+import {stateColors} from '../util/tracker'
 import * as shared from './render.shared'
 import type {Tab as FriendshipsTab} from './friendships'
 import type {Props} from './render'
@@ -39,7 +39,7 @@ class Render extends Component<void, Props, State> {
       return this._renderComingSoon()
     }
 
-    const headerColor = whichHeaderColor(this.props)
+    const trackerStateColors = stateColors(this.props)
 
     let proofNotice
     if (this.props.trackerState !== proofNormal) {
@@ -63,12 +63,12 @@ class Render extends Component<void, Props, State> {
 
     return (
       <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
-        <Box style={{...styleHeader, backgroundColor: headerColor}}>
+        <Box style={{...styleHeader, backgroundColor: trackerStateColors.header.background}}>
           {this.props.onBack && <BackButton title={null} onClick={this.props.onBack} style={{marginLeft: 16}} iconStyle={{color: globalColors.white}} />}
         </Box>
-        <ScrollView style={{flex: 1, backgroundColor: headerColor}} contentContainerStyle={{backgroundColor: globalColors.white}}>
+        <ScrollView style={{flex: 1, backgroundColor: trackerStateColors.header.background}} contentContainerStyle={{backgroundColor: globalColors.white}}>
           {proofNotice && (
-            <Box style={{...styleProofNotice, backgroundColor: headerColor}}>
+            <Box style={{...styleProofNotice, backgroundColor: trackerStateColors.header.background}}>
               <Text type='BodySmallSemibold' style={{color: globalColors.white}}>{proofNotice}</Text>
             </Box>
           )}

--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -196,22 +196,10 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
     }
     case Constants.updateProofState:
       const proofs = state.proofs
-      const allOk: boolean = proofs.reduce((acc, p) => acc && p.state === normal, true)
-      const anyWarnings: boolean = proofs.reduce((acc, p) => acc || p.state === warning, false)
-      const anyError: boolean = proofs.reduce((acc, p) => acc || p.state === error, false)
-      const anyPending: boolean = proofs.reduce((acc, p) => acc || p.state === checking, false)
-
-      // Helper to reduce boiler plate.
-      const anyMetaCheck = (v: SimpleProofMeta) => (acc, p) => acc || p.meta === v
-
-      const anyDeletedProofs : boolean = proofs.reduce(anyMetaCheck(metaDeleted), false)
-      const anyUnreachableProofs : boolean = proofs.reduce(anyMetaCheck(metaUnreachable), false)
-      const anyUpgradedProofs : boolean = proofs.reduce(anyMetaCheck(metaUpgraded), false)
-      const anyNewProofs: boolean = proofs.reduce(anyMetaCheck(metaNew), false)
-
-      const changed = !(proofs || []).every(function (proof, index, ar) {
-        return (!proof.meta || proof.meta === metaNone)
-      })
+      const allOk = proofs.every(p => p.state === normal)
+      const [anyWarnings, anyError, anyPending] = [warning, error, checking].map(s => proofs.some(p => p.state === s))
+      const [anyDeletedProofs, anyUnreachableProofs, anyUpgradedProofs, anyNewProofs] = [metaDeleted, metaUnreachable, metaUpgraded, metaNew].map(m => proofs.some(p => p.meta === m))
+      const changed = proofs.some(proof => proof.meta && proof.meta !== metaNone)
 
       const trackerMessage = deriveTrackerMessage(state.username, allOk, anyDeletedProofs, anyUnreachableProofs, anyUpgradedProofs, anyNewProofs)
       const reason = state.currentlyFollowing && trackerMessage ? trackerMessage : state.reason

--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -1,12 +1,13 @@
 /* @flow */
 
 import * as Constants from '../constants/tracker'
-import type {SimpleProofState, SimpleProofMeta, NonUserActions, TrackerState} from '../constants/tracker'
+import type {
+  Proof, OverviewProofState, SimpleProofState, SimpleProofMeta, NonUserActions, TrackerState,
+} from '../constants/tracker'
 import * as CommonConstants from '../constants/common'
 
 import {identifyCommon, proveCommon} from '../constants/types/keybase-v1'
 
-import type {Proof} from '../common-adapters/user-proofs'
 import type {Identity, RemoteProof, RevokedProof, LinkCheckResult, ProofState, TrackDiff,
   TrackDiffType, ProofStatus} from '../constants/types/flow-types'
 import type {Action} from '../constants/types/flux'
@@ -195,21 +196,16 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
       }
     }
     case Constants.updateProofState:
-      const proofs = state.proofs
-      const allOk = proofs.every(p => p.state === normal)
-      const [anyWarnings, anyError, anyPending] = [warning, error, checking].map(s => proofs.some(p => p.state === s))
-      const [anyDeletedProofs, anyUnreachableProofs, anyUpgradedProofs, anyNewProofs] = [metaDeleted, metaUnreachable, metaUpgraded, metaNew].map(m => proofs.some(p => p.meta === m))
-      const changed = proofs.some(proof => proof.meta && proof.meta !== metaNone)
-
-      const trackerMessage = deriveTrackerMessage(state.username, allOk, anyDeletedProofs, anyUnreachableProofs, anyUpgradedProofs, anyNewProofs)
+      const proofsGeneralState = overviewStateOfProofs(state.proofs)
+      const trackerMessage = deriveTrackerMessage(state.username, proofsGeneralState)
       const reason = state.currentlyFollowing && trackerMessage ? trackerMessage : state.reason
 
       return {
         ...state,
-        changed,
-        shouldFollow: deriveShouldFollow(allOk),
+        changed: proofsGeneralState.anyChanged,
+        shouldFollow: deriveShouldFollow(proofsGeneralState),
         reason,
-        trackerState: deriveTrackerState(allOk, anyWarnings, anyError, anyPending, anyDeletedProofs, anyUnreachableProofs, state.eldestKidChanged),
+        trackerState: deriveSimpleProofState(state.eldestKidChanged, proofsGeneralState),
       }
 
     case Constants.setProofs:
@@ -592,14 +588,17 @@ function updateProof (proofs: Array<Proof>, rp: RemoteProof, lcr: LinkCheckResul
   return updated
 }
 
-function deriveTrackerState (
-  allOk: boolean,
-  anyWarnings: boolean,
-  anyError: boolean,
-  anyPending: boolean,
-  anyDeletedProofs : boolean,
-  anyUnreachableProofs : boolean,
-  eldestKidChanged: boolean
+export function overviewStateOfProofs (proofs: Array<Proof>): OverviewProofState {
+  const allOk = proofs.every(p => p.state === normal)
+  const [anyWarnings, anyError, anyPending] = [warning, error, checking].map(s => proofs.some(p => p.state === s))
+  const [anyDeletedProofs, anyUnreachableProofs, anyUpgradedProofs, anyNewProofs] = [metaDeleted, metaUnreachable, metaUpgraded, metaNew].map(m => proofs.some(p => p.meta === m))
+  const anyChanged = proofs.some(proof => proof.meta && proof.meta !== metaNone)
+  return {allOk, anyWarnings, anyError, anyPending, anyDeletedProofs, anyUnreachableProofs, anyUpgradedProofs, anyNewProofs, anyChanged}
+}
+
+export function deriveSimpleProofState (
+  eldestKidChanged: boolean,
+  {allOk, anyWarnings, anyError, anyPending, anyDeletedProofs, anyUnreachableProofs}: {allOk: boolean, anyWarnings: boolean, anyError: boolean, anyPending: boolean, anyDeletedProofs : boolean, anyUnreachableProofs : boolean}
 ): SimpleProofState {
   if (eldestKidChanged) {
     return error
@@ -620,11 +619,7 @@ function deriveTrackerState (
 
 function deriveTrackerMessage (
   username: string,
-  allOk: boolean,
-  anyDeletedProofs : boolean,
-  anyUnreachableProofs : boolean,
-  anyUpgradedProofs : boolean,
-  anyNewProofs: boolean
+  {allOk, anyDeletedProofs, anyUnreachableProofs, anyUpgradedProofs, anyNewProofs}: {allOk: boolean, anyDeletedProofs: boolean, anyUnreachableProofs: boolean, anyUpgradedProofs: boolean, anyNewProofs: boolean}
 ): ?string {
   if (allOk) {
     return null
@@ -635,6 +630,6 @@ function deriveTrackerMessage (
   }
 }
 
-function deriveShouldFollow (allOk: boolean): boolean {
+function deriveShouldFollow ({allOk}: {allOk: boolean}): boolean {
   return allOk
 }

--- a/shared/search/user-pane/user.render.desktop.js
+++ b/shared/search/user-pane/user.render.desktop.js
@@ -2,19 +2,19 @@
 
 import React, {Component} from 'react'
 import {Box, UserProofs, UserBio, UserActions} from '../../common-adapters'
-import {headerColor as whichHeaderColor} from '../../common-adapters/user-bio.shared'
 import {globalColors, globalStyles, globalMargins} from '../../styles/style-guide'
 import {AVATAR_SIZE, HEADER_TOP_SPACE, HEADER_SIZE} from '../../profile/render.desktop'
+import {stateColors} from '../../util/tracker'
 import type {Props} from './user.render'
 
 export default class Render extends Component<void, Props, void> {
   render () {
-    const headerColor = whichHeaderColor(this.props)
+    const trackerStateColors = stateColors(this.props)
 
     return (
       <Box style={styleContainer}>
         <Box style={styleScroller} className='hide-scrollbar'>
-          <Box style={{...styleHeader, backgroundColor: headerColor}} />
+          <Box style={{...styleHeader, backgroundColor: trackerStateColors.header.background}} />
           <UserBio
             type='Tracker'
             avatarSize={AVATAR_SIZE}

--- a/shared/search/user-pane/user.render.js.flow
+++ b/shared/search/user-pane/user.render.js.flow
@@ -2,7 +2,7 @@
 
 import {Component} from 'react'
 import type {UserInfo} from '../../common-adapters/user-bio'
-import type {Proof} from '../../common-adapters/user-proofs'
+import type {Proof} from '../../constants/tracker'
 import type {SimpleProofState} from '../../constants/tracker'
 
 export type Props = {

--- a/shared/tracker/dumb.desktop.js
+++ b/shared/tracker/dumb.desktop.js
@@ -4,7 +4,7 @@ import {trackerPropsToRenderProps} from './index'
 import {normal, checking, revoked, error, metaUpgraded, metaUnreachable, metaPending, metaDeleted, metaNone, metaIgnored} from '../constants/tracker'
 import {globalStyles} from '../styles/style-guide'
 import type {TrackerProps} from '../tracker'
-import type {Proof} from '../common-adapters/user-proofs'
+import type {Proof} from '../constants/tracker'
 import type {DumbComponentMap} from '../constants/types/more'
 
 const proofMaker = (type, id = 'id-') => ({

--- a/shared/tracker/dumb.native.js
+++ b/shared/tracker/dumb.native.js
@@ -3,7 +3,7 @@ import Tracker from './render'
 import {trackerPropsToRenderProps} from './index'
 import {normal, checking, revoked, error, metaUpgraded, metaUnreachable, metaPending, metaDeleted, metaNone, metaIgnored} from '../constants/tracker'
 import type {TrackerProps} from '../tracker'
-import type {Proof} from '../common-adapters/user-proofs'
+import type {Proof} from '../constants/tracker'
 
 import type {DumbComponentMap} from '../constants/types/more'
 

--- a/shared/tracker/header.render.desktop.js
+++ b/shared/tracker/header.render.desktop.js
@@ -3,6 +3,7 @@
 import React, {Component} from 'react'
 import {Icon, Text} from '../common-adapters/index'
 import {globalStyles, globalColors} from '../styles/style-guide'
+import {stateColors} from '../util/tracker'
 
 import type {HeaderProps} from './header.render'
 
@@ -16,51 +17,18 @@ export default class HeaderRender extends Component {
   }
 
   render () {
-    let headerStyle = this.props.currentlyFollowing ? styleHeaderFollowing : styleHeaderNotFollowing
-    let headerTextStyle = styleHeaderTextNormal
+    const isWarningAboutTrackerShowingUpLater = this.props.loggedin && !this.props.currentlyfollowing && this.state.showCloseWarning
+    const headerText = isWarningAboutTrackerShowingUpLater ? 'You will see this window every time you access this folder.' : this.props.reason
 
-    if (this.props.currentlyFollowing) {
-      switch (this.props.trackerState) {
-        case 'warning':
-          headerStyle = styleHeaderWarning
-          headerTextStyle = styleHeaderTextWarning
-          break
-        case 'error': headerStyle = styleHeaderError; break
-      }
-    }
-
-    let headerText: string = this.props.reason
-    let isWarning = false
-    if (this.props.loggedIn && !this.props.currentlyFollowing && this.state.showCloseWarning) {
-      isWarning = true
-      headerStyle = styleHeaderWarning
-      headerTextStyle = styleHeaderTextWarning
-      headerText = 'You will see this window every time you access this folder.'
-    }
-
-    // If there's a lastAction, it overrides everything else.
-    switch (this.props.lastAction) {
-      case 'followed':
-      case 'refollowed':
-        headerStyle = styleHeaderFollowing
-        headerTextStyle = styleHeaderTextNormal
-        headerText = this.props.reason
-        break
-      case 'unfollowed':
-        headerStyle = styleHeaderNotFollowing
-        headerTextStyle = styleHeaderTextNormal
-        headerText = this.props.reason
-        break
-      case 'error':
-        headerStyle = styleHeaderWarning
-        headerTextStyle = styleHeaderTextWarning
-    }
+    const trackerStateColors = stateColors(this.props)
+    const headerBackgroundColor = isWarningAboutTrackerShowingUpLater ? globalColors.yellow : trackerStateColors.header.background
+    const headerTextColor = isWarningAboutTrackerShowingUpLater ? globalColors.brown_60 : trackerStateColors.header.text
 
     return (
       <div style={styleOuter}>
-        <div style={{...styleHeader, ...headerStyle}}>
-          <div style={{...styleHeader, ...headerStyle, height: 48, zIndex: 2, opacity: isWarning ? 1 : 0, backgroundColor: globalColors.yellow}} />
-          <Text type='BodySemibold' lineClamp={2} style={{...styleText, ...headerTextStyle, flex: 1, zIndex: isWarning ? 2 : 'inherit'}}>{headerText}</Text>
+        <div style={{...styleHeader, backgroundColor: headerBackgroundColor}}>
+          <div style={{...styleHeader, height: 48, zIndex: 2, opacity: isWarningAboutTrackerShowingUpLater ? 1 : 0, backgroundColor: globalColors.yellow}} />
+          <Text type='BodySemibold' lineClamp={2} style={{...styleText, color: headerTextColor, ...(isWarningAboutTrackerShowingUpLater ? {zIndex: 2} : {})}}>{headerText}</Text>
           <Icon type='iconfont-close' style={styleClose}
             onClick={() => this.props.onClose()}
             onMouseEnter={() => this.closeMouseEnter()}
@@ -93,36 +61,6 @@ const styleHeader = {
   width: 320,
 }
 
-const styleHeaderNotFollowing = {
-  backgroundColor: globalColors.blue,
-}
-
-const styleHeaderFollowing = {
-  backgroundColor: globalColors.green,
-}
-
-const styleHeaderWarning = {
-  backgroundColor: globalColors.yellow,
-}
-
-const styleHeaderTextNormal = {
-  color: globalColors.white,
-  fontSize: 14,
-  lineHeight: 'normal',
-  opacity: 1,
-}
-
-const styleHeaderTextWarning = {
-  color: globalColors.brown_60,
-  fontSize: 14,
-  lineHeight: 'normal',
-  opacity: 1,
-}
-
-const styleHeaderError = {
-  backgroundColor: globalColors.red,
-}
-
 const styleClose = {
   ...globalStyles.clickable,
   ...globalStyles.windowDraggingClickable,
@@ -134,6 +72,7 @@ const styleClose = {
 
 const styleText = {
   ...globalStyles.flexBoxRow,
+  flex: 1,
   alignItems: 'center',
   justifyContent: 'center',
   color: globalColors.white,
@@ -142,4 +81,5 @@ const styleText = {
   marginBottom: 32,
   fontSize: 14,
   textAlign: 'center',
+  lineHeight: 'normal',
 }

--- a/shared/tracker/header.render.desktop.js
+++ b/shared/tracker/header.render.desktop.js
@@ -17,7 +17,7 @@ export default class HeaderRender extends Component {
   }
 
   render () {
-    const isWarningAboutTrackerShowingUpLater = this.props.loggedin && !this.props.currentlyfollowing && this.state.showCloseWarning
+    const isWarningAboutTrackerShowingUpLater = this.props.loggedIn && !this.props.currentlyFollowing && this.state.showCloseWarning
     const headerText = isWarningAboutTrackerShowingUpLater ? 'You will see this window every time you access this folder.' : this.props.reason
 
     const trackerStateColors = stateColors(this.props)
@@ -27,7 +27,6 @@ export default class HeaderRender extends Component {
     return (
       <div style={styleOuter}>
         <div style={{...styleHeader, backgroundColor: headerBackgroundColor}}>
-          <div style={{...styleHeader, height: 48, zIndex: 2, opacity: isWarningAboutTrackerShowingUpLater ? 1 : 0, backgroundColor: globalColors.yellow}} />
           <Text type='BodySemibold' lineClamp={2} style={{...styleText, color: headerTextColor, ...(isWarningAboutTrackerShowingUpLater ? {zIndex: 2} : {})}}>{headerText}</Text>
           <Icon type='iconfont-close' style={styleClose}
             onClick={() => this.props.onClose()}

--- a/shared/tracker/header.render.js.flow
+++ b/shared/tracker/header.render.js.flow
@@ -8,7 +8,6 @@ export type HeaderProps = {
   onClose: () => void,
   trackerState: SimpleProofState,
   currentlyFollowing: boolean,
-  lastAction: ?string,
   loggedIn: boolean,
 }
 

--- a/shared/tracker/index.js
+++ b/shared/tracker/index.js
@@ -10,8 +10,7 @@ import {isLoading} from '../constants/tracker'
 
 import type {RenderPropsUnshaped} from './render'
 import type {UserInfo} from '../common-adapters/user-bio'
-import type {Proof} from '../common-adapters/user-proofs'
-import type {SimpleProofState} from '../constants/tracker'
+import type {Proof, SimpleProofState} from '../constants/tracker'
 
 export type TrackerProps = {
   currentlyFollowing: boolean,

--- a/shared/tracker/render.desktop.js
+++ b/shared/tracker/render.desktop.js
@@ -42,7 +42,6 @@ export default class Render extends Component<void, RenderProps, void> {
           onClose={this.props.onClose}
           trackerState={this.props.trackerState}
           currentlyFollowing={this.props.currentlyFollowing}
-          lastAction={this.props.lastAction}
           loggedIn={this.props.loggedIn}
         />
         <div style={{...styles.content, paddingBottom: calculatedPadding}} className='hide-scrollbar, scroll-container'>

--- a/shared/tracker/render.js.flow
+++ b/shared/tracker/render.js.flow
@@ -4,7 +4,7 @@ import {Component} from 'react'
 
 import type {SimpleProofState} from '../constants/tracker'
 import type {UserInfo} from '../common-adapters/user-bio'
-import type {Proof} from '../common-adapters/user-proofs'
+import type {Proof} from '../constants/tracker'
 import type {$Exact} from '../constants/types/more'
 
 export type RenderPropsUnshaped = {

--- a/shared/util/tracker.js
+++ b/shared/util/tracker.js
@@ -11,6 +11,7 @@ type StateColors = {
   },
   username: string
 }
+
 export function stateColors ({currentlyFollowing, trackerState}: {currentlyFollowing: boolean, trackerState: SimpleProofState}): StateColors {
   if ([warning, error].indexOf(trackerState) !== -1) {
     return {

--- a/shared/util/tracker.js
+++ b/shared/util/tracker.js
@@ -1,0 +1,32 @@
+/* @flow */
+
+import type {SimpleProofState} from '../constants/tracker'
+import {globalColors} from '../styles/style-guide'
+import {warning, error} from '../constants/tracker'
+
+type StateColors = {
+  header: {
+    background: string,
+    text: string
+  },
+  username: string
+}
+export function stateColors ({currentlyFollowing, trackerState}: {currentlyFollowing: boolean, trackerState: SimpleProofState}): StateColors {
+  if ([warning, error].indexOf(trackerState) !== -1) {
+    return {
+      header: {background: globalColors.red, text: globalColors.white},
+      username: globalColors.red,
+    }
+  }
+  if (currentlyFollowing) {
+    return {
+      header: {background: globalColors.green, text: globalColors.white},
+      username: globalColors.green2,
+    }
+  } else {
+    return {
+      header: {background: globalColors.blue, text: globalColors.white},
+      username: globalColors.orange,
+    }
+  }
+}


### PR DESCRIPTION
Logic for deciding header and username colors off of tracker state was implemented multiple times in the app, incorrectly in some places (bad @awendland from June 27th!), and complexly in other parts. This simplifies the implementation and consolidates it in one location, so that updates to the style apply everywhere.

**Other Fixes**
This brings some of the coloring up to date with the latest designs. The current GUI implementation is using yellow headers sometimes in response to proof states, yet the design always calls for red headers; yellow is reserved for warning that the tracker will show up again when the user is hovering over the close button.

| Current | Design |
|--------|--------|
| <img width="290" alt="screen shot 2016-07-29 at 12 12 10 pm" src="https://cloud.githubusercontent.com/assets/1152104/17260552/f142f7f2-5585-11e6-9808-58374dd661b5.png"> | <img width="328" alt="screen shot 2016-07-29 at 12 12 02 pm" src="https://cloud.githubusercontent.com/assets/1152104/17260554/f335f488-5585-11e6-8de3-b230a7efd030.png"> |

**Outstanding Issues**
[DESKTOP-1582](https://keybase.atlassian.net/browse/DESKTOP-1582) is still a problem with proofs getting out of sync/showing the wrong color after refresh. This does not attempt to fix that, but it does simplify the tracker logic which may make it easier to debug.