### PR TITLE
Add pvl instruction tests

### DIFF
--- a/go/engine/scanproofs.go
+++ b/go/engine/scanproofs.go
@@ -323,7 +323,8 @@ func (e *ScanProofsEngine) CheckOne(rec map[string]string, forcepvl bool) (libkb
 	}
 
 	if forcepvl {
-		perr := pvl.CheckProof(e.G(), pvl.GetHardcodedPvl(), link.GetProofType(), link, *hint)
+		perr := pvl.CheckProof(e.G(), pvl.GetHardcodedPvl(), link.GetProofType(),
+			pvl.NewProofInfo(link, *hint))
 		return perr, nil
 	}
 

--- a/go/externals/proof_support_coinbase.go
+++ b/go/externals/proof_support_coinbase.go
@@ -45,7 +45,8 @@ func (rc *CoinbaseChecker) GetTorError() libkb.ProofError { return nil }
 
 func (rc *CoinbaseChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_COINBASE, rc.proof, h)
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_COINBASE,
+			pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)
 }

--- a/go/externals/proof_support_dns.go
+++ b/go/externals/proof_support_dns.go
@@ -67,7 +67,8 @@ func (rc *DNSChecker) CheckDomain(ctx libkb.ProofContext, sig string, domain str
 
 func (rc *DNSChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_DNS, rc.proof, h)
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_DNS,
+			pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)
 }

--- a/go/externals/proof_support_github.go
+++ b/go/externals/proof_support_github.go
@@ -43,7 +43,8 @@ func (rc *GithubChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libk
 
 func (rc *GithubChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_GITHUB, rc.proof, h)
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_GITHUB,
+			pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)
 }

--- a/go/externals/proof_support_hackernews.go
+++ b/go/externals/proof_support_hackernews.go
@@ -61,7 +61,8 @@ func (h *HackerNewsChecker) CheckHint(ctx libkb.ProofContext, hint libkb.SigHint
 
 func (h *HackerNewsChecker) CheckStatus(ctx libkb.ProofContext, hint libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_HACKERNEWS, h.proof, hint)
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_HACKERNEWS,
+			pvl.NewProofInfo(h.proof, hint))
 	}
 	return h.CheckStatusOld(ctx, hint)
 }

--- a/go/externals/proof_support_reddit.go
+++ b/go/externals/proof_support_reddit.go
@@ -114,7 +114,8 @@ func (rc *RedditChecker) CheckData(h libkb.SigHint, dat *jsonw.Wrapper) libkb.Pr
 
 func (rc *RedditChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_REDDIT, rc.proof, h)
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_REDDIT,
+			pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)
 }

--- a/go/externals/proof_support_rooter.go
+++ b/go/externals/proof_support_rooter.go
@@ -130,7 +130,8 @@ func (rc *RooterChecker) rewriteURL(ctx libkb.ProofContext, s string) (string, e
 
 func (rc *RooterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) (perr libkb.ProofError) {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_ROOTER, rc.proof, h)
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_ROOTER,
+			pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)
 }

--- a/go/externals/proof_support_twitter.go
+++ b/go/externals/proof_support_twitter.go
@@ -87,7 +87,8 @@ func (rc *TwitterChecker) findSigInTweet(ctx libkb.ProofContext, h libkb.SigHint
 
 func (rc *TwitterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_TWITTER, rc.proof, h)
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_TWITTER,
+			pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)
 }

--- a/go/externals/proof_support_web.go
+++ b/go/externals/proof_support_web.go
@@ -62,7 +62,8 @@ func (rc *WebChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libkb.P
 
 func (rc *WebChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_GENERIC_WEB_SITE, rc.proof, h)
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_GENERIC_WEB_SITE,
+			pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)
 }

