### PR TITLE
Parameterize LogMaxSize and use a smaller value for mobile

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -54,6 +54,7 @@ func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride
 	config := libkb.AppConfig{
 		HomeDir:                     homeDir,
 		LogFile:                     logFile,
+		LogMaxSize:                  2 * 1024 * 1024, // 2MB
 		RunMode:                     runMode,
 		Debug:                       true,
 		LocalRPCDebug:               "",

--- a/go/engine/bug_3964_repairman_test.go
+++ b/go/engine/bug_3964_repairman_test.go
@@ -66,8 +66,8 @@ func (a *auditLog) CFatalf(ctx context.Context, format string, args ...interface
 func (a *auditLog) Profile(fmts string, args ...interface{}) {
 	a.l.Profile(fmts, args...)
 }
-func (a *auditLog) Configure(style string, debug bool, filename string) {
-	a.l.Configure(style, debug, filename)
+func (a *auditLog) Configure(style string, debug bool, filename string, maxSize int64) {
+	a.l.Configure(style, debug, filename, maxSize)
 }
 func (a *auditLog) RotateLogFile() error {
 	return a.l.RotateLogFile()

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -57,6 +57,7 @@ func (n NullConfiguration) GetAutoFork() (bool, bool)                     { retu
 func (n NullConfiguration) GetRunMode() (RunMode, error)                  { return NoRunMode, nil }
 func (n NullConfiguration) GetNoAutoFork() (bool, bool)                   { return false, false }
 func (n NullConfiguration) GetLogFile() string                            { return "" }
+func (n NullConfiguration) GetLogMaxSize() int64                          { return 0 }
 func (n NullConfiguration) GetScraperTimeout() (time.Duration, bool)      { return 0, false }
 func (n NullConfiguration) GetAPITimeout() (time.Duration, bool)          { return 0, false }
 func (n NullConfiguration) GetTorMode() (TorMode, error)                  { return TorNone, nil }
@@ -923,6 +924,10 @@ func (e *Env) GetLogFile() string {
 	)
 }
 
+func (e *Env) GetLogMaxSize() int64 {
+	return 128 * 1024 * 1024 // 128MB
+}
+
 func (e *Env) GetDefaultLogFile() string {
 	return filepath.Join(e.GetLogDir(), ServiceLogFileName)
 }
@@ -997,6 +1002,7 @@ type AppConfig struct {
 	NullConfiguration
 	HomeDir                     string
 	LogFile                     string
+	LogMaxSize                  int64
 	RunMode                     RunMode
 	Debug                       bool
 	LocalRPCDebug               string
@@ -1006,6 +1012,10 @@ type AppConfig struct {
 
 func (c AppConfig) GetLogFile() string {
 	return c.LogFile
+}
+
+func (c AppConfig) GetLogMaxSize() int64 {
+	return c.LogMaxSize
 }
 
 func (c AppConfig) GetDebug() (bool, bool) {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -231,10 +231,11 @@ func (g *GlobalContext) ConfigureLogging() error {
 	style := g.Env.GetLogFormat()
 	debug := g.Env.GetDebug()
 	logFile := g.Env.GetLogFile()
+	maxSize := g.Env.GetLogMaxSize()
 	if logFile == "" {
-		g.Log.Configure(style, debug, g.Env.GetDefaultLogFile())
+		g.Log.Configure(style, debug, g.Env.GetDefaultLogFile(), maxSize)
 	} else {
-		g.Log.Configure(style, debug, logFile)
+		g.Log.Configure(style, debug, logFile, maxSize)
 		g.Log.RotateLogFile()
 	}
 	g.Output = os.Stdout

--- a/go/logger/logger.go
+++ b/go/logger/logger.go
@@ -53,7 +53,7 @@ type Logger interface {
 	// Configure sets the style, debug level, and filename of the
 	// logger.  Output isn't redirected to the file until
 	// RotateLogFile is called for the first time.
-	Configure(style string, debug bool, filename string)
+	Configure(style string, debug bool, filename string, maxSize int64)
 	// RotateLogFile rotates the log file, if the underlying logger is
 	// writing to a file.
 	RotateLogFile() error

--- a/go/logger/null.go
+++ b/go/logger/null.go
@@ -30,7 +30,7 @@ func (l *Null) CNoticef(ctx context.Context, fmt string, arg ...interface{})   {
 func (l *Null) CWarningf(ctx context.Context, fmt string, arg ...interface{})  {}
 func (l *Null) CErrorf(ctx context.Context, fmt string, arg ...interface{})    {}
 func (l *Null) Error(fmt string, arg ...interface{})                           {}
-func (l *Null) Configure(style string, debug bool, filename string)            {}
+func (l *Null) Configure(style string, debug bool, filename string, maxSize int64) {}
 func (l *Null) RotateLogFile() error                                           { return nil }
 
 func (l *Null) CloneWithAddedDepth(depth int) Logger { return l }

--- a/go/logger/rotatelog.go
+++ b/go/logger/rotatelog.go
@@ -14,10 +14,13 @@ func (log *Standard) RotateLogFile() error {
 	if log.filename == "" {
 		return errors.New("No log filename specified")
 	}
+	if log.maxSize <= 0 {
+		return errors.New("No max log file size specified")
+	}
 	return SetLogFileConfig(&LogFileConfig{
 		Path:         log.filename,
 		MaxAge:       30 * 24 * time.Hour, // 30 days
-		MaxSize:      128 * 1024 * 1024,   // 128mb
+		MaxSize:      log.maxSize,         // 128mb
 		MaxKeepFiles: 3,
 	})
 }

--- a/go/logger/rpc_adapter.go
+++ b/go/logger/rpc_adapter.go
@@ -84,7 +84,7 @@ func (l RPCLoggerAdapter) Profile(format string, args ...interface{}) {
 	l.log.Profile(format, args)
 }
 
-func (l RPCLoggerAdapter) Configure(style string, debug bool, filename string) {
+func (l RPCLoggerAdapter) Configure(style string, debug bool, filename string, maxSize int64) {
 
 }
 

--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -76,6 +76,7 @@ type entry struct {
 type Standard struct {
 	internal       *logging.Logger
 	filename       string
+	maxSize        int64
 	configureMutex sync.Mutex
 	module         string
 
@@ -241,11 +242,12 @@ func (log *Standard) Profile(fmts string, arg ...interface{}) {
 // is enabled and a filename. If a filename is provided here it will
 // be used for logging straight away (this is a new feature).
 // SetLogFileConfig provides a way to set the log file with more control on rotation.
-func (log *Standard) Configure(style string, debug bool, filename string) {
+func (log *Standard) Configure(style string, debug bool, filename string, maxSize int64) {
 	log.configureMutex.Lock()
 	defer log.configureMutex.Unlock()
 
 	log.filename = filename
+	log.maxSize = maxSize
 
 	var logfmt string
 
@@ -339,6 +341,7 @@ func PickFirstError(errors ...error) error {
 func (log *Standard) CloneWithAddedDepth(depth int) Logger {
 	clone := Standard{
 		filename:        log.filename,
+		maxSize:         log.maxSize,
 		module:          log.module,
 		externalHandler: log.externalHandler,
 	}

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -130,7 +130,7 @@ func (log *TestLogger) Profile(fmts string, arg ...interface{}) {
 	log.log.Logf(prefixCaller(log.extraDepth, logging.CRITICAL, fmts), arg...)
 }
 
-func (log *TestLogger) Configure(style string, debug bool, filename string) {
+func (log *TestLogger) Configure(style string, debug bool, filename string, maxSize int64) {
 	// no-op
 }
 


### PR DESCRIPTION
r? @oconnor663 @patrickxb, CC @taruti

Hi core folks, here's an attempt to use different values of LogMaxSize in the desktop and mobile apps.  This value was previously hardcoded inside `go/logger/rotatelog.go`.  128MB * 3 rotated log files doesn't work for mobile!  But we support `keybase log send` on mobile, so we'd like to continue sharing the logging infrastructure, just with different sizes.

I'm offering this PR as a conversation starter for working out the best way to do this.  This PR seems pretty spammy to me (and would involve having to coordinate the same change in libkbfs's use of the logger), maybe there's something easier we can do?

Thanks!

(This isn't ready to merge.)