### PR TITLE
fix two GPG 2.1.x problems

### DIFF
--- a/go/client/cmd_stress.go
+++ b/go/client/cmd_stress.go
@@ -312,3 +312,6 @@ func (c *CmdStress) GetPassphrase(_ context.Context, arg keybase1.GetPassphraseA
 func (c *CmdStress) Sign(_ context.Context, arg keybase1.SignArg) (string, error) {
 	return "", nil
 }
+func (c *CmdStress) GetTTY(_ context.Context) (string, error) {
+	return "", nil
+}

--- a/go/client/gpg_ui.go
+++ b/go/client/gpg_ui.go
@@ -81,6 +81,10 @@ func (g GPGUI) ConfirmDuplicateKeyChosen(_ context.Context, _ int) (bool, error)
 	return g.parent.PromptYesNo(PromptDescriptorGPGConfirmDuplicateKey, "You've already selected this public key for use on Keybase. Would you like to update it on Keybase?", libkb.PromptDefaultYes)
 }
 
+func (g GPGUI) GetTTY(_ context.Context) (string, error) {
+	return g.tty, nil
+}
+
 func (g GPGUI) Sign(_ context.Context, arg keybase1.SignArg) (string, error) {
 	fp, err := libkb.PGPFingerprintFromSlice(arg.Fingerprint)
 	if err != nil {

--- a/go/engine/gpg_import_key.go
+++ b/go/engine/gpg_import_key.go
@@ -180,7 +180,7 @@ func (e *GPGImportKeyEngine) Run(ctx *Context) (err error) {
 		return err
 	}
 
-	tty, err := ctx.GPGUI.GetTTY(context.TODO())
+	tty, err := ctx.GPGUI.GetTTY(ctx.NetContext)
 	if err != nil {
 		e.G().Log.Warning("error getting TTY for GPG: %s", err)
 		err = nil

--- a/go/engine/gpg_import_key.go
+++ b/go/engine/gpg_import_key.go
@@ -180,7 +180,12 @@ func (e *GPGImportKeyEngine) Run(ctx *Context) (err error) {
 		return err
 	}
 
-	bundle, err := gpg.ImportKey(true, *(selected.GetFingerprint()))
+	tty, err := ctx.GPGUI.GetTTY(context.TODO())
+	if err != nil {
+		e.G().Log.Warning("error getting TTY for GPG: %s", err)
+	}
+
+	bundle, err := gpg.ImportKey(true, *(selected.GetFingerprint()), tty)
 	if err != nil {
 		return fmt.Errorf("ImportKey error: %s", err)
 	}

--- a/go/engine/gpg_import_key.go
+++ b/go/engine/gpg_import_key.go
@@ -183,6 +183,7 @@ func (e *GPGImportKeyEngine) Run(ctx *Context) (err error) {
 	tty, err := ctx.GPGUI.GetTTY(context.TODO())
 	if err != nil {
 		e.G().Log.Warning("error getting TTY for GPG: %s", err)
+		err = nil
 	}
 
 	bundle, err := gpg.ImportKey(true, *(selected.GetFingerprint()), tty)

--- a/go/engine/gpg_test.go
+++ b/go/engine/gpg_test.go
@@ -60,6 +60,10 @@ func (g *gpgtestui) Sign(_ context.Context, arg keybase1.SignArg) (string, error
 	return cli.Sign(*fp, arg.Msg)
 }
 
+func (g *gpgtestui) GetTTY(_ context.Context) (string, error) {
+	return "", nil
+}
+
 type gpgTestUIBadSign struct {
 	gpgtestui
 }

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -779,7 +779,7 @@ func (e *loginProvision) gpgImportKey(ctx *Context, fp *libkb.PGPFingerprint) (l
 		return nil, err
 	}
 
-	tty, err := ctx.GPGUI.GetTTY(context.TODO())
+	tty, err := ctx.GPGUI.GetTTY(ctx.NetContext)
 	if err != nil {
 		e.G().Log.Warning("error getting TTY for GPG: %s", err)
 		err = nil

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -781,7 +781,8 @@ func (e *loginProvision) gpgImportKey(ctx *Context, fp *libkb.PGPFingerprint) (l
 
 	tty, err := ctx.GPGUI.GetTTY(context.TODO())
 	if err != nil {
-		return nil, err
+		e.G().Log.Warning("error getting TTY for GPG: %s", err)
+		err = nil
 	}
 
 	bundle, err := cli.ImportKey(true, *fp, tty)

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -34,7 +34,7 @@ type loginProvision struct {
 // gpgInterface defines the portions of gpg client that provision
 // needs.  This allows tests to stub out gpg client calls.
 type gpgInterface interface {
-	ImportKey(secret bool, fp libkb.PGPFingerprint) (*libkb.PGPKeyBundle, error)
+	ImportKey(secret bool, fp libkb.PGPFingerprint, tty string) (*libkb.PGPKeyBundle, error)
 	Index(secret bool, query string) (ki *libkb.GpgKeyIndex, w libkb.Warnings, err error)
 }
 
@@ -772,12 +772,19 @@ func (e *loginProvision) gpgSignKey(ctx *Context, fp *libkb.PGPFingerprint) (lib
 }
 
 func (e *loginProvision) gpgImportKey(ctx *Context, fp *libkb.PGPFingerprint) (libkb.GenericKey, error) {
+
 	// import it with gpg
 	cli, err := e.gpgClient()
 	if err != nil {
 		return nil, err
 	}
-	bundle, err := cli.ImportKey(true, *fp)
+
+	tty, err := ctx.GPGUI.GetTTY(context.TODO())
+	if err != nil {
+		return nil, err
+	}
+
+	bundle, err := cli.ImportKey(true, *fp, tty)
 	if err != nil {
 		return nil, err
 	}

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -2450,7 +2450,7 @@ func newGPGImportFailer(g *libkb.GlobalContext) *gpgImportFailer {
 	return &gpgImportFailer{g: g}
 }
 
-func (g *gpgImportFailer) ImportKey(secret bool, fp libkb.PGPFingerprint) (*libkb.PGPKeyBundle, error) {
+func (g *gpgImportFailer) ImportKey(secret bool, fp libkb.PGPFingerprint, tty string) (*libkb.PGPKeyBundle, error) {
 	return nil, errors.New("failed to import key")
 }
 

--- a/go/engine/pgp_pull_test.go
+++ b/go/engine/pgp_pull_test.go
@@ -44,7 +44,7 @@ func createGpgClient(tc libkb.TestContext) *libkb.GpgCLI {
 
 func assertKeysPresent(t *testing.T, gpgClient *libkb.GpgCLI, fingerprints []string) {
 	for _, fingerprint := range fingerprints {
-		fpObj, err := gpgClient.ImportKey(false /*secret*/, *libkb.PGPFingerprintFromHexNoError(fingerprint))
+		fpObj, err := gpgClient.ImportKey(false /*secret*/, *libkb.PGPFingerprintFromHexNoError(fingerprint), "")
 		if err != nil {
 			t.Fatal("Should have fingerprint in keyring:", fingerprint)
 		}
@@ -56,7 +56,7 @@ func assertKeysPresent(t *testing.T, gpgClient *libkb.GpgCLI, fingerprints []str
 
 func assertKeysMissing(t *testing.T, gpgClient *libkb.GpgCLI, fingerprints []string) {
 	for _, fingerprint := range fingerprints {
-		_, err := gpgClient.ImportKey(false /*secret*/, *libkb.PGPFingerprintFromHexNoError(fingerprint))
+		_, err := gpgClient.ImportKey(false /*secret*/, *libkb.PGPFingerprintFromHexNoError(fingerprint), "")
 		if err == nil {
 			t.Fatal("Should not already have fingerprint in keyring:", fingerprint)
 		}

--- a/go/engine/pgp_update.go
+++ b/go/engine/pgp_update.go
@@ -87,7 +87,7 @@ func (e *PGPUpdateEngine) Run(ctx *Context) error {
 			ctx.LogUI.Warning("Skipping update for key %s", fingerprint.String())
 			continue
 		}
-		bundle, err := gpgCLI.ImportKey(false /* secret */, fingerprint)
+		bundle, err := gpgCLI.ImportKey(false /* secret */, fingerprint, "")
 		if err != nil {
 			_, isNoKey := err.(libkb.NoKeyError)
 			if isNoKey {

--- a/go/kbtest/ui.go
+++ b/go/kbtest/ui.go
@@ -51,6 +51,10 @@ func (g *gpgtestui) Sign(_ context.Context, _ keybase1.SignArg) (string, error) 
 	return "", fmt.Errorf("not implemented")
 }
 
+func (g *gpgtestui) GetTTY(_ context.Context) (string, error) {
+	return "", nil
+}
+
 //
 // FakeIdentifyUI
 //

--- a/go/libkb/gpg_cli_test.go
+++ b/go/libkb/gpg_cli_test.go
@@ -46,7 +46,7 @@ func TestGPGImportSecret(t *testing.T) {
 	if len(fps) != 1 {
 		t.Fatalf("num fingerprints: %d, expected 1", len(fps))
 	}
-	bundle, err := cli.ImportKey(true, fps[0])
+	bundle, err := cli.ImportKey(true, fps[0], "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/libkb/gpg_index.go
+++ b/go/libkb/gpg_index.go
@@ -299,7 +299,7 @@ func (k *GpgPrimaryKey) AddLine(l *GpgIndexLine) (err error) {
 			err = k.AddFingerprint(l)
 		case "uid":
 			err = k.AddUID(l)
-		case "uat":
+		case "uat", "grp": // ignore
 		case "sub", "ssb":
 			err = k.AddSubkey(l)
 		default:

--- a/go/libkb/gpg_index_test.go
+++ b/go/libkb/gpg_index_test.go
@@ -18,6 +18,9 @@ func parse(t *testing.T, kr string) *GpgKeyIndex {
 
 	if !w.IsEmpty() {
 		t.Errorf("Warnings in parsing:")
+		for _, e := range w.Warnings() {
+			t.Errorf(" - %s", e)
+		}
 		return nil
 	}
 	return i
@@ -64,6 +67,19 @@ func TestYubikeyOrigSecretKeys(t *testing.T) {
 	keylist := index.Emails.Get("dain@yubico.com")
 	if keylist != nil {
 		t.Errorf("nil keylist was expected")
+	}
+}
+
+func TestGPGIndex2Dot1(t *testing.T) {
+	index := parse(t, gpg2dot1)
+	if index == nil {
+		t.Fatal("parsing failed")
+	}
+	keylist := index.Emails.Get("themax+test@gmail.com")
+	if keylist == nil {
+		t.Errorf("nil keylist was not expected")
+	} else if len(keylist) != 1 {
+		t.Errorf("expected one key for max")
 	}
 }
 
@@ -214,4 +230,19 @@ fpr:::::::::20EE325B86A81BCBD3E56798F04367096FBA95E8:
 uid:::::::CBDD6BD90F5A01A814C4E5A0E05F8D7DC7B3D070::Dain Nilsson <dain@yubico.com>:
 ssb::2048:1:BFE3A8E58DB04E9F:1389358404:::::::::D2760001240102010006042129000000:
 ssb::2048:1:3B557A2E4C844B75:1389358510:::::::::D2760001240102010006042129000000:
+`
+
+// GPG 2.1.15ish broke everything...
+const gpg2dot1 = `
+sec:u:256:22:586422EFB7394E3D:1439134482:::u:::scSC:::+::ed25519::
+fpr:::::::::CC79CFE4C04CA6A75A69D20C586422EFB7394E3D:
+grp:::::::::57A65E8BF2417FF87D122A62385AF262B73EA6FC:
+uid:u::::1439134482::2667AF1B2E54C3582718E837343DC8F09B81E3F5::Early Adopter (PW is abcd) <early@adopt.er>:::::::::
+sec:u:256:22:7B2E3F571BF26EB7:1475200495:::u:::scESC:::+::ed25519::
+fpr:::::::::C0045FBD76822E6BBB78C7707B2E3F571BF26EB7:
+grp:::::::::3D436BF15A556C1D9BF5D420AB5C44A4008C4894:
+uid:u::::1475200495::92725E39A37C33E515983C6B0D25E7320ABB8247::Max Test <themax+test@gmail.com>:::::::::
+ssb:u:256:18:A0E78D11A79FE1EF:1475200495::::::e:::+::cv25519:
+fpr:::::::::39DC5F5D9252DDA6F5BF660CA0E78D11A79FE1EF:
+grp:::::::::7872FB84783726E5B066CEF45D6DEC2F2364A2A5:
 `

--- a/go/protocol/keybase1/gpg_ui.go
+++ b/go/protocol/keybase1/gpg_ui.go
@@ -36,12 +36,16 @@ type SignArg struct {
 	Fingerprint []byte `codec:"fingerprint" json:"fingerprint"`
 }
 
+type GetTTYArg struct {
+}
+
 type GpgUiInterface interface {
 	WantToAddGPGKey(context.Context, int) (bool, error)
 	ConfirmDuplicateKeyChosen(context.Context, int) (bool, error)
 	SelectKeyAndPushOption(context.Context, SelectKeyAndPushOptionArg) (SelectKeyRes, error)
 	SelectKey(context.Context, SelectKeyArg) (string, error)
 	Sign(context.Context, SignArg) (string, error)
+	GetTTY(context.Context) (string, error)
 }
 
 func GpgUiProtocol(i GpgUiInterface) rpc.Protocol {
@@ -128,6 +132,17 @@ func GpgUiProtocol(i GpgUiInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"getTTY": {
+				MakeArg: func() interface{} {
+					ret := make([]GetTTYArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					ret, err = i.GetTTY(ctx)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -160,5 +175,10 @@ func (c GpgUiClient) SelectKey(ctx context.Context, __arg SelectKeyArg) (res str
 
 func (c GpgUiClient) Sign(ctx context.Context, __arg SignArg) (res string, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.gpgUi.sign", []interface{}{__arg}, &res)
+	return
+}
+
+func (c GpgUiClient) GetTTY(ctx context.Context) (res string, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.gpgUi.getTTY", []interface{}{GetTTYArg{}}, &res)
 	return
 }

--- a/go/service/gpg.go
+++ b/go/service/gpg.go
@@ -41,3 +41,6 @@ func (r *RemoteGPGUI) ConfirmDuplicateKeyChosen(ctx context.Context, _ int) (boo
 func (r *RemoteGPGUI) Sign(ctx context.Context, arg keybase1.SignArg) (string, error) {
 	return r.uicli.Sign(ctx, arg)
 }
+func (r *RemoteGPGUI) GetTTY(ctx context.Context) (string, error) {
+	return r.uicli.GetTTY(ctx)
+}

--- a/protocol/avdl/keybase1/gpg_ui.avdl
+++ b/protocol/avdl/keybase1/gpg_ui.avdl
@@ -14,4 +14,5 @@ protocol gpgUi {
   SelectKeyRes selectKeyAndPushOption(int sessionID, array<GPGKey> keys);
   string selectKey(int sessionID, array<GPGKey> keys);
   string sign(bytes msg, bytes fingerprint);
+  string getTTY();
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4094,6 +4094,8 @@ type fsListResult = ListResult
 
 type gpgUiConfirmDuplicateKeyChosenResult = boolean
 
+type gpgUiGetTTYResult = string
+
 type gpgUiSelectKeyAndPushOptionResult = SelectKeyRes
 
 type gpgUiSelectKeyResult = string
@@ -4475,6 +4477,13 @@ export type incomingCallMapType = Exact<{
     response: {
       error: RPCErrorHandler,
       result: (result: gpgUiSignResult) => void,
+    }
+  ) => void,
+  'keybase.1.gpgUi.getTTY'?: (
+    params: Exact<{}>,
+    response: {
+      error: RPCErrorHandler,
+      result: (result: gpgUiGetTTYResult) => void,
     }
   ) => void,
   'keybase.1.gregorUI.pushState'?: (

--- a/protocol/json/keybase1/gpg_ui.json
+++ b/protocol/json/keybase1/gpg_ui.json
@@ -89,6 +89,10 @@
         }
       ],
       "response": "string"
+    },
+    "getTTY": {
+      "request": [],
+      "response": "string"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4094,6 +4094,8 @@ type fsListResult = ListResult
 
 type gpgUiConfirmDuplicateKeyChosenResult = boolean
 
+type gpgUiGetTTYResult = string
+
 type gpgUiSelectKeyAndPushOptionResult = SelectKeyRes
 
 type gpgUiSelectKeyResult = string
@@ -4475,6 +4477,13 @@ export type incomingCallMapType = Exact<{
     response: {
       error: RPCErrorHandler,
       result: (result: gpgUiSignResult) => void,
+    }
+  ) => void,
+  'keybase.1.gpgUi.getTTY'?: (
+    params: Exact<{}>,
+    response: {
+      error: RPCErrorHandler,
+      result: (result: gpgUiGetTTYResult) => void,
     }
   ) => void,
   'keybase.1.gregorUI.pushState'?: (


### PR DESCRIPTION
- plumb through TTY from client back to service for PGP export
- ignore 'grp' parameter in `--with-colons` output