### PR TITLE
[WIP] Filter seen messageIDs when updating message list

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -831,7 +831,7 @@ function _unboxedToMessage (message: MessageUnboxed, idx: number, yourName, your
 
       switch (payload.messageBody.messageType) {
         case CommonMessageType.text:
-          // If we get a histocal message w/ messageID and outboxID ignore the outboxID
+          // If we get a historical message w/ messageID and outboxID ignore the outboxID
           const outboxID = (isHistory && common.messageID) ? undefined : payload.clientHeader.outboxID && outboxIDToKey(payload.clientHeader.outboxID)
           return {
             type: 'Text',


### PR DESCRIPTION
Alternate fix to https://github.com/keybase/client/pull/5462. Not sure if this is working yet have seen mixed results when attempting to repro. The code is messier than I'd like -- hopefully can clean up with fresh eyes tomorrow. I'm also concerned that this may still produce buggy behavior when a message with key=outboxID gets replaced by a message with key=messageID... will that cause issues with the react-virtualized message list rendering?

Let's discuss. :smile: 

:eyeglasses: @keybase/react-hackers 