### PR TITLE
Installer (macOS): Remove mount dir on `keybase uninstall`

### DIFF
--- a/osx/Installer/Installer.m
+++ b/osx/Installer/Installer.m
@@ -39,6 +39,8 @@ typedef NS_ENUM (NSInteger, KBExit) {
 
   [KBAppearance setCurrentAppearance:[KBUIAppearance appearance]];
 
+  DDLogDebug(@"Version: %@", NSBundle.mainBundle.infoDictionary[(NSString *)kCFBundleVersionKey]);
+
   GBSettings *settings = [GBSettings settingsWithName:@"Settings" parent:nil];
 #if DEBUG
   [settings setObject:@"/Applications/Keybase.app" forKey:@"app-path"];
@@ -46,6 +48,11 @@ typedef NS_ENUM (NSInteger, KBExit) {
   [settings setObject:@"prod" forKey:@"run-mode"];
 #endif
   _settings = [[Settings alloc] initWithSettings:settings];
+  NSError *parseError = nil;
+  if (![_settings parseArgs:&parseError]) {
+    [self exit:KBExitError];
+    return;
+  }
 
   if ([_settings isUninstall]) {
     [self uninstall];

--- a/osx/Installer/Uninstaller.m
+++ b/osx/Installer/Uninstaller.m
@@ -26,6 +26,10 @@
       return;
     }
   }
+  if (settings.uninstallOptions & UninstallOptionMountDir) {
+    KBMountDir *mountDir = [[KBMountDir alloc] initWithConfig:environment.config helperTool:environment.helperTool];
+    [installables addObject:mountDir];
+  }
   [KBUninstaller uninstall:installables completion:completion];
 }
 

--- a/osx/KBKit/KBKit.xcodeproj/project.pbxproj
+++ b/osx/KBKit/KBKit.xcodeproj/project.pbxproj
@@ -349,6 +349,8 @@
 		006D68141C7D281400B1CA0B /* KBSharedFileList.m in Sources */ = {isa = PBXBuildFile; fileRef = 006D68121C7D281400B1CA0B /* KBSharedFileList.m */; };
 		008949981BFBB60C00CB605A /* KBCustomEnvView.m in Sources */ = {isa = PBXBuildFile; fileRef = 008949961BFBB60C00CB605A /* KBCustomEnvView.m */; };
 		008949991BFBB60C00CB605A /* KBCustomEnvView.h in Headers */ = {isa = PBXBuildFile; fileRef = 008949971BFBB60C00CB605A /* KBCustomEnvView.h */; };
+		009ABE521D6E577A00C724B0 /* KBMountDir.h in Headers */ = {isa = PBXBuildFile; fileRef = 009ABE501D6E577A00C724B0 /* KBMountDir.h */; };
+		009ABE531D6E577A00C724B0 /* KBMountDir.m in Sources */ = {isa = PBXBuildFile; fileRef = 009ABE511D6E577A00C724B0 /* KBMountDir.m */; };
 		00B82BD21BE9424600C1FC72 /* KBTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B82BD01BE9424600C1FC72 /* KBTask.h */; };
 		00B82BD31BE9424600C1FC72 /* KBTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 00B82BD11BE9424600C1FC72 /* KBTask.m */; };
 		00E206681C4DBD170095FD56 /* KBCommandLine.h in Headers */ = {isa = PBXBuildFile; fileRef = 00E206661C4DBD170095FD56 /* KBCommandLine.h */; };
