### PR TITLE
Chat: Avoid races when handling failures that arrive early

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -35,6 +35,7 @@ import type {
   BadgeAppForChat,
   ConversationBadgeStateRecord,
   ConversationIDKey,
+  CreatePendingFailure,
   DeleteMessage,
   EditMessage,
   InboxState,
@@ -52,6 +53,7 @@ import type {
   OpenFolder,
   OutboxIDKey,
   PostMessage,
+  RemovePendingFailure,
   RetryMessage,
   SelectConversation,
   SetupChatHandlers,
@@ -369,12 +371,12 @@ function * _postMessage (action: PostMessage): SagaGenerator<any, any> {
       },
     })
     if (hasPendingFailure) {
-      yield put({
+      yield put(({
         payload: {
           outboxID,
         },
         type: 'chat:removePendingFailure',
-      })
+      }: RemovePendingFailure))
     }
   }
 }
@@ -446,7 +448,7 @@ function * _incomingMessage (action: IncomingMessage): SagaGenerator<any, any> {
                 outboxID,
               },
               type: 'chat:createPendingFailure',
-            }))
+            }: CreatePendingFailure))
           }
         }
       }

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -104,7 +104,7 @@ const _metaDataSelector = (state: TypedState) => state.chat.get('metaData')
 const _routeSelector = (state: TypedState) => state.routeTree.get('routeState').get('selected')
 const _focusedSelector = (state: TypedState) => state.chat.get('focused')
 const _conversationStateSelector = (state: TypedState, conversationIDKey: ConversationIDKey) => state.chat.get('conversationStates', Map()).get(conversationIDKey)
-const _messageOutboxIDSelector = (state: TypedState, conversationIDKey: ConversationIDKey, outboxID: OutboxIDKey) => state.chat.get('conversationStates', Map()).get(conversationIDKey).get('messages').findIndex(m => m.outboxID === outboxID)
+const _messageOutboxIDSelector = (state: TypedState, conversationIDKey: ConversationIDKey, outboxID: OutboxIDKey) => state.chat.get('conversationStates', Map()).get(conversationIDKey).get('messages').find(m => m.outboxID === outboxID)
 const _pendingFailureSelector = (state: TypedState, outboxID: OutboxIDKey) => state.chat.get('pendingFailures').get(outboxID)
 const _devicenameSelector = (state: TypedState) => state.config && state.config.extendedConfig && state.config.extendedConfig.device && state.config.extendedConfig.device.name
 
