### PR TITLE
Hacky way to make sure we really quit

### DIFF
--- a/desktop/app/ctl.js
+++ b/desktop/app/ctl.js
@@ -8,11 +8,19 @@ export function ctlStop (callback) {
   exec(binPath, args, 'darwin', 'prod', false, callback)
 }
 
+function exitApp () {
+  // For some reason the first app.exit kills only popups (remote components and pinentry)
+  // The main window survives. This makes sure to keep exiting until we are actually out.
+  // It seems to work even when we have a broken reference to a browser window.
+  // (Which happens because our first exit killed the browser window w/o updating our book keeping state)
+  setInterval(() => app.exit(0), 200)
+}
+
 export function quit () {
   // Only quit the app in dev mode
   if (__DEV__) {
     console.log('Only quiting gui in dev mode')
-    app.exit(0)
+    exitApp()
     return
   }
 
@@ -22,6 +30,6 @@ export function quit () {
     if (stopErr) {
       console.log('Error in ctl stop, when quiting:', stopErr)
     }
-    app.exit(0)
+    exitApp()
   })
 }


### PR DESCRIPTION
@keybase/react-hackers 

to test/repro problem:

```

// build a pinentry window
windowState = {
  closed: false,
  sessionID: -1,
  features: [],
  type: 0,
  prompt: "doo stuff",
  windowTitle: "demo",
  canceled: false,
  submitted: false,
}

devEdit(['pinentry','pinentryStates',1], windowState)

// test app.exit(0)
require('electron').remote.app.exit(0) 
// or use quit button.
```
notice how it doesn't work the first time. Just closes windows.


I feel like app.exit(0) should kill everything and exit the process, and we shouldn't have to do this. But empirically looks like we do.

I went through a bunch of weird states, and this seems to work through those as well.

For example the case where we have dead references to windows or previous failed quits.
