### PR TITLE
Fix chat reducer mismerge

### DIFF
--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -154,7 +154,8 @@ function reducer (state: State = initialState, action: Actions) {
         .set('inbox', newInboxStates)
     }
     case Constants.pendingMessageWasSent: {
-      const {outboxID, conversationIDKey, messageID, messageState} = action.payload
+      const {conversationIDKey, message, messageState} = action.payload
+      const {messageID, outboxID} = message
       // $FlowIssue
       return state.update('conversationStates', conversationStates => updateConversationMessage(
         conversationStates,


### PR DESCRIPTION
@keybase/react-hackers 

The attachments PR overwrote a change I'd made to the pendingMessageWasSent reducer in a separate PR yesterday (fix device name), this PR adds the change back in and fixes the transition from pending to sent messages.