### PR TITLE
kill-kbfs

### DIFF
--- a/go/client/cmd_ctl_stop.go
+++ b/go/client/cmd_ctl_stop.go
@@ -9,12 +9,19 @@ import (
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
+	"os"
 )
 
 func NewCmdCtlStop(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:  "stop",
 		Usage: "Stop the background keybase service",
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "kill-kbfs",
+				Usage: "Shut down KBFS as well",
+			},
+		},
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(newCmdCtlStop(g), "stop", c)
 			cl.SetForkCmd(libcmdline.NoFork)
@@ -31,16 +38,33 @@ func newCmdCtlStop(g *libkb.GlobalContext) *CmdCtlStop {
 
 type CmdCtlStop struct {
 	libkb.Contextified
+	killKBFS bool
 }
 
 func (s *CmdCtlStop) ParseArgv(ctx *cli.Context) error {
+	s.killKBFS = ctx.Bool("kill-kbfs")
 	return nil
 }
 
 func (s *CmdCtlStop) Run() (err error) {
+	if s.killKBFS {
+		s.doKillKBFS()
+	}
 	return CtlServiceStop(s.G())
+
 }
 
 func (s *CmdCtlStop) GetUsage() libkb.Usage {
 	return libkb.Usage{}
+}
+
+func (s *CmdCtlStop) doKillKBFS() {
+	mountDir, err := s.G().Env.GetMountDir()
+	if err != nil {
+		s.G().Log.Errorf("KillKBFS: Error in GetMountDir: %s", err.Error())
+	} else {
+		// open special "file". Errors not relevant.
+		s.G().Log.Debug("KillKBFS: opening .kbfs_unmount")
+		os.Create(mountDir + ".kbfs_unmount")
+	}
 }

--- a/go/client/cmd_ctl_stop_windows.go
+++ b/go/client/cmd_ctl_stop_windows.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
-// +build !darwin,!windows
+// +build windows
 
 package client
 
@@ -9,13 +9,20 @@ import (
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
+	"os"
+	"path/filepath"
 )
 
 func NewCmdCtlStop(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:  "stop",
 		Usage: "Stop the background keybase service",
-
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "kill-kbfs",
+				Usage: "Shut down KBFS as well",
+			},
+		},
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(newCmdCtlStop(g), "stop", c)
 			cl.SetForkCmd(libcmdline.NoFork)
@@ -32,17 +39,33 @@ func newCmdCtlStop(g *libkb.GlobalContext) *CmdCtlStop {
 
 type CmdCtlStop struct {
 	libkb.Contextified
+	killKBFS bool
 }
 
 func (s *CmdCtlStop) ParseArgv(ctx *cli.Context) error {
+	s.killKBFS = ctx.Bool("kill-kbfs")
 	return nil
 }
 
 func (s *CmdCtlStop) Run() (err error) {
+	if s.killKBFS {
+		s.doKillKBFS()
+	}
 	return CtlServiceStop(s.G())
 
 }
 
 func (s *CmdCtlStop) GetUsage() libkb.Usage {
 	return libkb.Usage{}
+}
+
+func (s *CmdCtlStop) doKillKBFS() {
+	mountDir, err := s.G().Env.GetMountDir()
+	if err != nil {
+		s.G().Log.Errorf("KillKBFS: Error in GetMountDir: %s", err.Error())
+	} else {
+		// open special "file". Errors not relevant.
+		s.G().Log.Debug("KillKBFS: opening .kbfs_unmount")
+		os.Create(filepath.Join(mountDir, ".kbfs_unmount"))
+	}
 }

--- a/go/client/cmd_ctl_stop_windows.go
+++ b/go/client/cmd_ctl_stop_windows.go
@@ -66,6 +66,6 @@ func (s *CmdCtlStop) doKillKBFS() {
 	} else {
 		// open special "file". Errors not relevant.
 		s.G().Log.Debug("KillKBFS: opening .kbfs_unmount")
-		os.Create(filepath.Join(mountDir, ".kbfs_unmount"))
+		os.Open(filepath.Join(mountDir, ".kbfs_unmount"))
 	}
 }

