### PR TITLE
Add defaultDeviceID, deviceErr to ExtendedStatus

### DIFF
--- a/go/protocol/config.go
+++ b/go/protocol/config.go
@@ -38,6 +38,11 @@ type PlatformInfo struct {
 	GoVersion string `codec:"goVersion" json:"goVersion"`
 }
 
+type LoadDeviceErr struct {
+	Where string `codec:"where" json:"where"`
+	Desc  string `codec:"desc" json:"desc"`
+}
+
 type ExtendedStatus struct {
 	Standalone             bool            `codec:"standalone" json:"standalone"`
 	PassphraseStreamCached bool            `codec:"passphraseStreamCached" json:"passphraseStreamCached"`
@@ -49,12 +54,14 @@ type ExtendedStatus struct {
 	StoredSecret           bool            `codec:"storedSecret" json:"storedSecret"`
 	SecretPromptSkip       bool            `codec:"secretPromptSkip" json:"secretPromptSkip"`
 	Device                 *Device         `codec:"device,omitempty" json:"device,omitempty"`
+	DeviceErr              *LoadDeviceErr  `codec:"deviceErr,omitempty" json:"deviceErr,omitempty"`
 	LogDir                 string          `codec:"logDir" json:"logDir"`
 	Session                *SessionStatus  `codec:"session,omitempty" json:"session,omitempty"`
 	DefaultUsername        string          `codec:"defaultUsername" json:"defaultUsername"`
 	ProvisionedUsernames   []string        `codec:"provisionedUsernames" json:"provisionedUsernames"`
 	Clients                []ClientDetails `codec:"Clients" json:"Clients"`
 	PlatformInfo           PlatformInfo    `codec:"platformInfo" json:"platformInfo"`
+	DefaultDeviceID        DeviceID        `codec:"defaultDeviceID" json:"defaultDeviceID"`
 }
 
 type ForkType int

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -135,10 +135,12 @@ func (h ConfigHandler) GetExtendedStatus(_ context.Context, sessionID int) (res 
 	me, err := libkb.LoadMe(libkb.NewLoadUserArg(h.G()))
 	if err != nil {
 		h.G().Log.Debug("| could not load me user: %s", err)
+		res.DeviceErr = &keybase1.LoadDeviceErr{Where: "libkb.LoadMe", Desc: err.Error()}
 	} else {
 		device, err := me.GetComputedKeyFamily().GetCurrentDevice(h.G())
 		if err != nil {
 			h.G().Log.Debug("| GetCurrentDevice failed: %s", err)
+			res.DeviceErr = &keybase1.LoadDeviceErr{Where: "ckf.GetCurrentDevice", Desc: err.Error()}
 		} else {
 			res.Device = device.ProtExport()
 		}
@@ -183,6 +185,7 @@ func (h ConfigHandler) GetExtendedStatus(_ context.Context, sessionID int) (res 
 	}
 	res.ProvisionedUsernames = p
 	res.PlatformInfo = getPlatformInfo()
+	res.DefaultDeviceID = h.G().Env.GetDeviceID()
 
 	if me != nil && h.G().SecretStoreAll != nil {
 		s, err := h.G().SecretStoreAll.RetrieveSecret(me.GetNormalizedName())

--- a/protocol/avdl/config.avdl
+++ b/protocol/avdl/config.avdl
@@ -52,14 +52,15 @@ protocol config {
     boolean storedSecret;
     boolean secretPromptSkip;
     union { null, Device } device;
-    union { null, LoadDeviceErr } deviceErr;
+    union { null, LoadDeviceErr } deviceErr; /* if err getting device, this will describe it */
     string logDir;
     union { null, SessionStatus } session;
     string defaultUsername;
     array<string> provisionedUsernames;
     array<ClientDetails> Clients;
     PlatformInfo platformInfo;
-    DeviceID defaultDeviceID;
+    DeviceID defaultDeviceID;               /* this contains the device ID for defaultUsername
+                                               in the config file. */
   }
 
   ExtendedStatus getExtendedStatus(int sessionID);

--- a/protocol/avdl/config.avdl
+++ b/protocol/avdl/config.avdl
@@ -36,6 +36,11 @@ protocol config {
     string goVersion;
   }
 
+  record LoadDeviceErr {
+    string where;
+    string desc;
+  }
+
   record ExtendedStatus {
     boolean standalone;
     boolean passphraseStreamCached;
@@ -47,12 +52,14 @@ protocol config {
     boolean storedSecret;
     boolean secretPromptSkip;
     union { null, Device } device;
+    union { null, LoadDeviceErr } deviceErr;
     string logDir;
     union { null, SessionStatus } session;
     string defaultUsername;
     array<string> provisionedUsernames;
     array<ClientDetails> Clients;
     PlatformInfo platformInfo;
+    DeviceID defaultDeviceID;
   }
 
   ExtendedStatus getExtendedStatus(int sessionID);

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -382,12 +382,14 @@ export type ExtendedStatus = {
   storedSecret: boolean,
   secretPromptSkip: boolean,
   device?: ?Device,
+  deviceErr?: ?LoadDeviceErr,
   logDir: string,
   session?: ?SessionStatus,
   defaultUsername: string,
   provisionedUsernames?: ?Array<string>,
   Clients?: ?Array<ClientDetails>,
   platformInfo: PlatformInfo,
+  defaultDeviceID: DeviceID,
 }
 
 export type FSEditListRequest = {
@@ -696,6 +698,11 @@ export type LinkCheckResult = {
 
 export type ListResult = {
   files?: ?Array<File>,
+}
+
+export type LoadDeviceErr = {
+  where: string,
+  desc: string,
 }
 
 export type LogLevel =

--- a/protocol/json/config.json
+++ b/protocol/json/config.json
@@ -111,6 +111,20 @@
     },
     {
       "type": "record",
+      "name": "LoadDeviceErr",
+      "fields": [
+        {
+          "type": "string",
+          "name": "where"
+        },
+        {
+          "type": "string",
+          "name": "desc"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "ExtendedStatus",
       "fields": [
         {
@@ -157,6 +171,13 @@
           "name": "device"
         },
         {
+          "type": [
+            null,
+            "LoadDeviceErr"
+          ],
+          "name": "deviceErr"
+        },
+        {
           "type": "string",
           "name": "logDir"
         },
@@ -188,6 +209,10 @@
         {
           "type": "PlatformInfo",
           "name": "platformInfo"
+        },
+        {
+          "type": "DeviceID",
+          "name": "defaultDeviceID"
         }
       ]
     },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -382,12 +382,14 @@ export type ExtendedStatus = {
   storedSecret: boolean,
   secretPromptSkip: boolean,
   device?: ?Device,
+  deviceErr?: ?LoadDeviceErr,
   logDir: string,
   session?: ?SessionStatus,
   defaultUsername: string,
   provisionedUsernames?: ?Array<string>,
   Clients?: ?Array<ClientDetails>,
   platformInfo: PlatformInfo,
+  defaultDeviceID: DeviceID,
 }
 
 export type FSEditListRequest = {
@@ -696,6 +698,11 @@ export type LinkCheckResult = {
 
 export type ListResult = {
   files?: ?Array<File>,
+}
+
+export type LoadDeviceErr = {
+  where: string,
+  desc: string,
 }
 
 export type LogLevel =


### PR DESCRIPTION
Some users have had issues in the getExtendedStatus() RPC that electron calls.  Specifically, an API network error during LoadUser.  

From https://keybase.atlassian.net/browse/CORE-3564 

> 2016-07-27T19:37:13.758184 ▶ [DEBU keybase merkle_client.go:698] 0d5 | LookupPath 
> 2016-07-27T19:37:13.758212 ▶ [DEBU keybase api.go:139] 0d6 + API GET request to https://api.keybase.io/_/api/1.0/merkle/path.json?poll=10&uid=4ccb66554c32f35619adf3cf2cf31619
> 2016-07-27T19:37:13.758243 ▶ [DEBU keybase api.go:195] 0d7 | doRequestShared(fixHeaders) for merkle/path
> 2016-07-27T19:37:13.758262 ▶ [DEBU keybase api.go:195] 0d8 | doRequestShared(getCli) for merkle/path
> 2016-07-27T19:37:13.758277 ▶ [DEBU keybase api.go:195] 0d9 | doRequestShared(Do) for merkle/path
> 2016-07-27T19:37:13.758639 ▶ [DEBU keybase api.go:195] 0da | doRequestShared(Done) for merkle/path
> 2016-07-27T19:37:13.758675 ▶ [DEBU keybase loaduser.go:126] 0db * LoadUser: {Contextified:{g:0xc82015f680} UID: Name: PublicKeyOptional:false NoCacheResult:false Self:true ForceReload:false AllKeys:false LoginContext:<nil> AbortIfSigchainUnchanged:false ResolveBody:<nil>}: 6.162865ms
> 2016-07-27T19:37:13.758700 ▶ [DEBU keybase config.go:137] 0dc | could not load me user

The user object is used to get the full current device from the computed key family, and when it fails to load, the *Device field in ExtendedStatus was just silently nil.  Thus, callers (specifically desktop app) thought there was no device for this user and sent them to device provisioning.

I added two fields to ExtendedStatus:

1. `deviceErr`: includes any errors loading the me user or getting the current device from the computed key family.
2. defaultDeviceID is the deviceID in the config file.  No network is needed to get this, so if it is there then the user has a device.

@MarcoPolo does this sound good from desktop's point of view?  I have some other questions I'll ask you directly.

r? @maxtaco