### PR TITLE
Use oneway for chat ui attachment notifications

### DIFF
--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -92,7 +92,7 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 					err = i.ChatAttachmentUploadStart(ctx, (*typedArgs)[0].SessionID)
 					return
 				},
-				MethodType: rpc.MethodCall,
+				MethodType: rpc.MethodNotify,
 			},
 			"chatAttachmentUploadProgress": {
 				MakeArg: func() interface{} {
@@ -108,7 +108,7 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 					err = i.ChatAttachmentUploadProgress(ctx, (*typedArgs)[0])
 					return
 				},
-				MethodType: rpc.MethodCall,
+				MethodType: rpc.MethodNotify,
 			},
 			"chatAttachmentUploadDone": {
 				MakeArg: func() interface{} {
@@ -124,7 +124,7 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 					err = i.ChatAttachmentUploadDone(ctx, (*typedArgs)[0].SessionID)
 					return
 				},
-				MethodType: rpc.MethodCall,
+				MethodType: rpc.MethodNotify,
 			},
 			"chatAttachmentPreviewUploadStart": {
 				MakeArg: func() interface{} {
@@ -140,7 +140,7 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 					err = i.ChatAttachmentPreviewUploadStart(ctx, (*typedArgs)[0].SessionID)
 					return
 				},
-				MethodType: rpc.MethodCall,
+				MethodType: rpc.MethodNotify,
 			},
 			"chatAttachmentPreviewUploadDone": {
 				MakeArg: func() interface{} {
@@ -156,7 +156,7 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 					err = i.ChatAttachmentPreviewUploadDone(ctx, (*typedArgs)[0].SessionID)
 					return
 				},
-				MethodType: rpc.MethodCall,
+				MethodType: rpc.MethodNotify,
 			},
 			"chatAttachmentDownloadStart": {
 				MakeArg: func() interface{} {
@@ -172,7 +172,7 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 					err = i.ChatAttachmentDownloadStart(ctx, (*typedArgs)[0].SessionID)
 					return
 				},
-				MethodType: rpc.MethodCall,
+				MethodType: rpc.MethodNotify,
 			},
 			"chatAttachmentDownloadProgress": {
 				MakeArg: func() interface{} {
@@ -188,7 +188,7 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 					err = i.ChatAttachmentDownloadProgress(ctx, (*typedArgs)[0])
 					return
 				},
-				MethodType: rpc.MethodCall,
+				MethodType: rpc.MethodNotify,
 			},
 			"chatAttachmentDownloadDone": {
 				MakeArg: func() interface{} {
@@ -204,7 +204,7 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 					err = i.ChatAttachmentDownloadDone(ctx, (*typedArgs)[0].SessionID)
 					return
 				},
-				MethodType: rpc.MethodCall,
+				MethodType: rpc.MethodNotify,
 			},
 			"chatInboxUnverified": {
 				MakeArg: func() interface{} {
@@ -264,47 +264,47 @@ type ChatUiClient struct {
 
 func (c ChatUiClient) ChatAttachmentUploadStart(ctx context.Context, sessionID int) (err error) {
 	__arg := ChatAttachmentUploadStartArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatAttachmentUploadStart", []interface{}{__arg}, nil)
+	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatAttachmentUploadStart", []interface{}{__arg})
 	return
 }
 
 func (c ChatUiClient) ChatAttachmentUploadProgress(ctx context.Context, __arg ChatAttachmentUploadProgressArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatAttachmentUploadProgress", []interface{}{__arg}, nil)
+	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatAttachmentUploadProgress", []interface{}{__arg})
 	return
 }
 
 func (c ChatUiClient) ChatAttachmentUploadDone(ctx context.Context, sessionID int) (err error) {
 	__arg := ChatAttachmentUploadDoneArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatAttachmentUploadDone", []interface{}{__arg}, nil)
+	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatAttachmentUploadDone", []interface{}{__arg})
 	return
 }
 
 func (c ChatUiClient) ChatAttachmentPreviewUploadStart(ctx context.Context, sessionID int) (err error) {
 	__arg := ChatAttachmentPreviewUploadStartArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatAttachmentPreviewUploadStart", []interface{}{__arg}, nil)
+	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatAttachmentPreviewUploadStart", []interface{}{__arg})
 	return
 }
 
 func (c ChatUiClient) ChatAttachmentPreviewUploadDone(ctx context.Context, sessionID int) (err error) {
 	__arg := ChatAttachmentPreviewUploadDoneArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatAttachmentPreviewUploadDone", []interface{}{__arg}, nil)
+	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatAttachmentPreviewUploadDone", []interface{}{__arg})
 	return
 }
 
 func (c ChatUiClient) ChatAttachmentDownloadStart(ctx context.Context, sessionID int) (err error) {
 	__arg := ChatAttachmentDownloadStartArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatAttachmentDownloadStart", []interface{}{__arg}, nil)
+	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatAttachmentDownloadStart", []interface{}{__arg})
 	return
 }
 
 func (c ChatUiClient) ChatAttachmentDownloadProgress(ctx context.Context, __arg ChatAttachmentDownloadProgressArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatAttachmentDownloadProgress", []interface{}{__arg}, nil)
+	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatAttachmentDownloadProgress", []interface{}{__arg})
 	return
 }
 
 func (c ChatUiClient) ChatAttachmentDownloadDone(ctx context.Context, sessionID int) (err error) {
 	__arg := ChatAttachmentDownloadDoneArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "chat.1.chatUi.chatAttachmentDownloadDone", []interface{}{__arg}, nil)
+	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatAttachmentDownloadDone", []interface{}{__arg})
 	return
 }
 

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -1,16 +1,16 @@
 @namespace("chat.1")
 
 protocol chatUi {
-  void chatAttachmentUploadStart(int sessionID);	
-  void chatAttachmentUploadProgress(int sessionID, int bytesComplete, int bytesTotal);     
-  void chatAttachmentUploadDone(int sessionID);	
+  void chatAttachmentUploadStart(int sessionID) oneway;	
+  void chatAttachmentUploadProgress(int sessionID, int bytesComplete, int bytesTotal) oneway;     
+  void chatAttachmentUploadDone(int sessionID) oneway;	
 
-  void chatAttachmentPreviewUploadStart(int sessionID);	
-  void chatAttachmentPreviewUploadDone(int sessionID);	
+  void chatAttachmentPreviewUploadStart(int sessionID) oneway;	
+  void chatAttachmentPreviewUploadDone(int sessionID) oneway;	
 
-  void chatAttachmentDownloadStart(int sessionID);	
-  void chatAttachmentDownloadProgress(int sessionID, int bytesComplete, int bytesTotal);     
-  void chatAttachmentDownloadDone(int sessionID);	
+  void chatAttachmentDownloadStart(int sessionID) oneway;	
+  void chatAttachmentDownloadProgress(int sessionID, int bytesComplete, int bytesTotal) oneway;     
+  void chatAttachmentDownloadDone(int sessionID) oneway;	
 
   void chatInboxUnverified(int sessionID, GetInboxLocalRes inbox); 
   void chatInboxConversation(int sessionID, ConversationLocal conv);

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -10,7 +10,8 @@
           "type": "int"
         }
       ],
-      "response": null
+      "response": null,
+      "oneway": true
     },
     "chatAttachmentUploadProgress": {
       "request": [
@@ -27,7 +28,8 @@
           "type": "int"
         }
       ],
