### PR TITLE
Fix Web Proof: Remove ToLower()

### DIFF
--- a/go/externals/proof_support_web.go
+++ b/go/externals/proof_support_web.go
@@ -46,7 +46,7 @@ func (rc *WebChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libkb.P
 
 	files := webKeybaseFiles
 	urlBase := rc.proof.ToDisplayString()
-	theirURL := strings.ToLower(h.GetAPIURL())
+	theirURL := h.GetAPIURL()
 
 	for _, file := range files {
 		ourURL := urlBase + "/" + file


### PR DESCRIPTION
Full URLs are actually case sensitive, see [W3 HTML4.0 spec](https://www.w3.org/TR/WD-html40-970708/htmlweb.html). So transforming the `SigHint` API url is actually not an ideal solution, besides that it is hard-wired to two paths for `keybase.txt` to find anyway.

On the other hand, the string causing the problem is the part in `urlBase` which are *in the case of DNS names* **case insensitve**. But I don't know what you may allow to feed into `urlBase` (or better `rc.proof`): if it is really just a dns name or actually protocol + dns name + root path-something in the future, but just casting *everything* to lowercase as a solution looks a bit odd to me.

Nevertheless, maybe we want to transform `urlBase` `strings.ToLower()` instead assuming the assumption above holds true. But I think it's not necessary, encoding cleaning might be more useful at this (or a previous) point.

This fixes
  https://github.com/keybase/keybase-issues/issues/2546

in the failing web proof in `keybase id <someOne>`.

Needs also to be fixed in the copied code of it in the [kbfs codebase](https://github.com/keybase/kbfs/blob/ebd61c479834ede296e58c2c1e0473805934d8ce/vendor/github.com/keybase/client/go/externals/proof_support_web.go#L48-L56), but let us find a solution here first.