### PR TITLE
Fix chat missing device name

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -296,6 +296,8 @@ function * _incomingMessage (action: IncomingMessage): SagaGenerator<any, any> {
             type: Constants.pendingMessageWasSent,
             payload: {
               conversationIDKey,
+              deviceName: message.deviceName,
+              deviceType: message.deviceType,
               outboxID: message.outboxID,
               messageID: message.messageID,
               messageState: 'sent',

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -296,10 +296,7 @@ function * _incomingMessage (action: IncomingMessage): SagaGenerator<any, any> {
             type: Constants.pendingMessageWasSent,
             payload: {
               conversationIDKey,
-              deviceName: message.deviceName,
-              deviceType: message.deviceType,
-              outboxID: message.outboxID,
-              messageID: message.messageID,
+              message,
               messageState: 'sent',
             },
           })

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -110,7 +110,7 @@ function reducer (state: State = initialState, action: Actions) {
         .set('inbox', newInboxStates)
     }
     case Constants.pendingMessageWasSent: {
-      const {outboxID, messageID, messageState} = action.payload
+      const {deviceName, deviceType, outboxID, messageID, messageState} = action.payload
       const newConversationStates = state.get('conversationStates').update(
         action.payload.conversationIDKey,
         initialConversation,
@@ -122,6 +122,8 @@ function reducer (state: State = initialState, action: Actions) {
           }
           return conversation.updateIn(['messages', index], item => ({
             ...item,
+            deviceName,
+            deviceType,
             messageID,
             messageState,
           })).set('seenMessages', conversation.seenMessages.add(messageID))

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -110,23 +110,20 @@ function reducer (state: State = initialState, action: Actions) {
         .set('inbox', newInboxStates)
     }
     case Constants.pendingMessageWasSent: {
-      const {deviceName, deviceType, outboxID, messageID, messageState} = action.payload
+      const {conversationIDKey, message, messageState} = action.payload
       const newConversationStates = state.get('conversationStates').update(
-        action.payload.conversationIDKey,
+        conversationIDKey,
         initialConversation,
         conversation => {
-          const index = conversation.get('messages').findIndex(item => item.outboxID === outboxID)
+          const index = conversation.get('messages').findIndex(item => item.outboxID === message.outboxID)
           if (index < 0) {
             console.warn("Couldn't find an outbox entry to modify")
             return conversation
           }
           return conversation.updateIn(['messages', index], item => ({
-            ...item,
-            deviceName,
-            deviceType,
-            messageID,
+            ...message,
             messageState,
-          })).set('seenMessages', conversation.seenMessages.add(messageID))
+          })).set('seenMessages', conversation.seenMessages.add(message.messageID))
         }
       )
       return state.set('conversationStates', newConversationStates)


### PR DESCRIPTION
@keybase/react-hackers 

Chat messages that you sent were missing the device ID in their text popup, because the transition from being a pending message to a sent message only copied over the messageID from the finalized message, and not the deviceID.

I could have just added deviceID to the list of attributes to copy over (that's what the first commit in this PR did) but that's fragile, needing to be updated each time we add a new field to Message.  Instead, now we just completely replace the pending message with the one received from the server.