### PR TITLE
upgrade linux packaging container to Go 1.7.1

### DIFF
--- a/packaging/linux/Dockerfile
+++ b/packaging/linux/Dockerfile
@@ -26,7 +26,7 @@ RUN npm install -g npm
 RUN npm cache clean
 
 # Install Go directly from Google, because the Debian repos tend to be behind.
-RUN wget https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz -O /root/go.tar
+RUN wget "https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz" -O /root/go.tar
 RUN tar -C /usr/local -xzf /root/go.tar
 RUN rm /root/go.tar
 ENV PATH "$PATH:/usr/local/go/bin"


### PR DESCRIPTION
Made more urgent by: https://github.com/golang/go/issues/16208

r? @cjb @patrickxb 