### PR TITLE
Make inputs visible while typing on mobile

### DIFF
--- a/shared/common-adapters/progress-indicator.ios.js
+++ b/shared/common-adapters/progress-indicator.ios.js
@@ -1,14 +1,14 @@
 // @flow
 import React, {Component} from 'react'
 import type {Props} from './progress-indicator'
-import {ActivityIndicatorIOS} from 'react-native'
+import {ActivityIndicator} from 'react-native'
 import {globalColors} from '../styles/style-guide'
 
 class ProgressIndicator extends Component<void, Props, void> {
   render () {
     const size = (this.props.type === 'Large') ? 'large' : 'small'
 
-    return <ActivityIndicatorIOS
+    return <ActivityIndicator
       color={this.props.white ? globalColors.white : globalColors.black}
       size={size}
       style={{...style, ...this.props.style}} />

--- a/shared/common-adapters/user-card.native.js
+++ b/shared/common-adapters/user-card.native.js
@@ -28,7 +28,6 @@ const styles = {
   container: {
     ...globalStyles.flexBoxColumn,
     alignItems: 'stretch',
-    marginTop: 37,
   },
   inside: {
     ...globalStyles.flexBoxColumn,

--- a/shared/login/register/paper-key/index.render.native.js
+++ b/shared/login/register/paper-key/index.render.native.js
@@ -3,7 +3,7 @@ import Container from '../../forms/container'
 import React, {Component} from 'react'
 import type {Props} from './index.render'
 import {Box, Button, Icon, Input, Text} from '../../../common-adapters'
-import {globalStyles} from '../../../styles/style-guide'
+import {globalMargins, globalStyles} from '../../../styles/style-guide'
 
 class PaperKeyRender extends Component<void, Props, void> {
   render () {
@@ -48,24 +48,21 @@ const stylesContainer = {
 }
 
 const stylesButton = {
-  marginTop: 20,
+  marginTop: globalMargins.medium,
   marginBottom: 20,
 }
 
 const stylesInput = {
-  marginTop: 20,
-  marginBottom: 20,
   alignSelf: 'stretch',
   height: 80,
 }
 
 const stylesIcon = {
   marginTop: 30,
-  marginBottom: 30,
 }
 
 const stylesHeader = {
-  marginTop: 45,
+  marginTop: globalMargins.small,
 }
 
 export default PaperKeyRender

--- a/shared/login/register/passphrase/index.render.native.js
+++ b/shared/login/register/passphrase/index.render.native.js
@@ -49,12 +49,9 @@ class Render extends Component<void, Props, void> {
 
 const stylesContainer = {
   flex: 1,
-  marginTop: 40,
 }
 const stylesInput = {
   flex: 1,
-  marginTop: 40,
-  paddingBottom: 30,
 }
 const stylesForgot = {
   marginTop: 20,
@@ -64,7 +61,6 @@ const stylesCard = {
 }
 
 const usernameStyle = {
-  marginTop: 30,
   textAlign: 'center',
 }
 

--- a/shared/login/register/set-public-name/index.render.native.js
+++ b/shared/login/register/set-public-name/index.render.native.js
@@ -13,7 +13,7 @@ const SetPublicName = ({onBack, onSubmit, onChange, deviceNameError, deviceName,
         style={stylesContainer}
         onBack={onBack}>
         <Text type='Header' style={stylesHeader}>Set a public name for this device:</Text>
-        <Icon type='icon-phone-colors-64' style={stylesIcon} />
+        <Icon type='icon-phone-colors-32' style={stylesIcon} />
         <Input
           autoFocus={true}
           style={stylesInput}
@@ -46,7 +46,7 @@ const stylesContainer = {
 }
 
 const stylesHeader = {
-  marginTop: globalMargins.medium,
+  marginTop: globalMargins.small,
 }
 
 const stylesButton = {

--- a/shared/login/register/set-public-name/index.render.native.js
+++ b/shared/login/register/set-public-name/index.render.native.js
@@ -3,7 +3,7 @@ import Container from '../../forms/container'
 import React from 'react'
 import type {Props} from './index.render'
 import {Box, Button, Icon, Input, Text} from '../../../common-adapters'
-import {globalStyles} from '../../../styles/style-guide'
+import {globalMargins, globalStyles} from '../../../styles/style-guide'
 
 const SetPublicName = ({onBack, onSubmit, onChange, deviceNameError, deviceName, waiting, submitEnabled}: Props) => {
   submitEnabled = submitEnabled == null ? true : submitEnabled
@@ -45,6 +45,10 @@ const stylesContainer = {
   alignItems: 'center',
 }
 
+const stylesHeader = {
+  marginTop: globalMargins.medium,
+}
+
 const stylesButton = {
   marginTop: 20,
   marginBottom: 20,
@@ -57,12 +61,8 @@ const stylesInput = {
 }
 
 const stylesIcon = {
-  marginTop: 30,
-  marginBottom: 30,
-}
-
-const stylesHeader = {
-  marginTop: 45,
+  marginTop: globalMargins.small,
+  marginBottom: globalMargins.small,
 }
 
 export default SetPublicName

--- a/shared/login/register/set-public-name/index.render.native.js
+++ b/shared/login/register/set-public-name/index.render.native.js
@@ -17,6 +17,7 @@ const SetPublicName = ({onBack, onSubmit, onChange, deviceNameError, deviceName,
         <Input
           autoFocus={true}
           style={stylesInput}
+          errorText={deviceNameError}
           floatingLabelText='Device name'
           hintText='Device name'
           onEnterKeyDown={() => onSubmit()}

--- a/shared/login/register/username-or-email/index.render.native.js
+++ b/shared/login/register/username-or-email/index.render.native.js
@@ -60,11 +60,11 @@ const stylesContainer = {
 }
 const stylesInput = {
   flex: 1,
-  marginTop: 55,
+  marginTop: 25,
   marginBottom: 55,
 }
 const stylesOuterCard = {
-  marginTop: 40,
+  marginTop: 0,
 }
 const stylesCard = {
   alignItems: 'stretch',

--- a/shared/login/register/username-or-email/index.render.native.js
+++ b/shared/login/register/username-or-email/index.render.native.js
@@ -32,7 +32,7 @@ class Render extends Component<void, Props, State> {
         style={stylesContainer}
         outerStyle={{backgroundColor: globalColors.lightGrey, padding: 20}}
         onBack={this.props.onBack}>
-        <UserCard style={stylesCard} outerStyle={stylesOuterCard}>
+        <UserCard style={stylesCard}>
           <Input
             autoFocus={true}
             style={stylesInput}
@@ -62,9 +62,6 @@ const stylesInput = {
   flex: 1,
   marginTop: 25,
   marginBottom: 55,
-}
-const stylesOuterCard = {
-  marginTop: 0,
 }
 const stylesCard = {
   alignItems: 'stretch',

--- a/shared/login/signup/invite-code.render.native.js
+++ b/shared/login/signup/invite-code.render.native.js
@@ -20,7 +20,9 @@ class Render extends Component {
   }
 
   render () {
-    const submitInviteCode = () => { this.props.onInviteCodeSubmit(this.state.inviteCode) }
+    const submitInviteCode = () => {
+      this.props.onInviteCodeSubmit(this.state.inviteCode)
+    }
 
     return (
       <Container onBack={this.props.onBack} style={stylesContainer}>

--- a/shared/login/signup/invite-code.render.native.js
+++ b/shared/login/signup/invite-code.render.native.js
@@ -3,7 +3,7 @@ import Container from '../forms/container'
 import React, {Component} from 'react'
 import type {Props} from './invite-code.render'
 import {Text, Input, Button, Icon, Box} from '../../common-adapters'
-import {globalStyles} from '../../styles/style-guide'
+import {globalMargins, globalStyles} from '../../styles/style-guide'
 
 class Render extends Component {
   props: Props;
@@ -48,7 +48,7 @@ const styles = {
     alignItems: 'center',
   },
   header: {
-    marginTop: 74,
+    marginTop: globalMargins.medium,
   },
   icon: {
     marginTop: 22,

--- a/shared/login/signup/invite-code.render.native.js
+++ b/shared/login/signup/invite-code.render.native.js
@@ -20,8 +20,7 @@ class Render extends Component {
   }
 
   render () {
-    const submitInviteCode = () => { this.props.onInviteCodeSubmit(this.state.inviteCode)
-    }
+    const submitInviteCode = () => { this.props.onInviteCodeSubmit(this.state.inviteCode) }
 
     return (
       <Container onBack={this.props.onBack} style={stylesContainer}>
@@ -29,7 +28,7 @@ class Render extends Component {
         <Icon style={stylesIcon} type='icon-invite-code-48' />
         <Input autoFocus={true} style={stylesInput} hintText='goddess brown result reject' value={this.state.inviteCode} errorText={this.props.inviteCodeErrorText} onEnterKeyDown={submitInviteCode} onChangeText={inviteCode => this.setState({inviteCode})} />
         <Button style={stylesButton} waiting={this.props.waiting} type='Primary' label='Continue' onClick={submitInviteCode} disabled={!this.state.inviteCode} />
-        <Text style={stylesText} type='BodySmall'>Not invited?</Text>
+        <Text type='BodySmall'>Not invited?</Text>
         <Text type='BodySmallSecondaryLink' onClick={this.props.onRequestInvite}>Request an invite</Text>
         <Box style={{flex: 1}} />
       </Container>
@@ -42,19 +41,17 @@ const stylesContainer = {
   alignItems: 'center',
 }
 const stylesHeader = {
-  marginTop: globalMargins.medium,
+  marginTop: globalMargins.small,
 }
 const stylesIcon = {
   marginTop: globalMargins.small,
+  marginBottom: globalMargins.small,
 }
 const stylesInput = {
   alignSelf: 'stretch',
 }
-const stylesText = {
-  marginTop: globalMargins.small,
-}
 const stylesButton = {
-  marginTop: globalMargins.small,
+  marginTop: globalMargins.medium,
   marginBottom: globalMargins.small,
 }
 export default Render

--- a/shared/login/signup/invite-code.render.native.js
+++ b/shared/login/signup/invite-code.render.native.js
@@ -58,7 +58,7 @@ const styles = {
     marginTop: 0,
   },
   text: {
-    marginTop: 32,
+    marginTop: globalMargins.small,
   },
 }
 

--- a/shared/login/signup/invite-code.render.native.js
+++ b/shared/login/signup/invite-code.render.native.js
@@ -20,17 +20,16 @@ class Render extends Component {
   }
 
   render () {
-    const submitInviteCode = () => {
-      this.props.onInviteCodeSubmit(this.state.inviteCode)
+    const submitInviteCode = () => { this.props.onInviteCodeSubmit(this.state.inviteCode)
     }
 
     return (
-      <Container onBack={this.props.onBack} style={styles.container}>
-        <Text style={styles.header} type='Header'>Type in your invite code:</Text>
-        <Icon style={styles.icon} type='icon-invite-code-48' />
-        <Input autoFocus={true} style={styles.input} hintText='goddess brown result reject' value={this.state.inviteCode} errorText={this.props.inviteCodeErrorText} onEnterKeyDown={submitInviteCode} onChangeText={inviteCode => this.setState({inviteCode})} />
-        <Button style={styles.button} waiting={this.props.waiting} type='Primary' label='Continue' onClick={submitInviteCode} disabled={!this.state.inviteCode} />
-        <Text style={styles.text} type='BodySmall'>Not invited?</Text>
+      <Container onBack={this.props.onBack} style={stylesContainer}>
+        <Text style={stylesHeader} type='Header'>Type in your invite code:</Text>
+        <Icon style={stylesIcon} type='icon-invite-code-48' />
+        <Input autoFocus={true} style={stylesInput} hintText='goddess brown result reject' value={this.state.inviteCode} errorText={this.props.inviteCodeErrorText} onEnterKeyDown={submitInviteCode} onChangeText={inviteCode => this.setState({inviteCode})} />
+        <Button style={stylesButton} waiting={this.props.waiting} type='Primary' label='Continue' onClick={submitInviteCode} disabled={!this.state.inviteCode} />
+        <Text style={stylesText} type='BodySmall'>Not invited?</Text>
         <Text type='BodySmallSecondaryLink' onClick={this.props.onRequestInvite}>Request an invite</Text>
         <Box style={{flex: 1}} />
       </Container>
@@ -38,28 +37,24 @@ class Render extends Component {
   }
 }
 
-const styles = {
-  button: {
-    marginTop: 35,
-    alignSelf: 'stretch',
-  },
-  container: {
-    ...globalStyles.flexBoxColumn,
-    alignItems: 'center',
-  },
-  header: {
-    marginTop: globalMargins.medium,
-  },
-  icon: {
-    marginTop: 22,
-  },
-  input: {
-    alignSelf: 'stretch',
-    marginTop: 0,
-  },
-  text: {
-    marginTop: globalMargins.small,
-  },
+const stylesContainer = {
+  ...globalStyles.flexBoxColumn,
+  alignItems: 'center',
 }
-
+const stylesHeader = {
+  marginTop: globalMargins.medium,
+}
+const stylesIcon = {
+  marginTop: globalMargins.small,
+}
+const stylesInput = {
+  alignSelf: 'stretch',
+}
+const stylesText = {
+  marginTop: globalMargins.small,
+}
+const stylesButton = {
+  marginTop: globalMargins.small,
+  marginBottom: globalMargins.small,
+}
 export default Render

--- a/shared/login/signup/passphrase/index.render.native.js
+++ b/shared/login/signup/passphrase/index.render.native.js
@@ -29,8 +29,8 @@ const stylesOuter = {
 }
 
 const stylesSecond = {
-  marginTop: globalMargins.large,
-  marginBottom: globalMargins.large,
+  marginTop: globalMargins.medium,
+  marginBottom: globalMargins.small,
 }
 
 const stylesCard = {

--- a/shared/login/signup/passphrase/index.render.native.js
+++ b/shared/login/signup/passphrase/index.render.native.js
@@ -30,7 +30,7 @@ const stylesOuter = {
 
 const stylesSecond = {
   marginTop: globalMargins.small,
-  marginBottom: globalMargins.medium,
+  marginBottom: globalMargins.small,
 }
 
 const stylesCard = {

--- a/shared/login/signup/passphrase/index.render.native.js
+++ b/shared/login/signup/passphrase/index.render.native.js
@@ -28,9 +28,8 @@ const stylesOuter = {
   backgroundColor: globalColors.black_10,
 }
 
-
 const stylesSecond = {
-  marginTop: globalMargins.medium,
+  marginTop: globalMargins.small,
   marginBottom: globalMargins.medium,
 }
 

--- a/shared/login/signup/passphrase/index.render.native.js
+++ b/shared/login/signup/passphrase/index.render.native.js
@@ -3,7 +3,7 @@ import Container from '../../forms/container'
 import React, {Component} from 'react'
 import type {Props} from './index.render'
 import {UserCard, Input, Button} from '../../../common-adapters'
-import {globalColors} from '../../../styles/style-guide'
+import {globalColors, globalMargins} from '../../../styles/style-guide'
 
 class Render extends Component<void, Props, void> {
   render () {
@@ -12,10 +12,10 @@ class Render extends Component<void, Props, void> {
     return (
       <Container onBack={this.props.onBack} outerStyle={stylesOuter}>
         <UserCard style={stylesCard}>
-          <Input autoFocus={true} style={stylesFirst} type='password'
+          <Input autoFocus={true} type='password'
             onChangeText={pass1 => this.props.pass1Update(pass1)}
-            hintText='Create a passphrase' errorText={passphraseError} />
-          <Input type='password' style={stylesSecond} hintText='Confirm passphrase' onEnterKeyDown={this.props.onSubmit}
+            hintText='Create a passphrase' floatingLabelText='Create a passphrase' errorText={passphraseError} />
+          <Input type='password' style={stylesSecond} hintText='Confirm passphrase' floatingLabelText='Confirm passphrase' onEnterKeyDown={this.props.onSubmit}
             onChangeText={pass2 => this.props.pass2Update(pass2)} />
           <Button fullWidth={true} type='Primary' label='Continue' onClick={this.props.onSubmit} />
         </UserCard>
@@ -28,13 +28,10 @@ const stylesOuter = {
   backgroundColor: globalColors.black_10,
 }
 
-const stylesFirst = {
-  marginTop: 100,
-}
 
 const stylesSecond = {
-  marginTop: 55,
-  marginBottom: 30,
+  marginTop: globalMargins.medium,
+  marginBottom: globalMargins.medium,
 }
 
 const stylesCard = {

--- a/shared/login/signup/passphrase/index.render.native.js
+++ b/shared/login/signup/passphrase/index.render.native.js
@@ -29,8 +29,8 @@ const stylesOuter = {
 }
 
 const stylesSecond = {
-  marginTop: globalMargins.small,
-  marginBottom: globalMargins.small,
+  marginTop: globalMargins.large,
+  marginBottom: globalMargins.large,
 }
 
 const stylesCard = {

--- a/shared/login/signup/request-invite.render.native.js
+++ b/shared/login/signup/request-invite.render.native.js
@@ -3,7 +3,7 @@ import Container from '../forms/container'
 import React, {Component} from 'react'
 import type {Props} from './request-invite.render'
 import {Text, Icon, Input, Button, Box} from '../../common-adapters'
-import {globalStyles} from '../../styles/style-guide'
+import {globalMargins, globalStyles} from '../../styles/style-guide'
 
 class Render extends Component {
   props: Props;
@@ -15,12 +15,14 @@ class Render extends Component {
         <Icon style={stylesIcon} type='icon-invite-code-48' />
         <Input
           hintText='Your email address'
+          floatingLabelText='Your email address'
           value={this.props.email}
           errorText={this.props.emailErrorText}
           onChangeText={email => this.props.emailChange(email)}
           autoFocus={true} />
         <Input
           hintText='Your name'
+          floatingLabelText='Your name'
           value={this.props.name}
           errorText={this.props.nameErrorText}
           onChangeText={name => this.props.nameChange(name)} />
@@ -39,7 +41,7 @@ class Render extends Component {
 }
 
 const stylesButton = {
-  marginTop: 50,
+  marginTop: globalMargins.medium,
 }
 const stylesContainer = {
   ...globalStyles.flexBoxColumn,
@@ -47,11 +49,11 @@ const stylesContainer = {
   alignItems: 'stretch',
 }
 const stylesHeader = {
-  marginTop: 30,
+  marginTop: globalMargins.small,
   alignSelf: 'center',
 }
 const stylesIcon = {
-  marginTop: 40,
+  marginTop: globalMargins.small,
   alignSelf: 'center',
 }
 

--- a/shared/login/signup/success/index.render.native.js
+++ b/shared/login/signup/success/index.render.native.js
@@ -73,7 +73,7 @@ const paperKeyContainerStyle = {
   position: 'relative',
   alignSelf: 'center',
   marginTop: 32,
-  marginBottom: 65,
+  marginBottom: 32,
   padding: 32,
   borderRadius: 1,
   backgroundColor: globalColors.white,

--- a/shared/login/signup/username-email-form.render.native.js
+++ b/shared/login/signup/username-email-form.render.native.js
@@ -3,15 +3,15 @@ import Container from '../forms/container'
 import React, {Component} from 'react'
 import type {Props} from './username-email-form.render'
 import {UserCard, Input, Button} from '../../common-adapters'
-import {globalColors} from '../../styles/style-guide'
+import {globalColors, globalMargins} from '../../styles/style-guide'
 
 class Render extends Component<void, Props, void> {
   render () {
     return (
       <Container onBack={this.props.onBack} outerStyle={stylesOuter}>
         <UserCard>
-          <Input autoFocus={true} hintText='Create a username' value={this.props.username} errorText={this.props.usernameErrorText} onChangeText={username => this.props.usernameChange(username)} />
-          <Input style={stylesInput2} hintText='Email address' value={this.props.email} errorText={this.props.emailErrorText} onEnterKeyDown={this.props.onSubmit} onChangeText={email => this.props.emailChange(email)} keyboardType='email-address' />
+          <Input autoFocus={true} hintText='Create a username' floatingLabelText='Create a username' value={this.props.username} errorText={this.props.usernameErrorText} onChangeText={username => this.props.usernameChange(username)} />
+          <Input style={stylesInput2} hintText='Email address' floatingLabelText='Email address' value={this.props.email} errorText={this.props.emailErrorText} onEnterKeyDown={this.props.onSubmit} onChangeText={email => this.props.emailChange(email)} keyboardType='email-address' />
           <Button waiting={this.props.waiting} style={{marginTop: 40}} fullWidth={true} type='Primary' label='Continue' onClick={this.props.onSubmit} />
         </UserCard>
       </Container>
@@ -24,7 +24,7 @@ const stylesOuter = {
 }
 
 const stylesInput2 = {
-  marginTop: 70,
+  marginTop: globalMargins.medium,
 }
 
 export default Render

--- a/shared/profile/pgp/add.native.js
+++ b/shared/profile/pgp/add.native.js
@@ -2,6 +2,7 @@
 import React, {Component} from 'react'
 import {Button, Input, PlatformIcon, SmallInput, StandardScreen, Text} from '../../common-adapters'
 import {globalMargins, globalColors} from '../../styles/style-guide'
+import {KeyboardAvoidingView} from 'react-native'
 import type {Props} from './add'
 
 class PgpAdd extends Component<void, Props, void> {
@@ -13,57 +14,59 @@ class PgpAdd extends Component<void, Props, void> {
       autoCorrect: false,
     }
     return (
-      <StandardScreen
-        style={styleContainer}
-        onClose={this.props.onCancel}>
-        {/* TODO(MM) when we get the pgp icon, put it in here */}
-        <PlatformIcon
-          platform='pgp'
-          overlay='icon-proof-unfinished'
-          style={styleIcon} />
-        <Text
-          style={styleHeader}
-          type='Body'>
-          Fill in your public info.
-        </Text>
-        <Input
-          floatingLabelText='Your full name'
-          value={this.props.fullName}
-          onChangeText={this.props.onChangeFullName}
-          textStyle={{height: undefined}} />
-        <SmallInput
-          {...emailInputProps}
-          label='Email 1:'
-          hintText='(required)'
-          onChange={this.props.onChangeEmail1}
-          value={this.props.email1}
-          errorState={this.props.errorEmail1} />
-        <SmallInput
-          {...emailInputProps}
-          label='Email 2:'
-          hintText='(optional)'
-          onChange={this.props.onChangeEmail2}
-          value={this.props.email2}
-          errorState={this.props.errorEmail2} />
-        <SmallInput
-          {...emailInputProps}
-          label='Email 3:'
-          hintText='(optional)'
-          onChange={this.props.onChangeEmail3}
-          value={this.props.email3}
-          errorState={this.props.errorEmail3} />
-        <Text
-          style={styleInfoMessage(!!this.props.errorText)}
-          type='BodySmall'>
-          {this.props.errorText || 'Include any addresses you plan to use for PGP encrypted email.'}
-        </Text>
-        <Button
-          style={styleAction}
-          type='Primary'
-          label='Let the math begin'
-          disabled={nextDisabled}
-          onClick={this.props.onNext} />
-      </StandardScreen>
+      <KeyboardAvoidingView behavior='position'>
+        <StandardScreen
+          style={styleContainer}
+          onClose={this.props.onCancel}>
+          {/* TODO(MM) when we get the pgp icon, put it in here */}
+          <PlatformIcon
+            platform='pgp'
+            overlay='icon-proof-unfinished'
+            style={styleIcon} />
+          <Text
+            style={styleHeader}
+            type='Header'>
+            Fill in your public info
+          </Text>
+          <Input
+            floatingLabelText='Your full name'
+            value={this.props.fullName}
+            onChangeText={this.props.onChangeFullName}
+            textStyle={{height: undefined}} />
+          <SmallInput
+            {...emailInputProps}
+            label='Email 1:'
+            hintText='(required)'
+            onChange={this.props.onChangeEmail1}
+            value={this.props.email1}
+            errorState={this.props.errorEmail1} />
+          <SmallInput
+            {...emailInputProps}
+            label='Email 2:'
+            hintText='(optional)'
+            onChange={this.props.onChangeEmail2}
+            value={this.props.email2}
+            errorState={this.props.errorEmail2} />
+          <SmallInput
+            {...emailInputProps}
+            label='Email 3:'
+            hintText='(optional)'
+            onChange={this.props.onChangeEmail3}
+            value={this.props.email3}
+            errorState={this.props.errorEmail3} />
+          <Text
+            style={styleInfoMessage(!!this.props.errorText)}
+            type='BodySmall'>
+            {this.props.errorText || 'Include any addresses you plan to use for PGP encrypted email.'}
+          </Text>
+          <Button
+            style={styleAction}
+            type='Primary'
+            label='Let the math begin'
+            disabled={nextDisabled}
+            onClick={this.props.onNext} />
+        </StandardScreen>
+      </KeyboardAvoidingView>
     )
   }
 }


### PR DESCRIPTION
@keybase/react-hackers 

This PR does two things: reduces margins for most pages (around signup/login where there are text inputs) so that you can see what you're typing while you type, and adds a use of React Native's new KeyboardAvoidingView for one page (the "PGP Add" page with full name and emails).  KeyboardAvoidingView works great!

Here's a before-and-after (before on the left) MOV showing the change on iOS during a signup, and then the PGP Add screen in the dumb view at the end:

http://chris.printf.net/before-and-after.mov
