### PR TITLE
fix prev pointers not being added from GUI CORE-4495

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -391,6 +391,7 @@ func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID cha
 
 	tv, err := s.storage.FetchUpToLocalMaxMsgID(ctx, convID, uid, query, pagination)
 	if err != nil {
+		s.Debug(ctx, "PullLocalOnly: failed to fetch local messages: %s", err.Error())
 		return chat1.ThreadView{}, err
 	}
 

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -86,11 +86,17 @@ func (s *BlockingSender) addPrevPointersToMessage(ctx context.Context, msg chat1
 
 	var prevs []chat1.MessagePreviousPointer
 
-	res, err := s.G().ConvSource.PullLocalOnly(ctx, convID, msg.ClientHeader.Sender, nil, nil)
+	res, err := s.G().ConvSource.PullLocalOnly(ctx, convID, msg.ClientHeader.Sender, nil,
+		&chat1.Pagination{
+			Num: -1,
+		})
 	switch err.(type) {
 	case storage.MissError:
 		s.Debug(ctx, "No local messages; skipping prev pointers")
 	case nil:
+		if len(res.Messages) == 0 {
+			s.Debug(ctx, "no local messages found for prev pointers")
+		}
 		prevs, err = CheckPrevPointersAndGetUnpreved(&res)
 		if err != nil {
 			return chat1.MessagePlaintext{}, err

--- a/go/chat/storage/storage_blockengine.go
+++ b/go/chat/storage/storage_blockengine.go
@@ -356,13 +356,13 @@ func (be *blockEngine) readMessages(ctx context.Context, res resultCollector,
 	// Get block index
 	bi, err := be.fetchBlockIndex(ctx, convID, uid)
 	if err != nil {
-		return err
+		return res.error(err)
 	}
 
 	// Get the current block where max ID is found
 	b, err := be.getBlock(ctx, bi, maxID)
 	if err != nil {
-		return err
+		return res.error(err)
 	}
 
 	// Add messages to result set
@@ -380,13 +380,13 @@ func (be *blockEngine) readMessages(ctx context.Context, res resultCollector,
 		if msg.GetMessageID() == 0 {
 			be.Debug(ctx, "readMessages: cache entry empty: index: %d block: %d msgID: %d", index,
 				b.BlockID, be.getMsgID(b.BlockID, index))
-			return MissError{}
+			return res.error(MissError{})
 		}
 		bMsgID := msg.GetMessageID()
 
 		// Sanity check
 		if bMsgID != be.getMsgID(b.BlockID, index) {
-			return NewInternalError(be.DebugLabeler, "chat entry corruption: bMsgID: %d != %d (block: %d pos: %d)", bMsgID, be.getMsgID(b.BlockID, index), b.BlockID, index)
+			return res.error(NewInternalError(be.DebugLabeler, "chat entry corruption: bMsgID: %d != %d (block: %d pos: %d)", bMsgID, be.getMsgID(b.BlockID, index), b.BlockID, index))
 		}
 
 		be.Debug(ctx, "readMessages: adding msg_id: %d (blockid: %d pos: %d)",

--- a/go/chat/storage/storage_msgengine.go
+++ b/go/chat/storage/storage_msgengine.go
@@ -111,7 +111,14 @@ func (ms *msgEngine) writeMessages(ctx context.Context, convID chat1.Conversatio
 }
 
 func (ms *msgEngine) readMessages(ctx context.Context, rc resultCollector,
-	convID chat1.ConversationID, uid gregor1.UID, maxID chat1.MessageID) Error {
+	convID chat1.ConversationID, uid gregor1.UID, maxID chat1.MessageID) (err Error) {
+
+	// Run all errors through resultCollector
+	defer func() {
+		if err != nil {
+			err = rc.error(err)
+		}
+	}()
 
 	// Read all msgs in reverse order
 	for msgID := maxID; !rc.done() && msgID > 0; msgID-- {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -219,7 +219,7 @@ func NewDebugLabeler(g *libkb.GlobalContext, label string, verbose bool) DebugLa
 }
 
 func (d DebugLabeler) showVerbose() bool {
-	return false
+	return true
 }
 
 func (d DebugLabeler) showLog() bool {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -219,7 +219,7 @@ func NewDebugLabeler(g *libkb.GlobalContext, label string, verbose bool) DebugLa
 }
 
 func (d DebugLabeler) showVerbose() bool {
-	return true
+	return false
 }
 
 func (d DebugLabeler) showLog() bool {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -525,8 +525,8 @@ type ConversationSource interface {
 		msg chat1.MessageBoxed) (chat1.MessageUnboxed, bool, error)
 	Pull(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, query *chat1.GetThreadQuery,
 		pagination *chat1.Pagination) (chat1.ThreadView, []*chat1.RateLimit, error)
-	PullLocalOnly(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, query *chat1.GetThreadQuery,
-		pagination *chat1.Pagination) (chat1.ThreadView, error)
+	PullLocalOnly(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
+		query *chat1.GetThreadQuery, p *chat1.Pagination) (chat1.ThreadView, error)
 	GetMessages(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgIDs []chat1.MessageID, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
 	GetMessagesWithRemotes(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
 		msgs []chat1.MessageBoxed, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)


### PR DESCRIPTION
This patch fixes a somewhat serious bug where prev pointers were not being added if the entire thread was not stored locally. This never happens from the CLI, but can happen from the GUI since it pages in bodies instead of fetching everything. The fix does the following:

1.) Adds a test to make sure we add prev pointers in this situation (subset of the thread stored locally).
2.) Adds a new mode to collecting results out of the local cache to just read until we hit the end of what we have stored. "Hitting the end" is not an error in this mode, and can easily return 0 elements. This allows the call to `PullLocalOnly` in `addPrevPointersToMessages` to get as much as we have stored locally, which was the original intent.