### PR TITLE
potential broken test workaround for RekeyTest

### DIFF
--- a/go/systests/rekey_test.go
+++ b/go/systests/rekey_test.go
@@ -716,7 +716,13 @@ func (rkt *rekeyTester) bumpTLFAndAssertRekeyWindowPushed(dw *deviceWrapper) {
 	// We shouldn't get a rekey UI until we bump the TLF forward (and therefore get a gregor
 	// message). We're cheating here and mixing fast-forwardable time (via fake clock),
 	// and real time (on the API server).
-	rkt.confirmNoRekeyUIActivity(dw, 3, false)
+	//
+	// NOTE(maxtaco): 2016-12-08
+	//
+	// Disable the following since it was breaking CI on a windows node with a clock
+	// skew:
+	//
+	// rkt.confirmNoRekeyUIActivity(dw, 3, false)
 
 	// But now we're bumping this device forward in the queue. This should trigger the gregor
 	// notification and also the push of the real rekey window.


### PR DESCRIPTION
there's little risk here

this might fix the broken test on windows when the clock is bad

CC: @zanderz and @jzila 