--- a/go/libkb/util_test.go
+++ b/go/libkb/util_test.go
@@ -49,6 +49,8 @@ func TestWhitespaceNormalize(t *testing.T) {
 	}{
 		{" ab   cd    ef   gh ", "ab cd ef gh"},
 		{"a\nb  c\nd", "a b c d"},
+		{" a ", "a"},
+		{"\na\nb ", "a b"},
 		{
 			" Verifying myself: I am pomf on Keybase.io. 8a6cewzit2o7zuLKGbDqQADhzfOlGerGuBpq\n/ https://keybase.io/pomf/sigs/8a6cewzit2o7zuLKGbDqQADhzfOlGerGuBpq ",
 			"Verifying myself: I am pomf on Keybase.io. 8a6cewzit2o7zuLKGbDqQADhzfOlGerGuBpq / https://keybase.io/pomf/sigs/8a6cewzit2o7zuLKGbDqQADhzfOlGerGuBpq",

--- a/go/pvl/api_stub.go
+++ b/go/pvl/api_stub.go
@@ -1,0 +1,136 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build !production
+
+package pvl
+
+import (
+	"fmt"
+
+	libkb "github.com/keybase/client/go/libkb"
+)
+
+type StubAPIEngine struct {
+	expectations map[string]stubAPIEngineExpectation
+	calls        []stubAPIEngineCallRecord
+}
+
+type stubAPIEngineExpectation struct {
+	JSON *libkb.ExternalAPIRes
+	HTML *libkb.ExternalHTMLRes
+	Text *libkb.ExternalTextRes
+}
+
+type stubAPIEngineCallRecord struct {
+	kind     libkb.XAPIResType
+	endpoint string
+}
+
+func NewStubAPIEngine() *StubAPIEngine {
+	return &StubAPIEngine{
+		expectations: make(map[string]stubAPIEngineExpectation),
+		calls:        make([]stubAPIEngineCallRecord, 0),
+	}
+}
+
+func (e *StubAPIEngine) Get(arg libkb.APIArg) (*libkb.ExternalAPIRes, error) {
+	res, _, _, err := e.getMock(arg, libkb.XAPIResJSON)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+
+}
+
+func (e *StubAPIEngine) GetHTML(arg libkb.APIArg) (*libkb.ExternalHTMLRes, error) {
+	_, res, _, err := e.getMock(arg, libkb.XAPIResHTML)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (e *StubAPIEngine) GetText(arg libkb.APIArg) (*libkb.ExternalTextRes, error) {
+	_, _, res, err := e.getMock(arg, libkb.XAPIResText)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (e *StubAPIEngine) Post(arg libkb.APIArg) (*libkb.ExternalAPIRes, error) {
+	return nil, fmt.Errorf("unsupported operation Post for stub api")
+}
+
+func (e *StubAPIEngine) PostHTML(arg libkb.APIArg) (*libkb.ExternalHTMLRes, error) {
+	return nil, fmt.Errorf("unsupported operation Post for stub api")
+}
+
+func (e *StubAPIEngine) Set(endpoint string, canned *libkb.ExternalAPIRes) {
+	e.setCommon(endpoint, canned, nil, nil)
+}
+
+func (e *StubAPIEngine) SetHTML(endpoint string, canned *libkb.ExternalHTMLRes) {
+	e.setCommon(endpoint, nil, canned, nil)
+}
+
+func (e *StubAPIEngine) SetText(endpoint string, canned *libkb.ExternalTextRes) {
+	e.setCommon(endpoint, nil, nil, canned)
+}
+
+func (e *StubAPIEngine) setCommon(endpoint string, e1 *libkb.ExternalAPIRes, e2 *libkb.ExternalHTMLRes, e3 *libkb.ExternalTextRes) {
+	entry := e.expectations[endpoint]
+	if e1 != nil {
+		entry.JSON = e1
+	}
+	if e2 != nil {
+		entry.HTML = e2
+	}
+	if e3 != nil {
+		entry.Text = e3
+	}
+	e.expectations[endpoint] = entry
+}
+
+func (e *StubAPIEngine) ResetCalls() {
+	e.calls = make([]stubAPIEngineCallRecord, 0)
+}
+
+func (e *StubAPIEngine) AssertCalledOnceWith(kind libkb.XAPIResType, endpoint string) error {
+	if len(e.calls) == 0 {
+		return fmt.Errorf("stub api not called")
+	}
+	if len(e.calls) > 1 {
+		return fmt.Errorf("stub api called more than once")
+	}
+	call := e.calls[0]
+	expected := stubAPIEngineCallRecord{kind, endpoint}
+	if call != expected {
+		return fmt.Errorf("stub api called with wrong arguments\n  expected:  %v %v\ngot: %v %v",
+			expected.kind, expected.endpoint, call.kind, call.endpoint)
+	}
+	return nil
+}
+
+func (e *StubAPIEngine) getMock(arg libkb.APIArg, restype libkb.XAPIResType) (
+	*libkb.ExternalAPIRes, *libkb.ExternalHTMLRes, *libkb.ExternalTextRes, error) {
+	e.calls = append(e.calls, stubAPIEngineCallRecord{
+		kind:     restype,
+		endpoint: arg.Endpoint,
+	})
+
+	entry := e.expectations[arg.Endpoint]
+	okjson := entry.JSON != nil
+	okhtml := entry.HTML != nil
+	oktext := entry.Text != nil
+
+	ok := (okjson || (restype != libkb.XAPIResJSON)) &&
+		(okhtml || (restype != libkb.XAPIResHTML)) &&
+		(oktext || (restype != libkb.XAPIResText))
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("unexpected api call: %v %v", restype, arg.Endpoint)
+	}
+
+	return entry.JSON, entry.HTML, entry.Text, nil
+}

--- a/go/pvl/hardcoded.go
+++ b/go/pvl/hardcoded.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
 package pvl

--- a/go/pvl/helpers.go
+++ b/go/pvl/helpers.go
@@ -159,10 +159,6 @@ func jsonStringSimple(object *jsonw.Wrapper) (string, error) {
 		}
 		return "false", nil
 	}
-	isnil := object.IsNil()
-	if isnil {
-		return "null", nil
-	}
 
 	return "", fmt.Errorf("Non-simple object: %v", object)
 }
@@ -184,4 +180,20 @@ func selectionContents(selection *goquery.Selection, useAttr bool, attr string) 
 	})
 
 	return strings.Join(results, " ")
+}
+
+// pyindex converts an index into a real index like python.
+// Returns an index to use and whether the index is safe to use.
+func pyindex(index, len int) (int, bool) {
+	if len <= 0 {
+		return 0, false
+	}
+	// wrap from the end
+	if index < 0 {
+		index = len + index
+	}
+	if index < 0 || index >= len {
+		return 0, false
+	}
+	return index, true
 }

--- a/go/pvl/helpers.go
+++ b/go/pvl/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
 package pvl

--- a/go/pvl/helpers_test.go
+++ b/go/pvl/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
 package pvl

--- a/go/pvl/helpers_test.go
+++ b/go/pvl/helpers_test.go
@@ -275,7 +275,7 @@ var jsonStringSimpleTests = []jsonStringSimpleTest{
 	{true, makeJSONDangerous(`"hey"`), "hey"},
 	{true, makeJSONDangerous("true"), "true"},
 	{true, makeJSONDangerous("false"), "false"},
-	{true, makeJSONDangerous("null"), "null"},
+	{false, makeJSONDangerous("null"), ""},
 	{false, makeJSONDangerous(`{"a": "b", "1": 2}`), ""},
 	{false, makeJSONDangerous(`[1, {"a": "b"}, "three"]`), ""},
 }
