### PR TITLE
pgp purge command

### DIFF
--- a/go/client/cmd_pgp.go
+++ b/go/client/cmd_pgp.go
@@ -27,6 +27,7 @@ func NewCmdPGP(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 			NewCmdPGPImport(cl),
 			NewCmdPGPDrop(cl),
 			NewCmdPGPList(cl, g),
+			NewCmdPGPPurge(cl, g),
 		},
 	}
 }

--- a/go/client/cmd_pgp_purge.go
+++ b/go/client/cmd_pgp_purge.go
@@ -1,0 +1,56 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
+)
+
+func NewCmdPGPPurge(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "purge",
+		Usage: "Purge all PGP keys from Keybase keyring",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdPGPPurge{Contextified: libkb.NewContextified(g)}, "purge", c)
+		},
+	}
+}
+
+type CmdPGPPurge struct {
+	libkb.Contextified
+}
+
+func (s *CmdPGPPurge) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) > 0 {
+		return UnexpectedArgsError("pgp purge")
+	}
+
+	return nil
+}
+
+func (s *CmdPGPPurge) Run() error {
+	cli, err := GetPGPClient()
+	if err != nil {
+		return err
+	}
+
+	arg := keybase1.PGPPurgeArg{
+		DoPurge: false,
+	}
+
+	return cli.PGPPurge(context.TODO(), arg)
+}
+
+func (s *CmdPGPPurge) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		KbKeyring: true,
+		API:       true,
+	}
+}

--- a/go/engine/pgp_purge.go
+++ b/go/engine/pgp_purge.go
@@ -84,7 +84,7 @@ func (e *PGPPurge) export(ctx *Context, bundle *libkb.PGPKeyBundle) error {
 		return nil
 	}
 
-	filename := filepath.Join(e.G().Env.GetHome(), key.GetFingerprint().String()+".sp")
+	filename := filepath.Join(e.G().Env.GetConfigDir(), key.GetFingerprint().String()+".sp")
 	if err := e.encryptToFile(ctx, key, filename); err != nil {
 		return err
 	}

