### PR TITLE
Change error handling for unboxing wrt cache

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -81,13 +81,13 @@ func (b *Boxer) makeErrorMessage(msg chat1.MessageBoxed, err error) chat1.Messag
 // Returns (_, err) for non-permanent errors, and (MessageUnboxedError, nil) for permanent errors.
 // Permanent errors can be cached and must be treated as a value to deal with.
 // Whereas temporary errors are transient failures.
-func (b *Boxer) UnboxMessage(ctx context.Context, finder KeyFinder, boxed chat1.MessageBoxed) (res chat1.MessageUnboxed, err error) {
+func (b *Boxer) UnboxMessage(ctx context.Context, finder KeyFinder, boxed chat1.MessageBoxed) (chat1.MessageUnboxed, libkb.ChatUnboxingError) {
 	tlfName := boxed.ClientHeader.TlfName
 	tlfPublic := boxed.ClientHeader.TlfPublic
 	keys, err := finder.Find(ctx, b.tlf, tlfName, tlfPublic)
 	if err != nil {
 		// transient error
-		return chat1.MessageUnboxed{}, libkb.NewChatUnboxingError(err.Error())
+		return chat1.MessageUnboxed{}, libkb.NewTransientChatUnboxingError(err)
 	}
 
 	var matchKey *keybase1.CryptKey
@@ -100,16 +100,17 @@ func (b *Boxer) UnboxMessage(ctx context.Context, finder KeyFinder, boxed chat1.
 
 	if matchKey == nil {
 		err := fmt.Errorf("no key found for generation %d", boxed.KeyGeneration)
-		// transient error
-		return chat1.MessageUnboxed{}, libkb.NewChatUnboxingError(err.Error())
+		return chat1.MessageUnboxed{}, libkb.NewTransientChatUnboxingError(err)
 	}
 
-	pt, headerHash, err := b.unboxMessageWithKey(ctx, boxed, matchKey)
-	if err != nil {
+	pt, headerHash, ierr := b.unboxMessageWithKey(ctx, boxed, matchKey)
+	if ierr != nil {
 		b.log().Warning("failed to unbox message: msgID: %d err: %s", boxed.ServerHeader.MessageID,
-			err.Error())
-		// permanent error
-		return b.makeErrorMessage(boxed, err), nil
+			ierr.Error())
+		if ierr.IsPermanent() {
+			return b.makeErrorMessage(boxed, ierr.Inner()), nil
+		}
+		return chat1.MessageUnboxed{}, ierr
 	}
 
 	_, uimap := utils.GetUserInfoMapper(ctx, b.kbCtx)
@@ -133,11 +134,11 @@ func (b *Boxer) UnboxMessage(ctx context.Context, finder KeyFinder, boxed chat1.
 
 // unboxMessageWithKey unboxes a chat1.MessageBoxed into a keybase1.Message given
 // a keybase1.CryptKey.
-func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed, key *keybase1.CryptKey) (chat1.MessagePlaintext, chat1.Hash, error) {
+func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed, key *keybase1.CryptKey) (chat1.MessagePlaintext, chat1.Hash, libkb.ChatUnboxingError) {
 
 	var err error
 	if msg.ServerHeader == nil {
-		return chat1.MessagePlaintext{}, nil, errors.New("nil ServerHeader in MessageBoxed")
+		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(errors.New("nil ServerHeader in MessageBoxed"))
 	}
 
 	// compute the header hash
@@ -148,39 +149,39 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 	skipBodyVerification := false
 	if len(msg.BodyCiphertext.E) == 0 {
 		if msg.ServerHeader.SupersededBy == 0 {
-			return chat1.MessagePlaintext{}, nil, errors.New("empty body and not superseded in MessageBoxed")
+			return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(errors.New("empty body and not superseded in MessageBoxed"))
 		}
 		skipBodyVerification = true
 	} else {
 		packedBody, err := b.open(msg.BodyCiphertext, key)
 		if err != nil {
-			return chat1.MessagePlaintext{}, nil, err
+			return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(err)
 		}
 		if err := b.unmarshal(packedBody, &body); err != nil {
-			return chat1.MessagePlaintext{}, nil, err
+			return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(err)
 		}
 	}
 
 	// decrypt header
 	packedHeader, err := b.open(msg.HeaderCiphertext, key)
 	if err != nil {
-		return chat1.MessagePlaintext{}, nil, err
+		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(err)
 	}
 	var header chat1.HeaderPlaintext
 	if err := b.unmarshal(packedHeader, &header); err != nil {
-		return chat1.MessagePlaintext{}, nil, err
+		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(err)
 	}
 
 	// verify the message
-	if err := b.verifyMessage(ctx, header, msg, skipBodyVerification); err != nil {
-		return chat1.MessagePlaintext{}, nil, err
+	if ierr := b.verifyMessage(ctx, header, msg, skipBodyVerification); ierr != nil {
+		return chat1.MessagePlaintext{}, nil, ierr
 	}
 
 	// create a chat1.MessageClientHeader from versioned HeaderPlaintext
 	var clientHeader chat1.MessageClientHeader
 	headerVersion, err := header.Version()
 	if err != nil {
-		return chat1.MessagePlaintext{}, nil, err
+		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(err)
 	}
 	switch headerVersion {
 	case chat1.HeaderPlaintextVersion_V1:
@@ -195,7 +196,7 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 			SenderDevice: hp.SenderDevice,
 		}
 	default:
-		return chat1.MessagePlaintext{}, nil, libkb.NewChatHeaderVersionError(headerVersion)
+		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(libkb.NewChatHeaderVersionError(headerVersion))
 	}
 
 	if skipBodyVerification {
@@ -204,14 +205,14 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 		case chat1.HeaderPlaintextVersion_V1:
 			return chat1.MessagePlaintext{ClientHeader: clientHeader}, headerHash, nil
 		default:
-			return chat1.MessagePlaintext{}, nil, libkb.NewChatHeaderVersionError(headerVersion)
+			return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(libkb.NewChatHeaderVersionError(headerVersion))
 		}
 	}
 
 	// create an unboxed message from versioned BodyPlaintext and clientHeader
 	bodyVersion, err := body.Version()
 	if err != nil {
-		return chat1.MessagePlaintext{}, nil, err
+		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(err)
 	}
 	switch bodyVersion {
 	case chat1.BodyPlaintextVersion_V1:
@@ -220,7 +221,7 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 			MessageBody:  body.V1().MessageBody,
 		}, headerHash, nil
 	default:
-		return chat1.MessagePlaintext{}, nil, libkb.NewChatBodyVersionError(bodyVersion)
+		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(libkb.NewChatBodyVersionError(bodyVersion))
 	}
 }
 
@@ -448,27 +449,27 @@ func sign(msg []byte, kp libkb.NaclSigningKeyPair, prefix libkb.SignaturePrefix)
 }
 
 // verifyMessage checks that a message is valid.
