### PR TITLE
Declare webpack dll manifest's type to flow

### DIFF
--- a/desktop/webpack.config.development.js
+++ b/desktop/webpack.config.development.js
@@ -72,6 +72,7 @@ if (USING_DLL) {
   config.plugins.push(
     new webpack.DllReferencePlugin({
       context: './renderer',
+      // $FlowIssue
       manifest: require('./dll/vendor-manifest.json'),
     })
   )


### PR DESCRIPTION
@keybase/react-hackers 

We didn't see this error because jenkins tests ran on the flow branch before I merged the webpack changes.

The flow branch added a `@flow` to webpack config files. In the dev config we require this vendor-manifest.json file. The true error is that this json file isn't defined on jenkins so flow fails saying it can't find the module to require.