### PR TITLE
don't strip dots from usernames when creating facebook proofs

### DIFF
--- a/go/externals/proof_support_facebook.go
+++ b/go/externals/proof_support_facebook.go
@@ -156,7 +156,13 @@ func (t FacebookServiceType) NormalizeUsername(s string) (string, error) {
 func (t FacebookServiceType) NormalizeRemoteName(ctx libkb.ProofContext, s string) (string, error) {
 	// Allow a leading '@'.
 	s = strings.TrimPrefix(s, "@")
-	return t.NormalizeUsername(s)
+	if !facebookUsernameRegexp.MatchString(s) {
+		return "", libkb.NewBadUsernameError(s)
+	}
+	// This is the normalization function that gets called by the Prove engine.
+	// Avoid stripping dots, so that we can preserve them when the username is
+	// displayed.
+	return strings.ToLower(s), nil
 }
 
 func (t FacebookServiceType) GetPrompt() string {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -487,6 +487,11 @@ type ServiceType interface {
 	// NormalizeRemote normalizes the given remote username, which
 	// is usually but not always the same as the username. It also
 	// allows leaders like '@' and 'dns://'.
+	//
+	// In the case of Facebook, this version does the standard downcasing, but
+	// leaves the dots in (that NormalizeUsername above would strip out). This
+	// lets us keep the dots in the proof text, and display them on your
+	// profile page, even though we ignore them for proof checking.
 	NormalizeRemoteName(ctx ProofContext, name string) (string, error)
 
 	GetPrompt() string


### PR DESCRIPTION
r? @maxtaco 

@cjb and @malgorithms preferred to have dots preserved in Facebook usernames, since it's jarring to see your name rendered without them when you're used to seeing them. (Facebook is like GMail in that it lets you type whatever dots you want and still map to the same person.) Note that as with other proof types -- with the exception of HackerNews -- we still do case normalization. Does this sound reasonable to everyone?