### PR TITLE
Add basic routing for message attachment popup

### DIFF
--- a/shared/chat/conversation/attachment-popup/container.js
+++ b/shared/chat/conversation/attachment-popup/container.js
@@ -1,0 +1,13 @@
+// @flow
+import RenderAttachmentPopup from './'
+import {connect} from 'react-redux'
+import {navigateUp} from '../../../actions/route-tree'
+
+import type {TypedState} from '../../../constants/reducer'
+
+export default connect(
+  (state: TypedState, {routeProps}) => routeProps,
+  (dispatch: Dispatch) => ({
+    onClose: () => dispatch(navigateUp()),
+  })
+)(RenderAttachmentPopup)

--- a/shared/chat/conversation/attachment-popup/index.desktop.js
+++ b/shared/chat/conversation/attachment-popup/index.desktop.js
@@ -1,0 +1,29 @@
+// @flow
+import React from 'react'
+import {Box, Text} from '../../../common-adapters/index'
+import {globalColors, globalStyles} from '../../../styles'
+
+import type {Props} from './'
+
+const AttachmentPopup = ({message, onClose}: Props) => (
+  <Box style={stylesCover} onClick={onClose}>
+    <Box style={globalStyles.flexBoxColumn}>
+      <Text type='BodySemibold' style={{color: globalColors.white}}>Hello, world!</Text>
+      <Text type='Body' style={{color: globalColors.white}}>Path: {message.previewPath}</Text>
+    </Box>
+  </Box>
+)
+
+const stylesCover = {
+  ...globalStyles.flexBoxColumn,
+  background: globalColors.midnightBlue_75,
+  justifyContent: 'center',
+  alignItems: 'center',
+  position: 'absolute',
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+}
+
+export default AttachmentPopup

--- a/shared/chat/conversation/attachment-popup/index.js.flow
+++ b/shared/chat/conversation/attachment-popup/index.js.flow
@@ -1,0 +1,11 @@
+// @flow
+import {Component} from 'react'
+
+import type {AttachmentMessage} from '../../../constants/chat'
+
+export type Props = {
+  message: AttachmentMessage,
+  onClose: () => void,
+}
+
+export default class AttachmentPopup extends Component<void, Props, void> {}

--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -9,10 +9,11 @@ import {connect} from 'react-redux'
 import {deleteMessage, editMessage, loadMoreMessages, newChat, openFolder, postMessage, selectAttachment, loadAttachment} from '../../actions/chat'
 import {nothingSelected} from '../../constants/chat'
 import {onUserClick} from '../../actions/profile'
+import {navigateAppend} from '../../actions/route-tree'
 
 import type {TypedState} from '../../constants/reducer'
 import type {OpenInFileUI} from '../../constants/kbfs'
-import type {ConversationIDKey, Message} from '../../constants/chat'
+import type {ConversationIDKey, Message, AttachmentMessage} from '../../constants/chat'
 import type {Props} from '.'
 
 type OwnProps = {}
