### PR TITLE
Timestamps for chat

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -367,9 +367,9 @@ function * _loadMoreMessages (): SagaGenerator<any, any> {
   let newMessages = []
   messages.forEach((message, idx) => {
     if (idx >= 2) {
-      const maybe = _maybeAddTimestamp(messages[idx], messages[idx - 1])
-      if (maybe !== null) {
-        newMessages.push(maybe)
+      const timestamp = _maybeAddTimestamp(messages[idx], messages[idx - 1])
+      if (timestamp !== null) {
+        newMessages.push(timestamp)
       }
     }
     newMessages.push(message)

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -408,7 +408,7 @@ function _threadToPagination (thread) {
 }
 
 function _maybeAddTimestamp (message: Message, prevMessage: Message): MaybeTimestamp {
-  if (message.type !== 'Text' || prevMessage.type !== 'Text') {
+  if (prevMessage.type === 'Timestamp') {
     return null
   }
   if (message.timestamp - prevMessage.timestamp > Constants.howLongBetweenTimestampsMs) { // ms

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -214,8 +214,7 @@ function * _postMessage (action: PostMessage): SagaGenerator<any, any> {
     }
     let messages = []
     if (conversationState && conversationState.messages !== null) {
-      const messageList = conversationState.messages.toJS()
-      const prevMessage = messageList[messageList.length - 1]
+      const prevMessage = conversationState.messages.get(conversationState.messages.size - 1)
       const timestamp = _maybeAddTimestamp(message, prevMessage)
       if (timestamp !== null) {
         messages.push(timestamp)
@@ -265,8 +264,7 @@ function * _incomingMessage (action: IncomingMessage): SagaGenerator<any, any> {
         } else {
           // How long was it between the previous message and this one?
           if (conversationState && conversationState.messages !== null) {
-            const messages = conversationState.messages.toJS()
-            const prevMessage = messages[messages.length - 1]
+            const prevMessage = conversationState.messages.get(conversationState.messages.size - 1)
             const timestamp = _maybeAddTimestamp(message, prevMessage)
             if (timestamp !== null) {
               yield put({

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -205,7 +205,7 @@ function * _postMessage (action: PostMessage): SagaGenerator<any, any> {
       conversationIDKey: action.payload.conversationIDKey,
     }
 
-    // Should we add a timestamp before our new message?
+    // Time to decide: should we add a timestamp before our new message?
     const conversationStateSelector = (state: TypedState) => state.chat.get('conversationStates', Map()).get(conversationIDKey)
     const conversationState = yield select(conversationStateSelector)
     let messages = []

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -404,7 +404,7 @@ function _threadToPagination (thread) {
 }
 
 function _maybeAddTimestamp (message: Message, prevMessage: Message): MaybeTimestamp {
-  if (prevMessage.type === 'Timestamp') {
+  if (prevMessage.type === 'Timestamp' || message.type === 'Timestamp') {
     return null
   }
   if (message.timestamp - prevMessage.timestamp > Constants.howLongBetweenTimestampsMs) { // ms

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -206,12 +206,8 @@ function * _postMessage (action: PostMessage): SagaGenerator<any, any> {
     }
 
     // Should we add a timestamp before our new message?
-    // TODO short-term if we haven't seen this in the conversation list we'll refresh the inbox. Instead do an integration w/ gregor
     const conversationStateSelector = (state: TypedState) => state.chat.get('conversationStates', Map()).get(conversationIDKey)
     const conversationState = yield select(conversationStateSelector)
-    if (!conversationState) {
-      yield put(loadInbox())
-    }
     let messages = []
     if (conversationState && conversationState.messages !== null) {
       const prevMessage = conversationState.messages.get(conversationState.messages.size - 1)

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -416,7 +416,6 @@ function _maybeAddTimestamp (message: Message, prevMessage: Message): MaybeTimes
   return null
 }
 
-
 function _unboxedToMessage (message: MessageUnboxed, idx: number, yourName, conversationIDKey: ConversationIDKey): Message {
   if (message.state === LocalMessageUnboxedState.valid) {
     const payload = message.valid

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -30,13 +30,13 @@ import type {
   LoadedInbox,
   MaybeTimestamp,
   Message,
-  UnhandledMessage,
   NewChat,
   OpenFolder,
   PostMessage,
   SelectConversation,
   SetupNewChatHandler,
   StartConversation,
+  UnhandledMessage,
   UpdateMetadata,
 } from '../constants/chat'
 
@@ -443,7 +443,7 @@ function _unboxedToMessage (message: MessageUnboxed, idx: number, yourName, conv
             outboxID: payload.clientHeader.outboxID && payload.clientHeader.outboxID.toString('hex'),
           }
         default:
-          const unhandled: MessageUnhandled = {
+          const unhandled: UnhandledMessage = {
             ...common,
             type: 'Unhandled',
           }

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -255,7 +255,7 @@ class ConversationList extends Component<void, Props, State> {
 }
 
 class CellSizeCache extends defaultCellMeasurerCellSizeCache {
-  _indexToID: (index: number) => number;
+  _indexToID: (index: number) => ?number;
 
   constructor (indexToID) {
     super({uniformColumnWidth: true})

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -57,7 +57,7 @@ class ConversationList extends Component<void, Props, State> {
       // We want a stable key -- messages have an outboxID but no messageID,
       // then later gain a messageID.  So if we prefer outboxIDs to messageIDs
       // for the key, every row keeps its key.
-      const id = message && (message.outboxID || message.messageID)
+      const id = message && (message.outboxID || message.messageID || message.timestamp)
       if (id == null) {
         console.warn('id is null for index:', messageIndex)
       }

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -54,10 +54,17 @@ class ConversationList extends Component<void, Props, State> {
       // minus one because loader message is there
       const messageIndex = index - 1
       const message = this.state.messages.get(messageIndex)
-      // We want a stable key -- messages have an outboxID but no messageID,
-      // then later gain a messageID.  So if we prefer outboxIDs to messageIDs
-      // for the key, every row keeps its key.
-      const id = message && (message.outboxID || message.messageID || message.timestamp)
+      let id
+      if (message) {
+        if (message.type === 'Timestamp') {
+          id = message.timestamp
+        } else {
+          // We want a stable key -- messages have an outboxID but no
+          // messageID, then later gain a messageID.  So if we prefer
+          // outboxIDs to messageIDs for the key, every row keeps its key.
+          id = message && (message.outboxID || message.messageID)
+        }
+      }
       if (id == null) {
         console.warn('id is null for index:', messageIndex)
       }

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -7,25 +7,6 @@ import {Box} from '../../../common-adapters'
 
 import type {Message} from '../../../constants/chat'
 
-const momentFormatter = (timestamp: number): string => {
-  const now = moment()
-  const then = moment(timestamp)
-
-  if (now.diff(then, 'months') > 6) {
-    return 'MMM DD YYYY HH:mm A' // Jan 5 2016 4:34 PM
-  } else if (now.diff(then, 'days') > 6) {
-    return 'MMM DD HH:mm A' // Jan 5 4:34 PM
-  } else if (now.diff(then, 'hours') > 22) {
-    return 'ddd HH:mm A' // Wed 4:34 PM
-  } else {
-    return 'HH:mm A' // 4:34 PM
-  }
-}
-
-const timestampWithFormat = (timestamp: number, format: string): string => {
-  return moment(timestamp).format(format)
-}
-
 const factory = (message: Message, includeHeader: boolean, index: number, key: string, isFirstNewMessage: boolean, style: Object, isScrolling: boolean, onAction: (event: any) => void, isSelected: boolean) => {
   if (!message) {
     return <Box key={key} style={style} />

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -1,9 +1,30 @@
 // @flow
 import MessageText from './text'
+import Timestamp from './timestamp'
+import moment from 'moment'
 import React from 'react'
 import {Box} from '../../../common-adapters'
 
 import type {Message} from '../../../constants/chat'
+
+const momentFormatter = (timestamp: number): string => {
+  const now = moment()
+  const then = moment(timestamp)
+
+  if (now.diff(then, 'months') > 6) {
+    return 'MMM DD YYYY HH:mm A' // Jan 5 2016 4:34 PM
+  } else if (now.diff(then, 'days') > 6) {
+    return 'MMM DD HH:mm A' // Jan 5 4:34 PM
+  } else if (now.diff(then, 'hours') > 22) {
+    return 'ddd HH:mm A' // Wed 4:34 PM
+  } else {
+    return 'HH:mm A' // 4:34 PM
+  }
+}
+
+const timestampWithFormat = (timestamp: number, format: string): string => {
+  return moment(timestamp).format(format)
+}
 
 const factory = (message: Message, includeHeader: boolean, index: number, key: string, isFirstNewMessage: boolean, style: Object, isScrolling: boolean, onAction: (event: any) => void, isSelected: boolean) => {
   if (!message) {
@@ -22,6 +43,13 @@ const factory = (message: Message, includeHeader: boolean, index: number, key: s
         isFirstNewMessage={isFirstNewMessage}
         isSelected={isSelected}
         onAction={onAction}
+        />
+    case 'Timestamp':
+      const timestamp = timestampWithFormat(message.timestamp, momentFormatter(message.timestamp))
+      return <Timestamp
+        timestamp={timestamp}
+        key={message.timestamp}
+        style={style}
         />
     default:
       return <Box key={key} style={style} />

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -1,7 +1,7 @@
 // @flow
 import MessageText from './text'
 import Timestamp from './timestamp'
-import moment from 'moment'
+import {formatTimeForMessages} from '../../../util/timestamp'
 import React from 'react'
 import {Box} from '../../../common-adapters'
 
@@ -45,9 +45,8 @@ const factory = (message: Message, includeHeader: boolean, index: number, key: s
         onAction={onAction}
         />
     case 'Timestamp':
-      const timestamp = timestampWithFormat(message.timestamp, momentFormatter(message.timestamp))
       return <Timestamp
-        timestamp={timestamp}
+        timestamp={formatTimeForMessages(message.timestamp)}
         key={message.timestamp}
         style={style}
         />

--- a/shared/chat/conversation/messages/popup.desktop.js
+++ b/shared/chat/conversation/messages/popup.desktop.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import {Box, Icon, PopupMenu, Text} from '../../../common-adapters'
 import {globalStyles, globalColors} from '../../../styles'
-import {timestampToString} from '../../../constants/chat'
+import {formatTimeForMessages} from '../../../util/timestamp'
 import type {TextMessage} from '../../../constants/chat'
 import type {IconType} from '../../../common-adapters/icon'
 
@@ -22,7 +22,7 @@ const TextMessagePopup = ({message: {deviceName, deviceType, timestamp}}: {messa
       <Icon type={iconName} />
       <Text type='BodySmall' style={{color: globalColors.green2}}>ENCRYPTED & SIGNED</Text>
       <Text type='BodySmall' style={{color: globalColors.black_40}}>{`by ${deviceName}`}</Text>
-      <Text type='BodySmall' style={{color: globalColors.black_40}}>{timestampToString(timestamp)}</Text>
+      <Text type='BodySmall' style={{color: globalColors.black_40}}>{formatTimeForMessages(timestamp)}</Text>
     </Box>
   )
 }

--- a/shared/chat/conversation/messages/timestamp.desktop.js
+++ b/shared/chat/conversation/messages/timestamp.desktop.js
@@ -1,0 +1,19 @@
+// @flow
+import React from 'react'
+import {Box, Text} from '../../../common-adapters'
+import {globalStyles, globalMargins, globalColors} from '../../../styles'
+import type {Props} from './timestamp'
+
+const Timestamp = ({timestamp, style}: Props) => (
+  <Box key={timestamp} style={{...globalStyles.flexBoxRow, ...style}}>
+    <Text style={styleText} type='BodySmall'>{timestamp}</Text>
+  </Box>
+)
+
+export const styleText = {
+  padding: globalMargins.xtiny,
+  flex: 1,
+  textAlign: 'center',
+  color: globalColors.black_40,
+}
+export default Timestamp

--- a/shared/chat/conversation/messages/timestamp.js.flow
+++ b/shared/chat/conversation/messages/timestamp.js.flow
@@ -1,0 +1,9 @@
+// @flow
+import {Component} from 'react'
+
+export type Props = {
+  timestamp: string,
+  style: Object,
+}
+
+export default class Timestamp extends Component<void, Props, void> { }

--- a/shared/chat/conversation/messages/timestamp.native.js
+++ b/shared/chat/conversation/messages/timestamp.native.js
@@ -1,0 +1,8 @@
+// @flow
+// import React from 'react'
+
+import type {Props} from './timestamp'
+
+const Timestamp = ({timestamp}: Props) => null
+
+export default Timestamp

--- a/shared/chat/conversations-list/index.desktop.js
+++ b/shared/chat/conversations-list/index.desktop.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import {Box, Text, Avatar, Icon, Usernames} from '../../common-adapters'
 import {globalStyles, globalColors} from '../../styles'
-import {participantFilter, timestampToString} from '../../constants/chat'
+import {participantFilter} from '../../constants/chat'
 import {formatTimeForConversationList} from '../../util/timestamp'
 
 import type {Props} from './'

--- a/shared/chat/conversations-list/index.desktop.js
+++ b/shared/chat/conversations-list/index.desktop.js
@@ -3,6 +3,7 @@ import React from 'react'
 import {Box, Text, Avatar, Icon, Usernames} from '../../common-adapters'
 import {globalStyles, globalColors} from '../../styles'
 import {participantFilter, timestampToString} from '../../constants/chat'
+import {formatTimeForConversationList} from '../../util/timestamp'
 
 import type {Props} from './'
 
@@ -37,7 +38,7 @@ const ConversationList = ({inbox, onSelectConversation, selectedConversation, on
             <Text backgroundMode='Terminal' type='BodySmall' style={noWrapStyle}>{conversation.get('snippet')}</Text>
           </Box>
         </Box>
-        <Text backgroundMode='Terminal' type='BodySmall' style={{marginRight: 4}}>{timestampToString(conversation.get('time'), nowOverride)}</Text>
+        <Text backgroundMode='Terminal' type='BodySmall' style={{marginRight: 4}}>{formatTimeForConversationList(conversation.get('time'), nowOverride)}</Text>
       </Box>)
     })}
   </Box>

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -22,6 +22,9 @@ export type ParticipantItem = UserListItem
 export type MessageID = RPCMessageID
 export type Message = TextMessage | ErrorMessage | UnhandledMessage | TimestampMessage
 
+export type ClientMessage = MessageTimestamp
+export type ServerMessage = MessageText | MessageError | MessageUnhandled
+
 export type TextMessage = {
   type: 'Text',
   message: HiddenString,
@@ -145,12 +148,12 @@ export const updatedMetadata = 'chat:updatedMetadata'
 export const editMessage = 'chat:editMessage'
 export const deleteMessage = 'chat:deleteMessage'
 
-export type AppendMessages = NoErrorTypedAction<'chat:appendMessages', {conversationIDKey: ConversationIDKey, messages: Array<Message>}>
+export type AppendMessages = NoErrorTypedAction<'chat:appendMessages', {conversationIDKey: ConversationIDKey, messages: Array<ServerMessage>}>
 export type LoadInbox = NoErrorTypedAction<'chat:loadInbox', void>
 export type LoadedInbox = NoErrorTypedAction<'chat:loadedInbox', {inbox: List<InboxState>}>
 export type LoadMoreMessages = NoErrorTypedAction<'chat:loadMoreMessages', void>
 export type LoadingMessages = NoErrorTypedAction<'chat:loadingMessages', {conversationIDKey: ConversationIDKey}>
-export type PrependMessages = NoErrorTypedAction<'chat:prependMessages', {conversationIDKey: ConversationIDKey, messages: Array<Message>, moreToLoad: boolean, paginationNext: ?Buffer}>
+export type PrependMessages = NoErrorTypedAction<'chat:prependMessages', {conversationIDKey: ConversationIDKey, messages: Array<ServerMessage>, moreToLoad: boolean, paginationNext: ?Buffer}>
 export type SelectConversation = NoErrorTypedAction<'chat:selectConversation', {conversationIDKey: ConversationIDKey, fromUser: boolean}>
 export type SetupNewChatHandler = NoErrorTypedAction<'chat:setupNewChatHandler', void>
 export type IncomingMessage = NoErrorTypedAction<'chat:incomingMessage', {activity: ChatActivity}>

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -122,7 +122,8 @@ export type State = Record<{
   metaData: Map<string, MetaData>,
 }>
 
-const maxMessagesToLoadAtATime = 50
+export const howLongBetweenTimestampsMs = 1000 * 60 * 15
+export const maxMessagesToLoadAtATime = 50
 
 export const appendMessages = 'chat:appendMessages'
 export const selectConversation = 'chat:selectConversation'
@@ -219,7 +220,6 @@ export {
   conversationIDToKey,
   keyToConversationID,
   makeSnippet,
-  maxMessagesToLoadAtATime,
   participantFilter,
   timestampToString,
 }

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -1,7 +1,6 @@
 // @flow
 import HiddenString from '../util/hidden-string'
 import {Buffer} from 'buffer'
-import moment from 'moment'
 import {Set, List, Map, Record} from 'immutable'
 
 import type {UserListItem} from '../common-adapters/usernames'

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -21,7 +21,7 @@ export type ParticipantItem = UserListItem
 
 export type MessageID = RPCMessageID
 
-export type ClientMessage = MessageTimestamp
+export type ClientMessage = TimestampMessage
 export type ServerMessage = TextMessage | ErrorMessage | UnhandledMessage
 
 export type Message = ClientMessage | ServerMessage

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -20,10 +20,11 @@ export type ConversationIDKey = string
 export type ParticipantItem = UserListItem
 
 export type MessageID = RPCMessageID
-export type Message = TextMessage | ErrorMessage | UnhandledMessage | TimestampMessage
 
 export type ClientMessage = MessageTimestamp
-export type ServerMessage = MessageText | MessageError | MessageUnhandled
+export type ServerMessage = TextMessage | ErrorMessage | UnhandledMessage
+
+export type Message = ClientMessage | ServerMessage
 
 export type TextMessage = {
   type: 'Text',
@@ -189,21 +190,6 @@ function keyToConversationID (key: ConversationIDKey): ConversationID {
   return Buffer.from(key, 'hex')
 }
 
-function timestampToString (time: number, nowOverride?: number): string {
-  const m = moment(time)
-  const now = nowOverride ? moment(nowOverride) : moment()
-  const today = now.clone().startOf('day')
-  const weekOld = today.clone().subtract(7, 'days')
-
-  if (m.isSame(today, 'd')) {
-    return m.format('h:mm A')
-  } else if (m.isAfter(weekOld)) {
-    return m.format('dddd')
-  }
-
-  return m.format('MMM D')
-}
-
 // This is emoji aware hence all the weird ... stuff. See https://mathiasbynens.be/notes/javascript-unicode#iterating-over-symbols
 function makeSnippet (message: ?string = '', max: number) {
   // $FlowIssue flow doesn't understand spread + strings
@@ -224,5 +210,4 @@ export {
   keyToConversationID,
   makeSnippet,
   participantFilter,
-  timestampToString,
 }

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -55,12 +55,12 @@ export type UnhandledMessage = {
   messageID: MessageID,
 }
 
-export type MessageTimestamp = {
+export type TimestampMessage = {
   type: 'Timestamp',
   timestamp: number,
 }
 
-export type MaybeTimestamp = MessageTimestamp | null
+export type MaybeTimestamp = TimestampMessage | null
 
 export const ConversationStateRecord = Record({
   messages: List(),

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -20,6 +20,7 @@ export type ConversationIDKey = string
 export type ParticipantItem = UserListItem
 
 export type MessageID = RPCMessageID
+export type Message = TextMessage | ErrorMessage | UnhandledMessage | TimestampMessage
 
 export type TextMessage = {
   type: 'Text',
@@ -50,7 +51,12 @@ export type UnhandledMessage = {
   messageID: MessageID,
 }
 
-export type Message = TextMessage | ErrorMessage | UnhandledMessage
+export type MessageTimestamp = {
+  type: 'Timestamp',
+  timestamp: number,
+}
+
+export type MaybeTimestamp = MessageTimestamp | null
 
 export const ConversationStateRecord = Record({
   messages: List(),

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -4,13 +4,13 @@ import * as Constants from '../constants/chat'
 import * as WindowConstants from '../constants/window'
 import {Set, List, Map} from 'immutable'
 
-import type {Actions, State, ConversationState, AppendMessages, Message, MessageID} from '../constants/chat'
+import type {Actions, State, ConversationState, AppendMessages, Message, MessageID, ServerMessage} from '../constants/chat'
 
 const {StateRecord, ConversationStateRecord, makeSnippet} = Constants
 const initialState: State = new StateRecord()
 const initialConversation: ConversationState = new ConversationStateRecord()
 
-function dedupeMessages (seenMessages: Set<MessageID>, knownMessages: List<Message>, newMessages: Array<Message>): {seenMessages: Set<MessageID>, updatedMessages: List<Message>, unseenMessages: List<Message>} {
+function dedupeMessages (seenMessages: Set<MessageID>, knownMessages: List<ServerMessage>, newMessages: Array<ServerMessage>): {seenMessages: Set<MessageID>, updatedMessages: List<ServerMessage>, unseenMessages: List<ServerMessage>} {
   const newButSeenMessages = newMessages
     .filter(m => m.messageID && seenMessages.has(m.messageID))
     .reduce((acc, m) => acc.set(m.messageID, m), Map())

--- a/shared/util/timestamp.js
+++ b/shared/util/timestamp.js
@@ -1,0 +1,33 @@
+// @flow
+
+import moment from 'moment'
+
+export function formatTimeForConversationList (time: number, nowOverride?: number): string {
+  const m = moment(time)
+  const now = nowOverride ? moment(nowOverride) : moment()
+  const today = now.clone().startOf('day')
+  const weekOld = today.clone().subtract(7, 'days')
+
+  if (m.isSame(today, 'd')) {
+    return m.format('h:mm A')
+  } else if (m.isAfter(weekOld)) {
+    return m.format('dddd')
+  }
+
+  return m.format('MMM D')
+}
+
+export function formatTimeForMessages (time: number, nowOverride?: number): string {
+  const m = moment(time)
+  const now = nowOverride ? moment(nowOverride) : moment()
+
+  if (now.diff(m, 'months') > 6) {
+    return m.format('MMM DD YYYY h:mm A') // Jan 5 2016 4:34 PM
+  } else if (now.diff(m, 'days') > 6) {
+    return m.format('MMM DD h:mm A') // Jan 5 4:34 PM
+  } else if (now.diff(m, 'hours') > 22) {
+    return m.format('ddd h:mm A') // Wed 4:34 PM
+  } else {
+    return m.format('h:mm A') // 4:34 PM
+  }
+}


### PR DESCRIPTION
@keybase/react-hackers 

Here's a PR for chat timestamps!  Changes:

* On adding a new message ourselves, or receiving a new message, or going through a list of old messages:

* We go through them pairwise, adding a timestamp if the current one is more than a constant (currently 15 mins) newer than the previous one.

* A timestamp is a new kind of Message.  It's the only type without a MessageID (client generated rather than server generated).  I wasn't sure whether that was a good idea, it seems better than the alternatives (like annotating each Message that should also display a timestamp).

* For formatting the timestamps, the messages view uses a different moment formatting string than the timestamps in the conversation list view.  There's less screen space for the conversation list view ones, so it makes sense to provide more detail here.