### PR TITLE
Uninstall KBFS if incompatibility detected (Sierra)

### DIFF
--- a/go/install/install_osx.go
+++ b/go/install/install_osx.go
@@ -417,7 +417,11 @@ func Install(context Context, binPath string, components []string, force bool, l
 	}
 
 	if libkb.IsIn(string(ComponentNameKBFS), components, false) {
-		if !isKBFSCompatible(log) {
+		if !isKBFSCompatible(log) && !force {
+			// Uninstall in case it was started somehow
+			if uninstallErr := launchd.Uninstall(DefaultKBFSLabel(context.GetRunMode()), time.Second, log); uninstallErr != nil {
+				log.Errorf("KBFS is not compatible; Error trying to uninstall KBFS: %s", uninstallErr)
+			}
 			err = fmt.Errorf("Oops, the Keybase Filesystem isn't currently available on MacOS 10.12 (Sierra). We are working on a fix which should be available shortly.")
 		} else {
 			err = InstallKBFS(context, binPath, force, log)

--- a/go/launchd/launchd.go
+++ b/go/launchd/launchd.go
@@ -242,14 +242,16 @@ func (s Service) install(p Plist, plistDest string, wait time.Duration) error {
 
 // Uninstall will uninstall the launchd service
 func (s Service) Uninstall(wait time.Duration) error {
-	if _, err := s.Stop(wait); err != nil {
-		return err
-	}
-
+	// It's safer to remove the plist before stopping in case stopping
+	// hangs the system somehow, the plist will still be removed.
 	plistDest := s.plistDestination()
 	if _, err := os.Stat(plistDest); err == nil {
 		s.log.Info("Removing %s", plistDest)
 		return os.Remove(plistDest)
+	}
+
+	if _, err := s.Stop(wait); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Also changes launchd.Uninstall to remove plist first in case stopping
hangs somehow.