### PR TITLE
test that we set deletion headers for messages and edits

### DIFF
--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -141,6 +141,8 @@ func (s *BlockingSender) getAllDeletedEdits(ctx context.Context, msg chat1.Messa
 
 	// Modify original delete message
 	msg.ClientHeader.Deletes = deletes
+	// NOTE: If we ever add more fields to MessageDelete, we'll need to be
+	//       careful to preserve them here.
 	msg.MessageBody = chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: deletes})
 
 	return msg, nil

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -478,3 +478,76 @@ func TestDisconnectedFailure(t *testing.T) {
 	require.Equal(t, len(obids), len(listener.obids), "wrong amount of successes")
 	require.Equal(t, obids, listener.obids, "wrong obids for successes")
 }
+
+// The sender is responsible for making sure that a deletion of a single
+// message is expanded to include all of its edits.
+func TestDeletionHeaders(t *testing.T) {
+	world, ri, _, blockingSender, _, _ := setupTest(t, 1)
+	defer world.Cleanup()
+
+	u := world.GetUsers()[0]
+	res, err := ri.NewConversationRemote2(context.TODO(), chat1.NewConversationRemote2Arg{
+		IdTriple: chat1.ConversationIDTriple{
+			Tlfid:     []byte{4, 5, 6},
+			TopicType: 0,
+			TopicID:   []byte{0},
+		},
+		TLFMessage: chat1.MessageBoxed{
+			ClientHeader: chat1.MessageClientHeader{
+				TlfName:   u.Username,
+				TlfPublic: false,
+			},
+			KeyGeneration: 1,
+		},
+	})
+	require.NoError(t, err)
+
+	// Send a message and an edit.
+	_, firstMessageID, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Sender:      u.User.GetUID().ToBytes(),
+			TlfName:     u.Username,
+			MessageType: chat1.MessageType_TEXT,
+		},
+		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{Body: "foo"}),
+	}, 0)
+	require.NoError(t, err)
+	_, editID, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Sender:      u.User.GetUID().ToBytes(),
+			TlfName:     u.Username,
+			MessageType: chat1.MessageType_EDIT,
+			Supersedes:  firstMessageID,
+		},
+		MessageBody: chat1.NewMessageBodyWithEdit(chat1.MessageEdit{MessageID: firstMessageID, Body: "bar"}),
+	}, 0)
+	require.NoError(t, err)
+
+	// Now prepare a deletion.
+	deletion := chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Sender:      u.User.GetUID().ToBytes(),
+			TlfName:     u.Username,
+			MessageType: chat1.MessageType_DELETE,
+			Supersedes:  firstMessageID,
+		},
+		MessageBody: chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: []chat1.MessageID{firstMessageID}}),
+	}
+	preparedDeletion, err := blockingSender.Prepare(context.TODO(), deletion, &res.ConvID)
+	require.NoError(t, err)
+
+	// Assert that the deletion gets the edit too.
+	deletedIDs := map[chat1.MessageID]bool{}
+	for _, id := range preparedDeletion.ClientHeader.Deletes {
+		deletedIDs[id] = true
+	}
+	if len(deletedIDs) != 2 {
+		t.Fatalf("expected 2 deleted IDs, found %d", len(deletedIDs))
+	}
+	if !deletedIDs[firstMessageID] {
+		t.Fatalf("expected message #%d to be deleted", firstMessageID)
+	}
+	if !deletedIDs[3] {
+		t.Fatalf("expected message #%d to be deleted", editID)
+	}
+}

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -239,11 +239,13 @@ func (c *chatServiceHandler) DeleteV1(ctx context.Context, opts deleteOptionsV1)
 	arg := sendArgV1{
 		conversationID: convID,
 		channel:        opts.Channel,
-		body:           chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: messages}),
 		mtype:          chat1.MessageType_DELETE,
 		supersedes:     opts.MessageID,
 		deletes:        messages,
 		response:       "message deleted",
+
+		// NOTE: The service will fill in the IDs of edit messages that also need to be deleted.
+		body: chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: messages}),
 	}
 	return c.sendV1(ctx, arg)
 }


### PR DESCRIPTION
Checked this manually by breaking the getAllDeletedEdits function and
confirming that the test fails.

r? @mmaxim. I did a lot of copy-pasting here from other tests in the file,
and I'm sure there are things I can clean up.