### PR TITLE
Bump timeout for installer tasks (exec)

### DIFF
--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.35</string>
+	<string>1.1.36</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.35</string>
+	<string>1.1.36</string>
 	<key>KBFuseBuild</key>
 	<string>3.4.2</string>
 	<key>KBFuseVersion</key>

--- a/osx/KBKit/KBKit/Component/KBFSService.m
+++ b/osx/KBKit/KBKit/Component/KBFSService.m
@@ -108,7 +108,7 @@
 
 - (void)_install:(KBCompletion)completion {
   NSString *binPath = [self.config serviceBinPathWithPathOptions:0 servicePath:_servicePath];
-  [KBTask executeForJSONWithCommand:binPath args:@[@"-d", @"--log-format=file", @"install", @"--format=json", @"--components=kbfs"] timeout:5 completion:^(NSError *error, id response) {
+  [KBTask executeForJSONWithCommand:binPath args:@[@"-d", @"--log-format=file", @"install", @"--format=json", @"--components=kbfs"] timeout:KBDefaultInstallableTimeout completion:^(NSError *error, id response) {
     if (!error) error = [KBInstallable checkForStatusErrorFromResponse:response];
     completion(error);
   }];
@@ -116,7 +116,7 @@
 
 - (void)uninstall:(KBCompletion)completion {
   NSString *binPath = [self.config serviceBinPathWithPathOptions:0 servicePath:_servicePath];
-  [KBTask execute:binPath args:@[@"-d", @"--log-format=file", @"uninstall", @"--components=kbfs"] timeout:5 completion:^(NSError *error, NSData *outData, NSData *errData) {
+  [KBTask execute:binPath args:@[@"-d", @"--log-format=file", @"uninstall", @"--components=kbfs"] timeout:KBDefaultInstallableTimeout completion:^(NSError *error, NSData *outData, NSData *errData) {
     completion(error);
   }];
 }

--- a/osx/KBKit/KBKit/Component/KBFuseComponent.m
+++ b/osx/KBKit/KBKit/Component/KBFuseComponent.m
@@ -49,7 +49,7 @@ typedef void (^KBOnFuseStatus)(NSError *error, KBRFuseStatus *fuseStatus);
 
 + (void)status:(NSString *)binPath bundleVersion:(KBSemVersion *)bundleVersion completion:(KBOnFuseStatus)completion {
   NSString *bundleVersionFlag = NSStringWithFormat(@"--bundle-version=%@", [bundleVersion description]);
-  [KBTask execute:binPath args:@[@"-d", @"--log-format=file", @"fuse", @"status", bundleVersionFlag] timeout:5 completion:^(NSError *error, NSData *outData, NSData *errData) {
+  [KBTask execute:binPath args:@[@"-d", @"--log-format=file", @"fuse", @"status", bundleVersionFlag] timeout:KBDefaultInstallableTimeout completion:^(NSError *error, NSData *outData, NSData *errData) {
     if (error) {
       completion(error, nil);
       return;

--- a/osx/KBKit/KBKit/Component/KBInstallable.h
+++ b/osx/KBKit/KBKit/Component/KBInstallable.h
@@ -18,6 +18,9 @@ typedef NS_ENUM (NSInteger, KBInstallRuntimeStatus) {
   KBInstallRuntimeStatusStopped,
 };
 
+// Default timeout for running (external) install (or status) commands
+extern const NSTimeInterval KBDefaultInstallableTimeout;
+
 typedef void (^KBOnComponentStatus)(KBComponentStatus *installStatus);
 
 @interface KBInstallable : KBComponent

--- a/osx/KBKit/KBKit/Component/KBInstallable.m
+++ b/osx/KBKit/KBKit/Component/KBInstallable.m
@@ -10,6 +10,9 @@
 #import <GHKit/GHKit.h>
 #import <ObjectiveSugar/ObjectiveSugar.h>
 
+// This should be larger than the default timeout we use in install/status commands (> 10 seconds)
+const NSTimeInterval KBDefaultInstallableTimeout = 11.0;
+
 @interface KBInstallable ()
 @property KBEnvConfig *config;
 @end

--- a/osx/KBKit/KBKit/Component/KBKeybaseLaunchd.m
+++ b/osx/KBKit/KBKit/Component/KBKeybaseLaunchd.m
@@ -13,6 +13,7 @@
 #import "KBTask.h"
 #import <Mantle/Mantle.h>
 #import <ObjectiveSugar/ObjectiveSugar.h>
+#import "KBInstallable.h"
 
 @interface KBKeybaseLaunchd ()
 @end
@@ -20,13 +21,13 @@
 @implementation KBKeybaseLaunchd
 
 + (void)run:(NSString *)binPath args:(NSArray *)args completion:(KBCompletion)completion {
-  [KBTask execute:binPath args:args timeout:5 completion:^(NSError *error, NSData *outData, NSData *errData) {
+  [KBTask execute:binPath args:args timeout:KBDefaultInstallableTimeout completion:^(NSError *error, NSData *outData, NSData *errData) {
     completion(error);
   }];
 }
 
 + (void)list:(NSString *)binPath name:(NSString *)name completion:(KBOnServiceStatuses)completion {
-  [KBTask executeForJSONWithCommand:binPath args:@[@"--log-format=file", @"launchd", @"list", @"--format=json", name] timeout:5 completion:^(NSError *error, id value) {
+  [KBTask executeForJSONWithCommand:binPath args:@[@"--log-format=file", @"launchd", @"list", @"--format=json", name] timeout:KBDefaultInstallableTimeout completion:^(NSError *error, id value) {
     NSArray *statuses = [MTLJSONAdapter modelsOfClass:KBRServiceStatus.class fromJSONArray:value[name] error:&error];
     completion(nil, statuses);
   }];
@@ -34,7 +35,7 @@
 
 + (void)status:(NSString *)binPath name:(NSString *)name completion:(KBOnServiceStatus)completion {
   DDLogDebug(@"Checking launchd status for %@", name);
-  [KBTask executeForJSONWithCommand:binPath args:@[@"--log-format=file", @"launchd", @"status", @"--format=json", name] timeout:5 completion:^(NSError *error, id value) {
+  [KBTask executeForJSONWithCommand:binPath args:@[@"--log-format=file", @"launchd", @"status", @"--format=json", name] timeout:KBDefaultInstallableTimeout completion:^(NSError *error, id value) {
     if (error) {
       completion(error, nil);
       return;

--- a/osx/KBKit/KBKit/Component/KBService.m
+++ b/osx/KBKit/KBKit/Component/KBService.m
@@ -95,7 +95,7 @@
 
 - (void)install:(KBCompletion)completion {
   NSString *binPath = [self.config serviceBinPathWithPathOptions:0 servicePath:self.servicePath];
-  [KBTask executeForJSONWithCommand:binPath args:@[@"-d", @"--log-format=file", @"install", @"--format=json", @"--components=service"] timeout:5 completion:^(NSError *error, id response) {
+  [KBTask executeForJSONWithCommand:binPath args:@[@"-d", @"--log-format=file", @"install", @"--format=json", @"--components=service"] timeout:KBDefaultInstallableTimeout completion:^(NSError *error, id response) {
     if (!error) error = [KBInstallable checkForStatusErrorFromResponse:response];
     completion(error);
   }];
@@ -103,7 +103,7 @@
 
 - (void)uninstall:(KBCompletion)completion {
   NSString *binPath = [self.config serviceBinPathWithPathOptions:0 servicePath:self.servicePath];
-  [KBTask execute:binPath args:@[@"-d", @"--log-format=file", @"uninstall", @"--components=service"] timeout:5 completion:^(NSError *error, NSData *outData, NSData *errData) {
+  [KBTask execute:binPath args:@[@"-d", @"--log-format=file", @"uninstall", @"--components=service"] timeout:KBDefaultInstallableTimeout completion:^(NSError *error, NSData *outData, NSData *errData) {
     completion(error);
   }];
 }

--- a/osx/KBKit/KBKit/Component/KBUpdaterService.m
+++ b/osx/KBKit/KBKit/Component/KBUpdaterService.m
@@ -38,7 +38,7 @@
 
 - (void)install:(KBCompletion)completion {
   NSString *binPath = [self.config serviceBinPathWithPathOptions:0 servicePath:_servicePath];
-  [KBTask executeForJSONWithCommand:binPath args:@[@"-d", @"--log-format=file", @"install", @"--format=json", @"--components=updater"] timeout:5 completion:^(NSError *error, id response) {
+  [KBTask executeForJSONWithCommand:binPath args:@[@"-d", @"--log-format=file", @"install", @"--format=json", @"--components=updater"] timeout:KBDefaultInstallableTimeout completion:^(NSError *error, id response) {
     if (!error) error = [KBInstallable checkForStatusErrorFromResponse:response];
     completion(error);
   }];
@@ -46,7 +46,7 @@
 
 - (void)uninstall:(KBCompletion)completion {
   NSString *binPath = [self.config serviceBinPathWithPathOptions:0 servicePath:_servicePath];
-  [KBTask execute:binPath args:@[@"-d", @"--log-format=file", @"uninstall", @"--components=updater"] timeout:5 completion:^(NSError *error, NSData *outData, NSData *errData) {
+  [KBTask execute:binPath args:@[@"-d", @"--log-format=file", @"uninstall", @"--components=updater"] timeout:KBDefaultInstallableTimeout completion:^(NSError *error, NSData *outData, NSData *errData) {
     completion(error);
   }];
 }

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -76,7 +76,7 @@ shared_support_dir="$out_dir/Keybase.app/Contents/SharedSupport"
 resources_dir="$out_dir/Keybase.app/Contents/Resources/"
 
 # The KeybaseInstaller.app installs KBFuse, keybase.Helper, services and CLI via a native app
-installer_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseInstaller-1.1.35-darwin.tgz"
+installer_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseInstaller-1.1.36-darwin.tgz"
 # KeybaseUpdater.app is the native updater UI (prompt dialogs)
 updater_url="https://github.com/keybase/client/releases/download/v1.0.16/KeybaseUpdater-1.0.3-darwin.tgz"
 


### PR DESCRIPTION
Increasing timeout to 11 seconds, since the install commands in (go) client use 10 second timeout.

Also launchd can be slow to startup on boot under heavy load so 5 seconds isn't quite long enough of a timeout.