### PR TITLE
add chat local storage CORE-3851

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -91,7 +91,8 @@ func (b *Boxer) UnboxMessage(ctx context.Context, finder *KeyFinder, boxed chat1
 	_, uimap := GetUserInfoMapper(ctx, b.G())
 	username, deviceName, err := b.getSenderInfoLocal(uimap, messagePlaintext)
 	if err != nil {
-		return chat1.MessageFromServerOrError{}, libkb.ChatUnboxingError{Msg: err.Error()}
+		b.G().Log.Warning("unable to fetch sender informaton: UID: %s deviceID: %s",
+			boxed.ServerHeader.Sender, boxed.ServerHeader.SenderDevice)
 	}
 
 	res.Message = &chat1.MessageFromServer{

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -265,7 +265,11 @@ func (b *Boxer) UnboxMessages(ctx context.Context, boxed []chat1.MessageBoxed) (
 			errMsg := err.Error()
 			b.G().Log.Warning("failed to unbox message: msgID: %d err: %s", msg.ServerHeader.MessageID, errMsg)
 			unboxed = append(unboxed, chat1.MessageFromServerOrError{
-				UnboxingError: &errMsg,
+				UnboxingError: &chat1.MessageError{
+					Errmsg:      errMsg,
+					MessageID:   msg.ServerHeader.MessageID,
+					MessageType: msg.ServerHeader.MessageType,
+				},
 			})
 			continue
 		}

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/crypto/nacl/secretbox"
 	"golang.org/x/net/context"
 
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
@@ -32,29 +33,42 @@ func init() {
 }
 
 type Boxer struct {
-	tlf    keybase1.TlfInterface
-	hashV1 func(data []byte) chat1.Hash
-	sign   func(msg []byte, kp libkb.NaclSigningKeyPair, prefix libkb.SignaturePrefix) (chat1.SignatureInfo, error) // replaceable for testing
+	tlf     keybase1.TlfInterface
+	hashV1  func(data []byte) chat1.Hash
+	sign    func(msg []byte, kp libkb.NaclSigningKeyPair, prefix libkb.SignaturePrefix) (chat1.SignatureInfo, error) // replaceable for testing
+	udCache *lru.Cache
 	libkb.Contextified
 }
 
 func NewBoxer(g *libkb.GlobalContext, tlf keybase1.TlfInterface) *Boxer {
+	udc, _ := lru.New(10000)
 	return &Boxer{
 		tlf:          tlf,
 		hashV1:       hashSha256V1,
 		sign:         sign,
+		udCache:      udc,
 		Contextified: libkb.NewContextified(g),
 	}
 }
 
+type udCacheKey struct {
+	UID      keybase1.UID
+	DeviceID keybase1.DeviceID
+}
+
+type udCacheValue struct {
+	Username   string
+	DeviceName string
+}
+
 // unboxMessage unboxes a chat1.MessageBoxed into a keybase1.Message.  It finds
 // the appropriate keybase1.CryptKey.
-func (b *Boxer) UnboxMessage(ctx context.Context, finder *KeyFinder, boxed chat1.MessageBoxed) (messagePlaintext chat1.MessagePlaintext, headerHash chat1.Hash, err error) {
+func (b *Boxer) UnboxMessage(ctx context.Context, finder *KeyFinder, boxed chat1.MessageBoxed) (res chat1.MessageFromServerOrError, err error) {
 	tlfName := boxed.ClientHeader.TlfName
 	tlfPublic := boxed.ClientHeader.TlfPublic
 	keys, err := finder.Find(ctx, b.tlf, tlfName, tlfPublic)
 	if err != nil {
-		return chat1.MessagePlaintext{}, nil, libkb.ChatUnboxingError{Msg: err.Error()}
+		return chat1.MessageFromServerOrError{}, libkb.ChatUnboxingError{Msg: err.Error()}
 	}
 
 	var matchKey *keybase1.CryptKey
@@ -66,14 +80,29 @@ func (b *Boxer) UnboxMessage(ctx context.Context, finder *KeyFinder, boxed chat1
 	}
 
 	if matchKey == nil {
-		return chat1.MessagePlaintext{}, nil, libkb.ChatUnboxingError{Msg: fmt.Sprintf("no key found for generation %d", boxed.KeyGeneration)}
+		return chat1.MessageFromServerOrError{}, libkb.ChatUnboxingError{Msg: fmt.Sprintf("no key found for generation %d", boxed.KeyGeneration)}
 	}
 
-	if messagePlaintext, headerHash, err = b.unboxMessageWithKey(ctx, boxed, matchKey); err != nil {
-		return chat1.MessagePlaintext{}, nil, libkb.ChatUnboxingError{Msg: err.Error()}
+	messagePlaintext, headerHash, err := b.unboxMessageWithKey(ctx, boxed, matchKey)
+	if err != nil {
+		return chat1.MessageFromServerOrError{}, libkb.ChatUnboxingError{Msg: err.Error()}
 	}
 
-	return messagePlaintext, headerHash, nil
+	_, uimap := GetUserInfoMapper(ctx, b.G())
+	username, deviceName, err := b.getSenderInfoLocal(uimap, messagePlaintext)
+	if err != nil {
+		return chat1.MessageFromServerOrError{}, libkb.ChatUnboxingError{Msg: err.Error()}
+	}
+
+	res.Message = &chat1.MessageFromServer{
+		ServerHeader:     *boxed.ServerHeader,
+		MessagePlaintext: messagePlaintext,
+		SenderDeviceName: deviceName,
+		SenderUsername:   username,
+		HeaderHash:       headerHash,
+	}
+
+	return res, nil
 }
 
 // unboxMessageWithKey unboxes a chat1.MessageBoxed into a keybase1.Message given
@@ -169,6 +198,81 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 	default:
 		return chat1.MessagePlaintext{}, nil, libkb.NewChatBodyVersionError(bodyVersion)
 	}
+}
+
+// unboxThread transforms a chat1.ThreadViewBoxed to a keybase1.ThreadView.
+func (b *Boxer) UnboxThread(ctx context.Context, boxed chat1.ThreadViewBoxed, convID chat1.ConversationID) (thread chat1.ThreadView, err error) {
+	thread = chat1.ThreadView{
+		Pagination: boxed.Pagination,
+	}
+
+	if thread.Messages, err = b.UnboxMessages(ctx, boxed.Messages); err != nil {
+		return chat1.ThreadView{}, err
+	}
+
+	return thread, nil
+}
+
+func (b *Boxer) getUsernameAndDeviceName(uid keybase1.UID, deviceID keybase1.DeviceID,
+	uimap *UserInfoMapper) (string, string, error) {
+
+	if val, ok := b.udCache.Get(udCacheKey{UID: uid, DeviceID: deviceID}); ok {
+		if udval, ok := val.(udCacheValue); ok {
+			b.G().Log.Debug("getUsernameAndDeviceName: lru hit: u: %s d: %s", udval.Username,
+				udval.DeviceName)
+			return udval.Username, udval.DeviceName, nil
+		}
+	}
+
+	username, deviceName, err := uimap.Lookup(uid, deviceID)
+	if err != nil {
+		return username, deviceName, err
+	}
+	b.udCache.Add(udCacheKey{UID: uid, DeviceID: deviceID},
+		udCacheValue{Username: username, DeviceName: deviceName})
+	return username, deviceName, err
+}
+
+func (b *Boxer) getSenderInfoLocal(uimap *UserInfoMapper, messagePlaintext chat1.MessagePlaintext) (senderUsername string, senderDeviceName string, err error) {
+	version, err := messagePlaintext.Version()
+	if err != nil {
+		return "", "", err
+	}
+	switch version {
+	case chat1.MessagePlaintextVersion_V1:
+		v1 := messagePlaintext.V1()
+		uid := keybase1.UID(v1.ClientHeader.Sender.String())
+		did := keybase1.DeviceID(v1.ClientHeader.SenderDevice.String())
+		username, deviceName, err := b.getUsernameAndDeviceName(uid, did, uimap)
+		if err != nil {
+			return "", "", err
+		}
+
+		return username, deviceName, nil
+
+	default:
+		return "", "", libkb.NewChatMessageVersionError(version)
+	}
+}
+
+func (b *Boxer) UnboxMessages(ctx context.Context, boxed []chat1.MessageBoxed) (unboxed []chat1.MessageFromServerOrError, err error) {
+	finder := NewKeyFinder()
+	ctx, _ = GetUserInfoMapper(ctx, b.G())
+	for _, msg := range boxed {
+		decmsg, err := b.UnboxMessage(ctx, finder, msg)
+		if err != nil {
+			errMsg := err.Error()
+			b.G().Log.Warning("failed to unbox message: msgID: %d err: %s", msg.ServerHeader.MessageID, errMsg)
+			unboxed = append(unboxed, chat1.MessageFromServerOrError{
+				UnboxingError: &errMsg,
+			})
+			continue
+		}
+
+		unboxed = append(unboxed, decmsg)
+	}
+
+	return unboxed, nil
 }
 
 // boxMessage encrypts a keybase1.MessagePlaintext into a chat1.MessageBoxed.  It

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -288,11 +288,11 @@ func TestChatMessagePublic(t *testing.T) {
 		Ctime: gregor1.ToTime(time.Now()),
 	}
 
-	messagePlaintext, _, err := boxer.UnboxMessage(ctx, NewKeyFinder(), *boxed)
+	decmsg, err := boxer.UnboxMessage(ctx, NewKeyFinder(), *boxed)
 	if err != nil {
 		t.Fatal(err)
 	}
-	body := messagePlaintext.V1().MessageBody
+	body := decmsg.Message.MessagePlaintext.V1().MessageBody
 	if typ, _ := body.MessageType(); typ != chat1.MessageType_TEXT {
 		t.Errorf("body type: %d, expected %d", typ, chat1.MessageType_TEXT)
 	}

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -153,7 +153,7 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 }
 
 func (s *HybridConversationSource) Clear(convID chat1.ConversationID, uid gregor1.UID) error {
-	return s.storage.mustNuke(true, nil, convID, uid)
+	return s.storage.maybeNuke(true, nil, convID, uid)
 }
 
 func NewConversationSource(g *libkb.GlobalContext, typ string, boxer *Boxer,

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -1,10 +1,10 @@
 package chat
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
 )
 
 // keyFinder remembers results from previous calls to CryptKeys().

--- a/go/chat/pager/pager.go
+++ b/go/chat/pager/pager.go
@@ -1,0 +1,145 @@
+package pager
+
+import (
+	"errors"
+
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/go-codec/codec"
+)
+
+// inboxPagerFields is the info that gives a total ordering on the inbox
+type InboxPagerFields struct {
+	Mtime  gregor1.Time         `codec:"M"`
+	ConvID chat1.ConversationID `codec:"C"`
+}
+
+// pager provides the getPage and makePage functions for implementing
+// paging in the chat1 protocol
+type Pager struct {
+	codec codec.Handle
+}
+
+func NewPager() Pager {
+	mh := codec.MsgpackHandle{WriteExt: true}
+	return Pager{
+		codec: &mh,
+	}
+}
+
+func (p Pager) encode(input interface{}) ([]byte, error) {
+	var data []byte
+	enc := codec.NewEncoderBytes(&data, p.codec)
+	if err := enc.Encode(input); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (p Pager) decode(data []byte, res interface{}) error {
+	dec := codec.NewDecoderBytes(data, p.codec)
+	err := dec.Decode(res)
+	return err
+}
+
+func (p Pager) GetPage(getcond func(bool) string, page *chat1.Pagination,
+	pivot interface{}) (string, bool, error) {
+
+	var dat []byte
+	var cond string
+	var prev bool
+
+	// Set the query condition depending on what direction we are looking
+	if len(page.Next) > 0 {
+		cond = getcond(false)
+		dat = page.Next
+	} else if len(page.Previous) > 0 {
+		cond = getcond(true)
+		dat = page.Previous
+		prev = true
+	} else {
+		return "", false, nil
+	}
+
+	if err := p.decode(dat, pivot); err != nil {
+		return "", false, err
+	}
+
+	return cond, prev, nil
+}
+
+func (p Pager) MakePage(length, reqed int, next interface{}, prev interface{}) (*chat1.Pagination, error) {
+	prevEncoded, err := p.encode(prev)
+	if err != nil {
+		return nil, err
+	}
+	nextEncoded, err := p.encode(next)
+	if err != nil {
+		return nil, err
+	}
+
+	return &chat1.Pagination{
+		Num:      length,
+		Next:     nextEncoded,
+		Previous: prevEncoded,
+		Last:     (length < reqed),
+	}, nil
+}
+
+// inboxPager provides a convenient interface to pager for the inbox
+// use case
+type InboxPager struct {
+	Pager
+}
+
+func NewInboxPager() InboxPager {
+	return InboxPager{Pager: NewPager()}
+}
+
+func (p InboxPager) MakePage(res []chat1.Conversation, reqed int) (*chat1.Pagination, error) {
+	if len(res) == 0 {
+		return &chat1.Pagination{Num: 0, Last: true}, nil
+	}
+
+	if res[0].ReaderInfo == nil || res[len(res)-1].ReaderInfo == nil {
+		return nil, errors.New("need reader info to page conversations")
+	}
+
+	// Get first and last message IDs to encode in the result
+	prevPF := InboxPagerFields{Mtime: res[0].ReaderInfo.Mtime, ConvID: res[0].Metadata.ConversationID}
+	nextPF := InboxPagerFields{
+		Mtime:  res[len(res)-1].ReaderInfo.Mtime,
+		ConvID: res[len(res)-1].Metadata.ConversationID,
+	}
+
+	return p.Pager.MakePage(len(res), reqed, nextPF, prevPF)
+}
+
+// threadPager provides a covenient interface to pager for the thread use case
+type ThreadPager struct {
+	Pager
+}
+
+type Message interface {
+	GetMessageID() chat1.MessageID
+}
+
+func NewThreadPager() ThreadPager {
+	return ThreadPager{Pager: NewPager()}
+}
+
+func (p ThreadPager) MakePage(res []Message, reqed int) (*chat1.Pagination, error) {
+	if len(res) == 0 {
+		return &chat1.Pagination{Num: 0}, nil
+	}
+
+	// Get first and last message IDs to encode in the result
+	prevMsgID := res[0].GetMessageID()
+	nextMsgID := res[len(res)-1].GetMessageID()
+
+	return p.Pager.MakePage(len(res), reqed, nextMsgID, prevMsgID)
+}
+
+func (p ThreadPager) MakeIndex(msg Message) ([]byte, error) {
+	return p.encode(msg.GetMessageID())
+}

--- a/go/chat/storage.go
+++ b/go/chat/storage.go
@@ -1,7 +1,6 @@
 package chat
 
 import (
-	"context"
 	"fmt"
 	"sync"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/go-codec/codec"
+	"golang.org/x/net/context"
 )
 
 const maxBlockSize = 100

--- a/go/chat/storage.go
+++ b/go/chat/storage.go
@@ -1,20 +1,454 @@
 package chat
 
 import (
+	"context"
+	"fmt"
+	"sync"
+
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/go-codec/codec"
 )
 
+// TODO:
+// ***
+// Supersedes
+// Error handling
+// Gregor OOBM integration
+// ***
+
+const maxBlockSize = 100
+
 type Storage struct {
+	sync.Mutex
 	libkb.Contextified
 }
 
-func (s *Storage) Merge(convID chat1.ConversationID, uid gregor1.UID,
-	msgs []chat1.MessageFromServerOrError) error {
+type blockIndex struct {
+	ConvID   chat1.ConversationID
+	UID      gregor1.UID
+	MaxBlock int
+}
+
+type block struct {
+	BlockID int
+	Msgs    [maxBlockSize]chat1.MessageFromServerOrError
+}
+
+type convIndex struct {
+	ConvIDs []chat1.ConversationID
+}
+
+func NewStorage(g *libkb.GlobalContext) *Storage {
+	return &Storage{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func (s *Storage) debug(format string, args ...interface{}) {
+	s.G().Log.Debug("+ chatcache: "+format, args...)
+}
+
+func (s *Storage) makeBlockKey(convID chat1.ConversationID, uid gregor1.UID, blockID int) libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBChatBlocks,
+		Key: fmt.Sprintf("bl:%s:%s:%d", convID, uid, blockID),
+	}
+}
+
+func (s *Storage) makeBlockIndexKey(convID chat1.ConversationID, uid gregor1.UID) libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBChatBlockIndex,
+		Key: fmt.Sprintf("bi:%s:%s", convID, uid),
+	}
+}
+
+func (s *Storage) makeConvIndexKey(uid gregor1.UID) libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBChatConvIndex,
+		Key: uid.String(),
+	}
+}
+
+func (s *Storage) getBlockNumber(id chat1.MessageID) int {
+	return int(id) / maxBlockSize
+}
+
+func (s *Storage) getBlockPosition(id chat1.MessageID) int {
+	// We subtract off 1 here because there is no msgID == 0
+	return int(id)%maxBlockSize - 1
+}
+
+func (s *Storage) getMsgID(blockNum, blockPos int) chat1.MessageID {
+	return chat1.MessageID(blockNum*maxBlockSize + blockPos + 1)
+}
+
+func (s *Storage) getBlock(bi *blockIndex, id chat1.MessageID) (block, bool, error) {
+	if id == 0 {
+		return block{}, false, fmt.Errorf("invalid block id: %d", id)
+	}
+	return s.readBlock(bi, s.getBlockNumber(id))
+}
+
+func (s *Storage) encode(input interface{}) ([]byte, error) {
+	mh := codec.MsgpackHandle{WriteExt: true}
+	var data []byte
+	enc := codec.NewEncoderBytes(&data, &mh)
+	if err := enc.Encode(input); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (s *Storage) decode(data []byte, res interface{}) error {
+	mh := codec.MsgpackHandle{WriteExt: true}
+	dec := codec.NewDecoderBytes(data, &mh)
+	err := dec.Decode(res)
+	return err
+}
+
+func (s *Storage) getIndex(uid gregor1.UID) (convIndex, bool, error) {
+	raw, found, err := s.G().LocalDb.GetRaw(s.makeConvIndexKey(uid))
+	if err != nil {
+		return convIndex{}, false, err
+	}
+	if found {
+		var si convIndex
+		if err := s.decode(raw, &si); err == nil {
+			return si, true, nil
+		}
+	}
+	return convIndex{}, found, nil
+}
+
+func (s *Storage) mergeConvIndex(convID chat1.ConversationID, uid gregor1.UID) error {
+	// Get current index
+	si, found, err := s.getIndex(uid)
+	if err != nil {
+		return err
+	}
+
+	// Add new convID to index if it is not there
+	var res convIndex
+	if !found {
+		res.ConvIDs = []chat1.ConversationID{convID}
+	} else {
+		for _, cid := range si.ConvIDs {
+			if cid == convID {
+				return nil
+			}
+		}
+		res.ConvIDs = append(si.ConvIDs, convID)
+	}
+
+	// Write index out
+	dat, err := s.encode(res)
+	if err != nil {
+		return err
+	}
+	return s.G().LocalDb.PutRaw(s.makeConvIndexKey(uid), dat)
+}
+
+func (s *Storage) createBlockIndex(key libkb.DbKey, convID chat1.ConversationID, uid gregor1.UID) (blockIndex, error) {
+	bi := blockIndex{
+		ConvID:   convID,
+		UID:      uid,
+		MaxBlock: -1,
+	}
+
+	s.debug("createBlockIndex: creating new block index: convID: %d uid: %s", convID, uid)
+	_, err := s.createBlock(&bi)
+	if err != nil {
+		return bi, err
+	}
+
+	dat, err := s.encode(bi)
+	if err != nil {
+		return bi, err
+	}
+	return bi, s.G().LocalDb.PutRaw(key, dat)
+}
+
+func (s *Storage) readBlockIndex(convID chat1.ConversationID, uid gregor1.UID) (blockIndex, error) {
+	key := s.makeBlockIndexKey(convID, uid)
+	raw, found, err := s.G().LocalDb.GetRaw(key)
+	if err != nil {
+		return blockIndex{}, err
+	}
+	if !found {
+		// If not found, create a new one and return it
+		s.debug("readBlockIndex: no block index found, creating: convID: %d uid: %s", convID, uid)
+		return s.createBlockIndex(key, convID, uid)
+	}
+
+	// Decode and return
+	var bi blockIndex
+	if err = s.decode(raw, &bi); err != nil {
+		return bi, err
+	}
+	return bi, nil
+}
+
+func (s *Storage) createBlock(bi *blockIndex) (block, error) {
+
+	// Update block index with new block
+	bi.MaxBlock++
+	dat, err := s.encode(bi)
+	if err != nil {
+		return block{}, err
+	}
+	s.debug("createBlock: creating block: %d", bi.MaxBlock)
+	err = s.G().LocalDb.PutRaw(s.makeBlockIndexKey(bi.ConvID, bi.UID), dat)
+	if err != nil {
+		return block{}, err
+	}
+
+	// Write out new block
+	b := block{BlockID: bi.MaxBlock}
+	key := s.makeBlockKey(bi.ConvID, bi.UID, bi.MaxBlock)
+	dat, err = s.encode(b)
+	if err != nil {
+		return block{}, err
+	}
+
+	return b, s.G().LocalDb.PutRaw(key, dat)
+}
+
+func (s *Storage) readBlock(bi *blockIndex, id int) (block, bool, error) {
+
+	s.debug("readBlock: reading block: %d", id)
+	key := s.makeBlockKey(bi.ConvID, bi.UID, id)
+	raw, found, err := s.G().LocalDb.GetRaw(key)
+	if err != nil {
+		return block{}, false, err
+	}
+	if !found {
+		// Didn't find it for some reason
+		return block{}, false, nil
+	}
+
+	var b block
+	if err = s.decode(raw, &b); err != nil {
+		return block{}, found, err
+	}
+	return b, found, nil
+}
+
+func (s *Storage) Merge(convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageFromServerOrError) error {
+	s.Lock()
+	defer s.Unlock()
+
+	// Merge convID into uid index
+	if err := s.mergeConvIndex(convID, uid); err != nil {
+		return err
+	}
+
+	// Get block index first
+	bi, err := s.readBlockIndex(convID, uid)
+	if err != nil {
+		return err
+	}
+
+	// Write out new data into blocks
+	return s.writeMessages(&bi, msgs)
+}
+
+func (s *Storage) writeMessages(bi *blockIndex, msgs []chat1.MessageFromServerOrError) error {
+	var err error
+	var maxB block
+	var newBlock block
+	var lastWritten int
+	var found bool
+
+	// Get the maximum  block (create it if we need to)
+	maxID := msgs[0].Message.ServerHeader.MessageID
+	s.debug("writeMessages: maxID: %d num: %d", maxID, len(msgs))
+	if maxB, found, err = s.getBlock(bi, maxID); err != nil {
+		return err
+	}
+	if !found {
+		s.debug("writeMessages: block not found (creating): maxID: %d id: %d", maxID,
+			s.getBlockNumber(maxID))
+		if _, err = s.createBlock(bi); err != nil {
+			return nil
+		}
+		if maxB, found, err = s.getBlock(bi, maxID); err != nil {
+			return err
+		}
+		if !found {
+			return fmt.Errorf("weird block request, not found, aborting")
+		}
+	}
+
+	// Append to the block
+	newBlock.Msgs = maxB.Msgs
+	for index, msg := range msgs {
+		msgID := msg.Message.ServerHeader.MessageID
+		if s.getBlockNumber(msgID) != maxB.BlockID {
+			s.debug("writeMessages: crossed block boundary, aborting and writing out: msgID: %d", msgID)
+			break
+		}
+		newBlock.Msgs[s.getBlockPosition(msgID)] = msg
+		lastWritten = index
+	}
+
+	// Write the block
+	dat, err := s.encode(newBlock)
+	if err != nil {
+		return err
+	}
+	if err = s.G().LocalDb.PutRaw(s.makeBlockKey(bi.ConvID, bi.UID, maxB.BlockID), dat); err != nil {
+		return err
+	}
+
+	// We didn't write everything out in this block, move to another one
+	if lastWritten < len(msgs)-1 {
+		return s.writeMessages(bi, msgs[lastWritten+1:])
+	}
 	return nil
 }
 
-func (s *Storage) Fetch(convID chat1.ConversationID, uid gregor1.UID, page *chat1.Pagination) ([]chat1.MessageFromServerOrError, error) {
-	return nil, nil
+type doneFunc func(*[]chat1.MessageFromServerOrError, int) bool
+
+func (s *Storage) readMessages(res *[]chat1.MessageFromServerOrError, bi *blockIndex,
+	maxID chat1.MessageID, num int, df doneFunc) error {
+
+	// Get the current block where max ID is found
+	b, found, err := s.getBlock(bi, maxID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("no block for read")
+	}
+
+	// Add messages to result set
+	var lastAdded chat1.MessageID
+	maxPos := s.getBlockPosition(maxID)
+
+	s.debug("readMessages: BID: %d maxPos: %d maxID: %d num: %d", b.BlockID, maxPos, maxID, num)
+	for index := maxPos; len(*res) < num && index >= 0; index-- {
+
+		msg := b.Msgs[index]
+		if msg.Message == nil {
+			s.debug("readMessages: cache entry empty: index: %d block: %d msgID: %d", index, b.BlockID, s.getMsgID(b.BlockID, index))
+			return fmt.Errorf("chat entry not found: index: %d", index)
+		}
+		bMsgID := msg.Message.ServerHeader.MessageID
+
+		// Sanity check
+		if bMsgID != s.getMsgID(b.BlockID, index) {
+			return fmt.Errorf("chat entry corruption: bMsgID: %d != %d (block: %d pos: %d)",
+				bMsgID, s.getMsgID(b.BlockID, index), b.BlockID, index)
+		}
+
+		s.debug("readMessages: adding msg_id: %d", msg.Message.ServerHeader.MessageID)
+		*res = append(*res, msg)
+		lastAdded = msg.Message.ServerHeader.MessageID
+	}
+
+	// Check if we read anything, otherwise move to another block and try again
+	if !df(res, num) && b.BlockID > 0 {
+		return s.readMessages(res, bi, lastAdded-1, num, df)
+	}
+	return nil
+}
+
+func (s *Storage) getRemoteMaxID(ctx context.Context, ri chat1.RemoteInterface, convID chat1.ConversationID) (chat1.MessageID, error) {
+
+	s.debug("getRemoteMaxID: fetching remote max for: %d", convID)
+	conv, err := ri.GetInboxRemote(ctx, chat1.GetInboxRemoteArg{
+		Query: &chat1.GetInboxQuery{
+			ConvID: &convID,
+		},
+	})
+	if err != nil {
+		return 0, err
+	}
+	if len(conv.Inbox.Conversations) == 0 {
+		return 0, fmt.Errorf("no conv found: %d", convID)
+	}
+	return conv.Inbox.Conversations[0].ReaderInfo.MaxMsgid, nil
+}
+
+func (s *Storage) Fetch(ctx context.Context, ri chat1.RemoteInterface, convID chat1.ConversationID,
+	uid gregor1.UID, query *chat1.GetThreadQuery,
+	pagination *chat1.Pagination) ([]chat1.MessageFromServerOrError, error) {
+
+	s.Lock()
+	defer s.Unlock()
+
+	// Get block index first
+	bi, err := s.readBlockIndex(convID, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	// Calculate seek parameters
+	var maxID chat1.MessageID
+	var num int
+	if pagination == nil {
+		if maxID, err = s.getRemoteMaxID(ctx, ri, convID); err != nil {
+			return nil, err
+		}
+		num = 10000
+	} else {
+		var pid chat1.MessageID
+		num = pagination.Num
+		if len(pagination.Next) == 0 && len(pagination.Previous) == 0 {
+			if maxID, err = s.getRemoteMaxID(ctx, ri, convID); err != nil {
+				return nil, err
+			}
+		} else if len(pagination.Next) > 0 {
+			if err = s.decode(pagination.Next, &pid); err != nil {
+				return nil, err
+			}
+			maxID = pid
+		} else {
+			if err = s.decode(pagination.Previous, &pid); err != nil {
+				return nil, err
+			}
+			maxID = chat1.MessageID(int(pid) + num)
+		}
+	}
+	s.debug("Fetch: maxID: %d num: %d", maxID, num)
+
+	// Figure out how to determine we are done seeking
+	var df doneFunc
+	var typmap map[chat1.MessageType]bool
+	if query != nil && len(query.MessageTypes) > 0 {
+		typmap = make(map[chat1.MessageType]bool)
+		for _, mt := range query.MessageTypes {
+			typmap[mt] = true
+		}
+	}
+	simpleDoneFunc := func(msgs *[]chat1.MessageFromServerOrError, num int) bool {
+		return len(*msgs) >= num
+	}
+	typedDoneFunc := func(msgs *[]chat1.MessageFromServerOrError, num int) bool {
+		count := 0
+		for _, msg := range *msgs {
+			if _, ok := typmap[msg.Message.ServerHeader.MessageType]; ok {
+				count++
+			}
+		}
+		return count >= num
+	}
+	if len(typmap) > 0 {
+		s.debug("Fetch: using typed done function: types: %d", len(typmap))
+		df = typedDoneFunc
+	} else {
+		s.debug("Fetch: using simple done function")
+		df = simpleDoneFunc
+	}
+
+	// Run seek looking for all the messages
+	var res []chat1.MessageFromServerOrError
+	if err = s.readMessages(&res, &bi, maxID, num, df); err != nil {
+		return nil, err
+	}
+
+	s.debug("Fetch: cache hit: num: %d", len(res))
+	return res, nil
 }

--- a/go/chat/storage.go
+++ b/go/chat/storage.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-const maxBlockSize = 100
+const blockSize = 100
 
 type Storage struct {
 	sync.Mutex
@@ -20,18 +20,15 @@ type Storage struct {
 }
 
 type blockIndex struct {
-	ConvID   chat1.ConversationID
-	UID      gregor1.UID
-	MaxBlock int
+	ConvID    chat1.ConversationID
+	UID       gregor1.UID
+	MaxBlock  int
+	BlockSize int
 }
 
 type block struct {
 	BlockID int
-	Msgs    [maxBlockSize]chat1.MessageFromServerOrError
-}
-
-type convIndex struct {
-	ConvIDs []chat1.ConversationID
+	Msgs    [blockSize]chat1.MessageFromServerOrError
 }
 
 func NewStorage(g *libkb.GlobalContext) *Storage {
@@ -47,14 +44,14 @@ func (s *Storage) debug(format string, args ...interface{}) {
 func (s *Storage) makeBlockKey(convID chat1.ConversationID, uid gregor1.UID, blockID int) libkb.DbKey {
 	return libkb.DbKey{
 		Typ: libkb.DBChatBlocks,
-		Key: fmt.Sprintf("bl:%s:%s:%d", convID, uid, blockID),
+		Key: fmt.Sprintf("bl:%s:%s:%d", uid, convID, blockID),
 	}
 }
 
 func (s *Storage) makeBlockIndexKey(convID chat1.ConversationID, uid gregor1.UID) libkb.DbKey {
 	return libkb.DbKey{
 		Typ: libkb.DBChatBlockIndex,
-		Key: fmt.Sprintf("bi:%s:%s", convID, uid),
+		Key: fmt.Sprintf("bi:%s:%s", uid, convID),
 	}
 }
 
@@ -76,22 +73,23 @@ func (s *Storage) decode(data []byte, res interface{}) error {
 }
 
 func (s *Storage) getBlockNumber(id chat1.MessageID) int {
-	return int(id) / maxBlockSize
+	return int(id) / blockSize
 }
 
 func (s *Storage) getBlockPosition(id chat1.MessageID) int {
-	return int(id) % maxBlockSize
+	return int(id) % blockSize
 }
 
 func (s *Storage) getMsgID(blockNum, blockPos int) chat1.MessageID {
-	return chat1.MessageID(blockNum*maxBlockSize + blockPos)
+	return chat1.MessageID(blockNum*blockSize + blockPos)
 }
 
 func (s *Storage) createBlockIndex(key libkb.DbKey, convID chat1.ConversationID, uid gregor1.UID) (blockIndex, libkb.ChatStorageError) {
 	bi := blockIndex{
-		ConvID:   convID,
-		UID:      uid,
-		MaxBlock: 0,
+		ConvID:    convID,
+		UID:       uid,
+		MaxBlock:  0,
+		BlockSize: blockSize,
 	}
 
 	s.debug("createBlockIndex: creating new block index: convID: %d uid: %s", convID, uid)
@@ -209,11 +207,12 @@ func (s *Storage) writeBlock(bi blockIndex, b block) libkb.ChatStorageError {
 	return nil
 }
 
-func (s *Storage) mustNuke(force bool, err libkb.ChatStorageError, convID chat1.ConversationID, uid gregor1.UID) libkb.ChatStorageError {
+func (s *Storage) maybeNuke(force bool, err libkb.ChatStorageError, convID chat1.ConversationID, uid gregor1.UID) libkb.ChatStorageError {
 	// Clear index
 	if force || err.ShouldClear() {
 		s.G().Log.Warning("chat local storage corrupted: clearing")
 		if err := s.G().LocalDb.Delete(s.makeBlockIndexKey(convID, uid)); err != nil {
+			s.G().Log.Error("failed to delete chat index, clearing entire database")
 			if _, err = s.G().LocalDb.Nuke(); err != nil {
 				panic("unable to clear local storage")
 			}
@@ -223,6 +222,8 @@ func (s *Storage) mustNuke(force bool, err libkb.ChatStorageError, convID chat1.
 }
 
 func (s *Storage) Merge(convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageFromServerOrError) libkb.ChatStorageError {
+	// All public functions get locks to make access to the database single threaded.
+	// They should never be called from private functons.
 	s.Lock()
 	defer s.Unlock()
 
@@ -231,17 +232,17 @@ func (s *Storage) Merge(convID chat1.ConversationID, uid gregor1.UID, msgs []cha
 	// Get block index first
 	bi, err := s.readBlockIndex(convID, uid)
 	if err != nil {
-		return s.mustNuke(false, err, convID, uid)
+		return s.maybeNuke(false, err, convID, uid)
 	}
 
 	// Write out new data into blocks
 	if err = s.writeMessages(bi, msgs); err != nil {
-		return s.mustNuke(false, err, convID, uid)
+		return s.maybeNuke(false, err, convID, uid)
 	}
 
 	// Update supersededBy pointers
 	if err = s.updateSupersededBy(bi, msgs); err != nil {
-		return s.mustNuke(false, err, convID, uid)
+		return s.maybeNuke(false, err, convID, uid)
 	}
 
 	return nil
@@ -372,7 +373,7 @@ func (s *Storage) readMessages(res *[]chat1.MessageFromServerOrError, bi blockIn
 		}
 
 		msg := b.Msgs[index]
-		if msg.Message == nil {
+		if msg.Message == nil && msg.UnboxingError == nil {
 			s.debug("readMessages: cache entry empty: index: %d block: %d msgID: %d", index, b.BlockID, s.getMsgID(b.BlockID, index))
 			return libkb.ChatStorageMissError{}
 		}
@@ -399,7 +400,8 @@ func (s *Storage) readMessages(res *[]chat1.MessageFromServerOrError, bi blockIn
 func (s *Storage) Fetch(ctx context.Context, conv chat1.Conversation,
 	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination,
 	rl *[]*chat1.RateLimit) (chat1.ThreadView, libkb.ChatStorageError) {
-
+	// All public functions get locks to make access to the database single threaded.
+	// They should never be called from private functons.
 	s.Lock()
 	defer s.Unlock()
 
@@ -407,7 +409,7 @@ func (s *Storage) Fetch(ctx context.Context, conv chat1.Conversation,
 	convID := conv.Metadata.ConversationID
 	bi, err := s.readBlockIndex(convID, uid)
 	if err != nil {
-		return chat1.ThreadView{}, s.mustNuke(false, err, convID, uid)
+		return chat1.ThreadView{}, s.maybeNuke(false, err, convID, uid)
 	}
 
 	// Calculate seek parameters
@@ -424,13 +426,13 @@ func (s *Storage) Fetch(ctx context.Context, conv chat1.Conversation,
 		} else if len(pagination.Next) > 0 {
 			if derr := s.decode(pagination.Next, &pid); derr != nil {
 				err = libkb.ChatStorageRemoteError{Msg: "Fetch: failed to decode pager: " + derr.Error()}
-				return chat1.ThreadView{}, s.mustNuke(false, err, convID, uid)
+				return chat1.ThreadView{}, s.maybeNuke(false, err, convID, uid)
 			}
 			maxID = pid - 1
 		} else {
 			if derr := s.decode(pagination.Previous, &pid); derr != nil {
 				err = libkb.ChatStorageRemoteError{Msg: "Fetch: failed to decode pager: " + derr.Error()}
-				return chat1.ThreadView{}, s.mustNuke(false, err, convID, uid)
+				return chat1.ThreadView{}, s.maybeNuke(false, err, convID, uid)
 			}
 			maxID = chat1.MessageID(int(pid) + num)
 		}

--- a/go/chat/storage_test.go
+++ b/go/chat/storage_test.go
@@ -1,0 +1,255 @@
+package chat
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"testing"
+
+	"github.com/keybase/client/go/chat/pager"
+	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/stretchr/testify/require"
+)
+
+func setupStorageTest(t *testing.T, name string) (libkb.TestContext, *Storage) {
+	tc := externals.SetupTest(t, name, 2)
+	return tc, NewStorage(tc.G)
+}
+
+func randBytes(n int) []byte {
+	ret := make([]byte, n)
+	rand.Read(ret)
+	return ret
+}
+
+func makeMsgWithType(id chat1.MessageID, supersedes chat1.MessageID, typ chat1.MessageType) chat1.MessageFromServerOrError {
+	return chat1.MessageFromServerOrError{
+		Message: &chat1.MessageFromServer{
+			ServerHeader: chat1.MessageServerHeader{
+				MessageID:   id,
+				MessageType: typ,
+			},
+			MessagePlaintext: chat1.NewMessagePlaintextWithV1(chat1.MessagePlaintextV1{
+				ClientHeader: chat1.MessageClientHeader{
+					Supersedes: supersedes,
+				},
+			}),
+		},
+	}
+}
+
+func makeMsg(id chat1.MessageID, supersedes chat1.MessageID) chat1.MessageFromServerOrError {
+	return makeMsgWithType(id, supersedes, chat1.MessageType_TEXT)
+}
+
+func makeMsgRange(max int) (res []chat1.MessageFromServerOrError) {
+	for i := max; i > 0; i-- {
+		res = append(res, makeMsg(chat1.MessageID(i), chat1.MessageID(0)))
+	}
+	return res
+}
+
+func makeConvID(t *testing.T) chat1.ConversationID {
+	// Read into int64
+	var res uint64
+	rbytes := randBytes(8)
+	buf := bytes.NewReader(rbytes)
+	err := binary.Read(buf, binary.LittleEndian, &res)
+	require.NoError(t, err)
+	return chat1.ConversationID(res)
+}
+
+func makeUID() gregor1.UID {
+	raw := randBytes(16)
+	return gregor1.UID(raw)
+}
+
+func makeConversation(t *testing.T, maxID chat1.MessageID) chat1.Conversation {
+	convID := makeConvID(t)
+	return chat1.Conversation{
+		Metadata: chat1.ConversationMetadata{
+			ConversationID: convID,
+		},
+		ReaderInfo: &chat1.ConversationReaderInfo{
+			MaxMsgid: maxID,
+		},
+	}
+}
+
+func TestStorageBasic(t *testing.T) {
+	_, storage := setupStorageTest(t, "basic")
+
+	msgs := makeMsgRange(10)
+	conv := makeConversation(t, msgs[0].GetMessageID())
+	uid := makeUID()
+
+	require.NoError(t, storage.Merge(conv.Metadata.ConversationID, uid, msgs))
+	res, err := storage.Fetch(context.TODO(), conv, uid, nil, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, len(msgs), len(res.Messages), "wrong amount of messages")
+	for i := 0; i < len(res.Messages); i++ {
+		require.Equal(t, msgs[i].GetMessageID(), res.Messages[i].GetMessageID(), "msg mismatch")
+	}
+}
+
+func TestStorageLargeList(t *testing.T) {
+	_, storage := setupStorageTest(t, "large list")
+
+	msgs := makeMsgRange(2000)
+	conv := makeConversation(t, msgs[0].GetMessageID())
+	uid := makeUID()
+
+	require.NoError(t, storage.Merge(conv.Metadata.ConversationID, uid, msgs))
+	res, err := storage.Fetch(context.TODO(), conv, uid, nil, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, len(msgs), len(res.Messages), "wrong amount of messages")
+	for i := 0; i < len(res.Messages); i++ {
+		require.Equal(t, msgs[i].GetMessageID(), res.Messages[i].GetMessageID(), "msg mismatch")
+	}
+}
+
+func TestStorageSupersedes(t *testing.T) {
+	_, storage := setupStorageTest(t, "suprsedes")
+
+	msgs := makeMsgRange(110)
+	superseder := makeMsg(chat1.MessageID(111), 6)
+	superseder2 := makeMsg(chat1.MessageID(112), 11)
+	msgs = append([]chat1.MessageFromServerOrError{superseder}, msgs...)
+	conv := makeConversation(t, msgs[0].GetMessageID())
+	uid := makeUID()
+
+	require.NoError(t, storage.Merge(conv.Metadata.ConversationID, uid, msgs))
+	res, err := storage.Fetch(context.TODO(), conv, uid, nil, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, len(msgs), len(res.Messages), "wrong amount of messages")
+	for i := 0; i < len(res.Messages); i++ {
+		require.Equal(t, msgs[i].GetMessageID(), res.Messages[i].GetMessageID(), "msg mismatch")
+	}
+	sheader := res.Messages[len(msgs)-6].Message.ServerHeader
+	require.Equal(t, chat1.MessageID(6), sheader.MessageID, "MessageID incorrect")
+	require.Equal(t, chat1.MessageID(111), sheader.SupersededBy, "supersededBy incorrect")
+
+	require.NoError(t, storage.Merge(conv.Metadata.ConversationID, uid,
+		[]chat1.MessageFromServerOrError{superseder2}))
+	conv.ReaderInfo.MaxMsgid = 112
+	msgs = append([]chat1.MessageFromServerOrError{superseder2}, msgs...)
+	res, err = storage.Fetch(context.TODO(), conv, uid, nil, nil, nil)
+	require.NoError(t, err)
+
+	sheader = res.Messages[len(msgs)-11].Message.ServerHeader
+	require.Equal(t, chat1.MessageID(11), sheader.MessageID, "MessageID incorrect")
+	require.Equal(t, chat1.MessageID(112), sheader.SupersededBy, "supersededBy incorrect")
+}
+
+func TestStorageMiss(t *testing.T) {
+	_, storage := setupStorageTest(t, "miss")
+
+	msgs := makeMsgRange(10)
+	conv := makeConversation(t, 15)
+	uid := makeUID()
+
+	require.NoError(t, storage.Merge(conv.Metadata.ConversationID, uid, msgs))
+	_, err := storage.Fetch(context.TODO(), conv, uid, nil, nil, nil)
+	require.Error(t, err, "expected error")
+	require.IsType(t, libkb.ChatStorageMissError{}, err, "wrong error type")
+}
+
+func TestStoragePagination(t *testing.T) {
+
+	_, storage := setupStorageTest(t, "basic")
+
+	msgs := makeMsgRange(300)
+	conv := makeConversation(t, msgs[0].GetMessageID())
+	uid := makeUID()
+	require.NoError(t, storage.Merge(conv.Metadata.ConversationID, uid, msgs))
+
+	t.Logf("test next input")
+	tp := pager.NewThreadPager()
+	index, err := tp.MakeIndex(makeMsg(120, 0))
+	require.NoError(t, err)
+	p := chat1.Pagination{
+		Num:  100,
+		Next: index,
+	}
+	res, err := storage.Fetch(context.TODO(), conv, uid, nil, &p, nil)
+	require.NoError(t, err)
+	require.Equal(t, chat1.MessageID(119), msgs[181].GetMessageID(), "wrong msg id at border")
+	require.Equal(t, 100, len(res.Messages), "wrong amount of messages")
+	for i := 0; i < len(res.Messages); i++ {
+		require.Equal(t, msgs[i+181].GetMessageID(), res.Messages[i].GetMessageID(), "msg mismatch")
+	}
+	p = chat1.Pagination{
+		Num:      100,
+		Previous: res.Pagination.Previous,
+	}
+	t.Logf("fetching previous from result")
+	res, err = storage.Fetch(context.TODO(), conv, uid, nil, &p, nil)
+	require.NoError(t, err)
+	require.Equal(t, chat1.MessageID(219), msgs[81].GetMessageID(), "wrong msg id at broder")
+	require.Equal(t, 100, len(res.Messages), "wrong amount of messages")
+	for i := 0; i < len(res.Messages); i++ {
+		require.Equal(t, msgs[i+81].GetMessageID(), res.Messages[i].GetMessageID(), "msg mismatch")
+	}
+
+	t.Logf("test prev input")
+	index, err = tp.MakeIndex(makeMsg(120, 0))
+	require.NoError(t, err)
+	p = chat1.Pagination{
+		Num:      100,
+		Previous: index,
+	}
+	res, err = storage.Fetch(context.TODO(), conv, uid, nil, &p, nil)
+	require.NoError(t, err)
+	require.Equal(t, chat1.MessageID(220), msgs[80].GetMessageID(), "wrong msg id at border")
+	require.Equal(t, 100, len(res.Messages), "wrong amount of messages")
+	for i := 0; i < len(res.Messages); i++ {
+		require.Equal(t, msgs[i+80].GetMessageID(), res.Messages[i].GetMessageID(), "msg mismatch")
+	}
+	p = chat1.Pagination{
+		Num:  100,
+		Next: res.Pagination.Next,
+	}
+	t.Logf("fetching next from result")
+	res, err = storage.Fetch(context.TODO(), conv, uid, nil, &p, nil)
+	require.NoError(t, err)
+	require.Equal(t, 100, len(res.Messages), "wrong amount of messages")
+	for i := 0; i < len(res.Messages); i++ {
+		require.Equal(t, msgs[i+180].GetMessageID(), res.Messages[i].GetMessageID(), "msg mismatch")
+	}
+}
+
+func mkarray(m chat1.MessageFromServerOrError) []chat1.MessageFromServerOrError {
+	return []chat1.MessageFromServerOrError{m}
+}
+
+func TestStorageTypeFilter(t *testing.T) {
+	_, storage := setupStorageTest(t, "basic")
+
+	textmsgs := makeMsgRange(300)
+	uid := makeUID()
+	msgs := append(mkarray(makeMsgWithType(chat1.MessageID(301), 0, chat1.MessageType_EDIT)), textmsgs...)
+	msgs = append(mkarray(makeMsgWithType(chat1.MessageID(302), 0, chat1.MessageType_TLFNAME)), msgs...)
+	msgs = append(mkarray(makeMsgWithType(chat1.MessageID(303), 0, chat1.MessageType_ATTACHMENT)), msgs...)
+	msgs = append(mkarray(makeMsgWithType(chat1.MessageID(304), 0, chat1.MessageType_TEXT)), msgs...)
+	textmsgs = append(mkarray(makeMsgWithType(chat1.MessageID(304), 0, chat1.MessageType_TEXT)), textmsgs...)
+	conv := makeConversation(t, msgs[0].GetMessageID())
+
+	query := chat1.GetThreadQuery{
+		MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+	}
+
+	require.NoError(t, storage.Merge(conv.Metadata.ConversationID, uid, msgs))
+	res, err := storage.Fetch(context.TODO(), conv, uid, &query, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, len(msgs), len(res.Messages), "wrong amount of messages")
+	restexts := FilterByType(res.Messages, &query)
+	require.Equal(t, len(textmsgs), len(restexts), "wrong amount of text messages")
+	for i := 0; i < len(restexts); i++ {
+		require.Equal(t, textmsgs[i].GetMessageID(), restexts[i].GetMessageID(), "msg mismatch")
+	}
+
+}

--- a/go/chat/storage_test.go
+++ b/go/chat/storage_test.go
@@ -2,7 +2,6 @@ package chat
 
 import (
 	"bytes"
-	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"testing"
@@ -13,6 +12,7 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func setupStorageTest(t *testing.T, name string) (libkb.TestContext, *Storage) {

--- a/go/chat/utils.go
+++ b/go/chat/utils.go
@@ -87,3 +87,29 @@ func FilterByType(msgs []chat1.MessageFromServerOrError, query *chat1.GetThreadQ
 	}
 	return res
 }
+
+// AggRateLimitsP takes a list of rate limit responses and dedups them to the last one received
+// of each category
+func AggRateLimitsP(rlimits []*chat1.RateLimit) (res []chat1.RateLimit) {
+	m := make(map[string]chat1.RateLimit)
+	for _, l := range rlimits {
+		if l != nil {
+			m[l.Name] = *l
+		}
+	}
+	for _, v := range m {
+		res = append(res, v)
+	}
+	return res
+}
+
+func AggRateLimits(rlimits []chat1.RateLimit) (res []chat1.RateLimit) {
+	m := make(map[string]chat1.RateLimit)
+	for _, l := range rlimits {
+		m[l.Name] = l
+	}
+	for _, v := range m {
+		res = append(res, v)
+	}
+	return res
+}

--- a/go/client/cmd_chat_api.go
+++ b/go/client/cmd_chat_api.go
@@ -257,7 +257,7 @@ func (c *CmdChatAPI) ReadV1(ctx context.Context, opts readOptionsV1) Reply {
 	for _, m := range threadView.Thread.Messages {
 		if m.UnboxingError != nil {
 			thread.Messages = append(thread.Messages, MsgFromServer{
-				Error: m.UnboxingError,
+				Error: &m.UnboxingError.Errmsg,
 			})
 			continue
 		}

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -130,6 +130,9 @@ const (
 	DBTrackers2               = 0xf3
 	DBTrackers2Reverse        = 0xf4
 	DBNotificationDismiss     = 0xf5
+	DBChatBlockIndex          = 0xf6
+	DBChatConvIndex           = 0xf7
+	DBChatBlocks              = 0xf8
 )
 
 const (

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -131,8 +131,7 @@ const (
 	DBTrackers2Reverse        = 0xf4
 	DBNotificationDismiss     = 0xf5
 	DBChatBlockIndex          = 0xf6
-	DBChatConvIndex           = 0xf7
-	DBChatBlocks              = 0xf8
+	DBChatBlocks              = 0xf7
 )
 
 const (

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -852,6 +852,13 @@ func (e *Env) GetTimers() string {
 	)
 }
 
+func (e *Env) GetConvSourceType() string {
+	return e.GetString(
+		func() string { return os.Getenv("KEYBASE_CONV_SOURCE_TYPE") },
+		func() string { return "hybrid" },
+	)
+}
+
 func (e *Env) GetDeviceID() keybase1.DeviceID {
 	return e.config.GetDeviceID()
 }

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1717,3 +1717,63 @@ type ChatTLFFinalizedError struct {
 func (e ChatTLFFinalizedError) Error() string {
 	return fmt.Sprintf("unable to create conversation on finalized TLF: %s", e.TlfID)
 }
+
+//=============================================================================
+
+type ChatStorageError interface {
+	error
+	ShouldClear() bool
+	Message() string
+}
+
+type ChatStorageInternalError struct {
+	Msg string
+}
+
+func (e ChatStorageInternalError) ShouldClear() bool {
+	return true
+}
+
+func (e ChatStorageInternalError) Error() string {
+	return fmt.Sprintf("internal chat storage error: %s", e.Msg)
+}
+
+func (e ChatStorageInternalError) Message() string {
+	return e.Msg
+}
+
+func NewChatStorageInternalError(g *GlobalContext, msg string, args ...interface{}) ChatStorageInternalError {
+	g.Log.Debug("internal chat storage error: "+msg, args...)
+	return ChatStorageInternalError{Msg: msg}
+}
+
+type ChatStorageMissError struct {
+}
+
+func (e ChatStorageMissError) Error() string {
+	return "chat cache miss"
+}
+
+func (e ChatStorageMissError) ShouldClear() bool {
+	return false
+}
+
+func (e ChatStorageMissError) Message() string {
+	return e.Error()
+}
+
+type ChatStorageRemoteError struct {
+	Msg string
+}
+
+func (e ChatStorageRemoteError) Error() string {
+	return fmt.Sprintf("chat remote error: %s", e.Msg)
+}
+
+func (e ChatStorageRemoteError) ShouldClear() bool {
+	return false
+}
+
+func (e ChatStorageRemoteError) Message() string {
+	return e.Msg
+}

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1744,7 +1744,7 @@ func (e ChatStorageInternalError) Message() string {
 
 func NewChatStorageInternalError(g *GlobalContext, msg string, args ...interface{}) ChatStorageInternalError {
 	g.Log.Debug("internal chat storage error: "+msg, args...)
-	return ChatStorageInternalError{Msg: msg}
+	return ChatStorageInternalError{Msg: fmt.Sprintf(msg, args...)}
 }
 
 type ChatStorageMissError struct {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -86,6 +86,8 @@ type GlobalContext struct {
 
 	CardCache *UserCardCache // cache of keybase1.UserCard objects
 
+	ConvSource ConversationSource // source of remote message bodies for chat
+
 	// Can be overloaded by tests to get an improvement in performance
 	NewTriplesec func(pw []byte, salt []byte) (Triplesec, error)
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -22,6 +22,7 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	gregor "github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/chat1"
 	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	jsonw "github.com/keybase/go-jsonw"
@@ -515,4 +516,12 @@ type ServiceType interface {
 type ExternalServicesCollector interface {
 	GetServiceType(n string) ServiceType
 	ListProofCheckers(mode RunMode) []string
+}
+
+type ConversationSource interface {
+	Push(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
+		msg chat1.MessageBoxed) (chat1.MessageFromServerOrError, error)
+	Pull(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, query *chat1.GetThreadQuery,
+		pagination *chat1.Pagination) (chat1.ThreadView, []*chat1.RateLimit, error)
+	Clear(convID chat1.ConversationID, uid gregor1.UID) error
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -107,6 +107,17 @@ func (hash Hash) Eq(other Hash) bool {
 func (m MessageFromServerOrError) GetMessageID() MessageID {
 	if m.Message != nil {
 		return m.Message.ServerHeader.MessageID
+	} else if m.UnboxingError != nil {
+		return m.UnboxingError.MessageID
 	}
 	return 0
+}
+
+func (m MessageFromServerOrError) GetMessageType() MessageType {
+	if m.Message != nil {
+		return m.Message.ServerHeader.MessageType
+	} else if m.UnboxingError != nil {
+		return m.UnboxingError.MessageType
+	}
+	return MessageType_NONE
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -103,3 +103,10 @@ func (hash Hash) String() string {
 func (hash Hash) Eq(other Hash) bool {
 	return bytes.Equal(hash, other)
 }
+
+func (m MessageFromServerOrError) GetMessageID() MessageID {
+	if m.Message != nil {
+		return m.Message.ServerHeader.MessageID
+	}
+	return 0
+}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -363,8 +363,14 @@ type MessageFromServer struct {
 	HeaderHash       Hash                `codec:"headerHash" json:"headerHash"`
 }
 
+type MessageError struct {
+	Errmsg      string      `codec:"errmsg" json:"errmsg"`
+	MessageID   MessageID   `codec:"messageID" json:"messageID"`
+	MessageType MessageType `codec:"messageType" json:"messageType"`
+}
+
 type MessageFromServerOrError struct {
-	UnboxingError *string            `codec:"unboxingError,omitempty" json:"unboxingError,omitempty"`
+	UnboxingError *MessageError      `codec:"unboxingError,omitempty" json:"unboxingError,omitempty"`
 	Message       *MessageFromServer `codec:"message,omitempty" json:"message,omitempty"`
 }
 

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -221,7 +221,8 @@ func (h *chatLocalHandler) GetInboxAndUnboxLocal(ctx context.Context, arg chat1.
 
 // GetThreadLocal implements keybase.chatLocal.getThreadLocal protocol.
 func (h *chatLocalHandler) GetThreadLocal(ctx context.Context, arg chat1.GetThreadLocalArg) (chat1.GetThreadLocalRes, error) {
-	if err := h.assertLoggedIn(ctx); err != nil {
+	var err error
+	if err = h.assertLoggedIn(ctx); err != nil {
 		return chat1.GetThreadLocalRes{}, err
 	}
 
@@ -235,7 +236,7 @@ func (h *chatLocalHandler) GetThreadLocal(ctx context.Context, arg chat1.GetThre
 		h.G().Log.Debug("GetThreadLocal cache hit: convID: %d uid: %s", arg.ConversationID, uid)
 		return chat1.GetThreadLocalRes{
 			Thread: chat1.ThreadView{
-				Messages: localData,
+				Messages: chat.FilterByType(localData, arg.Query),
 			},
 		}, nil
 	}

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -27,6 +27,9 @@ type chatLocalHandler struct {
 	gh    *gregorHandler
 	tlf   keybase1.TlfInterface
 	boxer *chat.Boxer
+
+	// Only for testing
+	rc chat1.RemoteInterface
 }
 
 // newChatLocalHandler creates a chatLocalHandler.
@@ -39,7 +42,9 @@ func newChatLocalHandler(xp rpc.Transporter, g *libkb.GlobalContext, gh *gregorH
 		tlf:          tlf,
 		boxer:        chat.NewBoxer(g, tlf),
 	}
-	chat.SetConversationSource(chat.NewHybridConversationSource(g, h.boxer, h.remoteClient()))
+	if gh != nil {
+		chat.SetConversationSource(chat.NewHybridConversationSource(g, h.boxer, h.remoteClient()))
+	}
 	return h
 }
 
@@ -787,7 +792,14 @@ func (h *chatLocalHandler) getSecretUI() libkb.SecretUI {
 
 // remoteClient returns a client connection to gregord.
 func (h *chatLocalHandler) remoteClient() chat1.RemoteInterface {
+	if h.rc != nil {
+		return h.rc
+	}
 	return &chat1.RemoteClient{Cli: h.gh.cli}
+}
+
+func (h *chatLocalHandler) setTestRemoteClient(ri chat1.RemoteInterface) {
+	h.rc = ri
 }
 
 func (h *chatLocalHandler) assertLoggedIn(ctx context.Context) error {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -107,7 +107,7 @@ func (h *chatLocalHandler) GetInboxLocal(ctx context.Context, arg chat1.GetInbox
 	return chat1.GetInboxLocalRes{
 		ConversationsUnverified: ib.Inbox.Conversations,
 		Pagination:              ib.Inbox.Pagination,
-		RateLimits:              h.aggRateLimitsP([]*chat1.RateLimit{ib.RateLimit}),
+		RateLimits:              chat.AggRateLimitsP([]*chat1.RateLimit{ib.RateLimit}),
 	}, nil
 }
 

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -43,7 +43,8 @@ func newChatLocalHandler(xp rpc.Transporter, g *libkb.GlobalContext, gh *gregorH
 		boxer:        chat.NewBoxer(g, tlf),
 	}
 	if gh != nil {
-		chat.SetConversationSource(chat.NewHybridConversationSource(g, h.boxer, h.remoteClient()))
+		g.ConvSource = chat.NewConversationSource(g, g.Env.GetConvSourceType(), h.boxer,
+			h.remoteClient())
 	}
 	return h
 }
@@ -173,7 +174,7 @@ func (h *chatLocalHandler) GetThreadLocal(ctx context.Context, arg chat1.GetThre
 	if uid.IsNil() {
 		return chat1.GetThreadLocalRes{}, libkb.LoginRequiredError{}
 	}
-	thread, rl, err := chat.GetConversationSource().Pull(ctx, arg.ConversationID,
+	thread, rl, err := h.G().ConvSource.Pull(ctx, arg.ConversationID,
 		gregor1.UID(uid.ToBytes()), arg.Query, arg.Pagination)
 	if err != nil {
 		return chat1.GetThreadLocalRes{}, err

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -64,7 +64,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	mockRemote := kbtest.NewChatRemoteMock(c.world)
 	h.tlf = kbtest.NewTlfMock(c.world)
 	h.boxer = chat.NewBoxer(tc.G, h.tlf)
-	chat.SetConversationSource(chat.NewRemoteConversationSource(tc.G, h.boxer, mockRemote))
+	chat.SetConversationSource(chat.NewHybridConversationSource(tc.G, h.boxer, mockRemote))
 	h.setTestRemoteClient(mockRemote)
 
 	tuc := &chatTestUserContext{
@@ -376,7 +376,7 @@ func TestChatGracefulUnboxing(t *testing.T) {
 		t.Fatalf("unexpected response from GetThreadLocal. expected 3 items, got %d\n", len(tv.Thread.Messages))
 	}
 	if tv.Thread.Messages[0].Message != nil ||
-		tv.Thread.Messages[0].UnboxingError == nil || len(*tv.Thread.Messages[0].UnboxingError) == 0 {
+		tv.Thread.Messages[0].UnboxingError == nil || len(tv.Thread.Messages[0].UnboxingError.Errmsg) == 0 {
 		t.Fatalf("unexpected response from GetThreadLocal. expected an error message from bad msg, got %#+v\n", tv.Thread.Messages[0])
 	}
 	if tv.Thread.Messages[1].Message == nil || tv.Thread.Messages[1].Message.MessagePlaintext.V1().MessageBody.Text().Body != "innocent hello" {

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -61,9 +61,12 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 		t.Fatalf("user %s is not found", user.Username)
 	}
 	h := newChatLocalHandler(nil, tc.G, nil)
-	h.rc = kbtest.NewChatRemoteMock(c.world)
+	mockRemote := kbtest.NewChatRemoteMock(c.world)
 	h.tlf = kbtest.NewTlfMock(c.world)
 	h.boxer = chat.NewBoxer(tc.G, h.tlf)
+	chat.SetConversationSource(chat.NewRemoteConversationSource(tc.G, h.boxer, mockRemote))
+	h.setTestRemoteClient(mockRemote)
+
 	tuc := &chatTestUserContext{
 		h: h,
 		u: user,

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -64,7 +64,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	mockRemote := kbtest.NewChatRemoteMock(c.world)
 	h.tlf = kbtest.NewTlfMock(c.world)
 	h.boxer = chat.NewBoxer(tc.G, h.tlf)
-	chat.SetConversationSource(chat.NewHybridConversationSource(tc.G, h.boxer, mockRemote))
+	tc.G.ConvSource = chat.NewHybridConversationSource(tc.G, h.boxer, mockRemote)
 	h.setTestRemoteClient(mockRemote)
 
 	tuc := &chatTestUserContext{

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -11,7 +11,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/jonboulle/clockwork"
-	"github.com/keybase/client/go/chat"
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/gregor"
 	grclient "github.com/keybase/client/go/gregor/client"
@@ -869,7 +868,7 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 		g.G().Log.Debug("push handler: chat activity: newMessage: convID: %d sender: %s",
 			nm.ConvID, nm.Message.ServerHeader.Sender)
 		uid := m.UID().Bytes()
-		decmsg, err := chat.GetConversationSource().Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
+		decmsg, err := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
 		if err != nil {
 			g.G().Log.Error("push handler: chat activity: unable to storage message: %s", err.Error())
 		}

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -115,9 +115,15 @@ protocol local {
     string senderDeviceName;
     Hash headerHash;
   }
+  
+  record MessageError {
+    string errmsg;
+    MessageID messageID;
+    MessageType messageType;
+  }
 
   record MessageFromServerOrError {
-    union { null, string } unboxingError;
+    union { null, MessageError } unboxingError;
     union { null, MessageFromServer } message;
   }
 

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -550,6 +550,12 @@ export type MessageEdit = {
   body: string,
 }
 
+export type MessageError = {
+  errmsg: string,
+  messageID: MessageID,
+  messageType: MessageType,
+}
+
 export type MessageFromServer = {
   serverHeader: MessageServerHeader,
   messagePlaintext: MessagePlaintext,
@@ -559,7 +565,7 @@ export type MessageFromServer = {
 }
 
 export type MessageFromServerOrError = {
-  unboxingError?: ?string,
+  unboxingError?: ?MessageError,
   message?: ?MessageFromServer,
 }
 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -337,12 +337,30 @@
     },
     {
       "type": "record",
+      "name": "MessageError",
+      "fields": [
+        {
+          "type": "string",
+          "name": "errmsg"
+        },
+        {
+          "type": "MessageID",
+          "name": "messageID"
+        },
+        {
+          "type": "MessageType",
+          "name": "messageType"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "MessageFromServerOrError",
       "fields": [
         {
           "type": [
             null,
-            "string"
+            "MessageError"
           ],
           "name": "unboxingError"
         },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -550,6 +550,12 @@ export type MessageEdit = {
   body: string,
 }
 
+export type MessageError = {
+  errmsg: string,
+  messageID: MessageID,
+  messageType: MessageType,
+}
+
 export type MessageFromServer = {
   serverHeader: MessageServerHeader,
   messagePlaintext: MessagePlaintext,
@@ -559,7 +565,7 @@ export type MessageFromServer = {
 }
 
 export type MessageFromServerOrError = {
-  unboxingError?: ?string,
+  unboxingError?: ?MessageError,
   message?: ?MessageFromServer,
 }
 


### PR DESCRIPTION
@maxtaco @patrickxb @songgao @oconnor663 r?

A couple highlights from this patch:

1. The goal of the interface into storage is to act as much like the unboxed result from the server as possible. Therefore, we deal in `chat1.MessageFromServerOrError` types on the disk.
2. We use a chunked block scheme on the disk with LevelDB to actually store messages.
3. We don't attempt to send anything like a transaction through LevelDB, instead relying on a Go mutex to make all access to the store single threaded. If there is some weird consistency failure, we are aggressive about nuking local storage to recover.
4. We did not attempt a "smart sync" in this patch, instead just sending the entire `GetThreadLocal` request to the server if we miss the cache. A smarter solution would be to just get what the cache is missing.

I am happy to walk people through this PR if they want on video, I hope it looks ok!