### PR TITLE
Fix Web Proof: Remove ToLower()

### DIFF
--- a/go/externals/proof_support_web.go
+++ b/go/externals/proof_support_web.go
@@ -46,7 +46,7 @@ func (rc *WebChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libkb.P
 
 	files := webKeybaseFiles
 	urlBase := rc.proof.ToDisplayString()
-	theirURL := strings.ToLower(h.GetAPIURL())
+	theirURL := h.GetAPIURL()
 
 	for _, file := range files {
 		ourURL := urlBase + "/" + file


### PR DESCRIPTION
Pulling https://github.com/keybase/client/pull/4182 into a new PR so that CI runs.