### PR TITLE
Pinentry and tracker popups should always be on top of main window

### DIFF
--- a/shared/desktop/renderer/remote-component.desktop.js
+++ b/shared/desktop/renderer/remote-component.desktop.js
@@ -47,6 +47,7 @@ class RemoteComponent extends Component {
       ...this.props.windowsOpts}
 
     this.remoteWindow = new BrowserWindow(windowsOpts)
+    this.remoteWindow.setAlwaysOnTop(true)
 
     if (this.props.positionBottomRight && electron.screen.getPrimaryDisplay()) {
       const {width, height} = electron.screen.getPrimaryDisplay().workAreaSize


### PR DESCRIPTION
The pinentry and tracker popups can get lost behind the main window. Electron offers an easy way to avoid this.