### PR TITLE
handle cache misses when loading links from storage

### DIFF
--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -592,7 +592,7 @@ func ImportLinkFromStorage(id LinkID, selfUID keybase1.UID, g *GlobalContext) (*
 
 	jw, err := g.LocalDb.Get(DbKey{Typ: DBLink, Key: id.String()})
 	var ret *ChainLink
-	if err == nil {
+	if err == nil && ret != nil {
 		// May as well recheck onload (maybe revisit this)
 		ret = NewChainLink(g, nil, id, jw)
 		if err = ret.Unpack(true, selfUID); err != nil {

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -665,6 +665,10 @@ func (l *SigChainLoader) LoadLinksFromStorage() (err error) {
 		if link, err = ImportLinkFromStorage(curr, suid, l.G()); err != nil {
 			return
 		}
+		if link == nil {
+			l.G().Log.Debug("| ImportLinkFromStorage returned nil")
+			return
+		}
 		kid2 := link.ToEldestKID()
 
 		if loadKID.IsNil() {

--- a/go/libkb/sig_hints.go
+++ b/go/libkb/sig_hints.go
@@ -127,6 +127,7 @@ func LoadSigHints(uid keybase1.UID, g *GlobalContext) (sh *SigHints, err error) 
 	if err != nil {
 		return
 	}
+	// jw might be nil here, but that's allowed.
 	sh, err = NewSigHints(jw, uid, false, g)
 	if err == nil {
 		g.Log.Debug("| SigHints loaded @v%d", sh.version)


### PR DESCRIPTION
Previously we assumed that the cache would never return nil. This made
some sense, because we first try to load the merkle tip, and we always
cache the tip and links together. However, we've seen this cache miss
happen in the wild (https://github.com/keybase/client/issues/3632), and
it could certainly happen if the client happened to crash at a very
specific time while writing. It makes sense to handle it.

r? @maxtaco 