### PR TITLE
Integrate revoking proofs DESKTOP-1430

### DIFF
--- a/shared/actions/profile.js
+++ b/shared/actions/profile.js
@@ -165,8 +165,6 @@ function finishRevoking (): AsyncAction {
   }
 }
 
-let submitRevokeProofResponse: ?Object = null
-
 function submitRevokeProof (proofId: string): AsyncAction {
   return (dispatch) => {
     revokeRevokeSigsRpc({
@@ -187,16 +185,6 @@ function submitRevokeProof (proofId: string): AsyncAction {
   }
 }
 
-function cancelRevokeProof (): AsyncAction {
-  return (dispatch) => {
-    if (submitRevokeProofResponse) {
-      engine.cancelRPC(submitRevokeProofResponse, InputCancelError)
-      submitRevokeProofResponse = null
-    }
-    dispatch(finishRevoking())
-  }
-}
-
 export {
   addProof,
   editProfile,
@@ -205,5 +193,5 @@ export {
   submitUsername,
   cancelAddProof,
   submitRevokeProof,
-  cancelRevokeProof,
+  finishRevoking,
 }

--- a/shared/constants/profile.js
+++ b/shared/constants/profile.js
@@ -14,11 +14,19 @@ export type UpdatePlatform = TypedAction<'profile:updatePlatform', {platform: Pl
 export const updateUsername = 'profile:updateUsername'
 export type UpdateUsername = TypedAction<'profile:updateUsername', {username: string}, void>
 
+export const waitingRevokeProof = 'profile:revoke:waiting'
+export type WaitingRevokeProof = TypedAction<'profile:revoke:waiting', {waiting: boolean}, void>
+
+export const finishRevokeProof = 'profile:revoke:finish'
+export type FinishRevokeProof = TypedAction<'profile:revoke:finish', void, {error: string}>
+
 export const maxProfileBioChars = 256
 
 export type Actions = Waiting
   | UpdatePlatform
   | UpdateUsername
+  | WaitingRevokeProof
+  | FinishRevokeProof
 
 export type State = {
   error: ?string,
@@ -26,4 +34,8 @@ export type State = {
   username: string,
   platform: ?PlatformsExpanded,
   usernameValid: boolean,
+  revoke: {
+    waiting?: boolean,
+    error?: string,
+  },
 }

--- a/shared/constants/reducer.js
+++ b/shared/constants/reducer.js
@@ -4,6 +4,7 @@ import type {State as UnlockFoldersState} from '../reducers/unlock-folders'
 import type {State as SearchState} from '../reducers/search'
 import type {State as TotalTrackerState} from '../reducers/tracker'
 import type {FavoriteState} from '../constants/favorite'
+import type {State as ProfileState} from '../constants/profile'
 import type {ConfigState} from '../reducers/config'
 
 export type TypedState = {
@@ -12,7 +13,7 @@ export type TypedState = {
   config: ConfigState,
   tracker: TotalTrackerState,
   favorite: FavoriteState,
-
+  profile: ProfileState,
 }
 
 // TODO swap State with TypedState when TypedState includes everything we care about

--- a/shared/profile/dumb.js
+++ b/shared/profile/dumb.js
@@ -362,11 +362,8 @@ const dumbEditAvatar: DumbComponentMap<EditAvatar> = {
 }
 
 const revokeBase = {
-  platform: 'twitter',
-  username: 'chris',
-  onCancel: () => console.log('clicked Cancel'),
-  onRevoke: () => console.log('clicked Revoke'),
-  isHttps: false,
+  onCancel: () => console.log('Revoke Proof: clicked Cancel'),
+  onRevoke: () => console.log('Revoke Proof: clicked Revoke'),
 }
 
 const revokeTwitter = {
@@ -388,7 +385,7 @@ const dumbRevoke: DumbComponentMap<Revoke> = {
     'Bitcoin': {...revokeBase, platformHandle: '1BjgMvwVkpmmJ5HFGZ3L3H1G6fcKLNGT5h', platform: 'btc'},
     'DNS': {...revokeBase, platformHandle: 'chriscoyne.com', platform: 'dns'},
     'Website': {...revokeBase, platformHandle: 'chriscoyne.com', platform: 'genericWebSite'},
-    'https website': {...revokeBase, isHttps: true, platformHandle: 'chriscoyne.com', platform: 'genericWebSite'},
+    'https website': {...revokeBase, platformHandle: 'chriscoyne.com', platform: 'https'},
   },
 }
 

--- a/shared/profile/dumb.js
+++ b/shared/profile/dumb.js
@@ -369,10 +369,18 @@ const revokeBase = {
   isHttps: false,
 }
 
+const revokeTwitter = {
+  ...revokeBase,
+  platformHandle: 'alexrwendland',
+  platform: 'twitter',
+}
+
 const dumbRevoke: DumbComponentMap<Revoke> = {
   component: Revoke,
   mocks: {
-    'Twitter': {...revokeBase, platformHandle: 'malgorithms', platform: 'twitter'},
+    'Twitter': {...revokeTwitter},
+    'Twitter - Error': {...revokeTwitter, errorMessage: 'There was an error revoking your proof. You can click the button to try again.'},
+    'Twitter - Waiting': {...revokeTwitter, isWaiting: true},
     'Reddit': {...revokeBase, platformHandle: 'malgorithms', platform: 'reddit'},
     'GitHub': {...revokeBase, platformHandle: 'malgorithms', platform: 'github'},
     'Coinbase': {...revokeBase, platformHandle: 'malgorithms', platform: 'coinbase'},

--- a/shared/profile/index.js
+++ b/shared/profile/index.js
@@ -4,6 +4,7 @@ import React, {Component} from 'react'
 import Render from './render'
 import flags from '../util/feature-flags'
 import type {MissingProof} from '../common-adapters/user-proofs'
+import type {Proof} from '../constants/tracker'
 import type {Props} from './render'
 import {addProof} from '../actions/profile'
 import {connect} from 'react-redux'
@@ -12,6 +13,7 @@ import {isLoading} from '../constants/tracker'
 import {openInKBFS} from '../actions/kbfs'
 import {routeAppend, navigateUp} from '../actions/router'
 import ProveEnterUsername from './prove-enter-username-container'
+import Revoke from './revoke-container'
 
 class Profile extends Component<void, Props, void> {
   static parseRoute (currentPath, uri) {
@@ -26,6 +28,7 @@ class Profile extends Component<void, Props, void> {
       subRoutes: {
         'editprofile': EditProfile,
         ProveEnterUsername,
+        Revoke,
       },
     }
   }
@@ -70,6 +73,7 @@ export default connect(
     onFolderClick: folder => dispatch(openInKBFS(folder.path)),
     onEditProfile: () => dispatch(routeAppend({path: 'editprofile'})),
     onMissingProofClick: (missingProof: MissingProof) => dispatch(addProof(missingProof.type)),
+    onRevokeProof: (proof: Proof) => dispatch(routeAppend({path: 'Revoke', platform: proof.type, platformHandle: proof.name, proofId: proof.id})),
   }),
   (stateProps, dispatchProps, ownProps) => {
     const username = ownProps.username || stateProps.myUsername

--- a/shared/profile/post-proof.desktop.js
+++ b/shared/profile/post-proof.desktop.js
@@ -53,13 +53,16 @@ const styleErrorBanner = {
   alignItems: 'center',
   width: '100%',
   zIndex: 1,
-  height: globalMargins.large,
+  minHeight: globalMargins.large,
+  padding: globalMargins.tiny,
   marginTop: -globalMargins.large,
   backgroundColor: globalColors.red,
 }
 
 const styleErrorBannerText = {
   color: globalColors.white,
+  maxWidth: 512,
+  textAlign: 'center',
 }
 
 const styleContentContainer = {

--- a/shared/profile/post-proof.shared.js
+++ b/shared/profile/post-proof.shared.js
@@ -4,13 +4,17 @@ import {Text, Box, Icon} from '../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import {resolve as urlResolve} from 'url'
 import openUrl from '../util/open-url'
+import {subtitle} from '../util/platforms'
 import type {Props} from './post-proof'
 
 export function propsForPlatform (props: Props) {
+  const base = {
+    platformSubtitle: subtitle(props.platform),
+  }
   switch (props.platform) {
     case 'twitter':
       return {
-        platformSubtitle: '@twitter',
+        ...base,
         descriptionView: <Text type='Body'>Please tweet the below text <Text type='Body' style={globalStyles.italic}>exactly as it appears.</Text></Text>,
         proofActionText: 'Tweet it now',
         proofActionIcon: 'iconfont-tweet',
@@ -18,7 +22,7 @@ export function propsForPlatform (props: Props) {
       }
     case 'reddit':
       return {
-        platformSubtitle: '@reddit',
+        ...base,
         descriptionView: <Text type='Body'>Click the link below and post the form in the subreddit <Text type='Body' style={globalStyles.italic}>KeybaseProofs.</Text></Text>,
         noteText: 'Make sure you\'re signed in to Reddit, and don\'t edit the text or title before submitting.',
         proofActionText: 'Reddit form',
@@ -27,7 +31,7 @@ export function propsForPlatform (props: Props) {
       }
     case 'github':
       return {
-        platformSubtitle: '@github',
+        ...base,
         descriptionView: <Text type='Body'>Login to GitHub and paste the text below into a <Text type='BodySemibold'>public</Text> gist called <Text type='Body' style={globalStyles.italic}>keybase.md.</Text></Text>,
         proofActionText: 'Create gist now',
         proofActionIcon: 'iconfont-open-browser',
@@ -35,7 +39,7 @@ export function propsForPlatform (props: Props) {
       }
     case 'coinbase':
       return {
-        platformSubtitle: '@coinbase',
+        ...base,
         descriptionView: <Text type='Body'>Please paste the below text <Text type='Body' style={globalStyles.italic}>exactly as it appears</Text> as your "public key" on Coinbase.</Text>,
         proofActionText: 'Go to Coinbase to add as "public key"',
         proofActionIcon: 'iconfont-open-browser',
@@ -43,7 +47,7 @@ export function propsForPlatform (props: Props) {
       }
     case 'hackernews':
       return {
-        platformSubtitle: '@hackernews',
+        ...base,
         descriptionView: <Text type='Body'>Please add the below text <Text type='Body' style={globalStyles.italic}>exactly as it appears</Text> to your profile.</Text>,
         proofActionText: 'Go to Hacker News',
         proofActionIcon: 'iconfont-open-browser',
@@ -51,14 +55,14 @@ export function propsForPlatform (props: Props) {
       }
     case 'dns':
       return {
-        platformSubtitle: 'dns',
+        ...base,
         descriptionView: <Text type='Body'>Enter the following as a TXT entry in your DNS zone, <Text type='Body' style={globalStyles.italic}>exactly as it appears</Text>. If you need a "name" for you entry, give it "@".</Text>,
         onCompleteText: 'OK posted! Check for it!',
       }
     case 'genericWebSite':
       const [urlRoot, urlWellKnown] = [urlResolve(props.baseUrl || '', '/keybase.txt'), urlResolve(props.baseUrl || '', '/.well-known/keybase.txt')]
       return {
-        platformSubtitle: 'http(s)',
+        ...base,
         descriptionView: (
           <Box>
             <Text type='Body'>Please serve the text below <Text type='Body' style={globalStyles.italic}>exactly as it appears</Text> at one of these URL's.</Text>

--- a/shared/profile/revoke-container.js
+++ b/shared/profile/revoke-container.js
@@ -2,15 +2,15 @@
 import React, {Component} from 'react'
 import Revoke from './revoke'
 import {TypedConnector} from '../util/typed-connect'
-import {bindActionCreators} from 'redux'
 import {submitRevokeProof, cancelRevokeProof} from '../actions/profile'
 
+import type {PlatformsExpanded} from '../constants/types/more'
 import type {Props} from './revoke'
 import type {TypedState} from '../constants/reducer'
 import type {TypedDispatch} from '../constants/types/flux'
 
 type OwnProps = {
-  platform: string,
+  platform: PlatformsExpanded,
   proofId: string,
   platformHandle: string,
 }
@@ -38,12 +38,11 @@ const connector: TypedConnector<TypedState, TypedDispatch<{}>, OwnProps, Props> 
 
 export default connector.connect(
   (state, dispatch, ownProps) => ({
-    waiting: state.profile.revoke.waiting,
+    isWaiting: state.profile.revoke.waiting,
     errorMessage: state.profile.revoke.error,
-    ...bindActionCreators({
-      onCancel: () => cancelRevokeProof(),
-      onRevoke: () => submitRevokeProof(ownProps.proofId),
-    }, dispatch),
-    ...ownProps,
+    onCancel: () => { dispatch(cancelRevokeProof()) },
+    onRevoke: () => { dispatch(submitRevokeProof(ownProps.proofId)) },
+    platform: ownProps.platform,
+    platformHandle: ownProps.platformHandle,
   })
 )(RevokeContainer)

--- a/shared/profile/revoke-container.js
+++ b/shared/profile/revoke-container.js
@@ -1,0 +1,49 @@
+// @flow
+import React, {Component} from 'react'
+import Revoke from './revoke'
+import {TypedConnector} from '../util/typed-connect'
+import {bindActionCreators} from 'redux'
+import {submitRevokeProof, cancelRevokeProof} from '../actions/profile'
+
+import type {Props} from './revoke'
+import type {TypedState} from '../constants/reducer'
+import type {TypedDispatch} from '../constants/types/flux'
+
+type OwnProps = {
+  platform: string,
+  proofId: string,
+  platformHandle: string,
+}
+
+class RevokeContainer extends Component<void, Props, void> {
+  static parseRoute (currentPath, uri) {
+    return {
+      componentAtTop: {
+        title: 'Revoke Proof',
+        props: {
+          platform: currentPath.get('platform'),
+          proofId: currentPath.get('proofId'),
+          platformHandle: currentPath.get('platformHandle'),
+        },
+      },
+    }
+  }
+
+  render () {
+    return <Revoke {...this.props} />
+  }
+}
+
+const connector: TypedConnector<TypedState, TypedDispatch<{}>, OwnProps, Props> = new TypedConnector()
+
+export default connector.connect(
+  (state, dispatch, ownProps) => ({
+    waiting: state.profile.revoke.waiting,
+    errorMessage: state.profile.revoke.error,
+    ...bindActionCreators({
+      onCancel: () => cancelRevokeProof(),
+      onRevoke: () => submitRevokeProof(ownProps.proofId),
+    }, dispatch),
+    ...ownProps,
+  })
+)(RevokeContainer)

--- a/shared/profile/revoke-container.js
+++ b/shared/profile/revoke-container.js
@@ -2,7 +2,7 @@
 import React, {Component} from 'react'
 import Revoke from './revoke'
 import {TypedConnector} from '../util/typed-connect'
-import {submitRevokeProof, cancelRevokeProof} from '../actions/profile'
+import {submitRevokeProof, finishRevoking} from '../actions/profile'
 
 import type {PlatformsExpanded} from '../constants/types/more'
 import type {Props} from './revoke'
@@ -40,7 +40,7 @@ export default connector.connect(
   (state, dispatch, ownProps) => ({
     isWaiting: state.profile.revoke.waiting,
     errorMessage: state.profile.revoke.error,
-    onCancel: () => { dispatch(cancelRevokeProof()) },
+    onCancel: () => { dispatch(finishRevoking()) },
     onRevoke: () => { dispatch(submitRevokeProof(ownProps.proofId)) },
     platform: ownProps.platform,
     platformHandle: ownProps.platformHandle,

--- a/shared/profile/revoke.desktop.js
+++ b/shared/profile/revoke.desktop.js
@@ -8,7 +8,7 @@ import {subtitle as platformSubtitle} from '../util/platforms'
 
 import type {Props} from './revoke'
 
-const Render = ({platform, platformHandle, isHttps, onCancel, onRevoke}: Props) => {
+const Render = ({platform, platformHandle, isHttps, onCancel, onRevoke, isWaiting}: Props) => {
   const platformHandleSubtitle = platformSubtitle(platform, isHttps)
 
   return (
@@ -21,7 +21,7 @@ const Render = ({platform, platformHandle, isHttps, onCancel, onRevoke}: Props) 
         <Text type='Body' style={{marginTop: globalMargins.tiny, textAlign: 'center'}}>You can add it again later, if you change your mind.</Text>
         <Box style={{...globalStyles.flexBoxRow}}>
           <Button type='Secondary' onClick={onCancel} label='Cancel' style={{marginTop: globalMargins.medium}} />
-          <Button type='Danger' onClick={onRevoke} label='Yes, revoke it' style={{marginTop: globalMargins.medium}} />
+          <Button type='Danger' onClick={onRevoke} label='Yes, revoke it' style={{marginTop: globalMargins.medium}} waiting={isWaiting} />
         </Box>
       </Box>
     </Box>

--- a/shared/profile/revoke.desktop.js
+++ b/shared/profile/revoke.desktop.js
@@ -1,31 +1,103 @@
 /* @flow */
 
 import React from 'react'
-import {Box, Text, Button, PlatformIcon} from '../common-adapters'
+import {Box, Text, Icon, Button, PlatformIcon} from '../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import {formatMessage} from './revoke.shared'
 import {subtitle as platformSubtitle} from '../util/platforms'
 
 import type {Props} from './revoke'
 
-const Render = ({platform, platformHandle, isHttps, onCancel, onRevoke, isWaiting}: Props) => {
+const Render = ({platform, platformHandle, errorMessage, isHttps, onCancel, onRevoke, isWaiting}: Props) => {
   const platformHandleSubtitle = platformSubtitle(platform, isHttps)
 
   return (
-    <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
-      <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center', padding: globalMargins.large}}>
+    <Box style={styleContainer}>
+      <Icon style={styleClose} type='iconfont-close' onClick={() => onCancel()} />
+      {errorMessage && <Box style={styleErrorBanner}><Text style={styleErrorBannerText} type='BodySmallSemibold'>{errorMessage}</Text></Box>}
+      <Box style={styleContentContainer}>
         <PlatformIcon platform={platform} overlay={'iconfont-proof-broken'} overlayColor={globalColors.red} size={48} />
-        <Text type='Header' style={{...globalStyles.textDecoration('line-through'), color: globalColors.red}}>{platformHandle}</Text>
-        {!!platformHandleSubtitle && <Text type='Body' style={{color: globalColors.black_10}}>{platformHandleSubtitle}</Text>}
-        <Text type='Header' style={{marginTop: globalMargins.medium, textAlign: 'center'}}>{formatMessage(platform)}</Text>
-        <Text type='Body' style={{marginTop: globalMargins.tiny, textAlign: 'center'}}>You can add it again later, if you change your mind.</Text>
-        <Box style={{...globalStyles.flexBoxRow}}>
-          <Button type='Secondary' onClick={onCancel} label='Cancel' style={{marginTop: globalMargins.medium}} />
-          <Button type='Danger' onClick={onRevoke} label='Yes, revoke it' style={{marginTop: globalMargins.medium}} waiting={isWaiting} />
+        <Text style={stylePlatformUsername} type='Header'>{platformHandle}</Text>
+        {!!platformHandleSubtitle && <Text style={stylePlatformSubtitle} type='Body'>{platformHandleSubtitle}</Text>}
+        <Text style={styleDescriptionText} type='Header'>{formatMessage(platform)}</Text>
+        <Text style={styleReminderText} type='Body'>You can add it again later, if you change your mind.</Text>
+        <Box style={styleButtonsContainer}>
+          <Button type='Secondary' onClick={onCancel} label='Cancel' />
+          <Button type='Danger' onClick={onRevoke} label='Yes, revoke it' waiting={isWaiting} />
         </Box>
       </Box>
     </Box>
   )
+}
+
+const styleContainer = {
+  ...globalStyles.flexBoxColumn,
+  flex: 1,
+  alignItems: 'center',
+  position: 'relative',
+  paddingTop: globalMargins.large,
+  paddingBottom: globalMargins.large,
+  ...globalStyles.scrollable,
+}
+
+const styleClose = {
+  position: 'absolute',
+  top: globalMargins.small,
+  right: globalMargins.small,
+  ...globalStyles.clickable,
+  color: globalColors.black_10,
+}
+
+const styleErrorBanner = {
+  ...globalStyles.flexBoxColumn,
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: '100%',
+  zIndex: 1,
+  minHeight: globalMargins.large,
+  padding: globalMargins.tiny,
+  marginTop: -globalMargins.large,
+  backgroundColor: globalColors.red,
+}
+
+const styleErrorBannerText = {
+  color: globalColors.white,
+  maxWidth: 512,
+  textAlign: 'center',
+}
+
+const styleContentContainer = {
+  ...globalStyles.flexBoxColumn,
+  flex: 1,
+  justifyContent: 'center',
+  alignItems: 'center',
+  margin: globalMargins.large,
+  maxWidth: 512,
+  textAlign: 'center',
+}
+
+const stylePlatformUsername = {
+  ...globalStyles.textDecoration('line-through'),
+  color: globalColors.red,
+}
+
+const stylePlatformSubtitle = {
+  color: globalColors.black_10,
+}
+
+const styleDescriptionText = {
+  marginTop: globalMargins.medium,
+  textAlign: 'center',
+}
+
+const styleReminderText = {
+  marginTop: globalMargins.tiny,
+  textAlign: 'center',
+}
+
+const styleButtonsContainer = {
+  ...globalStyles.flexBoxRow,
+  marginTop: globalMargins.medium,
 }
 
 export default Render

--- a/shared/profile/revoke.desktop.js
+++ b/shared/profile/revoke.desktop.js
@@ -8,8 +8,8 @@ import {subtitle as platformSubtitle} from '../util/platforms'
 
 import type {Props} from './revoke'
 
-const Render = ({platform, platformHandle, errorMessage, isHttps, onCancel, onRevoke, isWaiting}: Props) => {
-  const platformHandleSubtitle = platformSubtitle(platform, isHttps)
+const Render = ({platform, platformHandle, errorMessage, onCancel, onRevoke, isWaiting}: Props) => {
+  const platformHandleSubtitle = platformSubtitle(platform)
 
   return (
     <Box style={styleContainer}>

--- a/shared/profile/revoke.desktop.js
+++ b/shared/profile/revoke.desktop.js
@@ -13,7 +13,7 @@ const Render = ({platform, platformHandle, errorMessage, onCancel, onRevoke, isW
 
   return (
     <Box style={styleContainer}>
-      <Icon style={styleClose} type='iconfont-close' onClick={() => onCancel()} />
+      {!isWaiting && <Icon style={styleClose} type='iconfont-close' onClick={() => onCancel()} />}
       {errorMessage && <Box style={styleErrorBanner}><Text style={styleErrorBannerText} type='BodySmallSemibold'>{errorMessage}</Text></Box>}
       <Box style={styleContentContainer}>
         <PlatformIcon platform={platform} overlay={'iconfont-proof-broken'} overlayColor={globalColors.red} size={48} />
@@ -22,7 +22,7 @@ const Render = ({platform, platformHandle, errorMessage, onCancel, onRevoke, isW
         <Text style={styleDescriptionText} type='Header'>{formatMessage(platform)}</Text>
         <Text style={styleReminderText} type='Body'>You can add it again later, if you change your mind.</Text>
         <Box style={styleButtonsContainer}>
-          <Button type='Secondary' onClick={onCancel} label='Cancel' />
+          <Button type='Secondary' onClick={onCancel} label='Cancel' disabled={isWaiting} />
           <Button type='Danger' onClick={onRevoke} label='Yes, revoke it' waiting={isWaiting} />
         </Box>
       </Box>

--- a/shared/profile/revoke.desktop.js
+++ b/shared/profile/revoke.desktop.js
@@ -3,49 +3,13 @@
 import React from 'react'
 import {Box, Text, Button, PlatformIcon} from '../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
-import {capitalize} from 'lodash'
+import {formatMessage} from './revoke.shared'
+import {subtitle as platformSubtitle} from '../util/platforms'
 
 import type {Props} from './revoke'
-import type {Platforms} from '../constants/types/more'
-
-function formatMessage (platform: Platforms | 'btc') {
-  const prefix = 'Are you sure you want to revoke your'
-  let body
-  switch (platform) {
-    case 'btc':
-      body = 'Bitcoin address'
-      break
-    case 'dns':
-    case 'genericWebSite':
-      body = 'website'
-      break
-    case 'hackernews':
-      body = 'Hacker News identity'
-      break
-    default:
-      body = `${capitalize(platform)} identity`
-  }
-  return `${prefix} ${body}?`
-}
-
-function formatSubtext (platform: Platforms | 'btc', isHttps: boolean) {
-  switch (platform) {
-    case 'btc':
-      return ''
-    case 'dns':
-      return 'dns'
-    case 'genericWebSite':
-      if (isHttps) {
-        return 'https'
-      }
-      return 'http'
-    default:
-      return `@${platform}`
-  }
-}
 
 const Render = ({platform, platformHandle, isHttps, onCancel, onRevoke}: Props) => {
-  const platformHandleSubtitle = formatSubtext(platform, isHttps)
+  const platformHandleSubtitle = platformSubtitle(platform, isHttps)
 
   return (
     <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>

--- a/shared/profile/revoke.js.flow
+++ b/shared/profile/revoke.js.flow
@@ -1,17 +1,19 @@
 // @flow
 
 import {Component} from 'react'
-import type {Platforms} from '../constants/types/more'
+import type {PlatformsExpanded} from '../constants/types/more'
 import type {IconType} from '../common-adapters/icon'
+import type {$Exact} from '../constants/types/more'
 
-export type Props = {
-  platform: Platforms | 'btc', // bitcoin isn't a real proof
+export type PropsLoose = {
+  platform: PlatformsExpanded,
   platformHandle: string,
   errorMessage?: ?string,
-  isHttps: boolean,
   onCancel: () => void,
   onRevoke: () => void,
   isWaiting?: boolean,
 }
+
+export type Props = $Exact<PropsLoose>
 
 export default class Render extends Component<void, Props, void> { }

--- a/shared/profile/revoke.js.flow
+++ b/shared/profile/revoke.js.flow
@@ -7,6 +7,7 @@ import type {IconType} from '../common-adapters/icon'
 export type Props = {
   platform: Platforms | 'btc', // bitcoin isn't a real proof
   platformHandle: string,
+  errorMessage?: ?string,
   isHttps: boolean,
   onCancel: () => void,
   onRevoke: () => void,

--- a/shared/profile/revoke.js.flow
+++ b/shared/profile/revoke.js.flow
@@ -10,7 +10,7 @@ export type Props = {
   isHttps: boolean,
   onCancel: () => void,
   onRevoke: () => void,
+  isWaiting?: boolean,
 }
 
-export default class Render extends Component<void, Props, void> {
-}
+export default class Render extends Component<void, Props, void> { }

--- a/shared/profile/revoke.shared.js
+++ b/shared/profile/revoke.shared.js
@@ -12,6 +12,8 @@ export function formatMessage (platform: PlatformsExpanded) {
       body = 'Bitcoin address'
       break
     case 'dns':
+    case 'http':
+    case 'https':
     case 'genericWebSite':
       body = 'website'
       break

--- a/shared/profile/revoke.shared.js
+++ b/shared/profile/revoke.shared.js
@@ -1,0 +1,26 @@
+/* @flow */
+
+import {capitalize} from 'lodash'
+
+import type {PlatformsExpanded} from '../constants/types/more'
+
+export function formatMessage (platform: PlatformsExpanded) {
+  const prefix = 'Are you sure you want to revoke your'
+  let body
+  switch (platform) {
+    case 'btc':
+      body = 'Bitcoin address'
+      break
+    case 'dns':
+    case 'genericWebSite':
+      body = 'website'
+      break
+    case 'hackernews':
+      body = 'Hacker News identity'
+      break
+    default:
+      body = `${capitalize(platform)} identity`
+  }
+  return `${prefix} ${body}?`
+}
+

--- a/shared/reducers/profile.js
+++ b/shared/reducers/profile.js
@@ -9,6 +9,7 @@ const initialState: State = {
   username: '',
   platform: null,
   usernameValid: true,
+  revoke: {},
 }
 
 export default function (state: State = initialState, action: Actions) {
@@ -38,6 +39,24 @@ export default function (state: State = initialState, action: Actions) {
       return {
         ...state,
         username: action.payload.username,
+      }
+    case Constants.waitingRevokeProof:
+      if (action.error) {
+        break
+      }
+      return {
+        ...state,
+        revoke: {
+          ...state.revoke,
+          waiting: action.payload.waiting,
+        },
+      }
+    case Constants.finishRevokeProof:
+      return {
+        ...state,
+        revoke: action.error
+          ? {error: action.payload.error}
+          : {},
       }
   }
 

--- a/shared/util/platforms.js
+++ b/shared/util/platforms.js
@@ -42,3 +42,22 @@ const ProveMessages = {
 export function proveMessage (platform: PlatformsExpanded) {
   return ProveMessages[platform]
 }
+
+export function subtitle (platform: PlatformsExpanded, isHttps?: boolean) {
+  switch (platform) {
+    case 'btc':
+      return ''
+    case 'dns':
+      return 'dns'
+    case 'genericWebSite':
+      if (isHttps == null) {
+        return 'http(s)'
+      }
+      if (isHttps) {
+        return 'https'
+      }
+      return 'http'
+    default:
+      return `@${platform}`
+  }
+}

--- a/shared/util/platforms.js
+++ b/shared/util/platforms.js
@@ -43,20 +43,16 @@ export function proveMessage (platform: PlatformsExpanded) {
   return ProveMessages[platform]
 }
 
-export function subtitle (platform: PlatformsExpanded, isHttps?: boolean) {
+export function subtitle (platform: PlatformsExpanded): ?string {
   switch (platform) {
     case 'btc':
-      return ''
+      return null
     case 'dns':
-      return 'dns'
+    case 'http':
+    case 'https':
+      return platform
     case 'genericWebSite':
-      if (isHttps == null) {
-        return 'http(s)'
-      }
-      if (isHttps) {
-        return 'https'
-      }
-      return 'http'
+      return 'http(s)'
     default:
       return `@${platform}`
   }


### PR DESCRIPTION
### Main Scope
Pipe through all the RPC gobbledy-gook to make this beautiful frontend feature actually work (the avdl generated stuff is actually super cool). Revoking a proof can be triggered from the drop down menu (kindly added by chromakode a couple commits back).

#### Things to note:
This is branched off of #3693 so that @chrisnojima and I could work concurrently on the integration of proof revoking and adding..

### Extra Goodness
Besides plumbing through the RPC magic, I also changed a couple other things:
- Consolidated some post-proofs/revoke-proofs util stuff
- Brought the post-proofs/revoke-proofs dumb components more into parity with eachother and the designs
- Added an un-specced error banner to the revoke proof page (I copied the standard banner style from the post proofs page)
- Improved typing on the revoke proofs props and some util/helper methods to ensure that all potential platform types were being handled.

### Two PSAs:
- *We should try using PlatformsExpanded everywhere that a `proof.type` is being accessed once it has been processed by actions/trackers because at that point `http` and `https` are valid types, and don't require a separate `isHttps` field.*
- *`bindActionCreators` is a horrible, flow destroying beast that makes all the typed wonderfulness of `TypedConnector` almost entirely worthless. It doesn't really even provide much syntactic benefit, and it definitely negatively outweighs the typing benefits of directly wrapping the functions in `dispatch` manually.*

@keybase/react-hackers 