### PR TITLE
Installer (macOS) 1.0.33

### DIFF
--- a/desktop/CHANGELOG.txt
+++ b/desktop/CHANGELOG.txt
@@ -2,6 +2,8 @@ Recent changes:
 ---------------
 - Search from the app! Want to share data in KBFS with a Twitter user? Just click the Twitter bird and type their username. This will popup a folder for you, and if they're not on Keybase yet, and invitation code to share.
 
+- Support for macOS 10.12 (Sierra)
+
 - Introducing the main GUI screen. This is where you'll look people up, manage your folders, and perform other actions. A lot of the features are stubbed out, but you can start playing with it.
 
 - Sharing before signup! Go ahead and put data in /keybase/private/you,friend@twitter/. If you have any invite codes, this will pop up a window with a link to DM them. It also works for end-to-end encryption with Reddit, Coinbase, Github, and Hacker News users.

--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.32</string>
+	<string>1.1.33</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.32</string>
+	<string>1.1.33</string>
 	<key>KBFuseBuild</key>
 	<string>3.4.0</string>
 	<key>KBFuseVersion</key>

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -76,7 +76,7 @@ shared_support_dir="$out_dir/Keybase.app/Contents/SharedSupport"
 resources_dir="$out_dir/Keybase.app/Contents/Resources/"
 
 # The KeybaseInstaller.app installs KBFuse, keybase.Helper, services and CLI via a native app
-installer_url="https://github.com/keybase/client/releases/download/v1.0.16/KeybaseInstaller-1.1.31-darwin.tgz"
+installer_url="https://github.com/keybase/client/releases/download/v1.0.16/KeybaseInstaller-1.1.33-darwin.tgz"
 # KeybaseUpdater.app is the native updater UI (prompt dialogs)
 updater_url="https://github.com/keybase/client/releases/download/v1.0.16/KeybaseUpdater-1.0.3-darwin.tgz"
 


### PR DESCRIPTION
This enables the new installer in builds.

- Includes Fuse 3.4.0 (to fix Sierra): https://github.com/keybase/client/pull/3529
- Installer has timeout and stops immediately on error and includes debugging for hung processes (to address reports of installer hangs): https://github.com/keybase/client/pull/3653
- Increase XPC connection attempts to Helper tool to address @patrickxb issue after upgrade: https://github.com/keybase/client/pull/3638
