### PR TITLE
Tweak appearance of engine logs

### DIFF
--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -100,10 +100,10 @@ class Engine {
   _handleCancel (seqid: number) {
     const cancelledSessionID = Object.keys(this._sessionsMap).find(key => this._sessionsMap[key].hasSeqID(seqid))
     if (cancelledSessionID) {
-      rpcLog('engineInternal', 'Received cancel for session', cancelledSessionID)
+      rpcLog('engineInternal', 'received cancel for session', {cancelledSessionID})
       this._sessionsMap[cancelledSessionID].cancel()
     } else {
-      rpcLog('engineInternal', "Received cancel but couldn't find session", cancelledSessionID)
+      rpcLog('engineInternal', "received cancel but couldn't find session", {cancelledSessionID})
     }
   }
 
@@ -138,7 +138,7 @@ class Engine {
       if (session && session.incomingCall(method, param, response)) { // Part of a session?
       } else if (this._incomingHandler[method]) { // General incoming
         const handler = this._incomingHandler[method]
-        rpcLog('engineInternal', 'Handling incoming')
+        rpcLog('engineInternal', 'handling incoming')
         handler(param, response)
       } else { // Unhandled
         this._handleUnhandled(sessionID, method, seqid, param, response)
@@ -175,7 +175,7 @@ class Engine {
     dangling?: boolean = false
   ): Session {
     const sessionID = this._generateSessionID()
-    rpcLog('engineInternal', `Session start ${sessionID}`)
+    rpcLog('engineInternal', 'session start', {sessionID})
 
     const session = new Session(
       sessionID,
@@ -192,7 +192,7 @@ class Engine {
 
   // Cleanup a session that ended
   _sessionEnded (session: Session) {
-    rpcLog('engineInternal', `Session end ${session.id}`)
+    rpcLog('engineInternal', 'session end', {sessionID: session.id})
     delete this._sessionsMap[String(session.id)]
   }
 
@@ -225,10 +225,10 @@ class Engine {
   // Setup a handler for a rpc w/o a session (id = 0)
   setIncomingHandler (method: MethodKey, handler: (param: Object, response: ?Object) => void) {
     if (this._incomingHandler[method]) {
-      rpcLog('engineInternal', "Duplicate incoming handler!!!! This isn't allowed", method)
+      rpcLog('engineInternal', "duplicate incoming handler!!! this isn't allowed", {method})
       return
     }
-    rpcLog('engineInternal', 'Registering incoming handler:', method)
+    rpcLog('engineInternal', 'registering incoming handler:', {method})
     this._incomingHandler[method] = handler
   }
 

--- a/shared/engine/session.js
+++ b/shared/engine/session.js
@@ -60,7 +60,7 @@ class Session {
   // and do internal bookkeeping if the request is done
   _makeWaitingHandler (isOutgoing: boolean, method: MethodKey, seqid: ?number) {
     return (waiting: boolean) => {
-      rpcLog('engineInternal', 'waiting state change', this.id, waiting, method, this, seqid)
+      rpcLog('engineInternal', 'waiting state change', {id: this.id, waiting, method, this: this, seqid})
       // Call the outer handler with all the params it needs
       this._waitingHandler && this._waitingHandler(waiting, method, this._id)
 
@@ -115,7 +115,7 @@ class Session {
       sessionID: this.id,
     }
 
-    rpcLog('engineInternal', 'session start call', this.id, method, this)
+    rpcLog('engineInternal', 'session start call', {id: this.id, method, this: this})
     const outgoingRequest = new OutgoingRequest(method, wrappedParam, wrappedCallback, this._makeWaitingHandler(true, method), this._invoke)
     this._outgoingRequests.push(outgoingRequest)
     outgoingRequest.send()
@@ -123,7 +123,7 @@ class Session {
 
   // We have an incoming call tied to a sessionID, called only by engine
   incomingCall (method: MethodKey, param: Object, response: ?Object): boolean {
-    rpcLog('engineInternal', 'session incoming call', this.id, method, this, response)
+    rpcLog('engineInternal', 'session incoming call', {id: this.id, method, this: this, response})
     const handler = this._incomingCallMap[method]
 
     if (!handler) {


### PR DESCRIPTION
While looking through the console, I found myself scrolling through a lot of long engine lines. I wanted these to be shorter and expandable to make more efficient use of the console space. 

These are some subjective and bikesheddy changes to the appearance of engine logs that I'd like to propose. :angel: 

1. Put extra arguments in an object map so that they are expandable and field names can be inspected
1. Shorten log prefixes to "[engine]" / "[engine] ->" / "[engine] <-" (I feel these are unambiguous when viewing the full content of the log line)
1. Lowercase all message titles

Before:
<img width="1280" alt="screen shot 2016-09-01 at 5 32 53 pm" src="https://cloud.githubusercontent.com/assets/16893/18188863/7c767282-706a-11e6-8d01-b567fd8c9ab8.png">

After:
<img width="1280" alt="screen shot 2016-09-01 at 5 31 53 pm" src="https://cloud.githubusercontent.com/assets/16893/18188869/803622fa-706a-11e6-9eb9-93a19d899fc0.png">

:eyeglasses: :bike: @keybase/react-hackers 