### PR TITLE
Enable set-headline

### DIFF
--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -26,6 +26,14 @@ var chatFlags = map[string]cli.Flag{
 		Name:  "set-topic-name",
 		Usage: `Set topic name for the conversation`,
 	},
+	"set-headline": cli.StringFlag{
+		Name:  "set-headline",
+		Usage: `Set the headline for the conversation`,
+	},
+	"clear-headline": cli.BoolFlag{
+		Name:  "clear-headline",
+		Usage: `Clear the headline for the conversation`,
+	},
 	"stdin": cli.BoolFlag{
 		Name:  "stdin",
 		Usage: "Use STDIN for message content. [conversation] is required and [message] is ignored.",

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -4,7 +4,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -19,9 +18,12 @@ import (
 
 type cmdChatSend struct {
 	libkb.Contextified
-	message      string
-	resolver     chatCLIConversationResolver
-	setTopicName string
+	resolver chatCLIConversationResolver
+	// Only one of these should be set
+	message       string
+	setTopicName  string
+	setHeadline   string
+	clearHeadline bool
 }
 
 func newCmdChatSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -32,7 +34,8 @@ func newCmdChatSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(&cmdChatSend{Contextified: libkb.NewContextified(g)}, "send", c)
 		},
-		Flags: mustGetChatFlags("topic-type", "topic-name", "set-topic-name", "stdin"),
+		Flags: mustGetChatFlags(
+			"topic-type", "topic-name", "set-topic-name", "set-headline", "clear-headline", "stdin"),
 	}
 }
 
@@ -74,22 +77,6 @@ func (c *cmdChatSend) Run() (err error) {
 		conversationInfo = *resolved
 	}
 
-	switch {
-	case userChosen && len(c.message) == 0:
-		c.message, err = c.G().UI.GetTerminalUI().Prompt(PromptDescriptorEnterChatMessage, fmt.Sprintf("Send to [%s]? Hit Ctrl-C to cancel, or enter message content to send: ", conversationInfo.TlfName))
-		if err != nil {
-			return err
-		}
-	case userChosen:
-		return errors.New("potential command line argument parsing error: we had a message before letting user choose a conversation")
-	case len(c.message) == 0:
-		c.message, err = c.G().UI.GetTerminalUI().Prompt(PromptDescriptorEnterChatMessage, "Please enter message content: ")
-		if err != nil {
-			return err
-		}
-	default:
-	}
-
 	var args chat1.PostLocalArg
 	args.ConversationID = conversationInfo.Id
 
@@ -97,8 +84,52 @@ func (c *cmdChatSend) Run() (err error) {
 	// msgV1.ClientHeader.{Sender,SenderDevice} are filled by service
 	msgV1.ClientHeader.Conv = conversationInfo.Triple
 	msgV1.ClientHeader.TlfName = conversationInfo.TlfName
-	msgV1.ClientHeader.MessageType = chat1.MessageType_TEXT
-	msgV1.MessageBody = chat1.NewMessageBodyWithText(chat1.MessageText{Body: c.message})
+
+	// Whether the user is really sure they want to send to the selected conversation.
+	// We require an additional confirmation if the choose menu was used.
+	confirmed := !userChosen
+
+	// Do one of set topic name, set headline, or send message
+	switch {
+	case c.setTopicName != "":
+		if conversationInfo.Triple.TopicType == chat1.TopicType_CHAT {
+			c.G().UI.GetTerminalUI().Printf("We are not supporting setting topic name for chat conversations yet. Ignoring --set-topic-name >.<")
+			return nil
+		}
+		msgV1.ClientHeader.MessageType = chat1.MessageType_METADATA
+		msgV1.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{ConversationTitle: c.setTopicName})
+	case c.setHeadline != "":
+		msgV1.ClientHeader.MessageType = chat1.MessageType_HEADLINE
+		msgV1.MessageBody = chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: c.setHeadline})
+	case c.clearHeadline:
+		msgV1.ClientHeader.MessageType = chat1.MessageType_HEADLINE
+		msgV1.MessageBody = chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: ""})
+	default:
+		// Ask for message contents
+		if len(c.message) == 0 {
+			promptText := "Please enter message content: "
+			if !confirmed {
+				promptText = fmt.Sprintf("Send to [%s]? Hit Ctrl-C to cancel, or enter message content to send: ", conversationInfo.TlfName)
+			}
+			c.message, err = c.G().UI.GetTerminalUI().Prompt(PromptDescriptorEnterChatMessage, promptText)
+			if err != nil {
+				return err
+			}
+			confirmed = true
+		}
+
+		msgV1.ClientHeader.MessageType = chat1.MessageType_TEXT
+		msgV1.MessageBody = chat1.NewMessageBodyWithText(chat1.MessageText{Body: c.message})
+	}
+
+	if !confirmed {
+		promptText := fmt.Sprintf("Send to [%s]? Hit Ctrl-C to cancel, or enter to send.", conversationInfo.TlfName)
+		c.message, err = c.G().UI.GetTerminalUI().Prompt(PromptDescriptorEnterChatMessage, promptText)
+		if err != nil {
+			return err
+		}
+		confirmed = true
+	}
 
 	args.MessagePlaintext = chat1.NewMessagePlaintextWithV1(msgV1)
 
