### PR TITLE
Prevent disruptive navigation after reconnect bootstrap

### DIFF
--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -148,7 +148,8 @@ export function retryBootstrap (): AsyncAction {
 }
 
 let bootstrapSetup = false
-export function bootstrap (): AsyncAction {
+type BootstrapOptions = {isReconnect?: boolean}
+export function bootstrap (opts?: BootstrapOptions = {}): AsyncAction {
   return (dispatch, getState) => {
     if (!bootstrapSetup) {
       bootstrapSetup = true
@@ -167,8 +168,10 @@ export function bootstrap (): AsyncAction {
           }
           dispatch({type: Constants.bootstrapped, payload: null})
           dispatch(listenForKBFSNotifications())
-          dispatch(navBasedOnLoginState())
-          dispatch((resetSignup(): Action))
+          if (!opts.isReconnect) {
+            dispatch(navBasedOnLoginState())
+            dispatch((resetSignup(): Action))
+          }
           dispatch(registerListeners())
         }).catch(error => {
           console.warn('[bootstrap] error bootstrapping: ', error)

--- a/shared/actions/gregor.js
+++ b/shared/actions/gregor.js
@@ -67,7 +67,7 @@ function registerReachability () {
         // TODO: We should be able to recover from connection problems
         // without re-bootstrapping. Originally we used to do this on HTML5
         // 'online' event, but reachability is more precise.
-        dispatch(bootstrap())
+        dispatch(bootstrap({isReconnect: true}))
       }
     })
 


### PR DESCRIPTION
When the app disconnects and reconnects, we currently fire off a bootstrap. This will navigate to the default tab when it completes -- so if you were in a chat when you got disconnected, you'll get pushed to the devices tab. We should revisit the TODO about whether bootstrap is necessary in this case, but in the mean time this tweak makes the behavior less disruptive.

:eyeglasses: @keybase/react-hackers 