### PR TITLE
expand protocol for supersede stuff CORE-3571

### DIFF
--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -145,6 +145,7 @@ type MessageServerHeader struct {
 	Sender       gregor1.UID      `codec:"sender" json:"sender"`
 	SenderDevice gregor1.DeviceID `codec:"senderDevice" json:"senderDevice"`
 	SupersededBy MessageID        `codec:"supersededBy" json:"supersededBy"`
+	Supersedes   MessageID        `codec:"supersedes" json:"supersedes"`
 	Ctime        gregor1.Time     `codec:"ctime" json:"ctime"`
 }
 
@@ -157,6 +158,7 @@ type MessageClientHeader struct {
 	Conv         ConversationIDTriple     `codec:"conv" json:"conv"`
 	TlfName      string                   `codec:"tlfName" json:"tlfName"`
 	MessageType  MessageType              `codec:"messageType" json:"messageType"`
+	Supersedes   MessageID                `codec:"supersedes" json:"supersedes"`
 	Prev         []MessagePreviousPointer `codec:"prev" json:"prev"`
 	Sender       gregor1.UID              `codec:"sender" json:"sender"`
 	SenderDevice gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -10,6 +10,7 @@ import (
 
 type MessageBoxed struct {
 	ServerHeader     *MessageServerHeader `codec:"serverHeader,omitempty" json:"serverHeader,omitempty"`
+	SupersededBy     *MessageBoxed        `codec:"supersededBy,omitempty" json:"supersededBy,omitempty"`
 	ClientHeader     MessageClientHeader  `codec:"clientHeader" json:"clientHeader"`
 	HeaderCiphertext EncryptedData        `codec:"headerCiphertext" json:"headerCiphertext"`
 	BodyCiphertext   EncryptedData        `codec:"bodyCiphertext" json:"bodyCiphertext"`

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -93,6 +93,7 @@ protocol common {
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;
     MessageID supersededBy;
+    MessageID supersedes;
     gregor1.Time ctime;
   }
 
@@ -105,6 +106,7 @@ protocol common {
     ConversationIDTriple conv;
     string tlfName;
     MessageType messageType;
+    MessageID supersedes;
     array<MessagePreviousPointer> prev;
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -3,8 +3,9 @@ protocol remote {
 
   record MessageBoxed {
     // Only set when returned from the server; on the way up to the
-    // server, it's null.
+    // server, they are null.
     union { null, MessageServerHeader } serverHeader;
+    union { null, MessageBoxed } supersededBy;
 
     // MessageClientHeader is needed by clients to get keys via TLF name.
     // The server needs it as well for sender uid, device id.

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -200,6 +200,7 @@ export type MarkAsReadRes = {
 
 export type MessageBoxed = {
   serverHeader?: ?MessageServerHeader,
+  supersededBy?: ?MessageBoxed,
   clientHeader: MessageClientHeader,
   headerCiphertext: EncryptedData,
   bodyCiphertext: EncryptedData,
@@ -210,6 +211,7 @@ export type MessageClientHeader = {
   conv: ConversationIDTriple,
   tlfName: string,
   messageType: MessageType,
+  supersedes: MessageID,
   prev?: ?Array<MessagePreviousPointer>,
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
@@ -228,6 +230,7 @@ export type MessageServerHeader = {
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
   supersededBy: MessageID,
+  supersedes: MessageID,
   ctime: gregor1.Time,
 }
 

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -297,6 +297,10 @@
           "name": "supersededBy"
         },
         {
+          "type": "MessageID",
+          "name": "supersedes"
+        },
+        {
           "type": "gregor1.Time",
           "name": "ctime"
         }
@@ -331,6 +335,10 @@
         {
           "type": "MessageType",
           "name": "messageType"
+        },
+        {
+          "type": "MessageID",
+          "name": "supersedes"
         },
         {
           "type": {

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -14,6 +14,13 @@
           "name": "serverHeader"
         },
         {
+          "type": [
+            null,
+            "MessageBoxed"
+          ],
+          "name": "supersededBy"
+        },
+        {
           "type": "MessageClientHeader",
           "name": "clientHeader"
         },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -200,6 +200,7 @@ export type MarkAsReadRes = {
 
 export type MessageBoxed = {
   serverHeader?: ?MessageServerHeader,
+  supersededBy?: ?MessageBoxed,
   clientHeader: MessageClientHeader,
   headerCiphertext: EncryptedData,
   bodyCiphertext: EncryptedData,
@@ -210,6 +211,7 @@ export type MessageClientHeader = {
   conv: ConversationIDTriple,
   tlfName: string,
   messageType: MessageType,
+  supersedes: MessageID,
   prev?: ?Array<MessagePreviousPointer>,
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
@@ -228,6 +230,7 @@ export type MessageServerHeader = {
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
   supersededBy: MessageID,
+  supersedes: MessageID,
   ctime: gregor1.Time,
 }
 


### PR DESCRIPTION
@patrickxb @oconnor663 @maxtaco 

Expand the treatment of the "superseded" idea. Add it to the client header so that when edit messages are sent, we can set the superseded_by field properly. Also expand the definition of `MessageBoxed` to include a `MessageBoxed` pointer to the message that superseded it. 