### PR TITLE
Only list rooter as an available proof type in dev mode

### DIFF
--- a/shared/constants/types/more.js
+++ b/shared/constants/types/more.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {Component} from 'react' // eslint-disable-line
+import pickBy from 'lodash/pickBy'
 import type {Device as _Device, DeviceID, Time} from './flow-types'
 
 const ProvablePlatformsMap = {
@@ -12,7 +13,7 @@ const ProvablePlatformsMap = {
   'dns': true,
   'http': true,
   'https': true,
-  'rooter': true,
+  'rooter': __DEV__,
 }
 
 const PlatformsExpandedMap = {
@@ -25,16 +26,16 @@ const PlatformsExpandedMap = {
   'dns': true,
   'http': true,
   'https': true,
-  'rooter': true,
+  'rooter': __DEV__,
   'btc': true,
   'dnsOrGenericWebSite': true,
   'pgp': true,
 }
 
-export const ProvablePlatforms = Object.keys(ProvablePlatformsMap)
+export const ProvablePlatforms = Object.keys(pickBy(ProvablePlatformsMap))
 export type ProvablePlatformsType = $Keys<typeof ProvablePlatformsMap>
 
-export const PlatformsExpanded = Object.keys(PlatformsExpandedMap)
+export const PlatformsExpanded = Object.keys(pickBy(PlatformsExpandedMap))
 export type PlatformsExpandedType = $Keys<typeof PlatformsExpandedMap>
 
 export type DeviceType = 'mobile' | 'desktop' | 'backup'


### PR DESCRIPTION
This approach passes flow. I tested it w/ a prod build.

:eyeglasses: @keybase/react-hackers 