@@ -714,6 +716,8 @@
 		006D68121C7D281400B1CA0B /* KBSharedFileList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KBSharedFileList.m; sourceTree = "<group>"; };
 		008949961BFBB60C00CB605A /* KBCustomEnvView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KBCustomEnvView.m; sourceTree = "<group>"; };
 		008949971BFBB60C00CB605A /* KBCustomEnvView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KBCustomEnvView.h; sourceTree = "<group>"; };
+		009ABE501D6E577A00C724B0 /* KBMountDir.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KBMountDir.h; sourceTree = "<group>"; };
+		009ABE511D6E577A00C724B0 /* KBMountDir.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KBMountDir.m; sourceTree = "<group>"; };
 		00B82BD01BE9424600C1FC72 /* KBTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KBTask.h; sourceTree = "<group>"; };
 		00B82BD11BE9424600C1FC72 /* KBTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KBTask.m; sourceTree = "<group>"; };
 		00E206661C4DBD170095FD56 /* KBCommandLine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KBCommandLine.h; sourceTree = "<group>"; };
@@ -832,6 +836,8 @@
 				00010B391BE19F8800A9C285 /* KBComponent.m */,
 				00010B3A1BE19F8800A9C285 /* KBComponentStatus.h */,
 				00010B3B1BE19F8800A9C285 /* KBComponentStatus.m */,
+				009ABE501D6E577A00C724B0 /* KBMountDir.h */,
+				009ABE511D6E577A00C724B0 /* KBMountDir.m */,
 				00010B3E1BE19F8800A9C285 /* KBFSService.h */,
 				00010B3F1BE19F8800A9C285 /* KBFSService.m */,
 				00010B401BE19F8800A9C285 /* KBFuseComponent.h */,
@@ -1470,6 +1476,7 @@
 				0033F4791C3F27D700317C79 /* KBLogFormatter.h in Headers */,
 				00010CFA1BE19F8900A9C285 /* KBEnvConfig.h in Headers */,
 				00010DA41BE19F8900A9C285 /* KBAlertView.h in Headers */,
+				009ABE521D6E577A00C724B0 /* KBMountDir.h in Headers */,
 				00010DC81BE19F8900A9C285 /* KBUserInfoLabels.h in Headers */,
 				00010D141BE19F8900A9C285 /* KBEnvSelectView.h in Headers */,
 				00010B101BE19F2100A9C285 /* KBKit.h in Headers */,
@@ -1783,6 +1790,7 @@
 				00010CA41BE19F8900A9C285 /* KBComponentStatus.m in Sources */,
 				00010D9B1BE19F8900A9C285 /* KBPGPVerifyAppView.m in Sources */,
 				00010D311BE19F8900A9C285 /* KBFilePreviewView.m in Sources */,
+				009ABE531D6E577A00C724B0 /* KBMountDir.m in Sources */,
 				00010CFD1BE19F8900A9C285 /* KBEnvironment.m in Sources */,
 				00010DD31BE19F8900A9C285 /* KBUsersAppView.m in Sources */,
 				00010D111BE19F8900A9C285 /* KBDebugPropertiesView.m in Sources */,

--- a/osx/KBKit/KBKit/Component/KBFSService.h
+++ b/osx/KBKit/KBKit/Component/KBFSService.h
@@ -11,10 +11,9 @@
 #import "KBComponent.h"
 #import "KBInstallable.h"
 #import "KBEnvConfig.h"
-#import "KBHelperTool.h"
 
 @interface KBFSService : KBInstallable
 
-- (instancetype)initWithConfig:(KBEnvConfig *)config helperTool:(KBHelperTool *)helperTool label:(NSString *)label servicePath:(NSString *)servicePath;
+- (instancetype)initWithConfig:(KBEnvConfig *)config label:(NSString *)label servicePath:(NSString *)servicePath;
 
 @end

--- a/osx/KBKit/KBKit/Component/KBMountDir.h
+++ b/osx/KBKit/KBKit/Component/KBMountDir.h
@@ -1,0 +1,20 @@
+//
+//  KBMountDir.h
+//  KBKit
+//
+//  Created by Gabriel on 8/24/16.
+//  Copyright © 2016 Gabriel Handford. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "KBComponent.h"
+#import "KBInstallable.h"
+#import "KBEnvConfig.h"
+#import "KBHelperTool.h"
+
+@interface KBMountDir : KBInstallable
+
+- (instancetype)initWithConfig:(KBEnvConfig *)config helperTool:(KBHelperTool *)helperTool;
+
+@end

