### PR TITLE
Use single image preview for large animated gifs

### DIFF
--- a/go/chat/attachment_preview.go
+++ b/go/chat/attachment_preview.go
@@ -152,8 +152,11 @@ func previewGIF(ctx context.Context, log logger.Logger, src io.Reader, basename 
 		return nil, errors.New("no image frames in GIF")
 	}
 
+	log.Debug("previewGIF: number of frames = %d", frames)
+
 	var baseDuration int
 	if frames > 40 {
+		log.Debug("previewGif: too many frames in gif for preview: %d, just using frame 0", frames)
 		baseDuration = gifDuration(g)
 		g.Image = g.Image[:1]
 		g.Delay = g.Delay[:1]
@@ -165,10 +168,9 @@ func previewGIF(ctx context.Context, log logger.Logger, src io.Reader, basename 
 	origBounds := g.Image[0].Bounds()
 	img := image.NewRGBA(origBounds)
 
-	log.Debug("previewGIF: number of frames = %d", len(g.Image))
-
 	// draw each frame, then resize it, replacing the existing frames.
 	width, height := previewDimensions(origBounds)
+	log.Debug("previewGif: resizing to %d x %d", width, height)
 	for index, frame := range g.Image {
 		bounds := frame.Bounds()
 		draw.Draw(img, bounds, frame, bounds.Min, draw.Over)

--- a/go/chat/attachment_preview.go
+++ b/go/chat/attachment_preview.go
@@ -147,8 +147,17 @@ func previewGIF(ctx context.Context, log logger.Logger, src io.Reader, basename 
 		return nil, err
 	}
 
-	if len(g.Image) == 0 {
+	frames := len(g.Image)
+	if frames == 0 {
 		return nil, errors.New("no image frames in GIF")
+	}
+
+	var baseDuration int
+	if frames > 40 {
+		baseDuration = gifDuration(g)
+		g.Image = g.Image[:1]
+		g.Delay = g.Delay[:1]
+		g.Disposal = g.Disposal[:1]
 	}
 
 	// create a new image based on the first frame to draw
@@ -178,17 +187,17 @@ func previewGIF(ctx context.Context, log logger.Logger, src io.Reader, basename 
 	}
 
 	res := &PreviewRes{
-		Source:        newBufferSource(&buf, basename),
-		ContentType:   "image/gif",
-		BaseWidth:     origBounds.Dx(),
-		BaseHeight:    origBounds.Dy(),
-		PreviewWidth:  int(width),
-		PreviewHeight: int(height),
+		Source:         newBufferSource(&buf, basename),
+		ContentType:    "image/gif",
+		BaseWidth:      origBounds.Dx(),
+		BaseHeight:     origBounds.Dy(),
+		PreviewWidth:   int(width),
+		PreviewHeight:  int(height),
+		BaseDurationMs: baseDuration,
 	}
 
 	if len(g.Image) > 1 {
-		res.BaseDurationMs = gifDuration(g)
-		res.PreviewDurationMs = res.BaseDurationMs // currently the same, but in the future maybe preview will be shorter
+		res.PreviewDurationMs = gifDuration(g)
 	}
 
 	return res, nil


### PR DESCRIPTION
If more than 40 frames in a gif, just use the first one.

cc @malgorithms @chromakode @MarcoPolo 