### PR TITLE
Ignore timestamp for unhandled

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -630,7 +630,7 @@ function _threadToPagination (thread) {
 }
 
 function _maybeAddTimestamp (message: Message, prevMessage: Message): MaybeTimestamp {
-  if (prevMessage.type === 'Timestamp' || message.type === 'Timestamp') {
+  if (prevMessage.type === 'Timestamp' || message.type === 'Timestamp' || message.type === 'Unhandled') {
     return null
   }
   // messageID 1 is an unhandled placeholder. We want to add a timestamp before


### PR DESCRIPTION
Don't add timestamp message for unhandled messages.