### PR TITLE
Fix tab switch in menubar

### DIFF
--- a/shared/actions/favorite.js
+++ b/shared/actions/favorite.js
@@ -20,7 +20,7 @@ function setupKBFSChangedHandler (): SetupKBFSChangedHandler {
   return {type: Constants.setupKBFSChangedHandler, payload: undefined}
 }
 
-function switchTab (showingPrivate: boolean): FavoriteSwitchTab {
+function favoriteSwitchTab (showingPrivate: boolean): FavoriteSwitchTab {
   return {type: Constants.favoriteSwitchTab, payload: {showingPrivate}, error: false}
 }
 
@@ -309,7 +309,7 @@ export {
   ignoreFolder,
   markTLFCreated,
   setupKBFSChangedHandler,
-  switchTab,
+  favoriteSwitchTab,
   toggleShowIgnored,
 }
 

--- a/shared/menubar/index.js
+++ b/shared/menubar/index.js
@@ -203,9 +203,9 @@ export default connect(
     badgeInfo: state.notifications && state.notifications.menuNotifications || {},
   }),
   dispatch => ({
+    ...bindActionCreators({...favoriteAction, openInKBFS, openRekeyDialog}, dispatch),
     onShowLoginTab: () => { dispatch(navigateTo([loginTab])) },
     switchTab: tab => { dispatch(switchTo([tab])) },
-    ...bindActionCreators({...favoriteAction, openInKBFS, openRekeyDialog}, dispatch),
   })
 )(Menubar)
 


### PR DESCRIPTION
There was a of name collision for switchTab!

It was being set to `dispatch(switchTo(...)` but because `bindActionCreators` was declared later, it was overwritten by the `switchTab` declared in `actions/favorite.js`.

I renamed switchTab to favoriteSwitchTab and moved the `...bindActionCreators` to the first element.
