### PR TITLE
move delete logic into the sender world instead of client CORE-4319

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -379,8 +379,9 @@ func (s *localizer) localizeConversation(ctx context.Context, uid gregor1.UID,
 			body := mm.Valid().MessageBody
 			typ, err := body.MessageType()
 			if err != nil {
-				errMsg := "unable to get message type"
-				return chat1.ConversationLocal{Error: &errMsg}
+				s.G().Log.Debug("localizeConversation: skipping max message: %d, no message type",
+					mm.GetMessageID())
+				continue
 			}
 			if typ == chat1.MessageType_METADATA {
 				conversationLocal.Info.TopicName = body.Metadata().ConversationTitle

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -107,6 +107,42 @@ func (s *BlockingSender) addPrevPointersToMessage(ctx context.Context, msg chat1
 	return updated, nil
 }
 
+func (s *BlockingSender) getAllDeletedEdits(ctx context.Context, msg chat1.MessagePlaintext,
+	convID chat1.ConversationID) (chat1.MessagePlaintext, error) {
+
+	// Make sure this is a valid delete message
+	if msg.ClientHeader.MessageType != chat1.MessageType_DELETE {
+		return msg, nil
+	}
+	if msg.ClientHeader.Supersedes == 0 {
+		return msg, fmt.Errorf("getAllDeletedEdits: no supersedes specified")
+	}
+
+	// Grab all the edits (!)
+	tv, _, err := s.G().ConvSource.Pull(ctx, convID, msg.ClientHeader.Sender, &chat1.GetThreadQuery{
+		MarkAsRead:   false,
+		MessageTypes: []chat1.MessageType{chat1.MessageType_EDIT},
+	}, nil)
+	if err != nil {
+		return msg, err
+	}
+
+	// Get all affected edits
+	deletes := []chat1.MessageID{msg.ClientHeader.Supersedes}
+	for _, m := range tv.Messages {
+		if m.IsValid() && m.GetMessageType() == chat1.MessageType_EDIT &&
+			m.Valid().MessageBody.Edit().MessageID == msg.ClientHeader.Supersedes {
+			deletes = append(deletes, m.GetMessageID())
+		}
+	}
+
+	// Modify original delete message
+	msg.ClientHeader.Deletes = deletes
+	msg.MessageBody = chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: deletes})
+
+	return msg, nil
+}
+
 func (s *BlockingSender) Prepare(ctx context.Context, plaintext chat1.MessagePlaintext, convID *chat1.ConversationID) (*chat1.MessageBoxed, error) {
 	msg, err := s.addSenderToMessage(plaintext)
 	if err != nil {
@@ -116,6 +152,14 @@ func (s *BlockingSender) Prepare(ctx context.Context, plaintext chat1.MessagePla
 	// convID will be nil in makeFirstMessage, for example
 	if convID != nil {
 		msg, err = s.addPrevPointersToMessage(ctx, msg, *convID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Make sure our delete message gets everything it should
+	if convID != nil {
+		msg, err = s.getAllDeletedEdits(ctx, msg, *convID)
 		if err != nil {
 			return nil, err
 		}

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -228,48 +228,20 @@ func (c *chatServiceHandler) SendV1(ctx context.Context, opts sendOptionsV1) Rep
 
 // DeleteV1 implements ChatServiceHandler.DeleteV1.
 func (c *chatServiceHandler) DeleteV1(ctx context.Context, opts deleteOptionsV1) Reply {
-	client, err := GetChatLocalClient(c.G())
-	if err != nil {
-		return c.errReply(err)
-	}
+
 	convID, _, err := c.resolveAPIConvID(ctx, opts.ConversationID, opts.Channel)
 	if err != nil {
 		return c.errReply(fmt.Errorf("invalid conv ID: %s", opts.ConversationID))
 	}
 
-	// Fetch any edits that exist for this message.
-	// TODO: This is a big and inefficient fetch that scans all edits in the
-	// entire conversation. We should have this in a local index instead.
-	readArg := chat1.GetThreadLocalArg{
-		ConversationID: convID,
-		Query: &chat1.GetThreadQuery{
-			MarkAsRead:   false,
-			MessageTypes: []chat1.MessageType{chat1.MessageType_EDIT},
-		},
-	}
-	threadView, err := client.GetThreadLocal(ctx, readArg)
-	messageAndEdits := []chat1.MessageID{opts.MessageID}
-	for _, m := range threadView.Thread.Messages {
-		st, err := m.State()
-		if err != nil {
-			return c.errReply(fmt.Errorf("invalid message: unknown state (%s)", err))
-		}
-		if st == chat1.MessageUnboxedState_ERROR {
-			c.G().Log.Warning("Failed to unbox edit %d: %s", m.Error().MessageID, m.Error().ErrMsg)
-			continue
-		}
-		if m.Valid().MessageBody.Edit().MessageID == opts.MessageID {
-			messageAndEdits = append(messageAndEdits, m.Valid().ServerHeader.MessageID)
-		}
-	}
-
+	messages := []chat1.MessageID{opts.MessageID}
 	arg := sendArgV1{
 		conversationID: convID,
 		channel:        opts.Channel,
-		body:           chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: messageAndEdits}),
+		body:           chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: messages}),
 		mtype:          chat1.MessageType_DELETE,
 		supersedes:     opts.MessageID,
-		deletes:        messageAndEdits,
+		deletes:        messages,
 		response:       "message deleted",
 	}
 	return c.sendV1(ctx, arg)

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -15,6 +15,8 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 
+	"encoding/json"
+
 	"github.com/keybase/client/go/chat"
 	"github.com/keybase/client/go/chat/msgchecker"
 	"github.com/keybase/client/go/chat/s3"
@@ -672,6 +674,9 @@ func (h *chatLocalHandler) PostLocalNonblock(ctx context.Context, arg chat1.Post
 	arg.Msg.ClientHeader.OutboxInfo = &chat1.OutboxInfo{
 		Prev: arg.ClientPrev,
 	}
+
+	out, _ := json.Marshal(arg)
+	h.G().Log.Debug("ARG: %s", out)
 
 	// Create non block sender
 	var identBreaks []keybase1.TLFIdentifyFailure

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -15,8 +15,6 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 
-	"encoding/json"
-
 	"github.com/keybase/client/go/chat"
 	"github.com/keybase/client/go/chat/msgchecker"
 	"github.com/keybase/client/go/chat/s3"
@@ -674,9 +672,6 @@ func (h *chatLocalHandler) PostLocalNonblock(ctx context.Context, arg chat1.Post
 	arg.Msg.ClientHeader.OutboxInfo = &chat1.OutboxInfo{
 		Prev: arg.ClientPrev,
 	}
-
-	out, _ := json.Marshal(arg)
-	h.G().Log.Debug("ARG: %s", out)
 
 	// Create non block sender
 	var identBreaks []keybase1.TLFIdentifyFailure


### PR DESCRIPTION
This transfers the logic for adding all the deleted edits to the delete message into the service, particularly the `BlockingSender` type. This establishes an interface to the service where you just need to set `supersedes` properly (and be a `DELETE` message), and the service will handle the rest of the job setting up the message properly. 

cc @gabriel 