### PR TITLE
more explicit gitignore for node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ build
 .vscode
 
 npm-debug.log
-node_modules
+desktop/node_modules
+react-native/node_modules
+packaging/desktop/node_modules/
 
 Keybase.app.dSYM.zip


### PR DESCRIPTION
so if you're switching between master and the new project layout you notice the node_modules moving
@keybase/react-hackers 