### PR TITLE
Avoid crashing on failed Chat attachment uploads

### DIFF
--- a/go/service/chat_asset.go
+++ b/go/service/chat_asset.go
@@ -80,7 +80,10 @@ func (f *fileSource) Open(sessionID int, cli *keybase1.StreamUiClient) (chat.Rea
 }
 
 func (f *fileSource) Close() error {
-	return f.buf.Close()
+	if f.buf != nil {
+	  return f.buf.Close()
+	}
+	return nil
 }
 
 type fileReadResetter struct {
@@ -122,5 +125,8 @@ func (f *fileReadResetter) Reset() error {
 
 func (f *fileReadResetter) Close() error {
 	f.buf = nil
-	return f.file.Close()
+	if f.file != nil {
+		return f.file.Close()
+	}
+	return nil
 }


### PR DESCRIPTION
r? @patrickxb 

Without this change, starting a Chat attachment upload with the network down leads to:
```
2017-01-05T14:56:38.944254 ▶ [DEBU keybase gregor.go:223] 2cccb push handler: should retry: name chat.1.remote.getS3Params, err context deadline exceeded (returning false)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x782572]

goroutine 121208 [running]:
panic(0x1006140, 0xc420012190)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/keybase/client/go/service.(*fileReadResetter).Close(0x0, 0x453bf0, 0xc4271f87d0)
        /root/build/gopaths/amd64/src/github.com/keybase/client/go/service/chat_asset.go:124 +0x22
github.com/keybase/client/go/service.(*fileSource).Close(0xc428b945a0, 0x0, 0x0)
        /root/build/gopaths/amd64/src/github.com/keybase/client/go/service/chat_asset.go:83 +0x2f
github.com/keybase/client/go/service.(*chatLocalHandler).PostFileAttachmentLocal(0xc420673680, 0x7f7f9e6e4b08, 0xc4233118c0, 0x91, 0xc421ee4a80, 0x20, 0x20, 0xc425c14510, 0x10, 0x10, ...)
        /root/build/gopaths/amd64/src/github.com/keybase/client/go/service/chat_local.go:741 +0x2e0
github.com/keybase/client/go/protocol/chat1.LocalProtocol.func26(0x7f7f9e6e4b08, 0xc4233118c0, 0xf43bc0, 0xc421ee4a60, 0x1, 0x1, 0x180a140, 0x1876d20)
        /root/build/gopaths/amd64/src/github.com/keybase/client/go/protocol/chat1/local.go:1051 +0xb2
github.com/keybase/client/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc.(*callRequest).Serve(0xc428b94240, 0x180d0c0, 0xc425b29380, 0xc421ee4ac0, 0x12492e0)
        /root/build/gopaths/amd64/src/github.com/keybase/client/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/request.go:76 +0x1f9
github.com/keybase/client/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc.(*receiveHandler).handleReceiveDispatch.func1(0x181ace0, 0xc428b94240, 0xc420673320, 0xc421ee4ac0, 0x12492e0)
        /root/build/gopaths/amd64/src/github.com/keybase/client/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/receiver.go:121 +0x5f
created by github.com/keybase/client/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc.(*receiveHandler).handleReceiveDispatch
        /root/build/gopaths/amd64/src/github.com/keybase/client/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/receiver.go:123 +0x3b3
```