### PR TITLE
Combine HMR handlers for Main and routes

### DIFF
--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -130,7 +130,8 @@ function setupHMR (store) {
     return
   }
 
-  module.hot.accept('../shared/main.desktop', () => {
+  module.hot && module.hot.accept(['../shared/main.desktop', '../shared/routes'], () => {
+    store.dispatch(setRouteDef(require('../shared/routes').default))
     try {
       store.dispatch({type: updateReloading, payload: {reloading: true}})
       const NewMain = require('../shared/main.desktop').default
@@ -139,10 +140,6 @@ function setupHMR (store) {
     } finally {
       setTimeout(() => store.dispatch({type: updateReloading, payload: {reloading: false}}), 10e3)
     }
-  })
-
-  module.hot && module.hot.accept(['../shared/main.desktop', '../shared/routes'], () => {
-    store.dispatch(setRouteDef(require('../shared/routes').default))
   })
 
   module.hot && module.hot.accept('../shared/local-debug-live', () => {


### PR DESCRIPTION
It's necessary to re-render the AppContainer whenever we're HMRing React
components because it forces a deep update (which is necessary because
some components like connect() will otherwise skip the update via
shouldComponentUpdate).

:eyeglasses: @keybase/react-hackers 