### PR TITLE
Unmount KBFS on stop (app quit)

### DIFF
--- a/go/client/cmd_ctl_stop_osx.go
+++ b/go/client/cmd_ctl_stop_osx.go
@@ -85,7 +85,7 @@ func ctlStop(g *libkb.GlobalContext, components map[string]bool, wait time.Durat
 		}
 	}
 	if ok := components[install.ComponentNameKBFS.String()]; ok {
-		if err := install.UninstallKBFSServices(runMode, g.Log); err != nil {
+		if err := install.UninstallKBFSOnStop(g, g.Log); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/go/install/fuse_status_osx.go
+++ b/go/install/fuse_status_osx.go
@@ -202,7 +202,7 @@ func checkFuseUpgrade(context Context, appPath string, force bool, log Log) (rei
 		if hasKBFuseMounts {
 			log.Info("We have mounts, let's uninstall KBFS so the installer can upgrade")
 			reinstallKBFS = true
-			err = UninstallKBFS(runMode, mountDir, true, log)
+			err = UninstallKBFS(runMode, mountDir, true, true, log)
 			if err != nil {
 				return
 			}

--- a/go/install/install_osx.go
+++ b/go/install/install_osx.go
@@ -643,7 +643,7 @@ func execNativeInstallerWithArg(arg string, runMode libkb.RunMode, log Log) erro
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(nativeInstallerAppBundleExecPath(appPath), fmt.Sprintf("--run-mode=%s", runMode), arg)
+	cmd := exec.Command(nativeInstallerAppBundleExecPath(appPath), fmt.Sprintf("--run-mode=%s", runMode), fmt.Sprintf("--app-path=%s", appPath), fmt.Sprintf("--timeout=10"), arg)
 	output, err := cmd.CombinedOutput()
 	log.Debug("Output (%s): %s", arg, string(output))
 	return err

--- a/go/install/install_osx.go
+++ b/go/install/install_osx.go
@@ -565,7 +565,7 @@ func Uninstall(context Context, components []string, log Log) keybase1.Uninstall
 	return newUninstallResult(componentResults)
 }
 
-// UninstallKBFSOnStop removes KBFS services and unmounts
+// UninstallKBFSOnStop removes KBFS services and unmounts and removes /keybase from the system
 func UninstallKBFSOnStop(context Context, log Log) error {
 	runMode := context.GetRunMode()
 	mountDir, err := context.GetMountDir()
@@ -575,8 +575,8 @@ func UninstallKBFSOnStop(context Context, log Log) error {
 	return UninstallKBFS(runMode, mountDir, false, true, log)
 }
 
-// UninstallKBFS uninstalls all KBFS services, unmounts and optionally removes the directory
-func UninstallKBFS(runMode libkb.RunMode, mountDir string, forceUnmount bool, removeDir bool, log Log) error {
+// UninstallKBFS uninstalls all KBFS services, unmounts and optionally removes the mount directory
+func UninstallKBFS(runMode libkb.RunMode, mountDir string, forceUnmount bool, removeMountDir bool, log Log) error {
 	err := UninstallKBFSServices(runMode, log)
 	if err != nil {
 		return err
@@ -605,7 +605,7 @@ func UninstallKBFS(runMode libkb.RunMode, mountDir string, forceUnmount bool, re
 		return fmt.Errorf("Mount has files after unmounting: %s", mountDir)
 	}
 
-	if removeDir {
+	if removeMountDir {
 		log.Info("Removing %s", mountDir)
 		if err := uninstallMountDir(runMode, log); err != nil {
 			return fmt.Errorf("Error removing mount dir: %s", err)


### PR DESCRIPTION
We were stopping KBFS on ctl stop and app quit, but not unmounting it. This PR does unmount on stop/quit (and removes the placeholder dir too).

Leaving the mount made the Keybase folder stay visible on desktop (if Finder config was set to show connected servers), even after Keybase app was quit.

@patrickxb @maxtaco ?

cc @keybase/react-hackers @strib 