### PR TITLE
send NotifyRouter message and modify inbox for TLF finalize CORE-4269

### DIFF
--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -182,13 +182,16 @@ func (i *Inbox) NewConversation(vers chat1.InboxVers, conv chat1.ConversationLoc
 		return err
 	}
 
-	// Find any conversations this guy might supersede
+	// Find any conversations this guy might supersede and set supersededBy pointer
 	for index := range ibox.Conversations {
 		iconv := &ibox.Conversations[index]
-		if iconv.Info.FinalizeInfo != nil && iconv.Info.Triple.Tlfid.Eq(conv.Info.Triple.Tlfid) &&
-			iconv.Info.Triple.TopicType == conv.Info.Triple.TopicType {
-			iconv.SupersededBy = append(iconv.SupersededBy, conv.Info.Id)
-			conv.Supersedes = append(conv.Supersedes, iconv.Info.Id)
+		if iconv.Info.FinalizeInfo != nil {
+			continue
+		}
+		for _, super := range conv.Supersedes {
+			if iconv.Info.Id.Eq(super) {
+				iconv.SupersededBy = append(iconv.SupersededBy, conv.Info.Id)
+			}
 		}
 	}
 

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -42,6 +42,8 @@ type NotifyListener interface {
 	KeyfamilyChanged(uid keybase1.UID)
 	NewChatActivity(uid keybase1.UID, activity chat1.ChatActivity)
 	ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks)
+	ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID,
+		finalizeInfo chat1.ConversationFinalizeInfo)
 	PGPKeyInSecretStoreFile()
 	BadgeState(badgeState keybase1.BadgeState)
 	ReachabilityChanged(r keybase1.Reachability)
@@ -521,6 +523,36 @@ func (n *NotifyRouter) HandleChatIdentifyUpdate(ctx context.Context, update keyb
 		n.listener.ChatIdentifyUpdate(update)
 	}
 	n.G().Log.Debug("- Sent ChatIdentifyUpdate notfication")
