### PR TITLE
change max headers to max messages CORE-3705

### DIFF
--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -98,7 +98,7 @@ type ConversationReaderInfo struct {
 type Conversation struct {
 	Metadata   ConversationMetadata    `codec:"metadata" json:"metadata"`
 	ReaderInfo *ConversationReaderInfo `codec:"readerInfo,omitempty" json:"readerInfo,omitempty"`
-	MaxHeaders []MessageServerHeader   `codec:"maxHeaders" json:"maxHeaders"`
+	MaxMsgs    []MessageBoxed          `codec:"maxMsgs" json:"maxMsgs"`
 }
 
 type MessageServerHeader struct {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -59,8 +59,8 @@ protocol common {
     ConversationMetadata metadata;
     union { null, ConversationReaderInfo } readerInfo; // information about the convo from a user perspective
 
-    // maxHeaders is the maximum header for each messageType in the conversation.
-    array<MessageServerHeader> maxHeaders;
+    // maxMsgs is the maximum message for each messageType in the conversation
+    array<MessageBoxed> maxMsgs;
   }
 
   record MessageServerHeader {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -91,7 +91,7 @@ export function remotePostRemoteRpc (request: $Exact<requestCommon & {callback?:
 export type Conversation = {
   metadata: ConversationMetadata,
   readerInfo?: ?ConversationReaderInfo,
-  maxHeaders?: ?Array<MessageServerHeader>,
+  maxMsgs?: ?Array<MessageBoxed>,
 }
 
 export type ConversationID = uint64

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -168,9 +168,9 @@
         {
           "type": {
             "type": "array",
-            "items": "MessageServerHeader"
+            "items": "MessageBoxed"
           },
-          "name": "maxHeaders"
+          "name": "maxMsgs"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -91,7 +91,7 @@ export function remotePostRemoteRpc (request: $Exact<requestCommon & {callback?:
 export type Conversation = {
   metadata: ConversationMetadata,
   readerInfo?: ?ConversationReaderInfo,
-  maxHeaders?: ?Array<MessageServerHeader>,
+  maxMsgs?: ?Array<MessageBoxed>,
 }
 
 export type ConversationID = uint64


### PR DESCRIPTION
@patrickxb @maxtaco @songgao 

Client side of CORE-3705, to change `MaxHeaders` to `MaxMsgs`. This allows us to not have to make another call to the server to get the full messages, where most of the interesting information is stored (useful for TLF name, topic name, text snippets, etc).