### PR TITLE
Have a timeout for our requestIdleCallback

### DIFF
--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -425,6 +425,8 @@ function serverCallMap (dispatch: Dispatch, getState: Function, skipPopups: bool
 
   const requestIdle = f => {
     if (!alreadyPending) {
+      // The timeout with the requestIdleCallback says f must be run when idle or if 1 second passes whichover comes first.
+      // The timeout is necessary because the callback fn f won't be called if the window is hidden.
       requestIdleCallback(f, {timeout: 1e3})
     } else {
       console.log('skipped idle call due to already pending')

--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -425,7 +425,7 @@ function serverCallMap (dispatch: Dispatch, getState: Function, skipPopups: bool
 
   const requestIdle = f => {
     if (!alreadyPending) {
-      requestIdleCallback(f)
+      requestIdleCallback(f, {timeout: 1e3})
     } else {
       console.log('skipped idle call due to already pending')
     }
@@ -643,7 +643,7 @@ function serverCallMap (dispatch: Dispatch, getState: Function, skipPopups: bool
         }
 
         onFinish && onFinish()
-      })
+      }, {timeout: 1e3})
 
       // if we're pending we still want to call onFinish
       if (alreadyPending) {

--- a/shared/engine/transport-shared.js
+++ b/shared/engine/transport-shared.js
@@ -77,7 +77,7 @@ function rpcLog (type: rpcLogType, title: string, info?: Object): void {
 
   requestIdleCallback(() => {
     logLocal(`%c${prefix}`, style, title, info)
-  })
+  }, {timeout: 1e3})
 }
 
 class TransportShared extends RobustTransport {

--- a/shared/store/action-logger.js
+++ b/shared/store/action-logger.js
@@ -62,7 +62,7 @@ export const actionLogger = (store: any) => (next: any) => (action: any) => {
     console.log.apply(console, log1)
     console.log.apply(console, log2)
     console.groupEnd && console.groupEnd()
-  })
+  }, {timeout: 1e3})
 
   // Make sure to print these after the groupEnd
   printTimingStats(shouldRunLogStats, loggingStatSink, true, 3)

--- a/shared/store/configure-store.js
+++ b/shared/store/configure-store.js
@@ -38,7 +38,7 @@ for (const method in console) {
     logger[method] = (...args) => {
       requestIdleCallback(() => {
         console[method](...args)
-      })
+      }, {timeout: 1e3})
     }
   }
 }


### PR DESCRIPTION
@keybase/react-hackers 

A tricky bug where tracker windows weren't coming up unless the main window was visible.

requestIdleCallback isn't called when the window is hidden, but we can specify a timeout which says we should call this function for sure after `timeout` has passed.

I went through our usages, and I feel like each of them should be called at least once a second for usability and our ability to debug log sends.