### PR TITLE
Handle decrypt/verify of pgp messages from non-keybase

### DIFF
--- a/go/client/pgp_ui.go
+++ b/go/client/pgp_ui.go
@@ -40,6 +40,21 @@ func (p PgpUI) OutputSignatureSuccess(_ context.Context, arg keybase1.OutputSign
 	return nil
 }
 
+func (p PgpUI) OutputSignatureSuccessNonKeybase(ctx context.Context, arg keybase1.OutputSignatureSuccessNonKeybaseArg) error {
+	signedAt := keybase1.FromTime(arg.SignedAt)
+	output := func(fmtString string, args ...interface{}) {
+		s := fmt.Sprintf(fmtString, args...)
+		s = ColorString("green", s)
+		p.w.Write([]byte(s))
+	}
+
+	if signedAt.IsZero() {
+		output("Signature verified. Signed by key %s (unknown to keybase).\n", arg.KeyID)
+	} else {
+		output("Signature verified. Signed by key %s (unknown to keybase) %s (%s).\n", arg.KeyID, humanize.Time(signedAt), signedAt)
+	}
+	return nil
+}
 func (p PgpUI) KeyGenerated(ctx context.Context, arg keybase1.KeyGeneratedArg) error {
 	return nil
 }

--- a/go/engine/pgp_common.go
+++ b/go/engine/pgp_common.go
@@ -4,6 +4,7 @@
 package engine
 
 import (
+	"fmt"
 	"time"
 
 	"golang.org/x/net/context"
@@ -20,4 +21,14 @@ func OutputSignatureSuccess(ctx *Context, fingerprint libkb.PGPFingerprint, owne
 		SignedAt:    keybase1.TimeFromSeconds(signatureTime.Unix()),
 	}
 	ctx.PgpUI.OutputSignatureSuccess(context.TODO(), arg)
+}
+
+// OutputSignatureSuccessNonKeybase prints the details of successful signature verification
+// when signing key is not known to keybase.
+func OutputSignatureSuccessNonKeybase(ctx *Context, keyID uint64, signatureTime time.Time) {
+	arg := keybase1.OutputSignatureSuccessNonKeybaseArg{
+		KeyID:    fmt.Sprintf("%X", keyID),
+		SignedAt: keybase1.TimeFromSeconds(signatureTime.Unix()),
+	}
+	ctx.PgpUI.OutputSignatureSuccessNonKeybase(ctx.NetContext, arg)
 }

--- a/go/protocol/keybase1/pgp_ui.go
+++ b/go/protocol/keybase1/pgp_ui.go
@@ -15,6 +15,12 @@ type OutputSignatureSuccessArg struct {
 	SignedAt    Time   `codec:"signedAt" json:"signedAt"`
 }
 
