### PR TITLE
on device revoke, output a list of endagered TLFs

### DIFF
--- a/go/client/cmd_device_remove.go
+++ b/go/client/cmd_device_remove.go
@@ -65,7 +65,7 @@ func (c *CmdDeviceRemove) confirmDelete(id keybase1.DeviceID) error {
 	}
 
 	tui.OutputDesc(OutputDescriptorEndageredTLFs, out)
-	ok, err := tui.PromptYesNo(PromptDescriptorDeviceRevoke, "Go ahead anyway", libkb.PromptDefaultNo)
+	ok, err := tui.PromptYesNo(PromptDescriptorDeviceRevoke, "Go ahead anyway?", libkb.PromptDefaultNo)
 	if err != nil {
 		return err
 	}

--- a/go/client/cmd_rekey_status.go
+++ b/go/client/cmd_rekey_status.go
@@ -34,7 +34,7 @@ func (c *CmdRekeyStatus) ParseArgv(ctx *cli.Context) error {
 }
 
 func (c *CmdRekeyStatus) Run() error {
-	cli, err := GetRekeyClient()
+	cli, err := GetRekeyClient(c.G())
 	if err != nil {
 		return err
 	}

--- a/go/client/cmd_rekey_trigger.go
+++ b/go/client/cmd_rekey_trigger.go
@@ -36,7 +36,7 @@ func (c *CmdRekeyTrigger) ParseArgv(ctx *cli.Context) error {
 }
 
 func (c *CmdRekeyTrigger) Run() error {
-	cli, err := GetRekeyClient()
+	cli, err := GetRekeyClient(c.G())
 	if err != nil {
 		return err
 	}

--- a/go/client/prompts.go
+++ b/go/client/prompts.go
@@ -52,9 +52,11 @@ const (
 	PromptDescriptorTrackExpireLocal
 	PromptDescriptorChooseConversation
 	PromptDescriptorEnterChatMessage
+	PromptDescriptorDeviceRevoke
 )
 
 const (
 	OutputDescriptorGeneric libkb.OutputDescriptor = iota
 	OutputDescriptorPrimaryPaperKey
+	OutputDescriptorEndageredTLFs
 )

--- a/go/client/rpc.go
+++ b/go/client/rpc.go
@@ -292,8 +292,8 @@ func GetPaperProvisionClient(g *libkb.GlobalContext) (cli keybase1.Paperprovisio
 	return cli, nil
 }
 
-func GetRekeyClient() (keybase1.RekeyClient, error) {
-	rcli, _, err := GetRPCClient()
+func GetRekeyClient(g *libkb.GlobalContext) (keybase1.RekeyClient, error) {
+	rcli, _, err := GetRPCClientWithContext(g)
 	if err != nil {
 		return keybase1.RekeyClient{}, err
 	}

--- a/go/protocol/keybase1/rekey.go
+++ b/go/protocol/keybase1/rekey.go
@@ -84,7 +84,6 @@ type RekeySyncArg struct {
 
 type GetRevokeWarningArg struct {
 	Session      int      `codec:"session" json:"session"`
-	ActingDevice DeviceID `codec:"actingDevice" json:"actingDevice"`
 	TargetDevice DeviceID `codec:"targetDevice" json:"targetDevice"`
 }
 

--- a/go/protocol/keybase1/rekey.go
+++ b/go/protocol/keybase1/rekey.go
@@ -84,6 +84,7 @@ type RekeySyncArg struct {
 
 type GetRevokeWarningArg struct {
 	Session      int      `codec:"session" json:"session"`
+	ActingDevice DeviceID `codec:"actingDevice" json:"actingDevice"`
 	TargetDevice DeviceID `codec:"targetDevice" json:"targetDevice"`
 }
 

--- a/go/systests/device_common_test.go
+++ b/go/systests/device_common_test.go
@@ -1,0 +1,527 @@
+package systests
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"github.com/jonboulle/clockwork"
+	"github.com/keybase/client/go/client"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/service"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	context "golang.org/x/net/context"
+	"io"
+	"testing"
+	"time"
+)
+
+//
+// device_common_test is common utilities for testing multiple devices;
+// for instance, to test rekey reminders on device revoke.
+//
+
+// Used for provisioning users and new devices within our testing framework
+type testUI struct {
+	libkb.Contextified
+	baseNullUI
+	sessionID          int
+	outputDescHook     func(libkb.OutputDescriptor, string) error
+	promptHook         func(libkb.PromptDescriptor, string) (string, error)
+	promptPasswordHook func(libkb.PromptDescriptor, string) (string, error)
+	promptYesNoHook    func(libkb.PromptDescriptor, string, libkb.PromptDefault) (bool, error)
+}
+
+var sessionCounter = 1
+
+func newTestUI(g *libkb.GlobalContext) *testUI {
+	x := sessionCounter
+	sessionCounter++
+	return &testUI{Contextified: libkb.NewContextified(g), sessionID: x}
+}
+
+func (t *testUI) GetTerminalUI() libkb.TerminalUI {
+	return t
+}
+
+func (t *testUI) Write(b []byte) (int, error) {
+	t.G().Log.Debug("Terminal write: %s", string(b))
+	return len(b), nil
+}
+
+func (t *testUI) ErrorWriter() io.Writer {
+	return t
+}
+
+func (t *testUI) Output(s string) error {
+	t.G().Log.Debug("Terminal Output: %s", s)
+	return nil
+}
+
+func (t *testUI) OutputDesc(d libkb.OutputDescriptor, s string) error {
+	if t.outputDescHook != nil {
+		return t.outputDescHook(d, s)
+	}
+	return t.Output(s)
+}
+
+func (t *testUI) OutputWriter() io.Writer {
+	return t
+}
+
+func (t *testUI) Printf(f string, args ...interface{}) (int, error) {
+	s := fmt.Sprintf(f, args...)
+	t.G().Log.Debug("Terminal Printf: %s", s)
+	return len(s), nil
+}
+
+func (t *testUI) Prompt(d libkb.PromptDescriptor, s string) (string, error) {
+	if t.promptHook != nil {
+		return t.promptHook(d, s)
+	}
+	return "", fmt.Errorf("Unhandled prompt: %q (%d)", s, d)
+}
+
+func (t *testUI) PromptForConfirmation(p string) error {
+	return fmt.Errorf("unhandled prompt for confirmation: %q", p)
+}
+
+func (t *testUI) PromptPassword(d libkb.PromptDescriptor, s string) (string, error) {
+	return "", fmt.Errorf("unhandled prompt for password: %q (%d)", s, d)
+}
+
+func (t *testUI) PromptYesNo(d libkb.PromptDescriptor, s string, def libkb.PromptDefault) (bool, error) {
+	if t.promptYesNoHook != nil {
+		return t.promptYesNoHook(d, s, def)
+	}
+	return false, fmt.Errorf("unhandled yes/no prompt: %q (%d)", s, d)
+}
+
+func (t *testUI) Tablify(headings []string, rowfunc func() []string) {
+	libkb.Tablify(t.OutputWriter(), headings, rowfunc)
+}
+
+func (t *testUI) TerminalSize() (width int, height int) {
+	return 80, 24
+}
+
+type backupKey struct {
+	KID      keybase1.KID
+	deviceID keybase1.DeviceID
+	secret   string
+}
+
+// testDevice wraps a mock "device", meaning an independent running service and
+// some connected clients. It's forked from deviceWrapper in rekey_test.
+type testDevice struct {
+	t          *testing.T
+	tctx       *libkb.TestContext
+	clones     []*libkb.TestContext
+	stopCh     chan error
+	service    *service.Service
+	testUI     *testUI
+	deviceID   keybase1.DeviceID
+	deviceName string
+	deviceKey  keybase1.PublicKey
+	cli        *rpc.Client
+	srv        *rpc.Server
+	userClient keybase1.UserClient
+}
+
+type testDeviceSet struct {
+	t          *testing.T
+	log        logger.Logger
+	devices    []*testDevice
+	fakeClock  clockwork.FakeClock
+	backupKeys []backupKey
+	username   string
+	uid        keybase1.UID
+}
+
+func (d *testDevice) startService(numClones int) {
+	for i := 0; i < numClones; i++ {
+		d.clones = append(d.clones, cloneContext(d.tctx))
+	}
+	d.stopCh = make(chan error)
+	svc := service.NewService(d.tctx.G, false)
+	d.service = svc
+	startCh := svc.GetStartChannel()
+	go func() {
+		d.stopCh <- svc.Run()
+	}()
+	<-startCh
+}
+
+func (d *testDevice) KID() keybase1.KID { return d.deviceKey.KID }
+
+func (d *testDevice) startClient() {
+	tctx := d.popClone()
+	g := tctx.G
+	ui := newTestUI(g)
+	d.testUI = ui
+	launch := func() error {
+		cli, xp, err := client.GetRPCClientWithContext(g)
+		if err != nil {
+			return err
+		}
+		srv := rpc.NewServer(xp, nil)
+		d.cli = cli
+		d.srv = srv
+		d.userClient = keybase1.UserClient{Cli: cli}
+		return nil
+	}
+
+	if err := launch(); err != nil {
+		d.t.Fatalf("Failed to launch rekey UI: %s", err)
+	}
+}
+
+func (d *testDevice) start(numClones int) *testDevice {
+	d.startService(numClones)
+	d.startClient()
+	return d
+}
+
+func (d *testDevice) stop() error {
+	return <-d.stopCh
+}
+
+func (d *testDevice) popClone() *libkb.TestContext {
+	if len(d.clones) == 0 {
+		panic("ran out of cloned environments")
+	}
+	ret := d.clones[0]
+	d.clones = d.clones[1:]
+	return ret
+}
+
+func newTestDeviceSet(t *testing.T, cl clockwork.FakeClock) *testDeviceSet {
+	if cl == nil {
+		cl = clockwork.NewFakeClockAt(time.Now())
+	}
+	return &testDeviceSet{
+		t:         t,
+		fakeClock: cl,
+	}
+}
+
+func (s *testDeviceSet) cleanup() {
+	for _, od := range s.devices {
+		od.tctx.Cleanup()
+	}
+}
+
+func (s *testDeviceSet) newDevice(nm string) *testDevice {
+	tctx := setupTest(s.t, nm)
+	tctx.G.SetClock(s.fakeClock)
+
+	// Opportunistically take a log as soon as we make one.
+	if s.log == nil {
+		s.log = tctx.G.Log
+	}
+
+	ret := &testDevice{t: s.t, tctx: tctx, deviceName: nm}
+	s.devices = append(s.devices, ret)
+	return ret
+}
+
+func (d *testDevice) loadEncryptionKIDs() (devices []keybase1.KID, backups []backupKey) {
+	keyMap := make(map[keybase1.KID]keybase1.PublicKey)
+	keys, err := d.userClient.LoadMyPublicKeys(context.TODO(), 0)
+	if err != nil {
+		d.t.Fatalf("Failed to LoadMyPublicKeys: %s", err)
+	}
+	for _, key := range keys {
+		keyMap[key.KID] = key
+	}
+
+	for _, key := range keys {
+		if key.IsSibkey {
+			continue
+		}
+		parent, found := keyMap[keybase1.KID(key.ParentID)]
+		if !found {
+			continue
+		}
+
+		switch parent.DeviceType {
+		case libkb.DeviceTypePaper:
+			backups = append(backups, backupKey{KID: key.KID, deviceID: parent.DeviceID})
+		case libkb.DeviceTypeDesktop:
+			devices = append(devices, key.KID)
+		default:
+		}
+	}
+	return devices, backups
+}
+
+func (d *testDevice) loadDeviceList() []keybase1.Device {
+	cli := keybase1.DeviceClient{Cli: d.cli}
+	devices, err := cli.DeviceList(context.TODO(), 0)
+	if err != nil {
+		d.t.Fatalf("devices: %s", err)
+	}
+	var ret []keybase1.Device
+	for _, device := range devices {
+		if device.Type == "desktop" {
+			ret = append(ret, device)
+		}
+
+	}
+	return ret
+}
+
+func (s *testDeviceSet) signupUser(dev *testDevice) {
+	userInfo := randomUser("rekey")
+	tctx := dev.popClone()
+	g := tctx.G
+	signupUI := signupUI{
+		info:         userInfo,
+		Contextified: libkb.NewContextified(g),
+	}
+	g.SetUI(&signupUI)
+	signup := client.NewCmdSignupRunner(g)
+	signup.SetTest()
+	if err := signup.Run(); err != nil {
+		s.t.Fatal(err)
+	}
+	s.t.Logf("signed up %s", userInfo.username)
+	s.username = userInfo.username
+	s.uid = libkb.UsernameToUID(s.username)
+	var backupKey backupKey
+	deviceKeys, backups := dev.loadEncryptionKIDs()
+	if len(deviceKeys) != 1 {
+		s.t.Fatalf("Expected 1 device back; got %d", len(deviceKeys))
+	}
+	if len(backups) != 1 {
+		s.t.Fatalf("Expected 1 backup back; got %d", len(backups))
+	}
+	dev.deviceKey.KID = deviceKeys[0]
+	backupKey = backups[0]
+	backupKey.secret = signupUI.info.displayedPaperKey
+	s.backupKeys = append(s.backupKeys, backupKey)
+
+	devices := dev.loadDeviceList()
+	if len(devices) != 1 {
+		s.t.Fatalf("Expected 1 device back; got %d", len(devices))
+	}
+	dev.deviceID = devices[0].DeviceID
+}
+
+type testProvisionUI struct {
+	baseNullUI
+	username   string
+	deviceName string
+	backupKey  backupKey
+}
+
+func (r *testProvisionUI) GetEmailOrUsername(context.Context, int) (string, error) {
+	return r.username, nil
+}
+func (r *testProvisionUI) PromptRevokePaperKeys(context.Context, keybase1.PromptRevokePaperKeysArg) (ret bool, err error) {
+	return false, nil
+}
+func (r *testProvisionUI) DisplayPaperKeyPhrase(context.Context, keybase1.DisplayPaperKeyPhraseArg) error {
+	return nil
+}
+func (r *testProvisionUI) DisplayPrimaryPaperKey(context.Context, keybase1.DisplayPrimaryPaperKeyArg) error {
+	return nil
+}
+func (r *testProvisionUI) ChooseProvisioningMethod(context.Context, keybase1.ChooseProvisioningMethodArg) (ret keybase1.ProvisionMethod, err error) {
+	return ret, nil
+}
+func (r *testProvisionUI) ChooseGPGMethod(context.Context, keybase1.ChooseGPGMethodArg) (ret keybase1.GPGMethod, err error) {
+	return ret, nil
+}
+func (r *testProvisionUI) SwitchToGPGSignOK(context.Context, keybase1.SwitchToGPGSignOKArg) (ret bool, err error) {
+	return ret, nil
+}
+func (r *testProvisionUI) ChooseDeviceType(context.Context, keybase1.ChooseDeviceTypeArg) (ret keybase1.DeviceType, err error) {
+	return ret, nil
+}
+func (r *testProvisionUI) DisplayAndPromptSecret(context.Context, keybase1.DisplayAndPromptSecretArg) (ret keybase1.SecretResponse, err error) {
+	return ret, nil
+}
+func (r *testProvisionUI) DisplaySecretExchanged(context.Context, int) error {
+	return nil
+}
+func (r *testProvisionUI) PromptNewDeviceName(context.Context, keybase1.PromptNewDeviceNameArg) (ret string, err error) {
+	return r.deviceName, nil
+}
+func (r *testProvisionUI) ProvisioneeSuccess(context.Context, keybase1.ProvisioneeSuccessArg) error {
+	return nil
+}
+func (r *testProvisionUI) ProvisionerSuccess(context.Context, keybase1.ProvisionerSuccessArg) error {
+	return nil
+}
+func (r *testProvisionUI) ChooseDevice(context.Context, keybase1.ChooseDeviceArg) (ret keybase1.DeviceID, err error) {
+	return r.backupKey.deviceID, nil
+}
+func (r *testProvisionUI) GetPassphrase(context.Context, keybase1.GetPassphraseArg) (ret keybase1.GetPassphraseRes, err error) {
+	ret.Passphrase = r.backupKey.secret
+	return ret, nil
+}
+
+func (s *testDeviceSet) findNewKIDs(newList []keybase1.KID) []keybase1.KID {
+	var ret []keybase1.KID
+	for _, newKID := range newList {
+		tmpFound := false
+		for _, device := range s.devices {
+			if !device.KID().IsNil() && newKID.Equal(device.KID()) {
+				tmpFound = true
+				break
+			}
+		}
+		if !tmpFound {
+			ret = append(ret, newKID)
+		}
+	}
+	return ret
+}
+
+func (s *testDeviceSet) findNewDevices(newList []keybase1.Device) []keybase1.Device {
+	var ret []keybase1.Device
+	for _, newDevice := range newList {
+		tmpFound := false
+		for _, device := range s.devices {
+			if !device.deviceID.IsNil() && newDevice.DeviceID.Eq(device.deviceID) {
+				tmpFound = true
+				break
+			}
+		}
+		if !tmpFound {
+			ret = append(ret, newDevice)
+		}
+	}
+	return ret
+}
+
+func (s *testDeviceSet) provision(d *testDevice) {
+	tctx := d.popClone()
+	g := tctx.G
+	var loginClient keybase1.LoginClient
+	ui := &testProvisionUI{username: s.username, backupKey: s.backupKeys[0], deviceName: d.deviceName}
+
+	launch := func() error {
+		cli, xp, err := client.GetRPCClientWithContext(g)
+		if err != nil {
+			return err
+		}
+		srv := rpc.NewServer(xp, nil)
+		protocols := []rpc.Protocol{
+			keybase1.LoginUiProtocol(ui),
+			keybase1.SecretUiProtocol(ui),
+			keybase1.ProvisionUiProtocol(ui),
+		}
+		for _, prot := range protocols {
+			if err = srv.Register(prot); err != nil {
+				return err
+			}
+		}
+		loginClient = keybase1.LoginClient{Cli: cli}
+		return nil
+	}
+
+	if err := launch(); err != nil {
+		s.t.Fatalf("Failed to login rekey UI: %s", err)
+	}
+	cmd := client.NewCmdLoginRunner(g)
+	if err := cmd.Run(); err != nil {
+		s.t.Fatalf("Login failed: %s\n", err)
+	}
+
+	deviceKeys, backups := d.loadEncryptionKIDs()
+	deviceKeys = s.findNewKIDs(deviceKeys)
+	if len(deviceKeys) != 1 {
+		s.t.Fatalf("expected 1 new device encryption key")
+	}
+	d.deviceKey.KID = deviceKeys[0]
+	if len(backups) != 1 {
+		s.t.Fatalf("expected 1 backup key only")
+	}
+	devices := s.findNewDevices(d.loadDeviceList())
+	if len(devices) != 1 {
+		s.t.Fatalf("expected 1 device ID; got %d", len(devices))
+	}
+	d.deviceID = devices[0].DeviceID
+}
+
+func (s *testDeviceSet) provisionNewDevice(name string, numClones int) *testDevice {
+	ret := s.newDevice(name)
+	ret.start(numClones + 1)
+	s.provision(ret)
+	return ret
+}
+
+func newTLFID() keybase1.TLFID {
+	var b []byte
+	b, err := libkb.RandBytes(16)
+	if err != nil {
+		return ""
+	}
+	b[15] = 0x16
+	return keybase1.TLFID(hex.EncodeToString(b))
+}
+
+type fakeTLF struct {
+	id       keybase1.TLFID
+	revision int
+}
+
+func newFakeTLF() *fakeTLF {
+	return &fakeTLF{
+		id:       newTLFID(),
+		revision: 0,
+	}
+}
+
+type tlfUser struct {
+	UID  keybase1.UID   `json:"uid"`
+	Keys []keybase1.KID `json:"encryptKeys"`
+}
+
+type tlfUpdate struct {
+	ID        keybase1.TLFID `json:"tlfid"`
+	UID       keybase1.UID   `json:"uid"`
+	KID       keybase1.KID   `json:"kid"`
+	Revision  int            `json:"folderREvision"`
+	Writers   []tlfUser      `json:"resolvedWriters"`
+	Readers   []tlfUser      `json:"resolvedReaders"`
+	IsPrivate bool           `json:"is_private"`
+}
+
+func (d *testDevice) keyNewTLF(uid keybase1.UID, writers []tlfUser, readers []tlfUser) *fakeTLF {
+	ret := newFakeTLF()
+	d.keyTLF(ret, uid, writers, readers)
+	return ret
+}
+
+func (d *testDevice) keyTLF(tlf *fakeTLF, uid keybase1.UID, writers []tlfUser, readers []tlfUser) {
+	tlf.revision++
+	up := tlfUpdate{
+		ID:        tlf.id,
+		UID:       uid,
+		KID:       d.KID(),
+		Revision:  tlf.revision,
+		Writers:   writers,
+		Readers:   readers,
+		IsPrivate: true,
+	}
+	g := d.tctx.G
+	b, err := json.Marshal(up)
+	if err != nil {
+		d.t.Fatalf("error marshalling: %s", err)
+	}
+	apiArg := libkb.APIArg{
+		Endpoint: "test/fake_generic_tlf",
+		Args: libkb.HTTPArgs{
+			"tlf_info": libkb.S{Val: string(b)},
+		},
+		NeedSession: true,
+	}
+	_, err = g.API.Post(apiArg)
+	if err != nil {
+		d.t.Fatalf("post error: %s", err)
+	}
+}

--- a/go/systests/device_test.go
+++ b/go/systests/device_test.go
@@ -1,0 +1,104 @@
+package systests
+
+import (
+	"fmt"
+	"github.com/keybase/client/go/client"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	context "golang.org/x/net/context"
+	"strings"
+	"testing"
+)
+
+func TestRevokeDevices(t *testing.T) {
+	set := newTestDeviceSet(t, nil)
+	defer set.cleanup()
+
+	// Set up first device
+	dev1 := set.newDevice("primary").start(4)
+
+	// Signup the new user for this device
+	set.signupUser(dev1)
+
+	// Provision a new device
+	dev2 := set.provisionNewDevice("secondary", 1)
+
+	alice := tlfUser{
+		keybase1.UID("295a7eea607af32040647123732bc819"),
+		[]keybase1.KID{},
+	}
+	mike := tlfUser{
+		keybase1.UID("ff261e3b26543a24ba6c0693820ead19"),
+		[]keybase1.KID{keybase1.KID("012073f26b5996912393f7d2961ca90968e4e83d6140e9771ba890ff8ba6ea97777e0a")},
+	}
+
+	// Add a new TLF (private/tester#alice) that's fully keyed
+	dev1.keyNewTLF(set.uid,
+		[]tlfUser{tlfUser{set.uid, []keybase1.KID{dev1.KID(), dev2.KID(), set.backupKeys[0].KID}}},
+		[]tlfUser{alice},
+	)
+
+	// Add a new TLF (private/tester#mike) that isn't keyed for the current
+	// device
+	tlf2 := dev1.keyNewTLF(set.uid,
+		[]tlfUser{tlfUser{set.uid, []keybase1.KID{dev2.KID(), set.backupKeys[0].KID}}},
+		[]tlfUser{mike},
+	)
+
+	// Call the server and process the API call. Make sure we get a list of
+	// "endangered" TLFs that includes private/tester#mike
+	cli := keybase1.RekeyClient{Cli: dev1.cli}
+	res, err := cli.GetRevokeWarning(context.TODO(), keybase1.GetRevokeWarningArg{
+		ActingDevice: dev1.deviceID,
+		TargetDevice: dev2.deviceID,
+	})
+
+	if err != nil {
+		t.Fatalf("Bad answer from RPC: %s", err)
+	}
+
+	if n := len(res.EndangeredTLFs); n != 1 {
+		t.Fatalf("Expected 1 endangered TLF: got %d", n)
+	}
+
+	if id := res.EndangeredTLFs[0].Id; id != tlf2.id {
+		t.Fatalf("Got wrong TLF ID; wanted %s; but got %s", tlf2.id, id)
+	}
+
+	expectedName := fmt.Sprintf("private/%s#%s", set.username, "t_mike")
+	if nm := res.EndangeredTLFs[0].Name; nm != expectedName {
+		t.Fatalf("Got wrong TLF name; wanted %q; but got %q", expectedName, nm)
+	}
+
+	run := func(accept bool) {
+		g := dev1.popClone().G
+		ui := newTestUI(g)
+		g.SetUI(ui)
+
+		var prompt string
+		ui.outputDescHook = func(d libkb.OutputDescriptor, s string) (err error) {
+			if d == client.OutputDescriptorEndageredTLFs {
+				prompt = s
+			}
+			return nil
+		}
+
+		ui.promptYesNoHook = func(libkb.PromptDescriptor, string, libkb.PromptDefault) (bool, error) {
+			return accept, nil
+		}
+
+		runner := client.NewCmdDeviceRemoveRunner(g)
+		runner.SetIDOrName(dev2.deviceName)
+		err = runner.Run()
+
+		if (err == nil) != accept {
+			t.Fatalf("With accept=%v, got unexpected error: %v", accept, err)
+		}
+
+		if strings.Index(prompt, expectedName) < 0 {
+			t.Fatalf("didn't find expected TLF name %q", expectedName)
+		}
+	}
+	run(false)
+	run(true)
+}

--- a/go/systests/rekey_test.go
+++ b/go/systests/rekey_test.go
@@ -1,7 +1,6 @@
 package systests
 
 import (
-	"encoding/hex"
 	"fmt"
 	"github.com/jonboulle/clockwork"
 	"github.com/keybase/client/go/client"
@@ -61,18 +60,6 @@ func (d *deviceWrapper) popClone() *libkb.TestContext {
 	return ret
 }
 
-type fakeTLF struct {
-	id       string
-	revision int
-}
-
-func newFakeTLF() *fakeTLF {
-	return &fakeTLF{
-		id:       newTLFId(),
-		revision: 0,
-	}
-}
-
 func (rkt *rekeyTester) getFakeTLF() *fakeTLF {
 	if rkt.fakeTLF == nil {
 		rkt.fakeTLF = newFakeTLF()
@@ -83,12 +70,6 @@ func (rkt *rekeyTester) getFakeTLF() *fakeTLF {
 func (tlf *fakeTLF) nextRevision() int {
 	tlf.revision++
 	return tlf.revision
-}
-
-type backupKey struct {
-	KID      keybase1.KID
-	deviceID keybase1.DeviceID
-	secret   string
 }
 
 type rekeyTester struct {
@@ -281,16 +262,6 @@ func (rkt *rekeyTester) confirmNoRekeyUIActivity(dw *deviceWrapper, hours int, f
 	assertNoActivity(hours + 1)
 }
 
-func newTLFId() string {
-	var b []byte
-	b, err := libkb.RandBytes(16)
-	if err != nil {
-		return ""
-	}
-	b[15] = 0x16
-	return hex.EncodeToString(b)
-}
-
 func (rkt *rekeyTester) makeFullyKeyedHomeTLF() {
 	kids := []keybase1.KID{}
 	for _, dev := range rkt.devices {
@@ -319,7 +290,7 @@ func (rkt *rekeyTester) changeKeysOnHomeTLF(kids []keybase1.KID) {
 	fakeTLF := rkt.getFakeTLF()
 	apiArg := libkb.APIArg{
 		Args: libkb.HTTPArgs{
-			"tlfid":          libkb.S{Val: fakeTLF.id},
+			"tlfid":          libkb.S{Val: string(fakeTLF.id)},
 			"kids":           libkb.S{Val: strings.Join(kidStrings, ",")},
 			"folderRevision": libkb.I{Val: fakeTLF.nextRevision()},
 		},

--- a/protocol/avdl/keybase1/rekey.avdl
+++ b/protocol/avdl/keybase1/rekey.avdl
@@ -81,5 +81,5 @@ protocol rekey {
    GetRevokeWarning computes the TLFs that will be endangered if actingDevice
    revokes targetDevice.
    */
-  RevokeWarning getRevokeWarning(int session, DeviceID targetDevice);
+  RevokeWarning getRevokeWarning(int session, DeviceID actingDevice, DeviceID targetDevice);
 }

--- a/protocol/avdl/keybase1/rekey.avdl
+++ b/protocol/avdl/keybase1/rekey.avdl
@@ -43,6 +43,10 @@ protocol rekey {
     IGNORED_2
   }
 
+  record RevokeWarning {
+    array<TLF> endangeredTLFs;
+  }
+
   /**
    ShowPendingRekeyStatus shows either pending gregor-initiated rekey harassments
    or nothing if none were pending.
@@ -72,4 +76,10 @@ protocol rekey {
    Force overrides a long-snooze.
    */
   void rekeySync(int sessionID, boolean force);
+
+  /**
+   GetRevokeWarning computes the TLFs that will be endangered if actingDevice
+   revokes targetDevice.
+   */
+  RevokeWarning getRevokeWarning(int session, DeviceID targetDevice);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1964,6 +1964,18 @@ export function rekeyGetPendingRekeyStatusRpcPromise (request: $Exact<requestCom
   return new Promise((resolve, reject) => { rekeyGetPendingRekeyStatusRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function rekeyGetRevokeWarningRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: rekeyGetRevokeWarningResult) => void} & {param: rekeyGetRevokeWarningRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'rekey.getRevokeWarning'})
+}
+
+export function rekeyGetRevokeWarningRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: rekeyGetRevokeWarningResult) => void} & {param: rekeyGetRevokeWarningRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => rekeyGetRevokeWarningRpc({...request, incomingCallMap, callback}))
+}
+
+export function rekeyGetRevokeWarningRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: rekeyGetRevokeWarningResult) => void} & {param: rekeyGetRevokeWarningRpcParam}>): Promise<rekeyGetRevokeWarningResult> {
+  return new Promise((resolve, reject) => { rekeyGetRevokeWarningRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function rekeyRekeyStatusFinishRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: rekeyRekeyStatusFinishResult) => void}>) {
   engineRpcOutgoing({...request, method: 'rekey.rekeyStatusFinish'})
 }
@@ -3439,6 +3451,10 @@ export type RemoteProof = {
   mTime: Time,
 }
 
+export type RevokeWarning = {
+  endangeredTLFs?: ?Array<TLF>,
+}
+
 export type RevokedKey = {
   key: PublicKey,
   time: KeybaseTime,
@@ -4564,6 +4580,12 @@ export type quotaVerifySessionRpcParam = Exact<{
   session: string
 }>
 
+export type rekeyGetRevokeWarningRpcParam = Exact<{
+  session: int,
+  actingDevice: DeviceID,
+  targetDevice: DeviceID
+}>
+
 export type rekeyRekeySyncRpcParam = Exact<{
   force: boolean
 }>
@@ -4951,6 +4973,8 @@ type quotaVerifySessionResult = VerifySessionRes
 
 type rekeyGetPendingRekeyStatusResult = ProblemSetDevices
 
+type rekeyGetRevokeWarningResult = RevokeWarning
+
 type rekeyRekeyStatusFinishResult = Outcome
 
 type rekeyUIDelegateRekeyUIResult = int
@@ -5144,6 +5168,7 @@ export type rpc =
   | quotaVerifySessionRpc
   | rekeyDebugShowRekeyStatusRpc
   | rekeyGetPendingRekeyStatusRpc
+  | rekeyGetRevokeWarningRpc
   | rekeyRekeyStatusFinishRpc
   | rekeyRekeySyncRpc
   | rekeyShowPendingRekeyStatusRpc

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4582,7 +4582,6 @@ export type quotaVerifySessionRpcParam = Exact<{
 
 export type rekeyGetRevokeWarningRpcParam = Exact<{
   session: int,
-  actingDevice: DeviceID,
   targetDevice: DeviceID
 }>
 

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4582,6 +4582,7 @@ export type quotaVerifySessionRpcParam = Exact<{
 
 export type rekeyGetRevokeWarningRpcParam = Exact<{
   session: int,
+  actingDevice: DeviceID,
   targetDevice: DeviceID
 }>
 

--- a/protocol/json/keybase1/rekey.json
+++ b/protocol/json/keybase1/rekey.json
@@ -184,6 +184,10 @@
           "type": "int"
         },
         {
+          "name": "actingDevice",
+          "type": "DeviceID"
+        },
+        {
           "name": "targetDevice",
           "type": "DeviceID"
         }

--- a/protocol/json/keybase1/rekey.json
+++ b/protocol/json/keybase1/rekey.json
@@ -184,10 +184,6 @@
           "type": "int"
         },
         {
-          "name": "actingDevice",
-          "type": "DeviceID"
-        },
-        {
           "name": "targetDevice",
           "type": "DeviceID"
         }

--- a/protocol/json/keybase1/rekey.json
+++ b/protocol/json/keybase1/rekey.json
@@ -107,6 +107,19 @@
         "FIXED_1",
         "IGNORED_2"
       ]
+    },
+    {
+      "type": "record",
+      "name": "RevokeWarning",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "TLF"
+          },
+          "name": "endangeredTLFs"
+        }
+      ]
     }
   ],
   "messages": {
@@ -163,6 +176,24 @@
       ],
       "response": null,
       "doc": "RekeySync flushes the current rekey loop and gets to a good stopping point\n   to assert state. Good for race-free testing, not very useful in production.\n   Force overrides a long-snooze."
+    },
+    "getRevokeWarning": {
+      "request": [
+        {
+          "name": "session",
+          "type": "int"
+        },
+        {
+          "name": "actingDevice",
+          "type": "DeviceID"
+        },
+        {
+          "name": "targetDevice",
+          "type": "DeviceID"
+        }
+      ],
+      "response": "RevokeWarning",
+      "doc": "GetRevokeWarning computes the TLFs that will be endangered if actingDevice\n   revokes targetDevice."
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1964,6 +1964,18 @@ export function rekeyGetPendingRekeyStatusRpcPromise (request: $Exact<requestCom
   return new Promise((resolve, reject) => { rekeyGetPendingRekeyStatusRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function rekeyGetRevokeWarningRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: rekeyGetRevokeWarningResult) => void} & {param: rekeyGetRevokeWarningRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'rekey.getRevokeWarning'})
+}
+
+export function rekeyGetRevokeWarningRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: rekeyGetRevokeWarningResult) => void} & {param: rekeyGetRevokeWarningRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => rekeyGetRevokeWarningRpc({...request, incomingCallMap, callback}))
+}
+
+export function rekeyGetRevokeWarningRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: rekeyGetRevokeWarningResult) => void} & {param: rekeyGetRevokeWarningRpcParam}>): Promise<rekeyGetRevokeWarningResult> {
+  return new Promise((resolve, reject) => { rekeyGetRevokeWarningRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function rekeyRekeyStatusFinishRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: rekeyRekeyStatusFinishResult) => void}>) {
   engineRpcOutgoing({...request, method: 'rekey.rekeyStatusFinish'})
 }
