### PR TITLE
Make pvl regex stricter

### DIFF
--- a/go/pvl/hardcoded.go
+++ b/go/pvl/hardcoded.go
@@ -18,73 +18,73 @@ var hardcodedPVLString = `
   "revision": 1,
   "services": {
     "coinbase": [
-      { "assert_regex_match": "/^https://coinbase\\.com/%{username_service}/public-key$/i" },
+      { "assert_regex_match": "^https://coinbase\\.com/%{username_service}/public-key$i" },
       { "fetch": "html" },
       { "selector_css": ["pre.statement", 0] },
       { "assert_find_base64": "sig" }
     ],
-    "dns": [{ "assert_regex_match": "/^keybase-site-verification=%{sig_id_medium}$/" }],
+    "dns": [{ "assert_regex_match": "^keybase-site-verification=%{sig_id_medium}$" }],
     "generic_web_site": [
-      { "assert_regex_match": "/^https?://%{hostname}/(?:\\.well-known/keybase\\.txt|keybase\\.txt)$/i" },
+      { "assert_regex_match": "^https?://%{hostname}/(?:\\.well-known/keybase\\.txt|keybase\\.txt)$i" },
       { "fetch": "string" },
       { "assert_find_base64": "sig" }
     ],
     "github": [
-      { "assert_regex_match": "/^https://gist\\.github(usercontent)?\\.com/%{username_service}/.*$/i" },
+      { "assert_regex_match": "^https://gist\\.github(usercontent)?\\.com/%{username_service}/.*$i" },
       { "fetch": "string" },
       { "assert_find_base64": "sig" }
     ],
     "hackernews": [
       {
-        "assert_regex_match": "/https://hacker-news\\.firebaseio\\.com/v0/user/%{username_service}/about.json/i"
+        "assert_regex_match": "^https://hacker-news\\.firebaseio\\.com/v0/user/%{username_service}/about.json$i"
       },
       { "fetch": "string" },
-      { "assert_regex_match": "/.*%{sig_id_medium}.*/" }
+      { "assert_regex_match": "^.*%{sig_id_medium}.*$" }
     ],
     "reddit": [
-      { "assert_regex_match": "/^https://(:?www\\.)?reddit\\.com/r/keybaseproofs/.*$/i" },
+      { "assert_regex_match": "^https://(:?www\\.)?reddit\\.com/r/keybaseproofs/.*$i" },
       { "fetch": "json" },
       { "selector_json": [0, "kind"] },
-      { "assert_regex_match": "/^Listing$/" },
+      { "assert_regex_match": "^Listing$" },
       { "selector_json": [0, "data", "children", 0, "kind"] },
-      { "assert_regex_match": "/^t3$/" },
+      { "assert_regex_match": "^t3$" },
       { "selector_json": [0, "data", "children", 0, "data", "subreddit"] },
-      { "assert_regex_match": "/^keybaseproofs$/i" },
+      { "assert_regex_match": "^keybaseproofs$i" },
       { "selector_json": [0, "data", "children", 0, "data", "author"] },
-      { "assert_regex_match": "/^%{username_service}$/i" },
+      { "assert_regex_match": "^%{username_service}$i" },
       { "selector_json": [0, "data", "children", 0, "data", "title"] },
-      { "assert_regex_match": "/^.*%{sig_id_medium}.*$/i" },
+      { "assert_regex_match": "^.*%{sig_id_medium}.*$i" },
       { "selector_json": [0, "data", "children", 0, "data", "selftext"] },
       { "assert_find_base64": "sig" }
     ],
     "rooter": [
-      { "assert_regex_match": "/^https?://[\\w:_\\-\\.]+/_/api/1\\.0/rooter/%{username_service}/.*$/i" },
+      { "assert_regex_match": "^https?://[\\w:_\\-\\.]+/_/api/1\\.0/rooter/%{username_service}/.*$i" },
       { "fetch": "json" },
       { "selector_json": ["status", "name"] },
-      { "assert_regex_match": "/ok/i" },
+      { "assert_regex_match": "^ok$i" },
       { "selector_json": ["toot", "post"] },
-      { "assert_regex_match": "/.*%{sig_id_medium}.*/" }
+      { "assert_regex_match": "^.*%{sig_id_medium}.*$" }
     ],
     "twitter": [
-      { "assert_regex_match": "/^https://twitter\\.com/%{username_service}/.*$/i" },
+      { "assert_regex_match": "^https://twitter\\.com/%{username_service}/.*$i" },
       { "fetch": "html" },
       {
         "attr": "data-screen-name",
         "selector_css": ["div.permalink-tweet-container div.permalink-tweet", 0]
       },
-      { "assert_regex_match": "/^%{username_service}$/i" },
+      { "assert_regex_match": "^%{username_service}$i" },
       { "selector_css": ["div.permalink-tweet-container div.permalink-tweet", 0, "p.tweet-text", 0] },
       { "whitespace_normalize": true },
       {
-        "regex_capture": "/^ *(?:@[a-zA-Z0-9_-]+\\s*)* *Verifying myself: I am ([A-Za-z0-9_]+) on Keybase\\.io\\. (?:\\S+) */.*$/i"
+        "regex_capture": "^ *(?:@[a-zA-Z0-9_-]+\\s*)* *Verifying myself: I am ([A-Za-z0-9_]+) on Keybase\\.io\\. (?:\\S+) */.*$i"
       },
-      { "assert_regex_match": "/^%{username_keybase}$/i" },
+      { "assert_regex_match": "^%{username_keybase}$i" },
       { "selector_css": ["div.permalink-tweet-container div.permalink-tweet", 0, "p.tweet-text", 0] },
       { "whitespace_normalize": true },
       {
-        "regex_capture": "/^ *(?:@[a-zA-Z0-9_-]+\\s*)* *Verifying myself: I am (?:[A-Za-z0-9_]+) on Keybase\\.io\\. (\\S+) */.*$/i"
+        "regex_capture": "^ *(?:@[a-zA-Z0-9_-]+\\s*)* *Verifying myself: I am (?:[A-Za-z0-9_]+) on Keybase\\.io\\. (\\S+) */.*$i"
       },
-      { "assert_regex_match": "/^%{sig_id_short}$/" }
+      { "assert_regex_match": "^%{sig_id_short}$" }
     ]
   }
 }

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -816,15 +816,15 @@ func interpretRegex(g ProofContextExt, template string, state ScriptState) (*reg
 	var perr libkb.ProofError = libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 		"Could not build regex %v", template)
 
-	// Parse out side bars and option letters.
-	if !strings.HasPrefix(template, "/") {
+	// Parse out bookends (^$) and option letters.
+	if !strings.HasPrefix(template, "^") {
 		return nil, perr
 	}
-	lastSlash := strings.LastIndex(template, "/")
-	if lastSlash == -1 {
+	lastDollar := strings.LastIndex(template, "$")
+	if lastDollar == -1 {
 		return nil, perr
 	}
-	opts := template[lastSlash+1:]
+	opts := template[lastDollar+1:]
 	if !regexp.MustCompile("[imsU]*").MatchString(opts) {
 		return nil, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 			"Could not build regex: %v (%v)", "invalid options", template)
@@ -843,7 +843,7 @@ func interpretRegex(g ProofContextExt, template string, state ScriptState) (*reg
 	}
 
 	// Do variable interpolation.
-	prepattern, perr := substitute(template[1:lastSlash], state, nil)
+	prepattern, perr := substitute(template[0:lastDollar+1], state, nil)
 	if perr != nil {
 		return nil, perr
 	}


### PR DESCRIPTION
Make the format for regexes in pvl require `^` and `$`. This makes it harder to shoot yourself in the foot and allow match partial strings. With this, to match partial strings you must explicitly put in `.*` like `^.*middle.*$`.

Options now come after the last `$` instead of after the last `/`. Which is weird, but still easy to parse.

old: `"/^https://coinbase\\.com/%{username_service}/public-key$/i"`
new: `"^https://coinbase\\.com/%{username_service}/public-key$i"`

r? @oconnor663 