### PR TITLE
Check whole CheckText for Facebook

### DIFF
--- a/go/externals/proof_support_facebook.go
+++ b/go/externals/proof_support_facebook.go
@@ -39,17 +39,27 @@ func (rc *FacebookChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) li
 	}
 
 	wantedURL := ("https://m.facebook.com/" + strings.ToLower(rc.proof.GetRemoteUsername()) + "/posts/")
-	wantedMediumID := "on Keybase.io. " + rc.proof.GetSigID().ToMediumID()
-
 	if !strings.HasPrefix(strings.ToLower(h.GetAPIURL()), wantedURL) {
 		return libkb.NewProofError(keybase1.ProofStatus_BAD_API_URL,
 			"Bad hint from server; URL should start with '%s', received '%s'", wantedURL, h.GetAPIURL())
 	}
 
-	// TODO: We could ignore this portion of the server's hint. Should we?
-	if !strings.Contains(h.GetCheckText(), wantedMediumID) {
-		return libkb.NewProofError(keybase1.ProofStatus_BAD_SIGNATURE,
-			"Bad proof-check text from server; need '%s' as a substring, received '%s'", wantedMediumID, h.GetCheckText())
+	// TODO: We could ignore the checktext portion of the server's hint. Should we?
+
+	checkText := libkb.WhitespaceNormalize(h.GetCheckText())
+	re := regexp.MustCompile("^Verifying myself: I am (\\S+) on Keybase.io. (\\S+)$")
+	match := re.FindStringSubmatch(checkText)
+	wantedCheckText := "Verifying myself: I am " + rc.proof.GetUsername() + " on Keybase.io. " + rc.proof.GetSigID().ToMediumID()
+	checkTextErr := libkb.NewProofError(keybase1.ProofStatus_BAD_SIGNATURE,
+		"Bad proof-check text from server; need '%s', received '%s'", wantedCheckText, checkText)
+	if len(match) != 3 {
+		return checkTextErr
+	}
+	if !libkb.Cicmp(match[1], rc.proof.GetUsername()) {
+		return checkTextErr
+	}
+	if match[2] != rc.proof.GetSigID().ToMediumID() {
+		return checkTextErr
 	}
 
 	return nil


### PR DESCRIPTION
Check the whole of the hint CheckText, making the check stricter and the possibility of getting rid of checktext easier to transition to.

Please double check issues of capitalization and TrimSpace.
Could the capitalization of the keybase username differ on the post? I tested it once with a local account `mlSTEELE5` and my keybase username was lowercase on both sides.
Could the hint check text have funky spacing? It shouldn't.

r? @oconnor663 