### PR TITLE
env flag to disable react perf

### DIFF
--- a/shared/util/dev.js
+++ b/shared/util/dev.js
@@ -1,7 +1,7 @@
 // @flow
 
 const injectReactQueryParams = (url: string): string => {
-  if (!__DEV__) {
+  if (!__DEV__ || process.env.KEYBASE_DISABLE_REACT_PERF) {
     return url
   }
 


### PR DESCRIPTION
@mmaxim was running into a lot of memory pressure due to this for some reason. clicking between conversations would leak ~100MB (unclear yet why)

@keybase/react-hackers 