--- a/osx/KBKit/KBKit/Component/KBMountDir.m
+++ b/osx/KBKit/KBKit/Component/KBMountDir.m
@@ -1,0 +1,103 @@
+//
+//  KBMountDir.m
+//  KBKit
+//
+//  Created by Gabriel on 8/24/16.
+//  Copyright © 2016 Gabriel Handford. All rights reserved.
+//
+
+#import "KBMountDir.h"
+
+@interface KBMountDir ()
+@property KBHelperTool *helperTool;
+@property KBEnvConfig *config;
+@end
+
+@implementation KBMountDir
+
+@synthesize error;
+
+- (instancetype)initWithConfig:(KBEnvConfig *)config helperTool:(KBHelperTool *)helperTool {
+  if ((self = [self initWithConfig:config name:@"Mount Directory" info:@"Location for mount directory" image:nil])) {
+    _helperTool = helperTool;
+  }
+  return self;
+}
+
+- (NSString *)name {
+  return @"Mount directory";
+}
+
+- (BOOL)checkMountDirExists {
+  NSString *directory = self.config.mountDir;
+  BOOL exists = [NSFileManager.defaultManager fileExistsAtPath:directory isDirectory:nil];
+  if (!exists) {
+    DDLogDebug(@"Mount directory doesn't exist: %@", directory);
+    return NO;
+  }
+
+  NSError *err = nil;
+  NSDictionary *attributes = [NSFileManager.defaultManager attributesOfItemAtPath:directory error:&err];
+  if (!attributes) {
+    DDLogDebug(@"Mount directory error: %@", error);
+    return NO;
+  }
+
+  // The mount dir might have 0700 permissions if left mounted but unattached to KBFS (owned by user).
+  // And the dir might have 0600 permissions if unmounted (owned by user).
+  // If mounted and attached to KBFS it will have 0755 permissions (owned by root).
+  DDLogDebug(@"Mount directory=%@, attributes=%@", directory, attributes);
+  return YES;
+}
+
+- (void)removeMountDir:(NSString *)mountDir completion:(KBCompletion)completion {
+  // Because the mount dir is in the root path, we need the helper tool to remove it, even if owned by the user
+  NSDictionary *params = @{@"path": mountDir};
+  DDLogDebug(@"Removing mount directory: %@", params);
+  [self.helperTool.helper sendRequest:@"remove" params:@[params] completion:^(NSError *err, id value) {
+    completion(err);
+  }];
+}
+
+- (void)createMountDir:(KBCompletion)completion {
+  uid_t uid = getuid();
+  gid_t gid = getgid();
+  NSNumber *permissions = [NSNumber numberWithShort:0600];
+  NSDictionary *params = @{@"directory": self.config.mountDir, @"uid": @(uid), @"gid": @(gid), @"permissions": permissions, @"excludeFromBackup": @(YES)};
+  DDLogDebug(@"Creating mount directory: %@", params);
+  [self.helperTool.helper sendRequest:@"createDirectory" params:@[params] completion:^(NSError *err, id value) {
+    completion(err);
+  }];
+}
+
+- (NSError *)statusError {
+  return nil;
+}
+
+- (void)install:(KBCompletion)completion {
+  if (![self checkMountDirExists]) {
+    [self createMountDir:^(NSError *err) {
+      if (err) {
+        completion(err);
+        return;
+      }
+      // Run check again after create for debug info
+      [self checkMountDirExists];
+      completion(nil);
+    }];
+  } else {
+    completion(nil);
+  }
+}
+
+- (void)uninstall:(KBCompletion)completion {
+  NSString *mountDir = self.config.mountDir;
+  if (![NSFileManager.defaultManager fileExistsAtPath:mountDir isDirectory:nil]) {
+    DDLogInfo(@"The mount directory doesn't exist: %@", mountDir);
+    completion(nil);
+    return;
+  }
+  [self removeMountDir:mountDir completion:completion];
+}
+
+@end

