### PR TITLE
Use badger mechanism for marking conversations as unread

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -1,7 +1,6 @@
 // @flow
 import * as Constants from '../constants/chat'
 import HiddenString from '../util/hidden-string'
-import _ from 'lodash'
 import engine from '../engine'
 import {List, Map} from 'immutable'
 import {NotifyPopup} from '../native/notifications'

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -1158,10 +1158,10 @@ function * _badgeAppForChat (action: BadgeAppForChat): SagaGenerator<any, any> {
   conversations.map(conv => {
     conversationsWithKeys[conversationIDToKey(conv.get('convID'))] = conv.get('UnreadMessages')
   })
-  const conversationsWithKeysMap = Map(conversationsWithKeys)
+  const conversationUnreadCounts = Map(conversationsWithKeys)
   yield put({
-    payload: conversationsWithKeysMap,
-    type: 'chat:updateUnreadConversations',
+    payload: conversationUnreadCounts,
+    type: 'chat:updateConversationUnreadCounts',
   })
 }
 

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -34,7 +34,7 @@ import type {TypedState} from '../constants/reducer'
 import type {
   AppendMessages,
   BadgeAppForChat,
-  ConversationBadgeState,
+  ConversationBadgeStateRecord,
   ConversationIDKey,
   CreatePendingFailure,
   DeleteMessage,
@@ -194,7 +194,7 @@ function updateLatestMessage (conversationIDKey: ConversationIDKey): UpdateLates
   return {type: 'chat:updateLatestMessage', payload: {conversationIDKey}}
 }
 
