### PR TITLE
UGGGG stub out BGidentifier

### DIFF
--- a/go/service/main.go
+++ b/go/service/main.go
@@ -391,6 +391,10 @@ func (d *Service) tryGregordConnect() error {
 }
 
 func (d *Service) runBackgroundIdentifierWithUID(u keybase1.UID) {
+	if true {
+		return
+	}
+
 	newBgi, err := StartOrReuseBackgroundIdentifier(d.backgroundIdentifier, d.G(), u)
 	if err != nil {
 		d.G().Log.Warning("Problem running new background identifier: %s", err)


### PR DESCRIPTION
:(

Works fine locally but reliably deadlocks on CI. I have no idea how to debug it, nor why this would be happening