### PR TITLE
Chat timestamps describe the message beneath them, not the message above them

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -416,7 +416,7 @@ function _maybeAddTimestamp (message: Message, prevMessage: Message): MaybeTimes
   if (message.timestamp - prevMessage.timestamp > Constants.howLongBetweenTimestampsMs) { // ms
     return {
       type: 'Timestamp',
-      timestamp: prevMessage.timestamp,
+      timestamp: message.timestamp,
     }
   }
   return null


### PR DESCRIPTION
@keybase/react-hackers r?