### PR TITLE
Delint

### DIFF
--- a/go/pvl/api_stub.go
+++ b/go/pvl/api_stub.go
@@ -11,7 +11,7 @@ import (
 	libkb "github.com/keybase/client/go/libkb"
 )
 
-type StubAPIEngine struct {
+type stubAPIEngine struct {
 	expectations map[string]stubAPIEngineExpectation
 	calls        []stubAPIEngineCallRecord
 }
@@ -27,14 +27,14 @@ type stubAPIEngineCallRecord struct {
 	endpoint string
 }
 
-func NewStubAPIEngine() *StubAPIEngine {
-	return &StubAPIEngine{
+func newStubAPIEngine() *stubAPIEngine {
+	return &stubAPIEngine{
 		expectations: make(map[string]stubAPIEngineExpectation),
 		calls:        make([]stubAPIEngineCallRecord, 0),
 	}
 }
 
-func (e *StubAPIEngine) Get(arg libkb.APIArg) (*libkb.ExternalAPIRes, error) {
+func (e *stubAPIEngine) Get(arg libkb.APIArg) (*libkb.ExternalAPIRes, error) {
 	res, _, _, err := e.getMock(arg, libkb.XAPIResJSON)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func (e *StubAPIEngine) Get(arg libkb.APIArg) (*libkb.ExternalAPIRes, error) {
 
 }
 
-func (e *StubAPIEngine) GetHTML(arg libkb.APIArg) (*libkb.ExternalHTMLRes, error) {
+func (e *stubAPIEngine) GetHTML(arg libkb.APIArg) (*libkb.ExternalHTMLRes, error) {
 	_, res, _, err := e.getMock(arg, libkb.XAPIResHTML)
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (e *StubAPIEngine) GetHTML(arg libkb.APIArg) (*libkb.ExternalHTMLRes, error
 	return res, nil
 }
 
-func (e *StubAPIEngine) GetText(arg libkb.APIArg) (*libkb.ExternalTextRes, error) {
+func (e *stubAPIEngine) GetText(arg libkb.APIArg) (*libkb.ExternalTextRes, error) {
 	_, _, res, err := e.getMock(arg, libkb.XAPIResText)
 	if err != nil {
 		return nil, err
@@ -59,27 +59,27 @@ func (e *StubAPIEngine) GetText(arg libkb.APIArg) (*libkb.ExternalTextRes, error
 	return res, nil
 }
 
-func (e *StubAPIEngine) Post(arg libkb.APIArg) (*libkb.ExternalAPIRes, error) {
+func (e *stubAPIEngine) Post(arg libkb.APIArg) (*libkb.ExternalAPIRes, error) {
 	return nil, fmt.Errorf("unsupported operation Post for stub api")
 }
 
-func (e *StubAPIEngine) PostHTML(arg libkb.APIArg) (*libkb.ExternalHTMLRes, error) {
+func (e *stubAPIEngine) PostHTML(arg libkb.APIArg) (*libkb.ExternalHTMLRes, error) {
 	return nil, fmt.Errorf("unsupported operation Post for stub api")
 }
 
-func (e *StubAPIEngine) Set(endpoint string, canned *libkb.ExternalAPIRes) {
+func (e *stubAPIEngine) Set(endpoint string, canned *libkb.ExternalAPIRes) {
 	e.setCommon(endpoint, canned, nil, nil)
 }
 
-func (e *StubAPIEngine) SetHTML(endpoint string, canned *libkb.ExternalHTMLRes) {
+func (e *stubAPIEngine) SetHTML(endpoint string, canned *libkb.ExternalHTMLRes) {
 	e.setCommon(endpoint, nil, canned, nil)
 }
 
-func (e *StubAPIEngine) SetText(endpoint string, canned *libkb.ExternalTextRes) {
+func (e *stubAPIEngine) SetText(endpoint string, canned *libkb.ExternalTextRes) {
 	e.setCommon(endpoint, nil, nil, canned)
 }
 
-func (e *StubAPIEngine) setCommon(endpoint string, e1 *libkb.ExternalAPIRes, e2 *libkb.ExternalHTMLRes, e3 *libkb.ExternalTextRes) {
+func (e *stubAPIEngine) setCommon(endpoint string, e1 *libkb.ExternalAPIRes, e2 *libkb.ExternalHTMLRes, e3 *libkb.ExternalTextRes) {
 	entry := e.expectations[endpoint]
 	if e1 != nil {
 		entry.JSON = e1
@@ -93,11 +93,11 @@ func (e *StubAPIEngine) setCommon(endpoint string, e1 *libkb.ExternalAPIRes, e2 
 	e.expectations[endpoint] = entry
 }
 
-func (e *StubAPIEngine) ResetCalls() {
+func (e *stubAPIEngine) ResetCalls() {
 	e.calls = make([]stubAPIEngineCallRecord, 0)
 }
 
-func (e *StubAPIEngine) AssertCalledOnceWith(kind libkb.XAPIResType, endpoint string) error {
+func (e *stubAPIEngine) AssertCalledOnceWith(kind libkb.XAPIResType, endpoint string) error {
 	if len(e.calls) == 0 {
 		return fmt.Errorf("stub api not called")
 	}
@@ -113,7 +113,7 @@ func (e *StubAPIEngine) AssertCalledOnceWith(kind libkb.XAPIResType, endpoint st
 	return nil
 }
 
-func (e *StubAPIEngine) getMock(arg libkb.APIArg, restype libkb.XAPIResType) (
+func (e *stubAPIEngine) getMock(arg libkb.APIArg, restype libkb.XAPIResType) (
 	*libkb.ExternalAPIRes, *libkb.ExternalHTMLRes, *libkb.ExternalTextRes, error) {
 	e.calls = append(e.calls, stubAPIEngineCallRecord{
 		kind:     restype,

--- a/go/pvl/debug.go
+++ b/go/pvl/debug.go
@@ -11,46 +11,46 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
-type ProofContextExt interface {
+type proofContextExt interface {
 	libkb.ProofContext
 	GetLogPvl() logger.Logger
 }
 
-type ProofContextExtImpl struct {
+type proofContextExtImpl struct {
 	libkb.ProofContext
 	pvlLogger logger.Logger
 }
 
-func NewProofContextExt(ctx libkb.ProofContext) ProofContextExt {
+func newProofContextExt(ctx libkb.ProofContext) proofContextExt {
 	pvlLogger := ctx.GetLog().CloneWithAddedDepth(1)
-	return &ProofContextExtImpl{
+	return &proofContextExtImpl{
 		ctx,
 		pvlLogger,
 	}
 }
 
-func (ctx *ProofContextExtImpl) GetLogPvl() logger.Logger {
+func (ctx *proofContextExtImpl) GetLogPvl() logger.Logger {
 	return ctx.pvlLogger
 }
 
-func debugWithState(g ProofContextExt, state ScriptState, format string, arg ...interface{}) {
+func debugWithState(g proofContextExt, state scriptState, format string, arg ...interface{}) {
 	s := fmt.Sprintf(format, arg...)
 	g.GetLogPvl().Debug("PVL @(service:%v script:%v pc:%v) %v",
 		debugServiceToString(state.Service), state.WhichScript, state.PC, s)
 }
 
-func debugWithStateError(g ProofContextExt, state ScriptState, err libkb.ProofError) {
+func debugWithStateError(g proofContextExt, state scriptState, err libkb.ProofError) {
 	g.GetLogPvl().Debug("PVL @(service:%v script:%v pc:%v) Error code=%v: %v",
 		debugServiceToString(state.Service), state.WhichScript, state.PC, err.GetProofStatus(), err.GetDesc())
 }
 
-func debugWithPosition(g ProofContextExt, service keybase1.ProofType, whichscript int, pc int, format string, arg ...interface{}) {
+func debugWithPosition(g proofContextExt, service keybase1.ProofType, whichscript int, pc int, format string, arg ...interface{}) {
 	s := fmt.Sprintf(format, arg...)
 	g.GetLogPvl().Debug("PVL @(service:%v script:%v pc:%v) %v",
 		debugServiceToString(service), whichscript, pc, s)
 }
 
-func debug(g ProofContextExt, format string, arg ...interface{}) {
+func debug(g proofContextExt, format string, arg ...interface{}) {
 	s := fmt.Sprintf(format, arg...)
 	g.GetLogPvl().Debug("PVL %v", s)
 }

--- a/go/pvl/hardcoded.go
+++ b/go/pvl/hardcoded.go
@@ -108,6 +108,7 @@ var hardcodedPVLString = `
 }
 `
 
+// GetHardcodedPvl returns the parsed hardcoded pvl
 func GetHardcodedPvl() *jsonw.Wrapper {
 	return &hardcodedPVL
 }

--- a/go/pvl/helpers.go
+++ b/go/pvl/helpers.go
@@ -21,14 +21,14 @@ import (
 // Only substitutes whitelisted variables.
 // It is an error to refer to an unknown variable or undefined numbered group.
 // Match is an optional slice which is a regex match.
-func substitute(template string, state ScriptState, match []string) (string, libkb.ProofError) {
+func substitute(template string, state scriptState, match []string) (string, libkb.ProofError) {
 	vars := state.Vars
 	webish := (state.Service == keybase1.ProofType_DNS || state.Service == keybase1.ProofType_GENERIC_WEB_SITE)
 
 	var outerr libkb.ProofError
 	// Regex to find %{name} occurrences.
 	// Match broadly here so that even %{} is sent to the default case and reported as invalid.
-	re := regexp.MustCompile("%\\{[\\w]*\\}")
+	re := regexp.MustCompile(`%\{[\w]*\}`)
 	substituteOne := func(vartag string) string {
 		// Strip off the %, {, and }
 		varname := vartag[2 : len(vartag)-1]
@@ -94,7 +94,7 @@ func jsonHasKey(w *jsonw.Wrapper, key string) bool {
 	return !w.AtKey(key).IsNil()
 }
 
-func jsonHasKeyCommand(w *jsonw.Wrapper, key CommandName) bool {
+func jsonHasKeyCommand(w *jsonw.Wrapper, key commandName) bool {
 	return !w.AtKey(string(key)).IsNil()
 }
 

--- a/go/pvl/helpers_test.go
+++ b/go/pvl/helpers_test.go
@@ -15,8 +15,8 @@ import (
 	jsonw "github.com/keybase/go-jsonw"
 )
 
-func sampleState() ScriptState {
-	var sampleVars = ScriptVariables{
+func sampleState() scriptState {
+	var sampleVars = scriptVariables{
 		UsernameService: "kronk",
 		UsernameKeybase: "kronk_on_kb",
 		Sig:             []byte{1, 2, 3, 4, 5},
@@ -25,7 +25,7 @@ func sampleState() ScriptState {
 		Hostname:        "%{sig_id_medium}",
 	}
 
-	var sampleState = ScriptState{
+	var sampleState = scriptState{
 		WhichScript:  0,
 		PC:           0,
 		Service:      keybase1.ProofType_TWITTER,
@@ -33,7 +33,7 @@ func sampleState() ScriptState {
 		ActiveString: "",
 		FetchURL:     "<<NONE>>",
 		HasFetched:   false,
-		FetchResult:  nil,
+		fetchResult:  nil,
 	}
 
 	return sampleState
@@ -84,7 +84,7 @@ func TestJSONHasKey(t *testing.T) {
 		if jsonHasKey(test.json, test.key) != test.has {
 			t.Fatalf("%v %v", i, !test.has)
 		}
-		if jsonHasKeyCommand(test.json, CommandName(test.key)) != test.has {
+		if jsonHasKeyCommand(test.json, commandName(test.key)) != test.has {
 			t.Fatalf("%v %v", i, !test.has)
 		}
 	}

--- a/go/pvl/interp_test.go
+++ b/go/pvl/interp_test.go
@@ -528,7 +528,7 @@ func runPvlTest(t *testing.T, unit *interpUnitTest) {
 
 	tc := libkb.SetupTest(t, unit.name, 1)
 	g := tc.G
-	xapi := NewStubAPIEngine()
+	xapi := newStubAPIEngine()
 	g.XAPI = xapi
 
 	pvl, err := makeTestPvl(unit.prepvl)


### PR DESCRIPTION
Export only that which needs to be exported. Even though that makes identifiers look silly in Go imho. :) This is entirely s/Public/private.

I aimed to please `gometalinter`, but it's very confused. Many of these:
```
interp.go:502:30:error: undeclared name: keybase1 (gotype)
```

r? @gabriel 