### PR TITLE
Signature V2, with ASCII-string prefixes

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -438,7 +438,8 @@ const (
 )
 
 const (
-	SignaturePrefixKBFS     SignaturePrefix = "Keybase-KBFS-1"
-	SignaturePrefixChat     SignaturePrefix = "Keybase-Chat-1"
-	SignaturePrefixSigchain SignaturePrefix = "Keybase-Sigchain-1"
+	SignaturePrefixKBFS       SignaturePrefix = "Keybase-KBFS-1"
+	SignaturePrefixChatHeader SignaturePrefix = "Keybase-Chat-Body-1"
+	SignaturePrefixChatBody   SignaturePrefix = "Keybase-Chat-Header-1"
+	SignaturePrefixSigchain   SignaturePrefix = "Keybase-Sigchain-1"
 )

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -437,8 +437,10 @@ const (
 	PGPAssertionKey = "pgp"
 )
 
+type SignaturePrefix string
+
 const (
-	SignaturePrefixKBFS     SignaturePrefix = "KEYBASE-KBFS-0"
-	SignaturePrefixChat     SignaturePrefix = "KEYBASE-CHAT-0"
-	SignaturePrefixSigchain SignaturePrefix = "KEYBASE-SIGCHAIN-0"
+	SignaturePrefixKBFS     SignaturePrefix = "Keybase-KBFS-1"
+	SignaturePrefixChat     SignaturePrefix = "Keybase-Chat-1"
+	SignaturePrefixSigchain SignaturePrefix = "Keybase-Sigchain-1"
 )

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -436,3 +436,9 @@ const (
 const (
 	PGPAssertionKey = "pgp"
 )
+
+const (
+	SignaturePrefixKBFS     SignaturePrefix = "KEYBASE-KBFS-0"
+	SignaturePrefixChat     SignaturePrefix = "KEYBASE-CHAT-0"
+	SignaturePrefixSigchain SignaturePrefix = "KEYBASE-SIGCHAIN-0"
+)

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -437,8 +437,6 @@ const (
 	PGPAssertionKey = "pgp"
 )
 
-type SignaturePrefix string
-
 const (
 	SignaturePrefixKBFS     SignaturePrefix = "Keybase-KBFS-1"
 	SignaturePrefixChat     SignaturePrefix = "Keybase-Chat-1"

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1415,3 +1415,19 @@ func IsExecError(err error) bool {
 	}
 	return false
 }
+
+//=============================================================================
+
+type BadSignaturePrefixError struct{}
+
+func (e BadSignaturePrefixError) Error() string { return "bad signature prefix" }
+
+//=============================================================================
+
+type UnhandledSignatureError struct {
+	version int
+}
+
+func (e UnhandledSignatureError) Error() string {
+	return fmt.Sprintf("unhandled signature version: %d", e.version)
+}

--- a/go/libkb/generickey.go
+++ b/go/libkb/generickey.go
@@ -14,6 +14,7 @@ type AlgoType int
 
 type GenericKey interface {
 	GetKID() keybase1.KID
+	GetBinaryKID() keybase1.BinaryKID
 	GetFingerprintP() *PGPFingerprint
 	GetAlgoType() AlgoType
 

--- a/go/libkb/gpg_key.go
+++ b/go/libkb/gpg_key.go
@@ -32,6 +32,10 @@ func (g *GPGKey) GetKID() keybase1.KID {
 	return g.kid
 }
 
+func (g *GPGKey) GetBinaryKID() keybase1.BinaryKID {
+	return g.GetKID().ToBinaryKID()
+}
+
 func (g *GPGKey) GetFingerprintP() *PGPFingerprint {
 	return g.fp
 }

--- a/go/libkb/naclwrap.go
+++ b/go/libkb/naclwrap.go
@@ -318,8 +318,6 @@ func (p SignaturePrefix) hasNullByte() bool {
 	return false
 }
 
-type SignaturePrefix string
-
 func (p SignaturePrefix) Prefix(msg []byte) []byte {
 	prefix := append([]byte(p), 0)
 	return append(prefix, msg...)

--- a/go/libkb/naclwrap.go
+++ b/go/libkb/naclwrap.go
@@ -312,12 +312,7 @@ func (k NaclSigningKeyPair) Sign(msg []byte) (ret *NaclSigInfo, err error) {
 type SignaturePrefix string
 
 func (p SignaturePrefix) hasNullByte() bool {
-	for _, b := range []byte(p) {
-		if b == 0 {
-			return true
-		}
-	}
-	return false
+	return bytes.IndexByte([]byte(p), byte(0)) != -1
 }
 
 func (p SignaturePrefix) Prefix(msg []byte) []byte {

--- a/go/libkb/naclwrap.go
+++ b/go/libkb/naclwrap.go
@@ -309,6 +309,8 @@ func (k NaclSigningKeyPair) Sign(msg []byte) (ret *NaclSigInfo, err error) {
 	return
 }
 
+type SignaturePrefix string
+
 func (p SignaturePrefix) hasNullByte() bool {
 	for _, b := range []byte(p) {
 		if b == 0 {

--- a/go/libkb/naclwrap.go
+++ b/go/libkb/naclwrap.go
@@ -18,12 +18,14 @@ import (
 type NaclSignature [ed25519.SignatureSize]byte
 
 type NaclSigInfo struct {
-	Kid      []byte        `codec:"key"`
-	Payload  []byte        `codec:"payload,omitempty"`
-	Sig      NaclSignature `codec:"sig"`
-	SigType  int           `codec:"sig_type"`
-	HashType int           `codec:"hash_type"`
-	Detached bool          `codec:"detached"`
+	Kid      keybase1.BinaryKID `codec:"key"`
+	Payload  []byte             `codec:"payload,omitempty"`
+	Sig      NaclSignature      `codec:"sig"`
+	SigType  int                `codec:"sig_type"`
+	HashType int                `codec:"hash_type"`
+	Detached bool               `codec:"detached"`
+	Version  int                `codec:"version,omitempty"`
+	Prefix   SignaturePrefix    `codec:"prefix,omitempty"`
 }
 
 type NaclEncryptionInfo struct {
@@ -179,6 +181,10 @@ func ImportNaclDHKeyPairFromHex(s string) (ret NaclDHKeyPair, err error) {
 }
 
 func (k NaclDHKeyPublic) GetKID() keybase1.KID {
+	return k.GetBinaryKID().ToKID()
+}
+
+func (k NaclDHKeyPublic) GetBinaryKID() keybase1.BinaryKID {
 	prefix := []byte{
 		byte(KeybaseKIDV1),
 		byte(KIDNaclDH),
@@ -186,7 +192,7 @@ func (k NaclDHKeyPublic) GetKID() keybase1.KID {
 	suffix := byte(IDSuffixKID)
 	out := append(prefix, k[:]...)
 	out = append(out, suffix)
-	return keybase1.KIDFromSlice(out)
+	return keybase1.BinaryKID(out)
 }
 
 func (k NaclDHKeyPair) GetFingerprintP() *PGPFingerprint {
@@ -201,7 +207,7 @@ func (k NaclSigningKeyPair) GetAlgoType() AlgoType {
 	return KIDNaclEddsa
 }
 
-func (k NaclSigningKeyPublic) GetKID() keybase1.KID {
+func (k NaclSigningKeyPublic) GetBinaryKID() keybase1.BinaryKID {
 	prefix := []byte{
 		byte(KeybaseKIDV1),
 		byte(KIDNaclEddsa),
@@ -209,11 +215,19 @@ func (k NaclSigningKeyPublic) GetKID() keybase1.KID {
 	suffix := byte(IDSuffixKID)
 	out := append(prefix, k[:]...)
 	out = append(out, suffix)
-	return keybase1.KIDFromSlice(out)
+	return keybase1.BinaryKID(out)
+}
+
+func (k NaclSigningKeyPublic) GetKID() keybase1.KID {
+	return k.GetBinaryKID().ToKID()
 }
 
 func (k NaclSigningKeyPair) GetKID() (ret keybase1.KID) {
 	return k.Public.GetKID()
+}
+
+func (k NaclSigningKeyPair) GetBinaryKID() (ret keybase1.BinaryKID) {
+	return k.Public.GetBinaryKID()
 }
 
 func (k NaclSigningKeyPair) ToShortIDString() string {
@@ -237,6 +251,9 @@ func (k NaclSigningKeyPair) GetFingerprintP() *PGPFingerprint {
 
 func (k NaclDHKeyPair) GetKID() keybase1.KID {
 	return k.Public.GetKID()
+}
+func (k NaclDHKeyPair) GetBinaryKID() (ret keybase1.BinaryKID) {
+	return k.Public.GetBinaryKID()
 }
 
 func (k NaclSigningKeyPair) CheckSecretKey() error {
@@ -277,13 +294,59 @@ func (k NaclSigningKeyPair) Sign(msg []byte) (ret *NaclSigInfo, err error) {
 		err = NoSecretKeyError{}
 		return
 	}
+
+	// Version 0 is just over the unprefixed message (assume version 0 if no version present)
+	// Version 1 is the same.
 	ret = &NaclSigInfo{
-		Kid:      k.GetKID().ToBytes(),
+		Kid:      k.GetBinaryKID(),
 		Payload:  msg,
 		Sig:      *k.Private.Sign(msg),
 		SigType:  SigKbEddsa,
 		HashType: HashPGPSha512,
 		Detached: true,
+		Version:  0,
+	}
+	return
+}
+
+func (p SignaturePrefix) hasNullByte() bool {
+	for _, b := range []byte(p) {
+		if b == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+type SignaturePrefix string
+
+func (p SignaturePrefix) Prefix(msg []byte) []byte {
+	prefix := append([]byte(p), 0)
+	return append(prefix, msg...)
+}
+
+func (k NaclSigningKeyPair) SignV2(msg []byte, prefix SignaturePrefix) (ret *NaclSigInfo, err error) {
+	if k.Private == nil {
+		err = NoSecretKeyError{}
+		return
+	}
+
+	if prefix.hasNullByte() || len(prefix) == 0 {
+		err = BadSignaturePrefixError{}
+		return
+	}
+
+	// Version 0 is just over the unprefixed message (assume version 0 if no version present)
+	// Version 1 is the same.
+	ret = &NaclSigInfo{
+		Kid:      k.GetBinaryKID(),
+		Payload:  msg,
+		Sig:      *k.Private.Sign(prefix.Prefix(msg)),
+		SigType:  SigKbEddsa,
+		HashType: HashPGPSha512,
+		Detached: true,
+		Version:  2,
+		Prefix:   prefix,
 	}
 	return
 }
@@ -350,7 +413,7 @@ func NaclVerifyAndExtract(s string) (key GenericKey, payload []byte, fullBody []
 	}
 
 	var nk *NaclSigningKeyPublic
-	err, nk = naclSig.Verify()
+	nk, err = naclSig.Verify()
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -412,15 +475,26 @@ func KIDToNaclSigningKeyPublic(bk []byte) *NaclSigningKeyPublic {
 	return &ret
 }
 
-func (s NaclSigInfo) Verify() (error, *NaclSigningKeyPublic) {
+func (s NaclSigInfo) Verify() (*NaclSigningKeyPublic, error) {
 	key := KIDToNaclSigningKeyPublic(s.Kid)
 	if key == nil {
-		return BadKeyError{}, nil
+		return nil, BadKeyError{}
 	}
-	if !key.Verify(s.Payload, &s.Sig) {
-		return VerificationError{}, nil
+
+	switch s.Version {
+	case 0, 1:
+		if !key.Verify(s.Payload, &s.Sig) {
+			return nil, VerificationError{}
+		}
+	case 2:
+		if !key.Verify(s.Prefix.Prefix(s.Payload), &s.Sig) {
+			return nil, VerificationError{}
+		}
+	default:
+		return nil, UnhandledSignatureError{}
 	}
-	return nil, key
+
+	return key, nil
 }
 
 func (s *NaclSigInfo) ArmoredEncode() (ret string, err error) {

--- a/go/libkb/naclwrap_test.go
+++ b/go/libkb/naclwrap_test.go
@@ -234,7 +234,7 @@ func TestNaclPrefixedSigs(t *testing.T) {
 
 	msg := []byte("test message")
 
-	sig, err := keyPair.SignV2(msg, SignaturePrefixChat)
+	sig, err := keyPair.SignV2(msg, SignaturePrefixChatHeader)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/libkb/naclwrap_test.go
+++ b/go/libkb/naclwrap_test.go
@@ -221,3 +221,60 @@ func TestNaclDecryptFromIced(t *testing.T) {
 		t.Error("failed to match plaintext")
 	}
 }
+
+// In V2, Nacl sigs are prefixed....
+func TestNaclPrefixedSigs(t *testing.T) {
+
+	keyPair, err := GenerateNaclSigningKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("keyPair: Public: %+v, Private: %+v", keyPair.Public, keyPair.Private)
+
+	msg := []byte("test message")
+
+	sig, err := keyPair.SignV2(msg, SignaturePrefixChat)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = sig.Verify()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sig.Version = 1
+	_, err = sig.Verify()
+	if err == nil {
+		t.Fatal("expected an error after we jiggled the version to 1")
+	}
+	if _, ok := err.(VerificationError); !ok {
+		t.Fatal("expected a VerificationError")
+	}
+
+	sig.Version = 2
+	sig.Prefix = SignaturePrefixKBFS
+	_, err = sig.Verify()
+	if err == nil {
+		t.Fatal("expected an error after we jiggled the prefix to the wrong one")
+	}
+	if _, ok := err.(VerificationError); !ok {
+		t.Fatal("expected a VerificationError")
+	}
+
+	_, err = keyPair.SignV2(msg, SignaturePrefix("a\x00b"))
+	if err == nil {
+		t.Fatal("expected a BadSignaturePrefixError")
+	}
+	if _, ok := err.(BadSignaturePrefixError); !ok {
+		t.Fatal("expected a BadSignaturePrefixError")
+	}
+	_, err = keyPair.SignV2(msg, SignaturePrefix(""))
+	if err == nil {
+		t.Fatal("expected a BadSignaturePrefixError")
+	}
+	if _, ok := err.(BadSignaturePrefixError); !ok {
+		t.Fatal("expected a BadSignaturePrefixError")
+	}
+}

--- a/go/libkb/pgp_key.go
+++ b/go/libkb/pgp_key.go
@@ -505,7 +505,7 @@ func (k *PGPKeyBundle) CanSign() bool {
 	return (k.PrivateKey != nil && !k.PrivateKey.Encrypted) || k.GPGFallbackKey != nil
 }
 
-func (k *PGPKeyBundle) GetKID() keybase1.KID {
+func (k *PGPKeyBundle) GetBinaryKID() keybase1.BinaryKID {
 
 	prefix := []byte{
 		byte(KeybaseKIDV1),
@@ -531,7 +531,11 @@ func (k *PGPKeyBundle) GetKID() keybase1.KID {
 	out := append(prefix, sum[:]...)
 	out = append(out, byte(IDSuffixKID))
 
-	return keybase1.KIDFromSlice(out)
+	return keybase1.BinaryKID(out)
+}
+
+func (k *PGPKeyBundle) GetKID() keybase1.KID {
+	return k.GetBinaryKID().ToKID()
 }
 
 func (k PGPKeyBundle) GetAlgoType() AlgoType {

--- a/go/protocol/common.go
+++ b/go/protocol/common.go
@@ -24,6 +24,7 @@ type UID string
 type DeviceID string
 type SigID string
 type KID string
+type BinaryKID []byte
 type TLFID string
 type Bytes32 [32]byte
 type Text struct {

--- a/go/protocol/extras.go
+++ b/go/protocol/extras.go
@@ -60,6 +60,14 @@ func KIDFromSlice(b []byte) KID {
 	return KID(hex.EncodeToString(b))
 }
 
+func (b BinaryKID) ToKID() KID {
+	return KIDFromSlice([]byte(b))
+}
+
+func (k KID) ToBinaryKID() BinaryKID {
+	return BinaryKID(k.ToBytes())
+}
+
 func KIDFromStringChecked(s string) (KID, error) {
 
 	// It's OK to have a 0-length KID. That means, no such key

--- a/go/service/chat_boxer.go
+++ b/go/service/chat_boxer.go
@@ -159,11 +159,13 @@ func (b *chatBoxer) verifyMessageBoxed(msg chat1.MessageBoxed) error {
 
 // verify verifies the signature of data using SignatureInfo.
 func (b *chatBoxer) verify(data []byte, si chat1.SignatureInfo) bool {
-	var pub libkb.NaclSigningKeyPublic
-	copy(pub[:], si.K)
-
-	var sig libkb.NaclSignature
-	copy(sig[:], si.S)
-
-	return pub.Verify(data, &sig)
+	sigInfo := libkb.NaclSigInfo{
+		Version: si.V,
+		Prefix:  libkb.SignaturePrefixChat,
+		Kid:     si.K,
+		Payload: data,
+	}
+	copy(sigInfo.Sig[:], si.S)
+	_, err := sigInfo.Verify()
+	return (err == nil)
 }

--- a/go/service/chat_boxer.go
+++ b/go/service/chat_boxer.go
@@ -142,11 +142,11 @@ func (b *chatBoxer) verifyMessageBoxed(msg chat1.MessageBoxed) error {
 	if err != nil {
 		return err
 	}
-	if !b.verify(header, msg.HeaderSignature) {
+	if !b.verify(header, msg.HeaderSignature, libkb.SignaturePrefixChatHeader) {
 		return libkb.BadSigError{E: "header signature invalid"}
 	}
 
-	if !b.verify(msg.BodyCiphertext.E, msg.BodySignature) {
+	if !b.verify(msg.BodyCiphertext.E, msg.BodySignature, libkb.SignaturePrefixChatBody) {
 		return libkb.BadSigError{E: "body signature invalid"}
 	}
 
@@ -158,10 +158,10 @@ func (b *chatBoxer) verifyMessageBoxed(msg chat1.MessageBoxed) error {
 }
 
 // verify verifies the signature of data using SignatureInfo.
-func (b *chatBoxer) verify(data []byte, si chat1.SignatureInfo) bool {
+func (b *chatBoxer) verify(data []byte, si chat1.SignatureInfo, prefix libkb.SignaturePrefix) bool {
 	sigInfo := libkb.NaclSigInfo{
 		Version: si.V,
-		Prefix:  libkb.SignaturePrefixChat,
+		Prefix:  prefix,
 		Kid:     si.K,
 		Payload: data,
 	}

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -157,17 +157,21 @@ func (h *chatLocalHandler) signJSON(data interface{}, kp libkb.NaclSigningKeyPai
 	return h.sign(encoded, kp)
 }
 
+func exportSigInfo(si *libkb.NaclSigInfo) chat1.SignatureInfo {
+	return chat1.SignatureInfo{
+		V: si.Version,
+		S: si.Sig[:],
+		K: si.Kid,
+	}
+}
+
 // sign signs msg with a NaclSigningKeyPair, returning a chat1.SignatureInfo.
 func (h *chatLocalHandler) sign(msg []byte, kp libkb.NaclSigningKeyPair) (chat1.SignatureInfo, error) {
-	sig := *kp.Private.Sign(msg)
-
-	info := chat1.SignatureInfo{
-		V: 1,
-		S: sig[:],
-		K: kp.Public[:],
+	sig, err := kp.SignV2(msg, libkb.SignaturePrefixChat)
+	if err != nil {
+		return chat1.SignatureInfo{}, err
 	}
-
-	return info, nil
+	return exportSigInfo(sig), nil
 }
 
 // keyFinder remembers results from previous calls to CryptKeys().

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -131,13 +131,13 @@ func (h *chatLocalHandler) unboxThread(ctx context.Context, boxed chat1.ThreadVi
 // signMessageBoxed signs the header and encrypted body of a chat1.MessageBoxed
 // with the NaclSigningKeyPair.
 func (h *chatLocalHandler) signMessageBoxed(msg *chat1.MessageBoxed, kp libkb.NaclSigningKeyPair) error {
-	header, err := h.signJSON(msg.ClientHeader, kp)
+	header, err := h.signJSON(msg.ClientHeader, kp, libkb.SignaturePrefixChatHeader)
 	if err != nil {
 		return err
 	}
 	msg.HeaderSignature = header
 
-	body, err := h.sign(msg.BodyCiphertext.E, kp)
+	body, err := h.sign(msg.BodyCiphertext.E, kp, libkb.SignaturePrefixChatBody)
 	if err != nil {
 		return err
 	}
@@ -148,13 +148,13 @@ func (h *chatLocalHandler) signMessageBoxed(msg *chat1.MessageBoxed, kp libkb.Na
 
 // signJSON signs data with a NaclSigningKeyPair, returning a chat1.SignatureInfo.
 // It encodes data to JSON before signing.
-func (h *chatLocalHandler) signJSON(data interface{}, kp libkb.NaclSigningKeyPair) (chat1.SignatureInfo, error) {
+func (h *chatLocalHandler) signJSON(data interface{}, kp libkb.NaclSigningKeyPair, prefix libkb.SignaturePrefix) (chat1.SignatureInfo, error) {
 	encoded, err := json.Marshal(data)
 	if err != nil {
 		return chat1.SignatureInfo{}, err
 	}
 
-	return h.sign(encoded, kp)
+	return h.sign(encoded, kp, prefix)
 }
 
 func exportSigInfo(si *libkb.NaclSigInfo) chat1.SignatureInfo {
@@ -166,8 +166,8 @@ func exportSigInfo(si *libkb.NaclSigInfo) chat1.SignatureInfo {
 }
 
 // sign signs msg with a NaclSigningKeyPair, returning a chat1.SignatureInfo.
-func (h *chatLocalHandler) sign(msg []byte, kp libkb.NaclSigningKeyPair) (chat1.SignatureInfo, error) {
-	sig, err := kp.SignV2(msg, libkb.SignaturePrefixChat)
+func (h *chatLocalHandler) sign(msg []byte, kp libkb.NaclSigningKeyPair, prefix libkb.SignaturePrefix) (chat1.SignatureInfo, error) {
+	sig, err := kp.SignV2(msg, prefix)
 	if err != nil {
 		return chat1.SignatureInfo{}, err
 	}

--- a/go/service/chat_test.go
+++ b/go/service/chat_test.go
@@ -101,7 +101,7 @@ func TestChatMessageSigned(t *testing.T) {
 		t.Fatal(err)
 	}
 	if boxed.HeaderSignature.V != 2 {
-		t.Errorf("HeaderSignature.V = %d, expected 1", boxed.HeaderSignature.V)
+		t.Errorf("HeaderSignature.V = %d, expected 2", boxed.HeaderSignature.V)
 	}
 	if len(boxed.HeaderSignature.S) == 0 {
 		t.Error("after signMessageBoxed, HeaderSignature.S is empty")
@@ -110,7 +110,7 @@ func TestChatMessageSigned(t *testing.T) {
 		t.Error("after signMessageBoxed, HeaderSignature.K is empty")
 	}
 	if boxed.BodySignature.V != 2 {
-		t.Errorf("BodySignature.V = %d, expected 1", boxed.BodySignature.V)
+		t.Errorf("BodySignature.V = %d, expected 2", boxed.BodySignature.V)
 	}
 	if len(boxed.BodySignature.S) == 0 {
 		t.Error("after signMessageBoxed, BodySignature.S is empty")

--- a/go/service/chat_test.go
+++ b/go/service/chat_test.go
@@ -100,7 +100,7 @@ func TestChatMessageSigned(t *testing.T) {
 	if err := handler.signMessageBoxed(&boxed, kp); err != nil {
 		t.Fatal(err)
 	}
-	if boxed.HeaderSignature.V != 1 {
+	if boxed.HeaderSignature.V != 2 {
 		t.Errorf("HeaderSignature.V = %d, expected 1", boxed.HeaderSignature.V)
 	}
 	if len(boxed.HeaderSignature.S) == 0 {
@@ -109,7 +109,7 @@ func TestChatMessageSigned(t *testing.T) {
 	if len(boxed.HeaderSignature.K) == 0 {
 		t.Error("after signMessageBoxed, HeaderSignature.K is empty")
 	}
-	if boxed.BodySignature.V != 1 {
+	if boxed.BodySignature.V != 2 {
 		t.Errorf("BodySignature.V = %d, expected 1", boxed.BodySignature.V)
 	}
 	if len(boxed.BodySignature.S) == 0 {

--- a/protocol/avdl/common.avdl
+++ b/protocol/avdl/common.avdl
@@ -26,8 +26,13 @@ protocol Common {
   @typedef("string")
   record SigID {}
 
+  // Most appearances of KIDs in protocol are in hex....
   @typedef("string")
   record KID {}
+
+  // But sometimes we need binary kids...
+  @typedef("bytes")
+  record BinaryKID {}
 
   @typedef("string")
   record TLFID {}

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -178,6 +178,8 @@ export function BTCRegisterBTCRpc (request: $Exact<{
   callback?: (null | (err: ?any) => void)}>) {
   engine.rpc({...request, method: 'BTC.registerBTC'})
 }
+export type BinaryKID = bytes
+
 export type BlockIdCombo = {
   blockHash: string,
   chargedTo: UID,

--- a/protocol/json/common.json
+++ b/protocol/json/common.json
@@ -73,6 +73,12 @@
     },
     {
       "type": "record",
+      "name": "BinaryKID",
+      "fields": [],
+      "typedef": "bytes"
+    },
+    {
+      "type": "record",
       "name": "TLFID",
       "fields": [],
       "typedef": "string"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -178,6 +178,8 @@ export function BTCRegisterBTCRpc (request: $Exact<{
   callback?: (null | (err: ?any) => void)}>) {
   engine.rpc({...request, method: 'BTC.registerBTC'})
 }
+export type BinaryKID = bytes
+
 export type BlockIdCombo = {
   blockHash: string,
   chargedTo: UID,


### PR DESCRIPTION
- change out SignatureInfo to match KBFS's
  - ship KIDs not raw Ed25519 keys over the wire
  - use Go-based typing to make sure we got it
  - introduce new keybase1.BinaryKID datatype
- add V2 prefixed signature options
- upgrade to V2 prefixed signatures in chat
- Add tests for a various verification failures