### PR TITLE
make SaltpackSenderIdentify understand revoked keys

### DIFF
--- a/go/client/cmd_verify.go
+++ b/go/client/cmd_verify.go
@@ -48,6 +48,10 @@ func NewCmdVerify(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comman
 				Name:  "S, signed-by",
 				Usage: "Assert signed by the given user (can use user assertion format).",
 			},
+			cli.BoolFlag{
+				Name:  "f, force",
+				Usage: "Output the verified message even if the sender's identity can't be verified",
+			},
 		},
 	}
 }
@@ -58,6 +62,7 @@ type CmdVerify struct {
 	detachedData []byte
 	signedBy     string
 	spui         *SaltpackUI
+	force        bool
 }
 
 func (c *CmdVerify) ParseArgv(ctx *cli.Context) error {
@@ -88,6 +93,8 @@ func (c *CmdVerify) ParseArgv(ctx *cli.Context) error {
 		c.detachedData = data
 	}
 
+	c.force = ctx.Bool("force")
+
 	return nil
 }
 
@@ -100,6 +107,7 @@ func (c *CmdVerify) Run() (err error) {
 	c.spui = &SaltpackUI{
 		Contextified: libkb.NewContextified(c.G()),
 		terminal:     c.G().UI.GetTerminalUI(),
+		force:        c.force,
 	}
 
 	protocols := []rpc.Protocol{

--- a/go/client/saltpack_ui.go
+++ b/go/client/saltpack_ui.go
@@ -27,6 +27,18 @@ func (s *SaltpackUI) doNonInteractive(arg keybase1.SaltpackPromptForDecryptArg) 
 			return nil
 		}
 		return libkb.IdentifyFailedError{Assertion: arg.Sender.Username, Reason: "sender identity failed"}
+	case keybase1.SaltpackSenderType_REVOKED:
+		if s.force {
+			s.G().Log.Warning("The key that signed this message is revoked, but forcing through.")
+			return nil
+		}
+		return libkb.IdentifyFailedError{Assertion: arg.Sender.Username, Reason: "sender key revoked"}
+	case keybase1.SaltpackSenderType_EXPIRED:
+		if s.force {
+			s.G().Log.Warning("The key that signed this message is expired, but forcing through.")
+			return nil
+		}
+		return libkb.IdentifyFailedError{Assertion: arg.Sender.Username, Reason: "sender key expired"}
 	default:
 		return nil
 	}
@@ -46,6 +58,12 @@ func (s *SaltpackUI) doInteractive(arg keybase1.SaltpackPromptForDecryptArg) err
 		why = "The sender of this message has chosen to remain anonymous"
 	case keybase1.SaltpackSenderType_TRACKING_BROKE:
 		why = "You follow the sender of this message, but your view of them is broken"
+		def = libkb.PromptDefaultNo
+	case keybase1.SaltpackSenderType_REVOKED:
+		why = "The key that signed this message has been revoked"
+		def = libkb.PromptDefaultNo
+	case keybase1.SaltpackSenderType_EXPIRED:
+		why = "The key that signed this message has expired"
 		def = libkb.PromptDefaultNo
 	}
 	why += ". Go ahead and decrypt?"
