### PR TITLE
JS style for private

### DIFF
--- a/shared/chat/conversation/messages/attachment.desktop.js
+++ b/shared/chat/conversation/messages/attachment.desktop.js
@@ -23,7 +23,7 @@ const colorForAuthor = (followState: Constants.FollowState) => {
 }
 
 // TODO abstract this part so it is the same as message text
-class _AttachmentMessage extends PureComponent<void, Props & {onIconClick: (event: any) => void, onOpenInPopup: (event: any) => void}, void> {
+class AttachmentMessage extends PureComponent<void, Props & {onIconClick: (event: any) => void, onOpenInPopup: (event: any) => void}, void> {
   render () {
     const {message, style, includeHeader, isFirstNewMessage, onLoadAttachment, onOpenInFileUI, onOpenInPopup, onIconClick} = this.props
     const {downloadedPath} = message
@@ -66,7 +66,7 @@ export default withHandlers({
   onOpenInPopup: (props: Props) => event => {
     props.onOpenInPopup(props.message, event)
   },
-})(_AttachmentMessage)
+})(AttachmentMessage)
 
 const stylesFirstNewMessage = {
   borderTop: `solid 1px ${globalColors.orange}`,

--- a/shared/chat/conversation/messages/text.desktop.js
+++ b/shared/chat/conversation/messages/text.desktop.js
@@ -44,7 +44,7 @@ const Retry = ({onRetry}: {onRetry: () => void}) => (
   </div>
 )
 
-class _MessageTextComponent extends PureComponent<void, Props & {onIconClick: (event: any) => void}, void> {
+class MessageTextComponent extends PureComponent<void, Props & {onIconClick: (event: any) => void}, void> {
   render () {
     const {message, style, includeHeader, isFirstNewMessage, onRetry, onIconClick} = this.props
     return (
@@ -130,4 +130,4 @@ export default compose(
       props.onAction(props.message, event)
     },
   })
-)(_MessageTextComponent)
+)(MessageTextComponent)


### PR DESCRIPTION
Starting a discussion here when to use leading underscores to denote "private".

I think for class names we don't want to use the underscore convention? I don't see that as a common style in any projects?

We do want to use underscore for:
- Private properties or methods
- React component methods not related to react

For a variable, it doesn't make a lot of sense to me... e.g. `const _messageTextStyle = {` since it's only visible to that file by default?

We might want to start a style guide at some point. Maybe adopt an existing style guide.. maybe [fb's](https://github.com/facebook/relay/blob/master/src/container/RelayRenderer.js)? 

