### PR TITLE
Enable pvl

### DIFF
--- a/go/pvl/hardcoded.go
+++ b/go/pvl/hardcoded.go
@@ -534,11 +534,13 @@ var hardcodedPVLString = `
         {
           "assert_regex_match": {
             "case_insensitive": true,
+            "from": "hint_url",
             "pattern": "^https?://[\\w:_\\-\\.]+/_/api/1\\.0/rooter/%{username_service}/.*$"
           }
         },
         {
           "fetch": {
+            "from": "hint_url",
             "kind": "json"
           }
         },

--- a/go/pvl/helpers.go
+++ b/go/pvl/helpers.go
@@ -246,3 +246,23 @@ func validateProtocol(s string, allowed []string) (string, bool) {
 	}
 	return canon, false
 }
+
+func rooterRewriteURL(ctx libkb.ProofContext, s string) (string, error) {
+	u1, err := url.Parse(s)
+	if err != nil {
+		return "", err
+	}
+	u2, err := url.Parse(ctx.GetServerURI())
+	if err != nil {
+		return "", err
+	}
+
+	u3 := url.URL{
+		Host:     u2.Host,
+		Scheme:   u2.Scheme,
+		Path:     u1.Path,
+		Fragment: u1.Fragment,
+	}
+
+	return u3.String(), nil
+}

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -807,7 +807,7 @@ func stepFetch(g proofContextExt, ins fetchT, state scriptState) (scriptState, l
 	case fetchModeHTML:
 		if ins.Into != "" {
 			return state, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
-				"JSON fetch must not specify 'into' register")
+				"HTML fetch must not specify 'into' register")
 		}
 		res, err1 := g.GetExternalAPI().GetHTML(libkb.NewAPIArg(from))
 		if err1 != nil {

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -18,7 +18,7 @@ import (
 )
 
 // UsePvl says whether to use PVL for verifying proofs.
-const UsePvl = false
+const UsePvl = true
 
 // SupportedVersion is which version of PVL is supported by this client.
 const SupportedVersion int = 1

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -773,6 +773,14 @@ func stepFetch(g proofContextExt, ins fetchT, state scriptState) (scriptState, l
 	if err != nil {
 		return state, err
 	}
+	if state.Service == keybase1.ProofType_ROOTER {
+		from2, err := rooterRewriteURL(g, from)
+		if err != nil {
+			return state, libkb.NewProofError(keybase1.ProofStatus_FAILED_PARSE,
+				"Could not rewrite rooter URL: %v", err)
+		}
+		from = from2
+	}
 
 	switch fetchMode(ins.Kind) {
 	case fetchModeString:

--- a/pvl-tools/pvl.cson
+++ b/pvl-tools/pvl.cson
@@ -249,9 +249,11 @@ services:
     # URL validation.
     { assert_regex_match: {
       , pattern: "^https?://[\\w:_\\-\\.]+/_/api/1\\.0/rooter/%{username_service}/.*$"
-      , case_insensitive: true} },
+      , case_insensitive: true
+      , from: "hint_url" } },
     # rooter is special cased by the interpreter to hit the api server
     { fetch: {
+      , from: "hint_url"
       , kind: "json" } },
     { selector_json: {
       , selectors: ["status", "name"]


### PR DESCRIPTION
This change switches all proof checkers to use PVL with [instructions hardcoded](https://github.com/keybase/client/blob/master/pvl-tools/pvl.cson) into the client. (Please give that a final read, [spec's here](https://keybase.io/docs/client/pvl_spec))

The error codes returned by PVL vs the Go checkers might be slightly different, which could effect caching. But they should be pretty close.

As for the validity of proofs, whether they pass or not, I have hard numbers [here](https://keybase.atlassian.net/browse/CORE-3755).

r? @maxtaco @oconnor663 
