### PR TITLE
trigger deliver loop on reconnect events, and make it configurable CORE-4292

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -13,11 +13,11 @@ import (
 
 type RemoteConversationSource struct {
 	libkb.Contextified
-	ri    chat1.RemoteInterface
+	ri    func() chat1.RemoteInterface
 	boxer *Boxer
 }
 
-func NewRemoteConversationSource(g *libkb.GlobalContext, b *Boxer, ri chat1.RemoteInterface) *RemoteConversationSource {
+func NewRemoteConversationSource(g *libkb.GlobalContext, b *Boxer, ri func() chat1.RemoteInterface) *RemoteConversationSource {
 	return &RemoteConversationSource{
 		Contextified: libkb.NewContextified(g),
 		ri:           ri,
@@ -39,7 +39,7 @@ func (s *RemoteConversationSource) Pull(ctx context.Context, convID chat1.Conver
 		Query:          query,
 		Pagination:     pagination,
 	}
-	boxed, err := s.ri.GetThreadRemote(ctx, rarg)
+	boxed, err := s.ri().GetThreadRemote(ctx, rarg)
 	rl := []*chat1.RateLimit{boxed.RateLimit}
 	if err != nil {
 		return chat1.ThreadView{}, rl, err
@@ -65,7 +65,7 @@ func (s *RemoteConversationSource) Clear(convID chat1.ConversationID, uid gregor
 func (s *RemoteConversationSource) GetMessages(ctx context.Context, convID chat1.ConversationID,
 	uid gregor1.UID, msgIDs []chat1.MessageID) ([]chat1.MessageUnboxed, error) {
 
-	rres, err := s.ri.GetMessagesRemote(ctx, chat1.GetMessagesRemoteArg{
+	rres, err := s.ri().GetMessagesRemote(ctx, chat1.GetMessagesRemoteArg{
 		ConversationID: convID,
 		MessageIDs:     msgIDs,
 	})
@@ -80,12 +80,13 @@ func (s *RemoteConversationSource) GetMessages(ctx context.Context, convID chat1
 
 type HybridConversationSource struct {
 	libkb.Contextified
-	ri      chat1.RemoteInterface
+	ri      func() chat1.RemoteInterface
 	boxer   *Boxer
 	storage *storage.Storage
 }
 
-func NewHybridConversationSource(g *libkb.GlobalContext, b *Boxer, storage *storage.Storage, ri chat1.RemoteInterface) *HybridConversationSource {
+func NewHybridConversationSource(g *libkb.GlobalContext, b *Boxer, storage *storage.Storage,
+	ri func() chat1.RemoteInterface) *HybridConversationSource {
 	return &HybridConversationSource{
 		Contextified: libkb.NewContextified(g),
 		ri:           ri,
@@ -123,7 +124,7 @@ func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.Conver
 func (s *HybridConversationSource) getConvMetadata(ctx context.Context, convID chat1.ConversationID,
 	rl *[]*chat1.RateLimit) (chat1.Conversation, error) {
 
-	conv, err := s.ri.GetInboxRemote(ctx, chat1.GetInboxRemoteArg{
+	conv, err := s.ri().GetInboxRemote(ctx, chat1.GetInboxRemoteArg{
 		Query: &chat1.GetInboxQuery{
 			ConvID: &convID,
 		},
@@ -162,7 +163,7 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 			// Before returning the stuff, send remote request to mark as read if
 			// requested.
 			if query != nil && query.MarkAsRead && len(localData.Messages) > 0 {
-				res, err := s.ri.MarkAsRead(ctx, chat1.MarkAsReadArg{
+				res, err := s.ri().MarkAsRead(ctx, chat1.MarkAsReadArg{
 					ConversationID: convID,
 					MsgID:          localData.Messages[0].GetMessageID(),
 				})
@@ -185,7 +186,7 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 		Query:          query,
 		Pagination:     pagination,
 	}
-	boxed, err := s.ri.GetThreadRemote(ctx, rarg)
+	boxed, err := s.ri().GetThreadRemote(ctx, rarg)
 	rl = append(rl, boxed.RateLimit)
 	if err != nil {
 		return chat1.ThreadView{}, rl, err
@@ -290,7 +291,7 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 	// Grab message from remote
 	s.G().Log.Debug("HybridConversationSource: GetMessages: convID: %s uid: %s total msgs: %d remote: %d", convID, uid, len(msgIDs), len(remoteMsgs))
 	if len(remoteMsgs) > 0 {
-		rmsgs, err := s.ri.GetMessagesRemote(ctx, chat1.GetMessagesRemoteArg{
+		rmsgs, err := s.ri().GetMessagesRemote(ctx, chat1.GetMessagesRemoteArg{
 			ConversationID: convID,
 			MessageIDs:     remoteMsgs,
 		})
@@ -329,7 +330,7 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 }
 
 func NewConversationSource(g *libkb.GlobalContext, typ string, boxer *Boxer, storage *storage.Storage,
-	ri chat1.RemoteInterface) libkb.ConversationSource {
+	ri func() chat1.RemoteInterface) libkb.ConversationSource {
 	if typ == "hybrid" {
 		return NewHybridConversationSource(g, boxer, storage, ri)
 	}

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -303,7 +303,8 @@ func (s *Deliverer) Queue(convID chat1.ConversationID, msg chat1.MessagePlaintex
 }
 
 func (s *Deliverer) deliverLoop() {
-	s.debug("starting non blocking sender deliver loop: uid: %s", s.outbox.GetUID())
+	s.debug("starting non blocking sender deliver loop: uid: %s duration: %v", s.outbox.GetUID(),
+		s.G().Env.GetChatDelivererInterval())
 	for {
 		// Wait for the signal to take action
 		select {
@@ -312,7 +313,7 @@ func (s *Deliverer) deliverLoop() {
 			return
 		case <-s.msgSentCh:
 			s.debug("flushing outbox on new message: uid: %s", s.outbox.GetUID())
-		case <-s.G().Clock().After(time.Minute):
+		case <-s.G().Clock().After(s.G().Env.GetChatDelivererInterval()):
 		}
 
 		// Fetch outbox

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -357,13 +357,13 @@ func (s *Deliverer) deliverLoop() {
 				if obr.State.Sending() > deliverMaxAttempts || !s.connected {
 					// Mark the entire outbox as an error if we can't send
 					s.debug("max failure attempts reached, marking all as errors and notifying")
-					obids, err := s.outbox.MarkAllAsError()
+					deadObrs, err := s.outbox.MarkAllAsError()
 					if err != nil {
 						s.G().Log.Error("unable to mark as error on outbox: uid: %s err: %s",
 							s.outbox.GetUID(), err.Error())
 					}
 					act := chat1.NewChatActivityWithFailedMessage(chat1.FailedMessageInfo{
-						OutboxIDs: obids,
+						OutboxRecords: deadObrs,
 					})
 					s.G().NotifyRouter.HandleNewChatActivity(context.Background(),
 						keybase1.UID(s.outbox.GetUID().String()), &act)

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -85,7 +85,8 @@ func setupTest(t *testing.T) (libkb.TestContext, chat1.RemoteInterface, *kbtest.
 		incoming: make(chan int),
 		failing:  make(chan []chat1.OutboxID),
 	}
-	tc.G.ConvSource = NewRemoteConversationSource(tc.G, boxer, ri)
+	tc.G.ConvSource = NewRemoteConversationSource(tc.G, boxer,
+		func() chat1.RemoteInterface { return ri })
 	tc.G.NotifyRouter.SetListener(&listener)
 	tc.G.MessageDeliverer = NewDeliverer(tc.G, baseSender)
 	tc.G.MessageDeliverer.Start(u.User.GetUID().ToBytes())

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -290,7 +290,7 @@ func (f FailingSender) Prepare(ctx context.Context, msg chat1.MessagePlaintext, 
 	return nil, nil
 }
 
-func TestFailing(t *testing.T) {
+func TestFailingSender(t *testing.T) {
 
 	tc, ri, u, sender, _, listener, _, _ := setupTest(t)
 	defer tc.Cleanup()
@@ -311,6 +311,7 @@ func TestFailing(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	tc.G.MessageDeliverer.Connected()
 	tc.G.MessageDeliverer.(*Deliverer).SetSender(FailingSender{})
 
 	// Send nonblock

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -57,7 +57,11 @@ func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActi
 				n.incoming <- len(n.obids)
 			}
 		} else if typ == chat1.ChatActivityType_FAILED_MESSAGE {
-			n.failing <- activity.FailedMessage().OutboxIDs
+			var rmsg []chat1.OutboxID
+			for _, obr := range activity.FailedMessage().OutboxRecords {
+				rmsg = append(rmsg, obr.OutboxID)
+			}
+			n.failing <- rmsg
 		}
 	}
 }

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -136,6 +136,7 @@ type sendOptionsV1 struct {
 	Channel        ChatChannel
 	ConversationID string `json:"conversation_id"`
 	Message        ChatMessage
+	Nonblock       bool `json:"nonblock"`
 }
 
 func (s sendOptionsV1) Check() error {

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -57,6 +57,7 @@ func (c *chatServiceHandler) ListV1(ctx context.Context, opts listOptionsV1) Rep
 			Status:    utils.VisibleChatConversationStatuses(),
 			TopicType: &topicType,
 		},
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	})
 	if err != nil {
 		return c.errReply(err)
@@ -116,6 +117,7 @@ func (c *chatServiceHandler) ReadV1(ctx context.Context, opts readOptionsV1) Rep
 		Query: &chat1.GetThreadQuery{
 			MarkAsRead: !opts.Peek,
 		},
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	}
 	threadView, err := client.GetThreadLocal(ctx, arg)
 	if err != nil {
@@ -219,6 +221,7 @@ func (c *chatServiceHandler) SendV1(ctx context.Context, opts sendOptionsV1) Rep
 		body:           chat1.NewMessageBodyWithText(chat1.MessageText{Body: opts.Message.Body}),
 		mtype:          chat1.MessageType_TEXT,
 		response:       "message sent",
+		nonblock:       opts.Nonblock,
 	}
 	return c.sendV1(ctx, arg)
 }
@@ -483,10 +486,11 @@ func (c *chatServiceHandler) DownloadV1(ctx context.Context, opts downloadOption
 	}
 
 	arg := chat1.DownloadAttachmentLocalArg{
-		ConversationID: convID,
-		MessageID:      opts.MessageID,
-		Sink:           sink,
-		Preview:        opts.Preview,
+		ConversationID:   convID,
+		MessageID:        opts.MessageID,
+		Sink:             sink,
+		Preview:          opts.Preview,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	}
 
 	dres, err := client.DownloadAttachmentLocal(ctx, arg)
@@ -566,8 +570,9 @@ func (c *chatServiceHandler) SetStatusV1(ctx context.Context, opts setStatusOpti
 	}
 
 	setStatusArg := chat1.SetConversationStatusLocalArg{
-		ConversationID: convID,
-		Status:         status,
+		ConversationID:   convID,
+		Status:           status,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	}
 
 	client, err := GetChatLocalClient(c.G())
@@ -631,6 +636,7 @@ type sendArgV1 struct {
 	supersedes     chat1.MessageID
 	deletes        []chat1.MessageID
 	response       string
+	nonblock       bool
 }
 
 func (c *chatServiceHandler) sendV1(ctx context.Context, arg sendArgV1) Reply {
@@ -650,16 +656,30 @@ func (c *chatServiceHandler) sendV1(ctx context.Context, arg sendArgV1) Reply {
 			ClientHeader: header.clientHeader,
 			MessageBody:  arg.body,
 		},
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	}
 	client, err := GetChatLocalClient(c.G())
 	if err != nil {
 		return c.errReply(err)
 	}
-	plres, err := client.PostLocal(ctx, postArg)
-	if err != nil {
-		return c.errReply(err)
+
+	if arg.nonblock {
+		var nbarg chat1.PostLocalNonblockArg
+		nbarg.ConversationID = postArg.ConversationID
+		nbarg.Msg = postArg.Msg
+		nbarg.IdentifyBehavior = postArg.IdentifyBehavior
+		plres, err := client.PostLocalNonblock(ctx, nbarg)
+		if err != nil {
+			return c.errReply(err)
+		}
+		header.rateLimits = append(header.rateLimits, plres.RateLimits...)
+	} else {
+		plres, err := client.PostLocal(ctx, postArg)
+		if err != nil {
+			return c.errReply(err)
+		}
+		header.rateLimits = append(header.rateLimits, plres.RateLimits...)
 	}
-	header.rateLimits = append(header.rateLimits, plres.RateLimits...)
 
 	res := SendRes{
 		Message: arg.response,

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -136,6 +136,15 @@ func (p CommandLine) GetGregorPingInterval() (time.Duration, bool) {
 	}
 	return ret, true
 }
+
+func (p CommandLine) GetChatDelivererInterval() (time.Duration, bool) {
+	ret, err := p.GetGDuration("chat-deliverer-interval")
+	if err != nil {
+		return 0, false
+	}
+	return ret, true
+}
+
 func (p CommandLine) GetRunMode() (libkb.RunMode, error) {
 	return libkb.StringToRunMode(p.GetGString("run-mode"))
 }

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -500,6 +500,10 @@ func (f JSONConfigFile) GetGregorPingInterval() (time.Duration, bool) {
 	return f.GetDurationAtPath("push.ping_interval")
 }
 
+func (f JSONConfigFile) GetChatDelivererInterval() (time.Duration, bool) {
+	return f.GetDurationAtPath("chat.deliverer_interval")
+}
+
 func (f JSONConfigFile) getCacheSize(w string) (int, bool) {
 	return f.jw.AtPathGetInt(w)
 }

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -18,65 +18,66 @@ import (
 
 type NullConfiguration struct{}
 
-func (n NullConfiguration) GetHome() string                               { return "" }
-func (n NullConfiguration) GetServerURI() string                          { return "" }
-func (n NullConfiguration) GetConfigFilename() string                     { return "" }
-func (n NullConfiguration) GetUpdaterConfigFilename() string              { return "" }
-func (n NullConfiguration) GetSessionFilename() string                    { return "" }
-func (n NullConfiguration) GetDbFilename() string                         { return "" }
-func (n NullConfiguration) GetChatDbFilename() string                     { return "" }
-func (n NullConfiguration) GetUsername() NormalizedUsername               { return NormalizedUsername("") }
-func (n NullConfiguration) GetEmail() string                              { return "" }
-func (n NullConfiguration) GetProxy() string                              { return "" }
-func (n NullConfiguration) GetGpgHome() string                            { return "" }
-func (n NullConfiguration) GetBundledCA(h string) string                  { return "" }
-func (n NullConfiguration) GetUserCacheMaxAge() (time.Duration, bool)     { return 0, false }
-func (n NullConfiguration) GetProofCacheSize() (int, bool)                { return 0, false }
-func (n NullConfiguration) GetProofCacheLongDur() (time.Duration, bool)   { return 0, false }
-func (n NullConfiguration) GetProofCacheMediumDur() (time.Duration, bool) { return 0, false }
-func (n NullConfiguration) GetProofCacheShortDur() (time.Duration, bool)  { return 0, false }
-func (n NullConfiguration) GetLinkCacheSize() (int, bool)                 { return 0, false }
-func (n NullConfiguration) GetLinkCacheCleanDur() (time.Duration, bool)   { return 0, false }
-func (n NullConfiguration) GetMerkleKIDs() []string                       { return nil }
-func (n NullConfiguration) GetCodeSigningKIDs() []string                  { return nil }
-func (n NullConfiguration) GetPinentry() string                           { return "" }
-func (n NullConfiguration) GetUID() (ret keybase1.UID)                    { return }
-func (n NullConfiguration) GetGpg() string                                { return "" }
-func (n NullConfiguration) GetGpgOptions() []string                       { return nil }
-func (n NullConfiguration) GetPGPFingerprint() *PGPFingerprint            { return nil }
-func (n NullConfiguration) GetSecretKeyringTemplate() string              { return "" }
-func (n NullConfiguration) GetSalt() []byte                               { return nil }
-func (n NullConfiguration) GetSocketFile() string                         { return "" }
-func (n NullConfiguration) GetPidFile() string                            { return "" }
-func (n NullConfiguration) GetStandalone() (bool, bool)                   { return false, false }
-func (n NullConfiguration) GetLocalRPCDebug() string                      { return "" }
-func (n NullConfiguration) GetTimers() string                             { return "" }
-func (n NullConfiguration) GetDeviceID() keybase1.DeviceID                { return "" }
-func (n NullConfiguration) GetProxyCACerts() ([]string, error)            { return nil, nil }
-func (n NullConfiguration) GetAutoFork() (bool, bool)                     { return false, false }
-func (n NullConfiguration) GetRunMode() (RunMode, error)                  { return NoRunMode, nil }
-func (n NullConfiguration) GetNoAutoFork() (bool, bool)                   { return false, false }
-func (n NullConfiguration) GetLogFile() string                            { return "" }
-func (n NullConfiguration) GetScraperTimeout() (time.Duration, bool)      { return 0, false }
-func (n NullConfiguration) GetAPITimeout() (time.Duration, bool)          { return 0, false }
-func (n NullConfiguration) GetTorMode() (TorMode, error)                  { return TorNone, nil }
-func (n NullConfiguration) GetTorHiddenAddress() string                   { return "" }
-func (n NullConfiguration) GetTorProxy() string                           { return "" }
-func (n NullConfiguration) GetUpdatePreferenceAuto() (bool, bool)         { return false, false }
-func (n NullConfiguration) GetUpdatePreferenceSnoozeUntil() keybase1.Time { return keybase1.Time(0) }
-func (n NullConfiguration) GetUpdateLastChecked() keybase1.Time           { return keybase1.Time(0) }
-func (n NullConfiguration) GetUpdatePreferenceSkip() string               { return "" }
-func (n NullConfiguration) GetUpdateURL() string                          { return "" }
-func (n NullConfiguration) GetUpdateDisabled() (bool, bool)               { return false, false }
-func (n NullConfiguration) GetVDebugSetting() string                      { return "" }
-func (n NullConfiguration) GetLocalTrackMaxAge() (time.Duration, bool)    { return 0, false }
-func (n NullConfiguration) GetGregorURI() string                          { return "" }
-func (n NullConfiguration) GetGregorSaveInterval() (time.Duration, bool)  { return 0, false }
-func (n NullConfiguration) GetGregorPingInterval() (time.Duration, bool)  { return 0, false }
-func (n NullConfiguration) IsAdmin() (bool, bool)                         { return false, false }
-func (n NullConfiguration) GetGregorDisabled() (bool, bool)               { return false, false }
-func (n NullConfiguration) GetMountDir() string                           { return "" }
-func (n NullConfiguration) GetBGIdentifierDisabled() (bool, bool)         { return false, false }
+func (n NullConfiguration) GetHome() string                                 { return "" }
+func (n NullConfiguration) GetServerURI() string                            { return "" }
+func (n NullConfiguration) GetConfigFilename() string                       { return "" }
+func (n NullConfiguration) GetUpdaterConfigFilename() string                { return "" }
+func (n NullConfiguration) GetSessionFilename() string                      { return "" }
+func (n NullConfiguration) GetDbFilename() string                           { return "" }
+func (n NullConfiguration) GetChatDbFilename() string                       { return "" }
+func (n NullConfiguration) GetUsername() NormalizedUsername                 { return NormalizedUsername("") }
+func (n NullConfiguration) GetEmail() string                                { return "" }
+func (n NullConfiguration) GetProxy() string                                { return "" }
+func (n NullConfiguration) GetGpgHome() string                              { return "" }
+func (n NullConfiguration) GetBundledCA(h string) string                    { return "" }
+func (n NullConfiguration) GetUserCacheMaxAge() (time.Duration, bool)       { return 0, false }
+func (n NullConfiguration) GetProofCacheSize() (int, bool)                  { return 0, false }
+func (n NullConfiguration) GetProofCacheLongDur() (time.Duration, bool)     { return 0, false }
+func (n NullConfiguration) GetProofCacheMediumDur() (time.Duration, bool)   { return 0, false }
+func (n NullConfiguration) GetProofCacheShortDur() (time.Duration, bool)    { return 0, false }
+func (n NullConfiguration) GetLinkCacheSize() (int, bool)                   { return 0, false }
+func (n NullConfiguration) GetLinkCacheCleanDur() (time.Duration, bool)     { return 0, false }
+func (n NullConfiguration) GetMerkleKIDs() []string                         { return nil }
+func (n NullConfiguration) GetCodeSigningKIDs() []string                    { return nil }
+func (n NullConfiguration) GetPinentry() string                             { return "" }
+func (n NullConfiguration) GetUID() (ret keybase1.UID)                      { return }
+func (n NullConfiguration) GetGpg() string                                  { return "" }
+func (n NullConfiguration) GetGpgOptions() []string                         { return nil }
+func (n NullConfiguration) GetPGPFingerprint() *PGPFingerprint              { return nil }
+func (n NullConfiguration) GetSecretKeyringTemplate() string                { return "" }
+func (n NullConfiguration) GetSalt() []byte                                 { return nil }
+func (n NullConfiguration) GetSocketFile() string                           { return "" }
+func (n NullConfiguration) GetPidFile() string                              { return "" }
+func (n NullConfiguration) GetStandalone() (bool, bool)                     { return false, false }
+func (n NullConfiguration) GetLocalRPCDebug() string                        { return "" }
+func (n NullConfiguration) GetTimers() string                               { return "" }
+func (n NullConfiguration) GetDeviceID() keybase1.DeviceID                  { return "" }
+func (n NullConfiguration) GetProxyCACerts() ([]string, error)              { return nil, nil }
+func (n NullConfiguration) GetAutoFork() (bool, bool)                       { return false, false }
+func (n NullConfiguration) GetRunMode() (RunMode, error)                    { return NoRunMode, nil }
+func (n NullConfiguration) GetNoAutoFork() (bool, bool)                     { return false, false }
+func (n NullConfiguration) GetLogFile() string                              { return "" }
+func (n NullConfiguration) GetScraperTimeout() (time.Duration, bool)        { return 0, false }
+func (n NullConfiguration) GetAPITimeout() (time.Duration, bool)            { return 0, false }
+func (n NullConfiguration) GetTorMode() (TorMode, error)                    { return TorNone, nil }
+func (n NullConfiguration) GetTorHiddenAddress() string                     { return "" }
+func (n NullConfiguration) GetTorProxy() string                             { return "" }
+func (n NullConfiguration) GetUpdatePreferenceAuto() (bool, bool)           { return false, false }
+func (n NullConfiguration) GetUpdatePreferenceSnoozeUntil() keybase1.Time   { return keybase1.Time(0) }
+func (n NullConfiguration) GetUpdateLastChecked() keybase1.Time             { return keybase1.Time(0) }
+func (n NullConfiguration) GetUpdatePreferenceSkip() string                 { return "" }
+func (n NullConfiguration) GetUpdateURL() string                            { return "" }
+func (n NullConfiguration) GetUpdateDisabled() (bool, bool)                 { return false, false }
+func (n NullConfiguration) GetVDebugSetting() string                        { return "" }
+func (n NullConfiguration) GetLocalTrackMaxAge() (time.Duration, bool)      { return 0, false }
+func (n NullConfiguration) GetGregorURI() string                            { return "" }
+func (n NullConfiguration) GetGregorSaveInterval() (time.Duration, bool)    { return 0, false }
+func (n NullConfiguration) GetGregorPingInterval() (time.Duration, bool)    { return 0, false }
+func (n NullConfiguration) GetChatDelivererInterval() (time.Duration, bool) { return 0, false }
+func (n NullConfiguration) IsAdmin() (bool, bool)                           { return false, false }
+func (n NullConfiguration) GetGregorDisabled() (bool, bool)                 { return false, false }
+func (n NullConfiguration) GetMountDir() string                             { return "" }
+func (n NullConfiguration) GetBGIdentifierDisabled() (bool, bool)           { return false, false }
 
 func (n NullConfiguration) GetBug3964RepairTime(NormalizedUsername) (time.Time, error) {
 	return time.Time{}, nil
@@ -596,6 +597,14 @@ func (e *Env) GetGregorPingInterval() time.Duration {
 		func() (time.Duration, bool) { return e.getEnvDuration("KEYBASE_PUSH_PING_INTERVAL") },
 		func() (time.Duration, bool) { return e.config.GetGregorPingInterval() },
 		func() (time.Duration, bool) { return e.cmd.GetGregorPingInterval() },
+	)
+}
+
+func (e *Env) GetChatDelivererInterval() time.Duration {
+	return e.GetDuration(30*time.Second,
+		func() (time.Duration, bool) { return e.getEnvDuration("KEYBASE_CHAT_DELIVERER_INTERVAL") },
+		func() (time.Duration, bool) { return e.config.GetChatDelivererInterval() },
+		func() (time.Duration, bool) { return e.cmd.GetChatDelivererInterval() },
 	)
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -528,7 +528,7 @@ type MessageDeliverer interface {
 	Queue(convID chat1.ConversationID, msg chat1.MessagePlaintext,
 		identifyBehavior keybase1.TLFIdentifyBehavior) (chat1.OutboxID, error)
 	Start(uid gregor1.UID)
-	Stop()
+	Stop() chan struct{}
 	ForceDeliverLoop()
 	Connected()
 	Disconnected()

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -529,6 +529,8 @@ type MessageDeliverer interface {
 	Start(uid gregor1.UID)
 	Stop()
 	ForceDeliverLoop()
+	Connected()
+	Disconnected()
 }
 
 // UserChangedHandler is a generic interface for handling user changed events.

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -70,6 +70,7 @@ type configGetter interface {
 	GetUpdaterConfigFilename() string
 	GetUserCacheMaxAge() (time.Duration, bool)
 	GetVDebugSetting() string
+	GetChatDelivererInterval() (time.Duration, bool)
 }
 
 type CommandLine interface {

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -72,7 +72,7 @@ type SetStatusInfo struct {
 }
 
 type FailedMessageInfo struct {
-	OutboxIDs []OutboxID `codec:"outboxIDs" json:"outboxIDs"`
+	OutboxRecords []OutboxRecord `codec:"outboxRecords" json:"outboxRecords"`
 }
 
 type ChatActivity struct {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -53,11 +53,6 @@ func newChatLocalHandler(xp rpc.Transporter, g *libkb.GlobalContext, gh *gregorH
 		store:        chat.NewAttachmentStore(g.Log, g.Env.GetRuntimeDir()),
 	}
 
-	if gh != nil {
-		g.ConvSource = chat.NewConversationSource(g, g.Env.GetConvSourceType(), h.boxer,
-			storage.New(g, h.getSecretUI), h.remoteClient())
-	}
-
 	return h
 }
 

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -73,7 +73,8 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 		return &libkb.TestSecretUI{Passphrase: user.Passphrase}
 	}
 	storage := storage.New(tc.G, f)
-	tc.G.ConvSource = chat.NewHybridConversationSource(tc.G, h.boxer, storage, mockRemote)
+	tc.G.ConvSource = chat.NewHybridConversationSource(tc.G, h.boxer, storage,
+		func() chat1.RemoteInterface { return mockRemote })
 	h.setTestRemoteClient(mockRemote)
 
 	tuc := &chatTestUserContext{

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -491,6 +491,9 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 		}(g.badger)
 	}
 
+	// Let the Deliverer know that we are back online
+	g.G().MessageDeliverer.Connected()
+
 	// Broadcast reconnect oobm. Spawn this off into a goroutine so that we don't delay
 	// reconnection any longer than we have to.
 	go func(m gregor1.Message) {
@@ -506,6 +509,7 @@ func (g *gregorHandler) OnConnectError(err error, reconnectThrottleDuration time
 
 func (g *gregorHandler) OnDisconnected(ctx context.Context, status rpc.DisconnectStatus) {
 	g.Debug("disconnected: %v", status)
+	g.G().MessageDeliverer.Disconnected()
 }
 
 func (g *gregorHandler) OnDoCommandError(err error, nextTime time.Duration) {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -232,8 +232,8 @@ func (d *Service) RunBackgroundOperations(uir *UIRouter) {
 	// We should revisit these on mobile, or at least, when mobile apps are
 	// backgrounded.
 	d.hourlyChecks()
-	d.startupGregor()
 	d.createMessageDeliverer()
+	d.startupGregor()
 	d.addGlobalHooks()
 	d.configurePath()
 	d.configureRekey(uir)

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -39,7 +39,7 @@ protocol NotifyChat {
   }
 
   record FailedMessageInfo {
-    array<OutboxID> outboxIDs;
+    array<OutboxRecord> outboxRecords;
   }
 
   variant ChatActivity switch (ChatActivityType activityType) {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -588,7 +588,7 @@ export type EncryptedData = {
 }
 
 export type FailedMessageInfo = {
-  outboxIDs?: ?Array<OutboxID>,
+  outboxRecords?: ?Array<OutboxRecord>,
 }
 
 export type GenericPayload = {

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -97,9 +97,9 @@
         {
           "type": {
             "type": "array",
-            "items": "OutboxID"
+            "items": "OutboxRecord"
           },
-          "name": "outboxIDs"
+          "name": "outboxRecords"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -588,7 +588,7 @@ export type EncryptedData = {
 }
 
 export type FailedMessageInfo = {
-  outboxIDs?: ?Array<OutboxID>,
+  outboxRecords?: ?Array<OutboxRecord>,
 }
 
 export type GenericPayload = {


### PR DESCRIPTION
This makes the deliverer loop a little more intelligent with respect to the status of the connection to Gregor. Also allows users to configure the duration of the retry loop.

cc @cjb 