### PR TITLE
default don't allow selection everywhere

### DIFF
--- a/desktop/renderer/style.css
+++ b/desktop/renderer/style.css
@@ -102,6 +102,7 @@ table {
 html {
     box-sizing: border-box;
     cursor: default;
+    -webkit-user-select: none;
 }
 
 *, *:before, *:after {


### PR DESCRIPTION
@keybase/react-hackers extra testing on this one please. This turns off user select at the root level in our css. This stops you from being able to drag and select text in the app
