### PR TITLE
Fix typo in tracker obscuring scrollbar styles

### DIFF
--- a/shared/tracker/render.desktop.js
+++ b/shared/tracker/render.desktop.js
@@ -45,7 +45,7 @@ export default class Render extends Component<void, RenderProps, void> {
           lastAction={this.props.lastAction}
           loggedIn={this.props.loggedIn}
         />
-        <div style={{...styles.content, paddingBottom: calculatedPadding}} className='hide-scrollbar, scroll-container'>
+        <div style={{...styles.content, paddingBottom: calculatedPadding}} className='hide-scrollbar scroll-container'>
           <UserBio type='Tracker'
             style={{marginTop: 50}}
             avatarSize={80}


### PR DESCRIPTION
:eyeglasses: @keybase/react-hackers 

This will restore the styles hiding the tracker window scrollbar. They appear to have been unintentionally disabled due to a typo.

There seems to be active debate about the need for scrollbar on this view. I have looked into the scrollbar details and believe it is possible to do a proper overlay scrollbar, but in the meantime we should probably correct this typo and return to the hidden scrollbar style.