### PR TITLE
Update some CLI output if Keybase not running

### DIFF
--- a/go/client/cmd_install_osx.go
+++ b/go/client/cmd_install_osx.go
@@ -227,12 +227,21 @@ func DiagnoseSocketError(ui libkb.UI, err error) {
 	t := ui.GetTerminalUI()
 	services, err := launchd.ListServices([]string{"keybase.service.", "homebrew.mxcl.keybase"})
 	if err != nil {
-		t.Printf("Error checking launchd services: %v\n\n", err)
+		t.Printf("Error checking launchd services: %s\n\n", err)
 		return
 	}
 
 	if len(services) == 0 {
-		t.Printf("\nThere are no Keybase services installed, you might try running: keybase install\n\n")
+		if libkb.IsBrewBuild {
+			t.Printf("\nThere are no Keybase services installed, you might try running:\n\n\tkeybase install\n\n")
+		} else {
+			bundlePath, err := install.AppBundleForPath()
+			if err != nil {
+				t.Printf("No app bundle: %s\n\n", err)
+				return
+			}
+			t.Printf("\nKeybase isn't running. To start you can run:\n\n\topen %s\n\n", bundlePath)
+		}
 	} else if len(services) > 1 {
 		t.Printf("\nWe found multiple services:\n")
 		for _, service := range services {

--- a/go/client/cmd_install_osx.go
+++ b/go/client/cmd_install_osx.go
@@ -240,7 +240,7 @@ func DiagnoseSocketError(ui libkb.UI, err error) {
 				t.Printf("No app bundle: %s\n\n", err)
 				return
 			}
-			t.Printf("\nKeybase isn't running. To start you can run:\n\n\topen %s\n\n", bundlePath)
+			t.Printf("\nKeybase isn't running. To start, you can run:\n\n\topen %s\n\n", bundlePath)
 		}
 	} else if len(services) > 1 {
 		t.Printf("\nWe found multiple services:\n")

--- a/go/client/cmd_update.go
+++ b/go/client/cmd_update.go
@@ -23,7 +23,6 @@ func NewCmdUpdate(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comman
 		HideHelp:     true,
 		Subcommands: []cli.Command{
 			newCmdUpdateCheck(cl, g), // Deprecated
-			newCmdUpdateRun(cl, g),   // Deprecated
 			newCmdUpdateCheckInUse(cl, g),
 			newCmdUpdateNotify(cl, g),
 		},
@@ -33,24 +32,19 @@ func NewCmdUpdate(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comman
 func newCmdUpdateCheck(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:  "check",
-		Usage: "Trigger an update check",
+		Usage: "Check for update",
 		Action: func(c *cli.Context) {
+			if libkb.IsBrewBuild {
+				g.Log.Errorf("\nTo update, run:\n\n\tbrew upgrade keybase")
+				return
+			}
+
 			updaterPath, err := install.UpdaterBinPath()
 			if err != nil {
 				g.Log.Errorf("Error finding updater path: %s", err)
 				return
 			}
-			g.Log.Errorf("This is no longer supported. Instead you can run:\n\n\t%s check", updaterPath)
-		},
-	}
-}
-
-func newCmdUpdateRun(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
-	return cli.Command{
-		Name:  "run",
-		Usage: "Run the updater with custom options",
-		Action: func(c *cli.Context) {
-			g.Log.Error("This is no longer supported. See update check.")
+			g.Log.Errorf("\nTo update, you can run:\n\n\t%s check", updaterPath)
 		},
 	}
 }


### PR DESCRIPTION
Meant to update these messages. If you try to use keybase from command line and Keybase.app isn't running, it tells you to start Keybase.app.

Also for `keybase update check`, telling the user to use `brew upgrade keybase` if it was a brew build.