### PR TITLE
better error handling in getConversationInfo

### DIFF
--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -60,6 +60,35 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 
 	table := &flexibletable.Table{}
 	for i, conv := range v {
+
+		if conv.Error != nil {
+			table.Insert(flexibletable.Row{
+				flexibletable.Cell{
+					Frame:     [2]string{"[", "]"},
+					Alignment: flexibletable.Right,
+					Content:   flexibletable.SingleCell{Item: strconv.Itoa(i + 1)},
+				},
+				flexibletable.Cell{
+					Alignment: flexibletable.Center,
+					Content:   flexibletable.SingleCell{Item: ""},
+				},
+				flexibletable.Cell{
+					Alignment: flexibletable.Left,
+					Content:   flexibletable.SingleCell{Item: "???"},
+				},
+				flexibletable.Cell{
+					Frame:     [2]string{"[", "]"},
+					Alignment: flexibletable.Right,
+					Content:   flexibletable.SingleCell{Item: "???"},
+				},
+				flexibletable.Cell{
+					Alignment: flexibletable.Left,
+					Content:   flexibletable.SingleCell{Item: *conv.Error},
+				},
+			})
+			continue
+		}
+
 		unread := ""
 		if conv.Messages[0].Message != nil &&
 			conv.ReadUpTo < conv.Messages[0].Message.ServerHeader.MessageID {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -360,6 +360,7 @@ type ConversationInfoLocal struct {
 }
 
 type ConversationLocal struct {
+	Error    *string                    `codec:"error,omitempty" json:"error,omitempty"`
 	Info     *ConversationInfoLocal     `codec:"info,omitempty" json:"info,omitempty"`
 	Messages []MessageFromServerOrError `codec:"messages" json:"messages"`
 	ReadUpTo MessageID                  `codec:"readUpTo" json:"readUpTo"`

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -539,7 +539,7 @@ func (h *chatLocalHandler) getConversationInfo(ctx context.Context,
 	conversationInfo.TopicType = conversationRemote.Metadata.IdTriple.TopicType
 
 	if len(conversationRemote.MaxMsgs) == 0 {
-		return conversationInfo, maxMessages,
+		return chat1.ConversationInfoLocal{}, nil,
 			libkb.UnexpectedChatDataFromServer{Msg: "conversation has an empty MaxMsgs field"}
 	}
 
@@ -560,7 +560,7 @@ func (h *chatLocalHandler) getConversationInfo(ctx context.Context,
 
 		username, deviceName, err := h.getSenderInfoLocal(uimap, messagePlaintext)
 		if err != nil {
-			return conversationInfo, maxMessages, err
+			return chat1.ConversationInfoLocal{}, nil, err
 		}
 		maxMessages = append(maxMessages, chat1.MessageFromServerOrError{
 			Message: &chat1.MessageFromServer{
@@ -573,7 +573,7 @@ func (h *chatLocalHandler) getConversationInfo(ctx context.Context,
 
 		version, err := messagePlaintext.Version()
 		if err != nil {
-			return conversationInfo, maxMessages, err
+			return chat1.ConversationInfoLocal{}, nil, err
 		}
 		switch version {
 		case chat1.MessagePlaintextVersion_V1:
@@ -588,18 +588,18 @@ func (h *chatLocalHandler) getConversationInfo(ctx context.Context,
 			}
 			conversationInfo.Triple = messagePlaintext.V1().ClientHeader.Conv
 		default:
-			return conversationInfo, maxMessages, libkb.NewChatMessageVersionError(version)
+			return chat1.ConversationInfoLocal{}, nil, libkb.NewChatMessageVersionError(version)
 		}
 	}
 
 	if len(conversationInfo.TlfName) == 0 {
-		return conversationInfo, maxMessages,
+		return chat1.ConversationInfoLocal{}, nil,
 			fmt.Errorf("no valid message in the conversation: convID: %d", conversationRemote.Metadata.ConversationID)
 	}
 
 	// verify Conv matches ConversationIDTriple in MessageClientHeader
 	if !conversationRemote.Metadata.IdTriple.Eq(conversationInfo.Triple) {
-		return conversationInfo, maxMessages, errors.New("server header conversation triple does not match client header triple")
+		return chat1.ConversationInfoLocal{}, nil, errors.New("server header conversation triple does not match client header triple")
 	}
 
 	return conversationInfo, maxMessages, nil

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -551,7 +551,7 @@ func (h *chatLocalHandler) getConversationInfo(ctx context.Context,
 		messagePlaintext, err := h.boxer.unboxMessage(ctx, kf, b)
 		if err != nil {
 			errMsg := err.Error()
-			h.G().Log.Warning("getConversationInfo: failed to unbox message: convID: %d msgID: %d err: %s", conversationRemote.Metadata.ConversationID, b.ServerHeader.MessageID, errMsg)
+			h.G().Log.Warning("failed to unbox message: convID: %d msgID: %d err: %s", conversationRemote.Metadata.ConversationID, b.ServerHeader.MessageID, errMsg)
 			maxMessages = append(maxMessages, chat1.MessageFromServerOrError{
 				UnboxingError: &errMsg,
 			})

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -148,6 +148,7 @@ protocol local {
   }
 
   record ConversationLocal {
+    union { null, string } error;
     union { null, ConversationInfoLocal } info;
     array<MessageFromServerOrError> messages;
     MessageID readUpTo;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -234,6 +234,7 @@ export type ConversationInfoLocal = {
 }
 
 export type ConversationLocal = {
+  error?: ?string,
   info?: ?ConversationInfoLocal,
   messages?: ?Array<MessageFromServerOrError>,
   readUpTo: MessageID,

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -411,6 +411,13 @@
         {
           "type": [
             null,
+            "string"
+          ],
+          "name": "error"
+        },
+        {
+          "type": [
+            null,
             "ConversationInfoLocal"
           ],
           "name": "info"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -234,6 +234,7 @@ export type ConversationInfoLocal = {
 }
 
 export type ConversationLocal = {
+  error?: ?string,
   info?: ?ConversationInfoLocal,
   messages?: ?Array<MessageFromServerOrError>,
   readUpTo: MessageID,


### PR DESCRIPTION
@songgao r?

You get this display now:

```
[mike@lisa-keybase]-[~/go/src/github.com/keybase/client/go] (mike/errorcleanup)$ kb chat list
▶ WARNING Running in devel mode
▶ WARNING failed to unbox message: convID: 12385818184558444544 msgID: 2 err: error unboxing chat message: box.Open failure; ciphertext was corrupted or wrong key
▶ WARNING failed to unbox message: convID: 12385818184558444544 msgID: 1 err: error unboxing chat message: box.Open failure; ciphertext was corrupted or wrong key
▶ WARNING failed to unbox message: convID: 10916103195311276032 msgID: 3 err: error unboxing chat message: box.Open failure; ciphertext was corrupted or wrong key
▶ WARNING failed to unbox message: convID: 10916103195311276032 msgID: 1 err: error unboxing chat message: box.Open failure; ciphertext was corrupted or wrong key
▶ WARNING failed to unbox message: convID: 8237287940140040192 msgID: 2 err: error unboxing chat message: box.Open failure; ciphertext was corrupted or wrong key
▶ WARNING failed to unbox message: convID: 8237287940140040192 msgID: 1 err: error unboxing chat message: box.Open failure; ciphertext was corrupted or wrong key
▶ WARNING failed to unbox message: convID: 11058899962229489664 msgID: 2 err: error unboxing chat message: box.Open failure; ciphertext was corrupted or wrong key
▶ WARNING failed to unbox message: convID: 11058899962229489664 msgID: 1 err: error unboxing chat message: box.Open failure; ciphertext was corrupted or wrong key
▶ WARNING failed to unbox message: convID: 3984166482157240320 msgID: 4 err: error unboxing chat message: box.Open failure; ciphertext was corrupted or wrong key
▶ WARNING failed to unbox message: convID: 3984166482157240320 msgID: 1 err: error unboxing chat message: box.Open failure; ciphertext was corrupted or wrong key
[1]  ??? [???] no valid message in the conversation: convID: 10916103195311276032
[2]  ??? [???] no valid message in the conversation: convID: 3984166482157240320
[3]  ??? [???] no valid message in the conversation: convID: 12385818184558444544
[4]  ??? [???] no valid message in the conversation: convID: 11058899962229489664
[5]  ??? [???] no valid message in the conversation: convID: 8237287940140040192
```