### PR TITLE
Update Electron 1.3.2

### DIFF
--- a/desktop/npm-shrinkwrap.json
+++ b/desktop/npm-shrinkwrap.json
@@ -1123,9 +1123,9 @@
       "resolved": "https://registry.npmjs.org/electron-positioner/-/electron-positioner-3.0.0.tgz"
     },
     "electron-prebuilt": {
-      "version": "1.2.7",
-      "from": "electron-prebuilt@1.2.7",
-      "resolved": "https://registry.npmjs.org/electron-prebuilt/-/electron-prebuilt-1.2.7.tgz"
+      "version": "1.3.2",
+      "from": "electron-prebuilt@1.3.2",
+      "resolved": "https://registry.npmjs.org/electron-prebuilt/-/electron-prebuilt-1.3.2.tgz"
     },
     "emojis-list": {
       "version": "2.0.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -110,5 +110,5 @@
   "optionalDependencies": {
     "fsevents": "1.0.14"
   },
-  "keybaseVendoredDependencies": "https://github.com/keybase/js-vendor-desktop.git#ac1deb16af4f20f19de821157ed0587fb73e85c2"
+  "keybaseVendoredDependencies": "https://github.com/keybase/js-vendor-desktop.git#9a9338c3a5847223b44db6449a097da5730f4727"
 }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "deep-diff": "^0.3.4",
     "deep-equal": "^1.0.1",
+    "electron-prebuilt": "1.3.2",
     "framed-msgpack-rpc": "git://github.com/keybase/node-framed-msgpack-rpc#f3e1a3eb410e0bcde950bae14ceef7015c7315c8",
     "getenv": "0.6.0",
     "immutable": "3.8.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -110,5 +110,5 @@
   "optionalDependencies": {
     "fsevents": "1.0.14"
   },
-  "keybaseVendoredDependencies": "https://github.com/keybase/js-vendor-desktop.git#9a9338c3a5847223b44db6449a097da5730f4727"
+  "keybaseVendoredDependencies": "https://github.com/keybase/js-vendor-desktop.git#69a46559ad44c6c76beed9aa9c91e70d8d9abba4"
 }


### PR DESCRIPTION
What I had trouble with:

- bad npm version
- this/repo/path ambiguous
- `npm i -S -E package@ver` and commit before running vendor-update
- that problem with lots of changes in shrinkwrap