### PR TITLE
Add ProofState_DELETED to protocol

### DIFF
--- a/go/protocol/keybase1/prove_common.go
+++ b/go/protocol/keybase1/prove_common.go
@@ -18,6 +18,7 @@ const (
 	ProofState_SUPERSEDED   ProofState = 5
 	ProofState_POSTED       ProofState = 6
 	ProofState_REVOKED      ProofState = 7
+	ProofState_DELETED      ProofState = 8
 )
 
 var ProofStateMap = map[string]ProofState{
@@ -29,6 +30,7 @@ var ProofStateMap = map[string]ProofState{
 	"SUPERSEDED":   5,
 	"POSTED":       6,
 	"REVOKED":      7,
+	"DELETED":      8,
 }
 
 // 3: It's been found in the hunt, but not proven yet

--- a/protocol/avdl/keybase1/prove_common.avdl
+++ b/protocol/avdl/keybase1/prove_common.avdl
@@ -9,7 +9,8 @@ protocol proveCommon {
     LOOKING_4,
     SUPERSEDED_5,
     POSTED_6,
-    REVOKED_7
+    REVOKED_7,
+    DELETED_8
   }
 
   /**

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -278,6 +278,7 @@ export const ProveCommonProofState = {
   superseded: 5,
   posted: 6,
   revoked: 7,
+  deleted: 8,
 }
 
 export const ProveCommonProofStatus = {
@@ -1930,6 +1931,7 @@ export type ProofState =
   | 5 // SUPERSEDED_5
   | 6 // POSTED_6
   | 7 // REVOKED_7
+  | 8 // DELETED_8
 
 export type ProofStatus =
     0 // NONE_0

--- a/protocol/json/keybase1/prove_common.json
+++ b/protocol/json/keybase1/prove_common.json
@@ -13,7 +13,8 @@
         "LOOKING_4",
         "SUPERSEDED_5",
         "POSTED_6",
-        "REVOKED_7"
+        "REVOKED_7",
+        "DELETED_8"
       ]
     },
     {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -278,6 +278,7 @@ export const ProveCommonProofState = {
   superseded: 5,
   posted: 6,
   revoked: 7,
+  deleted: 8,
 }
 
 export const ProveCommonProofStatus = {
@@ -1930,6 +1931,7 @@ export type ProofState =
   | 5 // SUPERSEDED_5
   | 6 // POSTED_6
   | 7 // REVOKED_7
+  | 8 // DELETED_8
 
 export type ProofStatus =
     0 // NONE_0


### PR DESCRIPTION
Just a protocol update. Avdl `ProofState`s now match iced.
Do you think the fact that `DELETED` didn't exist in Go could have led to bugs to look for?

`prove_common.go`
```avdl
  enum ProofState {
    NONE_0,
    OK_1,
    TEMP_FAILURE_2,
    PERM_FAILURE_3,
    LOOKING_4,
    SUPERSEDED_5,
    POSTED_6,
    REVOKED_7,
    DELETED_8
  }
```

```coffeescript
  proof_state :
    NONE : 0
    OK : 1
    TEMP_FAILURE : 2
    PERM_FAILURE : 3
    LOOKING : 4
    SUPERSEDED : 5
    POSTED : 6
    REVOKED : 7
    DELETED : 8
```

r? @maxtaco 