@@ -321,6 +321,34 @@ func TestSelectionContents(t *testing.T) {
 		out := selectionContents(sel, test.useAttr, test.attr)
 		if out != test.out {
 			t.Fatalf("%v mismatch\n%v\n%v", i, out, test.out)
+		}
+	}
+}
+
+func TestPyindex(t *testing.T) {
+	tests := []struct {
+		index int
+		len   int
+		x     int
+		ok    bool
+	}{
+		{0, 0, 0, false},
+		{0, -1, 0, false},
+		{0, 4, 0, true},
+		{3, 4, 3, true},
+		{4, 4, 0, false},
+		{5, 4, 0, false},
+		{-1, 4, 3, true},
+		{-2, 4, 2, true},
+		{-4, 4, 0, true},
+		{-5, 4, 0, false},
+	}
+
+	for i, test := range tests {
+		x, ok := pyindex(test.index, test.len)
+		if (x != test.x) || (ok != test.ok) {
+			t.Fatalf("%v mismatch (%v, %v):\n  expected %v %v\n  got %v %v",
+				i, test.index, test.len, test.x, test.ok, x, ok)
 		}
 	}
 }

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
 package pvl

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -95,22 +95,42 @@ var Steps = map[CommandName]Step{
 	CmdTransformURL:        stepTransformURL,
 }
 
+// ProofInfo contains all the data about a proof PVL needs to check it.
+// It can be derived from a RemoteProofChainLink and SigHint.
+type ProofInfo struct {
+	ArmoredSig     string
+	Username       string
+	RemoteUsername string
+	Hostname       string
+	APIURL         string
+}
+
+func NewProofInfo(link libkb.RemoteProofChainLink, h libkb.SigHint) ProofInfo {
+	return ProofInfo{
+		ArmoredSig:     link.GetArmoredSig(),
+		RemoteUsername: link.GetRemoteUsername(),
+		Username:       link.GetUsername(),
+		Hostname:       link.GetHostname(),
+		APIURL:         h.GetAPIURL(),
+	}
+}
+
 // Checkproof verifies one proof by running the pvl on the provided proof information.
