### PR TITLE
Footer row for padding

### DIFF
--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -12,7 +12,7 @@ import _ from 'lodash'
 import messageFactory from './messages'
 import shallowEqual from 'shallowequal'
 import {AutoSizer, CellMeasurer, List as VirtualizedList, defaultCellMeasurerCellSizeCache} from 'react-virtualized'
-import {ProgressIndicator} from '../../common-adapters'
+import {Box, ProgressIndicator} from '../../common-adapters'
 import {globalColors, globalStyles} from '../../styles'
 
 import type {List} from 'immutable'
@@ -50,9 +50,12 @@ class ConversationList extends Component<void, Props, State> {
   }
 
   _indexToID = index => {
-    // loader message
     if (index === 0) {
+      // loader
       return 0
+    } else if (index == this.state.messages.count() + 1) {
+      // footer
+      return -1
     } else {
       // minus one because loader message is there
       const messageIndex = index - 1
@@ -154,7 +157,8 @@ class ConversationList extends Component<void, Props, State> {
       this.props.onLoadMoreMessages()
     }
 
-    const isLockedToBottom = scrollTop + clientHeight === scrollHeight
+    // Lock to bottom if we are close to the bottom
+    const isLockedToBottom = scrollTop + clientHeight >= scrollHeight - 20
     this.setState({
       isLockedToBottom,
       isScrolling: true,
@@ -201,6 +205,9 @@ class ConversationList extends Component<void, Props, State> {
     if (index === 0) {
       return <LoadingMore style={style} key={key || index} hasMoreItems={this.props.moreToLoad} />
     }
+    if (index === this.state.messages.count() + 1) {
+      return <Box key={'footer'} style={{height: 20}} />
+    }
 
     const message = this.state.messages.get(index - 1)
     const prevMessage = this.state.messages.get(index - 2)
@@ -231,9 +238,8 @@ class ConversationList extends Component<void, Props, State> {
         </div>
       )
     }
-    const messageCount = this.state.messages.count()
-    const countWithLoading = messageCount + 1 // Loading row on top always
-    let scrollToIndex = this.state.isLockedToBottom ? countWithLoading - 1 : undefined
+    const rowCount = this.state.messages.count() + 2 // Loading row on top always and footer row
+    let scrollToIndex = this.state.isLockedToBottom ? rowCount - 1 : undefined
     let scrollTop = scrollToIndex ? undefined : this.state.scrollTop
 
     // We need to use both visibility and opacity css properties for the
@@ -276,7 +282,7 @@ class ConversationList extends Component<void, Props, State> {
               columnCount={1}
               ref={r => { this._cellMeasurer = r }}
               cellSizeCache={this._cellCache}
-              rowCount={countWithLoading}
+              rowCount={rowCount}
               width={width} >
               {({getRowHeight}) => {
                 return <VirtualizedList
@@ -287,7 +293,7 @@ class ConversationList extends Component<void, Props, State> {
                   onScroll={this._onScroll}
                   scrollTop={scrollTop}
                   scrollToIndex={scrollToIndex}
-                  rowCount={countWithLoading}
+                  rowCount={rowCount}
                   rowHeight={getRowHeight}
                   columnWidth={width}
                   rowRenderer={this._rowRenderer} />

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -53,7 +53,7 @@ class ConversationList extends Component<void, Props, State> {
     if (index === 0) {
       // loader
       return 0
-    } else if (index == this.state.messages.count() + 1) {
+    } else if (index === this.state.messages.count() + 1) {
       // footer
       return -1
     } else {


### PR DESCRIPTION
Adds padding by including a "footer" cell. Plays nicely with locking to bottom and other scroll logic.

I originally tried to do this by adding css padding the virtualized list inner container but it didn't play well with scroll logic. See https://github.com/keybase/client/pull/5253.

I also slightly relaxed lock to bottom to be `>= scrollHeight - 20` instead of `===`, so you don't have to be exactly at bottom.

![2017-01-06 at 1 42 pm](https://cloud.githubusercontent.com/assets/2669/21734002/11b0690c-d416-11e6-8d37-2f89d154c375.png)
