### PR TITLE
Bump up launchd test timeout, only runs slower on failure

### DIFF
--- a/go/launchd/launchd.go
+++ b/go/launchd/launchd.go
@@ -249,14 +249,16 @@ func waitForExit(wait time.Duration, delay time.Duration, fn loadStatusFn) error
 
 // Install will install the launchd service
 func (s Service) Install(p Plist, wait time.Duration) error {
-	plistDest := s.plistDestination()
-	return s.install(p, plistDest, wait)
+	return s.install(p, wait)
 }
 
-func (s Service) install(p Plist, plistDest string, wait time.Duration) error {
+func (s Service) savePlist(p Plist) error {
+	plistDest := s.plistDestination()
+
 	if _, ferr := os.Stat(p.binPath); os.IsNotExist(ferr) {
 		return fmt.Errorf("%s doesn't exist", p.binPath)
 	}
+
 	plist := p.plistXML()
 
 	// Plist directory (~/Library/LaunchAgents/) might not exist on clean OS installs
@@ -271,6 +273,11 @@ func (s Service) install(p Plist, plistDest string, wait time.Duration) error {
 		return err
 	}
 
+	return nil
+}
+
+func (s Service) install(p Plist, wait time.Duration) error {
+	s.savePlist(p)
 	return s.Start(wait)
 }
 

--- a/go/launchd/launchd_test.go
+++ b/go/launchd/launchd_test.go
@@ -65,12 +65,12 @@ func TestCheckPlist(t *testing.T) {
 		t.Fatalf("We shouldn't have a plist")
 	}
 
-	err = service.Install(plist, time.Second)
+	err = service.savePlist(plist)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Check valid plist after install
+	// Check valid plist after save
 	plistIsValidAfter, err := service.CheckPlist(plist)
 	if err != nil {
 		t.Fatal(err)
@@ -89,7 +89,7 @@ func TestCheckPlist(t *testing.T) {
 		t.Fatal("New plist should be invalid")
 	}
 
-	err = service.Install(plistNew, time.Second)
+	err = service.savePlist(plistNew)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +116,7 @@ func TestWaitForStatusOK(t *testing.T) {
 	fn := func() (*ServiceStatus, error) {
 		return &ServiceStatus{label: "ok", pid: "1"}, nil
 	}
-	status, err := waitForStatus(10*time.Millisecond, time.Millisecond, fn)
+	status, err := waitForStatus(time.Second, time.Millisecond, fn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,11 +134,14 @@ func TestWaitForStatusDelayed(t *testing.T) {
 		}
 		return nil, nil
 	}
-	status, err := waitForStatus(10*time.Millisecond, time.Millisecond, fn)
+	status, err := waitForStatus(time.Second, time.Millisecond, fn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status == nil || status.label != "ok_delayed" {
+	if status == nil {
+		t.Fatalf("Wait timed out")
+	}
+	if status.label != "ok_delayed" {
 		t.Fatalf("Invalid status")
 	}
 }
@@ -147,7 +150,7 @@ func TestWaitForStatusErrored(t *testing.T) {
 	fn := func() (*ServiceStatus, error) {
 		return nil, fmt.Errorf("status error")
 	}
-	_, err := waitForStatus(10*time.Millisecond, time.Millisecond, fn)
+	_, err := waitForStatus(time.Second, time.Millisecond, fn)
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -173,7 +176,7 @@ func TestWaitForExitOK(t *testing.T) {
 	fn := func() (*ServiceStatus, error) {
 		return nil, nil
 	}
-	err := waitForExit(10*time.Millisecond, time.Millisecond, fn)
+	err := waitForExit(time.Second, time.Millisecond, fn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +191,7 @@ func TestWaitForExitDelayed(t *testing.T) {
 		}
 		return nil, nil
 	}
-	err := waitForExit(10*time.Millisecond, time.Millisecond, fn)
+	err := waitForExit(time.Second, time.Millisecond, fn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +201,7 @@ func TestWaitForExitErrored(t *testing.T) {
 	fn := func() (*ServiceStatus, error) {
 		return nil, fmt.Errorf("status error")
 	}
-	err := waitForExit(10*time.Millisecond, time.Millisecond, fn)
+	err := waitForExit(time.Second, time.Millisecond, fn)
 	if err == nil {
 		t.Fatal("Expected error")
 	}

--- a/go/libkb/service_info_test.go
+++ b/go/libkb/service_info_test.go
@@ -13,7 +13,7 @@ func TestWaitForServiceInfoOK(t *testing.T) {
 	fn := func() (*ServiceInfo, error) {
 		return &ServiceInfo{Label: "ok", Pid: 1}, nil
 	}
-	info, err := waitForServiceInfo(10*time.Millisecond, time.Millisecond, fn)
+	info, err := waitForServiceInfo(time.Second, time.Millisecond, fn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func TestWaitForServiceInfoDelayed(t *testing.T) {
 		}
 		return nil, nil
 	}
-	info, err := waitForServiceInfo(10*time.Millisecond, time.Millisecond, fn)
+	info, err := waitForServiceInfo(time.Second, time.Millisecond, fn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +44,7 @@ func TestWaitForServiceInfoErrored(t *testing.T) {
 	fn := func() (*ServiceInfo, error) {
 		return nil, fmt.Errorf("info error")
 	}
-	_, err := waitForServiceInfo(10*time.Millisecond, time.Millisecond, fn)
+	_, err := waitForServiceInfo(time.Second, time.Millisecond, fn)
 	if err == nil {
 		t.Fatal("Expected error")
 	}


### PR DESCRIPTION
If CI slow, the timeout was too short. Bumped timeout to something large which would only run slower on test failure.