### PR TITLE
Fix displaying errors in signup

### DIFF
--- a/shared/actions/signup.js
+++ b/shared/actions/signup.js
@@ -268,7 +268,7 @@ function signup (skipMail: boolean, onDisplayPaperKey?: () => void): TypedAsyncA
             dispatch(({
               type: Constants.signup,
               error: true,
-              payload: {signupError: new HiddenString(err + '')},
+              payload: {signupError: new HiddenString(err.desc)},
             }: Signup))
             dispatch(nextPhase())
             reject()


### PR DESCRIPTION
@keybase/react-hackers 

We weren't looking at `error.desc`, I think this change happened with the new engine.