### PR TITLE
Add Title to attachments

### DIFF
--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -202,6 +202,7 @@ type attachOptionsV1 struct {
 	ConversationID string `json:"conversation_id"`
 	Filename       string
 	Preview        string
+	Title          string
 }
 
 func (a attachOptionsV1) Check() error {

--- a/go/client/chat_api_test.go
+++ b/go/client/chat_api_test.go
@@ -388,6 +388,10 @@ var echoTests = []echoTest{
 		output: `{"result":{"status":"ok"}}`,
 	},
 	{
+		input:  `{"method": "attach", "params":{"options": {"channel": {"name": "alice,bob"}, "filename": "photo.png", "preview": "preview.png", "title": "Check this out!"}}}`,
+		output: `{"result":{"status":"ok"}}`,
+	},
+	{
 		input:  `{"method": "download", "params":{"version": 1, "options": {"message_id": 34, "channel": {"name": "a123,nfnf,t_bob"}, "output": "/tmp/file"}}}`,
 		output: `{"result":{"status":"ok"}}`,
 	},

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -373,7 +373,11 @@ func newMessageView(g *libkb.GlobalContext, conversationID chat1.ConversationID,
 	case chat1.MessageType_ATTACHMENT:
 		mv.Renderable = true
 		att := body.Attachment()
-		mv.Body = fmt.Sprintf("%s <attachment ID: %d>", filepath.Base(att.Object.Filename), m.GetMessageID())
+		title := att.Object.Title
+		if title == "" {
+			title = filepath.Base(att.Object.Filename)
+		}
+		mv.Body = fmt.Sprintf("%s <attachment ID: %d>", title, m.GetMessageID())
 		if att.Preview != nil {
 			mv.Body += " [preview available]"
 		}

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -255,6 +255,10 @@ func (c *chatServiceHandler) AttachV1(ctx context.Context, opts attachOptionsV1)
 	defer fsource.Close()
 	src := c.G().XStreams.ExportReader(fsource)
 
+	title := info.Name()
+	if strings.TrimSpace(opts.Title) != "" {
+		title = opts.Title
+	}
 	arg := chat1.PostAttachmentLocalArg{
 		ConversationID: header.conversationID,
 		ClientHeader:   header.clientHeader,
@@ -263,6 +267,7 @@ func (c *chatServiceHandler) AttachV1(ctx context.Context, opts attachOptionsV1)
 			Size:     int(info.Size()),
 			Source:   src,
 		},
+		Title: title,
 	}
 
 	// check for preview

--- a/go/client/cmd_chat_upload.go
+++ b/go/client/cmd_chat_upload.go
@@ -14,6 +14,7 @@ type CmdChatUpload struct {
 	tlf      string
 	filename string
 	public   bool
+	title    string
 }
 
 func newCmdChatUpload(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -30,6 +31,10 @@ func newCmdChatUpload(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 				Name:  "public",
 				Usage: "Send to public conversation (default private)",
 			},
+			cli.StringFlag{
+				Name:  "title",
+				Usage: "Title of attachment (defaults to filename)",
+			},
 		},
 	}
 }
@@ -41,6 +46,7 @@ func (c *CmdChatUpload) ParseArgv(ctx *cli.Context) error {
 	c.tlf = ctx.Args()[0]
 	c.filename = ctx.Args()[1]
 	c.public = ctx.Bool("public")
+	c.title = ctx.String("title")
 
 	return nil
 }
@@ -52,6 +58,7 @@ func (c *CmdChatUpload) Run() error {
 			Public: c.public,
 		},
 		Filename: c.filename,
