### PR TITLE
Include Keybase in Finder favorites

### DIFF
--- a/go/launchd/launchd.go
+++ b/go/launchd/launchd.go
@@ -168,6 +168,10 @@ func (s Service) Restart(wait time.Duration) error {
 
 // WaitForStatus waits for service status to be available
 func (s Service) WaitForStatus(wait time.Duration, delay time.Duration) (*ServiceStatus, error) {
+	if wait <= 0 {
+		return s.LoadStatus()
+	}
+
 	t := time.Now()
 	i := 1
 	for time.Now().Sub(t) < wait {

--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.43</string>
+	<string>1.1.44</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.43</string>
+	<string>1.1.44</string>
 	<key>KBFuseBuild</key>
 	<string>3.5.2</string>
 	<key>KBFuseVersion</key>

--- a/osx/Installer/Options.h
+++ b/osx/Installer/Options.h
@@ -1,5 +1,5 @@
 //
-//  Settings.h
+//  Options.h
 //  Keybase
 //
 //  Created by Gabriel on 1/11/16.
@@ -22,7 +22,7 @@ typedef NS_OPTIONS (NSUInteger, UninstallOptions) {
   UninstallOptionAll = UninstallOptionMountDir | UninstallOptionFuse | UninstallOptionHelper,
 };
 
-@interface Settings : NSObject
+@interface Options : NSObject
 
 @property (readonly) NSString *appPath;
 @property (readonly) NSString *runMode;

--- a/osx/Installer/Options.m
+++ b/osx/Installer/Options.m
@@ -1,14 +1,14 @@
 //
-//  Settings.m
+//  Options.m
 //  Keybase
 //
 //  Created by Gabriel on 1/11/16.
 //  Copyright © 2016 Keybase. All rights reserved.
 //
 
-#import "Settings.h"
+#import "Options.h"
 
-@interface Settings ()
+@interface Options ()
 @property NSString *appPath;
 @property NSString *runMode;
 @property UninstallOptions uninstallOptions;
@@ -17,7 +17,7 @@
 @property GBSettings *settings;
 @end
 
-@implementation Settings
+@implementation Options
 
 - (instancetype)init {
   if ((self = [self initWithSettings:[GBSettings settingsWithName:@"Settings" parent:nil]])) {

--- a/osx/Installer/Uninstaller.h
+++ b/osx/Installer/Uninstaller.h
@@ -9,10 +9,10 @@
 #import <Foundation/Foundation.h>
 
 #import <KBKit/KBKit.h>
-#import "Settings.h"
+#import "Options.h"
 
 @interface Uninstaller : NSObject
 
-+ (void)uninstallWithSettings:(Settings *)settings completion:(KBCompletion)completion;
++ (void)uninstallWithOptions:(Options *)options completion:(KBCompletion)completion;
 
 @end

--- a/osx/Installer/Uninstaller.m
+++ b/osx/Installer/Uninstaller.m
@@ -12,27 +12,27 @@
 
 @implementation Uninstaller
 
-+ (void)uninstallWithSettings:(Settings *)settings completion:(KBCompletion)completion {
-  KBEnvironment *environment = settings.environment;
++ (void)uninstallWithOptions:(Options *)options completion:(KBCompletion)completion {
+  KBEnvironment *environment = options.environment;
   NSMutableArray *installables = [NSMutableArray array];
   // The order of the installables to uninstall is important.
   // For example, if you remove the helper first, kext won't unload.
-  if (settings.uninstallOptions & UninstallOptionMountDir) {
+  if (options.uninstallOptions & UninstallOptionMountDir) {
     KBMountDir *mountDir = [[KBMountDir alloc] initWithConfig:environment.config helperTool:environment.helperTool];
     [installables addObject:mountDir];
   }
-  if (settings.uninstallOptions & UninstallOptionFuse) {
+  if (options.uninstallOptions & UninstallOptionFuse) {
     if (!environment.fuse) {
       completion(KBMakeError(-1, @"No fuse to uninstall"));
       return;
     }
     [installables addObject:environment.fuse];
   }
-  if (settings.uninstallOptions & UninstallOptionHelper) {
+  if (options.uninstallOptions & UninstallOptionHelper) {
     [installables addObject:environment.helperTool];
   }
-  if (settings.uninstallOptions & UninstallOptionApp) {
-    [installables addObject:[[KBAppBundle alloc] initWithPath:settings.appPath]];
+  if (options.uninstallOptions & UninstallOptionApp) {
+    [installables addObject:[[KBAppBundle alloc] initWithPath:options.appPath]];
   }
   [KBUninstaller uninstall:installables completion:completion];
 }

--- a/osx/KBKit/KBKit/Component/KBInstaller.h
+++ b/osx/KBKit/KBKit/Component/KBInstaller.h
@@ -19,6 +19,5 @@
 - (void)uninstallWithEnvironment:(KBEnvironment *)environment completion:(dispatch_block_t)completion;
 
 + (void)setLoginItemEnabled:(BOOL)loginItemEnabled config:(KBEnvConfig *)config appPath:(NSString *)appPath;
-+ (void)setFileListFavoriteEnabled:(BOOL)fileListFavoriteEnabled config:(KBEnvConfig *)config;
 
 @end

--- a/osx/KBKit/KBKit/Component/KBInstaller.m
+++ b/osx/KBKit/KBKit/Component/KBInstaller.m
@@ -93,22 +93,6 @@
   [rover run];
 }
 
-+ (void)setFileListFavoriteEnabled:(BOOL)fileListFavoriteEnabled config:(KBEnvConfig *)config {
-  if (!config.mountDir) {
-    DDLogError(@"No mount dir");
-    return;
-  }
-
-  NSURL *URL = [NSURL fileURLWithPath:config.mountDir];
-  NSString *name = [config appName];
-  NSError *error = nil;
-  //DDLogDebug(@"File list favorite items: %@", [KBSharedFileList debugItemsForType:kLSSharedFileListFavoriteItems]);
-  DDLogDebug(@"File list favorite %@ (%@)", (fileListFavoriteEnabled ? @"enabled" : @"disabled"), URL);
-  BOOL changed = [KBSharedFileList setEnabled:fileListFavoriteEnabled URL:URL name:name type:kLSSharedFileListFavoriteItems insertAfter:kLSSharedFileListItemBeforeFirst error:&error];
-  DDLogDebug(@"File list favorites changed: %@", changed ? @"Yes" : @"No");
-  if (error) DDLogError(@"Error setting volume: %@", error);
-}
-
 + (void)setLoginItemEnabled:(BOOL)loginItemEnabled config:(KBEnvConfig *)config appPath:(NSString *)appPath {
   NSBundle *appBundle = [NSBundle bundleWithPath:appPath];
   if (!appBundle) {

--- a/osx/KBKit/KBKit/Component/KBMountDir.m
+++ b/osx/KBKit/KBKit/Component/KBMountDir.m
@@ -128,8 +128,8 @@
     return NO;
   }
 
-  // We can't reliably create a file list (Finder) favorite directly for /keybase, since it is a remove volume mount,
-  // and there is some funkiness there (like the URL property not resolving, or the display name being ignored.
+  // We can't reliably create a file list (Finder) favorite directly for /keybase, since it is a remote volume mount,
+  // and there is some funkiness there (like the URL property not resolving, or the display name being ignored).
   // If we create a symlink though, all these problems are avoided. So we'll create a symlink to /keybase and add this
   // as the file list favorite item.
   NSString *symPath = [config appPath:@"Keybase" options:0];

--- a/osx/KBKit/KBKit/Component/KBMountDir.m
+++ b/osx/KBKit/KBKit/Component/KBMountDir.m
@@ -128,6 +128,10 @@
     return NO;
   }
 
+  // We can't reliably create a file list (Finder) favorite directly for /keybase, since it is a remove volume mount,
+  // and there is some funkiness there (like the URL property not resolving, or the display name being ignored.
+  // If we create a symlink though, all these problems are avoided. So we'll create a symlink to /keybase and add this
+  // as the file list favorite item.
   NSString *symPath = [config appPath:@"Keybase" options:0];
   if (![[NSFileManager defaultManager] fileExistsAtPath:symPath]) {
     if ([[NSFileManager defaultManager] createSymbolicLinkAtPath:symPath withDestinationPath:config.mountDir error:error]) {

--- a/osx/KBKit/KBKit/Component/KBMountDir.m
+++ b/osx/KBKit/KBKit/Component/KBMountDir.m
@@ -7,6 +7,8 @@
 //
 
 #import "KBMountDir.h"
+#import "KBInstaller.h"
+#import "KBSharedFileList.h"
 
 @interface KBMountDir ()
 @property KBHelperTool *helperTool;
@@ -79,9 +81,13 @@
       }
       // Run check again after create for debug info
       [self checkMountDirExists];
+
+      // Enabled Finder favorite
+      [self setFinderFavoriteEnabled:YES];
       completion(nil);
     }];
   } else {
+    [self setFinderFavoriteEnabled:YES];
     completion(nil);
   }
 }
@@ -94,6 +100,51 @@
     return;
   }
   [self removeMountDir:mountDir completion:completion];
+  [self setFinderFavoriteEnabled:NO];
+}
+
+- (void)refreshComponent:(KBRefreshComponentCompletion)completion {
+  if ([self checkMountDirExists]) {
+    self.componentStatus = [KBComponentStatus componentStatusWithInstallStatus:KBRInstallStatusInstalled installAction:KBRInstallActionNone info:nil error:nil];
+  } else {
+    self.componentStatus = [KBComponentStatus componentStatusWithInstallStatus:KBRInstallStatusNotInstalled installAction:KBRInstallActionInstall info:nil error:nil];
+  }
+  completion(self.componentStatus);
+}
+
+- (BOOL)setFinderFavoriteEnabled:(BOOL)favoritedEnabled {
+  NSError *error = nil;
+  [KBMountDir setFileListFavoriteEnabled:favoritedEnabled config:self.config error:&error];
+  if (error) {
+    DDLogError(@"Error setting file list favorite: %@", error);
+    return NO;
+  }
+  return YES;
+}
+
++ (BOOL)setFileListFavoriteEnabled:(BOOL)fileListFavoriteEnabled config:(KBEnvConfig *)config error:(NSError **)error {
+  if (!config.mountDir) {
+    if (error) *error = KBMakeError(0, @"No mount dir");
+    return NO;
+  }
+
+  NSString *symPath = [config appPath:@"Keybase" options:0];
+  if (![[NSFileManager defaultManager] fileExistsAtPath:symPath]) {
+    if ([[NSFileManager defaultManager] createSymbolicLinkAtPath:symPath withDestinationPath:config.mountDir error:error]) {
+      return NO;
+    }
+  }
+
+  NSURL *URL = [NSURL fileURLWithPath:symPath];
+  NSString *name = [config appName];
+  //DDLogDebug(@"File list favorite items: %@", [KBSharedFileList debugItemsForType:kLSSharedFileListFavoriteItems]);
+  DDLogDebug(@"File list favorite %@ (%@)", (fileListFavoriteEnabled ? @"enabled" : @"disabled"), URL);
+  BOOL changed = [KBSharedFileList setEnabled:fileListFavoriteEnabled URL:URL name:name type:kLSSharedFileListFavoriteItems insertAfter:kLSSharedFileListItemBeforeFirst error:&error];
+  DDLogDebug(@"File list favorites changed: %@", changed ? @"Yes" : @"No");
+  if (error) {
+    return NO;
+  }
+  return changed;
 }
 
 @end

--- a/osx/Keybase.xcodeproj/project.pbxproj
+++ b/osx/Keybase.xcodeproj/project.pbxproj
@@ -1352,7 +1352,7 @@
 				CODE_SIGN_ENTITLEMENTS = Installer/Installer.entitlements;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 99229SGT5K;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Installer/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";

--- a/osx/Keybase.xcodeproj/project.pbxproj
+++ b/osx/Keybase.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		0057B0C61AE57A7A00BFB0E7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0057B0C21AE57A7A00BFB0E7 /* main.m */; };
 		0057B0DB1AE57B5900BFB0E7 /* keybase.Helper in Copy Files */ = {isa = PBXBuildFile; fileRef = 0057B0B41AE57A4900BFB0E7 /* keybase.Helper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		00938E2F1D3D9938003BB1EC /* kbfuse.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 00938E2E1D3D9938003BB1EC /* kbfuse.bundle */; };
+		0097BA671DD2589C0047118C /* Options.m in Sources */ = {isa = PBXBuildFile; fileRef = 0097BA661DD2589C0047118C /* Options.m */; };
+		0097BA681DD259B90047118C /* Options.m in Sources */ = {isa = PBXBuildFile; fileRef = 0097BA661DD2589C0047118C /* Options.m */; };
 		009E135C1B27654200C72B28 /* ShareViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 009E135B1B27654200C72B28 /* ShareViewController.xib */; };
 		009E136B1B27B39300C72B28 /* icon.icns in Resources */ = {isa = PBXBuildFile; fileRef = 009E136A1B27B39300C72B28 /* icon.icns */; };
 		009E136F1B27B39300C72B28 /* ActionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 009E136E1B27B39300C72B28 /* ActionViewController.m */; };
@@ -34,8 +36,6 @@
 		00DAF5C01B2F8969000D7F9A /* Social.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00DAF5BE1B2F885D000D7F9A /* Social.framework */; };
 		00E1CEEF1C44313B00ED3A35 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 00E1CEEE1C44313B00ED3A35 /* Media.xcassets */; };
 		00E1CEF01C44313B00ED3A35 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 00E1CEEE1C44313B00ED3A35 /* Media.xcassets */; };
