### PR TITLE
Handle Gregor out of band messages. Clear new tag on opened folders

### DIFF
--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -4,17 +4,16 @@ import _ from 'lodash'
 import {NotifyPopup} from '../native/notifications'
 import {apiserverGetRpcPromise, favoriteFavoriteAddRpcPromise, favoriteFavoriteIgnoreRpcPromise} from '../constants/types/flow-types'
 import {badgeApp} from './notifications'
-import {parseFolderNameToUsers, sortUserList} from '../util/kbfs'
 import {navigateBack} from '../actions/router'
 import {call, put, select} from 'redux-saga/effects'
 import {takeLatest, takeEvery} from 'redux-saga'
 
 import type {Action} from '../constants/types/flux'
-import type {FavoriteAdd, FavoriteAdded, FavoriteList, FavoriteListed, FavoriteIgnore, FavoriteIgnored, FolderState, FavoriteSwitchTab, FavoriteToggleIgnored, FolderWithMeta, MarkTLFCreated} from '../constants/favorite'
-import type {Folder as FoldersFolder, MetaType} from '../constants/folders'
+import type {FavoriteAdd, FavoriteAdded, FavoriteList, FavoriteListed, FavoriteIgnore, FavoriteIgnored, FolderState, FavoriteSwitchTab, FavoriteToggleIgnored, MarkTLFCreated} from '../constants/favorite'
+import type {FolderRPCWithMeta} from '../constants/folders'
 import type {SagaGenerator} from '../constants/types/saga'
 
