### PR TITLE
Mobile: Use multiline input for paper key

### DIFF
--- a/shared/login/register/paper-key/index.render.native.js
+++ b/shared/login/register/paper-key/index.render.native.js
@@ -16,7 +16,7 @@ class PaperKeyRender extends Component<void, Props, void> {
           <Icon type='icon-paper-key-48' style={stylesIcon} />
           <Input
             multiline={true}
-            rows={2}
+            rows={3}
             autoCorrect={true}
             autoFocus={true}
             style={stylesInput}
@@ -52,16 +52,17 @@ const stylesContainer = {
 
 const stylesButton = {
   marginTop: globalMargins.medium,
-  marginBottom: 20,
+  marginBottom: globalMargins.medium,
 }
 
 const stylesInput = {
   alignSelf: 'stretch',
-  height: 80,
+  height: 64,
+  marginBottom: globalMargins.large,
 }
 
 const stylesIcon = {
-  marginTop: 30,
+  marginTop: globalMargins.small,
 }
 
 const stylesHeader = {

--- a/shared/login/register/paper-key/index.render.native.js
+++ b/shared/login/register/paper-key/index.render.native.js
@@ -46,20 +46,20 @@ const stylesBox = {
   padding: 10,
 }
 
-const stylesButton = {
-  marginTop: globalMargins.tiny,
-}
-
 const stylesContainer = {
   alignItems: 'center',
 }
 
-const stylesHeader = {
-  marginTop: globalMargins.small,
+const stylesButton = {
+  marginTop: globalMargins.tiny,
 }
 
 const stylesInput = {
   alignSelf: 'stretch',
+}
+
+const stylesHeader = {
+  marginTop: globalMargins.small,
 }
 
 export default PaperKeyRender

--- a/shared/login/register/paper-key/index.render.native.js
+++ b/shared/login/register/paper-key/index.render.native.js
@@ -15,6 +15,8 @@ class PaperKeyRender extends Component<void, Props, void> {
           <Text type='Header' style={stylesHeader}>Type in your paper key:</Text>
           <Icon type='icon-paper-key-48' style={stylesIcon} />
           <Input
+            multiline={true}
+            rows={2}
             autoCorrect={true}
             autoFocus={true}
             style={stylesInput}

--- a/shared/login/register/paper-key/index.render.native.js
+++ b/shared/login/register/paper-key/index.render.native.js
@@ -51,14 +51,11 @@ const stylesContainer = {
 }
 
 const stylesButton = {
-  marginTop: globalMargins.medium,
   marginBottom: globalMargins.medium,
 }
 
 const stylesInput = {
   alignSelf: 'stretch',
-  height: 64,
-  marginBottom: globalMargins.large,
 }
 
 const stylesIcon = {

--- a/shared/login/register/paper-key/index.render.native.js
+++ b/shared/login/register/paper-key/index.render.native.js
@@ -13,7 +13,7 @@ class PaperKeyRender extends Component<void, Props, void> {
           style={stylesContainer}
           onBack={this.props.onBack}>
           <Text type='Header' style={stylesHeader}>Type in your paper key:</Text>
-          <Icon type='icon-paper-key-48' style={stylesIcon} />
+          <Icon type='icon-paper-key-48' />
           <Input
             multiline={true}
             rows={3}
@@ -46,24 +46,20 @@ const stylesBox = {
   padding: 10,
 }
 
+const stylesButton = {
+  marginTop: globalMargins.tiny,
+}
+
 const stylesContainer = {
   alignItems: 'center',
 }
 
-const stylesButton = {
-  marginBottom: globalMargins.medium,
+const stylesHeader = {
+  marginTop: globalMargins.small,
 }
 
 const stylesInput = {
   alignSelf: 'stretch',
-}
-
-const stylesIcon = {
-  marginTop: globalMargins.small,
-}
-
-const stylesHeader = {
-  marginTop: globalMargins.small,
 }
 
 export default PaperKeyRender


### PR DESCRIPTION
@keybase/react-hackers 

I think I discovered why we haven't done this already -- the multiline input is ugly in its initial (no text entered) state.  But it's more functional than the single line input here, and looks good once text is entered, so perhaps we should merge it anyway.  It'll at least remind us to fix it up when we can -- were we waiting on new RN for something?

Screens:

<img width="339" alt="screen shot 2016-10-06 at 12 12 30 pm" src="https://cloud.githubusercontent.com/assets/21217/19160746/104d1f0a-8bbf-11e6-974c-9d36c110f532.png">

<img width="337" alt="screen shot 2016-10-06 at 12 14 47 pm" src="https://cloud.githubusercontent.com/assets/21217/19160750/155973ae-8bbf-11e6-8fbf-546fbb25262d.png">

![pap1](https://cloud.githubusercontent.com/assets/21217/19160737/0476e7c4-8bbf-11e6-9a73-01d1077fd72e.png)

![pap2](https://cloud.githubusercontent.com/assets/21217/19160739/0816a450-8bbf-11e6-84d9-c733ddec43d3.png)