### PR TITLE
simple change for expiring track tokens

### DIFF
--- a/go/libkb/track_cache.go
+++ b/go/libkb/track_cache.go
@@ -20,8 +20,8 @@ func NewTrackCache() *TrackCache {
 	res := &TrackCache{
 		cache: ramcache.New(),
 	}
-	res.cache.TTL = 10 * time.Minute
-	res.cache.MaxAge = 10 * time.Minute
+	res.cache.TTL = 1 * time.Hour
+	res.cache.MaxAge = 1 * time.Hour
 	return res
 }
 


### PR DESCRIPTION
After an extensive discussion with @chrisnojima  and @malgorithms, we thought it might be worth it to fix this problem in electron, meaning: (1) kill tracker popups after ~10 minutes; and (2) refresh foreground identify windows after ~50 minutes.  The issue is that our earlier plan wouldn't solve all cases, so we'd still need to expose error case mitigation to electron. So probably makes sense to handle things in electron to begin with.