### PR TITLE
Run background operations on mobile

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -67,7 +67,9 @@ func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride
 	svc := service.NewService(kbCtx, false)
 	svc.StartLoopbackServer()
 	kbCtx.SetService()
-	kbCtx.SetUIRouter(service.NewUIRouter(kbCtx))
+	uir := service.NewUIRouter(kbCtx)
+	kbCtx.SetUIRouter(uir)
+	svc.RunBackgroundOperations(uir)
 
 	serviceLog := config.GetLogFile()
 	logs := libkb.Logs{

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -220,6 +220,14 @@ func (d *Service) Run() (err error) {
 		return
 	}
 
+	d.RunBackgroundOperations(uir)
+
+	d.G().ExitCode, err = d.ListenLoopWithStopper(l)
+
+	return err
+}
+
+func (d *Service) RunBackgroundOperations(uir *UIRouter) {
 	// These are all background-ish operations that the service performs.
 	// We should revisit these on mobile, or at least, when mobile apps are
 	// backgrounded.
@@ -231,10 +239,6 @@ func (d *Service) Run() (err error) {
 	d.configureRekey(uir)
 	d.tryLogin()
 	d.runBackgroundIdentifier()
-
-	d.G().ExitCode, err = d.ListenLoopWithStopper(l)
-
-	return err
 }
 
 func (d *Service) createMessageDeliverer() {

--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -131,10 +131,12 @@ export function getExtendedStatus (): AsyncAction {
   }
 }
 
-function _registerListeners (): AsyncAction {
+function registerListeners (): AsyncAction {
   return dispatch => {
     dispatch(registerGregorListeners())
-    dispatch(registerReachability())
+    if (!isMobile) {
+      dispatch(registerReachability())
+    }
   }
 }
 
@@ -167,7 +169,7 @@ export function bootstrap (): AsyncAction {
           dispatch(listenForKBFSNotifications())
           dispatch(navBasedOnLoginState())
           dispatch((resetSignup(): Action))
-          dispatch(_registerListeners())
+          dispatch(registerListeners())
         }).catch(error => {
           console.warn('[bootstrap] error bootstrapping: ', error)
           const triesRemaining = getState().config.bootstrapTriesRemaining


### PR DESCRIPTION
Chat crashes on mobile without certain background operations. Allowing mobile to start them up.

I did some energy/cpu/networking profiling and it seems ok. We can adjust some of these background operations later if we find them to be draining but actually doesn't look to bad right now. The profiling tools are pretty mature for this sort of thing so I think it's ok for now to not have a separate policy for mobile.

Disabling reachability on mobile cause we will use react-native APIs for that.

There is still an issue with KBFS auth on mobile being discussed here:
https://keybase.atlassian.net/browse/CORE-4282