### PR TITLE
don't replace trusted w/ untrusted on an inbox reload

### DIFF
--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -225,7 +225,13 @@ function reducer (state: State = initialState, action: Actions) {
     case Constants.updatedMetadata:
       return state.set('metaData', state.get('metaData').merge(action.payload))
     case Constants.loadedInbox:
-      return state.set('inbox', action.payload.inbox)
+      // Don't overwrite existing verified inbox data
+      const existingRows = state.get('inbox')
+      return state.set('inbox', action.payload.inbox.map(newRow => {
+        const id = newRow.get('conversationIDKey')
+        const existingRow = existingRows.find(existingRow => existingRow.get('conversationIDKey') === id)
+        return existingRow || newRow
+      }))
     case Constants.updateInboxComplete:
       return state.set('inbox', state.get('inbox').filter(i => i.get('validated')))
     case Constants.updateInbox:


### PR DESCRIPTION
@keybase/react-hackers this makes clicking between chat/other tab and back not reload the inbox in a visible way