### PR TITLE
Make <Input autocorrect={false}/> work and hook up to signup

### DIFF
--- a/shared/common-adapters/input.js.flow
+++ b/shared/common-adapters/input.js.flow
@@ -3,6 +3,7 @@ import {Component} from 'react'
 
 export type Props = $Shape<{
   autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters',
+  autoCorrect?: bool,
   autoFocus?: bool,
   autoGrow?: bool,
   blur: () => void,

--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -67,7 +67,6 @@ class Input extends Component<void, Props, State> {
     const isIOS = Platform.OS_IOS === OS
     const isShowingFloatingLabel = this.state.text.length > 0
     const password = this.props.type === 'password'
-    const passwordVisible = this.props.type === 'passwordVisible'
     const autoGrow = this.props.autoGrow
       ? {onContentSizeChange: (event) => this._onContentSizeChange(event)}
       : {}
@@ -89,7 +88,7 @@ class Input extends Component<void, Props, State> {
           }}
           keyboardType={this.props.keyboardType}
           ref={component => { this._textInput = component }}
-          autoCorrect={!(password || passwordVisible)}
+          autoCorrect={this.props.hasOwnProperty('autoCorrect') && this.props.autoCorrect}
           defaultValue={this.props.value}
           secureTextEntry={password}
           autoFocus={this.props.autoFocus}

--- a/shared/common-adapters/small-input.native.js
+++ b/shared/common-adapters/small-input.native.js
@@ -4,7 +4,7 @@ import type {SmallInputProps} from './small-input'
 import {Box, Text, NativeTextInput} from './index.native'
 import {globalColors, globalMargins, globalStyles} from '../styles'
 
-export default function SmallInput ({autoCapitalize, autoCorrect, errorState, hintText, label, onChange, style, value, autoFocus}: SmallInputProps) {
+export default function SmallInput ({autoCapitalize, autoCorrect = false, errorState, hintText, label, onChange, style, value, autoFocus}: SmallInputProps) {
   return (
     <Box style={{...styleContainer(!!errorState), ...style}}>
       <Text type='BodySmall' style={styleLabel(!!errorState)}>{label}</Text>

--- a/shared/dev/dumb-sheet/render.native.js
+++ b/shared/dev/dumb-sheet/render.native.js
@@ -138,7 +138,6 @@ class Render extends Component<void, Props, any> {
             style={inputStyle}
             onChange={filter => this._onFilterChange(filter.toLowerCase())}
             hintText=''
-            autoCorrect={false}
             autoCapitalize='none'
             value={this.state.localFilter} />
           <Button type='Primary' style={stylesButton} label='-' onClick={() => { this._incremement(false) }} />
@@ -150,7 +149,6 @@ class Render extends Component<void, Props, any> {
               dumbIndex: parseInt(filter, 10) || 0,
             })}
             hintText=''
-            autoCorrect={false}
             autoCapitalize='none'
           />
           <Button type='Primary' style={stylesButton} label='+' onClick={() => { this._incremement(true) }} />

--- a/shared/login/register/paper-key/index.render.native.js
+++ b/shared/login/register/paper-key/index.render.native.js
@@ -15,6 +15,7 @@ class PaperKeyRender extends Component<void, Props, void> {
           <Text type='Header' style={stylesHeader}>Type in your paper key:</Text>
           <Icon type='icon-paper-key-48' style={stylesIcon} />
           <Input
+            autoCorrect={true}
             autoFocus={true}
             style={stylesInput}
             floatingLabelText='Paper key'

--- a/shared/profile/edit-profile/render.native.js
+++ b/shared/profile/edit-profile/render.native.js
@@ -8,6 +8,7 @@ import type {Props} from './render'
 const EditProfileRender = (props: Props) => (
   <StandardScreen style={styleContainer} onClose={props.onBack}>
     <Input
+      autoCorrect={true}
       autoFocus={true}
       style={styleInput}
       floatingLabelText='Full name'
@@ -16,6 +17,7 @@ const EditProfileRender = (props: Props) => (
       onEnterKeyDown={props.onSubmit}
       onChangeText={fullname => props.onFullnameChange(fullname)} />
     <Input
+      autoCorrect={true}
       style={styleInput}
       floatingLabelText='Location'
       hintText='Location'
@@ -23,6 +25,7 @@ const EditProfileRender = (props: Props) => (
       onEnterKeyDown={props.onSubmit}
       onChangeText={location => props.onLocationChange(location)} />
     <Input
+      autoCorrect={true}
       style={styleInput}
       floatingLabelText='Bio'
       hintText='Bio'

--- a/shared/profile/pgp/add.native.js
+++ b/shared/profile/pgp/add.native.js
@@ -11,7 +11,6 @@ class PgpAdd extends Component<void, Props, void> {
     const emailInputProps = {
       style: styleEmailInput,
       autoCapitalize: 'none',
-      autoCorrect: false,
     }
     return (
       <NativeKeyboardAvoidingView behavior='position'>


### PR DESCRIPTION
@keybase/react-hackers 

It looks like we didn't support autoCorrect on &lt;Input /&gt; at all, so I hooked that up.  Is there a shorter way to do the test?  Originally I wanted to do:
```js
           autoCorrect={this.props.autoCorrect || (!(password || passwordVisible))}
```
which doesn't work 'cause `this.props.autoCorrect` will evaluate false both when it's not been passed, and when it's been explicitly set to false to disable autoCorrect.