### PR TITLE
Add retry ability for attachments

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -8,7 +8,7 @@ import {List, Map} from 'immutable'
 import {NotifyPopup} from '../native/notifications'
 import {apiserverGetRpcPromise, TlfKeysTLFIdentifyBehavior} from '../constants/types/flow-types'
 import {badgeApp} from './notifications'
-import {call, put, select, race, cancel, fork} from 'redux-saga/effects'
+import {call, put, select, race, cancel, fork, join} from 'redux-saga/effects'
 import {changedFocus} from '../constants/window'
 import {getPath} from '../route-tree'
 import {navigateTo, switchTo} from './route-tree'
@@ -151,6 +151,11 @@ function editMessage (message: Message): EditMessage {
 
 function deleteMessage (message: Message): DeleteMessage {
   return {type: Constants.deleteMessage, payload: {message}}
+}
+
+function retryAttachment (message: Constants.AttachmentMessage): Constants.SelectAttachment {
+  const {conversationIDKey, filename, title, previewType, outboxID} = message
+  return {type: Constants.selectAttachment, payload: {conversationIDKey, filename, title, type: previewType || 'Other', outboxID}}
 }
 
 function selectAttachment (conversationIDKey: ConversationIDKey, filename: string, title: string, type: Constants.AttachmentType): Constants.SelectAttachment {
@@ -977,13 +982,66 @@ function * _badgeAppForChat (action: BadgeAppForChat): SagaGenerator<any, any> {
   yield put(badgeApp('chatInbox', newConversations > 0, newConversations))
 }
 
-function * _selectAttachment ({payload: {conversationIDKey, filename, title, type}}: Constants.SelectAttachment): SagaGenerator<any, any> {
+function * _uploadAttachment ({param, conversationIDKey, outboxID}: {param: ChatTypes.localPostFileAttachmentLocalRpcParam, conversationIDKey: ConversationIDKey, outboxID: Constants.OutboxIDKey}) {
+  const channelConfig = singleFixedChannelConfig([
+    'chat.1.chatUi.chatAttachmentUploadStart',
+    'chat.1.chatUi.chatAttachmentPreviewUploadStart',
+    'chat.1.chatUi.chatAttachmentUploadProgress',
+    'chat.1.chatUi.chatAttachmentUploadDone',
+    'chat.1.chatUi.chatAttachmentPreviewUploadDone',
+    'finished',
+  ])
+
+  const channelMap = ((yield call(localPostFileAttachmentLocalRpcChannelMap, channelConfig, {param})): any)
+
+  const finishedTask = yield fork(function * () {
+    const finished = yield takeFromChannelMap(channelMap, 'finished')
+    if (finished.error) {
+      console.warn('error here!!')
+      throw new Error('Error in uploading attachment ' + finished.error)
+    }
+    return finished
+  })
+
+  const progressTask = yield effectOnChannelMap(c => safeTakeEvery(c, function * ({response}) {
+    const {bytesComplete, bytesTotal} = response.param
+    const action: Constants.UploadProgress = {
+      type: 'chat:uploadProgress',
+      payload: {bytesTotal, bytesComplete, conversationIDKey, outboxID},
+    }
+    yield put(action)
+    response.result()
+  }), channelMap, 'chat.1.chatUi.chatAttachmentUploadProgress')
+
+  const uploadStart = yield takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentUploadStart')
+  uploadStart.response.result()
+
+  const previewTask = yield fork(function * () {
+    const previewUploadStart = yield takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentPreviewUploadStart')
+    previewUploadStart.response.result()
+
+    const previewUploadDone = yield takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentPreviewUploadDone')
+    previewUploadDone.response.result()
+  })
+
+  const uploadDone = yield takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentUploadDone')
+  uploadDone.response.result()
+
+  const finished = yield join(finishedTask)
+  const {params: {messageID}} = finished
+  yield cancel(progressTask)
+  yield cancel(previewTask)
+  closeChannelMap(channelMap)
+
+  return messageID
+}
+
+function * _selectAttachment ({payload: {conversationIDKey, filename, title, type, outboxID = (Math.ceil(Math.random() * 1e9) + '')}}: Constants.SelectAttachment): SagaGenerator<any, any> {
   const clientHeader = yield call(_clientHeader, CommonMessageType.attachment, conversationIDKey)
   const attachment = {
     filename,
   }
 
-  const outboxID = Math.ceil(Math.random() * 1e9) + ''
   const username = yield select(usernameSelector)
 
   yield put({
@@ -1010,45 +1068,8 @@ function * _selectAttachment ({payload: {conversationIDKey, filename, title, typ
     identifyBehavior: yield call(_getPostingIdentifyBehavior, conversationIDKey),
   }
 
-  const channelConfig = singleFixedChannelConfig([
-    'chat.1.chatUi.chatAttachmentUploadStart',
-    'chat.1.chatUi.chatAttachmentPreviewUploadStart',
-    'chat.1.chatUi.chatAttachmentUploadProgress',
-    'chat.1.chatUi.chatAttachmentUploadDone',
-    'chat.1.chatUi.chatAttachmentPreviewUploadDone',
-    'finished',
-  ])
-
   try {
-    const channelMap = ((yield call(localPostFileAttachmentLocalRpcChannelMap, channelConfig, {param})): any)
-
-    const progressTask = yield effectOnChannelMap(c => safeTakeEvery(c, function * ({response}) {
-      const {bytesComplete, bytesTotal} = response.param
-      const action: Constants.UploadProgress = {
-        type: 'chat:uploadProgress',
-        payload: {bytesTotal, bytesComplete, conversationIDKey, outboxID},
-      }
-      yield put(action)
-      response.result()
-    }), channelMap, 'chat.1.chatUi.chatAttachmentUploadProgress')
-
-    const uploadStart = yield takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentUploadStart')
-    uploadStart.response.result()
-
-    const previewTask = yield fork(function * () {
-      const previewUploadStart = yield takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentPreviewUploadStart')
-      previewUploadStart.response.result()
-
-      const previewUploadDone = yield takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentPreviewUploadDone')
-      previewUploadDone.response.result()
-    })
-
-    const uploadDone = yield takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentUploadDone')
-    uploadDone.response.result()
-
-    const finished = yield takeFromChannelMap(channelMap, 'finished')
-    const {params: {messageID}} = finished
-
+    const messageID = yield call(_uploadAttachment, {param, conversationIDKey, outboxID})
     yield put(({
       type: 'chat:updateTempMessage',
       payload: {
@@ -1065,10 +1086,6 @@ function * _selectAttachment ({payload: {conversationIDKey, filename, title, typ
         messageID: messageID,
       },
     }: Constants.MarkSeenMessage))
-
-    yield cancel(progressTask)
-    yield cancel(previewTask)
-    closeChannelMap(channelMap)
   } catch (e) {
     yield put(({
       type: 'chat:updateTempMessage',
@@ -1200,6 +1217,7 @@ export {
   selectAttachment,
   openFolder,
   postMessage,
+  retryAttachment,
   retryMessage,
   selectConversation,
   setupChatHandlers,

--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -6,7 +6,7 @@ import React, {Component} from 'react'
 import {Box} from '../../common-adapters'
 import {List, Map} from 'immutable'
 import {connect} from 'react-redux'
-import {deleteMessage, editMessage, loadMoreMessages, newChat, openFolder, postMessage, retryMessage, selectAttachment, loadAttachment} from '../../actions/chat'
+import {deleteMessage, editMessage, loadMoreMessages, newChat, openFolder, postMessage, retryMessage, selectAttachment, loadAttachment, retryAttachment} from '../../actions/chat'
 import {nothingSelected, getBrokenUsers} from '../../constants/chat'
 import {onUserClick} from '../../actions/profile'
 import {getProfile} from '../../actions/tracker'
@@ -124,6 +124,7 @@ export default connect(
     onOpenInFileUI: (path: string) => dispatch(({payload: {path}, type: 'fs:openInFileUI'}: OpenInFileUI)),
     onOpenInPopup: (message: AttachmentMessage) => dispatch(navigateAppend([{props: {message}, selected: 'attachment'}])),
     onPostMessage: (selectedConversation, text) => dispatch(postMessage(selectedConversation, new HiddenString(text))),
+    onRetryAttachment: (message: AttachmentMessage) => dispatch(retryAttachment(message)),
     onRetryMessage: (outboxID: string) => dispatch(retryMessage(outboxID)),
     onShowProfile: (username: string) => dispatch(onUserClick(username, '')),
     onShowTracker: (username: string) => dispatch(getProfile(username, true, true)),

--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -40,6 +40,7 @@ const Conversation = (props: Props) => {
         onLoadMoreMessages={props.onLoadMoreMessages}
         onOpenInFileUI={props.onOpenInFileUI}
         onOpenInPopup={props.onOpenInPopup}
+        onRetryAttachment={props.onRetryAttachment}
         onRetryMessage={props.onRetryMessage}
         onShowProfile={props.onShowProfile}
         participants={props.participants}

--- a/shared/chat/conversation/index.js.flow
+++ b/shared/chat/conversation/index.js.flow
@@ -26,6 +26,7 @@ export type Props = {
   onOpenInFileUI: (filename: string) => void,
   onOpenInPopup: (message: AttachmentMessage) => void,
   onPostMessage: (text: string) => void,
+  onRetryAttachment: (message: AttachmentMessage) => void,
   onRetryMessage: (outboxID: string) => void,
   onShowProfile: (username: string) => void,
   onToggleSidePanel: () => void,

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -272,6 +272,7 @@ class ConversationList extends Component<void, Props, State> {
       metaDataMap: this.props.metaDataMap,
       onAction: this._onAction,
       onLoadAttachment: this.props.onLoadAttachment,
+      onRetryAttachment: () => { message.type === 'Attachment' && this.props.onRetryAttachment(message) },
       onOpenInFileUI: this.props.onOpenInFileUI,
       onOpenInPopup: this.props.onOpenInPopup,
       onRetry: this.props.onRetryMessage,

--- a/shared/chat/conversation/list.js.flow
+++ b/shared/chat/conversation/list.js.flow
@@ -19,6 +19,7 @@ export type Props = {
   onLoadMoreMessages: () => void,
   onOpenInFileUI: (filename: string) => void,
   onOpenInPopup: (message: AttachmentMessage) => void,
+  onRetryAttachment: (message: AttachmentMessage) => void,
   onRetryMessage: (outboxID: string) => void,
   onShowProfile: (username: string) => void,
   participants: List<string>,

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -9,8 +9,6 @@ import {formatTimeForMessages} from '../../../util/timestamp'
 
 import type {Message, AttachmentMessage, ServerMessage, MetaDataMap, FollowingMap} from '../../../constants/chat'
 
-const _onRetryTodo = (message: Message) => console.log('todo, hookup attachment onRetry, ', message)
-
 type Options = {
   message: Message,
   includeHeader: boolean,
@@ -25,6 +23,7 @@ type Options = {
   onOpenInFileUI: (path: string) => void,
   onOpenInPopup: (message: AttachmentMessage) => void,
   onRetry: (outboxID: string) => void,
+  onRetryAttachment: () => void,
   you: string,
   metaDataMap: MetaDataMap,
   followingMap: FollowingMap,
@@ -43,6 +42,7 @@ const factory = (options: Options) => {
     onOpenInFileUI,
     onOpenInPopup,
     onRetry,
+    onRetryAttachment,
     you,
     metaDataMap,
     followingMap,
@@ -82,7 +82,7 @@ const factory = (options: Options) => {
         metaDataMap={metaDataMap}
         followingMap={followingMap}
         message={message}
-        onRetry={_onRetryTodo}
+        onRetry={onRetryAttachment}
         includeHeader={includeHeader}
         isFirstNewMessage={isFirstNewMessage}
         onLoadAttachment={onLoadAttachment}

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -243,7 +243,9 @@ export type UpdateBadging = NoErrorTypedAction<'chat:updateBadging', {conversati
 export type UpdateLatestMessage = NoErrorTypedAction<'chat:updateLatestMessage', {conversationIDKey: ConversationIDKey}>
 export type UpdateMetadata = NoErrorTypedAction<'chat:updateMetadata', {users: Array<string>}>
 export type UpdatedMetadata = NoErrorTypedAction<'chat:updatedMetadata', {[key: string]: MetaData}>
-export type SelectAttachment = NoErrorTypedAction<'chat:selectAttachment', {conversationIDKey: ConversationIDKey, filename: string, title: string, type: AttachmentType}>
+
+// Pass an outboxID to specify that we are retrying an attachment
+export type SelectAttachment = NoErrorTypedAction<'chat:selectAttachment', {conversationIDKey: ConversationIDKey, filename: string, title: string, type: AttachmentType, outboxID?: OutboxIDKey}>
 export type UpdateBrokenTracker = NoErrorTypedAction<'chat:updateBrokenTracker', {userToBroken: {[username: string]: boolean}}>
 export type UploadProgress = NoErrorTypedAction<'chat:uploadProgress', {
   outboxID: OutboxIDKey,


### PR DESCRIPTION
@keybase/react-hackers 

Also fixes the overwriting of pending messages. We were accidentally filtering them out.

Retry for attachments is just making the same request again.