### PR TITLE
do a little bit more loggin in run_test.sh

### DIFF
--- a/go/test/run_tests.sh
+++ b/go/test/run_tests.sh
@@ -3,6 +3,10 @@
 cd "$(dirname "$BASH_SOURCE")/.."
 
 set -f -u -e
+
+# Log the Go version.
+echo "Running tests on commit $(git rev-parse --short HEAD) with $(go version)."
+
 DIRS=$(go list ./... | grep -v /vendor/ | sed -e 's/^github.com\/keybase\/client\/go\///')
 
 export KEYBASE_LOG_SETUPTEST_FUNCS=1


### PR DESCRIPTION
r? @cjb 

A logging change for the convenience of https://github.com/keybase/client/pull/3902. Waiting for CI to confirm that it logs Go version 1.7.