### PR TITLE
add unread list to API and remove GetInboxLocal

### DIFF
--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -121,7 +121,8 @@ func (c ChatMessage) Valid() bool {
 }
 
 type listOptionsV1 struct {
-	TopicType string `json:"topic_type,omitempty"`
+	UnreadOnly bool   `json:"unread_only,omitempty"`
+	TopicType  string `json:"topic_type,omitempty"`
 }
 
 func (l listOptionsV1) Check() error {

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -52,47 +52,47 @@ func (c *chatServiceHandler) ListV1(ctx context.Context, opts listOptionsV1) Rep
 		return c.errReply(err)
 	}
 
-	inbox, err := client.GetInboxLocal(ctx, chat1.GetInboxLocalArg{
+	res, err := client.GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
 		Query: &chat1.GetInboxLocalQuery{
-			Status:    utils.VisibleChatConversationStatuses(),
-			TopicType: &topicType,
+			Status:     utils.VisibleChatConversationStatuses(),
+			TopicType:  &topicType,
+			UnreadOnly: opts.UnreadOnly,
 		},
 		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	})
 	if err != nil {
 		return c.errReply(err)
 	}
-	rlimits = append(rlimits, inbox.RateLimits...)
+	rlimits = utils.AggRateLimits(res.RateLimits)
 
 	var cl ChatList
