### PR TITLE
Retry bootstrap if it fails

### DIFF
--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -122,7 +122,7 @@ export function bootstrap (): AsyncAction {
       bootstrapSetup = true
       console.log('[bootstrap] registered bootstrap')
       engine().listenOnConnect('bootstrap', () => {
-        console.log('[bootstrap] bootstrapping')
+        console.log('[bootstrap] bootstrapping on connect')
         dispatch(bootstrap())
       })
     } else if (getState().dev.reloading) {

--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -120,16 +120,16 @@ export function bootstrap (): AsyncAction {
   return (dispatch, getState) => {
     if (!bootstrapSetup) {
       bootstrapSetup = true
-      console.log('Registered bootstrap')
+      console.log('[bootstrap] registered bootstrap')
       engine().listenOnConnect('bootstrap', () => {
-        console.log('Bootstrapping')
+        console.log('[bootstrap] bootstrapping')
         dispatch(bootstrap())
       })
     } else if (getState().dev.reloading) {
       // Let's still register the listeners
       dispatch(_registerListeners())
     } else {
-      console.log('Performing bootstrap...')
+      console.log('[bootstrap] performing bootstrap...')
       Promise.all(
         [dispatch(getCurrentStatus()), dispatch(getExtendedStatus()), dispatch(getConfig())]).then(([username]) => {
           if (username) {
@@ -141,15 +141,15 @@ export function bootstrap (): AsyncAction {
           dispatch((resetSignup(): Action))
           dispatch(_registerListeners())
         }).catch(error => {
-          console.warn('Error bootstrapping: ', error)
+          console.warn('[bootstrap] error bootstrapping: ', error)
           const triesRemaining = getState().config.bootstrapTriesRemaining
           dispatch({type: Constants.bootstrapFailed, payload: null})
           if (triesRemaining > 0) {
             const retryDelay = Constants.bootstrapRetryDelay / triesRemaining
-            console.log(`Resetting engine in ${retryDelay / 1000}s (${triesRemaining} tries left)`)
+            console.log(`[bootstrap] resetting engine in ${retryDelay / 1000}s (${triesRemaining} tries left)`)
             setTimeout(() => engine().reset(), retryDelay)
           } else {
-            console.error('Exhausted bootstrap retries')
+            console.error('[bootstrap] exhausted bootstrap retries')
           }
         })
     }

--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -146,8 +146,8 @@ export function bootstrap (): AsyncAction {
           dispatch({type: Constants.bootstrapFailed, payload: null})
           if (triesRemaining > 0) {
             const retryDelay = Constants.bootstrapRetryDelay / triesRemaining
-            console.log(`Retrying bootstrap in ${retryDelay / 1000}s (${triesRemaining} tries left)`)
-            setTimeout(() => dispatch(bootstrap()), retryDelay)
+            console.log(`Resetting engine in ${retryDelay / 1000}s (${triesRemaining} tries left)`)
+            setTimeout(() => engine().reset(), retryDelay)
           } else {
             console.error('Exhausted bootstrap retries')
           }

--- a/shared/constants/config.js
+++ b/shared/constants/config.js
@@ -12,6 +12,7 @@ export const statusLoaded = 'config:statusLoaded'
 export const configLoaded = 'config:configLoaded'
 export const extendedConfigLoaded = 'config:extendedConfigLoaded'
 export const bootstrapped = 'config:bootstrapped'
+export const bootstrapFailed = 'config:bootstrapFailed'
 export const updateFollowing = 'config:updateFollowing'
 export const updateFollowers = 'config:updateFollowers'
 
@@ -23,6 +24,9 @@ export const devConfigLoading = 'config:devConfigLoading'
 export const devConfigLoaded = 'config:devConfigLoaded'
 export const devConfigUpdate = 'config:devConfigUpdate'
 export const devConfigSaved = 'config:devConfigSaved'
+
+export const MAX_BOOTSTRAP_TRIES = 3
+export const bootstrapRetryDelay = 10 * 1000
 
 export function privateFolderWithUsers (users: Array<string>): string {
   return `${defaultKBFSPath}${defaultPrivatePrefix}${uniq(users).join(',')}`

--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -218,8 +218,7 @@ class Engine {
     if (isMobile) {
       return
     }
-    resetClient()
-    this._setupClient()
+    resetClient(this._rpcClient)
   }
 
   // Setup a handler for a rpc w/o a session (id = 0)

--- a/shared/engine/index.platform.desktop.js
+++ b/shared/engine/index.platform.desktop.js
@@ -1,6 +1,6 @@
 // @flow
 import net from 'net'
-import type {incomingRPCCallbackType, connectCallbackType} from './index.platform'
+import type {createClientType, incomingRPCCallbackType, connectCallbackType} from './index.platform'
 import {TransportShared, sharedCreateClient, rpcLog} from './transport-shared'
 import {socketPath} from '../constants/platform.specific.desktop'
 
@@ -39,8 +39,9 @@ function createClient (incomingRPCCallback: incomingRPCCallbackType, connectCall
   return sharedCreateClient(new NativeTransport(incomingRPCCallback, connectCallback))
 }
 
-// Resets are handled internally by framed-msg-pack
-function resetClient () { }
+function resetClient (client: createClientType) {
+  client.transport.reset()
+}
 
 export {
   resetClient,

--- a/shared/engine/index.platform.js.flow
+++ b/shared/engine/index.platform.js.flow
@@ -9,6 +9,7 @@ export type invokeType = (method: string, param: ?Object, cb: (err: any, data: a
 export type createClientType = {
   transport: {
     needsConnect: boolean,
+    reset: () => void,
   },
   invoke: invokeType,
 };

--- a/shared/reducers/config.js
+++ b/shared/reducers/config.js
@@ -16,6 +16,7 @@ export type ConfigState = {
   kbfsPath: string,
   error: ?any,
   devConfig: ?any,
+  bootstrapTriesRemaining: number,
   bootstrapped: number,
   followers: {[key: string]: true},
   following: {[key: string]: true},
@@ -31,6 +32,7 @@ const initialState: ConfigState = {
   kbfsPath: Constants.defaultKBFSPath,
   error: null,
   devConfig: null,
+  bootstrapTriesRemaining: Constants.MAX_BOOTSTRAP_TRIES,
   bootstrapped: 0,
   followers: {},
   following: {},
@@ -108,9 +110,17 @@ export default function (state: ConfigState = initialState, action: Action): Con
         },
       }
 
+    case Constants.bootstrapFailed: {
+      return {
+        ...state,
+        bootstrapTriesRemaining: state.bootstrapTriesRemaining - 1,
+      }
+    }
+
     case Constants.bootstrapped: {
       return {
         ...state,
+        bootstrapTriesRemaining: Constants.MAX_BOOTSTRAP_TRIES,
         bootstrapped: state.bootstrapped + 1,
       }
     }


### PR DESCRIPTION
This will retry the bootstrap 3 times, with increasing delay (3s, 5s, then 10s). This doesn't improve the UX of the bootstrap finally failing, though -- should we ticket that separately, or should I follow this up with another PR for indicating failure to the user?

:eyeglasses: @keybase/react-hackers 