### PR TITLE
Ignore gregorUI.pushOutOfBandMessages in electron

### DIFF
--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -70,6 +70,8 @@ class Engine {
 
   _setupIgnoredHandlers () {
     this.setIncomingHandler('keybase.1.NotifyTracking.trackingChanged', () => {})
+    // TODO handle these out of band messages from gregor
+    this.setIncomingHandler('keybase.1.gregorUI.pushOutOfBandMessages', () => {})
   }
 
   // Called when we reconnect to the server


### PR DESCRIPTION
This ignores `keybase.1.gregorUI.pushOutOfBandMessages` that come from the service going to electron.

The problem being addressed here is that if you did `chat send` you'd see an error even though everyone works.
```
$ kbu chat send banana6@twitter
▶ WARNING Running in devel mode
▶ ERROR Error in firehose push out-of-band messages: Unhandled incoming RPC undefined keybase.1.gregorUI.pushOutOfBandMessages
```
Because an `OutOfBandMessage` from gregor of type `kbfs.favorites` would hit the service. And the service "firehose" would try to forward all OOBMs to electron. But electron didn't know about those. So now electron knows to ignore those for now.

r? @keybase/react-hackers 

Also, @mmaxim does this meet your expectations as far as what's hooked up so far?