### PR TITLE
Fix build: instead of skip_update_json, promote specific builds to testing

### DIFF
--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -36,8 +36,6 @@ updater_version=`$updater_binpath -version`
 
 icon_path="$client_dir/media/icons/Keybase.icns"
 
-skip_update_json=${SKIP_UPDATE_JSON:-}
-
 echo "Loading release tool"
 "$client_dir/packaging/goinstall.sh" "github.com/keybase/release"
 release_bin="$GOPATH/bin/release"
@@ -245,7 +243,7 @@ kbsign() {(
 
 update_json() {(
   cd "$out_dir"
-  if [ -n "$s3host" ] && [ ! "$skip_update_json" = "1" ]; then
+  if [ -n "$s3host" ]; then
     echo "Generating $update_json_name"
     "$release_bin" update-json --version="$app_version" --src="$zip_name" \
       --uri="$s3host/$platform-updates" --signature="$out_dir/$sig_name" --description="$client_dir/desktop/CHANGELOG.txt" > "$update_json_name"
@@ -273,9 +271,7 @@ save() {(
   mv "$out_dir/$sourcemap_name" "$save_dir/electron-sourcemaps"
   # Support files
   mkdir -p "$platform_dir-support"
-  if [ ! "$skip_update_json" = "1" ]; then
-    mv "$out_dir/$update_json_name" "$platform_dir-support"
-  fi
+  mv "$out_dir/$update_json_name" "$platform_dir-support"
 )}
 
 s3sync() {

--- a/packaging/prerelease/s3_index.sh
+++ b/packaging/prerelease/s3_index.sh
@@ -38,6 +38,3 @@ else
   echo "Invalid platform: $platform"
   exit 1
 fi
-
-echo "Checking if we need to promote a release for testing ($platform)"
-"$release_bin" promote-test-releases --bucket-name="$bucket_name" --platform="$platform"


### PR DESCRIPTION
r? @gabriel

Here's the other half of keybase/release#19 -- allow promoting a specific build to the test channel (previously only supported on prod).

This lets us make two builds (with two JSON files) when building for smoketesting, and promote the first of the two to the test channel.  Then the upgrade server can opt people in to receiving build two if needed.