### PR TITLE
Remove badge totals from protocol

### DIFF
--- a/go/badges/badgestate.go
+++ b/go/badges/badgestate.go
@@ -91,8 +91,6 @@ func (b *BadgeState) UpdateWithGregor(gstate gregor.State) error {
 		}
 	}
 
-	b.updateCounts()
-
 	return nil
 }
 
@@ -106,7 +104,6 @@ func (b *BadgeState) UpdateWithChat(update chat1.UnreadUpdate, inboxVers chat1.I
 	}
 
 	b.updateWithChat(update)
-	b.updateCounts()
 }
 
 func (b *BadgeState) UpdateWithChatFull(update chat1.UnreadUpdateFull) {
@@ -129,7 +126,6 @@ func (b *BadgeState) UpdateWithChatFull(update chat1.UnreadUpdateFull) {
 	}
 
 	b.inboxVers = update.InboxVers
-	b.updateCounts()
 }
 
 func (b *BadgeState) Clear() {
@@ -143,19 +139,4 @@ func (b *BadgeState) updateWithChat(update chat1.UnreadUpdate) {
 		ConvID:         keybase1.ChatConversationID(update.ConvID),
 		UnreadMessages: update.UnreadMessages,
 	}
-}
-
-func (b *BadgeState) updateCounts() {
-	// Compute chat counts
-	b.state.UnreadChatMessages = 0
-	b.state.UnreadChatConversations = 0
-	for _, info := range b.chatUnreadMap {
-		if info.UnreadMessages > 0 {
-			b.state.UnreadChatConversations++
-		}
-		b.state.UnreadChatMessages += info.UnreadMessages
-	}
-
-	// Compute total badge count
-	b.state.Total = b.state.NewTlfs + b.state.RekeysNeeded + b.state.NewFollowers + b.state.UnreadChatConversations
 }

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -275,7 +275,7 @@ func (n *NotifyRouter) HandleBadgeState(badgeState keybase1.BadgeState) {
 	if n == nil {
 		return
 	}
-	n.G().Log.Debug("Sending BadgeState notification: %v", badgeState.Total)
+	n.G().Log.Debug("Sending BadgeState notification")
 	// For all connections we currently have open...
 	n.cm.ApplyAll(func(id ConnectionID, xp rpc.Transporter) bool {
 		// If the connection wants the `Badges` notification type

--- a/go/protocol/keybase1/notify_badges.go
+++ b/go/protocol/keybase1/notify_badges.go
@@ -10,13 +10,10 @@ import (
 
 type ChatConversationID []byte
 type BadgeState struct {
-	Total                   int                     `codec:"total" json:"total"`
-	NewTlfs                 int                     `codec:"newTlfs" json:"newTlfs"`
-	RekeysNeeded            int                     `codec:"rekeysNeeded" json:"rekeysNeeded"`
-	NewFollowers            int                     `codec:"newFollowers" json:"newFollowers"`
-	UnreadChatMessages      int                     `codec:"unreadChatMessages" json:"unreadChatMessages"`
-	UnreadChatConversations int                     `codec:"unreadChatConversations" json:"unreadChatConversations"`
-	Conversations           []BadgeConversationInfo `codec:"conversations" json:"conversations"`
+	NewTlfs       int                     `codec:"newTlfs" json:"newTlfs"`
+	RekeysNeeded  int                     `codec:"rekeysNeeded" json:"rekeysNeeded"`
+	NewFollowers  int                     `codec:"newFollowers" json:"newFollowers"`
+	Conversations []BadgeConversationInfo `codec:"conversations" json:"conversations"`
 }
 
 type BadgeConversationInfo struct {

--- a/go/service/badger.go
+++ b/go/service/badger.go
@@ -79,7 +79,7 @@ func (b *Badger) send() error {
 	if err != nil {
 		return err
 	}
-	b.G().Log.Debug("Badger send (total:%v ucm:%v)", state.Total, state.UnreadChatMessages)
+	b.G().Log.Debug("Badger send")
 	b.G().NotifyRouter.HandleBadgeState(state)
 	return nil
 }

--- a/protocol/avdl/keybase1/notify_badges.avdl
+++ b/protocol/avdl/keybase1/notify_badges.avdl
@@ -5,18 +5,11 @@ protocol NotifyBadges {
   @typedef("bytes")  record ChatConversationID {}
 
   record BadgeState {
-    // Total badge count for the app
-    int total;
-
     @lint("ignore")
     int newTlfs;
     int rekeysNeeded;
     int newFollowers;
 
-    // Total number of unread chat messages
-    int unreadChatMessages;
-    // Number of chat conversations with unread messages
-    int unreadChatConversations;
     array<BadgeConversationInfo> conversations;
   }
 

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2756,12 +2756,9 @@ export type BadgeConversationInfo = {
 }
 
 export type BadgeState = {
-  total: int,
   newTlfs: int,
   rekeysNeeded: int,
   newFollowers: int,
-  unreadChatMessages: int,
-  unreadChatConversations: int,
   conversations?: ?Array<BadgeConversationInfo>,
 }
 

--- a/protocol/json/keybase1/notify_badges.json
+++ b/protocol/json/keybase1/notify_badges.json
@@ -19,10 +19,6 @@
       "fields": [
         {
           "type": "int",
-          "name": "total"
-        },
-        {
-          "type": "int",
           "name": "newTlfs",
           "lint": "ignore"
         },
@@ -33,14 +29,6 @@
         {
           "type": "int",
           "name": "newFollowers"
-        },
-        {
-          "type": "int",
-          "name": "unreadChatMessages"
-        },
-        {
-          "type": "int",
-          "name": "unreadChatConversations"
         },
         {
           "type": {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2756,12 +2756,9 @@ export type BadgeConversationInfo = {
 }
 
 export type BadgeState = {
-  total: int,
   newTlfs: int,
   rekeysNeeded: int,
   newFollowers: int,
-  unreadChatMessages: int,
-  unreadChatConversations: int,
   conversations?: ?Array<BadgeConversationInfo>,
 }
 


### PR DESCRIPTION
Remove anything that's a sum of badge numbers from the `BadgeState` message. It's better if the gui adds them up because there may be things that are discounted at the last minute. And they're not used (I'm guessing because the gui still compiles).

r? @mmaxim @cjb 