### PR TITLE
make explicit proof state for sighints not found

### DIFF
--- a/go/engine/track_proof_test.go
+++ b/go/engine/track_proof_test.go
@@ -339,11 +339,11 @@ func TestTrackProofRooterFail(t *testing.T) {
 	trackUser := CreateAndSignupFakeUser(tc, "track")
 
 	// proveRooterFail posts a bad sig id, so it won't be found.
-	// thus the state is ProofState_NONE
+	// thus the state is ProofState_SIG_HINT_MISSING
 	rbl := sb{
 		social:     true,
 		id:         proofUser.Username + "@rooter",
-		proofState: keybase1.ProofState_NONE,
+		proofState: keybase1.ProofState_SIG_HINT_MISSING,
 	}
 	outcome := keybase1.IdentifyOutcome{
 		NumProofFailures: 1,

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -35,11 +35,15 @@ func ProofErrorToState(pe ProofError) keybase1.ProofState {
 		return keybase1.ProofState_OK
 	}
 
-	if s := pe.GetProofStatus(); s == keybase1.ProofStatus_NO_HINT || s == keybase1.ProofStatus_UNKNOWN_TYPE {
-		return keybase1.ProofState_NONE
+	switch pe.GetProofStatus() {
+	case keybase1.ProofStatus_NO_HINT:
+		return keybase1.ProofState_SIG_HINT_MISSING
+	case keybase1.ProofStatus_UNKNOWN_TYPE:
+		return keybase1.ProofState_UNKNOWN_TYPE
+	default:
+		return keybase1.ProofState_TEMP_FAILURE
 	}
 
-	return keybase1.ProofState_TEMP_FAILURE
 }
 
 type ProofErrorImpl struct {

--- a/go/protocol/keybase1/prove_common.go
+++ b/go/protocol/keybase1/prove_common.go
@@ -10,39 +10,45 @@ import (
 type ProofState int
 
 const (
-	ProofState_NONE         ProofState = 0
-	ProofState_OK           ProofState = 1
-	ProofState_TEMP_FAILURE ProofState = 2
-	ProofState_PERM_FAILURE ProofState = 3
-	ProofState_LOOKING      ProofState = 4
-	ProofState_SUPERSEDED   ProofState = 5
-	ProofState_POSTED       ProofState = 6
-	ProofState_REVOKED      ProofState = 7
-	ProofState_DELETED      ProofState = 8
+	ProofState_NONE             ProofState = 0
+	ProofState_OK               ProofState = 1
+	ProofState_TEMP_FAILURE     ProofState = 2
+	ProofState_PERM_FAILURE     ProofState = 3
+	ProofState_LOOKING          ProofState = 4
+	ProofState_SUPERSEDED       ProofState = 5
+	ProofState_POSTED           ProofState = 6
+	ProofState_REVOKED          ProofState = 7
+	ProofState_DELETED          ProofState = 8
+	ProofState_UNKNOWN_TYPE     ProofState = 9
+	ProofState_SIG_HINT_MISSING ProofState = 10
 )
 
 var ProofStateMap = map[string]ProofState{
-	"NONE":         0,
-	"OK":           1,
-	"TEMP_FAILURE": 2,
-	"PERM_FAILURE": 3,
-	"LOOKING":      4,
-	"SUPERSEDED":   5,
-	"POSTED":       6,
-	"REVOKED":      7,
-	"DELETED":      8,
+	"NONE":             0,
+	"OK":               1,
+	"TEMP_FAILURE":     2,
+	"PERM_FAILURE":     3,
+	"LOOKING":          4,
+	"SUPERSEDED":       5,
+	"POSTED":           6,
+	"REVOKED":          7,
+	"DELETED":          8,
+	"UNKNOWN_TYPE":     9,
+	"SIG_HINT_MISSING": 10,
 }
 
 var ProofStateRevMap = map[ProofState]string{
-	0: "NONE",
-	1: "OK",
-	2: "TEMP_FAILURE",
-	3: "PERM_FAILURE",
-	4: "LOOKING",
-	5: "SUPERSEDED",
-	6: "POSTED",
-	7: "REVOKED",
-	8: "DELETED",
+	0:  "NONE",
+	1:  "OK",
+	2:  "TEMP_FAILURE",
+	3:  "PERM_FAILURE",
+	4:  "LOOKING",
+	5:  "SUPERSEDED",
+	6:  "POSTED",
+	7:  "REVOKED",
+	8:  "DELETED",
+	9:  "UNKNOWN_TYPE",
+	10: "SIG_HINT_MISSING",
 }
 
 func (e ProofState) String() string {

--- a/protocol/avdl/keybase1/prove_common.avdl
+++ b/protocol/avdl/keybase1/prove_common.avdl
@@ -10,7 +10,9 @@ protocol proveCommon {
     SUPERSEDED_5,
     POSTED_6,
     REVOKED_7,
-    DELETED_8
+    DELETED_8,
+    UNKNOWN_TYPE_9,
+    SIG_HINT_MISSING_10
   }
 
   /**

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -316,6 +316,8 @@ export const ProveCommonProofState = {
   posted: 6,
   revoked: 7,
   deleted: 8,
+  unknownType: 9,
+  sigHintMissing: 10,
 }
 
 export const ProveCommonProofStatus = {
@@ -3681,6 +3683,8 @@ export type ProofState =
   | 6 // POSTED_6
   | 7 // REVOKED_7
   | 8 // DELETED_8
+  | 9 // UNKNOWN_TYPE_9
+  | 10 // SIG_HINT_MISSING_10
 
 export type ProofStatus = 
     0 // NONE_0

--- a/protocol/json/keybase1/prove_common.json
+++ b/protocol/json/keybase1/prove_common.json
@@ -14,7 +14,9 @@
         "SUPERSEDED_5",
         "POSTED_6",
         "REVOKED_7",
-        "DELETED_8"
+        "DELETED_8",
+        "UNKNOWN_TYPE_9",
+        "SIG_HINT_MISSING_10"
       ]
     },
     {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -316,6 +316,8 @@ export const ProveCommonProofState = {
   posted: 6,
   revoked: 7,
   deleted: 8,
+  unknownType: 9,
+  sigHintMissing: 10,
 }
 
 export const ProveCommonProofStatus = {
@@ -3681,6 +3683,8 @@ export type ProofState =
   | 6 // POSTED_6
   | 7 // REVOKED_7
   | 8 // DELETED_8
+  | 9 // UNKNOWN_TYPE_9
+  | 10 // SIG_HINT_MISSING_10
 
 export type ProofStatus = 
     0 // NONE_0


### PR DESCRIPTION
- we saw buggy behavior because previously sighint not found and unknown proof type were ProofState_NONE, which
  was the same proof state as an unspecified temporary (snoozed) track. which produced weird output like this:

```
<snoozed> "candrencil2" on twitter failed: No server-given hint for sig=edd000917165e5ce2e3415289e3570ff670a5e07fa5f7a9d0fa1c3a0a5239cb60f (code=306) [failure temporarily ignored until 0001-01-01 00:00:00 UTC]
```