### PR TITLE
Fix broken people I don't follow

### DIFF
--- a/shared/profile/dumb.js
+++ b/shared/profile/dumb.js
@@ -280,18 +280,28 @@ const dumbMap: DumbComponentMap<Profile> = {
       ...propsBase,
       afterMount: c => c.setState({foldersExpanded: true}),
     },
+    'Unfollowed - Changed (Proofs unreachable)': {
+      ...propsBase,
+      proofs: proofsChanged,
+      trackerState: error,
+    },
+    'Unfollowed - Changed (Proofs deleted)': {
+      ...propsBase,
+      proofs: proofsDeleted,
+      trackerState: error,
+    },
     'Followed': {
       ...propsBase,
       proofs: proofsTracked,
       currentlyFollowing: true,
     },
-    'Changed': {
+    'Followed - Changed': {
       ...propsBase,
       proofs: proofsDeleted,
       trackerState: error,
       currentlyFollowing: true,
     },
-    'Changed - Scrolled': {
+    'Followed - Changed - Scrolled': {
       ...propsBase,
       proofs: proofsDeleted,
       trackerState: error,

--- a/shared/profile/dumb.js
+++ b/shared/profile/dumb.js
@@ -283,12 +283,10 @@ const dumbMap: DumbComponentMap<Profile> = {
     'Unfollowed - Changed (Proofs unreachable)': {
       ...propsBase,
       proofs: proofsChanged,
-      trackerState: error,
     },
     'Unfollowed - Changed (Proofs deleted)': {
       ...propsBase,
       proofs: proofsDeleted,
-      trackerState: error,
     },
     'Followed': {
       ...propsBase,

--- a/shared/tracker/dumb.desktop.js
+++ b/shared/tracker/dumb.desktop.js
@@ -266,7 +266,7 @@ const dumbMap: DumbComponentMap<Tracker> = {
     },
     'New user, follows me': trackerPropsToRenderProps(propsNewUserFollowsYou),
     'Followed': trackerPropsToRenderProps(propsFollowing),
-    'Changed/Broken proofs user you don\'t follow': trackerPropsToRenderProps({...propsChangedProofs, currentlyFollowing: false}),
+    'Changed/Broken proofs user you don\'t follow': trackerPropsToRenderProps({...propsNewUserFollowsYou, proofs: proofsChanged}),
     'Changed/Broken proofs': trackerPropsToRenderProps(propsChangedProofs),
     'You follow them': trackerPropsToRenderProps({...propsFollowing, userInfo: {...propsNewUser.userInfo, followsYou: false}}),
     'Unfollowed': trackerPropsToRenderProps(propsUnfollowed),

--- a/shared/util/tracker.js
+++ b/shared/util/tracker.js
@@ -12,16 +12,17 @@ type StateColors = {
 }
 
 export function stateColors (currentlyFollowing: boolean, trackerState: SimpleProofState, defaultColor?: string): StateColors {
-  if ([warning, error].indexOf(trackerState) !== -1) {
-    return {
-      header: {background: globalColors.red, text: globalColors.white},
-      username: globalColors.red,
-    }
-  }
   if (currentlyFollowing) {
-    return {
-      header: {background: globalColors.green, text: globalColors.white},
-      username: globalColors.green2,
+    if ([warning, error].indexOf(trackerState) !== -1) {
+      return {
+        header: {background: globalColors.red, text: globalColors.white},
+        username: globalColors.red,
+      }
+    } else {
+      return {
+        header: {background: globalColors.green, text: globalColors.white},
+        username: globalColors.green2,
+      }
     }
   } else {
     return {


### PR DESCRIPTION
@keybase/react-hackers Just fixed the tracker and profile page so that users I don't follow are blue no matter what, i.e even with broken proofs (before, they were red).