### PR TITLE
Add pvl types

### DIFF
--- a/go/pvl/parse.go
+++ b/go/pvl/parse.go
@@ -1,0 +1,240 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package pvl
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+func parse(in string) (pvlT, error) {
+	b := []byte(in)
+	p := pvlT{}
+	p.PvlVersion = -1
+	p.Revision = -1
+	err := json.Unmarshal(b, &p)
+	if p.PvlVersion == -1 {
+		return p, fmt.Errorf("pvl_version required")
+	}
+	if p.Revision == -1 {
+		return p, fmt.Errorf("revision required")
+	}
+	return p, err
+}
+
+type pvlT struct {
+	PvlVersion int `json:"pvl_version"`
+	Revision   int `json:"revision"`
+	// services is a map from service to a list of scripts.
+	// each script is a list of instructions.
+	Services servicesT `json:"services"`
+}
+
+type servicesT struct {
+	Map map[keybase1.ProofType][]scriptT
+}
+
+func (x *servicesT) UnmarshalJSON(b []byte) error {
+	// read as string map
+	m := make(map[string][]scriptT)
+	err := json.Unmarshal(b, &m)
+	if err != nil {
+		return err
+	}
+	// copy to ProofType map
+	x.Map = make(map[keybase1.ProofType][]scriptT)
+	for k, v := range m {
+		t, ok := keybase1.ProofTypeMap[strings.ToUpper(k)]
+		if ok {
+			x.Map[t] = v
+		}
+		// Unrecognized proof types are discarded silently
+		// So that old clients don't break if a new service is added
+	}
+	return nil
+}
+
+type scriptT struct {
+	Instructions []instructionT
+}
+
+func (x *scriptT) UnmarshalJSON(b []byte) error {
+	err := json.Unmarshal(b, &x.Instructions)
+	for _, ins := range x.Instructions {
+		if ins.variantsFilled() != 1 {
+			return fmt.Errorf("exactly 1 variant must appear in instruction")
+		}
+	}
+	return err
+}
+
+type instructionT struct {
+	// Exactly one of these shall be non-nil
+	// This list is duplicated to:
+	// - instructionT.variantsFilled
+	// - instructionT.String
+	// - stepInstruction
+	// This invariant is enforced by scriptT.UnmarshalJSON
+	AssertRegexMatch    *assertRegexMatchT    `json:"assert_regex_match,omitempty"`
+	AssertFindBase64    *assertFindBase64T    `json:"assert_find_base64,omitempty"`
+	WhitespaceNormalize *whitespaceNormalizeT `json:"whitespace_normalize,omitempty"`
+	RegexCapture        *regexCaptureT        `json:"regex_capture,omitempty"`
+	Fetch               *fetchT               `json:"fetch,omitempty"`
+	SelectorJSON        *selectorJSONT        `json:"selector_json,omitempty"`
+	SelectorCSS         *selectorCSST         `json:"selector_css,omitempty"`
+	TransformURL        *transformURLT        `json:"transform_url,omitempty"`
+}
+
+func (ins *instructionT) variantsFilled() int {
+	n := 0
+	if ins.AssertRegexMatch != nil {
+		n += 1
+	}
+	if ins.AssertFindBase64 != nil {
+		n += 1
+	}
+	if ins.WhitespaceNormalize != nil {
+		n += 1
+	}
+	if ins.RegexCapture != nil {
+		n += 1
+	}
+	if ins.Fetch != nil {
+		n += 1
+	}
+	if ins.SelectorJSON != nil {
+		n += 1
+	}
+	if ins.SelectorCSS != nil {
+		n += 1
+	}
+	if ins.TransformURL != nil {
+		n += 1
+	}
+	return n
+}
+
+func (x instructionT) Name() string {
+	switch {
+	case x.AssertRegexMatch != nil:
+		return string(cmdAssertRegexMatch)
+	case x.AssertFindBase64 != nil:
+		return string(cmdAssertFindBase64)
+	case x.WhitespaceNormalize != nil:
+		return string(cmdWhitespaceNormalize)
+	case x.RegexCapture != nil:
+		return string(cmdRegexCapture)
+	case x.Fetch != nil:
+		return string(cmdFetch)
+	case x.SelectorJSON != nil:
+		return string(cmdSelectorJSON)
+	case x.SelectorCSS != nil:
+		return string(cmdSelectorCSS)
+	case x.TransformURL != nil:
+		return string(cmdTransformURL)
+	}
+	return "<invalid instruction>"
+}
+
+func (x instructionT) String() string {
+	var s = ""
+	switch {
+	case x.AssertRegexMatch != nil:
+		s = fmt.Sprintf("%v", x.AssertRegexMatch)
+	case x.AssertFindBase64 != nil:
+		s = fmt.Sprintf("%v", x.AssertFindBase64)
+	case x.WhitespaceNormalize != nil:
+		s = fmt.Sprintf("%v", x.WhitespaceNormalize)
+	case x.RegexCapture != nil:
+		s = fmt.Sprintf("%v", x.RegexCapture)
+	case x.Fetch != nil:
+		s = fmt.Sprintf("%v", x.Fetch)
+	case x.SelectorJSON != nil:
+		s = fmt.Sprintf("%v", x.SelectorJSON)
+	case x.SelectorCSS != nil:
+		s = fmt.Sprintf("%v", x.SelectorCSS)
+	case x.TransformURL != nil:
+		s = fmt.Sprintf("%v", x.TransformURL)
+	}
+	if s != "" {
+		return fmt.Sprintf("[ins %v]", s)
+	} else {
+		return "[nil instruction]"
+	}
+}
+
+type assertRegexMatchT struct {
+	Pattern         string  `json:"pattern"`
+	CaseInsensitive bool    `json:"case_insensitive"`
+	MultiLine       bool    `json:"multiline"`
+	Error           *errorT `json:"error"`
+}
+
+type assertFindBase64T struct {
+	Var   string  `json:"var"`
+	Error *errorT `json:"error"`
+}
+
+type whitespaceNormalizeT struct {
+	Error *errorT `json:"error"`
+}
+
+type regexCaptureT struct {
+	Pattern         string  `json:"pattern"`
+	MultiLine       bool    `json:"multiline"`
+	CaseInsensitive bool    `json:"case_insensitive"`
+	Error           *errorT `json:"error"`
+}
+
+type fetchT struct {
+	Kind  string  `json:"kind"`
+	Error *errorT `json:"error"`
+}
+
+type selectorJSONT struct {
+	Selectors []interface{} `json:"selectors"`
+	Error     *errorT       `json:"error"`
+}
+
+type selectorCSST struct {
+	Selectors []interface{} `json:"selectors"`
+	Attr      string        `json:"attr"`
+	// Whether the final selection can contain multiple elements.
+	Multi bool    `json:"multi"`
+	Error *errorT `json:"error"`
+}
+
+type transformURLT struct {
+	Pattern         string  `json:"pattern"`
+	MultiLine       bool    `json:"multiline"`
+	CaseInsensitive bool    `json:"case_insensitive"`
+	ToPattern       string  `json:"to_pattern"`
+	Error           *errorT `json:"error"`
+}
+
+type errorT struct {
+	Status      keybase1.ProofStatus
+	Description string
+}
+
+func (x *errorT) UnmarshalJSON(b []byte) error {
+	ss := []string{}
+	err := json.Unmarshal(b, &ss)
+	if err != nil {
+		return err
+	}
+	if len(ss) != 2 {
+		return fmt.Errorf("error desc must be of length 2")
+	}
+	status, ok := keybase1.ProofStatusMap[ss[0]]
+	if !ok {
+		return fmt.Errorf("unrecognized proof status '%v'", ss[0])
+	}
+	x.Status = keybase1.ProofStatus(status)
+	x.Description = ss[1]
+	return nil
+}