--- a/go/engine/pgp_purge.go
+++ b/go/engine/pgp_purge.go
@@ -1,0 +1,45 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import (
+	"github.com/keybase/client/go/libkb"
+)
+
+// PGPPurge is an engine.
+type PGPPurge struct {
+	libkb.Contextified
+}
+
+// NewPGPPurge creates a PGPPurge engine.
+func NewPGPPurge(g *libkb.GlobalContext) *PGPPurge {
+	return &PGPPurge{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+// Name is the unique engine name.
+func (e *PGPPurge) Name() string {
+	return "PGPPurge"
+}
+
+// GetPrereqs returns the engine prereqs.
+func (e *PGPPurge) Prereqs() Prereqs {
+	return Prereqs{}
+}
+
+// RequiredUIs returns the required UIs.
+func (e *PGPPurge) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *PGPPurge) SubConsumers() []libkb.UIConsumer {
+	return nil
+}
+
+// Run starts the engine.
+func (e *PGPPurge) Run(ctx *Context) error {
+	return nil
+}

--- a/go/engine/pgp_purge_test.go
+++ b/go/engine/pgp_purge_test.go
@@ -1,0 +1,17 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import "testing"
+
+func TestPGPPurge(t *testing.T) {
+	tc := SetupEngineTest(t, "template")
+	defer tc.Cleanup()
+
+	ctx := &Context{}
+	eng := NewPGPPurge(tc.G)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/go/engine/pgp_purge_test.go
+++ b/go/engine/pgp_purge_test.go
@@ -3,15 +3,75 @@
 
 package engine
 
-import "testing"
+import (
+	"testing"
 
-func TestPGPPurge(t *testing.T) {
-	tc := SetupEngineTest(t, "template")
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
+)
+
+func TestPGPPurgeLksec(t *testing.T) {
+	tc := SetupEngineTest(t, "purge")
 	defer tc.Cleanup()
 
-	ctx := &Context{}
-	eng := NewPGPPurge(tc.G)
+	createFakeUserWithPGPSibkey(tc)
+
+	idUI := &FakeIdentifyUI{
+		Proofs: make(map[string]string),
+	}
+	ctx := &Context{
+		SecretUI:   &libkb.TestSecretUI{}, // empty on purpose...shouldn't be necessary
+		SaltpackUI: &fakeSaltpackUI{},
+		IdentifyUI: idUI,
+	}
+	eng := NewPGPPurge(tc.G, keybase1.PGPPurgeArg{})
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
+	}
+
+	if len(eng.KeyFiles()) != 1 {
+		t.Fatalf("number of exported key files: %d, expected 1", len(eng.KeyFiles()))
+	}
+}
+
+// Create a user with a synced PGP key.  PGPPurge shouldn't touch it.
+func TestPGPPurgeSync(t *testing.T) {
+	tc := SetupEngineTest(t, "purge")
+	u1 := createFakeUserWithPGPOnly(t, tc)
+	Logout(tc)
+	tc.Cleanup()
+
+	tc = SetupEngineTest(t, "purge")
+	defer tc.Cleanup()
+
+	lctx := &Context{
+		ProvisionUI: newTestProvisionUIPassphrase(),
+		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
+		LogUI:       tc.G.UI.GetLogUI(),
+		SecretUI:    u1.NewSecretUI(),
+		GPGUI:       &gpgtestui{},
+	}
+	leng := NewLogin(tc.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
+	if err := RunEngine(leng, lctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// user has device keys + synced 3sec pgp key
+
+	idUI := &FakeIdentifyUI{
+		Proofs: make(map[string]string),
+	}
+	ctx := &Context{
+		SecretUI:   &libkb.TestSecretUI{}, // empty on purpose...shouldn't be necessary
+		SaltpackUI: &fakeSaltpackUI{},
+		IdentifyUI: idUI,
+	}
+	eng := NewPGPPurge(tc.G, keybase1.PGPPurgeArg{})
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(eng.KeyFiles()) != 0 {
+		t.Fatalf("number of exported key files: %d, expected 0", len(eng.KeyFiles()))
 	}
 }

--- a/go/engine/pgp_purge_test.go
+++ b/go/engine/pgp_purge_test.go
@@ -40,7 +40,7 @@ func TestPGPPurgeRemove(t *testing.T) {
 	tc := SetupEngineTest(t, "purge")
 	defer tc.Cleanup()
 
-	createFakeUserWithPGPSibkey(tc)
+	u := createFakeUserWithPGPSibkey(tc)
 
 	idUI := &FakeIdentifyUI{
 		Proofs: make(map[string]string),
@@ -59,6 +59,14 @@ func TestPGPPurgeRemove(t *testing.T) {
 		t.Fatalf("number of exported key files: %d, expected 1", len(eng.KeyFiles()))
 	}
 
+	kr := libkb.NewSKBKeyringFile(tc.G.SKBFilenameForUser(libkb.NewNormalizedUsername(u.Username)))
+	if err := kr.LoadAndIndex(); err != nil {
+		t.Fatal(err)
+	}
+	if kr.HasPGPKeys() {
+		t.Fatal("after purge, keyring has pgp keys")
+	}
+
 	// redo, should purge 0 files
 
 	eng = NewPGPPurge(tc.G, keybase1.PGPPurgeArg{DoPurge: true})
@@ -69,6 +77,7 @@ func TestPGPPurgeRemove(t *testing.T) {
 	if len(eng.KeyFiles()) != 0 {
 		t.Fatalf("number of exported key files: %d, expected 0", len(eng.KeyFiles()))
 	}
+
 }
 
 // Create a user with a synced PGP key.  PGPPurge shouldn't touch it.

--- a/go/protocol/pgp.go
+++ b/go/protocol/pgp.go
@@ -68,6 +68,11 @@ type PGPCreateUids struct {
 	Ids        []PGPIdentity `codec:"ids" json:"ids"`
 }
 
+// Export all pgp keys in lksec, then if doPurge is true, remove the keys from lksec.
+type PGPPurgeRes struct {
+	Filenames []string `codec:"filenames" json:"filenames"`
+}
+
 type PGPSignArg struct {
 	SessionID int            `codec:"sessionID" json:"sessionID"`
 	Source    Stream         `codec:"source" json:"source"`
@@ -173,8 +178,7 @@ type PGPInterface interface {
 	PGPSelect(context.Context, PGPSelectArg) error
 	// Push updated key(s) to the server.
 	PGPUpdate(context.Context, PGPUpdateArg) error
-	// Export all pgp keys in lksec, then if doPurge is true, remove the keys from lksec.
-	PGPPurge(context.Context, PGPPurgeArg) error
+	PGPPurge(context.Context, PGPPurgeArg) (PGPPurgeRes, error)
 }
 
 func PGPProtocol(i PGPInterface) rpc.Protocol {
@@ -400,7 +404,7 @@ func PGPProtocol(i PGPInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]PGPPurgeArg)(nil), args)
 						return
 					}
-					err = i.PGPPurge(ctx, (*typedArgs)[0])
+					ret, err = i.PGPPurge(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -484,8 +488,7 @@ func (c PGPClient) PGPUpdate(ctx context.Context, __arg PGPUpdateArg) (err error
 	return
 }
 
-// Export all pgp keys in lksec, then if doPurge is true, remove the keys from lksec.
-func (c PGPClient) PGPPurge(ctx context.Context, __arg PGPPurgeArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpPurge", []interface{}{__arg}, nil)
+func (c PGPClient) PGPPurge(ctx context.Context, __arg PGPPurgeArg) (res PGPPurgeRes, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.pgp.pgpPurge", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/pgp.go
+++ b/go/service/pgp.go
@@ -241,12 +241,19 @@ func (h *PGPHandler) PGPUpdate(_ context.Context, arg keybase1.PGPUpdateArg) err
 	return engine.RunEngine(eng, &ctx)
 }
 
-func (h *PGPHandler) PGPPurge(ctx context.Context, arg keybase1.PGPPurgeArg) error {
+func (h *PGPHandler) PGPPurge(ctx context.Context, arg keybase1.PGPPurgeArg) (keybase1.PGPPurgeRes, error) {
 	ectx := &engine.Context{
 		LogUI:      h.getLogUI(arg.SessionID),
 		SessionID:  arg.SessionID,
+		SecretUI:   h.getSecretUI(arg.SessionID, h.G()),
+		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, h.G()),
 		NetContext: ctx,
 	}
-	eng := engine.NewPGPPurge(h.G())
-	return engine.RunEngine(eng, ectx)
+	eng := engine.NewPGPPurge(h.G(), arg)
+	var res keybase1.PGPPurgeRes
+	if err := engine.RunEngine(eng, ectx); err != nil {
+		return res, err
+	}
+	res.Filenames = eng.KeyFiles()
+	return res, nil
 }

--- a/go/service/pgp.go
+++ b/go/service/pgp.go
@@ -240,3 +240,13 @@ func (h *PGPHandler) PGPUpdate(_ context.Context, arg keybase1.PGPUpdateArg) err
 	eng := engine.NewPGPUpdateEngine(arg.Fingerprints, arg.All, h.G())
 	return engine.RunEngine(eng, &ctx)
 }
+
+func (h *PGPHandler) PGPPurge(ctx context.Context, arg keybase1.PGPPurgeArg) error {
+	ectx := &engine.Context{
+		LogUI:      h.getLogUI(arg.SessionID),
+		SessionID:  arg.SessionID,
+		NetContext: ctx,
+	}
+	eng := engine.NewPGPPurge(h.G())
+	return engine.RunEngine(eng, ectx)
+}

--- a/protocol/avdl/pgp.avdl
+++ b/protocol/avdl/pgp.avdl
@@ -102,4 +102,9 @@ protocol pgp {
     Push updated key(s) to the server.
     */
   void pgpUpdate(int sessionID, boolean all, array<string> fingerprints);
+
+  /**
+    Export all pgp keys in lksec, then if doPurge is true, remove the keys from lksec.
+    */
+  void pgpPurge(int sessionID, boolean doPurge);
 }

--- a/protocol/avdl/pgp.avdl
+++ b/protocol/avdl/pgp.avdl
@@ -106,5 +106,8 @@ protocol pgp {
   /**
     Export all pgp keys in lksec, then if doPurge is true, remove the keys from lksec.
     */
-  void pgpPurge(int sessionID, boolean doPurge);
+  record PGPPurgeRes {
+    array<string> filenames;
+  }
+  PGPPurgeRes pgpPurge(int sessionID, boolean doPurge);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -847,6 +847,10 @@ export type PGPIdentity = {
   email: string;
 }
 
+export type PGPPurgeRes = {
+  filenames?: ?Array<string>;
+}
+
 export type PGPQuery = {
   secret: boolean;
   query: string;
@@ -2711,11 +2715,13 @@ export type pgpPgpPurgeRpcParam = $Exact<{
   doPurge: boolean
 }>
 
+type pgpPgpPurgeResult = PGPPurgeRes
+
 export function pgpPgpPurgeRpc (request: $Exact<{
   param: pgpPgpPurgeRpcParam,
   waitingHandler?: (waiting: boolean, method: string, sessionID: string) => void,
   incomingCallMap?: incomingCallMapType,
-  callback?: (null | (err: ?any) => void)}>) {
+  callback?: (null | (err: ?any, response: pgpPgpPurgeResult) => void)}>) {
   engine.rpc({...request, method: 'pgp.pgpPurge'})
 }
 export type pgpPgpSelectRpcParam = $Exact<{
@@ -5425,7 +5431,7 @@ export type incomingCallMapType = $Exact<{
     }>,
     response: {
       error: (err: RPCError) => void,
-      result: () => void
+      result: (result: pgpPgpPurgeResult) => void
     }
   ) => void,
   'keybase.1.pgpUi.outputSignatureSuccess'?: (

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2707,6 +2707,17 @@ export function pgpPgpPullRpc (request: $Exact<{
   callback?: (null | (err: ?any) => void)}>) {
   engine.rpc({...request, method: 'pgp.pgpPull'})
 }
+export type pgpPgpPurgeRpcParam = $Exact<{
+  doPurge: boolean
+}>
+
+export function pgpPgpPurgeRpc (request: $Exact<{
+  param: pgpPgpPurgeRpcParam,
+  waitingHandler?: (waiting: boolean, method: string, sessionID: string) => void,
+  incomingCallMap?: incomingCallMapType,
+  callback?: (null | (err: ?any) => void)}>) {
+  engine.rpc({...request, method: 'pgp.pgpPurge'})
+}
 export type pgpPgpSelectRpcParam = $Exact<{
   fingerprintQuery: string,
   allowMulti: boolean,
@@ -3879,6 +3890,7 @@ export type rpc =
   | pgpPgpImportRpc
   | pgpPgpKeyGenRpc
   | pgpPgpPullRpc
+  | pgpPgpPurgeRpc
   | pgpPgpSelectRpc
   | pgpPgpSignRpc
   | pgpPgpUpdateRpc
@@ -5400,6 +5412,16 @@ export type incomingCallMapType = $Exact<{
       sessionID: int,
       all: boolean,
       fingerprints?: ?Array<string>
+    }>,
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
+    }
+  ) => void,
+  'keybase.1.pgp.pgpPurge'?: (
+    params: $Exact<{
+      sessionID: int,
+      doPurge: boolean
     }>,
     response: {
       error: (err: RPCError) => void,

--- a/protocol/json/pgp.json
+++ b/protocol/json/pgp.json
@@ -174,6 +174,20 @@
           "name": "ids"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "PGPPurgeRes",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "filenames"
+        }
+      ],
+      "doc": "Export all pgp keys in lksec, then if doPurge is true, remove the keys from lksec."
     }
   ],
   "messages": {
@@ -440,8 +454,7 @@
           "type": "boolean"
         }
       ],
-      "response": null,
-      "doc": "Export all pgp keys in lksec, then if doPurge is true, remove the keys from lksec."
+      "response": "PGPPurgeRes"
     }
   },
   "namespace": "keybase.1"

--- a/protocol/json/pgp.json
+++ b/protocol/json/pgp.json
@@ -428,6 +428,20 @@
       ],
       "response": null,
       "doc": "Push updated key(s) to the server."
+    },
+    "pgpPurge": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "doPurge",
+          "type": "boolean"
+        }
+      ],
+      "response": null,
+      "doc": "Export all pgp keys in lksec, then if doPurge is true, remove the keys from lksec."
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -847,6 +847,10 @@ export type PGPIdentity = {
   email: string;
 }
 
