### PR TITLE
Change MessageAttachment type, stubs for json api

### DIFF
--- a/go/chat/prev_test.go
+++ b/go/chat/prev_test.go
@@ -18,7 +18,7 @@ func expectCode(t *testing.T, err libkb.ChatThreadConsistencyError, code libkb.C
 		t.Fatalf("Expected an error. Got nil.")
 	}
 	if err.Code() != code {
-		t.Fatalf("Expected a code %d, but found %d.", code, err.Code)
+		t.Fatalf("Expected a code %d, but found %d.", code, err.Code())
 	}
 }
 

--- a/go/client/chat_api_decoder.go
+++ b/go/client/chat_api_decoder.go
@@ -84,6 +84,8 @@ func (d *ChatAPIDecoder) handleV1(ctx context.Context, c Call, w io.Writer) erro
 		return d.handler.EditV1(ctx, c, w)
 	case "delete":
 		return d.handler.DeleteV1(ctx, c, w)
+	case "attach":
+		return d.handler.AttachV1(ctx, c, w)
 	default:
 		return ErrInvalidMethod{name: c.Method, version: 1}
 	}

--- a/go/client/chat_api_test.go
+++ b/go/client/chat_api_test.go
@@ -20,6 +20,7 @@ type handlerTracker struct {
 	sendV1   int
 	editV1   int
 	deleteV1 int
+	attachV1 int
 }
 
 func (h *handlerTracker) ListV1(context.Context, Call, io.Writer) error {
@@ -44,6 +45,11 @@ func (h *handlerTracker) EditV1(context.Context, Call, io.Writer) error {
 
 func (h *handlerTracker) DeleteV1(context.Context, Call, io.Writer) error {
 	h.deleteV1++
+	return nil
+}
+
+func (h *handlerTracker) AttachV1(context.Context, Call, io.Writer) error {
+	h.attachV1++
 	return nil
 }
 
@@ -75,6 +81,10 @@ func (c *chatEcho) EditV1(context.Context, editOptionsV1) Reply {
 	return Reply{Result: echoOK}
 }
 
+func (c *chatEcho) AttachV1(context.Context, attachOptionsV1) Reply {
+	return Reply{Result: echoOK}
+}
+
 type topTest struct {
 	input    string
 	err      error
@@ -83,6 +93,7 @@ type topTest struct {
 	sendV1   int
 	editV1   int
 	deleteV1 int
+	attachV1 int
 }
 
 var topTests = []topTest{
@@ -103,6 +114,7 @@ var topTests = []topTest{
 	{input: `{"method": "list", "params":{"version": 1}}{"method": "read", "params":{"version": 1}}`, listV1: 1, readV1: 1},
 	{input: `{"id": 29, "method": "edit", "params":{"version": 1}}`, editV1: 1},
 	{input: `{"id": 30, "method": "delete", "params":{"version": 1}}`, deleteV1: 1},
+	{input: `{"method": "attach", "params":{"version": 1}}`, attachV1: 1},
 }
 
 // TestChatAPIDecoderTop tests that the "top-level" of the chat json makes it to
@@ -136,6 +148,9 @@ func TestChatAPIDecoderTop(t *testing.T) {
 		}
 		if h.deleteV1 != test.deleteV1 {
 			t.Errorf("test %d: input %s => deleteV1 = %d, expected %d", i, test.input, h.deleteV1, test.deleteV1)
+		}
+		if h.attachV1 != test.attachV1 {
+			t.Errorf("test %d: input %s => attachV1 = %d, expected %d", i, test.input, h.attachV1, test.attachV1)
 		}
 	}
 }

--- a/go/client/cmd_chat_api.go
+++ b/go/client/cmd_chat_api.go
@@ -373,16 +373,7 @@ func (c *CmdChatAPI) EditV1(ctx context.Context, opts editOptionsV1) Reply {
 
 // AttachV1 implements ChatServiceHandler.AttachV1.
 func (c *CmdChatAPI) AttachV1(ctx context.Context, opts attachOptionsV1) Reply {
-	/*
-		arg := sendArgV1{
-			convQuery:  c.getInboxLocalQuery(opts.ConversationID, opts.Channel),
-			body:       chat1.NewMessageBodyWithEdit(chat1.MessageEdit{MessageID: opts.MessageID, Body: opts.Message.Body}),
-			mtype:      chat1.MessageType_EDIT,
-			supersedes: opts.MessageID,
-			response:   "message edited",
-		}
-		return c.sendV1(ctx, arg)
-	*/
+	// TODO: implement
 	return Reply{}
 }
 

--- a/go/client/cmd_chat_api.go
+++ b/go/client/cmd_chat_api.go
@@ -371,6 +371,21 @@ func (c *CmdChatAPI) EditV1(ctx context.Context, opts editOptionsV1) Reply {
 	return c.sendV1(ctx, arg)
 }
 
+// AttachV1 implements ChatServiceHandler.AttachV1.
+func (c *CmdChatAPI) AttachV1(ctx context.Context, opts attachOptionsV1) Reply {
+	/*
+		arg := sendArgV1{
+			convQuery:  c.getInboxLocalQuery(opts.ConversationID, opts.Channel),
+			body:       chat1.NewMessageBodyWithEdit(chat1.MessageEdit{MessageID: opts.MessageID, Body: opts.Message.Body}),
+			mtype:      chat1.MessageType_EDIT,
+			supersedes: opts.MessageID,
+			response:   "message edited",
+		}
+		return c.sendV1(ctx, arg)
+	*/
+	return Reply{}
+}
+
 type sendArgV1 struct {
 	convQuery  chat1.GetInboxLocalQuery
 	body       chat1.MessageBody

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -318,6 +318,7 @@ func (s *LoginState) GetPassphraseStreamStored(ui SecretUI) (pps *PassphraseStre
 			s.G().Log.Debug("| got passphrase stream from secret store")
 			return stream, nil
 		}
+
 		s.G().Log.Debug("| failed to get passphrase stream from secret store: %s", err)
 	}
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -27,16 +27,18 @@ type MessageDelete struct {
 	MessageID MessageID `codec:"messageID" json:"messageID"`
 }
 
+type Asset struct {
+	Path     string `codec:"path" json:"path"`
+	Size     int    `codec:"size" json:"size"`
+	MimeType string `codec:"mimeType" json:"mimeType"`
+	EncHash  Hash   `codec:"encHash" json:"encHash"`
+}
+
 type MessageAttachment struct {
-	Path           string `codec:"path" json:"path"`
-	Size           int    `codec:"size" json:"size"`
-	PreviewPath    string `codec:"previewPath" json:"previewPath"`
-	PreviewSize    int    `codec:"previewSize" json:"previewSize"`
-	MimeType       string `codec:"mimeType" json:"mimeType"`
-	Metadata       []byte `codec:"metadata" json:"metadata"`
-	Key            []byte `codec:"key" json:"key"`
-	AttachmentHash Hash   `codec:"attachmentHash" json:"attachmentHash"`
-	PreviewHash    Hash   `codec:"previewHash" json:"previewHash"`
+	Object   Asset  `codec:"object" json:"object"`
+	Preview  *Asset `codec:"preview,omitempty" json:"preview,omitempty"`
+	Metadata []byte `codec:"metadata" json:"metadata"`
+	Key      []byte `codec:"key" json:"key"`
 }
 
 type MessageBody struct {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -32,13 +32,13 @@ type Asset struct {
 	Size     int    `codec:"size" json:"size"`
 	MimeType string `codec:"mimeType" json:"mimeType"`
 	EncHash  Hash   `codec:"encHash" json:"encHash"`
+	Key      []byte `codec:"key" json:"key"`
 }
 
 type MessageAttachment struct {
 	Object   Asset  `codec:"object" json:"object"`
 	Preview  *Asset `codec:"preview,omitempty" json:"preview,omitempty"`
 	Metadata []byte `codec:"metadata" json:"metadata"`
-	Key      []byte `codec:"key" json:"key"`
 }
 
 type MessageBody struct {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -28,13 +28,15 @@ type MessageDelete struct {
 }
 
 type MessageAttachment struct {
-	Path        string `codec:"path" json:"path"`
-	Size        int    `codec:"size" json:"size"`
-	PreviewPath string `codec:"previewPath" json:"previewPath"`
-	PreviewSize int    `codec:"previewSize" json:"previewSize"`
-	MimeType    string `codec:"mimeType" json:"mimeType"`
-	Metadata    []byte `codec:"metadata" json:"metadata"`
-	Key         []byte `codec:"key" json:"key"`
+	Path           string `codec:"path" json:"path"`
+	Size           int    `codec:"size" json:"size"`
+	PreviewPath    string `codec:"previewPath" json:"previewPath"`
+	PreviewSize    int    `codec:"previewSize" json:"previewSize"`
+	MimeType       string `codec:"mimeType" json:"mimeType"`
+	Metadata       []byte `codec:"metadata" json:"metadata"`
+	Key            []byte `codec:"key" json:"key"`
+	AttachmentHash Hash   `codec:"attachmentHash" json:"attachmentHash"`
+	PreviewHash    Hash   `codec:"previewHash" json:"previewHash"`
 }
 
 type MessageBody struct {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -27,56 +27,14 @@ type MessageDelete struct {
 	MessageID MessageID `codec:"messageID" json:"messageID"`
 }
 
-type MessageAttachmentVersion int
-
-const (
-	MessageAttachmentVersion_V1 MessageAttachmentVersion = 1
-)
-
-var MessageAttachmentVersionMap = map[string]MessageAttachmentVersion{
-	"V1": 1,
-}
-
-var MessageAttachmentVersionRevMap = map[MessageAttachmentVersion]string{
-	1: "V1",
-}
-
-type MessageAttachmentV1 struct {
-	Path string `codec:"path" json:"path"`
-	Key  []byte `codec:"key" json:"key"`
-}
-
 type MessageAttachment struct {
-	Version__ MessageAttachmentVersion `codec:"version" json:"version"`
-	V1__      *MessageAttachmentV1     `codec:"v1,omitempty" json:"v1,omitempty"`
-}
-
-func (o *MessageAttachment) Version() (ret MessageAttachmentVersion, err error) {
-	switch o.Version__ {
-	case MessageAttachmentVersion_V1:
-		if o.V1__ == nil {
-			err = errors.New("unexpected nil value for V1__")
-			return ret, err
-		}
-	}
-	return o.Version__, nil
-}
-
-func (o MessageAttachment) V1() MessageAttachmentV1 {
-	if o.Version__ != MessageAttachmentVersion_V1 {
-		panic("wrong case accessed")
-	}
-	if o.V1__ == nil {
-		return MessageAttachmentV1{}
-	}
-	return *o.V1__
-}
-
-func NewMessageAttachmentWithV1(v MessageAttachmentV1) MessageAttachment {
-	return MessageAttachment{
-		Version__: MessageAttachmentVersion_V1,
-		V1__:      &v,
-	}
+	Path        string `codec:"path" json:"path"`
+	Size        int    `codec:"size" json:"size"`
+	PreviewPath string `codec:"previewPath" json:"previewPath"`
+	PreviewSize int    `codec:"previewSize" json:"previewSize"`
+	MimeType    string `codec:"mimeType" json:"mimeType"`
+	Metadata    []byte `codec:"metadata" json:"metadata"`
+	Key         []byte `codec:"key" json:"key"`
 }
 
 type MessageBody struct {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -21,16 +21,18 @@ protocol local {
     MessageID messageID;
   }
 
+  record Asset {
+    string path;               // path to the object in storage
+    int size;                  // size of the object
+    string mimeType;           // mime type of the object
+    Hash encHash;              // hash of ciphertext object 
+  }
+
   record MessageAttachment {
-    string path;               // path to the attachment object
-    int size;                  // size of the attachment object (bytes)
-    string previewPath;        // path to the preview object (optional)
-    int previewSize;           // size of the preview object (required if previewPath set)
-    string mimeType;           // mime type of the attachment
-    bytes metadata;            // generic metadata (msgpack)
-    bytes key;                 // encryption key
-    Hash attachmentHash;       // hash on attachment object 
-    Hash previewHash;	       // hash on preview object
+    Asset object;                // the primary attachment object
+    union {null, Asset} preview; // the (optional) preview of object
+    bytes metadata;              // generic metadata (msgpack)
+    bytes key;                   // encryption key
   }
 
   variant MessageBody switch (MessageType messageType) {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -29,6 +29,8 @@ protocol local {
     string mimeType;           // mime type of the attachment
     bytes metadata;            // generic metadata (msgpack)
     bytes key;                 // encryption key
+    Hash attachmentHash;       // hash on attachment object 
+    Hash previewHash;	       // hash on preview object
   }
 
   variant MessageBody switch (MessageType messageType) {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -21,22 +21,14 @@ protocol local {
     MessageID messageID;
   }
 
-  enum MessageAttachmentVersion {
-    V1_1
-  }
-
-  // MessageAttachmentV1 is version 1 of MessageAttachment.
-  // This record is immutable.  To modify, create a new
-  // record type with a new version.
-  record MessageAttachmentV1 {
-    string path;         // path to the attachment object
-    bytes key;           // encryption key
-  }
-
-  // MessageAttachment is a variant container for all the versions
-  // of MessageAttachment.
-  variant MessageAttachment switch (MessageAttachmentVersion version ) {
-    case V1: MessageAttachmentV1;   
+  record MessageAttachment {
+    string path;               // path to the attachment object
+    int size;                  // size of the attachment object (bytes)
+    string previewPath;        // path to the preview object (optional)
+    int previewSize;           // size of the preview object (required if previewPath set)
+    string mimeType;           // mime type of the attachment
+    bytes metadata;            // generic metadata (msgpack)
+    bytes key;                 // encryption key
   }
 
   variant MessageBody switch (MessageType messageType) {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -26,13 +26,13 @@ protocol local {
     int size;                  // size of the object
     string mimeType;           // mime type of the object
     Hash encHash;              // hash of ciphertext object 
+    bytes key;                 // encryption key
   }
 
   record MessageAttachment {
     Asset object;                // the primary attachment object
     union {null, Asset} preview; // the (optional) preview of object
     bytes metadata;              // generic metadata (msgpack)
-    bytes key;                   // encryption key
   }
 
   variant MessageBody switch (MessageType messageType) {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -66,10 +66,6 @@ export const LocalHeaderPlaintextVersion = {
   v1: 1,
 }
 
-export const LocalMessageAttachmentVersion = {
-  v1: 1,
-}
-
 export const LocalMessagePlaintextVersion = {
   v1: 1,
 }
@@ -388,16 +384,15 @@ export type MarkAsReadRes = {
   rateLimit?: ?RateLimit,
 }
 
-export type MessageAttachment = 
-    { version : 1, v1 : ?MessageAttachmentV1 }
-
-export type MessageAttachmentV1 = {
+export type MessageAttachment = {
   path: string,
+  size: int,
+  previewPath: string,
+  previewSize: int,
+  mimeType: string,
+  metadata: bytes,
   key: bytes,
 }
-
-export type MessageAttachmentVersion = 
-    1 // V1_1
 
 export type MessageBody = 
     { messageType : 1, text : ?MessageText }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -195,6 +195,7 @@ export type Asset = {
   size: int,
   mimeType: string,
   encHash: Hash,
+  key: bytes,
 }
 
 export type BodyPlaintext = 
@@ -395,7 +396,6 @@ export type MessageAttachment = {
   object: Asset,
   preview?: ?Asset,
   metadata: bytes,
-  key: bytes,
 }
 
 export type MessageBody = 

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -392,6 +392,8 @@ export type MessageAttachment = {
   mimeType: string,
   metadata: bytes,
   key: bytes,
+  attachmentHash: Hash,
+  previewHash: Hash,
 }
 
 export type MessageBody = 

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -190,6 +190,13 @@ export function remoteTlfFinalizeRpcPromise (request: $Exact<requestCommon & req
   return new Promise((resolve, reject) => { remoteTlfFinalizeRpc({...request, param: request.param, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export type Asset = {
+  path: string,
+  size: int,
+  mimeType: string,
+  encHash: Hash,
+}
+
 export type BodyPlaintext = 
     { version : 1, v1 : ?BodyPlaintextV1 }
 
@@ -385,15 +392,10 @@ export type MarkAsReadRes = {
 }
 
 export type MessageAttachment = {
-  path: string,
-  size: int,
-  previewPath: string,
-  previewSize: int,
-  mimeType: string,
+  object: Asset,
+  preview?: ?Asset,
   metadata: bytes,
   key: bytes,
-  attachmentHash: Hash,
-  previewHash: Hash,
 }
 
 export type MessageBody = 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -75,6 +75,10 @@
         {
           "type": "Hash",
           "name": "encHash"
+        },
+        {
+          "type": "bytes",
+          "name": "key"
         }
       ]
     },
@@ -96,10 +100,6 @@
         {
           "type": "bytes",
           "name": "metadata"
-        },
-        {
-          "type": "bytes",
-          "name": "key"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -57,40 +57,36 @@
       ]
     },
     {
-      "type": "enum",
-      "name": "MessageAttachmentVersion",
-      "symbols": [
-        "V1_1"
-      ]
-    },
-    {
       "type": "record",
-      "name": "MessageAttachmentV1",
+      "name": "MessageAttachment",
       "fields": [
         {
           "type": "string",
           "name": "path"
         },
         {
+          "type": "int",
+          "name": "size"
+        },
+        {
+          "type": "string",
+          "name": "previewPath"
+        },
+        {
+          "type": "int",
+          "name": "previewSize"
+        },
+        {
+          "type": "string",
+          "name": "mimeType"
+        },
+        {
+          "type": "bytes",
+          "name": "metadata"
+        },
+        {
           "type": "bytes",
           "name": "key"
-        }
-      ]
-    },
-    {
-      "type": "variant",
-      "name": "MessageAttachment",
-      "switch": {
-        "type": "MessageAttachmentVersion",
-        "name": "version"
-      },
-      "cases": [
-        {
-          "label": {
-            "name": "V1",
-            "def": false
-          },
-          "body": "MessageAttachmentV1"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -58,7 +58,7 @@
     },
     {
       "type": "record",
-      "name": "MessageAttachment",
+      "name": "Asset",
       "fields": [
         {
           "type": "string",
@@ -70,15 +70,28 @@
         },
         {
           "type": "string",
-          "name": "previewPath"
-        },
-        {
-          "type": "int",
-          "name": "previewSize"
-        },
-        {
-          "type": "string",
           "name": "mimeType"
+        },
+        {
+          "type": "Hash",
+          "name": "encHash"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "MessageAttachment",
+      "fields": [
+        {
+          "type": "Asset",
+          "name": "object"
+        },
+        {
+          "type": [
+            null,
+            "Asset"
+          ],
+          "name": "preview"
         },
         {
           "type": "bytes",
@@ -87,14 +100,6 @@
         {
           "type": "bytes",
           "name": "key"
-        },
-        {
-          "type": "Hash",
-          "name": "attachmentHash"
-        },
-        {
-          "type": "Hash",
-          "name": "previewHash"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -87,6 +87,14 @@
         {
           "type": "bytes",
           "name": "key"
+        },
+        {
+          "type": "Hash",
+          "name": "attachmentHash"
+        },
+        {
+          "type": "Hash",
+          "name": "previewHash"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -66,10 +66,6 @@ export const LocalHeaderPlaintextVersion = {
   v1: 1,
 }
 
-export const LocalMessageAttachmentVersion = {
-  v1: 1,
-}
-
 export const LocalMessagePlaintextVersion = {
   v1: 1,
 }
@@ -388,16 +384,15 @@ export type MarkAsReadRes = {
   rateLimit?: ?RateLimit,
 }
 
-export type MessageAttachment = 
-    { version : 1, v1 : ?MessageAttachmentV1 }
-
-export type MessageAttachmentV1 = {
+export type MessageAttachment = {
   path: string,
+  size: int,
+  previewPath: string,
+  previewSize: int,
+  mimeType: string,
+  metadata: bytes,
   key: bytes,
 }
-
-export type MessageAttachmentVersion = 
-    1 // V1_1
 
 export type MessageBody = 
     { messageType : 1, text : ?MessageText }

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -195,6 +195,7 @@ export type Asset = {
   size: int,
   mimeType: string,
   encHash: Hash,
+  key: bytes,
 }
 
 export type BodyPlaintext = 
@@ -395,7 +396,6 @@ export type MessageAttachment = {
   object: Asset,
   preview?: ?Asset,
   metadata: bytes,
-  key: bytes,
 }
 
 export type MessageBody = 

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -392,6 +392,8 @@ export type MessageAttachment = {
   mimeType: string,
   metadata: bytes,
   key: bytes,
+  attachmentHash: Hash,
+  previewHash: Hash,
 }
 
 export type MessageBody = 

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -190,6 +190,13 @@ export function remoteTlfFinalizeRpcPromise (request: $Exact<requestCommon & req
   return new Promise((resolve, reject) => { remoteTlfFinalizeRpc({...request, param: request.param, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export type Asset = {
+  path: string,
+  size: int,
+  mimeType: string,
+  encHash: Hash,
+}
+
 export type BodyPlaintext = 
     { version : 1, v1 : ?BodyPlaintextV1 }
 
@@ -385,15 +392,10 @@ export type MarkAsReadRes = {
 }
 
 export type MessageAttachment = {
-  path: string,
-  size: int,
-  previewPath: string,
-  previewSize: int,
-  mimeType: string,
+  object: Asset,
+  preview?: ?Asset,
   metadata: bytes,
   key: bytes,
-  attachmentHash: Hash,
-  previewHash: Hash,
 }
 
 export type MessageBody = 


### PR DESCRIPTION
I meant for this to just have the change in chat_local.avdl to MessageAttachment, but some more stuff snuck in too, which is in progress work on integrating attachments into `keybase chat api`.

Also had to do some lint cleanup to commit.

I'll add some comments.