### PR TITLE
Ensure task read to EOF

### DIFF
--- a/osx/KBKit/KBKit/System/KBTask.h
+++ b/osx/KBKit/KBKit/System/KBTask.h
@@ -8,9 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
+typedef void (^KBTaskCompletion)(NSError *error, NSData *outData, NSData *errData);
+
 @interface KBTask : NSObject
 
-+ (void)execute:(NSString *)command args:(NSArray *)args timeout:(NSTimeInterval)timeout completion:(void (^)(NSError *error, NSData *outData, NSData *errData))completion;
++ (void)execute:(NSString *)command args:(NSArray *)args timeout:(NSTimeInterval)timeout completion:(KBTaskCompletion)completion;
 
 // Execute and parse JSON from stdout (otherwise error)
 + (void)executeForJSONWithCommand:(NSString *)command args:(NSArray *)args timeout:(NSTimeInterval)timeout completion:(void (^)(NSError *error, id value))completion;

--- a/osx/KBKit/KBKit/System/KBTask.m
+++ b/osx/KBKit/KBKit/System/KBTask.m
@@ -22,7 +22,6 @@
 @property NSMutableData *errData;
 - (instancetype)initWithTask:(NSTask *)task;
 - (void)start;
-- (void)readToEOF;
 @end
 
 @implementation KBTask
@@ -80,8 +79,6 @@
       replied = YES;
       DDLogDebug(@"Task dispatch completion");
       dispatch_async(dispatch_get_main_queue(), ^{
-        // Ensure we have all the data
-        [taskReader readToEOF];
         DDLogDebug(@"Task (out): %@", [[NSString alloc] initWithData:taskReader.outData encoding:NSUTF8StringEncoding]);
         DDLogDebug(@"Task (err): %@", [[NSString alloc] initWithData:taskReader.errData encoding:NSUTF8StringEncoding]);
         completion(nil, taskReader.outData, taskReader.errData);
@@ -168,17 +165,6 @@
 - (void)start {
   [self.outFh readToEndOfFileInBackgroundAndNotify];
   [self.errFh readToEndOfFileInBackgroundAndNotify];
-}
-
-- (void)readToEOF {
-  NSData *outData = [self.outFh readDataToEndOfFile];
-  if (outData.length > 0) {
-    [self.outData appendData:outData];
-  }
-  NSData *errData = [self.errFh readDataToEndOfFile];
-  if (errData.length > 0) {
-    [self.errData appendData:errData];
-  }
 }
 
 - (void)outData:(NSNotification *)notification {

--- a/osx/KBKit/KBKit/System/KBTask.m
+++ b/osx/KBKit/KBKit/System/KBTask.m
@@ -18,7 +18,7 @@
 @property NSMutableData *errData;
 - (instancetype)initWithTask:(NSTask *)task;
 - (void)start;
-- (void)flush;
+- (void)drain;
 @end
 
 @interface KBTask ()
@@ -73,7 +73,7 @@
     DDLogDebug(@"Task dispatch completion");
     dispatch_async(dispatch_get_main_queue(), ^{
       // Ensure we've read to EOF
-      [wself.taskReader flush];
+      [wself.taskReader drain];
       DDLogDebug(@"Task (out): %@", ([[NSString alloc] initWithData:wself.taskReader.outData encoding:NSUTF8StringEncoding]));
       DDLogDebug(@"Task (err): %@", ([[NSString alloc] initWithData:wself.taskReader.errData encoding:NSUTF8StringEncoding]));
       self.completion(nil, wself.taskReader.outData, wself.taskReader.errData);
@@ -180,12 +180,12 @@
   [self.errFh readToEndOfFileInBackgroundAndNotify];
 }
 
-- (void)flush {
-  [self flush:self.outFh data:self.outData];
-  [self flush:self.errFh data:self.errData];
+- (void)drain {
+  [self drain:self.outFh data:self.outData];
+  [self drain:self.errFh data:self.errData];
 }
 
-- (void)flush:(NSFileHandle *)fh data:(NSMutableData *)data {
+- (void)drain:(NSFileHandle *)fh data:(NSMutableData *)data {
   NSData *readData = [fh readDataToEndOfFile];
   if (readData.length > 0) {
     [data appendData:readData];


### PR DESCRIPTION
We should use `NSFileHandleReadToEndOfFileCompletionNotification` instead of the ReadCompletion one. This does a async read until EOF. I tested this and will not cause the pipe buffer to fill (the cause the of the previous installer hang).

Also, I did a bunch of testing on VMs and it is possible for the process to terminate before the EOF notifications, so, I changed the termination handler to wait until EOF to complete the task.