### PR TITLE
Reset console color mode on Windows

### DIFF
--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -115,6 +115,9 @@ func mainInner(g *libkb.GlobalContext) error {
 	checkSystemUser(g.Log)
 
 	if !cl.IsService() {
+		if err = logger.SaveConsoleMode(); err == nil {
+			defer logger.RestoreConsoleMode()
+		}
 		client.InitUI()
 	}
 

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -115,7 +115,7 @@ func mainInner(g *libkb.GlobalContext) error {
 	checkSystemUser(g.Log)
 
 	if !cl.IsService() {
-		if err = logger.SaveConsoleMode(); err == nil {
+		if logger.SaveConsoleMode() == nil {
 			defer logger.RestoreConsoleMode()
 		}
 		client.InitUI()

--- a/go/logger/output_nix.go
+++ b/go/logger/output_nix.go
@@ -17,3 +17,16 @@ func OutputWriter() io.Writer {
 func ErrorWriter() io.Writer {
 	return os.Stderr
 }
+
+// SaveConsoleMode records the current text attributes in a global, so
+// it can be restored later, in case nonstandard colors are expected.
+// (Windows only)
+func SaveConsoleMode() error {
+	return nil
+}
+
+// RestoreConsoleMode restores the current text attributes from a global,
+// in case nonstandard colors are expected.
+// (Windows only)
+func RestoreConsoleMode() {
+}

--- a/go/logger/output_windows.go
+++ b/go/logger/output_windows.go
@@ -20,16 +20,42 @@ import (
 	"syscall"
 
 	"golang.org/x/sys/windows"
+	"unsafe"
 )
 
 var (
-	kernel32DLL                 = windows.NewLazySystemDLL("kernel32.dll")
-	setConsoleTextAttributeProc = kernel32DLL.NewProc("SetConsoleTextAttribute")
-	stdOutMutex                 sync.Mutex
-	stdErrMutex                 sync.Mutex
+	kernel32DLL                    = windows.NewLazySystemDLL("kernel32.dll")
+	setConsoleTextAttributeProc    = kernel32DLL.NewProc("SetConsoleTextAttribute")
+	getConsoleScreenBufferInfoProc = kernel32DLL.NewProc("GetConsoleScreenBufferInfo")
+	stdOutMutex                    sync.Mutex
+	stdErrMutex                    sync.Mutex
+	consoleMode                    WORD
 )
 
-type WORD uint16
+type (
+	SHORT int16
+	WORD  uint16
+
+	SMALL_RECT struct {
+		Left   SHORT
+		Top    SHORT
+		Right  SHORT
+		Bottom SHORT
+	}
+
+	COORD struct {
+		X SHORT
+		Y SHORT
+	}
+
+	CONSOLE_SCREEN_BUFFER_INFO struct {
+		Size              COORD
+		CursorPosition    COORD
+		Attributes        WORD
+		Window            SMALL_RECT
+		MaximumWindowSize COORD
+	}
+)
 
 const (
 	// Character attributes
@@ -61,28 +87,43 @@ const (
 )
 
 var codesWin = map[byte]WORD{
-	0:  fgWhite | bgBlack, //	"reset":
-	1:  fgIntensity,       //CpBold          = CodePair{1, 22}
-	22: fgWhite,           //	UnBold:        // Just assume this means reset to white fg
-	39: fgWhite,           //	"resetfg":
-	49: fgWhite,           //	"resetbg":        // Just assume this means reset to white fg
-	30: fgBlack,           //	"black":
-	31: fgRed,             //	"red":
-	32: fgGreen,           //	"green":
-	33: fgYellow,          //	"yellow":
-	34: fgBlue,            //	"blue":
-	35: fgMagenta,         //	"magenta":
-	36: fgCyan,            //	"cyan":
-	37: fgWhite,           //	"white":
-	90: fgWhite,           //	"grey":
-	40: bgBlack,           //	"bgBlack":
-	41: bgRed,             //	"bgRed":
-	42: bgGreen,           //	"bgGreen":
-	43: bgYellow,          //	"bgYellow":
-	44: bgBlue,            //	"bgBlue":
-	45: bgMagenta,         //	"bgMagenta":
-	46: bgCyan,            //	"bgCyan":
-	47: bgWhite,           //	"bgWhite":
+	0:   fgWhite | bgBlack,       //	"reset":
+	1:   fgIntensity,             //CpBold          = CodePair{1, 22}
+	22:  fgWhite,                 //	UnBold:        // Just assume this means reset to white fg
+	39:  fgWhite,                 //	"resetfg":
+	49:  fgWhite,                 //	"resetbg":        // Just assume this means reset to white fg
+	30:  fgBlack,                 //	"black":
+	31:  fgRed,                   //	"red":
+	32:  fgGreen,                 //	"green":
+	33:  fgYellow,                //	"yellow":
+	34:  fgBlue,                  //	"blue":
+	35:  fgMagenta,               //	"magenta":
+	36:  fgCyan,                  //	"cyan":
+	37:  fgWhite,                 //	"white":
+	90:  fgBlack | fgIntensity,   //	"grey":
+	91:  fgRed | fgIntensity,     //	"red":
+	92:  fgGreen | fgIntensity,   //	"green":
+	93:  fgYellow | fgIntensity,  //	"yellow":
+	94:  fgBlue | fgIntensity,    //	"blue":
+	95:  fgMagenta | fgIntensity, //	"magenta":
+	96:  fgCyan | fgIntensity,    //	"cyan":
+	97:  fgWhite | fgIntensity,   //	"white":
+	40:  bgBlack,                 //	"bgBlack":
+	41:  bgRed,                   //	"bgRed":
+	42:  bgGreen,                 //	"bgGreen":
+	43:  bgYellow,                //	"bgYellow":
+	44:  bgBlue,                  //	"bgBlue":
+	45:  bgMagenta,               //	"bgMagenta":
+	46:  bgCyan,                  //	"bgCyan":
+	47:  bgWhite,                 //	"bgWhite":
+	100: bgBlack | bgIntensity,   //	"bgBlack":
+	101: bgRed | bgIntensity,     //	"bgRed":
+	102: bgGreen | bgIntensity,   //	"bgGreen":
+	103: bgYellow | bgIntensity,  //	"bgYellow":
+	104: bgBlue | bgIntensity,    //	"bgBlue":
+	105: bgMagenta | bgIntensity, //	"bgMagenta":
+	106: bgCyan | bgIntensity,    //	"bgCyan":
+	107: bgWhite | bgIntensity,   //	"bgWhite":
 }
 
 // Return our writer so we can override Write()
@@ -220,6 +261,30 @@ func setConsoleTextAttribute(handle uintptr, attribute WORD) error {
 	r1, r2, err := setConsoleTextAttributeProc.Call(handle, uintptr(attribute), 0)
 	use(attribute)
 	return checkError(r1, r2, err)
+}
+
+// GetConsoleScreenBufferInfo retrieves information about the specified console screen buffer.
+// http://msdn.microsoft.com/en-us/library/windows/desktop/ms683171(v=vs.85).aspx
+func getConsoleTextAttribute(handle uintptr) (WORD, error) {
+	var info CONSOLE_SCREEN_BUFFER_INFO
+	if err := checkError(getConsoleScreenBufferInfoProc.Call(handle, uintptr(unsafe.Pointer(&info)), 0)); err != nil {
+		return 0, err
+	}
+	return info.Attributes, nil
+}
+
+// SaveConsoleMode records the current text attributes in a global, so
+// it can be restored later, in case nonstandard colors are expected.
+func SaveConsoleMode() error {
+	var err error
+	consoleMode, err = getConsoleTextAttribute(os.Stdout.Fd())
+	return err
+}
+
+// RestoreConsoleMode restores the current text attributes from a global,
+// in case nonstandard colors are expected.
+func RestoreConsoleMode() {
+	setConsoleTextAttribute(os.Stdout.Fd(), consoleMode)
 }
 
 // checkError evaluates the results of a Windows API call and returns the error if it failed.


### PR DESCRIPTION
I started trying to use the current mode as a default instead of assuming white on black, but it was too complicated. This will at least restore the user's colors.
@maxtaco @cjb 