### PR TITLE
Tweak margins a bit to add confirm or pending on mobile

### DIFF
--- a/shared/profile/confirm-or-pending.native.js
+++ b/shared/profile/confirm-or-pending.native.js
@@ -1,9 +1,35 @@
 /* @flow */
 
+import React from 'react'
+import {Box, Text, Button, PlatformIcon} from '../common-adapters'
+import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
+import {propsForPlatform} from './confirm-or-pending.shared'
+
 import type {Props} from './confirm-or-pending'
 
-const Render = ({platform}: Props) => {
-  return null
+const Render = (props: Props) => {
+  const {platform, onReloadProfile, titleColor, username, platformIconOverlayColor} = props
+  const {
+    title, platformIconOverlay, usernameSubtitle, message, messageSubtitle,
+  } = propsForPlatform(props)
+
+  return (
+    <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
+      <Box style={{...globalStyles.flexBoxColumn, justifyContent: 'center', alignItems: 'center', backgroundColor: titleColor, height: globalMargins.large}}>
+        <Text backgroundMode='Terminal' type='BodySmallSemibold'>{title}</Text>
+      </Box>
+      <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center', paddingTop: globalMargins.small, paddingBottom: globalMargins.medium, paddingLeft: globalMargins.medium, paddingRight: globalMargins.medium}}>
+        <PlatformIcon platform={platform} overlay={platformIconOverlay} overlayColor={platformIconOverlayColor} size={48} />
+        <Text type='Header' style={{color: globalColors.blue}}>{username}</Text>
+        {!!usernameSubtitle && <Text type='Body' style={{color: globalColors.black_10}}>{usernameSubtitle}</Text>}
+        <Text type='Body' style={{marginTop: globalMargins.small, textAlign: 'center'}}>{message}</Text>
+        {!!messageSubtitle && <Text type='BodySmall' style={{textAlign: 'center'}}>{messageSubtitle}</Text>}
+      </Box>
+      <Box style={{...globalStyles.flexBoxRow, paddingLeft: globalMargins.small, paddingRight: globalMargins.small}}>
+        <Button type='Primary' onClick={onReloadProfile} label='Reload profile' style={{flex: 1}} />
+      </Box>
+    </Box>
+  )
 }
 
 export default Render

--- a/shared/profile/confirm-or-pending.native.js
+++ b/shared/profile/confirm-or-pending.native.js
@@ -18,10 +18,10 @@ const Render = (props: Props) => {
       <Box style={{...globalStyles.flexBoxColumn, justifyContent: 'center', alignItems: 'center', backgroundColor: titleColor, height: globalMargins.large}}>
         <Text backgroundMode='Terminal' type='BodySmallSemibold'>{title}</Text>
       </Box>
-      <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center', paddingTop: globalMargins.small, paddingBottom: globalMargins.medium, paddingLeft: globalMargins.medium, paddingRight: globalMargins.medium}}>
+      <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center', paddingTop: globalMargins.xlarge, paddingBottom: globalMargins.medium, paddingLeft: globalMargins.medium, paddingRight: globalMargins.medium}}>
         <PlatformIcon platform={platform} overlay={platformIconOverlay} overlayColor={platformIconOverlayColor} size={48} />
         <Text type='Header' style={{color: globalColors.blue}}>{username}</Text>
-        {!!usernameSubtitle && <Text type='Body' style={{color: globalColors.black_10}}>{usernameSubtitle}</Text>}
+        {!!usernameSubtitle && <Text type='Body' style={{color: globalColors.black_10, paddingBottom: globalMargins.large}}>{usernameSubtitle}</Text>}
         <Text type='Body' style={{marginTop: globalMargins.small, textAlign: 'center'}}>{message}</Text>
         {!!messageSubtitle && <Text type='BodySmall' style={{textAlign: 'center'}}>{messageSubtitle}</Text>}
       </Box>

--- a/shared/profile/confirm-or-pending.native.js
+++ b/shared/profile/confirm-or-pending.native.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react'
-import {Box, Text, Button, PlatformIcon} from '../common-adapters'
+import {Box, Text, Button, PlatformIcon, StandardScreen} from '../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import {propsForPlatform} from './confirm-or-pending.shared'
 
@@ -32,4 +32,8 @@ const Render = (props: Props) => {
   )
 }
 
-export default Render
+const Wrapped = (props: Props) => {
+  return <StandardScreen styleOuter={{padding: 0, paddingTop: globalMargins.small}}><Render {...props} /></StandardScreen>
+}
+
+export default Wrapped


### PR DESCRIPTION
@keybase/react-hackers 

Almost the exact same thing as the desktop version with some tweaks to margins.

Wait until @cjb's https://github.com/keybase/client/pull/3890 is merged since this uses platform icon.


Previews:


<img width="459" alt="screen shot 2016-08-15 at 4 12 45 pm" src="https://cloud.githubusercontent.com/assets/594035/17683158/7c885992-6305-11e6-86c3-8469b18e715f.png">
<img width="473" alt="screen shot 2016-08-15 at 4 08 34 pm" src="https://cloud.githubusercontent.com/assets/594035/17683160/7c8c2086-6305-11e6-9547-7b7881c6e950.png">
<img width="501" alt="screen shot 2016-08-15 at 4 08 46 pm" src="https://cloud.githubusercontent.com/assets/594035/17683161/7c8cdce2-6305-11e6-8e3c-e61768a6816f.png">
<img width="501" alt="screen shot 2016-08-15 at 4 08 57 pm" src="https://cloud.githubusercontent.com/assets/594035/17683159/7c8ae180-6305-11e6-8074-5491527afea3.png">
<img width="459" alt="screen shot 2016-08-15 at 4 11 49 pm" src="https://cloud.githubusercontent.com/assets/594035/17683162/7c8d2170-6305-11e6-90e4-62238cfd030f.png">
