### PR TITLE
Fix coinbase hint url comparison

### DIFF
--- a/go/externals/proof_support_coinbase.go
+++ b/go/externals/proof_support_coinbase.go
@@ -32,7 +32,7 @@ func (rc *CoinbaseChecker) ProfileURL() string {
 func (rc *CoinbaseChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	wanted := rc.ProfileURL()
 	url := h.GetAPIURL()
-	if strings.ToLower(wanted) == url {
+	if strings.ToLower(wanted) == strings.ToLower(url) {
 		return nil
 	}
 	return libkb.NewProofError(keybase1.ProofStatus_BAD_API_URL, "Bad hint from server; URL should be %q; got %q", wanted, url)


### PR DESCRIPTION
The coinbase hint validator was only downcasing one side of the url comparison.

This caused `keybase id ghostwheel` to fail for coinbase even though that proof is ok (which the server knows). With this fix, `keybase id ghostwheel` works again.

r? @oconnor663 