### PR TITLE
Update version.go

### DIFF
--- a/go/libkb/version.go
+++ b/go/libkb/version.go
@@ -4,4 +4,4 @@
 package libkb
 
 // Version is the current version (should be MAJOR.MINOR.PATCH)
-const Version = "1.0.17"
+const Version = "1.0.18"


### PR DESCRIPTION
Brew release is so old, and possible broken on Sierra for people with super old binaries.

Let's bump it now and deal with versioning questions later?