### PR TITLE
better ping loop control CORE-4414

### DIFF
--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -526,7 +526,7 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 		case g.pingCtlCh <- struct{}{}:
 			g.pingLoopWaiting = false
 		case <-ctx.Done():
-			return fmt.Errorf("OnConnect: context cancelled")
+			return ctx.Err()
 		}
 	}
 


### PR DESCRIPTION
This is very tricky, and I have gotten it wrong like 2 times, so if you both could take a close look I would appreciate it. The goal here is for the ping loop to only be running when the connection is good, and not when we are trying to reconnect to Gregor. We have to try and coordinate our own disconnect/reconnect logic with the RPC library. 

The old way was busted since `IsConnected` could start returning false, and we would never reconnect since the ping loop would skip that iteration (we would reconnect on any chat command, but for a bot just sitting there waiting for new messages it would just get stuck).