### PR TITLE
add `at` as an RPM dependency

### DIFF
--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -26,12 +26,12 @@ mode="$(cat "$build_root/MODE")"
 
 name="$("$here/../../binary_name.sh" "$mode")"
 
-dependencies=""
+dependencies="Requires: at"
 if [ "$mode" = "production" ] ; then
   repo_url="http://dist.keybase.io/linux/rpm/repo"
 elif [ "$mode" = "prerelease" ] ; then
   repo_url="http://prerelease.keybase.io/rpm"
-  dependencies="Requires: fuse, libXScrnSaver"
+  dependencies="Requires: at, fuse, libXScrnSaver"
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the
   # production URL, because we're moving to a model where we build a clean


### PR DESCRIPTION
This avoids a non-fatal error that shows up during install on minimal
RPM distros that are missing `at` by default. Tested by doing
`dnf remove at` on a Fedora VM and then manually installing an RPM file
packaged with this change.

Fixes https://github.com/keybase/client/issues/5242.