### PR TITLE
derive DEV_TOOL_EXTENSIONS

### DIFF
--- a/desktop/client.js
+++ b/desktop/client.js
@@ -3,6 +3,7 @@ const http = require('http')
 const fs = require('fs')
 const spawn = require('child_process').spawn
 const electron = require('electron')
+const path = require('path')
 
 try {
   fs.mkdirSync('dist')
@@ -12,8 +13,22 @@ try {
 const name = 'dist/main.bundle.js'
 const params = [name]
 
+// Find extensions
+let devToolRoots = process.env.KEYBASE_DEV_TOOL_ROOTS
+let devToolExtensions
+if (devToolRoots) {
+  devToolExtensions = {
+    KEYBASE_DEV_TOOL_EXTENSIONS: devToolRoots.split(',').map(root => path.join(root, fs.readdirSync(root)[0])).join(','),
+  }
+}
+
+const env = {
+  ...process.env,
+  ...devToolExtensions,
+}
+
 const handle = () => {
-  const e = spawn(electron, params, {stdio: 'inherit'})
+  const e = spawn(electron, params, {stdio: 'inherit', env})
   e.on('close', function () {})
 }
 


### PR DESCRIPTION
@keybase/react-hackers 
before we used to explicitly put a path to react devtools (which we should all be running) but setting an env var into our chrome plugins dir (like 

`
set -x KEYBASE_DEV_TOOL_EXTENSIONS '/Users/chrisnojima/Library/Application Support/Google/Chrome/Default/Extensions/fmkadmapgofadopljbjfkapdkoienihi/0.1.2.3'
`

but if chrome ever updates the version then this path breaks, doh. 

instead we just set the root
`
set -x KEYBASE_DEV_TOOL_ROOTS '/Users/chrisnojima/Library/Application Support/Google/Chrome/Default/Extensions/fmkadmapgofadopljbjfkapdkoienihi'
`

client.js now searches that for a version (the first one) and uses that instead