### PR TITLE
pin outbox to last seen message CORE-4062

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -187,6 +187,7 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 	default:
 		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(libkb.NewChatHeaderVersionError(headerVersion))
 	}
+	clientHeader.OutboxInfo = msg.ClientHeader.OutboxInfo
 	clientHeader.OutboxID = msg.ClientHeader.OutboxID
 
 	if skipBodyVerification {

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/keybase/client/go/chat/storage"
-	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
@@ -126,11 +125,10 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 	// Get conversation metadata
 	if conv, err := s.getConvMetadata(ctx, convID, &rl); err == nil {
 		// Try locally first
-		localData, err := s.storage.Fetch(ctx, conv, uid, query, pagination, &rl)
+		localData, err := s.storage.Fetch(ctx, conv, uid, query, pagination)
 		if err == nil {
 			// If found, then return the stuff
 			s.G().Log.Debug("Pull: cache hit: convID: %s uid: %s", convID, uid)
-			localData.Messages = utils.FilterByType(localData.Messages, query)
 
 			// Before returning the stuff, send remote request to mark as read if
 			// requested.

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -16,7 +16,7 @@ import (
 )
 
 type Sender interface {
-	Send(ctx context.Context, convID chat1.ConversationID, msg chat1.MessagePlaintext) (chat1.OutboxID, chat1.MessageID, *chat1.RateLimit, error)
+	Send(ctx context.Context, convID chat1.ConversationID, msg chat1.MessagePlaintext, clientPrev chat1.MessageID) (chat1.OutboxID, chat1.MessageID, *chat1.RateLimit, error)
 	Prepare(ctx context.Context, msg chat1.MessagePlaintext, convID *chat1.ConversationID) (*chat1.MessageBoxed, error)
 }
 
@@ -68,7 +68,9 @@ func (s *BlockingSender) addSenderToMessage(msg chat1.MessagePlaintext) (chat1.M
 	return updated, nil
 }
 
-func (s *BlockingSender) addPrevPointersToMessage(msg chat1.MessagePlaintext, convID chat1.ConversationID) (chat1.MessagePlaintext, error) {
+func (s *BlockingSender) addPrevPointersToMessage(ctx context.Context, msg chat1.MessagePlaintext,
+	convID chat1.ConversationID) (chat1.MessagePlaintext, error) {
+
 	// Make sure the caller hasn't already assembled this list. For now, this
 	// should never happen, and we'll return an error just in case we make a
 	// mistake in the future. But if there's some use case in the future where
@@ -106,7 +108,7 @@ func (s *BlockingSender) Prepare(ctx context.Context, plaintext chat1.MessagePla
 
 	// convID will be nil in makeFirstMessage, for example
 	if convID != nil {
-		msg, err = s.addPrevPointersToMessage(msg, *convID)
+		msg, err = s.addPrevPointersToMessage(ctx, msg, *convID)
 		if err != nil {
 			return nil, err
 		}
@@ -143,7 +145,7 @@ func (s *BlockingSender) getSigningKeyPair() (kp libkb.NaclSigningKeyPair, err e
 }
 
 func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
-	msg chat1.MessagePlaintext) (chat1.OutboxID, chat1.MessageID, *chat1.RateLimit, error) {
+	msg chat1.MessagePlaintext, clientPrev chat1.MessageID) (chat1.OutboxID, chat1.MessageID, *chat1.RateLimit, error) {
 
 	// Add a bunch of stuff to the message (like prev pointers, sender info, ...)
 	boxed, err := s.Prepare(ctx, msg, &convID)
@@ -187,6 +189,7 @@ type Deliverer struct {
 
 	sender     Sender
 	outbox     *storage.Outbox
+	storage    *storage.Storage
 	shutdownCh chan struct{}
 	msgSentCh  chan struct{}
 	delivering bool
@@ -198,6 +201,7 @@ func NewDeliverer(g *libkb.GlobalContext, sender Sender) *Deliverer {
 		shutdownCh:   make(chan struct{}, 1),
 		msgSentCh:    make(chan struct{}, 100),
 		sender:       sender,
+		storage:      storage.New(g, func() libkb.SecretUI { return DelivererSecretUI{} }),
 	}
 
 	g.PushShutdownHook(func() error {
@@ -281,10 +285,10 @@ func (s *Deliverer) deliverLoop() {
 		// Send messages
 		pops := 0
 		for _, obr := range obrs {
-			obr.Msg.ClientHeader.OutboxID = &obr.OutboxID
-			_, _, _, err := s.sender.Send(context.Background(), obr.ConvID, obr.Msg)
+			_, _, _, err := s.sender.Send(context.Background(), obr.ConvID, obr.Msg, 0)
 			if err != nil {
-				s.G().Log.Error("failed to send msg: convID: %s err: %s", obr.ConvID, err.Error())
+				s.G().Log.Error("failed to send msg: uid: %s convID: %s err: %s", s.outbox.GetUID(),
+					obr.ConvID, err.Error())
 				break
 			}
 			pops++
@@ -320,7 +324,12 @@ func (s *NonblockingSender) Prepare(ctx context.Context, plaintext chat1.Message
 }
 
 func (s *NonblockingSender) Send(ctx context.Context, convID chat1.ConversationID,
-	msg chat1.MessagePlaintext) (chat1.OutboxID, chat1.MessageID, *chat1.RateLimit, error) {
+	msg chat1.MessagePlaintext, clientPrev chat1.MessageID) (chat1.OutboxID, chat1.MessageID, *chat1.RateLimit, error) {
+
+	msg.ClientHeader.OutboxInfo = &chat1.OutboxInfo{
+		Prev:        clientPrev,
+		ComposeTime: gregor1.ToTime(time.Now()),
+	}
 	oid, err := s.G().MessageDeliverer.Queue(convID, msg)
 	return oid, 0, &chat1.RateLimit{}, err
 }

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"encoding/hex"
+
 	"github.com/jonboulle/clockwork"
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/utils"
@@ -41,8 +43,11 @@ func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActi
 	defer n.Unlock()
 	typ, err := activity.ActivityType()
 	if err == nil && typ == chat1.ChatActivityType_INCOMING_MESSAGE {
-		n.obids = append(n.obids, *activity.IncomingMessage().Message.Valid().ClientHeader.OutboxID)
-		n.action <- len(n.obids)
+		header := activity.IncomingMessage().Message.Valid().ClientHeader
+		if header.OutboxID != nil {
+			n.obids = append(n.obids, *activity.IncomingMessage().Message.Valid().ClientHeader.OutboxID)
+			n.action <- len(n.obids)
+		}
 	}
 }
 
@@ -53,7 +58,7 @@ func getUser(world *kbtest.ChatMockWorld) (libkb.TestContext, *kbtest.FakeUser) 
 	return libkb.TestContext{}, nil
 }
 
-func setupTest(t *testing.T) (libkb.TestContext, chat1.RemoteInterface, *kbtest.FakeUser, Sender, *chatListener, func() libkb.SecretUI, clockwork.FakeClock) {
+func setupTest(t *testing.T) (libkb.TestContext, chat1.RemoteInterface, *kbtest.FakeUser, Sender, Sender, *chatListener, func() libkb.SecretUI, clockwork.FakeClock) {
 	world := kbtest.NewChatMockWorld(t, "chatsender", 1)
 	ri := kbtest.NewChatRemoteMock(world)
 	tlf := kbtest.NewTlfMock(world)
@@ -74,11 +79,11 @@ func setupTest(t *testing.T) (libkb.TestContext, chat1.RemoteInterface, *kbtest.
 	tc.G.MessageDeliverer = NewDeliverer(tc.G, baseSender)
 	tc.G.MessageDeliverer.Start(u.User.GetUID().ToBytes())
 
-	return tc, ri, u, sender, &listener, f, world.Fc
+	return tc, ri, u, sender, baseSender, &listener, f, world.Fc
 }
 
 func TestNonblockChannel(t *testing.T) {
-	tc, ri, u, sender, listener, _, _ := setupTest(t)
+	tc, ri, u, sender, _, listener, _, _ := setupTest(t)
 	defer tc.Cleanup()
 
 	res, err := ri.NewConversationRemote2(context.TODO(), chat1.NewConversationRemote2Arg{
@@ -96,13 +101,15 @@ func TestNonblockChannel(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+
+	// Send nonblock
 	obid, _, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Sender:    u.User.GetUID().ToBytes(),
 			TlfName:   u.Username,
 			TlfPublic: false,
 		},
-	})
+	}, 0)
 	require.NoError(t, err)
 
 	select {
@@ -113,10 +120,37 @@ func TestNonblockChannel(t *testing.T) {
 
 	require.Equal(t, 1, len(listener.obids), "wrong length")
 	require.Equal(t, obid, listener.obids[0], "wrong obid")
+
+}
+
+type sentRecord struct {
+	msgID    *chat1.MessageID
+	outboxID *chat1.OutboxID
+}
+
+func checkThread(t *testing.T, thread chat1.ThreadView, ref []sentRecord) {
+	require.Equal(t, len(ref), len(thread.Messages), "size not equal")
+	for index, msg := range thread.Messages {
+		rindex := len(ref) - index - 1
+		t.Logf("checking index: %d rindex: %d", index, rindex)
+		if ref[rindex].msgID != nil {
+			t.Logf("msgID: ref: %d actual: %d", *ref[rindex].msgID, thread.Messages[index].GetMessageID())
+			require.NotZero(t, msg.GetMessageID(), "missing message ID")
+			require.Equal(t, *ref[rindex].msgID, msg.GetMessageID(), "invalid message ID")
+		} else if ref[index].outboxID != nil {
+			t.Logf("obID: ref: %s actual: %s",
+				hex.EncodeToString(*ref[rindex].outboxID),
+				hex.EncodeToString(msg.Outbox().OutboxID))
+			require.Equal(t, *ref[rindex].outboxID, msg.Outbox().OutboxID, "invalid outbox ID")
+		} else {
+			require.Fail(t, "unknown ref type")
+		}
+		t.Logf("index %d succeeded", index)
+	}
 }
 
 func TestNonblockTimer(t *testing.T) {
-	tc, ri, u, _, listener, f, clock := setupTest(t)
+	tc, ri, u, _, baseSender, listener, f, clock := setupTest(t)
 	defer tc.Cleanup()
 
 	res, err := ri.NewConversationRemote2(context.TODO(), chat1.NewConversationRemote2Arg{
@@ -127,25 +161,51 @@ func TestNonblockTimer(t *testing.T) {
 		},
 		TLFMessage: chat1.MessageBoxed{
 			ClientHeader: chat1.MessageClientHeader{
-				TlfName:   u.Username,
-				TlfPublic: false,
+				TlfName:     u.Username,
+				TlfPublic:   false,
+				MessageType: chat1.MessageType_TLFNAME,
 			},
 			KeyGeneration: 1,
 		},
 	})
 	require.NoError(t, err)
 
+	// Send a bunch of nonblocking messages
+	var sentRef []sentRecord
+	for i := 0; i < 5; i++ {
+		_, msgID, _, err := baseSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+			ClientHeader: chat1.MessageClientHeader{
+				Sender:      u.User.GetUID().ToBytes(),
+				TlfName:     u.Username,
+				TlfPublic:   false,
+				MessageType: chat1.MessageType_TEXT,
+			},
+			MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+				Body: "hi",
+			}),
+		}, 0)
+		t.Logf("generated msgID: %d", msgID)
+		require.NoError(t, err)
+		sentRef = append(sentRef, sentRecord{msgID: &msgID})
+	}
+
 	outbox := storage.NewOutbox(tc.G, u.User.GetUID().ToBytes(), f)
 	var obids []chat1.OutboxID
+	msgID := *sentRef[len(sentRef)-1].msgID
 	for i := 0; i < 5; i++ {
 		obid, err := outbox.PushMessage(res.ConvID, chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
 				Sender:    u.User.GetUID().ToBytes(),
 				TlfName:   u.Username,
 				TlfPublic: false,
+				OutboxInfo: &chat1.OutboxInfo{
+					Prev: msgID,
+				},
 			},
 		})
+		t.Logf("generated obid: %s prev: %d", hex.EncodeToString(obid), msgID)
 		require.NoError(t, err)
+		sentRef = append(sentRef, sentRecord{outboxID: &obid})
 		obids = append(obids, obid)
 	}
 
@@ -156,6 +216,33 @@ func TestNonblockTimer(t *testing.T) {
 	default:
 	}
 
+	// Send a bunch of nonblocking messages
+	for i := 0; i < 5; i++ {
+		_, msgID, _, err := baseSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+			ClientHeader: chat1.MessageClientHeader{
+				Sender:      u.User.GetUID().ToBytes(),
+				TlfName:     u.Username,
+				TlfPublic:   false,
+				MessageType: chat1.MessageType_TEXT,
+			},
+			MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+				Body: "hi",
+			}),
+		}, 0)
+		t.Logf("generated msgID: %d", msgID)
+		sentRef = append(sentRef, sentRecord{msgID: &msgID})
+		require.NoError(t, err)
+	}
+
+	// Check get thread, make sure it makes sense
+	typs := []chat1.MessageType{chat1.MessageType_TEXT}
+	tres, _, err := tc.G.ConvSource.Pull(context.TODO(), res.ConvID, u.User.GetUID().ToBytes(),
+		&chat1.GetThreadQuery{MessageTypes: typs}, nil)
+	tres.Messages = utils.FilterByType(tres.Messages, &chat1.GetThreadQuery{MessageTypes: typs})
+	t.Logf("source size: %d", len(tres.Messages))
+	require.NoError(t, err)
+	require.NoError(t, outbox.SprinkleIntoThread(&tres))
+	checkThread(t, tres, sentRef)
 	clock.Advance(5 * time.Minute)
 
 	// Should get a blast of all 5

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -241,7 +241,7 @@ func TestNonblockTimer(t *testing.T) {
 	tres.Messages = utils.FilterByType(tres.Messages, &chat1.GetThreadQuery{MessageTypes: typs})
 	t.Logf("source size: %d", len(tres.Messages))
 	require.NoError(t, err)
-	require.NoError(t, outbox.SprinkleIntoThread(&tres))
+	require.NoError(t, outbox.SprinkleIntoThread(res.ConvID, &tres))
 	checkThread(t, tres, sentRef)
 	clock.Advance(5 * time.Minute)
 

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -159,6 +159,7 @@ func (o *Outbox) PushMessage(convID chat1.ConversationID, msg chat1.MessagePlain
 	}
 
 	// Append record
+	msg.ClientHeader.OutboxID = &outboxID
 	obox.Records = append(obox.Records, chat1.OutboxRecord{
 		Msg:      msg,
 		ConvID:   convID,
@@ -226,6 +227,91 @@ func (o *Outbox) PopNOldestMessages(n int) error {
 	if err := o.writeDiskOutbox(obox); err != nil {
 		return o.maybeNuke(libkb.NewChatStorageInternalError(o.G(),
 			"error writing outbox: err: %s", err.Error()))
+	}
+
+	return nil
+}
+
+func (o *Outbox) RemoveMessage(obid chat1.OutboxID) error {
+	o.Lock()
+	defer o.Unlock()
+
+	// Read outbox for the user
+	obox, err := o.readDiskOutbox()
+	if err != nil {
+		return o.maybeNuke(libkb.NewChatStorageInternalError(o.G(),
+			"error reading outbox: err: %s", err.Error()))
+	}
+
+	// Scan to find the message and don't include it
+	var recs []chat1.OutboxRecord
+	for _, obr := range obox.Records {
+		if !obr.OutboxID.Eq(obid) {
+			recs = append(recs, obr)
+		}
+	}
+	obox.Records = recs
+
+	// Write out box
+	if err := o.writeDiskOutbox(obox); err != nil {
+		return o.maybeNuke(libkb.NewChatStorageInternalError(o.G(),
+			"error writing outbox: err: %s", err.Error()))
+	}
+
+	return nil
+}
+
+func (o *Outbox) getMsgOrdinal(msg chat1.MessageUnboxed) (chat1.MessageID, error) {
+	typ, err := msg.State()
+	if err != nil {
+		return 0, err
+	}
+
+	switch typ {
+	case chat1.MessageUnboxedState_OUTBOX:
+		return msg.Outbox().Msg.ClientHeader.OutboxInfo.Prev, nil
+	default:
+		return msg.GetMessageID(), nil
+	}
+}
+
+func (o *Outbox) insertMessage(thread *chat1.ThreadView, obr chat1.OutboxRecord) error {
+	prev := obr.Msg.ClientHeader.OutboxInfo.Prev
+	inserted := false
+	var res []chat1.MessageUnboxed
+	for index, msg := range thread.Messages {
+		ord, err := o.getMsgOrdinal(msg)
+		if err != nil {
+			return err
+		}
+		if !inserted && prev >= ord {
+			res = append(res, chat1.NewMessageUnboxedWithOutbox(obr))
+			o.G().Log.Debug("inserting at: %d msgID: %d", index, msg.GetMessageID())
+			inserted = true
+		}
+		res = append(res, msg)
+	}
+
+	thread.Messages = res
+	return nil
+}
+
+func (o *Outbox) SprinkleIntoThread(thread *chat1.ThreadView) error {
+	o.Lock()
+	defer o.Unlock()
+
+	// Read outbox for the user
+	obox, err := o.readDiskOutbox()
+	if err != nil {
+		return o.maybeNuke(libkb.NewChatStorageInternalError(o.G(), "error reading outbox: err: %s",
+			err.Error()))
+	}
+
+	// Sprinkle each outbox message in
+	for _, obr := range obox.Records {
+		if err := o.insertMessage(thread, obr); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -296,7 +296,7 @@ func (o *Outbox) insertMessage(thread *chat1.ThreadView, obr chat1.OutboxRecord)
 	return nil
 }
 
-func (o *Outbox) SprinkleIntoThread(thread *chat1.ThreadView) error {
+func (o *Outbox) SprinkleIntoThread(convID chat1.ConversationID, thread *chat1.ThreadView) error {
 	o.Lock()
 	defer o.Unlock()
 
@@ -309,6 +309,9 @@ func (o *Outbox) SprinkleIntoThread(thread *chat1.ThreadView) error {
 
 	// Sprinkle each outbox message in
 	for _, obr := range obox.Records {
+		if !obr.ConvID.Eq(convID) {
+			continue
+		}
 		if err := o.insertMessage(thread, obr); err != nil {
 			return err
 		}

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -242,8 +242,7 @@ func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.Conver
 }
 
 func (s *Storage) Fetch(ctx context.Context, conv chat1.Conversation,
-	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination,
-	rl *[]*chat1.RateLimit) (chat1.ThreadView, libkb.ChatStorageError) {
+	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination) (chat1.ThreadView, libkb.ChatStorageError) {
 	// All public functions get locks to make access to the database single threaded.
 	// They should never be called from private functons.
 	s.Lock()

--- a/go/chat/storage/storage_test.go
+++ b/go/chat/storage/storage_test.go
@@ -89,7 +89,7 @@ func doSimpleBench(b *testing.B, storage *Storage, uid gregor1.UID) {
 
 	for i := 0; i < b.N; i++ {
 		require.NoError(b, storage.Merge(context.TODO(), conv.Metadata.ConversationID, uid, msgs))
-		_, err := storage.Fetch(context.TODO(), conv, uid, nil, nil, nil)
+		_, err := storage.Fetch(context.TODO(), conv, uid, nil, nil)
 		require.NoError(b, err)
 		storage.MaybeNuke(true, nil, conv.Metadata.ConversationID, uid)
 	}
@@ -101,7 +101,7 @@ func doCommonBench(b *testing.B, storage *Storage, uid gregor1.UID) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		require.NoError(b, storage.Merge(context.TODO(), conv.Metadata.ConversationID, uid, msgs))
-		_, err := storage.Fetch(context.TODO(), conv, uid, nil, nil, nil)
+		_, err := storage.Fetch(context.TODO(), conv, uid, nil, nil)
 		require.NoError(b, err)
 
 		// Add some msgs
@@ -111,7 +111,7 @@ func doCommonBench(b *testing.B, storage *Storage, uid gregor1.UID) {
 		b.StartTimer()
 
 		require.NoError(b, storage.Merge(context.TODO(), conv.Metadata.ConversationID, uid, newmsgs))
-		storage.Fetch(context.TODO(), newconv, uid, nil, nil, nil)
+		storage.Fetch(context.TODO(), newconv, uid, nil, nil)
 	}
 }
 
@@ -141,7 +141,7 @@ func doRandomBench(b *testing.B, storage *Storage, uid gregor1.UID, num, len int
 			}
 			b.StartTimer()
 
-			_, err = storage.Fetch(context.TODO(), conv, uid, nil, &p, nil)
+			_, err = storage.Fetch(context.TODO(), conv, uid, nil, &p)
 			require.NoError(b, err)
 		}
 	}
@@ -202,7 +202,7 @@ func TestStorageBasic(t *testing.T) {
 	conv := makeConversation(msgs[0].GetMessageID())
 
 	require.NoError(t, storage.Merge(context.TODO(), conv.Metadata.ConversationID, uid, msgs))
-	res, err := storage.Fetch(context.TODO(), conv, uid, nil, nil, nil)
+	res, err := storage.Fetch(context.TODO(), conv, uid, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, len(msgs), len(res.Messages), "wrong amount of messages")
 	for i := 0; i < len(res.Messages); i++ {
@@ -217,7 +217,7 @@ func TestStorageLargeList(t *testing.T) {
 	conv := makeConversation(msgs[0].GetMessageID())
 
 	require.NoError(t, storage.Merge(context.TODO(), conv.Metadata.ConversationID, uid, msgs))
-	res, err := storage.Fetch(context.TODO(), conv, uid, nil, nil, nil)
+	res, err := storage.Fetch(context.TODO(), conv, uid, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, len(msgs), len(res.Messages), "wrong amount of messages")
 	for i := 0; i < len(res.Messages); i++ {
@@ -235,7 +235,7 @@ func TestStorageSupersedes(t *testing.T) {
 	conv := makeConversation(msgs[0].GetMessageID())
 
 	require.NoError(t, storage.Merge(context.TODO(), conv.Metadata.ConversationID, uid, msgs))
-	res, err := storage.Fetch(context.TODO(), conv, uid, nil, nil, nil)
+	res, err := storage.Fetch(context.TODO(), conv, uid, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, len(msgs), len(res.Messages), "wrong amount of messages")
 	for i := 0; i < len(res.Messages); i++ {
@@ -249,7 +249,7 @@ func TestStorageSupersedes(t *testing.T) {
 		[]chat1.MessageUnboxed{superseder2}))
 	conv.ReaderInfo.MaxMsgid = 112
 	msgs = append([]chat1.MessageUnboxed{superseder2}, msgs...)
-	res, err = storage.Fetch(context.TODO(), conv, uid, nil, nil, nil)
+	res, err = storage.Fetch(context.TODO(), conv, uid, nil, nil)
 	require.NoError(t, err)
 
 	sheader = res.Messages[len(msgs)-11].Valid().ServerHeader
@@ -264,7 +264,7 @@ func TestStorageMiss(t *testing.T) {
 	conv := makeConversation(15)
 
 	require.NoError(t, storage.Merge(context.TODO(), conv.Metadata.ConversationID, uid, msgs))
-	_, err := storage.Fetch(context.TODO(), conv, uid, nil, nil, nil)
+	_, err := storage.Fetch(context.TODO(), conv, uid, nil, nil)
 	require.Error(t, err, "expected error")
 	require.IsType(t, libkb.ChatStorageMissError{}, err, "wrong error type")
 }
@@ -285,7 +285,7 @@ func TestStoragePagination(t *testing.T) {
 		Num:  100,
 		Next: index,
 	}
-	res, err := storage.Fetch(context.TODO(), conv, uid, nil, &p, nil)
+	res, err := storage.Fetch(context.TODO(), conv, uid, nil, &p)
 	require.NoError(t, err)
 	require.Equal(t, chat1.MessageID(119), msgs[181].GetMessageID(), "wrong msg id at border")
 	require.Equal(t, 100, len(res.Messages), "wrong amount of messages")
@@ -297,7 +297,7 @@ func TestStoragePagination(t *testing.T) {
 		Previous: res.Pagination.Previous,
 	}
 	t.Logf("fetching previous from result")
-	res, err = storage.Fetch(context.TODO(), conv, uid, nil, &p, nil)
+	res, err = storage.Fetch(context.TODO(), conv, uid, nil, &p)
 	require.NoError(t, err)
 	require.Equal(t, chat1.MessageID(219), msgs[81].GetMessageID(), "wrong msg id at broder")
 	require.Equal(t, 100, len(res.Messages), "wrong amount of messages")
@@ -312,7 +312,7 @@ func TestStoragePagination(t *testing.T) {
 		Num:      100,
 		Previous: index,
 	}
-	res, err = storage.Fetch(context.TODO(), conv, uid, nil, &p, nil)
+	res, err = storage.Fetch(context.TODO(), conv, uid, nil, &p)
 	require.NoError(t, err)
 	require.Equal(t, chat1.MessageID(220), msgs[80].GetMessageID(), "wrong msg id at border")
 	require.Equal(t, 100, len(res.Messages), "wrong amount of messages")
@@ -324,7 +324,7 @@ func TestStoragePagination(t *testing.T) {
 		Next: res.Pagination.Next,
 	}
 	t.Logf("fetching next from result")
-	res, err = storage.Fetch(context.TODO(), conv, uid, nil, &p, nil)
+	res, err = storage.Fetch(context.TODO(), conv, uid, nil, &p)
 	require.NoError(t, err)
 	require.Equal(t, 100, len(res.Messages), "wrong amount of messages")
 	for i := 0; i < len(res.Messages); i++ {
@@ -352,7 +352,7 @@ func TestStorageTypeFilter(t *testing.T) {
 	}
 
 	require.NoError(t, storage.Merge(context.TODO(), conv.Metadata.ConversationID, uid, msgs))
-	res, err := storage.Fetch(context.TODO(), conv, uid, &query, nil, nil)
+	res, err := storage.Fetch(context.TODO(), conv, uid, &query, nil)
 	require.NoError(t, err)
 	require.Equal(t, len(msgs), len(res.Messages), "wrong amount of messages")
 	restexts := utils.FilterByType(res.Messages, &query)

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -181,6 +181,11 @@ type MessagePreviousPointer struct {
 	Hash Hash      `codec:"hash" json:"hash"`
 }
 
+type OutboxInfo struct {
+	Prev        MessageID    `codec:"prev" json:"prev"`
+	ComposeTime gregor1.Time `codec:"composeTime" json:"composeTime"`
+}
+
 type MessageClientHeader struct {
 	Conv         ConversationIDTriple     `codec:"conv" json:"conv"`
 	TlfName      string                   `codec:"tlfName" json:"tlfName"`
@@ -191,6 +196,7 @@ type MessageClientHeader struct {
 	Sender       gregor1.UID              `codec:"sender" json:"sender"`
 	SenderDevice gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
 	OutboxID     *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
+	OutboxInfo   *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
 }
 
 type EncryptedData struct {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -182,3 +182,7 @@ func (t ConversationIDTriple) Derivable(cid ConversationID) bool {
 	h10 := t.Hash10B()
 	return bytes.Equal(h10[2:], []byte(cid[2:]))
 }
+
+func (o OutboxID) Eq(r OutboxID) bool {
+	return bytes.Equal(o, r)
+}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -200,6 +200,86 @@ func NewMessageBodyWithHeadline(v MessageHeadline) MessageBody {
 	}
 }
 
+type OutboxStateType int
+
+const (
+	OutboxStateType_SENDING OutboxStateType = 0
+	OutboxStateType_ERROR   OutboxStateType = 1
+)
+
+var OutboxStateTypeMap = map[string]OutboxStateType{
+	"SENDING": 0,
+	"ERROR":   1,
+}
+
+var OutboxStateTypeRevMap = map[OutboxStateType]string{
+	0: "SENDING",
+	1: "ERROR",
+}
+
+type OutboxState struct {
+	State__   OutboxStateType `codec:"state" json:"state"`
+	Sending__ *int            `codec:"sending,omitempty" json:"sending,omitempty"`
+	Error__   *string         `codec:"error,omitempty" json:"error,omitempty"`
+}
+
+func (o *OutboxState) State() (ret OutboxStateType, err error) {
+	switch o.State__ {
+	case OutboxStateType_SENDING:
+		if o.Sending__ == nil {
+			err = errors.New("unexpected nil value for Sending__")
+			return ret, err
+		}
+	case OutboxStateType_ERROR:
+		if o.Error__ == nil {
+			err = errors.New("unexpected nil value for Error__")
+			return ret, err
+		}
+	}
+	return o.State__, nil
+}
+
+func (o OutboxState) Sending() int {
+	if o.State__ != OutboxStateType_SENDING {
+		panic("wrong case accessed")
+	}
+	if o.Sending__ == nil {
+		return 0
+	}
+	return *o.Sending__
+}
+
+func (o OutboxState) Error() string {
+	if o.State__ != OutboxStateType_ERROR {
+		panic("wrong case accessed")
+	}
+	if o.Error__ == nil {
+		return ""
+	}
+	return *o.Error__
+}
+
+func NewOutboxStateWithSending(v int) OutboxState {
+	return OutboxState{
+		State__:   OutboxStateType_SENDING,
+		Sending__: &v,
+	}
+}
+
+func NewOutboxStateWithError(v string) OutboxState {
+	return OutboxState{
+		State__: OutboxStateType_ERROR,
+		Error__: &v,
+	}
+}
+
+type OutboxRecord struct {
+	State    OutboxState      `codec:"state" json:"state"`
+	OutboxID OutboxID         `codec:"outboxID" json:"outboxID"`
+	ConvID   ConversationID   `codec:"convID" json:"convID"`
+	Msg      MessagePlaintext `codec:"Msg" json:"Msg"`
+}
+
 type HeaderPlaintextVersion int
 
 const (
@@ -223,6 +303,7 @@ type HeaderPlaintextV1 struct {
 	Sender          gregor1.UID              `codec:"sender" json:"sender"`
 	SenderDevice    gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
 	BodyHash        Hash                     `codec:"bodyHash" json:"bodyHash"`
+	OutboxInfo      *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
 	HeaderSignature *SignatureInfo           `codec:"headerSignature,omitempty" json:"headerSignature,omitempty"`
 }
 
@@ -318,18 +399,21 @@ type MessagePlaintext struct {
 type MessageUnboxedState int
 
 const (
-	MessageUnboxedState_VALID MessageUnboxedState = 1
-	MessageUnboxedState_ERROR MessageUnboxedState = 2
+	MessageUnboxedState_VALID  MessageUnboxedState = 1
+	MessageUnboxedState_ERROR  MessageUnboxedState = 2
+	MessageUnboxedState_OUTBOX MessageUnboxedState = 3
 )
 
 var MessageUnboxedStateMap = map[string]MessageUnboxedState{
-	"VALID": 1,
-	"ERROR": 2,
+	"VALID":  1,
+	"ERROR":  2,
+	"OUTBOX": 3,
 }
 
 var MessageUnboxedStateRevMap = map[MessageUnboxedState]string{
 	1: "VALID",
 	2: "ERROR",
+	3: "OUTBOX",
 }
 
 type MessageUnboxedValid struct {
@@ -348,9 +432,10 @@ type MessageUnboxedError struct {
 }
 
 type MessageUnboxed struct {
-	State__ MessageUnboxedState  `codec:"state" json:"state"`
-	Valid__ *MessageUnboxedValid `codec:"valid,omitempty" json:"valid,omitempty"`
-	Error__ *MessageUnboxedError `codec:"error,omitempty" json:"error,omitempty"`
+	State__  MessageUnboxedState  `codec:"state" json:"state"`
+	Valid__  *MessageUnboxedValid `codec:"valid,omitempty" json:"valid,omitempty"`
+	Error__  *MessageUnboxedError `codec:"error,omitempty" json:"error,omitempty"`
+	Outbox__ *OutboxRecord        `codec:"outbox,omitempty" json:"outbox,omitempty"`
 }
 
 func (o *MessageUnboxed) State() (ret MessageUnboxedState, err error) {
@@ -363,6 +448,11 @@ func (o *MessageUnboxed) State() (ret MessageUnboxedState, err error) {
 	case MessageUnboxedState_ERROR:
 		if o.Error__ == nil {
 			err = errors.New("unexpected nil value for Error__")
+			return ret, err
+		}
+	case MessageUnboxedState_OUTBOX:
+		if o.Outbox__ == nil {
+			err = errors.New("unexpected nil value for Outbox__")
 			return ret, err
 		}
 	}
@@ -389,6 +479,16 @@ func (o MessageUnboxed) Error() MessageUnboxedError {
 	return *o.Error__
 }
 
+func (o MessageUnboxed) Outbox() OutboxRecord {
+	if o.State__ != MessageUnboxedState_OUTBOX {
+		panic("wrong case accessed")
+	}
+	if o.Outbox__ == nil {
+		return OutboxRecord{}
+	}
+	return *o.Outbox__
+}
+
 func NewMessageUnboxedWithValid(v MessageUnboxedValid) MessageUnboxed {
 	return MessageUnboxed{
 		State__: MessageUnboxedState_VALID,
@@ -403,9 +503,11 @@ func NewMessageUnboxedWithError(v MessageUnboxedError) MessageUnboxed {
 	}
 }
 
-type ThreadView struct {
-	Messages   []MessageUnboxed `codec:"messages" json:"messages"`
-	Pagination *Pagination      `codec:"pagination,omitempty" json:"pagination,omitempty"`
+func NewMessageUnboxedWithOutbox(v OutboxRecord) MessageUnboxed {
+	return MessageUnboxed{
+		State__:  MessageUnboxedState_OUTBOX,
+		Outbox__: &v,
+	}
 }
 
 type UnreadFirstNumLimit struct {
@@ -431,10 +533,9 @@ type ConversationLocal struct {
 	MaxMessages []MessageUnboxed       `codec:"maxMessages" json:"maxMessages"`
 }
 
-type OutboxRecord struct {
-	OutboxID OutboxID         `codec:"outboxID" json:"outboxID"`
-	ConvID   ConversationID   `codec:"convID" json:"convID"`
-	Msg      MessagePlaintext `codec:"Msg" json:"Msg"`
+type ThreadView struct {
+	Messages   []MessageUnboxed `codec:"messages" json:"messages"`
+	Pagination *Pagination      `codec:"pagination,omitempty" json:"pagination,omitempty"`
 }
 
 type GetThreadQuery struct {
@@ -445,9 +546,8 @@ type GetThreadQuery struct {
 }
 
 type GetThreadLocalRes struct {
-	Thread     ThreadView     `codec:"thread" json:"thread"`
-	Outbox     []OutboxRecord `codec:"outbox" json:"outbox"`
-	RateLimits []RateLimit    `codec:"rateLimits" json:"rateLimits"`
+	Thread     ThreadView  `codec:"thread" json:"thread"`
+	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
 }
 
 type GetInboxLocalRes struct {
@@ -564,6 +664,7 @@ type PostLocalArg struct {
 type PostLocalNonblockArg struct {
 	ConversationID ConversationID   `codec:"conversationID" json:"conversationID"`
 	Msg            MessagePlaintext `codec:"msg" json:"msg"`
+	ClientPrev     MessageID        `codec:"clientPrev" json:"clientPrev"`
 }
 
 type SetConversationStatusLocalArg struct {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -215,14 +215,12 @@ func (h *chatLocalHandler) GetThreadLocal(ctx context.Context, arg chat1.GetThre
 
 	// Fetch outbox and tack onto the result
 	outbox := storage.NewOutbox(h.G(), uid.ToBytes(), h.getSecretUI)
-	obr, err := outbox.PullConversation(arg.ConversationID)
-	if err != nil {
+	if err = outbox.SprinkleIntoThread(&thread); err != nil {
 		return chat1.GetThreadLocalRes{}, err
 	}
 
 	return chat1.GetThreadLocalRes{
 		Thread:     thread,
-		Outbox:     obr,
 		RateLimits: utils.AggRateLimitsP(rl),
 	}, nil
 }
@@ -707,7 +705,7 @@ func (h *chatLocalHandler) PostLocal(ctx context.Context, arg chat1.PostLocalArg
 
 	sender := chat.NewBlockingSender(h.G(), h.boxer, h.remoteClient, h.getSecretUI)
 
-	_, _, rl, err := sender.Send(ctx, arg.ConversationID, arg.Msg)
+	_, _, rl, err := sender.Send(ctx, arg.ConversationID, arg.Msg, 0)
 	if err != nil {
 		return chat1.PostLocalRes{}, fmt.Errorf("PostLocal: unable to send message: %s", err.Error())
 	}
@@ -718,11 +716,16 @@ func (h *chatLocalHandler) PostLocal(ctx context.Context, arg chat1.PostLocalArg
 
 func (h *chatLocalHandler) PostLocalNonblock(ctx context.Context, arg chat1.PostLocalNonblockArg) (chat1.PostLocalNonblockRes, error) {
 
+	// Add outbox information
+	arg.Msg.ClientHeader.OutboxInfo = &chat1.OutboxInfo{
+		Prev: arg.ClientPrev,
+	}
+
 	// Create non block sender
 	sender := chat.NewBlockingSender(h.G(), h.boxer, h.remoteClient, h.getSecretUI)
 	nonblockSender := chat.NewNonblockingSender(h.G(), sender)
 
-	obid, _, rl, err := nonblockSender.Send(ctx, arg.ConversationID, arg.Msg)
+	obid, _, rl, err := nonblockSender.Send(ctx, arg.ConversationID, arg.Msg, arg.ClientPrev)
 	if err != nil {
 		return chat1.PostLocalNonblockRes{},
 			fmt.Errorf("PostLocalNonblock: unable to send message: err: %s", err.Error())

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -215,7 +215,7 @@ func (h *chatLocalHandler) GetThreadLocal(ctx context.Context, arg chat1.GetThre
 
 	// Fetch outbox and tack onto the result
 	outbox := storage.NewOutbox(h.G(), uid.ToBytes(), h.getSecretUI)
-	if err = outbox.SprinkleIntoThread(&thread); err != nil {
+	if err = outbox.SprinkleIntoThread(arg.ConversationID, &thread); err != nil {
 		return chat1.GetThreadLocalRes{}, err
 	}
 

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -128,6 +128,11 @@ protocol common {
     Hash hash;
   }
 
+  record OutboxInfo {
+    MessageID prev; // This is the message ID the sending client device saw as the previous
+    gregor1.Time composeTime;
+  }    
+  
   record MessageClientHeader {
     ConversationIDTriple conv;
     string tlfName;
@@ -137,7 +142,8 @@ protocol common {
     array<MessagePreviousPointer> prev;
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;
-    union { null, OutboxID } outboxID; 
+    union { null, OutboxID } outboxID;
+    union { null, OutboxInfo } outboxInfo;
   }
 
   // The same format as in KBFS (see libkbfs/data_types.go)

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -55,6 +55,23 @@ protocol local {
     case HEADLINE: MessageHeadline;
   }
 
+  enum OutboxStateType {
+    SENDING_0,
+    ERROR_1
+  }
+
+  variant OutboxState switch (OutboxStateType state) {
+    case SENDING: int; // # of attempts
+    case ERROR: string; // err msg
+  }
+
+  record OutboxRecord {
+    OutboxState state; 
+    OutboxID outboxID;
+    ConversationID convID;
+    MessagePlaintext Msg;
+  }   
+  
   enum HeaderPlaintextVersion {
     V1_1
   }
@@ -71,6 +88,7 @@ protocol local {
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;
     Hash bodyHash;
+    union { null, OutboxInfo } outboxInfo;
     union {null, SignatureInfo} headerSignature;
   }
 
@@ -104,7 +122,8 @@ protocol local {
 
   enum MessageUnboxedState {
     VALID_1,
-    ERROR_2
+    ERROR_2,
+    OUTBOX_3
   }
 
   record MessageUnboxedValid {
@@ -125,11 +144,7 @@ protocol local {
   variant MessageUnboxed switch (MessageUnboxedState state) {
     case VALID: MessageUnboxedValid;
     case ERROR: MessageUnboxedError;
-  }
-  
-  record ThreadView {
-    array<MessageUnboxed> messages;
-    union { null, Pagination } pagination;
+    case OUTBOX: OutboxRecord;
   }
 
   // This causes fetching to return N items, where N = IdeallyGetUnreadPlus +
@@ -163,12 +178,11 @@ protocol local {
     ConversationInfoLocal info;
     ConversationReaderInfo readerInfo;
     array<MessageUnboxed> maxMessages; // the latest message for each message type
-  }
+  } 
 
-  record OutboxRecord {
-    OutboxID outboxID;
-    ConversationID convID;
-    MessagePlaintext Msg; 
+  record ThreadView {
+    array<MessageUnboxed> messages;
+    union { null, Pagination } pagination;
   }
 
   GetThreadLocalRes getThreadLocal(ConversationID conversationID, union { null, GetThreadQuery} query, union { null, Pagination } pagination);
@@ -180,7 +194,6 @@ protocol local {
   }
   record GetThreadLocalRes {
     ThreadView thread;
-    array<OutboxRecord> outbox;
     array<RateLimit> rateLimits;
   }
 
@@ -228,7 +241,7 @@ protocol local {
     array<RateLimit> rateLimits;
     OutboxID outboxID;
   }
-  PostLocalNonblockRes postLocalNonblock(ConversationID conversationID, MessagePlaintext msg);
+  PostLocalNonblockRes postLocalNonblock(ConversationID conversationID, MessagePlaintext msg, MessageID clientPrev);
 
   SetConversationStatusLocalRes SetConversationStatusLocal(ConversationID conversationID, ConversationStatus status);
   record SetConversationStatusLocalRes {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -98,6 +98,12 @@ export const LocalHeaderPlaintextVersion = {
 export const LocalMessageUnboxedState = {
   valid: 1,
   error: 2,
+  outbox: 3,
+}
+
+export const LocalOutboxStateType = {
+  sending: 0,
+  error: 1,
 }
 
 export const NotifyChatChatActivityType = {
@@ -576,7 +582,6 @@ export type GetMessagesRemoteRes = {
 
 export type GetThreadLocalRes = {
   thread: ThreadView,
-  outbox?: ?Array<OutboxRecord>,
   rateLimits?: ?Array<RateLimit>,
 }
 
@@ -606,6 +611,7 @@ export type HeaderPlaintextV1 = {
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
   bodyHash: Hash,
+  outboxInfo?: ?OutboxInfo,
   headerSignature?: ?SignatureInfo,
 }
 
@@ -675,6 +681,7 @@ export type MessageClientHeader = {
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
   outboxID?: ?OutboxID,
+  outboxInfo?: ?OutboxInfo,
 }
 
 export type MessageConversationMetadata = {
@@ -729,6 +736,7 @@ export type MessageType =
 export type MessageUnboxed = 
     { state : 1, valid : ?MessageUnboxedValid }
   | { state : 2, error : ?MessageUnboxedError }
+  | { state : 3, outbox : ?OutboxRecord }
 
 export type MessageUnboxedError = {
   errMsg: string,
@@ -739,6 +747,7 @@ export type MessageUnboxedError = {
 export type MessageUnboxedState = 
     1 // VALID_1
   | 2 // ERROR_2
+  | 3 // OUTBOX_3
 
 export type MessageUnboxedValid = {
   clientHeader: MessageClientHeader,
@@ -779,11 +788,25 @@ export type NotifyChatNewChatActivityRpcParam = Exact<{
 
 export type OutboxID = bytes
 
+export type OutboxInfo = {
+  prev: MessageID,
+  composeTime: gregor1.Time,
+}
+
 export type OutboxRecord = {
+  state: OutboxState,
   outboxID: OutboxID,
   convID: ConversationID,
   Msg: MessagePlaintext,
 }
+
+export type OutboxState = 
+    { state : 0, sending : ?int }
+  | { state : 1, error : ?string }
+
+export type OutboxStateType = 
+    0 // SENDING_0
+  | 1 // ERROR_1
 
 export type Pagination = {
   next: bytes,
@@ -947,7 +970,8 @@ export type localPostAttachmentLocalRpcParam = Exact<{
 
 export type localPostLocalNonblockRpcParam = Exact<{
   conversationID: ConversationID,
-  msg: MessagePlaintext
+  msg: MessagePlaintext,
+  clientPrev: MessageID
 }>
 
 export type localPostLocalRpcParam = Exact<{

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -349,6 +349,20 @@
     },
     {
       "type": "record",
+      "name": "OutboxInfo",
+      "fields": [
+        {
+          "type": "MessageID",
+          "name": "prev"
+        },
+        {
+          "type": "gregor1.Time",
+          "name": "composeTime"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "MessageClientHeader",
       "fields": [
         {
@@ -392,6 +406,13 @@
             "OutboxID"
           ],
           "name": "outboxID"
+        },
+        {
+          "type": [
+            null,
+            "OutboxInfo"
+          ],
+          "name": "outboxInfo"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -196,6 +196,60 @@
     },
     {
       "type": "enum",
+      "name": "OutboxStateType",
+      "symbols": [
+        "SENDING_0",
+        "ERROR_1"
+      ]
+    },
+    {
+      "type": "variant",
+      "name": "OutboxState",
+      "switch": {
+        "type": "OutboxStateType",
+        "name": "state"
+      },
+      "cases": [
+        {
+          "label": {
+            "name": "SENDING",
+            "def": false
+          },
+          "body": "int"
+        },
+        {
+          "label": {
+            "name": "ERROR",
+            "def": false
+          },
+          "body": "string"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "OutboxRecord",
+      "fields": [
+        {
+          "type": "OutboxState",
+          "name": "state"
+        },
+        {
+          "type": "OutboxID",
+          "name": "outboxID"
+        },
+        {
+          "type": "ConversationID",
+          "name": "convID"
+        },
+        {
+          "type": "MessagePlaintext",
+          "name": "Msg"
+        }
+      ]
+    },
+    {
+      "type": "enum",
       "name": "HeaderPlaintextVersion",
       "symbols": [
         "V1_1"
@@ -239,6 +293,13 @@
         {
           "type": "Hash",
           "name": "bodyHash"
+        },
+        {
+          "type": [
+            null,
+            "OutboxInfo"
+          ],
+          "name": "outboxInfo"
         },
         {
           "type": [
@@ -319,7 +380,8 @@
       "name": "MessageUnboxedState",
       "symbols": [
         "VALID_1",
-        "ERROR_2"
+        "ERROR_2",
+        "OUTBOX_3"
       ]
     },
     {
@@ -391,26 +453,13 @@
             "def": false
           },
           "body": "MessageUnboxedError"
-        }
-      ]
-    },
-    {
-      "type": "record",
-      "name": "ThreadView",
-      "fields": [
-        {
-          "type": {
-            "type": "array",
-            "items": "MessageUnboxed"
-          },
-          "name": "messages"
         },
         {
-          "type": [
-            null,
-            "Pagination"
-          ],
-          "name": "pagination"
+          "label": {
+            "name": "OUTBOX",
+            "def": false
+          },
+          "body": "OutboxRecord"
         }
       ]
     },
@@ -502,19 +551,21 @@
     },
     {
       "type": "record",
-      "name": "OutboxRecord",
+      "name": "ThreadView",
       "fields": [
         {
-          "type": "OutboxID",
-          "name": "outboxID"
+          "type": {
+            "type": "array",
+            "items": "MessageUnboxed"
+          },
+          "name": "messages"
         },
         {
-          "type": "ConversationID",
-          "name": "convID"
-        },
-        {
-          "type": "MessagePlaintext",
-          "name": "Msg"
+          "type": [
+            null,
+            "Pagination"
+          ],
+          "name": "pagination"
         }
       ]
     },
@@ -556,13 +607,6 @@
         {
           "type": "ThreadView",
           "name": "thread"
-        },
-        {
-          "type": {
-            "type": "array",
-            "items": "OutboxRecord"
-          },
-          "name": "outbox"
         },
         {
           "type": {
@@ -1021,6 +1065,10 @@
         {
           "name": "msg",
           "type": "MessagePlaintext"
+        },
+        {
+          "name": "clientPrev",
+          "type": "MessageID"
         }
       ],
       "response": "PostLocalNonblockRes"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -98,6 +98,12 @@ export const LocalHeaderPlaintextVersion = {
 export const LocalMessageUnboxedState = {
   valid: 1,
   error: 2,
+  outbox: 3,
+}
+
+export const LocalOutboxStateType = {
+  sending: 0,
+  error: 1,
 }
 
 export const NotifyChatChatActivityType = {
@@ -576,7 +582,6 @@ export type GetMessagesRemoteRes = {
 
 export type GetThreadLocalRes = {
   thread: ThreadView,
-  outbox?: ?Array<OutboxRecord>,
   rateLimits?: ?Array<RateLimit>,
 }
 
@@ -606,6 +611,7 @@ export type HeaderPlaintextV1 = {
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
   bodyHash: Hash,
+  outboxInfo?: ?OutboxInfo,
   headerSignature?: ?SignatureInfo,
 }
 
@@ -675,6 +681,7 @@ export type MessageClientHeader = {
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
   outboxID?: ?OutboxID,
+  outboxInfo?: ?OutboxInfo,
 }
 
 export type MessageConversationMetadata = {
@@ -729,6 +736,7 @@ export type MessageType =
 export type MessageUnboxed = 
     { state : 1, valid : ?MessageUnboxedValid }
   | { state : 2, error : ?MessageUnboxedError }
+  | { state : 3, outbox : ?OutboxRecord }
 
 export type MessageUnboxedError = {
   errMsg: string,
@@ -739,6 +747,7 @@ export type MessageUnboxedError = {
 export type MessageUnboxedState = 
     1 // VALID_1
   | 2 // ERROR_2
+  | 3 // OUTBOX_3
 
 export type MessageUnboxedValid = {
   clientHeader: MessageClientHeader,
@@ -779,11 +788,25 @@ export type NotifyChatNewChatActivityRpcParam = Exact<{
 
 export type OutboxID = bytes
 
+export type OutboxInfo = {
+  prev: MessageID,
+  composeTime: gregor1.Time,
+}
+
 export type OutboxRecord = {
+  state: OutboxState,
   outboxID: OutboxID,
   convID: ConversationID,
   Msg: MessagePlaintext,
 }
+
+export type OutboxState = 
+    { state : 0, sending : ?int }
+  | { state : 1, error : ?string }
+
+export type OutboxStateType = 
+    0 // SENDING_0
+  | 1 // ERROR_1
 
 export type Pagination = {
   next: bytes,
@@ -947,7 +970,8 @@ export type localPostAttachmentLocalRpcParam = Exact<{
 
 export type localPostLocalNonblockRpcParam = Exact<{
   conversationID: ConversationID,
-  msg: MessagePlaintext
+  msg: MessagePlaintext,
+  clientPrev: MessageID
 }>
 
 export type localPostLocalRpcParam = Exact<{


### PR DESCRIPTION
@patrickxb r?

This pins all the outbox messages to whatever message the client thinks is the latest one. The client will pass in its last message, and the outbox will drop that info on the client header so we can re-construct the order on the other side.