### PR TITLE
write successul ID2 runs to level db, to speed up cold starts

### DIFF
--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -417,6 +417,9 @@ func (e *Identify2WithUID) maybeCacheResult() {
 		v := e.toUserPlusKeys()
 		e.getCache().Insert(&v)
 		e.G().Log.Debug("| insert %+v", v)
+		if err := e.storeSlowCacheToDB(); err != nil {
+			e.G().Log.Debug("| Error in storing slow cache to db: %s", err)
+		}
 	}
 	e.G().Log.Debug("- maybeCacheResult")
 }
@@ -766,17 +769,64 @@ func (e *Identify2WithUID) checkFastCacheHit() bool {
 	return true
 }
 
-func (e *Identify2WithUID) checkSlowCacheHit() bool {
+func (e *Identify2WithUID) dbKey(them keybase1.UID) libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBIdentify,
+		Key: fmt.Sprintf("%s:%s", e.me.GetUID(), them),
+	}
+}
+
+func (e *Identify2WithUID) loadSlowCacheFromDB() (ret *keybase1.UserPlusKeys) {
+	defer e.G().TraceOK("Identify2WithUID#loadSlowCacheFromDB", func() bool { return ret != nil })()
+	var ktm keybase1.Time
+	key := e.dbKey(e.them.GetUID())
+	found, err := e.G().LocalDb.GetInto(&ktm, key)
+	if err != nil {
+		e.G().Log.Debug("| Error loading key %s from cache: %s", key, err)
+		return nil
+	}
+	if !found {
+		e.G().Log.Debug("| Key wasn't found: %s", key)
+		return nil
+	}
+	tm := ktm.Time()
+	if time.Since(tm) > libkb.Identify2CacheLongTimeout {
+		e.G().Log.Debug("| Object timed out %s ago", time.Now().Sub(tm))
+		return nil
+	}
+	tmp := e.them.ExportToUserPlusKeys(ktm)
+	ret = &tmp
+	return ret
+}
+
+func (e *Identify2WithUID) storeSlowCacheToDB() (err error) {
+	defer e.G().Trace("Identify2WithUID#storeSlowCacheToDB", func() error { return err })()
+	key := e.dbKey(e.them.GetUID())
+	now := keybase1.ToTime(time.Now())
+	err = e.G().LocalDb.PutObj(key, nil, now)
+	return err
+}
+
+func (e *Identify2WithUID) checkSlowCacheHit() (ret bool) {
+	prfx := fmt.Sprintf("Identify2WithUID#checkSlowCacheHit(%s)", e.them.GetUID())
+	defer e.G().TraceOK(prfx, func() bool { return ret })()
+
 	if e.getCache() == nil {
 		return false
 	}
 
 	fn := func(u keybase1.UserPlusKeys) keybase1.Time { return u.Uvv.LastIdentifiedAt }
 	u, _ := e.getCache().Get(e.them.GetUID(), fn, libkb.Identify2CacheLongTimeout)
+
 	if u == nil {
+		u = e.loadSlowCacheFromDB()
+	}
+	if u == nil {
+		e.G().Log.Debug("%s: identify missed cache", prfx)
 		return false
 	}
 	if !e.them.IsCachedIdentifyFresh(u) {
+		e.G().Log.Debug("%s: cached identify was stale", prfx)
 		return false
 	}
 	e.cachedRes = u

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -799,6 +799,8 @@ func (e *Identify2WithUID) loadSlowCacheFromDB() (ret *keybase1.UserPlusKeys) {
 	return ret
 }
 
+// Store (meUID, themUID) -> SuccessfulIDTime as we cache users to the slow cache.
+// Thus, after a cold boot, we don't start up with a cold identify cache.
 func (e *Identify2WithUID) storeSlowCacheToDB() (err error) {
 	defer e.G().Trace("Identify2WithUID#storeSlowCacheToDB", func() error { return err })()
 	key := e.dbKey(e.them.GetUID())

--- a/go/libkb/cached_user_loader.go
+++ b/go/libkb/cached_user_loader.go
@@ -140,6 +140,13 @@ func (u *CachedUserLoader) putUPKToCache(obj *keybase1.UserPlusAllKeys) error {
 	return err
 }
 
+func (u *CachedUserLoader) PutUserToCache(user *User) error {
+	upak := user.ExportToUserPlusAllKeys(keybase1.Time(0))
+	upak.Base.Uvv.CachedAt = keybase1.ToTime(u.G().Clock().Now())
+	err := u.putUPKToCache(&upak)
+	return err
+}
+
 // loadWithInfo loads a user by UID from the CachedUserLoader object. The 'info'
 // object contains information about how the request was handled, but otherwise,
 // this method behaves like (and implements) the public CachedUserLoader#Load

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -189,6 +189,7 @@ const (
 	DBChatBlocks              = 0xf7
 	DBChatOutbox              = 0xf8
 	DBChatInbox               = 0xf9
+	DBIdentify                = 0xfa
 )
 
 const (

--- a/go/libkb/full_self_cacher.go
+++ b/go/libkb/full_self_cacher.go
@@ -82,6 +82,9 @@ func (m *FullSelfCacher) WithUser(arg LoadUserArg, f func(u *User) error) (err e
 	} else {
 		m.G().Log.Debug("| FullSelfCacher#WithUser[%s]: cache hit", id)
 		u = m.me
+		if m.G().CachedUserLoader != nil {
+			m.G().CachedUserLoader.PutUserToCache(u)
+		}
 	}
 	return f(u)
 }

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -392,8 +392,17 @@ func Trace(log logger.Logger, msg string, f func() error) func() {
 	return func() { log.Debug("- %s -> %s", msg, ErrToOk(f())) }
 }
 
+func TraceOK(log logger.Logger, msg string, f func() bool) func() {
+	log.Debug("+ %s", msg)
+	return func() { log.Debug("- %s -> %v", msg, f()) }
+}
+
 func (g *GlobalContext) Trace(msg string, f func() error) func() {
 	return Trace(g.Log, msg, f)
+}
+
+func (g *GlobalContext) TraceOK(msg string, f func() bool) func() {
+	return TraceOK(g.Log, msg, f)
 }
 
 // SplitByRunes splits string by runes


### PR DESCRIPTION
- the cache just stores (meUID, themUID) -> time of successful ID