### PR TITLE
disk caching for UPAKs

### DIFF
--- a/go/libkb/cached_user_loader.go
+++ b/go/libkb/cached_user_loader.go
@@ -190,7 +190,12 @@ func (u *CachedUserLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		}
 		if leaf.public != nil && leaf.public.Seqno == Seqno(upk.Base.Uvv.SigChain) {
 			u.G().Log.Debug("%s: cache-hit; fresh after poll", culDebug(arg.UID), fresh)
+
 			upk.Base.Uvv.CachedAt = keybase1.ToTime(u.G().Clock().Now())
+			// This is only necessary to update the levelDB representation,
+			// since the previous line updates the in-memory cache satisfactorially.
+			u.putUPKToCache(upk)
+
 			return upk.DeepCopy(), nil, nil
 		}
 

--- a/go/libkb/cached_user_loader.go
+++ b/go/libkb/cached_user_loader.go
@@ -334,6 +334,11 @@ func (u *CachedUserLoader) LookupUsername(uid keybase1.UID) NormalizedUsername {
 
 func (u *CachedUserLoader) lookupUsernameAndDeviceWithInfo(uid keybase1.UID, did keybase1.DeviceID, info *CachedUserLoadInfo) (username NormalizedUsername, deviceName string, deviceType string, err error) {
 	arg := NewLoadUserByUIDArg(u.G(), uid)
+
+	// First iteration through, say it's OK to load a stale user. Note that the
+	// mappings of UID to Username and DeviceID to DeviceName are immutable, so this
+	// data can never be stale. However, our user might be out of date and lack the
+	// mappings, so the second time through, we request a fresh object.
 	staleOK := []bool{true, false}
 	for _, b := range staleOK {
 		arg.StaleOK = b

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -168,6 +168,7 @@ func (j JSONLocalDbTransaction) Discard() {
 
 const (
 	DBUser                    = 0x00
+	DBUserPlusAllKeys         = 0x19
 	DBSig                     = 0x0f
 	DBLink                    = 0xe0
 	DBLocalTrack              = 0xe1

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -20,6 +20,7 @@ type LoadUserArg struct {
 	Self                     bool
 	ForceReload              bool
 	ForcePoll                bool // for cached user load, force a repoll
+	StaleOK                  bool // if stale cached versions are OK (for immutable fields)
 	AllKeys                  bool
 	LoginContext             LoginContext
 	AbortIfSigchainUnchanged bool

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -820,3 +820,12 @@ func (u UserVersionVector) Equal(u2 UserVersionVector) bool {
 func (d DurationSec) Duration() time.Duration {
 	return time.Duration(d) * time.Second
 }
+
+func (u UserPlusAllKeys) FindDevice(d DeviceID) *PublicKey {
+	for _, k := range u.Base.DeviceKeys {
+		if k.DeviceID.Eq(d) {
+			return &k
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
- expose methods for chat like LookupUsernameAndDevice
- some light testing, but didn't go overboard here.
- inspected by hand that it seems to do the right thing.