### PR TITLE
Don't show the orange line if new messages were written by yourself

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -350,14 +350,10 @@ function * _incomingMessage (action: IncomingMessage): SagaGenerator<any, any> {
         const appFocused = yield select(_focusedSelector)
         const selectedTab = yield select(_routeSelector)
         const chatTabSelected = (selectedTab === chatTab)
+        const conversationIsFocused = conversationIDKey === selectedConversationIDKey && appFocused && chatTabSelected
+        const messageIsYours = (message.type === 'Text' || message.type === 'Attachment') && message.author === yourName
 
-        if ((message && message.messageID &&
-             conversationIDKey === selectedConversationIDKey &&
-             appFocused && chatTabSelected) ||
-            (message &&
-             message.messageID &&
-             (message.type === 'Text' || message.type === 'Attachment') &&
-             message.author === yourName)) {
+        if (message && message.messageID && (conversationIsFocused || messageIsYours)) {
           yield call(localMarkAsReadLocalRpcPromise, {
             param: {
               conversationID: incomingMessage.convID,

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -344,17 +344,19 @@ function * _incomingMessage (action: IncomingMessage): SagaGenerator<any, any> {
         // Is this message for the currently selected and focused conversation?
         // And is the Chat tab the currently displayed route? If all that is
         // true, mark it as read ASAP to avoid badging it -- we don't need to
-        // badge, the user's looking at it already.
+        // badge, the user's looking at it already.  Also mark as read ASAP if
+        // it was written by the current user.
         const selectedConversationIDKey = yield select(_selectedSelector)
         const appFocused = yield select(_focusedSelector)
         const selectedTab = yield select(_routeSelector)
         const chatTabSelected = (selectedTab === chatTab)
 
-        if (message &&
-            message.messageID &&
-            conversationIDKey === selectedConversationIDKey &&
-            appFocused &&
-            chatTabSelected) {
+        if ((message && message.messageID &&
+             conversationIDKey === selectedConversationIDKey &&
+             appFocused && chatTabSelected) ||
+            (message && message.messageID &&
+             message.type === 'Text' &&
+             message.author === yourName)) {
           yield call(localMarkAsReadLocalRpcPromise, {
             param: {
               conversationID: incomingMessage.convID,

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -354,8 +354,9 @@ function * _incomingMessage (action: IncomingMessage): SagaGenerator<any, any> {
         if ((message && message.messageID &&
              conversationIDKey === selectedConversationIDKey &&
              appFocused && chatTabSelected) ||
-            (message && message.messageID &&
-             message.type === 'Text' &&
+            (message &&
+             message.messageID &&
+             (message.type === 'Text' || message.type === 'Attachment') &&
              message.author === yourName)) {
           yield call(localMarkAsReadLocalRpcPromise, {
             param: {


### PR DESCRIPTION
@keybase/react-hackers 

The JIRA ticket here was for not showing notifications or the orange line.  But we already check yourName when deciding whether to show popup notifications, and that seems to be working.  So this PR just updates the orange line code.

(Duplication of message && messageID check is necessary to avoid Flow failing to analyze properly.)