### PR TITLE
from chatGUIMode, use passive ID checking

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -102,7 +102,7 @@ func (i *Identify2WithUIDTester) MakeProofChecker(_ libkb.RemoteProofChainLink) 
 }
 func (i *Identify2WithUIDTester) GetServiceType(n string) libkb.ServiceType { return i }
 
-func (i *Identify2WithUIDTester) CheckStatus(_ libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+func (i *Identify2WithUIDTester) CheckStatus(_ libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode) libkb.ProofError {
 	if i.checkStatusHook != nil {
 		return i.checkStatusHook(h)
 	}
@@ -383,7 +383,8 @@ func TestIdentify2WithUIDWithBrokenTrackFromChatGUI(t *testing.T) {
 		return nil
 	}
 
-	var origUI libkb.IdentifyUI = tester
+	var origUI libkb.IdentifyUI
+	origUI = tester
 
 	checkBrokenRes := func(res *keybase1.Identify2Res) {
 		if !res.Upk.Uid.Equal(keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")) {

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -677,9 +677,14 @@ func (e *Identify2WithUID) runIdentifyUI(ctx *Context) (err error) {
 		return err
 	}
 
+	itm := libkb.IdentifyTableModeActive
+	if e.calledFromChatGUI() {
+		itm = libkb.IdentifyTableModePassive
+	}
+
 	if them.IDTable() == nil {
 		e.G().Log.Debug("| No IDTable for user")
-	} else if err = them.IDTable().Identify(ctx.GetNetContext(), e.state, e.forceRemoteCheck(), iui, e); err != nil {
+	} else if err = them.IDTable().Identify(ctx.GetNetContext(), e.state, e.forceRemoteCheck(), iui, e, itm); err != nil {
 		e.G().Log.Debug("| Failure in running IDTable")
 		return err
 	}

--- a/go/engine/scanproofs.go
+++ b/go/engine/scanproofs.go
@@ -408,7 +408,7 @@ func (e *ScanProofsEngine) CheckOne(ctx *Context, rec map[string]string, forcepv
 		return perr, foundhint, nil
 	}
 
-	perr = pc.CheckStatus(e.G(), *hint)
+	perr = pc.CheckStatus(e.G(), *hint, libkb.ProofCheckerModeActive)
 	if perr != nil {
 		return perr, foundhint, nil
 	}

--- a/go/externals/proof_support_coinbase.go
+++ b/go/externals/proof_support_coinbase.go
@@ -48,7 +48,7 @@ func (rc *CoinbaseChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) li
 
 func (rc *CoinbaseChecker) GetTorError() libkb.ProofError { return nil }
 
-func (rc *CoinbaseChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+func (rc *CoinbaseChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode) libkb.ProofError {
 	if pvl.UsePvl {
 		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_COINBASE,
 			pvl.NewProofInfo(rc.proof, h))

--- a/go/externals/proof_support_dns.go
+++ b/go/externals/proof_support_dns.go
@@ -70,7 +70,11 @@ func (rc *DNSChecker) CheckDomain(ctx libkb.ProofContext, sig string, domain str
 		len(txt), domain, sig)
 }
 
-func (rc *DNSChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+func (rc *DNSChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, pcm libkb.ProofCheckerMode) libkb.ProofError {
+	if pcm != libkb.ProofCheckerModeActive {
+		ctx.GetLog().CDebugf(ctx.GetNetContext(), "DNS check skipped since proof checking was not in active mode (%s)", h.GetAPIURL())
+		return libkb.ProofErrorUnchecked
+	}
 	if pvl.UsePvl {
 		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_DNS,
 			pvl.NewProofInfo(rc.proof, h))

--- a/go/externals/proof_support_facebook.go
+++ b/go/externals/proof_support_facebook.go
@@ -89,7 +89,7 @@ func (rc *FacebookChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) li
 	return nil
 }
 
-func (rc *FacebookChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+func (rc *FacebookChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode) libkb.ProofError {
 	if pvl.UsePvl {
 		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_FACEBOOK, pvl.NewProofInfo(rc.proof, h))
 	}

--- a/go/externals/proof_support_github.go
+++ b/go/externals/proof_support_github.go
@@ -46,7 +46,7 @@ func (rc *GithubChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libk
 		"Bad hint from server; URL start with either '%s' OR '%s'", ok1, ok2)
 }
 
-func (rc *GithubChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+func (rc *GithubChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode) libkb.ProofError {
 	if pvl.UsePvl {
 		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_GITHUB,
 			pvl.NewProofInfo(rc.proof, h))

--- a/go/externals/proof_support_hackernews.go
+++ b/go/externals/proof_support_hackernews.go
@@ -64,7 +64,7 @@ func (h *HackerNewsChecker) CheckHint(ctx libkb.ProofContext, hint libkb.SigHint
 	return libkb.NewProofError(keybase1.ProofStatus_BAD_API_URL, "Bad hint from server; URL should start with '%s'", wanted)
 }
 
-func (h *HackerNewsChecker) CheckStatus(ctx libkb.ProofContext, hint libkb.SigHint) libkb.ProofError {
+func (h *HackerNewsChecker) CheckStatus(ctx libkb.ProofContext, hint libkb.SigHint, _ libkb.ProofCheckerMode) libkb.ProofError {
 	if pvl.UsePvl {
 		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_HACKERNEWS,
 			pvl.NewProofInfo(h.proof, hint))

--- a/go/externals/proof_support_reddit.go
+++ b/go/externals/proof_support_reddit.go
@@ -117,7 +117,7 @@ func (rc *RedditChecker) CheckData(h libkb.SigHint, dat *jsonw.Wrapper) libkb.Pr
 	return nil
 }
 
-func (rc *RedditChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+func (rc *RedditChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode) libkb.ProofError {
 	if pvl.UsePvl {
 		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_REDDIT,
 			pvl.NewProofInfo(rc.proof, h))

--- a/go/externals/proof_support_rooter.go
+++ b/go/externals/proof_support_rooter.go
@@ -133,7 +133,7 @@ func (rc *RooterChecker) rewriteURL(ctx libkb.ProofContext, s string) (string, e
 	return u3.String(), nil
 }
 
-func (rc *RooterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) (perr libkb.ProofError) {
+func (rc *RooterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode) (perr libkb.ProofError) {
 	if pvl.UsePvl {
 		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_ROOTER,
 			pvl.NewProofInfo(rc.proof, h))

--- a/go/externals/proof_support_twitter.go
+++ b/go/externals/proof_support_twitter.go
@@ -90,7 +90,7 @@ func (rc *TwitterChecker) findSigInTweet(ctx libkb.ProofContext, h libkb.SigHint
 		checkText, inside)
 }
 
-func (rc *TwitterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+func (rc *TwitterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode) libkb.ProofError {
 	if pvl.UsePvl {
 		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_TWITTER,
 			pvl.NewProofInfo(rc.proof, h))

--- a/go/externals/proof_support_web.go
+++ b/go/externals/proof_support_web.go
@@ -64,7 +64,11 @@ func (rc *WebChecker) CheckHint(ctx libkb.ProofContext, h libkb.SigHint) libkb.P
 		h.GetAPIURL())
 }
 
-func (rc *WebChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint) libkb.ProofError {
+func (rc *WebChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, pcm libkb.ProofCheckerMode) libkb.ProofError {
+	if pcm != libkb.ProofCheckerModeActive {
+		ctx.GetLog().CDebugf(ctx.GetNetContext(), "Web check skipped since proof checking was not in active mode (%s)", h.GetAPIURL())
+		return libkb.ProofErrorUnchecked
+	}
 	if pvl.UsePvl {
 		return pvl.CheckProof(ctx, pvl.GetHardcodedPvlString(), keybase1.ProofType_GENERIC_WEB_SITE,
 			pvl.NewProofInfo(rc.proof, h))

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -40,6 +40,8 @@ func ProofErrorToState(pe ProofError) keybase1.ProofState {
 		return keybase1.ProofState_SIG_HINT_MISSING
 	case keybase1.ProofStatus_UNKNOWN_TYPE:
 		return keybase1.ProofState_UNKNOWN_TYPE
+	case keybase1.ProofStatus_UNCHECKED:
+		return keybase1.ProofState_UNCHECKED
 	default:
 		return keybase1.ProofState_TEMP_FAILURE
 	}

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -82,6 +82,11 @@ var ProofErrorHTTPOverTor = &ProofErrorImpl{
 	Desc:   "HTTP proofs aren't reliable over Tor",
 }
 
+var ProofErrorUnchecked = &ProofErrorImpl{
+	Status: keybase1.ProofStatus_UNCHECKED,
+	Desc:   "Proof unchecked due to privacy concerns",
+}
+
 type TorSessionRequiredError struct{}
 
 func (t TorSessionRequiredError) Error() string {

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1370,7 +1370,7 @@ func (idt *IdentityTable) proofRemoteCheck(ctx context.Context, hasPreviousTrack
 	// self-hosted services. We want to avoid so doing when the user is acting passively
 	// (such as when receiving a message).
 	pcm := ProofCheckerModePassive
-	if (hasPreviousTrack && res.trackedProofState != keybase1.ProofState_NONE) || itm == IdentifyTableModeActive {
+	if (hasPreviousTrack && res.trackedProofState != keybase1.ProofState_NONE && res.trackedProofState != keybase1.ProofState_UNCHECKED) || itm == IdentifyTableModeActive {
 		pcm = ProofCheckerModeActive
 	}
 	res.err = pc.CheckStatus(idt.G().CloneWithNetContext(ctx), *res.hint, pcm)

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1370,7 +1370,7 @@ func (idt *IdentityTable) proofRemoteCheck(ctx context.Context, hasPreviousTrack
 	// self-hosted services. We want to avoid so doing when the user is acting passively
 	// (such as when receiving a message).
 	pcm := ProofCheckerModePassive
-	if (hasPreviousTrack && res.trackedProofState != keybase1.ProofState_NONE && res.trackedProofState != keybase1.ProofState_UNCHECKED) || itm == IdentifyTableModeActive {
+	if (hasPreviousTrack && res.trackedProofState != keybase1.ProofState_NONE) || itm == IdentifyTableModeActive {
 		pcm = ProofCheckerModeActive
 	}
 	res.err = pc.CheckStatus(idt.G().CloneWithNetContext(ctx), *res.hint, pcm)

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -472,9 +472,17 @@ type AssertionContext interface {
 }
 
 // ProofChecker is an interface for performing a remote check for a proof
+
+type ProofCheckerMode int
+
+const (
+	ProofCheckerModePassive ProofCheckerMode = iota
+	ProofCheckerModeActive  ProofCheckerMode = iota
+)
+
 type ProofChecker interface {
 	CheckHint(ctx ProofContext, h SigHint) ProofError
-	CheckStatus(ctx ProofContext, h SigHint) ProofError
+	CheckStatus(ctx ProofContext, h SigHint, pcm ProofCheckerMode) ProofError
 	GetTorError() ProofError
 }
 

--- a/go/protocol/keybase1/prove_common.go
+++ b/go/protocol/keybase1/prove_common.go
@@ -21,6 +21,7 @@ const (
 	ProofState_DELETED          ProofState = 8
 	ProofState_UNKNOWN_TYPE     ProofState = 9
 	ProofState_SIG_HINT_MISSING ProofState = 10
+	ProofState_UNCHECKED        ProofState = 11
 )
 
 var ProofStateMap = map[string]ProofState{
@@ -35,6 +36,7 @@ var ProofStateMap = map[string]ProofState{
 	"DELETED":          8,
 	"UNKNOWN_TYPE":     9,
 	"SIG_HINT_MISSING": 10,
+	"UNCHECKED":        11,
 }
 
 var ProofStateRevMap = map[ProofState]string{
@@ -49,6 +51,7 @@ var ProofStateRevMap = map[ProofState]string{
 	8:  "DELETED",
 	9:  "UNKNOWN_TYPE",
 	10: "SIG_HINT_MISSING",
+	11: "UNCHECKED",
 }
 
 func (e ProofState) String() string {

--- a/go/protocol/keybase1/prove_common.go
+++ b/go/protocol/keybase1/prove_common.go
@@ -59,7 +59,9 @@ func (e ProofState) String() string {
 }
 
 // 3: It's been found in the hunt, but not proven yet
-// 1xx: Retryable soft errors
+// 1xx: Retryable soft errors; note that this will be put in the proof_cache, but won't
+// be returned from the proof cache in most cases. Their freshness will always be
+// RANCID.
 // 2xx: Will likely result in a hard error, if repeated enough
 // 3xx: Hard final errors
 type ProofStatus int
@@ -79,6 +81,7 @@ const (
 	ProofStatus_HTTP_500          ProofStatus = 150
 	ProofStatus_TIMEOUT           ProofStatus = 160
 	ProofStatus_INTERNAL_ERROR    ProofStatus = 170
+	ProofStatus_UNCHECKED         ProofStatus = 171
 	ProofStatus_BASE_HARD_ERROR   ProofStatus = 200
 	ProofStatus_NOT_FOUND         ProofStatus = 201
 	ProofStatus_CONTENT_FAILURE   ProofStatus = 202
@@ -120,6 +123,7 @@ var ProofStatusMap = map[string]ProofStatus{
 	"HTTP_500":          150,
 	"TIMEOUT":           160,
 	"INTERNAL_ERROR":    170,
+	"UNCHECKED":         171,
 	"BASE_HARD_ERROR":   200,
 	"NOT_FOUND":         201,
 	"CONTENT_FAILURE":   202,
@@ -161,6 +165,7 @@ var ProofStatusRevMap = map[ProofStatus]string{
 	150: "HTTP_500",
 	160: "TIMEOUT",
 	170: "INTERNAL_ERROR",
+	171: "UNCHECKED",
 	200: "BASE_HARD_ERROR",
 	201: "NOT_FOUND",
 	202: "CONTENT_FAILURE",

--- a/protocol/avdl/keybase1/prove_common.avdl
+++ b/protocol/avdl/keybase1/prove_common.avdl
@@ -12,7 +12,8 @@ protocol proveCommon {
     REVOKED_7,
     DELETED_8,
     UNKNOWN_TYPE_9,
-    SIG_HINT_MISSING_10
+    SIG_HINT_MISSING_10,
+    UNCHECKED_11
   }
 
   /**

--- a/protocol/avdl/keybase1/prove_common.avdl
+++ b/protocol/avdl/keybase1/prove_common.avdl
@@ -17,7 +17,9 @@ protocol proveCommon {
 
   /**
     3: It's been found in the hunt, but not proven yet
-    1xx: Retryable soft errors
+    1xx: Retryable soft errors; note that this will be put in the proof_cache, but won't
+       be returned from the proof cache in most cases. Their freshness will always be
+       RANCID.
     2xx: Will likely result in a hard error, if repeated enough
     3xx: Hard final errors
     */
@@ -37,6 +39,7 @@ protocol proveCommon {
     HTTP_500_150,
     TIMEOUT_160,
     INTERNAL_ERROR_170,
+    UNCHECKED_171,  /* must be a soft error so that it can't be returned to active mode identifiers */
 
     BASE_HARD_ERROR_200,
     NOT_FOUND_201,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -337,6 +337,7 @@ export const ProveCommonProofStatus = {
   http500: 150,
   timeout: 160,
   internalError: 170,
+  unchecked: 171,
   baseHardError: 200,
   notFound: 201,
   contentFailure: 202,
@@ -3703,6 +3704,7 @@ export type ProofStatus =
   | 150 // HTTP_500_150
   | 160 // TIMEOUT_160
   | 170 // INTERNAL_ERROR_170
+  | 171 // UNCHECKED_171
   | 200 // BASE_HARD_ERROR_200
   | 201 // NOT_FOUND_201
   | 202 // CONTENT_FAILURE_202

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -320,6 +320,7 @@ export const ProveCommonProofState = {
   deleted: 8,
   unknownType: 9,
   sigHintMissing: 10,
+  unchecked: 11,
 }
 
 export const ProveCommonProofStatus = {
@@ -3688,6 +3689,7 @@ export type ProofState =
   | 8 // DELETED_8
   | 9 // UNKNOWN_TYPE_9
   | 10 // SIG_HINT_MISSING_10
+  | 11 // UNCHECKED_11
 
 export type ProofStatus = 
     0 // NONE_0

--- a/protocol/json/keybase1/prove_common.json
+++ b/protocol/json/keybase1/prove_common.json
@@ -37,6 +37,7 @@
         "HTTP_500_150",
         "TIMEOUT_160",
         "INTERNAL_ERROR_170",
+        "UNCHECKED_171",
         "BASE_HARD_ERROR_200",
         "NOT_FOUND_201",
         "CONTENT_FAILURE_202",
@@ -62,7 +63,7 @@
         "BAD_HINT_TEXT_307",
         "INVALID_PVL_308"
       ],
-      "doc": "3: It's been found in the hunt, but not proven yet\n    1xx: Retryable soft errors\n    2xx: Will likely result in a hard error, if repeated enough\n    3xx: Hard final errors"
+      "doc": "3: It's been found in the hunt, but not proven yet\n    1xx: Retryable soft errors; note that this will be put in the proof_cache, but won't\n       be returned from the proof cache in most cases. Their freshness will always be\n       RANCID.\n    2xx: Will likely result in a hard error, if repeated enough\n    3xx: Hard final errors"
     },
     {
       "type": "enum",

--- a/protocol/json/keybase1/prove_common.json
+++ b/protocol/json/keybase1/prove_common.json
@@ -16,7 +16,8 @@
         "REVOKED_7",
         "DELETED_8",
         "UNKNOWN_TYPE_9",
-        "SIG_HINT_MISSING_10"
+        "SIG_HINT_MISSING_10",
+        "UNCHECKED_11"
       ]
     },
     {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -337,6 +337,7 @@ export const ProveCommonProofStatus = {
   http500: 150,
   timeout: 160,
   internalError: 170,
+  unchecked: 171,
   baseHardError: 200,
   notFound: 201,
   contentFailure: 202,
@@ -3703,6 +3704,7 @@ export type ProofStatus =
   | 150 // HTTP_500_150
   | 160 // TIMEOUT_160
   | 170 // INTERNAL_ERROR_170
+  | 171 // UNCHECKED_171
   | 200 // BASE_HARD_ERROR_200
   | 201 // NOT_FOUND_201
   | 202 // CONTENT_FAILURE_202

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -320,6 +320,7 @@ export const ProveCommonProofState = {
   deleted: 8,
   unknownType: 9,
   sigHintMissing: 10,
+  unchecked: 11,
 }
 
 export const ProveCommonProofStatus = {
@@ -3688,6 +3689,7 @@ export type ProofState =
   | 8 // DELETED_8
   | 9 // UNKNOWN_TYPE_9
   | 10 // SIG_HINT_MISSING_10
+  | 11 // UNCHECKED_11
 
 export type ProofStatus = 
     0 // NONE_0


### PR DESCRIPTION
- in passive ID checking, we don't ask for Web and DNS proofs to be resolved *unless* they're already tracked
- this means you can't send a chat to someone and expect them to ping your servera
- no tests for now.