### PR TITLE
Quick fix for \ => undefined

### DIFF
--- a/shared/common-adapters/markdown.js
+++ b/shared/common-adapters/markdown.js
@@ -167,7 +167,7 @@ function _parse (text: string, tagStack: TagStack, key: number): React$Element<*
         key,
       })
     } else {
-      if (firstChar === '\\') {
+      if (firstChar === '\\' && text.length > 1) {
         parseStack.push({
           text: text.slice(2),
           tagStack: tagStack.update(-1, m => ({...m, textSoFar: m.textSoFar + text[1]})),


### PR DESCRIPTION
@keybase/react-hackers 

Here's a quick fix for `\` at the end of a message being converted to `undefined`, while we wait for a better parser. 

Before:
> \ => undefined
> foo\ => fooundefined

After:
> \ => \
> foo\ => foo\