### PR TITLE
Fix `chat ls` rendering of self-conv

### DIFF
--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -53,6 +53,10 @@ type conversationListView []chat1.ConversationLocal
 // Make a name that looks like a tlfname but is sorted by activity and missing myUsername.
 func (v conversationListView) convName(g *libkb.GlobalContext, conv chat1.ConversationLocal, myUsername string) string {
 	convName := strings.Join(v.without(g, conv.Info.WriterNames, myUsername), ",")
+	if len(conv.Info.WriterNames) == 1 && conv.Info.WriterNames[0] == myUsername {
+		// The user is the only writer.
+		convName = myUsername
+	}
 	if len(conv.Info.ReaderNames) > 0 {
 		convName += "#" + strings.Join(conv.Info.ReaderNames, ",")
 	}


### PR DESCRIPTION
Conversations with yourself were rendered with a blank pseudo-tlfname in `chat ls`.

Wrong:
```
$ kbu chat ls # (I'm alice11)
[1]  t_bob  [alice11 2s] bob.
[2]        [alice11 39s] hi self
```

Fixed:
```
$ kbu chat ls
[1]  t_bob   [alice11 7m] bob.
[2]  alice11 [alice11 7m] hi self
```

r? 