### PR TITLE
Go to correct login screen when cancelling signup

### DIFF
--- a/shared/actions/signup.js
+++ b/shared/actions/signup.js
@@ -8,11 +8,12 @@ import type {CheckInviteCode, CheckUsernameEmail, CheckPassphrase, SubmitDeviceN
 import type {TypedAsyncAction, AsyncAction} from '../constants/types/flux'
 import {loginTab} from '../constants/tabs'
 import {isMobile} from '../constants/platform'
-import {navigateTo, navigateAppend} from '../actions/route-tree'
+import {navigateAppend} from '../actions/route-tree'
 import type {NavigateAppend, NavigateTo} from '../constants/route-tree'
 import {CommonDeviceType, signupSignupRpc, signupCheckInvitationCodeRpc, signupCheckUsernameAvailableRpc,
   signupInviteRequestRpc, deviceCheckDeviceNameFormatRpc} from '../constants/types/flow-types'
 import {isValidEmail, isValidName, isValidUsername} from '../util/simple-validators'
+import {navBasedOnLoginState} from './login'
 
 function nextPhase (): TypedAsyncAction<NavigateAppend> {
   return (dispatch, getState) => {
@@ -306,7 +307,7 @@ export function resetSignup (): ResetSignup {
 export function restartSignup (): TypedAsyncAction<RestartSignup | NavigateTo> {
   return dispatch => new Promise((resolve, reject) => {
     dispatch({type: Constants.restartSignup, payload: {}})
-    dispatch(navigateTo([loginTab]))
+    dispatch(navBasedOnLoginState())
     resolve()
   })
 }


### PR DESCRIPTION
This appears to be the root cause of a bunch of routing weirdness around signup. If you clicked back during the signup flow, you'd get taken to the intro screen instead of the login account picker. Interacting with the intro screen was confusing because it is only appropriate in the context of an unregistered user or a user who just revoked their device key.

Using `navBasedOnLoginState` does the right thing based on your current state.

With this fixed, the login screen flows no longer have weird cyclic transitions between the intro screen and login screens. There were two other cases raised in the original ticket which we're still discussing, but I suspect they are caused by separate issues. I'll open additional tickets if necessary once we've gotten to the bottom of them.

:eyeglasses: @keybase/react-hackers 