### PR TITLE
Only show 'ignored folders' if not on the widget

### DIFF
--- a/shared/folders/list.desktop.js
+++ b/shared/folders/list.desktop.js
@@ -81,12 +81,14 @@ class Render extends Component<void, Props, void> {
           {...this.props}
           isIgnored={false}
           tlfs={this.props.tlfs || []} />
-        <Ignored
-          isPublic={this.props.isPublic}
-          showIgnored={this.props.showIgnored}
-          styles={styles}
-          onToggle={this.props.onToggleShowIgnored}
-          rows={ignoredRows} />
+        {!this.props.smallMode &&
+          <Ignored
+            isPublic={this.props.isPublic}
+            showIgnored={this.props.showIgnored}
+            styles={styles}
+            onToggle={this.props.onToggleShowIgnored}
+            rows={ignoredRows} />
+        }
       </Box>
     )
   }


### PR DESCRIPTION
@keybase/react-hackers 

Fixes the bug where "Ignored folders" appears on the widget but isn't clickable.