### PR TITLE
Hookup follow/unfollow to profile. Use tracker store's reason in profile

### DIFF
--- a/desktop/renderer/style.css
+++ b/desktop/renderer/style.css
@@ -154,6 +154,6 @@ body {
 }
 
 .fade-anim-leave.fade-anim-leave-active {
-  opacity: 0.01;
+  opacity: 0;
   transition: opacity 250ms ease-in-out;
 }

--- a/shared/common-adapters/user-proofs.desktop.js
+++ b/shared/common-adapters/user-proofs.desktop.js
@@ -146,7 +146,7 @@ export default class ProofsRender extends Component {
               {[147, 77, 117].map((w, idx) => <LoadingProofRow key={idx} textBlockWidth={w} style={pad(idx)} />)}
             </Box>)
           : (
-            <Box key='non-loading' style={{...styleDoneLoading(loading)}}>
+            <Box key='non-loading'>
               {this.props.proofs && this.props.proofs.map((p, idx) =>
                 <ProofRow
                   key={`${p.id || ''}${p.type}`}
@@ -185,11 +185,6 @@ const styleLoading = {
   paddingLeft: globalMargins.medium,
   paddingRight: globalMargins.medium,
 }
-
-const styleDoneLoading = (loading) => ({
-  ...globalStyles.fadeOpacity,
-  opacity: !loading ? 1 : 0,
-})
 
 const styleRow = {
   ...globalStyles.flexBoxRow,

--- a/shared/constants/tracker.js
+++ b/shared/constants/tracker.js
@@ -6,6 +6,7 @@ import type {Folder} from '../folders/list'
 import type {UserInfo} from '../common-adapters/user-bio'
 import type {PlatformsExpanded} from '../constants/types/more'
 import type {Time} from '../constants/types/flow-types'
+import type {FriendshipUserInfo} from '../profile/friendships'
 
 // Types
 export type Proof = {
@@ -118,6 +119,8 @@ export type TrackerState = {
   username: string,
   shouldFollow: ?boolean,
   reason: ?string,
+  trackers: Array<FriendshipUserInfo>,
+  tracking: Array<FriendshipUserInfo>,
   waiting: boolean,
   userInfo: UserInfo,
   proofs: Array<Proof>,

--- a/shared/profile/dumb.js
+++ b/shared/profile/dumb.js
@@ -143,6 +143,7 @@ const propsBase: RenderProps = {
   trackerState: normal,
   currentlyFollowing: false,
   onPushProfile: username => console.log('onpush', username),
+  reason: '',
   onBack: () => console.log('onBack'),
   refresh: () => console.log('refresh'),
   onFollow: () => console.log('onFollow'),

--- a/shared/profile/index.js
+++ b/shared/profile/index.js
@@ -51,7 +51,6 @@ class Profile extends Component<void, ?Props, void> {
         showComingSoon={!flags.tabProfileEnabled}
         {...this.props}
         proofs={this.props.proofs || []}
-        loading={this.props.loading}
         onBack={!this.props.profileIsRoot ? this.props.onBack : undefined}
       />
     ) : (
@@ -102,7 +101,7 @@ export default connector.connect((state, dispatch, ownProps) => {
 
   const trackerState = stateProps.trackers[username]
 
-  if (trackerState.type !== 'tracker') {
+  if (trackerState && trackerState.type !== 'tracker') {
     console.warn('Expected a tracker type, trying to show profile for non user')
     return null
   }
@@ -115,8 +114,8 @@ export default connector.connect((state, dispatch, ownProps) => {
     bioEditFns,
     username,
     refresh,
-    followers: trackerState.trackers || [],
-    following: trackerState.tracking || [],
+    followers: trackerState ? trackerState.trackers : [],
+    following: trackerState ? trackerState.tracking : [],
     onMissingProofClick,
     onRecheckProof: () => console.log('TODO'),
     onRevokeProof: () => console.log('TODO'),

--- a/shared/profile/index.js
+++ b/shared/profile/index.js
@@ -1,16 +1,24 @@
 // @flow
 import React, {Component} from 'react'
-import {connect} from 'react-redux'
+import {Box, Text} from '../common-adapters'
 import Render from './render'
 import EditProfile from './edit-profile'
-import type {Props} from './render'
 import flags from '../util/feature-flags'
-import {getProfile, updateTrackers} from '../actions/tracker'
 import {routeAppend, navigateUp} from '../actions/router'
 import {openInKBFS} from '../actions/kbfs'
+import * as trackerActions from '../actions/tracker'
 import {isLoading} from '../constants/tracker'
+import {TypedConnector} from '../util/typed-connect'
 
-class Profile extends Component<void, Props, void> {
+import type {Props} from './render'
+import type {TypedState} from '../constants/reducer'
+import type {TypedDispatch, Action} from '../constants/types/flux'
+
+type OwnProps = {
+  username?: string,
+}
+
+class Profile extends Component<void, ?Props, void> {
   static parseRoute (currentPath, uri) {
     return {
       componentAtTop: {
@@ -27,67 +35,92 @@ class Profile extends Component<void, Props, void> {
   }
 
   componentDidMount () {
-    this.props.refresh(this.props.username)
+    this.props && this.props.refresh()
   }
 
   componentWillReceiveProps (nextProps) {
-    if (nextProps.username !== this.props.username) {
-      this.props.refresh(nextProps.username)
+    const oldUsername = this.props && this.props.username
+    if (nextProps && nextProps.username !== oldUsername) {
+      nextProps.refresh()
     }
   }
 
   render () {
-    return (
+    return this.props ? (
       <Render
         showComingSoon={!flags.tabProfileEnabled}
         {...this.props}
         proofs={this.props.proofs || []}
         loading={this.props.loading}
         onBack={!this.props.profileIsRoot ? this.props.onBack : undefined}
-        followers={this.props.trackers || []}
-        following={this.props.tracking || []}
       />
+    ) : (
+      <Box><Text type='Error'>Could not derive props; check the log</Text></Box>
     )
   }
 }
 
-export default connect(
-  state => ({
+const connector: TypedConnector<TypedState, TypedDispatch<Action>, OwnProps, ?Props> = new TypedConnector()
+
+export default connector.connect((state, dispatch, ownProps) => {
+  const stateProps = {
     myUsername: state.config.username,
     trackers: state.tracker.trackers,
-  }),
-  dispatch => ({
-    refresh: username => {
-      dispatch(getProfile(username))
-      dispatch(updateTrackers(username))
-    },
-    onUserClick: username => { dispatch(routeAppend({path: 'profile', username})) },
-    onBack: () => dispatch(navigateUp()),
-    onFolderClick: folder => dispatch(openInKBFS(folder.path)),
-    onEditProfile: () => dispatch(routeAppend({path: 'editprofile'})),
-  }),
-  (stateProps, dispatchProps, ownProps) => {
-    const username = ownProps.username || stateProps.myUsername
-    const isYou = username === stateProps.myUsername
-    const onEditProfile = () => dispatchProps.onEditProfile()
-    const bioEditFns = isYou && {
-      onBioEdit: onEditProfile,
-      onEditAvatarClick: onEditProfile,
-      onEditProfile: onEditProfile,
-      onLocationEdit: onEditProfile,
-      onNameEdit: onEditProfile,
-      onMissingProofClick: () => console.log('TODO onMissingProofClick'),
-    }
-
-    return {
-      ...ownProps,
-      ...stateProps.trackers[username],
-      ...dispatchProps,
-      isYou,
-      bioEditFns,
-      username,
-      refresh: username => dispatchProps.refresh(username),
-      loading: isLoading(stateProps.trackers[username]),
-    }
   }
-)(Profile)
+
+  const username = ownProps.username || stateProps.myUsername || ''
+
+  const {getProfile, updateTrackers, onFollow, onUnfollow} = trackerActions
+
+  const refresh = () => {
+    dispatch(getProfile(username))
+    dispatch(updateTrackers(username))
+  }
+
+  const dispatchProps = {
+    onUserClick: username => { dispatch(routeAppend({path: 'profile', username})) },
+    onBack: () => { dispatch(navigateUp()) },
+    onFolderClick: folder => { dispatch(openInKBFS(folder.path)) },
+    onEditProfile: () => { dispatch(routeAppend({path: 'editprofile'})) },
+    onFollow: () => { dispatch(onFollow(username, false)) },
+    onUnfollow: () => { dispatch(onUnfollow(username)) },
+    onAcceptProofs: () => { dispatch(onFollow(username, false)) },
+  }
+
+  const onMissingProofClick = () => { console.log('TODO onMissingProofClick') }
+
+  const isYou = username === stateProps.myUsername
+  const onEditProfile = () => { dispatchProps.onEditProfile() }
+  const bioEditFns = isYou ? {
+    onBioEdit: onEditProfile,
+    onEditAvatarClick: onEditProfile,
+    onEditProfile: onEditProfile,
+    onLocationEdit: onEditProfile,
+    onNameEdit: onEditProfile,
+    onMissingProofClick,
+  } : null
+
+  const trackerState = stateProps.trackers[username]
+
+  if (trackerState.type !== 'tracker') {
+    console.warn('Expected a tracker type, trying to show profile for non user')
+    return null
+  }
+
+  return {
+    ...ownProps,
+    ...trackerState,
+    ...dispatchProps,
+    isYou,
+    bioEditFns,
+    username,
+    refresh,
+    followers: trackerState.trackers || [],
+    following: trackerState.tracking || [],
+    onMissingProofClick,
+    onRecheckProof: () => console.log('TODO'),
+    onRevokeProof: () => console.log('TODO'),
+    onViewProof: () => console.log('TODO'),
+    loading: isLoading(trackerState),
+  }
+})(Profile)

--- a/shared/profile/render.desktop.js
+++ b/shared/profile/render.desktop.js
@@ -169,7 +169,7 @@ class Render extends Component<void, Props, State> {
           proofNotice = 'Some of your proofs are unreachable.'
         }
       } else {
-        proofNotice = `Some of ${this.props.username}'s proofs have changed since you last tracked them.`
+        proofNotice = this.props.reason
       }
     }
 

--- a/shared/profile/render.js.flow
+++ b/shared/profile/render.js.flow
@@ -32,6 +32,7 @@ export type Props = {
   tlfs: Array<Folder>,
   followers: Array<FriendshipUserInfo>,
   following: Array<FriendshipUserInfo>,
+  reason: ?string,
 }
 
 export default class Render extends Component<void, Props, void> { }

--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -66,6 +66,8 @@ function initialTrackerState (username: string): TrackerState {
     trackToken: null,
     trackerState: initialProofState,
     type: 'tracker',
+    trackers: [],
+    tracking: [],
     userInfo: {
       fullname: '', // TODO get this info,
       followersCount: -1,
@@ -197,8 +199,8 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
     }
     case Constants.updateProofState:
       const proofsGeneralState = overviewStateOfProofs(state.proofs)
-      const trackerMessage = deriveTrackerMessage(state.username, proofsGeneralState)
-      const reason = state.currentlyFollowing && trackerMessage ? trackerMessage : state.reason
+      const trackerMessage = deriveTrackerMessage(state.username, state.currentlyFollowing, proofsGeneralState)
+      const reason = trackerMessage || state.reason
 
       return {
         ...state,
@@ -619,9 +621,10 @@ export function deriveSimpleProofState (
 
 function deriveTrackerMessage (
   username: string,
+  currentlyFollowing: boolean,
   {allOk, anyDeletedProofs, anyUnreachableProofs, anyUpgradedProofs, anyNewProofs}: {allOk: boolean, anyDeletedProofs: boolean, anyUnreachableProofs: boolean, anyUpgradedProofs: boolean, anyNewProofs: boolean}
 ): ?string {
-  if (allOk) {
+  if (allOk || !currentlyFollowing) {
     return null
   } else if (anyDeletedProofs || anyUnreachableProofs) {
     return `Some of ${username}’s proofs have changed since you last followed them.`


### PR DESCRIPTION
@keybase/react-hackers 

This makes us use the same reason for the profile view as what the tracker uses (if it isn't your own profile).

Also hooks up the following/onfollowing to the profile, and switches to using the typed connector which caught this and other missing props field.