### PR TITLE
improve the "done function" so it is faster in typed case CORE-3950

### DIFF
--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -77,6 +77,7 @@ func decode(data []byte, res interface{}) error {
 	return err
 }
 
+// simpleResultCollector aggregates all results in a the basic way. It is not thread safe.
 type simpleResultCollector struct {
 	res    []chat1.MessageUnboxed
 	target int
@@ -104,9 +105,9 @@ func newSimpleResultCollector(num int) *simpleResultCollector {
 	}
 }
 
+// typedResultCollector aggregates results with a type contraints. It is not thread safe.
 type typedResultCollector struct {
 	res         []chat1.MessageUnboxed
-	typ         chat1.MessageType
 	target, cur int
 	typmap      map[chat1.MessageType]bool
 }


### PR DESCRIPTION
@songgao @mlsteele r?

Currently, the "done function" runs every time we add a message to the result list in local storage, which might be kind of slow for the "typed" version. This change makes it so that we do cheap operations all the time when checking to see if we have enough results.