### PR TITLE
Add a V2 version of typed connect that supports mapXToProps fns

### DIFF
--- a/shared/util/typed-connect.js
+++ b/shared/util/typed-connect.js
@@ -3,7 +3,7 @@
 import {Component} from 'react'
 import {connect} from 'react-redux'
 
-type TypedMergeProps<State, Dispatch, OwnProps, Props> = (state: State, dispatch: Dispatch, ownProps: OwnProps) => Props
+type TypedMergeProps<State, Dispatch, OwnProps, Props> = (stateProps: State, dispatchProps: Dispatch, ownProps: OwnProps) => Props
 
 export class ConnectedComponent<OwnProps> extends Component<void, OwnProps, void> {}
 
@@ -18,3 +18,16 @@ export class TypedConnector<State, Dispatch, OwnProps, Props> {
     )
   }
 }
+
+class _TypedConnectorV2<Props, StateProps, DispatchProps, OwnProps, Dispatch: Function, State> {
+  connect(
+    mapStateToProps: (state: Object, ownProps: OwnProps) => StateProps,
+    mapDispatchToProps: (dispatch: Dispatch, ownProps: OwnProps) => DispatchProps,
+    mergeProps: TypedMergeProps<StateProps, DispatchProps, OwnProps, Props>,
+    options?: {pure?: boolean, withRef?: boolean}
+  ): (component: ReactClass<Props>) => ReactClass<OwnProps> {
+    return connect(mapStateToProps, mapDispatchToProps, mergeProps, options)
+  }
+}
+
+export class TypedConnectorV2<State, Props, OwnProps> extends _TypedConnectorV2<Props, *, *, OwnProps, *, State> {}


### PR DESCRIPTION
@keybase/react-hackers this adds a new typed connector that supports all the mapXToProps.

a mergeProps function is required because we can't merge types together.