### PR TITLE
Windows update: Don't kill keybase until --kill-kbfs is issued

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -30,8 +30,8 @@
     <InstallExecuteSequence>
       <InstallValidate Suppress="yes">FAKE_PROPERTY</InstallValidate>
       <Custom Action="StopUpdater" Before="InstallValidate"/>
+      <Custom Action="StopMainApp" Before="StopGUI"/>
       <Custom Action="StopGUI" Before="InstallValidate"/>
-      <Custom Action="StopMainApp" Before="InstallValidate"/>
       <Custom Action="RunMainApp" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       <Custom Action="RunGUI" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       


### PR DESCRIPTION
This fixed the Win7 32 silent update case I found wasn't working today - but note that, unfortunately, those users will have to reboot still because this change is not in the (un)installer they currently have.
@maxtaco @cjb @oconnor663 