### PR TITLE
Use Go types in pvl

### DIFF
--- a/go/engine/scanproofs.go
+++ b/go/engine/scanproofs.go
@@ -398,7 +398,7 @@ func (e *ScanProofsEngine) CheckOne(rec map[string]string, forcepvl bool, ticker
 	}
 
 	if forcepvl {
-		perr := pvl.CheckProof(e.G(), pvl.GetHardcodedPvl(), link.GetProofType(),
+		perr := pvl.CheckProof(e.G(), pvl.GetHardcodedPvlString(), link.GetProofType(),
 			pvl.NewProofInfo(link, *hint))
 		return perr, foundhint, nil
 	}

--- a/go/externals/proof_support_coinbase.go
+++ b/go/externals/proof_support_coinbase.go
@@ -50,7 +50,7 @@ func (rc *CoinbaseChecker) GetTorError() libkb.ProofError { return nil }
 
 func (rc *CoinbaseChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_COINBASE,
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_COINBASE,
 			pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)

--- a/go/externals/proof_support_dns.go
+++ b/go/externals/proof_support_dns.go
@@ -72,7 +72,7 @@ func (rc *DNSChecker) CheckDomain(ctx libkb.ProofContext, sig string, domain str
 
 func (rc *DNSChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_DNS,
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_DNS,
 			pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)

--- a/go/externals/proof_support_facebook.go
+++ b/go/externals/proof_support_facebook.go
@@ -61,7 +61,7 @@ func (rc *FacebookChecker) ScreenNameCompare(s1, s2 string) bool {
 
 func (rc *FacebookChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_FACEBOOK, pvl.NewProofInfo(rc.proof, h))
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_FACEBOOK, pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)
 }

--- a/go/externals/proof_support_github.go
+++ b/go/externals/proof_support_github.go
@@ -48,7 +48,7 @@ func (rc *GithubChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libk
 
 func (rc *GithubChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_GITHUB,
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_GITHUB,
 			pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)

--- a/go/externals/proof_support_hackernews.go
+++ b/go/externals/proof_support_hackernews.go
@@ -66,7 +66,7 @@ func (h *HackerNewsChecker) CheckHint(ctx libkb.ProofContext, hint libkb.SigHint
 
 func (h *HackerNewsChecker) CheckStatus(ctx libkb.ProofContext, hint libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_HACKERNEWS,
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_HACKERNEWS,
 			pvl.NewProofInfo(h.proof, hint))
 	}
 	return h.CheckStatusOld(ctx, hint)

--- a/go/externals/proof_support_reddit.go
+++ b/go/externals/proof_support_reddit.go
@@ -119,7 +119,7 @@ func (rc *RedditChecker) CheckData(h libkb.SigHint, dat *jsonw.Wrapper) libkb.Pr
 
 func (rc *RedditChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_REDDIT,
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_REDDIT,
 			pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)

--- a/go/externals/proof_support_rooter.go
+++ b/go/externals/proof_support_rooter.go
@@ -135,7 +135,7 @@ func (rc *RooterChecker) rewriteURL(ctx libkb.ProofContext, s string) (string, e
 
 func (rc *RooterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) (perr libkb.ProofError) {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_ROOTER,
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_ROOTER,
 			pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)

--- a/go/externals/proof_support_twitter.go
+++ b/go/externals/proof_support_twitter.go
@@ -92,7 +92,7 @@ func (rc *TwitterChecker) findSigInTweet(ctx libkb.ProofContext, h libkb.SigHint
 
 func (rc *TwitterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_TWITTER,
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_TWITTER,
 			pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)

--- a/go/externals/proof_support_web.go
+++ b/go/externals/proof_support_web.go
@@ -66,7 +66,7 @@ func (rc *WebChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libkb.P
 
 func (rc *WebChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	if pvl.UsePvl {
-		return pvl.CheckProof(ctx, pvl.GetHardcodedPvl(), keybase1.ProofType_GENERIC_WEB_SITE,
+		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_GENERIC_WEB_SITE,
 			pvl.NewProofInfo(rc.proof, h))
 	}
 	return rc.CheckStatusOld(ctx, h)

--- a/go/pvl/hardcoded.go
+++ b/go/pvl/hardcoded.go
@@ -3,125 +3,137 @@
 
 package pvl
 
-import (
-	"log"
-
-	jsonw "github.com/keybase/go-jsonw"
-)
-
-// Filled from hardcodedPVLString by init.
-var hardcodedPVL jsonw.Wrapper
-
 var hardcodedPVLString = `
 {
   "pvl_version": 1,
   "revision": 1,
   "services": {
     "coinbase": [
-      {
-        "assert_regex_match": "^https://coinbase\\.com/%{username_service}/public-key$",
-        "case_insensitive": true
-      },
-      { "fetch": "html" },
-      { "selector_css": ["pre.statement", 0] },
-      { "assert_find_base64": "sig" }
+      [
+        { "regex_capture": { "pattern": "^https://coinbase\\.com/(.*)/public-key$" } },
+        { "assert_regex_match": { "case_insensitive": true, "pattern": "^%{username_service}$" } },
+        { "fetch": { "kind": "html" } },
+        { "selector_css": { "selectors": ["pre.statement", 0] } },
+        { "assert_find_base64": { "var": "sig" } }
+      ]
     ],
-    "dns": [{ "assert_regex_match": "^keybase-site-verification=%{sig_id_medium}$" }],
+    "dns": [[{ "assert_regex_match": { "pattern": "^keybase-site-verification=%{sig_id_medium}$" } }]],
     "generic_web_site": [
-      {
-        "assert_regex_match": "^%{protocol}://%{hostname}/(?:\\.well-known/keybase\\.txt|keybase\\.txt)$",
-        "error": ["BAD_API_URL", "Bad hint from server; didn't recognize API url: \"%{active_string}\""]
-      },
-      { "fetch": "string" },
-      { "assert_find_base64": "sig" }
+      [
+        {
+          "assert_regex_match": {
+            "error": ["BAD_API_URL", "Bad hint from server; didn't recognize API url: \"%{active_string}\""],
+            "pattern": "^%{protocol}://%{hostname}/(?:\\.well-known/keybase\\.txt|keybase\\.txt)$"
+          }
+        },
+        { "fetch": { "kind": "string" } },
+        { "assert_find_base64": { "var": "sig" } }
+      ]
     ],
     "github": [
-      {
-        "assert_regex_match": "^https://gist\\.github(usercontent)?\\.com/%{username_service}/.*$",
-        "case_insensitive": true
-      },
-      { "fetch": "string" },
-      { "assert_find_base64": "sig" }
+      [
+        {
+          "assert_regex_match": {
+            "case_insensitive": true,
+            "pattern": "^https://gist\\.github(usercontent)?\\.com/%{username_service}/.*$"
+          }
+        },
+        { "fetch": { "kind": "string" } },
+        { "assert_find_base64": { "var": "sig" } }
+      ]
     ],
     "hackernews": [
-      {
-        "assert_regex_match": "^https://hacker-news\\.firebaseio\\.com/v0/user/%{username_service}/about.json$",
-        "case_insensitive": true
-      },
-      { "fetch": "string" },
-      { "assert_regex_match": "^.*%{sig_id_medium}.*$" }
+      [
+        {
+          "assert_regex_match": {
+            "case_insensitive": true,
+            "pattern": "^https://hacker-news\\.firebaseio\\.com/v0/user/%{username_service}/about.json$"
+          }
+        },
+        { "fetch": { "kind": "string" } },
+        { "assert_regex_match": { "pattern": "^.*%{sig_id_medium}.*$" } }
+      ]
     ],
     "reddit": [
-      {
-        "assert_regex_match": "^https://(:?www\\.)?reddit\\.com/r/keybaseproofs/.*$",
-        "case_insensitive": true
-      },
-      { "fetch": "json" },
-      { "selector_json": [0, "kind"] },
-      { "assert_regex_match": "^Listing$" },
-      { "selector_json": [0, "data", "children", 0, "kind"] },
-      { "assert_regex_match": "^t3$" },
-      { "selector_json": [0, "data", "children", 0, "data", "subreddit"] },
-      { "assert_regex_match": "^keybaseproofs$", "case_insensitive": true },
-      { "selector_json": [0, "data", "children", 0, "data", "author"] },
-      { "assert_regex_match": "^%{username_service}$", "case_insensitive": true },
-      { "selector_json": [0, "data", "children", 0, "data", "title"] },
-      { "assert_regex_match": "^.*%{sig_id_medium}.*$", "case_insensitive": true },
-      { "selector_json": [0, "data", "children", 0, "data", "selftext"] },
-      { "assert_find_base64": "sig" }
+      [
+        {
+          "assert_regex_match": { "case_insensitive": true, "pattern": "^https://(:?www\\.)?reddit\\.com/r/keybaseproofs/.*$" }
+        },
+        { "fetch": { "kind": "json" } },
+        { "selector_json": { "selectors": [0, "kind"] } },
+        { "assert_regex_match": { "pattern": "^Listing$" } },
+        { "selector_json": { "selectors": [0, "data", "children", 0, "kind"] } },
+        { "assert_regex_match": { "pattern": "^t3$" } },
+        { "selector_json": { "selectors": [0, "data", "children", 0, "data", "subreddit"] } },
+        { "assert_regex_match": { "case_insensitive": true, "pattern": "^keybaseproofs$" } },
+        { "selector_json": { "selectors": [0, "data", "children", 0, "data", "author"] } },
+        { "assert_regex_match": { "case_insensitive": true, "pattern": "^%{username_service}$" } },
+        { "selector_json": { "selectors": [0, "data", "children", 0, "data", "title"] } },
+        { "assert_regex_match": { "case_insensitive": true, "pattern": "^.*%{sig_id_medium}.*$" } },
+        { "selector_json": { "selectors": [0, "data", "children", 0, "data", "selftext"] } },
+        { "assert_find_base64": { "var": "sig" } }
+      ]
     ],
     "rooter": [
-      {
-        "assert_regex_match": "^https?://[\\w:_\\-\\.]+/_/api/1\\.0/rooter/%{username_service}/.*$",
-        "case_insensitive": true
-      },
-      { "fetch": "json" },
-      { "selector_json": ["status", "name"] },
-      { "assert_regex_match": "^ok$", "case_insensitive": true },
-      { "selector_json": ["toot", "post"] },
-      { "assert_regex_match": "^.*%{sig_id_medium}.*$" }
+      [
+        {
+          "assert_regex_match": {
+            "case_insensitive": true,
+            "pattern": "^https?://[\\w:_\\-\\.]+/_/api/1\\.0/rooter/%{username_service}/.*$"
+          }
+        },
+        { "fetch": { "kind": "json" } },
+        { "selector_json": { "selectors": ["status", "name"] } },
+        { "assert_regex_match": { "case_insensitive": true, "pattern": "^ok$" } },
+        { "selector_json": { "selectors": ["toot", "post"] } },
+        { "assert_regex_match": { "pattern": "^.*%{sig_id_medium}.*$" } }
+      ]
     ],
     "twitter": [
-      { "assert_regex_match": "^https://twitter\\.com/%{username_service}/.*$", "case_insensitive": true },
-      { "fetch": "html" },
-      {
-        "attr": "data-screen-name",
-        "selector_css": ["div.permalink-tweet-container div.permalink-tweet", 0]
-      },
-      {
-        "assert_regex_match": "^%{username_service}$",
-        "case_insensitive": true,
-        "error": ["CONTENT_FAILURE", "Bad post authored; wanted \"%{username_service}\", got \"%{active_string}\""]
-      },
-      { "selector_css": ["div.permalink-tweet-container div.permalink-tweet", 0, "p.tweet-text", 0] },
-      { "whitespace_normalize": true },
-      {
-        "case_insensitive": true,
-        "regex_capture": "^ *(?:@[a-zA-Z0-9_-]+\\s*)* *Verifying myself: I am ([A-Za-z0-9_]+) on Keybase\\.io\\. (?:\\S+) */.*$"
-      },
-      { "assert_regex_match": "^%{username_keybase}$", "case_insensitive": true },
-      { "selector_css": ["div.permalink-tweet-container div.permalink-tweet", 0, "p.tweet-text", 0] },
-      { "whitespace_normalize": true },
-      {
-        "case_insensitive": true,
-        "regex_capture": "^ *(?:@[a-zA-Z0-9_-]+\\s*)* *Verifying myself: I am (?:[A-Za-z0-9_]+) on Keybase\\.io\\. (\\S+) */.*$"
-      },
-      { "assert_regex_match": "^%{sig_id_short}$" }
+      [
+        {
+          "assert_regex_match": { "case_insensitive": true, "pattern": "^https://twitter\\.com/%{username_service}/.*$" }
+        },
+        { "fetch": { "kind": "html" } },
+        {
+          "selector_css": { "attr": "data-screen-name", "selectors": ["div.permalink-tweet-container div.permalink-tweet", 0] }
+        },
+        {
+          "assert_regex_match": {
+            "case_insensitive": true,
+            "error": ["CONTENT_FAILURE", "Bad post authored; wanted \"%{username_service}\", got \"%{active_string}\""],
+            "pattern": "^%{username_service}$"
+          }
+        },
+        {
+          "selector_css": { "selectors": ["div.permalink-tweet-container div.permalink-tweet", 0, "p.tweet-text", 0] }
+        },
+        { "whitespace_normalize": { } },
+        {
+          "regex_capture": {
+            "case_insensitive": true,
+            "pattern": "^ *(?:@[a-zA-Z0-9_-]+\\s*)* *Verifying myself: I am ([A-Za-z0-9_]+) on Keybase\\.io\\. (?:\\S+) */.*$"
+          }
+        },
+        { "assert_regex_match": { "case_insensitive": true, "pattern": "^%{username_keybase}$" } },
+        {
+          "selector_css": { "selectors": ["div.permalink-tweet-container div.permalink-tweet", 0, "p.tweet-text", 0] }
+        },
+        { "whitespace_normalize": { } },
+        {
+          "regex_capture": {
+            "case_insensitive": true,
+            "pattern": "^ *(?:@[a-zA-Z0-9_-]+\\s*)* *Verifying myself: I am (?:[A-Za-z0-9_]+) on Keybase\\.io\\. (\\S+) */.*$"
+          }
+        },
+        { "assert_regex_match": { "pattern": "^%{sig_id_short}$" } }
+      ]
     ]
   }
 }
 `
 
-// GetHardcodedPvl returns the parsed hardcoded pvl
-func GetHardcodedPvl() *jsonw.Wrapper {
-	return &hardcodedPVL
-}
-
-func init() {
-	data := hardcodedPVLString
-	wrapper, err := jsonw.Unmarshal([]byte(data))
-	if err != nil {
-		log.Panicf("could not read pvl json: %v", err)
-	}
-	hardcodedPVL = *wrapper
+// GetHardcodedPvlString returns the unparsed pvl
+func GetHardcodedPvlString() string {
+	return hardcodedPVLString
 }

--- a/go/pvl/helpers.go
+++ b/go/pvl/helpers.go
@@ -107,14 +107,6 @@ func serviceToString(service keybase1.ProofType) (string, libkb.ProofError) {
 	return "", libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL, "Unsupported service %v", service)
 }
 
-func jsonHasKey(w *jsonw.Wrapper, key string) bool {
-	return !w.AtKey(key).IsNil()
-}
-
-func jsonHasKeyCommand(w *jsonw.Wrapper, key commandName) bool {
-	return !w.AtKey(string(key)).IsNil()
-}
-
 // Return the elements of an array.
 func jsonUnpackArray(w *jsonw.Wrapper) ([]*jsonw.Wrapper, error) {
 	w, err := w.ToArray()

--- a/go/pvl/helpers_test.go
+++ b/go/pvl/helpers_test.go
@@ -67,30 +67,6 @@ func TestServiceToString(t *testing.T) {
 	}
 }
 
-type jsonHasKeyTest struct {
-	json *jsonw.Wrapper
-	key  string
-	has  bool
-}
-
-var jsonHasKeyTests = []jsonHasKeyTest{
-	{jsonw.NewBool(true), "foo", false},
-	{makeJSONDangerous(`{"foo": "bar"}`), "foo", true},
-	{makeJSONDangerous(`{"baz": "bar"}`), "foo", false},
-	{makeJSONDangerous(`[0, 1, 2]`), "0", false},
-}
-
-func TestJSONHasKey(t *testing.T) {
-	for i, test := range jsonHasKeyTests {
-		if jsonHasKey(test.json, test.key) != test.has {
-			t.Fatalf("%v %v", i, !test.has)
-		}
-		if jsonHasKeyCommand(test.json, commandName(test.key)) != test.has {
-			t.Fatalf("%v %v", i, !test.has)
-		}
-	}
-}
-
 type substituteTest struct {
 	shouldwork    bool
 	service       keybase1.ProofType

--- a/go/pvl/interp_test.go
+++ b/go/pvl/interp_test.go
@@ -52,13 +52,17 @@ var interpUnitTests = []interpUnitTest{
 		name:      "basichtml",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_TWITTER: `[
-{"assert_regex_match": "^https://rooter\\.example\\.com/proofs/%{username_service}/[\\d]+\\.htjsxt$"},
-{"fetch": "html"},
-{"selector_css": [".twit", 0]},
-{"whitespace_normalize": true},
-{"assert_regex_match": "^.*goodproof.*$"}
-]`},
+			keybase1.ProofType_TWITTER: `[[
+{"assert_regex_match": {
+  "pattern": "^https://rooter\\.example\\.com/proofs/%{username_service}/[\\d]+\\.htjsxt$" } },
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": [".twit", 0] } },
+{"whitespace_normalize": {} },
+{"assert_regex_match": {
+  "pattern": "^.*goodproof.*$" }}
+]]`},
 		service:    keybase1.ProofType_TWITTER,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -73,10 +77,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "AssertRegexMatch-url-ok",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_COINBASE: `[
-{"assert_regex_match": "^https://rooter\\.example\\.com/proofs/%{username_service}/[\\d]+\\.htjsxt$"},
-{"fetch": "string"}
-]`},
+			keybase1.ProofType_COINBASE: `[[
+{"assert_regex_match": {
+  "pattern": "^https://rooter\\.example\\.com/proofs/%{username_service}/[\\d]+\\.htjsxt$" } },
+{"fetch": {
+  "kind": "string" } }
+]]`},
 		service:    keybase1.ProofType_COINBASE,
 		restype:    libkb.XAPIResText,
 		restext:    "1234",
@@ -85,10 +91,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "AssertRegexMatch-url-fail",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_HACKERNEWS: `[
-{"assert_regex_match": "^https://rooter\\.example\\.com/proofs/%{username_service}/+\\.htjsxt$"},
-{"fetch": "string"}
-]`},
+			keybase1.ProofType_HACKERNEWS: `[[
+{"assert_regex_match": {
+  "pattern": "^https://rooter\\.example\\.com/proofs/%{username_service}/+\\.htjsxt$" } },
+{"fetch": {
+  "kind": "string"} }
+]]`},
 		service:    keybase1.ProofType_HACKERNEWS,
 		restype:    libkb.XAPIResText,
 		restext:    "1234",
@@ -97,12 +105,15 @@ var interpUnitTests = []interpUnitTest{
 		name:      "AssertRegexMatch-content-ok",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_REDDIT: `[
-{"fetch": "html"},
-{"selector_css": [".twit", -1]},
-{"whitespace_normalize": true},
-{"assert_regex_match": "^short %{sig_id_short}$"}
-]`},
+			keybase1.ProofType_REDDIT: `[[
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": [".twit", -1] } },
+{"whitespace_normalize": {}},
+{"assert_regex_match": {
+  "pattern": "^short %{sig_id_short}$" } }
+]]`},
 		service:    keybase1.ProofType_REDDIT,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -111,12 +122,15 @@ var interpUnitTests = []interpUnitTest{
 		name:      "AssertRegexMatch-content-fail",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_TWITTER: `[
-{"fetch": "html"},
-{"selector_css": [".twit", -1]},
-{"whitespace_normalize": true},
-{"assert_regex_match": "^wrong %{sig_id_short}$"}
-]`},
+			keybase1.ProofType_TWITTER: `[[
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": [".twit", -1] } },
+{"whitespace_normalize": {}},
+{"assert_regex_match": {
+  "pattern": "^wrong %{sig_id_short}$" } }
+]]`},
 		service:    keybase1.ProofType_TWITTER,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -125,11 +139,14 @@ var interpUnitTests = []interpUnitTest{
 		name:      "AssertRegexMatch-content-fail-case",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_TWITTER: `[
-{"fetch": "html"},
-{"selector_css": [".twit", -1]},
-{"assert_regex_match": "^.*SHORT.*$"}
-]`},
+			keybase1.ProofType_TWITTER: `[[
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": [".twit", -1] } },
+{"assert_regex_match": {
+  "pattern": "^.*SHORT.*$" } }
+]]`},
 		service:    keybase1.ProofType_TWITTER,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -141,10 +158,11 @@ var interpUnitTests = []interpUnitTest{
 		name:      "AssertFindBase64-ok",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GENERIC_WEB_SITE: `[
-{"fetch": "string"},
-{"assert_find_base64": "sig"}
-]`},
+			keybase1.ProofType_GENERIC_WEB_SITE: `[[
+{"fetch": {
+  "kind": "string" } },
+{"assert_find_base64": {"var": "sig"}}
+]]`},
 		service: keybase1.ProofType_GENERIC_WEB_SITE,
 		restype: libkb.XAPIResText,
 		// the sig must be on a line with only spacing.
