### PR TITLE
Mobile PGP generating screen DESKTOP-1646

### DIFF
--- a/react-native/android/app/build.gradle
+++ b/react-native/android/app/build.gradle
@@ -162,6 +162,10 @@ dependencies {
         // workaround issue https://github.com/tony19/logback-android/issues/73
         exclude group: 'com.google.android', module: 'android'
     }
+    // Manually include GIF support for Fresco b/c it was removed from
+    // core library and RN doesn't auto add it back yet (RN 0.30.0)
+    // @see DESKTOP-1703
+    compile 'com.facebook.fresco:animated-gif:0.11.0'
     debugCompile 'com.hanhuy.android:viewserver:1.0.3'
     compile project(':keybaselib')
     testCompile 'junit:junit:4.12'

--- a/react-native/android/app/proguard-rules.pro
+++ b/react-native/android/app/proguard-rules.pro
@@ -9,6 +9,10 @@
 
 # Add any project specific keep options here:
 
+# @see DESKTOP-1703
+-keep class com.facebook.imagepipeline.animated.factory.AnimatedFactoryImpl {
+  public AnimatedFactoryImpl(com.facebook.imagepipeline.bitmaps.PlatformBitmapFactory, com.facebook.imagepipeline.core.ExecutorSupplier);
+
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface
 # class:

--- a/shared/actions/profile.js
+++ b/shared/actions/profile.js
@@ -12,7 +12,7 @@ import {constants as RpcConstants, proveCommon} from '../constants/types/keybase
 import {getMyProfile} from './tracker'
 import {navigateUp, navigateTo} from '../actions/router'
 import {profileTab} from '../constants/tabs'
-import {shell} from 'electron'
+import openURL from '../util/open-url'
 
 const InputCancelError = {desc: 'Cancel Add Proof', code: RpcConstants.StatusCode.scinputcanceled}
 
@@ -379,16 +379,16 @@ function outputInstructionsActionLink (): AsyncAction {
     const profile = getState().profile
     switch (profile.platform) {
       case 'coinbase':
-        shell.openExternal(`https://coinbase.com/${profile.username}#settings`)
+        openURL(`https://coinbase.com/${profile.username}#settings`)
         break
       case 'twitter':
-        shell.openExternal(`https://twitter.com/home?status=${profile.proof}`)
+        openURL(`https://twitter.com/home?status=${profile.proof}`)
         break
       case 'github':
-        shell.openExternal('https://gist.github.com/')
+        openURL('https://gist.github.com/')
         break
       case 'reddit':
-        shell.openExternal(profile.proof)
+        openURL(profile.proof)
         break
       default:
         break

--- a/shared/profile/pgp/generating-pgp.native.js
+++ b/shared/profile/pgp/generating-pgp.native.js
@@ -1,11 +1,44 @@
 // @flow
-import {Component} from 'react'
+import React, {Component} from 'react'
+import {Text, StandardScreen, Icon} from '../../common-adapters'
+import {globalMargins} from '../../styles/style-guide'
 import type {Props} from './generating-pgp'
 
 class GeneratingPgp extends Component<void, Props, void> {
   render () {
-    return null
+    return (
+      <StandardScreen onClose={this.props.onCancel} style={styleContainer}>
+        <Icon style={styleHeaderIcon} type='icon-pgp-key-48' />
+        <Text style={styleHeader} type='Header'>Generating your unique key...</Text>
+        <Text style={styleBody} type='BodySmall'>Math time! You are about to discover a <Text type='BodySmallItalic'>4096-bit</Text> key pair. This could take as long as a couple minutes.</Text>
+        <Icon style={styleLoadingIcon} type='icon-loader-infinity-64' />
+      </StandardScreen>
+    )
   }
+}
+
+const styleContainer = {
+  justifyContent: 'flex-start',
+}
+
+const styleHeaderIcon = {
+  marginTop: globalMargins.xtiny,
+  alignSelf: 'center',
+}
+
+const styleHeader = {
+  marginTop: globalMargins.small,
+  textAlign: 'center',
+}
+
+const styleBody = {
+  marginTop: globalMargins.xtiny,
+  textAlign: 'center',
+}
+
+const styleLoadingIcon = {
+  marginTop: globalMargins.medium,
+  alignSelf: 'center',
 }
 
 export default GeneratingPgp


### PR DESCRIPTION
### Main Focus

Implements the PGP generating screen for mobile.

### Additional Elements

1. Fixes a `import {shell} from 'external'` call in *actions/profile.js* which was used for `shell.openExternal` to open URLs. This was replaced with `import openURL from '../util/open-url'`. `openURL` has native specific handling.
2. Adds GIF support back into our RN Android build. Fresco, the image pipeline library, removed GIF support from it's core about 2 months ago which resulted in RN no longer having GIF support on Android. I've followed the [GitHub issue's](https://github.com/facebook/react-native/issues/7760) recommendation of adding the now separate GIF dependency into the gradle file.

### Some pics

<img width="432" alt="screen shot 2016-08-11 at 4 37 00 pm" src="https://cloud.githubusercontent.com/assets/1152104/17609313/a10e5f20-5fe8-11e6-8225-643572d251a9.png">
