### PR TITLE
Give a sensible error on multiple gpg key provisioning

### DIFF
--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -564,5 +564,11 @@ function makeKex2IncomingMap (dispatch, getState, onBack: SimpleCB, onProvisione
     'keybase.1.provisionUi.DisplaySecretExchanged': (param, response) => {
       response.result()
     },
+    'keybase.1.gpgUi.selectKey': (param, response) => {
+      response.error({
+        code: ConstantsStatusCode.sckeynotfound,
+        desc: 'Not supported in GUI',
+      })
+    },
   }
 }

--- a/shared/login/register/error/index.render.desktop.js
+++ b/shared/login/register/error/index.render.desktop.js
@@ -55,6 +55,12 @@ const renderError = (error: RPCError) => {
             </p>
           </div>)
       }
+    case ConstantsStatusCode.sckeynotfound:
+      return (
+        <p>
+          <Text type='Body'>Your PGP keychain has multiple keys installed, and we're not sure which one to use to provision your account. Please run <Text type='Terminal'>keybase login</Text> on the command line to continue.</Text>
+        </p>
+      )
     case ConstantsStatusCode.scnotfound:
       return (
         <p>


### PR DESCRIPTION
@keybase/react-hackers 

Here's a tested patch to give a friendly error during provisioning when the Keybase account has multiple PGP keys registered and the service needs to know which to use.

![screenshot from 2016-09-29 15-21-01](https://cloud.githubusercontent.com/assets/21217/18968954/1b9c044a-8659-11e6-975c-47d7cbef4b90.png)
