### PR TITLE
Retry on keyring file write error for Windows

### DIFF
--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -173,7 +173,7 @@ type SafeWriteLogger interface {
 }
 
 // SafeWriteToFile to safely write to a file. Use mode=0 for default permissions.
-func SafeWriteToFile(g SafeWriteLogger, t SafeWriter, mode os.FileMode) error {
+func safeWriteToFileOnce(g SafeWriteLogger, t SafeWriter, mode os.FileMode) error {
 	fn := t.GetFilename()
 	g.Debug(fmt.Sprintf("+ Writing to %s", fn))
 	tmpfn, tmp, err := OpenTempFile(fn, "", mode)

--- a/go/libkb/util_nix.go
+++ b/go/libkb/util_nix.go
@@ -46,3 +46,8 @@ func PosixLineEndings(arg string) string {
 func AppDataDir() (string, error) {
 	return "", errors.New("unsupported: AppDataDir")
 }
+
+// SafeWriteToFile is a pass-through to safeWriteToFileOnce on non-Windows.
+func SafeWriteToFile(g SafeWriteLogger, t SafeWriter, mode os.FileMode) error {
+	return safeWriteToFileOnce(g, t, mode)
+}

--- a/go/libkb/util_windows.go
+++ b/go/libkb/util_windows.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+	"time"
 
 	"golang.org/x/sys/windows"
 )
@@ -76,4 +77,22 @@ func AppDataDir() (string, error) {
 	}
 
 	return folder, nil
+}
+
+// SafeWriteToFile retries safeWriteToFileOnce a few times on Windows,
+// in case AV programs interfere with 2 writes in quick succession.
+func SafeWriteToFile(g SafeWriteLogger, t SafeWriter, mode os.FileMode) error {
+
+	var err error
+	for i := 0; i < 5; i++ {
+		if err != nil {
+			g.Debug("Retrying failed safeWriteToFileOnce - %s", err)
+			time.Sleep(10 * time.Millisecond)
+		}
+		err = safeWriteToFileOnce(g, t, mode)
+		if err == nil {
+			break
+		}
+	}
+	return err
 }


### PR DESCRIPTION
I have read that retrying after an access denied failure in MoveFileEx() often solves the problem. One suspect could be AV software, since we do 2 of these operations in quick succession.

BTW the user's log is [here](https://keybase.io/_/api/1.0/logdump/admin_get_raw_text?logdump_id=3b8523e6fbbef55dadf1c11c&log_name=keybase_log_gz), search for `2016-10-19T14:40:53.792049 - [DEBU keybase engine.go:66] 278 - RunEngine(DeviceKeygen) -> ERROR`

@maxtaco @patrickxb 