@@ -154,10 +172,11 @@ var interpUnitTests = []interpUnitTest{
 		name:      "AssertFindBase64-fail",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GENERIC_WEB_SITE: `[
-{"fetch": "string"},
-{"assert_find_base64": "sig"}
-]`},
+			keybase1.ProofType_GENERIC_WEB_SITE: `[[
+{"fetch": {
+  "kind": "string" } },
+{"assert_find_base64": {"var": "sig"}}
+]]`},
 		service:    keybase1.ProofType_GENERIC_WEB_SITE,
 		restype:    libkb.XAPIResText,
 		restext:    sig1[1:],
@@ -169,12 +188,16 @@ var interpUnitTests = []interpUnitTest{
 		name:      "WhitespaceNormalize-ok",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GENERIC_WEB_SITE: `[
-{"fetch": "string"},
-{"assert_regex_match": "^[\\s\\S]*\\t[\\s\\S]*$"},
-{"whitespace_normalize": true},
-{"assert_regex_match": "^A b c de f$", "case_insensitive": true}
-]`},
+			keybase1.ProofType_GENERIC_WEB_SITE: `[[
+{"fetch": {
+  "kind": "string" } },
+{"assert_regex_match": {
+  "pattern": "^[\\s\\S]*\\t[\\s\\S]*$" } },
+{"whitespace_normalize": {}},
+{"assert_regex_match": {
+  "pattern": "^A b c de f$",
+  "case_insensitive": true } }
+]]`},
 		service:    keybase1.ProofType_GENERIC_WEB_SITE,
 		restype:    libkb.XAPIResText,
 		restext:    "a b   \tc\tde  \n\tf",