-func CheckProof(g1 libkb.ProofContext, pvl *jsonw.Wrapper, service keybase1.ProofType, link libkb.RemoteProofChainLink, h libkb.SigHint) libkb.ProofError {
+func CheckProof(g1 libkb.ProofContext, pvl *jsonw.Wrapper, service keybase1.ProofType, info ProofInfo) libkb.ProofError {
 	g := NewProofContextExt(g1)
-	perr := checkProofInner(g, pvl, service, link, h)
+	perr := checkProofInner(g, pvl, service, info)
 	if perr != nil {
 		debug(g, "CheckProof failed: %v", perr)
 	}
 	return perr
 }
 
-func checkProofInner(g ProofContextExt, pvl *jsonw.Wrapper, service keybase1.ProofType, link libkb.RemoteProofChainLink, h libkb.SigHint) libkb.ProofError {
+func checkProofInner(g ProofContextExt, pvl *jsonw.Wrapper, service keybase1.ProofType, info ProofInfo) libkb.ProofError {
 	if perr := validateChunk(g, pvl, service); perr != nil {
 		return perr
 	}
 
-	sigBody, sigID, err := libkb.OpenSig(link.GetArmoredSig())
+	sigBody, sigID, err := libkb.OpenSig(info.ArmoredSig)
 	if err != nil {
 		return libkb.NewProofError(keybase1.ProofStatus_BAD_SIGNATURE,
 			"Bad signature: %v", err)
@@ -123,12 +143,12 @@ func checkProofInner(g ProofContextExt, pvl *jsonw.Wrapper, service keybase1.Pro
 
 	newstate := func(i int) ScriptState {
 		vars := ScriptVariables{
-			UsernameService: link.GetRemoteUsername(), // Blank for DNS-proofs
-			UsernameKeybase: link.GetUsername(),
+			UsernameService: info.RemoteUsername, // Blank for DNS-proofs
+			UsernameKeybase: info.Username,
 			Sig:             sigBody,
 			SigIDMedium:     sigID.ToMediumID(),
 			SigIDShort:      sigID.ToShortID(),
-			Hostname:        link.GetHostname(), // Blank for non-{DNS/Web} proofs
+			Hostname:        info.Hostname, // Blank for non-{DNS/Web} proofs
 		}
 
 		// Enforce prooftype-dependent variables.
@@ -144,8 +164,8 @@ func checkProofInner(g ProofContextExt, pvl *jsonw.Wrapper, service keybase1.Pro
 			PC:           0,
 			Service:      service,
 			Vars:         vars,
-			ActiveString: h.GetAPIURL(),
-			FetchURL:     h.GetAPIURL(),
+			ActiveString: info.APIURL,
+			FetchURL:     info.APIURL,
 			HasFetched:   false,
 			FetchResult:  nil,
 		}
@@ -498,7 +518,8 @@ func stepAssertRegexMatch(g ProofContextExt, ins *jsonw.Wrapper, state ScriptSta
 		return state, err
 	}
 	if !re.MatchString(state.ActiveString) {
-		debugWithState(g, state, "Regex did not match:\n  %v\n  %v\n  %v", rdesc.Template, re, state.ActiveString)
+		debugWithState(g, state, "Regex did not match:\n  %v\n  %v\n  %v",
+			rdesc.Template, re, state.ActiveString)
 		return state, libkb.NewProofError(keybase1.ProofStatus_CONTENT_FAILURE,
 			"Regex did not match (%v)", rdesc.Template)
 	}
@@ -657,8 +678,13 @@ func stepSelectorCSS(g ProofContextExt, ins *jsonw.Wrapper, state ScriptState) (
 	useAttr := err == nil
 
 	// Whether the final selection can contain multiple elements.
-	multi, err := ins.AtKey("multi").GetBool()
-	multi = multi && err == nil
+	multinil := ins.AtKey("multi").IsNil()
+	multi, multierr := ins.AtKey("multi").GetBool()
+	if !multinil && multierr != nil {
+		return state, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
+			"CSS selector multi option must be a bool: %v", multierr)
+	}
+	multi = !multinil && multi
 
 	selection, perr := runCSSSelectorInner(g, state.FetchResult.HTML.Selection, selectors)
 	if perr != nil {
@@ -699,8 +725,7 @@ func stepTransformURL(g ProofContextExt, ins *jsonw.Wrapper, state ScriptState) 
 
 	match := re.FindStringSubmatch(state.FetchURL)
 	if len(match) < 1 {
-		libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
-			"Regex transform did not match:\n  %v\n  %v\n  %v",
+		debugWithState(g, state, "Regex transform did not match:\n  %v\n  %v\n  %v",
 			sourceRdesc.Template, re, state.FetchURL)
 		return state, libkb.NewProofError(keybase1.ProofStatus_CONTENT_FAILURE,
 			"Regex transform did not match: %v", sourceRdesc.Template)
@@ -766,7 +791,7 @@ func runSelectorJSONInner(g ProofContextExt, state ScriptState, object *jsonw.Wr
 		s, err := jsonStringSimple(object)
 		if err != nil {
 			debugWithState(g, state, "JSON could not read object: %v (%v)", err, object)
-			return make([]string, 0), nil
+			return []string{}, nil
 		}
 		return []string{s}, nil
 	}
@@ -788,8 +813,16 @@ func runSelectorJSONInner(g ProofContextExt, state ScriptState, object *jsonw.Wr
 			debugWithState(g, state, "JSON select by index from non-array: %v (%v) (%v)", err, selectorIndex, object)
 			return []string{}, nil
 		}
+		length, err := object.Len()
+		if err != nil {
+			return []string{}, nil
+		}
 
-		nextobject := object.AtIndex(selectorIndex)
+		index, ok := pyindex(selectorIndex, length)
+		if !ok || index < 0 {
+			return []string{}, nil
+		}
+		nextobject := object.AtIndex(index)
 		return runSelectorJSONInner(g, state, nextobject, nextselectors)
 	case selectorIsKey:
 		object, err := object.ToDictionary()
@@ -814,6 +847,7 @@ func runSelectorJSONInner(g ProofContextExt, state ScriptState, object *jsonw.Wr
 			}
 			results = append(results, innerresults...)
 		}
+		return results, nil
 	}
 	return []string{}, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 		"Selector entry not recognized: %v", selector)

--- a/go/pvl/interp_data_for_test.go
+++ b/go/pvl/interp_data_for_test.go
@@ -1,0 +1,58 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package pvl
+
+var sig1 = "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgDF5p5xwkO9EIez5YMoECuOUAXvCPRctPH+sUNyTD23sKp3BheWxvYWTFAvJ7ImJvZHkiOnsia2V5Ijp7ImVsZGVzdF9raWQiOiIwMTIwMGM1ZTY5ZTcxYzI0M2JkMTA4N2IzZTU4MzI4MTAyYjhlNTAwNWVmMDhmNDVjYjRmMWZlYjE0MzcyNGMzZGI3YjBhIiwiaG9zdCI6ImtleWJhc2UuaW8iLCJraWQiOiIwMTIwMGM1ZTY5ZTcxYzI0M2JkMTA4N2IzZTU4MzI4MTAyYjhlNTAwNWVmMDhmNDVjYjRmMWZlYjE0MzcyNGMzZGI3YjBhIiwidWlkIjoiYmFhZDNkNDY0NWEzMDQ3NmQyZmE5N2U4MzY0NjY2MTkiLCJ1c2VybmFtZSI6InRlc3RlcnJhbHBoIn0sInNlcnZpY2UiOnsibmFtZSI6InR3aXR0ZXIiLCJ1c2VybmFtZSI6InRlc3RlcnJhbHBoIn0sInR5cGUiOiJ3ZWJfc2VydmljZV9iaW5kaW5nIiwidmVyc2lvbiI6MX0sImNsaWVudCI6eyJuYW1lIjoia2V5YmFzZS5pbyBnbyBjbGllbnQiLCJ2ZXJzaW9uIjoiMS4wLjQifSwiY3RpbWUiOjE0NDg5ODgxNTUsImV4cGlyZV9pbiI6NTA0NTc2MDAwLCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTQ0ODk4ODEzNywiaGFzaCI6IjAwMjhkNTY2NDczNmM4NGEzMGFmZDZmZmI4M2M4NGYzNjk2YjVlZTNlMmUzYjMyNmMyODY1ZTViYWIzYzAyYzFjY2U5ZGI2YTM3ZjU1ZWU1YmNiNmNlNzAzODY1ZmViZTA2M2U4YWFhZGE0ZWM5ZWJlNjI5OTIzYTA3OWRhYmUzIiwic2Vxbm8iOjMyODE4OX0sInByZXYiOiIwMzlhMzhiZTVhMjAzZWU0ODk3NDQ4NDMyMTMxNmFkMTJhOGI4ODQyNjZhN2UwMmM5MzI3N2YyYTEzNGY0ZDBlIiwic2Vxbm8iOjYsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RAVRhCtS9bupx1LdKkuXreFzRQyOyKTslTDpb0rGbx07XSZh7/vj1AZw3eLJnJsrc9DujP0gdgYjlz4i2DNLacAahzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B"
+var sig1IDmedium = "9JHQ8ZNOFRORQUpmH0jLbNbFClOccMEghH5lmQsP4Sk"
+var sig1IDshort = "9JHQ8ZNOFRORQUpmH0jLbNbFClOccMEghH5l"
+
+var info1 = ProofInfo{
+	ArmoredSig:     sig1,
+	Username:       "kronk",
+	RemoteUsername: "kronkinator",
+	Hostname:       "kronk.example.com",
+	APIURL:         "https://rooter.example.com/proofs/kronkinator/5.htjsxt",
+}
+
+var html1 = `
+<html>
+<head>
+<title>proofer</title>
+</head>
+<body>
+	<div class="twit">
+	goodproof
+	g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgDF5p5xwkO9EIez5YMoECuOUAXvCPRctPH+sUNyTD23sKp3BheWxvYWTFAvJ7ImJvZHkiOnsia2V5Ijp7ImVsZGVzdF9raWQiOiIwMTIwMGM1ZTY5ZTcxYzI0M2JkMTA4N2IzZTU4MzI4MTAyYjhlNTAwNWVmMDhmNDVjYjRmMWZlYjE0MzcyNGMzZGI3YjBhIiwiaG9zdCI6ImtleWJhc2UuaW8iLCJraWQiOiIwMTIwMGM1ZTY5ZTcxYzI0M2JkMTA4N2IzZTU4MzI4MTAyYjhlNTAwNWVmMDhmNDVjYjRmMWZlYjE0MzcyNGMzZGI3YjBhIiwidWlkIjoiYmFhZDNkNDY0NWEzMDQ3NmQyZmE5N2U4MzY0NjY2MTkiLCJ1c2VybmFtZSI6InRlc3RlcnJhbHBoIn0sInNlcnZpY2UiOnsibmFtZSI6InR3aXR0ZXIiLCJ1c2VybmFtZSI6InRlc3RlcnJhbHBoIn0sInR5cGUiOiJ3ZWJfc2VydmljZV9iaW5kaW5nIiwidmVyc2lvbiI6MX0sImNsaWVudCI6eyJuYW1lIjoia2V5YmFzZS5pbyBnbyBjbGllbnQiLCJ2ZXJzaW9uIjoiMS4wLjQifSwiY3RpbWUiOjE0NDg5ODgxNTUsImV4cGlyZV9pbiI6NTA0NTc2MDAwLCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTQ0ODk4ODEzNywiaGFzaCI6IjAwMjhkNTY2NDczNmM4NGEzMGFmZDZmZmI4M2M4NGYzNjk2YjVlZTNlMmUzYjMyNmMyODY1ZTViYWIzYzAyYzFjY2U5ZGI2YTM3ZjU1ZWU1YmNiNmNlNzAzODY1ZmViZTA2M2U4YWFhZGE0ZWM5ZWJlNjI5OTIzYTA3OWRhYmUzIiwic2Vxbm8iOjMyODE4OX0sInByZXYiOiIwMzlhMzhiZTVhMjAzZWU0ODk3NDQ4NDMyMTMxNmFkMTJhOGI4ODQyNjZhN2UwMmM5MzI3N2YyYTEzNGY0ZDBlIiwic2Vxbm8iOjYsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RAVRhCtS9bupx1LdKkuXreFzRQyOyKTslTDpb0rGbx07XSZh7/vj1AZw3eLJnJsrc9DujP0gdgYjlz4i2DNLacAahzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B
+	</div>
+	<div class="twit" data-x="y">
+	evil.com
+	</div>
+	<div class="twit">
+	short 9JHQ8ZNOFRORQUpmH0jLbNbFClOccMEghH5l
+	</div>
+</body>
+</html>
+`
+
+var json1 = ` {
+  "data": [
+    {
+	}, {
+      "type": "useless",
+      "data": "junk"
+    }, {
+      "type": "useful",
+      "poster": "kronk",
+      "data": "goodproof",
+      "extra": [1,2,3]
+    }, {
+      "type": "useless"
+    }, {
+      "type": "useful",
+      "poster": "eve",
+      "data": "evil.com",
+      "extra": [4,5,6]
+    }
+  ]
+}`

--- a/go/pvl/interp_test.go
+++ b/go/pvl/interp_test.go
@@ -2,3 +2,642 @@
 // this source code is governed by the included BSD license.
 
 package pvl
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+	libkb "github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	jsonw "github.com/keybase/go-jsonw"
+)
+
+type interpUnitTest struct {
+	name      string
+	proofinfo ProofInfo
+	prepvl    map[keybase1.ProofType]string
+	service   keybase1.ProofType
+
+	// What api call to expect
+	restype     libkb.XAPIResType
+	resjson     string
+	reshtml     string
+	restext     string
+	urloverride string
+	// (Optional) Expect a different url to be fetched than proofinfo.APIURL
+
+	// Whether the proof should validate
+	shouldwork bool
+	// (Optional) error status must equal. Must be specified for INVALID_PVL
+	errstatus keybase1.ProofStatus
+	// (Optional) error string must equal
+	errstr string
+}
+
+var interpUnitTests = []interpUnitTest{
+	// # Basic tests
+	{
+		name:      "basichtml",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_TWITTER: `[
+{"assert_regex_match": "^https://rooter\\.example\\.com/proofs/%{username_service}/[\\d]+\\.htjsxt$"},
+{"fetch": "html"},
+{"selector_css": [".twit", 0]},
+{"whitespace_normalize": true},
+{"assert_regex_match": "^.*goodproof.*$"}
+]`},
+		service:    keybase1.ProofType_TWITTER,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: true,
+	},
+
+	// # Tests for individual valid instructions.
+	// Test match and fail of each instruction.
+
+	// ## AssertRegexMatch,
+	{
+		name:      "AssertRegexMatch-url-ok",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_COINBASE: `[
+{"assert_regex_match": "^https://rooter\\.example\\.com/proofs/%{username_service}/[\\d]+\\.htjsxt$"},
+{"fetch": "string"}
+]`},
+		service:    keybase1.ProofType_COINBASE,
+		restype:    libkb.XAPIResText,
+		restext:    "1234",
+		shouldwork: true,
+	}, {
+		name:      "AssertRegexMatch-url-fail",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_HACKERNEWS: `[
+{"assert_regex_match": "^https://rooter\\.example\\.com/proofs/%{username_service}/+\\.htjsxt$"},
+{"fetch": "string"}
+]`},
+		service:    keybase1.ProofType_HACKERNEWS,
+		restype:    libkb.XAPIResText,
+		restext:    "1234",
+		shouldwork: false,
+	}, {
+		name:      "AssertRegexMatch-content-ok",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_REDDIT: `[
+{"fetch": "html"},
+{"selector_css": [".twit", -1]},
+{"whitespace_normalize": true},
+{"assert_regex_match": "^short %{sig_id_short}$"}
+]`},
+		service:    keybase1.ProofType_REDDIT,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: true,
+	}, {
+		name:      "AssertRegexMatch-content-fail",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_TWITTER: `[
+{"fetch": "html"},
+{"selector_css": [".twit", -1]},
+{"whitespace_normalize": true},
+{"assert_regex_match": "^wrong %{sig_id_short}$"}
+]`},
+		service:    keybase1.ProofType_TWITTER,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: false,
+	}, {
+		name:      "AssertRegexMatch-content-fail-case",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_TWITTER: `[
+{"fetch": "html"},
+{"selector_css": [".twit", -1]},
+{"assert_regex_match": "^.*SHORT.*$"}
+]`},
+		service:    keybase1.ProofType_TWITTER,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: false,
+	},
+
+	// ## AssertFindBase64,
+	{
+		name:      "AssertFindBase64-ok",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GENERIC_WEB_SITE: `[
+{"fetch": "string"},
+{"assert_find_base64": "sig"}
+]`},
+		service: keybase1.ProofType_GENERIC_WEB_SITE,
+		restype: libkb.XAPIResText,
+		// the sig must be on a line with only spacing.
+		restext:    fmt.Sprintf(" asdf\n  \t\t .\n %v\t\nzad\t.\n", sig1),
+		shouldwork: true,
+	}, {
+		name:      "AssertFindBase64-fail",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GENERIC_WEB_SITE: `[
+{"fetch": "string"},
+{"assert_find_base64": "sig"}
+]`},
+		service:    keybase1.ProofType_GENERIC_WEB_SITE,
+		restype:    libkb.XAPIResText,
+		restext:    sig1[1:],
+		shouldwork: false,
+	},
+
+	// ## WhitespaceNormalize,
+	{
+		name:      "WhitespaceNormalize-ok",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GENERIC_WEB_SITE: `[
+{"fetch": "string"},
+{"assert_regex_match": "^[\\s\\S]*\\t[\\s\\S]*$"},
+{"whitespace_normalize": true},
+{"assert_regex_match": "^A b c de f$", "case_insensitive": true}
+]`},
+		service:    keybase1.ProofType_GENERIC_WEB_SITE,
+		restype:    libkb.XAPIResText,
+		restext:    "a b   \tc\tde  \n\tf",
+		shouldwork: true,
+	},
+
+	// ## RegexCapture,
+	{
+		name:      "RegexCapture-ok-ignoregroup",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GENERIC_WEB_SITE: `[
+{"fetch": "html"},
+{"selector_css": ["div.twit", -1]},
+{"whitespace_normalize": true},
+{"regex_capture": "^(?:sHoRt) ([A-Za-z0-9+/=]+)$", "case_insensitive": true},
+{"assert_regex_match": "^%{sig_id_short}$"}
+]`},
+		service:    keybase1.ProofType_GENERIC_WEB_SITE,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: true,
+	}, {
+		// A repeated capture group returns its last match.
+		name:      "RegexCapture-ok-multimatch",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GENERIC_WEB_SITE: `[
+{"fetch": "html"},
+{"selector_css": ["div.twit", -1]},
+{"whitespace_normalize": true},
+{"regex_capture": "^(short).*$"},
+{"regex_capture": "^(\\w)+$"},
+{"assert_regex_match": "^t$"}
+]`},
+		service:    keybase1.ProofType_GENERIC_WEB_SITE,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: true,
+	}, {
+		name:      "RegexCapture-fail-nomatch",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GENERIC_WEB_SITE: `[
+{"fetch": "html"},
+{"selector_css": ["div.twit", -1]},
+{"regex_capture": "^(nowhere)$", "case_insensitive": true}
+]`},
+		service:    keybase1.ProofType_GENERIC_WEB_SITE,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: false,
+	}, {
+		name:      "RegexCapture-fail-nogroup",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GENERIC_WEB_SITE: `[
+{"fetch": "html"},
+{"selector_css": ["div.twit", -1]},
+{"whitespace_normalize": true},
+{"regex_capture": "^sHoRt.*$", "case_insensitive": true},
+{"assert_regex_match": "^%{sig_id_short}$/s"}
+]`},
+		service:    keybase1.ProofType_GENERIC_WEB_SITE,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: false,
+	},
+
+	// ## Fetch,
+	{
+		name:      "Fetch-string",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "string"},
+{"assert_regex_match": "^str9\n$"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResText,
+		restext:    "str9\n",
+		shouldwork: true,
+	}, {
+		name:      "Fetch-html",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "html"},
+{"selector_css": ["head title"]},
+{"assert_regex_match": "^proofer$"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: true,
+	}, {
+		name:      "Fetch-json",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "json"},
+{"selector_json": ["data", 2, "type"]},
+{"assert_regex_match": "^useful$"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResJSON,
+		resjson:    json1,
+		shouldwork: true,
+	},
+
+	// ## SelectorJSON,
+	{
+		name:      "SelectorJSON-simple",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "json"},
+{"selector_json": ["data", 2, "type"]},
+{"assert_regex_match": "^useful$"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResJSON,
+		resjson:    json1,
+		shouldwork: true,
+	}, {
+		name:      "SelectorJSON-index-dne",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "json"},
+{"selector_json": ["data", 500]}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResJSON,
+		resjson:    json1,
+		shouldwork: false,
+	}, {
+		name:      "SelectorJSON-key-dne",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "json"},
+{"selector_json": ["data", "a500"]}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResJSON,
+		resjson:    json1,
+		shouldwork: false,
+	}, {
+		name:      "SelectorJSON-index-neg",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "json"},
+{"selector_json": ["data", -1, "poster"]},
+{"assert_regex_match": "^eve$"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResJSON,
+		resjson:    json1,
+		shouldwork: true,
+	}, {
+		name:      "SelectorJSON-index-all",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "json"},
+{"selector_json": ["data", {"all": true}, "poster"]},
+{"assert_regex_match": "^kronk eve$"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResJSON,
+		resjson:    json1,
+		shouldwork: true,
+	},
+
+	// ## SelectorCSS,
+	{
+		name:      "SelectorCSS-ok",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "html"},
+{"selector_css": ["body .twit", -1]},
+{"whitespace_normalize": true},
+{"assert_regex_match": "^short %{sig_id_short}$"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: true,
+	}, {
+		name:      "SelectorCSS-fail-dontcrash",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "html"},
+{"selector_css": ["body .twit:eq(0)"]},
+{"assert_regex_match": "^$"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: false,
+	}, {
+		name:      "SelectorCSS-ok-multi",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "html"},
+{"selector_css": ["body .twit"],
+ "multi": true},
+{"assert_regex_match": "^[\\s\\S]*goodproof[\\s\\S]*evil\\.com[\\s\\S]*short[\\s\\S]*$"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: true,
+	}, {
+		name:      "SelectorCSS-fail-nonmulti",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "html"},
+{"selector_css": ["body .twit"]},
+{"whitespace_normalize": true},
+{"assert_regex_match": "^short %{sig_id_short}$"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: false,
+	}, {
+		name:      "SelectorCSS-ok-attr",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "html"},
+{"selector_css": ["body .twit[data-x]"],
+ "attr": "data-x"},
+{"assert_regex_match": "^y$"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: true,
+	}, {
+		name:      "SelectorCSS-ok-attr-dne",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "html"},
+{"selector_css": ["body .twit"],
+ "multi": true,
+ "attr": "dne"},
+{"assert_regex_match": "^$"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: true,
+	},
+
+	// ## TransformURL,
+	{
+		name:      "SelectorTransformURL-ok",
+		proofinfo: info1,
+		// Swap some parts of the paths. Also use an ignored capture group.
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"transform_url": "^https://rooter.example.com/(\\w+)/(?:%{username_service})/([^/])+\\.(htjsxt)$",
+ "to": "https://rooter.example.com/%{username_keybase}/keybase/%{1}/%{2}.%{3}"},
+{"assert_regex_match": "^https://rooter.example.com/kronk/keybase/proofs/5\\.htjsxt$"},
+{"fetch": "string"},
+{"assert_regex_match": "^ok$"}
+]`},
+		service:     keybase1.ProofType_GITHUB,
+		restype:     libkb.XAPIResText,
+		restext:     "ok",
+		urloverride: "https://rooter.example.com/kronk/keybase/proofs/5.htjsxt",
+		shouldwork:  true,
+	}, {
+		name:      "SelectorTransformURL-fail-afterfetch",
+		proofinfo: info1,
+		// Swap some parts of the paths. Also use an ignored capture group.
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"fetch": "string"},
+{"transform_url": "^$", "to": "^$"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResText,
+		restext:    "ok",
+		shouldwork: false,
+		errstatus:  keybase1.ProofStatus_INVALID_PVL,
+	}, {
+		name:      "SelectorTransformURL-fail-nomatch",
+		proofinfo: info1,
+		// Swap some parts of the paths. Also use an ignored capture group.
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"transform_url": "^$", "to": "^$"},
+{"fetch": "string"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResText,
+		restext:    "ok",
+		shouldwork: false,
+	}, {
+		name:      "SelectorTransformURL-fail-badsub",
+		proofinfo: info1,
+		// Swap some parts of the paths. Also use an ignored capture group.
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[
+{"transform_url": "^(.*)$",
+ "to": "%{2}"},
+{"fetch": "string"}
+]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResText,
+		restext:    "ok",
+		shouldwork: false,
+	},
+
+	// # Tests for invalid PVL at the top level
+
+	// Empty service entries should fail.
+	{
+		name:      "omitted-service",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_TWITTER: `[{"fetch": "string"}]`,
+		},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: false,
+		errstatus:  keybase1.ProofStatus_INVALID_PVL,
+	},
+}
+
+func TestUnits(t *testing.T) {
+	solo := ""
+	for _, unit := range interpUnitTests {
+		if len(solo) == 0 || unit.name == solo {
+			t.Logf("Testing: %v", unit.name)
+			runPvlTest(t, &unit)
+		}
+	}
+	if len(solo) > 0 {
+		// Soloing a test shall never be checked in.
+		t.Fatalf("soloed a test that passed\n\n\n*\n*\n*\n*\n*\n*\n*")
+	}
+}
+
+func runPvlTest(t *testing.T, unit *interpUnitTest) {
+	fail := func(f string, arg ...interface{}) {
+		f2 := fmt.Sprintf("[%v] ", unit.name) + f
+		t.Fatalf(f2, arg...)
+	}
+
+	tc := libkb.SetupTest(t, unit.name, 1)
+	g := tc.G
+	xapi := NewStubAPIEngine()
+	g.XAPI = xapi
+
+	pvl, err := makeTestPvl(unit.prepvl)
+	if err != nil {
+		fail("Error in prepvl: %v", err)
+	}
+
+	var url = unit.proofinfo.APIURL
+	if unit.urloverride != "" {
+		url = unit.urloverride
+	}
+
+	switch unit.restype {
+	case libkb.XAPIResJSON:
+		xapi.Set(url, newExternalJSONRes(t, unit.resjson))
+	case libkb.XAPIResHTML:
+		xapi.SetHTML(url, newExternalHTMLRes(t, unit.reshtml))
+	case libkb.XAPIResText:
+		xapi.SetText(url, newExternalTextRes(t, unit.restext))
+	default:
+		fail("unsupported restype: %v", unit.restype)
+	}
+
+	perr := CheckProof(g, pvl, unit.service, unit.proofinfo)
+	if perr == nil {
+		if !unit.shouldwork {
+			fail("proof should have failed")
+		}
+
+		err = xapi.AssertCalledOnceWith(unit.restype, url)
+		if err != nil {
+			fail("%v", err)
+		}
+	} else {
+		if unit.shouldwork {
+			fail("proof failed: %v", perr)
+		}
+		none := keybase1.ProofStatus_NONE
+		if unit.errstatus != none && perr.GetProofStatus() != unit.errstatus {
+			fail("status mismatch:\n  expected: %v\n  got: %v", unit.errstatus, perr.GetProofStatus())
+		}
+		if len(unit.errstr) > 0 && unit.errstr != perr.GetDesc() {
+			fail("status mismatch:\n  expected: %v\n  got: %v", unit.errstr, perr.GetDesc())
+		}
+		if unit.errstatus == none && perr.GetProofStatus() == keybase1.ProofStatus_INVALID_PVL {
+			fail("unexpected INVALID_PVL:\n  expected: %v\n  got: %v", unit.errstatus, perr.Error())
+		}
+	}
+}
+
+func makeTestPvl(rules map[keybase1.ProofType]string) (*jsonw.Wrapper, error) {
+	services := jsonw.NewDictionary()
+	for ptype, v1 := range rules {
+		var err error
+		ptypestr, err := serviceToString(ptype)
+		if err != nil {
+			return nil, err
+		}
+		v2, err := jsonw.Unmarshal([]byte(v1))
+		if err != nil {
+			return nil, err
+		}
+		err = services.SetKey(ptypestr, v2)
+		if err != nil {
+			return nil, err
+		}
+	}
+	pvl := jsonw.NewDictionary()
+	err := pvl.SetKey("pvl_version", jsonw.NewInt(SupportedVersion))
+	if err != nil {
+		return nil, err
+	}
+	err = pvl.SetKey("revision", jsonw.NewInt(1))
+	if err != nil {
+		return nil, err
+	}
+	err = pvl.SetKey("services", services)
+	if err != nil {
+		return nil, err
+	}
+	return pvl, nil
+}
+
+func newExternalJSONRes(t *testing.T, json string) *libkb.ExternalAPIRes {
+	if json == "" {
+		t.Fatalf("empty html string")
+	}
+	w, err := jsonw.Unmarshal([]byte(json))
+	if err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	return &libkb.ExternalAPIRes{HTTPStatus: 200, Body: w}
+}
+
+func newExternalHTMLRes(t *testing.T, html string) *libkb.ExternalHTMLRes {
+	if html == "" {
+		t.Fatalf("empty html string")
+	}
+	reader := strings.NewReader(html)
+	doc, err := goquery.NewDocumentFromReader(reader)
+	if err != nil {
+		t.Fatalf("invalid html: %v", err)
+	}
+	return &libkb.ExternalHTMLRes{HTTPStatus: 200, GoQuery: doc}
+}
+
+func newExternalTextRes(t *testing.T, text string) *libkb.ExternalTextRes {
+	if text == "" {
+		t.Fatalf("empty text response")
+	}
+	return &libkb.ExternalTextRes{HTTPStatus: 200, Body: text}
+}

--- a/go/pvl/interp_test.go
+++ b/go/pvl/interp_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
 package pvl


### PR DESCRIPTION
Adds some tests for each instruction. These tests should cover normal operation of pvl (both succeeding and failing instructions). They do not cover the darker corners of malformed pvl, running dns proofs, nor malformed top-level pvl.

Other goodies:
- add mocking mode to `StubAPIEngine`
- fixed crash on negative indices in selectors
- added `func pyindex` so that negative indices act as specified

r? @maxtaco @oconnor663 