### PR TITLE
Add background color to mobile tab bar to fill gaps caused by rounding

### DIFF
--- a/shared/common-adapters/tab-bar.native.js
+++ b/shared/common-adapters/tab-bar.native.js
@@ -91,7 +91,7 @@ class TabBar extends Component {
 
   render () {
     const tabBarButtons = (
-      <Box style={{...globalStyles.flexBoxRow, ...this.props.styleTabBar}}>
+      <Box style={{...globalStyles.flexBoxRow, backgroundColor: globalColors.midnightBlue, ...this.props.styleTabBar}}>
         {this._labels()}
       </Box>
     )


### PR DESCRIPTION
When the available space is not a factor of 5, we get 1px white gaps interspersed between the items. By using the same background color as the tabs, we can hide this visual artifact.

Background colored orange for demonstration:
<img src="https://cloud.githubusercontent.com/assets/16893/18146053/95e9ea20-6f82-11e6-97ec-70d8d92d7d9d.png" width="200">

Change result:
<img src="https://cloud.githubusercontent.com/assets/16893/18146055/98809180-6f82-11e6-90f4-f30a6d1a42b4.png" width="200">


:eyeglasses: @keybase/react-hackers 