### PR TITLE
resolve edit and deletes in GetThread and MaxMessages CORE-4371

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -199,6 +199,7 @@ func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.Conver
 
 	// Check conversation ID and change to error if it is wrong
 	if decmsg.IsValid() && !decmsg.Valid().ClientHeader.Conv.Derivable(convID) {
+		s.Debug(ctx, "invalid conversation ID detected, not derivable: %s", convID)
 		decmsg = chat1.NewMessageUnboxedWithError(chat1.MessageUnboxedError{
 			ErrMsg:      "invalid conversation ID",
 			MessageID:   msg.GetMessageID(),

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -41,7 +41,7 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 	}
 
 	// Resolve supersedes
-	if !q.DisableResolveSupersedes {
+	if q == nil || !q.DisableResolveSupersedes {
 		transform := newSupersedesTransform(s.G())
 		if thread.Messages, err = transform.run(ctx, convID, uid, thread.Messages, finalizeInfo); err != nil {
 			return err

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -41,7 +41,7 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 	}
 
 	// Resolve supersedes
-	if q.ResolveSupersedes {
+	if !q.DisableResolveSupersedes {
 		transform := newSupersedesTransform(s.G())
 		if thread.Messages, err = transform.run(ctx, convID, uid, thread.Messages, finalizeInfo); err != nil {
 			return err

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -43,7 +43,7 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 	// Resolve supersedes
 	if q.ResolveSupersedes {
 		transform := newSupersedesTransform(s.G())
-		if err = transform.run(ctx, convID, uid, thread, finalizeInfo); err != nil {
+		if thread.Messages, err = transform.run(ctx, convID, uid, thread.Messages, finalizeInfo); err != nil {
 			return err
 		}
 	}

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -12,17 +12,71 @@ import (
 	"golang.org/x/net/context"
 )
 
+type baseConversationSource struct {
+	libkb.Contextified
+	utils.DebugLabeler
+
+	getSecretUI func() libkb.SecretUI
+}
+
+func newBaseConversationSource(g *libkb.GlobalContext, getSecretUI func() libkb.SecretUI) *baseConversationSource {
+	return &baseConversationSource{
+		Contextified: libkb.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "baseConversationSource", false),
+		getSecretUI:  getSecretUI,
+	}
+}
+
+func (s *baseConversationSource) postProcessThread(ctx context.Context, uid gregor1.UID,
+	convID chat1.ConversationID, thread *chat1.ThreadView, q *chat1.GetThreadQuery,
+	finalizeInfo *chat1.ConversationFinalizeInfo) (err error) {
+
+	// Sanity check the prev pointers in this thread.
+	// TODO: We'll do this against what's in the cache once that's ready,
+	//       rather than only checking the messages we just fetched against
+	//       each other.
+	_, err = CheckPrevPointersAndGetUnpreved(thread)
+	if err != nil {
+		return err
+	}
+
+	// Resolve supersedes
+	if q.ResolveSupersedes {
+		transform := newSupersedesTransform(s.G())
+		if err = transform.run(ctx, convID, uid, thread, finalizeInfo); err != nil {
+			return err
+		}
+	}
+
+	// Run type filter if it exists
+	thread.Messages = utils.FilterByType(thread.Messages, q)
+
+	// Fetch outbox and tack onto the result
+	outbox := storage.NewOutbox(s.G(), uid, s.getSecretUI)
+	if err = outbox.SprinkleIntoThread(ctx, convID, thread); err != nil {
+		if _, ok := err.(storage.MissError); !ok {
+			return err
+		}
+	}
+
+	return nil
+}
+
 type RemoteConversationSource struct {
+	*baseConversationSource
+
 	libkb.Contextified
 	ri    func() chat1.RemoteInterface
 	boxer *Boxer
 }
 
-func NewRemoteConversationSource(g *libkb.GlobalContext, b *Boxer, ri func() chat1.RemoteInterface) *RemoteConversationSource {
+func NewRemoteConversationSource(g *libkb.GlobalContext, b *Boxer, ri func() chat1.RemoteInterface,
+	si func() libkb.SecretUI) *RemoteConversationSource {
 	return &RemoteConversationSource{
-		Contextified: libkb.NewContextified(g),
-		ri:           ri,
-		boxer:        b,
+		Contextified:           libkb.NewContextified(g),
+		baseConversationSource: newBaseConversationSource(g, si),
+		ri:    ri,
+		boxer: b,
 	}
 }
 
@@ -66,6 +120,11 @@ func (s *RemoteConversationSource) Pull(ctx context.Context, convID chat1.Conver
 		return chat1.ThreadView{}, rl, err
 	}
 
+	// Post process thread before returning
+	if err = s.postProcessThread(ctx, uid, convID, &thread, query, conv.Metadata.FinalizeInfo); err != nil {
+		return chat1.ThreadView{}, nil, err
+	}
+
 	return thread, rl, nil
 }
 
@@ -103,6 +162,7 @@ func (s *RemoteConversationSource) GetMessagesWithRemotes(ctx context.Context,
 type HybridConversationSource struct {
 	libkb.Contextified
 	utils.DebugLabeler
+	*baseConversationSource
 
 	ri      func() chat1.RemoteInterface
 	boxer   *Boxer
@@ -110,13 +170,14 @@ type HybridConversationSource struct {
 }
 
 func NewHybridConversationSource(g *libkb.GlobalContext, b *Boxer, storage *storage.Storage,
-	ri func() chat1.RemoteInterface) *HybridConversationSource {
+	ri func() chat1.RemoteInterface, si func() libkb.SecretUI) *HybridConversationSource {
 	return &HybridConversationSource{
-		Contextified: libkb.NewContextified(g),
-		DebugLabeler: utils.NewDebugLabeler(g, "HybridConversationSource", false),
-		ri:           ri,
-		boxer:        b,
-		storage:      storage,
+		Contextified:           libkb.NewContextified(g),
+		DebugLabeler:           utils.NewDebugLabeler(g, "HybridConversationSource", false),
+		baseConversationSource: newBaseConversationSource(g, si),
+		ri:      ri,
+		boxer:   b,
+		storage: storage,
 	}
 }
 
@@ -188,10 +249,7 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, convID chat1
 }
 
 func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.ConversationID,
-	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination) (chat1.ThreadView, []*chat1.RateLimit, error) {
-
-	var err error
-	var rl []*chat1.RateLimit
+	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination) (thread chat1.ThreadView, rl []*chat1.RateLimit, err error) {
 
 	if convID.IsNil() {
 		return chat1.ThreadView{}, rl, errors.New("HybridConversationSource.Pull called with empty convID")
@@ -200,30 +258,39 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 	// Get conversation metadata
 	conv, ratelim, err := utils.GetRemoteConv(ctx, s.G(), uid, convID)
 	rl = append(rl, ratelim)
+
+	// Post process thread before returning
+	defer func() {
+		if err == nil {
+			err = s.postProcessThread(ctx, uid, convID, &thread, query,
+				conv.Metadata.FinalizeInfo)
+		}
+	}()
+
 	if err == nil {
 		// Try locally first
-		localData, err := s.storage.Fetch(ctx, conv, uid, query, pagination)
+		thread, err = s.storage.Fetch(ctx, conv, uid, query, pagination)
 		if err == nil {
 			// If found, then return the stuff
 			s.Debug(ctx, "Pull: cache hit: convID: %s uid: %s", convID, uid)
 
 			// Identify this TLF by running crypt keys
-			if ierr := s.identifyTLF(ctx, convID, uid, localData.Messages, conv.Metadata.FinalizeInfo); ierr != nil {
+			if ierr := s.identifyTLF(ctx, convID, uid, thread.Messages, conv.Metadata.FinalizeInfo); ierr != nil {
 				s.Debug(ctx, "Pull: identify failed: %s", ierr.Error())
 				return chat1.ThreadView{}, nil, ierr
 			}
 
 			// Before returning the stuff, update SenderDeviceRevokedAt on each message.
-			updatedMessages, err := s.updateMessages(ctx, localData.Messages)
+			updatedMessages, err := s.updateMessages(ctx, thread.Messages)
 			if err != nil {
 				return chat1.ThreadView{}, rl, err
 			}
-			localData.Messages = updatedMessages
+			thread.Messages = updatedMessages
 
 			// Before returning the stuff, send remote request to mark as read if
 			// requested.
-			if query != nil && query.MarkAsRead && len(localData.Messages) > 0 {
-				readMsgID := localData.Messages[0].GetMessageID()
+			if query != nil && query.MarkAsRead && len(thread.Messages) > 0 {
+				readMsgID := thread.Messages[0].GetMessageID()
 				res, err := s.ri().MarkAsRead(ctx, chat1.MarkAsReadArg{
 					ConversationID: convID,
 					MsgID:          readMsgID,
@@ -238,7 +305,7 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 				rl = append(rl, res.RateLimit)
 			}
 
-			return localData, rl, nil
+			return thread, rl, nil
 		}
 	} else {
 		s.Debug(ctx, "Pull: error fetching conv metadata: convID: %s uid: %s err: %s", convID, uid,
@@ -258,14 +325,14 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 	}
 
 	// Unbox
-	thread, err := s.boxer.UnboxThread(ctx, boxed.Thread, convID, conv.Metadata.FinalizeInfo)
+	thread, err = s.boxer.UnboxThread(ctx, boxed.Thread, convID, conv.Metadata.FinalizeInfo)
 	if err != nil {
 		return chat1.ThreadView{}, rl, err
 	}
 
 	// Store locally (just warn on error, don't abort the whole thing)
 	if err = s.storage.Merge(ctx, convID, uid, thread.Messages); err != nil {
-		s.G().Log.Warning("Pull: unable to commit thread locally: convID: %s uid: %s", convID, uid)
+		s.Debug(ctx, "Pull: unable to commit thread locally: convID: %s uid: %s", convID, uid)
 	}
 
 	return thread, rl, nil
@@ -465,9 +532,9 @@ func (s *HybridConversationSource) GetMessagesWithRemotes(ctx context.Context,
 }
 
 func NewConversationSource(g *libkb.GlobalContext, typ string, boxer *Boxer, storage *storage.Storage,
-	ri func() chat1.RemoteInterface) libkb.ConversationSource {
+	ri func() chat1.RemoteInterface, si func() libkb.SecretUI) libkb.ConversationSource {
 	if typ == "hybrid" {
-		return NewHybridConversationSource(g, boxer, storage, ri)
+		return NewHybridConversationSource(g, boxer, storage, ri, si)
 	}
-	return NewRemoteConversationSource(g, boxer, ri)
+	return NewRemoteConversationSource(g, boxer, ri, si)
 }

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -1,0 +1,125 @@
+package chat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetThreadSupersedes(t *testing.T) {
+	world, ri, _, sender, _, _, tlf := setupTest(t, 1)
+	defer world.Cleanup()
+
+	u := world.GetUsers()[0]
+	tc := world.Tcs[u.Username]
+
+	cres, err := tlf.CryptKeys(context.TODO(), keybase1.TLFQuery{
+		TlfName: u.Username,
+	})
+	require.NoError(t, err)
+
+	trip := chat1.ConversationIDTriple{
+		Tlfid:     cres.NameIDBreaks.TlfID.ToBytes(),
+		TopicType: chat1.TopicType_CHAT,
+		TopicID:   []byte{0},
+	}
+	res, err := ri.NewConversationRemote2(context.TODO(), chat1.NewConversationRemote2Arg{
+		IdTriple: trip,
+		TLFMessage: chat1.MessageBoxed{
+			ClientHeader: chat1.MessageClientHeader{
+				TlfName:   u.Username,
+				TlfPublic: false,
+			},
+			KeyGeneration: 1,
+		},
+	})
+	require.NoError(t, err)
+
+	t.Logf("basic test")
+	_, msgID, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Conv:        trip,
+			Sender:      u.User.GetUID().ToBytes(),
+			TlfName:     u.Username,
+			TlfPublic:   false,
+			MessageType: chat1.MessageType_TEXT,
+		},
+		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+			Body: "HIHI",
+		}),
+	}, 0)
+	require.NoError(t, err)
+	thread, _, err := tc.G.ConvSource.Pull(context.TODO(), res.ConvID, u.User.GetUID().ToBytes(),
+		&chat1.GetThreadQuery{
+			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+		}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(thread.Messages), "wrong length")
+	require.Equal(t, msgID, thread.Messages[0].GetMessageID(), "wrong msgID")
+
+	_, editMsgID, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Conv:        trip,
+			Sender:      u.User.GetUID().ToBytes(),
+			TlfName:     u.Username,
+			TlfPublic:   false,
+			MessageType: chat1.MessageType_EDIT,
+			Supersedes:  msgID,
+		},
+		MessageBody: chat1.NewMessageBodyWithEdit(chat1.MessageEdit{
+			MessageID: msgID,
+			Body:      "EDITED",
+		}),
+	}, 0)
+	require.NoError(t, err)
+
+	t.Logf("testing an edit")
+	thread, _, err = tc.G.ConvSource.Pull(context.TODO(), res.ConvID, u.User.GetUID().ToBytes(),
+		&chat1.GetThreadQuery{
+			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+		}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(thread.Messages), "wrong length")
+	require.Equal(t, msgID, thread.Messages[0].GetMessageID(), "wrong msgID")
+	require.Equal(t, editMsgID, thread.Messages[0].Valid().ServerHeader.SupersededBy, "wrong super")
+	require.Equal(t, "EDITED", thread.Messages[0].Valid().MessageBody.Text().Body, "wrong body")
+
+	t.Logf("testing a delete")
+	_, deleteMsgID, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Conv:        trip,
+			Sender:      u.User.GetUID().ToBytes(),
+			TlfName:     u.Username,
+			TlfPublic:   false,
+			MessageType: chat1.MessageType_DELETE,
+			Supersedes:  msgID,
+		},
+		MessageBody: chat1.NewMessageBodyWithDelete(chat1.MessageDelete{
+			MessageIDs: []chat1.MessageID{msgID, editMsgID},
+		}),
+	}, 0)
+	require.NoError(t, err)
+	thread, _, err = tc.G.ConvSource.Pull(context.TODO(), res.ConvID, u.User.GetUID().ToBytes(),
+		&chat1.GetThreadQuery{
+			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+		}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(thread.Messages), "wrong length")
+
+	t.Logf("testing disabling resolve")
+	thread, _, err = tc.G.ConvSource.Pull(context.TODO(), res.ConvID, u.User.GetUID().ToBytes(),
+		&chat1.GetThreadQuery{
+			MessageTypes: []chat1.MessageType{
+				chat1.MessageType_TEXT,
+				chat1.MessageType_EDIT,
+				chat1.MessageType_DELETE},
+			DisableResolveSupersedes: true,
+		}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(thread.Messages), "wrong length")
+	require.Equal(t, msgID, thread.Messages[2].GetMessageID(), "wrong msgID")
+	require.Equal(t, deleteMsgID, thread.Messages[2].Valid().ServerHeader.SupersededBy, "wrong super")
+}

--- a/go/chat/identify_test.go
+++ b/go/chat/identify_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestChatBackgroundIdentify(t *testing.T) {
 
-	world, _, _, _, listener, _ := setupTest(t, 2)
+	world, _, _, _, listener, _, _ := setupTest(t, 2)
 	defer world.Cleanup()
 
 	u := world.GetUsers()[0]

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -210,6 +210,7 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	// Add a bunch of stuff to the message (like prev pointers, sender info, ...)
 	boxed, err := s.Prepare(ctx, msg, &convID)
 	if err != nil {
+		s.Debug(ctx, "error in Prepare: %s", err.Error())
 		return chat1.OutboxID{}, 0, nil, err
 	}
 

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 
 	"github.com/keybase/client/go/chat/storage"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -102,7 +103,8 @@ func setupTest(t *testing.T, numUsers int) (*kbtest.ChatMockWorld, chat1.RemoteI
 		identifyUpdate: make(chan keybase1.CanonicalTLFNameAndIDWithBreaks),
 	}
 	tc.G.ConvSource = NewHybridConversationSource(tc.G, boxer, storage.New(tc.G, f),
-		func() chat1.RemoteInterface { return ri })
+		func() chat1.RemoteInterface { return ri },
+		func() libkb.SecretUI { return &libkb.TestSecretUI{} })
 	tc.G.InboxSource = NewHybridInboxSource(tc.G,
 		func() keybase1.TlfInterface { return tlf },
 		func() chat1.RemoteInterface { return ri }, f)
@@ -276,7 +278,7 @@ func TestNonblockTimer(t *testing.T) {
 	typs := []chat1.MessageType{chat1.MessageType_TEXT}
 	tres, _, err := tc.G.ConvSource.Pull(context.TODO(), res.ConvID, u.User.GetUID().ToBytes(),
 		&chat1.GetThreadQuery{MessageTypes: typs}, nil)
-	tres.Messages = storage.FilterByType(tres.Messages, &chat1.GetThreadQuery{MessageTypes: typs})
+	tres.Messages = utils.FilterByType(tres.Messages, &chat1.GetThreadQuery{MessageTypes: typs})
 	t.Logf("source size: %d", len(tres.Messages))
 	require.NoError(t, err)
 	require.NoError(t, outbox.SprinkleIntoThread(context.TODO(), res.ConvID, &tres))

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -84,7 +84,7 @@ func userTc(t *testing.T, world *kbtest.ChatMockWorld, user *kbtest.FakeUser) *k
 	return &kbtest.ChatTestContext{}
 }
 
-func setupTest(t *testing.T, numUsers int) (*kbtest.ChatMockWorld, chat1.RemoteInterface, Sender, Sender, *chatListener, func() libkb.SecretUI) {
+func setupTest(t *testing.T, numUsers int) (*kbtest.ChatMockWorld, chat1.RemoteInterface, Sender, Sender, *chatListener, func() libkb.SecretUI, kbtest.TlfMock) {
 	world := kbtest.NewChatMockWorld(t, "chatsender", numUsers)
 	ri := kbtest.NewChatRemoteMock(world)
 	tlf := kbtest.NewTlfMock(world)
@@ -114,11 +114,11 @@ func setupTest(t *testing.T, numUsers int) (*kbtest.ChatMockWorld, chat1.RemoteI
 	tc.G.MessageDeliverer.Start(context.TODO(), u.User.GetUID().ToBytes())
 	tc.G.MessageDeliverer.Connected(context.TODO())
 
-	return world, ri, sender, baseSender, &listener, f
+	return world, ri, sender, baseSender, &listener, f, tlf
 }
 
 func TestNonblockChannel(t *testing.T) {
-	world, ri, sender, _, listener, _ := setupTest(t, 1)
+	world, ri, sender, _, listener, _, _ := setupTest(t, 1)
 	defer world.Cleanup()
 
 	u := world.GetUsers()[0]
@@ -186,7 +186,7 @@ func checkThread(t *testing.T, thread chat1.ThreadView, ref []sentRecord) {
 }
 
 func TestNonblockTimer(t *testing.T) {
-	world, ri, _, baseSender, listener, f := setupTest(t, 1)
+	world, ri, _, baseSender, listener, f, _ := setupTest(t, 1)
 	defer world.Cleanup()
 
 	u := world.GetUsers()[0]
@@ -321,7 +321,7 @@ func (f FailingSender) Prepare(ctx context.Context, msg chat1.MessagePlaintext, 
 
 func TestFailingSender(t *testing.T) {
 
-	world, ri, sender, _, listener, _ := setupTest(t, 1)
+	world, ri, sender, _, listener, _, _ := setupTest(t, 1)
 	defer world.Cleanup()
 
 	u := world.GetUsers()[0]
@@ -377,7 +377,7 @@ func TestFailingSender(t *testing.T) {
 
 func TestDisconnectedFailure(t *testing.T) {
 
-	world, ri, sender, baseSender, listener, _ := setupTest(t, 1)
+	world, ri, sender, baseSender, listener, _, _ := setupTest(t, 1)
 	defer world.Cleanup()
 
 	u := world.GetUsers()[0]

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -315,8 +315,8 @@ func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, convID chat1.Convers
 
 	// Figure out how to determine we are done seeking
 	var rc resultCollector
-	s.Debug(ctx, "Fetch: types: %v", query.MessageTypes)
 	if query != nil && len(query.MessageTypes) > 0 {
+		s.Debug(ctx, "Fetch: types: %v", query.MessageTypes)
 		rc = newTypedResultCollector(num, query.MessageTypes)
 	} else {
 		rc = newSimpleResultCollector(num)

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -207,25 +207,6 @@ func (s *Storage) Merge(ctx context.Context, convID chat1.ConversationID, uid gr
 	return nil
 }
 
-// getSupersedes must be called with a valid msg
-func (s *Storage) getSupersedes(msg chat1.MessageUnboxed) ([]chat1.MessageID, Error) {
-	body := msg.Valid().MessageBody
-	typ, err := body.MessageType()
-	if err != nil {
-		return nil, NewInternalError(s.DebugLabeler, "invalid msg: %s", err.Error())
-	}
-
-	// We use the message ID in the body over the field in the client header to avoid server trust.
-	switch typ {
-	case chat1.MessageType_EDIT:
-		return []chat1.MessageID{msg.Valid().MessageBody.Edit().MessageID}, nil
-	case chat1.MessageType_DELETE:
-		return msg.Valid().MessageBody.Delete().MessageIDs, nil
-	default:
-		return nil, nil
-	}
-}
-
 func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.ConversationID,
 	uid gregor1.UID, msgs []chat1.MessageUnboxed) Error {
 
@@ -239,8 +220,8 @@ func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.Conver
 			continue
 		}
 
-		superIDs, err := s.getSupersedes(msg)
-		if err != nil {
+		superIDs, ierr := utils.GetSupersedes(msg)
+		if ierr != nil {
 			continue
 		}
 		s.Debug(ctx, "updateSupersededBy: supersedes: %v", superIDs)
@@ -251,7 +232,7 @@ func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.Conver
 			// Read super msg
 			var superMsgs []chat1.MessageUnboxed
 			rc := newSimpleResultCollector(1)
-			err = s.engine.readMessages(ctx, rc, convID, uid, superID)
+			err := s.engine.readMessages(ctx, rc, convID, uid, superID)
 			if err != nil {
 				// If we don't have the message, just keep going
 				if _, ok := err.(MissError); ok {
@@ -334,6 +315,7 @@ func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, convID chat1.Convers
 
 	// Figure out how to determine we are done seeking
 	var rc resultCollector
+	s.Debug(ctx, "Fetch: types: %v", query.MessageTypes)
 	if query != nil && len(query.MessageTypes) > 0 {
 		rc = newTypedResultCollector(num, query.MessageTypes)
 	} else {
@@ -422,21 +404,4 @@ func (s *Storage) FetchMessages(ctx context.Context, convID chat1.ConversationID
 	}
 
 	return res, nil
-}
-
-func FilterByType(msgs []chat1.MessageUnboxed, query *chat1.GetThreadQuery) (res []chat1.MessageUnboxed) {
-	if query != nil && len(query.MessageTypes) > 0 {
-		typmap := make(map[chat1.MessageType]bool)
-		for _, mt := range query.MessageTypes {
-			typmap[mt] = true
-		}
-		for _, msg := range msgs {
-			if _, ok := typmap[msg.GetMessageType()]; ok {
-				res = append(res, msg)
-			}
-		}
-	} else {
-		res = msgs
-	}
-	return res
 }

--- a/go/chat/storage/storage_test.go
+++ b/go/chat/storage/storage_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/chat/pager"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
@@ -415,7 +416,7 @@ func TestStorageTypeFilter(t *testing.T) {
 	res, err := storage.Fetch(context.TODO(), conv, uid, &query, nil)
 	require.NoError(t, err)
 	require.Equal(t, len(msgs), len(res.Messages), "wrong amount of messages")
-	restexts := FilterByType(res.Messages, &query)
+	restexts := utils.FilterByType(res.Messages, &query)
 	require.Equal(t, len(textmsgs), len(restexts), "wrong amount of text messages")
 	for i := 0; i < len(restexts); i++ {
 		require.Equal(t, textmsgs[i].GetMessageID(), restexts[i].GetMessageID(), "msg mismatch")

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -1,0 +1,113 @@
+package chat
+
+import (
+	"context"
+
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+)
+
+type supersedesTransform struct {
+	libkb.Contextified
+	utils.DebugLabeler
+}
+
+func newSupersedesTransform(g *libkb.GlobalContext) *supersedesTransform {
+	return &supersedesTransform{
+		Contextified: libkb.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "supersedesTransform", false),
+	}
+}
+
+func (t *supersedesTransform) transformEdit(msg chat1.MessageUnboxed, superMsg chat1.MessageUnboxed) *chat1.MessageUnboxed {
+	clientHeader := msg.Valid().ClientHeader
+	clientHeader.MessageType = chat1.MessageType_TEXT
+	newMsg := chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
+		ClientHeader: clientHeader,
+		ServerHeader: msg.Valid().ServerHeader,
+		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+			Body: superMsg.Valid().MessageBody.Edit().Body,
+		}),
+		SenderUsername:        msg.Valid().SenderUsername,
+		SenderDeviceName:      msg.Valid().SenderDeviceName,
+		SenderDeviceType:      msg.Valid().SenderDeviceType,
+		HeaderHash:            msg.Valid().HeaderHash,
+		HeaderSignature:       msg.Valid().HeaderSignature,
+		SenderDeviceRevokedAt: msg.Valid().SenderDeviceRevokedAt,
+	})
+	return &newMsg
+}
+
+func (t *supersedesTransform) transform(ctx context.Context, msg chat1.MessageUnboxed,
+	superMsg chat1.MessageUnboxed) *chat1.MessageUnboxed {
+
+	switch superMsg.GetMessageType() {
+	case chat1.MessageType_DELETE:
+		return nil
+	case chat1.MessageType_EDIT:
+		return t.transformEdit(msg, superMsg)
+	}
+
+	return &msg
+}
+
+func (t *supersedesTransform) run(ctx context.Context,
+	convID chat1.ConversationID, uid gregor1.UID, thread *chat1.ThreadView,
+	finalizeInfo *chat1.ConversationFinalizeInfo) error {
+
+	var superMsgIDs []chat1.MessageID
+	smap := make(map[chat1.MessageID]chat1.MessageUnboxed)
+
+	// Collect all superseder messages for messages in the current thread view
+	for _, msg := range thread.Messages {
+		if msg.IsValid() {
+			supersededBy := msg.Valid().ServerHeader.SupersededBy
+			if supersededBy > 0 {
+				superMsgIDs = append(superMsgIDs, supersededBy)
+			}
+		}
+	}
+
+	// Get superseding messages
+	msgs, err := t.G().ConvSource.GetMessages(ctx, convID, uid, superMsgIDs, finalizeInfo)
+	if err != nil {
+		return err
+	}
+	for _, m := range msgs {
+		if m.IsValid() {
+			supers, err := utils.GetSupersedes(m)
+			if err != nil {
+				continue
+			}
+			for _, super := range supers {
+				smap[super] = m
+			}
+		}
+	}
+
+	// Run through all messages and transform superseded messages into final state
+	var newMsgs []chat1.MessageUnboxed
+	for _, msg := range thread.Messages {
+		if msg.IsValid() {
+			// If the message is superseded, then transform it and add that
+			if superMsg, ok := smap[msg.GetMessageID()]; ok {
+				t.Debug(ctx, "transforming: msgID: %d superMsgID: %d", msg.GetMessageID(),
+					superMsg.GetMessageID())
+				newMsg := t.transform(ctx, msg, superMsg)
+				if newMsg != nil {
+					// Might be a delete, so check if transform returned anything
+					newMsgs = append(newMsgs, *newMsg)
+				}
+			} else {
+				newMsgs = append(newMsgs, msg)
+			}
+		} else {
+			newMsgs = append(newMsgs, msg)
+		}
+	}
+	thread.Messages = newMsgs
+
+	return nil
+}

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -530,6 +530,16 @@ func (m *ChatRemoteMock) insertMsgAndSort(convID chat1.ConversationID, msg chat1
 	}
 	m.world.Msgs[convID.String()] = append(m.world.Msgs[convID.String()], &msg)
 	sort.Sort(msgByMessageIDDesc{world: m.world, convID: convID})
+
+	// If this message supersedes something, track it down and set supersededBy
+	if msg.ClientHeader.Supersedes > 0 {
+		for _, wmsg := range m.world.Msgs[convID.String()] {
+			if wmsg.GetMessageID() == msg.ClientHeader.Supersedes {
+				wmsg.ServerHeader.SupersededBy = msg.GetMessageID()
+			}
+		}
+	}
+
 	return msg
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -746,11 +746,11 @@ type ThreadView struct {
 }
 
 type GetThreadQuery struct {
-	MarkAsRead        bool          `codec:"markAsRead" json:"markAsRead"`
-	MessageTypes      []MessageType `codec:"messageTypes" json:"messageTypes"`
-	ResolveSupersedes bool          `codec:"resolveSupersedes" json:"resolveSupersedes"`
-	Before            *gregor1.Time `codec:"before,omitempty" json:"before,omitempty"`
-	After             *gregor1.Time `codec:"after,omitempty" json:"after,omitempty"`
+	MarkAsRead               bool          `codec:"markAsRead" json:"markAsRead"`
+	MessageTypes             []MessageType `codec:"messageTypes" json:"messageTypes"`
+	DisableResolveSupersedes bool          `codec:"disableResolveSupersedes" json:"disableResolveSupersedes"`
+	Before                   *gregor1.Time `codec:"before,omitempty" json:"before,omitempty"`
+	After                    *gregor1.Time `codec:"after,omitempty" json:"after,omitempty"`
 }
 
 type GetThreadLocalRes struct {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -746,10 +746,11 @@ type ThreadView struct {
 }
 
 type GetThreadQuery struct {
-	MarkAsRead   bool          `codec:"markAsRead" json:"markAsRead"`
-	MessageTypes []MessageType `codec:"messageTypes" json:"messageTypes"`
-	Before       *gregor1.Time `codec:"before,omitempty" json:"before,omitempty"`
-	After        *gregor1.Time `codec:"after,omitempty" json:"after,omitempty"`
+	MarkAsRead        bool          `codec:"markAsRead" json:"markAsRead"`
+	MessageTypes      []MessageType `codec:"messageTypes" json:"messageTypes"`
+	ResolveSupersedes bool          `codec:"resolveSupersedes" json:"resolveSupersedes"`
+	Before            *gregor1.Time `codec:"before,omitempty" json:"before,omitempty"`
+	After             *gregor1.Time `codec:"after,omitempty" json:"after,omitempty"`
 }
 
 type GetThreadLocalRes struct {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -480,7 +480,6 @@ func (h *chatLocalHandler) GetConversationForCLILocal(ctx context.Context, arg c
 		query.After = &gsince
 	}
 
-	query.ResolveSupersedes = true
 	tv, err := h.GetThreadLocal(ctx, chat1.GetThreadLocalArg{
 		ConversationID:   convLocal.Info.Id,
 		Query:            &query,

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -205,26 +205,6 @@ func (h *chatLocalHandler) GetThreadLocal(ctx context.Context, arg chat1.GetThre
 		return chat1.GetThreadLocalRes{}, err
 	}
 
-	// Sanity check the prev pointers in this thread.
-	// TODO: We'll do this against what's in the cache once that's ready,
-	//       rather than only checking the messages we just fetched against
-	//       each other.
-	_, err = chat.CheckPrevPointersAndGetUnpreved(&thread)
-	if err != nil {
-		return chat1.GetThreadLocalRes{}, err
-	}
-
-	// Run type filter if it exists
-	thread.Messages = storage.FilterByType(thread.Messages, arg.Query)
-
-	// Fetch outbox and tack onto the result
-	outbox := storage.NewOutbox(h.G(), uid.ToBytes(), h.getSecretUI)
-	if err = outbox.SprinkleIntoThread(ctx, arg.ConversationID, &thread); err != nil {
-		if _, ok := err.(storage.MissError); !ok {
-			return chat1.GetThreadLocalRes{}, err
-		}
-	}
-
 	return chat1.GetThreadLocalRes{
 		Thread:           thread,
 		RateLimits:       utils.AggRateLimitsP(rl),
@@ -500,6 +480,7 @@ func (h *chatLocalHandler) GetConversationForCLILocal(ctx context.Context, arg c
 		query.After = &gsince
 	}
 
+	query.ResolveSupersedes = true
 	tv, err := h.GetThreadLocal(ctx, chat1.GetThreadLocalArg{
 		ConversationID:   convLocal.Info.Id,
 		Query:            &query,

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -78,7 +78,8 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	}
 	storage := storage.New(tc.G, f)
 	tc.G.ConvSource = chat.NewHybridConversationSource(tc.G, h.boxer, storage,
-		func() chat1.RemoteInterface { return mockRemote })
+		func() chat1.RemoteInterface { return mockRemote },
+		func() libkb.SecretUI { return &libkb.TestSecretUI{} })
 	tc.G.InboxSource = chat.NewHybridInboxSource(tc.G,
 		func() keybase1.TlfInterface { return h.tlf },
 		func() chat1.RemoteInterface { return mockRemote },

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -270,7 +270,7 @@ func (d *Service) createChatSources() {
 		ri, si, func() keybase1.TlfInterface { return tlf })
 
 	d.G().ConvSource = chat.NewConversationSource(d.G(), d.G().Env.GetConvSourceType(),
-		boxer, storage.New(d.G(), si), ri)
+		boxer, storage.New(d.G(), si), ri, si)
 
 	// Add a tlfHandler into the user changed handler group so we can keep identify info
 	// fresh

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -275,7 +275,8 @@ protocol local {
   record GetThreadQuery {
     boolean markAsRead;
     array<MessageType> messageTypes;
-    boolean resolveSupersedes;
+    boolean disableResolveSupersedes;
+    
     union { null, gregor1.Time } before;
     union { null, gregor1.Time } after;
   }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -275,6 +275,7 @@ protocol local {
   record GetThreadQuery {
     boolean markAsRead;
     array<MessageType> messageTypes;
+    boolean resolveSupersedes;
     union { null, gregor1.Time } before;
     union { null, gregor1.Time } after;
   }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -848,7 +848,7 @@ export type GetThreadLocalRes = {
 export type GetThreadQuery = {
   markAsRead: boolean,
   messageTypes?: ?Array<MessageType>,
-  resolveSupersedes: boolean,
+  disableResolveSupersedes: boolean,
   before?: ?gregor1.Time,
   after?: ?gregor1.Time,
 }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -848,6 +848,7 @@ export type GetThreadLocalRes = {
 export type GetThreadQuery = {
   markAsRead: boolean,
   messageTypes?: ?Array<MessageType>,
+  resolveSupersedes: boolean,
   before?: ?gregor1.Time,
   after?: ?gregor1.Time,
 }

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -826,6 +826,10 @@
           "name": "messageTypes"
         },
         {
+          "type": "boolean",
+          "name": "resolveSupersedes"
+        },
+        {
           "type": [
             null,
             "gregor1.Time"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -827,7 +827,7 @@
         },
         {
           "type": "boolean",
-          "name": "resolveSupersedes"
+          "name": "disableResolveSupersedes"
         },
         {
           "type": [

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -848,7 +848,7 @@ export type GetThreadLocalRes = {
 export type GetThreadQuery = {
   markAsRead: boolean,
   messageTypes?: ?Array<MessageType>,
-  resolveSupersedes: boolean,
+  disableResolveSupersedes: boolean,
   before?: ?gregor1.Time,
   after?: ?gregor1.Time,
 }

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -848,6 +848,7 @@ export type GetThreadLocalRes = {
 export type GetThreadQuery = {
   markAsRead: boolean,
   messageTypes?: ?Array<MessageType>,
+  resolveSupersedes: boolean,
   before?: ?gregor1.Time,
   after?: ?gregor1.Time,
 }


### PR DESCRIPTION
This patch makes it so that calls into `GetThreadLocal` will by default "resolve" all superseding message types (edit and delete). It can be disabled with a parameter. This behavior also applies to `MaxMessages` when we are in the localization pipeline for inbox sources. This allows us to strip out all code from the client dealing with this, and fully rely on service level code. 

This also fixes up the remote mock testing to properly handle edits and deletes.