### PR TITLE
use a normal ping without a timeout if we are offline CORE-4414

### DIFF
--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -110,6 +110,7 @@ type gregorHandler struct {
 	startPingLoop sync.Once
 
 	cli              rpc.GenericClient
+	pingCli          rpc.GenericClient
 	sessionID        gregor1.SessionID
 	skipRetryConnect bool
 	freshReplay      bool
@@ -1159,16 +1160,27 @@ func (g *gregorHandler) pingLoop() {
 		select {
 		case <-g.G().Clock().After(duration):
 
-			if !g.IsConnected() {
-				g.Debug("ping loop: skipping ping since not connected")
-				continue
+			var err error
+			ctx := context.Background()
+			if g.IsConnected() {
+				// If we are connected, subject the ping call to a fairly
+				// aggressive timeout so our chat stuff can be responsive
+				// to changes in connectivity
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, timeout)
+				_, err = gregor1.IncomingClient{Cli: g.pingCli}.Ping(ctx)
+				cancel()
+			} else {
+				// If we are not connected, we don't want to timeout anything
+				// Just hook into the normal reconnect chan stuff in the RPC
+				// library
+				g.Debug("ping loop: normal ping, not connected")
+				_, err = gregor1.IncomingClient{Cli: g.pingCli}.Ping(ctx)
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), timeout)
-			_, err := gregor1.IncomingClient{Cli: g.cli}.Ping(ctx)
-			cancel()
 			if err != nil {
-				if err == ErrGregorTimeout {
+				g.Debug("ping loop: error: %s", err.Error())
+				if err == context.DeadlineExceeded {
 					g.Debug("ping loop: timeout: terminating connection")
 					g.Shutdown()
 
@@ -1208,6 +1220,7 @@ func (g *gregorHandler) connectTLS() error {
 	// of OnConnect should use g.cli, everything else should the client that is
 	// a paramater to OnConnect
 	g.cli = WrapGenericClientWithTimeout(g.conn.GetClient(), GregorRequestTimeout, ErrGregorTimeout)
+	g.pingCli = g.conn.GetClient() // Don't want this to have a timeout from here
 
 	// Start up ping loop to keep the connection to gregord alive, and to kick
 	// off the reconnect logic in the RPC library
@@ -1229,6 +1242,7 @@ func (g *gregorHandler) connectNoTLS() error {
 	g.conn = rpc.NewConnectionWithTransport(g, t, libkb.ErrorUnwrapper{}, g.G().Log, opts)
 	g.connMutex.Unlock()
 	g.cli = WrapGenericClientWithTimeout(g.conn.GetClient(), GregorRequestTimeout, ErrGregorTimeout)
+	g.pingCli = g.conn.GetClient()
 
 	// Start up ping loop to keep the connection to gregord alive, and to kick
 	// off the reconnect logic in the RPC library


### PR DESCRIPTION
I think this is a better solution than my last PR. This version checks to see if we are online, then does the following:

1.) If we are online, subject the `Ping` RPC to the timeout and kill the connection if we fail it.
2.) If we are not, do a normal call into `Ping` do that we just hook into the reconnect mechanism in the RPC library.

This handles the case if the connection just dropping, and the `Ping` loop being the only thing that can bring it back (the bot case).