### PR TITLE
visdiff: Work in a temp directory separate from the development directory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,7 +156,6 @@ if (env.CHANGE_TITLE && env.CHANGE_TITLE.contains('[ci-skip]')) {
                                                     sh "npm install"
                                                 }
                                                 sh "npm install ./visdiff"
-                                                sh "git rev-parse HEAD > ${env.BASEDIR}/visdiff_orig_revision"
                                                 try {
                                                     timeout(time: 10, unit: 'MINUTES') {
                                                         dir("desktop") {
@@ -166,7 +165,6 @@ if (env.CHANGE_TITLE && env.CHANGE_TITLE.contains('[ci-skip]')) {
                                                 } catch (e) {
                                                     helpers.slackMessage("#breaking-visdiff", "warning", "<@mgood>: visdiff failed: <${env.BUILD_URL}|${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME}>")
                                                 }
-                                                sh "git checkout \$(< ${env.BASEDIR}/visdiff_orig_revision)"
                                             }}}
                                         }
                                     }},

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,6 +149,7 @@ if (env.CHANGE_TITLE && env.CHANGE_TITLE.contains('[ci-skip]')) {
                                                     variable: 'VISDIFF_GH_TOKEN',
                                             ]]) {
                                             withEnv([
+                                                "VISDIFF_WORK_DIR=${env.BASEDIR}/visdiff",
                                                 "VISDIFF_PR_ID=${env.CHANGE_ID}",
                                             ]) {
                                                 dir("visdiff") {

--- a/desktop/npm-helper.js
+++ b/desktop/npm-helper.js
@@ -140,6 +140,15 @@ const commands = {
     shell: 'webpack --config webpack.config.visdiff.js && electron ./dist/render-visdiff.bundle.js',
     help: 'Render images of dumb components',
   },
+  'local-visdiff': {
+    env: {
+      VISDIFF_DRY_RUN: 1,
+      KEYBASE_JS_VENDOR_DIR: process.env['KEYBASE_JS_VENDOR_DIR'] || path.resolve('../../js-vendor-desktop'),
+    },
+    nodePathDesktop: true,
+    shell: 'npm install ../visdiff && keybase-visdiff',
+    help: 'Perform a local visdiff',
+  },
   'updated-fonts': {
     help: 'Update our font sizes automatically',
     code: updatedFonts,

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -21,6 +21,7 @@
     "setup-debug-main": "babel-node --presets es2015,stage-2 npm-helper.js setup-debug-main",
     "postinstall": "babel-node --presets es2015,stage-2 npm-helper.js postinstall",
     "render-screenshots": "babel-node --presets es2015,stage-2 npm-helper.js render-screenshots",
+    "local-visdiff": "babel-node --presets es2015,stage-2 npm-helper.js local-visdiff",
     "updated-fonts": "babel-node --presets es2015,stage-2 npm-helper.js updated-fonts",
     "wrap": "npm uninstall fsevents && npm prune && npm dedupe && npm shrinkwrap --dev",
     "shrinkwrap-audit": "babel-node --presets es2015,stage-2 npm-shrinkwrap-audit",

--- a/visdiff/src/index.js
+++ b/visdiff/src/index.js
@@ -84,6 +84,7 @@ function renderScreenshots (commitRange) {
 }
 
 function compareScreenshots (commitRange, diffDir, callback) {
+  console.log('Comparing screenshots...')
   const results = {}
 
   mkdirp.sync(`screenshots/${diffDir}`)
@@ -91,6 +92,7 @@ function compareScreenshots (commitRange, diffDir, callback) {
   const files0 = fs.readdirSync(`screenshots/${commitRange[0]}`)
   const files1 = fs.readdirSync(`screenshots/${commitRange[1]}`)
   const files = _.union(files0, files1)
+  const totalFiles = files.length
   function compareNext () {
     const filename = files.pop()
     if (!filename) {
@@ -101,6 +103,8 @@ function compareScreenshots (commitRange, diffDir, callback) {
     if (filename.startsWith('.')) {
       return
     }
+
+    console.log(`[${totalFiles - files.length} / ${totalFiles}] comparing ${filename}`)
 
     const diffPath = `screenshots/${diffDir}/${filename}`
 
@@ -254,6 +258,7 @@ function processDiff (diffDir, commitRange, results) {
   } else {
     console.log('No visual changes found as a result of these commits.')
   }
+  console.log(`Results in: ${path.resolve('screenshots', diffDir)}`)
 }
 
 function resolveCommit (name) {

--- a/visdiff/src/index.js
+++ b/visdiff/src/index.js
@@ -94,7 +94,7 @@ function compareScreenshots (commitRange, diffDir, callback) {
   function compareNext () {
     const filename = files.pop()
     if (!filename) {
-      callback(commitRange, results)
+      callback(diffDir, commitRange, results)
       return
     }
 
@@ -134,7 +134,7 @@ function compareScreenshots (commitRange, diffDir, callback) {
   compareNext()
 }
 
-function processDiff (commitRange, results) {
+function processDiff (diffDir, commitRange, results) {
   const changedResults = []
   const newResults = []
   const removedResults = []

--- a/visdiff/src/index.js
+++ b/visdiff/src/index.js
@@ -45,8 +45,10 @@ function checkout (commit) {
   const origPackageHash = packageHash()
 
   del.sync([`node_modules.${origPackageHash}`])
-  fs.renameSync('node_modules', `node_modules.${origPackageHash}`)
-  console.log(`Shelved node_modules to node_modules.${origPackageHash}.`)
+  if (fs.existsSync('node_modules')) {
+    fs.renameSync('node_modules', `node_modules.${origPackageHash}`)
+    console.log(`Shelved node_modules to node_modules.${origPackageHash}.`)
+  }
 
   spawn('git', ['checkout', '-f', commit])
 

--- a/visdiff/src/index.js
+++ b/visdiff/src/index.js
@@ -79,15 +79,15 @@ function renderScreenshots (commitRange) {
   const repoPath = spawn('git', ['rev-parse', '--show-toplevel'], {encoding: 'utf-8'}).stdout.trim()
   const relPath = path.relative(repoPath, process.cwd())
   if (!fs.existsSync(WORK_DIR)) {
-    console.log(`Creating work tree: ${WORK_DIR}`)
-    const result = spawn('git', ['worktree', 'add', '--detach', path.join(WORK_DIR)])
+    console.log(`Creating clone in work dir: ${WORK_DIR}`)
+    const result = spawn('git', ['clone', repoPath, path.join(WORK_DIR)])
     if (result.status !== 0) {
-      console.log(`Error creating work tree:`, result.error, result.stderr)
+      console.log(`Error creating work dir clone:`, result.error, result.stderr)
       process.exit(1)
     }
   }
   const workPath = path.join(WORK_DIR, relPath)
-  console.log(`Running in work tree: ${workPath}`)
+  console.log(`Running in work dir: ${workPath}`)
   process.chdir(workPath)
   for (const commit of commitRange) {
     checkout(commit)

--- a/visdiff/src/index.js
+++ b/visdiff/src/index.js
@@ -80,7 +80,11 @@ function renderScreenshots (commitRange) {
   const relPath = path.relative(repoPath, process.cwd())
   if (!fs.existsSync(WORK_DIR)) {
     console.log(`Creating work tree: ${WORK_DIR}`)
-    spawn('git', ['worktree', 'add', '--detach', path.join(WORK_DIR)])
+    const result = spawn('git', ['worktree', 'add', '--detach', path.join(WORK_DIR)])
+    if (result.status !== 0) {
+      console.log(`Error creating work tree:`, result.error, result.stderr)
+      process.exit(1)
+    }
   }
   const workPath = path.join(WORK_DIR, relPath)
   console.log(`Running in work tree: ${workPath}`)


### PR DESCRIPTION
This change lets you run a command like:

```sh
npm run local-visdiff HEAD~4...HEAD
```

To locally run visdiff in the background without affecting the local development directory. When it finishes, it'll output a path to the directory with diff screenshots.

:eyeglasses: @keybase/react-hackers 