### PR TITLE
Render edits and deletes

### DIFF
--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -126,7 +126,10 @@ func parseConversationResolver(ctx *cli.Context, tlfName string) (resolver chatC
 }
 
 func makeChatCLIConversationFetcher(ctx *cli.Context, tlfName string, markAsRead bool) (fetcher chatCLIConversationFetcher, err error) {
-	fetcher.query.MessageTypes = []chat1.MessageType{chat1.MessageType_TEXT, chat1.MessageType_ATTACHMENT}
+	fetcher.query.MessageTypes = []chat1.MessageType{
+		chat1.MessageType_TEXT,
+		chat1.MessageType_ATTACHMENT,
+	}
 	fetcher.query.Limit = chat1.UnreadFirstNumLimit{
 		NumRead: 2,
 		AtLeast: ctx.Int("at-least"),

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -1,12 +1,13 @@
 package client
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/flexibletable"
 	"github.com/keybase/client/go/libkb"

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -272,7 +272,7 @@ type messageView struct {
 	AuthorAndTimeWithDeviceName string
 	Body                        string
 
-	// Used internally for superseeders
+	// Used internally for supersedeers
 	messageType chat1.MessageType
 }
 
@@ -290,7 +290,7 @@ func newMessageView(g *libkb.GlobalContext, conversationID chat1.ConversationID,
 
 	mv.MessageID = m.Message.ServerHeader.MessageID
 
-	// Check what message superseeds this one.
+	// Check what message supersedes this one.
 	var mvsup *messageView
 	supersededBy := m.Message.ServerHeader.SupersededBy
 	if supersededBy != 0 {
@@ -337,7 +337,7 @@ func newMessageView(g *libkb.GlobalContext, conversationID chat1.ConversationID,
 				case chat1.MessageType_DELETE:
 					mv.Body = deletedTextCLI
 				default:
-					// Some unknown superseeder type
+					// Some unknown supersedeer type
 				}
 			}
 		case chat1.MessageType_TEXT:
@@ -351,7 +351,7 @@ func newMessageView(g *libkb.GlobalContext, conversationID chat1.ConversationID,
 					// This is unlikely because deleted messages are usually NONE
 					mv.Body = deletedTextCLI
 				default:
-					// Some unknown superseeder type
+					// Some unknown supersedeer type
 				}
 			}
 		case chat1.MessageType_ATTACHMENT:
@@ -365,7 +365,7 @@ func newMessageView(g *libkb.GlobalContext, conversationID chat1.ConversationID,
 				case chat1.MessageType_DELETE:
 					mv.Body = deletedTextCLI
 				default:
-					// Some unknown superseeder type
+					// Some unknown supersedeer type
 				}
 			}
 		case chat1.MessageType_EDIT:

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"errors"
+	"context"
 	"fmt"
 	"math"
 	"strconv"
@@ -102,6 +102,7 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 		}
 
 		unread := "*"
+		// show the last TEXT message
 		var msg chat1.MessageFromServerOrError
 		for _, m := range conv.MaxMessages {
 			if m.Message != nil {
@@ -114,10 +115,22 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 			}
 		}
 
