### PR TITLE
wait until localize is all done before returning

### DIFF
--- a/go/client/cmd_chat_list.go
+++ b/go/client/cmd_chat_list.go
@@ -6,8 +6,6 @@ package client
 import (
 	"golang.org/x/net/context"
 
-	"time"
-
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
@@ -43,10 +41,7 @@ func (c *cmdChatList) Run() error {
 		return err
 	}
 
-	if c.fetcher.async {
-		// Wait around for a bit to test async
-		time.Sleep(time.Second * 5)
-	} else {
+	if !c.fetcher.async {
 		if len(conversations) == 0 {
 			ui.Printf("no conversations\n")
 			return nil

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -123,7 +123,7 @@ func (h *chatLocalHandler) GetInboxNonblockLocal(ctx context.Context, arg chat1.
 		if lres.InboxRes == nil {
 			return fmt.Errorf("invalid conversation localize callback received")
 		}
-		chatUI.ChatInboxUnverified(context.Background(), chat1.ChatInboxUnverifiedArg{
+		chatUI.ChatInboxUnverified(ctx, chat1.ChatInboxUnverifiedArg{
 			SessionID: arg.SessionID,
 			Inbox: chat1.GetInboxLocalRes{
 				ConversationsUnverified: lres.InboxRes.ConvsUnverified,
@@ -140,13 +140,13 @@ func (h *chatLocalHandler) GetInboxNonblockLocal(ctx context.Context, arg chat1.
 	// Consume localize callbacks and send out to UI.
 	for convRes := range localizeCb {
 		if convRes.Err != nil {
-			chatUI.ChatInboxFailed(context.Background(), chat1.ChatInboxFailedArg{
+			chatUI.ChatInboxFailed(ctx, chat1.ChatInboxFailedArg{
 				SessionID: arg.SessionID,
 				Error:     convRes.Err.Error(),
 				ConvID:    convRes.ConvID,
 			})
 		} else if convRes.ConvRes != nil {
-			chatUI.ChatInboxConversation(context.Background(), chat1.ChatInboxConversationArg{
+			chatUI.ChatInboxConversation(ctx, chat1.ChatInboxConversationArg{
 				SessionID: arg.SessionID,
 				Conv:      *convRes.ConvRes,
 			})

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -138,22 +138,20 @@ func (h *chatLocalHandler) GetInboxNonblockLocal(ctx context.Context, arg chat1.
 	}
 
 	// Consume localize callbacks and send out to UI.
-	go func() {
-		for convRes := range localizeCb {
-			if convRes.Err != nil {
-				chatUI.ChatInboxFailed(context.Background(), chat1.ChatInboxFailedArg{
-					SessionID: arg.SessionID,
-					Error:     convRes.Err.Error(),
-					ConvID:    convRes.ConvID,
-				})
-			} else if convRes.ConvRes != nil {
-				chatUI.ChatInboxConversation(context.Background(), chat1.ChatInboxConversationArg{
-					SessionID: arg.SessionID,
-					Conv:      *convRes.ConvRes,
-				})
-			}
+	for convRes := range localizeCb {
+		if convRes.Err != nil {
+			chatUI.ChatInboxFailed(context.Background(), chat1.ChatInboxFailedArg{
+				SessionID: arg.SessionID,
+				Error:     convRes.Err.Error(),
+				ConvID:    convRes.ConvID,
+			})
+		} else if convRes.ConvRes != nil {
+			chatUI.ChatInboxConversation(context.Background(), chat1.ChatInboxConversationArg{
+				SessionID: arg.SessionID,
+				Conv:      *convRes.ConvRes,
+			})
 		}
-	}()
+	}
 
 	return nil
 }


### PR DESCRIPTION
@patrickxb r?

I mistakenly put the reader of the result channel in a goroutine (on purpose, I thought the way these session IDs worked was independent of when the RPC returned), so this changes it so that we don't return from the service RPC until the whole unboxing is complete.

cc @chrisnojima 