### PR TITLE
Disable open folder on mobile

### DIFF
--- a/shared/folders/files/render.native.js
+++ b/shared/folders/files/render.native.js
@@ -46,7 +46,6 @@ class Render extends Component<void, Props, void> {
     if (!this.props.recentFilesEnabled) {
       return (
         <Box style={{...globalStyles.flexBoxColumn, flex: 1, justifyContent: 'center', alignItems: 'center'}}>
-          <Button key='open' type='Primary' onClick={this.props.openCurrentFolder} label='Open folder' style={{marginBottom: 20}} />
           {ignored
           ? allowIgnore && <Button type='Secondary' onClick={this.props.unIgnoreCurrentFolder} label='Unignore folder' />
           : allowIgnore && <Button backgroundMode={isPrivate ? 'Terminal' : 'Normal'} type='Secondary' onClick={this.props.ignoreCurrentFolder} label='Ignore folder' />}


### PR DESCRIPTION
@keybase/react-hackers 

Nojima says "really when we can list files we won't show this anyways. the open folder / ignore buttons are just a workaround until we can do that"