### PR TITLE
fix vet on Windows

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -47,7 +47,12 @@ check_go_vet() {
 	gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '.go$' | grep -v go/vendor/)
 	[ -z "$gofiles" ] && return 0
 
-	warnings=$(go vet $(go list ./... 2>/dev/null | grep -v vendor) 2>&1)
+	# change from file names to a list of unique paths
+	godirs=$(dirname $gofiles | xargs -n1 | sort -u | xargs)
+
+	# Allow this one vet warning on Windows
+	warnings=$(go tool vet $godirs | grep -E -v 'go\\libkb\\util_windows\.go:[[:digit:]]+: possible misuse of unsafe\.Pointer' 2>&1)
+
 	[ -z "$warnings" ] && return 0
 
 	# go vet found issues


### PR DESCRIPTION
I also updated my golint, it was from October.

Problem here was that I was ignoring this vet result by skipping the whole hook, but that meant skipping lint. I would prefer running all these hook functions and not exiting them individually, what do you guys think? IOW, check_make_lint() would still be called even when check_go_vet() squawks?

Note that with this change, we once again only vet the changed subdirectories instead of ./...

Thanks for the heads up @mmaxim 
@maxtaco 