### PR TITLE
Fix profile proof popup menus & friends

### DIFF
--- a/shared/common-adapters/box.desktop.js
+++ b/shared/common-adapters/box.desktop.js
@@ -1,7 +1,10 @@
 // @flow
-import React from 'react'
+import React, {Component} from 'react'
 
-const Box = (props: any) => (
-  <div {...props} />
-)
-export default Box
+export default class Box extends Component {
+  render () {
+    return (
+      <div {...this.props} />
+    )
+  }
+}


### PR DESCRIPTION
Since Box changed to a stateless component, refs no longer work on it.

:eyeglasses: @keybase/react-hackers 