### PR TITLE
Appveyor isn't running on the KBFS repo anymore

### DIFF
--- a/packaging/linux/build_and_push_packages.sh
+++ b/packaging/linux/build_and_push_packages.sh
@@ -41,7 +41,7 @@ if [ ! "${NOWAIT:-}" = "1" ]; then
   "$release_bin" wait-ci --repo="client" --commit="$(git -C $client_dir rev-parse HEAD)" --context="Jenkins job master" --context="ci/circleci"
   if [ "$mode" != "production" ] ; then
     echo "Checking kbfs CI"
-    "$release_bin" wait-ci --repo="kbfs" --commit="$(git -C $kbfs_dir rev-parse HEAD)" --context="Jenkins job master" --context="continuous-integration/appveyor/branch"
+    "$release_bin" wait-ci --repo="kbfs" --commit="$(git -C $kbfs_dir rev-parse HEAD)" --context="Jenkins job master"
   fi
 fi
 

--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -95,7 +95,7 @@ if [ ! "$nowait" = "1" ]; then
   echo "Checking client CI"
   "$release_bin" wait-ci --repo="client" --commit=`git -C $client_dir log -1 --pretty=format:%h` --context="Jenkins job master" --context="ci/circleci"
   echo "Checking kbfs CI"
-  "$release_bin" wait-ci --repo="kbfs" --commit=`git -C $kbfs_dir log -1 --pretty=format:%h` --context="Jenkins job master" --context="continuous-integration/appveyor/branch"
+  "$release_bin" wait-ci --repo="kbfs" --commit=`git -C $kbfs_dir log -1 --pretty=format:%h` --context="Jenkins job master"
   echo "Checking updater CI"
   "$release_bin" wait-ci --repo="go-updater" --commit=`git -C $updater_dir log -1 --pretty=format:%h` --context="continuous-integration/travis-ci/push"
 


### PR DESCRIPTION
@gabriel @jzila 

Maybe it'll be running again in the future.  Maybe Jenkins will take over what it was testing.  But for now, let's get builds working again.