### PR TITLE
Add HasServerKeys

### DIFF
--- a/go/engine/hasserverkeys.go
+++ b/go/engine/hasserverkeys.go
@@ -1,0 +1,68 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import (
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+// HasServerKeys is an engine.
+type HasServerKeys struct {
+	libkb.Contextified
+	res keybase1.HasServerKeysRes
+}
+
+// NewHasServerKeys creates a HasServerKeys engine.
+func NewHasServerKeys(arg *keybase1.HasServerKeysArg, g *libkb.GlobalContext) *HasServerKeys {
+	return &HasServerKeys{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+// Name is the unique engine name.
+func (e *HasServerKeys) Name() string {
+	return "HasServerKeys"
+}
+
+// Prereqs returns the engine prereqs.
+func (e *HasServerKeys) Prereqs() Prereqs {
+	return Prereqs{
+		Session: true,
+	}
+}
+
+// RequiredUIs returns the required UIs.
+func (e *HasServerKeys) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *HasServerKeys) SubConsumers() []libkb.UIConsumer {
+	return nil
+}
+
+// Run starts the engine.
+func (e *HasServerKeys) Run(ctx *Context) error {
+	apiRes, err := e.G().API.Get(libkb.APIArg{
+		Endpoint:    "key/fetch_private",
+		Args:        libkb.HTTPArgs{},
+		NeedSession: true,
+	})
+	if err != nil {
+		return err
+	}
+	var spk libkb.ServerPrivateKeys
+	if err = apiRes.Body.UnmarshalAgain(&spk); err != nil {
+		e.G().Log.Debug("error unmarshaling ServerPrivateKeys")
+		return err
+	}
+	e.res.HasServerKeys = len(spk.PrivateKeys) > 0
+
+	return nil
+}
+
+func (e *HasServerKeys) GetResult() keybase1.HasServerKeysRes {
+	return e.res
+}

--- a/go/service/account.go
+++ b/go/service/account.go
@@ -57,3 +57,17 @@ func (h *AccountHandler) EmailChange(nctx context.Context, arg keybase1.EmailCha
 	eng := engine.NewEmailChange(&arg, h.G())
 	return engine.RunEngine(eng, ctx)
 }
+
+func (h *AccountHandler) HasServerKeys(_ context.Context, sessionID int) (keybase1.HasServerKeysRes, error) {
+	arg := keybase1.HasServerKeysArg{SessionID: sessionID}
+	var res keybase1.HasServerKeysRes
+	eng := engine.NewHasServerKeys(&arg, h.G())
+	ctx := &engine.Context{
+		SessionID: arg.SessionID,
+	}
+	err := engine.RunEngine(eng, ctx)
+	if err != nil {
+		return res, err
+	}
+	return eng.GetResult(), nil
+}

--- a/protocol/avdl/keybase1/account.avdl
+++ b/protocol/avdl/keybase1/account.avdl
@@ -16,4 +16,13 @@ protocol account {
    * change email to the new given email by signing a statement.
    */
   void emailChange(int sessionID, string newEmail);
+
+  /**
+   * Whether the logged-in user has uploaded private keys
+   * Will error if not logged in.
+   */
+  HasServerKeysRes hasServerKeys(int sessionID);
+  record HasServerKeysRes {
+    bool hasServerKeys;
+  }
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -536,6 +536,18 @@ export function accountEmailChangeRpcPromise (request: $Exact<requestCommon & re
   return new Promise((resolve, reject) => { accountEmailChangeRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function accountHasServerKeysRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: accountHasServerKeysResult) => void}>) {
+  engineRpcOutgoing({...request, method: 'account.hasServerKeys'})
+}
+
+export function accountHasServerKeysRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: accountHasServerKeysResult) => void}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => accountHasServerKeysRpc({...request, incomingCallMap, callback}))
+}
+
+export function accountHasServerKeysRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: accountHasServerKeysResult) => void}>): Promise<accountHasServerKeysResult> {
+  return new Promise((resolve, reject) => { accountHasServerKeysRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function accountPassphraseChangeRpc (request: Exact<requestCommon & requestErrorCallback & {param: accountPassphraseChangeRpcParam}>) {
   engineRpcOutgoing({...request, method: 'account.passphraseChange'})
 }
@@ -2896,6 +2908,10 @@ export type GetTLFCryptKeysRes = {
   CryptKeys?: ?Array<CryptKey>,
 }
 
+export type HasServerKeysRes = {
+  hasServerKeys: bool,
+}
+
 export type Hello2Res = {
   encryptionKey: KID,
   sigPayload: HelloRes,
@@ -4775,6 +4791,8 @@ type Kex2ProvisioneeHelloResult = HelloRes
 
 type SecretKeysGetSecretKeysResult = SecretKeys
 
+type accountHasServerKeysResult = HasServerKeysRes
+
 type accountPassphrasePromptResult = GetPassphraseRes
 
 type apiserverGetResult = APIRes
@@ -5005,6 +5023,7 @@ export type rpc =
   | ScanProofsScanProofsRpc
   | SecretKeysGetSecretKeysRpc
   | accountEmailChangeRpc
+  | accountHasServerKeysRpc
   | accountPassphraseChangeRpc
   | accountPassphrasePromptRpc
   | apiserverGetRpc

--- a/protocol/json/keybase1/account.json
+++ b/protocol/json/keybase1/account.json
@@ -6,7 +6,18 @@
       "type": "idl"
     }
   ],
-  "types": [],
+  "types": [
+    {
+      "type": "record",
+      "name": "HasServerKeysRes",
+      "fields": [
+        {
+          "type": "bool",
+          "name": "hasServerKeys"
+        }
+      ]
+    }
+  ],
   "messages": {
     "passphraseChange": {
       "request": [
@@ -56,6 +67,16 @@
       ],
       "response": null,
       "doc": "* change email to the new given email by signing a statement."
+    },
+    "hasServerKeys": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        }
+      ],
+      "response": "HasServerKeysRes",
+      "doc": "* Whether the logged-in user has uploaded private keys\n   * Will error if not logged in."
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -536,6 +536,18 @@ export function accountEmailChangeRpcPromise (request: $Exact<requestCommon & re
   return new Promise((resolve, reject) => { accountEmailChangeRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function accountHasServerKeysRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: accountHasServerKeysResult) => void}>) {
+  engineRpcOutgoing({...request, method: 'account.hasServerKeys'})
+}
+
+export function accountHasServerKeysRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: accountHasServerKeysResult) => void}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => accountHasServerKeysRpc({...request, incomingCallMap, callback}))
+}
+
+export function accountHasServerKeysRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: accountHasServerKeysResult) => void}>): Promise<accountHasServerKeysResult> {
+  return new Promise((resolve, reject) => { accountHasServerKeysRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function accountPassphraseChangeRpc (request: Exact<requestCommon & requestErrorCallback & {param: accountPassphraseChangeRpcParam}>) {
   engineRpcOutgoing({...request, method: 'account.passphraseChange'})
 }
@@ -2896,6 +2908,10 @@ export type GetTLFCryptKeysRes = {
   CryptKeys?: ?Array<CryptKey>,
 }
 
+export type HasServerKeysRes = {
+  hasServerKeys: bool,
+}
+
 export type Hello2Res = {
   encryptionKey: KID,
   sigPayload: HelloRes,
@@ -4775,6 +4791,8 @@ type Kex2ProvisioneeHelloResult = HelloRes
 
 type SecretKeysGetSecretKeysResult = SecretKeys
 
+type accountHasServerKeysResult = HasServerKeysRes
+
 type accountPassphrasePromptResult = GetPassphraseRes
 
 type apiserverGetResult = APIRes
@@ -5005,6 +5023,7 @@ export type rpc =
   | ScanProofsScanProofsRpc
   | SecretKeysGetSecretKeysRpc
   | accountEmailChangeRpc
+  | accountHasServerKeysRpc
   | accountPassphraseChangeRpc
   | accountPassphrasePromptRpc
   | apiserverGetRpc


### PR DESCRIPTION
Add an rpc `account.hasServerKeys` for asking whether the logged-in user has any uploaded pgp keys. Basically this just calls the server's `key/fetch_private`.

```
  /**
   * Whether the logged-in user has uploaded private keys
   * Will error if not logged in.
   */
  HasServerKeysRes hasServerKeys(int sessionID);
  record HasServerKeysRes {
    bool hasServerKeys;
  }
```

It will error if the user is not logged in or there are issues talking to the server. It works (returns false) for users who uploaded and then deleted a key.

@patrickxb I'm not sure what the `sessionID` arg is for, I copied it from some other similar engines, but it gets ignored in the end.

r? @patrickxb 
@chrisnojima will this interface work for you? It's a record instead of just a bool in case you need more related info in the future.