### PR TITLE
plumb through notify request handler

### DIFF
--- a/go/service/main.go
+++ b/go/service/main.go
@@ -87,6 +87,7 @@ func (d *Service) RegisterProtocols(srv *rpc.Server, xp rpc.Transporter, connID 
 		keybase1.ApiserverProtocol(NewAPIServerHandler(xp, g)),
 		keybase1.PaperprovisionProtocol(NewPaperProvisionHandler(xp, g)),
 		keybase1.RekeyProtocol(NewRekeyHandler2(xp, g, d.rekeyMaster)),
+		keybase1.NotifyFSRequestProtocol(newNotifyFSRequestHandler(xp, g)),
 		keybase1.GregorProtocol(newGregorRPCHandler(xp, g, d.gregor)),
 		chat1.LocalProtocol(newChatLocalHandler(xp, g, d.gregor)),
 	}

--- a/go/service/notify_fs_request.go
+++ b/go/service/notify_fs_request.go
@@ -1,0 +1,50 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package service
+
+import (
+	"errors"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	"golang.org/x/net/context"
+)
+
+type notifyFSRequestHandler struct {
+	*BaseHandler
+	libkb.Contextified
+}
+
+func (h *notifyFSRequestHandler) client() (*keybase1.NotifyFSRequestClient, error) {
+	xp := h.G().ConnectionManager.LookupByClientType(keybase1.ClientType_KBFS)
+	if xp == nil {
+		return nil, errors.New("KBFS client wasn't found")
+	}
+	return &keybase1.NotifyFSRequestClient{
+		Cli: rpc.NewClient(*xp, libkb.ErrorUnwrapper{}),
+	}, nil
+}
+
+func newNotifyFSRequestHandler(xp rpc.Transporter, g *libkb.GlobalContext) *notifyFSRequestHandler {
+	return &notifyFSRequestHandler{
+		BaseHandler:  NewBaseHandler(xp),
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func (h *notifyFSRequestHandler) FSEditListRequest(ctx context.Context, arg keybase1.FSEditListRequest) error {
+	cli, err := h.client()
+	if err != nil {
+		return err
+	}
+	return cli.FSEditListRequest(ctx, arg)
+}
+
+func (h *notifyFSRequestHandler) FSSyncStatusRequest(ctx context.Context, arg keybase1.FSSyncStatusRequest) error {
+	cli, err := h.client()
+	if err != nil {
+		return err
+	}
+	return cli.FSSyncStatusRequest(ctx, arg)
+}


### PR DESCRIPTION
- just forward to the first KBFS client we find
