### PR TITLE
protocol: add file edit notification protocol for KBFS

### DIFF
--- a/go/client/cmd_show_notifications.go
+++ b/go/client/cmd_show_notifications.go
@@ -124,6 +124,11 @@ func (d *notificationDisplay) FSActivity(_ context.Context, notification keybase
 	return d.printf("KBFS notification: %+v\n", notification)
 }
 
+func (d *notificationDisplay) FSEditListResponse(
+	_ context.Context, arg keybase1.FSEditListResponseArg) error {
+	return d.printf("KBFS edit list response: %+v\n", arg)
+}
+
 func (d *notificationDisplay) TrackingChanged(_ context.Context, arg keybase1.TrackingChangedArg) error {
 	return d.printf("Tracking changed for %s (%s)\n", arg.Username, arg.Uid)
 }

--- a/go/protocol/kbfs_common.go
+++ b/go/protocol/kbfs_common.go
@@ -25,6 +25,10 @@ const (
 	FSNotificationType_REKEYING        FSNotificationType = 4
 	FSNotificationType_CONNECTION      FSNotificationType = 5
 	FSNotificationType_MD_READ_SUCCESS FSNotificationType = 6
+	FSNotificationType_FILE_CREATED    FSNotificationType = 7
+	FSNotificationType_FILE_MODIFIED   FSNotificationType = 8
+	FSNotificationType_FILE_DELETED    FSNotificationType = 9
+	FSNotificationType_FILE_RENAMED    FSNotificationType = 10
 )
 
 type FSErrorType int
@@ -51,6 +55,13 @@ type FSNotification struct {
 	NotificationType     FSNotificationType `codec:"notificationType" json:"notificationType"`
 	ErrorType            FSErrorType        `codec:"errorType" json:"errorType"`
 	Params               map[string]string  `codec:"params" json:"params"`
+	WriterUid            UID                `codec:"writerUid" json:"writerUid"`
+	LocalTime            Time               `codec:"localTime" json:"localTime"`
+}
+
+type FSEditListRequest struct {
+	Folder    Folder `codec:"folder" json:"folder"`
+	RequestID int    `codec:"requestID" json:"requestID"`
 }
 
 type KbfsCommonInterface interface {

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -27,3 +27,9 @@ func (h *KBFSHandler) FSEvent(_ context.Context, arg keybase1.FSNotification) er
 	h.G().NotifyRouter.HandleFSActivity(arg)
 	return nil
 }
+
+func (h *KBFSHandler) FSEditList(_ context.Context, _ keybase1.FSEditListArg) (
+	err error) {
+	// TODO: route these messages.
+	return nil
+}

--- a/protocol/avdl/kbfs.avdl
+++ b/protocol/avdl/kbfs.avdl
@@ -20,4 +20,9 @@ protocol kbfs {
         */
   void FSEvent(FSNotification event);
 
+  /**
+    kbfs calls this as a response to receiving an FSEditListRequest with a
+    given requestID.
+        */
+  void FSEditList(array<FSNotification> edits, int requestID);
 }

--- a/protocol/avdl/kbfs_common.avdl
+++ b/protocol/avdl/kbfs_common.avdl
@@ -14,7 +14,11 @@ protocol kbfsCommon {
     VERIFYING_3,
     REKEYING_4,
     CONNECTION_5,
-    MD_READ_SUCCESS_6
+    MD_READ_SUCCESS_6,
+    FILE_CREATED_7,
+    FILE_MODIFIED_8,
+    FILE_DELETED_9,
+    FILE_RENAMED_10
   }
 
   enum FSErrorType {
@@ -39,6 +43,12 @@ protocol kbfsCommon {
     FSNotificationType notificationType;
     FSErrorType errorType;
     map<string> params;
+    UID writerUid;
+    Time localTime;
   }
 
+  record FSEditListRequest {
+    Folder folder;
+    int requestID;
+  }
 }

--- a/protocol/avdl/notify_fs.avdl
+++ b/protocol/avdl/notify_fs.avdl
@@ -6,4 +6,5 @@ protocol NotifyFS {
   @notify("")
   void FSActivity(FSNotification notification);
 
+  void FSEditListResponse(array<FSNotification> edits, int requestID) oneway;
 }

