### PR TITLE
Windows install: Don't always reboot after vc redist

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
@@ -114,7 +114,9 @@
                   SourceFile="Redist\VCRedist_2015\vc_redist.x86.exe"
                   DownloadUrl="https://download.microsoft.com/download/2/6/8/268f7be7-8d2a-42d6-a823-5c6941a3d70a/vc_redist.x86.exe"
       >
-        <ExitCode Behavior="scheduleReboot"/>
+        <ExitCode Value="1641" Behavior="scheduleReboot"/>
+        <ExitCode Value="3010" Behavior="scheduleReboot"/>
+        <ExitCode Value="0" Behavior="success" />
       </ExePackage>
 
 
@@ -134,7 +136,9 @@
                   SourceFile="Redist\VCRedist_2015\vc_redist.x64.exe"
                   DownloadUrl="https://download.microsoft.com/download/6/3/a/63abaf83-2ca6-4460-90d7-12de8e815b1a/vc_redist.x64.exe"
                   >
-        <ExitCode Behavior="scheduleReboot"/>
+        <ExitCode Value="1641" Behavior="scheduleReboot"/>
+        <ExitCode Value="3010" Behavior="scheduleReboot"/>
+        <ExitCode Value="0" Behavior="success" />
       </ExePackage>
 
       <MsuPackage Id="Win71_KB2999226_x86"

--- a/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
@@ -99,6 +99,8 @@
         <ExitCode Value="0" Behavior="success" />
       </ExePackage>
 
+      <!-- Note there are 2 VC redistributable package entries, one for x86 and one for x64,
+ 	   which need to remain in sync -->	    
       <ExePackage Id="vcredist_2015_x86.exe"
                   Name="vc_redist.x86.exe"
                   InstallCommand="/norestart /passive /chainingpackage ADMINDEPLOYMENT"
@@ -119,7 +121,8 @@
         <ExitCode Value="0" Behavior="success" />
       </ExePackage>
 
-
+      <!-- Note there are 2 VC redistributable package entries, one for x86 and one for x64,
+ 	   which need to remain in sync -->	    
       <ExePackage Id="vcredist_2015_x64.exe"
                   Name="vc_redist.x64.exe"
                   InstallCommand="/norestart /passive /chainingpackage ADMINDEPLOYMENT"


### PR DESCRIPTION
I had put in "scheduleReboot" before learning about testing for specific exit codes. The problem can still come up if the redist really does need a reboot, but this will cut down on it a lot.
@maxtaco @oconnor663 