### PR TITLE
handle symlinks in the RPM build

### DIFF
--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -75,8 +75,8 @@ build_one_architecture() {
   # RPM requires us to list every file included in the package. Using `find`
   # could backfire on us if we get weird whitespace in any filename, but
   # hopefully that will never happen. (Maintaining this list by hand would be
-  # much worse.)
-  files="$(cd "$copied_binaries" && find -type f | sed 's/\.//')"
+  # much worse.) Make sure to find *both* regular files and symlinks.
+  files="$(cd "$copied_binaries" && find -type f -o -type l | sed 's/\.//')"
 
   spec="$dest/SPECS/keybase-$rpm_arch.spec"
   mkdir -p "$(dirname "$spec")"


### PR DESCRIPTION
RPM packaging broke when the desktop/build/desktop/renderer/fonts
symlink got introduced. RPM requires us to explicitly list every file to
be packaged, but previously I had filtered for just regular files.

r? @cjb @chrisnojima 