### PR TITLE
Add markdown parser. Use that parser to display pretty error messages…

### DIFF
--- a/shared/login/register/dumb.js
+++ b/shared/login/register/dumb.js
@@ -2,9 +2,11 @@
 import Passphrase from './passphrase/dumb'
 import PaperKey from './paper-key/dumb'
 import CodePage from './code-page/dumb'
+import ErrorView from './error/dumb'
 
 export default {
   Passphrase,
   PaperKey,
   CodePage,
+  ErrorView,
 }

--- a/shared/login/register/error/dumb.js
+++ b/shared/login/register/error/dumb.js
@@ -1,0 +1,20 @@
+// @flow
+import Render from './index.render'
+import type {DumbComponentMap} from '../../../constants/types/more'
+
+const baseMock = {
+  onBack: () => console.log('onBack'),
+  error: {
+    code: 901,
+    desc: "You don't have a public key; try `keybase pgp select` or `keybase pgp import` if you have a key; or `keybase pgp gen` if you don't",
+  },
+}
+
+const dumbComponentMap: DumbComponentMap<Render> = {
+  component: Render,
+  mocks: {
+    'Normal': baseMock,
+  },
+}
+
+export default dumbComponentMap

--- a/shared/login/register/error/index.render.desktop.js
+++ b/shared/login/register/error/index.render.desktop.js
@@ -2,6 +2,7 @@
 import Container from '../../forms/container.desktop'
 import React from 'react'
 import openURL from '../../../util/open-url'
+import parseMarkdown from '../../../util/simple-md'
 import type {Props} from './index.render'
 import type {RPCError} from '../../../constants/types/flow-types'
 import {ConstantsStatusCode} from '../../../constants/types/flow-types'
@@ -58,7 +59,9 @@ const renderError = (error: RPCError) => {
     case ConstantsStatusCode.sckeynotfound:
       return (
         <p>
-          <Text type='Body'>Your PGP keychain has multiple keys installed, and we're not sure which one to use to provision your account. Please run <Text type='Terminal'>keybase login</Text> on the command line to continue.</Text>
+          {error.desc ? parseMarkdown(error.desc) : (
+            <Text type='Body'>Your PGP keychain has multiple keys installed, and we're not sure which one to use to provision your account. Please run <Text type='Terminal'>keybase login</Text> on the command line to continue.</Text>
+          )}
         </p>
       )
     case ConstantsStatusCode.scnotfound:

--- a/shared/util/simple-md.js
+++ b/shared/util/simple-md.js
@@ -1,0 +1,78 @@
+// @flow
+
+import {Text} from '../common-adapters'
+import React from 'react'
+import * as Immutable from 'immutable'
+
+const {List} = Immutable
+
+const openToClosePair = {
+  '`': '`',
+}
+
+const openToTag = {
+  '`': {Component: Text, props: {type: 'Terminal'}},
+}
+
+type TagStack = List<{
+  type: 'component',
+  componentInfo: {Component: ReactClass<*>, props: Object},
+  textSoFar: string,
+  closingTag: string,
+} | {type: 'plainString', textSoFar: string}>
+
+function _parseRecursive (text: string, tagStack: TagStack, key: number, elements: List<React$Element<*> | string>): Array<React$Element<*>> {
+  if (text.length === 0) {
+    if (tagStack.count() === 1) {
+      return elements.push(tagStack.last().textSoFar).toJS()
+    } else if (tagStack.count() > 1) {
+      console.warn('invalid markdown trying my best:', text)
+    } else {
+      return elements.toJS()
+    }
+  }
+
+  const topTag = tagStack.last()
+  const firstChar = text[0]
+  const restText = text.slice(1)
+
+  if (topTag && topTag.type === 'component' && topTag.closingTag === firstChar) {
+    const {textSoFar, componentInfo: {Component, props}} = topTag
+    return _parseRecursive(restText, tagStack.pop(), key + 1, elements.push(<Component key={key} {...props}>{textSoFar}</Component>))
+  } else if (openToTag[firstChar]) {
+    return _parseRecursive(
+      restText,
+      (topTag.type === 'plainString' ? tagStack.pop() : tagStack).push({
+        type: 'component',
+        componentInfo: openToTag[firstChar],
+        closingTag: openToClosePair[firstChar],
+        textSoFar: '',
+      }),
+      key,
+      topTag.type === 'plainString' ? elements.push(topTag.textSoFar) : elements
+    )
+  } else if (topTag) {
+    return _parseRecursive(
+      restText,
+      // $FlowIssue
+      tagStack.pop().push({...topTag, textSoFar: topTag.textSoFar + firstChar}),
+      key,
+      elements
+    )
+  } else {
+    return _parseRecursive(
+      restText,
+      tagStack.push({
+        type: 'plainString',
+        textSoFar: firstChar,
+      }),
+      key,
+      elements
+    )
+  }
+}
+
+function parseMarkdown (text: string): React$Element<*> {
+  return <Text type='Body'>{_parseRecursive(text, new List(), 0, new List())}</Text>
+}
+export default parseMarkdown


### PR DESCRIPTION
… from service

@keybase/react-hackers 

fixes the error screen on DESKTOP-1972.

The problem was that we had hardcoded the error message. The service was telling us the right error message:

> You don't have a public key; try `keybase pgp select` or `keybase pgp import` if you have a key; or `keybase pgp gen` if you don't

but our hardcoded error message wasn't the right one.

This fixes it by just showing the error message we get from the service. We parse it so it matches our styles (simple markdown parsing).

Will update the rest of `error/index.render.*` if this looks good
