### PR TITLE
Get chat working after account reset

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -400,9 +400,6 @@ func (b *Boxer) boxMessageWithKeysV1(msg chat1.MessagePlaintext, key *keybase1.C
 
 // seal encrypts data into chat1.EncryptedData.
 func (b *Boxer) seal(data interface{}, key *keybase1.CryptKey) (*chat1.EncryptedData, error) {
-
-	b.log().Warning("Boxer.seal key: %+v", key)
-
 	s, err := b.marshal(data)
 	if err != nil {
 		return nil, err
@@ -419,17 +416,12 @@ func (b *Boxer) seal(data interface{}, key *keybase1.CryptKey) (*chat1.Encrypted
 		E: sealed,
 		N: nonce[:],
 	}
-	b.log().Warning("Boxer.seal data: %+v", enc)
 
 	return enc, nil
 }
 
 // open decrypts chat1.EncryptedData.
 func (b *Boxer) open(data chat1.EncryptedData, key *keybase1.CryptKey) ([]byte, error) {
-
-	b.log().Warning("Boxer.open data: %+v", data)
-	b.log().Warning("Boxer.open key:  %+v", key)
-
 	if len(data.N) != libkb.NaclDHNonceSize {
 		return nil, libkb.DecryptBadNonceError{}
 	}

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -400,6 +400,9 @@ func (b *Boxer) boxMessageWithKeysV1(msg chat1.MessagePlaintext, key *keybase1.C
 
 // seal encrypts data into chat1.EncryptedData.
 func (b *Boxer) seal(data interface{}, key *keybase1.CryptKey) (*chat1.EncryptedData, error) {
+
+	b.log().Warning("Boxer.seal key: %+v", key)
+
 	s, err := b.marshal(data)
 	if err != nil {
 		return nil, err
@@ -416,11 +419,17 @@ func (b *Boxer) seal(data interface{}, key *keybase1.CryptKey) (*chat1.Encrypted
 		E: sealed,
 		N: nonce[:],
 	}
+	b.log().Warning("Boxer.seal data: %+v", enc)
+
 	return enc, nil
 }
 
 // open decrypts chat1.EncryptedData.
 func (b *Boxer) open(data chat1.EncryptedData, key *keybase1.CryptKey) ([]byte, error) {
+
+	b.log().Warning("Boxer.open data: %+v", data)
+	b.log().Warning("Boxer.open key:  %+v", key)
+
 	if len(data.N) != libkb.NaclDHNonceSize {
 		return nil, libkb.DecryptBadNonceError{}
 	}

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -545,12 +545,18 @@ func (b *Boxer) ValidSenderKey(ctx context.Context, sender gregor1.UID, key []by
 		return false, false, nil, libkb.NewTransientChatUnboxingError(fmt.Errorf("no CachedUserLoader available in context"))
 	}
 
-	found, revokedAt, err := cachedUserLoader.CheckKIDForUID(ctx, kbSender, kid)
+	found, revokedAt, deleted, err := cachedUserLoader.CheckKIDForUID(ctx, kbSender, kid)
 	if err != nil {
 		return false, false, nil, libkb.NewTransientChatUnboxingError(err)
 	}
 	if !found {
 		return false, false, nil, nil
+	}
+
+	if deleted {
+		// XXX something else to flag as a deleted key?
+		b.log().Warning("sender %s key %s was deleted", kbSender, kid)
+		return true, true, nil, nil
 	}
 
 	validAtCtime := true

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -90,7 +90,8 @@ func (s *RemoteConversationSource) GetMessages(ctx context.Context, convID chat1
 }
 
 func (s *RemoteConversationSource) GetMessagesWithRemotes(ctx context.Context,
-	convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageBoxed) ([]chat1.MessageUnboxed, error) {
+	convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageBoxed,
+	finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error) {
 	return s.boxer.UnboxMessages(ctx, msgs)
 }
 
@@ -441,7 +442,8 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 }
 
 func (s *HybridConversationSource) GetMessagesWithRemotes(ctx context.Context,
-	convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageBoxed) ([]chat1.MessageUnboxed, error) {
+	convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageBoxed,
+	finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error) {
 
 	var res []chat1.MessageUnboxed
 	var msgIDs []chat1.MessageID
@@ -483,7 +485,7 @@ func (s *HybridConversationSource) GetMessagesWithRemotes(ctx context.Context,
 	}
 
 	// Identify this TLF by running crypt keys
-	if ierr := s.identifyTLF(ctx, convID, uid, res); ierr != nil {
+	if ierr := s.identifyTLF(ctx, convID, uid, res, finalizeInfo); ierr != nil {
 		s.debug("GetMessagesWithRemotes: identify failed: %s", ierr.Error())
 		return nil, ierr
 	}

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -410,19 +410,7 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 			m = rmsgsTab[msgIDs[index]]
 		}
 
-		// XXX can skip this now that finalizeInfo passed to identifyTLF?
-		// XXX or is it good to have the new tlf name put in here?
-		if finalizeInfo != nil {
-			v := m.Valid()
-			v.ClientHeader.TlfName = v.ClientHeader.TLFNameExpanded(finalizeInfo)
-			m = chat1.NewMessageUnboxedWithValid(v)
-		}
 		res = append(res, m)
-	}
-
-	// XXX debug
-	for i, m := range res {
-		s.G().Log.Warning("Message %d: tlf = %q", i, m.Valid().ClientHeader.TlfName)
 	}
 
 	// Identify this TLF by running crypt keys

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -403,14 +403,11 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 	// Form final result
 	var res []chat1.MessageUnboxed
 	for index, msg := range msgs {
-		var m chat1.MessageUnboxed
 		if msg != nil {
-			m = *msg
+			res = append(res, *msg)
 		} else {
-			m = rmsgsTab[msgIDs[index]]
+			res = append(res, rmsgsTab[msgIDs[index]])
 		}
-
-		res = append(res, m)
 	}
 
 	// Identify this TLF by running crypt keys

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -175,7 +175,7 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, convID chat1
 
 	for _, msg := range msgs {
 		if msg.IsValid() {
-			tlfName := chat1.ExpandTLFName(msg.Valid().ClientHeader.TlfName, finalizeInfo)
+			tlfName := msg.Valid().ClientHeader.TLFNameExpanded(finalizeInfo)
 
 			s.debug("identifyTLF: identifying from msg ID: %d name: %s convID: %s",
 				msg.GetMessageID(), tlfName, convID)
@@ -414,7 +414,7 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 		// XXX or is it good to have the new tlf name put in here?
 		if finalizeInfo != nil {
 			v := m.Valid()
-			v.ClientHeader.TlfName = chat1.ExpandTLFName(v.ClientHeader.TlfName, finalizeInfo)
+			v.ClientHeader.TlfName = v.ClientHeader.TLFNameExpanded(finalizeInfo)
 			m = chat1.NewMessageUnboxedWithValid(v)
 		}
 		res = append(res, m)

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -412,13 +412,6 @@ func (s *localizer) localizeConversation(ctx context.Context, uid gregor1.UID,
 		return chat1.ConversationLocal{Error: &errMsg}
 	}
 
-	// If the conversation was finalized, change the TLF name.
-	/*
-		if conversationLocal.Info.FinalizeInfo != nil {
-			conversationLocal.Info.TlfName += " " + conversationLocal.Info.FinalizeInfo.ResetFull
-		}
-	*/
-
 	// Only do this check if there is a chance the TLF name might be an SBS name.
 	if strings.Contains(conversationLocal.Info.TlfName, "@") {
 		info, err := LookupTLF(ctx, s.getTlfInterface(), conversationLocal.Info.TLFNameExpanded(), conversationLocal.Info.Visibility)

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -89,19 +89,12 @@ func (s *RemoteInboxSource) Read(ctx context.Context, uid gregor1.UID,
 		if rquery != nil && rquery.TlfID != nil {
 			// inbox query contained a TLF name, so check to make sure that
 			// the conversation from the server matches tlfInfo from kbfs
-			/*
-				 XXX temp...make a version of tlfname that contains reset suffix
-				if convLocal.Info.TlfName != tlfInfo.CanonicalName {
-					return Inbox{}, ib.RateLimit, fmt.Errorf("server conversation TLF name mismatch: %s, expected %s", convLocal.Info.TlfName, tlfInfo.CanonicalName)
-				}
-			*/
-
-			/*
-				XXX temp ANY coming back for some reason on finalized tlf
-				if convLocal.Info.Visibility != rquery.Visibility() {
-					return Inbox{}, ib.RateLimit, fmt.Errorf("server conversation TLF visibility mismatch: %s, expected %s", convLocal.Info.Visibility, rquery.Visibility())
-				}
-			*/
+			if convLocal.Info.TLFNameExpanded() != tlfInfo.CanonicalName {
+				return Inbox{}, ib.RateLimit, fmt.Errorf("server conversation TLF name mismatch: %s, expected %s", convLocal.Info.TLFNameExpanded(), tlfInfo.CanonicalName)
+			}
+			if convLocal.Info.Visibility != rquery.Visibility() {
+				return Inbox{}, ib.RateLimit, fmt.Errorf("server conversation TLF visibility mismatch: %s, expected %s", convLocal.Info.Visibility, rquery.Visibility())
+			}
 			if !tlfInfo.ID.Eq(convLocal.Info.Triple.Tlfid) {
 				return Inbox{}, ib.RateLimit, fmt.Errorf("server conversation TLF ID mismatch: %s, expected %s", convLocal.Info.Triple.Tlfid, tlfInfo.ID)
 			}

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -413,13 +413,15 @@ func (s *localizer) localizeConversation(ctx context.Context, uid gregor1.UID,
 	}
 
 	// If the conversation was finalized, change the TLF name.
-	if conversationLocal.Info.FinalizeInfo != nil {
-		conversationLocal.Info.TlfName += " " + conversationLocal.Info.FinalizeInfo.ResetFull
-	}
+	/*
+		if conversationLocal.Info.FinalizeInfo != nil {
+			conversationLocal.Info.TlfName += " " + conversationLocal.Info.FinalizeInfo.ResetFull
+		}
+	*/
 
 	// Only do this check if there is a chance the TLF name might be an SBS name.
 	if strings.Contains(conversationLocal.Info.TlfName, "@") {
-		info, err := LookupTLF(ctx, s.getTlfInterface(), conversationLocal.Info.TlfName, conversationLocal.Info.Visibility)
+		info, err := LookupTLF(ctx, s.getTlfInterface(), conversationLocal.Info.TLFNameExpanded(), conversationLocal.Info.Visibility)
 		if err != nil {
 			errMsg := err.Error()
 			return chat1.ConversationLocal{Error: &errMsg}

--- a/go/chat/utils.go
+++ b/go/chat/utils.go
@@ -266,7 +266,7 @@ func AppendTLFResetSuffix(msgs []chat1.MessageBoxed, finalizeInfo *chat1.Convers
 
 	mod := make([]chat1.MessageBoxed, len(msgs))
 	for i, m := range msgs {
-		m.ClientHeader.TlfName += " " + finalizeInfo.ResetFull
+		m.ClientHeader.TlfName = chat1.ExpandTLFName(m.ClientHeader.TlfName, finalizeInfo)
 		mod[i] = m
 	}
 	return mod

--- a/go/chat/utils.go
+++ b/go/chat/utils.go
@@ -254,3 +254,20 @@ func IsVisibleChatMessageType(messageType chat1.MessageType) bool {
 	}
 	return false
 }
+
+func AppendTLFResetSuffix(msgs []chat1.MessageBoxed, finalizeInfo *chat1.ConversationFinalizeInfo) []chat1.MessageBoxed {
+	if finalizeInfo == nil {
+		return msgs
+	}
+
+	if len(finalizeInfo.ResetFull) == 0 {
+		return msgs
+	}
+
+	mod := make([]chat1.MessageBoxed, len(msgs))
+	for i, m := range msgs {
+		m.ClientHeader.TlfName += " " + finalizeInfo.ResetFull
+		mod[i] = m
+	}
+	return mod
+}

--- a/go/chat/utils.go
+++ b/go/chat/utils.go
@@ -266,7 +266,7 @@ func AppendTLFResetSuffix(msgs []chat1.MessageBoxed, finalizeInfo *chat1.Convers
 
 	mod := make([]chat1.MessageBoxed, len(msgs))
 	for i, m := range msgs {
-		m.ClientHeader.TlfName = chat1.ExpandTLFName(m.ClientHeader.TlfName, finalizeInfo)
+		m.ClientHeader.TlfName = m.ClientHeader.TLFNameExpanded(finalizeInfo)
 		mod[i] = m
 	}
 	return mod

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -76,6 +76,11 @@ func (v conversationListView) convName(g *libkb.GlobalContext, conv chat1.Conver
 	if len(conv.Info.ReaderNames) > 0 {
 		name += "#" + strings.Join(conv.Info.ReaderNames, ",")
 	}
+
+	if conv.Info.FinalizeInfo != nil {
+		name += " " + conv.Info.FinalizeInfo.BeforeSummary()
+	}
+
 	return name
 }
 

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -34,6 +34,10 @@ func (v conversationInfoListView) show(g *libkb.GlobalContext) error {
 		if conv.Info.Visibility == chat1.TLFVisibility_PUBLIC {
 			vis = "public"
 		}
+		var reset string
+		if conv.Info.FinalizeInfo != nil {
+			reset = conv.Info.FinalizeInfo.BeforeSummary()
+		}
 		table.Insert(flexibletable.Row{
 			flexibletable.Cell{
 				Frame:     [2]string{"[", "]"},
@@ -48,10 +52,14 @@ func (v conversationInfoListView) show(g *libkb.GlobalContext) error {
 				Alignment: flexibletable.Left,
 				Content:   flexibletable.MultiCell{Sep: ",", Items: participants},
 			},
+			flexibletable.Cell{
+				Alignment: flexibletable.Left,
+				Content:   flexibletable.SingleCell{Item: reset},
+			},
 		})
 	}
 	if err := table.Render(ui.OutputWriter(), " ", w, []flexibletable.ColumnConstraint{
-		5, 8, flexibletable.ExpandableWrappable,
+		5, 8, flexibletable.ExpandableWrappable, flexibletable.ExpandableWrappable,
 	}); err != nil {
 		return fmt.Errorf("rendering conversation info list view error: %v\n", err)
 	}

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -228,10 +228,10 @@ func (r *chatConversationResolver) Resolve(ctx context.Context, req chatConversa
 			if info.Triple.TopicType == chat1.TopicType_CHAT {
 				r.G.UI.GetTerminalUI().Printf("Found %s %s conversation: %s\n",
 					info.Visibility,
-					info.Triple.TopicType, info.TlfName)
+					info.Triple.TopicType, info.TLFNameExpandedSummary())
 			} else {
 				r.G.UI.GetTerminalUI().Printf("Found %s %s conversation [%s]: %s\n",
-					info.Visibility, info.Triple.TopicType, info.TopicName, info.TlfName)
+					info.Visibility, info.Triple.TopicType, info.TopicName, info.TLFNameExpandedSummary())
 			}
 		}
 		return &info, false, nil

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -87,9 +87,10 @@ func (c *chatServiceHandler) ListV1(ctx context.Context, opts listOptionsV1) Rep
 						Public:    pub,
 						TopicType: strings.ToLower(conv.Metadata.IdTriple.TopicType.String()),
 					},
-					Unread:     convUnread,
-					ActiveAt:   convMtime.UnixSeconds(),
-					ActiveAtMs: convMtime.UnixMilliseconds(),
+					Unread:       convUnread,
+					ActiveAt:     convMtime.UnixSeconds(),
+					ActiveAtMs:   convMtime.UnixMilliseconds(),
+					FinalizeInfo: conv.Metadata.FinalizeInfo,
 				}
 				maxID = msg.ServerHeader.MessageID
 			}
@@ -938,11 +939,12 @@ type Thread struct {
 
 // ConvSummary is used for JSON output of a conversation in the inbox.
 type ConvSummary struct {
-	ID         string      `json:"id"`
-	Channel    ChatChannel `json:"channel"`
-	Unread     bool        `json:"unread"`
-	ActiveAt   int64       `json:"active_at"`
-	ActiveAtMs int64       `json:"active_at_ms"`
+	ID           string                          `json:"id"`
+	Channel      ChatChannel                     `json:"channel"`
+	Unread       bool                            `json:"unread"`
+	ActiveAt     int64                           `json:"active_at"`
+	ActiveAtMs   int64                           `json:"active_at_ms"`
+	FinalizeInfo *chat1.ConversationFinalizeInfo `json:"finalize_info,omitempty"`
 }
 
 // ChatList is a list of conversations in the inbox.

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -78,7 +78,7 @@ func (c *chatServiceHandler) ListV1(ctx context.Context, opts listOptionsV1) Rep
 		maxID := chat1.MessageID(0)
 		for _, msg := range conv.MaxMsgs {
 			if msg.ServerHeader.MessageID > maxID {
-				tlf := msg.ClientHeader.TlfName
+				tlf := msg.ClientHeader.TLFNameExpanded(conv.Metadata.FinalizeInfo)
 				pub := msg.ClientHeader.TlfPublic
 				cl.Conversations[i] = ConvSummary{
 					ID: conv.Metadata.ConversationID.String(),

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -137,10 +137,8 @@ func TestIdEllen(t *testing.T) {
 	tc := SetupEngineTest(t, "id")
 	defer tc.Cleanup()
 	idUI, _, err := runIdentify(&tc, "t_ellen")
-	if err == nil {
-		t.Fatal("Expected no sigchain error.")
-	} else if _, ok := err.(libkb.NoSigChainError); !ok {
-		t.Fatalf("error: %T, expected NoSigChainError", err)
+	if err != nil {
+		t.Fatal(err)
 	}
 	checkDisplayKeys(t, idUI, 0, 0)
 }

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -866,27 +866,8 @@ func TestIdentify2NoSigchain(t *testing.T) {
 	ctx := Context{IdentifyUI: i}
 
 	err := eng.Run(&ctx)
-	if err == nil {
-		t.Fatal("identify2 ran successfully on user with no sigchain")
-	}
-	serr, ok := err.(libkb.NoSigChainError)
-	if !ok {
-		t.Fatalf("error: %T, expected libkb.NoSigChainError", err)
-	}
-
-	// make sure exported:
-	s := serr.ToStatus()
-	if s.Code != libkb.SCKeyNoEldest {
-		t.Errorf("status code: %v, expected %v", s.Code, libkb.SCKeyNoEldest)
-	}
-
-	// and importable:
-	ierr := libkb.ImportStatusAsError(&s)
-	if ierr == nil {
-		t.Fatal("import of SCKeyNoEldest returned nil")
-	}
-	if _, ok := ierr.(libkb.NoSigChainError); !ok {
-		t.Errorf("imported status error: %T, expected libkb.NoSigChainError", ierr)
+	if err != nil {
+		t.Fatalf("identify2 failed on user with no keys: %s", err)
 	}
 
 	// kbfs would like to have some info about the user

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -660,7 +660,9 @@ func (e *Identify2WithUID) runIdentifyUI(ctx *Context) (err error) {
 		return err
 	}
 
-	if err = them.IDTable().Identify(ctx.GetNetContext(), e.state, e.forceRemoteCheck(), iui, e); err != nil {
+	if them.IDTable() == nil {
+		e.G().Log.Debug("| No IDTable for user")
+	} else if err = them.IDTable().Identify(ctx.GetNetContext(), e.state, e.forceRemoteCheck(), iui, e); err != nil {
 		e.G().Log.Debug("| Failure in running IDTable")
 		return err
 	}
@@ -785,6 +787,7 @@ func (e *Identify2WithUID) loadThem(ctx *Context) (err error) {
 	arg := libkb.NewLoadUserArg(e.G())
 	arg.UID = e.arg.Uid
 	arg.ResolveBody = e.ResolveBody
+	arg.PublicKeyOptional = true
 	e.them, err = loadIdentifyUser(ctx, e.G(), arg, e.getCache())
 	if err != nil {
 		switch err.(type) {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -527,9 +527,9 @@ type ConversationSource interface {
 		pagination *chat1.Pagination) (chat1.ThreadView, []*chat1.RateLimit, error)
 	PullLocalOnly(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, query *chat1.GetThreadQuery,
 		pagination *chat1.Pagination) (chat1.ThreadView, error)
-	GetMessages(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgIDs []chat1.MessageID) ([]chat1.MessageUnboxed, error)
+	GetMessages(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgIDs []chat1.MessageID, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
 	GetMessagesWithRemotes(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
-		msgs []chat1.MessageBoxed) ([]chat1.MessageUnboxed, error)
+		msgs []chat1.MessageBoxed, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
 	Clear(convID chat1.ConversationID, uid gregor1.UID) error
 }
 

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -964,6 +964,7 @@ func (u *User) ExportToUserPlusKeys(idTime keybase1.Time) keybase1.UserPlusKeys 
 		// these will be added to UserPlusKeys
 		// deletedDeviceKeys := ckf.ExportDeletedDeviceKeys()
 		// u.G().Log.Warning("deleted device keys: %+v", deletedDeviceKeys)
+		ret.DeletedDeviceKeys = ckf.ExportDeletedDeviceKeys()
 	}
 
 	ret.Uvv = u.ExportToVersionVector(idTime)

--- a/go/libkb/upak.go
+++ b/go/libkb/upak.go
@@ -32,24 +32,29 @@ func checkKIDPGP(u *keybase1.UserPlusAllKeys, kid keybase1.KID) (found bool) {
 	return false
 }
 
-func checkKIDKeybase(u *keybase1.UserPlusAllKeys, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime) {
+func checkKIDKeybase(u *keybase1.UserPlusAllKeys, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool) {
 	for _, key := range u.Base.DeviceKeys {
 		if key.KID.Equal(kid) {
-			return true, nil
+			return true, nil, false
 		}
 	}
 	for _, key := range u.Base.RevokedDeviceKeys {
 		if key.Key.KID.Equal(kid) {
-			return true, &key.Time
+			return true, &key.Time, false
 		}
 	}
-	return false, nil
+	for _, key := range u.Base.DeletedDeviceKeys {
+		if key.KID.Equal(kid) {
+			return true, nil, true
+		}
+	}
+	return false, nil, false
 }
 
-func CheckKID(u *keybase1.UserPlusAllKeys, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime) {
+func CheckKID(u *keybase1.UserPlusAllKeys, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool) {
 	if IsPGPAlgo(AlgoType(kid.GetKeyType())) {
 		found = checkKIDPGP(u, kid)
-		return found, nil
+		return found, nil, false
 	}
 	return checkKIDKeybase(u, kid)
 }

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -15,7 +15,7 @@ import (
 type UPAKLoader interface {
 	ClearMemory()
 	Load(arg LoadUserArg) (ret *keybase1.UserPlusAllKeys, user *User, err error)
-	CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, err error)
+	CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool, err error)
 	LoadUserPlusKeys(ctx context.Context, uid keybase1.UID) (keybase1.UserPlusKeys, error)
 	Invalidate(ctx context.Context, uid keybase1.UID)
 	LoadDeviceKey(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (upk *keybase1.UserPlusAllKeys, deviceKey *keybase1.PublicKey, revoked *keybase1.RevokedKey, err error)
@@ -296,7 +296,7 @@ func (u *CachedUPAKLoader) Load(arg LoadUserArg) (ret *keybase1.UserPlusAllKeys,
 	return u.loadWithInfo(arg, nil)
 }
 
-func (u *CachedUPAKLoader) CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, err error) {
+func (u *CachedUPAKLoader) CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool, err error) {
 
 	var info CachedUserLoadInfo
 	larg := NewLoadUserByUIDArg(ctx, u.G(), uid)
@@ -304,19 +304,19 @@ func (u *CachedUPAKLoader) CheckKIDForUID(ctx context.Context, uid keybase1.UID,
 	upk, _, err := u.loadWithInfo(larg, &info)
 
 	if err != nil {
-		return false, nil, err
+		return false, nil, false, err
 	}
-	found, revokedAt = CheckKID(upk, kid)
+	found, revokedAt, deleted = CheckKID(upk, kid)
 	if found || info.LoadedLeaf || info.LoadedUser {
-		return found, revokedAt, nil
+		return found, revokedAt, deleted, nil
 	}
 	larg.ForceReload = true
 	upk, _, err = u.loadWithInfo(larg, nil)
 	if err != nil {
-		return false, nil, err
+		return false, nil, false, err
 	}
-	found, revokedAt = CheckKID(upk, kid)
-	return found, revokedAt, nil
+	found, revokedAt, deleted = CheckKID(upk, kid)
+	return found, revokedAt, deleted, nil
 }
 
 func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UID) (keybase1.UserPlusKeys, error) {

--- a/go/libkb/upak_loader_test.go
+++ b/go/libkb/upak_loader_test.go
@@ -6,11 +6,12 @@
 package libkb
 
 import (
+	"testing"
+	"time"
+
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/clockwork"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestCachedUserLoad(t *testing.T) {
@@ -79,21 +80,21 @@ func TestCheckKIDForUID(t *testing.T) {
 	rebeccaUID := keybase1.UID("99337e411d1004050e9e7ee2cf1a6219")
 	rebeccaKIDRevoked := keybase1.KID("0120e177772304cd9ec833ceb88eeb6e32a667151d9e4fb09df433a846d05e6c40350a")
 
-	found, revokedAt, err := tc.G.GetUPAKLoader().CheckKIDForUID(nil, georgeUID, georgeKIDSibkey)
-	if !found || (revokedAt != nil) || (err != nil) {
+	found, revokedAt, deleted, err := tc.G.GetUPAKLoader().CheckKIDForUID(nil, georgeUID, georgeKIDSibkey)
+	if !found || (revokedAt != nil) || deleted || (err != nil) {
 		t.Fatalf("bad CheckKIDForUID response")
 	}
-	found, revokedAt, err = tc.G.GetUPAKLoader().CheckKIDForUID(nil, georgeUID, georgeKIDSubkey)
-	if !found || (revokedAt != nil) || (err != nil) {
+	found, revokedAt, deleted, err = tc.G.GetUPAKLoader().CheckKIDForUID(nil, georgeUID, georgeKIDSubkey)
+	if !found || (revokedAt != nil) || deleted || (err != nil) {
 		t.Fatalf("bad CheckKIDForUID response")
 	}
-	found, revokedAt, err = tc.G.GetUPAKLoader().CheckKIDForUID(nil, georgeUID, kbKIDSibkey)
-	if found || (revokedAt != nil) || (err != nil) {
+	found, revokedAt, deleted, err = tc.G.GetUPAKLoader().CheckKIDForUID(nil, georgeUID, kbKIDSibkey)
+	if found || (revokedAt != nil) || deleted || (err != nil) {
 		t.Fatalf("bad CheckKIDForUID response")
 	}
 
-	found, revokedAt, err = tc.G.GetUPAKLoader().CheckKIDForUID(nil, rebeccaUID, rebeccaKIDRevoked)
-	if !found || (revokedAt == nil) || (err != nil) {
+	found, revokedAt, deleted, err = tc.G.GetUPAKLoader().CheckKIDForUID(nil, rebeccaUID, rebeccaKIDRevoked)
+	if !found || (revokedAt == nil) || deleted || (err != nil) {
 		t.Fatalf("bad CheckKIDForUID response")
 	}
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -226,14 +226,30 @@ func (q *GetInboxQuery) Visibility() TLFVisibility {
 	return visibility
 }
 
+// TLFNameExpanded returns a TLF name with a reset suffix if it exists.
+// This version can be used in requests to lookup the TLF.
 func (c ConversationInfoLocal) TLFNameExpanded() string {
 	return ExpandTLFName(c.TlfName, c.FinalizeInfo)
 }
 
+// TLFNameExpandedSummary returns a TLF name with a summary of the
+// account reset if there was one.
+// This version is for display purposes only and connot be used to lookup the TLF.
+func (c ConversationInfoLocal) TLFNameExpandedSummary() string {
+	if c.FinalizeInfo == nil {
+		return c.TlfName
+	}
+	return c.TlfName + " " + c.FinalizeInfo.BeforeSummary()
+}
+
+// TLFNameExpanded returns a TLF name with a reset suffix if it exists.
+// This version can be used in requests to lookup the TLF.
 func (h MessageClientHeader) TLFNameExpanded(finalizeInfo *ConversationFinalizeInfo) string {
 	return ExpandTLFName(h.TlfName, finalizeInfo)
 }
 
+// ExpandTLFName returns a TLF name with a reset suffix if it exists.
+// This version can be used in requests to lookup the TLF.
 func ExpandTLFName(name string, finalizeInfo *ConversationFinalizeInfo) string {
 	if finalizeInfo == nil {
 		return name
@@ -245,4 +261,8 @@ func ExpandTLFName(name string, finalizeInfo *ConversationFinalizeInfo) string {
 		return name
 	}
 	return name + " " + finalizeInfo.ResetFull
+}
+
+func (f *ConversationFinalizeInfo) BeforeSummary() string {
+	return fmt.Sprintf("(before %s account reset %s)", f.ResetUser, f.ResetDate)
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -263,6 +263,9 @@ func ExpandTLFName(name string, finalizeInfo *ConversationFinalizeInfo) string {
 	return name + " " + finalizeInfo.ResetFull
 }
 
+// BeforeSummary returns a summary of the finalize without "files" in it.
+// The canonical name for a TLF after reset has a "(files before ... account reset...)" suffix
+// which doesn't make much sense in other uses (like chat).
 func (f *ConversationFinalizeInfo) BeforeSummary() string {
 	return fmt.Sprintf("(before %s account reset %s)", f.ResetUser, f.ResetDate)
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // Eq compares two TLFIDs
@@ -223,4 +224,21 @@ func (q *GetInboxQuery) Visibility() TLFVisibility {
 		visibility = TLFVisibility_PUBLIC
 	}
 	return visibility
+}
+
+func (c ConversationInfoLocal) TLFNameExpanded() string {
+	return ExpandTLFName(c.TlfName, c.FinalizeInfo)
+}
+
+func ExpandTLFName(name string, finalizeInfo *ConversationFinalizeInfo) string {
+	if finalizeInfo == nil {
+		return name
+	}
+	if len(finalizeInfo.ResetFull) == 0 {
+		return name
+	}
+	if strings.Contains(name, " account reset ") {
+		return name
+	}
+	return name + " " + finalizeInfo.ResetFull
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -230,6 +230,10 @@ func (c ConversationInfoLocal) TLFNameExpanded() string {
 	return ExpandTLFName(c.TlfName, c.FinalizeInfo)
 }
 
+func (h MessageClientHeader) TLFNameExpanded(finalizeInfo *ConversationFinalizeInfo) string {
+	return ExpandTLFName(h.TlfName, finalizeInfo)
+}
+
 func ExpandTLFName(name string, finalizeInfo *ConversationFinalizeInfo) string {
 	if finalizeInfo == nil {
 		return name

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -190,6 +190,7 @@ type UserPlusKeys struct {
 	RevokedDeviceKeys []RevokedKey      `codec:"revokedDeviceKeys" json:"revokedDeviceKeys"`
 	PGPKeyCount       int               `codec:"pgpKeyCount" json:"pgpKeyCount"`
 	Uvv               UserVersionVector `codec:"uvv" json:"uvv"`
+	DeletedDeviceKeys []PublicKey       `codec:"deletedDeviceKeys" json:"deletedDeviceKeys"`
 }
 
 type RemoteTrack struct {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -589,6 +589,9 @@ func (h *chatLocalHandler) GetMessagesLocal(ctx context.Context, arg chat1.GetMe
 		return deflt, err
 	}
 
+	// XXX if arg.ConversationID is a finalized TLF, the TLF name in boxed.Msgs
+	// needs to be adjusted.
+
 	messages, err := h.boxer.UnboxMessages(ctx, boxed.Msgs)
 	if err != nil {
 		return deflt, err

--- a/go/service/tlf.go
+++ b/go/service/tlf.go
@@ -5,7 +5,6 @@ package service
 
 import (
 	"fmt"
-	"runtime/debug"
 
 	"golang.org/x/net/context"
 
@@ -65,8 +64,6 @@ func (h *tlfHandler) CryptKeys(ctx context.Context, arg keybase1.TLFQuery) (keyb
 	if err != nil {
 		return keybase1.GetTLFCryptKeysRes{}, err
 	}
-
-	debug.PrintStack()
 
 	resp, err := tlfClient.GetTLFCryptKeys(ctx, arg)
 	if err != nil {

--- a/go/service/tlf.go
+++ b/go/service/tlf.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"golang.org/x/net/context"
 
@@ -64,6 +65,8 @@ func (h *tlfHandler) CryptKeys(ctx context.Context, arg keybase1.TLFQuery) (keyb
 	if err != nil {
 		return keybase1.GetTLFCryptKeysRes{}, err
 	}
+
+	debug.PrintStack()
 
 	resp, err := tlfClient.GetTLFCryptKeys(ctx, arg)
 	if err != nil {

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -154,6 +154,10 @@ protocol Common {
       int pgpKeyCount;
 
       UserVersionVector uvv;
+      
+      // deletedDeviceKeys is a list of deleted device keys.
+      // (i.e. keys that were used before an account reset)
+      array<PublicKey> deletedDeviceKeys;
   }
 
   record RemoteTrack {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4152,6 +4152,7 @@ export type UserPlusKeys = {
   revokedDeviceKeys?: ?Array<RevokedKey>,
   pgpKeyCount: int,
   uvv: UserVersionVector,
+  deletedDeviceKeys?: ?Array<PublicKey>,
 }
 
 export type UserResolution = {

--- a/protocol/json/keybase1/common.json
+++ b/protocol/json/keybase1/common.json
@@ -378,6 +378,13 @@
         {
           "type": "UserVersionVector",
           "name": "uvv"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "PublicKey"
+          },
+          "name": "deletedDeviceKeys"
         }
       ]
     },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4152,6 +4152,7 @@ export type UserPlusKeys = {
   revokedDeviceKeys?: ?Array<RevokedKey>,
   pgpKeyCount: int,
   uvv: UserVersionVector,
+  deletedDeviceKeys?: ?Array<PublicKey>,
 }
 
 export type UserResolution = {


### PR DESCRIPTION
This PR makes chat work after account reset in CLI, json api.

Some notes:

1. I have not tried this with the GUI.  The design specifies a different display than CLI where the messages before the account reset show up in the same conversation.  Will talk to those involved and figure out the state of all that.
1. the user who performed the account reset will not be able to read the old conversation due to kbfs rekeying policy
1. all of this testing was done manually with a hacked up local mdserver.  When KBFS-1821 completed, automated tests should be written as this is some hairy stuff...