### PR TITLE
Change chat1 protocol to support multiple preview assets

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -232,10 +232,24 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 	}
 	switch bodyVersion {
 	case chat1.BodyPlaintextVersion_V1:
+		bodyUpgraded, err := chat1.ConvertMessageBodyV1ToV2(body.V1().MessageBody)
+		if err != nil {
+			return unboxMessageWithKeyRes{}, NewPermanentUnboxingError(err)
+		}
 		return unboxMessageWithKeyRes{
 			messagePlaintext: chat1.MessagePlaintext{
 				ClientHeader: clientHeader,
-				MessageBody:  body.V1().MessageBody,
+				MessageBody:  bodyUpgraded,
+			},
+			headerHash:            headerHash,
+			headerSignature:       headerSignature,
+			senderDeviceRevokedAt: validity.senderDeviceRevokedAt,
+		}, nil
+	case chat1.BodyPlaintextVersion_V2:
+		return unboxMessageWithKeyRes{
+			messagePlaintext: chat1.MessagePlaintext{
+				ClientHeader: clientHeader,
+				MessageBody:  body.V2().MessageBody,
 			},
 			headerHash:            headerHash,
 			headerSignature:       headerSignature,
@@ -343,7 +357,7 @@ func (b *Boxer) BoxMessage(ctx context.Context, msg chat1.MessagePlaintext, sign
 		return nil, NewBoxingError(msg, false)
 	}
 
-	boxed, err := b.boxMessageWithKeysV1(msg, recentKey, signingKeyPair)
+	boxed, err := b.boxMessageWithKeys(msg, recentKey, signingKeyPair)
 	if err != nil {
 		return nil, NewBoxingError(err.Error(), true)
 	}
@@ -351,15 +365,15 @@ func (b *Boxer) BoxMessage(ctx context.Context, msg chat1.MessagePlaintext, sign
 	return boxed, nil
 }
 
-// boxMessageWithKeysV1 encrypts and signs a keybase1.MessagePlaintextV1 into a
+// boxMessageWithKeys encrypts and signs a keybase1.MessagePlaintext into a
 // chat1.MessageBoxed given a keybase1.CryptKey.
-func (b *Boxer) boxMessageWithKeysV1(msg chat1.MessagePlaintext, key *keybase1.CryptKey,
+func (b *Boxer) boxMessageWithKeys(msg chat1.MessagePlaintext, key *keybase1.CryptKey,
 	signingKeyPair libkb.NaclSigningKeyPair) (*chat1.MessageBoxed, error) {
 
-	body := chat1.BodyPlaintextV1{
+	body := chat1.BodyPlaintextV2{
 		MessageBody: msg.MessageBody,
 	}
-	plaintextBody := chat1.NewBodyPlaintextWithV1(body)
+	plaintextBody := chat1.NewBodyPlaintextWithV2(body)
 	encryptedBody, err := b.seal(plaintextBody, key)
 	if err != nil {
 		return nil, err

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -113,7 +113,7 @@ func TestChatMessageBox(t *testing.T) {
 	msg := textMsg(t, "hello")
 	tc, boxer := setupChatTest(t, "box")
 	defer tc.Cleanup()
-	boxed, err := boxer.boxMessageWithKeysV1(msg, key, getSigningKeyPairForTest(t, tc, nil))
+	boxed, err := boxer.boxMessageWithKeys(msg, key, getSigningKeyPairForTest(t, tc, nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +137,7 @@ func TestChatMessageUnbox(t *testing.T) {
 
 	signKP := getSigningKeyPairForTest(t, tc, u)
 
-	boxed, err := boxer.boxMessageWithKeysV1(msg, key, signKP)
+	boxed, err := boxer.boxMessageWithKeys(msg, key, signKP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +184,7 @@ func TestChatMessageInvalidBodyHash(t *testing.T) {
 		return sum[:]
 	}
 
-	boxed, err := boxer.boxMessageWithKeysV1(msg, key, signKP)
+	boxed, err := boxer.boxMessageWithKeys(msg, key, signKP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +331,7 @@ func TestChatMessageInvalidHeaderSig(t *testing.T) {
 		return sigInfo, nil
 	}
 
-	boxed, err := boxer.boxMessageWithKeysV1(msg, key, signKP)
+	boxed, err := boxer.boxMessageWithKeys(msg, key, signKP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -369,7 +369,7 @@ func TestChatMessageInvalidSenderKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	boxed, err := boxer.boxMessageWithKeysV1(msg, key, signKP)
+	boxed, err := boxer.boxMessageWithKeys(msg, key, signKP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -430,7 +430,7 @@ func TestChatMessageRevokedKeyThenSent(t *testing.T) {
 	// Sign a message using a key of u's that has been revoked
 	t.Logf("signing message")
 	msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()))
-	boxed, err := boxer.boxMessageWithKeysV1(msg, key, signKP)
+	boxed, err := boxer.boxMessageWithKeys(msg, key, signKP)
 	require.NoError(t, err)
 
 	boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -483,7 +483,7 @@ func TestChatMessageSentThenRevokedSenderKey(t *testing.T) {
 	// Sign a message using a key of u's that has not yet been revoked
 	t.Logf("signing message")
 	msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()))
-	boxed, err := boxer.boxMessageWithKeysV1(msg, key, signKP)
+	boxed, err := boxer.boxMessageWithKeys(msg, key, signKP)
 	require.NoError(t, err)
 
 	boxed.ServerHeader = &chat1.MessageServerHeader{

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -420,7 +420,7 @@ func newMessageViewValid(g *libkb.GlobalContext, conversationID chat1.Conversati
 			title = filepath.Base(att.Object.Filename)
 		}
 		mv.Body = fmt.Sprintf("%s <attachment ID: %d>", title, m.ServerHeader.MessageID)
-		if att.Preview != nil {
+		if len(att.Previews) > 0 {
 			mv.Body += " [preview available]"
 		}
 		if mvsup != nil {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -165,10 +165,16 @@ type Asset struct {
 	Metadata  AssetMetadata `codec:"metadata" json:"metadata"`
 }
 
-type MessageAttachment struct {
+type MessageAttachmentV1 struct {
 	Object   Asset  `codec:"object" json:"object"`
 	Preview  *Asset `codec:"preview,omitempty" json:"preview,omitempty"`
 	Metadata []byte `codec:"metadata" json:"metadata"`
+}
+
+type MessageAttachment struct {
+	Object   Asset   `codec:"object" json:"object"`
+	Previews []Asset `codec:"previews" json:"previews"`
+	Metadata []byte  `codec:"metadata" json:"metadata"`
 }
 
 type MessageBody struct {
@@ -314,6 +320,154 @@ func NewMessageBodyWithMetadata(v MessageConversationMetadata) MessageBody {
 
 func NewMessageBodyWithHeadline(v MessageHeadline) MessageBody {
 	return MessageBody{
+		MessageType__: MessageType_HEADLINE,
+		Headline__:    &v,
+	}
+}
+
+type MessageBodyV1 struct {
+	MessageType__ MessageType                  `codec:"messageType" json:"messageType"`
+	Text__        *MessageText                 `codec:"text,omitempty" json:"text,omitempty"`
+	Attachment__  *MessageAttachmentV1         `codec:"attachment,omitempty" json:"attachment,omitempty"`
+	Edit__        *MessageEdit                 `codec:"edit,omitempty" json:"edit,omitempty"`
+	Delete__      *MessageDelete               `codec:"delete,omitempty" json:"delete,omitempty"`
+	Metadata__    *MessageConversationMetadata `codec:"metadata,omitempty" json:"metadata,omitempty"`
+	Headline__    *MessageHeadline             `codec:"headline,omitempty" json:"headline,omitempty"`
+}
+
+func (o *MessageBodyV1) MessageType() (ret MessageType, err error) {
+	switch o.MessageType__ {
+	case MessageType_TEXT:
+		if o.Text__ == nil {
+			err = errors.New("unexpected nil value for Text__")
+			return ret, err
+		}
+	case MessageType_ATTACHMENT:
+		if o.Attachment__ == nil {
+			err = errors.New("unexpected nil value for Attachment__")
+			return ret, err
+		}
+	case MessageType_EDIT:
+		if o.Edit__ == nil {
+			err = errors.New("unexpected nil value for Edit__")
+			return ret, err
+		}
+	case MessageType_DELETE:
+		if o.Delete__ == nil {
+			err = errors.New("unexpected nil value for Delete__")
+			return ret, err
+		}
+	case MessageType_METADATA:
+		if o.Metadata__ == nil {
+			err = errors.New("unexpected nil value for Metadata__")
+			return ret, err
+		}
+	case MessageType_HEADLINE:
+		if o.Headline__ == nil {
+			err = errors.New("unexpected nil value for Headline__")
+			return ret, err
+		}
+	}
+	return o.MessageType__, nil
+}
+
+func (o MessageBodyV1) Text() MessageText {
+	if o.MessageType__ != MessageType_TEXT {
+		panic("wrong case accessed")
+	}
+	if o.Text__ == nil {
+		return MessageText{}
+	}
+	return *o.Text__
+}
+
+func (o MessageBodyV1) Attachment() MessageAttachmentV1 {
+	if o.MessageType__ != MessageType_ATTACHMENT {
+		panic("wrong case accessed")
+	}
+	if o.Attachment__ == nil {
+		return MessageAttachmentV1{}
+	}
+	return *o.Attachment__
+}
+
+func (o MessageBodyV1) Edit() MessageEdit {
+	if o.MessageType__ != MessageType_EDIT {
+		panic("wrong case accessed")
+	}
+	if o.Edit__ == nil {
+		return MessageEdit{}
+	}
+	return *o.Edit__
+}
+
+func (o MessageBodyV1) Delete() MessageDelete {
+	if o.MessageType__ != MessageType_DELETE {
+		panic("wrong case accessed")
+	}
+	if o.Delete__ == nil {
+		return MessageDelete{}
+	}
+	return *o.Delete__
+}
+
+func (o MessageBodyV1) Metadata() MessageConversationMetadata {
+	if o.MessageType__ != MessageType_METADATA {
+		panic("wrong case accessed")
+	}
+	if o.Metadata__ == nil {
+		return MessageConversationMetadata{}
+	}
+	return *o.Metadata__
+}
+
+func (o MessageBodyV1) Headline() MessageHeadline {
+	if o.MessageType__ != MessageType_HEADLINE {
+		panic("wrong case accessed")
+	}
+	if o.Headline__ == nil {
+		return MessageHeadline{}
+	}
+	return *o.Headline__
+}
+
+func NewMessageBodyV1WithText(v MessageText) MessageBodyV1 {
+	return MessageBodyV1{
+		MessageType__: MessageType_TEXT,
+		Text__:        &v,
+	}
+}
+
+func NewMessageBodyV1WithAttachment(v MessageAttachmentV1) MessageBodyV1 {
+	return MessageBodyV1{
+		MessageType__: MessageType_ATTACHMENT,
+		Attachment__:  &v,
+	}
+}
+
+func NewMessageBodyV1WithEdit(v MessageEdit) MessageBodyV1 {
+	return MessageBodyV1{
+		MessageType__: MessageType_EDIT,
+		Edit__:        &v,
+	}
+}
+
+func NewMessageBodyV1WithDelete(v MessageDelete) MessageBodyV1 {
+	return MessageBodyV1{
+		MessageType__: MessageType_DELETE,
+		Delete__:      &v,
+	}
+}
+
+func NewMessageBodyV1WithMetadata(v MessageConversationMetadata) MessageBodyV1 {
+	return MessageBodyV1{
+		MessageType__: MessageType_METADATA,
+		Metadata__:    &v,
+	}
+}
+
+func NewMessageBodyV1WithHeadline(v MessageHeadline) MessageBodyV1 {
+	return MessageBodyV1{
 		MessageType__: MessageType_HEADLINE,
 		Headline__:    &v,
 	}
@@ -522,14 +676,17 @@ type BodyPlaintextVersion int
 
 const (
 	BodyPlaintextVersion_V1 BodyPlaintextVersion = 1
+	BodyPlaintextVersion_V2 BodyPlaintextVersion = 2
 )
 
 var BodyPlaintextVersionMap = map[string]BodyPlaintextVersion{
 	"V1": 1,
+	"V2": 2,
 }
 
 var BodyPlaintextVersionRevMap = map[BodyPlaintextVersion]string{
 	1: "V1",
+	2: "V2",
 }
 
 func (e BodyPlaintextVersion) String() string {
@@ -540,12 +697,17 @@ func (e BodyPlaintextVersion) String() string {
 }
 
 type BodyPlaintextV1 struct {
+	MessageBody MessageBodyV1 `codec:"messageBody" json:"messageBody"`
+}
+
+type BodyPlaintextV2 struct {
 	MessageBody MessageBody `codec:"messageBody" json:"messageBody"`
 }
 
 type BodyPlaintext struct {
 	Version__ BodyPlaintextVersion `codec:"version" json:"version"`
 	V1__      *BodyPlaintextV1     `codec:"v1,omitempty" json:"v1,omitempty"`
+	V2__      *BodyPlaintextV2     `codec:"v2,omitempty" json:"v2,omitempty"`
 }
 
 func (o *BodyPlaintext) Version() (ret BodyPlaintextVersion, err error) {
@@ -553,6 +715,11 @@ func (o *BodyPlaintext) Version() (ret BodyPlaintextVersion, err error) {
 	case BodyPlaintextVersion_V1:
 		if o.V1__ == nil {
 			err = errors.New("unexpected nil value for V1__")
+			return ret, err
+		}
+	case BodyPlaintextVersion_V2:
+		if o.V2__ == nil {
+			err = errors.New("unexpected nil value for V2__")
 			return ret, err
 		}
 	}
@@ -569,10 +736,27 @@ func (o BodyPlaintext) V1() BodyPlaintextV1 {
 	return *o.V1__
 }
 
+func (o BodyPlaintext) V2() BodyPlaintextV2 {
+	if o.Version__ != BodyPlaintextVersion_V2 {
+		panic("wrong case accessed")
+	}
+	if o.V2__ == nil {
+		return BodyPlaintextV2{}
+	}
+	return *o.V2__
+}
+
 func NewBodyPlaintextWithV1(v BodyPlaintextV1) BodyPlaintext {
 	return BodyPlaintext{
 		Version__: BodyPlaintextVersion_V1,
 		V1__:      &v,
+	}
+}
+
+func NewBodyPlaintextWithV2(v BodyPlaintextV2) BodyPlaintext {
+	return BodyPlaintext{
+		Version__: BodyPlaintextVersion_V2,
+		V2__:      &v,
 	}
 }
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -71,15 +71,30 @@ protocol local {
     AssetMetadata metadata;    // type-specific metadata
   }
 
-  record MessageAttachment {
+  record MessageAttachmentV1 {
     Asset object;                // the primary attachment object
     union {null, Asset} preview; // the (optional) preview of object
+    bytes metadata;              // generic metadata (msgpack)
+  }
+
+  record MessageAttachment {
+    Asset object;                // the primary attachment object
+    array<Asset> previews;       // the previews of object
     bytes metadata;              // generic metadata (msgpack)
   }
 
   variant MessageBody switch (MessageType messageType) {
     case TEXT: MessageText;
     case ATTACHMENT: MessageAttachment;
+    case EDIT: MessageEdit;
+    case DELETE: MessageDelete;
+    case METADATA: MessageConversationMetadata;
+    case HEADLINE: MessageHeadline;
+  }
+  
+  variant MessageBodyV1 switch (MessageType messageType) {
+    case TEXT: MessageText;
+    case ATTACHMENT: MessageAttachmentV1;
     case EDIT: MessageEdit;
     case DELETE: MessageDelete;
     case METADATA: MessageConversationMetadata;
@@ -153,13 +168,21 @@ protocol local {
   }
 
   enum BodyPlaintextVersion {
-    V1_1
+    V1_1,
+    V2_2
   }
 
   // BodyPlaintextV1 is version 1 of BodyPlaintext.
   // The fields here cannot change.  To modify,
   // create a new record type with a new version.
   record BodyPlaintextV1 {
+    MessageBodyV1 messageBody;
+  }
+  
+  // BodyPlaintextV2 is version 2 of BodyPlaintext.
+  // The fields here cannot change.  To modify,
+  // create a new record type with a new version.
+  record BodyPlaintextV2 {
     MessageBody messageBody;
   }
 
@@ -167,6 +190,7 @@ protocol local {
   // versions of BodyPlaintext.
   variant BodyPlaintext switch (BodyPlaintextVersion version) {
     case V1: BodyPlaintextV1;
+    case V2: BodyPlaintextV2;
   }
 
   record MessagePlaintext {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -96,6 +96,7 @@ export const LocalAssetMetadataType = {
 
 export const LocalBodyPlaintextVersion = {
   v1: 1,
+  v2: 2,
 }
 
 export const LocalHeaderPlaintextVersion = {
@@ -581,13 +582,19 @@ export type AssetMetadataVideo = {
 
 export type BodyPlaintext = 
     { version : 1, v1 : ?BodyPlaintextV1 }
+  | { version : 2, v2 : ?BodyPlaintextV2 }
 
 export type BodyPlaintextV1 = {
+  messageBody: MessageBodyV1,
+}
+
+export type BodyPlaintextV2 = {
   messageBody: MessageBody,
 }
 
 export type BodyPlaintextVersion = 
     1 // V1_1
+  | 2 // V2_2
 
 export type ChatActivity = 
     { activityType : 1, incomingMessage : ?IncomingMessage }
@@ -889,6 +896,12 @@ export type MerkleRoot = {
 
 export type MessageAttachment = {
   object: Asset,
+  previews?: ?Array<Asset>,
+  metadata: bytes,
+}
+
+export type MessageAttachmentV1 = {
+  object: Asset,
   preview?: ?Asset,
   metadata: bytes,
 }
@@ -896,6 +909,14 @@ export type MessageAttachment = {
 export type MessageBody = 
     { messageType : 1, text : ?MessageText }
   | { messageType : 2, attachment : ?MessageAttachment }
+  | { messageType : 3, edit : ?MessageEdit }
+  | { messageType : 4, delete : ?MessageDelete }
+  | { messageType : 5, metadata : ?MessageConversationMetadata }
+  | { messageType : 7, headline : ?MessageHeadline }
+
+export type MessageBodyV1 = 
+    { messageType : 1, text : ?MessageText }
+  | { messageType : 2, attachment : ?MessageAttachmentV1 }
   | { messageType : 3, edit : ?MessageEdit }
   | { messageType : 4, delete : ?MessageDelete }
   | { messageType : 5, metadata : ?MessageConversationMetadata }

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -218,7 +218,7 @@
     },
     {
       "type": "record",
-      "name": "MessageAttachment",
+      "name": "MessageAttachmentV1",
       "fields": [
         {
           "type": "Asset",
@@ -230,6 +230,27 @@
             "Asset"
           ],
           "name": "preview"
+        },
+        {
+          "type": "bytes",
+          "name": "metadata"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "MessageAttachment",
+      "fields": [
+        {
+          "type": "Asset",
+          "name": "object"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "Asset"
+          },
+          "name": "previews"
         },
         {
           "type": "bytes",
@@ -258,6 +279,58 @@
             "def": false
           },
           "body": "MessageAttachment"
+        },
+        {
+          "label": {
+            "name": "EDIT",
+            "def": false
+          },
+          "body": "MessageEdit"
+        },
+        {
+          "label": {
+            "name": "DELETE",
+            "def": false
+          },
+          "body": "MessageDelete"
+        },
+        {
+          "label": {
+            "name": "METADATA",
+            "def": false
+          },
+          "body": "MessageConversationMetadata"
+        },
+        {
+          "label": {
+            "name": "HEADLINE",
+            "def": false
+          },
+          "body": "MessageHeadline"
+        }
+      ]
+    },
+    {
+      "type": "variant",
+      "name": "MessageBodyV1",
+      "switch": {
+        "type": "MessageType",
+        "name": "messageType"
+      },
+      "cases": [
+        {
+          "label": {
+            "name": "TEXT",
+            "def": false
+          },
+          "body": "MessageText"
+        },
+        {
+          "label": {
+            "name": "ATTACHMENT",
+            "def": false
+          },
+          "body": "MessageAttachmentV1"
         },
         {
           "label": {
@@ -497,12 +570,23 @@
       "type": "enum",
       "name": "BodyPlaintextVersion",
       "symbols": [
-        "V1_1"
+        "V1_1",
+        "V2_2"
       ]
     },
     {
       "type": "record",
       "name": "BodyPlaintextV1",
+      "fields": [
+        {
+          "type": "MessageBodyV1",
+          "name": "messageBody"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "BodyPlaintextV2",
       "fields": [
         {
           "type": "MessageBody",
@@ -524,6 +608,13 @@
             "def": false
           },
           "body": "BodyPlaintextV1"
+        },
+        {
+          "label": {
+            "name": "V2",
+            "def": false
+          },
+          "body": "BodyPlaintextV2"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -96,6 +96,7 @@ export const LocalAssetMetadataType = {
 
 export const LocalBodyPlaintextVersion = {
   v1: 1,
+  v2: 2,
 }
 
 export const LocalHeaderPlaintextVersion = {
@@ -581,13 +582,19 @@ export type AssetMetadataVideo = {
 
 export type BodyPlaintext = 
     { version : 1, v1 : ?BodyPlaintextV1 }
+  | { version : 2, v2 : ?BodyPlaintextV2 }
 
 export type BodyPlaintextV1 = {
+  messageBody: MessageBodyV1,
+}
+
+export type BodyPlaintextV2 = {
   messageBody: MessageBody,
 }
 
 export type BodyPlaintextVersion = 
     1 // V1_1
+  | 2 // V2_2
 
 export type ChatActivity = 
     { activityType : 1, incomingMessage : ?IncomingMessage }
@@ -889,6 +896,12 @@ export type MerkleRoot = {
 
 export type MessageAttachment = {
   object: Asset,
+  previews?: ?Array<Asset>,
+  metadata: bytes,
+}
+
+export type MessageAttachmentV1 = {
+  object: Asset,
   preview?: ?Asset,
   metadata: bytes,
 }
@@ -896,6 +909,14 @@ export type MessageAttachment = {
 export type MessageBody = 
     { messageType : 1, text : ?MessageText }
   | { messageType : 2, attachment : ?MessageAttachment }
+  | { messageType : 3, edit : ?MessageEdit }
+  | { messageType : 4, delete : ?MessageDelete }
+  | { messageType : 5, metadata : ?MessageConversationMetadata }
+  | { messageType : 7, headline : ?MessageHeadline }
+
+export type MessageBodyV1 = 
+    { messageType : 1, text : ?MessageText }
+  | { messageType : 2, attachment : ?MessageAttachmentV1 }
   | { messageType : 3, edit : ?MessageEdit }
   | { messageType : 4, delete : ?MessageDelete }
   | { messageType : 5, metadata : ?MessageConversationMetadata }


### PR DESCRIPTION
This changes the local message protocol to support multiple previews of an asset.

The service interface to posting/download attachments, previews is untouched.  When design settles on what they want, we can add to the service interface to support their needs.