### PR TITLE
Update pvl for facebook

### DIFF
--- a/go/pvl/hardcoded.go
+++ b/go/pvl/hardcoded.go
@@ -67,16 +67,28 @@ var hardcodedPVLString = `
     "facebook": [
       [
         {
+          "assert_regex_match": {
+            "error": [
+              "BAD_USERNAME",
+              "Invalid characters in username '%{username_service}'"
+            ],
+            "from": "username_service",
+            "pattern": "^[a-zA-Z0-9\\.]+$"
+          }
+        },
+        {
           "regex_capture": {
             "error": [
               "BAD_API_URL",
-              "Bad hint from server; URL should start with 'https://m.facebook.com/%{username_service}/posts/', received '%{hint_url}'"
+              "Bad hint from server; URL should start with 'https://m.facebook.com/%{username_service}/posts/', got '%{hint_url}'"
             ],
             "from": "hint_url",
             "into": [
-              "username_from_url"
+              "unused1",
+              "username_from_url",
+              "post_id"
             ],
-            "pattern": "^https://m\\.facebook\\.com/([^/]*)/posts/.*$"
+            "pattern": "^https://(m|www)\\.facebook\\.com/([^/]*)/posts/([0-9]+)$"
           }
         },
         {
@@ -86,120 +98,117 @@ var hardcodedPVLString = `
             "cmp": "stripdots-then-cicmp",
             "error": [
               "BAD_API_URL",
-              "Bad hint from server; username in URL match '%{username_service}', received '%{username_from_url}'"
+              "Bad hint from server; username in URL should match '%{username_service}', received '%{username_from_url}'"
             ]
           }
         },
         {
+          "fill": {
+            "into": "our_url",
+            "with": "https://www.facebook.com/%{username_from_url}/posts/%{post_id}"
+          }
+        },
+        {
           "fetch": {
-            "from": "hint_url",
+            "from": "our_url",
             "kind": "html"
           }
         },
         {
           "selector_css": {
+            "data": true,
             "error": [
               "FAILED_PARSE",
-              "Couldn't find facebook post %{hint_url}. Is it deleted or private?"
+              "Could not find proof markup comment in Facebook's response"
             ],
-            "into": "unused",
-            "multi": true,
+            "into": "first_code_comment",
             "selectors": [
-              "#m_story_permalink_view"
-            ]
-          }
-        },
-        {
-          "selector_css": {
-            "attr": "href",
-            "error": [
-              "FAILED_PARSE",
-              "Couldn't find username href"
-            ],
-            "into": "username_link",
-            "selectors": [
-              "#m_story_permalink_view > div:first-child > div:first-child > div:first-child h3",
+              "code",
               0,
-              "a",
+              {
+                "contents": true
+              },
               0
             ]
           }
         },
         {
-          "parse_url": {
-            "error": [
-              "FAILED_PARSE",
-              "Failed to parse username URL: %{username_link}"
-            ],
-            "from": "username_link",
-            "path": "path"
+          "replace_all": {
+            "from": "first_code_comment",
+            "into": "fcc2",
+            "new": "--",
+            "old": "-\\-\\"
           }
         },
         {
-          "regex_capture": {
-            "error": [
-              "FAILED_PARSE",
-              "Username URL has no path"
-            ],
-            "from": "path",
-            "into": [
-              "split_path_1"
-            ],
-            "pattern": "^[^/]*/([^/]*)$"
+          "replace_all": {
+            "from": "fcc2",
+            "into": "fcc3",
+            "new": "\\",
+            "old": "\\\\"
           }
         },
         {
-          "assert_compare": {
-            "a": "split_path_1",
-            "b": "username_service",
-            "cmp": "stripdots-then-cicmp",
+          "parse_html": {
             "error": [
-              "BAD_USERNAME",
-              "Usernames don't match '%{split_path_1}' vs '%{username_service}'"
-            ]
+              "FAILED_PARSE",
+              "Failed to parse proof markup comment in Facebook post: %{fcc3}"
+            ],
+            "from": "fcc3"
           }
         },
         {
           "selector_css": {
             "error": [
               "FAILED_PARSE",
-              "Couldn't find proof text header"
+              "Could not find link text in Facebook's response"
             ],
-            "into": "header",
+            "into": "link_text",
+            "multi": true,
             "selectors": [
-              "#m_story_permalink_view > div:first-child > div:first-child > div:first-child h3",
-              1
+              "div.userContent+div a"
             ]
           }
         },
         {
           "whitespace_normalize": {
-            "from": "header",
-            "into": "header_nw"
+            "from": "link_text",
+            "into": "link_text_nw"
           }
         },
         {
           "regex_capture": {
             "error": [
               "TEXT_NOT_FOUND",
-              "Proof text not found: 'Verifying myself: I am %{username_keybase} on Keybase.io. %{sig_id_medium}' != '%{header_nw}'"
+              "Could not find Verifying myself: I am %{username_keybase} on Keybase.io. (%{sig_id_medium})"
             ],
-            "from": "header_nw",
+            "from": "link_text_nw",
             "into": [
-              "username_from_header"
+              "username_from_link",
+              "sig_from_link"
             ],
-            "pattern": "^Verifying myself: I am (\\S+) on Keybase\\.io\\. %{sig_id_medium}$"
+            "pattern": "^.*Verifying myself: I am (\\S+) on Keybase.io. (\\S+).*$"
           }
         },
         {
           "assert_compare": {
-            "a": "username_from_header",
+            "a": "username_from_link",
             "b": "username_keybase",
             "cmp": "cicmp",
             "error": [
-              "TEXT_NOT_FOUND",
-              "Wrong keybase username in proof text '%{username_from_header}' != 'username_keybase'"
+              "BAD_USERNAME",
+              "Wrong keybase username in post '%{username_from_link}' should be '%{username_keybase}'"
             ]
+          }
+        },
+        {
+          "assert_regex_match": {
+            "error": [
+              "BAD_SIGNATURE",
+              "Could not find sig; '%{sig_from_link}' != '%{sig_id_medium}'"
+            ],
+            "from": "sig_from_link",
+            "pattern": "^%{sig_id_medium}$"
           }
         }
       ]

--- a/go/pvl/helpers.go
+++ b/go/pvl/helpers.go
@@ -130,16 +130,25 @@ func jsonStringSimple(object *jsonw.Wrapper) (string, error) {
 	return "", fmt.Errorf("Non-simple object: %v", object)
 }
 
-// selectionContents gets the HTML contents of all elements in a selection, concatenated by a space.
+// selectionContents gets the value of all elements in a selection, concatenated by a space.
 // If getting the contents/attr value of any elements fails, that does not cause an error.
+// The value of an element can be:
+// 1. its Text (if attr=="" and data==false)
+// 2. its Data (if attr=="" and data==true)
+// 3. an attribute (if attr=="something" and data==false)
+// The value of an element is its Text, unless one of
 // The result can be an empty string.
-func selectionContents(selection *goquery.Selection, useAttr bool, attr string) string {
+func selectionContents(selection *goquery.Selection, attr string, data bool) string {
 	var results []string
 	selection.Each(func(i int, element *goquery.Selection) {
-		if useAttr {
+		if attr != "" {
 			res, ok := element.Attr(attr)
 			if ok {
 				results = append(results, res)
+			}
+		} else if data {
+			if len(element.Nodes) > 0 {
+				results = append(results, element.Nodes[0].Data)
 			}
 		} else {
 			results = append(results, element.Text())

--- a/go/pvl/helpers_test.go
+++ b/go/pvl/helpers_test.go
@@ -277,32 +277,39 @@ func TestJSONStringSimple(t *testing.T) {
 type selectionContentsTest struct {
 	html     *goquery.Document
 	selector string
-	useAttr  bool
+	contents bool
 	attr     string
+	data     bool
 	out      string
 }
 
 var selectionContentsDocument = makeHTMLDangerous(`
 <html>
 <head></head><div>a<span class="x" data-foo="y">b</span></div><div data-foo="z">c</div>
+<p>hea<!--vy han-->ded</p>
 </html>
 `)
 
 var selectionContentsTests = []selectionContentsTest{
-	{selectionContentsDocument, "div", false, "", "ab c"},
-	{selectionContentsDocument, "span", false, "", "b"},
-	{selectionContentsDocument, "span", true, "data-foo", "y"},
-	{selectionContentsDocument, "div", true, "data-foo", "z"},
-	{selectionContentsDocument, "span", true, "data-bar", ""},
-	{selectionContentsDocument, "div", true, "data-baz", ""},
+	{selectionContentsDocument, "div", false, "", false, "ab c"},
+	{selectionContentsDocument, "span", false, "", false, "b"},
+	{selectionContentsDocument, "span", false, "data-foo", false, "y"},
+	{selectionContentsDocument, "div", false, "data-foo", false, "z"},
+	{selectionContentsDocument, "span", false, "data-bar", false, ""},
+	{selectionContentsDocument, "div", false, "data-baz", false, ""},
+	{selectionContentsDocument, "p", false, "", false, "headed"},
+	{selectionContentsDocument, "p", true, "", true, "hea vy han ded"},
 }
 
 func TestSelectionContents(t *testing.T) {
 	for i, test := range selectionContentsTests {
 		sel := test.html.Find(test.selector)
-		out := selectionContents(sel, test.useAttr, test.attr)
+		if test.contents {
+			sel = sel.Contents()
+		}
+		out := selectionContents(sel, test.attr, test.data)
 		if out != test.out {
-			t.Fatalf("%v mismatch\n%v\n%v", i, out, test.out)
+			t.Fatalf("%v mismatch\n'%v'\n'%v'", i, out, test.out)
 		}
 	}
 }

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -4,6 +4,7 @@
 package pvl
 
 import (
+	"bytes"
 	b64 "encoding/base64"
 	"net"
 	"net/url"
@@ -66,8 +67,10 @@ const (
 	cmdAssertCompare       commandName = "assert_compare"
 	cmdWhitespaceNormalize commandName = "whitespace_normalize"
 	cmdRegexCapture        commandName = "regex_capture"
+	cmdReplaceAll          commandName = "replace_all"
 	cmdParseURL            commandName = "parse_url"
 	cmdFetch               commandName = "fetch"
+	cmdParseHTML           commandName = "parse_html"
 	cmdSelectorJSON        commandName = "selector_json"
 	cmdSelectorCSS         commandName = "selector_css"
 	cmdFill                commandName = "fill"
@@ -357,6 +360,7 @@ func validateScript(g proofContextExt, script *scriptT, service keybase1.ProofTy
 		case ins.AssertCompare != nil:
 		case ins.WhitespaceNormalize != nil:
 		case ins.RegexCapture != nil:
+		case ins.ReplaceAll != nil:
 		case ins.ParseURL != nil:
 		case ins.Fill != nil:
 
@@ -388,6 +392,7 @@ func validateScript(g proofContextExt, script *scriptT, service keybase1.ProofTy
 				return logerr(g, service, whichscript, i,
 					"Unsupported fetch type: %v", fetchType)
 			}
+		case ins.ParseHTML != nil:
 		case ins.SelectorJSON != nil:
 			// Can only select after fetching.
 			switch {
@@ -413,6 +418,12 @@ func validateScript(g proofContextExt, script *scriptT, service keybase1.ProofTy
 			case mode != fetchModeHTML:
 				return logerr(g, service, whichscript, i,
 					"Script contains css selector in non-html mode")
+			}
+
+			// Can only select one of text, attr, or data.
+			if ins.SelectorCSS.Attr != "" && ins.SelectorCSS.Data {
+				return logerr(g, service, whichscript, i,
+					"Script contains css selector with both 'attr' and 'data' set")
 			}
 		default:
 			return logerr(g, service, whichscript, i,
@@ -548,12 +559,18 @@ func stepInstruction(g proofContextExt, ins instructionT, state scriptState) (sc
 	case ins.RegexCapture != nil:
 		newState, stepErr = stepRegexCapture(g, *ins.RegexCapture, state)
 		customErrSpec = ins.RegexCapture.Error
+	case ins.ReplaceAll != nil:
+		newState, stepErr = stepReplaceAll(g, *ins.ReplaceAll, state)
+		customErrSpec = ins.ReplaceAll.Error
 	case ins.ParseURL != nil:
 		newState, stepErr = stepParseURL(g, *ins.ParseURL, state)
 		customErrSpec = ins.ParseURL.Error
 	case ins.Fetch != nil:
 		newState, stepErr = stepFetch(g, *ins.Fetch, state)
 		customErrSpec = ins.Fetch.Error
+	case ins.ParseHTML != nil:
+		newState, stepErr = stepParseHTML(g, *ins.ParseHTML, state)
+		customErrSpec = ins.ParseHTML.Error
 	case ins.SelectorJSON != nil:
 		newState, stepErr = stepSelectorJSON(g, *ins.SelectorJSON, state)
 		customErrSpec = ins.SelectorJSON.Error
@@ -704,6 +721,21 @@ func stepRegexCapture(g proofContextExt, ins regexCaptureT, state scriptState) (
 	return state, nil
 }
 
+func stepReplaceAll(g proofContextExt, ins replaceAllT, state scriptState) (scriptState, libkb.ProofError) {
+	from, err := state.Regs.Get(ins.From)
+	if err != nil {
+		return state, err
+	}
+
+	replaced := strings.Replace(from, ins.Old, ins.New, -1)
+	err = state.Regs.Set(ins.Into, replaced)
+	if err != nil {
+		return state, err
+	}
+
+	return state, nil
+}
+
 func stepParseURL(g proofContextExt, ins parseURLT, state scriptState) (scriptState, libkb.ProofError) {
 	s, err := state.Regs.Get(ins.From)
 	if err != nil {
@@ -805,6 +837,24 @@ func stepFetch(g proofContextExt, ins fetchT, state scriptState) (scriptState, l
 	}
 }
 
+func stepParseHTML(g proofContextExt, ins parseHTMLT, state scriptState) (scriptState, libkb.ProofError) {
+	from, err := state.Regs.Get(ins.From)
+	if err != nil {
+		return state, err
+	}
+
+	gq, err2 := goquery.NewDocumentFromReader(bytes.NewBuffer([]byte(from)))
+	if err2 != nil {
+		return state, libkb.NewProofError(keybase1.ProofStatus_FAILED_PARSE, "Failed to parse html from '%v': %v", ins.From, err2)
+	}
+
+	state.FetchResult = &fetchResult{
+		fetchMode: fetchModeHTML,
+		HTML:      gq,
+	}
+	return state, nil
+}
+
 func stepSelectorJSON(g proofContextExt, ins selectorJSONT, state scriptState) (scriptState, libkb.ProofError) {
 	if state.FetchResult == nil || state.FetchResult.fetchMode != fetchModeJSON {
 		return state, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
@@ -852,8 +902,7 @@ func stepSelectorCSS(g proofContextExt, ins selectorCSST, state scriptState) (sc
 	}
 
 	// Whether to get an attribute or the text contents.
-	useAttr := ins.Attr != ""
-	res := selectionContents(selection, useAttr, ins.Attr)
+	res := selectionContents(selection, ins.Attr, ins.Data)
 
 	err := state.Regs.Set(ins.Into, res)
 	return state, err
@@ -890,9 +939,11 @@ func runCSSSelectorInner(g proofContextExt, html *goquery.Selection, selectors [
 			selection = selection.Eq(selector.Index)
 		case selector.IsKey:
 			selection = selection.Find(selector.Key)
+		case selector.IsContents:
+			selection = selection.Contents()
 		default:
 			return nil, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
-				"Selector entry must be a string or int %v", selector)
+				"CSS selector entry must be a string, int, or 'contents' %v", selector)
 		}
 	}
 
@@ -957,9 +1008,10 @@ func runSelectorJSONInner(g proofContextExt, state scriptState, selectedObject *
 			results = append(results, innerresults...)
 		}
 		return results, nil
+	default:
+		return nil, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
+			"JSON selector entry must be a string, int, or 'all' %v", selector)
 	}
-	return []string{}, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
-		"Invalid selector entry: %v", selector)
 }
 
 // Take a regex descriptor, do variable substitution, and build a regex.

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -407,19 +407,6 @@ func validateScript(g proofContextExt, script *scriptT, service keybase1.ProofTy
 					"Script contains json selector in non-html mode")
 			}
 		case ins.SelectorCSS != nil:
-			// Can only select after fetching.
-			switch {
-			case service == keybase1.ProofType_DNS:
-				return logerr(g, service, whichscript, i,
-					"DNS script cannot use css selector")
-			case !modeknown:
-				return logerr(g, service, whichscript, i,
-					"Script cannot select before fetch")
-			case mode != fetchModeHTML:
-				return logerr(g, service, whichscript, i,
-					"Script contains css selector in non-html mode")
-			}
-
 			// Can only select one of text, attr, or data.
 			if ins.SelectorCSS.Attr != "" && ins.SelectorCSS.Data {
 				return logerr(g, service, whichscript, i,

--- a/go/pvl/interp_data_for_test.go
+++ b/go/pvl/interp_data_for_test.go
@@ -65,6 +65,26 @@ var html1 = `
 </html>
 `
 
+var html2 = `
+<html>
+<head>
+<title>proofer</title>
+</head>
+<body>
+	<div class="a">
+		<div class="b">
+			<!-- cow -->
+			a
+			<!-- bunga -->
+		</div>
+	</div>
+	<div class="moo" data-x="y">
+	evil.com
+	</div>
+</body>
+</html>
+`
+
 var json1 = ` {
   "data": [
     {

--- a/pvl-tools/pvl.cson
+++ b/pvl-tools/pvl.cson
@@ -30,67 +30,104 @@ services:
       , error: ["NOT_FOUND", "matching DNS entry not found"] } },
   ]]
   facebook: [[
-    # check url and extract username
+    # Check that the claimed username has no slashes or funny business that
+    # might trick us into checking a different url.
+    # Facebook usernames don't actually allow any special characters, but it's
+    # still possible for a malicious user to *claim* they have some slashes
+    # and a question mark in their name, in the hopes that that will trick us
+    # into hitting a totally unrelated URL. Guard against that happening by
+    # checking for special characters in the claimed name.
+    { assert_regex_match: {
+      , pattern: "^[a-zA-Z0-9\\.]+$"
+      , from: "username_service"
+      , error: ["BAD_USERNAME", "Invalid characters in username '%{username_service}'"] } },
+
+    # Check the provided url and extract the username and path.
+    # Accept either mobile or desktop urls. The fetched url will be rewritten later.
+    # We want to be strict about the structure of the url.
+    # No query parameters, no unexpected characters in the post ID.
     { regex_capture: {
-      , pattern: "^https://m\\.facebook\\.com/([^/]*)/posts/.*$"
+      , pattern: "^https://(m|www)\\.facebook\\.com/([^/]*)/posts/([0-9]+)$"
       , from: "hint_url"
-      , into: ["username_from_url"]
-      , error: ["BAD_API_URL", "Bad hint from server; URL should start with 'https://m.facebook.com/%{username_service}/posts/', received '%{hint_url}'"] } },
+      , into: ["unused1", "username_from_url", "post_id"]
+      , error: ["BAD_API_URL", "Bad hint from server; URL should start with 'https://m.facebook.com/%{username_service}/posts/', got '%{hint_url}'"] } },
+
+    # Check that the claimed username matches the url.
+    # Checking for the correct username is essential here. We rely on this
+    # check to prove that the user in question actually wrote the post. (Note
+    # that the m-site does *not* enforce this part of the URL. Only the
+    # desktop site does.)
     { assert_compare: {
       , cmp: "stripdots-then-cicmp"
       , a: "username_from_url"
       , b: "username_service"
-      , error: ["BAD_API_URL", "Bad hint from server; username in URL match '%{username_service}', received '%{username_from_url}'"] } },
+      , error: ["BAD_API_URL", "Bad hint from server; username in URL should match '%{username_service}', received '%{username_from_url}'"] } },
+
+    # Create the desktop url using the validated username and (not validated) post id.
+    { fill: {
+      , with: "https://www.facebook.com/%{username_from_url}/posts/%{post_id}"
+      , into: "our_url" } },
     { fetch: {
       , kind: "html"
-      , from: "hint_url" } },
-    # m.facebook.com returns 200's for posts you can't see, rather than 404's.
-    # Having a post that's deleted or private is going to be much more common
-    # than the obscure errors below. Do an explicit check for that, to produce
-    # a better error message.
-    {selector_css: {
-      , selectors: ["#m_story_permalink_view"]
+      , from: "our_url" } },
+
+    # Get the contents of the first (only) comment inside the first <code>
+    # block. Believe it or not, this comment contains the post markup below.
+    { selector_css: {
+      , selectors: ["code", 0, {contents: true}, 0]
+      , into: "first_code_comment"
+      , data: true
+      , error: ["FAILED_PARSE", "Could not find proof markup comment in Facebook's response"] } },
+
+    # Facebook escapes "--" as "-\-\" and "\" as "\\" when inserting text into
+    # comments. Unescape these.
+    { replace_all: {
+      , old: "-\\-\\"
+      , new: "--"
+      , from: "first_code_comment"
+      , into: "fcc2" } },
+    { replace_all: {
+      , old: "\\\\"
+      , new: "\\"
+      , from: "fcc2"
+      , into: "fcc3" } },
+
+    # Load the de-escaped comment as html
+    { parse_html: {
+      , from: "fcc3"
+      , error: ["FAILED_PARSE", "Failed to parse proof markup comment in Facebook post: %{fcc3}"] } },
+
+    # This query operates on the newly extractaparsed comment, not the original page load
+    # This is the selector for the post attachment links, which contains the
+	  # proof text. It's the "<a> tags inside the div that's the immediate
+	  # *sibling* of the 'userContet' div". The second of these three <a> tags
+	  # contains the proof text, the others are blank. But we just check their concatenation.
+    { selector_css: {
+      , selectors: ["div.userContent+div a"]
       , multi: true
-      , into: "unused"
-      , error: ["FAILED_PARSE", "Couldn't find facebook post %{hint_url}. Is it deleted or private?"] } }
-    # check the username in the post's link
-    { selector_css: {
-      , selectors: ["#m_story_permalink_view > div:first-child > div:first-child > div:first-child h3", 0, "a", 0]
-      , attr: "href"
-      , into: "username_link"
-      , error: ["FAILED_PARSE", "Couldn't find username href"] } },
-    { parse_url: {
-      , from: "username_link"
-      , path: "path"
-      , error: ["FAILED_PARSE", "Failed to parse username URL: %{username_link}"] } },
-    { regex_capture: {
-      , pattern: "^[^/]*/([^/]*)$"
-      , from: "path"
-      , into: ["split_path_1"]
-      , error: ["FAILED_PARSE", "Username URL has no path"] } },
-    { assert_compare: {
-      , cmp: "stripdots-then-cicmp"
-      , a: "split_path_1"
-      , b: "username_service"
-      , error: ["BAD_USERNAME", "Usernames don't match '%{split_path_1}' vs '%{username_service}'"] } },
-    # check the proof text
-    { selector_css: {
-      , selectors: ["#m_story_permalink_view > div:first-child > div:first-child > div:first-child h3", 1]
-      , into: "header"
-      , error: ["FAILED_PARSE", "Couldn't find proof text header"] } },
+      , into: "link_text"
+      , error: ["FAILED_PARSE", "Could not find link text in Facebook's response"] } },
     { whitespace_normalize: {
-      , from: "header"
-      , into: "header_nw" } },
+      , from: "link_text"
+      , into: "link_text_nw" } },
+
+    # Check the link text for username and sig
     { regex_capture: {
-      , pattern: "^Verifying myself: I am (\\S+) on Keybase\\.io\\. %{sig_id_medium}$"
-      , from: "header_nw"
-      , into: ["username_from_header"]
-      , error: ["TEXT_NOT_FOUND", "Proof text not found: 'Verifying myself: I am %{username_keybase} on Keybase.io. %{sig_id_medium}' != '%{header_nw}'"] } },
+      , pattern: "^.*Verifying myself: I am (\\S+) on Keybase.io. (\\S+).*$"
+      , from: "link_text_nw"
+      , into: ["username_from_link", "sig_from_link"]
+      , error: ["TEXT_NOT_FOUND", "Could not find Verifying myself: I am %{username_keybase} on Keybase.io. (%{sig_id_medium})"] } },
+    # Check username in link text
     { assert_compare: {
       , cmp: "cicmp"
-      , a: "username_from_header"
+      , a: "username_from_link"
       , b: "username_keybase"
-      , error: ["TEXT_NOT_FOUND", "Wrong keybase username in proof text '%{username_from_header}' != 'username_keybase'"] } }
+      , error: ["BAD_USERNAME", "Wrong keybase username in post '%{username_from_link}' should be '%{username_keybase}'"] } },
+    # Check the sig id in the link text
+    { assert_regex_match: {
+      , pattern: "^%{sig_id_medium}$"
+      , from: "sig_from_link"
+      , error: ["BAD_SIGNATURE", "Could not find sig; '%{sig_from_link}' != '%{sig_id_medium}'"] } },
   ]]
   github: [[
     # validate url and extract username


### PR DESCRIPTION
Update the pvl instructions and interpreter to match facebook. The check doesn't work exactly the same way, but should do the same thing. `hardcoded.go` is generated from `pvl.cson`.

Tested manually on some live facebook proofs. Not tested on any that should fail (other than simple 404s).

Added two new instructions. `replace_all` replaces all occurrences of `old` with `new`. `old` is a string instead of a regex out of laziness (the pvl regexer checks for `^$` which is incompatible with replace all).
```
    { replace_all: {
      , old: "-\\-\\"
      , new: "--"
      , from: "first_code_comment"
      , into: "fcc2" } },
```
And `parse_html` which reads the contents of the `from` register as html. It puts the result into the invisible `FetchResult` register. So it overwrites the original page. Making it set a named register would involve making registers have types other than string and would be a more significant change.
```
    { parse_html: {
      , from: "fcc3"
      , error: ["FAILED_PARSE", "Failed to parse proof markup comment in Facebook post: %{fcc3}"] } },
```

PVL's still turned off so this shouldn't change any client behavior.

r? @oconnor663 