### PR TITLE
add nonblock send mode, and add identify behavior to JSON API

### DIFF
--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -136,6 +136,7 @@ type sendOptionsV1 struct {
 	Channel        ChatChannel
 	ConversationID string `json:"conversation_id"`
 	Message        ChatMessage
+	Nonblock       bool `json:"nonblock"`
 }
 
 func (s sendOptionsV1) Check() error {

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -57,6 +57,7 @@ func (c *chatServiceHandler) ListV1(ctx context.Context, opts listOptionsV1) Rep
 			Status:    utils.VisibleChatConversationStatuses(),
 			TopicType: &topicType,
 		},
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	})
 	if err != nil {
 		return c.errReply(err)
@@ -116,6 +117,7 @@ func (c *chatServiceHandler) ReadV1(ctx context.Context, opts readOptionsV1) Rep
 		Query: &chat1.GetThreadQuery{
 			MarkAsRead: !opts.Peek,
 		},
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	}
 	threadView, err := client.GetThreadLocal(ctx, arg)
 	if err != nil {
@@ -219,6 +221,7 @@ func (c *chatServiceHandler) SendV1(ctx context.Context, opts sendOptionsV1) Rep
 		body:           chat1.NewMessageBodyWithText(chat1.MessageText{Body: opts.Message.Body}),
 		mtype:          chat1.MessageType_TEXT,
 		response:       "message sent",
+		nonblock:       opts.Nonblock,
 	}
 	return c.sendV1(ctx, arg)
 }
@@ -483,10 +486,11 @@ func (c *chatServiceHandler) DownloadV1(ctx context.Context, opts downloadOption
 	}
 
 	arg := chat1.DownloadAttachmentLocalArg{
-		ConversationID: convID,
-		MessageID:      opts.MessageID,
-		Sink:           sink,
-		Preview:        opts.Preview,
+		ConversationID:   convID,
+		MessageID:        opts.MessageID,
+		Sink:             sink,
+		Preview:          opts.Preview,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	}
 
 	dres, err := client.DownloadAttachmentLocal(ctx, arg)
@@ -566,8 +570,9 @@ func (c *chatServiceHandler) SetStatusV1(ctx context.Context, opts setStatusOpti
 	}
 
 	setStatusArg := chat1.SetConversationStatusLocalArg{
-		ConversationID: convID,
-		Status:         status,
+		ConversationID:   convID,
+		Status:           status,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	}
 
 	client, err := GetChatLocalClient(c.G())
@@ -631,6 +636,7 @@ type sendArgV1 struct {
 	supersedes     chat1.MessageID
 	deletes        []chat1.MessageID
 	response       string
+	nonblock       bool
 }
 
 func (c *chatServiceHandler) sendV1(ctx context.Context, arg sendArgV1) Reply {
@@ -650,16 +656,30 @@ func (c *chatServiceHandler) sendV1(ctx context.Context, arg sendArgV1) Reply {
 			ClientHeader: header.clientHeader,
 			MessageBody:  arg.body,
 		},
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	}
 	client, err := GetChatLocalClient(c.G())
 	if err != nil {
 		return c.errReply(err)
 	}
-	plres, err := client.PostLocal(ctx, postArg)
-	if err != nil {
-		return c.errReply(err)
+
+	if arg.nonblock {
+		var nbarg chat1.PostLocalNonblockArg
+		nbarg.ConversationID = postArg.ConversationID
+		nbarg.Msg = postArg.Msg
+		nbarg.IdentifyBehavior = postArg.IdentifyBehavior
+		plres, err := client.PostLocalNonblock(ctx, nbarg)
+		if err != nil {
+			return c.errReply(err)
+		}
+		header.rateLimits = append(header.rateLimits, plres.RateLimits...)
+	} else {
+		plres, err := client.PostLocal(ctx, postArg)
+		if err != nil {
+			return c.errReply(err)
+		}
+		header.rateLimits = append(header.rateLimits, plres.RateLimits...)
 	}
-	header.rateLimits = append(header.rateLimits, plres.RateLimits...)
 
 	res := SendRes{
 		Message: arg.response,


### PR DESCRIPTION
Made the JSON API use CLI mode for identifies, and added a nonblock send option.