### PR TITLE
Second attempt at fixing the pendingMessageWasSent reducer mis-merge

### DIFF
--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -156,6 +156,8 @@ function reducer (state: State = initialState, action: Actions) {
     case Constants.pendingMessageWasSent: {
       const {conversationIDKey, message} = action.payload
       const {messageID, outboxID} = message
+      // Entirely replace the placeholder pending message in the store with the
+      // finalized real message that we just received from the server.
       // $FlowIssue
       return state.update('conversationStates', conversationStates => updateConversationMessage(
         conversationStates,

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -154,18 +154,14 @@ function reducer (state: State = initialState, action: Actions) {
         .set('inbox', newInboxStates)
     }
     case Constants.pendingMessageWasSent: {
-      const {conversationIDKey, message, messageState} = action.payload
+      const {conversationIDKey, message} = action.payload
       const {messageID, outboxID} = message
       // $FlowIssue
       return state.update('conversationStates', conversationStates => updateConversationMessage(
         conversationStates,
         conversationIDKey,
         item => !!item.outboxID && item.outboxID === outboxID,
-          (m: Constants.TextMessage) => (({
-            ...m,
-            messageID,
-            messageState,
-          }): Constants.TextMessage)
+          (m: Constants.TextMessage) => message
       )).update('conversationStates', conversationStates => updateConversation(
         conversationStates,
         conversationIDKey,


### PR DESCRIPTION
@keybase/react-hackers 

(The part of my deviceName PR that entirely replaced the pending message in the store with the new server-received message was also lost by this mismerge; with the result that the device name was still showing up blank on messages that you sent.)