### PR TITLE
if clientprev is not specified, use local storage to figure it out CORE-4362

### DIFF
--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -350,6 +350,12 @@ func (o *Outbox) insertMessage(thread *chat1.ThreadView, obr chat1.OutboxRecord)
 		res = append(res, msg)
 	}
 
+	// If we didn't insert this guy, then put it at the front just so the user can see it
+	if !inserted {
+		res = append([]chat1.MessageUnboxed{chat1.NewMessageUnboxedWithOutbox(obr)},
+			res...)
+	}
+
 	thread.Messages = res
 	return nil
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -193,6 +193,10 @@ func (o OutboxID) Eq(r OutboxID) bool {
 	return bytes.Equal(o, r)
 }
 
+func (o OutboxID) String() string {
+	return hex.EncodeToString(o)
+}
+
 func (t TLFVisibility) Eq(r TLFVisibility) bool {
 	return int(t) == int(r)
 }


### PR DESCRIPTION
If the frontend does not specify a previous message, use the previous message from local storage.

cc @chrisnojima 