### PR TITLE
Remove useless position absolute that breaks layout

### DIFF
--- a/shared/common-adapters/user-bio.desktop.js
+++ b/shared/common-adapters/user-bio.desktop.js
@@ -26,7 +26,7 @@ class BioLoading extends Component<void, {style: Object, avatarSize: AvatarSize,
               following={false}
               followsYou={false} />
           </Box>
-          <Box style={{...stylesContent, ...globalStyles.fadeOpacity, position: 'absolute', opacity: this.props.loading ? 1 : 0}}>
+          <Box style={{...stylesContent, ...globalStyles.fadeOpacity, opacity: this.props.loading ? 1 : 0}}>
             <Box style={{...globalStyles.loadingTextStyle, width: 157}} />
             <Box style={{...globalStyles.loadingTextStyle, width: 87}} />
             <Box style={{...globalStyles.loadingTextStyle, width: 117}} />


### PR DESCRIPTION
@keybase/react-hackers 

New version of electron I think breaks the loading state:

before
<img width="335" alt="screen shot 2016-08-04 at 5 30 53 pm" src="https://cloud.githubusercontent.com/assets/594035/17422780/e26a4c6a-5a69-11e6-8551-fe0980b37dce.png">


after
<img width="365" alt="screen shot 2016-08-04 at 5 29 58 pm" src="https://cloud.githubusercontent.com/assets/594035/17422781/e558fcf0-5a69-11e6-870d-4088a91d211a.png">


I wonder if visdiff will pick it up
