### PR TITLE
add extra info to conversation prot for finalized tlf relationships CORE-3659

### DIFF
--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -421,11 +421,10 @@ func ImportStatusAsError(s *keybase1.Status) error {
 		for _, field := range s.Fields {
 			switch field.Key {
 			case "TlfID":
-				val, err := hex.DecodeString(field.Value)
+				var err error
+				tlfID, err = chat1.MakeTLFID(field.Value)
 				if err != nil {
 					G.Log.Warning("error parsing chat tlf finalized TLFID: %s", err.Error())
-				} else {
-					tlfID = chat1.TLFID(val)
 				}
 			}
 		}

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -136,9 +136,11 @@ type ConversationReaderInfo struct {
 }
 
 type Conversation struct {
-	Metadata   ConversationMetadata    `codec:"metadata" json:"metadata"`
-	ReaderInfo *ConversationReaderInfo `codec:"readerInfo,omitempty" json:"readerInfo,omitempty"`
-	MaxMsgs    []MessageBoxed          `codec:"maxMsgs" json:"maxMsgs"`
+	Metadata     ConversationMetadata    `codec:"metadata" json:"metadata"`
+	ReaderInfo   *ConversationReaderInfo `codec:"readerInfo,omitempty" json:"readerInfo,omitempty"`
+	Supersedes   *ConversationMetadata   `codec:"supersedes,omitempty" json:"supersedes,omitempty"`
+	SupersededBy *ConversationMetadata   `codec:"supersededBy,omitempty" json:"supersededBy,omitempty"`
+	MaxMsgs      []MessageBoxed          `codec:"maxMsgs" json:"maxMsgs"`
 }
 
 type MessageServerHeader struct {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -30,8 +30,24 @@ func MakeConversationID(val uint64) ConversationID {
 	return ConversationID(val)
 }
 
+func ConvertConversationID(val string) (ConversationID, error) {
+	raw, err := strconv.ParseUint(val, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return MakeConversationID(raw), nil
+}
+
 func MakeTLFID(val string) (TLFID, error) {
 	return hex.DecodeString(val)
+}
+
+func MakeTopicID(val string) (TopicID, error) {
+	return hex.DecodeString(val)
+}
+
+func MakeTopicType(val int64) TopicType {
+	return TopicType(val)
 }
 
 func (mid MessageID) String() string {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -84,6 +84,8 @@ protocol common {
   record Conversation {
     ConversationMetadata metadata;
     union { null, ConversationReaderInfo } readerInfo; // information about the convo from a user perspective
+    union { null, ConversationMetadata } supersedes; // metadata about the conversation this supersedes from a TLF finalize (if any).
+    union { null, ConversationMetadata } supersededBy; // metadata about the conversation that superseded this conversation from a TLF finalize.
 
     // maxMsgs is the maximum message for each messageType in the conversation
     array<MessageBoxed> maxMsgs;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -211,6 +211,8 @@ export type BodyPlaintextVersion =
 export type Conversation = {
   metadata: ConversationMetadata,
   readerInfo?: ?ConversationReaderInfo,
+  supersedes?: ?ConversationMetadata,
+  supersededBy?: ?ConversationMetadata,
   maxMsgs?: ?Array<MessageBoxed>,
 }
 

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -275,6 +275,20 @@
           "name": "readerInfo"
         },
         {
+          "type": [
+            null,
+            "ConversationMetadata"
+          ],
+          "name": "supersedes"
+        },
+        {
+          "type": [
+            null,
+            "ConversationMetadata"
+          ],
+          "name": "supersededBy"
+        },
+        {
           "type": {
             "type": "array",
             "items": "MessageBoxed"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -211,6 +211,8 @@ export type BodyPlaintextVersion =
 export type Conversation = {
   metadata: ConversationMetadata,
   readerInfo?: ?ConversationReaderInfo,
+  supersedes?: ?ConversationMetadata,
+  supersededBy?: ?ConversationMetadata,
   maxMsgs?: ?Array<MessageBoxed>,
 }
 


### PR DESCRIPTION
@maxtaco r?

This patch adds additions to `Conversation` to point forward and back in the finalize order.