### PR TITLE
Use pvl for hints when enabled

### DIFF
--- a/go/externals/proof_support_coinbase.go
+++ b/go/externals/proof_support_coinbase.go
@@ -33,6 +33,11 @@ func (rc *CoinbaseChecker) ProfileURL() string {
 }
 
 func (rc *CoinbaseChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+	if pvl.UsePvl {
+		// checking the hint is done later in CheckStatus
+		return nil
+	}
+
 	wanted := rc.ProfileURL()
 	url := h.GetAPIURL()
 	if strings.ToLower(wanted) == strings.ToLower(url) {

--- a/go/externals/proof_support_dns.go
+++ b/go/externals/proof_support_dns.go
@@ -30,6 +30,11 @@ func NewDNSChecker(p libkb.RemoteProofChainLink) (*DNSChecker, libkb.ProofError)
 func (rc *DNSChecker) GetTorError() libkb.ProofError { return libkb.ProofErrorDNSOverTor }
 
 func (rc *DNSChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+	if pvl.UsePvl {
+		// checking the hint is done later in CheckStatus
+		return nil
+	}
+
 	_, sigID, err := libkb.OpenSig(rc.proof.GetArmoredSig())
 
 	if err != nil {

--- a/go/externals/proof_support_facebook.go
+++ b/go/externals/proof_support_facebook.go
@@ -36,6 +36,11 @@ func NewFacebookChecker(p libkb.RemoteProofChainLink) (*FacebookChecker, libkb.P
 func (rc *FacebookChecker) GetTorError() libkb.ProofError { return nil }
 
 func (rc *FacebookChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+	if pvl.UsePvl {
+		// checking the hint is done later in CheckStatus
+		return nil
+	}
+
 	wantedURL := ("https://m.facebook.com/" + strings.ToLower(rc.proof.GetRemoteUsername()) + "/posts/")
 	wantedMediumID := "on Keybase.io. " + rc.proof.GetSigID().ToMediumID()
 

--- a/go/externals/proof_support_github.go
+++ b/go/externals/proof_support_github.go
@@ -30,6 +30,11 @@ func NewGithubChecker(p libkb.RemoteProofChainLink) (*GithubChecker, libkb.Proof
 func (rc *GithubChecker) GetTorError() libkb.ProofError { return nil }
 
 func (rc *GithubChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+	if pvl.UsePvl {
+		// checking the hint is done later in CheckStatus
+		return nil
+	}
+
 	given := strings.ToLower(h.GetAPIURL())
 	u := strings.ToLower(rc.proof.GetRemoteUsername())
 	ok1 := "https://gist.github.com/" + u + "/"

--- a/go/externals/proof_support_hackernews.go
+++ b/go/externals/proof_support_hackernews.go
@@ -51,6 +51,11 @@ func NewHackerNewsChecker(p libkb.RemoteProofChainLink) (*HackerNewsChecker, lib
 }
 
 func (h *HackerNewsChecker) CheckHint(ctx libkb.ProofContext, hint libkb.SigHint) libkb.ProofError {
+	if pvl.UsePvl {
+		// checking the hint is done later in CheckStatus
+		return nil
+	}
+
 	wanted := h.APIURL()
 	if libkb.Cicmp(wanted, hint.GetAPIURL()) {
 		return nil

--- a/go/externals/proof_support_reddit.go
+++ b/go/externals/proof_support_reddit.go
@@ -36,6 +36,11 @@ func NewRedditChecker(p libkb.RemoteProofChainLink) (*RedditChecker, libkb.Proof
 func (rc *RedditChecker) GetTorError() libkb.ProofError { return nil }
 
 func (rc *RedditChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+	if pvl.UsePvl {
+		// checking the hint is done later in CheckStatus
+		return nil
+	}
+
 	if strings.HasPrefix(strings.ToLower(h.GetAPIURL()), RedditSub) {
 		return nil
 	}

--- a/go/externals/proof_support_rooter.go
+++ b/go/externals/proof_support_rooter.go
@@ -33,6 +33,11 @@ func NewRooterChecker(p libkb.RemoteProofChainLink) (*RooterChecker, libkb.Proof
 func (rc *RooterChecker) GetTorError() libkb.ProofError { return nil }
 
 func (rc *RooterChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) (err libkb.ProofError) {
+	if pvl.UsePvl {
+		// checking the hint is done later in CheckStatus
+		return nil
+	}
+
 	ctx.GetLog().Debug("+ Rooter check hint: %v", h)
 	defer func() {
 		ctx.GetLog().Debug("- Rooter check hint: %v", err)

--- a/go/externals/proof_support_twitter.go
+++ b/go/externals/proof_support_twitter.go
@@ -31,6 +31,11 @@ func NewTwitterChecker(p libkb.RemoteProofChainLink) (*TwitterChecker, libkb.Pro
 func (rc *TwitterChecker) GetTorError() libkb.ProofError { return nil }
 
 func (rc *TwitterChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+	if pvl.UsePvl {
+		// checking the hint is done later in CheckStatus
+		return nil
+	}
+
 	wantedURL := ("https://twitter.com/" + strings.ToLower(rc.proof.GetRemoteUsername()) + "/")
 	wantedShortID := (" " + rc.proof.GetSigID().ToShortID() + " /")
 

--- a/go/externals/proof_support_web.go
+++ b/go/externals/proof_support_web.go
@@ -43,6 +43,10 @@ func (rc *WebChecker) GetTorError() libkb.ProofError {
 }
 
 func (rc *WebChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+	if pvl.UsePvl {
+		// checking the hint is done later in CheckStatus
+		return nil
+	}
 
 	files := webKeybaseFiles
 	urlBase := rc.proof.ToDisplayString()


### PR DESCRIPTION
This makes `CheckHint` always return nil if `UsePvl` is enabled. Because PVL is intended to replace `CheckHint` and `CheckStatus` together.

This does a little action at a distance. This return will never happen when `UsePvl` is on:
https://github.com/keybase/client/blob/miles/pvl-does-hints/go/libkb/id_table.go#L1340
I think that that's ok. As far as I can tell, the behavior would be different is that: if pvl returns a soft error for a bad hint, the cache could cause the proof to succeed. That seems ok.

r? @oconnor663 