### PR TITLE
Add revocation warning

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -56,19 +56,6 @@ func (b *Boxer) log() logger.Logger {
 	return b.kbCtx.GetLog()
 }
 
-func (b *Boxer) loadCachedUser(uid gregor1.UID) (*keybase1.UserPlusAllKeys, error) {
-	loader := b.kbCtx.GetCachedUserLoader()
-	if loader == nil {
-		return nil, fmt.Errorf("no CachedUserLoader available in context")
-	}
-	kbUID := keybase1.UID(uid.String())
-	upk, _, err := loader.Load(libkb.NewLoadUserByUIDArg(loader.G(), kbUID))
-	if err != nil {
-		return nil, err
-	}
-	return upk, nil
-}
-
 func (b *Boxer) makeErrorMessage(msg chat1.MessageBoxed, err error) chat1.MessageUnboxed {
 	return chat1.NewMessageUnboxedWithError(chat1.MessageUnboxedError{
 		ErrMsg:      err.Error(),

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -552,7 +552,7 @@ func (b *Boxer) ValidSenderKey(ctx context.Context, sender gregor1.UID, key []by
 	}
 
 	revoked := revokedAt2 != nil
-	validAtCtime := found && (!revoked || revokedAt2.After(ctime2))
+	validAtCtime := (!revoked || revokedAt2.After(ctime2))
 	return validAtCtime, revoked, nil
 }
 

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"time"
 
 	"golang.org/x/crypto/nacl/secretbox"
 	"golang.org/x/net/context"
@@ -55,6 +56,19 @@ func (b *Boxer) log() logger.Logger {
 	return b.kbCtx.GetLog()
 }
 
+func (b *Boxer) loadCachedUser(uid gregor1.UID) (*keybase1.UserPlusAllKeys, error) {
+	loader := b.kbCtx.GetCachedUserLoader()
+	if loader == nil {
+		return nil, fmt.Errorf("no CachedUserLoader available in context")
+	}
+	kbUID := keybase1.UID(uid.String())
+	upk, _, err := loader.Load(libkb.NewLoadUserByUIDArg(loader.G(), kbUID))
+	if err != nil {
+		return nil, err
+	}
+	return upk, nil
+}
+
 func (b *Boxer) makeErrorMessage(msg chat1.MessageBoxed, err error) chat1.MessageUnboxed {
 	return chat1.NewMessageUnboxedWithError(chat1.MessageUnboxedError{
 		ErrMsg:      err.Error(),
@@ -91,7 +105,7 @@ func (b *Boxer) UnboxMessage(ctx context.Context, finder KeyFinder, boxed chat1.
 		return chat1.MessageUnboxed{}, libkb.NewTransientChatUnboxingError(err)
 	}
 
-	pt, headerHash, ierr := b.unboxMessageWithKey(ctx, boxed, matchKey)
+	umwkr, ierr := b.unboxMessageWithKey(ctx, boxed, matchKey)
 	if ierr != nil {
 		b.log().Warning("failed to unbox message: msgID: %d err: %s", boxed.ServerHeader.MessageID,
 			ierr.Error())
@@ -100,6 +114,7 @@ func (b *Boxer) UnboxMessage(ctx context.Context, finder KeyFinder, boxed chat1.
 		}
 		return chat1.MessageUnboxed{}, ierr
 	}
+	pt := umwkr.messagePlaintext
 
 	_, uimap := utils.GetUserInfoMapper(ctx, b.kbCtx)
 	username, deviceName, deviceType, err := b.getSenderInfoLocal(uimap, pt.ClientHeader)
@@ -109,25 +124,35 @@ func (b *Boxer) UnboxMessage(ctx context.Context, finder KeyFinder, boxed chat1.
 		// ignore non-fatal error
 	}
 
+	b.log().Warning("@@@ Unboxed msgid:%v revoked:%v", boxed.ServerHeader.MessageID, umwkr.fromRevokedDevice)
+
 	return chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
-		ClientHeader:     pt.ClientHeader,
-		ServerHeader:     *boxed.ServerHeader,
-		MessageBody:      pt.MessageBody,
-		SenderUsername:   username,
-		SenderDeviceName: deviceName,
-		SenderDeviceType: deviceType,
-		HeaderHash:       headerHash,
+		ClientHeader:      pt.ClientHeader,
+		ServerHeader:      *boxed.ServerHeader,
+		MessageBody:       pt.MessageBody,
+		SenderUsername:    username,
+		SenderDeviceName:  deviceName,
+		SenderDeviceType:  deviceType,
+		HeaderHash:        umwkr.headerHash,
+		HeaderSignature:   umwkr.headerSignature,
+		FromRevokedDevice: umwkr.fromRevokedDevice,
 	}), nil
 
 }
 
+type unboxMessageWithKeyRes struct {
+	messagePlaintext  chat1.MessagePlaintext
+	headerHash        chat1.Hash
+	headerSignature   *chat1.SignatureInfo
+	fromRevokedDevice bool
+}
+
 // unboxMessageWithKey unboxes a chat1.MessageBoxed into a keybase1.Message given
 // a keybase1.CryptKey.
-func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed, key *keybase1.CryptKey) (chat1.MessagePlaintext, chat1.Hash, libkb.ChatUnboxingError) {
-
+func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed, key *keybase1.CryptKey) (unboxMessageWithKeyRes, libkb.ChatUnboxingError) {
 	var err error
 	if msg.ServerHeader == nil {
-		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(errors.New("nil ServerHeader in MessageBoxed"))
+		return unboxMessageWithKeyRes{}, libkb.NewPermanentChatUnboxingError(errors.New("nil ServerHeader in MessageBoxed"))
 	}
 
 	// compute the header hash
@@ -138,39 +163,48 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 	skipBodyVerification := false
 	if len(msg.BodyCiphertext.E) == 0 {
 		if msg.ServerHeader.SupersededBy == 0 {
-			return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(errors.New("empty body and not superseded in MessageBoxed"))
+			return unboxMessageWithKeyRes{}, libkb.NewPermanentChatUnboxingError(errors.New("empty body and not superseded in MessageBoxed"))
 		}
 		skipBodyVerification = true
 	} else {
 		packedBody, err := b.open(msg.BodyCiphertext, key)
 		if err != nil {
-			return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(err)
+			return unboxMessageWithKeyRes{}, libkb.NewPermanentChatUnboxingError(err)
 		}
 		if err := b.unmarshal(packedBody, &body); err != nil {
-			return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(err)
+			return unboxMessageWithKeyRes{}, libkb.NewPermanentChatUnboxingError(err)
 		}
 	}
 
 	// decrypt header
 	packedHeader, err := b.open(msg.HeaderCiphertext, key)
 	if err != nil {
-		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(err)
+		return unboxMessageWithKeyRes{}, libkb.NewPermanentChatUnboxingError(err)
 	}
 	var header chat1.HeaderPlaintext
 	if err := b.unmarshal(packedHeader, &header); err != nil {
-		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(err)
+		return unboxMessageWithKeyRes{}, libkb.NewPermanentChatUnboxingError(err)
 	}
 
 	// verify the message
-	if ierr := b.verifyMessage(ctx, header, msg, skipBodyVerification); ierr != nil {
-		return chat1.MessagePlaintext{}, nil, ierr
+	validity, ierr := b.verifyMessage(ctx, header, msg, skipBodyVerification)
+	if ierr != nil {
+		return unboxMessageWithKeyRes{}, ierr
 	}
 
 	// create a chat1.MessageClientHeader from versioned HeaderPlaintext
 	var clientHeader chat1.MessageClientHeader
 	headerVersion, err := header.Version()
 	if err != nil {
-		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(err)
+		return unboxMessageWithKeyRes{}, libkb.NewPermanentChatUnboxingError(err)
+	}
+
+	var headerSignature *chat1.SignatureInfo
+	switch headerVersion {
+	case chat1.HeaderPlaintextVersion_V1:
+		headerSignature = header.V1().HeaderSignature
+	default:
+		return unboxMessageWithKeyRes{}, libkb.NewPermanentChatUnboxingError(libkb.NewChatHeaderVersionError(headerVersion))
 	}
 
 	switch headerVersion {
@@ -188,32 +222,42 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 			OutboxID:     hp.OutboxID,
 		}
 	default:
-		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(libkb.NewChatHeaderVersionError(headerVersion))
+		return unboxMessageWithKeyRes{}, libkb.NewPermanentChatUnboxingError(libkb.NewChatHeaderVersionError(headerVersion))
 	}
 
 	if skipBodyVerification {
 		// body was deleted, so return empty body that matches header version
 		switch headerVersion {
 		case chat1.HeaderPlaintextVersion_V1:
-			return chat1.MessagePlaintext{ClientHeader: clientHeader}, headerHash, nil
+			return unboxMessageWithKeyRes{
+				messagePlaintext:  chat1.MessagePlaintext{ClientHeader: clientHeader},
+				headerHash:        headerHash,
+				headerSignature:   headerSignature,
+				fromRevokedDevice: validity.fromRevokedDevice,
+			}, nil
 		default:
-			return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(libkb.NewChatHeaderVersionError(headerVersion))
+			return unboxMessageWithKeyRes{}, libkb.NewPermanentChatUnboxingError(libkb.NewChatHeaderVersionError(headerVersion))
 		}
 	}
 
 	// create an unboxed message from versioned BodyPlaintext and clientHeader
 	bodyVersion, err := body.Version()
 	if err != nil {
-		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(err)
+		return unboxMessageWithKeyRes{}, libkb.NewPermanentChatUnboxingError(err)
 	}
 	switch bodyVersion {
 	case chat1.BodyPlaintextVersion_V1:
-		return chat1.MessagePlaintext{
-			ClientHeader: clientHeader,
-			MessageBody:  body.V1().MessageBody,
-		}, headerHash, nil
+		return unboxMessageWithKeyRes{
+			messagePlaintext: chat1.MessagePlaintext{
+				ClientHeader: clientHeader,
+				MessageBody:  body.V1().MessageBody,
+			},
+			headerHash:        headerHash,
+			headerSignature:   headerSignature,
+			fromRevokedDevice: validity.fromRevokedDevice,
+		}, nil
 	default:
-		return chat1.MessagePlaintext{}, nil, libkb.NewPermanentChatUnboxingError(libkb.NewChatBodyVersionError(bodyVersion))
+		return unboxMessageWithKeyRes{}, libkb.NewPermanentChatUnboxingError(libkb.NewChatBodyVersionError(bodyVersion))
 	}
 }
 
@@ -422,28 +466,32 @@ func sign(msg []byte, kp libkb.NaclSigningKeyPair, prefix libkb.SignaturePrefix)
 	return sigInfo, nil
 }
 
