### PR TITLE
Show new paper keys in the devices tab after creation

### DIFF
--- a/shared/devices/gen-paper-key/index.js
+++ b/shared/devices/gen-paper-key/index.js
@@ -13,7 +13,8 @@ type State = {
 type Props = {
   paperKey: HiddenString,
   generatePaperKey: () => void,
-  onBack: () => void
+  onBack: () => void,
+  onFinish: () => void
 }
 
 class GenPaperKey extends Component<void, Props, State> {

--- a/shared/devices/gen-paper-key/index.js
+++ b/shared/devices/gen-paper-key/index.js
@@ -3,7 +3,7 @@ import HiddenString from '../../util/hidden-string'
 import React, {Component} from 'react'
 import Render from '../../login/signup/success/index.render'
 import {connect} from 'react-redux'
-import {generatePaperKey} from '../../actions/devices'
+import {generatePaperKey, loadDevices} from '../../actions/devices'
 import {navigateUp} from '../../actions/router'
 
 type State = {
@@ -46,7 +46,7 @@ class GenPaperKey extends Component<void, Props, State> {
       <Render
         paperkey={this.props.paperKey}
         waiting={false}
-        onFinish={this.props.onBack}
+        onFinish={this.props.onFinish}
         onBack={this.props.onBack}
         title='Paper key generated!'
       />
@@ -64,6 +64,10 @@ export default connect(
     return {
       generatePaperKey: () => dispatch(generatePaperKey()),
       onBack: () => dispatch(navigateUp()),
+      onFinish: () => {
+        dispatch(loadDevices())
+        dispatch(navigateUp())
+      },
     }
   }
 )(GenPaperKey)


### PR DESCRIPTION
@keybase/react-hackers 

We weren't refreshing the devices list after creating a new paper key.