### PR TITLE
filter unverified inbox before sending to frontend CORE-4461

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -159,16 +159,19 @@ func (b *NonblockingLocalizer) filterInboxRes(ctx context.Context, inbox chat1.I
 	var res []chat1.Conversation
 	for _, conv := range inbox.ConvsUnverified {
 		localConv := cmap[conv.GetConvID().String()]
-		if localConv.IsEmpty {
-			b.Debug(ctx, "filterInboxRes: skipping because empty: convID: %s", conv.GetConvID())
-			continue
-		}
+
 		if localConv.Error != nil &&
 			localConv.Error.Typ != chat1.ConversationErrorType_LOCALMAXMESSAGENOTFOUND {
 			b.Debug(ctx, "filterInboxRes: skipping because error: convID: %s err: %s", conv.GetConvID(),
 				localConv.Error.Message)
 			continue
 		}
+
+		if localConv.IsEmpty {
+			b.Debug(ctx, "filterInboxRes: skipping because empty: convID: %s", conv.GetConvID())
+			continue
+		}
+
 		res = append(res, conv)
 	}
 
@@ -774,7 +777,6 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		}
 	}
 	conversationLocal.MaxMessages = newMaxMsgs
-
 	if len(conversationLocal.Info.TlfName) == 0 {
 		errMsg := "no valid message in the conversation"
 		conversationLocal.Error = &chat1.ConversationErrorLocal{

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -16,11 +16,21 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+type getMessagesRes struct {
+	err    error
+	errTyp chat1.ConversationErrorType
+	msgs   []chat1.MessageUnboxed
+}
+
+type getMessagesFunc func(context.Context, chat1.ConversationID, gregor1.UID, []chat1.MessageBoxed,
+	*chat1.ConversationFinalizeInfo) getMessagesRes
+
 type localizerPipeline struct {
 	libkb.Contextified
 	utils.DebugLabeler
 
 	getTlfInterface func() keybase1.TlfInterface
+	getMessages     getMessagesFunc
 }
 
 func newLocalizerPipeline(g *libkb.GlobalContext, getTlfInterface func() keybase1.TlfInterface) *localizerPipeline {
@@ -28,6 +38,16 @@ func newLocalizerPipeline(g *libkb.GlobalContext, getTlfInterface func() keybase
 		Contextified:    libkb.NewContextified(g),
 		DebugLabeler:    utils.NewDebugLabeler(g, "localizerPipeline", false),
 		getTlfInterface: getTlfInterface,
+	}
+}
+
+func newLocalizerPipelineCustom(g *libkb.GlobalContext, getTlfInterface func() keybase1.TlfInterface,
+	getMessages getMessagesFunc) *localizerPipeline {
+	return &localizerPipeline{
+		Contextified:    libkb.NewContextified(g),
+		DebugLabeler:    utils.NewDebugLabeler(g, "localizerPipeline", false),
+		getTlfInterface: getTlfInterface,
+		getMessages:     getMessages,
 	}
 }
 
@@ -66,6 +86,8 @@ type NonblockInboxResult struct {
 
 type NonblockingLocalizer struct {
 	libkb.Contextified
+	utils.DebugLabeler
+
 	pipeline   *localizerPipeline
 	localizeCb chan NonblockInboxResult
 }
@@ -74,15 +96,97 @@ func NewNonblockingLocalizer(g *libkb.GlobalContext, localizeCb chan NonblockInb
 	getTlfInterface func() keybase1.TlfInterface) *NonblockingLocalizer {
 	return &NonblockingLocalizer{
 		Contextified: libkb.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "NonblockingLocalizer", false),
 		pipeline:     newLocalizerPipeline(g, getTlfInterface),
 		localizeCb:   localizeCb,
 	}
 }
 
+func (b *NonblockingLocalizer) filterInboxRes(ctx context.Context, inbox chat1.Inbox, uid gregor1.UID) chat1.Inbox {
+
+	f := func(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
+		msgs []chat1.MessageBoxed, finalizeInfo *chat1.ConversationFinalizeInfo) getMessagesRes {
+
+		var msgIDs []chat1.MessageID
+		for _, msg := range msgs {
+			msgIDs = append(msgIDs, msg.GetMessageID())
+		}
+
+		st := storage.New(b.G(), func() libkb.SecretUI { return DelivererSecretUI{} })
+		res, err := st.FetchMessages(ctx, convID, uid, msgIDs)
+		if err != nil {
+			// Just say we didn't find it in this case
+			return getMessagesRes{
+				err:    err,
+				errTyp: chat1.ConversationErrorType_LOCALMAXMESSAGENOTFOUND,
+			}
+		}
+
+		// Make sure we get them all
+		var foundMsgs []chat1.MessageUnboxed
+		for _, msg := range res {
+			if msg != nil {
+				foundMsgs = append(foundMsgs, *msg)
+			}
+		}
+		if len(foundMsgs) != len(msgs) {
+			return getMessagesRes{
+				err:    errors.New("missing messages locally"),
+				errTyp: chat1.ConversationErrorType_LOCALMAXMESSAGENOTFOUND,
+			}
+		}
+
+		return getMessagesRes{
+			msgs: foundMsgs,
+		}
+	}
+
+	localizer := newLocalizerPipelineCustom(b.G(), b.pipeline.getTlfInterface, f)
+	convs, err := localizer.localizeConversationsPipeline(ctx, uid, inbox.ConvsUnverified, nil)
+	if err != nil {
+		// Any errors we just return original inbox
+		b.Debug(ctx, "filterInboxRes: error running localize pipeline: %s", err.Error())
+		return inbox
+	}
+
+	cmap := make(map[string]chat1.ConversationLocal)
+	for _, conv := range convs {
+		cmap[conv.GetConvID().String()] = conv
+	}
+
+	// Loop through and look for empty convs or known errors and skip them
+	var res []chat1.Conversation
+	for _, conv := range inbox.ConvsUnverified {
+		localConv := cmap[conv.GetConvID().String()]
+		if localConv.IsEmpty {
+			b.Debug(ctx, "filterInboxRes: skipping because empty: convID: %s", conv.GetConvID())
+			continue
+		}
+		if localConv.Error != nil &&
+			localConv.Error.Typ != chat1.ConversationErrorType_LOCALMAXMESSAGENOTFOUND {
+			b.Debug(ctx, "filterInboxRes: skipping because error: convID: %s err: %s", conv.GetConvID(),
+				localConv.Error.Message)
+			continue
+		}
+		res = append(res, conv)
+	}
+
+	return chat1.Inbox{
+		Version:         inbox.Version,
+		ConvsUnverified: res,
+		Convs:           inbox.Convs,
+		Pagination:      inbox.Pagination,
+	}
+}
+
 func (b *NonblockingLocalizer) Localize(ctx context.Context, uid gregor1.UID, inbox chat1.Inbox) ([]chat1.ConversationLocal, error) {
+
+	// Run some easy filters for empty messages and known errors to optimize UI drawing behavior
+	filteredInbox := b.filterInboxRes(ctx, inbox, uid)
+
 	// Send inbox over localize channel
 	b.localizeCb <- NonblockInboxResult{
-		InboxRes: &inbox,
+		InboxRes: &filteredInbox,
 	}
 
 	// Spawn off localization into its own goroutine and use cb to communicate with outside world
@@ -584,16 +688,43 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		return conversationLocal
 	}
 
-	var err error
-	conversationLocal.MaxMessages, err = s.G().ConvSource.GetMessagesWithRemotes(ctx,
-		conversationRemote.Metadata.ConversationID, uid, conversationRemote.MaxMsgs, conversationRemote.Metadata.FinalizeInfo)
-	if err != nil {
-		conversationLocal.Error = &chat1.ConversationErrorLocal{
-			Message:    err.Error(),
-			RemoteConv: conversationRemote,
-			Permanent:  s.isErrPermanent(err),
+	// Set empty to an initial value before the real one in case we hit an error processing
+	// max messages
+	conversationLocal.IsEmpty = true
+	for _, maxMsg := range conversationRemote.MaxMsgs {
+		if utils.IsVisibleChatMessageType(maxMsg.GetMessageType()) {
+			conversationLocal.IsEmpty = false
+			break
 		}
-		return conversationLocal
+	}
+
+	// Fetch max messages unboxed, using either a custom function or through
+	// the conversation source configured in the global context
+	var err error
+	if s.getMessages != nil {
+		gmRes := s.getMessages(ctx, conversationRemote.GetConvID(),
+			uid, conversationRemote.MaxMsgs, conversationRemote.Metadata.FinalizeInfo)
+		if gmRes.err != nil {
+			conversationLocal.Error = &chat1.ConversationErrorLocal{
+				Message:    gmRes.err.Error(),
+				RemoteConv: conversationRemote,
+				Permanent:  s.isErrPermanent(gmRes.err),
+				Typ:        gmRes.errTyp,
+			}
+			return conversationLocal
+		}
+		conversationLocal.MaxMessages = gmRes.msgs
+	} else {
+		conversationLocal.MaxMessages, err = s.G().ConvSource.GetMessagesWithRemotes(ctx,
+			conversationRemote.Metadata.ConversationID, uid, conversationRemote.MaxMsgs, conversationRemote.Metadata.FinalizeInfo)
+		if err != nil {
+			conversationLocal.Error = &chat1.ConversationErrorLocal{
+				Message:    err.Error(),
+				RemoteConv: conversationRemote,
+				Permanent:  s.isErrPermanent(err),
+			}
+			return conversationLocal
+		}
 	}
 
 	// Set to true later if visible messages are in max messages.

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -129,6 +129,7 @@ func (b *NonblockingLocalizer) filterInboxRes(ctx context.Context, inbox chat1.I
 				foundMsgs = append(foundMsgs, *msg)
 			}
 		}
+
 		if len(foundMsgs) != len(msgs) {
 			return getMessagesRes{
 				err:    errors.New("missing messages locally"),
@@ -609,6 +610,8 @@ func (s *localizerPipeline) localizeConversationsPipeline(ctx context.Context, u
 				// If a localize callback channel exists, send along the result as well
 				if localizeCb != nil {
 					if convLocal.Error != nil {
+						s.Debug(ctx, "error localizing: convID: %s err: %s", conv.conv.GetConvID(),
+							convLocal.Error.Message)
 						*localizeCb <- NonblockInboxResult{
 							Err:    errors.New(convLocal.Error.Message),
 							ConvID: conv.conv.Metadata.ConversationID,

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -672,8 +672,12 @@ func (i *Inbox) ReadMessage(ctx context.Context, vers chat1.InboxVers, convID ch
 	}
 
 	// Update conv
-	conv.ReaderInfo.Mtime = gregor1.ToTime(time.Now())
-	conv.ReaderInfo.ReadMsgid = msgID
+	if conv.ReaderInfo.ReadMsgid < msgID {
+		i.Debug(ctx, "ReadMessage: updating mtime: readMsgID: %d msgID: %d", conv.ReaderInfo.ReadMsgid,
+			msgID)
+		conv.ReaderInfo.Mtime = gregor1.ToTime(time.Now())
+		conv.ReaderInfo.ReadMsgid = msgID
+	}
 
 	// Write out to disk
 	ibox.InboxVersion = vers

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -22,7 +22,7 @@ import (
 	"github.com/keybase/client/go/protocol/gregor1"
 )
 
-const inboxVersion = 3
+const inboxVersion = 4
 
 type queryHash []byte
 

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -69,6 +69,9 @@ func (t *supersedesTransform) run(ctx context.Context,
 			}
 		}
 	}
+	if len(superMsgIDs) == 0 {
+		return originalMsgs, nil
+	}
 
 	// Get superseding messages
 	msgs, err := t.G().ConvSource.GetMessages(ctx, convID, uid, superMsgIDs, finalizeInfo)

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -723,10 +723,47 @@ type ConversationInfoLocal struct {
 	FinalizeInfo *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
 }
 
+type ConversationErrorType int
+
+const (
+	ConversationErrorType_MISC                    ConversationErrorType = 0
+	ConversationErrorType_MISSINGINFO             ConversationErrorType = 1
+	ConversationErrorType_SELFREKEYNEEDED         ConversationErrorType = 2
+	ConversationErrorType_OTHERREKEYNEEDED        ConversationErrorType = 3
+	ConversationErrorType_IDENTIFY                ConversationErrorType = 4
+	ConversationErrorType_LOCALMAXMESSAGENOTFOUND ConversationErrorType = 5
+)
+
+var ConversationErrorTypeMap = map[string]ConversationErrorType{
+	"MISC":                    0,
+	"MISSINGINFO":             1,
+	"SELFREKEYNEEDED":         2,
+	"OTHERREKEYNEEDED":        3,
+	"IDENTIFY":                4,
+	"LOCALMAXMESSAGENOTFOUND": 5,
+}
+
+var ConversationErrorTypeRevMap = map[ConversationErrorType]string{
+	0: "MISC",
+	1: "MISSINGINFO",
+	2: "SELFREKEYNEEDED",
+	3: "OTHERREKEYNEEDED",
+	4: "IDENTIFY",
+	5: "LOCALMAXMESSAGENOTFOUND",
+}
+
+func (e ConversationErrorType) String() string {
+	if v, ok := ConversationErrorTypeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type ConversationErrorLocal struct {
-	Message    string       `codec:"message" json:"message"`
-	RemoteConv Conversation `codec:"remoteConv" json:"remoteConv"`
-	Permanent  bool         `codec:"permanent" json:"permanent"`
+	Typ        ConversationErrorType `codec:"typ" json:"typ"`
+	Message    string                `codec:"message" json:"message"`
+	RemoteConv Conversation          `codec:"remoteConv" json:"remoteConv"`
+	Permanent  bool                  `codec:"permanent" json:"permanent"`
 }
 
 type ConversationLocal struct {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -240,7 +240,17 @@ protocol local {
     union { null, ConversationFinalizeInfo } finalizeInfo;
   }
 
+  enum ConversationErrorType {
+    MISC_0,
+    MISSINGINFO_1,
+    SELFREKEYNEEDED_2,
+    OTHERREKEYNEEDED_3,
+    IDENTIFY_4,
+    LOCALMAXMESSAGENOTFOUND_5 // special use-case internally
+  }
+
   record ConversationErrorLocal {
+    ConversationErrorType typ;
     string message;
     Conversation remoteConv;
     boolean permanent;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -98,6 +98,15 @@ export const LocalBodyPlaintextVersion = {
   v1: 1,
 }
 
+export const LocalConversationErrorType = {
+  misc: 0,
+  missinginfo: 1,
+  selfrekeyneeded: 2,
+  otherrekeyneeded: 3,
+  identify: 4,
+  localmaxmessagenotfound: 5,
+}
+
 export const LocalHeaderPlaintextVersion = {
   v1: 1,
 }
@@ -637,10 +646,19 @@ export type Conversation = {
 }
 
 export type ConversationErrorLocal = {
+  typ: ConversationErrorType,
   message: string,
   remoteConv: Conversation,
   permanent: boolean,
 }
+
+export type ConversationErrorType = 
+    0 // MISC_0
+  | 1 // MISSINGINFO_1
+  | 2 // SELFREKEYNEEDED_2
+  | 3 // OTHERREKEYNEEDED_3
+  | 4 // IDENTIFY_4
+  | 5 // LOCALMAXMESSAGENOTFOUND_5
 
 export type ConversationFinalizeInfo = {
   resetUser: string,

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -720,9 +720,25 @@
       ]
     },
     {
+      "type": "enum",
+      "name": "ConversationErrorType",
+      "symbols": [
+        "MISC_0",
+        "MISSINGINFO_1",
+        "SELFREKEYNEEDED_2",
+        "OTHERREKEYNEEDED_3",
+        "IDENTIFY_4",
+        "LOCALMAXMESSAGENOTFOUND_5"
+      ]
+    },
+    {
       "type": "record",
       "name": "ConversationErrorLocal",
       "fields": [
+        {
+          "type": "ConversationErrorType",
+          "name": "typ"
+        },
         {
           "type": "string",
           "name": "message"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -98,6 +98,15 @@ export const LocalBodyPlaintextVersion = {
   v1: 1,
 }
 
+export const LocalConversationErrorType = {
+  misc: 0,
+  missinginfo: 1,
+  selfrekeyneeded: 2,
+  otherrekeyneeded: 3,
+  identify: 4,
+  localmaxmessagenotfound: 5,
+}
+
 export const LocalHeaderPlaintextVersion = {
   v1: 1,
 }
@@ -637,10 +646,19 @@ export type Conversation = {
 }
 
 export type ConversationErrorLocal = {
+  typ: ConversationErrorType,
   message: string,
   remoteConv: Conversation,
   permanent: boolean,
 }
+
+export type ConversationErrorType = 
+    0 // MISC_0
+  | 1 // MISSINGINFO_1
+  | 2 // SELFREKEYNEEDED_2
+  | 3 // OTHERREKEYNEEDED_3
+  | 4 // IDENTIFY_4
+  | 5 // LOCALMAXMESSAGENOTFOUND_5
 
 export type ConversationFinalizeInfo = {
   resetUser: string,


### PR DESCRIPTION
The purpose of the patch is the following:

1.) Introduce more flexibility to the localize process to take a function to determine how we unbox the max messages list.
2.) Make a new function which just sees if we can grab all the max messages off the disk. This is much faster, and we can feel ok paying this cost upfront in the nonblocking inbox fetch.
3.) If we don't get all the messages, just don't filter anything.
4.) If we do, then filter out any conversations in an error state or that are empty.

In addition to that change, fixed a couple bugs:

1.) Don't bump `Mtime` on local inbox copy from `ReadMessage` event if we don't change anything. It turns out there is a codepath through `GetThread` which will generate these.
2.) Bail out of the supersedes code if there are no superseders. 