### PR TITLE
guard against inserting a blank TLF name

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -202,7 +202,7 @@ func (b *Boxer) boxMessageV1(ctx context.Context, msg chat1.MessagePlaintextV1, 
 			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 		})
 		if err != nil {
-			return nil, libkb.ChatBoxingError{Msg: err.Error()}
+			return nil, libkb.ChatBoxingError{Msg: "PublicCanonicalTLFNameAndID: " + err.Error()}
 		}
 		msg.ClientHeader.TlfName = string(res.CanonicalName)
 	} else {
@@ -211,18 +211,19 @@ func (b *Boxer) boxMessageV1(ctx context.Context, msg chat1.MessagePlaintextV1, 
 			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 		})
 		if err != nil {
-			return nil, libkb.ChatBoxingError{Msg: err.Error()}
+			return nil, libkb.ChatBoxingError{Msg: "CryptKeys: " + err.Error()}
 		}
 		msg.ClientHeader.TlfName = string(keys.NameIDBreaks.CanonicalName)
-		if len(msg.ClientHeader.TlfName) == 0 {
-			return nil, libkb.ChatBoxingError{Msg: fmt.Sprintf("blank TLF name received: original: %s canonical: %s", tlfName, msg.ClientHeader.TlfName)}
-		}
 
 		for _, key := range keys.CryptKeys {
 			if recentKey == nil || key.KeyGeneration > recentKey.KeyGeneration {
 				recentKey = &key
 			}
 		}
+	}
+
+	if len(msg.ClientHeader.TlfName) == 0 {
+		return nil, libkb.ChatBoxingError{Msg: fmt.Sprintf("blank TLF name received: original: %s canonical: %s", tlfName, msg.ClientHeader.TlfName)}
 	}
 
 	if recentKey == nil {

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -192,6 +192,9 @@ func (b *Boxer) boxMessageV1(ctx context.Context, msg chat1.MessagePlaintextV1, 
 	tlfName := msg.ClientHeader.TlfName
 	var recentKey *keybase1.CryptKey
 
+	if len(tlfName) == 0 {
+		return nil, libkb.ChatBoxingError{Msg: "blank TLF name given"}
+	}
 	if msg.ClientHeader.TlfPublic {
 		recentKey = &publicCryptKey
 		res, err := b.tlf.PublicCanonicalTLFNameAndID(ctx, keybase1.TLFQuery{
@@ -211,6 +214,9 @@ func (b *Boxer) boxMessageV1(ctx context.Context, msg chat1.MessagePlaintextV1, 
 			return nil, libkb.ChatBoxingError{Msg: err.Error()}
 		}
 		msg.ClientHeader.TlfName = string(keys.NameIDBreaks.CanonicalName)
+		if len(msg.ClientHeader.TlfName) == 0 {
+			return nil, libkb.ChatBoxingError{Msg: fmt.Sprintf("blank TLF name received: original: %s canonical: %s", tlfName, msg.ClientHeader.TlfName)}
+		}
 
 		for _, key := range keys.CryptKeys {
 			if recentKey == nil || key.KeyGeneration > recentKey.KeyGeneration {

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -270,6 +270,7 @@ func TestChatMessagePublic(t *testing.T) {
 	header := chat1.MessageClientHeader{
 		Sender:    gregor1.UID(u.User.GetUID().ToBytes()),
 		TlfPublic: true,
+		TlfName:   "hi",
 	}
 	msg := textMsgWithHeader(t, text, header)
 


### PR DESCRIPTION
@maxtaco r?

This stops us from inserting a blank TLF name (for whatever reason), which is what I think is triggering the error on the integration test. We should never let this happen anyway, so this check is good to have.