### PR TITLE
add new nonblocking inbox fetch functionality using chat UI CORE-4183

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -32,14 +32,12 @@ type InboxSource interface {
 
 type localizer struct {
 	libkb.Contextified
-	udc             *utils.UserDeviceCache
 	getTlfInterface func() keybase1.TlfInterface
 }
 
-func newLocalizer(g *libkb.GlobalContext, udc *utils.UserDeviceCache, getTlfInterface func() keybase1.TlfInterface) *localizer {
+func newLocalizer(g *libkb.GlobalContext, getTlfInterface func() keybase1.TlfInterface) *localizer {
 	return &localizer{
 		Contextified:    libkb.NewContextified(g),
-		udc:             udc,
 		getTlfInterface: getTlfInterface,
 	}
 }
@@ -55,10 +53,9 @@ type RemoteInboxSource struct {
 
 func NewRemoteInboxSource(g *libkb.GlobalContext, boxer *Boxer, ri func() chat1.RemoteInterface,
 	tlf func() keybase1.TlfInterface) *RemoteInboxSource {
-	udc := utils.NewUserDeviceCache(g)
 	return &RemoteInboxSource{
 		Contextified:     libkb.NewContextified(g),
-		localizer:        newLocalizer(g, udc, tlf),
+		localizer:        newLocalizer(g, tlf),
 		getTlfInterface:  tlf,
 		getChatInterface: ri,
 		boxer:            boxer,
@@ -133,7 +130,6 @@ type NonblockRemoteInboxSource struct {
 
 	localizer        *localizer
 	boxer            *Boxer
-	udc              *utils.UserDeviceCache
 	localizeCb       chan NonblockInboxResult
 	getTlfInterface  func() keybase1.TlfInterface
 	getChatInterface func() chat1.RemoteInterface
@@ -147,7 +143,7 @@ func NewNonblockRemoteInboxSource(g *libkb.GlobalContext, boxer *Boxer, ri func(
 		getChatInterface: ri,
 		boxer:            boxer,
 		localizeCb:       localizeCb,
-		localizer:        newLocalizer(g, udc, tlf),
+		localizer:        newLocalizer(g, tlf),
 	}
 }
 

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -86,6 +86,10 @@ var chatFlags = map[string]cli.Flag{
 		Name:  "u, unhide",
 		Usage: "Unhide/unblock the conversation",
 	},
+	"async": cli.BoolFlag{
+		Name:  "async",
+		Usage: "Fetch inbox and unbox asynchronously",
+	},
 }
 
 func mustGetChatFlags(keys ...string) (flags []cli.Flag) {
@@ -112,7 +116,7 @@ func getInboxFetcherUnreadFirstFlags() []cli.Flag {
 }
 
 func getInboxFetcherActivitySortedFlags() []cli.Flag {
-	return append(mustGetChatFlags("number", "since", "all"), getConversationResolverFlags()...)
+	return append(mustGetChatFlags("number", "since", "all", "async"), getConversationResolverFlags()...)
 }
 
 func parseConversationTopicType(ctx *cli.Context) (topicType chat1.TopicType, err error) {
@@ -190,6 +194,8 @@ func makeChatCLIInboxFetcherActivitySorted(ctx *cli.Context) (fetcher chatCLIInb
 	if !ctx.Bool("all") {
 		fetcher.query.Status = utils.VisibleChatConversationStatuses()
 	}
+
+	fetcher.async = ctx.Bool("async")
 
 	return fetcher, err
 }

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -129,7 +129,7 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 		}
 		if msg == nil {
 			// Skip conversations with no TEXT messages.
-			g.Log.Debug("Skipped conversation with no TEXT: %v", conv.Info.Id)
+			g.Log.Warning("Skipped conversation with no TEXT: %v", conv.Info.Id)
 			continue
 		}
 

--- a/go/client/chat_ui.go
+++ b/go/client/chat_ui.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 )
@@ -96,5 +97,107 @@ func (c *ChatUI) ChatAttachmentDownloadDone(context.Context, int) error {
 	}
 	w := c.terminal.ErrorWriter()
 	fmt.Fprintf(w, "Attachment download "+ColorString("magenta", "finished")+"\n")
+	return nil
+}
+
+func (c *ChatUI) ChatInboxConversation(ctx context.Context, arg chat1.ChatInboxConversationArg) error {
+	if c.noOutput {
+		return nil
+	}
+	w := c.terminal.ErrorWriter()
+	sender := "<unknown>"
+	snippet := "<blank>"
+	tlf := "<unknown>"
+	for _, msg := range arg.Conv.MaxMessages {
+		if msg.IsValid() && msg.GetMessageType() == chat1.MessageType_TEXT {
+			sender = msg.Valid().SenderUsername
+			snippet = msg.Valid().MessageBody.Text().Body
+			tlf = msg.Valid().ClientHeader.TlfName
+			break
+		}
+	}
+	fmt.Fprintf(w, "conversation unboxed: tlf: %s sender: %s snippet: %s\n", tlf, sender, snippet)
+	return nil
+}
+
+func (c *ChatUI) ChatInboxFailed(ctx context.Context, arg chat1.ChatInboxFailedArg) error {
+	if c.noOutput {
+		return nil
+	}
+	w := c.terminal.ErrorWriter()
+	fmt.Fprintf(w, "conversation unbox failure: convID: %s err: %s\n", arg.ConvID, arg.Error)
+	return nil
+}
+
+func (c *ChatUI) getUnverifiedConvo(conv chat1.Conversation) (chat1.ConversationLocal, error) {
+
+	if len(conv.MaxMsgs) == 0 {
+		return chat1.ConversationLocal{}, fmt.Errorf("no max messages")
+	}
+
+	// Get max text message
+	var txtMsg *chat1.MessageBoxed
+	for _, msg := range conv.MaxMsgs {
+		if msg.GetMessageType() == chat1.MessageType_TEXT {
+			txtMsg = &msg
+			break
+		}
+	}
+	if txtMsg == nil {
+		return chat1.ConversationLocal{}, fmt.Errorf("no text message found")
+	}
+
+	udc := utils.NewUserDeviceCache(c.G())
+	_, uimap := utils.GetUserInfoMapper(context.Background(), c.G())
+	rnames, wnames, err := utils.ReorderParticipants(udc, uimap,
+		txtMsg.ClientHeader.TlfName, conv.Metadata.ActiveList)
+	if err != nil {
+		return chat1.ConversationLocal{}, err
+	}
+	convLocal := chat1.ConversationLocal{
+		ReaderInfo: *conv.ReaderInfo,
+		MaxMessages: []chat1.MessageUnboxed{
+			chat1.MessageUnboxed{
+				State__: chat1.MessageUnboxedState_VALID,
+				Valid__: &chat1.MessageUnboxedValid{
+					MessageBody: chat1.MessageBody{
+						MessageType__: chat1.MessageType_TEXT,
+						Text__: &chat1.MessageText{
+							Body: "<pending>",
+						},
+					},
+					ClientHeader:   txtMsg.ClientHeader,
+					ServerHeader:   *txtMsg.ServerHeader,
+					SenderUsername: "???",
+				},
+			},
+		},
+		Info: chat1.ConversationInfoLocal{
+			Id:          conv.Metadata.ConversationID,
+			TlfName:     "<pending>",
+			WriterNames: wnames,
+			ReaderNames: rnames,
+		},
+	}
+
+	return convLocal, nil
+}
+
+func (c *ChatUI) ChatInboxUnverified(ctx context.Context, arg chat1.ChatInboxUnverifiedArg) error {
+
+	var convs []chat1.ConversationLocal
+	for _, conv := range arg.Inbox.ConversationsUnverified {
+		convLocal, err := c.getUnverifiedConvo(conv)
+		if err != nil {
+			c.G().Log.Error("unable to convert unverified conv: %s", err.Error())
+			continue
+		}
+		convs = append(convs, convLocal)
+	}
+
+	if err := conversationListView(convs).show(c.G(), string(c.G().Env.GetUsername()), false); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/go/client/chat_ui.go
+++ b/go/client/chat_ui.go
@@ -147,9 +147,7 @@ func (c *ChatUI) getUnverifiedConvo(conv chat1.Conversation) (chat1.Conversation
 		return chat1.ConversationLocal{}, fmt.Errorf("no text message found")
 	}
 
-	udc := utils.NewUserDeviceCache(c.G())
-	_, uimap := utils.GetUserInfoMapper(context.Background(), c.G())
-	rnames, wnames, err := utils.ReorderParticipants(udc, uimap,
+	rnames, wnames, err := utils.ReorderParticipants(c.G().UserDeviceCache,
 		txtMsg.ClientHeader.TlfName, conv.Metadata.ActiveList)
 	if err != nil {
 		return chat1.ConversationLocal{}, err

--- a/go/client/cmd_chat_list.go
+++ b/go/client/cmd_chat_list.go
@@ -6,6 +6,8 @@ package client
 import (
 	"golang.org/x/net/context"
 
+	"time"
+
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
@@ -41,13 +43,18 @@ func (c *cmdChatList) Run() error {
 		return err
 	}
 
-	if len(conversations) == 0 {
-		ui.Printf("no conversations\n")
-		return nil
-	}
+	if c.fetcher.async {
+		// Wait around for a bit to test async
+		time.Sleep(time.Second * 5)
+	} else {
+		if len(conversations) == 0 {
+			ui.Printf("no conversations\n")
+			return nil
+		}
 
-	if err = conversationListView(conversations).show(c.G(), string(c.G().Env.GetUsername()), c.showDeviceName); err != nil {
-		return err
+		if err = conversationListView(conversations).show(c.G(), string(c.G().Env.GetUsername()), c.showDeviceName); err != nil {
+			return err
+		}
 	}
 
 	// TODO: print summary of inbox. e.g.

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -457,3 +457,74 @@ func (m *ChatRemoteMock) GetS3Params(context.Context, chat1.ConversationID) (cha
 func (m *ChatRemoteMock) S3Sign(context.Context, chat1.S3SignArg) ([]byte, error) {
 	return nil, errors.New("GetS3Params not mocked")
 }
+
+type NonblockInboxResult struct {
+	ConvID   chat1.ConversationID
+	Err      error
+	ConvRes  *chat1.ConversationLocal
+	InboxRes *chat1.GetInboxLocalRes
+}
+
+type ChatUI struct {
+	cb chan NonblockInboxResult
+}
+
+func NewChatUI(cb chan NonblockInboxResult) *ChatUI {
+	return &ChatUI{
+		cb: cb,
+	}
+}
+
+func (c *ChatUI) ChatAttachmentUploadStart(context.Context) error {
+	return nil
+}
+
+func (c *ChatUI) ChatAttachmentUploadProgress(ctx context.Context, arg chat1.ChatAttachmentUploadProgressArg) error {
+	return nil
+}
+
+func (c *ChatUI) ChatAttachmentUploadDone(context.Context) error {
+	return nil
+}
+
+func (c *ChatUI) ChatAttachmentPreviewUploadStart(context.Context) error {
+	return nil
+}
+
+func (c *ChatUI) ChatAttachmentPreviewUploadDone(context.Context) error {
+	return nil
+}
+
+func (c *ChatUI) ChatAttachmentDownloadStart(context.Context) error {
+	return nil
+}
+
+func (c *ChatUI) ChatAttachmentDownloadProgress(ctx context.Context, arg chat1.ChatAttachmentDownloadProgressArg) error {
+	return nil
+}
+
+func (c *ChatUI) ChatAttachmentDownloadDone(context.Context) error {
+	return nil
+}
+
+func (c *ChatUI) ChatInboxConversation(ctx context.Context, arg chat1.ChatInboxConversationArg) error {
+	c.cb <- NonblockInboxResult{
+		ConvRes: &arg.Conv,
+		ConvID:  arg.Conv.Info.Id,
+	}
+	return nil
+}
+
+func (c *ChatUI) ChatInboxFailed(ctx context.Context, arg chat1.ChatInboxFailedArg) error {
+	c.cb <- NonblockInboxResult{
+		Err: fmt.Errorf("%s", arg.Error),
+	}
+	return nil
+}
+
+func (c *ChatUI) ChatInboxUnverified(ctx context.Context, arg chat1.ChatInboxUnverifiedArg) error {
+	c.cb <- NonblockInboxResult{
+		InboxRes: &arg.Inbox,
+	}
+	return nil
+}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -338,6 +338,9 @@ type ChatUI interface {
 	ChatAttachmentDownloadStart(context.Context) error
 	ChatAttachmentDownloadProgress(context.Context, chat1.ChatAttachmentDownloadProgressArg) error
 	ChatAttachmentDownloadDone(context.Context) error
+	ChatInboxUnverified(context.Context, chat1.ChatInboxUnverifiedArg) error
+	ChatInboxConversation(context.Context, chat1.ChatInboxConversationArg) error
+	ChatInboxFailed(context.Context, chat1.ChatInboxFailedArg) error
 }
 
 type PromptDefault int

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -44,6 +44,22 @@ type ChatAttachmentDownloadDoneArg struct {
 	SessionID int `codec:"sessionID" json:"sessionID"`
 }
 
+type ChatInboxUnverifiedArg struct {
+	SessionID int              `codec:"sessionID" json:"sessionID"`
+	Inbox     GetInboxLocalRes `codec:"inbox" json:"inbox"`
+}
+
+type ChatInboxConversationArg struct {
+	SessionID int               `codec:"sessionID" json:"sessionID"`
+	Conv      ConversationLocal `codec:"conv" json:"conv"`
+}
+
+type ChatInboxFailedArg struct {
+	SessionID int            `codec:"sessionID" json:"sessionID"`
+	ConvID    ConversationID `codec:"convID" json:"convID"`
+	Error     string         `codec:"error" json:"error"`
+}
+
 type ChatUiInterface interface {
 	ChatAttachmentUploadStart(context.Context, int) error
 	ChatAttachmentUploadProgress(context.Context, ChatAttachmentUploadProgressArg) error
@@ -53,6 +69,9 @@ type ChatUiInterface interface {
 	ChatAttachmentDownloadStart(context.Context, int) error
 	ChatAttachmentDownloadProgress(context.Context, ChatAttachmentDownloadProgressArg) error
 	ChatAttachmentDownloadDone(context.Context, int) error
+	ChatInboxUnverified(context.Context, ChatInboxUnverifiedArg) error
+	ChatInboxConversation(context.Context, ChatInboxConversationArg) error
+	ChatInboxFailed(context.Context, ChatInboxFailedArg) error
 }
 
 func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
@@ -187,6 +206,54 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"chatInboxUnverified": {
+				MakeArg: func() interface{} {
+					ret := make([]ChatInboxUnverifiedArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ChatInboxUnverifiedArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ChatInboxUnverifiedArg)(nil), args)
+						return
+					}
+					err = i.ChatInboxUnverified(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"chatInboxConversation": {
+				MakeArg: func() interface{} {
+					ret := make([]ChatInboxConversationArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ChatInboxConversationArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ChatInboxConversationArg)(nil), args)
+						return
+					}
+					err = i.ChatInboxConversation(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"chatInboxFailed": {
+				MakeArg: func() interface{} {
+					ret := make([]ChatInboxFailedArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ChatInboxFailedArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ChatInboxFailedArg)(nil), args)
+						return
+					}
+					err = i.ChatInboxFailed(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -238,5 +305,20 @@ func (c ChatUiClient) ChatAttachmentDownloadProgress(ctx context.Context, __arg 
 func (c ChatUiClient) ChatAttachmentDownloadDone(ctx context.Context, sessionID int) (err error) {
 	__arg := ChatAttachmentDownloadDoneArg{SessionID: sessionID}
 	err = c.Cli.Call(ctx, "chat.1.chatUi.chatAttachmentDownloadDone", []interface{}{__arg}, nil)
+	return
+}
+
+func (c ChatUiClient) ChatInboxUnverified(ctx context.Context, __arg ChatInboxUnverifiedArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatInboxUnverified", []interface{}{__arg}, nil)
+	return
+}
+
+func (c ChatUiClient) ChatInboxConversation(ctx context.Context, __arg ChatInboxConversationArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatInboxConversation", []interface{}{__arg}, nil)
+	return
+}
+
+func (c ChatUiClient) ChatInboxFailed(ctx context.Context, __arg ChatInboxFailedArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatInboxFailed", []interface{}{__arg}, nil)
 	return
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -676,6 +676,13 @@ type GetInboxAndUnboxLocalArg struct {
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
+type GetInboxNonblockLocalArg struct {
+	SessionID        int                          `codec:"sessionID" json:"sessionID"`
+	Query            *GetInboxLocalQuery          `codec:"query,omitempty" json:"query,omitempty"`
+	Pagination       *Pagination                  `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
+}
+
 type PostLocalArg struct {
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
 	Msg              MessagePlaintext             `codec:"msg" json:"msg"`
@@ -775,6 +782,7 @@ type LocalInterface interface {
 	GetThreadLocal(context.Context, GetThreadLocalArg) (GetThreadLocalRes, error)
 	GetInboxLocal(context.Context, GetInboxLocalArg) (GetInboxLocalRes, error)
 	GetInboxAndUnboxLocal(context.Context, GetInboxAndUnboxLocalArg) (GetInboxAndUnboxLocalRes, error)
+	GetInboxNonblockLocal(context.Context, GetInboxNonblockLocalArg) error
 	PostLocal(context.Context, PostLocalArg) (PostLocalRes, error)
 	PostLocalNonblock(context.Context, PostLocalNonblockArg) (PostLocalNonblockRes, error)
 	SetConversationStatusLocal(context.Context, SetConversationStatusLocalArg) (SetConversationStatusLocalRes, error)
@@ -839,6 +847,22 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.GetInboxAndUnboxLocal(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"getInboxNonblockLocal": {
+				MakeArg: func() interface{} {
+					ret := make([]GetInboxNonblockLocalArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]GetInboxNonblockLocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]GetInboxNonblockLocalArg)(nil), args)
+						return
+					}
+					err = i.GetInboxNonblockLocal(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -1087,6 +1111,11 @@ func (c LocalClient) GetInboxLocal(ctx context.Context, __arg GetInboxLocalArg) 
 
 func (c LocalClient) GetInboxAndUnboxLocal(ctx context.Context, __arg GetInboxAndUnboxLocalArg) (res GetInboxAndUnboxLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.getInboxAndUnboxLocal", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) GetInboxNonblockLocal(ctx context.Context, __arg GetInboxNonblockLocalArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.getInboxNonblockLocal", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -35,7 +35,8 @@ type chatLocalHandler struct {
 	store *chat.AttachmentStore
 
 	// Only for testing
-	rc chat1.RemoteInterface
+	rc         chat1.RemoteInterface
+	mockChatUI libkb.ChatUI
 }
 
 // newChatLocalHandler creates a chatLocalHandler.
@@ -85,6 +86,76 @@ func (h *chatLocalHandler) GetInboxLocal(ctx context.Context, arg chat1.GetInbox
 		RateLimits:              utils.AggRateLimitsP([]*chat1.RateLimit{ib.RateLimit}),
 		IdentifyFailures:        identifyFailures,
 	}, nil
+}
+
+func (h *chatLocalHandler) getChatUI(sessionID int) libkb.ChatUI {
+	if h.mockChatUI != nil {
+		return h.mockChatUI
+	}
+	return h.BaseHandler.getChatUI(sessionID)
+}
+
+func (h *chatLocalHandler) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNonblockLocalArg) error {
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
+	uid := h.G().Env.GetUID()
+	if uid.IsNil() {
+		return libkb.LoginRequiredError{}
+	}
+
+	// Create localized conversation callback channel
+	chatUI := h.getChatUI(arg.SessionID)
+	localizeCb := make(chan chat.NonblockInboxResult, 1)
+
+	inboxSource := chat.NewNonblockRemoteInboxSource(h.G(), h.boxer, h.remoteClient,
+		func() keybase1.TlfInterface { return h.tlf }, localizeCb)
+
+	// Invoke nonblocking inbox read and get remote inbox version to send back as our result
+	_, rl, err := inboxSource.Read(ctx, uid.ToBytes(), arg.Query, arg.Pagination, arg.IdentifyBehavior)
+	if err != nil {
+		return err
+	}
+
+	// Wait for inbox to get sent to us
+	select {
+	case lres := <-localizeCb:
+		if lres.InboxRes == nil {
+			return fmt.Errorf("invalid conversation localize callback received")
+		}
+		chatUI.ChatInboxUnverified(context.Background(), chat1.ChatInboxUnverifiedArg{
+			SessionID: arg.SessionID,
+			Inbox: chat1.GetInboxLocalRes{
+				ConversationsUnverified: lres.InboxRes.ConvsUnverified,
+				Pagination:              lres.InboxRes.Pagination,
+				RateLimits:              utils.AggRateLimitsP([]*chat1.RateLimit{rl}),
+			},
+		})
+	case <-time.After(15 * time.Second):
+		return fmt.Errorf("timeout waiting for inbox result")
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	// Consume localize callbacks and send out to UI.
+	go func() {
+		for convRes := range localizeCb {
+			if convRes.Err != nil {
+				chatUI.ChatInboxFailed(context.Background(), chat1.ChatInboxFailedArg{
+					SessionID: arg.SessionID,
+					Error:     convRes.Err.Error(),
+					ConvID:    convRes.ConvID,
+				})
+			} else if convRes.ConvRes != nil {
+				chatUI.ChatInboxConversation(context.Background(), chat1.ChatInboxConversationArg{
+					SessionID: arg.SessionID,
+					Conv:      *convRes.ConvRes,
+				})
+			}
+		}
+	}()
+
+	return nil
 }
 
 func (h *chatLocalHandler) MarkAsReadLocal(ctx context.Context, arg chat1.MarkAsReadLocalArg) (chat1.MarkAsReadRes, error) {

--- a/go/service/remote_chat_ui.go
+++ b/go/service/remote_chat_ui.go
@@ -52,3 +52,15 @@ func (r *RemoteChatUI) ChatAttachmentDownloadProgress(ctx context.Context, arg c
 func (r *RemoteChatUI) ChatAttachmentDownloadDone(ctx context.Context) error {
 	return r.cli.ChatAttachmentDownloadDone(ctx, r.sessionID)
 }
+
+func (r *RemoteChatUI) ChatInboxConversation(ctx context.Context, arg chat1.ChatInboxConversationArg) error {
+	return r.cli.ChatInboxConversation(ctx, arg)
+}
+
+func (r *RemoteChatUI) ChatInboxFailed(ctx context.Context, arg chat1.ChatInboxFailedArg) error {
+	return r.cli.ChatInboxFailed(ctx, arg)
+}
+
+func (r *RemoteChatUI) ChatInboxUnverified(ctx context.Context, arg chat1.ChatInboxUnverifiedArg) error {
+	return r.cli.ChatInboxUnverified(ctx, arg)
+}

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -11,4 +11,8 @@ protocol chatUi {
   void chatAttachmentDownloadStart(int sessionID);	
   void chatAttachmentDownloadProgress(int sessionID, int bytesComplete, int bytesTotal);     
   void chatAttachmentDownloadDone(int sessionID);	
+
+  void chatInboxUnverified(int sessionID, GetInboxLocalRes inbox); 
+  void chatInboxConversation(int sessionID, ConversationLocal conv);
+  void chatInboxFailed(int sessionID, ConversationID convID, string error);
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -258,6 +258,8 @@ protocol local {
     array<RateLimit> rateLimits;
   }
 
+  void getInboxNonblockLocal(int sessionID, union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior); 
+
   PostLocalRes postLocal(ConversationID conversationID, MessagePlaintext msg, keybase1.TLFIdentifyBehavior identifyBehavior);
   record PostLocalRes {
     array<RateLimit> rateLimits;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -187,6 +187,18 @@ export function localGetInboxLocalRpcPromise (request: $Exact<requestCommon & {c
   return new Promise((resolve, reject) => { localGetInboxLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function localGetInboxNonblockLocalRpc (request: Exact<requestCommon & requestErrorCallback & {param: localGetInboxNonblockLocalRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.getInboxNonblockLocal'})
+}
+
+export function localGetInboxNonblockLocalRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localGetInboxNonblockLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localGetInboxNonblockLocalRpc({...request, incomingCallMap, callback}))
+}
+
+export function localGetInboxNonblockLocalRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localGetInboxNonblockLocalRpcParam}>): Promise<any> {
+  return new Promise((resolve, reject) => { localGetInboxNonblockLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function localGetInboxSummaryForCLILocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxSummaryForCLILocalResult) => void} & {param: localGetInboxSummaryForCLILocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.getInboxSummaryForCLILocal'})
 }
@@ -1057,6 +1069,19 @@ export type chatUiChatAttachmentUploadProgressRpcParam = Exact<{
   bytesTotal: int
 }>
 
+export type chatUiChatInboxConversationRpcParam = Exact<{
+  conv: ConversationLocal
+}>
+
+export type chatUiChatInboxFailedRpcParam = Exact<{
+  convID: ConversationID,
+  error: string
+}>
+
+export type chatUiChatInboxUnverifiedRpcParam = Exact<{
+  inbox: GetInboxLocalRes
+}>
+
 export type localCancelPostRpcParam = Exact<{
   outboxID: OutboxID
 }>
@@ -1088,6 +1113,12 @@ export type localGetInboxAndUnboxLocalRpcParam = Exact<{
 }>
 
 export type localGetInboxLocalRpcParam = Exact<{
+  query?: ?GetInboxLocalQuery,
+  pagination?: ?Pagination,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
+export type localGetInboxNonblockLocalRpcParam = Exact<{
   query?: ?GetInboxLocalQuery,
   pagination?: ?Pagination,
   identifyBehavior: keybase1.TLFIdentifyBehavior
@@ -1283,6 +1314,7 @@ export type rpc =
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc
   | localGetInboxLocalRpc
+  | localGetInboxNonblockLocalRpc
   | localGetInboxSummaryForCLILocalRpc
   | localGetMessagesLocalRpc
   | localGetThreadLocalRpc
@@ -1356,6 +1388,28 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatAttachmentDownloadDone'?: (
     params: Exact<{
       sessionID: int
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.chatUi.chatInboxUnverified'?: (
+    params: Exact<{
+      sessionID: int,
+      inbox: GetInboxLocalRes
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.chatUi.chatInboxConversation'?: (
+    params: Exact<{
+      sessionID: int,
+      conv: ConversationLocal
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.chatUi.chatInboxFailed'?: (
+    params: Exact<{
+      sessionID: int,
+      convID: ConversationID,
+      error: string
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -90,6 +90,49 @@
         }
       ],
       "response": null
+    },
+    "chatInboxUnverified": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "inbox",
+          "type": "GetInboxLocalRes"
+        }
+      ],
+      "response": null
+    },
+    "chatInboxConversation": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "conv",
+          "type": "ConversationLocal"
+        }
+      ],
+      "response": null
+    },
+    "chatInboxFailed": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "error",
+          "type": "string"
+        }
+      ],
+      "response": null
     }
   },
   "namespace": "chat.1"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1157,6 +1157,33 @@
       ],
       "response": "GetInboxAndUnboxLocalRes"
     },
+    "getInboxNonblockLocal": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "query",
+          "type": [
+            null,
+            "GetInboxLocalQuery"
+          ]
+        },
+        {
+          "name": "pagination",
+          "type": [
+            null,
+            "Pagination"
+          ]
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
+        }
+      ],
+      "response": null
+    },
     "postLocal": {
       "request": [
         {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -187,6 +187,18 @@ export function localGetInboxLocalRpcPromise (request: $Exact<requestCommon & {c
   return new Promise((resolve, reject) => { localGetInboxLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function localGetInboxNonblockLocalRpc (request: Exact<requestCommon & requestErrorCallback & {param: localGetInboxNonblockLocalRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.getInboxNonblockLocal'})
+}
+
+export function localGetInboxNonblockLocalRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localGetInboxNonblockLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localGetInboxNonblockLocalRpc({...request, incomingCallMap, callback}))
+}
+
+export function localGetInboxNonblockLocalRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localGetInboxNonblockLocalRpcParam}>): Promise<any> {
+  return new Promise((resolve, reject) => { localGetInboxNonblockLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function localGetInboxSummaryForCLILocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxSummaryForCLILocalResult) => void} & {param: localGetInboxSummaryForCLILocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.getInboxSummaryForCLILocal'})
 }
@@ -1057,6 +1069,19 @@ export type chatUiChatAttachmentUploadProgressRpcParam = Exact<{
   bytesTotal: int
 }>
 
+export type chatUiChatInboxConversationRpcParam = Exact<{
+  conv: ConversationLocal
+}>
+
+export type chatUiChatInboxFailedRpcParam = Exact<{
+  convID: ConversationID,
+  error: string
+}>
+
+export type chatUiChatInboxUnverifiedRpcParam = Exact<{
+  inbox: GetInboxLocalRes
+}>
+
 export type localCancelPostRpcParam = Exact<{
   outboxID: OutboxID
 }>
@@ -1088,6 +1113,12 @@ export type localGetInboxAndUnboxLocalRpcParam = Exact<{
 }>
 
 export type localGetInboxLocalRpcParam = Exact<{
+  query?: ?GetInboxLocalQuery,
+  pagination?: ?Pagination,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
+export type localGetInboxNonblockLocalRpcParam = Exact<{
   query?: ?GetInboxLocalQuery,
   pagination?: ?Pagination,
   identifyBehavior: keybase1.TLFIdentifyBehavior
@@ -1283,6 +1314,7 @@ export type rpc =
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc
   | localGetInboxLocalRpc
+  | localGetInboxNonblockLocalRpc
   | localGetInboxSummaryForCLILocalRpc
   | localGetMessagesLocalRpc
   | localGetThreadLocalRpc
@@ -1356,6 +1388,28 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatAttachmentDownloadDone'?: (
     params: Exact<{
       sessionID: int
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.chatUi.chatInboxUnverified'?: (
+    params: Exact<{
+      sessionID: int,
+      inbox: GetInboxLocalRes
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.chatUi.chatInboxConversation'?: (
+    params: Exact<{
+      sessionID: int,
+      conv: ConversationLocal
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.chatUi.chatInboxFailed'?: (
+    params: Exact<{
+      sessionID: int,
+      convID: ConversationID,
+      error: string
     }>,
     response: CommonResponseHandler
   ) => void,


### PR DESCRIPTION
@patrickxb r?

The point of this is to allow for a two stage `GetInbox` flow on the UI side. The GUI will kick off an inbox fetch with `GetInboxNonblockLocal`, which will deliver back to the UI in the following manner:

1.) A `ChatInboxUnverified` chat UI RPC with the server trust inbox (quick to get).
2.) A series of `ChatInboxConversation` calls for each conversation that it successfully unboxes.

There is also a command line option to see this in action, here is an example:

```
[mike@lisa-keybase]-[~/go/src/github.com/keybase/client/go] (mike/CORE-4183)$ kb chat list --async
▶ WARNING Running in devel mode
[1] * #candrencil4,mike     [??? 20h] <pending>
[2]   #candrencil3,mike      [??? 8d] <pending>
[3]   #mike,t_alice         [??? 15d] <pending>
[4]   #mike,t_alice,t_bob   [??? 22d] <pending>
[5]   #mike,t_bob,t_rosetta [??? 25d] <pending>
[6]   #mike,t_rosetta       [??? 25d] <pending>
[7]   #mike,t_bob           [??? 25d] <pending>
conversation unboxed: tlf: candrencil3,mike sender: mike snippet: die
conversation unboxed: tlf: mike,t_rosetta sender: mike snippet: hi
conversation unboxed: tlf: candrencil4,mike sender: candrencil4 snippet: die
conversation unboxed: tlf: mike,t_bob sender: mike snippet: hi
conversation unboxed: tlf: mike,t_bob,t_rosetta sender: mike snippet: hi
conversation unboxed: tlf: mike,t_alice,t_bob sender: mike snippet: hi cool cats
conversation unboxed: tlf: mike,t_alice sender: mike snippet: hi
```

The lines beginning with "conversation unboxed" come from the chat UI upon receiving the callbacks.

Let me know if you want me to explain more!