### PR TITLE
Don't need focus on show

### DIFF
--- a/desktop/app/index.js
+++ b/desktop/app/index.js
@@ -23,7 +23,6 @@ function start () {
   const shouldQuit = app.makeSingleInstance(() => {
     if (mainWindow) {
       mainWindow.show(true)
-      mainWindow.window.focus()
     }
   })
 

--- a/desktop/app/window.js
+++ b/desktop/app/window.js
@@ -2,8 +2,6 @@
 import {showDockIcon} from './dock-icon'
 import menuHelper from './menu-helper'
 import {ipcMain, BrowserWindow} from 'electron'
-// $FlowIssue
-import {focusOnShow} from '../shared/local-debug'
 
 export default class Window {
   filename: string;
@@ -82,9 +80,6 @@ export default class Window {
     if (this.window) {
       if (!this.window.isVisible()) {
         this.window.show()
-      }
-      if (!this.window.isFocused() && focusOnShow) {
-        this.window.focus()
       }
       return
     } else {

--- a/shared/local-debug.desktop.js
+++ b/shared/local-debug.desktop.js
@@ -21,7 +21,6 @@ let config: {[key:string]: any} = {
   printOutstandingRPCs: false,
   reactPerf: false,
   overrideLoggedInTab: null,
-  focusOnShow: true,
   printRoutes: false,
   skipSecondaryDevtools: true,
   initialTabState: {},
@@ -48,7 +47,6 @@ if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) {
   config.printOutstandingRPCs = true
   config.reactPerf = false
   config.overrideLoggedInTab = Tabs.settingsTab
-  config.focusOnShow = false
   config.printRoutes = true
   config.initialTabState = {
     [Tabs.loginTab]: [],
@@ -70,7 +68,6 @@ export const {
   devStoreChangingFunctions,
   enableActionLogging,
   enableStoreLogging,
-  focusOnShow,
   forceMainWindowPosition,
   forwardLogs,
   isTesting,


### PR DESCRIPTION
This messes with the ability to start app in background, and it's not required. When main window is shown it gets focus by default.
