### PR TITLE
Add saga to unset searchActive on switchTab

### DIFF
--- a/shared/actions/search.js
+++ b/shared/actions/search.js
@@ -5,12 +5,7 @@ import {apiserverGetRpc} from '../constants/types/flow-types'
 import {capitalize, trim} from 'lodash'
 import {filterNull} from '../util/arrays'
 import {isFollowing as isFollowing_} from './config'
-import {switchTab} from '../constants/router'
-import {put, select} from 'redux-saga/effects'
-import {takeEvery} from 'redux-saga'
 
-import type {SagaGenerator} from '../constants/types/saga'
-import type {TypedState} from '../constants/reducer'
 import type {ExtraInfo, Search, Results, SelectPlatform, SelectUserForInfo,
   AddUserToGroup, RemoveUserFromGroup, ToggleUserGroup, SearchResult,
   SearchPlatforms, Reset, Waiting, SetActive} from '../constants/search'
@@ -251,20 +246,3 @@ export function setActive (active: boolean): SetActive {
     payload: {active},
   }
 }
-
-function * unsetActiveOnSwitchTab (): SagaGenerator<any, any> {
-  const selector = ({search: {searchActive}}: TypedState) => searchActive
-  // $FlowIssue
-  const searchActive: boolean = yield select(selector)
-  if (searchActive) {
-    yield put(setActive(false))
-  }
-}
-
-function * searchSaga (): SagaGenerator<any, any> {
-  yield [
-    takeEvery(switchTab, unsetActiveOnSwitchTab),
-  ]
-}
-
-export default searchSaga

--- a/shared/actions/search.js
+++ b/shared/actions/search.js
@@ -1,13 +1,19 @@
 // @flow
 import * as Constants from '../constants/search'
-import type {ExtraInfo, Search, Results, SelectPlatform, SelectUserForInfo,
-  AddUserToGroup, RemoveUserFromGroup, ToggleUserGroup, SearchResult,
-  SearchPlatforms, Reset, Waiting, SetActive} from '../constants/search'
 import type {TypedAsyncAction} from '../constants/types/flux'
 import {apiserverGetRpc} from '../constants/types/flow-types'
 import {capitalize, trim} from 'lodash'
 import {filterNull} from '../util/arrays'
 import {isFollowing as isFollowing_} from './config'
+import {switchTab} from '../constants/router'
+import {put, select} from 'redux-saga/effects'
+import {takeEvery} from 'redux-saga'
+
+import type {SagaGenerator} from '../constants/types/saga'
+import type {TypedState} from '../constants/reducer'
+import type {ExtraInfo, Search, Results, SelectPlatform, SelectUserForInfo,
+  AddUserToGroup, RemoveUserFromGroup, ToggleUserGroup, SearchResult,
+  SearchPlatforms, Reset, Waiting, SetActive} from '../constants/search'
 
 const {platformToLogo16, platformToLogo32, searchResultKeys} = Constants
 
@@ -245,3 +251,20 @@ export function setActive (active: boolean): SetActive {
     payload: {active},
   }
 }
+
+function * unsetActiveOnSwitchTab (): SagaGenerator<any, any> {
+  const selector = ({search: {searchActive}}: TypedState) => searchActive
+  // $FlowIssue
+  const searchActive: boolean = yield select(selector)
+  if (searchActive) {
+    yield put(setActive(false))
+  }
+}
+
+function * searchSaga (): SagaGenerator<any, any> {
+  yield [
+    takeEvery(switchTab, unsetActiveOnSwitchTab),
+  ]
+}
+
+export default searchSaga

--- a/shared/reducers/search.js
+++ b/shared/reducers/search.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import * as Constants from '../constants/search'
+import {switchTab} from '../constants/router'
 import * as CommonConstants from '../constants/common'
 import type {IconType} from '../common-adapters/icon'
 import type {SearchResult, SearchActions, SearchPlatforms} from '../constants/search'
@@ -163,6 +164,15 @@ export default function (state: State = initialState, action: SearchActions): St
       return {
         ...state,
         searchActive: action.payload && action.payload.active,
+      }
+    // TODO (MM): We shouldn't be changing the same state in multiple spots
+    // doing this here, instead of making a saga to fire the setActive action after
+    // a switchTab.
+    // In the future search will be a tab too, so we won't have this notion of searchActive
+    case switchTab:
+      return {
+        ...state,
+        searchActive: false,
       }
   }
 

