### PR TITLE
GetPassphraseStreamStored: Fall back if stored data invalid

### DIFF
--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -283,6 +283,23 @@ func (s *LoginState) GetPassphraseStreamWithPassphrase(passphrase string) (pps *
 	return nil, err
 }
 
+func (s *LoginState) getStoredPassphraseStream(username NormalizedUsername) (pps *PassphraseStream, err error) {
+	secret, err := s.G().SecretStoreAll.RetrieveSecret(s.G().Env.GetUsername())
+	if err != nil {
+		return pps, err
+	}
+	lks := NewLKSecWithFullSecret(secret, s.G().Env.GetUID(), s.G())
+	if err = lks.LoadServerHalf(nil); err != nil {
+		return pps, err
+	}
+	stream, err := NewPassphraseStreamLKSecOnly(secret)
+	if err != nil {
+		return pps, err
+	}
+	stream.SetGeneration(lks.Generation())
+	return stream, nil
+}
+
 // GetPassphraseStreamStored either returns a cached, verified passphrase
 // stream from a previous login, the secret store, or generates a new one via
 // login.
@@ -304,19 +321,10 @@ func (s *LoginState) GetPassphraseStreamStored(ui SecretUI) (pps *PassphraseStre
 	// 2. try from secret store
 	if s.G().SecretStoreAll != nil {
 		s.G().Log.Debug("| trying to get passphrase stream from secret store")
-		secret, err := s.G().SecretStoreAll.RetrieveSecret(s.G().Env.GetUsername())
+		pps, err = s.getStoredPassphraseStream(s.G().Env.GetUsername())
 		if err == nil {
-			lks := NewLKSecWithFullSecret(secret, s.G().Env.GetUID(), s.G())
-			if err = lks.LoadServerHalf(nil); err != nil {
-				return pps, err
-			}
-			stream, err := NewPassphraseStreamLKSecOnly(secret)
-			if err != nil {
-				return pps, err
-			}
-			stream.SetGeneration(lks.Generation())
 			s.G().Log.Debug("| got passphrase stream from secret store")
-			return stream, nil
+			return pps, nil
 		}
 
 		s.G().Log.Debug("| failed to get passphrase stream from secret store: %s", err)

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -283,18 +283,18 @@ func (s *LoginState) GetPassphraseStreamWithPassphrase(passphrase string) (pps *
 	return nil, err
 }
 
-func (s *LoginState) getStoredPassphraseStream(username NormalizedUsername) (pps *PassphraseStream, err error) {
+func (s *LoginState) getStoredPassphraseStream(username NormalizedUsername) (*PassphraseStream, error) {
 	secret, err := s.G().SecretStoreAll.RetrieveSecret(s.G().Env.GetUsername())
 	if err != nil {
-		return pps, err
+		return nil, err
 	}
 	lks := NewLKSecWithFullSecret(secret, s.G().Env.GetUID(), s.G())
 	if err = lks.LoadServerHalf(nil); err != nil {
-		return pps, err
+		return nil, err
 	}
 	stream, err := NewPassphraseStreamLKSecOnly(secret)
 	if err != nil {
-		return pps, err
+		return nil, err
 	}
 	stream.SetGeneration(lks.Generation())
 	return stream, nil


### PR DESCRIPTION
While fixing up the Android secret store I discovered a case where the stored secret data was invalid, causing the LKSec step to return an error which was propagated up, breaking the flow. We should fall back to user entry in these cases instead of halting. As an added bonus, it's possible that if the secret store was corrupt (or we introduced reading code that was not backwards compatible), replacing the stored value when the user enters their passphrase could fix the problem. 

:eyeglasses: @keybase/react-hackers @patrickxb 