### PR TITLE
Make SelectionContents less strict

### DIFF
--- a/go/pvl/helpers.go
+++ b/go/pvl/helpers.go
@@ -102,26 +102,20 @@ func pvlJSONStringSimple(object *jsonw.Wrapper) (string, error) {
 }
 
 // pvlSelectionContents gets the HTML contents of all elements in a selection, concatenated by a space.
-func pvlSelectionContents(selection *goquery.Selection, useAttr bool, attr string) (string, error) {
-	len := selection.Length()
-	results := make([]string, len)
-	errs := make([]error, len)
+// If getting the contents/attr value of any elements fails, that does not cause an error.
+// The result can be an empty string.
+func pvlSelectionContents(selection *goquery.Selection, useAttr bool, attr string) string {
+	var results []string
 	selection.Each(func(i int, element *goquery.Selection) {
 		if useAttr {
 			res, ok := element.Attr(attr)
-			results[i] = res
-			if !ok {
-				errs[i] = fmt.Errorf("Could not get attr %v of element", attr)
+			if ok {
+				results = append(results, res)
 			}
 		} else {
-			results[i] = element.Text()
-			errs[i] = nil
+			results = append(results, element.Text())
 		}
 	})
-	for _, err := range errs {
-		if err != nil {
-			return "", err
-		}
-	}
-	return strings.Join(results, " "), nil
+
+	return strings.Join(results, " ")
 }

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -668,11 +668,7 @@ func pvlStepSelectorCSS(g ProofContextExt, ins *jsonw.Wrapper, state PvlScriptSt
 			"CSS selector matched too many elements")
 	}
 
-	res, err := pvlSelectionContents(selection, useAttr, attr)
-	if err != nil {
-		return state, libkb.NewProofError(keybase1.ProofStatus_CONTENT_FAILURE,
-			"Could not get html for selection: %v", err)
-	}
+	res := pvlSelectionContents(selection, useAttr, attr)
 
 	state.ActiveString = res
 	return state, nil
@@ -749,7 +745,7 @@ func pvlRunCSSSelectorInner(g ProofContextExt, html *goquery.Selection, selector
 			selection = selection.Find(selectorString)
 		default:
 			return nil, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
-				"Selector entry string or int %v", selector)
+				"Selector entry must be a string or int %v", selector)
 		}
 	}
 


### PR DESCRIPTION
Make `pvlSelectionContents` not fail as a whole when a member fails. This makes sense for getting `attr`s because you might select a bunch of elements only some of which have `data-foo`, and that should work.

Also fix `pvlJSONStringSimple`.

r? @maxtaco @oconnor663 