### PR TITLE
Add merkle root info to ClientHeader

### DIFF
--- a/go/chat/utils/context.go
+++ b/go/chat/utils/context.go
@@ -18,4 +18,5 @@ type KeybaseContext interface {
 	Clock() clockwork.Clock
 	GetCachedUserLoader() *libkb.CachedUserLoader
 	GetUserDeviceCache() *libkb.UserDeviceCache
+	GetMerkleClient() *libkb.MerkleClient
 }

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -684,6 +684,7 @@ func (c *chatServiceHandler) makePostHeader(ctx context.Context, arg sendArgV1, 
 	existing := gilres.Conversations
 	switch len(existing) {
 	case 0:
+
 		ncres, err := client.NewConversationLocal(ctx, chat1.NewConversationLocalArg{
 			TlfName:       *query.TlfName,
 			TlfVisibility: *query.TlfVisibility,

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -110,6 +110,7 @@ func (g *GlobalContext) GetExternalAPI() ExternalAPI            { return g.XAPI 
 func (g *GlobalContext) GetServerURI() string                   { return g.Env.GetServerURI() }
 func (g *GlobalContext) GetCachedUserLoader() *CachedUserLoader { return g.CachedUserLoader }
 func (g *GlobalContext) GetUserDeviceCache() *UserDeviceCache   { return g.UserDeviceCache }
+func (g *GlobalContext) GetMerkleClient() *MerkleClient         { return g.MerkleClient }
 
 func NewGlobalContext() *GlobalContext {
 	log := logger.New("keybase")

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -196,6 +196,7 @@ type MessageClientHeader struct {
 	Prev         []MessagePreviousPointer `codec:"prev" json:"prev"`
 	Sender       gregor1.UID              `codec:"sender" json:"sender"`
 	SenderDevice gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
+	MerkleRoot   *MerkleRoot              `codec:"merkleRoot,omitempty" json:"merkleRoot,omitempty"`
 	OutboxID     *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	OutboxInfo   *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
 }
@@ -210,6 +211,11 @@ type SignatureInfo struct {
 	V int    `codec:"v" json:"v"`
 	S []byte `codec:"s" json:"s"`
 	K []byte `codec:"k" json:"k"`
+}
+
+type MerkleRoot struct {
+	Seqno int64  `codec:"seqno" json:"seqno"`
+	Hash  []byte `codec:"hash" json:"hash"`
 }
 
 type InboxResType int

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -163,7 +163,6 @@ func (d *Service) Handle(c net.Conn) {
 }
 
 func (d *Service) Run() (err error) {
-
 	defer func() {
 		if d.startCh != nil {
 			close(d.startCh)

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -144,6 +144,8 @@ protocol common {
     array<MessagePreviousPointer> prev;
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;
+    // Latest merkle root when sent. Can be nil.
+    union { null, MerkleRoot } merkleRoot;
     union { null, OutboxID } outboxID;
     union { null, OutboxInfo } outboxInfo;
   }
@@ -159,6 +161,11 @@ protocol common {
     int   v; // version = 1
     bytes s; // signature; output of EdDSA
     bytes k; // Verifying key
+  }
+
+  record MerkleRoot {
+    long seqno;
+    bytes hash;
   }
 
   enum InboxResType {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -760,6 +760,11 @@ export type MarkAsReadRes = {
   rateLimit?: ?RateLimit,
 }
 
+export type MerkleRoot = {
+  seqno: long,
+  hash: bytes,
+}
+
 export type MessageAttachment = {
   object: Asset,
   preview?: ?Asset,
@@ -792,6 +797,7 @@ export type MessageClientHeader = {
   prev?: ?Array<MessagePreviousPointer>,
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
+  merkleRoot?: ?MerkleRoot,
   outboxID?: ?OutboxID,
   outboxInfo?: ?OutboxInfo,
 }

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -413,6 +413,13 @@
         {
           "type": [
             null,
+            "MerkleRoot"
+          ],
+          "name": "merkleRoot"
+        },
+        {
+          "type": [
+            null,
             "OutboxID"
           ],
           "name": "outboxID"
@@ -459,6 +466,20 @@
         {
           "type": "bytes",
           "name": "k"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "MerkleRoot",
+      "fields": [
+        {
+          "type": "long",
+          "name": "seqno"
+        },
+        {
+          "type": "bytes",
+          "name": "hash"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -760,6 +760,11 @@ export type MarkAsReadRes = {
   rateLimit?: ?RateLimit,
 }
 
+export type MerkleRoot = {
+  seqno: long,
+  hash: bytes,
+}
+
 export type MessageAttachment = {
   object: Asset,
   preview?: ?Asset,
@@ -792,6 +797,7 @@ export type MessageClientHeader = {
   prev?: ?Array<MessagePreviousPointer>,
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
+  merkleRoot?: ?MerkleRoot,
   outboxID?: ?OutboxID,
   outboxInfo?: ?OutboxInfo,
 }


### PR DESCRIPTION
Add the last known merkle root to outgoing chat messages `ClientHeader`s. There are no immediate plans to use this info, but it might prove useful to have in the future when validating messages from revoked devices.

Here's a question. This uses `MerkleClient.LastRootInfo` as the 'latest' merkle root, but that doesn't cause any fetching. So couldn't that merkle root be super out of date? This conundrum is the same faced by proof creation. And it seems to do the [same thing](https://github.com/keybase/client/blob/master/go/libkb/kbsig.go#L310). So before making MerkleClient check the ctime to figure if the root is stale or something, I'd like to make sure to understand how proof creation works.

This PR uses a new `chat1.MerkleRoot`. There already exists [`keybase1.MerkleRoot`](https://github.com/keybase/client/blob/master/protocol/avdl/keybase1/metadata.avdl#L28). I wasn't sure about using it because it has `Version` instead of `Seqno` and is used by kbfs-server, and might usually represent a different tree (?) .

r? @maxtaco 