### PR TITLE
Use icon from keybase.exe for kbfs mount

### DIFF
--- a/go/service/kbfs_mount.go
+++ b/go/service/kbfs_mount.go
@@ -32,8 +32,13 @@ func (h *KBFSMountHandler) GetAllAvailableMountDirs(ctx context.Context) (res []
 }
 
 func (h *KBFSMountHandler) SetCurrentMountDir(_ context.Context, drive string) (err error) {
+	oldMount, _ := h.G().Env.GetMountDir()
 	w := h.G().Env.GetConfigWriter()
-	w.SetStringAtPath("mountdir", drive)
+	err = w.SetStringAtPath("mountdir", drive)
+	if err != nil {
+		return err
+	}
 	h.G().ConfigReload()
+	doMountChange(oldMount, drive)
 	return nil
 }

--- a/go/service/kbfs_mount_nix.go
+++ b/go/service/kbfs_mount_nix.go
@@ -12,3 +12,7 @@ import (
 func getMountDirs() ([]string, error) {
 	return []string{}, errors.New("getMountDirs is Windows only")
 }
+
+func doMountChange(oldMount string, newMount string) error {
+	return nil
+}

--- a/go/service/kbfs_mount_windows.go
+++ b/go/service/kbfs_mount_windows.go
@@ -7,7 +7,9 @@ package service
 
 import (
 	"fmt"
+	"github.com/kardianos/osext"
 	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
 	"strings"
 	"syscall"
 	"unsafe"
@@ -17,6 +19,8 @@ var (
 	kernel32DLL        = windows.NewLazySystemDLL("kernel32.dll")
 	getVolumeProc      = kernel32DLL.NewProc("GetVolumeInformationW")
 	queryDosDeviceProc = kernel32DLL.NewProc("QueryDosDeviceW")
+	shell32DLL		   = windows.NewLazySystemDLL("shell32.dll")
+	shChangeNotifyProc = shell32DLL.NewProc("SHChangeNotify") 
 )
 
 // getVolumeName requires a drive letter and colon with a
@@ -95,4 +99,45 @@ func getMountDirs() ([]string, error) {
 		err = fmt.Errorf("No drive letters available")
 	}
 	return drives, err
+}
+
+// Notify the shell that the thing located at path has changed
+func notifyShell(path string){
+	shChangeNotifyProc.Call(
+		uintptr(0x00002000),		// SHCNE_UPDATEITEM
+		uintptr(0x0005),			// SHCNF_PATHW
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(path))),
+		0)
+}
+
+// Manipulate registry entries to reflect the mount point icon in the shell
+func doMountChange(oldMount string, newMount string) error {
+	if len(oldMount) != 0 {
+		// DeleteKey doesn't work if there are subkeys
+		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+oldMount[:1]+`\DefaultIcon`)
+		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+oldMount[:1]+`\DefaultLabel`)
+		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+oldMount[:1])
+		notifyShell(oldMount)
+	}
+	if len(newMount) == 0 {
+		return nil
+	}
+	k, _, err := registry.CreateKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+newMount[:1]+`\DefaultIcon`, registry.SET_VALUE|registry.CREATE_SUB_KEY|registry.WRITE)
+	defer k.Close()
+	if err != nil {
+		return err
+	}
+	keybaseExe, err := osext.Executable()
+	if err != nil {
+		return err
+	}
+	// Use the first icon bound into keybase.exe - note we can add different ones and change the 0 here
+	err = k.SetStringValue("", keybaseExe+",0")
+
+	// Also give a nice label
+	k2, _, err := registry.CreateKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+newMount[:1]+`\DefaultLabel`, registry.SET_VALUE|registry.CREATE_SUB_KEY|registry.WRITE)
+	defer k2.Close()
+	err = k2.SetStringValue("", "Keybase")
+	notifyShell(newMount)
+	return err
 }

--- a/go/service/kbfs_mount_windows.go
+++ b/go/service/kbfs_mount_windows.go
@@ -19,8 +19,8 @@ var (
 	kernel32DLL        = windows.NewLazySystemDLL("kernel32.dll")
 	getVolumeProc      = kernel32DLL.NewProc("GetVolumeInformationW")
 	queryDosDeviceProc = kernel32DLL.NewProc("QueryDosDeviceW")
-	shell32DLL		   = windows.NewLazySystemDLL("shell32.dll")
-	shChangeNotifyProc = shell32DLL.NewProc("SHChangeNotify") 
+	shell32DLL         = windows.NewLazySystemDLL("shell32.dll")
+	shChangeNotifyProc = shell32DLL.NewProc("SHChangeNotify")
 )
 
 // getVolumeName requires a drive letter and colon with a
@@ -102,24 +102,24 @@ func getMountDirs() ([]string, error) {
 }
 
 // Notify the shell that the thing located at path has changed
-func notifyShell(path string){
+func notifyShell(path string) {
 	shChangeNotifyProc.Call(
-		uintptr(0x00002000),		// SHCNE_UPDATEITEM
-		uintptr(0x0005),			// SHCNF_PATHW
+		uintptr(0x00002000), // SHCNE_UPDATEITEM
+		uintptr(0x0005),     // SHCNF_PATHW
 		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(path))),
 		0)
 }
 
 // Manipulate registry entries to reflect the mount point icon in the shell
 func doMountChange(oldMount string, newMount string) error {
-	if len(oldMount) != 0 {
+	if oldMount != "" {
 		// DeleteKey doesn't work if there are subkeys
 		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+oldMount[:1]+`\DefaultIcon`)
 		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+oldMount[:1]+`\DefaultLabel`)
 		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+oldMount[:1])
 		notifyShell(oldMount)
 	}
-	if len(newMount) == 0 {
+	if newMount == "" {
 		return nil
 	}
 	k, _, err := registry.CreateKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+newMount[:1]+`\DefaultIcon`, registry.SET_VALUE|registry.CREATE_SUB_KEY|registry.WRITE)


### PR DESCRIPTION
This unfortunately won't work for private and public folders, but we can do the mount point icon this way.
We may want to also do `keybase kbfsmount set ""` at uninstall?
@maxtaco @taruti 