### PR TITLE
Remove babel requirement for npm-vendor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,6 @@ if (env.CHANGE_TITLE && env.CHANGE_TITLE.contains('[ci-skip]')) {
                                         "KEYBASE_JS_VENDOR_DIR=${env.BASEDIR}/js-vendor-desktop",
                                     ]) {
                                         dir("desktop") {
-                                            sh "npm run babel-install"
                                             sh "npm run vendor-install"
                                             sh "unzip ${env.KEYBASE_JS_VENDOR_DIR}/flow/flow-linux64*.zip -d ${env.BASEDIR}"
                                             sh "${env.BASEDIR}/flow/flow status shared"

--- a/desktop/npm-vendor.js
+++ b/desktop/npm-vendor.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-// @flow
+/* eslint-disable flowtype/require-valid-file-annotation */
+// (we can't strip flowtypes on this before flow is installed)
 
 var os = require('os')
 var path = require('path')
@@ -22,7 +23,6 @@ function ensureSymlink (target, dest) {
 
   var absDest = path.resolve(dest)
   console.log('Linking', target, '->', absDest)
-  // $FlowIssue
   fs.symlinkSync(absDest, target)
 }
 
@@ -30,7 +30,6 @@ function spawn (command, args, options) {
   options = options || {}
   args = args || []
   console.log((options.cwd || '') + '>', command, args.join(' '))
-  // $FlowIssue
   var res = spawnSync(command, args, Object.assign({stdio: 'inherit', encoding: 'utf8'}, options))
   if (res.error) {
     throw res.error

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "_helper": "npm run _node -- npm-helper.js",
     "_node": "babel-node --presets es2015,stage-2 --plugins transform-flow-strip-types",
-    "babel-install": "npm install babel-cli babel-preset-es2015 babel-preset-stage-2 babel-preset-react",
     "build-dev": "npm run _helper build-dev",
     "build-main-thread": "npm run _helper build-main-thread",
     "build-prod": "npm run _helper build-prod",
@@ -33,8 +32,8 @@
     "test": "npm run _helper test && npm run mocha",
     "undiff-log": "npm run _helper undiff-log",
     "updated-fonts": "npm run _helper updated-fonts",
-    "vendor-install": "npm run _node npm-vendor.js",
-    "vendor-update": "npm run _node npm-vendor.js update",
+    "vendor-install": "node npm-vendor.js",
+    "vendor-update": "node npm-vendor.js update",
     "watch-test-file": "KEYBASE_RUN_MODE=devel npm run _helper watch-test-file",
     "wrap": "npm uninstall fsevents && npm prune && npm dedupe && npm shrinkwrap --dev"
   },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/main.bundle.js",
   "scripts": {
     "_helper": "npm run _node -- npm-helper.js",
-    "_node": "babel-node --presets es2015,stage-2 --plugins transform-flow-strip-types ",
+    "_node": "babel-node --presets es2015,stage-2 --plugins transform-flow-strip-types",
     "babel-install": "npm install babel-cli babel-preset-es2015 babel-preset-stage-2 babel-preset-react",
     "build-dev": "npm run _helper build-dev",
     "build-main-thread": "npm run _helper build-main-thread",


### PR DESCRIPTION
Also fixes visdiff, which is currently breaking due to no `babel-node` installed.

:eyeglasses: @keybase/react-hackers 