### PR TITLE
Add Reflect polyfill for native

### DIFF
--- a/react-native/package.json
+++ b/react-native/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "buffer": "5.0.0",
+    "core-js": "1.2.7",
     "deep-diff": "0.3.4",
     "framed-msgpack-rpc": "1.1.13",
     "getenv": "0.7.0",

--- a/shared/index.native.js
+++ b/shared/index.native.js
@@ -1,4 +1,6 @@
 // @flow
+import 'core-js/es6/reflect'  // required for babel-plugin-transform-builtin-extend in RN iOS and Android
+import 'core-js/es6/object'  // required for babel-plugin-transform-builtin-extend in RN Android
 import './globals.native'
 import DumbSheet from './dev/dumb-sheet'
 import Main from './main'

--- a/shared/package.json
+++ b/shared/package.json
@@ -2,6 +2,7 @@
   "name": "keybase-shared",
   "description": "Shared code for desktop and mobile clients",
   "dependencies": {
+    "core-js": "1.2.7",
     "deep-diff": "0.3.4",
     "deep-equal": "1.0.1",
     "framed-msgpack-rpc": "1.1.13",


### PR DESCRIPTION
Turns out native is currently broken outside of browser debugging mode because we were leaning on Chrome's support of the es6 Reflect API.

~This change switches babel-plugin-transform-builtin-extend to use an alternate transform that doesn't require newfangled ES6 functions.~

This is needed by babel-plugin-transform-builtin-extend. I added this two days ago and didn't think to test in this way. Oops! :sweat:

:eyeglasses: @keybase/react-hackers 