### PR TITLE
Remove 'Save in Keychain' and deps

### DIFF
--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -17,9 +17,10 @@ import {defaultModeForDeviceRoles, qrGenerate} from './provision-helpers'
 import {devicesTab, loginTab} from '../../constants/tabs'
 import {isMobile} from '../../constants/platform'
 import {loadDevices} from '../devices'
-import {loginRecoverAccountFromEmailAddressRpc, loginLoginRpc, loginLogoutRpc,
-  deviceDeviceAddRpc, loginGetConfiguredAccountsRpc, loginClearStoredSecretRpc,
-  CommonClientType, ConstantsStatusCode, ProvisionUiGPGMethod, ProvisionUiDeviceType, PassphraseCommonPassphraseType,
+import {loginRecoverAccountFromEmailAddressRpc, loginLoginRpc,  loginLogoutRpc,
+  deviceDeviceAddRpc, loginGetConfiguredAccountsRpc, CommonClientType,
+  ConstantsStatusCode, ProvisionUiGPGMethod, ProvisionUiDeviceType,
+  PassphraseCommonPassphraseType
 } from '../../constants/types/flow-types'
 import {navigateTo, routeAppend, navigateUp, switchTab} from '../router'
 import {overrideLoggedInTab} from '../../local-debug'

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -260,7 +260,7 @@ export function autoLogin () : AsyncAction {
   }
 }
 
