### PR TITLE
Call ToLower on remote proofs reported to the front end

### DIFF
--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -84,7 +84,7 @@ func ExportRemoteProof(p RemoteProofChainLink) keybase1.RemoteProof {
 	return keybase1.RemoteProof{
 		ProofType:     p.GetProofType(),
 		Key:           k,
-		Value:         v,
+		Value:         strings.ToLower(v),
 		DisplayMarkup: v,
 		SigID:         p.GetSigID(),
 		MTime:         keybase1.ToTime(p.GetCTime()),


### PR DESCRIPTION
- Works on either the CLI or Electron, across all proof values