@@ -186,13 +209,18 @@ var interpUnitTests = []interpUnitTest{
 		name:      "RegexCapture-ok-ignoregroup",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GENERIC_WEB_SITE: `[
-{"fetch": "html"},
-{"selector_css": ["div.twit", -1]},
-{"whitespace_normalize": true},
-{"regex_capture": "^(?:sHoRt) ([A-Za-z0-9+/=]+)$", "case_insensitive": true},
-{"assert_regex_match": "^%{sig_id_short}$"}
-]`},
+			keybase1.ProofType_GENERIC_WEB_SITE: `[[
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": ["div.twit", -1] } },
+{"whitespace_normalize": {}},
+{"regex_capture": {
+  "pattern": "^(?:sHoRt) ([A-Za-z0-9+/=]+)$",
+  "case_insensitive": true } },
+{"assert_regex_match": {
+  "pattern": "^%{sig_id_short}$" } }
+]]`},
 		service:    keybase1.ProofType_GENERIC_WEB_SITE,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -202,14 +230,19 @@ var interpUnitTests = []interpUnitTest{
 		name:      "RegexCapture-ok-multimatch",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GENERIC_WEB_SITE: `[
-{"fetch": "html"},
-{"selector_css": ["div.twit", -1]},
-{"whitespace_normalize": true},
-{"regex_capture": "^(short).*$"},
-{"regex_capture": "^(\\w)+$"},
-{"assert_regex_match": "^t$"}
-]`},
+			keybase1.ProofType_GENERIC_WEB_SITE: `[[
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": ["div.twit", -1] } },
+{"whitespace_normalize": {}},
+{"regex_capture": {
+  "pattern": "^(short).*$" } },
+{"regex_capture": {
+  "pattern": "^(\\w)+$" } },
+{"assert_regex_match": {
+  "pattern": "^t$" } }
+]]`},
 		service:    keybase1.ProofType_GENERIC_WEB_SITE,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -218,11 +251,15 @@ var interpUnitTests = []interpUnitTest{
 		name:      "RegexCapture-fail-nomatch",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GENERIC_WEB_SITE: `[
-{"fetch": "html"},
-{"selector_css": ["div.twit", -1]},
-{"regex_capture": "^(nowhere)$", "case_insensitive": true}
-]`},
+			keybase1.ProofType_GENERIC_WEB_SITE: `[[
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": ["div.twit", -1] } },
+{"regex_capture": {
+  "pattern": "^(nowhere)$",
+  "case_insensitive": true } }
+]]`},
 		service:    keybase1.ProofType_GENERIC_WEB_SITE,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -231,13 +268,18 @@ var interpUnitTests = []interpUnitTest{
 		name:      "RegexCapture-fail-nogroup",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GENERIC_WEB_SITE: `[
-{"fetch": "html"},
-{"selector_css": ["div.twit", -1]},
-{"whitespace_normalize": true},
-{"regex_capture": "^sHoRt.*$", "case_insensitive": true},
-{"assert_regex_match": "^%{sig_id_short}$/s"}
-]`},
+			keybase1.ProofType_GENERIC_WEB_SITE: `[[
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": ["div.twit", -1] } },
+{"whitespace_normalize": {}},
+{"regex_capture": {
+  "pattern": "^sHoRt.*$",
+  "case_insensitive": true } },
+{"assert_regex_match": {
+  "pattern": "^%{sig_id_short}$/s" } }
+]]`},
 		service:    keybase1.ProofType_GENERIC_WEB_SITE,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -249,10 +291,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "Fetch-string",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "string"},