--- a/protocol/avdl/notify_fs_request.avdl
+++ b/protocol/avdl/notify_fs_request.avdl
@@ -1,0 +1,8 @@
+@namespace("keybase.1")
+protocol NotifyFSRequest {
+
+  import idl "kbfs_common.avdl";
+
+  @notify("")
+  void FSEditListRequest(FSEditListRequest req);
+}

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -380,6 +380,11 @@ export type ExtendedStatus = {
   platformInfo: PlatformInfo,
 }
 
+export type FSEditListRequest = {
+  folder: Folder,
+  requestID: int,
+}
+
 export type FSErrorType =
     0 // ACCESS_DENIED_0
   | 1 // USER_NOT_FOUND_1
@@ -401,6 +406,8 @@ export type FSNotification = {
   notificationType: FSNotificationType,
   errorType: FSErrorType,
   params: {[key: string]: string},
+  writerUid: UID,
+  localTime: Time,
 }
 
 export type FSNotificationType =
@@ -411,6 +418,10 @@ export type FSNotificationType =
   | 4 // REKEYING_4
   | 5 // CONNECTION_5
   | 6 // MD_READ_SUCCESS_6
+  | 7 // FILE_CREATED_7
+  | 8 // FILE_MODIFIED_8
+  | 9 // FILE_DELETED_9
+  | 10 // FILE_RENAMED_10
 
 export type FSStatusCode =
     0 // START_0
