### PR TITLE
Remove extraneous multiline prop causing React warnings

### DIFF
--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -109,7 +109,6 @@ class Input extends Component<void, Props, State> {
           hintStyle={{...styles.hintStyle, ...(this.props.multiline ? {textAlign: 'center'} : {top: 3, bottom: 'auto'}), ...this.props.hintStyle}}
           hintText={this.props.hintText}
           inputStyle={{...(this.props.small ? {} : {marginTop: 6}), ...inputStyle, ...alignStyle, ...this.props.inputStyle}}
-          multiline={this.props.multiline}
           name='name'
           onBlur={() => this.setState({focused: false})}
           onChange={event => this.onChange(event)}


### PR DESCRIPTION
The casing of this prop differs from Material UI, causing it to be
passed through to the input element which results in a warning. We're
handling cases where multiline is set above, so this prop was only being
set to undefined.

:eyeglasses: @keybase/react-hackers 