### PR TITLE
Skip moving update.json into place when smoketesting

### DIFF
--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -273,7 +273,9 @@ save() {(
   mv "$out_dir/$sourcemap_name" "$save_dir/electron-sourcemaps"
   # Support files
   mkdir -p "$platform_dir-support"
-  mv "$out_dir/$update_json_name" "$platform_dir-support"
+  if [ ! "$skip_update_json" = "1" ]; then
+    mv "$out_dir/$update_json_name" "$platform_dir-support"
+  fi
 )}
 
 s3sync() {


### PR DESCRIPTION
r? @gabriel 

Should fix:
```
Saving files to /tmp/build_desktop/darwin
mv: rename /tmp/package_darwin/build/Keybase-darwin-x64/update-darwin-prod-1.0.17-20161007010711+61672fe.json to /tmp/build_desktop/darwin-support/update-darwin-prod-1.0.17-20161007010711+61672fe.json: No such file or directory
```