### PR TITLE
Support read-only tlfs in chat ls

### DIFF
--- a/go/chat/utils/kbfs.go
+++ b/go/chat/utils/kbfs.go
@@ -1,0 +1,191 @@
+// Copyright 2016 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// This is all stuff copied from libkbfs.
+
+package utils
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+const (
+	// ReaderSep is the string that separates readers from writers in a
+	// TLF name.
+	ReaderSep = "#"
+
+	// TlfHandleExtensionSep is the string that separates the folder
+	// participants from an extension suffix in the TLF name.
+	TlfHandleExtensionSep = " "
+
+	// PublicUIDName is the name given to keybase1.PublicUID.  This string
+	// should correspond to an illegal or reserved Keybase user name.
+	PublicUIDName = "_public"
+)
+
+func splitAndNormalizeTLFName(name string, public bool) (
+	writerNames, readerNames []string,
+	extensionSuffix string, err error) {
+
+	names := strings.SplitN(name, TlfHandleExtensionSep, 2)
+	if len(names) > 2 {
+		return nil, nil, "", BadTLFNameError{name}
+	}
+	if len(names) > 1 {
+		extensionSuffix = names[1]
+	}
+
+	splitNames := strings.SplitN(names[0], ReaderSep, 3)
+	if len(splitNames) > 2 {
+		return nil, nil, "", BadTLFNameError{name}
+	}
+	writerNames = strings.Split(splitNames[0], ",")
+	if len(splitNames) > 1 {
+		readerNames = strings.Split(splitNames[1], ",")
+	}
+
+	hasPublic := len(readerNames) == 0
+
+	if public && !hasPublic {
+		// No public folder exists for this folder.
+		return nil, nil, "", NoSuchNameError{Name: name}
+	}
+
+	normalizedName, err := normalizeNamesInTLF(
+		writerNames, readerNames, extensionSuffix)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	if normalizedName != name {
+		return nil, nil, "", TlfNameNotCanonical{name, normalizedName}
+	}
+
+	return writerNames, readerNames, strings.ToLower(extensionSuffix), nil
+}
+
+// normalizeNamesInTLF takes a split TLF name and, without doing any
+// resolutions or identify calls, normalizes all elements of the
+// name. It then returns the normalized name.
+func normalizeNamesInTLF(writerNames, readerNames []string,
+	extensionSuffix string) (string, error) {
+	sortedWriterNames := make([]string, len(writerNames))
+	var err error
+	for i, w := range writerNames {
+		sortedWriterNames[i], err = normalizeAssertionOrName(w)
+		if err != nil {
+			return "", err
+		}
+	}
+	sort.Strings(sortedWriterNames)
+	normalizedName := strings.Join(sortedWriterNames, ",")
+	if len(readerNames) > 0 {
+		sortedReaderNames := make([]string, len(readerNames))
+		for i, r := range readerNames {
+			sortedReaderNames[i], err = normalizeAssertionOrName(r)
+			if err != nil {
+				return "", err
+			}
+		}
+		sort.Strings(sortedReaderNames)
+		normalizedName += ReaderSep + strings.Join(sortedReaderNames, ",")
+	}
+	if len(extensionSuffix) != 0 {
+		// This *should* be normalized already but make sure.  I can see not
+		// doing so might surprise a caller.
+		normalizedName += TlfHandleExtensionSep + strings.ToLower(extensionSuffix)
+	}
+
+	return normalizedName, nil
+}
+
+// TODO: this function can likely be replaced with a call to
+// AssertionParseAndOnly when CORE-2967 and CORE-2968 are fixed.
+func normalizeAssertionOrName(s string) (string, error) {
+	if libkb.CheckUsername.F(s) {
+		return libkb.NewNormalizedUsername(s).String(), nil
+	}
+
+	// TODO: this fails for http and https right now (see CORE-2968).
+	socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertion(s)
+	if isSocialAssertion {
+		return socialAssertion.String(), nil
+	}
+
+	if expr, err := externals.AssertionParseAndOnly(s); err == nil {
+		// If the expression only contains a single url, make sure
+		// it's not a just considered a single keybase username.  If
+		// it is, then some non-username slipped into the default
+		// "keybase" case and should be considered an error.
+		urls := expr.CollectUrls(nil)
+		if len(urls) == 1 && urls[0].IsKeybase() {
+			return "", NoSuchUserError{s}
+		}
+
+		// Normalize and return.  Ideally `AssertionParseAndOnly`
+		// would normalize for us, but that doesn't work yet, so for
+		// now we'll just lower-case.  This will incorrectly lower
+		// case http/https/web assertions, as well as case-sensitive
+		// social assertions in AND expressions.  TODO: see CORE-2967.
+		return strings.ToLower(s), nil
+	}
+
+	return "", BadTLFNameError{s}
+}
+
+// NoSuchNameError indicates that the user tried to access a
+// subdirectory entry that doesn't exist.
+type NoSuchNameError struct {
+	Name string
+}
+
+// Error implements the error interface for NoSuchNameError
+func (e NoSuchNameError) Error() string {
+	return fmt.Sprintf("%s doesn't exist", e.Name)
+}
+
+// BadTLFNameError indicates a top-level folder name that has an
+// incorrect format.
+type BadTLFNameError struct {
+	Name string
+}
+
+// Error implements the error interface for BadTLFNameError.
+func (e BadTLFNameError) Error() string {
+	return fmt.Sprintf("TLF name %s is in an incorrect format", e.Name)
+}
+
+// TlfNameNotCanonical indicates that a name isn't a canonical, and
+// that another (not necessarily canonical) name should be tried.
+type TlfNameNotCanonical struct {
+	Name, NameToTry string
+}
+
+func (e TlfNameNotCanonical) Error() string {
+	return fmt.Sprintf("TLF name %s isn't canonical: try %s instead",
+		e.Name, e.NameToTry)
+}
+
+// NoSuchUserError indicates that the given user couldn't be resolved.
+type NoSuchUserError struct {
+	Input string
+}
+
+// Error implements the error interface for NoSuchUserError
+func (e NoSuchUserError) Error() string {
+	return fmt.Sprintf("%s is not a Keybase user", e.Input)
+}
+
+// ToStatus implements the keybase1.ToStatusAble interface for NoSuchUserError
+func (e NoSuchUserError) ToStatus() keybase1.Status {
+	return keybase1.Status{
+		Name: "NotFound",
+		Code: int(keybase1.StatusCode_SCNotFound),
+		Desc: e.Error(),
+	}
+}

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -114,7 +114,7 @@ func AggRateLimits(rlimits []chat1.RateLimit) (res []chat1.RateLimit) {
 // Only allows usernames from tlfname in the output.
 // This never fails, worse comes to worst it just returns the split of tlfname.
 func ReorderParticipants(udc *UserDeviceCache, uimap *UserInfoMapper, tlfname string, activeList []gregor1.UID) (writerNames []string, readerNames []string, err error) {
-	srcWriterNames, srcReaderNames, _, err := splitAndNormalizeTLFName2(tlfname, false)
+	srcWriterNames, srcReaderNames, _, err := splitAndNormalizeTLFNameCanonicalize(tlfname, false)
 	if err != nil {
 		return writerNames, readerNames, err
 	}
@@ -158,7 +158,7 @@ func ReorderParticipants(udc *UserDeviceCache, uimap *UserInfoMapper, tlfname st
 }
 
 // Drive splitAndNormalizeTLFName with one attempt to follow TlfNameNotCanonical.
-func splitAndNormalizeTLFName2(name string, public bool) (writerNames, readerNames []string, extensionSuffix string, err error) {
+func splitAndNormalizeTLFNameCanonicalize(name string, public bool) (writerNames, readerNames []string, extensionSuffix string, err error) {
 	writerNames, readerNames, extensionSuffix, err = splitAndNormalizeTLFName(name, public)
 	if retryErr, retry := err.(TlfNameNotCanonical); retry {
 		return splitAndNormalizeTLFName(retryErr.NameToTry, public)

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -50,6 +50,24 @@ func (v conversationInfoListView) show(g *libkb.GlobalContext) error {
 
 type conversationListView []chat1.ConversationLocal
 
+// Make a name that looks like a tlfname but is sorted by activity and missing myUsername.
+func (v conversationListView) convName(g *libkb.GlobalContext, conv chat1.ConversationLocal, myUsername string) string {
+	convName := strings.Join(v.without(g, conv.Info.WriterNames, myUsername), ",")
+	if len(conv.Info.ReaderNames) > 0 {
+		convName += "#" + strings.Join(v.without(g, conv.Info.ReaderNames, myUsername), ",")
+	}
+	return convName
+}
+
+func (v conversationListView) without(g *libkb.GlobalContext, slice []string, el string) (res []string) {
+	for _, x := range slice {
+		if x != el {
+			res = append(res, x)
+		}
+	}
+	return res
+}
+
 func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, showDeviceName bool) error {
 	if len(v) == 0 {
 		return nil
@@ -87,18 +105,6 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 				},
 			})
 			continue
-		}
-
-		participants := conv.Info.Usernames
-
-		if len(participants) > 1 {
-			var withoutMe []string
-			for _, p := range participants {
-				if p != myUsername {
-					withoutMe = append(withoutMe, p)
-				}
-			}
-			participants = withoutMe
 		}
 
 		unread := "*"
@@ -153,7 +159,7 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 			},
 			flexibletable.Cell{
 				Alignment: flexibletable.Left,
-				Content:   flexibletable.MultiCell{Sep: ",", Items: participants},
+				Content:   flexibletable.SingleCell{Item: v.convName(g, conv, myUsername)},
 			},
 			flexibletable.Cell{
 				Frame:     [2]string{"[", "]"},

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -54,7 +54,7 @@ type conversationListView []chat1.ConversationLocal
 func (v conversationListView) convName(g *libkb.GlobalContext, conv chat1.ConversationLocal, myUsername string) string {
 	convName := strings.Join(v.without(g, conv.Info.WriterNames, myUsername), ",")
 	if len(conv.Info.ReaderNames) > 0 {
-		convName += "#" + strings.Join(v.without(g, conv.Info.ReaderNames, myUsername), ",")
+		convName += "#" + strings.Join(conv.Info.ReaderNames, ",")
 	}
 	return convName
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -414,12 +414,13 @@ type UnreadFirstNumLimit struct {
 }
 
 type ConversationInfoLocal struct {
-	Id         ConversationID       `codec:"id" json:"id"`
-	Triple     ConversationIDTriple `codec:"triple" json:"triple"`
-	TlfName    string               `codec:"tlfName" json:"tlfName"`
-	TopicName  string               `codec:"topicName" json:"topicName"`
-	Visibility TLFVisibility        `codec:"visibility" json:"visibility"`
-	Usernames  []string             `codec:"usernames" json:"usernames"`
+	Id          ConversationID       `codec:"id" json:"id"`
+	Triple      ConversationIDTriple `codec:"triple" json:"triple"`
+	TlfName     string               `codec:"tlfName" json:"tlfName"`
+	TopicName   string               `codec:"topicName" json:"topicName"`
+	Visibility  TLFVisibility        `codec:"visibility" json:"visibility"`
+	WriterNames []string             `codec:"writerNames" json:"writerNames"`
+	ReaderNames []string             `codec:"readerNames" json:"readerNames"`
 }
 
 type ConversationLocal struct {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -522,11 +522,14 @@ func (h *chatLocalHandler) localizeConversation(
 		return chat1.ConversationLocal{}, err
 	}
 
-	conversationLocal.Info.Usernames = utils.ReorderParticipants(
+	conversationLocal.Info.WriterNames, conversationLocal.Info.ReaderNames, err = utils.ReorderParticipants(
 		h.udc,
 		uimap,
 		conversationLocal.Info.TlfName,
 		conversationRemote.Metadata.ActiveList)
+	if err != nil {
+		return chat1.ConversationLocal{}, fmt.Errorf("error reordering participants: %v", err.Error())
+	}
 
 	// verify Conv matches ConversationIDTriple in MessageClientHeader
 	if !conversationRemote.Metadata.IdTriple.Eq(conversationLocal.Info.Triple) {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -152,8 +152,9 @@ protocol local {
     string tlfName;
     string topicName;
     TLFVisibility visibility;
-    // List of usernames, sometimes sorted by activity.
-    array<string> usernames;
+    // Lists of usernames, optionally sorted by activity.
+    array<string> writerNames;
+    array<string> readerNames;
   }
 
   record ConversationLocal {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -152,7 +152,7 @@ protocol local {
     string tlfName;
     string topicName;
     TLFVisibility visibility;
-    // Lists of usernames, optionally sorted by activity.
+    // Lists of usernames, always complete, optionally sorted by activity.
     array<string> writerNames;
     array<string> readerNames;
   }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -420,7 +420,8 @@ export type ConversationInfoLocal = {
   tlfName: string,
   topicName: string,
   visibility: TLFVisibility,
-  usernames?: ?Array<string>,
+  writerNames?: ?Array<string>,
+  readerNames?: ?Array<string>,
 }
 
 export type ConversationLocal = {

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -457,7 +457,14 @@
             "type": "array",
             "items": "string"
           },
-          "name": "usernames"
+          "name": "writerNames"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "readerNames"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -420,7 +420,8 @@ export type ConversationInfoLocal = {
   tlfName: string,
   topicName: string,
   visibility: TLFVisibility,
-  usernames?: ?Array<string>,
+  writerNames?: ?Array<string>,
+  readerNames?: ?Array<string>,
 }
 
 export type ConversationLocal = {


### PR DESCRIPTION
Part 2 of https://github.com/keybase/client/pull/4699

Support chat tlfs with read-only members.

`chat/utils/kbfs.go` is stuff copied from [libkbfs](https://github.com/keybase/kbfs/tree/master/libkbfs).

```
(as gil) $ kbc ls
[1] * frank,harry                   [frank 5m] frank
[2] * frank,blarp#bozo@hackernews    [gil 11m] gil
[3] * blarp,frank#bozo@hackerne... [blarp 33m] start
[4] * zane,frank#bozo@hackernew...  [zane 39m] start
[5] * zane#gil                      [zane 41m] start
```

r? @mmaxim 