### PR TITLE
refactor of libkb in preparation for pulling out proofs

### DIFF
--- a/go/engine/favorite_list.go
+++ b/go/engine/favorite_list.go
@@ -56,7 +56,7 @@ func (f *FavoritesAPIResult) GetAppStatus() *libkb.AppStatus {
 
 // Run starts the engine.
 func (e *FavoriteList) Run(ctx *Context) error {
-	arg := libkb.NewRetryAPIArg(e.G(), "kbfs/favorite/list")
+	arg := libkb.NewRetryAPIArg("kbfs/favorite/list")
 	arg.NeedSession = true
 	return e.G().API.GetDecode(arg, &e.result)
 }

--- a/go/engine/identify.go
+++ b/go/engine/identify.go
@@ -316,10 +316,9 @@ func getUserCard(g *libkb.GlobalContext, uid keybase1.UID, useSession bool) (ret
 	defer g.Trace("getUserCard", func() error { return err })()
 
 	arg := libkb.APIArg{
-		Endpoint:     "user/card",
-		NeedSession:  useSession,
-		Contextified: libkb.NewContextified(g),
-		Args:         libkb.HTTPArgs{"uid": libkb.S{Val: uid.String()}},
+		Endpoint:    "user/card",
+		NeedSession: useSession,
+		Args:        libkb.HTTPArgs{"uid": libkb.S{Val: uid.String()}},
 	}
 
 	var card card

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -71,11 +71,11 @@ func (i *Identify2WithUIDTester) MakeProofChecker(_ libkb.RemoteProofChainLink) 
 	return i, nil
 }
 
-func (i *Identify2WithUIDTester) CheckHint(_ *libkb.GlobalContext, h libkb.SigHint) libkb.ProofError {
+func (i *Identify2WithUIDTester) CheckHint(_ libkb.GlobalContextLite, h libkb.SigHint) libkb.ProofError {
 	return nil
 }
 
-func (i *Identify2WithUIDTester) CheckStatus(_ *libkb.GlobalContext, h libkb.SigHint) libkb.ProofError {
+func (i *Identify2WithUIDTester) CheckStatus(_ libkb.GlobalContextLite, h libkb.SigHint) libkb.ProofError {
 	if i.checkStatusHook != nil {
 		return i.checkStatusHook(h)
 	}

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -417,11 +417,10 @@ func (e *Kex2Provisionee) postSigs(signingArgs, encryptArgs *libkb.HTTPArgs) err
 	payload["sigs"] = []map[string]string{firstValues(signingArgs.ToValues()), firstValues(encryptArgs.ToValues())}
 
 	arg := libkb.APIArg{
-		Endpoint:     "key/multi",
-		NeedSession:  true,
-		JSONPayload:  payload,
-		SessionR:     e,
-		Contextified: libkb.NewContextified(e.G()),
+		Endpoint:    "key/multi",
+		NeedSession: true,
+		JSONPayload: payload,
+		SessionR:    e,
 	}
 
 	_, err := e.G().API.PostJSON(arg)

--- a/go/engine/kex2_provisioner.go
+++ b/go/engine/kex2_provisioner.go
@@ -214,9 +214,8 @@ func (e *Kex2Provisioner) CounterSign(input keybase1.HelloRes) (sig []byte, err 
 // API server.
 func (e *Kex2Provisioner) sessionForY() (token, csrf string, err error) {
 	resp, err := e.G().API.Post(libkb.APIArg{
-		Endpoint:     "new_session",
-		NeedSession:  true,
-		Contextified: libkb.NewContextified(e.G()),
+		Endpoint:    "new_session",
+		NeedSession: true,
 	})
 	if err != nil {
 		return "", "", err

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -865,10 +865,9 @@ func getPaperKey(g *libkb.GlobalContext, ctx *Context, lastErr error) (pair *key
 func (e *loginProvision) uidByKID(kid keybase1.KID) (keybase1.UID, error) {
 	var nilUID keybase1.UID
 	arg := libkb.APIArg{
-		Endpoint:     "key/owner",
-		NeedSession:  false,
-		Contextified: libkb.NewContextified(e.G()),
-		Args:         libkb.HTTPArgs{"kid": libkb.S{Val: kid.String()}},
+		Endpoint:    "key/owner",
+		NeedSession: false,
+		Args:        libkb.HTTPArgs{"kid": libkb.S{Val: kid.String()}},
 	}
 	res, err := e.G().API.Get(arg)
 	if err != nil {

--- a/go/engine/paperprovision.go
+++ b/go/engine/paperprovision.go
@@ -131,10 +131,9 @@ func (e *PaperProvisionEngine) Run(ctx *Context) (err error) {
 func (e *PaperProvisionEngine) uidByKID(kid keybase1.KID) (keybase1.UID, error) {
 	var nilUID keybase1.UID
 	arg := libkb.APIArg{
-		Endpoint:     "key/owner",
-		NeedSession:  false,
-		Contextified: libkb.NewContextified(e.G()),
-		Args:         libkb.HTTPArgs{"kid": libkb.S{Val: kid.String()}},
+		Endpoint:    "key/owner",
+		NeedSession: false,
+		Args:        libkb.HTTPArgs{"kid": libkb.S{Val: kid.String()}},
 	}
 	res, err := e.G().API.Get(arg)
 	if err != nil {

--- a/go/engine/prove.go
+++ b/go/engine/prove.go
@@ -234,7 +234,6 @@ func (p *Prove) checkAutoPost(ctx *Context, txt string) error {
 			"post":     libkb.S{Val: txt},
 			"username": libkb.S{Val: p.arg.Username},
 		},
-		Contextified: libkb.NewContextified(p.G()),
 	}
 	_, err := p.G().API.Post(apiArg)
 	if err != nil {

--- a/go/libkb/api_test.go
+++ b/go/libkb/api_test.go
@@ -203,10 +203,9 @@ func TestInstallIDHeaders(t *testing.T) {
 		t.Fatal(err)
 	}
 	res, err := api.Get(APIArg{
-		Endpoint:     "pkg/show",
-		NeedSession:  false,
-		Args:         HTTPArgs{},
-		Contextified: NewContextified(tc.G),
+		Endpoint:    "pkg/show",
+		NeedSession: false,
+		Args:        HTTPArgs{},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/go/libkb/apiarg.go
+++ b/go/libkb/apiarg.go
@@ -17,27 +17,24 @@ type APIArg struct {
 	InitialTimeout  time.Duration // optional
 	RetryMultiplier float64       // optional
 	RetryCount      int           // optional
-	Contextified
 }
 
 // NewAPIArg creates a standard APIArg that will result
 // in one API request with the default timeout.
-func NewAPIArg(g *GlobalContext, endpoint string) APIArg {
+func NewAPIArg(endpoint string) APIArg {
 	return APIArg{
-		Endpoint:     endpoint,
-		Contextified: NewContextified(g),
+		Endpoint: endpoint,
 	}
 }
 
 // NewRetryAPIArg creates an APIArg that will cause the http client
 // to use a much smaller request timeout, but retry the request
 // several times, backing off on the timeout each time.
-func NewRetryAPIArg(g *GlobalContext, endpoint string) APIArg {
+func NewRetryAPIArg(endpoint string) APIArg {
 	return APIArg{
 		Endpoint:        endpoint,
 		InitialTimeout:  HTTPRetryInitialTimeout,
 		RetryMultiplier: HTTPRetryMutliplier,
 		RetryCount:      HTTPRetryCount,
-		Contextified:    NewContextified(g),
 	}
 }

--- a/go/libkb/assertion_parser.go
+++ b/go/libkb/assertion_parser.go
@@ -166,7 +166,7 @@ func (p *Parser) parseFactor() (ret AssertionExpression) {
 	tok := p.lexer.Get()
 	switch tok.Typ {
 	case URL:
-		url, err := ParseAssertionURL(tok.getString(), false)
+		url, err := ParseAssertionURL(AllServices{}, tok.getString(), false)
 		if err != nil {
 			p.err = err
 		} else {

--- a/go/libkb/delegatekey.go
+++ b/go/libkb/delegatekey.go
@@ -262,10 +262,9 @@ func (d *Delegator) post(lctx LoginContext) (err error) {
 	}
 
 	arg := APIArg{
-		Endpoint:     "key/add",
-		NeedSession:  true,
-		Args:         hargs,
-		Contextified: NewContextified(d.G()),
+		Endpoint:    "key/add",
+		NeedSession: true,
+		Args:        hargs,
 	}
 	if lctx != nil {
 		arg.SessionR = lctx.LocalSession()

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -88,6 +88,13 @@ type GlobalContext struct {
 	NewTriplesec func(pw []byte, salt []byte) (Triplesec, error)
 }
 
+func (g *GlobalContext) GetLog() logger.Logger       { return g.Log }
+func (g *GlobalContext) GetAPI() API                 { return g.API }
+func (g *GlobalContext) GetExternalAPI() ExternalAPI { return g.XAPI }
+func (g *GlobalContext) GetServerURI() string        { return g.Env.GetServerURI() }
+
+var _ GlobalContextLite = (*GlobalContext)(nil)
+
 func NewGlobalContext() *GlobalContext {
 	log := logger.New("keybase")
 	return &GlobalContext{
@@ -493,7 +500,7 @@ func NewContextified(gc *GlobalContext) Contextified {
 	return Contextified{g: gc}
 }
 
-type Contexitifier interface {
+type Contextifier interface {
 	G() *GlobalContext
 }
 
@@ -584,10 +591,6 @@ func (g *GlobalContext) GetUnforwardedLogger() (log UnforwardedLoggerWithLegacyI
 		return log
 	}
 	return nil
-}
-
-func (g *GlobalContext) GetLog() logger.Logger {
-	return g.Log
 }
 
 // GetLogf returns a logger with a minimal formatter style interface

--- a/go/libkb/invite.go
+++ b/go/libkb/invite.go
@@ -55,7 +55,6 @@ func callSendInvitation(g *GlobalContext, params HTTPArgs) (*Invitation, error) 
 	arg := APIArg{
 		Endpoint:       "send_invitation",
 		NeedSession:    true,
-		Contextified:   NewContextified(g),
 		Args:           params,
 		AppStatusCodes: []int{SCOk, SCThrottleControl},
 	}

--- a/go/libkb/kex2_router.go
+++ b/go/libkb/kex2_router.go
@@ -35,7 +35,6 @@ func (k *KexRouter) Post(sessID kex2.SessionID, sender kex2.DeviceID, seqno kex2
 			"seqno":  I{Val: int(seqno)},
 			"msg":    B64Arg(msg),
 		},
-		Contextified: NewContextified(k.G()),
 	})
 
 	return err
@@ -71,7 +70,6 @@ func (k *KexRouter) Get(sessID kex2.SessionID, receiver kex2.DeviceID, low kex2.
 			"low":      I{Val: int(low)},
 			"poll":     I{Val: int(poll / time.Millisecond)},
 		},
-		Contextified: NewContextified(k.G()),
 	}
 	var j kexResp
 

--- a/go/libkb/key_lookup.go
+++ b/go/libkb/key_lookup.go
@@ -64,9 +64,8 @@ func keyLookup(g *GlobalContext, arg keyLookupArg) (username string, uid keybase
 
 	// lookup key on api server
 	args := APIArg{
-		Endpoint:     "key/basics",
-		Args:         httpArgs,
-		Contextified: NewContextified(g),
+		Endpoint: "key/basics",
+		Args:     httpArgs,
 	}
 
 	if err = g.API.GetDecode(args, &data); err != nil {

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -299,7 +299,6 @@ func LoadUserFromServer(g *GlobalContext, uid keybase1.UID, body *jsonw.Wrapper)
 			Args: HTTPArgs{
 				"uid": UIDArg(uid),
 			},
-			Contextified: NewContextified(g),
 		})
 
 		if err != nil {

--- a/go/libkb/log_send.go
+++ b/go/libkb/log_send.go
@@ -86,8 +86,7 @@ func (l *LogSendContext) post(status, kbfsLog, svcLog, desktopLog, updaterLog, s
 	l.G().Log.Debug("body size: %d\n", body.Len())
 
 	arg := APIArg{
-		Contextified: NewContextified(l.G()),
-		Endpoint:     "logdump/send",
+		Endpoint: "logdump/send",
 	}
 
 	resp, err := l.G().API.PostRaw(arg, mpart.FormDataContentType(), &body)

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -281,10 +281,9 @@ func (mc *MerkleClient) LookupPath(q HTTPArgs) (vp *VerificationPath, err error)
 	q.Add("poll", I{10})
 
 	res, err := mc.G().API.Get(APIArg{
-		Endpoint:     "merkle/path",
-		NeedSession:  false,
-		Args:         q,
-		Contextified: NewContextified(mc.G()),
+		Endpoint:    "merkle/path",
+		NeedSession: false,
+		Args:        q,
 	})
 
 	if err != nil {

--- a/go/libkb/post.go
+++ b/go/libkb/post.go
@@ -188,9 +188,8 @@ func PostDeviceLKS(g *GlobalContext, sr SessionReader, deviceID keybase1.DeviceI
 		debug.PrintStack()
 	}
 	arg := APIArg{
-		Contextified: NewContextified(g),
-		Endpoint:     "device/update",
-		NeedSession:  true,
+		Endpoint:    "device/update",
+		NeedSession: true,
 		Args: HTTPArgs{
 			"device_id":       S{Val: deviceID.String()},
 			"type":            S{Val: deviceType},

--- a/go/libkb/proof_checkers.go
+++ b/go/libkb/proof_checkers.go
@@ -7,13 +7,6 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol"
 )
 
-// ProofChecker is an interface for performing a remote check for a proof
-type ProofChecker interface {
-	CheckHint(g *GlobalContext, h SigHint) ProofError
-	CheckStatus(g *GlobalContext, h SigHint) ProofError
-	GetTorError() ProofError
-}
-
 // MakeProofCheckFunc is a function that given a remoteProofChainLink
 // will make a ProofChecker.
 type MakeProofCheckerFunc func(l RemoteProofChainLink) (ProofChecker, ProofError)

--- a/go/libkb/proof_support_dns.go
+++ b/go/libkb/proof_support_dns.go
@@ -25,7 +25,7 @@ func NewDNSChecker(p RemoteProofChainLink) (*DNSChecker, ProofError) {
 
 func (rc *DNSChecker) GetTorError() ProofError { return ProofErrorDNSOverTor }
 
-func (rc *DNSChecker) CheckHint(g *GlobalContext, h SigHint) ProofError {
+func (rc *DNSChecker) CheckHint(g GlobalContextLite, h SigHint) ProofError {
 	_, sigID, err := OpenSig(rc.proof.GetArmoredSig())
 
 	if err != nil {
@@ -43,7 +43,7 @@ func (rc *DNSChecker) CheckHint(g *GlobalContext, h SigHint) ProofError {
 	return nil
 }
 
-func (rc *DNSChecker) CheckDomain(g *GlobalContext, sig string, domain string) ProofError {
+func (rc *DNSChecker) CheckDomain(g GlobalContextLite, sig string, domain string) ProofError {
 	txt, err := net.LookupTXT(domain)
 	if err != nil {
 		return NewProofError(keybase1.ProofStatus_DNS_ERROR,
@@ -51,7 +51,7 @@ func (rc *DNSChecker) CheckDomain(g *GlobalContext, sig string, domain string) P
 	}
 
 	for _, record := range txt {
-		g.Log.Debug("For %s, got TXT record: %s", domain, record)
+		g.GetLog().Debug("For %s, got TXT record: %s", domain, record)
 		if record == sig {
 			return nil
 		}
@@ -61,10 +61,10 @@ func (rc *DNSChecker) CheckDomain(g *GlobalContext, sig string, domain string) P
 		len(txt), domain, sig)
 }
 
-func (rc *DNSChecker) CheckStatus(g *GlobalContext, h SigHint) ProofError {
+func (rc *DNSChecker) CheckStatus(g GlobalContextLite, h SigHint) ProofError {
 
 	wanted := h.checkText
-	g.Log.Debug("| DNS proof, want TXT value: %s", wanted)
+	g.GetLog().Debug("| DNS proof, want TXT value: %s", wanted)
 
 	domain := rc.proof.GetHostname()
 
@@ -94,7 +94,7 @@ func (t DNSServiceType) NormalizeUsername(s string) (string, error) {
 	return strings.ToLower(s), nil
 }
 
-func (t DNSServiceType) NormalizeRemoteName(g *GlobalContext, s string) (string, error) {
+func (t DNSServiceType) NormalizeRemoteName(_ GlobalContextLite, s string) (string, error) {
 	// Allow a leading 'dns://' and preserve case.
 	s = strings.TrimPrefix(s, "dns://")
 	if !IsValidHostname(s) {
@@ -145,7 +145,6 @@ func (t DNSServiceType) LastWriterWins() bool { return false }
 
 func init() {
 	RegisterServiceType(DNSServiceType{})
-	RegisterSocialNetwork("dns")
 	RegisterMakeProofCheckerFunc("dns",
 		func(l RemoteProofChainLink) (ProofChecker, ProofError) {
 			return NewDNSChecker(l)

--- a/go/libkb/proof_support_github.go
+++ b/go/libkb/proof_support_github.go
@@ -25,7 +25,7 @@ func NewGithubChecker(p RemoteProofChainLink) (*GithubChecker, ProofError) {
 
 func (rc *GithubChecker) GetTorError() ProofError { return nil }
 
-func (rc *GithubChecker) CheckHint(g *GlobalContext, h SigHint) ProofError {
+func (rc *GithubChecker) CheckHint(g GlobalContextLite, h SigHint) ProofError {
 	given := strings.ToLower(h.apiURL)
 	u := strings.ToLower(rc.proof.GetRemoteUsername())
 	ok1 := "https://gist.github.com/" + u + "/"
@@ -37,8 +37,8 @@ func (rc *GithubChecker) CheckHint(g *GlobalContext, h SigHint) ProofError {
 		"Bad hint from server; URL start with either '%s' OR '%s'", ok1, ok2)
 }
 
-func (rc *GithubChecker) CheckStatus(g *GlobalContext, h SigHint) ProofError {
-	res, err := g.XAPI.GetText(NewAPIArg(g, h.apiURL))
+func (rc *GithubChecker) CheckStatus(g GlobalContextLite, h SigHint) ProofError {
+	res, err := g.GetExternalAPI().GetText(NewAPIArg(h.apiURL))
 
 	if err != nil {
 		return XapiError(err, h.apiURL)
@@ -76,7 +76,7 @@ func (t GithubServiceType) NormalizeUsername(s string) (string, error) {
 	return strings.ToLower(s), nil
 }
 
-func (t GithubServiceType) NormalizeRemoteName(g *GlobalContext, s string) (ret string, err error) {
+func (t GithubServiceType) NormalizeRemoteName(g GlobalContextLite, s string) (ret string, err error) {
 	// Allow a leading '@'.
 	s = strings.TrimPrefix(s, "@")
 	return t.NormalizeUsername(s)
@@ -116,7 +116,6 @@ func (t GithubServiceType) CheckProofText(text string, id keybase1.SigID, sig st
 
 func init() {
 	RegisterServiceType(GithubServiceType{})
-	RegisterSocialNetwork("github")
 	RegisterMakeProofCheckerFunc("github",
 		func(l RemoteProofChainLink) (ProofChecker, ProofError) {
 			return NewGithubChecker(l)

--- a/go/libkb/proof_support_reddit.go
+++ b/go/libkb/proof_support_reddit.go
@@ -31,7 +31,7 @@ func NewRedditChecker(p RemoteProofChainLink) (*RedditChecker, ProofError) {
 
 func (rc *RedditChecker) GetTorError() ProofError { return nil }
 
-func (rc *RedditChecker) CheckHint(g *GlobalContext, h SigHint) ProofError {
+func (rc *RedditChecker) CheckHint(g GlobalContextLite, h SigHint) ProofError {
 	if strings.HasPrefix(strings.ToLower(h.apiURL), RedditSub) {
 		return nil
 	}
@@ -108,8 +108,8 @@ func (rc *RedditChecker) CheckData(h SigHint, dat *jsonw.Wrapper) ProofError {
 	return nil
 }
 
-func (rc *RedditChecker) CheckStatus(g *GlobalContext, h SigHint) ProofError {
-	res, err := g.XAPI.Get(NewAPIArg(g, h.apiURL))
+func (rc *RedditChecker) CheckStatus(g GlobalContextLite, h SigHint) ProofError {
+	res, err := g.GetExternalAPI().Get(NewAPIArg(h.apiURL))
 	if err != nil {
 		return XapiError(err, h.apiURL)
 	}
@@ -157,7 +157,7 @@ func (t RedditServiceType) NormalizeUsername(s string) (string, error) {
 	return strings.ToLower(s), nil
 }
 
-func (t RedditServiceType) NormalizeRemoteName(g *GlobalContext, s string) (ret string, err error) {
+func (t RedditServiceType) NormalizeRemoteName(g GlobalContextLite, s string) (ret string, err error) {
 	return t.NormalizeUsername(s)
 }
 
@@ -210,7 +210,6 @@ func (t RedditServiceType) CheckProofText(text string, id keybase1.SigID, sig st
 
 func init() {
 	RegisterServiceType(RedditServiceType{})
-	RegisterSocialNetwork("reddit")
 	RegisterMakeProofCheckerFunc("reddit",
 		func(l RemoteProofChainLink) (ProofChecker, ProofError) {
 			return NewRedditChecker(l)

--- a/go/libkb/proof_support_web.go
+++ b/go/libkb/proof_support_web.go
@@ -38,7 +38,7 @@ func (rc *WebChecker) GetTorError() ProofError {
 	return nil
 }
 
-func (rc *WebChecker) CheckHint(g *GlobalContext, h SigHint) ProofError {
+func (rc *WebChecker) CheckHint(g GlobalContextLite, h SigHint) ProofError {
 
 	files := webKeybaseFiles
 	urlBase := rc.proof.ToDisplayString()
@@ -57,8 +57,8 @@ func (rc *WebChecker) CheckHint(g *GlobalContext, h SigHint) ProofError {
 
 }
 
-func (rc *WebChecker) CheckStatus(g *GlobalContext, h SigHint) ProofError {
-	res, err := g.XAPI.GetText(NewAPIArg(g, h.apiURL))
+func (rc *WebChecker) CheckStatus(g GlobalContextLite, h SigHint) ProofError {
+	res, err := g.GetExternalAPI().GetText(NewAPIArg(h.apiURL))
 
 	if err != nil {
 		return XapiError(err, h.apiURL)
@@ -110,20 +110,19 @@ func ParseWeb(s string) (hostname string, prot string, err error) {
 	return
 }
 
-func (t WebServiceType) NormalizeRemoteName(g *GlobalContext, s string) (ret string, err error) {
+func (t WebServiceType) NormalizeRemoteName(g GlobalContextLite, s string) (ret string, err error) {
 	// The remote name is a full (case-preserved) URL.
 	var prot, host string
 	if host, prot, err = ParseWeb(s); err != nil {
 		return
 	}
 	var res *APIRes
-	res, err = g.API.Get(APIArg{
+	res, err = g.GetAPI().Get(APIArg{
 		Endpoint:    "remotes/check",
 		NeedSession: true,
 		Args: HTTPArgs{
 			"hostname": S{host},
 		},
-		Contextified: NewContextified(g),
 	})
 	if err != nil {
 		return
@@ -208,7 +207,6 @@ func (t WebServiceType) LastWriterWins() bool { return false }
 
 func init() {
 	RegisterServiceType(WebServiceType{})
-	RegisterSocialNetwork("web")
 	RegisterMakeProofCheckerFunc("http",
 		func(l RemoteProofChainLink) (ProofChecker, ProofError) {
 			return NewWebChecker(l)

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -68,7 +68,7 @@ func (r *Resolver) resolve(input string, withBody bool) (res ResolveResult) {
 	defer r.G().Trace(fmt.Sprintf("Resolving username %q", input), func() error { return res.err })()
 
 	var au AssertionURL
-	if au, res.err = ParseAssertionURL(input, false); res.err != nil {
+	if au, res.err = ParseAssertionURL(AllServices{}, input, false); res.err != nil {
 		return res
 	}
 	res = r.resolveURL(au, input, withBody, false)
@@ -157,7 +157,6 @@ func (r *Resolver) resolveURLViaServerLookup(au AssertionURL, input string, with
 		NeedSession:    false,
 		Args:           ha,
 		AppStatusCodes: []int{SCOk, SCNotFound},
-		Contextified:   NewContextified(r.G()),
 	})
 
 	if res.err != nil {

--- a/go/libkb/session.go
+++ b/go/libkb/session.go
@@ -251,7 +251,7 @@ func (s *Session) check() error {
 		return nil
 	}
 
-	arg := NewRetryAPIArg(s.G(), "sesscheck")
+	arg := NewRetryAPIArg("sesscheck")
 	arg.SessionR = s
 	arg.NeedSession = true
 	arg.AppStatusCodes = []int{SCOk, SCBadSession}

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -142,7 +142,6 @@ func (sc *SigChain) LoadFromServer(t *MerkleTriple, selfUID keybase1.UID) (dirty
 			"uid": UIDArg(sc.uid),
 			"low": I{int(low)},
 		},
-		Contextified: NewContextified(sc.G()),
 	})
 
 	if err != nil {

--- a/go/libkb/sig_hints.go
+++ b/go/libkb/sig_hints.go
@@ -145,7 +145,6 @@ func (sh *SigHints) Refresh() error {
 			"uid": UIDArg(sh.uid),
 			"low": I{sh.version},
 		},
-		Contextified: NewContextified(sh.G()),
 	})
 	if err != nil {
 		return err

--- a/go/libkb/social_assertion.go
+++ b/go/libkb/social_assertion.go
@@ -23,7 +23,7 @@ func IsSocialAssertion(s string) bool {
 // transformed to the user@twitter format.  Only registered
 // services are allowed.
 func NormalizeSocialAssertion(s string) (keybase1.SocialAssertion, bool) {
-	url, err := ParseAssertionURL(s, true)
+	url, err := ParseAssertionURL(AllServices{}, s, true)
 	if err != nil || !url.IsRemote() {
 		return keybase1.SocialAssertion{}, false
 	}

--- a/go/libkb/special_keys.go
+++ b/go/libkb/special_keys.go
@@ -90,7 +90,6 @@ func (sk *SpecialKeyRing) Load(kid keybase1.KID) (GenericKey, error) {
 			Args: HTTPArgs{
 				"kid": S{kid.String()},
 			},
-			Contextified: NewContextified(sk.G()),
 		})
 		var w *Warnings
 		if err == nil {

--- a/go/libkb/syncer.go
+++ b/go/libkb/syncer.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Syncer interface {
-	Contexitifier
+	Contextifier
 	sync.Locker
 	loadFromStorage(keybase1.UID) error
 	syncFromServer(keybase1.UID, SessionReader) error

--- a/go/service/apiserver.go
+++ b/go/service/apiserver.go
@@ -70,7 +70,6 @@ func (a *APIServerHandler) setupArg(arg GenericArg) libkb.APIArg {
 		Args:           kbargs,
 		HTTPStatus:     httpStatuses,
 		AppStatusCodes: appStatusCodes,
-		Contextified:   libkb.NewContextified(a.G()),
 	}
 
 	return kbarg

--- a/go/service/rekey_master.go
+++ b/go/service/rekey_master.go
@@ -149,10 +149,9 @@ func queryAPIServerForRekeyInfo(g *libkb.GlobalContext) (keybase1.ProblemSet, er
 
 	var tmp rekeyQueryResult
 	err := g.API.PostDecode(libkb.APIArg{
-		Contextified: libkb.NewContextified(g),
-		Endpoint:     "kbfs/problem_sets",
-		NeedSession:  true,
-		Args:         args,
+		Endpoint:    "kbfs/problem_sets",
+		NeedSession: true,
+		Args:        args,
 	}, &tmp)
 
 	return tmp.ProblemSet, err

--- a/go/systests/rekey_test.go
+++ b/go/systests/rekey_test.go
@@ -323,9 +323,8 @@ func (rkt *rekeyTester) changeKeysOnHomeTLF(kids []keybase1.KID) {
 			"kids":           libkb.S{Val: strings.Join(kidStrings, ",")},
 			"folderRevision": libkb.I{Val: fakeTLF.nextRevision()},
 		},
-		Endpoint:     "test/fake_home_tlf",
-		NeedSession:  true,
-		Contextified: libkb.NewContextified(g),
+		Endpoint:    "test/fake_home_tlf",
+		NeedSession: true,
 	}
 	_, err := g.API.Post(apiArg)
 	if err != nil {
@@ -346,9 +345,8 @@ func (rkt *rekeyTester) bumpTLF(kid keybase1.KID) {
 		Args: libkb.HTTPArgs{
 			"kid": libkb.S{Val: string(kid)},
 		},
-		Endpoint:     "kbfs/bump_rekey",
-		NeedSession:  true,
-		Contextified: libkb.NewContextified(g),
+		Endpoint:    "kbfs/bump_rekey",
+		NeedSession: true,
 	}
 
 	_, err := g.API.Post(apiArg)
@@ -368,8 +366,7 @@ func (rkt *rekeyTester) kickRekeyd() {
 		Args: libkb.HTTPArgs{
 			"timeout": libkb.I{Val: 2000},
 		},
-		NeedSession:  true,
-		Contextified: libkb.NewContextified(g),
+		NeedSession: true,
 	}
 
 	_, err := g.API.Post(apiArg)


### PR DESCRIPTION
- make the context we pass into ProofCheckers narrower, exposing only API
  and Logger fields of the full GlobalContext. We call this lighter context
  GlobalContextLite for now (happy to consider other names).
- Decontextify APIArg since we can just get that stuff from the API engines
  themselves. This also pulls the APIArg into the interfaces file, where it really
  should live.
- Simplify the services management
- Get rid of the "social networks" table; we can infer it from ServiceType objects
- Introduce an "AssertionContext" which is a small piece of context/state we need
  to parse and understand assertions. It eventually can be moved into another library.