### PR TITLE
don't overwrite KEYBASE_RUN_MODE in run_keybase if set

### DIFF
--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -36,7 +36,7 @@ if which flock &> /dev/null && [ -e "$lockfile" ] ; then
   flock "$lockfile" true
 fi
 
-export KEYBASE_RUN_MODE=prod
+export KEYBASE_RUN_MODE="${KEYBASE_RUN_MODE:-prod}"
 export KEYBASE_DEBUG=1
 logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
 mkdir -p "$logdir"


### PR DESCRIPTION
r? @cjb @maxtaco 

I wasted 10 minutes of @chrisnojima's time by forgetting that this script overwrites KEYBASE_RUN_MODE. Seems better to make it not do that.