### PR TITLE
cache results of GetInboxRemote CORE-4186

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --update fuse jq bash openssl && \
 USER keybase
 WORKDIR /home/keybase
 
-ENV KEYBASE_DEBUG=1 \
+ENV KEYBASE_DEBUG=0 \
     KEYBASE_RUN_MODE=devel \
     KEYBASE_SERVER_URI="http://kbweb.local:3000" \
     PATH=/home/keybase:$PATH

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --update fuse jq bash openssl && \
 USER keybase
 WORKDIR /home/keybase
 
-ENV KEYBASE_DEBUG=0 \
+ENV KEYBASE_DEBUG=1 \
     KEYBASE_RUN_MODE=devel \
     KEYBASE_SERVER_URI="http://kbweb.local:3000" \
     PATH=/home/keybase:$PATH

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -37,20 +37,20 @@ type Boxer struct {
 	tlf    keybase1.TlfInterface
 	hashV1 func(data []byte) chat1.Hash
 	sign   func(msg []byte, kp libkb.NaclSigningKeyPair, prefix libkb.SignaturePrefix) (chat1.SignatureInfo, error) // replaceable for testing
-	kbCtx  KeybaseContext
+	libkb.Contextified
 }
 
-func NewBoxer(kbCtx KeybaseContext, tlf keybase1.TlfInterface) *Boxer {
+func NewBoxer(g *libkb.GlobalContext, tlf keybase1.TlfInterface) *Boxer {
 	return &Boxer{
-		tlf:    tlf,
-		hashV1: hashSha256V1,
-		sign:   sign,
-		kbCtx:  kbCtx,
+		tlf:          tlf,
+		hashV1:       hashSha256V1,
+		sign:         sign,
+		Contextified: libkb.NewContextified(g),
 	}
 }
 
 func (b *Boxer) log() logger.Logger {
-	return b.kbCtx.GetLog()
+	return b.G().GetLog()
 }
 
 func (b *Boxer) makeErrorMessage(msg chat1.MessageBoxed, err error) chat1.MessageUnboxed {
@@ -256,7 +256,7 @@ func (b *Boxer) UnboxThread(ctx context.Context, boxed chat1.ThreadViewBoxed, co
 }
 
 func (b *Boxer) getUsernameAndDevice(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (string, string, string, error) {
-	nun, devName, devType, err := b.kbCtx.GetUPAKLoader().LookupUsernameAndDevice(ctx, uid, deviceID)
+	nun, devName, devType, err := b.G().GetUPAKLoader().LookupUsernameAndDevice(ctx, uid, deviceID)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -283,7 +283,7 @@ func (b *Boxer) UnboxMessages(ctx context.Context, boxed []chat1.MessageBoxed) (
 
 // Can return (nil, nil) if there is no saved merkle root.
 func (b *Boxer) latestMerkleRoot() (*chat1.MerkleRoot, error) {
-	merkleClient := b.kbCtx.GetMerkleClient()
+	merkleClient := b.G().GetMerkleClient()
 	if merkleClient == nil {
 		return nil, fmt.Errorf("no MerkleClient available")
 	}
@@ -541,7 +541,7 @@ func (b *Boxer) ValidSenderKey(ctx context.Context, sender gregor1.UID, key []by
 	kid := keybase1.KIDFromSlice(key)
 	ctime2 := gregor1.FromTime(ctime)
 
-	cachedUserLoader := b.kbCtx.GetUPAKLoader()
+	cachedUserLoader := b.G().GetUPAKLoader()
 	if cachedUserLoader == nil {
 		return false, false, nil, libkb.NewTransientChatUnboxingError(fmt.Errorf("no CachedUserLoader available in context"))
 	}

--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -3,21 +3,8 @@ package chat
 import (
 	"context"
 
-	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/clockwork"
 )
-
-// KeybaseContext defines what chat needs from Keybase
-type KeybaseContext interface {
-	GetLog() logger.Logger
-	LoadUserByUID(uid keybase1.UID) (*libkb.User, error)
-	UIDToUsername(uid keybase1.UID) (libkb.NormalizedUsername, error)
-	Clock() clockwork.Clock
-	GetUPAKLoader() libkb.UPAKLoader
-	GetMerkleClient() *libkb.MerkleClient
-}
 
 type identifyModeKey int
 type keyfinderKey int

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -79,7 +79,7 @@ func (s *RemoteConversationSource) GetMessages(ctx context.Context, convID chat1
 		MessageIDs:     msgIDs,
 	})
 
-	rres.Msgs = AppendTLFResetSuffix(rres.Msgs, finalizeInfo)
+	rres.Msgs = utils.AppendTLFResetSuffix(rres.Msgs, finalizeInfo)
 
 	msgs, err := s.boxer.UnboxMessages(ctx, rres.Msgs)
 	if err != nil {
@@ -264,7 +264,7 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 		return chat1.ThreadView{}, rl, err
 	}
 
-	boxed.Thread.Messages = AppendTLFResetSuffix(boxed.Thread.Messages, conv.Metadata.FinalizeInfo)
+	boxed.Thread.Messages = utils.AppendTLFResetSuffix(boxed.Thread.Messages, conv.Metadata.FinalizeInfo)
 
 	// Unbox
 	thread, err := s.boxer.UnboxThread(ctx, boxed.Thread, convID)
@@ -385,7 +385,7 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 			return nil, err
 		}
 
-		rmsgs.Msgs = AppendTLFResetSuffix(rmsgs.Msgs, finalizeInfo)
+		rmsgs.Msgs = utils.AppendTLFResetSuffix(rmsgs.Msgs, finalizeInfo)
 
 		// Unbox all the remote messages
 		rmsgsUnboxed, err := s.boxer.UnboxMessages(ctx, rmsgs.Msgs)

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/keybase/client/go/chat/storage"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
@@ -96,6 +97,8 @@ func (s *RemoteConversationSource) GetMessagesWithRemotes(ctx context.Context,
 
 type HybridConversationSource struct {
 	libkb.Contextified
+	utils.DebugLabeler
+
 	ri      func() chat1.RemoteInterface
 	boxer   *Boxer
 	storage *storage.Storage
@@ -105,14 +108,11 @@ func NewHybridConversationSource(g *libkb.GlobalContext, b *Boxer, storage *stor
 	ri func() chat1.RemoteInterface) *HybridConversationSource {
 	return &HybridConversationSource{
 		Contextified: libkb.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "HybridConversationSource"),
 		ri:           ri,
 		boxer:        b,
 		storage:      storage,
 	}
-}
-
-func (s *HybridConversationSource) debug(msg string, args ...interface{}) {
-	s.G().Log.Debug("HybridConversationSource: "+msg, args...)
 }
 
 func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.ConversationID,
@@ -176,8 +176,7 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, convID chat1
 	for _, msg := range msgs {
 		if msg.IsValid() {
 			tlfName := msg.Valid().ClientHeader.TLFNameExpanded(finalizeInfo)
-
-			s.debug("identifyTLF: identifying from msg ID: %d name: %s convID: %s",
+			s.Debug(ctx, "identifyTLF: identifying from msg ID: %d name: %s convID: %s",
 				msg.GetMessageID(), tlfName, convID)
 
 			vis := chat1.TLFVisibility_PRIVATE
@@ -185,14 +184,14 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, convID chat1
 				vis = chat1.TLFVisibility_PUBLIC
 			}
 			if _, err := LookupTLF(ctx, s.boxer.tlf, tlfName, vis); err != nil {
-				s.debug("identifyTLF: failure: name: %s convID: %s", tlfName, convID)
+				s.Debug(ctx, "identifyTLF: failure: name: %s convID: %s", tlfName, convID)
 				return err
 			}
 			return nil
 		}
 	}
 
-	s.debug("identifyTLF: no identify performed, no valid messages found")
+	s.Debug(ctx, "identifyTLF: no identify performed, no valid messages found")
 	return nil
 }
 
@@ -213,11 +212,11 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 		localData, err := s.storage.Fetch(ctx, conv, uid, query, pagination)
 		if err == nil {
 			// If found, then return the stuff
-			s.debug("Pull: cache hit: convID: %s uid: %s", convID, uid)
+			s.Debug(ctx, "Pull: cache hit: convID: %s uid: %s", convID, uid)
 
 			// Identify this TLF by running crypt keys
 			if ierr := s.identifyTLF(ctx, convID, uid, localData.Messages, conv.Metadata.FinalizeInfo); ierr != nil {
-				s.debug("Pull: identify failed: %s", ierr.Error())
+				s.Debug(ctx, "Pull: identify failed: %s", ierr.Error())
 				return chat1.ThreadView{}, nil, ierr
 			}
 
@@ -244,7 +243,7 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 			return localData, rl, nil
 		}
 	} else {
-		s.debug("Pull: error fetching conv metadata: convID: %s uid: %s err: %s", convID, uid,
+		s.Debug(ctx, "Pull: error fetching conv metadata: convID: %s uid: %s err: %s", convID, uid,
 			err.Error())
 	}
 
@@ -298,7 +297,7 @@ func (s *HybridConversationSource) updateMessage(ctx context.Context, message ch
 		m := message.Valid()
 		if m.HeaderSignature == nil {
 			// Skip revocation check for messages cached before the sig was part of the cache.
-			s.debug("updateMessage skipping message (%v) with no cached HeaderSignature", m.ServerHeader.MessageID)
+			s.Debug(ctx, "updateMessage skipping message (%v) with no cached HeaderSignature", m.ServerHeader.MessageID)
 			return message, nil
 		}
 
@@ -334,7 +333,7 @@ func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID cha
 	// Identify this TLF by running crypt keys
 	// XXX might need finalize info
 	if ierr := s.identifyTLF(ctx, convID, uid, tv.Messages, nil); ierr != nil {
-		s.debug("PullLocalOnly: identify failed: %s", ierr.Error())
+		s.Debug(ctx, "PullLocalOnly: identify failed: %s", ierr.Error())
 		return chat1.ThreadView{}, ierr
 	}
 
@@ -370,7 +369,7 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 	}
 
 	// Grab message from remote
-	s.debug("GetMessages: convID: %s uid: %s total msgs: %d remote: %d", convID, uid, len(msgIDs),
+	s.Debug(ctx, "GetMessages: convID: %s uid: %s total msgs: %d remote: %d", convID, uid, len(msgIDs),
 		len(remoteMsgs))
 	if len(remoteMsgs) > 0 {
 		rmsgs, err := s.ri().GetMessagesRemote(ctx, chat1.GetMessagesRemoteArg{
@@ -412,7 +411,7 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 
 	// Identify this TLF by running crypt keys
 	if ierr := s.identifyTLF(ctx, convID, uid, res, finalizeInfo); ierr != nil {
-		s.debug("GetMessages: identify failed: %s", ierr.Error())
+		s.Debug(ctx, "GetMessages: identify failed: %s", ierr.Error())
 		return nil, ierr
 	}
 
@@ -441,7 +440,7 @@ func (s *HybridConversationSource) GetMessagesWithRemotes(ctx context.Context,
 		}
 	}
 
-	s.debug("GetMessagesWithRemotes: convID: %s uid: %s total msgs: %d hits: %d", convID, uid,
+	s.Debug(ctx, "GetMessagesWithRemotes: convID: %s uid: %s total msgs: %d hits: %d", convID, uid,
 		len(msgs), len(lmsgsTab))
 	var merges []chat1.MessageUnboxed
 	for _, msg := range msgs {
@@ -464,7 +463,7 @@ func (s *HybridConversationSource) GetMessagesWithRemotes(ctx context.Context,
 
 	// Identify this TLF by running crypt keys
 	if ierr := s.identifyTLF(ctx, convID, uid, res, finalizeInfo); ierr != nil {
-		s.debug("GetMessagesWithRemotes: identify failed: %s", ierr.Error())
+		s.Debug(ctx, "GetMessagesWithRemotes: identify failed: %s", ierr.Error())
 		return nil, ierr
 	}
 

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -21,7 +21,7 @@ type localizerPipeline struct {
 	getTlfInterface func() keybase1.TlfInterface
 }
 
-func newLocalizerPipline(g *libkb.GlobalContext, getTlfInterface func() keybase1.TlfInterface) *localizerPipeline {
+func newLocalizerPipeline(g *libkb.GlobalContext, getTlfInterface func() keybase1.TlfInterface) *localizerPipeline {
 	return &localizerPipeline{
 		Contextified:    libkb.NewContextified(g),
 		getTlfInterface: getTlfInterface,
@@ -36,7 +36,7 @@ type BlockingLocalizer struct {
 func NewBlockingLocalizer(g *libkb.GlobalContext, getTlfInterface func() keybase1.TlfInterface) *BlockingLocalizer {
 	return &BlockingLocalizer{
 		Contextified: libkb.NewContextified(g),
-		pipeline:     newLocalizerPipline(g, getTlfInterface),
+		pipeline:     newLocalizerPipeline(g, getTlfInterface),
 	}
 }
 
@@ -71,7 +71,7 @@ func NewNonblockingLocalizer(g *libkb.GlobalContext, localizeCb chan NonblockInb
 	getTlfInterface func() keybase1.TlfInterface) *NonblockingLocalizer {
 	return &NonblockingLocalizer{
 		Contextified: libkb.NewContextified(g),
-		pipeline:     newLocalizerPipline(g, getTlfInterface),
+		pipeline:     newLocalizerPipeline(g, getTlfInterface),
 		localizeCb:   localizeCb,
 	}
 }

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -275,6 +275,11 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, query *chat1.G
 func (s *HybridInboxSource) ReadRemote(ctx context.Context, uid gregor1.UID,
 	localizer libkb.ChatLocalizer, query *chat1.GetInboxLocalQuery, p *chat1.Pagination) (chat1.Inbox, *chat1.RateLimit, error) {
 
+	if localizer == nil {
+		localizer = NewBlockingLocalizer(s.G(), s.getTlfInterface)
+	}
+	s.Debug(ctx, "ReadRemote: using localizer: %s", localizer.Name())
+
 	rquery, tlfInfo, err := GetInboxQueryLocalToRemote(ctx, s.getTlfInterface(), query)
 	if err != nil {
 		return chat1.Inbox{}, nil, err

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -223,14 +223,9 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	if _, _, err = s.G().ConvSource.Push(ctx, convID, msg.ClientHeader.Sender, *boxed); err != nil {
 		return chat1.OutboxID{}, 0, nil, err
 	}
-	// TODO: make this cache write work
-	/*if err = storage.NewInbox(s.G(), boxed.ClientHeader.Sender, func() libkb.SecretUI {
-		return DelivererSecretUI{}
-	}).NewMessage(0, convID, unboxed); err != nil {
-		if _, ok := err.(libkb.ChatStorageMissError); !ok {
-			return chat1.OutboxID{}, nil, err
-		}
-	}*/
+	if err = s.G().InboxSource.NewMessage(ctx, boxed.ClientHeader.Sender, 0, convID, *boxed); err != nil {
+		return chat1.OutboxID{}, 0, nil, err
+	}
 
 	return []byte{}, plres.MsgHeader.MessageID, plres.RateLimit, nil
 }

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -94,6 +94,9 @@ func setupTest(t *testing.T) (libkb.TestContext, chat1.RemoteInterface, *kbtest.
 	}
 	tc.G.ConvSource = NewRemoteConversationSource(tc.G, boxer,
 		func() chat1.RemoteInterface { return ri })
+	tc.G.InboxSource = NewRemoteInboxSource(tc.G,
+		func() chat1.RemoteInterface { return ri },
+		func() keybase1.TlfInterface { return tlf })
 	tc.G.NotifyRouter.SetListener(&listener)
 	tc.G.MessageDeliverer = NewDeliverer(tc.G, baseSender)
 	tc.G.MessageDeliverer.Start(u.User.GetUID().ToBytes())

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -92,11 +92,11 @@ func setupTest(t *testing.T) (libkb.TestContext, chat1.RemoteInterface, *kbtest.
 		incoming: make(chan int),
 		failing:  make(chan []chat1.OutboxID),
 	}
-	tc.G.ConvSource = NewRemoteConversationSource(tc.G, boxer,
+	tc.G.ConvSource = NewHybridConversationSource(tc.G, boxer, storage.New(tc.G, f),
 		func() chat1.RemoteInterface { return ri })
-	tc.G.InboxSource = NewRemoteInboxSource(tc.G,
-		func() chat1.RemoteInterface { return ri },
-		func() keybase1.TlfInterface { return tlf })
+	tc.G.InboxSource = NewHybridInboxSource(tc.G,
+		func() keybase1.TlfInterface { return tlf },
+		func() chat1.RemoteInterface { return ri }, f)
 	tc.G.NotifyRouter.SetListener(&listener)
 	tc.G.MessageDeliverer = NewDeliverer(tc.G, baseSender)
 	tc.G.MessageDeliverer.Start(u.User.GetUID().ToBytes())

--- a/go/chat/storage/basebox.go
+++ b/go/chat/storage/basebox.go
@@ -99,3 +99,16 @@ func (i *baseBox) writeDiskBox(key libkb.DbKey, data interface{}) error {
 
 	return nil
 }
+
+func (i *baseBox) maybeNuke(err libkb.ChatStorageError, key libkb.DbKey) libkb.ChatStorageError {
+	if err != nil && err.ShouldClear() {
+		if err := i.G().LocalChatDb.Delete(key); err != nil {
+			i.G().Log.Error("unable to clear box on error! err: %s", err.Error())
+		}
+	}
+	return err
+}
+
+func (i *baseBox) maybeNukeFn(ef func() libkb.ChatStorageError, key libkb.DbKey) libkb.ChatStorageError {
+	return i.maybeNuke(ef(), key)
+}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -254,7 +254,8 @@ func (i *Inbox) applyQuery(ctx context.Context, query *chat1.GetInboxQuery, conv
 		if query.TopicType != nil && *query.TopicType != conv.Metadata.IdTriple.TopicType {
 			ok = false
 		}
-		if query.TlfVisibility != nil && *query.TlfVisibility != conv.Metadata.Visibility {
+		if query.TlfVisibility != nil && *query.TlfVisibility != chat1.TLFVisibility_ANY &&
+			*query.TlfVisibility != conv.Metadata.Visibility {
 			ok = false
 		}
 		if query.UnreadOnly && conv.ReaderInfo.ReadMsgid >= conv.ReaderInfo.MaxMsgid {

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -99,13 +99,6 @@ func (i *Inbox) dbKey() libkb.DbKey {
 	}
 }
 
-func (i *Inbox) dbKeyQueries() libkb.DbKey {
-	return libkb.DbKey{
-		Typ: libkb.DBChatInbox,
-		Key: fmt.Sprintf("ibq:%s", i.uid),
-	}
-}
-
 func (i *Inbox) readDiskInbox() (inboxDiskData, libkb.ChatStorageError) {
 	var ibox inboxDiskData
 	found, err := i.readDiskBox(i.dbKey(), &ibox)
@@ -423,15 +416,6 @@ func (i *Inbox) Read(ctx context.Context, query *chat1.GetInboxQuery, p *chat1.P
 
 	i.Debug(ctx, "Read: hit: version: %d", ibox.InboxVersion)
 	return ibox.InboxVersion, res, pagination, nil
-}
-
-func (i *Inbox) clear() libkb.ChatStorageError {
-	err := i.G().LocalChatDb.Delete(i.dbKey())
-	if err != nil {
-		return libkb.NewChatStorageInternalError(i.G(), "error clearing inbox: uid: %s err: %s", i.uid,
-			err.Error())
-	}
-	return nil
 }
 
 func (i *Inbox) handleVersion(ctx context.Context, ourvers chat1.InboxVers, updatevers chat1.InboxVers) (chat1.InboxVers, bool, libkb.ChatStorageError) {

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -418,6 +418,15 @@ func (i *Inbox) Read(ctx context.Context, query *chat1.GetInboxQuery, p *chat1.P
 	return ibox.InboxVersion, res, pagination, nil
 }
 
+func (i *Inbox) clear() libkb.ChatStorageError {
+	err := i.G().LocalChatDb.Delete(i.dbKey())
+	if err != nil {
+		return libkb.NewChatStorageInternalError(i.G(), "error clearing inbox: uid: %s err: %s", i.uid,
+			err.Error())
+	}
+	return nil
+}
+
 func (i *Inbox) handleVersion(ctx context.Context, ourvers chat1.InboxVers, updatevers chat1.InboxVers) (chat1.InboxVers, bool, libkb.ChatStorageError) {
 	// Our version is at least as new as this update, let's not continue
 	if updatevers == 0 {

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -46,7 +46,8 @@ type inboxDiskQuery struct {
 func (q inboxDiskQuery) queryMatch(other inboxDiskQuery) bool {
 	if q.QueryHash.Empty() && other.QueryHash.Empty() {
 		return true
-	} else if !q.QueryHash.Empty() && !other.QueryHash.Empty() {
+	}
+	if !q.QueryHash.Empty() && !other.QueryHash.Empty() {
 		return q.QueryHash.Eq(other.QueryHash)
 	}
 	return false
@@ -55,7 +56,8 @@ func (q inboxDiskQuery) queryMatch(other inboxDiskQuery) bool {
 func (q inboxDiskQuery) paginationMatch(other inboxDiskQuery) bool {
 	if q.Pagination == nil && other.Pagination == nil {
 		return true
-	} else if q.Pagination != nil && other.Pagination != nil {
+	}
+	if q.Pagination != nil && other.Pagination != nil {
 		return q.Pagination.Eq(*other.Pagination)
 	}
 	return false

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -591,6 +591,12 @@ func (i *Inbox) NewMessage(ctx context.Context, vers chat1.InboxVers, convID cha
 	conv.Metadata.ActiveList = i.promoteWriter(ctx, msg.ClientHeader.Sender,
 		conv.Metadata.ActiveList)
 
+	// If we are the sender, and the conv is ignored, set it back to unfiled
+	if bytes.Equal(msg.ClientHeader.Sender.Bytes(), i.uid) &&
+		conv.Metadata.Status == chat1.ConversationStatus_IGNORED {
+		conv.Metadata.Status = chat1.ConversationStatus_UNFILED
+	}
+
 	// Slot in at the top
 	mconv := *conv
 	i.Debug(ctx, "NewMessage: promoting convID: %s to the top of %d convs", convID,

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -84,7 +84,7 @@ type Inbox struct {
 func NewInbox(g *libkb.GlobalContext, uid gregor1.UID, getSecretUI func() libkb.SecretUI) *Inbox {
 	return &Inbox{
 		Contextified: libkb.NewContextified(g),
-		DebugLabeler: utils.NewDebugLabeler(g, "Inbox(uid="+uid.String()+")"),
+		DebugLabeler: utils.NewDebugLabeler(g, "Inbox"),
 		baseBox:      newBaseBox(g, getSecretUI),
 		uid:          uid,
 	}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -1,28 +1,82 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
 	"time"
 
+	"bytes"
+
+	"sort"
+
+	"crypto/sha1"
+
+	"encoding/hex"
+
+	"github.com/keybase/client/go/chat/pager"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 )
 
-const inboxVersion = 1
+const inboxVersion = 3
+
+type queryHash []byte
+
+func (q queryHash) Empty() bool {
+	return len(q) == 0
+}
+
+func (q queryHash) String() string {
+	return hex.EncodeToString(q)
+}
+
+func (q queryHash) Eq(r queryHash) bool {
+	return bytes.Equal(q, r)
+}
+
+type inboxDiskQuery struct {
+	QueryHash  queryHash         `codec:"Q"`
+	Pagination *chat1.Pagination `codec:"P"`
+}
+
+func (q inboxDiskQuery) queryMatch(other inboxDiskQuery) bool {
+	if q.QueryHash.Empty() && other.QueryHash.Empty() {
+		return true
+	} else if !q.QueryHash.Empty() && !other.QueryHash.Empty() {
+		return q.QueryHash.Eq(other.QueryHash)
+	}
+	return false
+}
+
+func (q inboxDiskQuery) paginationMatch(other inboxDiskQuery) bool {
+	if q.Pagination == nil && other.Pagination == nil {
+		return true
+	} else if q.Pagination != nil && other.Pagination != nil {
+		return q.Pagination.Eq(*other.Pagination)
+	}
+	return false
+}
+
+func (q inboxDiskQuery) match(other inboxDiskQuery) bool {
+	return q.queryMatch(other) && q.paginationMatch(other)
+}
 
 type inboxDiskData struct {
-	Version       int                       `codec:"V"`
-	InboxVersion  chat1.InboxVers           `codec:"I"`
-	Conversations []chat1.ConversationLocal `codec:"C"`
+	Version       int                  `codec:"V"`
+	InboxVersion  chat1.InboxVers      `codec:"I"`
+	Conversations []chat1.Conversation `codec:"C"`
+	Queries       []inboxDiskQuery     `codec:"Q"`
 }
 
 type Inbox struct {
 	sync.Mutex
 	libkb.Contextified
 	*baseBox
+	utils.DebugLabeler
 
 	uid gregor1.UID
 }
@@ -30,19 +84,23 @@ type Inbox struct {
 func NewInbox(g *libkb.GlobalContext, uid gregor1.UID, getSecretUI func() libkb.SecretUI) *Inbox {
 	return &Inbox{
 		Contextified: libkb.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "Inbox(uid="+uid.String()+")"),
 		baseBox:      newBaseBox(g, getSecretUI),
 		uid:          uid,
 	}
-}
-
-func (i *Inbox) debug(msg string, args ...interface{}) {
-	i.G().Log.Debug("Inbox(uid="+i.uid.String()+": "+msg, args...)
 }
 
 func (i *Inbox) dbKey() libkb.DbKey {
 	return libkb.DbKey{
 		Typ: libkb.DBChatInbox,
 		Key: fmt.Sprintf("ib:%s", i.uid),
+	}
+}
+
+func (i *Inbox) dbKeyQueries() libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBChatInbox,
+		Key: fmt.Sprintf("ibq:%s", i.uid),
 	}
 }
 
@@ -72,72 +130,273 @@ func (i *Inbox) writeDiskInbox(ibox inboxDiskData) libkb.ChatStorageError {
 	return nil
 }
 
-func (i *Inbox) Replace(vers chat1.InboxVers, convs []chat1.ConversationLocal) libkb.ChatStorageError {
+type ByDatabaseOrder []chat1.Conversation
+
+func dbConvLess(a pager.InboxEntry, b pager.InboxEntry) bool {
+	if a.GetMtime() > b.GetMtime() {
+		return true
+	} else if a.GetMtime() < b.GetMtime() {
+		return false
+	}
+	return bytes.Compare(a.GetConvID(), b.GetConvID()) > 0
+}
+
+func (a ByDatabaseOrder) Len() int      { return len(a) }
+func (a ByDatabaseOrder) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ByDatabaseOrder) Less(i, j int) bool {
+	return dbConvLess(a[i], a[j])
+}
+
+func (i *Inbox) mergeConvs(l []chat1.Conversation, r []chat1.Conversation) (res []chat1.Conversation) {
+	m := make(map[string]bool)
+	for _, conv := range l {
+		m[conv.Metadata.ConversationID.String()] = true
+		res = append(res, conv)
+	}
+	for _, conv := range r {
+		if !m[conv.Metadata.ConversationID.String()] {
+			res = append(res, conv)
+		}
+	}
+	sort.Sort(ByDatabaseOrder(res))
+	return res
+}
+
+func (i *Inbox) hashQuery(query *chat1.GetInboxQuery) (queryHash, libkb.ChatStorageError) {
+	if query == nil {
+		return nil, nil
+	}
+
+	dat, err := encode(*query)
+	if err != nil {
+		return nil, libkb.NewChatStorageInternalError(i.G(), "failed to encode query: %s", err.Error())
+	}
+
+	hasher := sha1.New()
+	hasher.Write(dat)
+	return hasher.Sum(nil), nil
+}
+
+func (i *Inbox) Merge(ctx context.Context, vers chat1.InboxVers, convs []chat1.Conversation,
+	query *chat1.GetInboxQuery, p *chat1.Pagination) (err libkb.ChatStorageError) {
 	i.Lock()
 	defer i.Unlock()
+	defer i.maybeNukeFn(func() libkb.ChatStorageError { return err }, i.dbKey())
 
-	i.debug("Replace: vers: %d", vers)
-	data := inboxDiskData{
-		Version:       inboxVersion,
-		InboxVersion:  vers,
-		Conversations: convs,
+	i.Debug(ctx, "Merge: vers: %d", vers)
+
+	// Read inbox off disk to determine if we can merge, or need to full replace
+	ibox, err := i.readDiskInbox()
+	if err != nil {
+		if _, ok := err.(libkb.ChatStorageMissError); !ok {
+			return err
+		}
 	}
+
+	// Set up query stuff
+	hquery, err := i.hashQuery(query)
+	if err != nil {
+		return err
+	}
+	i.Debug(ctx, "Merge: query hash: %s", hquery)
+	qp := inboxDiskQuery{QueryHash: hquery, Pagination: p}
+	var data inboxDiskData
+
+	// Replace the inbox under these conditions
+	if ibox.InboxVersion != vers || err != nil {
+		i.Debug(ctx, "Merge: replacing inbox: ibox.vers: %v vers: %v", ibox.InboxVersion, vers)
+		data = inboxDiskData{
+			Version:       inboxVersion,
+			InboxVersion:  vers,
+			Conversations: convs,
+			Queries:       []inboxDiskQuery{qp},
+		}
+	} else {
+		i.Debug(ctx, "Merge: merging inbox: version match")
+		data = inboxDiskData{
+			Version:       inboxVersion,
+			InboxVersion:  vers,
+			Conversations: i.mergeConvs(convs, ibox.Conversations),
+			Queries:       append(ibox.Queries, qp),
+		}
+	}
+
+	// Write out new inbox
 	if err := i.writeDiskInbox(data); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (i *Inbox) applyQuery(query *chat1.GetInboxLocalQuery, convs []chat1.ConversationLocal) []chat1.ConversationLocal {
+func (i *Inbox) applyQuery(query *chat1.GetInboxQuery, convs []chat1.Conversation) []chat1.Conversation {
 	if query == nil {
 		return convs
 	}
-	var res []chat1.ConversationLocal
+	var res []chat1.Conversation
 	for _, conv := range convs {
 		ok := true
-		if query.ConvID != nil && !query.ConvID.Eq(conv.Info.Id) {
-			ok = false
-		} else if query.After != nil && !query.After.After(conv.ReaderInfo.Mtime) {
-			ok = false
-		} else if query.Before != nil && !query.Before.Before(conv.ReaderInfo.Mtime) {
-			ok = false
-		} else if query.TopicName != nil && *query.TopicName != conv.Info.TopicName {
-			ok = false
-		} else if query.TopicType != nil && *query.TopicType != conv.Info.Triple.TopicType {
-			ok = false
-		} else if query.TlfVisibility != nil && *query.TlfVisibility != conv.Info.Visibility {
-			ok = false
-		} else if query.UnreadOnly && conv.ReaderInfo.ReadMsgid >= conv.ReaderInfo.MaxMsgid {
-			ok = false
-		} else if query.TlfName != nil && *query.TlfName != conv.Info.TlfName {
-			ok = false
-		} else if query.ReadOnly && conv.ReaderInfo.ReadMsgid < conv.ReaderInfo.MaxMsgid {
+
+		// Basic checks
+		if query.ConvID != nil && !query.ConvID.Eq(conv.Metadata.ConversationID) {
 			ok = false
 		}
+		if query.After != nil && !query.After.After(conv.ReaderInfo.Mtime) {
+			ok = false
+		}
+		if query.Before != nil && !query.Before.Before(conv.ReaderInfo.Mtime) {
+			ok = false
+		}
+		if query.TopicType != nil && *query.TopicType != conv.Metadata.IdTriple.TopicType {
+			ok = false
+		}
+		if query.TlfVisibility != nil && *query.TlfVisibility != conv.Metadata.Visibility {
+			ok = false
+		}
+		if query.UnreadOnly && conv.ReaderInfo.ReadMsgid >= conv.ReaderInfo.MaxMsgid {
+			ok = false
+		}
+		if query.ReadOnly && conv.ReaderInfo.ReadMsgid < conv.ReaderInfo.MaxMsgid {
+			ok = false
+		}
+		if query.TlfID != nil && !query.TlfID.Eq(conv.Metadata.IdTriple.Tlfid) {
+			ok = false
+		}
+
+		// Check to see if the conv status is in the query list
+		if len(query.Status) > 0 {
+			found := false
+			for _, s := range query.Status {
+				if s == conv.Metadata.Status {
+					found = true
+					break
+				}
+			}
+			if !found {
+				ok = false
+			}
+		}
+
+		// If we are finalized and are superseded, then don't return this
+		if query.OneChatTypePerTLF == nil ||
+			(query.OneChatTypePerTLF != nil && *query.OneChatTypePerTLF) {
+			if conv.Metadata.FinalizeInfo != nil && len(conv.SupersededBy) > 0 {
+				ok = false
+			}
+		}
+
 		if ok {
 			res = append(res, conv)
 		}
-		// TODO: Status filter
-		// TODO: ComputeActiveList
-		// TODO: OneChatTypePerTLF
 	}
 	return res
 }
 
-func (i *Inbox) Read(query *chat1.GetInboxLocalQuery, p *chat1.Pagination) (chat1.InboxVers, []chat1.ConversationLocal, libkb.ChatStorageError) {
+func (i *Inbox) applyPagination(ctx context.Context, convs []chat1.Conversation,
+	p *chat1.Pagination) ([]chat1.Conversation, *chat1.Pagination, libkb.ChatStorageError) {
+
+	if p == nil {
+		return convs, nil, nil
+	}
+
+	var res []chat1.Conversation
+	var pnext, pprev pager.InboxPagerFields
+	num := p.Num
+	hasnext := len(p.Next) > 0
+	hasprev := len(p.Previous) > 0
+	i.Debug(ctx, "applyPagination: num: %d", num)
+	if hasnext {
+		if err := decode(p.Next, &pnext); err != nil {
+			return nil, nil, libkb.ChatStorageRemoteError{Msg: "applyPagination: failed to decode pager: " + err.Error()}
+		}
+		i.Debug(ctx, "applyPagination: using next pointer: mtime: %v", pnext.Mtime)
+	} else if hasprev {
+		if err := decode(p.Previous, &pprev); err != nil {
+			return nil, nil, libkb.ChatStorageRemoteError{Msg: "applyPagination: failed to decode pager: " + err.Error()}
+		}
+		i.Debug(ctx, "applyPagination: using prev pinter: mtime: %v", pprev.Mtime)
+	} else {
+		i.Debug(ctx, "applyPagination: no next or prev pointers, just using num limit")
+	}
+
+	// TODO: fix me
+	for _, conv := range convs {
+		if len(res) >= num {
+			i.Debug(ctx, "applyPagination: reached num results (%d), stopping", num)
+			break
+		}
+
+		if hasnext {
+			if dbConvLess(conv, pnext) {
+				res = append(res, conv)
+			}
+		} else if hasprev {
+			if dbConvLess(pprev, conv) {
+				res = append(res, conv)
+			}
+		} else {
+			res = append(res, conv)
+		}
+	}
+
+	var pres []pager.InboxEntry
+	for _, r := range res {
+		pres = append(pres, r)
+	}
+	pagination, err := pager.NewInboxPager().MakePage(pres, num)
+	if err != nil {
+		return nil, nil, libkb.NewChatStorageInternalError(i.G(),
+			"failure to create inbox page: %s", err.Error())
+	}
+	return res, pagination, nil
+}
+
+func (i *Inbox) queryExists(ctx context.Context, ibox inboxDiskData, query *chat1.GetInboxQuery,
+	p *chat1.Pagination) bool {
+
+	hquery, err := i.hashQuery(query)
+	if err != nil {
+		i.Debug(ctx, "Read: queryExists: error hashing query: %s", err.Error())
+		return false
+	}
+	i.Debug(ctx, "Read: queryExists: query hash: %s", hquery)
+
+	qp := inboxDiskQuery{QueryHash: hquery, Pagination: p}
+	for _, q := range ibox.Queries {
+		if q.match(qp) {
+			return true
+		}
+	}
+	return false
+}
+
+func (i *Inbox) Read(ctx context.Context, query *chat1.GetInboxQuery, p *chat1.Pagination) (vers chat1.InboxVers, res []chat1.Conversation, pagination *chat1.Pagination, err libkb.ChatStorageError) {
 	i.Lock()
 	defer i.Unlock()
+	defer i.maybeNukeFn(func() libkb.ChatStorageError { return err }, i.dbKey())
 
 	ibox, err := i.readDiskInbox()
 	if err != nil {
-		return 0, nil, err
+		if _, ok := err.(libkb.ChatStorageMissError); ok {
+			i.Debug(ctx, "Read: miss: no inbox found")
+		}
+		return 0, nil, nil, err
 	}
 
-	ibox.Conversations = i.applyQuery(query, ibox.Conversations)
-	// TODO pagination
+	// Check to make sure query parameters have been seen before
+	if !i.queryExists(ctx, ibox, query, p) {
+		i.Debug(ctx, "Read: miss: query or pagination unknown")
+		return 0, nil, nil, libkb.ChatStorageMissError{}
+	}
 
-	i.debug("Read: hit: version: %d", ibox.InboxVersion)
-	return ibox.InboxVersion, ibox.Conversations, nil
+	// Apply query and pagination
+	res = i.applyQuery(query, ibox.Conversations)
+	res, pagination, err = i.applyPagination(ctx, ibox.Conversations, p)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	i.Debug(ctx, "Read: hit: version: %d", ibox.InboxVersion)
+	return ibox.InboxVersion, res, pagination, nil
 }
 
 func (i *Inbox) clear() libkb.ChatStorageError {
@@ -149,28 +408,37 @@ func (i *Inbox) clear() libkb.ChatStorageError {
 	return nil
 }
 
-func (i *Inbox) handleVersion(ourvers chat1.InboxVers, updatevers chat1.InboxVers) (chat1.InboxVers, bool, libkb.ChatStorageError) {
+func (i *Inbox) handleVersion(ctx context.Context, ourvers chat1.InboxVers, updatevers chat1.InboxVers) (chat1.InboxVers, bool, libkb.ChatStorageError) {
 	// Our version is at least as new as this update, let's not continue
 	if updatevers == 0 {
-		i.debug("handleVersion: received an self update: ours: %d update: %d", ourvers, updatevers)
-		return ourvers + 1, true, nil
+		// Don't do anything to the version if we are just writing into ourselves, we'll
+		// get the correct version when Gregor bounces the update back at us
+		i.Debug(ctx, "handleVersion: received an self update: ours: %d update: %d", ourvers, updatevers)
+		return ourvers, true, nil
 	} else if ourvers >= updatevers {
-		i.debug("handleVersion: received an old update: ours: %d update: %d", ourvers, updatevers)
+		i.Debug(ctx, "handleVersion: received an old update: ours: %d update: %d", ourvers, updatevers)
 		return ourvers, false, nil
 	} else if updatevers == ourvers+1 {
-		i.debug("handleVersion: received an incremental update: ours: %d update: %d", ourvers, updatevers)
+		i.Debug(ctx, "handleVersion: received an incremental update: ours: %d update: %d", ourvers, updatevers)
 		return updatevers, true, nil
 	}
 
-	i.debug("handleVersion: received a non-incremental update, clearing: ours: %d update: %d", ourvers, updatevers)
-	return ourvers, false, i.clear()
+	i.Debug(ctx, "handleVersion: received a non-incremental update, clearing: ours: %d update: %d",
+		ourvers, updatevers)
+
+	// Nuke our own storage if we hit this case
+	if err := i.clear(); err != nil {
+		return ourvers, false, err
+	}
+	return ourvers, false, libkb.NewChatStorageVersionMismatchError(ourvers, updatevers)
 }
 
-func (i *Inbox) NewConversation(vers chat1.InboxVers, conv chat1.ConversationLocal) error {
+func (i *Inbox) NewConversation(ctx context.Context, vers chat1.InboxVers, conv chat1.Conversation) (err libkb.ChatStorageError) {
 	i.Lock()
 	defer i.Unlock()
+	defer i.maybeNukeFn(func() libkb.ChatStorageError { return err }, i.dbKey())
 
-	i.debug("NewConversation: vers: %d convID: %s", vers, conv.Info.Id)
+	i.Debug(ctx, "NewConversation: vers: %d convID: %s", vers, conv.GetConvID())
 	ibox, err := i.readDiskInbox()
 	if err != nil {
 		return err
@@ -178,25 +446,25 @@ func (i *Inbox) NewConversation(vers chat1.InboxVers, conv chat1.ConversationLoc
 
 	// Check inbox versions, make sure it makes sense (clear otherwise)
 	var cont bool
-	if vers, cont, err = i.handleVersion(ibox.InboxVersion, vers); !cont {
+	if vers, cont, err = i.handleVersion(ctx, ibox.InboxVersion, vers); !cont {
 		return err
 	}
 
 	// Find any conversations this guy might supersede and set supersededBy pointer
 	for index := range ibox.Conversations {
 		iconv := &ibox.Conversations[index]
-		if iconv.Info.FinalizeInfo != nil {
+		if iconv.Metadata.FinalizeInfo != nil {
 			continue
 		}
 		for _, super := range conv.Supersedes {
-			if iconv.Info.Id.Eq(super) {
-				iconv.SupersededBy = append(iconv.SupersededBy, conv.Info.Id)
+			if iconv.GetConvID().Eq(super.ConversationID) {
+				iconv.SupersededBy = append(iconv.SupersededBy, conv.Metadata)
 			}
 		}
 	}
 
 	// Add the convo
-	ibox.Conversations = append([]chat1.ConversationLocal{conv}, ibox.Conversations...)
+	ibox.Conversations = append([]chat1.Conversation{conv}, ibox.Conversations...)
 
 	// Write out to disk
 	ibox.InboxVersion = vers
@@ -207,13 +475,13 @@ func (i *Inbox) NewConversation(vers chat1.InboxVers, conv chat1.ConversationLoc
 	return nil
 }
 
-func (i *Inbox) getConv(convID chat1.ConversationID, convs []chat1.ConversationLocal) (int, *chat1.ConversationLocal) {
+func (i *Inbox) getConv(convID chat1.ConversationID, convs []chat1.Conversation) (int, *chat1.Conversation) {
 
 	var index int
-	var conv chat1.ConversationLocal
+	var conv chat1.Conversation
 	found := false
 	for index, conv = range convs {
-		if conv.Info.Id.Eq(convID) {
+		if conv.GetConvID().Eq(convID) {
 			found = true
 			break
 		}
@@ -225,11 +493,24 @@ func (i *Inbox) getConv(convID chat1.ConversationID, convs []chat1.ConversationL
 	return index, &convs[index]
 }
 
-func (i *Inbox) NewMessage(vers chat1.InboxVers, convID chat1.ConversationID, msg chat1.MessageUnboxed) libkb.ChatStorageError {
+func (i *Inbox) promoteWriter(ctx context.Context, sender gregor1.UID, writers []gregor1.UID) []gregor1.UID {
+	for index, w := range writers {
+		if bytes.Equal(w.Bytes(), sender.Bytes()) {
+			writers = append(writers[:index], writers[index+1:]...)
+			writers = append([]gregor1.UID{sender}, writers...)
+			return writers
+		}
+	}
+	return writers
+}
+
+func (i *Inbox) NewMessage(ctx context.Context, vers chat1.InboxVers, convID chat1.ConversationID,
+	msg chat1.MessageBoxed) (err libkb.ChatStorageError) {
 	i.Lock()
 	defer i.Unlock()
+	defer i.maybeNukeFn(func() libkb.ChatStorageError { return err }, i.dbKey())
 
-	i.debug("NewMessage: vers: %d convID: %s", vers, convID)
+	i.Debug(ctx, "NewMessage: vers: %d convID: %s", vers, convID)
 	ibox, err := i.readDiskInbox()
 	if err != nil {
 		return err
@@ -237,38 +518,45 @@ func (i *Inbox) NewMessage(vers chat1.InboxVers, convID chat1.ConversationID, ms
 
 	// Check inbox versions, make sure it makes sense (clear otherwise)
 	var cont bool
-	if vers, cont, err = i.handleVersion(ibox.InboxVersion, vers); !cont {
+	if vers, cont, err = i.handleVersion(ctx, ibox.InboxVersion, vers); !cont {
 		return err
 	}
 
 	// Find conversation
 	index, conv := i.getConv(convID, ibox.Conversations)
 	if conv == nil {
-		i.debug("NewMessage: no conversation found: convID: %s, clearing", convID)
+		i.Debug(ctx, "NewMessage: no conversation found: convID: %s, clearing", convID)
 		return i.clear()
 	}
+	mconv := *conv
 
 	// Update conversation
 	found := false
 	typ := msg.GetMessageType()
-	for mindex, maxmsg := range conv.MaxMessages {
+	for mindex, maxmsg := range conv.MaxMsgs {
 		if maxmsg.GetMessageType() == typ {
-			conv.MaxMessages[mindex] = msg
+			conv.MaxMsgs[mindex] = msg
 			found = true
 			break
 		}
 	}
 	if !found {
-		conv.MaxMessages = append(conv.MaxMessages, msg)
+		conv.MaxMsgs = append(conv.MaxMsgs, msg)
+	}
+	// If we are all up to date on the thread, mark this message as read too
+	if conv.ReaderInfo.ReadMsgid == conv.ReaderInfo.MaxMsgid {
+		conv.ReaderInfo.ReadMsgid = msg.GetMessageID()
 	}
 	conv.ReaderInfo.MaxMsgid = msg.GetMessageID()
 	conv.ReaderInfo.Mtime = gregor1.ToTime(time.Now())
-	// TODO: How do we handle ReaderNames?
+	conv.Metadata.ActiveList = i.promoteWriter(ctx, msg.ClientHeader.Sender,
+		conv.Metadata.ActiveList)
 
 	// Slot in at the top
-	i.debug("NewMessage: promoting convID: %s to the top of %d convs", convID, len(ibox.Conversations))
+	i.Debug(ctx, "NewMessage: promoting convID: %s to the top of %d convs", convID,
+		len(ibox.Conversations))
 	ibox.Conversations = append(ibox.Conversations[:index], ibox.Conversations[index+1:]...)
-	ibox.Conversations = append([]chat1.ConversationLocal{*conv}, ibox.Conversations...)
+	ibox.Conversations = append([]chat1.Conversation{mconv}, ibox.Conversations...)
 
 	// Write out to disk
 	ibox.InboxVersion = vers
@@ -279,11 +567,13 @@ func (i *Inbox) NewMessage(vers chat1.InboxVers, convID chat1.ConversationID, ms
 	return nil
 }
 
-func (i *Inbox) ReadMessage(vers chat1.InboxVers, convID chat1.ConversationID, msgID chat1.MessageID) libkb.ChatStorageError {
+func (i *Inbox) ReadMessage(ctx context.Context, vers chat1.InboxVers, convID chat1.ConversationID,
+	msgID chat1.MessageID) (err libkb.ChatStorageError) {
 	i.Lock()
 	defer i.Unlock()
+	defer i.maybeNukeFn(func() libkb.ChatStorageError { return err }, i.dbKey())
 
-	i.debug("ReadMessage: vers: %d convID: %s", vers, convID)
+	i.Debug(ctx, "ReadMessage: vers: %d convID: %s", vers, convID)
 	ibox, err := i.readDiskInbox()
 	if err != nil {
 		return err
@@ -291,14 +581,14 @@ func (i *Inbox) ReadMessage(vers chat1.InboxVers, convID chat1.ConversationID, m
 
 	// Check inbox versions, make sure it makes sense (clear otherwise)
 	var cont bool
-	if vers, cont, err = i.handleVersion(ibox.InboxVersion, vers); !cont {
+	if vers, cont, err = i.handleVersion(ctx, ibox.InboxVersion, vers); !cont {
 		return err
 	}
 
 	// Find conversation
 	_, conv := i.getConv(convID, ibox.Conversations)
 	if conv == nil {
-		i.debug("ReadMessage: no conversation found: convID: %s, clearing", convID)
+		i.Debug(ctx, "ReadMessage: no conversation found: convID: %s, clearing", convID)
 		return i.clear()
 	}
 
@@ -315,11 +605,13 @@ func (i *Inbox) ReadMessage(vers chat1.InboxVers, convID chat1.ConversationID, m
 	return nil
 }
 
-func (i *Inbox) SetStatus(vers chat1.InboxVers, convID chat1.ConversationID, status chat1.ConversationStatus) libkb.ChatStorageError {
+func (i *Inbox) SetStatus(ctx context.Context, vers chat1.InboxVers, convID chat1.ConversationID,
+	status chat1.ConversationStatus) (err libkb.ChatStorageError) {
 	i.Lock()
 	defer i.Unlock()
+	defer i.maybeNukeFn(func() libkb.ChatStorageError { return err }, i.dbKey())
 
-	i.debug("SetStatus: vers: %d convID: %s", vers, convID)
+	i.Debug(ctx, "SetStatus: vers: %d convID: %s", vers, convID)
 	ibox, err := i.readDiskInbox()
 	if err != nil {
 		return err
@@ -327,23 +619,19 @@ func (i *Inbox) SetStatus(vers chat1.InboxVers, convID chat1.ConversationID, sta
 
 	// Check inbox versions, make sure it makes sense (clear otherwise)
 	var cont bool
-	if vers, cont, err = i.handleVersion(ibox.InboxVersion, vers); !cont {
+	if vers, cont, err = i.handleVersion(ctx, ibox.InboxVersion, vers); !cont {
 		return err
 	}
 
 	// Find conversation
-	index, conv := i.getConv(convID, ibox.Conversations)
+	_, conv := i.getConv(convID, ibox.Conversations)
 	if conv == nil {
-		i.debug("SetStatus: no conversation found: convID: %s, clearing", convID)
+		i.Debug(ctx, "SetStatus: no conversation found: convID: %s, clearing", convID)
 		return i.clear()
 	}
 
-	// Update conv
-	if status == chat1.ConversationStatus_IGNORED || status == chat1.ConversationStatus_BLOCKED {
-		// Remove conv
-		ibox.Conversations = append(ibox.Conversations[:index], ibox.Conversations[index+1:]...)
-	}
 	conv.ReaderInfo.Mtime = gregor1.ToTime(time.Now())
+	conv.Metadata.Status = status
 
 	// Write out to disk
 	ibox.InboxVersion = vers
@@ -354,12 +642,13 @@ func (i *Inbox) SetStatus(vers chat1.InboxVers, convID chat1.ConversationID, sta
 	return nil
 }
 
-func (i *Inbox) TlfFinalize(vers chat1.InboxVers, convIDs []chat1.ConversationID,
-	finalizeInfo chat1.ConversationFinalizeInfo) libkb.ChatStorageError {
+func (i *Inbox) TlfFinalize(ctx context.Context, vers chat1.InboxVers, convIDs []chat1.ConversationID,
+	finalizeInfo chat1.ConversationFinalizeInfo) (err libkb.ChatStorageError) {
 	i.Lock()
 	defer i.Unlock()
+	defer i.maybeNukeFn(func() libkb.ChatStorageError { return err }, i.dbKey())
 
-	i.debug("TlfFinalize: vers: %d convIDs: %v finalizeInfo: %v", vers, convIDs, finalizeInfo)
+	i.Debug(ctx, "TlfFinalize: vers: %d convIDs: %v finalizeInfo: %v", vers, convIDs, finalizeInfo)
 	ibox, err := i.readDiskInbox()
 	if err != nil {
 		return err
@@ -367,7 +656,7 @@ func (i *Inbox) TlfFinalize(vers chat1.InboxVers, convIDs []chat1.ConversationID
 
 	// Check inbox versions, make sure it makes sense (clear otherwise)
 	var cont bool
-	if vers, cont, err = i.handleVersion(ibox.InboxVersion, vers); !cont {
+	if vers, cont, err = i.handleVersion(ctx, ibox.InboxVersion, vers); !cont {
 		return err
 	}
 
@@ -375,17 +664,41 @@ func (i *Inbox) TlfFinalize(vers chat1.InboxVers, convIDs []chat1.ConversationID
 		// Find conversation
 		_, conv := i.getConv(convID, ibox.Conversations)
 		if conv == nil {
-			i.debug("TlfFinalize: no conversation found: convID: %s", convID)
+			i.Debug(ctx, "TlfFinalize: no conversation found: convID: %s", convID)
 			continue
 		}
 
-		conv.Info.FinalizeInfo = &finalizeInfo
+		conv.Metadata.FinalizeInfo = &finalizeInfo
 	}
 
 	// Write out to disk
 	ibox.InboxVersion = vers
 	if err := i.writeDiskInbox(ibox); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (i *Inbox) VersionSync(ctx context.Context, vers chat1.InboxVers) (err libkb.ChatStorageError) {
+	i.Lock()
+	defer i.Unlock()
+	defer i.maybeNukeFn(func() libkb.ChatStorageError { return err }, i.dbKey())
+
+	ibox, err := i.readDiskInbox()
+	if err != nil {
+		if _, ok := err.(libkb.ChatStorageMissError); !ok {
+			return err
+		}
+		return nil
+	}
+
+	// If the versions don't match here, we just clear the inbox for the user
+	if ibox.InboxVersion != vers {
+		if err = i.clear(); err != nil {
+			return err
+		}
+		return libkb.NewChatStorageVersionMismatchError(ibox.InboxVersion, vers)
 	}
 
 	return nil

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -421,7 +421,7 @@ func TestInboxReadMessage(t *testing.T) {
 
 func TestInboxSetStatus(t *testing.T) {
 
-	_, inbox, _ := setupInboxTest(t, "basic")
+	_, inbox, uid := setupInboxTest(t, "basic")
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 10
@@ -443,6 +443,14 @@ func TestInboxSetStatus(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(res), "length")
 	require.Equal(t, conv.GetConvID(), res[0].GetConvID(), "id")
+
+	t.Logf("sending new message to wake up conv")
+	msg := makeInboxMsg(3, chat1.MessageType_TEXT)
+	msg.ClientHeader.Sender = uid
+	require.NoError(t, inbox.NewMessage(context.TODO(), 3, conv.GetConvID(), msg))
+	_, res, _, err = inbox.Read(context.TODO(), &q, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(res), "ignore not unset")
 
 	validateBadUpdate(t, inbox, func() error {
 		return inbox.SetStatus(context.TODO(), 10, conv.GetConvID(), chat1.ConversationStatus_BLOCKED)

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -1,0 +1,471 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"encoding/hex"
+
+	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/stretchr/testify/require"
+)
+
+func setupInboxTest(t testing.TB, name string) (libkb.TestContext, *Inbox, gregor1.UID) {
+	tc := externals.SetupTest(t, name, 2)
+	u, err := kbtest.CreateAndSignupFakeUser("ib", tc.G)
+	require.NoError(t, err)
+	f := func() libkb.SecretUI {
+		return &libkb.TestSecretUI{Passphrase: u.Passphrase}
+	}
+	uid := gregor1.UID(u.User.GetUID().ToBytes())
+	return tc, NewInbox(tc.G, uid, f), uid
+}
+
+func makeTlfID() chat1.TLFID {
+	return randBytes(8)
+}
+
+func makeConvo(mtime gregor1.Time, rmsg chat1.MessageID, mmsg chat1.MessageID) chat1.Conversation {
+	return chat1.Conversation{
+		Metadata: chat1.ConversationMetadata{
+			ConversationID: randBytes(8),
+			IdTriple: chat1.ConversationIDTriple{
+				Tlfid:     makeTlfID(),
+				TopicType: chat1.TopicType_CHAT,
+				TopicID:   randBytes(8),
+			},
+			Visibility: chat1.TLFVisibility_PRIVATE,
+			Status:     chat1.ConversationStatus_UNFILED,
+		},
+		ReaderInfo: &chat1.ConversationReaderInfo{
+			Mtime:     mtime,
+			ReadMsgid: rmsg,
+			MaxMsgid:  mmsg,
+		},
+	}
+}
+
+func makeInboxMsg(id chat1.MessageID, typ chat1.MessageType) chat1.MessageBoxed {
+	return chat1.MessageBoxed{
+		ClientHeader: chat1.MessageClientHeader{
+			MessageType: typ,
+		},
+		ServerHeader: &chat1.MessageServerHeader{
+			MessageID: id,
+		},
+	}
+}
+
+func convListCompare(t *testing.T, l []chat1.Conversation, r []chat1.Conversation, name string) {
+	require.Equal(t, len(l), len(r), name+" size mismatch")
+	for i := 0; i < len(l); i++ {
+		t.Logf("convListCompare: l: %s(%d) r: %s(%d)", l[i].GetConvID(), l[i].GetMtime(),
+			r[i].GetConvID(), r[i].GetMtime())
+		require.Equal(t, l[i], r[i], name+" mismatch")
+	}
+}
+
+func TestInboxBasic(t *testing.T) {
+
+	_, inbox, _ := setupInboxTest(t, "basic")
+
+	// Create an inbox with a bunch of convos, merge it and read it back out
+	numConvs := 10
+	var convs []chat1.Conversation
+	for i := numConvs - 1; i >= 0; i-- {
+		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
+	}
+
+	// Fetch with no query parameter
+	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	vers, res, _, err := inbox.Read(context.TODO(), nil, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, chat1.InboxVers(1), vers, "version mismatch")
+	convListCompare(t, convs, res, "basic")
+	require.Equal(t, gregor1.Time(numConvs-1), res[0].GetMtime(), "order wrong")
+
+	// Fetch half of the messages (expect miss on first try)
+	vers, res, _, err = inbox.Read(context.TODO(), nil, &chat1.Pagination{
+		Num: numConvs / 2,
+	})
+	require.IsType(t, libkb.ChatStorageMissError{}, err, "expected miss error")
+	require.NoError(t, inbox.Merge(context.TODO(), 2, convs, nil, &chat1.Pagination{
+		Num: numConvs / 2,
+	}))
+	vers, res, _, err = inbox.Read(context.TODO(), nil, &chat1.Pagination{
+		Num: numConvs / 2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, chat1.InboxVers(2), vers, "version mismatch")
+	convListCompare(t, convs[:numConvs/2], res, "half")
+}
+
+func TestInboxQueries(t *testing.T) {
+
+	_, inbox, _ := setupInboxTest(t, "queries")
+
+	// Create an inbox with a bunch of convos, merge it and read it back out
+	numConvs := 20
+	var convs []chat1.Conversation
+	for i := 0; i < numConvs; i++ {
+		conv := makeConvo(gregor1.Time(i), 1, 1)
+		convs = append(convs, conv)
+	}
+
+	// Make two dev convos
+	var devs, publics, unreads, ignored, full []chat1.Conversation
+	convs[3].Metadata.IdTriple.TopicType = chat1.TopicType_DEV
+	convs[7].Metadata.IdTriple.TopicType = chat1.TopicType_DEV
+	devs = append(devs, []chat1.Conversation{convs[7], convs[3]}...)
+
+	// Make one public convos
+	convs[13].Metadata.Visibility = chat1.TLFVisibility_PUBLIC
+	publics = append(publics, convs[13])
+
+	// Make three unread convos
+	makeUnread := func(ri *chat1.ConversationReaderInfo) {
+		ri.MaxMsgid = 5
+		ri.ReadMsgid = 3
+	}
+	makeUnread(convs[5].ReaderInfo)
+	makeUnread(convs[13].ReaderInfo)
+	makeUnread(convs[19].ReaderInfo)
+	unreads = append(unreads, []chat1.Conversation{convs[19], convs[13], convs[5]}...)
+
+	// Make two ignored
+	convs[18].Metadata.Status = chat1.ConversationStatus_IGNORED
+	convs[4].Metadata.Status = chat1.ConversationStatus_IGNORED
+	ignored = append(ignored, []chat1.Conversation{convs[18], convs[4]}...)
+
+	// Mark one as finalized and superseded by
+	convs[6].Metadata.FinalizeInfo = &chat1.ConversationFinalizeInfo{
+		ResetFull: "reset",
+	}
+	convs[6].SupersededBy = append(convs[6].SupersededBy, convs[17].Metadata)
+	convs[17].Supersedes = append(convs[17].Supersedes, convs[6].Metadata)
+	for i := len(convs) - 1; i >= 0; i-- {
+		if i == 6 {
+			continue
+		}
+		full = append(full, convs[i])
+	}
+	for _, conv := range full {
+		t.Logf("convID: %s", conv.GetConvID())
+	}
+
+	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+
+	// Merge in queries and try to read them back out
+	var q *chat1.GetInboxQuery
+	mergeReadAndCheck := func(t *testing.T, ref []chat1.Conversation, name string) {
+		require.NoError(t, inbox.Merge(context.TODO(), 1, []chat1.Conversation{}, q, nil))
+		_, res, _, err := inbox.Read(context.TODO(), q, nil)
+		require.NoError(t, err)
+		convListCompare(t, ref, res, name)
+	}
+	t.Logf("merging all convs with nil query")
+	q = nil
+	mergeReadAndCheck(t, full, "all")
+
+	t.Logf("merging dev query")
+	devtype := chat1.TopicType_DEV
+	q = &chat1.GetInboxQuery{TopicType: &devtype}
+	mergeReadAndCheck(t, devs, "devs")
+
+	t.Logf("merging public query")
+	publicVis := chat1.TLFVisibility_PUBLIC
+	q = &chat1.GetInboxQuery{TlfVisibility: &publicVis}
+	mergeReadAndCheck(t, publics, "public")
+
+	t.Logf("merging unread query")
+	q = &chat1.GetInboxQuery{UnreadOnly: true}
+	mergeReadAndCheck(t, unreads, "unread")
+
+	t.Logf("merging ignore query")
+	q = &chat1.GetInboxQuery{Status: []chat1.ConversationStatus{chat1.ConversationStatus_IGNORED}}
+	mergeReadAndCheck(t, ignored, "ignored")
+
+	t.Logf("merging tlf ID query")
+	q = &chat1.GetInboxQuery{TlfID: &full[0].Metadata.IdTriple.Tlfid}
+	tlfIDs := []chat1.Conversation{full[0]}
+	mergeReadAndCheck(t, tlfIDs, "tlfids")
+
+	t.Logf("merging after query")
+	after := full[:4]
+	atime := gregor1.Time(15)
+	q = &chat1.GetInboxQuery{After: &atime}
+	mergeReadAndCheck(t, after, "after")
+
+	t.Logf("merging before query")
+	before := full[5:]
+	btime := gregor1.Time(15)
+	q = &chat1.GetInboxQuery{Before: &btime}
+	mergeReadAndCheck(t, before, "before")
+}
+
+func TestInboxPagination(t *testing.T) {
+
+	_, inbox, _ := setupInboxTest(t, "basic")
+
+	// Create an inbox with a bunch of convos, merge it and read it back out
+	numConvs := 50
+	var convs []chat1.Conversation
+	for i := numConvs - 1; i >= 0; i-- {
+		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
+	}
+	firstPage := convs[:10]
+	secondPage := convs[10:20]
+	thirdPage := convs[20:35]
+
+	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+
+	// Get first page
+	t.Logf("first page")
+	require.NoError(t, inbox.Merge(context.TODO(), 1, []chat1.Conversation{}, nil, &chat1.Pagination{
+		Num: 10,
+	}))
+	_, res, p, err := inbox.Read(context.TODO(), nil, &chat1.Pagination{
+		Num: 10,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 10, p.Num, "wrong pagination number")
+	convListCompare(t, firstPage, res, "first page")
+
+	// Get the second page
+	t.Logf("second page")
+	require.NoError(t, inbox.Merge(context.TODO(), 1, []chat1.Conversation{}, nil, &chat1.Pagination{
+		Num:  10,
+		Next: p.Next,
+	}))
+	_, res, p, err = inbox.Read(context.TODO(), nil, &chat1.Pagination{
+		Num:  10,
+		Next: p.Next,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 10, p.Num, "wrong pagination number")
+	convListCompare(t, secondPage, res, "second page")
+
+	// Get the third page
+	t.Logf("third page")
+	require.NoError(t, inbox.Merge(context.TODO(), 1, []chat1.Conversation{}, nil, &chat1.Pagination{
+		Num:  15,
+		Next: p.Next,
+	}))
+	_, res, p, err = inbox.Read(context.TODO(), nil, &chat1.Pagination{
+		Num:  15,
+		Next: p.Next,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 15, p.Num, "wrong pagination number")
+	convListCompare(t, thirdPage, res, "third page")
+
+	// Get the second page (through prev)
+	t.Logf("second page (redux)")
+	require.NoError(t, inbox.Merge(context.TODO(), 1, []chat1.Conversation{}, nil, &chat1.Pagination{
+		Num:      10,
+		Previous: p.Previous,
+	}))
+	_, res, p, err = inbox.Read(context.TODO(), nil, &chat1.Pagination{
+		Num:      10,
+		Previous: p.Previous,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 10, p.Num, "wrong pagination number")
+	convListCompare(t, secondPage, res, "second page (redux)")
+
+}
+
+func validateBadUpdate(t *testing.T, inbox *Inbox, f func() error) {
+	require.IsType(t, libkb.ChatStorageVersionMismatchError{}, f())
+	_, _, _, err := inbox.Read(context.TODO(), nil, nil)
+	require.IsType(t, libkb.ChatStorageMissError{}, err)
+}
+
+func TestInboxNewConversation(t *testing.T) {
+	_, inbox, _ := setupInboxTest(t, "basic")
+
+	// Create an inbox with a bunch of convos, merge it and read it back out
+	numConvs := 10
+	var convs []chat1.Conversation
+	for i := numConvs - 1; i >= 0; i-- {
+		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
+	}
+	convs[5].Metadata.FinalizeInfo = &chat1.ConversationFinalizeInfo{
+		ResetFull: "reset",
+	}
+
+	t.Logf("basic newconv")
+	newConv := makeConvo(gregor1.Time(11), 1, 1)
+	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.NewConversation(context.TODO(), 2, newConv))
+	_, res, _, err := inbox.Read(context.TODO(), nil, nil)
+	require.NoError(t, err)
+	convs = append([]chat1.Conversation{newConv}, convs...)
+	convListCompare(t, convs, res, "newconv")
+
+	t.Logf("supersede newconv")
+	newConv = makeConvo(gregor1.Time(12), 1, 1)
+	newConv.Supersedes = append(newConv.Supersedes, convs[6].Metadata)
+	require.NoError(t, inbox.NewConversation(context.TODO(), 3, newConv))
+	_, res, _, err = inbox.Read(context.TODO(), nil, nil)
+	require.NoError(t, err)
+	convs = append([]chat1.Conversation{newConv}, convs...)
+	convListCompare(t, append(convs[:7], convs[8:]...), res, "newconv finalized")
+
+	validateBadUpdate(t, inbox, func() error {
+		return inbox.NewConversation(context.TODO(), 5, newConv)
+	})
+}
+
+func TestInboxNewMessage(t *testing.T) {
+
+	_, inbox, uid := setupInboxTest(t, "basic")
+
+	// Create an inbox with a bunch of convos, merge it and read it back out
+	numConvs := 10
+	var convs []chat1.Conversation
+	for i := numConvs - 1; i >= 0; i-- {
+		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
+	}
+
+	uid1 := uid
+	uid2, err := hex.DecodeString("22")
+	require.NoError(t, err)
+	uid3, err := hex.DecodeString("33")
+	require.NoError(t, err)
+
+	convs[5].Metadata.ActiveList = []gregor1.UID{uid2, uid3, uid1}
+	conv := convs[5]
+	msg := makeInboxMsg(2, chat1.MessageType_TEXT)
+	msg.ClientHeader.Sender = uid1
+	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	_, res, _, err := inbox.Read(context.TODO(), nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, convs[0].GetConvID(), res[0].GetConvID(), "conv not promoted")
+	require.NoError(t, inbox.NewMessage(context.TODO(), 2, conv.GetConvID(), msg))
+	_, res, _, err = inbox.Read(context.TODO(), nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, conv.GetConvID(), res[0].GetConvID(), "conv not promoted")
+	require.Equal(t, chat1.MessageID(2), res[0].ReaderInfo.MaxMsgid, "wrong max msgid")
+	require.Equal(t, chat1.MessageID(2), res[0].ReaderInfo.ReadMsgid, "wrong read msgid")
+	require.Equal(t, []gregor1.UID{uid1, uid2, uid3}, res[0].Metadata.ActiveList, "active list")
+	maxMsg, err := res[0].GetMaxMessage(chat1.MessageType_TEXT)
+	require.NoError(t, err)
+	require.Equal(t, chat1.MessageID(2), maxMsg.GetMessageID(), "max msg not updated")
+
+	// Send another one from a diff User
+	msg = makeInboxMsg(3, chat1.MessageType_TEXT)
+	msg.ClientHeader.Sender = uid2
+	require.NoError(t, inbox.NewMessage(context.TODO(), 3, conv.GetConvID(), msg))
+	_, res, _, err = inbox.Read(context.TODO(), nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, chat1.MessageID(3), res[0].ReaderInfo.MaxMsgid, "wrong max msgid")
+	require.Equal(t, chat1.MessageID(2), res[0].ReaderInfo.ReadMsgid, "wrong read msgid")
+	require.Equal(t, []gregor1.UID{uid2, uid1, uid3}, res[0].Metadata.ActiveList, "active list")
+	maxMsg, err = res[0].GetMaxMessage(chat1.MessageType_TEXT)
+	require.NoError(t, err)
+	require.Equal(t, chat1.MessageID(3), maxMsg.GetMessageID(), "max msg not updated")
+
+	validateBadUpdate(t, inbox, func() error {
+		return inbox.NewMessage(context.TODO(), 10, conv.GetConvID(), msg)
+	})
+}
+
+func TestInboxReadMessage(t *testing.T) {
+
+	_, inbox, _ := setupInboxTest(t, "basic")
+
+	uid2, err := hex.DecodeString("22")
+	require.NoError(t, err)
+
+	// Create an inbox with a bunch of convos, merge it and read it back out
+	numConvs := 10
+	var convs []chat1.Conversation
+	for i := numConvs - 1; i >= 0; i-- {
+		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
+	}
+
+	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	_, res, _, err := inbox.Read(context.TODO(), nil, nil)
+	require.NoError(t, err)
+
+	conv := convs[5]
+	msg := makeInboxMsg(2, chat1.MessageType_TEXT)
+	msg.ClientHeader.Sender = uid2
+	require.NoError(t, inbox.NewMessage(context.TODO(), 2, conv.GetConvID(), msg))
+	_, res, _, err = inbox.Read(context.TODO(), nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, chat1.MessageID(2), res[0].ReaderInfo.MaxMsgid, "wrong max msgid")
+	require.Equal(t, chat1.MessageID(1), res[0].ReaderInfo.ReadMsgid, "wrong read msgid")
+	require.NoError(t, inbox.ReadMessage(context.TODO(), 3, conv.GetConvID(), 2))
+	_, res, _, err = inbox.Read(context.TODO(), nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, chat1.MessageID(2), res[0].ReaderInfo.MaxMsgid, "wrong max msgid")
+	require.Equal(t, chat1.MessageID(2), res[0].ReaderInfo.ReadMsgid, "wrong read msgid")
+
+	validateBadUpdate(t, inbox, func() error {
+		return inbox.ReadMessage(context.TODO(), 10, conv.GetConvID(), 3)
+	})
+}
+
+func TestInboxSetStatus(t *testing.T) {
+
+	_, inbox, _ := setupInboxTest(t, "basic")
+
+	// Create an inbox with a bunch of convos, merge it and read it back out
+	numConvs := 10
+	var convs []chat1.Conversation
+	for i := numConvs - 1; i >= 0; i-- {
+		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
+	}
+
+	conv := convs[5]
+	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.SetStatus(context.TODO(), 2, conv.GetConvID(),
+		chat1.ConversationStatus_IGNORED))
+
+	q := chat1.GetInboxQuery{
+		Status: []chat1.ConversationStatus{chat1.ConversationStatus_IGNORED},
+	}
+	require.NoError(t, inbox.Merge(context.TODO(), 2, []chat1.Conversation{}, &q, nil))
+	_, res, _, err := inbox.Read(context.TODO(), &q, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res), "length")
+	require.Equal(t, conv.GetConvID(), res[0].GetConvID(), "id")
+
+	validateBadUpdate(t, inbox, func() error {
+		return inbox.SetStatus(context.TODO(), 10, conv.GetConvID(), chat1.ConversationStatus_BLOCKED)
+	})
+}
+
+func TestInboxTlfFinalize(t *testing.T) {
+
+	_, inbox, _ := setupInboxTest(t, "basic")
+
+	// Create an inbox with a bunch of convos, merge it and read it back out
+	numConvs := 10
+	var convs []chat1.Conversation
+	for i := numConvs - 1; i >= 0; i-- {
+		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
+	}
+
+	conv := convs[5]
+	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
+	require.NoError(t, inbox.TlfFinalize(context.TODO(), 2, []chat1.ConversationID{conv.GetConvID()},
+		chat1.ConversationFinalizeInfo{ResetFull: "reset"}))
+	_, res, _, err := inbox.Read(context.TODO(), nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, len(convs), len(res), "length")
+	require.Equal(t, conv.GetConvID(), res[5].GetConvID(), "id")
+	require.NotNil(t, res[5].Metadata.FinalizeInfo, "finalize info")
+
+	validateBadUpdate(t, inbox, func() error {
+		return inbox.TlfFinalize(context.TODO(), 10, []chat1.ConversationID{conv.GetConvID()},
+			chat1.ConversationFinalizeInfo{ResetFull: "reset"})
+	})
+}

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -308,17 +308,23 @@ func TestInboxNewConversation(t *testing.T) {
 	convs = append([]chat1.Conversation{newConv}, convs...)
 	convListCompare(t, convs, res, "newconv")
 
+	t.Logf("repeat conv")
+	require.NoError(t, inbox.NewConversation(context.TODO(), 3, newConv))
+	_, res, _, err = inbox.Read(context.TODO(), nil, nil)
+	require.NoError(t, err)
+	convListCompare(t, convs, res, "repeatconv")
+
 	t.Logf("supersede newconv")
 	newConv = makeConvo(gregor1.Time(12), 1, 1)
 	newConv.Supersedes = append(newConv.Supersedes, convs[6].Metadata)
-	require.NoError(t, inbox.NewConversation(context.TODO(), 3, newConv))
+	require.NoError(t, inbox.NewConversation(context.TODO(), 4, newConv))
 	_, res, _, err = inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
 	convs = append([]chat1.Conversation{newConv}, convs...)
 	convListCompare(t, append(convs[:7], convs[8:]...), res, "newconv finalized")
 
 	validateBadUpdate(t, inbox, func() error {
-		return inbox.NewConversation(context.TODO(), 5, newConv)
+		return inbox.NewConversation(context.TODO(), 10, newConv)
 	})
 }
 

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -1,0 +1,69 @@
+package chat
+
+import (
+	"context"
+
+	"github.com/keybase/client/go/chat/storage"
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type Syncer struct {
+	libkb.Contextified
+	utils.DebugLabeler
+}
+
+func NewSyncer(g *libkb.GlobalContext) *Syncer {
+	return &Syncer{
+		Contextified: libkb.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "Syncer"),
+	}
+}
+
+func (s *Syncer) SendChatStaleNotifications(uid gregor1.UID) {
+	// Alert Electron that all chat information could be out of date. Empty conversation ID
+	// list means everything needs to be refreshed
+	kuid := keybase1.UID(uid.String())
+	s.G().NotifyRouter.HandleChatInboxStale(context.Background(), kuid)
+	s.G().NotifyRouter.HandleChatThreadsStale(context.Background(), kuid, []chat1.ConversationID{})
+}
+
+func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID) error {
+	s.Debug(ctx, "Connected: running")
+
+	// Grab the latest inbox version, and compare it to what we have
+	// If we don't have the latest, then we clear the Inbox cache and
+	// send alerts to clients that they should refresh.
+	vers, err := cli.GetInboxVersion(ctx, uid)
+	if err != nil {
+		s.Debug(ctx, "Connected: failed to sync inbox version: uid: %s error: %s", uid, err.Error())
+		return err
+	}
+
+	ibox := storage.NewInbox(s.G(), uid, func() libkb.SecretUI {
+		return DelivererSecretUI{}
+	})
+	// If we miss here, then let's send notifications out to clients letting
+	// them know everything is hosed
+	if verr := ibox.VersionSync(ctx, vers); verr != nil {
+		s.Debug(ctx, "Connected: error during version sync: %s, sending notifications", verr.Error())
+		s.SendChatStaleNotifications(uid)
+	} else {
+		s.Debug(ctx, "Connected: version sync success! version: %d", vers)
+	}
+
+	// Let the Deliverer know that we are back online
+	s.G().MessageDeliverer.Connected()
+
+	return nil
+}
+
+func (s *Syncer) Disconnected(ctx context.Context) {
+	s.Debug(ctx, "Disconnected: running")
+
+	// Let the Deliverer know we are offline
+	s.G().MessageDeliverer.Disconnected()
+}

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -1,0 +1,27 @@
+package chat
+
+import (
+	"context"
+
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type TLFInfo struct {
+	ID            chat1.TLFID
+	CanonicalName string
+}
+
+func LookupTLF(ctx context.Context, tlfcli keybase1.TlfInterface, tlfName string,
+	visibility chat1.TLFVisibility) (*TLFInfo, error) {
+
+	res, err := CtxKeyFinder(ctx).Find(ctx, tlfcli, tlfName, visibility == chat1.TLFVisibility_PUBLIC)
+	if err != nil {
+		return nil, err
+	}
+	info := &TLFInfo{
+		ID:            chat1.TLFID(res.NameIDBreaks.TlfID.ToBytes()),
+		CanonicalName: res.NameIDBreaks.CanonicalName.String(),
+	}
+	return info, nil
+}

--- a/go/chat/utils/kbfs.go
+++ b/go/chat/utils/kbfs.go
@@ -3,7 +3,7 @@
 
 // This is all stuff copied from libkbfs.
 
-package chat
+package utils
 
 import (
 	"fmt"

--- a/go/chat/utils/utils_test.go
+++ b/go/chat/utils/utils_test.go
@@ -1,4 +1,4 @@
-package chat
+package utils
 
 import (
 	"testing"

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/keybase/cli"
-	"github.com/keybase/client/go/chat"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/protocol/chat1"
 )
 
@@ -194,7 +194,7 @@ func makeChatCLIInboxFetcherActivitySorted(ctx *cli.Context) (fetcher chatCLIInb
 	}
 
 	if !ctx.Bool("include-hidden") {
-		fetcher.query.Status = chat.VisibleChatConversationStatuses()
+		fetcher.query.Status = utils.VisibleChatConversationStatuses()
 	}
 
 	fetcher.async = ctx.Bool("async")
@@ -224,7 +224,7 @@ func makeChatCLIInboxFetcherUnreadFirst(ctx *cli.Context) (fetcher chatCLIInboxF
 	}
 
 	if !ctx.Bool("include-hidden") {
-		fetcher.query.Status = chat.VisibleChatConversationStatuses()
+		fetcher.query.Status = utils.VisibleChatConversationStatuses()
 	}
 
 	return fetcher, err

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -134,7 +134,7 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 				},
 				flexibletable.Cell{
 					Alignment: flexibletable.Left,
-					Content:   flexibletable.SingleCell{Item: *conv.Error},
+					Content:   flexibletable.SingleCell{Item: conv.Error.Message},
 				},
 			})
 			continue

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -212,7 +212,7 @@ func (r *chatConversationResolver) Resolve(ctx context.Context, req chatConversa
 		return nil, false, errors.New("no conversation found")
 	case 1:
 		if conversations[0].Error != nil {
-			return nil, false, errors.New(*conversations[0].Error)
+			return nil, false, errors.New(conversations[0].Error.Message)
 		}
 		info := conversations[0].Info
 		if req.TlfName != info.TlfName {

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/keybase/client/go/chat"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
@@ -54,7 +54,7 @@ func (c *chatServiceHandler) ListV1(ctx context.Context, opts listOptionsV1) Rep
 
 	inbox, err := client.GetInboxLocal(ctx, chat1.GetInboxLocalArg{
 		Query: &chat1.GetInboxLocalQuery{
-			Status:    chat.VisibleChatConversationStatuses(),
+			Status:    utils.VisibleChatConversationStatuses(),
 			TopicType: &topicType,
 		},
 		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,

--- a/go/client/chat_ui.go
+++ b/go/client/chat_ui.go
@@ -8,7 +8,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/keybase/client/go/chat"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 )
@@ -109,7 +109,15 @@ func (c *ChatUI) ChatInboxConversation(ctx context.Context, arg chat1.ChatInboxC
 	snippet := "<blank>"
 	tlf := arg.Conv.Info.TlfName + " (unverified)"
 	for _, msg := range arg.Conv.MaxMessages {
-		if msg.IsValid() && msg.GetMessageType() == chat1.MessageType_TEXT {
+		if msg.IsValid() {
+			body := msg.Valid().MessageBody
+			typ, err := (&body).MessageType()
+			if err != nil {
+				continue
+			}
+			if typ != chat1.MessageType_TEXT {
+				continue
+			}
 			sender = msg.Valid().SenderUsername
 			snippet = msg.Valid().MessageBody.Text().Body
 			tlf = msg.Valid().ClientHeader.TlfName
@@ -147,7 +155,7 @@ func (c *ChatUI) getUnverifiedConvo(ctx context.Context, conv chat1.Conversation
 		return chat1.ConversationLocal{}, fmt.Errorf("no text message found")
 	}
 
-	rnames, wnames, err := chat.ReorderParticipants(ctx, c.G().GetUPAKLoader(),
+	rnames, wnames, err := utils.ReorderParticipants(ctx, c.G().GetUPAKLoader(),
 		txtMsg.ClientHeader.TlfName, conv.Metadata.ActiveList)
 	if err != nil {
 		return chat1.ConversationLocal{}, err

--- a/go/client/cmd_chat_read.go
+++ b/go/client/cmd_chat_read.go
@@ -41,7 +41,7 @@ func (c *cmdChatRead) Run() error {
 	}
 
 	if convLocal.Error != nil {
-		ui.Printf("proccessing conversation error: %s\n", *convLocal.Error)
+		ui.Printf("proccessing conversation error: %s\n", convLocal.Error.Message)
 		return nil
 	}
 

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -923,6 +923,13 @@ func (e *Env) GetConvSourceType() string {
 	)
 }
 
+func (e *Env) GetInboxSourceType() string {
+	return e.GetString(
+		func() string { return os.Getenv("KEYBASE_INBOX_SOURCE_TYPE") },
+		func() string { return "hybrid" },
+	)
+}
+
 func (e *Env) GetDeviceID() keybase1.DeviceID {
 	return e.config.GetDeviceID()
 }

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1850,6 +1850,29 @@ func (e ChatStorageMiscError) Message() string {
 	return e.Msg
 }
 
+type ChatStorageVersionMismatchError struct {
+	old, new chat1.InboxVers
+}
+
+func NewChatStorageVersionMismatchError(oldVers chat1.InboxVers, newVers chat1.InboxVers) ChatStorageVersionMismatchError {
+	return ChatStorageVersionMismatchError{
+		old: oldVers,
+		new: newVers,
+	}
+}
+
+func (e ChatStorageVersionMismatchError) Error() string {
+	return fmt.Sprintf("version mismatch error: old %d new: %d", e.old, e.new)
+}
+
+func (e ChatStorageVersionMismatchError) ShouldClear() bool {
+	return true
+}
+
+func (e ChatStorageVersionMismatchError) Message() string {
+	return e.Error()
+}
+
 //=============================================================================
 
 type InvalidAddressError struct {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -99,6 +99,7 @@ type GlobalContext struct {
 	uchMu               *sync.Mutex          // protects the UserChangedHandler array
 	UserChangedHandlers []UserChangedHandler // a list of handlers that deal generically with userchanged events
 
+	InboxSource      InboxSource        // source of remote inbox entries for chat
 	ConvSource       ConversationSource // source of remote message bodies for chat
 	MessageDeliverer MessageDeliverer   // background message delivery service
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -545,6 +545,7 @@ type MessageDeliverer interface {
 
 type ChatLocalizer interface {
 	Localize(ctx context.Context, uid gregor1.UID, inbox chat1.Inbox) ([]chat1.ConversationLocal, error)
+	Name() string
 }
 
 type InboxSource interface {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -543,6 +543,28 @@ type MessageDeliverer interface {
 	Disconnected()
 }
 
+type ChatLocalizer interface {
+	Localize(ctx context.Context, uid gregor1.UID, inbox chat1.Inbox) ([]chat1.ConversationLocal, error)
+}
+
+type InboxSource interface {
+	Read(ctx context.Context, uid gregor1.UID, localizer ChatLocalizer, query *chat1.GetInboxLocalQuery,
+		p *chat1.Pagination) (chat1.Inbox, *chat1.RateLimit, error)
+	ReadRemote(ctx context.Context, uid gregor1.UID, localizer ChatLocalizer,
+		query *chat1.GetInboxLocalQuery, p *chat1.Pagination) (chat1.Inbox, *chat1.RateLimit, error)
+
+	NewConversation(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
+		conv chat1.Conversation) error
+	NewMessage(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
+		msg chat1.MessageBoxed) error
+	ReadMessage(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
+		msgID chat1.MessageID) error
+	SetStatus(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
+		status chat1.ConversationStatus) error
+	TlfFinalize(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
+		convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) error
+}
+
 // UserChangedHandler is a generic interface for handling user changed events.
 // If the call returns an error, we'll remove this handler from the list, under the
 // supposition that it's now dead.

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/keybase/client/go/protocol/gregor1"
 )
 
 // Eq compares two TLFIDs
@@ -268,4 +270,25 @@ func ExpandTLFName(name string, finalizeInfo *ConversationFinalizeInfo) string {
 // which doesn't make much sense in other uses (like chat).
 func (f *ConversationFinalizeInfo) BeforeSummary() string {
 	return fmt.Sprintf("(before %s account reset %s)", f.ResetUser, f.ResetDate)
+}
+
+func (p Pagination) Eq(other Pagination) bool {
+	return p.Last == other.Last && bytes.Equal(p.Next, other.Next) &&
+		bytes.Equal(p.Previous, other.Previous) && p.Num == other.Num
+}
+
+func (c ConversationLocal) GetMtime() gregor1.Time {
+	return c.ReaderInfo.Mtime
+}
+
+func (c ConversationLocal) GetConvID() ConversationID {
+	return c.Info.Id
+}
+
+func (c Conversation) GetMtime() gregor1.Time {
+	return c.ReaderInfo.Mtime
+}
+
+func (c Conversation) GetConvID() ConversationID {
+	return c.Metadata.ConversationID
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -292,3 +292,12 @@ func (c Conversation) GetMtime() gregor1.Time {
 func (c Conversation) GetConvID() ConversationID {
 	return c.Metadata.ConversationID
 }
+
+func (c Conversation) GetMaxMessage(typ MessageType) (MessageBoxed, error) {
+	for _, msg := range c.MaxMsgs {
+		if msg.GetMessageType() == typ {
+			return msg, nil
+		}
+	}
+	return MessageBoxed{}, fmt.Errorf("max message not found: %v", typ)
+}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -407,6 +407,13 @@ type OutboxRecord struct {
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
+type Inbox struct {
+	Version         InboxVers           `codec:"version" json:"version"`
+	ConvsUnverified []Conversation      `codec:"convsUnverified" json:"convsUnverified"`
+	Convs           []ConversationLocal `codec:"convs" json:"convs"`
+	Pagination      *Pagination         `codec:"pagination,omitempty" json:"pagination,omitempty"`
+}
+
 type HeaderPlaintextVersion int
 
 const (
@@ -680,8 +687,14 @@ type ConversationInfoLocal struct {
 	FinalizeInfo *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
 }
 
+type ConversationErrorLocal struct {
+	Message    string       `codec:"message" json:"message"`
+	RemoteConv Conversation `codec:"remoteConv" json:"remoteConv"`
+	Permanent  bool         `codec:"permanent" json:"permanent"`
+}
+
 type ConversationLocal struct {
-	Error            *string                       `codec:"error,omitempty" json:"error,omitempty"`
+	Error            *ConversationErrorLocal       `codec:"error,omitempty" json:"error,omitempty"`
 	Info             ConversationInfoLocal         `codec:"info" json:"info"`
 	ReaderInfo       ConversationReaderInfo        `codec:"readerInfo" json:"readerInfo"`
 	Supersedes       []ConversationID              `codec:"supersedes" json:"supersedes"`

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -327,8 +327,7 @@ func (h *chatLocalHandler) NewConversationLocal(ctx context.Context, arg chat1.N
 		// create succeeded; grabbing the conversation and returning
 		uid := h.G().Env.GetUID()
 
-		localizer := chat.NewBlockingLocalizer(h.G(), func() keybase1.TlfInterface { return h.tlf })
-		ib, rl, err := h.G().InboxSource.ReadRemote(ctx, uid.ToBytes(), localizer,
+		ib, rl, err := h.G().InboxSource.ReadRemote(ctx, uid.ToBytes(), nil,
 			&chat1.GetInboxLocalQuery{
 				ConvID: &convID,
 			}, nil)

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -77,6 +77,9 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	storage := storage.New(tc.G, f)
 	tc.G.ConvSource = chat.NewHybridConversationSource(tc.G, h.boxer, storage,
 		func() chat1.RemoteInterface { return mockRemote })
+	tc.G.InboxSource = chat.NewRemoteInboxSource(tc.G,
+		func() chat1.RemoteInterface { return mockRemote },
+		func() keybase1.TlfInterface { return h.tlf })
 	h.setTestRemoteClient(mockRemote)
 	h.gh, _ = newGregorHandler(tc.G)
 

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -77,9 +77,10 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	storage := storage.New(tc.G, f)
 	tc.G.ConvSource = chat.NewHybridConversationSource(tc.G, h.boxer, storage,
 		func() chat1.RemoteInterface { return mockRemote })
-	tc.G.InboxSource = chat.NewRemoteInboxSource(tc.G,
+	tc.G.InboxSource = chat.NewHybridInboxSource(tc.G,
+		func() keybase1.TlfInterface { return h.tlf },
 		func() chat1.RemoteInterface { return mockRemote },
-		func() keybase1.TlfInterface { return h.tlf })
+		f)
 	h.setTestRemoteClient(mockRemote)
 	h.gh, _ = newGregorHandler(tc.G)
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/keybase/client/go/chat"
-	cstorage "github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/gregor"
 	grclient "github.com/keybase/client/go/gregor/client"
@@ -116,6 +115,7 @@ type gregorHandler struct {
 	freshReplay      bool
 
 	identNotifier *chat.IdentifyNotifier
+	chatSync      *chat.Syncer
 
 	transportForTesting *connTransport
 
@@ -157,6 +157,7 @@ func newGregorHandler(g *libkb.GlobalContext) (*gregorHandler, error) {
 		pushStateFilter: func(m gregor.Message) bool { return true },
 		badger:          nil,
 		identNotifier:   chat.NewIdentifyNotifier(g),
+		chatSync:        chat.NewSyncer(g),
 	}
 
 	// Attempt to create a gregor client initially, if we are not logged in
@@ -492,14 +493,22 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 			len(replayedMsgs), len(consumedMsgs))
 	}
 
+	// Sync chat data using a Syncer object
+	gcli, err := g.getGregorCli()
+	if err == nil {
+		chatCli := chat1.RemoteClient{Cli: cli}
+		uid := gcli.User.(gregor1.UID)
+		if err := g.chatSync.Connected(ctx, chatCli, uid); err != nil {
+			return err
+		}
+	}
+
+	// Sync badge state in the background
 	if g.badger != nil {
 		go func(badger *Badger) {
 			badger.Resync(context.Background(), &chat1.RemoteClient{Cli: g.cli})
 		}(g.badger)
 	}
-
-	// Let the Deliverer know that we are back online
-	g.G().MessageDeliverer.Connected()
 
 	// Broadcast reconnect oobm. Spawn this off into a goroutine so that we don't delay
 	// reconnection any longer than we have to.
@@ -516,7 +525,9 @@ func (g *gregorHandler) OnConnectError(err error, reconnectThrottleDuration time
 
 func (g *gregorHandler) OnDisconnected(ctx context.Context, status rpc.DisconnectStatus) {
 	g.Debug("disconnected: %v", status)
-	g.G().MessageDeliverer.Disconnected()
+
+	// Alert chat syncer that we are now disconnected
+	g.chatSync.Disconnected(ctx)
 }
 
 func (g *gregorHandler) OnDoCommandError(err error, nextTime time.Duration) {
@@ -824,15 +835,6 @@ func (h IdentifyUIHandler) handleShowTrackerPopupDismiss(ctx context.Context, cl
 	return nil
 }
 
-func (g *gregorHandler) sendChatStaleNotifications() {
-
-	// Alert Electron that all chat information could be out of date. Empty conversation ID
-	// list means everything needs to be refreshed
-	uid := keybase1.UID(g.gregorCli.User.String())
-	g.G().NotifyRouter.HandleChatInboxStale(context.Background(), uid)
-	g.G().NotifyRouter.HandleChatThreadsStale(context.Background(), uid, []chat1.ConversationID{})
-}
-
 func (g *gregorHandler) handleOutOfBandMessage(ctx context.Context, obm gregor.OutOfBandMessage) error {
 	g.Debug("handleOutOfBand: %+v", obm)
 
@@ -855,7 +857,6 @@ func (g *gregorHandler) handleOutOfBandMessage(ctx context.Context, obm gregor.O
 		return g.chatTlfFinalize(ctx, obm)
 	case "internal.reconnect":
 		g.G().Log.Debug("reconnected to push server")
-		g.sendChatStaleNotifications()
 		return nil
 	default:
 		return fmt.Errorf("unhandled system: %s", obm.System())
@@ -927,12 +928,9 @@ func (g *gregorHandler) chatTlfFinalize(ctx context.Context, m gregor.OutOfBandM
 	}
 
 	// Update inbox
-	if err := cstorage.NewInbox(g.G(), m.UID().Bytes(), func() libkb.SecretUI {
-		return chat.DelivererSecretUI{}
-	}).TlfFinalize(update.InboxVers, update.ConvIDs, update.FinalizeInfo); err != nil {
-		if _, ok := (err).(libkb.ChatStorageMissError); !ok {
-			g.G().Log.Error("push handler: tlf finalize: unable to update inbox: %s", err.Error())
-		}
+	if err := g.G().InboxSource.TlfFinalize(ctx, m.UID().Bytes(), update.InboxVers, update.ConvIDs,
+		update.FinalizeInfo); err != nil {
+		g.G().Log.Error("push handler: tlf finalize: unable to update inbox: %s", err.Error())
 	}
 
 	// Send notify for each conversation ID
@@ -961,6 +959,9 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 
 	g.G().Log.Debug("push handler: chat activity: action %s", gm.Action)
 
+	var identBreaks []keybase1.TLFIdentifyFailure
+	ctx = chat.Context(ctx, keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks, g.identNotifier)
+
 	action := gm.Action
 	reader.Reset(m.Body().Bytes())
 	switch action {
@@ -982,18 +983,12 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 		}
 		uid := m.UID().Bytes()
 
-		var identBreaks []keybase1.TLFIdentifyFailure
-		ctx = chat.Context(ctx, keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks, g.identNotifier)
 		decmsg, append, err := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
 		if err != nil {
 			g.G().Log.Error("push handler: chat activity: unable to storage message: %s", err.Error())
 		}
-		if err = cstorage.NewInbox(g.G(), uid, func() libkb.SecretUI {
-			return chat.DelivererSecretUI{}
-		}).NewMessage(nm.InboxVers, nm.ConvID, decmsg); err != nil {
-			if _, ok := (err).(libkb.ChatStorageMissError); !ok {
-				g.G().Log.Error("push handler: chat activity: unable to update inbox: %s", err.Error())
-			}
+		if err = g.G().InboxSource.NewMessage(ctx, uid, nm.InboxVers, nm.ConvID, nm.Message); err != nil {
+			g.G().Log.Error("push handler: chat activity: unable to update inbox: %s", err.Error())
 		}
 
 		activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
@@ -1025,13 +1020,10 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 			nm.ConvID, nm.MsgID)
 
 		uid := m.UID().Bytes()
-		if err = cstorage.NewInbox(g.G(), uid, func() libkb.SecretUI {
-			return chat.DelivererSecretUI{}
-		}).ReadMessage(nm.InboxVers, nm.ConvID, nm.MsgID); err != nil {
-			if _, ok := (err).(libkb.ChatStorageMissError); !ok {
-				g.G().Log.Error("push handler: chat activity: unable to update inbox: %s", err.Error())
-			}
+		if err = g.G().InboxSource.ReadMessage(ctx, uid, nm.InboxVers, nm.ConvID, nm.MsgID); err != nil {
+			g.G().Log.Error("push handler: chat activity: unable to update inbox: %s", err.Error())
 		}
+
 		activity = chat1.NewChatActivityWithReadMessage(chat1.ReadMessageInfo{
 			MsgID:  nm.MsgID,
 			ConvID: nm.ConvID,
@@ -1051,12 +1043,8 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 			nm.ConvID, nm.Status)
 
 		uid := m.UID().Bytes()
-		if err = cstorage.NewInbox(g.G(), uid, func() libkb.SecretUI {
-			return chat.DelivererSecretUI{}
-		}).SetStatus(nm.InboxVers, nm.ConvID, nm.Status); err != nil {
-			if _, ok := (err).(libkb.ChatStorageMissError); !ok {
-				g.G().Log.Error("push handler: chat activity: unable to update inbox: %s", err.Error())
-			}
+		if err = g.G().InboxSource.SetStatus(ctx, uid, nm.InboxVers, nm.ConvID, nm.Status); err != nil {
+			g.G().Log.Error("push handler: chat activity: unable to update inbox: %s", err.Error())
 		}
 		activity = chat1.NewChatActivityWithSetStatus(chat1.SetStatusInfo{
 			ConvID: nm.ConvID,
@@ -1078,17 +1066,10 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 		uid := m.UID().Bytes()
 
 		// We need to get this conversation and then localize it
-		var inbox chat.Inbox
+		var inbox chat1.Inbox
 		tlf := newTlfHandler(nil, g.G())
-		boxer := chat.NewBoxer(g.G(), tlf)
-		inboxSource := chat.NewRemoteInboxSource(g.G(), boxer,
-			func() chat1.RemoteInterface { return chat1.RemoteClient{Cli: g.cli} },
-			func() keybase1.TlfInterface { return tlf })
-
-		var identBreaks []keybase1.TLFIdentifyFailure
-		ctx = chat.Context(context.Background(), keybase1.TLFIdentifyBehavior_CHAT_GUI,
-			&identBreaks, g.identNotifier)
-		if inbox, _, err = inboxSource.Read(ctx, uid, &chat1.GetInboxLocalQuery{
+		localizer := chat.NewBlockingLocalizer(g.G(), func() keybase1.TlfInterface { return tlf })
+		if inbox, _, err = g.G().InboxSource.ReadRemote(ctx, uid, localizer, &chat1.GetInboxLocalQuery{
 			ConvID: &nm.ConvID,
 		}, nil); err != nil {
 			g.G().Log.Error("push handler: chat activity: unable to read conversation: %s", err.Error())
@@ -1098,14 +1079,11 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 			g.G().Log.Error("push handler: chat activity: unable to find conversation")
 			return fmt.Errorf("unable to find conversation")
 		}
-
-		if err = cstorage.NewInbox(g.G(), uid, func() libkb.SecretUI {
-			return chat.DelivererSecretUI{}
-		}).NewConversation(nm.InboxVers, inbox.Convs[0]); err != nil {
-			if _, ok := (err).(libkb.ChatStorageMissError); !ok {
-				g.G().Log.Error("push handler: chat activity: unable to update inbox: %s", err.Error())
-			}
+		updateConv := inbox.ConvsUnverified[0]
+		if err = g.G().InboxSource.NewConversation(ctx, uid, nm.InboxVers, updateConv); err != nil {
+			g.G().Log.Error("push handler: chat activity: unable to update inbox: %s", err.Error())
 		}
+
 		activity = chat1.NewChatActivityWithNewConversation(chat1.NewConversationInfo{
 			Conv: inbox.Convs[0],
 		})

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1067,9 +1067,7 @@ func (g *gregorHandler) newChatActivity(ctx context.Context, m gregor.OutOfBandM
 
 		// We need to get this conversation and then localize it
 		var inbox chat1.Inbox
-		tlf := newTlfHandler(nil, g.G())
-		localizer := chat.NewBlockingLocalizer(g.G(), func() keybase1.TlfInterface { return tlf })
-		if inbox, _, err = g.G().InboxSource.ReadRemote(ctx, uid, localizer, &chat1.GetInboxLocalQuery{
+		if inbox, _, err = g.G().InboxSource.ReadRemote(ctx, uid, nil, &chat1.GetInboxLocalQuery{
 			ConvID: &nm.ConvID,
 		}, nil); err != nil {
 			g.G().Log.Error("push handler: chat activity: unable to read conversation: %s", err.Error())

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -105,6 +105,13 @@ protocol local {
     keybase1.TLFIdentifyBehavior identifyBehavior;
   }
 
+  record Inbox {
+    InboxVers version;
+    array<Conversation> convsUnverified;
+    array<ConversationLocal> convs;
+    union { null, Pagination } pagination;
+  }
+
   enum HeaderPlaintextVersion {
     V1_1
   }
@@ -220,11 +227,17 @@ protocol local {
     union { null, ConversationFinalizeInfo } finalizeInfo;
   }
 
+  record ConversationErrorLocal {
+    string message;
+    Conversation remoteConv;
+    boolean permanent;
+  }
+
   // ConversationLocal, whenever present, has a valid `identifyFailures` field that
   // faithfully represent identify result. If identify information is not
   // availabe, we should use a different type.
   record ConversationLocal {
-    union { null, string } error;
+    union { null, ConversationErrorLocal } error;
     ConversationInfoLocal info;
     ConversationReaderInfo readerInfo;
     array<ConversationID> supersedes;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -605,6 +605,12 @@ export type Conversation = {
   maxMsgs?: ?Array<MessageBoxed>,
 }
 
+export type ConversationErrorLocal = {
+  message: string,
+  remoteConv: Conversation,
+  permanent: boolean,
+}
+
 export type ConversationFinalizeInfo = {
   resetUser: string,
   resetDate: string,
@@ -633,7 +639,7 @@ export type ConversationInfoLocal = {
 }
 
 export type ConversationLocal = {
-  error?: ?string,
+  error?: ?ConversationErrorLocal,
   info: ConversationInfoLocal,
   readerInfo: ConversationReaderInfo,
   supersedes?: ?Array<ConversationID>,
@@ -826,6 +832,13 @@ export type HeaderPlaintextV1 = {
 
 export type HeaderPlaintextVersion = 
     1 // V1_1
+
+export type Inbox = {
+  version: InboxVers,
+  convsUnverified?: ?Array<Conversation>,
+  convs?: ?Array<ConversationLocal>,
+  pagination?: ?Pagination,
+}
 
 export type InboxResType = 
     0 // VERSIONHIT_0

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -349,6 +349,37 @@
       ]
     },
     {
+      "type": "record",
+      "name": "Inbox",
+      "fields": [
+        {
+          "type": "InboxVers",
+          "name": "version"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "Conversation"
+          },
+          "name": "convsUnverified"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "ConversationLocal"
+          },
+          "name": "convs"
+        },
+        {
+          "type": [
+            null,
+            "Pagination"
+          ],
+          "name": "pagination"
+        }
+      ]
+    },
+    {
       "type": "enum",
       "name": "HeaderPlaintextVersion",
       "symbols": [
@@ -662,12 +693,30 @@
     },
     {
       "type": "record",
+      "name": "ConversationErrorLocal",
+      "fields": [
+        {
+          "type": "string",
+          "name": "message"
+        },
+        {
+          "type": "Conversation",
+          "name": "remoteConv"
+        },
+        {
+          "type": "boolean",
+          "name": "permanent"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "ConversationLocal",
       "fields": [
         {
           "type": [
             null,
-            "string"
+            "ConversationErrorLocal"
           ],
           "name": "error"
         },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -605,6 +605,12 @@ export type Conversation = {
   maxMsgs?: ?Array<MessageBoxed>,
 }
 
+export type ConversationErrorLocal = {
+  message: string,
+  remoteConv: Conversation,
+  permanent: boolean,
+}
+
 export type ConversationFinalizeInfo = {
   resetUser: string,
   resetDate: string,
@@ -633,7 +639,7 @@ export type ConversationInfoLocal = {
 }
 
 export type ConversationLocal = {
-  error?: ?string,
+  error?: ?ConversationErrorLocal,
   info: ConversationInfoLocal,
   readerInfo: ConversationReaderInfo,
   supersedes?: ?Array<ConversationID>,
@@ -826,6 +832,13 @@ export type HeaderPlaintextV1 = {
 
 export type HeaderPlaintextVersion = 
     1 // V1_1
+
+export type Inbox = {
+  version: InboxVers,
+  convsUnverified?: ?Array<Conversation>,
+  convs?: ?Array<ConversationLocal>,
+  pagination?: ?Pagination,
+}
 
 export type InboxResType = 
     0 // VERSIONHIT_0


### PR DESCRIPTION
So this patch is very large because I refactored inboxsource.go a bunch (which spilled over into chat_local.go and gregor.go). I've outlined my strategy below:

1.) We store the server result from `GetInboxRemote` on the disk. Unboxing of `MaxMessages` uses the bodies cache, so we don't need to store them twice.
2.) In order to know we can serve a given query+pagination request for reading the inbox, we track which queries we've seen before. IFF we have seen the query+pagination before, we will serve results from the cache.
3.) inbox.go implements running query conditions and performing pagination in a way identical to the server. It also handles finalize mechanics properly.
4.) Add way more logging, and label it better so chat activity is more easily pulled out of the logs with grep.
5.) Add the `Syncer` type, which now runs the show on alerting the frontend about changes in the validity of both the inbox and bodies cache. This will be triggered either from traditional reasons (disconnect, bad Gregor new message), but as well if the inbox version mismatches the stored copy. On reconnect, we load the inbox version and compare to the disk.
6.) Trigger `Syncer` notifications if we detect an inbox version mismatch on any Gregor message from `HybridInboxSource`.
7.) Put `InboxSource` on the global context, so it can be easily found and configured from the environment.
8.) Add a bunch of tests for inbox.go, and use `HybridInboxSource` in all the rest of the `chat`and `service` package tests.

Anyway, apologies for the length of this, but I wasn't sure how else to get this up here.