### PR TITLE
Zanderz/core 4038

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseBundle/Bundle.wxs
@@ -9,6 +9,8 @@
 
     <Variable Name="DokanInstallFolder" Type="string" Value="[ProgramFiles6432Folder]Dokan\Dokan Library-1.0.0"/>
 
+    <Variable Name="nodriver" bal:Overridable="yes" />
+    
     <Log PathVariable="LOGPATH_PROP"/>
     <util:FileSearchRef Id='WINTRUST_FileSearch' />
     <util:RegistrySearchRef Id='InnoCLIUninstall' />
@@ -27,7 +29,7 @@
             />
     </BootstrapperApplicationRef>
 
-    <!-- Keybase Dokany Build 58 
+    <!-- Dokany 
          This is the target we need to install with. If it's not there,
          we may need to invoke the dokan cleaner. -->
     <util:RegistrySearch Id="DokanUninstall"
@@ -47,11 +49,6 @@
                  Format="raw"
                  Win64="yes"
                  />
-
-    <bal:Condition
-      Message="Please uninstall any previous versions of the Dokan driver package before continuing.">
-      <![CDATA[NOT InnoUninstallString]]>
-    </bal:Condition>
 
     <util:FileSearch Id="SearchSystem"
                      Path="[SystemFolder]advapi32.dll"
@@ -90,7 +87,7 @@
       -->
       <ExePackage
         SourceFile="$(env.GOPATH)\src\github.com\keybase\client\go\tools\dokanclean\dokanclean.exe"
-        DetectCondition="DokanUninstallString"
+        DetectCondition="DokanUninstallString OR nodriver"
         Description="Remove previous drivers"
         PerMachine="yes"
         Permanent="yes">
@@ -216,7 +213,7 @@
                   />
 
       <MsiPackage SourceFile="$(var.DOKAN_PATH)\dokan_wix\bin\x86\$(var.Configuration)\Dokan_x86.msi"
-                  InstallCondition="NOT VersionNT64"
+                  InstallCondition="NOT VersionNT64 AND NOT nodriver"
                   Compressed="yes"
                   Visible="yes"
                   Permanent="yes"
@@ -228,7 +225,7 @@
       </MsiPackage>
 
       <MsiPackage SourceFile="$(var.DOKAN_PATH)\dokan_wix\bin\x64\$(var.Configuration)\Dokan_x64.msi"
-                  InstallCondition="VersionNT64"
+                  InstallCondition="VersionNT64 AND NOT nodriver"
                   Compressed="yes"
                   Visible="yes"
                   Permanent="yes"


### PR DESCRIPTION
I tested it, it works. If you invoke the installer on the command line and add `nodriver=1`, it will skip the drivers. Our updater may still be irritating for driver-switching people but that will be another ticket.
@maxtaco @oconnor663 