### PR TITLE
Fix LoginState#requests leak in tests

### DIFF
--- a/go/client/chat_test.go
+++ b/go/client/chat_test.go
@@ -92,7 +92,7 @@ func (c *chatLocalMock) PostLocal(ctx context.Context, arg keybase1.PostLocalArg
 	return errors.New("not implemented")
 }
 
-func (h *chatLocalMock) CompleteAndCanonicalizeTlfName(ctx context.Context, tlfName string) (res keybase1.CanonicalTlfName, err error) {
+func (c *chatLocalMock) CompleteAndCanonicalizeTlfName(ctx context.Context, tlfName string) (res keybase1.CanonicalTlfName, err error) {
 	return res, errors.New("not implemented")
 }
 

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -187,11 +187,9 @@ func (s *LoginState) Shutdown() error {
 
 		if s.loginReqs != nil {
 			close(s.loginReqs)
-			s.loginReqs = nil // block future sends to this channel
 		}
 		if s.acctReqs != nil {
 			close(s.acctReqs)
-			s.acctReqs = nil // block future sends to this channel
 		}
 	}, "LoginState - Shutdown")
 	if aerr != nil {
@@ -882,7 +880,7 @@ func (s *LoginState) requests() {
 	// We're supposed to timeout & cleanup Paper Keys after an hour of inactivity.
 	maketimer := func() <-chan time.Time { return s.G().Clock().After(1 * time.Minute) }
 	timer := maketimer()
-	s.G().Log.Debug("LoginState: Running request loop")
+	s.G().Log.Debug("+ LoginState: Running request loop")
 
 	for {
 		select {
@@ -916,6 +914,7 @@ func (s *LoginState) requests() {
 			break
 		}
 	}
+	s.G().Log.Debug("- LoginState: Leaving request loop")
 }
 
 func (s *LoginState) loginWithStoredSecret(lctx LoginContext, username string) error {

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -187,11 +187,15 @@ func (s *LoginState) Shutdown() error {
 
 		if s.loginReqs != nil {
 			close(s.loginReqs)
+
+			// block future sends to this channel; we have observed this in some
+			// tests every now and then do to races in shutdown. It shouldn't be a
+			// problem in production.
 			s.loginReqs = nil
 		}
 		if s.acctReqs != nil {
 			close(s.acctReqs)
-			s.acctReqs = nil
+			s.acctReqs = nil // block future sends to this channel
 		}
 	}, "LoginState - Shutdown")
 	if aerr != nil {

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -89,10 +89,9 @@ type TestContext struct {
 }
 
 func (tc *TestContext) Cleanup() {
+	tc.G.Log.Debug("global context shutdown:")
+	tc.G.Shutdown()
 	if len(tc.Tp.Home) > 0 {
-		tc.G.Log.Debug("global context shutdown:")
-		tc.G.Log.Debug("cleaning up %s", tc.Tp.Home)
-		tc.G.Shutdown()
 		tc.G.Log.Debug("cleaning up %s", tc.Tp.Home)
 		os.RemoveAll(tc.Tp.Home)
 		tc.G.Log.Debug("clearing stored secrets:")


### PR DESCRIPTION
- The problem was that we were closing the 2 channels, and then niling them out;
  the requests loop was therefore unable to receive close messages, since the channels
  had been nilled out.
- fix vet error in chat_test