### PR TITLE
visdiff: Switch back to font ready to attempt to fix FOIT

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ if (env.CHANGE_TITLE && env.CHANGE_TITLE.contains('[ci-skip]')) {
                                                 try {
                                                     timeout(time: 10, unit: 'MINUTES') {
                                                         dir("desktop") {
-                                                            sh "../node_modules/.bin/keybase-visdiff 'merge-base(origin/master, HEAD)...HEAD'"
+                                                            sh "strace ../node_modules/.bin/keybase-visdiff 'merge-base(origin/master, HEAD)...HEAD' 2>&1 | tail -n 4000"
                                                         }
                                                     }
                                                 } catch (e) {

--- a/desktop/npm-helper.js
+++ b/desktop/npm-helper.js
@@ -136,7 +136,7 @@ const commands = {
       ELECTRON_ENABLE_LOGGING: 1,
     },
     nodePathDesktop: true,
-    shell: 'webpack --config webpack.config.visdiff.js && electron ./dist/render-visdiff.bundle.js',
+    shell: 'webpack --config webpack.config.visdiff.js && electron ./dist/render-visdiff.bundle.js ' + rest.join(' ') + ' || echo "electron quit"',
     help: 'Render images of dumb components',
   },
   'updated-fonts': {

--- a/desktop/test/render-visdiff.js
+++ b/desktop/test/render-visdiff.js
@@ -46,6 +46,11 @@ app.on('ready', () => {
     rendering++
   }
 
+  ipcMain.on('visdiff-ready', ev => {
+    console.log('Worker ready:', ev.sender.getTitle())
+    renderNext(ev.sender)
+  })
+
   ipcMain.on('display-done', (ev, msg) => {
     const sender = ev.sender
     sender.getOwnerBrowserWindow().capturePage(msg.rect, img => {
@@ -68,7 +73,7 @@ app.on('ready', () => {
   for (let i = 0; i < WORKER_COUNT; i++) {
     setTimeout(() => {
       console.log('Creating new worker window', i)
-      const workerWin = new BrowserWindow({show: false, width: CANVAS_SIZE, height: CANVAS_SIZE})
+      const workerWin = new BrowserWindow({show: false, width: CANVAS_SIZE, height: CANVAS_SIZE, title: i})
       console.log('Created new worker window', i)
 
       workerWin.on('ready-to-show', () => console.log('Worker window ready-to-show:', i))
@@ -78,8 +83,6 @@ app.on('ready', () => {
       workerWin.on('responsive', () => console.log('Worker window responsive:', i))
       workerWin.on('closed', () => console.log('Worker window closed:', i))
 
-      // TODO: once we're on electron v1.2.3, try ready-to-show event.
-      workerWin.webContents.once('did-finish-load', () => renderNext(workerWin.webContents))
       const workerURL = resolveRootAsURL('renderer', `index.html?src=${scriptPath}`)
       console.log('Loading worker', i, workerURL)
       workerWin.loadURL(workerURL)

--- a/desktop/test/render-visdiff.js
+++ b/desktop/test/render-visdiff.js
@@ -47,7 +47,7 @@ app.on('ready', () => {
   }
 
   ipcMain.on('visdiff-ready', ev => {
-    console.log('Worker ready:', ev.sender.getTitle())
+    console.log('Worker ready:', ev.sender.getOwnerBrowserWindow().id)
     renderNext(ev.sender)
   })
 
@@ -73,20 +73,20 @@ app.on('ready', () => {
   for (let i = 0; i < WORKER_COUNT; i++) {
     setTimeout(() => {
       console.log('Creating new worker window', i)
-      const workerWin = new BrowserWindow({show: false, width: CANVAS_SIZE, height: CANVAS_SIZE, title: i})
-      console.log('Created new worker window', i)
+      const workerWin = new BrowserWindow({show: false, width: CANVAS_SIZE, height: CANVAS_SIZE})
+      console.log('Created new worker window', i, 'window id:', workerWin.id)
 
-      workerWin.on('ready-to-show', () => console.log('Worker window ready-to-show:', i))
-      workerWin.webContents.on('did-finish-load', () => console.log('Worker window did-finish-load:', i))
-      workerWin.webContents.on('did-fail-load', () => console.log('Worker window did-fail-load:', i))
-      workerWin.on('unresponsive', () => console.log('Worker window unresponsive:', i))
-      workerWin.on('responsive', () => console.log('Worker window responsive:', i))
-      workerWin.on('closed', () => console.log('Worker window closed:', i))
+      workerWin.on('ready-to-show', () => console.log('Worker window ready-to-show:', workerWin.id))
+      workerWin.webContents.on('did-finish-load', () => console.log('Worker window did-finish-load:', workerWin.id))
+      workerWin.webContents.on('did-fail-load', () => console.log('Worker window did-fail-load:', workerWin.id))
+      workerWin.on('unresponsive', () => console.log('Worker window unresponsive:', workerWin.id))
+      workerWin.on('responsive', () => console.log('Worker window responsive:', workerWin.id))
+      workerWin.on('closed', () => console.log('Worker window closed:', workerWin.id))
 
       const workerURL = resolveRootAsURL('renderer', `index.html?src=${scriptPath}`)
-      console.log('Loading worker', i, workerURL)
+      console.log('Loading worker', workerWin.id, workerURL)
       workerWin.loadURL(workerURL)
-      console.log('Loaded worker', i, workerURL)
+      console.log('Loaded worker', workerWin.id, workerURL)
     }, i * 150)
   }
 

--- a/desktop/test/render-visdiff.js
+++ b/desktop/test/render-visdiff.js
@@ -38,7 +38,7 @@ app.on('ready', () => {
     console.log('Rendering next. Remaining:', toRender.length, 'Currently rendering:', rendering)
     if (!toRender.length) {
       if (rendering === 0) {
-        app.quit()
+        process.exit(0)
       }
       return
     }
@@ -59,7 +59,7 @@ app.on('ready', () => {
       fs.writeFile(path.join(outputDir, filename), img.toPng(), err => {
         if (err) {
           console.log('Error writing image', err)
-          app.exit(1)
+          process.exit(1)
         }
         count++
         console.log(`[${count} / ${total}] wrote ${filename}`)

--- a/shared/test/render-dumb-sheet.js
+++ b/shared/test/render-dumb-sheet.js
@@ -51,3 +51,16 @@ ipcRenderer.on('display', (ev, msg) => {
     }, 1000)
   })
 })
+
+declare class ExtendedDocument extends Document {
+  fonts: {
+    ready: Promise<*>
+  }
+}
+declare var document: ExtendedDocument
+
+window.addEventListener('load', () =>
+  document.fonts.ready.then(() =>
+    ipcRenderer.send('visdiff-ready')
+  )
+)


### PR DESCRIPTION
Patrick ran into a FOIT (flash of invisible text) false positive today. We were originally using this logic to try to delay rendering until after fonts loaded, but IIRC I still saw FOITs occur with it in place. In any case, let's try adding it back and see if it makes a difference.

:eyeglasses: @keybase/react-hackers 