+type OutputSignatureSuccessNonKeybaseArg struct {
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	KeyID     string `codec:"keyID" json:"keyID"`
+	SignedAt  Time   `codec:"signedAt" json:"signedAt"`
+}
+
 type KeyGeneratedArg struct {
 	SessionID int     `codec:"sessionID" json:"sessionID"`
 	Kid       KID     `codec:"kid" json:"kid"`
@@ -31,6 +37,7 @@ type FinishedArg struct {
 
 type PGPUiInterface interface {
 	OutputSignatureSuccess(context.Context, OutputSignatureSuccessArg) error
+	OutputSignatureSuccessNonKeybase(context.Context, OutputSignatureSuccessNonKeybaseArg) error
 	KeyGenerated(context.Context, KeyGeneratedArg) error
 	ShouldPushPrivate(context.Context, int) (bool, error)
 	Finished(context.Context, int) error
@@ -52,6 +59,22 @@ func PGPUiProtocol(i PGPUiInterface) rpc.Protocol {
 						return
 					}
 					err = i.OutputSignatureSuccess(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"outputSignatureSuccessNonKeybase": {
+				MakeArg: func() interface{} {
+					ret := make([]OutputSignatureSuccessNonKeybaseArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]OutputSignatureSuccessNonKeybaseArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]OutputSignatureSuccessNonKeybaseArg)(nil), args)
+						return
+					}
+					err = i.OutputSignatureSuccessNonKeybase(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -114,6 +137,11 @@ type PGPUiClient struct {
 
 func (c PGPUiClient) OutputSignatureSuccess(ctx context.Context, __arg OutputSignatureSuccessArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.pgpUi.outputSignatureSuccess", []interface{}{__arg}, nil)
+	return
+}
+
+func (c PGPUiClient) OutputSignatureSuccessNonKeybase(ctx context.Context, __arg OutputSignatureSuccessNonKeybaseArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.pgpUi.outputSignatureSuccessNonKeybase", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/service/pgp.go
+++ b/go/service/pgp.go
@@ -27,6 +27,10 @@ func (u *RemotePgpUI) OutputSignatureSuccess(ctx context.Context, arg keybase1.O
 	return u.cli.OutputSignatureSuccess(ctx, arg)
 }
 
+func (u *RemotePgpUI) OutputSignatureSuccessNonKeybase(ctx context.Context, arg keybase1.OutputSignatureSuccessNonKeybaseArg) error {
+	return u.cli.OutputSignatureSuccessNonKeybase(ctx, arg)
+}
+
 func (u *RemotePgpUI) KeyGenerated(ctx context.Context, arg keybase1.KeyGeneratedArg) error {
 	arg.SessionID = u.sessionID
 	return u.cli.KeyGenerated(ctx, arg)
@@ -123,7 +127,7 @@ func (h *PGPHandler) PGPDecrypt(_ context.Context, arg keybase1.PGPDecryptArg) (
 		return keybase1.PGPSigVerification{}, err
 	}
 
-	return sigVer(h.G(), eng.SignatureStatus(), eng.Owner()), nil
+	return sigVer(h.G(), eng.SignatureStatus(), eng.Signer()), nil
 }
 
 func (h *PGPHandler) PGPVerify(_ context.Context, arg keybase1.PGPVerifyArg) (keybase1.PGPSigVerification, error) {
@@ -147,18 +151,18 @@ func (h *PGPHandler) PGPVerify(_ context.Context, arg keybase1.PGPVerifyArg) (ke
 		return keybase1.PGPSigVerification{}, err
 	}
 
-	return sigVer(h.G(), eng.SignatureStatus(), eng.Owner()), nil
+	return sigVer(h.G(), eng.SignatureStatus(), eng.Signer()), nil
 }
 
-func sigVer(g *libkb.GlobalContext, ss *libkb.SignatureStatus, owner *libkb.User) keybase1.PGPSigVerification {
+func sigVer(g *libkb.GlobalContext, ss *libkb.SignatureStatus, signer *libkb.User) keybase1.PGPSigVerification {
 	var res keybase1.PGPSigVerification
 	if ss.IsSigned {
 		res.IsSigned = ss.IsSigned
 		res.Verified = ss.Verified
-		if owner != nil {
-			signer := owner.Export()
-			if signer != nil {
-				res.Signer = *signer
+		if signer != nil {
+			signerExp := signer.Export()
+			if signerExp != nil {
+				res.Signer = *signerExp
 			}
 		}
 		if ss.Entity != nil {

--- a/protocol/avdl/keybase1/pgp_ui.avdl
+++ b/protocol/avdl/keybase1/pgp_ui.avdl
@@ -3,7 +3,11 @@
 protocol pgpUi {
   import idl "common.avdl";
 
+  // signed by known keybase key + user:
   void outputSignatureSuccess(int sessionID, string fingerprint, string username, Time signedAt);
+
+  // signing key unknown to keybase:
+  void outputSignatureSuccessNonKeybase(int sessionID, string keyID, Time signedAt);
 
   // pgpKeyGenDefault calls these:
   void keyGenerated(int sessionID, KID kid, KeyInfo key);

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4664,6 +4664,11 @@ export type pgpUiKeyGeneratedRpcParam = Exact<{
   key: KeyInfo
 }>
 
+export type pgpUiOutputSignatureSuccessNonKeybaseRpcParam = Exact<{
+  keyID: string,
+  signedAt: Time
+}>
+
 export type pgpUiOutputSignatureSuccessRpcParam = Exact<{
   fingerprint: string,
   username: string,
@@ -5755,6 +5760,14 @@ export type incomingCallMapType = Exact<{
       sessionID: int,
       fingerprint: string,
       username: string,
+      signedAt: Time
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.pgpUi.outputSignatureSuccessNonKeybase'?: (
+    params: Exact<{
+      sessionID: int,
+      keyID: string,
       signedAt: Time
     }>,
     response: CommonResponseHandler

--- a/protocol/json/keybase1/pgp_ui.json
+++ b/protocol/json/keybase1/pgp_ui.json
@@ -29,6 +29,23 @@
       ],
       "response": null
     },
+    "outputSignatureSuccessNonKeybase": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "keyID",
+          "type": "string"
+        },
+        {
+          "name": "signedAt",
+          "type": "Time"
+        }
+      ],
+      "response": null
+    },
     "keyGenerated": {
       "request": [
         {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4664,6 +4664,11 @@ export type pgpUiKeyGeneratedRpcParam = Exact<{
   key: KeyInfo
 }>
 
+export type pgpUiOutputSignatureSuccessNonKeybaseRpcParam = Exact<{
+  keyID: string,
+  signedAt: Time
+}>
+
 export type pgpUiOutputSignatureSuccessRpcParam = Exact<{
   fingerprint: string,
   username: string,
@@ -5755,6 +5760,14 @@ export type incomingCallMapType = Exact<{
       sessionID: int,
       fingerprint: string,
       username: string,
+      signedAt: Time
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.pgpUi.outputSignatureSuccessNonKeybase'?: (
+    params: Exact<{
+      sessionID: int,
+      keyID: string,
       signedAt: Time
     }>,
     response: CommonResponseHandler


### PR DESCRIPTION
This was completely messed up before.  But now, pgp
decrypt, verify on messages encrypted, signed by keys
that keybase doesn't know about are handled correctly.

Also, fixed bug in scankeys where it stored only one
key owner.  The scankeys object can be used for multiple
keys so the owner has to be stored with the key id.
This was causing identifies to happen on the wrong user
in some cases.