### PR TITLE
Include visibility hidden so action button doesn't participate in copy/paste

### DIFF
--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -226,17 +226,26 @@ class ConversationList extends Component<void, Props, State> {
     let scrollToIndex = this.state.isLockedToBottom ? countWithLoading - 1 : undefined
     let scrollTop = scrollToIndex ? undefined : this.state.scrollTop
 
+    // We need to use both visibility and opacity css properties for the
+    // action button hide/show on hover.
+    // We use opacity because it shows/hides the button immediately on
+    // hover, while visibility has slight lag.
+    // We use visibility so that the action button content isn't copied
+    // during copy/paste actions since user-select isn't working in
+    // Chrome.
     const realCSS = `
     .message {
       background-color: transparent;
     }
     .message .action-button {
+      visibility: hidden;
       opacity: 0;
     }
     .message:hover {
       background-color: ${globalColors.black_05};
     }
     .message:hover .action-button {
+      visibility: visible;
       opacity: 1;
     }
     `


### PR DESCRIPTION
We need to use both visibility and opacity css properties for the action button hide/show on hover.
We use opacity because it shows/hides the button immediately on hover, while visibility has slight lag. We use visibility so that the action button content isn't copied during copy/paste actions since [user-select isn't working in Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=147490).