@@ -778,6 +789,29 @@ export function NotifyFSFSActivityRpc (request: $Exact<{
   incomingCallMap?: incomingCallMapType,
   callback?: (null | (err: ?any) => void)}>) {
   engine.rpc({...request, method: 'NotifyFS.FSActivity'})
+}
+export type NotifyFSFSEditListResponseRpcParam = $Exact<{
+  edits?: ?Array<FSNotification>,
+  requestID: int
+}>
+
+export function NotifyFSFSEditListResponseRpc (request: $Exact<{
+  param: NotifyFSFSEditListResponseRpcParam,
+  waitingHandler?: (waiting: boolean, method: string, sessionID: string) => void,
+  incomingCallMap?: incomingCallMapType,
+  callback?: (null | (err: ?any) => void)}>) {
+  engine.rpc({...request, method: 'NotifyFS.FSEditListResponse'})
+}
+export type NotifyFSRequestFSEditListRequestRpcParam = $Exact<{
+  req: FSEditListRequest
+}>
+
+export function NotifyFSRequestFSEditListRequestRpc (request: $Exact<{
+  param: NotifyFSRequestFSEditListRequestRpcParam,
+  waitingHandler?: (waiting: boolean, method: string, sessionID: string) => void,
+  incomingCallMap?: incomingCallMapType,
+  callback?: (null | (err: ?any) => void)}>) {
+  engine.rpc({...request, method: 'NotifyFSRequest.FSEditListRequest'})
 }
 export type NotifyFavoritesFavoritesChangedRpcParam = $Exact<{
   uid: UID
@@ -2283,6 +2317,18 @@ export function identifyUiStartRpc (request: $Exact<{
   incomingCallMap?: incomingCallMapType,
   callback?: (null | (err: ?any) => void)}>) {
   engine.rpc({...request, method: 'identifyUi.start'})
+}
+export type kbfsFSEditListRpcParam = $Exact<{
+  edits?: ?Array<FSNotification>,
+  requestID: int
+}>
+
+export function kbfsFSEditListRpc (request: $Exact<{
+  param: kbfsFSEditListRpcParam,
+  waitingHandler?: (waiting: boolean, method: string, sessionID: string) => void,
+  incomingCallMap?: incomingCallMapType,
+  callback?: (null | (err: ?any) => void)}>) {
+  engine.rpc({...request, method: 'kbfs.FSEditList'})
 }
 export type kbfsFSEventRpcParam = $Exact<{
   event: FSNotification
@@ -3894,6 +3940,8 @@ export type rpc =
   | Kex2ProvisionerKexStartRpc
   | NotifyAppExitRpc
   | NotifyFSFSActivityRpc
+  | NotifyFSFSEditListResponseRpc
+  | NotifyFSRequestFSEditListRequestRpc
   | NotifyFavoritesFavoritesChangedRpc
   | NotifyKeyfamilyKeyfamilyChangedRpc
   | NotifyPaperKeyPaperKeyCachedRpc
@@ -3985,6 +4033,7 @@ export type rpc =
   | identifyUiReportLastTrackRpc
   | identifyUiReportTrackTokenRpc
   | identifyUiStartRpc
+  | kbfsFSEditListRpc
   | kbfsFSEventRpc
   | logRegisterLoggerRpc
   | logUiLogRpc
@@ -4935,6 +4984,16 @@ export type incomingCallMapType = $Exact<{
       result: () => void
     }
   ) => void,
+  'keybase.1.kbfs.FSEditList'?: (
+    params: $Exact<{
+      edits?: ?Array<FSNotification>,
+      requestID: int
+    }>,
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
+    }
+  ) => void,
   'keybase.1.Kex2Provisionee.hello'?: (
     params: $Exact<{
       uid: UID,
@@ -5375,6 +5434,23 @@ export type incomingCallMapType = $Exact<{
   'keybase.1.NotifyFS.FSActivity'?: (
     params: $Exact<{
       notification: FSNotification
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyFS.FSEditListResponse'?: (
+    params: $Exact<{
+      edits?: ?Array<FSNotification>,
+      requestID: int
+    }>,
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
+    }
+  ) => void,
+  'keybase.1.NotifyFSRequest.FSEditListRequest'?: (
+    params: $Exact<{
+      req: FSEditListRequest
     }> /* ,
     response: {} // Notify call
     */

--- a/protocol/js/keybase-v1.js
+++ b/protocol/js/keybase-v1.js
@@ -230,6 +230,10 @@ export const kbfsCommon = {
     'rekeying': 4,
     'connection': 5,
     'mdReadSuccess': 6,
+    'fileCreated': 7,
+    'fileModified': 8,
+    'fileDeleted': 9,
+    'fileRenamed': 10,
   },
   'FSErrorType': {
     'accessDenied': 0,
@@ -269,6 +273,8 @@ export const notifyCtl = {}
 export const NotifyFavorites = {}
 
 export const NotifyFS = {}
+
+export const NotifyFSRequest = {}
 
 export const NotifyKeyfamily = {}
 
@@ -504,6 +510,7 @@ export default {
   notifyCtl,
   NotifyFavorites,
   NotifyFS,
+  NotifyFSRequest,
   NotifyKeyfamily,
   NotifyPaperKey,
   NotifyService,

--- a/protocol/json/kbfs.json
+++ b/protocol/json/kbfs.json
@@ -17,6 +17,23 @@
       ],
       "response": null,
       "doc": "Idea is that kbfs would call the function below whenever these actions are\n    performed on a file.\n\n    Note that this list/interface is very temporary and highly likely to change\n    significantly.\n\n    It is just a starting point to get kbfs notifications through the daemon to\n    the clients."
+    },
+    "FSEditList": {
+      "request": [
+        {
+          "name": "edits",
+          "type": {
+            "type": "array",
+            "items": "FSNotification"
+          }
+        },
+        {
+          "name": "requestID",
+          "type": "int"
+        }
+      ],
+      "response": null,
+      "doc": "kbfs calls this as a response to receiving an FSEditListRequest with a\n    given requestID."
     }
   },
   "namespace": "keybase.1"

--- a/protocol/json/kbfs_common.json
+++ b/protocol/json/kbfs_common.json
@@ -21,7 +21,11 @@
         "VERIFYING_3",
         "REKEYING_4",
         "CONNECTION_5",
-        "MD_READ_SUCCESS_6"
+        "MD_READ_SUCCESS_6",
+        "FILE_CREATED_7",
+        "FILE_MODIFIED_8",
+        "FILE_DELETED_9",
+        "FILE_RENAMED_10"
       ]
     },
     {
@@ -75,6 +79,28 @@
             "values": "string"
           },
           "name": "params"
+        },
+        {
+          "type": "UID",
+          "name": "writerUid"
+        },
+        {
+          "type": "Time",
+          "name": "localTime"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "FSEditListRequest",
+      "fields": [
+        {
+          "type": "Folder",
+          "name": "folder"
+        },
+        {
+          "type": "int",
+          "name": "requestID"
         }
       ]
     }

