### PR TITLE
Standard screen native DESKTOP-1666

### DIFF
--- a/shared/common-adapters/confirm.desktop.js
+++ b/shared/common-adapters/confirm.desktop.js
@@ -1,14 +1,13 @@
 // @flow
 import React, {Component} from 'react'
 import type {Props} from './confirm'
-import {Box, Icon, Button} from './'
+import {Box, Button, StandardScreen} from './'
 import {globalStyles, globalColors} from '../styles/style-guide'
 
 class Confirm extends Component<void, Props, void> {
   render () {
     return (
-      <Box style={{...styleContainer, ...backgroundColorThemed[this.props.theme]}}>
-        <Icon style={{...styleClose, ...styleCloseThemed[this.props.theme]}} type='iconfont-close' onClick={this.props.onCancel} />
+      <StandardScreen style={styleContainer} styleOuter={{...backgroundColorThemed[this.props.theme]}} styleClose={styleCloseThemed[this.props.theme]} onClose={this.props.onCancel}>
         <Box style={styleIconContainer}>
           {this.props.header}
         </Box>
@@ -17,18 +16,13 @@ class Confirm extends Component<void, Props, void> {
           <Button type='Secondary' style={cancelButtonThemed[this.props.theme]} labelStyle={cancelButtonLabelThemed[this.props.theme]} onClick={this.props.onCancel} label='Cancel' />
           <Button type={this.props.danger ? 'Danger' : 'Primary'} onClick={this.props.onSubmit} label={this.props.submitLabel} />
         </Box>
-      </Box>
+      </StandardScreen>
     )
   }
 }
 
 const styleContainer = {
-  ...globalStyles.flexBoxColumn,
-  flex: 1,
-  padding: 64,
-  alignItems: 'center',
-  justifyContent: 'center',
-  position: 'relative',
+  maxWidth: 512,
 }
 
 const styleIconContainer = {
@@ -60,13 +54,6 @@ const cancelButtonLabelThemed = {
   'private': {
     color: globalColors.white,
   },
-}
-
-const styleClose = {
-  ...globalStyles.clickable,
-  position: 'absolute',
-  right: 16,
-  top: 16,
 }
 
 const styleCloseThemed = {

--- a/shared/common-adapters/confirm.native.js
+++ b/shared/common-adapters/confirm.native.js
@@ -1,40 +1,24 @@
 // @flow
 import React, {Component} from 'react'
 import type {Props} from './confirm'
-import {Box, Button, Text} from './'
+import {Box, Button, StandardScreen} from './'
 import {globalStyles, globalColors} from '../styles/style-guide'
 
 class Confirm extends Component<void, Props, void> {
   render () {
     return (
-      <Box style={{...styleContainer, ...backgroundColorThemed[this.props.theme]}}>
-        <Text type='BodyPrimaryLink' style={{...styleClose, ...styleCloseThemed[this.props.theme]}} onClick={this.props.onCancel}>Cancel</Text>
-        <Box style={styleInnerContainer}>
+      <StandardScreen styleOuter={backgroundColorThemed[this.props.theme]} styleClose={styleCloseThemed[this.props.theme]} onClose={this.props.onCancel}>
+        <Box style={styleBodyContainer}>
           <Box style={styleIconContainer}>
             {this.props.header}
           </Box>
-          <Box style={styleBodyContainer}>
-            {this.props.body}
-          </Box>
+          {this.props.body}
         </Box>
         <Button type={this.props.danger ? 'Danger' : 'Primary'} onClick={this.props.onSubmit} label={this.props.submitLabel} style={{...styleButton, marginBottom: 16}} />
         <Button type='Secondary' onClick={this.props.onCancel} label='Cancel' style={{...styleButton, ...cancelButtonThemed[this.props.theme]}} labelStyle={cancelButtonLabelThemed[this.props.theme]} />
-      </Box>
+      </StandardScreen>
     )
   }
-}
-
-const styleContainer = {
-  ...globalStyles.flexBoxColumn,
-  padding: 16,
-  flex: 1,
-}
-
-const styleInnerContainer = {
-  ...globalStyles.flexBoxColumn,
-  alignItems: 'center',
-  justifyContent: 'center',
-  flex: 1,
 }
 
 const styleIconContainer = {
@@ -47,7 +31,9 @@ const styleIconContainer = {
 
 const styleBodyContainer = {
   ...globalStyles.flexBoxColumn,
+  flex: 1,
   alignItems: 'center',
+  justifyContent: 'center',
   marginLeft: 16,
   marginRight: 16,
   marginBottom: 16,
@@ -78,12 +64,6 @@ const cancelButtonLabelThemed = {
   'private': {
     color: globalColors.white,
   },
-}
-
-const styleClose = {
-  alignSelf: 'flex-start',
-  marginTop: 7,
-  marginBottom: 12,
 }
 
 const styleCloseThemed = {

--- a/shared/common-adapters/dumb.desktop.js
+++ b/shared/common-adapters/dumb.desktop.js
@@ -243,12 +243,12 @@ const standardScreenMap: DumbComponentMap<StandardScreen> = {
 }
 
 export default {
+  Avatar: avatarMap,
   Checkbox: checkboxMap,
-  TabBar: tabBarMap,
+  ChoiceList: choiceListMap,
+  Icon: iconMap,
   ListItem: listItemMap,
   PopupMenu: popupMenuMap,
-  Avatar: avatarMap,
-  Icon: iconMap,
-  ChoiceList: choiceListMap,
   StandardScreen: standardScreenMap,
+  TabBar: tabBarMap,
 }

--- a/shared/common-adapters/dumb.native.js
+++ b/shared/common-adapters/dumb.native.js
@@ -2,7 +2,7 @@
 import Checkbox from './checkbox'
 import React from 'react'
 import type {DumbComponentMap} from '../constants/types/more'
-import {TabBar, Text, Box, ListItem, Button, Avatar} from './index'
+import {Avatar, Box, Button, ListItem, StandardScreen, TabBar, Text} from './index'
 import {TabBarButton, TabBarItem} from './tab-bar'
 import {globalColors} from '../styles/style-guide'
 
@@ -132,9 +132,39 @@ const listItemMap: DumbComponentMap<ListItem> = {
   },
 }
 
+const standardScreenProps = {
+  onClose: () => console.log('StandardScreen: onClose'),
+  children: <Text type='Header'>Whoa, look at this centered thing</Text>,
+}
+
+const standardScreenMap: DumbComponentMap<StandardScreen> = {
+  component: StandardScreen,
+  mocks: {
+    'Normal': {
+      ...standardScreenProps,
+    },
+    'Error w/ Custom Close Text': {
+      ...standardScreenProps,
+      onCloseText: 'Back',
+      notification: {
+        message: 'Something went horribly wrong! :-(',
+        type: 'error',
+      },
+    },
+    'Success w/ Custom Notification Element': {
+      ...standardScreenProps,
+      notification: {
+        message: <Text type='BodySmallSemibold' style={{color: globalColors.white, textAlign: 'center'}}>You won a unicorn! <Text type='BodySmallPrimaryLink'>Make sure to feed it</Text> :-)</Text>,
+        type: 'success',
+      },
+    },
+  },
+}
+
 export default {
-  'TabBarButton': tabBarButtonMap,
-  'TabBar': tabBarMap,
   'Checkbox': checkboxMap,
-  ListItem: listItemMap,
+  'ListItem': listItemMap,
+  'StandardScreen': standardScreenMap,
+  'TabBar': tabBarMap,
+  'TabBarButton': tabBarButtonMap,
 }

--- a/shared/common-adapters/standard-screen.desktop.js
+++ b/shared/common-adapters/standard-screen.desktop.js
@@ -4,18 +4,18 @@ import {Box, Text, Icon} from '../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import type {Props, NotificationType} from './standard-screen'
 
-const StandardScreen = ({children, onClose, notification, style}: Props) => {
+const StandardScreen = (props: Props) => {
   return (
-    <Box style={styleContainer}>
-      {!!onClose && <Icon style={styleClose} type='iconfont-close' onClick={onClose} />}
-      {!!notification && <Box style={styleBanner(notification.type)}>
-        {typeof notification.message === 'string'
-          ? <Text style={styleBannerText} type='BodySmallSemibold'>{notification.message}</Text>
-          : notification.message
+    <Box style={{...styleContainer, ...props.styleOuter}}>
+      {!!props.onClose && <Icon style={{...styleClose, ...props.styleClose}} type='iconfont-close' onClick={props.onClose} />}
+      {!!props.notification && <Box style={{...styleBanner(props.notification.type), ...props.styleBanner}}>
+        {typeof props.notification.message === 'string'
+          ? <Text style={styleBannerText} type='BodySmallSemibold'>{props.notification.message}</Text>
+          : props.notification.message
         }
       </Box>}
-      <Box style={{...styleContentContainer, ...style}}>
-        {children}
+      <Box style={{...styleContentContainer, ...props.style}}>
+        {props.children}
       </Box>
     </Box>
   )

--- a/shared/common-adapters/standard-screen.js.flow
+++ b/shared/common-adapters/standard-screen.js.flow
@@ -5,12 +5,16 @@ export type NotificationType = 'error' | 'success'
 
 export type Props = {
   children?: ?any,
-  onClose?: ?(event: SyntheticMouseEvent) => void,
+  onClose?: ?(event: SyntheticEvent) => void,
+  onCloseText?: ?string, // Native only
   notification?: {
     message: string | React$Element<*>,
     type: NotificationType,
   },
   style?: ?Object,
+  styleOuter?: ?Object,
+  styleClose?: ?Object,
+  styleBanner?: ?Object,
 }
 
 export default class StandardScreen extends Component<void, Props, void> { }

--- a/shared/common-adapters/standard-screen.native.js
+++ b/shared/common-adapters/standard-screen.native.js
@@ -1,11 +1,64 @@
 // @flow
-import {Component} from 'react'
+import React from 'react'
 import type {Props} from './standard-screen'
+import {Box, Text} from './'
+import {globalColors, globalMargins, globalStyles} from '../styles/style-guide'
 
-class StandardScreen extends Component<void, Props, void> {
-  render () {
-    return null
-  }
+const StandardScreen = (props: Props) => {
+  return (
+    <Box style={{...styleContainer, ...props.styleOuter}}>
+      <Box style={styleCloseContainer}>
+        {!!props.onClose && <Text type='BodyPrimaryLink' style={{...styleClose, ...props.styleClose}} onClick={props.onClose}>{props.onCloseText || 'Cancel'}</Text>}
+      </Box>
+      {!!props.notification &&
+        <Box style={{...styleBanner(props.notification.type), ...props.styleBanner}}>
+          {typeof props.notification.message === 'string' ? <Text style={styleBannerText} type='BodySmallSemibold'>{props.notification.message}</Text> : props.notification.message}
+        </Box>}
+      <Box style={{...styleContentContainer(!!props.notification), ...props.style}}>
+        {props.children}
+      </Box>
+    </Box>
+  )
 }
+
+const styleContainer = {
+  ...globalStyles.flexBoxColumn,
+  padding: globalMargins.small,
+  flex: 1,
+}
+
+const styleCloseContainer = {
+  ...globalStyles.flexBoxRow,
+  height: globalMargins.large - globalMargins.tiny,
+  alignItems: 'center',
+}
+
+const styleClose = {
+  color: globalColors.blue,
+}
+
+const MIN_BANNER_HEIGHT = globalMargins.large
+
+const styleBanner = (type) => ({
+  ...globalStyles.flexBoxColumn,
+  minHeight: MIN_BANNER_HEIGHT,
+  padding: globalMargins.tiny,
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: type === 'error' ? globalColors.red : globalColors.green,
+})
+
+const styleBannerText = {
+  color: globalColors.white,
+  textAlign: 'center',
+}
+
+const styleContentContainer = (isBannerShowing) => ({
+  ...globalStyles.flexBoxColumn,
+  alignItems: 'center',
+  justifyContent: 'center',
+  flex: 1,
+  ...(isBannerShowing ? {marginTop: -MIN_BANNER_HEIGHT} : {}),
+})
 
 export default StandardScreen

--- a/shared/common-adapters/text.js.flow
+++ b/shared/common-adapters/text.js.flow
@@ -23,7 +23,7 @@ export type Props = {
   inline?: boolean,
   link?: boolean,
   reversed?: boolean,
-  onClick?: (e: SyntheticEvent) => void,
+  onClick?: ?(e: SyntheticEvent) => void,
   lineClamp?: number,
   style?: Object,
   children?: React$Element<*>,


### PR DESCRIPTION
Implements StandardScreen for native. I dogfooded the implementation by moving the `common-adapters/confirm` component to using StandardScreen as its base. Upon comparing the confirm screens before and after, it appears that the implementation works, though it would be nice to have a detail-oriented review to second that opinion.

A couple related designs that StandardScreen should help with:

| First Entry | Second Entry |
|-----------|---------------|
| [Zeplin](https://app.zeplin.io/project.html#pid=56b23de5d195f43d333abd1e&sid=56fecb8fa065d38a7d623e28) <img width="200" alt="screen shot 2016-08-09 at 6 09 21 pm" src="https://cloud.githubusercontent.com/assets/1152104/17538678/6ec61ed2-5e5c-11e6-9330-ed363ac61e1c.png"> | [Zeplin](https://app.zeplin.io/project.html#pid=56b23de5d195f43d333abd1e&sid=5784f9006e43f51c67974198) <img width="200" alt="screen shot 2016-08-09 at 6 09 58 pm" src="https://cloud.githubusercontent.com/assets/1152104/17538688/822236b4-5e5c-11e6-9e9b-dd19ec452b89.png"> |

@keybase/react-hackers 