### PR TITLE
fix main window not closing

### DIFF
--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -79,8 +79,6 @@ function setupApp (store) {
   })
 
   const currentWindow = electron.remote.getCurrentWindow()
-  // This fixes reload problems with stale listeners
-  currentWindow.removeAllListeners()
   currentWindow.on('focus', () => { store.dispatch(changedFocus(true)) })
   currentWindow.on('blur', () => { store.dispatch(changedFocus(false)) })
 


### PR DESCRIPTION
@keybase/react-hackers this removes the listenrs the main window makes which breaks the custom closing stuff