--- a/go/client/cmd_ctl_watchdog2.go
+++ b/go/client/cmd_ctl_watchdog2.go
@@ -73,6 +73,7 @@ func (c *CmdWatchdog2) Run() error {
 			"-log-to-file",
 			mountDir,
 		},
+		ExitOn: watchdog.ExitOnSuccess,
 	}
 	programs = append(programs, kbfsProgram)
 

--- a/go/tools/dokanclean/main.go
+++ b/go/tools/dokanclean/main.go
@@ -1,0 +1,126 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build windows
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// Make sure reboot status takes precedence; otherwise favor errors over OK
+func mergeResults(current int, next int) int {
+	// ERROR_SUCCESS_REBOOT_INITIATED	1641	The installer has initiated a restart. This message is indicative of a success.
+	// ERROR_SUCCESS_REBOOT_REQUIRED	3010	A restart is required to complete the install. This message is indicative of a success. This does not include installs where the ForceReboot action is run.
+	if current == 1641 || current == 3010 || current > next {
+		return current
+	}
+	return next
+}
+
+func doUninstallAction(uninst string, list bool) int {
+	retval := 1
+
+	// Parse out the command, which may be inside quotes, and arguments
+	// e.g.:
+	//    "C:\ProgramData\Package Cache\{d36c41f1-e204-487e-9c4a-29834dddcabe}\DokanSetup.exe" /uninstall /quiet
+	var command string
+	if strings.HasPrefix(uninst, "\"") {
+		if commandEnd := strings.Index(uninst[1:], "\""); commandEnd != -1 {
+			command = uninst[1 : commandEnd+1]
+			uninst = strings.TrimSpace(uninst[commandEnd+2:])
+		}
+	}
+	args := strings.Split(uninst, " ")
+	if command == "" {
+		command = args[0]
+		args = args[1:]
+	}
+
+	// If this is an msi package, it probably has no QuietUninstallString
+	if strings.HasPrefix(strings.ToLower(command), "msiexec") {
+		args = append(args, "/quiet")
+	}
+
+	args = append(args, "/norestart")
+
+	if list {
+		fmt.Printf("%s %v\n", command, args)
+	} else {
+		uninstCmd := exec.Command(command, args...)
+		err := uninstCmd.Run()
+		if err != nil {
+			fmt.Printf("Error %s uninstalling %s\n", err.Error(), uninst)
+			if e2, ok := err.(*exec.ExitError); ok {
+				if s, ok := e2.Sys().(syscall.WaitStatus); ok {
+					retval = int(s.ExitCode)
+				}
+			}
+		} else {
+			retval = 0
+		}
+	}
+	return retval
+}
+
+// Read all the uninstall subkeys and find the ones with DisplayName starting with "Dokan Library".
+// If not just listing, execute each uninstaller we find and merge return codes.
+func findDokanUninstall(list bool, wow64 bool) (result int) {
+	var access uint32 = registry.ENUMERATE_SUB_KEYS | registry.QUERY_VALUE
+	if wow64 {
+		access = access | registry.WOW64_32KEY
+	}
+
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall", access)
+	if err != nil {
+		fmt.Printf("Error %s opening uninstall subkeys\n", err.Error())
+		return
+	}
+	defer k.Close()
+
+	names, err := k.ReadSubKeyNames(-1)
+	if err != nil {
+		fmt.Printf("Error %s reading subkeys\n", err.Error())
+		return
+	}
+	for _, name := range names {
+		subKey, err := registry.OpenKey(k, name, registry.QUERY_VALUE)
+		if err != nil {
+			fmt.Printf("Error %s opening subkey %s\n", err.Error(), name)
+		}
+
+		displayName, _, err := subKey.GetStringValue("DisplayName")
+		if err == nil && strings.HasPrefix(displayName, "Dokan Library") {
+			fmt.Printf("Found %s  %s\n", displayName, name)
+			uninstall, _, err := subKey.GetStringValue("QuietUninstallString")
+			if err != nil {
+				uninstall, _, err = subKey.GetStringValue("UninstallString")
+			}
+			if err != nil {
+				fmt.Printf("Error %s opening subkey UninstallString", err.Error())
+			} else {
+				result = mergeResults(result, doUninstallAction(uninstall, list))
+			}
+		}
+	}
+	return
+}
+
+func main() {
+
+	listPtr := flag.Bool("l", false, "list only, don't perform uninstall")
+
+	flag.Parse()
+
+	code := findDokanUninstall(*listPtr, false)
+	code = mergeResults(code, findDokanUninstall(*listPtr, true))
+	os.Exit(code)
+}

