### PR TITLE
Chat attachments with filenames instead of stream interface

### DIFF
--- a/go/chat/attachment_test.go
+++ b/go/chat/attachment_test.go
@@ -184,10 +184,8 @@ func makeUploadTask(t *testing.T, size int) (plaintext []byte, task *UploadTask)
 			Bucket:    "upload-test",
 			ObjectKey: randString(t, 8),
 		},
-		LocalSrc: chat1.LocalSource{
-			Filename: randString(t, 8),
-			Size:     size,
-		},
+		Filename:       randString(t, 8),
+		FileSize:       size,
 		Plaintext:      newBytesReadResetter(plaintext),
 		S3Signer:       &ptsigner{},
 		ConversationID: randBytes(t, 16),

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -204,6 +204,7 @@ type attachOptionsV1 struct {
 	Filename       string
 	Preview        string
 	Title          string
+	NoStream       bool
 }
 
 func (a attachOptionsV1) Check() error {

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -223,6 +223,7 @@ type downloadOptionsV1 struct {
 	MessageID      chat1.MessageID `json:"message_id"`
 	Output         string
 	Preview        bool
+	NoStream       bool
 }
 
 func (a downloadOptionsV1) Check() error {

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -339,7 +339,6 @@ func (c *chatServiceHandler) AttachV1(ctx context.Context, opts attachOptionsV1)
 
 // attachV1NoStream uses PostFileAttachmentLocal instead of PostAttachmentLocal.
 func (c *chatServiceHandler) attachV1NoStream(ctx context.Context, opts attachOptionsV1) Reply {
-	c.G().Log.Warning("not using stream interface")
 	convID, err := chat1.MakeConvID(opts.ConversationID)
 	if err != nil {
 		return c.errReply(fmt.Errorf("invalid conv ID: %s", opts.ConversationID))

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -250,6 +250,9 @@ func (c *chatServiceHandler) EditV1(ctx context.Context, opts editOptionsV1) Rep
 
 // AttachV1 implements ChatServiceHandler.AttachV1.
 func (c *chatServiceHandler) AttachV1(ctx context.Context, opts attachOptionsV1) Reply {
+	if opts.NoStream {
+		return c.attachV1NoStream(ctx, opts)
+	}
 	convID, err := chat1.MakeConvID(opts.ConversationID)
 	if err != nil {
 		return c.errReply(fmt.Errorf("invalid conv ID: %s", opts.ConversationID))
@@ -319,6 +322,76 @@ func (c *chatServiceHandler) AttachV1(ctx context.Context, opts attachOptionsV1)
 		return c.errReply(err)
 	}
 	pres, err := client.PostAttachmentLocal(ctx, arg)
+	if err != nil {
+		return c.errReply(err)
+	}
+	header.rateLimits = append(header.rateLimits, pres.RateLimits...)
+
+	res := SendRes{
+		Message: "attachment sent",
+		RateLimits: RateLimits{
+			RateLimits: c.aggRateLimits(header.rateLimits),
+		},
+	}
+
+	return Reply{Result: res}
+}
+
+// attachV1NoStream uses PostFileAttachmentLocal instead of PostAttachmentLocal.
+func (c *chatServiceHandler) attachV1NoStream(ctx context.Context, opts attachOptionsV1) Reply {
+	c.G().Log.Warning("not using stream interface")
+	convID, err := chat1.MakeConvID(opts.ConversationID)
+	if err != nil {
+		return c.errReply(fmt.Errorf("invalid conv ID: %s", opts.ConversationID))
+	}
+	sarg := sendArgV1{
+		conversationID: convID,
+		channel:        opts.Channel,
+		mtype:          chat1.MessageType_ATTACHMENT,
+	}
+	query, err := c.getInboxLocalQuery(ctx, sarg.conversationID, sarg.channel)
+	if err != nil {
+		return c.errReply(err)
+	}
+	header, err := c.makePostHeader(ctx, sarg, query)
+	if err != nil {
+		return c.errReply(err)
+	}
+
+	arg := chat1.PostFileAttachmentLocalArg{
+		ConversationID: header.conversationID,
+		ClientHeader:   header.clientHeader,
+		Attachment: chat1.LocalFileSource{
+			Filename: opts.Filename,
+		},
+		Title: opts.Title,
+	}
+
+	// check for preview
+	if len(opts.Preview) > 0 {
+		plocal := chat1.LocalFileSource{
+			Filename: opts.Preview,
+		}
+		arg.Preview = &plocal
+	}
+
+	ui := &ChatUI{
+		Contextified: libkb.NewContextified(c.G()),
+		terminal:     c.G().UI.GetTerminalUI(),
+	}
+
+	client, err := GetChatLocalClient(c.G())
+	if err != nil {
+		return c.errReply(err)
+	}
+	protocols := []rpc.Protocol{
+		NewStreamUIProtocol(c.G()),
+		chat1.ChatUiProtocol(ui),
+	}
+	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
+		return c.errReply(err)
+	}
+	pres, err := client.PostFileAttachmentLocal(ctx, arg)
 	if err != nil {
 		return c.errReply(err)
 	}

--- a/go/service/chat_asset.go
+++ b/go/service/chat_asset.go
@@ -116,7 +116,7 @@ func (f *fileReadResetter) Reset() error {
 	if err != nil {
 		return err
 	}
-	f.buf = bufio.NewReader(f.file)
+	f.buf.Reset(f.file)
 	return nil
 }
 

--- a/go/service/chat_asset.go
+++ b/go/service/chat_asset.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/keybase/client/go/chat"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type assetSource interface {
+	FileSize() int
+	Basename() string
+	Open(sessionID int, cli *keybase1.StreamUiClient) (chat.ReadResetter, error)
+}
+
+type streamSource struct {
+	chat1.LocalSource
+}
+
+func (s streamSource) FileSize() int {
+	return s.Size
+}
+
+func (s streamSource) Basename() string {
+	return filepath.Base(s.Filename)
+}
+
+func (s streamSource) Open(sessionID int, cli *keybase1.StreamUiClient) (chat.ReadResetter, error) {
+	return libkb.NewRemoteStreamBuffered(s.Source, cli, sessionID), nil
+}
+
+type fileSource struct {
+	chat1.LocalFileSource
+	info os.FileInfo
+}
+
+func newFileSource(s chat1.LocalFileSource) (*fileSource, error) {
+	i, err := os.Stat(s.Filename)
+	if err != nil {
+		return nil, err
+	}
+	return &fileSource{
+		LocalFileSource: s,
+		info:            i,
+	}, nil
+}
+
+func (f fileSource) FileSize() int {
+	return int(f.info.Size())
+}
+
+func (f fileSource) Basename() string {
+	return f.info.Name()
+}
+
+func (f fileSource) Open(sessionID int, cli *keybase1.StreamUiClient) (chat.ReadResetter, error) {
+	return newFileReadResetter(f.Filename)
+}
+
+type fileReadResetter struct {
+	filename string
+	file     *os.File
+	buf      *bufio.Reader
+}
+
+func newFileReadResetter(name string) (chat.ReadResetter, error) {
+	f := &fileReadResetter{filename: name}
+	if err := f.open(); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func (f *fileReadResetter) open() error {
+	ff, err := os.Open(f.filename)
+	if err != nil {
+		return err
+	}
+	f.file = ff
+	f.buf = bufio.NewReader(f.file)
+	return nil
+}
+
+func (f *fileReadResetter) Read(p []byte) (int, error) {
+	return f.buf.Read(p)
+}
+
+func (f *fileReadResetter) Reset() error {
+	_, err := f.file.Seek(0, io.SeekStart)
+	if err != nil {
+		return err
+	}
+	f.buf = bufio.NewReader(f.file)
+	return nil
+}

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -639,6 +639,11 @@ func (h *chatLocalHandler) PostAttachmentLocal(ctx context.Context, arg chat1.Po
 	return h.PostLocal(ctx, postArg)
 }
 
+// PostFileAttachmentLocal implements chat1.LocalInterface.PostFileAttachmentLocal.
+func (h *chatLocalHandler) PostFileAttachmentLocal(ctx context.Context, arg chat1.PostFileAttachmentLocalArg) (chat1.PostLocalRes, error) {
+	return chat1.PostLocalRes{}, nil
+}
+
 // DownloadAttachmentLocal implements chat1.LocalInterface.DownloadAttachmentLocal.
 func (h *chatLocalHandler) DownloadAttachmentLocal(ctx context.Context, arg chat1.DownloadAttachmentLocalArg) (chat1.DownloadAttachmentLocalRes, error) {
 	chatUI := h.getChatUI(arg.SessionID)
@@ -712,6 +717,11 @@ func (h *chatLocalHandler) DownloadAttachmentLocal(ctx context.Context, arg chat
 	}
 
 	return chat1.DownloadAttachmentLocalRes{RateLimits: msgs.RateLimits}, nil
+}
+
+// DownloadFileAttachmentLocal implements chat1.LocalInterface.DownloadFileAttachmentLocal.
+func (h *chatLocalHandler) DownloadFileAttachmentLocal(ctx context.Context, arg chat1.DownloadFileAttachmentLocalArg) (chat1.DownloadAttachmentLocalRes, error) {
+	return chat1.DownloadAttachmentLocalRes{}, nil
 }
 
 func (h *chatLocalHandler) CancelPost(ctx context.Context, outboxID chat1.OutboxID) error {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -566,12 +566,15 @@ func (h *chatLocalHandler) PostAttachmentLocal(ctx context.Context, arg chat1.Po
 		SessionID:      arg.SessionID,
 		ConversationID: arg.ConversationID,
 		ClientHeader:   arg.ClientHeader,
-		Attachment:     streamSource{arg.Attachment},
+		Attachment:     newStreamSource(arg.Attachment),
 		Title:          arg.Title,
 		Metadata:       arg.Metadata,
 	}
+	defer parg.Attachment.Close()
+
 	if arg.Preview != nil {
-		parg.Preview = streamSource{*arg.Preview}
+		parg.Preview = newStreamSource(*arg.Preview)
+		defer parg.Preview.Close()
 	}
 
 	return h.postAttachmentLocal(ctx, parg)
@@ -591,12 +594,15 @@ func (h *chatLocalHandler) PostFileAttachmentLocal(ctx context.Context, arg chat
 		return chat1.PostLocalRes{}, err
 	}
 	parg.Attachment = asrc
+	defer parg.Attachment.Close()
+
 	if arg.Preview != nil {
 		psrc, err := newFileSource(*arg.Preview)
 		if err != nil {
 			return chat1.PostLocalRes{}, err
 		}
 		parg.Preview = psrc
+		defer parg.Preview.Close()
 	}
 
 	return h.postAttachmentLocal(ctx, parg)

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -807,7 +807,8 @@ func (h *chatLocalHandler) uploadAsset(ctx context.Context, sessionID int, param
 
 	task := chat.UploadTask{
 		S3Params:       params,
-		LocalSrc:       local,
+		Filename:       local.Filename,
+		FileSize:       local.Size,
 		Plaintext:      src,
 		S3Signer:       h,
 		ConversationID: conversationID,

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -714,7 +714,19 @@ func (h *chatLocalHandler) DownloadAttachmentLocal(ctx context.Context, arg chat
 
 // DownloadFileAttachmentLocal implements chat1.LocalInterface.DownloadFileAttachmentLocal.
 func (h *chatLocalHandler) DownloadFileAttachmentLocal(ctx context.Context, arg chat1.DownloadFileAttachmentLocalArg) (chat1.DownloadAttachmentLocalRes, error) {
-	return chat1.DownloadAttachmentLocalRes{}, nil
+	darg := downloadAttachmentArg{
+		SessionID:      arg.SessionID,
+		ConversationID: arg.ConversationID,
+		MessageID:      arg.MessageID,
+		Preview:        arg.Preview,
+	}
+	sink, err := os.Create(arg.Filename)
+	if err != nil {
+		return chat1.DownloadAttachmentLocalRes{}, err
+	}
+	darg.Sink = sink
+
+	return h.downloadAttachmentLocal(ctx, darg)
 }
 
 type downloadAttachmentArg struct {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -251,15 +251,6 @@ protocol local {
     array<RateLimit> rateLimits;
   }
 
-  record LocalSource {
-    keybase1.Stream source;
-    string filename;
-    int size;
-  }
-
-  // Post an attachment in source to conversationID.
-  PostLocalRes postAttachmentLocal(int sessionID, ConversationID conversationID, MessageClientHeader clientHeader, LocalSource attachment, union { null, LocalSource } preview, string title, bytes metadata);
-
   NewConversationLocalRes newConversationLocal(string tlfName, TopicType topicType, TLFVisibility tlfVisibility, union { null, string } topicName);
   record NewConversationLocalRes {
     ConversationLocal conv;
@@ -312,11 +303,35 @@ protocol local {
     array<RateLimit> rateLimits;
   }
 
-  // Download an attachment from a message into sink.
+  // LocalSource is a stream attachment source.
+  record LocalSource {
+    keybase1.Stream source;
+    string filename;
+    int size;
+  }
+
+  // Post an attachment from stream source to conversationID.
+  PostLocalRes postAttachmentLocal(int sessionID, ConversationID conversationID, MessageClientHeader clientHeader, LocalSource attachment, union { null, LocalSource } preview, string title, bytes metadata);
+
+  // LocalFileSource is a file attachment source.  Filename must be readable
+  // by the service for the duration of the attachment upload.
+  record LocalFileSource {
+    string filename;
+  }
+
+  // Post an attachment from file source to conversationID.
+  PostLocalRes postFileAttachmentLocal(int sessionID, ConversationID conversationID, MessageClientHeader clientHeader, LocalFileSource attachment, union { null, LocalFileSource } preview, string title, bytes metadata);
+
   record DownloadAttachmentLocalRes {
     array<RateLimit> rateLimits;
   }
+
+  // Download an attachment from a message into sink stream.
   DownloadAttachmentLocalRes DownloadAttachmentLocal(int sessionID, ConversationID conversationID, MessageID messageID, keybase1.Stream sink, boolean preview);
+  
+  // Download an attachment from a message into a local file.  
+  // Filename must be writable by the service.
+  DownloadAttachmentLocalRes DownloadFileAttachmentLocal(int sessionID, ConversationID conversationID, MessageID messageID, string filename, boolean preview);
 
   void CancelPost(OutboxID outboxID); 
   void RetryPost(OutboxID outboxID);

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -139,6 +139,18 @@ export function localDownloadAttachmentLocalRpcPromise (request: $Exact<requestC
   return new Promise((resolve, reject) => { localDownloadAttachmentLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function localDownloadFileAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadFileAttachmentLocalResult) => void} & {param: localDownloadFileAttachmentLocalRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.DownloadFileAttachmentLocal'})
+}
+
+export function localDownloadFileAttachmentLocalRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadFileAttachmentLocalResult) => void} & {param: localDownloadFileAttachmentLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localDownloadFileAttachmentLocalRpc({...request, incomingCallMap, callback}))
+}
+
+export function localDownloadFileAttachmentLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadFileAttachmentLocalResult) => void} & {param: localDownloadFileAttachmentLocalRpcParam}>): Promise<localDownloadFileAttachmentLocalResult> {
+  return new Promise((resolve, reject) => { localDownloadFileAttachmentLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function localGetConversationForCLILocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {param: localGetConversationForCLILocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.getConversationForCLILocal'})
 }
@@ -233,6 +245,18 @@ export function localPostAttachmentLocalRpcChannelMap (channelConfig: ChannelCon
 
 export function localPostAttachmentLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostAttachmentLocalResult) => void} & {param: localPostAttachmentLocalRpcParam}>): Promise<localPostAttachmentLocalResult> {
   return new Promise((resolve, reject) => { localPostAttachmentLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
+export function localPostFileAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {param: localPostFileAttachmentLocalRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.postFileAttachmentLocal'})
+}
+
+export function localPostFileAttachmentLocalRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {param: localPostFileAttachmentLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localPostFileAttachmentLocalRpc({...request, incomingCallMap, callback}))
+}
+
+export function localPostFileAttachmentLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {param: localPostFileAttachmentLocalRpcParam}>): Promise<localPostFileAttachmentLocalResult> {
+  return new Promise((resolve, reject) => { localPostFileAttachmentLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function localPostLocalNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalNonblockResult) => void} & {param: localPostLocalNonblockRpcParam}>) {
@@ -693,6 +717,10 @@ export type IncomingMessage = {
   convID: ConversationID,
 }
 
+export type LocalFileSource = {
+  filename: string,
+}
+
 export type LocalSource = {
   source: keybase1.Stream,
   filename: string,
@@ -1017,6 +1045,13 @@ export type localDownloadAttachmentLocalRpcParam = Exact<{
   preview: boolean
 }>
 
+export type localDownloadFileAttachmentLocalRpcParam = Exact<{
+  conversationID: ConversationID,
+  messageID: MessageID,
+  filename: string,
+  preview: boolean
+}>
+
 export type localGetConversationForCLILocalRpcParam = Exact<{
   query: GetConversationForCLILocalQuery
 }>
@@ -1058,6 +1093,15 @@ export type localPostAttachmentLocalRpcParam = Exact<{
   clientHeader: MessageClientHeader,
   attachment: LocalSource,
   preview?: ?LocalSource,
+  title: string,
+  metadata: bytes
+}>
+
+export type localPostFileAttachmentLocalRpcParam = Exact<{
+  conversationID: ConversationID,
+  clientHeader: MessageClientHeader,
+  attachment: LocalFileSource,
+  preview?: ?LocalFileSource,
   title: string,
   metadata: bytes
 }>
@@ -1142,6 +1186,8 @@ export type remoteTlfFinalizeRpcParam = Exact<{
 
 type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 
+type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
+
 type localGetConversationForCLILocalResult = GetConversationForCLILocalRes
 
 type localGetInboxAndUnboxLocalResult = GetInboxAndUnboxLocalRes
@@ -1157,6 +1203,8 @@ type localGetThreadLocalResult = GetThreadLocalRes
 type localNewConversationLocalResult = NewConversationLocalRes
 
 type localPostAttachmentLocalResult = PostLocalRes
+
+type localPostFileAttachmentLocalResult = PostLocalRes
 
 type localPostLocalNonblockResult = PostLocalNonblockRes
 
@@ -1189,6 +1237,7 @@ type remoteSetConversationStatusResult = SetConversationStatusRes
 export type rpc =
     localCancelPostRpc
   | localDownloadAttachmentLocalRpc
+  | localDownloadFileAttachmentLocalRpc
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc
   | localGetInboxLocalRpc
@@ -1197,6 +1246,7 @@ export type rpc =
   | localGetThreadLocalRpc
   | localNewConversationLocalRpc
   | localPostAttachmentLocalRpc
+  | localPostFileAttachmentLocalRpc
   | localPostLocalNonblockRpc
   | localPostLocalRpc
   | localRetryPostRpc

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -811,24 +811,6 @@
     },
     {
       "type": "record",
-      "name": "LocalSource",
-      "fields": [
-        {
-          "type": "keybase1.Stream",
-          "name": "source"
-        },
-        {
-          "type": "string",
-          "name": "filename"
-        },
-        {
-          "type": "int",
-          "name": "size"
-        }
-      ]
-    },
-    {
-      "type": "record",
       "name": "NewConversationLocalRes",
       "fields": [
         {
@@ -983,6 +965,34 @@
     },
     {
       "type": "record",
+      "name": "LocalSource",
+      "fields": [
+        {
+          "type": "keybase1.Stream",
+          "name": "source"
+        },
+        {
+          "type": "string",
+          "name": "filename"
+        },
+        {
+          "type": "int",
+          "name": "size"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "LocalFileSource",
+      "fields": [
+        {
+          "type": "string",
+          "name": "filename"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "DownloadAttachmentLocalRes",
       "fields": [
         {
@@ -1100,42 +1110,6 @@
       ],
       "response": "SetConversationStatusLocalRes"
     },
-    "postAttachmentLocal": {
-      "request": [
-        {
-          "name": "sessionID",
-          "type": "int"
-        },
-        {
-          "name": "conversationID",
-          "type": "ConversationID"
-        },
-        {
-          "name": "clientHeader",
-          "type": "MessageClientHeader"
-        },
-        {
-          "name": "attachment",
-          "type": "LocalSource"
-        },
-        {
-          "name": "preview",
-          "type": [
-            null,
-            "LocalSource"
-          ]
-        },
-        {
-          "name": "title",
-          "type": "string"
-        },
-        {
-          "name": "metadata",
-          "type": "bytes"
-        }
-      ],
-      "response": "PostLocalRes"
-    },
     "newConversationLocal": {
       "request": [
         {
@@ -1194,6 +1168,78 @@
       ],
       "response": "GetMessagesLocalRes"
     },
+    "postAttachmentLocal": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "clientHeader",
+          "type": "MessageClientHeader"
+        },
+        {
+          "name": "attachment",
+          "type": "LocalSource"
+        },
+        {
+          "name": "preview",
+          "type": [
+            null,
+            "LocalSource"
+          ]
+        },
+        {
+          "name": "title",
+          "type": "string"
+        },
+        {
+          "name": "metadata",
+          "type": "bytes"
+        }
+      ],
+      "response": "PostLocalRes"
+    },
+    "postFileAttachmentLocal": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "clientHeader",
+          "type": "MessageClientHeader"
+        },
+        {
+          "name": "attachment",
+          "type": "LocalFileSource"
+        },
+        {
+          "name": "preview",
+          "type": [
+            null,
+            "LocalFileSource"
+          ]
+        },
+        {
+          "name": "title",
+          "type": "string"
+        },
+        {
+          "name": "metadata",
+          "type": "bytes"
+        }
+      ],
+      "response": "PostLocalRes"
+    },
     "DownloadAttachmentLocal": {
       "request": [
         {
@@ -1211,6 +1257,31 @@
         {
           "name": "sink",
           "type": "keybase1.Stream"
+        },
+        {
+          "name": "preview",
+          "type": "boolean"
+        }
+      ],
+      "response": "DownloadAttachmentLocalRes"
+    },
+    "DownloadFileAttachmentLocal": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "messageID",
+          "type": "MessageID"
+        },
+        {
+          "name": "filename",
+          "type": "string"
         },
         {
           "name": "preview",

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -139,6 +139,18 @@ export function localDownloadAttachmentLocalRpcPromise (request: $Exact<requestC
   return new Promise((resolve, reject) => { localDownloadAttachmentLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function localDownloadFileAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadFileAttachmentLocalResult) => void} & {param: localDownloadFileAttachmentLocalRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.DownloadFileAttachmentLocal'})
+}
+
+export function localDownloadFileAttachmentLocalRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadFileAttachmentLocalResult) => void} & {param: localDownloadFileAttachmentLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localDownloadFileAttachmentLocalRpc({...request, incomingCallMap, callback}))
+}
+
+export function localDownloadFileAttachmentLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadFileAttachmentLocalResult) => void} & {param: localDownloadFileAttachmentLocalRpcParam}>): Promise<localDownloadFileAttachmentLocalResult> {
+  return new Promise((resolve, reject) => { localDownloadFileAttachmentLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function localGetConversationForCLILocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {param: localGetConversationForCLILocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.getConversationForCLILocal'})
 }
@@ -233,6 +245,18 @@ export function localPostAttachmentLocalRpcChannelMap (channelConfig: ChannelCon
 
 export function localPostAttachmentLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostAttachmentLocalResult) => void} & {param: localPostAttachmentLocalRpcParam}>): Promise<localPostAttachmentLocalResult> {
   return new Promise((resolve, reject) => { localPostAttachmentLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
+export function localPostFileAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {param: localPostFileAttachmentLocalRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.postFileAttachmentLocal'})
+}
+
+export function localPostFileAttachmentLocalRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {param: localPostFileAttachmentLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localPostFileAttachmentLocalRpc({...request, incomingCallMap, callback}))
+}
+
+export function localPostFileAttachmentLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {param: localPostFileAttachmentLocalRpcParam}>): Promise<localPostFileAttachmentLocalResult> {
+  return new Promise((resolve, reject) => { localPostFileAttachmentLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function localPostLocalNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalNonblockResult) => void} & {param: localPostLocalNonblockRpcParam}>) {
@@ -693,6 +717,10 @@ export type IncomingMessage = {
   convID: ConversationID,
 }
 
+export type LocalFileSource = {
+  filename: string,
+}
+
 export type LocalSource = {
   source: keybase1.Stream,
   filename: string,
@@ -1017,6 +1045,13 @@ export type localDownloadAttachmentLocalRpcParam = Exact<{
   preview: boolean
 }>
 
+export type localDownloadFileAttachmentLocalRpcParam = Exact<{
+  conversationID: ConversationID,
+  messageID: MessageID,
+  filename: string,
+  preview: boolean
+}>
+
 export type localGetConversationForCLILocalRpcParam = Exact<{
   query: GetConversationForCLILocalQuery
 }>
@@ -1058,6 +1093,15 @@ export type localPostAttachmentLocalRpcParam = Exact<{
   clientHeader: MessageClientHeader,
   attachment: LocalSource,
   preview?: ?LocalSource,
+  title: string,
+  metadata: bytes
+}>
+
+export type localPostFileAttachmentLocalRpcParam = Exact<{
+  conversationID: ConversationID,
+  clientHeader: MessageClientHeader,
+  attachment: LocalFileSource,
+  preview?: ?LocalFileSource,
   title: string,
   metadata: bytes
 }>
@@ -1142,6 +1186,8 @@ export type remoteTlfFinalizeRpcParam = Exact<{
 
 type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 
+type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
+
 type localGetConversationForCLILocalResult = GetConversationForCLILocalRes
 
 type localGetInboxAndUnboxLocalResult = GetInboxAndUnboxLocalRes
@@ -1157,6 +1203,8 @@ type localGetThreadLocalResult = GetThreadLocalRes
 type localNewConversationLocalResult = NewConversationLocalRes
 
 type localPostAttachmentLocalResult = PostLocalRes
+
+type localPostFileAttachmentLocalResult = PostLocalRes
 
 type localPostLocalNonblockResult = PostLocalNonblockRes
 
@@ -1189,6 +1237,7 @@ type remoteSetConversationStatusResult = SetConversationStatusRes
 export type rpc =
     localCancelPostRpc
   | localDownloadAttachmentLocalRpc
+  | localDownloadFileAttachmentLocalRpc
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc
   | localGetInboxLocalRpc
@@ -1197,6 +1246,7 @@ export type rpc =
   | localGetThreadLocalRpc
   | localNewConversationLocalRpc
   | localPostAttachmentLocalRpc
+  | localPostFileAttachmentLocalRpc
   | localPostLocalNonblockRpc
   | localPostLocalRpc
   | localRetryPostRpc


### PR DESCRIPTION
Instead of using the keybase stream interface to stream file contents to/from the service, this allows clients to provide a local filename as an attachment upload source or download destination.

This was requested by @chrisnojima as it would be easier for desktop to integrate than implementing the stream interface and because js msgpack performance is subpar.

The existing stream interface is left unchanged and CLI, json api use it by default.  There is a new option "nostream" that can be used in the json api that will use these endpoints instead of the stream endpoints.

r? @mmaxim 

cc @chrisnojima @maxtaco 