### PR TITLE
add navsettings to settings screen

### DIFF
--- a/shared/settings/delete/container.js
+++ b/shared/settings/delete/container.js
@@ -1,0 +1,17 @@
+// @flow
+// import React from 'react'
+import {connect} from 'react-redux'
+// import Delete from './index'
+
+import type {TypedState} from '../../constants/reducer'
+import type {Props} from './index'
+
+const DeleteContainer = (props: Props) => (
+  null
+  // <Delete {...props} />
+)
+
+export default connect(
+  (state: TypedState, ownProps: {}) => ({}),
+  (dispatch: any, ownProps: {}) => ({}),
+)(DeleteContainer)

--- a/shared/settings/index.js
+++ b/shared/settings/index.js
@@ -1,63 +1,30 @@
 // @flow
 import React, {Component} from 'react'
-import {connect} from 'react-redux'
 import Render from './render'
-import {routeAppend} from '../actions/router'
-import about from './about'
-import logSend from '../dev/log-send'
-import account from './account'
-// import billing from './about'
-// import appPrefs from './about'
-// import invites from './about'
-// import notifs from './about'
-// import deleteMe from './about'
 import devMenu from '../dev/dev-menu'
 import flags from '../util/feature-flags'
-
-const billing = about
-const invites = about
-const appPrefs = about
-const notifs = about
-const deleteMe = about
+import {connect} from 'react-redux'
+import {routeAppend} from '../actions/router'
 
 class Settings extends Component {
   static parseRoute () {
     return {
       componentAtTop: {title: 'Settings'},
-      subRoutes: {about, account, billing, appPrefs, invites, notifs, deleteMe, devMenu, logSend},
+      subRoutes: {devMenu},
     }
   }
 
   render () {
-    return (
-      <Render
-        showComingSoon={!flags.tabSettingsEnabled}
-        onAccount={this.props.onAccount}
-        onBilling={this.props.onBilling}
-        onPrefs={this.props.onPrefs}
-        onInvites={this.props.onInvites}
-        onNotifications={this.props.onNotifications}
-        onDeleteMe={this.props.onDeleteMe}
-        onLogSend={this.props.onLogSend}
-        onAbout={this.props.onAbout}
-        onDev={this.props.onDev} />
-    )
+    return <Render {...this.props} />
   }
 }
 
 // $FlowIssue type this connector
 export default connect(
-  state => ({}),
-  dispatch => {
-    return {
-      onAccount: () => dispatch(routeAppend(['account'])),
-      onBilling: () => dispatch(routeAppend(['billing'])),
-      onPrefs: () => dispatch(routeAppend(['app-prefs'])),
-      onInvites: () => dispatch(routeAppend(['invites'])),
-      onNotifications: () => dispatch(routeAppend(['notifs'])),
-      onDeleteMe: () => dispatch(routeAppend(['delete-me'])),
-      onLogSend: () => dispatch(routeAppend(['logSend'])),
-      onAbout: () => dispatch(routeAppend(['about'])),
-      onDev: () => dispatch(routeAppend(['devMenu'])),
-    }
-  })(Settings)
+  state => ({
+    showComingSoon: !flags.tabSettingsEnabled,
+  }),
+  dispatch => ({
+    onDevMenu: () => dispatch(routeAppend(['devMenu'])),
+  })
+)(Settings)

--- a/shared/settings/landing/container.js
+++ b/shared/settings/landing/container.js
@@ -1,0 +1,17 @@
+// @flow
+// import React from 'react'
+import {connect} from 'react-redux'
+// import Landing from './index'
+
+import type {TypedState} from '../../constants/reducer'
+import type {Props} from './index'
+
+const LandingContainer = (props: Props) => (
+  null
+  // <Landing {...props} />
+)
+
+export default connect(
+  (state: TypedState, ownProps: {}) => ({}),
+  (dispatch: any, ownProps: {}) => ({}),
+)(LandingContainer)

--- a/shared/settings/notifications/container.js
+++ b/shared/settings/notifications/container.js
@@ -1,0 +1,44 @@
+// @flow
+import React from 'react'
+import {connect} from 'react-redux'
+import Notifications from './index'
+
+import type {TypedState} from '../../constants/reducer'
+import type {Props} from './index'
+
+const NotificationsContainer = (props: Props) => (
+  <Notifications {...props} />
+)
+
+// TODO real integration
+export default connect(
+  (state: TypedState, ownProps: {}) => ({
+    settings: [
+      {
+        name: 'follow',
+        subscribed: true,
+        description: 'when someone follows me',
+      },
+      {
+        name: 'twitter_friend_joined',
+        subscribed: true,
+        description: 'when someone I follow on Twitter joins',
+      },
+      {
+        name: 'filesystem_attention',
+        subscribed: true,
+        description: 'when the Keybase filesystem needs my attention',
+      },
+      {
+        name: 'newsletter',
+        subscribed: true,
+        description: 'Keybase news, once in a great while',
+      },
+    ],
+    unsubscribedFromAll: false,
+    onSave: () => console.log('onSave'),
+    onToggle: (name: string) => console.log('on toggle', name),
+    onToggleUnsubscribeAll: () => console.log('on subscribe all'),
+  }),
+  (dispatch: any, ownProps: {}) => ({}),
+)(NotificationsContainer)

--- a/shared/settings/render.desktop.js
+++ b/shared/settings/render.desktop.js
@@ -1,36 +1,75 @@
 // @flow
+import DeleteContainer from './delete/container'
+import LandingContainer from './landing/container'
+import NavSettings from './nav'
+import NotificationsContainer from './notifications/container'
 import React, {Component} from 'react'
-import MenuList from './menu-list'
-import type {MenuListItem} from './menu-list'
 import SettingsHelp from './help.desktop'
