### PR TITLE
Android KeyStore: Throw exceptions for missing keys

### DIFF
--- a/react-native/android/app/src/main/java/io/keybase/ossifrage/KeyStore.java
+++ b/react-native/android/app/src/main/java/io/keybase/ossifrage/KeyStore.java
@@ -86,15 +86,11 @@ public class KeyStore implements ExternalKeyStore {
         try {
             entry = ks.getEntry(keyStoreAlias(serviceName), null);
         } catch (Exception e) {
-            return null;
-        }
-
-        if (wrappedSecret == null) {
-            return null;
+            throw new KeyStoreException("Failed to get the RSA keys from the keystore");
         }
 
         if (!(entry instanceof PrivateKeyEntry)){
-            return null;
+            throw new KeyStoreException("No RSA keys in the keystore");
         }
 
         return unwrapSecret((PrivateKeyEntry) entry, wrappedSecret).getEncoded();
@@ -151,10 +147,10 @@ public class KeyStore implements ExternalKeyStore {
     }
 
 
-    private static byte[] readWrappedSecret(SharedPreferences prefs, String prefsKey) {
+    private static byte[] readWrappedSecret(SharedPreferences prefs, String prefsKey) throws Exception {
         final String wrappedKey = prefs.getString(prefsKey,"");
         if (wrappedKey.isEmpty()) {
-            return null;
+            throw new KeyStoreException("No secret for " + prefsKey);
         }
         return Base64.decode(wrappedKey, Base64.NO_WRAP);
     }


### PR DESCRIPTION
Android was returning null secrets when they were missing instead of raising an exception (like the other implementations do). This would cause callers that expected non-failure to be a real secret to fail when they tried to decode null secrets.

:eyeglasses: @keybase/react-hackers 