### PR TITLE
this fix gets us half the way there

### DIFF
--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -535,7 +535,7 @@ func (c *ChainLink) PutSigCheckCache(cki *ComputedKeyInfos) {
 	return
 }
 
-func (c *ChainLink) VerifySigWithKeyFamily(ckf ComputedKeyFamily) (cached bool, err error) {
+func (c *ChainLink) VerifySigWithKeyFamily(ckf ComputedKeyFamily, laxEtimeCheck bool) (cached bool, err error) {
 
 	var key GenericKey
 	var sigID keybase1.SigID
@@ -545,7 +545,7 @@ func (c *ChainLink) VerifySigWithKeyFamily(ckf ComputedKeyFamily) (cached bool, 
 		return cached, err
 	}
 
-	if key, _, err = ckf.FindActiveSibkeyAtTime(c.GetKID(), c.GetCTime()); err != nil {
+	if key, _, err = ckf.FindActiveSibkeyAtTime(c.GetKID(), c.GetCTime(), laxEtimeCheck); err != nil {
 		return
 	}
 

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -437,15 +437,21 @@ func (sc *SigChain) verifySubchain(kf KeyFamily, links []*ChainLink) (cached boo
 		isFinalLink := (linkIndex == len(links)-1)
 		isLastLinkInSameKeyRun := (isFinalLink || newKID != links[linkIndex+1].GetKID())
 
+		laxEtimeCheck := false
+
 		if pgpcl, ok := tcl.(*PGPUpdateChainLink); ok {
 			if hash := pgpcl.GetPGPFullHash(); hash != "" {
 				sc.G().Log.Debug("| Setting active PGP hash for %s: %s", pgpcl.kid, hash)
 				ckf.SetActivePGPHash(pgpcl.kid, hash)
+				if pgpcl.kid == link.GetKID() {
+					laxEtimeCheck = true
+					sc.G().Log.Debug("| Activated lax expire time check")
+				}
 			}
 		}
 
 		if isModifyingKeys || isFinalLink || isLastLinkInSameKeyRun {
-			_, err = link.VerifySigWithKeyFamily(ckf)
+			_, err = link.VerifySigWithKeyFamily(ckf, laxEtimeCheck)
 			if err != nil {
 				sc.G().Log.Debug("| Failure in VerifySigWithKeyFamily: %s", err)
 				return


### PR DESCRIPTION
- need to confer with @oconnor663 for the second half. the issue is that
  HasActiveKey and GetKeyRole() don't do the right thing w/r/t PGP key
  updates the extend expiration times. They just take the first ETime and
  not the one that's been pushed forward via pgp_update links.