### PR TITLE
Uninstall component for app

### DIFF
--- a/go/client/cmd_install_osx.go
+++ b/go/client/cmd_install_osx.go
@@ -42,7 +42,7 @@ func NewCmdInstall(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 			},
 			cli.StringFlag{
 				Name:  "c, components",
-				Usage: "Components to install, comma separated. Specify 'cli' for command line, 'service' for service, kbfs for 'kbfs', or blank for all.",
+				Usage: fmt.Sprintf("Components to install, comma separated (%q)", install.ComponentNames),
 			},
 			cli.DurationFlag{
 				Name:  "t, timeout",
@@ -134,6 +134,8 @@ func (v *CmdInstall) Run() error {
 	return nil
 }
 
+var defaultUninstallComponents = []string{"service", "kbfs", "updater", "fuse", "helper"}
+
 func NewCmdUninstall(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name: "uninstall",
@@ -144,7 +146,7 @@ func NewCmdUninstall(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Com
 			},
 			cli.StringFlag{
 				Name:  "c, components",
-				Usage: "Components to uninstall, comma separated. Specify 'cli' for command line, 'service' for service, 'kbfs' for KBFS, or blank for all.",
+				Usage: fmt.Sprintf("Components to uninstall, comma separated (%q)", install.ComponentNames),
 			},
 		},
 		ArgumentHelp: "",
@@ -179,7 +181,7 @@ func (v *CmdUninstall) ParseArgv(ctx *cli.Context) error {
 		if libkb.IsBrewBuild {
 			v.components = []string{"service"}
 		} else {
-			v.components = []string{"service", "kbfs", "updater", "fuse", "helper"}
+			v.components = defaultUninstallComponents
 		}
 	} else {
 		v.components = strings.Split(ctx.String("components"), ",")

--- a/go/install/install.go
+++ b/go/install/install.go
@@ -63,7 +63,7 @@ const (
 )
 
 // ComponentNames are all the valid component names
-var ComponentNames = []ComponentName{ComponentNameCLI, ComponentNameService, ComponentNameKBFS, ComponentNameUpdater}
+var ComponentNames = []ComponentName{ComponentNameCLI, ComponentNameService, ComponentNameKBFS, ComponentNameUpdater, ComponentNameFuse, ComponentNameHelper, ComponentNameApp}
 
 // String returns string for ComponentName
 func (c ComponentName) String() string {

--- a/go/install/install_osx.go
+++ b/go/install/install_osx.go
@@ -562,6 +562,11 @@ func Uninstall(context Context, components []string, log Log) keybase1.Uninstall
 		componentResults = append(componentResults, componentResult(string(ComponentNameHelper), err))
 	}
 
+	if libkb.IsIn(string(ComponentNameApp), components, false) {
+		err = uninstallApp(context.GetRunMode(), log)
+		componentResults = append(componentResults, componentResult(string(ComponentNameApp), err))
+	}
+
 	return newUninstallResult(componentResults)
 }
 
@@ -636,6 +641,11 @@ func uninstallFuse(runMode libkb.RunMode, log Log) error {
 func uninstallHelper(runMode libkb.RunMode, log Log) error {
 	log.Info("Removing privileged helper tool")
 	return execNativeInstallerWithArg("--uninstall-helper", runMode, log)
+}
+
+func uninstallApp(runMode libkb.RunMode, log Log) error {
+	log.Info("Removing app")
+	return execNativeInstallerWithArg("--uninstall-app", runMode, log)
 }
 
 func execNativeInstallerWithArg(arg string, runMode libkb.RunMode, log Log) error {


### PR DESCRIPTION
Will be used by the updater to remove the app, before replacing, if there is a permissions problem, such as the app being owned by a different user.