-      "response": null
+      "response": null,
+      "oneway": true
     },
     "chatAttachmentUploadDone": {
       "request": [
@@ -36,7 +38,8 @@
           "type": "int"
         }
       ],
-      "response": null
+      "response": null,
+      "oneway": true
     },
     "chatAttachmentPreviewUploadStart": {
       "request": [
@@ -45,7 +48,8 @@
           "type": "int"
         }
       ],
-      "response": null
+      "response": null,
+      "oneway": true
     },
     "chatAttachmentPreviewUploadDone": {
       "request": [
@@ -54,7 +58,8 @@
           "type": "int"
         }
       ],
-      "response": null
+      "response": null,
+      "oneway": true
     },
     "chatAttachmentDownloadStart": {
       "request": [
@@ -63,7 +68,8 @@
           "type": "int"
         }
       ],
-      "response": null
+      "response": null,
+      "oneway": true
     },
     "chatAttachmentDownloadProgress": {
       "request": [
@@ -80,7 +86,8 @@
           "type": "int"
         }
       ],
-      "response": null
+      "response": null,
+      "oneway": true
     },
     "chatAttachmentDownloadDone": {
       "request": [
@@ -89,7 +96,8 @@
           "type": "int"
         }
       ],
-      "response": null
+      "response": null,
+      "oneway": true
     },
     "chatInboxUnverified": {
       "request": [


### PR DESCRIPTION
There was an issue where electron wasn't responding to chatAttachmentUploadDone and thus the service was hanging and never sending the MessageAttachment to gregord.

Changing these to oneway should make it so there is no wait.
