### PR TITLE
Fix gomobile on android

### DIFF
--- a/react-native/android/app/src/main/java/io/keybase/ossifrage/KeyStore.java
+++ b/react-native/android/app/src/main/java/io/keybase/ossifrage/KeyStore.java
@@ -26,9 +26,10 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 import go.keybase.Keybase;
+import go.keybase.ExternalKeyStore;
 import io.keybase.ossifrage.keystore.KeyStoreHelper;
 
-public class KeyStore implements Keybase.ExternalKeyStore {
+public class KeyStore implements ExternalKeyStore {
     private final Context context;
     private final SharedPreferences prefs;
     private final java.security.KeyStore ks;

--- a/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -10,20 +10,15 @@ import android.util.Log;
 import android.view.KeyEvent;
 
 import com.burnweb.rnpermissions.RNPermissionsPackage;
-import com.eguma.barcodescanner.BarcodeScannerPackage;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.ReactPackage;
 import com.facebook.react.ReactRootView;
-import com.facebook.react.shell.MainReactPackage;
 
 import java.io.File;
 import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-import java.util.Arrays;
-import java.util.List;
 
 import go.keybase.Keybase;
 
@@ -32,8 +27,6 @@ import static go.keybase.Keybase.LogSend;
 
 public class MainActivity extends ReactActivity {
     private static final String TAG = MainActivity.class.getName();
-    private ReactInstanceManager mReactInstanceManager;
-    private ReactRootView mReactRootView;
     private File logFile;
 
     @Override


### PR DESCRIPTION
@keybase/react-hackers 

This fixes our go code on android and circle ci errors.

I think gomobile changed how they export types so instead of implementing `go.keybase.Keybase.ExternalKeystore` we have to implement `go.keybase.ExternalKeyStore`