### PR TITLE
Add waiting for settings actions

### DIFF
--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -91,7 +91,7 @@ function * _onUpdatePGPSettings (): SagaGenerator<any, any> {
 
 function * _onSubmitNewEmail (): SagaGenerator<any, any> {
   try {
-    yield put(Constants.waitingForResponseAction(true))
+    yield put(Constants.waiting(true))
 
     const newEmailSelector = ({settings: {email: {newEmail}}}: TypedState) => newEmail
     const newEmail: string = ((yield select(newEmailSelector)): any)
@@ -106,13 +106,13 @@ function * _onSubmitNewEmail (): SagaGenerator<any, any> {
   } catch (error) {
     yield put({type: Constants.onUpdateEmailError, payload: {error}})
   } finally {
-    yield put(Constants.waitingForResponseAction(false))
+    yield put(Constants.waiting(false))
   }
 }
 
 function * _onSubmitNewPassphrase (): SagaGenerator<any, any> {
   try {
-    yield put(Constants.waitingForResponseAction(true))
+    yield put(Constants.waiting(true))
 
     const selector = (state: TypedState) => state.settings.passphrase
     const {newPassphrase, newPassphraseConfirm} = ((yield select(selector)): any)
@@ -131,13 +131,13 @@ function * _onSubmitNewPassphrase (): SagaGenerator<any, any> {
   } catch (error) {
     yield put({type: Constants.onUpdatePassphraseError, payload: {error}})
   } finally {
-    yield put(Constants.waitingForResponseAction(false))
+    yield put(Constants.waiting(false))
   }
 }
 
 function * saveNotificationsSaga (): SagaGenerator<any, any> {
   try {
-    yield put(Constants.waitingForResponseAction(true))
+    yield put(Constants.waiting(true))
     const current = yield select(state => state.settings.notifications)
 
     if (!current || !current.settings) {
@@ -169,7 +169,7 @@ function * saveNotificationsSaga (): SagaGenerator<any, any> {
       payload: undefined,
     })
   } finally {
-    yield put(Constants.waitingForResponseAction(false))
+    yield put(Constants.waiting(false))
   }
 }
 
@@ -257,7 +257,7 @@ function * refreshInvitesSaga (): SagaGenerator<any, any> {
 
 function * sendInviteSaga (invitesSendAction: InvitesSend): SagaGenerator<any, any> {
   try {
-    yield put(Constants.waitingForResponseAction(true))
+    yield put(Constants.waiting(true))
 
     const {email, message} = invitesSendAction.payload
     const args = [{key: 'email', value: email}]
@@ -292,7 +292,7 @@ function * sendInviteSaga (invitesSendAction: InvitesSend): SagaGenerator<any, a
       error: true,
     }: InvitesSent))
   } finally {
-    yield put(Constants.waitingForResponseAction(false))
+    yield put(Constants.waiting(false))
   }
   yield put(invitesRefresh())
 }

--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -91,6 +91,8 @@ function * _onUpdatePGPSettings (): SagaGenerator<any, any> {
 
 function * _onSubmitNewEmail (): SagaGenerator<any, any> {
   try {
+    yield put(Constants.waitingForResponseAction(true))
+
     const newEmailSelector = ({settings: {email: {newEmail}}}: TypedState) => newEmail
     const newEmail: string = ((yield select(newEmailSelector)): any)
 
@@ -103,11 +105,15 @@ function * _onSubmitNewEmail (): SagaGenerator<any, any> {
     yield put(navigateUp())
   } catch (error) {
     yield put({type: Constants.onUpdateEmailError, payload: {error}})
+  } finally {
+    yield put(Constants.waitingForResponseAction(false))
   }
 }
 
 function * _onSubmitNewPassphrase (): SagaGenerator<any, any> {
   try {
+    yield put(Constants.waitingForResponseAction(true))
+
     const selector = (state: TypedState) => state.settings.passphrase
     const {newPassphrase, newPassphraseConfirm} = ((yield select(selector)): any)
     if (newPassphrase.stringValue() !== newPassphraseConfirm.stringValue()) {
@@ -124,40 +130,47 @@ function * _onSubmitNewPassphrase (): SagaGenerator<any, any> {
     yield put(navigateUp())
   } catch (error) {
     yield put({type: Constants.onUpdatePassphraseError, payload: {error}})
+  } finally {
+    yield put(Constants.waitingForResponseAction(false))
   }
 }
 
 function * saveNotificationsSaga (): SagaGenerator<any, any> {
-  const current = yield select(state => state.settings.notifications)
+  try {
+    yield put(Constants.waitingForResponseAction(true))
+    const current = yield select(state => state.settings.notifications)
 
-  if (!current || !current.settings) {
-    throw new Error('No notifications loaded yet')
+    if (!current || !current.settings) {
+      throw new Error('No notifications loaded yet')
+    }
+
+    const JSONPayload = current.settings
+    .map(s => ({
+      key: `${s.name}|email`,
+      value: s.subscribed ? '1' : '0'}))
+    .concat({
+      key: `unsub|email`,
+      value: current.unsubscribedFromAll ? '1' : '0'})
+
+    const result = yield call(apiserverPostJSONRpcPromise, {
+      param: {
+        endpoint: 'account/subscribe',
+        args: [],
+        JSONPayload,
+      },
+    })
+
+    if (!result || !result.body || JSON.parse(result.body).status.code !== 0) {
+      throw new Error(`Invalid response ${result || '(no result)'}`)
+    }
+
+    yield put({
+      type: Constants.notificationsSaved,
+      payload: undefined,
+    })
+  } finally {
+    yield put(Constants.waitingForResponseAction(false))
   }
-
-  const JSONPayload = current.settings
-  .map(s => ({
-    key: `${s.name}|email`,
-    value: s.subscribed ? '1' : '0'}))
-  .concat({
-    key: `unsub|email`,
-    value: current.unsubscribedFromAll ? '1' : '0'})
-
-  const result = yield call(apiserverPostJSONRpcPromise, {
-    param: {
-      endpoint: 'account/subscribe',
-      args: [],
-      JSONPayload,
-    },
-  })
-
-  if (!result || !result.body || JSON.parse(result.body).status.code !== 0) {
-    throw new Error(`Invalid response ${result || '(no result)'}`)
-  }
-
-  yield put({
-    type: Constants.notificationsSaved,
-    payload: undefined,
-  })
 }
 
 function * reclaimInviteSaga (invitesReclaimAction: InvitesReclaim): SagaGenerator<any, any> {
@@ -243,12 +256,15 @@ function * refreshInvitesSaga (): SagaGenerator<any, any> {
 }
 
 function * sendInviteSaga (invitesSendAction: InvitesSend): SagaGenerator<any, any> {
-  const {email, message} = invitesSendAction.payload
-  const args = [{key: 'email', value: email}]
-  if (message) {
-    args.push({key: 'invitation_message', value: message})
-  }
   try {
+    yield put(Constants.waitingForResponseAction(true))
+
+    const {email, message} = invitesSendAction.payload
+    const args = [{key: 'email', value: email}]
+    if (message) {
+      args.push({key: 'invitation_message', value: message})
+    }
+
     const response: ?{body: string} = yield call(apiserverPostRpcPromise, {
       param: {
         endpoint: 'send_invitation',
@@ -275,6 +291,8 @@ function * sendInviteSaga (invitesSendAction: InvitesSend): SagaGenerator<any, a
       payload: {errorText: e.desc + e.name, errorObj: e},
       error: true,
     }: InvitesSent))
+  } finally {
+    yield put(Constants.waitingForResponseAction(false))
   }
   yield put(invitesRefresh())
 }

--- a/shared/constants/settings.js
+++ b/shared/constants/settings.js
@@ -134,7 +134,7 @@ export type State = {
 }
 
 export const waitingForResponse = 'settings:waitingForResponse'
-export function waitingForResponseAction (waiting: boolean) : TypedAction<'settings:waitingForResponse', boolean, void> {
+export function waiting (waiting: boolean) : TypedAction<'settings:waitingForResponse', boolean, void> {
   return {
     type: 'settings:waitingForResponse',
     payload: waiting,

--- a/shared/constants/settings.js
+++ b/shared/constants/settings.js
@@ -126,8 +126,17 @@ export type EmailState = {
 
 export type State = {
   allowDeleteAccount: boolean,
+  waitingForResponse: boolean,
   invites: InvitesState,
   notifications: NotificationsState,
   email: EmailState,
   passphrase: PassphraseState,
+}
+
+export const waitingForResponse = 'settings:waitingForResponse'
+export function waitingForResponseAction (waiting: boolean) : TypedAction<'settings:waitingForResponse', boolean, void> {
+  return {
+    type: 'settings:waitingForResponse',
+    payload: waiting,
+  }
 }

--- a/shared/reducers/settings.js
+++ b/shared/reducers/settings.js
@@ -7,6 +7,7 @@ import type {Actions, State} from '../constants/settings'
 
 const initialState: State = {
   allowDeleteAccount: false,
+  waitingForResponse: false,
   invites: {
     pendingInvites: [],
     acceptedInvites: [],
@@ -180,6 +181,11 @@ function reducer (state: State = initialState, action: Actions): State {
           ...state.email,
           error: action.payload.error,
         },
+      }
+    case Constants.waitingForResponse:
+      return {
+        ...state,
+        waitingForResponse: action.payload,
       }
   }
   return state

--- a/shared/settings/dumb.js
+++ b/shared/settings/dumb.js
@@ -22,6 +22,7 @@ const updateEmailBase = {
   email: 'party@mypla.ce',
   isVerified: true,
   edited: false,
+  waitingForResponse: false,
   onChangeNewEmail: () => console.log('onChangeNewEmail'),
   onSave: () => console.log('onSave'),
   onBack: () => console.log('onBack'),
@@ -60,6 +61,7 @@ const updatePassphraseBase = {
   newPassphraseError: null,
   newPassphraseConfirmError: null,
   canSave: true,
+  waitingForResponse: false,
   onBack: () => console.log('onBack'),
   onSave: () => console.log('onSave'),
   onUpdatePGPSettings: () => console.log('onUpdatePGPSettings'),
@@ -324,6 +326,7 @@ const commonSettings = {
   unsubscribedFromAll: false,
   allowSave: true,
   allowEdit: true,
+  waitingForResponse: false,
   onRefresh: () => console.log('onRefresh'),
   onSave: () => console.log('onSave'),
   onToggle: (name: string) => console.log('on toggle', name),
@@ -468,6 +471,7 @@ const invitesBase = {
   onClickUser: username => console.log('onClickUser', username),
   onReclaimInvitation: invitationId => console.log('onReclaimInvitation', invitationId),
   onGenerateInvitation: () => console.log('onGenerateInvitation'),
+  waitingForResponse: false,
   parentProps: {
     style: {
       width: 504,

--- a/shared/settings/email/container.js
+++ b/shared/settings/email/container.js
@@ -11,6 +11,7 @@ const UserEmailContainer = Routable(() => ({componentAtTop: {title: 'Change Emai
 
 export default connect(
   (state: TypedState, ownProps: {}) => {
+    const {waitingForResponse} = state.settings
     const {emails, error, newEmail} = state.settings.email
     if (emails.length > 0) {
       const {email, isVerified} = emails[0]
@@ -19,6 +20,7 @@ export default connect(
         isVerified,
         edited: newEmail && newEmail !== email,
         error,
+        waitingForResponse,
       }
     }
     return {
@@ -26,6 +28,7 @@ export default connect(
       isVerified: false,
       edited: false,
       error: null,
+      waitingForResponse,
     }
   },
   (dispatch: any, ownProps: {}) => ({

--- a/shared/settings/email/index.desktop.js
+++ b/shared/settings/email/index.desktop.js
@@ -37,7 +37,8 @@ function UpdateEmail (props: Props) {
         style={{alignSelf: 'center', marginTop: globalMargins.medium}}
         type='Primary'
         label='Save'
-        onClick={props.onSave} />
+        onClick={props.onSave}
+        waiting={props.waitingForResponse} />
 
       {!!props.onResendConfirmationCode &&
         <Text

--- a/shared/settings/email/index.js.flow
+++ b/shared/settings/email/index.js.flow
@@ -9,6 +9,7 @@ export type Props = {
   onBack: () => void,
   onChangeNewEmail: (nextEmail: string) => void,
   onSave: () => void,
+  waitingForResponse: boolean,
   onResendConfirmationCode: ?(() => void),
 }
 

--- a/shared/settings/invites/container.js
+++ b/shared/settings/invites/container.js
@@ -44,7 +44,10 @@ class InvitationsContainer extends Component<void, Props, State> {
 }
 
 export default connect(
-  (state: TypedState, ownProps: {}) => state.settings.invites,
+  (state: TypedState, ownProps: {}) => ({
+    ...state.settings.invites,
+    waitingForResponse: state.settings.waitingForResponse,
+  }),
   (dispatch: any, ownProps: {}) => ({
     onGenerateInvitation: (email: string, message: string) => dispatch(invitesSend(email, message)),
     onRefresh: () => dispatch(invitesRefresh()),

--- a/shared/settings/invites/index.desktop.js
+++ b/shared/settings/invites/index.desktop.js
@@ -35,6 +35,7 @@ function Invites (props: Props) {
           type='Primary'
           label='Generate invitation'
           onClick={props.onGenerateInvitation}
+          waiting={props.waitingForResponse}
           style={{alignSelf: 'center', marginTop: globalMargins.medium}}
         />
       </Box>

--- a/shared/settings/invites/index.js.flow
+++ b/shared/settings/invites/index.js.flow
@@ -40,6 +40,7 @@ export type Props = {
   onReclaimInvitation: (invitationId: string) => void,
   onRefresh: () => void,
   onGenerateInvitation: () => void,
+  waitingForResponse: boolean,
 }
 
 export default class Invites extends Component<void, Props, void> {}

--- a/shared/settings/notifications/container.js
+++ b/shared/settings/notifications/container.js
@@ -17,7 +17,10 @@ class NotificationsContainer extends Component {
 }
 
 export default connect(
-  (state: TypedState, ownProps: {}) => state.settings.notifications,
+  (state: TypedState, ownProps: {}) => ({
+    ...state.settings.notifications,
+    waitingForResponse: state.settings.waitingForResponse,
+  }),
   (dispatch: any, ownProps: {}) => ({
     onSave: () => dispatch(notificationsSave()),
     onToggle: (name: string) => dispatch(notificationsToggle(name)),

--- a/shared/settings/notifications/index.desktop.js
+++ b/shared/settings/notifications/index.desktop.js
@@ -36,7 +36,8 @@ function Notifications (props: Props) {
         type='Primary'
         label='Save'
         disabled={!props.allowSave || !props.allowEdit}
-        onClick={props.onSave} />
+        onClick={props.onSave}
+        waiting={props.waitingForResponse} />
     </Box>)
 }
 

--- a/shared/settings/notifications/index.js.flow
+++ b/shared/settings/notifications/index.js.flow
@@ -15,6 +15,7 @@ export type Props = {
   onToggle: (name: string) => void,
   onToggleUnsubscribeAll: () => void,
   onSave: () => void,
+  waitingForResponse: boolean,
   onRefresh: () => void,
 }
 

--- a/shared/settings/passphrase/container.js
+++ b/shared/settings/passphrase/container.js
@@ -35,6 +35,7 @@ export default connect(
     newPassphraseConfirmError: state.settings.passphrase.newPassphraseConfirmError ? state.settings.passphrase.newPassphraseConfirmError.stringValue() : null,
     hasPGPKeyOnServer: state.settings.passphrase.hasPGPKeyOnServer,
     canSave: state.settings.passphrase.canSave,
+    waitingForResponse: state.settings.waitingForResponse,
   }),
   (dispatch: any, ownProps: {}) => ({
     onChangeNewPassphrase: (passphrase: string) => dispatch(onChangeNewPassphrase(new HiddenString(passphrase))),

--- a/shared/settings/passphrase/index.desktop.js
+++ b/shared/settings/passphrase/index.desktop.js
@@ -42,7 +42,8 @@ function UpdatePassphrase (props: Props) {
         type='Primary'
         label='Save'
         disabled={!props.canSave}
-        onClick={props.onSave} />
+        onClick={props.onSave}
+        waiting={props.waitingForResponse} />
     </StandardScreen>
   )
 }

--- a/shared/settings/passphrase/index.js.flow
+++ b/shared/settings/passphrase/index.js.flow
@@ -15,6 +15,7 @@ export type Props = {
   canSave: boolean,
   onBack: () => void,
   onSave: () => void,
+  waitingForResponse: boolean,
   onUpdatePGPSettings: () => void,
 }
 


### PR DESCRIPTION
Follows similar pattern for other "waitingForResponse" actions.

We might want to come up with a saga middleware way to do this since it seems to be common boilerplate everywhere.
