### PR TITLE
Add chat hide command

### DIFF
--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -121,9 +121,6 @@ func getInboxFetcherActivitySortedFlags() []cli.Flag {
 
 func parseConversationTopicType(ctx *cli.Context) (topicType chat1.TopicType, err error) {
 	switch t := strings.ToLower(ctx.String("topic-type")); t {
-	case "":
-		// Default to CHAT
-		topicType = chat1.TopicType_CHAT
 	case "chat":
 		topicType = chat1.TopicType_CHAT
 	case "dev":

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -82,6 +82,14 @@ var chatFlags = map[string]cli.Flag{
 		Name:  "all",
 		Usage: `Include hidden conversations`,
 	},
+	"block": cli.BoolFlag{
+		Name:  "b, block",
+		Usage: "Block the conversation (instead of hiding until next activity)",
+	},
+	"unhide": cli.BoolFlag{
+		Name:  "u, unhide",
+		Usage: "Unhide/unblock the conversation",
+	},
 }
 
 func mustGetChatFlags(keys ...string) (flags []cli.Flag) {

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -113,12 +113,15 @@ func getInboxFetcherActivitySortedFlags() []cli.Flag {
 
 func parseConversationTopicType(ctx *cli.Context) (topicType chat1.TopicType, err error) {
 	switch t := strings.ToLower(ctx.String("topic-type")); t {
+	case "":
+		// Default to CHAT
+		topicType = chat1.TopicType_CHAT
 	case "chat":
 		topicType = chat1.TopicType_CHAT
 	case "dev":
 		topicType = chat1.TopicType_DEV
 	default:
-		err = fmt.Errorf("invalid topic-type %s. Has to be one of %v", t, []string{"chat", "dev"})
+		err = fmt.Errorf("invalid topic-type '%s'. Has to be one of %v", t, []string{"chat", "dev"})
 	}
 	return topicType, err
 }

--- a/go/client/cmd_chat.go
+++ b/go/client/cmd_chat.go
@@ -17,6 +17,7 @@ func NewCmdChat(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 		Subcommands: []cli.Command{
 			newCmdChatAPI(cl, g),
 			newCmdChatDownload(cl, g),
+			newCmdChatHide(cl, g),
 			newCmdChatList(cl, g),
 			newCmdChatListUnread(cl, g),
 			newCmdChatRead(cl, g),

--- a/go/client/cmd_chat_hide.go
+++ b/go/client/cmd_chat_hide.go
@@ -25,20 +25,7 @@ func newCmdChatHide(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 			cmd := &CmdChatHide{Contextified: libkb.NewContextified(g)}
 			cl.ChooseCommand(cmd, "hide", c)
 		},
-		Flags: []cli.Flag{
-			cli.BoolFlag{
-				Name:  "b, block",
-				Usage: "Block the conversation (instead of hiding until next activity)",
-			},
-			cli.BoolFlag{
-				Name:  "u, unhide",
-				Usage: "Unhide/unblock the conversation",
-			},
-			cli.BoolFlag{
-				Name:  "public",
-				Usage: "Apply to public conversation (default private)",
-			},
-		},
+		Flags: append(getConversationResolverFlags(), mustGetChatFlags("block", "unhide")...),
 	}
 }
 

--- a/go/client/cmd_chat_hide.go
+++ b/go/client/cmd_chat_hide.go
@@ -1,0 +1,119 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+)
+
+type CmdChatHide struct {
+	libkb.Contextified
+	resolvingRequest chatConversationResolvingRequest
+	status           chat1.ConversationStatus
+}
+
+func newCmdChatHide(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "hide",
+		Usage:        "Hide or block a conversation.",
+		ArgumentHelp: "[<conversation>]",
+		Action: func(c *cli.Context) {
+			cmd := &CmdChatHide{Contextified: libkb.NewContextified(g)}
+			cl.ChooseCommand(cmd, "hide", c)
+		},
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "b, block",
+				Usage: "Block the conversation (instead of hiding until next activity)",
+			},
+			cli.BoolFlag{
+				Name:  "u, unhide",
+				Usage: "Unhide/unblock the conversation",
+			},
+			cli.BoolFlag{
+				Name:  "public",
+				Usage: "Apply to public conversation (default private)",
+			},
+		},
+	}
+}
+
+func (c *CmdChatHide) ParseArgv(ctx *cli.Context) error {
+	var err error
+
+	if len(ctx.Args()) > 1 {
+		return fmt.Errorf("too many arguments")
+	}
+
+	tlfName := ""
+	if len(ctx.Args()) == 1 {
+		tlfName = ctx.Args()[0]
+	}
+
+	c.resolvingRequest, err = parseConversationResolvingRequest(ctx, tlfName)
+	if err != nil {
+		return err
+	}
+
+	block := ctx.Bool("block")
+	unhide := ctx.Bool("unhide")
+
+	c.status = chat1.ConversationStatus_IGNORED
+	if block && unhide {
+		return fmt.Errorf("cannot do both --block and --unhide")
+	}
+	if block {
+		c.status = chat1.ConversationStatus_BLOCKED
+	}
+	if unhide {
+		c.status = chat1.ConversationStatus_UNFILED
+	}
+
+	return nil
+}
+
+func (c *CmdChatHide) Run() error {
+	ctx := context.TODO()
+
+	chatClient, err := GetChatLocalClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	resolver := &chatConversationResolver{G: c.G(), ChatClient: chatClient}
+	resolver.TlfClient, err = GetTlfClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	conversationInfo, _, err := resolver.Resolve(ctx, c.resolvingRequest, chatConversationResolvingBehavior{
+		CreateIfNotExists: false,
+		Interactive:       false,
+	})
+	if err != nil {
+		return err
+	}
+
+	setStatusArg := chat1.SetConversationStatusLocalArg{
+		ConversationID: conversationInfo.Id,
+		Status:         c.status,
+	}
+
+	_, err = chatClient.SetConversationStatusLocal(ctx, setStatusArg)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CmdChatHide) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		API:       true,
+		KbKeyring: true,
+		Config:    true,
+	}
+}


### PR DESCRIPTION
This PR is in line after https://github.com/keybase/client/pull/4784

Adds `keybase chat hide`

```
$ keybase chat hide -h
NAME:
   keybase chat hide - Hide or block a conversation.

USAGE:
   keybase chat hide [command options] [<conversation>]

OPTIONS:
   -b, --block  Block the conversation (instead of hiding until next activity)
   -u, --unhide Unhide/unblock the conversation
   --public     Apply to public conversation (default private)
```

One weird thing is if you have one conversation in your life and run `keybase chat hide` then it will hide that one, instead of being a usage error. I figure this will get changed soon enough with resolver that it's not worth fixing for now.

Docker tests coming soon. They will be mentioned below.

r? @songgao || @mmaxim 