### PR TITLE
Retry/timeout fixes for for helper tool (XPC client)

### DIFF
--- a/osx/Podfile
+++ b/osx/Podfile
@@ -3,7 +3,7 @@ target "Installer" do
   pod "ObjectiveSugar"
   pod "GBCli"
   pod "Slash"
-  pod "MPMessagePack", :path => "~/Projects/MPMessagePack"
+  pod "MPMessagePack"
   pod "KBKit", :path => "KBKit"
 end
 
@@ -13,7 +13,7 @@ target "Status" do
   pod "ObjectiveSugar"
   pod "GBCli"
   pod "Slash"
-  pod "MPMessagePack", :path => "~/Projects/MPMessagePack"
+  pod "MPMessagePack"
   pod "KBKit", :path => "KBKit"
 end
 
@@ -21,5 +21,5 @@ end
 # here to a minimum.
 target "keybase.Helper" do
   platform :osx, "10.10"
-  pod "MPMessagePack", :path => "~/Projects/MPMessagePack"
+  pod "MPMessagePack"
 end

--- a/osx/Podfile
+++ b/osx/Podfile
@@ -3,7 +3,7 @@ target "Installer" do
   pod "ObjectiveSugar"
   pod "GBCli"
   pod "Slash"
-  pod "MPMessagePack"
+  pod "MPMessagePack", :path => "~/Projects/MPMessagePack"
   pod "KBKit", :path => "KBKit"
 end
 
@@ -13,7 +13,7 @@ target "Status" do
   pod "ObjectiveSugar"
   pod "GBCli"
   pod "Slash"
-  pod "MPMessagePack"
+  pod "MPMessagePack", :path => "~/Projects/MPMessagePack"
   pod "KBKit", :path => "KBKit"
 end
 
@@ -21,5 +21,5 @@ end
 # here to a minimum.
 target "keybase.Helper" do
   platform :osx, "10.10"
-  pod "MPMessagePack"
+  pod "MPMessagePack", :path => "~/Projects/MPMessagePack"
 end

--- a/osx/Podfile.lock
+++ b/osx/Podfile.lock
@@ -45,7 +45,7 @@ PODS:
     - Mantle/extobjc (= 2.0.7)
   - Mantle/extobjc (2.0.7)
   - MDPSplitView (1.0.2)
-  - MPMessagePack (1.3.8):
+  - MPMessagePack (1.3.11):
     - GHODictionary
   - ObjectiveSugar (1.1.0)
   - Slash (0.1.4)
@@ -79,7 +79,7 @@ SPEC CHECKSUMS:
   KBKit: 9f139696e2cd916f05ee603e33aabfd558ac8ccd
   Mantle: bc40bb061d8c2c6fb48d5083e04d928c3b7f73d9
   MDPSplitView: 127b4b371e813ec29333e515fb1c057126a75671
-  MPMessagePack: 7744c19284340b5f24986d581c0f21076461fbef
+  MPMessagePack: 71e6be8e3c058b521c5ddaaa54c8b9191ef4b59d
   ObjectiveSugar: a6a25f23d657c19df0a0b972466d5b5ca9f5295c
   Slash: 7184f2a98e13ad62303037db3a706c88e98b197e
   Tikppa: 5174130e6bae70e8b2b0c93bc2efca4927d34ac6


### PR DESCRIPTION
There were some bugs in the MPMessagePack library XPC client retry/timeout code that could cause multiple error responses to be returned.

- Using the new XPC client fixes these issues, we can avoid closing and using new helper for every RPC call
- We enable retry and timeout for all XPC requests
- Include logging on XPC calls

I ran some fuzz testing on it... nuking the helper amid a request loop, etc.