### PR TITLE
Open at login setting

### DIFF
--- a/desktop/app/app-state.js
+++ b/desktop/app/app-state.js
@@ -63,7 +63,6 @@ export default class AppState {
   }
 
   checkOpenAtLogin () {
-    console.log('Checking open at login')
     if (!this.state.openAtLoginSet && appBundlePath() === '/Applications/Keybase.app') {
       console.log('Setting open at login')
       app.setLoginItemSettings({

--- a/desktop/app/app-state.js
+++ b/desktop/app/app-state.js
@@ -7,6 +7,7 @@
 import {app, screen} from 'electron'
 import fs from 'fs'
 import path from 'path'
+import {appBundlePath} from './paths'
 import jsonfile from 'jsonfile'
 import deepEqual from 'deep-equal'
 import type {State, Options, Config, Managed} from './app-state'
@@ -28,6 +29,7 @@ export default class AppState {
       displayBounds: null,
       tab: null,
       dockHidden: false,
+      openAtLoginSet: false,
     }
 
     this.config = {
@@ -58,6 +60,18 @@ export default class AppState {
         console.log('Error saving file:', err)
       }
     })
+  }
+
+  checkOpenAtLogin () {
+    console.log('Checking open at login')
+    if (!this.state.openAtLoginSet && appBundlePath() === '/Applications/Keybase.app') {
+      console.log('Setting open at login')
+      app.setLoginItemSettings({
+        openAtLogin: true,
+      })
+      this.state.openAtLoginSet = true
+      this.saveState()
+    }
   }
 
   manageWindow (win: any) {

--- a/desktop/app/app-state.js.flow
+++ b/desktop/app/app-state.js.flow
@@ -11,6 +11,7 @@ export type State = {
   displayBounds: ?any,
   tab: ?string,
   dockHidden: boolean,
+  openAtLoginSet: boolean,
 }
 
 export type Config = {

--- a/desktop/app/installer.js
+++ b/desktop/app/installer.js
@@ -24,7 +24,6 @@ export default callback => {
       quit()
       return
     }
-
     callback(err)
   })
 }

--- a/desktop/app/installer.js
+++ b/desktop/app/installer.js
@@ -24,6 +24,7 @@ export default callback => {
       quit()
       return
     }
+
     callback(err)
   })
 }

--- a/desktop/app/main-window.js
+++ b/desktop/app/main-window.js
@@ -33,15 +33,8 @@ export default function () {
     mainWindow.window.setPosition(forceMainWindowPosition.x, forceMainWindowPosition.y)
   }
 
-  let isRestore = false
-  if (getenv.boolish('KEYBASE_RESTORE_UI', false) || app.getLoginItemSettings().restoreState) {
-    isRestore = true
-  }
-
-  let openHidden = false
-  if ((getenv.string('KEYBASE_START_UI', '') === 'hideWindow') || app.getLoginItemSettings().wasOpenedAsHidden) {
-    openHidden = true
-  }
+  const isRestore = getenv.boolish('KEYBASE_RESTORE_UI', false) || app.getLoginItemSettings().restoreState
+  const openHidden = (getenv.string('KEYBASE_START_UI', '') === 'hideWindow') || app.getLoginItemSettings().wasOpenedAsHidden
 
   // We show the main window on startup if:
   //  - We are not restoring the UI (after update)

--- a/go/install/install.go
+++ b/go/install/install.go
@@ -39,7 +39,6 @@ type Context interface {
 	GetRunMode() libkb.RunMode
 	GetServiceInfoPath() string
 	GetKBFSInfoPath() string
-	GetAppStartMode() (libkb.AppStartMode, error)
 }
 
 // ComponentName defines a component name

--- a/go/install/install_osx.go
+++ b/go/install/install_osx.go
@@ -826,34 +826,6 @@ func OSVersion() (semver.Version, error) {
 	return semver.Make(swver)
 }
 
