### PR TITLE
Add chat mute status and command

### DIFF
--- a/go/badges/badger.go
+++ b/go/badges/badger.go
@@ -78,7 +78,7 @@ func (b *Badger) Send() error {
 	if err != nil {
 		return err
 	}
-	b.G().Log.Debug("Badger send")
+	b.G().Log.Debug("Badger send: %+v", state)
 	b.G().NotifyRouter.HandleBadgeState(state)
 	return nil
 }

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -617,13 +617,13 @@ func (i *Inbox) NewMessage(ctx context.Context, vers chat1.InboxVers, convID cha
 	conv.Metadata.ActiveList = i.promoteWriter(ctx, msg.ClientHeader.Sender,
 		conv.Metadata.ActiveList)
 
-	// If we are the sender, and the conv is blocked, set it back to unfiled
+	// If we are the sender, adjust the status.
 	if bytes.Equal(msg.ClientHeader.Sender.Bytes(), i.uid) &&
-		conv.Metadata.Status == chat1.ConversationStatus_BLOCKED {
+		utils.GetConversationStatusBehavior(conv.Metadata.Status).SendingRemovesStatus {
 		conv.Metadata.Status = chat1.ConversationStatus_UNFILED
 	}
-	// If any message is posted to an ignored convo, then we set to unfiled
-	if conv.Metadata.Status == chat1.ConversationStatus_IGNORED {
+	// If we are a participant, adjust the status.
+	if utils.GetConversationStatusBehavior(conv.Metadata.Status).ActivityRemovesStatus {
 		conv.Metadata.Status = chat1.ConversationStatus_UNFILED
 	}
 

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -138,6 +138,7 @@ func TestInboxQueries(t *testing.T) {
 	unreads = append(unreads, []chat1.Conversation{convs[19], convs[13], convs[5]}...)
 
 	// Make two ignored
+	// TODO add tests for other statuses
 	convs[18].Metadata.Status = chat1.ConversationStatus_IGNORED
 	convs[4].Metadata.Status = chat1.ConversationStatus_IGNORED
 	ignored = append(ignored, []chat1.Conversation{convs[18], convs[4]}...)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -172,39 +172,90 @@ func AllChatConversationStatuses() (res []chat1.ConversationStatus) {
 	return
 }
 
-// Which convs show badges.
-func BadgingChatConversationStatuses() []chat1.ConversationStatus {
-	return []chat1.ConversationStatus{
-		chat1.ConversationStatus_UNFILED,
-		chat1.ConversationStatus_IGNORED,
-	}
+// ConversationStatusBehavior describes how a ConversationStatus behaves
+type ConversationStatusBehavior struct {
+	// Whether to show the conv in the inbox
+	ShowInInbox bool
+	// Whether sending to this conv sets it back to UNFILED
+	SendingRemovesStatus bool
+	// Whether any incoming activity sets it back to UNFILED
+	ActivityRemovesStatus bool
+	// Whether to show desktop notifications
+	DesktopNotifications bool
+	// Whether to send push notifications
+	PushNotifications bool
+	// Whether to show as part of badging
+	ShowBadges bool
 }
 
-func IsBadgingChatConversationStatus(status chat1.ConversationStatus) bool {
-	for _, s := range BadgingChatConversationStatuses() {
-		if status == s {
-			return true
+// When changing these, be sure to update gregor's postMessage as well
+func GetConversationStatusBehavior(s chat1.ConversationStatus) ConversationStatusBehavior {
+	switch s {
+	case chat1.ConversationStatus_UNFILED:
+		return ConversationStatusBehavior{
+			ShowInInbox:           true,
+			SendingRemovesStatus:  false,
+			ActivityRemovesStatus: false,
+			DesktopNotifications:  true,
+			PushNotifications:     true,
+			ShowBadges:            true,
+		}
+	case chat1.ConversationStatus_FAVORITE:
+		return ConversationStatusBehavior{
+			ShowInInbox:           true,
+			SendingRemovesStatus:  false,
+			ActivityRemovesStatus: false,
+			DesktopNotifications:  true,
+			PushNotifications:     true,
+			ShowBadges:            true,
+		}
+	case chat1.ConversationStatus_IGNORED:
+		return ConversationStatusBehavior{
+			ShowInInbox:           false,
+			SendingRemovesStatus:  true,
+			ActivityRemovesStatus: true,
+			DesktopNotifications:  true,
+			PushNotifications:     true,
+			ShowBadges:            true,
+		}
+	case chat1.ConversationStatus_BLOCKED:
+		return ConversationStatusBehavior{
+			ShowInInbox:           false,
+			SendingRemovesStatus:  true,
+			ActivityRemovesStatus: false,
+			DesktopNotifications:  false,
+			PushNotifications:     false,
+			ShowBadges:            false,
+		}
+	case chat1.ConversationStatus_MUTED:
+		return ConversationStatusBehavior{
+			ShowInInbox:           true,
+			SendingRemovesStatus:  false,
+			ActivityRemovesStatus: false,
+			DesktopNotifications:  false,
+			PushNotifications:     false,
+			ShowBadges:            false,
+		}
+	default:
+		return ConversationStatusBehavior{
+			ShowInInbox:           true,
+			SendingRemovesStatus:  false,
+			ActivityRemovesStatus: false,
+			DesktopNotifications:  true,
+			PushNotifications:     true,
+			ShowBadges:            true,
 		}
 	}
-	return false
 }
 
 // Which convs show in the inbox.
-func VisibleChatConversationStatuses() []chat1.ConversationStatus {
-	return []chat1.ConversationStatus{
-		chat1.ConversationStatus_UNFILED,
-		chat1.ConversationStatus_FAVORITE,
-		chat1.ConversationStatus_MUTED,
-	}
-}
-
-func IsVisibleChatConversationStatus(status chat1.ConversationStatus) bool {
-	for _, s := range VisibleChatConversationStatuses() {
-		if status == s {
-			return true
+func VisibleChatConversationStatuses() (res []chat1.ConversationStatus) {
+	for _, s := range chat1.ConversationStatusMap {
+		if GetConversationStatusBehavior(s).ShowInInbox {
+			res = append(res, s)
 		}
 	}
-	return false
+	return
 }
 
 func VisibleChatMessageTypes() []chat1.MessageType {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -172,10 +172,29 @@ func AllChatConversationStatuses() (res []chat1.ConversationStatus) {
 	return
 }
 
+// Which convs show badges.
+func BadgingChatConversationStatuses() []chat1.ConversationStatus {
+	return []chat1.ConversationStatus{
+		chat1.ConversationStatus_UNFILED,
+		chat1.ConversationStatus_IGNORED,
+	}
+}
+
+func IsBadgingChatConversationStatus(status chat1.ConversationStatus) bool {
+	for _, s := range BadgingChatConversationStatuses() {
+		if status == s {
+			return true
+		}
+	}
+	return false
+}
+
+// Which convs show in the inbox.
 func VisibleChatConversationStatuses() []chat1.ConversationStatus {
 	return []chat1.ConversationStatus{
 		chat1.ConversationStatus_UNFILED,
 		chat1.ConversationStatus_FAVORITE,
+		chat1.ConversationStatus_MUTED,
 	}
 }
 

--- a/go/client/cmd_chat.go
+++ b/go/client/cmd_chat.go
@@ -18,6 +18,7 @@ func NewCmdChat(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 			newCmdChatAPI(cl, g),
 			newCmdChatDownload(cl, g),
 			newCmdChatHide(cl, g),
+			newCmdChatMute(cl, g),
 			newCmdChatList(cl, g),
 			newCmdChatListUnread(cl, g),
 			newCmdChatRead(cl, g),

--- a/go/client/cmd_chat_hide.go
+++ b/go/client/cmd_chat_hide.go
@@ -11,6 +11,8 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
+// TODO hide is going to need some awesome help to make sense with mute.
+
 type CmdChatHide struct {
 	libkb.Contextified
 	resolvingRequest chatConversationResolvingRequest

--- a/go/client/cmd_chat_mute.go
+++ b/go/client/cmd_chat_mute.go
@@ -11,26 +11,26 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-type CmdChatHide struct {
+type CmdChatMute struct {
 	libkb.Contextified
 	resolvingRequest chatConversationResolvingRequest
 	status           chat1.ConversationStatus
 }
 
-func newCmdChatHide(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+func newCmdChatMute(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
-		Name:         "hide",
-		Usage:        "Hide or block a conversation.",
+		Name:         "mute",
+		Usage:        "Mute or unmute a conversation.",
 		ArgumentHelp: "[<conversation>]",
 		Action: func(c *cli.Context) {
-			cmd := &CmdChatHide{Contextified: libkb.NewContextified(g)}
-			cl.ChooseCommand(cmd, "hide", c)
+			cmd := &CmdChatMute{Contextified: libkb.NewContextified(g)}
+			cl.ChooseCommand(cmd, "mute", c)
 		},
-		Flags: append(getConversationResolverFlags(), mustGetChatFlags("block", "unhide")...),
+		Flags: append(getConversationResolverFlags(), mustGetChatFlags("unhide")...),
 	}
 }
 
-func (c *CmdChatHide) ParseArgv(ctx *cli.Context) error {
+func (c *CmdChatMute) ParseArgv(ctx *cli.Context) error {
 	var err error
 
 	if len(ctx.Args()) > 1 {
@@ -47,16 +47,9 @@ func (c *CmdChatHide) ParseArgv(ctx *cli.Context) error {
 		return err
 	}
 
-	block := ctx.Bool("block")
 	unhide := ctx.Bool("unhide")
 
-	c.status = chat1.ConversationStatus_IGNORED
-	if block && unhide {
-		return fmt.Errorf("cannot do both --block and --unhide")
-	}
-	if block {
-		c.status = chat1.ConversationStatus_BLOCKED
-	}
+	c.status = chat1.ConversationStatus_MUTED
 	if unhide {
 		c.status = chat1.ConversationStatus_UNFILED
 	}
@@ -64,7 +57,7 @@ func (c *CmdChatHide) ParseArgv(ctx *cli.Context) error {
 	return nil
 }
 
-func (c *CmdChatHide) Run() error {
+func (c *CmdChatMute) Run() error {
 	ctx := context.TODO()
 
 	chatClient, err := GetChatLocalClient(c.G())
@@ -99,7 +92,7 @@ func (c *CmdChatHide) Run() error {
 	return nil
 }
 
-func (c *CmdChatHide) GetUsage() libkb.Usage {
+func (c *CmdChatMute) GetUsage() libkb.Usage {
 	return libkb.Usage{
 		API:       true,
 		KbKeyring: true,

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -82,6 +82,7 @@ const (
 	ConversationStatus_FAVORITE ConversationStatus = 1
 	ConversationStatus_IGNORED  ConversationStatus = 2
 	ConversationStatus_BLOCKED  ConversationStatus = 3
+	ConversationStatus_MUTED    ConversationStatus = 4
 )
 
 var ConversationStatusMap = map[string]ConversationStatus{
@@ -89,6 +90,7 @@ var ConversationStatusMap = map[string]ConversationStatus{
 	"FAVORITE": 1,
 	"IGNORED":  2,
 	"BLOCKED":  3,
+	"MUTED":    4,
 }
 
 var ConversationStatusRevMap = map[ConversationStatus]string{
@@ -96,6 +98,7 @@ var ConversationStatusRevMap = map[ConversationStatus]string{
 	1: "FAVORITE",
 	2: "IGNORED",
 	3: "BLOCKED",
+	4: "MUTED",
 }
 
 func (e ConversationStatus) String() string {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -164,6 +164,7 @@ var ConversationStatusGregorMap = map[ConversationStatus]string{
 	ConversationStatus_FAVORITE: "favorite",
 	ConversationStatus_IGNORED:  "ignored",
 	ConversationStatus_BLOCKED:  "blocked",
+	ConversationStatus_MUTED:    "muted",
 }
 
 var ConversationStatusGregorRevMap = map[string]ConversationStatus{
@@ -171,6 +172,7 @@ var ConversationStatusGregorRevMap = map[string]ConversationStatus{
 	"favorite": ConversationStatus_FAVORITE,
 	"ignored":  ConversationStatus_IGNORED,
 	"blocked":  ConversationStatus_BLOCKED,
+	"muted":    ConversationStatus_MUTED,
 }
 
 func (t ConversationIDTriple) Hash() []byte {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -854,3 +854,7 @@ func (u UserPlusAllKeys) FindDevice(d DeviceID) *PublicKey {
 	}
 	return nil
 }
+
+func (s ChatConversationID) String() string {
+	return hex.EncodeToString(s)
+}

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -33,10 +33,10 @@ protocol common {
   }
 
   enum ConversationStatus {
-    // default status of the conversation
+    // Default status of the conversation
     UNFILED_0,
 
-    // ???
+    // Not used yet.
     FAVORITE_1,
 
     // This status is useful for temporarily muting a conversation. Unless told
@@ -46,10 +46,14 @@ protocol common {
     // status, it's automatically changed back to UNFILED.
     IGNORED_2,
 
-    // The conversation is muted (i.e. not included in GetInboxRemote results
+    // The conversation is blocked (i.e. not included in GetInboxRemote results
     // by default), until SetConversationStatus is called with a different
     // status.
-    BLOCKED_3
+    BLOCKED_3,
+
+    // The conversation appears in the inbox with no snippet,
+    // and does not emit notifications nor badges.
+    MUTED_4
   }
 
   record Pagination {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -57,6 +57,7 @@ export const CommonConversationStatus = {
   favorite: 1,
   ignored: 2,
   blocked: 3,
+  muted: 4,
 }
 
 export const CommonInboxResType = {
@@ -747,6 +748,7 @@ export type ConversationStatus =
   | 1 // FAVORITE_1
   | 2 // IGNORED_2
   | 3 // BLOCKED_3
+  | 4 // MUTED_4
 
 export type DownloadAttachmentLocalRes = {
   rateLimits?: ?Array<RateLimit>,

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -91,7 +91,8 @@
         "UNFILED_0",
         "FAVORITE_1",
         "IGNORED_2",
-        "BLOCKED_3"
+        "BLOCKED_3",
+        "MUTED_4"
       ]
     },
     {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -57,6 +57,7 @@ export const CommonConversationStatus = {
   favorite: 1,
   ignored: 2,
   blocked: 3,
+  muted: 4,
 }
 
 export const CommonInboxResType = {
@@ -747,6 +748,7 @@ export type ConversationStatus =
   | 1 // FAVORITE_1
   | 2 // IGNORED_2
   | 3 // BLOCKED_3
+  | 4 // MUTED_4
 
 export type DownloadAttachmentLocalRes = {
   rateLimits?: ?Array<RateLimit>,


### PR DESCRIPTION
Adds a `chat mute` command and teaches `inbox.go` how to handle `muted`. Now there's both `chat hide` and `chat mute`, but let's clean that up later.

This is the client side of https://github.com/keybase/gregor/pull/276

```
NAME:
   keybase chat mute - Mute or unmute a conversation.

USAGE:
   keybase chat mute [command options] [<conversation>]

OPTIONS:
   --topic-type "chat"	Specify topic name of the conversation. Has to be chat or dev
   --topic-name 	Specify topic name of the conversation.
   --public		Only select public conversations. Exclusive to --private
   --private		Only select private conversations. Exclusive to --public. If both --public and --private are present, --private takes priority.
   -u, --unhide		Unhide/unblock the conversation
```

r? @mmaxim 

cc @patrickxb I cherry-picked just `MessageType_ATTACHMENTUPLOADED`. So that I could vendor into my local gregor without it blowing up (because it has code that depends on vendoring from the future). Hopefully this won't get in your way too much if it gets merged first?

cc @cjb Here's this. But it depends on future gregor, so I'll ping you when that gets deployed.