--- a/shared/search/user-pane/index.js
+++ b/shared/search/user-pane/index.js
@@ -3,7 +3,6 @@ import {fullName} from '../../constants/search'
 import keybaseUrl from '../../constants/urls'
 import {TypedConnector} from '../../util/typed-connect'
 import {getProfile, onFollow, onUnfollow} from '../../actions/tracker'
-import {setActive} from '../../actions/search'
 import {onClickAvatar, onClickFollowers, onClickFollowing} from '../../actions/profile'
 import openURL from '../../util/open-url'
 import Render from './render'
@@ -48,18 +47,9 @@ export default connector.connect(
             onFollow: () => { dispatch(onFollow(username, false)) },
             onUnfollow: () => { dispatch(onUnfollow(username)) },
             onAcceptProofs: () => { dispatch(onFollow(username, false)) },
-            onClickAvatar: () => {
-              dispatch(setActive(false))
-              dispatch(onClickAvatar(username, uid))
-            },
-            onClickFollowers: () => {
-              dispatch(setActive(false))
-              dispatch(onClickFollowers(username, uid))
-            },
-            onClickFollowing: () => {
-              dispatch(setActive(false))
-              dispatch(onClickFollowing(username, uid))
-            },
+            onClickAvatar: () => { dispatch(onClickAvatar(username, uid)) },
+            onClickFollowers: () => { dispatch(onClickFollowers(username, uid)) },
+            onClickFollowing: () => { dispatch(onClickFollowing(username, uid)) },
           },
         }
       } else {

--- a/shared/store/configure-store.js
+++ b/shared/store/configure-store.js
@@ -3,12 +3,6 @@ import {Iterable} from 'immutable'
 import configureStoreNative from './configure-store.platform'
 import createLogger from 'redux-logger'
 import createSagaMiddleware from 'redux-saga'
-import deviceSaga from '../actions/devices'
-import gregorSaga from '../actions/gregor'
-import profileSaga from '../actions/profile'
-import favoriteSaga from '../actions/favorite'
-import kbfsSaga from '../actions/kbfs'
-import pgpSaga from '../actions/pgp'
 import rootReducer from '../reducers'
 import thunkMiddleware from 'redux-thunk'
 import {actionLogger} from './action-logger'
@@ -17,6 +11,14 @@ import {call} from 'redux-saga/effects'
 import {closureCheck} from './closure-check'
 import {enableStoreLogging, enableActionLogging, closureStoreCheck} from '../local-debug'
 import {requestIdleCallback} from '../util/idle-callback'
+
+import deviceSaga from '../actions/devices'
+import favoriteSaga from '../actions/favorite'
+import gregorSaga from '../actions/gregor'
+import kbfsSaga from '../actions/kbfs'
+import pgpSaga from '../actions/pgp'
+import profileSaga from '../actions/profile'
+import searchSaga from '../actions/search'
 
 // Transform objects from Immutable on printing
 const objToJS = state => {
@@ -55,12 +57,13 @@ const loggerMiddleware: any = enableStoreLogging ? createLogger({
 
 function * mainSaga (getState) {
   yield [
-    call(gregorSaga),
-    call(profileSaga),
-    call(favoriteSaga),
-    call(pgpSaga),
     call(deviceSaga),
+    call(favoriteSaga),
+    call(gregorSaga),
     call(kbfsSaga),
+    call(pgpSaga),
+    call(profileSaga),
+    call(searchSaga),
   ]
 }
 

--- a/shared/store/configure-store.js
+++ b/shared/store/configure-store.js
@@ -18,7 +18,6 @@ import gregorSaga from '../actions/gregor'
 import kbfsSaga from '../actions/kbfs'
 import pgpSaga from '../actions/pgp'
 import profileSaga from '../actions/profile'
-import searchSaga from '../actions/search'
 
 // Transform objects from Immutable on printing
 const objToJS = state => {
@@ -63,7 +62,6 @@ function * mainSaga (getState) {
     call(kbfsSaga),
     call(pgpSaga),
     call(profileSaga),
-    call(searchSaga),
   ]
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

I made changes that moved searchState to the store.

There used to be some logic to check when tabs switched to unset the `searchActive` state. With a refactor here: https://github.com/keybase/client/pull/4311. That went away.

I initially thought we'd want to call setActive and switchTab, but on second thought that is too error prone (evidence by this bug).

So instead we have a small saga that just takes every switchTab action. When a switchTab happens it check to see if search is active, if it is it will toggle it off.