### PR TITLE
record from PostLocal, and simplify MessageServerHeader CORE-3955

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -109,7 +109,7 @@ func (b *Boxer) UnboxMessage(ctx context.Context, finder *KeyFinder, boxed chat1
 	username, deviceName, err := b.getSenderInfoLocal(uimap, pt.ClientHeader)
 	if err != nil {
 		b.log().Warning("unable to fetch sender informaton: UID: %s deviceID: %s",
-			boxed.ServerHeader.Sender, boxed.ServerHeader.SenderDevice)
+			pt.ClientHeader.Sender, pt.ClientHeader.SenderDevice)
 	}
 
 	return chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{

--- a/go/chat/storage/storage_test.go
+++ b/go/chat/storage/storage_test.go
@@ -37,11 +37,11 @@ func randBytes(n int) []byte {
 func makeMsgWithType(id chat1.MessageID, supersedes chat1.MessageID, typ chat1.MessageType) chat1.MessageUnboxed {
 	msg := chat1.MessageUnboxedValid{
 		ServerHeader: chat1.MessageServerHeader{
-			MessageID:   id,
-			MessageType: typ,
+			MessageID: id,
 		},
 		ClientHeader: chat1.MessageClientHeader{
-			Supersedes: supersedes,
+			MessageType: typ,
+			Supersedes:  supersedes,
 		},
 	}
 	return chat1.NewMessageUnboxedWithValid(msg)

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -259,7 +259,7 @@ func (m *ChatRemoteMock) GetThreadRemote(ctx context.Context, arg chat1.GetThrea
 
 		}
 		res.Thread.Messages = append(res.Thread.Messages, *msg)
-		if mts != nil && mts[msg.ServerHeader.MessageType] {
+		if mts != nil && mts[msg.GetMessageType()] {
 			count++
 		} else if mts == nil {
 			count++
@@ -387,8 +387,8 @@ func (s msgByMessageIDDesc) Less(i, j int) bool {
 func (m *ChatRemoteMock) getMaxMsgs(convID chat1.ConversationID) (maxMsgs []chat1.MessageBoxed) {
 	finder := make(map[chat1.MessageType]*chat1.MessageBoxed)
 	for _, msg := range m.world.Msgs[convID] {
-		if existing, ok := finder[msg.ServerHeader.MessageType]; !ok || existing.ServerHeader.MessageID < msg.ServerHeader.MessageID {
-			finder[msg.ServerHeader.MessageType] = msg
+		if existing, ok := finder[msg.GetMessageType()]; !ok || existing.GetMessageID() < msg.GetMessageID() {
+			finder[msg.GetMessageType()] = msg
 		}
 	}
 
@@ -401,11 +401,8 @@ func (m *ChatRemoteMock) getMaxMsgs(convID chat1.ConversationID) (maxMsgs []chat
 
 func (m *ChatRemoteMock) insertMsgAndSort(convID chat1.ConversationID, msg chat1.MessageBoxed) (inserted chat1.MessageBoxed) {
 	msg.ServerHeader = &chat1.MessageServerHeader{
-		Ctime:        gregor1.ToTime(m.world.Fc.Now()),
-		MessageID:    chat1.MessageID(len(m.world.Msgs[convID]) + 1),
-		MessageType:  msg.ClientHeader.MessageType,
-		Sender:       msg.ClientHeader.Sender,
-		SenderDevice: msg.ClientHeader.SenderDevice,
+		Ctime:     gregor1.ToTime(m.world.Fc.Now()),
+		MessageID: chat1.MessageID(len(m.world.Msgs[convID]) + 1),
 	}
 	m.world.Msgs[convID] = append(m.world.Msgs[convID], &msg)
 	sort.Sort(msgByMessageIDDesc{world: m.world, convID: convID})

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -142,13 +142,9 @@ type Conversation struct {
 }
 
 type MessageServerHeader struct {
-	MessageType  MessageType      `codec:"messageType" json:"messageType"`
-	MessageID    MessageID        `codec:"messageID" json:"messageID"`
-	Sender       gregor1.UID      `codec:"sender" json:"sender"`
-	SenderDevice gregor1.DeviceID `codec:"senderDevice" json:"senderDevice"`
-	SupersededBy MessageID        `codec:"supersededBy" json:"supersededBy"`
-	Supersedes   MessageID        `codec:"supersedes" json:"supersedes"`
-	Ctime        gregor1.Time     `codec:"ctime" json:"ctime"`
+	MessageID    MessageID    `codec:"messageID" json:"messageID"`
+	SupersededBy MessageID    `codec:"supersededBy" json:"supersededBy"`
+	Ctime        gregor1.Time `codec:"ctime" json:"ctime"`
 }
 
 type MessagePreviousPointer struct {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -119,7 +119,7 @@ func (m MessageUnboxed) GetMessageID() MessageID {
 func (m MessageUnboxed) GetMessageType() MessageType {
 	if state, err := m.State(); err == nil {
 		if state == MessageUnboxedState_VALID {
-			return m.Valid().ServerHeader.MessageType
+			return m.Valid().ClientHeader.MessageType
 		}
 		if state == MessageUnboxedState_ERROR {
 			return m.Error().MessageType

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -42,8 +42,8 @@ type GetConversationMetadataRemoteRes struct {
 }
 
 type PostRemoteRes struct {
-	MsgID     MessageID  `codec:"msgID" json:"msgID"`
-	RateLimit *RateLimit `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	MsgHeader MessageServerHeader `codec:"msgHeader" json:"msgHeader"`
+	RateLimit *RateLimit          `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
 type NewConversationRemoteRes struct {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -866,7 +866,7 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 			return err
 		}
 		g.G().Log.Debug("push handler: chat activity: newMessage: convID: %d sender: %s",
-			nm.ConvID, nm.Message.ServerHeader.Sender)
+			nm.ConvID, nm.Message.ClientHeader.Sender)
 		uid := m.UID().Bytes()
 		decmsg, err := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
 		if err != nil {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -88,12 +88,8 @@ protocol common {
   }
 
   record MessageServerHeader {
-    MessageType messageType;
     MessageID messageID;
-    gregor1.UID sender;
-    gregor1.DeviceID senderDevice;
     MessageID supersededBy;
-    MessageID supersedes; // not populated
     gregor1.Time ctime;
   }
 

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -42,7 +42,7 @@ protocol remote {
   }
 
   record PostRemoteRes {
-    MessageID msgID;
+    MessageServerHeader msgHeader;
     union { null, RateLimit } rateLimit;
   }
 

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -567,12 +567,8 @@ export type MessagePreviousPointer = {
 }
 
 export type MessageServerHeader = {
-  messageType: MessageType,
   messageID: MessageID,
-  sender: gregor1.UID,
-  senderDevice: gregor1.DeviceID,
   supersededBy: MessageID,
-  supersedes: MessageID,
   ctime: gregor1.Time,
 }
 
@@ -646,7 +642,7 @@ export type PostLocalRes = {
 }
 
 export type PostRemoteRes = {
-  msgID: MessageID,
+  msgHeader: MessageServerHeader,
   rateLimit?: ?RateLimit,
 }
 

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -280,28 +280,12 @@
       "name": "MessageServerHeader",
       "fields": [
         {
-          "type": "MessageType",
-          "name": "messageType"
-        },
-        {
           "type": "MessageID",
           "name": "messageID"
         },
         {
-          "type": "gregor1.UID",
-          "name": "sender"
-        },
-        {
-          "type": "gregor1.DeviceID",
-          "name": "senderDevice"
-        },
-        {
           "type": "MessageID",
           "name": "supersededBy"
-        },
-        {
-          "type": "MessageID",
-          "name": "supersedes"
         },
         {
           "type": "gregor1.Time",

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -127,8 +127,8 @@
       "name": "PostRemoteRes",
       "fields": [
         {
-          "type": "MessageID",
-          "name": "msgID"
+          "type": "MessageServerHeader",
+          "name": "msgHeader"
         },
         {
           "type": [

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -567,12 +567,8 @@ export type MessagePreviousPointer = {
 }
 
 export type MessageServerHeader = {
-  messageType: MessageType,
   messageID: MessageID,
-  sender: gregor1.UID,
-  senderDevice: gregor1.DeviceID,
   supersededBy: MessageID,
-  supersedes: MessageID,
   ctime: gregor1.Time,
 }
 
@@ -646,7 +642,7 @@ export type PostLocalRes = {
 }
 
 export type PostRemoteRes = {
-  msgID: MessageID,
+  msgHeader: MessageServerHeader,
   rateLimit?: ?RateLimit,
 }
 


### PR DESCRIPTION
@patrickxb @maxtaco r?

This records the message sent from `PostLocal` directly into the local storage, and also removes a bunch of repeated fields off of `MessageServerHeader` and reduces it down to just the bits of information we are trusting from the server (ID, ctime, supersededBy).