### PR TITLE
clickable and selectable work better

### DIFF
--- a/shared/common-adapters/user-proofs.desktop.js
+++ b/shared/common-adapters/user-proofs.desktop.js
@@ -69,7 +69,7 @@ class ProofRow extends PureComponent<void, ProofRowProps, ProofRowState> {
         <Box style={styleProofNameSection}>
           <Box style={styleProofNameLabelContainer}>
             <Text inline={true} className='hover-underline-container' type='Body' onClick={() => onClickProfile(proof)} style={styleProofName}>
-              <Text inline={true} type='Body' className='underline' style={shared.proofNameStyle(proof)}>{proof.name}</Text>
+              <Text inline={true} type='Body' className='underline' style={{...shared.proofNameStyle(proof), ...globalStyles.selectable, ...globalStyles.clickable}}>{proof.name}</Text>
               {proof.id && <Text className='no-underline' inline={true} type='Body' style={styleProofType}><wbr />@{proof.type}<wbr /></Text>}
             </Text>
             {proof.meta && proof.meta !== metaNone && <Meta title={proof.meta} style={{backgroundColor: shared.metaColor(proof)}} />}
@@ -238,8 +238,8 @@ const styleProofNameLabelContainer = {
 }
 
 const styleProofName = {
-  ...globalStyles.clickable,
   ...globalStyles.selectable,
+  ...globalStyles.clickable,
   display: 'inline-block',
   wordBreak: 'break-all',
   flex: 1,

--- a/shared/styles/index.desktop.js
+++ b/shared/styles/index.desktop.js
@@ -78,7 +78,7 @@ const util = {
     overflowY: 'auto',
   },
   selectable: {
-    WebkitUserSelect: 'initial',
+    WebkitUserSelect: 'text',
     cursor: 'text',
   },
   noSelect: {


### PR DESCRIPTION
This came out of a quick conversation with @oconnor663 and @cecileboucheron . The proof rows should have the hand cursor and yet be selectable. this PR makes this work better. We could have a clickableSelectable global style but for now you have to import them in order. Also the webkit select style is now text vs inherit so it will actually be set explicitly instead of it being set implicitly but still allowing it to be unset higher up in the hierarchy

@keybase/react-hackers 