### PR TITLE
Only use outboxID for keying own messages

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -831,7 +831,7 @@ function _unboxedToMessage (message: MessageUnboxed, idx: number, yourName, your
 
       switch (payload.messageBody.messageType) {
         case CommonMessageType.text:
-          // If we get a histocal message w/ messageID and outboxID ignore the outboxID
+          // If we get a historical message w/ messageID and outboxID ignore the outboxID
           const outboxID = (isHistory && common.messageID) ? undefined : payload.clientHeader.outboxID && outboxIDToKey(payload.clientHeader.outboxID)
           return {
             type: 'Text',

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -467,7 +467,7 @@ function * _incomingMessage (action: IncomingMessage): SagaGenerator<any, any> {
         const yourName = yield select(usernameSelector)
         const yourDeviceName = yield select(_devicenameSelector)
         const conversationIDKey = conversationIDToKey(incomingMessage.convID)
-        const message = _unboxedToMessage(messageUnboxed, 0, yourName, yourDeviceName, conversationIDKey, false)
+        const message = _unboxedToMessage(messageUnboxed, 0, yourName, yourDeviceName, conversationIDKey)
 
         // Is this message for the currently selected and focused conversation?
         // And is the Chat tab the currently displayed route? If all that is
@@ -716,7 +716,7 @@ function * _loadMoreMessages (action: LoadMoreMessages): SagaGenerator<any, any>
 
   const yourName = yield select(usernameSelector)
   const yourDeviceName = yield select(_devicenameSelector)
-  const messages = (thread && thread.thread && thread.thread.messages || []).map((message, idx) => _unboxedToMessage(message, idx, yourName, yourDeviceName, conversationIDKey, true)).reverse()
+  const messages = (thread && thread.thread && thread.thread.messages || []).map((message, idx) => _unboxedToMessage(message, idx, yourName, yourDeviceName, conversationIDKey)).reverse()
   let newMessages = []
   messages.forEach((message, idx) => {
     if (idx > 0) {
@@ -792,7 +792,7 @@ const _temporaryAttachmentMessageForUpload = (convID: ConversationIDKey, usernam
   key: `temp-${outboxID}`,
 })
 
-function _unboxedToMessage (message: MessageUnboxed, idx: number, yourName, yourDeviceName, conversationIDKey: ConversationIDKey, isHistory: boolean): Message {
+function _unboxedToMessage (message: MessageUnboxed, idx: number, yourName, yourDeviceName, conversationIDKey: ConversationIDKey): Message {
   if (message && message.state === LocalMessageUnboxedState.outbox && message.outbox) {
     // Outbox messages are always text, not attachments.
     const payload: OutboxRecord = message.outbox
@@ -832,7 +832,8 @@ function _unboxedToMessage (message: MessageUnboxed, idx: number, yourName, your
       switch (payload.messageBody.messageType) {
         case CommonMessageType.text:
           // If we get a historical message w/ messageID and outboxID ignore the outboxID
-          const outboxID = (isHistory && common.messageID) ? undefined : payload.clientHeader.outboxID && outboxIDToKey(payload.clientHeader.outboxID)
+          const messageIsYours = common.author === yourName
+          const outboxID = !messageIsYours ? undefined : payload.clientHeader.outboxID && outboxIDToKey(payload.clientHeader.outboxID)
           return {
             type: 'Text',
             ...common,


### PR DESCRIPTION
This should fix duplicate messages showing up. We were determining the key of a message inconsistently based on whether if was loaded via `loadMoreMessages` or `incomingMessage` via the `isHistory` parameter of `_unboxedToMessage`. 

I think it would be best resolve this so that we always consistently key messages, rather than attempting to filter out the dupes in a filtering operation. So this solution will use `outboxID` for key always if it's a message we sent, otherwise it'll use `messageID`. If there's some problem with this approach, we can always filter by `messageID` in `_filterMessages`, but I think that's less preferable because it could make an bug caused by inconsistent message keys more subtle in the future. 

:eyeglasses: @keybase/react-hackers 