### PR TITLE
Fix search pane input styling

### DIFF
--- a/shared/search/user-search/search-bar.desktop.js
+++ b/shared/search/user-search/search-bar.desktop.js
@@ -96,10 +96,9 @@ class SearchBar extends Component<void, Props, void> {
             onChange={() => this._onDebouncedSearch()}
             value={this.props.searchText}
             hintText={this.props.searchHintText}
-            hintStyle={{textAlign: 'left', marginTop: 3}}
+            hintStyle={{textAlign: 'left'}}
             underlineShow={false}
-            style={stylesInput}
-            textStyle={{height: 31}} />
+            style={stylesInput} />
           {this.props.searchText && <Icon type='iconfont-remove' style={{marginRight: 16}}
             onClick={() => this.refs.searchBox.clearValue()} />}
         </Box>
@@ -125,6 +124,7 @@ const stylesInput = {
   textAlign: 'left',
   marginLeft: 16,
   marginRight: 30,
+  marginBottom: 0,
 }
 const serviceContainerStyle = {
   ...globalStyles.flexBoxColumn,


### PR DESCRIPTION
Broken by my Input alignment tweaks in https://github.com/keybase/client/pull/4270 :anguished: 

![image](https://cloud.githubusercontent.com/assets/16893/18604297/ce7be988-7c2f-11e6-9b89-320473629bc7.png)

:eyeglasses: @keybase/react-hackers 