-// RunAfterStartup runs after service startup
-func RunAfterStartup(context Context, isService bool, log Log) {
-	// Ensure the app is running (if it exists and is supported on the platform)
-	if libkb.IsBrewBuild {
-		return
-	}
-	if context.GetRunMode() != libkb.ProductionRunMode {
-		return
-	}
-	mode, err := context.GetAppStartMode()
-	if err != nil {
-		log.Errorf("Error getting app start mode: %s", err)
-	}
-	log.Debug("App start mode: %s", mode)
-	switch mode {
-	case libkb.AppStartModeService:
-		if !isService {
-			return
-		}
-	case libkb.AppStartModeDisabled:
-		return
-	}
-
-	if err := RunApp(context, log); err != nil {
-		log.Errorf("Error starting the app: %s", err)
-	}
-}
-
 func installUpdater(context Context, keybaseBinPath string, force bool, log Log) error {
 	if context.GetRunMode() != libkb.ProductionRunMode {
 		return fmt.Errorf("Updater not supported in this run mode")

--- a/go/install/install_unix.go
+++ b/go/install/install_unix.go
@@ -82,11 +82,6 @@ func KBFSBinPath(runMode libkb.RunMode, binPath string) (string, error) {
 	return kbfsBinPathDefault(runMode, binPath)
 }
 
-// RunAfterStartup is not used on unix
-func RunAfterStartup(context Context, isService bool, log Log) error {
-	return nil
-}
-
 // kbfsBinName returns the name for the KBFS executable
 func kbfsBinName() string {
 	return "kbfsfuse"

--- a/go/install/install_windows.go
+++ b/go/install/install_windows.go
@@ -36,11 +36,6 @@ func updaterBinName() (string, error) {
 	return "upd.exe", nil
 }
 
-// RunAfterStartup is not supported on Windows
-func RunAfterStartup(context Context, isService bool, log Log) error {
-	return nil
-}
-
 // RunApp starts the app
 func RunApp(context Context, log Log) error {
 	// TODO: Start the app

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -125,9 +125,6 @@ func mainInner(g *libkb.GlobalContext) error {
 		return err
 	}
 
-	// Install hook for after startup
-	install.RunAfterStartup(g, cl.IsService(), g.Log)
-
 	err = cmd.Run()
 	if !cl.IsService() {
 		// Errors that come up in printing this warning are logged but ignored.

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -260,10 +260,6 @@ func (p CommandLine) GetMountDir() string {
 	return p.GetGString("mountdir")
 }
 
-func (p CommandLine) GetAppStartMode() string {
-	return p.GetGString("app-start-mode")
-}
-
 func (p CommandLine) GetBool(s string, glbl bool) (bool, bool) {
 	var v bool
 	if glbl {

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -674,11 +674,6 @@ func (f JSONConfigFile) IsAdmin() (bool, bool) {
 	return f.GetBoolAtPath("is_admin")
 }
 
-func (f JSONConfigFile) GetAppStartMode() string {
-	s, _ := f.GetStringAtPath("app_start_mode")
-	return s
-}
-
 func (f JSONConfigFile) GetTimeAtPath(path string) keybase1.Time {
 	var ret keybase1.Time
 	s, _ := f.GetStringAtPath(path)

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -436,12 +436,3 @@ const (
 const (
 	PGPAssertionKey = "pgp"
 )
-
-type AppStartMode string
-
-const (
-	AppStartModeError    AppStartMode = "error"
-	AppStartModeDefault  AppStartMode = "default" // It will be "service" in most cases
-	AppStartModeDisabled AppStartMode = "disabled"
-	AppStartModeService  AppStartMode = "service" // Open app after service start
-)

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -69,7 +69,6 @@ func (n NullConfiguration) GetUpdateURL() string                          { retu
 func (n NullConfiguration) GetUpdateDisabled() (bool, bool)               { return false, false }
 func (n NullConfiguration) GetVDebugSetting() string                      { return "" }
 func (n NullConfiguration) GetLocalTrackMaxAge() (time.Duration, bool)    { return 0, false }
-func (n NullConfiguration) GetAppStartMode() string                       { return "" }
 func (n NullConfiguration) GetGregorURI() string                          { return "" }
 func (n NullConfiguration) GetGregorSaveInterval() (time.Duration, bool)  { return 0, false }
 func (n NullConfiguration) GetGregorPingInterval() (time.Duration, bool)  { return 0, false }
@@ -1038,40 +1037,6 @@ func (e *Env) GetMountDir() (string, error) {
 	default:
 		return "", fmt.Errorf("Invalid run mode: %s", runMode)
 	}
-}
-
-func ParseAppStartMode(s string) (AppStartMode, error) {
-	switch s {
-	case "":
-		return AppStartModeDefault, nil
-	case "service":
-		return AppStartModeService, nil
-	case "disabled":
-		return AppStartModeDisabled, nil
-	default:
-		return AppStartModeError, fmt.Errorf("Bad app start mode: '%s'", s)
-	}
-}
-
-func (e *Env) GetAppStartMode() (AppStartMode, error) {
-
-	sources := []string{
-		e.cmd.GetAppStartMode(),
-		os.Getenv("KEYBASE_APP_START_MODE"),
-		e.config.GetAppStartMode(),
-	}
-
-	for _, source := range sources {
-		// If there was an error, or a non-default selection, then
-		// return out of here.
-		if mode, err := ParseAppStartMode(source); err != nil || mode != AppStartModeDefault {
-			return mode, err
-		}
-	}
-
-	// The default mode is Service, meaning the service should be
-	// starting the app.
-	return AppStartModeService, nil
 }
 
 // GetServiceInfoPath returns path to info file written by the Keybase service after startup

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -627,10 +627,6 @@ func (g *GlobalContext) CallLogoutHooks() {
 	}
 }
 
-func (g *GlobalContext) GetAppStartMode() (AppStartMode, error) {
-	return g.Env.GetAppStartMode()
-}
-
 func (g *GlobalContext) GetConfigDir() string {
 	return g.Env.GetConfigDir()
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -62,7 +62,6 @@ type CommandLine interface {
 	GetLocalRPCDebug() string
 	GetTimers() string
 	GetRunMode() (RunMode, error)
-	GetAppStartMode() string
 
 	GetScraperTimeout() (time.Duration, bool)
 	GetAPITimeout() (time.Duration, bool)
@@ -165,7 +164,6 @@ type ConfigReader interface {
 	GetUpdateURL() string
 	GetUpdateDisabled() (bool, bool)
 	GetLocalTrackMaxAge() (time.Duration, bool)
-	GetAppStartMode() string
 	IsAdmin() (bool, bool)
 
 	GetTorMode() (TorMode, error)


### PR DESCRIPTION
Electron support for login items has improved a ton!
https://github.com/electron/electron/blob/master/docs/api/app.md#appsetloginitemsettingssettings-macos-windows

- Sets system preferences login item on first run (if it has never been set and is installed in /Applications)
- Uses system preferences login item setting whether to start on boot instead of "app start mode" from service
- Restores UI if opened from login (boot)
- Hides window & dock if login item is set to open as hidden
- Removes app_start_mode setting and all code associated with it

A lot of manual testing.