### PR TITLE
ignore flow-typed from unused files

### DIFF
--- a/desktop/webpack.config.development.js
+++ b/desktop/webpack.config.development.js
@@ -38,6 +38,7 @@ config.plugins.push(new UnusedFilesWebpackPlugin({
       '../shared/constants/types/flux.js',
       '../shared/constants/types/saga.js',
       '../shared/constants/reducer.js',
+      '../shared/flow-typed/*.js',
       // Tests
       '../shared/test/**',
       // Misc


### PR DESCRIPTION
@keybase/react-hackers if we add files that aren't included in the package the unused-files webpack plugin will complains. we usually either delete those files, or add them to the ignore list to make the warning go away. (this actually shows up in the webpack dashboard output when a bundle is updated)