@@ -106,51 +137,88 @@ func (c *cmdChatSend) Run() (err error) {
 		return err
 	}
 
-	if len(c.setTopicName) > 0 {
-		if conversationInfo.Triple.TopicType == chat1.TopicType_CHAT {
-			c.G().UI.GetTerminalUI().Printf("We are not supporting setting topic name for chat conversations yet. Ignoring --set-topic-name >.<")
-		}
-		msgV1.ClientHeader.MessageType = chat1.MessageType_METADATA
-		msgV1.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{ConversationTitle: c.setTopicName})
-		args.MessagePlaintext = chat1.NewMessagePlaintextWithV1(msgV1)
-		if _, err := chatClient.PostLocal(ctx, args); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
 func (c *cmdChatSend) ParseArgv(ctx *cli.Context) (err error) {
-	switch len(ctx.Args()) {
-	case 2:
-		c.message = ctx.Args().Get(1)
-		fallthrough
-	case 1:
+	c.setTopicName = ctx.String("set-topic-name")
+	c.setHeadline = ctx.String("set-headline")
+	c.clearHeadline = ctx.Bool("clear-headline")
+	useStdin := ctx.Bool("stdin")
+
+	// Get the TLF name from the first position arg
+	if len(ctx.Args()) >= 1 {
 		tlfName := ctx.Args().Get(0)
 		if c.resolver, err = parseConversationResolver(ctx, tlfName); err != nil {
 			return err
 		}
-	case 0:
-		if ctx.Bool("stdin") {
-			return fmt.Errorf("--stdin requires 1 argument [conversation]")
-		}
-		if c.resolver, err = parseConversationResolver(ctx, ""); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("keybase chat send takes 1 or 2 args")
 	}
 
-	if ctx.Bool("stdin") {
-		bytes, err := ioutil.ReadAll(os.Stdin)
-		if err != nil {
-			return err
+	nActions := 0
+
+	if c.setTopicName != "" {
+		nActions++
+		if useStdin {
+			return fmt.Errorf("stdin not supported when setting topic name")
 		}
-		c.message = string(bytes)
+		if len(ctx.Args()) > 1 {
+			return fmt.Errorf("cannot send message and set topic name simultaneously")
+		}
 	}
 
-	c.setTopicName = ctx.String("set-topic-name")
+	if c.setHeadline != "" {
+		nActions++
+		if useStdin {
+			return fmt.Errorf("stdin not supported with --set-headline")
+		}
+		if len(ctx.Args()) > 1 {
+			return fmt.Errorf("cannot send message and set headline name simultaneously")
+		}
+	}
+
+	if c.clearHeadline {
+		nActions++
+		if useStdin {
+			return fmt.Errorf("stdin not supported with --clear-headline")
+		}
+		if len(ctx.Args()) > 1 {
+			return fmt.Errorf("cannot send message and clear headline name simultaneously")
+		}
+	}
+
+	// Send a normal message.
+	if nActions == 0 {
+		nActions++
+		if useStdin {
+			if len(ctx.Args()) > 1 {
+				return fmt.Errorf("too many args for sending from stdin")
+			}
+			bytes, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				return err
+			}
+			c.message = string(bytes)
+		} else {
+			switch len(ctx.Args()) {
+			case 0, 1:
+				c.message = ""
+			case 2:
+				c.message = ctx.Args().Get(1)
+			default:
+				cli.ShowCommandHelp(ctx, "send")
+				return fmt.Errorf("chat send takes 1 or 2 args")
+			}
+		}
+	}
+
+	if nActions < 1 {
+		cli.ShowCommandHelp(ctx, "send")
+		return fmt.Errorf("Incorrect Usage.")
+	}
+	if nActions > 1 {
+		cli.ShowCommandHelp(ctx, "send")
+		return fmt.Errorf("only one of message, --set-headline, --clear-headline, or --set-topic-name allowed")
+	}
 
 	return nil
 }

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -24,6 +24,7 @@ const (
 	MessageType_DELETE     MessageType = 4
 	MessageType_METADATA   MessageType = 5
 	MessageType_TLFNAME    MessageType = 6
+	MessageType_HEADLINE   MessageType = 7
 )
 
 var MessageTypeMap = map[string]MessageType{
@@ -34,6 +35,7 @@ var MessageTypeMap = map[string]MessageType{
 	"DELETE":     4,
 	"METADATA":   5,
 	"TLFNAME":    6,
+	"HEADLINE":   7,
 }
 
 var MessageTypeRevMap = map[MessageType]string{
@@ -44,6 +46,7 @@ var MessageTypeRevMap = map[MessageType]string{
 	4: "DELETE",
 	5: "METADATA",
 	6: "TLFNAME",
+	7: "HEADLINE",
 }
 
 type TopicType int

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -27,6 +27,10 @@ type MessageDelete struct {
 	MessageID MessageID `codec:"messageID" json:"messageID"`
 }
 
+type MessageHeadline struct {
+	Headline string `codec:"headline" json:"headline"`
+}
+
 type Asset struct {
 	Path     string `codec:"path" json:"path"`
 	Size     int    `codec:"size" json:"size"`
@@ -48,6 +52,7 @@ type MessageBody struct {
 	Edit__        *MessageEdit                 `codec:"edit,omitempty" json:"edit,omitempty"`
 	Delete__      *MessageDelete               `codec:"delete,omitempty" json:"delete,omitempty"`
 	Metadata__    *MessageConversationMetadata `codec:"metadata,omitempty" json:"metadata,omitempty"`
+	Headline__    *MessageHeadline             `codec:"headline,omitempty" json:"headline,omitempty"`
 }
 
 func (o *MessageBody) MessageType() (ret MessageType, err error) {
@@ -75,6 +80,11 @@ func (o *MessageBody) MessageType() (ret MessageType, err error) {
 	case MessageType_METADATA:
 		if o.Metadata__ == nil {
 			err = errors.New("unexpected nil value for Metadata__")
+			return ret, err
+		}
+	case MessageType_HEADLINE:
+		if o.Headline__ == nil {
+			err = errors.New("unexpected nil value for Headline__")
 			return ret, err
 		}
 	}
@@ -131,6 +141,16 @@ func (o MessageBody) Metadata() MessageConversationMetadata {
 	return *o.Metadata__
 }
 
+func (o MessageBody) Headline() MessageHeadline {
+	if o.MessageType__ != MessageType_HEADLINE {
+		panic("wrong case accessed")
+	}
+	if o.Headline__ == nil {
+		return MessageHeadline{}
+	}
+	return *o.Headline__
+}
+
 func NewMessageBodyWithText(v MessageText) MessageBody {
 	return MessageBody{
 		MessageType__: MessageType_TEXT,
@@ -163,6 +183,13 @@ func NewMessageBodyWithMetadata(v MessageConversationMetadata) MessageBody {
 	return MessageBody{
 		MessageType__: MessageType_METADATA,
 		Metadata__:    &v,
+	}
+}
+
+func NewMessageBodyWithHeadline(v MessageHeadline) MessageBody {
+	return MessageBody{
+		MessageType__: MessageType_HEADLINE,
+		Headline__:    &v,
 	}
 }
 

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -17,7 +17,8 @@ protocol common {
     EDIT_3,
     DELETE_4,
     METADATA_5,
-    TLFNAME_6 // Only used as the very first message in conversations whose topic name is not set when created
+    TLFNAME_6, // Only used as the very first message in conversations whose topic name is not set when created
+    HEADLINE_7
   }
 
   enum TopicType {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -21,6 +21,10 @@ protocol local {
     MessageID messageID;
   }
 
+  record MessageHeadline {
+    string headline;
+  }
+
   record Asset {
     string path;               // path to the object in storage
     int size;                  // size of the object
@@ -41,6 +45,7 @@ protocol local {
     case EDIT: MessageEdit;
     case DELETE: MessageDelete;
     case METADATA: MessageConversationMetadata;
+    case HEADLINE: MessageHeadline;
   }
 
   enum MessagePlaintextVersion {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -44,6 +44,7 @@ export const CommonMessageType = {
   delete: 4,
   metadata: 5,
   tlfname: 6,
+  headline: 7,
 }
 
 export const CommonTLFVisibility = {
@@ -404,6 +405,7 @@ export type MessageBody =
   | { messageType : 3, edit : ?MessageEdit }
   | { messageType : 4, delete : ?MessageDelete }
   | { messageType : 5, metadata : ?MessageConversationMetadata }
+  | { messageType : 7, headline : ?MessageHeadline }
 
 export type MessageBoxed = {
   serverHeader?: ?MessageServerHeader,
@@ -451,6 +453,10 @@ export type MessageFromServerOrError = {
   message?: ?MessageFromServer,
 }
 
+export type MessageHeadline = {
+  headline: string,
+}
+
 export type MessageID = uint
 
 export type MessagePlaintext = 
@@ -491,6 +497,7 @@ export type MessageType =
   | 4 // DELETE_4
   | 5 // METADATA_5
   | 6 // TLFNAME_6
+  | 7 // HEADLINE_7
 
 export type NewConversationLocalRes = {
   conv: ConversationLocal,

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -54,7 +54,8 @@
         "EDIT_3",
         "DELETE_4",
         "METADATA_5",
-        "TLFNAME_6"
+        "TLFNAME_6",
+        "HEADLINE_7"
       ]
     },
     {

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -58,6 +58,16 @@
     },
     {
       "type": "record",
+      "name": "MessageHeadline",
+      "fields": [
+        {
+          "type": "string",
+          "name": "headline"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "Asset",
       "fields": [
         {
@@ -145,6 +155,13 @@
             "def": false
           },
           "body": "MessageConversationMetadata"
+        },
+        {
+          "label": {
+            "name": "HEADLINE",
+            "def": false
+          },
+          "body": "MessageHeadline"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -44,6 +44,7 @@ export const CommonMessageType = {
   delete: 4,
   metadata: 5,
   tlfname: 6,
+  headline: 7,
 }
 
 export const CommonTLFVisibility = {
@@ -404,6 +405,7 @@ export type MessageBody =
   | { messageType : 3, edit : ?MessageEdit }
   | { messageType : 4, delete : ?MessageDelete }
   | { messageType : 5, metadata : ?MessageConversationMetadata }
+  | { messageType : 7, headline : ?MessageHeadline }
 
 export type MessageBoxed = {
   serverHeader?: ?MessageServerHeader,
@@ -451,6 +453,10 @@ export type MessageFromServerOrError = {
   message?: ?MessageFromServer,
 }
 
+export type MessageHeadline = {
+  headline: string,
+}
+
 export type MessageID = uint
 
 export type MessagePlaintext = 
@@ -491,6 +497,7 @@ export type MessageType =
   | 4 // DELETE_4
   | 5 // METADATA_5
   | 6 // TLFNAME_6
+  | 7 // HEADLINE_7
 
 export type NewConversationLocalRes = {
   conv: ConversationLocal,


### PR DESCRIPTION
Add the ability to send `Headline` messages from `chat send` as well as see them in `chat read`

`keybase chat send gil --set-headline "fishing tips"`
`keybase chat send gil --clear-headline`

Introduces `MessageType.HEADLINE`. It looks like old clients will not have any problem with the existence of Headline messages, and will ignore them. But I'm not totally clear on why that is.

Headline messages cannot be deleted by a Delete message, and do not use `supersedes`/`supersededBy`. It's easy to find the latest headline through `maxMessages`.

```
$ kbu chat read gil
fetching conversation frank,gil ...

headline: fishing tips

[1]  [frank 31m] mesa
[2]  [frank 33m] a mesasege
[3]  [frank 34m] test
[4]   [frank 3h] yo
[5]   [frank 4d] hi
```

r? @songgao 
cc @mmaxim 