-func (b *Boxer) verifyMessage(ctx context.Context, header chat1.HeaderPlaintext, msg chat1.MessageBoxed, skipBodyVerification bool) error {
+func (b *Boxer) verifyMessage(ctx context.Context, header chat1.HeaderPlaintext, msg chat1.MessageBoxed, skipBodyVerification bool) libkb.ChatUnboxingError {
 	headerVersion, err := header.Version()
 	if err != nil {
-		return err
+		return libkb.NewPermanentChatUnboxingError(err)
 	}
 
 	switch headerVersion {
 	case chat1.HeaderPlaintextVersion_V1:
 		return b.verifyMessageHeaderV1(ctx, header.V1(), msg, skipBodyVerification)
 	default:
-		return libkb.NewChatHeaderVersionError(headerVersion)
+		return libkb.NewPermanentChatUnboxingError(libkb.NewChatHeaderVersionError(headerVersion))
 	}
 }
 
 // verifyMessageHeaderV1 checks the body hash, header signature, and signing key validity.
-func (b *Boxer) verifyMessageHeaderV1(ctx context.Context, header chat1.HeaderPlaintextV1, msg chat1.MessageBoxed, skipBodyVerification bool) error {
+func (b *Boxer) verifyMessageHeaderV1(ctx context.Context, header chat1.HeaderPlaintextV1, msg chat1.MessageBoxed, skipBodyVerification bool) libkb.ChatUnboxingError {
 	if !skipBodyVerification {
 		// check body hash
 		bh := b.hashV1(msg.BodyCiphertext.E)
 		if !libkb.SecureByteArrayEq(bh[:], header.BodyHash) {
-			return libkb.ChatBodyHashInvalid{}
+			return libkb.NewPermanentChatUnboxingError(libkb.ChatBodyHashInvalid{})
 		}
 	}
 
@@ -477,19 +478,19 @@ func (b *Boxer) verifyMessageHeaderV1(ctx context.Context, header chat1.HeaderPl
 	hcopy.HeaderSignature = nil
 	hpack, err := b.marshal(hcopy)
 	if err != nil {
-		return err
+		return libkb.NewPermanentChatUnboxingError(err)
 	}
 	if !b.verify(hpack, *header.HeaderSignature, libkb.SignaturePrefixChat) {
-		return libkb.BadSigError{E: "header signature invalid"}
+		return libkb.NewPermanentChatUnboxingError(libkb.BadSigError{E: "header signature invalid"})
 	}
 
 	// check key validity
-	valid, err := b.validSenderKey(ctx, header.Sender, header.HeaderSignature.K, msg.ServerHeader.Ctime)
-	if err != nil {
-		return err
+	valid, ierr := b.validSenderKey(ctx, header.Sender, header.HeaderSignature.K, msg.ServerHeader.Ctime)
+	if ierr != nil {
+		return ierr
 	}
 	if !valid {
-		return errors.New("key invalid for sender at message ctime")
+		return libkb.NewPermanentChatUnboxingError(errors.New("key invalid for sender at message ctime"))
 	}
 
 	return nil
@@ -510,10 +511,10 @@ func (b *Boxer) verify(data []byte, si chat1.SignatureInfo, prefix libkb.Signatu
 }
 
 // validSenderKey checks that the key is active for sender at ctime.
-func (b *Boxer) validSenderKey(ctx context.Context, sender gregor1.UID, key []byte, ctime gregor1.Time) (bool, error) {
+func (b *Boxer) validSenderKey(ctx context.Context, sender gregor1.UID, key []byte, ctime gregor1.Time) (bool, libkb.ChatUnboxingError) {
 	kbSender, err := keybase1.UIDFromString(hex.EncodeToString(sender.Bytes()))
 	if err != nil {
-		return false, err
+		return false, libkb.NewPermanentChatUnboxingError(err)
 	}
 	kid := keybase1.KIDFromSlice(key)
 	t := gregor1.FromTime(ctime)
@@ -522,15 +523,15 @@ func (b *Boxer) validSenderKey(ctx context.Context, sender gregor1.UID, key []by
 	ctx, uimap = utils.GetUserInfoMapper(ctx, b.kbCtx)
 	user, err := uimap.User(kbSender)
 	if err != nil {
-		return false, err
+		return false, libkb.NewTransientChatUnboxingError(err)
 	}
 	ckf := user.GetComputedKeyFamily()
 	if ckf == nil {
-		return false, errors.New("no computed key family")
+		return false, libkb.NewPermanentChatUnboxingError(errors.New("no computed key family"))
 	}
 	activeKey, _, err := ckf.FindActiveSibkeyAtTime(kid, t)
 	if err != nil {
-		return false, err
+		return false, libkb.NewPermanentChatUnboxingError(err)
 	}
 	if activeKey == nil {
 		return false, nil

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -5,6 +5,7 @@ package chat
 
 import (
 	"crypto/sha256"
+	"strings"
 	"testing"
 	"time"
 
@@ -163,9 +164,9 @@ func TestChatMessageInvalidBodyHash(t *testing.T) {
 	// put original hash fn back
 	boxer.hashV1 = origHashFn
 
-	_, _, err = boxer.unboxMessageWithKey(context.TODO(), *boxed, key)
-	if _, ok := err.(libkb.ChatBodyHashInvalid); !ok {
-		t.Fatalf("unexpected error for invalid body hash: %s", err)
+	_, _, ierr := boxer.unboxMessageWithKey(context.TODO(), *boxed, key)
+	if _, ok := ierr.Inner().(libkb.ChatBodyHashInvalid); !ok {
+		t.Fatalf("unexpected error for invalid body hash: %s", ierr)
 	}
 }
 
@@ -258,9 +259,9 @@ func TestChatMessageUnboxNoCryptKey(t *testing.T) {
 	}
 
 	// This should produce a non-permanent error. So err will be set.
-	decmsg, err := boxer.UnboxMessage(ctx, NewKeyFinderMock(), *boxed)
-	if _, ok := err.(libkb.ChatUnboxingError); !ok {
-		t.Fatal(err)
+	decmsg, ierr := boxer.UnboxMessage(ctx, NewKeyFinderMock(), *boxed)
+	if !strings.Contains(ierr.Error(), "no key found") {
+		t.Fatalf("error should contain 'no key found': %v", ierr)
 	}
 	if decmsg.IsValid() {
 		t.Fatalf("message should not be unboxable")
@@ -310,9 +311,9 @@ func TestChatMessageInvalidHeaderSig(t *testing.T) {
 	// put original signing fn back
 	boxer.sign = origSign
 
-	_, _, err = boxer.unboxMessageWithKey(context.TODO(), *boxed, key)
-	if _, ok := err.(libkb.BadSigError); !ok {
-		t.Fatalf("unexpected error for invalid header signature: %s", err)
+	_, _, ierr := boxer.unboxMessageWithKey(context.TODO(), *boxed, key)
+	if _, ok := ierr.Inner().(libkb.BadSigError); !ok {
+		t.Fatalf("unexpected error for invalid header signature: %s", ierr)
 	}
 }
 
@@ -344,9 +345,9 @@ func TestChatMessageInvalidSenderKey(t *testing.T) {
 		Ctime: gregor1.ToTime(time.Now()),
 	}
 
-	_, _, err = boxer.unboxMessageWithKey(context.TODO(), *boxed, key)
-	if _, ok := err.(libkb.NoKeyError); !ok {
-		t.Fatalf("unexpected error for invalid sender key: %v", err)
+	_, _, ierr := boxer.unboxMessageWithKey(context.TODO(), *boxed, key)
+	if _, ok := ierr.Inner().(libkb.NoKeyError); !ok {
+		t.Fatalf("unexpected error for invalid sender key: %v", ierr)
 	}
 }
 

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -75,6 +75,7 @@ func NewHybridConversationSource(g *libkb.GlobalContext, b *Boxer, storage *stor
 
 func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.ConversationID,
 	uid gregor1.UID, msg chat1.MessageBoxed) (chat1.MessageUnboxed, error) {
+	var err error
 
 	decmsg, err := s.boxer.UnboxMessage(ctx, NewKeyFinder(), msg)
 	if err != nil {

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -11,22 +11,26 @@ import (
 // It is not intended to be used by multiple concurrent goroutines
 // or held onto for very long, just to remember the keys while
 // unboxing a thread of messages.
-type KeyFinder struct {
+type KeyFinder interface {
+	Find(ctx context.Context, tlf keybase1.TlfInterface, tlfName string, tlfPublic bool) (keybase1.GetTLFCryptKeysRes, error)
+}
+
+type KeyFinderImpl struct {
 	keys map[string]keybase1.GetTLFCryptKeysRes
 }
 
 // newKeyFinder creates a keyFinder.
-func NewKeyFinder() *KeyFinder {
-	return &KeyFinder{keys: make(map[string]keybase1.GetTLFCryptKeysRes)}
+func NewKeyFinder() KeyFinder {
+	return &KeyFinderImpl{keys: make(map[string]keybase1.GetTLFCryptKeysRes)}
 }
 
-func (k *KeyFinder) cacheKey(tlfName string, tlfPublic bool) string {
+func (k *KeyFinderImpl) cacheKey(tlfName string, tlfPublic bool) string {
 	return fmt.Sprintf("%s|%v", tlfName, tlfPublic)
 }
 
 // find finds keybase1.TLFCryptKeys for tlfName, checking for existing
 // results.
-func (k *KeyFinder) Find(ctx context.Context, tlf keybase1.TlfInterface, tlfName string, tlfPublic bool) (keybase1.GetTLFCryptKeysRes, error) {
+func (k *KeyFinderImpl) Find(ctx context.Context, tlf keybase1.TlfInterface, tlfName string, tlfPublic bool) (keybase1.GetTLFCryptKeysRes, error) {
 	ckey := k.cacheKey(tlfName, tlfPublic)
 	existing, ok := k.keys[ckey]
 	if ok {

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1535,13 +1535,28 @@ func (e ChatBoxingError) Error() string {
 
 //=============================================================================
 
-type ChatUnboxingError struct {
-	Msg string
+type ChatUnboxingError interface {
+	Error() string
+	IsChatUnboxingError()
 }
 
-func (e ChatUnboxingError) Error() string {
-	return fmt.Sprintf("error unboxing chat message: %s", e.Msg)
+var _ error = (ChatUnboxingError)(nil)
+
+func NewChatUnboxingError(msg string) ChatUnboxingError {
+	return &ChatUnboxingErrorImpl{
+		msg: msg,
+	}
 }
+
+type ChatUnboxingErrorImpl struct {
+	msg string
+}
+
+func (e ChatUnboxingErrorImpl) Error() string {
+	return fmt.Sprintf("error unboxing chat message: %s", e.msg)
+}
+
+func (e ChatUnboxingErrorImpl) IsChatUnboxingError() {}
 
 //=============================================================================
 

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1537,26 +1537,39 @@ func (e ChatBoxingError) Error() string {
 
 type ChatUnboxingError interface {
 	Error() string
-	IsChatUnboxingError()
+	Inner() error
+	IsPermanent() bool
 }
 
 var _ error = (ChatUnboxingError)(nil)
 
-func NewChatUnboxingError(msg string) ChatUnboxingError {
-	return &ChatUnboxingErrorImpl{
-		msg: msg,
-	}
+func NewPermanentChatUnboxingError(inner error) ChatUnboxingError {
+	return &PermanentChatUnboxingError{inner}
 }
 
-type ChatUnboxingErrorImpl struct {
-	msg string
+type PermanentChatUnboxingError struct{ inner error }
+
+func (e PermanentChatUnboxingError) Error() string {
+	return fmt.Sprintf("error unboxing chat message: %s", e.inner.Error())
 }
 
-func (e ChatUnboxingErrorImpl) Error() string {
-	return fmt.Sprintf("error unboxing chat message: %s", e.msg)
+func (e PermanentChatUnboxingError) IsPermanent() bool { return true }
+
+func (e PermanentChatUnboxingError) Inner() error { return e.inner }
+
+func NewTransientChatUnboxingError(inner error) ChatUnboxingError {
+	return &TransientChatUnboxingError{inner}
 }
 
-func (e ChatUnboxingErrorImpl) IsChatUnboxingError() {}
+type TransientChatUnboxingError struct{ inner error }
+
+func (e TransientChatUnboxingError) Error() string {
+	return fmt.Sprintf("error unboxing chat message: %s", e.inner.Error())
+}
+
+func (e TransientChatUnboxingError) IsPermanent() bool { return false }
+
+func (e TransientChatUnboxingError) Inner() error { return e.inner }
 
 //=============================================================================
 


### PR DESCRIPTION
Now `UnboxMessage` can return 3 states:
1. success: `(MessageUnboxedValid, nil)`
2. permanent failure: `(MessageUnboxedError, nil)`. These get cached as values. For example, invalid header hash.
3. transient failure: `(_, error)`. These are real go errors, and do not get cached. For example, finding tlf crypt keys fails.

`UnboxMessages` fails if any of its `UnboxMessage` calls yield a transient failure.

r? @mmaxim 