@@ -430,12 +430,13 @@ function * _incomingMessage (action: IncomingMessage): SagaGenerator<any, any> {
           // have, just set it to failed.  If we haven't, record this as a
           // pending failure, and pick up the pending failure at the bottom of
           // _postMessage() instead.
-          const pendingMessageExists = yield select(_messageOutboxIDSelector, conversationIDKey, outboxID)
-          if (pendingMessageExists) {
+          const pendingMessage = yield select(_messageOutboxIDSelector, conversationIDKey, outboxID)
+          if (pendingMessage) {
             yield put(({
               payload: {
                 conversationIDKey,
                 message: {
+                  ...pendingMessage,
                   messageState: 'failed',
                 },
                 outboxID,

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -338,7 +338,7 @@ function * _postMessage (action: PostMessage): SagaGenerator<any, any> {
       outboxID,
       key: outboxID,
       timestamp: Date.now(),
-      messageState: hasPendingFailure ? 'failed': 'pending',
+      messageState: hasPendingFailure ? 'failed' : 'pending',
       message: new HiddenString(action.payload.text.stringValue()),
       you: author,
       deviceType: isMobile ? 'mobile' : 'desktop',
@@ -429,7 +429,6 @@ function * _incomingMessage (action: IncomingMessage): SagaGenerator<any, any> {
           // pending failure, and pick up the pending failure at the bottom of
           // _postMessage() instead.
           const pendingMessageExists = yield select(_messageOutboxIDSelector, conversationIDKey, outboxID)
-          console.warn('outboxIDsel returned ', pendingMessageExists)
           if (pendingMessageExists) {
             yield put(({
               payload: {

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -104,7 +104,7 @@ const _metaDataSelector = (state: TypedState) => state.chat.get('metaData')
 const _routeSelector = (state: TypedState) => state.routeTree.get('routeState').get('selected')
 const _focusedSelector = (state: TypedState) => state.chat.get('focused')
 const _conversationStateSelector = (state: TypedState, conversationIDKey: ConversationIDKey) => state.chat.get('conversationStates', Map()).get(conversationIDKey)
-const _messageOutboxIDSelector = (state: TypedState, conversationIDKey: ConversationIDKey, outboxID: OutboxIDKey) => state.chat.get('conversationStates', Map()).get(conversationIDKey).get(outboxID)
+const _messageOutboxIDSelector = (state: TypedState, conversationIDKey: ConversationIDKey, outboxID: OutboxIDKey) => state.chat.get('conversationStates', Map()).get(conversationIDKey).get('messages').findIndex(m => m.outboxID === outboxID)
 const _pendingFailureSelector = (state: TypedState, outboxID: OutboxIDKey) => state.chat.get('pendingFailures').get(outboxID)
 const _devicenameSelector = (state: TypedState) => state.config && state.config.extendedConfig && state.config.extendedConfig.device && state.config.extendedConfig.device.name
 

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -175,6 +175,7 @@ export const StateRecord = Record({
   conversationStates: Map(),
   focused: false,
   metaData: Map(),
+  pendingFailures: Set(),
 })
 
 export type State = Record<{
@@ -182,6 +183,7 @@ export type State = Record<{
   conversationStates: Map<ConversationIDKey, ConversationState>,
   focused: boolean,
   metaData: MetaDataMap,
+  pendingFailures: Set<OutboxIDKey>,
 }>
 
 export const maxAttachmentPreviewSize = 320
@@ -194,6 +196,7 @@ export const nothingSelected = 'chat:noneSelected'
 export type AppendMessages = NoErrorTypedAction<'chat:appendMessages', {conversationIDKey: ConversationIDKey, isSelected: boolean, messages: Array<ServerMessage>}>
 export type BadgeAppForChat = NoErrorTypedAction<'chat:badgeAppForChat', Array<ConversationBadgeStateRecord>>
 export type ClearMessages = NoErrorTypedAction<'chat:clearMessages', {ConversationIDKey: ConversationIDKey}>
+export type CreatePendingFailure = NoErrorTypedAction<'chat:createPendingFailure', {outboxID: OutboxIDKey}>
 export type DeleteMessage = NoErrorTypedAction<'chat:deleteMessage', {message: Message}>
 export type EditMessage = NoErrorTypedAction<'chat:editMessage', {message: Message}>
 export type InboxStale = NoErrorTypedAction<'chat:inboxStale', void>

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -212,6 +212,7 @@ export type NewChat = NoErrorTypedAction<'chat:newChat', {existingParticipants: 
 export type OpenFolder = NoErrorTypedAction<'chat:openFolder', void>
 export type PostMessage = NoErrorTypedAction<'chat:postMessage', {conversationIDKey: ConversationIDKey, text: HiddenString}>
 export type PrependMessages = NoErrorTypedAction<'chat:prependMessages', {conversationIDKey: ConversationIDKey, messages: Array<ServerMessage>, moreToLoad: boolean, paginationNext: ?Buffer}>
+export type RemovePendingFailure = NoErrorTypedAction<'chat:removePendingFailure', {outboxID: OutboxIDKey}>
 export type RetryMessage = NoErrorTypedAction<'chat:retryMessage', {outboxIDKey: OutboxIDKey}>
 export type SelectConversation = NoErrorTypedAction<'chat:selectConversation', {conversationIDKey: ConversationIDKey, fromUser: boolean}>
 export type SetupChatHandlers = NoErrorTypedAction<'chat:setupChatHandlers', void>

--- a/shared/global-errors/index.desktop.js
+++ b/shared/global-errors/index.desktop.js
@@ -87,7 +87,14 @@ class GlobalError extends Component<void, Props, State> {
       return null
     }
     return (
-      <Box />
+      <Box style={{...containerOverlayStyle}}>
+        <Box style={{...overlayRowStyle}}>
+          <Text type='BodyBig' style={{color: globalColors.white, textAlign: 'center'}}>Keybase is currently unreachable. Trying to reconnect you…</Text>
+        </Box>
+        <Box style={{...overlayFillStyle}}>
+          <Icon type='icon-loader-connecting-112' />
+        </Box>
+      </Box>
     )
   }
 

--- a/shared/global-errors/index.desktop.js
+++ b/shared/global-errors/index.desktop.js
@@ -87,14 +87,7 @@ class GlobalError extends Component<void, Props, State> {
       return null
     }
     return (
-      <Box style={{...containerOverlayStyle}}>
-        <Box style={{...overlayRowStyle}}>
-          <Text type='BodyBig' style={{color: globalColors.white, textAlign: 'center'}}>Keybase is currently unreachable. Trying to reconnect you…</Text>
-        </Box>
-        <Box style={{...overlayFillStyle}}>
-          <Icon type='icon-loader-connecting-112' />
-        </Box>
-      </Box>
+      <Box />
     )
   }
 

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -217,6 +217,14 @@ function reducer (state: State = initialState, action: Actions) {
         conversation => conversation.update('seenMessages', seenMessages => seenMessages.add(messageID))
       ))
     }
+    case 'chat:createPendingFailure': {
+      const {outboxID} = action.payload
+      return state.set('pendingFailures', state.get('pendingFailures').add(outboxID))
+    }
+    case 'chat:removePendingFailure': {
+      const {outboxID} = action.payload
+      return state.set('pendingFailures', state.get('pendingFailures').remove(outboxID))
+    }
     case 'chat:attachmentLoaded': {
       const {conversationIDKey, messageID, path, isPreview} = action.payload
 


### PR DESCRIPTION
@keybase/react-hackers 

Avoid races when handling failures that arrive early, before we've added the pending message to our conversation store.

This happens because the _postMessage and _incomingMessage sagas can interleave -- _incomingMessage runs while _postMessage is yielded, after we've sent the message RPC but before we've finished adding the resulting message object to our internal store.

So to avoid the race:

* if the pending message exists in our store, just mark it failed

* if it doesn't, create a pendingFailure entry.

* when posting a message, and preparing to add it to our store, see if it exists in the pendingFailures set.  If it does, mark it failed immediately and remove it from the set.