### PR TITLE
New error for saltpack decrypt of unicode file

### DIFF
--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1407,10 +1407,10 @@ func (e UnknownStreamError) Error() string {
 	return "unknown stream format"
 }
 
-type UnicodeUnsupportedError struct{}
+type UTF16UnsupportedError struct{}
 
-func (e UnicodeUnsupportedError) Error() string {
-	return "unicode not supported"
+func (e UTF16UnsupportedError) Error() string {
+	return "UTF-16 not supported"
 }
 
 type WrongCryptoFormatError struct {

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1407,6 +1407,12 @@ func (e UnknownStreamError) Error() string {
 	return "unknown stream format"
 }
 
+type UnicodeUnsupportedError struct{}
+
+func (e UnicodeUnsupportedError) Error() string {
+	return "unicode not supported"
+}
+
 type WrongCryptoFormatError struct {
 	Wanted, Received CryptoMessageFormat
 	Operation        string

--- a/go/libkb/stream_classifier.go
+++ b/go/libkb/stream_classifier.go
@@ -222,7 +222,7 @@ func matchesSaltpackType(messageStart string, typeString string) bool {
 	return match && (err == nil)
 }
 
-func hasUnicodeHeader(b []byte) bool {
+func isUTF16Mark(b []byte) bool {
 	if len(b) < 2 {
 		return false
 	}
@@ -284,8 +284,8 @@ func ClassifyStream(r io.Reader) (sc StreamClassification, out io.Reader, err er
 		// Format etc. set by isSaltpackBinary().
 	case isPGPBinary(buf[:n], &sc):
 		// Format etc. set by isPGPBinary().
-	case hasUnicodeHeader(buf[:n]):
-		err = UnicodeUnsupportedError{}
+	case isUTF16Mark(buf[:n]):
+		err = UTF16UnsupportedError{}
 	default:
 		err = UnknownStreamError{}
 	}

--- a/go/libkb/stream_classifier.go
+++ b/go/libkb/stream_classifier.go
@@ -222,6 +222,13 @@ func matchesSaltpackType(messageStart string, typeString string) bool {
 	return match && (err == nil)
 }
 
+func hasUnicodeHeader(b []byte) bool {
+	if len(b) < 2 {
+		return false
+	}
+	return ((b[0] == 0xFE && b[1] == 0xFF) || (b[0] == 0xFF && b[1] == 0xFE))
+}
+
 var encryptionArmorHeader = saltpack.MakeArmorHeader(saltpack.MessageTypeEncryption, KeybaseSaltpackBrand)
 var signedArmorHeader = saltpack.MakeArmorHeader(saltpack.MessageTypeAttachedSignature, KeybaseSaltpackBrand)
 var detachedArmorHeader = saltpack.MakeArmorHeader(saltpack.MessageTypeDetachedSignature, KeybaseSaltpackBrand)
@@ -277,6 +284,8 @@ func ClassifyStream(r io.Reader) (sc StreamClassification, out io.Reader, err er
 		// Format etc. set by isSaltpackBinary().
 	case isPGPBinary(buf[:n], &sc):
 		// Format etc. set by isPGPBinary().
+	case hasUnicodeHeader(buf[:n]):
+		err = UnicodeUnsupportedError{}
 	default:
 		err = UnknownStreamError{}
 	}

--- a/go/libkb/util_nix.go
+++ b/go/libkb/util_nix.go
@@ -59,3 +59,8 @@ func SafeWriteToFile(g SafeWriteLogger, t SafeWriter, mode os.FileMode) error {
 func RemoteSettingsRepairman(g *GlobalContext) error {
 	return nil
 }
+
+// Unicode error detection is windows only for now
+func isUnicodeMark(b []byte) bool {
+	return false
+}


### PR DESCRIPTION
Maybe we want to support this someday - converting from Unicode is not that hard and we're bound to come across this elsewhere - but until then we can have this. Saltpack calls out Ascii I believe.
@maxtaco @oconnor663 