+		Title:    c.title,
 	}
 	h := newChatServiceHandler(c.G())
 	reply := h.AttachV1(context.Background(), opts)

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -43,6 +43,7 @@ type Asset struct {
 	EncHash   Hash   `codec:"encHash" json:"encHash"`
 	Key       []byte `codec:"key" json:"key"`
 	VerifyKey []byte `codec:"verifyKey" json:"verifyKey"`
+	Title     string `codec:"title" json:"title"`
 }
 
 type MessageAttachment struct {
@@ -576,6 +577,7 @@ type PostAttachmentLocalArg struct {
 	ClientHeader   MessageClientHeader `codec:"clientHeader" json:"clientHeader"`
 	Attachment     LocalSource         `codec:"attachment" json:"attachment"`
 	Preview        *LocalSource        `codec:"preview,omitempty" json:"preview,omitempty"`
+	Title          string              `codec:"title" json:"title"`
 }
 
 type NewConversationLocalArg struct {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -578,6 +578,7 @@ type PostAttachmentLocalArg struct {
 	Attachment     LocalSource         `codec:"attachment" json:"attachment"`
 	Preview        *LocalSource        `codec:"preview,omitempty" json:"preview,omitempty"`
 	Title          string              `codec:"title" json:"title"`
+	Metadata       []byte              `codec:"metadata" json:"metadata"`
 }
 
 type NewConversationLocalArg struct {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -772,10 +772,20 @@ func (h *chatLocalHandler) PostAttachmentLocal(ctx context.Context, arg chat1.Po
 		return chat1.PostLocalRes{}, err
 	}
 
+	// Title on Asset set to filename in uploadAsset, but if
+	// a title was specified, then use that instead.
+	if arg.Title != "" {
+		object.Title = arg.Title
+		if preview != nil {
+			preview.Title = arg.Title
+		}
+	}
+
 	// send an attachment message
 	attachment := chat1.MessageAttachment{
-		Object:  object,
-		Preview: preview,
+		Object:   object,
+		Preview:  preview,
+		Metadata: arg.Metadata,
 	}
 	postArg := chat1.PostLocalArg{
 		ConversationID: arg.ConversationID,
@@ -932,6 +942,7 @@ func (h *chatLocalHandler) uploadAsset(ctx context.Context, sessionID int, param
 
 	asset := chat1.Asset{
 		Filename:  filepath.Base(local.Filename),
+		Title:     filepath.Base(local.Filename),
 		Region:    upRes.Region,
 		Endpoint:  upRes.Endpoint,
 		Bucket:    upRes.Bucket,

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -37,6 +37,7 @@ protocol local {
     Hash encHash;              // hash of ciphertext object 
     bytes key;                 // encryption key
     bytes verifyKey;           // signature verification key
+    string title;              // title of the asset (defaults to filename if not provided)
   }
 
   record MessageAttachment {
@@ -238,7 +239,7 @@ protocol local {
   }
 
   // Post an attachment in source to conversationID.
-  PostLocalRes postAttachmentLocal(int sessionID, ConversationID conversationID, MessageClientHeader clientHeader, LocalSource attachment, union { null, LocalSource } preview);
+  PostLocalRes postAttachmentLocal(int sessionID, ConversationID conversationID, MessageClientHeader clientHeader, LocalSource attachment, union { null, LocalSource } preview, string title);
 
   NewConversationLocalRes newConversationLocal(string tlfName, TopicType topicType, TLFVisibility tlfVisibility, union { null, string } topicName);
   record NewConversationLocalRes {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -239,7 +239,7 @@ protocol local {
   }
 
   // Post an attachment in source to conversationID.
-  PostLocalRes postAttachmentLocal(int sessionID, ConversationID conversationID, MessageClientHeader clientHeader, LocalSource attachment, union { null, LocalSource } preview, string title);
+  PostLocalRes postAttachmentLocal(int sessionID, ConversationID conversationID, MessageClientHeader clientHeader, LocalSource attachment, union { null, LocalSource } preview, string title, bytes metadata);
 
   NewConversationLocalRes newConversationLocal(string tlfName, TopicType topicType, TLFVisibility tlfVisibility, union { null, string } topicName);
   record NewConversationLocalRes {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -911,7 +911,8 @@ export type localPostAttachmentLocalRpcParam = Exact<{
   clientHeader: MessageClientHeader,
   attachment: LocalSource,
   preview?: ?LocalSource,
-  title: string
+  title: string,
+  metadata: bytes
 }>
 
 export type localPostLocalNonblockRpcParam = Exact<{

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -388,6 +388,7 @@ export type Asset = {
   encHash: Hash,
   key: bytes,
   verifyKey: bytes,
+  title: string,
 }
 
 export type BodyPlaintext = 
@@ -909,7 +910,8 @@ export type localPostAttachmentLocalRpcParam = Exact<{
   conversationID: ConversationID,
   clientHeader: MessageClientHeader,
   attachment: LocalSource,
-  preview?: ?LocalSource
+  preview?: ?LocalSource,
+  title: string
 }>
 
 export type localPostLocalNonblockRpcParam = Exact<{

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -114,6 +114,10 @@
         {
           "type": "bytes",
           "name": "verifyKey"
+        },
+        {
+          "type": "string",
+          "name": "title"
         }
       ]
     },
@@ -1057,6 +1061,10 @@
             null,
             "LocalSource"
           ]
+        },
+        {
+          "name": "title",
+          "type": "string"
         }
       ],
       "response": "PostLocalRes"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1065,6 +1065,10 @@
         {
           "name": "title",
           "type": "string"
+        },
+        {
+          "name": "metadata",
+          "type": "bytes"
         }
       ],
       "response": "PostLocalRes"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -911,7 +911,8 @@ export type localPostAttachmentLocalRpcParam = Exact<{
   clientHeader: MessageClientHeader,
   attachment: LocalSource,
   preview?: ?LocalSource,
-  title: string
+  title: string,
+  metadata: bytes
 }>
 
 export type localPostLocalNonblockRpcParam = Exact<{

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -388,6 +388,7 @@ export type Asset = {
   encHash: Hash,
   key: bytes,
   verifyKey: bytes,
+  title: string,
 }
 
 export type BodyPlaintext = 
@@ -909,7 +910,8 @@ export type localPostAttachmentLocalRpcParam = Exact<{
   conversationID: ConversationID,
   clientHeader: MessageClientHeader,
   attachment: LocalSource,
-  preview?: ?LocalSource
+  preview?: ?LocalSource,
+  title: string
 }>
 
 export type localPostLocalNonblockRpcParam = Exact<{


### PR DESCRIPTION
This adds a title field to attachments as described in slack by @malgorithms.  If no title is provided by caller, it uses the filename for the title.  The original filename is (still) in the attachment data, this just adds a title.

r? @mmaxim 

cc @malgorithms 