@@ -75,14 +93,15 @@ func (s *SaltpackUI) SaltpackVerifySuccess(_ context.Context, arg keybase1.Saltp
 	// write messages to stderr
 	w := s.terminal.ErrorWriter()
 	var un string
-	if arg.Sender.SenderType == keybase1.SaltpackSenderType_UNKNOWN {
+	switch arg.Sender.SenderType {
+	case keybase1.SaltpackSenderType_UNKNOWN:
 		un = "The signer of this message is unknown to Keybase"
-	} else {
-		var you string
-		if arg.Sender.SenderType == keybase1.SaltpackSenderType_SELF {
-			you = " (you)"
-		}
-		un = fmt.Sprintf("Signed by %s%s", ColorString("bold", arg.Sender.Username), you)
+	case keybase1.SaltpackSenderType_TRACKING_OK, keybase1.SaltpackSenderType_NOT_TRACKED:
+		un = fmt.Sprintf("Signed by %s", ColorString("bold", arg.Sender.Username))
+	case keybase1.SaltpackSenderType_SELF:
+		un = fmt.Sprintf("Signed by %s (you)", ColorString("bold", arg.Sender.Username))
+	default:
+		return fmt.Errorf("Unexpected sender type: %s", arg.Sender.SenderType)
 	}
 	fmt.Fprintf(w, ColorString("green", fmt.Sprintf("Signature verified. %s.\n", un)))
 	if arg.Sender.SenderType == keybase1.SaltpackSenderType_UNKNOWN {
@@ -90,4 +109,33 @@ func (s *SaltpackUI) SaltpackVerifySuccess(_ context.Context, arg keybase1.Saltp
 	}
 
 	return nil
+}
+
+// This function is responsible for short-circuiting the output of the bad
+// message. It returns an error if the --force argument isn't present, and the
+// VerifyEngine bubbles that up. This is similar to doNonInteractive above.
+func (s *SaltpackUI) SaltpackVerifyBadSender(_ context.Context, arg keybase1.SaltpackVerifyBadSenderArg) error {
+	// write messages to stderr
+	var message string
+	var errorReason string
+	switch arg.Sender.SenderType {
+	case keybase1.SaltpackSenderType_TRACKING_BROKE:
+		message = fmt.Sprintf("Signed by %s, but their tracking statement is broken.", ColorString("bold", arg.Sender.Username))
+		errorReason = "tracking statement broken"
+	case keybase1.SaltpackSenderType_REVOKED:
+		message = fmt.Sprintf("Signed by %s, but the key they used (%s) is revoked.", ColorString("bold", arg.Sender.Username), arg.SigningKID.String())
+		errorReason = "sender key revoked"
+	case keybase1.SaltpackSenderType_EXPIRED:
+		message = fmt.Sprintf("Signed by %s, but the key they used (%s) is expired.", ColorString("bold", arg.Sender.Username), arg.SigningKID.String())
+		errorReason = "sender key expired"
+	default:
+		return fmt.Errorf("Unexpected bad sender type: %s", arg.Sender.SenderType)
+	}
+	w := s.terminal.ErrorWriter()
+	fmt.Fprintf(w, ColorString("red", fmt.Sprintf("Problem verifying the sender: %s\n", message)))
+
+	if s.force {
+		return nil
+	}
+	return libkb.IdentifyFailedError{Assertion: arg.Sender.Username, Reason: errorReason}
 }

--- a/go/client/saltpack_ui.go
+++ b/go/client/saltpack_ui.go
@@ -123,10 +123,10 @@ func (s *SaltpackUI) SaltpackVerifyBadSender(_ context.Context, arg keybase1.Sal
 		message = fmt.Sprintf("Signed by %s, but their tracking statement is broken.", ColorString("bold", arg.Sender.Username))
 		errorReason = "tracking statement broken"
 	case keybase1.SaltpackSenderType_REVOKED:
-		message = fmt.Sprintf("Signed by %s, but the key they used (%s) is revoked.", ColorString("bold", arg.Sender.Username), arg.SigningKID.String())
+		message = fmt.Sprintf("Signed by %s, but the key they used is revoked:\n    %s", ColorString("bold", arg.Sender.Username), arg.SigningKID.String())
 		errorReason = "sender key revoked"
 	case keybase1.SaltpackSenderType_EXPIRED:
-		message = fmt.Sprintf("Signed by %s, but the key they used (%s) is expired.", ColorString("bold", arg.Sender.Username), arg.SigningKID.String())
+		message = fmt.Sprintf("Signed by %s, but the key they used is expired:\n    %s", ColorString("bold", arg.Sender.Username), arg.SigningKID.String())
 		errorReason = "sender key expired"
 	default:
 		return fmt.Errorf("Unexpected bad sender type: %s", arg.Sender.SenderType)
@@ -137,5 +137,6 @@ func (s *SaltpackUI) SaltpackVerifyBadSender(_ context.Context, arg keybase1.Sal
 	if s.force {
 		return nil
 	}
+	fmt.Fprintf(w, ColorString("red", "Use --force to see the message anyway.\n"))
 	return libkb.IdentifyFailedError{Assertion: arg.Sender.Username, Reason: errorReason}
 }

--- a/go/engine/saltpack_decrypt_test.go
+++ b/go/engine/saltpack_decrypt_test.go
@@ -6,6 +6,7 @@ package engine
 import (
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -24,6 +25,18 @@ func (s fakeSaltpackUI) SaltpackPromptForDecrypt(_ context.Context, arg keybase1
 
 func (s fakeSaltpackUI) SaltpackVerifySuccess(_ context.Context, arg keybase1.SaltpackVerifySuccessArg) error {
 	return nil
+}
+
+type FakeBadSenderError struct {
+	senderType keybase1.SaltpackSenderType
+}
+
+func (e *FakeBadSenderError) Error() string {
+	return fmt.Sprintf("fakeSaltpackUI bad sender error: %s", e.senderType.String())
+}
+
+func (s fakeSaltpackUI) SaltpackVerifyBadSender(_ context.Context, arg keybase1.SaltpackVerifyBadSenderArg) error {
+	return &FakeBadSenderError{arg.Sender.SenderType}
 }
 
 func TestSaltpackDecrypt(t *testing.T) {

--- a/go/engine/saltpack_encrypt_test.go
+++ b/go/engine/saltpack_encrypt_test.go
@@ -4,9 +4,11 @@
 package engine
 
 import (
-	"golang.org/x/net/context"
+	"fmt"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -27,6 +29,10 @@ func (s *fakeSaltpackUI2) SaltpackPromptForDecrypt(_ context.Context, arg keybas
 
 func (s *fakeSaltpackUI2) SaltpackVerifySuccess(_ context.Context, arg keybase1.SaltpackVerifySuccessArg) error {
 	return nil
+}
+
+func (s *fakeSaltpackUI2) SaltpackVerifyBadSender(_ context.Context, arg keybase1.SaltpackVerifyBadSenderArg) error {
+	return fmt.Errorf("fakeSaltpackUI2 SaltpackVerifyBadSender error: %s", arg.Sender.SenderType.String())
 }
 
 func TestSaltpackEncrypt(t *testing.T) {

--- a/go/engine/saltpack_verify.go
+++ b/go/engine/saltpack_verify.go
@@ -97,11 +97,26 @@ func (e *SaltpackVerify) identifySender(ctx *Context, key saltpack.SigningPublic
 		return err
 	}
 
-	arg := keybase1.SaltpackVerifySuccessArg{
+	if senderTypeIsSuccessful(spsiEng.Result().SenderType) {
+		arg := keybase1.SaltpackVerifySuccessArg{
+			Sender:     spsiEng.Result(),
+			SigningKID: kid,
+		}
+		return ctx.SaltpackUI.SaltpackVerifySuccess(context.TODO(), arg)
+	}
+
+	arg := keybase1.SaltpackVerifyBadSenderArg{
 		Sender:     spsiEng.Result(),
 		SigningKID: kid,
 	}
-	ctx.SaltpackUI.SaltpackVerifySuccess(context.TODO(), arg)
+	// This will return an error if --force is not given.
+	return ctx.SaltpackUI.SaltpackVerifyBadSender(context.TODO(), arg)
+}
 
-	return nil
+func senderTypeIsSuccessful(senderType keybase1.SaltpackSenderType) bool {
+	return (senderType == keybase1.SaltpackSenderType_NOT_TRACKED ||
+		senderType == keybase1.SaltpackSenderType_UNKNOWN ||
+		senderType == keybase1.SaltpackSenderType_ANONYMOUS ||
+		senderType == keybase1.SaltpackSenderType_TRACKING_OK ||
+		senderType == keybase1.SaltpackSenderType_SELF)
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -307,6 +307,7 @@ type SecretUI interface {
 type SaltpackUI interface {
 	SaltpackPromptForDecrypt(context.Context, keybase1.SaltpackPromptForDecryptArg, bool) error
 	SaltpackVerifySuccess(context.Context, keybase1.SaltpackVerifySuccessArg) error
+	SaltpackVerifyBadSender(context.Context, keybase1.SaltpackVerifyBadSenderArg) error
 }
 
 type LogUI interface {

--- a/go/libkb/key_lookup.go
+++ b/go/libkb/key_lookup.go
@@ -20,8 +20,8 @@ func PGPLookupFingerprint(g *GlobalContext, fp *PGPFingerprint) (username string
 	return keyLookup(g, keyLookupArg{fp: fp})
 }
 
-func KeyLookupKID(g *GlobalContext, k keybase1.KID) (username string, uid keybase1.UID, err error) {
-	return keyLookup(g, keyLookupArg{kid: k})
+func KeyLookupKIDIncludingRevoked(g *GlobalContext, k keybase1.KID) (username string, uid keybase1.UID, err error) {
+	return keyLookup(g, keyLookupArg{kid: k, includeRevoked: true})
 }
 
 func KeyLookupByBoxPublicKey(g *GlobalContext, k saltpack.BoxPublicKey) (username string, uid keybase1.UID, err error) {
@@ -29,10 +29,11 @@ func KeyLookupByBoxPublicKey(g *GlobalContext, k saltpack.BoxPublicKey) (usernam
 }
 
 type keyLookupArg struct {
-	fp     *PGPFingerprint
-	hexID  string
-	uintID uint64
-	kid    keybase1.KID
+	fp             *PGPFingerprint
+	hexID          string
+	uintID         uint64
+	kid            keybase1.KID
+	includeRevoked bool
 }
 
 type keyBasicsReply struct {
@@ -47,6 +48,7 @@ func (k *keyBasicsReply) GetAppStatus() *AppStatus {
 
 func keyLookup(g *GlobalContext, arg keyLookupArg) (username string, uid keybase1.UID, err error) {
 	httpArgs := make(HTTPArgs)
+	httpArgs["include_revoked"] = B{Val: arg.includeRevoked}
 	switch {
 	case arg.fp != nil:
 		httpArgs["fingerprint"] = S{arg.fp.String()}

--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -1026,3 +1026,35 @@ func (ckf *ComputedKeyFamily) HasActiveDevice() bool {
 	}
 	return false
 }
+
+// Returns (&senderType, err). A non-nil error indicates some unexpected
+// condition (like the key doesn't exist at all), which should be propagated.
+// If the sender type is nil, the key is active, and the caller should proceed
+// with an identify. Otherwise the key is no longer active, and the sender type
+// indicates why.
+func (ckf ComputedKeyFamily) GetSaltpackSenderTypeIfInactive(kid keybase1.KID) (*keybase1.SaltpackSenderType, error) {
+	info := ckf.cki.Infos[kid]
+	if info == nil {
+		// This shouldn't happen without a server bug/attack or a very unlikely
+		// race condition (e.g. a user account reset between the API server
+		// telling us they own a key, and the loaduser confirming it.)
+		return nil, fmt.Errorf("Key %s not found in key infos", kid.String())
+	}
+	if info.Status == KeyRevoked {
+		ret := keybase1.SaltpackSenderType_REVOKED
+		return &ret, nil
+	}
+	if info.Status == KeyUncancelled {
+		// TODO: Get rid of the whole concept of expiration?
+		if info.GetETime().Before(time.Now()) && !info.GetETime().IsZero() {
+			ret := keybase1.SaltpackSenderType_EXPIRED
+			return &ret, nil
+		}
+		// An active key. The caller needs to do an identify to determine the
+		// final sender type (UNTRACKED, TRACKING_BROKE, etc.).
+		return nil, nil
+	}
+	// This also shouldn't happen without a server bug or a very unlikely race
+	// condition.
+	return nil, fmt.Errorf("Key %s neither active nor revoked (%d)", kid.String(), info.Status)
+}

--- a/go/service/saltpack.go
+++ b/go/service/saltpack.go
@@ -39,6 +39,11 @@ func (r *RemoteSaltpackUI) SaltpackVerifySuccess(ctx context.Context, arg keybas
 	return r.cli.SaltpackVerifySuccess(ctx, arg)
 }
 
+func (r *RemoteSaltpackUI) SaltpackVerifyBadSender(ctx context.Context, arg keybase1.SaltpackVerifyBadSenderArg) (err error) {
+	arg.SessionID = r.sessionID
+	return r.cli.SaltpackVerifyBadSender(ctx, arg)
+}
+
 func NewSaltpackHandler(xp rpc.Transporter, g *libkb.GlobalContext) *SaltpackHandler {
 	return &SaltpackHandler{
 		BaseHandler:  NewBaseHandler(xp),

--- a/protocol/avdl/keybase1/saltpack_ui.avdl
+++ b/protocol/avdl/keybase1/saltpack_ui.avdl
@@ -9,7 +9,9 @@ protocol saltpackUi {
     ANONYMOUS_2,
     TRACKING_BROKE_3,
     TRACKING_OK_4,
-    SELF_5
+    SELF_5,
+    REVOKED_6,
+    EXPIRED_7
   }
 
   record SaltpackSender {
@@ -23,4 +25,5 @@ protocol saltpackUi {
   void saltpackPromptForDecrypt(int sessionID, SaltpackSender sender, boolean usedDelegateUI);
 
   void saltpackVerifySuccess(int sessionID, KID signingKID, SaltpackSender sender);
+  void saltpackVerifyBadSender(int sessionID, KID signingKID, SaltpackSender sender);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -423,6 +423,8 @@ export const SaltpackUiSaltpackSenderType = {
   trackingBroke: 3,
   trackingOk: 4,
   self: 5,
+  revoked: 6,
+  expired: 7,
 }
 
 export const TlfKeysTLFIdentifyBehavior = {
@@ -3749,6 +3751,8 @@ export type SaltpackSenderType =
   | 3 // TRACKING_BROKE_3
   | 4 // TRACKING_OK_4
   | 5 // SELF_5
+  | 6 // REVOKED_6
+  | 7 // EXPIRED_7
 
 export type SaltpackSignOptions = {
   detached: boolean,
@@ -4941,6 +4945,11 @@ export type saltpackUiSaltpackPromptForDecryptRpcParam = Exact<{
   usedDelegateUI: boolean
 }>
 
+export type saltpackUiSaltpackVerifyBadSenderRpcParam = Exact<{
+  signingKID: KID,
+  sender: SaltpackSender
+}>
+
 export type saltpackUiSaltpackVerifySuccessRpcParam = Exact<{
   signingKID: KID,
   sender: SaltpackSender
@@ -6119,6 +6128,14 @@ export type incomingCallMapType = Exact<{
     response: CommonResponseHandler
   ) => void,
   'keybase.1.saltpackUi.saltpackVerifySuccess'?: (
+    params: Exact<{
+      sessionID: int,
+      signingKID: KID,
+      sender: SaltpackSender
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.saltpackUi.saltpackVerifyBadSender'?: (
     params: Exact<{
       sessionID: int,
       signingKID: KID,

--- a/protocol/json/keybase1/saltpack_ui.json
+++ b/protocol/json/keybase1/saltpack_ui.json
@@ -16,7 +16,9 @@
         "ANONYMOUS_2",
         "TRACKING_BROKE_3",
         "TRACKING_OK_4",
-        "SELF_5"
+        "SELF_5",
+        "REVOKED_6",
+        "EXPIRED_7"
       ]
     },
     {
@@ -57,6 +59,23 @@
       "response": null
     },
     "saltpackVerifySuccess": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "signingKID",
+          "type": "KID"
+        },
+        {
+          "name": "sender",
+          "type": "SaltpackSender"
+        }
+      ],
+      "response": null
+    },
+    "saltpackVerifyBadSender": {
       "request": [
         {
           "name": "sessionID",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -423,6 +423,8 @@ export const SaltpackUiSaltpackSenderType = {
   trackingBroke: 3,
   trackingOk: 4,
   self: 5,
+  revoked: 6,
+  expired: 7,
 }
 
 export const TlfKeysTLFIdentifyBehavior = {
@@ -3749,6 +3751,8 @@ export type SaltpackSenderType =
   | 3 // TRACKING_BROKE_3
   | 4 // TRACKING_OK_4
   | 5 // SELF_5
+  | 6 // REVOKED_6
+  | 7 // EXPIRED_7
 
 export type SaltpackSignOptions = {
   detached: boolean,
@@ -4941,6 +4945,11 @@ export type saltpackUiSaltpackPromptForDecryptRpcParam = Exact<{
   usedDelegateUI: boolean
 }>
 
+export type saltpackUiSaltpackVerifyBadSenderRpcParam = Exact<{
+  signingKID: KID,
+  sender: SaltpackSender
+}>
+
 export type saltpackUiSaltpackVerifySuccessRpcParam = Exact<{
   signingKID: KID,
   sender: SaltpackSender
@@ -6119,6 +6128,14 @@ export type incomingCallMapType = Exact<{
     response: CommonResponseHandler
   ) => void,
   'keybase.1.saltpackUi.saltpackVerifySuccess'?: (
+    params: Exact<{
+      sessionID: int,
+      signingKID: KID,
+      sender: SaltpackSender
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.saltpackUi.saltpackVerifyBadSender'?: (
     params: Exact<{
       sessionID: int,
       signingKID: KID,


### PR DESCRIPTION
There's also a security fix here. Previously we were taking the server's
word that the user reported by key/basics.json actually owned the key we
were asking about. Now we check it ourselves. The key difference is that
now we get all of our final results from LoadUser, which walks the
sigchain and checks the Merkle tree, and which might in some distant
future cross-check the Merkle tree against the blockchain.

This will have to go in after https://github.com/keybase/keybase/pull/1100, and the tests will fail until that one lands too.

r? @maxtaco @patrickxb 