### PR TITLE
Add global ESC LIFO handler system

### DIFF
--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -262,7 +262,8 @@ class ConversationList extends Component<void, Props, State> {
     })
 
     const container = document.getElementById('popupContainer')
-    ReactDOM.render(popupComponent, container)
+    // FIXME: this is the right way to render portals retaining context for now, though it will change in the future.
+    ReactDOM.unstable_renderSubtreeIntoContainer(this, popupComponent, container)
   }
 
   _onAction = (message, event) => {

--- a/shared/common-adapters/popup-dialog.desktop.js
+++ b/shared/common-adapters/popup-dialog.desktop.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react'
 import {Box, Icon} from './'
+import EscapeHandler from '../util/escape-handler'
 import {globalColors, globalMargins, globalStyles} from '../styles'
 
 import type {Props} from './popup-dialog'
@@ -11,14 +12,16 @@ function stopBubbling (ev) {
 
 export function PopupDialog ({children, onClose, fill}: Props) {
   return (
-    <Box style={styleCover} onClick={onClose}>
-      <Box style={{...styleContainer, ...(fill ? styleContainerFill : null)}}>
-        <Icon type='iconfont-close' style={styleClose} />
-        <Box style={styleClipContainer} onClick={stopBubbling}>
-          {children}
+    <EscapeHandler onESC={onClose}>
+      <Box style={styleCover} onClick={onClose}>
+        <Box style={{...styleContainer, ...(fill ? styleContainerFill : null)}}>
+          <Icon type='iconfont-close' style={styleClose} />
+          <Box style={styleClipContainer} onClick={stopBubbling}>
+            {children}
+          </Box>
         </Box>
       </Box>
-    </Box>
+    </EscapeHandler>
   )
 }
 

--- a/shared/common-adapters/popup-menu.desktop.js
+++ b/shared/common-adapters/popup-menu.desktop.js
@@ -2,6 +2,7 @@
 import React, {Component} from 'react'
 import type {Props, HeaderTextProps} from './popup-menu'
 import {Box, Text} from '../common-adapters/index'
+import EscapeHandler from '../util/escape-handler'
 import {globalColors, globalMargins, globalStyles} from '../styles'
 
 class PopupMenu extends Component<void, Props, void> {
@@ -18,31 +19,33 @@ class PopupMenu extends Component<void, Props, void> {
     `
 
     return (
-      <Box style={{...stylesMenuCatcher}} onClick={e => {
-        this.props.onHidden()
-        e.stopPropagation()
-      }}>
-        <style>{realCSS}</style>
-        <Box style={{...stylesMenu, ...this.props.style}}>
-          {this.props.header && this.props.header.view}
-          <Box style={{...globalStyles.flexBoxColumn, flexShrink: 0, paddingTop: globalMargins.tiny, paddingBottom: globalMargins.tiny}}>
-            {
-              this.props.items.filter(Boolean).map((i, idx) => {
-                if (i === 'Divider') {
-                  return <Divider key={idx} />
-                }
+      <EscapeHandler onESC={this.props.onHidden}>
+        <Box style={{...stylesMenuCatcher}} onClick={e => {
+          this.props.onHidden()
+          e.stopPropagation()
+        }}>
+          <style>{realCSS}</style>
+          <Box style={{...stylesMenu, ...this.props.style}}>
+            {this.props.header && this.props.header.view}
+            <Box style={{...globalStyles.flexBoxColumn, flexShrink: 0, paddingTop: globalMargins.tiny, paddingBottom: globalMargins.tiny}}>
+              {
+                this.props.items.filter(Boolean).map((i, idx) => {
+                  if (i === 'Divider') {
+                    return <Divider key={idx} />
+                  }
 
-                return (
-                  <Box key={i.title} className={i.danger ? 'menu-hover-danger' : 'menu-hover'} style={stylesRow} onClick={i.onClick}>
-                    <Text className='title' type='Body' style={{...stylesMenuText, ...i.style}}>{i.title}</Text>
-                    {i.subTitle && <Text className='subtitle' key={i.subTitle} type='BodySmall' style={{...stylesMenuText, ...i.style}}>{i.subTitle}</Text>}
-                  </Box>
-                )
-              })
-            }
+                  return (
+                    <Box key={i.title} className={i.danger ? 'menu-hover-danger' : 'menu-hover'} style={stylesRow} onClick={i.onClick}>
+                      <Text className='title' type='Body' style={{...stylesMenuText, ...i.style}}>{i.title}</Text>
+                      {i.subTitle && <Text className='subtitle' key={i.subTitle} type='BodySmall' style={{...stylesMenuText, ...i.style}}>{i.subTitle}</Text>}
+                    </Box>
+                  )
+                })
+              }
+            </Box>
           </Box>
         </Box>
-      </Box>
+      </EscapeHandler>
     )
   }
 }

--- a/shared/desktop/renderer/index.js
+++ b/shared/desktop/renderer/index.js
@@ -21,6 +21,7 @@ import {changedFocus} from '../../actions/window'
 import {devEditAction} from '../../reducers/dev-edit'
 import {disable as disableDragDrop} from '../../util/drag-drop'
 import {getUserImage, loadUserImage} from '../../util/pictures'
+import {GlobalEscapeHandler} from '../../util/escape-handler'
 import {initAvatarLookup, initAvatarLoad} from '../../common-adapters'
 import {listenForNotifications} from '../../actions/notifications'
 import {merge, throttle} from 'lodash'
@@ -149,12 +150,14 @@ function render (store, MainComponent) {
   ReactDOM.render((
     <AppContainer>
       <Root store={store}>
-        <div style={{display: 'flex', flex: 1}}>
-          <RemoteManager />
-          <FontLoader />
-          <MainComponent />
-          {dt}
-        </div>
+        <GlobalEscapeHandler>
+          <div style={{display: 'flex', flex: 1}}>
+            <RemoteManager />
+            <FontLoader />
+            <MainComponent />
+            {dt}
+          </div>
+        </GlobalEscapeHandler>
       </Root>
     </AppContainer>), document.getElementById('root'))
 }

--- a/shared/util/escape-handler.desktop.js
+++ b/shared/util/escape-handler.desktop.js
@@ -1,0 +1,78 @@
+// @flow
+import React, {Component} from 'react'
+
+import type {GlobalProps, Props} from './escape-handler'
+
+class EscapeHandler extends Component<void, Props, void> {
+  static contextTypes = {
+    addESCHandler: React.PropTypes.func,
+    removeESCHandler: React.PropTypes.func,
+  }
+
+  componentDidMount () {
+    this.context.addESCHandler(this)
+  }
+
+  componentWillUnmount () {
+    this.context.removeESCHandler(this)
+  }
+
+  onESC () {
+    this.props.onESC()
+  }
+
+  render () {
+    return this.props.children
+  }
+}
+
+class GlobalEscapeHandler extends Component<void, GlobalProps, void> {
+  _stack: Array<EscapeHandler> = []
+
+  componentDidMount () {
+    document.body.addEventListener('keydown', this._handleESC)
+  }
+
+  componentWillUnmount () {
+    document.body.removeEventListener('keydown', this._handleESC)
+  }
+
+  static childContextTypes = {
+    addESCHandler: React.PropTypes.func,
+    removeESCHandler: React.PropTypes.func,
+  }
+
+  getChildContext () {
+    return {
+      addESCHandler: this.add,
+      removeESCHandler: this.remove,
+    }
+  }
+
+  _handleESC = () => {
+    const receiver = this._stack.pop()
+    if (!receiver) {
+      return
+    }
+    receiver.onESC()
+  }
+
+  add = (receiver: EscapeHandler) => {
+    this._stack.push(receiver)
+  }
+
+  remove = (receiver: EscapeHandler) => {
+    const idx = this._stack.indexOf(receiver)
+    if (idx !== -1) {
+      this._stack.splice(idx, 1)
+    }
+  }
+
+  render () {
+    return this.props.children
+  }
+}
+
+export {GlobalEscapeHandler}
+
+export default EscapeHandler

--- a/shared/util/escape-handler.js.flow
+++ b/shared/util/escape-handler.js.flow
@@ -1,0 +1,15 @@
+// @flow
+import {Component} from 'react'
+
+export type GlobalProps = {
+  children?: React$Element<*>,
+}
+
+export class GlobalEscapeHandler extends Component<void, GlobalProps, void> {}
+
+export type Props = {
+  onESC: () => void,
+  children?: React$Element<*>,
+}
+
+export default class EscapeHandler extends Component<void, Props, void> {}


### PR DESCRIPTION
This adds some helpers to make ESC to close work properly when there are multiple nested ESC listeners onscreen, without requiring a lot of state management.

I first tried several variants of a global `addEventListener` + `stopImmediatePropagation` for this, but the callbacks end up being called FIFO order relative to when they are registered. To be able to press ESC and have a menu dismissed but the popup under it stick around, we need a LIFO queue of ESC handlers.

At first I implemented the queue as a singleton object on `window`. Using React `context` seemed a better way to structure it, and got rid of the global. To get `context` to flow to the popup menu we render as a faux-portal, I needed to use `unsafe_renderSubtreeIntoContainer`. This is currently the recommended approach for portals: it's what's used by react-portal and the like, but it will change in the future. We should use something like react-portal for these cases so we can get the right implementation now and in the future.

:eyeglasses: @keybase/react-hackers 