### PR TITLE
Put userInfoMapper in request context

### DIFF
--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -4,6 +4,7 @@
 package engine
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -108,7 +109,7 @@ func (e *Identify2WithUID) WantDelegate(k libkb.UIKind) bool {
 
 // Run then engine
 func (e *Identify2WithUID) Run(ctx *Context) (err error) {
-
+	defer libkb.TimeLog(fmt.Sprintf("Identify2WithUID.Run(UID=%v, Assertion=%s", e.arg.Uid, e.arg.UserAssertion), e.G().Clock().Now(), e.G().Log.Debug)
 	e.G().Log.Debug("+ Identify2WithUID.Run(UID=%v, Assertion=%s)", e.arg.Uid, e.arg.UserAssertion)
 
 	if e.arg.Uid.IsNil() {

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -4,6 +4,8 @@
 package engine
 
 import (
+	"fmt"
+
 	gregor "github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -98,6 +100,7 @@ func (e *ResolveThenIdentify2) resolveUID(ctx *Context) (err error) {
 }
 
 func (e *ResolveThenIdentify2) Run(ctx *Context) (err error) {
+	defer libkb.TimeLog(fmt.Sprintf("ResolveThenIdentify2: %+v", e.arg), e.G().Clock().Now(), e.G().Log.Debug)
 	defer e.G().Trace("ResolveThenIdentify2::Run", func() error { return err })()
 
 	e.i2eng = NewIdentify2WithUID(e.G(), e.arg)

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -448,7 +448,7 @@ func Digest(r io.Reader) (string, error) {
 // TimeLog calls out with the time since start.  Use like this:
 //    defer TimeLog("MyFunc", time.Now(), e.G().Log.Warning)
 func TimeLog(name string, start time.Time, out func(string, ...interface{})) {
-	out("* %s: %s", name, time.Since(start))
+	out("time> %s: %s", name, time.Since(start))
 }
 
 func WhitespaceNormalize(s string) string {

--- a/go/service/chat_boxer_test.go
+++ b/go/service/chat_boxer_test.go
@@ -118,7 +118,7 @@ func TestChatMessageUnbox(t *testing.T) {
 		Ctime: gregor1.ToTime(time.Now()),
 	}
 
-	unboxed, err := handler.boxer.unboxMessageWithKey(*boxed, key)
+	unboxed, err := handler.boxer.unboxMessageWithKey(context.TODO(), *boxed, key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestChatMessageInvalidBodyHash(t *testing.T) {
 	// put original hash fn back
 	handler.boxer.hashV1 = origHashFn
 
-	_, err = handler.boxer.unboxMessageWithKey(*boxed, key)
+	_, err = handler.boxer.unboxMessageWithKey(context.TODO(), *boxed, key)
 	if _, ok := err.(libkb.ChatBodyHashInvalid); !ok {
 		t.Fatalf("unexpected error for invalid body hash: %s", err)
 	}
@@ -216,7 +216,7 @@ func TestChatMessageInvalidHeaderSig(t *testing.T) {
 	// put original signing fn back
 	handler.boxer.sign = origSign
 
-	_, err = handler.boxer.unboxMessageWithKey(*boxed, key)
+	_, err = handler.boxer.unboxMessageWithKey(context.TODO(), *boxed, key)
 	if _, ok := err.(libkb.BadSigError); !ok {
 		t.Fatalf("unexpected error for invalid header signature: %s", err)
 	}
@@ -250,7 +250,7 @@ func TestChatMessageInvalidSenderKey(t *testing.T) {
 		Ctime: gregor1.ToTime(time.Now()),
 	}
 
-	_, err = handler.boxer.unboxMessageWithKey(*boxed, key)
+	_, err = handler.boxer.unboxMessageWithKey(context.TODO(), *boxed, key)
 	if _, ok := err.(libkb.NoKeyError); !ok {
 		t.Fatalf("unexpected error for invalid sender key: %v", err)
 	}

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -358,7 +358,8 @@ func (h *chatLocalHandler) getConversationInfo(ctx context.Context, conversation
 	}
 
 	kf := newKeyFinder()
-	uimap := newUserInfoMapper(h.G())
+	var uimap *userInfoMapper
+	ctx, uimap = getUserInfoMapper(ctx, h.G())
 	for _, b := range conversationRemote.MaxMsgs {
 		unboxed, err := h.boxer.unboxMessage(ctx, kf, b)
 		if err != nil {
@@ -472,7 +473,8 @@ func (h *chatLocalHandler) getConversationMessages(ctx context.Context, conversa
 		return conv, err
 	}
 
-	uimap := newUserInfoMapper(h.G())
+	var uimap *userInfoMapper
+	ctx, uimap = getUserInfoMapper(ctx, h.G())
 	for _, m := range tview.Messages {
 		isNew := false
 		if conversationRemote.ReaderInfo != nil && m.ServerHeader.MessageID > conversationRemote.ReaderInfo.ReadMsgid {
@@ -674,7 +676,8 @@ func (h *chatLocalHandler) unboxThread(ctx context.Context, boxed chat1.ThreadVi
 	}
 
 	finder := newKeyFinder()
-	uimap := newUserInfoMapper(h.G())
+	var uimap *userInfoMapper
+	ctx, uimap = getUserInfoMapper(ctx, h.G())
 	for _, msg := range boxed.Messages {
 		unboxed, err := h.boxer.unboxMessage(ctx, finder, msg)
 		if err != nil {

--- a/go/service/user_info_mapper.go
+++ b/go/service/user_info_mapper.go
@@ -3,9 +3,15 @@ package service
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
+
+type uictxkey int
+
+var uiKey uictxkey = 1
 
 // userInfoMapper looks up usernames and device names, memoizing the results.
 // Only intended to be used for a single request (i.e., getting all the
@@ -14,6 +20,20 @@ type userInfoMapper struct {
 	users       map[keybase1.UID]*libkb.User
 	deviceNames map[string]string
 	libkb.Contextified
+}
+
+func userInfoFromContext(ctx context.Context) (*userInfoMapper, bool) {
+	ui, ok := ctx.Value(uiKey).(*userInfoMapper)
+	return ui, ok
+}
+
+func getUserInfoMapper(ctx context.Context, g *libkb.GlobalContext) (context.Context, *userInfoMapper) {
+	ui, ok := userInfoFromContext(ctx)
+	if ok {
+		return ctx, ui
+	}
+	ui = newUserInfoMapper(g)
+	return context.WithValue(ctx, uiKey, ui), ui
 }
 
 func newUserInfoMapper(g *libkb.GlobalContext) *userInfoMapper {
@@ -25,16 +45,9 @@ func newUserInfoMapper(g *libkb.GlobalContext) *userInfoMapper {
 }
 
 func (u *userInfoMapper) lookup(uid keybase1.UID, deviceID keybase1.DeviceID) (username, deviceName string, err error) {
-	user, ok := u.users[uid]
-	if !ok {
-		arg := libkb.NewLoadUserByUIDArg(u.G(), uid)
-		arg.PublicKeyOptional = true
-		var err error
-		user, err = libkb.LoadUser(arg)
-		if err != nil {
-			return "", "", err
-		}
-		u.users[uid] = user
+	user, err := u.user(uid)
+	if err != nil {
+		return "", "", err
 	}
 
 	dkey := fmt.Sprintf("%s:%s", uid, deviceID)
@@ -52,4 +65,19 @@ func (u *userInfoMapper) lookup(uid keybase1.UID, deviceID keybase1.DeviceID) (u
 	}
 
 	return user.GetNormalizedName().String(), dname, nil
+}
+
+func (u *userInfoMapper) user(uid keybase1.UID) (*libkb.User, error) {
+	user, ok := u.users[uid]
+	if !ok {
+		arg := libkb.NewLoadUserByUIDArg(u.G(), uid)
+		arg.PublicKeyOptional = true
+		var err error
+		user, err = libkb.LoadUser(arg)
+		if err != nil {
+			return nil, err
+		}
+		u.users[uid] = user
+	}
+	return user, nil
 }


### PR DESCRIPTION
The chat_local service handler uses userInfoMapper to avoid loading users, devices repeatedly.  

This PR puts it in the request context so that one userInfoMapper is used for the entire request.  Before it was possible for there to be several.  Also, the verifying of the sender's signing key was calling LoadUser and now it uses the userInfoMapper.

With this change, the number of LoadUser calls is drastically reduced.