### PR TITLE
integrate rate limits into chat local api CORE-3736

### DIFF
--- a/go/client/chat_cli_utils.go
+++ b/go/client/chat_cli_utils.go
@@ -66,7 +66,7 @@ func (r *conversationResolver) Resolve(ctx context.Context, g *libkb.GlobalConte
 		r.TlfName = string(cname)
 	}
 
-	conversations, err := chatClient.ResolveConversationLocal(ctx, chat1.ConversationInfoLocal{
+	rcres, err := chatClient.ResolveConversationLocal(ctx, chat1.ConversationInfoLocal{
 		TlfName:    r.TlfName,
 		TopicName:  r.TopicName,
 		TopicType:  r.TopicType,
@@ -76,6 +76,7 @@ func (r *conversationResolver) Resolve(ctx context.Context, g *libkb.GlobalConte
 		return nil, false, err
 	}
 
+	conversations := rcres.Convs
 	switch len(conversations) {
 	case 0:
 		return nil, false, nil
@@ -183,12 +184,12 @@ func (f messageFetcher) fetch(ctx context.Context, g *libkb.GlobalContext) (conv
 	g.UI.GetTerminalUI().Printf("fetching conversation %s ...\n", conversationInfo.TlfName)
 	f.selector.Conversations = append(f.selector.Conversations, conversationInfo.Id)
 
-	conversations, err = chatClient.GetMessagesLocal(ctx, f.selector)
+	gmres, err := chatClient.GetMessagesLocal(ctx, f.selector)
 	if err != nil {
 		return nil, fmt.Errorf("GetMessagesLocal error: %s", err)
 	}
 
-	return conversations, nil
+	return gmres.Msgs, nil
 }
 
 type inboxFetcher struct {

--- a/go/client/chat_test.go
+++ b/go/client/chat_test.go
@@ -20,13 +20,14 @@ const (
 type chatLocalMock struct {
 }
 
-func (c *chatLocalMock) GetInboxLocal(ctx context.Context, arg chat1.GetInboxLocalArg) (iview chat1.InboxView, err error) {
-	iview.Conversations = append(iview.Conversations, chat1.Conversation{
+func (c *chatLocalMock) GetInboxLocal(ctx context.Context, arg chat1.GetInboxLocalArg) (res chat1.GetInboxLocalRes, err error) {
+	res.Inbox.Conversations = append(res.Inbox.Conversations, chat1.Conversation{
 		Metadata: chat1.ConversationMetadata{
 			ConversationID: chatLocalMockConversationID,
 		},
 	})
-	return iview, nil
+
+	return res, nil
 }
 
 func (c *chatLocalMock) mockMessage(idSeed byte, msgType chat1.MessageType, body chat1.MessageBody) chat1.Message {
@@ -54,34 +55,34 @@ func (c *chatLocalMock) mockMessage(idSeed byte, msgType chat1.MessageType, body
 	}
 }
 
-func (c *chatLocalMock) GetThreadLocal(ctx context.Context, arg chat1.GetThreadLocalArg) (tview chat1.ThreadView, err error) {
+func (c *chatLocalMock) GetThreadLocal(ctx context.Context, arg chat1.GetThreadLocalArg) (res chat1.GetThreadLocalRes, err error) {
 	if arg.ConversationID != chatLocalMockConversationID {
-		return tview, errors.New("unexpected ConversationID")
+		return res, errors.New("unexpected ConversationID")
 	}
 
 	body := chat1.NewMessageBodyWithText(chat1.MessageText{
 		Body: "O_O blah blah blah this is a really long line and I don't know what I'm talking about hahahahaha OK long enough",
 	})
 	msg := c.mockMessage(2, chat1.MessageType_TEXT, body)
-	tview.Messages = append(tview.Messages, msg)
+	res.Thread.Messages = append(res.Thread.Messages, msg)
 
 	body = chat1.NewMessageBodyWithText(chat1.MessageText{
 		Body: "Not much; just drinking.",
 	})
 	msg = c.mockMessage(3, chat1.MessageType_TEXT, body)
-	tview.Messages = append(tview.Messages, msg)
+	res.Thread.Messages = append(res.Thread.Messages, msg)
 
 	body = chat1.NewMessageBodyWithText(chat1.MessageText{
 		Body: "Hey what's up!",
 	})
 	msg = c.mockMessage(4, chat1.MessageType_TEXT, body)
-	tview.Messages = append(tview.Messages, msg)
+	res.Thread.Messages = append(res.Thread.Messages, msg)
 
-	return tview, nil
+	return res, nil
 }
 
-func (c *chatLocalMock) PostLocal(ctx context.Context, arg chat1.PostLocalArg) error {
-	return errors.New("PostLocal not implemented")
+func (c *chatLocalMock) PostLocal(ctx context.Context, arg chat1.PostLocalArg) (chat1.PostLocalRes, error) {
+	return chat1.PostLocalRes{}, errors.New("PostLocal not implemented")
 }
 
 func (c *chatLocalMock) CompleteAndCanonicalizeTlfName(ctx context.Context, tlfName string) (res keybase1.CanonicalTlfName, err error) {
@@ -89,26 +90,28 @@ func (c *chatLocalMock) CompleteAndCanonicalizeTlfName(ctx context.Context, tlfN
 	return keybase1.CanonicalTlfName(tlfName), nil
 }
 
-func (c *chatLocalMock) ResolveConversationLocal(ctx context.Context, arg chat1.ConversationInfoLocal) (conversations []chat1.ConversationInfoLocal, err error) {
-	conversations = append(conversations, chat1.ConversationInfoLocal{
+func (c *chatLocalMock) ResolveConversationLocal(ctx context.Context, arg chat1.ConversationInfoLocal) (res chat1.ResolveConversationLocalRes, err error) {
+	res.Convs = append(res.Convs, chat1.ConversationInfoLocal{
 		TlfName:   "morty,rick,songgao",
 		TopicName: "random",
 		TopicType: chat1.TopicType_CHAT,
 		Id:        chatLocalMockConversationID,
 	})
-	return conversations, nil
+	return res, nil
 }
 
 func (c *chatLocalMock) GetInboxSummaryLocal(ctx context.Context, arg chat1.GetInboxSummaryLocalArg) (res chat1.GetInboxSummaryLocalRes, err error) {
-	res.Conversations, err = c.GetMessagesLocal(ctx, chat1.MessageSelector{})
+	gmres, err := c.GetMessagesLocal(ctx, chat1.MessageSelector{})
 	if err != nil {
 		return res, err
 	}
+	res.Conversations = gmres.Msgs
 
-	res.More, err = c.GetMessagesLocal(ctx, chat1.MessageSelector{})
+	gmres, err = c.GetMessagesLocal(ctx, chat1.MessageSelector{})
 	if err != nil {
 		return res, err
 	}
+	res.More = gmres.Msgs
 	res.More[0].Info.TlfName = "morty,songgao"
 	res.More[0].Info.Id++
 	res.More[0].Messages[0].ServerHeader.Ctime -= 1000 * 3600 * 24 * 5
@@ -118,21 +121,22 @@ func (c *chatLocalMock) GetInboxSummaryLocal(ctx context.Context, arg chat1.GetI
 	return res, nil
 }
 
-func (c *chatLocalMock) UpdateTopicNameLocal(ctx context.Context, arg chat1.UpdateTopicNameLocalArg) (err error) {
-	return errors.New("UpdateTopicNameLocal not implemented")
+func (c *chatLocalMock) UpdateTopicNameLocal(ctx context.Context, arg chat1.UpdateTopicNameLocalArg) (res chat1.UpdateTopicNameLocalRes, err error) {
+	return res, errors.New("UpdateTopicNameLocal not implemented")
 }
 
-func (c *chatLocalMock) GetMessagesLocal(ctx context.Context, arg chat1.MessageSelector) (messages []chat1.ConversationLocal, err error) {
-	tview, err := c.GetThreadLocal(ctx, chat1.GetThreadLocalArg{
+func (c *chatLocalMock) GetMessagesLocal(ctx context.Context, arg chat1.MessageSelector) (res chat1.GetMessagesLocalRes, err error) {
+	tvres, err := c.GetThreadLocal(ctx, chat1.GetThreadLocalArg{
 		ConversationID: chatLocalMockConversationID,
 	})
 	if err != nil {
-		return nil, err
+		return chat1.GetMessagesLocalRes{}, err
 	}
+	tview := tvres.Thread
 	tview.Messages[0].Info = &chat1.MessageInfoLocal{IsNew: true, SenderUsername: "songgao", SenderDeviceName: "MacBook"}
 	tview.Messages[1].Info = &chat1.MessageInfoLocal{IsNew: true, SenderUsername: "rick", SenderDeviceName: "bottle-opener"}
 	tview.Messages[2].Info = &chat1.MessageInfoLocal{IsNew: false, SenderUsername: "morty", SenderDeviceName: "toothbrush"}
-	return []chat1.ConversationLocal{
+	res.Msgs = []chat1.ConversationLocal{
 		chat1.ConversationLocal{
 			Info: &chat1.ConversationInfoLocal{
 				Id:        chatLocalMockConversationID,
@@ -142,11 +146,12 @@ func (c *chatLocalMock) GetMessagesLocal(ctx context.Context, arg chat1.MessageS
 			},
 			Messages: tview.Messages,
 		},
-	}, nil
+	}
+	return res, nil
 }
 
-func (c *chatLocalMock) NewConversationLocal(ctx context.Context, cID chat1.ConversationInfoLocal) (id chat1.ConversationInfoLocal, err error) {
-	return id, errors.New("NewConversationLocal not implemented")
+func (c *chatLocalMock) NewConversationLocal(ctx context.Context, cID chat1.ConversationInfoLocal) (res chat1.NewConversationLocalRes, err error) {
+	return res, errors.New("NewConversationLocal not implemented")
 }
 
 func TestCliList(t *testing.T) {

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -69,7 +69,7 @@ func (c *cmdChatSend) Run() (err error) {
 	}
 
 	if resolved == nil {
-		conversationInfo, err = chatClient.NewConversationLocal(ctx, chat1.ConversationInfoLocal{
+		ncres, err := chatClient.NewConversationLocal(ctx, chat1.ConversationInfoLocal{
 			TlfName:   c.resolver.TlfName,
 			TopicName: c.resolver.TopicName,
 			TopicType: c.resolver.TopicType,
@@ -77,6 +77,7 @@ func (c *cmdChatSend) Run() (err error) {
 		if err != nil {
 			return fmt.Errorf("creating conversation error: %v\n", err)
 		}
+		conversationInfo = ncres.Conv
 	} else {
 		conversationInfo = *resolved
 	}
@@ -109,7 +110,7 @@ func (c *cmdChatSend) Run() (err error) {
 
 	args.MessagePlaintext = chat1.NewMessagePlaintextWithV1(msgV1)
 
-	if err = chatClient.PostLocal(ctx, args); err != nil {
+	if _, err = chatClient.PostLocal(ctx, args); err != nil {
 		return err
 	}
 
@@ -121,7 +122,7 @@ func (c *cmdChatSend) Run() (err error) {
 		msgV1.ClientHeader.Prev = nil // TODO
 		msgV1.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{ConversationTitle: c.setTopicName})
 		args.MessagePlaintext = chat1.NewMessagePlaintextWithV1(msgV1)
-		if err := chatClient.PostLocal(ctx, args); err != nil {
+		if _, err := chatClient.PostLocal(ctx, args); err != nil {
 			return err
 		}
 	}

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -74,9 +74,10 @@ type Pagination struct {
 }
 
 type RateLimit struct {
-	CallsRemaining int `codec:"callsRemaining" json:"callsRemaining"`
-	WindowReset    int `codec:"windowReset" json:"windowReset"`
-	MaxCalls       int `codec:"maxCalls" json:"maxCalls"`
+	Name           string `codec:"name" json:"name"`
+	CallsRemaining int    `codec:"callsRemaining" json:"callsRemaining"`
+	WindowReset    int    `codec:"windowReset" json:"windowReset"`
+	MaxCalls       int    `codec:"maxCalls" json:"maxCalls"`
 }
 
 type TLFVisibility int

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -358,10 +358,44 @@ type ConversationLocal struct {
 	Messages []Message              `codec:"messages" json:"messages"`
 }
 
+type GetInboxLocalRes struct {
+	Inbox      InboxView   `codec:"inbox" json:"inbox"`
+	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
+}
+
+type GetThreadLocalRes struct {
+	Thread     ThreadView  `codec:"thread" json:"thread"`
+	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
+}
+
+type PostLocalRes struct {
+	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
+}
+
+type ResolveConversationLocalRes struct {
+	Convs      []ConversationInfoLocal `codec:"convs" json:"convs"`
+	RateLimits []RateLimit             `codec:"rateLimits" json:"rateLimits"`
+}
+
+type NewConversationLocalRes struct {
+	Conv       ConversationInfoLocal `codec:"conv" json:"conv"`
+	RateLimits []RateLimit           `codec:"rateLimits" json:"rateLimits"`
+}
+
+type UpdateTopicNameLocalRes struct {
+	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
+}
+
+type GetMessagesLocalRes struct {
+	Msgs       []ConversationLocal `codec:"msgs" json:"msgs"`
+	RateLimits []RateLimit         `codec:"rateLimits" json:"rateLimits"`
+}
+
 type GetInboxSummaryLocalRes struct {
 	Conversations []ConversationLocal `codec:"conversations" json:"conversations"`
 	More          []ConversationLocal `codec:"more" json:"more"`
 	MoreTotal     int                 `codec:"moreTotal" json:"moreTotal"`
+	RateLimits    []RateLimit         `codec:"rateLimits" json:"rateLimits"`
 }
 
 type GetInboxLocalArg struct {
@@ -406,13 +440,13 @@ type GetInboxSummaryLocalArg struct {
 }
 
 type LocalInterface interface {
-	GetInboxLocal(context.Context, GetInboxLocalArg) (InboxView, error)
-	GetThreadLocal(context.Context, GetThreadLocalArg) (ThreadView, error)
-	PostLocal(context.Context, PostLocalArg) error
-	ResolveConversationLocal(context.Context, ConversationInfoLocal) ([]ConversationInfoLocal, error)
-	NewConversationLocal(context.Context, ConversationInfoLocal) (ConversationInfoLocal, error)
-	UpdateTopicNameLocal(context.Context, UpdateTopicNameLocalArg) error
-	GetMessagesLocal(context.Context, MessageSelector) ([]ConversationLocal, error)
+	GetInboxLocal(context.Context, GetInboxLocalArg) (GetInboxLocalRes, error)
+	GetThreadLocal(context.Context, GetThreadLocalArg) (GetThreadLocalRes, error)
+	PostLocal(context.Context, PostLocalArg) (PostLocalRes, error)
+	ResolveConversationLocal(context.Context, ConversationInfoLocal) (ResolveConversationLocalRes, error)
+	NewConversationLocal(context.Context, ConversationInfoLocal) (NewConversationLocalRes, error)
+	UpdateTopicNameLocal(context.Context, UpdateTopicNameLocalArg) (UpdateTopicNameLocalRes, error)
+	GetMessagesLocal(context.Context, MessageSelector) (GetMessagesLocalRes, error)
 	GetInboxSummaryLocal(context.Context, GetInboxSummaryLocalArg) (GetInboxSummaryLocalRes, error)
 }
 
@@ -463,7 +497,7 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]PostLocalArg)(nil), args)
 						return
 					}
-					err = i.PostLocal(ctx, (*typedArgs)[0])
+					ret, err = i.PostLocal(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -511,7 +545,7 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]UpdateTopicNameLocalArg)(nil), args)
 						return
 					}
-					err = i.UpdateTopicNameLocal(ctx, (*typedArgs)[0])
+					ret, err = i.UpdateTopicNameLocal(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -556,39 +590,39 @@ type LocalClient struct {
 	Cli rpc.GenericClient
 }
 
-func (c LocalClient) GetInboxLocal(ctx context.Context, __arg GetInboxLocalArg) (res InboxView, err error) {
+func (c LocalClient) GetInboxLocal(ctx context.Context, __arg GetInboxLocalArg) (res GetInboxLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.getInboxLocal", []interface{}{__arg}, &res)
 	return
 }
 
-func (c LocalClient) GetThreadLocal(ctx context.Context, __arg GetThreadLocalArg) (res ThreadView, err error) {
+func (c LocalClient) GetThreadLocal(ctx context.Context, __arg GetThreadLocalArg) (res GetThreadLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.getThreadLocal", []interface{}{__arg}, &res)
 	return
 }
 
-func (c LocalClient) PostLocal(ctx context.Context, __arg PostLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postLocal", []interface{}{__arg}, nil)
+func (c LocalClient) PostLocal(ctx context.Context, __arg PostLocalArg) (res PostLocalRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.postLocal", []interface{}{__arg}, &res)
 	return
 }
 
-func (c LocalClient) ResolveConversationLocal(ctx context.Context, conversation ConversationInfoLocal) (res []ConversationInfoLocal, err error) {
+func (c LocalClient) ResolveConversationLocal(ctx context.Context, conversation ConversationInfoLocal) (res ResolveConversationLocalRes, err error) {
 	__arg := ResolveConversationLocalArg{Conversation: conversation}
 	err = c.Cli.Call(ctx, "chat.1.local.resolveConversationLocal", []interface{}{__arg}, &res)
 	return
 }
 
-func (c LocalClient) NewConversationLocal(ctx context.Context, conversation ConversationInfoLocal) (res ConversationInfoLocal, err error) {
+func (c LocalClient) NewConversationLocal(ctx context.Context, conversation ConversationInfoLocal) (res NewConversationLocalRes, err error) {
 	__arg := NewConversationLocalArg{Conversation: conversation}
 	err = c.Cli.Call(ctx, "chat.1.local.newConversationLocal", []interface{}{__arg}, &res)
 	return
 }
 
-func (c LocalClient) UpdateTopicNameLocal(ctx context.Context, __arg UpdateTopicNameLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.updateTopicNameLocal", []interface{}{__arg}, nil)
+func (c LocalClient) UpdateTopicNameLocal(ctx context.Context, __arg UpdateTopicNameLocalArg) (res UpdateTopicNameLocalRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.updateTopicNameLocal", []interface{}{__arg}, &res)
 	return
 }
 
-func (c LocalClient) GetMessagesLocal(ctx context.Context, selector MessageSelector) (res []ConversationLocal, err error) {
+func (c LocalClient) GetMessagesLocal(ctx context.Context, selector MessageSelector) (res GetMessagesLocalRes, err error) {
 	__arg := GetMessagesLocalArg{Selector: selector}
 	err = c.Cli.Call(ctx, "chat.1.local.getMessagesLocal", []interface{}{__arg}, &res)
 	return

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -38,16 +38,16 @@ func makeChatTestContext(t *testing.T, name string) (ctc chatTestContext) {
 	return ctc
 }
 
-func mustCreateConversationForTest(t *testing.T, ctc chatTestContext, topicType chat1.TopicType, others ...string) (created chat1.ConversationInfoLocal) {
+func mustCreateConversationForTest(t *testing.T, ctc chatTestContext, topicType chat1.TopicType, others ...string) chat1.ConversationInfoLocal {
 	var err error
-	created, err = ctc.h.NewConversationLocal(context.Background(), chat1.ConversationInfoLocal{
+	ncres, err := ctc.h.NewConversationLocal(context.Background(), chat1.ConversationInfoLocal{
 		TlfName:   strings.Join(others, ",") + "," + ctc.world.me.Username,
 		TopicType: topicType,
 	})
 	if err != nil {
 		t.Fatalf("NewConversationLocal error: %v\n", err)
 	}
-	return created
+	return ncres.Conv
 }
 
 func TestNewConversationLocal(t *testing.T) {
@@ -92,12 +92,13 @@ func TestResolveConversationLocal(t *testing.T) {
 
 	created := mustCreateConversationForTest(t, ctc, chat1.TopicType_CHAT, "t_alice")
 
-	conversations, err := ctc.h.ResolveConversationLocal(context.Background(), chat1.ConversationInfoLocal{
+	rcres, err := ctc.h.ResolveConversationLocal(context.Background(), chat1.ConversationInfoLocal{
 		Id: created.Id,
 	})
 	if err != nil {
 		t.Fatalf("ResolveConversationLocal error: %v", err)
 	}
+	conversations := rcres.Convs
 	if len(conversations) != 1 {
 		t.Fatalf("unexpected response from ResolveConversationLocal. expected 1 items, got %d\n", len(conversations))
 	}
@@ -119,12 +120,13 @@ func TestResolveConversationLocalTlfName(t *testing.T) {
 
 	created := mustCreateConversationForTest(t, ctc, chat1.TopicType_CHAT, "t_alice")
 
-	conversations, err := ctc.h.ResolveConversationLocal(context.Background(), chat1.ConversationInfoLocal{
+	rcres, err := ctc.h.ResolveConversationLocal(context.Background(), chat1.ConversationInfoLocal{
 		TlfName: "t_alice" + "," + ctc.world.me.Username, // not canonical
 	})
 	if err != nil {
 		t.Fatalf("ResolveConversationLocal error: %v", err)
 	}
+	conversations := rcres.Convs
 	if len(conversations) != 1 {
 		t.Fatalf("unexpected response from ResolveConversationLocal. expected 1 item, got %d\n", len(conversations))
 	}
@@ -145,7 +147,7 @@ func mustPostLocalForTest(t *testing.T, ctc chatTestContext, conv chat1.Conversa
 	if err != nil {
 		t.Fatalf("msg.MessageType() error: %v\n", err)
 	}
-	err = ctc.h.PostLocal(context.Background(), chat1.PostLocalArg{
+	_, err = ctc.h.PostLocal(context.Background(), chat1.PostLocalArg{
 		ConversationID: conv.Id,
 		MessagePlaintext: chat1.NewMessagePlaintextWithV1(chat1.MessagePlaintextV1{
 			ClientHeader: chat1.MessageClientHeader{
@@ -188,12 +190,13 @@ func TestGetThreadLocal(t *testing.T) {
 	created := mustCreateConversationForTest(t, ctc, chat1.TopicType_CHAT, "t_alice")
 	mustPostLocalForTest(t, ctc, created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello!"}))
 
-	tv, err := ctc.h.GetThreadLocal(context.Background(), chat1.GetThreadLocalArg{
+	tvres, err := ctc.h.GetThreadLocal(context.Background(), chat1.GetThreadLocalArg{
 		ConversationID: created.Id,
 	})
 	if err != nil {
 		t.Fatalf("GetThreadLocal error: %v", err)
 	}
+	tv := tvres.Thread
 	if len(tv.Messages) != 2 {
 		t.Fatalf("unexpected response from GetThreadLocal . expected 2 items, got %d\n", len(tv.Messages))
 	}

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -34,6 +34,7 @@ protocol common {
   }
 
   record RateLimit {
+    string name;
     int callsRemaining; // Number of calls remaining for the given RPC in the current window
     int windowReset; // Amount of time (in seconds) until the window resets for this rate limit bucket
     int maxCalls; // Max amount of calls allowed in a window for the given RPC

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -139,16 +139,56 @@ protocol local {
     array<Message> messages;
   }
 
-  InboxView getInboxLocal(union { null, GetInboxQuery} query, union { null, Pagination } pagination);
-  ThreadView getThreadLocal(ConversationID conversationID, union { null, GetThreadQuery} query, union { null, Pagination } pagination);
-  void postLocal(ConversationID conversationID, MessagePlaintext messagePlaintext);
+  record GetInboxLocalRes {
+    InboxView inbox;
+    array<RateLimit> rateLimits;
+  }
+
+  record GetThreadLocalRes {
+    ThreadView thread;
+    array<RateLimit> rateLimits;
+  }
+
+  record PostLocalRes {
+    array<RateLimit> rateLimits;
+  }
+
+  record ResolveConversationLocalRes {
+    array<ConversationInfoLocal> convs;
+    array<RateLimit> rateLimits;
+  }
+
+  record NewConversationLocalRes {
+    ConversationInfoLocal conv;
+    array<RateLimit> rateLimits;
+  }
+
+  record UpdateTopicNameLocalRes {
+    array<RateLimit> rateLimits;
+  }
+
+  record GetMessagesLocalRes {
+    array<ConversationLocal> msgs;
+    array<RateLimit> rateLimits;
+  }
+
+  record GetInboxSummaryLocalRes {
+    array<ConversationLocal> conversations;
+    array<ConversationLocal> more;
+    int moreTotal;
+    array<RateLimit> rateLimits;
+  }
+
+  GetInboxLocalRes getInboxLocal(union { null, GetInboxQuery} query, union { null, Pagination } pagination);
+  GetThreadLocalRes getThreadLocal(ConversationID conversationID, union { null, GetThreadQuery} query, union { null, Pagination } pagination);
+  PostLocalRes postLocal(ConversationID conversationID, MessagePlaintext messagePlaintext);
 
   // resolveConversationLocal resolves information related to a conversation.
   // If conversation.id is given (non-zero), it is used to locate the
   // conversation. Otherwise, tlfName, topicName, and topicType, if any of
   // which are non zero value, are used to search for conversation. Any
   // matching conversation is added to a list and returned to the caller.
-  array<ConversationInfoLocal> resolveConversationLocal(ConversationInfoLocal conversation);
+  ResolveConversationLocalRes resolveConversationLocal(ConversationInfoLocal conversation);
 
   // newConversationLocal creates a new conversation. conversation.id field is
   // ignored. tlfName and topicType fields are required. topicName, if not
@@ -156,18 +196,12 @@ protocol local {
   // Calling newConversationLocal with a topic name is same to calling with an
   // empty topic name and following-up with an updateTopicName call. The
   // returned ConversationInfoLocal has all fields populated.
-  ConversationInfoLocal newConversationLocal(ConversationInfoLocal conversation);
+  NewConversationLocalRes newConversationLocal(ConversationInfoLocal conversation);
 
-  void updateTopicNameLocal(ConversationID conversationID, string newTopicName);
+  UpdateTopicNameLocalRes updateTopicNameLocal(ConversationID conversationID, string newTopicName);
 
   // selector.conversations is required
-  array<ConversationLocal> getMessagesLocal(MessageSelector selector);
-
-  record GetInboxSummaryLocalRes {
-    array<ConversationLocal> conversations;
-    array<ConversationLocal> more;
-    int moreTotal;
-  }
+  GetMessagesLocalRes getMessagesLocal(MessageSelector selector);
 
   // if since is given, limit is ignored
   GetInboxSummaryLocalRes getInboxSummaryLocal(TopicType topicType, string after, string before, int limit, TLFVisibility visibility);

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -110,11 +110,11 @@ export function localNewConversationLocalRpcPromise (request: $Exact<requestComm
   return new Promise((resolve, reject) => { localNewConversationLocalRpc({...request, param: request.param, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
-export function localPostLocalRpc (request: Exact<requestCommon & requestErrorCallback & {param: localPostLocalRpcParam}>) {
+export function localPostLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {param: localPostLocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'local.postLocal'})
 }
 
-export function localPostLocalRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localPostLocalRpcParam}>): Promise<any> {
+export function localPostLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {param: localPostLocalRpcParam}>): Promise<localPostLocalResult> {
   return new Promise((resolve, reject) => { localPostLocalRpc({...request, param: request.param, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
@@ -126,11 +126,11 @@ export function localResolveConversationLocalRpcPromise (request: $Exact<request
   return new Promise((resolve, reject) => { localResolveConversationLocalRpc({...request, param: request.param, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
-export function localUpdateTopicNameLocalRpc (request: Exact<requestCommon & requestErrorCallback & {param: localUpdateTopicNameLocalRpcParam}>) {
+export function localUpdateTopicNameLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localUpdateTopicNameLocalResult) => void} & {param: localUpdateTopicNameLocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'local.updateTopicNameLocal'})
 }
 
-export function localUpdateTopicNameLocalRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTopicNameLocalRpcParam}>): Promise<any> {
+export function localUpdateTopicNameLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localUpdateTopicNameLocalResult) => void} & {param: localUpdateTopicNameLocalRpcParam}>): Promise<localUpdateTopicNameLocalResult> {
   return new Promise((resolve, reject) => { localUpdateTopicNameLocalRpc({...request, param: request.param, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
@@ -270,6 +270,11 @@ export type GetInboxByTLFIDRemoteRes = {
   rateLimit?: ?RateLimit,
 }
 
+export type GetInboxLocalRes = {
+  inbox: InboxView,
+  rateLimits?: ?Array<RateLimit>,
+}
+
 export type GetInboxQuery = {
   convID?: ?ConversationID,
   topicType?: ?TopicType,
@@ -290,11 +295,22 @@ export type GetInboxSummaryLocalRes = {
   conversations?: ?Array<ConversationLocal>,
   more?: ?Array<ConversationLocal>,
   moreTotal: int,
+  rateLimits?: ?Array<RateLimit>,
+}
+
+export type GetMessagesLocalRes = {
+  msgs?: ?Array<ConversationLocal>,
+  rateLimits?: ?Array<RateLimit>,
 }
 
 export type GetMessagesRemoteRes = {
   msgs?: ?Array<MessageBoxed>,
   rateLimit?: ?RateLimit,
+}
+
+export type GetThreadLocalRes = {
+  thread: ThreadView,
+  rateLimits?: ?Array<RateLimit>,
 }
 
 export type GetThreadQuery = {
@@ -444,6 +460,11 @@ export type MessageType =
   | 5 // METADATA_5
   | 6 // TLFNAME_6
 
+export type NewConversationLocalRes = {
+  conv: ConversationInfoLocal,
+  rateLimits?: ?Array<RateLimit>,
+}
+
 export type NewConversationRemoteRes = {
   convID: ConversationID,
   rateLimit?: ?RateLimit,
@@ -462,15 +483,25 @@ export type Pagination = {
   last: boolean,
 }
 
+export type PostLocalRes = {
+  rateLimits?: ?Array<RateLimit>,
+}
+
 export type PostRemoteRes = {
   msgID: MessageID,
   rateLimit?: ?RateLimit,
 }
 
 export type RateLimit = {
+  name: string,
   callsRemaining: int,
   windowReset: int,
   maxCalls: int,
+}
+
+export type ResolveConversationLocalRes = {
+  convs?: ?Array<ConversationInfoLocal>,
+  rateLimits?: ?Array<RateLimit>,
 }
 
 export type SignatureInfo = {
@@ -504,6 +535,10 @@ export type TopicType =
     0 // NONE_0
   | 1 // CHAT_1
   | 2 // DEV_2
+
+export type UpdateTopicNameLocalRes = {
+  rateLimits?: ?Array<RateLimit>,
+}
 
 export type localGetInboxLocalRpcParam = Exact<{
   query?: ?GetInboxQuery,
@@ -585,17 +620,21 @@ export type remoteTlfFinalizeRpcParam = Exact<{
   tlfID: TLFID
 }>
 
-type localGetInboxLocalResult = InboxView
+type localGetInboxLocalResult = GetInboxLocalRes
 
 type localGetInboxSummaryLocalResult = GetInboxSummaryLocalRes
 
-type localGetMessagesLocalResult = ?Array<ConversationLocal>
+type localGetMessagesLocalResult = GetMessagesLocalRes
 
-type localGetThreadLocalResult = ThreadView
+type localGetThreadLocalResult = GetThreadLocalRes
 
-type localNewConversationLocalResult = ConversationInfoLocal
+type localNewConversationLocalResult = NewConversationLocalRes
 
-type localResolveConversationLocalResult = ?Array<ConversationInfoLocal>
+type localPostLocalResult = PostLocalRes
+
+type localResolveConversationLocalResult = ResolveConversationLocalRes
+
+type localUpdateTopicNameLocalResult = UpdateTopicNameLocalRes
 
 type remoteGetInboxRemoteResult = GetInboxRemoteRes
 

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -93,6 +93,10 @@
       "name": "RateLimit",
       "fields": [
         {
+          "type": "string",
+          "name": "name"
+        },
+        {
           "type": "int",
           "name": "callsRemaining"
         },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -405,6 +405,123 @@
     },
     {
       "type": "record",
+      "name": "GetInboxLocalRes",
+      "fields": [
+        {
+          "type": "InboxView",
+          "name": "inbox"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "GetThreadLocalRes",
+      "fields": [
+        {
+          "type": "ThreadView",
+          "name": "thread"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "PostLocalRes",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "ResolveConversationLocalRes",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "ConversationInfoLocal"
+          },
+          "name": "convs"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "NewConversationLocalRes",
+      "fields": [
+        {
+          "type": "ConversationInfoLocal",
+          "name": "conv"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "UpdateTopicNameLocalRes",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "GetMessagesLocalRes",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "ConversationLocal"
+          },
+          "name": "msgs"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "GetInboxSummaryLocalRes",
       "fields": [
         {
@@ -424,6 +541,13 @@
         {
           "type": "int",
           "name": "moreTotal"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
         }
       ]
     }
@@ -446,7 +570,7 @@
           ]
         }
       ],
-      "response": "InboxView"
+      "response": "GetInboxLocalRes"
     },
     "getThreadLocal": {
       "request": [
@@ -469,7 +593,7 @@
           ]
         }
       ],
-      "response": "ThreadView"
+      "response": "GetThreadLocalRes"
     },
     "postLocal": {
       "request": [
@@ -482,7 +606,7 @@
           "type": "MessagePlaintext"
         }
       ],
-      "response": null
+      "response": "PostLocalRes"
     },
     "resolveConversationLocal": {
       "request": [
@@ -491,10 +615,7 @@
           "type": "ConversationInfoLocal"
         }
       ],
-      "response": {
-        "type": "array",
-        "items": "ConversationInfoLocal"
-      }
+      "response": "ResolveConversationLocalRes"
     },
     "newConversationLocal": {
       "request": [
@@ -503,7 +624,7 @@
           "type": "ConversationInfoLocal"
         }
       ],
-      "response": "ConversationInfoLocal"
+      "response": "NewConversationLocalRes"
     },
     "updateTopicNameLocal": {
       "request": [
@@ -516,7 +637,7 @@
           "type": "string"
         }
       ],
-      "response": null
+      "response": "UpdateTopicNameLocalRes"
     },
     "getMessagesLocal": {
       "request": [
@@ -525,10 +646,7 @@
           "type": "MessageSelector"
         }
       ],
-      "response": {
-        "type": "array",
-        "items": "ConversationLocal"
-      }
+      "response": "GetMessagesLocalRes"
     },
     "getInboxSummaryLocal": {
       "request": [

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -110,11 +110,11 @@ export function localNewConversationLocalRpcPromise (request: $Exact<requestComm
   return new Promise((resolve, reject) => { localNewConversationLocalRpc({...request, param: request.param, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
-export function localPostLocalRpc (request: Exact<requestCommon & requestErrorCallback & {param: localPostLocalRpcParam}>) {
+export function localPostLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {param: localPostLocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'local.postLocal'})
 }
 
-export function localPostLocalRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localPostLocalRpcParam}>): Promise<any> {
+export function localPostLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {param: localPostLocalRpcParam}>): Promise<localPostLocalResult> {
   return new Promise((resolve, reject) => { localPostLocalRpc({...request, param: request.param, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
@@ -126,11 +126,11 @@ export function localResolveConversationLocalRpcPromise (request: $Exact<request
   return new Promise((resolve, reject) => { localResolveConversationLocalRpc({...request, param: request.param, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
-export function localUpdateTopicNameLocalRpc (request: Exact<requestCommon & requestErrorCallback & {param: localUpdateTopicNameLocalRpcParam}>) {
+export function localUpdateTopicNameLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localUpdateTopicNameLocalResult) => void} & {param: localUpdateTopicNameLocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'local.updateTopicNameLocal'})
 }
 
-export function localUpdateTopicNameLocalRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTopicNameLocalRpcParam}>): Promise<any> {
+export function localUpdateTopicNameLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localUpdateTopicNameLocalResult) => void} & {param: localUpdateTopicNameLocalRpcParam}>): Promise<localUpdateTopicNameLocalResult> {
   return new Promise((resolve, reject) => { localUpdateTopicNameLocalRpc({...request, param: request.param, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
@@ -270,6 +270,11 @@ export type GetInboxByTLFIDRemoteRes = {
   rateLimit?: ?RateLimit,
 }
 
+export type GetInboxLocalRes = {
+  inbox: InboxView,
+  rateLimits?: ?Array<RateLimit>,
+}
+
 export type GetInboxQuery = {
   convID?: ?ConversationID,
   topicType?: ?TopicType,
@@ -290,11 +295,22 @@ export type GetInboxSummaryLocalRes = {
   conversations?: ?Array<ConversationLocal>,
   more?: ?Array<ConversationLocal>,
   moreTotal: int,
+  rateLimits?: ?Array<RateLimit>,
+}
+
+export type GetMessagesLocalRes = {
+  msgs?: ?Array<ConversationLocal>,
+  rateLimits?: ?Array<RateLimit>,
 }
 
 export type GetMessagesRemoteRes = {
   msgs?: ?Array<MessageBoxed>,
   rateLimit?: ?RateLimit,
+}
+
+export type GetThreadLocalRes = {
+  thread: ThreadView,
+  rateLimits?: ?Array<RateLimit>,
 }
 
 export type GetThreadQuery = {
@@ -444,6 +460,11 @@ export type MessageType =
   | 5 // METADATA_5
   | 6 // TLFNAME_6
 
+export type NewConversationLocalRes = {
+  conv: ConversationInfoLocal,
+  rateLimits?: ?Array<RateLimit>,
+}
+
 export type NewConversationRemoteRes = {
   convID: ConversationID,
   rateLimit?: ?RateLimit,
@@ -462,15 +483,25 @@ export type Pagination = {
   last: boolean,
 }
 
+export type PostLocalRes = {
+  rateLimits?: ?Array<RateLimit>,
+}
+
 export type PostRemoteRes = {
   msgID: MessageID,
   rateLimit?: ?RateLimit,
 }
 
 export type RateLimit = {
+  name: string,
   callsRemaining: int,
   windowReset: int,
   maxCalls: int,
+}
+
+export type ResolveConversationLocalRes = {
+  convs?: ?Array<ConversationInfoLocal>,
+  rateLimits?: ?Array<RateLimit>,
 }
 
 export type SignatureInfo = {
@@ -504,6 +535,10 @@ export type TopicType =
     0 // NONE_0
   | 1 // CHAT_1
   | 2 // DEV_2
+
+export type UpdateTopicNameLocalRes = {
+  rateLimits?: ?Array<RateLimit>,
+}
 
 export type localGetInboxLocalRpcParam = Exact<{
   query?: ?GetInboxQuery,
@@ -585,17 +620,21 @@ export type remoteTlfFinalizeRpcParam = Exact<{
   tlfID: TLFID
 }>
 
-type localGetInboxLocalResult = InboxView
+type localGetInboxLocalResult = GetInboxLocalRes
 
 type localGetInboxSummaryLocalResult = GetInboxSummaryLocalRes
 
-type localGetMessagesLocalResult = ?Array<ConversationLocal>
+type localGetMessagesLocalResult = GetMessagesLocalRes
 
-type localGetThreadLocalResult = ThreadView
+type localGetThreadLocalResult = GetThreadLocalRes
 
-type localNewConversationLocalResult = ConversationInfoLocal
+type localNewConversationLocalResult = NewConversationLocalRes
 
-type localResolveConversationLocalResult = ?Array<ConversationInfoLocal>
+type localPostLocalResult = PostLocalRes
+
+type localResolveConversationLocalResult = ResolveConversationLocalRes
+
+type localUpdateTopicNameLocalResult = UpdateTopicNameLocalRes
 
 type remoteGetInboxRemoteResult = GetInboxRemoteRes
 


### PR DESCRIPTION
@patrickxb @songgao @maxtaco r?

The idea here is to return a list of all relevant server rate limits from all the local chat RPC endpoints. Since the server groups everything under the "chat" rate limit label right not, this is a little overkill, but should be future proofed against the server having custom per RPC rate limits. 

The idea would be for the JSON API to also return a list of rate limits per category. Let me know if you all think this is too confusing, but I wasn't sure what else to do. Like I said, in practice right now there will be only one returned, since the server isn't setting per call limits.