### PR TITLE
change conversation ID to be a byte array CORE-3998

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -103,7 +103,7 @@ func (s *HybridConversationSource) getConvMetadata(ctx context.Context, convID c
 		return chat1.Conversation{}, libkb.ChatStorageRemoteError{Msg: err.Error()}
 	}
 	if len(conv.Inbox.Conversations) == 0 {
-		return chat1.Conversation{}, libkb.ChatStorageRemoteError{Msg: fmt.Sprintf("conv not found: %d", convID)}
+		return chat1.Conversation{}, libkb.ChatStorageRemoteError{Msg: fmt.Sprintf("conv not found: %s", convID)}
 	}
 	return conv.Inbox.Conversations[0], nil
 }
@@ -120,7 +120,7 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 		localData, err := s.storage.Fetch(ctx, conv, uid, query, pagination, &rl)
 		if err == nil {
 			// If found, then return the stuff
-			s.G().Log.Debug("Pull: cache hit: convID: %d uid: %s", convID, uid)
+			s.G().Log.Debug("Pull: cache hit: convID: %s uid: %s", convID, uid)
 			localData.Messages = utils.FilterByType(localData.Messages, query)
 
 			// Before returning the stuff, send remote request to mark as read if
@@ -139,7 +139,7 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 			return localData, rl, nil
 		}
 	} else {
-		s.G().Log.Debug("Pull: error fetching conv metadata: convID: %d uid: %s err: %s", convID, uid,
+		s.G().Log.Debug("Pull: error fetching conv metadata: convID: %s uid: %s err: %s", convID, uid,
 			err.Error())
 	}
 
@@ -163,7 +163,7 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 
 	// Store locally (just warn on error, don't abort the whole thing)
 	if err = s.storage.Merge(ctx, convID, uid, thread.Messages); err != nil {
-		s.G().Log.Warning("Pull: unable to commit thread locally: convID: %d uid: %s", convID, uid)
+		s.G().Log.Warning("Pull: unable to commit thread locally: convID: %s uid: %s", convID, uid)
 	}
 
 	return thread, rl, nil

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -167,7 +167,7 @@ func (s *Storage) Merge(ctx context.Context, convID chat1.ConversationID, uid gr
 	defer s.Unlock()
 
 	var err libkb.ChatStorageError
-	s.debug("Merge: convID: %d uid: %s num msgs: %d", convID, uid, len(msgs))
+	s.debug("Merge: convID: %s uid: %s num msgs: %d", convID, uid, len(msgs))
 
 	// Fetch secret key
 	key, ierr := s.getSecretBoxKey()

--- a/go/chat/storage/storage_test.go
+++ b/go/chat/storage/storage_test.go
@@ -1,9 +1,7 @@
 package storage
 
 import (
-	"bytes"
 	"crypto/rand"
-	"encoding/binary"
 	"math/big"
 	"testing"
 
@@ -68,12 +66,8 @@ func addMsgs(num int, msgs []chat1.MessageUnboxed) []chat1.MessageUnboxed {
 }
 
 func makeConvID() chat1.ConversationID {
-	// Read into int64
-	var res uint64
 	rbytes := randBytes(8)
-	buf := bytes.NewReader(rbytes)
-	binary.Read(buf, binary.LittleEndian, &res)
-	return chat1.ConversationID(res)
+	return chat1.ConversationID(rbytes)
 }
 
 func makeConversation(maxID chat1.MessageID) chat1.Conversation {

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -359,10 +359,10 @@ func (a *ChatAPI) encodeReply(call Call, reply Reply, w io.Writer) error {
 }
 
 func checkChannelConv(method string, channel ChatChannel, convID chat1.ConversationID) error {
-	if !channel.Valid() && convID == 0 {
+	if !channel.Valid() && convID.IsNil() {
 		return ErrInvalidOptions{version: 1, method: method, err: errors.New("need channel or conversation_id")}
 	}
-	if channel.Valid() && convID > 0 {
+	if channel.Valid() && !convID.IsNil() {
 		return ErrInvalidOptions{version: 1, method: method, err: errors.New("include channel or conversation_id, not both")}
 	}
 	return nil

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -131,7 +131,7 @@ func (c ChatMessage) Valid() bool {
 
 type sendOptionsV1 struct {
 	Channel        ChatChannel
-	ConversationID chat1.ConversationID `json:"conversation_id"`
+	ConversationID string `json:"conversation_id"`
 	Message        ChatMessage
 }
 
@@ -147,7 +147,7 @@ func (s sendOptionsV1) Check() error {
 
 type readOptionsV1 struct {
 	Channel        ChatChannel
-	ConversationID chat1.ConversationID `json:"conversation_id"`
+	ConversationID string `json:"conversation_id"`
 	Limit          string
 }
 
@@ -157,8 +157,8 @@ func (r readOptionsV1) Check() error {
 
 type editOptionsV1 struct {
 	Channel        ChatChannel
-	ConversationID chat1.ConversationID `json:"conversation_id"`
-	MessageID      chat1.MessageID      `json:"message_id"`
+	ConversationID string          `json:"conversation_id"`
+	MessageID      chat1.MessageID `json:"message_id"`
 	Message        ChatMessage
 }
 
@@ -180,8 +180,8 @@ func (e editOptionsV1) Check() error {
 
 type deleteOptionsV1 struct {
 	Channel        ChatChannel
-	ConversationID chat1.ConversationID `json:"conversation_id"`
-	MessageID      chat1.MessageID      `json:"message_id"`
+	ConversationID string          `json:"conversation_id"`
+	MessageID      chat1.MessageID `json:"message_id"`
 }
 
 func (d deleteOptionsV1) Check() error {
@@ -199,7 +199,7 @@ func (d deleteOptionsV1) Check() error {
 
 type attachOptionsV1 struct {
 	Channel        ChatChannel
-	ConversationID chat1.ConversationID `json:"conversation_id"`
+	ConversationID string `json:"conversation_id"`
 	Filename       string
 	Preview        string
 }
@@ -216,8 +216,8 @@ func (a attachOptionsV1) Check() error {
 
 type downloadOptionsV1 struct {
 	Channel        ChatChannel
-	ConversationID chat1.ConversationID `json:"conversation_id"`
-	MessageID      chat1.MessageID      `json:"message_id"`
+	ConversationID string          `json:"conversation_id"`
+	MessageID      chat1.MessageID `json:"message_id"`
 	Output         string
 	Preview        bool
 }
@@ -358,11 +358,11 @@ func (a *ChatAPI) encodeReply(call Call, reply Reply, w io.Writer) error {
 	return enc.Encode(reply)
 }
 
-func checkChannelConv(method string, channel ChatChannel, convID chat1.ConversationID) error {
-	if !channel.Valid() && convID.IsNil() {
+func checkChannelConv(method string, channel ChatChannel, convID string) error {
+	if !channel.Valid() && len(convID) == 0 {
 		return ErrInvalidOptions{version: 1, method: method, err: errors.New("need channel or conversation_id")}
 	}
-	if channel.Valid() && !convID.IsNil() {
+	if channel.Valid() && len(convID) > 0 {
 		return ErrInvalidOptions{version: 1, method: method, err: errors.New("include channel or conversation_id, not both")}
 	}
 	return nil

--- a/go/client/chat_api_test.go
+++ b/go/client/chat_api_test.go
@@ -195,10 +195,10 @@ var optTests = []optTest{
 		input: `{"method": "read", "params":{"version": 1, "options": {"channel": {"name": "alice,bob"}}}}`,
 	},
 	{
-		input: `{"method": "read", "params":{"version": 1, "options": {"conversation_id": 123}}}`,
+		input: `{"method": "read", "params":{"version": 1, "options": {"conversation_id": "123"}}}`,
 	},
 	{
-		input: `{"method": "read", "params":{"version": 1, "options": {"channel": {"name": "alice,bob"}, "conversation_id": 999111}}}`,
+		input: `{"method": "read", "params":{"version": 1, "options": {"channel": {"name": "alice,bob"}, "conversation_id": "999111"}}}`,
 		err:   ErrInvalidOptions{},
 	},
 	{
@@ -217,17 +217,17 @@ var optTests = []optTest{
 		input: `{"method": "send", "params":{"version": 1, "options": {"channel": {"name": "alice,bob"}, "message": {"body": "hi"}}}}`,
 	},
 	{
-		input: `{"method": "send", "params":{"version": 1, "options": {"conversation_id": 123, "message": {"body": "hi"}}}}`,
+		input: `{"method": "send", "params":{"version": 1, "options": {"conversation_id": "123", "message": {"body": "hi"}}}}`,
 	},
 	{
-		input: `{"method": "send", "params":{"version": 1, "options": {"conversation_id": 222, "channel": {"name": "alice,bob"}, "message": {"body": "hi"}}}}`,
+		input: `{"method": "send", "params":{"version": 1, "options": {"conversation_id": "222", "channel": {"name": "alice,bob"}, "message": {"body": "hi"}}}}`,
 		err:   ErrInvalidOptions{},
 	},
 	{
 		input: `{"method": "list", "params":{"version": 1}}{"method": "list", "params":{"version": 1}}`,
 	},
 	{
-		input: `{"method": "list", "params":{"version": 1}}{"method": "read", "params":{"version": 1, "options": {"conversation_id": 7777}}}`,
+		input: `{"method": "list", "params":{"version": 1}}{"method": "read", "params":{"version": 1, "options": {"conversation_id": "7777"}}}`,
 	},
 	{
 		input: `{"method": "read", "params":{"version": 1, "options": {"channel": {"name": "alice,bob"}}}`, /* missing closing bracket at end */
@@ -280,7 +280,7 @@ var optTests = []optTest{
 		input: `{"id": 30, "method": "edit", "params":{"version": 1, "options": {"channel": {"name": "alice,bob"}, "message_id": 123, "message": {"body": "edited"}}}}`,
 	},
 	{
-		input: `{"id": 30, "method": "edit", "params":{"version": 1, "options": {"conversation_id": 333, "message_id": 123, "message": {"body": "edited"}}}}`,
+		input: `{"id": 30, "method": "edit", "params":{"version": 1, "options": {"conversation_id": "333", "message_id": 123, "message": {"body": "edited"}}}}`,
 	},
 	{
 		input: `{"id": 30, "method": "delete", "params":{"version": 1, "options": {}}}`,
@@ -360,7 +360,7 @@ var echoTests = []echoTest{
 		output: `{"result":{"status":"ok"}}`,
 	},
 	{
-		input:  `{"method": "read", "params":{"version": 1, "options": {"conversation_id": 123}}}`,
+		input:  `{"method": "read", "params":{"version": 1, "options": {"conversation_id": "123"}}}`,
 		output: `{"result":{"status":"ok"}}`,
 	},
 	{
@@ -372,7 +372,7 @@ var echoTests = []echoTest{
 		output: `{"result":{"status":"ok"}}` + "\n" + `{"result":{"status":"ok"}}`,
 	},
 	{
-		input:  `{"method": "list", "params":{"version": 1}}{"method": "read", "params":{"version": 1, "options": {"conversation_id": 123}}}`,
+		input:  `{"method": "list", "params":{"version": 1}}{"method": "read", "params":{"version": 1, "options": {"conversation_id": "123"}}}`,
 		output: `{"result":{"status":"ok"}}` + "\n" + `{"result":{"status":"ok"}}`,
 	},
 	{

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -81,7 +81,7 @@ func (c *chatServiceHandler) ReadV1(ctx context.Context, opts readOptionsV1) Rep
 		return c.errReply(err)
 	}
 
-	if opts.ConversationID == 0 {
+	if opts.ConversationID.IsNil() {
 		// resolve conversation id
 		query, err := c.getInboxLocalQuery(ctx, opts.ConversationID, opts.Channel)
 		if err != nil {
@@ -319,7 +319,7 @@ func (c *chatServiceHandler) DownloadV1(ctx context.Context, opts downloadOption
 	}
 
 	var rlimits []chat1.RateLimit
-	if opts.ConversationID == 0 {
+	if opts.ConversationID.IsNil() {
 		// resolve conversation id
 		query, err := c.getInboxLocalQuery(ctx, opts.ConversationID, opts.Channel)
 		if err != nil {
@@ -466,7 +466,7 @@ func (c *chatServiceHandler) makePostHeader(ctx context.Context, arg sendArgV1, 
 }
 
 func (c *chatServiceHandler) getInboxLocalQuery(ctx context.Context, id chat1.ConversationID, channel ChatChannel) (chat1.GetInboxLocalQuery, error) {
-	if id > 0 {
+	if !id.IsNil() {
 		return chat1.GetInboxLocalQuery{ConvID: &id}, nil
 	}
 

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1655,7 +1655,7 @@ type ChatConvExistsError struct {
 }
 
 func (e ChatConvExistsError) Error() string {
-	return fmt.Sprintf("conversation already exists: %d", e.ConvID)
+	return fmt.Sprintf("conversation already exists: %s", e.ConvID)
 }
 
 //=============================================================================

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -376,12 +376,7 @@ func ImportStatusAsError(s *keybase1.Status) error {
 		for _, field := range s.Fields {
 			switch field.Key {
 			case "ConvID":
-				var err error
-				val, err := strconv.ParseUint(field.Value, 10, 64)
-				if err != nil {
-					G.Log.Warning("error parsing chat conv exists conv ID: %s", err)
-				}
-				convID = chat1.MakeConversationID(val)
+				convID = chat1.ConversationID(field.Value)
 			}
 		}
 		return ChatConvExistsError{

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -11,7 +11,7 @@ import (
 type ThreadID []byte
 type MessageID uint
 type TopicID []byte
-type ConversationID uint64
+type ConversationID []byte
 type TLFID []byte
 type Hash []byte
 type MessageType int

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -22,20 +22,28 @@ func (id TLFID) String() string {
 	return hex.EncodeToString(id)
 }
 
+func MakeConvID(val string) (ConversationID, error) {
+	return hex.DecodeString(val)
+}
+
+func (cid ConversationID) Bytes() []byte {
+	return []byte(cid)
+}
+
 func (cid ConversationID) String() string {
-	return strconv.FormatUint(uint64(cid), 10)
+	return hex.EncodeToString(cid)
 }
 
-func MakeConversationID(val uint64) ConversationID {
-	return ConversationID(val)
+func (cid ConversationID) IsNil() bool {
+	return len(cid) == 0
 }
 
-func ConvertConversationID(val string) (ConversationID, error) {
-	raw, err := strconv.ParseUint(val, 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	return MakeConversationID(raw), nil
+func (cid ConversationID) Eq(c ConversationID) bool {
+	return bytes.Equal(cid, c)
+}
+
+func (cid ConversationID) Less(c ConversationID) bool {
+	return bytes.Compare(cid, c) < 0
 }
 
 func MakeTLFID(val string) (TLFID, error) {

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -162,7 +162,7 @@ func TestChatNewChatConversationLocalTwice(t *testing.T) {
 	c1 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
 	c2 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
 
-	if c2.Id != c1.Id {
+	if !c2.Id.Eq(c1.Id) {
 		t.Fatalf("2nd call to NewConversationLocal for a chat conversation did not return the same conversation ID")
 	}
 }
@@ -199,7 +199,7 @@ func TestChatGetInboxAndUnboxLocal(t *testing.T) {
 	if conversations[0].Info.TlfName != conv.MaxMsgs[0].ClientHeader.TlfName {
 		t.Fatalf("unexpected TlfName in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.TlfName, conv.MaxMsgs[0].ClientHeader.TlfName)
 	}
-	if conversations[0].Info.Id != created.Id {
+	if !conversations[0].Info.Id.Eq(created.Id) {
 		t.Fatalf("unexpected Id in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.Id, created.Id)
 	}
 	if conversations[0].Info.Triple.TopicType != chat1.TopicType_CHAT {
@@ -231,7 +231,7 @@ func TestChatGetInboxAndUnboxLocalTlfName(t *testing.T) {
 	if conversations[0].Info.TlfName != conv.MaxMsgs[0].ClientHeader.TlfName {
 		t.Fatalf("unexpected TlfName in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.TlfName, conv.MaxMsgs[0].ClientHeader.TlfName)
 	}
-	if conversations[0].Info.Id != created.Id {
+	if !conversations[0].Info.Id.Eq(created.Id) {
 		t.Fatalf("unexpected Id in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.Id, created.Id)
 	}
 	if conversations[0].Info.Triple.TopicType != chat1.TopicType_CHAT {
@@ -254,7 +254,7 @@ func TestChatPostLocal(t *testing.T) {
 	mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello!"}))
 
 	// we just posted this message, so should be the first one.
-	msg := ctc.world.Msgs[created.Id][0]
+	msg := ctc.world.Msgs[created.Id.String()][0]
 
 	if msg.ClientHeader.TlfName == created.TlfName {
 		t.Fatalf("PostLocal didn't canonicalize TLF name")
@@ -403,7 +403,7 @@ func TestChatGracefulUnboxing(t *testing.T) {
 	mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "evil hello"}))
 
 	// make evil hello evil
-	ctc.world.Msgs[created.Id][0].BodyCiphertext.E[0]++
+	ctc.world.Msgs[created.Id.String()][0].BodyCiphertext.E[0]++
 
 	tv, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(context.Background(), chat1.GetThreadLocalArg{
 		ConversationID: created.Id,
@@ -453,7 +453,7 @@ func TestChatGetInboxSummaryForCLILocal(t *testing.T) {
 	if len(res.Conversations) != 5 {
 		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 3 items, got %d\n", len(res.Conversations))
 	}
-	if res.Conversations[0].Info.Id != withUser123.Id {
+	if !res.Conversations[0].Info.Id.Eq(withUser123.Id) {
 		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal; newest updated conversation is not the first in response.\n")
 	}
 	// TODO: fix this when merging master back in
@@ -498,7 +498,7 @@ func TestChatGetInboxSummaryForCLILocal(t *testing.T) {
 	if len(res.Conversations) != 2 {
 		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 2 items, got %d\n", len(res.Conversations))
 	}
-	if res.Conversations[0].Info.Id != withUser1.Id {
+	if !res.Conversations[0].Info.Id.Eq(withUser1.Id) {
 		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal; unread conversation is not the first in response.\n")
 	}
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -865,7 +865,7 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 			g.G().Log.Error("push handler: chat activity: error decoding newMessage: %s", err.Error())
 			return err
 		}
-		g.G().Log.Debug("push handler: chat activity: newMessage: convID: %d sender: %s",
+		g.G().Log.Debug("push handler: chat activity: newMessage: convID: %s sender: %s",
 			nm.ConvID, nm.Message.ClientHeader.Sender)
 		uid := m.UID().Bytes()
 		decmsg, err := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -6,7 +6,7 @@ protocol common {
   @typedef("bytes")  record ThreadID {}
   @typedef("uint")   record MessageID {}
   @typedef("bytes")  record TopicID {}
-  @typedef("uint64") record ConversationID {}
+  @typedef("bytes")  record ConversationID {}
   @typedef("bytes")  record TLFID {}
   @typedef("bytes")  record Hash {}
 

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -374,7 +374,7 @@ export type Conversation = {
   maxMsgs?: ?Array<MessageBoxed>,
 }
 
-export type ConversationID = uint64
+export type ConversationID = bytes
 
 export type ConversationIDTriple = {
   tlfid: TLFID,

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -30,7 +30,7 @@
       "type": "record",
       "name": "ConversationID",
       "fields": [],
-      "typedef": "uint64"
+      "typedef": "bytes"
     },
     {
       "type": "record",

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -374,7 +374,7 @@ export type Conversation = {
   maxMsgs?: ?Array<MessageBoxed>,
 }
 
-export type ConversationID = uint64
+export type ConversationID = bytes
 
 export type ConversationIDTriple = {
   tlfid: TLFID,


### PR DESCRIPTION
@maxtaco @patrickxb @chrisnojima r?

The purpose of this PR is to change the `ConversationID` type to a byte array. I chose that over string because it is a little more consistent with the types in the rest of the chat API (everything comes out as bytes). 

@chrisnojima, if this is too annoying in JS, let me know, and I can see about making it a string.