### PR TITLE
fix @brentmaxwell's sigchain via PGP vendor

### DIFF
--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.18
+- Some people (like @brentmaxwell) had broken sigchains due to bad 
+  short signature IDs. Ignore those. (via vendored PR: keybase/go-crypto#36)
+
 ## 1.0.17
 - Allow signatures with DSA keys without needing to specify explicit signing flags
   in the Public key. Also, better tie-breaking if there are two self-signatures

--- a/go/vendor/github.com/keybase/go-crypto/openpgp/packet/public_key.go
+++ b/go/vendor/github.com/keybase/go-crypto/openpgp/packet/public_key.go
@@ -64,7 +64,7 @@ func (e *edDSAkey) Verify(payload []byte, r parsedMPI, s parsedMPI) bool {
 	var key [ed25519.PublicKeySize]byte
 	var sig [ed25519.SignatureSize]byte
 
-	// note(mnk): I'm not entirely sure why we need to ignore the first byte.
+	// NOTE(maxtaco): I'm not entirely sure why we need to ignore the first byte.
 	copy(key[:], e.p.bytes[1:])
 	n := copy(sig[:], r.bytes)
 	copy(sig[n:], s.bytes)
@@ -570,9 +570,18 @@ func (pk *PublicKey) VerifySignature(signed hash.Hash, sig *Signature) (err erro
 	signed.Write(sig.HashSuffix)
 	hashBytes := signed.Sum(nil)
 
-	if hashBytes[0] != sig.HashTag[0] || hashBytes[1] != sig.HashTag[1] {
-		return errors.SignatureError("hash tag doesn't match")
-	}
+	// NOTE(maxtaco) 2016-08-22
+	//
+	// We used to do this:
+	//
+	// if hashBytes[0] != sig.HashTag[0] || hashBytes[1] != sig.HashTag[1] {
+	//	  return errors.SignatureError("hash tag doesn't match")
+	// }
+	//
+	// But don't do anything in this case. Some GPGs generate bad
+	// 2-byte hash prefixes, but GPG also doesn't seem to care on
+	// import. See BrentMaxwell's key. I think it's safe to disable
+	// this check!
 
 	if pk.PubKeyAlgo != sig.PubKeyAlgo {
 		return errors.InvalidArgumentError("public key and signature use different algorithms")

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -162,8 +162,8 @@
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp/packet",
-			"revision": "24795fd7db28eb65a498ff3cb0ce21ab59702c53",
-			"revisionTime": "2016-06-10T21:37:45-04:00"
+			"revision": "ba409f9a785a2517b7d10d9afc85cea9f665a2b3",
+			"revisionTime": "2016-08-22T17:27:46-04:00"
 		},
 		{
 			"path": "github.com/keybase/go-crypto/openpgp/s2k",


### PR DESCRIPTION
- he had a bad PGP public key failing on short hash IDs. Fixing that fixes the rest of his sigchain
- PGP eTimes live to fight another day