--- a/osx/KBKit/KBKit/Component/KBMountDir.m
+++ b/osx/KBKit/KBKit/Component/KBMountDir.m
@@ -70,10 +70,6 @@
   }];
 }
 
-- (NSError *)statusError {
-  return nil;
-}
-
 - (void)install:(KBCompletion)completion {
   if (![self checkMountDirExists]) {
     [self createMountDir:^(NSError *err) {

--- a/osx/KBKit/KBKit/KBKit.h
+++ b/osx/KBKit/KBKit/KBKit.h
@@ -55,6 +55,7 @@ FOUNDATION_EXPORT const unsigned char KBKitVersionString[];
 #import <KBKit/KBCommandLine.h>
 #import <KBKit/KBUninstaller.h>
 #import <KBKit/KBAppBundle.h>
+#import <KBKit/KBMountDir.h>
 
 // IO
 #import <KBKit/KBFileReader.h>

--- a/osx/KBKit/KBKit/System/KBEnvironment.h
+++ b/osx/KBKit/KBKit/System/KBEnvironment.h
@@ -20,13 +20,15 @@ typedef NS_OPTIONS (NSUInteger, KBInstallOptions) {
   KBInstallOptionFuse = 1 << 3,
   KBInstallOptionKBFS = 1 << 4,
   KBInstallOptionUpdater = 1 << 5,
+  KBInstallOptionMountDir = 1 << 6,
   KBInstallOptionCLI = 1 << 10,
 
-  KBInstallOptionAll = KBInstallOptionService | KBInstallOptionHelper | KBInstallOptionFuse | KBInstallOptionKBFS | KBInstallOptionUpdater | KBInstallOptionCLI,
+  KBInstallOptionAll = KBInstallOptionService | KBInstallOptionHelper | KBInstallOptionFuse | KBInstallOptionMountDir | KBInstallOptionKBFS | KBInstallOptionUpdater | KBInstallOptionCLI,
 };
 
 @interface KBEnvironment : NSObject
 
+@property (readonly) KBHelperTool *helperTool;
 @property (readonly) KBEnvConfig *config;
 @property (readonly) KBService *service;
 @property (readonly) KBFSService *kbfs;

--- a/osx/Utils/Settings.h
+++ b/osx/Utils/Settings.h
@@ -15,6 +15,7 @@ typedef NS_OPTIONS (NSUInteger, UninstallOptions) {
   UninstallOptionNone = 0,
   UninstallOptionApp = 1 << 0,
   UninstallOptionKext = 1 << 1,
+  UninstallOptionMountDir = 1 << 2,
 };
 
 @interface Settings : NSObject
@@ -24,6 +25,8 @@ typedef NS_OPTIONS (NSUInteger, UninstallOptions) {
 @property (readonly) UninstallOptions uninstallOptions;
 
 - (instancetype)initWithSettings:(GBSettings *)settings;
+
+- (BOOL)parseArgs:(NSError **)error;
 
 - (KBEnvironment *)environment;
 

--- a/osx/Utils/Settings.m
+++ b/osx/Utils/Settings.m
@@ -26,35 +26,46 @@
 
 - (instancetype)initWithSettings:(GBSettings *)settings {
   if ((self = [super init])) {
-    NSArray *args = NSProcessInfo.processInfo.arguments;
     self.settings = settings;
-    GBCommandLineParser *parser = [[GBCommandLineParser alloc] init];
-    [parser registerOption:@"app-path" shortcut:'a' requirement:GBValueRequired];
-    [parser registerOption:@"run-mode" shortcut:'r' requirement:GBValueRequired];
-    [parser registerSwitch:@"uninstall-app"];
-    [parser registerSwitch:@"uninstall-kext"];
-    [parser registerSwitch:@"install-fuse"];
-    [parser registerSettings:self.settings];
-    NSArray *subargs = [args subarrayWithRange:NSMakeRange(1, args.count-1)];
-    [parser parseOptionsWithArguments:subargs commandLine:args[0]];
-    self.runMode = [self.settings objectForKey:@"run-mode"];
-    NSAssert(self.runMode, @"No run mode");
-    self.appPath = [self.settings objectForKey:@"app-path"];
-    NSAssert(self.appPath, @"No app path");
-    if ([[self.settings objectForKey:@"uninstall-app"] boolValue]) {
-      self.uninstallOptions |= UninstallOptionApp;
-    }
-    if ([[self.settings objectForKey:@"uninstall-kext"] boolValue]) {
-      self.uninstallOptions |= UninstallOptionKext;
-    }
-    if ([[self.settings objectForKey:@"install-fuse"] boolValue]) {
-      self.installOptions |= KBInstallOptionFuse;
-    }
-    if (self.installOptions == 0) {
-      self.installOptions = KBInstallOptionAll;
-    }
   }
   return self;
+}
+
+- (BOOL)parseArgs:(NSError **)error {
+  NSArray *args = NSProcessInfo.processInfo.arguments;
+  GBCommandLineParser *parser = [[GBCommandLineParser alloc] init];
+  [parser registerOption:@"app-path" shortcut:'a' requirement:GBValueRequired];
+  [parser registerOption:@"run-mode" shortcut:'r' requirement:GBValueRequired];
+  [parser registerSwitch:@"uninstall-app"];
+  [parser registerSwitch:@"uninstall-kext"];
+  [parser registerSwitch:@"uninstall-mountdir"];
+  [parser registerSwitch:@"install-fuse"];
+  [parser registerSettings:self.settings];
+  NSArray *subargs = [args subarrayWithRange:NSMakeRange(1, args.count-1)];
+  if (![parser parseOptionsWithArguments:subargs commandLine:args[0]]) {
+    if (error) *error = KBMakeError(-1, @"Unable to process arguments");
+    return NO;
+  }
+  self.runMode = [self.settings objectForKey:@"run-mode"];
+  NSAssert(self.runMode, @"No run mode");
+  self.appPath = [self.settings objectForKey:@"app-path"];
+  NSAssert(self.appPath, @"No app path");
+  if ([[self.settings objectForKey:@"uninstall-app"] boolValue]) {
+    self.uninstallOptions |= UninstallOptionApp;
+  }
+  if ([[self.settings objectForKey:@"uninstall-kext"] boolValue]) {
+    self.uninstallOptions |= UninstallOptionKext;
+  }
+  if ([[self.settings objectForKey:@"uninstall-mountdir"] boolValue]) {
+    self.uninstallOptions |= UninstallOptionMountDir;
+  }
+  if ([[self.settings objectForKey:@"install-fuse"] boolValue]) {
+    self.installOptions |= KBInstallOptionFuse;
+  }
+  if (self.installOptions == 0) {
+    self.installOptions = KBInstallOptionAll;
+  }
+  return YES;
 }
 
 - (KBEnvironment *)environment {


### PR DESCRIPTION
_This is code from a branch I made when testing mount directory issues on Sierra. It would be nice to get into master cause it has the mount dir uninstall behavior._

- Removes mount dir when user runs: `keybase uninstall`
- Installer accepts `--uninstall-mountdir` to remove mount dir (`keybase uninstall` calls this)
- Installer now errors if command line arguments are invalid; Otherwise if there was an invalid arg, the default install behavior would occur, which would be undesirable if you were trying to use an uninstall option

This breaks out mount directory creation and removal (install/uninstall) out of `KBFSService` into its own "install component" `KBMountDir`.

I did lots of testing on snapshotted VMs and will do more before this goes out.

