### PR TITLE
Add ChatTLFResolve notification

### DIFF
--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -48,6 +48,8 @@ func (n *chatListener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDW
 }
 func (n *chatListener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationFinalizeInfo) {
 }
+func (n *chatListener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationResolveInfo) {
+}
 func (n *chatListener) ChatInboxStale(uid keybase1.UID)                                {}
 func (n *chatListener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {}
 func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActivity) {

--- a/go/engine/paperkey_submit_test.go
+++ b/go/engine/paperkey_submit_test.go
@@ -108,5 +108,7 @@ func (n *nlistener) ReachabilityChanged(r keybase1.Reachability)                
 func (n *nlistener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks) {}
 func (n *nlistener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationFinalizeInfo) {
 }
+func (n *nlistener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationResolveInfo) {
+}
 func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                {}
 func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {}

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -44,7 +44,8 @@ type NotifyListener interface {
 	ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks)
 	ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID,
 		finalizeInfo chat1.ConversationFinalizeInfo)
-	ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID)
+	ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID,
+		resolveInfo chat1.ConversationResolveInfo)
 	ChatInboxStale(uid keybase1.UID)
 	ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID)
 	PGPKeyInSecretStoreFile()
@@ -583,7 +584,7 @@ func (n *NotifyRouter) HandleChatTLFResolve(ctx context.Context, uid keybase1.UI
 	})
 	wg.Wait()
 	if n.listener != nil {
-		n.listener.ChatTLFResolve(uid, convID)
+		n.listener.ChatTLFResolve(uid, convID, resolveInfo)
 	}
 	n.G().Log.Debug("- Sent ChatTLFResolve notification")
 }

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -170,6 +170,10 @@ type ConversationFinalizeInfo struct {
 	ResetTimestamp gregor1.Time `codec:"resetTimestamp" json:"resetTimestamp"`
 }
 
