### PR TITLE
Fix error code check in provisioning

### DIFF
--- a/shared/login/register/error/index.render.desktop.js
+++ b/shared/login/register/error/index.render.desktop.js
@@ -11,7 +11,7 @@ const renderError = (error: Object) => {
     acc[f.key] = f.value
     return acc
   }, {})
-  switch (error.code) {
+  switch (error.raw.code) {
     case errorMap['scdevicenoprovision']:
       return (
         <div>
@@ -62,7 +62,7 @@ const renderError = (error: Object) => {
     case errorMap['sckeysyncedpgpnotfound']:
       return (
         <p>
-          <Text type='Body'>Sorry, your account is already established with a PGP public key, but this we can't access the corresponding private key. </Text>
+          <Text type='Body'>Sorry, your account is already established with a PGP public key, but we can't access the corresponding private key.</Text>
           <Text type='Body' style={{display: 'inline-block', marginTop: 10, marginBottom: 10}}>You need to prove you're you. We suggest one of the following:</Text>
           <Text type='BodySmall' style={{display: 'inline-block'}}> - Install GPG and put your PGP private key on this machine and try again</Text>
           <Text type='BodySmall' style={{display: 'inline-block'}}> - Reset your account and start fresh: </Text>


### PR DESCRIPTION
@keybase/react-hackers 

When rendering error strings during provisioning, we receive an EngineError and switch on `error.code`.  But the EngineError constructor takes an object that looks like:
```js
{
  desc: ..,
  code: ..,
}
```
and returns an Error object that looks like:
```js
{
  message: ..,
  raw: {
    desc: ..,
    code: ..,
  }
}
```
So, `error.code` will *always* be null on an EngineError -- the test should be for `error.raw.code` instead.

This fixes keybase/keybase-issues#2494, screenshot attached.

![screenshot from 2016-08-18 11-05-32](https://cloud.githubusercontent.com/assets/21217/17778919/c63e884c-6533-11e6-9bd6-fcd8adf28d6d.png)