### PR TITLE
Fix `keybase passphrase recover` for paperkey

### DIFF
--- a/go/engine/login_with_paperkey.go
+++ b/go/engine/login_with_paperkey.go
@@ -1,0 +1,135 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// This engine makes sure the user is logged in and unlocked.
+// It asks for a paper key if need be. It does not ask for a passphrase.
+
+package engine
+
+import "github.com/keybase/client/go/libkb"
+
+// LoginWithPaperKey is an engine.
+type LoginWithPaperKey struct {
+	libkb.Contextified
+}
+
+// NewLoginWithPaperKey creates a LoginWithPaperKey engine.
+// Uses the paperkey to log in and unlock LKS.
+func NewLoginWithPaperKey(g *libkb.GlobalContext) *LoginWithPaperKey {
+	return &LoginWithPaperKey{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+// Name is the unique engine name.
+func (e *LoginWithPaperKey) Name() string {
+	return "LoginWithPaperKey"
+}
+
+// GetPrereqs returns the engine prereqs.
+func (e *LoginWithPaperKey) Prereqs() Prereqs {
+	return Prereqs{}
+}
+
+// RequiredUIs returns the required UIs.
+func (e *LoginWithPaperKey) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{
+		libkb.LogUIKind,
+		libkb.SecretUIKind,
+	}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *LoginWithPaperKey) SubConsumers() []libkb.UIConsumer {
+	return []libkb.UIConsumer{}
+}
+
+// Run starts the engine.
+func (e *LoginWithPaperKey) Run(ctx *Context) error {
+	me, err := libkb.LoadMe(libkb.NewLoadUserForceArg(e.G()))
+	if err != nil {
+		return err
+	}
+
+	kp, err := findDeviceKeys(ctx, e, me)
+	if err == nil {
+		// Device keys are unlocked. Just log in with them.
+		e.G().Log.Debug("Logging in with unlocked device key")
+		err = e.G().LoginState().LoginWithKey(ctx.LoginContext, me, kp.sigKey, nil)
+		return err
+	}
+
+	// Prompts for a paper key.
+	e.G().Log.Debug("No device keys available; getting paper key")
+	kp, err = findPaperKeys(ctx, e.G(), me)
+	if err != nil {
+		return err
+	}
+
+	e.G().Log.Debug("Logging in")
+	err = e.G().LoginState().LoginWithKey(ctx.LoginContext, me, kp.sigKey, func(lctx libkb.LoginContext) error {
+		// Now we're logged in.
+		e.G().Log.Debug("Logged in")
+		ctx.LoginContext = lctx
+
+		// Get the LKS client half.
+		gen, clientLKS, err := fetchLKS(ctx, e.G(), kp.encKey)
+		if err != nil {
+			return err
+		}
+		lks := libkb.NewLKSecWithClientHalf(clientLKS, gen, me.GetUID(), e.G())
+		e.G().Log.Debug("Got LKS client half")
+
+		// Get the LKS server half.
+		err = lks.Load(lctx)
+		if err != nil {
+			return err
+		}
+		e.G().Log.Debug("Got LKS full")
+
+		secretStore := libkb.NewSecretStore(e.G(), me.GetNormalizedName())
+		e.G().Log.Debug("Got secret store")
+
+		// Extract the LKS secret
+		secret, err := lks.GetSecret(lctx)
+		if err != nil {
+			return err
+		}
+		e.G().Log.Debug("Got LKS secret")
+
+		err = secretStore.StoreSecret(secret)
+		if err != nil {
+			return err
+		}
+		e.G().Log.Debug("Stored secret with LKS from paperky")
+
+		// This could prompt but shouldn't because of the secret store.
+		err = e.unlockDeviceKeys(ctx, me)
+		if err != nil {
+			return err
+		}
+		e.G().Log.Debug("Unlocked device keys")
+
+		return nil
+	})
+
+	return err
+}
+
+func (e *LoginWithPaperKey) unlockDeviceKeys(ctx *Context, me *libkb.User) error {
+	ska := libkb.SecretKeyArg{
+		Me:      me,
+		KeyType: libkb.DeviceSigningKeyType,
+	}
+	_, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "unlock device keys"))
+	if err != nil {
+		return err
+	}
+	ska.KeyType = libkb.DeviceEncryptionKeyType
+	_, err = e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "unlock device keys"))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go/engine/login_with_paperkey_test.go
+++ b/go/engine/login_with_paperkey_test.go
@@ -1,0 +1,235 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+// Test logging in with paper key when
+// loggedin: true
+// unlocked: true
+// Does not ask for anything.
+func TestLoginWithPaperKeyAlreadyIn(t *testing.T) {
+	tc := SetupEngineTest(t, "loginwithpaperkey")
+	defer tc.Cleanup()
+	_, paperkey := CreateAndSigunpLPK(tc, "login")
+
+	t.Logf("checking logged in status [before]")
+	AssertLoggedInLPK(&tc, true)
+	t.Logf("checking unlocked status [before]")
+	AssertDeviceKeysLock(&tc, true)
+
+	t.Logf("running LoginWithPaperKey")
+	ctx := &Context{
+		LogUI: tc.G.UI.GetLogUI(),
+		SecretUI: &TestSecretUIPaperKey{
+			T:                         t,
+			Paperkey:                  paperkey,
+			AllowedGetPassphraseCalls: 0,
+		},
+	}
+	eng := NewLoginWithPaperKey(tc.G)
+	err := RunEngine(eng, ctx)
+	require.NoError(t, err)
+
+	t.Logf("checking logged in status [after]")
+	AssertLoggedInLPK(&tc, true)
+	t.Logf("checking unlocked status [after]")
+	AssertDeviceKeysLock(&tc, true)
+}
+
+// Test logging in with paper key when
+// loggedin: false
+// unlocked: false
+// Asks for a paperky.
+func TestLoginWithPaperKeyFromScratch(t *testing.T) {
+	tc := SetupEngineTest(t, "loginwithpaperkey")
+	defer tc.Cleanup()
+	_, paperkey := CreateAndSigunpLPK(tc, "login")
+
+	t.Logf("logging out")
+	Logout(tc)
+
+	t.Logf("checking logged in status [before]")
+	AssertLoggedInLPK(&tc, false)
+	t.Logf("checking unlocked status [before]")
+	AssertDeviceKeysLock(&tc, false)
+
+	t.Logf("running LoginWithPaperKey")
+	ctx := &Context{
+		LogUI: tc.G.UI.GetLogUI(),
+		SecretUI: &TestSecretUIPaperKey{
+			T:                         t,
+			Paperkey:                  paperkey,
+			AllowedGetPassphraseCalls: 1,
+		},
+	}
+	eng := NewLoginWithPaperKey(tc.G)
+	err := RunEngine(eng, ctx)
+	require.NoError(t, err)
+
+	t.Logf("checking logged in status [after]")
+	AssertLoggedInLPK(&tc, true)
+	t.Logf("checking unlocked status [after]")
+	AssertDeviceKeysLock(&tc, true)
+}
+
+// Test logging in with paper key when
+// loggedin: false
+// unlocked: true
+// Does not ask for anything.
+func TestLoginWithPaperKeyLoggedOutAndUnlocked(t *testing.T) {
+	tc := SetupEngineTest(t, "loginwithpaperkey")
+	defer tc.Cleanup()
+	_, paperkey := CreateAndSigunpLPK(tc, "login")
+
+	t.Logf("logging out")
+	err := tc.G.LoginState().LocalSession(func(sess *libkb.Session) {
+		sess.Invalidate()
+	}, "test")
+	require.NoError(t, err)
+
+	t.Logf("checking logged in status [before]")
+	AssertLoggedInLPK(&tc, false)
+	t.Logf("checking unlocked status [before]")
+	AssertDeviceKeysLock(&tc, true)
+
+	t.Logf("running LoginWithPaperKey")
+	ctx := &Context{
+		LogUI: tc.G.UI.GetLogUI(),
+		SecretUI: &TestSecretUIPaperKey{
+			T:                         t,
+			Paperkey:                  paperkey,
+			AllowedGetPassphraseCalls: 1,
+		},
+	}
+	eng := NewLoginWithPaperKey(tc.G)
+	err = RunEngine(eng, ctx)
+	require.NoError(t, err)
+
+	t.Logf("checking logged in status [after]")
+	AssertLoggedInLPK(&tc, true)
+	t.Logf("checking unlocked status [after]")
+	AssertDeviceKeysLock(&tc, true)
+}
+
+// Test logging in with paper key when
+// loggedin: true
+// unlocked: false
+// Asks for a paperkey.
+func TestLoginWithPaperKeyLoggedInAndLocked(t *testing.T) {
+	tc := SetupEngineTest(t, "loginwithpaperkey")
+	defer tc.Cleanup()
+	u, paperkey := CreateAndSigunpLPK(tc, "login")
+
+	t.Logf("locking keys")
+	err := tc.G.LoginState().Account(func(a *libkb.Account) {
+		a.ClearCachedSecretKeys()
+	}, "test")
+	require.NoError(t, err)
+	err = tc.G.SecretStoreAll.ClearSecret(libkb.NormalizedUsername(u.Username))
+	require.NoError(t, err)
+
+	t.Logf("checking logged in status [before]")
+	AssertLoggedInLPK(&tc, true)
+	t.Logf("checking unlocked status [before]")
+	AssertDeviceKeysLock(&tc, false)
+
+	t.Logf("running LoginWithPaperKey")
+	ctx := &Context{
+		LogUI: tc.G.UI.GetLogUI(),
+		SecretUI: &TestSecretUIPaperKey{
+			T:                         t,
+			Paperkey:                  paperkey,
+			AllowedGetPassphraseCalls: 1,
+		},
+	}
+	eng := NewLoginWithPaperKey(tc.G)
+	err = RunEngine(eng, ctx)
+	require.NoError(t, err)
+
+	t.Logf("checking logged in status [after]")
+	AssertLoggedInLPK(&tc, true)
+	t.Logf("checking unlocked status [after]")
+	AssertDeviceKeysLock(&tc, true)
+}
+
+// Returns the user and paper key.
+func CreateAndSigunpLPK(tc libkb.TestContext, prefix string) (*FakeUser, string) {
+	u := CreateAndSignupFakeUser(tc, prefix)
+
+	ctx := &Context{
+		LogUI:    tc.G.UI.GetLogUI(),
+		LoginUI:  &libkb.TestLoginUI{},
+		SecretUI: &libkb.TestSecretUI{},
+	}
+	beng := NewPaperKey(tc.G)
+	if err := RunEngine(beng, ctx); err != nil {
+		tc.T.Fatal(err)
+	}
+
+	backupPassphrase := beng.Passphrase()
+
+	return u, backupPassphrase
+}
+
+func AssertLoggedInLPK(tc *libkb.TestContext, shouldBeLoggedIn bool) {
+	sessionIsValid, err := tc.G.LoginState().LoggedInProvisionedLoad()
+	t := tc.T
+	require.NoError(t, err)
+	if shouldBeLoggedIn {
+		require.Equal(t, true, sessionIsValid, "user should be logged in")
+	} else {
+		require.Equal(t, false, sessionIsValid, "user should not be logged in")
+	}
+}
+
+func AssertDeviceKeysLock(tc *libkb.TestContext, shouldBeUnlocked bool) {
+	var err error
+	var err2 error
+	t := tc.T
+
+	err = tc.G.LoginState().Account(func(a *libkb.Account) {
+		_, err2 = a.CachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType})
+	}, "test")
+	require.NoError(t, err)
+	if shouldBeUnlocked {
+		require.NoError(t, err2, "device signing key should be available")
+	} else {
+		require.Error(t, err2, "device signing key should be unavailable")
+	}
+
+	err = tc.G.LoginState().Account(func(a *libkb.Account) {
+		_, err2 = a.CachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceEncryptionKeyType})
+	}, "test")
+	require.NoError(t, err)
+	if shouldBeUnlocked {
+		require.NoError(t, err2, "device encryption key should be available")
+	} else {
+		require.Error(t, err2, "device encryption key should be unavailable")
+	}
+}
+
+type TestSecretUIPaperKey struct {
+	T                         *testing.T
+	Paperkey                  string
+	AllowedGetPassphraseCalls int
+	nGetPassphraseCalls       int
+}
+
+func (t *TestSecretUIPaperKey) GetPassphrase(p keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
+	require.Equal(t.T, keybase1.PassphraseType_PAPER_KEY, p.Type, "TestSecretUIPaperKey prompted for non-paperkey")
+	t.nGetPassphraseCalls++
+	require.True(t.T, t.nGetPassphraseCalls <= t.AllowedGetPassphraseCalls, "GetPassphrase called too many times on paperkey")
+	return keybase1.GetPassphraseRes{
+		Passphrase: t.Paperkey,
+		// What's this?
+		StoreSecret: false,
+	}, nil
+}

