### PR TITLE
Add option for whether to reset engine on HMR

### DIFF
--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -22,7 +22,7 @@ import {disable as disableDragDrop} from '../shared/util/drag-drop'
 import {listenForNotifications} from '../shared/actions/notifications'
 import {changedFocus} from '../shared/actions/window'
 import {merge} from 'lodash'
-import {reduxDevToolsEnable, devStoreChangingFunctions} from '../shared/local-debug.desktop'
+import {reduxDevToolsEnable, devStoreChangingFunctions, resetEngineOnHMR} from '../shared/local-debug.desktop'
 import {setRouteDef} from '../shared/actions/route-tree'
 import {setupContextMenu} from '../app/menu-helper'
 // $FlowIssue
@@ -133,7 +133,9 @@ function setupHMR (store) {
       store.dispatch({type: updateReloading, payload: {reloading: true}})
       const NewMain = require('../shared/main.desktop').default
       render(store, NewMain)
-      engine().reset()
+      if (resetEngineOnHMR) {
+        engine().reset()
+      }
     } finally {
       setTimeout(() => store.dispatch({type: updateReloading, payload: {reloading: false}}), 10e3)
     }

--- a/shared/local-debug.desktop.js
+++ b/shared/local-debug.desktop.js
@@ -29,6 +29,7 @@ let config: {[key: string]: any} = {
   logStatFrequency: 0,
   actionStatFrequency: 0,
   isTesting: false,
+  resetEngineOnHMR: false,
 }
 
 if (__DEV__ && process.env.KEYBASE_LOCAL_DEBUG) {
@@ -81,6 +82,7 @@ export const {
   showAllTrackers,
   showDevTools,
   skipSecondaryDevtools,
+  resetEngineOnHMR,
 } = config
 
 export function initTabbedRouterState () {


### PR DESCRIPTION
This causes a bootstrap after every HMR, which resets the route state and other things. I think that in the common case when you're using HMR and iterating on UI you don't want this behavior, so this relegates it to an opt-in local-debug setting.

:eyeglasses: @keybase/react-hackers 