### PR TITLE
If webpack's dll isn't present load the entry chunk anyways

### DIFF
--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -43,6 +43,9 @@
       if (__DEV__) {
         var vendor = document.createElement('script')
         vendor.onload = loadEntryChunk
+        // In case we don't have a dll, we just load the main entry chunk
+        // This happens when we don't use a DLL
+        vendor.onerror = loadEntryChunk
         vendor.src = '../dist/dll/dll.vendor.js'
         document.head.appendChild(vendor)
       } else {

--- a/desktop/renderer/launcher.html
+++ b/desktop/renderer/launcher.html
@@ -59,6 +59,9 @@ body {
       if (__DEV__) {
         var vendor = document.createElement('script')
         vendor.onload = loadEntryChunk
+        // In case we don't have a dll, we just load the main entry chunk
+        // This happens when we don't use a DLL
+        vendor.onerror = loadEntryChunk
         vendor.src = '../dist/dll/dll.vendor.js'
         document.head.appendChild(vendor)
       } else {

--- a/desktop/renderer/remoteComponent.html
+++ b/desktop/renderer/remoteComponent.html
@@ -45,6 +45,9 @@
       if (__DEV__) {
         var vendor = document.createElement('script')
         vendor.onload = loadEntryChunk
+        // In case we don't have a dll, we just load the main entry chunk
+        // This happens when we don't use a DLL
+        vendor.onerror = loadEntryChunk
         vendor.src = '../dist/dll/dll.vendor.js'
         document.head.appendChild(vendor)
       } else {


### PR DESCRIPTION
@keybase/react-hackers 

So this isn't an ideal solution, hopefully @chrisnojima 's render html from webpack can clean this up.

The problem is we don't know in the html if we are using the dll. The args that we do pass in the url come from the main thread, and the main thread doesn't know if we are using dll either.

So there isn't a good way to tell this context that dll is being used or not, so we try to fetch the dll, and if it fails we still load the entry chunk.

If you run `npm start` `__DEV__` is true but the dll wasn't used (the main entry chunk has everything). So fetching the dll fails. The failback lets the main entry chunk continue.