### PR TITLE
Integrate website choice screen DESKTOP-1663

### DIFF
--- a/shared/actions/profile.js
+++ b/shared/actions/profile.js
@@ -143,10 +143,7 @@ function _updateSigID (sigID: SigID): UpdateSigID {
 
 function _askTextOrDNS (): AsyncAction {
   return (dispatch) => {
-    const replace = 'dns'
-    console.warn(`TEMP hardcoded to using ${replace} proof for all web`)
-    // really show the screen then have that do addProof
-    dispatch(addProof(replace)) // TEMP hardcoded
+    dispatch(navigateTo([{path: 'ProveWebsiteChoice'}], profileTab))
   }
 }
 

--- a/shared/profile/index.js
+++ b/shared/profile/index.js
@@ -3,6 +3,7 @@ import ConfirmOrPending from './confirm-or-pending-container'
 import EditProfile from './edit-profile'
 import PostProof from './post-proof-container'
 import ProveEnterUsername from './prove-enter-username-container'
+import ProveWebsiteChoice from './prove-website-choice-container'
 import React, {Component} from 'react'
 import Render from './render'
 import Revoke from './revoke-container'
@@ -40,6 +41,7 @@ class Profile extends Component<void, ?Props, void> {
       subRoutes: {
         'editprofile': EditProfile,
         ProveEnterUsername,
+        ProveWebsiteChoice,
         Revoke,
         PostProof,
         ConfirmOrPending,

--- a/shared/profile/prove-enter-username.desktop.js
+++ b/shared/profile/prove-enter-username.desktop.js
@@ -5,7 +5,7 @@ import type {Props} from './prove-enter-username'
 import {Box, Icon, Text, Button, Input, PlatformIcon} from '../common-adapters'
 import {constants} from '../constants/types/keybase-v1'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
-import {shell} from 'electron'
+import openURL from '../util/open-url'
 
 function standardText (name) {
   return {
@@ -61,7 +61,7 @@ function customError (error: string, code: ?number) {
   if (code === constants.StatusCode.scprofilenotpublic) {
     return <Box style={{...globalStyles.flexBoxColumn, justifyContent: 'center', alignItems: 'center'}}>
       <Text style={styleErrorBannerText} type='BodySmallSemibold'>You haven't set a public "Coinbase URL". You need to do that now.</Text>
-      <Box style={{...globalStyles.flexBoxRow, alignItems: 'center'}} onClick={() => shell.openExternal('https://www.coinbase.com/settings#payment_page')}>
+      <Box style={{...globalStyles.flexBoxRow, alignItems: 'center'}} onClick={() => openURL('https://www.coinbase.com/settings#payment_page')}>
         <Text style={styleErrorBannerText} type='BodySmallSemibold'>Go to Coinbase</Text>
         <Icon type='iconfont-open-browser' style={{color: globalColors.white_40, marginLeft: 4}} />
       </Box>

--- a/shared/profile/prove-website-choice-container.js
+++ b/shared/profile/prove-website-choice-container.js
@@ -1,0 +1,31 @@
+// @flow
+import React, {Component} from 'react'
+import ProveWebsiteChoice from './prove-website-choice'
+import type {Props} from './prove-website-choice'
+import type {TypedDispatch} from '../constants/types/flux'
+import type {TypedState} from '../constants/reducer'
+import {TypedConnector} from '../util/typed-connect'
+import {addProof, cancelAddProof} from '../actions/profile'
+
+class ProveWebsiteChoiceContainer extends Component<void, Props, void> {
+  static parseRoute (currentPath, uri) {
+    return {componentAtTop: {title: ''}}
+  }
+
+  render () {
+    return <ProveWebsiteChoice {...this.props} />
+  }
+}
+
+const connector: TypedConnector<TypedState, TypedDispatch<{}>, {}, Props> = new TypedConnector()
+
+export default connector.connect(
+  (state, dispatch) => {
+    return {
+      // Pass https to addProof because addProof doesn't actually care if it's http/https, it will try
+      // both with a preference for https
+      onOptionClick: (choice) => { dispatch(addProof(choice === 'file' ? 'https' : 'dns')) },
+      onCancel: () => { dispatch(cancelAddProof()) },
+    }
+  }
+)(ProveWebsiteChoiceContainer)

--- a/shared/router/meta-navigator.js
+++ b/shared/router/meta-navigator.js
@@ -118,6 +118,9 @@ class MetaNavigator extends Component {
         if (nextPath && subRoutes[nextPath.get('path')]) {
           nextComponent = subRoutes[nextPath.get('path')]
           parseNextRoute = nextComponent.parseRoute
+          if (!parseNextRoute) {
+            console.warn(`MetaNavigator: sub-route '${nextPath.get('path')}' lacks a static parseRoute function`)
+          }
         }
       }
 


### PR DESCRIPTION
Integrates the screen for choosing which website proof to use (either file, a catch-all term for http/https, or dns).

Minor `console.warn` addition to meta navigator that will report if the provided subRoute does not have a parseRoute method (an error that I didn't recognize for a bit and is easy to protect against).