-export function relogin (user: string, passphrase: string, store: boolean) : AsyncAction {
+export function relogin (user: string, passphrase: string) : AsyncAction {
   return dispatch => {
     const deviceType: DeviceType = isMobile ? 'mobile' : 'desktop'
     loginLoginRpc({
@@ -274,7 +274,7 @@ export function relogin (user: string, passphrase: string, store: boolean) : Asy
         'keybase.1.secretUi.getPassphrase': ({pinentry: {type}}, response) => {
           response.result({
             passphrase,
-            storeSecret: store,
+            storeSecret: true,
           })
         },
         'keybase.1.provisionUi.chooseDevice': ({devices}, response) => {
@@ -330,19 +330,6 @@ export function logoutDone () : AsyncAction {
     dispatch(switchTab(loginTab))
     dispatch(navBasedOnLoginState())
     dispatch(bootstrap())
-  }
-}
-
-export function saveInKeychainChanged (username: string, saveInKeychain: bool) : AsyncAction {
-  return (dispatch, getState) => {
-    if (saveInKeychain) {
-      return
-    }
-
-    loginClearStoredSecretRpc({
-      param: {username},
-      callback: error => { error && console.log(error) },
-    })
   }
 }
 

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -17,10 +17,10 @@ import {defaultModeForDeviceRoles, qrGenerate} from './provision-helpers'
 import {devicesTab, loginTab} from '../../constants/tabs'
 import {isMobile} from '../../constants/platform'
 import {loadDevices} from '../devices'
-import {loginRecoverAccountFromEmailAddressRpc, loginLoginRpc,  loginLogoutRpc,
+import {loginRecoverAccountFromEmailAddressRpc, loginLoginRpc, loginLogoutRpc,
   deviceDeviceAddRpc, loginGetConfiguredAccountsRpc, CommonClientType,
   ConstantsStatusCode, ProvisionUiGPGMethod, ProvisionUiDeviceType,
-  PassphraseCommonPassphraseType
+  PassphraseCommonPassphraseType,
 } from '../../constants/types/flow-types'
 import {navigateTo, routeAppend, navigateUp, switchTab} from '../router'
 import {overrideLoggedInTab} from '../../local-debug'

--- a/shared/login/login/index.js
+++ b/shared/login/login/index.js
@@ -3,12 +3,11 @@ import React, {Component} from 'react'
 import Render from './index.render'
 import type {Props} from './index.render'
 import {connect} from 'react-redux'
-import {openAccountResetPage, relogin, login, saveInKeychainChanged} from '../../actions/login'
+import {openAccountResetPage, relogin, login} from '../../actions/login'
 import {routeAppend} from '../../actions/router'
 
 type State = {
   selectedUser: ?string,
-  saveInKeychain: boolean,
   showTyping: boolean,
   passphrase: string
 }
@@ -21,7 +20,6 @@ class Login extends Component {
 
     this.state = {
       selectedUser: props.lastUser,
-      saveInKeychain: true,
       showTyping: false,
       passphrase: '',
     }
@@ -29,13 +27,8 @@ class Login extends Component {
 
   _onSubmit () {
     if (this.state.selectedUser) {
-      this.props.onLogin(this.state.selectedUser, this.state.passphrase, this.state.saveInKeychain)
+      this.props.onLogin(this.state.selectedUser, this.state.passphrase)
     }
-  }
-
-  _onSaveInKeychainChange (saveInKeychain) {
-    this.props.onSaveInKeychainChange(this.state.selectedUser, saveInKeychain)
-    this.setState({saveInKeychain})
   }
 
   render () {
@@ -43,11 +36,9 @@ class Login extends Component {
       onSubmit={() => this._onSubmit()}
       passphrase={this.state.passphrase}
       showTyping={this.state.showTyping}
-      saveInKeychain={this.state.saveInKeychain}
       selectedUser={this.state.selectedUser}
       passphraseChange={passphrase => this.setState({passphrase})}
       showTypingChange={showTyping => this.setState({showTyping})}
-      saveInKeychainChange={saveInKeychain => this._onSaveInKeychainChange(saveInKeychain)}
       selectedUserChange={selectedUser => this.setState({selectedUser})}
     />
   }
@@ -76,9 +67,8 @@ export default connect(
   },
   dispatch => ({
     onForgotPassphrase: () => dispatch(openAccountResetPage()),
-    onLogin: (user, passphrase, store) => dispatch(relogin(user, passphrase, store)),
+    onLogin: (user, passphrase) => dispatch(relogin(user, passphrase)),
     onSignup: () => dispatch(routeAppend(['signup'])),
     onSomeoneElse: () => { dispatch(login()) },
-    onSaveInKeychainChange: (user, saveInKeychain) => { dispatch(saveInKeychainChanged(user, saveInKeychain)) },
   })
 )(Login)

--- a/shared/login/login/index.render.desktop.js
+++ b/shared/login/login/index.render.desktop.js
@@ -17,7 +17,6 @@ class LoginRender extends Component<void, Props, void> {
     }
 
     const checkboxProps = [
-      {label: 'Save in Keychain', checked: this.props.saveInKeychain, onCheck: check => { this.props.saveInKeychainChange(check) }, style: {marginRight: 13}},
       {label: 'Show Typing', checked: this.props.showTyping, onCheck: check => { this.props.showTypingChange(check) }},
     ]
 

--- a/shared/login/login/index.render.js.flow
+++ b/shared/login/login/index.render.js.flow
@@ -14,7 +14,6 @@ export type Props = {
   selectedUserChange: (selectedUser: string) => void,
   passphraseChange: (passphrase: string) => void,
   showTypingChange: (typingChange: boolean) => void,
-  saveInKeychainChange: (saveInKeychain: boolean) => void,
   onSubmit: () => void
 }
 

--- a/shared/login/login/index.render.native.js
+++ b/shared/login/login/index.render.native.js
@@ -17,7 +17,6 @@ class LoginRender extends Component<void, Props, void> {
     }
 
     const checkboxProps = [
-      {label: 'Save in Keychain', checked: this.props.saveInKeychain, onCheck: check => { this.props.saveInKeychainChange(check) }, style: {marginRight: 13}},
       {label: 'Show Typing', checked: this.props.showTyping, onCheck: check => { this.props.showTypingChange(check) }},
     ]
 


### PR DESCRIPTION
@keybase/react-hackers 

Core now ignores this option and always saves by default, so this checkbox is now superfluous (and harmful in a sense).  @patrickxb says it's safe to continue replying to the RPC with storeSecret: true even though the option is gone.