### PR TITLE
Handle helper tool install error codes

### DIFF
--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.38</string>
+	<string>1.1.39</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.38</string>
+	<string>1.1.39</string>
 	<key>KBFuseBuild</key>
 	<string>3.4.2</string>
 	<key>KBFuseVersion</key>

--- a/osx/Installer/Installer.m
+++ b/osx/Installer/Installer.m
@@ -128,6 +128,31 @@ typedef NS_ENUM (NSInteger, KBExit) {
     return;
   }
 
+  // Helper auth canceled, denied or not allowed
+  if ([error.domain isEqualToString:@"keybase.Helper"] &&
+      (error.code == errAuthorizationCanceled || error.code == errAuthorizationDenied || error.code == errAuthorizationInteractionNotAllowed)) {
+    NSString *title = @"Keybase: Installation Required";
+    NSString *message = [NSString stringWithFormat:@"We were unable to install a helper tool needed for Keybase to work properly (%@).", @(error.code)];
+    [self showQuitDialogWithTitle:title message:message error:error environment:environment completion:completion];
+  } else {
+    [self showErrorDialog:error environment:environment completion:completion];
+  }
+}
+
+- (void)showQuitDialogWithTitle:(NSString *)title message:(NSString *)message error:(NSError *)error environment:(KBEnvironment *)environment completion:(void (^)(NSError *error, KBExit exit))completion {
+  NSAlert *alert = [[NSAlert alloc] init];
+  [alert setMessageText:title];
+  [alert setInformativeText:message];
+  [alert addButtonWithTitle:@"Quit"];
+
+  [alert setAlertStyle:NSWarningAlertStyle];
+  NSModalResponse response = [alert runModal];
+  if (response == NSAlertFirstButtonReturn) {
+    completion(error, KBExitError);
+  }
+}
+
+- (void)showErrorDialog:(NSError *)error environment:(KBEnvironment *)environment completion:(void (^)(NSError *error, KBExit exit))completion {
   NSAlert *alert = [[NSAlert alloc] init];
   [alert setMessageText:@"Keybase Error"];
   [alert setInformativeText:error.localizedDescription];

--- a/osx/Installer/Installer.m
+++ b/osx/Installer/Installer.m
@@ -149,6 +149,9 @@ typedef NS_ENUM (NSInteger, KBExit) {
   NSModalResponse response = [alert runModal];
   if (response == NSAlertFirstButtonReturn) {
     completion(error, KBExitError);
+  } else {
+    DDLogError(@"Unknown error dialog return button");
+    completion(error, KBExitError);
   }
 }
 
@@ -168,6 +171,9 @@ typedef NS_ENUM (NSInteger, KBExit) {
     completion(error, KBExitIgnoreError);
   } else if (response == NSAlertThirdButtonReturn) {
     [self showMoreDetails:error environment:environment completion:completion];
+  } else {
+    DDLogError(@"Unknown error dialog return button");
+    completion(error, KBExitError);
   }
 }
 

--- a/osx/Installer/Uninstaller.m
+++ b/osx/Installer/Uninstaller.m
@@ -30,6 +30,9 @@
     KBMountDir *mountDir = [[KBMountDir alloc] initWithConfig:environment.config helperTool:environment.helperTool];
     [installables addObject:mountDir];
   }
+  if (settings.uninstallOptions & UninstallOptionHelper) {
+    [installables addObject:environment.helperTool];
+  }
   [KBUninstaller uninstall:installables completion:completion];
 }
 

--- a/osx/Utils/Settings.h
+++ b/osx/Utils/Settings.h
@@ -16,6 +16,7 @@ typedef NS_OPTIONS (NSUInteger, UninstallOptions) {
   UninstallOptionApp = 1 << 0,
   UninstallOptionKext = 1 << 1,
   UninstallOptionMountDir = 1 << 2,
+  UninstallOptionHelper = 1 << 3,
 };
 
 @interface Settings : NSObject

--- a/osx/Utils/Settings.m
+++ b/osx/Utils/Settings.m
@@ -39,6 +39,7 @@
   [parser registerSwitch:@"uninstall-app"];
   [parser registerSwitch:@"uninstall-kext"];
   [parser registerSwitch:@"uninstall-mountdir"];
+  [parser registerSwitch:@"uninstall-helper"];
   [parser registerSwitch:@"install-fuse"];
   [parser registerSettings:self.settings];
   NSArray *subargs = [args subarrayWithRange:NSMakeRange(1, args.count-1)];
@@ -58,6 +59,9 @@
   }
   if ([[self.settings objectForKey:@"uninstall-mountdir"] boolValue]) {
     self.uninstallOptions |= UninstallOptionMountDir;
+  }
+  if ([[self.settings objectForKey:@"uninstall-helper"] boolValue]) {
+    self.uninstallOptions |= UninstallOptionHelper;
   }
   if ([[self.settings objectForKey:@"install-fuse"] boolValue]) {
     self.installOptions |= KBInstallOptionFuse;

--- a/packaging/desktop/kbfuse.sh
+++ b/packaging/desktop/kbfuse.sh
@@ -15,7 +15,7 @@ cd $dir
 client_dir="$dir/../.."
 fuse_dir="$client_dir/osx/Fuse"
 tmp_dir="/tmp/desktop-kbfuse"
-installer_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseInstaller-1.1.38-darwin.tgz"
+installer_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseInstaller-1.1.39-darwin.tgz"
 
 if [ "$EUID" -ne 0 ]; then
   echo "Please run as root"

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -76,7 +76,7 @@ shared_support_dir="$out_dir/Keybase.app/Contents/SharedSupport"
 resources_dir="$out_dir/Keybase.app/Contents/Resources/"
 
 # The KeybaseInstaller.app installs KBFuse, keybase.Helper, services and CLI via a native app
-installer_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseInstaller-1.1.38-darwin.tgz"
+installer_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseInstaller-1.1.39-darwin.tgz"
 # KeybaseUpdater.app is the native updater UI (prompt dialogs)
 updater_url="https://github.com/keybase/client/releases/download/v1.0.16/KeybaseUpdater-1.0.3-darwin.tgz"
 


### PR DESCRIPTION
- Show quit dialog with nicer message on helper tool install cancel, denied or not allowed
- Command line option to `--uninstall-helper`
- Don't touch helper plist (makes re-install funky)