### PR TITLE
Fix mobile by removing 'url' dependency in profile reducer

### DIFF
--- a/shared/reducers/profile.js
+++ b/shared/reducers/profile.js
@@ -2,7 +2,6 @@
 import * as CommonConstants from '../constants/common'
 import * as Constants from '../constants/profile'
 import type {Actions, State} from '../constants/profile'
-import {parse as parseUrl} from 'url'
 
 const initialState: State = {
   errorText: null,
@@ -28,10 +27,12 @@ function checkUsernameValid (platform, username): boolean {
 
 function cleanupUsername (platform, username): string {
   if (['http', 'https'].includes(platform)) {
-    const urlParsed = parseUrl(username)
     // Ensure that only the hostname is getting returned, with no
-    // protocal or path information
-    return urlParsed.hostname || username
+    // protocal, port, or path information
+    return username && username
+      .replace(/^.*?:\/\//, '') // Remove protocal information (if present)
+      .replace(/:.*/, '') // Remove port information (if present)
+      .replace(/\/.*/, '') // Remove path information (if present)
   }
   return username
 }


### PR DESCRIPTION
`reducers/profile` broke native by adding a dependency on `url.parse` which is unavailable in RN. This function was only being used to cleanup a URL to get it's hostname, so I've attempted to replicate that functionality using simple string replace statements. I chose to go this route instead of using a regex capture group because we are not trying to validate the URL, and for all we know the URL entered may be something like `hello, my name is bob`, which we don't need to handle anyways. Instead, I wrote a chain of replaces that will remove the protocol part of a input, if present, the port part of an input, if present, and any path data in an input, if present. I tested it across these cases:

    'http://facebook.com',
    'https://facebook.com',
    'www.facebook.com',
    'hello.hi.facebook.com',
    'alexwendland.co.uk',
    'hello.edu/test',
    'hello.me:80',
    'http://hello.me:90/test/test',
    '',
    'ftp://test.edu',
    this is definitely not right

Which produced these results:

    'facebook.com',
    'facebook.com',
    'www.facebook.com',
    'hello.hi.facebook.com',
    'alexwendland.co.uk',
    'hello.edu',
    'hello.me',
    'hello.me',
    '',
    'test.com',
    'this is definitely not right'