### PR TITLE
small test change that catches the CORE-3964 bug

### DIFF
--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -2227,6 +2227,20 @@ func TestProvisionerSecretStore(t *testing.T) {
 	if err := AssertProvisioned(tcY); err != nil {
 		t.Fatal(err)
 	}
+
+	// On device Y, logout and login. This should tickle Bug3964
+	Logout(tcY)
+	ctx = &Context{
+		ProvisionUI: newTestProvisionUIPassphrase(),
+		LoginUI:     &libkb.TestLoginUI{},
+		LogUI:       tcY.G.UI.GetLogUI(),
+		SecretUI:    userX.NewSecretUI(),
+		GPGUI:       &gpgtestui{},
+	}
+	eng = NewLogin(tcY.G, libkb.DeviceTypeDesktop, userX.Username, keybase1.ClientType_CLI)
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
 }
 
 type testProvisionUI struct {


### PR DESCRIPTION
- Tested that 604e9ecd219f413cf03f3ba50f2ed0e91ef29013 fails with this test expansion, so good! That commit was the commit just before the problem
  was recognized and the triggering PRs were reverted.