### PR TITLE
Comment out pending proof badge for now

### DIFF
--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -545,9 +545,11 @@ function diffAndStatusMeta (diff: ?TrackDiffType, proofResult: ?ProofResult, isT
       return null
     }
 
-    if (state === ProveCommonProofState.tempFailure) {
-      return metaPending
-    }
+    // FIXME: uncomment once the backend indicates pending-state failures based
+    // on low proof age.
+    // if (state === ProveCommonProofState.tempFailure) {
+    //   return metaPending
+    // }
 
     // The full mapping between the proof status we get back from the server
     // and a simplified representation that we show the users.


### PR DESCRIPTION
Old proofs (such as DNS) which fail due to resolution error are returned by the Go code as a `TEMP_FAILURE`, which we stick a pending badge on. In the future we should display the pending badge only for proofs that are newer than a threshold (which may vary between services). For now we'll comment out this behavior since it leads to misleading display.

Interestingly, with this change a DNS failure reveals a more specific badged error:

![screen shot 2016-09-08 at 2 19 36 pm](https://cloud.githubusercontent.com/assets/16893/18367453/127627b8-75d0-11e6-94d7-8175d9def09f.png)

:eyeglasses: @keybase/react-hackers 