### PR TITLE
blast out chat UI calls for async inbox afap

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -317,9 +317,16 @@ func (s *localizer) localizeConversationsPipeline(ctx context.Context, uid grego
 
 				// If a localize callback channel exists, send along the result as well
 				if localizeCb != nil {
-					*localizeCb <- NonblockInboxResult{
-						ConvRes: &convLocal,
-						ConvID:  convLocal.Info.Id,
+					if convLocal.Error != nil {
+						*localizeCb <- NonblockInboxResult{
+							Err:    errors.New(*convLocal.Error),
+							ConvID: conv.conv.Metadata.ConversationID,
+						}
+					} else {
+						*localizeCb <- NonblockInboxResult{
+							ConvRes: &convLocal,
+							ConvID:  convLocal.Info.Id,
+						}
 					}
 				}
 			}

--- a/go/client/chat_ui.go
+++ b/go/client/chat_ui.go
@@ -107,7 +107,7 @@ func (c *ChatUI) ChatInboxConversation(ctx context.Context, arg chat1.ChatInboxC
 	w := c.terminal.ErrorWriter()
 	sender := "<unknown>"
 	snippet := "<blank>"
-	tlf := "<unknown>"
+	tlf := arg.Conv.Info.TlfName + " (unverified)"
 	for _, msg := range arg.Conv.MaxMessages {
 		if msg.IsValid() && msg.GetMessageType() == chat1.MessageType_TEXT {
 			sender = msg.Valid().SenderUsername

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"golang.org/x/net/context"
@@ -139,21 +140,26 @@ func (h *chatLocalHandler) GetInboxNonblockLocal(ctx context.Context, arg chat1.
 	}
 
 	// Consume localize callbacks and send out to UI.
+	var wg sync.WaitGroup
 	for convRes := range localizeCb {
-		if convRes.Err != nil {
-			chatUI.ChatInboxFailed(ctx, chat1.ChatInboxFailedArg{
-				SessionID: arg.SessionID,
-				Error:     convRes.Err.Error(),
-				ConvID:    convRes.ConvID,
-			})
-		} else if convRes.ConvRes != nil {
-			chatUI.ChatInboxConversation(ctx, chat1.ChatInboxConversationArg{
-				SessionID: arg.SessionID,
-				Conv:      *convRes.ConvRes,
-			})
-		}
+		wg.Add(1)
+		go func(convRes chat.NonblockInboxResult) {
+			if convRes.Err != nil {
+				chatUI.ChatInboxFailed(ctx, chat1.ChatInboxFailedArg{
+					SessionID: arg.SessionID,
+					Error:     convRes.Err.Error(),
+					ConvID:    convRes.ConvID,
+				})
+			} else if convRes.ConvRes != nil {
+				chatUI.ChatInboxConversation(ctx, chat1.ChatInboxConversationArg{
+					SessionID: arg.SessionID,
+					Conv:      *convRes.ConvRes,
+				})
+			}
+			wg.Done()
+		}(convRes)
 	}
-
+	wg.Wait()
 	return nil
 }
 


### PR DESCRIPTION
This makes a goroutine for every call out to Electron when sending callbacks for the async inbox load. It seems to make the loads faster, although still slower than the CLI. This also fixes the bug where error callbacks weren't being sent.

cc @chrisnojima 