-const {pathFromFolder, folderFromPath} = Constants
+const {folderFromFolderRPCWithMeta, folderRPCFromPath} = Constants
 
 function switchTab (showingPrivate: boolean): FavoriteSwitchTab {
   return {type: Constants.favoriteSwitchTab, payload: {showingPrivate}, error: false}
@@ -43,7 +42,7 @@ function markTLFCreated (folder: any): MarkTLFCreated {
 
 const injectMeta = type => f => { f.meta = type }
 
-const _jsonToFolders = (json: Object, myKID: any): Array<FolderWithMeta> => {
+const _jsonToFolders = (json: Object, myKID: any): Array<FolderRPCWithMeta> => {
   const folderSets = [json.favorites, json.ignored, json.new]
   const fillFolder = folder => {
     folder.waitingForParticipantUnlock = []
@@ -97,40 +96,12 @@ function _folderSort (username, a, b) {
 }
 
 function _folderToState (txt: string = '', username: string, loggedIn: boolean): FolderState {
-  const folders: Array<FolderWithMeta> = _getFavoritesRPCToFolders(txt, username, loggedIn)
-  let privateBadge = 0
-  let publicBadge = 0
+  const folders: Array<FolderRPCWithMeta> = _getFavoritesRPCToFolders(txt, username, loggedIn)
 
-  const converted: Array<FoldersFolder & {sortName: string}> = folders.map(f => {
-    const users = sortUserList(parseFolderNameToUsers(username, f.name))
+  const converted = folders.map(f => folderFromFolderRPCWithMeta(username, f)).sort((a, b) => _folderSort(username, a, b))
 
-    const {sortName, path} = pathFromFolder({users, isPublic: !f.private})
-    const groupAvatar = f.private ? (users.length > 2) : (users.length > 1)
-    const userAvatar = groupAvatar ? null : users[users.length - 1].username
-    const meta: MetaType = f.meta
-    if (meta === 'new') {
-      if (f.private) {
-        privateBadge++
-      } else {
-        publicBadge++
-      }
-    }
-    const ignored = f.meta === 'ignored'
-    return {
-      path,
-      users,
-      sortName,
-      hasData: false, // TODO don't have this info
-      isPublic: !f.private,
-      groupAvatar,
-      userAvatar,
-      ignored,
-      meta,
-      recentFiles: [],
-      waitingForParticipantUnlock: f.waitingForParticipantUnlock,
-      youCanUnlock: f.youCanUnlock,
-    }
-  }).sort((a, b) => _folderSort(username, a, b))
+  const privateBadge = converted.reduce((acc, f) => !f.isPublic ? acc + 1 : acc, 0)
+  const publicBadge = converted.reduce((acc, f) => f.isPublic ? acc + 1 : acc, 0)
 
   const [priFolders, pubFolders] = _.partition(converted, {isPublic: false})
   const [privIgnored, priv] = _.partition(priFolders, {ignored: true})
@@ -151,7 +122,7 @@ function _folderToState (txt: string = '', username: string, loggedIn: boolean):
   }
 }
 
-function _getFavoritesRPCToFolders (txt: string, username: string = '', loggedIn: boolean): Array<FolderWithMeta> {
+function _getFavoritesRPCToFolders (txt: string, username: string = '', loggedIn: boolean): Array<FolderRPCWithMeta> {
   let json
   try {
     json = JSON.parse(txt)
@@ -168,7 +139,7 @@ function _getFavoritesRPCToFolders (txt: string, username: string = '', loggedIn
   json.new && json.new.forEach(injectMeta('new'))
 
   // figure out who can solve the rekey
-  const folders: Array<FolderWithMeta> = _jsonToFolders(json, myKID)
+  const folders: Array<FolderRPCWithMeta> = _jsonToFolders(json, myKID)
 
   // Ensure private/public folders exist for us
   if (username && loggedIn) {
@@ -197,7 +168,7 @@ function _getFavoritesRPCToFolders (txt: string, username: string = '', loggedIn
 }
 
 function * _addSaga (action: FavoriteAdd): SagaGenerator<any, any> {
-  const folder = folderFromPath(action.payload.path)
+  const folder = folderRPCFromPath(action.payload.path)
   if (!folder) {
     const action: FavoriteAdded = {type: Constants.favoriteAdded, error: true, payload: {errorText: 'No folder specified'}}
     yield put(action)
@@ -216,7 +187,7 @@ function * _addSaga (action: FavoriteAdd): SagaGenerator<any, any> {
 }
 
 function * _ignoreSaga (action: FavoriteAdd): SagaGenerator<any, any> {
-  const folder = folderFromPath(action.payload.path)
+  const folder = folderRPCFromPath(action.payload.path)
   if (!folder) {
     const action: FavoriteIgnored = {type: Constants.favoriteIgnored, error: true, payload: {errorText: 'No folder specified'}}
     yield put(action)

--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -10,7 +10,7 @@ import {call, put, select} from 'redux-saga/effects'
 import {takeLatest, takeEvery} from 'redux-saga'
 
 import type {Action} from '../constants/types/flux'
-import type {FavoriteAdd, FavoriteAdded, FavoriteList, FavoriteListed, FavoriteIgnore, FavoriteIgnored, FolderState, FavoriteSwitchTab, FavoriteToggleIgnored, FolderWithMeta} from '../constants/favorite'
+import type {FavoriteAdd, FavoriteAdded, FavoriteList, FavoriteListed, FavoriteIgnore, FavoriteIgnored, FolderState, FavoriteSwitchTab, FavoriteToggleIgnored, FolderWithMeta, MarkTLFCreated} from '../constants/favorite'
 import type {Folder as FoldersFolder, MetaType} from '../constants/folders'
 import type {SagaGenerator} from '../constants/types/saga'
 
@@ -34,6 +34,11 @@ function favoriteFolder (path: string): FavoriteAdd {
 
 function ignoreFolder (path: string): FavoriteIgnore {
   return {type: Constants.favoriteIgnore, payload: {path}}
+}
+
+// TODO(mm) type properly
+function markTLFCreated (folder: any): MarkTLFCreated {
+  return {type: Constants.markTLFCreated, payload: {folder}}
 }
 
 const injectMeta = type => f => { f.meta = type }
@@ -294,11 +299,12 @@ function * favoriteSaga (): SagaGenerator<any, any> {
 }
 
 export {
-  favoriteList,
-  toggleShowIgnored,
-  switchTab,
   favoriteFolder,
+  favoriteList,
   ignoreFolder,
+  markTLFCreated,
+  switchTab,
+  toggleShowIgnored,
 }
 
 export default favoriteSaga

--- a/shared/actions/gregor.js
+++ b/shared/actions/gregor.js
@@ -1,21 +1,26 @@
 // @flow
 
 import * as Constants from '../constants/gregor'
+import {canonicalizeTLF, folderFromPath} from '../constants/favorite.js'
 import {call, put, select} from 'redux-saga/effects'
 import {takeEvery} from 'redux-saga'
-import {favoriteList} from './favorite'
+import {favoriteList, markTLFCreated} from './favorite'
 import engine from '../engine'
 import {delegateUiCtlRegisterGregorFirehoseRpc} from '../constants/types/flow-types'
 
-import type {PushState, UpdateSeenMsgs, MsgMap, NonNullGregorItem} from '../constants/gregor'
+import type {PushState, PushOOBM, UpdateSeenMsgs, MsgMap, NonNullGregorItem} from '../constants/gregor'
 import type {Dispatch} from '../constants/types/flux'
 import type {PushReason} from '../constants/types/flow-types'
-import type {State as GregorState, ItemAndMetadata as GregorItem} from '../constants/types/flow-types-gregor'
+import type {State as GregorState, ItemAndMetadata as GregorItem, OutOfBandMessage} from '../constants/types/flow-types-gregor'
 import type {SagaGenerator} from '../constants/types/saga'
 import type {TypedState} from '../constants/reducer'
 
 function pushState (state: GregorState, reason: PushReason): PushState {
   return {type: Constants.pushState, payload: {state, reason}}
+}
+
+function pushOOBM (messages: Array<OutOfBandMessage>): PushOOBM {
+  return {type: Constants.pushOOBM, payload: {messages}}
 }
 
 function updateSeenMsgs (seenMsgs: Array<NonNullGregorItem>): UpdateSeenMsgs {
@@ -52,6 +57,14 @@ function registerGregorListeners () {
       dispatch(pushState(state, reason))
       response && response.result()
     })
+
+    engine().setIncomingHandler('keybase.1.gregorUI.pushOutOfBandMessages', ({oobm}, response) => {
+      if (oobm) {
+        const filteredOOBM = oobm.filter(oobm => !!oobm)
+        dispatch(pushOOBM(filteredOOBM))
+      }
+      response && response.result()
+    })
   }
 }
 
@@ -84,8 +97,36 @@ function * handlePushState (pushAction: PushState): SagaGenerator<any, any> {
   }
 }
 
+function * handleKbfsFavoritesOOBM (kbfsFavoriteMessages: Array<OutOfBandMessage>) {
+  const msgsWithParsedBodies = kbfsFavoriteMessages.map(m => ({...m, body: JSON.parse(m.body.toString())}))
+  const createdTLFs = msgsWithParsedBodies.filter(m => m.body.action === 'create')
+
+  yield createdTLFs.map(m => {
+    const folder = m.body.tlf ? markTLFCreated(pathFromFolder(canonicalizeTLF(m.body.tlf))) : null
+    if (folder != null) {
+      return put(folder)
+    }
+    console.warn('Failed to parse tlf for oobm:', m)
+  }).filter(i => !!i)
+}
+
+function * handlePushOOBM (pushOOBM: pushOOBM) {
+  if (!pushOOBM.error) {
+    const {payload: {messages}} = pushOOBM
+
+    yield [
+      call(handleKbfsFavoritesOOBM, messages.filter(i => i.system === 'kbfs.favorites')),
+    ]
+  } else {
+    console.log('Error in gregor oobm', pushOOBM.payload)
+  }
+}
+
 function * gregorSaga (): SagaGenerator<any, any> {
-  yield takeEvery(Constants.pushState, handlePushState)
+  yield [
+    takeEvery(Constants.pushState, handlePushState),
+    takeEvery(Constants.pushOOBM, handlePushOOBM),
+  ]
 }
 
 export {

--- a/shared/actions/gregor.js
+++ b/shared/actions/gregor.js
@@ -1,7 +1,8 @@
 // @flow
 
 import * as Constants from '../constants/gregor'
-import {canonicalizeTLF, folderFromPath} from '../constants/favorite.js'
+import {usernameSelector} from '../constants/selectors'
+import {folderFromPath} from '../constants/favorite.js'
 import {call, put, select} from 'redux-saga/effects'
 import {takeEvery} from 'redux-saga'
 import {favoriteList, markTLFCreated} from './favorite'
@@ -101,8 +102,9 @@ function * handleKbfsFavoritesOOBM (kbfsFavoriteMessages: Array<OutOfBandMessage
   const msgsWithParsedBodies = kbfsFavoriteMessages.map(m => ({...m, body: JSON.parse(m.body.toString())}))
   const createdTLFs = msgsWithParsedBodies.filter(m => m.body.action === 'create')
 
+  const username: string = ((yield select(usernameSelector)): any)
   yield createdTLFs.map(m => {
-    const folder = m.body.tlf ? markTLFCreated(pathFromFolder(canonicalizeTLF(m.body.tlf))) : null
+    const folder = m.body.tlf ? markTLFCreated(folderFromPath(username, m.body.tlf)) : null
     if (folder != null) {
       return put(folder)
     }

--- a/shared/actions/gregor.js
+++ b/shared/actions/gregor.js
@@ -60,9 +60,11 @@ function registerGregorListeners () {
     })
 
     engine().setIncomingHandler('keybase.1.gregorUI.pushOutOfBandMessages', ({oobm}, response) => {
-      if (oobm) {
+      if (oobm && oobm.length) {
         const filteredOOBM = oobm.filter(oobm => !!oobm)
-        dispatch(pushOOBM(filteredOOBM))
+        if (filteredOOBM.length) {
+          dispatch(pushOOBM(filteredOOBM))
+        }
       }
       response && response.result()
     })

--- a/shared/constants/favorite.js
+++ b/shared/constants/favorite.js
@@ -1,9 +1,10 @@
 // @flow
 import {defaultKBFSPath} from './config'
 
+import {parseFolderNameToUsers, sortUserList} from '../util/kbfs'
 import type {Exact} from '../constants/types/more'
 import type {Folder as FolderRPC} from '../constants/types/flow-types'
-import type {Folder, ParticipantUnlock, Device, MetaType} from './folders'
+import type {Folder, MetaType, FolderRPCWithMeta} from './folders'
 import type {TypedAction, NoErrorTypedAction} from './types/flux'
 import type {UserList} from '../common-adapters/usernames'
 
@@ -59,7 +60,7 @@ export const favoriteToggleIgnored = 'favorite:favoriteToggleIgnored'
 export type FavoriteToggleIgnored = TypedAction<'favorite:favoriteToggleIgnored', {isPrivate: boolean}, void>
 
 export const markTLFCreated = 'favorite:markTLFCreated'
-export type MarkTLFCreated = TypedAction<'favorite:markTLFCreated', {folder: FolderRPC}, void>
+export type MarkTLFCreated = TypedAction<'favorite:markTLFCreated', {folder: Folder}, void>
 
 export type FavoriteAction = FavoriteAdd | FavoriteAdded | FavoriteList | FavoriteListed | FavoriteIgnore | FavoriteIgnored | FavoriteSwitchTab | FavoriteToggleIgnored
 
@@ -71,7 +72,7 @@ function canonicalizeTLF (tlf: string): string {
   return tlf
 }
 
-function pathFromFolder ({isPublic, users}: {isPublic: boolean, users: UserList}) {
+function pathFromFolder ({isPublic, users}: {isPublic: boolean, users: UserList}): {sortName: string, path: string} {
   const rwers = users.filter(u => !u.readOnly).map(u => u.username)
   const readers = users.filter(u => !!u.readOnly).map(u => u.username)
   const sortName = rwers.join(',') + (readers.length ? `#${readers.join(',')}` : '')
@@ -79,13 +80,7 @@ function pathFromFolder ({isPublic, users}: {isPublic: boolean, users: UserList}
   return {sortName, path}
 }
 
-export type FolderWithMeta = {
-  meta: MetaType,
-  waitingForParticipantUnlock: Array<ParticipantUnlock>,
-  youCanUnlock: Array<Device>,
-} & FolderRPC
-
-function folderFromPath (path: string): ?FolderRPC {
+function folderRPCFromPath (path: string): ?FolderRPC {
   if (path.startsWith(`${defaultKBFSPath}/private/`)) {
     return {
       name: path.replace(`${defaultKBFSPath}/private/`, ''),
@@ -105,10 +100,51 @@ function folderFromPath (path: string): ?FolderRPC {
   }
 }
 
+function folderFromFolderRPCWithMeta (username: string, f: FolderRPCWithMeta): Folder {
+  const users = sortUserList(parseFolderNameToUsers(username, f.name))
+
+  const {sortName, path} = pathFromFolder({users, isPublic: !f.private})
+  const groupAvatar = f.private ? (users.length > 2) : (users.length > 1)
+  const userAvatar = groupAvatar ? null : users[users.length - 1].username
+  const meta: MetaType = f.meta
+  const ignored = f.meta === 'ignored'
+
+  return {
+    path,
+    users,
+    sortName,
+    hasData: false, // TODO don't have this info
+    isPublic: !f.private,
+    groupAvatar,
+    userAvatar,
+    ignored,
+    meta,
+    recentFiles: [],
+    waitingForParticipantUnlock: f.waitingForParticipantUnlock,
+    youCanUnlock: f.youCanUnlock,
+  }
+}
+
+function folderFromFolderRPC (username: string, f: FolderRPC): Folder {
+  return folderFromFolderRPCWithMeta(username, {...f, waitingForParticipantUnlock: [], youCanUnlock: [], meta: null})
+}
+
+function folderFromPath (username: string, path: string): ?Folder {
+  const folderRPC = folderRPCFromPath(canonicalizeTLF(path))
+  if (folderRPC == null) {
+    return null
+  } else {
+    return folderFromFolderRPC(username, folderRPC)
+  }
+}
+
 export type {Folder as FolderRPC} from '../constants/types/flow-types'
 
 export {
-  folderFromPath,
-  pathFromFolder,
   canonicalizeTLF,
+  folderFromFolderRPCWithMeta,
+  folderFromFolderRPC,
+  folderFromPath,
+  folderRPCFromPath,
+  pathFromFolder,
 }

--- a/shared/constants/favorite.js
+++ b/shared/constants/favorite.js
@@ -58,7 +58,18 @@ export type FavoriteSwitchTab = TypedAction<'favorite:favoriteSwitchTab', {showi
 export const favoriteToggleIgnored = 'favorite:favoriteToggleIgnored'
 export type FavoriteToggleIgnored = TypedAction<'favorite:favoriteToggleIgnored', {isPrivate: boolean}, void>
 
+export const markTLFCreated = 'favorite:markTLFCreated'
+export type MarkTLFCreated = TypedAction<'favorite:markTLFCreated', {folder: FolderRPC}, void>
+
 export type FavoriteAction = FavoriteAdd | FavoriteAdded | FavoriteList | FavoriteListed | FavoriteIgnore | FavoriteIgnored | FavoriteSwitchTab | FavoriteToggleIgnored
+
+// Sometimes we have paths that are just private/foo instead of /keybase/private/foo
+function canonicalizeTLF (tlf: string): string {
+  if (tlf.indexOf(defaultKBFSPath) === -1) {
+    return `${defaultKBFSPath}/${tlf}`
+  }
+  return tlf
+}
 
 function pathFromFolder ({isPublic, users}: {isPublic: boolean, users: UserList}) {
   const rwers = users.filter(u => !u.readOnly).map(u => u.username)
@@ -99,4 +110,5 @@ export type {Folder as FolderRPC} from '../constants/types/flow-types'
 export {
   folderFromPath,
   pathFromFolder,
+  canonicalizeTLF,
 }

--- a/shared/constants/favorite.js
+++ b/shared/constants/favorite.js
@@ -66,7 +66,7 @@ export type FavoriteAction = FavoriteAdd | FavoriteAdded | FavoriteList | Favori
 
 // Sometimes we have paths that are just private/foo instead of /keybase/private/foo
 function canonicalizeTLF (tlf: string): string {
-  if (tlf.indexOf(defaultKBFSPath) === -1) {
+  if (tlf.indexOf(defaultKBFSPath) !== 0) {
     return `${defaultKBFSPath}/${tlf}`
   }
   return tlf

--- a/shared/constants/folders.js
+++ b/shared/constants/folders.js
@@ -3,6 +3,7 @@
 import type {UserList} from '../common-adapters/usernames'
 import type {Props as FileProps} from '../folders/files/file/render'
 import type {DeviceType} from '../constants/types/more'
+import type {Folder as FolderRPC} from '../constants/types/flow-types'
 
 export type FileSection = {
   name: string,
@@ -26,6 +27,7 @@ export type MetaType = 'new' | 'rekey' | 'ignored' | null
 export type Folder = {
   users: UserList,
   path: string,
+  sortName: string,
   meta?: MetaType,
   modified?: {
     when: string,
@@ -40,3 +42,9 @@ export type Folder = {
   waitingForParticipantUnlock: Array<ParticipantUnlock>,
   youCanUnlock: Array<Device>,
 }
+
+export type FolderRPCWithMeta = {
+  meta: MetaType,
+  waitingForParticipantUnlock: Array<ParticipantUnlock>,
+  youCanUnlock: Array<Device>,
+} & FolderRPC

--- a/shared/constants/gregor.js
+++ b/shared/constants/gregor.js
@@ -1,11 +1,14 @@
 // @flow
 
-import type {State as GregorState, Item, Metadata} from '../constants/types/flow-types-gregor'
+import type {State as GregorState, Item, Metadata, OutOfBandMessage} from '../constants/types/flow-types-gregor'
 import type {PushReason} from '../constants/types/flow-types'
 import type {TypedAction} from '../constants/types/flux'
 
 export const pushState = 'gregor:pushState'
 export type PushState = TypedAction<'gregor:pushState', {state: GregorState, reason: PushReason}, void>
+
+export const pushOOBM = 'gregor:pushOOBM'
+export type PushOOBM = TypedAction<'gregor:pushOOBM', {messages: Array<OutOfBandMessage>}, void>
 
 export const updateSeenMsgs = 'gregor:updateSeenMsgs'
 export type UpdateSeenMsgs = TypedAction<'gregor:updateSeenMsgs', {seenMsgs: Array<NonNullGregorItem>}, void>

--- a/shared/constants/selectors.js
+++ b/shared/constants/selectors.js
@@ -1,0 +1,8 @@
+// @flow
+import type {TypedState} from './reducer'
+
+const usernameSelector = ({config: {username}}: TypedState) => username
+
+export {
+  usernameSelector,
+}

--- a/shared/folders/dumb.js
+++ b/shared/folders/dumb.js
@@ -9,7 +9,7 @@ import {globalStyles} from '../styles'
 import {pathFromFolder} from '../constants/favorite'
 
 function createFolder (partialFolder: $Shape<Folder>) {
-  return {...partialFolder, path: pathFromFolder(partialFolder).path}
+  return {...partialFolder, ...pathFromFolder(partialFolder)}
 }
 
 const f1: Folder = createFolder({
@@ -115,7 +115,7 @@ const f5: Folder = createFolder({
   youCanUnlock: [],
 })
 
-const f6: Folder = {
+const f6: Folder = createFolder({
   path: '/keybase/private/cecileb,jenbeeb',
   users: [
     {username: 'cecileb', you: true},
@@ -124,14 +124,13 @@ const f6: Folder = {
   meta: 'rekey',
   ignored: false,
   isPublic: false,
-  isFirst: false,
   hasData: false,
   groupAvatar: false,
   userAvatar: 'jenbee',
   recentFiles: [],
   waitingForParticipantUnlock: [],
   youCanUnlock: [],
-}
+})
 
 const tlfs: Array<Folder> = [f1, f2, f3, f4, f5, f6]
 

--- a/shared/reducers/favorite.js
+++ b/shared/reducers/favorite.js
@@ -8,10 +8,12 @@ const initialState: FavoriteState = {
     privateBadge: 0,
     private: {
       isPublic: false,
+      tlfs: [],
     },
     publicBadge: 0,
     public: {
       isPublic: true,
+      tlfs: [],
     },
   },
   viewState: {
@@ -28,9 +30,32 @@ export default function (state: FavoriteState = initialState, action: FavoriteAc
 
     case Constants.markTLFCreated: {
       if (action.error) { break }
-      // TODO(mm) implement this
-      // const folderCreated = action.payload.folder
-      break
+      const folderCreated = action.payload.folder
+      const stripMetaForCreatedFolder = f => f.sortName === folderCreated.sortName && f.meta === 'new' ? {...f, meta: null} : f
+      // TODO(mm) this is ugly. Would be cleaner with immutable
+      if (folderCreated.isPublic) {
+        return {
+          ...state,
+          folderState: {
+            ...state.folderState,
+            public: {
+              ...state.folderState.public,
+              tlfs: state.folderState.public.tlfs.map(stripMetaForCreatedFolder),
+            },
+          },
+        }
+      } else {
+        return {
+          ...state,
+          folderState: {
+            ...state.folderState,
+            private: {
+              ...state.folderState.private,
+              tlfs: state.folderState.private.tlfs.map(stripMetaForCreatedFolder),
+            },
+          },
+        }
+      }
     }
 
     case Constants.favoriteListed:

--- a/shared/reducers/favorite.js
+++ b/shared/reducers/favorite.js
@@ -26,6 +26,13 @@ export default function (state: FavoriteState = initialState, action: FavoriteAc
     case CommonConstants.resetStore:
       return {...initialState}
 
+    case Constants.markTLFCreated: {
+      if (action.error) { break }
+      // TODO(mm) implement this
+      // const folderCreated = action.payload.folder
+      break
+    }
+
     case Constants.favoriteListed:
       if (action.error) {
         break


### PR DESCRIPTION
@keybase/react-hackers 
Hooks up out of band messages (OOBM).

Adds helpers to transform between `(path: string) -> folderRPC` and `folderRPC -> Folder` (`Folder` is what is used in the store)

Handles logic to clear new tag on an opened folder. 