### PR TITLE
Fix PGPKeygen to call key/add for public key

### DIFF
--- a/go/engine/pgp_keygen_test.go
+++ b/go/engine/pgp_keygen_test.go
@@ -9,12 +9,51 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol"
 )
 
-func TestPGPKeyGen(t *testing.T) {
+func TestPGPKeyGenPush(t *testing.T) {
 	tc := SetupEngineTest(t, "pgpkeygen")
 	defer tc.Cleanup()
 
 	u := CreateAndSignupFakeUser(tc, "pgp")
 	pgpUI := &TestPgpUI{ShouldPush: true}
+	ctx := &Context{
+		LogUI:    tc.G.UI.GetLogUI(),
+		SecretUI: u.NewSecretUI(),
+		PgpUI:    pgpUI,
+	}
+	arg := keybase1.PGPKeyGenDefaultArg{
+		CreateUids: keybase1.PGPCreateUids{
+			UseDefault: true,
+			Ids: []keybase1.PGPIdentity{
+				{Username: u.Username, Email: u.Email},
+			},
+		},
+	}
+	eng := NewPGPKeyGen(tc.G, arg)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	xarg := keybase1.PGPExportArg{
+		Options: keybase1.PGPQuery{
+			Secret: true,
+			Query:  pgpUI.Generated.Key.Fingerprint,
+		},
+	}
+	xe := NewPGPKeyExportEngine(xarg, tc.G)
+	if err := RunEngine(xe, ctx); err != nil {
+		t.Fatal(err)
+	}
+	if len(xe.Results()) != 1 {
+		t.Errorf("result keys: %d, expected 1", len(xe.Results()))
+	}
+}
+
+func TestPGPKeyGenNoPush(t *testing.T) {
+	tc := SetupEngineTest(t, "pgpkeygen")
+	defer tc.Cleanup()
+
+	u := CreateAndSignupFakeUser(tc, "pgp")
+	pgpUI := &TestPgpUI{ShouldPush: false}
 	ctx := &Context{
 		LogUI:    tc.G.UI.GetLogUI(),
 		SecretUI: u.NewSecretUI(),

--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -639,6 +639,7 @@ func (kf *KeyFamily) LocalDelegate(key GenericKey) (err error) {
 // account whether the key has been cancelled at time t.
 func (ckf ComputedKeyFamily) GetKeyRoleAtTime(kid keybase1.KID, t time.Time) (ret KeyRole) {
 	if info, err := ckf.getCkiIfActiveAtTime(kid, t); err != nil {
+		ckf.G().Log.Debug("GetKeyRoleAtTime %s, %s => err %s", kid, t, err)
 		ret = DLGNone
 	} else if info.Sibkey {
 		ret = DLGSibkey


### PR DESCRIPTION
First version of this engine did not call key/add unless it was pushing a private pgp key.  This fixes that.  

cc: @MarcoPolo 

r? @maxtaco 