+
+import type {SettingsItem} from './nav'
 import type {Props} from './render'
 
+const InvitationsContainer = LandingContainer // TODO add invitations
+
 type State = {
-  menuItems: Array<MenuListItem>
+    content: any,
+    items: Array<SettingsItem>,
 }
 
 class Render extends Component<void, Props, State> {
   state: State;
+  _textToContent: {[key: string]: any}
 
   constructor (props: Props) {
     super(props)
 
-    this.state = {
-      menuItems: [
-        {name: 'Account', hasChildren: true, onClick: this.props.onAccount},
-        {name: 'Billing Settings', hasChildren: true, onClick: this.props.onBilling},
-        {name: 'App Preferences', hasChildren: true, onClick: this.props.onPrefs},
-        {name: 'Invitations', hasChildren: true, onClick: this.props.onInvites},
-        {name: 'Notifications', hasChildren: true, onClick: this.props.onNotifications},
-        {name: 'Delete me', hasChildren: true, onClick: this.props.onDeleteMe},
-        {name: 'Log Send', hasChildren: false, onClick: this.props.onLogSend},
-        {name: 'About', hasChildren: true, onClick: this.props.onAbout},
-      ],
+    this._textToContent = {
+      'Your Account': <LandingContainer />,
+      'Invitations': <InvitationsContainer />,
+      'Notifications': <NotificationsContainer />,
+      'Delete me': <DeleteContainer />,
+      ...(__DEV__ ? {'Dev Menu': null} : {}),
     }
 
-    if (__DEV__) {
-      this.state.menuItems.push({name: 'Dev Menu', hasChildren: true, onClick: this.props.onDev})
+    // TODO handle badges and etc
+    const items = [{
+      text: 'Your Account',
+      onClick: () => this._select('Your Account'),
+      selected: true,
+    }, {
+      text: 'Invitations',
+      onClick: () => this._select('Invitations'),
+    }, {
+      text: 'Notifications',
+      onClick: () => this._select('Notifications'),
+    }, {
+      text: 'Delete me',
+      onClick: () => this._select('Delete me'),
+    },
+      ...(__DEV__ ? [{
+        text: 'Dev Menu',
+        onClick: () => props.onDevMenu(),
+      }] : []),
+    ]
+
+    this.state = {
+      content: this._textToContent[items[0].text],
+      items,
     }
+  }
+
+  _select (key: string) {
+    const items = this.state.items.map(item => {
+      return {
+        ...item,
+        selected: item.text === key,
+      }
+    })
+
+    this.setState({
+      content: this._textToContent[key],
+      items,
+    })
   }
 
   _renderComingSoon () {
@@ -42,9 +81,10 @@ class Render extends Component<void, Props, State> {
       return this._renderComingSoon()
     }
 
-    return <MenuList items={this.state.menuItems} />
+    return <NavSettings
+      content={this.state.content}
+      items={this.state.items} />
   }
-
 }
 
 export default Render

--- a/shared/settings/render.js.flow
+++ b/shared/settings/render.js.flow
@@ -2,15 +2,8 @@
 import {Component} from 'react'
 
 export type Props = {
-  onAccount: () => void,
-  onBilling: () => void,
-  onPrefs: () => void,
-  onInvites: () => void,
-  onNotifications: () => void,
-  onDeleteMe: () => void,
-  onLogSend: () => void,
-  onAbout: () => void,
-  onDev: () => void
+  showComingSoon: boolean,
+  onDevMenu: () => void,
 }
 
 export default class Render extends Component<void, Props, void> { }

--- a/shared/settings/render.native.js
+++ b/shared/settings/render.native.js
@@ -1,38 +1,9 @@
 // @flow
 import React, {Component} from 'react'
-import MenuList from './menu-list'
-import type {MenuListItem} from './menu-list'
 import {ComingSoon} from '../common-adapters'
 import type {Props} from './render'
 
-type State = {
-  menuItems: Array<MenuListItem>
-}
-
-class Render extends Component<void, Props, State> {
-  state: State;
-
-  constructor (props: Props) {
-    super(props)
-
-    this.state = {
-      menuItems: [
-        {name: 'Account', hasChildren: true, onClick: this.props.onAccount},
-        {name: 'Billing Settings', hasChildren: true, onClick: this.props.onBilling},
-        {name: 'App Preferences', hasChildren: true, onClick: this.props.onPrefs},
-        {name: 'Invitations', hasChildren: true, onClick: this.props.onInvites},
-        {name: 'Notifications', hasChildren: true, onClick: this.props.onNotifications},
-        {name: 'Delete me', hasChildren: true, onClick: this.props.onDeleteMe},
-        {name: 'Log Send', hasChildren: false, onClick: this.props.onLogSend},
-        {name: 'About', hasChildren: true, onClick: this.props.onAbout},
-      ],
-    }
-
-    if (__DEV__) {
-      this.state.menuItems.push({name: 'Dev Menu', hasChildren: true, onClick: this.props.onDev})
-    }
-  }
-
+class Render extends Component<void, Props, void> {
   _renderComingSoon () {
     return <ComingSoon />
   }
@@ -42,7 +13,7 @@ class Render extends Component<void, Props, State> {
       return this._renderComingSoon()
     }
 
-    return <MenuList items={this.state.menuItems} />
+    return null
   }
 
 }


### PR DESCRIPTION
I started to integrate the notifications page but realized we need to actually make the settings nav work in the app. this is the first step towards that. it doesn't have any badging or errors or anything like that plumbed through. Just loading up the tabs when you click on the sub nav.

if tabs have sub content in them we'll have to expand this to work with that. i didn't need that and didn't want to continue to add more of this stuff w/o talking to @MarcoPolo 