### PR TITLE
Improve pvl

### DIFF
--- a/go/pvl/hardcoded.go
+++ b/go/pvl/hardcoded.go
@@ -109,10 +109,25 @@ var hardcodedPVLString = `
         },
         { "whitespace_normalize": { "from": "header", "into": "header_nw" } },
         {
-          "assert_regex_match": {
-            "error": ["TEXT_NOT_FOUND", "Proof text not found: '' != ''"],
+          "regex_capture": {
+            "error": [
+              "TEXT_NOT_FOUND",
+              "Proof text not found: 'Verifying myself: I am %{username_keybase} on Keybase.io. %{sig_id_medium}' != '%{header_nw}'"
+            ],
             "from": "header_nw",
-            "pattern": "^Verifying myself: I am %{username_keybase} on Keybase\\.io\\. %{sig_id_medium}$"
+            "into": ["username_from_header"],
+            "pattern": "^Verifying myself: I am (\\S+) on Keybase\\.io\\. %{sig_id_medium}$"
+          }
+        },
+        {
+          "assert_compare": {
+            "a": "username_from_header",
+            "b": "username_keybase",
+            "cmp": "cicmp",
+            "error": [
+              "TEXT_NOT_FOUND",
+              "Wrong keybase username in proof text '%{username_from_header}' != 'username_keybase'"
+            ]
           }
         }
       ]
@@ -121,7 +136,7 @@ var hardcodedPVLString = `
       [
         {
           "assert_regex_match": {
-            "error": ["BAD_API_URL", "Bad hint from server; didn't recognize API url: \"%{active_string}\""],
+            "error": ["BAD_API_URL", "Bad hint from server; didn't recognize API url: \"%{hint_url}\""],
             "from": "hint_url",
             "pattern": "^%{protocol}://%{hostname}/(?:\\.well-known/keybase\\.txt|keybase\\.txt)$"
           }

--- a/go/pvl/hardcoded.go
+++ b/go/pvl/hardcoded.go
@@ -29,7 +29,7 @@ var hardcodedPVLString = `
       [
         {
           "assert_regex_match": {
-            "error": ["CONTENT_FAILURE", "matching DNS entry not found"],
+            "error": ["NOT_FOUND", "matching DNS entry not found"],
             "from": "txt",
             "pattern": "^keybase-site-verification=%{sig_id_medium}$"
           }
@@ -61,6 +61,14 @@ var hardcodedPVLString = `
           }
         },
         { "fetch": { "from": "hint_url", "kind": "html" } },
