### PR TITLE
Focus chat entry to handle global unhandled keypresses

### DIFF
--- a/shared/chat/conversation/input.desktop.js
+++ b/shared/chat/conversation/input.desktop.js
@@ -53,12 +53,13 @@ class Conversation extends Component<void, Props, State> {
     }
   }
 
-  _handleGlobalKeyPress (ev) {
+  _handleGlobalKeyPress (ev: Event) {
     if (!this._input) {
       return
     }
 
-    if (ev.target.tagName === 'INPUT' || ev.target.tagName === 'TEXTAREA') {
+    const target = ev.target
+    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
       return
     }
 

--- a/shared/chat/conversation/input.desktop.js
+++ b/shared/chat/conversation/input.desktop.js
@@ -17,6 +17,7 @@ const _cachedInput: {[key: ?string]: ?string} = { }
 class Conversation extends Component<void, Props, State> {
   _input: any;
   _fileInput: any;
+  _globalKeyDownHandler: (ev: Event) => void;
   state: State;
 
   _setRef = r => {
@@ -27,6 +28,15 @@ class Conversation extends Component<void, Props, State> {
     super(props)
     const {emojiPickerOpen} = props
     this.state = {emojiPickerOpen, text: _cachedInput[props.selectedConversation] || ''}
+    this._globalKeyDownHandler = ev => this._handleGlobalKeyPress(ev)
+  }
+
+  componentDidMount () {
+    document.body.addEventListener('keydown', this._globalKeyDownHandler)
+  }
+
+  componentWillUnmount () {
+    document.body.removeEventListener('keydown', this._globalKeyDownHandler)
   }
 
   componentWillReceiveProps (nextProps: Props) {
@@ -41,6 +51,18 @@ class Conversation extends Component<void, Props, State> {
     if (!this.props.isLoading && prevProps.isLoading) {
       this.focusInput()
     }
+  }
+
+  _handleGlobalKeyPress (ev) {
+    if (!this._input) {
+      return
+    }
+
+    if (ev.target.tagName === 'INPUT' || ev.target.tagName === 'TEXTAREA') {
+      return
+    }
+
+    this._input.focus()
   }
 
   _insertEmoji (emojiColons: string) {

--- a/shared/chat/conversation/input.desktop.js
+++ b/shared/chat/conversation/input.desktop.js
@@ -52,7 +52,7 @@ class Conversation extends Component<void, Props, State> {
     }
   }
 
-  _handleGlobalKeyPress (ev: Event) {
+  _globalKeyDownHandler = (ev: Event) => {
     if (!this._input) {
       return
     }
@@ -64,7 +64,6 @@ class Conversation extends Component<void, Props, State> {
 
     this._input.focus()
   }
-  _globalKeyDownHandler = (ev: Event) => this._handleGlobalKeyPress(ev)
 
   _insertEmoji (emojiColons: string) {
     const text: string = this.state.text || ''

--- a/shared/chat/conversation/input.desktop.js
+++ b/shared/chat/conversation/input.desktop.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-env browser */
 import React, {Component} from 'react'
 import {Box, Icon, Input, Text} from '../../common-adapters'
 import {globalColors, globalMargins, globalStyles} from '../../styles'

--- a/shared/chat/conversation/input.desktop.js
+++ b/shared/chat/conversation/input.desktop.js
@@ -17,7 +17,6 @@ const _cachedInput: {[key: ?string]: ?string} = { }
 class Conversation extends Component<void, Props, State> {
   _input: any;
   _fileInput: any;
-  _globalKeyDownHandler: (ev: Event) => void;
   state: State;
 
   _setRef = r => {
@@ -28,7 +27,6 @@ class Conversation extends Component<void, Props, State> {
     super(props)
     const {emojiPickerOpen} = props
     this.state = {emojiPickerOpen, text: _cachedInput[props.selectedConversation] || ''}
-    this._globalKeyDownHandler = ev => this._handleGlobalKeyPress(ev)
   }
 
   componentDidMount () {
@@ -65,6 +63,7 @@ class Conversation extends Component<void, Props, State> {
 
     this._input.focus()
   }
+  _globalKeyDownHandler = (ev: Event) => this._handleGlobalKeyPress(ev)
 
   _insertEmoji (emojiColons: string) {
     const text: string = this.state.text || ''


### PR DESCRIPTION
I thought we'd need to manually add the characters to the input value,
but just focusing seems to do the trick. Perhaps React is handling the
input keypresses itself.

:eyeglasses: @keybase/react-hackers 