-		authorAndTime := messageFormatter(msg).authorAndTime(showDeviceName)
-		body, err := messageFormatter(msg).body(g)
+		mv, err := newMessageView(g, conv.Info.Id, msg)
 		if err != nil {
-			return fmt.Errorf("rendering message body error: %v\n", err)
+			g.Log.Error("Message render error: %s", err)
+		}
+
+		var authorAndTime string
+		if showDeviceName {
+			authorAndTime = mv.AuthorAndTimeWithDeviceName
+		} else {
+			authorAndTime = mv.AuthorAndTime
+		}
+
+		// This will show a blank link for convs whose last message cannot be displayed.
+		body := ""
+		if mv.Renderable {
+			body = mv.Body
 		}
 
 		table.Insert(flexibletable.Row{
@@ -169,19 +182,31 @@ func (v conversationView) show(g *libkb.GlobalContext, showDeviceName bool) erro
 	w, _ := ui.TerminalSize()
 
 	table := &flexibletable.Table{}
-	for i, m := range v.messages {
+	i := -1
+	for _, m := range v.messages {
+		mv, err := newMessageView(g, v.conversation.Info.Id, m)
+		if err != nil {
+			g.Log.Error("Message render error: %s", err)
+		}
+
+		if !mv.Renderable {
+			continue
+		}
+
 		unread := ""
 		if m.Message != nil &&
 			v.conversation.ReaderInfo.ReadMsgid < m.Message.ServerHeader.MessageID {
 			unread = "*"
 		}
 
-		authorAndTime := messageFormatter(m).authorAndTime(showDeviceName)
-		body, err := messageFormatter(m).body(g)
-		if err != nil {
-			return fmt.Errorf("rendering message body error: %v\n", err)
+		var authorAndTime string
+		if showDeviceName {
+			authorAndTime = mv.AuthorAndTimeWithDeviceName
+		} else {
+			authorAndTime = mv.AuthorAndTime
 		}
 
+		i++
 		table.Insert(flexibletable.Row{
 			flexibletable.Cell{
 				Frame:     [2]string{"[", "]"},
@@ -199,7 +224,7 @@ func (v conversationView) show(g *libkb.GlobalContext, showDeviceName bool) erro
 			},
 			flexibletable.Cell{
 				Alignment: flexibletable.Left,
-				Content:   flexibletable.SingleCell{Item: body},
+				Content:   flexibletable.SingleCell{Item: mv.Body},
 			},
 		})
 	}
@@ -212,55 +237,154 @@ func (v conversationView) show(g *libkb.GlobalContext, showDeviceName bool) erro
 	return nil
 }
 
-type messageFormatter chat1.MessageFromServerOrError
+// TODO what is this doing here?
+func fetchOneMessage(g *libkb.GlobalContext, conversationID chat1.ConversationID, messageID chat1.MessageID) (chat1.MessageFromServerOrError, error) {
+	deflt := chat1.MessageFromServerOrError{}
 
-func (f messageFormatter) authorAndTime(showDeviceName bool) string {
-	m := chat1.MessageFromServerOrError(f)
-	if m.Message == nil {
-		return ""
+	chatClient, err := GetChatLocalClient(g)
+	if err != nil {
+		return deflt, err
 	}
-	t := gregor1.FromTime(m.Message.ServerHeader.Ctime)
-	if showDeviceName {
-		return fmt.Sprintf("%s <%s> %s", m.Message.SenderUsername, m.Message.SenderDeviceName, shortDurationFromNow(t))
+
+	arg := chat1.GetMessagesLocalArg{
+		ConversationID: conversationID,
+		MessageIDs:     []chat1.MessageID{messageID},
 	}
-	return fmt.Sprintf("%s %s", m.Message.SenderUsername, shortDurationFromNow(t))
+	res, err := chatClient.GetMessagesLocal(context.TODO(), arg)
+	if err != nil {
+		return deflt, err
+	}
+	if len(res.Messages) < 0 {
+		return deflt, fmt.Errorf("empty messages list")
+	}
+	return res.Messages[0], nil
 }
 
-func (f messageFormatter) body(g *libkb.GlobalContext) (string, error) {
-	m := chat1.MessageFromServerOrError(f)
-	if m.Message != nil {
-		version, err := m.Message.MessagePlaintext.Version()
+const deletedTextCLI = "[deleted]"
+
+// Everything you need to show a message.
+// Takes into account superseding edits and deletions.
+type messageView struct {
+	MessageID chat1.MessageID
+	// Whether to show this message. Show texts, but not edits or deletes.
+	Renderable                  bool
+	AuthorAndTime               string
+	AuthorAndTimeWithDeviceName string
+	Body                        string
+
+	// Used internally for superseeders
+	messageType chat1.MessageType
+}
+
+// newMessageView extracts from a message the parts for display
+// It may fetch the superseding message. So that for example a TEXT message will show its EDIT text.
+func newMessageView(g *libkb.GlobalContext, conversationID chat1.ConversationID, m chat1.MessageFromServerOrError) (messageView, error) {
+	mv := messageView{}
+
+	if m.Message == nil {
+		if m.UnboxingError != nil {
+			return mv, fmt.Errorf(fmt.Sprintf("<%s>", *m.UnboxingError))
+		}
+		return mv, fmt.Errorf("unexpected data")
+	}
+
+	mv.MessageID = m.Message.ServerHeader.MessageID
+
+	// Check what message superseeds this one.
+	var mvsup *messageView
+	supersededBy := m.Message.ServerHeader.SupersededBy
+	if supersededBy != 0 {
+		msup, err := fetchOneMessage(g, conversationID, supersededBy)
 		if err != nil {
-			g.Log.Warning("MessagePlaintext version error: %s", err)
-			return "", err
+			return mv, err
 		}
-		switch version {
-		case chat1.MessagePlaintextVersion_V1:
-			body := m.Message.MessagePlaintext.V1().MessageBody
-			typ, err := body.MessageType()
-			if err != nil {
-				return "", err
+		mvsupInner, err := newMessageView(g, conversationID, msup)
+		if err != nil {
+			return mv, err
+		}
+		mvsup = &mvsupInner
+	}
+
+	t := gregor1.FromTime(m.Message.ServerHeader.Ctime)
+	mv.AuthorAndTime = fmt.Sprintf("%s %s",
+		m.Message.SenderUsername, shortDurationFromNow(t))
+	mv.AuthorAndTimeWithDeviceName = fmt.Sprintf("%s <%s> %s",
+		m.Message.SenderUsername, m.Message.SenderDeviceName, shortDurationFromNow(t))
+
+	version, err := m.Message.MessagePlaintext.Version()
+	if err != nil {
+		g.Log.Warning("MessagePlaintext version error: %s", err)
+		return mv, err
+	}
+	switch version {
+	case chat1.MessagePlaintextVersion_V1:
+		plaintext := m.Message.MessagePlaintext.V1()
+		body := plaintext.MessageBody
+		typ, err := plaintext.MessageBody.MessageType()
+		mv.messageType = typ
+		if err != nil {
+			return mv, err
+		}
+		switch typ {
+		case chat1.MessageType_NONE:
+			// NONE is what you get when a message has been deleted.
+			mv.Renderable = true
+			if mvsup != nil {
+				switch mvsup.messageType {
+				case chat1.MessageType_EDIT:
+					// Use the edited body
+					mv.Body = mvsup.Body
+				case chat1.MessageType_DELETE:
+					mv.Body = deletedTextCLI
+				default:
+					// Some unknown superseeder type
+				}
 			}
-			switch typ {
-			case chat1.MessageType_TEXT:
-				return body.Text().Body, nil
-			case chat1.MessageType_ATTACHMENT:
-				// TODO: will fix this in CORE-3899
-				return "{Attachment} | Caption: <unimplemented>", nil
-			default:
-				return fmt.Sprintf("unsupported MessageType: %s", typ.String()), nil
+		case chat1.MessageType_TEXT:
+			mv.Renderable = true
+			mv.Body = body.Text().Body
+			if mvsup != nil {
+				switch mvsup.messageType {
+				case chat1.MessageType_EDIT:
+					mv.Body = mvsup.Body
+				case chat1.MessageType_DELETE:
+					// This is unlikely because deleted messages are usually NONE
+					mv.Body = deletedTextCLI
+				default:
+					// Some unknown superseeder type
+				}
 			}
+		case chat1.MessageType_ATTACHMENT:
+			mv.Renderable = true
+			// TODO: will fix this in CORE-3899
+			mv.Body = fmt.Sprintf("{Attachment} | Caption: <unimplemented>")
+			if mvsup != nil {
+				switch mvsup.messageType {
+				case chat1.MessageType_EDIT:
+					// Editing attachments is not supported, ignore the edit
+				case chat1.MessageType_DELETE:
+					mv.Body = deletedTextCLI
+				default:
+					// Some unknown superseeder type
+				}
+			}
+		case chat1.MessageType_EDIT:
+			mv.Renderable = false
+			// Return the edit body for display in the original
+			mv.Body = fmt.Sprintf("%v [edited]", body.Edit().Body)
+		case chat1.MessageType_DELETE:
+			mv.Renderable = false
+		case chat1.MessageType_METADATA:
+			mv.Renderable = false
+		case chat1.MessageType_TLFNAME:
+			mv.Renderable = false
 		default:
-			g.Log.Warning("messageFormatter.body unhandled MessagePlaintext version %v", version)
-			return "", err
+			return mv, fmt.Errorf(fmt.Sprintf("unsupported MessageType: %s", typ.String()))
 		}
+	default:
+		return mv, fmt.Errorf(fmt.Sprintf("MessagePlaintext version error: %s", err))
 	}
-
-	if m.UnboxingError != nil {
-		return fmt.Sprintf("<%s>", *m.UnboxingError), nil
-	}
-
-	return "", errors.New("unexpected data")
+	return mv, nil
 }
 
 func shortDurationFromNow(t time.Time) string {

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/keybase/client/go/flexibletable"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -236,29 +234,6 @@ func (v conversationView) show(g *libkb.GlobalContext, showDeviceName bool) erro
 	}
 
 	return nil
-}
-
-// TODO what is this doing here?
-func fetchOneMessage(g *libkb.GlobalContext, conversationID chat1.ConversationID, messageID chat1.MessageID) (chat1.MessageFromServerOrError, error) {
-	deflt := chat1.MessageFromServerOrError{}
-
-	chatClient, err := GetChatLocalClient(g)
-	if err != nil {
-		return deflt, err
-	}
-
-	arg := chat1.GetMessagesLocalArg{
-		ConversationID: conversationID,
-		MessageIDs:     []chat1.MessageID{messageID},
-	}
-	res, err := chatClient.GetMessagesLocal(context.TODO(), arg)
-	if err != nil {
-		return deflt, err
-	}
-	if len(res.Messages) < 0 {
-		return deflt, fmt.Errorf("empty messages list")
-	}
-	return res.Messages[0], nil
 }
 
 const deletedTextCLI = "[deleted]"

--- a/go/client/chat_cli_utils.go
+++ b/go/client/chat_cli_utils.go
@@ -133,3 +133,25 @@ func (f chatCLIInboxFetcher) fetch(ctx context.Context, g *libkb.GlobalContext) 
 
 	return res.Conversations, nil
 }
+
+func fetchOneMessage(g *libkb.GlobalContext, conversationID chat1.ConversationID, messageID chat1.MessageID) (chat1.MessageFromServerOrError, error) {
+	deflt := chat1.MessageFromServerOrError{}
+
+	chatClient, err := GetChatLocalClient(g)
+	if err != nil {
+		return deflt, err
+	}
+
+	arg := chat1.GetMessagesLocalArg{
+		ConversationID: conversationID,
+		MessageIDs:     []chat1.MessageID{messageID},
+	}
+	res, err := chatClient.GetMessagesLocal(context.TODO(), arg)
+	if err != nil {
+		return deflt, err
+	}
+	if len(res.Messages) < 0 {
+		return deflt, fmt.Errorf("empty messages list")
+	}
+	return res.Messages[0], nil
+}

--- a/go/flexibletable/errors.go
+++ b/go/flexibletable/errors.go
@@ -15,6 +15,14 @@ func (e InconsistentRowsError) Error() string {
 		e.existingRows, e.newRow)
 }
 
+// NoRowsError indicates no rows in the table.
+type NoRowsError struct{}
+
+// Error implements the error interface
+func (e NoRowsError) Error() string {
+	return "no rows"
+}
+
 // WidthTooSmallError indicates the width constraints is too small.
 type WidthTooSmallError struct{}
 

--- a/go/flexibletable/table.go
+++ b/go/flexibletable/table.go
@@ -130,6 +130,9 @@ func (t Table) renderSecondPass(constraints []ColumnConstraint, widths []int) (r
 // how each column should be constrained while being rendered. Positive values
 // limit the maximum width.
 func (t Table) Render(w io.Writer, cellSep string, maxWidth int, constraints []ColumnConstraint) error {
+	if len(t.rows) == 0 {
+		return NoRowsError{}
+	}
 	if len(constraints) != len(t.rows[0]) {
 		return InconsistentRowsError{existingRows: len(t.rows[0]), newRow: len(constraints)}
 	}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -474,6 +474,11 @@ type GetConversationForCLILocalRes struct {
 	RateLimits   []RateLimit                `codec:"rateLimits" json:"rateLimits"`
 }
 
+type GetMessagesLocalRes struct {
+	Messages   []MessageFromServerOrError `codec:"messages" json:"messages"`
+	RateLimits []RateLimit                `codec:"rateLimits" json:"rateLimits"`
+}
+
 type GetThreadLocalArg struct {
 	ConversationID ConversationID  `codec:"conversationID" json:"conversationID"`
 	Query          *GetThreadQuery `codec:"query,omitempty" json:"query,omitempty"`
@@ -505,6 +510,11 @@ type GetConversationForCLILocalArg struct {
 	Query GetConversationForCLILocalQuery `codec:"query" json:"query"`
 }
 
+type GetMessagesLocalArg struct {
+	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
+	MessageIDs     []MessageID    `codec:"messageIDs" json:"messageIDs"`
+}
+
 type LocalInterface interface {
 	GetThreadLocal(context.Context, GetThreadLocalArg) (GetThreadLocalRes, error)
 	GetInboxLocal(context.Context, GetInboxLocalArg) (GetInboxLocalRes, error)
@@ -512,6 +522,7 @@ type LocalInterface interface {
 	NewConversationLocal(context.Context, NewConversationLocalArg) (NewConversationLocalRes, error)
 	GetInboxSummaryForCLILocal(context.Context, GetInboxSummaryForCLILocalQuery) (GetInboxSummaryForCLILocalRes, error)
 	GetConversationForCLILocal(context.Context, GetConversationForCLILocalQuery) (GetConversationForCLILocalRes, error)
+	GetMessagesLocal(context.Context, GetMessagesLocalArg) (GetMessagesLocalRes, error)
 }
 
 func LocalProtocol(i LocalInterface) rpc.Protocol {
@@ -614,6 +625,22 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"GetMessagesLocal": {
+				MakeArg: func() interface{} {
+					ret := make([]GetMessagesLocalArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]GetMessagesLocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]GetMessagesLocalArg)(nil), args)
+						return
+					}
+					ret, err = i.GetMessagesLocal(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -651,5 +678,10 @@ func (c LocalClient) GetInboxSummaryForCLILocal(ctx context.Context, query GetIn
 func (c LocalClient) GetConversationForCLILocal(ctx context.Context, query GetConversationForCLILocalQuery) (res GetConversationForCLILocalRes, err error) {
 	__arg := GetConversationForCLILocalArg{Query: query}
 	err = c.Cli.Call(ctx, "chat.1.local.getConversationForCLILocal", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) GetMessagesLocal(ctx context.Context, __arg GetMessagesLocalArg) (res GetMessagesLocalRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.GetMessagesLocal", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -576,7 +576,6 @@ func (h *chatLocalHandler) getSenderInfoLocal(uimap *chat.UserInfoMapper, messag
 	}
 }
 
-// GetMessagesLocal implements keybase.chatLocal.GetMessagesLocal protocol.
 func (h *chatLocalHandler) GetConversationForCLILocal(ctx context.Context, arg chat1.GetConversationForCLILocalQuery) (res chat1.GetConversationForCLILocalRes, err error) {
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return chat1.GetConversationForCLILocalRes{}, err
@@ -628,6 +627,7 @@ func (h *chatLocalHandler) GetConversationForCLILocal(ctx context.Context, arg c
 	}
 	rlimits = append(rlimits, tv.RateLimits...)
 
+	// apply message count limits
 	var messages []chat1.MessageFromServerOrError
 	for _, m := range tv.Thread.Messages {
 		messages = append(messages, m)

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -92,7 +92,7 @@ protocol common {
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;
     MessageID supersededBy;
-    MessageID supersedes;
+    MessageID supersedes; // not populated
     gregor1.Time ctime;
   }
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -152,9 +152,8 @@ protocol local {
     union { null, string } error;
     ConversationInfoLocal info;
     ConversationReaderInfo readerInfo;
-    array<MessageFromServerOrError> maxMessages;
+    array<MessageFromServerOrError> maxMessages; // the latest message for each message type
   }
-
 
   GetThreadLocalRes getThreadLocal(ConversationID conversationID, union { null, GetThreadQuery} query, union { null, Pagination } pagination);
   record GetThreadQuery {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -237,4 +237,11 @@ protocol local {
     array<MessageFromServerOrError> messages;
     array<RateLimit> rateLimits;
   }
+
+  // Get messages by ID.
+  GetMessagesLocalRes GetMessagesLocal(ConversationID conversationID, array<MessageID> messageIDs);
+  record GetMessagesLocalRes {
+    array<MessageFromServerOrError> messages;
+    array<RateLimit> rateLimits;
+  }
 }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -98,6 +98,14 @@ export function localGetInboxSummaryForCLILocalRpcPromise (request: $Exact<reque
   return new Promise((resolve, reject) => { localGetInboxSummaryForCLILocalRpc({...request, param: request.param, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function localGetMessagesLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetMessagesLocalResult) => void} & {param: localGetMessagesLocalRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'local.GetMessagesLocal'})
+}
+
+export function localGetMessagesLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetMessagesLocalResult) => void} & {param: localGetMessagesLocalRpcParam}>): Promise<localGetMessagesLocalResult> {
+  return new Promise((resolve, reject) => { localGetMessagesLocalRpc({...request, param: request.param, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function localGetThreadLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadLocalResult) => void} & {param: localGetThreadLocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'local.getThreadLocal'})
 }
@@ -321,6 +329,11 @@ export type GetInboxSummaryForCLILocalQuery = {
 
 export type GetInboxSummaryForCLILocalRes = {
   conversations?: ?Array<ConversationLocal>,
+  rateLimits?: ?Array<RateLimit>,
+}
+
+export type GetMessagesLocalRes = {
+  messages?: ?Array<MessageFromServerOrError>,
   rateLimits?: ?Array<RateLimit>,
 }
 
@@ -570,6 +583,11 @@ export type localGetInboxSummaryForCLILocalRpcParam = Exact<{
   query: GetInboxSummaryForCLILocalQuery
 }>
 
+export type localGetMessagesLocalRpcParam = Exact<{
+  conversationID: ConversationID,
+  messageIDs?: ?Array<MessageID>
+}>
+
 export type localGetThreadLocalRpcParam = Exact<{
   conversationID: ConversationID,
   query?: ?GetThreadQuery,
@@ -633,6 +651,8 @@ type localGetInboxLocalResult = GetInboxLocalRes
 
 type localGetInboxSummaryForCLILocalResult = GetInboxSummaryForCLILocalRes
 
+type localGetMessagesLocalResult = GetMessagesLocalRes
+
 type localGetThreadLocalResult = GetThreadLocalRes
 
 type localNewConversationLocalResult = NewConversationLocalRes
@@ -657,6 +677,7 @@ export type rpc =
     localGetConversationForCLILocalRpc
   | localGetInboxLocalRpc
   | localGetInboxSummaryForCLILocalRpc
+  | localGetMessagesLocalRpc
   | localGetThreadLocalRpc
   | localNewConversationLocalRpc
   | localPostLocalRpc

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -705,6 +705,26 @@
           "name": "rateLimits"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "GetMessagesLocalRes",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "MessageFromServerOrError"
+          },
+          "name": "messages"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        }
+      ]
     }
   ],
   "messages": {
@@ -804,6 +824,22 @@
         }
       ],
       "response": "GetConversationForCLILocalRes"
+    },
+    "GetMessagesLocal": {
+      "request": [
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "messageIDs",
+          "type": {
+            "type": "array",
+            "items": "MessageID"
+          }
+        }
+      ],
+      "response": "GetMessagesLocalRes"
     }
   },
   "namespace": "chat.1"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -98,6 +98,14 @@ export function localGetInboxSummaryForCLILocalRpcPromise (request: $Exact<reque
   return new Promise((resolve, reject) => { localGetInboxSummaryForCLILocalRpc({...request, param: request.param, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function localGetMessagesLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetMessagesLocalResult) => void} & {param: localGetMessagesLocalRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'local.GetMessagesLocal'})
+}
+
+export function localGetMessagesLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetMessagesLocalResult) => void} & {param: localGetMessagesLocalRpcParam}>): Promise<localGetMessagesLocalResult> {
+  return new Promise((resolve, reject) => { localGetMessagesLocalRpc({...request, param: request.param, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function localGetThreadLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadLocalResult) => void} & {param: localGetThreadLocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'local.getThreadLocal'})
 }
@@ -321,6 +329,11 @@ export type GetInboxSummaryForCLILocalQuery = {
 
 export type GetInboxSummaryForCLILocalRes = {
   conversations?: ?Array<ConversationLocal>,
+  rateLimits?: ?Array<RateLimit>,
+}
+
+export type GetMessagesLocalRes = {
+  messages?: ?Array<MessageFromServerOrError>,
   rateLimits?: ?Array<RateLimit>,
 }
 
@@ -570,6 +583,11 @@ export type localGetInboxSummaryForCLILocalRpcParam = Exact<{
   query: GetInboxSummaryForCLILocalQuery
 }>
 
+export type localGetMessagesLocalRpcParam = Exact<{
+  conversationID: ConversationID,
+  messageIDs?: ?Array<MessageID>
+}>
+
 export type localGetThreadLocalRpcParam = Exact<{
   conversationID: ConversationID,
   query?: ?GetThreadQuery,
@@ -633,6 +651,8 @@ type localGetInboxLocalResult = GetInboxLocalRes
 
 type localGetInboxSummaryForCLILocalResult = GetInboxSummaryForCLILocalRes
 
+type localGetMessagesLocalResult = GetMessagesLocalRes
+
 type localGetThreadLocalResult = GetThreadLocalRes
 
 type localNewConversationLocalResult = NewConversationLocalRes
@@ -657,6 +677,7 @@ export type rpc =
     localGetConversationForCLILocalRpc
   | localGetInboxLocalRpc
   | localGetInboxSummaryForCLILocalRpc
+  | localGetMessagesLocalRpc
   | localGetThreadLocalRpc
   | localNewConversationLocalRpc
   | localPostLocalRpc


### PR DESCRIPTION
Renders edits and deletes in CLI `read` and `ls`.

- added GetMessagesLocal which is GetMessagesRemote + unboxing
- show `[deleted]` for deleted messages and `new text [edited]` for edits

🎈  @mmaxim @songgao @patrickxb 

Looks like this:
```
$ kbu chat read gil --at-least 7
▶ WARNING Running in devel mode
fetching conversation frank,gil ...

[1]   [gil 23h] [deleted]
[2]   [gil 23h] let's try this again
[3]    [gil 2d] oof
[4]  [frank 3d] [deleted]
[5]    [gil 3d] bandicoot [edited]
[6]  [frank 3d] what's your favorite animal?
[7]    [gil 3d] hi dude
```

The reason for `[deleted]` instead of hiding the message is that showing the last N non-deleted messages is more work, and this way is easy.