### PR TITLE
Fix status timeout

### DIFF
--- a/go/client/cmd_launchd_osx.go
+++ b/go/client/cmd_launchd_osx.go
@@ -283,7 +283,7 @@ func (v *CmdLaunchdStatus) ParseArgv(ctx *cli.Context) error {
 }
 
 func (v *CmdLaunchdStatus) Run() error {
-	serviceStatus, err := install.ServiceStatus(v.G(), v.label, 0, v.G().Log)
+	serviceStatus, err := install.ServiceStatus(v.G(), v.label, defaultLaunchdWait, v.G().Log)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There should be a default timeout here, so that it can wait for service info file with correct pid.