--- a/go/tools/dokanclean/main.go
+++ b/go/tools/dokanclean/main.go
@@ -71,6 +71,11 @@ func doUninstallAction(uninst string, list bool) int {
 	return retval
 }
 
+func removeKeybaseStartupShortcuts() {
+	os.Remove(os.ExpandEnv("$APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\GUIStartup.lnk"))
+	os.Remove(os.ExpandEnv("$APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\KeybaseStartup.lnk"))
+}
+
 // Read all the uninstall subkeys and find the ones with DisplayName starting with "Dokan Library".
 // If not just listing, execute each uninstaller we find and merge return codes.
 func findDokanUninstall(list bool, wow64 bool) (result int) {
@@ -122,5 +127,8 @@ func main() {
 
 	code := findDokanUninstall(*listPtr, false)
 	code = mergeResults(code, findDokanUninstall(*listPtr, true))
+	if !*listPtr {
+		removeKeybaseStartupShortcuts()
+	}
 	os.Exit(code)
 }

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -191,11 +191,12 @@
   <Fragment>
     <CustomAction Id="StopMainApp"
               Directory="INSTALLFOLDER"
-              ExeCommand="[INSTALLFOLDER]runquiet.exe -wait [INSTALLFOLDER]keybase.exe ctl stop"
+              ExeCommand="[INSTALLFOLDER]runquiet.exe -wait [INSTALLFOLDER]keybase.exe ctl stop --kill-kbfs"
               Execute="immediate"
               Return="ignore"/>
   </Fragment>
   <Fragment>
+    <!-- This is just in case --kill-kbfs doesn't work -->
     <CustomAction Id="StopKBFS"
               Directory="INSTALLFOLDER"
               ExeCommand="[INSTALLFOLDER]runquiet.exe -wait [WindowsFolder]\System32\taskkill.exe /F /IM kbfsdokan.exe"

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -24,10 +24,12 @@
       <InstallValidate Suppress="yes">FAKE_PROPERTY</InstallValidate>
       <Custom Action="StopUpdater" Before="InstallValidate"/>
       <Custom Action="StopGUI" Before="InstallValidate"/>
-      <Custom Action="StopKBFS" Before="InstallValidate"/>
       <Custom Action="StopMainApp" Before="InstallValidate"/>
-      <Custom Action="RunMainApp" Before="InstallFinalize">NOT (REMOVE ~= "ALL")</Custom>
-      <Custom Action="RunGUI" Before="InstallFinalize">NOT (REMOVE ~= "ALL")</Custom>
+      <Custom Action="StopKBFS" Before="InstallValidate"/>
+      <!-- Force reboot for this version until everyone has kill-kbfs -->
+      <ScheduleReboot Before="InstallFinalize">UPGRADINGPRODUCTCODE</ScheduleReboot>
+      <Custom Action="RunMainApp" Before="InstallFinalize">NOT REBOOT AND NOT (REMOVE ~= "ALL")</Custom>
+      <Custom Action="RunGUI" Before="InstallFinalize">NOT REBOOT AND NOT (REMOVE ~= "ALL")</Custom>
     </InstallExecuteSequence>
 
 
@@ -196,7 +198,7 @@
               Return="ignore"/>
   </Fragment>
   <Fragment>
-    <!-- This is just in case --kill-kbfs doesn't work -->
+    <!-- This is just in case kill-kbfs doesn't work -->
     <CustomAction Id="StopKBFS"
               Directory="INSTALLFOLDER"
               ExeCommand="[INSTALLFOLDER]runquiet.exe -wait [WindowsFolder]\System32\taskkill.exe /F /IM kbfsdokan.exe"

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -26,10 +26,8 @@
       <Custom Action="StopGUI" Before="InstallValidate"/>
       <Custom Action="StopMainApp" Before="InstallValidate"/>
       <Custom Action="StopKBFS" Before="InstallValidate"/>
-      <!-- Force reboot for this version until everyone has kill-kbfs -->
-      <ScheduleReboot Before="InstallFinalize">UPGRADINGPRODUCTCODE</ScheduleReboot>
-      <Custom Action="RunMainApp" Before="InstallFinalize">NOT REBOOT AND NOT (REMOVE ~= "ALL")</Custom>
-      <Custom Action="RunGUI" Before="InstallFinalize">NOT REBOOT AND NOT (REMOVE ~= "ALL")</Custom>
+      <Custom Action="RunMainApp" Before="InstallFinalize">NOT (REMOVE ~= "ALL")</Custom>
+      <Custom Action="RunGUI" Before="InstallFinalize">NOT (REMOVE ~= "ALL")</Custom>
     </InstallExecuteSequence>
 
 
@@ -193,7 +191,7 @@
   <Fragment>
     <CustomAction Id="StopMainApp"
               Directory="INSTALLFOLDER"
-              ExeCommand="[INSTALLFOLDER]runquiet.exe -wait [INSTALLFOLDER]keybase.exe ctl stop --kill-kbfs"
+              ExeCommand="[INSTALLFOLDER]runquiet.exe -wait [INSTALLFOLDER]keybase.exe ctl stop"
               Execute="immediate"
               Return="ignore"/>
   </Fragment>

--- a/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
@@ -64,7 +64,26 @@
                  Format="raw"
                  Win64="yes"
                  />
-    
+
+    <!-- Dokan Bundle 1.0.0RC4.3 -->
+    <util:RegistrySearch Id="DokanBundleUninstall"
+             Variable="DokanBundleUninstallString"
+             Root="HKLM"
+             Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{d36c41f1-e204-487e-9c4a-29834dddcabe}"
+             Value="QuietUninstallString"
+             Format="raw"
+             />
+    <util:RegistrySearch Id="DokanBundleUninstall64"
+                 After="DokanBundleUninstall"
+                 Condition="NOT DokanBundleUninstallString"
+                 Variable="DokanBundleUninstallString"
+                 Root="HKLM"
+                 Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{d36c41f1-e204-487e-9c4a-29834dddcabe}"
+                 Value="QuietUninstallString"
+                 Format="raw"
+                 Win64="yes"
+                 />
+
     <bal:Condition
       Message="Please uninstall any previous versions of the Dokan driver package before continuing.">
       <![CDATA[NOT InnoUninstallString]]>
@@ -102,6 +121,15 @@
 
     <Chain>
       <PackageGroupRef Id="NetFx40Web"/>
+      
+      <ExePackage
+        SourceFile="$(env.GOPATH)\src\github.com\keybase\client\go\tools\runquiet\runquiet.exe"
+        InstallCommand="-wait [DokanBundleUninstallString]"
+        DetectCondition="NOT DokanBundleUninstallString"
+        PerMachine="yes"
+        Permanent="yes">
+        <ExitCode Behavior="forceReboot"/>
+      </ExePackage>
 
       <ExePackage Id="vcredist_2015_x86.exe"
                   Name="vc_redist.x86.exe"

--- a/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
@@ -78,11 +78,14 @@
     <util:RegistrySearch Id="vcredist_2015_x64_versionnumbercheck" Root="HKLM" Key="SOFTWARE\Classes\Installer\Dependencies\Microsoft.VS.VC_RuntimeMinimumVSU_amd64,v14" Value="Version" Variable="vcredist_2015_x64_versionnumber" Result="value" Win64="yes"/>
 
     <bal:Condition Message="Installation failed because your version of Windows is too old. Dokan requires Windows 7 SP1 or newer."><![CDATA[Installed OR VersionNT > v6.1 OR (VersionNT = v6.1 AND ServicePackLevel >= 1)]]></bal:Condition>
-
+    
     <Chain>
       <PackageGroupRef Id="NetFx40Web"/>
       
-      <!-- Remember: if DetectCondition is true, this package is considered already present. -->
+      <!-- Remember: if DetectCondition is true, this package is considered already present. 
+        WixBundleAction of 4 means install. 3 is uninstall, 5 is upgrade.
+        Making this permanent prevents it from being invoked on uninstall or other removal.
+      -->
       <ExePackage
         SourceFile="$(env.GOPATH)\src\github.com\keybase\client\go\tools\dokanclean\dokanclean.exe"
         DetectCondition="DokanUninstallString"

--- a/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
@@ -24,62 +24,24 @@
             SuppressOptionsUI="yes"
             />
     </BootstrapperApplicationRef>
-    
-    <!-- From the old Inno installer for Dokan 0.8.0 -->
-    <util:RegistrySearch Id="InnoUninstall2"
-             Variable="InnoUninstallString"
-             Root="HKLM"
-             Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{DEB2E54C-C39F-4DC8-93A7-ABE0AB91DDCA}_is1"
-             Value="QuietUninstallString"
-             Format="raw"
-                 />
-    <util:RegistrySearch Id="InnoUninstall264"
-                 After="InnoUninstall2"
-                 Condition="NOT InnoUninstallString"
-                 Variable="InnoUninstallString"
-                 Root="HKLM"
-                 Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{DEB2E54C-C39F-4DC8-93A7-ABE0AB91DDCA}_is1"
-                 Value="QuietUninstallString"
-                 Format="raw"
-                 Win64="yes"
-                 />
-    
-    <!-- From the old Inno installer for Dokan 1.0.0RC2 -->
-    <util:RegistrySearch Id="InnoUninstall3"
-             Variable="InnoUninstallString"
-             After="InnoUninstall264"
-             Condition="NOT InnoUninstallString"
-             Root="HKLM"
-             Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{1B2672D9-2BAD-4C11-BA53-A75AF6FD7789}_is1"
-             Value="QuietUninstallString"
-             Format="raw"
-                 />
-    <util:RegistrySearch Id="InnoUninstall364"
-                 After="InnoUninstall3"
-                 Condition="NOT InnoUninstallString"
-                 Variable="InnoUninstallString"
-                 Root="HKLM"
-                 Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{1B2672D9-2BAD-4C11-BA53-A75AF6FD7789}_is1"
-                 Value="QuietUninstallString"
-                 Format="raw"
-                 Win64="yes"
-                 />
 
-    <!-- Dokan Bundle 1.0.0RC4.3 -->
-    <util:RegistrySearch Id="DokanBundleUninstall"
-             Variable="DokanBundleUninstallString"
+    <!-- Keybase Dokany Build 58 
+         This is the target we need to install with. If it's not there,
+         we may need to invoke the dokan cleaner. -->
+    <util:RegistrySearch Id="DokanUninstall"
+             Variable="DokanUninstallString"
              Root="HKLM"
-             Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{d36c41f1-e204-487e-9c4a-29834dddcabe}"
-             Value="QuietUninstallString"
+             Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{65A3A986-3DC3-0100-0000-160803110110}"
+             Value="UninstallString"
              Format="raw"
              />
-    <util:RegistrySearch Id="DokanBundleUninstall64"
-                 After="DokanBundleUninstall"
-                 Condition="NOT DokanBundleUninstallString"
-                 Variable="DokanBundleUninstallString"
+    <util:RegistrySearch Id="DokanUninstall64"
+                 After="DokanUninstall"
+                 Condition="NOT DokanUninstallString"
+                 Variable="DokanUninstallString"
                  Root="HKLM"
-                 Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{d36c41f1-e204-487e-9c4a-29834dddcabe}"
-                 Value="QuietUninstallString"
+                 Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{65A3A964-3DC3-0100-0000-160803110110}"
+                 Value="UninstallString"
                  Format="raw"
                  Win64="yes"
                  />
@@ -117,19 +79,19 @@
 
     <bal:Condition Message="Installation failed because your version of Windows is too old. Dokan requires Windows 7 SP1 or newer."><![CDATA[Installed OR VersionNT > v6.1 OR (VersionNT = v6.1 AND ServicePackLevel >= 1)]]></bal:Condition>
 
-
-
     <Chain>
       <PackageGroupRef Id="NetFx40Web"/>
       
+      <!-- Remember: if DetectCondition is true, this package is considered already present. -->
       <ExePackage
-        SourceFile="$(env.GOPATH)\src\github.com\keybase\client\go\tools\runquiet\runquiet.exe"
-        InstallCommand="-wait [DokanBundleUninstallString]"
-        DetectCondition="NOT DokanBundleUninstallString"
+        SourceFile="$(env.GOPATH)\src\github.com\keybase\client\go\tools\dokanclean\dokanclean.exe"
+        DetectCondition="DokanUninstallString"
         Description="Remove previous drivers"
         PerMachine="yes"
         Permanent="yes">
-        <ExitCode Behavior="forceReboot"/>
+        <ExitCode Value="1641" Behavior="forceReboot"/>
+        <ExitCode Value="3010" Behavior="forceReboot"/>
+        <ExitCode Value="0" Behavior="success" />
       </ExePackage>
 
       <ExePackage Id="vcredist_2015_x86.exe"

--- a/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
@@ -126,6 +126,7 @@
         SourceFile="$(env.GOPATH)\src\github.com\keybase\client\go\tools\runquiet\runquiet.exe"
         InstallCommand="-wait [DokanBundleUninstallString]"
         DetectCondition="NOT DokanBundleUninstallString"
+        Description="Remove previous drivers"
         PerMachine="yes"
         Permanent="yes">
         <ExitCode Behavior="forceReboot"/>

--- a/packaging/windows/build_prerelease.cmd
+++ b/packaging/windows/build_prerelease.cmd
@@ -56,6 +56,11 @@ pushd %GOPATH%\src\github.com\keybase\client\go\tools\runquiet
 go build -ldflags "-H windowsgui"
 popd
 
+:: dokanclean
+pushd %GOPATH%\src\github.com\keybase\client\go\tools\dokanclean
+go build
+popd
+
 :: Then the desktop:
 pushd  %GOPATH%\src\github.com\keybase\client\desktop
 :: rmdir /s /q node_modules

--- a/packaging/windows/doinstaller_wix.cmd
+++ b/packaging/windows/doinstaller_wix.cmd
@@ -58,6 +58,10 @@ SignTool.exe sign /i digicert /a /tr http://timestamp.digicert.com %GOPATH%\src\
 IF %ERRORLEVEL% NEQ 0 (k
   EXIT /B 1
 )
+SignTool.exe sign /i digicert /a /tr http://timestamp.digicert.com %GOPATH%\src\github.com\keybase\client\go\tools\dokanclean\dokanclean.exe
+IF %ERRORLEVEL% NEQ 0 (k
+  EXIT /B 1
+)
 SignTool.exe sign /i digicert /a /tr http://timestamp.digicert.com %GOPATH%\src\github.com\keybase\client\desktop\release\win32-ia32\Keybase-win32-ia32\Keybase.exe
 IF %ERRORLEVEL% NEQ 0 (
   EXIT /B 1


### PR DESCRIPTION
This rolls up the dokanclean PR also, which hadn't been merged, along with the changes for it to remove startup shortcuts. Also included is the one-time force clean, to make sure kill-kbfs gets in.

Note this approach puts kill-kbfs in keybase.exe - I think it belongs in the same place the mount name lives, which for better or worse is keybase.exe right now, which started because watchdog2 has to know how to launch kbfs.

@maxtaco @taruti 