### PR TITLE
Add account delete

### DIFF
--- a/go/client/cmd_account_delete.go
+++ b/go/client/cmd_account_delete.go
@@ -1,0 +1,52 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"errors"
+
+	"golang.org/x/net/context"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+)
+
+type CmdAccountDelete struct {
+	libkb.Contextified
+}
+
+func NewCmdAccountDelete(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "acctdelete",
+		Usage: "Delete account",
+		Action: func(c *cli.Context) {
+			cmd := &CmdAccountDelete{Contextified: libkb.NewContextified(g)}
+			cl.ChooseCommand(cmd, "acctdelete", c)
+		},
+	}
+}
+
+func (c *CmdAccountDelete) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 0 {
+		return errors.New("acctdelete takes no arguments")
+	}
+	return nil
+}
+
+func (c *CmdAccountDelete) Run() error {
+	cli, err := GetLoginClient(c.G())
+	if err != nil {
+		return err
+	}
+	return cli.AccountDelete(context.Background(), 0)
+}
+
+func (c *CmdAccountDelete) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		API:       true,
+		KbKeyring: true,
+		Config:    true,
+	}
+}

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -15,6 +15,7 @@ import (
 
 func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
 	return []cli.Command{
+		NewCmdAccountDelete(cl, g),
 		NewCmdAPICall(cl, g),
 		NewCmdChat(cl, g),
 		NewCmdCheckTracking(cl, g),

--- a/go/engine/account_delete.go
+++ b/go/engine/account_delete.go
@@ -1,0 +1,96 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build !production
+//
+// This engine deletes the user's account.  Currently not
+// enabled in production.
+
+package engine
+
+import (
+	"github.com/keybase/client/go/libkb"
+)
+
+// AccountDelete is an engine.
+type AccountDelete struct {
+	libkb.Contextified
+}
+
+// NewAccountDelete creates a AccountDelete engine.
+func NewAccountDelete(g *libkb.GlobalContext) *AccountDelete {
+	return &AccountDelete{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+// Name is the unique engine name.
+func (e *AccountDelete) Name() string {
+	return "AccountDelete"
+}
+
+// GetPrereqs returns the engine prereqs.
+func (e *AccountDelete) Prereqs() Prereqs {
+	return Prereqs{
+		Device: true,
+	}
+}
+
+// RequiredUIs returns the required UIs.
+func (e *AccountDelete) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *AccountDelete) SubConsumers() []libkb.UIConsumer {
+	return nil
+}
+
+// Run starts the engine.
+func (e *AccountDelete) Run(ctx *Context) error {
+	var postErr error
+	aerr := e.G().LoginState().Account(func(a *libkb.Account) {
+		if err := a.LoginSession().Load(); err != nil {
+			postErr = err
+			return
+		}
+		session, err := a.LoginSession().SessionEncoded()
+		if err != nil {
+			e.G().Log.Warning("SessionEncoded error: %s", err)
+			postErr = err
+			return
+		}
+
+		hmacPwh, err := e.G().LoginState().ComputeLoginPw(a)
+		if err != nil {
+			postErr = err
+			return
+		}
+
+		arg := libkb.APIArg{
+			Endpoint:    "delete",
+			NeedSession: true,
+			SessionR:    a.LocalSession(),
+			Args: libkb.HTTPArgs{
+				"hmac_pwh":      libkb.HexArg(hmacPwh),
+				"login_session": libkb.S{Val: session},
+			},
+		}
+		_, postErr = e.G().API.Post(arg)
+		if postErr != nil {
+			e.G().Log.Warning("API.Post error: %s", postErr)
+
+		}
+	}, "AccountDelete - Run")
+	if aerr != nil {
+		return aerr
+	}
+	if postErr != nil {
+		return postErr
+	}
+
+	e.G().Log.Debug("account deleted, logging out")
+	e.G().Logout()
+
+	return nil
+}

--- a/go/engine/account_delete_test.go
+++ b/go/engine/account_delete_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 func TestAccountDelete(t *testing.T) {
@@ -31,5 +32,38 @@ func TestAccountDelete(t *testing.T) {
 	}
 	if _, ok := err.(libkb.NotFoundError); !ok {
 		t.Errorf("loading deleted user error type: %T, expected libkb.NotFoundError", err)
+	}
+}
+
+func TestAccountDeleteIdentify(t *testing.T) {
+	tc := SetupEngineTest(t, "acct")
+	defer tc.Cleanup()
+
+	fu := CreateAndSignupFakeUser(tc, "acct")
+	u, err := libkb.LoadUser(libkb.NewLoadUserByNameArg(tc.G, fu.Username))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := &Context{}
+	eng := NewAccountDelete(tc.G)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	i := newIdentify2WithUIDTester(tc.G)
+	tc.G.Services = i
+	arg := &keybase1.Identify2Arg{
+		Uid: u.GetUID(),
+	}
+	ieng := NewIdentify2WithUID(tc.G, arg)
+	ictx := &Context{IdentifyUI: i}
+
+	err = RunEngine(ieng, ictx)
+	if err == nil {
+		t.Fatal("identify2 ran successfully on deleted user")
+	}
+	if _, ok := err.(libkb.DeletedError); !ok {
+		t.Errorf("identify2 error: %T, expected libkb.DeletedError", err)
 	}
 }

--- a/go/engine/account_delete_test.go
+++ b/go/engine/account_delete_test.go
@@ -1,0 +1,35 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build !production
+//
+// This is a test template for the AccountDelete engine.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+)
+
+func TestAccountDelete(t *testing.T) {
+	tc := SetupEngineTest(t, "acct")
+	defer tc.Cleanup()
+
+	fu := CreateAndSignupFakeUser(tc, "acct")
+
+	ctx := &Context{}
+	eng := NewAccountDelete(tc.G)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := libkb.LoadUser(libkb.NewLoadUserByNameArg(tc.G, fu.Username))
+	if err == nil {
+		t.Fatal("no error loading deleted user")
+	}
+	if _, ok := err.(libkb.NotFoundError); !ok {
+		t.Errorf("loading deleted user error type: %T, expected libkb.NotFoundError", err)
+	}
+}

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -477,9 +477,14 @@ func (e *Identify2WithUID) loadThem(ctx *Context) (err error) {
 	arg.ResolveBody = e.ResolveBody
 	e.them, err = libkb.LoadUser(arg)
 	if err != nil {
-		if _, ok := err.(libkb.NoKeyError); ok {
+		switch err.(type) {
+		case libkb.NoKeyError:
 			// convert this error to NoSigChainError
 			return libkb.NoSigChainError{}
+		case libkb.DeletedError:
+			return err
+		case libkb.NotFoundError:
+			return libkb.UserNotFoundError{UID: arg.UID, Msg: "in Identify2WithUID"}
 		}
 	}
 	if e.them == nil {

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -140,6 +140,7 @@ const (
 	SCBadLoginUserNotFound   = int(keybase1.StatusCode_SCBadLoginUserNotFound)
 	SCBadLoginPassword       = int(keybase1.StatusCode_SCBadLoginPassword)
 	SCNotFound               = int(keybase1.StatusCode_SCNotFound)
+	SCDeleted                = int(keybase1.StatusCode_SCDeleted)
 	SCThrottleControl        = int(keybase1.StatusCode_SCThrottleControl)
 	SCGeneric                = int(keybase1.StatusCode_SCGeneric)
 	SCAlreadyLoggedIn        = int(keybase1.StatusCode_SCAlreadyLoggedIn)

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1453,3 +1453,14 @@ type UnhandledSignatureError struct {
 func (e UnhandledSignatureError) Error() string {
 	return fmt.Sprintf("unhandled signature version: %d", e.version)
 }
+
+type DeletedError struct {
+	Msg string
+}
+
+func (e DeletedError) Error() string {
+	if len(e.Msg) == 0 {
+		return "Deleted"
+	}
+	return e.Msg
+}

--- a/go/libkb/login_session.go
+++ b/go/libkb/login_session.go
@@ -147,7 +147,7 @@ func (s *LoginSession) Dump() {
 }
 
 func (s *LoginSession) Load() error {
-	if s.loaded {
+	if s.loaded && !s.cleared {
 		return fmt.Errorf("LoginSession already loaded for %s", s.sessionFor)
 	}
 

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -378,7 +378,7 @@ func (s *LoginState) VerifyPlaintextPassphrase(pp string) (ppStream *PassphraseS
 	return
 }
 
-func (s *LoginState) computeLoginPw(lctx LoginContext) (macSum []byte, err error) {
+func (s *LoginState) ComputeLoginPw(lctx LoginContext) (macSum []byte, err error) {
 	loginSession, e := lctx.LoginSession().Session()
 	if e != nil {
 		err = e
@@ -703,7 +703,7 @@ func (s *LoginState) passphraseLogin(lctx LoginContext, username, passphrase str
 		return err
 	}
 
-	lgpw, err := s.computeLoginPw(lctx)
+	lgpw, err := s.ComputeLoginPw(lctx)
 	if err != nil {
 		return err
 	}

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -281,12 +281,21 @@ func (mc *MerkleClient) LookupPath(q HTTPArgs) (vp *VerificationPath, err error)
 	q.Add("poll", I{10})
 
 	res, err := mc.G().API.Get(APIArg{
-		Endpoint:    "merkle/path",
-		NeedSession: false,
-		Args:        q,
+		Endpoint:       "merkle/path",
+		NeedSession:    false,
+		Args:           q,
+		AppStatusCodes: []int{SCOk, SCNotFound, SCDeleted},
 	})
 
 	if err != nil {
+		return
+	}
+	switch res.AppStatus.Code {
+	case SCNotFound:
+		err = NotFoundError{}
+		return
+	case SCDeleted:
+		err = DeletedError{}
 		return
 	}
 

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -156,16 +156,21 @@ func (r *Resolver) resolveURLViaServerLookup(au AssertionURL, input string, with
 		Endpoint:       "user/lookup",
 		NeedSession:    false,
 		Args:           ha,
-		AppStatusCodes: []int{SCOk, SCNotFound},
+		AppStatusCodes: []int{SCOk, SCNotFound, SCDeleted},
 	})
 
 	if res.err != nil {
 		r.G().Log.Debug("API user/lookup %q error: %s", input, res.err)
 		return
 	}
-	if ares.AppStatus.Code == SCNotFound {
+	switch ares.AppStatus.Code {
+	case SCNotFound:
 		r.G().Log.Debug("API user/lookup %q not found", input)
 		res.err = NotFoundError{}
+		return
+	case SCDeleted:
+		r.G().Log.Debug("API user/lookup %q deleted", input)
+		res.err = DeletedError{Msg: fmt.Sprintf("user %q deleted", input)}
 		return
 	}
 

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -339,6 +339,8 @@ func ImportStatusAsError(s *keybase1.Status) error {
 		return GPGUnavailableError{}
 	case SCNotFound:
 		return NotFoundError{Msg: s.Desc}
+	case SCDeleted:
+		return DeletedError{Msg: s.Desc}
 	case SCDecryptionError:
 		return DecryptionError{}
 	case SCKeyRevoked:
@@ -1168,6 +1170,14 @@ func (e NotFoundError) ToStatus() keybase1.Status {
 	return keybase1.Status{
 		Code: SCNotFound,
 		Name: "SC_NOT_FOUND",
+		Desc: e.Error(),
+	}
+}
+
+func (e DeletedError) ToStatus() keybase1.Status {
+	return keybase1.Status{
+		Code: SCDeleted,
+		Name: "SC_DELETED",
 		Desc: e.Error(),
 	}
 }

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -17,6 +17,7 @@ const (
 	StatusCode_SCBadLoginPassword       StatusCode = 204
 	StatusCode_SCNotFound               StatusCode = 205
 	StatusCode_SCThrottleControl        StatusCode = 210
+	StatusCode_SCDeleted                StatusCode = 216
 	StatusCode_SCGeneric                StatusCode = 218
 	StatusCode_SCAlreadyLoggedIn        StatusCode = 235
 	StatusCode_SCCanceled               StatusCode = 237
@@ -84,6 +85,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCBadLoginPassword":       204,
 	"SCNotFound":               205,
 	"SCThrottleControl":        210,
+	"SCDeleted":                216,
 	"SCGeneric":                218,
 	"SCAlreadyLoggedIn":        235,
 	"SCCanceled":               237,

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -134,3 +134,16 @@ func (h *LoginHandler) PGPProvision(ctx context.Context, arg keybase1.PGPProvisi
 	eng := engine.NewPGPProvision(h.G(), arg.Username, arg.DeviceName, arg.Passphrase)
 	return engine.RunEngine(eng, ectx)
 }
+
+func (h *LoginHandler) AccountDelete(ctx context.Context, sessionID int) error {
+	if h.G().Env.GetRunMode() == libkb.ProductionRunMode {
+		return errors.New("AccountDelete is a devel-only RPC")
+	}
+	ectx := &engine.Context{
+		LogUI:      h.getLogUI(sessionID),
+		NetContext: ctx,
+		SessionID:  sessionID,
+	}
+	eng := engine.NewAccountDelete(h.G())
+	return engine.RunEngine(eng, ectx)
+}

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -9,6 +9,7 @@ protocol constants {
     SCBadLoginPassword_204,
     SCNotFound_205,
     SCThrottleControl_210,
+    SCDeleted_216,
     SCGeneric_218,
     SCAlreadyLoggedIn_235,
     SCCanceled_237,

--- a/protocol/avdl/keybase1/login.avdl
+++ b/protocol/avdl/keybase1/login.avdl
@@ -62,4 +62,9 @@ protocol login {
     with no user interaction.
     */
   void pgpProvision(int sessionID, string username, string passphrase, string deviceName);
+
+  /**
+    accountDelete is for devel/testing to delete the current user's account.
+    */
+  void accountDelete(int sessionID);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1411,6 +1411,7 @@ export type StatusCode =
   | 204 // SCBadLoginPassword_204
   | 205 // SCNotFound_205
   | 210 // SCThrottleControl_210
+  | 216 // SCDeleted_216
   | 218 // SCGeneric_218
   | 235 // SCAlreadyLoggedIn_235
   | 237 // SCCanceled_237

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -107,6 +107,12 @@ export function identifyUiFinishRpc (request: $Exact<{
   callback?: (null | (err: ?any) => void)}>) {
   engine.rpc({...request, method: 'identifyUi.finish'})
 }
+export function loginAccountDeleteRpc (request: $Exact<{
+  waitingHandler?: (waiting: boolean, method: string, sessionID: string) => void,
+  incomingCallMap?: incomingCallMapType,
+  callback?: (null | (err: ?any) => void)}>) {
+  engine.rpc({...request, method: 'login.accountDelete'})
+}
 export function loginLogoutRpc (request: $Exact<{
   waitingHandler?: (waiting: boolean, method: string, sessionID: string) => void,
   incomingCallMap?: incomingCallMapType,
@@ -4219,6 +4225,7 @@ export type rpc =
   | kbfsFSEventRpc
   | logRegisterLoggerRpc
   | logUiLogRpc
+  | loginAccountDeleteRpc
   | loginClearStoredSecretRpc
   | loginDeprovisionRpc
   | loginGetConfiguredAccountsRpc
@@ -5366,6 +5373,15 @@ export type incomingCallMapType = $Exact<{
       username: string,
       passphrase: string,
       deviceName: string
+    }>,
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
+    }
+  ) => void,
+  'keybase.1.login.accountDelete'?: (
+    params: $Exact<{
+      sessionID: int
     }>,
     response: {
       error: (err: RPCError) => void,

--- a/protocol/js/keybase-v1.js
+++ b/protocol/js/keybase-v1.js
@@ -56,6 +56,7 @@ export const constants = {
     'scbadloginpassword': 204,
     'scnotfound': 205,
     'scthrottlecontrol': 210,
+    'scdeleted': 216,
     'scgeneric': 218,
     'scalreadyloggedin': 235,
     'sccanceled': 237,

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -13,6 +13,7 @@
         "SCBadLoginPassword_204",
         "SCNotFound_205",
         "SCThrottleControl_210",
+        "SCDeleted_216",
         "SCGeneric_218",
         "SCAlreadyLoggedIn_235",
         "SCCanceled_237",

--- a/protocol/json/keybase1/login.json
+++ b/protocol/json/keybase1/login.json
@@ -175,6 +175,16 @@
       ],
       "response": null,
       "doc": "pgpProvision is for devel/testing to provision a device via pgp using CLI\n    with no user interaction."
+    },
+    "accountDelete": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        }
+      ],
+      "response": null,
+      "doc": "accountDelete is for devel/testing to delete the current user's account."
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1411,6 +1411,7 @@ export type StatusCode =
   | 204 // SCBadLoginPassword_204
   | 205 // SCNotFound_205
   | 210 // SCThrottleControl_210
+  | 216 // SCDeleted_216
   | 218 // SCGeneric_218
   | 235 // SCAlreadyLoggedIn_235
   | 237 // SCCanceled_237

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -107,6 +107,12 @@ export function identifyUiFinishRpc (request: $Exact<{
   callback?: (null | (err: ?any) => void)}>) {
   engine.rpc({...request, method: 'identifyUi.finish'})
 }
+export function loginAccountDeleteRpc (request: $Exact<{
+  waitingHandler?: (waiting: boolean, method: string, sessionID: string) => void,
+  incomingCallMap?: incomingCallMapType,
+  callback?: (null | (err: ?any) => void)}>) {
+  engine.rpc({...request, method: 'login.accountDelete'})
+}
 export function loginLogoutRpc (request: $Exact<{
   waitingHandler?: (waiting: boolean, method: string, sessionID: string) => void,
   incomingCallMap?: incomingCallMapType,
@@ -4219,6 +4225,7 @@ export type rpc =
   | kbfsFSEventRpc
   | logRegisterLoggerRpc
   | logUiLogRpc
+  | loginAccountDeleteRpc
   | loginClearStoredSecretRpc
   | loginDeprovisionRpc
   | loginGetConfiguredAccountsRpc
@@ -5366,6 +5373,15 @@ export type incomingCallMapType = $Exact<{
       username: string,
       passphrase: string,
       deviceName: string
+    }>,
+    response: {
+      error: (err: RPCError) => void,
+      result: () => void
+    }
+  ) => void,
+  'keybase.1.login.accountDelete'?: (
+    params: $Exact<{
+      sessionID: int
     }>,
     response: {
       error: (err: RPCError) => void,

--- a/shared/constants/types/keybase-v1.js
+++ b/shared/constants/types/keybase-v1.js
@@ -56,6 +56,7 @@ export const constants = {
     'scbadloginpassword': 204,
     'scnotfound': 205,
     'scthrottlecontrol': 210,
+    'scdeleted': 216,
     'scgeneric': 218,
     'scalreadyloggedin': 235,
     'sccanceled': 237,


### PR DESCRIPTION
Added AccountDelete engine, `keybase acctdelete` (non-production only).

SCDeleted constant => libkb.DeletedError and appropriate rpc_exim translations

SCDeleted status code allowed in relevant API args.

r? @maxtaco 

cc: @jzila 