### PR TITLE
Fuse upgrade needs to check plist (if not loaded)

### DIFF
--- a/go/install/fuse_status_osx.go
+++ b/go/install/fuse_status_osx.go
@@ -128,7 +128,7 @@ func KeybaseFuseStatusForAppBundle(appPath string, log Log) (keybase1.FuseStatus
 
 func findStringInPlist(key string, plistData []byte, log Log) string {
 	// Hack to parse plist, instead of parsing we'll use a regex
-	res := fmt.Sprintf(`<key>%s<\/key>\s*<string>(\S+)<\/string>`, key)
+	res := fmt.Sprintf(`<key>%s<\/key>\s*<string>([\S ]+)<\/string>`, key)
 	re := regexp.MustCompile(res)
 	submatch := re.FindStringSubmatch(string(plistData))
 	if len(submatch) == 2 {

--- a/go/install/fuse_status_osx.go
+++ b/go/install/fuse_status_osx.go
@@ -19,6 +19,8 @@ import (
 	"github.com/keybase/go-kext"
 )
 
+const installPath = "/Library/Filesystems/kbfuse.fs"
+
 // KeybaseFuseStatus returns Fuse status
 func KeybaseFuseStatus(bundleVersion string, log Log) keybase1.FuseStatus {
 	st := keybase1.FuseStatus{
@@ -29,31 +31,39 @@ func KeybaseFuseStatus(bundleVersion string, log Log) keybase1.FuseStatus {
 
 	var kextInfo *kext.Info
 
-	// Check kbfuse 3.x
-	path := "/Library/Filesystems/kbfuse.fs"
-	if _, err := os.Stat(path); err == nil {
-		st.Path = path
+	if _, err := os.Stat(installPath); err == nil {
+		st.Path = installPath
 		kextID := "com.github.kbfuse.filesystems.kbfuse"
-		info, err := kext.LoadInfo(kextID)
-		if err != nil {
+		var loadErr error
+		kextInfo, loadErr = kext.LoadInfo(kextID)
+		if loadErr != nil {
 			st.InstallStatus = keybase1.InstallStatus_ERROR
 			st.InstallAction = keybase1.InstallAction_REINSTALL
-			st.Status = keybase1.Status{Code: libkb.SCGeneric, Name: "INSTALL_ERROR", Desc: err.Error()}
+			st.Status = keybase1.Status{Code: libkb.SCGeneric, Name: "INSTALL_ERROR", Desc: fmt.Sprintf("Error loading kext info: %s", loadErr)}
 			return st
 		}
-		if info == nil {
-			// This means the kext isn't loaded. If kext isn't loaded then kbfs will
-			// load it when it start up by calling load_kbfuse (in the kext bundle).
-			// TODO: Go ahead and load the kext ahead of time?
-			st.InstallStatus = keybase1.InstallStatus_INSTALLED
-			st.InstallAction = keybase1.InstallAction_NONE
-			st.Status = keybase1.StatusOK(fmt.Sprintf("Fuse installed (%s) but kext was not loaded (%s)", st.Path, kextID))
-			return st
+		if kextInfo == nil {
+			log.Debug("No kext info available (kext not loaded)")
+			// This means the kext isn't loaded, which is ok, kbfs will call
+			// load_kbfuse when it starts up.
+			// We have to get the version from the installed plist.
+			installedVersion, fivErr := fuseInstallVersion(log)
+			if fivErr != nil {
+				st.InstallStatus = keybase1.InstallStatus_ERROR
+				st.InstallAction = keybase1.InstallAction_REINSTALL
+				st.Status = keybase1.Status{Code: libkb.SCGeneric, Name: "INSTALL_ERROR", Desc: fmt.Sprintf("Error loading (plist) info: %s", fivErr)}
+				return st
+			}
+			if installedVersion != "" {
+				kextInfo = &kext.Info{
+					Version: installedVersion,
+					Started: false,
+				}
+			}
 		}
 
 		// Installed
 		st.KextID = kextID
-		kextInfo = info
 	}
 
 	// If neither is found, we have no install
@@ -108,7 +118,7 @@ func mountInfo(fstype string) ([]keybase1.FuseMountInfo, error) {
 
 // KeybaseFuseStatusForAppBundle returns Fuse status for application at appPath
 func KeybaseFuseStatusForAppBundle(appPath string, log Log) (keybase1.FuseStatus, error) {
-	bundleVersion, err := fuseBundleVersion(appPath)
+	bundleVersion, err := fuseBundleVersion(appPath, log)
 	if err != nil {
 		return keybase1.FuseStatus{}, err
 	}
@@ -116,29 +126,48 @@ func KeybaseFuseStatusForAppBundle(appPath string, log Log) (keybase1.FuseStatus
 	return fuseStatus, err
 }
 
-func fuseBundleVersion(appPath string) (string, error) {
-	plistPath := filepath.Join(appPath, "Contents/Resources/KeybaseInstaller.app/Contents/Info.plist")
-
-	if _, err := os.Stat(plistPath); os.IsNotExist(err) {
-		return "", nil
-	}
-
-	f, err := os.Open(plistPath)
-	if err != nil {
-		return "", err
-	}
-	data, err := ioutil.ReadAll(f)
-	if err != nil {
-		return "", err
-	}
-
-	// Hack to parse plist
-	re := regexp.MustCompile(`<key>KBFuseVersion<\/key>\s*<string>(\S+)<\/string>`)
-	submatch := re.FindStringSubmatch(string(data))
+func findStringInPlist(key string, plistData []byte, log Log) string {
+	// Hack to parse plist, instead of parsing we'll use a regex
+	res := fmt.Sprintf(`<key>%s<\/key>\s*<string>(\S+)<\/string>`, key)
+	re := regexp.MustCompile(res)
+	submatch := re.FindStringSubmatch(string(plistData))
 	if len(submatch) == 2 {
-		return submatch[1], nil
+		return submatch[1]
 	}
-	return "", nil
+	log.Debug("No key (%s) found", key)
+	return ""
+}
+
+func loadPlist(plistPath string, log Log) ([]byte, error) {
+	if _, err := os.Stat(plistPath); os.IsNotExist(err) {
+		log.Debug("No plist found: %s", plistPath)
+		return nil, err
+	}
+	log.Debug("Loading plist: %s", plistPath)
+	plistFile, err := os.Open(plistPath)
+	defer plistFile.Close()
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadAll(plistFile)
+}
+
+func fuseBundleVersion(appPath string, log Log) (string, error) {
+	plistPath := filepath.Join(appPath, "Contents/Resources/KeybaseInstaller.app/Contents/Info.plist")
+	plistData, err := loadPlist(plistPath, log)
+	if err != nil {
+		return "", err
+	}
+	return findStringInPlist("KBFuseVersion", plistData, log), nil
+}
+
+func fuseInstallVersion(log Log) (string, error) {
+	plistPath := filepath.Join(installPath, "Contents/Info.plist")
+	plistData, err := loadPlist(plistPath, log)
+	if err != nil {
+		return "", err
+	}
+	return findStringInPlist("CFBundleVersion", plistData, log), nil
 }
 
 // checkFuseUpgrade will see if the Fuse version in the Keybase.app bundle

--- a/go/install/fuse_status_osx_test.go
+++ b/go/install/fuse_status_osx_test.go
@@ -1,0 +1,35 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build darwin
+
+package install
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindStringInPlist(t *testing.T) {
+	const plistTestData = `<?xml version="1.0" encoding="UTF-8"?>
+  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+  <plist version="1.0">
+  <dict>
+  	<key>CFBundleName</key>
+  	<string>Keybase</string>
+  	<key>CFBundleVersion</key>
+  	<string>1.0.17-20160825110028+67f6e3b</string>
+  	<key>NSMainNibFile</key>
+  	<string>MainMenu</string>
+  </dict>
+  </plist>`
+	version := findStringInPlist("CFBundleVersion", []byte(plistTestData), testLog)
+	assert.Equal(t, "1.0.17-20160825110028+67f6e3b", version)
+}
+
+func TestFindStringInPlistWithWhitespace(t *testing.T) {
+	const plistTestData = `    <key> test </key>` + "\n\n \t" + `  <string> value </string>  ` + "\n\t"
+	value := findStringInPlist(" test ", []byte(plistTestData), testLog)
+	assert.Equal(t, " value ", value)
+}

--- a/go/install/fuse_status_osx_test.go
+++ b/go/install/fuse_status_osx_test.go
@@ -33,3 +33,9 @@ func TestFindStringInPlistWithWhitespace(t *testing.T) {
 	value := findStringInPlist(" test ", []byte(plistTestData), testLog)
 	assert.Equal(t, " value ", value)
 }
+
+func TestFindStringInPlistWithNoWhitespace(t *testing.T) {
+	const plistTestData = `<key>test</key><string>value</string>`
+	value := findStringInPlist("test", []byte(plistTestData), testLog)
+	assert.Equal(t, "value", value)
+}

--- a/go/install/install_test.go
+++ b/go/install/install_test.go
@@ -10,7 +10,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/keybase/client/go/logger"
 )
+
+var testLog = logger.New("test")
 
 func TestCommandLine(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "kbbin")


### PR DESCRIPTION
Upgrade only happened if kext was loaded (because we get installed version from a system call).
If kext couldn't load (as it was on people who upgraded to Sierra from an old version), then no upgrade would happen, and then fuse wouldn't work cause they were still on old version.