### PR TITLE
Mobile PGP enter info DESKTOP-1647

### DIFF
--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -107,7 +107,7 @@ const floatingLabelStyle = {
   textAlign: 'center',
   position: 'relative',
   height: 21,
-  top: -21,
+  top: -12,
 }
 
 const errorText = {

--- a/shared/common-adapters/small-input.desktop.js
+++ b/shared/common-adapters/small-input.desktop.js
@@ -1,5 +1,4 @@
 // @flow
-
 import React from 'react'
 import Box from './box'
 import Input from './input'
@@ -8,14 +7,14 @@ import {globalStyles, globalColors} from '../styles/style-guide'
 
 import type {SmallInputProps} from './small-input'
 
-export default function SmallInput ({hintText, label, onChange, value, errorState}: SmallInputProps) {
+export default function SmallInput ({errorState, hintText, label, onChange, style, value}: SmallInputProps) {
   return (
-    <Box style={{...globalStyles.flexBoxRow, position: 'relative'}}>
-      <Text type='BodySmall' style={{position: 'absolute', bottom: 6, left: 2, color: (errorState ? globalColors.red : globalColors.blue)}}>{label}</Text>
-      <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
+    <Box style={{...styleContainer, ...style}}>
+      <Text type='BodySmall' style={styleLabel(errorState)}>{label}</Text>
+      <Box style={styleInputContainer}>
         <Input hintText={hintText}
-          hintStyle={{textAlign: 'left', marginLeft: 60, marginTop: 6, top: undefined}}
-          inputStyle={{textAlign: 'left', marginLeft: 60, top: 2}}
+          hintStyle={styleInputHint}
+          inputStyle={styleInputUser}
           value={value}
           textStyle={{height: undefined}}
           underlineStyle={errorState ? {backgroundColor: globalColors.red} : {}}
@@ -23,4 +22,34 @@ export default function SmallInput ({hintText, label, onChange, value, errorStat
       </Box>
     </Box>
   )
+}
+
+const styleContainer = {
+  ...globalStyles.flexBoxRow,
+  position: 'relative',
+}
+
+const styleLabel = (hasError: boolean) => ({
+  position: 'absolute',
+  bottom: 6,
+  left: 2,
+  color: (hasError ? globalColors.red : globalColors.blue),
+})
+
+const styleInputContainer = {
+  ...globalStyles.flexBoxColumn,
+  flex: 1,
+}
+
+const styleInputHint = {
+  textAlign: 'left',
+  marginLeft: 60,
+  marginTop: 6,
+  top: undefined,
+}
+
+const styleInputUser = {
+  textAlign: 'left',
+  marginLeft: 60,
+  top: 2,
 }

--- a/shared/common-adapters/small-input.js.flow
+++ b/shared/common-adapters/small-input.js.flow
@@ -8,6 +8,9 @@ export type SmallInputProps = {
   value: ?string,
   onChange: (next: string) => void,
   errorState: boolean,
+  style?: Object,
+  autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters', // Native only
+  autoCorrect?: boolean, // Native only
 }
 
 declare export default class Icon extends Component<void, SmallInputProps, void> {}

--- a/shared/common-adapters/small-input.native.js
+++ b/shared/common-adapters/small-input.native.js
@@ -39,4 +39,5 @@ const styleLabel = (hasError: boolean) => ({
 const styleInput = {
   textAlign: 'left',
   flex: 1,
+  padding: 0,
 }

--- a/shared/common-adapters/small-input.native.js
+++ b/shared/common-adapters/small-input.native.js
@@ -1,7 +1,42 @@
 // @flow
+import React from 'react'
+import {TextInput} from 'react-native'
+import Box from './box'
+import Text from './text.native'
+import {globalColors, globalMargins, globalStyles} from '../styles/style-guide'
 
 import type {SmallInputProps} from './small-input'
 
-export default function SmallInput ({hintText, label, onChange, value, errorState}: SmallInputProps) {
-  return null
+export default function SmallInput ({autoCapitalize, autoCorrect, errorState, hintText, label, onChange, style, value}: SmallInputProps) {
+  return (
+    <Box style={{...styleContainer(errorState), ...style}}>
+      <Text type='BodySmall' style={styleLabel(errorState)}>{label}</Text>
+      <TextInput
+        style={{...Text.textStyle({type: 'BodySemibold'}, {}), ...styleInput}}
+        placeholder={hintText}
+        placeholderTextColor={globalColors.black_10}
+        underlineColorAndroid={'transparent'}
+        autoCapitalize={autoCapitalize}
+        autoCorrect={autoCorrect}
+        value={value}
+        onChangeText={onChange} />
+    </Box>
+  )
+}
+
+const styleContainer = (hasError: boolean) => ({
+  ...globalStyles.flexBoxRow,
+  borderBottomWidth: 1,
+  borderColor: (hasError ? globalColors.red : globalColors.black_10),
+  paddingBottom: 2,
+})
+
+const styleLabel = (hasError: boolean) => ({
+  color: (hasError ? globalColors.red : globalColors.blue),
+  marginRight: globalMargins.xtiny,
+})
+
+const styleInput = {
+  textAlign: 'left',
+  flex: 1,
 }

--- a/shared/profile/dumb.js
+++ b/shared/profile/dumb.js
@@ -1,13 +1,9 @@
 /* @flow */
 import ConfirmOrPending from './confirm-or-pending'
 import EditAvatar from './edit-avatar'
-import FinishedGeneratedPgp from './pgp/finished-generating-pgp'
-import GeneratingPgp from './pgp/generating-pgp'
 import PostProof from './post-proof'
 import Profile from './render'
 import ProveEnterUsername from './prove-enter-username'
-import ProvePgpChoice from './pgp/prove-pgp-choice'
-import ProvePgpImport from './pgp/prove-pgp-import'
 import ProveWebsiteChoice from './prove-website-choice'
 import Revoke from './revoke'
 import pgpDumb from './pgp/dumb'
@@ -483,44 +479,6 @@ const dumbProveWebsiteChoice: DumbComponentMap<ProveWebsiteChoice> = {
   },
 }
 
-const dumbProvePgpChoice: DumbComponentMap<ProvePgpChoice> = {
-  component: ProvePgpChoice,
-  mocks: {
-    'Import or Generate': {
-      onCancel: () => console.log('ProvePgpChoice: onCancel'),
-      onOptionClick: op => console.log(`ProvePgpChoice: onOptionClick = ${op}`),
-    },
-  },
-}
-
-const dumbProvePgpImport: DumbComponentMap<ProvePgpImport> = {
-  component: ProvePgpImport,
-  mocks: {
-    'Import PGP': {
-      onCancel: () => console.log('ProvePgpImport: onCancel'),
-    },
-  },
-}
-
-const dumbFinishedGeneratingPgp: DumbComponentMap<FinishedGeneratedPgp> = {
-  component: FinishedGeneratedPgp,
-  mocks: {
-    ' ': {
-      onDone: shouldStoreKeyOnServer => console.log(`FinishedGeneratedPgp: onDone [shouldStoreKeyOnServer: ${String(shouldStoreKeyOnServer)}]`),
-      pgpKeyString: '-----BEGIN PGP PUBLIC KEY BLOCK-----\nComment: GPGTools - https://gpgtools.org\n\nmQINBFWtLwEBEADLvrTe/bzrKVL0Z4bofdrLACmwC8PGXk3iD6t+1uTBKVMpfqkH\nQxGVECp598wS8XI6ZC+sMUM+AGTROi+HUsfn2cFk6y6pYl/z9A7lgctoX5xKXYTt\nE4xAZBeN1mn+x2YTjHW2lga/SZmh5qpSn5AMeNe42R0EtZ9FrCwD+IiOlw/LqGoh\n7DHKVDHmqK//mfK/lFTJck+HPkgmLyC4iYjpGuqXKqODUtMFT4+bHYfowG8WkvVX\ncf59Z6Fc7PA+rSFy9QXt7TP1po5Mnxxr9jcqQzzy3BSrAhHxAPj3F9rWBLUG0yGJ\nmAy6c1yTsbSgviiA0n4gjqPVj3iD3aiOx/KGxCdN/vru37Gp5q4KiBz7yHIqvg3B\nSeCBEOremB3gZG24OIVncpr0U6qITaFIe6iHmx53sID9JAKwfxAIwcktXe+aGtWp\n',
-    },
-  },
-}
-
-const dumbGeneratingPgp: DumbComponentMap<GeneratingPgp> = {
-  component: GeneratingPgp,
-  mocks: {
-    'Generating PGP': {
-      onCancel: () => console.log('GeneratingPgp: onCancel'),
-    },
-  },
-}
-
 export default {
   'Profile': dumbMap,
   'Edit Avatar': dumbEditAvatar,
@@ -529,9 +487,5 @@ export default {
   'New Proof: Enter Username': dumbProveEnterUsername,
   'New Proof: Post': dumbPostProof,
   'New Proof: Website': dumbProveWebsiteChoice,
-  'New Proof: PGP': dumbProvePgpChoice,
-  'New Proof: PGP import': dumbProvePgpImport,
-  'New Proof: PGP generating': dumbGeneratingPgp,
-  'New Proof: PGP generate finished': dumbFinishedGeneratingPgp,
   ...pgpDumb,
 }

--- a/shared/profile/pgp/add.desktop.js
+++ b/shared/profile/pgp/add.desktop.js
@@ -1,7 +1,6 @@
 // @flow
-
 import React, {Component} from 'react'
-import {Box, Button, Icon, Input, SmallInput, Text} from '../../common-adapters'
+import {Box, Button, Icon, Input, SmallInput, StandardScreen, Text} from '../../common-adapters'
 import {globalStyles, globalMargins, globalColors} from '../../styles/style-guide'
 import type {Props} from './add'
 
@@ -9,39 +8,90 @@ class PgpAdd extends Component<void, Props, void> {
   render () {
     const nextDisabled = !this.props.email1 || !this.props.fullName
     return (
-      <Box style={containerStyle}>
+      <StandardScreen
+        style={styleContainer}
+        onClose={this.props.onCancel}>
         {/* TODO(MM) when we get the pgp icon, put it in here */}
         <Icon
           type={'iconfont-identity-pgp'}
-          style={{width: 48, height: 48, fontSize: 48, alignSelf: 'center'}} />
+          style={styleIcon} />
         <Text
-          style={{marginTop: globalMargins.medium, alignSelf: 'center'}}
+          style={styleHeader}
           type='Body'>
           Fill in your public info.
         </Text>
-        <Input floatingLabelText='Your full name' value={this.props.fullName}
-          onChangeText={this.props.onChangeFullName} textStyle={{height: undefined}} />
-        <SmallInput label='Email 1:' hintText='(required)' onChange={this.props.onChangeEmail1} value={this.props.email1} errorState={this.props.errorEmail1} />
-        <SmallInput label='Email 2:' hintText='(optional)' onChange={this.props.onChangeEmail2} value={this.props.email2} errorState={this.props.errorEmail2} />
-        <SmallInput label='Email 3:' hintText='(optional)' onChange={this.props.onChangeEmail3} value={this.props.email3} errorState={this.props.errorEmail3} />
+        <Input
+          floatingLabelText='Your full name'
+          value={this.props.fullName}
+          onChangeText={this.props.onChangeFullName}
+          textStyle={{height: undefined}} />
+        <SmallInput
+          label='Email 1:'
+          hintText='(required)'
+          onChange={this.props.onChangeEmail1}
+          value={this.props.email1}
+          errorState={this.props.errorEmail1} />
+        <SmallInput
+          label='Email 2:'
+          hintText='(optional)'
+          onChange={this.props.onChangeEmail2}
+          value={this.props.email2}
+          errorState={this.props.errorEmail2} />
+        <SmallInput
+          label='Email 3:'
+          hintText='(optional)'
+          onChange={this.props.onChangeEmail3}
+          value={this.props.email3}
+          errorState={this.props.errorEmail3} />
         <Text
-          style={{marginTop: globalMargins.small, marginBottom: globalMargins.medium, alignSelf: 'center',
-            ...(this.props.errorText ? {color: globalColors.red} : {})}}
+          style={styleInfoMessage(!!this.props.errorText)}
           type='BodySmall'>
           {this.props.errorText || 'Include any addresses you plan to use for PGP encrypted email.'}
         </Text>
-        <Box style={{...globalStyles.flexBoxRow, alignSelf: 'center'}}>
-          <Button type='Secondary' label='Cancel' onClick={this.props.onCancel} />
-          <Button type='Primary' label='Let the math begin' disabled={nextDisabled} onClick={this.props.onNext} />
+        <Box style={styleActions}>
+          <Button
+            type='Secondary'
+            label='Cancel'
+            onClick={this.props.onCancel} />
+          <Button
+            type='Primary'
+            label='Let the math begin'
+            disabled={nextDisabled}
+            onClick={this.props.onNext} />
         </Box>
-      </Box>
+      </StandardScreen>
     )
   }
 }
 
-const containerStyle = {
-  ...globalStyles.flexBoxColumn,
-  padding: globalMargins.medium,
+const styleContainer = {
+  alignItems: undefined,
+  maxWidth: 460,
+  width: '100%',
+}
+
+const styleIcon = {
+  width: 48,
+  height: 48,
+  fontSize: 48,
+  alignSelf: 'center',
+}
+
+const styleHeader = {
+  marginTop: globalMargins.medium,
+  alignSelf: 'center',
+}
+
+const styleInfoMessage = (errorText: boolean) => ({
+  marginTop: globalMargins.small,
+  alignSelf: 'center',
+  ...(errorText ? {color: globalColors.red} : {}),
+})
+
+const styleActions = {
+  ...globalStyles.flexBoxRow,
+  alignSelf: 'center',
+  marginTop: globalMargins.medium,
 }
 
 export default PgpAdd

--- a/shared/profile/pgp/add.native.js
+++ b/shared/profile/pgp/add.native.js
@@ -1,12 +1,99 @@
 // @flow
-
-import {Component} from 'react'
+import React, {Component} from 'react'
+import {Button, Icon, Input, SmallInput, StandardScreen, Text} from '../../common-adapters'
+import {globalMargins, globalColors} from '../../styles/style-guide'
 import type {Props} from './add'
 
 class PgpAdd extends Component<void, Props, void> {
   render () {
-    return null
+    const nextDisabled = !this.props.email1 || !this.props.fullName
+    const emailInputProps = {
+      style: styleEmailInput,
+      autoCapitalize: 'none',
+      autoCorrect: false,
+    }
+    return (
+      <StandardScreen
+        style={styleContainer}
+        onClose={this.props.onCancel}>
+        {/* TODO(MM) when we get the pgp icon, put it in here */}
+        <Icon
+          type={'iconfont-identity-pgp'}
+          style={styleIcon} />
+        <Text
+          style={styleHeader}
+          type='Body'>
+          Fill in your public info.
+        </Text>
+        <Input
+          floatingLabelText='Your full name'
+          value={this.props.fullName}
+          onChangeText={this.props.onChangeFullName}
+          textStyle={{height: undefined}} />
+        <SmallInput
+          {...emailInputProps}
+          label='Email 1:'
+          hintText='(required)'
+          onChange={this.props.onChangeEmail1}
+          value={this.props.email1}
+          errorState={this.props.errorEmail1} />
+        <SmallInput
+          {...emailInputProps}
+          label='Email 2:'
+          hintText='(optional)'
+          onChange={this.props.onChangeEmail2}
+          value={this.props.email2}
+          errorState={this.props.errorEmail2} />
+        <SmallInput
+          {...emailInputProps}
+          label='Email 3:'
+          hintText='(optional)'
+          onChange={this.props.onChangeEmail3}
+          value={this.props.email3}
+          errorState={this.props.errorEmail3} />
+        <Text
+          style={styleInfoMessage(!!this.props.errorText)}
+          type='BodySmall'>
+          {this.props.errorText || 'Include any addresses you plan to use for PGP encrypted email.'}
+        </Text>
+        <Button
+          style={styleAction}
+          type='Primary'
+          label='Let the math begin'
+          disabled={nextDisabled}
+          onClick={this.props.onNext} />
+      </StandardScreen>
+    )
   }
+}
+
+const styleContainer = {
+}
+
+const styleIcon = {
+  width: 48,
+  height: 48,
+  fontSize: 48,
+  alignSelf: 'center',
+}
+
+const styleHeader = {
+  marginTop: globalMargins.medium,
+  alignSelf: 'center',
+}
+
+const styleEmailInput = {
+  marginTop: globalMargins.small,
+}
+
+const styleInfoMessage = (errorText: boolean) => ({
+  marginTop: globalMargins.small,
+  textAlign: 'center',
+  ...(errorText ? {color: globalColors.red} : {}),
+})
+
+const styleAction = {
+  marginTop: globalMargins.small + globalMargins.tiny,
 }
 
 export default PgpAdd

--- a/shared/profile/pgp/dumb.js
+++ b/shared/profile/pgp/dumb.js
@@ -1,7 +1,20 @@
 // @flow
-
+import ProvePgpChoice from './prove-pgp-choice'
 import PgpAdd from './add'
+import GeneratingPgp from './generating-pgp'
+import FinishedGeneratedPgp from './finished-generating-pgp'
+import ProvePgpImport from './prove-pgp-import'
 import type {DumbComponentMap} from '../../constants/types/more'
+
+const dumbProvePgpChoice: DumbComponentMap<ProvePgpChoice> = {
+  component: ProvePgpChoice,
+  mocks: {
+    'Import or Generate': {
+      onCancel: () => console.log('ProvePgpChoice: onCancel'),
+      onOptionClick: op => console.log(`ProvePgpChoice: onOptionClick = ${op}`),
+    },
+  },
+}
 
 const addBase = {
   fullName: 'Chris Coyne',
@@ -37,6 +50,38 @@ const addMap: DumbComponentMap<PgpAdd> = {
   },
 }
 
+const dumbProvePgpImport: DumbComponentMap<ProvePgpImport> = {
+  component: ProvePgpImport,
+  mocks: {
+    'Import PGP': {
+      onCancel: () => console.log('ProvePgpImport: onCancel'),
+    },
+  },
+}
+
+const dumbFinishedGeneratingPgp: DumbComponentMap<FinishedGeneratedPgp> = {
+  component: FinishedGeneratedPgp,
+  mocks: {
+    ' ': {
+      onDone: shouldStoreKeyOnServer => console.log(`FinishedGeneratedPgp: onDone [shouldStoreKeyOnServer: ${String(shouldStoreKeyOnServer)}]`),
+      pgpKeyString: '-----BEGIN PGP PUBLIC KEY BLOCK-----\nComment: GPGTools - https://gpgtools.org\n\nmQINBFWtLwEBEADLvrTe/bzrKVL0Z4bofdrLACmwC8PGXk3iD6t+1uTBKVMpfqkH\nQxGVECp598wS8XI6ZC+sMUM+AGTROi+HUsfn2cFk6y6pYl/z9A7lgctoX5xKXYTt\nE4xAZBeN1mn+x2YTjHW2lga/SZmh5qpSn5AMeNe42R0EtZ9FrCwD+IiOlw/LqGoh\n7DHKVDHmqK//mfK/lFTJck+HPkgmLyC4iYjpGuqXKqODUtMFT4+bHYfowG8WkvVX\ncf59Z6Fc7PA+rSFy9QXt7TP1po5Mnxxr9jcqQzzy3BSrAhHxAPj3F9rWBLUG0yGJ\nmAy6c1yTsbSgviiA0n4gjqPVj3iD3aiOx/KGxCdN/vru37Gp5q4KiBz7yHIqvg3B\nSeCBEOremB3gZG24OIVncpr0U6qITaFIe6iHmx53sID9JAKwfxAIwcktXe+aGtWp\n',
+    },
+  },
+}
+
+const dumbGeneratingPgp: DumbComponentMap<GeneratingPgp> = {
+  component: GeneratingPgp,
+  mocks: {
+    'Generating PGP': {
+      onCancel: () => console.log('GeneratingPgp: onCancel'),
+    },
+  },
+}
+
 export default {
-  'Add Pgp': addMap,
+  'New Proof: PGP': dumbProvePgpChoice,
+  'New Proof: PGP add': addMap,
+  'New Proof: PGP import': dumbProvePgpImport,
+  'New Proof: PGP generating': dumbGeneratingPgp,
+  'New Proof: PGP generate finished': dumbFinishedGeneratingPgp,
 }

--- a/shared/profile/prove-enter-username.native.js
+++ b/shared/profile/prove-enter-username.native.js
@@ -1,7 +1,7 @@
 // @flow
 import React, {Component} from 'react'
 import {platformText} from './prove-enter-username.shared'
-import {Box, Icon, Text, Button, Input, PlatformIcon} from '../common-adapters'
+import {Box, Icon, Text, Button, Input, PlatformIcon, StandardScreen} from '../common-adapters'
 import {constants} from '../constants/types/keybase-v1'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import openURL from '../util/open-url'
@@ -28,7 +28,7 @@ function UsernameTips ({platform}: {platform: PlatformsExpandedType}) {
 
 function customError (error: string, code: ?number) {
   if (code === constants.StatusCode.scprofilenotpublic) {
-    return <Box style={{...globalStyles.flexBoxColumn, justifyContent: 'center', alignItems: 'center'}}>
+    return <Box>
       <Text style={{...styleErrorBannerText, marginLeft: globalMargins.small, marginRight: globalMargins.small}} type='BodySmallSemibold'>You haven't set a public "Coinbase URL". You need to do that now.</Text>
       <Box style={{...globalStyles.flexBoxRow, alignItems: 'center'}} onClick={() => openURL('https://www.coinbase.com/settings#payment_page')}>
         <Text style={styleErrorBannerText} type='BodySmallSemibold'>Go to Coinbase</Text>
@@ -62,13 +62,10 @@ class Render extends Component<void, Props, State> {
 
   render () {
     const {floatingLabelText, hintText} = platformText[this.props.platform]
+    const notification = this.props.errorText ? {notification: {type: 'error', message: customError(this.props.errorText, this.props.errorCode)}} : {}
     return (
-      <Box style={styleContainer}>
-        <Box style={styleCancel}>
-          <Text type='BodyPrimaryLink' style={{position: 'absolute', top: 0, color: globalColors.blue}} onClick={this.props.onCancel}>Cancel</Text>
-        </Box>
-        {!!this.props.errorText && <Box style={styleErrorBanner}>{customError(this.props.errorText, this.props.errorCode)}</Box>}
-        <PlatformIcon style={{marginTop: globalMargins.medium}} platform={this.props.platform} overlay={'icon-proof-pending'} overlayColor={globalColors.grey} size={48} />
+      <StandardScreen {...notification}>
+        <PlatformIcon style={styleIcon} platform={this.props.platform} overlay={'icon-proof-pending'} overlayColor={globalColors.grey} size={48} />
         <Input
           style={styleInput}
           autoFocus={true}
@@ -80,52 +77,30 @@ class Render extends Component<void, Props, State> {
         <UsernameTips platform={this.props.platform} />
         <Button
           style={styleButton}
-          fullWidth={true}
           type='Primary'
           disabled={!this.props.canContinue}
           onClick={() => this.handleContinue()}
           label='Continue' />
-      </Box>
+      </StandardScreen>
     )
   }
-}
-
-const styleContainer = {
-  ...globalStyles.flexBoxColumn,
-  flex: 1,
-  alignItems: 'center',
-}
-
-const styleCancel = {
-  ...globalStyles.flexBoxRow,
-  alignSelf: 'flex-start',
-  marginLeft: globalMargins.small,
-  marginBottom: globalMargins.medium,
-}
-
-const styleErrorBanner = {
-  ...globalStyles.flexBoxColumn,
-  justifyContent: 'center',
-  alignItems: 'center',
-  minHeight: globalMargins.large,
-  backgroundColor: globalColors.red,
 }
 
 const styleErrorBannerText = {
   color: globalColors.white,
 }
 
+const styleIcon = {
+  alignSelf: 'center',
+}
+
 const styleInput = {
-  alignSelf: 'stretch',
   marginBottom: 0,
-  marginLeft: globalMargins.small,
-  marginRight: globalMargins.small,
   marginTop: globalMargins.large,
 }
 
 const styleInfoBanner = {
   ...globalStyles.flexBoxColumn,
-  alignSelf: 'stretch',
   alignItems: 'flex-start',
   backgroundColor: globalColors.yellow,
   padding: globalMargins.small,
@@ -133,9 +108,6 @@ const styleInfoBanner = {
 }
 
 const styleButton = {
-  alignSelf: 'stretch',
-  marginLeft: globalMargins.small,
-  marginRight: globalMargins.small,
   marginTop: globalMargins.large,
 }
 


### PR DESCRIPTION
## Additional Mobile PGP Dumbies

#### Main Focus

Implements the dumb component for the PGP info entry screen (Name, Email(s)) on mobile.

#### Additional

* Implements `SmallInput` on mobile
* Reduces distance between entered text and floating label on native `Input` to bring it more in line with the design docs

| iOS | Android|
|-----|--------|
|<img width="432" alt="screen shot 2016-08-17 at 3 09 47 pm" src="https://cloud.githubusercontent.com/assets/1152104/17755299/220beac6-648e-11e6-9b1b-661b858c0d0d.png">|<img width="418" alt="screen shot 2016-08-17 at 4 00 39 pm" src="https://cloud.githubusercontent.com/assets/1152104/17756285/c4e30874-6493-11e6-8689-3ee4da2d72ca.png">|

