### PR TITLE
GUI async chat

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -2,7 +2,7 @@
 import * as Constants from '../constants/chat'
 import HiddenString from '../util/hidden-string'
 import engine from '../engine'
-import {CommonMessageType, CommonTLFVisibility, LocalMessageUnboxedState, NotifyChatChatActivityType, localGetInboxAndUnboxLocalRpcPromise, localGetThreadLocalRpcPromise, localPostLocalRpcPromise} from '../constants/types/flow-types-chat'
+import {CommonMessageType, CommonTLFVisibility, LocalMessageUnboxedState, NotifyChatChatActivityType, localGetInboxAndUnboxLocalRpcPromise, localGetThreadLocalRpcPromise, localPostLocalNonblockRpcPromise} from '../constants/types/flow-types-chat'
 import {List, Map} from 'immutable'
 import {call, put, select} from 'redux-saga/effects'
 import {safeTakeEvery, safeTakeLatest} from '../util/saga'
@@ -118,7 +118,7 @@ function * _postMessage (action: PostMessage): SagaGenerator<any, any> {
     senderDevice: Buffer.from(deviceID, 'hex'),
   }
 
-  yield call(localPostLocalRpcPromise, {
+  const sent = yield call(localPostLocalNonblockRpcPromise, {
     param: {
       conversationID: keyToConversationID(action.payload.conversationIDKey),
       msg: {
@@ -132,24 +132,61 @@ function * _postMessage (action: PostMessage): SagaGenerator<any, any> {
       },
     },
   })
+
+  const author = yield select(usernameSelector)
+  if (sent && author) {
+    const message: Message = {
+      type: 'Text',
+      author,
+      outboxID: sent.outboxID.toString('hex'),
+      timestamp: Date.now(),
+      messageState: 'pending',
+      message: new HiddenString(action.payload.text.stringValue()),
+      followState: 'You',
+    }
+    yield put({
+      type: Constants.appendMessages,
+      payload: {
+        conversationIDKey: action.payload.conversationIDKey,
+        messages: [message],
+      },
+    })
+  }
 }
 
 function * _incomingMessage (action: IncomingMessage): SagaGenerator<any, any> {
-  if (action.payload.activity.activityType === NotifyChatChatActivityType.incomingMessage) {
-    const incomingMessage: ?IncomingMessageRPCType = action.payload.activity.incomingMessage
-    if (incomingMessage) {
-      const messageUnboxed: MessageUnboxed = incomingMessage.message
-      const yourName = yield select(usernameSelector)
-      const message = _unboxedToMessage(messageUnboxed, 0, yourName)
-
-      yield put({
-        type: Constants.appendMessages,
-        payload: {
-          conversationIDKey: conversationIDToKey(incomingMessage.convID),
-          messages: [message],
-        },
-      })
-    }
+  switch (action.payload.activity.activityType) {
+    case NotifyChatChatActivityType.incomingMessage:
+      const incomingMessage: ?IncomingMessageRPCType = action.payload.activity.incomingMessage
+      if (incomingMessage) {
+        const messageUnboxed: MessageUnboxed = incomingMessage.message
+        const yourName = yield select(usernameSelector)
+        const message = _unboxedToMessage(messageUnboxed, 0, yourName)
+        if (message.outboxID && message.type === 'Text') {
+          // If the message has an outboxID, then we sent it and have already
+          // rendered it in the message list; we just need to mark it as sent.
+          yield put({
+            type: Constants.pendingMessageWasSent,
+            payload: {
+              conversationIDKey: conversationIDToKey(incomingMessage.convID),
+              outboxID: message.outboxID,
+              messageID: message.messageID,
+              messageState: 'sent',
+            },
+          })
+        } else {
+          yield put({
+            type: Constants.appendMessages,
+            payload: {
+              conversationIDKey: conversationIDToKey(incomingMessage.convID),
+              messages: [message],
+            },
+          })
+        }
+      }
+      break
+    default:
+      console.warn('Unsupported incoming message type for Chat')
   }
 }
 
@@ -262,6 +299,8 @@ function _unboxedToMessage (message: MessageUnboxed, idx: number, yourName): Mes
             ...common,
             message: new HiddenString(payload.messageBody && payload.messageBody.text && payload.messageBody.text.body || ''),
             followState: isYou ? 'You' : 'Following', // TODO get this
+            messageState: 'sent', // TODO, distinguish sent/pending once CORE sends it.
+            outboxID: payload.clientHeader.outboxID && payload.clientHeader.outboxID.toString('hex'),
           }
         default:
           return {

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -49,6 +49,9 @@ class ConversationList extends Component<void, Props, State> {
       // minus one because loader message is there
       const messageIndex = index - 1
       const message = this.state.messages.get(messageIndex)
+      // We want a stable key -- messages have an outboxID but no
+      // messageID, then later gain a messageID.  So if we prefer
+      // outboxIDs to messageIDs for the key, every row keeps its key.
       const id = message && (message.outboxID || message.messageID)
       if (id == null) {
         console.warn('id is null for index:', messageIndex)
@@ -58,7 +61,7 @@ class ConversationList extends Component<void, Props, State> {
   }
 
   componentWillUpdate (nextProps: Props, nextState: State) {
-    // If a message has moved from pending to send, tell the List to 
+    // If a message has moved from pending to send, tell the List to
     // discard heights for it and everything after it, so that they're
     // re-rendered.'
     if (this._toRemeasure.length) {

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -91,16 +91,16 @@ class ConversationList extends Component<void, Props, State> {
   componentWillReceiveProps (nextProps: Props) {
     // If we're not scrolling let's update our internal messages
     if (!this.state.isScrolling) {
-      this._invalidateChangedMessages()
+      this._invalidateChangedMessages(nextProps)
       this.setState({
         messages: nextProps.messages,
       })
     }
   }
 
-  _invalidateChangedMessages () {
+  _invalidateChangedMessages (props: Props) {
     this.state.messages.forEach((item, index) => {
-      if (item.messageID !== this.props.messages.get(index, {}).messageID) {
+      if (item.messageID !== props.messages.get(index, {}).messageID) {
         this._toRemeasure.push(index + 1)
       }
     })
@@ -108,7 +108,7 @@ class ConversationList extends Component<void, Props, State> {
 
   _onScrollSettled = _.debounce(() => {
     // If we've stopped scrolling let's update our internal messages
-    this._invalidateChangedMessages()
+    this._invalidateChangedMessages(this.props)
     this.setState({
       isScrolling: false,
       ...(this.state.messages !== this.props.messages ? {messages: this.props.messages} : null),

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -140,6 +140,7 @@ class ConversationList extends Component<void, Props, State> {
     if (index === 0) {
       return <LoadingMore style={style} key={key || index} hasMoreItems={this.props.moreToLoad} />
     }
+
     const message = this.state.messages.get(index - 1)
     return messageFactory(message, index, key, style, isScrolling)
   }

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -49,9 +49,9 @@ class ConversationList extends Component<void, Props, State> {
       // minus one because loader message is there
       const messageIndex = index - 1
       const message = this.state.messages.get(messageIndex)
-      // We want a stable key -- messages have an outboxID but no
-      // messageID, then later gain a messageID.  So if we prefer
-      // outboxIDs to messageIDs for the key, every row keeps its key.
+      // We want a stable key -- messages have an outboxID but no messageID,
+      // then later gain a messageID.  So if we prefer outboxIDs to messageIDs
+      // for the key, every row keeps its key.
       const id = message && (message.outboxID || message.messageID)
       if (id == null) {
         console.warn('id is null for index:', messageIndex)
@@ -61,9 +61,8 @@ class ConversationList extends Component<void, Props, State> {
   }
 
   componentWillUpdate (nextProps: Props, nextState: State) {
-    // If a message has moved from pending to send, tell the List to
-    // discard heights for it and everything after it, so that they're
-    // re-rendered.'
+    // If a message has moved from pending to sent, tell the List to discard
+    // heights for it and everything after it, so that they're re-rendered.
     if (this._toRemeasure.length) {
       this._toRemeasure.forEach(item => {
         this._list.recomputeRowHeights(item)

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -26,6 +26,7 @@ class ConversationList extends Component<void, Props, State> {
   _cellMeasurer: any;
   _list: any;
   state: State;
+  _toRemeasure: List;
 
   constructor (props: Props) {
     super(props)

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -63,7 +63,7 @@ class ConversationList extends Component<void, Props, State> {
 
   componentWillUpdate (nextProps: Props, nextState: State) {
     // If a message has moved from pending to sent, tell the List to discard
-    // heights for it and everything after it, so that they're re-rendered.
+    // heights for it (which will re-render it and everything after it)
     if (this._toRemeasure.length) {
       this._toRemeasure.forEach(item => {
         this._list.recomputeRowHeights(item)

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -18,6 +18,7 @@ const factory = (message: Message, index: number, key: string, style: Object, is
         author={message.author}
         message={message.message.stringValue()}
         followState={message.followState}
+        messageState={message.messageState}
         />
     default:
       return <Box key={key} style={style} />

--- a/shared/chat/conversation/messages/text.desktop.js
+++ b/shared/chat/conversation/messages/text.desktop.js
@@ -12,13 +12,13 @@ const _marginColor = (followState) => ({
   'Broken': globalColors.red,
 }[followState])
 
-const MessageText = ({author, message, followState, style}: Props) => (
+const MessageText = ({author, message, followState, messageState, style}: Props) => (
   <Box style={{...globalStyles.flexBoxRow, padding: globalMargins.tiny, ...style}}>
     <Box style={{width: 2, alignSelf: 'stretch', backgroundColor: _marginColor(followState)}} />
     <Avatar size={24} username={author} style={{marginRight: globalMargins.tiny}} />
     <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
       <Text type='BodySemibold' style={{...(followState === 'You' ? globalStyles.fontItalic : null)}}>{author}</Text>
-      <Text type='Body'>{message}</Text>
+      <Text type='Body' style={messageState === 'pending' ? {color: globalColors.black_40} : {}}>{message}</Text>
     </Box>
   </Box>
 )

--- a/shared/chat/conversation/messages/text.js.flow
+++ b/shared/chat/conversation/messages/text.js.flow
@@ -1,13 +1,14 @@
 // @flow
 import {Component} from 'react'
 
-import type {FollowState} from '../../../constants/chat'
+import type {FollowState, MessageState} from '../../../constants/chat'
 
 export type Props = {
   author: string,
   message: string,
   followState: FollowState,
   style: Object,
+  messageState: MessageState,
 }
 
 export default class MessageText extends Component<void, Props, void> { }

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -8,14 +8,17 @@ import type {NoErrorTypedAction} from './types/flux'
 
 export type MessageType = 'Text'
 export type FollowState = 'You' | 'Following' | 'Broken' | 'NotFollowing'
+export type MessageState = 'pending' | 'sent' | 'failed'
 
 export type Message = {
   type: 'Text',
   message: HiddenString,
   author: string,
   timestamp: number,
-  messageID: number,
+  messageID?: number,
   followState: FollowState,
+  messageState: MessageState,
+  outboxID?: ?string,
 } | {
   type: 'Error',
   reason: string,
@@ -87,6 +90,7 @@ export const prependMessages = 'chat:prependMessages'
 export const setupNewChatHandler = 'chat:setupNewChatHandler'
 export const incomingMessage = 'chat:incomingMessage'
 export const postMessage = 'chat:postMessage'
+export const pendingMessageWasSent = 'chat:pendingMessageWasSent'
 
 export type AppendMessages = NoErrorTypedAction<'chat:appendMessages', {conversationIDKey: ConversationIDKey, messages: Array<Message>}>
 export type LoadInbox = NoErrorTypedAction<'chat:loadInbox', void>
@@ -98,7 +102,7 @@ export type SelectConversation = NoErrorTypedAction<'chat:selectConversation', {
 export type SetupNewChatHandler = NoErrorTypedAction<'chat:setupNewChatHandler', void>
 export type IncomingMessage = NoErrorTypedAction<'chat:incomingMessage', {activity: ChatActivity}>
 export type PostMessage = NoErrorTypedAction<'chat:postMessage', {conversationIDKey: ConversationIDKey, text: HiddenString}>
-
+export type PendingMessageWasSent = NoErrorTypedAction<'chat:pendingMessageWasSent', {newMessage: Message}>
 export type Actions = AppendMessages | LoadMoreMessages | PrependMessages | SelectConversation | LoadInbox | LoadedInbox
 
 function conversationIDToKey (conversationID: ConversationID): ConversationIDKey {

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -44,15 +44,15 @@ function reducer (state: State = initialState, action: Actions) {
         initialConversation,
         conversation => {
           const index = conversation.get('messages').findIndex(item => item.outboxID === outboxID)
-          if (index <= 0) {
+          if (index < 0) {
             console.warn("Couldn't find an outbox entry to modify")
-            return conversation.get('messages')
+            return conversation
           }
-          return conversation.set('messages', conversation.get('messages').update(index, item => ({
+          return conversation.updateIn(['messages', index], item => ({
             ...item,
             messageID,
             messageState,
-          })))
+          }))
         }
       )
       return state.set('conversationStates', newConversationStates)

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -37,6 +37,26 @@ function reducer (state: State = initialState, action: Actions) {
 
       return state.set('conversationStates', newConversationStates)
     }
+    case Constants.pendingMessageWasSent: {
+      const {outboxID, messageID, messageState} = action.payload
+      const newConversationStates = state.get('conversationStates').update(
+        action.payload.conversationIDKey,
+        initialConversation,
+        conversation => {
+          const index = conversation.get('messages').findIndex(item => item.outboxID === outboxID)
+          if (index <= 0) {
+            console.warn("Couldn't find an outbox entry to modify")
+            return conversation.get('messages')
+          }
+          return conversation.set('messages', conversation.get('messages').update(index, item => ({
+            ...item,
+            messageID,
+            messageState,
+          })))
+        }
+      )
+      return state.set('conversationStates', newConversationStates)
+    }
     case Constants.selectConversation:
       return state.set('selectedConversation', action.payload.conversationIDKey)
     case Constants.loadingMessages: {


### PR DESCRIPTION
@keybase/react-hackers 

Here's a final PR for async chat, I've answered @chrisnojima's review comments from the WIP PR #4849.

Description:
* When sending, we use the `nonblock` RPC and store the returned outboxID
* When we get a `NotifyChatChatActivityType.newMessage` notification, we look to see if it has an outboxID -- if so, it was a pending messge that's now sent, so we call a new `pendingMessageWasSent` action, which finds the message that was sent, fills in its real `messageID` (which we just learned for the first time), and changes its `messageState` field to `sent`.
* The render function now uses `black_40` for pending messages, as per the Zeplin design.
* The render function wasn't being called, because the react-virtualized List isn't changing dramatically -- it still has the same number of elements, we just updated some properties inside an element.  So now we manually call `_invalidateChangedMessages()` if we got an updated messageID for a message, which calls `List.recomputeRowHeights(indexOfNewMessage)` in response.  @chrisnojima and I struggled a whole bunch to get this working and it's still not very satisfying.