### PR TITLE
ForceDisplay for Identify2

### DIFF
--- a/go/client/cmd_id.go
+++ b/go/client/cmd_id.go
@@ -20,6 +20,7 @@ type CmdID struct {
 	user           string
 	useDelegateUI  bool
 	skipProofCache bool
+	forceDisplay   bool
 }
 
 func (v *CmdID) ParseArgv(ctx *cli.Context) error {
@@ -33,13 +34,15 @@ func (v *CmdID) ParseArgv(ctx *cli.Context) error {
 	}
 	v.useDelegateUI = ctx.Bool("ui")
 	v.skipProofCache = ctx.Bool("skip-proof-cache")
+	v.forceDisplay = ctx.Bool("force-display")
 	return nil
 }
 
 func (v *CmdID) makeArg() keybase1.Identify2Arg {
 	return keybase1.Identify2Arg{
 		UserAssertion:    v.user,
-		UseDelegateUI:    v.useDelegateUI,
+		UseDelegateUI:    v.useDelegateUI || v.forceDisplay,
+		ForceDisplay:     v.forceDisplay,
 		Reason:           keybase1.IdentifyReason{Reason: "CLI id command"},
 		ForceRemoteCheck: v.skipProofCache,
 		AlwaysBlock:      true,
@@ -87,6 +90,11 @@ func NewCmdID(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 			cli.BoolFlag{
 				Name:      "ui",
 				Usage:     "Use identify UI.",
+				HideUsage: !develUsage,
+			},
+			cli.BoolFlag{
+				Name:      "force-display",
+				Usage:     "Force identify UI to draw (even if still fresh)",
 				HideUsage: !develUsage,
 			},
 			cli.BoolFlag{

--- a/go/client/identify_ui.go
+++ b/go/client/identify_ui.go
@@ -76,7 +76,7 @@ func (i *IdentifyUIServer) DisplayUserCard(_ context.Context, arg keybase1.Displ
 }
 
 func (i *IdentifyUIServer) Start(_ context.Context, arg keybase1.StartArg) error {
-	i.ui.Start(arg.Username, arg.Reason)
+	i.ui.Start(arg.Username, arg.Reason, arg.ForceDisplay)
 	return nil
 }
 

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -50,7 +50,7 @@ type IdentifyUI struct {
 	BaseIdentifyUI
 }
 
-func (ui BaseIdentifyUI) Start(username string, reason keybase1.IdentifyReason) error {
+func (ui BaseIdentifyUI) Start(username string, reason keybase1.IdentifyReason, forceDisplay bool) error {
 	msg := "Identifying "
 	switch reason.Type {
 	case keybase1.IdentifyReasonType_TRACK:

--- a/go/engine/buffered_identify_ui.go
+++ b/go/engine/buffered_identify_ui.go
@@ -14,6 +14,7 @@ import (
 type start struct {
 	s string
 	r keybase1.IdentifyReason
+	f bool
 }
 
 type proofCheck struct {
@@ -53,10 +54,10 @@ func newBufferedIdentifyUI(g *libkb.GlobalContext, u libkb.IdentifyUI, c keybase
 	}
 }
 
-func (b *bufferedIdentifyUI) Start(s string, r keybase1.IdentifyReason) error {
+func (b *bufferedIdentifyUI) Start(s string, r keybase1.IdentifyReason, f bool) error {
 	b.Lock()
 	defer b.Unlock()
-	b.start = &start{s, r}
+	b.start = &start{s, r, f}
 	return b.flush(false)
 }
 
@@ -81,7 +82,7 @@ func (b *bufferedIdentifyUI) flush(trackingBroke bool) (err error) {
 	}()
 
 	if b.start != nil {
-		err = b.raw.Start(b.start.s, b.start.r)
+		err = b.raw.Start(b.start.s, b.start.r, b.start.f)
 		if err != nil {
 			return err
 		}

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -250,7 +250,7 @@ func (ui *FakeIdentifyUI) ReportLastTrack(*keybase1.TrackSummary) error {
 	return nil
 }
 
-func (ui *FakeIdentifyUI) Start(username string, _ keybase1.IdentifyReason) error {
+func (ui *FakeIdentifyUI) Start(username string, _ keybase1.IdentifyReason, _ bool) error {
 	ui.Lock()
 	defer ui.Unlock()
 	ui.StartCount++

--- a/go/engine/identify.go
+++ b/go/engine/identify.go
@@ -119,7 +119,7 @@ func (e *Identify) Run(ctx *Context) error {
 		}
 	}
 
-	ctx.IdentifyUI.Start(e.user.GetName(), e.arg.Reason)
+	ctx.IdentifyUI.Start(e.user.GetName(), e.arg.Reason, false /* force display */)
 
 	e.outcome, err = e.run(ctx)
 	if err != nil {

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -155,7 +155,7 @@ func (i *Identify2WithUIDTester) Dismiss(_ string, _ keybase1.DismissReason) err
 	return nil
 }
 
-func (i *Identify2WithUIDTester) Start(string, keybase1.IdentifyReason) error {
+func (i *Identify2WithUIDTester) Start(string, keybase1.IdentifyReason, bool) error {
 	i.startCh <- struct{}{}
 	return nil
 }

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -392,7 +392,7 @@ func (e *Identify2WithUID) runIdentifyUI(ctx *Context) (err error) {
 	e.remotesReceived = e.them.BaseProofSet()
 
 	iui := ctx.IdentifyUI
-	if e.useTracking && e.arg.CanSuppressUI {
+	if e.useTracking && e.arg.CanSuppressUI && !e.arg.ForceDisplay {
 		iui = newBufferedIdentifyUI(e.G(), iui, keybase1.ConfirmResult{
 			IdentityConfirmed: true,
 		})
@@ -401,7 +401,7 @@ func (e *Identify2WithUID) runIdentifyUI(ctx *Context) (err error) {
 	}
 
 	e.G().Log.Debug("| IdentifyUI.Start(%s)", e.them.GetName())
-	if err = iui.Start(e.them.GetName(), e.arg.Reason); err != nil {
+	if err = iui.Start(e.them.GetName(), e.arg.Reason, e.arg.ForceDisplay); err != nil {
 		return err
 	}
 	for _, k := range e.identifyKeys {

--- a/go/engine/loopback_identify_ui.go
+++ b/go/engine/loopback_identify_ui.go
@@ -23,7 +23,7 @@ func newLoopbackIdentifyUI(g *libkb.GlobalContext, tb **keybase1.IdentifyTrackBr
 	}
 }
 
-func (b *loopbackIdentifyUI) Start(s string, r keybase1.IdentifyReason) error {
+func (b *loopbackIdentifyUI) Start(s string, r keybase1.IdentifyReason, f bool) error {
 	return nil
 }
 

--- a/go/kbtest/ui.go
+++ b/go/kbtest/ui.go
@@ -140,7 +140,7 @@ func (ui *FakeIdentifyUI) DisplayKey(ik keybase1.IdentifyKey) error {
 func (ui *FakeIdentifyUI) ReportLastTrack(*keybase1.TrackSummary) error {
 	return nil
 }
-func (ui *FakeIdentifyUI) Start(username string, _ keybase1.IdentifyReason) error {
+func (ui *FakeIdentifyUI) Start(username string, _ keybase1.IdentifyReason, forceDisplay bool) error {
 	ui.Lock()
 	defer ui.Unlock()
 	ui.StartCount++

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -272,7 +272,7 @@ type ExternalAPI interface {
 }
 
 type IdentifyUI interface {
-	Start(string, keybase1.IdentifyReason) error
+	Start(string, keybase1.IdentifyReason, bool) error
 	FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error
 	FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error
 	Confirm(*keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error)

--- a/go/protocol/keybase1/identify.go
+++ b/go/protocol/keybase1/identify.go
@@ -54,6 +54,7 @@ type Identify2Arg struct {
 	NoSkipSelf            bool           `codec:"noSkipSelf" json:"noSkipSelf"`
 	CanSuppressUI         bool           `codec:"canSuppressUI" json:"canSuppressUI"`
 	ChatGUIMode           bool           `codec:"chatGUIMode" json:"chatGUIMode"`
+	ForceDisplay          bool           `codec:"forceDisplay" json:"forceDisplay"`
 }
 
 type IdentifyInterface interface {

--- a/go/protocol/keybase1/identify_ui.go
+++ b/go/protocol/keybase1/identify_ui.go
@@ -151,9 +151,10 @@ type DelegateIdentifyUIArg struct {
 }
 
 type StartArg struct {
-	SessionID int            `codec:"sessionID" json:"sessionID"`
-	Username  string         `codec:"username" json:"username"`
-	Reason    IdentifyReason `codec:"reason" json:"reason"`
+	SessionID    int            `codec:"sessionID" json:"sessionID"`
+	Username     string         `codec:"username" json:"username"`
+	Reason       IdentifyReason `codec:"reason" json:"reason"`
+	ForceDisplay bool           `codec:"forceDisplay" json:"forceDisplay"`
 }
 
 type DisplayKeyArg struct {

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -93,7 +93,7 @@ type showTrackerPopupIdentifyUI struct {
 
 var _ libkb.IdentifyUI = (*showTrackerPopupIdentifyUI)(nil)
 
-func (ui *showTrackerPopupIdentifyUI) Start(name string, reason keybase1.IdentifyReason) error {
+func (ui *showTrackerPopupIdentifyUI) Start(name string, reason keybase1.IdentifyReason, force bool) error {
 	ui.startedUsername = name
 	return nil
 }

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -259,10 +259,10 @@ func (u *RemoteIdentifyUI) DisplayUserCard(card keybase1.UserCard) error {
 	return u.uicli.DisplayUserCard(ctx, keybase1.DisplayUserCardArg{SessionID: u.sessionID, Card: card})
 }
 
-func (u *RemoteIdentifyUI) Start(username string, reason keybase1.IdentifyReason) error {
+func (u *RemoteIdentifyUI) Start(username string, reason keybase1.IdentifyReason, force bool) error {
 	ctx, cancel := u.newContext()
 	defer cancel()
-	return u.uicli.Start(ctx, keybase1.StartArg{SessionID: u.sessionID, Username: username, Reason: reason})
+	return u.uicli.Start(ctx, keybase1.StartArg{SessionID: u.sessionID, Username: username, Reason: reason, ForceDisplay: force})
 }
 
 func (u *RemoteIdentifyUI) Finish() error {

--- a/go/systests/tracking_test.go
+++ b/go/systests/tracking_test.go
@@ -31,7 +31,7 @@ func (*identifyUI) Confirm(*keybase1.IdentifyOutcome) (keybase1.ConfirmResult, e
 		RemoteConfirmed:   true,
 	}, nil
 }
-func (*identifyUI) Start(string, keybase1.IdentifyReason) error {
+func (*identifyUI) Start(string, keybase1.IdentifyReason, bool) error {
 	return nil
 }
 func (*identifyUI) FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error {

--- a/protocol/avdl/keybase1/identify.avdl
+++ b/protocol/avdl/keybase1/identify.avdl
@@ -40,7 +40,7 @@ protocol identify {
   /*
    * Note that UID can be empty, in which case a resolution is also forced.
    */
-  Identify2Res identify2(int sessionID, UID uid, string userAssertion, IdentifyReason reason, boolean useDelegateUI=false, boolean alwaysBlock=false, boolean noErrorOnTrackFailure=false, boolean forceRemoteCheck=false, boolean needProofSet=false, boolean allowEmptySelfID=false, boolean noSkipSelf=true, boolean canSuppressUI=false, boolean chatGUIMode=false);
+  Identify2Res identify2(int sessionID, UID uid, string userAssertion, IdentifyReason reason, boolean useDelegateUI=false, boolean alwaysBlock=false, boolean noErrorOnTrackFailure=false, boolean forceRemoteCheck=false, boolean needProofSet=false, boolean allowEmptySelfID=false, boolean noSkipSelf=true, boolean canSuppressUI=false, boolean chatGUIMode=false, boolean forceDisplay=false);
 
 
 }

--- a/protocol/avdl/keybase1/identify_ui.avdl
+++ b/protocol/avdl/keybase1/identify_ui.avdl
@@ -114,7 +114,7 @@ protocol identifyUi {
   // following exchange. Return 0 on failure.
   int delegateIdentifyUI();
 
-  void start(int sessionID, string username, IdentifyReason reason);
+  void start(int sessionID, string username, IdentifyReason reason, boolean forceDisplay=false);
   void displayKey(int sessionID, IdentifyKey key);
   void reportLastTrack(int sessionID, union { null, TrackSummary } track);
   void launchNetworkChecks(int sessionID, Identity identity, User user);

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4108,7 +4108,8 @@ export type identifyIdentify2RpcParam = Exact<{
   allowEmptySelfID?: boolean,
   noSkipSelf?: boolean,
   canSuppressUI?: boolean,
-  chatGUIMode?: boolean
+  chatGUIMode?: boolean,
+  forceDisplay?: boolean
 }>
 
 export type identifyIdentifyRpcParam = Exact<{
@@ -4186,7 +4187,8 @@ export type identifyUiReportTrackTokenRpcParam = Exact<{
 
 export type identifyUiStartRpcParam = Exact<{
   username: string,
-  reason: IdentifyReason
+  reason: IdentifyReason,
+  forceDisplay?: boolean
 }>
 
 export type kbfsFSEditListRpcParam = Exact<{
@@ -5260,7 +5262,8 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       sessionID: int,
       username: string,
-      reason: IdentifyReason
+      reason: IdentifyReason,
+      forceDisplay?: boolean
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/protocol/json/keybase1/identify.json
+++ b/protocol/json/keybase1/identify.json
@@ -178,6 +178,11 @@
           "name": "chatGUIMode",
           "type": "boolean",
           "default": false
+        },
+        {
+          "name": "forceDisplay",
+          "type": "boolean",
+          "default": false
         }
       ],
       "response": "Identify2Res"

--- a/protocol/json/keybase1/identify_ui.json
+++ b/protocol/json/keybase1/identify_ui.json
@@ -409,6 +409,11 @@
         {
           "name": "reason",
           "type": "IdentifyReason"
+        },
+        {
+          "name": "forceDisplay",
+          "type": "boolean",
+          "default": false
         }
       ],
       "response": null

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4108,7 +4108,8 @@ export type identifyIdentify2RpcParam = Exact<{
   allowEmptySelfID?: boolean,
   noSkipSelf?: boolean,
   canSuppressUI?: boolean,
-  chatGUIMode?: boolean
+  chatGUIMode?: boolean,
+  forceDisplay?: boolean
 }>
 
 export type identifyIdentifyRpcParam = Exact<{
@@ -4186,7 +4187,8 @@ export type identifyUiReportTrackTokenRpcParam = Exact<{
 
 export type identifyUiStartRpcParam = Exact<{
   username: string,
-  reason: IdentifyReason
+  reason: IdentifyReason,
+  forceDisplay?: boolean
 }>
 
 export type kbfsFSEditListRpcParam = Exact<{
@@ -5260,7 +5262,8 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       sessionID: int,
       username: string,
-      reason: IdentifyReason
+      reason: IdentifyReason,
+      forceDisplay?: boolean
     }>,
     response: CommonResponseHandler
   ) => void,


### PR DESCRIPTION
Electron sometimes caches Identifies, so this PR allows passing of flags to disable that. Plumbed all the way through the command line.