### PR TITLE
Fix menubar badging

### DIFF
--- a/shared/main.desktop.js
+++ b/shared/main.desktop.js
@@ -48,7 +48,7 @@ class Main extends Component<void, Props, void> {
 
   componentDidUpdate (prevProps) {
     if (this.props.menuBadge !== prevProps.menuBadge) {
-      ipcRenderer.send(this.props.menuBadge ? 'showTrayRegular' : 'showTrayBadged')
+      ipcRenderer.send('showTray', this.props.menuBadge)
     }
   }
 


### PR DESCRIPTION
@keybase/react-hackers 

It looks like the routeTree merge switched to using a previous IPC API for showTray (where we send showTrayRegular or showTrayBadged) instead of the current one understood by the main process.  (It might have been a merge race between routeTree and that API change..?)

Anyway, this fixes badging by reintroducing that change.  The actual reducer where we calculate when to badge was already doing the right thing with chat messages and KBFS TLFs, as far as I can tell. 