### PR TITLE
Fix error handling

### DIFF
--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -85,7 +85,7 @@ function * _onUpdatePGPSettings (): SagaGenerator<any, any> {
     const {hasServerKeys} = yield call(accountHasServerKeysRpcPromise)
     yield put(_onUpdatedPGPSettings(hasServerKeys))
   } catch (error) {
-    yield put({type: Constants.onUpdatePassphraseError, payload: {error: error.message}})
+    yield put({type: Constants.onUpdatePassphraseError, payload: {error}})
   }
 }
 
@@ -103,7 +103,7 @@ function * _onSubmitNewEmail (): SagaGenerator<any, any> {
     yield put({type: Constants.loadedSettings, payload: userSettings})
     yield put(navigateUp())
   } catch (error) {
-    yield put({type: Constants.onUpdateEmailError, payload: {error: error.message}})
+    yield put({type: Constants.onUpdateEmailError, payload: {error}})
   }
 }
 
@@ -124,7 +124,7 @@ function * _onSubmitNewPassphrase (): SagaGenerator<any, any> {
     })
     yield put(navigateUp())
   } catch (error) {
-    yield put({type: Constants.onUpdatePassphraseError, payload: {error: error.message}})
+    yield put({type: Constants.onUpdatePassphraseError, payload: {error}})
   }
 }
 

