### PR TITLE
attach outbox ID to the client header, and remove sent notification

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -171,6 +171,7 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 	if err != nil {
 		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(err)
 	}
+
 	switch headerVersion {
 	case chat1.HeaderPlaintextVersion_V1:
 		hp := header.V1()
@@ -186,6 +187,7 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 	default:
 		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(libkb.NewChatHeaderVersionError(headerVersion))
 	}
+	clientHeader.OutboxID = msg.ClientHeader.OutboxID
 
 	if skipBodyVerification {
 		// body was deleted, so return empty body that matches header version

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -40,8 +40,8 @@ func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActi
 	n.Lock()
 	defer n.Unlock()
 	typ, err := activity.ActivityType()
-	if err == nil && typ == chat1.ChatActivityType_MESSAGE_SENT {
-		n.obids = append(n.obids, activity.MessageSent().OutboxID)
+	if err == nil && typ == chat1.ChatActivityType_INCOMING_MESSAGE {
+		n.obids = append(n.obids, *activity.IncomingMessage().Message.Valid().ClientHeader.OutboxID)
 		n.action <- len(n.obids)
 	}
 }

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -152,7 +152,7 @@ func (o *Outbox) PushMessage(convID chat1.ConversationID, msg chat1.MessagePlain
 
 	// Generate new outbox ID
 	var outboxID chat1.OutboxID
-	outboxID, err = libkb.RandBytes(16)
+	outboxID, err = libkb.RandBytes(8)
 	if err != nil {
 		return nil, o.maybeNuke(libkb.NewChatStorageInternalError(o.G(),
 			"error getting outboxID: err: %s", err.Error()))

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -23,6 +23,7 @@ type ChatMockWorld struct {
 	Fc clockwork.FakeClock
 
 	Tcs     map[string]*libkb.TestContext
+	TcsByID map[string]*libkb.TestContext
 	Users   map[string]*FakeUser
 	tlfs    map[keybase1.CanonicalTlfName]chat1.TLFID
 	tlfKeys map[keybase1.CanonicalTlfName][]keybase1.CryptKey
@@ -38,6 +39,7 @@ func NewChatMockWorld(t *testing.T, name string, numUsers int) (world *ChatMockW
 	world = &ChatMockWorld{
 		Fc:      clockwork.NewFakeClockAt(time.Now()),
 		Tcs:     make(map[string]*libkb.TestContext),
+		TcsByID: make(map[string]*libkb.TestContext),
 		Users:   make(map[string]*FakeUser),
 		tlfs:    make(map[keybase1.CanonicalTlfName]chat1.TLFID),
 		tlfKeys: make(map[keybase1.CanonicalTlfName][]keybase1.CryptKey),
@@ -52,6 +54,7 @@ func NewChatMockWorld(t *testing.T, name string, numUsers int) (world *ChatMockW
 		}
 		world.Users[u.Username] = u
 		world.Tcs[u.Username] = &tc
+		world.TcsByID[u.User.GetUID().String()] = &tc
 	}
 
 	world.Fc.Advance(time.Hour)
@@ -289,6 +292,7 @@ func (m *ChatRemoteMock) GetConversationMetadataRemote(ctx context.Context, conv
 }
 
 func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg) (res chat1.PostRemoteRes, err error) {
+	uid := arg.MessageBoxed.ClientHeader.Sender
 	conv := m.world.GetConversationByID(arg.ConversationID)
 	ri := m.makeReaderInfo(conv.Metadata.ConversationID)
 	inserted := m.insertMsgAndSort(arg.ConversationID, arg.MessageBoxed)
@@ -299,6 +303,19 @@ func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg
 	sort.Sort(convByNewlyUpdated{mock: m})
 	res.MsgHeader = *inserted.ServerHeader
 	res.RateLimit = &chat1.RateLimit{}
+
+	// hit notify router with new message
+	if m.world.TcsByID[uid.String()].G.NotifyRouter != nil {
+		activity := chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
+			Message: chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
+				ClientHeader: inserted.ClientHeader,
+				ServerHeader: *inserted.ServerHeader,
+			}),
+		})
+		m.world.TcsByID[uid.String()].G.NotifyRouter.HandleNewChatActivity(context.Background(),
+			keybase1.UID(uid.String()), &activity)
+	}
+
 	return
 }
 

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -16,6 +16,7 @@ type ConversationID []byte
 type TLFID []byte
 type Hash []byte
 type InboxVers uint64
