### PR TITLE
export remote track links in UPAK, and use in identify

### DIFF
--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -129,7 +129,7 @@ func (e *loginProvision) Run(ctx *Context) error {
 	// provisioning was successful, so the user has changed:
 	e.G().NotifyRouter.HandleKeyfamilyChanged(e.arg.User.GetUID())
 	// Remove this after kbfs notification change complete
-	e.G().NotifyRouter.HandleUserChanged(e.arg.User.GetUID())
+	e.G().UserChanged(e.arg.User.GetUID())
 
 	return nil
 }

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -100,7 +100,7 @@ func (e *PaperKeyGen) Run(ctx *Context) error {
 	}
 	e.G().NotifyRouter.HandleKeyfamilyChanged(e.arg.Me.GetUID())
 	// Remove this after kbfs notification change complete
-	e.G().NotifyRouter.HandleUserChanged(e.arg.Me.GetUID())
+	e.G().UserChanged(e.arg.Me.GetUID())
 
 	return nil
 }

--- a/go/engine/paperkey_submit.go
+++ b/go/engine/paperkey_submit.go
@@ -71,7 +71,7 @@ func (e *PaperKeySubmit) Run(ctx *Context) error {
 	e.G().NotifyRouter.HandlePaperKeyCached(me.GetUID(), e.pair.encKey.GetKID(), e.pair.sigKey.GetKID())
 
 	// XXX - this is temporary until KBFS handles the above notification
-	e.G().NotifyRouter.HandleUserChanged(me.GetUID())
+	e.G().UserChanged(me.GetUID())
 
 	return nil
 }

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -4,10 +4,9 @@
 package engine
 
 import (
-	"testing"
-
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"testing"
 )
 
 func runTrack(tc libkb.TestContext, fu *FakeUser, username string) (idUI *FakeIdentifyUI, them *libkb.User, err error) {
@@ -354,6 +353,14 @@ func TestIdentifyTrackRaceDetection(t *testing.T) {
 		fui1 := &FakeIdentifyUI{}
 		fui2 := &FakeIdentifyUI{}
 		doID(dev1, fui1)
+		if i > 0 {
+			// Device2 won't know that device1 made a change to the ME user
+			// in time to make this test pass. So we hack in an invalidation.
+			// We might have used the fact the userchanged notifications are bounced
+			// off of the server, but that might slow down this test, so do the
+			// simple and non-flakey thing.
+			dev2.G.CachedUserLoader.Invalidate(libkb.UsernameToUID(user.Username))
+		}
 		doID(dev2, fui2)
 		trackSucceed(dev1, fui1)
 		trackFail(dev2, fui2, (i == 0))

--- a/go/engine/track_token.go
+++ b/go/engine/track_token.go
@@ -123,9 +123,12 @@ func (e *TrackToken) Run(ctx *Context) (err error) {
 	}
 
 	if err == nil {
-		// Remove these after desktop notification change complete:
-		e.G().NotifyRouter.HandleUserChanged(e.arg.Me.GetUID())
-		e.G().NotifyRouter.HandleUserChanged(e.them.GetUID())
+		// Remove this after desktop notification change complete:
+		e.G().UserChanged(e.them.GetUID())
+
+		// Remove these after desktop notification change complete, but
+		// add in: e.G().BustLocalUserCache(e.arg.Me.GetUID())
+		e.G().UserChanged(e.arg.Me.GetUID())
 
 		// Keep these:
 		e.G().NotifyRouter.HandleTrackingChanged(e.arg.Me.GetUID(), e.arg.Me.GetName())

--- a/go/engine/track_token_test.go
+++ b/go/engine/track_token_test.go
@@ -436,14 +436,15 @@ func TestTrackFailTempRecover(t *testing.T) {
 	// Advance the clock to make sure local temp track goes away
 	fakeClock.Advance(tc.G.Env.GetLocalTrackMaxAge() + time.Minute)
 
-	if _, e2 := eng.i2eng.getTrackChainLink(true); e2 == nil {
-		t.Fatalf("Expected no temporary LocalTrackChainLinkFor %s", username)
+	if err := eng.i2eng.createIdentifyState(); err != nil {
+		t.Fatal(err)
 	}
-
-	if _, e2 := eng.i2eng.getTrackChainLink(false); e2 != nil {
+	if eng.i2eng.state.TrackLookup() == nil {
 		t.Fatalf("Expected permanent LocalTrackChainLinkFor %s", username)
 	}
-
+	if eng.i2eng.state.TmpTrackLookup() != nil {
+		t.Fatalf("Expected no temporary LocalTrackChainLinkFor %s", username)
+	}
 	assertTracking(tc, username)
 }
 

--- a/go/engine/untrack.go
+++ b/go/engine/untrack.go
@@ -99,8 +99,8 @@ func (e *UntrackEngine) Run(ctx *Context) (err error) {
 		return
 	}
 
-	e.G().NotifyRouter.HandleUserChanged(e.arg.Me.GetUID())
-	e.G().NotifyRouter.HandleUserChanged(them.GetUID())
+	e.G().UserChanged(e.arg.Me.GetUID())
+	e.G().UserChanged(them.GetUID())
 
 	e.G().NotifyRouter.HandleTrackingChanged(e.arg.Me.GetUID(), e.arg.Me.GetName())
 	e.G().NotifyRouter.HandleTrackingChanged(them.GetUID(), them.GetName())

--- a/go/libkb/cached_user_loader.go
+++ b/go/libkb/cached_user_loader.go
@@ -141,6 +141,7 @@ func (u *CachedUserLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 	ret.Base.Uvv.CachedAt = keybase1.ToTime(u.G().Clock().Now())
 	u.Lock()
 	u.m[arg.UID.String()] = ret
+	u.G().Log.Debug("| CachedUserLoader#Load(%s): Caching: %+v", arg.UID, *ret)
 	u.Unlock()
 
 	return ret, user, nil
@@ -196,4 +197,11 @@ func (u *CachedUserLoader) LoadUserPlusKeys(uid keybase1.UID) (keybase1.UserPlus
 	}
 	up = upak.Base
 	return up, nil
+}
+
+func (u *CachedUserLoader) Invalidate(uid keybase1.UID) {
+	u.Lock()
+	defer u.Unlock()
+	u.G().Log.Debug("CachedUserLoader#Invalidate(%s)", uid)
+	delete(u.m, uid.String())
 }

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -31,6 +31,10 @@ func GetLinkID(w *jsonw.Wrapper) (LinkID, error) {
 	return ret, err
 }
 
+func ImportLinkID(i keybase1.LinkID) (LinkID, error) {
+	return LinkIDFromHex(string(i))
+}
+
 func GetLinkIDVoid(w *jsonw.Wrapper, l *LinkID, e *error) {
 	ret, err := GetLinkID(w)
 	if err != nil {
@@ -748,4 +752,8 @@ func (c *ChainLink) Copy() ChainLink {
 	}
 
 	return r
+}
+
+func (c ChainLink) LinkID() LinkID {
+	return c.id
 }

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -136,6 +136,7 @@ func (g *GlobalContext) Init() *GlobalContext {
 	g.Resolver = NewResolver(g)
 	g.RateLimits = NewRateLimits(g)
 	g.CachedUserLoader = NewCachedUserLoader(g, CachedUserTimeout)
+
 	return g
 }
 
@@ -744,4 +745,17 @@ func (g *GlobalContext) UIDToUsername(uid keybase1.UID) (NormalizedUsername, err
 		return NormalizedUsername(""), err
 	}
 	return NewNormalizedUsername(leaf.username), nil
+}
+
+func (g *GlobalContext) BustLocalUserCache(u keybase1.UID) {
+	if g.CachedUserLoader != nil {
+		g.CachedUserLoader.Invalidate(u)
+	}
+}
+
+func (g *GlobalContext) UserChanged(u keybase1.UID) {
+	g.BustLocalUserCache(u)
+	if g.NotifyRouter != nil {
+		g.NotifyRouter.HandleUserChanged(u)
+	}
 }

--- a/go/libkb/identify_state.go
+++ b/go/libkb/identify_state.go
@@ -51,6 +51,10 @@ func (s *IdentifyState) Result() *IdentifyOutcome {
 	return s.res
 }
 
+func (s *IdentifyState) TmpTrackLookup() *TrackLookup {
+	return s.tmpTrack
+}
+
 func (s *IdentifyState) computeRevokedProofs() {
 	if s.track == nil {
 		return

--- a/go/libkb/track.go
+++ b/go/libkb/track.go
@@ -421,7 +421,7 @@ func localTrackChainLinkFor(tracker, trackee keybase1.UID, localExpires bool, g 
 	if localExpires {
 		linkETime = cl.GetCTime().Add(g.Env.GetLocalTrackMaxAge())
 
-		g.Log.Debug("| := local track created %s, expires: %s, it is now %s", cl.GetCTime(), linkETime.String(), g.Clock().Now())
+		g.Log.Debug("| local track created %s, expires: %s, it is now %s", cl.GetCTime(), linkETime.String(), g.Clock().Now())
 
 		if linkETime.Before(g.Clock().Now()) {
 			g.Log.Debug("| expired local track, deleting")

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -24,6 +24,7 @@ type UID string
 type DeviceID string
 type SigID string
 type KID string
+type LinkID string
 type BinaryKID []byte
 type TLFID string
 type Bytes32 [32]byte
@@ -176,9 +177,16 @@ type UserPlusKeys struct {
 	Uvv               UserVersionVector `codec:"uvv" json:"uvv"`
 }
 
+type RemoteTrack struct {
+	Username string `codec:"username" json:"username"`
+	Uid      UID    `codec:"uid" json:"uid"`
+	LinkID   LinkID `codec:"linkID" json:"linkID"`
+}
+
 type UserPlusAllKeys struct {
-	Base    UserPlusKeys `codec:"base" json:"base"`
-	PGPKeys []PublicKey  `codec:"pgpKeys" json:"pgpKeys"`
+	Base         UserPlusKeys  `codec:"base" json:"base"`
+	PGPKeys      []PublicKey   `codec:"pgpKeys" json:"pgpKeys"`
+	RemoteTracks []RemoteTrack `codec:"remoteTracks" json:"remoteTracks"`
 }
 
 type MerkleTreeID int

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -779,6 +780,16 @@ func (u *UserPlusAllKeys) DeepCopy() *UserPlusAllKeys {
 	var ret UserPlusAllKeys
 	dec.Decode(&ret)
 	return &ret
+}
+
+func (u UserPlusAllKeys) GetRemoteTrack(s string) *RemoteTrack {
+	i := sort.Search(len(u.RemoteTracks), func(j int) bool {
+		return u.RemoteTracks[j].Username >= s
+	})
+	if i < 0 || i >= len(u.RemoteTracks) {
+		return nil
+	}
+	return &u.RemoteTracks[i]
 }
 
 func (u UserPlusAllKeys) GetUID() UID {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -786,7 +786,7 @@ func (u UserPlusAllKeys) GetRemoteTrack(s string) *RemoteTrack {
 	i := sort.Search(len(u.RemoteTracks), func(j int) bool {
 		return u.RemoteTracks[j].Username >= s
 	})
-	if i < 0 || i >= len(u.RemoteTracks) {
+	if i >= len(u.RemoteTracks) {
 		return nil
 	}
 	return &u.RemoteTracks[i]

--- a/go/service/user_handler.go
+++ b/go/service/user_handler.go
@@ -46,7 +46,7 @@ func (r *userHandler) keyChange() error {
 }
 
 func (r *userHandler) identityChange() error {
-	r.G().NotifyRouter.HandleUserChanged(r.G().Env.GetUID())
+	r.G().UserChanged(r.G().Env.GetUID())
 	return nil
 }
 

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -30,6 +30,10 @@ protocol Common {
   @typedef("string")
   record KID {}
 
+  // Chain link IDs
+  @typedef("string")
+  record LinkID {}
+
   // But sometimes we need binary kids...
   @typedef("bytes")
   record BinaryKID {}
@@ -144,9 +148,16 @@ protocol Common {
       UserVersionVector uvv;
   }
 
+  record RemoteTrack {
+      string username;
+      UID uid;
+      LinkID linkID;
+  }
+
   record UserPlusAllKeys {
       UserPlusKeys base;
       array<PublicKey> pgpKeys;
+      array<RemoteTrack> remoteTracks;
   }
 
   enum MerkleTreeID {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3240,6 +3240,8 @@ export type LinkCheckResult = {
   breaksTracking: boolean,
 }
 
+export type LinkID = string
+
 export type ListResult = {
   files?: ?Array<File>,
 }
@@ -3616,6 +3618,12 @@ export type RemoteProof = {
   displayMarkup: string,
   sigID: SigID,
   mTime: Time,
+}
+
+export type RemoteTrack = {
+  username: string,
+  uid: UID,
+  linkID: LinkID,
 }
 
 export type RevokeWarning = {
@@ -4054,6 +4062,7 @@ export type UserCard = {
 export type UserPlusAllKeys = {
   base: UserPlusKeys,
   pgpKeys?: ?Array<PublicKey>,
+  remoteTracks?: ?Array<RemoteTrack>,
 }
 
 export type UserPlusKeys = {

--- a/protocol/json/keybase1/common.json
+++ b/protocol/json/keybase1/common.json
@@ -73,6 +73,12 @@
     },
     {
       "type": "record",
+      "name": "LinkID",
+      "fields": [],
+      "typedef": "string"
+    },
+    {
+      "type": "record",
       "name": "BinaryKID",
       "fields": [],
       "typedef": "bytes"
@@ -367,6 +373,24 @@
     },
     {
       "type": "record",
+      "name": "RemoteTrack",
+      "fields": [
+        {
+          "type": "string",
+          "name": "username"
+        },
+        {
+          "type": "UID",
+          "name": "uid"
+        },
+        {
+          "type": "LinkID",
+          "name": "linkID"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "UserPlusAllKeys",
       "fields": [
         {
@@ -379,6 +403,13 @@
             "items": "PublicKey"
           },
           "name": "pgpKeys"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RemoteTrack"
+          },
+          "name": "remoteTracks"
         }
       ]
     },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3240,6 +3240,8 @@ export type LinkCheckResult = {
   breaksTracking: boolean,
 }
 
+export type LinkID = string
+
 export type ListResult = {
   files?: ?Array<File>,
 }
@@ -3616,6 +3618,12 @@ export type RemoteProof = {
   displayMarkup: string,
   sigID: SigID,
   mTime: Time,
+}
+
+export type RemoteTrack = {
+  username: string,
+  uid: UID,
+  linkID: LinkID,
 }
 
 export type RevokeWarning = {
@@ -4054,6 +4062,7 @@ export type UserCard = {
 export type UserPlusAllKeys = {
   base: UserPlusKeys,
   pgpKeys?: ?Array<PublicKey>,
+  remoteTracks?: ?Array<RemoteTrack>,
 }
 
 export type UserPlusKeys = {


### PR DESCRIPTION
- this is a very useful optimization, since if you're doing a ton of identifies, you only need to load yourself once
- make sure we invalidate the self when we track or otherwise have a userChanged event
- all tests pass, though TestIdentifyTrackRaceDetection might be flakey