### PR TITLE
Fix computer-provisions-computer case

### DIFF
--- a/shared/login/register/code-page/index.render.desktop.js
+++ b/shared/login/register/code-page/index.render.desktop.js
@@ -82,10 +82,11 @@ class CodePageRender extends Component<void, Props, void> {
           onChange={event => this.props.onChangeText(event.target.value)}
         />
         <Button type='Primary' style={{alignSelf: 'flex-end', marginTop: 35, marginBottom: 20}} label='Continue' onClick={() => this.props.textEntered(codePageModeEnterText)} />
-        <p style={{...globalStyles.flexBoxRow, alignItems: 'flex-end'}} onClick={() => this.props.setCodePageMode(codePageModeShowCode)}>
+        {this._otherIsPhone() && <p style={{...globalStyles.flexBoxRow, alignItems: 'flex-end'}} onClick={() => this.props.setCodePageMode(codePageModeShowCode)}>
           <Icon style={{marginRight: 15}} type='icon-phone-qr-code-48' />
           <Text type='BodyPrimaryLink' onClick={() => this.props.setCodePageMode(codePageModeShowCode)}>Scan QR code instead</Text>
         </p>
+        }
       </Container>
     )
   }


### PR DESCRIPTION
@keybase/react-hackers 

Looks like this is sufficient to fix c1c2 -- now we have:

c1 GUI provisioning c2 GUI: c1 enters text code, c2 displays text code

c1 GUI provisioning c2 terminal: c1 enters text code, c2 displays text code

c1 terminal provisioning c2 GUI: c1 enters text code, c2 displays text code