--- a/go/pvl/parse.go
+++ b/go/pvl/parse.go
@@ -16,14 +16,19 @@ func parse(in string) (pvlT, error) {
 	p := pvlT{}
 	p.PvlVersion = -1
 	p.Revision = -1
+
 	err := json.Unmarshal(b, &p)
+	if err != nil {
+		return p, err
+	}
+
 	if p.PvlVersion == -1 {
 		return p, fmt.Errorf("pvl_version required")
 	}
 	if p.Revision == -1 {
 		return p, fmt.Errorf("revision required")
 	}
-	return p, err
+	return p, nil
 }
 
 type pvlT struct {
@@ -76,7 +81,7 @@ type instructionT struct {
 	// Exactly one of these shall be non-nil
 	// This list is duplicated to:
 	// - instructionT.variantsFilled
-	// - instructionT.String
+	// - instructionT.Name
 	// - stepInstruction
 	// This invariant is enforced by scriptT.UnmarshalJSON
 	AssertRegexMatch    *assertRegexMatchT    `json:"assert_regex_match,omitempty"`
@@ -92,79 +97,56 @@ type instructionT struct {
 func (ins *instructionT) variantsFilled() int {
 	n := 0
 	if ins.AssertRegexMatch != nil {
-		n += 1
+		n++
 	}
 	if ins.AssertFindBase64 != nil {
-		n += 1
+		n++
 	}
 	if ins.WhitespaceNormalize != nil {
-		n += 1
+		n++
 	}
 	if ins.RegexCapture != nil {
-		n += 1
+		n++
 	}
 	if ins.Fetch != nil {
-		n += 1
+		n++
 	}
 	if ins.SelectorJSON != nil {
-		n += 1
+		n++
 	}
 	if ins.SelectorCSS != nil {
-		n += 1
+		n++
 	}
 	if ins.TransformURL != nil {
-		n += 1
+		n++
 	}
 	return n
 }
 
-func (x instructionT) Name() string {
+func (ins instructionT) Name() string {
 	switch {
-	case x.AssertRegexMatch != nil:
+	case ins.AssertRegexMatch != nil:
 		return string(cmdAssertRegexMatch)
-	case x.AssertFindBase64 != nil:
+	case ins.AssertFindBase64 != nil:
 		return string(cmdAssertFindBase64)
-	case x.WhitespaceNormalize != nil:
+	case ins.WhitespaceNormalize != nil:
 		return string(cmdWhitespaceNormalize)
-	case x.RegexCapture != nil:
+	case ins.RegexCapture != nil:
 		return string(cmdRegexCapture)
-	case x.Fetch != nil:
+	case ins.Fetch != nil:
 		return string(cmdFetch)
-	case x.SelectorJSON != nil:
+	case ins.SelectorJSON != nil:
 		return string(cmdSelectorJSON)
-	case x.SelectorCSS != nil:
+	case ins.SelectorCSS != nil:
 		return string(cmdSelectorCSS)
-	case x.TransformURL != nil:
+	case ins.TransformURL != nil:
 		return string(cmdTransformURL)
 	}
 	return "<invalid instruction>"
 }
 
-func (x instructionT) String() string {
-	var s = ""
-	switch {
-	case x.AssertRegexMatch != nil:
-		s = fmt.Sprintf("%v", x.AssertRegexMatch)
-	case x.AssertFindBase64 != nil:
-		s = fmt.Sprintf("%v", x.AssertFindBase64)
-	case x.WhitespaceNormalize != nil:
-		s = fmt.Sprintf("%v", x.WhitespaceNormalize)
-	case x.RegexCapture != nil:
-		s = fmt.Sprintf("%v", x.RegexCapture)
-	case x.Fetch != nil:
-		s = fmt.Sprintf("%v", x.Fetch)
-	case x.SelectorJSON != nil:
-		s = fmt.Sprintf("%v", x.SelectorJSON)
-	case x.SelectorCSS != nil:
-		s = fmt.Sprintf("%v", x.SelectorCSS)
-	case x.TransformURL != nil:
-		s = fmt.Sprintf("%v", x.TransformURL)
-	}
-	if s != "" {
-		return fmt.Sprintf("[ins %v]", s)
-	} else {
-		return "[nil instruction]"
-	}
+func (ins instructionT) String() string {
+	return fmt.Sprintf("[ins %v]", ins.Name())
 }
 
 type assertRegexMatchT struct {

--- a/go/pvl/parse_test.go
+++ b/go/pvl/parse_test.go
@@ -1,0 +1,180 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package pvl
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// TestParse parses the hardcoded string
+func TestParse(t *testing.T) {
+	p, err := parse(pvlStringForParseTest)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if p.PvlVersion < 0 {
+		t.Fatalf("version should be >=0: %v", p.PvlVersion)
+	}
+}
+
+// TestParse2 checks a few of the parse output's details.
+func TestParse2(t *testing.T) {
+	p, err := parse(pvlStringForParseTest)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if p.PvlVersion != 1 {
+		t.Fatalf("version should be 1 got %v", p.PvlVersion)
+	}
+	if p.Revision != 1 {
+		t.Fatalf("revision should be 1")
+	}
+	cbss, ok := p.Services.Map[keybase1.ProofType_COINBASE]
+	if !ok {
+		t.Fatalf("no coinbase service entry")
+	}
+	if len(cbss) < 1 {
+		t.Fatalf("no scripts")
+	}
+	cbs := cbss[0]
+	if len(cbs.Instructions) < 1 {
+		t.Fatalf("empty script")
+	}
+	if cbs.Instructions[0].RegexCapture == nil {
+		t.Fatalf("first instruction is not a RegexCapture")
+	}
+}
+
+// in the near future this will go away and hardcodedPVLString will be used instead.
+var pvlStringForParseTest = `
+{
+  "pvl_version": 1,
+  "revision": 1,
+  "services": {
+    "coinbase": [
+      [
+        { "regex_capture": { "pattern": "^https://coinbase\\.com/(.*)/public-key$" } },
+        { "assert_regex_match": { "case_insensitive": true, "pattern": "^%{username_service}$" } },
+        { "fetch": { "kind": "html" } },
+        { "selector_css": { "selectors": ["pre.statement", 0] } },
+        { "assert_find_base64": { "var": "sig" } }
+      ]
+    ],
+    "dns": [[{ "assert_regex_match": { "pattern": "^keybase-site-verification=%{sig_id_medium}$" } }]],
+    "generic_web_site": [
+      [
+        {
+          "assert_regex_match": {
+            "error": ["BAD_API_URL", "Bad hint from server; didn't recognize API url: \"%{active_string}\""],
+            "pattern": "^%{protocol}://%{hostname}/(?:\\.well-known/keybase\\.txt|keybase\\.txt)$"
+          }
+        },
+        { "fetch": { "kind": "string" } },
+        { "assert_find_base64": { "var": "sig" } }
+      ]
+    ],
+    "github": [
+      [
+        {
+          "assert_regex_match": {
+            "case_insensitive": true,
+            "pattern": "^https://gist\\.github(usercontent)?\\.com/%{username_service}/.*$"
+          }
+        },
+        { "fetch": { "kind": "string" } },
+        { "assert_find_base64": { "var": "sig" } }
+      ]
+    ],
+    "hackernews": [
+      [
+        {
+          "assert_regex_match": {
+            "case_insensitive": true,
+            "pattern": "^https://hacker-news\\.firebaseio\\.com/v0/user/%{username_service}/about.json$"
+          }
+        },
+        { "fetch": { "kind": "string" } },
+        { "assert_regex_match": { "pattern": "^.*%{sig_id_medium}.*$" } }
+      ]
+    ],
+    "reddit": [
+      [
+        {
+          "assert_regex_match": { "case_insensitive": true, "pattern": "^https://(:?www\\.)?reddit\\.com/r/keybaseproofs/.*$" }
+        },
+        { "fetch": { "kind": "json" } },
+        { "selector_json": { "selectors": [0, "kind"] } },
+        { "assert_regex_match": { "pattern": "^Listing$" } },
+        { "selector_json": { "selectors": [0, "data", "children", 0, "kind"] } },
+        { "assert_regex_match": { "pattern": "^t3$" } },
+        { "selector_json": { "selectors": [0, "data", "children", 0, "data", "subreddit"] } },
+        { "assert_regex_match": { "case_insensitive": true, "pattern": "^keybaseproofs$" } },
+        { "selector_json": { "selectors": [0, "data", "children", 0, "data", "author"] } },
+        { "assert_regex_match": { "case_insensitive": true, "pattern": "^%{username_service}$" } },
+        { "selector_json": { "selectors": [0, "data", "children", 0, "data", "title"] } },
+        { "assert_regex_match": { "case_insensitive": true, "pattern": "^.*%{sig_id_medium}.*$" } },
+        { "selector_json": { "selectors": [0, "data", "children", 0, "data", "selftext"] } },
+        { "assert_find_base64": { "var": "sig" } }
+      ]
+    ],
+    "rooter": [
+      [
+        {
+          "assert_regex_match": {
+            "case_insensitive": true,
+            "pattern": "^https?://[\\w:_\\-\\.]+/_/api/1\\.0/rooter/%{username_service}/.*$"
+          }
+        },
+        { "fetch": { "kind": "json" } },
+        { "selector_json": { "selectors": ["status", "name"] } },
+        { "assert_regex_match": { "case_insensitive": true, "pattern": "^ok$" } },
+        { "selector_json": { "selectors": ["toot", "post"] } },
+        { "assert_regex_match": { "pattern": "^.*%{sig_id_medium}.*$" } }
+      ]
+    ],
+    "twitter": [
+      [
+        {
+          "assert_regex_match": { "case_insensitive": true, "pattern": "^https://twitter\\.com/%{username_service}/.*$" }
+        },
+        { "fetch": { "kind": "html" } },
+        {
+          "selector_css": { "attr": "data-screen-name", "selectors": ["div.permalink-tweet-container div.permalink-tweet", 0] }
+        },
+        {
+          "assert_regex_match": {
+            "case_insensitive": true,
+            "error": ["CONTENT_FAILURE", "Bad post authored; wanted \"%{username_service}\", got \"%{active_string}\""],
+            "pattern": "^%{username_service}$"
+          }
+        },
+        {
+          "selector_css": { "selectors": ["div.permalink-tweet-container div.permalink-tweet", 0, "p.tweet-text", 0] }
+        },
+        { "whitespace_normalize": { } },
+        {
+          "regex_capture": {
+            "case_insensitive": true,
+            "pattern": "^ *(?:@[a-zA-Z0-9_-]+\\s*)* *Verifying myself: I am ([A-Za-z0-9_]+) on Keybase\\.io\\. (?:\\S+) */.*$"
+          }
+        },
+        { "assert_regex_match": { "case_insensitive": true, "pattern": "^%{username_keybase}$" } },
+        {
+          "selector_css": { "selectors": ["div.permalink-tweet-container div.permalink-tweet", 0, "p.tweet-text", 0] }
+        },
+        { "whitespace_normalize": { } },
+        {
+          "regex_capture": {
+            "case_insensitive": true,
+            "pattern": "^ *(?:@[a-zA-Z0-9_-]+\\s*)* *Verifying myself: I am (?:[A-Za-z0-9_]+) on Keybase\\.io\\. (\\S+) */.*$"
+          }
+        },
+        { "assert_regex_match": { "pattern": "^%{sig_id_short}$" } }
+      ]
+    ]
+  }
+}
+`


### PR DESCRIPTION
This is in line after https://github.com/keybase/client/pull/4327

Add Go types like `pvlT` and `assertRegexMatchT`. Parsing is done by Go's json parser with some help from custom `UnmarshalJSON` methods.

These are not used by the interpreter yet, all dead code until the next PR. There's a test `TestParse` which parses an example.

This is for the new `{"assert_regex_match": {"pattern": "^foo$" } }` format.

r? @oconnor663 