### PR TITLE
Save/restore state (include dock), hide on start option

### DIFF
--- a/desktop/app/app-state.js
+++ b/desktop/app/app-state.js
@@ -191,7 +191,7 @@ export default class AppState {
   }
 
   _loadAppListeners () {
-    app.on('-keybase-dock-show', () => {
+    app.on('-keybase-dock-showing', () => {
       this.state.dockHidden = false
       this.saveState()
     })

--- a/desktop/app/app-state.js
+++ b/desktop/app/app-state.js
@@ -27,6 +27,7 @@ export default class AppState {
       isFullScreen: null,
       displayBounds: null,
       tab: null,
+      dockHidden: false,
     }
 
     this.config = {
@@ -37,6 +38,7 @@ export default class AppState {
     this.managed = {
       debounceChangeTimer: null,
       winRef: null,
+      showHandlers: [],
       resizeHandlers: [],
       moveHandlers: [],
       closeHandlers: [],
@@ -57,6 +59,18 @@ export default class AppState {
     })
   }
 
+  manageApp (app: any) {
+    app.on('-keybase-dock-show', () => {
+      this.state.dockHidden = false
+      this.saveState()
+    })
+
+    app.on('-keybase-dock-hide', () => {
+      this.state.dockHidden = true
+      this.saveState()
+    })
+  }
+
   manageWindow (win: any) {
     // TODO: Do we want to maximize or setFullScreen if the state says we were?
     // if (this.config.maximize && this.state.isMaximized) {
@@ -65,6 +79,10 @@ export default class AppState {
     // if (this.config.fullScreen && this.state.isFullScreen) {
     //   win.setFullScreen(true)
     // }
+
+    let showHandler = () => { this._showHandler() }
+    this.managed.showHandlers.push(showHandler)
+    win.on('show', showHandler)
 
     let resizeHandler = () => { this._debounceChangeHandler() }
     this.managed.resizeHandlers.push(resizeHandler)
@@ -160,6 +178,10 @@ export default class AppState {
       this.state.windowHidden = !winRef.isVisible()
     }
     this.saveState()
+  }
+
+  _showHandler () {
+    this._updateState()
   }
 
   _closeHandler () {

--- a/desktop/app/app-state.js
+++ b/desktop/app/app-state.js
@@ -4,7 +4,7 @@
 // This is modified from https://github.com/mawie81/electron-window-state
 //
 
-import electron from 'electron'
+import {app, screen} from 'electron'
 import fs from 'fs'
 import path from 'path'
 import jsonfile from 'jsonfile'
@@ -31,7 +31,7 @@ export default class AppState {
     }
 
     this.config = {
-      path: path.join(electron.app.getPath('userData'), 'app-state.json'),
+      path: path.join(app.getPath('userData'), 'app-state.json'),
       eventHandlingDelay: 100,
     }
 
@@ -46,6 +46,7 @@ export default class AppState {
     }
 
     this._loadStateSync()
+    this._loadAppListeners()
   }
 
   saveState () {
@@ -56,18 +57,6 @@ export default class AppState {
       if (err) {
         console.log('Error saving file:', err)
       }
-    })
-  }
-
-  manageApp (app: any) {
-    app.on('-keybase-dock-show', () => {
-      this.state.dockHidden = false
-      this.saveState()
-    })
-
-    app.on('-keybase-dock-hide', () => {
-      this.state.dockHidden = true
-      this.saveState()
     })
   }
 
@@ -103,9 +92,13 @@ export default class AppState {
     this.managed.winRef = win
   }
 
-  clear () {
+  _clearWindow () {
     let winRef = this.managed.winRef
     if (winRef) {
+      for (let showHandler of this.managed.showHandlers) {
+        winRef.removeListener('show', showHandler)
+      }
+      this.managed.showHandlers = []
       for (let resizeHandler of this.managed.resizeHandlers) {
         winRef.removeListener('resize', resizeHandler)
       }
@@ -135,7 +128,7 @@ export default class AppState {
       width: state.width,
       height: state.height,
     }
-    let displayBounds = electron.screen.getDisplayMatching(rect).bounds
+    let displayBounds = screen.getDisplayMatching(rect).bounds
     console.log('Check bounds:', rect, state.displayBounds, displayBounds)
     return deepEqual(state.displayBounds, displayBounds, {strict: true})
   }
@@ -174,7 +167,7 @@ export default class AppState {
       }
       this.state.isMaximized = winRef.isMaximized()
       this.state.isFullScreen = winRef.isFullScreen()
-      this.state.displayBounds = electron.screen.getDisplayMatching(winBounds).bounds
+      this.state.displayBounds = screen.getDisplayMatching(winBounds).bounds
       this.state.windowHidden = !winRef.isVisible()
     }
     this.saveState()
@@ -189,11 +182,23 @@ export default class AppState {
   }
 
   _closedHandler () {
-    this.clear()
+    this._clearWindow()
   }
 
   _debounceChangeHandler () {
     clearTimeout(this.managed.debounceChangeTimer)
     this.managed.debounceChangeTimer = setTimeout(() => { this._updateState() }, this.config.eventHandlingDelay)
+  }
+
+  _loadAppListeners () {
+    app.on('-keybase-dock-show', () => {
+      this.state.dockHidden = false
+      this.saveState()
+    })
+
+    app.on('-keybase-dock-hide', () => {
+      this.state.dockHidden = true
+      this.saveState()
+    })
   }
 }

--- a/desktop/app/app-state.js.flow
+++ b/desktop/app/app-state.js.flow
@@ -10,6 +10,7 @@ export type State = {
   isFullScreen: ?boolean,
   displayBounds: ?any,
   tab: ?string,
+  dockHidden: boolean,
 }
 
 export type Config = {
@@ -25,6 +26,7 @@ export type Options = {
 export type Managed = {
   winRef: ?any,
   debounceChangeTimer: ?number,
+  showHandlers: Array<function>,
   resizeHandlers: Array<function>,
   moveHandlers: Array<function>,
   closeHandlers: Array<function>,

--- a/desktop/app/dock-icon.js
+++ b/desktop/app/dock-icon.js
@@ -2,22 +2,18 @@
 
 import {app} from 'electron'
 
-// TODO: Let's switch to using app.dock.isVisible if this gets merged:
-// https://github.com/electron/electron/pull/6683
-let isDockHidden = false
-
 export function showDockIcon () {
-  if (isDockHidden) {
-    isDockHidden = false
-    app.dock && app.dock.show()
-    app.emit('-keybase-dock-show', {}, this)
+  if (app.dock && !app.dock.isVisible()) {
+    // Be aware that app.dock.isVisible() won't be true immediately
+    // after app.dock.show() since there is a slight delay there.
+    app.dock.show()
+    app.emit('-keybase-dock-showing', {}, this)
   }
 }
 
 export function hideDockIcon () {
-  if (!isDockHidden) {
-    isDockHidden = true
-    app.dock && app.dock.hide()
+  if (app.dock && app.dock.isVisible()) {
+    app.dock.hide()
     app.emit('-keybase-dock-hide', {}, this)
   }
 }

--- a/desktop/app/dock-icon.js
+++ b/desktop/app/dock-icon.js
@@ -2,18 +2,22 @@
 
 import {app} from 'electron'
 
-let isDockVisible = false
+// TODO: Let's switch to using app.dock.isVisible if this gets merged:
+// https://github.com/electron/electron/pull/6683
+let isDockHidden = false
 
 export function showDockIcon () {
-  if (!isDockVisible) {
-    isDockVisible = true
+  if (isDockHidden) {
+    isDockHidden = false
     app.dock && app.dock.show()
+    app.emit('-keybase-dock-show', {}, this)
   }
 }
 
 export function hideDockIcon () {
-  if (isDockVisible) {
-    isDockVisible = false
+  if (!isDockHidden) {
+    isDockHidden = true
     app.dock && app.dock.hide()
+    app.emit('-keybase-dock-hide', {}, this)
   }
 }

--- a/desktop/app/index.js
+++ b/desktop/app/index.js
@@ -14,7 +14,6 @@ import hello from '../shared/util/hello'
 import semver from 'semver'
 import os from 'os'
 import {setupExecuteActionsListener, executeActionsForContext} from '../shared/util/quit-helper.desktop'
-import {hideDockIcon} from './dock-icon'
 
 let mainWindow = null
 
@@ -78,9 +77,6 @@ function start () {
   app.once('ready', () => {
     mainWindow = MainWindow()
     storeHelper(mainWindow)
-    if (!mainWindow.initiallyVisible) {
-      hideDockIcon()
-    }
   })
 
   // Called when the user clicks the dock icon

--- a/desktop/app/main-window.js
+++ b/desktop/app/main-window.js
@@ -1,5 +1,5 @@
 import Window from './window'
-import {app, ipcMain} from 'electron'
+import {ipcMain} from 'electron'
 import {resolveRoot} from '../resolve-root'
 import hotPath from '../hot-path'
 import {windowStyle} from '../shared/styles/style-guide'
@@ -27,7 +27,6 @@ export default function () {
   )
 
   appState.manageWindow(mainWindow.window)
-  appState.manageApp(app)
 
   if (__DEV__ && forceMainWindowPosition) {
     mainWindow.window.setPosition(forceMainWindowPosition.x, forceMainWindowPosition.y)

--- a/desktop/app/main-window.js
+++ b/desktop/app/main-window.js
@@ -32,8 +32,16 @@ export default function () {
     mainWindow.window.setPosition(forceMainWindowPosition.x, forceMainWindowPosition.y)
   }
 
-  let isRestore = getenv.boolish('KEYBASE_RESTORE_UI', false)
-  if (!isRestore || (isRestore && !appState.state.windowHidden)) {
+  const isRestore = getenv.boolish('KEYBASE_RESTORE_UI', false)
+  const startUI = getenv.string('KEYBASE_START_UI', '')
+
+  // We show the main window on startup if:
+  //  - We are not restoring the UI (after update, or boot)
+  //    Or, we are restoring UI and the window was previously visible (in app state)
+  //  - And, startUI is not set to 'hideWindow'.
+  const showMainWindow = (!isRestore || (isRestore && !appState.state.windowHidden)) && (startUI !== 'hideWindow')
+
+  if (showMainWindow) {
     // On Windows we can try showing before Windows is ready
     // This will result in a dropped .show request
     // We add a listener to `did-finish-load` so we can show it when


### PR DESCRIPTION
This allows us to restore app state (window visibility) properly.