+type verifyMessageRes struct {
+	fromRevokedDevice bool
+}
+
 // verifyMessage checks that a message is valid.
-func (b *Boxer) verifyMessage(ctx context.Context, header chat1.HeaderPlaintext, msg chat1.MessageBoxed, skipBodyVerification bool) libkb.ChatUnboxingError {
+func (b *Boxer) verifyMessage(ctx context.Context, header chat1.HeaderPlaintext, msg chat1.MessageBoxed, skipBodyVerification bool) (verifyMessageRes, libkb.ChatUnboxingError) {
 	headerVersion, err := header.Version()
 	if err != nil {
-		return libkb.NewPermanentChatUnboxingError(err)
+		return verifyMessageRes{}, libkb.NewPermanentChatUnboxingError(err)
 	}
 
 	switch headerVersion {
 	case chat1.HeaderPlaintextVersion_V1:
 		return b.verifyMessageHeaderV1(ctx, header.V1(), msg, skipBodyVerification)
 	default:
-		return libkb.NewPermanentChatUnboxingError(libkb.NewChatHeaderVersionError(headerVersion))
+		return verifyMessageRes{}, libkb.NewPermanentChatUnboxingError(libkb.NewChatHeaderVersionError(headerVersion))
 	}
 }
 
 // verifyMessageHeaderV1 checks the body hash, header signature, and signing key validity.
-func (b *Boxer) verifyMessageHeaderV1(ctx context.Context, header chat1.HeaderPlaintextV1, msg chat1.MessageBoxed, skipBodyVerification bool) libkb.ChatUnboxingError {
+func (b *Boxer) verifyMessageHeaderV1(ctx context.Context, header chat1.HeaderPlaintextV1, msg chat1.MessageBoxed, skipBodyVerification bool) (verifyMessageRes, libkb.ChatUnboxingError) {
 	if !skipBodyVerification {
 		// check body hash
 		bh := b.hashV1(msg.BodyCiphertext.E)
 		if !libkb.SecureByteArrayEq(bh[:], header.BodyHash) {
-			return libkb.NewPermanentChatUnboxingError(libkb.ChatBodyHashInvalid{})
+			return verifyMessageRes{}, libkb.NewPermanentChatUnboxingError(libkb.ChatBodyHashInvalid{})
 		}
 	}
 
@@ -452,23 +500,25 @@ func (b *Boxer) verifyMessageHeaderV1(ctx context.Context, header chat1.HeaderPl
 	hcopy.HeaderSignature = nil
 	hpack, err := b.marshal(hcopy)
 	if err != nil {
-		return libkb.NewPermanentChatUnboxingError(err)
+		return verifyMessageRes{}, libkb.NewPermanentChatUnboxingError(err)
 	}
 	if !b.verify(hpack, *header.HeaderSignature, libkb.SignaturePrefixChat) {
-		return libkb.NewPermanentChatUnboxingError(libkb.BadSigError{E: "header signature invalid"})
+		return verifyMessageRes{}, libkb.NewPermanentChatUnboxingError(libkb.BadSigError{E: "header signature invalid"})
 	}
 
 	// check key validity
-	valid, ierr := b.validSenderKey(ctx, header.Sender, header.HeaderSignature.K, msg.ServerHeader.Ctime)
+	validAtCtime, revoked, ierr := b.ValidSenderKey(ctx, header.Sender, header.HeaderSignature.K, msg.ServerHeader.Ctime)
+	b.log().Warning("@@@ msgid:%v validAtCtime:%v revoked:%v err:%v", msg.ServerHeader.MessageID, validAtCtime, revoked, ierr)
 	if ierr != nil {
-		return ierr
+		return verifyMessageRes{}, ierr
 	}
-	if !valid {
-		return libkb.NewPermanentChatUnboxingError(errors.New("key invalid for sender at message ctime"))
+	if !validAtCtime {
+		return verifyMessageRes{}, libkb.NewPermanentChatUnboxingError(libkb.NoKeyError{Msg: "key invalid for sender at message ctime"})
 	}
 
-	return nil
-
+	return verifyMessageRes{
+		fromRevokedDevice: revoked,
+	}, nil
 }
 
 // verify verifies the signature of data using SignatureInfo.
@@ -484,34 +534,50 @@ func (b *Boxer) verify(data []byte, si chat1.SignatureInfo, prefix libkb.Signatu
 	return (err == nil)
 }
 
-// validSenderKey checks that the key is active for sender at ctime.
-func (b *Boxer) validSenderKey(ctx context.Context, sender gregor1.UID, key []byte, ctime gregor1.Time) (bool, libkb.ChatUnboxingError) {
+// ValidSenderKey checks that the key was active for sender at ctime.
+// This trusts the server for ctime, so a colluding server could use a revoked key and this check wouldn't notice.
+// Returns (validAtCtime, revoked, err)
+func (b *Boxer) ValidSenderKey(ctx context.Context, sender gregor1.UID, key []byte, ctime gregor1.Time) (bool, bool, libkb.ChatUnboxingError) {
 	kbSender, err := keybase1.UIDFromString(hex.EncodeToString(sender.Bytes()))
 	if err != nil {
-		return false, libkb.NewPermanentChatUnboxingError(err)
+		return false, false, libkb.NewPermanentChatUnboxingError(err)
 	}
 	kid := keybase1.KIDFromSlice(key)
-	t := gregor1.FromTime(ctime)
+	ctime2 := gregor1.FromTime(ctime)
 
-	var uimap *utils.UserInfoMapper
-	ctx, uimap = utils.GetUserInfoMapper(ctx, b.kbCtx)
-	user, err := uimap.User(kbSender)
-	if err != nil {
-		return false, libkb.NewTransientChatUnboxingError(err)
-	}
-	ckf := user.GetComputedKeyFamily()
-	if ckf == nil {
-		return false, libkb.NewPermanentChatUnboxingError(errors.New("no computed key family"))
-	}
-	activeKey, _, err := ckf.FindActiveSibkeyAtTime(kid, t)
-	if err != nil {
-		return false, libkb.NewPermanentChatUnboxingError(err)
-	}
-	if activeKey == nil {
-		return false, nil
+	cachedUserLoader := b.kbCtx.GetCachedUserLoader()
+	if cachedUserLoader == nil {
+		return false, false, libkb.NewTransientChatUnboxingError(fmt.Errorf("no CachedUserLoader available in context"))
 	}
 
-	return true, nil
+	found, revokedAt, err := cachedUserLoader.CheckKIDForUID(kbSender, kid)
+	if err != nil {
+		return false, false, libkb.NewTransientChatUnboxingError(err)
+	}
+	if !found {
+		return false, false, nil
+	}
+
+	var revokedAt2 *time.Time
+	if revokedAt != nil {
+		if revokedAt.Unix.IsZero() {
+			return false, false, libkb.NewPermanentChatUnboxingError(fmt.Errorf("zero clock time on expired key"))
+		}
+		t := b.keybase1KeybaseTimeToTime(*revokedAt)
+		revokedAt2 = &t
+	}
+
+	revoked := revokedAt2 != nil
+	validAtCtime := found && (!revoked || revokedAt2.After(ctime2))
+	b.log().Warning("@@@ key:%v", kid)
+	return validAtCtime, revoked, nil
+}
+
+func (b *Boxer) keybase1KeybaseTimeToTime(t1 keybase1.KeybaseTime) time.Time {
+	// u is in milliseconds
+	u := int64(t1.Unix)
+	t2 := time.Unix(u/1e3, (u%1e3)*1e6)
+	return t2
 }
 
 func (b *Boxer) marshal(v interface{}) ([]byte, error) {

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -124,8 +124,6 @@ func (b *Boxer) UnboxMessage(ctx context.Context, finder KeyFinder, boxed chat1.
 		// ignore non-fatal error
 	}
 
-	b.log().Warning("@@@ Unboxed msgid:%v revoked:%v", boxed.ServerHeader.MessageID, umwkr.fromRevokedDevice)
-
 	return chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
 		ClientHeader:      pt.ClientHeader,
 		ServerHeader:      *boxed.ServerHeader,
@@ -508,7 +506,6 @@ func (b *Boxer) verifyMessageHeaderV1(ctx context.Context, header chat1.HeaderPl
 
 	// check key validity
 	validAtCtime, revoked, ierr := b.ValidSenderKey(ctx, header.Sender, header.HeaderSignature.K, msg.ServerHeader.Ctime)
-	b.log().Warning("@@@ msgid:%v validAtCtime:%v revoked:%v err:%v", msg.ServerHeader.MessageID, validAtCtime, revoked, ierr)
 	if ierr != nil {
 		return verifyMessageRes{}, ierr
 	}
@@ -569,7 +566,6 @@ func (b *Boxer) ValidSenderKey(ctx context.Context, sender gregor1.UID, key []by
 
 	revoked := revokedAt2 != nil
 	validAtCtime := found && (!revoked || revokedAt2.After(ctime2))
-	b.log().Warning("@@@ key:%v", kid)
 	return validAtCtime, revoked, nil
 }
 

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
@@ -78,6 +79,35 @@ func getSigningKeyPairForTest(t *testing.T, tc libkb.TestContext, u *kbtest.Fake
 		t.Fatal("signing key not nacl")
 	}
 	return signKP
+}
+
+func getActiveDevicesAndKeys(tc libkb.TestContext, u *kbtest.FakeUser) ([]*libkb.Device, []libkb.GenericKey) {
+	arg := libkb.NewLoadUserByNameArg(tc.G, u.Username)
+	arg.PublicKeyOptional = true
+	user, err := libkb.LoadUser(arg)
+	if err != nil {
+		tc.T.Fatal(err)
+	}
+	sibkeys := user.GetComputedKeyFamily().GetAllActiveSibkeys()
+	subkeys := user.GetComputedKeyFamily().GetAllActiveSubkeys()
+
+	activeDevices := []*libkb.Device{}
+	for _, device := range user.GetComputedKeyFamily().GetAllDevices() {
+		if device.Status != nil && *device.Status == libkb.DeviceStatusActive {
+			activeDevices = append(activeDevices, device)
+		}
+	}
+	return activeDevices, append(sibkeys, subkeys...)
+}
+
+func doRevokeDevice(tc libkb.TestContext, u *kbtest.FakeUser, id keybase1.DeviceID, force bool) error {
+	revokeEngine := engine.NewRevokeDeviceEngine(engine.RevokeDeviceEngineArgs{ID: id, Force: force}, tc.G)
+	ctx := &engine.Context{
+		LogUI:    tc.G.UI.GetLogUI(),
+		SecretUI: u.NewSecretUI(),
+	}
+	err := engine.RunEngine(revokeEngine, ctx)
+	return err
 }
 
 func TestChatMessageBox(t *testing.T) {
@@ -272,6 +302,7 @@ func TestChatMessageUnboxNoCryptKey(t *testing.T) {
 		t.Fatalf("message should not be unboxable")
 	}
 }
+
 func TestChatMessageInvalidHeaderSig(t *testing.T) {
 	key := cryptKey(t)
 	text := "hi"
@@ -354,6 +385,129 @@ func TestChatMessageInvalidSenderKey(t *testing.T) {
 	if _, ok := ierr.Inner().(libkb.NoKeyError); !ok {
 		t.Fatalf("unexpected error for invalid sender key: %v", ierr)
 	}
+}
+
+// Sent with a revoked sender key after revocation
+func TestChatMessageRevokedKeyThenSent(t *testing.T) {
+	key := cryptKey(t)
+	text := "hi"
+	tc, boxer := setupChatTest(t, "unbox")
+	defer tc.Cleanup()
+
+	// need a real user
+	u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
+	require.NoError(t, err)
+	t.Logf("using username:%+v uid: %+v", u.Username, u.User.GetUID())
+
+	// pick a device
+	devices, _ := getActiveDevicesAndKeys(tc, u)
+	var thisDevice *libkb.Device
+	for _, device := range devices {
+		if device.Type != libkb.DeviceTypePaper {
+			thisDevice = device
+		}
+	}
+	require.NotNil(t, thisDevice, "thisDevice should be non-nil")
+
+	// Find the key
+	f := func() libkb.SecretUI { return u.NewSecretUI() }
+	signingKey, err := engine.GetMySecretKey(tc.G, f, libkb.DeviceSigningKeyType, "some chat or something test")
+	require.NoError(t, err, "get device signing key")
+	signKP, ok := signingKey.(libkb.NaclSigningKeyPair)
+	require.Equal(t, true, ok, "signing key must be nacl")
+	t.Logf("found signing kp: %+v", signKP.GetKID())
+
+	// Revoke the key
+	t.Logf("revoking device id:%+v", thisDevice.ID)
+	err = doRevokeDevice(tc, u, thisDevice.ID, true)
+	require.NoError(t, err, "revoke device")
+
+	// Sleep for a second because revocation timestamps are only second-resolution.
+	time.Sleep(1 * time.Second)
+
+	// Reset the cache
+	// tc.G.CachedUserLoader = libkb.NewCachedUserLoader(tc.G, libkb.CachedUserTimeout)
+
+	// Sign a message using a key of u's that has been revoked
+	t.Logf("signing message")
+	msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()))
+	boxed, err := boxer.boxMessageWithKeysV1(msg, key, signKP)
+	require.NoError(t, err)
+
+	boxed.ServerHeader = &chat1.MessageServerHeader{
+		Ctime: gregor1.ToTime(time.Now()),
+	}
+
+	// The message should not unbox
+	umwkr, ierr := boxer.unboxMessageWithKey(context.TODO(), *boxed, key)
+	require.NotNil(t, ierr, "unboxing must err (%v)", umwkr.fromRevokedDevice)
+	require.IsType(t, libkb.NoKeyError{}, ierr.Inner(), "unexpected error for revoked sender key: %v", ierr)
+
+	// Test key validity
+	validAtCtime, revoked, err := boxer.ValidSenderKey(context.TODO(), gregor1.UID(u.User.GetUID().ToBytes()), signKP.GetBinaryKID(), boxed.ServerHeader.Ctime)
+	require.NoError(t, err, "ValidSenderKey")
+	require.False(t, validAtCtime, "revoked key should be invalid (v:%v r:%v)", validAtCtime, revoked)
+	require.True(t, revoked, "key should be revoked (v:%v r:%v)", validAtCtime, revoked)
+}
+
+// Sent with a revoked sender key before revocation
+func TestChatMessageSentThenRevokedSenderKey(t *testing.T) {
+	key := cryptKey(t)
+	text := "hi"
+	tc, boxer := setupChatTest(t, "unbox")
+	defer tc.Cleanup()
+
+	// need a real user
+	u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
+	require.NoError(t, err)
+	t.Logf("using username:%+v uid: %+v", u.Username, u.User.GetUID())
+
+	// pick a device
+	devices, _ := getActiveDevicesAndKeys(tc, u)
+	var thisDevice *libkb.Device
+	for _, device := range devices {
+		if device.Type != libkb.DeviceTypePaper {
+			thisDevice = device
+		}
+	}
+	require.NotNil(t, thisDevice, "thisDevice should be non-nil")
+
+	// Find the key
+	f := func() libkb.SecretUI { return u.NewSecretUI() }
+	signingKey, err := engine.GetMySecretKey(tc.G, f, libkb.DeviceSigningKeyType, "some chat or something test")
+	require.NoError(t, err, "get device signing key")
+	signKP, ok := signingKey.(libkb.NaclSigningKeyPair)
+	require.Equal(t, true, ok, "signing key must be nacl")
+	t.Logf("found signing kp: %+v", signKP.GetKID())
+
+	// Sign a message using a key of u's that has not yet been revoked
+	t.Logf("signing message")
+	msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()))
+	boxed, err := boxer.boxMessageWithKeysV1(msg, key, signKP)
+	require.NoError(t, err)
+
+	boxed.ServerHeader = &chat1.MessageServerHeader{
+		Ctime: gregor1.ToTime(time.Now()),
+	}
+
+	// Sleep for a second because revocation timestamps are only second-resolution.
+	time.Sleep(1 * time.Second)
+
+	// Revoke the key
+	t.Logf("revoking device id:%+v", thisDevice.ID)
+	err = doRevokeDevice(tc, u, thisDevice.ID, true)
+	require.NoError(t, err, "revoke device")
+
+	// The message should unbox but with FromRevokedDevice set
+	umwkr, ierr := boxer.unboxMessageWithKey(context.TODO(), *boxed, key)
+	require.Nil(t, ierr, "unboxing err")
+	require.True(t, umwkr.fromRevokedDevice, "message should be noticed as signed by revoked key")
+
+	// Test key validity
+	validAtCtime, revoked, err := boxer.ValidSenderKey(context.TODO(), gregor1.UID(u.User.GetUID().ToBytes()), signKP.GetBinaryKID(), boxed.ServerHeader.Ctime)
+	require.NoError(t, err, "ValidSenderKey")
+	require.True(t, validAtCtime, "revoked key should be valid at time (v:%v r:%v)", validAtCtime, revoked)
+	require.True(t, revoked, "key should be revoked (v:%v r:%v)", validAtCtime, revoked)
 }
 
 func TestChatMessagePublic(t *testing.T) {

--- a/go/chat/utils/context.go
+++ b/go/chat/utils/context.go
@@ -16,4 +16,5 @@ type KeybaseContext interface {
 	LoadUserByUID(uid keybase1.UID) (*libkb.User, error)
 	UIDToUsername(uid keybase1.UID) (libkb.NormalizedUsername, error)
 	Clock() clockwork.Clock
+	GetCachedUserLoader() *libkb.CachedUserLoader
 }

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -333,7 +333,6 @@ func newMessageView(g *libkb.GlobalContext, conversationID chat1.ConversationID,
 
 	mv.MessageID = m.GetMessageID()
 	mv.FromRevokedDevice = m.Valid().FromRevokedDevice
-	fmt.Printf("@@@ render msgid:%v FromRevokedDevice:%v\n", mv.MessageID, mv.FromRevokedDevice)
 
 	// Check what message supersedes this one.
 	var mvsup *messageView

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -198,6 +198,7 @@ func (v conversationView) show(g *libkb.GlobalContext, showDeviceName bool) erro
 
 	ui := g.UI.GetTerminalUI()
 	w, _ := ui.TerminalSize()
+	showRevokeAdvisory := false
 
 	headline, err := v.headline(g)
 	if err != nil {
@@ -218,6 +219,10 @@ func (v conversationView) show(g *libkb.GlobalContext, showDeviceName bool) erro
 
 		if !mv.Renderable {
 			continue
+		}
+
+		if mv.FromRevokedDevice {
+			showRevokeAdvisory = true
 		}
 
 		unread := ""
@@ -261,6 +266,10 @@ func (v conversationView) show(g *libkb.GlobalContext, showDeviceName bool) erro
 		return fmt.Errorf("rendering conversation view error: %v\n", err)
 	}
 
+	if showRevokeAdvisory {
+		g.UI.GetTerminalUI().Printf("\nNote: Messages with (!) next to the sender were sent from a device that is now revoked.\n")
+	}
+
 	return nil
 }
 
@@ -293,11 +302,13 @@ const deletedTextCLI = "[deleted]"
 // Takes into account superseding edits and deletions.
 type messageView struct {
 	MessageID chat1.MessageID
+
 	// Whether to show this message. Show texts, but not edits or deletes.
 	Renderable                  bool
 	AuthorAndTime               string
 	AuthorAndTimeWithDeviceName string
 	Body                        string
+	FromRevokedDevice           bool
 
 	// Used internally for supersedeers
 	messageType chat1.MessageType
@@ -315,8 +326,14 @@ func newMessageView(g *libkb.GlobalContext, conversationID chat1.ConversationID,
 	if st == chat1.MessageUnboxedState_ERROR {
 		return mv, fmt.Errorf("<%s>", m.Error().ErrMsg)
 	}
+	// TODO handle messages in outbox properly
+	if st == chat1.MessageUnboxedState_OUTBOX {
+		return mv, fmt.Errorf("<message waiting to be sent>")
+	}
 
 	mv.MessageID = m.GetMessageID()
+	mv.FromRevokedDevice = m.Valid().FromRevokedDevice
+	fmt.Printf("@@@ render msgid:%v FromRevokedDevice:%v\n", mv.MessageID, mv.FromRevokedDevice)
 
 	// Check what message supersedes this one.
 	var mvsup *messageView
@@ -332,12 +349,6 @@ func newMessageView(g *libkb.GlobalContext, conversationID chat1.ConversationID,
 		}
 		mvsup = &mvsupInner
 	}
-
-	t := gregor1.FromTime(m.Valid().ServerHeader.Ctime)
-	mv.AuthorAndTime = fmt.Sprintf("%s %s",
-		m.Valid().SenderUsername, shortDurationFromNow(t))
-	mv.AuthorAndTimeWithDeviceName = fmt.Sprintf("%s <%s> %s",
-		m.Valid().SenderUsername, m.Valid().SenderDeviceName, shortDurationFromNow(t))
 
 	body := m.Valid().MessageBody
 	typ, err := body.MessageType()
@@ -364,6 +375,9 @@ func newMessageView(g *libkb.GlobalContext, conversationID chat1.ConversationID,
 		mv.Renderable = true
 		mv.Body = body.Text().Body
 		if mvsup != nil {
+			if mvsup.FromRevokedDevice {
+				mv.FromRevokedDevice = true
+			}
 			switch mvsup.messageType {
 			case chat1.MessageType_EDIT:
 				mv.Body = mvsup.Body
@@ -386,6 +400,9 @@ func newMessageView(g *libkb.GlobalContext, conversationID chat1.ConversationID,
 			mv.Body += " [preview available]"
 		}
 		if mvsup != nil {
+			if mvsup.FromRevokedDevice {
+				mv.FromRevokedDevice = true
+			}
 			switch mvsup.messageType {
 			case chat1.MessageType_EDIT:
 				// Editing attachments is not supported, ignore the edit
@@ -410,6 +427,16 @@ func newMessageView(g *libkb.GlobalContext, conversationID chat1.ConversationID,
 	default:
 		return mv, fmt.Errorf(fmt.Sprintf("unsupported MessageType: %s", typ.String()))
 	}
+
+	possiblyRevokedMark := ""
+	if mv.FromRevokedDevice {
+		possiblyRevokedMark = "(!)"
+	}
+	t := gregor1.FromTime(m.Valid().ServerHeader.Ctime)
+	mv.AuthorAndTime = fmt.Sprintf("%s%s %s",
+		m.Valid().SenderUsername, possiblyRevokedMark, shortDurationFromNow(t))
+	mv.AuthorAndTimeWithDeviceName = fmt.Sprintf("%s%s <%s> %s",
+		m.Valid().SenderUsername, possiblyRevokedMark, m.Valid().SenderDeviceName, shortDurationFromNow(t))
 
 	return mv, nil
 }

--- a/go/libkb/cached_user_loader.go
+++ b/go/libkb/cached_user_loader.go
@@ -3,9 +3,10 @@ package libkb
 import (
 	"errors"
 	"fmt"
-	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"sync"
 	"time"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
 type CachedUserLoader struct {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -103,10 +103,11 @@ type GlobalTestOptions struct {
 	NoBug3964Repair bool
 }
 
-func (g *GlobalContext) GetLog() logger.Logger       { return g.Log }
-func (g *GlobalContext) GetAPI() API                 { return g.API }
-func (g *GlobalContext) GetExternalAPI() ExternalAPI { return g.XAPI }
-func (g *GlobalContext) GetServerURI() string        { return g.Env.GetServerURI() }
+func (g *GlobalContext) GetLog() logger.Logger                  { return g.Log }
+func (g *GlobalContext) GetAPI() API                            { return g.API }
+func (g *GlobalContext) GetExternalAPI() ExternalAPI            { return g.XAPI }
+func (g *GlobalContext) GetServerURI() string                   { return g.Env.GetServerURI() }
+func (g *GlobalContext) GetCachedUserLoader() *CachedUserLoader { return g.CachedUserLoader }
 
 func NewGlobalContext() *GlobalContext {
 	log := logger.New("keybase")

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -419,13 +419,15 @@ var MessageUnboxedStateRevMap = map[MessageUnboxedState]string{
 }
 
 type MessageUnboxedValid struct {
-	ClientHeader     MessageClientHeader `codec:"clientHeader" json:"clientHeader"`
-	ServerHeader     MessageServerHeader `codec:"serverHeader" json:"serverHeader"`
-	MessageBody      MessageBody         `codec:"messageBody" json:"messageBody"`
-	SenderUsername   string              `codec:"senderUsername" json:"senderUsername"`
-	SenderDeviceName string              `codec:"senderDeviceName" json:"senderDeviceName"`
-	SenderDeviceType string              `codec:"senderDeviceType" json:"senderDeviceType"`
-	HeaderHash       Hash                `codec:"headerHash" json:"headerHash"`
+	ClientHeader      MessageClientHeader `codec:"clientHeader" json:"clientHeader"`
+	ServerHeader      MessageServerHeader `codec:"serverHeader" json:"serverHeader"`
+	MessageBody       MessageBody         `codec:"messageBody" json:"messageBody"`
+	SenderUsername    string              `codec:"senderUsername" json:"senderUsername"`
+	SenderDeviceName  string              `codec:"senderDeviceName" json:"senderDeviceName"`
+	SenderDeviceType  string              `codec:"senderDeviceType" json:"senderDeviceType"`
+	HeaderHash        Hash                `codec:"headerHash" json:"headerHash"`
+	HeaderSignature   *SignatureInfo      `codec:"headerSignature,omitempty" json:"headerSignature,omitempty"`
+	FromRevokedDevice bool                `codec:"fromRevokedDevice" json:"fromRevokedDevice"`
 }
 
 type MessageUnboxedError struct {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -136,6 +136,11 @@ protocol local {
     string senderDeviceName;
     string senderDeviceType;
     Hash headerHash;
+    union {null, SignatureInfo} headerSignature;
+    // Whether the message was sent by a device that is now revoked.
+    // We aren't sure whether the device was revoked when the message was sent.
+    // Re-evaluated when unboxed or pulled from the cache.
+    bool fromRevokedDevice;
   }
 
   record MessageUnboxedError {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -846,6 +846,8 @@ export type MessageUnboxedValid = {
   senderDeviceName: string,
   senderDeviceType: string,
   headerHash: Hash,
+  headerSignature?: ?SignatureInfo,
+  fromRevokedDevice: bool,
 }
 
 export type NewConversationInfo = {

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -429,6 +429,17 @@
         {
           "type": "Hash",
           "name": "headerHash"
+        },
+        {
+          "type": [
+            null,
+            "SignatureInfo"
+          ],
+          "name": "headerSignature"
+        },
+        {
+          "type": "bool",
+          "name": "fromRevokedDevice"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -846,6 +846,8 @@ export type MessageUnboxedValid = {
   senderDeviceName: string,
   senderDeviceType: string,
   headerHash: Hash,
+  headerSignature?: ?SignatureInfo,
+  fromRevokedDevice: bool,
 }
 
 export type NewConversationInfo = {


### PR DESCRIPTION
This addresses [CORE-4106](https://keybase.atlassian.net/browse/CORE-4106)

Two fields are added to `MessageUnboxedValid`
```
    union {null, SignatureInfo} headerSignature;
    // Whether the message was sent by a device that is now revoked.
    // We aren't sure whether the device was revoked when the message was sent.
    // Re-evaluated when unboxed or pulled from the cache.
    bool fromRevokedDevice;
```

`MessageUnboxedValid.FromRevokedDevice` is calculated on unboxing, and updated whenver the message is pulled from the cache in `HybridConversationSource.Pull`.

Here's what the CLI looks like if you read a conversation with messages in it from revoked devices. The warning appears only if messages from revoked devices are shown.
```
$ keybase chat read
▶ WARNING Running in devel mode
Found CHAT conversation: abel,t_bob

[1]     [abel 5h] init again (2) from ht
[2]  [abel(!) 3h] msg1 from abel1
[3]  [abel(!) 3h] msg1 from abel2

Note: Messages with (!) next to the sender were sent from a device that is now revoked.
```

If a new key is used to send a message, `CheckKIDForUID` punches through the cache so that's not a problem. But the revocation info is otherwise pulled every 10 minutes. So if someone steals a device and compromises the server and sends a message in 9 minutes and you read it in those 9 minutes then you won't see a warning. But after 10 minutes the warning will appear.

r? @maxtaco @mmaxim 

Tests for Boxer are in the making. I'm not sure how to test the convsource part.