### PR TITLE
Zanderz/core 3927

### DIFF
--- a/packaging/windows/doinstaller_wix.cmd
+++ b/packaging/windows/doinstaller_wix.cmd
@@ -136,6 +136,9 @@ IF %UpdateChannel% EQU Test (
 IF %UpdateChannel% EQU Smoke (
   set JSON_UPDATE_FILENAME=update-windows-prod-%KEYBASE_VERSION%.json
 )
+IF %UpdateChannel% EQU Smoke2 (
+  set JSON_UPDATE_FILENAME=update-windows-prod-%KEYBASE_VERSION%.json
+)
 echo %JSON_UPDATE_FILENAME%
 
 :: Run keybase sign to get signature of update

--- a/packaging/windows/doinstaller_wix.cmd
+++ b/packaging/windows/doinstaller_wix.cmd
@@ -127,7 +127,16 @@ IF %ERRORLEVEL% NEQ 0 (
   EXIT /B 1
 )
 
-if NOT DEFINED JSON_UPDATE_FILENAME set JSON_UPDATE_FILENAME=update-windows-prod-v2.json
+:: UpdateChannel Smoke Test None
+echo UpdateChannel: %UpdateChannel%
+set JSON_UPDATE_FILENAME=update-windows-prod-v2.json
+IF %UpdateChannel% EQ Test (
+  set JSON_UPDATE_FILENAME=update-windows-prod-test-v2.json
+)
+IF %UpdateChannel% EQ Smoke (
+  set JSON_UPDATE_FILENAME=update-windows-prod-KEYBASE_VERSION.json
+)
+
 
 :: Run keybase sign to get signature of update
 set KeybaseBin="%APPDATA%\Keybase\keybase.exe"

--- a/packaging/windows/doinstaller_wix.cmd
+++ b/packaging/windows/doinstaller_wix.cmd
@@ -127,14 +127,14 @@ IF %ERRORLEVEL% NEQ 0 (
   EXIT /B 1
 )
 
-:: UpdateChannel Smoke Test None
+:: UpdateChannel is a Jenkins select parameter, one of: Smoke, Test, None
 echo UpdateChannel: %UpdateChannel%
 set JSON_UPDATE_FILENAME=update-windows-prod-v2.json
 IF %UpdateChannel% EQU Test (
   set JSON_UPDATE_FILENAME=update-windows-prod-test-v2.json
 )
 IF %UpdateChannel% EQU Smoke (
-  set JSON_UPDATE_FILENAME=update-windows-prod-KEYBASE_VERSION.json
+  set JSON_UPDATE_FILENAME=update-windows-prod-%KEYBASE_VERSION%.json
 )
 echo %JSON_UPDATE_FILENAME%
 

--- a/packaging/windows/doinstaller_wix.cmd
+++ b/packaging/windows/doinstaller_wix.cmd
@@ -130,13 +130,13 @@ IF %ERRORLEVEL% NEQ 0 (
 :: UpdateChannel Smoke Test None
 echo UpdateChannel: %UpdateChannel%
 set JSON_UPDATE_FILENAME=update-windows-prod-v2.json
-IF %UpdateChannel% EQ Test (
+IF %UpdateChannel% EQU Test (
   set JSON_UPDATE_FILENAME=update-windows-prod-test-v2.json
 )
-IF %UpdateChannel% EQ Smoke (
+IF %UpdateChannel% EQU Smoke (
   set JSON_UPDATE_FILENAME=update-windows-prod-KEYBASE_VERSION.json
 )
-
+echo %JSON_UPDATE_FILENAME%
 
 :: Run keybase sign to get signature of update
 set KeybaseBin="%APPDATA%\Keybase\keybase.exe"


### PR DESCRIPTION
Jenkins was changed to match this and perform the relevant promotion, per this build made off this branch:
https://ci.keybase.io/job/gui_wix/214/
@maxtaco @cjb @oconnor663 

The build can be duplicated by copying all the hashes for the 4 repos, but there needs to be a better way, but that's a separate PR.