--- a/protocol/json/notify_fs.json
+++ b/protocol/json/notify_fs.json
@@ -17,6 +17,23 @@
       ],
       "response": null,
       "notify": ""
+    },
+    "FSEditListResponse": {
+      "request": [
+        {
+          "name": "edits",
+          "type": {
+            "type": "array",
+            "items": "FSNotification"
+          }
+        },
+        {
+          "name": "requestID",
+          "type": "int"
+        }
+      ],
+      "response": null,
+      "oneway": true
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -380,6 +380,11 @@ export type ExtendedStatus = {
   platformInfo: PlatformInfo,
 }
 
+export type FSEditListRequest = {
+  folder: Folder,
+  requestID: int,
+}
+
 export type FSErrorType =
     0 // ACCESS_DENIED_0
   | 1 // USER_NOT_FOUND_1
@@ -401,6 +406,8 @@ export type FSNotification = {
   notificationType: FSNotificationType,
   errorType: FSErrorType,
   params: {[key: string]: string},
+  writerUid: UID,
+  localTime: Time,
 }
 
 export type FSNotificationType =
@@ -411,6 +418,10 @@ export type FSNotificationType =
   | 4 // REKEYING_4
   | 5 // CONNECTION_5
   | 6 // MD_READ_SUCCESS_6
+  | 7 // FILE_CREATED_7
+  | 8 // FILE_MODIFIED_8
+  | 9 // FILE_DELETED_9
+  | 10 // FILE_RENAMED_10
 
 export type FSStatusCode =
     0 // START_0
@@ -778,6 +789,29 @@ export function NotifyFSFSActivityRpc (request: $Exact<{
   incomingCallMap?: incomingCallMapType,
   callback?: (null | (err: ?any) => void)}>) {
   engine.rpc({...request, method: 'NotifyFS.FSActivity'})
+}
+export type NotifyFSFSEditListResponseRpcParam = $Exact<{
+  edits?: ?Array<FSNotification>,
+  requestID: int
+}>
+
+export function NotifyFSFSEditListResponseRpc (request: $Exact<{
+  param: NotifyFSFSEditListResponseRpcParam,
+  waitingHandler?: (waiting: boolean, method: string, sessionID: string) => void,
+  incomingCallMap?: incomingCallMapType,
+  callback?: (null | (err: ?any) => void)}>) {
+  engine.rpc({...request, method: 'NotifyFS.FSEditListResponse'})
+}
+export type NotifyFSRequestFSEditListRequestRpcParam = $Exact<{
+  req: FSEditListRequest
+}>
+
+export function NotifyFSRequestFSEditListRequestRpc (request: $Exact<{
+  param: NotifyFSRequestFSEditListRequestRpcParam,
+  waitingHandler?: (waiting: boolean, method: string, sessionID: string) => void,
+  incomingCallMap?: incomingCallMapType,
+  callback?: (null | (err: ?any) => void)}>) {
+  engine.rpc({...request, method: 'NotifyFSRequest.FSEditListRequest'})
 }
 export type NotifyFavoritesFavoritesChangedRpcParam = $Exact<{
   uid: UID
@@ -2283,6 +2317,18 @@ export function identifyUiStartRpc (request: $Exact<{
   incomingCallMap?: incomingCallMapType,
   callback?: (null | (err: ?any) => void)}>) {
   engine.rpc({...request, method: 'identifyUi.start'})
+}
+export type kbfsFSEditListRpcParam = $Exact<{
+  edits?: ?Array<FSNotification>,
+  requestID: int
+}>
+
+export function kbfsFSEditListRpc (request: $Exact<{
+  param: kbfsFSEditListRpcParam,
+  waitingHandler?: (waiting: boolean, method: string, sessionID: string) => void,
+  incomingCallMap?: incomingCallMapType,
+  callback?: (null | (err: ?any) => void)}>) {
+  engine.rpc({...request, method: 'kbfs.FSEditList'})
 }
 export type kbfsFSEventRpcParam = $Exact<{
   event: FSNotification
@@ -3894,6 +3940,8 @@ export type rpc =
   | Kex2ProvisionerKexStartRpc
   | NotifyAppExitRpc
   | NotifyFSFSActivityRpc
+  | NotifyFSFSEditListResponseRpc
+  | NotifyFSRequestFSEditListRequestRpc
   | NotifyFavoritesFavoritesChangedRpc
   | NotifyKeyfamilyKeyfamilyChangedRpc
   | NotifyPaperKeyPaperKeyCachedRpc
@@ -3985,6 +4033,7 @@ export type rpc =
   | identifyUiReportLastTrackRpc
   | identifyUiReportTrackTokenRpc
   | identifyUiStartRpc
+  | kbfsFSEditListRpc
   | kbfsFSEventRpc
   | logRegisterLoggerRpc
   | logUiLogRpc
@@ -4935,6 +4984,16 @@ export type incomingCallMapType = $Exact<{
       result: () => void
     }
   ) => void,
+  'keybase.1.kbfs.FSEditList'?: (
+    params: $Exact<{
+      edits?: ?Array<FSNotification>,
+      requestID: int
+    }>,
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
+    }
+  ) => void,
   'keybase.1.Kex2Provisionee.hello'?: (
     params: $Exact<{
       uid: UID,
@@ -5375,6 +5434,23 @@ export type incomingCallMapType = $Exact<{
   'keybase.1.NotifyFS.FSActivity'?: (
     params: $Exact<{
       notification: FSNotification
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyFS.FSEditListResponse'?: (
+    params: $Exact<{
+      edits?: ?Array<FSNotification>,
+      requestID: int
+    }>,
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
+    }
+  ) => void,
+  'keybase.1.NotifyFSRequest.FSEditListRequest'?: (
+    params: $Exact<{
+      req: FSEditListRequest
     }> /* ,
     response: {} // Notify call
     */

--- a/shared/constants/types/keybase-v1.js
+++ b/shared/constants/types/keybase-v1.js
@@ -230,6 +230,10 @@ export const kbfsCommon = {
     'rekeying': 4,
     'connection': 5,
     'mdReadSuccess': 6,
+    'fileCreated': 7,
+    'fileModified': 8,
+    'fileDeleted': 9,
+    'fileRenamed': 10,
   },
   'FSErrorType': {
     'accessDenied': 0,
@@ -269,6 +273,8 @@ export const notifyCtl = {}
 export const NotifyFavorites = {}
 
 export const NotifyFS = {}
+
+export const NotifyFSRequest = {}
 
 export const NotifyKeyfamily = {}
 
@@ -504,6 +510,7 @@ export default {
   notifyCtl,
   NotifyFavorites,
   NotifyFS,
+  NotifyFSRequest,
   NotifyKeyfamily,
   NotifyPaperKey,
   NotifyService,


### PR DESCRIPTION
Here's how I envision we use this protocol:

 
* We add a new notification channels: `kbfsrequests`.
* KBFS subscribes to `kbfsrequests`.
* The GUI subscribes to the `kbfs` channel, as usual, when it starts up.
* After the `kbfs` subscription, (and until it sees its first complete list of notifications, periodically), the GUI sends requests via `kbfsrequests` for each favorite it cares about:
  * `FSEditListRequest(FavoriteName, requestID)`
  * `FSSyncListRequest(FavoriteName, requestID)`
* When KBFS receives one of these requests, it responds on the `kbfs` notification channel with:
  * `FSEditListRequest`: a list of up to the last N file edit notifications per writer for the TLF.
  * `FSSyncListRequest`: a complete list of outstanding sync operations for the TLF.
* Each of the above requests causes KBFS to subscribe for updates from the mdserver for that TLF.
* For every TLF to which KBFS is currently subscribed, KBFS sends out the following notifications on the `kbfs` notification channel:
  * Notifications for every file edit operation, as they happen, per-TLF.  Each notification message can actually contain a list of individual edit notifications, since each MD revision can include edits to several files (e.g., conflict resolution).
  * Notifications when an async write operation is queued up.
  * Notifications when an async write operation finishes (or makes progress).
* It will be up to the GUI to improve performance by keeping a cached copy of the complete list of changes, and modify it correctly as new notifications roll in.  It would perform badly to request the complete list for every render.

Issue: KBFS-1300