### PR TITLE
Fix ChatConvExists decoding

### DIFF
--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -376,7 +376,11 @@ func ImportStatusAsError(s *keybase1.Status) error {
 		for _, field := range s.Fields {
 			switch field.Key {
 			case "ConvID":
-				convID = chat1.ConversationID(field.Value)
+				bs, err := chat1.MakeConvID(field.Value)
+				if err != nil {
+					G.Log.Warning("error parsing ChatConvExistsError")
+				}
+				convID = chat1.ConversationID(bs)
 			}
 		}
 		return ChatConvExistsError{


### PR DESCRIPTION
This fixes the issue where NewConversation2 would fail for chats that already exist.
The problem was that `ConversationID.String` hex'd the redirect ConvID and `ImportStatusAsError` didn't decode it. Now it's explicitly hex'd and unhex'd.

This wasn't noticed probably because it isn't hit by the CLI at all, because the CLI pre-checks for conversations. I suspect that TLFIDs in exceptions might have the same problem (not fixed here).

r? @mmaxim 