### PR TITLE
Use random topicIDs

### DIFF
--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -125,7 +125,7 @@ type listOptionsV1 struct {
 func (l listOptionsV1) Check() error {
 	_, err := TopicTypeFromStrDefault(l.TopicType)
 	if err != nil {
-		return err
+		return ErrInvalidOptions{version: 1, method: methodList, err: err}
 	}
 	return nil
 }

--- a/go/client/chat_api_test.go
+++ b/go/client/chat_api_test.go
@@ -73,7 +73,7 @@ var echoOK = echoResult{Status: "ok"}
 
 type chatEcho struct{}
 
-func (c *chatEcho) ListV1(context.Context) Reply {
+func (c *chatEcho) ListV1(context.Context, listOptionsV1) Reply {
 	return Reply{Result: echoOK}
 }
 
@@ -190,7 +190,7 @@ var optTests = []optTest{
 		input: `{"method": "list", "params":{"version": 1}}`,
 	},
 	{
-		input: `{"method": "list", "params":{"version": 1, "options": {"filter": "all"}}}`,
+		input: `{"method": "list", "params":{"version": 1, "options": {"topic_type": "boozle"}}}`,
 		err:   ErrInvalidOptions{},
 	},
 	{
@@ -235,6 +235,9 @@ var optTests = []optTest{
 	},
 	{
 		input: `{"method": "list", "params":{"version": 1}}{"method": "list", "params":{"version": 1}}`,
+	},
+	{
+		input: `{"method": "list", "params":{"version": 1, "options": {"topic_type": "dEv"}}}`,
 	},
 	{
 		input: `{"method": "list", "params":{"version": 1}}{"method": "read", "params":{"version": 1, "options": {"conversation_id": "7777"}}}`,
@@ -347,7 +350,7 @@ func TestChatAPIDecoderOptions(t *testing.T) {
 		if test.err != nil {
 			if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
 				t.Errorf("test %d: input: %s", i, test.input)
-				t.Errorf("test %d: error type %T, expected %T (%s)", i, err, test.err, err)
+				t.Errorf("test %d: error type %T, expected %T (%v)", i, err, test.err, err)
 				continue
 			}
 		} else if err != nil {

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -15,7 +15,7 @@ import (
 
 // ChatServiceHandler can call the service.
 type ChatServiceHandler interface {
-	ListV1(context.Context) Reply
+	ListV1(context.Context, listOptionsV1) Reply
 	ReadV1(context.Context, readOptionsV1) Reply
 	SendV1(context.Context, sendOptionsV1) Reply
 	EditV1(context.Context, editOptionsV1) Reply
@@ -37,16 +37,22 @@ func newChatServiceHandler(g *libkb.GlobalContext) *chatServiceHandler {
 }
 
 // ListV1 implements ChatServiceHandler.ListV1.
-func (c *chatServiceHandler) ListV1(ctx context.Context) Reply {
+func (c *chatServiceHandler) ListV1(ctx context.Context, opts listOptionsV1) Reply {
 	var rlimits []chat1.RateLimit
 	client, err := GetChatLocalClient(c.G())
 	if err != nil {
 		return c.errReply(err)
 	}
 
+	topicType, err := TopicTypeFromStrDefault(opts.TopicType)
+	if err != nil {
+		return c.errReply(err)
+	}
+
 	inbox, err := client.GetInboxLocal(ctx, chat1.GetInboxLocalArg{
 		Query: &chat1.GetInboxLocalQuery{
-			Status: libkb.VisibleChatConversationStatuses(),
+			Status:    libkb.VisibleChatConversationStatuses(),
+			TopicType: &topicType,
 		},
 	})
 	if err != nil {
@@ -86,8 +92,7 @@ func (c *chatServiceHandler) ReadV1(ctx context.Context, opts readOptionsV1) Rep
 		return c.errReply(err)
 	}
 
-	// TODO safety argument, is the use of an unverified convID ok here?
-	convID, rlimits, err := c.resolveAPIConvIDUnverified(ctx, opts.ConversationID, opts.Channel)
+	convID, rlimits, err := c.resolveAPIConvID(ctx, opts.ConversationID, opts.Channel)
 	if err != nil {
 		return c.errReply(err)
 	}
@@ -327,8 +332,7 @@ func (c *chatServiceHandler) DownloadV1(ctx context.Context, opts downloadOption
 		return c.errReply(err)
 	}
 
-	// TODO safety argument, is the use of an unverified convID ok here?
-	convID, rlimits, err := c.resolveAPIConvIDUnverified(ctx, opts.ConversationID, opts.Channel)
+	convID, rlimits, err := c.resolveAPIConvID(ctx, opts.ConversationID, opts.Channel)
 	if err != nil {
 		return c.errReply(err)
 	}
@@ -361,7 +365,7 @@ func (c *chatServiceHandler) SetStatusV1(ctx context.Context, opts setStatusOpti
 	var rlimits []chat1.RateLimit
 
 	// Unverified convID is ok here because status is completely server controlled anyway.
-	convID, rlimits, err := c.resolveAPIConvIDUnverified(ctx, opts.ConversationID, opts.Channel)
+	convID, rlimits, err := c.resolveAPIConvID(ctx, opts.ConversationID, opts.Channel)
 	if err != nil {
 		return c.errReply(err)
 	}
@@ -408,6 +412,7 @@ func (c *chatServiceHandler) sendV1(ctx context.Context, arg sendArgV1) Reply {
 	if err != nil {
 		return c.errReply(err)
 	}
+
 	header, err := c.makePostHeader(ctx, arg, query)
 	if err != nil {
 		return c.errReply(err)
@@ -453,7 +458,7 @@ func (c *chatServiceHandler) makePostHeader(ctx context.Context, arg sendArgV1, 
 	}
 
 	// find the conversation
-	gilres, err := client.GetInboxLocal(ctx, chat1.GetInboxLocalArg{Query: &query})
+	gilres, err := client.GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{Query: &query})
 	if err != nil {
 		c.G().Log.Warning("GetInboxLocal error: %s", err)
 		return nil, err
@@ -462,7 +467,7 @@ func (c *chatServiceHandler) makePostHeader(ctx context.Context, arg sendArgV1, 
 	header.rateLimits = append(header.rateLimits, gilres.RateLimits...)
 
 	var convTriple chat1.ConversationIDTriple
-	existing := gilres.ConversationsUnverified
+	existing := gilres.Conversations
 	switch len(existing) {
 	case 0:
 		ncres, err := client.NewConversationLocal(ctx, chat1.NewConversationLocalArg{
@@ -477,7 +482,7 @@ func (c *chatServiceHandler) makePostHeader(ctx context.Context, arg sendArgV1, 
 		header.rateLimits = append(header.rateLimits, ncres.RateLimits...)
 		convTriple, header.conversationID = ncres.Conv.Info.Triple, ncres.Conv.Info.Id
 	case 1:
-		convTriple, header.conversationID = existing[0].Metadata.IdTriple, existing[0].Metadata.ConversationID
+		convTriple, header.conversationID = existing[0].Info.Triple, existing[0].Info.Id
 	default:
 		return nil, fmt.Errorf("multiple conversations matched")
 	}
@@ -527,7 +532,10 @@ func (c *chatServiceHandler) getInboxLocalQuery(ctx context.Context, id chat1.Co
 	if channel.Public {
 		vis = chat1.TLFVisibility_PUBLIC
 	}
-	tt := channel.TopicTypeEnum()
+	tt, err := TopicTypeFromStrDefault(channel.TopicType)
+	if err != nil {
+		return chat1.GetInboxLocalQuery{}, err
+	}
 	return chat1.GetInboxLocalQuery{
 		TlfName:       &tlfName,
 		TlfVisibility: &vis,
@@ -589,10 +597,9 @@ func (c *chatServiceHandler) aggRateLimits(rlimits []chat1.RateLimit) (res []Rat
 }
 
 // Resolve the ConvID of the specified conversation.
-// Note that it could be a server lie, so don't use it for getting keys.
 // Prefers using ChatChannel but if it is blank (default-valued) then uses ConvIDStr.
-// Uses tlfclient and GetInboxLocal's ConversationsUnverified.
-func (c *chatServiceHandler) resolveAPIConvIDUnverified(ctx context.Context, convIDStr string, channel ChatChannel) (chat1.ConversationID, []chat1.RateLimit, error) {
+// Uses tlfclient and GetInboxAndUnboxLocal's ConversationsUnverified.
+func (c *chatServiceHandler) resolveAPIConvID(ctx context.Context, convIDStr string, channel ChatChannel) (chat1.ConversationID, []chat1.RateLimit, error) {
 	var convID chat1.ConversationID
 	var rlimits []chat1.RateLimit
 
@@ -617,22 +624,33 @@ func (c *chatServiceHandler) resolveAPIConvIDUnverified(ctx context.Context, con
 	if err != nil {
 		return convID, rlimits, err
 	}
-	gilres, err := client.GetInboxLocal(ctx, chat1.GetInboxLocalArg{
+	gilres, err := client.GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
 		Query: &query,
 	})
 	if err != nil {
 		return convID, rlimits, err
 	}
 	rlimits = append(rlimits, gilres.RateLimits...)
-	existing := gilres.ConversationsUnverified
+	existing := gilres.Conversations
 	if len(existing) > 1 {
 		return convID, rlimits, fmt.Errorf("multiple conversations matched %q", channel.Name)
 	}
 	if len(existing) == 0 {
 		return convID, rlimits, fmt.Errorf("no conversations matched %q", channel.Name)
 	}
-	convID = existing[0].Metadata.ConversationID
+	convID = existing[0].Info.Id
 	return convID, rlimits, nil
+}
+
+func TopicTypeFromStrDefault(str string) (chat1.TopicType, error) {
+	if len(str) == 0 {
+		return chat1.TopicType_CHAT, nil
+	}
+	tt, ok := chat1.TopicTypeMap[strings.ToUpper(str)]
+	if !ok {
+		return chat1.TopicType_NONE, fmt.Errorf("invalid topic type: '%v'", str)
+	}
+	return tt, nil
 }
 
 // MsgSender is used for JSON output of the sender of a message.

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -307,6 +307,13 @@ func (m *ChatRemoteMock) NewConversationRemote2(ctx context.Context, arg chat1.N
 		if conv.Metadata.IdTriple.Tlfid.Eq(arg.IdTriple.Tlfid) &&
 			conv.Metadata.IdTriple.TopicID.String() == arg.IdTriple.TopicID.String() &&
 			conv.Metadata.IdTriple.TopicType == arg.IdTriple.TopicType {
+			// Identical triple
+			return res, libkb.ChatConvExistsError{ConvID: conv.Metadata.ConversationID}
+		}
+		if arg.IdTriple.TopicType == chat1.TopicType_CHAT &&
+			conv.Metadata.IdTriple.Tlfid.Eq(arg.IdTriple.Tlfid) &&
+			conv.Metadata.IdTriple.TopicType == arg.IdTriple.TopicType {
+			// Existing CHAT conv
 			return res, libkb.ChatConvExistsError{ConvID: conv.Metadata.ConversationID}
 		}
 	}

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -210,6 +210,7 @@ const (
 	SCChatAlreadySuperseded  = int(keybase1.StatusCode_SCChatAlreadySuperseded)
 	SCChatAlreadyDeleted     = int(keybase1.StatusCode_SCChatAlreadyDeleted)
 	SCChatTLFFinalized       = int(keybase1.StatusCode_SCChatTLFFinalized)
+	SCChatCollision          = int(keybase1.StatusCode_SCChatCollision)
 	SCBadEmail               = int(keybase1.StatusCode_SCBadEmail)
 )
 

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1660,6 +1660,15 @@ func (e ChatConvExistsError) Error() string {
 
 //=============================================================================
 
+type ChatCollisionError struct {
+}
+
+func (e ChatCollisionError) Error() string {
+	return fmt.Sprintf("conversation id collision")
+}
+
+//=============================================================================
+
 type ChatUnknownTLFIDError struct {
 	TlfID chat1.TLFID
 }

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -460,6 +460,8 @@ func ImportStatusAsError(s *keybase1.Status) error {
 		return ExistsError{Msg: s.Desc}
 	case SCInvalidAddress:
 		return InvalidAddressError{Msg: s.Desc}
+	case SCChatCollision:
+		return ChatCollisionError{}
 	default:
 		ase := AppStatusError{
 			Code:   s.Code,
@@ -1427,6 +1429,14 @@ func (e ChatTLFFinalizedError) ToStatus() keybase1.Status {
 		Name:   "SC_CHAT_TLF_FINALIZED",
 		Desc:   e.Error(),
 		Fields: []keybase1.StringKVPair{kv},
+	}
+}
+
+func (e ChatCollisionError) ToStatus() keybase1.Status {
+	return keybase1.Status{
+		Code: SCChatCollision,
+		Name: "SC_CHAT_COLLISION",
+		Desc: e.Error(),
 	}
 }
 

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -91,6 +91,7 @@ const (
 	StatusCode_SCChatAlreadySuperseded  StatusCode = 2507
 	StatusCode_SCChatAlreadyDeleted     StatusCode = 2508
 	StatusCode_SCChatTLFFinalized       StatusCode = 2509
+	StatusCode_SCChatCollision          StatusCode = 2510
 )
 
 var StatusCodeMap = map[string]StatusCode{
@@ -175,6 +176,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCChatAlreadySuperseded":  2507,
 	"SCChatAlreadyDeleted":     2508,
 	"SCChatTLFFinalized":       2509,
+	"SCChatCollision":          2510,
 }
 
 var StatusCodeRevMap = map[StatusCode]string{
@@ -259,6 +261,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2507: "SCChatAlreadySuperseded",
 	2508: "SCChatAlreadyDeleted",
 	2509: "SCChatTLFFinalized",
+	2510: "SCChatCollision",
 }
 
 type ConstantsInterface interface {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -108,6 +108,10 @@ func (h *chatLocalHandler) GetInboxLocal(ctx context.Context, arg chat1.GetInbox
 		return chat1.GetInboxLocalRes{}, err
 	}
 
+	if arg.Query != nil && arg.Query.TopicName != nil {
+		return chat1.GetInboxLocalRes{}, fmt.Errorf("cannot query by TopicName without unboxing")
+	}
+
 	rquery, err := h.getInboxQueryLocalToRemote(ctx, arg.Query)
 	if err != nil {
 		return chat1.GetInboxLocalRes{}, err
@@ -168,7 +172,7 @@ func (h *chatLocalHandler) GetInboxAndUnboxLocal(ctx context.Context, arg chat1.
 			}
 		}
 
-		// server can't query on topic name, so we'd have to do it ourselves in the loop
+		// server can't query on topic name, so we have to do it ourselves in the loop
 		if arg.Query != nil && arg.Query.TopicName != nil && *arg.Query.TopicName != convLocal.Info.TopicName {
 			continue
 		}

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -82,7 +82,8 @@ protocol constants {
     SCChatBroadcast_2506,
     SCChatAlreadySuperseded_2507,
     SCChatAlreadyDeleted_2508,
-    SCChatTLFFinalized_2509
+    SCChatTLFFinalized_2509,
+    SCChatCollision_2510
   }
 
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -170,6 +170,7 @@ export const ConstantsStatusCode = {
   scchatalreadysuperseded: 2507,
   scchatalreadydeleted: 2508,
   scchattlffinalized: 2509,
+  scchatcollision: 2510,
 }
 
 export const CtlExitCode = {
@@ -3856,6 +3857,7 @@ export type StatusCode =
   | 2507 // SCChatAlreadySuperseded_2507
   | 2508 // SCChatAlreadyDeleted_2508
   | 2509 // SCChatTLFFinalized_2509
+  | 2510 // SCChatCollision_2510
 
 export type Stream = {
   fd: int,

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -86,7 +86,8 @@
         "SCChatBroadcast_2506",
         "SCChatAlreadySuperseded_2507",
         "SCChatAlreadyDeleted_2508",
-        "SCChatTLFFinalized_2509"
+        "SCChatTLFFinalized_2509",
+        "SCChatCollision_2510"
       ]
     }
   ],

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -170,6 +170,7 @@ export const ConstantsStatusCode = {
   scchatalreadysuperseded: 2507,
   scchatalreadydeleted: 2508,
   scchattlffinalized: 2509,
+  scchatcollision: 2510,
 }
 
 export const CtlExitCode = {
@@ -3856,6 +3857,7 @@ export type StatusCode =
   | 2507 // SCChatAlreadySuperseded_2507
   | 2508 // SCChatAlreadyDeleted_2508
   | 2509 // SCChatTLFFinalized_2509
+  | 2510 // SCChatCollision_2510
 
 export type Stream = {
   fd: int,


### PR DESCRIPTION
Add `ChatCollisionError` which the server returns if a topicID is ok, but the resulting convID collides. The client will retry generating random topicIDs 3 times in `NewConversationLocal` for all topic types.

r? @mmaxim 