### PR TITLE
set --auto-forked in run_keybase

### DIFF
--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -42,7 +42,9 @@ logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
 mkdir -p "$logdir"
 
 echo Launching keybase service...
-keybase -d --log-file="$logdir/keybase.service.log" service &>> "$logdir/keybase.start.log" &
+# We set the --auto-forked flag here so that updated clients that try to
+# restart this service will know to re-fork it themselves. That's all it does.
+keybase -d --log-file="$logdir/keybase.service.log" service --auto-forked &>> "$logdir/keybase.start.log" &
 echo Mounting /keybase...
 kbfsfuse -debug -log-to-file /keybase &>> "$logdir/keybase.start.log" &
 echo Launching Keybase GUI...


### PR DESCRIPTION
When we were auto-restarting the service on Linux after updates, we were
getting errors like this:

    ERROR dial unix /run/user/1000/keybase/keybased.sock: connect: no such file or directory

The problem was that the new client was not detecting that the service
needed to be auto-forked. We need to set the --auto-forked flag when
spawning it in order for the client to know it needs to restart it.

The name of the flag is slightly confusing, since it's more about what
to do in the future than what was done in the past. The long term
solution is probably to dispense with auto-forking entirely and use the
watchdog from Windows, or systemd.

r? @maxtaco @gabriel 