-function badgeAppForChat (conversations: [ConversationBadgeState]): BadgeAppForChat {
+function badgeAppForChat (conversations: List<ConversationBadgeStateRecord>): BadgeAppForChat {
   return {type: 'chat:badgeAppForChat', payload: conversations}
 }
 
@@ -1143,20 +1143,20 @@ function * _badgeAppForChat (action: BadgeAppForChat): SagaGenerator<any, any> {
   const selectedConversationIDKey = yield select(_selectedSelector)
   const windowFocused = yield select(_focusedSelector)
 
-  const newConversations = _.reduce(conversations, (acc, conv) => {
+  const newConversations = conversations.reduce((acc, conv) => {
     // Badge this conversation if it's unread and either the app doesn't have
     // focus (so the user didn't see the message) or the conversation isn't
     // selected (same).
-    const unread = conv.UnreadMessages > 0
-    const selected = (conversationIDToKey(conv.convID) === selectedConversationIDKey)
+    const unread = conv.get('UnreadMessages') > 0
+    const selected = (conversationIDToKey(conv.get('convID')) === selectedConversationIDKey)
     const addThisConv = (unread && (!selected || !windowFocused))
     return addThisConv ? acc + 1 : acc
   }, 0)
   yield put(badgeApp('chatInbox', newConversations > 0, newConversations))
 
   let conversationsWithKeys = {}
-  conversations.forEach(conv => {
-    conversationsWithKeys[conversationIDToKey(conv.convID)] = conv.UnreadMessages
+  conversations.map(conv => {
+    conversationsWithKeys[conversationIDToKey(conv.get('convID'))] = conv.get('UnreadMessages')
   })
   const conversationsWithKeysMap = Map(conversationsWithKeys)
   yield put({

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -93,7 +93,6 @@ const loadedInboxActionTransformer = action => ({
         conversationIDKey,
         muted,
         time,
-        unreadCount,
         validated,
         participants,
         info,
@@ -107,7 +106,6 @@ const loadedInboxActionTransformer = action => ({
         muted,
         participantsCount: participants.count(),
         time,
-        unreadCount,
         validated,
       }
     }),
@@ -285,7 +283,6 @@ function _inboxConversationToConversation (convo: ConversationLocal, author: ?st
     muted: false,
     time: convo.readerInfo.mtime,
     snippet,
-    unreadCount: convo.readerInfo.maxMsgid - convo.readerInfo.readMsgid,
     validated: true,
   })
 }
@@ -307,7 +304,6 @@ function _inboxToConversations (inbox: GetInboxLocalRes, author: ?string, follow
       muted: false, // TODO integrate this when it's available
       time: convoUnverified.readerInfo && convoUnverified.readerInfo.mtime,
       snippet: ' ',
-      unreadCount: convoUnverified.readerInfo && (convoUnverified.readerInfo.maxMsgid - convoUnverified.readerInfo.readMsgid),
       validated: false,
     })
   }).filter(Boolean))

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -34,7 +34,7 @@ import type {TypedState} from '../constants/reducer'
 import type {
   AppendMessages,
   BadgeAppForChat,
-  ConversationBadgeStateRecord,
+  ConversationBadgeState,
   ConversationIDKey,
   CreatePendingFailure,
   DeleteMessage,
@@ -194,7 +194,7 @@ function updateLatestMessage (conversationIDKey: ConversationIDKey): UpdateLates
   return {type: 'chat:updateLatestMessage', payload: {conversationIDKey}}
 }
 
-function badgeAppForChat (conversations: List<ConversationBadgeStateRecord>): BadgeAppForChat {
+function badgeAppForChat (conversations: List<ConversationBadgeState>): BadgeAppForChat {
   return {type: 'chat:badgeAppForChat', payload: conversations}
 }
 

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -34,7 +34,7 @@ import type {TypedState} from '../constants/reducer'
 import type {
   AppendMessages,
   BadgeAppForChat,
-  ConversationBadgeStateRecord,
+  ConversationBadgeState,
   ConversationIDKey,
   CreatePendingFailure,
   DeleteMessage,
@@ -194,7 +194,7 @@ function updateLatestMessage (conversationIDKey: ConversationIDKey): UpdateLates
   return {type: 'chat:updateLatestMessage', payload: {conversationIDKey}}
 }
 
-function badgeAppForChat (conversations: Array<ConversationBadgeStateRecord>): BadgeAppForChat {
+function badgeAppForChat (conversations: [ConversationBadgeState]): BadgeAppForChat {
   return {type: 'chat:badgeAppForChat', payload: conversations}
 }
 
@@ -1153,6 +1153,16 @@ function * _badgeAppForChat (action: BadgeAppForChat): SagaGenerator<any, any> {
     return addThisConv ? acc + 1 : acc
   }, 0)
   yield put(badgeApp('chatInbox', newConversations > 0, newConversations))
+
+  let conversationsWithKeys = {}
+  conversations.forEach(conv => {
+    conversationsWithKeys[conversationIDToKey(conv.convID)] = conv.UnreadMessages
+  })
+  const conversationsWithKeysMap = Map(conversationsWithKeys)
+  yield put({
+    payload: conversationsWithKeysMap,
+    type: 'chat:updateUnreadConversations',
+  })
 }
 
 function * _uploadAttachment ({param, conversationIDKey, outboxID}: {param: ChatTypes.localPostFileAttachmentLocalRpcParam, conversationIDKey: ConversationIDKey, outboxID: Constants.OutboxIDKey}) {

--- a/shared/chat/conversations-list/container.js
+++ b/shared/chat/conversations-list/container.js
@@ -19,13 +19,14 @@ class ConversationListContainer extends Component {
 
 export default connect(
   (state: TypedState, {routeSelected}) => ({
+    conversationUnreadCounts: state.chat.get('conversationUnreadCounts'),
     inbox: state.chat.get('inbox'),
     selectedConversation: routeSelected,
     you: state.config.username || '',
   }),
   (dispatch: Dispatch) => ({
     loadInbox: () => dispatch(loadInbox()),
-    onSelectConversation: (key: ConversationIDKey) => dispatch(selectConversation(key, true)),
     onNewChat: () => dispatch(newChat([])),
+    onSelectConversation: (key: ConversationIDKey) => dispatch(selectConversation(key, true)),
   })
 )(ConversationListContainer)

--- a/shared/chat/conversations-list/index.desktop.js
+++ b/shared/chat/conversations-list/index.desktop.js
@@ -98,6 +98,10 @@ const Row = shouldUpdate((props: RowProps, nextProps: RowProps) => {
     return true
   }
 
+  if (props.unreadCount !== nextProps.unreadCount) {
+    return true
+  }
+
   return false
 })(_Row)
 

--- a/shared/chat/conversations-list/index.desktop.js
+++ b/shared/chat/conversations-list/index.desktop.js
@@ -37,13 +37,13 @@ const rowBorderColor = (idx: number, lastParticipantIndex: number, hasUnread: bo
   return isSelected ? globalColors.white : globalColors.darkBlue4
 }
 
-type RowProps = Props & {conversation: InboxState}
+type RowProps = Props & {conversation: InboxState, unreadCount: number}
 
-const _Row = ({onSelectConversation, selectedConversation, onNewChat, nowOverride, conversation, you}: RowProps) => {
+const _Row = ({onSelectConversation, selectedConversation, onNewChat, nowOverride, conversation, unreadCount, you}: RowProps) => {
   const participants = participantFilter(conversation.get('participants'), you)
   const isSelected = selectedConversation === conversation.get('conversationIDKey')
   const isMuted = conversation.get('muted')
-  const hasUnread = !!conversation.get('unreadCount')
+  const hasUnread = !!unreadCount
   const avatarProps = participants.slice(0, 2).map((username, idx) => ({
     backgroundColor: isSelected ? globalColors.white : hasUnread ? globalColors.darkBlue : globalColors.darkBlue4,
     username,
@@ -60,7 +60,7 @@ const _Row = ({onSelectConversation, selectedConversation, onNewChat, nowOverrid
   return (
     <div
       onClick={() => onSelectConversation(conversation.get('conversationIDKey'))}
-      title={`${conversation.get('unreadCount')} unread`}
+      title={`${unreadCount} unread`}
       style={{...rowContainerStyle, backgroundColor}}>
       <div style={{...globalStyles.flexBoxRow, flex: 1, maxWidth: 48, alignItems: 'center', justifyContent: 'flex-start', paddingLeft: 4}}>
         <MultiAvatar singleSize={32} multiSize={24} avatarProps={avatarProps} />
@@ -119,7 +119,7 @@ const ConversationList = (props: Props) => (
     <div style={containerStyle}>
       <AddNewRow {...props} />
       <div style={scrollableStyle}>
-        {props.inbox.map(conversation => <Row {...props} key={conversation.get('conversationIDKey')} conversation={conversation} />)}
+        {props.inbox.map(conversation => <Row {...props} unreadCount={props.conversationUnreadCounts.get(conversation.get('conversationIDKey'))} key={conversation.get('conversationIDKey')} conversation={conversation} />)}
       </div>
     </div>
     {props.children}

--- a/shared/chat/conversations-list/index.js.flow
+++ b/shared/chat/conversations-list/index.js.flow
@@ -1,6 +1,6 @@
 // @flow
 import {Component} from 'react'
-import {List} from 'immutable'
+import {List, Map} from 'immutable'
 
 import type {InboxState, ConversationIDKey} from '../../constants/chat'
 
@@ -11,6 +11,7 @@ export type Props = {
   selectedConversation: ConversationIDKey,
   onNewChat: () => void,
   children?: React$Element<*>,
+  conversationUnreadCounts: Map<ConversationIDKey, number>,
   you: string,
 }
 

--- a/shared/chat/dumb.js
+++ b/shared/chat/dumb.js
@@ -148,9 +148,18 @@ const inbox = [
   }),
 ]
 
+const conversationUnreadCounts = {
+  convo1: 3,
+  convo2: 0,
+  convo3: 0,
+  convo5: 0,
+  convo6: 1,
+}
+
 const commonConversationsProps = {
   nowOverride: now,
   inbox: List(inbox),
+  conversationUnreadCounts: Map(conversationUnreadCounts),
   onSelectConversation: (key: ConversationIDKey) => console.log('selected', key),
   selectedConversation: null,
   onNewChat: () => console.log('new chat'),

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -231,7 +231,7 @@ export type StartConversation = NoErrorTypedAction<'chat:startConversation', {us
 export type UpdateBadging = NoErrorTypedAction<'chat:updateBadging', {conversationIDKey: ConversationIDKey}>
 export type UpdateLatestMessage = NoErrorTypedAction<'chat:updateLatestMessage', {conversationIDKey: ConversationIDKey}>
 export type UpdateMetadata = NoErrorTypedAction<'chat:updateMetadata', {users: Array<string>}>
-export type UpdateUnreadConversationCounts = NoErrorTypedAction<'chat:updateConversationUnreadCounts', Map<ConversationIDKey, number>>
+export type UpdateConversationUnreadCounts = NoErrorTypedAction<'chat:updateConversationUnreadCounts', Map<ConversationIDKey, number>>
 export type UpdatedMetadata = NoErrorTypedAction<'chat:updatedMetadata', {[key: string]: MetaData}>
 
 // Pass an outboxID to specify that we are retrying an attachment

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -108,6 +108,11 @@ export type DeletedMessage = {
 
 export type MaybeTimestamp = TimestampMessage | null
 
+export type ConversationBadgeState = {
+  convID: ConversationID,
+  UnreadMessages: number,
+}
+
 export const ConversationStateRecord = Record({
   messages: List(),
   seenMessages: Set(),
@@ -130,11 +135,6 @@ export type ConversationState = Record<{
   paginationPrevious: ?Buffer,
   firstNewMessageID: ?MessageID,
   deletedIDs: Set<MessageID>,
-}>
-
-export type ConversationBadgeStateRecord = Record<{
-  convID: ConversationID,
-  UnreadMessages: number,
 }>
 
 export const InboxStateRecord = Record({
@@ -183,6 +183,7 @@ export const StateRecord = Record({
   focused: false,
   metaData: Map(),
   pendingFailures: Set(),
+  conversationUnreadCounts: Map(),
 })
 
 export type State = Record<{
@@ -191,6 +192,7 @@ export type State = Record<{
   focused: boolean,
   metaData: MetaDataMap,
   pendingFailures: Set<OutboxIDKey>,
+  conversationUnreadCounts: Map<ConversationIDKey, number>,
 }>
 
 export const maxAttachmentPreviewSize = 320
@@ -201,7 +203,7 @@ export const maxMessagesToLoadAtATime = 50
 export const nothingSelected = 'chat:noneSelected'
 
 export type AppendMessages = NoErrorTypedAction<'chat:appendMessages', {conversationIDKey: ConversationIDKey, isSelected: boolean, messages: Array<ServerMessage>}>
-export type BadgeAppForChat = NoErrorTypedAction<'chat:badgeAppForChat', Array<ConversationBadgeStateRecord>>
+export type BadgeAppForChat = NoErrorTypedAction<'chat:badgeAppForChat', [ConversationBadgeState]>
 export type ClearMessages = NoErrorTypedAction<'chat:clearMessages', {conversationIDKey: ConversationIDKey}>
 export type CreatePendingFailure = NoErrorTypedAction<'chat:createPendingFailure', {outboxID: OutboxIDKey}>
 export type DeleteMessage = NoErrorTypedAction<'chat:deleteMessage', {message: Message}>
@@ -228,6 +230,7 @@ export type StartConversation = NoErrorTypedAction<'chat:startConversation', {us
 export type UpdateBadging = NoErrorTypedAction<'chat:updateBadging', {conversationIDKey: ConversationIDKey}>
 export type UpdateLatestMessage = NoErrorTypedAction<'chat:updateLatestMessage', {conversationIDKey: ConversationIDKey}>
 export type UpdateMetadata = NoErrorTypedAction<'chat:updateMetadata', {users: Array<string>}>
+export type UpdateUnreadConversationCounts = NoErrorTypedAction<'chat:updateConversationUnreadCounts', Map<ConversationIDKey, number>>
 export type UpdatedMetadata = NoErrorTypedAction<'chat:updatedMetadata', {[key: string]: MetaData}>
 
 // Pass an outboxID to specify that we are retrying an attachment

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -152,7 +152,6 @@ export const InboxStateRecord = Record({
   time: 0,
   snippet: '',
   snippetKey: null,
-  unreadCount: 0,
   validated: false,
 })
 
@@ -166,7 +165,6 @@ export type InboxState = Record<{
   time: number,
   snippet: string,
   snippetKey: any,
-  unreadCount: number,
   validated: boolean,
 }>
 

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -108,7 +108,6 @@ export type DeletedMessage = {
 
 export type MaybeTimestamp = TimestampMessage | null
 
-
 export const ConversationStateRecord = Record({
   messages: List(),
   seenMessages: Set(),

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -108,10 +108,6 @@ export type DeletedMessage = {
 
 export type MaybeTimestamp = TimestampMessage | null
 
-export type ConversationBadgeState = {
-  convID: ConversationID,
-  UnreadMessages: number,
-}
 
 export const ConversationStateRecord = Record({
   messages: List(),
@@ -135,6 +131,11 @@ export type ConversationState = Record<{
   paginationPrevious: ?Buffer,
   firstNewMessageID: ?MessageID,
   deletedIDs: Set<MessageID>,
+}>
+
+export type ConversationBadgeStateRecord = Record<{
+  convID: ConversationID,
+  UnreadMessages: number,
 }>
 
 export const InboxStateRecord = Record({
@@ -203,7 +204,7 @@ export const maxMessagesToLoadAtATime = 50
 export const nothingSelected = 'chat:noneSelected'
 
 export type AppendMessages = NoErrorTypedAction<'chat:appendMessages', {conversationIDKey: ConversationIDKey, isSelected: boolean, messages: Array<ServerMessage>}>
-export type BadgeAppForChat = NoErrorTypedAction<'chat:badgeAppForChat', [ConversationBadgeState]>
+export type BadgeAppForChat = NoErrorTypedAction<'chat:badgeAppForChat', List<ConversationBadgeStateRecord>>
 export type ClearMessages = NoErrorTypedAction<'chat:clearMessages', {conversationIDKey: ConversationIDKey}>
 export type CreatePendingFailure = NoErrorTypedAction<'chat:createPendingFailure', {outboxID: OutboxIDKey}>
 export type DeleteMessage = NoErrorTypedAction<'chat:deleteMessage', {message: Message}>

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -133,10 +133,15 @@ export type ConversationState = Record<{
   deletedIDs: Set<MessageID>,
 }>
 
-export type ConversationBadgeStateRecord = Record<{
+export type ConversationBadgeState = Record<{
   convID: ConversationID,
   UnreadMessages: number,
 }>
+
+export const ConversationBadgeStateRecord = Record({
+  convID: undefined,
+  UnreadMessages: 0,
+})
 
 export const InboxStateRecord = Record({
   info: null,
@@ -204,7 +209,7 @@ export const maxMessagesToLoadAtATime = 50
 export const nothingSelected = 'chat:noneSelected'
 
 export type AppendMessages = NoErrorTypedAction<'chat:appendMessages', {conversationIDKey: ConversationIDKey, isSelected: boolean, messages: Array<ServerMessage>}>
-export type BadgeAppForChat = NoErrorTypedAction<'chat:badgeAppForChat', List<ConversationBadgeStateRecord>>
+export type BadgeAppForChat = NoErrorTypedAction<'chat:badgeAppForChat', List<ConversationBadgeState>>
 export type ClearMessages = NoErrorTypedAction<'chat:clearMessages', {conversationIDKey: ConversationIDKey}>
 export type CreatePendingFailure = NoErrorTypedAction<'chat:createPendingFailure', {outboxID: OutboxIDKey}>
 export type DeleteMessage = NoErrorTypedAction<'chat:deleteMessage', {message: Message}>

--- a/shared/native/notification-listeners.desktop.js
+++ b/shared/native/notification-listeners.desktop.js
@@ -1,5 +1,6 @@
 // @flow
 import {remote} from 'electron'
+import {List, Record} from 'immutable'
 import {bootstrap} from '../actions/config'
 import {logoutDone} from '../actions/login'
 import {badgeApp} from '../actions/notifications'
@@ -45,7 +46,11 @@ export default function (dispatch: Dispatch, getState: () => Object, notify: any
     },
     'keybase.1.NotifyBadges.badgeState': ({badgeState}) => {
       const {conversations, newTlfs} = badgeState
-      dispatch(badgeAppForChat(conversations))
+      let convos = List()
+      conversations.forEach(conversation => {
+        convos.push(Record(conversation))
+      })
+      dispatch(badgeAppForChat(convos))
       dispatch(badgeApp('newTLFs', newTlfs > 0, newTlfs))
     },
     'keybase.1.NotifyService.shutdown': () => {

--- a/shared/native/notification-listeners.desktop.js
+++ b/shared/native/notification-listeners.desktop.js
@@ -7,9 +7,7 @@ import {badgeApp} from '../actions/notifications'
 import {badgeAppForChat} from '../actions/chat'
 import {kbfsNotification} from '../util/kbfs-notifications'
 import {pgpKeyInSecretStoreFile} from '../constants/pgp'
-
 import {ConversationBadgeStateRecord} from '../constants/chat'
-
 import type {Dispatch} from '../constants/types/flux'
 import type {incomingCallMapType} from '../constants/types/flow-types'
 

--- a/shared/native/notification-listeners.desktop.js
+++ b/shared/native/notification-listeners.desktop.js
@@ -8,6 +8,7 @@ import {badgeAppForChat} from '../actions/chat'
 import {kbfsNotification} from '../util/kbfs-notifications'
 import {pgpKeyInSecretStoreFile} from '../constants/pgp'
 import {ConversationBadgeStateRecord} from '../constants/chat'
+
 import type {Dispatch} from '../constants/types/flux'
 import type {incomingCallMapType} from '../constants/types/flow-types'
 

--- a/shared/native/notification-listeners.desktop.js
+++ b/shared/native/notification-listeners.desktop.js
@@ -8,6 +8,8 @@ import {badgeAppForChat} from '../actions/chat'
 import {kbfsNotification} from '../util/kbfs-notifications'
 import {pgpKeyInSecretStoreFile} from '../constants/pgp'
 
+import {ConversationBadgeStateRecord} from '../constants/chat'
+
 import type {Dispatch} from '../constants/types/flux'
 import type {incomingCallMapType} from '../constants/types/flow-types'
 
@@ -46,7 +48,7 @@ export default function (dispatch: Dispatch, getState: () => Object, notify: any
     },
     'keybase.1.NotifyBadges.badgeState': ({badgeState}) => {
       const {conversations, newTlfs} = badgeState
-      const convos = List(conversations.map(conversation => Record(conversation)))
+      const convos = List(conversations.map(conversation => ConversationBadgeStateRecord(conversation)))
       console.warn('convos is ', convos)
       console.warn(convos)
       dispatch(badgeAppForChat(convos))

--- a/shared/native/notification-listeners.desktop.js
+++ b/shared/native/notification-listeners.desktop.js
@@ -46,10 +46,9 @@ export default function (dispatch: Dispatch, getState: () => Object, notify: any
     },
     'keybase.1.NotifyBadges.badgeState': ({badgeState}) => {
       const {conversations, newTlfs} = badgeState
-      let convos = List()
-      conversations.forEach(conversation => {
-        convos.push(Record(conversation))
-      })
+      const convos = List(conversations.map(conversation => Record(conversation)))
+      console.warn('convos is ', convos)
+      console.warn(convos)
       dispatch(badgeAppForChat(convos))
       dispatch(badgeApp('newTLFs', newTlfs > 0, newTlfs))
     },

--- a/shared/native/notification-listeners.desktop.js
+++ b/shared/native/notification-listeners.desktop.js
@@ -1,6 +1,6 @@
 // @flow
 import {remote} from 'electron'
-import {List, Record} from 'immutable'
+import {List} from 'immutable'
 import {bootstrap} from '../actions/config'
 import {logoutDone} from '../actions/login'
 import {badgeApp} from '../actions/notifications'

--- a/shared/native/notification-listeners.desktop.js
+++ b/shared/native/notification-listeners.desktop.js
@@ -48,8 +48,6 @@ export default function (dispatch: Dispatch, getState: () => Object, notify: any
     'keybase.1.NotifyBadges.badgeState': ({badgeState}) => {
       const {conversations, newTlfs} = badgeState
       const convos = List(conversations.map(conversation => ConversationBadgeStateRecord(conversation)))
-      console.warn('convos is ', convos)
-      console.warn(convos)
       dispatch(badgeAppForChat(convos))
       dispatch(badgeApp('newTLFs', newTlfs > 0, newTlfs))
     },

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -369,6 +369,8 @@ function reducer (state: State = initialState, action: Actions) {
       })
 
       return state.set('metaData', metaData)
+    case 'chat:updateUnreadConversations':
+      return state.set('conversationUnreadCounts', action.payload)
     case WindowConstants.changedFocus:
       return state.set('focused', action.payload)
   }

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -191,7 +191,7 @@ function reducer (state: State = initialState, action: Actions) {
 
       return state
         .set('conversationStates', newConversationStates)
-        .set('inbox', sortInbox(state.get('inbox')))
+        .set('inbox', sortInbox(newInboxStates))
     }
     case 'chat:updateTempMessage': {
       if (action.error) {

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -369,7 +369,7 @@ function reducer (state: State = initialState, action: Actions) {
       })
 
       return state.set('metaData', metaData)
-    case 'chat:updateUnreadConversations':
+    case 'chat:updateConversationUnreadCounts':
       return state.set('conversationUnreadCounts', action.payload)
     case WindowConstants.changedFocus:
       return state.set('focused', action.payload)

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -116,12 +116,9 @@ function reducer (state: State = initialState, action: Actions) {
             .set('isRequesting', false)
         })
 
-      // Reset the unread count
-      const newInboxStates = state.get('inbox').map(inbox => inbox.get('conversationIDKey') !== conversationIDKey ? inbox : inbox.set('unreadCount', 0))
-
       return state
         .set('conversationStates', newConversationStates)
-        .set('inbox', sortInbox(newInboxStates))
+        .set('inbox', sortInbox(state.get('inbox')))
     }
     case 'chat:appendMessages': {
       const appendAction: AppendMessages = action
@@ -167,7 +164,6 @@ function reducer (state: State = initialState, action: Actions) {
         }
 
         let newInbox = inbox
-          .set('unreadCount', isSelected ? 0 : inbox.get('unreadCount') + appendMessages.length)
           .set('time', message.timestamp)
 
         if (snippet) {
@@ -195,7 +191,7 @@ function reducer (state: State = initialState, action: Actions) {
 
       return state
         .set('conversationStates', newConversationStates)
-        .set('inbox', sortInbox(newInboxStates))
+        .set('inbox', sortInbox(state.get('inbox')))
     }
     case 'chat:updateTempMessage': {
       if (action.error) {
@@ -328,12 +324,7 @@ function reducer (state: State = initialState, action: Actions) {
       state = state.set('conversationStates', newConversationStates)
       return state
     case 'chat:selectConversation':
-      const conversationIDKey = action.payload.conversationIDKey
-
-      // Set unread to zero
-      const newInboxStates = state.get('inbox').map(inbox => inbox.get('conversationIDKey') !== conversationIDKey ? inbox : inbox.set('unreadCount', 0))
       return state
-        .set('inbox', newInboxStates)
     case 'chat:loadingMessages': {
       const newConversationStates = state.get('conversationStates').update(
         action.payload.conversationIDKey,


### PR DESCRIPTION
@keybase/react-hackers 

Previously, we used the inbox's UnreadCount attribute to mark conversations as unread in the conversations-list sidebar.  That doesn't get updated frequently, though -- the best source of truth is the badging mechanism, which gives us an unread count for every conversation whenever something changes (e.g. you read a message on a different device).

This PR connects the conversation-list component to a new area of the store, chat.unreadConversationCounts, populated from the badgeState updates.

There's some immutable ugliness I'll leave a question about in a comment below.