@@ -3439,6 +3451,10 @@ export type RemoteProof = {
   mTime: Time,
 }
 
+export type RevokeWarning = {
+  endangeredTLFs?: ?Array<TLF>,
+}
+
 export type RevokedKey = {
   key: PublicKey,
   time: KeybaseTime,
@@ -4564,6 +4580,12 @@ export type quotaVerifySessionRpcParam = Exact<{
   session: string
 }>
 
+export type rekeyGetRevokeWarningRpcParam = Exact<{
+  session: int,
+  actingDevice: DeviceID,
+  targetDevice: DeviceID
+}>
+
 export type rekeyRekeySyncRpcParam = Exact<{
   force: boolean
 }>
@@ -4951,6 +4973,8 @@ type quotaVerifySessionResult = VerifySessionRes
 
 type rekeyGetPendingRekeyStatusResult = ProblemSetDevices
 
+type rekeyGetRevokeWarningResult = RevokeWarning
+
 type rekeyRekeyStatusFinishResult = Outcome
 
 type rekeyUIDelegateRekeyUIResult = int
@@ -5144,6 +5168,7 @@ export type rpc =
   | quotaVerifySessionRpc
   | rekeyDebugShowRekeyStatusRpc
   | rekeyGetPendingRekeyStatusRpc
+  | rekeyGetRevokeWarningRpc
   | rekeyRekeyStatusFinishRpc
   | rekeyRekeySyncRpc
   | rekeyShowPendingRekeyStatusRpc

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4582,7 +4582,6 @@ export type quotaVerifySessionRpcParam = Exact<{
 
 export type rekeyGetRevokeWarningRpcParam = Exact<{
   session: int,
-  actingDevice: DeviceID,
   targetDevice: DeviceID
 }>
 

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4582,6 +4582,7 @@ export type quotaVerifySessionRpcParam = Exact<{
 
 export type rekeyGetRevokeWarningRpcParam = Exact<{
   session: int,
+  actingDevice: DeviceID,
   targetDevice: DeviceID
 }>
 


### PR DESCRIPTION
- expect testing framework for using multiple devices
- plumb RPCs through to the client and test for expected output