### PR TITLE
Guard against null prevMessage

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -758,7 +758,7 @@ function _threadToPagination (thread) {
 }
 
 function _maybeAddTimestamp (message: Message, prevMessage: Message): MaybeTimestamp {
-  if (prevMessage.type === 'Timestamp' || message.type === 'Timestamp' || message.type === 'Deleted' || message.type === 'Unhandled') {
+  if (prevMessage == null || prevMessage.type === 'Timestamp' || message.type === 'Timestamp' || message.type === 'Deleted' || message.type === 'Unhandled') {
     return null
   }
   // messageID 1 is an unhandled placeholder. We want to add a timestamp before


### PR DESCRIPTION
@keybase/react-hackers 

We've had reports of a `"type" being accessed on an undefined variable` crash, which I can't repro but am assuming comes from this check:
```js
function _maybeAddTimestamp (message: Message, prevMessage: Message): MaybeTimestamp {
  if (prevMessage.type === 'Timestamp'  [...]
```
I'm not sure how `prevMessage` would be undefined in the code below, but might as well guard it.