### PR TITLE
import go-framed-msgpack-rpc changes and set a constant 2 second reconnect backoff

### DIFF
--- a/go/client/cmd_ping.go
+++ b/go/client/cmd_ping.go
@@ -189,7 +189,10 @@ func PingGregor(g *libkb.GlobalContext) error {
 		pingErrors:   make(chan error),
 		pingSuccess:  make(chan struct{}),
 	}
-	connection := rpc.NewConnectionWithTransport(rpcHandler, transport, keybase1.ErrorUnwrapper{}, true, keybase1.WrapError, g.Log, nil)
+	opts := rpc.ConnectionOpts{
+		WrapErrorFunc: keybase1.WrapError,
+	}
+	connection := rpc.NewConnectionWithTransport(rpcHandler, transport, keybase1.ErrorUnwrapper{}, g.Log, opts)
 	select {
 	case err := <-rpcHandler.pingErrors:
 		pingError = fmt.Errorf("Gregor ping FAILED: %s", err.Error())

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1218,7 +1218,10 @@ func (g *gregorHandler) connectTLS() error {
 	g.Debug("Using CA for gregor: %s", libkb.ShortCA(rawCA))
 
 	g.connMutex.Lock()
-	g.conn = rpc.NewTLSConnection(uri.HostPort, []byte(rawCA), libkb.ErrorUnwrapper{}, g, true, libkb.NewRPCLogFactory(g.G()), libkb.WrapError, g.G().Log, nil)
+	opts := rpc.ConnectionOpts{
+		WrapErrorFunc: libkb.WrapError,
+	}
+	g.conn = rpc.NewTLSConnection(uri.HostPort, []byte(rawCA), libkb.ErrorUnwrapper{}, g, libkb.NewRPCLogFactory(g.G()), g.G().Log, opts)
 	g.connMutex.Unlock()
 
 	// The client we get here will reconnect to gregord on disconnect if necessary.
@@ -1241,7 +1244,10 @@ func (g *gregorHandler) connectNoTLS() error {
 	t := newConnTransport(g.G(), uri.HostPort)
 	g.transportForTesting = t
 	g.connMutex.Lock()
-	g.conn = rpc.NewConnectionWithTransport(g, t, libkb.ErrorUnwrapper{}, true, libkb.WrapError, g.G().Log, nil)
+	opts := rpc.ConnectionOpts{
+		WrapErrorFunc: libkb.WrapError,
+	}
+	g.conn = rpc.NewConnectionWithTransport(g, t, libkb.ErrorUnwrapper{}, g.G().Log, opts)
 	g.connMutex.Unlock()
 	g.cli = WrapGenericClientWithTimeout(g.conn.GetClient(), GregorRequestTimeout, ErrGregorTimeout)
 

--- a/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/connection_test_util.go
+++ b/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/connection_test_util.go
@@ -146,8 +146,11 @@ func MakeConnectionForTest(t TestLogger) (net.Conn, *Connection) {
 	logFactory := NewSimpleLogFactory(logOutput, nil)
 	transporter := NewTransport(clientConn, logFactory, testWrapError)
 	st := singleTransport{transporter}
+	opts := ConnectionOpts{
+		WrapErrorFunc: testWrapError,
+		TagsFunc:      testLogTags,
+	}
 	conn := NewConnectionWithTransport(testConnectionHandler{}, st,
-		testErrorUnwrapper{}, true, testWrapError,
-		logOutput, testLogTags)
+		testErrorUnwrapper{}, logOutput, opts)
 	return serverConn, conn
 }

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -233,10 +233,10 @@
 			"revisionTime": "2016-03-19T10:18:54-07:00"
 		},
 		{
-			"checksumSHA1": "SC+9sm//Kzu5V1lUcFa/GyhtZas=",
+			"checksumSHA1": "dL7Tcu8TAzoc40pk74eWfKZzdoY=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc",
-			"revision": "f08dee4c9e838e5a6c499ad4ed2e9a4ab6433361",
-			"revisionTime": "2016-10-03T19:37:48Z"
+			"revision": "8ef73e843df090005cb21ab5cc66c7acc8446fdc",
+			"revisionTime": "2017-01-11T17:52:48Z"
 		},
 		{
 			"path": "github.com/keybase/go-jsonw",


### PR DESCRIPTION
~TODO: Proper govendor after https://github.com/keybase/go-framed-msgpack-rpc/pull/103 lands.~