### PR TITLE
Throw on cold start build-dev failure

### DIFF
--- a/desktop/server.js
+++ b/desktop/server.js
@@ -15,17 +15,14 @@ if (NO_SERVER) {
   console.log('Starting local file build')
   compiler.run(function (err, stats) {
     if (err) {
-      console.error(err)
-      return
+      throw err
     }
     var jsonStats = stats.toJson()
     if (jsonStats.errors.length > 0) {
-      console.error(jsonStats.errors.join('\n'))
-      return
+      throw jsonStats.errors.join('\n')
     }
     if (jsonStats.warnings.length > 0) {
-      console.log(jsonStats.warnings.join('\n'))
-      return
+      throw jsonStats.warnings.join('\n')
     }
     console.log(stats)
   })

--- a/desktop/test.js
+++ b/desktop/test.js
@@ -11,17 +11,14 @@ if (getenv.boolish('WATCH', false)) {
   mocha.addFile('./dist/test.bundle.js')
   compiler.watch({}, function (err, stats) {
     if (err) {
-      console.error(err)
-      return
+      throw err
     }
     var jsonStats = stats.toJson()
     if (jsonStats.errors.length > 0) {
-      console.error(jsonStats.errors.join('\n'))
-      return
+      throw jsonStats.errors.join('\n')
     }
     if (jsonStats.warnings.length > 0) {
-      console.log(jsonStats.warnings.join('\n'))
-      return
+      throw jsonStats.warnings.join('\n')
     }
     console.log('done, running tests')
     try {


### PR DESCRIPTION
Before `npm start` wouldn't exit if there was a syntax
error.