### PR TITLE
Speed up identify

### DIFF
--- a/shared/nav.desktop.js
+++ b/shared/nav.desktop.js
@@ -191,7 +191,7 @@ export default connect(
   ({
     router,
     config: {extendedConfig, username},
-    favorite: {publicBadge, privateBadge},
+    favorite: {publicBadge = 0, privateBadge = 0},
     notifications: {menuBadge}}) => ({
       router,
       provisioned: extendedConfig && !!extendedConfig.defaultDeviceID,

--- a/shared/profile/index.js
+++ b/shared/profile/index.js
@@ -5,24 +5,22 @@ import ErrorComponent from '../common-adapters/error-profile'
 import PostProof from './post-proof-container'
 import ProveEnterUsername from './prove-enter-username-container'
 import ProveWebsiteChoice from './prove-website-choice-container'
-import React, {Component} from 'react'
+import React, {PureComponent} from 'react'
 import Render from './render'
 import Revoke from './revoke-container'
 import flags from '../util/feature-flags'
+import pgpRouter from './pgp'
 import {Box, Text} from '../common-adapters'
-import {TypedConnector} from '../util/typed-connect'
 import {addProof, checkSpecificProof} from '../actions/profile'
+import {connect} from 'react-redux'
 import {getProfile, updateTrackers, onFollow, onUnfollow, openProofUrl} from '../actions/tracker'
 import {isLoading} from '../constants/tracker'
 import {openInKBFS} from '../actions/kbfs'
 import {routeAppend, navigateUp} from '../actions/router'
-import pgpRouter from './pgp'
 
 import type {MissingProof} from '../common-adapters/user-proofs'
 import type {Proof} from '../constants/tracker'
 import type {Props} from './render'
-import type {TypedDispatch, Action} from '../constants/types/flux'
-import type {TypedState} from '../constants/reducer'
 
 type OwnProps = {
   userOverride?: {
@@ -31,7 +29,7 @@ type OwnProps = {
   }
 }
 
-class Profile extends Component<void, ?Props, void> {
+class Profile extends PureComponent<void, ?Props, void> {
   static parseRoute (currentPath, uri) {
     return {
       componentAtTop: {
@@ -84,68 +82,71 @@ class Profile extends Component<void, ?Props, void> {
   }
 }
 
-const connector: TypedConnector<TypedState, TypedDispatch<Action>, OwnProps, ?Props> = new TypedConnector()
+export default connect(
+  (state, ownProps: OwnProps) => {
+    const myUsername = state.config.username
+    const myUid = state.config.uid
+    const username = ownProps.userOverride && ownProps.userOverride.username || myUsername
+    const uid = ownProps.userOverride && ownProps.userOverride.uid || myUid
 
-export default connector.connect((state, dispatch, ownProps) => {
-  const stateProps = {
-    myUsername: state.config.username,
-    myUid: state.config.uid,
-    trackers: state.tracker.trackers,
-  }
-
-  const {username, uid} = ownProps.userOverride ? ownProps.userOverride : {
-    username: stateProps.myUsername || '',
-    uid: stateProps.myUid || '',
-  }
-
-  const refresh = () => {
-    dispatch(getProfile(username))
-    dispatch(updateTrackers(username, uid))
-  }
-
-  const dispatchProps = {
+    return {
+      username,
+      uid,
+      myUid,
+      myUsername,
+      trackerState: state.tracker.trackers[username],
+    }
+  },
+  (dispatch, ownProps: OwnProps) => ({
     onUserClick: (username, uid) => { dispatch(routeAppend({path: 'profile', userOverride: {username, uid}})) },
     onBack: () => { dispatch(navigateUp()) },
     onFolderClick: folder => { dispatch(openInKBFS(folder.path)) },
     onEditProfile: () => { dispatch(routeAppend({path: 'editprofile'})) },
-    onFollow: () => { dispatch(onFollow(username, false)) },
-    onUnfollow: () => { dispatch(onUnfollow(username)) },
-    onAcceptProofs: () => { dispatch(onFollow(username, false)) },
     onMissingProofClick: (missingProof: MissingProof) => { dispatch(addProof(missingProof.type)) },
     onRecheckProof: (proof: Proof) => { dispatch(checkSpecificProof(proof && proof.id)) },
     onRevokeProof: (proof: Proof) => {
       dispatch(routeAppend({path: 'Revoke', platform: proof.type, platformHandle: proof.name, proofId: proof.id}))
     },
     onViewProof: (proof: Proof) => { dispatch(openProofUrl(proof)) },
+    getProfile: username => dispatch(getProfile(username)),
+    updateTrackers: (username, uid) => dispatch(updateTrackers(username, uid)),
+    onFollow: username => { dispatch(onFollow(username, false)) },
+    onUnfollow: username => { dispatch(onUnfollow(username)) },
+    onAcceptProofs: username => { dispatch(onFollow(username, false)) },
+  }),
+  (stateProps, dispatchProps, ownProps) => {
+    const refresh = () => {
+      dispatchProps.getProfile(stateProps.username)
+      dispatchProps.updateTrackers(stateProps.username, stateProps.uid)
+    }
+    const isYou = stateProps.username === stateProps.myUsername
+    const bioEditFns = isYou ? {
+      onBioEdit: dispatchProps.onEditProfile,
+      onEditAvatarClick: dispatchProps.onEditProfile,
+      onEditProfile: dispatchProps.onEditProfile,
+      onLocationEdit: dispatchProps.onEditProfile,
+      onNameEdit: dispatchProps.onEditProfile,
+    } : null
+
+    if (stateProps.trackerState && stateProps.trackerState.type !== 'tracker') {
+      console.warn('Expected a tracker type, trying to show profile for non user')
+      return null
+    }
+
+    return {
+      ...ownProps,
+      ...stateProps.trackerState,
+      ...dispatchProps,
+      isYou,
+      bioEditFns,
+      username: stateProps.username,
+      refresh,
+      followers: stateProps.trackerState ? stateProps.trackerState.trackers : [],
+      following: stateProps.trackerState ? stateProps.trackerState.tracking : [],
+      loading: isLoading(stateProps.trackerState),
+      onFollow: username => dispatchProps.onFollow(stateProps.username),
+      onUnfollow: username => dispatchProps.onUnfollow(stateProps.username),
+      onAcceptProofs: username => dispatchProps.onFollow(stateProps.username),
+    }
   }
-
-  const isYou = username === stateProps.myUsername
-  const onEditProfile = () => { dispatchProps.onEditProfile() }
-  const bioEditFns = isYou ? {
-    onBioEdit: onEditProfile,
-    onEditAvatarClick: onEditProfile,
-    onEditProfile: onEditProfile,
-    onLocationEdit: onEditProfile,
-    onNameEdit: onEditProfile,
-  } : null
-
-  const trackerState = stateProps.trackers[username]
-
-  if (trackerState && trackerState.type !== 'tracker') {
-    console.warn('Expected a tracker type, trying to show profile for non user')
-    return null
-  }
-
-  return {
-    ...ownProps,
-    ...trackerState,
-    ...dispatchProps,
-    isYou,
-    bioEditFns,
-    username,
-    refresh,
-    followers: trackerState ? trackerState.trackers : [],
-    following: trackerState ? trackerState.tracking : [],
-    loading: isLoading(trackerState),
-  }
-})(Profile)
+)(Profile)

--- a/shared/profile/render.desktop.js
+++ b/shared/profile/render.desktop.js
@@ -1,5 +1,5 @@
 /* @flow */
-import React, {Component} from 'react'
+import React, {PureComponent} from 'react'
 import {findDOMNode} from 'react-dom'
 import _ from 'lodash'
 import moment from 'moment'
@@ -28,7 +28,7 @@ type State = {
   }
 }
 
-class Render extends Component<void, Props, State> {
+class ProfileRender extends PureComponent<void, Props, State> {
   state: State;
   _proofList: ?UserProofs;
   _scrollContainer: ?React$Component<*, *, *>;
@@ -370,4 +370,4 @@ const styleProofMenu = {
   zIndex: 5,
 }
 
-export default Render
+export default ProfileRender

--- a/shared/tracker/action.render.desktop.js
+++ b/shared/tracker/action.render.desktop.js
@@ -1,15 +1,13 @@
 /* @flow */
 
-import React, {Component} from 'react'
+import React, {PureComponent} from 'react'
 import {Button, Text, Icon} from '../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../styles/style-guide'
 import {normal} from '../constants/tracker'
 
 import type {ActionProps} from './action.render'
 
-export default class ActionRender extends Component {
-  props: ActionProps;
-
+export default class ActionRender extends PureComponent<void, ActionProps, void> {
   render () {
     const {loggedIn} = this.props
 

--- a/shared/tracker/header.render.desktop.js
+++ b/shared/tracker/header.render.desktop.js
@@ -1,15 +1,17 @@
 /* @flow */
-
-import React, {Component} from 'react'
+import React, {PureComponent} from 'react'
 import {Icon, Text} from '../common-adapters/index'
 import {globalStyles, globalColors} from '../styles/style-guide'
 import {stateColors} from '../util/tracker'
 
 import type {HeaderProps} from './header.render'
 
-export default class HeaderRender extends Component {
-  props: HeaderProps;
-  state: {showCloseWarning: boolean};
+type State = {
+  showCloseWarning: boolean,
+}
+
+export default class HeaderRender extends PureComponent<void, HeaderProps, State> {
+  state: State;
 
   constructor (props: HeaderProps) {
     super(props)

--- a/shared/tracker/index.js
+++ b/shared/tracker/index.js
@@ -45,9 +45,7 @@ export function trackerPropsToRenderProps (tprops: TrackerProps): RenderPropsUns
   return {...tprops}
 }
 
-class Tracker extends Component {
-  props: TrackerProps;
-
+class Tracker extends Component<void, TrackerProps, void> {
   componentWillMount () {
     this.props.startTimer()
   }

--- a/shared/tracker/render.desktop.js
+++ b/shared/tracker/render.desktop.js
@@ -1,7 +1,5 @@
 /* @flow */
-
-import React, {Component} from 'react'
-
+import React, {PureComponent} from 'react'
 import Header from './header.render.desktop'
 import Action, {calcFooterHeight} from './action.render.desktop'
 import {UserProofs, UserBio} from '../common-adapters'
@@ -11,9 +9,7 @@ import {autoResize} from '../../desktop/renderer/remote-component-helper'
 
 import type {RenderProps} from './render'
 
-export default class Render extends Component<void, RenderProps, void> {
-  props: RenderProps;
-
+export default class Render extends PureComponent<void, RenderProps, void> {
   componentDidMount () {
     autoResize()
   }

--- a/shared/util/idle-callback.js
+++ b/shared/util/idle-callback.js
@@ -1,4 +1,5 @@
 // @flow
+
 const requestIdleCallback = typeof window !== 'undefined' && window.requestIdleCallback ||
   function (cb: any) {
     var start = Date.now()

--- a/shared/util/idle-callback.js
+++ b/shared/util/idle-callback.js
@@ -1,5 +1,4 @@
 // @flow
-
 const requestIdleCallback = typeof window !== 'undefined' && window.requestIdleCallback ||
   function (cb: any) {
     var start = Date.now()


### PR DESCRIPTION
first pass at speeding up identify. 

- [x] wrap callback handling in idle handler. 
- [x] pure component used
- [x] removed profile from typed connect due to deoptimization problems

This makes things much faster for me. for example me doing ls on a new folder with 10 participants w/ 1 file 
- Old: 33.4 seconds + timeout
- New: 1.41 seconds + works

@keybase/react-hackers 