### PR TITLE
Show tracker card as red if we get a 'clash' state

### DIFF
--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -432,6 +432,11 @@ function _serverCallMap (dispatch: Dispatch, getState: Function, isGetProfile: b
       if (getState().tracker.pendingIdentifies[username]) {
         console.log('Bailing on idenitifies in time window', username)
         alreadyPending = true
+
+        // Display anyways
+        if (forceDisplay) {
+          dispatch({type: Constants.showTracker, payload: {username}})
+        }
         return
       }
 

--- a/shared/reducers/tracker.js
+++ b/shared/reducers/tracker.js
@@ -512,7 +512,10 @@ function stateToColor (state: SimpleProofState): string {
   return 'gray'
 }
 
-function proofStateToSimpleProofState (proofState: ProofState, diff: ?TrackDiff, remoteDiff: ?TrackDiff): ?SimpleProofState {
+function proofStateToSimpleProofState (proofState: ProofState, diff: ?TrackDiff, remoteDiff: ?TrackDiff, breaksTracking: boolean): ?SimpleProofState {
+  if (breaksTracking) {
+    return error
+  }
   // If there is no difference in what we've tracked from the server or remote resource it's good.
   if (diff && remoteDiff && diff.type === IdentifyCommonTrackDiffType.none && remoteDiff.type === IdentifyCommonTrackDiffType.none) {
     return normal
@@ -667,7 +670,7 @@ function revokedProofToProof (rv: RevokedProof): Proof {
 }
 
 function remoteProofToProof (username: string, oldProofState: SimpleProofState, rp: RemoteProof, lcr: ?LinkCheckResult): Proof {
-  const proofState: SimpleProofState = lcr && proofStateToSimpleProofState(lcr.proofResult.state, lcr.diff, lcr.remoteDiff) || oldProofState
+  const proofState: SimpleProofState = lcr && proofStateToSimpleProofState(lcr.proofResult.state, lcr.diff, lcr.remoteDiff, lcr.breaksTracking) || oldProofState
   const isTracked = !!(lcr && lcr.diff && lcr.diff.type === IdentifyCommonTrackDiffType.none && !lcr.breaksTracking)
   const {diffMeta, statusMeta} = diffAndStatusMeta(lcr && lcr.diff && lcr.diff.type, lcr && lcr.proofResult, isTracked)
   const humanUrl = ((rp.key !== 'dns') && lcr && lcr.hint && lcr.hint.humanUrl) || `https://keybase.io/${username}/sigchain#${rp.sigID}`


### PR DESCRIPTION
If a user changes from github user 'a' to 'b' we get a special 'clash' state from the server. We weren't doing the right thing here. Now if we get the breaksTracking flag on any proof we'll automatically mark it as an error and the entire thing goes red.

Additionally our ignoring of cached/ in-flight trackers could make the `keybase id --force-display` not display the tracker. That's fixed too

- [x] show error if we ever get breaksTracking
- [x] Always show the tracker even if we have it marked as pending if we get a forceDisplay

@keybase/react-hackers 
