### PR TITLE
ability to read public chats user is not in CORE-4372

### DIFF
--- a/go/client/chat_cli_fetchers.go
+++ b/go/client/chat_cli_fetchers.go
@@ -34,7 +34,7 @@ func (f chatCLIConversationFetcher) fetch(ctx context.Context, g *libkb.GlobalCo
 
 	hasTTY := isatty.IsTerminal(os.Stdout.Fd())
 
-	conversationInfo, _, err := resolver.Resolve(ctx, f.resolvingRequest, chatConversationResolvingBehavior{
+	conversation, _, err := resolver.Resolve(ctx, f.resolvingRequest, chatConversationResolvingBehavior{
 		CreateIfNotExists: false,
 		Interactive:       hasTTY,
 		IdentifyBehavior:  keybase1.TLFIdentifyBehavior_CHAT_CLI,
@@ -42,13 +42,13 @@ func (f chatCLIConversationFetcher) fetch(ctx context.Context, g *libkb.GlobalCo
 	if err != nil {
 		return chat1.ConversationLocal{}, nil, fmt.Errorf("resolving conversation error: %v\n", err)
 	}
-	if conversationInfo == nil {
+	if conversation == nil {
 		return chat1.ConversationLocal{}, nil, nil
 	}
-	f.query.ConversationId = conversationInfo.Id
+	f.query.Conv = *conversation
 
-	if conversationInfo.Id == nil || len(conversationInfo.Id) == 0 {
-		return chat1.ConversationLocal{}, nil, fmt.Errorf("empty conversationInfo.Id: %+v", conversationInfo)
+	if conversation.Info.Id == nil || len(conversation.Info.Id) == 0 {
+		return chat1.ConversationLocal{}, nil, fmt.Errorf("empty conversationInfo.Id: %+v", conversation.Info)
 	}
 
 	gcfclres, err := chatClient.GetConversationForCLILocal(ctx, f.query)

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -756,7 +756,6 @@ func (c *chatServiceHandler) getExistingConvs(ctx context.Context, id chat1.Conv
 		return gilres.Conversations, gilres.RateLimits, nil
 	}
 
-	// canonicalize the tlf name (no visibility necessary?)
 	tlfClient, err := GetTlfClient(c.G())
 	if err != nil {
 		return nil, nil, err

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -864,8 +864,12 @@ func (c *chatServiceHandler) findConversation(ctx context.Context, convIDStr str
 	if err != nil {
 		return conv, rlimits, err
 	}
-	gilres, err := client.GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
-		Query: &query,
+	gilres, err := client.FindConversationsLocal(ctx, chat1.FindConversationsLocalArg{
+		TlfName:          *query.TlfName,
+		Visibility:       query.Visibility(),
+		TopicType:        *query.TopicType,
+		TopicName:        *query.TopicName,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	})
 	if err != nil {
 		return conv, rlimits, err

--- a/go/client/cmd_chat_hide.go
+++ b/go/client/cmd_chat_hide.go
@@ -78,7 +78,7 @@ func (c *CmdChatHide) Run() error {
 		return err
 	}
 
-	conversationInfo, _, err := resolver.Resolve(ctx, c.resolvingRequest, chatConversationResolvingBehavior{
+	conversation, _, err := resolver.Resolve(ctx, c.resolvingRequest, chatConversationResolvingBehavior{
 		CreateIfNotExists: false,
 		Interactive:       false,
 		IdentifyBehavior:  keybase1.TLFIdentifyBehavior_CHAT_CLI,
@@ -88,7 +88,7 @@ func (c *CmdChatHide) Run() error {
 	}
 
 	setStatusArg := chat1.SetConversationStatusLocalArg{
-		ConversationID: conversationInfo.Id,
+		ConversationID: conversation.Info.Id,
 		Status:         c.status,
 	}
 

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -58,7 +58,7 @@ func (c *cmdChatSend) Run() (err error) {
 	}
 
 	ctx := context.TODO()
-	conversationInfo, userChosen, err := resolver.Resolve(ctx, c.resolvingRequest, chatConversationResolvingBehavior{
+	conversation, userChosen, err := resolver.Resolve(ctx, c.resolvingRequest, chatConversationResolvingBehavior{
 		CreateIfNotExists: true,
 		Interactive:       c.hasTTY,
 		IdentifyBehavior:  keybase1.TLFIdentifyBehavior_CHAT_CLI,
@@ -66,6 +66,7 @@ func (c *cmdChatSend) Run() (err error) {
 	if err != nil {
 		return err
 	}
+	conversationInfo := conversation.Info
 
 	var args chat1.PostLocalArg
 	args.ConversationID = conversationInfo.Id
@@ -75,6 +76,7 @@ func (c *cmdChatSend) Run() (err error) {
 	// msgV1.ClientHeader.{Sender,SenderDevice} are filled by service
 	msg.ClientHeader.Conv = conversationInfo.Triple
 	msg.ClientHeader.TlfName = conversationInfo.TlfName
+	msg.ClientHeader.TlfPublic = (conversationInfo.Visibility == chat1.TLFVisibility_PUBLIC)
 
 	// Whether the user is really sure they want to send to the selected conversation.
 	// We require an additional confirmation if the choose menu was used.

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -503,7 +503,6 @@ func (n *NotifyRouter) HandleNewChatActivity(ctx context.Context, uid keybase1.U
 }
 
 func (n *NotifyRouter) HandleChatIdentifyUpdate(ctx context.Context, update keybase1.CanonicalTLFNameAndIDWithBreaks) {
-	n.G().Log.Debug("WTFWTFWTF")
 	if n == nil {
 		return
 	}
@@ -523,7 +522,6 @@ func (n *NotifyRouter) HandleChatIdentifyUpdate(ctx context.Context, update keyb
 	})
 	wg.Wait()
 	if n.listener != nil {
-		n.G().Log.Debug("SENDING THIS STUPID UPDATE")
 		n.listener.ChatIdentifyUpdate(update)
 	}
 	n.G().Log.Debug("- Sent ChatIdentifyUpdate notification")

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -832,11 +832,11 @@ type GetInboxSummaryForCLILocalRes struct {
 }
 
 type GetConversationForCLILocalQuery struct {
-	MarkAsRead     bool                `codec:"markAsRead" json:"markAsRead"`
-	MessageTypes   []MessageType       `codec:"MessageTypes" json:"MessageTypes"`
-	Since          *string             `codec:"Since,omitempty" json:"Since,omitempty"`
-	Limit          UnreadFirstNumLimit `codec:"limit" json:"limit"`
-	ConversationId ConversationID      `codec:"conversationId" json:"conversationId"`
+	MarkAsRead   bool                `codec:"markAsRead" json:"markAsRead"`
+	MessageTypes []MessageType       `codec:"MessageTypes" json:"MessageTypes"`
+	Since        *string             `codec:"Since,omitempty" json:"Since,omitempty"`
+	Limit        UnreadFirstNumLimit `codec:"limit" json:"limit"`
+	Conv         ConversationLocal   `codec:"conv" json:"conv"`
 }
 
 type GetConversationForCLILocalRes struct {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -866,6 +866,12 @@ type DownloadAttachmentLocalRes struct {
 	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identifyFailures"`
 }
 
+type FindConversationsLocalRes struct {
+	Conversations    []ConversationLocal           `codec:"conversations" json:"conversations"`
+	RateLimits       []RateLimit                   `codec:"rateLimits" json:"rateLimits"`
+	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identifyFailures"`
+}
+
 type GetThreadLocalArg struct {
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
 	Query            *GetThreadQuery              `codec:"query,omitempty" json:"query,omitempty"`
@@ -1012,11 +1018,12 @@ type MarkAsReadLocalArg struct {
 	MsgID          MessageID      `codec:"msgID" json:"msgID"`
 }
 
-type FindConversationsArg struct {
-	TlfName    string        `codec:"tlfName" json:"tlfName"`
-	Visibility TLFVisibility `codec:"visibility" json:"visibility"`
-	TopicType  TopicType     `codec:"topicType" json:"topicType"`
-	TopicName  string        `codec:"topicName" json:"topicName"`
+type FindConversationsLocalArg struct {
+	TlfName          string                       `codec:"tlfName" json:"tlfName"`
+	Visibility       TLFVisibility                `codec:"visibility" json:"visibility"`
+	TopicType        TopicType                    `codec:"topicType" json:"topicType"`
+	TopicName        string                       `codec:"topicName" json:"topicName"`
+	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 type LocalInterface interface {
@@ -1040,7 +1047,7 @@ type LocalInterface interface {
 	CancelPost(context.Context, OutboxID) error
 	RetryPost(context.Context, OutboxID) error
 	MarkAsReadLocal(context.Context, MarkAsReadLocalArg) (MarkAsReadRes, error)
-	FindConversations(context.Context, FindConversationsArg) ([]ConversationLocal, error)
+	FindConversationsLocal(context.Context, FindConversationsLocalArg) (FindConversationsLocalRes, error)
 }
 
 func LocalProtocol(i LocalInterface) rpc.Protocol {
@@ -1367,18 +1374,18 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"findConversations": {
+			"findConversationsLocal": {
 				MakeArg: func() interface{} {
-					ret := make([]FindConversationsArg, 1)
+					ret := make([]FindConversationsLocalArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]FindConversationsArg)
+					typedArgs, ok := args.(*[]FindConversationsLocalArg)
 					if !ok {
-						err = rpc.NewTypeError((*[]FindConversationsArg)(nil), args)
+						err = rpc.NewTypeError((*[]FindConversationsLocalArg)(nil), args)
 						return
 					}
-					ret, err = i.FindConversations(ctx, (*typedArgs)[0])
+					ret, err = i.FindConversationsLocal(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -1495,7 +1502,7 @@ func (c LocalClient) MarkAsReadLocal(ctx context.Context, __arg MarkAsReadLocalA
 	return
 }
 
-func (c LocalClient) FindConversations(ctx context.Context, __arg FindConversationsArg) (res []ConversationLocal, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.findConversations", []interface{}{__arg}, &res)
+func (c LocalClient) FindConversationsLocal(ctx context.Context, __arg FindConversationsLocalArg) (res FindConversationsLocalRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.findConversationsLocal", []interface{}{__arg}, &res)
 	return
 }

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -65,6 +65,11 @@ type SetConversationStatusRes struct {
 	RateLimit *RateLimit `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
+type GetPublicConversationsRes struct {
+	Conversations []Conversation `codec:"conversations" json:"conversations"`
+	RateLimit     *RateLimit     `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+}
+
 type UnreadUpdateFull struct {
 	Ignore    bool           `codec:"ignore" json:"ignore"`
 	InboxVers InboxVers      `codec:"inboxVers" json:"inboxVers"`
@@ -91,6 +96,11 @@ type GetThreadRemoteArg struct {
 	ConversationID ConversationID  `codec:"conversationID" json:"conversationID"`
 	Query          *GetThreadQuery `codec:"query,omitempty" json:"query,omitempty"`
 	Pagination     *Pagination     `codec:"pagination,omitempty" json:"pagination,omitempty"`
+}
+
+type GetPublicConversationsArg struct {
+	TlfID     TLFID     `codec:"tlfID" json:"tlfID"`
+	TopicType TopicType `codec:"topicType" json:"topicType"`
 }
 
 type PostRemoteArg struct {
@@ -156,6 +166,7 @@ type TlfResolveArg struct {
 type RemoteInterface interface {
 	GetInboxRemote(context.Context, GetInboxRemoteArg) (GetInboxRemoteRes, error)
 	GetThreadRemote(context.Context, GetThreadRemoteArg) (GetThreadRemoteRes, error)
+	GetPublicConversations(context.Context, GetPublicConversationsArg) (GetPublicConversationsRes, error)
 	PostRemote(context.Context, PostRemoteArg) (PostRemoteRes, error)
 	NewConversationRemote(context.Context, ConversationIDTriple) (NewConversationRemoteRes, error)
 	NewConversationRemote2(context.Context, NewConversationRemote2Arg) (NewConversationRemoteRes, error)
@@ -202,6 +213,22 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.GetThreadRemote(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"getPublicConversations": {
+				MakeArg: func() interface{} {
+					ret := make([]GetPublicConversationsArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]GetPublicConversationsArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]GetPublicConversationsArg)(nil), args)
+						return
+					}
+					ret, err = i.GetPublicConversations(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -413,6 +440,11 @@ func (c RemoteClient) GetInboxRemote(ctx context.Context, __arg GetInboxRemoteAr
 
 func (c RemoteClient) GetThreadRemote(ctx context.Context, __arg GetThreadRemoteArg) (res GetThreadRemoteRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.getThreadRemote", []interface{}{__arg}, &res)
+	return
+}
+
+func (c RemoteClient) GetPublicConversations(ctx context.Context, __arg GetPublicConversationsArg) (res GetPublicConversationsRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.remote.getPublicConversations", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -481,20 +481,7 @@ func (h *chatLocalHandler) GetConversationForCLILocal(ctx context.Context, arg c
 		arg.Limit.AtMost = int(^uint(0) >> 1) // maximum int
 	}
 
-	ibres, err := h.GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
-		Query: &chat1.GetInboxLocalQuery{
-			ConvID: &arg.ConversationId,
-		},
-		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-	})
-	if err != nil {
-		return chat1.GetConversationForCLILocalRes{}, fmt.Errorf("getting conversation %v error: %v", arg.ConversationId, err)
-	}
-	rlimits = append(rlimits, ibres.RateLimits...)
-	if len(ibres.Conversations) != 1 {
-		return chat1.GetConversationForCLILocalRes{}, fmt.Errorf("unexpected number (%d) of conversation; need 1", len(ibres.Conversations))
-	}
-	convLocal := ibres.Conversations[0]
+	convLocal := arg.Conv
 
 	var since time.Time
 	if arg.Since != nil {
@@ -514,7 +501,7 @@ func (h *chatLocalHandler) GetConversationForCLILocal(ctx context.Context, arg c
 	}
 
 	tv, err := h.GetThreadLocal(ctx, chat1.GetThreadLocalArg{
-		ConversationID:   arg.ConversationId,
+		ConversationID:   convLocal.Info.Id,
 		Query:            &query,
 		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	})

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -1303,3 +1303,87 @@ func (h *chatLocalHandler) deleteAssets(ctx context.Context, conversationID chat
 
 	h.G().Log.Debug("deleted %d assets", len(assets))
 }
+
+func (h *chatLocalHandler) FindConversationsLocal(ctx context.Context,
+	arg chat1.FindConversationsLocalArg) (res chat1.FindConversationsLocalRes, err error) {
+	defer h.Trace(ctx, func() error { return err }, "FindConversationsLocal")()
+
+	if err = h.assertLoggedIn(ctx); err != nil {
+		return res, err
+	}
+	uid := h.G().Env.GetUID()
+
+	var identBreaks []keybase1.TLFIdentifyFailure
+	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
+
+	// First look in the local user inbox
+	query := chat1.GetInboxLocalQuery{
+		TlfName:       &arg.TlfName,
+		TlfVisibility: &arg.Visibility,
+		TopicType:     &arg.TopicType,
+		TopicName:     &arg.TopicName,
+	}
+	inbox, err := h.GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
+		Query:            &query,
+		IdentifyBehavior: arg.IdentifyBehavior,
+	})
+	if err != nil {
+		return res, err
+	}
+	res.RateLimits = append(res.RateLimits, inbox.RateLimits...)
+	res.IdentifyFailures = inbox.IdentifyFailures
+
+	// If we have inbox hits, return those
+	if len(inbox.Conversations) > 0 {
+		h.Debug(ctx, "FindConversation: found conversations in inbox: tlfName: %s num: %d",
+			arg.TlfName, len(inbox.Conversations))
+		res.Conversations = inbox.Conversations
+	} else if arg.Visibility == chat1.TLFVisibility_PUBLIC {
+		h.Debug(ctx, "FindConversation: no conversations found in inbox, trying public chats")
+
+		// If we miss the inbox, and we are looking for a public TLF, let's try and find
+		// any conversation that matches
+		_, tlfInfo, err := chat.GetInboxQueryLocalToRemote(ctx, h.tlf, &query)
+		if err != nil {
+			return res, err
+		}
+
+		// Call into gregor to try and find some public convs
+		pubConvs, err := h.remoteClient().GetPublicConversations(ctx, chat1.GetPublicConversationsArg{
+			TlfID:     tlfInfo.ID,
+			TopicType: arg.TopicType,
+		})
+		if err != nil {
+			return res, err
+		}
+		if pubConvs.RateLimit != nil {
+			res.RateLimits = append(res.RateLimits, *pubConvs.RateLimit)
+		}
+
+		// Localize the convs (if any)
+		if len(pubConvs.Conversations) > 0 {
+			localizer := chat.NewBlockingLocalizer(h.G(), func() keybase1.TlfInterface {
+				return h.tlf
+			})
+			convsLocal, err := localizer.Localize(ctx, uid.ToBytes(), chat1.Inbox{
+				ConvsUnverified: pubConvs.Conversations,
+			})
+			if err != nil {
+				return res, nil
+			}
+
+			// Search for conversations that match the topic name
+			for _, convLocal := range convsLocal {
+				if convLocal.Info.TopicName == arg.TopicName {
+					h.Debug(ctx, "FindConversation: found matching public conv: id: %s topicName: %s",
+						convLocal.GetConvID(), arg.TopicName)
+					res.Conversations = append(res.Conversations, convLocal)
+				}
+			}
+		}
+
+	}
+
+	res.RateLimits = utils.AggRateLimits(res.RateLimits)
+	return res, nil
+}

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -69,6 +69,8 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	}
 	h := newChatLocalHandler(nil, tc.G, nil)
 	mockRemote := kbtest.NewChatRemoteMock(c.world)
+	mockRemote.SetCurrentUser(user.User.GetUID().ToBytes())
+
 	h.tlf = kbtest.NewTlfMock(c.world)
 	h.boxer = chat.NewBoxer(tc.G, h.tlf)
 	f := func() libkb.SecretUI {
@@ -109,18 +111,26 @@ func (c *chatTestContext) users() (users []*kbtest.FakeUser) {
 	return users
 }
 
-func mustCreateConversationForTest(t *testing.T, ctc *chatTestContext, creator *kbtest.FakeUser, topicType chat1.TopicType, others ...string) (created chat1.ConversationInfoLocal) {
-	created = mustCreateConversationForTestNoAdvanceClock(t, ctc, creator, topicType, others...)
+func mustCreatePublicConversationForTest(t *testing.T, ctc *chatTestContext, creator *kbtest.FakeUser, topicType chat1.TopicType, others ...string) (created chat1.ConversationInfoLocal) {
+	created = mustCreateConversationForTestNoAdvanceClock(t, ctc, creator, topicType,
+		chat1.TLFVisibility_PUBLIC, others...)
 	ctc.advanceFakeClock(time.Second)
 	return created
 }
 
-func mustCreateConversationForTestNoAdvanceClock(t *testing.T, ctc *chatTestContext, creator *kbtest.FakeUser, topicType chat1.TopicType, others ...string) (created chat1.ConversationInfoLocal) {
+func mustCreateConversationForTest(t *testing.T, ctc *chatTestContext, creator *kbtest.FakeUser, topicType chat1.TopicType, others ...string) (created chat1.ConversationInfoLocal) {
+	created = mustCreateConversationForTestNoAdvanceClock(t, ctc, creator, topicType,
+		chat1.TLFVisibility_PRIVATE, others...)
+	ctc.advanceFakeClock(time.Second)
+	return created
+}
+
+func mustCreateConversationForTestNoAdvanceClock(t *testing.T, ctc *chatTestContext, creator *kbtest.FakeUser, topicType chat1.TopicType, visibility chat1.TLFVisibility, others ...string) (created chat1.ConversationInfoLocal) {
 	var err error
 	ncres, err := ctc.as(t, creator).chatLocalHandler().NewConversationLocal(context.Background(), chat1.NewConversationLocalArg{
 		TlfName:       strings.Join(others, ",") + "," + creator.Username,
 		TopicType:     topicType,
-		TlfVisibility: chat1.TLFVisibility_PRIVATE,
+		TlfVisibility: visibility,
 	})
 	if err != nil {
 		t.Fatalf("NewConversationLocal error: %v\n", err)
@@ -930,4 +940,70 @@ func TestPostLocalNonblock(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no event received")
 	}
+}
+
+func TestFindConversations(t *testing.T) {
+	ctc := makeChatTestContext(t, "FindConversations", 3)
+	defer ctc.cleanup()
+	users := ctc.users()
+
+	t.Logf("basic test")
+	created := mustCreatePublicConversationForTest(t, ctc, users[2], chat1.TopicType_CHAT,
+		users[1].Username)
+	convRemote := ctc.world.GetConversationByID(created.Id)
+	require.NotNil(t, convRemote)
+	convRemote.Metadata.Visibility = chat1.TLFVisibility_PUBLIC
+	convRemote.Metadata.ActiveList =
+		[]gregor1.UID{users[2].User.GetUID().ToBytes(), users[1].User.GetUID().ToBytes()}
+
+	res, err := ctc.as(t, users[0]).chatLocalHandler().FindConversationsLocal(context.TODO(),
+		chat1.FindConversationsLocalArg{
+			TlfName:          created.TlfName,
+			Visibility:       chat1.TLFVisibility_PUBLIC,
+			TopicType:        chat1.TopicType_CHAT,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res.Conversations), "no conv found")
+	require.Equal(t, created.Id, res.Conversations[0].GetConvID(), "wrong conv")
+
+	t.Logf("test topic name")
+	_, err = ctc.as(t, users[2]).chatLocalHandler().PostLocal(context.TODO(), chat1.PostLocalArg{
+		ConversationID:   created.Id,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		Msg: chat1.MessagePlaintext{
+			ClientHeader: chat1.MessageClientHeader{
+				Conv:        created.Triple,
+				MessageType: chat1.MessageType_METADATA,
+				TlfName:     created.TlfName,
+				TlfPublic:   true,
+			},
+			MessageBody: chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
+				ConversationTitle: "MIKE",
+			}),
+		},
+	})
+	require.NoError(t, err)
+
+	res, err = ctc.as(t, users[0]).chatLocalHandler().FindConversationsLocal(context.TODO(),
+		chat1.FindConversationsLocalArg{
+			TlfName:          created.TlfName,
+			Visibility:       chat1.TLFVisibility_PUBLIC,
+			TopicType:        chat1.TopicType_CHAT,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		})
+	require.NoError(t, err)
+	require.Equal(t, 0, len(res.Conversations), "conv found")
+
+	res, err = ctc.as(t, users[0]).chatLocalHandler().FindConversationsLocal(context.TODO(),
+		chat1.FindConversationsLocalArg{
+			TlfName:          created.TlfName,
+			Visibility:       chat1.TLFVisibility_PUBLIC,
+			TopicType:        chat1.TopicType_CHAT,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+			TopicName:        "MIKE",
+		})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res.Conversations), "conv found")
+	require.Equal(t, created.Id, res.Conversations[0].GetConvID(), "wrong conv")
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -397,7 +397,7 @@ protocol local {
     UnreadFirstNumLimit limit;
 
     @lint("ignore")
-    ConversationID conversationId;
+    ConversationLocal conv;
   }
   record GetConversationForCLILocalRes {
     ConversationLocal conversation;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -454,4 +454,6 @@ protocol local {
 
   MarkAsReadRes markAsReadLocal(int sessionID, ConversationID conversationID, MessageID msgID);
 
+  array<ConversationLocal> findConversations(string tlfName, TLFVisibility visibility, TopicType topicType, string topicName);
+
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -454,6 +454,13 @@ protocol local {
 
   MarkAsReadRes markAsReadLocal(int sessionID, ConversationID conversationID, MessageID msgID);
 
-  array<ConversationLocal> findConversations(string tlfName, TLFVisibility visibility, TopicType topicType, string topicName);
+  record FindConversationsLocalRes {
+    array<ConversationLocal> conversations;
+
+    array<RateLimit> rateLimits;
+    array<keybase1.TLFIdentifyFailure> identifyFailures;
+  }
+
+  FindConversationsLocalRes findConversationsLocal(string tlfName, TLFVisibility visibility, TopicType topicType, string topicName, keybase1.TLFIdentifyBehavior identifyBehavior);
 
 }

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -66,8 +66,14 @@ protocol remote {
     union { null, RateLimit } rateLimit;
   }
 
+  record GetPublicConversationsRes {
+    array<Conversation> conversations; 
+    union { null, RateLimit } rateLimit;
+  }
+
   GetInboxRemoteRes getInboxRemote(InboxVers vers, union { null, GetInboxQuery } query, union { null, Pagination } pagination);
   GetThreadRemoteRes getThreadRemote(ConversationID conversationID, union { null, GetThreadQuery } query, union { null, Pagination } pagination);
+  GetPublicConversationsRes getPublicConversations(TLFID tlfID, TopicType topicType);
 
   PostRemoteRes postRemote(ConversationID conversationID, MessageBoxed messageBoxed);
   NewConversationRemoteRes newConversationRemote(ConversationIDTriple idTriple);

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -165,16 +165,16 @@ export function localDownloadFileAttachmentLocalRpcPromise (request: $Exact<requ
   return new Promise((resolve, reject) => { localDownloadFileAttachmentLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
-export function localFindConversationsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsResult) => void} & {param: localFindConversationsRpcParam}>) {
-  engineRpcOutgoing({...request, method: 'chat.1.local.findConversations'})
+export function localFindConversationsLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsLocalResult) => void} & {param: localFindConversationsLocalRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.findConversationsLocal'})
 }
 
-export function localFindConversationsRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsResult) => void} & {param: localFindConversationsRpcParam}>): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localFindConversationsRpc({...request, incomingCallMap, callback}))
+export function localFindConversationsLocalRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsLocalResult) => void} & {param: localFindConversationsLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localFindConversationsLocalRpc({...request, incomingCallMap, callback}))
 }
 
-export function localFindConversationsRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsResult) => void} & {param: localFindConversationsRpcParam}>): Promise<localFindConversationsResult> {
-  return new Promise((resolve, reject) => { localFindConversationsRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+export function localFindConversationsLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsLocalResult) => void} & {param: localFindConversationsLocalRpcParam}>): Promise<localFindConversationsLocalResult> {
+  return new Promise((resolve, reject) => { localFindConversationsLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function localGetConversationForCLILocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {param: localGetConversationForCLILocalRpcParam}>) {
@@ -415,6 +415,18 @@ export function remoteGetMessagesRemoteRpcChannelMap (channelConfig: ChannelConf
 
 export function remoteGetMessagesRemoteRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetMessagesRemoteResult) => void} & {param: remoteGetMessagesRemoteRpcParam}>): Promise<remoteGetMessagesRemoteResult> {
   return new Promise((resolve, reject) => { remoteGetMessagesRemoteRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
+export function remoteGetPublicConversationsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetPublicConversationsResult) => void} & {param: remoteGetPublicConversationsRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.remote.getPublicConversations'})
+}
+
+export function remoteGetPublicConversationsRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetPublicConversationsResult) => void} & {param: remoteGetPublicConversationsRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => remoteGetPublicConversationsRpc({...request, incomingCallMap, callback}))
+}
+
+export function remoteGetPublicConversationsRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetPublicConversationsResult) => void} & {param: remoteGetPublicConversationsRpcParam}>): Promise<remoteGetPublicConversationsResult> {
+  return new Promise((resolve, reject) => { remoteGetPublicConversationsRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function remoteGetS3ParamsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetS3ParamsResult) => void} & {param: remoteGetS3ParamsRpcParam}>) {
@@ -704,6 +716,12 @@ export type FailedMessageInfo = {
   outboxRecords?: ?Array<OutboxRecord>,
 }
 
+export type FindConversationsLocalRes = {
+  conversations?: ?Array<ConversationLocal>,
+  rateLimits?: ?Array<RateLimit>,
+  identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
+}
+
 export type GenericPayload = {
   Action: string,
 }
@@ -809,6 +827,11 @@ export type GetMessagesLocalRes = {
 
 export type GetMessagesRemoteRes = {
   msgs?: ?Array<MessageBoxed>,
+  rateLimit?: ?RateLimit,
+}
+
+export type GetPublicConversationsRes = {
+  conversations?: ?Array<Conversation>,
   rateLimit?: ?RateLimit,
 }
 
@@ -1295,11 +1318,12 @@ export type localDownloadFileAttachmentLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
-export type localFindConversationsRpcParam = Exact<{
+export type localFindConversationsLocalRpcParam = Exact<{
   tlfName: string,
   visibility: TLFVisibility,
   topicType: TopicType,
-  topicName: string
+  topicName: string,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetConversationForCLILocalRpcParam = Exact<{
@@ -1437,6 +1461,11 @@ export type remoteGetMessagesRemoteRpcParam = Exact<{
   messageIDs?: ?Array<MessageID>
 }>
 
+export type remoteGetPublicConversationsRpcParam = Exact<{
+  tlfID: TLFID,
+  topicType: TopicType
+}>
+
 export type remoteGetS3ParamsRpcParam = Exact<{
   conversationID: ConversationID
 }>
@@ -1498,7 +1527,7 @@ type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 
 type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
 
-type localFindConversationsResult = ?Array<ConversationLocal>
+type localFindConversationsLocalResult = FindConversationsLocalRes
 
 type localGetConversationForCLILocalResult = GetConversationForCLILocalRes
 
@@ -1538,6 +1567,8 @@ type remoteGetInboxVersionResult = InboxVers
 
 type remoteGetMessagesRemoteResult = GetMessagesRemoteRes
 
+type remoteGetPublicConversationsResult = GetPublicConversationsRes
+
 type remoteGetS3ParamsResult = S3Params
 
 type remoteGetThreadRemoteResult = GetThreadRemoteRes
@@ -1560,7 +1591,7 @@ export type rpc =
     localCancelPostRpc
   | localDownloadAttachmentLocalRpc
   | localDownloadFileAttachmentLocalRpc
-  | localFindConversationsRpc
+  | localFindConversationsLocalRpc
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc
   | localGetInboxNonblockLocalRpc
@@ -1581,6 +1612,7 @@ export type rpc =
   | remoteGetInboxRemoteRpc
   | remoteGetInboxVersionRpc
   | remoteGetMessagesRemoteRpc
+  | remoteGetPublicConversationsRpc
   | remoteGetS3ParamsRpc
   | remoteGetThreadRemoteRpc
   | remoteGetUnreadUpdateFullRpc

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -731,7 +731,7 @@ export type GetConversationForCLILocalQuery = {
   MessageTypes?: ?Array<MessageType>,
   Since?: ?string,
   limit: UnreadFirstNumLimit,
-  conversationId: ConversationID,
+  conv: ConversationLocal,
 }
 
 export type GetConversationForCLILocalRes = {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -165,6 +165,18 @@ export function localDownloadFileAttachmentLocalRpcPromise (request: $Exact<requ
   return new Promise((resolve, reject) => { localDownloadFileAttachmentLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function localFindConversationsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsResult) => void} & {param: localFindConversationsRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.findConversations'})
+}
+
+export function localFindConversationsRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsResult) => void} & {param: localFindConversationsRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localFindConversationsRpc({...request, incomingCallMap, callback}))
+}
+
+export function localFindConversationsRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsResult) => void} & {param: localFindConversationsRpcParam}>): Promise<localFindConversationsResult> {
+  return new Promise((resolve, reject) => { localFindConversationsRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function localGetConversationForCLILocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {param: localGetConversationForCLILocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.getConversationForCLILocal'})
 }
@@ -1283,6 +1295,13 @@ export type localDownloadFileAttachmentLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
+export type localFindConversationsRpcParam = Exact<{
+  tlfName: string,
+  visibility: TLFVisibility,
+  topicType: TopicType,
+  topicName: string
+}>
+
 export type localGetConversationForCLILocalRpcParam = Exact<{
   query: GetConversationForCLILocalQuery
 }>
@@ -1479,6 +1498,8 @@ type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 
 type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
 
+type localFindConversationsResult = ?Array<ConversationLocal>
+
 type localGetConversationForCLILocalResult = GetConversationForCLILocalRes
 
 type localGetInboxAndUnboxLocalResult = GetInboxAndUnboxLocalRes
@@ -1539,6 +1560,7 @@ export type rpc =
     localCancelPostRpc
   | localDownloadAttachmentLocalRpc
   | localDownloadFileAttachmentLocalRpc
+  | localFindConversationsRpc
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc
   | localGetInboxNonblockLocalRpc

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1216,8 +1216,8 @@
           "name": "limit"
         },
         {
-          "type": "ConversationID",
-          "name": "conversationId",
+          "type": "ConversationLocal",
+          "name": "conv",
           "lint": "ignore"
         }
       ]

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1802,6 +1802,30 @@
         }
       ],
       "response": "MarkAsReadRes"
+    },
+    "findConversations": {
+      "request": [
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "visibility",
+          "type": "TLFVisibility"
+        },
+        {
+          "name": "topicType",
+          "type": "TopicType"
+        },
+        {
+          "name": "topicName",
+          "type": "string"
+        }
+      ],
+      "response": {
+        "type": "array",
+        "items": "ConversationLocal"
+      }
     }
   },
   "namespace": "chat.1"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1320,6 +1320,33 @@
           "name": "identifyFailures"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "FindConversationsLocalRes",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "ConversationLocal"
+          },
+          "name": "conversations"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFIdentifyFailure"
+          },
+          "name": "identifyFailures"
+        }
+      ]
     }
   ],
   "messages": {
@@ -1803,7 +1830,7 @@
       ],
       "response": "MarkAsReadRes"
     },
-    "findConversations": {
+    "findConversationsLocal": {
       "request": [
         {
           "name": "tlfName",
@@ -1820,12 +1847,13 @@
         {
           "name": "topicName",
           "type": "string"
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
-      "response": {
-        "type": "array",
-        "items": "ConversationLocal"
-      }
+      "response": "FindConversationsLocalRes"
     }
   },
   "namespace": "chat.1"

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -210,6 +210,26 @@
     },
     {
       "type": "record",
+      "name": "GetPublicConversationsRes",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "Conversation"
+          },
+          "name": "conversations"
+        },
+        {
+          "type": [
+            null,
+            "RateLimit"
+          ],
+          "name": "rateLimit"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "UnreadUpdateFull",
       "fields": [
         {
@@ -310,6 +330,19 @@
         }
       ],
       "response": "GetThreadRemoteRes"
+    },
+    "getPublicConversations": {
+      "request": [
+        {
+          "name": "tlfID",
+          "type": "TLFID"
+        },
+        {
+          "name": "topicType",
+          "type": "TopicType"
+        }
+      ],
+      "response": "GetPublicConversationsRes"
     },
     "postRemote": {
       "request": [

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -165,16 +165,16 @@ export function localDownloadFileAttachmentLocalRpcPromise (request: $Exact<requ
   return new Promise((resolve, reject) => { localDownloadFileAttachmentLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
-export function localFindConversationsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsResult) => void} & {param: localFindConversationsRpcParam}>) {
-  engineRpcOutgoing({...request, method: 'chat.1.local.findConversations'})
+export function localFindConversationsLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsLocalResult) => void} & {param: localFindConversationsLocalRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.findConversationsLocal'})
 }
 
-export function localFindConversationsRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsResult) => void} & {param: localFindConversationsRpcParam}>): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localFindConversationsRpc({...request, incomingCallMap, callback}))
+export function localFindConversationsLocalRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsLocalResult) => void} & {param: localFindConversationsLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localFindConversationsLocalRpc({...request, incomingCallMap, callback}))
 }
 
-export function localFindConversationsRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsResult) => void} & {param: localFindConversationsRpcParam}>): Promise<localFindConversationsResult> {
-  return new Promise((resolve, reject) => { localFindConversationsRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+export function localFindConversationsLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsLocalResult) => void} & {param: localFindConversationsLocalRpcParam}>): Promise<localFindConversationsLocalResult> {
+  return new Promise((resolve, reject) => { localFindConversationsLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function localGetConversationForCLILocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {param: localGetConversationForCLILocalRpcParam}>) {
@@ -415,6 +415,18 @@ export function remoteGetMessagesRemoteRpcChannelMap (channelConfig: ChannelConf
 
 export function remoteGetMessagesRemoteRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetMessagesRemoteResult) => void} & {param: remoteGetMessagesRemoteRpcParam}>): Promise<remoteGetMessagesRemoteResult> {
   return new Promise((resolve, reject) => { remoteGetMessagesRemoteRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
+export function remoteGetPublicConversationsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetPublicConversationsResult) => void} & {param: remoteGetPublicConversationsRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.remote.getPublicConversations'})
+}
+
+export function remoteGetPublicConversationsRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetPublicConversationsResult) => void} & {param: remoteGetPublicConversationsRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => remoteGetPublicConversationsRpc({...request, incomingCallMap, callback}))
+}
+
+export function remoteGetPublicConversationsRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetPublicConversationsResult) => void} & {param: remoteGetPublicConversationsRpcParam}>): Promise<remoteGetPublicConversationsResult> {
+  return new Promise((resolve, reject) => { remoteGetPublicConversationsRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function remoteGetS3ParamsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetS3ParamsResult) => void} & {param: remoteGetS3ParamsRpcParam}>) {
@@ -704,6 +716,12 @@ export type FailedMessageInfo = {
   outboxRecords?: ?Array<OutboxRecord>,
 }
 
+export type FindConversationsLocalRes = {
+  conversations?: ?Array<ConversationLocal>,
+  rateLimits?: ?Array<RateLimit>,
+  identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
+}
+
 export type GenericPayload = {
   Action: string,
 }
@@ -809,6 +827,11 @@ export type GetMessagesLocalRes = {
 
 export type GetMessagesRemoteRes = {
   msgs?: ?Array<MessageBoxed>,
+  rateLimit?: ?RateLimit,
+}
+
+export type GetPublicConversationsRes = {
+  conversations?: ?Array<Conversation>,
   rateLimit?: ?RateLimit,
 }
 
@@ -1295,11 +1318,12 @@ export type localDownloadFileAttachmentLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
-export type localFindConversationsRpcParam = Exact<{
+export type localFindConversationsLocalRpcParam = Exact<{
   tlfName: string,
   visibility: TLFVisibility,
   topicType: TopicType,
-  topicName: string
+  topicName: string,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetConversationForCLILocalRpcParam = Exact<{
@@ -1437,6 +1461,11 @@ export type remoteGetMessagesRemoteRpcParam = Exact<{
   messageIDs?: ?Array<MessageID>
 }>
 
+export type remoteGetPublicConversationsRpcParam = Exact<{
+  tlfID: TLFID,
+  topicType: TopicType
+}>
+
 export type remoteGetS3ParamsRpcParam = Exact<{
   conversationID: ConversationID
 }>
@@ -1498,7 +1527,7 @@ type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 
 type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
 
-type localFindConversationsResult = ?Array<ConversationLocal>
+type localFindConversationsLocalResult = FindConversationsLocalRes
 
 type localGetConversationForCLILocalResult = GetConversationForCLILocalRes
 
@@ -1538,6 +1567,8 @@ type remoteGetInboxVersionResult = InboxVers
 
 type remoteGetMessagesRemoteResult = GetMessagesRemoteRes
 
+type remoteGetPublicConversationsResult = GetPublicConversationsRes
+
 type remoteGetS3ParamsResult = S3Params
 
 type remoteGetThreadRemoteResult = GetThreadRemoteRes
@@ -1560,7 +1591,7 @@ export type rpc =
     localCancelPostRpc
   | localDownloadAttachmentLocalRpc
   | localDownloadFileAttachmentLocalRpc
-  | localFindConversationsRpc
+  | localFindConversationsLocalRpc
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc
   | localGetInboxNonblockLocalRpc
@@ -1581,6 +1612,7 @@ export type rpc =
   | remoteGetInboxRemoteRpc
   | remoteGetInboxVersionRpc
   | remoteGetMessagesRemoteRpc
+  | remoteGetPublicConversationsRpc
   | remoteGetS3ParamsRpc
   | remoteGetThreadRemoteRpc
   | remoteGetUnreadUpdateFullRpc

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -731,7 +731,7 @@ export type GetConversationForCLILocalQuery = {
   MessageTypes?: ?Array<MessageType>,
   Since?: ?string,
   limit: UnreadFirstNumLimit,
-  conversationId: ConversationID,
+  conv: ConversationLocal,
 }
 
 export type GetConversationForCLILocalRes = {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -165,6 +165,18 @@ export function localDownloadFileAttachmentLocalRpcPromise (request: $Exact<requ
   return new Promise((resolve, reject) => { localDownloadFileAttachmentLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function localFindConversationsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsResult) => void} & {param: localFindConversationsRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.findConversations'})
+}
+
+export function localFindConversationsRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsResult) => void} & {param: localFindConversationsRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localFindConversationsRpc({...request, incomingCallMap, callback}))
+}
+
+export function localFindConversationsRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsResult) => void} & {param: localFindConversationsRpcParam}>): Promise<localFindConversationsResult> {
+  return new Promise((resolve, reject) => { localFindConversationsRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function localGetConversationForCLILocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {param: localGetConversationForCLILocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.getConversationForCLILocal'})
 }
@@ -1283,6 +1295,13 @@ export type localDownloadFileAttachmentLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
+export type localFindConversationsRpcParam = Exact<{
+  tlfName: string,
+  visibility: TLFVisibility,
+  topicType: TopicType,
+  topicName: string
+}>
+
 export type localGetConversationForCLILocalRpcParam = Exact<{
   query: GetConversationForCLILocalQuery
 }>
@@ -1479,6 +1498,8 @@ type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 
 type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
 
+type localFindConversationsResult = ?Array<ConversationLocal>
+
 type localGetConversationForCLILocalResult = GetConversationForCLILocalRes
 
 type localGetInboxAndUnboxLocalResult = GetInboxAndUnboxLocalRes
@@ -1539,6 +1560,7 @@ export type rpc =
     localCancelPostRpc
   | localDownloadAttachmentLocalRpc
   | localDownloadFileAttachmentLocalRpc
+  | localFindConversationsRpc
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc
   | localGetInboxNonblockLocalRpc


### PR DESCRIPTION
Key components to this PR are the following:

1.) New local service endpoint, `FindConversationsLocal`, which takes a conversation spec (like TLF name, public, topic type), and attempts to find matching conversations. It basically just runs `GetInboxAndUnbox` as is traditionally done here, but it will also attempt to find public conversations if our initial search comes back empty. 
2.) Change the CLI and JSON API to use this function when they are resolving a TLF name to a conversation ID.