### PR TITLE
Make it possible to copy-paste chat emojis

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -42,7 +42,7 @@
     "deep-diff": "0.3.4",
     "deep-equal": "1.0.1",
     "emoji-datasource": "2.4.4",
-    "emoji-mart": "0.3.4",
+    "emoji-mart": "0.3.5",
     "framed-msgpack-rpc": "1.1.13",
     "getenv": "0.7.0",
     "immutable": "3.8.1",

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -1906,9 +1906,9 @@ emoji-datasource@2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/emoji-datasource/-/emoji-datasource-2.4.4.tgz#b97ac1896bc208ecf1833564a20687a5215d0389"
 
-emoji-mart@0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/emoji-mart/-/emoji-mart-0.3.4.tgz#5da9db3de675b029c48900a38f8991bbdaf108cb"
+emoji-mart@0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/emoji-mart/-/emoji-mart-0.3.5.tgz#18cc38ce77bfe795226a1b29a323cce7e39eb889"
 
 emojis-list@^2.0.0:
   version "2.1.0"

--- a/shared/common-adapters/emoji.desktop.js
+++ b/shared/common-adapters/emoji.desktop.js
@@ -11,7 +11,12 @@ import type {Props} from 'emoji-mart'
 const backgroundImageFn = (set: string, sheetSize: string) => emojiSet
 
 const EmojiWrapper = (props: Props) => {
-  return <Emoji {...props} emoji={[':', ...props.children, ':'].join('')} backgroundImageFn={backgroundImageFn} />
+  const emojiText = `:${props.children}:`
+  return (
+    <Emoji {...props} emoji={emojiText} backgroundImageFn={backgroundImageFn}>
+      <Emoji emoji={emojiText} native={true} />
+    </Emoji>
+  )
 }
 
 export {backgroundImageFn}


### PR DESCRIPTION
:eyeglasses: @keybase/react-hackers 

This gets the task done, but it's still tricky to select a line of just emojis. I experimented a bit with various applications of `-webkit-user-select`, but haven't found a good solution yet.