### PR TITLE
unversion MessagePlaintext, and improve MessageFromServerOrError CORE-3911

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -26,9 +26,9 @@ func NewRemoteConversationSource(g *libkb.GlobalContext, b *Boxer, ri chat1.Remo
 }
 
 func (s *RemoteConversationSource) Push(ctx context.Context, convID chat1.ConversationID,
-	uid gregor1.UID, msg chat1.MessageBoxed) (chat1.MessageFromServerOrError, error) {
+	uid gregor1.UID, msg chat1.MessageBoxed) (chat1.MessageUnboxed, error) {
 	// Do nothing here, we don't care about pushed messages
-	return chat1.MessageFromServerOrError{}, nil
+	return chat1.MessageUnboxed{}, nil
 }
 
 func (s *RemoteConversationSource) Pull(ctx context.Context, convID chat1.ConversationID,
@@ -74,7 +74,7 @@ func NewHybridConversationSource(g *libkb.GlobalContext, b *Boxer, storage *stor
 }
 
 func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.ConversationID,
-	uid gregor1.UID, msg chat1.MessageBoxed) (chat1.MessageFromServerOrError, error) {
+	uid gregor1.UID, msg chat1.MessageBoxed) (chat1.MessageUnboxed, error) {
 
 	decmsg, err := s.boxer.UnboxMessage(ctx, NewKeyFinder(), msg)
 	if err != nil {
@@ -82,7 +82,7 @@ func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.Conver
 	}
 
 	// Store the message
-	if err = s.storage.Merge(ctx, convID, uid, []chat1.MessageFromServerOrError{decmsg}); err != nil {
+	if err = s.storage.Merge(ctx, convID, uid, []chat1.MessageUnboxed{decmsg}); err != nil {
 		return decmsg, err
 	}
 

--- a/go/chat/prev_test.go
+++ b/go/chat/prev_test.go
@@ -25,22 +25,18 @@ func expectCode(t *testing.T, err libkb.ChatThreadConsistencyError, code libkb.C
 func threadViewFromDummies(dummies []dummyMessage) chat1.ThreadView {
 	threadView := chat1.ThreadView{}
 	for _, dummy := range dummies {
-		messageFromServer := chat1.MessageFromServer{
+		messageValid := chat1.MessageUnboxedValid{
 			HeaderHash: dummy.hash,
 			ServerHeader: chat1.MessageServerHeader{
 				MessageID: dummy.id,
 			},
-			MessagePlaintext: chat1.NewMessagePlaintextWithV1(chat1.MessagePlaintextV1{
-				ClientHeader: chat1.MessageClientHeader{
-					Prev: dummy.prevs,
-				},
-				// no need for a body
-			}),
+			ClientHeader: chat1.MessageClientHeader{
+				Prev: dummy.prevs,
+			},
+			// no need for a body
 		}
-		messageFromServerOrError := chat1.MessageFromServerOrError{
-			Message: &messageFromServer,
-		}
-		threadView.Messages = append(threadView.Messages, messageFromServerOrError)
+		msg := chat1.NewMessageUnboxedWithValid(messageValid)
+		threadView.Messages = append(threadView.Messages, msg)
 	}
 	return threadView
 }

--- a/go/chat/storage/storage_blockengine.go
+++ b/go/chat/storage/storage_blockengine.go
@@ -33,7 +33,7 @@ type blockIndex struct {
 
 type block struct {
 	BlockID int
-	Msgs    [blockSize]chat1.MessageFromServerOrError
+	Msgs    [blockSize]chat1.MessageUnboxed
 }
 
 type boxedBlock struct {
@@ -288,7 +288,7 @@ func (be *blockEngine) writeBlock(ctx context.Context, bi blockIndex, b block) l
 }
 
 func (be *blockEngine) writeMessages(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
-	msgs []chat1.MessageFromServerOrError) libkb.ChatStorageError {
+	msgs []chat1.MessageUnboxed) libkb.ChatStorageError {
 
 	var err libkb.ChatStorageError
 	var maxB block
@@ -351,7 +351,7 @@ func (be *blockEngine) writeMessages(ctx context.Context, convID chat1.Conversat
 	return nil
 }
 
-func (be *blockEngine) readMessages(ctx context.Context, res *[]chat1.MessageFromServerOrError,
+func (be *blockEngine) readMessages(ctx context.Context, res *[]chat1.MessageUnboxed,
 	convID chat1.ConversationID, uid gregor1.UID, maxID chat1.MessageID, num int, df doneFunc) libkb.ChatStorageError {
 
 	// Get block index

--- a/go/chat/storage/storage_msgengine.go
+++ b/go/chat/storage/storage_msgengine.go
@@ -53,7 +53,7 @@ func (ms *msgEngine) makeMsgKey(convID chat1.ConversationID, uid gregor1.UID, ms
 }
 
 func (ms *msgEngine) writeMessages(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
-	msgs []chat1.MessageFromServerOrError) libkb.ChatStorageError {
+	msgs []chat1.MessageUnboxed) libkb.ChatStorageError {
 
 	// Sanity check
 	if len(msgs) == 0 {
@@ -108,7 +108,7 @@ func (ms *msgEngine) writeMessages(ctx context.Context, convID chat1.Conversatio
 	return nil
 }
 
-func (ms *msgEngine) readMessages(ctx context.Context, res *[]chat1.MessageFromServerOrError,
+func (ms *msgEngine) readMessages(ctx context.Context, res *[]chat1.MessageUnboxed,
 	convID chat1.ConversationID, uid gregor1.UID, maxID chat1.MessageID, num int, df doneFunc) libkb.ChatStorageError {
 
 	// Read all msgs in reverse order
@@ -144,7 +144,7 @@ func (ms *msgEngine) readMessages(ctx context.Context, res *[]chat1.MessageFromS
 		}
 
 		// Decode payload
-		var msg chat1.MessageFromServerOrError
+		var msg chat1.MessageUnboxed
 		if err = decode(pt, &msg); err != nil {
 			return libkb.NewChatStorageInternalError(ms.G(), "readMessages: failed to decode: %s", err.Error())
 		}

--- a/go/chat/storage/storage_test.go
+++ b/go/chat/storage/storage_test.go
@@ -34,37 +34,34 @@ func randBytes(n int) []byte {
 	return ret
 }
 
-func makeMsgWithType(id chat1.MessageID, supersedes chat1.MessageID, typ chat1.MessageType) chat1.MessageFromServerOrError {
-	return chat1.MessageFromServerOrError{
-		Message: &chat1.MessageFromServer{
-			ServerHeader: chat1.MessageServerHeader{
-				MessageID:   id,
-				MessageType: typ,
-			},
-			MessagePlaintext: chat1.NewMessagePlaintextWithV1(chat1.MessagePlaintextV1{
-				ClientHeader: chat1.MessageClientHeader{
-					Supersedes: supersedes,
-				},
-			}),
+func makeMsgWithType(id chat1.MessageID, supersedes chat1.MessageID, typ chat1.MessageType) chat1.MessageUnboxed {
+	msg := chat1.MessageUnboxedValid{
+		ServerHeader: chat1.MessageServerHeader{
+			MessageID:   id,
+			MessageType: typ,
+		},
+		ClientHeader: chat1.MessageClientHeader{
+			Supersedes: supersedes,
 		},
 	}
+	return chat1.NewMessageUnboxedWithValid(msg)
 }
 
-func makeMsg(id chat1.MessageID, supersedes chat1.MessageID) chat1.MessageFromServerOrError {
+func makeMsg(id chat1.MessageID, supersedes chat1.MessageID) chat1.MessageUnboxed {
 	return makeMsgWithType(id, supersedes, chat1.MessageType_TEXT)
 }
 
-func makeMsgRange(max int) (res []chat1.MessageFromServerOrError) {
+func makeMsgRange(max int) (res []chat1.MessageUnboxed) {
 	for i := max; i > 0; i-- {
 		res = append(res, makeMsg(chat1.MessageID(i), chat1.MessageID(0)))
 	}
 	return res
 }
 
-func addMsgs(num int, msgs []chat1.MessageFromServerOrError) []chat1.MessageFromServerOrError {
+func addMsgs(num int, msgs []chat1.MessageUnboxed) []chat1.MessageUnboxed {
 	maxID := msgs[0].GetMessageID()
 	for i := 0; i < num; i++ {
-		msgs = append([]chat1.MessageFromServerOrError{makeMsg(chat1.MessageID(int(maxID)+i+1), 0)},
+		msgs = append([]chat1.MessageUnboxed{makeMsg(chat1.MessageID(int(maxID)+i+1), 0)},
 			msgs...)
 	}
 	return msgs
@@ -240,7 +237,7 @@ func TestStorageSupersedes(t *testing.T) {
 	msgs := makeMsgRange(110)
 	superseder := makeMsg(chat1.MessageID(111), 6)
 	superseder2 := makeMsg(chat1.MessageID(112), 11)
-	msgs = append([]chat1.MessageFromServerOrError{superseder}, msgs...)
+	msgs = append([]chat1.MessageUnboxed{superseder}, msgs...)
 	conv := makeConversation(msgs[0].GetMessageID())
 
 	require.NoError(t, storage.Merge(context.TODO(), conv.Metadata.ConversationID, uid, msgs))
@@ -250,18 +247,18 @@ func TestStorageSupersedes(t *testing.T) {
 	for i := 0; i < len(res.Messages); i++ {
 		require.Equal(t, msgs[i].GetMessageID(), res.Messages[i].GetMessageID(), "msg mismatch")
 	}
-	sheader := res.Messages[len(msgs)-6].Message.ServerHeader
+	sheader := res.Messages[len(msgs)-6].Valid().ServerHeader
 	require.Equal(t, chat1.MessageID(6), sheader.MessageID, "MessageID incorrect")
 	require.Equal(t, chat1.MessageID(111), sheader.SupersededBy, "supersededBy incorrect")
 
 	require.NoError(t, storage.Merge(context.TODO(), conv.Metadata.ConversationID, uid,
-		[]chat1.MessageFromServerOrError{superseder2}))
+		[]chat1.MessageUnboxed{superseder2}))
 	conv.ReaderInfo.MaxMsgid = 112
-	msgs = append([]chat1.MessageFromServerOrError{superseder2}, msgs...)
+	msgs = append([]chat1.MessageUnboxed{superseder2}, msgs...)
 	res, err = storage.Fetch(context.TODO(), conv, uid, nil, nil, nil)
 	require.NoError(t, err)
 
-	sheader = res.Messages[len(msgs)-11].Message.ServerHeader
+	sheader = res.Messages[len(msgs)-11].Valid().ServerHeader
 	require.Equal(t, chat1.MessageID(11), sheader.MessageID, "MessageID incorrect")
 	require.Equal(t, chat1.MessageID(112), sheader.SupersededBy, "supersededBy incorrect")
 }
@@ -341,8 +338,8 @@ func TestStoragePagination(t *testing.T) {
 	}
 }
 
-func mkarray(m chat1.MessageFromServerOrError) []chat1.MessageFromServerOrError {
-	return []chat1.MessageFromServerOrError{m}
+func mkarray(m chat1.MessageUnboxed) []chat1.MessageUnboxed {
+	return []chat1.MessageUnboxed{m}
 }
 
 func TestStorageTypeFilter(t *testing.T) {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -65,18 +65,14 @@ func Collar(lower int, ideal int, upper int) int {
 	return ideal
 }
 
-func FilterByType(msgs []chat1.MessageFromServerOrError, query *chat1.GetThreadQuery) (res []chat1.MessageFromServerOrError) {
+func FilterByType(msgs []chat1.MessageUnboxed, query *chat1.GetThreadQuery) (res []chat1.MessageUnboxed) {
 	if query != nil && len(query.MessageTypes) > 0 {
 		typmap := make(map[chat1.MessageType]bool)
 		for _, mt := range query.MessageTypes {
 			typmap[mt] = true
 		}
 		for _, msg := range msgs {
-			if msg.Message != nil {
-				if _, ok := typmap[msg.Message.ServerHeader.MessageType]; ok {
-					res = append(res, msg)
-				}
-			} else {
+			if _, ok := typmap[msg.GetMessageType()]; ok {
 				res = append(res, msg)
 			}
 		}

--- a/go/client/chat_cli_utils.go
+++ b/go/client/chat_cli_utils.go
@@ -94,7 +94,7 @@ type chatCLIConversationFetcher struct {
 	chatClient chat1.LocalInterface // for testing only
 }
 
-func (f chatCLIConversationFetcher) fetch(ctx context.Context, g *libkb.GlobalContext) (conversations chat1.ConversationLocal, messages []chat1.MessageFromServerOrError, err error) {
+func (f chatCLIConversationFetcher) fetch(ctx context.Context, g *libkb.GlobalContext) (conversations chat1.ConversationLocal, messages []chat1.MessageUnboxed, err error) {
 	chatClient := f.chatClient // should be nil unless in test
 	if chatClient == nil {
 		chatClient, err = GetChatLocalClient(g)
@@ -149,8 +149,8 @@ func (f chatCLIInboxFetcher) fetch(ctx context.Context, g *libkb.GlobalContext) 
 	return res.Conversations, nil
 }
 
-func fetchOneMessage(g *libkb.GlobalContext, conversationID chat1.ConversationID, messageID chat1.MessageID) (chat1.MessageFromServerOrError, error) {
-	deflt := chat1.MessageFromServerOrError{}
+func fetchOneMessage(g *libkb.GlobalContext, conversationID chat1.ConversationID, messageID chat1.MessageID) (chat1.MessageUnboxed, error) {
+	deflt := chat1.MessageUnboxed{}
 
 	chatClient, err := GetChatLocalClient(g)
 	if err != nil {

--- a/go/client/chat_sorter.go
+++ b/go/client/chat_sorter.go
@@ -10,27 +10,27 @@ import (
 )
 
 type messageSorter struct {
-	Messages []chat1.MessageFromServerOrError
+	Messages []chat1.MessageUnboxed
 }
 
 // Return a copy sorted by message id.
 // Messages without IDs (errors) end up at the top (non-stable ordering).
-func (s messageSorter) ascending() []chat1.MessageFromServerOrError {
-	xs := make([]chat1.MessageFromServerOrError, len(s.Messages))
+func (s messageSorter) ascending() []chat1.MessageUnboxed {
+	xs := make([]chat1.MessageUnboxed, len(s.Messages))
 	copy(xs, s.Messages)
 	sort.Sort(byMessageIDAsc(xs))
 	return xs
 }
 
-type byMessageIDAsc []chat1.MessageFromServerOrError
+type byMessageIDAsc []chat1.MessageUnboxed
 
 func (a byMessageIDAsc) Len() int           { return len(a) }
 func (a byMessageIDAsc) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a byMessageIDAsc) Less(i, j int) bool { return a.key(i) < a.key(j) }
 func (a byMessageIDAsc) key(i int) int {
 	m := a[i]
-	if m.Message == nil {
+	if !m.IsValid() {
 		return -1
 	}
-	return int(m.Message.ServerHeader.MessageID)
+	return int(m.GetMessageID())
 }

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -92,10 +92,10 @@ func (c *cmdChatSend) Run() (err error) {
 	var args chat1.PostLocalArg
 	args.ConversationID = conversationInfo.Id
 
-	var msgV1 chat1.MessagePlaintextV1
+	var msg chat1.MessagePlaintext
 	// msgV1.ClientHeader.{Sender,SenderDevice} are filled by service
-	msgV1.ClientHeader.Conv = conversationInfo.Triple
-	msgV1.ClientHeader.TlfName = conversationInfo.TlfName
+	msg.ClientHeader.Conv = conversationInfo.Triple
+	msg.ClientHeader.TlfName = conversationInfo.TlfName
 
 	// Whether the user is really sure they want to send to the selected conversation.
 	// We require an additional confirmation if the choose menu was used.
@@ -108,14 +108,14 @@ func (c *cmdChatSend) Run() (err error) {
 			c.G().UI.GetTerminalUI().Printf("We are not supporting setting topic name for chat conversations yet. Ignoring --set-topic-name >.<\n")
 			return nil
 		}
-		msgV1.ClientHeader.MessageType = chat1.MessageType_METADATA
-		msgV1.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{ConversationTitle: c.setTopicName})
+		msg.ClientHeader.MessageType = chat1.MessageType_METADATA
+		msg.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{ConversationTitle: c.setTopicName})
 	case c.setHeadline != "":
-		msgV1.ClientHeader.MessageType = chat1.MessageType_HEADLINE
-		msgV1.MessageBody = chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: c.setHeadline})
+		msg.ClientHeader.MessageType = chat1.MessageType_HEADLINE
+		msg.MessageBody = chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: c.setHeadline})
 	case c.clearHeadline:
-		msgV1.ClientHeader.MessageType = chat1.MessageType_HEADLINE
-		msgV1.MessageBody = chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: ""})
+		msg.ClientHeader.MessageType = chat1.MessageType_HEADLINE
+		msg.MessageBody = chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: ""})
 	default:
 		// Ask for message contents
 		if len(c.message) == 0 {
@@ -130,8 +130,8 @@ func (c *cmdChatSend) Run() (err error) {
 			confirmed = true
 		}
 
-		msgV1.ClientHeader.MessageType = chat1.MessageType_TEXT
-		msgV1.MessageBody = chat1.NewMessageBodyWithText(chat1.MessageText{Body: c.message})
+		msg.ClientHeader.MessageType = chat1.MessageType_TEXT
+		msg.MessageBody = chat1.NewMessageBodyWithText(chat1.MessageText{Body: c.message})
 	}
 
 	if !confirmed {
@@ -143,7 +143,7 @@ func (c *cmdChatSend) Run() (err error) {
 		confirmed = true
 	}
 
-	args.MessagePlaintext = chat1.NewMessagePlaintextWithV1(msgV1)
+	args.Msg = msg
 
 	if _, err = chatClient.PostLocal(ctx, args); err != nil {
 		return err

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1604,13 +1604,6 @@ func NewChatBodyVersionError(version chat1.BodyPlaintextVersion) ChatVersionErro
 	}
 }
 
-func NewChatMessageVersionError(version chat1.MessagePlaintextVersion) ChatVersionError {
-	return ChatVersionError{
-		Kind:    "message",
-		Version: int(version),
-	}
-}
-
 //=============================================================================
 
 type ChatBodyHashInvalid struct{}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -520,7 +520,7 @@ type ExternalServicesCollector interface {
 
 type ConversationSource interface {
 	Push(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
-		msg chat1.MessageBoxed) (chat1.MessageFromServerOrError, error)
+		msg chat1.MessageBoxed) (chat1.MessageUnboxed, error)
 	Pull(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, query *chat1.GetThreadQuery,
 		pagination *chat1.Pagination) (chat1.ThreadView, []*chat1.RateLimit, error)
 	Clear(convID chat1.ConversationID, uid gregor1.UID) error

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -104,22 +104,35 @@ func (hash Hash) Eq(other Hash) bool {
 	return bytes.Equal(hash, other)
 }
 
-func (m MessageFromServerOrError) GetMessageID() MessageID {
-	if m.Message != nil {
-		return m.Message.ServerHeader.MessageID
-	} else if m.UnboxingError != nil {
-		return m.UnboxingError.MessageID
+func (m MessageUnboxed) GetMessageID() MessageID {
+	if state, err := m.State(); err == nil {
+		if state == MessageUnboxedState_VALID {
+			return m.Valid().ServerHeader.MessageID
+		}
+		if state == MessageUnboxedState_ERROR {
+			return m.Error().MessageID
+		}
 	}
 	return 0
 }
 
-func (m MessageFromServerOrError) GetMessageType() MessageType {
-	if m.Message != nil {
-		return m.Message.ServerHeader.MessageType
-	} else if m.UnboxingError != nil {
-		return m.UnboxingError.MessageType
+func (m MessageUnboxed) GetMessageType() MessageType {
+	if state, err := m.State(); err == nil {
+		if state == MessageUnboxedState_VALID {
+			return m.Valid().ServerHeader.MessageType
+		}
+		if state == MessageUnboxedState_ERROR {
+			return m.Error().MessageType
+		}
 	}
 	return MessageType_NONE
+}
+
+func (m MessageUnboxed) IsValid() bool {
+	if state, err := m.State(); err == nil {
+		return state == MessageUnboxedState_VALID
+	}
+	return false
 }
 
 func (m MessageBoxed) GetMessageID() MessageID {
@@ -127,5 +140,5 @@ func (m MessageBoxed) GetMessageID() MessageID {
 }
 
 func (m MessageBoxed) GetMessageType() MessageType {
-	return m.ServerHeader.MessageType
+	return m.ClientHeader.MessageType
 }

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -27,8 +27,8 @@ var ChatActivityTypeRevMap = map[ChatActivityType]string{
 }
 
 type ChatActivity struct {
-	ActivityType    ChatActivityType          `codec:"ActivityType" json:"ActivityType"`
-	IncomingMessage *MessageFromServerOrError `codec:"IncomingMessage,omitempty" json:"IncomingMessage,omitempty"`
+	ActivityType    ChatActivityType `codec:"ActivityType" json:"ActivityType"`
+	IncomingMessage *MessageUnboxed  `codec:"IncomingMessage,omitempty" json:"IncomingMessage,omitempty"`
 }
 
 type NewChatActivityArg struct {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -280,9 +280,9 @@ func (h *chatLocalHandler) NewConversationLocal(ctx context.Context, arg chat1.N
 }
 
 func (h *chatLocalHandler) makeFirstMessage(ctx context.Context, triple chat1.ConversationIDTriple, tlfName string, tlfVisibility chat1.TLFVisibility, topicName *string) (*chat1.MessageBoxed, error) {
-	var v1 chat1.MessagePlaintextV1
+	var msg chat1.MessagePlaintext
 	if topicName != nil {
-		v1 = chat1.MessagePlaintextV1{
+		msg = chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
 				Conv:        triple,
 				TlfName:     tlfName,
@@ -297,7 +297,7 @@ func (h *chatLocalHandler) makeFirstMessage(ctx context.Context, triple chat1.Co
 				}),
 		}
 	} else {
-		v1 = chat1.MessagePlaintextV1{
+		msg = chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
 				Conv:        triple,
 				TlfName:     tlfName,
@@ -308,7 +308,7 @@ func (h *chatLocalHandler) makeFirstMessage(ctx context.Context, triple chat1.Co
 			},
 		}
 	}
-	return h.prepareMessageForRemote(ctx, chat1.NewMessagePlaintextWithV1(v1), nil)
+	return h.prepareMessageForRemote(ctx, msg, nil)
 }
 
 func (h *chatLocalHandler) localizeConversationsPipeline(ctx context.Context, convs []chat1.Conversation) ([]chat1.ConversationLocal, error) {
@@ -485,31 +485,19 @@ func (h *chatLocalHandler) localizeConversation(
 
 	var maxValidID chat1.MessageID
 	for _, mm := range conversationLocal.MaxMessages {
-		if mm.Message != nil {
-			messagePlaintext := mm.Message.MessagePlaintext
-			version, err := messagePlaintext.Version()
-			if err != nil {
+		if mm.IsValid() {
+			body := mm.Valid().MessageBody
+			if t, err := body.MessageType(); err != nil {
 				return chat1.ConversationLocal{}, err
+			} else if t == chat1.MessageType_METADATA {
+				conversationLocal.Info.TopicName = body.Metadata().ConversationTitle
 			}
-			switch version {
-			case chat1.MessagePlaintextVersion_V1:
-				body := messagePlaintext.V1().MessageBody
 
-				if t, err := body.MessageType(); err != nil {
-					return chat1.ConversationLocal{}, err
-				} else if t == chat1.MessageType_METADATA {
-					conversationLocal.Info.TopicName = body.Metadata().ConversationTitle
-				}
-
-				if mm.Message.ServerHeader.MessageID >= maxValidID {
-					conversationLocal.Info.TlfName = messagePlaintext.V1().ClientHeader.TlfName
-					maxValidID = mm.Message.ServerHeader.MessageID
-				}
-				conversationLocal.Info.Triple = messagePlaintext.V1().ClientHeader.Conv
-			default:
-				errMsg := libkb.NewChatMessageVersionError(version).Error()
-				return chat1.ConversationLocal{Error: &errMsg}, nil
+			if mm.GetMessageID() >= maxValidID {
+				conversationLocal.Info.TlfName = mm.Valid().ClientHeader.TlfName
+				maxValidID = mm.GetMessageID()
 			}
+			conversationLocal.Info.Triple = mm.Valid().ClientHeader.Conv
 		}
 	}
 
@@ -582,13 +570,13 @@ func (h *chatLocalHandler) GetConversationForCLILocal(ctx context.Context, arg c
 	rlimits = append(rlimits, tv.RateLimits...)
 
 	// apply message count limits
-	var messages []chat1.MessageFromServerOrError
+	var messages []chat1.MessageUnboxed
 	for _, m := range tv.Thread.Messages {
 		messages = append(messages, m)
 
 		arg.Limit.AtMost--
 		arg.Limit.AtLeast--
-		if m.Message.ServerHeader.MessageID <= convLocal.ReaderInfo.ReadMsgid {
+		if m.GetMessageID() <= convLocal.ReaderInfo.ReadMsgid {
 			arg.Limit.NumRead--
 		}
 		if arg.Limit.AtMost <= 0 ||
@@ -655,25 +643,14 @@ func (h *chatLocalHandler) addSenderToMessage(msg chat1.MessagePlaintext) (chat1
 		return chat1.MessagePlaintext{}, err
 	}
 
-	version, err := msg.Version()
-	if err != nil {
-		return chat1.MessagePlaintext{}, err
+	header := msg.ClientHeader
+	header.Sender = gregor1.UID(huid)
+	header.SenderDevice = gregor1.DeviceID(hdid)
+	updated := chat1.MessagePlaintext{
+		ClientHeader: header,
+		MessageBody:  msg.MessageBody,
 	}
-
-	switch version {
-	case chat1.MessagePlaintextVersion_V1:
-		header := msg.V1().ClientHeader
-		header.Sender = gregor1.UID(huid)
-		header.SenderDevice = gregor1.DeviceID(hdid)
-		updated := chat1.MessagePlaintextV1{
-			ClientHeader: header,
-			MessageBody:  msg.V1().MessageBody,
-		}
-		return chat1.NewMessagePlaintextWithV1(updated), nil
-	default:
-		return chat1.MessagePlaintext{}, libkb.NewChatMessageVersionError(version)
-	}
-
+	return updated, nil
 }
 
 func (h *chatLocalHandler) addPrevPointersToMessage(msg chat1.MessagePlaintext, convID chat1.ConversationID) (chat1.MessagePlaintext, error) {
@@ -681,7 +658,7 @@ func (h *chatLocalHandler) addPrevPointersToMessage(msg chat1.MessagePlaintext, 
 	// should never happen, and we'll return an error just in case we make a
 	// mistake in the future. But if there's some use case in the future where
 	// a caller wants to specify custom prevs, we can relax this.
-	if len(msg.V1().ClientHeader.Prev) != 0 {
+	if len(msg.ClientHeader.Prev) != 0 {
 		return chat1.MessagePlaintext{}, fmt.Errorf("chatLocalHandler expects an empty prev list")
 	}
 
@@ -702,13 +679,13 @@ func (h *chatLocalHandler) addPrevPointersToMessage(msg chat1.MessagePlaintext, 
 
 	// Make an attempt to avoid changing anything in the input message. There
 	// are a lot of shared pointers though, so this is
-	header := msg.V1().ClientHeader
+	header := msg.ClientHeader
 	header.Prev = prevs
-	updated := chat1.MessagePlaintextV1{
+	updated := chat1.MessagePlaintext{
 		ClientHeader: header,
-		MessageBody:  msg.V1().MessageBody,
+		MessageBody:  msg.MessageBody,
 	}
-	return chat1.NewMessagePlaintextWithV1(updated), nil
+	return updated, nil
 }
 
 func (h *chatLocalHandler) prepareMessageForRemote(ctx context.Context, plaintext chat1.MessagePlaintext, convID *chat1.ConversationID) (*chat1.MessageBoxed, error) {
@@ -748,7 +725,7 @@ func (h *chatLocalHandler) PostLocal(ctx context.Context, arg chat1.PostLocalArg
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return chat1.PostLocalRes{}, err
 	}
-	boxed, err := h.prepareMessageForRemote(ctx, arg.MessagePlaintext, &arg.ConversationID)
+	boxed, err := h.prepareMessageForRemote(ctx, arg.Msg, &arg.ConversationID)
 	if err != nil {
 		return chat1.PostLocalRes{}, err
 	}

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -123,14 +123,14 @@ func mustPostLocalForTestNoAdvanceClock(t *testing.T, ctc *chatTestContext, asUs
 	}
 	_, err = ctc.as(t, asUser).chatLocalHandler().PostLocal(context.Background(), chat1.PostLocalArg{
 		ConversationID: conv.Id,
-		MessagePlaintext: chat1.NewMessagePlaintextWithV1(chat1.MessagePlaintextV1{
+		Msg: chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
 				Conv:        conv.Triple,
 				MessageType: mt,
 				TlfName:     conv.TlfName,
 			},
 			MessageBody: msg,
-		}),
+		},
 	})
 	if err != nil {
 		t.Fatalf("PostLocal error: %v", err)
@@ -283,7 +283,7 @@ func TestChatGetThreadLocal(t *testing.T) {
 	if len(tv.Messages) != 2 {
 		t.Fatalf("unexpected response from GetThreadLocal . expected 2 items, got %d\n", len(tv.Messages))
 	}
-	if tv.Messages[0].Message.MessagePlaintext.V1().MessageBody.Text().Body != "hello!" {
+	if tv.Messages[0].Valid().MessageBody.Text().Body != "hello!" {
 		t.Fatalf("unexpected response from GetThreadLocal . expected 'hello!' got %#+v\n", tv.Messages[0])
 	}
 }
@@ -313,8 +313,8 @@ func TestChatGetThreadLocalMarkAsRead(t *testing.T) {
 
 	var found bool
 	for _, m := range res.Conversations[0].MaxMessages {
-		if m.Message.ServerHeader.MessageType == chat1.MessageType_TEXT {
-			if res.Conversations[0].ReaderInfo.ReadMsgid == m.Message.ServerHeader.MessageID {
+		if m.GetMessageType() == chat1.MessageType_TEXT {
+			if res.Conversations[0].ReaderInfo.ReadMsgid == m.GetMessageID() {
 				t.Fatalf("conversation was not marked as read\n")
 			}
 			found = true
@@ -351,8 +351,8 @@ func TestChatGetThreadLocalMarkAsRead(t *testing.T) {
 
 	found = false
 	for _, m := range res.Conversations[0].MaxMessages {
-		if m.Message.ServerHeader.MessageType == chat1.MessageType_TEXT {
-			if res.Conversations[0].ReaderInfo.ReadMsgid != m.Message.ServerHeader.MessageID {
+		if m.GetMessageType() == chat1.MessageType_TEXT {
+			if res.Conversations[0].ReaderInfo.ReadMsgid != m.GetMessageID() {
 				t.Fatalf("conversation was not marked as read\n")
 			}
 			found = true
@@ -385,12 +385,11 @@ func TestChatGracefulUnboxing(t *testing.T) {
 	if len(tv.Thread.Messages) != 3 {
 		t.Fatalf("unexpected response from GetThreadLocal. expected 3 items, got %d\n", len(tv.Thread.Messages))
 	}
-	if tv.Thread.Messages[0].Message != nil ||
-		tv.Thread.Messages[0].UnboxingError == nil || len(tv.Thread.Messages[0].UnboxingError.Errmsg) == 0 {
+	if tv.Thread.Messages[0].IsValid() || len(tv.Thread.Messages[0].Error().ErrMsg) == 0 {
 		t.Fatalf("unexpected response from GetThreadLocal. expected an error message from bad msg, got %#+v\n", tv.Thread.Messages[0])
 	}
-	if tv.Thread.Messages[1].Message == nil || tv.Thread.Messages[1].Message.MessagePlaintext.V1().MessageBody.Text().Body != "innocent hello" {
-		t.Fatalf("unexpected response from GetThreadLocal. expected 'innocent hello' got %#+v\n", tv.Thread.Messages[1].Message)
+	if !tv.Thread.Messages[1].IsValid() || tv.Thread.Messages[1].Valid().MessageBody.Text().Body != "innocent hello" {
+		t.Fatalf("unexpected response from GetThreadLocal. expected 'innocent hello' got %#+v\n", tv.Thread.Messages[1].Valid())
 	}
 }
 
@@ -529,10 +528,10 @@ func TestGetMessagesLocal(t *testing.T) {
 		t.Fatalf("GetMessagesLocal error: %v", err)
 	}
 	for i, msg := range res.Messages {
-		if msg.Message == nil {
+		if !msg.IsValid() {
 			t.Fatalf("Missing message: %v", getIDs[i])
 		}
-		msgID := msg.Message.ServerHeader.MessageID
+		msgID := msg.GetMessageID()
 		if msgID != getIDs[i] {
 			t.Fatalf("Wrong message ID: got %v but expected %v", msgID, getIDs[i])
 		}

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -48,24 +48,6 @@ protocol local {
     case HEADLINE: MessageHeadline;
   }
 
-  enum MessagePlaintextVersion {
-    V1_1
-  }
-
-  // MessagePlaintextV1 is version 1 of MessagePlaintext.
-  // The fields here cannot change.  To modify,
-  // create a new record type with a new version.
-  record MessagePlaintextV1 {
-    MessageClientHeader clientHeader;
-    MessageBody messageBody;
-  }
-
-  // MessagePlaintext is a variant container for all the 
-  // versions of MessagePlaintext.
-  variant MessagePlaintext switch (MessagePlaintextVersion version) {
-    case V1: MessagePlaintextV1;
-  }
-
   enum HeaderPlaintextVersion {
     V1_1
   }
@@ -108,27 +90,38 @@ protocol local {
     case V1: BodyPlaintextV1;
   }
 
-  record MessageFromServer {
+  record MessagePlaintext {
+    MessageClientHeader clientHeader;
+    MessageBody messageBody;
+  }
+
+  enum MessageUnboxedState {
+    VALID_1,
+    ERROR_2
+  }
+
+  record MessageUnboxedValid {
+    MessageClientHeader clientHeader;
     MessageServerHeader serverHeader;
-    MessagePlaintext messagePlaintext;
+    MessageBody messageBody;
     string senderUsername;
     string senderDeviceName;
     Hash headerHash;
   }
-  
-  record MessageError {
-    string errmsg;
+
+  record MessageUnboxedError {
+    string errMsg;
     MessageID messageID;
     MessageType messageType;
-  }
+  } 
 
-  record MessageFromServerOrError {
-    union { null, MessageError } unboxingError;
-    union { null, MessageFromServer } message;
+  variant MessageUnboxed switch (MessageUnboxedState state) {
+    case VALID: MessageUnboxedValid;
+    case ERROR: MessageUnboxedError;
   }
-
+  
   record ThreadView {
-    array<MessageFromServerOrError> messages;
+    array<MessageUnboxed> messages;
     union { null, Pagination } pagination;
   }
 
@@ -159,7 +152,7 @@ protocol local {
     union { null, string } error;
     ConversationInfoLocal info;
     ConversationReaderInfo readerInfo;
-    array<MessageFromServerOrError> maxMessages; // the latest message for each message type
+    array<MessageUnboxed> maxMessages; // the latest message for each message type
   }
 
   GetThreadLocalRes getThreadLocal(ConversationID conversationID, union { null, GetThreadQuery} query, union { null, Pagination } pagination);
@@ -204,7 +197,7 @@ protocol local {
   }
 
 
-  PostLocalRes postLocal(ConversationID conversationID, MessagePlaintext messagePlaintext);
+  PostLocalRes postLocal(ConversationID conversationID, MessagePlaintext msg);
   record PostLocalRes {
     array<RateLimit> rateLimits;
   }
@@ -248,14 +241,14 @@ protocol local {
   }
   record GetConversationForCLILocalRes {
     ConversationLocal conversation;
-    array<MessageFromServerOrError> messages;
+    array<MessageUnboxed> messages;
     array<RateLimit> rateLimits;
   }
 
   // Get messages by ID.
   GetMessagesLocalRes GetMessagesLocal(ConversationID conversationID, array<MessageID> messageIDs);
   record GetMessagesLocalRes {
-    array<MessageFromServerOrError> messages;
+    array<MessageUnboxed> messages;
     array<RateLimit> rateLimits;
   }
 }

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -11,7 +11,7 @@ protocol NotifyChat {
 
   record ChatActivity {
     ChatActivityType ActivityType;
-    union { null, MessageFromServerOrError } IncomingMessage;
+    union { null, MessageUnboxed } IncomingMessage;
   }
 
   @notify("")

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -85,8 +85,9 @@ export const LocalHeaderPlaintextVersion = {
   v1: 1,
 }
 
-export const LocalMessagePlaintextVersion = {
-  v1: 1,
+export const LocalMessageUnboxedState = {
+  valid: 1,
+  error: 2,
 }
 
 export const NotifyChatChatActivityType = {
@@ -306,7 +307,7 @@ export type BodyPlaintextVersion =
 
 export type ChatActivity = {
   ActivityType: ChatActivityType,
-  IncomingMessage?: ?MessageFromServerOrError,
+  IncomingMessage?: ?MessageUnboxed,
 }
 
 export type ChatActivityType = 
@@ -341,7 +342,7 @@ export type ConversationLocal = {
   error?: ?string,
   info: ConversationInfoLocal,
   readerInfo: ConversationReaderInfo,
-  maxMessages?: ?Array<MessageFromServerOrError>,
+  maxMessages?: ?Array<MessageUnboxed>,
 }
 
 export type ConversationMetadata = {
@@ -376,7 +377,7 @@ export type GetConversationForCLILocalQuery = {
 
 export type GetConversationForCLILocalRes = {
   conversation: ConversationLocal,
-  messages?: ?Array<MessageFromServerOrError>,
+  messages?: ?Array<MessageUnboxed>,
   rateLimits?: ?Array<RateLimit>,
 }
 
@@ -448,7 +449,7 @@ export type GetInboxSummaryForCLILocalRes = {
 }
 
 export type GetMessagesLocalRes = {
-  messages?: ?Array<MessageFromServerOrError>,
+  messages?: ?Array<MessageUnboxed>,
   rateLimits?: ?Array<RateLimit>,
 }
 
@@ -549,41 +550,16 @@ export type MessageEdit = {
   body: string,
 }
 
-export type MessageError = {
-  errmsg: string,
-  messageID: MessageID,
-  messageType: MessageType,
-}
-
-export type MessageFromServer = {
-  serverHeader: MessageServerHeader,
-  messagePlaintext: MessagePlaintext,
-  senderUsername: string,
-  senderDeviceName: string,
-  headerHash: Hash,
-}
-
-export type MessageFromServerOrError = {
-  unboxingError?: ?MessageError,
-  message?: ?MessageFromServer,
-}
-
 export type MessageHeadline = {
   headline: string,
 }
 
 export type MessageID = uint
 
-export type MessagePlaintext = 
-    { version : 1, v1 : ?MessagePlaintextV1 }
-
-export type MessagePlaintextV1 = {
+export type MessagePlaintext = {
   clientHeader: MessageClientHeader,
   messageBody: MessageBody,
 }
-
-export type MessagePlaintextVersion = 
-    1 // V1_1
 
 export type MessagePreviousPointer = {
   id: MessageID,
@@ -613,6 +589,29 @@ export type MessageType =
   | 5 // METADATA_5
   | 6 // TLFNAME_6
   | 7 // HEADLINE_7
+
+export type MessageUnboxed = 
+    { state : 1, valid : ?MessageUnboxedValid }
+  | { state : 2, error : ?MessageUnboxedError }
+
+export type MessageUnboxedError = {
+  errMsg: string,
+  messageID: MessageID,
+  messageType: MessageType,
+}
+
+export type MessageUnboxedState = 
+    1 // VALID_1
+  | 2 // ERROR_2
+
+export type MessageUnboxedValid = {
+  clientHeader: MessageClientHeader,
+  serverHeader: MessageServerHeader,
+  messageBody: MessageBody,
+  senderUsername: string,
+  senderDeviceName: string,
+  headerHash: Hash,
+}
 
 export type NewConversationLocalRes = {
   conv: ConversationLocal,
@@ -674,7 +673,7 @@ export type TLFVisibility =
 export type ThreadID = bytes
 
 export type ThreadView = {
-  messages?: ?Array<MessageFromServerOrError>,
+  messages?: ?Array<MessageUnboxed>,
   pagination?: ?Pagination,
 }
 
@@ -734,7 +733,7 @@ export type localNewConversationLocalRpcParam = Exact<{
 
 export type localPostLocalRpcParam = Exact<{
   conversationID: ConversationID,
-  messagePlaintext: MessagePlaintext
+  msg: MessagePlaintext
 }>
 
 export type remoteGetInboxRemoteRpcParam = Exact<{

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -167,44 +167,6 @@
     },
     {
       "type": "enum",
-      "name": "MessagePlaintextVersion",
-      "symbols": [
-        "V1_1"
-      ]
-    },
-    {
-      "type": "record",
-      "name": "MessagePlaintextV1",
-      "fields": [
-        {
-          "type": "MessageClientHeader",
-          "name": "clientHeader"
-        },
-        {
-          "type": "MessageBody",
-          "name": "messageBody"
-        }
-      ]
-    },
-    {
-      "type": "variant",
-      "name": "MessagePlaintext",
-      "switch": {
-        "type": "MessagePlaintextVersion",
-        "name": "version"
-      },
-      "cases": [
-        {
-          "label": {
-            "name": "V1",
-            "def": false
-          },
-          "body": "MessagePlaintextV1"
-        }
-      ]
-    },
-    {
-      "type": "enum",
       "name": "HeaderPlaintextVersion",
       "symbols": [
         "V1_1"
@@ -311,15 +273,41 @@
     },
     {
       "type": "record",
-      "name": "MessageFromServer",
+      "name": "MessagePlaintext",
       "fields": [
+        {
+          "type": "MessageClientHeader",
+          "name": "clientHeader"
+        },
+        {
+          "type": "MessageBody",
+          "name": "messageBody"
+        }
+      ]
+    },
+    {
+      "type": "enum",
+      "name": "MessageUnboxedState",
+      "symbols": [
+        "VALID_1",
+        "ERROR_2"
+      ]
+    },
+    {
+      "type": "record",
+      "name": "MessageUnboxedValid",
+      "fields": [
+        {
+          "type": "MessageClientHeader",
+          "name": "clientHeader"
+        },
         {
           "type": "MessageServerHeader",
           "name": "serverHeader"
         },
         {
-          "type": "MessagePlaintext",
-          "name": "messagePlaintext"
+          "type": "MessageBody",
+          "name": "messageBody"
         },
         {
           "type": "string",
@@ -337,11 +325,11 @@
     },
     {
       "type": "record",
-      "name": "MessageError",
+      "name": "MessageUnboxedError",
       "fields": [
         {
           "type": "string",
-          "name": "errmsg"
+          "name": "errMsg"
         },
         {
           "type": "MessageID",
@@ -354,22 +342,26 @@
       ]
     },
     {
-      "type": "record",
-      "name": "MessageFromServerOrError",
-      "fields": [
+      "type": "variant",
+      "name": "MessageUnboxed",
+      "switch": {
+        "type": "MessageUnboxedState",
+        "name": "state"
+      },
+      "cases": [
         {
-          "type": [
-            null,
-            "MessageError"
-          ],
-          "name": "unboxingError"
+          "label": {
+            "name": "VALID",
+            "def": false
+          },
+          "body": "MessageUnboxedValid"
         },
         {
-          "type": [
-            null,
-            "MessageFromServer"
-          ],
-          "name": "message"
+          "label": {
+            "name": "ERROR",
+            "def": false
+          },
+          "body": "MessageUnboxedError"
         }
       ]
     },
@@ -380,7 +372,7 @@
         {
           "type": {
             "type": "array",
-            "items": "MessageFromServerOrError"
+            "items": "MessageUnboxed"
           },
           "name": "messages"
         },
@@ -459,7 +451,7 @@
         {
           "type": {
             "type": "array",
-            "items": "MessageFromServerOrError"
+            "items": "MessageUnboxed"
           },
           "name": "maxMessages"
         }
@@ -764,7 +756,7 @@
         {
           "type": {
             "type": "array",
-            "items": "MessageFromServerOrError"
+            "items": "MessageUnboxed"
           },
           "name": "messages"
         },
@@ -784,7 +776,7 @@
         {
           "type": {
             "type": "array",
-            "items": "MessageFromServerOrError"
+            "items": "MessageUnboxed"
           },
           "name": "messages"
         },
@@ -867,7 +859,7 @@
           "type": "ConversationID"
         },
         {
-          "name": "messagePlaintext",
+          "name": "msg",
           "type": "MessagePlaintext"
         }
       ],

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -27,7 +27,7 @@
         {
           "type": [
             null,
-            "MessageFromServerOrError"
+            "MessageUnboxed"
           ],
           "name": "IncomingMessage"
         }

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -85,8 +85,9 @@ export const LocalHeaderPlaintextVersion = {
   v1: 1,
 }
 
-export const LocalMessagePlaintextVersion = {
-  v1: 1,
+export const LocalMessageUnboxedState = {
+  valid: 1,
+  error: 2,
 }
 
 export const NotifyChatChatActivityType = {
@@ -306,7 +307,7 @@ export type BodyPlaintextVersion =
 
 export type ChatActivity = {
   ActivityType: ChatActivityType,
-  IncomingMessage?: ?MessageFromServerOrError,
+  IncomingMessage?: ?MessageUnboxed,
 }
 
 export type ChatActivityType = 
@@ -341,7 +342,7 @@ export type ConversationLocal = {
   error?: ?string,
   info: ConversationInfoLocal,
   readerInfo: ConversationReaderInfo,
-  maxMessages?: ?Array<MessageFromServerOrError>,
+  maxMessages?: ?Array<MessageUnboxed>,
 }
 
 export type ConversationMetadata = {
@@ -376,7 +377,7 @@ export type GetConversationForCLILocalQuery = {
 
 export type GetConversationForCLILocalRes = {
   conversation: ConversationLocal,
-  messages?: ?Array<MessageFromServerOrError>,
+  messages?: ?Array<MessageUnboxed>,
   rateLimits?: ?Array<RateLimit>,
 }
 
@@ -448,7 +449,7 @@ export type GetInboxSummaryForCLILocalRes = {
 }
 
 export type GetMessagesLocalRes = {
-  messages?: ?Array<MessageFromServerOrError>,
+  messages?: ?Array<MessageUnboxed>,
   rateLimits?: ?Array<RateLimit>,
 }
 
@@ -549,41 +550,16 @@ export type MessageEdit = {
   body: string,
 }
 
-export type MessageError = {
-  errmsg: string,
-  messageID: MessageID,
-  messageType: MessageType,
-}
-
-export type MessageFromServer = {
-  serverHeader: MessageServerHeader,
-  messagePlaintext: MessagePlaintext,
-  senderUsername: string,
-  senderDeviceName: string,
-  headerHash: Hash,
-}
-
-export type MessageFromServerOrError = {
-  unboxingError?: ?MessageError,
-  message?: ?MessageFromServer,
-}
-
 export type MessageHeadline = {
   headline: string,
 }
 
 export type MessageID = uint
 
-export type MessagePlaintext = 
-    { version : 1, v1 : ?MessagePlaintextV1 }
-
-export type MessagePlaintextV1 = {
+export type MessagePlaintext = {
   clientHeader: MessageClientHeader,
   messageBody: MessageBody,
 }
-
-export type MessagePlaintextVersion = 
-    1 // V1_1
 
 export type MessagePreviousPointer = {
   id: MessageID,
@@ -613,6 +589,29 @@ export type MessageType =
   | 5 // METADATA_5
   | 6 // TLFNAME_6
   | 7 // HEADLINE_7
+
+export type MessageUnboxed = 
+    { state : 1, valid : ?MessageUnboxedValid }
+  | { state : 2, error : ?MessageUnboxedError }
+
+export type MessageUnboxedError = {
+  errMsg: string,
+  messageID: MessageID,
+  messageType: MessageType,
+}
+
+export type MessageUnboxedState = 
+    1 // VALID_1
+  | 2 // ERROR_2
+
+export type MessageUnboxedValid = {
+  clientHeader: MessageClientHeader,
+  serverHeader: MessageServerHeader,
+  messageBody: MessageBody,
+  senderUsername: string,
+  senderDeviceName: string,
+  headerHash: Hash,
+}
 
 export type NewConversationLocalRes = {
   conv: ConversationLocal,
@@ -674,7 +673,7 @@ export type TLFVisibility =
 export type ThreadID = bytes
 
 export type ThreadView = {
-  messages?: ?Array<MessageFromServerOrError>,
+  messages?: ?Array<MessageUnboxed>,
   pagination?: ?Pagination,
 }
 
@@ -734,7 +733,7 @@ export type localNewConversationLocalRpcParam = Exact<{
 
 export type localPostLocalRpcParam = Exact<{
   conversationID: ConversationID,
-  messagePlaintext: MessagePlaintext
+  msg: MessagePlaintext
 }>
 
 export type remoteGetInboxRemoteRpcParam = Exact<{


### PR DESCRIPTION
@patrickxb @songgao @oconnor663 @mlsteele @maxtaco r?

I just went ahead and tagged all the chat developers on this PR since it touches code that everyone has worked on.

The purpose of this patch is to un-version `MessagePlaintext` in order to simplify a bunch of the code that uses it. All version specific code now takes place in `chat.Boxer`, and any client code of that just deals with a normal type. 

I also changed `MessageFromServerOrError` into a variant type, and renamed it to `MessageUnboxed`, since I think that is a more accurate name. The variant type also makes the code easier to understand and write.