### PR TITLE
new tlfFinalize spec, plus return more info about finalized convos CORE-4248

### DIFF
--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -391,7 +391,7 @@ func (m *ChatRemoteMock) SetConversationStatus(ctx context.Context, arg chat1.Se
 	return chat1.SetConversationStatusRes{}, errors.New("not implemented")
 }
 
-func (m *ChatRemoteMock) TlfFinalize(ctx context.Context, tlfID chat1.TLFID) error {
+func (m *ChatRemoteMock) TlfFinalize(ctx context.Context, arg chat1.TlfFinalizeArg) error {
 	return nil
 }
 

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -149,11 +149,17 @@ type ConversationIDTriple struct {
 	TopicID   TopicID   `codec:"topicID" json:"topicID"`
 }
 
+type ConversationFinalizeInfo struct {
+	ResetUser      string       `codec:"resetUser" json:"resetUser"`
+	ResetDate      string       `codec:"resetDate" json:"resetDate"`
+	ResetTimestamp gregor1.Time `codec:"resetTimestamp" json:"resetTimestamp"`
+}
+
 type ConversationMetadata struct {
-	IdTriple       ConversationIDTriple `codec:"idTriple" json:"idTriple"`
-	ConversationID ConversationID       `codec:"conversationID" json:"conversationID"`
-	IsFinalized    bool                 `codec:"isFinalized" json:"isFinalized"`
-	ActiveList     []gregor1.UID        `codec:"activeList" json:"activeList"`
+	IdTriple       ConversationIDTriple      `codec:"idTriple" json:"idTriple"`
+	ConversationID ConversationID            `codec:"conversationID" json:"conversationID"`
+	FinalizeInfo   *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
+	ActiveList     []gregor1.UID             `codec:"activeList" json:"activeList"`
 }
 
 type ConversationReaderInfo struct {

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -4,6 +4,7 @@
 package chat1
 
 import (
+	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
 )
@@ -122,7 +123,10 @@ type SetConversationStatusArg struct {
 }
 
 type TlfFinalizeArg struct {
-	TlfID TLFID `codec:"tlfID" json:"tlfID"`
+	TlfID          TLFID        `codec:"tlfID" json:"tlfID"`
+	ResetUser      string       `codec:"resetUser" json:"resetUser"`
+	ResetDate      string       `codec:"resetDate" json:"resetDate"`
+	ResetTimestamp gregor1.Time `codec:"resetTimestamp" json:"resetTimestamp"`
 }
 
 type GetUnreadUpdateFullArg struct {
@@ -147,7 +151,7 @@ type RemoteInterface interface {
 	GetMessagesRemote(context.Context, GetMessagesRemoteArg) (GetMessagesRemoteRes, error)
 	MarkAsRead(context.Context, MarkAsReadArg) (MarkAsReadRes, error)
 	SetConversationStatus(context.Context, SetConversationStatusArg) (SetConversationStatusRes, error)
-	TlfFinalize(context.Context, TLFID) error
+	TlfFinalize(context.Context, TlfFinalizeArg) error
 	GetUnreadUpdateFull(context.Context, InboxVers) (UnreadUpdateFull, error)
 	GetS3Params(context.Context, ConversationID) (S3Params, error)
 	S3Sign(context.Context, S3SignArg) ([]byte, error)
@@ -296,7 +300,7 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]TlfFinalizeArg)(nil), args)
 						return
 					}
