### PR TITLE
Cleanup some settings code

### DIFF
--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -22,7 +22,6 @@ import {loginRecoverAccountFromEmailAddressRpc, loginLoginRpc, loginLogoutRpc,
   PassphraseCommonPassphraseType,
 } from '../../constants/types/flow-types'
 import {navigateTo, routeAppend, navigateUp, switchTab} from '../router'
-import {overrideLoggedInTab} from '../../local-debug'
 import {RPCError} from '../../util/errors'
 
 const InputCancelError = {desc: 'Cancel Login', code: ConstantsStatusCode.scinputcanceled}
@@ -51,12 +50,7 @@ export function navBasedOnLoginState (): AsyncAction {
       dispatch(switchTab(loginTab))
     } else {
       if (status.loggedIn) { // logged in
-        if (overrideLoggedInTab) {
-          console.log('Loading overridden logged in tab')
-          dispatch(switchTab(overrideLoggedInTab))
-        } else {
-          dispatch(switchTab(devicesTab))
-        }
+        dispatch(switchTab(devicesTab))
       } else if (status.registered) { // relogging in
         dispatch(getAccounts())
         dispatch(navigateTo(['login'], loginTab))

--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -280,25 +280,12 @@ function * sendInviteSaga (invitesSendAction: InvitesSend): SagaGenerator<any, a
 }
 
 function * refreshNotificationsSaga (): SagaGenerator<any, any> {
-  // If the rpc is fast don't clear it out first
-  const delayThenEmptyTask = yield fork(function * () {
-    yield call(delay, 500)
-    yield put({
-      type: Constants.notificationsRefreshed,
-      payload: {
-        settings: null,
-        unsubscribedFromAll: null,
-      }})
-  })
-
   const json: ?{body: string} = yield call(apiserverGetRpcPromise, {
     param: {
       endpoint: 'account/subscriptions',
       args: [],
     },
   })
-
-  yield cancel(delayThenEmptyTask)
 
   const results: {
     notifications: {

--- a/shared/local-debug.desktop.js
+++ b/shared/local-debug.desktop.js
@@ -20,7 +20,6 @@ let config: {[key:string]: any} = {
   devStoreChangingFunctions: false,
   printOutstandingRPCs: false,
   reactPerf: false,
-  overrideLoggedInTab: null,
   printRoutes: false,
   skipSecondaryDevtools: true,
   initialTabState: {},
@@ -46,7 +45,6 @@ if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) {
   config.devStoreChangingFunctions = true
   config.printOutstandingRPCs = true
   config.reactPerf = false
-  config.overrideLoggedInTab = Tabs.settingsTab
   config.printRoutes = true
   config.initialTabState = {
     [Tabs.loginTab]: [],
@@ -72,7 +70,6 @@ export const {
   forwardLogs,
   isTesting,
   logStatFrequency,
-  overrideLoggedInTab,
   printOutstandingRPCs,
   printRPC,
   printRoutes,

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -21,7 +21,6 @@ let config: {[key: string]: any} = {
   printOutstandingRPCs: false,
   reactPerf: false,
   initialTabState: {},
-  overrideLoggedInTab: null,
   printRoutes: false,
   logStatFrequency: 0,
   actionStatFrequency: 0,
@@ -43,7 +42,6 @@ if (__DEV__ && true) {
     [Tabs.loginTab]: [],
     [Tabs.settingsTab]: ['devMenu', 'dumbSheet'],
   }
-  config.overrideLoggedInTab = Tabs.settingsTab
   config.printRoutes = true
 }
 
@@ -59,7 +57,6 @@ export const {
   devStoreChangingFunctions,
   printOutstandingRPCs,
   reactPerf,
-  overrideLoggedInTab,
   printRoutes,
   logStatFrequency,
   actionStatFrequency,


### PR DESCRIPTION
- Removes overrideLoggedInTab which can cause things the be loaded before being logged in (which is generally bad). Also doesn't feel like we need it.
- Remove delayThenEmptyTask for notifications. Doesn't seem to really do anything and seems unnecessary.