### PR TITLE
fix spaces in logs

### DIFF
--- a/shared/util/forward-logs.desktop.js
+++ b/shared/util/forward-logs.desktop.js
@@ -93,12 +93,12 @@ function setupTarget () {
   keys.forEach(key => {
     const override = (...args) => {
       if (args.length) {
-        output[key](`${key}: ${Date()} (${Date.now()}): ${util.format.apply(util, args)}\n`)
+        output[key](`${key}: ${Date()} (${Date.now()}): ${util.format('%s', ...args)}\n`)
       }
     }
 
     console[key] = override
-    ipcMain.on(`console.${key}`, (event, args) => {
+    ipcMain.on(`console.${key}`, (event, ...args) => {
       const prologue = `From ${event.sender.getTitle()}: `
       output[key](prologue)
       override(...args)
@@ -114,7 +114,7 @@ function setupSource () {
   ['log', 'warn', 'error'].forEach(key => {
     console[key] = (...args) => {
       try {
-        const toSend = util.inspect(args)
+        const toSend = util.format('%j', args)
         ipcRenderer.send('console.' + key, toSend + '\n')
       } catch (_) {}
     }


### PR DESCRIPTION
so this fixes the extra spaces in the logs, but also makes the logs print compressed json blobs (so not indented anymore). Doesn't seem like there's a nice way for us to output it like JSON.stringify(args, null, 4) and still be safe. The real fix is that we need just pure json objects in the store. So this is just a hotfix for now

so a
```
console.log({a: {b:1, c:2}})
```
will produce
```
From Keybase: log: Fri Oct 14 2016 09:01:49 GMT-0400 (EDT) (1476450109123): [{"a":{"b":1,"c":2}}]
```

@keybase/react-hackers 