### PR TITLE
Fix provisioning error display

### DIFF
--- a/shared/login/register/error/index.render.desktop.js
+++ b/shared/login/register/error/index.render.desktop.js
@@ -54,6 +54,12 @@ const renderError = (error: RPCError) => {
             </p>
           </div>)
       }
+    case ConstantsStatusCode.scnotfound:
+      return (
+        <p>
+          <Text type='Body'>The username you provided doesn't exist on Keybase, please try logging in again with a different username.</Text>
+        </p>
+      )
     case ConstantsStatusCode.scbadloginpassword:
       return (
         <p>
@@ -71,7 +77,7 @@ const renderError = (error: RPCError) => {
           <Text type='BodySmall' style={{display: 'inline-block'}}> - Go back and provision with another device or paper key</Text>
         </p>)
     default:
-      return <Text type='Body'>Unknown error: {error.toString()}</Text>
+      return <Text type='Body'>Unknown error: {error.desc}</Text>
   }
 }
 

--- a/shared/login/register/error/index.render.native.js
+++ b/shared/login/register/error/index.render.native.js
@@ -23,7 +23,7 @@ const styles = {
 }
 
 const renderError = error => {
-  return <Text type='Body'>Unknown error: {error.toString()}</Text>
+  return <Text type='Body'>Unknown error: {error.desc}</Text>
 }
 
 export default Render

--- a/shared/reducers/login.js
+++ b/shared/reducers/login.js
@@ -145,7 +145,7 @@ export default function (state: LoginState = initialState, action: any): LoginSt
       break
     case Constants.loginDone:
       if (action.error) {
-        toMerge = {loginError: action.payload && action.payload.message}
+        toMerge = {loginError: action.payload && action.payload.desc}
       } else {
         return state
       }


### PR DESCRIPTION
@keybase/react-hackers 

A few bugs here.  Nothing was limited to mobile, I think it all stems from a recent refactor of the login Error class.

* Provisioning errors caused an `Error: [object Object]` because `error.toString()` no longer exists now that we aren't using Node's own Error class.  Use `error.desc` instead to get text from the service.

* When we thread these errors through our reducer, it's now `action.payload.desc` rather than `action.payload.message`.  This meant that if you typoed your password on the main login screen, errorText didn't make it through to the Render component and the screen just blinked at you without explaining the login failure.

* Added a custom error render handler for the error 'scnotfound', which is the error you get when you try to log in with a username that doesn't exist.  Before this handler, you'd just see "Error: Not found", which doesn't tell you what the problem is, so now there's some helpful text.