### PR TITLE
Fix build

### DIFF
--- a/go/externals/test_common.go
+++ b/go/externals/test_common.go
@@ -1,8 +1,14 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build !production
+
 package externals
 
 import (
-	"github.com/keybase/client/go/libkb"
 	"testing"
+
+	"github.com/keybase/client/go/libkb"
 )
 
 func SetupTest(tb testing.TB, name string, depth int) (tc libkb.TestContext) {


### PR DESCRIPTION
I guess thats what the kbtest package is for... I guess moving test_common into that would be a lot more effort though.

Seems weird to have to set a tag to get a build without test stuff.