### PR TITLE
Improve scan-proofs

### DIFF
--- a/go/engine/scanproofs.go
+++ b/go/engine/scanproofs.go
@@ -335,7 +335,8 @@ func (e *ScanProofsEngine) ProcessOne(i int, rec map[string]string, cache *ScanP
 	if err != nil {
 		return err
 	}
-	perr2, foundhint2, err := e.CheckOne(rec, true, tickers)
+	// Skip the rate limit on the second check.
+	perr2, foundhint2, err := e.CheckOne(rec, true, nil)
 	if err != nil {
 		return err
 	}

--- a/go/engine/scanproofs.go
+++ b/go/engine/scanproofs.go
@@ -276,7 +276,7 @@ func (e *ScanProofsEngine) Run(ctx *Context) (err error) {
 func (e *ScanProofsEngine) ProcessOne(i int, rec map[string]string, cache *ScanProofsCache, ignored []string, tickers ScanProofsTickers) error {
 	serverstate, err := strconv.Atoi(rec["state"])
 	if err != nil {
-		return fmt.Errorf("Could not read serverstate: %v", err)
+		return fmt.Errorf("Could not read server state: %v", err)
 	}
 
 	shouldsucceed := true
@@ -331,8 +331,13 @@ func (e *ScanProofsEngine) ProcessOne(i int, rec map[string]string, cache *ScanP
 		return nil
 	}
 
+	deluserstr := "Error loading user: Deleted"
 	perr1, foundhint1, err := e.CheckOne(rec, false, tickers)
 	if err != nil {
+		if err.Error() == deluserstr {
+			e.G().Log.Info("deleted user")
+			return nil
+		}
 		return err
 	}
 	// Skip the rate limit on the second check.
@@ -428,7 +433,7 @@ func (e *ScanProofsEngine) GetSigHint(uid keybase1.UID, sigid keybase1.SigID) (*
 func (e *ScanProofsEngine) GetRemoteProofChainLink(uid keybase1.UID, sigid keybase1.SigID) (libkb.RemoteProofChainLink, error) {
 	user, err := libkb.LoadUser(libkb.NewLoadUserByUIDArg(e.G(), uid))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error loading user: %v", err)
 	}
 
 	link := user.LinkFromSigID(sigid)


### PR DESCRIPTION
1. In the case where a sighint doesn't exist on the server, that error was getting dropped on the floor. It should have been marked as a client failure. This actually probably makes up a good portion of the `server=no,client=ok` cases that I was seeing. Those were the reason for making proofd check `PERM_FAILURE`s in the first place. So, whoops. Some of those were valid, just not the ~5000 count that were due to this bug. Anyway, fixed.

2. Saving the cache is pretty slow because it's 16MB (~2s). This update makes it save only when something has changed. Sqlite would be better, but I don't it's worth it.

3. Skip deleted users.

r? @maxtaco 