### PR TITLE
Reverse conversation message order

### DIFF
--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -195,8 +195,9 @@ func (v conversationView) show(g *libkb.GlobalContext, showDeviceName bool) erro
 	}
 
 	table := &flexibletable.Table{}
-	i := -1
-	for _, m := range v.messages {
+	visualIndex := 0
+	sortedMessages := messageSorter{Messages: v.messages}.ascending()
+	for _, m := range sortedMessages {
 		mv, err := newMessageView(g, v.conversation.Info.Id, m)
 		if err != nil {
 			g.Log.Error("Message render error: %s", err)
@@ -219,12 +220,12 @@ func (v conversationView) show(g *libkb.GlobalContext, showDeviceName bool) erro
 			authorAndTime = mv.AuthorAndTime
 		}
 
-		i++
+		visualIndex++
 		table.Insert(flexibletable.Row{
 			flexibletable.Cell{
 				Frame:     [2]string{"[", "]"},
 				Alignment: flexibletable.Right,
-				Content:   flexibletable.SingleCell{Item: strconv.Itoa(i + 1)},
+				Content:   flexibletable.SingleCell{Item: strconv.Itoa(visualIndex)},
 			},
 			flexibletable.Cell{
 				Alignment: flexibletable.Center,
@@ -307,7 +308,7 @@ func newMessageView(g *libkb.GlobalContext, conversationID chat1.ConversationID,
 		if m.UnboxingError != nil {
 			return mv, fmt.Errorf(fmt.Sprintf("<%s>", *m.UnboxingError))
 		}
-		return mv, fmt.Errorf("unexpected data")
+		return mv, fmt.Errorf("unexpected empty message")
 	}
 
 	mv.MessageID = m.Message.ServerHeader.MessageID

--- a/go/client/chat_sorter.go
+++ b/go/client/chat_sorter.go
@@ -1,0 +1,36 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"sort"
+
+	"github.com/keybase/client/go/protocol/chat1"
+)
+
+type messageSorter struct {
+	Messages []chat1.MessageFromServerOrError
+}
+
+// Return a copy sorted by message id.
+// Messages without IDs (errors) end up at the top (non-stable ordering).
+func (s messageSorter) ascending() []chat1.MessageFromServerOrError {
+	xs := make([]chat1.MessageFromServerOrError, len(s.Messages))
+	copy(xs, s.Messages)
+	sort.Sort(byMessageIDAsc(xs))
+	return xs
+}
+
+type byMessageIDAsc []chat1.MessageFromServerOrError
+
+func (a byMessageIDAsc) Len() int           { return len(a) }
+func (a byMessageIDAsc) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byMessageIDAsc) Less(i, j int) bool { return a.key(i) < a.key(j) }
+func (a byMessageIDAsc) key(i int) int {
+	m := a[i]
+	if m.Message == nil {
+		return -1
+	}
+	return int(m.Message.ServerHeader.MessageID)
+}


### PR DESCRIPTION
Sort messages before displaying in `chat read` so time progresses down.

```
$ keybase chat read frank
Found CHAT conversation: frank,gil
fetching conversation frank,gil ...

[1]  [frank 25m] the beginnings of a conversation
[2]    [gil 24m] what a fine beginning it is
[3]  [frank 23m] shall we say more?
[4]    [gil 23m] sure. what's the latest message you've sent?
[5]  [frank 23m] this one!
```

The sort method is called `ascending`, but don't be fooled.

r? @mmaxim || @songgao 