### PR TITLE
always refresh device list

### DIFF
--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -13,9 +13,9 @@ import {routeAppend} from '../actions/router'
 
 class Devices extends Component {
   componentWillMount () {
-    const {devices, waitingForServer, loggedIn} = this.props
+    const {waitingForServer, loggedIn} = this.props
 
-    if (loggedIn && !devices && !waitingForServer) {
+    if (loggedIn && !waitingForServer) {
       this.props.loadDevices()
     }
   }


### PR DESCRIPTION
Just refresh devices when we mount the root list
Should fix: https://github.com/keybase/client/issues/4680

@keybase/react-hackers 