### PR TITLE
WIP: Async GUI chat

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -171,6 +171,7 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 	if err != nil {
 		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(err)
 	}
+
 	switch headerVersion {
 	case chat1.HeaderPlaintextVersion_V1:
 		hp := header.V1()
@@ -186,6 +187,7 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 	default:
 		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(libkb.NewChatHeaderVersionError(headerVersion))
 	}
+	clientHeader.OutboxID = msg.ClientHeader.OutboxID
 
 	if skipBodyVerification {
 		// body was deleted, so return empty body that matches header version

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -40,8 +40,8 @@ func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActi
 	n.Lock()
 	defer n.Unlock()
 	typ, err := activity.ActivityType()
-	if err == nil && typ == chat1.ChatActivityType_MESSAGE_SENT {
-		n.obids = append(n.obids, activity.MessageSent().OutboxID)
+	if err == nil && typ == chat1.ChatActivityType_INCOMING_MESSAGE {
+		n.obids = append(n.obids, *activity.IncomingMessage().Message.Valid().ClientHeader.OutboxID)
 		n.action <- len(n.obids)
 	}
 }

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -152,7 +152,7 @@ func (o *Outbox) PushMessage(convID chat1.ConversationID, msg chat1.MessagePlain
 
 	// Generate new outbox ID
 	var outboxID chat1.OutboxID
-	outboxID, err = libkb.RandBytes(16)
+	outboxID, err = libkb.RandBytes(8)
 	if err != nil {
 		return nil, o.maybeNuke(libkb.NewChatStorageInternalError(o.G(),
 			"error getting outboxID: err: %s", err.Error()))

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -23,6 +23,7 @@ type ChatMockWorld struct {
 	Fc clockwork.FakeClock
 
 	Tcs     map[string]*libkb.TestContext
+	TcsByID map[string]*libkb.TestContext
 	Users   map[string]*FakeUser
 	tlfs    map[keybase1.CanonicalTlfName]chat1.TLFID
 	tlfKeys map[keybase1.CanonicalTlfName][]keybase1.CryptKey
@@ -38,6 +39,7 @@ func NewChatMockWorld(t *testing.T, name string, numUsers int) (world *ChatMockW
 	world = &ChatMockWorld{
 		Fc:      clockwork.NewFakeClockAt(time.Now()),
 		Tcs:     make(map[string]*libkb.TestContext),
+		TcsByID: make(map[string]*libkb.TestContext),
 		Users:   make(map[string]*FakeUser),
 		tlfs:    make(map[keybase1.CanonicalTlfName]chat1.TLFID),
 		tlfKeys: make(map[keybase1.CanonicalTlfName][]keybase1.CryptKey),
@@ -52,6 +54,7 @@ func NewChatMockWorld(t *testing.T, name string, numUsers int) (world *ChatMockW
 		}
 		world.Users[u.Username] = u
 		world.Tcs[u.Username] = &tc
+		world.TcsByID[u.User.GetUID().String()] = &tc
 	}
 
 	world.Fc.Advance(time.Hour)
@@ -289,6 +292,7 @@ func (m *ChatRemoteMock) GetConversationMetadataRemote(ctx context.Context, conv
 }
 
 func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg) (res chat1.PostRemoteRes, err error) {
+	uid := arg.MessageBoxed.ClientHeader.Sender
 	conv := m.world.GetConversationByID(arg.ConversationID)
 	ri := m.makeReaderInfo(conv.Metadata.ConversationID)
 	inserted := m.insertMsgAndSort(arg.ConversationID, arg.MessageBoxed)
@@ -299,6 +303,19 @@ func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg
 	sort.Sort(convByNewlyUpdated{mock: m})
 	res.MsgHeader = *inserted.ServerHeader
 	res.RateLimit = &chat1.RateLimit{}
+
+	// hit notify router with new message
+	if m.world.TcsByID[uid.String()].G.NotifyRouter != nil {
+		activity := chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
+			Message: chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
+				ClientHeader: inserted.ClientHeader,
+				ServerHeader: *inserted.ServerHeader,
+			}),
+		})
+		m.world.TcsByID[uid.String()].G.NotifyRouter.HandleNewChatActivity(context.Background(),
+			keybase1.UID(uid.String()), &activity)
+	}
+
 	return
 }
 

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -16,6 +16,7 @@ type ConversationID []byte
 type TLFID []byte
 type Hash []byte
 type InboxVers uint64
