### PR TITLE
Mobile: Import PGP warning

### DIFF
--- a/shared/profile/pgp/prove-pgp-import.native.js
+++ b/shared/profile/pgp/prove-pgp-import.native.js
@@ -8,17 +8,26 @@ class ProvePgpImport extends Component<void, Props, void> {
   render () {
     return (
       <StandardScreen onClose={this.props.onCancel} style={styleContainer}>
-        <Icon type='icon-pgp-key-48' />
-        <Text type='Body'>Importing a PGP key is not supported on our mobile app. To continue, download the Keybase desktop app and follow the instructions there.</Text>
+        <Icon style={styleHeaderIcon} type='icon-pgp-key-48' />
+        <Text style={styleBody} type='Body'>Importing a PGP key is not supported on our mobile app. To continue, download the Keybase desktop app and follow the instructions there.</Text>
       </StandardScreen>
     )
   }
 }
 
 const styleContainer = {
-  maxWidth: 576,
-  padding: globalMargins.medium,
-  marginLeft: globalMargins.medium,
-  marginRight: globalMargins.medium,
+  justifyContent: 'flex-start',
 }
+
+const styleHeaderIcon = {
+  marginTop: globalMargins.large,
+  alignSelf: 'center',
+}
+
+const styleBody = {
+  marginTop: globalMargins.large,
+  textAlign: 'center',
+  margin: globalMargins.medium,
+}
+
 export default ProvePgpImport


### PR DESCRIPTION
@keybase/react-hackers 

Just the "we don't do that" screen for native, looks like I already merged in a partial version of this.  @awendland, we'll need to apply your PGP icon fix here too.  

Zeplin vs screenshot:

![zeplin](https://cloud.githubusercontent.com/assets/21217/17743398/9bdd01cc-6471-11e6-9cad-ec490f23c384.png)

![device-2016-08-17-115201](https://cloud.githubusercontent.com/assets/21217/17743438/bd066640-6471-11e6-98fa-c6cb43dc4b3b.png)
