### PR TITLE
Use exit instead of quit to avoid hitting the before-quit listener

### DIFF
--- a/desktop/app/ctl.js
+++ b/desktop/app/ctl.js
@@ -12,7 +12,7 @@ export function quit () {
   // Only quit the app in dev mode
   if (__DEV__) {
     console.log('Only quiting gui in dev mode')
-    app.quit()
+    app.exit(0)
     return
   }
 
@@ -22,6 +22,6 @@ export function quit () {
     if (stopErr) {
       console.log('Error in ctl stop, when quiting:', stopErr)
     }
-    app.quit()
+    app.exit(0)
   })
 }

--- a/desktop/app/index.js
+++ b/desktop/app/index.js
@@ -98,13 +98,6 @@ function start () {
     })
   })
 
-  app.on('before-quit', event => {
-    const windows = BrowserWindow.getAllWindows()
-    windows.forEach(w => {
-      w.destroy()
-    })
-  })
-
   // quit through dock. only listen once
   app.once('before-quit', event => {
     console.log('Quit through before-quit')

--- a/shared/util/quit-helper.desktop.js
+++ b/shared/util/quit-helper.desktop.js
@@ -6,9 +6,6 @@ import {hideDockIcon} from '../../desktop/app/dock-icon'
 export type Context = 'uiWindow' | 'mainThread' | 'quitButton' | 'beforeQuit'
 export type Action = 'closePopups' | 'quitMainWindow' | 'quitApp'
 
-// Don't do beforeQuit path if we're really quitting
-let isQuitting = false
-
 // Logic to figure out what to do given your context
 function quitOnContext (context: Context): Array<Action> {
   switch (context) {
@@ -30,11 +27,6 @@ function isMainThread () {
 }
 
 function _executeActions (actions: Array<Action>) {
-  // Don't allow us to re-enter this logic if we're already shutting down
-  if (isQuitting) {
-    return
-  }
-
   actions.forEach(a => {
     switch (a) {
       case 'quitMainWindow':
@@ -44,13 +36,7 @@ function _executeActions (actions: Array<Action>) {
         app.emit('close-windows')
         break
       case 'quitApp':
-        isQuitting = true
-        try {
-          quit()
-        } catch (err) {
-          isQuitting = false
-          console.warn("Couldn't quit")
-        }
+        quit()
         break
     }
   })


### PR DESCRIPTION
@keybase/react-hackers @gabriel 

In the latest admin release if you tried to quit with the menubar (with the main window open) you would end up closing some of the ui windows, and calling a ctl stop, but still have a dock icon visible (and main window).

The problem was that before-quit was preventing our call to `app.quit()` and our logic for checking we aren't quitting while quitting meant that we wouldn't actually be able to quit after that point.

We've removed all the `isQuitting` logic and are using `app.exit(0)` which doesn't call `before-quit`.