### PR TITLE
Use preview metadata for sizing attachment messages

### DIFF
--- a/go/chat/attachment_preview.go
+++ b/go/chat/attachment_preview.go
@@ -9,7 +9,6 @@ import (
 	"image/gif"
 	"image/jpeg"
 	"io"
-	"log"
 
 	"golang.org/x/net/context"
 
@@ -77,9 +76,19 @@ func (b *bufReadResetter) Reset() error {
 	return nil
 }
 
+type PreviewRes struct {
+	Source        *BufferSource
+	ContentType   string
+	BaseWidth     int
+	BaseHeight    int
+	PreviewWidth  int
+	PreviewHeight int
+}
+
 // Preview creates preview assets from src.  It returns an in-memory BufferSource
 // and the content type of the preview asset.
-func Preview(ctx context.Context, src io.Reader, contentType, basename string) (*BufferSource, string, error) {
+// func Preview(ctx context.Context, src io.Reader, contentType, basename string) (*BufferSource, string, error) {
+func Preview(ctx context.Context, src io.Reader, contentType, basename string) (*PreviewRes, error) {
 	switch contentType {
 	case "image/jpeg", "image/png":
 		return previewImage(ctx, src, basename)
@@ -87,15 +96,16 @@ func Preview(ctx context.Context, src io.Reader, contentType, basename string) (
 		return previewGIF(ctx, src, basename)
 	}
 
-	return nil, "", nil
+	return nil, nil
 }
 
 // previewImage will resize a single-frame image into a jpeg.
-func previewImage(ctx context.Context, src io.Reader, basename string) (*BufferSource, string, error) {
+// func previewImage(ctx context.Context, src io.Reader, basename string) (*BufferSource, string, error) {
+func previewImage(ctx context.Context, src io.Reader, basename string) (*PreviewRes, error) {
 	// images.Decode in camlistore correctly handles exif orientation information.
 	img, _, err := images.Decode(src, nil)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	width, height := previewDimensions(img.Bounds())
@@ -104,22 +114,30 @@ func previewImage(ctx context.Context, src io.Reader, basename string) (*BufferS
 	preview := resize.Resize(width, height, img, resize.NearestNeighbor)
 	var buf bytes.Buffer
 	if err := jpeg.Encode(&buf, preview, nil); err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
-	return newBufferSource(&buf, basename), "image/jpeg", nil
+	return &PreviewRes{
+		Source:        newBufferSource(&buf, basename),
+		ContentType:   "image/jpeg",
+		BaseWidth:     img.Bounds().Dx(),
+		BaseHeight:    img.Bounds().Dy(),
+		PreviewWidth:  int(width),
+		PreviewHeight: int(height),
+	}, nil
 }
 
 // previewGIF handles resizing multiple frames in an animated gif.
 // Based on code in https://github.com/dpup/go-scratch/blob/master/gif-resize/gif-resize.go
-func previewGIF(ctx context.Context, src io.Reader, basename string) (*BufferSource, string, error) {
+// func previewGIF(ctx context.Context, src io.Reader, basename string) (*BufferSource, string, error) {
+func previewGIF(ctx context.Context, src io.Reader, basename string) (*PreviewRes, error) {
 	g, err := gif.DecodeAll(src)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	if len(g.Image) == 0 {
-		return nil, "", errors.New("no image frames in GIF")
+		return nil, errors.New("no image frames in GIF")
 	}
 
 	// create a new image based on the first frame to draw
@@ -142,10 +160,17 @@ func previewGIF(ctx context.Context, src io.Reader, basename string) (*BufferSou
 	// encode all the frames into buf
 	var buf bytes.Buffer
 	if err := gif.EncodeAll(&buf, g); err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
-	return newBufferSource(&buf, basename), "image/gif", nil
+	return &PreviewRes{
+		Source:        newBufferSource(&buf, basename),
+		ContentType:   "image/gif",
+		BaseWidth:     origBounds.Dx(),
+		BaseHeight:    origBounds.Dy(),
+		PreviewWidth:  int(width),
+		PreviewHeight: int(height),
+	}, nil
 }
 
 func previewDimensions(origBounds image.Rectangle) (uint, uint) {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -45,6 +45,7 @@ type Asset struct {
 	VerifyKey []byte `codec:"verifyKey" json:"verifyKey"`
 	Title     string `codec:"title" json:"title"`
 	Nonce     []byte `codec:"nonce" json:"nonce"`
+	Metadata  string `codec:"metadata" json:"metadata"`
 }
 
 type MessageAttachment struct {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -4,6 +4,7 @@
 package service
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -826,8 +827,10 @@ func (h *chatLocalHandler) postAttachmentLocal(ctx context.Context, arg postAtta
 	if preview != nil {
 		preview.Title = arg.Title
 		preview.MimeType = pre.PreviewContentType
+		preview.Metadata = pre.PreviewMetadata()
 	}
 	object.MimeType = pre.ContentType
+	object.Metadata = pre.BaseMetadata()
 
 	// send an attachment message
 	attachment := chat1.MessageAttachment{
@@ -1013,10 +1016,42 @@ func (h *chatLocalHandler) Sign(payload []byte) ([]byte, error) {
 	return h.remoteClient().S3Sign(context.Background(), arg)
 }
 
+type dimension struct {
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+func (d *dimension) Encode() string {
+	if d.Width == 0 && d.Height == 0 {
+		return ""
+	}
+	enc, err := json.Marshal(d)
+	if err != nil {
+		return ""
+	}
+	return string(enc)
+}
+
 type preprocess struct {
 	ContentType        string
 	Preview            *chat.BufferSource
 	PreviewContentType string
+	BaseDim            *dimension
+	PreviewDim         *dimension
+}
+
+func (p *preprocess) BaseMetadata() string {
+	if p.BaseDim == nil {
+		return ""
+	}
+	return p.BaseDim.Encode()
+}
+
+func (p *preprocess) PreviewMetadata() string {
+	if p.PreviewDim == nil {
+		return ""
+	}
+	return p.PreviewDim.Encode()
 }
 
 func (h *chatLocalHandler) preprocessAsset(ctx context.Context, sessionID int, attachment, preview assetSource) (*preprocess, error) {
@@ -1040,9 +1075,20 @@ func (h *chatLocalHandler) preprocessAsset(ctx context.Context, sessionID int, a
 
 	if preview == nil {
 		src.Reset()
-		p.Preview, p.PreviewContentType, err = chat.Preview(ctx, src, p.ContentType, attachment.Basename())
+		previewRes, err := chat.Preview(ctx, src, p.ContentType, attachment.Basename())
 		if err != nil {
 			return nil, err
+		}
+		if previewRes == nil {
+			return &p, nil
+		}
+		p.Preview = previewRes.Source
+		p.PreviewContentType = previewRes.ContentType
+		if previewRes.BaseWidth > 0 || previewRes.BaseHeight > 0 {
+			p.BaseDim = &dimension{Width: previewRes.BaseWidth, Height: previewRes.BaseHeight}
+		}
+		if previewRes.PreviewWidth > 0 || previewRes.PreviewHeight > 0 {
+			p.PreviewDim = &dimension{Width: previewRes.PreviewWidth, Height: previewRes.PreviewHeight}
 		}
 	}
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -39,6 +39,7 @@ protocol local {
     bytes verifyKey;           // signature verification key
     string title;              // title of the asset (defaults to filename if not provided)
     bytes nonce;               // encryption nonce
+    string metadata;           // json-encoded metadata
   }
 
   record MessageAttachment {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -488,6 +488,7 @@ export type Asset = {
   verifyKey: bytes,
   title: string,
   nonce: bytes,
+  metadata: string,
 }
 
 export type BodyPlaintext = 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -125,6 +125,10 @@
         {
           "type": "bytes",
           "name": "nonce"
+        },
+        {
+          "type": "string",
+          "name": "metadata"
         }
       ]
     },

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -677,6 +677,14 @@ function _unboxedToMessage (message: MessageUnboxed, idx: number, yourName, conv
           // $FlowIssue
           const preview = payload.messageBody.attachment.preview
           const mimeType = preview && preview.mimeType
+          let previewMetadata = {}
+          if (preview && preview.metadata) {
+            try {
+              previewMetadata = JSON.parse(preview.metadata)
+            } catch (err) {
+              console.warn('Error parsing preview metadata:', err)
+            }
+          }
 
           return {
             type: 'Attachment',
@@ -688,6 +696,7 @@ function _unboxedToMessage (message: MessageUnboxed, idx: number, yourName, conv
             title: payload.messageBody.attachment.object.title,
             previewType: mimeType && mimeType.indexOf('image') === 0 ? 'Image' : 'Other',
             previewPath: null,
+            previewSize: {width: previewMetadata.width, height: previewMetadata.height},
             downloadedPath: null,
             key: common.messageID,
           }

--- a/shared/chat/conversation/messages/attachment.desktop.js
+++ b/shared/chat/conversation/messages/attachment.desktop.js
@@ -46,7 +46,9 @@ class _AttachmentMessage extends PureComponent<void, Props & {onIconClick: (even
                   <Text type='Body' style={{marginTop: globalMargins.xtiny, flex: 1}} onClick={() => onOpenInFileUI(downloadedPath)}>
                     Show downloaded file.
                   </Text>}
-                {!!message.previewPath && message.previewType === 'Image' && <Box style={{marginTop: globalMargins.xtiny, flex: 1}} onClick={onOpenInPopup}><img src={message.previewPath} /></Box>}
+                {!!message.previewPath && message.previewType === 'Image' && <Box style={{marginTop: globalMargins.xtiny, flex: 1}} onClick={onOpenInPopup}>
+                  <img src={message.previewPath} style={{width: message.previewSize.width, height: message.previewSize.height}} />
+                </Box>}
                 <div className='action-button'>
                   <Icon type='iconfont-ellipsis' style={{marginLeft: globalMargins.tiny, marginRight: globalMargins.tiny}} onClick={onIconClick} />
                 </div>

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -63,6 +63,11 @@ export type UnhandledMessage = {
   key: any,
 }
 
+type AttachmentSize = {
+  width: ?number,
+  height: ?number,
+}
+
 export type AttachmentMessage = {
   type: 'Attachment',
   timestamp: number,
@@ -76,6 +81,7 @@ export type AttachmentMessage = {
   title: string,
   previewType: ?('Image' | 'Other'),
   previewPath: ?string,
+  previewSize: AttachmentSize,
   downloadedPath: ?string,
   key: any,
 }

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -488,6 +488,7 @@ export type Asset = {
   verifyKey: bytes,
   title: string,
   nonce: bytes,
+  metadata: string,
 }
 
 export type BodyPlaintext = 


### PR DESCRIPTION
This should be on top of https://github.com/keybase/client/pull/5291, but the included merge commit causes GitHub's commit list to be deceptively long if I base of Patrick's branch.

:eyeglasses: @keybase/react-hackers 