### PR TITLE
StandardScreen visual tweaks

### DIFF
--- a/shared/common-adapters/dumb.desktop.js
+++ b/shared/common-adapters/dumb.desktop.js
@@ -306,6 +306,7 @@ const choiceListMap: DumbComponentMap<ChoiceList> = {
 const standardScreenProps = {
   onClose: () => console.log('StandardScreen: onClose'),
   children: <Text type='Header'>Whoa, look at this centered thing</Text>,
+  parentProps: {style: {display: 'flex', height: 578}},
 }
 
 const standardScreenMap: DumbComponentMap<StandardScreen> = {

--- a/shared/common-adapters/standard-screen.desktop.js
+++ b/shared/common-adapters/standard-screen.desktop.js
@@ -20,7 +20,7 @@ const StandardScreen = (props: Props) => {
       <Box style={styleTopStack}>
         {topStack}
       </Box>
-      <Box style={{...styleInnerContainer, paddingBottom: (topStackCount + 1) * globalMargins.large}}>
+      <Box style={{...styleInnerContainer, paddingBottom: topStackCount * globalMargins.large}}>
         {!!props.onClose && <Icon style={{...styleClose, ...props.styleClose}} type='iconfont-close' onClick={props.onClose} />}
         <Box style={{...styleContentContainer, ...props.style}}>
           {props.children}

--- a/shared/common-adapters/standard-screen.desktop.js
+++ b/shared/common-adapters/standard-screen.desktop.js
@@ -8,7 +8,6 @@ const StandardScreen = (props: Props) => {
   return (
     <Box style={{...styleContainer, ...props.styleOuter}}>
       <Box style={styleTopStack}>
-        {!!props.onClose && <Icon style={{...styleClose, ...props.styleClose}} type='iconfont-close' onClick={props.onClose} />}
         {!!props.onBack && <BackButton onClick={props.onBack} style={{...styleBack, ...props.styleBack}} />}
         {!!props.notification && <Box style={{...styleBanner(props.notification.type), ...props.styleBanner}}>
           {typeof props.notification.message === 'string'
@@ -18,6 +17,7 @@ const StandardScreen = (props: Props) => {
         </Box>}
       </Box>
       <Box style={{...styleContentContainer, ...props.style}}>
+        {!!props.onClose && <Icon style={{...styleClose, ...props.styleClose}} type='iconfont-close' onClick={props.onClose} />}
         {props.children}
       </Box>
     </Box>
@@ -28,16 +28,14 @@ const styleContainer = {
   ...globalStyles.flexBoxColumn,
   ...globalStyles.scrollable,
   flex: 1,
-  alignItems: 'center',
+  alignItems: 'stretch',
   position: 'relative',
-  paddingBottom: globalMargins.large,
 }
 
 const styleTopStack = {
   ...globalStyles.flexBoxColumn,
   position: 'relative',
   alignItems: 'stretch',
-  minHeight: globalMargins.large,
   width: '100%',
 }
 
@@ -74,10 +72,11 @@ const styleBannerText = {
 
 const styleContentContainer = {
   ...globalStyles.flexBoxColumn,
+  position: 'relative',
   flex: 1,
   justifyContent: 'center',
   alignItems: 'center',
-  margin: globalMargins.large,
+  padding: globalMargins.large,
   textAlign: 'center',
 }
 

--- a/shared/common-adapters/standard-screen.desktop.js
+++ b/shared/common-adapters/standard-screen.desktop.js
@@ -20,9 +20,11 @@ const StandardScreen = (props: Props) => {
       <Box style={styleTopStack}>
         {topStack}
       </Box>
-      <Box style={{...styleContentContainer, paddingBottom: (topStackCount + 1) * globalMargins.large, ...props.style}}>
+      <Box style={{...styleInnerContainer, paddingBottom: (topStackCount + 1) * globalMargins.large}}>
         {!!props.onClose && <Icon style={{...styleClose, ...props.styleClose}} type='iconfont-close' onClick={props.onClose} />}
-        {props.children}
+        <Box style={{...styleContentContainer, ...props.style}}>
+          {props.children}
+        </Box>
       </Box>
     </Box>
   )
@@ -74,13 +76,19 @@ const styleBannerText = {
   color: globalColors.white,
 }
 
+const styleInnerContainer = {
+  ...globalStyles.flexBoxColumn,
+  flex: 1,
+  alignItems: 'center',
+  position: 'relative',
+}
+
 const styleContentContainer = {
   ...globalStyles.flexBoxColumn,
-  position: 'relative',
   flex: 1,
   justifyContent: 'center',
   alignItems: 'center',
-  padding: globalMargins.large,
+  margin: globalMargins.large,
   textAlign: 'center',
 }
 

--- a/shared/common-adapters/standard-screen.desktop.js
+++ b/shared/common-adapters/standard-screen.desktop.js
@@ -5,18 +5,22 @@ import {globalStyles, globalColors, globalMargins} from '../styles'
 import type {Props, NotificationType} from './standard-screen'
 
 const StandardScreen = (props: Props) => {
+  const topStack = [
+    !!props.onBack && <BackButton key='back' onClick={props.onBack} style={{...styleBack, ...props.styleBack}} />,
+    !!props.notification && (<Box key='banner' style={{...styleBanner(props.notification.type), ...props.styleBanner}}>
+      {typeof props.notification.message === 'string'
+        ? <Text style={styleBannerText} type='BodySmallSemibold'>{props.notification.message}</Text>
+        : props.notification.message
+      }
+    </Box>),
+  ]
+  const topStackCount = topStack.reduce((acc, x) => acc + !!x, 0)
   return (
     <Box style={{...styleContainer, ...props.styleOuter}}>
       <Box style={styleTopStack}>
-        {!!props.onBack && <BackButton onClick={props.onBack} style={{...styleBack, ...props.styleBack}} />}
-        {!!props.notification && <Box style={{...styleBanner(props.notification.type), ...props.styleBanner}}>
-          {typeof props.notification.message === 'string'
-            ? <Text style={styleBannerText} type='BodySmallSemibold'>{props.notification.message}</Text>
-            : props.notification.message
-          }
-        </Box>}
+        {topStack}
       </Box>
-      <Box style={{...styleContentContainer, ...props.style}}>
+      <Box style={{...styleContentContainer, paddingBottom: (topStackCount + 1) * globalMargins.large, ...props.style}}>
         {!!props.onClose && <Icon style={{...styleClose, ...props.styleClose}} type='iconfont-close' onClick={props.onClose} />}
         {props.children}
       </Box>


### PR DESCRIPTION
Two small fixes:

 * Push down the close button when a notification is showing
 * Add padding to the bottom of the screen to maintain vertical centering if both a notification and back button are showing.

<img width="705" alt="screen shot 2016-09-16 at 4 45 39 pm" src="https://cloud.githubusercontent.com/assets/16893/18604086/0de34a56-7c2d-11e6-8d80-aaf81cc267f3.png">

:eyeglasses: @keybase/react-hackers 