### PR TITLE
Allow passphrase recover to ditch synced pgp keys

### DIFF
--- a/go/client/cmd_passphrase_recover.go
+++ b/go/client/cmd_passphrase_recover.go
@@ -34,6 +34,7 @@ func (c *CmdPassphraseRecover) confirm() error {
 	ui := c.G().UI.GetTerminalUI()
 	ui.Printf("Password recovery will put your account on probation for 5 days.\n")
 	ui.Printf("You won't be able to perform certain actions, like revoking devices.\n")
+	ui.Printf("If you have uploaded an encrypted PGP private key, it will be lost.\n")
 	return ui.PromptForConfirmation("Continue with password recovery?")
 }
 

--- a/go/client/cmd_passphrase_recover.go
+++ b/go/client/cmd_passphrase_recover.go
@@ -34,7 +34,14 @@ func (c *CmdPassphraseRecover) confirm() error {
 	ui := c.G().UI.GetTerminalUI()
 	ui.Printf("Password recovery will put your account on probation for 5 days.\n")
 	ui.Printf("You won't be able to perform certain actions, like revoking devices.\n")
-	ui.Printf("If you have uploaded an encrypted PGP private key, it will be lost.\n")
+
+	hsk, err := hasServerKeys(c.G())
+	if err != nil {
+		return err
+	}
+	if hsk.HasServerKeys {
+		ui.Printf("You have uploaded an encrypted PGP private key, it will be lost.\n")
+	}
 	return ui.PromptForConfirmation("Continue with password recovery?")
 }
 

--- a/go/client/passphrase_common.go
+++ b/go/client/passphrase_common.go
@@ -31,3 +31,11 @@ func passphraseChange(g *libkb.GlobalContext, arg keybase1.PassphraseChangeArg) 
 	}
 	return cli.PassphraseChange(context.TODO(), arg)
 }
+
+func hasServerKeys(g *libkb.GlobalContext) (res keybase1.HasServerKeysRes, err error) {
+	cli, err := GetAccountClient(g)
+	if err != nil {
+		return res, err
+	}
+	return cli.HasServerKeys(context.TODO(), 0 /* SessionID */)
+}

--- a/go/engine/hasserverkeys.go
+++ b/go/engine/hasserverkeys.go
@@ -59,6 +59,7 @@ func (e *HasServerKeys) Run(ctx *Context) error {
 		return err
 	}
 	e.res.HasServerKeys = len(spk.PrivateKeys) > 0
+	e.G().Log.Debug("HasServerKeys: %v", e.res.HasServerKeys)
 
 	return nil
 }

--- a/go/engine/passphrase_change.go
+++ b/go/engine/passphrase_change.go
@@ -269,8 +269,7 @@ func (c *PassphraseChange) runForcedUpdate(ctx *Context) (err error) {
 	return c.forceUpdatePassphrase(ctx, kp.sigKey, ppGen, oldClientHalf)
 }
 
-// runStandardUpdate is for when the user knows the current
-// password.
+// runStandardUpdate is for when the user knows the current password.
 func (c *PassphraseChange) runStandardUpdate(ctx *Context) (err error) {
 
 	c.G().Log.Debug("+ PassphraseChange.runStandardUpdate")
@@ -453,12 +452,6 @@ func (c *PassphraseChange) findAndDecryptPrivatePGPKeysLossy(ctx *Context) ([]li
 
 	var keyList []libkb.GenericKey
 	nLost := 0
-
-	// Using a paper key makes TripleSec-synced keys unrecoverable
-	if c.usingPaper {
-		c.G().Log.Debug("using a paper key, thus TripleSec-synced keys are unrecoverable")
-		return keyList, 0, nil
-	}
 
 	// Only use the synced secret keys:
 	blocks, err := c.me.AllSyncedSecretKeys(ctx.LoginContext)

--- a/go/libkb/skb.go
+++ b/go/libkb/skb.go
@@ -449,7 +449,7 @@ func (s *SKB) UnlockWithStoredSecret(lctx LoginContext, secretRetriever SecretRe
 	return s.unlockSecretKeyFromSecretRetriever(lctx, secretRetriever)
 }
 
-var errUnlockNotPossible = errors.New("unlock not possible")
+var ErrUnlockNotPossible = errors.New("unlock not possible")
 
 func (s *SKB) UnlockNoPrompt(lctx LoginContext, secretStore SecretStore) (GenericKey, error) {
 	// already have decrypted secret?
@@ -477,7 +477,7 @@ func (s *SKB) UnlockNoPrompt(lctx LoginContext, secretStore SecretStore) (Generi
 		s.G().LoginState().PassphraseStreamCache(func(sc *PassphraseStreamCache) {
 			tsec = sc.Triplesec()
 			pps = sc.PassphraseStream()
-		}, "skb - PromptAndUnlock - tsec, pps")
+		}, "skb - UnlockNoPrompt - tsec, pps")
 	}
 
 	if tsec != nil || pps != nil {
@@ -496,7 +496,7 @@ func (s *SKB) UnlockNoPrompt(lctx LoginContext, secretStore SecretStore) (Generi
 	}
 
 	// failed to unlock without prompting user for passphrase
-	return nil, errUnlockNotPossible
+	return nil, ErrUnlockNotPossible
 }
 
 func (s *SKB) unlockPrompt(arg SecretKeyPromptArg, secretStore SecretStore, me *User) (GenericKey, error) {
@@ -560,7 +560,7 @@ func (s *SKB) PromptAndUnlock(arg SecretKeyPromptArg, secretStore SecretStore, m
 	if err == nil {
 		return
 	}
-	if err != errUnlockNotPossible {
+	if err != ErrUnlockNotPossible {
 		return
 	}
 

--- a/go/systests/passphrase_test.go
+++ b/go/systests/passphrase_test.go
@@ -114,12 +114,6 @@ func TestPassphraseRecover(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// logout before recovering passphrase
-	logout := client.NewCmdLogoutRunner(tc2.G)
-	if err := logout.Run(); err != nil {
-		t.Fatal(err)
-	}
-
 	// the paper key displayed during signup is in userInfo now, and it will be used
 	// during passphrase recovery
 	tc.G.Log.Debug("signup paper key: %s", userInfo.displayedPaperKey)


### PR DESCRIPTION
This change allows `keybase passphrase recover` to work without needing the existing passphrase. The problem was that if there was an uploaded pgp key it would try to decrypt it, requiring the old passphrase.

This change will enable users to recover, but has a few undesirable properties about the state it leaves them in:
- Their PGP public key is still shown on their profile even though they _may_ have lost access to the secret key.
- The PGP secret key is still accessible and unlocked in some cases on the original device, but will cease to be syncing with the server (I think)

r? @maxtaco 