### PR TITLE
Windows: Pipline installer build

### DIFF
--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -9,6 +9,7 @@ def doBuild() {
         // Reset symlink due to node/git/windows problems
         bat 'if EXIST src\\github.com\\keybase\\client\\shared cd src\\github.com\\keybase\\client && git checkout shared'
         bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\shared cd src\\github.com\\keybase\\client && git checkout desktop/shared'
+        bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\renderer\\fonts cd src\\github.com\\keybase\\client && git checkout desktop/renderer/fonts'
         parallel(
             checkout_client: {
                 dir('src/github.com/keybase/client') {

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -69,12 +69,12 @@ def doBuild() {
 
     stage('Publish to S3') {
         if (UpdateChannel != "None"){    
-            publish('prerelease.keybase.io/windows', 
-                    '', 
-                    'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\*.exe') 
-            publish('prerelease.keybase.io', 
-                    '', 
-                    'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\update-windows-prod-test-v2.json') 
+            publish("prerelease.keybase.io/windows", 
+                    "", 
+                    "src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\*.exe") 
+            publish("prerelease.keybase.io", 
+                    "", 
+                    "src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\update-windows-prod-test-v2.json") 
         } else {
             echo "No update channel"
         }
@@ -110,9 +110,9 @@ def doBuild() {
     }
     stage('Publish smoke updater jsons to S3') {
         if (UpdateChannel == "Smoke2") {
-            publish('prerelease.keybase.io/windows-support', 
-                'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\update-windows-prod-test-v2.json',
-                'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\*.json') 
+            publish("prerelease.keybase.io/windows-support", 
+                "src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\update-windows-prod-test-v2.json",
+                "src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\*.json") 
             def smokeBSemVer = ''
             dir('src\\github.com\\keybase\\client\\go\\keybase') {
                 smokeBSemVer = bat(returnStdout: true, script: '@echo off && winresource.exe -cv').trim()

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -6,11 +6,10 @@ def getCommit(path) {
 
 def doBuild() {
     stage('Checkout Client') {
-        parallel(
-            
-            // Reset symlink due to node/git/windows problems
-            bat 'if EXIST src\\github.com\\keybase\\client\\shared cd src\\github.com\\keybase\\client && git checkout shared'
-            bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\shared cd src\\github.com\\keybase\\client && git checkout desktop/shared'
+        // Reset symlink due to node/git/windows problems
+        bat 'if EXIST src\\github.com\\keybase\\client\\shared cd src\\github.com\\keybase\\client && git checkout shared'
+        bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\shared cd src\\github.com\\keybase\\client && git checkout desktop/shared'
+        parallel(            
             checkout([
                 poll: false,
                 scm: [

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -67,15 +67,15 @@ def doBuild() {
             }            
         )
     }
+    // Make sure any previous desktop build is deleted
+    bat '''
+        if EXIST src\\github.com\\keybase\\client\\desktop\\release rmdir /q /s src\\github.com\\keybase\\client\\desktop\\release
+        path
+    '''                
     stage('Build Client') {
         bat '"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && src\\github.com\\keybase\\client\\packaging\\windows\\build_prerelease.cmd'
     } 
     stage('Build UI') {
-        // Make sure any previous desktop build is deleted
-        bat '''
-            if EXIST src\\github.com\\keybase\\client\\desktop\\release rmdir /q /s src\\github.com\\keybase\\client\\desktop\\release
-            path
-        '''                
         bat 'src\\github.com\\keybase\\client\\packaging\\windows\\buildui.bat'
     }
     stage('Build Installer') {

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -9,7 +9,7 @@ def doBuild() {
         // Reset symlink due to node/git/windows problems
         bat 'if EXIST src\\github.com\\keybase\\client\\shared cd src\\github.com\\keybase\\client && git checkout shared'
         bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\shared cd src\\github.com\\keybase\\client && git checkout desktop/shared'
-        bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\renderer\\fonts cd src\\github.com\\keybase\\client && git checkout desktop/renderer/fonts'
+        bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\renderer\\fonts cd src\\github.com\\keybase\\client && rd desktop\\renderer\\fonts'
         parallel(
             checkout_client: {
                 dir('src/github.com/keybase/client') {

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -25,10 +25,10 @@ def doBuild() {
         bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\shared cd src\\github.com\\keybase\\client && git checkout desktop/shared'
         bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\renderer\\fonts cd src\\github.com\\keybase\\client && rd desktop\\renderer\\fonts'
         parallel(
-            checkout_client: { checkout_repo('client', ClientRevision) },
-            checkout_kbfs: { checkout_repo('kbfs', KBFSRevision) },
-            checkout_updater: { checkout_repo('go-updater', UpdaterRevision) },
-            checkout_release: { checkout_repo('release', ReleaseRevision) },
+            checkout_client: { checkout_keybase('client', ClientRevision) },
+            checkout_kbfs: { checkout_keybase('kbfs', KBFSRevision) },
+            checkout_updater: { checkout_keybase('go-updater', UpdaterRevision) },
+            checkout_release: { checkout_keybase('release', ReleaseRevision) },
         )
     }
     // Make sure any previous desktop build is deleted

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -9,66 +9,62 @@ def doBuild() {
         // Reset symlink due to node/git/windows problems
         bat 'if EXIST src\\github.com\\keybase\\client\\shared cd src\\github.com\\keybase\\client && git checkout shared'
         bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\shared cd src\\github.com\\keybase\\client && git checkout desktop/shared'
-        parallel(            
-            checkout([
-                poll: false,
-                scm: [
-                    $class: 'GitSCM',
-                    branches: [[name: '${ClientRevision}']],
-                    doGenerateSubmoduleConfigurations: false,
-                    extensions: [[
-                        $class: 'RelativeTargetDirectory',
-                        relativeTargetDir: 'src\\github.com\\keybase\\client'
-                    ]], 
-                    submoduleCfg: [],
-                    userRemoteConfigs: [[url: 'https://github.com/keybase/client.git']]
-                ],
-            ])
-
-
-            checkout([
-                poll: false, 
-                scm: [
-                    $class: 'GitSCM',
-                    branches: [[name: '${KBFSRevision}']],
-                    doGenerateSubmoduleConfigurations: false,
-                    extensions: [[
-                        $class: 'RelativeTargetDirectory',
-                        relativeTargetDir: 'src\\github.com\\keybase\\kbfs'
-                    ]],
-                    submoduleCfg: [],
-                    userRemoteConfigs: [[url: 'https://github.com/keybase/kbfs.git']]
-                ],
-            ])
-            checkout([
-                poll: false, 
-                scm: [
-                    $class: 'GitSCM',
-                    branches: [[name: '${UpdaterRevision}']],
-                    doGenerateSubmoduleConfigurations: false,
-                    extensions: [[
-                        $class: 'RelativeTargetDirectory',
-                        relativeTargetDir: 'src\\github.com\\keybase\\go-updater'
-                    ]],
-                    submoduleCfg: [],
-                    userRemoteConfigs: [[url: 'https://github.com/keybase/go-updater.git']]
-                ],
-            ])            
-            checkout([
-                poll: false, 
-                scm: [
-                    $class: 'GitSCM',
-                    branches: [[name: '${ReleaseRevision}']],
-                    doGenerateSubmoduleConfigurations: false,
-                    extensions: [[
-                        $class: 'RelativeTargetDirectory',
-                        relativeTargetDir: 'src\\github.com\\keybase\\release'
-                    ]],
-                    submoduleCfg: [],
-                    userRemoteConfigs: [[url: 'https://github.com/keybase/release.git']]
-                ],
-            ])            
-        )
+        checkout([
+            poll: false,
+            scm: [
+                $class: 'GitSCM',
+                branches: [[name: '${ClientRevision}']],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [[
+                    $class: 'RelativeTargetDirectory',
+                    relativeTargetDir: 'src\\github.com\\keybase\\client'
+                ]], 
+                submoduleCfg: [],
+                userRemoteConfigs: [[url: 'https://github.com/keybase/client.git']]
+            ],
+        ])
+        checkout([
+            poll: false, 
+            scm: [
+                $class: 'GitSCM',
+                branches: [[name: '${KBFSRevision}']],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [[
+                    $class: 'RelativeTargetDirectory',
+                    relativeTargetDir: 'src\\github.com\\keybase\\kbfs'
+                ]],
+                submoduleCfg: [],
+                userRemoteConfigs: [[url: 'https://github.com/keybase/kbfs.git']]
+            ],
+        ])
+        checkout([
+            poll: false, 
+            scm: [
+                $class: 'GitSCM',
+                branches: [[name: '${UpdaterRevision}']],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [[
+                    $class: 'RelativeTargetDirectory',
+                    relativeTargetDir: 'src\\github.com\\keybase\\go-updater'
+                ]],
+                submoduleCfg: [],
+                userRemoteConfigs: [[url: 'https://github.com/keybase/go-updater.git']]
+            ],
+        ])            
+        checkout([
+            poll: false, 
+            scm: [
+                $class: 'GitSCM',
+                branches: [[name: '${ReleaseRevision}']],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [[
+                    $class: 'RelativeTargetDirectory',
+                    relativeTargetDir: 'src\\github.com\\keybase\\release'
+                ]],
+                submoduleCfg: [],
+                userRemoteConfigs: [[url: 'https://github.com/keybase/release.git']]
+            ],
+        ])            
     }
     stage('Build Client') {
         bat '"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && src\\github.com\\keybase\\client\\packaging\\windows\\build_prerelease.cmd'

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -11,58 +11,66 @@ def doBuild() {
         bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\shared cd src\\github.com\\keybase\\client && git checkout desktop/shared'
         parallel(
             checkout_client: {
-                dir('src/github.com/keybase/client') {                        
-                    checkout([
-                        poll: false,
-                        scm: [
-                            $class: 'GitSCM',
-                            branches: [[name: '${ClientRevision}']],
-                            doGenerateSubmoduleConfigurations: false,
-                            submoduleCfg: [],
-                            userRemoteConfigs: [[url: 'https://github.com/keybase/client.git']]
-                        ],
-                    ])
+                dir('src/github.com/keybase/client') {
+                    retry (3) {                        
+                        checkout([
+                            poll: false,
+                            scm: [
+                                $class: 'GitSCM',
+                                branches: [[name: '${ClientRevision}']],
+                                doGenerateSubmoduleConfigurations: false,
+                                submoduleCfg: [],
+                                userRemoteConfigs: [[url: 'https://github.com/keybase/client.git']]
+                            ],
+                        ])
+                    }
                 }
             },
             checkout_kbfs: {
-                dir('src/github.com/keybase/kbfs') {                        
-                    checkout([
-                        poll: false, 
-                        scm: [
-                            $class: 'GitSCM',
-                            branches: [[name: '${KBFSRevision}']],
-                            doGenerateSubmoduleConfigurations: false,
-                            userRemoteConfigs: [[url: 'https://github.com/keybase/kbfs.git']]
-                        ],
-                    ])
+                dir('src/github.com/keybase/kbfs') {
+                    retry (3) {                        
+                        checkout([
+                            poll: false, 
+                            scm: [
+                                $class: 'GitSCM',
+                                branches: [[name: '${KBFSRevision}']],
+                                doGenerateSubmoduleConfigurations: false,
+                                userRemoteConfigs: [[url: 'https://github.com/keybase/kbfs.git']]
+                            ],
+                        ])
+                    }
                 }
             },
             checkout_updater: {
-                dir('src/github.com/keybase/go-updater') {                        
-                    checkout([
-                        poll: false, 
-                        scm: [
-                            $class: 'GitSCM',
-                            branches: [[name: '${UpdaterRevision}']],
-                            doGenerateSubmoduleConfigurations: false,
-                            submoduleCfg: [],
-                            userRemoteConfigs: [[url: 'https://github.com/keybase/go-updater.git']]
-                        ],
-                    ])
+                dir('src/github.com/keybase/go-updater') {     
+                    retry (3) {                   
+                        checkout([
+                            poll: false, 
+                            scm: [
+                                $class: 'GitSCM',
+                                branches: [[name: '${UpdaterRevision}']],
+                                doGenerateSubmoduleConfigurations: false,
+                                submoduleCfg: [],
+                                userRemoteConfigs: [[url: 'https://github.com/keybase/go-updater.git']]
+                            ],
+                        ])
+                    }
                 }
             },
             checkout_release: {
-                dir('src/github.com/keybase/release') {                        
-                    checkout([
-                        poll: false, 
-                        scm: [
-                            $class: 'GitSCM',
-                            branches: [[name: '${ReleaseRevision}']],
-                            doGenerateSubmoduleConfigurations: false,
-                            submoduleCfg: [],
-                            userRemoteConfigs: [[url: 'https://github.com/keybase/release.git']]
-                        ],
-                    ])
+                dir('src/github.com/keybase/release') {
+                    retry (3) {
+                        checkout([
+                            poll: false, 
+                            scm: [
+                                $class: 'GitSCM',
+                                branches: [[name: '${ReleaseRevision}']],
+                                doGenerateSubmoduleConfigurations: false,
+                                submoduleCfg: [],
+                                userRemoteConfigs: [[url: 'https://github.com/keybase/release.git']]
+                            ],
+                        ])
+                    }
                 }
             }            
         )
@@ -82,9 +90,8 @@ def doBuild() {
         bat 'call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && src\\github.com\\keybase\\client\\packaging\\windows\\doinstaller_wix.cmd'
         archiveArtifacts 'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\*.*'
     }
-    // Disable publishing until ready to merge
-    // if (UpdateChannel != "None"){
-    if (UpdateChannel == "publish_enabled"){    
+    
+    if (UpdateChannel != "None"){    
         stage('Publish to S3') {
             step([
                 $class: 'S3BucketPublisher',

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -52,7 +52,7 @@ def doBuild() {
                 }
             },
             checkout_release: {
-                dir('src/github.com/keybase/go-updater') {                        
+                dir('src/github.com/keybase/release') {                        
                     checkout([
                         poll: false, 
                         scm: [

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -9,62 +9,63 @@ def doBuild() {
         // Reset symlink due to node/git/windows problems
         bat 'if EXIST src\\github.com\\keybase\\client\\shared cd src\\github.com\\keybase\\client && git checkout shared'
         bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\shared cd src\\github.com\\keybase\\client && git checkout desktop/shared'
-        checkout([
-            poll: false,
-            scm: [
-                $class: 'GitSCM',
-                branches: [[name: '${ClientRevision}']],
-                doGenerateSubmoduleConfigurations: false,
-                extensions: [[
-                    $class: 'RelativeTargetDirectory',
-                    relativeTargetDir: 'src\\github.com\\keybase\\client'
-                ]], 
-                submoduleCfg: [],
-                userRemoteConfigs: [[url: 'https://github.com/keybase/client.git']]
-            ],
-        ])
-        checkout([
-            poll: false, 
-            scm: [
-                $class: 'GitSCM',
-                branches: [[name: '${KBFSRevision}']],
-                doGenerateSubmoduleConfigurations: false,
-                extensions: [[
-                    $class: 'RelativeTargetDirectory',
-                    relativeTargetDir: 'src\\github.com\\keybase\\kbfs'
-                ]],
-                submoduleCfg: [],
-                userRemoteConfigs: [[url: 'https://github.com/keybase/kbfs.git']]
-            ],
-        ])
-        checkout([
-            poll: false, 
-            scm: [
-                $class: 'GitSCM',
-                branches: [[name: '${UpdaterRevision}']],
-                doGenerateSubmoduleConfigurations: false,
-                extensions: [[
-                    $class: 'RelativeTargetDirectory',
-                    relativeTargetDir: 'src\\github.com\\keybase\\go-updater'
-                ]],
-                submoduleCfg: [],
-                userRemoteConfigs: [[url: 'https://github.com/keybase/go-updater.git']]
-            ],
-        ])            
-        checkout([
-            poll: false, 
-            scm: [
-                $class: 'GitSCM',
-                branches: [[name: '${ReleaseRevision}']],
-                doGenerateSubmoduleConfigurations: false,
-                extensions: [[
-                    $class: 'RelativeTargetDirectory',
-                    relativeTargetDir: 'src\\github.com\\keybase\\release'
-                ]],
-                submoduleCfg: [],
-                userRemoteConfigs: [[url: 'https://github.com/keybase/release.git']]
-            ],
-        ])            
+        parallel(
+            checkout_client: {
+                dir('src/github.com/keybase/client') {                        
+                    checkout([
+                        poll: false,
+                        scm: [
+                            $class: 'GitSCM',
+                            branches: [[name: '${ClientRevision}']],
+                            doGenerateSubmoduleConfigurations: false,
+                            submoduleCfg: [],
+                            userRemoteConfigs: [[url: 'https://github.com/keybase/client.git']]
+                        ],
+                    ])
+                }
+            },
+            checkout_kbfs: {
+                dir('src/github.com/keybase/kbfs') {                        
+                    checkout([
+                        poll: false, 
+                        scm: [
+                            $class: 'GitSCM',
+                            branches: [[name: '${KBFSRevision}']],
+                            doGenerateSubmoduleConfigurations: false,
+                            userRemoteConfigs: [[url: 'https://github.com/keybase/kbfs.git']]
+                        ],
+                    ])
+                }
+            },
+            checkout_updater: {
+                dir('src/github.com/keybase/go-updater') {                        
+                    checkout([
+                        poll: false, 
+                        scm: [
+                            $class: 'GitSCM',
+                            branches: [[name: '${UpdaterRevision}']],
+                            doGenerateSubmoduleConfigurations: false,
+                            submoduleCfg: [],
+                            userRemoteConfigs: [[url: 'https://github.com/keybase/go-updater.git']]
+                        ],
+                    ])
+                }
+            },
+            checkout_release: {
+                dir('src/github.com/keybase/go-updater') {                        
+                    checkout([
+                        poll: false, 
+                        scm: [
+                            $class: 'GitSCM',
+                            branches: [[name: '${ReleaseRevision}']],
+                            doGenerateSubmoduleConfigurations: false,
+                            submoduleCfg: [],
+                            userRemoteConfigs: [[url: 'https://github.com/keybase/release.git']]
+                        ],
+                    ])
+                }
+            }            
+        )
     }
     stage('Build Client') {
         bat '"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && src\\github.com\\keybase\\client\\packaging\\windows\\build_prerelease.cmd'

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -4,69 +4,210 @@ def getCommit(path) {
     }
 }
 
-def doBuild(){
-  stage 'Checkout Client'
-  bat 'if EXIST src\\github.com\\keybase\\client\\shared cd src\\github.com\\keybase\\client && git checkout shared'
-  bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\shared cd src\\github.com\\keybase\\client && git checkout desktop/shared'
-  checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${ClientRevision}']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'src\\github.com\\keybase\\client']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/keybase/client.git']]]
-  stage 'Checkout KBFS'
-  checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${KBFSRevision}']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'src\\github.com\\keybase\\kbfs']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/keybase/kbfs.git']]]
-  stage 'Checkout go-updater'
-  checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${UpdaterRevision}']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'src\\github.com\\keybase\\go-updater']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/keybase/go-updater.git']]]
-  stage 'Checkout release'
-  checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${ReleaseRevision}']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'src\\github.com\\keybase\\release']], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/keybase/release.git']]]
-  bat '''
-    if EXIST src\\github.com\\keybase\\client\\desktop\\release rmdir /q /s src\\github.com\\keybase\\client\\desktop\\release
-    path
-  '''
-  
-  stage 'Build Client'
-  bat '"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && src\\github.com\\keybase\\client\\packaging\\windows\\build_prerelease.cmd' 
-  stage 'Build UI'
-  bat 'src\\github.com\\keybase\\client\\packaging\\windows\\buildui.bat'
-  stage 'Build Installer'
-  bat 'call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && src\\github.com\\keybase\\client\\packaging\\windows\\doinstaller_wix.cmd'
-  archiveArtifacts 'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\*.*'
-
-  if (UpdateChannel != "None"){
-    stage 'Publish to S3'
-
-    step([$class: 'S3BucketPublisher', dontWaitForConcurrentBuildCompletion: false, entries: [[bucket: 'prerelease.keybase.io/windows', excludedFile: '', flatten: true, gzipFiles: false, keepForever: false, managedArtifacts: false, noUploadOnFailure: true, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: 'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\*.exe', storageClass: 'STANDARD', uploadFromSlave: true, useServerSideEncryption: false]], profileName: 'keybase', userMetadata: []])
-    step([$class: 'S3BucketPublisher', dontWaitForConcurrentBuildCompletion: false, entries: [[bucket: 'prerelease.keybase.io', excludedFile: '', flatten: true, gzipFiles: false, keepForever: false, managedArtifacts: false, noUploadOnFailure: true, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: 'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\update-windows-prod-test-v2.json', storageClass: 'STANDARD', uploadFromSlave: true, useServerSideEncryption: false]], profileName: 'keybase', userMetadata: []])
-  }
-
-  if (UpdateChannel == "Smoke"){
-    def clientCommit = getCommit('src\\github.com\\keybase\\client')
-    def kbfsCommit =  getCommit('src\\github.com\\keybase\\kbfs')
-    def updaterCommit =  getCommit('src\\github.com\\keybase\\go-updater')
-    def releaseCommit =  getCommit('src\\github.com\\keybase\\release')
-    def smokeASemVer = ''
-    dir('src\\github.com\\keybase\\client\\go\\keybase') {
-        smokeASemVer = bat(returnStdout: true, script: '@echo off && winresource.exe -cv').trim()
+def doBuild() {
+    parallel(
+        stage('Checkout Client') {
+            // Reset symlink due to node/git/windows problems
+            bat 'if EXIST src\\github.com\\keybase\\client\\shared cd src\\github.com\\keybase\\client && git checkout shared'
+            bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\shared cd src\\github.com\\keybase\\client && git checkout desktop/shared'
+            checkout([
+                poll: false,
+                scm: [
+                    $class: 'GitSCM',
+                    branches: [[name: '${ClientRevision}']],
+                    doGenerateSubmoduleConfigurations: false,
+                    extensions: [[
+                        $class: 'RelativeTargetDirectory',
+                        relativeTargetDir: 'src\\github.com\\keybase\\client'
+                    ]], 
+                    submoduleCfg: [],
+                    userRemoteConfigs: [[url: 'https://github.com/keybase/client.git']]
+                ],
+            ])
+        }
+        stage('Checkout KBFS') {
+            checkout([
+                poll: false, 
+                scm: [
+                    $class: 'GitSCM',
+                    branches: [[name: '${KBFSRevision}']],
+                    doGenerateSubmoduleConfigurations: false,
+                    extensions: [[
+                        $class: 'RelativeTargetDirectory',
+                        relativeTargetDir: 'src\\github.com\\keybase\\kbfs'
+                    ]],
+                    submoduleCfg: [],
+                    userRemoteConfigs: [[url: 'https://github.com/keybase/kbfs.git']]
+                ],
+            ])
+        }
+        stage('Checkout go-updater') {
+            checkout([
+                poll: false, 
+                scm: [
+                    $class: 'GitSCM',
+                    branches: [[name: '${UpdaterRevision}']],
+                    doGenerateSubmoduleConfigurations: false,
+                    extensions: [[
+                        $class: 'RelativeTargetDirectory',
+                        relativeTargetDir: 'src\\github.com\\keybase\\go-updater'
+                    ]],
+                    submoduleCfg: [],
+                    userRemoteConfigs: [[url: 'https://github.com/keybase/go-updater.git']]
+                ],
+            ])            
+        }        
+        stage('Checkout Release') {
+            checkout([
+                poll: false, 
+                scm: [
+                    $class: 'GitSCM',
+                    branches: [[name: '${ReleaseRevision}']],
+                    doGenerateSubmoduleConfigurations: false,
+                    extensions: [[
+                        $class: 'RelativeTargetDirectory',
+                        relativeTargetDir: 'src\\github.com\\keybase\\release'
+                    ]],
+                    submoduleCfg: [],
+                    userRemoteConfigs: [[url: 'https://github.com/keybase/release.git']]
+                ],
+            ])            
+        }
+    )
+    stage('Build Client') {
+        bat '"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && src\\github.com\\keybase\\client\\packaging\\windows\\build_prerelease.cmd'
+    } 
+    stage('Build UI') {
+        // Make sure any previous desktop build is deleted
+        bat '''
+            if EXIST src\\github.com\\keybase\\client\\desktop\\release rmdir /q /s src\\github.com\\keybase\\client\\desktop\\release
+            path
+        '''                
+        bat 'src\\github.com\\keybase\\client\\packaging\\windows\\buildui.bat'
     }
-    build job: 'windows-installer-pipeline', parameters: [string(name: 'ClientRevision', value: "${clientCommit}"), string(name: 'KBFSRevision', value: "${kbfsCommit}"), string(name: 'UpdaterRevision', value: "${updaterCommit}"), string(name: 'ReleaseRevision', value: "${releaseCommit}"), string(name: 'DOKAN_PATH', value: "${DOKAN_PATH}"), string(name: 'UpdateChannel', value: 'Smoke2'), string(name: 'SmokeASemVer', value: "${smokeASemVer}")], wait: false
-  }
-  if (UpdateChannel == "Smoke2"){
-    stage 'Publish smoke updater jsons to S3'
-    step([$class: 'S3BucketPublisher', dontWaitForConcurrentBuildCompletion: false, entries: [[bucket: 'prerelease.keybase.io/windows-support', excludedFile: 'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\update-windows-prod-test-v2.json', flatten: true, gzipFiles: false, keepForever: false, managedArtifacts: false, noUploadOnFailure: true, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: 'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\*.json', storageClass: 'STANDARD', uploadFromSlave: true, useServerSideEncryption: false]], profileName: 'keybase', userMetadata: []])
-    def smokeBSemVer = ''
-    dir('src\\github.com\\keybase\\client\\go\\keybase') {
-        smokeBSemVer = bat(returnStdout: true, script: '@echo off && winresource.exe -cv').trim()
+    stage('Build Installer') {
+        bat 'call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && src\\github.com\\keybase\\client\\packaging\\windows\\doinstaller_wix.cmd'
+        archiveArtifacts 'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\*.*'
     }
-    withCredentials([[$class: 'StringBinding', credentialsId: 'KEYBASE_TOKEN', variable: 'KEYBASE_TOKEN']]) {
-      dir('src\\github.com\\keybase\\release') {
-          bat 'release announce-build --build-a="${SmokeASemVer}" --build-b="${smokeBSemVer}" --platform="windows"'
-      }
+    // Disable publishing until ready to merge
+    // if (UpdateChannel != "None"){
+    if (UpdateChannel == "publish_enabled"){    
+        stage('Publish to S3') {
+            step([
+                $class: 'S3BucketPublisher',
+                dontWaitForConcurrentBuildCompletion: false,
+                entries: [[
+                    bucket: 'prerelease.keybase.io/windows',
+                    excludedFile: '',
+                    flatten: true,
+                    gzipFiles: false,
+                    keepForever: false,
+                    managedArtifacts: false,
+                    noUploadOnFailure: true,
+                    selectedRegion: 'us-east-1',
+                    showDirectlyInBrowser: false,
+                    sourceFile: 'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\*.exe',
+                    storageClass: 'STANDARD',
+                    uploadFromSlave: true,
+                    useServerSideEncryption: false
+                ]],
+                profileName: 'keybase',
+                userMetadata: []
+            ])
+            step([
+                $class: 'S3BucketPublisher',
+                dontWaitForConcurrentBuildCompletion: false,
+                entries: [[
+                    bucket: 'prerelease.keybase.io',
+                    excludedFile: '',
+                    flatten: true,
+                    gzipFiles: false,
+                    keepForever: false,
+                    managedArtifacts: false,
+                    noUploadOnFailure: true,
+                    selectedRegion: 'us-east-1',
+                    showDirectlyInBrowser: false,
+                    sourceFile: 'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\update-windows-prod-test-v2.json',
+                    storageClass: 'STANDARD',
+                    uploadFromSlave: true,
+                    useServerSideEncryption: false
+                ]],
+            profileName: 'keybase',
+            userMetadata: []])
+        }
     }
-  }
+
+    if (UpdateChannel == "Smoke"){
+        stage('Invoke SmokeB build') {
+            def clientCommit = getCommit('src\\github.com\\keybase\\client')
+            def kbfsCommit =  getCommit('src\\github.com\\keybase\\kbfs')
+            def updaterCommit =  getCommit('src\\github.com\\keybase\\go-updater')
+            def releaseCommit =  getCommit('src\\github.com\\keybase\\release')
+            def smokeASemVer = ''
+            dir('src\\github.com\\keybase\\client\\go\\keybase') {
+                smokeASemVer = bat(returnStdout: true, script: '@echo off && winresource.exe -cv').trim()
+            }
+            build([
+                job: 'windows-installer-pipeline',
+                parameters: [
+                    string(name: 'ClientRevision', value: "${clientCommit}"),
+                    string(name: 'KBFSRevision', value: "${kbfsCommit}"),
+                    string(name: 'UpdaterRevision', value: "${updaterCommit}"),
+                    string(name: 'ReleaseRevision', value: "${releaseCommit}"),
+                    string(name: 'DOKAN_PATH', value: "${DOKAN_PATH}"),
+                    string(name: 'UpdateChannel', value: 'Smoke2'),
+                    string(name: 'SmokeASemVer', value: "${smokeASemVer}"
+                )],
+                wait: false
+            ])
+        }
+    }
+    if (UpdateChannel == "Smoke2") {
+        stage('Publish smoke updater jsons to S3') {
+            step([
+                $class: 'S3BucketPublisher',
+                dontWaitForConcurrentBuildCompletion: false,
+                entries: [[
+                    bucket: 'prerelease.keybase.io/windows-support',
+                    excludedFile: 'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\update-windows-prod-test-v2.json',
+                    flatten: true,
+                    gzipFiles: false,
+                    keepForever: false,
+                    managedArtifacts: false,
+                    noUploadOnFailure: true,
+                    selectedRegion: 'us-east-1',
+                    showDirectlyInBrowser: false,
+                    sourceFile: 'src\\github.com\\keybase\\client\\packaging\\windows\\${BUILD_TAG}\\*.json',
+                    storageClass: 'STANDARD',
+                    uploadFromSlave: true,
+                    useServerSideEncryption: false
+                ]],
+                profileName: 'keybase',
+                userMetadata: []
+            ])
+            def smokeBSemVer = ''
+            dir('src\\github.com\\keybase\\client\\go\\keybase') {
+                smokeBSemVer = bat(returnStdout: true, script: '@echo off && winresource.exe -cv').trim()
+            }
+            withCredentials([[
+                $class: 'StringBinding',
+                credentialsId: 'KEYBASE_TOKEN',
+                variable: 'KEYBASE_TOKEN'
+                ]]) {
+                dir('src\\github.com\\keybase\\release') {
+                    bat "release announce-build --build-a=\"${params.SmokeASemVer}\" --build-b=\"${smokeBSemVer}\" --platform=\"windows\""
+                }
+            }
+        }
+    }
 }
 
 // Invoke the build with a separate workspace for each executor,
 // and with GOPATH set to that workspace
 node ('windows-release') {
-  ws("${WORKSPACE}_${EXECUTOR_NUMBER}") {
-    withEnv(["GOPATH=${pwd()}"]) {
-      doBuild()
+    ws("${WORKSPACE}_${EXECUTOR_NUMBER}") {
+        withEnv(["GOPATH=${pwd()}"]) {
+            doBuild()
+        }
     }
-  }
 }

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -141,7 +141,7 @@ def doBuild() {
                 smokeASemVer = bat(returnStdout: true, script: '@echo off && winresource.exe -cv').trim()
             }
             build([
-                job: '${env.JOB_NAME}',
+                job: "${env.JOB_NAME}",
                 parameters: [
                     string(name: 'ClientRevision', value: "${clientCommit}"),
                     string(name: 'KBFSRevision', value: "${kbfsCommit}"),

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -5,8 +5,9 @@ def getCommit(path) {
 }
 
 def doBuild() {
-    parallel(
-        stage('Checkout Client') {
+    stage('Checkout Client') {
+        parallel(
+            
             // Reset symlink due to node/git/windows problems
             bat 'if EXIST src\\github.com\\keybase\\client\\shared cd src\\github.com\\keybase\\client && git checkout shared'
             bat 'if EXIST src\\github.com\\keybase\\client\\desktop\\shared cd src\\github.com\\keybase\\client && git checkout desktop/shared'
@@ -24,8 +25,8 @@ def doBuild() {
                     userRemoteConfigs: [[url: 'https://github.com/keybase/client.git']]
                 ],
             ])
-        }
-        stage('Checkout KBFS') {
+
+
             checkout([
                 poll: false, 
                 scm: [
@@ -40,8 +41,6 @@ def doBuild() {
                     userRemoteConfigs: [[url: 'https://github.com/keybase/kbfs.git']]
                 ],
             ])
-        }
-        stage('Checkout go-updater') {
             checkout([
                 poll: false, 
                 scm: [
@@ -56,8 +55,6 @@ def doBuild() {
                     userRemoteConfigs: [[url: 'https://github.com/keybase/go-updater.git']]
                 ],
             ])            
-        }        
-        stage('Checkout Release') {
             checkout([
                 poll: false, 
                 scm: [
@@ -72,8 +69,8 @@ def doBuild() {
                     userRemoteConfigs: [[url: 'https://github.com/keybase/release.git']]
                 ],
             ])            
-        }
-    )
+        )
+    }
     stage('Build Client') {
         bat '"%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat" && src\\github.com\\keybase\\client\\packaging\\windows\\build_prerelease.cmd'
     } 

--- a/packaging/windows/Jenkinsfile.groovy
+++ b/packaging/windows/Jenkinsfile.groovy
@@ -141,7 +141,7 @@ def doBuild() {
                 smokeASemVer = bat(returnStdout: true, script: '@echo off && winresource.exe -cv').trim()
             }
             build([
-                job: 'windows-installer-pipeline',
+                job: '${env.JOB_NAME}',
                 parameters: [
                     string(name: 'ClientRevision', value: "${clientCommit}"),
                     string(name: 'KBFSRevision', value: "${kbfsCommit}"),

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wixproj
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wixproj
@@ -15,7 +15,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;GuiSourceDir=$(SolutionDir)\..\..\..\desktop\release\win32-ia32\Keybase-win32-ia32</DefineConstants>
+    <DefineConstants>Debug;GuiSourceDir=$(GOPATH)\src\github.com\keybase\client\desktop\release\win32-ia32\Keybase-win32-ia32</DefineConstants>
     <SuppressIces>ICE20;ICE38</SuppressIces>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
@@ -23,7 +23,7 @@
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <SuppressValidation>False</SuppressValidation>
     <SuppressIces>ICE20;ICE38</SuppressIces>
-    <DefineConstants>GuiSourceDir=$(SolutionDir)\..\..\..\desktop\release\win32-ia32\Keybase-win32-ia32</DefineConstants>
+    <DefineConstants>GuiSourceDir=$(GOPATH)\src\github.com\keybase\client\desktop\release\win32-ia32\Keybase-win32-ia32</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="gui.wxs" />

--- a/packaging/windows/build_prerelease.cmd
+++ b/packaging/windows/build_prerelease.cmd
@@ -2,8 +2,6 @@
 set GOARCH=386
 set GO15VENDOREXPERIMENT=1
 
-:: for Jenkins
-if DEFINED WORKSPACE set GOPATH=%WORKSPACE%
 if NOT DEFINED DOKAN_PATH set DOKAN_PATH=%GOPATH%\bin\dokan-dev\dokan-v1.0.0-RC4.2
 echo DOKAN_PATH %DOKAN_PATH%
 
@@ -17,6 +15,8 @@ pushd %GOPATH%\src\github.com\keybase\client\go\keybase
 del keybase.exe
 go version
 go generate
+
+if DEFINED BUILD_NUMBER set KEYBASE_WINBUILD=%BUILD_NUMBER%
 
 for /f %%i in ('winresource.exe -cv') do set KEYBASE_VERSION=%%i
 echo KEYBASE_VERSION %KEYBASE_VERSION%
@@ -61,10 +61,9 @@ pushd %GOPATH%\src\github.com\keybase\client\go\tools\dokanclean
 go build
 popd
 
-:: Then the desktop:
-pushd  %GOPATH%\src\github.com\keybase\client\desktop
-:: rmdir /s /q node_modules
-npm i
-
-buildui.bat
+:: release
+pushd %GOPATH%\src\github.com\keybase\release
+go build
 popd
+
+

--- a/packaging/windows/buildui.bat
+++ b/packaging/windows/buildui.bat
@@ -1,8 +1,14 @@
-if DEFINED WORKSPACE set GOPATH=%WORKSPACE%
 pushd %GOPATH%\src\github.com\keybase\client\go\keybase
 
 for /f %%i in ('winresource.exe -cv') do set KEYBASE_VERSION=%%i
-echo %KEYBASE_VERSION%
+echo Calling vcvars
 
+echo on
+call "%ProgramFiles(x86)%\\Microsoft Visual Studio 14.0\\vc\\bin\\vcvars32.bat"
+
+echo on
 pushd  %GOPATH%\src\github.com\keybase\client\desktop
+echo Calling npm i
+call npm i
+
 npm run package -- --arch ia32 --platform win32 --appVersion %KEYBASE_VERSION% --icon %GOPATH%\src\github.com\keybase\client\media\icons\Keybase.ico

--- a/packaging/windows/doinstaller_gui.cmd
+++ b/packaging/windows/doinstaller_gui.cmd
@@ -2,8 +2,7 @@
 :: $1 is full path to keybase.exe
 :: todo: specify output?
 ::
-:: For Jenkins:
-if DEFINED WORKSPACE set GOPATH=%WORKSPACE%
+
 set GOARCH=386
 ::
 :: get the target build folder. Assume winresource.exe has been built.


### PR DESCRIPTION
I think we're ready to go with this finally. Note that since multi executor was activated on the windows release slave, the regular smoke build is broken anyway, so we may as well switch to this sooner as later.
@maxtaco @jzila