### PR TITLE
cached failed ID2's in ChatUI mode

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -41,10 +41,13 @@ type cacheStats struct {
 	timeout int
 	miss    int
 	notime  int
+	breaks  int
 }
 
-func (c cacheStats) eq(h, t, m, n int) bool {
-	return h == c.hit && t == c.timeout && m == c.miss && n == c.notime
+type identify2testCache map[keybase1.UID](*keybase1.Identify2Res)
+
+func (c cacheStats) eq(h, t, m, n, b int) bool {
+	return h == c.hit && t == c.timeout && m == c.miss && n == c.notime && b == c.breaks
 }
 
 type Identify2WithUIDTester struct {
@@ -53,7 +56,7 @@ type Identify2WithUIDTester struct {
 	finishCh        chan struct{}
 	startCh         chan struct{}
 	checkStatusHook func(libkb.SigHint) libkb.ProofError
-	cache           map[keybase1.UID](*keybase1.UserPlusKeys)
+	cache           identify2testCache
 	slowStats       cacheStats
 	fastStats       cacheStats
 	now             time.Time
@@ -65,7 +68,7 @@ func newIdentify2WithUIDTester(g *libkb.GlobalContext) *Identify2WithUIDTester {
 		Contextified: libkb.NewContextified(g),
 		finishCh:     make(chan struct{}),
 		startCh:      make(chan struct{}, 1),
-		cache:        make(map[keybase1.UID](*keybase1.UserPlusKeys)),
+		cache:        make(identify2testCache),
 		now:          time.Now(),
 		userLoads:    make(map[keybase1.UID]int),
 	}
@@ -166,12 +169,16 @@ func (i *Identify2WithUIDTester) Start(string, keybase1.IdentifyReason, bool) er
 	return nil
 }
 
-func (i *Identify2WithUIDTester) Get(uid keybase1.UID, gctf libkb.GetCheckTimeFunc, timeout time.Duration) (*keybase1.UserPlusKeys, error) {
+func (i *Identify2WithUIDTester) Get(uid keybase1.UID, gctf libkb.GetCheckTimeFunc, gcdf libkb.GetCacheDurationFunc, breaksOK bool) (*keybase1.Identify2Res, error) {
 	res := i.cache[uid]
 	stats := &i.slowStats
-	if timeout == libkb.Identify2CacheShortTimeout {
+
+	// Please execuse this horrible hack, but use the `GetCacheDurationFunc` to see if we're dealing
+	// with a fast cache duration
+	if gcdf(keybase1.Identify2Res{}) == libkb.Identify2CacheShortTimeout {
 		stats = &i.fastStats
 	}
+
 	if res == nil {
 		stats.miss++
 		return nil, nil
@@ -182,7 +189,11 @@ func (i *Identify2WithUIDTester) Get(uid keybase1.UID, gctf libkb.GetCheckTimeFu
 			stats.notime++
 			return nil, libkb.TimeoutError{}
 		}
-
+		if res.TrackBreaks != nil && !breaksOK {
+			stats.breaks++
+			return nil, libkb.TrackBrokenError{}
+		}
+		timeout := gcdf(*res)
 		thenTime := keybase1.FromTime(then)
 		if i.now.Sub(thenTime) > timeout {
 			stats.timeout++
@@ -193,11 +204,11 @@ func (i *Identify2WithUIDTester) Get(uid keybase1.UID, gctf libkb.GetCheckTimeFu
 	return res, nil
 }
 
-func (i *Identify2WithUIDTester) Insert(up *keybase1.UserPlusKeys) error {
+func (i *Identify2WithUIDTester) Insert(up *keybase1.Identify2Res) error {
 	tmp := *up
 	copy := &tmp
-	copy.Uvv.CachedAt = keybase1.ToTime(i.now)
-	i.cache[up.Uid] = copy
+	copy.Upk.Uvv.CachedAt = keybase1.ToTime(i.now)
+	i.cache[up.Upk.Uid] = copy
 	return nil
 }
 func (i *Identify2WithUIDTester) DidFullUserLoad(uid keybase1.UID) {
@@ -305,16 +316,16 @@ func TestIdentify2WithUIDWithTrackAndSuppress(t *testing.T) {
 	}
 }
 
-func identify2WithUIDWithBrokenTrackMakeEngine(t *testing.T, arg *keybase1.Identify2Arg) (*Identify2WithUID, libkb.IdentifyUI, func(), error) {
+func identify2WithUIDWithBrokenTrackMakeEngine(t *testing.T, arg *keybase1.Identify2Arg) (libkb.TestContext, *Identify2WithUID, *Identify2WithUIDTester, func(), error) {
 	tc := SetupEngineTest(t, "testIdentify2WithUIDWithBrokenTrack")
-	defer tc.Cleanup()
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	eng := NewIdentify2WithUID(tc.G, arg)
 
 	eng.testArgs = &Identify2WithUIDTestArgs{
-		noMe: true,
-		tcl:  importTrackingLink(t, tc.G),
+		noMe:  true,
+		cache: i,
+		tcl:   importTrackingLink(t, tc.G),
 	}
 	i.checkStatusHook = func(l libkb.SigHint) libkb.ProofError {
 		if strings.Contains(l.GetHumanURL(), "twitter") {
@@ -326,65 +337,153 @@ func identify2WithUIDWithBrokenTrackMakeEngine(t *testing.T, arg *keybase1.Ident
 	ctx := Context{IdentifyUI: i}
 	waiter := launchWaiter(t, i.finishCh)
 	err := eng.Run(&ctx)
-	return eng, i, waiter, err
+	return tc, eng, i, waiter, err
 }
 
-func testIdentify2WithUIDWithBrokenTrack(t *testing.T, suppress bool) {
+func testIdentify2WithUIDWithBrokenTrack(t *testing.T, suppress bool) (libkb.TestContext, *Identify2WithUIDTester) {
 	arg := &keybase1.Identify2Arg{
 		Uid:           tracyUID,
 		CanSuppressUI: suppress,
 	}
-	_, _, waiter, err := identify2WithUIDWithBrokenTrackMakeEngine(t, arg)
+	tc, _, i, waiter, err := identify2WithUIDWithBrokenTrackMakeEngine(t, arg)
 
 	if err == nil {
 		t.Fatal("expected an ID2 error since twitter proof failed")
 	}
 	waiter()
+	return tc, i
 }
 
 func TestIdentify2WithUIDWithBrokenTrack(t *testing.T) {
-	testIdentify2WithUIDWithBrokenTrack(t, false)
+	tc, _ := testIdentify2WithUIDWithBrokenTrack(t, false)
+	tc.Cleanup()
 }
 
 func TestIdentify2WithUIDWithBrokenTrackWithSuppressUI(t *testing.T) {
-	testIdentify2WithUIDWithBrokenTrack(t, true)
+	tc, _ := testIdentify2WithUIDWithBrokenTrack(t, true)
+	tc.Cleanup()
 }
 
 func TestIdentify2WithUIDWithBrokenTrackFromChatGUI(t *testing.T) {
-	arg := &keybase1.Identify2Arg{
-		Uid:         tracyUID,
-		ChatGUIMode: true,
+
+	tc := SetupEngineTest(t, "testIdentify2WithUIDWithBrokenTrack")
+	defer tc.Cleanup()
+	tester := newIdentify2WithUIDTester(tc.G)
+	tc.G.Services = tester
+	tester.checkStatusHook = func(l libkb.SigHint) libkb.ProofError {
+		if strings.Contains(l.GetHumanURL(), "twitter") {
+			tc.G.Log.Debug("failing twitter proof %s", l.GetHumanURL())
+			return libkb.NewProofError(keybase1.ProofStatus_DELETED, "gone!")
+		}
+		return nil
 	}
 
-	eng, origUI, waiter, err := identify2WithUIDWithBrokenTrackMakeEngine(t, arg)
+	var origUI libkb.IdentifyUI = tester
 
-	if err != nil {
-		t.Fatalf("expected no ID2 error; got %v\n", err)
+	checkBrokenRes := func(res *keybase1.Identify2Res) {
+		if !res.Upk.Uid.Equal(keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")) {
+			t.Fatal("bad UID for t_tracy")
+		}
+		if res.Upk.Username != "t_tracy" {
+			t.Fatal("bad username for t_tracy")
+		}
+		if len(res.Upk.DeviceKeys) != 4 {
+			t.Fatal("wrong # of device keys for tracy")
+		}
+		if len(res.TrackBreaks.Proofs) != 1 {
+			t.Fatal("Expected to get back 1 broken proof")
+		}
+		if res.TrackBreaks.Proofs[0].RemoteProof.Key != "twitter" {
+			t.Fatal("Expected a twitter proof type")
+		}
+		if res.TrackBreaks.Proofs[0].Lcr.RemoteDiff.Type != keybase1.TrackDiffType_REMOTE_FAIL {
+			t.Fatal("wrong remote failure type")
+		}
 	}
 
-	// Since we threw away the test UI, we have to manually complete the UI here,
-	// otherwise the waiter() will block indefinitely.
-	origUI.Finish()
-	waiter()
+	runChatGUI := func() {
+		// Now run the engine again, but in normal mode, and check that we don't hit
+		// the cached broken gy.
+		eng := NewIdentify2WithUID(tc.G, &keybase1.Identify2Arg{Uid: tracyUID, ChatGUIMode: true})
 
-	res := eng.Result()
-	if !res.Upk.Uid.Equal(keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")) {
-		t.Fatal("bad UID for t_tracy")
+		eng.testArgs = &Identify2WithUIDTestArgs{
+			noMe:  true,
+			cache: tester,
+			tcl:   importTrackingLink(t, tc.G),
+		}
+
+		ctx := Context{IdentifyUI: tester}
+
+		waiter := launchWaiter(t, tester.finishCh)
+		err := eng.Run(&ctx)
+		// Since we threw away the test UI, we have to manually complete the UI here,
+		// otherwise the waiter() will block indefinitely.
+		origUI.Finish()
+		waiter()
+		res := eng.Result()
+		if err != nil {
+			t.Fatalf("expected no ID2 error; got %v\n", err)
+		}
+		checkBrokenRes(res)
 	}
-	if res.Upk.Username != "t_tracy" {
-		t.Fatal("bad username for t_tracy")
+
+	runStandard := func() {
+		// Now run the engine again, but in normal mode, and check that we don't hit
+		// the cached broken gy.
+		eng := NewIdentify2WithUID(tc.G, &keybase1.Identify2Arg{Uid: tracyUID})
+
+		eng.testArgs = &Identify2WithUIDTestArgs{
+			noMe:  true,
+			cache: tester,
+			tcl:   importTrackingLink(t, tc.G),
+		}
+
+		ctx := Context{IdentifyUI: tester}
+
+		waiter := launchWaiter(t, tester.finishCh)
+		err := eng.Run(&ctx)
+		waiter()
+		if err == nil {
+			t.Fatalf("Expected a break with running ID2 in standard mode")
+		}
 	}
-	if len(res.Upk.DeviceKeys) != 4 {
-		t.Fatal("wrong # of device keys for tracy")
+
+	runChatGUI()
+
+	// First time through, we should miss both caches
+	if !tester.fastStats.eq(0, 0, 1, 0, 0) || !tester.slowStats.eq(0, 0, 1, 0, 0) {
+		t.Fatalf("bad cache stats: %+v, %+v", tester.fastStats, tester.slowStats)
 	}
-	if len(res.TrackBreaks.Proofs) != 1 {
-		t.Fatal("Expected to get back 1 broken proof")
+
+	runStandard()
+
+	// If we run without the chat GUI, we should hit the cache, but have it be
+	// disqualified because the cached copy has broken tracker statements.
+	if !tester.fastStats.eq(0, 0, 1, 0, 1) || !tester.slowStats.eq(0, 0, 1, 0, 1) {
+		t.Fatalf("bad cache stats: %+v, %+v", tester.fastStats, tester.slowStats)
 	}
-	if res.TrackBreaks.Proofs[0].RemoteProof.Key != "twitter" {
-		t.Fatal("Expected a twitter proof type")
+
+	runChatGUI()
+
+	// The next time we run with the chat GUI, we should hit the fast cache.
+	if !tester.fastStats.eq(1, 0, 1, 0, 1) || !tester.slowStats.eq(0, 0, 1, 0, 1) {
+		t.Fatalf("bad cache stats: %+v, %+v", tester.fastStats, tester.slowStats)
 	}
-	if res.TrackBreaks.Proofs[0].Lcr.RemoteDiff.Type != keybase1.TrackDiffType_REMOTE_FAIL {
-		t.Fatal("wrong remote failure type")
+
+	tester.incNow(time.Second + libkb.Identify2CacheShortTimeout)
+	runChatGUI()
+
+	// A fast cache timeout and a slow cache hit!
+	if !tester.fastStats.eq(1, 1, 1, 0, 1) || !tester.slowStats.eq(1, 0, 1, 0, 1) {
+		t.Fatalf("bad cache stats: %+v, %+v", tester.fastStats, tester.slowStats)
+	}
+
+	tester.incNow(time.Second + libkb.Identify2CacheBrokenTimeout)
+	runChatGUI()
+
+	// After the broken timeout passes, we should get timeouts on both caches
+	if !tester.fastStats.eq(1, 2, 1, 0, 1) || !tester.slowStats.eq(1, 1, 1, 0, 1) {
+		t.Fatalf("bad cache stats: %+v, %+v", tester.fastStats, tester.slowStats)
 	}
 }
 
@@ -607,7 +706,7 @@ func TestIdentify2WithUIDCache(t *testing.T) {
 	<-i.startCh
 	<-i.finishCh
 
-	if !i.fastStats.eq(0, 0, 1, 0) || !i.slowStats.eq(0, 0, 1, 0) {
+	if !i.fastStats.eq(0, 0, 1, 0, 0) || !i.slowStats.eq(0, 0, 1, 0, 0) {
 		t.Fatalf("bad cache stats %+v %+v", i.fastStats, i.slowStats)
 	}
 
@@ -615,7 +714,7 @@ func TestIdentify2WithUIDCache(t *testing.T) {
 	run()
 
 	// A new fast-path hit
-	if !i.fastStats.eq(1, 0, 1, 0) || !i.slowStats.eq(0, 0, 1, 0) {
+	if !i.fastStats.eq(1, 0, 1, 0, 0) || !i.slowStats.eq(0, 0, 1, 0, 0) {
 		t.Fatalf("bad cache stats %+v %+v", i.fastStats, i.slowStats)
 	}
 
@@ -623,7 +722,7 @@ func TestIdentify2WithUIDCache(t *testing.T) {
 	run()
 
 	// A new fast-path timeout and a new slow-path hit
-	if !i.fastStats.eq(1, 1, 1, 0) || !i.slowStats.eq(1, 0, 1, 0) {
+	if !i.fastStats.eq(1, 1, 1, 0, 0) || !i.slowStats.eq(1, 0, 1, 0, 0) {
 		t.Fatalf("bad cache stats %+v %+v", i.fastStats, i.slowStats)
 	}
 
@@ -633,14 +732,14 @@ func TestIdentify2WithUIDCache(t *testing.T) {
 	<-i.finishCh
 
 	// A new slow-path timeout and a new slow-path timeout
-	if !i.fastStats.eq(1, 2, 1, 0) || !i.slowStats.eq(1, 1, 1, 0) {
+	if !i.fastStats.eq(1, 2, 1, 0, 0) || !i.slowStats.eq(1, 1, 1, 0, 0) {
 		t.Fatalf("bad cache stats %+v %+v", i.fastStats, i.slowStats)
 	}
 
 	i.incNow(time.Second)
 	run()
 	// A new fast-path hit
-	if !i.fastStats.eq(2, 2, 1, 0) || !i.slowStats.eq(1, 1, 1, 0) {
+	if !i.fastStats.eq(2, 2, 1, 0, 0) || !i.slowStats.eq(1, 1, 1, 0, 0) {
 		t.Fatalf("bad cache stats %+v %+v", i.fastStats, i.slowStats)
 	}
 
@@ -648,7 +747,7 @@ func TestIdentify2WithUIDCache(t *testing.T) {
 	i.incNow(time.Second)
 	run()
 	// A new slow-path hit; we have to use the slow path with assertions
-	if !i.fastStats.eq(2, 2, 1, 0) || !i.slowStats.eq(2, 1, 1, 0) {
+	if !i.fastStats.eq(2, 2, 1, 0, 0) || !i.slowStats.eq(2, 1, 1, 0, 0) {
 		t.Fatalf("bad cache stats %+v %+v", i.fastStats, i.slowStats)
 	}
 }
@@ -691,14 +790,14 @@ func TestIdentify2WithUIDLocalAssertions(t *testing.T) {
 	<-i.finishCh
 
 	// Don't attempt to hit fast cache, since we're using local assertions.
-	if !i.fastStats.eq(0, 0, 0, 0) || !i.slowStats.eq(0, 0, 1, 0) {
+	if !i.fastStats.eq(0, 0, 0, 0, 0) || !i.slowStats.eq(0, 0, 1, 0, 0) {
 		t.Fatalf("bad cache stats %+v %+v", i.fastStats, i.slowStats)
 	}
 
 	i.incNow(time.Second)
 	run()
 	// A new slow-path hit
-	if !i.fastStats.eq(0, 0, 0, 0) || !i.slowStats.eq(1, 0, 1, 0) {
+	if !i.fastStats.eq(0, 0, 0, 0, 0) || !i.slowStats.eq(1, 0, 1, 0, 0) {
 		t.Fatalf("bad cache stats %+v %+v", i.fastStats, i.slowStats)
 	}
 	if n := numTracyLoads(); n != 1 {
@@ -708,7 +807,7 @@ func TestIdentify2WithUIDLocalAssertions(t *testing.T) {
 	i.incNow(time.Second)
 	run()
 	// A new slow-path hit
-	if !i.fastStats.eq(0, 0, 0, 0) || !i.slowStats.eq(2, 0, 1, 0) {
+	if !i.fastStats.eq(0, 0, 0, 0, 0) || !i.slowStats.eq(2, 0, 1, 0, 0) {
 		t.Fatalf("bad cache stats %+v %+v", i.fastStats, i.slowStats)
 	}
 	if n := numTracyLoads(); n != 2 {
@@ -720,14 +819,14 @@ func TestIdentify2WithUIDLocalAssertions(t *testing.T) {
 	<-i.startCh
 	<-i.finishCh
 	// A new slow-path timeout
-	if !i.fastStats.eq(0, 0, 0, 0) || !i.slowStats.eq(2, 1, 1, 0) {
+	if !i.fastStats.eq(0, 0, 0, 0, 0) || !i.slowStats.eq(2, 1, 1, 0, 0) {
 		t.Fatalf("bad cache stats %+v %+v", i.fastStats, i.slowStats)
 	}
 
 	i.incNow(time.Second)
 	run()
 	// A new slow-path hit
-	if !i.fastStats.eq(0, 0, 0, 0) || !i.slowStats.eq(3, 1, 1, 0) {
+	if !i.fastStats.eq(0, 0, 0, 0, 0) || !i.slowStats.eq(3, 1, 1, 0, 0) {
 		t.Fatalf("bad cache stats %+v %+v", i.fastStats, i.slowStats)
 	}
 }

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -316,8 +316,9 @@ func TestIdentify2WithUIDWithTrackAndSuppress(t *testing.T) {
 	}
 }
 
-func identify2WithUIDWithBrokenTrackMakeEngine(t *testing.T, arg *keybase1.Identify2Arg) (libkb.TestContext, *Identify2WithUID, *Identify2WithUIDTester, func(), error) {
+func identify2WithUIDWithBrokenTrackMakeEngine(t *testing.T, arg *keybase1.Identify2Arg) (func(), error) {
 	tc := SetupEngineTest(t, "testIdentify2WithUIDWithBrokenTrack")
+	defer tc.Cleanup()
 	i := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = i
 	eng := NewIdentify2WithUID(tc.G, arg)
@@ -337,36 +338,33 @@ func identify2WithUIDWithBrokenTrackMakeEngine(t *testing.T, arg *keybase1.Ident
 	ctx := Context{IdentifyUI: i}
 	waiter := launchWaiter(t, i.finishCh)
 	err := eng.Run(&ctx)
-	return tc, eng, i, waiter, err
+	return waiter, err
 }
 
-func testIdentify2WithUIDWithBrokenTrack(t *testing.T, suppress bool) (libkb.TestContext, *Identify2WithUIDTester) {
+func testIdentify2WithUIDWithBrokenTrack(t *testing.T, suppress bool) {
 	arg := &keybase1.Identify2Arg{
 		Uid:           tracyUID,
 		CanSuppressUI: suppress,
 	}
-	tc, _, i, waiter, err := identify2WithUIDWithBrokenTrackMakeEngine(t, arg)
+	waiter, err := identify2WithUIDWithBrokenTrackMakeEngine(t, arg)
 
 	if err == nil {
 		t.Fatal("expected an ID2 error since twitter proof failed")
 	}
 	waiter()
-	return tc, i
 }
 
 func TestIdentify2WithUIDWithBrokenTrack(t *testing.T) {
-	tc, _ := testIdentify2WithUIDWithBrokenTrack(t, false)
-	tc.Cleanup()
+	testIdentify2WithUIDWithBrokenTrack(t, false)
 }
 
 func TestIdentify2WithUIDWithBrokenTrackWithSuppressUI(t *testing.T) {
-	tc, _ := testIdentify2WithUIDWithBrokenTrack(t, true)
-	tc.Cleanup()
+	testIdentify2WithUIDWithBrokenTrack(t, true)
 }
 
 func TestIdentify2WithUIDWithBrokenTrackFromChatGUI(t *testing.T) {
 
-	tc := SetupEngineTest(t, "testIdentify2WithUIDWithBrokenTrack")
+	tc := SetupEngineTest(t, "TestIdentify2WithUIDWithBrokenTrackFromChatGUI")
 	defer tc.Cleanup()
 	tester := newIdentify2WithUIDTester(tc.G)
 	tc.G.Services = tester

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -83,15 +83,16 @@ const (
 	UserCacheMaxAge      = 5 * time.Minute
 	PGPFingerprintHexLen = 40
 
-	ProofCacheSize             = 0x1000
-	ProofCacheLongDur          = 48 * time.Hour
-	ProofCacheMediumDur        = 6 * time.Hour
-	ProofCacheShortDur         = 30 * time.Minute
-	Identify2CacheLongTimeout  = 6 * time.Hour
-	Identify2CacheShortTimeout = 1 * time.Minute
-	CachedUserTimeout          = 10 * time.Minute // How long we'll go without rerequesting hints/merkle seqno
-	LinkCacheSize              = 0x10000
-	LinkCacheCleanDur          = 1 * time.Minute
+	ProofCacheSize              = 0x1000
+	ProofCacheLongDur           = 48 * time.Hour
+	ProofCacheMediumDur         = 6 * time.Hour
+	ProofCacheShortDur          = 30 * time.Minute
+	Identify2CacheLongTimeout   = 6 * time.Hour
+	Identify2CacheBrokenTimeout = 1 * time.Hour
+	Identify2CacheShortTimeout  = 1 * time.Minute
+	CachedUserTimeout           = 10 * time.Minute // How long we'll go without rerequesting hints/merkle seqno
+	LinkCacheSize               = 0x10000
+	LinkCacheCleanDur           = 1 * time.Minute
 
 	SigShortIDBytes  = 27
 	LocalTrackMaxAge = 48 * time.Hour

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1211,6 +1211,14 @@ func (e IdentifyTimeoutError) Error() string {
 
 //=============================================================================
 
+type TrackBrokenError struct{}
+
+func (e TrackBrokenError) Error() string {
+	return "track of user was broken"
+}
+
+//=============================================================================
+
 type IdentifyDidNotCompleteError struct{}
 
 func (e IdentifyDidNotCompleteError) Error() string {

--- a/go/libkb/identify2_cache.go
+++ b/go/libkb/identify2_cache.go
@@ -18,13 +18,14 @@ type Identify2Cache struct {
 }
 
 type Identify2Cacher interface {
-	Get(keybase1.UID, GetCheckTimeFunc, time.Duration) (*keybase1.UserPlusKeys, error)
-	Insert(up *keybase1.UserPlusKeys) error
+	Get(keybase1.UID, GetCheckTimeFunc, GetCacheDurationFunc, bool) (*keybase1.Identify2Res, error)
+	Insert(up *keybase1.Identify2Res) error
 	DidFullUserLoad(keybase1.UID)
 	Shutdown()
 }
 
-type GetCheckTimeFunc func(keybase1.UserPlusKeys) keybase1.Time
+type GetCheckTimeFunc func(keybase1.Identify2Res) keybase1.Time
+type GetCacheDurationFunc func(keybase1.Identify2Res) time.Duration
 
 // NewIdentify2Cache creates a Identify2Cache and sets the object max age to
 // maxAge.  Once a user is inserted, after maxAge duration passes,
@@ -39,7 +40,7 @@ func NewIdentify2Cache(maxAge time.Duration) *Identify2Cache {
 }
 
 // Get returns a user object.  If none exists for uid, it will return nil.
-func (c *Identify2Cache) Get(uid keybase1.UID, gctf GetCheckTimeFunc, timeout time.Duration) (*keybase1.UserPlusKeys, error) {
+func (c *Identify2Cache) Get(uid keybase1.UID, gctf GetCheckTimeFunc, gcdf GetCacheDurationFunc, breaksOK bool) (*keybase1.Identify2Res, error) {
 	v, err := c.cache.Get(string(uid))
 	if err != nil {
 		if err == ramcache.ErrNotFound {
@@ -47,7 +48,7 @@ func (c *Identify2Cache) Get(uid keybase1.UID, gctf GetCheckTimeFunc, timeout ti
 		}
 		return nil, err
 	}
-	up, ok := v.(*keybase1.UserPlusKeys)
+	up, ok := v.(*keybase1.Identify2Res)
 	if !ok {
 		return nil, fmt.Errorf("invalid type in cache: %T", v)
 	}
@@ -55,12 +56,16 @@ func (c *Identify2Cache) Get(uid keybase1.UID, gctf GetCheckTimeFunc, timeout ti
 	if gctf != nil {
 		then := gctf(*up)
 		if then == 0 {
-			return nil, TimeoutError{}
+			return nil, IdentifyTimeoutError{}
+		}
+		if up.TrackBreaks != nil && !breaksOK {
+			return nil, TrackBrokenError{}
 		}
 
 		thenTime := keybase1.FromTime(then)
+		timeout := gcdf(*up)
 		if time.Since(thenTime) > timeout {
-			return nil, TimeoutError{}
+			return nil, IdentifyTimeoutError{}
 		}
 	}
 
@@ -68,11 +73,11 @@ func (c *Identify2Cache) Get(uid keybase1.UID, gctf GetCheckTimeFunc, timeout ti
 }
 
 // Insert adds a user to the cache, keyed on UID.
-func (c *Identify2Cache) Insert(up *keybase1.UserPlusKeys) error {
+func (c *Identify2Cache) Insert(up *keybase1.Identify2Res) error {
 	tmp := *up
 	copy := &tmp
-	copy.Uvv.CachedAt = keybase1.ToTime(time.Now())
-	return c.cache.Set(string(up.Uid), copy)
+	copy.Upk.Uvv.CachedAt = keybase1.ToTime(time.Now())
+	return c.cache.Set(string(up.Upk.Uid), copy)
 }
 
 // Shutdown stops any goroutines in the cache.


### PR DESCRIPTION
- don't ever write them out to disk
- cache them for only 1 hr (rather than 6)