### PR TITLE
disable drag drop by default

### DIFF
--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -17,6 +17,7 @@ import loadPerf from '../shared/util/load-perf'
 import {AppContainer} from 'react-hot-loader'
 import {bootstrap} from '../shared/actions/config'
 import {devEditAction} from '../shared/reducers/dev-edit'
+import {disable as disableDragDrop} from '../shared/util/drag-drop'
 import {listenForNotifications} from '../shared/actions/notifications'
 import {merge} from 'lodash'
 import {reduxDevToolsEnable, devStoreChangingFunctions} from '../shared/local-debug.desktop'
@@ -36,6 +37,7 @@ function setupStore () {
 
 function setupApp (store) {
   setupSource()
+  disableDragDrop()
   makeEngine()
   loadPerf()
 

--- a/desktop/renderer/launcher.js
+++ b/desktop/renderer/launcher.js
@@ -6,6 +6,7 @@ import Root from './container'
 import hello from '../shared/util/hello'
 import loadPerf from '../shared/util/load-perf'
 import reactDOM from 'react-dom'
+import {disable as disableDragDrop} from '../shared/util/drag-drop'
 import {makeEngine} from '../shared/engine'
 import {remote} from 'electron'
 import {setupContextMenu} from '../app/menu-helper'
@@ -13,6 +14,7 @@ import {setupContextMenu} from '../app/menu-helper'
 import {setupSource} from '../shared/util/forward-logs'
 
 setupSource()
+disableDragDrop()
 makeEngine()
 hello(process.pid, 'Menubar', process.argv, __VERSION__) // eslint-disable-line no-undef
 

--- a/desktop/renderer/remote-component-loader.js
+++ b/desktop/renderer/remote-component-loader.js
@@ -11,6 +11,7 @@ import pinentry from '../shared/pinentry'
 import purgeMessage from '../shared/pgp/container.desktop'
 import tracker from '../shared/tracker'
 import unlockFolders from '../shared/unlock-folders'
+import {disable as disableDragDrop} from '../shared/util/drag-drop'
 // $FlowIssue
 import {globalColors} from '../shared/styles'
 import {remote, ipcRenderer} from 'electron'
@@ -19,6 +20,7 @@ import {setupContextMenu} from '../app/menu-helper'
 import {setupSource} from '../shared/util/forward-logs'
 
 setupSource()
+disableDragDrop()
 makeEngine()
 
 // $FlowIssue

--- a/shared/util/drag-drop.js
+++ b/shared/util/drag-drop.js
@@ -1,0 +1,10 @@
+// @flow
+
+function disable () {
+  document.addEventListener('dragover', event => event.preventDefault())
+  document.addEventListener('drop', event => event.preventDefault())
+}
+
+export {
+  disable,
+}


### PR DESCRIPTION
@keybase/react-hackers stops you dragging a file onto electron and having the contents being replaced by the file. you can still specify drag/drop on an element (not in this code but it works) so we can enable chat attachments on top of this