### PR TITLE
Fix pinentry being blank

### DIFF
--- a/desktop/.babelrc
+++ b/desktop/.babelrc
@@ -1,7 +1,6 @@
 {
   "presets": ["babel-preset-es2015", "babel-preset-stage-1", "babel-preset-react"],
   "plugins": [
-    "transform-flow-strip-types",
     "babel-plugin-transform-runtime",
     "react-hot-loader/babel",
     ["babel-plugin-transform-builtin-extend", {

--- a/desktop/.babelrc
+++ b/desktop/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["babel-preset-es2015", "babel-preset-stage-1", "babel-preset-react"],
   "plugins": [
+    "transform-flow-strip-types",
     "babel-plugin-transform-runtime",
     "react-hot-loader/babel",
     ["babel-plugin-transform-builtin-extend", {

--- a/desktop/app/store-helper.js
+++ b/desktop/app/store-helper.js
@@ -6,9 +6,9 @@ import {selector as remotePurgeMessageSelector} from '../shared/pgp/container.de
 import {selector as trackerSelector} from '../shared/tracker'
 import {selector as unlockFoldersSelector} from '../shared/unlock-folders'
 
-// import type {Components} from '../renderer/remote-component'
+import type {Components} from '../renderer/remote-component'
 
-const componentToSelector :{[key: string]: Function} = {
+const componentToSelector :{[key: Components]: Function} = {
   'tracker': trackerSelector,
   'menubar': menubarSelector,
   'unlockFolders': unlockFoldersSelector,

--- a/desktop/app/store-helper.js
+++ b/desktop/app/store-helper.js
@@ -1,29 +1,39 @@
 // @flow
 import {ipcMain} from 'electron'
-import {selector as trackerSelector} from '../shared/tracker'
 import {selector as menubarSelector} from '../shared/menubar'
+import {selector as pineentrySelector} from '../shared/pinentry'
+import {selector as remotePurgeMessageSelector} from '../shared/pgp/container.desktop'
+import {selector as trackerSelector} from '../shared/tracker'
 import {selector as unlockFoldersSelector} from '../shared/unlock-folders'
+
+// import type {Components} from '../renderer/remote-component'
+
+const componentToSelector :{[key: string]: Function} = {
+  'tracker': trackerSelector,
+  'menubar': menubarSelector,
+  'unlockFolders': unlockFoldersSelector,
+  'pinentry': pineentrySelector,
+  'purgeMessage': remotePurgeMessageSelector,
+}
 
 export default function (mainWindow: any) {
   const subscribeStoreSubscribers = []
   let store = {}
 
   ipcMain.on('subscribeStore', (event, component, selectorParams) => {
-    let selector = {
-      'tracker': trackerSelector,
-      'menubar': menubarSelector,
-      'unlockFolders': unlockFoldersSelector,
-    }[component]
+    let selector = componentToSelector[component]
 
     if (selector) {
       selector = selector(selectorParams)
+    } else {
+      throw new Error(`Missing remote selector!: ${component}`)
     }
 
     const sender = event.sender
     subscribeStoreSubscribers.push({sender, selector})
 
     try {
-      const newStore = selector ? selector(store) : store
+      const newStore = selector(store)
       if (newStore) {
         sender.send('stateChange', newStore)
       }
@@ -36,7 +46,7 @@ export default function (mainWindow: any) {
     let dead = []
     subscribeStoreSubscribers.forEach((sub, idx) => {
       try {
-        const newStore = sub.selector ? sub.selector(store) : store
+        const newStore = sub.selector(store)
         if (newStore) {
           sub.sender.send('stateChange', newStore)
         }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/main.bundle.js",
   "scripts": {
     "_helper": "yarn run _node -- npm-helper.js",
-    "_node": "babel-node --presets es2015,stage-2 --plugins transform-flow-strip-types",
+    "_node": "babel-node",
     "apply-new-fonts": "yarn run _helper apply-new-fonts",
     "build-dev": "yarn run _helper build-dev",
     "build-main-thread": "yarn run _helper build-main-thread",

--- a/desktop/renderer/index.js
+++ b/desktop/renderer/index.js
@@ -25,6 +25,8 @@ import {merge, throttle} from 'lodash'
 import {reduxDevToolsEnable, devStoreChangingFunctions, resetEngineOnHMR} from '../shared/local-debug.desktop'
 import {selector as menubarSelector} from '../shared/menubar'
 import {selector as unlockFoldersSelector} from '../shared/unlock-folders'
+import {selector as pineentrySelector} from '../shared/pinentry'
+import {selector as remotePurgeMessageSelector} from '../shared/pgp/container.desktop'
 import {setRouteDef} from '../shared/actions/route-tree'
 import {setupContextMenu} from '../app/menu-helper'
 // $FlowIssue
@@ -84,12 +86,16 @@ function setupApp (store) {
 
   const _menubarSelector = menubarSelector()
   const _unlockFoldersSelector = unlockFoldersSelector()
+  const _pineentrySelector = pineentrySelector()
+  const _remotePurgeMessageSelector = remotePurgeMessageSelector()
 
   const subsetsRemotesCareAbout = (store) => {
     return {
       tracker: store.tracker,
       menu: _menubarSelector(store),
       unlockFolder: _unlockFoldersSelector(store),
+      pinentry: _pineentrySelector(store),
+      pgpPurgeMessage: _remotePurgeMessageSelector(store),
     }
   }
 
@@ -110,7 +116,6 @@ function setupApp (store) {
   hello(process.pid, 'Main Renderer', process.argv, __VERSION__) // eslint-disable-line no-undef
 
   store.dispatch(updateDebugConfig(require('../shared/local-debug-live')))
-
   store.dispatch(bootstrap())
 }
 

--- a/desktop/renderer/launcher.js
+++ b/desktop/renderer/launcher.js
@@ -22,7 +22,7 @@ if (module.hot) {
   module.hot.accept()
 }
 
-const store = new RemoteStore({component: 'menubar'})
+let _store
 
 class RemoteMenubar extends Component {
   constructor () {
@@ -31,7 +31,7 @@ class RemoteMenubar extends Component {
   }
   render () {
     return (
-      <Root store={store}>
+      <Root store={_store}>
         <Menubar />
       </Root>
     )
@@ -41,6 +41,9 @@ class RemoteMenubar extends Component {
 setupContextMenu(remote.getCurrentWindow())
 
 function load () {
+  if (!_store) {
+    _store = new RemoteStore({component: 'menubar'})
+  }
   reactDOM.render(<RemoteMenubar />, document.getElementById('root'))
 }
 

--- a/desktop/renderer/remote-component-loader.js
+++ b/desktop/renderer/remote-component-loader.js
@@ -74,7 +74,9 @@ class RemoteComponentLoader extends Component<void, any, State> {
 
     const title = this.props.title
     hello(process.pid, 'Remote Component: ' + (title || ''), process.argv, __VERSION__) // eslint-disable-line no-undef
+  }
 
+  componentWillMount () {
     const component = this.props.component
     const selectorParams = this.props.selectorParams
     const components = {tracker, pinentry, unlockFolders, purgeMessage}
@@ -85,9 +87,7 @@ class RemoteComponentLoader extends Component<void, any, State> {
 
     this.store = new RemoteStore({component, selectorParams})
     this.ComponentClass = components[component]
-  }
 
-  componentWillMount () {
     const currentWindow = getCurrentWindow()
     setupContextMenu(currentWindow)
 
@@ -143,6 +143,11 @@ class RemoteComponentLoader extends Component<void, any, State> {
   }
 
   componentWillUnmount () {
+    if (this.store) {
+      this.store.cleanup()
+      this.store = null
+    }
+
     try {
       getCurrentWindow().removeAllListeners('hasProps')
     } catch (_) { }

--- a/desktop/renderer/remote-component.desktop.js
+++ b/desktop/renderer/remote-component.desktop.js
@@ -3,22 +3,26 @@ import React, {Component} from 'react'
 import hotPath from '../hot-path'
 import menuHelper from '../app/menu-helper'
 import {injectReactQueryParams} from '../shared/util/dev'
-import {remote, ipcRenderer, screen as electronScreen} from 'electron'
+import electron from 'electron'
 import {resolveRootAsURL} from '../resolve-root'
 import {showDevTools, skipSecondaryDevtools} from '../shared/local-debug.desktop'
 
-const {BrowserWindow} = remote
+const BrowserWindow = electron.BrowserWindow || electron.remote.BrowserWindow
+const ipcRenderer = electron.ipcRenderer
+
 const remoteIdsToComponents = {}
 
 // Remember if we close, it's an error to try to close an already closed window
-ipcRenderer.on('remoteWindowClosed', (event, remoteWindowId) => {
-  if (!remoteIdsToComponents[remoteWindowId]) {
-    return
-  }
+if (ipcRenderer) {
+  ipcRenderer.on('remoteWindowClosed', (event, remoteWindowId) => {
+    if (!remoteIdsToComponents[remoteWindowId]) {
+      return
+    }
 
-  remoteIdsToComponents[remoteWindowId].onClosed()
-  remoteIdsToComponents[remoteWindowId] = null
-})
+    remoteIdsToComponents[remoteWindowId].onClosed()
+    remoteIdsToComponents[remoteWindowId] = null
+  })
+}
 
 class RemoteComponent extends Component {
   closed: ?boolean;
@@ -44,8 +48,8 @@ class RemoteComponent extends Component {
 
     this.remoteWindow = new BrowserWindow(windowsOpts)
 
-    if (this.props.positionBottomRight && electronScreen.getPrimaryDisplay()) {
-      const {width, height} = electronScreen.getPrimaryDisplay().workAreaSize
+    if (this.props.positionBottomRight && electron.screen.getPrimaryDisplay()) {
+      const {width, height} = electron.screen.getPrimaryDisplay().workAreaSize
       this.remoteWindow.setPosition(width - windowsOpts.width - 100, height - windowsOpts.height - 100, false)
     }
 

--- a/desktop/renderer/remote-component.js.flow
+++ b/desktop/renderer/remote-component.js.flow
@@ -1,14 +1,20 @@
 // @flow
-import React, {Component} from 'react'
+import {Component} from 'react'
+
+export type Components = 'tracker'
+| 'menubar'
+| 'unlockFolders'
+| 'pinentry'
+| 'purgeMessage'
 
 export type Props = {
-  component: string,
+  component: Components,
   windowsOpts?: Object,
   title?: string,
   onRemoteClose?: () => void,
   hidden?: boolean,
   selectorParams?: string,
-  ignoreNewProps?: boolean
+  ignoreNewProps?: boolean,
 }
 
 export default class RemoteComponent extends Component<void, Props, void> { }

--- a/desktop/renderer/remote-pinentry.js
+++ b/desktop/renderer/remote-pinentry.js
@@ -27,6 +27,10 @@ class RemotePinentry extends Component<void, Props, void> {
   render () {
     const {pinentryStates} = this.props
 
+    if (!pinentryStates) {
+      return null
+    }
+
     return (
       <div>
         {Object.keys(pinentryStates).filter(sid => !pinentryStates[sid].closed).map(pSessionID => {
@@ -59,4 +63,3 @@ export default connect(
     onSubmit: (sid: number, passphrase: string, features: GUIEntryFeatures) => dispatch(onSubmit(sid, passphrase, features)),
   })
 )(RemotePinentry)
-

--- a/desktop/webpack.config.base.js
+++ b/desktop/webpack.config.base.js
@@ -15,6 +15,12 @@ console.warn('Injecting defines: ', defines)
 module.exports = {
   module: {
     loaders: [{
+      test: /\.flow?$/,
+      loader: 'null',
+    }, {
+      test: /\.native\.js?$/,
+      loader: 'null',
+    }, {
       test: /\.jsx?$/,
       loader: 'babel',
       exclude: /(node_modules|\/dist\/)/,

--- a/shared/pinentry/index.js
+++ b/shared/pinentry/index.js
@@ -5,10 +5,21 @@ import PinentryRender from './index.render'
 
 class Pinentry extends Component {
   render () {
+    if (!this.props.features) {
+      return null
+    }
     return <PinentryRender {...this.props} />
   }
 }
 
 export default connect(
-  (state, ownProps) => state.pinentry.pinentryStates[ownProps.sessionID]
+  (state, ownProps) => state.pinentry.pinentryStates[ownProps.sessionID] || {}
 )(Pinentry)
+
+export function selector (): (store: Object) => ?Object {
+  return store => ({
+    pinentry: {
+      pinentryStates: store.pinentry.pinentryStates || {},
+    },
+  })
+}


### PR DESCRIPTION
This fixes pinentry and also cleans up some code since i'm back in this old code
Pinenentry was broken because we weren't introspecting its selector to know when it needed changes sent to it.
The structure of the remote-components i think is overly complex and adding new ones requires touching a lot of code. I'm hesitant to waste time fixing this up now (and i hope we don't add many more remote windows) but if we do in the future we should likely refactor some of this code to make this easier

- [x] Add selectors and hookup the comparison for the ipc sending for pinentry / remotePurgeMessage
- [x] Add types for remote components. Enforce the existence of selectors 
- [x] Now that we have a babelrc we can remove the params in the package.json scripts
- [x] Add ability for remote-store to cleanup ipc events
- [x] Allow remote-component-desktop to be loaded from main thread or renderer
- [x] Have webpack ignore flow and native files

@keybase/react-hackers 