### PR TITLE
Fix device loading after getting an error

### DIFF
--- a/shared/actions/devices.js
+++ b/shared/actions/devices.js
@@ -56,7 +56,7 @@ function * _deviceListSaga (): SagaGenerator<any, any> {
   } catch (e) {
     yield put(({
       type: Constants.showDevices,
-      payload: {errorText: e.toString()},
+      payload: {errorText: e.desc + e.name, errorObj: e},
       error: true,
     }: ShowDevices))
   }
@@ -82,19 +82,19 @@ function * _deviceRemoveSaga (removeAction: RemoveDevice): SagaGenerator<any, an
         }: DeviceRemoved))
       }
       yield call(loginDeprovisionRpcPromise, {param: {username, doRevoke: true}})
+      yield put(navigateTo([], loginTab))
+      yield put(switchTab(loginTab))
+      yield put(setRevokedSelf(name))
       yield put(({
         type: Constants.deviceRemoved,
         payload: undefined,
         error: false,
       }: DeviceRemoved))
-      yield put(setRevokedSelf(name))
-      yield put(navigateTo([], loginTab))
-      yield put(switchTab(loginTab))
     } catch (e) {
       console.warn('Error removing the current device:', e)
       yield put(({
         type: Constants.deviceRemoved,
-        payload: {errorText: e.toString()},
+        payload: {errorText: e.desc + e.name, errorObj: e},
         error: true,
       }: DeviceRemoved))
     }
@@ -113,7 +113,7 @@ function * _deviceRemoveSaga (removeAction: RemoveDevice): SagaGenerator<any, an
       console.warn('Error removing a device:', e)
       yield put(({
         type: Constants.deviceRemoved,
-        payload: {errorText: e.toString()},
+        payload: {errorText: e.desc + e.name, errorObj: e},
         error: true,
       }: DeviceRemoved))
     }
@@ -187,7 +187,7 @@ function * _devicePaperKeySaga (): SagaGenerator<any, any> {
     console.warn('error in generating paper key', e)
     yield put(({
       type: Constants.paperKeyLoaded,
-      payload: {errorText: e.toString()},
+      payload: {errorText: e.desc + e.name, errorObj: e},
       error: true,
     }: PaperKeyLoaded))
   }

--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -13,9 +13,9 @@ import {routeAppend} from '../actions/router'
 
 class Devices extends Component {
   componentWillMount () {
-    const {devices, waitingForServer, error} = this.props
+    const {devices, waitingForServer, loggedIn} = this.props
 
-    if (!devices && !waitingForServer && !error) {
+    if (loggedIn && !devices && !waitingForServer) {
       this.props.loadDevices()
     }
   }
@@ -53,7 +53,8 @@ class Devices extends Component {
 export default connect(
   (state: any) => {
     const {devices, waitingForServer, error} = state.devices
-    return {devices, waitingForServer, error}
+    const {loggedIn} = state.config
+    return {devices, waitingForServer, error, loggedIn}
   },
   (dispatch: any) => {
     return {

--- a/shared/reducers/devices.js
+++ b/shared/reducers/devices.js
@@ -24,7 +24,7 @@ export default function (state = initialState, action) {
     case Constants.showDevices:
       let devices
       if (action.error) {
-        devices = []
+        devices = null
       } else {
         devices = _.chain(action.payload)
           .map(dev => ({
@@ -47,6 +47,11 @@ export default function (state = initialState, action) {
         error: action.error && action.payload,
         devices,
         waitingForServer: false,
+      }
+    case Constants.removeDevice:
+      return {
+        ...state,
+        waitingForServer: true,
       }
     case Constants.deviceRemoved:
       return {


### PR DESCRIPTION
@keybase/react-hackers @cjb 

Fixes DESKTOP-1888

the bug was that after you revoked the device and logged out it would call `loadDevices`. That would lead to the error `LOGIN_REQUIRED`. 

The logic in the component is to not try to load devices if there ever was an error. So we never tried to refresh the screen.

This cleans up the code a bit and fixes the bug 