### PR TITLE
Fix alignment of icons in mobile tab bar

### DIFF
--- a/shared/common-adapters/tab-bar.native.js
+++ b/shared/common-adapters/tab-bar.native.js
@@ -34,7 +34,7 @@ class TabBarButton extends Component<void, TabBarButtonProps, void> {
     return (
       <Box style={{...globalStyles.flexBoxColumn, backgroundColor, ...stylesTabBarButtonIcon, ...this.props.style}}>
         {this.props.source.type === 'icon'
-          ? <Icon type={this.props.source.icon} style={{fontSize: 48, width: 80, textAlign: 'center', color: this.props.selected ? globalColors.blue3 : globalColors.blue3_40, ...this.props.styleIcon}} />
+          ? <Icon type={this.props.source.icon} style={{fontSize: 48, width: 48, textAlign: 'center', color: this.props.selected ? globalColors.blue3 : globalColors.blue3_40, ...this.props.styleIcon}} />
           : this.props.source.avatar}
         {badgeNumber > 0 &&
           <Box style={{...styleBadgeOuter, borderColor: backgroundColor, backgroundColor}}>


### PR DESCRIPTION
<img src="https://cloud.githubusercontent.com/assets/16893/18144955/25d9e5cc-6f7e-11e6-9c36-f9698009c180.png" width="200"> <img src="https://cloud.githubusercontent.com/assets/16893/18144960/296de17a-6f7e-11e6-9a8e-3775bc653e7a.png" width="200">

:eyeglasses: @keybase/react-hackers 