### PR TITLE
Fix libXScrnSaver requirement

### DIFF
--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -34,7 +34,7 @@ elif [ "$mode" = "prerelease" ] ; then
   if [ "$rpm_arch" = "x86_64" ] ; then
     dependencies="Requires: fuse, 'libXss.so.1()(64bit)'"
   else
-    dependencies="Requires: fuse, 'libXss.so.1()(32bit)'"
+    dependencies="Requires: fuse, 'libXss.so.1'"
   fi
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -31,7 +31,11 @@ if [ "$mode" = "production" ] ; then
   repo_url="http://dist.keybase.io/linux/rpm/repo"
 elif [ "$mode" = "prerelease" ] ; then
   repo_url="http://prerelease.keybase.io/rpm"
-  dependencies="Requires: fuse, 'libXss.so.1()(64bit)'"
+  if [ "$rpm_arch" = "x86_64" ] ; then
+    dependencies="Requires: fuse, 'libXss.so.1()(64bit)'"
+  else
+    dependencies="Requires: fuse, 'libXss.so.1()(32bit)'"
+  fi
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the
   # production URL, because we're moving to a model where we build a clean

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -31,7 +31,7 @@ if [ "$mode" = "production" ] ; then
   repo_url="http://dist.keybase.io/linux/rpm/repo"
 elif [ "$mode" = "prerelease" ] ; then
   repo_url="http://prerelease.keybase.io/rpm"
-  dependencies="Requires: fuse, libXss.so.1"
+  dependencies="Requires: fuse, 'libXss.so.1()(64bit)'"
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the
   # production URL, because we're moving to a model where we build a clean

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -27,9 +27,9 @@ mode="$(cat "$build_root/MODE")"
 name="$("$here/../../binary_name.sh" "$mode")"
 
 if [ "$rpm_arch" = "x86_64" ] ; then
-  dependencies="Requires: fuse, 'libXss.so.1()(64bit)'"
+  dependencies="Requires: fuse, libappindicator1, 'libXss.so.1()(64bit)'"
 else
-  dependencies="Requires: fuse, 'libXss.so.1'"
+  dependencies="Requires: fuse, libappindicator1, 'libXss.so.1'"
 fi
   
 if [ "$mode" = "production" ] ; then

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -26,16 +26,16 @@ mode="$(cat "$build_root/MODE")"
 
 name="$("$here/../../binary_name.sh" "$mode")"
 
-dependencies=""
+if [ "$rpm_arch" = "x86_64" ] ; then
+  dependencies="Requires: fuse, 'libXss.so.1()(64bit)'"
+else
+  dependencies="Requires: fuse, 'libXss.so.1'"
+fi
+  
 if [ "$mode" = "production" ] ; then
   repo_url="http://dist.keybase.io/linux/rpm/repo"
 elif [ "$mode" = "prerelease" ] ; then
-  repo_url="http://prerelease.keybase.io/rpm"
-  if [ "$rpm_arch" = "x86_64" ] ; then
-    dependencies="Requires: fuse, 'libXss.so.1()(64bit)'"
-  else
-    dependencies="Requires: fuse, 'libXss.so.1'"
-  fi
+  repo_url="http://prerelease.keybase.io/rpm"  
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the
   # production URL, because we're moving to a model where we build a clean

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -31,7 +31,7 @@ if [ "$mode" = "production" ] ; then
   repo_url="http://dist.keybase.io/linux/rpm/repo"
 elif [ "$mode" = "prerelease" ] ; then
   repo_url="http://prerelease.keybase.io/rpm"
-  dependencies="Requires: fuse, libXScrnSaver"
+  dependencies="Requires: fuse, libXss.so.1"
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the
   # production URL, because we're moving to a model where we build a clean


### PR DESCRIPTION
openSUSE and some others distributions uses a different name for package libXScrnSaver, it's called libXss1.
This fix uses the name of the module provided by the package, this will make dependency independent of package name.

https://github.com/keybase/keybase-issues/issues/2445
