### PR TITLE
Use defaultDeviceID to determine provisioned status

### DIFF
--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -44,7 +44,7 @@ export function navBasedOnLoginState () :AsyncAction {
 
     // No status?
     if (!status || !Object.keys(status).length || !extendedConfig || !Object.keys(extendedConfig).length ||
-      !extendedConfig.device) { // Not provisioned?
+      !extendedConfig.defaultDeviceID) { // Not provisioned?
       dispatch(navigateTo([], loginTab))
       dispatch(switchTab(loginTab))
     } else {

--- a/shared/nav.android.js
+++ b/shared/nav.android.js
@@ -213,7 +213,7 @@ export default connect(
     notifications: {menuBadge}}) => ({
       router,
       bootstrapped,
-      provisioned: extendedConfig && !!extendedConfig.device,
+      provisioned: extendedConfig && !!extendedConfig.defaultDeviceID,
       username,
       dumbFullscreen,
       folderBadge: flags.tabFoldersEnabled ? privateBadge + publicBadge : 0,

--- a/shared/nav.desktop.js
+++ b/shared/nav.desktop.js
@@ -194,7 +194,7 @@ export default connect(
     favorite: {publicBadge, privateBadge},
     notifications: {menuBadge}}) => ({
       router,
-      provisioned: extendedConfig && !!extendedConfig.device,
+      provisioned: extendedConfig && !!extendedConfig.defaultDeviceID,
       username,
       menuBadge,
       folderBadge: flags.tabFoldersEnabled ? publicBadge + privateBadge : 0,

--- a/shared/nav.ios.js
+++ b/shared/nav.ios.js
@@ -186,7 +186,7 @@ export default connect(
   ({router, favorite: {privateBadge, publicBadge}, config: {bootstrapped, extendedConfig, username}, dev: {debugConfig: {dumbFullscreen}}}) => ({
     router,
     bootstrapped,
-    provisioned: extendedConfig && !!extendedConfig.device,
+    provisioned: extendedConfig && !!extendedConfig.defaultDeviceID,
     username,
     dumbFullscreen,
     folderBadge: flags.tabFoldersEnabled ? privateBadge + publicBadge : 0,


### PR DESCRIPTION
@keybase/react-hackers 

This should avoid any network related issues we've seen when determining whether our device was provisioned

cc @patrickxb 