### PR TITLE
Remove flow type from visdiff webpack since it breaks visdiff on ci

### DIFF
--- a/desktop/webpack.config.visdiff.js
+++ b/desktop/webpack.config.visdiff.js
@@ -1,4 +1,4 @@
-const webpack = require('webpack') // eslint-disable-line
+const webpack = require('webpack') // eslint-disable-line flowtype/require-valid-file-annotation
 const webpackTargetElectronRenderer = require('webpack-target-electron-renderer')
 const baseConfig = require('./webpack.config.base')
 const config = Object.assign({}, baseConfig)

--- a/desktop/webpack.config.visdiff.js
+++ b/desktop/webpack.config.visdiff.js
@@ -1,8 +1,7 @@
-// @flow
-const webpack = require('webpack')
+const webpack = require('webpack') // eslint-disable-line
 const webpackTargetElectronRenderer = require('webpack-target-electron-renderer')
 const baseConfig = require('./webpack.config.base')
-const config: any = Object.assign({}, baseConfig)
+const config = Object.assign({}, baseConfig)
 
 const defines = {
   '__DEV__': true,


### PR DESCRIPTION
@keybase/react-hackers 