### PR TITLE
Fix remote component resizing

### DIFF
--- a/desktop/renderer/remote-component-helper.js
+++ b/desktop/renderer/remote-component-helper.js
@@ -7,7 +7,7 @@ export function autoResize () {
   // This only works when I delay a frame, unclear what the solution is but this seems fine for now
   setTimeout(() => {
     try {
-      const element = window.document.getElementById('root')
+      const element = window.document.getElementById('RemoteComponentRoot').firstChild
       const browserWindow = remote.getCurrentWindow()
       if (element && (element.scrollHeight != null) && (element.offsetTop != null) && !browserWindow.isDestroyed()) {
         // try 5 times to get a stable window size, doesn't seem like a better way to do this...

--- a/desktop/renderer/remote-component-loader.js
+++ b/desktop/renderer/remote-component-loader.js
@@ -156,7 +156,7 @@ class RemoteComponentLoader extends Component<void, any, State> {
       return <div />
     }
     return (
-      <div style={styles.container}>
+      <div id='RemoteComponentRoot' style={styles.container}>
         <Root store={this.store}>
           <this.ComponentClass {...this.state.props} />
         </Root>
@@ -168,6 +168,7 @@ class RemoteComponentLoader extends Component<void, any, State> {
 const styles = {
   container: {
     overflow: 'hidden',
+    display: 'block',
     backgroundColor: globalColors.white,
   },
   loading: {

--- a/desktop/renderer/remote-pinentry.js
+++ b/desktop/renderer/remote-pinentry.js
@@ -34,7 +34,7 @@ class RemotePinentry extends Component<void, Props, void> {
           return (
             <RemoteComponent
               title='Pinentry'
-              windowsOpts={{width: 500, height: 260}}
+              windowsOpts={{width: 440, height: 210}}
               waitForState={true}
               onRemoteClose={() => this.props.onCancel(sid)}
               component='pinentry'

--- a/shared/pinentry/index.render.desktop.js
+++ b/shared/pinentry/index.render.desktop.js
@@ -102,7 +102,7 @@ export default class PinentryRender extends Component<DefaultProps, Props, State
     })
 
     return (
-      <Box style={{...globalStyles.flexBoxColumn, backgroundColor: globalColors.white, marginBottom: globalMargins.medium}}>
+      <Box style={{...globalStyles.flexBoxColumn, backgroundColor: globalColors.white, paddingBottom: globalMargins.medium}}>
         <Header icon={true} title='' onClose={() => this.props.onCancel()} />
         <Box style={{...globalStyles.flexBoxColumn, paddingLeft: 30, paddingRight: 30}}>
           <Text type='Body' style={{textAlign: 'center'}}>{this.props.prompt}</Text>


### PR DESCRIPTION
@keybase/react-hackers Fixes component resizing.

I think it broke because we made the root div a flex box, so the height measurements weren't accurate. I think you have to have a block as the parent to get the measurements you want. This sets the remotecomponent div inside root as a block and the first child (the content of the remote component) as the measuring target.
