### PR TITLE
Copy plaintext to clipboard, no styling

### DIFF
--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -14,7 +14,7 @@ import shallowEqual from 'shallowequal'
 import {AutoSizer, CellMeasurer, List as VirtualizedList, defaultCellMeasurerCellSizeCache} from 'react-virtualized'
 import {Box, ProgressIndicator} from '../../common-adapters'
 import {globalColors, globalStyles} from '../../styles'
-
+import {clipboard} from 'electron'
 import type {List} from 'immutable'
 import type {Message, MessageID} from '../../constants/chat'
 import type {Props} from './list'
@@ -267,7 +267,11 @@ class ConversationList extends Component<void, Props, State> {
     `
 
     return (
-      <div style={{...globalStyles.flexBoxColumn, flex: 1, position: 'relative'}}>
+      <div style={{...globalStyles.flexBoxColumn, flex: 1, position: 'relative'}} onCopyCapture={(e) => {
+        // Copy text only, not HTML/styling.
+        e.preventDefault()
+        clipboard.writeText(window.getSelection().toString())
+      }}>
         <style>{realCSS}</style>
         <AutoSizer
           onResize={({width}) => {


### PR DESCRIPTION
@keybase/react-hackers 

We were previously copying formatting (font size etc) with our chat message copy to clipboard.  This PR gives us plaintext only.

Slack goes one better -- 'foo **bold** bar' will copy as `foo *bold* bar` -- the source code used to create the message is what's copied, not the output.  To do that we'd need to go over each Message object that's selected, find the original source code for it, and deal with the case where the selection is part way through a Message.  It sounds extremely difficult to get right.

So let's try this for now!