### PR TITLE
fix connmgr races

### DIFF
--- a/go/libkb/connmgr.go
+++ b/go/libkb/connmgr.go
@@ -215,14 +215,15 @@ func (c *ConnectionManager) ApplyAll(f ApplyFn) {
 // routing loop running.
 func NewConnectionManager() *ConnectionManager {
 	ret := &ConnectionManager{
-		lookup:             make(map[ConnectionID](*rpcConnection)),
-		addConnectionCh:    make(chan *addConnectionObj),
-		lookupConnectionCh: make(chan *lookupConnectionObj),
-		removeConnectionCh: make(chan ConnectionID),
-		labelConnectionCh:  make(chan labelConnectionObj),
-		applyAllCh:         make(chan ApplyFn),
-		listAllCh:          make(chan chan<- []keybase1.ClientDetails),
-		shutdownCh:         make(chan struct{}),
+		lookup:               make(map[ConnectionID](*rpcConnection)),
+		addConnectionCh:      make(chan *addConnectionObj),
+		lookupConnectionCh:   make(chan *lookupConnectionObj),
+		removeConnectionCh:   make(chan ConnectionID),
+		labelConnectionCh:    make(chan labelConnectionObj),
+		applyAllCh:           make(chan ApplyFn),
+		listAllCh:            make(chan chan<- []keybase1.ClientDetails),
+		shutdownCh:           make(chan struct{}),
+		lookupByClientTypeCh: make(chan *lookupByClientTypeObj),
 	}
 	go ret.run()
 	return ret

--- a/go/service/fs.go
+++ b/go/service/fs.go
@@ -31,7 +31,7 @@ func (h *fsHandler) fsClient() (*keybase1.FsClient, error) {
 		return nil, fmt.Errorf("KBFS client wasn't found")
 	}
 	return &keybase1.FsClient{
-		Cli: rpc.NewClient(*xp, libkb.ErrorUnwrapper{}),
+		Cli: rpc.NewClient(xp, libkb.ErrorUnwrapper{}),
 	}, nil
 }
 

--- a/go/service/notify_fs_request.go
+++ b/go/service/notify_fs_request.go
@@ -22,7 +22,7 @@ func (h *notifyFSRequestHandler) client() (*keybase1.NotifyFSRequestClient, erro
 		return nil, errors.New("KBFS client wasn't found")
 	}
 	return &keybase1.NotifyFSRequestClient{
-		Cli: rpc.NewClient(*xp, libkb.ErrorUnwrapper{}),
+		Cli: rpc.NewClient(xp, libkb.ErrorUnwrapper{}),
 	}, nil
 }
 

--- a/go/service/tlf.go
+++ b/go/service/tlf.go
@@ -31,7 +31,7 @@ func (h *tlfHandler) tlfKeysClient() (*keybase1.TlfKeysClient, error) {
 		return nil, fmt.Errorf("KBFS client wasn't found")
 	}
 	return &keybase1.TlfKeysClient{
-		Cli: rpc.NewClient(*xp, libkb.ErrorUnwrapper{}),
+		Cli: rpc.NewClient(xp, libkb.ErrorUnwrapper{}),
 	}, nil
 }
 


### PR DESCRIPTION
You can only access the lookup from inside the inner loop. public meethods should not penetrate the interior.