### PR TITLE
fix profile.proofText

### DIFF
--- a/shared/actions/profile.js
+++ b/shared/actions/profile.js
@@ -404,13 +404,13 @@ function outputInstructionsActionLink (): AsyncAction {
         openURL(`https://coinbase.com/${profile.username}#settings`)
         break
       case 'twitter':
-        openURL(`https://twitter.com/home?status=${profile.proof}`)
+        openURL(`https://twitter.com/home?status=${profile.proofText}`)
         break
       case 'github':
         openURL('https://gist.github.com/')
         break
       case 'reddit':
-        openURL(profile.proof)
+        openURL(profile.proofText)
         break
       default:
         break


### PR DESCRIPTION
@keybase/react-hackers 

This store attribute's name was changed but these callers weren't.  Fixes clicking on "Reddit Form" doing nothing in the proof creation view.