### PR TITLE
Add string resources to runquiet

### DIFF
--- a/go/tools/winresource/main.go
+++ b/go/tools/winresource/main.go
@@ -45,6 +45,8 @@ func main() {
 	printCustomBuildPtr := flag.Bool("cb", false, "print custom build number to console (no .syso output)")
 	printWinVerPtr := flag.Bool("w", false, "print windows format version to console (no .syso output)")
 	iconPtr := flag.String("i", "../../media/icons/Keybase.ico", "icon pathname")
+	fileDescriptionPtr := flag.String("d", "Keybase utility", "File Description")
+	originalFilenamePtr := flag.String("n", "keybase.exe", "File name")
 
 	flag.Parse()
 
@@ -94,12 +96,13 @@ func main() {
 			FileType:       "01",
 			FileSubType:    "00",
 		},
+
 		StringFileInfo: goversioninfo.StringFileInfo{
 			CompanyName:      "Keybase, Inc.",
-			FileDescription:  "Keybase utility",
+			FileDescription:  *fileDescriptionPtr,
 			InternalName:     "Keybase",
 			LegalCopyright:   "Copyright (c) 2015, Keybase",
-			OriginalFilename: "keybase.exe",
+			OriginalFilename: *originalFilenamePtr,
 			ProductName:      "Keybase",
 			ProductVersion:   libkb.VersionString(),
 		},

--- a/packaging/windows/build_prerelease.cmd
+++ b/packaging/windows/build_prerelease.cmd
@@ -52,6 +52,7 @@ popd
 
 :: Runquiet
 pushd %GOPATH%\src\github.com\keybase\client\go\tools\runquiet
+..\winresource\winresource.exe  -d "Keybase quiet start utility" -n "runquiet.exe" -i ../../../media/icons/Keybase.ico
 go build -ldflags "-H windowsgui"
 popd
 


### PR DESCRIPTION
...so that it doesn't say "runquiet" in the startup panel of task manager
![image](https://cloud.githubusercontent.com/assets/862397/17754331/d752d0da-6488-11e6-8681-c0e713123f44.png)

@gabriel @maxtaco 