### PR TITLE
Start/stop via ctl should install/uninstall services

### DIFF
--- a/go/client/cmd_ctl_start_osx.go
+++ b/go/client/cmd_ctl_start_osx.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/install"
-	"github.com/keybase/client/go/launchd"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 )
@@ -63,23 +62,22 @@ func ctlStart(g *libkb.GlobalContext, components map[string]bool) error {
 	if libkb.IsBrewBuild {
 		return ctlBrewStart(g)
 	}
-	runMode := g.Env.GetRunMode()
 	g.Log.Debug("Components: %v", components)
 	errs := []error{}
 	if ok := components[install.ComponentNameService.String()]; ok {
-		if err := startLaunchdService(g, install.DefaultServiceLabel(runMode), g.Env.GetServiceInfoPath(), true); err != nil {
+		if err := install.InstallService(g, "", false, g.Log); err != nil {
 			errs = append(errs, err)
 			g.Log.Errorf("%s", err)
 		}
 	}
 	if ok := components[install.ComponentNameKBFS.String()]; ok {
-		if err := startLaunchdService(g, install.DefaultKBFSLabel(runMode), g.Env.GetKBFSInfoPath(), true); err != nil {
+		if err := install.InstallKBFS(g, "", false, g.Log); err != nil {
 			errs = append(errs, err)
 			g.Log.Errorf("%s", err)
 		}
 	}
 	if ok := components[install.ComponentNameUpdater.String()]; ok {
-		if err := launchd.Start(install.DefaultUpdaterLabel(runMode), defaultLaunchdWait, g.Log); err != nil {
+		if err := install.InstallUpdater(g, "", false, g.Log); err != nil {
 			errs = append(errs, err)
 			g.Log.Errorf("%s", err)
 		}

--- a/go/client/cmd_ctl_stop_osx.go
+++ b/go/client/cmd_ctl_stop_osx.go
@@ -80,17 +80,17 @@ func ctlStop(g *libkb.GlobalContext, components map[string]bool, wait time.Durat
 		}
 	}
 	if ok := components[install.ComponentNameService.String()]; ok {
-		if _, err := launchd.Stop(install.DefaultServiceLabel(runMode), wait, g.Log); err != nil {
+		if err := install.UninstallKeybaseServices(runMode, g.Log); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	if ok := components[install.ComponentNameKBFS.String()]; ok {
-		if _, err := launchd.Stop(install.DefaultKBFSLabel(runMode), wait, g.Log); err != nil {
+		if err := install.UninstallKBFSServices(runMode, g.Log); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	if ok := components[install.ComponentNameUpdater.String()]; ok {
-		if _, err := launchd.Stop(install.DefaultUpdaterLabel(runMode), wait, g.Log); err != nil {
+		if err := install.UninstallUpdaterService(runMode, g.Log); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/go/client/cmd_install_osx.go
+++ b/go/client/cmd_install_osx.go
@@ -117,7 +117,9 @@ func (v *CmdInstall) Run() error {
 		}
 		fmt.Fprintf(os.Stdout, "%s\n", out)
 	} else {
-		outputComponentResults(v.G(), "Install", result.ComponentResults)
+		if err := result.Status.GoError(); err != nil {
+			v.G().Log.Errorf("%s", err)
+		}
 	}
 	return nil
 }
@@ -167,7 +169,7 @@ func (v *CmdUninstall) ParseArgv(ctx *cli.Context) error {
 		if libkb.IsBrewBuild {
 			v.components = []string{"service"}
 		} else {
-			v.components = []string{"service", "kbfs", "updater"}
+			v.components = []string{"service", "kbfs", "updater", "fuse", "helper"}
 		}
 	} else {
 		v.components = strings.Split(ctx.String("components"), ",")
@@ -184,16 +186,11 @@ func (v *CmdUninstall) Run() error {
 		}
 		fmt.Fprintf(os.Stdout, "%s\n", out)
 	} else {
-		outputComponentResults(v.G(), "Uninstall", result.ComponentResults)
+		if err := result.Status.GoError(); err != nil {
+			v.G().Log.Errorf("%s", err)
+		}
 	}
 	return nil
-}
-
-func outputComponentResults(g *libkb.GlobalContext, action string, crs []keybase1.ComponentResult) {
-	for _, cr := range crs {
-		cn := install.ComponentNameFromString(cr.Name)
-		g.Log.Info("%s %s: %s", action, cn.Description(), cr.Status.Desc)
-	}
 }
 
 func DiagnoseSocketError(ui libkb.UI, err error) {

--- a/go/install/install.go
+++ b/go/install/install.go
@@ -55,6 +55,10 @@ const (
 	ComponentNameUpdater ComponentName = "updater"
 	// ComponentNameApp is the UI app
 	ComponentNameApp ComponentName = "app"
+	// ComponentNameFuse is the Fuse component
+	ComponentNameFuse ComponentName = "fuse"
+	// ComponentNameHelper is the privileged helper tool
+	ComponentNameHelper ComponentName = "helper"
 	// ComponentNameUnknown is placeholder for unknown components
 	ComponentNameUnknown ComponentName = "unknown"
 )
@@ -80,6 +84,10 @@ func (c ComponentName) Description() string {
 		return "Command Line"
 	case ComponentNameUpdater:
 		return "Updater"
+	case ComponentNameFuse:
+		return "Fuse"
+	case ComponentNameHelper:
+		return "Privileged Helper Tool"
 	}
 	return "Unknown"
 }
@@ -97,6 +105,10 @@ func ComponentNameFromString(s string) ComponentName {
 		return ComponentNameUpdater
 	case string(ComponentNameApp):
 		return ComponentNameApp
+	case string(ComponentNameFuse):
+		return ComponentNameFuse
+	case string(ComponentNameHelper):
+		return ComponentNameHelper
 	}
 	return ComponentNameUnknown
 }

--- a/go/install/update_osx.go
+++ b/go/install/update_osx.go
@@ -16,7 +16,7 @@ func AfterUpdateApply(context Context, willRestart bool, force bool, log Log) er
 	}
 	if reinstallKBFS {
 		log.Info("Re-installing KBFS")
-		err := KBFS(context, "", false, log)
+		err := InstallKBFS(context, "", false, log)
 		if err != nil {
 			log.Errorf("Error re-installing KBFS (after Fuse upgrade): %s", err)
 		}

--- a/go/launchd/launchd.go
+++ b/go/launchd/launchd.go
@@ -134,7 +134,6 @@ func exitStatus(err error) int {
 // Returns true, nil on successful stop.
 // If false, nil is returned it means there was nothing to stop.
 func (s Service) Stop(wait time.Duration) (bool, error) {
-	s.log.Info("Stopping %s", s.label)
 	// We stop by removing the job. This works for non-demand and demand jobs.
 	output, err := exec.Command("/bin/launchctl", "remove", s.label).CombinedOutput()
 	s.log.Debug("Output (launchctl remove): %s", string(output))
@@ -156,6 +155,7 @@ func (s Service) Stop(wait time.Duration) (bool, error) {
 			return false, waitErr
 		}
 	}
+	s.log.Info("Stopped %s", s.label)
 	return true, nil
 }
 
@@ -200,11 +200,11 @@ func (s Service) WaitForExit(wait time.Duration) error {
 			running = false
 			break
 		}
-		// Tell user we're waiting for exit after 4 seconds, every 4 seconds
-		if i%4 == 0 {
+		// Tell user we're waiting for exit every second
+		if i%5 == 0 {
 			s.log.Info("Waiting for %s to exit...", s.label)
 		}
-		time.Sleep(time.Second)
+		time.Sleep(200 * time.Millisecond)
 		i++
 	}
 	if running {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -429,10 +429,17 @@ func FormatTime(t Time) string {
 }
 
 func (s Status) Error() string {
-	if s.Code == 0 {
+	if s.Code == int(StatusCode_SCOk) {
 		return ""
 	}
 	return fmt.Sprintf("%s (%s/%d)", s.Desc, s.Name, s.Code)
+}
+
+func (s Status) GoError() error {
+	if s.Code == int(StatusCode_SCOk) {
+		return nil
+	}
+	return fmt.Errorf(s.Error())
 }
 
 func (s InstallStatus) String() string {

--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.39</string>
+	<string>1.1.40</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.39</string>
+	<string>1.1.40</string>
 	<key>KBFuseBuild</key>
 	<string>3.4.2</string>
 	<key>KBFuseVersion</key>

--- a/osx/Utils/Settings.h
+++ b/osx/Utils/Settings.h
@@ -14,9 +14,12 @@
 typedef NS_OPTIONS (NSUInteger, UninstallOptions) {
   UninstallOptionNone = 0,
   UninstallOptionApp = 1 << 0,
-  UninstallOptionKext = 1 << 1,
+  UninstallOptionFuse = 1 << 1,
   UninstallOptionMountDir = 1 << 2,
   UninstallOptionHelper = 1 << 3,
+
+  // Uninstall all (except for app)
+  UninstallOptionAll = UninstallOptionMountDir | UninstallOptionFuse | UninstallOptionHelper,
 };
 
 @interface Settings : NSObject

--- a/osx/Utils/Settings.m
+++ b/osx/Utils/Settings.m
@@ -37,9 +37,10 @@
   [parser registerOption:@"app-path" shortcut:'a' requirement:GBValueRequired];
   [parser registerOption:@"run-mode" shortcut:'r' requirement:GBValueRequired];
   [parser registerSwitch:@"uninstall-app"];
-  [parser registerSwitch:@"uninstall-kext"];
+  [parser registerSwitch:@"uninstall-fuse"];
   [parser registerSwitch:@"uninstall-mountdir"];
   [parser registerSwitch:@"uninstall-helper"];
+  [parser registerSwitch:@"uninstall"];
   [parser registerSwitch:@"install-fuse"];
   [parser registerSettings:self.settings];
   NSArray *subargs = [args subarrayWithRange:NSMakeRange(1, args.count-1)];
@@ -54,8 +55,8 @@
   if ([[self.settings objectForKey:@"uninstall-app"] boolValue]) {
     self.uninstallOptions |= UninstallOptionApp;
   }
-  if ([[self.settings objectForKey:@"uninstall-kext"] boolValue]) {
-    self.uninstallOptions |= UninstallOptionKext;
+  if ([[self.settings objectForKey:@"uninstall-fuse"] boolValue]) {
+    self.uninstallOptions |= UninstallOptionFuse;
   }
   if ([[self.settings objectForKey:@"uninstall-mountdir"] boolValue]) {
     self.uninstallOptions |= UninstallOptionMountDir;
@@ -63,6 +64,10 @@
   if ([[self.settings objectForKey:@"uninstall-helper"] boolValue]) {
     self.uninstallOptions |= UninstallOptionHelper;
   }
+  if ([[self.settings objectForKey:@"uninstall"] boolValue]) {
+    self.installOptions |= UninstallOptionAll;
+  }
+
   if ([[self.settings objectForKey:@"install-fuse"] boolValue]) {
     self.installOptions |= KBInstallOptionFuse;
   }

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -76,7 +76,7 @@ shared_support_dir="$out_dir/Keybase.app/Contents/SharedSupport"
 resources_dir="$out_dir/Keybase.app/Contents/Resources/"
 
 # The KeybaseInstaller.app installs KBFuse, keybase.Helper, services and CLI via a native app
-installer_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseInstaller-1.1.39-darwin.tgz"
+installer_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseInstaller-1.1.40-darwin.tgz"
 # KeybaseUpdater.app is the native updater UI (prompt dialogs)
 updater_url="https://github.com/keybase/client/releases/download/v1.0.16/KeybaseUpdater-1.0.3-darwin.tgz"
 


### PR DESCRIPTION
See https://keybase.atlassian.net/browse/DESKTOP-1756

Currently we are leaving behind launchd plists on stop. This makes it so it stops the services and removes the plists.

The PR makes some install/uninstall methods public and uses them in ctl start/stop on macOS.

Also:
- Adds removal of fuse and helper to `keybase uninstall`
- Lowers launchd status delay from 1s to 200ms
- Don't log that we're stopping a service that doesn't exist
- Bump installer version