--- a/go/engine/passphrase_change.go
+++ b/go/engine/passphrase_change.go
@@ -48,6 +48,7 @@ func (c *PassphraseChange) Prereqs() Prereqs {
 // RequiredUIs returns the required UIs.
 func (c *PassphraseChange) RequiredUIs() []libkb.UIKind {
 	return []libkb.UIKind{
+		libkb.LogUIKind,
 		libkb.SecretUIKind,
 	}
 }
@@ -94,40 +95,7 @@ func (c *PassphraseChange) Run(ctx *Context) (err error) {
 
 // findDeviceKeys looks for device keys and unlocks them.
 func (c *PassphraseChange) findDeviceKeys(ctx *Context) (*keypair, error) {
-	// need to be logged in to get a device key (unlocked)
-	lin, _, err := IsLoggedIn(c, ctx)
-	if err != nil {
-		return nil, err
-	}
-	if !lin {
-		return nil, libkb.LoginRequiredError{}
-	}
-
-	// Get unlocked device for decryption and signing
-	// passing in nil SecretUI since we don't know the passphrase.
-	c.G().Log.Debug("runForcedUpdate: getting device encryption key")
-	parg := libkb.SecretKeyPromptArg{
-		LoginContext: ctx.LoginContext,
-		Ska: libkb.SecretKeyArg{
-			Me:      c.me,
-			KeyType: libkb.DeviceEncryptionKeyType,
-		},
-		Reason: "change passphrase",
-	}
-	encKey, err := c.G().Keyrings.GetSecretKeyWithPrompt(parg)
-	if err != nil {
-		return nil, err
-	}
-	c.G().Log.Debug("runForcedUpdate: got device encryption key")
-	c.G().Log.Debug("runForcedUpdate: getting device signing key")
-	parg.Ska.KeyType = libkb.DeviceSigningKeyType
-	sigKey, err := c.G().Keyrings.GetSecretKeyWithPrompt(parg)
-	if err != nil {
-		return nil, err
-	}
-	c.G().Log.Debug("runForcedUpdate: got device signing key")
-
-	return &keypair{encKey: encKey, sigKey: sigKey}, nil
+	return findDeviceKeys(ctx, c, c.me)
 }
 
 // findPaperKeys checks if the user has paper keys.  If he/she

--- a/go/engine/passphrase_change.go
+++ b/go/engine/passphrase_change.go
@@ -48,7 +48,6 @@ func (c *PassphraseChange) Prereqs() Prereqs {
 // RequiredUIs returns the required UIs.
 func (c *PassphraseChange) RequiredUIs() []libkb.UIKind {
 	return []libkb.UIKind{
-		libkb.LogUIKind,
 		libkb.SecretUIKind,
 	}
 }

--- a/go/pinentry/pinentry.go
+++ b/go/pinentry/pinentry.go
@@ -207,7 +207,7 @@ func (pi *pinentryInstance) Run(arg keybase1.SecretEntryArg) (res *keybase1.Secr
 	switch {
 	case strings.HasPrefix(line, "D "):
 		res = &keybase1.SecretEntryRes{Text: resDecode(line[2:])}
-	case strings.HasPrefix(line, "ERR 83886179 canceled"):
+	case strings.HasPrefix(line, "ERR 83886179 canceled") || strings.HasPrefix(line, "ERR 83886179 Operation cancelled"):
 		res = &keybase1.SecretEntryRes{Canceled: true}
 	case line == "OK":
 		res = &keybase1.SecretEntryRes{}

--- a/go/protocol/keybase1/login.go
+++ b/go/protocol/keybase1/login.go
@@ -24,6 +24,10 @@ type LoginArg struct {
 	ClientType      ClientType `codec:"clientType" json:"clientType"`
 }
 
+type LoginWithPaperKeyArg struct {
+	SessionID int `codec:"sessionID" json:"sessionID"`
+}
+
 type ClearStoredSecretArg struct {
 	SessionID int    `codec:"sessionID" json:"sessionID"`
 	Username  string `codec:"username" json:"username"`
@@ -86,6 +90,10 @@ type LoginInterface interface {
 	// will be attempted.  If the device is already provisioned, login
 	// via email address does not work.
 	Login(context.Context, LoginArg) error
+	// Login and unlock by
+	// - trying unlocked device keys if available
+	// - prompting for a paper key and using that
+	LoginWithPaperKey(context.Context, int) error
 	// Removes any existing stored secret for the given username.
 	// loginWithStoredSecret(_, username) will fail after this is called.
 	ClearStoredSecret(context.Context, ClearStoredSecretArg) error
@@ -140,6 +148,22 @@ func LoginProtocol(i LoginInterface) rpc.Protocol {
 						return
 					}
 					err = i.Login(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"loginWithPaperKey": {
+				MakeArg: func() interface{} {
+					ret := make([]LoginWithPaperKeyArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]LoginWithPaperKeyArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]LoginWithPaperKeyArg)(nil), args)
+						return
+					}
+					err = i.LoginWithPaperKey(ctx, (*typedArgs)[0].SessionID)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -331,6 +355,15 @@ func (c LoginClient) GetConfiguredAccounts(ctx context.Context, sessionID int) (
 // via email address does not work.
 func (c LoginClient) Login(ctx context.Context, __arg LoginArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.login.login", []interface{}{__arg}, nil)
+	return
+}
+
+// Login and unlock by
+// - trying unlocked device keys if available
+// - prompting for a paper key and using that
+func (c LoginClient) LoginWithPaperKey(ctx context.Context, sessionID int) (err error) {
+	__arg := LoginWithPaperKeyArg{SessionID: sessionID}
+	err = c.Cli.Call(ctx, "keybase.1.login.loginWithPaperKey", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -120,6 +120,17 @@ func (h *LoginHandler) Login(ctx context.Context, arg keybase1.LoginArg) error {
 	return engine.RunEngine(eng, ectx)
 }
 
+func (h *LoginHandler) LoginWithPaperKey(ctx context.Context, sessionID int) error {
+	ectx := &engine.Context{
+		LogUI:      h.getLogUI(sessionID),
+		SecretUI:   h.getSecretUI(sessionID, h.G()),
+		NetContext: ctx,
+		SessionID:  sessionID,
+	}
+	eng := engine.NewLoginWithPaperKey(h.G())
+	return engine.RunEngine(eng, ectx)
+}
+
 func (h *LoginHandler) PGPProvision(ctx context.Context, arg keybase1.PGPProvisionArg) error {
 	if h.G().Env.GetRunMode() == libkb.ProductionRunMode {
 		return errors.New("PGPProvision is a devel-only RPC")

--- a/protocol/avdl/keybase1/login.avdl
+++ b/protocol/avdl/keybase1/login.avdl
@@ -29,6 +29,13 @@ protocol login {
   void login(int sessionID, string deviceType, string usernameOrEmail, ClientType clientType);
 
   /**
+    Login and unlock by
+	- trying unlocked device keys if available
+	- prompting for a paper key and using that
+    */
+  void loginWithPaperKey(int sessionID);
+
+  /**
     Removes any existing stored secret for the given username.
     loginWithStoredSecret(_, username) will fail after this is called.
     */

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1490,6 +1490,18 @@ export function loginLoginRpcPromise (request: $Exact<requestCommon & requestErr
   return new Promise((resolve, reject) => { loginLoginRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function loginLoginWithPaperKeyRpc (request: Exact<requestCommon & requestErrorCallback>) {
+  engineRpcOutgoing({...request, method: 'keybase.1.login.loginWithPaperKey'})
+}
+
+export function loginLoginWithPaperKeyRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => loginLoginWithPaperKeyRpc({...request, incomingCallMap, callback}))
+}
+
+export function loginLoginWithPaperKeyRpcPromise (request: $Exact<requestCommon & requestErrorCallback>): Promise<any> {
+  return new Promise((resolve, reject) => { loginLoginWithPaperKeyRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function loginLogoutRpc (request: Exact<requestCommon & requestErrorCallback>) {
   engineRpcOutgoing({...request, method: 'keybase.1.login.logout'})
 }
@@ -5552,6 +5564,7 @@ export type rpc =
   | loginDeprovisionRpc
   | loginGetConfiguredAccountsRpc
   | loginLoginRpc
+  | loginLoginWithPaperKeyRpc
   | loginLogoutRpc
   | loginPaperKeyRpc
   | loginPaperKeySubmitRpc

--- a/protocol/json/keybase1/login.json
+++ b/protocol/json/keybase1/login.json
@@ -58,6 +58,16 @@
       "response": null,
       "doc": "Performs login.  deviceType should be libkb.DeviceTypeDesktop\n    or libkb.DeviceTypeMobile.  usernameOrEmail is optional.\n    If the current device isn't provisioned, this function will\n    provision it.\n\n    Note that if usernameOrEmail is an email address, only provisioning\n    will be attempted.  If the device is already provisioned, login\n    via email address does not work."
     },
+    "loginWithPaperKey": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        }
+      ],
+      "response": null,
+      "doc": "Login and unlock by\n\t- trying unlocked device keys if available\n\t- prompting for a paper key and using that"
+    },
     "clearStoredSecret": {
       "request": [
         {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1490,6 +1490,18 @@ export function loginLoginRpcPromise (request: $Exact<requestCommon & requestErr
   return new Promise((resolve, reject) => { loginLoginRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function loginLoginWithPaperKeyRpc (request: Exact<requestCommon & requestErrorCallback>) {
+  engineRpcOutgoing({...request, method: 'keybase.1.login.loginWithPaperKey'})
+}
+
+export function loginLoginWithPaperKeyRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => loginLoginWithPaperKeyRpc({...request, incomingCallMap, callback}))
+}
+
+export function loginLoginWithPaperKeyRpcPromise (request: $Exact<requestCommon & requestErrorCallback>): Promise<any> {
+  return new Promise((resolve, reject) => { loginLoginWithPaperKeyRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function loginLogoutRpc (request: Exact<requestCommon & requestErrorCallback>) {
   engineRpcOutgoing({...request, method: 'keybase.1.login.logout'})
 }
@@ -5552,6 +5564,7 @@ export type rpc =
   | loginDeprovisionRpc
   | loginGetConfiguredAccountsRpc
   | loginLoginRpc
+  | loginLoginWithPaperKeyRpc
   | loginLogoutRpc
   | loginPaperKeyRpc
   | loginPaperKeySubmitRpc


### PR DESCRIPTION
You couldn't passphrase recover with a paper key because of an earlier bungle. This should make the `keybase passphrase recover` experience ideal.

This PR adds a `LoginWithPaperKey` engine that makes sure a user is logged in and has unlocked keys. It will do this silently if possible, or ask for a paperkey if need be. It will not ask for a passphrase.

The existing recover engine is left almost untouched. It now has lots of code paths that probably won't be triggered (like asking for a paper key). The recover command is what really changed. The reason for adding the new engine and putting more logic in the command is that lots of user interaction like prompting for a new passphrase seemed easiest to do from the command (client). Also because the GUI uses that engine, so it shouldn't do weird prompts and checks that only make sense for CLI.

Here's a flow chart of how I think the experience should go. Please excuse my handwriting :)
![scannable document on jan 20 2017 5_19_23 pm](https://cloud.githubusercontent.com/assets/705646/22167475/a3326e88-df34-11e6-8a99-7a08ce267890.png)

Also I noticed that the `login` command has a bunch of machinery for cancellation, but `paperkey` doesn't. Is it necessary for `recover`?

r? @patrickxb @maxtaco 