--- a/shared/constants/settings.js
+++ b/shared/constants/settings.js
@@ -111,7 +111,7 @@ export type PassphraseState = {
   newPassphrase: HiddenString,
   newPassphraseConfirm: HiddenString,
   showTyping: boolean,
-  errorMessage: ?HiddenString,
+  error: ?Error,
   newPassphraseError: ?HiddenString,
   newPassphraseConfirmError: ?HiddenString,
   hasPGPKeyOnServer: ?boolean,
@@ -121,7 +121,7 @@ export type PassphraseState = {
 export type EmailState = {
   emails: Array<Email>,
   newEmail: string,
-  errorMessage: ?string,
+  error: ?Error,
 }
 
 export type State = {

--- a/shared/global-errors/container.js
+++ b/shared/global-errors/container.js
@@ -7,8 +7,7 @@ import type {TypedState} from '../constants/reducer'
 
 export default connect(
   (state: TypedState) => ({
-    summary: state.config.globalError && state.config.globalError.summary,
-    details: state.config.globalError && state.config.globalError.details,
+    error: state.config.globalError,
   }),
   (dispatch: any) => ({
     onDismiss: () => dispatch({type: globalErrorDismiss}),

--- a/shared/global-errors/index.desktop.js
+++ b/shared/global-errors/index.desktop.js
@@ -21,13 +21,13 @@ class GlobalError extends Component<void, Props, State> {
 
     this.state = {
       size: 'Closed',
-      cachedSummary: props.summary,
-      cachedDetails: props.details,
+      cachedSummary: this._summaryForError(props.error),
+      cachedDetails: this._detailsForError(props.error),
     }
   }
 
   componentWillMount () {
-    this._resetError(!!this.props.summary)
+    this._resetError(!!this.props.error)
   }
 
   _onExpandClick = () => {
@@ -47,20 +47,27 @@ class GlobalError extends Component<void, Props, State> {
     if (newError) {
       this.timerID = this.props.setTimeout(() => {
         this.props.onDismiss()
-      }, 3000)
+      }, 5000)
     }
   }
 
+  _summaryForError (err: ?Error): ?string {
+    return err ? err.message : null
+  }
+
+  _detailsForError (err: ?Error): ?string {
+    return err ? err.stack : null
+  }
+
   componentWillReceiveProps (nextProps: Props) {
-    if (nextProps.summary !== this.props.summary ||
-      nextProps.details !== this.props.details) {
+    if (nextProps.error !== this.props.error) {
       this.props.setTimeout(() => {
         this.setState({
-          cachedSummary: nextProps.summary,
-          cachedDetails: nextProps.details,
+          cachedSummary: this._summaryForError(nextProps.error),
+          cachedDetails: this._detailsForError(nextProps.error),
         })
-      }, nextProps.summary ? 0 : 3000) // if its set, do it immediately, if its cleared set it in a bit
-      this._resetError(!!nextProps.summary)
+      }, nextProps.error ? 0 : 3000) // if its set, do it immediately, if its cleared set it in a bit
+      this._resetError(!!nextProps.error)
     }
   }
 

--- a/shared/global-errors/index.js.flow
+++ b/shared/global-errors/index.js.flow
@@ -2,8 +2,7 @@
 import {Component} from 'react'
 
 export type Props = {
-  summary: ?string,
-  details: ?string,
+  error: ?Error,
   onDismiss: () => void,
   setTimeout: (cb: () => void, delay: number) => any,
   clearTimeout: (id: any) => void,

--- a/shared/global-errors/index.native.js
+++ b/shared/global-errors/index.native.js
@@ -21,13 +21,13 @@ class GlobalError extends Component<void, Props, State> {
 
     this.state = {
       size: 'Closed',
-      cachedSummary: props.summary,
-      cachedDetails: props.details,
+      cachedSummary: this._summaryForError(props.error),
+      cachedDetails: this._detailsForError(props.error),
     }
   }
 
   componentWillMount () {
-    this._resetError(!!this.props.summary)
+    this._resetError(!!this.props.error)
   }
 
   _onExpandClick = () => {
@@ -51,16 +51,23 @@ class GlobalError extends Component<void, Props, State> {
     }
   }
 
+  _summaryForError (err: ?Error): ?string {
+    return err ? err.message : null
+  }
+
+  _detailsForError (err: ?Error): ?string {
+    return err ? err.stack : null
+  }
+
   componentWillReceiveProps (nextProps: Props) {
-    if (nextProps.summary !== this.props.summary ||
-      nextProps.details !== this.props.details) {
+    if (nextProps.error !== this.props.error) {
       this.props.setTimeout(() => {
         this.setState({
-          cachedSummary: nextProps.summary,
-          cachedDetails: nextProps.details,
+          cachedSummary: this._summaryForError(nextProps.error),
+          cachedDetails: this._detailsForError(nextProps.error),
         })
-      }, nextProps.summary ? 0 : 3000) // if its set, do it immediately, if its cleared set it in a bit
-      this._resetError(!!nextProps.summary)
+      }, nextProps.error ? 0 : 3000) // if its set, do it immediately, if its cleared set it in a bit
+      this._resetError(!!nextProps.error)
     }
   }
 

--- a/shared/reducers/config.js
+++ b/shared/reducers/config.js
@@ -7,10 +7,7 @@ import type {Action} from '../constants/types/flux'
 import type {Config, GetCurrentStatusRes, ExtendedStatus} from '../constants/types/flow-types'
 
 export type ConfigState = {
-  globalError: ?{
-    summary: ?string,
-    details: ?string,
-  },
+  globalError: ?Error,
   status: ?GetCurrentStatusRes,
   config: ?Config,
   extendedConfig: ?ExtendedStatus,
@@ -26,10 +23,7 @@ export type ConfigState = {
 }
 
 const initialState: ConfigState = {
-  globalError: {
-    summary: null,
-    details: null,
-  },
+  globalError: null,
   status: null,
   config: null,
   extendedConfig: null,
@@ -133,19 +127,13 @@ export default function (state: ConfigState = initialState, action: Action): Con
     case Constants.globalErrorDismiss: {
       return {
         ...state,
-        globalError: {
-          summary: null,
-          details: null,
-        },
+        globalError: null,
       }
     }
     case Constants.globalError: {
       return {
         ...state,
-        globalError: {
-          summary: action.payload.summary,
-          details: action.payload.details,
-        },
+        globalError: action.payload,
       }
     }
 

--- a/shared/reducers/settings.js
+++ b/shared/reducers/settings.js
@@ -20,13 +20,13 @@ const initialState: State = {
   email: {
     emails: [],
     newEmail: '',
-    errorMessage: null,
+    error: null,
   },
   passphrase: {
     newPassphrase: new HiddenString(''),
     newPassphraseConfirm: new HiddenString(''),
     showTyping: false,
-    errorMessage: null,
+    error: null,
     newPassphraseError: null,
     newPassphraseConfirmError: null,
     hasPGPKeyOnServer: null,
@@ -127,7 +127,7 @@ function reducer (state: State = initialState, action: Actions): State {
           ...state.passphrase,
           newPassphrase: action.payload.passphrase,
           canSave: _canSave(action.payload.passphrase, state.passphrase.newPassphraseConfirm, state.passphrase.hasPGPKeyOnServer !== null),
-          errorMessage: null,
+          error: null,
         },
       }
     case Constants.onChangeNewPassphraseConfirm:
@@ -137,7 +137,7 @@ function reducer (state: State = initialState, action: Actions): State {
           ...state.passphrase,
           newPassphraseConfirm: action.payload.passphrase,
           canSave: _canSave(state.passphrase.newPassphrase, action.payload.passphrase, state.passphrase.hasPGPKeyOnServer !== null),
-          errorMessage: null,
+          error: null,
         },
       }
     case Constants.onUpdatedPGPSettings:
@@ -153,7 +153,7 @@ function reducer (state: State = initialState, action: Actions): State {
         ...state,
         passphrase: {
           ...state.passphrase,
-          errorMessage: action.payload.error,
+          error: action.payload.error,
         },
       }
     case Constants.onChangeShowPassphrase:
@@ -170,7 +170,7 @@ function reducer (state: State = initialState, action: Actions): State {
         email: {
           ...state.email,
           newEmail: action.payload.email,
-          errorMessage: null,
+          error: null,
         },
       }
     case Constants.onUpdateEmailError:
@@ -178,7 +178,7 @@ function reducer (state: State = initialState, action: Actions): State {
         ...state,
         email: {
           ...state.email,
-          errorMessage: action.payload.error,
+          error: action.payload.error,
         },
       }
   }

--- a/shared/settings/email/container.js
+++ b/shared/settings/email/container.js
@@ -22,14 +22,14 @@ class UserEmailContainer extends Component<void, Props, void> {
 
 export default connect(
   (state: TypedState, ownProps: {}) => {
-    const {emails, errorMessage, newEmail} = state.settings.email
+    const {emails, error, newEmail} = state.settings.email
     if (emails.length > 0) {
       const email = emails[0].email
       return {
         email,
         isVerified: emails[0].isVerified,
         edited: newEmail && newEmail !== email,
-        errorMessage,
+        error,
       }
     }
     return {}

--- a/shared/settings/email/index.desktop.js
+++ b/shared/settings/email/index.desktop.js
@@ -20,7 +20,7 @@ function VerifiedText ({isVerified, style}: {isVerified: boolean, style?: Object
 }
 
 function UpdateEmail (props: Props) {
-  const error = props.errorMessage ? {message: props.errorMessage, type: 'error'} : null
+  const error = props.error ? {message: props.error.message, type: 'error'} : null
   return (
     <StandardScreen
       onBack={props.onBack}
@@ -29,9 +29,9 @@ function UpdateEmail (props: Props) {
         floatingLabelText='Email'
         value={props.email}
         onChangeText={props.onChangeNewEmail}
-        textStyle={{height: undefined}} />
+        textStyle={{height: undefined}} style={{width: 400}} />
       {!props.edited &&
-        <VerifiedText isVerified={props.isVerified} style={{marginTop: 2}} />
+        <VerifiedText isVerified={props.isVerified} style={{marginTop: 2, justifyContent: 'center'}} />
       }
       <Button
         style={{alignSelf: 'center', marginTop: globalMargins.medium}}

--- a/shared/settings/email/index.js.flow
+++ b/shared/settings/email/index.js.flow
@@ -5,7 +5,7 @@ export type Props = {
   email: ?string,
   isVerified: boolean,
   edited: boolean,
-  errorMessage?: ?string,
+  error?: ?Error,
   onBack: () => void,
   onChangeNewEmail: (nextEmail: string) => void,
   onSave: () => void,

--- a/shared/settings/passphrase/container.js
+++ b/shared/settings/passphrase/container.js
@@ -30,7 +30,7 @@ export default connect(
     newPassphrase: state.settings.passphrase.newPassphrase.stringValue(),
     newPassphraseConfirm: state.settings.passphrase.newPassphraseConfirm.stringValue(),
     showTyping: state.settings.passphrase.showTyping,
-    errorMessage: state.settings.passphrase.errorMessage ? state.settings.passphrase.errorMessage.stringValue() : null,
+    error: state.settings.passphrase.error,
     newPassphraseError: state.settings.passphrase.newPassphraseError ? state.settings.passphrase.newPassphraseError.stringValue() : null,
     newPassphraseConfirmError: state.settings.passphrase.newPassphraseConfirmError ? state.settings.passphrase.newPassphraseConfirmError.stringValue() : null,
     hasPGPKeyOnServer: state.settings.passphrase.hasPGPKeyOnServer,
@@ -45,4 +45,3 @@ export default connect(
     onSave: () => dispatch(onSubmitNewPassphrase()),
   })
 )(PassphraseContainer)
-

--- a/shared/settings/passphrase/index.desktop.js
+++ b/shared/settings/passphrase/index.desktop.js
@@ -7,13 +7,13 @@ import type {Props} from './index'
 
 function UpdatePassphrase (props: Props) {
   const inputType = props.showTyping ? 'passwordVisible' : 'password'
-  const error = props.errorMessage
-    ? {message: props.errorMessage, type: 'error'}
+  const notification = props.error
+    ? {message: props.error.message, type: 'error'}
     : props.hasPGPKeyOnServer ? {message: 'Forgot your passphrase?  That\'s ok, but you will need to make a new PGP key, assuming you don\'t have a backup of your old private one.', type: 'error'} : null
   return (
     <StandardScreen
       onBack={props.onBack}
-      notification={error} >
+      notification={notification} >
       <Input
         floatingLabelText='New passphrase'
         value={props.newPassphrase}

--- a/shared/settings/passphrase/index.js.flow
+++ b/shared/settings/passphrase/index.js.flow
@@ -8,7 +8,7 @@ export type Props = {
   newPassphrase: string,
   newPassphraseConfirm: string,
   showTyping: boolean,
-  errorMessage?: ?string,
+  error?: ?Error,
   newPassphraseError: ?string,
   newPassphraseConfirmError: ?string,
   hasPGPKeyOnServer: boolean,

--- a/shared/store/configure-store.js
+++ b/shared/store/configure-store.js
@@ -12,6 +12,7 @@ import {enableStoreLogging, enableActionLogging, closureStoreCheck} from '../loc
 import {globalError} from '../constants/config'
 import {isMobile} from '../constants/platform'
 import {requestIdleCallback} from '../util/idle-callback'
+import {convertToError} from '../util/errors'
 
 // Transform objects from Immutable on printing
 const objToJS = state => {
@@ -42,31 +43,11 @@ for (const method in console) {
 
 let theStore: Store
 
-const errorToPayload = (error: any): {summary: ?string, details: ?string} => {
-  let summary
-  let details
-
-  if (error.hasOwnProperty('desc') && error.hasOwnProperty('code')) {
-    summary = `Rpc error: ${error.desc}`
-    details = `Code: ${error.code}`
-  } else {
-    if (error.message && error.message.length < 50) {
-      summary = `Throw error: ${error.message}`
-      details = error.stack
-    } else {
-      summary = `Throw error: ${error.name}`
-      details = `${error.message}. ${error.stack}`
-    }
-  }
-
-  return {summary, details}
-}
-
 const crashHandler = (error) => {
   if (theStore) {
     theStore.dispatch({
       type: globalError,
-      payload: errorToPayload(error),
+      payload: convertToError(error),
     })
   } else {
     console.warn('Got crash before store created?', error)

--- a/shared/util/errors.js
+++ b/shared/util/errors.js
@@ -1,0 +1,23 @@
+// @flow
+
+class RPCError extends Error {
+  code: number;
+
+  constructor (message: string, code: number) {
+    super(message || 'Unknown RPC Error')
+    this.code = code
+  }
+}
+
+// convertToError converts an RPC error object (or any object) into an Error
+export function convertToError (err: Object): Error {
+  if (err instanceof Error) {
+    return err
+  }
+
+  if (err.hasOwnProperty('desc') && err.hasOwnProperty('code')) {
+    return new RPCError(err.desc, err.code)
+  }
+
+  return new Error('Unknown error: ${err}')
+}


### PR DESCRIPTION
We have a few different ways of storing error information. We should use the builtin javascript Error type.

This also converts the RPC error object (code/desc) to an `RPCError` subtype in the engine (we might want to open ticket for RPC library to do this instead). This is needed for the saga error handling to work properly.

Going forward, please don't create custom ways of storing error information or convert Errors into other custom types. This also makes debugging easier.