### PR TITLE
Sort usernames in conversations by latest activity

### DIFF
--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
@@ -55,7 +56,8 @@ func textMsgWithHeader(t *testing.T, text string, header chat1.MessageClientHead
 
 func setupChatTest(t *testing.T, name string) (libkb.TestContext, *Boxer) {
 	tc := externals.SetupTest(t, name, 2)
-	return tc, NewBoxer(tc.G, nil)
+	udc := utils.NewUserDeviceCache(tc.G)
+	return tc, NewBoxer(tc.G, nil, udc)
 }
 
 func getSigningKeyPairForTest(t *testing.T, tc libkb.TestContext, u *kbtest.FakeUser) libkb.NaclSigningKeyPair {

--- a/go/chat/utils/user_device_cache.go
+++ b/go/chat/utils/user_device_cache.go
@@ -1,0 +1,93 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package utils
+
+import (
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type udCacheKey struct {
+	UID        keybase1.UID
+	WithDevice bool
+	DeviceID   keybase1.DeviceID
+}
+
+type udCacheValue struct {
+	Username   string
+	DeviceName string
+}
+
+// UserDeviceCache looks up usernames and device names, memoizing the results.
+// These bindings are immutable and can be cached forever.
+type UserDeviceCache struct {
+	sync.Mutex
+	cache *lru.Cache
+	kbCtx KeybaseContext
+}
+
+func NewUserDeviceCache(kbCtx KeybaseContext) *UserDeviceCache {
+	udc, _ := lru.New(10000)
+	return &UserDeviceCache{
+		cache: udc,
+		kbCtx: kbCtx,
+	}
+}
+
+type udFiller func() (udCacheValue, error)
+
+// Lookup an entry in the cache. Call filler to fill it if it misses.
+func (c *UserDeviceCache) lookup(cKey udCacheKey, filler udFiller) (udCacheValue, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	if val, ok := c.cache.Get(cKey); ok {
+		if udval, ok := val.(udCacheValue); ok {
+			c.kbCtx.GetLog().Debug("UserDeviceCache hit: u: %s d: %s", udval.Username, udval.DeviceName)
+			return udval, nil
+		}
+	}
+
+	cVal, err := filler()
+	if err != nil {
+		return cVal, err
+	}
+	c.cache.Add(cKey, cVal)
+	return cVal, nil
+}
+
+func (c *UserDeviceCache) LookupUsernameAndDeviceName(uimap *UserInfoMapper, uid keybase1.UID, deviceID keybase1.DeviceID) (username string, devicename string, err error) {
+	cKey := udCacheKey{
+		UID:        uid,
+		WithDevice: true,
+		DeviceID:   deviceID,
+	}
+	val, err := c.lookup(cKey, func() (udCacheValue, error) {
+		username, deviceName, err := uimap.Lookup(uid, deviceID)
+		return udCacheValue{
+			Username:   username,
+			DeviceName: deviceName,
+		}, err
+	})
+	return val.Username, val.DeviceName, err
+}
+
+func (c *UserDeviceCache) LookupUsername(uimap *UserInfoMapper, uid keybase1.UID) (username string, err error) {
+	cKey := udCacheKey{
+		UID:        uid,
+		WithDevice: false,
+	}
+	val, err := c.lookup(cKey, func() (udCacheValue, error) {
+		user, err := uimap.User(uid)
+		if err != nil {
+			return udCacheValue{}, err
+		}
+		return udCacheValue{
+			Username: user.GetNormalizedName().String(),
+		}, nil
+	})
+	return val.Username, err
+}

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -89,7 +89,7 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 			continue
 		}
 
-		participants := strings.Split(conv.Info.TlfName, ",")
+		participants := conv.Info.Usernames
 
 		if len(participants) > 1 {
 			var withoutMe []string

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -113,6 +113,7 @@ type GetInboxQuery struct {
 	OneChatTypePerTLF *bool           `codec:"oneChatTypePerTLF,omitempty" json:"oneChatTypePerTLF,omitempty"`
 	UnreadOnly        bool            `codec:"unreadOnly" json:"unreadOnly"`
 	ReadOnly          bool            `codec:"readOnly" json:"readOnly"`
+	ComputeActiveList bool            `codec:"computeActiveList" json:"computeActiveList"`
 }
 
 type ConversationIDTriple struct {
@@ -125,6 +126,7 @@ type ConversationMetadata struct {
 	IdTriple       ConversationIDTriple `codec:"idTriple" json:"idTriple"`
 	ConversationID ConversationID       `codec:"conversationID" json:"conversationID"`
 	IsFinalized    bool                 `codec:"isFinalized" json:"isFinalized"`
+	ActiveList     []gregor1.UID        `codec:"activeList" json:"activeList"`
 }
 
 type ConversationReaderInfo struct {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -418,6 +418,7 @@ type ConversationInfoLocal struct {
 	TlfName    string               `codec:"tlfName" json:"tlfName"`
 	TopicName  string               `codec:"topicName" json:"topicName"`
 	Visibility TLFVisibility        `codec:"visibility" json:"visibility"`
+	Usernames  []string             `codec:"usernames" json:"usernames"`
 }
 
 type ConversationLocal struct {
@@ -456,6 +457,7 @@ type GetInboxLocalQuery struct {
 	OneChatTypePerTLF *bool           `codec:"oneChatTypePerTLF,omitempty" json:"oneChatTypePerTLF,omitempty"`
 	UnreadOnly        bool            `codec:"unreadOnly" json:"unreadOnly"`
 	ReadOnly          bool            `codec:"readOnly" json:"readOnly"`
+	ComputeActiveList bool            `codec:"computeActiveList" json:"computeActiveList"`
 }
 
 type GetInboxAndUnboxLocalRes struct {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -518,7 +518,6 @@ func (h *chatLocalHandler) localizeConversation(
 		return chat1.ConversationLocal{}, err
 	}
 
-	// TODO need this more validation to make sure it's not a trick?
 	conversationLocal.Info.Usernames = utils.ReorderParticipants(
 		h.udc,
 		uimap,

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -29,6 +29,7 @@ type chatLocalHandler struct {
 	libkb.Contextified
 	gh    *gregorHandler
 	tlf   keybase1.TlfInterface
+	udc   *utils.UserDeviceCache
 	boxer *chat.Boxer
 
 	// Only for testing
@@ -38,12 +39,14 @@ type chatLocalHandler struct {
 // newChatLocalHandler creates a chatLocalHandler.
 func newChatLocalHandler(xp rpc.Transporter, g *libkb.GlobalContext, gh *gregorHandler) *chatLocalHandler {
 	tlf := newTlfHandler(nil, g)
+	udc := utils.NewUserDeviceCache(g)
 	h := &chatLocalHandler{
 		BaseHandler:  NewBaseHandler(xp),
 		Contextified: libkb.NewContextified(g),
 		gh:           gh,
 		tlf:          tlf,
-		boxer:        chat.NewBoxer(g, tlf),
+		udc:          udc,
+		boxer:        chat.NewBoxer(g, tlf, udc),
 	}
 	if gh != nil {
 		g.ConvSource = chat.NewConversationSource(g, g.Env.GetConvSourceType(), h.boxer,
@@ -87,6 +90,7 @@ func (h *chatLocalHandler) getInboxQueryLocalToRemote(ctx context.Context, lquer
 	rquery.TopicType = lquery.TopicType
 	rquery.UnreadOnly = lquery.UnreadOnly
 	rquery.ReadOnly = lquery.ReadOnly
+	rquery.ComputeActiveList = lquery.ComputeActiveList
 	rquery.ConvID = lquery.ConvID
 
 	return rquery, nil
@@ -392,6 +396,7 @@ func (h *chatLocalHandler) GetInboxSummaryForCLILocal(ctx context.Context, arg c
 	}
 
 	var queryBase chat1.GetInboxLocalQuery
+	queryBase.ComputeActiveList = true
 	if !after.IsZero() {
 		gafter := gregor1.ToTime(after)
 		queryBase.After = &gafter
@@ -465,6 +470,8 @@ func (h *chatLocalHandler) localizeConversation(
 	ctx context.Context, conversationRemote chat1.Conversation) (
 	conversationLocal chat1.ConversationLocal, err error) {
 
+	ctx, uimap := utils.GetUserInfoMapper(ctx, h.G())
+
 	conversationLocal.Info = chat1.ConversationInfoLocal{
 		Id: conversationRemote.Metadata.ConversationID,
 	}
@@ -510,6 +517,13 @@ func (h *chatLocalHandler) localizeConversation(
 	if _, conversationLocal.Info.TlfName, err = h.cryptKeysWrapper(ctx, conversationLocal.Info.TlfName); err != nil {
 		return chat1.ConversationLocal{}, err
 	}
+
+	// TODO need this more validation to make sure it's not a trick?
+	conversationLocal.Info.Usernames = utils.ReorderParticipants(
+		h.udc,
+		uimap,
+		conversationLocal.Info.TlfName,
+		conversationRemote.Metadata.ActiveList)
 
 	// verify Conv matches ConversationIDTriple in MessageClientHeader
 	if !conversationRemote.Metadata.IdTriple.Eq(conversationLocal.Info.Triple) {

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -65,7 +65,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	h := newChatLocalHandler(nil, tc.G, nil)
 	mockRemote := kbtest.NewChatRemoteMock(c.world)
 	h.tlf = kbtest.NewTlfMock(c.world)
-	h.boxer = chat.NewBoxer(tc.G, h.tlf)
+	h.boxer = chat.NewBoxer(tc.G, h.tlf, h.udc)
 	f := func() libkb.SecretUI {
 		return &libkb.TestSecretUI{Passphrase: user.Passphrase}
 	}

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -57,6 +57,7 @@ protocol common {
     union { null, boolean } oneChatTypePerTLF;
     boolean unreadOnly;
     boolean readOnly;
+    boolean computeActiveList;
   }
 
   record ConversationIDTriple {
@@ -69,6 +70,9 @@ protocol common {
     ConversationIDTriple idTriple;
     ConversationID conversationID;
     bool isFinalized;
+    // List of users sorted by recency of last [intentional] post.
+    // Most recent first. May be incomplete or empty.
+    array<gregor1.UID> activeList;
   }
 
   record ConversationReaderInfo {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -151,6 +151,8 @@ protocol local {
     string tlfName;
     string topicName;
     TLFVisibility visibility;
+    // List of usernames, sometimes sorted by activity.
+    array<string> usernames;
   }
 
   record ConversationLocal {
@@ -194,6 +196,7 @@ protocol local {
     union { null, boolean } oneChatTypePerTLF;
     boolean unreadOnly;
     boolean readOnly;
+    boolean computeActiveList;
   }
   record GetInboxAndUnboxLocalRes {
     array<ConversationLocal> conversations;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -388,6 +388,7 @@ export type ConversationInfoLocal = {
   tlfName: string,
   topicName: string,
   visibility: TLFVisibility,
+  usernames?: ?Array<string>,
 }
 
 export type ConversationLocal = {
@@ -401,6 +402,7 @@ export type ConversationMetadata = {
   idTriple: ConversationIDTriple,
   conversationID: ConversationID,
   isFinalized: bool,
+  activeList?: ?Array<gregor1.UID>,
 }
 
 export type ConversationReaderInfo = {
@@ -464,6 +466,7 @@ export type GetInboxLocalQuery = {
   oneChatTypePerTLF?: ?boolean,
   unreadOnly: boolean,
   readOnly: boolean,
+  computeActiveList: boolean,
 }
 
 export type GetInboxLocalRes = {
@@ -482,6 +485,7 @@ export type GetInboxQuery = {
   oneChatTypePerTLF?: ?boolean,
   unreadOnly: boolean,
   readOnly: boolean,
+  computeActiveList: boolean,
 }
 
 export type GetInboxRemoteRes = {

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -180,6 +180,10 @@
         {
           "type": "boolean",
           "name": "readOnly"
+        },
+        {
+          "type": "boolean",
+          "name": "computeActiveList"
         }
       ]
     },
@@ -216,6 +220,13 @@
         {
           "type": "bool",
           "name": "isFinalized"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "gregor1.UID"
+          },
+          "name": "activeList"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -447,6 +447,13 @@
         {
           "type": "TLFVisibility",
           "name": "visibility"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "usernames"
         }
       ]
     },
@@ -620,6 +627,10 @@
         {
           "type": "boolean",
           "name": "readOnly"
+        },
+        {
+          "type": "boolean",
+          "name": "computeActiveList"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -388,6 +388,7 @@ export type ConversationInfoLocal = {
   tlfName: string,
   topicName: string,
   visibility: TLFVisibility,
+  usernames?: ?Array<string>,
 }
 
 export type ConversationLocal = {
@@ -401,6 +402,7 @@ export type ConversationMetadata = {
   idTriple: ConversationIDTriple,
   conversationID: ConversationID,
   isFinalized: bool,
+  activeList?: ?Array<gregor1.UID>,
 }
 
 export type ConversationReaderInfo = {
@@ -464,6 +466,7 @@ export type GetInboxLocalQuery = {
   oneChatTypePerTLF?: ?boolean,
   unreadOnly: boolean,
   readOnly: boolean,
+  computeActiveList: boolean,
 }
 
 export type GetInboxLocalRes = {
@@ -482,6 +485,7 @@ export type GetInboxQuery = {
   oneChatTypePerTLF?: ?boolean,
   unreadOnly: boolean,
   readOnly: boolean,
+  computeActiveList: boolean,
 }
 
 export type GetInboxRemoteRes = {


### PR DESCRIPTION
`kbc ls` will now do its best to show participants sorted by the time of their latest activity. Activity means posting a `TEXT` or `ATTACHMENT` message.

This involved factoring out `UserDeviceCache`. The instance of `UserDeviceCache` lives for as long as the daemon process (at least it should), it is attached to the `chatLocalHandler`. The `UserDeviceCache` is not chat specific and could instead live in `libkb.GlobalContext` or something. The username lookups are done in the service in `chatLocalHandler.localizeConversation`.

Protocol changes:
- Add `GetInboxLocalQuery.ComputeActiveList` and `GetInboxQuery.ComputeActiveList`
- Add `ConversationMetadata.ActiveList`
- Add `ConversationInfoLocal.Usernames`
Would you check my thinking that these should be backwards compatible?

Two problems with this PR:
1. ~~Server trust. Some more validation is needed to make sure that `ActiveList` is a subset of the tlfname.~~ Fixed.
2. In reader-only tlfs like `alice#bob`, this will show something really wrong like `bob,alice`. Is chat going to support those?

r? @mmaxim 