### PR TITLE
Ui pgp storage message

### DIFF
--- a/desktop/renderer/remote-component-loader.js
+++ b/desktop/renderer/remote-component-loader.js
@@ -11,6 +11,7 @@ import engine from '../shared/engine'
 import tracker from '../shared/tracker'
 import pinentry from '../shared/pinentry'
 import unlockFolders from '../shared/unlock-folders'
+import purgeMessage from '../shared/pgp/container.desktop'
 
 import {setupContextMenu} from '../app/menu-helper'
 import loadPerf from '../shared/util/load-perf'
@@ -81,7 +82,7 @@ class RemoteComponentLoader extends Component {
 
     hello(process.pid, 'Remote Component: ' + (title || ''), process.argv, __VERSION__) // eslint-disable-line no-undef
 
-    const component = {tracker, pinentry, unlockFolders}
+    const component = {tracker, pinentry, unlockFolders, purgeMessage}
 
     if (!componentToLoad || !component[componentToLoad]) {
       throw new TypeError('Invalid Remote Component passed through')

--- a/desktop/renderer/remote-manager.js
+++ b/desktop/renderer/remote-manager.js
@@ -4,6 +4,7 @@ import React, {Component} from 'react'
 import RemoteTracker from './remote-tracker'
 import RemotePinentry from './remote-pinentry'
 import RemoteUnlockFolders from './remote-unlock-folders'
+import RemotePurgeMessage from './remote-purge-message'
 
 class RemoteManager extends Component<void, {}, void> {
   render () {
@@ -12,6 +13,7 @@ class RemoteManager extends Component<void, {}, void> {
         <RemoteTracker />
         <RemotePinentry />
         <RemoteUnlockFolders />
+        <RemotePurgeMessage />
       </div>
     )
   }

--- a/desktop/renderer/remote-purge-message.js
+++ b/desktop/renderer/remote-purge-message.js
@@ -1,0 +1,47 @@
+// @flow
+import React, {Component} from 'react'
+import {connect} from 'react-redux'
+import RemoteComponent from './remote-component'
+import * as Constants from '../../shared/constants/pgp'
+
+type Props = {
+  close: () => void,
+  open: boolean,
+}
+
+class RemotePurgeMessage extends Component<void, Props, void> {
+  shouldComponentUpdate (nextProps, nextState) {
+    return nextProps !== this.props
+  }
+
+  render () {
+    const {open} = this.props
+    if (!open) {
+      return null
+    }
+
+    const windowsOpts = {width: 600, height: 450}
+    return (
+      <div>
+        <RemoteComponent
+          title='PgpPurgeMessage'
+          windowsOpts={windowsOpts}
+          waitForState={false}
+          onRemoteClose={() => this.props.close()}
+          component='purgeMessage'
+          onSubmit={() => {}}
+          onCancel={() => this.props.close()}
+          sessionID={0} />
+      </div>
+    )
+  }
+}
+
+export default connect(
+  state => ({
+    open: state.pgp.open,
+  }),
+  dispatch => ({
+    onClose: () => { dispatch({type: Constants.pgpAckedMessage, payload: {hitOk: false}}) },
+  })
+)(RemotePurgeMessage)

--- a/shared/actions/notifications.js
+++ b/shared/actions/notifications.js
@@ -27,6 +27,7 @@ export function listenForNotifications (): (dispatch: Dispatch) => void {
       kbfs: true,
       service: true,
       app: true,
+      pgp: true,
     })
 
     const listeners = ListenerCreator(dispatch, getState, NotifyPopup)

--- a/shared/actions/pgp.js
+++ b/shared/actions/pgp.js
@@ -18,9 +18,7 @@ function pgpStorageDismiss () {
 }
 
 function * pgpSecurityModelChangeMessageSaga ({payload: {hitOk}}: PgpAckedMessage): any {
-  if (hitOk) {
-    pgpStorageDismiss()
-  }
+  pgpStorageDismiss()
 }
 
 function * saga (): any {

--- a/shared/actions/pgp.js
+++ b/shared/actions/pgp.js
@@ -1,0 +1,30 @@
+// @flow
+
+import * as Constants from '../constants/pgp'
+import {takeEvery} from 'redux-saga'
+import {pgpPgpStorageDismissRpc} from '../constants/types/flow-types'
+
+import type {PgpAckedMessage} from '../constants/pgp'
+
+function pgpStorageDismiss () {
+  // make rpc call to pgpStorageDismiss
+  pgpPgpStorageDismissRpc({
+    callback: (err) => {
+      if (err) {
+        console.warn(`Error in sending pgpPgpStorageDismissRpc: ${err}`)
+      }
+    },
+  })
+}
+
+function * pgpSecurityModelChangeMessageSaga ({payload: {hitOk}}: PgpAckedMessage): any {
+  if (hitOk) {
+    pgpStorageDismiss()
+  }
+}
+
+function * saga (): any {
+  yield takeEvery(Constants.pgpAckedMessage, pgpSecurityModelChangeMessageSaga)
+}
+
+export default saga

--- a/shared/constants/pgp.js
+++ b/shared/constants/pgp.js
@@ -1,0 +1,11 @@
+// @flow
+
+import type {TypedAction} from './types/flux'
+
+export const pgpKeyInSecretStoreFile = 'pgp:pgpKeyInSecretStoreFile'
+export type PgpKeyInSecretStoreFile = TypedAction<'pgp:pgpKeyInSecretStoreFile', void, void>
+
+export const pgpAckedMessage = 'pgp:pgpAckedMessage'
+export type PgpAckedMessage = TypedAction<'pgp:pgpAckedMessage', {hitOk: boolean}, {hitOk: boolean}>
+
+export type Actions = PgpKeyInSecretStoreFile | PgpAckedMessage

--- a/shared/dev/dumb-component-map.desktop.js
+++ b/shared/dev/dumb-component-map.desktop.js
@@ -1,42 +1,44 @@
 // @flow
 import CommonMap from '../common-adapters/dumb.desktop'
-import RegisterMap from '../login/register/dumb'
-import DevicesMap from '../devices/dumb'
-import LoginMap from '../login/dumb.desktop'
-import SignupMap from '../login/signup/dumb.desktop'
-import MenubarMap from '../menubar/dumb.desktop'
-import TrackerMap from '../tracker/dumb.desktop'
-import PinentryMap from '../pinentry/dumb.desktop'
 import DevicePageMap from '../devices/device-page/dumb.desktop'
 import DeviceRevokeMap from '../devices/device-revoke/dumb.desktop'
-import TabBarMap from '../tab-bar/dumb.desktop'
-import FoldersMap from '../folders/dumb'
-import FoldersConfirmMap from '../folders/confirm/dumb'
-import ProfileMap from '../profile/dumb'
+import DevicesMap from '../devices/dumb'
 import EditProfileMap from '../profile/edit-profile/dumb'
+import FoldersConfirmMap from '../folders/confirm/dumb'
+import FoldersMap from '../folders/dumb'
+import LoginMap from '../login/dumb.desktop'
+import MenubarMap from '../menubar/dumb.desktop'
+import PgpMap from '../pgp/dumb.desktop'
+import PinentryMap from '../pinentry/dumb.desktop'
+import ProfileMap from '../profile/dumb'
+import RegisterMap from '../login/register/dumb'
 import SearchMap from '../search/dumb'
 import SearchUserPaneMap from '../search/user-pane/dumb'
+import SignupMap from '../login/signup/dumb.desktop'
+import TabBarMap from '../tab-bar/dumb.desktop'
+import TrackerMap from '../tracker/dumb.desktop'
 import UnlockFoldersMap from '../unlock-folders/dumb'
 
 const map: any = {
   ...CommonMap,
-  ...DevicesMap,
-  ...LoginMap,
-  ...SignupMap,
-  ...MenubarMap,
-  ...TrackerMap,
-  ...PinentryMap,
   ...DevicePageMap,
   ...DeviceRevokeMap,
-  ...TabBarMap,
-  ...FoldersMap,
-  ...FoldersConfirmMap,
-  ...ProfileMap,
+  ...DevicesMap,
   ...EditProfileMap,
+  ...FoldersConfirmMap,
+  ...FoldersMap,
+  ...LoginMap,
+  ...MenubarMap,
+  ...PgpMap,
+  ...PinentryMap,
+  ...ProfileMap,
+  ...RegisterMap,
   ...SearchMap,
   ...SearchUserPaneMap,
+  ...SignupMap,
+  ...TabBarMap,
+  ...TrackerMap,
   ...UnlockFoldersMap,
-  ...RegisterMap,
 }
 
 export default map

--- a/shared/native/notification-listeners.desktop.js
+++ b/shared/native/notification-listeners.desktop.js
@@ -5,6 +5,8 @@ import {bootstrap} from '../actions/config'
 import {logoutDone} from '../actions/login'
 // import {favoriteList} from '../actions/favorite'
 import {kbfsNotification} from '../util/kbfs-notifications'
+import {pgpKeyInSecretStoreFile} from '../constants/pgp'
+
 import type {Dispatch} from '../constants/types/flux'
 import type {incomingCallMapType} from '../constants/types/flow-types'
 
@@ -49,6 +51,9 @@ export default function (dispatch: Dispatch, getState: () => Object, notify: any
     'keybase.1.NotifyApp.exit': () => {
       console.log('App exit requested')
       remote.app.exit(0)
+    },
+    'keybase.1.NotifyPGP.pgpKeyInSecretStoreFile': () => {
+      dispatch({type: pgpKeyInSecretStoreFile, payload: undefined})
     },
   }
 }

--- a/shared/pgp/container.desktop.js
+++ b/shared/pgp/container.desktop.js
@@ -1,0 +1,18 @@
+// @flow
+import {TypedConnector} from '../util/typed-connect'
+import PurgeMessage from './purge-message.desktop'
+import * as Constants from '../constants/pgp'
+
+import type {Props} from './purge-message.desktop'
+
+const connector: TypedConnector<{}, any, {}, Props> = new TypedConnector()
+
+export default connector.connect(
+  ({unlockFolders: {devices, phase, paperkeyError, waiting}}, dispatch, ownProps) => ({
+    onClose: () => { dispatch({type: Constants.pgpAckedMessage, payload: {hitOk: false}}) },
+    onOk: () => { dispatch({type: Constants.pgpAckedMessage, payload: {hitOk: true}}) },
+  }))(PurgeMessage)
+
+export function selector (): (store: Object) => ?Object {
+  return () => ({})
+}

--- a/shared/pgp/dumb.desktop.js
+++ b/shared/pgp/dumb.desktop.js
@@ -1,0 +1,17 @@
+/* @flow */
+import type {DumbComponentMap} from '../constants/types/more'
+import PurgeMessage from './purge-message.desktop'
+
+const dumbPurgeMessage: DumbComponentMap<PurgeMessage> = {
+  component: PurgeMessage,
+  mocks: {
+    'Purge Message': {
+      onClose: () => console.log('onClose'),
+      onOk: () => console.log('onOk'),
+    },
+  },
+}
+
+export default {
+  'PGP Purge Message': dumbPurgeMessage,
+}

--- a/shared/pgp/purge-message.desktop.js
+++ b/shared/pgp/purge-message.desktop.js
@@ -1,0 +1,49 @@
+// @flow
+import React, {Component} from 'react'
+import {Box, Button, Header, Text} from '../common-adapters'
+import {globalStyles, globalMargins} from '../styles/style-guide'
+
+export type Props = {
+  onClose: () => void,
+  onOk: () => void,
+}
+
+class PgpPurgeMessage extends Component<void, Props, void> {
+  _toItalics (s: string) {
+    return (
+      <Text inline={true} type='BodySemiboldItalic'>{s}</Text>
+    )
+  }
+
+  render () {
+    return (
+      <Box style={{...globalStyles.flexBoxColumn}}>
+        <Box >
+          <Header icon={true} type='Default' title='' onClose={this.props.onClose || (() => {})} />
+        </Box>
+        <Box style={{...globalStyles.flexBoxColumn, margin: globalMargins.medium, marginTop: globalMargins.tiny}}>
+          <Text style={{textAlign: 'center'}} type='Header'>Policy change on passphrases</Text>
+          <Text style={{marginTop: globalMargins.small, textIndent: 20}} type='Body'>
+            {`
+              We've gotten lots of feedback that it's annoying as all hell to enter a Keybase passphrase
+              after restarts and updates. The consensus is you can trust a device's storage to keep a secret
+              that's`} {this._toItalics('specific')} {`to that device.  Passphrases stink, like passed gas, and are bloody painful, like passed stones.
+            `}
+          </Text>
+
+          <Text style={{marginTop: globalMargins.small, textIndent: 20}} type='Body'>
+            {`
+              Note, however: on this device you've got a PGP private key in Keybase's local keychain.
+              Some people `} {this._toItalics('want')} {` to type a passphrase to unlock their PGP key, and this new policy would bypass that.
+              If you're such a person, you can run the following command to remove your PGP private key. If you do it, you'll have to use GPG for your PGP operations.
+            `}
+          </Text>
+          <Text style={{marginTop: globalMargins.small, textIndent: 20}} type='Terminal'>keybase pgp purge</Text>
+        </Box>
+        <Button style={{marginRight: globalMargins.medium, marginBottom: globalMargins.small, alignSelf: 'flex-end'}} type='Primary' onClick={this.props.onOk} label='ok, got it!' />
+      </Box>
+    )
+  }
+}
+
+export default PgpPurgeMessage

--- a/shared/reducers/dev.js
+++ b/shared/reducers/dev.js
@@ -28,6 +28,7 @@ export default function (state: DevState = initialState, action: DevAction): Sta
 
   if (action.type === updateReloading && !action.error) {
     return {
+      ...state,
       reloading: action.payload.reloading,
     }
   }

--- a/shared/reducers/index.js
+++ b/shared/reducers/index.js
@@ -8,6 +8,7 @@ import favorite from './favorite'
 import gregor from './gregor'
 import login from './login'
 import notifications from './notifications'
+import pgp from './pgp'
 import pinentry from './pinentry'
 import profile from './profile'
 import router from './router'
@@ -47,6 +48,7 @@ const combinedReducer = combineReducers({
   gregor,
   login,
   notifications,
+  pgp,
   pinentry,
   profile,
   router,

--- a/shared/reducers/pgp.js
+++ b/shared/reducers/pgp.js
@@ -9,7 +9,7 @@ export type State = {
 }
 
 const initialState: State = {
-  open: true,
+  open: false,
 }
 
 export default function (state: State = initialState, action: Actions): State {

--- a/shared/reducers/pgp.js
+++ b/shared/reducers/pgp.js
@@ -1,0 +1,35 @@
+/* @flow */
+
+import * as Constants from '../constants/pgp'
+import * as CommonConstants from '../constants/common'
+import type {Actions} from '../constants/pgp'
+
+export type State = {
+  open: boolean,
+}
+
+const initialState: State = {
+  open: true,
+}
+
+export default function (state: State = initialState, action: Actions): State {
+  switch (action.type) {
+    case CommonConstants.resetStore:
+      return {
+        ...initialState,
+      }
+
+    case Constants.pgpKeyInSecretStoreFile:
+      return {
+        ...state,
+        open: true,
+      }
+    case Constants.pgpAckedMessage:
+      return {
+        ...state,
+        open: false,
+      }
+  }
+  return state
+}
+

--- a/shared/store/configure-store.js
+++ b/shared/store/configure-store.js
@@ -5,6 +5,7 @@ import createLogger from 'redux-logger'
 import createSagaMiddleware from 'redux-saga'
 import gregorSaga from '../actions/gregor'
 import profileSaga from '../actions/profile'
+import pgpSaga from '../actions/pgp'
 import rootReducer from '../reducers'
 import thunkMiddleware from 'redux-thunk'
 import {actionLogger} from './action-logger'
@@ -53,6 +54,7 @@ function * mainSaga (getState) {
   yield [
     call(gregorSaga),
     call(profileSaga),
+    call(pgpSaga),
   ]
 }
 


### PR DESCRIPTION
@keybase/react-hackers 


Adds the UI's ability to show a popup giving the pgp purge message, and handles sending an ack back to the service.

Ack is sent back only when the user hits ok.

The choice was made here to use a separate store, so in the future when we remove this it won't be too hard to take out.

The name is confusingly pgp, if there is a better option I'm happy to change it.


## Preview

![screen shot 2016-08-26 at 4 01 05 pm](https://cloud.githubusercontent.com/assets/594035/18023444/f765ea20-6bad-11e6-98c7-d05d22956275.png)
