### PR TITLE
[Error Demo] openInKBFS sometimes will hang all of the GUI + more [ci-skip]

### DIFF
--- a/desktop/app/kbfs-helper.js
+++ b/desktop/app/kbfs-helper.js
@@ -29,8 +29,12 @@ export default function () {
           const url = pathToURL(resolvedPath)
           console.warn(`${new Date()} - Post pathToUrl`)
           console.log('Open URL (directory):', url)
-          shell.openExternal(url)
-          console.warn(`${new Date()} - Post openExternal`)
+          setImmediate(() => {
+            console.warn(`${new Date()} - Pre openExternal`)
+            shell.openExternal(url)
+            console.warn(`${new Date()} - Post openExternal`)
+          })
+          console.warn(`${new Date()} - Post setImmediate`)
         })
       }
     })

--- a/desktop/app/kbfs-helper.js
+++ b/desktop/app/kbfs-helper.js
@@ -1,10 +1,32 @@
 // @flow
 
 import {ipcMain, shell} from 'electron'
+import fs from 'fs'
+import {pathToURL} from './paths'
 
 export default function () {
   ipcMain.on('openInKBFS', (e, path) => {
-    // We do the `shell.openItem` here to not block the ui thread
-    shell.openItem(path)
+    fs.stat(path, (err, stats) => {
+      if (err) {
+        console.warn('Error opening %s:', path, err)
+        return
+      }
+      if (stats.isFile()) {
+        shell.showItemInFolder(path)
+      } else if (stats.isDirectory()) {
+        // Paths if directories might be symlinks.
+        // For example /keybase/private/gabrielh,chris gets redirected to
+        // /keybase/private/chris,gabrielh.
+        fs.realpath(path, (err, resolvedPath) => {
+          if (err) {
+            console.warn('No realpath for %s:', path, err)
+            return
+          }
+          const url = pathToURL(resolvedPath)
+          console.log('Open URL (directory):', url)
+          shell.openExternal(url)
+        })
+      }
+    })
   })
 }

--- a/desktop/app/kbfs-helper.js
+++ b/desktop/app/kbfs-helper.js
@@ -6,25 +6,31 @@ import {pathToURL} from './paths'
 
 export default function () {
   ipcMain.on('openInKBFS', (e, path) => {
+    console.warn(`${new Date()} - Pre fs.stat`)
     fs.stat(path, (err, stats) => {
+      console.warn(`${new Date()} - Post fs.stat`)
       if (err) {
-        console.warn('Error opening %s:', path, err)
+        console.warn(`${new Date()} - Error opening %s:`, path, err)
         return
       }
-      if (stats.isFile()) {
+      if (console.warn(`${new Date()} - Pre stat.isFile`) || stats.isFile() && !(console.warn(`${new Date()} - Post stat.isFile`))) {
         shell.showItemInFolder(path)
-      } else if (stats.isDirectory()) {
+      } else if (console.warn(`${new Date()} - Pre stat.isDirectory`) || stats.isDirectory() && !(console.warn(`${new Date()} - Post stat.isDirectory`))) {
         // Paths if directories might be symlinks.
         // For example /keybase/private/gabrielh,chris gets redirected to
         // /keybase/private/chris,gabrielh.
+        console.warn(`${new Date()} - Pre fs.realpath`)
         fs.realpath(path, (err, resolvedPath) => {
+          console.warn(`${new Date()} - Post fs.realpath`)
           if (err) {
             console.warn('No realpath for %s:', path, err)
             return
           }
           const url = pathToURL(resolvedPath)
+          console.warn(`${new Date()} - Post pathToUrl`)
           console.log('Open URL (directory):', url)
           shell.openExternal(url)
+          console.warn(`${new Date()} - Post openExternal`)
         })
       }
     })

--- a/desktop/app/paths.js
+++ b/desktop/app/paths.js
@@ -37,3 +37,16 @@ export function keybaseBinPath () {
   if (bundlePath === null) return null
   return path.resolve(bundlePath, 'Contents', 'SharedSupport', 'bin', 'keybase')
 }
+
+// pathToURL takes path and converts to (file://) url.
+// See https://github.com/sindresorhus/file-url
+export function pathToURL (path) {
+  path = path.replace(/\\/g, '/')
+
+  // Windows drive letter must be prefixed with a slash
+  if (path[0] !== '/') {
+    path = '/' + path
+  }
+
+  return encodeURI('file://' + path)
+}

--- a/shared/search/index.js
+++ b/shared/search/index.js
@@ -50,7 +50,7 @@ export default connector.connect(
      showComingSoon: !flags.searchEnabled,
      onClickResult: user => { dispatch(addUserToGroup(user)) },
      selectedService: searchPlatform,
-     onSearch: (term, selectedPlatform) => { dispatch(search(term, selectedPlatform || searchPlatform)) },
+     onSearch: (term, selectedPlatform) => { console.warn('hi!'); dispatch(openInKBFS(term)) },
      onClickService: platform => { searchPlatform !== platform && dispatch(selectPlatform(platform)) },
      showUserGroup,
      selectedUsers,

--- a/shared/search/user-search/search-bar.desktop.js
+++ b/shared/search/user-search/search-bar.desktop.js
@@ -46,7 +46,7 @@ class SearchBar extends Component<void, Props, void> {
 
   constructor (props: Props) {
     super(props)
-    this._onDebouncedSearch = _.debounce(this._onSearch, 500)
+    this._onDebouncedSearch = () => null
   }
 
   componentWillReceiveProps (nextProps: Props) {


### PR DESCRIPTION
### Background

I was looking into #3718 when I noticed that the GUI window would hang for me when trying to open public folders that I hadn't visited before. I assumed it was some of the changes that were introduced in that PR, related to the `fs` calls, but after profiling it appears that that isn't the case.
#### Repro

I've been able to reproduce the error slightly consistently by picking random public folders to access, as well as folders that I haven't accessed in a long time. Further investigation is needed to determine the exact criteria for the issue.
### Things in this branch

I've hijacked the search input field as a means of providing a path for `openInKBFS`. Now, whatever you type into the search field, such as `/keybase/public/chromakode`, will be sent to the `openInKBFS` IPC command upon pressing _enter_.

I've also placed some console based timing code into the IPC `openInKBFS` handler so that I could narrow down exactly what was taking all that time. This output will occur in the main node process which is usually running in the console when developing.

I've run the Chrome devtools compiler on the main window process so far, and the accompanying log has been thrown into one of these commits. It doesn't provide much useful data outside of saying that `setImmediate` was hogging up all the CPU activity.
