### PR TITLE
send stale notifications when required CORE-4268

### DIFF
--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -177,7 +177,7 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	boxed.ServerHeader = &plres.MsgHeader
 
 	// Write new message out to cache
-	if _, err = s.G().ConvSource.Push(ctx, convID, msg.ClientHeader.Sender, *boxed); err != nil {
+	if _, _, err = s.G().ConvSource.Push(ctx, convID, msg.ClientHeader.Sender, *boxed); err != nil {
 		return chat1.OutboxID{}, 0, nil, err
 	}
 	// TODO: make this cache write work

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -47,6 +47,8 @@ func (n *chatListener) ReachabilityChanged(r keybase1.Reachability)             
 func (n *chatListener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks) {}
 func (n *chatListener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationFinalizeInfo) {
 }
+func (n *chatListener) ChatInboxStale(uid keybase1.UID)                                {}
+func (n *chatListener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {}
 func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActivity) {
 	n.Lock()
 	defer n.Unlock()

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -24,6 +24,7 @@ type Storage struct {
 	libkb.Contextified
 	getSecretUI func() libkb.SecretUI
 	engine      storageEngine
+	idtracker   *msgIDTracker
 }
 
 type storageEngine interface {
@@ -33,8 +34,6 @@ type storageEngine interface {
 		msgs []chat1.MessageUnboxed) libkb.ChatStorageError
 	readMessages(ctx context.Context, res resultCollector,
 		convID chat1.ConversationID, uid gregor1.UID, maxID chat1.MessageID) libkb.ChatStorageError
-	getMaxMessageID(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) (
-		chat1.MessageID, libkb.ChatStorageError)
 }
 
 func New(g *libkb.GlobalContext, getSecretUI func() libkb.SecretUI) *Storage {
@@ -42,6 +41,7 @@ func New(g *libkb.GlobalContext, getSecretUI func() libkb.SecretUI) *Storage {
 		Contextified: libkb.NewContextified(g),
 		getSecretUI:  getSecretUI,
 		engine:       newBlockEngine(g),
+		idtracker:    newMsgIDTracker(g),
 	}
 }
 
@@ -156,6 +156,17 @@ func (s *Storage) MaybeNuke(force bool, err libkb.ChatStorageError, convID chat1
 	return err
 }
 
+func (s *Storage) GetMaxMsgID(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) (chat1.MessageID, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	maxMsgID, err := s.idtracker.getMaxMessageID(ctx, convID, uid)
+	if err != nil {
+		return maxMsgID, s.MaybeNuke(false, err, convID, uid)
+	}
+	return maxMsgID, nil
+}
+
 func (s *Storage) Merge(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageUnboxed) libkb.ChatStorageError {
 	// All public functions get locks to make access to the database single threaded.
 	// They should never be called from private functons.
@@ -184,6 +195,13 @@ func (s *Storage) Merge(ctx context.Context, convID chat1.ConversationID, uid gr
 	// Update supersededBy pointers
 	if err = s.updateAllSupersededBy(ctx, convID, uid, msgs); err != nil {
 		return s.MaybeNuke(false, err, convID, uid)
+	}
+
+	// Update max msg ID if needed
+	if len(msgs) > 0 {
+		if err := s.idtracker.bumpMaxMessageID(ctx, convID, uid, msgs[0].GetMessageID()); err != nil {
+			return s.MaybeNuke(false, err, convID, uid)
+		}
 	}
 
 	return nil
@@ -347,7 +365,7 @@ func (s *Storage) FetchUpToLocalMaxMsgID(ctx context.Context, convID chat1.Conve
 	s.Lock()
 	defer s.Unlock()
 
-	maxMsgID, err := s.engine.getMaxMessageID(ctx, convID, uid)
+	maxMsgID, err := s.idtracker.getMaxMessageID(ctx, convID, uid)
 	if err != nil {
 		return chat1.ThreadView{}, err
 	}

--- a/go/chat/storage/storage_blockengine.go
+++ b/go/chat/storage/storage_blockengine.go
@@ -15,13 +15,11 @@ const blockSize = 100
 
 type blockEngine struct {
 	libkb.Contextified
-	msgIDTracker
 }
 
 func newBlockEngine(g *libkb.GlobalContext) *blockEngine {
 	return &blockEngine{
 		Contextified: libkb.NewContextified(g),
-		msgIDTracker: msgIDTracker{Contextified: libkb.NewContextified(g)},
 	}
 }
 
@@ -329,8 +327,6 @@ func (be *blockEngine) writeMessages(ctx context.Context, convID chat1.Conversat
 		}
 	}
 
-	var maxMsgID chat1.MessageID
-
 	// Append to the block
 	newBlock = maxB
 	for index, msg := range msgs {
@@ -341,20 +337,11 @@ func (be *blockEngine) writeMessages(ctx context.Context, convID chat1.Conversat
 		}
 		newBlock.Msgs[be.getBlockPosition(msgID)] = msg
 		lastWritten = index
-
-		if msg.GetMessageID() > maxMsgID {
-			maxMsgID = msg.GetMessageID()
-		}
 	}
 
 	// Write the block
 	if err = be.writeBlock(ctx, bi, newBlock); err != nil {
 		return libkb.NewChatStorageInternalError(be.G(), "writeMessages: failed to write block: %s", err.Message())
-	}
-
-	// bump max message ID to whatever that has been written
-	if err := be.bumpMaxMessageID(ctx, convID, uid, maxMsgID); err != nil {
-		return err
 	}
 
 	// We didn't write everything out in this block, move to another one

--- a/go/chat/storage/storage_msgengine.go
+++ b/go/chat/storage/storage_msgengine.go
@@ -12,7 +12,6 @@ import (
 
 type msgEngine struct {
 	libkb.Contextified
-	msgIDTracker
 }
 
 type boxedLocalMessage struct {
@@ -34,7 +33,6 @@ func (b boxedLocalMessage) GetMessageType() chat1.MessageType {
 func newMsgEngine(g *libkb.GlobalContext) *msgEngine {
 	return &msgEngine{
 		Contextified: libkb.NewContextified(g),
-		msgIDTracker: msgIDTracker{Contextified: libkb.NewContextified(g)},
 	}
 }
 
@@ -61,8 +59,6 @@ func (ms *msgEngine) writeMessages(ctx context.Context, convID chat1.Conversatio
 	if len(msgs) == 0 {
 		return nil
 	}
-
-	var maxMsgID chat1.MessageID
 
 	// Write out all the messages
 	for _, msg := range msgs {
@@ -107,14 +103,6 @@ func (ms *msgEngine) writeMessages(ctx context.Context, convID chat1.Conversatio
 			return libkb.NewChatStorageInternalError(ms.G(), "writeMessages: failed to write msg: %s",
 				err.Error())
 		}
-
-		if msg.GetMessageID() > maxMsgID {
-			maxMsgID = msg.GetMessageID()
-		}
-	}
-
-	if err := ms.bumpMaxMessageID(ctx, convID, uid, maxMsgID); err != nil {
-		return err
 	}
 
 	return nil

--- a/go/chat/storage/storage_msgid_tracker.go
+++ b/go/chat/storage/storage_msgid_tracker.go
@@ -13,6 +13,12 @@ type msgIDTracker struct {
 	libkb.Contextified
 }
 
+func newMsgIDTracker(g *libkb.GlobalContext) *msgIDTracker {
+	return &msgIDTracker{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
 func (t *msgIDTracker) makeMaxMsgIDKey(convID chat1.ConversationID, uid gregor1.UID) libkb.DbKey {
 	return libkb.DbKey{
 		Typ: libkb.DBChatBlocks,

--- a/go/engine/paperkey_submit_test.go
+++ b/go/engine/paperkey_submit_test.go
@@ -108,3 +108,5 @@ func (n *nlistener) ReachabilityChanged(r keybase1.Reachability)                
 func (n *nlistener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks) {}
 func (n *nlistener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationFinalizeInfo) {
 }
+func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                {}
+func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -515,7 +515,7 @@ type ExternalServicesCollector interface {
 
 type ConversationSource interface {
 	Push(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
-		msg chat1.MessageBoxed) (chat1.MessageUnboxed, error)
+		msg chat1.MessageBoxed) (chat1.MessageUnboxed, bool, error)
 	Pull(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, query *chat1.GetThreadQuery,
 		pagination *chat1.Pagination) (chat1.ThreadView, []*chat1.RateLimit, error)
 	PullLocalOnly(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, query *chat1.GetThreadQuery,

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -42,13 +42,10 @@ type NotifyListener interface {
 	KeyfamilyChanged(uid keybase1.UID)
 	NewChatActivity(uid keybase1.UID, activity chat1.ChatActivity)
 	ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks)
-<<<<<<< HEAD
 	ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID,
 		finalizeInfo chat1.ConversationFinalizeInfo)
-=======
 	ChatInboxStale(uid keybase1.UID)
 	ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID)
->>>>>>> send stale notifications whenever we reconnect to gregor, or detect
 	PGPKeyInSecretStoreFile()
 	BadgeState(badgeState keybase1.BadgeState)
 	ReachabilityChanged(r keybase1.Reachability)
@@ -542,7 +539,11 @@ func (n *NotifyRouter) HandleChatTLFFinalize(ctx context.Context, uid keybase1.U
 			go func() {
 				(chat1.NotifyChatClient{
 					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
-				}).ChatTLFFinalize(context.Background(), uid, convID, finalizeInfo)
+				}).ChatTLFFinalize(context.Background(), chat1.ChatTLFFinalizeArg{
+					Uid:          uid,
+					ConvID:       convID,
+					FinalizeInfo: finalizeInfo,
+				})
 				wg.Done()
 			}()
 		}

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -215,10 +215,21 @@ type ChatTLFFinalizeArg struct {
 	FinalizeInfo ConversationFinalizeInfo `codec:"finalizeInfo" json:"finalizeInfo"`
 }
 
+type ChatInboxStaleArg struct {
+	Uid keybase1.UID `codec:"uid" json:"uid"`
+}
+
+type ChatThreadsStaleArg struct {
+	Uid     keybase1.UID     `codec:"uid" json:"uid"`
+	ConvIDs []ConversationID `codec:"convIDs" json:"convIDs"`
+}
+
 type NotifyChatInterface interface {
 	NewChatActivity(context.Context, NewChatActivityArg) error
 	ChatIdentifyUpdate(context.Context, keybase1.CanonicalTLFNameAndIDWithBreaks) error
 	ChatTLFFinalize(context.Context, ChatTLFFinalizeArg) error
+	ChatInboxStale(context.Context, keybase1.UID) error
+	ChatThreadsStale(context.Context, ChatThreadsStaleArg) error
 }
 
 func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
@@ -273,6 +284,38 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodNotify,
 			},
+			"ChatInboxStale": {
+				MakeArg: func() interface{} {
+					ret := make([]ChatInboxStaleArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ChatInboxStaleArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ChatInboxStaleArg)(nil), args)
+						return
+					}
+					err = i.ChatInboxStale(ctx, (*typedArgs)[0].Uid)
+					return
+				},
+				MethodType: rpc.MethodNotify,
+			},
+			"ChatThreadsStale": {
+				MakeArg: func() interface{} {
+					ret := make([]ChatThreadsStaleArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ChatThreadsStaleArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ChatThreadsStaleArg)(nil), args)
+						return
+					}
+					err = i.ChatThreadsStale(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodNotify,
+			},
 		},
 	}
 }
@@ -294,5 +337,16 @@ func (c NotifyChatClient) ChatIdentifyUpdate(ctx context.Context, update keybase
 
 func (c NotifyChatClient) ChatTLFFinalize(ctx context.Context, __arg ChatTLFFinalizeArg) (err error) {
 	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatTLFFinalize", []interface{}{__arg})
+	return
+}
+
+func (c NotifyChatClient) ChatInboxStale(ctx context.Context, uid keybase1.UID) (err error) {
+	__arg := ChatInboxStaleArg{Uid: uid}
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatInboxStale", []interface{}{__arg})
+	return
+}
+
+func (c NotifyChatClient) ChatThreadsStale(ctx context.Context, __arg ChatThreadsStaleArg) (err error) {
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatThreadsStale", []interface{}{__arg})
 	return
 }

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -104,17 +104,15 @@ func (n *nlistener) PGPKeyInSecretStoreFile()                                   
 func (n *nlistener) FSSyncStatusResponse(arg keybase1.FSSyncStatusArg)                  {}
 func (n *nlistener) FSSyncEvent(arg keybase1.FSPathSyncStatus)                          {}
 func (n *nlistener) ReachabilityChanged(r keybase1.Reachability)                        {}
-<<<<<<< HEAD
 func (n *nlistener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationFinalizeInfo) {
-=======
-func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                    {}
+}
+func (n *nlistener) ChatInboxStale(uid keybase1.UID) {}
 func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {
 	select {
 	case n.threadStale <- cids:
 	case <-time.After(n.testChanTimeout):
 		require.Fail(n.t, "thread send timeout")
 	}
->>>>>>> send stale notifications whenever we reconnect to gregor, or detect
 }
 func (n *nlistener) BadgeState(badgeState keybase1.BadgeState) {
 	select {

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -70,6 +70,7 @@ type nlistener struct {
 	t                *testing.T
 	favoritesChanged []keybase1.UID
 	badgeState       chan keybase1.BadgeState
+	threadStale      chan []chat1.ConversationID
 	testChanTimeout  time.Duration
 }
 
@@ -79,6 +80,7 @@ func newNlistener(t *testing.T) *nlistener {
 	return &nlistener{
 		t:               t,
 		badgeState:      make(chan keybase1.BadgeState, 1),
+		threadStale:     make(chan []chat1.ConversationID, 1),
 		testChanTimeout: 20 * time.Second,
 	}
 }
@@ -102,7 +104,17 @@ func (n *nlistener) PGPKeyInSecretStoreFile()                                   
 func (n *nlistener) FSSyncStatusResponse(arg keybase1.FSSyncStatusArg)                  {}
 func (n *nlistener) FSSyncEvent(arg keybase1.FSPathSyncStatus)                          {}
 func (n *nlistener) ReachabilityChanged(r keybase1.Reachability)                        {}
+<<<<<<< HEAD
 func (n *nlistener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationFinalizeInfo) {
+=======
+func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                    {}
+func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {
+	select {
+	case n.threadStale <- cids:
+	case <-time.After(n.testChanTimeout):
+		require.Fail(n.t, "thread send timeout")
+	}
+>>>>>>> send stale notifications whenever we reconnect to gregor, or detect
 }
 func (n *nlistener) BadgeState(badgeState keybase1.BadgeState) {
 	select {

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -61,4 +61,12 @@ protocol NotifyChat {
   @notify("")
   @lint("ignore")
   void ChatTLFFinalize(keybase1.UID uid, ConversationID convID, ConversationFinalizeInfo finalizeInfo);
+  
+  @notify("")
+  @lint("ignore") 
+  void ChatInboxStale(keybase1.UID uid);
+
+  @notify("")
+  @lint("ignore")
+  void ChatThreadsStale(keybase1.UID uid, array<ConversationID> convIDs);
 }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -936,10 +936,19 @@ export type NotifyChatChatIdentifyUpdateRpcParam = Exact<{
   update: keybase1.CanonicalTLFNameAndIDWithBreaks
 }>
 
+export type NotifyChatChatInboxStaleRpcParam = Exact<{
+  uid: keybase1.UID
+}>
+
 export type NotifyChatChatTLFFinalizeRpcParam = Exact<{
   uid: keybase1.UID,
   convID: ConversationID,
   finalizeInfo: ConversationFinalizeInfo
+}>
+
+export type NotifyChatChatThreadsStaleRpcParam = Exact<{
+  uid: keybase1.UID,
+  convIDs?: ?Array<ConversationID>
 }>
 
 export type NotifyChatNewChatActivityRpcParam = Exact<{
@@ -1480,6 +1489,21 @@ export type incomingCallMapType = Exact<{
       uid: keybase1.UID,
       convID: ConversationID,
       finalizeInfo: ConversationFinalizeInfo
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatInboxStale'?: (
+    params: Exact<{
+      uid: keybase1.UID
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatThreadsStale'?: (
+    params: Exact<{
+      uid: keybase1.UID,
+      convIDs?: ?Array<ConversationID>
     }> /* ,
     response: {} // Notify call
     */

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -194,6 +194,35 @@
       "response": null,
       "notify": "",
       "lint": "ignore"
+    },
+    "ChatInboxStale": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "keybase1.UID"
+        }
+      ],
+      "response": null,
+      "notify": "",
+      "lint": "ignore"
+    },
+    "ChatThreadsStale": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "keybase1.UID"
+        },
+        {
+          "name": "convIDs",
+          "type": {
+            "type": "array",
+            "items": "ConversationID"
+          }
+        }
+      ],
+      "response": null,
+      "notify": "",
+      "lint": "ignore"
     }
   },
   "namespace": "chat.1"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -936,10 +936,19 @@ export type NotifyChatChatIdentifyUpdateRpcParam = Exact<{
   update: keybase1.CanonicalTLFNameAndIDWithBreaks
 }>
 
+export type NotifyChatChatInboxStaleRpcParam = Exact<{
+  uid: keybase1.UID
+}>
+
 export type NotifyChatChatTLFFinalizeRpcParam = Exact<{
   uid: keybase1.UID,
   convID: ConversationID,
   finalizeInfo: ConversationFinalizeInfo
+}>
+
+export type NotifyChatChatThreadsStaleRpcParam = Exact<{
+  uid: keybase1.UID,
+  convIDs?: ?Array<ConversationID>
 }>
 
 export type NotifyChatNewChatActivityRpcParam = Exact<{
@@ -1480,6 +1489,21 @@ export type incomingCallMapType = Exact<{
       uid: keybase1.UID,
       convID: ConversationID,
       finalizeInfo: ConversationFinalizeInfo
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatInboxStale'?: (
+    params: Exact<{
+      uid: keybase1.UID
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatThreadsStale'?: (
+    params: Exact<{
+      uid: keybase1.UID,
+      convIDs?: ?Array<ConversationID>
     }> /* ,
     response: {} // Notify call
     */


### PR DESCRIPTION
The purpose of this patch is to send notifications via `NotifyRouter` that elements of the chat state are stale. Right now, we label the entire inbox stale, as well as some subset of threads. The semantics are the following:

1.) If we disconnect, we notify that everything is stale. The `ChatThreadsStale` RPC will contain an empty list of conversations in this case.
2.) If we detect a Gregor new message that leaves a gap between the most recent we know about, we will generate a `ChatThreadsStale` message with just that conversation ID.

In the future, we might not have to label everything stale on disconnect, but this is the easiest thing to make sure we are consistent in the short-term during connection outages.

cc @chrisnojima 