### PR TITLE
Cleanup local-debug.native.js to clarify dumbFilter usage

### DIFF
--- a/shared/local-debug-live.js
+++ b/shared/local-debug-live.js
@@ -1,11 +1,17 @@
 // @flow
 import {envVarDebugJson} from './local-debug'
 
+/*
+ * This file is used for setting the dumbFilter & related settings
+ * on both desktop and native
+ */
+
+// Shared settings
 const dumbFilterJson = (envVarDebugJson() || {}).dumbFilter || ''
-const dumbFilterOverride = '' // to override during a hot reload session
+const dumbFilterOverride = '' // Changing this will apply during a hot reload session
 
 export const dumbFilter = dumbFilterOverride || dumbFilterJson
 
-// the following only apply to mobile:
-export const dumbIndex = 30
+// Mobile only settings
+export const dumbIndex = 0
 export const dumbFullscreen = false

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -39,9 +39,6 @@ if (__DEV__ && true) {
     [Tabs.settingsTab]: ['devMenu', 'dumbSheet'],
   }
   config.overrideLoggedInTab = Tabs.settingsTab
-  config.dumbFilter = ''
-  config.dumbIndex = 0
-  config.dumbFullscreen = false
   config.printRoutes = true
 }
 


### PR DESCRIPTION
Minor changes so that how to set `dumbFilter` on native is no longer misleading