### PR TITLE
disconnect the entire gregor connection if the ping call times out CORE-4329

### DIFF
--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -136,6 +136,13 @@ func (p CommandLine) GetGregorPingInterval() (time.Duration, bool) {
 	}
 	return ret, true
 }
+func (p CommandLine) GetGregorPingTimeout() (time.Duration, bool) {
+	ret, err := p.GetGDuration("push-ping-timeout")
+	if err != nil {
+		return 0, false
+	}
+	return ret, true
+}
 
 func (p CommandLine) GetChatDelivererInterval() (time.Duration, bool) {
 	ret, err := p.GetGDuration("chat-deliverer-interval")

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -500,6 +500,10 @@ func (f JSONConfigFile) GetGregorPingInterval() (time.Duration, bool) {
 	return f.GetDurationAtPath("push.ping_interval")
 }
 
+func (f JSONConfigFile) GetGregorPingTimeout() (time.Duration, bool) {
+	return f.GetDurationAtPath("push.ping_timeout")
+}
+
 func (f JSONConfigFile) GetChatDelivererInterval() (time.Duration, bool) {
 	return f.GetDurationAtPath("chat.deliverer_interval")
 }

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -73,6 +73,7 @@ func (n NullConfiguration) GetLocalTrackMaxAge() (time.Duration, bool)      { re
 func (n NullConfiguration) GetGregorURI() string                            { return "" }
 func (n NullConfiguration) GetGregorSaveInterval() (time.Duration, bool)    { return 0, false }
 func (n NullConfiguration) GetGregorPingInterval() (time.Duration, bool)    { return 0, false }
+func (n NullConfiguration) GetGregorPingTimeout() (time.Duration, bool)     { return 0, false }
 func (n NullConfiguration) GetChatDelivererInterval() (time.Duration, bool) { return 0, false }
 func (n NullConfiguration) IsAdmin() (bool, bool)                           { return false, false }
 func (n NullConfiguration) GetGregorDisabled() (bool, bool)                 { return false, false }
@@ -597,6 +598,14 @@ func (e *Env) GetGregorPingInterval() time.Duration {
 		func() (time.Duration, bool) { return e.getEnvDuration("KEYBASE_PUSH_PING_INTERVAL") },
 		func() (time.Duration, bool) { return e.config.GetGregorPingInterval() },
 		func() (time.Duration, bool) { return e.cmd.GetGregorPingInterval() },
+	)
+}
+
+func (e *Env) GetGregorPingTimeout() time.Duration {
+	return e.GetDuration(5*time.Second,
+		func() (time.Duration, bool) { return e.getEnvDuration("KEYBASE_PUSH_PING_TIMEOUT") },
+		func() (time.Duration, bool) { return e.config.GetGregorPingTimeout() },
+		func() (time.Duration, bool) { return e.cmd.GetGregorPingTimeout() },
 	)
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -42,6 +42,7 @@ type configGetter interface {
 	GetGregorDisabled() (bool, bool)
 	GetBGIdentifierDisabled() (bool, bool)
 	GetGregorPingInterval() (time.Duration, bool)
+	GetGregorPingTimeout() (time.Duration, bool)
 	GetGregorSaveInterval() (time.Duration, bool)
 	GetGregorURI() string
 	GetHome() string

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -104,6 +104,7 @@ type gregorHandler struct {
 	// This mutex protects the con object
 	connMutex sync.Mutex
 	conn      *rpc.Connection
+	uri       *rpc.FMPURI
 
 	cli              rpc.GenericClient
 	sessionID        gregor1.SessionID
@@ -223,15 +224,15 @@ func (g *gregorHandler) getRPCCli() rpc.GenericClient {
 }
 
 func (g *gregorHandler) Debug(s string, args ...interface{}) {
-	g.G().Log.Debug("push handler: "+s, args...)
+	g.G().Log.Debug("PushHandler: "+s, args...)
 }
 
 func (g *gregorHandler) Warning(s string, args ...interface{}) {
-	g.G().Log.Warning("push handler: "+s, args...)
+	g.G().Log.Warning("PushHandler: "+s, args...)
 }
 
 func (g *gregorHandler) Errorf(s string, args ...interface{}) {
-	g.G().Log.Errorf("push handler: "+s, args...)
+	g.G().Log.Errorf("PushHandler: "+s, args...)
 }
 
 func (g *gregorHandler) SetPushStateFilter(f func(m gregor.Message) bool) {
@@ -252,10 +253,11 @@ func (g *gregorHandler) Connect(uri *rpc.FMPURI) (err error) {
 	// set up this channel.
 	g.shutdownCh = make(chan struct{})
 
+	g.uri = uri
 	if uri.UseTLS() {
-		err = g.connectTLS(uri)
+		err = g.connectTLS()
 	} else {
-		err = g.connectNoTLS(uri)
+		err = g.connectNoTLS()
 	}
 
 	return err
@@ -1169,21 +1171,46 @@ func (g *gregorHandler) auth(ctx context.Context, cli rpc.GenericClient) (err er
 }
 
 func (g *gregorHandler) pingLoop() {
+
+	duration := g.G().Env.GetGregorPingInterval()
+	timeout := g.G().Env.GetGregorPingTimeout()
+	g.Debug("ping loop: starting up: duration: %v timeout: %v", duration, timeout)
+	defer g.Debug("ping loop: terminating")
+
 	for {
 		select {
-		case <-g.G().Clock().After(g.G().Env.GetGregorPingInterval()):
-			_, err := gregor1.IncomingClient{Cli: g.cli}.Ping(context.Background())
-			if err != nil {
-				g.Warning("error in ping loop: %s", err)
+		case <-g.G().Clock().After(duration):
+
+			if !g.IsConnected() {
+				g.Debug("ping loop: skipping ping since not connected")
+				continue
 			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			_, err := gregor1.IncomingClient{Cli: g.cli}.Ping(ctx)
+			if err != nil {
+				if err == ErrGregorTimeout {
+					cancel()
+					g.Debug("ping loop: timeout: terminating connection")
+					g.Shutdown()
+
+					if err := g.Connect(g.uri); err != nil {
+						g.Debug("ping loop: error connecting: %s", err.Error())
+					}
+
+					return
+				}
+			}
+
 		case <-g.shutdownCh:
 			return
 		}
 	}
+
 }
 
-func (g *gregorHandler) connectTLS(uri *rpc.FMPURI) error {
-
+func (g *gregorHandler) connectTLS() error {
+	uri := g.uri
 	g.Debug("connecting to gregord via TLS at %s", uri)
 	rawCA := g.G().Env.GetBundledCA(uri.Host)
 	if len(rawCA) == 0 {
@@ -1209,8 +1236,8 @@ func (g *gregorHandler) connectTLS(uri *rpc.FMPURI) error {
 	return nil
 }
 
-func (g *gregorHandler) connectNoTLS(uri *rpc.FMPURI) error {
-
+func (g *gregorHandler) connectNoTLS() error {
+	uri := g.uri
 	g.Debug("connecting to gregord without TLS at %s", uri)
 	t := newConnTransport(g.G(), uri.HostPort)
 	g.transportForTesting = t
@@ -1391,9 +1418,12 @@ type timeoutClient struct {
 var _ rpc.GenericClient = (*timeoutClient)(nil)
 
 func (t *timeoutClient) Call(ctx context.Context, method string, arg interface{}, res interface{}) error {
-	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, t.timeout)
-	defer timeoutCancel()
-	err := t.inner.Call(timeoutCtx, method, arg, res)
+	var timeoutCancel context.CancelFunc
+	if _, ok := ctx.Deadline(); !ok {
+		ctx, timeoutCancel = context.WithTimeout(ctx, t.timeout)
+		defer timeoutCancel()
+	}
+	err := t.inner.Call(ctx, method, arg, res)
 	if err == context.DeadlineExceeded {
 		return t.timeoutErr
 	}
@@ -1401,9 +1431,12 @@ func (t *timeoutClient) Call(ctx context.Context, method string, arg interface{}
 }
 
 func (t *timeoutClient) Notify(ctx context.Context, method string, arg interface{}) error {
-	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, t.timeout)
-	defer timeoutCancel()
-	err := t.inner.Notify(timeoutCtx, method, arg)
+	var timeoutCancel context.CancelFunc
+	if _, ok := ctx.Deadline(); !ok {
+		ctx, timeoutCancel = context.WithTimeout(ctx, t.timeout)
+		defer timeoutCancel()
+	}
+	err := t.inner.Notify(ctx, method, arg)
 	if err == context.DeadlineExceeded {
 		return t.timeoutErr
 	}

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1419,10 +1419,8 @@ var _ rpc.GenericClient = (*timeoutClient)(nil)
 
 func (t *timeoutClient) Call(ctx context.Context, method string, arg interface{}, res interface{}) error {
 	var timeoutCancel context.CancelFunc
-	if _, ok := ctx.Deadline(); !ok {
-		ctx, timeoutCancel = context.WithTimeout(ctx, t.timeout)
-		defer timeoutCancel()
-	}
+	ctx, timeoutCancel = context.WithTimeout(ctx, t.timeout)
+	defer timeoutCancel()
 	err := t.inner.Call(ctx, method, arg, res)
 	if err == context.DeadlineExceeded {
 		return t.timeoutErr
@@ -1432,10 +1430,8 @@ func (t *timeoutClient) Call(ctx context.Context, method string, arg interface{}
 
 func (t *timeoutClient) Notify(ctx context.Context, method string, arg interface{}) error {
 	var timeoutCancel context.CancelFunc
-	if _, ok := ctx.Deadline(); !ok {
-		ctx, timeoutCancel = context.WithTimeout(ctx, t.timeout)
-		defer timeoutCancel()
-	}
+	ctx, timeoutCancel = context.WithTimeout(ctx, t.timeout)
+	defer timeoutCancel()
 	err := t.inner.Notify(ctx, method, arg)
 	if err == context.DeadlineExceeded {
 		return t.timeoutErr

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1188,9 +1188,9 @@ func (g *gregorHandler) pingLoop() {
 
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			_, err := gregor1.IncomingClient{Cli: g.cli}.Ping(ctx)
+			cancel()
 			if err != nil {
 				if err == ErrGregorTimeout {
-					cancel()
 					g.Debug("ping loop: timeout: terminating connection")
 					g.Shutdown()
 


### PR DESCRIPTION
The basic idea here is to use a deadline context on the `Ping` RPC in the ping loop that is fairly aggressive (and configurable). If we hit that deadline, then we terminate the current connection and make a new one (instead of relying on anything in the RPC library). We are also careful the ping loop doesn't spawn two of these connections somehow.

This means the max time to disconnect is now 15 seconds (with default params), which I think is reasonable.

cc @cjb 