### PR TITLE
make sure tracking always blocks waiting for identify to complete

### DIFF
--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
@@ -217,6 +218,13 @@ func (ui *FakeIdentifyUI) FinishSocialProofCheck(proof keybase1.RemoteProof, res
 func (ui *FakeIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (result keybase1.ConfirmResult, err error) {
 	ui.Lock()
 	defer ui.Unlock()
+
+	// Do a short sleep. This helps trigger bugs when other code is racing
+	// against the UI here. (Note from Jack: In the bug I initially added this
+	// for, 10ms was just enough to trigger it. I'm adding in an extra factor
+	// of 10.)
+	time.Sleep(100 * time.Millisecond)
+
 	ui.Outcome = outcome
 	result.IdentityConfirmed = outcome.TrackOptions.BypassConfirm
 	result.RemoteConfirmed = outcome.TrackOptions.BypassConfirm && !outcome.TrackOptions.ExpiringLocal

--- a/go/engine/track.go
+++ b/go/engine/track.go
@@ -61,6 +61,7 @@ func (e *TrackEngine) Run(ctx *Context) error {
 		ForceRemoteCheck:      e.arg.ForceRemoteCheck,
 		NeedProofSet:          true,
 		NoErrorOnTrackFailure: true,
+		AlwaysBlock:           true,
 	}
 
 	ieng := NewResolveThenIdentify2WithTrack(e.G(), arg, e.arg.Options)

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -89,7 +89,11 @@ func trackBob(tc libkb.TestContext, fu *FakeUser) {
 }
 
 func trackBobWithOptions(tc libkb.TestContext, fu *FakeUser, options keybase1.TrackOptions, secretUI libkb.SecretUI) {
-	idUI, res, err := runTrackWithOptions(tc, fu, "t_bob", options, secretUI, false)
+	// Refer to t_bob as kbtester1@twitter. This helps test a different
+	// codepath through idenfity2. (For example, in one case it triggered a
+	// race condition that aborted tracking without waiting for the UI to
+	// confirm, which wasn't present in the regular "t_bob" case.)
+	idUI, res, err := runTrackWithOptions(tc, fu, "kbtester1@twitter", options, secretUI, false)
 	if err != nil {
 		tc.T.Fatal(err)
 	}


### PR DESCRIPTION
We were short circuiting early with an error when you ran a command
like:

    keybase track malgorithms@twitter

See https://github.com/keybase/keybase-issues/issues/2465.

r? @maxtaco. @patrickxb discovered that this fixes the issue, but neither
of us is very clear on what unblock is doing and how to interpret the fact
that it's getting called in this case ([here](https://github.com/keybase/client/blob/master/go/engine/identify2_with_uid.go#L295)).