### PR TITLE
use context to capture identify mode, and use everywhere CORE-4240

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -271,7 +271,7 @@ func (b *Boxer) getSenderInfoLocal(clientHeader chat1.MessageClientHeader) (send
 }
 
 func (b *Boxer) UnboxMessages(ctx context.Context, boxed []chat1.MessageBoxed) (unboxed []chat1.MessageUnboxed, err error) {
-	finder := NewKeyFinder()
+	finder := NewKeyFinder(b.log())
 	for _, msg := range boxed {
 		decmsg, err := b.UnboxMessage(ctx, finder, msg)
 		if err != nil {

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -248,7 +248,7 @@ func TestChatMessageUnboxInvalidBodyHash(t *testing.T) {
 	boxer.hashV1 = origHashFn
 
 	// This should produce a permanent error. So err will be nil, but the decmsg will be state=error.
-	decmsg, err := boxer.UnboxMessage(ctx, NewKeyFinder(), *boxed)
+	decmsg, err := boxer.UnboxMessage(ctx, NewKeyFinder(tc.G.Log), *boxed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -544,7 +544,7 @@ func TestChatMessagePublic(t *testing.T) {
 		Ctime: gregor1.ToTime(time.Now()),
 	}
 
-	decmsg, err := boxer.UnboxMessage(ctx, NewKeyFinder(), *boxed)
+	decmsg, err := boxer.UnboxMessage(ctx, NewKeyFinder(tc.G.Log), *boxed)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -98,7 +98,7 @@ func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.Conver
 	uid gregor1.UID, msg chat1.MessageBoxed) (chat1.MessageUnboxed, error) {
 	var err error
 
-	decmsg, err := s.boxer.UnboxMessage(ctx, NewKeyFinder(), msg)
+	decmsg, err := s.boxer.UnboxMessage(ctx, NewKeyFinder(s.G().Log), msg)
 	if err != nil {
 		return decmsg, err
 	}

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -155,7 +155,7 @@ func (s *NonblockRemoteInboxSource) Read(ctx context.Context, uid gregor1.UID,
 	query *chat1.GetInboxLocalQuery, p *chat1.Pagination) (
 	Inbox, *chat1.RateLimit, error) {
 
-	rquery, err := utils.GetInboxQueryLocalToRemote(ctx, s.getTlfInterface(), query)
+	rquery, _, err := utils.GetInboxQueryLocalToRemote(ctx, s.getTlfInterface(), query)
 	if err != nil {
 		return Inbox{}, nil, err
 	}
@@ -413,11 +413,11 @@ func (s *localizer) localizeConversation(ctx context.Context, uid gregor1.UID,
 
 	info, err := utils.LookupTLF(ctx, s.getTlfInterface(), conversationLocal.Info.TlfName, conversationLocal.Info.Visibility)
 	if err != nil {
-		return chat1.ConversationLocal{}, err
+		errMsg := err.Error()
+		return chat1.ConversationLocal{Error: &errMsg}
 	}
 	// Not sure about the utility of this TlfName assignment, but the previous code did this:
 	conversationLocal.Info.TlfName = info.CanonicalName
-	conversationLocal.IdentifyFailures = info.IdentifyFailures
 
 	conversationLocal.Info.WriterNames, conversationLocal.Info.ReaderNames, err = utils.ReorderParticipants(
 		s.G().GetUserDeviceCache(),

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"fmt"
 
+	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
 )
@@ -17,11 +18,15 @@ type KeyFinder interface {
 
 type KeyFinderImpl struct {
 	keys map[string]keybase1.GetTLFCryptKeysRes
+	log  logger.Logger
 }
 
 // newKeyFinder creates a keyFinder.
-func NewKeyFinder() KeyFinder {
-	return &KeyFinderImpl{keys: make(map[string]keybase1.GetTLFCryptKeysRes)}
+func NewKeyFinder(log logger.Logger) KeyFinder {
+	return &KeyFinderImpl{
+		keys: make(map[string]keybase1.GetTLFCryptKeysRes),
+		log:  log,
+	}
 }
 
 func (k *KeyFinderImpl) cacheKey(tlfName string, tlfPublic bool) string {
@@ -38,8 +43,7 @@ func (k *KeyFinderImpl) Find(ctx context.Context, tlf keybase1.TlfInterface, tlf
 	}
 
 	query := keybase1.TLFQuery{
-		TlfName:          tlfName,
-		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		TlfName: tlfName,
 	}
 
 	var keys keybase1.GetTLFCryptKeysRes

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -28,22 +28,23 @@ type chatListener struct {
 
 var _ libkb.NotifyListener = (*chatListener)(nil)
 
-func (n *chatListener) Logout()                                                      {}
-func (n *chatListener) Login(username string)                                        {}
-func (n *chatListener) ClientOutOfDate(to, uri, msg string)                          {}
-func (n *chatListener) UserChanged(uid keybase1.UID)                                 {}
-func (n *chatListener) TrackingChanged(uid keybase1.UID, username string)            {}
-func (n *chatListener) FSActivity(activity keybase1.FSNotification)                  {}
-func (n *chatListener) FSEditListResponse(arg keybase1.FSEditListArg)                {}
-func (n *chatListener) FSEditListRequest(arg keybase1.FSEditListRequest)             {}
-func (n *chatListener) FSSyncStatusResponse(arg keybase1.FSSyncStatusArg)            {}
-func (n *chatListener) FSSyncEvent(arg keybase1.FSPathSyncStatus)                    {}
-func (n *chatListener) PaperKeyCached(uid keybase1.UID, encKID, sigKID keybase1.KID) {}
-func (n *chatListener) FavoritesChanged(uid keybase1.UID)                            {}
-func (n *chatListener) KeyfamilyChanged(uid keybase1.UID)                            {}
-func (n *chatListener) PGPKeyInSecretStoreFile()                                     {}
-func (n *chatListener) BadgeState(badgeState keybase1.BadgeState)                    {}
-func (n *chatListener) ReachabilityChanged(r keybase1.Reachability)                  {}
+func (n *chatListener) Logout()                                                            {}
+func (n *chatListener) Login(username string)                                              {}
+func (n *chatListener) ClientOutOfDate(to, uri, msg string)                                {}
+func (n *chatListener) UserChanged(uid keybase1.UID)                                       {}
+func (n *chatListener) TrackingChanged(uid keybase1.UID, username string)                  {}
+func (n *chatListener) FSActivity(activity keybase1.FSNotification)                        {}
+func (n *chatListener) FSEditListResponse(arg keybase1.FSEditListArg)                      {}
+func (n *chatListener) FSEditListRequest(arg keybase1.FSEditListRequest)                   {}
+func (n *chatListener) FSSyncStatusResponse(arg keybase1.FSSyncStatusArg)                  {}
+func (n *chatListener) FSSyncEvent(arg keybase1.FSPathSyncStatus)                          {}
+func (n *chatListener) PaperKeyCached(uid keybase1.UID, encKID, sigKID keybase1.KID)       {}
+func (n *chatListener) FavoritesChanged(uid keybase1.UID)                                  {}
+func (n *chatListener) KeyfamilyChanged(uid keybase1.UID)                                  {}
+func (n *chatListener) PGPKeyInSecretStoreFile()                                           {}
+func (n *chatListener) BadgeState(badgeState keybase1.BadgeState)                          {}
+func (n *chatListener) ReachabilityChanged(r keybase1.Reachability)                        {}
+func (n *chatListener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks) {}
 func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActivity) {
 	n.Lock()
 	defer n.Unlock()
@@ -212,7 +213,7 @@ func TestNonblockTimer(t *testing.T) {
 					Prev: msgID,
 				},
 			},
-		})
+		}, keybase1.TLFIdentifyBehavior_CHAT_CLI)
 		t.Logf("generated obid: %s prev: %d", hex.EncodeToString(obid), msgID)
 		require.NoError(t, err)
 		sentRef = append(sentRef, sentRecord{outboxID: &obid})

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -7,6 +7,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 type Outbox struct {
@@ -69,7 +70,8 @@ func (o *Outbox) readDiskOutbox() (diskOutbox, libkb.ChatStorageError) {
 	return obox, nil
 }
 
-func (o *Outbox) PushMessage(convID chat1.ConversationID, msg chat1.MessagePlaintext) (chat1.OutboxID, libkb.ChatStorageError) {
+func (o *Outbox) PushMessage(convID chat1.ConversationID, msg chat1.MessagePlaintext,
+	identifyBehavior keybase1.TLFIdentifyBehavior) (chat1.OutboxID, libkb.ChatStorageError) {
 	o.Lock()
 	defer o.Unlock()
 
@@ -96,10 +98,11 @@ func (o *Outbox) PushMessage(convID chat1.ConversationID, msg chat1.MessagePlain
 	outboxID := chat1.OutboxID(rbs)
 	msg.ClientHeader.OutboxID = &outboxID
 	obox.Records = append(obox.Records, chat1.OutboxRecord{
-		State:    chat1.NewOutboxStateWithSending(0),
-		Msg:      msg,
-		ConvID:   convID,
-		OutboxID: outboxID,
+		State:            chat1.NewOutboxStateWithSending(0),
+		Msg:              msg,
+		ConvID:           convID,
+		OutboxID:         outboxID,
+		IdentifyBehavior: identifyBehavior,
 	})
 
 	// Write out box

--- a/go/client/chat_cli_fetchers.go
+++ b/go/client/chat_cli_fetchers.go
@@ -79,12 +79,13 @@ func (f chatCLIInboxFetcher) fetch(ctx context.Context, g *libkb.GlobalContext) 
 			return nil, err
 		}
 
-		err = chatClient.GetInboxNonblockLocal(ctx, chat1.GetInboxNonblockLocalArg{
+		_, err := chatClient.GetInboxNonblockLocal(ctx, chat1.GetInboxNonblockLocalArg{
 			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 		})
 		if err != nil {
 			return nil, err
 		}
+
 	} else {
 		res, err := chatClient.GetInboxSummaryForCLILocal(ctx, f.query)
 		if err != nil {

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -148,7 +148,7 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 		if msg == nil {
 			// Skip conversations with no visible messages.
 			// This should never happen.
-			g.Log.Error("Skipped conversation with no visible messages: %v", conv.Info.Id)
+			g.Log.Error("Skipped conversation with no visible messages: %s", conv.Info.Id)
 			continue
 		}
 

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -69,6 +69,7 @@ func (c *cmdChatSend) Run() (err error) {
 
 	var args chat1.PostLocalArg
 	args.ConversationID = conversationInfo.Id
+	args.IdentifyBehavior = keybase1.TLFIdentifyBehavior_CHAT_CLI
 
 	var msg chat1.MessagePlaintext
 	// msgV1.ClientHeader.{Sender,SenderDevice} are filled by service
@@ -127,6 +128,7 @@ func (c *cmdChatSend) Run() (err error) {
 		var nbarg chat1.PostLocalNonblockArg
 		nbarg.ConversationID = args.ConversationID
 		nbarg.Msg = args.Msg
+		nbarg.IdentifyBehavior = args.IdentifyBehavior
 		if _, err = chatClient.PostLocalNonblock(ctx, nbarg); err != nil {
 			return err
 		}

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -550,12 +550,13 @@ func (e *Identify2WithUID) runIdentifyUI(ctx *Context) (err error) {
 	e.remotesReceived = e.them.BaseProofSet()
 
 	iui := ctx.IdentifyUI
-	if e.useTracking && e.arg.CanSuppressUI && !e.arg.ForceDisplay {
+	if e.calledFromChatGUI() {
+		e.G().Log.Debug("| using the loopback identify UI")
+		iui = newLoopbackIdentifyUI(e.G(), &e.trackBreaks)
+	} else if e.useTracking && e.arg.CanSuppressUI && !e.arg.ForceDisplay {
 		iui = newBufferedIdentifyUI(e.G(), iui, keybase1.ConfirmResult{
 			IdentityConfirmed: true,
 		})
-	} else if e.calledFromChatGUI() {
-		iui = newLoopbackIdentifyUI(e.G(), &e.trackBreaks)
 	}
 
 	e.G().Log.Debug("| IdentifyUI.Start(%s)", e.them.GetName())

--- a/go/engine/paperkey_submit_test.go
+++ b/go/engine/paperkey_submit_test.go
@@ -99,9 +99,10 @@ func (n *nlistener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActivit
 func (n *nlistener) PaperKeyCached(uid keybase1.UID, encKID, sigKID keybase1.KID) {
 	n.paperEncKIDs = append(n.paperEncKIDs, encKID)
 }
-func (n *nlistener) KeyfamilyChanged(uid keybase1.UID)                 {}
-func (n *nlistener) PGPKeyInSecretStoreFile()                          {}
-func (n *nlistener) FSSyncStatusResponse(arg keybase1.FSSyncStatusArg) {}
-func (n *nlistener) FSSyncEvent(arg keybase1.FSPathSyncStatus)         {}
-func (n *nlistener) BadgeState(badgeState keybase1.BadgeState)         {}
-func (n *nlistener) ReachabilityChanged(r keybase1.Reachability)       {}
+func (n *nlistener) KeyfamilyChanged(uid keybase1.UID)                                  {}
+func (n *nlistener) PGPKeyInSecretStoreFile()                                           {}
+func (n *nlistener) FSSyncStatusResponse(arg keybase1.FSSyncStatusArg)                  {}
+func (n *nlistener) FSSyncEvent(arg keybase1.FSPathSyncStatus)                          {}
+func (n *nlistener) BadgeState(badgeState keybase1.BadgeState)                          {}
+func (n *nlistener) ReachabilityChanged(r keybase1.Reachability)                        {}
+func (n *nlistener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks) {}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -524,7 +524,8 @@ type ConversationSource interface {
 }
 
 type MessageDeliverer interface {
-	Queue(convID chat1.ConversationID, msg chat1.MessagePlaintext) (chat1.OutboxID, error)
+	Queue(convID chat1.ConversationID, msg chat1.MessagePlaintext,
+		identifyBehavior keybase1.TLFIdentifyBehavior) (chat1.OutboxID, error)
 	Start(uid gregor1.UID)
 	Stop()
 	ForceDeliverLoop()

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -502,18 +502,12 @@ func (n *NotifyRouter) HandleChatIdentifyUpdate(ctx context.Context, update keyb
 	if n == nil {
 		return
 	}
-
 	var wg sync.WaitGroup
-
 	n.G().Log.Debug("+ Sending ChatIdentifyUpdate notfication")
-	// For all connections we currently have open...
 	n.cm.ApplyAll(func(id ConnectionID, xp rpc.Transporter) bool {
-		// If the connection wants the `Chat` notification type
 		if n.getNotificationChannels(id).Chat {
 			wg.Add(1)
-			// In the background do...
 			go func() {
-				// A send of a `NewChatActivity` RPC with the user's UID
 				(chat1.NotifyChatClient{
 					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
 				}).ChatIdentifyUpdate(context.Background(), update)

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -41,6 +41,7 @@ type NotifyListener interface {
 	PaperKeyCached(uid keybase1.UID, encKID keybase1.KID, sigKID keybase1.KID)
 	KeyfamilyChanged(uid keybase1.UID)
 	NewChatActivity(uid keybase1.UID, activity chat1.ChatActivity)
+	ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks)
 	PGPKeyInSecretStoreFile()
 	BadgeState(badgeState keybase1.BadgeState)
 	ReachabilityChanged(r keybase1.Reachability)
@@ -495,6 +496,37 @@ func (n *NotifyRouter) HandleNewChatActivity(ctx context.Context, uid keybase1.U
 		n.listener.NewChatActivity(uid, *activity)
 	}
 	n.G().Log.Debug("- Sent NewChatActivity notfication")
+}
+
+func (n *NotifyRouter) HandleChatIdentifyUpdate(ctx context.Context, update keybase1.CanonicalTLFNameAndIDWithBreaks) {
+	if n == nil {
+		return
+	}
+
+	var wg sync.WaitGroup
+
+	n.G().Log.Debug("+ Sending ChatIdentifyUpdate notfication")
+	// For all connections we currently have open...
+	n.cm.ApplyAll(func(id ConnectionID, xp rpc.Transporter) bool {
+		// If the connection wants the `Chat` notification type
+		if n.getNotificationChannels(id).Chat {
+			wg.Add(1)
+			// In the background do...
+			go func() {
+				// A send of a `NewChatActivity` RPC with the user's UID
+				(chat1.NotifyChatClient{
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+				}).ChatIdentifyUpdate(context.Background(), update)
+				wg.Done()
+			}()
+		}
+		return true
+	})
+	wg.Wait()
+	if n.listener != nil {
+		n.listener.ChatIdentifyUpdate(update)
+	}
+	n.G().Log.Debug("- Sent ChatIdentifyUpdate notfication")
 }
 
 // HandlePaperKeyCached is called whenever a paper key is cached

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -749,11 +749,36 @@ func (t TLFID) ToBytes() []byte {
 }
 
 func (b TLFIdentifyBehavior) AlwaysRunIdentify() bool {
-	return b == TLFIdentifyBehavior_CHAT_GUI || b == TLFIdentifyBehavior_CHAT_CLI
+	return b == TLFIdentifyBehavior_CHAT_GUI || b == TLFIdentifyBehavior_CHAT_CLI ||
+		b == TLFIdentifyBehavior_CHAT_GUI_STRICT
 }
 
 func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
 	return b == TLFIdentifyBehavior_CHAT_GUI
+}
+
+func (c CanonicalTLFNameAndIDWithBreaks) Eq(r CanonicalTLFNameAndIDWithBreaks) bool {
+	if c.CanonicalName != r.CanonicalName {
+		return false
+	}
+	if c.TlfID != r.TlfID {
+		return false
+	}
+	if len(c.Breaks.Breaks) != len(r.Breaks.Breaks) {
+		return false
+	}
+
+	m := make(map[string]bool)
+	for _, b := range c.Breaks.Breaks {
+		m[b.User.Username] = true
+	}
+	for _, b := range r.Breaks.Breaks {
+		if !m[b.User.Username] {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (c CanonicalTlfName) String() string {

--- a/go/protocol/keybase1/tlf_keys.go
+++ b/go/protocol/keybase1/tlf_keys.go
@@ -11,21 +11,24 @@ import (
 type TLFIdentifyBehavior int
 
 const (
-	TLFIdentifyBehavior_DEFAULT_KBFS TLFIdentifyBehavior = 0
-	TLFIdentifyBehavior_CHAT_CLI     TLFIdentifyBehavior = 1
-	TLFIdentifyBehavior_CHAT_GUI     TLFIdentifyBehavior = 2
+	TLFIdentifyBehavior_DEFAULT_KBFS    TLFIdentifyBehavior = 0
+	TLFIdentifyBehavior_CHAT_CLI        TLFIdentifyBehavior = 1
+	TLFIdentifyBehavior_CHAT_GUI        TLFIdentifyBehavior = 2
+	TLFIdentifyBehavior_CHAT_GUI_STRICT TLFIdentifyBehavior = 3
 )
 
 var TLFIdentifyBehaviorMap = map[string]TLFIdentifyBehavior{
-	"DEFAULT_KBFS": 0,
-	"CHAT_CLI":     1,
-	"CHAT_GUI":     2,
+	"DEFAULT_KBFS":    0,
+	"CHAT_CLI":        1,
+	"CHAT_GUI":        2,
+	"CHAT_GUI_STRICT": 3,
 }
 
 var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
 	0: "DEFAULT_KBFS",
 	1: "CHAT_CLI",
 	2: "CHAT_GUI",
+	3: "CHAT_GUI_STRICT",
 }
 
 func (e TLFIdentifyBehavior) String() string {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -73,7 +73,7 @@ func (h *chatLocalHandler) GetInboxLocal(ctx context.Context, arg chat1.GetInbox
 
 	var breaks []keybase1.TLFIdentifyFailure
 	ctx = utils.IdentifyModeCtx(ctx, arg.IdentifyBehavior, &breaks)
-	rquery, tlfInfo, err := utils.GetInboxQueryLocalToRemote(ctx, h.tlf, arg.Query)
+	rquery, _, err := utils.GetInboxQueryLocalToRemote(ctx, h.tlf, arg.Query)
 	if err != nil {
 		return chat1.GetInboxLocalRes{}, err
 	}
@@ -84,7 +84,8 @@ func (h *chatLocalHandler) GetInboxLocal(ctx context.Context, arg chat1.GetInbox
 	if err != nil {
 		return chat1.GetInboxLocalRes{}, err
 	}
-	inbox = chat1.GetInboxLocalRes{
+
+	return chat1.GetInboxLocalRes{
 		ConversationsUnverified: ib.Inbox.Full().Conversations,
 		Pagination:              ib.Inbox.Full().Pagination,
 		RateLimits:              utils.AggRateLimitsP([]*chat1.RateLimit{ib.RateLimit}),
@@ -269,7 +270,7 @@ func (h *chatLocalHandler) NewConversationLocal(ctx context.Context, arg chat1.N
 
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = utils.IdentifyModeCtx(ctx, arg.IdentifyBehavior, &identBreaks)
-	info, err := utils.LookupTLF(ctx, h.tlf, arg.TlfName, arg.TlfVisibility, arg.IdentifyBehavior)
+	info, err := utils.LookupTLF(ctx, h.tlf, arg.TlfName, arg.TlfVisibility)
 	if err != nil {
 		return chat1.NewConversationLocalRes{}, err
 	}

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -234,7 +234,7 @@ func TestGetInboxNonblock(t *testing.T) {
 		convs[mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[i+1]).user().Username).Id.String()] = true
 	}
 
-	err := ctc.as(t, users[0]).chatLocalHandler().GetInboxNonblockLocal(context.TODO(),
+	_, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxNonblockLocal(context.TODO(),
 		chat1.GetInboxNonblockLocalArg{
 			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 		},
@@ -708,7 +708,7 @@ func TestGetOutbox(t *testing.T) {
 				Prev: 10,
 			},
 		},
-	})
+	}, keybase1.TLFIdentifyBehavior_CHAT_CLI)
 	require.NoError(t, err)
 
 	thread, err := h.GetThreadLocal(context.Background(), chat1.GetThreadLocalArg{

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keybase/client/go/chat"
 	cstorage "github.com/keybase/client/go/chat/storage"
 	istorage "github.com/keybase/client/go/chat/storage"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/gregor"
 	grclient "github.com/keybase/client/go/gregor/client"
@@ -925,6 +926,8 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 
 		uid := m.UID().Bytes()
 
+		var identBreaks []keybase1.TLFIdentifyFailure
+		ctx = utils.IdentifyModeCtx(ctx, keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks)
 		decmsg, err := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
 		if err != nil {
 			g.G().Log.Error("push handler: chat activity: unable to storage message: %s", err.Error())
@@ -1015,9 +1018,13 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 		inboxSource := chat.NewRemoteInboxSource(g.G(), boxer,
 			func() chat1.RemoteInterface { return chat1.RemoteClient{Cli: g.cli} },
 			func() keybase1.TlfInterface { return tlf })
-		if inbox, _, err = inboxSource.Read(context.Background(), uid, &chat1.GetInboxLocalQuery{
+
+		var identBreaks []keybase1.TLFIdentifyFailure
+		ctx = utils.IdentifyModeCtx(context.Background(), keybase1.TLFIdentifyBehavior_CHAT_GUI,
+			&identBreaks)
+		if inbox, _, err = inboxSource.Read(ctx, uid, &chat1.GetInboxLocalQuery{
 			ConvID: &nm.ConvID,
-		}, nil, keybase1.TLFIdentifyBehavior_CHAT_GUI); err != nil {
+		}, nil); err != nil {
 			g.G().Log.Error("push handler: chat activity: unable to read conversation: %s", err.Error())
 			return err
 		}

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -95,12 +95,13 @@ func (n *nlistener) PaperKeyCached(uid keybase1.UID, encKID, sigKID keybase1.KID
 func (n *nlistener) FavoritesChanged(uid keybase1.UID) {
 	n.favoritesChanged = append(n.favoritesChanged, uid)
 }
-func (n *nlistener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActivity) {}
-func (n *nlistener) KeyfamilyChanged(uid keybase1.UID)                             {}
-func (n *nlistener) PGPKeyInSecretStoreFile()                                      {}
-func (n *nlistener) FSSyncStatusResponse(arg keybase1.FSSyncStatusArg)             {}
-func (n *nlistener) FSSyncEvent(arg keybase1.FSPathSyncStatus)                     {}
-func (n *nlistener) ReachabilityChanged(r keybase1.Reachability)                   {}
+func (n *nlistener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActivity)      {}
+func (n *nlistener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks) {}
+func (n *nlistener) KeyfamilyChanged(uid keybase1.UID)                                  {}
+func (n *nlistener) PGPKeyInSecretStoreFile()                                           {}
+func (n *nlistener) FSSyncStatusResponse(arg keybase1.FSSyncStatusArg)                  {}
+func (n *nlistener) FSSyncEvent(arg keybase1.FSPathSyncStatus)                          {}
+func (n *nlistener) ReachabilityChanged(r keybase1.Reachability)                        {}
 
 func (n *nlistener) BadgeState(badgeState keybase1.BadgeState) {
 	select {

--- a/go/service/tlf.go
+++ b/go/service/tlf.go
@@ -8,20 +8,26 @@ import (
 
 	"golang.org/x/net/context"
 
+	"sync"
+
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 
 type tlfHandler struct {
+	sync.RWMutex
 	*BaseHandler
 	libkb.Contextified
+	identCache map[string]keybase1.CanonicalTLFNameAndIDWithBreaks
 }
 
 func newTlfHandler(xp rpc.Transporter, g *libkb.GlobalContext) *tlfHandler {
 	return &tlfHandler{
 		BaseHandler:  NewBaseHandler(xp),
 		Contextified: libkb.NewContextified(g),
+		identCache:   make(map[string]keybase1.CanonicalTLFNameAndIDWithBreaks),
 	}
 }
 
@@ -35,12 +41,62 @@ func (h *tlfHandler) tlfKeysClient() (*keybase1.TlfKeysClient, error) {
 	}, nil
 }
 
+func appendBreaks(l []keybase1.TLFIdentifyFailure, r []keybase1.TLFIdentifyFailure) []keybase1.TLFIdentifyFailure {
+	m := make(map[string]bool)
+	var res []keybase1.TLFIdentifyFailure
+	for _, f := range l {
+		m[f.User.Username] = true
+		res = append(res, f)
+	}
+	for _, f := range r {
+		if !m[f.User.Username] {
+			res = append(res, f)
+		}
+	}
+	return res
+}
+
+func (h *tlfHandler) sendNotifyEvent(update keybase1.CanonicalTLFNameAndIDWithBreaks) {
+	h.RLock()
+	tlfName := update.CanonicalName.String()
+	if stored, ok := h.identCache[tlfName]; ok {
+		// We have the exact update stored, don't send it again
+		if stored.Eq(update) {
+			defer h.RUnlock()
+			h.G().Log.Debug("sendNotifyEvent: hit cache, not sending notify: %s", tlfName)
+			return
+		}
+	}
+	h.RUnlock()
+
+	h.Lock()
+	defer h.Unlock()
+
+	h.G().Log.Debug("sendNotifyEvent: cache miss, sending notify: %s dat: %v", tlfName, update)
+	h.G().NotifyRouter.HandleChatIdentifyUpdate(context.Background(), update)
+	h.identCache[tlfName] = update
+}
+
 func (h *tlfHandler) CryptKeys(ctx context.Context, arg keybase1.TLFQuery) (keybase1.GetTLFCryptKeysRes, error) {
+
 	tlfClient, err := h.tlfKeysClient()
 	if err != nil {
 		return keybase1.GetTLFCryptKeysRes{}, err
 	}
-	return tlfClient.GetTLFCryptKeys(ctx, arg)
+	ident, breaks, ok := utils.IdentifyMode(ctx)
+	if ok {
+		arg.IdentifyBehavior = ident
+	}
+	resp, err := tlfClient.GetTLFCryptKeys(ctx, arg)
+	if err != nil {
+		return resp, err
+	}
+
+	h.sendNotifyEvent(resp.NameIDBreaks)
+	if ok {
+		*breaks = appendBreaks(*breaks, resp.NameIDBreaks.Breaks.Breaks)
+	}
+	return resp, nil
 }
 
 func (h *tlfHandler) PublicCanonicalTLFNameAndID(ctx context.Context, arg keybase1.TLFQuery) (keybase1.CanonicalTLFNameAndIDWithBreaks, error) {
@@ -48,7 +104,20 @@ func (h *tlfHandler) PublicCanonicalTLFNameAndID(ctx context.Context, arg keybas
 	if err != nil {
 		return keybase1.CanonicalTLFNameAndIDWithBreaks{}, err
 	}
-	return tlfClient.GetPublicCanonicalTLFNameAndID(ctx, arg)
+	ident, breaks, ok := utils.IdentifyMode(ctx)
+	if ok {
+		arg.IdentifyBehavior = ident
+	}
+	resp, err := tlfClient.GetPublicCanonicalTLFNameAndID(ctx, arg)
+	if err != nil {
+		return resp, err
+	}
+
+	h.sendNotifyEvent(resp)
+	if ok {
+		*breaks = appendBreaks(*breaks, resp.Breaks.Breaks)
+	}
+	return resp, nil
 }
 
 func (h *tlfHandler) CompleteAndCanonicalizePrivateTlfName(ctx context.Context, arg keybase1.TLFQuery) (res keybase1.CanonicalTLFNameAndIDWithBreaks, err error) {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -72,6 +72,7 @@ protocol local {
     ConversationID convID;
     @lint("ignore")
     MessagePlaintext Msg;
+    keybase1.TLFIdentifyBehavior identifyBehavior;
   }
 
   enum HeaderPlaintextVersion {
@@ -258,9 +259,14 @@ protocol local {
     array<ConversationLocal> conversations;
     union { null, Pagination } pagination;
     array<RateLimit> rateLimits;
+    array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
-  void getInboxNonblockLocal(int sessionID, union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior); 
+  GetInboxNonblockLocalRes getInboxNonblockLocal(int sessionID, union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior); 
+  record GetInboxNonblockLocalRes {
+    array<keybase1.TLFIdentifyFailure> identifyFailures;
+    array<RateLimit> rateLimits;
+  }
 
   PostLocalRes postLocal(ConversationID conversationID, MessagePlaintext msg, keybase1.TLFIdentifyBehavior identifyBehavior);
   record PostLocalRes {
@@ -287,6 +293,7 @@ protocol local {
   record NewConversationLocalRes {
     ConversationLocal conv;
     array<RateLimit> rateLimits;
+    array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
 

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -53,4 +53,8 @@ protocol NotifyChat {
   @notify("")
   @lint("ignore")
   void NewChatActivity(keybase1.UID uid, ChatActivity activity);
+
+  @notify("")
+  @lint("ignore")
+  void ChatIdentifyUpdate(keybase1.CanonicalTLFNameAndIDWithBreaks update);
 }

--- a/protocol/avdl/keybase1/tlf_keys.avdl
+++ b/protocol/avdl/keybase1/tlf_keys.avdl
@@ -9,7 +9,8 @@ protocol tlfKeys {
   enum TLFIdentifyBehavior {
     DEFAULT_KBFS_0,
     CHAT_CLI_1,
-    CHAT_GUI_2
+    CHAT_GUI_2,
+    CHAT_GUI_STRICT_3
   }
 
   @typedef("string")

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -187,15 +187,15 @@ export function localGetInboxLocalRpcPromise (request: $Exact<requestCommon & {c
   return new Promise((resolve, reject) => { localGetInboxLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
-export function localGetInboxNonblockLocalRpc (request: Exact<requestCommon & requestErrorCallback & {param: localGetInboxNonblockLocalRpcParam}>) {
+export function localGetInboxNonblockLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {param: localGetInboxNonblockLocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.getInboxNonblockLocal'})
 }
 
-export function localGetInboxNonblockLocalRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localGetInboxNonblockLocalRpcParam}>): ChannelMap<*> {
+export function localGetInboxNonblockLocalRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {param: localGetInboxNonblockLocalRpcParam}>): ChannelMap<*> {
   return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localGetInboxNonblockLocalRpc({...request, incomingCallMap, callback}))
 }
 
-export function localGetInboxNonblockLocalRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localGetInboxNonblockLocalRpcParam}>): Promise<any> {
+export function localGetInboxNonblockLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {param: localGetInboxNonblockLocalRpcParam}>): Promise<localGetInboxNonblockLocalResult> {
   return new Promise((resolve, reject) => { localGetInboxNonblockLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
@@ -618,6 +618,7 @@ export type GetInboxAndUnboxLocalRes = {
   conversations?: ?Array<ConversationLocal>,
   pagination?: ?Pagination,
   rateLimits?: ?Array<RateLimit>,
+  identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
 
 export type GetInboxByTLFIDRemoteRes = {
@@ -645,6 +646,11 @@ export type GetInboxLocalRes = {
   pagination?: ?Pagination,
   rateLimits?: ?Array<RateLimit>,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
+}
+
+export type GetInboxNonblockLocalRes = {
+  identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
+  rateLimits?: ?Array<RateLimit>,
 }
 
 export type GetInboxQuery = {
@@ -900,6 +906,7 @@ export type NewConversationInfo = {
 export type NewConversationLocalRes = {
   conv: ConversationLocal,
   rateLimits?: ?Array<RateLimit>,
+  identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
 
 export type NewConversationPayload = {
@@ -922,6 +929,10 @@ export type NewMessagePayload = {
   unreadUpdate?: ?UnreadUpdate,
 }
 
+export type NotifyChatChatIdentifyUpdateRpcParam = Exact<{
+  update: keybase1.CanonicalTLFNameAndIDWithBreaks
+}>
+
 export type NotifyChatNewChatActivityRpcParam = Exact<{
   uid: keybase1.UID,
   activity: ChatActivity
@@ -939,6 +950,7 @@ export type OutboxRecord = {
   outboxID: OutboxID,
   convID: ConversationID,
   Msg: MessagePlaintext,
+  identifyBehavior: keybase1.TLFIdentifyBehavior,
 }
 
 export type OutboxState = 
@@ -1288,6 +1300,8 @@ type localGetInboxAndUnboxLocalResult = GetInboxAndUnboxLocalRes
 
 type localGetInboxLocalResult = GetInboxLocalRes
 
+type localGetInboxNonblockLocalResult = GetInboxNonblockLocalRes
+
 type localGetInboxSummaryForCLILocalResult = GetInboxSummaryForCLILocalRes
 
 type localGetMessagesLocalResult = GetMessagesLocalRes
@@ -1440,6 +1454,13 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       uid: keybase1.UID,
       activity: ChatActivity
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatIdentifyUpdate'?: (
+    params: Exact<{
+      update: keybase1.CanonicalTLFNameAndIDWithBreaks
     }> /* ,
     response: {} // Notify call
     */

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -429,6 +429,7 @@ export const TlfKeysTLFIdentifyBehavior = {
   defaultKbfs: 0,
   chatCli: 1,
   chatGui: 2,
+  chatGuiStrict: 3,
 }
 
 export const UiPromptDefault = {
@@ -4025,6 +4026,7 @@ export type TLFIdentifyBehavior =
     0 // DEFAULT_KBFS_0
   | 1 // CHAT_CLI_1
   | 2 // CHAT_GUI_2
+  | 3 // CHAT_GUI_STRICT_3
 
 export type TLFIdentifyFailure = {
   user: User,

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -253,6 +253,10 @@
           "type": "MessagePlaintext",
           "name": "Msg",
           "lint": "ignore"
+        },
+        {
+          "type": "keybase1.TLFIdentifyBehavior",
+          "name": "identifyBehavior"
         }
       ]
     },
@@ -810,6 +814,33 @@
             "items": "RateLimit"
           },
           "name": "rateLimits"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFIdentifyFailure"
+          },
+          "name": "identifyFailures"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "GetInboxNonblockLocalRes",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFIdentifyFailure"
+          },
+          "name": "identifyFailures"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
         }
       ]
     },
@@ -895,6 +926,13 @@
             "items": "RateLimit"
           },
           "name": "rateLimits"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFIdentifyFailure"
+          },
+          "name": "identifyFailures"
         }
       ]
     },
@@ -1193,7 +1231,7 @@
           "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
-      "response": null
+      "response": "GetInboxNonblockLocalRes"
     },
     "postLocal": {
       "request": [

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -164,6 +164,17 @@
       "response": null,
       "notify": "",
       "lint": "ignore"
+    },
+    "ChatIdentifyUpdate": {
+      "request": [
+        {
+          "name": "update",
+          "type": "keybase1.CanonicalTLFNameAndIDWithBreaks"
+        }
+      ],
+      "response": null,
+      "notify": "",
+      "lint": "ignore"
     }
   },
   "namespace": "chat.1"

--- a/protocol/json/keybase1/tlf_keys.json
+++ b/protocol/json/keybase1/tlf_keys.json
@@ -17,7 +17,8 @@
       "symbols": [
         "DEFAULT_KBFS_0",
         "CHAT_CLI_1",
-        "CHAT_GUI_2"
+        "CHAT_GUI_2",
+        "CHAT_GUI_STRICT_3"
       ]
     },
     {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -187,15 +187,15 @@ export function localGetInboxLocalRpcPromise (request: $Exact<requestCommon & {c
   return new Promise((resolve, reject) => { localGetInboxLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
-export function localGetInboxNonblockLocalRpc (request: Exact<requestCommon & requestErrorCallback & {param: localGetInboxNonblockLocalRpcParam}>) {
+export function localGetInboxNonblockLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {param: localGetInboxNonblockLocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.getInboxNonblockLocal'})
 }
 
-export function localGetInboxNonblockLocalRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localGetInboxNonblockLocalRpcParam}>): ChannelMap<*> {
+export function localGetInboxNonblockLocalRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {param: localGetInboxNonblockLocalRpcParam}>): ChannelMap<*> {
   return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localGetInboxNonblockLocalRpc({...request, incomingCallMap, callback}))
 }
 
-export function localGetInboxNonblockLocalRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localGetInboxNonblockLocalRpcParam}>): Promise<any> {
+export function localGetInboxNonblockLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {param: localGetInboxNonblockLocalRpcParam}>): Promise<localGetInboxNonblockLocalResult> {
   return new Promise((resolve, reject) => { localGetInboxNonblockLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
@@ -618,6 +618,7 @@ export type GetInboxAndUnboxLocalRes = {
   conversations?: ?Array<ConversationLocal>,
   pagination?: ?Pagination,
   rateLimits?: ?Array<RateLimit>,
+  identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
 
 export type GetInboxByTLFIDRemoteRes = {
@@ -645,6 +646,11 @@ export type GetInboxLocalRes = {
   pagination?: ?Pagination,
   rateLimits?: ?Array<RateLimit>,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
+}
+
+export type GetInboxNonblockLocalRes = {
+  identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
+  rateLimits?: ?Array<RateLimit>,
 }
 
 export type GetInboxQuery = {
@@ -900,6 +906,7 @@ export type NewConversationInfo = {
 export type NewConversationLocalRes = {
   conv: ConversationLocal,
   rateLimits?: ?Array<RateLimit>,
+  identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
 
 export type NewConversationPayload = {
@@ -922,6 +929,10 @@ export type NewMessagePayload = {
   unreadUpdate?: ?UnreadUpdate,
 }
 
+export type NotifyChatChatIdentifyUpdateRpcParam = Exact<{
+  update: keybase1.CanonicalTLFNameAndIDWithBreaks
+}>
+
 export type NotifyChatNewChatActivityRpcParam = Exact<{
   uid: keybase1.UID,
   activity: ChatActivity
@@ -939,6 +950,7 @@ export type OutboxRecord = {
   outboxID: OutboxID,
   convID: ConversationID,
   Msg: MessagePlaintext,
+  identifyBehavior: keybase1.TLFIdentifyBehavior,
 }
 
 export type OutboxState = 
@@ -1288,6 +1300,8 @@ type localGetInboxAndUnboxLocalResult = GetInboxAndUnboxLocalRes
 
 type localGetInboxLocalResult = GetInboxLocalRes
 
+type localGetInboxNonblockLocalResult = GetInboxNonblockLocalRes
+
 type localGetInboxSummaryForCLILocalResult = GetInboxSummaryForCLILocalRes
 
 type localGetMessagesLocalResult = GetMessagesLocalRes
@@ -1440,6 +1454,13 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       uid: keybase1.UID,
       activity: ChatActivity
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatIdentifyUpdate'?: (
+    params: Exact<{
+      update: keybase1.CanonicalTLFNameAndIDWithBreaks
     }> /* ,
     response: {} // Notify call
     */

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -429,6 +429,7 @@ export const TlfKeysTLFIdentifyBehavior = {
   defaultKbfs: 0,
   chatCli: 1,
   chatGui: 2,
+  chatGuiStrict: 3,
 }
 
 export const UiPromptDefault = {
@@ -4025,6 +4026,7 @@ export type TLFIdentifyBehavior =
     0 // DEFAULT_KBFS_0
   | 1 // CHAT_CLI_1
   | 2 // CHAT_GUI_2
+  | 3 // CHAT_GUI_STRICT_3
 
 export type TLFIdentifyFailure = {
   user: User,


### PR DESCRIPTION
This PR does a bunch of stuff:

1.) We no longer thread the identify behavior through every possible call. Instead, we load it into the context at the entry point to each RPC endpoint. This allows us to handle it at the lowest level in `tlfHandler`. We also attach a result object to that context value, so that the endpoints can collect all of the unique identify breaks encountered along the way.
2.) We fix the `Outbox` and `Deliverer` to use the identify behavior that was used to spawn the message.
3.) We change `tlfHandler` so that it will notify (through `NotifyRouter`) whenever the tracking state of some TLF changes from what it last sent. This is the interface @chrisnojima would prefer to use for getting this information to Electron. Note that each RPC also returns all of this information.
4.) We fix a variety of bugs, most notably that sometimes in chat GUI mode, we were not returning breaks properly to KBFS.
5.) Add a new identify mode, `TLFIdentifyBehavior_CHAT_GUI_STRICT`, which acts like CLI mode. Nojima wanted this for the case when we want identify failures to block us (like if we send a message, and the user doesn't now the recipient is busted).

This change also makes it so that chat never causes a tracker popup to show up as a result of a broken tracking statement (or anything else). As long as the context is setup properly, then everything should just work.