### PR TITLE
Support rekey errors for chat convs

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -76,7 +76,7 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, fina
 	tlfPublic := boxed.ClientHeader.TlfPublic
 	keys, err := CtxKeyFinder(ctx).Find(ctx, b.tlf, tlfName, tlfPublic)
 	if err != nil {
-		// transient error
+		// transient error. Rekey errors come through here
 		return chat1.MessageUnboxed{}, NewTransientUnboxingError(err)
 	}
 

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -79,7 +79,7 @@ func (b *BlockingLocalizer) Name() string {
 
 type NonblockInboxResult struct {
 	ConvID   chat1.ConversationID
-	Err      error
+	Err      *chat1.ConversationErrorLocal
 	ConvRes  *chat1.ConversationLocal
 	InboxRes *chat1.Inbox
 }
@@ -167,7 +167,7 @@ func (b *NonblockingLocalizer) filterInboxRes(ctx context.Context, inbox chat1.I
 			continue
 		}
 
-		if localConv.IsEmpty {
+		if localConv.Error == nil && localConv.IsEmpty {
 			b.Debug(ctx, "filterInboxRes: skipping because empty: convID: %s", conv.GetConvID())
 			continue
 		}
@@ -657,7 +657,7 @@ func (s *localizerPipeline) localizeConversationsPipeline(ctx context.Context, u
 						s.Debug(ctx, "error localizing: convID: %s err: %s", conv.conv.GetConvID(),
 							convLocal.Error.Message)
 						*localizeCb <- NonblockInboxResult{
-							Err:    errors.New(convLocal.Error.Message),
+							Err:    convLocal.Error,
 							ConvID: conv.conv.Metadata.ConversationID,
 						}
 					} else {
@@ -752,6 +752,12 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		gmRes := s.getMessages(ctx, conversationRemote.GetConvID(),
 			uid, conversationRemote.MaxMsgs, conversationRemote.Metadata.FinalizeInfo)
 		if gmRes.err != nil {
+			convErr := s.checkRekeyError2(ctx, gmRes.err, conversationRemote)
+			if convErr != nil {
+				conversationLocal.Error = convErr
+				return conversationLocal
+			}
+
 			conversationLocal.Error = &chat1.ConversationErrorLocal{
 				Message:    gmRes.err.Error(),
 				RemoteConv: conversationRemote,
@@ -765,6 +771,12 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		conversationLocal.MaxMessages, err = s.G().ConvSource.GetMessagesWithRemotes(ctx,
 			conversationRemote.Metadata.ConversationID, uid, conversationRemote.MaxMsgs, conversationRemote.Metadata.FinalizeInfo)
 		if err != nil {
+			convErr := s.checkRekeyError2(ctx, err, conversationRemote)
+			if convErr != nil {
+				conversationLocal.Error = convErr
+				return conversationLocal
+			}
+
 			conversationLocal.Error = &chat1.ConversationErrorLocal{
 				Message:    err.Error(),
 				RemoteConv: conversationRemote,
@@ -883,6 +895,93 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 	}
 
 	return conversationLocal
+}
+
+// Wraps checkRekeyError to return either a ConversationErrorLocal or nil.
+func (s *localizerPipeline) checkRekeyError2(ctx context.Context, fromErr error, conversationRemote chat1.Conversation) *chat1.ConversationErrorLocal {
+	convErr, err2 := s.checkRekeyError(ctx, fromErr, conversationRemote)
+	if err2 != nil {
+		errMsg := fmt.Sprintf("failed to get rekey info: convID: %s: %s",
+			conversationRemote.Metadata.ConversationID, err2.Error())
+		return &chat1.ConversationErrorLocal{
+			Message:    errMsg,
+			RemoteConv: conversationRemote,
+			Permanent:  false,
+		}
+	}
+	if convErr != nil {
+		return convErr
+	}
+	return nil
+}
+
+// Checks fromErr to see if it is a rekey error.
+// Returns (ConversationErrorRekey, nil) if it is
+// Returns (nil, nil) if it is a different kind of error
+// Returns (nil, err) if there is an error building the ConversationErrorRekey
+func (s *localizerPipeline) checkRekeyError(ctx context.Context, fromErr error, conversationRemote chat1.Conversation) (*chat1.ConversationErrorLocal, error) {
+	convErrTyp := chat1.ConversationErrorType_MISC
+	var rekeyInfo *chat1.ConversationErrorRekey
+
+	switch fromErr := fromErr.(type) {
+	case UnboxingError:
+		switch fromErr := fromErr.Inner().(type) {
+		case libkb.NeedSelfRekeyError:
+			convErrTyp = chat1.ConversationErrorType_SELFREKEYNEEDED
+			rekeyInfo = &chat1.ConversationErrorRekey{
+				TlfName: fromErr.Tlf,
+			}
+		case libkb.NeedOtherRekeyError:
+			convErrTyp = chat1.ConversationErrorType_OTHERREKEYNEEDED
+			rekeyInfo = &chat1.ConversationErrorRekey{
+				TlfName: fromErr.Tlf,
+			}
+		}
+	}
+	if rekeyInfo == nil {
+		// Not a rekey error.
+		return nil, nil
+	}
+
+	if len(conversationRemote.MaxMsgs) == 0 {
+		return nil, errors.New("can't determine isPrivate with no maxMsgs")
+	}
+	rekeyInfo.TlfPublic = conversationRemote.MaxMsgs[0].ClientHeader.TlfPublic
+
+	// Fill readers and writers
+	writerNames, readerNames, err := utils.ReorderParticipants(
+		ctx,
+		s.G().GetUPAKLoader(),
+		rekeyInfo.TlfName,
+		conversationRemote.Metadata.ActiveList)
+	if err != nil {
+		return nil, err
+	}
+	rekeyInfo.WriterNames = writerNames
+	rekeyInfo.ReaderNames = readerNames
+
+	// Fill rekeyers list
+	myUsername := string(s.G().Env.GetUsername())
+	rekeyExcludeSelf := (convErrTyp != chat1.ConversationErrorType_SELFREKEYNEEDED)
+	for _, w := range writerNames {
+		if rekeyExcludeSelf && w == myUsername {
+			// Skip self if self can't rekey.
+			continue
+		}
+		if strings.Contains(w, "@") {
+			// Skip assertions. They can't rekey.
+			continue
+		}
+		rekeyInfo.Rekeyers = append(rekeyInfo.Rekeyers, w)
+	}
+
+	return &chat1.ConversationErrorLocal{
+		Typ:        convErrTyp,
+		Message:    fromErr.Error(),
+		RemoteConv: conversationRemote,
+		Permanent:  s.isErrPermanent(err),
+		RekeyInfo:  rekeyInfo,
+	}, nil
 }
 
 func readRemote(ctx context.Context, ri chat1.RemoteInterface, uid gregor1.UID,

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -92,6 +92,26 @@ func (v conversationListView) convName(g *libkb.GlobalContext, conv chat1.Conver
 	return name
 }
 
+// Make a name that looks like a tlfname but is sorted by activity and missing myUsername.
+// This is the less featureful version for convs that can't be unboxed.
+func (v conversationListView) convNameLite(g *libkb.GlobalContext, convErr chat1.ConversationErrorRekey, myUsername string) string {
+	var name string
+	if convErr.TlfPublic {
+		name = "(public) " + strings.Join(convErr.WriterNames, ",")
+	} else {
+		name = strings.Join(v.without(g, convErr.WriterNames, myUsername), ",")
+		if len(convErr.WriterNames) == 1 && convErr.WriterNames[0] == myUsername {
+			// The user is the only writer.
+			name = myUsername
+		}
+	}
+	if len(convErr.ReaderNames) > 0 {
+		name += "#" + strings.Join(convErr.ReaderNames, ",")
+	}
+
+	return name
+}
+
 func (v conversationListView) without(g *libkb.GlobalContext, slice []string, el string) (res []string) {
 	for _, x := range slice {
 		if x != el {
@@ -113,7 +133,7 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 	for i, conv := range v {
 
 		if conv.Error != nil {
-			table.Insert(flexibletable.Row{
+			row := flexibletable.Row{
 				flexibletable.Cell{
 					Frame:     [2]string{"[", "]"},
 					Alignment: flexibletable.Right,
@@ -136,7 +156,20 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 					Alignment: flexibletable.Left,
 					Content:   flexibletable.SingleCell{Item: conv.Error.Message},
 				},
-			})
+			}
+
+			if conv.Error.RekeyInfo != nil {
+				row[2].Content = flexibletable.SingleCell{Item: v.convNameLite(g, *conv.Error.RekeyInfo, myUsername)}
+				row[3].Content = flexibletable.SingleCell{Item: ""}
+				switch conv.Error.Typ {
+				case chat1.ConversationErrorType_SELFREKEYNEEDED:
+					row[4].Content = flexibletable.SingleCell{Item: "Rekey needed. Waiting for a participant to open their Keybase app."}
+				case chat1.ConversationErrorType_OTHERREKEYNEEDED:
+					row[4].Content = flexibletable.SingleCell{Item: "Rekey needed. Waiting for another participant to open their Keybase app."}
+				}
+			}
+
+			table.Insert(row)
 			continue
 		}
 

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -57,9 +57,9 @@ type ChatInboxConversationArg struct {
 }
 
 type ChatInboxFailedArg struct {
-	SessionID int            `codec:"sessionID" json:"sessionID"`
-	ConvID    ConversationID `codec:"convID" json:"convID"`
-	Error     string         `codec:"error" json:"error"`
+	SessionID int                    `codec:"sessionID" json:"sessionID"`
+	ConvID    ConversationID         `codec:"convID" json:"convID"`
+	Error     ConversationErrorLocal `codec:"error" json:"error"`
 }
 
 type ChatUiInterface interface {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -760,10 +760,19 @@ func (e ConversationErrorType) String() string {
 }
 
 type ConversationErrorLocal struct {
-	Typ        ConversationErrorType `codec:"typ" json:"typ"`
-	Message    string                `codec:"message" json:"message"`
-	RemoteConv Conversation          `codec:"remoteConv" json:"remoteConv"`
-	Permanent  bool                  `codec:"permanent" json:"permanent"`
+	Typ        ConversationErrorType   `codec:"typ" json:"typ"`
+	Message    string                  `codec:"message" json:"message"`
+	RemoteConv Conversation            `codec:"remoteConv" json:"remoteConv"`
+	Permanent  bool                    `codec:"permanent" json:"permanent"`
+	RekeyInfo  *ConversationErrorRekey `codec:"rekeyInfo,omitempty" json:"rekeyInfo,omitempty"`
+}
+
+type ConversationErrorRekey struct {
+	TlfName     string   `codec:"tlfName" json:"tlfName"`
+	TlfPublic   bool     `codec:"tlfPublic" json:"tlfPublic"`
+	Rekeyers    []string `codec:"rekeyers" json:"rekeyers"`
+	WriterNames []string `codec:"writerNames" json:"writerNames"`
+	ReaderNames []string `codec:"readerNames" json:"readerNames"`
 }
 
 type ConversationLocal struct {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -122,8 +122,8 @@ func (h *chatLocalHandler) GetInboxNonblockLocal(ctx context.Context, arg chat1.
 			if convRes.Err != nil {
 				chatUI.ChatInboxFailed(ctx, chat1.ChatInboxFailedArg{
 					SessionID: arg.SessionID,
-					Error:     convRes.Err.Error(),
 					ConvID:    convRes.ConvID,
+					Error:     *convRes.Err,
 				})
 			} else if convRes.ConvRes != nil {
 				chatUI.ChatInboxConversation(ctx, chat1.ChatInboxConversationArg{

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -14,5 +14,5 @@ protocol chatUi {
 
   void chatInboxUnverified(int sessionID, GetInboxLocalRes inbox); 
   void chatInboxConversation(int sessionID, ConversationLocal conv);
-  void chatInboxFailed(int sessionID, ConversationID convID, string error);
+  void chatInboxFailed(int sessionID, ConversationID convID, ConversationErrorLocal error);
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -254,6 +254,19 @@ protocol local {
     string message;
     Conversation remoteConv;
     boolean permanent;
+    // Only set if typ is for rekeying.
+    union { null, ConversationErrorRekey} rekeyInfo;
+  }
+
+  record ConversationErrorRekey {
+    // All of this stuff is server trust. Don't use it to send messages.
+    string tlfName;
+    boolean tlfPublic;
+    // Users who could rekey this conv.
+    array<string> rekeyers;
+    // Lists of usernames in the conv. Untrusted.
+    array<string> writerNames;
+    array<string> readerNames;
   }
 
   // ConversationLocal, whenever present, has a valid `identifyFailures` field that

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -650,6 +650,15 @@ export type ConversationErrorLocal = {
   message: string,
   remoteConv: Conversation,
   permanent: boolean,
+  rekeyInfo?: ?ConversationErrorRekey,
+}
+
+export type ConversationErrorRekey = {
+  tlfName: string,
+  tlfPublic: boolean,
+  rekeyers?: ?Array<string>,
+  writerNames?: ?Array<string>,
+  readerNames?: ?Array<string>,
 }
 
 export type ConversationErrorType = 
@@ -1318,7 +1327,7 @@ export type chatUiChatInboxConversationRpcParam = Exact<{
 
 export type chatUiChatInboxFailedRpcParam = Exact<{
   convID: ConversationID,
-  error: string
+  error: ConversationErrorLocal
 }>
 
 export type chatUiChatInboxUnverifiedRpcParam = Exact<{
@@ -1724,7 +1733,7 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       sessionID: int,
       convID: ConversationID,
-      error: string
+      error: ConversationErrorLocal
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -145,7 +145,7 @@
         },
         {
           "name": "error",
-          "type": "string"
+          "type": "ConversationErrorLocal"
         }
       ],
       "response": null

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -750,6 +750,48 @@
         {
           "type": "boolean",
           "name": "permanent"
+        },
+        {
+          "type": [
+            null,
+            "ConversationErrorRekey"
+          ],
+          "name": "rekeyInfo"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "ConversationErrorRekey",
+      "fields": [
+        {
+          "type": "string",
+          "name": "tlfName"
+        },
+        {
+          "type": "boolean",
+          "name": "tlfPublic"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "rekeyers"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "writerNames"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "readerNames"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -650,6 +650,15 @@ export type ConversationErrorLocal = {
   message: string,
   remoteConv: Conversation,
   permanent: boolean,
+  rekeyInfo?: ?ConversationErrorRekey,
+}
+
+export type ConversationErrorRekey = {
+  tlfName: string,
+  tlfPublic: boolean,
+  rekeyers?: ?Array<string>,
+  writerNames?: ?Array<string>,
+  readerNames?: ?Array<string>,
 }
 
 export type ConversationErrorType = 
@@ -1318,7 +1327,7 @@ export type chatUiChatInboxConversationRpcParam = Exact<{
 
 export type chatUiChatInboxFailedRpcParam = Exact<{
   convID: ConversationID,
-  error: string
+  error: ConversationErrorLocal
 }>
 
 export type chatUiChatInboxUnverifiedRpcParam = Exact<{
@@ -1724,7 +1733,7 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       sessionID: int,
       convID: ConversationID,
-      error: string
+      error: ConversationErrorLocal
     }>,
     response: CommonResponseHandler
   ) => void,


### PR DESCRIPTION
Reify rekey-needed errors as `ConversationErrorLocal`s with `RekeyInfo` set. `RekeyInfo` should contain all you need to render the ui for it. Also adds CLI support for rekeys.

```
$ kbu chat ls
[1]  bob [] Rekey needed. Waiting for a participant to open their Keybase app.
```

(* I don't really know what reify means, but it sounds awesome.)