### PR TITLE
add function to get messages from cache with boxed versions CORE-4350

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -344,14 +344,9 @@ func (s *localizer) localizeConversation(ctx context.Context, uid gregor1.UID,
 		return chat1.ConversationLocal{Error: &errMsg}
 	}
 
-	var msgIDs []chat1.MessageID
-	for _, m := range conversationRemote.MaxMsgs {
-		msgIDs = append(msgIDs, m.GetMessageID())
-	}
-
 	var err error
-	conversationLocal.MaxMessages, err = s.G().ConvSource.GetMessages(ctx,
-		conversationRemote.Metadata.ConversationID, uid, msgIDs)
+	conversationLocal.MaxMessages, err = s.G().ConvSource.GetMessagesWithRemotes(ctx,
+		conversationRemote.Metadata.ConversationID, uid, conversationRemote.MaxMsgs)
 	if err != nil {
 		errMsg := err.Error()
 		return chat1.ConversationLocal{Error: &errMsg}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -528,6 +528,8 @@ type ConversationSource interface {
 	PullLocalOnly(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, query *chat1.GetThreadQuery,
 		pagination *chat1.Pagination) (chat1.ThreadView, error)
 	GetMessages(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgIDs []chat1.MessageID) ([]chat1.MessageUnboxed, error)
+	GetMessagesWithRemotes(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
+		msgs []chat1.MessageBoxed) ([]chat1.MessageUnboxed, error)
 	Clear(convID chat1.ConversationID, uid gregor1.UID) error
 }
 


### PR DESCRIPTION
When unboxing the `MaxMessages` list from `GetInboxRemote`, then we check to see if those messages are already in the message bodies cache. If they are not, then we fetch them from the server. However, in the case of `MaxMessages`, we already have the boxed version, so just use that instead if going to the server.