### PR TITLE
Fix paperkey crash on login

### DIFF
--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -547,7 +547,7 @@ function makeKex2IncomingMap (dispatch, getState, onBack: SimpleCB, onProvisione
       dispatch(navigateAppend([{
         selected: 'success',
         props: {
-          paperKey: new HiddenString(phrase),
+          paperkey: new HiddenString(phrase),
           waiting: false,
           onFinish: () => { response.result() },
           onBack: () => onBack(response),

--- a/shared/login/signup/success/index.js
+++ b/shared/login/signup/success/index.js
@@ -4,14 +4,16 @@ import {connect} from 'react-redux'
 import {sawPaperKey} from '../../../actions/signup'
 import {navigateUp} from '../../../actions/route-tree'
 
-// $FlowIssue
+type OwnProps = any
+
 export default connect(
-  state => ({
+  (state: any, {routeProps}: OwnProps) => ({
     paperkey: state.signup.paperkey,
     waiting: state.signup.waiting,
+    ...routeProps,
   }),
-  dispatch => ({
-    onFinish: () => { dispatch(sawPaperKey()) },
-    onBack: () => { dispatch(navigateUp()) },
+  (dispatch, {routeProps}: OwnProps) => ({
+    onFinish: routeProps.onFinish ? routeProps.onFinish : () => { dispatch(sawPaperKey()) },
+    onBack: routeProps.onBack ? routeProps.onBack : () => { dispatch(navigateUp()) },
   })
 )(RenderSuccess)

--- a/shared/login/signup/success/index.js
+++ b/shared/login/signup/success/index.js
@@ -4,6 +4,12 @@ import {connect} from 'react-redux'
 import {sawPaperKey} from '../../../actions/signup'
 import {navigateUp} from '../../../actions/route-tree'
 
+// This component's a bit special.
+//
+// It's using `state.signup` values when called from the signup path, and
+// routeTree state generated from RPC action payloads when called from either
+// the provisioning/login path or the "Devices->Add new paper key" path.
+
 type OwnProps = any
 
 export default connect(


### PR DESCRIPTION
@keybase/react-hackers 

In both the login (KEX) flow for provisioning and the signup (rpc) path, we end up at the `shared/login/signup/success` component.  But it needs to use state from the store in the signup path (this was working), whereas in the login path it uses routeTree state received from a KEX action payload (this wasn't hooked up at all).

The result was that users saw an error on their initial login with the app trying to call `this.props.paperkey.stringValue()` on a prop that was `null` because the routeProps were being ignored.