-	cl.Conversations = make([]ConvSummary, len(inbox.ConversationsUnverified))
-	for i, conv := range inbox.ConversationsUnverified {
+	cl.Conversations = make([]ConvSummary, len(res.Conversations))
+	for i, conv := range res.Conversations {
 		readerInfo := conv.ReaderInfo
 		convUnread := false
 		var convMtime gregor1.Time
-		if readerInfo != nil {
-			convUnread = readerInfo.ReadMsgid < readerInfo.MaxMsgid
-			convMtime = readerInfo.Mtime
-		}
+
+		convUnread = readerInfo.ReadMsgid < readerInfo.MaxMsgid
+		convMtime = readerInfo.Mtime
 
 		maxID := chat1.MessageID(0)
-		for _, msg := range conv.MaxMsgs {
-			if msg.ServerHeader.MessageID > maxID {
-				tlf := msg.ClientHeader.TLFNameExpanded(conv.Metadata.FinalizeInfo)
-				pub := msg.ClientHeader.TlfPublic
+		for _, msg := range conv.MaxMessages {
+			if msg.IsValid() && msg.GetMessageID() > maxID {
+				tlf := msg.Valid().ClientHeader.TLFNameExpanded(conv.Info.FinalizeInfo)
+				pub := msg.Valid().ClientHeader.TlfPublic
 				cl.Conversations[i] = ConvSummary{
-					ID: conv.Metadata.ConversationID.String(),
+					ID: conv.GetConvID().String(),
 					Channel: ChatChannel{
 						Name:      tlf,
 						Public:    pub,
-						TopicType: strings.ToLower(conv.Metadata.IdTriple.TopicType.String()),
+						TopicType: strings.ToLower(conv.Info.Triple.TopicType.String()),
 					},
 					Unread:       convUnread,
 					ActiveAt:     convMtime.UnixSeconds(),
 					ActiveAtMs:   convMtime.UnixMilliseconds(),
-					FinalizeInfo: conv.Metadata.FinalizeInfo,
+					FinalizeInfo: conv.Info.FinalizeInfo,
 				}
-				maxID = msg.ServerHeader.MessageID
+				maxID = msg.GetMessageID()
 			}
 		}
 	}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -873,12 +873,6 @@ type GetThreadLocalArg struct {
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
-type GetInboxLocalArg struct {
-	Query            *GetInboxLocalQuery          `codec:"query,omitempty" json:"query,omitempty"`
-	Pagination       *Pagination                  `codec:"pagination,omitempty" json:"pagination,omitempty"`
-	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
-}
-
 type GetInboxAndUnboxLocalArg struct {
 	Query            *GetInboxLocalQuery          `codec:"query,omitempty" json:"query,omitempty"`
 	Pagination       *Pagination                  `codec:"pagination,omitempty" json:"pagination,omitempty"`
@@ -1020,7 +1014,6 @@ type MarkAsReadLocalArg struct {
 
 type LocalInterface interface {
 	GetThreadLocal(context.Context, GetThreadLocalArg) (GetThreadLocalRes, error)
-	GetInboxLocal(context.Context, GetInboxLocalArg) (GetInboxLocalRes, error)
 	GetInboxAndUnboxLocal(context.Context, GetInboxAndUnboxLocalArg) (GetInboxAndUnboxLocalRes, error)
 	GetInboxNonblockLocal(context.Context, GetInboxNonblockLocalArg) (GetInboxNonblockLocalRes, error)
 	PostLocal(context.Context, PostLocalArg) (PostLocalRes, error)
@@ -1058,22 +1051,6 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.GetThreadLocal(ctx, (*typedArgs)[0])
-					return
-				},
-				MethodType: rpc.MethodCall,
-			},
-			"getInboxLocal": {
-				MakeArg: func() interface{} {
-					ret := make([]GetInboxLocalArg, 1)
-					return &ret
-				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]GetInboxLocalArg)
-					if !ok {
-						err = rpc.NewTypeError((*[]GetInboxLocalArg)(nil), args)
-						return
-					}
-					ret, err = i.GetInboxLocal(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -1392,11 +1369,6 @@ type LocalClient struct {
 
 func (c LocalClient) GetThreadLocal(ctx context.Context, __arg GetThreadLocalArg) (res GetThreadLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.getThreadLocal", []interface{}{__arg}, &res)
-	return
-}
-
-func (c LocalClient) GetInboxLocal(ctx context.Context, __arg GetInboxLocalArg) (res GetInboxLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getInboxLocal", []interface{}{__arg}, &res)
 	return
 }
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -284,8 +284,6 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
-  // topicName in GetInboxLocalQuery is ignored
-  GetInboxLocalRes getInboxLocal(union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
   record GetInboxLocalRes {
     array<Conversation> conversationsUnverified;
     union { null, Pagination } pagination;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -189,18 +189,6 @@ export function localGetInboxAndUnboxLocalRpcPromise (request: $Exact<requestCom
   return new Promise((resolve, reject) => { localGetInboxAndUnboxLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
-export function localGetInboxLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxLocalResult) => void} & {param: localGetInboxLocalRpcParam}>) {
-  engineRpcOutgoing({...request, method: 'chat.1.local.getInboxLocal'})
-}
-
-export function localGetInboxLocalRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxLocalResult) => void} & {param: localGetInboxLocalRpcParam}>): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localGetInboxLocalRpc({...request, incomingCallMap, callback}))
-}
-
-export function localGetInboxLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxLocalResult) => void} & {param: localGetInboxLocalRpcParam}>): Promise<localGetInboxLocalResult> {
-  return new Promise((resolve, reject) => { localGetInboxLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
-}
-
 export function localGetInboxNonblockLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {param: localGetInboxNonblockLocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.getInboxNonblockLocal'})
 }
@@ -1288,12 +1276,6 @@ export type localGetInboxAndUnboxLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
-export type localGetInboxLocalRpcParam = Exact<{
-  query?: ?GetInboxLocalQuery,
-  pagination?: ?Pagination,
-  identifyBehavior: keybase1.TLFIdentifyBehavior
-}>
-
 export type localGetInboxNonblockLocalRpcParam = Exact<{
   query?: ?GetInboxLocalQuery,
   pagination?: ?Pagination,
@@ -1478,8 +1460,6 @@ type localGetConversationForCLILocalResult = GetConversationForCLILocalRes
 
 type localGetInboxAndUnboxLocalResult = GetInboxAndUnboxLocalRes
 
-type localGetInboxLocalResult = GetInboxLocalRes
-
 type localGetInboxNonblockLocalResult = GetInboxNonblockLocalRes
 
 type localGetInboxSummaryForCLILocalResult = GetInboxSummaryForCLILocalRes
@@ -1538,7 +1518,6 @@ export type rpc =
   | localDownloadFileAttachmentLocalRpc
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc
-  | localGetInboxLocalRpc
   | localGetInboxNonblockLocalRpc
   | localGetInboxSummaryForCLILocalRpc
   | localGetMessagesLocalRpc

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1350,29 +1350,6 @@
       ],
       "response": "GetThreadLocalRes"
     },
-    "getInboxLocal": {
-      "request": [
-        {
-          "name": "query",
-          "type": [
-            null,
-            "GetInboxLocalQuery"
-          ]
-        },
-        {
-          "name": "pagination",
-          "type": [
-            null,
-            "Pagination"
-          ]
-        },
-        {
-          "name": "identifyBehavior",
-          "type": "keybase1.TLFIdentifyBehavior"
-        }
-      ],
-      "response": "GetInboxLocalRes"
-    },
     "getInboxAndUnboxLocal": {
       "request": [
         {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -189,18 +189,6 @@ export function localGetInboxAndUnboxLocalRpcPromise (request: $Exact<requestCom
   return new Promise((resolve, reject) => { localGetInboxAndUnboxLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
-export function localGetInboxLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxLocalResult) => void} & {param: localGetInboxLocalRpcParam}>) {
-  engineRpcOutgoing({...request, method: 'chat.1.local.getInboxLocal'})
-}
-
-export function localGetInboxLocalRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxLocalResult) => void} & {param: localGetInboxLocalRpcParam}>): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localGetInboxLocalRpc({...request, incomingCallMap, callback}))
-}
-
-export function localGetInboxLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxLocalResult) => void} & {param: localGetInboxLocalRpcParam}>): Promise<localGetInboxLocalResult> {
-  return new Promise((resolve, reject) => { localGetInboxLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
-}
-
 export function localGetInboxNonblockLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {param: localGetInboxNonblockLocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.getInboxNonblockLocal'})
 }
@@ -1288,12 +1276,6 @@ export type localGetInboxAndUnboxLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
-export type localGetInboxLocalRpcParam = Exact<{
-  query?: ?GetInboxLocalQuery,
-  pagination?: ?Pagination,
-  identifyBehavior: keybase1.TLFIdentifyBehavior
-}>
-
 export type localGetInboxNonblockLocalRpcParam = Exact<{
   query?: ?GetInboxLocalQuery,
   pagination?: ?Pagination,
@@ -1478,8 +1460,6 @@ type localGetConversationForCLILocalResult = GetConversationForCLILocalRes
 
 type localGetInboxAndUnboxLocalResult = GetInboxAndUnboxLocalRes
 
-type localGetInboxLocalResult = GetInboxLocalRes
-
 type localGetInboxNonblockLocalResult = GetInboxNonblockLocalRes
 
 type localGetInboxSummaryForCLILocalResult = GetInboxSummaryForCLILocalRes
@@ -1538,7 +1518,6 @@ export type rpc =
   | localDownloadFileAttachmentLocalRpc
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc
-  | localGetInboxLocalRpc
   | localGetInboxNonblockLocalRpc
   | localGetInboxSummaryForCLILocalRpc
   | localGetMessagesLocalRpc


### PR DESCRIPTION
Patch does two things for the API:

1.) Uses `GetInboxAndUnboxLocal` for `ListV1` instead of `GetInboxLocal` (which I deleted). `ReadV1` needs to call `GetInboxAndUnboxLocal` anyway, so I don't think this is a performance hit (and might be gain since now the `Inbox` cache is in play).
2.) Add a `unread_only` option `ListV1`, which will just return the unread conversations only.