### PR TITLE
run GetTLFCryptKeys if we get a user changed event CORE-4353

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -215,6 +215,11 @@ func (i *Identify2WithUIDTester) DidFullUserLoad(uid keybase1.UID) {
 	i.userLoads[uid]++
 }
 
+func (i *Identify2WithUIDTester) Delete(uid keybase1.UID) error {
+	delete(i.cache, uid)
+	return nil
+}
+
 func (i *Identify2WithUIDTester) Shutdown() {}
 
 var _ libkb.Identify2Cacher = (*Identify2WithUIDTester)(nil)

--- a/go/libkb/identify2_cache.go
+++ b/go/libkb/identify2_cache.go
@@ -22,6 +22,7 @@ type Identify2Cacher interface {
 	Insert(up *keybase1.Identify2Res) error
 	DidFullUserLoad(keybase1.UID)
 	Shutdown()
+	Delete(uid keybase1.UID) error
 }
 
 type GetCheckTimeFunc func(keybase1.Identify2Res) keybase1.Time
@@ -78,6 +79,10 @@ func (c *Identify2Cache) Insert(up *keybase1.Identify2Res) error {
 	copy := &tmp
 	copy.Upk.Uvv.CachedAt = keybase1.ToTime(time.Now())
 	return c.cache.Set(string(up.Upk.Uid), copy)
+}
+
+func (c *Identify2Cache) Delete(uid keybase1.UID) error {
+	return c.cache.Delete(string(uid))
 }
 
 // Shutdown stops any goroutines in the cache.

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -271,6 +271,10 @@ func (d *Service) createChatSources() {
 
 	d.G().ConvSource = chat.NewConversationSource(d.G(), d.G().Env.GetConvSourceType(),
 		boxer, storage.New(d.G(), si), ri)
+
+	// Add a tlfHandler into the user changed handler group so we can keep identify info
+	// fresh
+	d.G().AddUserChangedHandler(newTlfHandler(nil, d.G()))
 }
 
 func (d *Service) configureRekey(uir *UIRouter) {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -242,6 +242,10 @@ func (d *Service) RunBackgroundOperations(uir *UIRouter) {
 	d.configureRekey(uir)
 	d.tryLogin()
 	d.runBackgroundIdentifier()
+
+	// Add a tlfHandler into the user changed handler group so we can keep identify info
+	// fresh
+	d.G().AddUserChangedHandler(newTlfHandler(nil, d.G()))
 }
 
 func (d *Service) createMessageDeliverer() {
@@ -272,9 +276,6 @@ func (d *Service) createChatSources() {
 	d.G().ConvSource = chat.NewConversationSource(d.G(), d.G().Env.GetConvSourceType(),
 		boxer, storage.New(d.G(), si), ri)
 
-	// Add a tlfHandler into the user changed handler group so we can keep identify info
-	// fresh
-	d.G().AddUserChangedHandler(newTlfHandler(nil, d.G()))
 }
 
 func (d *Service) configureRekey(uir *UIRouter) {

--- a/go/service/tlf.go
+++ b/go/service/tlf.go
@@ -156,6 +156,12 @@ func (h *tlfHandler) HandleUserChanged(uid keybase1.UID) (err error) {
 	notifier := chat.NewIdentifyNotifier(h.G())
 	ctx := chat.Context(context.Background(), ident, &breaks, notifier)
 
+	// Take this guy out of the cache, we want this to run fresh
+	if err = h.G().Identify2Cache.Delete(uid); err != nil {
+		h.G().Log.Debug("tlfHandler: HandleUserChanged(): unable to delete cache entry: uid: %s: err: %s", uid, err.Error())
+		return err
+	}
+
 	// Run against CryptKeys to generate notifications if necessary
 	_, err = h.CryptKeys(ctx, keybase1.TLFQuery{
 		TlfName:          tlfName,


### PR DESCRIPTION
The idea here is to listen for a "user changed" event (which is generated in a variety of relevant places, especially tracking), and to then run `GetTLFCryptKeys`  on the TLF with the current user and the user that has been tracked. This gets the necessary notifications to the frontend.