### PR TITLE
Add domain and protocol validation to pvl checkers

### DIFF
--- a/go/pvl/hardcoded.go
+++ b/go/pvl/hardcoded.go
@@ -29,8 +29,8 @@ var hardcodedPVLString = `
     "dns": [{ "assert_regex_match": "^keybase-site-verification=%{sig_id_medium}$" }],
     "generic_web_site": [
       {
-        "assert_regex_match": "^https?://%{hostname}/(?:\\.well-known/keybase\\.txt|keybase\\.txt)$",
-        "case_insensitive": true
+        "assert_regex_match": "^%{protocol}://%{hostname}/(?:\\.well-known/keybase\\.txt|keybase\\.txt)$",
+        "error": ["BAD_API_URL", "Bad hint from server; didn't recognize API url: \"%{active_string}\""]
       },
       { "fetch": "string" },
       { "assert_find_base64": "sig" }

--- a/go/pvl/helpers.go
+++ b/go/pvl/helpers.go
@@ -238,7 +238,7 @@ func validateDomain(s string) bool {
 	// To disallow the likes of "8.8.8.8."
 	dotsplit := strings.Split(strings.TrimSuffix(u.Host, "."), ".")
 	if len(dotsplit) > 0 {
-		hasalpha := regexp.MustCompile(`^.*\D.*$`)
+		hasalpha := regexp.MustCompile(`\D`)
 		group := dotsplit[len(dotsplit)-1]
 		if !hasalpha.MatchString(group) {
 			return false

--- a/go/pvl/helpers_test.go
+++ b/go/pvl/helpers_test.go
@@ -374,10 +374,13 @@ func TestValidateDomain(t *testing.T) {
 		s  string
 		ok bool
 	}{
+		// allow domains
 		{"example.com", true},
 		{"www.example.com", true},
 		{"com.", true},
+		{"0x0f.example.com", true},
 
+		// disallow ports, paths, protocols, and other junk
 		{"example.com:8080", false},
 		{"www.example.com:8080", false},
 		{"http://example.com", false},
@@ -388,8 +391,22 @@ func TestValidateDomain(t *testing.T) {
 		{"http://http://", false},
 		{"http://http://example.com", false},
 		{"http://http:/example.com", false},
-
 		{"http://ht$%$&$tp:/example.com", false},
+
+		// disallow ips, even when weirdly formatted
+		{"8.8.8.8", false},
+		{"8.8.8.8.", false},
+		{"8.8.8.00008", false},
+		{"8.8.8.", false},
+		{"8.", false},
+		{"8", false},
+		{"8.8.8", false},
+		{"2001:db8:a0b:12f0::1", false},
+		{"::21", false},
+		{":21:", false},
+		{":21:", false},
+		{"2001:db8:a0b:12f0::1%eth0", false},
+		{"[2001:db8:a0b:12f0::1]:21", false},
 	}
 
 	for i, test := range tests {

--- a/go/pvl/helpers_test.go
+++ b/go/pvl/helpers_test.go
@@ -398,6 +398,8 @@ func TestValidateDomain(t *testing.T) {
 		{"8.8.8.8.", false},
 		{"8.8.8.00008", false},
 		{"8.8.8.", false},
+		{"8.8.8.8/24", false},
+		{"8.8.8/24", false},
 		{"8.", false},
 		{"8", false},
 		{"8.8.8", false},

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -170,9 +170,9 @@ func checkProofInner(g proofContextExt, pvl *jsonw.Wrapper, service keybase1.Pro
 		}
 	}
 	if service == keybase1.ProofType_GENERIC_WEB_SITE {
-		cp, ok := validateProtocol(vars.Protocol, []string{"http", "https"})
+		canonicalProtocol, ok := validateProtocol(vars.Protocol, []string{"http", "https"})
 		if ok {
-			vars.Protocol = cp
+			vars.Protocol = canonicalProtocol
 		} else {
 			return libkb.NewProofError(keybase1.ProofStatus_BAD_SIGNATURE,
 				"Bad protocol in sig: %s", vars.Protocol)

--- a/go/pvl/interp_data_for_test.go
+++ b/go/pvl/interp_data_for_test.go
@@ -14,6 +14,25 @@ var info1 = ProofInfo{
 	Username:       "kronk",
 	RemoteUsername: "kronkinator",
 	Hostname:       "kronk.example.com",
+	Protocol:       "http:",
+	APIURL:         "https://rooter.example.com/proofs/kronkinator/5.htjsxt",
+}
+
+var infoBadDomain = ProofInfo{
+	ArmoredSig:     sig1,
+	Username:       "kronk",
+	RemoteUsername: "kronkinator",
+	Hostname:       "kronk.example.com/foo", // Path in domain
+	Protocol:       "http:",
+	APIURL:         "https://rooter.example.com/proofs/kronkinator/5.htjsxt",
+}
+
+var infoBadProto = ProofInfo{
+	ArmoredSig:     sig1,
+	Username:       "kronk",
+	RemoteUsername: "kronkinator",
+	Hostname:       "kronk.example.com",
+	Protocol:       "spdy:", // Bad protocol.
 	APIURL:         "https://rooter.example.com/proofs/kronkinator/5.htjsxt",
 }
 

--- a/go/pvl/interp_test.go
+++ b/go/pvl/interp_test.go
@@ -582,6 +582,39 @@ var interpUnitTests = []interpUnitTest{
 		errstatus:  keybase1.ProofStatus_INVALID_PVL,
 	},
 
+	// ## Tests for bad proofinfo
+	{
+		name:       "bad-sig-path-in-domain-web",
+		proofinfo:  infoBadDomain,
+		prepvlstr:  `{"pvl_version": 1, "revision": 2, "services": {"generic_web_site": [{"fetch": "html"}]}}`,
+		service:    keybase1.ProofType_GENERIC_WEB_SITE,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: false,
+		errstatus:  keybase1.ProofStatus_BAD_SIGNATURE,
+	},
+	{
+		name:      "bad-sig-path-in-domain-dns",
+		proofinfo: infoBadDomain,
+		prepvlstr: `{"pvl_version": 1, "revision": 2, "services": {"dns": [{"assert_regex_match": "$foo^"}]}}`,
+		service:   keybase1.ProofType_DNS,
+		resdns: map[string][]string{
+			info1.Hostname: {"NO", "ok"},
+		},
+		shouldwork: false,
+		errstatus:  keybase1.ProofStatus_BAD_SIGNATURE,
+	},
+	{
+		name:       "bad-sig-proto",
+		proofinfo:  infoBadProto,
+		prepvlstr:  `{"pvl_version": 1, "revision": 2, "services": {"generic_web_site": [{"fetch": "html"}]}}`,
+		service:    keybase1.ProofType_GENERIC_WEB_SITE,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: false,
+		errstatus:  keybase1.ProofStatus_BAD_SIGNATURE,
+	},
+
 	// ## (Invalid) AssertRegexMatch
 	{
 		name:      "AssertRegexMatch-invalid-missing^",


### PR DESCRIPTION
This fixes problems with `generic_web_site` and `dns` checking (in pvl).

`generic_web_site` used to match case insensitively which is bad for paths. `https://example.com/keybase.txt` isn't `http://example.com/keYBAse.txt`.

Both `generic_web_site` and `dns` used to accept whatever the hint provided as a domain. Now they check that it's a valid domain with no port, query string, path, or any such funny business. The non-pvl system needs this too, but that's not in this PR.

`generic_web_site` used to accept either `http` or `https` as a hint from the server regardless of the protocol specified in the sig. Now it requires that the hint match the sig protocol exactly. Also the protocol is validated so you can only have `http` or `https` (plus some funky colons).

r? @oconnor663 