### PR TITLE
Fixes chat input lag / high load

### DIFF
--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -17,31 +17,21 @@ import type {Props} from '.'
 type OwnProps = {}
 type State = {
   sidePanelOpen: boolean,
-  inputText: string,
 }
 
 class ConversationContainer extends Component<void, Props, State> {
   state: State
-  _inputTextMap: {[key: string]: ?string}= {}
 
   constructor (props: Props) {
     super(props)
-    this.state = {sidePanelOpen: false, inputText: ''}
+    this.state = {sidePanelOpen: false}
   }
 
   componentWillReceiveProps (nextProps: Props) {
     if (this.props.selectedConversation !== nextProps.selectedConversation) {
       this.setState({
         sidePanelOpen: false,
-        inputText: this._inputTextMap[nextProps.selectedConversation || ''] || '',
       })
-    }
-  }
-
-  _setInputText = (inputText: string) => {
-    if (this.props.selectedConversation) {
-      this._inputTextMap[this.props.selectedConversation] = inputText
-      this.setState({inputText})
     }
   }
 
@@ -58,8 +48,6 @@ class ConversationContainer extends Component<void, Props, State> {
       {...this.props}
       sidePanelOpen={this.state.sidePanelOpen}
       onToggleSidePanel={this._onToggleSidePanel}
-      setInputText={this._setInputText}
-      inputText={this.state.inputText}
     />
   }
 }

--- a/shared/chat/conversation/header.desktop.js
+++ b/shared/chat/conversation/header.desktop.js
@@ -4,7 +4,7 @@ import {Box, Icon, Usernames} from '../../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../../styles'
 import {participantFilter} from '../../constants/chat'
 
