### PR TITLE
Fix panic from non-full inbox

### DIFF
--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -153,6 +153,13 @@ func (h *chatLocalHandler) GetInboxAndUnboxLocal(ctx context.Context, arg chat1.
 	}
 
 	ctx, _ = utils.GetUserInfoMapper(ctx, h.G())
+	typ, err := ib.Inbox.Rtype()
+	if err != nil {
+		return chat1.GetInboxAndUnboxLocalRes{}, err
+	}
+	if typ != chat1.InboxResType_FULL {
+		return chat1.GetInboxAndUnboxLocalRes{}, fmt.Errorf("inbox response not 'full' type")
+	}
 	convLocals, err := h.localizeConversationsPipeline(ctx, ib.Inbox.Full().Conversations)
 	if err != nil {
 		return chat1.GetInboxAndUnboxLocalRes{}, err


### PR DESCRIPTION
`keybase chat ls` caused the service to panic when trying to access the `Full` variant of a `chat1.InboxView` that isn't there. This is an artifact of https://github.com/keybase/client/pull/4811. With this change, it's still an error, but not a panic.

update: Since updating my local gregor/server/client this error doesn't show up. 👍 

r? @mmaxim 