### PR TITLE
if you unmount disable any throttled/debounced functions in flight.

### DIFF
--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -68,6 +68,13 @@ class ConversationList extends Component<void, Props, State> {
     return !shallowEqual(this.props, nextProps) || !shallowEqual(this.state, nextState)
   }
 
+  componentWillUnmount () {
+    // Stop any throttled/debounced functions
+    this._onScroll.cancel()
+    this._recomputeListDebounced.cancel()
+    this._onScrollSettled.cancel()
+  }
+
   componentWillUpdate (nextProps: Props, nextState: State) {
     // If a message has moved from pending to sent, tell the List to discard
     // heights for it (which will re-render it and everything after it)

--- a/shared/reducers/index.js
+++ b/shared/reducers/index.js
@@ -26,23 +26,24 @@ import {List} from 'immutable'
 import {combineReducers} from 'redux'
 import {resetStore} from '../constants/common.js'
 
-let history = List()
-let index = 0
+// Disabling this for now. Causes us to leak all actions in a session
+// let history = List()
+// let index = 0
 
-function timeTravel (state: State, action: any): State {
-  if (action.type !== Constants.timeTravel) {
-    history = history.slice(0, index + 1).push(state)
-    index = history.size - 1
-    return state
-  } else {
-    const {direction} = action.payload
+// function timeTravel (state: State, action: any): State {
+  // if (action.type !== Constants.timeTravel) {
+    // history = history.slice(0, index + 1).push(state)
+    // index = history.size - 1
+    // return state
+  // } else {
+    // const {direction} = action.payload
 
-    if (direction === Constants.timeTravelBack) {
-      return history.get(--index, state)
-    }
-    return history.get(++index, state)
-  }
-}
+    // if (direction === Constants.timeTravelBack) {
+      // return history.get(--index, state)
+    // }
+    // return history.get(++index, state)
+  // }
+// }
 
 const combinedReducer = combineReducers({
   chat,
@@ -72,9 +73,9 @@ if (__DEV__) {
     return (
       devEdit(
         serialize(
-          timeTravel(
+          // timeTravel(
             combinedReducer(state, action),
-            action),
+            // action),
           action),
         action)
     )

--- a/shared/reducers/index.js
+++ b/shared/reducers/index.js
@@ -1,5 +1,5 @@
 // @flow
-import * as Constants from '../constants/dev'
+// import * as Constants from '../constants/dev'
 import chat from './chat'
 import config from './config'
 import dev from './dev'
@@ -22,7 +22,7 @@ import signup from './signup'
 import tracker from './tracker'
 import type {State} from '../constants/reducer'
 import unlockFolders from './unlock-folders'
-import {List} from 'immutable'
+// import {List} from 'immutable'
 import {combineReducers} from 'redux'
 import {resetStore} from '../constants/common.js'
 


### PR DESCRIPTION
Also removing timetravel as we likely don't use it and it leaks all our actions. we can just use reactotron if we really need this (and its only hooked up in native)

@keybase/react-hackers 