### PR TITLE
implement edit deletion on the client

### DIFF
--- a/go/chat/prev.go
+++ b/go/chat/prev.go
@@ -15,7 +15,7 @@ import (
 // TODO: All of this should happen in the cache instead of here all at once.
 func CheckPrevPointersAndGetUnpreved(thread *chat1.ThreadView) ([]chat1.MessagePreviousPointer, libkb.ChatThreadConsistencyError) {
 	// Filter out the messages that gave unboxing errors, and index the rest by
-	// ID. Enforce that there are no duplicate IDs.
+	// ID. Enforce that there are no duplicate IDs or absurd prev pointers.
 	// TODO: What should we really be doing with unboxing errors? Do we worry
 	//       about an evil server causing them intentionally?
 	knownMessages := make(map[chat1.MessageID]chat1.MessageUnboxedValid)
@@ -35,6 +35,18 @@ func CheckPrevPointersAndGetUnpreved(thread *chat1.ThreadView) ([]chat1.MessageP
 					id)
 			}
 
+			// Check that each prev pointer (if any) is a lower ID than the
+			// message itself.
+			for _, prev := range msg.ClientHeader.Prev {
+				if prev.Id > id {
+					return nil, libkb.NewChatThreadConsistencyError(
+						libkb.OutOfOrderID,
+						"MessageID %d thinks that message %d is previous.",
+						id,
+						prev.Id)
+				}
+			}
+
 			knownMessages[id] = msg
 			unprevedIDs[id] = struct{}{}
 		}
@@ -43,21 +55,10 @@ func CheckPrevPointersAndGetUnpreved(thread *chat1.ThreadView) ([]chat1.MessageP
 	// Using the index we built above, check each prev pointer on each message
 	// to make sure its hash is correct. Some prev pointers might refer to
 	// messages we don't have locally, and in that case we just check that all
-	// prev pointers to that message are *consistent*. While we're at it, also
-	// enforce that each prev's ID is less than the ID of the message that's
-	// pointing to it.
+	// prev pointers to that message are *consistent*.
 	seenHashes := make(map[chat1.MessageID]chat1.Hash)
 	for id, msg := range knownMessages {
 		for _, prev := range msg.ClientHeader.Prev {
-			// Check that the prev's ID doesn't come after us. That would make no sense.
-			if prev.Id > id {
-				return nil, libkb.NewChatThreadConsistencyError(
-					libkb.OutOfOrderID,
-					"MessageID %d thinks that message %d is previous.",
-					id,
-					prev.Id)
-			}
-
 			// If this message has been referred to before, check that it's
 			// always referred to with the same hash.
 			seenHash := seenHashes[prev.Id]

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -202,7 +202,7 @@ func (s *Storage) getSupersedes(msg chat1.MessageUnboxed) ([]chat1.MessageID, li
 	case chat1.MessageType_EDIT:
 		return []chat1.MessageID{msg.Valid().MessageBody.Edit().MessageID}, nil
 	case chat1.MessageType_DELETE:
-		return []chat1.MessageID{msg.Valid().MessageBody.Delete().MessageID}, nil
+		return msg.Valid().MessageBody.Delete().MessageIDs, nil
 	default:
 		return nil, nil
 	}

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -225,6 +225,7 @@ func (c *chatServiceHandler) DeleteV1(ctx context.Context, opts deleteOptionsV1)
 		body:           chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: messageAndEdits}),
 		mtype:          chat1.MessageType_DELETE,
 		supersedes:     opts.MessageID,
+		deletes:        messageAndEdits,
 		response:       "message deleted",
 	}
 	return c.sendV1(ctx, arg)
@@ -432,6 +433,7 @@ type sendArgV1 struct {
 	body           chat1.MessageBody
 	mtype          chat1.MessageType
 	supersedes     chat1.MessageID
+	deletes        []chat1.MessageID
 	response       string
 }
 
