### PR TITLE
Move renderer.html js into its own .js file

### DIFF
--- a/shared/.eslintignore
+++ b/shared/.eslintignore
@@ -6,6 +6,7 @@
 /desktop/build/**
 /desktop/dist/**
 /desktop/release/**
+/desktop/renderer/renderer-load.js
 /flow-typed/**
 /libs/flow-interface.js
 /libs/immutable-interface.js

--- a/shared/desktop/package.js
+++ b/shared/desktop/package.js
@@ -64,6 +64,7 @@ function main () {
   fs.removeSync(desktopPath('build/images/folders'))
   fs.removeSync(desktopPath('build/images/iconfont'))
   copySync('renderer', 'build/desktop/renderer', filterAllowOnlyTypes('html'))
+  copySync('renderer/renderer-load.js', 'build/desktop/renderer/renderer-load.js')
   fs.removeSync(desktopPath('build/desktop/renderer/fonts'))
 
   fs.writeJsonSync(desktopPath('build/package.json'), {

--- a/shared/desktop/renderer/renderer-load.js
+++ b/shared/desktop/renderer/renderer-load.js
@@ -1,0 +1,15 @@
+require('electron').ipcRenderer.once('load', (event, options) => {
+  document.title = options.title || document.title
+  options.scripts.map(({src, async, defer}) => {
+    const script = document.createElement('script')
+    if (src == null) {
+      throw new Error('No src for script. Nothing to load')
+    }
+    script.src = src
+    async != null && (script.async = async)
+    defer != null && (script.defer = defer)
+    script.onload = () => window.load && window.load(options)
+    script.onerror = e => console.warn('error loading initial scripts:', e)
+    document.head.appendChild(script)
+  })
+})

--- a/shared/desktop/renderer/renderer.html
+++ b/shared/desktop/renderer/renderer.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <!-- The sha here is for the inline script below -->
-    <meta charset="utf-8" http-equiv="Content-Security-Policy" content="default-src file: filesystem: http://localhost:4000 https://keybase.io/; img-src data: http://localhost:4000 https://keybase.io/ https://pbs.twimg.com/ https://avatars.githubusercontent.com/ https://images.coinbase.com/ https://s3.amazonaws.com/keybase_processed_uploads/ file:; style-src 'unsafe-inline'; script-src file: http://localhost:4000 chrome-extension://react-developer-tools 'unsafe-eval'"/>
+    <meta charset="utf-8" http-equiv="Content-Security-Policy" content="default-src file: filesystem: http://localhost:4000 https://keybase.io/; img-src data: http://localhost:4000 https://keybase.io/ https://pbs.twimg.com/ https://avatars.githubusercontent.com/ https://images.coinbase.com/ https://s3.amazonaws.com/keybase_processed_uploads/ file:; style-src 'unsafe-inline'; script-src file: http://localhost:4000 chrome-extension://react-developer-tools 'unsafe-eval'" />
     <title>Keybase</title>
   </head>
   <body>
     <div id="root">
-      <div title="loading..." style="flex: 1;background-color: #f5f5f5"/>
+      <div title="loading..." style="flex: 1;background-color: #f5f5f5" />
     </div>
     <script src="renderer-load.js"></script>
   </body>

--- a/shared/desktop/renderer/renderer.html
+++ b/shared/desktop/renderer/renderer.html
@@ -2,29 +2,13 @@
 <html>
   <head>
     <!-- The sha here is for the inline script below -->
-    <meta charset="utf-8" http-equiv="Content-Security-Policy" content="default-src file: filesystem: http://localhost:4000 https://keybase.io/; img-src data: http://localhost:4000 https://keybase.io/ https://pbs.twimg.com/ https://avatars.githubusercontent.com/ https://images.coinbase.com/ https://s3.amazonaws.com/keybase_processed_uploads/ file:; style-src 'unsafe-inline'; script-src file: http://localhost:4000 chrome-extension://react-developer-tools 'unsafe-eval' 'sha256-akuE+JRql7/9raAmKPMveeChrxKqtL83YJAn8sLzrLA='"/>
+    <meta charset="utf-8" http-equiv="Content-Security-Policy" content="default-src file: filesystem: http://localhost:4000 https://keybase.io/; img-src data: http://localhost:4000 https://keybase.io/ https://pbs.twimg.com/ https://avatars.githubusercontent.com/ https://images.coinbase.com/ https://s3.amazonaws.com/keybase_processed_uploads/ file:; style-src 'unsafe-inline'; script-src file: http://localhost:4000 chrome-extension://react-developer-tools 'unsafe-eval'"/>
     <title>Keybase</title>
   </head>
   <body>
     <div id="root">
-      <div title="loading..." style="flex: 1;background-color: #f5f5f5">
+      <div title="loading..." style="flex: 1;background-color: #f5f5f5"/>
     </div>
-    <script>
-      require('electron').ipcRenderer.once('load', (event, options) => {
-        document.title = options.title || document.title
-        options.scripts.map(({src, async, defer}) => {
-          const script = document.createElement('script')
-          if (src == null) {
-            throw new Error('No src for script. Nothing to load')
-          }
-          script.src = src
-          async != null && (script.async = async)
-          defer != null && (script.defer = defer)
-          script.onload = () => window.load && window.load(options)
-          script.onerror = e => console.warn('error loading initial scripts:', e)
-          document.head.appendChild(script)
-        })
-      })
-    </script>
+    <script src="renderer-load.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Now that we have csp its kinda a pain to iterate on the script to boot everything up. Instead let's pull that out into its own file.

@keybase/react-hackers 