### PR TITLE
Retain pending messages when clearing threads

### DIFF
--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -80,6 +80,7 @@ function reducer (state: State = initialState, action: Actions) {
         console.warn('Attempted to clear conversation state that doesn\'t exist')
         return
       }
+      // $FlowIssue
       const clearedConversationState = initialConversation.merge({
         firstNewMessageID: origConversationState.get('firstNewMessageID'),
         messages: origConversationState.get('messages').filter(m => m.messageState === 'pending'),

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -80,7 +80,10 @@ function reducer (state: State = initialState, action: Actions) {
         console.warn('Attempted to clear conversation state that doesn\'t exist')
         return
       }
-      const clearedConversationState = initialConversation.set('firstNewMessageID', origConversationState.get('firstNewMessageID'))
+      const clearedConversationState = initialConversation.merge({
+        firstNewMessageID: origConversationState.get('firstNewMessageID'),
+        messages: origConversationState.get('messages').filter(m => m.messageState === 'pending'),
+      })
       // $FlowIssue
       return state.update('conversationStates', conversationStates =>
         conversationStates.set(conversationIDKey, clearedConversationState)


### PR DESCRIPTION
This should hopefully fix a bug where thread messages get cleared while
sending a message, causing a pending message to disappear.

Looks like I introduced this bug when I implemented the stale thread reloading :tada: 

:eyeglasses: @keybase/react-hackers