-		00E1CEF51C4432F900ED3A35 /* Settings.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E1CEF41C4432F900ED3A35 /* Settings.m */; };
-		00E1CEF61C4432F900ED3A35 /* Settings.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E1CEF41C4432F900ED3A35 /* Settings.m */; };
 		140F37DCFE61D8AA9A83FF5C /* libPods-keybase.Helper.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AF01BC4A44FA5C6796C1C820 /* libPods-keybase.Helper.a */; };
 		2B53DDCDBBFA7E3B74F64EE3 /* libPods-Status.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ECBDAE14DC630518EBC27C76 /* libPods-Status.a */; };
 		E144464761C164A1896A2D78 /* libPods-Installer.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C3C8C0FAD444743EC88E6FF1 /* libPods-Installer.a */; };
@@ -138,6 +138,8 @@
 		0057B0C11AE57A7A00BFB0E7 /* keybase.Helper.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = keybase.Helper.plist; sourceTree = "<group>"; };
 		0057B0C21AE57A7A00BFB0E7 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		00938E2E1D3D9938003BB1EC /* kbfuse.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = kbfuse.bundle; path = Fuse/kbfuse.bundle; sourceTree = "<group>"; };
+		0097BA651DD2589C0047118C /* Options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Options.h; sourceTree = "<group>"; };
+		0097BA661DD2589C0047118C /* Options.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Options.m; sourceTree = "<group>"; };
 		009E135B1B27654200C72B28 /* ShareViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ShareViewController.xib; sourceTree = "<group>"; };
 		009E13611B2794CF00C72B28 /* Installer.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Installer.entitlements; sourceTree = "<group>"; };
 		009E13661B27B39300C72B28 /* Action.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Action.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -159,8 +161,6 @@
 		00CC43561A3A9E6C006118A9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		00DAF5BE1B2F885D000D7F9A /* Social.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Social.framework; path = System/Library/Frameworks/Social.framework; sourceTree = SDKROOT; };
 		00E1CEEE1C44313B00ED3A35 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
-		00E1CEF31C4432F900ED3A35 /* Settings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Settings.h; sourceTree = "<group>"; };
-		00E1CEF41C4432F900ED3A35 /* Settings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Settings.m; sourceTree = "<group>"; };
 		00F808061A4A5F600038BC63 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		10F5D4AFBFC1E22180FEFFCD /* Pods-Installer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Installer.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Installer/Pods-Installer.debug.xcconfig"; sourceTree = "<group>"; };
 		398CF2F9A9EB653FFE008EB6 /* Pods-Installer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Installer.release.xcconfig"; path = "Pods/Target Support Files/Pods-Installer/Pods-Installer.release.xcconfig"; sourceTree = "<group>"; };
@@ -374,7 +374,6 @@
 				00938E2E1D3D9938003BB1EC /* kbfuse.bundle */,
 				0036080C1C442E6100B3300E /* Status */,
 				00734B291B263FB500F3B714 /* Extensions */,
