### PR TITLE
check camelcase in linter and add special handling

### DIFF
--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -87,6 +87,7 @@ protocol common {
   }
 
   record ConversationIDTriple {
+    @lint("ignore")
     TLFID tlfid;
     TopicType topicType;
     TopicID topicID;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -317,6 +317,7 @@ protocol local {
 
     UnreadFirstNumLimit limit;
 
+    @lint("ignore")
     ConversationID conversationId;
   }
   record GetConversationForCLILocalRes {

--- a/protocol/avdl/keybase1/backend_common.avdl
+++ b/protocol/avdl/keybase1/backend_common.avdl
@@ -3,6 +3,7 @@
 protocol backendCommon {
   import idl "common.avdl";
 
+  @lint("ignore")
   record BlockIdCombo{
     string blockHash;
     UID chargedTo;

--- a/protocol/avdl/keybase1/identify_ui.avdl
+++ b/protocol/avdl/keybase1/identify_ui.avdl
@@ -10,6 +10,7 @@ protocol identifyUi {
   }
 
   record IdentifyRow {
+    @lint("ignore")
     int rowId;
     RemoteProof proof;
     union { null, TrackDiff } trackDiff;
@@ -25,6 +26,7 @@ protocol identifyUi {
   }
 
   record Cryptocurrency {
+    @lint("ignore")
     int rowId;
     bytes pkhash;
     string address;
@@ -49,6 +51,7 @@ protocol identifyUi {
   }
 
   record SigHint {
+    @lint("ignore")
     string remoteId;
     string humanUrl;
     string apiUrl;
@@ -68,6 +71,7 @@ protocol identifyUi {
   }
 
   record LinkCheckResult {
+    @lint("ignore")
     int proofId;
     ProofResult proofResult;
     ProofResult snoozedResult;

--- a/protocol/avdl/keybase1/kbfs_common.avdl
+++ b/protocol/avdl/keybase1/kbfs_common.avdl
@@ -44,6 +44,7 @@ protocol kbfsCommon {
     FSNotificationType notificationType;
     FSErrorType errorType;
     map<string> params;
+    @lint("ignore")
     UID writerUid;
     Time localTime;
   }

--- a/protocol/avdl/keybase1/notify_badges.avdl
+++ b/protocol/avdl/keybase1/notify_badges.avdl
@@ -8,6 +8,7 @@ protocol NotifyBadges {
     // Total badge count for the app
     int total;
 
+    @lint("ignore")
     int newTlfs;
     int rekeysNeeded;
     int newFollowers;

--- a/protocol/avdl/keybase1/pgp.avdl
+++ b/protocol/avdl/keybase1/pgp.avdl
@@ -84,13 +84,16 @@ protocol pgp {
   array<KeyInfo> pgpExportByFingerprint(int sessionID, PGPQuery options);
   array<KeyInfo> pgpExportByKID(int sessionID, PGPQuery options);
 
+  @lint("ignore")
   record PGPCreateUids {
     boolean useDefault;
     array<PGPIdentity> ids;
   }
 
+  @lint("ignore")
   void pgpKeyGen(int sessionID, int primaryBits, int subkeyBits, PGPCreateUids createUids, boolean allowMulti, boolean doExport, boolean pushSecret);
 
+  @lint("ignore")
   void pgpKeyGenDefault(int sessionID, PGPCreateUids createUids);
 
   void pgpDeletePrimary(int sessionID);

--- a/protocol/avdl/keybase1/rekey.avdl
+++ b/protocol/avdl/keybase1/rekey.avdl
@@ -17,6 +17,7 @@ protocol rekey {
 
     // MK Note 2016.06.29 -- Please excuse snake case here. It's too much
     // of a pain to change it on the server, so leave it here.
+    @lint("ignore")
     array<KID> solution_kids;
   }
 

--- a/protocol/avdl/keybase1/session.avdl
+++ b/protocol/avdl/keybase1/session.avdl
@@ -7,7 +7,9 @@ protocol session {
     UID uid;
     string username;
     string token;
+    @lint("ignore")
     KID deviceSubkeyKid;
+    @lint("ignore")
     KID deviceSibkeyKid;
   }
 

--- a/protocol/avdl/keybase1/signup.avdl
+++ b/protocol/avdl/keybase1/signup.avdl
@@ -5,8 +5,11 @@ protocol signup {
   import idl "common.avdl";
 
   record SignupRes {
+    @lint("ignore")
     boolean passphraseOk;
+    @lint("ignore")
     boolean postOk;
+    @lint("ignore")
     boolean writeOk;
   }
 

--- a/protocol/avdl/keybase1/tlf.avdl
+++ b/protocol/avdl/keybase1/tlf.avdl
@@ -19,5 +19,6 @@ protocol tlf {
   // The tlfName can be either complete or partial. If the user's username is
   // not present in tlfName, it gets appended automatically. The canonical TLF
   // name is returned.
+  @lint("ignore")
   CanonicalTLFNameAndIDWithBreaks completeAndCanonicalizePrivateTlfName(TLFQuery query);
 }

--- a/protocol/avdl/keybase1/tlf_keys.avdl
+++ b/protocol/avdl/keybase1/tlf_keys.avdl
@@ -13,6 +13,7 @@ protocol tlfKeys {
   }
 
   @typedef("string")
+  @lint("ignore")
   record CanonicalTlfName {}
 
   record CryptKey {

--- a/protocol/bin/flow.js
+++ b/protocol/bin/flow.js
@@ -5,6 +5,7 @@ var fs = promise.promisifyAll(require('fs'))
 var path = require('path')
 var codeGenerators = require('./js-code-generators.js')
 var colors = require('colors')
+var camelcase = require('camelcase');
 
 var projects = {
   'chat1': {
@@ -386,12 +387,53 @@ function decapitalize (s) {
   return s.charAt(0).toLowerCase() + s.slice(1)
 }
 
-function isCapitalized (s) {
-  return decapitalize(s) != s
-}
+const shorthands = [
 
-function isNotCapitalized (s) {
-  return capitalize(s) != s
+  {re:  /Tty([A-Zs]|$)/g, into: 'TTY$1', re2: /^TTY/, into2: 'tty'},
+  {re:  /Tlf([A-Zs]|$)/g, into: 'TLF$1', re2: /^TLF/, into2: 'tlf'},
+  {re:  /Uid([A-Zs]|$)/g, into: 'UID$1', re2: /^UID/, into2: 'uid'},
+  {re:  /Kid([A-Zs]|$)/g, into: 'KID$1', re2: /^KID/, into2: 'kid'},
+  {re:  /Cli([A-Z]|$)/g,  into: 'CLI$1', re2: /^CLI/, into2: 'cli'},
+  {re:  /Api([A-Zs]|$)/g, into: 'API$1', re2: /^API/, into2: 'api'},
+  {re:  /Btc([A-Z]|$)/g,  into: 'BTC$1', re2: /^BTC/, into2: 'btc'},
+  {re:  /Pgp([A-Z]|$)/g,  into: 'PGP$1', re2: /^PGP/, into2: 'pgp'},
+  {re:  /Gpg([A-Z]|$)/g,  into: 'GPG$1', re2: /^GPG/, into2: 'gpg'},
+  {re:  /Uri([A-Zs]|$)/g, into: 'URI$1', re2: /^URI/, into2: 'uri'},
+  {re:  /Gui([A-Z]|$)/g,  into: 'GUI$1', re2: /^GUI/, into2: 'gui'},
+
+  {re:  /Kbfs([A-Z]|$)/g, into: 'KBFS$1', re2: /^KBFS/, into2: 'kbfs'},
+  {re:  /Json([A-Z]|$)/g, into: 'JSON$1', re2: /^JSON/, into2: 'json'},
+
+  {re:  /Ed25519([A-Z]|$)/g, into: 'ED25519$1', re2: /^ED25519/, into2: 'ed25519'},
+
+  {re:  /Id([A-Zs]|$)/g , into: 'ID$1' , re2: /^ID/,  into2: 'id' },
+  {re:  /Kv([A-Zs]|$)/g,  into: 'KV$1',  re2: /^KV/,  into2: 'kv' },
+  {re:  /Ui([A-Z]|$)/g,   into: 'UI$1',  re2: /^UI/,  into2: 'ui' }, // this has to be placed after the one for UID
+  {re:  /Fs([A-Z]|$)/g,   into: 'FS$1',  re2: /^FS/,  into2: 'fs' },
+  {re:  /Md([A-Z]|$)/g,   into: 'MD$1',  re2: /^MD/,  into2: 'md' },
+  {re:  /Ok([A-Z]|$)/g,   into: 'OK$1',  re2: /^OK/,  into2: 'ok' },
+]
+
+function camelcaseWithSpecialHandlings(s, shouldCapitalize) {
+  const capitalized = capitalize(camelcase(s))
+  let specialized = capitalized
+  for ( let shorthand of shorthands ) {
+    specialized = specialized.replace(shorthand.re, shorthand.into)
+  }
+  specialized = specialized.replace(/[Tt][Ll][Ff][Ii][Dd]([A-Zs]|$)/g, 'TLFID$1')
+
+  // since the handling FS would replace TLFs with TLFS
+  specialized = specialized.replace(/T[Ll]FS/g, 'TLFs')
+
+  if (shouldCapitalize) {
+    return specialized
+  }
+
+  for ( let shorthand of shorthands ) {
+    specialized = specialized.replace(shorthand.re2, shorthand.into2)
+  }
+
+  return decapitalize(specialized)
 }
 
 function lintTypedef (record, typedef) {
@@ -406,12 +448,14 @@ function lintTypedef (record, typedef) {
 
 function lintRecord (record) {
   lintTypedef(record, record.typedef)
-  if (isNotCapitalized(record.name)) {
-    lintError(`Record name should be capitalized: ${t.name}`, record.lint)
+  const rName = camelcaseWithSpecialHandlings(record.name, true)
+  if (rName !== record.name) {
+    lintError(`Record name ${record.name} should be ${rName}`, record.lint)
   }
   record.fields.forEach(f => {
-    if (isCapitalized(f.name)) {
-      lintError(`Record variable names should not be capitalized: ${record.name}.${f.name}`, f.lint)
+    const fName = camelcaseWithSpecialHandlings(f.name, false)
+    if (fName !== f.name) {
+      lintError(`Record variable name ${record.name}.${f.name} should be ${rName}.${fName}`, f.lint)
     }
     if (f.type === 'bool') {
       lintError(`Use boolean instead of bool: ${f.name}`)
@@ -420,13 +464,15 @@ function lintRecord (record) {
 }
 
 function lintMessage (name, message) {
-  if (isCapitalized(name)) {
-    lintError(`Method names should not be capitalized: ${name}`, message.lint)
+  const mName = camelcaseWithSpecialHandlings(name, false)
+  if (mName !== name) {
+    lintError(`Method name ${name} should be ${mName}`, message.lint)
   }
 
   message.request.forEach(f => {
-    if (isCapitalized(f.name)) {
-      lintError(`Method arg names should not be capitalized: ${f.name}`, message.lint)
+    const fName = camelcaseWithSpecialHandlings(f.name, false)
+    if (fName !== f.name) {
+      lintError(`Method arg name ${f.name} should be ${fName}`, message.lint)
     }
     if (f.type === 'bool') {
       lintError(`Use boolean instead of bool: ${f.name}`)
@@ -435,7 +481,8 @@ function lintMessage (name, message) {
 }
 
 function lintJSON(json) {
-  if (isNotCapitalized(json.protocol)) {
+  const pName = camelcaseWithSpecialHandlings(json.protocol, true)
+  if (pName !== json.protocol) {
     // Ignore protocol name lint errors by default
     // lintError(`Protocol names should be capitalized: ${json.protocol}`, 'ignore')
   }

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -224,7 +224,8 @@
       "fields": [
         {
           "type": "TLFID",
-          "name": "tlfid"
+          "name": "tlfid",
+          "lint": "ignore"
         },
         {
           "type": "TopicType",

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -978,7 +978,8 @@
         },
         {
           "type": "ConversationID",
-          "name": "conversationId"
+          "name": "conversationId",
+          "lint": "ignore"
         }
       ]
     },

--- a/protocol/json/keybase1/backend_common.json
+++ b/protocol/json/keybase1/backend_common.json
@@ -19,7 +19,8 @@
           "type": "UID",
           "name": "chargedTo"
         }
-      ]
+      ],
+      "lint": "ignore"
     },
     {
       "type": "record",

--- a/protocol/json/keybase1/identify_ui.json
+++ b/protocol/json/keybase1/identify_ui.json
@@ -35,7 +35,8 @@
       "fields": [
         {
           "type": "int",
-          "name": "rowId"
+          "name": "rowId",
+          "lint": "ignore"
         },
         {
           "type": "RemoteProof",
@@ -82,7 +83,8 @@
       "fields": [
         {
           "type": "int",
-          "name": "rowId"
+          "name": "rowId",
+          "lint": "ignore"
         },
         {
           "type": "bytes",
@@ -175,7 +177,8 @@
       "fields": [
         {
           "type": "string",
-          "name": "remoteId"
+          "name": "remoteId",
+          "lint": "ignore"
         },
         {
           "type": "string",
@@ -224,7 +227,8 @@
       "fields": [
         {
           "type": "int",
-          "name": "proofId"
+          "name": "proofId",
+          "lint": "ignore"
         },
         {
           "type": "ProofResult",

--- a/protocol/json/keybase1/kbfs_common.json
+++ b/protocol/json/keybase1/kbfs_common.json
@@ -83,7 +83,8 @@
         },
         {
           "type": "UID",
-          "name": "writerUid"
+          "name": "writerUid",
+          "lint": "ignore"
         },
         {
           "type": "Time",

--- a/protocol/json/keybase1/notify_badges.json
+++ b/protocol/json/keybase1/notify_badges.json
@@ -23,7 +23,8 @@
         },
         {
           "type": "int",
-          "name": "newTlfs"
+          "name": "newTlfs",
+          "lint": "ignore"
         },
         {
           "type": "int",

--- a/protocol/json/keybase1/pgp.json
+++ b/protocol/json/keybase1/pgp.json
@@ -173,7 +173,8 @@
           },
           "name": "ids"
         }
-      ]
+      ],
+      "lint": "ignore"
     },
     {
       "type": "record",
@@ -385,7 +386,8 @@
           "type": "boolean"
         }
       ],
-      "response": null
+      "response": null,
+      "lint": "ignore"
     },
     "pgpKeyGenDefault": {
       "request": [
@@ -398,7 +400,8 @@
           "type": "PGPCreateUids"
         }
       ],
-      "response": null
+      "response": null,
+      "lint": "ignore"
     },
     "pgpDeletePrimary": {
       "request": [

--- a/protocol/json/keybase1/rekey.json
+++ b/protocol/json/keybase1/rekey.json
@@ -56,7 +56,8 @@
             "type": "array",
             "items": "KID"
           },
-          "name": "solution_kids"
+          "name": "solution_kids",
+          "lint": "ignore"
         }
       ]
     },

--- a/protocol/json/keybase1/session.json
+++ b/protocol/json/keybase1/session.json
@@ -25,11 +25,13 @@
         },
         {
           "type": "KID",
-          "name": "deviceSubkeyKid"
+          "name": "deviceSubkeyKid",
+          "lint": "ignore"
         },
         {
           "type": "KID",
-          "name": "deviceSibkeyKid"
+          "name": "deviceSibkeyKid",
+          "lint": "ignore"
         }
       ]
     }

--- a/protocol/json/keybase1/signup.json
+++ b/protocol/json/keybase1/signup.json
@@ -13,15 +13,18 @@
       "fields": [
         {
           "type": "boolean",
-          "name": "passphraseOk"
+          "name": "passphraseOk",
+          "lint": "ignore"
         },
         {
           "type": "boolean",
-          "name": "postOk"
+          "name": "postOk",
+          "lint": "ignore"
         },
         {
           "type": "boolean",
-          "name": "writeOk"
+          "name": "writeOk",
+          "lint": "ignore"
         }
       ]
     }

--- a/protocol/json/keybase1/tlf.json
+++ b/protocol/json/keybase1/tlf.json
@@ -36,7 +36,8 @@
           "type": "TLFQuery"
         }
       ],
-      "response": "CanonicalTLFNameAndIDWithBreaks"
+      "response": "CanonicalTLFNameAndIDWithBreaks",
+      "lint": "ignore"
     }
   },
   "namespace": "keybase.1"

--- a/protocol/json/keybase1/tlf_keys.json
+++ b/protocol/json/keybase1/tlf_keys.json
@@ -24,7 +24,8 @@
       "type": "record",
       "name": "CanonicalTlfName",
       "fields": [],
-      "typedef": "string"
+      "typedef": "string",
+      "lint": "ignore"
     },
     {
       "type": "record",

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -20,6 +20,7 @@
     "avdl-compiler": "1.3.9",
     "avdl2json": "2.2.3",
     "bluebird": "^2.10.0",
+    "camelcase": "^4.0.0",
     "iced-coffee-script": "^108.0.9",
     "iced-error": "0.0.9",
     "iced-logger": "^0.0.6",


### PR DESCRIPTION
This checks camel cases, and makes shorthands such as `TLF` and `ID` legit. ~~Although in Go it'd still be `TlfMessage` unless we change the Go emitter. (I guess the Go compiler thing isn't really urgent since we can change it anytime without changing content on the wire.)~~ Relevant PR in `node-avdl-compiler`: keybase/node-avdl-compiler#10

r? @gabriel @maxtaco @patrickxb Thanks!