### PR TITLE
Add Asset.Metadata, populate with image size if possible

### DIFF
--- a/go/chat/attachment_preview.go
+++ b/go/chat/attachment_preview.go
@@ -9,7 +9,6 @@ import (
 	"image/gif"
 	"image/jpeg"
 	"io"
-	"log"
 
 	"golang.org/x/net/context"
 
@@ -77,9 +76,19 @@ func (b *bufReadResetter) Reset() error {
 	return nil
 }
 
+type PreviewRes struct {
+	Source        *BufferSource
+	ContentType   string
+	BaseWidth     int
+	BaseHeight    int
+	PreviewWidth  int
+	PreviewHeight int
+}
+
 // Preview creates preview assets from src.  It returns an in-memory BufferSource
 // and the content type of the preview asset.
-func Preview(ctx context.Context, src io.Reader, contentType, basename string) (*BufferSource, string, error) {
+// func Preview(ctx context.Context, src io.Reader, contentType, basename string) (*BufferSource, string, error) {
+func Preview(ctx context.Context, src io.Reader, contentType, basename string) (*PreviewRes, error) {
 	switch contentType {
 	case "image/jpeg", "image/png":
 		return previewImage(ctx, src, basename)
@@ -87,15 +96,16 @@ func Preview(ctx context.Context, src io.Reader, contentType, basename string) (
 		return previewGIF(ctx, src, basename)
 	}
 
-	return nil, "", nil
+	return nil, nil
 }
 
 // previewImage will resize a single-frame image into a jpeg.
-func previewImage(ctx context.Context, src io.Reader, basename string) (*BufferSource, string, error) {
+// func previewImage(ctx context.Context, src io.Reader, basename string) (*BufferSource, string, error) {
+func previewImage(ctx context.Context, src io.Reader, basename string) (*PreviewRes, error) {
 	// images.Decode in camlistore correctly handles exif orientation information.
 	img, _, err := images.Decode(src, nil)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	width, height := previewDimensions(img.Bounds())
@@ -104,22 +114,30 @@ func previewImage(ctx context.Context, src io.Reader, basename string) (*BufferS
 	preview := resize.Resize(width, height, img, resize.NearestNeighbor)
 	var buf bytes.Buffer
 	if err := jpeg.Encode(&buf, preview, nil); err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
-	return newBufferSource(&buf, basename), "image/jpeg", nil
+	return &PreviewRes{
+		Source:        newBufferSource(&buf, basename),
+		ContentType:   "image/jpeg",
+		BaseWidth:     img.Bounds().Dx(),
+		BaseHeight:    img.Bounds().Dy(),
+		PreviewWidth:  int(width),
+		PreviewHeight: int(height),
+	}, nil
 }
 
 // previewGIF handles resizing multiple frames in an animated gif.
 // Based on code in https://github.com/dpup/go-scratch/blob/master/gif-resize/gif-resize.go
-func previewGIF(ctx context.Context, src io.Reader, basename string) (*BufferSource, string, error) {
+// func previewGIF(ctx context.Context, src io.Reader, basename string) (*BufferSource, string, error) {
+func previewGIF(ctx context.Context, src io.Reader, basename string) (*PreviewRes, error) {
 	g, err := gif.DecodeAll(src)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	if len(g.Image) == 0 {
-		return nil, "", errors.New("no image frames in GIF")
+		return nil, errors.New("no image frames in GIF")
 	}
 
 	// create a new image based on the first frame to draw
@@ -142,10 +160,17 @@ func previewGIF(ctx context.Context, src io.Reader, basename string) (*BufferSou
 	// encode all the frames into buf
 	var buf bytes.Buffer
 	if err := gif.EncodeAll(&buf, g); err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
-	return newBufferSource(&buf, basename), "image/gif", nil
+	return &PreviewRes{
+		Source:        newBufferSource(&buf, basename),
+		ContentType:   "image/gif",
+		BaseWidth:     origBounds.Dx(),
+		BaseHeight:    origBounds.Dy(),
+		PreviewWidth:  int(width),
+		PreviewHeight: int(height),
+	}, nil
 }
 
 func previewDimensions(origBounds image.Rectangle) (uint, uint) {

--- a/go/chat/attachment_preview.go
+++ b/go/chat/attachment_preview.go
@@ -87,7 +87,6 @@ type PreviewRes struct {
 
 // Preview creates preview assets from src.  It returns an in-memory BufferSource
 // and the content type of the preview asset.
-// func Preview(ctx context.Context, src io.Reader, contentType, basename string) (*BufferSource, string, error) {
 func Preview(ctx context.Context, src io.Reader, contentType, basename string) (*PreviewRes, error) {
 	switch contentType {
 	case "image/jpeg", "image/png":
@@ -100,7 +99,6 @@ func Preview(ctx context.Context, src io.Reader, contentType, basename string) (
 }
 
 // previewImage will resize a single-frame image into a jpeg.
-// func previewImage(ctx context.Context, src io.Reader, basename string) (*BufferSource, string, error) {
 func previewImage(ctx context.Context, src io.Reader, basename string) (*PreviewRes, error) {
 	// images.Decode in camlistore correctly handles exif orientation information.
 	img, _, err := images.Decode(src, nil)
@@ -129,7 +127,6 @@ func previewImage(ctx context.Context, src io.Reader, basename string) (*Preview
 
 // previewGIF handles resizing multiple frames in an animated gif.
 // Based on code in https://github.com/dpup/go-scratch/blob/master/gif-resize/gif-resize.go
-// func previewGIF(ctx context.Context, src io.Reader, basename string) (*BufferSource, string, error) {
 func previewGIF(ctx context.Context, src io.Reader, basename string) (*PreviewRes, error) {
 	g, err := gif.DecodeAll(src)
 	if err != nil {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -45,6 +45,7 @@ type Asset struct {
 	VerifyKey []byte `codec:"verifyKey" json:"verifyKey"`
 	Title     string `codec:"title" json:"title"`
 	Nonce     []byte `codec:"nonce" json:"nonce"`
+	Metadata  string `codec:"metadata" json:"metadata"`
 }
 
 type MessageAttachment struct {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -1022,6 +1022,9 @@ type dimension struct {
 }
 
 func (d *dimension) Encode() string {
+	if d.Width == 0 && d.Height == 0 {
+		return ""
+	}
 	enc, err := json.Marshal(d)
 	if err != nil {
 		return ""
@@ -1076,10 +1079,17 @@ func (h *chatLocalHandler) preprocessAsset(ctx context.Context, sessionID int, a
 		if err != nil {
 			return nil, err
 		}
+		if previewRes == nil {
+			return &p, nil
+		}
 		p.Preview = previewRes.Source
 		p.PreviewContentType = previewRes.ContentType
-		p.BaseDim = &dimension{Width: previewRes.BaseWidth, Height: previewRes.BaseHeight}
-		p.PreviewDim = &dimension{Width: previewRes.PreviewWidth, Height: previewRes.PreviewHeight}
+		if previewRes.BaseWidth > 0 || previewRes.BaseHeight > 0 {
+			p.BaseDim = &dimension{Width: previewRes.BaseWidth, Height: previewRes.BaseHeight}
+		}
+		if previewRes.PreviewWidth > 0 || previewRes.PreviewHeight > 0 {
+			p.PreviewDim = &dimension{Width: previewRes.PreviewWidth, Height: previewRes.PreviewHeight}
+		}
 	}
 
 	return &p, nil

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -1079,16 +1079,15 @@ func (h *chatLocalHandler) preprocessAsset(ctx context.Context, sessionID int, a
 		if err != nil {
 			return nil, err
 		}
-		if previewRes == nil {
-			return &p, nil
-		}
-		p.Preview = previewRes.Source
-		p.PreviewContentType = previewRes.ContentType
-		if previewRes.BaseWidth > 0 || previewRes.BaseHeight > 0 {
-			p.BaseDim = &dimension{Width: previewRes.BaseWidth, Height: previewRes.BaseHeight}
-		}
-		if previewRes.PreviewWidth > 0 || previewRes.PreviewHeight > 0 {
-			p.PreviewDim = &dimension{Width: previewRes.PreviewWidth, Height: previewRes.PreviewHeight}
+		if previewRes != nil {
+			p.Preview = previewRes.Source
+			p.PreviewContentType = previewRes.ContentType
+			if previewRes.BaseWidth > 0 || previewRes.BaseHeight > 0 {
+				p.BaseDim = &dimension{Width: previewRes.BaseWidth, Height: previewRes.BaseHeight}
+			}
+			if previewRes.PreviewWidth > 0 || previewRes.PreviewHeight > 0 {
+				p.PreviewDim = &dimension{Width: previewRes.PreviewWidth, Height: previewRes.PreviewHeight}
+			}
 		}
 	}
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -39,6 +39,7 @@ protocol local {
     bytes verifyKey;           // signature verification key
     string title;              // title of the asset (defaults to filename if not provided)
     bytes nonce;               // encryption nonce
+    string metadata;           // json-encoded metadata
   }
 
   record MessageAttachment {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -488,6 +488,7 @@ export type Asset = {
   verifyKey: bytes,
   title: string,
   nonce: bytes,
+  metadata: string,
 }
 
 export type BodyPlaintext = 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -125,6 +125,10 @@
         {
           "type": "bytes",
           "name": "nonce"
+        },
+        {
+          "type": "string",
+          "name": "metadata"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -488,6 +488,7 @@ export type Asset = {
   verifyKey: bytes,
   title: string,
   nonce: bytes,
+  metadata: string,
 }
 
 export type BodyPlaintext = 


### PR DESCRIPTION
Adds metadata field to the Asset struct.

If the asset is processed and a preview is generated, then the metadata field is populated with width, height. for the base asset and the preview asset.

cc @chrisnojima 