### PR TITLE
Fix preview again

### DIFF
--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -755,8 +755,9 @@ func (h *chatLocalHandler) PostAttachmentLocal(ctx context.Context, arg chat1.Po
 			chatUI.ChatAttachmentPreviewUploadStart(ctx)
 			// add preview suffix to object key (P in hex)
 			// the s3path in gregor is expecting hex here
-			params.ObjectKey += "50"
-			prev, err := h.uploadAsset(ctx, arg.SessionID, params, *arg.Preview, nil)
+			paramsCopy := params
+			paramsCopy.ObjectKey += "50"
+			prev, err := h.uploadAsset(ctx, arg.SessionID, paramsCopy, *arg.Preview, nil)
 			chatUI.ChatAttachmentPreviewUploadDone(ctx)
 			if err == nil {
 				preview = &prev

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -753,11 +753,13 @@ func (h *chatLocalHandler) PostAttachmentLocal(ctx context.Context, arg chat1.Po
 	if arg.Preview != nil {
 		g.Go(func() error {
 			chatUI.ChatAttachmentPreviewUploadStart(ctx)
+			// copy the params so as not to mess with the main params above
+			previewParams := params
+
 			// add preview suffix to object key (P in hex)
 			// the s3path in gregor is expecting hex here
-			paramsCopy := params
-			paramsCopy.ObjectKey += "50"
-			prev, err := h.uploadAsset(ctx, arg.SessionID, paramsCopy, *arg.Preview, nil)
+			previewParams.ObjectKey += "50"
+			prev, err := h.uploadAsset(ctx, arg.SessionID, previewParams, *arg.Preview, nil)
 			chatUI.ChatAttachmentPreviewUploadDone(ctx)
 			if err == nil {
 				preview = &prev


### PR DESCRIPTION
This really fixes it...the multiple goroutines were sharing params local var and messing it up.

Ran kbfsdocker on this repeatedly, no more failures.

r? @mmaxim 