### PR TITLE
Zanderz/dokan 2016.09.07

### DIFF
--- a/go/tools/dokanclean/main.go
+++ b/go/tools/dokanclean/main.go
@@ -80,8 +80,10 @@ func removeKeybaseStartupShortcuts() {
 // If not just listing, execute each uninstaller we find and merge return codes.
 func findDokanUninstall(list bool, wow64 bool) (result int) {
 	var access uint32 = registry.ENUMERATE_SUB_KEYS | registry.QUERY_VALUE
+	// Assume this is build 32 bit, so we need this flag to see 64 but registry
+	//   https://msdn.microsoft.com/en-us/library/windows/desktop/aa384129(v=vs.110).aspx
 	if wow64 {
-		access = access | registry.WOW64_32KEY
+		access = access | registry.WOW64_64KEY
 	}
 
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall", access)
@@ -103,7 +105,11 @@ func findDokanUninstall(list bool, wow64 bool) (result int) {
 		}
 
 		displayName, _, err := subKey.GetStringValue("DisplayName")
+		if list {
+			fmt.Printf("  %s -- %s\n", name, displayName)
+		}
 		if err == nil && strings.HasPrefix(displayName, "Dokan Library") {
+
 			fmt.Printf("Found %s  %s\n", displayName, name)
 			uninstall, _, err := subKey.GetStringValue("QuietUninstallString")
 			if err != nil {
@@ -124,8 +130,10 @@ func main() {
 	listPtr := flag.Bool("l", false, "list only, don't perform uninstall")
 
 	flag.Parse()
-
 	code := findDokanUninstall(*listPtr, false)
+	if *listPtr {
+		fmt.Print(" -- wow64 -- \n")
+	}
 	code = mergeResults(code, findDokanUninstall(*listPtr, true))
 	if !*listPtr {
 		removeKeybaseStartupShortcuts()

--- a/go/tools/dokanclean/main.go
+++ b/go/tools/dokanclean/main.go
@@ -78,6 +78,8 @@ func removeKeybaseStartupShortcuts() {
 
 // Read all the uninstall subkeys and find the ones with DisplayName starting with "Dokan Library".
 // If not just listing, execute each uninstaller we find and merge return codes.
+// TODO: only delete the one matching the product key the keybase installer writes to the registry
+// https://keybase.atlassian.net/browse/CORE-3743
 func findDokanUninstall(list bool, wow64 bool) (result int) {
 	var access uint32 = registry.ENUMERATE_SUB_KEYS | registry.QUERY_VALUE
 	// Assume this is build 32 bit, so we need this flag to see 64 but registry

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -24,8 +24,7 @@
       <InstallValidate Suppress="yes">FAKE_PROPERTY</InstallValidate>
       <Custom Action="StopUpdater" Before="InstallValidate"/>
       <Custom Action="StopGUI" Before="InstallValidate"/>
-      <Custom Action="StopMainApp" Before="StopKBFS"/>
-      <Custom Action="StopKBFS" Before="InstallValidate"/>
+      <Custom Action="StopMainApp" Before="InstallValidate"/>
       <Custom Action="RunMainApp" Before="InstallFinalize">NOT (REMOVE ~= "ALL")</Custom>
       <Custom Action="RunGUI" Before="InstallFinalize">NOT (REMOVE ~= "ALL")</Custom>
     </InstallExecuteSequence>
@@ -201,14 +200,6 @@
     <CustomAction Id="StopMainApp"
               Directory="INSTALLFOLDER"
               ExeCommand="[INSTALLFOLDER]runquiet.exe -wait &quot;[INSTALLFOLDER]keybase.exe&quot; ctl stop --kill-kbfs"
-              Execute="immediate"
-              Return="ignore"/>
-  </Fragment>
-  <Fragment>
-    <!-- This is just in case kill-kbfs doesn't work -->
-    <CustomAction Id="StopKBFS"
-              Directory="INSTALLFOLDER"
-              ExeCommand="[INSTALLFOLDER]runquiet.exe -wait [WindowsFolder]\System32\taskkill.exe /F /IM kbfsdokan.exe"
               Execute="immediate"
               Return="ignore"/>
   </Fragment>

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -98,7 +98,16 @@
         </RegistryKey>
         <File Id="upd.exe" Source="$(env.GOPATH)\src\github.com\keybase\go-updater\service\upd.exe" Checksum="yes"/>
       </Component>
-
+      
+      <Component Id="RegistryEntries" Guid="{753F8CE7-57CF-4824-865F-55B1FA520C48}">
+        <RegistryKey Root="HKCU"
+                     Key="Software\Keybase\Keybase"
+              Action="createAndRemoveOnUninstall">
+          <RegistryValue Type="string" Name="DOKANPRODUCT86" Value="[DOKANPRODUCT86]"/>
+          <RegistryValue Type="string" Name="DOKANPRODUCT64" Value="[DOKANPRODUCT64]"/>
+        </RegistryKey>
+      </Component>
+      
     </ComponentGroup>
   </Fragment>
   <Fragment>

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -97,7 +97,7 @@
         </RegistryKey>
         <File Id="upd.exe" Source="$(env.GOPATH)\src\github.com\keybase\go-updater\service\upd.exe" Checksum="yes"/>
       </Component>
-      
+      <!-- The cleaner will look at these to make sure it only scrubs the driver we installed -->
       <Component Id="RegistryEntries" Guid="{753F8CE7-57CF-4824-865F-55B1FA520C48}">
         <RegistryKey Root="HKCU"
                      Key="Software\Keybase\Keybase"

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -24,7 +24,7 @@
       <InstallValidate Suppress="yes">FAKE_PROPERTY</InstallValidate>
       <Custom Action="StopUpdater" Before="InstallValidate"/>
       <Custom Action="StopGUI" Before="InstallValidate"/>
-      <Custom Action="StopMainApp" Before="InstallValidate"/>
+      <Custom Action="StopMainApp" Before="StopKBFS"/>
       <Custom Action="StopKBFS" Before="InstallValidate"/>
       <Custom Action="RunMainApp" Before="InstallFinalize">NOT (REMOVE ~= "ALL")</Custom>
       <Custom Action="RunGUI" Before="InstallFinalize">NOT (REMOVE ~= "ALL")</Custom>

--- a/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
@@ -259,7 +259,7 @@
     <!-- check for GDR/LDR version. See https://github.com/dokan-dev/dokany/commit/9782a6491775ef3660a71f40f381d3f48e511f14 -->
     <bal:Condition
       Message="Microsoft patch KB3033929 is not installed. A reboot is needed between the installation of said patch and the installation of Keybase. https://support.microsoft.com/en-us/kb/3033929">
-      <![CDATA[Installed OR VersionNT > v6.1 OR (VersionNT = v6.1 AND ((WINTRUSTVERSION >= v6.1.7601.18741 AND WINTRUSTVERSION <= v6.1.7601.22000) OR WINTRUSTVERSION >= v6.1.7601.22947))]]>
+      <![CDATA[Installed OR VersionNT > v6.1 OR (VersionNT = v6.1 AND ((WINTRUSTVERSION >= v6.1.7601.18741 AND WINTRUSTVERSION < v6.1.7601.22000) OR WINTRUSTVERSION >= v6.1.7601.22948))]]>
     </bal:Condition>
   </Fragment>
   <Fragment>

--- a/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
@@ -6,6 +6,9 @@
   <Bundle Name="Keybase" Version="$(env.KEYBASE_WINVER)" Manufacturer="Keybase, Inc." UpgradeCode="418432ab-0366-40fd-a396-8cc0c4200252">
 
     <Variable Name="DokanInstallFolder" Type="string" Value="[ProgramFiles6432Folder]Dokan\Dokan Library-1.0.0"/>
+    <!-- These match Keybase's Dokany Build 70 Sept 7 2016 -->
+    <Variable Name="DokanProduct86" Type="string" Value="{65A3A986-3DC3-0100-0000-160907160859}"/>
+    <Variable Name="DokanProduct64" Type="string" Value="{65A3A964-3DC3-0100-0000-160907160859}"/>
 
     <Log PathVariable="LOGPATH_PROP"/>
     <util:FileSearchRef Id='WINTRUST_FileSearch' />
@@ -31,7 +34,7 @@
     <util:RegistrySearch Id="DokanUninstall"
              Variable="DokanUninstallString"
              Root="HKLM"
-             Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{65A3A986-3DC3-0100-0000-160803110110}"
+             Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\[DokanProduct86]"
              Value="UninstallString"
              Format="raw"
              />
@@ -40,7 +43,7 @@
                  Condition="NOT DokanUninstallString"
                  Variable="DokanUninstallString"
                  Root="HKLM"
-                 Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{65A3A964-3DC3-0100-0000-160803110110}"
+                 Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\[DokanProduct64]"
                  Value="UninstallString"
                  Format="raw"
                  Win64="yes"
@@ -241,6 +244,8 @@
                   SourceFile="$(var.KeybaseApps.TargetPath)"
                   DisplayInternalUI='no'
                   Permanent="no">
+        <MsiProperty Name="DOKANPRODUCT86" Value="[DokanProduct86]" />
+        <MsiProperty Name="DOKANPRODUCT64" Value="[DokanProduct64]" />
       </MsiPackage>
 
     </Chain>
@@ -277,7 +282,7 @@
           Value="UninstallString" 
           Win64="yes"/>
 
-    <!-- These two are for the most recent KBFS -->
+    <!-- These two are for the older inno based KBFS -->
     <util:RegistrySearch Id="InnoKBFSUninstall"
                  Variable="InnoKBFSUninstallString"
                  Root="HKLM"

--- a/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
@@ -6,9 +6,9 @@
   <Bundle Name="Keybase" Version="$(env.KEYBASE_WINVER)" Manufacturer="Keybase, Inc." UpgradeCode="418432ab-0366-40fd-a396-8cc0c4200252">
 
     <Variable Name="DokanInstallFolder" Type="string" Value="[ProgramFiles6432Folder]Dokan\Dokan Library-1.0.0"/>
-    <!-- These match Keybase's Dokany Build 70 Sept 7 2016 -->
-    <Variable Name="DokanProduct86" Type="string" Value="{65A3A986-3DC3-0100-0000-160907160859}"/>
-    <Variable Name="DokanProduct64" Type="string" Value="{65A3A964-3DC3-0100-0000-160907160859}"/>
+    <!-- These match Keybase's Dokany Build 71 Sept 7 2016 -->
+    <Variable Name="DokanProduct86" Type="string" Value="{65A3A986-3DC3-0100-0000-160907182735}"/>
+    <Variable Name="DokanProduct64" Type="string" Value="{65A3A964-3DC3-0100-0000-160907182735}"/>
 
     <Log PathVariable="LOGPATH_PROP"/>
     <util:FileSearchRef Id='WINTRUST_FileSearch' />

--- a/packaging/windows/build_prerelease.cmd
+++ b/packaging/windows/build_prerelease.cmd
@@ -52,7 +52,7 @@ popd
 
 :: Runquiet
 pushd %GOPATH%\src\github.com\keybase\client\go\tools\runquiet
-..\winresource\winresource.exe  -d "Keybase quiet start utility" -n "runquiet.exe" -i ../../../media/icons/Keybase.ico
+..\..\keybase\winresource.exe  -d "Keybase quiet start utility" -n "runquiet.exe" -i ../../../media/icons/Keybase.ico
 go build -ldflags "-H windowsgui"
 popd
 


### PR DESCRIPTION
Today's test channel build, v1.0.17-20160908172133+f09996a, is based on this. Before releasing this driver update, I made another client build to test the auto update case, and found a handful of issues that are now fixed with this PR. Part of todays' efforts involved moving our Dokan build to ci.keybase.io, which works now also.

As soon as this is merged, automatic nightly windows builds can be turned on, which @cjb says should automatically go in the test channel each night.

@maxtaco @taruti 