### PR TITLE
Autofocus the chat input box when it's created

### DIFF
--- a/shared/chat/conversation/input.desktop.js
+++ b/shared/chat/conversation/input.desktop.js
@@ -77,6 +77,7 @@ class Conversation extends Component<void, Props, State> {
         <Box style={{...globalStyles.flexBoxRow, alignItems: 'flex-end'}}>
           <input type='file' style={{display: 'none'}} ref={r => { this._fileInput = r }} onChange={() => this._pickFile()} />
           <Input
+            autoFocus={true}
             small={true}
             style={styleInput}
             ref={this._setRef}


### PR DESCRIPTION
@keybase/react-hackers 

We already had lifecycle hooks to focus the input box when its props change, but were missing an autoFocus={true} to focus it on creation, like when you switch back to an existing conversation.