### PR TITLE
Launchd service shouldn't set RunAtLoad

### DIFF
--- a/go/launchd/launchd.go
+++ b/go/launchd/launchd.go
@@ -66,6 +66,7 @@ type Plist struct {
 	args      []string
 	envVars   []EnvVar
 	keepAlive bool
+	runAtLoad bool
 	logPath   string
 	comment   string
 }
@@ -78,6 +79,7 @@ func NewPlist(label string, binPath string, args []string, envVars []EnvVar, log
 		args:      args,
 		envVars:   envVars,
 		keepAlive: true,
+		runAtLoad: false,
 		logPath:   logPath,
 		comment:   comment,
 	}
@@ -527,6 +529,8 @@ func (p Plist) plistXML() string {
 	options := []string{}
 	if p.keepAlive {
 		options = append(options, encodeTag("key", "KeepAlive"), encodeBool(true))
+	}
+	if p.runAtLoad {
 		options = append(options, encodeTag("key", "RunAtLoad"), encodeBool(true))
 	}
 


### PR DESCRIPTION
We start services on app start so we don't want this set.

Moved RunAtLoad setting to `Plist` bool, and defaults to false.
KeepAlive is still true which means if the services crash they will restart.

This prevents the services from starting on boot if the plists were somehow left behind after an app or OS crash.

We should have removed this when we switched to starting the app from the login item.

https://keybase.atlassian.net/browse/DESKTOP-1897