### PR TITLE
lock KeyFinder down since it is used across goroutines now

### DIFF
--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -33,14 +33,13 @@ func (k *KeyFinderImpl) cacheKey(tlfName string, tlfPublic bool) string {
 // results.
 func (k *KeyFinderImpl) Find(ctx context.Context, tlf keybase1.TlfInterface, tlfName string, tlfPublic bool) (keybase1.GetTLFCryptKeysRes, error) {
 
-	k.Lock()
 	ckey := k.cacheKey(tlfName, tlfPublic)
+	k.Lock()
 	existing, ok := k.keys[ckey]
+	k.Unlock()
 	if ok {
-		defer k.Unlock()
 		return existing, nil
 	}
-	k.Unlock()
 
 	query := keybase1.TLFQuery{
 		TlfName: tlfName,
@@ -62,8 +61,8 @@ func (k *KeyFinderImpl) Find(ctx context.Context, tlf keybase1.TlfInterface, tlf
 	}
 
 	k.Lock()
-	defer k.Unlock()
 	k.keys[ckey] = keys
+	k.Unlock()
 
 	return keys, nil
 }

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -2,24 +2,23 @@ package chat
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
 )
 
-// keyFinder remembers results from previous calls to CryptKeys().
-// It is not intended to be used by multiple concurrent goroutines
-// or held onto for very long, just to remember the keys while
-// unboxing a thread of messages.
+// KeyFinder remembers results from previous calls to CryptKeys().
 type KeyFinder interface {
 	Find(ctx context.Context, tlf keybase1.TlfInterface, tlfName string, tlfPublic bool) (keybase1.GetTLFCryptKeysRes, error)
 }
 
 type KeyFinderImpl struct {
+	sync.Mutex
 	keys map[string]keybase1.GetTLFCryptKeysRes
 }
 
-// newKeyFinder creates a keyFinder.
+// NewKeyFinder creates a KeyFinder.
 func NewKeyFinder() KeyFinder {
 	return &KeyFinderImpl{
 		keys: make(map[string]keybase1.GetTLFCryptKeysRes),
@@ -30,19 +29,22 @@ func (k *KeyFinderImpl) cacheKey(tlfName string, tlfPublic bool) string {
 	return fmt.Sprintf("%s|%v", tlfName, tlfPublic)
 }
 
-// find finds keybase1.TLFCryptKeys for tlfName, checking for existing
+// Find finds keybase1.TLFCryptKeys for tlfName, checking for existing
 // results.
 func (k *KeyFinderImpl) Find(ctx context.Context, tlf keybase1.TlfInterface, tlfName string, tlfPublic bool) (keybase1.GetTLFCryptKeysRes, error) {
+
+	k.Lock()
 	ckey := k.cacheKey(tlfName, tlfPublic)
 	existing, ok := k.keys[ckey]
 	if ok {
+		defer k.Unlock()
 		return existing, nil
 	}
+	k.Unlock()
 
 	query := keybase1.TLFQuery{
 		TlfName: tlfName,
 	}
-
 	var keys keybase1.GetTLFCryptKeysRes
 	if tlfPublic {
 		res, err := tlf.PublicCanonicalTLFNameAndID(ctx, query)
@@ -59,6 +61,8 @@ func (k *KeyFinderImpl) Find(ctx context.Context, tlf keybase1.TlfInterface, tlf
 		}
 	}
 
+	k.Lock()
+	defer k.Unlock()
 	k.keys[ckey] = keys
 
 	return keys, nil


### PR DESCRIPTION
Lock down the `KeyFinder` now that it is used in parallel.