### PR TITLE
limit number of dumb items to 10

### DIFF
--- a/shared/dev/dumb-sheet.render.desktop.js
+++ b/shared/dev/dumb-sheet.render.desktop.js
@@ -73,7 +73,7 @@ class Render extends Component<void, Props, any> {
 
           return (
             <Box key={key} style={styleBox}>
-              <Text type='Header' style={{marginBottom: 5}}>{key}</Text>
+              <Text type='Header' style={{marginBottom: 5}} onClick={() => this._onFilterChange(key)}>{key}</Text>
               {items}
             </Box>
           )

--- a/shared/dev/dumb-sheet.render.desktop.js
+++ b/shared/dev/dumb-sheet.render.desktop.js
@@ -34,6 +34,7 @@ class Render extends Component<void, Props, any> {
 
   render () {
     const filter = this.props.dumbFilter.toLowerCase()
+    let numItemsLeftWeCanShow = 10
 
     return (
       <Box style={{...globalStyles.scrollable, padding: 20}}>
@@ -52,6 +53,10 @@ class Render extends Component<void, Props, any> {
           const items = Object.keys(map.mocks)
             .filter(mockKey => !filter || includeAllChildren || (key.toLowerCase() + mockKey.toLowerCase()).indexOf(filter) !== -1)
             .map((mockKey, idx) => {
+              --numItemsLeftWeCanShow
+
+              if (numItemsLeftWeCanShow <= 0) return null
+
               return (
                 <DumbSheetItem
                   key={mockKey}


### PR DESCRIPTION
in order to stop empty filters from blowing up your cpu i'm limiting how many components can be shown at a time. might be a simple solution. if its annoying we can change or up the number

@keybase/react-hackers 