### PR TITLE
Mobile Website & PGP choice screen DESKTOP-1644 DESKTOP-1645

### DIFF
--- a/shared/common-adapters/choice-list.desktop.js
+++ b/shared/common-adapters/choice-list.desktop.js
@@ -75,7 +75,7 @@ const styleInfoContainer = {
   ...globalStyles.flexBoxColumn,
   flex: 1,
   justifyContent: 'center',
-  alignItems: 'left',
+  alignItems: 'left', // TODO (AW): invalid prop value
   textAlign: 'left',
   marginLeft: globalMargins.small,
 }

--- a/shared/common-adapters/choice-list.native.js
+++ b/shared/common-adapters/choice-list.native.js
@@ -1,11 +1,99 @@
 // @flow
-import {Component} from 'react'
+import React, {Component} from 'react'
+import {TouchableHighlight} from 'react-native'
+import {Box, Text, Icon} from '../common-adapters'
+import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import type {Props} from './choice-list'
 
-class Render extends Component<void, Props, void> {
+type State = {
+  activeIndex: ?number,
+}
+
+class ChoiceList extends Component<void, Props, State> {
+  state: State;
+
+  constructor (props: Props) {
+    super(props)
+    this.state = {
+      activeIndex: null,
+    }
+  }
+
+  componentWillReceiveProps (nextProps: Props) {
+    if (nextProps !== this.props) {
+      this.setState({
+        activeIndex: null,
+      })
+    }
+  }
+
   render () {
-    return null
+    const {options} = this.props
+    return (
+      <Box>
+        {options.map((op, idx) => (
+          <TouchableHighlight
+            key={idx}
+            underlayColor={globalColors.blue4}
+            onPress={op.onClick}
+            onPressIn={() => this.setState({activeIndex: idx})}
+            onPressOut={() => this.setState({activeIndex: null})}>
+            <Box style={styleEntry}>
+              <Box style={styleIconContainer(this.state.activeIndex === idx)}>
+              {typeof op.icon === 'string'
+                ? <Icon style={styleIcon} type={op.icon} />
+                : <Box style={styleIcon}>{op.icon}</Box>}
+              </Box>
+              <Box style={styleInfoContainer}>
+                <Text style={styleInfoTitle} type='Body'>{op.title}</Text>
+                <Text style={styleInfoDescription} type='BodySmall'>{op.description}</Text>
+              </Box>
+            </Box>
+          </TouchableHighlight>
+        ))}
+      </Box>
+    )
   }
 }
 
-export default Render
+const styleEntry = {
+  ...globalStyles.flexBoxRow,
+  ...globalStyles.clickable,
+  paddingTop: globalMargins.tiny,
+  paddingBottom: globalMargins.tiny,
+  paddingLeft: globalMargins.small,
+  paddingRight: globalMargins.small,
+}
+
+const styleIconContainer = (active) => ({
+  ...globalStyles.flexBoxColumn,
+  alignItems: 'center',
+  justifyContent: 'center',
+  alignSelf: 'center',
+  width: globalMargins.large + globalMargins.medium,
+  height: globalMargins.large + globalMargins.medium,
+  ...(active ? {} : {backgroundColor: globalColors.lightGrey}),
+  borderRadius: (globalMargins.large + globalMargins.medium) / 2,
+})
+
+const styleIcon = {
+  width: globalMargins.large,
+  height: globalMargins.large,
+}
+
+const styleInfoContainer = {
+  ...globalStyles.flexBoxColumn,
+  flex: 1,
+  justifyContent: 'center',
+  marginLeft: globalMargins.small,
+}
+
+const styleInfoTitle = {
+  color: globalColors.blue,
+}
+
+const styleInfoDescription = {
+  color: globalColors.black_40,
+}
+
+export default ChoiceList

--- a/shared/common-adapters/dumb.native.js
+++ b/shared/common-adapters/dumb.native.js
@@ -2,7 +2,7 @@
 import Checkbox from './checkbox'
 import React from 'react'
 import type {DumbComponentMap} from '../constants/types/more'
-import {Avatar, Box, Button, ListItem, StandardScreen, TabBar, Text} from './index'
+import {Avatar, Box, Button, ChoiceList, ListItem, StandardScreen, TabBar, Text} from './index'
 import {TabBarButton, TabBarItem} from './tab-bar'
 import {globalColors} from '../styles/style-guide'
 
@@ -132,6 +132,28 @@ const listItemMap: DumbComponentMap<ListItem> = {
   },
 }
 
