### PR TITLE
Display newlines inside chat messages

### DIFF
--- a/shared/chat/conversation/messages/text.desktop.js
+++ b/shared/chat/conversation/messages/text.desktop.js
@@ -34,4 +34,5 @@ export default class MessageTextComponent extends PureComponent<void, Props & {o
 const _messageTextStyle = {
   marginTop: globalMargins.xtiny,
   flex: 1,
+  whiteSpace: 'pre-wrap',
 }


### PR DESCRIPTION
@keybase/react-hackers 

Before this PR, messages like:
```
foo
bar
```
would be displayed as
```
foo bar
```