+export type PGPPurgeRes = {
+  filenames?: ?Array<string>;
+}
+
 export type PGPQuery = {
   secret: boolean;
   query: string;
@@ -2711,11 +2715,13 @@ export type pgpPgpPurgeRpcParam = $Exact<{
   doPurge: boolean
 }>
 
+type pgpPgpPurgeResult = PGPPurgeRes
+
 export function pgpPgpPurgeRpc (request: $Exact<{
   param: pgpPgpPurgeRpcParam,
   waitingHandler?: (waiting: boolean, method: string, sessionID: string) => void,
   incomingCallMap?: incomingCallMapType,
-  callback?: (null | (err: ?any) => void)}>) {
+  callback?: (null | (err: ?any, response: pgpPgpPurgeResult) => void)}>) {
   engine.rpc({...request, method: 'pgp.pgpPurge'})
 }
 export type pgpPgpSelectRpcParam = $Exact<{
@@ -5425,7 +5431,7 @@ export type incomingCallMapType = $Exact<{
     }>,
     response: {
       error: (err: RPCError) => void,
-      result: () => void
+      result: (result: pgpPgpPurgeResult) => void
     }
   ) => void,
   'keybase.1.pgpUi.outputSignatureSuccess'?: (

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2707,6 +2707,17 @@ export function pgpPgpPullRpc (request: $Exact<{
   callback?: (null | (err: ?any) => void)}>) {
   engine.rpc({...request, method: 'pgp.pgpPull'})
 }
+export type pgpPgpPurgeRpcParam = $Exact<{
+  doPurge: boolean
+}>
+
+export function pgpPgpPurgeRpc (request: $Exact<{
+  param: pgpPgpPurgeRpcParam,
+  waitingHandler?: (waiting: boolean, method: string, sessionID: string) => void,
+  incomingCallMap?: incomingCallMapType,
+  callback?: (null | (err: ?any) => void)}>) {
+  engine.rpc({...request, method: 'pgp.pgpPurge'})
+}
 export type pgpPgpSelectRpcParam = $Exact<{
   fingerprintQuery: string,
   allowMulti: boolean,
@@ -3879,6 +3890,7 @@ export type rpc =
   | pgpPgpImportRpc
   | pgpPgpKeyGenRpc
   | pgpPgpPullRpc
+  | pgpPgpPurgeRpc
   | pgpPgpSelectRpc
   | pgpPgpSignRpc
   | pgpPgpUpdateRpc
@@ -5400,6 +5412,16 @@ export type incomingCallMapType = $Exact<{
       sessionID: int,
       all: boolean,
       fingerprints?: ?Array<string>
+    }>,
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
+    }
+  ) => void,
+  'keybase.1.pgp.pgpPurge'?: (
+    params: $Exact<{
+      sessionID: int,
+      doPurge: boolean
     }>,
     response: {
       error: (err: RPCError) => void,


### PR DESCRIPTION
Added `keybase pgp purge` command.

Every time it runs, it exports any pgp keys in lksec to saltpack encrypted files in $HOME.

If run with `-p` flag, it will also remove the pgp keys from lksec.

Idea was that they would run `keybase pgp purge`, make sure they could store the keys somewhere else, then run `keybase pgp purge -p` to actually remove them.

r? @maxtaco 