### PR TITLE
add better interface to post local nonblock CORE-4321

### DIFF
--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -856,6 +856,37 @@ type PostLocalNonblockArg struct {
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
+type PostTextNonblockArg struct {
+	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
+	Conv             ConversationIDTriple         `codec:"conv" json:"conv"`
+	TlfName          string                       `codec:"tlfName" json:"tlfName"`
+	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
+	Body             string                       `codec:"body" json:"body"`
+	ClientPrev       MessageID                    `codec:"clientPrev" json:"clientPrev"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
+}
+
+type PostDeleteNonblockArg struct {
+	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
+	Conv             ConversationIDTriple         `codec:"conv" json:"conv"`
+	TlfName          string                       `codec:"tlfName" json:"tlfName"`
+	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
+	Supersedes       MessageID                    `codec:"supersedes" json:"supersedes"`
+	ClientPrev       MessageID                    `codec:"clientPrev" json:"clientPrev"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
+}
+
+type PostEditNonblockArg struct {
+	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
+	Conv             ConversationIDTriple         `codec:"conv" json:"conv"`
+	TlfName          string                       `codec:"tlfName" json:"tlfName"`
+	TlfPublic        bool                         `codec:"tlfPublic" json:"tlfPublic"`
+	Supersedes       MessageID                    `codec:"supersedes" json:"supersedes"`
+	Body             string                       `codec:"body" json:"body"`
+	ClientPrev       MessageID                    `codec:"clientPrev" json:"clientPrev"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
+}
+
 type SetConversationStatusLocalArg struct {
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
 	Status           ConversationStatus           `codec:"status" json:"status"`
@@ -945,6 +976,9 @@ type LocalInterface interface {
 	GetInboxNonblockLocal(context.Context, GetInboxNonblockLocalArg) (GetInboxNonblockLocalRes, error)
 	PostLocal(context.Context, PostLocalArg) (PostLocalRes, error)
 	PostLocalNonblock(context.Context, PostLocalNonblockArg) (PostLocalNonblockRes, error)
+	PostTextNonblock(context.Context, PostTextNonblockArg) (PostLocalNonblockRes, error)
+	PostDeleteNonblock(context.Context, PostDeleteNonblockArg) (PostLocalNonblockRes, error)
+	PostEditNonblock(context.Context, PostEditNonblockArg) (PostLocalNonblockRes, error)
 	SetConversationStatusLocal(context.Context, SetConversationStatusLocalArg) (SetConversationStatusLocalRes, error)
 	NewConversationLocal(context.Context, NewConversationLocalArg) (NewConversationLocalRes, error)
 	GetInboxSummaryForCLILocal(context.Context, GetInboxSummaryForCLILocalQuery) (GetInboxSummaryForCLILocalRes, error)
@@ -1055,6 +1089,54 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.PostLocalNonblock(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"postTextNonblock": {
+				MakeArg: func() interface{} {
+					ret := make([]PostTextNonblockArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]PostTextNonblockArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]PostTextNonblockArg)(nil), args)
+						return
+					}
+					ret, err = i.PostTextNonblock(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"postDeleteNonblock": {
+				MakeArg: func() interface{} {
+					ret := make([]PostDeleteNonblockArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]PostDeleteNonblockArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]PostDeleteNonblockArg)(nil), args)
+						return
+					}
+					ret, err = i.PostDeleteNonblock(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"postEditNonblock": {
+				MakeArg: func() interface{} {
+					ret := make([]PostEditNonblockArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]PostEditNonblockArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]PostEditNonblockArg)(nil), args)
+						return
+					}
+					ret, err = i.PostEditNonblock(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -1286,6 +1368,21 @@ func (c LocalClient) PostLocal(ctx context.Context, __arg PostLocalArg) (res Pos
 
 func (c LocalClient) PostLocalNonblock(ctx context.Context, __arg PostLocalNonblockArg) (res PostLocalNonblockRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.postLocalNonblock", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) PostTextNonblock(ctx context.Context, __arg PostTextNonblockArg) (res PostLocalNonblockRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.postTextNonblock", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) PostDeleteNonblock(ctx context.Context, __arg PostDeleteNonblockArg) (res PostLocalNonblockRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.postDeleteNonblock", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) PostEditNonblock(ctx context.Context, __arg PostEditNonblockArg) (res PostLocalNonblockRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.postEditNonblock", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -669,6 +669,58 @@ func (h *chatLocalHandler) PostLocal(ctx context.Context, arg chat1.PostLocalArg
 	}, nil
 }
 
+func (h *chatLocalHandler) PostDeleteNonblock(ctx context.Context, arg chat1.PostDeleteNonblockArg) (chat1.PostLocalNonblockRes, error) {
+
+	var parg chat1.PostLocalNonblockArg
+	parg.ClientPrev = arg.ClientPrev
+	parg.ConversationID = arg.ConversationID
+	parg.IdentifyBehavior = arg.IdentifyBehavior
+	parg.Msg.ClientHeader.Conv = arg.Conv
+	parg.Msg.ClientHeader.MessageType = chat1.MessageType_DELETE
+	parg.Msg.ClientHeader.Supersedes = arg.Supersedes
+	parg.Msg.ClientHeader.TlfName = arg.TlfName
+	parg.Msg.ClientHeader.TlfPublic = arg.TlfPublic
+
+	return h.PostLocalNonblock(ctx, parg)
+}
+
+func (h *chatLocalHandler) PostEditNonblock(ctx context.Context, arg chat1.PostEditNonblockArg) (chat1.PostLocalNonblockRes, error) {
+
+	var parg chat1.PostLocalNonblockArg
+	parg.ClientPrev = arg.ClientPrev
+	parg.ConversationID = arg.ConversationID
+	parg.IdentifyBehavior = arg.IdentifyBehavior
+	parg.Msg.ClientHeader.Conv = arg.Conv
+	parg.Msg.ClientHeader.MessageType = chat1.MessageType_EDIT
+	parg.Msg.ClientHeader.Supersedes = arg.Supersedes
+	parg.Msg.ClientHeader.TlfName = arg.TlfName
+	parg.Msg.ClientHeader.TlfPublic = arg.TlfPublic
+	parg.Msg.MessageBody = chat1.NewMessageBodyWithEdit(chat1.MessageEdit{
+		MessageID: arg.Supersedes,
+		Body:      arg.Body,
+	})
+
+	return h.PostLocalNonblock(ctx, parg)
+}
+
+func (h *chatLocalHandler) PostTextNonblock(ctx context.Context, arg chat1.PostTextNonblockArg) (chat1.PostLocalNonblockRes, error) {
+
+	var parg chat1.PostLocalNonblockArg
+	parg.ClientPrev = arg.ClientPrev
+	parg.ConversationID = arg.ConversationID
+	parg.IdentifyBehavior = arg.IdentifyBehavior
+	parg.Msg.ClientHeader.Conv = arg.Conv
+	parg.Msg.ClientHeader.MessageType = chat1.MessageType_TEXT
+	parg.Msg.ClientHeader.TlfName = arg.TlfName
+	parg.Msg.ClientHeader.TlfPublic = arg.TlfPublic
+	parg.Msg.MessageBody = chat1.NewMessageBodyWithText(chat1.MessageText{
+		Body: arg.Body,
+	})
+
+	return h.PostLocalNonblock(ctx, parg)
+
+}
+
 func (h *chatLocalHandler) PostLocalNonblock(ctx context.Context, arg chat1.PostLocalNonblockArg) (chat1.PostLocalNonblockRes, error) {
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return chat1.PostLocalNonblockRes{}, err

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -80,6 +80,12 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	h.setTestRemoteClient(mockRemote)
 	h.gh, _ = newGregorHandler(tc.G)
 
+	baseSender := chat.NewBlockingSender(tc.G, h.boxer,
+		func() chat1.RemoteInterface { return mockRemote }, f)
+	tc.G.MessageDeliverer = chat.NewDeliverer(tc.G, baseSender)
+	tc.G.MessageDeliverer.Start(user.User.GetUID().ToBytes())
+	tc.G.MessageDeliverer.Connected()
+
 	tuc := &chatTestUserContext{
 		h: h,
 		u: user,
@@ -89,6 +95,12 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 }
 
 func (c *chatTestContext) cleanup() {
+	for _, u := range c.users() {
+		deliverer := c.world.Tcs[u.Username].G.MessageDeliverer
+		if deliverer != nil {
+			deliverer.Stop()
+		}
+	}
 	c.world.Cleanup()
 }
 
@@ -807,5 +819,117 @@ func TestChatGap(t *testing.T) {
 	case <-listener.threadStale:
 		require.Fail(t, "should not get stale event here")
 	default:
+	}
+}
+
+type chatListener struct {
+	newMessage chan chat1.MessageUnboxed
+}
+
+func (n *chatListener) Logout()                                                            {}
+func (n *chatListener) Login(username string)                                              {}
+func (n *chatListener) ClientOutOfDate(to, uri, msg string)                                {}
+func (n *chatListener) UserChanged(uid keybase1.UID)                                       {}
+func (n *chatListener) TrackingChanged(uid keybase1.UID, username string)                  {}
+func (n *chatListener) FSActivity(activity keybase1.FSNotification)                        {}
+func (n *chatListener) FSEditListResponse(arg keybase1.FSEditListArg)                      {}
+func (n *chatListener) FSEditListRequest(arg keybase1.FSEditListRequest)                   {}
+func (n *chatListener) FSSyncStatusResponse(arg keybase1.FSSyncStatusArg)                  {}
+func (n *chatListener) FSSyncEvent(arg keybase1.FSPathSyncStatus)                          {}
+func (n *chatListener) PaperKeyCached(uid keybase1.UID, encKID, sigKID keybase1.KID)       {}
+func (n *chatListener) FavoritesChanged(uid keybase1.UID)                                  {}
+func (n *chatListener) KeyfamilyChanged(uid keybase1.UID)                                  {}
+func (n *chatListener) PGPKeyInSecretStoreFile()                                           {}
+func (n *chatListener) BadgeState(badgeState keybase1.BadgeState)                          {}
+func (n *chatListener) ReachabilityChanged(r keybase1.Reachability)                        {}
+func (n *chatListener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks) {}
+func (n *chatListener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationFinalizeInfo) {
+}
+func (n *chatListener) ChatInboxStale(uid keybase1.UID)                                {}
+func (n *chatListener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {}
+func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActivity) {
+	typ, _ := activity.ActivityType()
+	if typ == chat1.ChatActivityType_INCOMING_MESSAGE {
+		n.newMessage <- activity.IncomingMessage().Message
+	}
+}
+
+func TestPostLocalNonblock(t *testing.T) {
+	ctc := makeChatTestContext(t, "PostLocalNonblock", 2)
+	defer ctc.cleanup()
+	users := ctc.users()
+
+	var err error
+	created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
+
+	listener := chatListener{
+		newMessage: make(chan chat1.MessageUnboxed),
+	}
+	ctc.as(t, users[0]).h.G().SetService()
+	ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(&listener)
+
+	t.Logf("send a text message")
+	arg := chat1.PostTextNonblockArg{
+		ConversationID:   created.Id,
+		Conv:             created.Triple,
+		TlfName:          created.TlfName,
+		TlfPublic:        created.Visibility == chat1.TLFVisibility_PUBLIC,
+		Body:             "hi",
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+	}
+	res, err := ctc.as(t, users[0]).chatLocalHandler().PostTextNonblock(context.TODO(), arg)
+	require.NoError(t, err)
+	var unboxed chat1.MessageUnboxed
+	select {
+	case unboxed = <-listener.newMessage:
+		require.True(t, unboxed.IsValid(), "invalid message")
+		require.NotNil(t, unboxed.Valid().ClientHeader.OutboxID, "no outbox ID")
+		require.Equal(t, res.OutboxID, *unboxed.Valid().ClientHeader.OutboxID, "mismatch outbox ID")
+		require.Equal(t, chat1.MessageType_TEXT, unboxed.GetMessageType(), "invalid type")
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no event received")
+	}
+
+	t.Logf("edit the message")
+	earg := chat1.PostEditNonblockArg{
+		ConversationID:   created.Id,
+		Conv:             created.Triple,
+		TlfName:          created.TlfName,
+		TlfPublic:        created.Visibility == chat1.TLFVisibility_PUBLIC,
+		Supersedes:       unboxed.GetMessageID(),
+		Body:             "hi2",
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+	}
+	res, err = ctc.as(t, users[0]).chatLocalHandler().PostEditNonblock(context.TODO(), earg)
+	require.NoError(t, err)
+	select {
+	case unboxed = <-listener.newMessage:
+		require.True(t, unboxed.IsValid(), "invalid message")
+		require.NotNil(t, unboxed.Valid().ClientHeader.OutboxID, "no outbox ID")
+		require.Equal(t, res.OutboxID, *unboxed.Valid().ClientHeader.OutboxID, "mismatch outbox ID")
+		require.Equal(t, chat1.MessageType_EDIT, unboxed.GetMessageType(), "invalid type")
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no event received")
+	}
+
+	t.Logf("delete the message")
+	darg := chat1.PostDeleteNonblockArg{
+		ConversationID:   created.Id,
+		Conv:             created.Triple,
+		TlfName:          created.TlfName,
+		TlfPublic:        created.Visibility == chat1.TLFVisibility_PUBLIC,
+		Supersedes:       unboxed.GetMessageID(),
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+	}
+	res, err = ctc.as(t, users[0]).chatLocalHandler().PostDeleteNonblock(context.TODO(), darg)
+	require.NoError(t, err)
+	select {
+	case unboxed = <-listener.newMessage:
+		require.True(t, unboxed.IsValid(), "invalid message")
+		require.NotNil(t, unboxed.Valid().ClientHeader.OutboxID, "no outbox ID")
+		require.Equal(t, res.OutboxID, *unboxed.Valid().ClientHeader.OutboxID, "mismatch outbox ID")
+		require.Equal(t, chat1.MessageType_DELETE, unboxed.GetMessageType(), "invalid type")
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no event received")
 	}
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -320,6 +320,11 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
+  PostLocalNonblockRes postTextNonblock(ConversationID conversationID, ConversationIDTriple conv, string tlfName, boolean tlfPublic, string body, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
+  PostLocalNonblockRes postDeleteNonblock(ConversationID conversationID, ConversationIDTriple conv, string tlfName, boolean tlfPublic, MessageID supersedes,MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
+  PostLocalNonblockRes postEditNonblock(ConversationID conversationID, ConversationIDTriple conv, string tlfName, boolean tlfPublic, MessageID supersedes, string body, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
+
+
   @lint("ignore")
   SetConversationStatusLocalRes SetConversationStatusLocal(ConversationID conversationID, ConversationStatus status, keybase1.TLFIdentifyBehavior identifyBehavior);
   record SetConversationStatusLocalRes {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -278,6 +278,30 @@ export function localPostAttachmentLocalRpcPromise (request: $Exact<requestCommo
   return new Promise((resolve, reject) => { localPostAttachmentLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function localPostDeleteNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostDeleteNonblockResult) => void} & {param: localPostDeleteNonblockRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.postDeleteNonblock'})
+}
+
+export function localPostDeleteNonblockRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostDeleteNonblockResult) => void} & {param: localPostDeleteNonblockRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localPostDeleteNonblockRpc({...request, incomingCallMap, callback}))
+}
+
+export function localPostDeleteNonblockRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostDeleteNonblockResult) => void} & {param: localPostDeleteNonblockRpcParam}>): Promise<localPostDeleteNonblockResult> {
+  return new Promise((resolve, reject) => { localPostDeleteNonblockRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
+export function localPostEditNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostEditNonblockResult) => void} & {param: localPostEditNonblockRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.postEditNonblock'})
+}
+
+export function localPostEditNonblockRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostEditNonblockResult) => void} & {param: localPostEditNonblockRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localPostEditNonblockRpc({...request, incomingCallMap, callback}))
+}
+
+export function localPostEditNonblockRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostEditNonblockResult) => void} & {param: localPostEditNonblockRpcParam}>): Promise<localPostEditNonblockResult> {
+  return new Promise((resolve, reject) => { localPostEditNonblockRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function localPostFileAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {param: localPostFileAttachmentLocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.postFileAttachmentLocal'})
 }
@@ -312,6 +336,18 @@ export function localPostLocalRpcChannelMap (channelConfig: ChannelConfig<*>, re
 
 export function localPostLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {param: localPostLocalRpcParam}>): Promise<localPostLocalResult> {
   return new Promise((resolve, reject) => { localPostLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
+export function localPostTextNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {param: localPostTextNonblockRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.postTextNonblock'})
+}
+
+export function localPostTextNonblockRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {param: localPostTextNonblockRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localPostTextNonblockRpc({...request, incomingCallMap, callback}))
+}
+
+export function localPostTextNonblockRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {param: localPostTextNonblockRpcParam}>): Promise<localPostTextNonblockResult> {
+  return new Promise((resolve, reject) => { localPostTextNonblockRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function localRetryPostRpc (request: Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>) {
@@ -1264,6 +1300,27 @@ export type localPostAttachmentLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
+export type localPostDeleteNonblockRpcParam = Exact<{
+  conversationID: ConversationID,
+  conv: ConversationIDTriple,
+  tlfName: string,
+  tlfPublic: boolean,
+  supersedes: MessageID,
+  clientPrev: MessageID,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
+export type localPostEditNonblockRpcParam = Exact<{
+  conversationID: ConversationID,
+  conv: ConversationIDTriple,
+  tlfName: string,
+  tlfPublic: boolean,
+  supersedes: MessageID,
+  body: string,
+  clientPrev: MessageID,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
 export type localPostFileAttachmentLocalRpcParam = Exact<{
   conversationID: ConversationID,
   clientHeader: MessageClientHeader,
@@ -1284,6 +1341,16 @@ export type localPostLocalNonblockRpcParam = Exact<{
 export type localPostLocalRpcParam = Exact<{
   conversationID: ConversationID,
   msg: MessagePlaintext,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
+export type localPostTextNonblockRpcParam = Exact<{
+  conversationID: ConversationID,
+  conv: ConversationIDTriple,
+  tlfName: string,
+  tlfPublic: boolean,
+  body: string,
+  clientPrev: MessageID,
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
@@ -1387,11 +1454,17 @@ type localNewConversationLocalResult = NewConversationLocalRes
 
 type localPostAttachmentLocalResult = PostLocalRes
 
+type localPostDeleteNonblockResult = PostLocalNonblockRes
+
+type localPostEditNonblockResult = PostLocalNonblockRes
+
 type localPostFileAttachmentLocalResult = PostLocalRes
 
 type localPostLocalNonblockResult = PostLocalNonblockRes
 
 type localPostLocalResult = PostLocalRes
+
+type localPostTextNonblockResult = PostLocalNonblockRes
 
 type localSetConversationStatusLocalResult = SetConversationStatusLocalRes
 
@@ -1433,9 +1506,12 @@ export type rpc =
   | localMarkAsReadLocalRpc
   | localNewConversationLocalRpc
   | localPostAttachmentLocalRpc
+  | localPostDeleteNonblockRpc
+  | localPostEditNonblockRpc
   | localPostFileAttachmentLocalRpc
   | localPostLocalNonblockRpc
   | localPostLocalRpc
+  | localPostTextNonblockRpc
   | localRetryPostRpc
   | localSetConversationStatusLocalRpc
   | remoteGetInboxRemoteRpc

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1384,6 +1384,109 @@
       ],
       "response": "PostLocalNonblockRes"
     },
+    "postTextNonblock": {
+      "request": [
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "conv",
+          "type": "ConversationIDTriple"
+        },
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "tlfPublic",
+          "type": "boolean"
+        },
+        {
+          "name": "body",
+          "type": "string"
+        },
+        {
+          "name": "clientPrev",
+          "type": "MessageID"
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
+        }
+      ],
+      "response": "PostLocalNonblockRes"
+    },
+    "postDeleteNonblock": {
+      "request": [
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "conv",
+          "type": "ConversationIDTriple"
+        },
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "tlfPublic",
+          "type": "boolean"
+        },
+        {
+          "name": "supersedes",
+          "type": "MessageID"
+        },
+        {
+          "name": "clientPrev",
+          "type": "MessageID"
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
+        }
+      ],
+      "response": "PostLocalNonblockRes"
+    },
+    "postEditNonblock": {
+      "request": [
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "conv",
+          "type": "ConversationIDTriple"
+        },
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "tlfPublic",
+          "type": "boolean"
+        },
+        {
+          "name": "supersedes",
+          "type": "MessageID"
+        },
+        {
+          "name": "body",
+          "type": "string"
+        },
+        {
+          "name": "clientPrev",
+          "type": "MessageID"
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
+        }
+      ],
+      "response": "PostLocalNonblockRes"
+    },
     "SetConversationStatusLocal": {
       "request": [
         {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -278,6 +278,30 @@ export function localPostAttachmentLocalRpcPromise (request: $Exact<requestCommo
   return new Promise((resolve, reject) => { localPostAttachmentLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function localPostDeleteNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostDeleteNonblockResult) => void} & {param: localPostDeleteNonblockRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.postDeleteNonblock'})
+}
+
+export function localPostDeleteNonblockRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostDeleteNonblockResult) => void} & {param: localPostDeleteNonblockRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localPostDeleteNonblockRpc({...request, incomingCallMap, callback}))
+}
+
+export function localPostDeleteNonblockRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostDeleteNonblockResult) => void} & {param: localPostDeleteNonblockRpcParam}>): Promise<localPostDeleteNonblockResult> {
+  return new Promise((resolve, reject) => { localPostDeleteNonblockRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
+export function localPostEditNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostEditNonblockResult) => void} & {param: localPostEditNonblockRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.postEditNonblock'})
+}
+
+export function localPostEditNonblockRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostEditNonblockResult) => void} & {param: localPostEditNonblockRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localPostEditNonblockRpc({...request, incomingCallMap, callback}))
+}
+
+export function localPostEditNonblockRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostEditNonblockResult) => void} & {param: localPostEditNonblockRpcParam}>): Promise<localPostEditNonblockResult> {
+  return new Promise((resolve, reject) => { localPostEditNonblockRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function localPostFileAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {param: localPostFileAttachmentLocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.postFileAttachmentLocal'})
 }
@@ -312,6 +336,18 @@ export function localPostLocalRpcChannelMap (channelConfig: ChannelConfig<*>, re
 
 export function localPostLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {param: localPostLocalRpcParam}>): Promise<localPostLocalResult> {
   return new Promise((resolve, reject) => { localPostLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
+export function localPostTextNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {param: localPostTextNonblockRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.postTextNonblock'})
+}
+
+export function localPostTextNonblockRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {param: localPostTextNonblockRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localPostTextNonblockRpc({...request, incomingCallMap, callback}))
+}
+
+export function localPostTextNonblockRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {param: localPostTextNonblockRpcParam}>): Promise<localPostTextNonblockResult> {
+  return new Promise((resolve, reject) => { localPostTextNonblockRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function localRetryPostRpc (request: Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>) {
@@ -1264,6 +1300,27 @@ export type localPostAttachmentLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
+export type localPostDeleteNonblockRpcParam = Exact<{
+  conversationID: ConversationID,
+  conv: ConversationIDTriple,
+  tlfName: string,
+  tlfPublic: boolean,
+  supersedes: MessageID,
+  clientPrev: MessageID,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
+export type localPostEditNonblockRpcParam = Exact<{
+  conversationID: ConversationID,
+  conv: ConversationIDTriple,
+  tlfName: string,
+  tlfPublic: boolean,
+  supersedes: MessageID,
+  body: string,
+  clientPrev: MessageID,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
 export type localPostFileAttachmentLocalRpcParam = Exact<{
   conversationID: ConversationID,
   clientHeader: MessageClientHeader,
@@ -1284,6 +1341,16 @@ export type localPostLocalNonblockRpcParam = Exact<{
 export type localPostLocalRpcParam = Exact<{
   conversationID: ConversationID,
   msg: MessagePlaintext,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
+export type localPostTextNonblockRpcParam = Exact<{
+  conversationID: ConversationID,
+  conv: ConversationIDTriple,
+  tlfName: string,
+  tlfPublic: boolean,
+  body: string,
+  clientPrev: MessageID,
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
@@ -1387,11 +1454,17 @@ type localNewConversationLocalResult = NewConversationLocalRes
 
 type localPostAttachmentLocalResult = PostLocalRes
 
+type localPostDeleteNonblockResult = PostLocalNonblockRes
+
+type localPostEditNonblockResult = PostLocalNonblockRes
+
 type localPostFileAttachmentLocalResult = PostLocalRes
 
 type localPostLocalNonblockResult = PostLocalNonblockRes
 
 type localPostLocalResult = PostLocalRes
+
+type localPostTextNonblockResult = PostLocalNonblockRes
 
 type localSetConversationStatusLocalResult = SetConversationStatusLocalRes
 
@@ -1433,9 +1506,12 @@ export type rpc =
   | localMarkAsReadLocalRpc
   | localNewConversationLocalRpc
   | localPostAttachmentLocalRpc
+  | localPostDeleteNonblockRpc
+  | localPostEditNonblockRpc
   | localPostFileAttachmentLocalRpc
   | localPostLocalNonblockRpc
   | localPostLocalRpc
+  | localPostTextNonblockRpc
   | localRetryPostRpc
   | localSetConversationStatusLocalRpc
   | remoteGetInboxRemoteRpc


### PR DESCRIPTION
This adds function to post text/edits/deletes in a slightly easier manner so the frontend doesn't need to guess which fields need to be filled in in `MessagePlaintext`.

cc @chrisnojima @gabriel 