### PR TITLE
Have TestLogger print out duration instead of time

### DIFF
--- a/go/chat/attachment_test.go
+++ b/go/chat/attachment_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/keybase/client/go/chat/s3"
 	"github.com/keybase/client/go/chat/signencrypt"
@@ -92,7 +93,8 @@ func TestSignEncrypter(t *testing.T) {
 }
 
 func makeTestStore(t *testing.T, kt func(enc, sig []byte)) *AttachmentStore {
-	return newAttachmentStoreTesting(logger.NewTestLogger(t), kt)
+	return newAttachmentStoreTesting(
+		logger.NewTestLogger(t, time.Now()), kt)
 }
 
 func testStoreMultis(t *testing.T, s *AttachmentStore) []*s3.MemMulti {

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -23,42 +24,6 @@ import (
 	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
-
-// TestConfig tracks libkb config during a test
-type TestConfig struct {
-	configFileName string
-}
-
-func (c *TestConfig) GetConfigFileName() string { return c.configFileName }
-
-func (c *TestConfig) InitTest(t *testing.T, initConfig string) {
-	G.Log = logger.NewTestLogger(t)
-	G.Init()
-
-	var f *os.File
-	var err error
-	if f, err = ioutil.TempFile(os.TempDir(), "testconfig"); err != nil {
-		t.Fatalf("couldn't create temp file: %s", err)
-	}
-	c.configFileName = f.Name()
-	if _, err = f.WriteString(initConfig); err != nil {
-		t.Fatalf("couldn't write config file: %s", err)
-	}
-	f.Close()
-
-	// XXX: The global G prevents us from running tests in parallel
-	G.Env.Test.ConfigFilename = c.configFileName
-
-	if err = G.ConfigureConfig(); err != nil {
-		t.Fatalf("couldn't configure the config: %s", err)
-	}
-}
-
-func (c *TestConfig) CleanTest() {
-	if c.configFileName != "" {
-		os.Remove(c.configFileName)
-	}
-}
 
 // TestOutput is a mock interface for capturing and testing output
 type TestOutput struct {
@@ -192,7 +157,7 @@ func setupTestContext(tb testing.TB, name string, tcPrev *TestContext) (tc TestC
 	// In debugging mode, dump all log, don't use the test logger.
 	// We only use the environment variable to discover debug mode
 	if val, _ := getEnvBool("KEYBASE_DEBUG"); !val {
-		g.Log = logger.NewTestLogger(tb)
+		g.Log = logger.NewTestLogger(tb, time.Now())
 	}
 
 	buf := make([]byte, 5)

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	logging "github.com/keybase/go-logging"
@@ -31,103 +32,115 @@ type TestLogBackend interface {
 // test that is trying to test an error condition.  No context tags
 // are logged.
 type TestLogger struct {
-	log        TestLogBackend
-	extraDepth int
+	log              TestLogBackend
+	extraDepth       int
+	startTime        *time.Time
+	setStartTimeOnce *sync.Once
 }
 
 func NewTestLogger(log TestLogBackend) *TestLogger {
-	return &TestLogger{log: log}
+	return &TestLogger{
+		log:              log,
+		startTime:        &time.Time{},
+		setStartTimeOnce: &sync.Once{},
+	}
 }
 
 // Verify TestLogger fully implements the Logger interface.
 var _ Logger = (*TestLogger)(nil)
 
-func prefixCaller(extraDepth int, lvl logging.Level, fmts string) string {
+func (log *TestLogger) prefixCaller(
+	extraDepth int, lvl logging.Level, fmts string) string {
+	log.setStartTimeOnce.Do(func() {
+		*log.startTime = time.Now()
+	})
+
 	// The testing library doesn't let us control the stack depth,
 	// and it always prints out its own prefix, so use \r to clear
 	// it out (at least on a terminal) and do our own formatting.
 	_, file, line, _ := runtime.Caller(2 + extraDepth)
 	elements := strings.Split(file, "/")
-	return fmt.Sprintf("\r%s %s:%d: [%.1s] %s", time.Now(),
-		elements[len(elements)-1], line, lvl, fmts)
+	dt := time.Since(*log.startTime)
+	return fmt.Sprintf("\r%s:%d: %s [%.1s] %s",
+		elements[len(elements)-1], line, dt, lvl, fmts)
 }
 
 func (log *TestLogger) Debug(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.DEBUG, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.DEBUG, fmts), arg...)
 }
 
 func (log *TestLogger) CDebugf(ctx context.Context, fmts string,
 	arg ...interface{}) {
 	log.log.Logf(prepareString(ctx,
-		prefixCaller(log.extraDepth, logging.DEBUG, fmts)), arg...)
+		log.prefixCaller(log.extraDepth, logging.DEBUG, fmts)), arg...)
 }
 
 func (log *TestLogger) Info(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.INFO, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.INFO, fmts), arg...)
 }
 
 func (log *TestLogger) CInfof(ctx context.Context, fmts string,
 	arg ...interface{}) {
 	log.log.Logf(prepareString(ctx,
-		prefixCaller(log.extraDepth, logging.INFO, fmts)), arg...)
+		log.prefixCaller(log.extraDepth, logging.INFO, fmts)), arg...)
 }
 
 func (log *TestLogger) Notice(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.NOTICE, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.NOTICE, fmts), arg...)
 }
 
 func (log *TestLogger) CNoticef(ctx context.Context, fmts string,
 	arg ...interface{}) {
 	log.log.Logf(prepareString(ctx,
-		prefixCaller(log.extraDepth, logging.NOTICE, fmts)), arg...)
+		log.prefixCaller(log.extraDepth, logging.NOTICE, fmts)), arg...)
 }
 
 func (log *TestLogger) Warning(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.WARNING, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.WARNING, fmts), arg...)
 }
 
 func (log *TestLogger) CWarningf(ctx context.Context, fmts string,
 	arg ...interface{}) {
 	log.log.Logf(prepareString(ctx,
-		prefixCaller(log.extraDepth, logging.WARNING, fmts)), arg...)
+		log.prefixCaller(log.extraDepth, logging.WARNING, fmts)), arg...)
 }
 
 func (log *TestLogger) Error(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.ERROR, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.ERROR, fmts), arg...)
 }
 
 func (log *TestLogger) Errorf(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.ERROR, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.ERROR, fmts), arg...)
 }
 
 func (log *TestLogger) CErrorf(ctx context.Context, fmts string,
 	arg ...interface{}) {
 	log.log.Logf(prepareString(ctx,
-		prefixCaller(log.extraDepth, logging.ERROR, fmts)), arg...)
+		log.prefixCaller(log.extraDepth, logging.ERROR, fmts)), arg...)
 }
 
 func (log *TestLogger) Critical(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
 }
 
 func (log *TestLogger) CCriticalf(ctx context.Context, fmts string,
 	arg ...interface{}) {
 	log.log.Logf(prepareString(ctx,
-		prefixCaller(log.extraDepth, logging.CRITICAL, fmts)), arg...)
+		log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts)), arg...)
 }
 
 func (log *TestLogger) Fatalf(fmts string, arg ...interface{}) {
-	log.log.Fatalf(prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.log.Fatalf(log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
 }
 
 func (log *TestLogger) CFatalf(ctx context.Context, fmts string,
 	arg ...interface{}) {
 	log.log.Fatalf(prepareString(ctx,
-		prefixCaller(log.extraDepth, logging.CRITICAL, fmts)), arg...)
+		log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts)), arg...)
 }
 
 func (log *TestLogger) Profile(fmts string, arg ...interface{}) {
-	log.log.Logf(prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
+	log.log.Logf(log.prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
 }
 
 func (log *TestLogger) Configure(style string, debug bool, filename string) {

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -29,8 +29,7 @@ type TestLogBackend interface {
 
 // TestLogger is a Logger that writes to a TestLogBackend.  All
 // messages except Fatal are printed using Logf, to avoid failing a
-// test that is trying to test an error condition.  No context tags
-// are logged.
+// test that is trying to test an error condition.
 type TestLogger struct {
 	log              TestLogBackend
 	extraDepth       int

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -37,6 +37,10 @@ type TestLogger struct {
 	firstLogOnce *sync.Once
 }
 
+// NewTestLogger returns a logger to be used for a specific test. The
+// given startTime is used for calculating durations from the start of
+// the test, which is printed out for each log. Only one *TestLogger
+// should be used per test.
 func NewTestLogger(log TestLogBackend, startTime time.Time) *TestLogger {
 	return &TestLogger{
 		log:          log,

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -51,7 +51,9 @@ var _ Logger = (*TestLogger)(nil)
 
 func (log *TestLogger) prefixCaller(
 	extraDepth int, lvl logging.Level, fmts string) string {
+	var first bool
 	log.setStartTimeOnce.Do(func() {
+		first = true
 		*log.startTime = time.Now()
 	})
 
@@ -61,8 +63,12 @@ func (log *TestLogger) prefixCaller(
 	_, file, line, _ := runtime.Caller(2 + extraDepth)
 	elements := strings.Split(file, "/")
 	dt := time.Since(*log.startTime)
+	dtStr := dt.String()
+	if first {
+		dtStr += " (started at " + log.startTime.String() + ")"
+	}
 	return fmt.Sprintf("\r%s:%d: %s [%.1s] %s",
-		elements[len(elements)-1], line, dt, lvl, fmts)
+		elements[len(elements)-1], line, dtStr, lvl, fmts)
 }
 
 func (log *TestLogger) Debug(fmts string, arg ...interface{}) {


### PR DESCRIPTION
Printing out the time on every log consumes a lot of
columns, and printing out a duration seems more informative.