-import type {Props} from './'
+import type {Props} from './header'
 
 const Header = ({participants, onOpenFolder, onToggleSidePanel, sidePanelOpen}: Props) => (
   <Box style={containerStyle}>

--- a/shared/chat/conversation/header.js.flow
+++ b/shared/chat/conversation/header.js.flow
@@ -1,0 +1,14 @@
+// @flow
+import {Component} from 'react'
+import {List} from 'immutable'
+
+import type {ParticipantItem} from '../../constants/chat'
+
+export type Props = {
+  participants: List<ParticipantItem>,
+  onOpenFolder: () => void,
+  onToggleSidePanel: () => void,
+  sidePanelOpen: boolean,
+}
+
+export default class Header extends Component<void, Props, void> { }

--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -17,9 +17,31 @@ const Conversation = (props: Props) => {
   return (
     <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
       <Header {...props} />
-      <List {...props} />
+      <List
+        messages={props.messages}
+        selectedConversation={props.selectedConversation}
+        onLoadMoreMessages={props.onLoadMoreMessages}
+        onEditMessage={props.onEditMessage}
+        onDeleteMessage={props.onDeleteMessage}
+        moreToLoad={props.moreToLoad}
+        firstNewMessageID={props.firstNewMessageID}
+        onLoadAttachment={props.onLoadAttachment}
+        onOpenInFileUI={props.onOpenInFileUI}
+        validated={props.validated}
+        sidePanelOpen={props.sidePanelOpen}
+        participants={props.participants}
+        onShowProfile={props.onShowProfile}
+        metaData={props.metaData}
+        onAddParticipant={props.onAddParticipant}
+      />
       {banner}
-      <Input {...props} />
+      <Input
+        emojiPickerOpen={props.emojiPickerOpen}
+        selectedConversation={props.selectedConversation}
+        isLoading={props.isLoading}
+        inputText={props.inputText}
+        setInputText={props.setInputText}
+      />
     </Box>
   )
 }

--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -16,31 +16,36 @@ const Conversation = (props: Props) => {
   const banner = bannerMessage && <Banner {...bannerMessage} />
   return (
     <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
-      <Header {...props} />
-      <List
-        messages={props.messages}
-        selectedConversation={props.selectedConversation}
-        onLoadMoreMessages={props.onLoadMoreMessages}
-        onEditMessage={props.onEditMessage}
-        onDeleteMessage={props.onDeleteMessage}
-        moreToLoad={props.moreToLoad}
-        firstNewMessageID={props.firstNewMessageID}
-        onLoadAttachment={props.onLoadAttachment}
-        onOpenInFileUI={props.onOpenInFileUI}
-        validated={props.validated}
-        sidePanelOpen={props.sidePanelOpen}
+      <Header
+        onOpenFolder={props.onOpenFolder}
+        onToggleSidePanel={props.onToggleSidePanel}
         participants={props.participants}
-        onShowProfile={props.onShowProfile}
+        sidePanelOpen={props.sidePanelOpen}
+      />
+      <List
+        firstNewMessageID={props.firstNewMessageID}
+        messages={props.messages}
         metaData={props.metaData}
+        moreToLoad={props.moreToLoad}
         onAddParticipant={props.onAddParticipant}
+        onDeleteMessage={props.onDeleteMessage}
+        onEditMessage={props.onEditMessage}
+        onLoadAttachment={props.onLoadAttachment}
+        onLoadMoreMessages={props.onLoadMoreMessages}
+        onOpenInFileUI={props.onOpenInFileUI}
+        onShowProfile={props.onShowProfile}
+        participants={props.participants}
+        selectedConversation={props.selectedConversation}
+        sidePanelOpen={props.sidePanelOpen}
+        validated={props.validated}
       />
       {banner}
       <Input
         emojiPickerOpen={props.emojiPickerOpen}
-        selectedConversation={props.selectedConversation}
         isLoading={props.isLoading}
-        inputText={props.inputText}
-        setInputText={props.setInputText}
+        onAttach={props.onAttach}
+        onPostMessage={props.onPostMessage}
+        selectedConversation={props.selectedConversation}
       />
     </Box>
   )

--- a/shared/chat/conversation/input.desktop.js
+++ b/shared/chat/conversation/input.desktop.js
@@ -5,11 +5,14 @@ import {globalColors, globalMargins, globalStyles} from '../../styles'
 import {Picker} from 'emoji-mart'
 import {backgroundImageFn} from '../../common-adapters/emoji'
 
-import type {Props} from './'
+import type {Props} from './input'
 
 type State = {
   emojiPickerOpen: boolean,
+  text: string,
 }
+
+const _cachedInput: {[key: ?string]: ?string} = { }
 
 class Conversation extends Component<void, Props, State> {
   _input: any;
@@ -23,12 +26,14 @@ class Conversation extends Component<void, Props, State> {
   constructor (props: Props) {
     super(props)
     const {emojiPickerOpen} = props
-    this.state = {emojiPickerOpen}
+    this.state = {emojiPickerOpen, text: _cachedInput[props.selectedConversation] || ''}
   }
 
   componentWillReceiveProps (nextProps: Props) {
     if (nextProps.selectedConversation !== this.props.selectedConversation) {
       this._input && this._input.focus()
+      _cachedInput[this.props.selectedConversation] = this.state.text
+      this.setState({text: _cachedInput[nextProps.selectedConversation] || ''})
     }
   }
 
@@ -39,11 +44,11 @@ class Conversation extends Component<void, Props, State> {
   }
 
   _insertEmoji (emojiColons: string) {
-    const inputText = this.props.inputText || ''
+    const text: string = this.state.text || ''
     if (this._input) {
       const {selectionStart = 0, selectionEnd = 0} = this._input.selections() || {}
-      const nextInputText = [inputText.substring(0, selectionStart), emojiColons, inputText.substring(selectionEnd)].join('')
-      this.props.setInputText(nextInputText)
+      const nextText = [text.substring(0, selectionStart), emojiColons, text.substring(selectionEnd)].join('')
+      this.setState({text: nextText})
       this._input.focus()
     }
   }
@@ -77,15 +82,15 @@ class Conversation extends Component<void, Props, State> {
             ref={this._setRef}
             hintText='Write a message'
             hideUnderline={true}
-            onChangeText={inputText => this.props.setInputText(inputText)}
-            value={this.props.inputText}
+            onChangeText={text => this.setState({text})}
+            value={this.state.text}
             multiline={true}
             rowsMin={1}
             onEnterKeyDown={(e) => {
               e.preventDefault()
-              if (this.props.inputText) {
-                this.props.onPostMessage(this.props.inputText)
-                this.props.setInputText('')
+              if (this.state.text) {
+                this.props.onPostMessage(this.state.text)
+                this.setState({text: ''})
               }
             }}
           />

--- a/shared/chat/conversation/input.js.flow
+++ b/shared/chat/conversation/input.js.flow
@@ -1,0 +1,14 @@
+// @flow
+import {Component} from 'react'
+
+import type {ConversationIDKey} from '../../constants/chat'
+
+export type Props = {
+  emojiPickerOpen: boolean,
+  isLoading: boolean,
+  onAttach: () => void,
+  onPostMessage: (text: string) => void,
+  selectedConversation: ?ConversationIDKey,
+}
+
+export default class Input extends Component<void, Props, void> { }

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -4,12 +4,13 @@
 // We load that in in our constructor, after you stop scrolling or if we get an update and we're not currently scrolling
 
 import LoadingMore from './messages/loading-more'
+import Popup from './messages/popup'
 import React, {Component} from 'react'
 import ReactDOM from 'react-dom'
 import SidePanel from './side-panel/index.desktop'
-import Popup from './messages/popup'
 import _ from 'lodash'
 import messageFactory from './messages'
+import shallowEqual from 'shallowequal'
 import {AutoSizer, CellMeasurer, List, defaultCellMeasurerCellSizeCache} from 'react-virtualized'
 import {ProgressIndicator} from '../../common-adapters'
 import {globalColors, globalStyles} from '../../styles'
@@ -61,6 +62,10 @@ class ConversationList extends Component<void, Props, State> {
       }
       return id
     }
+  }
+
+  shouldComponentUpdate (nextProps: Props, nextState: State) {
+    return !shallowEqual(this.props, nextProps) || !shallowEqual(this.state, nextState)
   }
 
   componentWillUpdate (nextProps: Props, nextState: State) {

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -16,7 +16,7 @@ import {ProgressIndicator} from '../../common-adapters'
 import {globalColors, globalStyles} from '../../styles'
 
 import type {Message, MessageID} from '../../constants/chat'
-import type {Props} from './'
+import type {Props} from './list'
 
 type State = {
   isLockedToBottom: boolean,

--- a/shared/chat/conversation/list.js.flow
+++ b/shared/chat/conversation/list.js.flow
@@ -2,34 +2,24 @@
 import {Component} from 'react'
 import {List, Map} from 'immutable'
 
-import type {Props as BannerMessage} from './banner'
 import type {ConversationIDKey, Message, MessageID, MetaData, ParticipantItem} from '../../constants/chat'
 
 export type Props = {
-  bannerMessage: ?BannerMessage,
-  emojiPickerOpen: boolean,
   firstNewMessageID: ?MessageID,
-  inputText: string,
-  isLoading: boolean,
   messages: List<Message>,
   metaData: Map<string, MetaData>,
   moreToLoad: boolean,
   onAddParticipant: () => void,
-  onAttach: () => void,
   onDeleteMessage: (message: Message) => void,
   onEditMessage: (message: Message) => void,
   onLoadAttachment: (messageID: MessageID, filename: string) => void,
   onLoadMoreMessages: () => void,
-  onOpenFolder: () => void,
   onOpenInFileUI: (filename: string) => void,
-  onPostMessage: (text: string) => void,
   onShowProfile: (username: string) => void,
-  onToggleSidePanel: () => void,
   participants: List<ParticipantItem>,
   selectedConversation: ?ConversationIDKey,
-  setInputText: (text: string) => void,
   sidePanelOpen: boolean,
   validated: boolean,
 }
 
-export default class Conversation extends Component<void, Props, void> { }
+export default class ConversationList extends Component<void, Props, void> { }

--- a/shared/chat/conversation/side-panel/index.desktop.js
+++ b/shared/chat/conversation/side-panel/index.desktop.js
@@ -4,7 +4,7 @@ import {Box, Divider} from '../../../common-adapters'
 import {globalStyles, globalColors} from '../../../styles'
 import Participants from './participants.desktop'
 
-import type {Props} from '..'
+import type {Props} from '.'
 
 const border = `1px solid ${globalColors.black_05}`
 const SidePanel = (props: Props) => (

--- a/shared/chat/conversation/side-panel/index.js.flow
+++ b/shared/chat/conversation/side-panel/index.js.flow
@@ -1,0 +1,14 @@
+// @flow
+import {Component} from 'react'
+import {List, Map} from 'immutable'
+
+import type {MetaData, ParticipantItem} from '../../../constants/chat'
+
+export type Props = {
+  onAddParticipant: () => void,
+  participants: List<ParticipantItem>,
+  onShowProfile: (username: string) => void,
+  metaData: Map<string, MetaData>,
+}
+
+export default class SidePanel extends Component<void, Props, void> { }

--- a/shared/chat/conversation/side-panel/participants.desktop.js
+++ b/shared/chat/conversation/side-panel/participants.desktop.js
@@ -3,7 +3,7 @@ import React from 'react'
 import {Box, Avatar, Text, Usernames, Divider, Icon} from '../../../common-adapters'
 import {globalStyles, globalMargins, globalColors} from '../../../styles'
 
-import type {Props} from '..'
+import type {Props} from '.'
 
 const Participants = (props: Props) => (
   <Box style={{...globalStyles.flexBoxColumn}}>

--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -73,7 +73,7 @@ class Input extends Component<void, Props, State> {
       return
     }
 
-    node.style.height = 'auto'
+    node.style.height = '1px'
     node.style.height = `${node.scrollHeight}px`
   }
 


### PR DESCRIPTION
When I implemented the ability to retain unsent chat input values while switching conversations I accidentally caused the input changes to flow to all the other components which would cause the list to re-render

So this pr

- [x] Moves the conversation/input cache to the input itself so no one else knows about it
- [x] Sends subsets of the props to the various components so they're more decoupled
- [x] Fixes the autoresizing of input so it'll downsize correctly (random bug i saw)

@keybase/react-hackers 