### PR TITLE
Include AssetMetadata in ChatUI.*UploadStart

### DIFF
--- a/go/client/chat_ui.go
+++ b/go/client/chat_ui.go
@@ -20,7 +20,7 @@ type ChatUI struct {
 	lastPercentReported int
 }
 
-func (c *ChatUI) ChatAttachmentUploadStart(context.Context, int) error {
+func (c *ChatUI) ChatAttachmentUploadStart(context.Context, chat1.ChatAttachmentUploadStartArg) error {
 	if c.noOutput {
 		return nil
 	}
@@ -51,7 +51,7 @@ func (c *ChatUI) ChatAttachmentUploadDone(context.Context, int) error {
 	return nil
 }
 
-func (c *ChatUI) ChatAttachmentPreviewUploadStart(context.Context, int) error {
+func (c *ChatUI) ChatAttachmentPreviewUploadStart(context.Context, chat1.ChatAttachmentPreviewUploadStartArg) error {
 	if c.noOutput {
 		return nil
 	}

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -486,7 +486,7 @@ func NewChatUI(cb chan NonblockInboxResult) *ChatUI {
 	}
 }
 
-func (c *ChatUI) ChatAttachmentUploadStart(context.Context) error {
+func (c *ChatUI) ChatAttachmentUploadStart(context.Context, chat1.AssetMetadata) error {
 	return nil
 }
 
@@ -498,7 +498,7 @@ func (c *ChatUI) ChatAttachmentUploadDone(context.Context) error {
 	return nil
 }
 
-func (c *ChatUI) ChatAttachmentPreviewUploadStart(context.Context) error {
+func (c *ChatUI) ChatAttachmentPreviewUploadStart(context.Context, chat1.AssetMetadata) error {
 	return nil
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -334,10 +334,10 @@ type ProvisionUI interface {
 }
 
 type ChatUI interface {
-	ChatAttachmentUploadStart(context.Context) error
+	ChatAttachmentUploadStart(context.Context, chat1.AssetMetadata) error
 	ChatAttachmentUploadProgress(context.Context, chat1.ChatAttachmentUploadProgressArg) error
 	ChatAttachmentUploadDone(context.Context) error
-	ChatAttachmentPreviewUploadStart(context.Context) error
+	ChatAttachmentPreviewUploadStart(context.Context, chat1.AssetMetadata) error
 	ChatAttachmentPreviewUploadDone(context.Context) error
 	ChatAttachmentDownloadStart(context.Context) error
 	ChatAttachmentDownloadProgress(context.Context, chat1.ChatAttachmentDownloadProgressArg) error

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -9,7 +9,8 @@ import (
 )
 
 type ChatAttachmentUploadStartArg struct {
-	SessionID int `codec:"sessionID" json:"sessionID"`
+	SessionID int           `codec:"sessionID" json:"sessionID"`
+	Metadata  AssetMetadata `codec:"metadata" json:"metadata"`
 }
 
 type ChatAttachmentUploadProgressArg struct {
@@ -23,7 +24,8 @@ type ChatAttachmentUploadDoneArg struct {
 }
 
 type ChatAttachmentPreviewUploadStartArg struct {
-	SessionID int `codec:"sessionID" json:"sessionID"`
+	SessionID int           `codec:"sessionID" json:"sessionID"`
+	Metadata  AssetMetadata `codec:"metadata" json:"metadata"`
 }
 
 type ChatAttachmentPreviewUploadDoneArg struct {
@@ -61,10 +63,10 @@ type ChatInboxFailedArg struct {
 }
 
 type ChatUiInterface interface {
-	ChatAttachmentUploadStart(context.Context, int) error
+	ChatAttachmentUploadStart(context.Context, ChatAttachmentUploadStartArg) error
 	ChatAttachmentUploadProgress(context.Context, ChatAttachmentUploadProgressArg) error
 	ChatAttachmentUploadDone(context.Context, int) error
-	ChatAttachmentPreviewUploadStart(context.Context, int) error
+	ChatAttachmentPreviewUploadStart(context.Context, ChatAttachmentPreviewUploadStartArg) error
 	ChatAttachmentPreviewUploadDone(context.Context, int) error
 	ChatAttachmentDownloadStart(context.Context, int) error
 	ChatAttachmentDownloadProgress(context.Context, ChatAttachmentDownloadProgressArg) error
@@ -89,7 +91,7 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]ChatAttachmentUploadStartArg)(nil), args)
 						return
 					}
-					err = i.ChatAttachmentUploadStart(ctx, (*typedArgs)[0].SessionID)
+					err = i.ChatAttachmentUploadStart(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodNotify,
@@ -137,7 +139,7 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]ChatAttachmentPreviewUploadStartArg)(nil), args)
 						return
 					}
-					err = i.ChatAttachmentPreviewUploadStart(ctx, (*typedArgs)[0].SessionID)
+					err = i.ChatAttachmentPreviewUploadStart(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodNotify,
@@ -262,8 +264,7 @@ type ChatUiClient struct {
 	Cli rpc.GenericClient
 }
 
-func (c ChatUiClient) ChatAttachmentUploadStart(ctx context.Context, sessionID int) (err error) {
-	__arg := ChatAttachmentUploadStartArg{SessionID: sessionID}
+func (c ChatUiClient) ChatAttachmentUploadStart(ctx context.Context, __arg ChatAttachmentUploadStartArg) (err error) {
 	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatAttachmentUploadStart", []interface{}{__arg})
 	return
 }
@@ -279,8 +280,7 @@ func (c ChatUiClient) ChatAttachmentUploadDone(ctx context.Context, sessionID in
 	return
 }
 
-func (c ChatUiClient) ChatAttachmentPreviewUploadStart(ctx context.Context, sessionID int) (err error) {
-	__arg := ChatAttachmentPreviewUploadStartArg{SessionID: sessionID}
+func (c ChatUiClient) ChatAttachmentPreviewUploadStart(ctx context.Context, __arg ChatAttachmentPreviewUploadStartArg) (err error) {
 	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatAttachmentPreviewUploadStart", []interface{}{__arg})
 	return
 }

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -866,7 +866,7 @@ func (h *chatLocalHandler) postAttachmentLocal(ctx context.Context, arg postAtta
 	var g errgroup.Group
 
 	g.Go(func() error {
-		chatUI.ChatAttachmentUploadStart(ctx)
+		chatUI.ChatAttachmentUploadStart(ctx, pre.BaseMetadata())
 		var err error
 		object, err = h.uploadAsset(ctx, arg.SessionID, params, arg.Attachment, arg.ConversationID, progress)
 		chatUI.ChatAttachmentUploadDone(ctx)
@@ -878,7 +878,7 @@ func (h *chatLocalHandler) postAttachmentLocal(ctx context.Context, arg postAtta
 
 	if arg.Preview != nil {
 		g.Go(func() error {
-			chatUI.ChatAttachmentPreviewUploadStart(ctx)
+			chatUI.ChatAttachmentPreviewUploadStart(ctx, pre.PreviewMetadata())
 			// copy the params so as not to mess with the main params above
 			previewParams := params
 

--- a/go/service/remote_chat_ui.go
+++ b/go/service/remote_chat_ui.go
@@ -19,8 +19,12 @@ func NewRemoteChatUI(sessionID int, c *rpc.Client) *RemoteChatUI {
 	}
 }
 
-func (r *RemoteChatUI) ChatAttachmentUploadStart(ctx context.Context) error {
-	return r.cli.ChatAttachmentUploadStart(ctx, r.sessionID)
+func (r *RemoteChatUI) ChatAttachmentUploadStart(ctx context.Context, metadata chat1.AssetMetadata) error {
+	arg := chat1.ChatAttachmentUploadStartArg{
+		SessionID: r.sessionID,
+		Metadata:  metadata,
+	}
+	return r.cli.ChatAttachmentUploadStart(ctx, arg)
 }
 
 func (r *RemoteChatUI) ChatAttachmentUploadProgress(ctx context.Context, arg chat1.ChatAttachmentUploadProgressArg) error {
@@ -32,8 +36,12 @@ func (r *RemoteChatUI) ChatAttachmentUploadDone(ctx context.Context) error {
 	return r.cli.ChatAttachmentUploadDone(ctx, r.sessionID)
 }
 
-func (r *RemoteChatUI) ChatAttachmentPreviewUploadStart(ctx context.Context) error {
-	return r.cli.ChatAttachmentPreviewUploadStart(ctx, r.sessionID)
+func (r *RemoteChatUI) ChatAttachmentPreviewUploadStart(ctx context.Context, metadata chat1.AssetMetadata) error {
+	arg := chat1.ChatAttachmentPreviewUploadStartArg{
+		SessionID: r.sessionID,
+		Metadata:  metadata,
+	}
+	return r.cli.ChatAttachmentPreviewUploadStart(ctx, arg)
 }
 
 func (r *RemoteChatUI) ChatAttachmentPreviewUploadDone(ctx context.Context) error {

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -1,11 +1,11 @@
 @namespace("chat.1")
 
 protocol chatUi {
-  void chatAttachmentUploadStart(int sessionID) oneway;	
+  void chatAttachmentUploadStart(int sessionID, AssetMetadata metadata) oneway;	
   void chatAttachmentUploadProgress(int sessionID, int bytesComplete, int bytesTotal) oneway;     
   void chatAttachmentUploadDone(int sessionID) oneway;	
 
-  void chatAttachmentPreviewUploadStart(int sessionID) oneway;	
+  void chatAttachmentPreviewUploadStart(int sessionID, AssetMetadata metadata) oneway;	
   void chatAttachmentPreviewUploadDone(int sessionID) oneway;	
 
   void chatAttachmentDownloadStart(int sessionID) oneway;	

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1200,9 +1200,17 @@ export type chatUiChatAttachmentDownloadProgressRpcParam = Exact<{
   bytesTotal: int
 }>
 
+export type chatUiChatAttachmentPreviewUploadStartRpcParam = Exact<{
+  metadata: AssetMetadata
+}>
+
 export type chatUiChatAttachmentUploadProgressRpcParam = Exact<{
   bytesComplete: int,
   bytesTotal: int
+}>
+
+export type chatUiChatAttachmentUploadStartRpcParam = Exact<{
+  metadata: AssetMetadata
 }>
 
 export type chatUiChatInboxConversationRpcParam = Exact<{
@@ -1530,7 +1538,8 @@ export type rpc =
 export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatAttachmentUploadStart'?: (
     params: Exact<{
-      sessionID: int
+      sessionID: int,
+      metadata: AssetMetadata
     }>,
     response: CommonResponseHandler
   ) => void,
@@ -1550,7 +1559,8 @@ export type incomingCallMapType = Exact<{
   ) => void,
   'keybase.1.chatUi.chatAttachmentPreviewUploadStart'?: (
     params: Exact<{
-      sessionID: int
+      sessionID: int,
+      metadata: AssetMetadata
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -8,6 +8,10 @@
         {
           "name": "sessionID",
           "type": "int"
+        },
+        {
+          "name": "metadata",
+          "type": "AssetMetadata"
         }
       ],
       "response": null,
@@ -46,6 +50,10 @@
         {
           "name": "sessionID",
           "type": "int"
+        },
+        {
+          "name": "metadata",
+          "type": "AssetMetadata"
         }
       ],
       "response": null,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1200,9 +1200,17 @@ export type chatUiChatAttachmentDownloadProgressRpcParam = Exact<{
   bytesTotal: int
 }>
 
+export type chatUiChatAttachmentPreviewUploadStartRpcParam = Exact<{
+  metadata: AssetMetadata
+}>
+
 export type chatUiChatAttachmentUploadProgressRpcParam = Exact<{
   bytesComplete: int,
   bytesTotal: int
+}>
+
+export type chatUiChatAttachmentUploadStartRpcParam = Exact<{
+  metadata: AssetMetadata
 }>
 
 export type chatUiChatInboxConversationRpcParam = Exact<{
@@ -1530,7 +1538,8 @@ export type rpc =
 export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatAttachmentUploadStart'?: (
     params: Exact<{
-      sessionID: int
+      sessionID: int,
+      metadata: AssetMetadata
     }>,
     response: CommonResponseHandler
   ) => void,
@@ -1550,7 +1559,8 @@ export type incomingCallMapType = Exact<{
   ) => void,
   'keybase.1.chatUi.chatAttachmentPreviewUploadStart'?: (
     params: Exact<{
-      sessionID: int
+      sessionID: int,
+      metadata: AssetMetadata
     }>,
     response: CommonResponseHandler
   ) => void,


### PR DESCRIPTION
Desktop wants image dimensions before uploads start.

cc @MarcoPolo @chromakode 