-					err = i.TlfFinalize(ctx, (*typedArgs)[0].TlfID)
+					err = i.TlfFinalize(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -398,8 +402,7 @@ func (c RemoteClient) SetConversationStatus(ctx context.Context, __arg SetConver
 	return
 }
 
-func (c RemoteClient) TlfFinalize(ctx context.Context, tlfID TLFID) (err error) {
-	__arg := TlfFinalizeArg{TlfID: tlfID}
+func (c RemoteClient) TlfFinalize(ctx context.Context, __arg TlfFinalizeArg) (err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.tlfFinalize", []interface{}{__arg}, nil)
 	return
 }

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -93,10 +93,19 @@ protocol common {
     TopicID topicID;
   }
 
+  record ConversationFinalizeInfo {
+    string resetUser;
+    string resetDate;
+    gregor1.Time resetTimestamp;
+  }
+
   record ConversationMetadata  {
     ConversationIDTriple idTriple;
     ConversationID conversationID;
-    boolean isFinalized;
+
+    // Finalize info for underlying TLF
+    union { null, ConversationFinalizeInfo } finalizeInfo;
+
     // List of users sorted by recency of last [intentional] post.
     // Most recent first. May be incomplete or empty.
     array<gregor1.UID> activeList;

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -1,6 +1,8 @@
 @namespace("chat.1")
 protocol remote {
 
+  import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
+  
   record MessageBoxed {
     // Only set when returned from the server; on the way up to the
     // server, they are null.
@@ -83,7 +85,7 @@ protocol remote {
   // tlfFinalize is an endpoint for kbfstlfd to notify Gregor that a TLF ID has been finalized.
   // Gregor keeps an internal record of these TLF IDs, so that it can always return the latest
   // conversation per TLF ID on GetInboxRemote.
-  void tlfFinalize(TLFID tlfID);
+  void tlfFinalize(TLFID tlfID, string resetUser, string resetDate, gregor1.Time resetTimestamp);
 
   @lint("ignore")
   UnreadUpdateFull GetUnreadUpdateFull(InboxVers inboxVers);

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -523,6 +523,12 @@ export type Conversation = {
   maxMsgs?: ?Array<MessageBoxed>,
 }
 
+export type ConversationFinalizeInfo = {
+  resetUser: string,
+  resetDate: string,
+  resetTimestamp: gregor1.Time,
+}
+
 export type ConversationID = bytes
 
 export type ConversationIDTriple = {
@@ -552,7 +558,7 @@ export type ConversationLocal = {
 export type ConversationMetadata = {
   idTriple: ConversationIDTriple,
   conversationID: ConversationID,
-  isFinalized: boolean,
+  finalizeInfo?: ?ConversationFinalizeInfo,
   activeList?: ?Array<gregor1.UID>,
 }
 
@@ -1253,7 +1259,10 @@ export type remoteSetConversationStatusRpcParam = Exact<{
 }>
 
 export type remoteTlfFinalizeRpcParam = Exact<{
-  tlfID: TLFID
+  tlfID: TLFID,
+  resetUser: string,
+  resetDate: string,
+  resetTimestamp: gregor1.Time
 }>
 
 type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -239,6 +239,24 @@
     },
     {
       "type": "record",
+      "name": "ConversationFinalizeInfo",
+      "fields": [
+        {
+          "type": "string",
+          "name": "resetUser"
+        },
+        {
+          "type": "string",
+          "name": "resetDate"
+        },
+        {
+          "type": "gregor1.Time",
+          "name": "resetTimestamp"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "ConversationMetadata",
       "fields": [
         {
@@ -250,8 +268,11 @@
           "name": "conversationID"
         },
         {
-          "type": "boolean",
-          "name": "isFinalized"
+          "type": [
+            null,
+            "ConversationFinalizeInfo"
+          ],
+          "name": "finalizeInfo"
         },
         {
           "type": {

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -1,6 +1,12 @@
 {
   "protocol": "remote",
-  "imports": [],
+  "imports": [
+    {
+      "path": "github.com/keybase/client/go/protocol/gregor1",
+      "type": "idl",
+      "import_as": "gregor1"
+    }
+  ],
   "types": [
     {
       "type": "record",
@@ -389,6 +395,18 @@
         {
           "name": "tlfID",
           "type": "TLFID"
+        },
+        {
+          "name": "resetUser",
+          "type": "string"
+        },
+        {
+          "name": "resetDate",
+          "type": "string"
+        },
+        {
+          "name": "resetTimestamp",
+          "type": "gregor1.Time"
         }
       ],
       "response": null

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -523,6 +523,12 @@ export type Conversation = {
   maxMsgs?: ?Array<MessageBoxed>,
 }
 
+export type ConversationFinalizeInfo = {
+  resetUser: string,
+  resetDate: string,
+  resetTimestamp: gregor1.Time,
+}
+
 export type ConversationID = bytes
 
 export type ConversationIDTriple = {
@@ -552,7 +558,7 @@ export type ConversationLocal = {
 export type ConversationMetadata = {
   idTriple: ConversationIDTriple,
   conversationID: ConversationID,
-  isFinalized: boolean,
+  finalizeInfo?: ?ConversationFinalizeInfo,
   activeList?: ?Array<gregor1.UID>,
 }
 
@@ -1253,7 +1259,10 @@ export type remoteSetConversationStatusRpcParam = Exact<{
 }>
 
 export type remoteTlfFinalizeRpcParam = Exact<{
-  tlfID: TLFID
+  tlfID: TLFID,
+  resetUser: string,
+  resetDate: string,
+  resetTimestamp: gregor1.Time
 }>
 
 type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes


### PR DESCRIPTION
@patrickxb r? 

This adds some more fields to `Conversation` that should give more information about the nature of the finalized TLF. The information should also be enough to reconstruct the finalized TLF modified name.