### PR TITLE
add error state logic to outbox CORE-4128

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -183,12 +183,12 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 			Prev:         hp.Prev,
 			Sender:       hp.Sender,
 			SenderDevice: hp.SenderDevice,
+			OutboxInfo:   hp.OutboxInfo,
+			OutboxID:     hp.OutboxID,
 		}
 	default:
 		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(libkb.NewChatHeaderVersionError(headerVersion))
 	}
-	clientHeader.OutboxInfo = msg.ClientHeader.OutboxInfo
-	clientHeader.OutboxID = msg.ClientHeader.OutboxID
 
 	if skipBodyVerification {
 		// body was deleted, so return empty body that matches header version
@@ -339,6 +339,8 @@ func (b *Boxer) boxMessageWithKeysV1(msg chat1.MessagePlaintext, key *keybase1.C
 		Sender:       msg.ClientHeader.Sender,
 		SenderDevice: msg.ClientHeader.SenderDevice,
 		BodyHash:     bodyHash[:],
+		OutboxInfo:   msg.ClientHeader.OutboxInfo,
+		OutboxID:     msg.ClientHeader.OutboxID,
 	}
 
 	// sign the header and insert the signature

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"encoding/hex"
+
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
@@ -191,6 +193,8 @@ func (d DelivererSecretUI) GetPassphrase(pinentry keybase1.GUIEntryArg, terminal
 	return keybase1.GetPassphraseRes{}, fmt.Errorf("no secret UI available")
 }
 
+const deliverMaxAttempts = 5
+
 type Deliverer struct {
 	libkb.Contextified
 	sync.Mutex
@@ -251,6 +255,14 @@ func (s *Deliverer) doStop() {
 	}
 }
 
+func (s *Deliverer) ForceDeliverLoop() {
+	s.msgSentCh <- struct{}{}
+}
+
+func (s *Deliverer) SetSender(sender Sender) {
+	s.sender = sender
+}
+
 func (s *Deliverer) Queue(convID chat1.ConversationID, msg chat1.MessagePlaintext) (chat1.OutboxID, error) {
 
 	s.debug("queued new message: convID: %s uid: %s", convID, s.outbox.GetUID())
@@ -296,10 +308,45 @@ func (s *Deliverer) deliverLoop() {
 		// Send messages
 		pops := 0
 		for _, obr := range obrs {
-			_, _, _, err := s.sender.Send(context.Background(), obr.ConvID, obr.Msg, 0)
+
+			// Check type
+			state, err := obr.State.State()
 			if err != nil {
-				s.G().Log.Error("failed to send msg: uid: %s convID: %s err: %s", s.outbox.GetUID(),
-					obr.ConvID, err.Error())
+				s.G().Log.Error("strange entry in the outbox, invalid type: %s", err.Error())
+			}
+			if state != chat1.OutboxStateType_SENDING {
+				s.debug("skipping error state record: id: %s convID: %s uid: %s",
+					hex.EncodeToString(obr.OutboxID), obr.ConvID, s.outbox.GetUID())
+				continue
+			}
+
+			// Do the actual send
+			_, _, _, err = s.sender.Send(context.Background(), obr.ConvID, obr.Msg, 0)
+			if err != nil {
+				s.G().Log.Error("failed to send msg: uid: %s convID: %s err: %s attempts: %d",
+					s.outbox.GetUID(), obr.ConvID, err.Error(), obr.State.Sending())
+
+				// Process failure
+				if obr.State.Sending() > deliverMaxAttempts {
+					// Mark the entire outbox as an error if we can't send
+					s.debug("max failure attempts reached, marking all as errors and notifying")
+					obids, err := s.outbox.MarkAllAsError()
+					if err != nil {
+						s.G().Log.Error("unable to mark as error on outbox: uid: %s err: %s",
+							s.outbox.GetUID(), err.Error())
+					}
+					act := chat1.NewChatActivityWithFailedMessage(chat1.FailedMessageInfo{
+						OutboxIDs: obids,
+					})
+					s.G().NotifyRouter.HandleNewChatActivity(context.Background(),
+						keybase1.UID(s.outbox.GetUID().String()), &act)
+				} else {
+					if err = s.outbox.RecordFailedAttempt(obr.OutboxID); err != nil {
+						s.G().Log.Error("unable to record failed attempt on outbox: uid %s err: %s",
+							s.outbox.GetUID(), err.Error())
+					}
+				}
+
 				break
 			}
 			pops++

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -96,6 +96,7 @@ func (o *Outbox) PushMessage(convID chat1.ConversationID, msg chat1.MessagePlain
 	outboxID := chat1.OutboxID(rbs)
 	msg.ClientHeader.OutboxID = &outboxID
 	obox.Records = append(obox.Records, chat1.OutboxRecord{
+		State:    chat1.NewOutboxStateWithSending(0),
 		Msg:      msg,
 		ConvID:   convID,
 		OutboxID: outboxID,
@@ -159,6 +160,129 @@ func (o *Outbox) PopNOldestMessages(n int) error {
 
 	// Write out box
 	obox.Version = outboxVersion
+	if err := o.writeDiskBox(o.dbKey(), obox); err != nil {
+		return o.maybeNuke(libkb.NewChatStorageInternalError(o.G(),
+			"error writing outbox: err: %s", err.Error()))
+	}
+
+	return nil
+}
+
+func (o *Outbox) RecordFailedAttempt(obid chat1.OutboxID) error {
+	o.Lock()
+	defer o.Unlock()
+
+	// Read outbox for the user
+	obox, err := o.readDiskOutbox()
+	if err != nil {
+		return o.maybeNuke(err)
+	}
+
+	// Loop through and find record
+	var recs []chat1.OutboxRecord
+	for _, obr := range obox.Records {
+		if obr.OutboxID.Eq(obid) {
+			state, err := obr.State.State()
+			if err != nil {
+				return err
+			}
+			if state == chat1.OutboxStateType_SENDING {
+				obr.State = chat1.NewOutboxStateWithSending(obr.State.Sending() + 1)
+			}
+		}
+
+		recs = append(recs, obr)
+	}
+
+	// Write out box
+	obox.Records = recs
+	if err := o.writeDiskBox(o.dbKey(), obox); err != nil {
+		return o.maybeNuke(libkb.NewChatStorageInternalError(o.G(),
+			"error writing outbox: err: %s", err.Error()))
+	}
+
+	return nil
+}
+
+func (o *Outbox) RetryMessage(obid chat1.OutboxID) error {
+	o.Lock()
+	defer o.Unlock()
+
+	// Read outbox for the user
+	obox, err := o.readDiskOutbox()
+	if err != nil {
+		return o.maybeNuke(err)
+	}
+
+	// Loop through and find record
+	var recs []chat1.OutboxRecord
+	for _, obr := range obox.Records {
+		if obr.OutboxID.Eq(obid) {
+			obr.State = chat1.NewOutboxStateWithSending(0)
+		}
+		recs = append(recs, obr)
+	}
+
+	// Write out box
+	obox.Records = recs
+	if err := o.writeDiskBox(o.dbKey(), obox); err != nil {
+		return o.maybeNuke(libkb.NewChatStorageInternalError(o.G(),
+			"error writing outbox: err: %s", err.Error()))
+	}
+
+	return nil
+}
+
+func (o *Outbox) MarkAllAsError() ([]chat1.OutboxID, error) {
+	o.Lock()
+	defer o.Unlock()
+
+	// Read outbox for the user
+	obox, err := o.readDiskOutbox()
+	if err != nil {
+		return nil, o.maybeNuke(err)
+	}
+
+	// Loop through and find record
+	var recs []chat1.OutboxRecord
+	var res []chat1.OutboxID
+	for _, obr := range obox.Records {
+		obr.State = chat1.NewOutboxStateWithError("failed to send")
+		recs = append(recs, obr)
+		res = append(res, obr.OutboxID)
+	}
+
+	// Write out box
+	obox.Records = recs
+	if err := o.writeDiskBox(o.dbKey(), obox); err != nil {
+		return res, o.maybeNuke(libkb.NewChatStorageInternalError(o.G(),
+			"error writing outbox: err: %s", err.Error()))
+	}
+
+	return res, nil
+}
+
+func (o *Outbox) MarkAsError(obid chat1.OutboxID) error {
+	o.Lock()
+	defer o.Unlock()
+
+	// Read outbox for the user
+	obox, err := o.readDiskOutbox()
+	if err != nil {
+		return o.maybeNuke(err)
+	}
+
+	// Loop through and find record
+	var recs []chat1.OutboxRecord
+	for _, obr := range obox.Records {
+		if obr.OutboxID.Eq(obid) {
+			obr.State = chat1.NewOutboxStateWithError("failed to send")
+		}
+		recs = append(recs, obr)
+	}
+
+	// Write out box
+	obox.Records = recs
 	if err := o.writeDiskBox(o.dbKey(), obox); err != nil {
 		return o.maybeNuke(libkb.NewChatStorageInternalError(o.G(),
 			"error writing outbox: err: %s", err.Error()))

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -520,4 +520,5 @@ type MessageDeliverer interface {
 	Queue(convID chat1.ConversationID, msg chat1.MessagePlaintext) (chat1.OutboxID, error)
 	Start(uid gregor1.UID)
 	Stop()
+	ForceDeliverLoop()
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -304,6 +304,7 @@ type HeaderPlaintextV1 struct {
 	SenderDevice    gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
 	BodyHash        Hash                     `codec:"bodyHash" json:"bodyHash"`
 	OutboxInfo      *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
+	OutboxID        *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	HeaderSignature *SignatureInfo           `codec:"headerSignature,omitempty" json:"headerSignature,omitempty"`
 }
 
@@ -710,6 +711,14 @@ type DownloadAttachmentLocalArg struct {
 	Preview        bool            `codec:"preview" json:"preview"`
 }
 
+type CancelPostArg struct {
+	OutboxID OutboxID `codec:"outboxID" json:"outboxID"`
+}
+
+type RetryPostArg struct {
+	OutboxID OutboxID `codec:"outboxID" json:"outboxID"`
+}
+
 type LocalInterface interface {
 	GetThreadLocal(context.Context, GetThreadLocalArg) (GetThreadLocalRes, error)
 	GetInboxLocal(context.Context, GetInboxLocalArg) (GetInboxLocalRes, error)
@@ -723,6 +732,8 @@ type LocalInterface interface {
 	GetConversationForCLILocal(context.Context, GetConversationForCLILocalQuery) (GetConversationForCLILocalRes, error)
 	GetMessagesLocal(context.Context, GetMessagesLocalArg) (GetMessagesLocalRes, error)
 	DownloadAttachmentLocal(context.Context, DownloadAttachmentLocalArg) (DownloadAttachmentLocalRes, error)
+	CancelPost(context.Context, OutboxID) error
+	RetryPost(context.Context, OutboxID) error
 }
 
 func LocalProtocol(i LocalInterface) rpc.Protocol {
@@ -921,6 +932,38 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"CancelPost": {
+				MakeArg: func() interface{} {
+					ret := make([]CancelPostArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]CancelPostArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]CancelPostArg)(nil), args)
+						return
+					}
+					err = i.CancelPost(ctx, (*typedArgs)[0].OutboxID)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"RetryPost": {
+				MakeArg: func() interface{} {
+					ret := make([]RetryPostArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]RetryPostArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]RetryPostArg)(nil), args)
+						return
+					}
+					err = i.RetryPost(ctx, (*typedArgs)[0].OutboxID)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -988,5 +1031,17 @@ func (c LocalClient) GetMessagesLocal(ctx context.Context, __arg GetMessagesLoca
 
 func (c LocalClient) DownloadAttachmentLocal(ctx context.Context, __arg DownloadAttachmentLocalArg) (res DownloadAttachmentLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.DownloadAttachmentLocal", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) CancelPost(ctx context.Context, outboxID OutboxID) (err error) {
+	__arg := CancelPostArg{OutboxID: outboxID}
+	err = c.Cli.Call(ctx, "chat.1.local.CancelPost", []interface{}{__arg}, nil)
+	return
+}
+
+func (c LocalClient) RetryPost(ctx context.Context, outboxID OutboxID) (err error) {
+	__arg := RetryPostArg{OutboxID: outboxID}
+	err = c.Cli.Call(ctx, "chat.1.local.RetryPost", []interface{}{__arg}, nil)
 	return
 }

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -18,6 +18,7 @@ const (
 	ChatActivityType_READ_MESSAGE     ChatActivityType = 2
 	ChatActivityType_NEW_CONVERSATION ChatActivityType = 3
 	ChatActivityType_SET_STATUS       ChatActivityType = 4
+	ChatActivityType_FAILED_MESSAGE   ChatActivityType = 5
 )
 
 var ChatActivityTypeMap = map[string]ChatActivityType{
@@ -26,6 +27,7 @@ var ChatActivityTypeMap = map[string]ChatActivityType{
 	"READ_MESSAGE":     2,
 	"NEW_CONVERSATION": 3,
 	"SET_STATUS":       4,
+	"FAILED_MESSAGE":   5,
 }
 
 var ChatActivityTypeRevMap = map[ChatActivityType]string{
@@ -34,6 +36,7 @@ var ChatActivityTypeRevMap = map[ChatActivityType]string{
 	2: "READ_MESSAGE",
 	3: "NEW_CONVERSATION",
 	4: "SET_STATUS",
+	5: "FAILED_MESSAGE",
 }
 
 type IncomingMessage struct {
@@ -61,12 +64,17 @@ type SetStatusInfo struct {
 	Status ConversationStatus `codec:"status" json:"status"`
 }
 
+type FailedMessageInfo struct {
+	OutboxIDs []OutboxID `codec:"outboxIDs" json:"outboxIDs"`
+}
+
 type ChatActivity struct {
 	ActivityType__    ChatActivityType     `codec:"activityType" json:"activityType"`
 	IncomingMessage__ *IncomingMessage     `codec:"incomingMessage,omitempty" json:"incomingMessage,omitempty"`
 	ReadMessage__     *ReadMessageInfo     `codec:"readMessage,omitempty" json:"readMessage,omitempty"`
 	NewConversation__ *NewConversationInfo `codec:"newConversation,omitempty" json:"newConversation,omitempty"`
 	SetStatus__       *SetStatusInfo       `codec:"setStatus,omitempty" json:"setStatus,omitempty"`
+	FailedMessage__   *FailedMessageInfo   `codec:"failedMessage,omitempty" json:"failedMessage,omitempty"`
 }
 
 func (o *ChatActivity) ActivityType() (ret ChatActivityType, err error) {
@@ -89,6 +97,11 @@ func (o *ChatActivity) ActivityType() (ret ChatActivityType, err error) {
 	case ChatActivityType_SET_STATUS:
 		if o.SetStatus__ == nil {
 			err = errors.New("unexpected nil value for SetStatus__")
+			return ret, err
+		}
+	case ChatActivityType_FAILED_MESSAGE:
+		if o.FailedMessage__ == nil {
+			err = errors.New("unexpected nil value for FailedMessage__")
 			return ret, err
 		}
 	}
@@ -135,6 +148,16 @@ func (o ChatActivity) SetStatus() SetStatusInfo {
 	return *o.SetStatus__
 }
 
+func (o ChatActivity) FailedMessage() FailedMessageInfo {
+	if o.ActivityType__ != ChatActivityType_FAILED_MESSAGE {
+		panic("wrong case accessed")
+	}
+	if o.FailedMessage__ == nil {
+		return FailedMessageInfo{}
+	}
+	return *o.FailedMessage__
+}
+
 func NewChatActivityWithIncomingMessage(v IncomingMessage) ChatActivity {
 	return ChatActivity{
 		ActivityType__:    ChatActivityType_INCOMING_MESSAGE,
@@ -160,6 +183,13 @@ func NewChatActivityWithSetStatus(v SetStatusInfo) ChatActivity {
 	return ChatActivity{
 		ActivityType__: ChatActivityType_SET_STATUS,
 		SetStatus__:    &v,
+	}
+}
+
+func NewChatActivityWithFailedMessage(v FailedMessageInfo) ChatActivity {
+	return ChatActivity{
+		ActivityType__:  ChatActivityType_FAILED_MESSAGE,
+		FailedMessage__: &v,
 	}
 }
 

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -723,7 +723,7 @@ func (h *chatLocalHandler) RetryPost(ctx context.Context, outboxID chat1.OutboxI
 		return err
 	}
 
-	// Force the send lopop to try again
+	// Force the send loop to try again
 	h.G().MessageDeliverer.ForceDeliverLoop()
 
 	return nil

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -697,6 +697,38 @@ func (h *chatLocalHandler) DownloadAttachmentLocal(ctx context.Context, arg chat
 	return chat1.DownloadAttachmentLocalRes{RateLimits: msgs.RateLimits}, nil
 }
 
+func (h *chatLocalHandler) CancelPost(ctx context.Context, outboxID chat1.OutboxID) error {
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
+
+	uid := h.G().Env.GetUID()
+	outbox := storage.NewOutbox(h.G(), uid.ToBytes(), h.getSecretUI)
+	if err := outbox.RemoveMessage(outboxID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *chatLocalHandler) RetryPost(ctx context.Context, outboxID chat1.OutboxID) error {
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
+
+	// Mark as retry in the outbox
+	uid := h.G().Env.GetUID()
+	outbox := storage.NewOutbox(h.G(), uid.ToBytes(), h.getSecretUI)
+	if err := outbox.RetryMessage(outboxID); err != nil {
+		return err
+	}
+
+	// Force the send lopop to try again
+	h.G().MessageDeliverer.ForceDeliverLoop()
+
+	return nil
+}
+
 // getSecretUI returns a SecretUI, preferring a delegated SecretUI if
 // possible.
 func (h *chatLocalHandler) getSecretUI() libkb.SecretUI {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -89,6 +89,7 @@ protocol local {
     gregor1.DeviceID senderDevice;
     Hash bodyHash;
     union { null, OutboxInfo } outboxInfo;
+    union { null, OutboxID } outboxID;
     union {null, SignatureInfo} headerSignature;
   }
 
@@ -315,4 +316,8 @@ protocol local {
     array<RateLimit> rateLimits;
   }
   DownloadAttachmentLocalRes DownloadAttachmentLocal(int sessionID, ConversationID conversationID, MessageID messageID, keybase1.Stream sink, boolean preview);
+
+  void CancelPost(OutboxID outboxID); 
+  void RetryPost(OutboxID outboxID);
+
 }

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -9,7 +9,8 @@ protocol NotifyChat {
     INCOMING_MESSAGE_1,
     READ_MESSAGE_2,
     NEW_CONVERSATION_3,
-    SET_STATUS_4
+    SET_STATUS_4,
+    FAILED_MESSAGE_5
   }
 
   record IncomingMessage {
@@ -37,11 +38,16 @@ protocol NotifyChat {
     ConversationStatus status;
   }
 
+  record FailedMessageInfo {
+    array<OutboxID> outboxIDs;
+  }
+
   variant ChatActivity switch (ChatActivityType activityType) {
     case INCOMING_MESSAGE: IncomingMessage;
     case READ_MESSAGE: ReadMessageInfo;
     case NEW_CONVERSATION: NewConversationInfo;
     case SET_STATUS: SetStatusInfo;
+    case FAILED_MESSAGE: FailedMessageInfo;
   }
 
   @notify("")

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -112,6 +112,19 @@ export const NotifyChatChatActivityType = {
   readMessage: 2,
   newConversation: 3,
   setStatus: 4,
+  failedMessage: 5,
+}
+
+export function localCancelPostRpc (request: Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.CancelPost'})
+}
+
+export function localCancelPostRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localCancelPostRpc({...request, incomingCallMap, callback}))
+}
+
+export function localCancelPostRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>): Promise<any> {
+  return new Promise((resolve, reject) => { localCancelPostRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function localDownloadAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {param: localDownloadAttachmentLocalRpcParam}>) {
@@ -244,6 +257,18 @@ export function localPostLocalRpcChannelMap (channelConfig: ChannelConfig<*>, re
 
 export function localPostLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {param: localPostLocalRpcParam}>): Promise<localPostLocalResult> {
   return new Promise((resolve, reject) => { localPostLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
+export function localRetryPostRpc (request: Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.RetryPost'})
+}
+
+export function localRetryPostRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localRetryPostRpc({...request, incomingCallMap, callback}))
+}
+
+export function localRetryPostRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>): Promise<any> {
+  return new Promise((resolve, reject) => { localRetryPostRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function localSetConversationStatusLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localSetConversationStatusLocalResult) => void} & {param: localSetConversationStatusLocalRpcParam}>) {
@@ -431,6 +456,7 @@ export type ChatActivity =
   | { activityType : 2, readMessage : ?ReadMessageInfo }
   | { activityType : 3, newConversation : ?NewConversationInfo }
   | { activityType : 4, setStatus : ?SetStatusInfo }
+  | { activityType : 5, failedMessage : ?FailedMessageInfo }
 
 export type ChatActivityType = 
     0 // RESERVED_0
@@ -438,6 +464,7 @@ export type ChatActivityType =
   | 2 // READ_MESSAGE_2
   | 3 // NEW_CONVERSATION_3
   | 4 // SET_STATUS_4
+  | 5 // FAILED_MESSAGE_5
 
 export type Conversation = {
   metadata: ConversationMetadata,
@@ -499,6 +526,10 @@ export type EncryptedData = {
   v: int,
   e: bytes,
   n: bytes,
+}
+
+export type FailedMessageInfo = {
+  outboxIDs?: ?Array<OutboxID>,
 }
 
 export type GenericPayload = {
@@ -633,6 +664,7 @@ export type HeaderPlaintextV1 = {
   senderDevice: gregor1.DeviceID,
   bodyHash: Hash,
   outboxInfo?: ?OutboxInfo,
+  outboxID?: ?OutboxID,
   headerSignature?: ?SignatureInfo,
 }
 
@@ -972,6 +1004,10 @@ export type chatUiChatAttachmentUploadProgressRpcParam = Exact<{
   bytesTotal: int
 }>
 
+export type localCancelPostRpcParam = Exact<{
+  outboxID: OutboxID
+}>
+
 export type localDownloadAttachmentLocalRpcParam = Exact<{
   conversationID: ConversationID,
   messageID: MessageID,
@@ -1033,6 +1069,10 @@ export type localPostLocalNonblockRpcParam = Exact<{
 export type localPostLocalRpcParam = Exact<{
   conversationID: ConversationID,
   msg: MessagePlaintext
+}>
+
+export type localRetryPostRpcParam = Exact<{
+  outboxID: OutboxID
 }>
 
 export type localSetConversationStatusLocalRpcParam = Exact<{
@@ -1145,7 +1185,8 @@ type remoteS3SignResult = bytes
 type remoteSetConversationStatusResult = SetConversationStatusRes
 
 export type rpc =
-    localDownloadAttachmentLocalRpc
+    localCancelPostRpc
+  | localDownloadAttachmentLocalRpc
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc
   | localGetInboxLocalRpc
@@ -1156,6 +1197,7 @@ export type rpc =
   | localPostAttachmentLocalRpc
   | localPostLocalNonblockRpc
   | localPostLocalRpc
+  | localRetryPostRpc
   | localSetConversationStatusLocalRpc
   | remoteGetInboxRemoteRpc
   | remoteGetMessagesRemoteRpc

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -304,6 +304,13 @@
         {
           "type": [
             null,
+            "OutboxID"
+          ],
+          "name": "outboxID"
+        },
+        {
+          "type": [
+            null,
             "SignatureInfo"
           ],
           "name": "headerSignature"
@@ -1204,6 +1211,24 @@
         }
       ],
       "response": "DownloadAttachmentLocalRes"
+    },
+    "CancelPost": {
+      "request": [
+        {
+          "name": "outboxID",
+          "type": "OutboxID"
+        }
+      ],
+      "response": null
+    },
+    "RetryPost": {
+      "request": [
+        {
+          "name": "outboxID",
+          "type": "OutboxID"
+        }
+      ],
+      "response": null
     }
   },
   "namespace": "chat.1"

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -16,7 +16,8 @@
         "INCOMING_MESSAGE_1",
         "READ_MESSAGE_2",
         "NEW_CONVERSATION_3",
-        "SET_STATUS_4"
+        "SET_STATUS_4",
+        "FAILED_MESSAGE_5"
       ]
     },
     {
@@ -90,6 +91,19 @@
       ]
     },
     {
+      "type": "record",
+      "name": "FailedMessageInfo",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "OutboxID"
+          },
+          "name": "outboxIDs"
+        }
+      ]
+    },
+    {
       "type": "variant",
       "name": "ChatActivity",
       "switch": {
@@ -124,6 +138,13 @@
             "def": false
           },
           "body": "SetStatusInfo"
+        },
+        {
+          "label": {
+            "name": "FAILED_MESSAGE",
+            "def": false
+          },
+          "body": "FailedMessageInfo"
         }
       ]
     }

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -112,6 +112,19 @@ export const NotifyChatChatActivityType = {
   readMessage: 2,
   newConversation: 3,
   setStatus: 4,
+  failedMessage: 5,
+}
+
+export function localCancelPostRpc (request: Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.CancelPost'})
+}
+
+export function localCancelPostRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localCancelPostRpc({...request, incomingCallMap, callback}))
+}
+
+export function localCancelPostRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>): Promise<any> {
+  return new Promise((resolve, reject) => { localCancelPostRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function localDownloadAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {param: localDownloadAttachmentLocalRpcParam}>) {
@@ -244,6 +257,18 @@ export function localPostLocalRpcChannelMap (channelConfig: ChannelConfig<*>, re
 
 export function localPostLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {param: localPostLocalRpcParam}>): Promise<localPostLocalResult> {
   return new Promise((resolve, reject) => { localPostLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
+export function localRetryPostRpc (request: Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.RetryPost'})
+}
+
+export function localRetryPostRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localRetryPostRpc({...request, incomingCallMap, callback}))
+}
+
+export function localRetryPostRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>): Promise<any> {
+  return new Promise((resolve, reject) => { localRetryPostRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function localSetConversationStatusLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localSetConversationStatusLocalResult) => void} & {param: localSetConversationStatusLocalRpcParam}>) {
@@ -431,6 +456,7 @@ export type ChatActivity =
   | { activityType : 2, readMessage : ?ReadMessageInfo }
   | { activityType : 3, newConversation : ?NewConversationInfo }
   | { activityType : 4, setStatus : ?SetStatusInfo }
+  | { activityType : 5, failedMessage : ?FailedMessageInfo }
 
 export type ChatActivityType = 
     0 // RESERVED_0
@@ -438,6 +464,7 @@ export type ChatActivityType =
   | 2 // READ_MESSAGE_2
   | 3 // NEW_CONVERSATION_3
   | 4 // SET_STATUS_4
+  | 5 // FAILED_MESSAGE_5
 
 export type Conversation = {
   metadata: ConversationMetadata,
@@ -499,6 +526,10 @@ export type EncryptedData = {
   v: int,
   e: bytes,
   n: bytes,
+}
+
+export type FailedMessageInfo = {
+  outboxIDs?: ?Array<OutboxID>,
 }
 
 export type GenericPayload = {
@@ -633,6 +664,7 @@ export type HeaderPlaintextV1 = {
   senderDevice: gregor1.DeviceID,
   bodyHash: Hash,
   outboxInfo?: ?OutboxInfo,
+  outboxID?: ?OutboxID,
   headerSignature?: ?SignatureInfo,
 }
 
@@ -972,6 +1004,10 @@ export type chatUiChatAttachmentUploadProgressRpcParam = Exact<{
   bytesTotal: int
 }>
 
+export type localCancelPostRpcParam = Exact<{
+  outboxID: OutboxID
+}>
+
 export type localDownloadAttachmentLocalRpcParam = Exact<{
   conversationID: ConversationID,
   messageID: MessageID,
@@ -1033,6 +1069,10 @@ export type localPostLocalNonblockRpcParam = Exact<{
 export type localPostLocalRpcParam = Exact<{
   conversationID: ConversationID,
   msg: MessagePlaintext
+}>
+
+export type localRetryPostRpcParam = Exact<{
+  outboxID: OutboxID
 }>
 
 export type localSetConversationStatusLocalRpcParam = Exact<{
@@ -1145,7 +1185,8 @@ type remoteS3SignResult = bytes
 type remoteSetConversationStatusResult = SetConversationStatusRes
 
 export type rpc =
-    localDownloadAttachmentLocalRpc
+    localCancelPostRpc
+  | localDownloadAttachmentLocalRpc
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc
   | localGetInboxLocalRpc
@@ -1156,6 +1197,7 @@ export type rpc =
   | localPostAttachmentLocalRpc
   | localPostLocalNonblockRpc
   | localPostLocalRpc
+  | localRetryPostRpc
   | localSetConversationStatusLocalRpc
   | remoteGetInboxRemoteRpc
   | remoteGetMessagesRemoteRpc


### PR DESCRIPTION
@patrickxb r?

This adds a failure stats to messages in the outbox once they fail the maximum number of times. I decided to make the entire outbox as failed if one does in order to make sure we don't have any ordering problems with the messages getting sent. 