### PR TITLE
Fix file notifications using tlf properly

### DIFF
--- a/shared/util/kbfs-notifications.js
+++ b/shared/util/kbfs-notifications.js
@@ -1,7 +1,6 @@
 // @flow
 import _ from 'lodash'
 import {KbfsCommonFSErrorType, KbfsCommonFSNotificationType, KbfsCommonFSStatusCode} from '../constants/types/flow-types'
-import {getTLF} from '../util/kbfs'
 import path from 'path'
 import type {FSNotification} from '../constants/types/flow-types'
 

--- a/shared/util/kbfs-notifications.js
+++ b/shared/util/kbfs-notifications.js
@@ -10,10 +10,16 @@ type DecodedKBFSError = {
   'body': string,
 }
 
+function tlfForNotification (notification: FSNotification): string {
+  // The notification.filename is canonical platform independent path.
+  // To get the TLF we can look at the first 3 directories.
+  // /keybase/private/gabrielh/foo.txt => /keybase/private/gabrielh
+  return notification.filename.split(path.sep).slice(0, 4).join(path.sep)
+}
+
 export function decodeKBFSError (user: string, notification: FSNotification): DecodedKBFSError {
   console.log('Notification (kbfs error):', notification)
-  const basedir = notification.filename.split(path.sep)[0]
-  const tlf = `/keybase${getTLF(notification.publicTopLevelFolder, basedir)}`
+  const tlf = tlfForNotification(notification)
   switch (notification.errorType) {
     case KbfsCommonFSErrorType.accessDenied:
       let prefix = user ? `${user} does` : 'You do'
@@ -166,8 +172,7 @@ export function kbfsNotification (notification: FSNotification, notify: any, get
     return
   }
 
-  const basedir = notification.filename.split(path.sep)[0]
-  const tlf = getTLF(notification.publicTopLevelFolder, basedir)
+  const tlf = tlfForNotification(notification)
 
   let title = `KBFS: ${action}`
   let body = `Files in ${tlf} ${notification.status}`

--- a/shared/util/kbfs.js
+++ b/shared/util/kbfs.js
@@ -29,17 +29,3 @@ export function sortUserList (users: UserList): UserList {
   const sortByUsername = (a, b) => +(a.username > b.username)
   return youAsRwer.concat(rwers.sort(sortByUsername), youAsReader, readers.sort(sortByUsername))
 }
-
-export function stripPublicTag (folderName: string): string {
-  return folderName.replace('#public', '')
-}
-
-export function getTLF (isPublic: boolean, basedir: string): string {
-  if (isPublic) {
-    // Public filenames look like cjb#public/foo.txt
-    return `/public/${stripPublicTag(basedir)}`
-  } else {
-    // Private filenames look like cjb/foo.txt
-    return `/private/${basedir}`
-  }
-}


### PR DESCRIPTION
I fixed KBFS to send the full canonical path for FSNotifications:
https://github.com/keybase/kbfs/pull/495

This updates our notify handler, to calculate a TLF which is simply the first 3 directories of the canonical path.