@@ -529,6 +531,7 @@ func (c *chatServiceHandler) makePostHeader(ctx context.Context, arg sendArgV1, 
 		TlfPublic:   visibility == chat1.TLFVisibility_PUBLIC,
 		MessageType: arg.mtype,
 		Supersedes:  arg.supersedes,
+		Deletes:     arg.deletes,
 	}
 
 	return &header, nil

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -191,7 +191,7 @@ func (c *chatServiceHandler) DeleteV1(ctx context.Context, opts deleteOptionsV1)
 	arg := sendArgV1{
 		conversationID: convID,
 		channel:        opts.Channel,
-		body:           chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageID: opts.MessageID}),
+		body:           chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: []chat1.MessageID{opts.MessageID}}),
 		mtype:          chat1.MessageType_DELETE,
 		supersedes:     opts.MessageID,
 		response:       "message deleted",

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -192,6 +192,7 @@ type MessageClientHeader struct {
 	TlfPublic    bool                     `codec:"tlfPublic" json:"tlfPublic"`
 	MessageType  MessageType              `codec:"messageType" json:"messageType"`
 	Supersedes   MessageID                `codec:"supersedes" json:"supersedes"`
+	Deletes      []MessageID              `codec:"deletes" json:"deletes"`
 	Prev         []MessagePreviousPointer `codec:"prev" json:"prev"`
 	Sender       gregor1.UID              `codec:"sender" json:"sender"`
 	SenderDevice gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -25,7 +25,7 @@ type MessageEdit struct {
 }
 
 type MessageDelete struct {
-	MessageID MessageID `codec:"messageID" json:"messageID"`
+	MessageIDs []MessageID `codec:"messageIDs" json:"messageIDs"`
 }
 
 type MessageHeadline struct {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -139,6 +139,7 @@ protocol common {
     boolean tlfPublic;
     MessageType messageType;
     MessageID supersedes;
+    array<MessageID> deletes;
     array<MessagePreviousPointer> prev;
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -19,7 +19,7 @@ protocol local {
   }
 
   record MessageDelete {
-    MessageID messageID;
+    array<MessageID> messageIDs;
   }
 
   record MessageHeadline {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -743,7 +743,7 @@ export type MessageConversationMetadata = {
 }
 
 export type MessageDelete = {
-  messageID: MessageID,
+  messageIDs?: ?Array<MessageID>,
 }
 
 export type MessageEdit = {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -731,6 +731,7 @@ export type MessageClientHeader = {
   tlfPublic: boolean,
   messageType: MessageType,
   supersedes: MessageID,
+  deletes?: ?Array<MessageID>,
   prev?: ?Array<MessagePreviousPointer>,
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -388,6 +388,13 @@
         {
           "type": {
             "type": "array",
+            "items": "MessageID"
+          },
+          "name": "deletes"
+        },
+        {
+          "type": {
+            "type": "array",
             "items": "MessagePreviousPointer"
           },
           "name": "prev"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -56,8 +56,11 @@
       "name": "MessageDelete",
       "fields": [
         {
-          "type": "MessageID",
-          "name": "messageID"
+          "type": {
+            "type": "array",
+            "items": "MessageID"
+          },
+          "name": "messageIDs"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -743,7 +743,7 @@ export type MessageConversationMetadata = {
 }
 
 export type MessageDelete = {
-  messageID: MessageID,
+  messageIDs?: ?Array<MessageID>,
 }
 
 export type MessageEdit = {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -731,6 +731,7 @@ export type MessageClientHeader = {
   tlfPublic: boolean,
   messageType: MessageType,
   supersedes: MessageID,
+  deletes?: ?Array<MessageID>,
   prev?: ?Array<MessagePreviousPointer>,
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,


### PR DESCRIPTION
I'm adding a new field, `Deletes`, to the `MessageClientHeader`. There's no change to the `HeaderPlaintext`, since this data (like `Supersedes`) is only meaningful to the server, and is not reconstructed when clients parse messages. (Instead clients should rely on the bodies of edit/delete messages to figure out what they delete. We don't currently check this however.)

r? @mmaxim 