### PR TITLE
make the outbox more race proof, when sending remove entries CORE-4420

### DIFF
--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -457,6 +457,7 @@ func (s *Deliverer) deliverLoop() {
 				}); err != nil {
 					s.Debug(bgctx, "unable to fail message: %s", err.Error())
 				}
+				continue
 			}
 
 			// Do the actual send
@@ -467,7 +468,6 @@ func (s *Deliverer) deliverLoop() {
 				_, _, _, err = s.sender.Send(bctx, obr.ConvID, obr.Msg, 0)
 			}
 			if err != nil {
-				// Send failed
 				s.Debug(bgctx, "failed to send msg: uid: %s convID: %s err: %s attempts: %d",
 					s.outbox.GetUID(), obr.ConvID, err.Error(), obr.State.Sending())
 
@@ -476,6 +476,7 @@ func (s *Deliverer) deliverLoop() {
 					// Record failure if we hit this case, and put the rest of this loop in a
 					// mode where all other entries also fail.
 					s.Debug(bgctx, "failure condition reached, marking all as errors and notifying: errTyp: %v attempts: %d", errTyp, obr.State.Sending())
+					markRestAsError = true
 
 					if err := s.failMessage(bgctx, obr, chat1.OutboxStateError{
 						Message: err.Error(),
@@ -489,8 +490,6 @@ func (s *Deliverer) deliverLoop() {
 							s.outbox.GetUID(), err.Error())
 					}
 				}
-
-				break
 			}
 		}
 	}

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -444,7 +444,6 @@ func (s *Deliverer) deliverLoop() {
 		markRestAsError := false
 		for _, obr := range obrs {
 
-			s.Debug(bgctx, "OBSENDING: %s ctime: %v", obr.OutboxID, obr.Ctime)
 			// Check type
 			state, err := obr.State.State()
 			if err != nil {

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -419,7 +419,7 @@ func TestDisconnectedFailure(t *testing.T) {
 				break
 			}
 			continue
-		case <-time.After(2 * time.Second):
+		case <-time.After(20 * time.Second):
 			require.Fail(t, "timeout in failing loop")
 			break
 		}
@@ -450,7 +450,7 @@ func TestDisconnectedFailure(t *testing.T) {
 				break
 			}
 			continue
-		case <-time.After(2 * time.Second):
+		case <-time.After(20 * time.Second):
 			require.Fail(t, "timeout in incoming loop")
 			break
 		}

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -438,7 +438,6 @@ func TestDisconnectedFailure(t *testing.T) {
 	}
 	outbox := storage.NewOutbox(tc.G, u.User.GetUID().ToBytes(), f)
 	for _, obid := range obids {
-		t.Logf("ORDER: %s", obid)
 		require.NoError(t, outbox.RetryMessage(context.TODO(), obid))
 	}
 	tc.G.MessageDeliverer.Connected(context.TODO())

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -217,7 +217,7 @@ func TestNonblockTimer(t *testing.T) {
 	var obids []chat1.OutboxID
 	msgID := *sentRef[len(sentRef)-1].msgID
 	for i := 0; i < 5; i++ {
-		obid, err := outbox.PushMessage(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+		obr, err := outbox.PushMessage(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
 				Sender:    u.User.GetUID().ToBytes(),
 				TlfName:   u.Username,
@@ -227,6 +227,7 @@ func TestNonblockTimer(t *testing.T) {
 				},
 			},
 		}, keybase1.TLFIdentifyBehavior_CHAT_CLI)
+		obid := obr.OutboxID
 		t.Logf("generated obid: %s prev: %d", hex.EncodeToString(obid), msgID)
 		require.NoError(t, err)
 		sentRef = append(sentRef, sentRecord{outboxID: &obid})

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -267,7 +267,6 @@ func (o *Outbox) MarkAsError(ctx context.Context, obr chat1.OutboxRecord, errRec
 	o.Lock()
 	defer o.Unlock()
 
-	o.Debug(ctx, "MARK: %s", obr.OutboxID)
 	// Read outbox for the user
 	obox, err := o.readDiskOutbox(ctx)
 	if err != nil {

--- a/go/chat/storage/outbox_test.go
+++ b/go/chat/storage/outbox_test.go
@@ -1,0 +1,120 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"time"
+
+	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func setupOutboxTest(t testing.TB, name string) (libkb.TestContext, *Outbox, gregor1.UID, clockwork.FakeClock) {
+	tc := externals.SetupTest(t, name, 2)
+	u, err := kbtest.CreateAndSignupFakeUser("ob", tc.G)
+	require.NoError(t, err)
+	f := func() libkb.SecretUI {
+		return &libkb.TestSecretUI{Passphrase: u.Passphrase}
+	}
+	uid := gregor1.UID(u.User.GetUID().ToBytes())
+	cl := clockwork.NewFakeClock()
+	ob := NewOutbox(tc.G, uid, f)
+	ob.SetClock(cl)
+	return tc, ob, uid, cl
+}
+
+func makeMsgPlaintext(body string, uid gregor1.UID) chat1.MessagePlaintext {
+	return chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Sender: uid,
+		},
+		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{Body: body}),
+	}
+}
+
+func TestChatOutbox(t *testing.T) {
+
+	_, ob, uid, cl := setupOutboxTest(t, "outbox")
+
+	var obrs []chat1.OutboxRecord
+	conv := makeConvo(gregor1.Time(5), 1, 1)
+
+	for i := 0; i < 5; i++ {
+		obr, err := ob.PushMessage(context.TODO(), conv.GetConvID(), makeMsgPlaintext("hi", uid),
+			keybase1.TLFIdentifyBehavior_CHAT_CLI)
+		require.NoError(t, err)
+		obrs = append(obrs, obr)
+		cl.Advance(time.Millisecond)
+	}
+
+	// Basic pull
+	res, err := ob.PullAllConversations(context.TODO(), true, false)
+	require.NoError(t, err)
+	require.Equal(t, obrs, res, "wrong obids")
+
+	// Pull with remove
+	res, err = ob.PullAllConversations(context.TODO(), true, true)
+	require.NoError(t, err)
+	require.Equal(t, obrs, res, "wrong obids")
+	emptyRes, err := ob.PullAllConversations(context.TODO(), true, true)
+	require.NoError(t, err)
+	require.Zero(t, len(emptyRes), "not empty")
+
+	// Record a failed attempt
+	require.NoError(t, ob.RecordFailedAttempt(context.TODO(), obrs[3]))
+
+	// Check to make sure this record now has a failure
+	res, err = ob.PullAllConversations(context.TODO(), true, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res), "wrong len")
+	state, err := res[0].State.State()
+	require.NoError(t, err)
+	require.Equal(t, chat1.OutboxStateType_SENDING, state, "wrong state")
+	require.Equal(t, 1, res[0].State.Sending(), "wrong attempts")
+
+	// Mark one as an error
+	require.NoError(t, ob.MarkAsError(context.TODO(), obrs[2], chat1.OutboxStateError{
+		Message: "failed",
+		Typ:     chat1.OutboxErrorType_MISC,
+	}))
+
+	// Check for correct order
+	res, err = ob.PullAllConversations(context.TODO(), true, false)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(res), "wrong len")
+	state, err = res[0].State.State()
+	require.NoError(t, err)
+	require.Equal(t, chat1.OutboxStateType_ERROR, state, "wrong state")
+	state, err = res[1].State.State()
+	require.NoError(t, err)
+	require.Equal(t, chat1.OutboxStateType_SENDING, state, "wrong state")
+
+	// Pull without errors
+	res, err = ob.PullAllConversations(context.TODO(), false, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res), "wrong len")
+
+	// Retry the error
+	require.NoError(t, ob.RetryMessage(context.TODO(), obrs[2].OutboxID))
+	res, err = ob.PullAllConversations(context.TODO(), true, false)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(res), "wrong len")
+	state, err = res[0].State.State()
+	require.NoError(t, err)
+	require.Equal(t, chat1.OutboxStateType_SENDING, state, "wrong state")
+	require.Equal(t, 0, res[0].State.Sending(), "wrong attempts")
+
+	// Remove 2
+	require.NoError(t, ob.RemoveMessage(context.TODO(), obrs[2].OutboxID))
+	res, err = ob.PullAllConversations(context.TODO(), true, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res), "wrong len")
+	require.Equal(t, obrs[3].OutboxID, res[0].OutboxID, "wrong element")
+}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -535,7 +535,7 @@ type ConversationSource interface {
 
 type MessageDeliverer interface {
 	Queue(ctx context.Context, convID chat1.ConversationID, msg chat1.MessagePlaintext,
-		identifyBehavior keybase1.TLFIdentifyBehavior) (chat1.OutboxID, error)
+		identifyBehavior keybase1.TLFIdentifyBehavior) (chat1.OutboxRecord, error)
 	Start(ctx context.Context, uid gregor1.UID)
 	Stop(ctx context.Context) chan struct{}
 	ForceDeliverLoop(ctx context.Context)

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -719,7 +719,7 @@ func TestGetOutbox(t *testing.T) {
 	tc := ctc.world.Tcs[ctc.as(t, users[0]).user().Username]
 	outbox := storage.NewOutbox(tc.G, users[0].User.GetUID().ToBytes(), h.getSecretUI)
 
-	obid, err := outbox.PushMessage(context.TODO(), created.Id, chat1.MessagePlaintext{
+	obr, err := outbox.PushMessage(context.TODO(), created.Id, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Sender:    u.User.GetUID().ToBytes(),
 			TlfName:   u.Username,
@@ -738,7 +738,7 @@ func TestGetOutbox(t *testing.T) {
 
 	routbox := extractOutbox(t, thread.Thread.Messages)
 	require.Equal(t, 1, len(routbox), "wrong size outbox")
-	require.Equal(t, obid, routbox[0].Outbox().OutboxID, "wrong outbox ID")
+	require.Equal(t, obr.OutboxID, routbox[0].Outbox().OutboxID, "wrong outbox ID")
 
 	thread, err = h.GetThreadLocal(context.Background(), chat1.GetThreadLocalArg{
 		ConversationID: created2.Id,


### PR DESCRIPTION
The main purpose of this patch is to change the `Deliverer` loop to remove entries off the disk when sending from the `Outbox`. This guards against some pathological case where two threads might try sending the same set of messages. On errors, we add them back into the `Outbox` in `ctime` order.