@@ -99,6 +100,7 @@ export default connect(
     onAddParticipant: (participants: Array<string>) => dispatch(newChat(participants)),
     onAttach: (selectedConversation, filename, title) => dispatch(selectAttachment(selectedConversation, filename, title)),
     onLoadAttachment: (selectedConversation, messageID, filename) => dispatch(loadAttachment(selectedConversation, messageID, false, downloadFilePath(filename))),
+    onOpenInPopup: (message: AttachmentMessage) => dispatch(navigateAppend([{selected: 'attachment', props: {message}}])),
     onOpenInFileUI: (path: string) => dispatch(({type: 'fs:openInFileUI', payload: {path}}: OpenInFileUI)),
   }),
   (stateProps, dispatchProps, ownProps: OwnProps) => ({

--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -33,6 +33,7 @@ const Conversation = (props: Props) => {
         onLoadAttachment={props.onLoadAttachment}
         onLoadMoreMessages={props.onLoadMoreMessages}
         onOpenInFileUI={props.onOpenInFileUI}
+        onOpenInPopup={props.onOpenInPopup}
         onShowProfile={props.onShowProfile}
         participants={props.participants}
         selectedConversation={props.selectedConversation}

--- a/shared/chat/conversation/index.js.flow
+++ b/shared/chat/conversation/index.js.flow
@@ -3,7 +3,7 @@ import {Component} from 'react'
 import {List, Map} from 'immutable'
 
 import type {Props as BannerMessage} from './banner'
-import type {ConversationIDKey, Message, MessageID, MetaData, ParticipantItem} from '../../constants/chat'
+import type {ConversationIDKey, Message, AttachmentMessage, MessageID, MetaData, ParticipantItem} from '../../constants/chat'
 
 export type Props = {
   bannerMessage: ?BannerMessage,
@@ -22,6 +22,7 @@ export type Props = {
   onLoadMoreMessages: () => void,
   onOpenFolder: () => void,
   onOpenInFileUI: (filename: string) => void,
+  onOpenInPopup: (message: AttachmentMessage) => void,
   onPostMessage: (text: string) => void,
   onShowProfile: (username: string) => void,
   onToggleSidePanel: () => void,

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -201,7 +201,7 @@ class ConversationList extends Component<void, Props, State> {
     // TODO: We need to update the message component selected status
     // when showing popup, which isn't currently working.
 
-    return messageFactory(message, isFirstMessage || !skipMsgHeader, index, key, isFirstNewMessage, style, isScrolling, this._onAction, isSelected, this.props.onLoadAttachment, this.props.onOpenInFileUI)
+    return messageFactory(message, isFirstMessage || !skipMsgHeader, index, key, isFirstNewMessage, style, isScrolling, this._onAction, isSelected, this.props.onLoadAttachment, this.props.onOpenInFileUI, this.props.onOpenInPopup)
   }
 
   _recomputeListDebounced = _.debounce(() => {

--- a/shared/chat/conversation/list.js.flow
+++ b/shared/chat/conversation/list.js.flow
@@ -2,7 +2,7 @@
 import {Component} from 'react'
 import {List, Map} from 'immutable'
 
-import type {ConversationIDKey, Message, MessageID, MetaData, ParticipantItem} from '../../constants/chat'
+import type {ConversationIDKey, AttachmentMessage, Message, MessageID, MetaData, ParticipantItem} from '../../constants/chat'
 
 export type Props = {
   firstNewMessageID: ?MessageID,
@@ -15,6 +15,7 @@ export type Props = {
   onLoadAttachment: (messageID: MessageID, filename: string) => void,
   onLoadMoreMessages: () => void,
   onOpenInFileUI: (filename: string) => void,
+  onOpenInPopup: (message: AttachmentMessage) => void,
   onShowProfile: (username: string) => void,
   participants: List<ParticipantItem>,
   selectedConversation: ?ConversationIDKey,

--- a/shared/chat/conversation/messages/attachment.desktop.js
+++ b/shared/chat/conversation/messages/attachment.desktop.js
@@ -23,9 +23,9 @@ const colorForAuthor = (followState: Constants.FollowState) => {
 }
 
 // TODO abstract this part so it is the same as message text
-class _AttachmentMessage extends PureComponent<void, Props & {onIconClick: (event: any) => void}, void> {
+class _AttachmentMessage extends PureComponent<void, Props & {onIconClick: (event: any) => void, onOpenInPopup: (event: any) => void}, void> {
   render () {
-    const {message, style, includeHeader, isFirstNewMessage, onLoadAttachment, onOpenInFileUI, onIconClick} = this.props
+    const {message, style, includeHeader, isFirstNewMessage, onLoadAttachment, onOpenInFileUI, onOpenInPopup, onIconClick} = this.props
     const {downloadedPath} = message
     return (
       <Box style={{...globalStyles.flexBoxColumn, flex: 1, ...(isFirstNewMessage ? stylesFirstNewMessage : null), ...style}} className='message'>
@@ -46,7 +46,7 @@ class _AttachmentMessage extends PureComponent<void, Props & {onIconClick: (even
                   <Text type='Body' style={{marginTop: globalMargins.xtiny, flex: 1}} onClick={() => onOpenInFileUI(downloadedPath)}>
                     Show downloaded file.
                   </Text>}
-                {!!message.previewPath && message.previewType === 'Image' && <Box style={{marginTop: globalMargins.xtiny, flex: 1}}><img src={message.previewPath} /></Box>}
+                {!!message.previewPath && message.previewType === 'Image' && <Box style={{marginTop: globalMargins.xtiny, flex: 1}} onClick={onOpenInPopup}><img src={message.previewPath} /></Box>}
                 <div className='action-button'>
                   <Icon type='iconfont-ellipsis' style={{marginLeft: globalMargins.tiny, marginRight: globalMargins.tiny}} onClick={onIconClick} />
                 </div>
@@ -62,6 +62,9 @@ class _AttachmentMessage extends PureComponent<void, Props & {onIconClick: (even
 export default withHandlers({
   onIconClick: (props: Props) => event => {
     props.onAction(props.message, event)
+  },
+  onOpenInPopup: (props: Props) => event => {
+    props.onOpenInPopup(props.message, event)
   },
 })(_AttachmentMessage)
 

--- a/shared/chat/conversation/messages/attachment.js.flow
+++ b/shared/chat/conversation/messages/attachment.js.flow
@@ -10,6 +10,7 @@ export type Props = {
   onLoadAttachment: (messageID: MessageID, filename: string) => void,
   onAction: (message: ServerMessage, event: any) => void,
   onOpenInFileUI: (path: string) => void,
+  onOpenInPopup: (message: AttachmentMessage) => void,
   style: Object,
 }
 

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -1,17 +1,17 @@
 // @flow
 import * as ChatConstants from '../../../constants/chat'
-import AttachmentMessage from './attachment'
+import AttachmentMessageRender from './attachment'
 import MessageText from './text'
 import React from 'react'
 import Timestamp from './timestamp'
 import {Box} from '../../../common-adapters'
 import {formatTimeForMessages} from '../../../util/timestamp'
 
-import type {Message, ServerMessage} from '../../../constants/chat'
+import type {Message, AttachmentMessage, ServerMessage} from '../../../constants/chat'
 
 const _onRetry = () => console.log('todo, hookup onRetry')
 
-const factory = (message: Message, includeHeader: boolean, index: number, key: string, isFirstNewMessage: boolean, style: Object, isScrolling: boolean, onAction: (message: ServerMessage, event: any) => void, isSelected: boolean, onLoadAttachment: (messageID: ChatConstants.MessageID, filename: string) => void, onOpenInFileUI: (path: string) => void) => {
+const factory = (message: Message, includeHeader: boolean, index: number, key: string, isFirstNewMessage: boolean, style: Object, isScrolling: boolean, onAction: (message: ServerMessage, event: any) => void, isSelected: boolean, onLoadAttachment: (messageID: ChatConstants.MessageID, filename: string) => void, onOpenInFileUI: (path: string) => void, onOpenInPopup: (message: AttachmentMessage) => void) => {
   if (!message) {
     return <Box key={key} style={style} />
   }
@@ -36,7 +36,7 @@ const factory = (message: Message, includeHeader: boolean, index: number, key: s
         style={style}
         />
     case 'Attachment':
-      return <AttachmentMessage
+      return <AttachmentMessageRender
         key={key}
         style={style}
         message={message}
@@ -45,6 +45,7 @@ const factory = (message: Message, includeHeader: boolean, index: number, key: s
         isFirstNewMessage={isFirstNewMessage}
         onLoadAttachment={onLoadAttachment}
         onOpenInFileUI={onOpenInFileUI}
+        onOpenInPopup={onOpenInPopup}
         messageID={message.messageID}
         onAction={onAction}
         />

--- a/shared/chat/routes.js
+++ b/shared/chat/routes.js
@@ -2,11 +2,18 @@
 import {RouteDefNode} from '../route-tree'
 import ConversationList from './conversations-list/container'
 import Conversation from './conversation/container'
+import AttachmentPopup from './conversation/attachment-popup/container'
 import {nothingSelected} from '../constants/chat'
 
 const conversationRoute = new RouteDefNode({
   component: Conversation,
-  children: {},
+  children: {
+    attachment: {
+      component: AttachmentPopup,
+      tags: {layerOnTop: true},
+      children: {},
+    },
+  },
 })
 
 const routeTree = new RouteDefNode({

--- a/shared/nav.desktop.js
+++ b/shared/nav.desktop.js
@@ -12,6 +12,11 @@ import type {Tab} from './constants/tabs'
 import type {Props} from './nav'
 
 function Nav (props: Props) {
+  const visibleScreen = props.routeStack.findLast(r => !r.tags.layerOnTop)
+  if (!visibleScreen) {
+    throw new Error('no route component to render without layerOnTop tag')
+  }
+  const layerScreens = props.routeStack.filter(r => r.tags.layerOnTop)
   return (
     <Box style={stylesTabsContainer}>
       {props.routeSelected !== loginTab &&
@@ -26,7 +31,8 @@ function Nav (props: Props) {
         />
       }
       <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
-        {props.children}
+        {visibleScreen.component}
+        {layerScreens.map(r => r.leafComponent)}
       </Box>
       <div id='popupContainer' />
       <GlobalError />

--- a/shared/route-tree/index.js
+++ b/shared/route-tree/index.js
@@ -7,11 +7,13 @@ import type {ConnectedComponent as TypedConnectedComponent} from '../util/typed-
 
 type LeafTagsParams = {
   modal: boolean,
+  layerOnTop: boolean,
   underStatusBar: boolean,
 }
 
 export const LeafTags: (spec?: LeafTagsParams) => LeafTagsParams & I.Record<LeafTagsParams> = I.Record({
   modal: false,
+  layerOnTop: false,
   underStatusBar: false,
 })
 

--- a/shared/route-tree/render-route.js
+++ b/shared/route-tree/render-route.js
@@ -71,12 +71,14 @@ type _RenderRouteResultParams = {
   path: I.List<string>,
   tags: LeafTags,
   component: React$Element<any>,
+  leafComponent: React$Element<any>,
 }
 
 const _RenderRouteResult: (spec?: _RenderRouteResultParams) => _RenderRouteResultParams & I.Record<_RenderRouteResultParams> = I.Record({
   path: I.List(),
   tags: LeafTags(),
   component: null,
+  leafComponent: null,
 })
 
 export type RouteRenderStack = I.Stack<_RenderRouteResult>
@@ -113,6 +115,7 @@ function _RenderRoute ({routeDef, routeState, setRouteState, path}: _RenderRoute
       stack = stack.map(r => (
         r.update('component', child => (
           <RenderRouteNode
+            key={pathToString(path)}
             isContainer={true}
             routeDef={routeDef}
             routeState={routeState}
@@ -130,17 +133,21 @@ function _RenderRoute ({routeDef, routeState, setRouteState, path}: _RenderRoute
 
   if (routeDef.component) {
     // If this path has a leaf component to render, add it to the stack.
+    const routeComponent = (
+      <RenderRouteNode
+        key={pathToString(path)}
+        isContainer={false}
+        routeDef={routeDef}
+        routeState={routeState}
+        path={path}
+        setRouteState={setRouteState}
+      />
+    )
+
     const result = new _RenderRouteResult({
       path,
-      component: (
-        <RenderRouteNode
-          isContainer={false}
-          routeDef={routeDef}
-          routeState={routeState}
-          path={path}
-          setRouteState={setRouteState}
-        />
-      ),
+      component: routeComponent,
+      leafComponent: routeComponent,
       tags: routeDef.tags,
     })
     stack = stack.unshift(result)

--- a/shared/styles/colors.js
+++ b/shared/styles/colors.js
@@ -26,6 +26,7 @@ export default {
   lightGrey2: '#e6e6e6',
   lightGrey: '#f0f0f0',
   midnightBlue: '#082640',
+  midnightBlue_75: 'rgba(8, 38, 64, 0.75)',
   orange: '#ff6f21',
   red: '#ff4d61',
   red_75: 'rgba(255,0,0,0.75)',


### PR DESCRIPTION
Part 2 of message attachment via routes. This is some basic scaffolding to render a route on top of the other routes (via `layerOnTop` tag). The route is passed the message data object via `routeProps` and can render its content using the data. Clicking on the semi-transparent cover `Box` triggers `navigateUp` which closes the popup.

:eyeglasses: @keybase/react-hackers 