### PR TITLE
Add showComingSoon to type. Type profile connect

### DIFF
--- a/shared/profile/dumb.js
+++ b/shared/profile/dumb.js
@@ -141,6 +141,7 @@ const following = [
 
 const propsBase: RenderProps = {
   ...mockUserInfo,
+  showComingSoon: false,
   isYou: false,
   loading: false,
   bioEditFns: null,

--- a/shared/profile/index.desktop.js
+++ b/shared/profile/index.desktop.js
@@ -10,7 +10,6 @@ import Friendships from './friendships'
 import {globalStyles, globalColors, globalMargins} from '../styles'
 import ProfileHelp from './help.desktop'
 import * as shared from './index.shared'
-import ErrorComponent from '../common-adapters/error-profile'
 import type {Tab as FriendshipsTab} from './friendships'
 import type {Proof} from '../constants/tracker'
 import type {Props} from './index'
@@ -172,12 +171,8 @@ class ProfileRender extends PureComponent<void, Props, State> {
   }
 
   render () {
-    if (this.props.showComingSoon) {
+    if (this.props.showComingSoon === true) {
       return this._renderComingSoon()
-    }
-
-    if (this.props && this.props.error) {
-      return <ErrorComponent error={this.props.error} />
     }
 
     const {loading} = this.props

--- a/shared/profile/index.js.flow
+++ b/shared/profile/index.js.flow
@@ -34,6 +34,7 @@ export type Props = {
   following: Array<FriendshipUserInfo>,
   reason: ?string,
   error: ?string,
+  showComingSoon: boolean,
 }
 
 export default class Render extends Component<void, Props, void> { }


### PR DESCRIPTION
@keybase/react-hackers 

Oops we leaked the profile tab!

### What happened
https://github.com/keybase/client/commit/cebed74e84925f34ae7b210b7e826d26cbb5d711#diff-d25024c09b8d8f6b8478aac8180d264cL124 we didn't retain the logic to pass feature flags as showComingSoon prop.

#### Compounding problems

1. We didn't add `showComingSoon` to the type of the component (so no error was thrown when we failed to pass it in)

1. the connect was not typed in the container, so even if we had added the type, it would not have been type checked

1. PureComponent is not typed in the same way, so even if the two problems above were fixed Flow would not have caught it (this is still a TODO)

1. showComingSoon was checked for existence rather than `=== true` which meant flow wouldn't complain if it wasn't defined in the render component's type