### PR TITLE
Fix chat animation showing up on page loads

### DIFF
--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -277,7 +277,7 @@ class ConversationList extends Component<void, Props, State> {
     if (index === 0) {
       return (
         <div style={{...globalStyles.flexBoxColumn, alignItems: 'center', flex: 1, justifyContent: 'center', height: 116}}>
-          <Icon type='icon-secured-266' />
+          {!this.props.moreToLoad && <Icon type='icon-secured-266' />}
         </div>
       )
     } else if (index === 1) {


### PR DESCRIPTION
The secure chat animation was showing up on page loads via scrolling. We should only show if we don't have more to load (we are at the beginning of chat). This makes it so you'll only see it in new chats as designed.