### PR TITLE
Be explicit about what gets logged

### DIFF
--- a/shared/constants/reducer.js
+++ b/shared/constants/reducer.js
@@ -37,6 +37,27 @@ export type TypedState = {
   unlockFolders: UnlockFoldersState,
 }
 
+export type StateLogTransformer = (state: TypedState) => Object
+
 // TODO swap State with TypedState when TypedState includes everything we care about
 export type State = {[key: string]: any}
 export const stateKey = 'reducer:stateKey'
+
+// TODO expand this
+export const stateLogTransformer: StateLogTransformer = (state) => {
+  const {
+    config: {
+      username, uid, loggedIn, error, bootstrapTriesRemaining, bootStatus,
+    },
+    routeTree,
+    tracker,
+  } = state
+
+  return {
+    config: {
+      username, uid, loggedIn, error, bootstrapTriesRemaining, bootStatus,
+    },
+    routeTree,
+    tracker,
+  }
+}

--- a/shared/constants/types/flux.js
+++ b/shared/constants/types/flux.js
@@ -1,14 +1,18 @@
 // @flow
 import type {TypedState} from '../reducer'
 
+export type LogTransformer = (action: TypedAction<*, *, *>) => Object
+
 export type TypedAction<T, P, E> = {
   error?: false,
   type: T,
   payload: P,
+  logTransformer?: LogTransformer,
 } | {
   error: true,
   type: T,
   payload: E,
+  logTransformer?: LogTransformer,
 }
 
 export type NoErrorTypedAction<T, P> = TypedAction<T, P, P>
@@ -20,3 +24,41 @@ export type Dispatch = (action: AsyncAction | Action) => ?Promise<*>
 
 export type TypedAsyncAction<A> = (dispatch: TypedDispatch<A>, getState: GetState) => ?Promise<*>
 export type TypedDispatch<-A> = (action: TypedAsyncAction<A> | A) => ?Promise<*>
+
+function _deepKeysOnly (m: Object) {
+  return Object.keys(m).reduce((acc, k) => {
+    if (typeof m[k] === 'object') {
+      acc[k] = _deepKeysOnly(m[k])
+    } else {
+      acc[k] = null
+    }
+    return acc
+  }, {})
+}
+
+function _shallowKeysOnly (m: Object) {
+  return Object.keys(m).reduce((acc, k) => {
+    acc[k] = null
+    return acc
+  }, {})
+}
+
+export const shallowKeyOnlyLogTransformer: LogTransformer = (action) => {
+  const {payload, ...rest} = action
+  return {
+    ...rest,
+    payload: _shallowKeysOnly(payload),
+  }
+}
+
+export const deepKeyOnlyLogTransformer: LogTransformer = (action) => {
+  const {payload, ...rest} = action
+  return {
+    ...rest,
+    payload: _deepKeysOnly(payload),
+  }
+}
+
+export const noPayloadTransformer: LogTransformer = (action) => {
+  return {...action, payload: null}
+}

--- a/shared/constants/types/flux.js
+++ b/shared/constants/types/flux.js
@@ -25,40 +25,6 @@ export type Dispatch = (action: AsyncAction | Action) => ?Promise<*>
 export type TypedAsyncAction<A> = (dispatch: TypedDispatch<A>, getState: GetState) => ?Promise<*>
 export type TypedDispatch<-A> = (action: TypedAsyncAction<A> | A) => ?Promise<*>
 
-function _deepKeysOnly (m: Object) {
-  return Object.keys(m).reduce((acc, k) => {
-    if (typeof m[k] === 'object') {
-      acc[k] = _deepKeysOnly(m[k])
-    } else {
-      acc[k] = null
-    }
-    return acc
-  }, {})
-}
-
-function _shallowKeysOnly (m: Object) {
-  return Object.keys(m).reduce((acc, k) => {
-    acc[k] = null
-    return acc
-  }, {})
-}
-
-export const shallowKeyOnlyLogTransformer: LogTransformer = (action) => {
-  const {payload, ...rest} = action
-  return {
-    ...rest,
-    payload: _shallowKeysOnly(payload),
-  }
-}
-
-export const deepKeyOnlyLogTransformer: LogTransformer = (action) => {
-  const {payload, ...rest} = action
-  return {
-    ...rest,
-    payload: _deepKeysOnly(payload),
-  }
-}
-
 export const noPayloadTransformer: LogTransformer = (action) => {
   return {...action, payload: null}
 }


### PR DESCRIPTION
@keybase/react-hackers 

Explicitly pick what gets logged. Default to no payload data.


This is a simple pass to remove a bunch of logging. In a future PR I'll add more things to the whitelist (if you think of any, feel free to add here).

I think this is also a great use case for lenses since it should make describing paths much simpler and typesafe