### PR TITLE
change TLF finalize pointers to lists and add gregor update CORE-4235

### DIFF
--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -185,8 +185,8 @@ type ConversationReaderInfo struct {
 type Conversation struct {
 	Metadata     ConversationMetadata    `codec:"metadata" json:"metadata"`
 	ReaderInfo   *ConversationReaderInfo `codec:"readerInfo,omitempty" json:"readerInfo,omitempty"`
-	Supersedes   *ConversationMetadata   `codec:"supersedes,omitempty" json:"supersedes,omitempty"`
-	SupersededBy *ConversationMetadata   `codec:"supersededBy,omitempty" json:"supersededBy,omitempty"`
+	Supersedes   []ConversationMetadata  `codec:"supersedes" json:"supersedes"`
+	SupersededBy []ConversationMetadata  `codec:"supersededBy" json:"supersededBy"`
 	MaxMsgs      []MessageBoxed          `codec:"maxMsgs" json:"maxMsgs"`
 }
 

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -47,6 +47,11 @@ type UnreadUpdate struct {
 	UnreadMessages int            `codec:"UnreadMessages" json:"UnreadMessages"`
 }
 
+type TLFFinalizeUpdate struct {
+	FinalizeInfo ConversationFinalizeInfo `codec:"finalizeInfo" json:"finalizeInfo"`
+	ConvIDs      []ConversationID         `codec:"convIDs" json:"convIDs"`
+}
+
 type GregorInterface interface {
 }
 

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -122,8 +122,8 @@ protocol common {
   record Conversation {
     ConversationMetadata metadata;
     union { null, ConversationReaderInfo } readerInfo; // information about the convo from a user perspective
-    union { null, ConversationMetadata } supersedes; // metadata about the conversation this supersedes from a TLF finalize (if any).
-    union { null, ConversationMetadata } supersededBy; // metadata about the conversation that superseded this conversation from a TLF finalize.
+    array<ConversationMetadata> supersedes; // metadata about the conversations this supersedes from a TLF finalize (if any).
+    array<ConversationMetadata> supersededBy; // metadata about the conversations that superseded this conversation from a TLF finalize.
 
     // maxMsgs is the maximum message for each messageType in the conversation
     array<MessageBoxed> maxMsgs;

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -49,4 +49,9 @@ protocol gregor {
         int UnreadMessages;
     }
 
+    record TLFFinalizeUpdate {
+        ConversationFinalizeInfo finalizeInfo;
+        array<ConversationID> convIDs;
+    }
+
 }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -518,8 +518,8 @@ export type ChatActivityType =
 export type Conversation = {
   metadata: ConversationMetadata,
   readerInfo?: ?ConversationReaderInfo,
-  supersedes?: ?ConversationMetadata,
-  supersededBy?: ?ConversationMetadata,
+  supersedes?: ?Array<ConversationMetadata>,
+  supersededBy?: ?Array<ConversationMetadata>,
   maxMsgs?: ?Array<MessageBoxed>,
 }
 
@@ -1027,6 +1027,11 @@ export type SignatureInfo = {
   v: int,
   s: bytes,
   k: bytes,
+}
+
+export type TLFFinalizeUpdate = {
+  finalizeInfo: ConversationFinalizeInfo,
+  convIDs?: ?Array<ConversationID>,
 }
 
 export type TLFID = bytes

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -319,17 +319,17 @@
           "name": "readerInfo"
         },
         {
-          "type": [
-            null,
-            "ConversationMetadata"
-          ],
+          "type": {
+            "type": "array",
+            "items": "ConversationMetadata"
+          },
           "name": "supersedes"
         },
         {
-          "type": [
-            null,
-            "ConversationMetadata"
-          ],
+          "type": {
+            "type": "array",
+            "items": "ConversationMetadata"
+          },
           "name": "supersededBy"
         },
         {

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -143,6 +143,23 @@
           "lint": "ignore"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "TLFFinalizeUpdate",
+      "fields": [
+        {
+          "type": "ConversationFinalizeInfo",
+          "name": "finalizeInfo"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "ConversationID"
+          },
+          "name": "convIDs"
+        }
+      ]
     }
   ],
   "messages": {},

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -518,8 +518,8 @@ export type ChatActivityType =
 export type Conversation = {
   metadata: ConversationMetadata,
   readerInfo?: ?ConversationReaderInfo,
-  supersedes?: ?ConversationMetadata,
-  supersededBy?: ?ConversationMetadata,
+  supersedes?: ?Array<ConversationMetadata>,
+  supersededBy?: ?Array<ConversationMetadata>,
   maxMsgs?: ?Array<MessageBoxed>,
 }
 
@@ -1027,6 +1027,11 @@ export type SignatureInfo = {
   v: int,
   s: bytes,
   k: bytes,
+}
+
+export type TLFFinalizeUpdate = {
+  finalizeInfo: ConversationFinalizeInfo,
+  convIDs?: ?Array<ConversationID>,
 }
 
 export type TLFID = bytes


### PR DESCRIPTION
This patch adds a new update type for TLF finalize Gregor messages, and changes the supersedes pointers to lists, since "DEV" type conversations can have multiple conversations per TLF.