### PR TITLE
Remove secret from secret store on Logout

### DIFF
--- a/go/engine/login_state_test.go
+++ b/go/engine/login_state_test.go
@@ -315,8 +315,6 @@ func TestLoginWithStoredSecret(t *testing.T) {
 		t.Errorf("secretUI.GetKeybasePassphrase() unexpectedly not called")
 	}
 
-	Logout(tc)
-
 	if !userHasStoredSecret(&tc, fu.Username) {
 		t.Errorf("User %s unexpectedly does not have a stored secret", fu.Username)
 	}
@@ -416,8 +414,6 @@ func TestLoginWithPassphraseWithStore(t *testing.T) {
 		t.Error(err)
 	}
 
-	Logout(tc)
-
 	if !userHasStoredSecret(&tc, fu.Username) {
 		t.Errorf("User %s unexpectedly does not have a stored secret", fu.Username)
 	}
@@ -439,10 +435,8 @@ func TestLoginWithPassphraseWithStore(t *testing.T) {
 
 // TODO: Test LoginWithPassphrase with pubkey login failing.
 
-// Test that the signup with saving the secret, logout, then login
-// flow works.
-func TestSignupWithStoreThenLogin(t *testing.T) {
-
+// Signup followed by logout clears the stored secret
+func TestSignupWithStoreThenLogout(t *testing.T) {
 	tc := SetupEngineTest(t, "signup with store then login")
 	defer tc.Cleanup()
 
@@ -457,16 +451,6 @@ func TestSignupWithStoreThenLogin(t *testing.T) {
 	_ = SignupFakeUserWithArg(tc, fu, arg)
 
 	Logout(tc)
-
-	// TODO: Mock out the SecretStore and make sure that it's
-	// actually consulted.
-	if err := tc.G.LoginState().LoginWithStoredSecret(fu.Username, nil); err != nil {
-		t.Error(err)
-	}
-
-	if err := libkb.ClearStoredSecret(tc.G, fu.NormalizedUsername()); err != nil {
-		t.Error(err)
-	}
 
 	if userHasStoredSecret(&tc, fu.Username) {
 		t.Errorf("User %s unexpectedly has a stored secret", fu.Username)

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -162,6 +162,9 @@ func (g *GlobalContext) ResetLoginState() {
 func (g *GlobalContext) Logout() error {
 	g.loginStateMu.Lock()
 	defer g.loginStateMu.Unlock()
+
+	username := g.Env.GetUsername()
+
 	if err := g.loginState.Logout(); err != nil {
 		return err
 	}
@@ -179,6 +182,13 @@ func (g *GlobalContext) Logout() error {
 
 	// get a clean LoginState:
 	g.createLoginStateLocked()
+
+	// remove stored secret
+	if g.SecretStoreAll != nil {
+		if err := g.SecretStoreAll.ClearSecret(username); err != nil {
+			g.Log.Debug("clear stored secret error: %s", err)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
When a user logs out, anything stored in secret store for that user should be removed. 

This is part of CORE-2723, but can be merged independently.

r? @maxtaco 

cc: @malgorithms 