### PR TITLE
identify2 uses the user cache if possible

### DIFF
--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -130,11 +130,11 @@ func (i *identifyUser) isNil() bool {
 func loadIdentifyUser(g *libkb.GlobalContext, arg libkb.LoadUserArg, cache libkb.Identify2Cacher) (*identifyUser, error) {
 	ret := &identifyUser{arg: arg}
 	err := ret.load(g)
+	if ret != nil && ret.full != nil && cache != nil {
+		cache.DidFullUserLoad(ret.GetUID())
+	}
 	if ret.isNil() {
 		ret = nil
-	}
-	if ret.full != nil && cache != nil {
-		cache.DidFullUserLoad(ret.GetUID())
 	}
 	return ret, err
 }

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -130,11 +130,10 @@ func (i *identifyUser) isNil() bool {
 func loadIdentifyUser(g *libkb.GlobalContext, arg libkb.LoadUserArg, cache libkb.Identify2Cacher) (*identifyUser, error) {
 	ret := &identifyUser{arg: arg}
 	err := ret.load(g)
-	if ret != nil && ret.full != nil && cache != nil {
-		cache.DidFullUserLoad(ret.GetUID())
-	}
 	if ret.isNil() {
 		ret = nil
+	} else if ret.full != nil && cache != nil {
+		cache.DidFullUserLoad(ret.GetUID())
 	}
 	return ret, err
 }

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -133,7 +133,7 @@ func loadIdentifyUser(g *libkb.GlobalContext, arg libkb.LoadUserArg, cache libkb
 	if ret.isNil() {
 		ret = nil
 	}
-	if ret.full != nil {
+	if ret.full != nil && cache != nil {
 		cache.DidFullUserLoad(ret.GetUID())
 	}
 	return ret, err

--- a/go/libkb/identify2_cache.go
+++ b/go/libkb/identify2_cache.go
@@ -20,6 +20,7 @@ type Identify2Cache struct {
 type Identify2Cacher interface {
 	Get(keybase1.UID, GetCheckTimeFunc, time.Duration) (*keybase1.UserPlusKeys, error)
 	Insert(up *keybase1.UserPlusKeys) error
+	DidFullUserLoad(keybase1.UID)
 	Shutdown()
 }
 
@@ -78,3 +79,6 @@ func (c *Identify2Cache) Insert(up *keybase1.UserPlusKeys) error {
 func (c *Identify2Cache) Shutdown() {
 	c.cache.Shutdown()
 }
+
+// DidFullUserLoad is a noop unless we're testing...
+func (c *Identify2Cache) DidFullUserLoad(_ keybase1.UID) {}

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -788,3 +788,20 @@ func (u UserPlusAllKeys) GetUID() UID {
 func (u UserPlusAllKeys) GetName() string {
 	return u.Base.GetName()
 }
+
+func (u UserPlusAllKeys) Export() *User {
+	return &User{Uid: u.GetUID(), Username: u.GetName()}
+}
+
+func (u UserVersionVector) Equal(u2 UserVersionVector) bool {
+	if u2.Id == 0 || u.Id == 0 || u2.Id != u.Id {
+		return false
+	}
+	if u2.SigHints == 0 || u.SigHints == 0 || u2.SigHints != u.SigHints {
+		return false
+	}
+	if u2.SigChain == 0 || u.SigChain == 0 || u2.SigChain != u.SigChain {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
- update tests to check that the user cache is being properly accessed