### PR TITLE
use net.context.Context-based logging along the ID2 path

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -101,7 +101,7 @@ func (b *Boxer) UnboxMessage(ctx context.Context, finder KeyFinder, boxed chat1.
 	}
 	pt := umwkr.messagePlaintext
 
-	username, deviceName, deviceType, err := b.getSenderInfoLocal(pt.ClientHeader)
+	username, deviceName, deviceType, err := b.getSenderInfoLocal(ctx, pt.ClientHeader)
 	if err != nil {
 		b.log().Warning("unable to fetch sender informaton: UID: %s deviceID: %s",
 			pt.ClientHeader.Sender, pt.ClientHeader.SenderDevice)
@@ -256,18 +256,18 @@ func (b *Boxer) UnboxThread(ctx context.Context, boxed chat1.ThreadViewBoxed, co
 	return thread, nil
 }
 
-func (b *Boxer) getUsernameAndDevice(uid keybase1.UID, deviceID keybase1.DeviceID) (string, string, string, error) {
+func (b *Boxer) getUsernameAndDevice(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (string, string, string, error) {
 	udc := b.kbCtx.GetUserDeviceCache()
 	if udc == nil {
 		return "", "", "", fmt.Errorf("missing UserDeviceCache")
 	}
-	return udc.LookupUsernameAndDevice(uid, deviceID)
+	return udc.LookupUsernameAndDevice(ctx, uid, deviceID)
 }
 
-func (b *Boxer) getSenderInfoLocal(clientHeader chat1.MessageClientHeader) (senderUsername string, senderDeviceName string, senderDeviceType string, err error) {
+func (b *Boxer) getSenderInfoLocal(ctx context.Context, clientHeader chat1.MessageClientHeader) (senderUsername string, senderDeviceName string, senderDeviceType string, err error) {
 	uid := keybase1.UID(clientHeader.Sender.String())
 	did := keybase1.DeviceID(clientHeader.SenderDevice.String())
-	return b.getUsernameAndDevice(uid, did)
+	return b.getUsernameAndDevice(ctx, uid, did)
 }
 
 func (b *Boxer) UnboxMessages(ctx context.Context, boxed []chat1.MessageBoxed) (unboxed []chat1.MessageUnboxed, err error) {
@@ -555,7 +555,7 @@ func (b *Boxer) ValidSenderKey(ctx context.Context, sender gregor1.UID, key []by
 		return false, nil, libkb.NewTransientChatUnboxingError(fmt.Errorf("no CachedUserLoader available in context"))
 	}
 
-	found, revokedAt, err := cachedUserLoader.CheckKIDForUID(kbSender, kid)
+	found, revokedAt, err := cachedUserLoader.CheckKIDForUID(ctx, kbSender, kid)
 	if err != nil {
 		return false, nil, libkb.NewTransientChatUnboxingError(err)
 	}

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -423,6 +423,7 @@ func (s *localizer) localizeConversation(ctx context.Context, uid gregor1.UID,
 	conversationLocal.Info.TlfName = info.CanonicalName
 
 	conversationLocal.Info.WriterNames, conversationLocal.Info.ReaderNames, err = utils.ReorderParticipants(
+		ctx,
 		s.G().GetUserDeviceCache(),
 		conversationLocal.Info.TlfName,
 		conversationRemote.Metadata.ActiveList)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -115,7 +115,7 @@ func AggRateLimits(rlimits []chat1.RateLimit) (res []chat1.RateLimit) {
 // Reorder participants based on the order in activeList.
 // Only allows usernames from tlfname in the output.
 // This never fails, worse comes to worst it just returns the split of tlfname.
-func ReorderParticipants(udc *libkb.UserDeviceCache, tlfname string, activeList []gregor1.UID) (writerNames []string, readerNames []string, err error) {
+func ReorderParticipants(ctx context.Context, udc *libkb.UserDeviceCache, tlfname string, activeList []gregor1.UID) (writerNames []string, readerNames []string, err error) {
 	srcWriterNames, srcReaderNames, _, err := splitAndNormalizeTLFNameCanonicalize(tlfname, false)
 	if err != nil {
 		return writerNames, readerNames, err
@@ -131,7 +131,7 @@ func ReorderParticipants(udc *libkb.UserDeviceCache, tlfname string, activeList 
 	// Fill from the active list first.
 	for _, uid := range activeList {
 		kbUID := keybase1.UID(uid.String())
-		user, err := udc.LookupUsername(kbUID)
+		user, err := udc.LookupUsername(ctx, kbUID)
 		if err != nil {
 			continue
 		}

--- a/go/client/chat_ui.go
+++ b/go/client/chat_ui.go
@@ -129,7 +129,7 @@ func (c *ChatUI) ChatInboxFailed(ctx context.Context, arg chat1.ChatInboxFailedA
 	return nil
 }
 
-func (c *ChatUI) getUnverifiedConvo(conv chat1.Conversation) (chat1.ConversationLocal, error) {
+func (c *ChatUI) getUnverifiedConvo(ctx context.Context, conv chat1.Conversation) (chat1.ConversationLocal, error) {
 
 	if len(conv.MaxMsgs) == 0 {
 		return chat1.ConversationLocal{}, fmt.Errorf("no max messages")
@@ -147,7 +147,7 @@ func (c *ChatUI) getUnverifiedConvo(conv chat1.Conversation) (chat1.Conversation
 		return chat1.ConversationLocal{}, fmt.Errorf("no text message found")
 	}
 
-	rnames, wnames, err := utils.ReorderParticipants(c.G().UserDeviceCache,
+	rnames, wnames, err := utils.ReorderParticipants(ctx, c.G().UserDeviceCache,
 		txtMsg.ClientHeader.TlfName, conv.Metadata.ActiveList)
 	if err != nil {
 		return chat1.ConversationLocal{}, err
@@ -185,7 +185,7 @@ func (c *ChatUI) ChatInboxUnverified(ctx context.Context, arg chat1.ChatInboxUnv
 
 	var convs []chat1.ConversationLocal
 	for _, conv := range arg.Inbox.ConversationsUnverified {
-		convLocal, err := c.getUnverifiedConvo(conv)
+		convLocal, err := c.getUnverifiedConvo(ctx, conv)
 		if err != nil {
 			c.G().Log.Error("unable to convert unverified conv: %s", err.Error())
 			continue

--- a/go/engine/cached_user_loader_test.go
+++ b/go/engine/cached_user_loader_test.go
@@ -53,7 +53,7 @@ func TestLoadDeviceKeyNew(t *testing.T) {
 	t.Logf("using device1:%+v", device1.ID)
 
 	t.Logf("load existing device key")
-	upk, deviceKey, revoked, err := tc.G.CachedUserLoader.LoadDeviceKey(user.GetUID(), device1.ID)
+	upk, deviceKey, revoked, err := tc.G.CachedUserLoader.LoadDeviceKey(nil, user.GetUID(), device1.ID)
 	require.NoError(t, err)
 	require.Equal(t, user.GetNormalizedName().String(), upk.Base.Username, "usernames must match")
 	require.Equal(t, device1.ID, deviceKey.DeviceID, "deviceID must match")
@@ -103,7 +103,7 @@ func TestLoadDeviceKeyNew(t *testing.T) {
 	t.Logf("using device2:%+v", device2.ID)
 
 	t.Logf("load brand new device (while old is cached)")
-	upk, deviceKey, revoked, err = tc.G.CachedUserLoader.LoadDeviceKey(user.GetUID(), device2.ID)
+	upk, deviceKey, revoked, err = tc.G.CachedUserLoader.LoadDeviceKey(nil, user.GetUID(), device2.ID)
 	require.NoError(t, err)
 	require.Equal(t, user.GetNormalizedName().String(), upk.Base.Username, "usernames must match")
 	require.Equal(t, device2.ID, deviceKey.DeviceID, "deviceID must match")
@@ -144,7 +144,7 @@ func TestLoadDeviceKeyRevoked(t *testing.T) {
 	assertNumDevicesAndKeys(tc, fu, 1, 2)
 
 	t.Logf("load revoked device")
-	upk, deviceKey, revoked, err := tc.G.CachedUserLoader.LoadDeviceKey(user.GetUID(), thisDevice.ID)
+	upk, deviceKey, revoked, err := tc.G.CachedUserLoader.LoadDeviceKey(nil, user.GetUID(), thisDevice.ID)
 	require.NoError(t, err)
 	require.Equal(t, user.GetNormalizedName().String(), upk.Base.Username, "usernames must match")
 	require.Equal(t, thisDevice.ID, deviceKey.DeviceID, "deviceID must match")

--- a/go/engine/context.go
+++ b/go/engine/context.go
@@ -5,11 +5,8 @@ package engine
 
 import (
 	"fmt"
-
-	"golang.org/x/net/context"
-
 	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/logger"
+	"golang.org/x/net/context"
 )
 
 type Context struct {
@@ -70,24 +67,7 @@ func (c *Context) SecretKeyPromptArg(ska libkb.SecretKeyArg, reason string) libk
 }
 
 func (c *Context) CloneGlobalContextWithLogTags(g *libkb.GlobalContext, k string) *libkb.GlobalContext {
-	netCtx := c.GetNetContext()
-	gen := true
-	if tags, ok := logger.LogTagsFromContext(netCtx); ok {
-		if _, found := tags[k]; found {
-			gen = false
-		}
-	}
-	if gen {
-		newTags := make(logger.CtxLogTags)
-		newTags[k] = k
-		netCtx = logger.NewContextWithLogTags(netCtx, newTags)
-	}
-
-	if _, found := netCtx.Value(k).(string); !found {
-		tag, _ := libkb.RandString("", 5)
-		netCtx = context.WithValue(netCtx, k, tag)
-	}
+	netCtx := libkb.WithLogTag(c.GetNetContext(), k)
 	c.NetContext = netCtx
-
 	return g.CloneWithNewNetContext(netCtx)
 }

--- a/go/engine/context.go
+++ b/go/engine/context.go
@@ -69,5 +69,5 @@ func (c *Context) SecretKeyPromptArg(ska libkb.SecretKeyArg, reason string) libk
 func (c *Context) CloneGlobalContextWithLogTags(g *libkb.GlobalContext, k string) *libkb.GlobalContext {
 	netCtx := libkb.WithLogTag(c.GetNetContext(), k)
 	c.NetContext = netCtx
-	return g.CloneWithNewNetContext(netCtx)
+	return g.CloneWithNetContextAndNewLogger(netCtx)
 }

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -259,8 +259,8 @@ func (e *Identify2WithUID) Run(ctx *Context) (err error) {
 
 	e.SetGlobalContext(ctx.CloneGlobalContextWithLogTags(e.G(), "ID2"))
 
-	defer libkb.TimeLog(fmt.Sprintf("Identify2WithUID.Run(UID=%v, Assertion=%s", e.arg.Uid, e.arg.UserAssertion), e.G().Clock().Now(), e.G().Log.Debug)
-	e.G().Log.Debug("+ Identify2WithUID.Run(UID=%v, Assertion=%s)", e.arg.Uid, e.arg.UserAssertion)
+	n := fmt.Sprintf("Identify2WithUID#Run(UID=%v, Assertion=%s)", e.arg.Uid, e.arg.UserAssertion)
+	defer e.G().CTraceTimed(ctx.GetNetContext(), n, func() error { return err })()
 	e.G().Log.Debug("| Full Arg: %+v", e.arg)
 
 	if e.arg.Uid.IsNil() {
@@ -277,9 +277,6 @@ func (e *Identify2WithUID) Run(ctx *Context) (err error) {
 
 	// Potentially reset the error based on the error and the calling context.
 	err = e.resetError(err)
-
-	e.G().Log.Debug("- Identify2WithUID.Run() -> %v", err)
-
 	return err
 }
 

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -129,6 +129,7 @@ func (i *identifyUser) isNil() bool {
 }
 
 func loadIdentifyUser(g *libkb.GlobalContext, arg libkb.LoadUserArg, cache libkb.Identify2Cacher) (*identifyUser, error) {
+	arg.SetGlobalContext(g)
 	ret := &identifyUser{arg: arg}
 	err := ret.load(g)
 	if ret.isNil() {
@@ -254,6 +255,9 @@ func (e *Identify2WithUID) resetError(err error) error {
 
 // Run then engine
 func (e *Identify2WithUID) Run(ctx *Context) (err error) {
+
+	e.SetGlobalContext(ctx.CloneGlobalContextWithLogTags(e.G(), "id2"))
+
 	defer libkb.TimeLog(fmt.Sprintf("Identify2WithUID.Run(UID=%v, Assertion=%s", e.arg.Uid, e.arg.UserAssertion), e.G().Clock().Now(), e.G().Log.Debug)
 	e.G().Log.Debug("+ Identify2WithUID.Run(UID=%v, Assertion=%s)", e.arg.Uid, e.arg.UserAssertion)
 	e.G().Log.Debug("| Full Arg: %+v", e.arg)
@@ -309,7 +313,7 @@ func (e *Identify2WithUID) hitFastCache() bool {
 func (e *Identify2WithUID) runReturnError(ctx *Context) (err error) {
 
 	e.G().Log.Debug("+ acquire singleflight lock for %s", e.arg.Uid)
-	lock := locktab.AcquireOnName(e.arg.Uid.String())
+	lock := locktab.AcquireOnName(e.G(), e.arg.Uid.String())
 	e.G().Log.Debug("- acquired singleflight lock")
 
 	defer func() {

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -588,7 +588,7 @@ func (e *Identify2WithUID) runIdentifyUI(ctx *Context) (err error) {
 		return err
 	}
 
-	if err = them.IDTable().Identify(e.state, e.forceRemoteCheck(), iui, e); err != nil {
+	if err = them.IDTable().Identify(ctx.GetNetContext(), e.state, e.forceRemoteCheck(), iui, e); err != nil {
 		e.G().Log.Debug("| Failure in running IDTable")
 		return err
 	}

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -81,7 +81,7 @@ func (e *PGPEncrypt) Run(ctx *Context) error {
 			return libkb.LoginRequiredError{Context: "you must be logged in to encrypt for yourself"}
 		}
 	} else {
-		me, err := libkb.LoadMeByUID(e.G(), uid)
+		me, err := libkb.LoadMeByUID(ctx.GetNetContext(), e.G(), uid)
 		if err != nil {
 			return err
 		}

--- a/go/engine/pgp_pull.go
+++ b/go/engine/pgp_pull.go
@@ -170,7 +170,7 @@ func (e *PGPPullEngine) processUserWhenLoggedOut(ctx *Context, u string) error {
 	}
 	// with more plumbing, there is likely a more efficient way to get this identified user out
 	// of the identify2 engine, but `pgp pull` is not likely to be called often.
-	arg := libkb.NewLoadUserByUIDArg(e.G(), idRes.Upk.Uid)
+	arg := libkb.NewLoadUserByUIDArg(ctx.GetNetContext(), e.G(), idRes.Upk.Uid)
 	user, err := libkb.LoadUser(arg)
 	if err != nil {
 		return err

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -100,7 +100,7 @@ func (e *ResolveThenIdentify2) resolveUID(ctx *Context) (err error) {
 }
 
 func (e *ResolveThenIdentify2) Run(ctx *Context) (err error) {
-	e.SetGlobalContext(ctx.CloneGlobalContextWithLogTags(e.G(), "id2"))
+	e.SetGlobalContext(ctx.CloneGlobalContextWithLogTags(e.G(), "ID2"))
 
 	defer libkb.TimeLog(fmt.Sprintf("ResolveThenIdentify2: %+v", e.arg), e.G().Clock().Now(), e.G().Log.Debug)
 	defer e.G().Trace("ResolveThenIdentify2::Run", func() error { return err })()

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -81,7 +81,7 @@ func (e *ResolveThenIdentify2) resolveUID(ctx *Context) (err error) {
 		return libkb.LoginRequiredError{Context: "to identify without specifying a user assertion"}
 	}
 
-	rres := e.G().Resolver.ResolveFullExpressionWithBody(e.arg.UserAssertion)
+	rres := e.G().Resolver.ResolveFullExpressionWithBody(ctx.GetNetContext(), e.arg.UserAssertion)
 	if err = rres.GetError(); err != nil {
 		return err
 	}
@@ -100,6 +100,8 @@ func (e *ResolveThenIdentify2) resolveUID(ctx *Context) (err error) {
 }
 
 func (e *ResolveThenIdentify2) Run(ctx *Context) (err error) {
+	e.SetGlobalContext(ctx.CloneGlobalContextWithLogTags(e.G(), "id2"))
+
 	defer libkb.TimeLog(fmt.Sprintf("ResolveThenIdentify2: %+v", e.arg), e.G().Clock().Now(), e.G().Log.Debug)
 	defer e.G().Trace("ResolveThenIdentify2::Run", func() error { return err })()
 

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -4,8 +4,6 @@
 package engine
 
 import (
-	"fmt"
-
 	gregor "github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -102,8 +100,7 @@ func (e *ResolveThenIdentify2) resolveUID(ctx *Context) (err error) {
 func (e *ResolveThenIdentify2) Run(ctx *Context) (err error) {
 	e.SetGlobalContext(ctx.CloneGlobalContextWithLogTags(e.G(), "ID2"))
 
-	defer libkb.TimeLog(fmt.Sprintf("ResolveThenIdentify2: %+v", e.arg), e.G().Clock().Now(), e.G().Log.Debug)
-	defer e.G().Trace("ResolveThenIdentify2::Run", func() error { return err })()
+	defer e.G().CTraceTimed(ctx.GetNetContext(), "ResolveThenIdentify2#Run", func() error { return err })()
 
 	e.i2eng = NewIdentify2WithUID(e.G(), e.arg)
 	if e.responsibleGregorItem != nil {

--- a/go/engine/saltpack_encrypt.go
+++ b/go/engine/saltpack_encrypt.go
@@ -82,7 +82,7 @@ func (e *SaltpackEncrypt) loadMe(ctx *Context) error {
 	if err != nil || !loggedIn {
 		return err
 	}
-	e.me, err = libkb.LoadMeByUID(e.G(), uid)
+	e.me, err = libkb.LoadMeByUID(ctx.GetNetContext(), e.G(), uid)
 	return err
 }
 

--- a/go/engine/track.go
+++ b/go/engine/track.go
@@ -71,7 +71,7 @@ func (e *TrackEngine) Run(ctx *Context) error {
 
 	upk := ieng.Result().Upk
 	var err error
-	e.them, err = libkb.LoadUser(libkb.NewLoadUserByUIDArg(e.G(), upk.Uid))
+	e.them, err = libkb.LoadUser(libkb.NewLoadUserByUIDArg(ctx.GetNetContext(), e.G(), upk.Uid))
 	if err != nil {
 		return err
 	}

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -364,7 +364,7 @@ func TestIdentifyTrackRaceDetection(t *testing.T) {
 			// We might have used the fact the userchanged notifications are bounced
 			// off of the server, but that might slow down this test, so do the
 			// simple and non-flakey thing.
-			dev2.G.CachedUserLoader.Invalidate(libkb.UsernameToUID(user.Username))
+			dev2.G.CachedUserLoader.Invalidate(nil, libkb.UsernameToUID(user.Username))
 		}
 		doID(dev2, fui2)
 		trackSucceed(dev1, fui1)

--- a/go/engine/user_card.go
+++ b/go/engine/user_card.go
@@ -45,6 +45,7 @@ func getUserCard(g *libkb.GlobalContext, uid keybase1.UID, useSession bool) (ret
 		Endpoint:    "user/card",
 		NeedSession: useSession,
 		Args:        libkb.HTTPArgs{"uid": libkb.S{Val: uid.String()}},
+		NetContext:  g.NetContext,
 	}
 
 	var card card

--- a/go/engine/user_test.go
+++ b/go/engine/user_test.go
@@ -19,7 +19,7 @@ func TestLoadUserPlusKeysHasKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	up, err := libkb.LoadUserPlusKeys(tc.G, me.GetUID())
+	up, err := libkb.LoadUserPlusKeys(nil, tc.G, me.GetUID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestLoadUserPlusKeysRevoked(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	up, err := libkb.LoadUserPlusKeys(tc.G, me.GetUID())
+	up, err := libkb.LoadUserPlusKeys(nil, tc.G, me.GetUID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestLoadUserPlusKeysRevoked(t *testing.T) {
 	}
 	fakeClock.Advance(libkb.CachedUserTimeout + 2*time.Second)
 
-	up2, err := libkb.LoadUserPlusKeys(tc.G, me.GetUID())
+	up2, err := libkb.LoadUserPlusKeys(nil, tc.G, me.GetUID())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/externals/proof_support_coinbase.go
+++ b/go/externals/proof_support_coinbase.go
@@ -58,7 +58,7 @@ func (rc *CoinbaseChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) 
 
 func (rc *CoinbaseChecker) CheckStatusOld(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	url := h.GetAPIURL()
-	res, err := ctx.GetExternalAPI().GetHTML(libkb.NewAPIArg(url))
+	res, err := ctx.GetExternalAPI().GetHTML(libkb.NewAPIArgWithNetContext(ctx.GetNetContext(), url))
 	if err != nil {
 		return libkb.XapiError(err, url)
 	}
@@ -121,7 +121,7 @@ func (t CoinbaseServiceType) GetPrompt() string {
 }
 
 func (t CoinbaseServiceType) PreProofCheck(ctx libkb.ProofContext, normalizedUsername string) (*libkb.Markup, error) {
-	_, err := ctx.GetExternalAPI().GetHTML(libkb.NewAPIArg(coinbaseUserURL(normalizedUsername)))
+	_, err := ctx.GetExternalAPI().GetHTML(libkb.NewAPIArgWithNetContext(ctx.GetNetContext(), coinbaseUserURL(normalizedUsername)))
 	if err != nil {
 		if ae, ok := err.(*libkb.APIError); ok && ae.Code == 404 {
 			err = libkb.NewProfileNotPublicError(fmt.Sprintf("%s isn't public! Change your settings at %s",

--- a/go/externals/proof_support_facebook.go
+++ b/go/externals/proof_support_facebook.go
@@ -99,7 +99,7 @@ func (rc *FacebookChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) 
 func (rc *FacebookChecker) CheckStatusOld(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	desktopURL := makeDesktopURL(h.GetAPIURL())
 
-	res, err := ctx.GetExternalAPI().GetHTML(libkb.NewAPIArg(desktopURL))
+	res, err := ctx.GetExternalAPI().GetHTML(libkb.NewAPIArgWithNetContext(ctx.GetNetContext(), desktopURL))
 	if err != nil {
 		return libkb.XapiError(err, desktopURL)
 	}

--- a/go/externals/proof_support_github.go
+++ b/go/externals/proof_support_github.go
@@ -55,7 +55,7 @@ func (rc *GithubChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) li
 }
 
 func (rc *GithubChecker) CheckStatusOld(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
-	res, err := ctx.GetExternalAPI().GetText(libkb.NewAPIArg(h.GetAPIURL()))
+	res, err := ctx.GetExternalAPI().GetText(libkb.NewAPIArgWithNetContext(ctx.GetNetContext(), h.GetAPIURL()))
 
 	if err != nil {
 		return libkb.XapiError(err, h.GetAPIURL())

--- a/go/externals/proof_support_hackernews.go
+++ b/go/externals/proof_support_hackernews.go
@@ -73,7 +73,7 @@ func (h *HackerNewsChecker) CheckStatus(ctx libkb.ProofContext, hint libkb.SigHi
 }
 
 func (h *HackerNewsChecker) CheckStatusOld(ctx libkb.ProofContext, hint libkb.SigHint) libkb.ProofError {
-	res, err := ctx.GetExternalAPI().GetText(libkb.NewAPIArg(hint.GetAPIURL()))
+	res, err := ctx.GetExternalAPI().GetText(libkb.NewAPIArgWithNetContext(ctx.GetNetContext(), hint.GetAPIURL()))
 
 	if err != nil {
 		return libkb.XapiError(err, hint.GetAPIURL())
@@ -101,7 +101,7 @@ func (h *HackerNewsChecker) CheckStatusOld(ctx libkb.ProofContext, hint libkb.Si
 
 func CheckKarma(ctx libkb.ProofContext, un string) (int, error) {
 	u := KarmaURL(un)
-	res, err := ctx.GetExternalAPI().Get(libkb.NewAPIArg(u))
+	res, err := ctx.GetExternalAPI().Get(libkb.NewAPIArgWithNetContext(ctx.GetNetContext(), u))
 	if err != nil {
 		return 0, libkb.XapiError(err, u)
 	}

--- a/go/externals/proof_support_reddit.go
+++ b/go/externals/proof_support_reddit.go
@@ -126,7 +126,7 @@ func (rc *RedditChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) li
 }
 
 func (rc *RedditChecker) CheckStatusOld(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
-	res, err := ctx.GetExternalAPI().Get(libkb.NewAPIArg(h.GetAPIURL()))
+	res, err := ctx.GetExternalAPI().Get(libkb.NewAPIArgWithNetContext(ctx.GetNetContext(), h.GetAPIURL()))
 	if err != nil {
 		return libkb.XapiError(err, h.GetAPIURL())
 	}

--- a/go/externals/proof_support_rooter.go
+++ b/go/externals/proof_support_rooter.go
@@ -153,7 +153,7 @@ func (rc *RooterChecker) CheckStatusOld(ctx libkb.ProofContext, h libkb.SigHint)
 	}
 	ctx.GetLog().Debug("| URL after rewriter is: %s", url)
 
-	res, err := ctx.GetExternalAPI().Get(libkb.NewAPIArg(url))
+	res, err := ctx.GetExternalAPI().Get(libkb.NewAPIArgWithNetContext(ctx.GetNetContext(), url))
 
 	if err != nil {
 		perr = libkb.XapiError(err, url)

--- a/go/externals/proof_support_twitter.go
+++ b/go/externals/proof_support_twitter.go
@@ -100,7 +100,7 @@ func (rc *TwitterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) l
 
 func (rc *TwitterChecker) CheckStatusOld(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
 	url := h.GetAPIURL()
-	res, err := ctx.GetExternalAPI().GetHTML(libkb.NewAPIArg(url))
+	res, err := ctx.GetExternalAPI().GetHTML(libkb.NewAPIArgWithNetContext(ctx.GetNetContext(), url))
 	if err != nil {
 		return libkb.XapiError(err, url)
 	}

--- a/go/externals/proof_support_web.go
+++ b/go/externals/proof_support_web.go
@@ -73,7 +73,7 @@ func (rc *WebChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb
 }
 
 func (rc *WebChecker) CheckStatusOld(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
-	res, err := ctx.GetExternalAPI().GetText(libkb.NewAPIArg(h.GetAPIURL()))
+	res, err := ctx.GetExternalAPI().GetText(libkb.NewAPIArgWithNetContext(ctx.GetNetContext(), h.GetAPIURL()))
 
 	if err != nil {
 		return libkb.XapiError(err, h.GetAPIURL())

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -137,13 +137,13 @@ func (api *BaseAPIEngine) getCli(cookied bool) (ret *Client) {
 func (api *BaseAPIEngine) PrepareGet(url1 url.URL, arg APIArg) (*http.Request, error) {
 	url1.RawQuery = arg.getHTTPArgs().Encode()
 	ruri := url1.String()
-	api.G().Log.Debug("+ API GET request to %s", ruri)
+	api.G().Log.CDebugf(arg.NetContext, "+ API GET request to %s", ruri)
 	return http.NewRequest("GET", ruri, nil)
 }
 
 func (api *BaseAPIEngine) PreparePost(url1 url.URL, arg APIArg, sendJSON bool) (*http.Request, error) {
 	ruri := url1.String()
-	api.G().Log.Debug(fmt.Sprintf("+ API Post request to %s", ruri))
+	api.G().Log.CDebugf(arg.NetContext, fmt.Sprintf("+ API Post request to %s", ruri))
 
 	var body io.Reader
 
@@ -193,7 +193,7 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 	}
 
 	dbg := func(s string) {
-		api.G().Log.Debug(fmt.Sprintf("| doRequestShared(%s) for %s", s, arg.Endpoint))
+		api.G().Log.CDebugf(arg.NetContext, fmt.Sprintf("| doRequestShared(%s) for %s", s, arg.Endpoint))
 	}
 
 	dbg("fixHeaders")
@@ -210,7 +210,7 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 	if api.G().Env.GetAPIDump() {
 		jpStr, _ := json.MarshalIndent(arg.JSONPayload, "", "  ")
 		argStr, _ := json.MarshalIndent(arg.getHTTPArgs(), "", "  ")
-		api.G().Log.Debug(fmt.Sprintf("| full request: json:%s querystring:%s", jpStr, argStr))
+		api.G().Log.CDebugf(arg.NetContext, fmt.Sprintf("| full request: json:%s querystring:%s", jpStr, argStr))
 	}
 
 	timer := api.G().Timers.Start(timerType)
@@ -230,7 +230,7 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 	if err != nil {
 		return nil, nil, APINetError{err: err}
 	}
-	api.G().Log.Debug(fmt.Sprintf("| Result is: %s", internalResp.Status))
+	api.G().Log.CDebugf(arg.NetContext, fmt.Sprintf("| Result is: %s", internalResp.Status))
 
 	// The server sends "client version out of date" messages through the API
 	// headers. If the client is *really* out of date, the request status will
@@ -260,7 +260,7 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 		jw = jsonw.NewWrapper(obj)
 		if api.G().Env.GetAPIDump() {
 			b, _ := json.MarshalIndent(obj, "", "  ")
-			api.G().Log.Debug(fmt.Sprintf("| full reply: %s", b))
+			api.G().Log.CDebugf(arg.NetContext, fmt.Sprintf("| full reply: %s", b))
 		}
 	}
 
@@ -293,7 +293,7 @@ func doRetry(g Contextifier, arg APIArg, cli *Client, req *http.Request) (*http.
 	var lastErr error
 	for i := 0; i < retries; i++ {
 		if i > 0 {
-			g.G().Log.Debug("retry attempt %d of %d for %s", i, retries, arg.Endpoint)
+			g.G().Log.CDebugf(arg.NetContext, "retry attempt %d of %d for %s", i, retries, arg.Endpoint)
 		}
 		resp, err := doTimeout(cli, req, timeout)
 		if err == nil {
@@ -546,7 +546,7 @@ func (a *InternalAPIEngine) checkSessionExpired(arg APIArg, ast *AppStatus) erro
 	if !loggedIn {
 		return nil
 	}
-	a.G().Log.Debug("local session -> is logged in, remote -> not logged in.  invalidating local session:")
+	a.G().Log.CDebugf(arg.NetContext, "local session -> is logged in, remote -> not logged in.  invalidating local session:")
 	if arg.SessionR != nil {
 		arg.SessionR.Invalidate()
 	} else {
@@ -675,12 +675,12 @@ func (a *InternalAPIEngine) DoRequest(arg APIArg, req *http.Request) (*APIRes, e
 	// http.AppStatus
 	appStatus, err := a.checkAppStatusFromJSONWrapper(arg, status)
 	if err != nil {
-		a.G().Log.Debug("- API call %s error: %s", arg.Endpoint, err)
+		a.G().Log.CDebugf(arg.NetContext, "- API call %s error: %s", arg.Endpoint, err)
 		return nil, err
 	}
 
 	body := jw
-	a.G().Log.Debug("- API call %s success", arg.Endpoint)
+	a.G().Log.CDebugf(arg.NetContext, "- API call %s success", arg.Endpoint)
 	return &APIRes{status, body, resp.StatusCode, appStatus}, err
 }
 

--- a/go/libkb/apiarg.go
+++ b/go/libkb/apiarg.go
@@ -1,6 +1,7 @@
 package libkb
 
 import (
+	"golang.org/x/net/context"
 	"net/url"
 	"time"
 )
@@ -17,6 +18,7 @@ type APIArg struct {
 	InitialTimeout  time.Duration // optional
 	RetryMultiplier float64       // optional
 	RetryCount      int           // optional
+	NetContext      context.Context
 }
 
 // NewAPIArg creates a standard APIArg that will result

--- a/go/libkb/apiarg.go
+++ b/go/libkb/apiarg.go
@@ -29,6 +29,13 @@ func NewAPIArg(endpoint string) APIArg {
 	}
 }
 
+func NewAPIArgWithNetContext(ctx context.Context, endpoint string) APIArg {
+	return APIArg{
+		NetContext: ctx,
+		Endpoint:   endpoint,
+	}
+}
+
 // NewRetryAPIArg creates an APIArg that will cause the http client
 // to use a much smaller request timeout, but retry the request
 // several times, backing off on the timeout each time.

--- a/go/libkb/bug_3964_repair.go
+++ b/go/libkb/bug_3964_repair.go
@@ -1,0 +1,1 @@
+package libkb

--- a/go/libkb/cached_user_loader.go
+++ b/go/libkb/cached_user_loader.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
 )
 
 type CachedUserLoader struct {
@@ -35,14 +36,14 @@ func (u *CachedUserLoader) ClearMemory() {
 	u.m = make(map[string]*keybase1.UserPlusAllKeys)
 }
 
-func (u *CachedUserLoader) getCachedUPK(g *GlobalContext, uid keybase1.UID, info *CachedUserLoadInfo) (*keybase1.UserPlusAllKeys, bool) {
+func (u *CachedUserLoader) getCachedUPK(ctx context.Context, uid keybase1.UID, info *CachedUserLoadInfo) (*keybase1.UserPlusAllKeys, bool) {
 	u.Lock()
 	upk := u.m[uid.String()]
 	u.Unlock()
 
 	// Try loading from persistent storage if we missed memory cache.
 	if upk != nil {
-		g.GetLog().Debug("| hit memory cache")
+		u.G().Log.CDebugf(ctx, "| hit memory cache")
 		if info != nil {
 			info.InCache = true
 		}
@@ -50,11 +51,11 @@ func (u *CachedUserLoader) getCachedUPK(g *GlobalContext, uid keybase1.UID, info
 		var tmp keybase1.UserPlusAllKeys
 		found, err := u.G().LocalDb.GetInto(&tmp, culDBKey(uid))
 		if err != nil {
-			g.GetLog().Warning("trouble accessing UserPlusAllKeys cache: %s", err)
+			u.G().Log.CWarningf(ctx, "trouble accessing UserPlusAllKeys cache: %s", err)
 		} else if !found {
-			g.GetLog().Debug("| missed disk cache")
+			u.G().Log.CDebugf(ctx, "| missed disk cache")
 		} else {
-			g.GetLog().Debug("| hit disk cache")
+			u.G().Log.CDebugf(ctx, "| hit disk cache")
 			upk = &tmp
 			if info != nil {
 				info.InDiskCache = true
@@ -67,19 +68,19 @@ func (u *CachedUserLoader) getCachedUPK(g *GlobalContext, uid keybase1.UID, info
 	}
 
 	if upk == nil {
-		g.GetLog().Debug("| missed cache")
+		u.G().Log.CDebugf(ctx, "| missed cache")
 		return nil, true
 	}
 	fresh := false
 	if u.Freshness == time.Duration(0) {
-		g.GetLog().Debug("| cache miss since cache disabled")
+		u.G().Log.CDebugf(ctx, "| cache miss since cache disabled")
 	} else {
 		diff := u.G().Clock().Now().Sub(keybase1.FromTime(upk.Base.Uvv.CachedAt))
 		fresh = (diff <= u.Freshness)
 		if fresh {
-			g.GetLog().Debug("| cache hit was fresh (cached %s ago)", diff)
+			u.G().Log.CDebugf(ctx, "| cache hit was fresh (cached %s ago)", diff)
 		} else {
-			g.GetLog().Debug("| cache hit was stale (by %s)", u.Freshness-diff)
+			u.G().Log.CDebugf(ctx, "| cache hit was stale (by %s)", u.Freshness-diff)
 		}
 	}
 	return upk, fresh
@@ -127,15 +128,15 @@ func (u *CachedUserLoader) extractDeviceKey(upk *keybase1.UserPlusAllKeys, devic
 	return deviceKey, revoked, nil
 }
 
-func (u *CachedUserLoader) putUPKToCache(g *GlobalContext, obj *keybase1.UserPlusAllKeys) error {
+func (u *CachedUserLoader) putUPKToCache(ctx context.Context, obj *keybase1.UserPlusAllKeys) error {
 	uid := obj.Base.Uid
-	g.GetLog().Debug("| %s: Caching: %+v", culDebug(uid), *obj)
+	u.G().Log.CDebugf(ctx, "| %s: Caching: %+v", culDebug(uid), *obj)
 	u.Lock()
 	u.m[uid.String()] = obj
 	u.Unlock()
-	err := g.LocalDb.PutObj(culDBKey(uid), nil, *obj)
+	err := u.G().LocalDb.PutObj(culDBKey(uid), nil, *obj)
 	if err != nil {
-		g.GetLog().Warning("Error in writing UPAK for %s: %s", uid, err)
+		u.G().Log.CWarningf(ctx, "Error in writing UPAK for %s: %s", uid, err)
 	}
 	return err
 }
@@ -143,7 +144,7 @@ func (u *CachedUserLoader) putUPKToCache(g *GlobalContext, obj *keybase1.UserPlu
 func (u *CachedUserLoader) PutUserToCache(user *User) error {
 	upak := user.ExportToUserPlusAllKeys(keybase1.Time(0))
 	upak.Base.Uvv.CachedAt = keybase1.ToTime(u.G().Clock().Now())
-	err := u.putUPKToCache(u.G(), &upak)
+	err := u.putUPKToCache(nil, &upak)
 	return err
 }
 
@@ -152,29 +153,36 @@ func (u *CachedUserLoader) PutUserToCache(user *User) error {
 // this method behaves like (and implements) the public CachedUserLoader#Load
 // method below.
 func (u *CachedUserLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInfo) (ret *keybase1.UserPlusAllKeys, user *User, err error) {
-	defer arg.G().Trace(culDebug(arg.UID), func() error { return err })()
+
+	// Shorthand
+	g := u.G()
+
+	// Add a LU= tax to this context, for all subsequent debugging
+	ctx := arg.WithLogTag()
+
+	defer g.CTrace(ctx, culDebug(arg.UID), func() error { return err })()
 
 	if arg.UID.IsNil() {
 		err = errors.New("need a UID to load UPK from loader")
 		return nil, nil, err
 	}
 
-	lock := u.locktab.AcquireOnName(arg.G(), arg.UID.String())
-	defer lock.Release()
+	lock := u.locktab.AcquireOnName(ctx, g, arg.UID.String())
+	defer lock.Release(ctx)
 
 	var upk *keybase1.UserPlusAllKeys
 	var fresh bool
 
 	if !arg.ForceReload {
-		upk, fresh = u.getCachedUPK(arg.G(), arg.UID, info)
+		upk, fresh = u.getCachedUPK(ctx, arg.UID, info)
 	}
 	if arg.ForcePoll {
-		arg.G().Log.Debug("%s: force-poll required us to repoll (fresh=%v)", culDebug(arg.UID), fresh)
+		g.Log.CDebugf(ctx, "%s: force-poll required us to repoll (fresh=%v)", culDebug(arg.UID), fresh)
 		fresh = false
 	}
 
 	if upk != nil {
-		arg.G().Log.Debug("%s: cache-hit; fresh=%v", culDebug(arg.UID), fresh)
+		g.Log.CDebugf(ctx, "%s: cache-hit; fresh=%v", culDebug(arg.UID), fresh)
 		if fresh || arg.StaleOK {
 			return upk.DeepCopy(), nil, nil
 		}
@@ -183,13 +191,13 @@ func (u *CachedUserLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		}
 
 		var sigHints *SigHints
-		sigHints, err = LoadSigHints(arg.UID, arg.G())
+		sigHints, err = LoadSigHints(ctx, arg.UID, g)
 		if err != nil {
 			return nil, nil, err
 		}
 
 		var leaf *MerkleUserLeaf
-		leaf, err = lookupMerkleLeaf(arg.G(), arg.UID, true, sigHints)
+		leaf, err = lookupMerkleLeaf(ctx, g, arg.UID, true, sigHints)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -197,12 +205,12 @@ func (u *CachedUserLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 			info.LoadedLeaf = true
 		}
 		if leaf.public != nil && leaf.public.Seqno == Seqno(upk.Base.Uvv.SigChain) {
-			arg.G().Log.Debug("%s: cache-hit; fresh after poll", culDebug(arg.UID))
+			g.Log.CDebugf(ctx, "%s: cache-hit; fresh after poll", culDebug(arg.UID))
 
-			upk.Base.Uvv.CachedAt = keybase1.ToTime(arg.G().Clock().Now())
+			upk.Base.Uvv.CachedAt = keybase1.ToTime(g.Clock().Now())
 			// This is only necessary to update the levelDB representation,
 			// since the previous line updates the in-memory cache satisfactorially.
-			u.putUPKToCache(arg.G(), upk)
+			u.putUPKToCache(ctx, upk)
 
 			return upk.DeepCopy(), nil, nil
 		}
@@ -214,7 +222,7 @@ func (u *CachedUserLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		arg.MerkleLeaf = leaf
 	}
 
-	arg.G().Log.Debug("%s: LoadUser", culDebug(arg.UID))
+	g.Log.CDebugf(ctx, "%s: LoadUser", culDebug(arg.UID))
 	user, err = LoadUser(arg)
 	if info != nil {
 		info.LoadedUser = true
@@ -233,8 +241,8 @@ func (u *CachedUserLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 
 	tmp := user.ExportToUserPlusAllKeys(keybase1.Time(0))
 	ret = &tmp
-	ret.Base.Uvv.CachedAt = keybase1.ToTime(arg.G().Clock().Now())
-	err = u.putUPKToCache(arg.G(), ret)
+	ret.Base.Uvv.CachedAt = keybase1.ToTime(g.Clock().Now())
+	err = u.putUPKToCache(ctx, ret)
 
 	return ret, user, nil
 }
@@ -247,10 +255,11 @@ func (u *CachedUserLoader) Load(arg LoadUserArg) (ret *keybase1.UserPlusAllKeys,
 	return u.loadWithInfo(arg, nil)
 }
 
-func (u *CachedUserLoader) CheckKIDForUID(uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, err error) {
+func (u *CachedUserLoader) CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, err error) {
 
 	var info CachedUserLoadInfo
-	upk, _, err := u.loadWithInfo(NewLoadUserByUIDArg(u.G(), uid), &info)
+	larg := NewLoadUserByUIDArg(ctx, u.G(), uid)
+	upk, _, err := u.loadWithInfo(larg, &info)
 
 	if err != nil {
 		return false, nil, err
@@ -259,7 +268,8 @@ func (u *CachedUserLoader) CheckKIDForUID(uid keybase1.UID, kid keybase1.KID) (f
 	if found || info.LoadedLeaf || info.LoadedUser {
 		return found, revokedAt, nil
 	}
-	upk, _, err = u.loadWithInfo(NewLoadUserByUIDForceArg(u.G(), uid), nil)
+	larg.ForceReload = true
+	upk, _, err = u.loadWithInfo(larg, nil)
 	if err != nil {
 		return false, nil, err
 	}
@@ -267,7 +277,7 @@ func (u *CachedUserLoader) CheckKIDForUID(uid keybase1.UID, kid keybase1.KID) (f
 	return found, revokedAt, nil
 }
 
-func (u *CachedUserLoader) LoadUserPlusKeys(uid keybase1.UID) (keybase1.UserPlusKeys, error) {
+func (u *CachedUserLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UID) (keybase1.UserPlusKeys, error) {
 	var up keybase1.UserPlusKeys
 	if uid.IsNil() {
 		return up, NoUIDError{}
@@ -276,6 +286,7 @@ func (u *CachedUserLoader) LoadUserPlusKeys(uid keybase1.UID) (keybase1.UserPlus
 	arg := NewLoadUserArg(u.G())
 	arg.UID = uid
 	arg.PublicKeyOptional = true
+	arg.NetContext = ctx
 
 	// We need to force a reload to make KBFS tests pass
 	arg.ForcePoll = true
@@ -291,10 +302,10 @@ func (u *CachedUserLoader) LoadUserPlusKeys(uid keybase1.UID) (keybase1.UserPlus
 	return up, nil
 }
 
-func (u *CachedUserLoader) Invalidate(uid keybase1.UID) {
+func (u *CachedUserLoader) Invalidate(ctx context.Context, uid keybase1.UID) {
 	u.G().Log.Debug("CachedUserLoader#Invalidate(%s)", uid)
-	lock := u.locktab.AcquireOnName(u.G(), uid.String())
-	defer lock.Release()
+	lock := u.locktab.AcquireOnName(ctx, u.G(), uid.String())
+	defer lock.Release(ctx)
 
 	u.Lock()
 	delete(u.m, uid.String())
@@ -309,9 +320,10 @@ func (u *CachedUserLoader) Invalidate(uid keybase1.UID) {
 
 // Load the PublicKey for a user's device from the local cache, falling back to LoadUser, and cache the user.
 // If the user exists but the device doesn't, will force a load in case the device is very new.
-func (u *CachedUserLoader) LoadDeviceKey(uid keybase1.UID, deviceID keybase1.DeviceID) (upk *keybase1.UserPlusAllKeys, deviceKey *keybase1.PublicKey, revoked *keybase1.RevokedKey, err error) {
+func (u *CachedUserLoader) LoadDeviceKey(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (upk *keybase1.UserPlusAllKeys, deviceKey *keybase1.PublicKey, revoked *keybase1.RevokedKey, err error) {
 	var info CachedUserLoadInfo
-	upk, _, err = u.loadWithInfo(NewLoadUserByUIDArg(u.G(), uid), &info)
+	larg := NewLoadUserByUIDArg(ctx, u.G(), uid)
+	upk, _, err = u.loadWithInfo(larg, &info)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -323,7 +335,8 @@ func (u *CachedUserLoader) LoadDeviceKey(uid keybase1.UID, deviceID keybase1.Dev
 	}
 
 	// Try again with a forced load in case the device is very new.
-	upk, _, err = u.loadWithInfo(NewLoadUserByUIDForceArg(u.G(), uid), nil)
+	larg.ForcePoll = true
+	upk, _, err = u.loadWithInfo(larg, nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -332,9 +345,9 @@ func (u *CachedUserLoader) LoadDeviceKey(uid keybase1.UID, deviceID keybase1.Dev
 	return upk, deviceKey, revoked, err
 }
 
-func (u *CachedUserLoader) LookupUsername(uid keybase1.UID) (NormalizedUsername, error) {
+func (u *CachedUserLoader) LookupUsername(ctx context.Context, uid keybase1.UID) (NormalizedUsername, error) {
 	var info CachedUserLoadInfo
-	arg := NewLoadUserByUIDArg(u.G(), uid)
+	arg := NewLoadUserByUIDArg(ctx, u.G(), uid)
 	arg.StaleOK = true
 	upk, _, err := u.loadWithInfo(arg, &info)
 	var blank NormalizedUsername
@@ -347,8 +360,8 @@ func (u *CachedUserLoader) LookupUsername(uid keybase1.UID) (NormalizedUsername,
 	return NewNormalizedUsername(upk.Base.Username), nil
 }
 
-func (u *CachedUserLoader) lookupUsernameAndDeviceWithInfo(uid keybase1.UID, did keybase1.DeviceID, info *CachedUserLoadInfo) (username NormalizedUsername, deviceName string, deviceType string, err error) {
-	arg := NewLoadUserByUIDArg(u.G(), uid)
+func (u *CachedUserLoader) lookupUsernameAndDeviceWithInfo(ctx context.Context, uid keybase1.UID, did keybase1.DeviceID, info *CachedUserLoadInfo) (username NormalizedUsername, deviceName string, deviceType string, err error) {
+	arg := NewLoadUserByUIDArg(ctx, u.G(), uid)
 
 	// First iteration through, say it's OK to load a stale user. Note that the
 	// mappings of UID to Username and DeviceID to DeviceName are immutable, so this
@@ -371,12 +384,12 @@ func (u *CachedUserLoader) lookupUsernameAndDeviceWithInfo(uid keybase1.UID, did
 	return NormalizedUsername(""), "", "", err
 }
 
-func (u *CachedUserLoader) LookupUsernameAndDevice(uid keybase1.UID, did keybase1.DeviceID) (username NormalizedUsername, deviceName string, deviceType string, err error) {
-	return u.lookupUsernameAndDeviceWithInfo(uid, did, nil)
+func (u *CachedUserLoader) LookupUsernameAndDevice(ctx context.Context, uid keybase1.UID, did keybase1.DeviceID) (username NormalizedUsername, deviceName string, deviceType string, err error) {
+	return u.lookupUsernameAndDeviceWithInfo(ctx, uid, did, nil)
 }
 
 func (u *CachedUserLoader) ListFollowedUIDs(uid keybase1.UID) ([]keybase1.UID, error) {
-	arg := NewLoadUserByUIDArg(u.G(), uid)
+	arg := NewLoadUserByUIDArg(nil, u.G(), uid)
 	upk, _, err := u.Load(arg)
 	if err != nil {
 		return nil, err

--- a/go/libkb/cached_user_loader_test.go
+++ b/go/libkb/cached_user_loader_test.go
@@ -79,20 +79,20 @@ func TestCheckKIDForUID(t *testing.T) {
 	rebeccaUID := keybase1.UID("99337e411d1004050e9e7ee2cf1a6219")
 	rebeccaKIDRevoked := keybase1.KID("0120e177772304cd9ec833ceb88eeb6e32a667151d9e4fb09df433a846d05e6c40350a")
 
-	found, revokedAt, err := tc.G.CachedUserLoader.CheckKIDForUID(georgeUID, georgeKIDSibkey)
+	found, revokedAt, err := tc.G.CachedUserLoader.CheckKIDForUID(nil, georgeUID, georgeKIDSibkey)
 	if !found || (revokedAt != nil) || (err != nil) {
 		t.Fatalf("bad CheckKIDForUID response")
 	}
-	found, revokedAt, err = tc.G.CachedUserLoader.CheckKIDForUID(georgeUID, georgeKIDSubkey)
+	found, revokedAt, err = tc.G.CachedUserLoader.CheckKIDForUID(nil, georgeUID, georgeKIDSubkey)
 	if !found || (revokedAt != nil) || (err != nil) {
 		t.Fatalf("bad CheckKIDForUID response")
 	}
-	found, revokedAt, err = tc.G.CachedUserLoader.CheckKIDForUID(georgeUID, kbKIDSibkey)
+	found, revokedAt, err = tc.G.CachedUserLoader.CheckKIDForUID(nil, georgeUID, kbKIDSibkey)
 	if found || (revokedAt != nil) || (err != nil) {
 		t.Fatalf("bad CheckKIDForUID response")
 	}
 
-	found, revokedAt, err = tc.G.CachedUserLoader.CheckKIDForUID(rebeccaUID, rebeccaKIDRevoked)
+	found, revokedAt, err = tc.G.CachedUserLoader.CheckKIDForUID(nil, rebeccaUID, rebeccaKIDRevoked)
 	if !found || (revokedAt == nil) || (err != nil) {
 		t.Fatalf("bad CheckKIDForUID response")
 	}
@@ -141,7 +141,7 @@ func TestLookupUsernameAndDevice(t *testing.T) {
 	test := func() {
 		uid := keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")
 		did := keybase1.DeviceID("e5f7f7ca6b6277de4d2c45f57b767f18")
-		un, name, typ, err := tc.G.CachedUserLoader.LookupUsernameAndDevice(uid, did)
+		un, name, typ, err := tc.G.CachedUserLoader.LookupUsernameAndDevice(nil, uid, did)
 		require.NoError(t, err)
 		require.Equal(t, un.String(), "t_tracy", "tracy was right")
 		require.Equal(t, name, "work", "right device name")
@@ -162,10 +162,10 @@ func TestLookupUsername(t *testing.T) {
 	tc := SetupTest(t, "LookupUsernameAndDevice", 1)
 	defer tc.Cleanup()
 	uid := keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")
-	un, err := tc.G.CachedUserLoader.LookupUsername(uid)
+	un, err := tc.G.CachedUserLoader.LookupUsername(nil, uid)
 	require.NoError(t, err)
 	require.Equal(t, un, NewNormalizedUsername("t_tracy"), "tracy came back")
 	badUID := keybase1.UID("eb72f49f2dde6429e5d78003dae0b919")
-	_, err = tc.G.CachedUserLoader.LookupUsername(badUID)
+	_, err = tc.G.CachedUserLoader.LookupUsername(nil, badUID)
 	require.Error(t, err)
 }

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -776,7 +776,7 @@ func (g *GlobalContext) SetServices(s ExternalServicesCollector) {
 }
 
 func (g *GlobalContext) LoadUserByUID(uid keybase1.UID) (*User, error) {
-	arg := NewLoadUserByUIDArg(g, uid)
+	arg := NewLoadUserByUIDArg(nil, g, uid)
 	arg.PublicKeyOptional = true
 	return LoadUser(arg)
 }
@@ -793,7 +793,7 @@ func (g *GlobalContext) UIDToUsername(uid keybase1.UID) (NormalizedUsername, err
 
 func (g *GlobalContext) BustLocalUserCache(u keybase1.UID) {
 	if g.CachedUserLoader != nil {
-		g.CachedUserLoader.Invalidate(u)
+		g.CachedUserLoader.Invalidate(g.NetContext, u)
 	}
 }
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -26,6 +26,7 @@ import (
 	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/clockwork"
+	"golang.org/x/net/context"
 )
 
 type ShutdownHook func() error
@@ -42,7 +43,7 @@ type GlobalContext struct {
 	Log               logger.Logger  // Handles all logging
 	VDL               *VDebugLog     // verbose debug log
 	Env               *Env           // Env variables, cmdline args & config
-	SKBKeyringMu      sync.Mutex     // Protects all attempts to mutate the SKBKeyringFile
+	SKBKeyringMu      *sync.Mutex    // Protects all attempts to mutate the SKBKeyringFile
 	Keyrings          *Keyrings      // Gpg Keychains holding keys
 	API               API            // How to make a REST call to the server
 	Resolver          *Resolver      // cache of resolve results
@@ -55,7 +56,7 @@ type GlobalContext struct {
 	GpgClient         *GpgCLI        // A standard GPG-client (optional)
 	ShutdownHooks     []ShutdownHook // on shutdown, fire these...
 	SocketInfo        Socket         // which socket to bind/connect to
-	socketWrapperMu   sync.RWMutex
+	socketWrapperMu   *sync.RWMutex
 	SocketWrapper     *SocketWrapper     // only need one connection per
 	LoopbackListener  *LoopbackListener  // If we're in loopback mode, we'll connect through here
 	XStreams          *ExportedStreams   // a table of streams we've exported to the daemon (or vice-versa)
@@ -65,8 +66,8 @@ type GlobalContext struct {
 	LinkCache         *LinkCache         // cache of ChainLinks
 	UI                UI                 // Interact with the UI
 	Service           bool               // whether we're in server mode
-	shutdownOnce      sync.Once          // whether we've shut down or not
-	loginStateMu      sync.RWMutex       // protects loginState pointer, which gets destroyed on logout
+	shutdownOnce      *sync.Once         // whether we've shut down or not
+	loginStateMu      *sync.RWMutex      // protects loginState pointer, which gets destroyed on logout
 	loginState        *LoginState        // What phase of login the user's in
 	ConnectionManager *ConnectionManager // keep tabs on all active client connections
 	NotifyRouter      *NotifyRouter      // How to route notifications
@@ -76,19 +77,19 @@ type GlobalContext struct {
 	Services         ExternalServicesCollector // All known external services
 	ExitCode         keybase1.ExitCode         // Value to return to OS on Exit()
 	RateLimits       *RateLimits               // tracks the last time certain actions were taken
-	clockMu          sync.Mutex                // protects Clock
+	clockMu          *sync.Mutex               // protects Clock
 	clock            clockwork.Clock           // RealClock unless we're testing
 	SecretStoreAll   *SecretStoreLocked        // nil except for tests and supported platforms
-	hookMu           sync.RWMutex              // protects loginHooks, logoutHooks
+	hookMu           *sync.RWMutex             // protects loginHooks, logoutHooks
 	loginHooks       []LoginHook               // call these on login
 	logoutHooks      []LogoutHook              // call these on logout
 	GregorDismisser  GregorDismisser           // for dismissing gregor items that we've handled
 	GregorListener   GregorListener            // for alerting about clients connecting and registering UI protocols
-	OutOfDateInfo    keybase1.OutOfDateInfo    // Stores out of date messages we got from API server headers.
+	OutOfDateInfo    *keybase1.OutOfDateInfo   // Stores out of date messages we got from API server headers.
 	CachedUserLoader *CachedUserLoader         // Load flat users with the ability to hit the cache
 	UserDeviceCache  *UserDeviceCache          // Cache user and device names forever
 
-	uchMu               sync.Mutex           // protects the UserChangedHandler array
+	uchMu               *sync.Mutex          // protects the UserChangedHandler array
 	UserChangedHandlers []UserChangedHandler // a list of handlers that deal generically with userchanged events
 
 	CardCache *UserCardCache // cache of keybase1.UserCard objects
@@ -103,6 +104,8 @@ type GlobalContext struct {
 
 	// Options specified for testing only
 	TestOptions GlobalTestOptions
+
+	NetContext context.Context
 }
 
 type GlobalTestOptions struct {
@@ -120,11 +123,31 @@ func (g *GlobalContext) GetMerkleClient() *MerkleClient         { return g.Merkl
 func NewGlobalContext() *GlobalContext {
 	log := logger.New("keybase")
 	return &GlobalContext{
-		Log:          log,
-		VDL:          NewVDebugLog(log),
-		clock:        clockwork.NewRealClock(),
-		NewTriplesec: NewSecureTriplesec,
+		Log:             log,
+		VDL:             NewVDebugLog(log),
+		SKBKeyringMu:    new(sync.Mutex),
+		socketWrapperMu: new(sync.RWMutex),
+		shutdownOnce:    new(sync.Once),
+		loginStateMu:    new(sync.RWMutex),
+		clockMu:         new(sync.Mutex),
+		clock:           clockwork.NewRealClock(),
+		hookMu:          new(sync.RWMutex),
+		OutOfDateInfo:   &keybase1.OutOfDateInfo{},
+		uchMu:           new(sync.Mutex),
+		NewTriplesec:    NewSecureTriplesec,
+		NetContext:      context.TODO(),
 	}
+}
+
+func (g *GlobalContext) CloneWithNewNetContext(netCtx context.Context) *GlobalContext {
+	tmp := *g
+
+	// For legacy code that doesn't thread contexts through to logging properly,
+	// change the underlying logger.
+	tmp.Log = logger.NewSingleContextLogger(netCtx, g.Log)
+	tmp.NetContext = netCtx
+
+	return &tmp
 }
 
 var G *GlobalContext
@@ -761,7 +784,7 @@ func (g *GlobalContext) LoadUserByUID(uid keybase1.UID) (*User, error) {
 func (g *GlobalContext) UIDToUsername(uid keybase1.UID) (NormalizedUsername, error) {
 	q := NewHTTPArgs()
 	q.Add("uid", UIDArg(uid))
-	leaf, err := g.MerkleClient.LookupUser(q, nil)
+	leaf, err := g.MerkleClient.LookupUser(g.NetContext, q, nil)
 	if err != nil {
 		return NormalizedUsername(""), err
 	}

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -119,6 +119,7 @@ func (g *GlobalContext) GetServerURI() string                   { return g.Env.G
 func (g *GlobalContext) GetCachedUserLoader() *CachedUserLoader { return g.CachedUserLoader }
 func (g *GlobalContext) GetUserDeviceCache() *UserDeviceCache   { return g.UserDeviceCache }
 func (g *GlobalContext) GetMerkleClient() *MerkleClient         { return g.MerkleClient }
+func (g *GlobalContext) GetNetContext() context.Context         { return g.NetContext }
 
 func NewGlobalContext() *GlobalContext {
 	log := logger.New("keybase")
@@ -139,14 +140,18 @@ func NewGlobalContext() *GlobalContext {
 	}
 }
 
-func (g *GlobalContext) CloneWithNewNetContext(netCtx context.Context) *GlobalContext {
+func (g *GlobalContext) CloneWithNetContextAndNewLogger(netCtx context.Context) *GlobalContext {
 	tmp := *g
-
 	// For legacy code that doesn't thread contexts through to logging properly,
 	// change the underlying logger.
 	tmp.Log = logger.NewSingleContextLogger(netCtx, g.Log)
 	tmp.NetContext = netCtx
+	return &tmp
+}
 
+func (g *GlobalContext) CloneWithNetContext(netCtx context.Context) *GlobalContext {
+	tmp := *g
+	tmp.NetContext = netCtx
 	return &tmp
 }
 

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1122,7 +1122,7 @@ func (idt *IdentityTable) VerifySelfSig(nun NormalizedUsername, uid keybase1.UID
 			continue
 		}
 		if NewNormalizedUsername(link.GetUsername()).Eq(nun) && link.GetUID().Equal(uid) {
-			G.Log.Debug("| Found self-signature for %s @%s", string(nun),
+			idt.G().Log.Debug("| Found self-signature for %s @%s", string(nun),
 				link.ToDebugString())
 			return true
 		}

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -10,6 +10,7 @@ import (
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	jsonw "github.com/keybase/go-jsonw"
+	"golang.org/x/net/context"
 )
 
 type TypedChainLink interface {
@@ -528,11 +529,11 @@ func (l *TrackChainLink) ToServiceBlocks() (ret []*ServiceBlock) {
 		} else if t, e := proof.AtKey("proof_type").GetInt(); e != nil {
 			l.G().Log.Warning("Bad 'proof_type' in track statement: %s", e)
 		} else if sb, e := ParseServiceBlock(proof.AtKey("check_data_json"), keybase1.ProofType(t)); e != nil {
-			G.Log.Warning("Bad remote_key_proof.check_data_json: %s", e)
+			l.G().Log.Warning("Bad remote_key_proof.check_data_json: %s", e)
 		} else {
 			sb.proofState = keybase1.ProofState(i)
 			if sb.proofState != keybase1.ProofState_OK {
-				G.Log.Debug("Including broken proof at index = %d\n", index)
+				l.G().Log.Debug("Including broken proof at index = %d\n", index)
 			}
 			ret = append(ret, sb)
 		}
@@ -785,7 +786,7 @@ func ParseUntrackChainLink(b GenericChainLink) (ret *UntrackChainLink, err error
 func (u *UntrackChainLink) insertIntoTable(tab *IdentityTable) {
 	tab.insertLink(u)
 	if list, found := tab.tracks[u.whomUsername]; !found {
-		G.Log.Debug("| Useless untrack of %s; no previous tracking statement found",
+		u.G().Log.Debug("| Useless untrack of %s; no previous tracking statement found",
 			u.whomUsername)
 	} else {
 		for _, obj := range list {
@@ -1208,11 +1209,11 @@ type CheckCompletedListener interface {
 	CCLCheckCompleted(lcr *LinkCheckResult)
 }
 
-func (idt *IdentityTable) Identify(is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener) error {
+func (idt *IdentityTable) Identify(ctx context.Context, is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener) error {
 	errs := make(chan error, len(is.res.ProofChecks))
 	for _, lcr := range is.res.ProofChecks {
 		go func(l *LinkCheckResult) {
-			errs <- idt.identifyActiveProof(l, is, forceRemoteCheck, ui, ccl)
+			errs <- idt.identifyActiveProof(ctx, l, is, forceRemoteCheck, ui, ccl)
 		}(lcr)
 	}
 
@@ -1235,8 +1236,8 @@ func (idt *IdentityTable) Identify(is IdentifyState, forceRemoteCheck bool, ui I
 
 //=========================================================================
 
-func (idt *IdentityTable) identifyActiveProof(lcr *LinkCheckResult, is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener) error {
-	idt.proofRemoteCheck(is.HasPreviousTrack(), forceRemoteCheck, lcr)
+func (idt *IdentityTable) identifyActiveProof(ctx context.Context, lcr *LinkCheckResult, is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener) error {
+	idt.proofRemoteCheck(ctx, is.HasPreviousTrack(), forceRemoteCheck, lcr)
 	if ccl != nil {
 		ccl.CCLCheckCompleted(lcr)
 	}
@@ -1286,10 +1287,10 @@ func (idt *IdentityTable) ComputeRemoteDiff(tracked, trackedTmp, observed keybas
 	return ret
 }
 
-func (idt *IdentityTable) proofRemoteCheck(hasPreviousTrack, forceRemoteCheck bool, res *LinkCheckResult) {
+func (idt *IdentityTable) proofRemoteCheck(ctx context.Context, hasPreviousTrack, forceRemoteCheck bool, res *LinkCheckResult) {
 	p := res.link
 
-	idt.G().Log.Debug("+ RemoteCheckProof %s", p.ToDebugString())
+	idt.G().Log.CDebugf(ctx, "+ RemoteCheckProof %s", p.ToDebugString())
 	doCache := false
 	sid := p.GetSigID()
 
@@ -1308,13 +1309,13 @@ func (idt *IdentityTable) proofRemoteCheck(hasPreviousTrack, forceRemoteCheck bo
 		}
 
 		if doCache {
-			idt.G().Log.Debug("| Caching results under key=%s", sid)
+			idt.G().Log.CDebugf(ctx, "| Caching results under key=%s", sid)
 			if cacheErr := idt.G().ProofCache.Put(sid, res.err); cacheErr != nil {
-				idt.G().Log.Warning("proof cache put error: %s", cacheErr)
+				idt.G().Log.CWarningf(ctx, "proof cache put error: %s", cacheErr)
 			}
 		}
 
-		idt.G().Log.Debug("- RemoteCheckProof %s", p.ToDebugString())
+		idt.G().Log.CDebugf(ctx, "- RemoteCheckProof %s", p.ToDebugString())
 	}()
 
 	res.hint = idt.sigHints.Lookup(sid)
@@ -1351,11 +1352,11 @@ func (idt *IdentityTable) proofRemoteCheck(hasPreviousTrack, forceRemoteCheck bo
 	doCache = true
 
 	if res.err = pc.CheckHint(idt.G(), *res.hint); res.err != nil {
-		idt.G().Log.Debug("| Hint failed with error: %s", res.err.Error())
+		idt.G().Log.CDebugf(ctx, "| Hint failed with error: %s", res.err.Error())
 		return
 	}
 
-	res.err = pc.CheckStatus(idt.G(), *res.hint)
+	res.err = pc.CheckStatus(idt.G().CloneWithNetContext(ctx), *res.hint)
 
 	// If no error than all good
 	if res.err == nil {
@@ -1367,7 +1368,7 @@ func (idt *IdentityTable) proofRemoteCheck(hasPreviousTrack, forceRemoteCheck bo
 	// not to cache it.
 	if ProofErrorIsSoft(res.err) && res.cached != nil && res.cached.Status == nil &&
 		res.cached.Freshness() != keybase1.CheckResultFreshness_RANCID {
-		idt.G().Log.Debug("| Got soft error (%s) but returning success (last seen at %s)",
+		idt.G().Log.CDebugf(ctx, "| Got soft error (%s) but returning success (last seen at %s)",
 			res.err.Error(), res.cached.Time)
 		res.snoozedErr = res.err
 		res.err = nil
@@ -1375,7 +1376,7 @@ func (idt *IdentityTable) proofRemoteCheck(hasPreviousTrack, forceRemoteCheck bo
 		return
 	}
 
-	idt.G().Log.Warning("| Check status (%s) failed with error: %s", p.ToDebugString(), res.err.Error())
+	idt.G().Log.CWarningf(ctx, "| Check status (%s) failed with error: %s", p.ToDebugString(), res.err.Error())
 
 	return
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -454,10 +454,15 @@ type APIContext interface {
 	GetServerURI() string
 }
 
+type NetContext interface {
+	GetNetContext() context.Context
+}
+
 // ProofContext defines features needed by the proof system
 type ProofContext interface {
 	LogContext
 	APIContext
+	NetContext
 }
 
 type AssertionContext interface {

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -8,6 +8,7 @@ import (
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	jsonw "github.com/keybase/go-jsonw"
+	"golang.org/x/net/context"
 	"runtime/debug"
 )
 
@@ -30,6 +31,10 @@ type LoadUserArg struct {
 	// failed LoadUserPlusKeys load
 	MerkleLeaf *MerkleUserLeaf
 	SigHints   *SigHints
+
+	// NetContext is the context to build on top of.  We'll make a new
+	// Debug Tag for this LoadUser Operation.
+	NetContext context.Context
 }
 
 func NewLoadUserArg(g *GlobalContext) LoadUserArg {
@@ -54,9 +59,10 @@ func NewLoadUserByNameArg(g *GlobalContext, name string) LoadUserArg {
 	return arg
 }
 
-func NewLoadUserByUIDArg(g *GlobalContext, uid keybase1.UID) LoadUserArg {
+func NewLoadUserByUIDArg(ctx context.Context, g *GlobalContext, uid keybase1.UID) LoadUserArg {
 	arg := NewLoadUserArg(g)
 	arg.UID = uid
+	arg.NetContext = ctx
 	return arg
 }
 
@@ -71,6 +77,23 @@ func NewLoadUserPubOptionalArg(g *GlobalContext) LoadUserArg {
 	arg := NewLoadUserArg(g)
 	arg.PublicKeyOptional = true
 	return arg
+}
+
+func (arg *LoadUserArg) GetNetContext() context.Context {
+	if arg.NetContext != nil {
+		return arg.NetContext
+	}
+	if ctx := arg.G().NetContext; ctx != nil {
+		return ctx
+	}
+	return context.Background()
+}
+
+func (arg *LoadUserArg) WithLogTag() context.Context {
+	ctx := WithLogTag(arg.GetNetContext(), "LU")
+	arg.NetContext = ctx
+	arg.SetGlobalContext(arg.G().CloneWithNewNetContext(ctx))
+	return ctx
 }
 
 func (arg *LoadUserArg) checkUIDName() error {
@@ -139,13 +162,16 @@ func LoadMe(arg LoadUserArg) (*User, error) {
 	return LoadUser(arg)
 }
 
-func LoadMeByUID(g *GlobalContext, uid keybase1.UID) (*User, error) {
-	return LoadMe(NewLoadUserByUIDArg(g, uid))
+func LoadMeByUID(ctx context.Context, g *GlobalContext, uid keybase1.UID) (*User, error) {
+	return LoadMe(NewLoadUserByUIDArg(ctx, g, uid))
 }
 
 func LoadUser(arg LoadUserArg) (ret *User, err error) {
-	defer TimeLog(fmt.Sprintf("LoadUser: %+v", arg), arg.G().Clock().Now(), arg.G().Log.Debug)
-	arg.G().Log.Debug("LoadUser: %+v", arg)
+
+	ctx := arg.WithLogTag()
+
+	defer TimeLog(fmt.Sprintf("LoadUser(%+v)", arg), arg.G().Clock().Now(), arg.G().Log.Debug)
+	defer arg.G().CTrace(ctx, fmt.Sprintf("LoadUser(%+v)", arg), func() error { return err })()
 	var refresh bool
 
 	if arg.G().VDL.DumpSiteLoadUser() {
@@ -167,7 +193,7 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 		return nil, err
 	}
 
-	arg.G().Log.Debug("+ LoadUser(uid=%v, name=%v)", arg.UID, arg.Name)
+	arg.G().Log.CDebugf(ctx, "+ LoadUser(uid=%v, name=%v)", arg.UID, arg.Name)
 
 	// resolve the uid from the name, if necessary
 	rres, err := arg.resolveUID()
@@ -178,7 +204,7 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 	// check to see if this is a self load
 	arg.checkSelf()
 
-	arg.G().Log.Debug("| resolved to %s", arg.UID)
+	arg.G().Log.CDebugf(ctx, "| resolved to %s", arg.UID)
 
 	// We can get the user object's body from either the resolution result or
 	// if it was plumbed through as a parameter.
@@ -191,14 +217,14 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 	// They might have already been loaded in.
 	var sigHints *SigHints
 	if sigHints = arg.SigHints; sigHints == nil {
-		sigHints, err = LoadSigHints(arg.UID, arg.G())
+		sigHints, err = LoadSigHints(ctx, arg.UID, arg.G())
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	// load user from local, remote
-	ret, refresh, err = loadUser(arg.G(), arg.UID, resolveBody, sigHints, arg.ForceReload, arg.MerkleLeaf)
+	ret, refresh, err = loadUser(ctx, arg.G(), arg.UID, resolveBody, sigHints, arg.ForceReload, arg.MerkleLeaf)
 	if err != nil {
 		return nil, err
 	}
@@ -209,11 +235,11 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 	// that the username queried for matches the User returned (if it
 	// was indeed queried for)
 	if err = ret.leaf.MatchUser(ret, arg.UID, rres.GetNormalizedQueriedUsername()); err != nil {
-		return
+		return ret, err
 	}
 
-	if err = ret.LoadSigChains(arg.AllKeys, &ret.leaf, arg.Self); err != nil {
-		return
+	if err = ret.LoadSigChains(ctx, arg.AllKeys, &ret.leaf, arg.Self); err != nil {
+		return ret, err
 	}
 
 	if arg.AbortIfSigchainUnchanged && ret.sigChain().wasFullyCached {
@@ -225,19 +251,19 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 	}
 
 	// Proactively cache fetches from remote server to local storage
-	if e2 := ret.Store(); e2 != nil {
-		G.Log.Warning("Problem storing user %s: %s", ret.GetName(), e2)
+	if e2 := ret.Store(ctx); e2 != nil {
+		arg.G().Log.CWarningf(ctx, "Problem storing user %s: %s", ret.GetName(), e2)
 	}
 
 	if ret.HasActiveKey() {
 		if err = ret.MakeIDTable(); err != nil {
-			return
+			return ret, err
 		}
 
 		// Check that the user has self-signed only after we
 		// consider revocations. See: https://github.com/keybase/go/issues/43
 		if err = ret.VerifySelfSig(); err != nil {
-			return
+			return ret, err
 		}
 
 	} else if !arg.PublicKeyOptional {
@@ -249,18 +275,18 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 		err = NoKeyError{emsg}
 	}
 
-	return
+	return ret, err
 }
 
-func loadUser(g *GlobalContext, uid keybase1.UID, resolveBody *jsonw.Wrapper, sigHints *SigHints, force bool, leaf *MerkleUserLeaf) (*User, bool, error) {
-	local, err := loadUserFromLocalStorage(g, uid)
+func loadUser(ctx context.Context, g *GlobalContext, uid keybase1.UID, resolveBody *jsonw.Wrapper, sigHints *SigHints, force bool, leaf *MerkleUserLeaf) (*User, bool, error) {
+	local, err := loadUserFromLocalStorage(ctx, g, uid)
 	var refresh bool
 	if err != nil {
-		g.Log.Warning("Failed to load %s from storage: %s", uid, err)
+		g.Log.CWarningf(ctx, "Failed to load %s from storage: %s", uid, err)
 	}
 
 	if leaf == nil {
-		leaf, err = lookupMerkleLeaf(g, uid, (local != nil), sigHints)
+		leaf, err = lookupMerkleLeaf(ctx, g, uid, (local != nil), sigHints)
 		if err != nil {
 			return nil, refresh, err
 		}
@@ -269,7 +295,7 @@ func loadUser(g *GlobalContext, uid keybase1.UID, resolveBody *jsonw.Wrapper, si
 	var f1, loadRemote bool
 
 	if local == nil {
-		g.Log.Debug("| No local user stored for %s", uid)
+		g.Log.CDebugf(ctx, "| No local user stored for %s", uid)
 		loadRemote = true
 	} else if f1, err = local.CheckBasicsFreshness(leaf.idVersion); err != nil {
 		return nil, refresh, err
@@ -278,12 +304,12 @@ func loadUser(g *GlobalContext, uid keybase1.UID, resolveBody *jsonw.Wrapper, si
 		refresh = loadRemote
 	}
 
-	g.Log.Debug("| Freshness: basics=%v; for %s", f1, uid)
+	g.Log.CDebugf(ctx, "| Freshness: basics=%v; for %s", f1, uid)
 
 	var ret *User
 	if !loadRemote && !force {
 		ret = local
-	} else if ret, err = LoadUserFromServer(g, uid, resolveBody); err != nil {
+	} else if ret, err = LoadUserFromServer(ctx, g, uid, resolveBody); err != nil {
 		return nil, refresh, err
 	}
 
@@ -297,19 +323,19 @@ func loadUser(g *GlobalContext, uid keybase1.UID, resolveBody *jsonw.Wrapper, si
 	return ret, refresh, nil
 }
 
-func loadUserFromLocalStorage(g *GlobalContext, uid keybase1.UID) (u *User, err error) {
-	g.Log.Debug("+ loadUserFromLocalStorage(%s)", uid)
+func loadUserFromLocalStorage(ctx context.Context, g *GlobalContext, uid keybase1.UID) (u *User, err error) {
+	g.Log.CDebugf(ctx, "+ loadUserFromLocalStorage(%s)", uid)
 	jw, err := g.LocalDb.Get(DbKeyUID(DBUser, uid))
 	if err != nil {
 		return nil, err
 	}
 
 	if jw == nil {
-		g.Log.Debug("- loadUserFromLocalStorage(%s): Not found", uid)
+		g.Log.CDebugf(ctx, "- loadUserFromLocalStorage(%s): Not found", uid)
 		return nil, nil
 	}
 
-	g.Log.Debug("| Loaded successfully")
+	g.Log.CDebugf(ctx, "| Loaded successfully")
 
 	if u, err = NewUserFromLocalStorage(g, jw); err != nil {
 		return nil, err
@@ -319,8 +345,8 @@ func loadUserFromLocalStorage(g *GlobalContext, uid keybase1.UID) (u *User, err 
 		err = fmt.Errorf("Bad lookup; uid mismatch: %s != %s", uid, u.id)
 	}
 
-	g.Log.Debug("| Loaded username %s (uid=%s)", u.name, uid)
-	g.Log.Debug("- loadUserFromLocalStorage(%s,%s)", u.name, uid)
+	g.Log.CDebugf(ctx, "| Loaded username %s (uid=%s)", u.name, uid)
+	g.Log.CDebugf(ctx, "- loadUserFromLocalStorage(%s,%s)", u.name, uid)
 
 	return
 }
@@ -353,8 +379,8 @@ func LoadUserEmails(g *GlobalContext) (emails []keybase1.Email, err error) {
 	return
 }
 
-func LoadUserFromServer(g *GlobalContext, uid keybase1.UID, body *jsonw.Wrapper) (u *User, err error) {
-	g.Log.Debug("+ Load User from server: %s", uid)
+func LoadUserFromServer(ctx context.Context, g *GlobalContext, uid keybase1.UID, body *jsonw.Wrapper) (u *User, err error) {
+	g.Log.CDebugf(ctx, "+ Load User from server: %s", uid)
 
 	// Res.body might already have been preloaded a a result of a Resolve call earlier.
 	if body == nil {
@@ -364,6 +390,7 @@ func LoadUserFromServer(g *GlobalContext, uid keybase1.UID, body *jsonw.Wrapper)
 			Args: HTTPArgs{
 				"uid": UIDArg(uid),
 			},
+			NetContext: ctx,
 		})
 
 		if err != nil {
@@ -371,15 +398,15 @@ func LoadUserFromServer(g *GlobalContext, uid keybase1.UID, body *jsonw.Wrapper)
 		}
 		body = res.Body.AtKey("them")
 	} else {
-		g.Log.Debug("| Skipped load; got user object previously")
+		g.Log.CDebugf(ctx, "| Skipped load; got user object previously")
 	}
 
 	if u, err = NewUserFromServer(g, body); err != nil {
-		return
+		return u, err
 	}
-	g.Log.Debug("- Load user from server: %s -> %s", uid, ErrToOk(err))
+	g.Log.CDebugf(ctx, "- Load user from server: %s -> %s", uid, ErrToOk(err))
 
-	return
+	return u, err
 }
 
 func myUID(g *GlobalContext, lctx LoginContext) keybase1.UID {
@@ -389,7 +416,7 @@ func myUID(g *GlobalContext, lctx LoginContext) keybase1.UID {
 	return g.GetMyUID()
 }
 
-func lookupMerkleLeaf(g *GlobalContext, uid keybase1.UID, localExists bool, sigHints *SigHints) (f *MerkleUserLeaf, err error) {
+func lookupMerkleLeaf(ctx context.Context, g *GlobalContext, uid keybase1.UID, localExists bool, sigHints *SigHints) (f *MerkleUserLeaf, err error) {
 	if uid.IsNil() {
 		err = fmt.Errorf("uid parameter for lookupMerkleLeaf empty")
 		return
@@ -398,7 +425,7 @@ func lookupMerkleLeaf(g *GlobalContext, uid keybase1.UID, localExists bool, sigH
 	q := NewHTTPArgs()
 	q.Add("uid", UIDArg(uid))
 
-	f, err = g.MerkleClient.LookupUser(g.NetContext, q, sigHints)
+	f, err = g.MerkleClient.LookupUser(ctx, q, sigHints)
 	if err == nil && f == nil && localExists {
 		err = fmt.Errorf("User not found in server Merkle tree")
 	}
@@ -406,6 +433,6 @@ func lookupMerkleLeaf(g *GlobalContext, uid keybase1.UID, localExists bool, sigH
 	return
 }
 
-func LoadUserPlusKeys(g *GlobalContext, uid keybase1.UID) (keybase1.UserPlusKeys, error) {
-	return g.CachedUserLoader.LoadUserPlusKeys(uid)
+func LoadUserPlusKeys(ctx context.Context, g *GlobalContext, uid keybase1.UID) (keybase1.UserPlusKeys, error) {
+	return g.CachedUserLoader.LoadUserPlusKeys(ctx, uid)
 }

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -169,9 +169,8 @@ func LoadMeByUID(ctx context.Context, g *GlobalContext, uid keybase1.UID) (*User
 func LoadUser(arg LoadUserArg) (ret *User, err error) {
 
 	ctx := arg.WithLogTag()
+	defer arg.G().CTraceTimed(ctx, fmt.Sprintf("LoadUser(%+v)", arg), func() error { return err })()
 
-	defer TimeLog(fmt.Sprintf("LoadUser(%+v)", arg), arg.G().Clock().Now(), arg.G().Log.Debug)
-	defer arg.G().CTrace(ctx, fmt.Sprintf("LoadUser(%+v)", arg), func() error { return err })()
 	var refresh bool
 
 	if arg.G().VDL.DumpSiteLoadUser() {

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -92,7 +92,7 @@ func (arg *LoadUserArg) GetNetContext() context.Context {
 func (arg *LoadUserArg) WithLogTag() context.Context {
 	ctx := WithLogTag(arg.GetNetContext(), "LU")
 	arg.NetContext = ctx
-	arg.SetGlobalContext(arg.G().CloneWithNewNetContext(ctx))
+	arg.SetGlobalContext(arg.G().CloneWithNetContextAndNewLogger(ctx))
 	return ctx
 }
 

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -398,7 +398,7 @@ func lookupMerkleLeaf(g *GlobalContext, uid keybase1.UID, localExists bool, sigH
 	q := NewHTTPArgs()
 	q.Add("uid", UIDArg(uid))
 
-	f, err = g.MerkleClient.LookupUser(q, sigHints)
+	f, err = g.MerkleClient.LookupUser(g.NetContext, q, sigHints)
 	if err == nil && f == nil && localExists {
 		err = fmt.Errorf("User not found in server Merkle tree")
 	}

--- a/go/libkb/loaduser_test.go
+++ b/go/libkb/loaduser_test.go
@@ -14,7 +14,7 @@ func TestLoadUserPlusKeys(t *testing.T) {
 
 	// this is kind of pointless as there is no cache anymore
 	for i := 0; i < 10; i++ {
-		u, err := LoadUserPlusKeys(tc.G, "295a7eea607af32040647123732bc819")
+		u, err := LoadUserPlusKeys(nil, tc.G, "295a7eea607af32040647123732bc819")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -27,7 +27,7 @@ func TestLoadUserPlusKeys(t *testing.T) {
 	}
 
 	for _, uid := range []keybase1.UID{"295a7eea607af32040647123732bc819", "afb5eda3154bc13c1df0189ce93ba119", "9d56bd0c02ac2711e142faf484ea9519", "c4c565570e7e87cafd077509abf5f619", "561247eb1cc3b0f5dc9d9bf299da5e19"} {
-		_, err := LoadUserPlusKeys(tc.G, uid)
+		_, err := LoadUserPlusKeys(nil, tc.G, uid)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -39,7 +39,7 @@ func TestLoadUserPlusKeysNoKeys(t *testing.T) {
 	defer tc.Cleanup()
 
 	// t_ellen has no keys.  There should be no error loading her.
-	u, err := LoadUserPlusKeys(tc.G, "561247eb1cc3b0f5dc9d9bf299da5e19")
+	u, err := LoadUserPlusKeys(nil, tc.G, "561247eb1cc3b0f5dc9d9bf299da5e19")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestRevokedKeys(t *testing.T) {
 	tc := SetupTest(t, "revoked keys", 1)
 	defer tc.Cleanup()
 
-	u, err := LoadUserPlusKeys(tc.G, "ff261e3b26543a24ba6c0693820ead19")
+	u, err := LoadUserPlusKeys(nil, tc.G, "ff261e3b26543a24ba6c0693820ead19")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ func BenchmarkLoadSigChains(b *testing.B) {
 	u.sigChainMem = nil
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err = u.LoadSigChains(true, &u.leaf, false); err != nil {
+		if err = u.LoadSigChains(nil, true, &u.leaf, false); err != nil {
 			b.Fatal(err)
 		}
 		u.sigChainMem = nil
@@ -103,7 +103,7 @@ func BenchmarkLoadUserPlusKeys(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := LoadUserPlusKeys(tc.G, uid)
+		_, err := LoadUserPlusKeys(nil, tc.G, uid)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/go/libkb/locktab.go
+++ b/go/libkb/locktab.go
@@ -9,6 +9,7 @@ import (
 
 type NamedLock struct {
 	sync.Mutex
+	lctx   LogContext
 	refs   int
 	name   string
 	parent *LockTable
@@ -23,16 +24,16 @@ func (l *NamedLock) decref() {
 }
 
 func (l *NamedLock) Release() {
-	G.Log.Debug("+ LockTable.Release(%s)", l.name)
+	l.lctx.GetLog().Debug("+ LockTable.Release(%s)", l.name)
 	l.Unlock()
 	l.parent.Lock()
 	l.decref()
 	if l.refs == 0 {
-		G.Log.Debug("| LockTable.unref(%s)", l.name)
+		l.lctx.GetLog().Debug("| LockTable.unref(%s)", l.name)
 		delete(l.parent.locks, l.name)
 	}
 	l.parent.Unlock()
-	G.Log.Debug("- LockTable.Unlock(%s)", l.name)
+	l.lctx.GetLog().Debug("- LockTable.Unlock(%s)", l.name)
 }
 
 type LockTable struct {
@@ -46,17 +47,17 @@ func (t *LockTable) init() {
 	}
 }
 
-func (t *LockTable) AcquireOnName(s string) (ret *NamedLock) {
-	G.Log.Debug("+ LockTable.Lock(%s)", s)
+func (t *LockTable) AcquireOnName(g LogContext, s string) (ret *NamedLock) {
+	g.GetLog().Debug("+ LockTable.Lock(%s)", s)
 	t.Lock()
 	t.init()
 	if ret = t.locks[s]; ret == nil {
-		ret = &NamedLock{refs: 0, name: s, parent: t}
+		ret = &NamedLock{lctx: g, refs: 0, name: s, parent: t}
 		t.locks[s] = ret
 	}
 	ret.incref()
 	t.Unlock()
 	ret.Lock()
-	G.Log.Debug("- LockTable.Lock(%s)", s)
+	g.GetLog().Debug("- LockTable.Lock(%s)", s)
 	return ret
 }

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -6,11 +6,10 @@ package libkb
 import (
 	"errors"
 	"fmt"
-	"runtime/debug"
-	"time"
-
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
+	"runtime/debug"
+	"time"
 )
 
 // PassphraseGeneration represents which generation of the passphrase is

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -317,7 +317,7 @@ func (mc *MerkleClient) LookupPath(ctx context.Context, q HTTPArgs, sigHints *Si
 	}
 
 	if sigHints != nil {
-		if err = sigHints.RefreshWith(res.Body.AtKey("sigs")); err != nil {
+		if err = sigHints.RefreshWith(ctx, res.Body.AtKey("sigs")); err != nil {
 			return
 		}
 	}

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -14,6 +14,7 @@ import (
 	chat1 "github.com/keybase/client/go/protocol/chat1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	jsonw "github.com/keybase/go-jsonw"
+	"golang.org/x/net/context"
 )
 
 type Seqno int64
@@ -165,8 +166,8 @@ func NewMerkleClient(g *GlobalContext) *MerkleClient {
 	}
 }
 
-func (mc *MerkleClient) Init() error {
-	return mc.LoadRoot()
+func (mc *MerkleClient) init(ctx context.Context) error {
+	return mc.loadRoot(ctx)
 }
 
 func merkleHeadKey() DbKey {
@@ -176,14 +177,14 @@ func merkleHeadKey() DbKey {
 	}
 }
 
-func (mc *MerkleClient) LoadRoot() error {
-	mc.G().Log.Debug("+ MerkleClient.LoadRoot()")
+func (mc *MerkleClient) loadRoot(ctx context.Context) error {
+	mc.G().Log.CDebugf(ctx, "+ MerkleClient#loadRoot()")
 	curr, err := mc.G().LocalDb.Lookup(merkleHeadKey())
 	if err != nil {
 		return err
 	}
 	if curr == nil {
-		mc.G().Log.Debug("- MerkleClient.LoadRoot() -> nil")
+		mc.G().Log.CDebugf(ctx, "- MerkleClient#loadRoot() -> nil")
 		return nil
 	}
 	mr, err := NewMerkleRootFromJSON(curr, mc.G())
@@ -192,7 +193,7 @@ func (mc *MerkleClient) LoadRoot() error {
 	}
 	mc.Lock()
 	mc.lastRoot = mr
-	mc.G().Log.Debug("- MerkleClient.LoadRoot() -> %v", mc.lastRoot)
+	mc.G().Log.CDebugf(ctx, "- MerkleClient#loadRoot() -> %v", mc.lastRoot)
 	mc.Unlock()
 	return nil
 }
@@ -285,7 +286,7 @@ func importPathFromJSON(jw *jsonw.Wrapper) (out []*PathStep, err error) {
 	return
 }
 
-func (mc *MerkleClient) LookupPath(q HTTPArgs, sigHints *SigHints) (vp *VerificationPath, err error) {
+func (mc *MerkleClient) LookupPath(ctx context.Context, q HTTPArgs, sigHints *SigHints) (vp *VerificationPath, err error) {
 
 	// Poll for 10s and ask for a race-free state.
 	q.Add("poll", I{10})
@@ -300,6 +301,7 @@ func (mc *MerkleClient) LookupPath(q HTTPArgs, sigHints *SigHints) (vp *Verifica
 		NeedSession:    false,
 		Args:           q,
 		AppStatusCodes: []int{SCOk, SCNotFound, SCDeleted},
+		NetContext:     ctx,
 	})
 
 	if err != nil {
@@ -410,7 +412,7 @@ func (mc *MerkleClient) findValidKIDAndSig(root *MerkleRoot) (keybase1.KID, stri
 	return nilKID, "", MerkleClientError{"no known verifying key"}
 }
 
-func (mc *MerkleClient) VerifyRoot(root *MerkleRoot, seqnoWhenCalled Seqno) error {
+func (mc *MerkleClient) verifyRoot(ctx context.Context, root *MerkleRoot, seqnoWhenCalled Seqno) error {
 
 	// First make sure it's not a rollback
 	if seqnoWhenCalled >= 0 && seqnoWhenCalled > root.seqno {
@@ -418,7 +420,7 @@ func (mc *MerkleClient) VerifyRoot(root *MerkleRoot, seqnoWhenCalled Seqno) erro
 			seqnoWhenCalled, root.seqno)
 	}
 
-	mc.G().Log.Debug("| Merkle root: got back %d, >= cached %d", int(root.seqno), int(seqnoWhenCalled))
+	mc.G().Log.CDebugf(ctx, "| Merkle root: got back %d, >= cached %d", int(root.seqno), int(seqnoWhenCalled))
 
 	mc.Lock()
 	defer mc.Unlock()
@@ -433,14 +435,14 @@ func (mc *MerkleClient) VerifyRoot(root *MerkleRoot, seqnoWhenCalled Seqno) erro
 	if err != nil {
 		return err
 	}
-	mc.G().Log.Debug("+ Merkle: using KID=%s for verifying server sig", kid)
+	mc.G().Log.CDebugf(ctx, "+ Merkle: using KID=%s for verifying server sig", kid)
 
 	key, err := mc.keyring.Load(kid)
 	if err != nil {
 		return err
 	}
 
-	mc.G().Log.Debug("- Merkle: server sig verified")
+	mc.G().Log.CDebugf(ctx, "- Merkle: server sig verified")
 
 	if key == nil {
 		return MerkleClientError{"no known verifying key"}
@@ -544,11 +546,11 @@ func parseV2(jw *jsonw.Wrapper) (*MerkleUserLeaf, error) {
 	return &user, nil
 }
 
-func parseMerkleUserLeaf(jw *jsonw.Wrapper, g *GlobalContext) (user *MerkleUserLeaf, err error) {
-	g.Log.Debug("+ ParsingMerkleUserLeaf")
+func parseMerkleUserLeaf(ctx context.Context, jw *jsonw.Wrapper, g *GlobalContext) (user *MerkleUserLeaf, err error) {
+	g.Log.CDebugf(ctx, "+ ParsingMerkleUserLeaf")
 
 	if jw == nil {
-		g.Log.Debug("| empty leaf found; user wasn't in tree")
+		g.Log.CDebugf(ctx, "| empty leaf found; user wasn't in tree")
 		user = &MerkleUserLeaf{}
 		return
 	}
@@ -582,23 +584,23 @@ func parseMerkleUserLeaf(jw *jsonw.Wrapper, g *GlobalContext) (user *MerkleUserL
 		err = fmt.Errorf("Unexpected version: %d", v)
 	}
 
-	g.Log.Debug("- ParsingMerkleUserLeaf -> %v", ErrToOk(err))
+	g.Log.CDebugf(ctx, "- ParsingMerkleUserLeaf -> %v", ErrToOk(err))
 	return
 }
 
-func (vp *VerificationPath) VerifyUsername() (username string, err error) {
+func (vp *VerificationPath) verifyUsername(ctx context.Context) (username string, err error) {
 	if CheckUIDAgainstUsername(vp.uid, vp.username) == nil {
-		vp.G().Log.Debug("| Username %s mapped to %s via direct hash", vp.username, vp.uid)
+		vp.G().Log.CDebugf(ctx, "| Username %s mapped to %s via direct hash", vp.username, vp.uid)
 		username = vp.username
 		return
 	}
 
-	vp.G().Log.Debug("| Failed to map Username %s -> UID %s via direct hash", vp.username, vp.uid)
+	vp.G().Log.CDebugf(ctx, "| Failed to map Username %s -> UID %s via direct hash", vp.username, vp.uid)
 
 	if vp.usernameCased != vp.username && strings.ToLower(vp.usernameCased) == vp.username {
-		vp.G().Log.Debug("| Checking cased username difference: %s v %s", vp.username, vp.usernameCased)
+		vp.G().Log.CDebugf(ctx, "| Checking cased username difference: %s v %s", vp.username, vp.usernameCased)
 		if CheckUIDAgainstCasedUsername(vp.uid, vp.usernameCased) == nil {
-			vp.G().Log.Debug("| Username %s mapped to %s via direct hash (w/ username casing)", vp.usernameCased, vp.uid)
+			vp.G().Log.CDebugf(ctx, "| Username %s mapped to %s via direct hash (w/ username casing)", vp.usernameCased, vp.uid)
 			username = vp.username
 			return
 		}
@@ -626,13 +628,13 @@ func (vp *VerificationPath) VerifyUsername() (username string, err error) {
 		return
 	}
 
-	vp.G().Log.Debug("| Username %s mapped to %s via Merkle lookup", vp.username, vp.uid)
+	vp.G().Log.CDebugf(ctx, "| Username %s mapped to %s via Merkle lookup", vp.username, vp.uid)
 	username = vp.username
 
 	return
 }
 
-func (vp *VerificationPath) VerifyUser() (user *MerkleUserLeaf, err error) {
+func (vp *VerificationPath) verifyUser(ctx context.Context) (user *MerkleUserLeaf, err error) {
 	curr := vp.root.rootHash
 
 	var leaf *jsonw.Wrapper
@@ -648,12 +650,12 @@ func (vp *VerificationPath) VerifyUser() (user *MerkleUserLeaf, err error) {
 	if err == nil {
 		// noop
 	} else if _, ok := err.(MerkleNotFoundError); ok {
-		vp.G().Log.Debug(fmt.Sprintf("In checking Merkle tree: %s", err))
+		vp.G().Log.CDebugf(ctx, fmt.Sprintf("In checking Merkle tree: %s", err))
 	} else {
 		return
 	}
 
-	user, err = parseMerkleUserLeaf(leaf, vp.G())
+	user, err = parseMerkleUserLeaf(ctx, leaf, vp.G())
 	if user != nil {
 		user.uid = vp.uid
 	}
@@ -713,13 +715,13 @@ func (path PathSteps) VerifyPath(curr NodeHash, uidS string) (juser *jsonw.Wrapp
 	return
 }
 
-func (mc *MerkleClient) LookupUser(q HTTPArgs, sigHints *SigHints) (u *MerkleUserLeaf, err error) {
+func (mc *MerkleClient) LookupUser(ctx context.Context, q HTTPArgs, sigHints *SigHints) (u *MerkleUserLeaf, err error) {
 
-	mc.G().Log.Debug("+ MerkleClient.LookupUser(%v)", q)
+	mc.G().Log.CDebugf(ctx, "+ MerkleClient.LookupUser(%v)", q)
 
 	var path *VerificationPath
 
-	if err = mc.Init(); err != nil {
+	if err = mc.init(ctx); err != nil {
 		return
 	}
 
@@ -730,29 +732,29 @@ func (mc *MerkleClient) LookupUser(q HTTPArgs, sigHints *SigHints) (u *MerkleUse
 	// was a change on the server side. See CORE-4064.
 	seqnoBeforeCall := mc.LastSeqno()
 
-	mc.G().Log.Debug("| LookupPath")
-	if path, err = mc.LookupPath(q, sigHints); err != nil {
+	mc.G().Log.CDebugf(ctx, "| LookupPath")
+	if path, err = mc.LookupPath(ctx, q, sigHints); err != nil {
 		return
 	}
 
-	mc.G().Log.Debug("| VerifyRoot")
-	if err = mc.VerifyRoot(path.root, seqnoBeforeCall); err != nil {
+	mc.G().Log.CDebugf(ctx, "| VerifyRoot")
+	if err = mc.verifyRoot(ctx, path.root, seqnoBeforeCall); err != nil {
 		return
 	}
 
-	mc.G().Log.Debug("| VerifyUser")
-	if u, err = path.VerifyUser(); err != nil {
+	mc.G().Log.CDebugf(ctx, "| VerifyUser")
+	if u, err = path.verifyUser(ctx); err != nil {
 		return
 	}
 
-	mc.G().Log.Debug("| VerifyUsername")
-	if u.username, err = path.VerifyUsername(); err != nil {
+	mc.G().Log.CDebugf(ctx, "| VerifyUsername")
+	if u.username, err = path.verifyUsername(ctx); err != nil {
 		return
 	}
 
 	u.idVersion = path.idVersion
 
-	mc.G().Log.Debug("- MerkleClient.LookupUser(%v) -> OK", q)
+	mc.G().Log.CDebugf(ctx, "- MerkleClient.LookupUser(%v) -> OK", q)
 	return
 }
 
@@ -775,7 +777,7 @@ func (mr *MerkleRoot) ToInfo() chat1.MerkleRoot {
 
 func (mc *MerkleClient) LastRootToSigJSON() (ret *jsonw.Wrapper, err error) {
 	// Lazy-init, only when needed.
-	if err = mc.Init(); err == nil {
+	if err = mc.init(context.TODO()); err == nil {
 		mc.RLock()
 		if mc.lastRoot != nil {
 			ret = mc.lastRoot.ToSigJSON()
@@ -788,7 +790,7 @@ func (mc *MerkleClient) LastRootToSigJSON() (ret *jsonw.Wrapper, err error) {
 // Can return (nil, nil) if no root is known.
 func (mc *MerkleClient) LastRootInfo() (*chat1.MerkleRoot, error) {
 	// Lazy-init, only when needed.
-	err := mc.Init()
+	err := mc.init(context.TODO())
 	if err != nil {
 		return nil, err
 	}

--- a/go/libkb/net_context.go
+++ b/go/libkb/net_context.go
@@ -1,0 +1,26 @@
+package libkb
+
+import (
+	"github.com/keybase/client/go/logger"
+	"golang.org/x/net/context"
+)
+
+func WithLogTag(ctx context.Context, k string) context.Context {
+	addLogTags := true
+	if tags, ok := logger.LogTagsFromContext(ctx); ok {
+		if _, found := tags[k]; found {
+			addLogTags = false
+		}
+	}
+	if addLogTags {
+		newTags := make(logger.CtxLogTags)
+		newTags[k] = k
+		ctx = logger.NewContextWithLogTags(ctx, newTags)
+	}
+
+	if _, found := ctx.Value(k).(string); !found {
+		tag := RandStringB64(3)
+		ctx = context.WithValue(ctx, k, tag)
+	}
+	return ctx
+}

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -9,6 +9,7 @@ import (
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	jsonw "github.com/keybase/go-jsonw"
+	"golang.org/x/net/context"
 	"stathat.com/c/ramcache"
 )
 
@@ -71,24 +72,24 @@ func (r *Resolver) resolve(input string, withBody bool) (res ResolveResult) {
 	if au, res.err = ParseAssertionURL(r.G().MakeAssertionContext(), input, false); res.err != nil {
 		return res
 	}
-	res = r.resolveURL(au, input, withBody, false)
+	res = r.resolveURL(context.TODO(), au, input, withBody, false)
 	return res
 }
 
 func (r *Resolver) ResolveFullExpression(input string) (res ResolveResult) {
-	return r.resolveFullExpression(input, false, false)
+	return r.resolveFullExpression(context.TODO(), input, false, false)
 }
 
 func (r *Resolver) ResolveFullExpressionNeedUsername(input string) (res ResolveResult) {
-	return r.resolveFullExpression(input, false, true)
+	return r.resolveFullExpression(context.TODO(), input, false, true)
 }
 
-func (r *Resolver) ResolveFullExpressionWithBody(input string) (res ResolveResult) {
-	return r.resolveFullExpression(input, true, false)
+func (r *Resolver) ResolveFullExpressionWithBody(ctx context.Context, input string) (res ResolveResult) {
+	return r.resolveFullExpression(ctx, input, true, false)
 }
 
-func (r *Resolver) resolveFullExpression(input string, withBody bool, needUsername bool) (res ResolveResult) {
-	defer r.G().Trace(fmt.Sprintf("Resolver#resolveFullExpression(%q)", input), func() error { return res.err })()
+func (r *Resolver) resolveFullExpression(ctx context.Context, input string, withBody bool, needUsername bool) (res ResolveResult) {
+	defer r.G().CTrace(ctx, fmt.Sprintf("Resolver#resolveFullExpression(%q)", input), func() error { return res.err })()
 
 	var expr AssertionExpression
 	expr, res.err = AssertionParseAndOnly(r.G().MakeAssertionContext(), input)
@@ -100,16 +101,16 @@ func (r *Resolver) resolveFullExpression(input string, withBody bool, needUserna
 		res.err = ResolutionError{Input: input, Msg: "Cannot find a resolvable factor"}
 		return res
 	}
-	return r.resolveURL(u, input, withBody, needUsername)
+	return r.resolveURL(ctx, u, input, withBody, needUsername)
 }
 
-func (r *Resolver) getFromDiskCache(key string) (ret *ResolveResult) {
-	defer r.G().TraceOK(fmt.Sprintf("Resolver#getFromDiskCache(%q)", key), func() bool { return ret != nil })()
+func (r *Resolver) getFromDiskCache(ctx context.Context, key string) (ret *ResolveResult) {
+	defer r.G().CTraceOK(ctx, fmt.Sprintf("Resolver#getFromDiskCache(%q)", key), func() bool { return ret != nil })()
 	var uid keybase1.UID
 	found, err := r.G().LocalDb.GetInto(&uid, resolveDbKey(key))
 	r.Stats.diskGets++
 	if err != nil {
-		r.G().Log.Warning("Problem fetching resolve result from local DB: %s", err)
+		r.G().Log.CWarningf(ctx, "Problem fetching resolve result from local DB: %s", err)
 		return nil
 	}
 	if !found {
@@ -120,7 +121,7 @@ func (r *Resolver) getFromDiskCache(key string) (ret *ResolveResult) {
 	return &ResolveResult{uid: uid}
 }
 
-func (r *Resolver) resolveURL(au AssertionURL, input string, withBody bool, needUsername bool) ResolveResult {
+func (r *Resolver) resolveURL(ctx context.Context, au AssertionURL, input string, withBody bool, needUsername bool) ResolveResult {
 
 	// A standard keybase UID, so it's already resolved... unless we explicitly
 	// need it!
@@ -132,17 +133,17 @@ func (r *Resolver) resolveURL(au AssertionURL, input string, withBody bool, need
 
 	ck := au.CacheKey()
 
-	if p := r.getFromMemCache(ck); p != nil && (!needUsername || len(p.resolvedKbUsername) > 0) {
+	if p := r.getFromMemCache(ctx, ck); p != nil && (!needUsername || len(p.resolvedKbUsername) > 0) {
 		return *p
 	}
 
-	if p := r.getFromDiskCache(ck); p != nil && (!needUsername || len(p.resolvedKbUsername) > 0) {
+	if p := r.getFromDiskCache(ctx, ck); p != nil && (!needUsername || len(p.resolvedKbUsername) > 0) {
 		p.mutable = !au.IsKeybase()
 		r.putToMemCache(ck, *p)
 		return *p
 	}
 
-	res := r.resolveURLViaServerLookup(au, input, withBody)
+	res := r.resolveURLViaServerLookup(ctx, au, input, withBody)
 
 	// Cache for a shorter period of time if it's not a Keybase identity
 	res.mutable = !au.IsKeybase()
@@ -152,8 +153,8 @@ func (r *Resolver) resolveURL(au AssertionURL, input string, withBody bool, need
 	return res
 }
 
-func (r *Resolver) resolveURLViaServerLookup(au AssertionURL, input string, withBody bool) (res ResolveResult) {
-	defer r.G().Trace(fmt.Sprintf("resolvedKbUsername#resolveURLViaServerLookup(input = %q)", input), func() error { return res.err })()
+func (r *Resolver) resolveURLViaServerLookup(ctx context.Context, au AssertionURL, input string, withBody bool) (res ResolveResult) {
+	defer r.G().CTrace(ctx, fmt.Sprintf("Reoslver#resolveURLViaServerLookup(input = %q)", input), func() error { return res.err })()
 
 	var key, val string
 	var ares *APIRes
@@ -181,19 +182,20 @@ func (r *Resolver) resolveURLViaServerLookup(au AssertionURL, input string, with
 		NeedSession:    false,
 		Args:           ha,
 		AppStatusCodes: []int{SCOk, SCNotFound, SCDeleted},
+		NetContext:     ctx,
 	})
 
 	if res.err != nil {
-		r.G().Log.Debug("API user/lookup %q error: %s", input, res.err)
+		r.G().Log.CDebugf(ctx, "API user/lookup %q error: %s", input, res.err)
 		return
 	}
 	switch ares.AppStatus.Code {
 	case SCNotFound:
-		r.G().Log.Debug("API user/lookup %q not found", input)
+		r.G().Log.CDebugf(ctx, "API user/lookup %q not found", input)
 		res.err = NotFoundError{}
 		return
 	case SCDeleted:
-		r.G().Log.Debug("API user/lookup %q deleted", input)
+		r.G().Log.CDebugf(ctx, "API user/lookup %q deleted", input)
 		res.err = DeletedError{Msg: fmt.Sprintf("user %q deleted", input)}
 		return
 	}
@@ -267,8 +269,8 @@ func (r *Resolver) Shutdown() {
 	r.cache.Shutdown()
 }
 
-func (r *Resolver) getFromMemCache(key string) (ret *ResolveResult) {
-	defer r.G().TraceOK(fmt.Sprintf("Resolver#getFromMemCache(%q)", key), func() bool { return ret != nil })()
+func (r *Resolver) getFromMemCache(ctx context.Context, key string) (ret *ResolveResult) {
+	defer r.G().CTraceOK(ctx, fmt.Sprintf("Resolver#getFromMemCache(%q)", key), func() bool { return ret != nil })()
 	if r.cache == nil {
 		return nil
 	}

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -76,12 +76,12 @@ func (r *Resolver) resolve(input string, withBody bool) (res ResolveResult) {
 	return res
 }
 
-func (r *Resolver) ResolveFullExpression(input string) (res ResolveResult) {
-	return r.resolveFullExpression(context.TODO(), input, false, false)
+func (r *Resolver) ResolveFullExpression(ctx context.Context, input string) (res ResolveResult) {
+	return r.resolveFullExpression(ctx, input, false, false)
 }
 
-func (r *Resolver) ResolveFullExpressionNeedUsername(input string) (res ResolveResult) {
-	return r.resolveFullExpression(context.TODO(), input, false, true)
+func (r *Resolver) ResolveFullExpressionNeedUsername(ctx context.Context, input string) (res ResolveResult) {
+	return r.resolveFullExpression(ctx, input, false, true)
 }
 
 func (r *Resolver) ResolveFullExpressionWithBody(ctx context.Context, input string) (res ResolveResult) {

--- a/go/libkb/sig_chain_test.go
+++ b/go/libkb/sig_chain_test.go
@@ -179,7 +179,7 @@ func doChainTest(t *testing.T, testCase TestCase) {
 		sigchain.chainLinks = append(sigchain.chainLinks, link)
 	}
 	if sigchainErr == nil {
-		_, sigchainErr = sigchain.VerifySigsAndComputeKeys(eldestKID, &ckf)
+		_, sigchainErr = sigchain.VerifySigsAndComputeKeys(nil, eldestKID, &ckf)
 	}
 
 	// Some tests expect an error. If we get one, make sure it's the right

--- a/go/libkb/sig_info.go
+++ b/go/libkb/sig_info.go
@@ -1,0 +1,6 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package libkb
+
+import ()

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base32"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -386,6 +387,14 @@ func RandString(prefix string, numbytes int) (string, error) {
 		str = strings.Join([]string{prefix, str}, "")
 	}
 	return str, nil
+}
+
+func RandStringB64(numTriads int) string {
+	buf, err := RandBytes(numTriads * 3)
+	if err != nil {
+		return ""
+	}
+	return base64.URLEncoding.EncodeToString(buf)
 }
 
 func Trace(log logger.Logger, msg string, f func() error) func() {

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
 )
 
 // PrereleaseBuild can be set at compile time for prerelease builds.
@@ -392,17 +393,36 @@ func Trace(log logger.Logger, msg string, f func() error) func() {
 	return func() { log.Debug("- %s -> %s", msg, ErrToOk(f())) }
 }
 
+func CTrace(ctx context.Context, log logger.Logger, msg string, f func() error) func() {
+	log.CDebugf(ctx, "+ %s", msg)
+	return func() { log.CDebugf(ctx, "- %s -> %s", msg, ErrToOk(f())) }
+}
+
 func TraceOK(log logger.Logger, msg string, f func() bool) func() {
 	log.Debug("+ %s", msg)
 	return func() { log.Debug("- %s -> %v", msg, f()) }
 }
 
+func CTraceOK(ctx context.Context, log logger.Logger, msg string, f func() bool) func() {
+	log.CDebugf(ctx, "+ %s", msg)
+	return func() { log.CDebugf(ctx, "- %s -> %v", msg, f()) }
+}
+
+
 func (g *GlobalContext) Trace(msg string, f func() error) func() {
 	return Trace(g.Log, msg, f)
 }
 
+func (g *GlobalContext) CTrace(ctx context.Context, msg string, f func() error) func() {
+	return CTrace(ctx, g.Log, msg, f)
+}
+
 func (g *GlobalContext) TraceOK(msg string, f func() bool) func() {
 	return TraceOK(g.Log, msg, f)
+}
+
+func (g *GlobalContext) CTraceOK(ctx context.Context, msg string, f func() bool) func() {
+	return CTraceOK(ctx, g.Log, msg, f)
 }
 
 // SplitByRunes splits string by runes

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
 	"golang.org/x/net/context"
 )
 
@@ -407,6 +408,14 @@ func CTrace(ctx context.Context, log logger.Logger, msg string, f func() error) 
 	return func() { log.CDebugf(ctx, "- %s -> %s", msg, ErrToOk(f())) }
 }
 
+func CTraceTimed(ctx context.Context, log logger.Logger, msg string, f func() error, cl clockwork.Clock) func() {
+	log.CDebugf(ctx, "+ %s", msg)
+	start := cl.Now()
+	return func() {
+		log.CDebugf(ctx, "- %s -> %v [time=%s]", msg, f(), cl.Since(start))
+	}
+}
+
 func TraceOK(log logger.Logger, msg string, f func() bool) func() {
 	log.Debug("+ %s", msg)
 	return func() { log.Debug("- %s -> %v", msg, f()) }
@@ -424,6 +433,10 @@ func (g *GlobalContext) Trace(msg string, f func() error) func() {
 
 func (g *GlobalContext) CTrace(ctx context.Context, msg string, f func() error) func() {
 	return CTrace(ctx, g.Log, msg, f)
+}
+
+func (g *GlobalContext) CTraceTimed(ctx context.Context, msg string, f func() error) func() {
+	return CTraceTimed(ctx, g.Log, msg, f, g.Clock())
 }
 
 func (g *GlobalContext) TraceOK(msg string, f func() bool) func() {
@@ -492,6 +505,12 @@ func Digest(r io.Reader) (string, error) {
 //    defer TimeLog("MyFunc", time.Now(), e.G().Log.Warning)
 func TimeLog(name string, start time.Time, out func(string, ...interface{})) {
 	out("time> %s: %s", name, time.Since(start))
+}
+
+// CTimeLog calls out with the time since start.  Use like this:
+//    defer CTimeLog(ctx, "MyFunc", time.Now(), e.G().Log.Warning)
+func CTimeLog(ctx context.Context, name string, start time.Time, out func(context.Context, string, ...interface{})) {
+	out(ctx, "time> %s: %s", name, time.Since(start))
 }
 
 func WhitespaceNormalize(s string) string {

--- a/go/libkb/x
+++ b/go/libkb/x
@@ -1,0 +1,172 @@
+=== RUN   TestCachedUserLoad
+shitass <nil> true
+shitass &{{295a7eea607af32040647123732bc819 t_alice [] [] 1 {33 3 3 449884800000 0}} [{01010d3a98c56466fcda42e945bd1641da4e29ded110eda9ed27d96d10df899b5d850a 2373fd089f28f328916b88f99c7927c0bdfdadf9 [{Test 0 test+t_0@test.keybase.io}] true true     1424293518000 1581973518000}]} true
+returning at fresh
+--- FAIL: TestCachedUserLoad (0.13s)
+	test_logger.go:56: 2016-11-18 14:11:03.693999708 -0500 EST test_common.go:206: [D] SetupTest CachedUserLoader_1fac70209e
+	test_logger.go:56: 2016-11-18 14:11:03.69406694 -0500 EST login_state.go:920: [D] + LoginState: Running request loop
+	test_logger.go:56: 2016-11-18 14:11:03.694101757 -0500 EST test_common.go:215: [D] SetupTest home directory: /var/folders/p2/d6br3rk10rg9mp3pnknx1cyw0000gp/T/CachedUserLoader_1fac70209e062219486
+	test_logger.go:56: 2016-11-18 14:11:03.694292515 -0500 EST json.go:50: [D] + loading config file: /var/folders/p2/d6br3rk10rg9mp3pnknx1cyw0000gp/T/CachedUserLoader_1fac70209e062219486/Library/Application Support/KeybaseDevel/config.json
+	test_logger.go:56: 2016-11-18 14:11:03.69432016 -0500 EST json.go:58: [D] No config file found; tried /var/folders/p2/d6br3rk10rg9mp3pnknx1cyw0000gp/T/CachedUserLoader_1fac70209e062219486/Library/Application Support/KeybaseDevel/config.json
+	test_logger.go:56: 2016-11-18 14:11:03.694374808 -0500 EST globals.go:302: [D] Created Identify2Cache, max age: 5m0s
+	test_logger.go:56: 2016-11-18 14:11:03.694424204 -0500 EST globals.go:305: [D] Created LinkCache, max size: 65536, clean dur: 1m0s
+	test_logger.go:56: 2016-11-18 14:11:03.694441656 -0500 EST globals.go:307: [D] Created CardCache, max age: 5m0s
+	test_logger.go:56: 2016-11-18 14:11:03.69450183 -0500 EST util.go:391: [D] + CachedUserLoader#Load(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.69451373 -0500 EST locktab.go:50: [D] + LockTable.Lock(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.694520326 -0500 EST locktab.go:60: [D] - LockTable.Lock(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.694532381 -0500 EST cached_user_loader.go:32: [D] | missed cached
+	test_logger.go:56: 2016-11-18 14:11:03.694574499 -0500 EST loaduser.go:139: [D] LoadUser: {Contextified:{g:<nil>} UID:295a7eea607af32040647123732bc819 Name: PublicKeyOptional:false NoCacheResult:false Self:false ForceReload:false AllKeys:false LoginContext:<nil> AbortIfSigchainUnchanged:false ResolveBody:<nil> MerkleLeaf:<nil> SigHints:<nil>}
+	test_logger.go:56: 2016-11-18 14:11:03.694594758 -0500 EST loaduser.go:157: [D] + LoadUser(uid=295a7eea607af32040647123732bc819, name=)
+	test_logger.go:56: 2016-11-18 14:11:03.694605156 -0500 EST login_state.go:1046: [D] + Account "G - GetMyUID - GetUID"
+	test_logger.go:56: 2016-11-18 14:11:03.694627367 -0500 EST login_state.go:1048: [D] - Account "G - GetMyUID - GetUID"
+	test_logger.go:56: 2016-11-18 14:11:03.694637681 -0500 EST loaduser.go:168: [D] | resolved to 295a7eea607af32040647123732bc819
+	test_logger.go:56: 2016-11-18 14:11:03.694649723 -0500 EST sig_hints.go:126: [D] + LoadSigHints(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.69466661 -0500 EST leveldb.go:109: [D] + LevelDb.open
+	test_logger.go:56: 2016-11-18 14:11:03.694671757 -0500 EST leveldb.go:111: [D] | Opening LevelDB for local cache: &{{{0 0} 0 0 1 0} <nil> 0xc4201a53d0 /var/folders/p2/d6br3rk10rg9mp3pnknx1cyw0000gp/T/CachedUserLoader_1fac70209e062219486/Library/Application Support/KeybaseDevel/keybase.leveldb {0xc42008b600}} /var/folders/p2/d6br3rk10rg9mp3pnknx1cyw0000gp/T/CachedUserLoader_1fac70209e062219486/Library/Application Support/KeybaseDevel/keybase.leveldb
+	test_logger.go:56: 2016-11-18 14:11:03.697040589 -0500 EST leveldb.go:124: [D] - LevelDb.open -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.697084619 -0500 EST sig_hints.go:135: [D] | SigHints loaded @v0
+	test_logger.go:56: 2016-11-18 14:11:03.697091809 -0500 EST sig_hints.go:137: [D] - LoadSigHints(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.697099751 -0500 EST loaduser.go:288: [D] + loadUserFromLocalStorage(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.697112563 -0500 EST loaduser.go:295: [D] - loadUserFromLocalStorage(295a7eea607af32040647123732bc819): Not found
+	test_logger.go:56: 2016-11-18 14:11:03.697124325 -0500 EST merkle_client.go:708: [D] + MerkleClient.LookupUser(map[uid:295a7eea607af32040647123732bc819])
+	test_logger.go:56: 2016-11-18 14:11:03.697140163 -0500 EST merkle_client.go:170: [D] + MerkleClient.LoadRoot()
+	test_logger.go:56: 2016-11-18 14:11:03.697148208 -0500 EST merkle_client.go:176: [D] - MerkleClient.LoadRoot() -> nil
+	test_logger.go:56: 2016-11-18 14:11:03.697155211 -0500 EST merkle_client.go:723: [D] | LookupPath
+	test_logger.go:56: 2016-11-18 14:11:03.697178152 -0500 EST api.go:140: [D] + API GET request to http://localhost:3000/_/api/1.0/merkle/path.json?poll=10&sig_hints_low=0&uid=295a7eea607af32040647123732bc819
+	test_logger.go:56: 2016-11-18 14:11:03.697204373 -0500 EST api.go:196: [D] | doRequestShared(fixHeaders) for merkle/path
+	test_logger.go:56: 2016-11-18 14:11:03.69722168 -0500 EST api.go:196: [D] | doRequestShared(getCli) for merkle/path
+	test_logger.go:56: 2016-11-18 14:11:03.697227446 -0500 EST api.go:129: [D] | Cli wasn't found; remaking for cookied=false
+	test_logger.go:56: 2016-11-18 14:11:03.69724283 -0500 EST api.go:196: [D] | doRequestShared(Do) for merkle/path
+	test_logger.go:56: 2016-11-18 14:11:03.728520716 -0500 EST api.go:196: [D] | doRequestShared(Done) for merkle/path
+	test_logger.go:56: 2016-11-18 14:11:03.728546119 -0500 EST api.go:233: [D] | Result is: 200 OK
+	test_logger.go:56: 2016-11-18 14:11:03.728945747 -0500 EST api.go:644: [D] - API call merkle/path success
+	test_logger.go:56: 2016-11-18 14:11:03.728969548 -0500 EST util.go:391: [D] + RefreshWith
+	test_logger.go:56: 2016-11-18 14:11:03.729003022 -0500 EST util.go:392: [D] - RefreshWith -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.729058159 -0500 EST merkle_client.go:728: [D] | VerifyRoot
+	test_logger.go:56: 2016-11-18 14:11:03.7290658 -0500 EST merkle_client.go:411: [D] | Merkle root: got back 205647, >= cached -1
+	test_logger.go:56: 2016-11-18 14:11:03.729073572 -0500 EST merkle_client.go:426: [D] + Merkle: using KID=0101be58b6c82db64f6ccabb05088db443c69f87d5d48857d709ed6f73948dabe67d0a for verifying server sig
+	test_logger.go:56: 2016-11-18 14:11:03.729085719 -0500 EST special_keys.go:69: [D] + SpecialKeyRing.Load(0101be58b6c82db64f6ccabb05088db443c69f87d5d48857d709ed6f73948dabe67d0a)
+	test_logger.go:56: 2016-11-18 14:11:03.72910487 -0500 EST special_keys.go:85: [D] | Load(0101be58b6c82db64f6ccabb05088db443c69f87d5d48857d709ed6f73948dabe67d0a) going to network
+	test_logger.go:56: 2016-11-18 14:11:03.729117255 -0500 EST api.go:140: [D] + API GET request to http://localhost:3000/_/api/1.0/key/special.json?kid=0101be58b6c82db64f6ccabb05088db443c69f87d5d48857d709ed6f73948dabe67d0a
+	test_logger.go:56: 2016-11-18 14:11:03.729132557 -0500 EST api.go:196: [D] | doRequestShared(fixHeaders) for key/special
+	test_logger.go:56: 2016-11-18 14:11:03.729142691 -0500 EST api.go:196: [D] | doRequestShared(getCli) for key/special
+	test_logger.go:56: 2016-11-18 14:11:03.729149039 -0500 EST api.go:196: [D] | doRequestShared(Do) for key/special
+	test_logger.go:56: 2016-11-18 14:11:03.732098018 -0500 EST api.go:196: [D] | doRequestShared(Done) for key/special
+	test_logger.go:56: 2016-11-18 14:11:03.732122201 -0500 EST api.go:233: [D] | Result is: 200 OK
+	test_logger.go:56: 2016-11-18 14:11:03.732236025 -0500 EST api.go:644: [D] - API call key/special success
+	test_logger.go:56: 2016-11-18 14:11:03.732797377 -0500 EST pgp_key.go:175: [D] | Storing Key (kid=0101be58b6c82db64f6ccabb05088db443c69f87d5d48857d709ed6f73948dabe67d0a) to Local DB
+	test_logger.go:56: 2016-11-18 14:11:03.732981749 -0500 EST special_keys.go:113: [D] - SpecialKeyRing.Load(0101be58b6c82db64f6ccabb05088db443c69f87d5d48857d709ed6f73948dabe67d0a)
+	test_logger.go:56: 2016-11-18 14:11:03.732999516 -0500 EST merkle_client.go:433: [D] - Merkle: server sig verified
+	test_logger.go:56: 2016-11-18 14:11:03.733385116 -0500 EST merkle_client.go:733: [D] | VerifyUser
+	test_logger.go:56: 2016-11-18 14:11:03.733619715 -0500 EST merkle_client.go:538: [D] + ParsingMerkleUserLeaf
+	test_logger.go:56: 2016-11-18 14:11:03.733639403 -0500 EST merkle_client.go:575: [D] - ParsingMerkleUserLeaf -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.733645791 -0500 EST merkle_client.go:738: [D] | VerifyUsername
+	test_logger.go:56: 2016-11-18 14:11:03.733664718 -0500 EST merkle_client.go:581: [D] | Username t_alice mapped to 295a7eea607af32040647123732bc819 via direct hash
+	test_logger.go:56: 2016-11-18 14:11:03.733674537 -0500 EST merkle_client.go:745: [D] - MerkleClient.LookupUser(map[uid:295a7eea607af32040647123732bc819 poll:10 sig_hints_low:0]) -> OK
+	test_logger.go:56: 2016-11-18 14:11:03.733690339 -0500 EST loaduser.go:259: [D] | No local user stored for 295a7eea607af32040647123732bc819
+	test_logger.go:56: 2016-11-18 14:11:03.733696299 -0500 EST loaduser.go:268: [D] | Freshness: basics=false; for 295a7eea607af32040647123732bc819
+	test_logger.go:56: 2016-11-18 14:11:03.733701755 -0500 EST loaduser.go:344: [D] + Load User from server: 295a7eea607af32040647123732bc819
+	test_logger.go:56: 2016-11-18 14:11:03.733715002 -0500 EST api.go:140: [D] + API GET request to http://localhost:3000/_/api/1.0/user/lookup.json?uid=295a7eea607af32040647123732bc819
+	test_logger.go:56: 2016-11-18 14:11:03.733735302 -0500 EST api.go:196: [D] | doRequestShared(fixHeaders) for user/lookup
+	test_logger.go:56: 2016-11-18 14:11:03.733747764 -0500 EST api.go:196: [D] | doRequestShared(getCli) for user/lookup
+	test_logger.go:56: 2016-11-18 14:11:03.733755026 -0500 EST api.go:196: [D] | doRequestShared(Do) for user/lookup
+	test_logger.go:56: 2016-11-18 14:11:03.80588699 -0500 EST api.go:196: [D] | doRequestShared(Done) for user/lookup
+	test_logger.go:56: 2016-11-18 14:11:03.805920384 -0500 EST api.go:233: [D] | Result is: 200 OK
+	test_logger.go:56: 2016-11-18 14:11:03.806188556 -0500 EST api.go:644: [D] - API call user/lookup success
+	test_logger.go:56: 2016-11-18 14:11:03.806215428 -0500 EST util.go:391: [D] + ParseKeyFamily
+	test_logger.go:56: 2016-11-18 14:11:03.806904457 -0500 EST keyfamily.go:131: [D] adding PGP kid 01010d3a98c56466fcda42e945bd1641da4e29ded110eda9ed27d96d10df899b5d850a with full hash fbbabd015f4fe83644059baaee4665fc1bc3548fcf69eed229c7f8b295b26636
+	test_logger.go:56: 2016-11-18 14:11:03.80692457 -0500 EST util.go:392: [D] - ParseKeyFamily -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.806933125 -0500 EST loaduser.go:367: [D] - Load user from server: 295a7eea607af32040647123732bc819 -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.806948098 -0500 EST sig_chain.go:872: [D] + SigChainLoader.Load(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.806964319 -0500 EST sig_chain.go:878: [D] | SigChainLoader.Load(295a7eea607af32040647123732bc819) GetFingerprint
+	test_logger.go:56: 2016-11-18 14:11:03.806969358 -0500 EST sig_chain.go:878: [D] | SigChainLoader.Load(295a7eea607af32040647123732bc819) AccessPreload
+	test_logger.go:56: 2016-11-18 14:11:03.806977892 -0500 EST sig_chain.go:619: [D] | Preload failed
+	test_logger.go:56: 2016-11-18 14:11:03.806982183 -0500 EST sig_chain.go:878: [D] | SigChainLoader.Load(295a7eea607af32040647123732bc819) LoadLinksFromStorage
+	test_logger.go:56: 2016-11-18 14:11:03.806986857 -0500 EST sig_chain.go:637: [D] + SigChainLoader.LoadFromStorage(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.807002022 -0500 EST sig_chain.go:610: [D] | LastLinkId was null
+	test_logger.go:56: 2016-11-18 14:11:03.807010532 -0500 EST sig_chain.go:641: [D] | Failed to load last link ID
+	test_logger.go:56: 2016-11-18 14:11:03.807019023 -0500 EST sig_chain.go:643: [D] | no error loading last link ID from storage
+	test_logger.go:56: 2016-11-18 14:11:03.807025552 -0500 EST sig_chain.go:646: [D] | mt (MerkleTriple) nil result from load last link ID from storage
+	test_logger.go:56: 2016-11-18 14:11:03.807032485 -0500 EST sig_chain.go:638: [D] - SigChainLoader.LoadFromStorage(295a7eea607af32040647123732bc819) -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.807043056 -0500 EST sig_chain.go:878: [D] | SigChainLoader.Load(295a7eea607af32040647123732bc819) MakeSigChain
+	test_logger.go:56: 2016-11-18 14:11:03.807048219 -0500 EST sig_chain.go:878: [D] | SigChainLoader.Load(295a7eea607af32040647123732bc819) VerifyChain
+	test_logger.go:56: 2016-11-18 14:11:03.807056368 -0500 EST sig_chain.go:215: [D] + SigChain::VerifyChain()
+	test_logger.go:56: 2016-11-18 14:11:03.807061292 -0500 EST sig_chain.go:217: [D] - SigChain::VerifyChain() -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.80706562 -0500 EST sig_chain.go:878: [D] | SigChainLoader.Load(295a7eea607af32040647123732bc819) CheckFreshness
+	test_logger.go:56: 2016-11-18 14:11:03.807073678 -0500 EST sig_chain.go:734: [D] + CheckFreshness
+	test_logger.go:56: 2016-11-18 14:11:03.807078495 -0500 EST sig_chain.go:740: [D] | Server triple: &{3 72efdba2829ccac7e2560a696c50384a384da5447528602453b499c3598cfdee c06c0cd9c9328dff400317cb3e0da888259b843d1348066d96c4685a88597f010f}
+	test_logger.go:56: 2016-11-18 14:11:03.807101944 -0500 EST sig_chain.go:749: [D] | Client triple=nil
+	test_logger.go:56: 2016-11-18 14:11:03.807109964 -0500 EST sig_chain.go:754: [D] | Future triple=nil
+	test_logger.go:56: 2016-11-18 14:11:03.807118344 -0500 EST sig_chain.go:783: [D] | Local chain version is out-of-date: -1 < 3
+	test_logger.go:56: 2016-11-18 14:11:03.807124103 -0500 EST sig_chain.go:792: [D] - CheckFreshness (295a7eea607af32040647123732bc819) -> (false,ok)
+	test_logger.go:56: 2016-11-18 14:11:03.807129791 -0500 EST sig_chain.go:878: [D] | SigChainLoader.Load(295a7eea607af32040647123732bc819) LoadFromServer
+	test_logger.go:56: 2016-11-18 14:11:03.807149974 -0500 EST sig_chain.go:292: [D] + GetLastLoadedSeqno()
+	test_logger.go:56: 2016-11-18 14:11:03.807154962 -0500 EST sig_chain.go:294: [D] - GetLastLoadedSeqno() -> 0
+	test_logger.go:56: 2016-11-18 14:11:03.807159515 -0500 EST sig_chain.go:135: [D] + Load SigChain from server (uid=295a7eea607af32040647123732bc819, low=0)
+	test_logger.go:56: 2016-11-18 14:11:03.807172839 -0500 EST api.go:140: [D] + API GET request to http://localhost:3000/_/api/1.0/sig/get.json?low=0&uid=295a7eea607af32040647123732bc819
+	test_logger.go:56: 2016-11-18 14:11:03.807189771 -0500 EST api.go:196: [D] | doRequestShared(fixHeaders) for sig/get
+	test_logger.go:56: 2016-11-18 14:11:03.807199816 -0500 EST api.go:196: [D] | doRequestShared(getCli) for sig/get
+	test_logger.go:56: 2016-11-18 14:11:03.807206044 -0500 EST api.go:196: [D] | doRequestShared(Do) for sig/get
+	test_logger.go:56: 2016-11-18 14:11:03.816737039 -0500 EST api.go:196: [D] | doRequestShared(Done) for sig/get
+	test_logger.go:56: 2016-11-18 14:11:03.816765818 -0500 EST api.go:233: [D] | Result is: 200 OK
+	test_logger.go:56: 2016-11-18 14:11:03.81710925 -0500 EST api.go:644: [D] - API call sig/get success
+	test_logger.go:56: 2016-11-18 14:11:03.817126832 -0500 EST sig_chain.go:159: [D] | Got back 3 new entries
+	test_logger.go:56: 2016-11-18 14:11:03.81728008 -0500 EST chain_link.go:314: [D] | Found chain tail advertised in Merkle tree @3
+	test_logger.go:56: 2016-11-18 14:11:03.817295741 -0500 EST sig_chain.go:136: [D] - Loaded SigChain -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.817303554 -0500 EST sig_chain.go:878: [D] | SigChainLoader.Load(295a7eea607af32040647123732bc819) VerifyChain
+	test_logger.go:56: 2016-11-18 14:11:03.817310084 -0500 EST sig_chain.go:215: [D] + SigChain::VerifyChain()
+	test_logger.go:56: 2016-11-18 14:11:03.818001154 -0500 EST sig_chain.go:217: [D] - SigChain::VerifyChain() -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.818009731 -0500 EST sig_chain.go:878: [D] | SigChainLoader.Load(295a7eea607af32040647123732bc819) Store
+	test_logger.go:56: 2016-11-18 14:11:03.818285718 -0500 EST sig_chain.go:878: [D] | SigChainLoader.Load(295a7eea607af32040647123732bc819) VerifySig
+	test_logger.go:56: 2016-11-18 14:11:03.818297515 -0500 EST sig_chain.go:821: [D] VerifySigsAndComputeKeys(): l.leaf: &{0xc42011f500 <nil> 33 t_alice 295a7eea607af32040647123732bc819 01010d3a98c56466fcda42e945bd1641da4e29ded110eda9ed27d96d10df899b5d850a}, l.leaf.eldest: 01010d3a98c56466fcda42e945bd1641da4e29ded110eda9ed27d96d10df899b5d850a, l.ckf: {{<nil>} 0xc4202150e0 <nil>}
+	test_logger.go:56: 2016-11-18 14:11:03.818319024 -0500 EST sig_chain.go:487: [D] + VerifySigsAndComputeKeys for user 295a7eea607af32040647123732bc819 (eldest = 01010d3a98c56466fcda42e945bd1641da4e29ded110eda9ed27d96d10df899b5d850a)
+	test_logger.go:56: 2016-11-18 14:11:03.818326911 -0500 EST sig_chain.go:215: [D] + SigChain::VerifyChain()
+	test_logger.go:56: 2016-11-18 14:11:03.818336251 -0500 EST sig_chain.go:222: [D] | short-circuit at link 2
+	test_logger.go:56: 2016-11-18 14:11:03.818341564 -0500 EST sig_chain.go:217: [D] - SigChain::VerifyChain() -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.818349574 -0500 EST sig_chain.go:384: [D] + verifySubchain
+	test_logger.go:56: 2016-11-18 14:11:03.81872043 -0500 EST chain_link.go:531: [D] Caching SigCheck for link 72efdba2829ccac7e2560a696c50384a384da5447528602453b499c3598cfdee:
+	test_logger.go:56: 2016-11-18 14:11:03.818729972 -0500 EST sig_chain.go:386: [D] - verifySubchain -> false, ok
+	test_logger.go:56: 2016-11-18 14:11:03.818736006 -0500 EST sig_chain.go:489: [D] - VerifySigsAndComputeKeys for user 295a7eea607af32040647123732bc819 -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.818745564 -0500 EST sig_chain.go:878: [D] | SigChainLoader.Load(295a7eea607af32040647123732bc819) Store
+	test_logger.go:56: 2016-11-18 14:11:03.818794359 -0500 EST sig_chain.go:837: [D] | Storing dirtyTail @ 3 (&{3 72efdba2829ccac7e2560a696c50384a384da5447528602453b499c3598cfdee c06c0cd9c9328dff400317cb3e0da888259b843d1348066d96c4685a88597f010f})
+	test_logger.go:56: 2016-11-18 14:11:03.818977656 -0500 EST sig_chain.go:874: [D] - SigChainLoader.Load(295a7eea607af32040647123732bc819) -> (true, ok)
+	test_logger.go:56: 2016-11-18 14:11:03.818989187 -0500 EST loaduser.go:138: [D] time> SigChainLoader.Load: t_alice: 286003h11m3.818984555s
+	test_logger.go:56: 2016-11-18 14:11:03.818996173 -0500 EST loaduser.go:138: [D] time> LoadSigChains: t_alice: 286003h11m3.818994548s
+	test_logger.go:56: 2016-11-18 14:11:03.819001785 -0500 EST user.go:246: [D] + Store user t_alice
+	test_logger.go:56: 2016-11-18 14:11:03.819006942 -0500 EST sig_hints.go:114: [D] + SigHints.Store() for uid=295a7eea607af32040647123732bc819
+	test_logger.go:56: 2016-11-18 14:11:03.819052896 -0500 EST sig_hints.go:121: [D] - SigHints.Store() for uid=295a7eea607af32040647123732bc819 -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.819061649 -0500 EST user.go:274: [D] + StoreTopLevel
+	test_logger.go:56: 2016-11-18 14:11:03.81917361 -0500 EST user.go:287: [D] - StoreTopLevel -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.819180193 -0500 EST user.go:268: [D] - Store user t_alice -> OK
+	test_logger.go:56: 2016-11-18 14:11:03.819187366 -0500 EST user.go:447: [D] + HasActiveKey
+	test_logger.go:56: 2016-11-18 14:11:03.819201054 -0500 EST user.go:457: [D] | Checking user's ComputedKeyFamily
+	test_logger.go:56: 2016-11-18 14:11:03.819210526 -0500 EST user.go:449: [D] - HasActiveKey -> true
+	test_logger.go:56: 2016-11-18 14:11:03.819258685 -0500 EST util.go:391: [D] + IdentityTable::populate
+	test_logger.go:56: 2016-11-18 14:11:03.819289848 -0500 EST util.go:392: [D] - IdentityTable::populate -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.819296092 -0500 EST user.go:422: [D] + VerifySelfSig for user t_alice
+	test_logger.go:56: 2016-11-18 14:11:03.819306252 -0500 EST id_table.go:1126: [D] | Found self-signature for t_alice @uid=295a7eea607af32040647123732bc819, seq=3, link=72efdba2829ccac7e2560a696c50384a384da5447528602453b499c3598cfdee
+	test_logger.go:56: 2016-11-18 14:11:03.819313818 -0500 EST user.go:425: [D] - VerifySelfSig via SigChain
+	test_logger.go:56: 2016-11-18 14:11:03.8193216 -0500 EST loaduser.go:138: [D] time> LoadUser: {Contextified:{g:<nil>} UID:295a7eea607af32040647123732bc819 Name: PublicKeyOptional:false NoCacheResult:false Self:false ForceReload:false AllKeys:false LoginContext:<nil> AbortIfSigchainUnchanged:false ResolveBody:<nil> MerkleLeaf:<nil> SigHints:<nil>}: 286003h11m3.819319925s
+	test_logger.go:56: 2016-11-18 14:11:03.819349081 -0500 EST keyfamily.go:747: [D] + GetRevokedKeys
+	test_logger.go:56: 2016-11-18 14:11:03.819354997 -0500 EST keyfamily.go:777: [D] - GetRevokedKeys
+	test_logger.go:56: 2016-11-18 14:11:03.819360459 -0500 EST sig_chain.go:278: [D] + GetLastKnownSeqno()
+	test_logger.go:56: 2016-11-18 14:11:03.819365147 -0500 EST sig_chain.go:292: [D] + GetLastLoadedSeqno()
+	test_logger.go:56: 2016-11-18 14:11:03.819369519 -0500 EST sig_chain.go:297: [D] | Fetched from main chain
+	test_logger.go:56: 2016-11-18 14:11:03.819378326 -0500 EST sig_chain.go:294: [D] - GetLastLoadedSeqno() -> 3
+	test_logger.go:56: 2016-11-18 14:11:03.819382979 -0500 EST sig_chain.go:280: [D] - GetLastKnownSeqno() -> 3
+	test_logger.go:56: 2016-11-18 14:11:03.819398933 -0500 EST locktab.go:26: [D] + LockTable.Release(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.81940887 -0500 EST locktab.go:31: [D] | LockTable.unref(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.81941377 -0500 EST locktab.go:35: [D] - LockTable.Unlock(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.819418984 -0500 EST util.go:392: [D] - CachedUserLoader#Load(295a7eea607af32040647123732bc819) -> ok
+	test_logger.go:56: 2016-11-18 14:11:03.819426748 -0500 EST util.go:391: [D] + CachedUserLoader#Load(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.819431341 -0500 EST locktab.go:50: [D] + LockTable.Lock(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.819439787 -0500 EST locktab.go:60: [D] - LockTable.Lock(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.81944498 -0500 EST cached_user_loader.go:38: [D] | cache hit was fresh (cached 6s ago)
+	test_logger.go:56: 2016-11-18 14:11:03.81964258 -0500 EST locktab.go:26: [D] + LockTable.Release(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.819649662 -0500 EST locktab.go:31: [D] | LockTable.unref(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.819654209 -0500 EST locktab.go:35: [D] - LockTable.Unlock(295a7eea607af32040647123732bc819)
+	test_logger.go:56: 2016-11-18 14:11:03.819658678 -0500 EST util.go:392: [D] - CachedUserLoader#Load(295a7eea607af32040647123732bc819) -> ok
+	cached_user_loader_test.go:47: wrong info: {InCache:true TimedOut:false StaleVersion:false LoadedLeaf:false LoadedUser:true}
+FAIL
+exit status 1
+FAIL	github.com/keybase/client/go/libkb	0.148s

--- a/go/logger/single_context_logger.go
+++ b/go/logger/single_context_logger.go
@@ -1,0 +1,79 @@
+package logger
+
+import (
+	"golang.org/x/net/context"
+)
+
+// SingleContextLogger logs everything in the same context. Useful for adding context-logging
+// into code that doesn't yet support it.
+type SingleContextLogger struct {
+	ctx    context.Context
+	logger Logger
+}
+
+func NewSingleContextLogger(ctx context.Context, l Logger) *SingleContextLogger {
+	return &SingleContextLogger{ctx: ctx, logger: l}
+}
+
+var _ Logger = (*SingleContextLogger)(nil)
+
+func (s *SingleContextLogger) Debug(format string, args ...interface{}) {
+	s.logger.CDebugf(s.ctx, format, args...)
+}
+func (s *SingleContextLogger) CDebugf(ctx context.Context, format string, args ...interface{}) {
+	s.logger.CDebugf(ctx, format, args...)
+}
+func (s *SingleContextLogger) Info(format string, args ...interface{}) {
+	s.logger.CInfof(s.ctx, format, args...)
+}
+func (s *SingleContextLogger) CInfof(ctx context.Context, format string, args ...interface{}) {
+	s.logger.CInfof(ctx, format, args...)
+}
+func (s *SingleContextLogger) Notice(format string, args ...interface{}) {
+	s.logger.CNoticef(s.ctx, format, args...)
+}
+func (s *SingleContextLogger) CNoticef(ctx context.Context, format string, args ...interface{}) {
+	s.logger.CNoticef(ctx, format, args...)
+}
+func (s *SingleContextLogger) Warning(format string, args ...interface{}) {
+	s.logger.CWarningf(s.ctx, format, args...)
+}
+func (s *SingleContextLogger) CWarningf(ctx context.Context, format string, args ...interface{}) {
+	s.logger.CWarningf(ctx, format, args...)
+}
+func (s *SingleContextLogger) Error(format string, args ...interface{}) {
+	s.logger.CErrorf(s.ctx, format, args...)
+}
+func (s *SingleContextLogger) Errorf(format string, args ...interface{}) {
+	s.logger.CErrorf(s.ctx, format, args...)
+}
+func (s *SingleContextLogger) CErrorf(ctx context.Context, format string, args ...interface{}) {
+	s.logger.CErrorf(ctx, format, args...)
+}
+func (s *SingleContextLogger) Critical(format string, args ...interface{}) {
+	s.logger.CCriticalf(s.ctx, format, args...)
+}
+func (s *SingleContextLogger) CCriticalf(ctx context.Context, format string, args ...interface{}) {
+	s.logger.CCriticalf(ctx, format, args...)
+}
+func (s *SingleContextLogger) Fatalf(format string, args ...interface{}) {
+	s.logger.CFatalf(s.ctx, format, args...)
+}
+func (s *SingleContextLogger) CFatalf(ctx context.Context, format string, args ...interface{}) {
+	s.logger.CFatalf(ctx, format, args...)
+}
+func (s *SingleContextLogger) Profile(fmts string, arg ...interface{}) {
+	s.logger.Profile(fmts, arg...)
+}
+func (s *SingleContextLogger) Configure(style string, debug bool, filename string) {
+	s.logger.Configure(style, debug, filename)
+}
+func (s *SingleContextLogger) RotateLogFile() error {
+	return s.logger.RotateLogFile()
+}
+func (s *SingleContextLogger) CloneWithAddedDepth(depth int) Logger {
+	return s.logger.CloneWithAddedDepth(depth)
+}
+func (s *SingleContextLogger) SetExternalHandler(handler ExternalHandler) {
+	s.logger.SetExternalHandler(handler)
+}

--- a/go/pvl/debug.go
+++ b/go/pvl/debug.go
@@ -42,24 +42,24 @@ func (ctx *proofContextExtImpl) getStubDNS() *stubDNSEngine {
 
 func debugWithState(g proofContextExt, state scriptState, format string, arg ...interface{}) {
 	s := fmt.Sprintf(format, arg...)
-	g.GetLogPvl().Debug("PVL @(service:%v script:%v pc:%v) %v",
+	g.GetLogPvl().CDebugf(g.GetNetContext(), "PVL @(service:%v script:%v pc:%v) %v",
 		debugServiceToString(state.Service), state.WhichScript, state.PC, s)
 }
 
 func debugWithStateError(g proofContextExt, state scriptState, err libkb.ProofError) {
-	g.GetLogPvl().Debug("PVL @(service:%v script:%v pc:%v) Error code=%v: %v",
+	g.GetLogPvl().CDebugf(g.GetNetContext(), "PVL @(service:%v script:%v pc:%v) Error code=%v: %v",
 		debugServiceToString(state.Service), state.WhichScript, state.PC, err.GetProofStatus(), err.GetDesc())
 }
 
 func debugWithPosition(g proofContextExt, service keybase1.ProofType, whichscript int, pc int, format string, arg ...interface{}) {
 	s := fmt.Sprintf(format, arg...)
-	g.GetLogPvl().Debug("PVL @(service:%v script:%v pc:%v) %v",
+	g.GetLogPvl().CDebugf(g.GetNetContext(), "PVL @(service:%v script:%v pc:%v) %v",
 		debugServiceToString(service), whichscript, pc, s)
 }
 
 func debug(g proofContextExt, format string, arg ...interface{}) {
 	s := fmt.Sprintf(format, arg...)
-	g.GetLogPvl().Debug("PVL %v", s)
+	g.GetLogPvl().CDebugf(g.GetNetContext(), "PVL %v", s)
 }
 
 // debugServiceToString returns the name of a service or number string if it is invalid.

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -785,7 +785,7 @@ func stepFetch(g proofContextExt, ins fetchT, state scriptState) (scriptState, l
 	switch fetchMode(ins.Kind) {
 	case fetchModeString:
 		debugWithState(g, state, "fetchurl: %v", from)
-		res, err1 := g.GetExternalAPI().GetText(libkb.NewAPIArg(from))
+		res, err1 := g.GetExternalAPI().GetText(libkb.NewAPIArgWithNetContext(g.GetNetContext(), from))
 		if err1 != nil {
 			return state, libkb.XapiError(err1, from)
 		}
@@ -803,7 +803,7 @@ func stepFetch(g proofContextExt, ins fetchT, state scriptState) (scriptState, l
 			return state, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 				"JSON fetch must not specify 'into' register")
 		}
-		res, err1 := g.GetExternalAPI().Get(libkb.NewAPIArg(from))
+		res, err1 := g.GetExternalAPI().Get(libkb.NewAPIArgWithNetContext(g.GetNetContext(), from))
 		if err1 != nil {
 			return state, libkb.XapiError(err1, from)
 		}
@@ -817,7 +817,7 @@ func stepFetch(g proofContextExt, ins fetchT, state scriptState) (scriptState, l
 			return state, libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL,
 				"HTML fetch must not specify 'into' register")
 		}
-		res, err1 := g.GetExternalAPI().GetHTML(libkb.NewAPIArg(from))
+		res, err1 := g.GetExternalAPI().GetHTML(libkb.NewAPIArgWithNetContext(g.GetNetContext(), from))
 		if err1 != nil {
 			return state, libkb.XapiError(err1, from)
 		}

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -299,7 +299,7 @@ func (h ConfigHandler) HelloIAm(_ context.Context, arg keybase1.ClientDetails) e
 }
 
 func (h ConfigHandler) CheckAPIServerOutOfDateWarning(_ context.Context) (keybase1.OutOfDateInfo, error) {
-	return h.G().OutOfDateInfo, nil
+	return *h.G().OutOfDateInfo, nil
 }
 
 func (h ConfigHandler) WaitForClient(_ context.Context, arg keybase1.WaitForClientArg) (bool, error) {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -792,7 +792,7 @@ func (h IdentifyUIHandler) handleShowTrackerPopupDismiss(ctx context.Context, cl
 		h.G().Log.Debug("failed to convert UID from string", err)
 		return err
 	}
-	user, err := libkb.LoadUser(libkb.NewLoadUserByUIDArg(h.G(), uid))
+	user, err := libkb.LoadUser(libkb.NewLoadUserByUIDArg(ctx, h.G(), uid))
 	if err != nil {
 		h.G().Log.Debug("failed to load user from UID", err)
 		return err

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -91,8 +91,8 @@ func (h *UserHandler) ListTrackingJSON(_ context.Context, arg keybase1.ListTrack
 	return
 }
 
-func (h *UserHandler) LoadUser(_ context.Context, arg keybase1.LoadUserArg) (user keybase1.User, err error) {
-	loadUserArg := libkb.NewLoadUserByUIDArg(h.G(), arg.Uid)
+func (h *UserHandler) LoadUser(ctx context.Context, arg keybase1.LoadUserArg) (user keybase1.User, err error) {
+	loadUserArg := libkb.NewLoadUserByUIDArg(ctx, h.G(), arg.Uid)
 	loadUserArg.PublicKeyOptional = true
 	u, err := libkb.LoadUser(loadUserArg)
 	if err != nil {
@@ -115,8 +115,8 @@ func (h *UserHandler) LoadUserByName(_ context.Context, arg keybase1.LoadUserByN
 	return
 }
 
-func (h *UserHandler) LoadUserPlusKeys(_ context.Context, arg keybase1.LoadUserPlusKeysArg) (keybase1.UserPlusKeys, error) {
-	return libkb.LoadUserPlusKeys(h.G(), arg.Uid)
+func (h *UserHandler) LoadUserPlusKeys(ctx context.Context, arg keybase1.LoadUserPlusKeysArg) (keybase1.UserPlusKeys, error) {
+	return libkb.LoadUserPlusKeys(ctx, h.G(), arg.Uid)
 }
 
 func (h *UserHandler) Search(_ context.Context, arg keybase1.SearchArg) (results []keybase1.SearchResult, err error) {
@@ -165,10 +165,10 @@ func (h *UserHandler) loadPublicKeys(ctx context.Context, larg libkb.LoadUserArg
 	return publicKeys, nil
 }
 
-func (h *UserHandler) LoadAllPublicKeysUnverified(_ context.Context,
+func (h *UserHandler) LoadAllPublicKeysUnverified(ctx context.Context,
 	arg keybase1.LoadAllPublicKeysUnverifiedArg) (keys []keybase1.PublicKey, err error) {
 
-	u, err := libkb.LoadUserFromServer(h.G(), arg.Uid, nil)
+	u, err := libkb.LoadUserFromServer(ctx, h.G(), arg.Uid, nil)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
- This is obviously going to be a work in progress, but here are some interesting upgrades:
  - Thread net.context.Context through API, MerkleClient, LockTable, and Resolver, changing Debug to CDebugf
  - Introduce a new SingleContextLogger that will have the request context built in, so we don't have
    to change absolutely everything all at once. This gets a lot of coverage
  - Allow GlobalContexts to be cloned, where the Logger and NetContext fields can be updated; this meant
    only that we had to reference locks (and a few other fields) by Reference rather than by value.
- More TODOs as we go...