### PR TITLE
Fix buffer overflow surfaced by async chat

### DIFF
--- a/shared/util/saga.js
+++ b/shared/util/saga.js
@@ -42,7 +42,7 @@ function closeChannelMap<T> (channelMap: ChannelMap<T>): void {
 
 function singleFixedChannelConfig<T> (ks: Array<string>): ChannelConfig<T> {
   return ks.reduce((acc, k) => {
-    acc[k] = () => buffers.fixed(1)
+    acc[k] = () => buffers.expanding(1)
     return acc
   }, {})
 }


### PR DESCRIPTION
@keybase/react-hackers 

This seems to fix it for me.