### PR TITLE
Desktop: Style chat input widget

### DIFF
--- a/shared/chat/conversation/input.desktop.js
+++ b/shared/chat/conversation/input.desktop.js
@@ -48,7 +48,6 @@ const styleIcon = {
   paddingTop: globalMargins.xtiny,
   paddingLeft: globalMargins.xtiny,
   paddingRight: globalMargins.xtiny,
-
 }
 
 const styleFooter = {

--- a/shared/chat/conversation/input.desktop.js
+++ b/shared/chat/conversation/input.desktop.js
@@ -14,7 +14,7 @@ class Conversation extends Component<void, Props, void> {
 
   render () {
     return (
-      <Box style={{...globalStyles.flexBoxColumn, minHeight: 48, borderTop: `solid 1px ${globalColors.black_05}`}}>
+      <Box style={{...globalStyles.flexBoxColumn, borderTop: `solid 1px ${globalColors.black_05}`}}>
         <Box style={{...globalStyles.flexBoxRow}}>
           <Input
             small={true}
@@ -28,8 +28,8 @@ class Conversation extends Component<void, Props, void> {
               this._input.clearValue()
             }}
           />
-          <Icon style={styleIcon} type='iconfont-emoji' />
-          <Icon style={styleIcon} type='iconfont-attachment' />
+          <Icon onClick={() => console.log('emoji callback')} style={styleIcon} type='iconfont-emoji' />
+          <Icon onClick={() => console.log('attachment callback')} style={styleIcon} type='iconfont-attachment' />
         </Box>
         <Text type='BodySmall' style={styleFooter}>*bold*, _italics_, `code`, >quote</Text>
       </Box>
@@ -45,7 +45,10 @@ const styleInput = {
 }
 
 const styleIcon = {
-  padding: 5,
+  paddingTop: globalMargins.xtiny,
+  paddingLeft: globalMargins.xtiny,
+  paddingRight: globalMargins.xtiny,
+
 }
 
 const styleFooter = {
@@ -53,7 +56,7 @@ const styleFooter = {
   color: globalColors.black_20,
   textAlign: 'right',
   marginTop: 0,
-  marginBottom: globalMargins.tiny,
+  marginBottom: globalMargins.xtiny,
   marginRight: globalMargins.tiny,
 }
 

--- a/shared/chat/conversation/input.desktop.js
+++ b/shared/chat/conversation/input.desktop.js
@@ -1,7 +1,7 @@
 // @flow
 import React, {Component} from 'react'
-import {Box, Input} from '../../common-adapters'
-import {globalStyles, globalColors} from '../../styles'
+import {Box, Icon, Input, Text} from '../../common-adapters'
+import {globalColors, globalMargins, globalStyles} from '../../styles'
 
 import type {Props} from './'
 
@@ -14,22 +14,47 @@ class Conversation extends Component<void, Props, void> {
 
   render () {
     return (
-      <Box style={{...globalStyles.flexBoxRow, minHeight: 48, borderTop: `solid 1px ${globalColors.black_05}`}}>
-        <Input
-          small={true}
-          style={{flex: 1, textAlign: 'left'}}
-          hintStyle={{textAlign: 'left'}}
-          ref={this._setRef}
-          hintText={`Write to ${this.props.participants.join(', ')}`}
-          underlineShow={false}
-          onEnterKeyDown={() => {
-            this.props.onPostMessage(this._input.getValue())
-            this._input.clearValue()
-          }}
-        />
+      <Box style={{...globalStyles.flexBoxColumn, minHeight: 48, borderTop: `solid 1px ${globalColors.black_05}`}}>
+        <Box style={{...globalStyles.flexBoxRow}}>
+          <Input
+            small={true}
+            style={styleInput}
+            hintStyle={{textAlign: 'left'}}
+            ref={this._setRef}
+            hintText={`Write to ${this.props.participants.join(', ')}`}
+            underlineShow={false}
+            onEnterKeyDown={() => {
+              this.props.onPostMessage(this._input.getValue())
+              this._input.clearValue()
+            }}
+          />
+          <Icon style={styleIcon} type='iconfont-emoji' />
+          <Icon style={styleIcon} type='iconfont-attachment' />
+        </Box>
+        <Text type='BodySmall' style={styleFooter}>*bold*, _italics_, `code`, >quote</Text>
       </Box>
     )
   }
+}
+
+const styleInput = {
+  flex: 1,
+  marginLeft: globalMargins.tiny,
+  marginRight: globalMargins.tiny,
+  textAlign: 'left',
+}
+
+const styleIcon = {
+  padding: 5,
+}
+
+const styleFooter = {
+  flex: 1,
+  color: globalColors.black_20,
+  textAlign: 'right',
+  marginTop: 0,
+  marginBottom: globalMargins.tiny,
+  marginRight: globalMargins.tiny,
 }
 
 export default Conversation


### PR DESCRIPTION
@keybase/react-hackers 

App above, Zeplin below.  There'll be some styling tweaks needed later (and an icon fix for the emoji SVG, which I think is coming separately) once rework on the small input widget has happened, but this gets us close for now.

![screenshot from 2016-11-08 13-28-57](https://cloud.githubusercontent.com/assets/21217/20113134/16fcde4a-a5bd-11e6-9425-dc26f6badfc5.png)
