### PR TITLE
Fix Android secret store initialization

### DIFF
--- a/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -31,14 +31,14 @@ public class MainActivity extends ReactActivity {
     @Override
     @TargetApi(Build.VERSION_CODES.KITKAT)
     protected void onCreate(Bundle savedInstanceState) {
-        logFile = this.getFileStreamPath("android.log");
-        initOnce(this.getFilesDir().getPath(), logFile.getAbsolutePath(), "staging", false);
-
         try {
             Keybase.setGlobalExternalKeyStore(new KeyStore(this, getSharedPreferences("KeyStore", MODE_PRIVATE)));
         } catch (KeyStoreException | CertificateException | IOException | NoSuchAlgorithmException e) {
             e.printStackTrace();
         }
+
+        logFile = this.getFileStreamPath("android.log");
+        initOnce(this.getFilesDir().getPath(), logFile.getAbsolutePath(), "staging", false);
 
         super.onCreate(savedInstanceState);
     }


### PR DESCRIPTION
We were setting the KeyStore implementation after the Go code went to look for it.

:eyeglasses: @keybase/react-hackers 