### PR TITLE
Support command line install from ~/Applications

### DIFF
--- a/go/client/cmd_install_osx.go
+++ b/go/client/cmd_install_osx.go
@@ -126,15 +126,18 @@ func (v *CmdInstall) Run() error {
 			return err
 		}
 		fmt.Fprintf(os.Stdout, "%s\n", out)
-	} else {
-		if err := result.Status.GoError(); err != nil {
-			v.G().Log.Errorf("%s", err)
-		}
 	}
 	return nil
 }
 
-var defaultUninstallComponents = []string{"service", "kbfs", "updater", "fuse", "helper"}
+var defaultUninstallComponents = []string{
+	install.ComponentNameService.String(),
+	install.ComponentNameKBFS.String(),
+	install.ComponentNameUpdater.String(),
+	install.ComponentNameFuse.String(),
+	install.ComponentNameHelper.String(),
+	install.ComponentNameCLI.String(),
+}
 
 func NewCmdUninstall(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
@@ -190,6 +193,10 @@ func (v *CmdUninstall) ParseArgv(ctx *cli.Context) error {
 }
 
 func (v *CmdUninstall) Run() error {
+	bundlePath, err := install.AppBundleForPath()
+	if err != nil {
+		return err
+	}
 	result := install.Uninstall(v.G(), v.components, v.G().Log)
 	if v.format == "json" {
 		out, err := json.MarshalIndent(result, "", "  ")
@@ -198,9 +205,8 @@ func (v *CmdUninstall) Run() error {
 		}
 		fmt.Fprintf(os.Stdout, "%s\n", out)
 	} else {
-		if err := result.Status.GoError(); err != nil {
-			v.G().Log.Errorf("%s", err)
-		}
+		t := v.G().UI.GetTerminalUI()
+		t.Printf("\nYou can now remove %s to complete your uninstall.\n", bundlePath)
 	}
 	return nil
 }

--- a/go/install/install.go
+++ b/go/install/install.go
@@ -177,7 +177,7 @@ func KBFSBundleVersion(context Context, binPath string) (string, error) {
 	return kbfsVersion, nil
 }
 
-func createCommandLine(binPath string, linkPath string) error {
+func createCommandLine(binPath string, linkPath string, log Log) error {
 	if _, err := os.Lstat(linkPath); err == nil {
 		err := os.Remove(linkPath)
 		if err != nil {
@@ -185,6 +185,7 @@ func createCommandLine(binPath string, linkPath string) error {
 		}
 	}
 
+	log.Info("Linking %s to %s", linkPath, binPath)
 	return os.Symlink(binPath, linkPath)
 }
 
@@ -200,17 +201,23 @@ func defaultLinkPath() (string, error) {
 	return linkPath, nil
 }
 
-func uninstallCommandLine() error {
+func uninstallCommandLine(log Log) error {
 	linkPath, err := defaultLinkPath()
+	if err != nil {
+		return nil
+	}
 
+	log.Debug("Link path: %s", linkPath)
 	fi, err := os.Lstat(linkPath)
 	if os.IsNotExist(err) {
+		log.Debug("Path doesn't exist: %s", linkPath)
 		return nil
 	}
 	isLink := (fi.Mode()&os.ModeSymlink != 0)
 	if !isLink {
 		return fmt.Errorf("Path is not a symlink: %s", linkPath)
 	}
+	log.Info("Removing %s", linkPath)
 	return os.Remove(linkPath)
 }
 

--- a/go/install/install_test.go
+++ b/go/install/install_test.go
@@ -30,7 +30,7 @@ func TestCommandLine(t *testing.T) {
 	linkPath := filepath.Join(testDir, "kbtest")
 
 	// Install
-	err = installCommandLineForBinPath(binPath, linkPath, true)
+	err = installCommandLineForBinPath(binPath, linkPath, true, testLog)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
@@ -40,7 +40,7 @@ func TestCommandLine(t *testing.T) {
 	}
 
 	// Install again
-	err = installCommandLineForBinPath(binPath, linkPath, true)
+	err = installCommandLineForBinPath(binPath, linkPath, true, testLog)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/go/launchd/launchd.go
+++ b/go/launchd/launchd.go
@@ -157,7 +157,7 @@ func (s Service) Stop(wait time.Duration) (bool, error) {
 			return false, waitErr
 		}
 	}
-	s.log.Info("Stopped %s (wait=%s)", s.label, wait)
+	s.log.Info("Stopped %s", s.label)
 	return true, nil
 }
 

--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.44</string>
+	<string>1.1.45</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.44</string>
+	<string>1.1.45</string>
 	<key>KBFuseBuild</key>
 	<string>3.5.2</string>
 	<key>KBFuseVersion</key>

--- a/osx/Installer/Options.m
+++ b/osx/Installer/Options.m
@@ -44,6 +44,7 @@
   [parser registerSwitch:@"uninstall-helper"];
   [parser registerSwitch:@"uninstall"];
   [parser registerSwitch:@"install-fuse"];
+  [parser registerSwitch:@"install-mountdir"];
   [parser registerSettings:self.settings];
   NSArray *subargs = [args subarrayWithRange:NSMakeRange(1, args.count-1)];
   if (![parser parseOptionsWithArguments:subargs commandLine:args[0]]) {
@@ -78,6 +79,9 @@
 
   if ([[self.settings objectForKey:@"install-fuse"] boolValue]) {
     self.installOptions |= KBInstallOptionFuse;
+  }
+  if ([[self.settings objectForKey:@"install-mountdir"] boolValue]) {
+    self.installOptions |= KBInstallOptionMountDir;
   }
   if (self.installOptions == 0) {
     self.installOptions = KBInstallOptionAll;

--- a/osx/KBKit/KBKit/Component/KBCommandLine.m
+++ b/osx/KBKit/KBKit/Component/KBCommandLine.m
@@ -29,8 +29,8 @@
     return;
   }
 
-  if (![self.config isInApplications:self.servicePath]) {
-    completion(KBMakeWarning(@"Command line install is not supported from this location."));
+  if (![self.config isInApplications:self.servicePath] && ![self.config isInUserApplications:self.servicePath]) {
+    completion(KBMakeWarning(@"Command line install is not supported from this location: %@", self.servicePath));
     return;
   }
 

--- a/osx/KBKit/KBKit/KBDefines.h
+++ b/osx/KBKit/KBKit/KBDefines.h
@@ -47,7 +47,7 @@ typedef NS_ENUM (NSInteger, KBErrorResponse) {
 
 #define KBMakeErrorWithRecovery(CODE, MSG, RECOVERY, ...) [NSError errorWithDomain:@"Keybase" code:CODE userInfo:@{NSLocalizedDescriptionKey: MSG, NSLocalizedRecoveryOptionsErrorKey: @[@"OK"], NSLocalizedRecoverySuggestionErrorKey:[NSString stringWithFormat:RECOVERY, ##__VA_ARGS__]}]
 
-#define KBMakeWarning(MSG) KBMakeError(KBErrorCodeWarning, MSG)
+#define KBMakeWarning(MSG, ...) KBMakeError(KBErrorCodeWarning, MSG, ##__VA_ARGS__)
 #define KBIsWarning(ERR) ((ERR.code == KBErrorCodeWarning))
 
 

--- a/osx/Scripts/README.md
+++ b/osx/Scripts/README.md
@@ -14,7 +14,7 @@
 
 ### Test Installer
 
-./build/KeybaseInstaller.app/Contents/MacOS/Keybase --app-path=/Applications/Keybase.app --run-mode=prod
+./build/KeybaseInstaller.app/Contents/MacOS/Keybase --app-path=/Applications/Keybase.app --run-mode=prod --timeout=10
 
 ### Releasing Installer
 

--- a/packaging/desktop/kbfuse.sh
+++ b/packaging/desktop/kbfuse.sh
@@ -15,7 +15,7 @@ cd $dir
 client_dir="$dir/../.."
 fuse_dir="$client_dir/osx/Fuse"
 tmp_dir="/tmp/desktop-kbfuse"
-installer_url="https://github.com/keybase/client/releases/download/v1.0.18/KeybaseInstaller-1.1.44-darwin.tgz"
+installer_url="https://github.com/keybase/client/releases/download/v1.0.18/KeybaseInstaller-1.1.45-darwin.tgz"
 
 if [ "$EUID" -ne 0 ]; then
   echo "Please run as root"

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -76,7 +76,7 @@ shared_support_dir="$out_dir/Keybase.app/Contents/SharedSupport"
 resources_dir="$out_dir/Keybase.app/Contents/Resources/"
 
 # The KeybaseInstaller.app installs KBFuse, keybase.Helper, services and CLI via a native app
-installer_url="https://github.com/keybase/client/releases/download/v1.0.18/KeybaseInstaller-1.1.44-darwin.tgz"
+installer_url="https://github.com/keybase/client/releases/download/v1.0.18/KeybaseInstaller-1.1.45-darwin.tgz"
 # KeybaseUpdater.app is the native updater UI (prompt dialogs)
 updater_url="https://github.com/keybase/client/releases/download/v1.0.17/KeybaseUpdater-1.0.5-darwin.tgz"
 


### PR DESCRIPTION
Allows `/usr/local/bin/keybase` to be linked from `~/Applications/Keybase.app`.

Also cleaned up some logging and added blurb about removing the Keybase app when someone does a `keybase uninstall`.