### PR TITLE
plumb through identifyBehavior and identify breaks

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -258,7 +258,7 @@ func (b *Boxer) UnboxMessages(ctx context.Context, boxed []chat1.MessageBoxed, i
 		}
 	}
 
-	breaks = keybase1.FlattenTLFUserBreaks(breaks)
+	breaks = utils.FlattenTLFUserBreaks(breaks)
 
 	return unboxed, breaks, nil
 }

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -203,7 +203,7 @@ func TestChatMessageUnboxInvalidBodyHash(t *testing.T) {
 		return sum[:]
 	}
 
-	boxed, err := boxer.BoxMessage(ctx, msg, signKP)
+	boxed, _, err := boxer.BoxMessage(ctx, msg, signKP, keybase1.TLFIdentifyBehavior_CHAT_CLI)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -217,7 +217,7 @@ func TestChatMessageUnboxInvalidBodyHash(t *testing.T) {
 	boxer.hashV1 = origHashFn
 
 	// This should produce a permanent error. So err will be nil, but the decmsg will be state=error.
-	decmsg, err := boxer.UnboxMessage(ctx, NewKeyFinder(), *boxed)
+	decmsg, _, err := boxer.UnboxMessage(ctx, NewKeyFinder(), *boxed, keybase1.TLFIdentifyBehavior_CHAT_CLI)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,7 +250,7 @@ func TestChatMessageUnboxNoCryptKey(t *testing.T) {
 
 	ctx := context.Background()
 
-	boxed, err := boxer.BoxMessage(ctx, msg, signKP)
+	boxed, _, err := boxer.BoxMessage(ctx, msg, signKP, keybase1.TLFIdentifyBehavior_CHAT_CLI)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,7 +261,7 @@ func TestChatMessageUnboxNoCryptKey(t *testing.T) {
 	}
 
 	// This should produce a non-permanent error. So err will be set.
-	decmsg, ierr := boxer.UnboxMessage(ctx, NewKeyFinderMock(), *boxed)
+	decmsg, _, ierr := boxer.UnboxMessage(ctx, NewKeyFinderMock(), *boxed, keybase1.TLFIdentifyBehavior_CHAT_CLI)
 	if !strings.Contains(ierr.Error(), "no key found") {
 		t.Fatalf("error should contain 'no key found': %v", ierr)
 	}
@@ -378,7 +378,7 @@ func TestChatMessagePublic(t *testing.T) {
 
 	ctx := context.Background()
 
-	boxed, err := boxer.BoxMessage(ctx, msg, signKP)
+	boxed, _, err := boxer.BoxMessage(ctx, msg, signKP, keybase1.TLFIdentifyBehavior_CHAT_CLI)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -389,7 +389,7 @@ func TestChatMessagePublic(t *testing.T) {
 		Ctime: gregor1.ToTime(time.Now()),
 	}
 
-	decmsg, err := boxer.UnboxMessage(ctx, NewKeyFinder(), *boxed)
+	decmsg, _, err := boxer.UnboxMessage(ctx, NewKeyFinder(), *boxed, keybase1.TLFIdentifyBehavior_CHAT_CLI)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -411,6 +411,6 @@ func NewKeyFinderMock() KeyFinder {
 	return &KeyFinderMock{}
 }
 
-func (k *KeyFinderMock) Find(ctx context.Context, tlf keybase1.TlfInterface, tlfName string, tlfPublic bool) (keybase1.GetTLFCryptKeysRes, error) {
+func (k *KeyFinderMock) Find(ctx context.Context, tlf keybase1.TlfInterface, tlfName string, tlfPublic bool, identifyBehavior keybase1.TLFIdentifyBehavior) (keybase1.GetTLFCryptKeysRes, error) {
 	return keybase1.GetTLFCryptKeysRes{}, nil
 }

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -12,7 +12,7 @@ import (
 // or held onto for very long, just to remember the keys while
 // unboxing a thread of messages.
 type KeyFinder interface {
-	Find(ctx context.Context, tlf keybase1.TlfInterface, tlfName string, tlfPublic bool) (keybase1.GetTLFCryptKeysRes, error)
+	Find(ctx context.Context, tlf keybase1.TlfInterface, tlfName string, tlfPublic bool, identifyBehavior keybase1.TLFIdentifyBehavior) (keybase1.GetTLFCryptKeysRes, error)
 }
 
 type KeyFinderImpl struct {
@@ -30,7 +30,7 @@ func (k *KeyFinderImpl) cacheKey(tlfName string, tlfPublic bool) string {
 
 // find finds keybase1.TLFCryptKeys for tlfName, checking for existing
 // results.
-func (k *KeyFinderImpl) Find(ctx context.Context, tlf keybase1.TlfInterface, tlfName string, tlfPublic bool) (keybase1.GetTLFCryptKeysRes, error) {
+func (k *KeyFinderImpl) Find(ctx context.Context, tlf keybase1.TlfInterface, tlfName string, tlfPublic bool, identifyBehavior keybase1.TLFIdentifyBehavior) (keybase1.GetTLFCryptKeysRes, error) {
 	ckey := k.cacheKey(tlfName, tlfPublic)
 	existing, ok := k.keys[ckey]
 	if ok {
@@ -39,7 +39,7 @@ func (k *KeyFinderImpl) Find(ctx context.Context, tlf keybase1.TlfInterface, tlf
 
 	query := keybase1.TLFQuery{
 		TlfName:          tlfName,
-		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		IdentifyBehavior: identifyBehavior,
 	}
 
 	var keys keybase1.GetTLFCryptKeysRes

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -64,8 +64,8 @@ func setupTest(t *testing.T) (libkb.TestContext, chat1.RemoteInterface, *kbtest.
 	f := func() libkb.SecretUI {
 		return &libkb.TestSecretUI{Passphrase: u.Passphrase}
 	}
-	baseSender := NewBlockingSender(tc.G, boxer, func() chat1.RemoteInterface { return ri }, f)
-	sender := NewNonblockingSender(tc.G, baseSender)
+	baseSender := NewBlockingSender(tc.G, boxer, func() chat1.RemoteInterface { return ri }, f, keybase1.TLFIdentifyBehavior_CHAT_CLI)
+	sender := NewNonblockingSender(tc.G, baseSender, tlf, keybase1.TLFIdentifyBehavior_CHAT_CLI)
 	listener := chatListener{
 		action: make(chan int),
 	}
@@ -96,7 +96,7 @@ func TestNonblockChannel(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	obid, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+	obid, _, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Sender:    u.User.GetUID().ToBytes(),
 			TlfName:   u.Username,

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -165,3 +165,16 @@ func splitAndNormalizeTLFNameCanonicalize(name string, public bool) (writerNames
 	}
 	return writerNames, readerNames, extensionSuffix, err
 }
+
+func FlattenTLFUserBreaks(breaks []keybase1.TLFUserBreak) (flattened []keybase1.TLFUserBreak) {
+	uids := make(map[string]bool)
+	for _, b := range breaks {
+		uid := b.User.Uid.String()
+		if !uids[uid] {
+			uids[uid] = true
+			flattened = append(flattened, b)
+		}
+	}
+
+	return flattened
+}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -510,9 +510,9 @@ type ExternalServicesCollector interface {
 
 type ConversationSource interface {
 	Push(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
-		msg chat1.MessageBoxed) (chat1.MessageUnboxed, error)
+		msg chat1.MessageBoxed, identifyBehavior keybase1.TLFIdentifyBehavior) (chat1.MessageUnboxed, error)
 	Pull(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, query *chat1.GetThreadQuery,
-		pagination *chat1.Pagination) (chat1.ThreadView, []*chat1.RateLimit, error)
+		pagination *chat1.Pagination, identifyBehavior keybase1.TLFIdentifyBehavior) (chat1.ThreadView, []*chat1.RateLimit, []keybase1.TLFUserBreak, error)
 	Clear(convID chat1.ConversationID, uid gregor1.UID) error
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -425,10 +425,11 @@ type ConversationInfoLocal struct {
 }
 
 type ConversationLocal struct {
-	Error       *string                `codec:"error,omitempty" json:"error,omitempty"`
-	Info        ConversationInfoLocal  `codec:"info" json:"info"`
-	ReaderInfo  ConversationReaderInfo `codec:"readerInfo" json:"readerInfo"`
-	MaxMessages []MessageUnboxed       `codec:"maxMessages" json:"maxMessages"`
+	Error       *string                 `codec:"error,omitempty" json:"error,omitempty"`
+	Info        ConversationInfoLocal   `codec:"info" json:"info"`
+	ReaderInfo  ConversationReaderInfo  `codec:"readerInfo" json:"readerInfo"`
+	MaxMessages []MessageUnboxed        `codec:"maxMessages" json:"maxMessages"`
+	Breaks      []keybase1.TLFUserBreak `codec:"breaks" json:"breaks"`
 }
 
 type OutboxRecord struct {
@@ -445,15 +446,17 @@ type GetThreadQuery struct {
 }
 
 type GetThreadLocalRes struct {
-	Thread     ThreadView     `codec:"thread" json:"thread"`
-	Outbox     []OutboxRecord `codec:"outbox" json:"outbox"`
-	RateLimits []RateLimit    `codec:"rateLimits" json:"rateLimits"`
+	Thread     ThreadView              `codec:"thread" json:"thread"`
+	Outbox     []OutboxRecord          `codec:"outbox" json:"outbox"`
+	RateLimits []RateLimit             `codec:"rateLimits" json:"rateLimits"`
+	Breaks     []keybase1.TLFUserBreak `codec:"breaks" json:"breaks"`
 }
 
 type GetInboxLocalRes struct {
-	ConversationsUnverified []Conversation `codec:"conversationsUnverified" json:"conversationsUnverified"`
-	Pagination              *Pagination    `codec:"pagination,omitempty" json:"pagination,omitempty"`
-	RateLimits              []RateLimit    `codec:"rateLimits" json:"rateLimits"`
+	ConversationsUnverified []Conversation          `codec:"conversationsUnverified" json:"conversationsUnverified"`
+	Pagination              *Pagination             `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	RateLimits              []RateLimit             `codec:"rateLimits" json:"rateLimits"`
+	Breaks                  []keybase1.TLFUserBreak `codec:"breaks" json:"breaks"`
 }
 
 type GetInboxLocalQuery struct {
@@ -478,13 +481,15 @@ type GetInboxAndUnboxLocalRes struct {
 }
 
 type PostLocalRes struct {
-	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
+	RateLimits []RateLimit             `codec:"rateLimits" json:"rateLimits"`
+	Breaks     []keybase1.TLFUserBreak `codec:"breaks" json:"breaks"`
 }
 
 type OutboxID []byte
 type PostLocalNonblockRes struct {
-	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
-	OutboxID   OutboxID    `codec:"outboxID" json:"outboxID"`
+	RateLimits []RateLimit             `codec:"rateLimits" json:"rateLimits"`
+	OutboxID   OutboxID                `codec:"outboxID" json:"outboxID"`
+	Breaks     []keybase1.TLFUserBreak `codec:"breaks" json:"breaks"`
 }
 
 type SetConversationStatusLocalRes struct {
@@ -498,8 +503,9 @@ type LocalSource struct {
 }
 
 type NewConversationLocalRes struct {
-	Conv       ConversationLocal `codec:"conv" json:"conv"`
-	RateLimits []RateLimit       `codec:"rateLimits" json:"rateLimits"`
+	Conv       ConversationLocal       `codec:"conv" json:"conv"`
+	RateLimits []RateLimit             `codec:"rateLimits" json:"rateLimits"`
+	Breaks     []keybase1.TLFUserBreak `codec:"breaks" json:"breaks"`
 }
 
 type GetInboxSummaryForCLILocalQuery struct {
@@ -533,38 +539,45 @@ type GetConversationForCLILocalRes struct {
 }
 
 type GetMessagesLocalRes struct {
-	Messages   []MessageUnboxed `codec:"messages" json:"messages"`
-	RateLimits []RateLimit      `codec:"rateLimits" json:"rateLimits"`
+	Messages   []MessageUnboxed        `codec:"messages" json:"messages"`
+	RateLimits []RateLimit             `codec:"rateLimits" json:"rateLimits"`
+	Breaks     []keybase1.TLFUserBreak `codec:"breaks" json:"breaks"`
 }
 
 type DownloadAttachmentLocalRes struct {
-	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
+	RateLimits []RateLimit             `codec:"rateLimits" json:"rateLimits"`
+	Breaks     []keybase1.TLFUserBreak `codec:"breaks" json:"breaks"`
 }
 
 type GetThreadLocalArg struct {
-	ConversationID ConversationID  `codec:"conversationID" json:"conversationID"`
-	Query          *GetThreadQuery `codec:"query,omitempty" json:"query,omitempty"`
-	Pagination     *Pagination     `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
+	Query            *GetThreadQuery              `codec:"query,omitempty" json:"query,omitempty"`
+	Pagination       *Pagination                  `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 type GetInboxLocalArg struct {
-	Query      *GetInboxLocalQuery `codec:"query,omitempty" json:"query,omitempty"`
-	Pagination *Pagination         `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	Query            *GetInboxLocalQuery          `codec:"query,omitempty" json:"query,omitempty"`
+	Pagination       *Pagination                  `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 type GetInboxAndUnboxLocalArg struct {
-	Query      *GetInboxLocalQuery `codec:"query,omitempty" json:"query,omitempty"`
-	Pagination *Pagination         `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	Query            *GetInboxLocalQuery          `codec:"query,omitempty" json:"query,omitempty"`
+	Pagination       *Pagination                  `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 type PostLocalArg struct {
-	ConversationID ConversationID   `codec:"conversationID" json:"conversationID"`
-	Msg            MessagePlaintext `codec:"msg" json:"msg"`
+	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
+	Msg              MessagePlaintext             `codec:"msg" json:"msg"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 type PostLocalNonblockArg struct {
-	ConversationID ConversationID   `codec:"conversationID" json:"conversationID"`
-	Msg            MessagePlaintext `codec:"msg" json:"msg"`
+	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
+	Msg              MessagePlaintext             `codec:"msg" json:"msg"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 type SetConversationStatusLocalArg struct {
@@ -573,20 +586,22 @@ type SetConversationStatusLocalArg struct {
 }
 
 type PostAttachmentLocalArg struct {
-	SessionID      int                 `codec:"sessionID" json:"sessionID"`
-	ConversationID ConversationID      `codec:"conversationID" json:"conversationID"`
-	ClientHeader   MessageClientHeader `codec:"clientHeader" json:"clientHeader"`
-	Attachment     LocalSource         `codec:"attachment" json:"attachment"`
-	Preview        *LocalSource        `codec:"preview,omitempty" json:"preview,omitempty"`
-	Title          string              `codec:"title" json:"title"`
-	Metadata       []byte              `codec:"metadata" json:"metadata"`
+	SessionID        int                          `codec:"sessionID" json:"sessionID"`
+	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
+	ClientHeader     MessageClientHeader          `codec:"clientHeader" json:"clientHeader"`
+	Attachment       LocalSource                  `codec:"attachment" json:"attachment"`
+	Preview          *LocalSource                 `codec:"preview,omitempty" json:"preview,omitempty"`
+	Title            string                       `codec:"title" json:"title"`
+	Metadata         []byte                       `codec:"metadata" json:"metadata"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 type NewConversationLocalArg struct {
-	TlfName       string        `codec:"tlfName" json:"tlfName"`
-	TopicType     TopicType     `codec:"topicType" json:"topicType"`
-	TlfVisibility TLFVisibility `codec:"tlfVisibility" json:"tlfVisibility"`
-	TopicName     *string       `codec:"topicName,omitempty" json:"topicName,omitempty"`
+	TlfName          string                       `codec:"tlfName" json:"tlfName"`
+	TopicType        TopicType                    `codec:"topicType" json:"topicType"`
+	TlfVisibility    TLFVisibility                `codec:"tlfVisibility" json:"tlfVisibility"`
+	TopicName        *string                      `codec:"topicName,omitempty" json:"topicName,omitempty"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 type GetInboxSummaryForCLILocalArg struct {
@@ -598,16 +613,18 @@ type GetConversationForCLILocalArg struct {
 }
 
 type GetMessagesLocalArg struct {
-	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
-	MessageIDs     []MessageID    `codec:"messageIDs" json:"messageIDs"`
+	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
+	MessageIDs       []MessageID                  `codec:"messageIDs" json:"messageIDs"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 type DownloadAttachmentLocalArg struct {
-	SessionID      int             `codec:"sessionID" json:"sessionID"`
-	ConversationID ConversationID  `codec:"conversationID" json:"conversationID"`
-	MessageID      MessageID       `codec:"messageID" json:"messageID"`
-	Sink           keybase1.Stream `codec:"sink" json:"sink"`
-	Preview        bool            `codec:"preview" json:"preview"`
+	SessionID        int                          `codec:"sessionID" json:"sessionID"`
+	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
+	MessageID        MessageID                    `codec:"messageID" json:"messageID"`
+	Sink             keybase1.Stream              `codec:"sink" json:"sink"`
+	Preview          bool                         `codec:"preview" json:"preview"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 type LocalInterface interface {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -757,3 +757,16 @@ func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
 func (c CanonicalTlfName) String() string {
 	return string(c)
 }
+
+func FlattenTLFUserBreaks(breaks []TLFUserBreak) (flattened []TLFUserBreak) {
+	uids := make(map[string]bool)
+	for _, b := range breaks {
+		uid := b.User.Uid.String()
+		if !uids[uid] {
+			uids[uid] = true
+			flattened = append(flattened, b)
+		}
+	}
+
+	return flattened
+}

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -757,16 +757,3 @@ func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
 func (c CanonicalTlfName) String() string {
 	return string(c)
 }
-
-func FlattenTLFUserBreaks(breaks []TLFUserBreak) (flattened []TLFUserBreak) {
-	uids := make(map[string]bool)
-	for _, b := range breaks {
-		uid := b.User.Uid.String()
-		if !uids[uid] {
-			uids[uid] = true
-			flattened = append(flattened, b)
-		}
-	}
-
-	return flattened
-}

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -72,7 +72,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 		return &libkb.TestSecretUI{Passphrase: user.Passphrase}
 	}
 	storage := storage.New(tc.G, f)
-	tc.G.ConvSource = chat.NewHybridConversationSource(tc.G, h.boxer, storage, mockRemote)
+	tc.G.ConvSource = chat.NewHybridConversationSource(tc.G, h.boxer, storage, mockRemote, h.tlf)
 	h.setTestRemoteClient(mockRemote)
 
 	tuc := &chatTestUserContext{

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -868,7 +868,11 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 		g.G().Log.Debug("push handler: chat activity: newMessage: convID: %s sender: %s",
 			nm.ConvID, nm.Message.ClientHeader.Sender)
 		uid := m.UID().Bytes()
-		decmsg, err := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
+		decmsg, err := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message,
+			// Since this happens at background, we use GUI mode so that identify
+			// failure doesn't error
+			keybase1.TLFIdentifyBehavior_CHAT_GUI,
+		)
 		if err != nil {
 			g.G().Log.Error("push handler: chat activity: unable to storage message: %s", err.Error())
 		}

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -226,7 +226,12 @@ func (d *Service) createMessageDeliverer() {
 	tlf := newTlfHandler(nil, d.G())
 	udc := utils.NewUserDeviceCache(d.G())
 
-	sender := chat.NewBlockingSender(d.G(), chat.NewBoxer(d.G(), tlf, udc), ri, si)
+	sender := chat.NewBlockingSender(d.G(), chat.NewBoxer(d.G(), tlf, udc), ri, si,
+		// We use GUI behavior for the MessageDeliverer here so the deliverer never
+		// has identify errors. The NonblockingSender that queues messages into the
+		// deliverer should do identify according to the pre-set identifyBehavior,
+		// before returning.
+		keybase1.TLFIdentifyBehavior_CHAT_GUI)
 	d.G().MessageDeliverer = chat.NewDeliverer(d.G(), sender)
 
 	uid := d.G().Env.GetUID()

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -163,6 +163,7 @@ protocol local {
     ConversationInfoLocal info;
     ConversationReaderInfo readerInfo;
     array<MessageUnboxed> maxMessages; // the latest message for each message type
+    array<keybase1.TLFUserBreak> breaks;
   }
 
   record OutboxRecord {
@@ -171,7 +172,7 @@ protocol local {
     MessagePlaintext Msg; 
   }
 
-  GetThreadLocalRes getThreadLocal(ConversationID conversationID, union { null, GetThreadQuery} query, union { null, Pagination } pagination);
+  GetThreadLocalRes getThreadLocal(ConversationID conversationID, union { null, GetThreadQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
   record GetThreadQuery {
     boolean markAsRead;
     array<MessageType> messageTypes;
@@ -182,17 +183,24 @@ protocol local {
     ThreadView thread;
     array<OutboxRecord> outbox;
     array<RateLimit> rateLimits;
+    array<keybase1.TLFUserBreak> breaks;
   }
 
   // topicName in GetInboxLocalQuery is ignored
-  GetInboxLocalRes getInboxLocal(union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination);
+  GetInboxLocalRes getInboxLocal(union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
   record GetInboxLocalRes {
     array<Conversation> conversationsUnverified;
     union { null, Pagination } pagination;
     array<RateLimit> rateLimits;
+
+   // This only contains identify breaks if a TLF name is specified in arg. It
+   // doesn't contain breaks otherwise, since GetInboxLocal doesn't run
+   // identify for each conversation in the inbox. GetInboxAndUnboxLocal should
+   // be used if identify breaks are needed.
+    array<keybase1.TLFUserBreak> breaks;
   }
 
-  GetInboxAndUnboxLocalRes getInboxAndUnboxLocal(union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination);
+  GetInboxAndUnboxLocalRes getInboxAndUnboxLocal(union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior );
   record GetInboxLocalQuery {
     // Local analog of common:GetInboxQuery
 
@@ -219,17 +227,19 @@ protocol local {
     array<RateLimit> rateLimits;
   }
 
-  PostLocalRes postLocal(ConversationID conversationID, MessagePlaintext msg);
+  PostLocalRes postLocal(ConversationID conversationID, MessagePlaintext msg, keybase1.TLFIdentifyBehavior identifyBehavior);
   record PostLocalRes {
     array<RateLimit> rateLimits;
+    array<keybase1.TLFUserBreak> breaks;
   }
 
   @typedef("bytes") record OutboxID {}
   record PostLocalNonblockRes {
     array<RateLimit> rateLimits;
     OutboxID outboxID;
+    array<keybase1.TLFUserBreak> breaks;
   }
-  PostLocalNonblockRes postLocalNonblock(ConversationID conversationID, MessagePlaintext msg);
+  PostLocalNonblockRes postLocalNonblock(ConversationID conversationID, MessagePlaintext msg, keybase1.TLFIdentifyBehavior identifyBehavior);
 
   SetConversationStatusLocalRes SetConversationStatusLocal(ConversationID conversationID, ConversationStatus status);
   record SetConversationStatusLocalRes {
@@ -243,12 +253,13 @@ protocol local {
   }
 
   // Post an attachment in source to conversationID.
-  PostLocalRes postAttachmentLocal(int sessionID, ConversationID conversationID, MessageClientHeader clientHeader, LocalSource attachment, union { null, LocalSource } preview, string title, bytes metadata);
+  PostLocalRes postAttachmentLocal(int sessionID, ConversationID conversationID, MessageClientHeader clientHeader, LocalSource attachment, union { null, LocalSource } preview, string title, bytes metadata, keybase1.TLFIdentifyBehavior identifyBehavior);
 
-  NewConversationLocalRes newConversationLocal(string tlfName, TopicType topicType, TLFVisibility tlfVisibility, union { null, string } topicName);
+  NewConversationLocalRes newConversationLocal(string tlfName, TopicType topicType, TLFVisibility tlfVisibility, union { null, string } topicName, keybase1.TLFIdentifyBehavior identifyBehavior);
   record NewConversationLocalRes {
     ConversationLocal conv;
     array<RateLimit> rateLimits;
+    array<keybase1.TLFUserBreak> breaks;
   }
 
 
@@ -291,15 +302,17 @@ protocol local {
   }
 
   // Get messages by ID.
-  GetMessagesLocalRes GetMessagesLocal(ConversationID conversationID, array<MessageID> messageIDs);
+  GetMessagesLocalRes GetMessagesLocal(ConversationID conversationID, array<MessageID> messageIDs, keybase1.TLFIdentifyBehavior identifyBehavior);
   record GetMessagesLocalRes {
     array<MessageUnboxed> messages;
     array<RateLimit> rateLimits;
+    array<keybase1.TLFUserBreak> breaks;
   }
 
   // Download an attachment from a message into sink.
   record DownloadAttachmentLocalRes {
     array<RateLimit> rateLimits;
+    array<keybase1.TLFUserBreak> breaks;
   }
-  DownloadAttachmentLocalRes DownloadAttachmentLocal(int sessionID, ConversationID conversationID, MessageID messageID, keybase1.Stream sink, boolean preview);
+  DownloadAttachmentLocalRes DownloadAttachmentLocal(int sessionID, ConversationID conversationID, MessageID messageID, keybase1.Stream sink, boolean preview, keybase1.TLFIdentifyBehavior identifyBehavior);
 }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -441,6 +441,7 @@ export type ConversationLocal = {
   info: ConversationInfoLocal,
   readerInfo: ConversationReaderInfo,
   maxMessages?: ?Array<MessageUnboxed>,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type ConversationMetadata = {
@@ -464,6 +465,7 @@ export type ConversationStatus =
 
 export type DownloadAttachmentLocalRes = {
   rateLimits?: ?Array<RateLimit>,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type EncryptedData = {
@@ -525,6 +527,7 @@ export type GetInboxLocalRes = {
   conversationsUnverified?: ?Array<Conversation>,
   pagination?: ?Pagination,
   rateLimits?: ?Array<RateLimit>,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type GetInboxQuery = {
@@ -565,6 +568,7 @@ export type GetInboxSummaryForCLILocalRes = {
 export type GetMessagesLocalRes = {
   messages?: ?Array<MessageUnboxed>,
   rateLimits?: ?Array<RateLimit>,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type GetMessagesRemoteRes = {
@@ -576,6 +580,7 @@ export type GetThreadLocalRes = {
   thread: ThreadView,
   outbox?: ?Array<OutboxRecord>,
   rateLimits?: ?Array<RateLimit>,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type GetThreadQuery = {
@@ -744,6 +749,7 @@ export type MessageUnboxedValid = {
 export type NewConversationLocalRes = {
   conv: ConversationLocal,
   rateLimits?: ?Array<RateLimit>,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type NewConversationRemoteRes = {
@@ -780,10 +786,12 @@ export type Pagination = {
 export type PostLocalNonblockRes = {
   rateLimits?: ?Array<RateLimit>,
   outboxID: OutboxID,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type PostLocalRes = {
   rateLimits?: ?Array<RateLimit>,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type PostRemoteRes = {
@@ -868,7 +876,8 @@ export type localDownloadAttachmentLocalRpcParam = Exact<{
   conversationID: ConversationID,
   messageID: MessageID,
   sink: keybase1.Stream,
-  preview: boolean
+  preview: boolean,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetConversationForCLILocalRpcParam = Exact<{
@@ -877,12 +886,14 @@ export type localGetConversationForCLILocalRpcParam = Exact<{
 
 export type localGetInboxAndUnboxLocalRpcParam = Exact<{
   query?: ?GetInboxLocalQuery,
-  pagination?: ?Pagination
+  pagination?: ?Pagination,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetInboxLocalRpcParam = Exact<{
   query?: ?GetInboxLocalQuery,
-  pagination?: ?Pagination
+  pagination?: ?Pagination,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetInboxSummaryForCLILocalRpcParam = Exact<{
@@ -891,20 +902,23 @@ export type localGetInboxSummaryForCLILocalRpcParam = Exact<{
 
 export type localGetMessagesLocalRpcParam = Exact<{
   conversationID: ConversationID,
-  messageIDs?: ?Array<MessageID>
+  messageIDs?: ?Array<MessageID>,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetThreadLocalRpcParam = Exact<{
   conversationID: ConversationID,
   query?: ?GetThreadQuery,
-  pagination?: ?Pagination
+  pagination?: ?Pagination,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localNewConversationLocalRpcParam = Exact<{
   tlfName: string,
   topicType: TopicType,
   tlfVisibility: TLFVisibility,
-  topicName?: ?string
+  topicName?: ?string,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localPostAttachmentLocalRpcParam = Exact<{
@@ -913,17 +927,20 @@ export type localPostAttachmentLocalRpcParam = Exact<{
   attachment: LocalSource,
   preview?: ?LocalSource,
   title: string,
-  metadata: bytes
+  metadata: bytes,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localPostLocalNonblockRpcParam = Exact<{
   conversationID: ConversationID,
-  msg: MessagePlaintext
+  msg: MessagePlaintext,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localPostLocalRpcParam = Exact<{
   conversationID: ConversationID,
-  msg: MessagePlaintext
+  msg: MessagePlaintext,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localSetConversationStatusLocalRpcParam = Exact<{

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -497,6 +497,13 @@
             "items": "MessageUnboxed"
           },
           "name": "maxMessages"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFUserBreak"
+          },
+          "name": "breaks"
         }
       ]
     },
@@ -570,6 +577,13 @@
             "items": "RateLimit"
           },
           "name": "rateLimits"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFUserBreak"
+          },
+          "name": "breaks"
         }
       ]
     },
@@ -597,6 +611,13 @@
             "items": "RateLimit"
           },
           "name": "rateLimits"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFUserBreak"
+          },
+          "name": "breaks"
         }
       ]
     },
@@ -718,6 +739,13 @@
             "items": "RateLimit"
           },
           "name": "rateLimits"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFUserBreak"
+          },
+          "name": "breaks"
         }
       ]
     },
@@ -741,6 +769,13 @@
         {
           "type": "OutboxID",
           "name": "outboxID"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFUserBreak"
+          },
+          "name": "breaks"
         }
       ]
     },
@@ -789,6 +824,13 @@
             "items": "RateLimit"
           },
           "name": "rateLimits"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFUserBreak"
+          },
+          "name": "breaks"
         }
       ]
     },
@@ -926,6 +968,13 @@
             "items": "RateLimit"
           },
           "name": "rateLimits"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFUserBreak"
+          },
+          "name": "breaks"
         }
       ]
     },
@@ -939,6 +988,13 @@
             "items": "RateLimit"
           },
           "name": "rateLimits"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFUserBreak"
+          },
+          "name": "breaks"
         }
       ]
     }
@@ -963,6 +1019,10 @@
             null,
             "Pagination"
           ]
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
       "response": "GetThreadLocalRes"
@@ -982,6 +1042,10 @@
             null,
             "Pagination"
           ]
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
       "response": "GetInboxLocalRes"
@@ -1001,6 +1065,10 @@
             null,
             "Pagination"
           ]
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
       "response": "GetInboxAndUnboxLocalRes"
@@ -1014,6 +1082,10 @@
         {
           "name": "msg",
           "type": "MessagePlaintext"
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
       "response": "PostLocalRes"
@@ -1027,6 +1099,10 @@
         {
           "name": "msg",
           "type": "MessagePlaintext"
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
       "response": "PostLocalNonblockRes"
@@ -1076,6 +1152,10 @@
         {
           "name": "metadata",
           "type": "bytes"
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
       "response": "PostLocalRes"
@@ -1100,6 +1180,10 @@
             null,
             "string"
           ]
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
       "response": "NewConversationLocalRes"
@@ -1134,6 +1218,10 @@
             "type": "array",
             "items": "MessageID"
           }
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
       "response": "GetMessagesLocalRes"
@@ -1159,6 +1247,10 @@
         {
           "name": "preview",
           "type": "boolean"
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
       "response": "DownloadAttachmentLocalRes"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -441,6 +441,7 @@ export type ConversationLocal = {
   info: ConversationInfoLocal,
   readerInfo: ConversationReaderInfo,
   maxMessages?: ?Array<MessageUnboxed>,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type ConversationMetadata = {
@@ -464,6 +465,7 @@ export type ConversationStatus =
 
 export type DownloadAttachmentLocalRes = {
   rateLimits?: ?Array<RateLimit>,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type EncryptedData = {
@@ -525,6 +527,7 @@ export type GetInboxLocalRes = {
   conversationsUnverified?: ?Array<Conversation>,
   pagination?: ?Pagination,
   rateLimits?: ?Array<RateLimit>,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type GetInboxQuery = {
@@ -565,6 +568,7 @@ export type GetInboxSummaryForCLILocalRes = {
 export type GetMessagesLocalRes = {
   messages?: ?Array<MessageUnboxed>,
   rateLimits?: ?Array<RateLimit>,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type GetMessagesRemoteRes = {
@@ -576,6 +580,7 @@ export type GetThreadLocalRes = {
   thread: ThreadView,
   outbox?: ?Array<OutboxRecord>,
   rateLimits?: ?Array<RateLimit>,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type GetThreadQuery = {
@@ -744,6 +749,7 @@ export type MessageUnboxedValid = {
 export type NewConversationLocalRes = {
   conv: ConversationLocal,
   rateLimits?: ?Array<RateLimit>,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type NewConversationRemoteRes = {
@@ -780,10 +786,12 @@ export type Pagination = {
 export type PostLocalNonblockRes = {
   rateLimits?: ?Array<RateLimit>,
   outboxID: OutboxID,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type PostLocalRes = {
   rateLimits?: ?Array<RateLimit>,
+  breaks?: ?Array<keybase1.TLFUserBreak>,
 }
 
 export type PostRemoteRes = {
@@ -868,7 +876,8 @@ export type localDownloadAttachmentLocalRpcParam = Exact<{
   conversationID: ConversationID,
   messageID: MessageID,
   sink: keybase1.Stream,
-  preview: boolean
+  preview: boolean,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetConversationForCLILocalRpcParam = Exact<{
@@ -877,12 +886,14 @@ export type localGetConversationForCLILocalRpcParam = Exact<{
 
 export type localGetInboxAndUnboxLocalRpcParam = Exact<{
   query?: ?GetInboxLocalQuery,
-  pagination?: ?Pagination
+  pagination?: ?Pagination,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetInboxLocalRpcParam = Exact<{
   query?: ?GetInboxLocalQuery,
-  pagination?: ?Pagination
+  pagination?: ?Pagination,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetInboxSummaryForCLILocalRpcParam = Exact<{
@@ -891,20 +902,23 @@ export type localGetInboxSummaryForCLILocalRpcParam = Exact<{
 
 export type localGetMessagesLocalRpcParam = Exact<{
   conversationID: ConversationID,
-  messageIDs?: ?Array<MessageID>
+  messageIDs?: ?Array<MessageID>,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetThreadLocalRpcParam = Exact<{
   conversationID: ConversationID,
   query?: ?GetThreadQuery,
-  pagination?: ?Pagination
+  pagination?: ?Pagination,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localNewConversationLocalRpcParam = Exact<{
   tlfName: string,
   topicType: TopicType,
   tlfVisibility: TLFVisibility,
-  topicName?: ?string
+  topicName?: ?string,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localPostAttachmentLocalRpcParam = Exact<{
@@ -913,17 +927,20 @@ export type localPostAttachmentLocalRpcParam = Exact<{
   attachment: LocalSource,
   preview?: ?LocalSource,
   title: string,
-  metadata: bytes
+  metadata: bytes,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localPostLocalNonblockRpcParam = Exact<{
   conversationID: ConversationID,
-  msg: MessagePlaintext
+  msg: MessagePlaintext,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localPostLocalRpcParam = Exact<{
   conversationID: ConversationID,
-  msg: MessagePlaintext
+  msg: MessagePlaintext,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localSetConversationStatusLocalRpcParam = Exact<{


### PR DESCRIPTION
r? @mmaxim @maxtaco @patrickxb Thanks!

I'm particularly not sure about the senders and the `Deliverer`. It makes most sense to me, and thus is what I did, that the `Deliverer` never errors identifies, or collects breaks, and it's the `NonblockingSender`'s responsibility to run identify and either error or collect breaks if necessary. In other words, messages queued into the `Deliverer` is always ready to send. As a result, the `Deliverer` uses a sender with GUI mode. Does it sound good to you guys?