### PR TITLE
separate the identify notification logic from TLF handler and put in context CORE-4327

### DIFF
--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -21,9 +21,11 @@ type KeybaseContext interface {
 
 type identifyModeKey int
 type keyfinderKey int
+type identifyNotifierKey int
 
 var identModeKey identifyModeKey
 var kfKey keyfinderKey
+var inKey identifyNotifierKey
 
 type identModeData struct {
 	mode   keybase1.TLFIdentifyBehavior
@@ -54,21 +56,34 @@ func CtxKeyFinder(ctx context.Context) KeyFinder {
 	return NewKeyFinder()
 }
 
+func CtxIdentifyNotifier(ctx context.Context) *IdentifyNotifier {
+	var in *IdentifyNotifier
+	var ok bool
+	val := ctx.Value(inKey)
+	if in, ok = val.(*IdentifyNotifier); ok {
+		return in
+	}
+	return nil
+}
+
 func Context(ctx context.Context, mode keybase1.TLFIdentifyBehavior,
-	breaks *[]keybase1.TLFIdentifyFailure) context.Context {
+	breaks *[]keybase1.TLFIdentifyFailure, notifier *IdentifyNotifier) context.Context {
 	res := identifyModeCtx(ctx, mode, breaks)
 	res = context.WithValue(res, kfKey, NewKeyFinder())
+	res = context.WithValue(res, inKey, notifier)
 	return res
 }
 
 func BackgroundContext(sourceCtx context.Context) context.Context {
 
 	rctx := context.Background()
-	if ident, breaks, ok := IdentifyMode(sourceCtx); ok {
-		rctx = Context(rctx, ident, breaks)
-	}
 
+	in := CtxIdentifyNotifier(sourceCtx)
+	if ident, breaks, ok := IdentifyMode(sourceCtx); ok {
+		rctx = Context(rctx, ident, breaks, in)
+	}
 	rctx = context.WithValue(rctx, kfKey, CtxKeyFinder(sourceCtx))
+	rctx = context.WithValue(rctx, inKey, in)
 
 	return rctx
 }

--- a/go/chat/identify_notifier.go
+++ b/go/chat/identify_notifier.go
@@ -1,0 +1,43 @@
+package chat
+
+import (
+	"context"
+	"sync"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type IdentifyNotifier struct {
+	libkb.Contextified
+	sync.RWMutex
+	identCache map[string]keybase1.CanonicalTLFNameAndIDWithBreaks
+}
+
+func NewIdentifyNotifier(g *libkb.GlobalContext) *IdentifyNotifier {
+	return &IdentifyNotifier{
+		Contextified: libkb.NewContextified(g),
+		identCache:   make(map[string]keybase1.CanonicalTLFNameAndIDWithBreaks),
+	}
+}
+
+func (i *IdentifyNotifier) Send(update keybase1.CanonicalTLFNameAndIDWithBreaks) {
+	i.RLock()
+	tlfName := update.CanonicalName.String()
+	if stored, ok := i.identCache[tlfName]; ok {
+		// We have the exact update stored, don't send it again
+		if stored.Eq(update) {
+			defer i.RUnlock()
+			i.G().Log.Debug("IdentifyNotifier: hit cache, not sending notify: %s", tlfName)
+			return
+		}
+	}
+	i.RUnlock()
+
+	i.Lock()
+	defer i.Unlock()
+
+	i.G().Log.Debug("IdentifyNotifier: cache miss, sending notify: %s dat: %v", tlfName, update)
+	i.G().NotifyRouter.HandleChatIdentifyUpdate(context.Background(), update)
+	i.identCache[tlfName] = update
+}

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -30,10 +30,11 @@ import (
 type chatLocalHandler struct {
 	*BaseHandler
 	libkb.Contextified
-	gh    *gregorHandler
-	tlf   keybase1.TlfInterface
-	boxer *chat.Boxer
-	store *chat.AttachmentStore
+	gh            *gregorHandler
+	tlf           keybase1.TlfInterface
+	boxer         *chat.Boxer
+	store         *chat.AttachmentStore
+	identNotifier *chat.IdentifyNotifier
 
 	// Only for testing
 	rc         chat1.RemoteInterface
@@ -44,12 +45,13 @@ type chatLocalHandler struct {
 func newChatLocalHandler(xp rpc.Transporter, g *libkb.GlobalContext, gh *gregorHandler) *chatLocalHandler {
 	tlf := newTlfHandler(nil, g)
 	h := &chatLocalHandler{
-		BaseHandler:  NewBaseHandler(xp),
-		Contextified: libkb.NewContextified(g),
-		gh:           gh,
-		tlf:          tlf,
-		boxer:        chat.NewBoxer(g, tlf),
-		store:        chat.NewAttachmentStore(g.Log, g.Env.GetRuntimeDir()),
+		BaseHandler:   NewBaseHandler(xp),
+		Contextified:  libkb.NewContextified(g),
+		gh:            gh,
+		tlf:           tlf,
+		boxer:         chat.NewBoxer(g, tlf),
+		store:         chat.NewAttachmentStore(g.Log, g.Env.GetRuntimeDir()),
+		identNotifier: chat.NewIdentifyNotifier(g),
 	}
 
 	return h
@@ -66,7 +68,7 @@ func (h *chatLocalHandler) GetInboxLocal(ctx context.Context, arg chat1.GetInbox
 	}
 
 	var breaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, arg.IdentifyBehavior, &breaks)
+	ctx = chat.Context(ctx, arg.IdentifyBehavior, &breaks, h.identNotifier)
 	rquery, _, err := chat.GetInboxQueryLocalToRemote(ctx, h.tlf, arg.Query)
 	if err != nil {
 		return chat1.GetInboxLocalRes{}, err
@@ -108,7 +110,7 @@ func (h *chatLocalHandler) GetInboxNonblockLocal(ctx context.Context, arg chat1.
 	localizeCb := make(chan chat.NonblockInboxResult, 1)
 
 	var breaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, arg.IdentifyBehavior, &breaks)
+	ctx = chat.Context(ctx, arg.IdentifyBehavior, &breaks, h.identNotifier)
 	inboxSource := chat.NewNonblockRemoteInboxSource(h.G(), h.boxer, h.remoteClient,
 		func() keybase1.TlfInterface { return h.tlf }, localizeCb)
 
@@ -188,7 +190,7 @@ func (h *chatLocalHandler) GetInboxAndUnboxLocal(ctx context.Context, arg chat1.
 
 	// Create inbox source
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks)
+	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	inbox := chat.NewRemoteInboxSource(h.G(), h.boxer, h.remoteClient,
 		func() keybase1.TlfInterface { return h.tlf })
 
@@ -221,7 +223,7 @@ func (h *chatLocalHandler) GetThreadLocal(ctx context.Context, arg chat1.GetThre
 		return chat1.GetThreadLocalRes{}, libkb.LoginRequiredError{}
 	}
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks)
+	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	thread, rl, err := h.G().ConvSource.Pull(ctx, arg.ConversationID,
 		gregor1.UID(uid.ToBytes()), arg.Query, arg.Pagination)
 	if err != nil {
@@ -264,7 +266,7 @@ func (h *chatLocalHandler) NewConversationLocal(ctx context.Context, arg chat1.N
 	}
 
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks)
+	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	info, err := chat.LookupTLF(ctx, h.tlf, arg.TlfName, arg.TlfVisibility)
 	if err != nil {
 		return chat1.NewConversationLocalRes{}, err
@@ -399,7 +401,7 @@ func (h *chatLocalHandler) GetInboxSummaryForCLILocal(ctx context.Context, arg c
 	}
 
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, keybase1.TLFIdentifyBehavior_CHAT_CLI, &identBreaks)
+	ctx = chat.Context(ctx, keybase1.TLFIdentifyBehavior_CHAT_CLI, &identBreaks, h.identNotifier)
 	var after time.Time
 	if len(arg.After) > 0 {
 		after, err = chat.ParseTimeFromRFC3339OrDurationFromPast(h.G(), arg.After)
@@ -495,7 +497,7 @@ func (h *chatLocalHandler) GetConversationForCLILocal(ctx context.Context, arg c
 	}
 
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, keybase1.TLFIdentifyBehavior_CHAT_CLI, &identBreaks)
+	ctx = chat.Context(ctx, keybase1.TLFIdentifyBehavior_CHAT_CLI, &identBreaks, h.identNotifier)
 
 	var rlimits []chat1.RateLimit
 
@@ -575,7 +577,7 @@ func (h *chatLocalHandler) GetMessagesLocal(ctx context.Context, arg chat1.GetMe
 		return deflt, err
 	}
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks)
+	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 
 	rarg := chat1.GetMessagesRemoteArg{
 		ConversationID: arg.ConversationID,
@@ -609,7 +611,7 @@ func (h *chatLocalHandler) SetConversationStatusLocal(ctx context.Context, arg c
 	}
 
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks)
+	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	scsres, err := h.remoteClient().SetConversationStatus(ctx, chat1.SetConversationStatusArg{
 		ConversationID: arg.ConversationID,
 		Status:         arg.Status,
@@ -631,7 +633,7 @@ func (h *chatLocalHandler) PostLocal(ctx context.Context, arg chat1.PostLocalArg
 	}
 
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks)
+	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	err := msgchecker.CheckMessagePlaintext(arg.Msg)
 	if err != nil {
 		return chat1.PostLocalRes{}, err
@@ -675,7 +677,7 @@ func (h *chatLocalHandler) PostLocalNonblock(ctx context.Context, arg chat1.Post
 
 	// Create non block sender
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks)
+	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	sender := chat.NewBlockingSender(h.G(), h.boxer, h.remoteClient, h.getSecretUI)
 	nonblockSender := chat.NewNonblockingSender(h.G(), sender)
 
@@ -857,7 +859,7 @@ func (h *chatLocalHandler) DownloadAttachmentLocal(ctx context.Context, arg chat
 	darg.Sink = libkb.NewRemoteStreamBuffered(arg.Sink, cli, arg.SessionID)
 
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks)
+	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	return h.downloadAttachmentLocal(ctx, darg)
 }
 
@@ -891,7 +893,7 @@ type downloadAttachmentArg struct {
 func (h *chatLocalHandler) downloadAttachmentLocal(ctx context.Context, arg downloadAttachmentArg) (chat1.DownloadAttachmentLocalRes, error) {
 
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks)
+	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	chatUI := h.getChatUI(arg.SessionID)
 	progress := func(bytesComplete, bytesTotal int) {
 		parg := chat1.ChatAttachmentDownloadProgressArg{

--- a/go/service/tlf.go
+++ b/go/service/tlf.go
@@ -70,8 +70,7 @@ func (h *tlfHandler) CryptKeys(ctx context.Context, arg keybase1.TLFQuery) (keyb
 		return resp, err
 	}
 
-	in := chat.CtxIdentifyNotifier(ctx)
-	if in != nil {
+	if in := chat.CtxIdentifyNotifier(ctx); in != nil {
 		in.Send(resp.NameIDBreaks)
 	}
 	if ok {
@@ -98,8 +97,7 @@ func (h *tlfHandler) PublicCanonicalTLFNameAndID(ctx context.Context, arg keybas
 		return resp, err
 	}
 
-	in := chat.CtxIdentifyNotifier(ctx)
-	if in != nil {
+	if in := chat.CtxIdentifyNotifier(ctx); in != nil {
 		in.Send(resp)
 	}
 	if ok {


### PR DESCRIPTION
The point of this change is to separate out the logic for notifying the frontend about TLF identify results from tlf.go, and put it into it's own module.

The goal of the cache inside `IdentifyNotifier` is so that we don't spam the same data out for every identify. We try to have the cache run per chat local handler object, to correspond to either the CLI or Electron connecting to the service. 

I'd be happy to explain this change tomorrow in more detail in person.