### PR TITLE
Fix public chat

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -367,6 +367,7 @@ func (s *localizer) localizeConversation(ctx context.Context, uid gregor1.UID,
 
 	conversationLocal.Info = chat1.ConversationInfoLocal{
 		Id: conversationRemote.Metadata.ConversationID,
+		// XXX put conversationRemote visibility here
 	}
 
 	if len(conversationRemote.MaxMsgs) == 0 {

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -91,8 +91,12 @@ func (s *RemoteInboxSource) Read(ctx context.Context, uid gregor1.UID,
 		if rquery != nil && rquery.TlfID != nil {
 			// Verify using signed TlfName to make sure server returned genuine
 			// conversation.
-			signedTlfID, _, _, err := utils.CryptKeysWrapper(ctx, s.getTlfInterface(),
-				convLocal.Info.TlfName, identifyBehavior)
+			var signedTlfID chat1.TLFID
+			if rquery.TlfVisibility != nil && *rquery.TlfVisibility == chat1.TLFVisibility_PUBLIC {
+				signedTlfID, _, _, err = utils.PublicTLFID(ctx, s.getTlfInterface(), convLocal.Info.TlfName, identifyBehavior)
+			} else {
+				signedTlfID, _, _, err = utils.CryptKeysWrapper(ctx, s.getTlfInterface(), convLocal.Info.TlfName, identifyBehavior)
+			}
 			if err != nil {
 				return Inbox{}, ib.RateLimit, err
 			}

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -240,8 +240,6 @@ func (s *HybridInboxSource) Read(ctx context.Context, uid gregor1.UID, query *ch
 			convs := make([]chat1.ConversationLocal, 0, len(convsStorage))
 			for _, cs := range convsStorage {
 				info, err := utils.LookupTLF(ctx, s.remote.getTlfInterface(), cs.Info.TlfName, cs.Info.Visibility, identifyBehavior)
-				//				_, _, failures, err := utils.CryptKeysWrapper(ctx,
-				//					s.remote.getTlfInterface(), cs.Info.TlfName, identifyBehavior)
 				if err != nil {
 					return Inbox{}, nil, err
 				}

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -366,8 +366,8 @@ func (s *localizer) localizeConversation(ctx context.Context, uid gregor1.UID,
 	conversationLocal chat1.ConversationLocal, err error) {
 
 	conversationLocal.Info = chat1.ConversationInfoLocal{
-		Id: conversationRemote.Metadata.ConversationID,
-		// XXX put conversationRemote visibility here
+		Id:         conversationRemote.Metadata.ConversationID,
+		Visibility: conversationRemote.Metadata.Visibility,
 	}
 
 	if len(conversationRemote.MaxMsgs) == 0 {

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -105,7 +105,7 @@ func (s *RemoteInboxSource) Read(ctx context.Context, uid gregor1.UID,
 			// ???
 
 			// Verify using signed TlfName to make sure server returned genuine conversation.
-			info, err := utils.LookupTLF(ctx, s.getTlfInterface(), convLocal.Info.TlfName, rquery.Visibility(), identifyBehavior)
+			info, err := utils.LookupTLF(ctx, s.getTlfInterface(), convLocal.Info.TlfName, convLocal.Info.Visibility, identifyBehavior)
 			if err != nil {
 				return Inbox{}, ib.RateLimit, err
 			}

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -214,7 +214,7 @@ func lookupPrivateTLF(ctx context.Context, tlfcli keybase1.TlfInterface, query k
 func GetInboxQueryLocalToRemote(ctx context.Context,
 	tlfInterface keybase1.TlfInterface, lquery *chat1.GetInboxLocalQuery,
 	identifyBehavior keybase1.TLFIdentifyBehavior) (
-	rquery *chat1.GetInboxQuery, breaks []keybase1.TLFIdentifyFailure, err error) {
+	rquery *chat1.GetInboxQuery, info *TLFInfo, err error) {
 
 	if lquery == nil {
 		return nil, nil, nil
@@ -222,12 +222,12 @@ func GetInboxQueryLocalToRemote(ctx context.Context,
 
 	rquery = &chat1.GetInboxQuery{}
 	if lquery.TlfName != nil && len(*lquery.TlfName) > 0 {
-		info, err := LookupTLF(ctx, tlfInterface, *lquery.TlfName, lquery.Visibility(), identifyBehavior)
+		var err error
+		info, err = LookupTLF(ctx, tlfInterface, *lquery.TlfName, lquery.Visibility(), identifyBehavior)
 		if err != nil {
 			return nil, nil, err
 		}
 		rquery.TlfID = &info.ID
-		breaks = info.IdentifyFailures
 	}
 
 	rquery.After = lquery.After
@@ -241,7 +241,7 @@ func GetInboxQueryLocalToRemote(ctx context.Context,
 	rquery.OneChatTypePerTLF = lquery.OneChatTypePerTLF
 	rquery.Status = lquery.Status
 
-	return rquery, breaks, nil
+	return rquery, info, nil
 }
 
 const (

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -199,14 +199,14 @@ func lookupPublicTLF(ctx context.Context, tlfcli keybase1.TlfInterface, query ke
 }
 
 func lookupPrivateTLF(ctx context.Context, tlfcli keybase1.TlfInterface, query keybase1.TLFQuery) (*TLFInfo, error) {
-	resp, err := tlfcli.CryptKeys(ctx, query)
+	resp, err := tlfcli.CompleteAndCanonicalizePrivateTlfName(ctx, query)
 	if err != nil {
 		return nil, err
 	}
 	info := TLFInfo{
-		ID:               chat1.TLFID(resp.NameIDBreaks.TlfID.ToBytes()),
-		CanonicalName:    string(resp.NameIDBreaks.CanonicalName),
-		IdentifyFailures: resp.NameIDBreaks.Breaks.Breaks,
+		ID:               chat1.TLFID(resp.TlfID.ToBytes()),
+		CanonicalName:    string(resp.CanonicalName),
+		IdentifyFailures: resp.Breaks.Breaks,
 	}
 	return &info, nil
 }

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -141,9 +141,12 @@ func parseConversationResolvingRequest(ctx *cli.Context, tlfName string) (req ch
 		return chatConversationResolvingRequest{}, errors.New("multiple topics are not yet supported")
 	}
 
-	req.Visibility = chat1.TLFVisibility_PRIVATE
-	if ctx.Bool("public") {
+	if ctx.Bool("private") {
+		req.Visibility = chat1.TLFVisibility_PRIVATE
+	} else if ctx.Bool("public") {
 		req.Visibility = chat1.TLFVisibility_PUBLIC
+	} else {
+		req.Visibility = chat1.TLFVisibility_ANY
 	}
 
 	return req, nil

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -140,13 +140,12 @@ func parseConversationResolvingRequest(ctx *cli.Context, tlfName string) (req ch
 	if req.TopicType == chat1.TopicType_CHAT && len(req.TopicName) != 0 {
 		return chatConversationResolvingRequest{}, errors.New("multiple topics are not yet supported")
 	}
-	if ctx.Bool("private") {
-		req.Visibility = chat1.TLFVisibility_PRIVATE
-	} else if ctx.Bool("public") {
+
+	req.Visibility = chat1.TLFVisibility_PRIVATE
+	if ctx.Bool("public") {
 		req.Visibility = chat1.TLFVisibility_PUBLIC
-	} else {
-		req.Visibility = chat1.TLFVisibility_ANY
 	}
+
 	return req, nil
 }
 

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -27,6 +27,10 @@ func (v conversationInfoListView) show(g *libkb.GlobalContext) error {
 	table := &flexibletable.Table{}
 	for i, conv := range v {
 		participants := strings.Split(conv.TlfName, ",")
+		vis := "private"
+		if conv.Visibility == chat1.TLFVisibility_PUBLIC {
+			vis = "public"
+		}
 		table.Insert(flexibletable.Row{
 			flexibletable.Cell{
 				Frame:     [2]string{"[", "]"},
@@ -35,12 +39,16 @@ func (v conversationInfoListView) show(g *libkb.GlobalContext) error {
 			},
 			flexibletable.Cell{
 				Alignment: flexibletable.Left,
+				Content:   flexibletable.SingleCell{Item: vis},
+			},
+			flexibletable.Cell{
+				Alignment: flexibletable.Left,
 				Content:   flexibletable.MultiCell{Sep: ",", Items: participants},
 			},
 		})
 	}
 	if err := table.Render(ui.OutputWriter(), " ", w, []flexibletable.ColumnConstraint{
-		5, flexibletable.ExpandableWrappable,
+		5, 8, flexibletable.ExpandableWrappable,
 	}); err != nil {
 		return fmt.Errorf("rendering conversation info list view error: %v\n", err)
 	}
@@ -52,15 +60,20 @@ type conversationListView []chat1.ConversationLocal
 
 // Make a name that looks like a tlfname but is sorted by activity and missing myUsername.
 func (v conversationListView) convName(g *libkb.GlobalContext, conv chat1.ConversationLocal, myUsername string) string {
-	convName := strings.Join(v.without(g, conv.Info.WriterNames, myUsername), ",")
-	if len(conv.Info.WriterNames) == 1 && conv.Info.WriterNames[0] == myUsername {
-		// The user is the only writer.
-		convName = myUsername
+	var name string
+	if conv.Info.Visibility == chat1.TLFVisibility_PUBLIC {
+		name = "(public) " + strings.Join(conv.Info.WriterNames, ",")
+	} else {
+		name = strings.Join(v.without(g, conv.Info.WriterNames, myUsername), ",")
+		if len(conv.Info.WriterNames) == 1 && conv.Info.WriterNames[0] == myUsername {
+			// The user is the only writer.
+			name = myUsername
+		}
 	}
 	if len(conv.Info.ReaderNames) > 0 {
-		convName += "#" + strings.Join(conv.Info.ReaderNames, ",")
+		name += "#" + strings.Join(conv.Info.ReaderNames, ",")
 	}
-	return convName
+	return name
 }
 
 func (v conversationListView) without(g *libkb.GlobalContext, slice []string, el string) (res []string) {

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -49,20 +49,29 @@ type chatConversationResolver struct {
 // completeAndCanonicalizeTLFName completes tlfName and canonicalizes it if
 // necessary. The new TLF name is stored to req.ctx.canonicalizedTlfName.
 // len(tlfName) must > 0
-// TODO: support public TLFs
-func (r *chatConversationResolver) completeAndCanonicalizeTLFName(
-	ctx context.Context, tlfName string, req chatConversationResolvingRequest) error {
-	cname, err := r.TlfClient.CompleteAndCanonicalizePrivateTlfName(ctx, keybase1.TLFQuery{
+func (r *chatConversationResolver) completeAndCanonicalizeTLFName(ctx context.Context, tlfName string, req chatConversationResolvingRequest) error {
+
+	query := keybase1.TLFQuery{
 		TlfName:          tlfName,
 		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-	})
+	}
+	var cname keybase1.CanonicalTLFNameAndIDWithBreaks
+	var err error
+	var visout string
+	if req.Visibility == chat1.TLFVisibility_PUBLIC {
+		visout = "public"
+		cname, err = r.TlfClient.PublicCanonicalTLFNameAndID(ctx, query)
+	} else {
+		visout = "private"
+		cname, err = r.TlfClient.CompleteAndCanonicalizePrivateTlfName(ctx, query)
+	}
 	if err != nil {
 		return fmt.Errorf("completing TLF name error: %v", err)
 	}
 	if string(cname.CanonicalName) != tlfName {
 		// If we auto-complete TLF name, we should let users know.
 		// TODO: don't spam user here if it's just re-ordering
-		r.G.UI.GetTerminalUI().Printf("Using TLF %s.\n", cname.CanonicalName)
+		r.G.UI.GetTerminalUI().Printf("Using %s conversation %s.\n", visout, cname.CanonicalName)
 	}
 	req.ctx.canonicalizedTlfName = string(cname.CanonicalName)
 
@@ -218,11 +227,13 @@ func (r *chatConversationResolver) Resolve(ctx context.Context, req chatConversa
 			// Either way, we present a visual confirmation so that user knows chich
 			// conversation she's sending into or reading from.
 			if conversations[0].Triple.TopicType == chat1.TopicType_CHAT {
-				r.G.UI.GetTerminalUI().Printf("Found %s conversation: %s\n",
-					conversations[0].Triple.TopicType.String(), conversations[0].TlfName)
+				r.G.UI.GetTerminalUI().Printf("Found %s %s conversation: %s\n",
+					conversations[0].Visibility,
+					conversations[0].Triple.TopicType, conversations[0].TlfName)
 			} else {
-				r.G.UI.GetTerminalUI().Printf("Found %s conversation [%s]: %s\n",
-					conversations[0].Triple.TopicType.String(), conversations[0].TopicName, conversations[0].TlfName)
+				r.G.UI.GetTerminalUI().Printf("Found %s %s conversation [%s]: %s\n",
+					conversations[0].Visibility,
+					conversations[0].Triple.TopicType, conversations[0].TopicName, conversations[0].TlfName)
 			}
 		}
 		return &conversations[0], false, nil

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -151,9 +151,9 @@ func (r *chatConversationResolver) create(ctx context.Context, req chatConversat
 	conversationInfo *chat1.ConversationInfoLocal, err error) {
 	var newConversation string
 	if req.TopicType == chat1.TopicType_CHAT {
-		newConversation = fmt.Sprintf("Creating a new %s conversation", req.TopicType.String())
+		newConversation = fmt.Sprintf("Creating a new %s %s conversation", req.Visibility, req.TopicType)
 	} else {
-		newConversation = fmt.Sprintf("Creating a new %s conversation [%s]", req.TopicType.String(), req.TopicName)
+		newConversation = fmt.Sprintf("Creating a new %s %s conversation [%s]", req.Visibility, req.TopicType, req.TopicName)
 	}
 
 	if len(req.ctx.canonicalizedTlfName) == 0 {

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -154,6 +154,10 @@ func (c *cmdChatSend) ParseArgv(ctx *cli.Context) (err error) {
 	if c.resolvingRequest, err = parseConversationResolvingRequest(ctx, tlfName); err != nil {
 		return err
 	}
+	// TLFVisibility_ANY doesn't make any sense for send, so switch that to PRIVATE:
+	if c.resolvingRequest.Visibility == chat1.TLFVisibility_ANY {
+		c.resolvingRequest.Visibility = chat1.TLFVisibility_PRIVATE
+	}
 
 	nActions := 0
 

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -147,9 +147,15 @@ func (m TlfMock) CryptKeys(ctx context.Context, arg keybase1.TLFQuery) (res keyb
 	return res, nil
 }
 
-// Not used by service tests
-func (m TlfMock) CompleteAndCanonicalizePrivateTlfName(ctx context.Context, arg keybase1.TLFQuery) (res keybase1.CanonicalTLFNameAndIDWithBreaks, err error) {
-	return keybase1.CanonicalTLFNameAndIDWithBreaks{}, errors.New("unimplemented")
+func (m TlfMock) CompleteAndCanonicalizePrivateTlfName(ctx context.Context, arg keybase1.TLFQuery) (keybase1.CanonicalTLFNameAndIDWithBreaks, error) {
+	var res keybase1.CanonicalTLFNameAndIDWithBreaks
+	res.CanonicalName = CanonicalTlfNameForTest(arg.TlfName)
+	var err error
+	res.TlfID, err = m.getTlfID(res.CanonicalName)
+	if err != nil {
+		return keybase1.CanonicalTLFNameAndIDWithBreaks{}, err
+	}
+	return res, nil
 }
 
 func (m TlfMock) PublicCanonicalTLFNameAndID(ctx context.Context, arg keybase1.TLFQuery) (keybase1.CanonicalTLFNameAndIDWithBreaks, error) {
@@ -346,6 +352,7 @@ func (m *ChatRemoteMock) NewConversationRemote2(ctx context.Context, arg chat1.N
 		Metadata: chat1.ConversationMetadata{
 			IdTriple:       arg.IdTriple,
 			ConversationID: res.ConvID,
+			Visibility:     chat1.TLFVisibility_PRIVATE,
 		},
 		MaxMsgs: []chat1.MessageBoxed{first},
 	})

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -196,3 +196,27 @@ func (o OutboxID) Eq(r OutboxID) bool {
 func (t TLFVisibility) Eq(r TLFVisibility) bool {
 	return int(t) == int(r)
 }
+
+// Visibility is a helper to get around a nil pointer for visibility,
+// and to get around TLFVisibility_ANY.  The default is PRIVATE.
+// Note:  not sure why visibility is a pointer, or what TLFVisibility_ANY
+// is for, but don't want to change the API.
+func (q *GetInboxLocalQuery) Visibility() TLFVisibility {
+	visibility := TLFVisibility_PRIVATE
+	if q.TlfVisibility != nil && *q.TlfVisibility == TLFVisibility_PUBLIC {
+		visibility = TLFVisibility_PUBLIC
+	}
+	return visibility
+}
+
+// Visibility is a helper to get around a nil pointer for visibility,
+// and to get around TLFVisibility_ANY.  The default is PRIVATE.
+// Note:  not sure why visibility is a pointer, or what TLFVisibility_ANY
+// is for, but don't want to change the API.
+func (q *GetInboxQuery) Visibility() TLFVisibility {
+	visibility := TLFVisibility_PRIVATE
+	if q.TlfVisibility != nil && *q.TlfVisibility == TLFVisibility_PUBLIC {
+		visibility = TLFVisibility_PUBLIC
+	}
+	return visibility
+}

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -71,7 +71,7 @@ func (h *chatLocalHandler) GetInboxLocal(ctx context.Context, arg chat1.GetInbox
 		return chat1.GetInboxLocalRes{}, fmt.Errorf("cannot query by TopicName without unboxing")
 	}
 
-	rquery, identifyFailures, err := utils.GetInboxQueryLocalToRemote(ctx, h.tlf, arg.Query, arg.IdentifyBehavior)
+	rquery, tlfInfo, err := utils.GetInboxQueryLocalToRemote(ctx, h.tlf, arg.Query, arg.IdentifyBehavior)
 	if err != nil {
 		return chat1.GetInboxLocalRes{}, err
 	}
@@ -86,7 +86,7 @@ func (h *chatLocalHandler) GetInboxLocal(ctx context.Context, arg chat1.GetInbox
 		ConversationsUnverified: ib.Inbox.Full().Conversations,
 		Pagination:              ib.Inbox.Full().Pagination,
 		RateLimits:              utils.AggRateLimitsP([]*chat1.RateLimit{ib.RateLimit}),
-		IdentifyFailures:        identifyFailures,
+		IdentifyFailures:        tlfInfo.IdentifyFailures,
 	}, nil
 }
 

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -82,12 +82,15 @@ func (h *chatLocalHandler) GetInboxLocal(ctx context.Context, arg chat1.GetInbox
 	if err != nil {
 		return chat1.GetInboxLocalRes{}, err
 	}
-	return chat1.GetInboxLocalRes{
+	inbox = chat1.GetInboxLocalRes{
 		ConversationsUnverified: ib.Inbox.Full().Conversations,
 		Pagination:              ib.Inbox.Full().Pagination,
 		RateLimits:              utils.AggRateLimitsP([]*chat1.RateLimit{ib.RateLimit}),
-		IdentifyFailures:        tlfInfo.IdentifyFailures,
-	}, nil
+	}
+	if tlfInfo != nil {
+		inbox.IdentifyFailures = tlfInfo.IdentifyFailures
+	}
+	return inbox, nil
 }
 
 func (h *chatLocalHandler) getChatUI(sessionID int) libkb.ChatUI {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -254,9 +254,21 @@ func (h *chatLocalHandler) NewConversationLocal(ctx context.Context, arg chat1.N
 		return chat1.NewConversationLocalRes{}, err
 	}
 
+	private := true
+	if arg.TlfVisibility == chat1.TLFVisibility_PUBLIC {
+		private = false
+	}
+
 	// we are ignoring the `identifyFailures` here since the `Read` after creating the
 	// conversation will get the identifyFailures for us.
-	tlfID, cname, _, err := utils.CryptKeysWrapper(ctx, h.tlf, arg.TlfName, arg.IdentifyBehavior)
+	var tlfID chat1.TLFID
+	var cname string
+	var err error
+	if private {
+		tlfID, cname, _, err = utils.CryptKeysWrapper(ctx, h.tlf, arg.TlfName, arg.IdentifyBehavior)
+	} else {
+		tlfID, cname, _, err = utils.PublicTLFID(ctx, h.tlf, arg.TlfName, arg.IdentifyBehavior)
+	}
 	if err != nil {
 		return chat1.NewConversationLocalRes{}, err
 	}

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -277,9 +277,11 @@ func TestChatGetInboxAndUnboxLocalTlfName(t *testing.T) {
 	created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
 
 	tlfName := ctc.as(t, users[1]).user().Username + "," + ctc.as(t, users[0]).user().Username // not canonical
+	visibility := chat1.TLFVisibility_PRIVATE
 	gilres, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxAndUnboxLocal(context.Background(), chat1.GetInboxAndUnboxLocalArg{
 		Query: &chat1.GetInboxLocalQuery{
-			TlfName: &tlfName,
+			TlfName:       &tlfName,
+			TlfVisibility: &visibility,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
There were several codepaths where CryptKeysWrapper was used to look up TLF information for public TLFs.  This fixes all of that.  It also doesn't use GetCryptKeys to look up TLF information, so there could be a minor performance gain there.

It also fixes the CLI UX to show public information about the conversations in the list view and conversation selector shown in `keybase chat read`.

r? @mmaxim 

cc @malgorithms who reported the issue.