### PR TITLE
Improve identify performance

### DIFF
--- a/go/engine/identify.go
+++ b/go/engine/identify.go
@@ -315,7 +315,7 @@ func (c *card) GetAppStatus() *libkb.AppStatus {
 func getUserCard(g *libkb.GlobalContext, uid keybase1.UID, useSession bool) (ret *keybase1.UserCard, err error) {
 	defer g.Trace("getUserCard", func() error { return err })()
 
-	cached, err := g.CardCache.Get(uid)
+	cached, err := g.CardCache.Get(uid, useSession)
 	if err != nil {
 		g.Log.Debug("CardCache.Get error: %s", err)
 	} else if cached != nil {
@@ -350,7 +350,7 @@ func getUserCard(g *libkb.GlobalContext, uid keybase1.UID, useSession bool) (ret
 		TheyFollowYou: card.TheyFollowYou,
 	}
 
-	if err := g.CardCache.Set(ret); err != nil {
+	if err := g.CardCache.Set(ret, useSession); err != nil {
 		g.Log.Debug("CardCache.Set error: %s", err)
 	}
 

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -501,13 +501,28 @@ func (e *Identify2WithUID) loadThem(ctx *Context) (err error) {
 	return err
 }
 
-func (e *Identify2WithUID) loadUsers(ctx *Context) (err error) {
-	if err = e.loadMe(ctx); err != nil {
-		return err
+func (e *Identify2WithUID) loadUsers(ctx *Context) error {
+	var loadMeErr, loadThemErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		loadMeErr = e.loadMe(ctx)
+		wg.Done()
+	}()
+	wg.Add(1)
+	go func() {
+		loadThemErr = e.loadThem(ctx)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	if loadMeErr != nil {
+		return loadMeErr
 	}
-	if err = e.loadThem(ctx); err != nil {
-		return err
+	if loadThemErr != nil {
+		return loadThemErr
 	}
+
 	return nil
 }
 

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -148,7 +148,7 @@ func (e *Identify2WithUID) runReturnError(ctx *Context) (err error) {
 		return err
 	}
 
-	if !e.useAnyAssertions() && e.checkFastCacheHit() && e.allowEarlyOuts() {
+	if !e.useAnyAssertions() && e.allowEarlyOuts() && e.checkFastCacheHit() {
 		e.G().Log.Debug("| hit fast cache")
 		return nil
 	}
@@ -167,7 +167,7 @@ func (e *Identify2WithUID) runReturnError(ctx *Context) (err error) {
 		return nil
 	}
 
-	if !e.useRemoteAssertions() && e.checkSlowCacheHit() && e.allowEarlyOuts() {
+	if !e.useRemoteAssertions() && e.allowEarlyOuts() && e.checkSlowCacheHit() {
 		e.G().Log.Debug("| hit slow cache, first check")
 		return nil
 	}
@@ -190,7 +190,7 @@ func (e *Identify2WithUID) runReturnError(ctx *Context) (err error) {
 		return err
 	}
 
-	if e.useRemoteAssertions() && e.checkSlowCacheHit() && e.allowEarlyOuts() {
+	if e.useRemoteAssertions() && e.allowEarlyOuts() && e.checkSlowCacheHit() {
 		e.G().Log.Debug("| hit slow cache, second check")
 		return nil
 	}

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -596,7 +596,7 @@ func ImportLinkFromStorage(id LinkID, selfUID keybase1.UID, g *GlobalContext) (*
 		// May as well recheck onload (maybe revisit this)
 		ret = NewChainLink(g, nil, id, jw)
 		if err = ret.Unpack(true, selfUID); err != nil {
-			ret = nil
+			return nil, err
 		}
 		ret.storedLocally = true
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -182,8 +182,12 @@ func (g *GlobalContext) Logout() error {
 	if g.Identify2Cache != nil {
 		g.Identify2Cache.Shutdown()
 	}
+	if g.CardCache != nil {
+		g.CardCache.Shutdown()
+	}
 	g.TrackCache = NewTrackCache()
 	g.Identify2Cache = NewIdentify2Cache(g.Env.GetUserCacheMaxAge())
+	g.CardCache = NewUserCardCache(g.Env.GetUserCacheMaxAge())
 
 	// get a clean LoginState:
 	g.createLoginStateLocked()

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -84,6 +84,8 @@ type GlobalContext struct {
 	GregorListener  GregorListener            // for alerting about clients connecting and registering UI protocols
 	OutOfDateInfo   keybase1.OutOfDateInfo    // Stores out of date messages we got from API server headers.
 
+	CardCache *UserCardCache // cache of keybase1.UserCard objects
+
 	// Can be overloaded by tests to get an improvement in performance
 	NewTriplesec func(pw []byte, salt []byte) (Triplesec, error)
 }
@@ -279,9 +281,12 @@ func (g *GlobalContext) ConfigureCaches() error {
 	g.Resolver.EnableCaching()
 	g.TrackCache = NewTrackCache()
 	g.Identify2Cache = NewIdentify2Cache(g.Env.GetUserCacheMaxAge())
+	g.Log.Debug("Created Identify2Cache, max age: %s", g.Env.GetUserCacheMaxAge())
 	g.ProofCache = NewProofCache(g, g.Env.GetProofCacheSize())
 	g.LinkCache = NewLinkCache(g.Env.GetLinkCacheSize(), g.Env.GetLinkCacheCleanDur())
 	g.Log.Debug("Created LinkCache, max size: %d, clean dur: %s", g.Env.GetLinkCacheSize(), g.Env.GetLinkCacheCleanDur())
+	g.CardCache = NewUserCardCache(g.Env.GetUserCacheMaxAge())
+	g.Log.Debug("Created CardCache, max age: %s", g.Env.GetUserCacheMaxAge())
 
 	// We consider the local DB as a cache; it's caching our
 	// fetches from the server after all (and also our cryptographic
@@ -346,6 +351,9 @@ func (g *GlobalContext) Shutdown() error {
 		}
 		if g.LinkCache != nil {
 			g.LinkCache.Shutdown()
+		}
+		if g.CardCache != nil {
+			g.CardCache.Shutdown()
 		}
 		if g.Resolver != nil {
 			g.Resolver.Shutdown()

--- a/go/libkb/usercard_cache.go
+++ b/go/libkb/usercard_cache.go
@@ -1,0 +1,52 @@
+package libkb
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+
+	"stathat.com/c/ramcache"
+)
+
+// UserCardCache caches keybase1.UserCard objects in memory.
+type UserCardCache struct {
+	cache *ramcache.Ramcache
+}
+
+// NewUserCardCache creates a UserCardCache.  keybase1.UserCards will expire
+// after maxAge.
+func NewUserCardCache(maxAge time.Duration) *UserCardCache {
+	c := &UserCardCache{
+		cache: ramcache.New(),
+	}
+	c.cache.MaxAge = maxAge
+	c.cache.TTL = maxAge
+	return c
+}
+
+// Get looks for a keybase1.UserCard for uid.  It returns nil, nil if not found.
+func (c *UserCardCache) Get(uid keybase1.UID) (*keybase1.UserCard, error) {
+	v, err := c.cache.Get(uid.String())
+	if err != nil {
+		if err == ramcache.ErrNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	card, ok := v.(keybase1.UserCard)
+	if !ok {
+		return nil, fmt.Errorf("invalid type in cache: %T", v)
+	}
+	return &card, nil
+}
+
+// Set stores card in the UserCardCache.
+func (c *UserCardCache) Set(card *keybase1.UserCard) error {
+	return c.cache.Set(card.Uid.String(), *card)
+}
+
+// Shutdown stops any goroutines in the cache.
+func (c *UserCardCache) Shutdown() {
+	c.cache.Shutdown()
+}


### PR DESCRIPTION
The lowest hanging fruit was caching user/card lookups.

I abandoned everything else I tried as they had negligible performance gains:

1. using encoding/json instead of jsonw for sig chain
2. doing some loaduser operations concurrently
3. many other little things

While the above all seemed like good ideas, in the interest of stability, I think we should leave it all out as loaduser and sigchains are pretty sensitive operations.

This change does not speed up the initial (cold service) identify.  But subsequent identifies should be noticeably faster.  On average, I'm seeing `keybase id chris` taking 300ms.  Current production is around 700-800ms.