### PR TITLE
Handle error cases in identify

### DIFF
--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -146,6 +146,7 @@ export function triggerIdentify (uid: string = '', userAssertion: string = ''
 
     // Don't identify ourself
     if (allowSelf || myUID !== uid) {
+      dispatch({type: Constants.identifyStarted, payload: null})
       identifyIdentify2Rpc({
         param: {
           uid,
@@ -166,6 +167,12 @@ export function triggerIdentify (uid: string = '', userAssertion: string = ''
         incomingCallMap,
         callback: (error, response) => {
           console.log('called identify and got back', error, response)
+          if (error) {
+            // TODO(MM) figure out why we have this discrepancy
+            // The type is supposedly error.desc, but in practice we do error.raw.desc
+            dispatch({type: Constants.identifyFinished, error: true, payload: {error: error.raw && error.raw.desc || error.desc}})
+          }
+          dispatch({type: Constants.identifyFinished, payload: null})
           clearTimeout(clearPendingTimeout)
           dispatch(pendingIdentify(userAssertion || uid, false))
           resolve()

--- a/shared/common-adapters/error-profile.js
+++ b/shared/common-adapters/error-profile.js
@@ -1,0 +1,19 @@
+// @flow
+import React from 'react'
+import Box from './box'
+import Text from './text'
+import {globalColors, globalMargins} from '../styles/style-guide'
+
+export type Props = {
+  error: string
+}
+
+export default function ErrorLoadingProfile ({error}: Props) {
+  return (
+    <Box style={{width: 320, flex: 1}}>
+      <Box style={{marginTop: globalMargins.xlarge, textAlign: 'center'}}>
+        <Text type='Error' style={{textAlign: 'center', color: globalColors.black_40}}>Error loading profile: {error}</Text>
+      </Box>
+    </Box>
+  )
+}

--- a/shared/constants/tracker.js
+++ b/shared/constants/tracker.js
@@ -100,10 +100,17 @@ export type ShowNonUser = TypedAction<'tracker:showNonUser', identifyUiDisplayTL
 export const pendingIdentify = 'tracker:pendingIdentify'
 export type PendingIdentify = TypedAction<'tracker:pendingIdentify', {username: string, pending: boolean}, void>
 
+export const identifyStarted = 'tracker:identifyStarted'
+export type IdentifyStarted = TypedAction<'tracker:identifyStarted', void, {error: string}>
+
+export const identifyFinished = 'tracker:identifyFinished'
+export type IdentifyFinished = TypedAction<'tracker:identifyFinished', void, void>
+
 export type NonUserActions = ShowNonUser | OnClose | PendingIdentify | UpdateFolders
 
 export type TrackerState = {
   type: 'tracker',
+  error: ?string,
   eldestKidChanged: boolean,
   currentlyFollowing: boolean,
   lastAction: ?('followed' | 'refollowed' | 'unfollowed' | 'error'),

--- a/shared/profile/index.js
+++ b/shared/profile/index.js
@@ -1,6 +1,7 @@
 // @flow
 import ConfirmOrPending from './confirm-or-pending-container'
 import EditProfile from './edit-profile'
+import ErrorComponent from '../common-adapters/error-profile'
 import PostProof from './post-proof-container'
 import ProveEnterUsername from './prove-enter-username-container'
 import ProveWebsiteChoice from './prove-website-choice-container'
@@ -8,11 +9,6 @@ import React, {Component} from 'react'
 import Render from './render'
 import Revoke from './revoke-container'
 import flags from '../util/feature-flags'
-import type {MissingProof} from '../common-adapters/user-proofs'
-import type {Proof} from '../constants/tracker'
-import type {Props} from './render'
-import type {TypedDispatch, Action} from '../constants/types/flux'
-import type {TypedState} from '../constants/reducer'
 import {Box, Text} from '../common-adapters'
 import {TypedConnector} from '../util/typed-connect'
 import {addProof, checkSpecificProof} from '../actions/profile'
@@ -20,6 +16,12 @@ import {getProfile, updateTrackers, onFollow, onUnfollow, openProofUrl} from '..
 import {isLoading} from '../constants/tracker'
 import {openInKBFS} from '../actions/kbfs'
 import {routeAppend, navigateUp} from '../actions/router'
+
+import type {MissingProof} from '../common-adapters/user-proofs'
+import type {Proof} from '../constants/tracker'
+import type {Props} from './render'
+import type {TypedDispatch, Action} from '../constants/types/flux'
+import type {TypedState} from '../constants/reducer'
 
 type OwnProps = {
   userOverride?: {
@@ -61,6 +63,10 @@ class Profile extends Component<void, ?Props, void> {
   }
 
   render () {
+    if (this.props && this.props.error) {
+      return <ErrorComponent error={this.props.error} />
+    }
+
     return this.props ? (
       <Render
         showComingSoon={!flags.tabProfileEnabled}

--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -49,6 +49,7 @@ const initialState: State = {
 function initialTrackerState (username: string): TrackerState {
   return {
     closed: true,
+    error: null,
     currentlyFollowing: false,
     eldestKidChanged: false,
     hidden: false,
@@ -125,6 +126,8 @@ function dedupeProofs (proofs: Array<Proof>): Array<Proof> {
 
 function updateUserState (state: TrackerState, action: Action): TrackerState {
   switch (action.type) {
+    case Constants.identifyStarted:
+      return {...state, error: null}
     case Constants.updateReason:
       // In case the reason is null, let's use our existing reason
       return {
@@ -348,6 +351,11 @@ function updateUserState (state: TrackerState, action: Action): TrackerState {
         ...state,
         tlfs: action.payload.tlfs,
       }
+    case Constants.identifyFinished:
+      if (action.error) {
+        return {...state, error: action.payload.error}
+      }
+      return {...state, error: null}
     default:
       return state
   }

--- a/shared/search/user-pane/index.js
+++ b/shared/search/user-pane/index.js
@@ -20,6 +20,12 @@ export default connector.connect(
     if (userForInfoPane && userForInfoPane.service === 'keybase') {
       const username = userForInfoPane.username
       const trackerState = trackers[username]
+      if (username && trackerState && trackerState.type === 'tracker' && !!trackerState.error) {
+        return {
+          mode: 'error',
+          error: trackerState.error,
+        }
+      }
       if (username && trackerState && trackerState.type === 'tracker') {
         const currentlyFollowing = trackerState.lastAction === 'followed' || trackerState.lastAction === 'refollowed' || trackerState.currentlyFollowing
         // TODO (mm) ideally userInfo should be null until we get a response from the server

--- a/shared/search/user-pane/render.js
+++ b/shared/search/user-pane/render.js
@@ -1,11 +1,13 @@
 // @flow
-import React, {Component} from 'react'
-import UserInfo from './user.render'
-import NonUserInfo from './non-user.render'
+import ErrorComponent from '../../common-adapters/error-profile'
 import Help from './help'
 import Loading from './loading'
-import type {Props as UserInfoPaneProps} from './user.render'
+import NonUserInfo from './non-user.render'
+import React, {Component} from 'react'
+import UserInfo from './user.render'
+
 import type {Props as NonUserInfoProps} from './non-user.render'
+import type {Props as UserInfoPaneProps} from './user.render'
 
 export type Props = {
   mode: 'keybase',
@@ -16,6 +18,9 @@ export type Props = {
 } | {
   mode: 'loading',
   username: string,
+} | {
+  mode: 'error',
+  error: string,
 } | {
   mode: 'nothingSelected'
 }
@@ -28,6 +33,8 @@ class Render extends Component<void, Props, void> {
       return <NonUserInfo {...this.props.nonUserInfoProps} />
     } else if (this.props.mode === 'loading') {
       return <Loading username={this.props.username} />
+    } else if (this.props.mode === 'error') {
+      return <ErrorComponent error={this.props.error} />
     }
 
     return (

--- a/shared/tracker/index.js
+++ b/shared/tracker/index.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux'
 import Render from './render'
 
 import * as trackerActions from '../actions/tracker'
+import ErrorLoadingProfile from '../common-adapters/error-profile.js'
 import {bindActionCreators} from 'redux'
 import {isLoading} from '../constants/tracker'
 
@@ -66,6 +67,10 @@ class Tracker extends Component {
   render () {
     if (this.props.closed) {
       return <div />
+    }
+
+    if (this.props.error) {
+      return <ErrorLoadingProfile error={this.props.error} />
     }
 
     const renderProps = trackerPropsToRenderProps(this.props)


### PR DESCRIPTION
@keybase/react-hackers 

This records errors in identifies and builds a basic ui to tell the user that the error happened.

This doesn't happen very often so I've deferred building a better error handling system. It is just a box with error text.

When this error happened we were also being told every user you followed has trackingChanged, so the service was identifying all your followers (Aug 5. bug).

I think the error happened because of this, and we haven't seen too many other cases of errors. Although now maybe we'll see more and better reports from users because it looks less broken and more clear what went wrong.