### PR TITLE
Use a type-safe proxy to wrap the type-unsafe external keystore

### DIFF
--- a/go/bind/keystore_android.go
+++ b/go/bind/keystore_android.go
@@ -5,12 +5,12 @@
 
 package keybase
 
-// import "github.com/keybase/client/go/libkb"
+import "github.com/keybase/client/go/libkb"
 
-// ExternalKeyStore - We have to duplicate the interface defined in libkb.ExternalKeyStore
+// UnsafeExternalKeyStore - We have to duplicate the interface defined in libkb.UnsafeExternalKeyStore
 // Otherwise we get an undefined param error when we use this as an argument
 // in an exported func
-type ExternalKeyStore interface {
+type UnsafeExternalKeyStore interface {
 	RetrieveSecret(serviceName string, key string) ([]byte, error)
 	StoreSecret(serviceName string, key string, secret []byte) error
 	ClearSecret(serviceName string, key string) error
@@ -18,12 +18,7 @@ type ExternalKeyStore interface {
 	SetupKeyStore(serviceName string, key string) error
 }
 
-func SetGlobalExternalKeyStore(s ExternalKeyStore) {
+func SetGlobalExternalKeyStore(s UnsafeExternalKeyStore) {
 	// TODO: Gross! can we fix this?
-	//
-	// Commented out by MNK on 10/19/2016 -- I don't know how to get
-	// Android to start compiling without a fair amount of work here,
-	// so let's comment it out for now.
-	//
-	// libkb.SetGlobalExternalKeyStore(libkb.ExternalKeyStore(s))
+	libkb.SetGlobalExternalKeyStore(libkb.UnsafeExternalKeyStore(s))
 }

--- a/go/libkb/secret_store_external.go
+++ b/go/libkb/secret_store_external.go
@@ -59,7 +59,7 @@ func (w TypeSafeExternalKeyStoreProxy) GetUsersWithStoredSecretsMsgPack(serviceN
 }
 
 func (w TypeSafeExternalKeyStoreProxy) SetupKeyStore(serviceName string, key string) error {
-	return w.SetupKeyStore(serviceName, key)
+	return w.UnsafeExternalKeyStore.SetupKeyStore(serviceName, key)
 }
 
 // externalKeyStore is the reference to some external key store

--- a/react-native/android/app/src/main/java/io/keybase/ossifrage/KeyStore.java
+++ b/react-native/android/app/src/main/java/io/keybase/ossifrage/KeyStore.java
@@ -26,10 +26,10 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 import go.keybase.Keybase;
-import go.keybase.ExternalKeyStore;
+import go.keybase.UnsafeExternalKeyStore;
 import io.keybase.ossifrage.keystore.KeyStoreHelper;
 
-public class KeyStore implements ExternalKeyStore {
+public class KeyStore implements UnsafeExternalKeyStore {
     private final Context context;
     private final SharedPreferences prefs;
     private final java.security.KeyStore ks;

--- a/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
+++ b/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
@@ -14,8 +14,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import go.keybase.Keybase;
+
 import static go.keybase.Keybase.readB64;
-import static go.keybase.Keybase.reset;
 import static go.keybase.Keybase.writeB64;
 import static go.keybase.Keybase.version;
 
@@ -108,7 +109,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
     @ReactMethod
     public void reset() {
       try {
-          reset();
+          Keybase.reset();
       } catch (Exception e) {
           e.printStackTrace();
       }


### PR DESCRIPTION
r? @maxtaco 