### PR TITLE
Chat inbox username flex-start

### DIFF
--- a/shared/chat/conversations-list/index.desktop.js
+++ b/shared/chat/conversations-list/index.desktop.js
@@ -59,7 +59,7 @@ const Row = ({onSelectConversation, selectedConversation, onNewChat, nowOverride
       </Box>
       <Box style={{...globalStyles.flexBoxRow, flex: 1, borderBottom: `solid 1px ${globalColors.black_10}`, paddingRight: 8, paddingTop: 4, paddingBottom: 4}}>
         <Box style={{...globalStyles.flexBoxColumn, flex: 1, position: 'relative'}}>
-          <Box style={{...globalStyles.flexBoxColumn, position: 'absolute', top: 0, bottom: 0, left: 0, right: 0, alignItems: 'center', justifyContent: 'center'}}>
+          <Box style={{...globalStyles.flexBoxColumn, position: 'absolute', top: 0, bottom: 0, left: 0, right: 0, alignItems: 'center', justifyContent: 'flex-start'}}>
             <Usernames
               inline={true}
               type='BodySemibold'


### PR DESCRIPTION
Fixes empty chat username from being centered. Should be top aligned.
![2016-12-14 at 2 08 pm](https://cloud.githubusercontent.com/assets/2669/21203352/e797f1ba-c206-11e6-9aba-5c380b72c157.png)

![2016-12-14 at 2 11 pm](https://cloud.githubusercontent.com/assets/2669/21203426/3e65672a-c207-11e6-8a88-8920b16c8e25.png)
