### PR TITLE
Fix bug in Kex2 Provisioner that mistook an LKSecFullSecret for an LKSecClientHalf

### DIFF
--- a/go/bind/keystore_android.go
+++ b/go/bind/keystore_android.go
@@ -5,7 +5,7 @@
 
 package keybase
 
-import "github.com/keybase/client/go/libkb"
+// import "github.com/keybase/client/go/libkb"
 
 // ExternalKeyStore - We have to duplicate the interface defined in libkb.ExternalKeyStore
 // Otherwise we get an undefined param error when we use this as an argument

--- a/go/bind/keystore_android.go
+++ b/go/bind/keystore_android.go
@@ -11,8 +11,8 @@ import "github.com/keybase/client/go/libkb"
 // Otherwise we get an undefined param error when we use this as an argument
 // in an exported func
 type ExternalKeyStore interface {
-	RetrieveSecret(serviceName string, key string) ([]byte, error)
-	StoreSecret(serviceName string, key string, secret []byte) error
+	RetrieveSecret(serviceName string, key string) (libkb.LKSecFullSecret, error)
+	StoreSecret(serviceName string, key string, libkb.LKSecFullSecret) error
 	ClearSecret(serviceName string, key string) error
 	GetUsersWithStoredSecretsMsgPack(serviceName string) ([]byte, error)
 	SetupKeyStore(serviceName string, key string) error

--- a/go/bind/keystore_android.go
+++ b/go/bind/keystore_android.go
@@ -20,5 +20,10 @@ type ExternalKeyStore interface {
 
 func SetGlobalExternalKeyStore(s ExternalKeyStore) {
 	// TODO: Gross! can we fix this?
-	libkb.SetGlobalExternalKeyStore(libkb.ExternalKeyStore(s))
+	//
+	// Commented out by MNK on 10/19/2016 -- I don't know how to get
+	// Android to start compiling without a fair amount of work here,
+	// so let's comment it out for now.
+	//
+	// libkb.SetGlobalExternalKeyStore(libkb.ExternalKeyStore(s))
 }

--- a/go/bind/keystore_android.go
+++ b/go/bind/keystore_android.go
@@ -12,7 +12,7 @@ import "github.com/keybase/client/go/libkb"
 // in an exported func
 type ExternalKeyStore interface {
 	RetrieveSecret(serviceName string, key string) (libkb.LKSecFullSecret, error)
-	StoreSecret(serviceName string, key string, libkb.LKSecFullSecret) error
+	StoreSecret(serviceName string, key string, secret libkb.LKSecFullSecret) error
 	ClearSecret(serviceName string, key string) error
 	GetUsersWithStoredSecretsMsgPack(serviceName string) ([]byte, error)
 	SetupKeyStore(serviceName string, key string) error

--- a/go/bind/keystore_android.go
+++ b/go/bind/keystore_android.go
@@ -11,8 +11,8 @@ import "github.com/keybase/client/go/libkb"
 // Otherwise we get an undefined param error when we use this as an argument
 // in an exported func
 type ExternalKeyStore interface {
-	RetrieveSecret(serviceName string, key string) (libkb.LKSecFullSecret, error)
-	StoreSecret(serviceName string, key string, secret libkb.LKSecFullSecret) error
+	RetrieveSecret(serviceName string, key string) ([]byte, error)
+	StoreSecret(serviceName string, key string, secret []byte) error
 	ClearSecret(serviceName string, key string) error
 	GetUsersWithStoredSecretsMsgPack(serviceName string) ([]byte, error)
 	SetupKeyStore(serviceName string, key string) error

--- a/go/engine/device_add.go
+++ b/go/engine/device_add.go
@@ -67,7 +67,7 @@ func (e *DeviceAdd) Run(ctx *Context) (err error) {
 	// provisioner needs ppstream, and UI is confusing when it asks for
 	// it at the same time as asking for the secret, so get it first
 	// before prompting for the kex2 secret:
-	pps, err := e.G().LoginState().GetPassphraseStream(ctx.SecretUI)
+	pps, err := e.G().LoginState().GetPassphraseStreamStored(ctx.SecretUI)
 	if err != nil {
 		return err
 	}

--- a/go/engine/device_keygen.go
+++ b/go/engine/device_keygen.go
@@ -260,7 +260,7 @@ func (e *DeviceKeygen) pushLKS(ctx *Context) {
 	}
 
 	serverHalf := e.args.Lks.GetServerHalf()
-	if len(serverHalf) == 0 {
+	if serverHalf.IsNil() {
 		e.pushErr = fmt.Errorf("LKS server half is empty, and should not be")
 		return
 	}

--- a/go/engine/kex2_provisioner.go
+++ b/go/engine/kex2_provisioner.go
@@ -92,10 +92,10 @@ func (e *Kex2Provisioner) Run(ctx *Context) error {
 	if e.pps.PassphraseStream == nil {
 		e.G().Log.Debug("kex2 provisioner needs passphrase stream, getting it from LoginState")
 		pps, err := e.G().LoginState().GetPassphraseStreamStored(ctx.SecretUI)
-		e.pps = pps.Export()
 		if err != nil {
 			return err
 		}
+		e.pps = pps.Export()
 	}
 
 	// ctx needed by some kex2 functions

--- a/go/engine/kex2_provisioner.go
+++ b/go/engine/kex2_provisioner.go
@@ -91,7 +91,8 @@ func (e *Kex2Provisioner) Run(ctx *Context) error {
 	// get current passphrase stream if necessary:
 	if e.pps.PassphraseStream == nil {
 		e.G().Log.Debug("kex2 provisioner needs passphrase stream, getting it from LoginState")
-		e.pps, err = e.G().LoginState().GetPassphraseStreamExport(ctx.SecretUI)
+		pps, err := e.G().LoginState().GetPassphraseStreamStored(ctx.SecretUI)
+		e.pps = pps.Export()
 		if err != nil {
 			return err
 		}

--- a/go/engine/login_state_test.go
+++ b/go/engine/login_state_test.go
@@ -275,7 +275,7 @@ func userHasStoredSecretViaSecretStore(tc *libkb.TestContext, username string) b
 	secret, err := tc.G.SecretStoreAll.RetrieveSecret(libkb.NewNormalizedUsername(username))
 	// TODO: Have RetrieveSecret return platform-independent errors
 	// so that we can make sure we got the right one.
-	return (len(secret) > 0 && err == nil)
+	return (!secret.IsNil() && err == nil)
 }
 
 func userHasStoredSecret(tc *libkb.TestContext, username string) bool {

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -190,7 +190,7 @@ func TestLocalKeySecurityStoreSecret(t *testing.T) {
 		t.Error(err)
 	}
 
-	if string(secret) != string(storedSecret) {
+	if !secret.Equal(storedSecret) {
 		t.Errorf("Expected %v, got %v", secret, storedSecret)
 	}
 

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -284,19 +284,18 @@ func (s *LoginState) GetPassphraseStreamWithPassphrase(passphrase string) (pps *
 }
 
 func (s *LoginState) getStoredPassphraseStream(username NormalizedUsername) (*PassphraseStream, error) {
-	secret, err := s.G().SecretStoreAll.RetrieveSecret(s.G().Env.GetUsername())
+	fullSecret, err := s.G().SecretStoreAll.RetrieveSecret(s.G().Env.GetUsername())
 	if err != nil {
 		return nil, err
 	}
-	lks := NewLKSecWithFullSecret(secret, s.G().Env.GetUID(), s.G())
+	lks := NewLKSecWithFullSecret(fullSecret, s.G().Env.GetUID(), s.G())
 	if err = lks.LoadServerHalf(nil); err != nil {
 		return nil, err
 	}
-	stream, err := NewPassphraseStreamLKSecOnly(secret)
+	stream, err := NewPassphraseStreamLKSecOnly(lks)
 	if err != nil {
 		return nil, err
 	}
-	stream.SetGeneration(lks.Generation())
 	return stream, nil
 }
 

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -283,11 +283,29 @@ func (s *LoginState) GetPassphraseStreamWithPassphrase(passphrase string) (pps *
 	return nil, err
 }
 
-// GetPassphraseStreamExport either returns a cached, verified passphrase stream
-// export, or generates a new one via login.
-func (s *LoginState) GetPassphraseStreamExport(ui SecretUI) (pps keybase1.PassphraseStream, err error) {
-	s.G().Log.Debug("+ GetPassphraseStreamExport() called")
-	defer func() { s.G().Log.Debug("- GetPassphraseStreamExport() -> %s", ErrToOk(err)) }()
+func (s *LoginState) getStoredPassphraseStream(username NormalizedUsername) (*PassphraseStream, error) {
+	secret, err := s.G().SecretStoreAll.RetrieveSecret(s.G().Env.GetUsername())
+	if err != nil {
+		return nil, err
+	}
+	lks := NewLKSecWithFullSecret(secret, s.G().Env.GetUID(), s.G())
+	if err = lks.LoadServerHalf(nil); err != nil {
+		return nil, err
+	}
+	stream, err := NewPassphraseStreamLKSecOnly(secret)
+	if err != nil {
+		return nil, err
+	}
+	stream.SetGeneration(lks.Generation())
+	return stream, nil
+}
+
+// GetPassphraseStreamStored either returns a cached, verified passphrase
+// stream from a previous login, the secret store, or generates a new one via
+// login.
+func (s *LoginState) GetPassphraseStreamStored(ui SecretUI) (pps *PassphraseStream, err error) {
+	s.G().Log.Debug("+ GetPassphraseStreamStored() called")
+	defer func() { s.G().Log.Debug("- GetPassphraseStreamStored() -> %s", ErrToOk(err)) }()
 
 	// 1. try cached
 	s.G().Log.Debug("| trying cached passphrase stream")
@@ -297,28 +315,20 @@ func (s *LoginState) GetPassphraseStreamExport(ui SecretUI) (pps keybase1.Passph
 	}
 	if full != nil {
 		s.G().Log.Debug("| cached passphrase stream ok, using it")
-		return full.Export(), nil
+		return full, nil
 	}
 
 	// 2. try from secret store
 	if s.G().SecretStoreAll != nil {
 		s.G().Log.Debug("| trying to get passphrase stream from secret store")
-		secret, err := s.G().SecretStoreAll.RetrieveSecret(s.G().Env.GetUsername())
-		if err != nil {
-			return pps, err
+		pps, err = s.getStoredPassphraseStream(s.G().Env.GetUsername())
+		if err == nil {
+			s.G().Log.Debug("| got passphrase stream from secret store")
+			return pps, nil
 		}
-		lks := NewLKSecWithFullSecret(secret, s.G().Env.GetUID(), s.G())
-		if err = lks.LoadServerHalf(nil); err != nil {
-			return pps, err
-		}
-		stream, err := NewPassphraseStreamLKSecOnly(secret)
-		if err != nil {
-			return pps, err
-		}
-		stream.SetGeneration(lks.Generation())
-		return stream.Export(), nil
+
+		s.G().Log.Debug("| failed to get passphrase stream from secret store: %s", err)
 	}
-	s.G().Log.Debug("| no secret store available")
 
 	// 3. login and get it
 	s.G().Log.Debug("| using full GetPassphraseStream")
@@ -328,7 +338,7 @@ func (s *LoginState) GetPassphraseStreamExport(ui SecretUI) (pps keybase1.Passph
 	}
 	if full != nil {
 		s.G().Log.Debug("| success using full GetPassphraseStream")
-		return full.Export(), nil
+		return full, nil
 	}
 	return pps, nil
 }

--- a/go/libkb/passphrase_stream.go
+++ b/go/libkb/passphrase_stream.go
@@ -48,7 +48,7 @@ const (
 	dhIndex    = eddsaIndex + eddsaLen
 	dhLen      = 32
 	lksIndex   = dhIndex + dhLen
-	lksLen     = 32
+	lksLen     = LKSecLen // == 32
 	extraLen   = pwhLen + eddsaLen + dhLen + lksLen
 )
 
@@ -68,15 +68,17 @@ func NewPassphraseStream(s []byte) *PassphraseStream {
 // (stream[lksIndex:]).  The rest of the stream is zeros.
 // This is used to create a passphrase stream from the information in the
 // secret store, which only contains the lksec portion of the stream.
-func NewPassphraseStreamLKSecOnly(s []byte) (*PassphraseStream, error) {
-	if len(s) != lksLen {
-		return nil, fmt.Errorf("invalid lksec stream length %d (expected %d)", len(s), lksLen)
+func NewPassphraseStreamLKSecOnly(s *LKSec) (*PassphraseStream, error) {
+
+	clientHalf, err := s.ComputeClientHalf()
+	if err != nil {
+		return nil, err
 	}
 	stream := make([]byte, extraLen)
-	copy(stream[lksIndex:], s)
+	copy(stream[lksIndex:], clientHalf.Bytes())
 	ps := &PassphraseStream{
 		stream: stream,
-		gen:    PassphraseGeneration(0),
+		gen:    s.Generation(),
 	}
 	return ps, nil
 }
@@ -97,8 +99,9 @@ func (ps PassphraseStream) DHSeed() []byte {
 	return ps.stream[dhIndex:lksIndex]
 }
 
-func (ps PassphraseStream) LksClientHalf() []byte {
-	return ps.stream[lksIndex:]
+func (ps PassphraseStream) LksClientHalf() LKSecClientHalf {
+	ret, _ := NewLKSecClientHalfFromBytes(ps.stream[lksIndex:])
+	return ret
 }
 
 func (ps PassphraseStream) PDPKA5KID() (keybase1.KID, error) {

--- a/go/libkb/passphrase_stream_test.go
+++ b/go/libkb/passphrase_stream_test.go
@@ -64,7 +64,7 @@ func TestTSPassKey(t *testing.T) {
 		if hex.EncodeToString(dk.DHSeed()) != test.dkey {
 			t.Errorf("%s: dh = %x, expected %q", test.name, dk.DHSeed(), test.dkey)
 		}
-		if hex.EncodeToString(dk.LksClientHalf()) != test.lkey {
+		if hex.EncodeToString(dk.LksClientHalf().Bytes()) != test.lkey {
 			t.Errorf("%s: lks = %x, expected %q", test.name, dk.LksClientHalf(), test.lkey)
 		}
 	}

--- a/go/libkb/post.go
+++ b/go/libkb/post.go
@@ -4,7 +4,6 @@
 package libkb
 
 import (
-	"encoding/hex"
 	"fmt"
 	"runtime/debug"
 
@@ -177,10 +176,10 @@ func CheckPostedViaSigID(sigID keybase1.SigID) (found bool, status keybase1.Proo
 	return rfound, keybase1.ProofStatus(rstatus), keybase1.ProofState(rstate), rerr
 }
 
-func PostDeviceLKS(g *GlobalContext, sr SessionReader, deviceID keybase1.DeviceID, deviceType string, serverHalf []byte,
+func PostDeviceLKS(g *GlobalContext, sr SessionReader, deviceID keybase1.DeviceID, deviceType string, serverHalf LKSecServerHalf,
 	ppGen PassphraseGeneration,
 	clientHalfRecovery string, clientHalfRecoveryKID keybase1.KID) error {
-	if len(serverHalf) == 0 {
+	if serverHalf.IsNil() {
 		return fmt.Errorf("PostDeviceLKS: called with empty serverHalf")
 	}
 	if ppGen < 1 {
@@ -193,7 +192,7 @@ func PostDeviceLKS(g *GlobalContext, sr SessionReader, deviceID keybase1.DeviceI
 		Args: HTTPArgs{
 			"device_id":       S{Val: deviceID.String()},
 			"type":            S{Val: deviceType},
-			"lks_server_half": S{Val: hex.EncodeToString(serverHalf)},
+			"lks_server_half": S{Val: serverHalf.EncodeToHex()},
 			"ppgen":           I{Val: int(ppGen)},
 			"lks_client_half": S{Val: clientHalfRecovery},
 			"kid":             S{Val: clientHalfRecoveryKID.String()},

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -10,11 +10,11 @@ import (
 )
 
 type SecretRetriever interface {
-	RetrieveSecret() ([]byte, error)
+	RetrieveSecret() (LKSecFullSecret, error)
 }
 
 type SecretStorer interface {
-	StoreSecret(secret []byte) error
+	StoreSecret(secret LKSecFullSecret) error
 }
 
 type SecretStore interface {
@@ -23,8 +23,8 @@ type SecretStore interface {
 }
 
 type SecretStoreAll interface {
-	RetrieveSecret(username NormalizedUsername) ([]byte, error)
-	StoreSecret(username NormalizedUsername, secret []byte) error
+	RetrieveSecret(username NormalizedUsername) (LKSecFullSecret, error)
+	StoreSecret(username NormalizedUsername, secret LKSecFullSecret) error
 	ClearSecret(username NormalizedUsername) error
 	GetUsersWithStoredSecrets() ([]string, error)
 	GetApprovalPrompt() string
@@ -42,11 +42,11 @@ type SecretStoreImp struct {
 	store    *SecretStoreLocked
 }
 
-func (s *SecretStoreImp) RetrieveSecret() ([]byte, error) {
+func (s *SecretStoreImp) RetrieveSecret() (LKSecFullSecret, error) {
 	return s.store.RetrieveSecret(s.username)
 }
 
-func (s *SecretStoreImp) StoreSecret(secret []byte) error {
+func (s *SecretStoreImp) StoreSecret(secret LKSecFullSecret) error {
 	return s.store.StoreSecret(s.username, secret)
 }
 
@@ -124,16 +124,16 @@ func NewSecretStoreLocked(g *GlobalContext) *SecretStoreLocked {
 	}
 }
 
-func (s *SecretStoreLocked) RetrieveSecret(username NormalizedUsername) ([]byte, error) {
+func (s *SecretStoreLocked) RetrieveSecret(username NormalizedUsername) (LKSecFullSecret, error) {
 	if s == nil || s.SecretStoreAll == nil {
-		return nil, nil
+		return LKSecFullSecret{}, nil
 	}
 	s.Lock()
 	defer s.Unlock()
 	return s.SecretStoreAll.RetrieveSecret(username)
 }
 
-func (s *SecretStoreLocked) StoreSecret(username NormalizedUsername, secret []byte) error {
+func (s *SecretStoreLocked) StoreSecret(username NormalizedUsername, secret LKSecFullSecret) error {
 	if s == nil || s.SecretStoreAll == nil {
 		return nil
 	}

--- a/go/libkb/secret_store_external.go
+++ b/go/libkb/secret_store_external.go
@@ -13,8 +13,8 @@ import "sync"
 
 // ExternalKeyStore is the interface for the actual (external) keystore.
 type ExternalKeyStore interface {
-	RetrieveSecret(serviceName string, key string) ([]byte, error)
-	StoreSecret(serviceName string, key string, secret []byte) error
+	RetrieveSecret(serviceName string, key string) (LKSecFullSecret, error)
+	StoreSecret(serviceName string, key string, secret LKSecFullSecret) error
 	ClearSecret(serviceName string, key string) error
 	GetUsersWithStoredSecretsMsgPack(serviceName string) ([]byte, error)
 	SetupKeyStore(serviceName string, key string) error
@@ -49,12 +49,12 @@ type secretStoreAccountName struct {
 
 var _ SecretStoreAll = secretStoreAccountName{}
 
-func (s secretStoreAccountName) StoreSecret(username NormalizedUsername, secret []byte) (err error) {
+func (s secretStoreAccountName) StoreSecret(username NormalizedUsername, secret LKSecFullSecret) (err error) {
 	s.externalKeyStore.SetupKeyStore(s.serviceName(), string(username))
 	return s.externalKeyStore.StoreSecret(s.serviceName(), string(username), secret)
 }
 
-func (s secretStoreAccountName) RetrieveSecret(username NormalizedUsername) ([]byte, error) {
+func (s secretStoreAccountName) RetrieveSecret(username NormalizedUsername) (LKSecFullSecret, error) {
 	s.externalKeyStore.SetupKeyStore(s.serviceName(), string(username))
 	return s.externalKeyStore.RetrieveSecret(s.serviceName(), string(username))
 }

--- a/go/libkb/secret_store_file.go
+++ b/go/libkb/secret_store_file.go
@@ -24,20 +24,20 @@ func NewSecretStoreFile(dir string) *SecretStoreFile {
 	return &SecretStoreFile{dir: dir}
 }
 
-func (s *SecretStoreFile) RetrieveSecret(username NormalizedUsername) ([]byte, error) {
+func (s *SecretStoreFile) RetrieveSecret(username NormalizedUsername) (LKSecFullSecret, error) {
 	secret, err := ioutil.ReadFile(s.userpath(username))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, ErrSecretForUserNotFound
+			return LKSecFullSecret{}, ErrSecretForUserNotFound
 		}
 
-		return nil, err
+		return LKSecFullSecret{}, err
 	}
 
-	return secret, nil
+	return newLKSecFullSecretFromBytes(secret)
 }
 
-func (s *SecretStoreFile) StoreSecret(username NormalizedUsername, secret []byte) error {
+func (s *SecretStoreFile) StoreSecret(username NormalizedUsername, secret LKSecFullSecret) error {
 	if err := os.MkdirAll(s.dir, 0700); err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func (s *SecretStoreFile) StoreSecret(username NormalizedUsername, secret []byte
 			return err
 		}
 	}
-	if _, err := f.Write(secret); err != nil {
+	if _, err := f.Write(secret.Bytes()); err != nil {
 		return err
 	}
 	if err := f.Close(); err != nil {

--- a/go/libkb/secret_store_none.go
+++ b/go/libkb/secret_store_none.go
@@ -32,7 +32,7 @@ func (t TestSecretStoreAll) GetApprovalPrompt() string {
 }
 
 func NewTestSecretStoreAll(c SecretStoreContext, g *GlobalContext) SecretStoreAll {
-	ret := TestSecretStoreAll{context: c, secretStoreNoneMap: map[NormalizedUsername]LKSecFullSecret}
+	ret := TestSecretStoreAll{context: c, secretStoreNoneMap: map[NormalizedUsername]LKSecFullSecret }
 	ret.SetGlobalContext(g)
 	return ret
 }

--- a/go/libkb/secret_store_none.go
+++ b/go/libkb/secret_store_none.go
@@ -45,7 +45,7 @@ func (t TestSecretStoreAll) RetrieveSecret(accountName NormalizedUsername) (ret 
 
 	ret, ok := t.secretStoreNoneMap[accountName]
 
-	t.G().Log.Debug("| TestSecretStore::RetrieveSecret(%d)", len(ret))
+	t.G().Log.Debug("| TestSecretStore::RetrieveSecret(isNil=%v)", ret.IsNil())
 
 	if !ok {
 		return LKSecFullSecret{}, errors.New("No secret to retrieve")

--- a/go/libkb/secret_store_none.go
+++ b/go/libkb/secret_store_none.go
@@ -12,7 +12,7 @@ import (
 // Used by tests that want to mock out the secret store.
 type TestSecretStoreAll struct {
 	context            SecretStoreContext
-	secretStoreNoneMap map[NormalizedUsername][]byte
+	secretStoreNoneMap map[NormalizedUsername]LKSFullSecret
 	Contextified
 }
 
@@ -41,7 +41,7 @@ func (t TestSecretStoreAll) GetAllUserNames() (NormalizedUsername, []NormalizedU
 	return t.context.GetAllUserNames()
 }
 
-func (t TestSecretStoreAll) RetrieveSecret(accountName NormalizedUsername) (ret []byte, err error) {
+func (t TestSecretStoreAll) RetrieveSecret(accountName NormalizedUsername) (ret LKSFullSecret, err error) {
 
 	ret, ok := t.secretStoreNoneMap[accountName]
 
@@ -54,7 +54,7 @@ func (t TestSecretStoreAll) RetrieveSecret(accountName NormalizedUsername) (ret 
 	return
 }
 
-func (t TestSecretStoreAll) StoreSecret(accountName NormalizedUsername, secret []byte) error {
+func (t TestSecretStoreAll) StoreSecret(accountName NormalizedUsername, secret LKSFullSecret) error {
 	t.G().Log.Debug("| TestSecretStore::StoreSecret(%d)", len(secret))
 
 	t.secretStoreNoneMap[accountName] = secret

--- a/go/libkb/secret_store_none.go
+++ b/go/libkb/secret_store_none.go
@@ -32,7 +32,7 @@ func (t TestSecretStoreAll) GetApprovalPrompt() string {
 }
 
 func NewTestSecretStoreAll(c SecretStoreContext, g *GlobalContext) SecretStoreAll {
-	ret := TestSecretStoreAll{context: c, secretStoreNoneMap: map[NormalizedUsername]LKSecFullSecret }
+	ret := TestSecretStoreAll{context: c, secretStoreNoneMap: make(map[NormalizedUsername]LKSecFullSecret)}
 	ret.SetGlobalContext(g)
 	return ret
 }

--- a/go/libkb/secret_store_none.go
+++ b/go/libkb/secret_store_none.go
@@ -32,7 +32,7 @@ func (t TestSecretStoreAll) GetApprovalPrompt() string {
 }
 
 func NewTestSecretStoreAll(c SecretStoreContext, g *GlobalContext) SecretStoreAll {
-	ret := TestSecretStoreAll{context: c, secretStoreNoneMap: map[NormalizedUsername][]byte{}}
+	ret := TestSecretStoreAll{context: c, secretStoreNoneMap: map[NormalizedUsername]LKSecFullSecret}
 	ret.SetGlobalContext(g)
 	return ret
 }
@@ -48,14 +48,14 @@ func (t TestSecretStoreAll) RetrieveSecret(accountName NormalizedUsername) (ret 
 	t.G().Log.Debug("| TestSecretStore::RetrieveSecret(%d)", len(ret))
 
 	if !ok {
-		return nil, errors.New("No secret to retrieve")
+		return LKSecFullSecret{}, errors.New("No secret to retrieve")
 	}
 
-	return
+	return ret, nil
 }
 
 func (t TestSecretStoreAll) StoreSecret(accountName NormalizedUsername, secret LKSecFullSecret) error {
-	t.G().Log.Debug("| TestSecretStore::StoreSecret(%d)", len(secret))
+	t.G().Log.Debug("| TestSecretStore::StoreSecret(isNil=%v)", secret.IsNil())
 
 	t.secretStoreNoneMap[accountName] = secret
 	return nil

--- a/go/libkb/secret_store_none.go
+++ b/go/libkb/secret_store_none.go
@@ -12,7 +12,7 @@ import (
 // Used by tests that want to mock out the secret store.
 type TestSecretStoreAll struct {
 	context            SecretStoreContext
-	secretStoreNoneMap map[NormalizedUsername]LKSFullSecret
+	secretStoreNoneMap map[NormalizedUsername]LKSecFullSecret
 	Contextified
 }
 
@@ -41,7 +41,7 @@ func (t TestSecretStoreAll) GetAllUserNames() (NormalizedUsername, []NormalizedU
 	return t.context.GetAllUserNames()
 }
 
-func (t TestSecretStoreAll) RetrieveSecret(accountName NormalizedUsername) (ret LKSFullSecret, err error) {
+func (t TestSecretStoreAll) RetrieveSecret(accountName NormalizedUsername) (ret LKSecFullSecret, err error) {
 
 	ret, ok := t.secretStoreNoneMap[accountName]
 
@@ -54,7 +54,7 @@ func (t TestSecretStoreAll) RetrieveSecret(accountName NormalizedUsername) (ret 
 	return
 }
 
-func (t TestSecretStoreAll) StoreSecret(accountName NormalizedUsername, secret LKSFullSecret) error {
+func (t TestSecretStoreAll) StoreSecret(accountName NormalizedUsername, secret LKSecFullSecret) error {
 	t.G().Log.Debug("| TestSecretStore::StoreSecret(%d)", len(secret))
 
 	t.secretStoreNoneMap[accountName] = secret

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -54,7 +54,7 @@ type SKB struct {
 	// TODO(akalin): Remove this in favor of making LKSec
 	// Contextified (see
 	// https://github.com/keybase/client/issues/329 ).
-	newLKSecForTest func(clientHalf []byte) *LKSec
+	newLKSecForTest func(clientHalf LKSecClientHalf) *LKSec
 
 	sync.Mutex // currently only for uid
 }
@@ -371,7 +371,7 @@ func (s *SKB) lksUnlock(lctx LoginContext, pps *PassphraseStream, secretStorer S
 	pps.SetGeneration(ppGen)
 
 	if secretStorer != nil {
-		var secret []byte
+		var secret LKSecFullSecret
 		secret, err = lks.GetSecret(lctx)
 		if err != nil {
 			unlocked = nil

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -189,7 +189,7 @@ func (h ConfigHandler) GetExtendedStatus(_ context.Context, sessionID int) (res 
 
 	if me != nil && h.G().SecretStoreAll != nil {
 		s, err := h.G().SecretStoreAll.RetrieveSecret(me.GetNormalizedName())
-		if err == nil && s != nil {
+		if err == nil && !s.IsNil() {
 			res.StoredSecret = true
 		}
 	}

--- a/shared/actions/signup.js
+++ b/shared/actions/signup.js
@@ -245,7 +245,7 @@ function signup (skipMail: boolean, onDisplayPaperKey?: () => void): TypedAsyncA
           inviteCode,
           passphrase: passphrase.stringValue(),
           skipMail,
-          storeSecret: false,
+          storeSecret: true,
           username,
         },
         incomingCallMap: {


### PR DESCRIPTION
- Put a type system in place to prevent future bugs
- Revive PRs #4516 and #4570 
- Should solve #4661 and #4634 