+type OutboxID []byte
 type MessageType int
 
 const (
@@ -189,6 +190,7 @@ type MessageClientHeader struct {
 	Prev         []MessagePreviousPointer `codec:"prev" json:"prev"`
 	Sender       gregor1.UID              `codec:"sender" json:"sender"`
 	SenderDevice gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
+	OutboxID     *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 }
 
 type EncryptedData struct {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -481,7 +481,6 @@ type PostLocalRes struct {
 	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
 }
 
-type OutboxID []byte
 type PostLocalNonblockRes struct {
 	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
 	OutboxID   OutboxID    `codec:"outboxID" json:"outboxID"`

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -15,19 +15,16 @@ type ChatActivityType int
 const (
 	ChatActivityType_RESERVED         ChatActivityType = 0
 	ChatActivityType_INCOMING_MESSAGE ChatActivityType = 1
-	ChatActivityType_MESSAGE_SENT     ChatActivityType = 2
 )
 
 var ChatActivityTypeMap = map[string]ChatActivityType{
 	"RESERVED":         0,
 	"INCOMING_MESSAGE": 1,
-	"MESSAGE_SENT":     2,
 }
 
 var ChatActivityTypeRevMap = map[ChatActivityType]string{
 	0: "RESERVED",
 	1: "INCOMING_MESSAGE",
-	2: "MESSAGE_SENT",
 }
 
 type IncomingMessage struct {
@@ -35,17 +32,9 @@ type IncomingMessage struct {
 	ConvID  ConversationID `codec:"convID" json:"convID"`
 }
 
-type MessageSentInfo struct {
-	ConvID    ConversationID `codec:"convID" json:"convID"`
-	RateLimit RateLimit      `codec:"rateLimit" json:"rateLimit"`
-	OutboxID  OutboxID       `codec:"outboxID" json:"outboxID"`
-	MessageID MessageID      `codec:"messageID" json:"messageID"`
-}
-
 type ChatActivity struct {
 	ActivityType__    ChatActivityType `codec:"activityType" json:"activityType"`
 	IncomingMessage__ *IncomingMessage `codec:"incomingMessage,omitempty" json:"incomingMessage,omitempty"`
-	MessageSent__     *MessageSentInfo `codec:"messageSent,omitempty" json:"messageSent,omitempty"`
 }
 
 func (o *ChatActivity) ActivityType() (ret ChatActivityType, err error) {
@@ -53,11 +42,6 @@ func (o *ChatActivity) ActivityType() (ret ChatActivityType, err error) {
 	case ChatActivityType_INCOMING_MESSAGE:
 		if o.IncomingMessage__ == nil {
 			err = errors.New("unexpected nil value for IncomingMessage__")
-			return ret, err
-		}
-	case ChatActivityType_MESSAGE_SENT:
-		if o.MessageSent__ == nil {
-			err = errors.New("unexpected nil value for MessageSent__")
 			return ret, err
 		}
 	}
@@ -74,27 +58,10 @@ func (o ChatActivity) IncomingMessage() IncomingMessage {
 	return *o.IncomingMessage__
 }
 
-func (o ChatActivity) MessageSent() MessageSentInfo {
-	if o.ActivityType__ != ChatActivityType_MESSAGE_SENT {
-		panic("wrong case accessed")
-	}
-	if o.MessageSent__ == nil {
-		return MessageSentInfo{}
-	}
-	return *o.MessageSent__
-}
-
 func NewChatActivityWithIncomingMessage(v IncomingMessage) ChatActivity {
 	return ChatActivity{
 		ActivityType__:    ChatActivityType_INCOMING_MESSAGE,
 		IncomingMessage__: &v,
-	}
-}
-
-func NewChatActivityWithMessageSent(v MessageSentInfo) ChatActivity {
-	return ChatActivity{
-		ActivityType__: ChatActivityType_MESSAGE_SENT,
-		MessageSent__:  &v,
 	}
 }
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -865,8 +865,16 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 			g.G().Log.Error("push handler: chat activity: error decoding newMessage: %s", err.Error())
 			return err
 		}
+
 		g.G().Log.Debug("push handler: chat activity: newMessage: convID: %s sender: %s",
 			nm.ConvID, nm.Message.ClientHeader.Sender)
+		if nm.Message.ClientHeader.OutboxID != nil {
+			g.G().Log.Debug("push handler: chat activity: newMessage: outboxID: %s",
+				hex.EncodeToString(*nm.Message.ClientHeader.OutboxID))
+		} else {
+			g.G().Log.Debug("push handler: chat activity: newMessage: outboxID is empty")
+		}
+
 		uid := m.UID().Bytes()
 		decmsg, err := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
 		if err != nil {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -10,6 +10,7 @@ protocol common {
   @typedef("bytes")  record TLFID {}
   @typedef("bytes")  record Hash {}
   @typedef("uint64") record InboxVers {}
+  @typedef("bytes")  record OutboxID {}
 
   enum MessageType {
     NONE_0,
@@ -136,6 +137,7 @@ protocol common {
     array<MessagePreviousPointer> prev;
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;
+    union { null, OutboxID } outboxID; 
   }
 
   // The same format as in KBFS (see libkbfs/data_types.go)

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -224,7 +224,6 @@ protocol local {
     array<RateLimit> rateLimits;
   }
 
-  @typedef("bytes") record OutboxID {}
   record PostLocalNonblockRes {
     array<RateLimit> rateLimits;
     OutboxID outboxID;

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -6,8 +6,7 @@ protocol NotifyChat {
 
   enum ChatActivityType {
     RESERVED_0,
-    INCOMING_MESSAGE_1,
-    MESSAGE_SENT_2
+    INCOMING_MESSAGE_1
   }
 
   record IncomingMessage {
@@ -15,16 +14,8 @@ protocol NotifyChat {
     ConversationID convID;
   }
 
-  record MessageSentInfo {
-    ConversationID convID;
-    RateLimit rateLimit;
-    OutboxID outboxID;
-    MessageID messageID;
-  }
-
   variant ChatActivity switch (ChatActivityType activityType) {
     case INCOMING_MESSAGE: IncomingMessage;
-    case MESSAGE_SENT: MessageSentInfo;
   }
 
   @notify("")

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -103,7 +103,6 @@ export const LocalMessageUnboxedState = {
 export const NotifyChatChatActivityType = {
   reserved: 0,
   incomingMessage: 1,
-  messageSent: 2,
 }
 
 export function localDownloadAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {param: localDownloadAttachmentLocalRpcParam}>) {
@@ -408,12 +407,10 @@ export type BodyPlaintextVersion =
 
 export type ChatActivity = 
     { activityType : 1, incomingMessage : ?IncomingMessage }
-  | { activityType : 2, messageSent : ?MessageSentInfo }
 
 export type ChatActivityType = 
     0 // RESERVED_0
   | 1 // INCOMING_MESSAGE_1
-  | 2 // MESSAGE_SENT_2
 
 export type Conversation = {
   metadata: ConversationMetadata,
@@ -677,6 +674,7 @@ export type MessageClientHeader = {
   prev?: ?Array<MessagePreviousPointer>,
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
+  outboxID?: ?OutboxID,
 }
 
 export type MessageConversationMetadata = {
@@ -706,13 +704,6 @@ export type MessagePlaintext = {
 export type MessagePreviousPointer = {
   id: MessageID,
   hash: Hash,
-}
-
-export type MessageSentInfo = {
-  convID: ConversationID,
-  rateLimit: RateLimit,
-  outboxID: OutboxID,
-  messageID: MessageID,
 }
 
 export type MessageServerHeader = {

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -51,6 +51,12 @@
       "typedef": "uint64"
     },
     {
+      "type": "record",
+      "name": "OutboxID",
+      "fields": [],
+      "typedef": "bytes"
+    },
+    {
       "type": "enum",
       "name": "MessageType",
       "symbols": [
@@ -379,6 +385,13 @@
         {
           "type": "gregor1.DeviceID",
           "name": "senderDevice"
+        },
+        {
+          "type": [
+            null,
+            "OutboxID"
+          ],
+          "name": "outboxID"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -723,12 +723,6 @@
     },
     {
       "type": "record",
-      "name": "OutboxID",
-      "fields": [],
-      "typedef": "bytes"
-    },
-    {
-      "type": "record",
       "name": "PostLocalNonblockRes",
       "fields": [
         {

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -13,8 +13,7 @@
       "name": "ChatActivityType",
       "symbols": [
         "RESERVED_0",
-        "INCOMING_MESSAGE_1",
-        "MESSAGE_SENT_2"
+        "INCOMING_MESSAGE_1"
       ]
     },
     {
@@ -32,28 +31,6 @@
       ]
     },
     {
-      "type": "record",
-      "name": "MessageSentInfo",
-      "fields": [
-        {
-          "type": "ConversationID",
-          "name": "convID"
-        },
-        {
-          "type": "RateLimit",
-          "name": "rateLimit"
-        },
-        {
-          "type": "OutboxID",
-          "name": "outboxID"
-        },
-        {
-          "type": "MessageID",
-          "name": "messageID"
-        }
-      ]
-    },
-    {
       "type": "variant",
       "name": "ChatActivity",
       "switch": {
@@ -67,13 +44,6 @@
             "def": false
           },
           "body": "IncomingMessage"
-        },
-        {
-          "label": {
-            "name": "MESSAGE_SENT",
-            "def": false
-          },
-          "body": "MessageSentInfo"
         }
       ]
     }

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -2,7 +2,7 @@
 import * as Constants from '../constants/chat'
 import HiddenString from '../util/hidden-string'
 import engine from '../engine'
-import {CommonMessageType, CommonTLFVisibility, LocalMessageUnboxedState, NotifyChatChatActivityType, localGetInboxAndUnboxLocalRpcPromise, localGetThreadLocalRpcPromise, localPostLocalRpcPromise} from '../constants/types/flow-types-chat'
+import {CommonMessageType, CommonTLFVisibility, LocalMessageUnboxedState, NotifyChatChatActivityType, localGetInboxAndUnboxLocalRpcPromise, localGetThreadLocalRpcPromise, localPostLocalNonblockRpcPromise} from '../constants/types/flow-types-chat'
 import {List, Map} from 'immutable'
 import {call, put, select} from 'redux-saga/effects'
 import {safeTakeEvery, safeTakeLatest} from '../util/saga'
@@ -118,7 +118,7 @@ function * _postMessage (action: PostMessage): SagaGenerator<any, any> {
     senderDevice: Buffer.from(deviceID, 'hex'),
   }
 
-  yield call(localPostLocalRpcPromise, {
+  const sent = yield call(localPostLocalNonblockRpcPromise, {
     param: {
       conversationID: keyToConversationID(action.payload.conversationIDKey),
       msg: {
@@ -132,24 +132,61 @@ function * _postMessage (action: PostMessage): SagaGenerator<any, any> {
       },
     },
   })
+
+  const author = yield select(usernameSelector)
+  if (sent && author) {
+    const message: Message = {
+      type: 'Text',
+      author,
+      outboxID: sent.outboxID.toString('hex'),
+      timestamp: Date.now(),
+      messageState: 'pending',
+      message: new HiddenString(action.payload.text.stringValue()),
+      followState: 'You',
+    }
+    yield put({
+      type: Constants.appendMessages,
+      payload: {
+        conversationIDKey: action.payload.conversationIDKey,
+        messages: [message],
+      },
+    })
+  }
 }
 
 function * _incomingMessage (action: IncomingMessage): SagaGenerator<any, any> {
-  if (action.payload.activity.activityType === NotifyChatChatActivityType.incomingMessage) {
-    const incomingMessage: ?IncomingMessageRPCType = action.payload.activity.incomingMessage
-    if (incomingMessage) {
-      const messageUnboxed: MessageUnboxed = incomingMessage.message
-      const yourName = yield select(usernameSelector)
-      const message = _unboxedToMessage(messageUnboxed, 0, yourName)
-
-      yield put({
-        type: Constants.appendMessages,
-        payload: {
-          conversationIDKey: conversationIDToKey(incomingMessage.convID),
-          messages: [message],
-        },
-      })
-    }
+  switch (action.payload.activity.activityType) {
+    case NotifyChatChatActivityType.incomingMessage:
+      const incomingMessage: ?IncomingMessageRPCType = action.payload.activity.incomingMessage
+      if (incomingMessage) {
+        const messageUnboxed: MessageUnboxed = incomingMessage.message
+        const yourName = yield select(usernameSelector)
+        const message = _unboxedToMessage(messageUnboxed, 0, yourName)
+        if (message.outboxID && message.type === 'Text') {
+          // If the message has an outboxID, then we sent it and have already
+          // rendered it in the message list; we just need to mark it as sent.
+          yield put({
+            type: Constants.pendingMessageWasSent,
+            payload: {
+              conversationIDKey: conversationIDToKey(incomingMessage.convID),
+              outboxID: message.outboxID,
+              messageID: message.messageID,
+              messageState: 'sent',
+            },
+          })
+        } else {
+          yield put({
+            type: Constants.appendMessages,
+            payload: {
+              conversationIDKey: conversationIDToKey(incomingMessage.convID),
+              messages: [message],
+            },
+          })
+        }
+      }
+      break
+    default:
+      console.warn('Unsupported incoming message type for Chat')
   }
 }
 
@@ -262,6 +299,8 @@ function _unboxedToMessage (message: MessageUnboxed, idx: number, yourName): Mes
             ...common,
             message: new HiddenString(payload.messageBody && payload.messageBody.text && payload.messageBody.text.body || ''),
             followState: isYou ? 'You' : 'Following', // TODO get this
+            messageState: 'sent', // TODO, distinguish sent/pending once CORE sends it.
+            outboxID: payload.clientHeader.outboxID && payload.clientHeader.outboxID.toString('hex'),
           }
         default:
           return {

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -18,6 +18,7 @@ const factory = (message: Message, index: number, key: string, style: Object, is
         author={message.author}
         message={message.message.stringValue()}
         followState={message.followState}
+        messageState={message.messageState}
         />
     default:
       return <Box key={key} style={style} />

--- a/shared/chat/conversation/messages/text.desktop.js
+++ b/shared/chat/conversation/messages/text.desktop.js
@@ -12,13 +12,13 @@ const _marginColor = (followState) => ({
   'Broken': globalColors.red,
 }[followState])
 
-const MessageText = ({author, message, followState, style}: Props) => (
+const MessageText = ({author, message, followState, messageState, style}: Props) => (
   <Box style={{...globalStyles.flexBoxRow, padding: globalMargins.tiny, ...style}}>
     <Box style={{width: 2, alignSelf: 'stretch', backgroundColor: _marginColor(followState)}} />
     <Avatar size={24} username={author} style={{marginRight: globalMargins.tiny}} />
     <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
       <Text type='BodySemibold' style={{...(followState === 'You' ? globalStyles.fontItalic : null)}}>{author}</Text>
-      <Text type='Body'>{message}</Text>
+      <Text type='Body' style={messageState === 'pending' ? {color: globalColors.black_40} : {}}>{message}</Text>
     </Box>
   </Box>
 )

--- a/shared/chat/conversation/messages/text.js.flow
+++ b/shared/chat/conversation/messages/text.js.flow
@@ -1,13 +1,14 @@
 // @flow
 import {Component} from 'react'
 
-import type {FollowState} from '../../../constants/chat'
+import type {FollowState, MessageState} from '../../../constants/chat'
 
 export type Props = {
   author: string,
   message: string,
   followState: FollowState,
   style: Object,
+  messageState: MessageState,
 }
 
 export default class MessageText extends Component<void, Props, void> { }

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -8,14 +8,17 @@ import type {NoErrorTypedAction} from './types/flux'
 
 export type MessageType = 'Text'
 export type FollowState = 'You' | 'Following' | 'Broken' | 'NotFollowing'
+export type MessageState = 'pending' | 'sent' | 'failed'
 
 export type Message = {
   type: 'Text',
   message: HiddenString,
   author: string,
   timestamp: number,
-  messageID: number,
+  messageID?: number,
   followState: FollowState,
+  messageState: MessageState,
+  outboxID?: ?string,
 } | {
   type: 'Error',
   reason: string,
@@ -87,6 +90,7 @@ export const prependMessages = 'chat:prependMessages'
 export const setupNewChatHandler = 'chat:setupNewChatHandler'
 export const incomingMessage = 'chat:incomingMessage'
 export const postMessage = 'chat:postMessage'
+export const pendingMessageWasSent = 'chat:pendingMessageWasSent'
 
 export type AppendMessages = NoErrorTypedAction<'chat:appendMessages', {conversationIDKey: ConversationIDKey, messages: Array<Message>}>
 export type LoadInbox = NoErrorTypedAction<'chat:loadInbox', void>
@@ -98,7 +102,7 @@ export type SelectConversation = NoErrorTypedAction<'chat:selectConversation', {
 export type SetupNewChatHandler = NoErrorTypedAction<'chat:setupNewChatHandler', void>
 export type IncomingMessage = NoErrorTypedAction<'chat:incomingMessage', {activity: ChatActivity}>
 export type PostMessage = NoErrorTypedAction<'chat:postMessage', {conversationIDKey: ConversationIDKey, text: HiddenString}>
-
+export type PendingMessageWasSent = NoErrorTypedAction<'chat:pendingMessageWasSent', {newMessage: Message}>
 export type Actions = AppendMessages | LoadMoreMessages | PrependMessages | SelectConversation | LoadInbox | LoadedInbox
 
 function conversationIDToKey (conversationID: ConversationID): ConversationIDKey {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -103,7 +103,6 @@ export const LocalMessageUnboxedState = {
 export const NotifyChatChatActivityType = {
   reserved: 0,
   incomingMessage: 1,
-  messageSent: 2,
 }
 
 export function localDownloadAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {param: localDownloadAttachmentLocalRpcParam}>) {
@@ -408,12 +407,10 @@ export type BodyPlaintextVersion =
 
 export type ChatActivity = 
     { activityType : 1, incomingMessage : ?IncomingMessage }
-  | { activityType : 2, messageSent : ?MessageSentInfo }
 
 export type ChatActivityType = 
     0 // RESERVED_0
   | 1 // INCOMING_MESSAGE_1
-  | 2 // MESSAGE_SENT_2
 
 export type Conversation = {
   metadata: ConversationMetadata,
@@ -677,6 +674,7 @@ export type MessageClientHeader = {
   prev?: ?Array<MessagePreviousPointer>,
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
+  outboxID?: ?OutboxID,
 }
 
 export type MessageConversationMetadata = {
@@ -706,13 +704,6 @@ export type MessagePlaintext = {
 export type MessagePreviousPointer = {
   id: MessageID,
   hash: Hash,
-}
-
-export type MessageSentInfo = {
-  convID: ConversationID,
-  rateLimit: RateLimit,
-  outboxID: OutboxID,
-  messageID: MessageID,
 }
 
 export type MessageServerHeader = {

--- a/shared/login/forms/intro.render.desktop.js
+++ b/shared/login/forms/intro.render.desktop.js
@@ -37,14 +37,14 @@ class Intro extends Component<void, IntroProps, void> {
     return (
       <Box style={{...stylesLoginForm, marginTop: this.props.justRevokedSelf || this.props.justDeletedSelf || this.props.justLoginFromRevokedDevice ? 0 : 45}}>
         {!!this.props.justRevokedSelf && <Box style={stylesRevoked}>
-          <Text type='BodySemiboldItalic' style={{color: globalColors.white}}>{this.props.justRevokedSelf}</Text>
-          <Text type='BodySemiboldItalic' style={{color: globalColors.white}}>&nbsp;was revoked successfully</Text>
+          <Text type='BodySemibold' style={{color: globalColors.white}}>{this.props.justRevokedSelf}</Text>
+          <Text type='BodySemibold' style={{color: globalColors.white}}>&nbsp;was revoked successfully</Text>
         </Box>}
         {!!this.props.justDeletedSelf && <Box style={stylesRevoked}>
-          <Text type='BodySemiboldItalic' style={{color: globalColors.white}}>Your Keybase account "{this.props.justDeletedSelf}" has been deleted. Au revoir!</Text>
+          <Text type='BodySemibold' style={{color: globalColors.white}}>Your Keybase account "{this.props.justDeletedSelf}" has been deleted. Au revoir!</Text>
         </Box>}
-        {!!this.props.justLoginFromRevokedDevice && <Box style={stylesRevoked}>
-          <Text type='BodySemiboldItalic' style={{color: globalColors.white}}>This device has been revoked, please log in again.</Text>
+        {!!this.props.justLoginFromRevokedDevice && <Box style={{...stylesRevoked, backgroundColor: globalColors.blue}}>
+          <Text type='BodySemibold' style={{color: globalColors.white}}>This device has been revoked, please log in again.</Text>
         </Box>}
         <Icon type='icon-keybase-logo-160' />
         <Text style={stylesHeader} type='HeaderBig'>Join Keybase</Text>

--- a/shared/login/signup/invite-code.render.desktop.js
+++ b/shared/login/signup/invite-code.render.desktop.js
@@ -42,7 +42,7 @@ class InviteCodeRender extends Component<void, Props, State> {
 const stylesButton = {
   marginTop: 10,
   marginRight: 0,
-  alignSelf: 'flex-end',
+  alignSelf: 'center',
 }
 const stylesContainer = {
   ...globalStyles.flexBoxColumn,

--- a/shared/pinentry/index.render.desktop.js
+++ b/shared/pinentry/index.render.desktop.js
@@ -113,7 +113,7 @@ export default class PinentryRender extends Component<DefaultProps, Props, State
             checkboxContainerStyle={{paddingLeft: 60, paddingRight: 60, ...checkboxContainerStyle}}
             checkboxesProps={checkboxProps}
           />
-          <Button style={{alignSelf: 'flex-end'}} type='Primary' label={this.props.submitLabel} onClick={submitPassphrase} disabled={!this.state.passphrase} />
+          <Button style={{alignSelf: 'center'}} type='Primary' label={this.props.submitLabel} onClick={submitPassphrase} disabled={!this.state.passphrase} />
         </Box>
       </Box>
     )

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -37,6 +37,26 @@ function reducer (state: State = initialState, action: Actions) {
 
       return state.set('conversationStates', newConversationStates)
     }
+    case Constants.pendingMessageWasSent: {
+      const {outboxID, messageID, messageState} = action.payload
+      const newConversationStates = state.get('conversationStates').update(
+        action.payload.conversationIDKey,
+        initialConversation,
+        conversation => {
+          const index = conversation.get('messages').findIndex(item => item.outboxID === outboxID)
+          if (index <= 0) {
+            console.warn("Couldn't find an outbox entry to modify")
+            return conversation.get('messages')
+          }
+          return conversation.set('messages', conversation.get('messages').update(index, item => ({
+            ...item,
+            messageID,
+            messageState,
+          })))
+        }
+      )
+      return state.set('conversationStates', newConversationStates)
+    }
     case Constants.selectConversation:
       return state.set('selectedConversation', action.payload.conversationIDKey)
     case Constants.loadingMessages: {


### PR DESCRIPTION
(CC @chrisnojima in case you're interested.)

Here's what happening so far:

* When sending, we use the `nonblock` RPC and store the returned outboxID
* When we get a `NotifyChatChatActivityType.messageSent` notification, we take the outboxID and messageID in that payload and call a new `updateMessage` action, which finds the message that was sent, fills in its real `messageID` (which we just learned for the first time), and changes its `messageState` field to `sent`.
* I modified the conversation rendering to show pending messages in italic for debugging, I can leave that in or take it out.

TODO:

* Can the core tell us about failed messages yet?  How?
* It looks like the UI doesn't re-render when I fire the `updateMessage` action, which modifies `chat.conversationStates.somekey.messages` in the store?  It should re-render.
* CORE is going to silence the new `incomingMessage` from gregor when it's for a message you sent yourself, so that we don't have to selectively filter out our own messages from the incoming message stream.
* CORE is going to send `pending` state messages along when loading a thread, and we should set our own `messageState` to match.