### PR TITLE
running an explicit identify that fails cleans out the ID cache

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -468,8 +468,18 @@ func TestIdentify2WithUIDWithBrokenTrackFromChatGUI(t *testing.T) {
 
 	runChatGUI()
 
-	// The next time we run with the chat GUI, we should hit the fast cache.
-	if !tester.fastStats.eq(1, 0, 1, 0, 1) || !tester.slowStats.eq(0, 0, 1, 0, 1) {
+	// The next time we run with the chat GUI, we won't hit the slow or fast
+	// cache, since the failure in standard mode cleared out the cache for this
+	// user.
+	if !tester.fastStats.eq(0, 0, 2, 0, 1) || !tester.slowStats.eq(0, 0, 2, 0, 1) {
+		t.Fatalf("bad cache stats: %+v, %+v", tester.fastStats, tester.slowStats)
+	}
+
+	tester.incNow(time.Second)
+	runChatGUI()
+
+	// Now we should get a fast cache hit
+	if !tester.fastStats.eq(1, 0, 2, 0, 1) || !tester.slowStats.eq(0, 0, 2, 0, 1) {
 		t.Fatalf("bad cache stats: %+v, %+v", tester.fastStats, tester.slowStats)
 	}
 
@@ -477,7 +487,7 @@ func TestIdentify2WithUIDWithBrokenTrackFromChatGUI(t *testing.T) {
 	runChatGUI()
 
 	// A fast cache timeout and a slow cache hit!
-	if !tester.fastStats.eq(1, 1, 1, 0, 1) || !tester.slowStats.eq(1, 0, 1, 0, 1) {
+	if !tester.fastStats.eq(1, 1, 2, 0, 1) || !tester.slowStats.eq(1, 0, 2, 0, 1) {
 		t.Fatalf("bad cache stats: %+v, %+v", tester.fastStats, tester.slowStats)
 	}
 
@@ -485,7 +495,7 @@ func TestIdentify2WithUIDWithBrokenTrackFromChatGUI(t *testing.T) {
 	runChatGUI()
 
 	// After the broken timeout passes, we should get timeouts on both caches
-	if !tester.fastStats.eq(1, 2, 1, 0, 1) || !tester.slowStats.eq(1, 1, 1, 0, 1) {
+	if !tester.fastStats.eq(1, 2, 2, 0, 1) || !tester.slowStats.eq(1, 1, 2, 0, 1) {
 		t.Fatalf("bad cache stats: %+v, %+v", tester.fastStats, tester.slowStats)
 	}
 }

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -478,24 +478,41 @@ func (e *Identify2WithUID) maybeCacheResult() {
 	canCacheFailures := e.canSucceedWithTrackBreaks()
 
 	e.G().Log.Debug("+ maybeCacheResult (ok=%v; canCacheFailures=%v)", isOK, canCacheFailures)
+	defer e.G().Log.Debug("- maybeCacheResult")
 
-	if (isOK || canCacheFailures) && e.getCache() != nil {
-		v := e.exportToResult()
-		if v == nil {
-			e.G().Log.Debug("| not caching; nil result")
-			return
+	if e.getCache() == nil {
+		e.G().Log.Debug("| cache is disabled, so nothing to do")
+		return
+	}
+
+	// If we hit an identify failure, and we're not allowed to cache failures,
+	// then at least bust out the cache.
+	if !isOK && !canCacheFailures {
+		e.G().Log.Debug("| clearing cache due to failure")
+		uid := e.them.GetUID()
+		e.getCache().Delete(uid)
+		if err := e.removeSlowCacheFromDB(); err != nil {
+			e.G().Log.Debug("| Error in removing slow cache from db: %s", err)
 		}
-		e.getCache().Insert(v)
-		e.G().Log.Debug("| insert %+v", v)
+		return
+	}
 
-		// Don't write failures to the disk cache
-		if isOK {
-			if err := e.storeSlowCacheToDB(); err != nil {
-				e.G().Log.Debug("| Error in storing slow cache to db: %s", err)
-			}
+	// Common case --- (isOK || canCacheFailures)
+	v := e.exportToResult()
+	if v == nil {
+		e.G().Log.Debug("| not caching; nil result")
+		return
+	}
+	e.getCache().Insert(v)
+	e.G().Log.Debug("| insert %+v", v)
+
+	// Don't write failures to the disk cache
+	if isOK {
+		if err := e.storeSlowCacheToDB(); err != nil {
+			e.G().Log.Debug("| Error in storing slow cache to db: %s", err)
 		}
 	}
-	e.G().Log.Debug("- maybeCacheResult")
+	return
 }
 
 func (e *Identify2WithUID) insertTrackToken(ctx *Context, outcome *libkb.IdentifyOutcome, ui libkb.IdentifyUI) (err error) {
@@ -898,6 +915,19 @@ func (e *Identify2WithUID) storeSlowCacheToDB() (err error) {
 	key := e.dbKey(e.them.GetUID())
 	now := keybase1.ToTime(time.Now())
 	err = e.G().LocalDb.PutObj(key, nil, now)
+	return err
+}
+
+// Remove (themUID) from the identify cache, if they're there.
+func (e *Identify2WithUID) removeSlowCacheFromDB() (err error) {
+	prfx := fmt.Sprintf("Identify2WithUID#removeSlowCacheFromDB(%s)", e.them.GetUID())
+	defer e.G().Trace(prfx, func() error { return err })()
+	if e.me == nil {
+		e.G().Log.Debug("not removing from persistent slow cache since no me user")
+		return nil
+	}
+	key := e.dbKey(e.them.GetUID())
+	err = e.G().LocalDb.Delete(key)
 	return err
 }
 


### PR DESCRIPTION
In my testing, I've been surprised that while running `keybase id bob` shows a failure, KBFS or Chat is still happily plugging away, even after a restart of the service. The reason is that the persisted slow cache timestamp never gets deleted until it times out. But we should explicitly clean it out after a failure. This will help testing and debugging.