### PR TITLE
update node and bump the overall version on our Linux packaging Dockerfile

### DIFF
--- a/packaging/linux/Dockerfile
+++ b/packaging/linux/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get install -y fakeroot reprepro rpm createrepo git wget build-essential
 RUN pip install s3cmd
 
 # Install a recent version of Node.
-RUN curl -sL https://deb.nodesource.com/setup_5.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 RUN apt-get update
 RUN apt-get install -y nodejs
 RUN npm install -g npm

--- a/packaging/linux/docker_build.sh
+++ b/packaging/linux/docker_build.sh
@@ -63,7 +63,7 @@ gpg_tempfile="$gpg_tempdir/code_signing_key"
 gpg --export-secret-key --armor "$code_signing_fingerprint" > "$gpg_tempfile"
 
 # Make sure the Docker image is built.
-image=keybase_packaging_v6
+image=keybase_packaging_v7
 if [ -z "$(docker images -q "$image")" ] ; then
   echo "Docker image '$image' not yet built. Building..."
   docker build -t "$image" "$clientdir/packaging/linux"


### PR DESCRIPTION
r? @cjb @patrickxb 

I noticed a warning about still using Node 5 when I was looking at our build output just now:

```
================================================================================
                              DEPRECATION WARNING
  Node.js v5.x is no longer actively supported!
  You will not receive security or critical stability updates for this version.
  You should migrate to a supported version of Node.js as soon as possible.
  Use the installation script that corresponds to the version of Node.js you
  wish to install. e.g.
   * https://deb.nodesource.com/setup_4.x — Node.js v4 LTS "Argon" (recommended)
   * https://deb.nodesource.com/setup_6.x — Node.js v6 Current
  Please see https://github.com/nodejs/LTS/ for detailsabout which version
  may be appropriate for you.
  The NodeSource Node.js Linux distributions GitHub repository contains
  information about which versions of Node.js and whichLinux distributions
  are supported and how to use the install scripts.
    https://github.com/nodesource/distributions
================================================================================
```