### PR TITLE
Fix installer NSTask hitting pipe limit if kernel under load

### DIFF
--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.36</string>
+	<string>1.1.37</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.36</string>
+	<string>1.1.37</string>
 	<key>KBFuseBuild</key>
 	<string>3.4.2</string>
 	<key>KBFuseVersion</key>

--- a/osx/KBKit/KBKit/System/KBTask.m
+++ b/osx/KBKit/KBKit/System/KBTask.m
@@ -80,7 +80,7 @@
   @try {
     DDLogDebug(@"Task: %@ %@", command, [args join:@" "]);
     [task launch];
-    //[task waitUntilExit];
+    [task waitUntilExit];
   } @catch (NSException *e) {
     NSString *errorMessage = NSStringWithFormat(@"%@ (%@ %@)", e.reason, command, [args join:@" "]);
     DDLogError(@"Error running task: %@", errorMessage);

--- a/osx/KBKit/KBKit/System/KBTask.m
+++ b/osx/KBKit/KBKit/System/KBTask.m
@@ -11,9 +11,22 @@
 #import "KBDefines.h"
 #include <signal.h>
 
+@interface KBTaskReader : NSObject
+@property NSFileHandle *outFh;
+@property NSFileHandle *errFh;
+@property NSMutableData *outData;
+@property NSMutableData *errData;
+- (instancetype)initWithOutPipe:(NSPipe *)outPipe errPipe:(NSPipe *)errPipe;
+@end
+
 @implementation KBTask
 
 + (void)execute:(NSString *)command args:(NSArray *)args timeout:(NSTimeInterval)timeout completion:(void (^)(NSError *error, NSData *outData, NSData *errData))completion {
+  KBTask *task = [[KBTask alloc] init];
+  [task execute:command args:args timeout:timeout completion:completion];
+}
+
+- (void)execute:(NSString *)command args:(NSArray *)args timeout:(NSTimeInterval)timeout completion:(void (^)(NSError *error, NSData *outData, NSData *errData))completion {
   NSTask *task = [[NSTask alloc] init];
   task.launchPath = command;
   task.arguments = args;
@@ -22,6 +35,8 @@
   [task setStandardOutput:outPipe];
   NSPipe *errPipe = [NSPipe pipe];
   [task setStandardError:errPipe];
+
+  KBTaskReader *taskReader = [[KBTaskReader alloc] initWithOutPipe:outPipe errPipe:errPipe];
 
   dispatch_queue_t taskQueue = dispatch_queue_create("taskQueue", NULL);
 
@@ -32,49 +47,40 @@
       if (!replied) {
         timedOut = YES;
 
-        // Dump golang stack to log
-        kill(task.processIdentifier, SIGABRT);
-
         NSString *taskDesc = NSStringWithFormat(@"%@ %@", command, [args join:@" "]);
-        [self readOutPipe:outPipe errPipe:errPipe description:taskDesc completion:^(NSData *outData, NSData *errData) {
-          DDLogError(@"Task timed out: %@", taskDesc);
-          dispatch_async(dispatch_get_main_queue(), ^{
-            completion(KBMakeError(KBErrorCodeTimeout, @"Task timed out: %@", taskDesc), nil, nil);
-          });
+        DDLogError(@"Task timed out: %@", taskDesc);
+        dispatch_async(dispatch_get_main_queue(), ^{
+          completion(KBMakeError(KBErrorCodeTimeout, @"Task timed out: %@", taskDesc), nil, nil);
+        });
 
-          // Terminate/cleanup task after timeout
-          @try {
-            [task terminate];
-          } @catch(NSException *e) {
-            DDLogDebug(@"Task error in terminate after timeout: %@", e);
-          }
-        }];
+        // Terminate/cleanup task after timeout
+        @try {
+          [task terminate];
+        } @catch(NSException *e) {
+          DDLogDebug(@"Task error in terminate after timeout: %@", e);
+        }
       }
     });
   }
 
   task.terminationHandler = ^(NSTask *t) {
     dispatch_async(taskQueue, ^{
-      NSString *taskDesc = NSStringWithFormat(@"%@ %@", command, [args join:@" "]);
       if (timedOut) {
         DDLogDebug(@"Task termination handler, timed out, skipping");
         return;
       }
       replied = YES;
-      DDLogDebug(@"Task termination handler, reading output");
-      [self readOutPipe:outPipe errPipe:errPipe description:taskDesc completion:^(NSData *outData, NSData *errData) {
-        DDLogDebug(@"Task dispatch completion");
-        dispatch_async(dispatch_get_main_queue(), ^{
-          completion(nil, outData, errData);
-        });
-      }];
+      DDLogDebug(@"Task dispatch completion");
+      dispatch_async(dispatch_get_main_queue(), ^{
+        completion(nil, taskReader.outData, taskReader.errData);
+      });
     });
   };
 
   @try {
     DDLogDebug(@"Task: %@ %@", command, [args join:@" "]);
     [task launch];
-    [task waitUntilExit];
+    //[task waitUntilExit];
   } @catch (NSException *e) {
     NSString *errorMessage = NSStringWithFormat(@"%@ (%@ %@)", e.reason, command, [args join:@" "]);
     DDLogError(@"Error running task: %@", errorMessage);
@@ -84,6 +90,12 @@
 }
 
 + (void)executeForJSONWithCommand:(NSString *)command args:(NSArray *)args timeout:(NSTimeInterval)timeout completion:(void (^)(NSError *error, id value))completion {
+  KBTask *task = [[KBTask alloc] init];
+  [task executeForJSONWithCommand:command args:args timeout:timeout completion:completion];
+}
+
+
+- (void)executeForJSONWithCommand:(NSString *)command args:(NSArray *)args timeout:(NSTimeInterval)timeout completion:(void (^)(NSError *error, id value))completion {
   [self execute:command args:args timeout:timeout completion:^(NSError *error, NSData *outData, NSData *errData) {
     if (error) {
       completion(error, nil);
@@ -109,19 +121,51 @@
   }];
 }
 
-+ (void)readOutPipe:(NSPipe *)outPipe errPipe:(NSPipe *)errPipe description:(NSString *)description completion:(void (^)(NSData *outData, NSData *errData))completion {
-  NSFileHandle *outRead = [outPipe fileHandleForReading];
-  NSData *outData = [outRead readDataToEndOfFile];
-  NSFileHandle *errRead = [errPipe fileHandleForReading];
-  NSData *errData = [errRead readDataToEndOfFile];
+@end
 
-  if ([outData length] > 0) {
-    DDLogDebug(@"Task %@ (out): %@", description, [[NSString alloc] initWithData:outData encoding:NSUTF8StringEncoding]);
+@implementation KBTaskReader
+
+- (instancetype)initWithOutPipe:(NSPipe *)outPipe errPipe:(NSPipe *)errPipe {
+  if ((self = [super init])) {
+    self.outFh = [outPipe fileHandleForReading];
+    self.outData = [NSMutableData data];
+    GHWeakSelf wself = self;
+    [[NSNotificationCenter defaultCenter] addObserverForName:NSFileHandleReadCompletionNotification object:self.outFh queue:nil usingBlock:^(NSNotification *notification) {
+      [wself outData:notification];
+    }];
+    [self.outFh readInBackgroundAndNotify];
+
+    self.errFh = [errPipe fileHandleForReading];
+    self.errData = [NSMutableData data];
+    [[NSNotificationCenter defaultCenter] addObserverForName:NSFileHandleReadCompletionNotification object:self.errFh queue:nil usingBlock:^(NSNotification *notification) {
+      [wself errData:notification];
+    }];
+    [self.errFh readInBackgroundAndNotify];
   }
-  if ([errData length] > 0) {
-    DDLogDebug(@"Task %@ (err): %@", description, [[NSString alloc] initWithData:errData encoding:NSUTF8StringEncoding]);
+  return self;
+}
+
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:NSFileHandleReadCompletionNotification object:self.outFh];
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:NSFileHandleReadCompletionNotification object:self.errFh];
+}
+
+- (void)outData:(NSNotification *)notification {
+  NSData *data = [[notification userInfo] objectForKey:NSFileHandleNotificationDataItem];
+  if (data.length > 0) {
+    DDLogDebug(@"Task (out): %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+    [self.outData appendData:data];
   }
-  completion(outData, errData);
+  [self.outFh readInBackgroundAndNotify];
+}
+
+- (void)errData:(NSNotification *)notification {
+  NSData *data = [[notification userInfo] objectForKey:NSFileHandleNotificationDataItem];
+  if (data.length > 0) {
+    DDLogDebug(@"Task (err): %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+    [self.errData appendData:data];
+  }
+  [self.errFh readInBackgroundAndNotify];
 }
 
 @end

--- a/packaging/desktop/kbfuse.sh
+++ b/packaging/desktop/kbfuse.sh
@@ -15,7 +15,7 @@ cd $dir
 client_dir="$dir/../.."
 fuse_dir="$client_dir/osx/Fuse"
 tmp_dir="/tmp/desktop-kbfuse"
-installer_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseInstaller-1.1.35-darwin.tgz"
+installer_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseInstaller-1.1.37-darwin.tgz"
 
 if [ "$EUID" -ne 0 ]; then
   echo "Please run as root"

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -76,7 +76,7 @@ shared_support_dir="$out_dir/Keybase.app/Contents/SharedSupport"
 resources_dir="$out_dir/Keybase.app/Contents/Resources/"
 
 # The KeybaseInstaller.app installs KBFuse, keybase.Helper, services and CLI via a native app
-installer_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseInstaller-1.1.36-darwin.tgz"
+installer_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseInstaller-1.1.37-darwin.tgz"
 # KeybaseUpdater.app is the native updater UI (prompt dialogs)
 updater_url="https://github.com/keybase/client/releases/download/v1.0.16/KeybaseUpdater-1.0.3-darwin.tgz"
 


### PR DESCRIPTION
We read as data comes in. I was able to reproduce if keybase generated more than 64k of output, and verify the fix.