### PR TITLE
split out error text

### DIFF
--- a/shared/common-adapters/form-with-checkbox.desktop.js
+++ b/shared/common-adapters/form-with-checkbox.desktop.js
@@ -2,22 +2,25 @@
 import React, {Component} from 'react'
 import type {Props as CheckboxProps} from './checkbox'
 import type {Props} from './form-with-checkbox'
-import {Checkbox, Input, Box} from './index'
+import {Checkbox, Input, Box, Text} from './index'
 import {globalStyles} from '../styles'
 
 class FormWithCheckbox extends Component<void, Props, void> {
   render () {
     const {inputProps, checkboxesProps} = this.props
+    const {errorText = ''} = inputProps
+    const inputWOError = {...inputProps, errorText: null}
 
     return (
       <Box style={{...globalStyles.flexBoxColumn, marginBottom: 15, ...this.props.style}}>
-        <Input errorStyle={{marginTop: 26}} {...inputProps} />
+        <Input errorStyle={{marginTop: 26}} {...inputWOError} />
         <Box style={{...styles.checkboxContainer, ...this.props.checkboxContainerStyle}}>
           {checkboxesProps.map(p => {
             const checkProps: CheckboxProps = {key: p.label, ...p}
             return <Checkbox key={p.label} {...checkProps} />
           })}
         </Box>
+        {!!errorText && <Text type='BodySmallError' style={{textAlign: 'center'}}>{errorText}</Text>}
       </Box>
     )
   }


### PR DESCRIPTION
@keybase/react-hackers this fixes the problem with multi-line error in the form with error. instead of being able to inject a child into input and all the side effects of a change like that i instead just pull the error out and show it below