### PR TITLE
Create SecretUI only when needed in crypto

### DIFF
--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -216,9 +216,12 @@ func TestSignAfterRevoke(t *testing.T) {
 
 	// Still logged in on tc1, a revoked device.
 
+	f := func() libkb.SecretUI {
+		return u.NewSecretUI()
+	}
 	// Test signing with (revoked) device key on tc1, which works...
 	msg := []byte("test message")
-	ret, err := SignED25519(tc1.G, u.NewSecretUI(), keybase1.SignED25519Arg{
+	ret, err := SignED25519(tc1.G, f, keybase1.SignED25519Arg{
 		Msg: msg,
 	})
 	if err != nil {
@@ -237,7 +240,7 @@ func TestSignAfterRevoke(t *testing.T) {
 	AssertLoggedOut(tc1)
 
 	// And now this should fail.
-	ret, err = SignED25519(tc1.G, u.NewSecretUI(), keybase1.SignED25519Arg{
+	ret, err = SignED25519(tc1.G, f, keybase1.SignED25519Arg{
 		Msg: msg,
 	})
 	if err == nil {
@@ -263,8 +266,12 @@ func TestLogoutIfRevokedNoop(t *testing.T) {
 
 	AssertLoggedIn(tc)
 
+	f := func() libkb.SecretUI {
+		return u.NewSecretUI()
+	}
+
 	msg := []byte("test message")
-	ret, err := SignED25519(tc.G, u.NewSecretUI(), keybase1.SignED25519Arg{
+	ret, err := SignED25519(tc.G, f, keybase1.SignED25519Arg{
 		Msg: msg,
 	})
 	if err != nil {

--- a/go/service/crypto.go
+++ b/go/service/crypto.go
@@ -63,18 +63,25 @@ func (c *CryptoHandler) getSecretUI(sessionID int, reason string) libkb.SecretUI
 	return errorSecretUI{reason}
 }
 
+func (c *CryptoHandler) secretUIMaker(sessionID int, reason string) func() libkb.SecretUI {
+	f := func() libkb.SecretUI {
+		return c.getSecretUI(sessionID, reason)
+	}
+	return f
+}
+
 func (c *CryptoHandler) SignED25519(_ context.Context, arg keybase1.SignED25519Arg) (keybase1.ED25519SignatureInfo, error) {
-	return engine.SignED25519(c.G(), c.getSecretUI(arg.SessionID, arg.Reason), arg)
+	return engine.SignED25519(c.G(), c.secretUIMaker(arg.SessionID, arg.Reason), arg)
 }
 
 func (c *CryptoHandler) SignToString(_ context.Context, arg keybase1.SignToStringArg) (string, error) {
-	return engine.SignToString(c.G(), c.getSecretUI(arg.SessionID, arg.Reason), arg)
+	return engine.SignToString(c.G(), c.secretUIMaker(arg.SessionID, arg.Reason), arg)
 }
 
 func (c *CryptoHandler) UnboxBytes32(_ context.Context, arg keybase1.UnboxBytes32Arg) (keybase1.Bytes32, error) {
-	return engine.UnboxBytes32(c.G(), c.getSecretUI(arg.SessionID, arg.Reason), arg)
+	return engine.UnboxBytes32(c.G(), c.secretUIMaker(arg.SessionID, arg.Reason), arg)
 }
 
 func (c *CryptoHandler) UnboxBytes32Any(_ context.Context, arg keybase1.UnboxBytes32AnyArg) (keybase1.UnboxAnyRes, error) {
-	return engine.UnboxBytes32Any(c.G(), c.getSecretUI(arg.SessionID, arg.Reason), arg)
+	return engine.UnboxBytes32Any(c.G(), c.secretUIMaker(arg.SessionID, arg.Reason), arg)
 }


### PR DESCRIPTION
I noticed watching the service log while KBFS was hard at work that all the crypto endpoints get a delegated secretUI when a secretUI was never needed (since the keys were cached).

This change makes it so that the secretUI is only instantiated if it is actually needed by any of the crypto operations.

r? @maxtaco 