### PR TITLE
Add tests for LoadUserPlusKeys, Identify2 on user w/ no keys

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -725,6 +725,15 @@ func TestIdentify2NoSigchain(t *testing.T) {
 	if _, ok := ierr.(libkb.NoSigChainError); !ok {
 		t.Errorf("imported status error: %T, expected libkb.NoSigChainError", ierr)
 	}
+
+	// kbfs would like to have some info about the user
+	result := eng.Result()
+	if result == nil {
+		t.Fatal("no result on id2 w/ no sigchain")
+	}
+	if result.Upk.Username != u {
+		t.Errorf("result username: %q, expected %q", result.Upk.Username, u)
+	}
 }
 
 var tracyUID = keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")

--- a/go/libkb/loaduser_test.go
+++ b/go/libkb/loaduser_test.go
@@ -35,6 +35,20 @@ func TestLoadUserPlusKeys(t *testing.T) {
 	}
 }
 
+func TestLoadUserPlusKeysNoKeys(t *testing.T) {
+	tc := SetupTest(t, "user plus keys", 1)
+	defer tc.Cleanup()
+
+	// t_ellen has no keys.  There should be no error loading her.
+	u, err := LoadUserPlusKeys(tc.G, "561247eb1cc3b0f5dc9d9bf299da5e19")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Username != "t_ellen" {
+		t.Errorf("username: %s, expected t_ellen", u.Username)
+	}
+}
+
 func TestRevokedKeys(t *testing.T) {
 	tc := SetupTest(t, "revoked keys", 1)
 	defer tc.Cleanup()


### PR DESCRIPTION
Make sure that LoadUserPlusKeys, Identify2 work on users without keys.

Add two tests.  LoadUserPlusKeys works fine, no error.  Identify2 returns NoSigChainError, but also returns data in keybase1.Identify2Res.  @strib said this will work for kbfs.

r? @oconnor663 