### PR TITLE
Fix btc/zcash proofs

### DIFF
--- a/shared/actions/profile/proofs.js
+++ b/shared/actions/profile/proofs.js
@@ -279,7 +279,7 @@ function * _submitCryptoAddress (action: SubmitBTCAddress | SubmitZcashAddress):
     yield call(cryptocurrencyRegisterAddressRpcPromise, {param: {address, force: true, wantedFamily}})
     yield put(_waitingForResponse(false))
     yield put(_updateProofStatus(true, ProveCommonProofStatus.ok))
-    yield put(navigateAppend(['ConfirmOrPending'], [profileTab]))
+    yield put(navigateAppend(['postProof', 'confirmOrPending'], [profileTab]))
   } catch (error) {
     console.warn('Error making proof')
     yield put(_waitingForResponse(false))

--- a/shared/login/register/paper-key/index.render.desktop.js
+++ b/shared/login/register/paper-key/index.render.desktop.js
@@ -17,6 +17,7 @@ const Render = ({onBack, onSubmit, onChangePaperKey, error, paperKey, waitingFor
         rowsMax={3}
         style={styles.input}
         errorText={error}
+        floatingHintTextOverride='Paper key'
         hintText='opp blezzard tofi pando agg whi pany yaga jocket daubt bruwnstane hubit yas'
         onEnterKeyDown={() => onSubmit()}
         onChangeText={text => onChangePaperKey(text)}

--- a/shared/profile/prove-enter-username-container.js
+++ b/shared/profile/prove-enter-username-container.js
@@ -35,7 +35,7 @@ export default connector.connect(
     }
 
     return {
-      canContinue: profile.usernameValid,
+      canContinue: true,
       errorCode: profile.errorCode,
       errorText: profile.errorText,
       onCancel: () => { dispatch(cancelAddProof()) },

--- a/shared/profile/prove-enter-username.js.flow
+++ b/shared/profile/prove-enter-username.js.flow
@@ -9,7 +9,7 @@ export type Props = {
   username: string,
   errorText: ?string,
   errorCode: ?number,
-  canContinue?: boolean,
+  canContinue: boolean,
   onUsernameChange?: (username: string) => void,
   onContinue: (username: string) => void,
   onCancel: () => void,


### PR DESCRIPTION
- Fix continue button always disabled (changed to always be enabled), it will verify address on submit/continue (since input is now handled in state)
- Fix post proof route
- Also fixing paper key floating hint text (unrelated bug I noticed)