### PR TITLE
Fix 'Someone else...' dropdown on mobile

### DIFF
--- a/shared/common-adapters/dropdown.native.js
+++ b/shared/common-adapters/dropdown.native.js
@@ -111,10 +111,11 @@ class Dropdown extends Component<void, Props, State> {
         return
       }
 
-      this.setState({value})
-      if (selectOnChange) {
-        this._selected()
-      }
+      this.setState({value}, () => {
+        if (selectOnChange) {
+          this._selected()
+        }
+      })
     }
 
     return (


### PR DESCRIPTION
@keybase/react-hackers 

The dropdown calls `this.setState({value})` and then `this._selected()`, which looks at `this.state.value` to see what was chosen.  But `setState()` is asynchronous -- it registers a pending state transition, it's not atomic.  To wait for setState to complete before inspecting `this.state`, we can pass our callback as the second argument to `setState()`.

Tested on Android and iOS.