### PR TITLE
Configure proof services for mobile

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"sync"
 
+	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -40,6 +41,7 @@ func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride
 	fmt.Printf("Go: Using log: %s\n", logFile)
 	kbCtx = libkb.G
 	kbCtx.Init()
+	kbCtx.SetServices(externals.GetServices())
 	usage := libkb.Usage{
 		Config:    true,
 		API:       true,

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -15,6 +15,10 @@ import (
 //=============================================================================
 
 func MakeProofChecker(c ExternalServicesCollector, l RemoteProofChainLink) (ProofChecker, ProofError) {
+	if c == nil {
+		return nil, NewProofError(keybase1.ProofStatus_UNKNOWN_TYPE,
+			"No proof services configured")
+	}
 	k := l.TableKey()
 	st := c.GetServiceType(k)
 	if st == nil {

--- a/react-native/gobuild.sh
+++ b/react-native/gobuild.sh
@@ -69,7 +69,7 @@ echo "Build gomobile..."
 rsync -pr --ignore-times "$vendor_path/" "$GOPATH/src/"
 
 if [ ! "$skip_gomobile_init" = "1" ]; then
-  echo "Doing gomobile init"
+  echo "Doing gomobile init (to skip, set SKIP_GOMOBILE_INIT=1)"
   "$GOPATH/bin/gomobile" init
 fi
 

--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -235,23 +235,27 @@ function * _listSaga (): SagaGenerator<any, any> {
     return
   }
 
-  const results = yield call(apiserverGetRpcPromise, {
-    param: {
-      endpoint: 'kbfs/favorite/list',
-      args: [{key: 'problems', value: '1'}],
-    },
-  })
-  const username = yield select(state => state.config && state.config.username)
-  const loggedIn = yield select(state => state.config && state.config.loggedIn)
-  const state: FolderState = _folderToState(results && results.body, username || '', loggedIn || false)
+  try {
+    const results = yield call(apiserverGetRpcPromise, {
+      param: {
+        endpoint: 'kbfs/favorite/list',
+        args: [{key: 'problems', value: '1'}],
+      },
+    })
+    const username = yield select(state => state.config && state.config.username)
+    const loggedIn = yield select(state => state.config && state.config.loggedIn)
+    const state: FolderState = _folderToState(results && results.body, username || '', loggedIn || false)
 
-  const listedAction: FavoriteListed = {type: Constants.favoriteListed, payload: {folders: state}}
-  yield put(listedAction)
+    const listedAction: FavoriteListed = {type: Constants.favoriteListed, payload: {folders: state}}
+    yield put(listedAction)
 
-  const badgeAction: Action = badgeApp('newTLFs', !!(state.publicBadge || state.privateBadge))
-  yield put(badgeAction)
+    const badgeAction: Action = badgeApp('newTLFs', !!(state.publicBadge || state.privateBadge))
+    yield put(badgeAction)
 
-  yield call(_notify, state)
+    yield call(_notify, state)
+  } catch (e) {
+    console.warn('Error listing favorites:', e)
+  }
 }
 
 // If the notify data has changed, show a popup

--- a/shared/search/index.js
+++ b/shared/search/index.js
@@ -52,7 +52,7 @@ export default connector.connect(
      showUserGroup,
      selectedUsers,
      onRemoveUserFromGroup: user => { dispatch(removeUserFromGroup(user)) },
-     onClickUserInGroup: user => { dispatch(isMobile ? routeAppend({path: 'profile', username: user.username}) : selectUserForInfo(user)) },
+     onClickUserInGroup: user => { dispatch(isMobile ? routeAppend({path: 'profile', userOverride: {username: user.username}}) : selectUserForInfo(user)) },
      onReset: () => { dispatch(reset()) },
      onAddAnotherUserToGroup: () => { dispatch(hideUserGroup()) },
      onOpenPrivateGroupFolder: () => { username && dispatch(openInKBFS(privateFolderWithUsers(selectedUsers.map(searchResultToAssertion).concat(username)))) },


### PR DESCRIPTION
Fixes crash in proof checking on mobile (esp. for coyne), need to `SetServices`.

Also some other unrelated mobile fixes:
- Wrap favorites list saga in try catch
- Fix clicking on user in search going to the actual user
- Pro tip to skip gomobile init