+type ConversationResolveInfo struct {
+	NewTLFName string `codec:"newTLFName" json:"newTLFName"`
+}
+
 type ConversationMetadata struct {
 	IdTriple       ConversationIDTriple      `codec:"idTriple" json:"idTriple"`
 	ConversationID ConversationID            `codec:"conversationID" json:"conversationID"`

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -215,6 +215,12 @@ type ChatTLFFinalizeArg struct {
 	FinalizeInfo ConversationFinalizeInfo `codec:"finalizeInfo" json:"finalizeInfo"`
 }
 
+type ChatTLFResolveArg struct {
+	Uid         keybase1.UID            `codec:"uid" json:"uid"`
+	ConvID      ConversationID          `codec:"convID" json:"convID"`
+	ResolveInfo ConversationResolveInfo `codec:"resolveInfo" json:"resolveInfo"`
+}
+
 type ChatInboxStaleArg struct {
 	Uid keybase1.UID `codec:"uid" json:"uid"`
 }
@@ -228,6 +234,7 @@ type NotifyChatInterface interface {
 	NewChatActivity(context.Context, NewChatActivityArg) error
 	ChatIdentifyUpdate(context.Context, keybase1.CanonicalTLFNameAndIDWithBreaks) error
 	ChatTLFFinalize(context.Context, ChatTLFFinalizeArg) error
+	ChatTLFResolve(context.Context, ChatTLFResolveArg) error
 	ChatInboxStale(context.Context, keybase1.UID) error
 	ChatThreadsStale(context.Context, ChatThreadsStaleArg) error
 }
@@ -280,6 +287,22 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 						return
 					}
 					err = i.ChatTLFFinalize(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodNotify,
+			},
+			"ChatTLFResolve": {
+				MakeArg: func() interface{} {
+					ret := make([]ChatTLFResolveArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ChatTLFResolveArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ChatTLFResolveArg)(nil), args)
+						return
+					}
+					err = i.ChatTLFResolve(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodNotify,
@@ -337,6 +360,11 @@ func (c NotifyChatClient) ChatIdentifyUpdate(ctx context.Context, update keybase
 
 func (c NotifyChatClient) ChatTLFFinalize(ctx context.Context, __arg ChatTLFFinalizeArg) (err error) {
 	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatTLFFinalize", []interface{}{__arg})
+	return
+}
+
+func (c NotifyChatClient) ChatTLFResolve(ctx context.Context, __arg ChatTLFResolveArg) (err error) {
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatTLFResolve", []interface{}{__arg})
 	return
 }
 

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -843,6 +843,8 @@ func (n *chatListener) ReachabilityChanged(r keybase1.Reachability)             
 func (n *chatListener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks) {}
 func (n *chatListener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationFinalizeInfo) {
 }
+func (n *chatListener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationResolveInfo) {
+}
 func (n *chatListener) ChatInboxStale(uid keybase1.UID)                                {}
 func (n *chatListener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {}
 func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActivity) {

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -106,6 +106,8 @@ func (n *nlistener) FSSyncEvent(arg keybase1.FSPathSyncStatus)                  
 func (n *nlistener) ReachabilityChanged(r keybase1.Reachability)                        {}
 func (n *nlistener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationFinalizeInfo) {
 }
+func (n *nlistener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationResolveInfo) {
+}
 func (n *nlistener) ChatInboxStale(uid keybase1.UID) {}
 func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {
 	select {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -102,6 +102,10 @@ protocol common {
     gregor1.Time resetTimestamp;
   }
 
+  record ConversationResolveInfo {
+    string newTLFName;
+  }
+
   record ConversationMetadata  {
     ConversationIDTriple idTriple;
     ConversationID conversationID;

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -63,6 +63,10 @@ protocol NotifyChat {
   void ChatTLFFinalize(keybase1.UID uid, ConversationID convID, ConversationFinalizeInfo finalizeInfo);
 
   @notify("")
+  @lint("ignore")
+  void ChatTLFResolve(keybase1.UID uid, ConversationID convID);
+
+  @notify("")
   @lint("ignore") 
   void ChatInboxStale(keybase1.UID uid);
 

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -64,7 +64,7 @@ protocol NotifyChat {
 
   @notify("")
   @lint("ignore")
-  void ChatTLFResolve(keybase1.UID uid, ConversationID convID);
+  void ChatTLFResolve(keybase1.UID uid, ConversationID convID, ConversationResolveInfo resolveInfo);
 
   @notify("")
   @lint("ignore") 

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -671,6 +671,10 @@ export type ConversationReaderInfo = {
   maxMsgid: MessageID,
 }
 
+export type ConversationResolveInfo = {
+  newTLFName: string,
+}
+
 export type ConversationStatus = 
     0 // UNFILED_0
   | 1 // FAVORITE_1
@@ -1053,7 +1057,8 @@ export type NotifyChatChatTLFFinalizeRpcParam = Exact<{
 
 export type NotifyChatChatTLFResolveRpcParam = Exact<{
   uid: keybase1.UID,
-  convID: ConversationID
+  convID: ConversationID,
+  resolveInfo: ConversationResolveInfo
 }>
 
 export type NotifyChatChatThreadsStaleRpcParam = Exact<{
@@ -1679,7 +1684,8 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatTLFResolve'?: (
     params: Exact<{
       uid: keybase1.UID,
-      convID: ConversationID
+      convID: ConversationID,
+      resolveInfo: ConversationResolveInfo
     }> /* ,
     response: {} // Notify call
     */

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1051,6 +1051,11 @@ export type NotifyChatChatTLFFinalizeRpcParam = Exact<{
   finalizeInfo: ConversationFinalizeInfo
 }>
 
+export type NotifyChatChatTLFResolveRpcParam = Exact<{
+  uid: keybase1.UID,
+  convID: ConversationID
+}>
+
 export type NotifyChatChatThreadsStaleRpcParam = Exact<{
   uid: keybase1.UID,
   convIDs?: ?Array<ConversationID>
@@ -1667,6 +1672,14 @@ export type incomingCallMapType = Exact<{
       uid: keybase1.UID,
       convID: ConversationID,
       finalizeInfo: ConversationFinalizeInfo
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatTLFResolve'?: (
+    params: Exact<{
+      uid: keybase1.UID,
+      convID: ConversationID
     }> /* ,
     response: {} // Notify call
     */

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -263,6 +263,16 @@
     },
     {
       "type": "record",
+      "name": "ConversationResolveInfo",
+      "fields": [
+        {
+          "type": "string",
+          "name": "newTLFName"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "ConversationMetadata",
       "fields": [
         {

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -195,6 +195,21 @@
       "notify": "",
       "lint": "ignore"
     },
+    "ChatTLFResolve": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "keybase1.UID"
+        },
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        }
+      ],
+      "response": null,
+      "notify": "",
+      "lint": "ignore"
+    },
     "ChatInboxStale": {
       "request": [
         {

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -204,6 +204,10 @@
         {
           "name": "convID",
           "type": "ConversationID"
+        },
+        {
+          "name": "resolveInfo",
+          "type": "ConversationResolveInfo"
         }
       ],
       "response": null,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -671,6 +671,10 @@ export type ConversationReaderInfo = {
   maxMsgid: MessageID,
 }
 
+export type ConversationResolveInfo = {
+  newTLFName: string,
+}
+
 export type ConversationStatus = 
     0 // UNFILED_0
   | 1 // FAVORITE_1
@@ -1053,7 +1057,8 @@ export type NotifyChatChatTLFFinalizeRpcParam = Exact<{
 
 export type NotifyChatChatTLFResolveRpcParam = Exact<{
   uid: keybase1.UID,
-  convID: ConversationID
+  convID: ConversationID,
+  resolveInfo: ConversationResolveInfo
 }>
 
 export type NotifyChatChatThreadsStaleRpcParam = Exact<{
@@ -1679,7 +1684,8 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatTLFResolve'?: (
     params: Exact<{
       uid: keybase1.UID,
-      convID: ConversationID
+      convID: ConversationID,
+      resolveInfo: ConversationResolveInfo
     }> /* ,
     response: {} // Notify call
     */

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1051,6 +1051,11 @@ export type NotifyChatChatTLFFinalizeRpcParam = Exact<{
   finalizeInfo: ConversationFinalizeInfo
 }>
 
+export type NotifyChatChatTLFResolveRpcParam = Exact<{
+  uid: keybase1.UID,
+  convID: ConversationID
+}>
+
 export type NotifyChatChatThreadsStaleRpcParam = Exact<{
   uid: keybase1.UID,
   convIDs?: ?Array<ConversationID>
@@ -1667,6 +1672,14 @@ export type incomingCallMapType = Exact<{
       uid: keybase1.UID,
       convID: ConversationID,
       finalizeInfo: ConversationFinalizeInfo
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatTLFResolve'?: (
+    params: Exact<{
+      uid: keybase1.UID,
+      convID: ConversationID
     }> /* ,
     response: {} // Notify call
     */


### PR DESCRIPTION
This `ChatTLFResolve` notification is sent to electron when a client gets a `chat.tlfresolve` `OOBM`. This notification comes along when a conversation you were already in has someone SBS resolve in it.

cc @chrisnojima 