### PR TITLE
make IdentifySummaryError fail immediate

### DIFF
--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1262,6 +1262,10 @@ func (e IdentifySummaryError) Error() string {
 	return fmt.Sprintf("%s", strings.Join(e.problems, "; "))
 }
 
+func (e IdentifySummaryError) IsImmediateFail() (chat1.OutboxErrorType, bool) {
+	return chat1.OutboxErrorType_IDENTIFY, true
+}
+
 //=============================================================================
 
 type NotLatestSubchainError struct {


### PR DESCRIPTION
Sometimes this error makes its way into `Deliverer` without being part of `BoxMessage`, so detect it too.