+}
+
+func (n *NotifyRouter) HandleChatTLFFinalize(ctx context.Context, uid keybase1.UID,
+	convID chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) {
+	if n == nil {
+		return
+	}
+	var wg sync.WaitGroup
+	n.G().Log.Debug("+ Sending ChatTLFFinalize notfication")
+	n.cm.ApplyAll(func(id ConnectionID, xp rpc.Transporter) bool {
+		if n.getNotificationChannels(id).Chat {
+			wg.Add(1)
+			go func() {
+				(chat1.NotifyChatClient{
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+				}).ChatTLFFinalize(context.Background(), chat1.ChatTLFFinalizeArg{
+					Uid:          uid,
+					ConvID:       convID,
+					FinalizeInfo: finalizeInfo,
+				})
+				wg.Done()
+			}()
+		}
+		return true
+	})
+	wg.Wait()
+	if n.listener != nil {
+		n.listener.ChatTLFFinalize(uid, convID, finalizeInfo)
+	}
+	n.G().Log.Debug("- Sent ChatTLFFinalize notfication")
 }
 
 // HandlePaperKeyCached is called whenever a paper key is cached

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -50,6 +50,7 @@ type UnreadUpdate struct {
 type TLFFinalizeUpdate struct {
 	FinalizeInfo ConversationFinalizeInfo `codec:"finalizeInfo" json:"finalizeInfo"`
 	ConvIDs      []ConversationID         `codec:"convIDs" json:"convIDs"`
+	InboxVers    InboxVers                `codec:"inboxVers" json:"inboxVers"`
 }
 
 type GregorInterface interface {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -551,19 +551,22 @@ type UnreadFirstNumLimit struct {
 }
 
 type ConversationInfoLocal struct {
-	Id          ConversationID       `codec:"id" json:"id"`
-	Triple      ConversationIDTriple `codec:"triple" json:"triple"`
-	TlfName     string               `codec:"tlfName" json:"tlfName"`
-	TopicName   string               `codec:"topicName" json:"topicName"`
-	Visibility  TLFVisibility        `codec:"visibility" json:"visibility"`
-	WriterNames []string             `codec:"writerNames" json:"writerNames"`
-	ReaderNames []string             `codec:"readerNames" json:"readerNames"`
+	Id           ConversationID            `codec:"id" json:"id"`
+	Triple       ConversationIDTriple      `codec:"triple" json:"triple"`
+	TlfName      string                    `codec:"tlfName" json:"tlfName"`
+	TopicName    string                    `codec:"topicName" json:"topicName"`
+	Visibility   TLFVisibility             `codec:"visibility" json:"visibility"`
+	WriterNames  []string                  `codec:"writerNames" json:"writerNames"`
+	ReaderNames  []string                  `codec:"readerNames" json:"readerNames"`
+	FinalizeInfo *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
 }
 
 type ConversationLocal struct {
 	Error            *string                       `codec:"error,omitempty" json:"error,omitempty"`
 	Info             ConversationInfoLocal         `codec:"info" json:"info"`
 	ReaderInfo       ConversationReaderInfo        `codec:"readerInfo" json:"readerInfo"`
+	Supersedes       []ConversationID              `codec:"supersedes" json:"supersedes"`
+	SupersededBy     []ConversationID              `codec:"supersededBy" json:"supersededBy"`
 	MaxMessages      []MessageUnboxed              `codec:"maxMessages" json:"maxMessages"`
 	IsEmpty          bool                          `codec:"isEmpty" json:"isEmpty"`
 	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identifyFailures"`

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -342,8 +342,7 @@ func (h *chatLocalHandler) NewConversationLocal(ctx context.Context, arg chat1.N
 		}
 		res.Conv = ib.Convs[0]
 		// Update inbox cache
-		if err = storage.NewInbox(h.G(), uid.ToBytes(),
-			h.getSecretUI).NewConversation(0, storage.FromConversationLocal(res.Conv)); err != nil {
+		if err = storage.NewInbox(h.G(), uid.ToBytes(), h.getSecretUI).NewConversation(0, res.Conv); err != nil {
 			if _, ok := err.(libkb.ChatStorageMissError); !ok {
 				return chat1.NewConversationLocalRes{}, err
 			}

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/keybase/client/go/chat"
 	cstorage "github.com/keybase/client/go/chat/storage"
-	istorage "github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/gregor"
@@ -901,19 +900,28 @@ func (g *gregorHandler) chatTlfFinalize(ctx context.Context, m gregor.OutOfBandM
 
 	g.G().Log.Debug("push handler: tlf finalize received")
 
-	var finalizeInfo chat1.TLFFinalizeUpdate
+	var update chat1.TLFFinalizeUpdate
 	reader := bytes.NewReader(m.Body().Bytes())
 	dec := codec.NewDecoder(reader, &codec.MsgpackHandle{WriteExt: true})
-	err := dec.Decode(&finalizeInfo)
+	err := dec.Decode(&update)
 	if err != nil {
 		return err
 	}
 
 	// Send one for each conversation ID
 	uid := m.UID().String()
-	for _, convID := range finalizeInfo.ConvIDs {
+	for _, convID := range update.ConvIDs {
 		g.G().NotifyRouter.HandleChatTLFFinalize(context.Background(), keybase1.UID(uid),
-			convID, finalizeInfo.FinalizeInfo)
+			convID, update.FinalizeInfo)
+	}
+
+	// Update inbox
+	if err := cstorage.NewInbox(g.G(), m.UID().Bytes(), func() libkb.SecretUI {
+		return chat.DelivererSecretUI{}
+	}).TlfFinalize(update.InboxVers, update.ConvIDs, update.FinalizeInfo); err != nil {
+		if _, ok := (err).(libkb.ChatStorageMissError); !ok {
+			g.G().Log.Error("push handler: tlf finalize: unable to update inbox: %s", err.Error())
+		}
 	}
 
 	return nil
@@ -1066,7 +1074,7 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 
 		if err = cstorage.NewInbox(g.G(), uid, func() libkb.SecretUI {
 			return chat.DelivererSecretUI{}
-		}).NewConversation(nm.InboxVers, istorage.FromConversationLocal(inbox.Convs[0])); err != nil {
+		}).NewConversation(nm.InboxVers, inbox.Convs[0]); err != nil {
 			if _, ok := (err).(libkb.ChatStorageMissError); !ok {
 				g.G().Log.Error("push handler: chat activity: unable to update inbox: %s", err.Error())
 			}

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -908,13 +908,6 @@ func (g *gregorHandler) chatTlfFinalize(ctx context.Context, m gregor.OutOfBandM
 		return err
 	}
 
-	// Send one for each conversation ID
-	uid := m.UID().String()
-	for _, convID := range update.ConvIDs {
-		g.G().NotifyRouter.HandleChatTLFFinalize(context.Background(), keybase1.UID(uid),
-			convID, update.FinalizeInfo)
-	}
-
 	// Update inbox
 	if err := cstorage.NewInbox(g.G(), m.UID().Bytes(), func() libkb.SecretUI {
 		return chat.DelivererSecretUI{}
@@ -922,6 +915,13 @@ func (g *gregorHandler) chatTlfFinalize(ctx context.Context, m gregor.OutOfBandM
 		if _, ok := (err).(libkb.ChatStorageMissError); !ok {
 			g.G().Log.Error("push handler: tlf finalize: unable to update inbox: %s", err.Error())
 		}
+	}
+
+	// Send notify for each conversation ID
+	uid := m.UID().String()
+	for _, convID := range update.ConvIDs {
+		g.G().NotifyRouter.HandleChatTLFFinalize(context.Background(), keybase1.UID(uid),
+			convID, update.FinalizeInfo)
 	}
 
 	return nil

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -52,6 +52,7 @@ protocol gregor {
     record TLFFinalizeUpdate {
         ConversationFinalizeInfo finalizeInfo;
         array<ConversationID> convIDs;
+        InboxVers inboxVers;
     }
 
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -184,6 +184,8 @@ protocol local {
     // Lists of usernames, always complete, optionally sorted by activity.
     array<string> writerNames;
     array<string> readerNames;
+
+    union { null, ConversationFinalizeInfo } finalizeInfo;
   }
 
   // ConversationLocal, whenever present, has a valid `identifyFailures` field that
@@ -193,9 +195,13 @@ protocol local {
     union { null, string } error;
     ConversationInfoLocal info;
     ConversationReaderInfo readerInfo;
+    array<ConversationID> supersedes;
+    array<ConversationID> supersededBy;
+
     array<MessageUnboxed> maxMessages; // the latest message for each message type
-	// Whether this conversation has no content-ful messages.
-	boolean isEmpty;
+	
+    // Whether this conversation has no content-ful messages.
+	  boolean isEmpty;
 
     // This field, if null or empty, indicates identify succeeded without any
     // break.

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -57,4 +57,8 @@ protocol NotifyChat {
   @notify("")
   @lint("ignore")
   void ChatIdentifyUpdate(keybase1.CanonicalTLFNameAndIDWithBreaks update);
+
+  @notify("")
+  @lint("ignore")
+  void ChatTLFFinalize(keybase1.UID uid, ConversationID convID, ConversationFinalizeInfo finalizeInfo);
 }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -545,12 +545,15 @@ export type ConversationInfoLocal = {
   visibility: TLFVisibility,
   writerNames?: ?Array<string>,
   readerNames?: ?Array<string>,
+  finalizeInfo?: ?ConversationFinalizeInfo,
 }
 
 export type ConversationLocal = {
   error?: ?string,
   info: ConversationInfoLocal,
   readerInfo: ConversationReaderInfo,
+  supersedes?: ?Array<ConversationID>,
+  supersededBy?: ?Array<ConversationID>,
   maxMessages?: ?Array<MessageUnboxed>,
   isEmpty: boolean,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
@@ -1052,6 +1055,7 @@ export type SignatureInfo = {
 export type TLFFinalizeUpdate = {
   finalizeInfo: ConversationFinalizeInfo,
   convIDs?: ?Array<ConversationID>,
+  inboxVers: InboxVers,
 }
 
 export type TLFID = bytes

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -933,6 +933,12 @@ export type NotifyChatChatIdentifyUpdateRpcParam = Exact<{
   update: keybase1.CanonicalTLFNameAndIDWithBreaks
 }>
 
+export type NotifyChatChatTLFFinalizeRpcParam = Exact<{
+  uid: keybase1.UID,
+  convID: ConversationID,
+  finalizeInfo: ConversationFinalizeInfo
+}>
+
 export type NotifyChatNewChatActivityRpcParam = Exact<{
   uid: keybase1.UID,
   activity: ChatActivity
@@ -1461,6 +1467,15 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatIdentifyUpdate'?: (
     params: Exact<{
       update: keybase1.CanonicalTLFNameAndIDWithBreaks
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatTLFFinalize'?: (
+    params: Exact<{
+      uid: keybase1.UID,
+      convID: ConversationID,
+      finalizeInfo: ConversationFinalizeInfo
     }> /* ,
     response: {} // Notify call
     */

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -158,6 +158,10 @@
             "items": "ConversationID"
           },
           "name": "convIDs"
+        },
+        {
+          "type": "InboxVers",
+          "name": "inboxVers"
         }
       ]
     }

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -558,6 +558,13 @@
             "items": "string"
           },
           "name": "readerNames"
+        },
+        {
+          "type": [
+            null,
+            "ConversationFinalizeInfo"
+          ],
+          "name": "finalizeInfo"
         }
       ]
     },
@@ -579,6 +586,20 @@
         {
           "type": "ConversationReaderInfo",
           "name": "readerInfo"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "ConversationID"
+          },
+          "name": "supersedes"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "ConversationID"
+          },
+          "name": "supersededBy"
         },
         {
           "type": {

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -175,6 +175,25 @@
       "response": null,
       "notify": "",
       "lint": "ignore"
+    },
+    "ChatTLFFinalize": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "keybase1.UID"
+        },
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "finalizeInfo",
+          "type": "ConversationFinalizeInfo"
+        }
+      ],
+      "response": null,
+      "notify": "",
+      "lint": "ignore"
     }
   },
   "namespace": "chat.1"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -545,12 +545,15 @@ export type ConversationInfoLocal = {
   visibility: TLFVisibility,
   writerNames?: ?Array<string>,
   readerNames?: ?Array<string>,
+  finalizeInfo?: ?ConversationFinalizeInfo,
 }
 
 export type ConversationLocal = {
   error?: ?string,
   info: ConversationInfoLocal,
   readerInfo: ConversationReaderInfo,
+  supersedes?: ?Array<ConversationID>,
+  supersededBy?: ?Array<ConversationID>,
   maxMessages?: ?Array<MessageUnboxed>,
   isEmpty: boolean,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
@@ -1052,6 +1055,7 @@ export type SignatureInfo = {
 export type TLFFinalizeUpdate = {
   finalizeInfo: ConversationFinalizeInfo,
   convIDs?: ?Array<ConversationID>,
+  inboxVers: InboxVers,
 }
 
 export type TLFID = bytes

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -933,6 +933,12 @@ export type NotifyChatChatIdentifyUpdateRpcParam = Exact<{
   update: keybase1.CanonicalTLFNameAndIDWithBreaks
 }>
 
+export type NotifyChatChatTLFFinalizeRpcParam = Exact<{
+  uid: keybase1.UID,
+  convID: ConversationID,
+  finalizeInfo: ConversationFinalizeInfo
+}>
+
 export type NotifyChatNewChatActivityRpcParam = Exact<{
   uid: keybase1.UID,
   activity: ChatActivity
@@ -1461,6 +1467,15 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatIdentifyUpdate'?: (
     params: Exact<{
       update: keybase1.CanonicalTLFNameAndIDWithBreaks
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatTLFFinalize'?: (
+    params: Exact<{
+      uid: keybase1.UID,
+      convID: ConversationID,
+      finalizeInfo: ConversationFinalizeInfo
     }> /* ,
     response: {} // Notify call
     */


### PR DESCRIPTION
The purpose of this commit is the following:

1.) Send a notification to the frontend alerting that a TLF finalize has just taken place. 
2.) Modify the on-disk inbox to reflect the TLF finalize as well, and also change `NewConversation` to properly set `supersededBy` pointers.