### PR TITLE
stop checking PGP Etimes

### DIFF
--- a/go/vendor/github.com/keybase/go-crypto/openpgp/packet/public_key.go
+++ b/go/vendor/github.com/keybase/go-crypto/openpgp/packet/public_key.go
@@ -64,7 +64,7 @@ func (e *edDSAkey) Verify(payload []byte, r parsedMPI, s parsedMPI) bool {
 	var key [ed25519.PublicKeySize]byte
 	var sig [ed25519.SignatureSize]byte
 
-	// note(mnk): I'm not entirely sure why we need to ignore the first byte.
+	// NOTE(maxtaco): I'm not entirely sure why we need to ignore the first byte.
 	copy(key[:], e.p.bytes[1:])
 	n := copy(sig[:], r.bytes)
 	copy(sig[n:], s.bytes)
@@ -570,9 +570,18 @@ func (pk *PublicKey) VerifySignature(signed hash.Hash, sig *Signature) (err erro
 	signed.Write(sig.HashSuffix)
 	hashBytes := signed.Sum(nil)
 
-	if hashBytes[0] != sig.HashTag[0] || hashBytes[1] != sig.HashTag[1] {
-		return errors.SignatureError("hash tag doesn't match")
-	}
+	// NOTE(maxtaco) 2016-08-22
+	//
+	// We used to do this:
+	//
+	// if hashBytes[0] != sig.HashTag[0] || hashBytes[1] != sig.HashTag[1] {
+	//	  return errors.SignatureError("hash tag doesn't match")
+	// }
+	//
+	// But don't do anything in this case. Some GPGs generate bad
+	// 2-byte hash prefixes, but GPG also doesn't seem to care on
+	// import. See BrentMaxwell's key. I think it's safe to disable
+	// this check!
 
 	if pk.PubKeyAlgo != sig.PubKeyAlgo {
 		return errors.InvalidArgumentError("public key and signature use different algorithms")

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -137,8 +137,8 @@
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp",
-			"revision": "555af76fbcf22e132aa26af3abb8581a614cdee6",
-			"revisionTime": "2016-07-12T08:26:31-04:00"
+			"revision": "f0e86003ab641a4c55f210722aac979161f4ce86",
+			"revisionTime": "2016-08-22T17:23:51-04:00"
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp/armor",
@@ -162,8 +162,8 @@
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp/packet",
-			"revision": "24795fd7db28eb65a498ff3cb0ce21ab59702c53",
-			"revisionTime": "2016-06-10T21:37:45-04:00"
+			"revision": "f0e86003ab641a4c55f210722aac979161f4ce86",
+			"revisionTime": "2016-08-22T17:23:51-04:00"
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp/s2k",


### PR DESCRIPTION
- Just use the Keybase etime instead
- Requires a further upstream patch from go-crypto to also consume the intermediate broken key
- vendor in go-crypto changes that disregard 2-byte hash checking