### PR TITLE
Allow @2x @3x for icon gifs

### DIFF
--- a/shared/common-adapters/icon.desktop.js
+++ b/shared/common-adapters/icon.desktop.js
@@ -79,11 +79,7 @@ class Icon extends Component<void, Exact<Props>, void> {
 
 const imgName = (type, ext, mult) => `${resolveImageAsURL('icons', type)}${mult > 1 ? `@${mult}x` : ''}.${ext} ${mult}x`
 const imgPath = (type, ext) => {
-  if (ext === 'gif') {
-    return `${resolveImageAsURL('icons', type)}.${ext}`
-  } else {
-    return [1, 2, 3].map(mult => imgName(type, ext, mult)).join(', ')
-  }
+  return [1, 2, 3].map(mult => imgName(type, ext, mult)).join(', ')
 }
 
 export const styles = {


### PR DESCRIPTION
We have @2x and @3x for icon gifs so we can use the same logic.
Tested with the chat secure animation gif.