### PR TITLE
Back out caching changes to Avatar

### DIFF
--- a/shared/common-adapters/avatar.desktop.js
+++ b/shared/common-adapters/avatar.desktop.js
@@ -61,9 +61,7 @@ class Avatar extends PureComponent<void, Props, State> {
     const borderStyle = this.props.borderColor ? {borderRadius: '50%', borderWidth: 2, borderStyle: 'solid', borderColor: this.props.borderColor} : {borderRadius: '50%'}
 
     const showLoadingColor = (this.props.loadingColor && !this.state.avatarLoaded) || this.props.forceLoading
-    const alreadyGood = _avatarCache.hasOwnProperty(url) && _avatarCache[url]
-    const alreadyBad = _avatarCache.hasOwnProperty(url) && !_avatarCache[url]
-    const showNoAvatar = alreadyBad || (!showLoadingColor && ((!alreadyGood && !this.state.avatarLoaded) || this.state.errored))
+    const showNoAvatar = !showLoadingColor && ((!_avatarCache.hasOwnProperty(url) && !this.state.avatarLoaded) || this.state.errored)
 
     return (
       <div onClick={this.props.onClick} style={{...globalStyles.noSelect, position: 'relative', width, height, ...this.props.style}}>
@@ -77,7 +75,6 @@ class Avatar extends PureComponent<void, Props, State> {
         {showNoAvatar &&
           <img src={noAvatar} style={{...avatarStyle, ...borderStyle, display: 'block'}} />}
         {showLoadingColor && <div style={{...avatarStyle, ...borderStyle, backgroundColor: this.props.loadingColor}} />}
-        {!alreadyBad &&
         <img
           src={url}
           style={{
@@ -90,7 +87,6 @@ class Avatar extends PureComponent<void, Props, State> {
           }}
           onError={this._imgOnError}
           onLoad={this._imgOnLoad} />
-        }
         <div>
           {size > 16 && (this.props.following || this.props.followsYou) &&
             <div>


### PR DESCRIPTION
This isn't calling onAvatarLoaded any more when the avatar is cached,
which can cause the friendships lists on the profile page to not appear.

:eyeglasses: @keybase/react-hackers 