### PR TITLE
Update message props on react virtualized

### DIFF
--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -38,6 +38,7 @@ class ConversationList extends Component<void, Props, State> {
   _list: any;
   state: State;
   _toRemeasure: Array<number>;
+  _shouldForceUpdateGrid: boolean;
   _lastWidth: ?number;
 
   constructor (props: Props) {
@@ -52,6 +53,7 @@ class ConversationList extends Component<void, Props, State> {
 
     this._cellCache = new CellSizeCache(this._indexToID)
     this._toRemeasure = []
+    this._shouldForceUpdateGrid = false
   }
 
   _indexToID = index => {
@@ -90,6 +92,11 @@ class ConversationList extends Component<void, Props, State> {
         this._list && this._list.recomputeRowHeights(item)
       })
       this._toRemeasure = []
+    }
+
+    if (this._shouldForceUpdateGrid) {
+      this._shouldForceUpdateGrid = false
+      this._list && this._list.forceUpdateGrid()
     }
   }
 
@@ -134,10 +141,12 @@ class ConversationList extends Component<void, Props, State> {
 
       if (item.type === 'Text' && oldMessage.type === 'Text' && item.messageState !== oldMessage.messageState) {
         this._toRemeasure.push(index + 1)
-      }
-
-      if (item.type === 'Attachment' && oldMessage.type === 'Attachment' && item.previewPath !== oldMessage.previewPath) {
+      } else if (item.type === 'Attachment' && oldMessage.type === 'Attachment' &&
+                 (item.previewPath !== oldMessage.previewPath ||
+                  !shallowEqual(item.previewSize, oldMessage.previewSize))) {
         this._toRemeasure.push(index + 1)
+      } else if (!shallowEqual(item, oldMessage)) {
+        this._shouldForceUpdateGrid = true
       }
     })
   }

--- a/shared/chat/conversation/messages/shared.desktop.js
+++ b/shared/chat/conversation/messages/shared.desktop.js
@@ -58,6 +58,12 @@ class _MessageComponent extends PureComponent<void, MessageProps, void> {
       if (key === 'style') {
         return shallowEqual(obj, oth)
       }
+
+      // Messages can be updated, for example progress state on attachments
+      if (key === 'message') {
+        return shallowEqual(obj, oth)
+      }
+
       return undefined
     })
   }


### PR DESCRIPTION
@keybase/react-hackers 

This looks fairly confusing as evidenced by this search: https://github.com/bvaughn/react-virtualized/issues?utf8=%E2%9C%93&q=is%3Aissue%20forceUpdate%20

The author says the best way to update the content (if the height hasn't changed is to call forceUpdate). This lets us know when we need to call forceUpdate without remeasuring.

Also see: https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#forceupdategrid