-{"assert_regex_match": "^str9\n$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "string" } },
+{"assert_regex_match": {
+  "pattern": "^str9\n$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResText,
 		restext:    "str9\n",
@@ -261,11 +305,14 @@ var interpUnitTests = []interpUnitTest{
 		name:      "Fetch-html",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"selector_css": ["head title"]},
-{"assert_regex_match": "^proofer$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": ["head title"] } },
+{"assert_regex_match": {
+  "pattern": "^proofer$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -274,11 +321,14 @@ var interpUnitTests = []interpUnitTest{
 		name:      "Fetch-json",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "json"},
-{"selector_json": ["data", 2, "type"]},
-{"assert_regex_match": "^useful$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "json" } },
+{"selector_json": {
+  "selectors": ["data", 2, "type"] } },
+{"assert_regex_match": {
+  "pattern": "^useful$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResJSON,
 		resjson:    json1,
@@ -290,11 +340,14 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorJSON-simple",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "json"},
-{"selector_json": ["data", 2, "type"]},
-{"assert_regex_match": "^useful$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "json" } },
+{"selector_json": {
+  "selectors": ["data", 2, "type"] } },
+{"assert_regex_match": {
+  "pattern": "^useful$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResJSON,
 		resjson:    json1,
@@ -303,10 +356,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorJSON-index-dne",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "json"},
-{"selector_json": ["data", 500]}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "json" } },
+{"selector_json": {
+  "selectors": ["data", 500] } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResJSON,
 		resjson:    json1,
@@ -315,10 +370,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorJSON-key-dne",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "json"},
-{"selector_json": ["data", "a500"]}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "json" } },
+{"selector_json": {
+  "selectors": ["data", "a500"] } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResJSON,
 		resjson:    json1,
@@ -327,11 +384,14 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorJSON-index-neg",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "json"},
-{"selector_json": ["data", -1, "poster"]},
-{"assert_regex_match": "^eve$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "json" } },
+{"selector_json": {
+  "selectors": ["data", -1, "poster"] } },
+{"assert_regex_match": {
+  "pattern": "^eve$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResJSON,
 		resjson:    json1,
@@ -340,11 +400,14 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorJSON-index-all",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "json"},
-{"selector_json": ["data", {"all": true}, "poster"]},
-{"assert_regex_match": "^kronk eve$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "json" } },
+{"selector_json": {
+  "selectors": ["data", {"all": true }, "poster"] } },
+{"assert_regex_match": {
+  "pattern": "^kronk eve$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResJSON,
 		resjson:    json1,
@@ -354,11 +417,14 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorJSON-index-nonarray",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "json"},
-{"selector_json": ["data", {"all": true}, "extra", 0, 0]},
-{"assert_regex_match": "^4$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "json" } },
+{"selector_json": {
+  "selectors": ["data", {"all": true }, "extra", 0, 0] } },
+{"assert_regex_match": {
+  "pattern": "^4$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResJSON,
 		resjson:    json1,
@@ -370,12 +436,15 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorCSS-ok",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"selector_css": ["body .twit", -1]},
-{"whitespace_normalize": true},
-{"assert_regex_match": "^short %{sig_id_short}$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": ["body .twit", -1] } },
+{"whitespace_normalize": {}},
+{"assert_regex_match": {
+  "pattern": "^short %{sig_id_short}$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -384,11 +453,14 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorCSS-fail-dontcrash",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"selector_css": ["body .twit:eq(0)"]},
-{"assert_regex_match": "^$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": ["body .twit:eq(0)"] } },
+{"assert_regex_match": {
+  "pattern": "^$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -397,12 +469,15 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorCSS-ok-multi",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"selector_css": ["body .twit"],
- "multi": true},
-{"assert_regex_match": "^[\\s\\S]*goodproof[\\s\\S]*evil\\.com[\\s\\S]*short[\\s\\S]*$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": ["body .twit"],
+  "multi": true } },
+{"assert_regex_match": {
+  "pattern": "^[\\s\\S]*goodproof[\\s\\S]*evil\\.com[\\s\\S]*short[\\s\\S]*$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -411,12 +486,15 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorCSS-fail-nonmulti",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"selector_css": ["body .twit"]},
-{"whitespace_normalize": true},
-{"assert_regex_match": "^short %{sig_id_short}$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": ["body .twit"] } },
+{"whitespace_normalize": {}},
+{"assert_regex_match": {
+  "pattern": "^short %{sig_id_short}$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -425,12 +503,15 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorCSS-ok-attr",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"selector_css": ["body .twit[data-x]"],
- "attr": "data-x"},
-{"assert_regex_match": "^y$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": ["body .twit[data-x]"],
+  "attr": "data-x" } },
+{"assert_regex_match": {
+  "pattern": "^y$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -439,13 +520,16 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorCSS-ok-attr-dne",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"selector_css": ["body .twit"],
- "multi": true,
- "attr": "dne"},
-{"assert_regex_match": "^$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"selector_css": {
+  "selectors": ["body .twit"],
+  "multi": true,
+  "attr": "dne" } },
+{"assert_regex_match": {
+  "pattern": "^$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -458,13 +542,17 @@ var interpUnitTests = []interpUnitTest{
 		proofinfo: info1,
 		// Swap some parts of the paths. Also use an ignored capture group.
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"transform_url": "^https://rooter.example.com/(\\w+)/(?:%{username_service})/([^/])+\\.(htjsxt)$",
- "to": "https://rooter.example.com/%{username_keybase}/keybase/%{1}/%{2}.%{3}"},
-{"assert_regex_match": "^https://rooter.example.com/kronk/keybase/proofs/5\\.htjsxt$"},
-{"fetch": "string"},
-{"assert_regex_match": "^ok$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"transform_url": {
+  "pattern": "^https://rooter.example.com/(\\w+)/(?:%{username_service})/([^/])+\\.(htjsxt)$",
+  "to_pattern": "https://rooter.example.com/%{username_keybase}/keybase/%{1}/%{2}.%{3}" } },
+{"assert_regex_match": {
+  "pattern": "^https://rooter.example.com/kronk/keybase/proofs/5\\.htjsxt$" } },
+{"fetch": {
+  "kind": "string" } },
+{"assert_regex_match": {
+  "pattern": "^ok$" } }
+]]`},
 		service:     keybase1.ProofType_GITHUB,
 		restype:     libkb.XAPIResText,
 		restext:     "ok",
@@ -475,10 +563,11 @@ var interpUnitTests = []interpUnitTest{
 		proofinfo: info1,
 		// Swap some parts of the paths. Also use an ignored capture group.
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "string"},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "string" } },
 {"transform_url": "^$", "to": "^$"}
-]`},
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResText,
 		restext:    "ok",
@@ -489,10 +578,13 @@ var interpUnitTests = []interpUnitTest{
 		proofinfo: info1,
 		// Swap some parts of the paths. Also use an ignored capture group.
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"transform_url": "^$", "to": "^$"},
-{"fetch": "string"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"transform_url": {
+  "pattern": "^$",
+  "to_pattern": "^$" } },
+{"fetch": {
+  "kind": "string" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResText,
 		restext:    "ok",
@@ -502,11 +594,13 @@ var interpUnitTests = []interpUnitTest{
 		proofinfo: info1,
 		// Swap some parts of the paths. Also use an ignored capture group.
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"transform_url": "^(.*)$",
- "to": "%{2}"},
-{"fetch": "string"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"transform_url": {
+  "pattern": "^(.*)$",
+  "to_pattern": "%{2}" } },
+{"fetch": {
+  "kind": "string" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResText,
 		restext:    "ok",
@@ -519,7 +613,7 @@ var interpUnitTests = []interpUnitTest{
 		proofinfo: info1,
 		// Empty service entries should fail.
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_TWITTER: `[{"fetch": "string"}]`,
+			keybase1.ProofType_TWITTER: `[[ {"fetch": { "kind": "string" } } ]]`,
 		},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
@@ -565,7 +659,7 @@ var interpUnitTests = []interpUnitTest{
 	}, {
 		name:       "empty-script",
 		proofinfo:  info1,
-		prepvlstr:  `{"pvl_version": 1, "revision": 2, "services": {"github": []}}`,
+		prepvlstr:  `{"pvl_version": 1, "revision": 2, "services": {"github": [[]]}}`,
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -580,13 +674,26 @@ var interpUnitTests = []interpUnitTest{
 		reshtml:    html1,
 		shouldwork: false,
 		errstatus:  keybase1.ProofStatus_INVALID_PVL,
+	}, {
+		name:       "no-scripts",
+		proofinfo:  info1,
+		prepvlstr:  `{"pvl_version": 1, "revision": 2, "services": {"github": []}}`,
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResHTML,
+		reshtml:    html1,
+		shouldwork: false,
+		errstatus:  keybase1.ProofStatus_INVALID_PVL,
 	},
 
 	// ## Tests for bad proofinfo
 	{
-		name:       "bad-sig-path-in-domain-web",
-		proofinfo:  infoBadDomain,
-		prepvlstr:  `{"pvl_version": 1, "revision": 2, "services": {"generic_web_site": [{"fetch": "html"}]}}`,
+		name:      "bad-sig-path-in-domain-web",
+		proofinfo: infoBadDomain,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GENERIC_WEB_SITE: `[[
+{"fetch": {
+  "kind": "string" } }
+]]`},
 		service:    keybase1.ProofType_GENERIC_WEB_SITE,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -596,8 +703,12 @@ var interpUnitTests = []interpUnitTest{
 	{
 		name:      "bad-sig-path-in-domain-dns",
 		proofinfo: infoBadDomain,
-		prepvlstr: `{"pvl_version": 1, "revision": 2, "services": {"dns": [{"assert_regex_match": "$foo^"}]}}`,
-		service:   keybase1.ProofType_DNS,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_DNS: `[[
+{"assert_regex_match": {
+  "pattern": "^foo$" } }
+]]`},
+		service: keybase1.ProofType_DNS,
 		resdns: map[string][]string{
 			info1.Hostname: {"NO", "ok"},
 		},
@@ -605,9 +716,13 @@ var interpUnitTests = []interpUnitTest{
 		errstatus:  keybase1.ProofStatus_BAD_SIGNATURE,
 	},
 	{
-		name:       "bad-sig-proto",
-		proofinfo:  infoBadProto,
-		prepvlstr:  `{"pvl_version": 1, "revision": 2, "services": {"generic_web_site": [{"fetch": "html"}]}}`,
+		name:      "bad-sig-proto",
+		proofinfo: infoBadProto,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GENERIC_WEB_SITE: `[[
+{"fetch": {
+  "kind": "string" } }
+]]`},
 		service:    keybase1.ProofType_GENERIC_WEB_SITE,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -620,10 +735,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "AssertRegexMatch-invalid-missing^",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"assert_regex_match": "foobar$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"assert_regex_match": {
+  "pattern": "foobar$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -633,10 +750,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "AssertRegexMatch-invalid-missing$",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"assert_regex_match": "^foobar"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"assert_regex_match": {
+  "pattern": "^foobar" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -646,10 +765,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "AssertRegexMatch-invalid-badvar",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"assert_regex_match": "^%{hostname}$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"assert_regex_match": {
+  "pattern": "^%{hostname}$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -659,10 +780,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "AssertRegexMatch-invalid-redesc",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"assert_regex_match": ["^foobar$"]}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"assert_regex_match": {
+  "pattern": ["^foobar$"] } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -672,10 +795,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "AssertRegexMatch-invalid-badre",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"assert_regex_match": "^foo)(bar$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"assert_regex_match": {
+  "pattern": "^foo)(bar$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -688,10 +813,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "AssertFindBase64-invalid-badtarget",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "string"},
-{"assert_find_base64": "username_keybase"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "string" } },
+{"assert_find_base64": {
+  "var": "username_keybase" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResText,
 		restext:    "foobar",
@@ -708,10 +835,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "RegexCapture-invalid-missing^",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"regex_capture": "(f)oobar$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"regex_capture": {
+  "pattern": "(f)oobar$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -721,10 +850,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "RegexCapture-invalid-missing$",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"regex_capture": "^(f)oobar"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"regex_capture": {
+  "pattern": "^(f)oobar" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -734,10 +865,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "RegexCapture-invalid-badvar",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"regex_capture": "^(%{hostname})$"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"regex_capture": {
+  "pattern": "^(%{hostname})$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -747,10 +880,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "RegexCapture-invalid-redesc",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"regex_capture": ["^(f)oobar$"]}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "html" } },
+{"regex_capture": {
+  "pattern": ["^(f)oobar$"] } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -763,9 +898,9 @@ var interpUnitTests = []interpUnitTest{
 		name:      "Fetch-invalid-type",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "whatsthis"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": { "kind": "whatsthis" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResText,
 		restext:    "foobar",
@@ -775,9 +910,9 @@ var interpUnitTests = []interpUnitTest{
 		name:      "Fetch-invalid-indns",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_DNS: `[
-{"fetch": "text"}
-]`},
+			keybase1.ProofType_DNS: `[[
+{"fetch": { "kind": "text" } }
+]]`},
 		service:    keybase1.ProofType_DNS,
 		restype:    libkb.XAPIResText,
 		restext:    "foobar",
@@ -788,10 +923,10 @@ var interpUnitTests = []interpUnitTest{
 		name:      "Fetch-invalid-multiple",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "string"},
-{"fetch": "string"}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": { "kind": "string" } },
+{"fetch": { "kind": "string" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResText,
 		restext:    "foobar",
@@ -804,10 +939,11 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorJSON-invalid-scripttype",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "string"},
-{"selector_json": [0]}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": { "kind": "string" } },
+{"selector_json": {
+  "selectors": [0] } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResText,
 		restext:    "foobar",
@@ -817,10 +953,11 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorJSON-invalid-selectorlist",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "json"},
-{"selector_json": 0}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": { "kind": "json" } },
+{"selector_json": {
+  "selectors": 0 } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResJSON,
 		resjson:    json1,
@@ -830,10 +967,11 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorJSON-invalid-empty",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "json"},
-{"selector_json": []}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": { "kind": "json" } },
+{"selector_json": {
+  "selectors": [] } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResJSON,
 		resjson:    json1,
@@ -843,10 +981,11 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorJSON-invalid-spec",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "json"},
-{"selector_json": [{"foo": "bar"}]}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": { "kind": "json" } },
+{"selector_json": {
+  "selectors": [{"foo": "bar" }] } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResJSON,
 		resjson:    json1,
@@ -859,10 +998,11 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorCSS-invalid-scripttype",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "json"},
-{"selector_css": [0]}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": { "kind": "json" } },
+{"selector_css": {
+  "selectors": [0] } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResJSON,
 		resjson:    json1,
@@ -872,10 +1012,11 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorCSS-invalid-selectorlist",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"selector_css": 0}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": { "kind": "html" } },
+{"selector_css": {
+  "selectors": 0 } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -885,10 +1026,11 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorCSS-invalid-empty",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"selector_css": []}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": { "kind": "html" } },
+{"selector_css": {
+  "selectors": [] } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -898,10 +1040,11 @@ var interpUnitTests = []interpUnitTest{
 		name:      "SelectorCSS-invalid-spec",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{"fetch": "html"},
-{"selector_css": [{"foo": "bar"}]}
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": { "kind": "html" } },
+{"selector_css": {
+  "selectors": [{"foo": "bar" }] } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResHTML,
 		reshtml:    html1,
@@ -918,11 +1061,13 @@ var interpUnitTests = []interpUnitTest{
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
 			keybase1.ProofType_FACEBOOK: `[[
-  {"fetch": "string"},
-  {"assert_regex_match": "^ok$"}
+{"fetch": { "kind": "string" } },
+{"assert_regex_match": {
+  "pattern": "^ok$" } }
 ], [
-  {"fetch": "string"},
-  {"assert_regex_match": "^NO$"}
+{"fetch": { "kind": "string" } },
+{"assert_regex_match": {
+  "pattern": "^NO$" } }
 ]]`},
 		service:    keybase1.ProofType_FACEBOOK,
 		restype:    libkb.XAPIResText,
@@ -933,11 +1078,13 @@ var interpUnitTests = []interpUnitTest{
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
 			keybase1.ProofType_FACEBOOK: `[[
-  {"fetch": "string"},
-  {"assert_regex_match": "^NO$"}
+{"fetch": { "kind": "string" } },
+{"assert_regex_match": {
+  "pattern": "^NO$" } }
 ], [
-  {"fetch": "string"},
-  {"assert_regex_match": "^ok$"}
+{"fetch": { "kind": "string" } },
+{"assert_regex_match": {
+  "pattern": "^ok$" } }
 ]]`},
 		service:          keybase1.ProofType_FACEBOOK,
 		restype:          libkb.XAPIResText,
@@ -949,11 +1096,13 @@ var interpUnitTests = []interpUnitTest{
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
 			keybase1.ProofType_FACEBOOK: `[[
-  {"fetch": "string"},
-  {"assert_regex_match": "^ok$"}
+{"fetch": { "kind": "string" } },
+{"assert_regex_match": {
+  "pattern": "^ok$" } }
 ], [
-  {"fetch": "string"},
-  {"assert_regex_match": "^ok"}
+{"fetch": { "kind": "string" } },
+{"assert_regex_match": {
+  "pattern": "^ok" } }
 ]]`},
 		service:    keybase1.ProofType_FACEBOOK,
 		restype:    libkb.XAPIResText,
@@ -964,13 +1113,15 @@ var interpUnitTests = []interpUnitTest{
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
 			keybase1.ProofType_FACEBOOK: `[[
-  {"fetch": "string"},
-  {"assert_regex_match": "^NO$"
-  ,"error": "HOST_UNREACHABLE"}
+{"fetch": { "kind": "string" } },
+{"assert_regex_match": {
+  "pattern": "^NO$",
+  "error": ["HOST_UNREACHABLE", "x"] } }
 ], [
-  {"fetch": "string"},
-  {"assert_regex_match": "^NO$"
-  ,"error": "HOST_UNREACHABLE"}
+{"fetch": { "kind": "string" } },
+{"assert_regex_match": {
+  "pattern": "^NO$",
+  "error": ["HOST_UNREACHABLE", "x"] } }
 ]]`},
 		service:    keybase1.ProofType_FACEBOOK,
 		restype:    libkb.XAPIResText,
@@ -983,14 +1134,14 @@ var interpUnitTests = []interpUnitTest{
 	// Checking a DNS proof is different from checking other proofs.
 	// It runs each script against each TXT record of 2 domains.
 	// That mechanism is tested here.
-	// TODO
 	{
 		name:      "DNS-second-record-ok",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_DNS: `[
-{"assert_regex_match": "^ok$"}
-]`},
+			keybase1.ProofType_DNS: `[[
+{"assert_regex_match": {
+  "pattern": "^ok$" } }
+]]`},
 		service: keybase1.ProofType_DNS,
 		resdns: map[string][]string{
 			info1.Hostname: {"NO", "ok"},
@@ -1000,9 +1151,10 @@ var interpUnitTests = []interpUnitTest{
 		name:      "DNS-_keybase-ok",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_DNS: `[
-{"assert_regex_match": "^ok$"}
-]`},
+			keybase1.ProofType_DNS: `[[
+{"assert_regex_match": {
+  "pattern": "^ok$" } }
+]]`},
 		service: keybase1.ProofType_DNS,
 		resdns: map[string][]string{
 			info1.Hostname:               {"NO_1", "NO_2"},
@@ -1013,9 +1165,10 @@ var interpUnitTests = []interpUnitTest{
 		name:      "DNS-no-records",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_DNS: `[
-{"assert_regex_match": "^ok$"}
-]`},
+			keybase1.ProofType_DNS: `[[
+{"assert_regex_match": {
+  "pattern": "^ok$" } }
+]]`},
 		service: keybase1.ProofType_DNS,
 		resdns: map[string][]string{
 			info1.Hostname:               {},
@@ -1026,9 +1179,10 @@ var interpUnitTests = []interpUnitTest{
 		name:      "DNS-no-matching-records",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_DNS: `[
-{"assert_regex_match": "^ok$"}
-]`},
+			keybase1.ProofType_DNS: `[[
+{"assert_regex_match": {
+  "pattern": "^ok$" } }
+]]`},
 		service: keybase1.ProofType_DNS,
 		resdns: map[string][]string{
 			info1.Hostname:               {"NO_1"},
@@ -1039,9 +1193,10 @@ var interpUnitTests = []interpUnitTest{
 		name:      "DNS-error-then-succeed",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_DNS: `[
-{"assert_regex_match": "^ok$"}
-]`},
+			keybase1.ProofType_DNS: `[[
+{"assert_regex_match": {
+  "pattern": "^ok$" } }
+]]`},
 		service: keybase1.ProofType_DNS,
 		resdns: map[string][]string{
 			info1.Hostname:               {"ERROR"},
@@ -1049,13 +1204,15 @@ var interpUnitTests = []interpUnitTest{
 		},
 		shouldwork: true,
 	}, {
-		name:      "DNS-error-then-succeed",
+		name:      "DNS-error-then-succeed-2",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
 			keybase1.ProofType_DNS: `[[
-  {"assert_regex_match": "^ok1$"}
+{"assert_regex_match": {
+  "pattern": "^ok1$" } }
 ], [
-  {"assert_regex_match": "^ok2$"}
+{"assert_regex_match": {
+  "pattern": "^ok2$" } }
 ]]`},
 		service: keybase1.ProofType_DNS,
 		resdns: map[string][]string{
@@ -1066,31 +1223,15 @@ var interpUnitTests = []interpUnitTest{
 
 	// # Custom Errors
 	{
-		// With a custom status, the code will change
-		// but the description will stay the same.
-		name:      "CustomError-code",
+		name:      "CustomError-ok",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{ "fetch": "string" },
-{ "assert_regex_match": "^foo$"
-, "error": "PERMISSION_DENIED" }
-]`},
-		service:    keybase1.ProofType_GITHUB,
-		restype:    libkb.XAPIResText,
-		restext:    "bar",
-		shouldwork: false,
-		errstatus:  keybase1.ProofStatus_PERMISSION_DENIED,
-		errstr:     "Regex did not match (^foo$)",
-	}, {
-		name:      "CustomError-code-and-desc",
-		proofinfo: info1,
-		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{ "fetch": "string" },
-{ "assert_regex_match": "^foo$"
-, "error": ["PERMISSION_DENIED", "whoops!"] }
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{ "fetch": { "kind": "string"  } },
+{ "assert_regex_match": {
+  "pattern": "^foo$",
+  "error": ["PERMISSION_DENIED", "whoops!"] } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResText,
 		restext:    "bar",
@@ -1101,26 +1242,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "CustomError-wrong-short-array",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{ "fetch": "string" },
-{ "assert_regex_match": "^foo$"
-, "error": ["PERMISSION_DENIED"] }
-]`},
-		service:    keybase1.ProofType_GITHUB,
-		restype:    libkb.XAPIResText,
-		restext:    "bar",
-		shouldwork: false,
-		errstatus:  keybase1.ProofStatus_INVALID_PVL,
-	}, {
-		// If the error spec is bad, the default error is used.
-		name:      "CustomError-wrong",
-		proofinfo: info1,
-		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{ "fetch": "string" },
-{ "assert_regex_match": "^foo$"
-, "error": {} }
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{ "fetch": { "kind": "string"  } },
+{ "assert_regex_match": {
+  "pattern": "^foo$",
+  "error": ["PERMISSION_DENIED"] } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResText,
 		restext:    "bar",
@@ -1130,11 +1257,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "CustomError-wrong-type1",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{ "fetch": "string" },
-{ "assert_regex_match": "^foo$"
-, "error": 108 }
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{ "fetch": { "kind": "string"  } },
+{ "assert_regex_match": {
+  "pattern": "^foo$",
+  "error": 108 } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResText,
 		restext:    "bar",
@@ -1144,25 +1272,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "CustomError-wrong-type2",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{ "fetch": "string" },
-{ "assert_regex_match": "^foo$"
-, "error": [{}, "hmph"] }
-]`},
-		service:    keybase1.ProofType_GITHUB,
-		restype:    libkb.XAPIResText,
-		restext:    "bar",
-		shouldwork: false,
-		errstatus:  keybase1.ProofStatus_INVALID_PVL,
-	}, {
-		name:      "CustomError-wrong-type3",
-		proofinfo: info1,
-		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{ "fetch": "string" },
-{ "assert_regex_match": "^foo$"
-, "error": ["TIMEOUT", []] }
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{ "fetch": { "kind": "string"  } },
+{ "assert_regex_match": {
+  "pattern": "^foo$",
+  "error": ["TIMEOUT", []] } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResText,
 		restext:    "bar",
@@ -1174,11 +1289,12 @@ var interpUnitTests = []interpUnitTest{
 		name:      "CustomError-and-invalid",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{ "fetch": "string" },
-{ "assert_regex_match": "^%{invalid}"
-, "error": "PERMISSION_DENIED" }
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{ "fetch": { "kind": "string"  } },
+{ "assert_regex_match": {
+  "pattern": "^%{invalid}$",
+  "error": ["PERMISSION_DENIED", "whoops"] } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResText,
 		restext:    "bar",
@@ -1189,10 +1305,11 @@ var interpUnitTests = []interpUnitTest{
 		name:      "CustomError-none",
 		proofinfo: info1,
 		prepvl: map[keybase1.ProofType]string{
-			keybase1.ProofType_GITHUB: `[
-{ "fetch": "string" },
-{ "assert_regex_match": "^foo$" }
-]`},
+			keybase1.ProofType_GITHUB: `[[
+{ "fetch": { "kind": "string" } },
+{ "assert_regex_match": {
+  "pattern": "^foo$" } }
+]]`},
 		service:    keybase1.ProofType_GITHUB,
 		restype:    libkb.XAPIResText,
 		restext:    "bar",
@@ -1227,7 +1344,7 @@ func runPvlTest(t *testing.T, unit *interpUnitTest) {
 	xapi := newStubAPIEngine()
 	g.XAPI = xapi
 
-	var pvl *jsonw.Wrapper
+	var pvl string
 	var err error
 	switch {
 	case (unit.prepvl == nil) == (unit.prepvlstr == ""):
@@ -1238,10 +1355,7 @@ func runPvlTest(t *testing.T, unit *interpUnitTest) {
 			fail("Error in prepvl: %v", err)
 		}
 	default:
-		pvl, err = jsonw.Unmarshal([]byte(unit.prepvlstr))
-		if err != nil {
-			fail("Error in prepvlstr: %v", err)
-		}
+		pvl = unit.prepvlstr
 	}
 
 	var url = unit.proofinfo.APIURL
@@ -1304,36 +1418,42 @@ func runPvlTest(t *testing.T, unit *interpUnitTest) {
 	}
 }
 
-func makeTestPvl(rules map[keybase1.ProofType]string) (*jsonw.Wrapper, error) {
+func makeTestPvl(rules map[keybase1.ProofType]string) (string, error) {
+	var pvl string
 	services := jsonw.NewDictionary()
 	for ptype, v1 := range rules {
 		var err error
 		ptypestr, err := serviceToString(ptype)
 		if err != nil {
-			return nil, err
+			return pvl, err
 		}
 		v2, err := jsonw.Unmarshal([]byte(v1))
 		if err != nil {
-			return nil, err
+			return pvl, err
 		}
 		err = services.SetKey(ptypestr, v2)
 		if err != nil {
-			return nil, err
+			return pvl, err
 		}
 	}
-	pvl := jsonw.NewDictionary()
-	err := pvl.SetKey("pvl_version", jsonw.NewInt(SupportedVersion))
+	pvlStr := jsonw.NewDictionary()
+	err := pvlStr.SetKey("pvl_version", jsonw.NewInt(SupportedVersion))
 	if err != nil {
-		return nil, err
+		return pvl, err
 	}
-	err = pvl.SetKey("revision", jsonw.NewInt(1))
+	err = pvlStr.SetKey("revision", jsonw.NewInt(1))
 	if err != nil {
-		return nil, err
+		return pvl, err
 	}
-	err = pvl.SetKey("services", services)
+	err = pvlStr.SetKey("services", services)
 	if err != nil {
-		return nil, err
+		return pvl, err
 	}
+	pvlB, err := pvlStr.Marshal()
+	if err != nil {
+		return pvl, err
+	}
+	pvl = string(pvlB)
 	return pvl, nil
 }
 

--- a/go/pvl/parse.go
+++ b/go/pvl/parse.go
@@ -216,7 +216,7 @@ func (x *errorT) UnmarshalJSON(b []byte) error {
 	if !ok {
 		return fmt.Errorf("unrecognized proof status '%v'", ss[0])
 	}
-	x.Status = keybase1.ProofStatus(status)
+	x.Status = status
 	x.Description = ss[1]
 	return nil
 }

--- a/go/pvl/parse_test.go
+++ b/go/pvl/parse_test.go
@@ -11,7 +11,7 @@ import (
 
 // TestParse parses the hardcoded string
 func TestParse(t *testing.T) {
-	p, err := parse(pvlStringForParseTest)
+	p, err := parse(hardcodedPVLString)
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -22,7 +22,7 @@ func TestParse(t *testing.T) {
 
 // TestParse2 checks a few of the parse output's details.
 func TestParse2(t *testing.T) {
-	p, err := parse(pvlStringForParseTest)
+	p, err := parse(hardcodedPVLString)
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -47,134 +47,3 @@ func TestParse2(t *testing.T) {
 		t.Fatalf("first instruction is not a RegexCapture")
 	}
 }
-
-// in the near future this will go away and hardcodedPVLString will be used instead.
-var pvlStringForParseTest = `
-{
-  "pvl_version": 1,
-  "revision": 1,
-  "services": {
-    "coinbase": [
-      [
-        { "regex_capture": { "pattern": "^https://coinbase\\.com/(.*)/public-key$" } },
-        { "assert_regex_match": { "case_insensitive": true, "pattern": "^%{username_service}$" } },
-        { "fetch": { "kind": "html" } },
-        { "selector_css": { "selectors": ["pre.statement", 0] } },
-        { "assert_find_base64": { "var": "sig" } }
-      ]
-    ],
-    "dns": [[{ "assert_regex_match": { "pattern": "^keybase-site-verification=%{sig_id_medium}$" } }]],
-    "generic_web_site": [
-      [
-        {
-          "assert_regex_match": {
-            "error": ["BAD_API_URL", "Bad hint from server; didn't recognize API url: \"%{active_string}\""],
-            "pattern": "^%{protocol}://%{hostname}/(?:\\.well-known/keybase\\.txt|keybase\\.txt)$"
-          }
-        },
-        { "fetch": { "kind": "string" } },
-        { "assert_find_base64": { "var": "sig" } }
-      ]
-    ],
-    "github": [
-      [
-        {
-          "assert_regex_match": {
-            "case_insensitive": true,
-            "pattern": "^https://gist\\.github(usercontent)?\\.com/%{username_service}/.*$"
-          }
-        },
-        { "fetch": { "kind": "string" } },
-        { "assert_find_base64": { "var": "sig" } }
-      ]
-    ],
-    "hackernews": [
-      [
-        {
-          "assert_regex_match": {
-            "case_insensitive": true,
-            "pattern": "^https://hacker-news\\.firebaseio\\.com/v0/user/%{username_service}/about.json$"
-          }
-        },
-        { "fetch": { "kind": "string" } },
-        { "assert_regex_match": { "pattern": "^.*%{sig_id_medium}.*$" } }
-      ]
-    ],
-    "reddit": [
-      [
-        {
-          "assert_regex_match": { "case_insensitive": true, "pattern": "^https://(:?www\\.)?reddit\\.com/r/keybaseproofs/.*$" }
-        },
-        { "fetch": { "kind": "json" } },
-        { "selector_json": { "selectors": [0, "kind"] } },
-        { "assert_regex_match": { "pattern": "^Listing$" } },
-        { "selector_json": { "selectors": [0, "data", "children", 0, "kind"] } },
-        { "assert_regex_match": { "pattern": "^t3$" } },
-        { "selector_json": { "selectors": [0, "data", "children", 0, "data", "subreddit"] } },
-        { "assert_regex_match": { "case_insensitive": true, "pattern": "^keybaseproofs$" } },
-        { "selector_json": { "selectors": [0, "data", "children", 0, "data", "author"] } },
-        { "assert_regex_match": { "case_insensitive": true, "pattern": "^%{username_service}$" } },
-        { "selector_json": { "selectors": [0, "data", "children", 0, "data", "title"] } },
-        { "assert_regex_match": { "case_insensitive": true, "pattern": "^.*%{sig_id_medium}.*$" } },
-        { "selector_json": { "selectors": [0, "data", "children", 0, "data", "selftext"] } },
-        { "assert_find_base64": { "var": "sig" } }
-      ]
-    ],
-    "rooter": [
-      [
-        {
-          "assert_regex_match": {
-            "case_insensitive": true,
-            "pattern": "^https?://[\\w:_\\-\\.]+/_/api/1\\.0/rooter/%{username_service}/.*$"
-          }
-        },
-        { "fetch": { "kind": "json" } },
-        { "selector_json": { "selectors": ["status", "name"] } },
-        { "assert_regex_match": { "case_insensitive": true, "pattern": "^ok$" } },
-        { "selector_json": { "selectors": ["toot", "post"] } },
-        { "assert_regex_match": { "pattern": "^.*%{sig_id_medium}.*$" } }
-      ]
-    ],
-    "twitter": [
-      [
-        {
-          "assert_regex_match": { "case_insensitive": true, "pattern": "^https://twitter\\.com/%{username_service}/.*$" }
-        },
-        { "fetch": { "kind": "html" } },
-        {
-          "selector_css": { "attr": "data-screen-name", "selectors": ["div.permalink-tweet-container div.permalink-tweet", 0] }
-        },
-        {
-          "assert_regex_match": {
-            "case_insensitive": true,
-            "error": ["CONTENT_FAILURE", "Bad post authored; wanted \"%{username_service}\", got \"%{active_string}\""],
-            "pattern": "^%{username_service}$"
-          }
-        },
-        {
-          "selector_css": { "selectors": ["div.permalink-tweet-container div.permalink-tweet", 0, "p.tweet-text", 0] }
-        },
-        { "whitespace_normalize": { } },
-        {
-          "regex_capture": {
-            "case_insensitive": true,
-            "pattern": "^ *(?:@[a-zA-Z0-9_-]+\\s*)* *Verifying myself: I am ([A-Za-z0-9_]+) on Keybase\\.io\\. (?:\\S+) */.*$"
-          }
-        },
-        { "assert_regex_match": { "case_insensitive": true, "pattern": "^%{username_keybase}$" } },
-        {
-          "selector_css": { "selectors": ["div.permalink-tweet-container div.permalink-tweet", 0, "p.tweet-text", 0] }
-        },
-        { "whitespace_normalize": { } },
-        {
-          "regex_capture": {
-            "case_insensitive": true,
-            "pattern": "^ *(?:@[a-zA-Z0-9_-]+\\s*)* *Verifying myself: I am (?:[A-Za-z0-9_]+) on Keybase\\.io\\. (\\S+) */.*$"
-          }
-        },
-        { "assert_regex_match": { "pattern": "^%{sig_id_short}$" } }
-      ]
-    ]
-  }
-}
-`


### PR DESCRIPTION
This is in line after https://github.com/keybase/client/pull/4371

Switched to using Go types in the interpreter. This marks the switch to instructions like `{"assert_regex_match": {"pattern": "^foo$" } }`. Named registers are yet to come.

r? @oconnor663 