### PR TITLE
React list measuring fixes

### DIFF
--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -346,7 +346,7 @@ class ConversationList extends Component<void, Props, State> {
               width={width - scrollbarWidth} >
               {({getRowHeight}) => {
                 return <VirtualizedList
-                  style={{outline: 'none'}}
+                  style={listStyle}
                   height={height}
                   ref={r => { this._list = r }}
                   width={width}
@@ -367,6 +367,11 @@ class ConversationList extends Component<void, Props, State> {
       </div>
     )
   }
+}
+
+const listStyle = {
+  outline: 'none',
+  overflowX: 'hidden',
 }
 
 class CellSizeCache extends defaultCellMeasurerCellSizeCache {

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -30,6 +30,7 @@ type State = {
 
 const scrollbarWidth = 20
 const lockedToBottomSlop = 20
+const listBottomMargin = 10
 
 class ConversationList extends Component<void, Props, State> {
   _cellCache: any;
@@ -366,7 +367,7 @@ class ConversationList extends Component<void, Props, State> {
 const listStyle = {
   outline: 'none',
   overflowX: 'hidden',
-  paddingBottom: 10,
+  paddingBottom: listBottomMargin,
 }
 
 class CellSizeCache extends defaultCellMeasurerCellSizeCache {

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -11,7 +11,7 @@ import _ from 'lodash'
 import messageFactory from './messages'
 import shallowEqual from 'shallowequal'
 import {AutoSizer, CellMeasurer, List as VirtualizedList, defaultCellMeasurerCellSizeCache} from 'react-virtualized'
-import {Box, ProgressIndicator} from '../../common-adapters'
+import {ProgressIndicator} from '../../common-adapters'
 import {TextPopupMenu, AttachmentPopupMenu} from './messages/popup'
 import {clipboard} from 'electron'
 import {globalColors, globalStyles} from '../../styles'
@@ -29,6 +29,7 @@ type State = {
 }
 
 const scrollbarWidth = 20
+const lockedToBottomSlop = 20
 
 class ConversationList extends Component<void, Props, State> {
   _cellCache: any;
@@ -54,11 +55,7 @@ class ConversationList extends Component<void, Props, State> {
 
   _indexToID = index => {
     if (index === 0) {
-      // loader
-      return 0
-    } else if (index === this.state.messages.count() + 1) {
-      // footer
-      return -1
+      return 'loader'
     } else {
       // minus one because loader message is there
       const messageIndex = index - 1
@@ -165,7 +162,7 @@ class ConversationList extends Component<void, Props, State> {
     }
 
     // Lock to bottom if we are close to the bottom
-    const isLockedToBottom = scrollTop + clientHeight >= scrollHeight - 20
+    const isLockedToBottom = scrollTop + clientHeight >= scrollHeight - lockedToBottomSlop
     this.setState({
       isLockedToBottom,
       isScrolling: true,
@@ -174,7 +171,7 @@ class ConversationList extends Component<void, Props, State> {
 
     // This is debounced so it resets the call
     this._onScrollSettled()
-  }, 100)
+  }, 200)
 
   _hidePopup () {
     ReactDOM.unmountComponentAtNode(document.getElementById('popupContainer'))
@@ -243,9 +240,6 @@ class ConversationList extends Component<void, Props, State> {
     if (index === 0) {
       return <LoadingMore style={style} key={key || index} hasMoreItems={this.props.moreToLoad} />
     }
-    if (index === this.state.messages.count() + 1) {
-      return <Box key={'footer'} style={{height: 20}} />
-    }
 
     const message = this.state.messages.get(index - 1)
     const prevMessage = this.state.messages.get(index - 2)
@@ -293,7 +287,7 @@ class ConversationList extends Component<void, Props, State> {
         </div>
       )
     }
-    const rowCount = this.state.messages.count() + 2 // Loading row on top always and footer row
+    const rowCount = this.state.messages.count() + 1 // Loading row
     let scrollToIndex = this.state.isLockedToBottom ? rowCount - 1 : undefined
     let scrollTop = scrollToIndex ? undefined : this.state.scrollTop
 
@@ -372,10 +366,11 @@ class ConversationList extends Component<void, Props, State> {
 const listStyle = {
   outline: 'none',
   overflowX: 'hidden',
+  paddingBottom: 10,
 }
 
 class CellSizeCache extends defaultCellMeasurerCellSizeCache {
-  _indexToID: (index: number) => ?number;
+  _indexToID: (index: number) => any;
 
   constructor (indexToID) {
     super({uniformColumnWidth: true, uniformRowHeight: false})
@@ -408,3 +403,14 @@ class CellSizeCache extends defaultCellMeasurerCellSizeCache {
 }
 
 export default ConversationList
+
+if (__DEV__) {
+  window.showReactVirtualListMeasurer = () => {
+    const holder = window.document.body.lastChild
+    holder.style.zIndex = 9999
+    holder.style.backgroundColor = 'red'
+    holder.style.visibility = 'visible'
+    holder.style.left = '320px'
+    holder.style.top = '320px'
+  }
+}

--- a/shared/common-adapters/markdown.js
+++ b/shared/common-adapters/markdown.js
@@ -35,6 +35,7 @@ const codeSnippetBlockStyle = {
   paddingLeft: globalMargins.tiny,
   paddingRight: globalMargins.tiny,
   whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
 }
 
 // Order matters, since we want to match the longer ticks first

--- a/shared/common-adapters/markdown.js
+++ b/shared/common-adapters/markdown.js
@@ -13,9 +13,15 @@ import type {PropsOf} from '../constants/types/more'
 
 type TagInfo<C> = {Component: Class<C>, props: PropsOf<C>}
 
+const wrapStyle = {
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+}
+
 const codeSnippetStyle = {
   ...globalStyles.fontTerminal,
   ...globalStyles.rounded,
+  ...wrapStyle,
   fontSize: 12,
   paddingLeft: globalMargins.xtiny,
   paddingRight: globalMargins.xtiny,
@@ -25,6 +31,7 @@ const codeSnippetStyle = {
 
 const codeSnippetBlockStyle = {
   ...codeSnippetStyle,
+  ...wrapStyle,
   display: 'block',
   color: globalColors.black_75,
   backgroundColor: globalColors.beige,
@@ -34,8 +41,6 @@ const codeSnippetBlockStyle = {
   paddingBottom: globalMargins.xtiny,
   paddingLeft: globalMargins.tiny,
   paddingRight: globalMargins.tiny,
-  whiteSpace: 'pre-wrap',
-  wordBreak: 'break-word',
 }
 
 // Order matters, since we want to match the longer ticks first
@@ -58,7 +63,12 @@ const markToRegex = {
   ':': ':',
 }
 
-const plainStringTag = {Component: Text, props: {type: 'Body', style: {color: undefined}}}
+const plainStringStyle = {
+  ...wrapStyle,
+  color: undefined,
+}
+
+const plainStringTag = {Component: Text, props: {type: 'Body', style: plainStringStyle}}
 
 class EmojiIfExists extends PureComponent<void, EmojiProps, void> {
   render () {
@@ -71,9 +81,9 @@ class EmojiIfExists extends PureComponent<void, EmojiProps, void> {
 const initialOpenToTag = {
   '`': {Component: Text, props: {type: 'Body', style: codeSnippetStyle}},
   '```': {Component: Text, props: {type: 'Body', style: codeSnippetBlockStyle}},
-  '*': {Component: Text, props: {type: 'BodySemibold', style: {color: undefined}}},
-  '_': {Component: Text, props: {type: 'Body', style: {fontStyle: 'italic', fontWeight: undefined, color: undefined}}},
-  '~': {Component: Text, props: {type: 'Body', style: {textDecoration: 'line-through', fontWeight: undefined, color: undefined}}},
+  '*': {Component: Text, props: {type: 'BodySemibold', style: {...wrapStyle, color: undefined}}},
+  '_': {Component: Text, props: {type: 'Body', style: {...wrapStyle, fontStyle: 'italic', fontWeight: undefined, color: undefined}}},
+  '~': {Component: Text, props: {type: 'Body', style: {...wrapStyle, textDecoration: 'line-through', fontWeight: undefined, color: undefined}}},
   ':': {Component: EmojiIfExists, props: {size: 16}},
 }
 

--- a/shared/desktop/renderer/index.js
+++ b/shared/desktop/renderer/index.js
@@ -126,6 +126,19 @@ function setupApp (store) {
   store.dispatch(bootstrap())
 }
 
+const FontLoader = () => (
+  <div style={{height: 0, overflow: 'hidden', width: 0}}>
+    <p style={{fontFamily: 'kb'}}>kb</p>
+    <p style={{fontFamily: 'Source Code Pro', fontWeight: 400}}>source code pro 400</p>
+    <p style={{fontFamily: 'Source Code Pro', fontWeight: 600}}>source code pro 600</p>
+    <p style={{fontFamily: 'OpenSans', fontWeight: 400}}>open sans 400</p>
+    <p style={{fontFamily: 'OpenSans', fontStyle: 'italic', fontWeight: 400}}>open sans 400 i</p>
+    <p style={{fontFamily: 'OpenSans', fontWeight: 600}}>open sans 600</p>
+    <p style={{fontFamily: 'OpenSans', fontStyle: 'italic', fontWeight: 600}}>open sans 600 i</p>
+    <p style={{fontFamily: 'OpenSans', fontWeight: 700}}>open sans 700</p>
+  </div>
+)
+
 function render (store, MainComponent) {
   let dt
   if (__DEV__ && reduxDevToolsEnable) { // eslint-disable-line no-undef
@@ -138,6 +151,7 @@ function render (store, MainComponent) {
       <Root store={store}>
         <div style={{display: 'flex', flex: 1}}>
           <RemoteManager />
+          <FontLoader />
           <MainComponent />
           {dt}
         </div>


### PR DESCRIPTION
Couple of problems

- [x] Long lines weren't wrapping
- [x] Footer row was causing measuring problems (caching needed to be invalidated, removed for now)
- [x] Horizontal scrollbar could show sometimes, lets just never let that happen
- [x] In dev builds enable window. showReactVirtualListMeasurer so we can show the renderer react list uses to measure things
- [x] Preload all fonts, this causes mismeasurement of cells due to fonts not being loaded

@keybase/react-hackers 