+const choiceListMap: DumbComponentMap<ChoiceList> = {
+  component: ChoiceList,
+  mocks: {
+    'Two Choices': {
+      options: [
+        {
+          title: 'Host a TXT file',
+          description: 'Host a text file on your site, such as yoursite.com/keybase.txt.',
+          icon: 'icon-file-txt-48',
+          onClick: () => console.log('ChoiceList: onClick TXT file'),
+        },
+        {
+          title: 'Set a DNS',
+          description: 'Place a Keybase proof in your DNS records.',
+          icon: 'icon-dns-48',
+          onClick: () => console.log('ChoiceList: onClick DNS'),
+        },
+      ],
+    },
+  },
+}
+
 const standardScreenProps = {
   onClose: () => console.log('StandardScreen: onClose'),
   children: <Text type='Header'>Whoa, look at this centered thing</Text>,
@@ -163,6 +185,7 @@ const standardScreenMap: DumbComponentMap<StandardScreen> = {
 
 export default {
   'Checkbox': checkboxMap,
+  'ChoiceList': choiceListMap,
   'ListItem': listItemMap,
   'StandardScreen': standardScreenMap,
   'TabBar': tabBarMap,

--- a/shared/common-adapters/standard-screen.native.js
+++ b/shared/common-adapters/standard-screen.native.js
@@ -55,7 +55,7 @@ const styleBannerText = {
 
 const styleContentContainer = (isBannerShowing) => ({
   ...globalStyles.flexBoxColumn,
-  alignItems: 'center',
+  alignItems: 'stretch',
   justifyContent: 'center',
   flex: 1,
   ...(isBannerShowing ? {marginTop: -MIN_BANNER_HEIGHT} : {}),

--- a/shared/profile/pgp/prove-pgp-choice.native.js
+++ b/shared/profile/pgp/prove-pgp-choice.native.js
@@ -1,11 +1,38 @@
 // @flow
-import {Component} from 'react'
+import React, {Component} from 'react'
+import {StandardScreen, ChoiceList, Text} from '../../common-adapters'
+import {globalMargins} from '../../styles/style-guide'
 import type {Props} from './prove-pgp-choice'
 
 class ProvePgpChoice extends Component<void, Props, void> {
   render () {
-    return null
+    return (
+      <StandardScreen onClose={this.props.onCancel}>
+        <Text style={styleTitle} type='Header'>Add a PGP key</Text>
+        <ChoiceList
+          options={[
+            {
+              title: 'Get a new PGP key',
+              description: 'Keybase will generate a new PGP key and add it to your profile.',
+              icon: 'icon-pgp-key-48',
+              onClick: () => this.props.onOptionClick('generate'),
+            },
+            {
+              title: 'I have one already',
+              description: 'Import an existing PGP key to your Keybase profile.',
+              icon: 'icon-pgp-key-48',
+              onClick: () => this.props.onOptionClick('import'),
+            },
+          ]}
+        />
+      </StandardScreen>
+    )
   }
+}
+
+const styleTitle = {
+  marginBottom: globalMargins.small,
+  textAlign: 'center',
 }
 
 export default ProvePgpChoice

--- a/shared/profile/prove-website-choice.native.js
+++ b/shared/profile/prove-website-choice.native.js
@@ -1,11 +1,38 @@
 // @flow
-import {Component} from 'react'
+import React, {Component} from 'react'
+import {StandardScreen, ChoiceList, Text} from '../common-adapters'
+import {globalMargins} from '../styles/style-guide'
 import type {Props} from './prove-website-choice'
 
 class ProveWebsiteChoice extends Component<void, Props, void> {
   render () {
-    return null
+    return (
+      <StandardScreen onClose={this.props.onCancel}>
+        <Text style={styleTitle} type='Header'>Prove your website in two ways:</Text>
+        <ChoiceList
+          options={[
+            {
+              title: 'Host a TXT file',
+              description: 'Host a text file on your site, such as yoursite.com/keybase.txt.',
+              icon: 'icon-file-txt-48',
+              onClick: () => this.props.onOptionClick('file'),
+            },
+            {
+              title: 'Set a DNS',
+              description: 'Place a Keybase proof in your DNS records.',
+              icon: 'icon-dns-48',
+              onClick: () => this.props.onOptionClick('dns'),
+            },
+          ]}
+        />
+      </StandardScreen>
+    )
   }
+}
+
+const styleTitle = {
+  marginBottom: globalMargins.small,
+  textAlign: 'center',
 }
 
 export default ProveWebsiteChoice


### PR DESCRIPTION
Implements mobile version of ChoiceList. Then implements mobile screens for prove Website choice and import/gen PGP choice screens on top of ChoiceList and StandardScreen.

There is a cancel button on these screens, but they have awkward spacing because the dumb sheet provides a strangely large component. Normally they would just fill up screen height. So you can't see the cancel button that's at the top.

| PGP | Website | Website w/ Hover State | Website w/ Cancel |
|------|---------|-------------------------|-------------------|
|<img width="432" alt="screen shot 2016-08-10 at 4 50 42 pm" src="https://cloud.githubusercontent.com/assets/1152104/17575049/ef63ea4c-5f1a-11e6-8b35-6825157c91f7.png">|<img width="432" alt="screen shot 2016-08-10 at 4 50 50 pm" src="https://cloud.githubusercontent.com/assets/1152104/17575064/042b85e8-5f1b-11e6-8952-37ac030a85be.png">|<img width="432" alt="screen shot 2016-08-10 at 4 54 28 pm" src="https://cloud.githubusercontent.com/assets/1152104/17575087/352fafc0-5f1b-11e6-9805-cedbb3b461f3.png">|<img width="432" alt="screen shot 2016-08-10 at 4 53 11 pm" src="https://cloud.githubusercontent.com/assets/1152104/17575069/0a2ddbd0-5f1b-11e6-8850-3c18b0c735f1.png">|

* The background on the icon will not normally be there when hovering, it just reappeared when I lifted my mouse to click again to take the screenshot.

@keybase/react-hackers 