### PR TITLE
React Native 0.36.0

### DIFF
--- a/react-native/npm-shrinkwrap.json
+++ b/react-native/npm-shrinkwrap.json
@@ -2846,9 +2846,9 @@
       "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz"
     },
     "react-native": {
-      "version": "0.34.1",
-      "from": "react-native@0.34.1",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.34.1.tgz",
+      "version": "0.36.0",
+      "from": "react-native@0.36.0",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.36.0.tgz",
       "dependencies": {
         "base64-js": {
           "version": "0.0.8",

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -25,7 +25,7 @@
     "purepack": "1.0.4",
     "qrcode-generator": "1.0.5",
     "react": "15.3.2",
-    "react-native": "0.34.1",
+    "react-native": "0.36.0",
     "react-native-barcodescanner": "3.1.1",
     "react-native-camera": "git://github.com/lwansbrough/react-native-camera.git#6074ec3c8275ef5eb5fc39489c9a379f6ced923b",
     "react-redux": "4.4.5",

--- a/shared/common-adapters/tab-bar.native.js
+++ b/shared/common-adapters/tab-bar.native.js
@@ -32,7 +32,7 @@ class TabBarButton extends Component<void, TabBarButtonProps, void> {
     const badgeNumber = this.props.badgeNumber || 0
 
     return (
-      <Box style={{backgroundColor, ...stylesTabBarButtonIcon, ...this.props.style, flex: 1}}>
+      <Box style={{backgroundColor, ...stylesTabBarButtonIcon, ...this.props.style, flexGrow: 1}}>
         {this.props.source.type === 'icon'
           ? <Icon type={this.props.source.icon} style={{fontSize: 48, width: 48, textAlign: 'center', color: this.props.selected ? globalColors.blue3 : globalColors.blue3_40, ...this.props.styleIcon}} />
           : this.props.source.avatar}
@@ -53,7 +53,7 @@ class TabBar extends Component<void, Props, void> {
       const key = item.props.label || _.get(item, 'props.tabBarButton.props.label') || i
       return (
         <NativeTouchableWithoutFeedback key={key} onPress={item.props.onClick || (() => {})}>
-          <Box style={{...item.props.styleContainer, flex: 1}}>
+          <Box style={{...item.props.styleContainer, flexGrow: 1}}>
             {item.props.tabBarButton || <SimpleTabBarButton {...item.props} />}
           </Box>
         </NativeTouchableWithoutFeedback>
@@ -94,7 +94,7 @@ const stylesTab = {
 
 const stylesTabBarButtonIcon = {
   ...globalStyles.flexBoxColumn,
-  flex: 1,
+  flexGrow: 1,
   justifyContent: 'center',
   alignItems: 'center',
   position: 'relative',

--- a/shared/folders/list.native.js
+++ b/shared/folders/list.native.js
@@ -57,7 +57,7 @@ class ListRender extends Component<void, Props, void> {
 
 const stylesContainer = {
   ...globalStyles.flexBoxColumn,
-  flex: 1,
+  flexGrow: 1,
 }
 
 const stylesIgnoreContainer = {

--- a/shared/login/register/passphrase/index.render.native.js
+++ b/shared/login/register/passphrase/index.render.native.js
@@ -18,7 +18,6 @@ class PassphraseRender extends Component<void, Props, void> {
         <UserCard style={stylesCard} username={this.props.username}>
           <Text type='HeaderBig' style={{color: globalColors.orange, ...usernameStyle}}>{this.props.username}</Text>
           <FormWithCheckbox
-            style={stylesInput}
             inputProps={{
               autoFocus: true,
               type: showTyping ? 'passwordVisible' : 'password',
@@ -47,9 +46,6 @@ class PassphraseRender extends Component<void, Props, void> {
 }
 
 const stylesContainer = {
-  flex: 1,
-}
-const stylesInput = {
   flex: 1,
 }
 const stylesForgot = {


### PR DESCRIPTION
@keybase/react-hackers 

Looks like the only breaking change for us was this one:
> Fix unconstraint sizing in main axis (0a9b6be)
> Most of your layouts will continue to function as before however some of them might not. Typically this is due to having a flex: 1 style where it is currently a no-op due to being measured with an undefined size but after this change it may collapse your component to take zero size due to the implicit flexBasis: 0 now being correctly treated. Removing the bad flex: 1 style or changing it to flexGrow: 1 should solve most if not all layout issues your see after this change.