### PR TITLE
Some trivial cleanups for provisioning flow on mobile

### DIFF
--- a/shared/devices/device-page/index.render.native.js
+++ b/shared/devices/device-page/index.render.native.js
@@ -75,13 +75,14 @@ const Render = ({banner, name, type, deviceID, currentDevice, timeline,
 
   return (
     <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center'}}>
-      <BackButton style={{marginLeft: 13, marginTop: 13}} onClick={onBack} />
+      <BackButton style={{alignSelf: 'flex-start', marginLeft: 13, marginTop: 13}} onClick={onBack} />
       {(banner != null) && <Banner type={banner.type} desc={banner.desc} />}
       <Icon type={icon} style={{opacity: revokedAt ? 0.4 : 1, marginTop: 32}} />
       <Header name={name} isCurrent={currentDevice} isRevoked={revokedAt} />
       {!!timeline && <Timeline timeline={timeline} />}
       {!revokedAt && <Button type='Danger' style={{marginTop: 15}} label={`Revoke this ${revokeName}`} onClick={() => showRemoveDevicePage(device)} />}
-    </Box>)
+    </Box>
+  )
 }
 
 const stylesBanner = {

--- a/shared/devices/render.native.js
+++ b/shared/devices/render.native.js
@@ -30,9 +30,6 @@ const DeviceRow = ({device, revoked, showRemoveDevicePage, showExistingDevicePag
           <Text style={textStyle} type='BodySemibold'>{device.name}</Text>
           {device.currentDevice && <Text type='BodySmall'>Current device</Text>}
         </Box>
-        <ClickableBox onClick={() => showRemoveDevicePage(device)}>
-          <Box>{!revoked && <Text style={{color: globalColors.red, paddingLeft: 16}} type='BodyPrimaryLink'>Revoke</Text>}</Box>
-        </ClickableBox>
       </Box>
     </ClickableBox>
   )

--- a/shared/login/register/passphrase/index.js
+++ b/shared/login/register/passphrase/index.js
@@ -6,8 +6,7 @@ import {openAccountResetPage} from '../../../actions/login'
 
 type State = {
   showTyping: boolean,
-  saveInKeychain: boolean,
-  passphrase: ?string
+  passphrase: ?string,
 }
 
 type Props = {
@@ -25,7 +24,7 @@ class Passphrase extends Component<void, Props, State> {
 
   constructor (props: Props) {
     super(props)
-    this.state = {showTyping: false, saveInKeychain: false, passphrase: null}
+    this.state = {showTyping: false, passphrase: null}
   }
 
   onChange (passphrase: string) {
@@ -36,7 +35,7 @@ class Passphrase extends Component<void, Props, State> {
     return <Render
       onBack={this.props.onBack}
       prompt={this.props.prompt}
-      username={this.props.prompt}
+      username={this.props.username}
       waitingForResponse={this.props.waitingForResponse}
       onForgotPassphrase={() => {
         this.props.onForgotPassphrase()
@@ -45,10 +44,8 @@ class Passphrase extends Component<void, Props, State> {
       passphrase={this.state.passphrase}
       onSubmit={() => this.props.onSubmit(this.state.passphrase || '')}
       onChange={p => this.onChange(p)}
-      saveInKeychain={this.state.saveInKeychain}
       showTyping={this.state.showTyping}
-      toggleShowTyping={showTyping => this.setState({showTyping})}
-      toggleSaveInKeychain={saveInKeychain => this.setState({saveInKeychain})} />
+      toggleShowTyping={showTyping => this.setState({showTyping})} />
   }
 }
 

--- a/shared/login/register/passphrase/index.render.js.flow
+++ b/shared/login/register/passphrase/index.render.js.flow
@@ -12,9 +12,7 @@ export type Props = {
   error?: ?string,
   username: ?string,
   showTyping: boolean,
-  saveInKeychain: boolean,
   toggleShowTyping: () => void,
-  toggleSaveInKeychain: () => void
 }
 
 export default class Passphrase extends Component<void, Props, void> { }

--- a/shared/login/register/passphrase/index.render.native.js
+++ b/shared/login/register/passphrase/index.render.native.js
@@ -3,12 +3,12 @@ import Container from '../../forms/container'
 import React, {Component} from 'react'
 import type {Props} from './index.render'
 import {Button, UserCard, Text, FormWithCheckbox} from '../../../common-adapters'
-import {globalColors} from '../../../styles'
+import {globalColors, globalMargins} from '../../../styles'
 import {specialStyles} from '../../../common-adapters/text'
 
 class Render extends Component<void, Props, void> {
   render () {
-    const {saveInKeychain, showTyping, toggleSaveInKeychain, toggleShowTyping} = this.props
+    const {showTyping, toggleShowTyping} = this.props
 
     return (
       <Container
@@ -29,7 +29,6 @@ class Render extends Component<void, Props, void> {
               errorText: this.props.error,
             }}
             checkboxesProps={[
-              {label: 'Save in keychain', checked: !!(saveInKeychain), onCheck: toggleSaveInKeychain},
               {label: 'Show typing', checked: !!(showTyping), onCheck: toggleShowTyping},
             ]} />
 
@@ -59,9 +58,9 @@ const stylesForgot = {
 const stylesCard = {
   alignItems: 'stretch',
 }
-
 const usernameStyle = {
   textAlign: 'center',
+  paddingBottom: globalMargins.small,
 }
 
 export default Render

--- a/shared/login/register/username-or-email/index.render.native.js
+++ b/shared/login/register/username-or-email/index.render.native.js
@@ -39,6 +39,7 @@ class Render extends Component<void, Props, State> {
             hintText='Username or email'
             floatingLabelText='Username or email'
             onChangeText={text => this.onChange(text)}
+            onEnterKeyDown={() => this.onSubmit()}
             value={this.state.usernameOrEmail}
           />
           <Button


### PR DESCRIPTION
@keybase/react-hackers 

Some small cleanups from while I was going through mobile provisioning:

- [x] Device page: Back button should be aligned left, not center
- [x] Remove "Revoke" hover from the main devices page on mobile, leave it on the per-device page instead
- [x] Remove "Save in Keychain" from the UI entirely, it's assumed true now.
- [x] Username prompt on login page should be just the username, not the full "Please enter the passphrase (minimum 12 characters).." string that the service sends.
- [x] Bring up "Continue" button on passphrase page
- [x] Enter key should submit form on "username or email" login page