+type OutboxID []byte
 type MessageType int
 
 const (
@@ -189,6 +190,7 @@ type MessageClientHeader struct {
 	Prev         []MessagePreviousPointer `codec:"prev" json:"prev"`
 	Sender       gregor1.UID              `codec:"sender" json:"sender"`
 	SenderDevice gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
+	OutboxID     *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 }
 
 type EncryptedData struct {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -481,7 +481,6 @@ type PostLocalRes struct {
 	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
 }
 
-type OutboxID []byte
 type PostLocalNonblockRes struct {
 	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
 	OutboxID   OutboxID    `codec:"outboxID" json:"outboxID"`

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -15,19 +15,16 @@ type ChatActivityType int
 const (
 	ChatActivityType_RESERVED         ChatActivityType = 0
 	ChatActivityType_INCOMING_MESSAGE ChatActivityType = 1
-	ChatActivityType_MESSAGE_SENT     ChatActivityType = 2
 )
 
 var ChatActivityTypeMap = map[string]ChatActivityType{
 	"RESERVED":         0,
 	"INCOMING_MESSAGE": 1,
-	"MESSAGE_SENT":     2,
 }
 
 var ChatActivityTypeRevMap = map[ChatActivityType]string{
 	0: "RESERVED",
 	1: "INCOMING_MESSAGE",
-	2: "MESSAGE_SENT",
 }
 
 type IncomingMessage struct {
@@ -35,17 +32,9 @@ type IncomingMessage struct {
 	ConvID  ConversationID `codec:"convID" json:"convID"`
 }
 
-type MessageSentInfo struct {
-	ConvID    ConversationID `codec:"convID" json:"convID"`
-	RateLimit RateLimit      `codec:"rateLimit" json:"rateLimit"`
-	OutboxID  OutboxID       `codec:"outboxID" json:"outboxID"`
-	MessageID MessageID      `codec:"messageID" json:"messageID"`
-}
-
 type ChatActivity struct {
 	ActivityType__    ChatActivityType `codec:"activityType" json:"activityType"`
 	IncomingMessage__ *IncomingMessage `codec:"incomingMessage,omitempty" json:"incomingMessage,omitempty"`
-	MessageSent__     *MessageSentInfo `codec:"messageSent,omitempty" json:"messageSent,omitempty"`
 }
 
 func (o *ChatActivity) ActivityType() (ret ChatActivityType, err error) {
@@ -53,11 +42,6 @@ func (o *ChatActivity) ActivityType() (ret ChatActivityType, err error) {
 	case ChatActivityType_INCOMING_MESSAGE:
 		if o.IncomingMessage__ == nil {
 			err = errors.New("unexpected nil value for IncomingMessage__")
-			return ret, err
-		}
-	case ChatActivityType_MESSAGE_SENT:
-		if o.MessageSent__ == nil {
-			err = errors.New("unexpected nil value for MessageSent__")
 			return ret, err
 		}
 	}
@@ -74,27 +58,10 @@ func (o ChatActivity) IncomingMessage() IncomingMessage {
 	return *o.IncomingMessage__
 }
 
-func (o ChatActivity) MessageSent() MessageSentInfo {
-	if o.ActivityType__ != ChatActivityType_MESSAGE_SENT {
-		panic("wrong case accessed")
-	}
-	if o.MessageSent__ == nil {
-		return MessageSentInfo{}
-	}
-	return *o.MessageSent__
-}
-
 func NewChatActivityWithIncomingMessage(v IncomingMessage) ChatActivity {
 	return ChatActivity{
 		ActivityType__:    ChatActivityType_INCOMING_MESSAGE,
 		IncomingMessage__: &v,
-	}
-}
-
-func NewChatActivityWithMessageSent(v MessageSentInfo) ChatActivity {
-	return ChatActivity{
-		ActivityType__: ChatActivityType_MESSAGE_SENT,
-		MessageSent__:  &v,
 	}
 }
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -865,8 +865,14 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 			g.G().Log.Error("push handler: chat activity: error decoding newMessage: %s", err.Error())
 			return err
 		}
+
 		g.G().Log.Debug("push handler: chat activity: newMessage: convID: %s sender: %s",
 			nm.ConvID, nm.Message.ClientHeader.Sender)
+		if nm.Message.ClientHeader.OutboxID != nil {
+			g.G().Log.Debug("push handler: chat activity: newMessage: outboxID: %s",
+				nm.Message.ClientHeader.OutboxID)
+		}
+
 		uid := m.UID().Bytes()
 		decmsg, err := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
 		if err != nil {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -870,7 +870,9 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 			nm.ConvID, nm.Message.ClientHeader.Sender)
 		if nm.Message.ClientHeader.OutboxID != nil {
 			g.G().Log.Debug("push handler: chat activity: newMessage: outboxID: %s",
-				nm.Message.ClientHeader.OutboxID)
+				hex.EncodeToString(*nm.Message.ClientHeader.OutboxID))
+		} else {
+			g.G().Log.Debug("push handler: chat activity: newMessage: outboxID is empty")
 		}
 
 		uid := m.UID().Bytes()

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -10,6 +10,7 @@ protocol common {
   @typedef("bytes")  record TLFID {}
   @typedef("bytes")  record Hash {}
   @typedef("uint64") record InboxVers {}
+  @typedef("bytes")  record OutboxID {}
 
   enum MessageType {
     NONE_0,
@@ -136,6 +137,7 @@ protocol common {
     array<MessagePreviousPointer> prev;
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;
+    union { null, OutboxID } outboxID; 
   }
 
   // The same format as in KBFS (see libkbfs/data_types.go)

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -224,7 +224,6 @@ protocol local {
     array<RateLimit> rateLimits;
   }
 
-  @typedef("bytes") record OutboxID {}
   record PostLocalNonblockRes {
     array<RateLimit> rateLimits;
     OutboxID outboxID;

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -6,8 +6,7 @@ protocol NotifyChat {
 
   enum ChatActivityType {
     RESERVED_0,
-    INCOMING_MESSAGE_1,
-    MESSAGE_SENT_2
+    INCOMING_MESSAGE_1
   }
 
   record IncomingMessage {
@@ -15,16 +14,8 @@ protocol NotifyChat {
     ConversationID convID;
   }
 
-  record MessageSentInfo {
-    ConversationID convID;
-    RateLimit rateLimit;
-    OutboxID outboxID;
-    MessageID messageID;
-  }
-
   variant ChatActivity switch (ChatActivityType activityType) {
     case INCOMING_MESSAGE: IncomingMessage;
-    case MESSAGE_SENT: MessageSentInfo;
   }
 
   @notify("")

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -103,7 +103,6 @@ export const LocalMessageUnboxedState = {
 export const NotifyChatChatActivityType = {
   reserved: 0,
   incomingMessage: 1,
-  messageSent: 2,
 }
 
 export function localDownloadAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {param: localDownloadAttachmentLocalRpcParam}>) {
@@ -408,12 +407,10 @@ export type BodyPlaintextVersion =
 
 export type ChatActivity = 
     { activityType : 1, incomingMessage : ?IncomingMessage }
-  | { activityType : 2, messageSent : ?MessageSentInfo }
 
 export type ChatActivityType = 
     0 // RESERVED_0
   | 1 // INCOMING_MESSAGE_1
-  | 2 // MESSAGE_SENT_2
 
 export type Conversation = {
   metadata: ConversationMetadata,
@@ -677,6 +674,7 @@ export type MessageClientHeader = {
   prev?: ?Array<MessagePreviousPointer>,
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
+  outboxID?: ?OutboxID,
 }
 
 export type MessageConversationMetadata = {
@@ -706,13 +704,6 @@ export type MessagePlaintext = {
 export type MessagePreviousPointer = {
   id: MessageID,
   hash: Hash,
-}
-
-export type MessageSentInfo = {
-  convID: ConversationID,
-  rateLimit: RateLimit,
-  outboxID: OutboxID,
-  messageID: MessageID,
 }
 
 export type MessageServerHeader = {

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -51,6 +51,12 @@
       "typedef": "uint64"
     },
     {
+      "type": "record",
+      "name": "OutboxID",
+      "fields": [],
+      "typedef": "bytes"
+    },
+    {
       "type": "enum",
       "name": "MessageType",
       "symbols": [
@@ -379,6 +385,13 @@
         {
           "type": "gregor1.DeviceID",
           "name": "senderDevice"
+        },
+        {
+          "type": [
+            null,
+            "OutboxID"
+          ],
+          "name": "outboxID"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -723,12 +723,6 @@
     },
     {
       "type": "record",
-      "name": "OutboxID",
-      "fields": [],
-      "typedef": "bytes"
-    },
-    {
-      "type": "record",
       "name": "PostLocalNonblockRes",
       "fields": [
         {

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -13,8 +13,7 @@
       "name": "ChatActivityType",
       "symbols": [
         "RESERVED_0",
-        "INCOMING_MESSAGE_1",
-        "MESSAGE_SENT_2"
+        "INCOMING_MESSAGE_1"
       ]
     },
     {
@@ -32,28 +31,6 @@
       ]
     },
     {
-      "type": "record",
-      "name": "MessageSentInfo",
-      "fields": [
-        {
-          "type": "ConversationID",
-          "name": "convID"
-        },
-        {
-          "type": "RateLimit",
-          "name": "rateLimit"
-        },
-        {
-          "type": "OutboxID",
-          "name": "outboxID"
-        },
-        {
-          "type": "MessageID",
-          "name": "messageID"
-        }
-      ]
-    },
-    {
       "type": "variant",
       "name": "ChatActivity",
       "switch": {
@@ -67,13 +44,6 @@
             "def": false
           },
           "body": "IncomingMessage"
-        },
-        {
-          "label": {
-            "name": "MESSAGE_SENT",
-            "def": false
-          },
-          "body": "MessageSentInfo"
         }
       ]
     }

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -103,7 +103,6 @@ export const LocalMessageUnboxedState = {
 export const NotifyChatChatActivityType = {
   reserved: 0,
   incomingMessage: 1,
-  messageSent: 2,
 }
 
 export function localDownloadAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {param: localDownloadAttachmentLocalRpcParam}>) {
@@ -408,12 +407,10 @@ export type BodyPlaintextVersion =
 
 export type ChatActivity = 
     { activityType : 1, incomingMessage : ?IncomingMessage }
-  | { activityType : 2, messageSent : ?MessageSentInfo }
 
 export type ChatActivityType = 
     0 // RESERVED_0
   | 1 // INCOMING_MESSAGE_1
-  | 2 // MESSAGE_SENT_2
 
 export type Conversation = {
   metadata: ConversationMetadata,
@@ -677,6 +674,7 @@ export type MessageClientHeader = {
   prev?: ?Array<MessagePreviousPointer>,
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
+  outboxID?: ?OutboxID,
 }
 
 export type MessageConversationMetadata = {
@@ -706,13 +704,6 @@ export type MessagePlaintext = {
 export type MessagePreviousPointer = {
   id: MessageID,
   hash: Hash,
-}
-
-export type MessageSentInfo = {
-  convID: ConversationID,
-  rateLimit: RateLimit,
-  outboxID: OutboxID,
-  messageID: MessageID,
 }
 
 export type MessageServerHeader = {


### PR DESCRIPTION
@patrickxb r?

This removes the separate notification when a message is delivered from the outbox, and instead just decorates all messages with their outbox ID (if any). This way when Electron gets the "newMessage" notification, it can check for OutboxID to know how to render. It takes up more space, but we are talking 8 bytes, and it is the easiest solution I can think of.

@cjb cc