-				00E1CEF21C4432E600ED3A35 /* Utils */,
 				0013926F1B06B18A0082DEA8 /* Resources */,
 				0057B0BB1AE57A7A00BFB0E7 /* Helper */,
 				4A1398D8A1B7A96F0CD7F917 /* Tests */,
@@ -405,6 +404,8 @@
 				00AA043B1C03D6AF0047E448 /* Installer.m */,
 				003634061C6039770089465B /* Uninstaller.h */,
 				003634071C6039770089465B /* Uninstaller.m */,
+				0097BA651DD2589C0047118C /* Options.h */,
+				0097BA661DD2589C0047118C /* Options.m */,
 				00CC434C1A3A9E6C006118A9 /* Supporting Files */,
 			);
 			path = Installer;
@@ -419,15 +420,6 @@
 				00CC43511A3A9E6C006118A9 /* main.m */,
 			);
 			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		00E1CEF21C4432E600ED3A35 /* Utils */ = {
-			isa = PBXGroup;
-			children = (
-				00E1CEF31C4432F900ED3A35 /* Settings.h */,
-				00E1CEF41C4432F900ED3A35 /* Settings.m */,
-			);
-			path = Utils;
 			sourceTree = "<group>";
 		};
 		468C135BF6D934E5DFBB8513 /* Frameworks */ = {
@@ -676,7 +668,7 @@
 					00CC43481A3A9E6C006118A9 = {
 						CreatedOnToolsVersion = 6.1.1;
 						DevelopmentTeam = 99229SGT5K;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.Mac = {
 								enabled = 1;
@@ -921,9 +913,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0097BA681DD259B90047118C /* Options.m in Sources */,
 				0005BC9E1C445ADB0062EF1D /* main.m in Sources */,
 				0005BCA21C445BA20062EF1D /* Status.m in Sources */,
-				00E1CEF61C4432F900ED3A35 /* Settings.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -967,9 +959,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				00E1CEF51C4432F900ED3A35 /* Settings.m in Sources */,
 				003634081C6039770089465B /* Uninstaller.m in Sources */,
 				00CC43521A3A9E6C006118A9 /* main.m in Sources */,
+				0097BA671DD2589C0047118C /* Options.m in Sources */,
 				00AA043C1C03D6AF0047E448 /* Installer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1358,15 +1350,17 @@
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Installer/Installer.entitlements;
-				CODE_SIGN_IDENTITY = "Developer ID Application: Keybase, Inc. (99229SGT5K)";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 99229SGT5K;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Installer/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = keybase.Installer;
 				PRODUCT_NAME = Keybase;
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -1380,7 +1374,7 @@
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Installer/Installer.entitlements;
-				CODE_SIGN_IDENTITY = "Developer ID Application: Keybase, Inc. (99229SGT5K)";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEVELOPMENT_TEAM = 99229SGT5K;

--- a/packaging/desktop/kbfuse.sh
+++ b/packaging/desktop/kbfuse.sh
@@ -15,7 +15,7 @@ cd $dir
 client_dir="$dir/../.."
 fuse_dir="$client_dir/osx/Fuse"
 tmp_dir="/tmp/desktop-kbfuse"
-installer_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseInstaller-1.1.43-darwin.tgz"
+installer_url="https://github.com/keybase/client/releases/download/v1.0.18/KeybaseInstaller-1.1.44-darwin.tgz"
 
 if [ "$EUID" -ne 0 ]; then
   echo "Please run as root"

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -76,7 +76,7 @@ shared_support_dir="$out_dir/Keybase.app/Contents/SharedSupport"
 resources_dir="$out_dir/Keybase.app/Contents/Resources/"
 
 # The KeybaseInstaller.app installs KBFuse, keybase.Helper, services and CLI via a native app
-installer_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseInstaller-1.1.43-darwin.tgz"
+installer_url="https://github.com/keybase/client/releases/download/v1.0.18/KeybaseInstaller-1.1.44-darwin.tgz"
 # KeybaseUpdater.app is the native updater UI (prompt dialogs)
 updater_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseUpdater-1.0.5-darwin.tgz"
 


### PR DESCRIPTION
We can't reliably create a file list (Finder) favorite directly for /keybase, since it is a remote volume mount, and there is some funkiness there (like the URL property not resolving, or the display name being ignored). If we create a symlink though, all these problems are avoided. So we'll create a symlink to /keybase and add this as the file list favorite item.

Also I'm changing project file to use Automatic Provisioning. We build and sign using a script, and we verify the signing identity in the install scripts, so this change doesn't affect our builds and makes it easier to test directly from Xcode.