+        {
+          "selector_css": {
+            "error": ["FAILED_PARSE", "Couldn't find facebook post %{hint_url}. Is it deleted or private?"],
+            "into": "unused",
+            "multi": true,
+            "selectors": ["#m_story_permalink_view"]
+          }
+        },
         {
           "selector_css": {
             "attr": "href",

--- a/go/pvl/helpers.go
+++ b/go/pvl/helpers.go
@@ -17,12 +17,8 @@ import (
 	jsonw "github.com/keybase/go-jsonw"
 )
 
-// Substitute vars for %{name} in the string.
-// Only substitutes whitelisted variables.
-// It is an error to refer to an unknown variable or undefined numbered group.
-// Match is an optional slice which is a regex match.
-// AllowActiveString makes active_string a valid variable.
-func substitute(template string, state scriptState) (string, libkb.ProofError) {
+// Substitute register values for %{name} in the string.
+func substitute(template string, state scriptState, regexEscape bool) (string, libkb.ProofError) {
 	var outerr libkb.ProofError
 	// Regex to find %{name} occurrences.
 	// Match broadly here so that even %{} is sent to the default case and reported as invalid.
@@ -36,7 +32,10 @@ func substitute(template string, state scriptState) (string, libkb.ProofError) {
 				"Invalid substitution: %v", err)
 			return ""
 		}
-		return regexp.QuoteMeta(value)
+		if regexEscape {
+			return regexp.QuoteMeta(value)
+		}
+		return value
 	}
 	res := re.ReplaceAllStringFunc(template, substituteOne)
 	if outerr != nil {

--- a/go/pvl/helpers.go
+++ b/go/pvl/helpers.go
@@ -18,7 +18,18 @@ import (
 )
 
 // Substitute register values for %{name} in the string.
-func substitute(template string, state scriptState, regexEscape bool) (string, libkb.ProofError) {
+// Regex-escape variable values
+func substituteReEscape(template string, state scriptState) (string, libkb.ProofError) {
+	return substituteInner(template, state, true)
+}
+
+// Substitute register values for %{name} in the string.
+// Does not escape register values
+func substituteExact(template string, state scriptState) (string, libkb.ProofError) {
+	return substituteInner(template, state, false)
+}
+
+func substituteInner(template string, state scriptState, regexEscape bool) (string, libkb.ProofError) {
 	var outerr libkb.ProofError
 	// Regex to find %{name} occurrences.
 	// Match broadly here so that even %{} is sent to the default case and reported as invalid.

--- a/go/pvl/helpers_test.go
+++ b/go/pvl/helpers_test.go
@@ -119,7 +119,13 @@ func TestSubstitute(t *testing.T) {
 	for i, test := range substituteTests {
 		state := sampleState()
 		state.Service = test.service
-		res, err := substitute(test.a, state, test.regexEscape)
+		var res string
+		var err error
+		if test.regexEscape {
+			res, err = substituteReEscape(test.a, state)
+		} else {
+			res, err = substituteExact(test.a, state)
+		}
 		if (err == nil) != test.shouldwork {
 			t.Fatalf("%v error mismatch: %v ; %v ; '%v'", i, test.shouldwork, err, res)
 		}

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -624,6 +624,8 @@ func stepAssertCompare(g proofContextExt, ins assertCompareT, state scriptState)
 
 	var same bool
 	switch ins.Cmp {
+	case "exact":
+		same = (a == b)
 	case "cicmp":
 		same = libkb.Cicmp(a, b)
 	case "stripdots-then-cicmp":

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -855,7 +855,7 @@ func stepSelectorCSS(g proofContextExt, ins selectorCSST, state scriptState) (sc
 }
 
 func stepFill(g proofContextExt, ins fillT, state scriptState) (scriptState, libkb.ProofError) {
-	s, err := substitute(ins.With, state, false)
+	s, err := substituteExact(ins.With, state)
 	if err != nil {
 		debugWithState(g, state, "Fill did not succeed:\n  %v\n  %v\n  %v",
 			ins.With, err, ins.Into)
@@ -983,7 +983,7 @@ func interpretRegex(g proofContextExt, state scriptState, rdesc regexDescriptor)
 	}
 
 	// Do variable interpolation.
-	prepattern, perr := substitute(rdesc.Template, state, true)
+	prepattern, perr := substituteReEscape(rdesc.Template, state)
 	if perr != nil {
 		return nil, perr
 	}
@@ -1018,7 +1018,7 @@ func replaceCustomError(g proofContextExt, state scriptState, spec *errorT, err1
 
 	if (spec.Status != err1.GetProofStatus()) || (spec.Description != err1.GetDesc()) {
 		newDesc := spec.Description
-		subbedDesc, subErr := substitute(spec.Description, state, false)
+		subbedDesc, subErr := substituteExact(spec.Description, state)
 		if subErr == nil {
 			newDesc = subbedDesc
 		}

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -443,7 +443,12 @@ func runDNS(g proofContextExt, userdomain string, scripts []scriptT, mknewstate 
 	if len(errs) == 0 {
 		return nil
 	}
-	return errs[0]
+	var descs []string
+	for _, err := range errs {
+		descs = append(descs, err.GetDesc())
+	}
+	// Use the code from the first error
+	return libkb.NewProofError(errs[0].GetProofStatus(), strings.Join(descs, "; "))
 }
 
 // Run each script on each TXT record of the domain.

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -106,6 +106,10 @@ func CheckProof(g1 libkb.ProofContext, pvlS string, service keybase1.ProofType, 
 	if perr != nil {
 		debug(g, "CheckProof failed: %v", perr)
 	}
+	if perr != nil && perr.GetProofStatus() == keybase1.ProofStatus_INVALID_PVL {
+		return libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
+			"Invalid proof verification instructions! Let us know at https://github.com/keybase/keybase-issues/new")
+	}
 	return perr
 }
 

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -855,7 +855,7 @@ func stepSelectorCSS(g proofContextExt, ins selectorCSST, state scriptState) (sc
 }
 
 func stepFill(g proofContextExt, ins fillT, state scriptState) (scriptState, libkb.ProofError) {
-	s, err := substitute(ins.With, state)
+	s, err := substitute(ins.With, state, false)
 	if err != nil {
 		debugWithState(g, state, "Fill did not succeed:\n  %v\n  %v\n  %v",
 			ins.With, err, ins.Into)
@@ -983,7 +983,7 @@ func interpretRegex(g proofContextExt, state scriptState, rdesc regexDescriptor)
 	}
 
 	// Do variable interpolation.
-	prepattern, perr := substitute(rdesc.Template, state)
+	prepattern, perr := substitute(rdesc.Template, state, true)
 	if perr != nil {
 		return nil, perr
 	}

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -1017,7 +1017,12 @@ func replaceCustomError(g proofContextExt, state scriptState, spec *errorT, err1
 	}
 
 	if (spec.Status != err1.GetProofStatus()) || (spec.Description != err1.GetDesc()) {
-		err2 := libkb.NewProofError(spec.Status, spec.Description)
+		newDesc := spec.Description
+		subbedDesc, subErr := substitute(spec.Description, state, false)
+		if subErr == nil {
+			newDesc = subbedDesc
+		}
+		err2 := libkb.NewProofError(spec.Status, newDesc)
 		debugWithState(g, state, "Replacing error with custom error")
 		debugWithStateError(g, state, err2)
 

--- a/go/pvl/interp_data_for_test.go
+++ b/go/pvl/interp_data_for_test.go
@@ -36,6 +36,15 @@ var infoBadProto = ProofInfo{
 	APIURL:         "https://rooter.example.com/proofs/kronkinator/5.htjsxt",
 }
 
+var infoBadSig = ProofInfo{
+	ArmoredSig:     sig1 + "w",
+	Username:       "kronk",
+	RemoteUsername: "kronkinator",
+	Hostname:       "kronk.example.com",
+	Protocol:       "http:",
+	APIURL:         "https://rooter.example.com/proofs/kronkinator/5.htjsxt",
+}
+
 var html1 = `
 <html>
 <head>

--- a/go/pvl/interp_test.go
+++ b/go/pvl/interp_test.go
@@ -966,8 +966,7 @@ var interpUnitTests = []interpUnitTest{
 		restext:    "fuzztroo",
 		shouldwork: false,
 		errstatus:  keybase1.ProofStatus_BAD_SIGNATURE,
-	},
-	{
+	}, {
 		name:      "bad-sig-path-in-domain-dns",
 		proofinfo: infoBadDomain,
 		prepvl: map[keybase1.ProofType]string{
@@ -982,10 +981,24 @@ var interpUnitTests = []interpUnitTest{
 		},
 		shouldwork: false,
 		errstatus:  keybase1.ProofStatus_BAD_SIGNATURE,
-	},
-	{
+	}, {
 		name:      "bad-sig-proto",
 		proofinfo: infoBadProto,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GENERIC_WEB_SITE: `[[
+{"fetch": {
+  "kind": "string",
+  "from": "hint_url",
+  "into": "tmp1" } }
+]]`},
+		service:    keybase1.ProofType_GENERIC_WEB_SITE,
+		restype:    libkb.XAPIResText,
+		restext:    "fuzztroo",
+		shouldwork: false,
+		errstatus:  keybase1.ProofStatus_BAD_SIGNATURE,
+	}, {
+		name:      "bad-sig-sig",
+		proofinfo: infoBadSig,
 		prepvl: map[keybase1.ProofType]string{
 			keybase1.ProofType_GENERIC_WEB_SITE: `[[
 {"fetch": {

--- a/go/pvl/interp_test.go
+++ b/go/pvl/interp_test.go
@@ -290,6 +290,42 @@ var interpUnitTests = []interpUnitTest{
 		restype:    libkb.XAPIResText,
 		restext:    "kr0nk",
 		shouldwork: false,
+	}, {
+		name:      "AssertCompare-exact-ok",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GENERIC_WEB_SITE: `[[
+{"fetch": {
+  "kind": "string",
+  "from": "hint_url",
+  "into": "tmp1" } },
+{"assert_compare": {
+  "cmp": "exact",
+  "a": "username_keybase",
+  "b": "tmp1" } }
+]]`},
+		service:    keybase1.ProofType_GENERIC_WEB_SITE,
+		restype:    libkb.XAPIResText,
+		restext:    "kronk",
+		shouldwork: true,
+	}, {
+		name:      "AssertCompare-exact-fail",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GENERIC_WEB_SITE: `[[
+{"fetch": {
+  "kind": "string",
+  "from": "hint_url",
+  "into": "tmp1" } },
+{"assert_compare": {
+  "cmp": "exact",
+  "a": "username_keybase",
+  "b": "tmp1" } }
+]]`},
+		service:    keybase1.ProofType_GENERIC_WEB_SITE,
+		restype:    libkb.XAPIResText,
+		restext:    "kroNk",
+		shouldwork: false,
 	},
 
 	// ## RegexCapture and WhitespaceNormalize tested together

--- a/go/pvl/interp_test.go
+++ b/go/pvl/interp_test.go
@@ -845,6 +845,26 @@ var interpUnitTests = []interpUnitTest{
 		restype:    libkb.XAPIResText,
 		restext:    "foozle",
 		shouldwork: true,
+	}, {
+		name:      "Fill-ok-noregexesc",
+		proofinfo: info1,
+		prepvl: map[keybase1.ProofType]string{
+			keybase1.ProofType_GITHUB: `[[
+{"fetch": {
+  "kind": "string",
+  "from": "hint_url",
+  "into": "tmp1" } },
+{"fill": {
+  "with": "%{tmp1}-%{username_keybase}",
+  "into": "tmp2" } },
+{"assert_regex_match": {
+  "pattern": "^\\(x\\)-kronk$",
+  "from": "tmp2" } }
+]]`},
+		service:    keybase1.ProofType_GITHUB,
+		restype:    libkb.XAPIResText,
+		restext:    "(x)",
+		shouldwork: true,
 	},
 
 	// # Tests for invalid PVL at the top level


### PR DESCRIPTION
Atop https://github.com/keybase/client/pull/4463 (I hope this separation makes it easier to review each)

### 1
DNS error messages are now the same as existing system, no more "Multiple errors"

### 2
If a client ever tries to run invalid pvl, that means we screwed up. So a user doesn't need to see a message like `Invalid register name 'oop@'`. Now all errors are debug logged (So I assume we get them in log sends?) and the users sees:

```
✖ "mlsteele" on coinbase failed: Invalid proof verification instructions! Let us know at https://github.com/keybase/keybase-issues/new (code=308)
```

### 3
Added `exact` comparison method to `assert_compare`

### 4
Don't regex-escape when substituting in the `fill` instruction

### 5
Add a test for a bad sig

### 6
Fix substitution in error messages

### 7
Better error for deleted facebook proofs, to match https://github.com/keybase/client/pull/4461

r? @maxtaco || @oconnor663 