### PR TITLE
Only re-id if we've seen the tracking state before. Don't call userUpdated

### DIFF
--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -51,14 +51,13 @@ export function stopTimer (): Action {
 }
 
 export function registerTrackerChangeListener (): TrackerActionCreator {
-  return dispatch => {
+  return (dispatch, getState) => {
     const params = {
       'keybase.1.NotifyTracking.trackingChanged': ({username}) => {
-        dispatch({
-          type: Constants.userUpdated,
-          payload: {},
-        })
-        dispatch(getProfile(username))
+        const trackerState = getState().tracker.trackers[username]
+        if (trackerState && trackerState.type === 'tracker' && !trackerState.closed) {
+          dispatch(getProfile(username))
+        }
       },
     }
 

--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -55,7 +55,7 @@ export function registerTrackerChangeListener (): TrackerActionCreator {
     const params = {
       'keybase.1.NotifyTracking.trackingChanged': ({username}) => {
         const trackerState = getState().tracker.trackers[username]
-        if (trackerState && trackerState.type === 'tracker' && !trackerState.closed) {
+        if (trackerState && trackerState.type === 'tracker') {
           dispatch(getProfile(username))
         }
       },

--- a/shared/constants/tracker.js
+++ b/shared/constants/tracker.js
@@ -83,8 +83,6 @@ export const onWaiting = 'tracker:onWaiting'
 export const showTracker = 'tracker:showTracker'
 export const updateTrackToken = 'tracker:updateTrackToken'
 
-export const userUpdated = 'tracker:userUpdated'
-
 export const startTimer = 'tracker:startTimer'
 export const stopTimer = 'tracker:stopTimer'
 

--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -136,16 +136,6 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
         ...state,
         trackToken: action.payload && action.payload.trackToken,
       }
-    case Constants.userUpdated:
-      if (state.lastAction || state.waiting) {
-        return state
-      } else {
-        return {
-          ...state,
-          closed: true,
-          hidden: false,
-        }
-      }
     case Constants.onClose:
       return {
         ...state,


### PR DESCRIPTION
@keybase/react-hackers 

Doesn't dispatch useless actions, and doesn't id unless the tracker popup is active.