### PR TITLE
make the facebook gating prod-only

### DIFF
--- a/go/client/cmd_prove.go
+++ b/go/client/cmd_prove.go
@@ -104,7 +104,7 @@ func (p *CmdProve) installOutputHook(ui *ProveUI) {
 
 // NewCmdProve makes a new prove command from the given CLI parameters.
 func NewCmdProve(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
-	serviceList := strings.Join(g.Services.ListProofCheckers(), ", ")
+	serviceList := strings.Join(g.Services.ListProofCheckers(g.GetRunMode()), ", ")
 	description := fmt.Sprintf("Supported services are: %s.", serviceList)
 	cmd := cli.Command{
 		Name:         "prove",

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -69,8 +69,8 @@ func newIdentify2WithUIDTester(g *libkb.GlobalContext) *Identify2WithUIDTester {
 	}
 }
 
-func (i *Identify2WithUIDTester) ListProofCheckers() []string { return nil }
-func (i *Identify2WithUIDTester) AllStringKeys() []string     { return nil }
+func (i *Identify2WithUIDTester) ListProofCheckers(mode libkb.RunMode) []string { return nil }
+func (i *Identify2WithUIDTester) AllStringKeys() []string                       { return nil }
 func (i *Identify2WithUIDTester) CheckProofText(text string, id keybase1.SigID, sig string) error {
 	return nil
 }

--- a/go/engine/prove.go
+++ b/go/engine/prove.go
@@ -317,9 +317,9 @@ func (p *Prove) Run(ctx *Context) (err error) {
 		return
 	}
 
-	// Disable creating Facebook proofs for now. (The proof type still exists,
-	// because we support checking them.) TODO: Delete me!
-	if p.st.GetTypeName() == "facebook" {
+	// Disable creating Facebook proofs in prod for now. (The proof type still
+	// exists, because we support checking them.) TODO: Delete me!
+	if p.G().GetRunMode() == libkb.ProductionRunMode && p.st.GetTypeName() == "facebook" {
 		return fmt.Errorf("Facebook proofs aren't ready yet, but they will be soon!")
 	}
 

--- a/go/externals/services.go
+++ b/go/externals/services.go
@@ -23,11 +23,11 @@ func (e externalServicesCollection) GetServiceType(s string) libkb.ServiceType {
 	return e[strings.ToLower(s)]
 }
 
-func (e externalServicesCollection) ListProofCheckers() []string {
+func (e externalServicesCollection) ListProofCheckers(mode libkb.RunMode) []string {
 	var ret []string
 	for k, v := range e {
-		// Don't display Facebook until it's supported. TODO: Delete me!
-		if k == "facebook" {
+		// Don't display Facebook in prod until it's supported. TODO: Delete me!
+		if k == "facebook" && mode == libkb.ProductionRunMode {
 			continue
 		}
 		if useDevelProofCheckers || !v.IsDevelOnly() {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -514,5 +514,5 @@ type ServiceType interface {
 
 type ExternalServicesCollector interface {
 	GetServiceType(n string) ServiceType
-	ListProofCheckers() []string
+	ListProofCheckers(mode RunMode) []string
 }


### PR DESCRIPTION
In gating only the proof creation codepaths, I forgot to restrict those gates to prod mode.

r? @mlsteele @maxtaco 