### PR TITLE
Add babel-plugin-transform-builtin-extend so extending Error works

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -74,6 +74,7 @@
     "babel-loader": "6.2.5",
     "babel-plugin-react-transform": "2.0.2",
     "babel-plugin-transform-runtime": "6.15.0",
+    "babel-plugin-transform-builtin-extend": "1.1.0",
     "babel-preset-es2015": "6.16.0",
     "babel-preset-react": "6.16.0",
     "babel-preset-stage-1": "6.16.0",

--- a/desktop/webpack.config.base.js
+++ b/desktop/webpack.config.base.js
@@ -17,7 +17,7 @@ module.exports = {
       exclude: /(node_modules|\/dist\/)/,
       query: {
         cacheDirectory: true,
-        plugins: ['transform-runtime', 'react-hot-loader/babel'],
+        plugins: ['transform-runtime', 'react-hot-loader/babel', ['babel-plugin-transform-builtin-extend', {globals: ['Error']}]],
         presets: ['es2015', 'stage-1', 'react'],
       },
     }, {


### PR DESCRIPTION
http://stackoverflow.com/questions/30402287/extended-errors-do-not-have-message-or-stack-trace

:eyeglasses: @keybase/react-hackers @gabriel 
