### PR TITLE
support default variants

### DIFF
--- a/protocol/bin/flow.js
+++ b/protocol/bin/flow.js
@@ -109,9 +109,9 @@ function analyzeTypes (json, project) {
       case 'record':
         return [`export type ${t.name} = ${parseRecord(t)}`]
       case 'enum':
-        return [`export type ${t.name} = ${parseEnum(t)}`]
+        return [`export type ${t.name} =${parseEnum(t)}`]
       case 'variant':
-        return [`export type ${t.name} = ${parseVariant(t, project)}`]
+        return [`export type ${t.name} =${parseVariant(t, project)}`]
       case 'fixed':
         return [`export type ${t.name} = any`]
       default:
@@ -274,21 +274,15 @@ function parseRecord (t) {
     return t.typedef
   }
 
-  var objectMapType = '{'
-
-  if (t.fields.length) {
-    objectMapType += '\n'
-  }
-
-  t.fields.forEach(f => {
-    var innerType = parseInnerType(f.type)
+  const divider = t.fields.length ? '\n' : ''
+  const fields = t.fields.map(f => {
+    const innerType = parseInnerType(f.type)
 
     // If we have a maybe type, let's also make the key optional
-    objectMapType += `  ${f.name}${(innerType[0] === '?') ? '?' : ''}: ${innerType},\n`
-  })
-  objectMapType += '}'
+    return `  ${f.name}${(innerType[0] === '?') ? '?' : ''}: ${innerType},\n`
+  }).join('')
 
-  return objectMapType
+  return `{${divider}${fields}}`
 }
 
 function parseVariant (t, project) {

--- a/protocol/bin/flow.js
+++ b/protocol/bin/flow.js
@@ -296,15 +296,17 @@ function parseVariant (t, project) {
   if (parts.length > 1) {
     project = projects[parts.shift()]
   }
+
   var type = parts.shift()
   return '\n    ' + t.cases.map(c => {
-    var label = fixCase(c.label.name)
-    var out = `{ ${t.switch.name} : ${project.enums[type][label]}`
-    if (c.body !== null) {
-      out += `, ${label} : ?${c.body}`
+    if (c.label.def) {
+      const bodyStr = c.body ? `, 'default': ?${c.body}` : ''
+      return `{ ${t.switch.name}: any${bodyStr} }`
+    } else {
+      var label = fixCase(c.label.name)
+      const bodyStr = c.body ?  `, ${label}: ?${c.body}` : ''
+      return `{ ${t.switch.name}: ${project.enums[type][label]}${bodyStr} }`
     }
-    out += ` }`
-    return out
   }).join('\n  | ')
 }
 

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -594,9 +594,9 @@ export type Asset = {
 }
 
 export type AssetMetadata = 
-    { assetType : 1, image : ?AssetMetadataImage }
-  | { assetType : 2, video : ?AssetMetadataVideo }
-  | { assetType : 3, audio : ?AssetMetadataAudio }
+    { assetType: 1, image: ?AssetMetadataImage }
+  | { assetType: 2, video: ?AssetMetadataVideo }
+  | { assetType: 3, audio: ?AssetMetadataAudio }
 
 export type AssetMetadataAudio = {
   durationMs: int,
@@ -623,8 +623,9 @@ export type AssetTag =
     0 // PRIMARY_0
 
 export type BodyPlaintext = 
-    { version : 1, v1 : ?BodyPlaintextV1 }
-  | { version : 2, v2 : ?BodyPlaintextV2 }
+    { version: 1, v1: ?BodyPlaintextV1 }
+  | { version: 2, v2: ?BodyPlaintextV2 }
+  | { version: any, 'default': ?BodyPlaintextUnsupported }
 
 export type BodyPlaintextUnsupported = {
   vi: BodyPlaintextVersionInfo,
@@ -647,11 +648,11 @@ export type BodyPlaintextVersionInfo = {
 }
 
 export type ChatActivity = 
-    { activityType : 1, incomingMessage : ?IncomingMessage }
-  | { activityType : 2, readMessage : ?ReadMessageInfo }
-  | { activityType : 3, newConversation : ?NewConversationInfo }
-  | { activityType : 4, setStatus : ?SetStatusInfo }
-  | { activityType : 5, failedMessage : ?FailedMessageInfo }
+    { activityType: 1, incomingMessage: ?IncomingMessage }
+  | { activityType: 2, readMessage: ?ReadMessageInfo }
+  | { activityType: 3, newConversation: ?NewConversationInfo }
+  | { activityType: 4, setStatus: ?SetStatusInfo }
+  | { activityType: 5, failedMessage: ?FailedMessageInfo }
 
 export type ChatActivityType = 
     0 // RESERVED_0
@@ -912,7 +913,7 @@ export type GetThreadRemoteRes = {
 export type Hash = bytes
 
 export type HeaderPlaintext = 
-    { version : 1, v1 : ?HeaderPlaintextV1 }
+    { version: 1, v1: ?HeaderPlaintextV1 }
 
 export type HeaderPlaintextV1 = {
   conv: ConversationIDTriple,
@@ -945,8 +946,8 @@ export type InboxResType =
 export type InboxVers = uint64
 
 export type InboxView = 
-    { rtype : 0 }
-  | { rtype : 1, full : ?InboxViewFull }
+    { rtype: 0 }
+  | { rtype: 1, full: ?InboxViewFull }
 
 export type InboxViewFull = {
   vers: InboxVers,
@@ -1000,21 +1001,21 @@ export type MessageAttachmentV1 = {
 }
 
 export type MessageBody = 
-    { messageType : 1, text : ?MessageText }
-  | { messageType : 2, attachment : ?MessageAttachment }
-  | { messageType : 3, edit : ?MessageEdit }
-  | { messageType : 4, delete : ?MessageDelete }
-  | { messageType : 5, metadata : ?MessageConversationMetadata }
-  | { messageType : 7, headline : ?MessageHeadline }
-  | { messageType : 8, attachmentuploaded : ?MessageAttachmentUploaded }
+    { messageType: 1, text: ?MessageText }
+  | { messageType: 2, attachment: ?MessageAttachment }
+  | { messageType: 3, edit: ?MessageEdit }
+  | { messageType: 4, delete: ?MessageDelete }
+  | { messageType: 5, metadata: ?MessageConversationMetadata }
+  | { messageType: 7, headline: ?MessageHeadline }
+  | { messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded }
 
 export type MessageBodyV1 = 
-    { messageType : 1, text : ?MessageText }
-  | { messageType : 2, attachment : ?MessageAttachmentV1 }
-  | { messageType : 3, edit : ?MessageEdit }
-  | { messageType : 4, delete : ?MessageDelete }
-  | { messageType : 5, metadata : ?MessageConversationMetadata }
-  | { messageType : 7, headline : ?MessageHeadline }
+    { messageType: 1, text: ?MessageText }
+  | { messageType: 2, attachment: ?MessageAttachmentV1 }
+  | { messageType: 3, edit: ?MessageEdit }
+  | { messageType: 4, delete: ?MessageDelete }
+  | { messageType: 5, metadata: ?MessageConversationMetadata }
+  | { messageType: 7, headline: ?MessageHeadline }
 
 export type MessageBoxed = {
   serverHeader?: ?MessageServerHeader,
@@ -1090,9 +1091,9 @@ export type MessageType =
   | 8 // ATTACHMENTUPLOADED_8
 
 export type MessageUnboxed = 
-    { state : 1, valid : ?MessageUnboxedValid }
-  | { state : 2, error : ?MessageUnboxedError }
-  | { state : 3, outbox : ?OutboxRecord }
+    { state: 1, valid: ?MessageUnboxedValid }
+  | { state: 2, error: ?MessageUnboxedError }
+  | { state: 3, outbox: ?OutboxRecord }
 
 export type MessageUnboxedError = {
   errMsg: string,
@@ -1201,8 +1202,8 @@ export type OutboxRecord = {
 }
 
 export type OutboxState = 
-    { state : 0, sending : ?int }
-  | { state : 1, error : ?OutboxStateError }
+    { state: 0, sending: ?int }
+  | { state: 1, error: ?OutboxStateError }
 
 export type OutboxStateError = {
   message: string,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -593,7 +593,7 @@ export type Asset = {
   tag: AssetTag,
 }
 
-export type AssetMetadata = 
+export type AssetMetadata =
     { assetType: 1, image: ?AssetMetadataImage }
   | { assetType: 2, video: ?AssetMetadataVideo }
   | { assetType: 3, audio: ?AssetMetadataAudio }
@@ -607,7 +607,7 @@ export type AssetMetadataImage = {
   height: int,
 }
 
-export type AssetMetadataType = 
+export type AssetMetadataType =
     0 // NONE_0
   | 1 // IMAGE_1
   | 2 // VIDEO_2
@@ -619,10 +619,10 @@ export type AssetMetadataVideo = {
   durationMs: int,
 }
 
-export type AssetTag = 
+export type AssetTag =
     0 // PRIMARY_0
 
-export type BodyPlaintext = 
+export type BodyPlaintext =
     { version: 1, v1: ?BodyPlaintextV1 }
   | { version: 2, v2: ?BodyPlaintextV2 }
   | { version: any, 'default': ?BodyPlaintextUnsupported }
@@ -639,7 +639,7 @@ export type BodyPlaintextV2 = {
   messageBody: MessageBody,
 }
 
-export type BodyPlaintextVersion = 
+export type BodyPlaintextVersion =
     1 // V1_1
   | 2 // V2_2
 
@@ -647,14 +647,14 @@ export type BodyPlaintextVersionInfo = {
   crit: boolean,
 }
 
-export type ChatActivity = 
+export type ChatActivity =
     { activityType: 1, incomingMessage: ?IncomingMessage }
   | { activityType: 2, readMessage: ?ReadMessageInfo }
   | { activityType: 3, newConversation: ?NewConversationInfo }
   | { activityType: 4, setStatus: ?SetStatusInfo }
   | { activityType: 5, failedMessage: ?FailedMessageInfo }
 
-export type ChatActivityType = 
+export type ChatActivityType =
     0 // RESERVED_0
   | 1 // INCOMING_MESSAGE_1
   | 2 // READ_MESSAGE_2
@@ -686,7 +686,7 @@ export type ConversationErrorRekey = {
   readerNames?: ?Array<string>,
 }
 
-export type ConversationErrorType = 
+export type ConversationErrorType =
     0 // MISC_0
   | 1 // MISSINGINFO_1
   | 2 // SELFREKEYNEEDED_2
@@ -751,7 +751,7 @@ export type ConversationResolveInfo = {
   newTLFName: string,
 }
 
-export type ConversationStatus = 
+export type ConversationStatus =
     0 // UNFILED_0
   | 1 // FAVORITE_1
   | 2 // IGNORED_2
@@ -912,7 +912,7 @@ export type GetThreadRemoteRes = {
 
 export type Hash = bytes
 
-export type HeaderPlaintext = 
+export type HeaderPlaintext =
     { version: 1, v1: ?HeaderPlaintextV1 }
 
 export type HeaderPlaintextV1 = {
@@ -929,7 +929,7 @@ export type HeaderPlaintextV1 = {
   headerSignature?: ?SignatureInfo,
 }
 
-export type HeaderPlaintextVersion = 
+export type HeaderPlaintextVersion =
     1 // V1_1
 
 export type Inbox = {
@@ -939,13 +939,13 @@ export type Inbox = {
   pagination?: ?Pagination,
 }
 
-export type InboxResType = 
+export type InboxResType =
     0 // VERSIONHIT_0
   | 1 // FULL_1
 
 export type InboxVers = uint64
 
-export type InboxView = 
+export type InboxView =
     { rtype: 0 }
   | { rtype: 1, full: ?InboxViewFull }
 
@@ -1000,7 +1000,7 @@ export type MessageAttachmentV1 = {
   metadata: bytes,
 }
 
-export type MessageBody = 
+export type MessageBody =
     { messageType: 1, text: ?MessageText }
   | { messageType: 2, attachment: ?MessageAttachment }
   | { messageType: 3, edit: ?MessageEdit }
@@ -1009,7 +1009,7 @@ export type MessageBody =
   | { messageType: 7, headline: ?MessageHeadline }
   | { messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded }
 
-export type MessageBodyV1 = 
+export type MessageBodyV1 =
     { messageType: 1, text: ?MessageText }
   | { messageType: 2, attachment: ?MessageAttachmentV1 }
   | { messageType: 3, edit: ?MessageEdit }
@@ -1079,7 +1079,7 @@ export type MessageText = {
   body: string,
 }
 
-export type MessageType = 
+export type MessageType =
     0 // NONE_0
   | 1 // TEXT_1
   | 2 // ATTACHMENT_2
@@ -1090,7 +1090,7 @@ export type MessageType =
   | 7 // HEADLINE_7
   | 8 // ATTACHMENTUPLOADED_8
 
-export type MessageUnboxed = 
+export type MessageUnboxed =
     { state: 1, valid: ?MessageUnboxedValid }
   | { state: 2, error: ?MessageUnboxedError }
   | { state: 3, outbox: ?OutboxRecord }
@@ -1101,7 +1101,7 @@ export type MessageUnboxedError = {
   messageType: MessageType,
 }
 
-export type MessageUnboxedState = 
+export type MessageUnboxedState =
     1 // VALID_1
   | 2 // ERROR_2
   | 3 // OUTBOX_3
@@ -1179,7 +1179,7 @@ export type NotifyChatNewChatActivityRpcParam = Exact<{
   activity: ChatActivity
 }>
 
-export type OutboxErrorType = 
+export type OutboxErrorType =
     0 // MISC_0
   | 1 // OFFLINE_1
   | 2 // IDENTIFY_2
@@ -1201,7 +1201,7 @@ export type OutboxRecord = {
   identifyBehavior: keybase1.TLFIdentifyBehavior,
 }
 
-export type OutboxState = 
+export type OutboxState =
     { state: 0, sending: ?int }
   | { state: 1, error: ?OutboxStateError }
 
@@ -1210,7 +1210,7 @@ export type OutboxStateError = {
   typ: OutboxErrorType,
 }
 
-export type OutboxStateType = 
+export type OutboxStateType =
     0 // SENDING_0
   | 1 // ERROR_1
 
@@ -1311,7 +1311,7 @@ export type TLFResolveUpdate = {
   inboxVers: InboxVers,
 }
 
-export type TLFVisibility = 
+export type TLFVisibility =
     0 // ANY_0
   | 1 // PUBLIC_1
   | 2 // PRIVATE_2
@@ -1330,7 +1330,7 @@ export type ThreadViewBoxed = {
 
 export type TopicID = bytes
 
-export type TopicType = 
+export type TopicType =
     0 // NONE_0
   | 1 // CHAT_1
   | 2 // DEV_2

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -2882,12 +2882,12 @@ export type CheckResult = {
   freshness: CheckResultFreshness,
 }
 
-export type CheckResultFreshness = 
+export type CheckResultFreshness =
     0 // FRESH_0
   | 1 // AGED_1
   | 2 // RANCID_2
 
-export type ChooseType = 
+export type ChooseType =
     0 // EXISTING_DEVICE_0
   | 1 // NEW_DEVICE_1
 
@@ -2906,7 +2906,7 @@ export type ClientDetails = {
   version: string,
 }
 
-export type ClientType = 
+export type ClientType =
     0 // NONE_0
   | 1 // CLI_1
   | 2 // GUI_2
@@ -2974,7 +2974,7 @@ export type DbKey = {
   key: string,
 }
 
-export type DbType = 
+export type DbType =
     0 // MAIN_0
   | 1 // CHAT_1
 
@@ -3005,7 +3005,7 @@ export type DeviceDetail = {
 
 export type DeviceID = string
 
-export type DeviceType = 
+export type DeviceType =
     0 // DESKTOP_0
   | 1 // MOBILE_1
 
@@ -3015,7 +3015,7 @@ export type DismissReason = {
   resource: string,
 }
 
-export type DismissReasonType = 
+export type DismissReasonType =
     0 // NONE_0
   | 1 // HANDLED_ELSEWHERE_1
 
@@ -3042,7 +3042,7 @@ export type Email = {
 
 export type EncryptedBytes32 = any
 
-export type ExitCode = 
+export type ExitCode =
     0 // OK_0
   | 2 // NOTOK_2
   | 4 // RESTART_4
@@ -3073,7 +3073,7 @@ export type FSEditListRequest = {
   requestID: int,
 }
 
-export type FSErrorType = 
+export type FSErrorType =
     0 // ACCESS_DENIED_0
   | 1 // USER_NOT_FOUND_1
   | 2 // REVOKED_DATA_DETECTED_2
@@ -3099,7 +3099,7 @@ export type FSNotification = {
   localTime: Time,
 }
 
-export type FSNotificationType = 
+export type FSNotificationType =
     0 // ENCRYPTING_0
   | 1 // DECRYPTING_1
   | 2 // SIGNING_2
@@ -3120,7 +3120,7 @@ export type FSPathSyncStatus = {
   syncedBytes: int64,
 }
 
-export type FSStatusCode = 
+export type FSStatusCode =
     0 // START_0
   | 1 // FINISH_1
   | 2 // ERROR_2
@@ -3157,7 +3157,7 @@ export type FileDescriptor = {
   type: FileType,
 }
 
-export type FileType = 
+export type FileType =
     0 // UNKNOWN_0
   | 1 // DIRECTORY_1
   | 2 // FILE_2
@@ -3173,7 +3173,7 @@ export type Folder = {
   created: boolean,
 }
 
-export type ForkType = 
+export type ForkType =
     0 // NONE_0
   | 1 // AUTO_1
   | 2 // WATCHDOG_2
@@ -3205,7 +3205,7 @@ export type GPGKey = {
   identities?: ?Array<PGPIdentity>,
 }
 
-export type GPGMethod = 
+export type GPGMethod =
     0 // GPG_NONE_0
   | 1 // GPG_IMPORT_1
   | 2 // GPG_SIGN_2
@@ -3299,7 +3299,7 @@ export type IdentifyReason = {
   resource: string,
 }
 
-export type IdentifyReasonType = 
+export type IdentifyReasonType =
     0 // NONE_0
   | 1 // ID_1
   | 2 // TRACK_2
@@ -3337,7 +3337,7 @@ export type Identity = {
   breaksTracking: boolean,
 }
 
-export type InstallAction = 
+export type InstallAction =
     0 // UNKNOWN_0
   | 1 // NONE_1
   | 2 // UPGRADE_2
@@ -3350,7 +3350,7 @@ export type InstallResult = {
   fatal: boolean,
 }
 
-export type InstallStatus = 
+export type InstallStatus =
     0 // UNKNOWN_0
   | 1 // ERROR_1
   | 2 // NOT_INSTALLED_2
@@ -3433,7 +3433,7 @@ export type LoadDeviceErr = {
   desc: string,
 }
 
-export type LogLevel = 
+export type LogLevel =
     0 // NONE_0
   | 1 // DEBUG_1
   | 2 // INFO_2
@@ -3454,7 +3454,7 @@ export type MerkleRoot = {
   root: bytes,
 }
 
-export type MerkleTreeID = 
+export type MerkleTreeID =
     0 // MASTER_0
   | 1 // KBFS_PUBLIC_1
   | 2 // KBFS_PRIVATE_2
@@ -3559,7 +3559,7 @@ export type OutOfDateInfo = {
   criticalClockSkew: long,
 }
 
-export type Outcome = 
+export type Outcome =
     0 // NONE_0
   | 1 // FIXED_1
   | 2 // IGNORED_2
@@ -3622,7 +3622,7 @@ export type PassphraseStream = {
   generation: int,
 }
 
-export type PassphraseType = 
+export type PassphraseType =
     0 // NONE_0
   | 1 // PAPER_KEY_1
   | 2 // PASS_PHRASE_2
@@ -3662,12 +3662,12 @@ export type Process = {
   fileDescriptors?: ?Array<FileDescriptor>,
 }
 
-export type PromptDefault = 
+export type PromptDefault =
     0 // NONE_0
   | 1 // YES_1
   | 2 // NO_2
 
-export type PromptOverwriteType = 
+export type PromptOverwriteType =
     0 // SOCIAL_0
   | 1 // SITE_1
 
@@ -3677,7 +3677,7 @@ export type ProofResult = {
   desc: string,
 }
 
-export type ProofState = 
+export type ProofState =
     0 // NONE_0
   | 1 // OK_1
   | 2 // TEMP_FAILURE_2
@@ -3691,7 +3691,7 @@ export type ProofState =
   | 10 // SIG_HINT_MISSING_10
   | 11 // UNCHECKED_11
 
-export type ProofStatus = 
+export type ProofStatus =
     0 // NONE_0
   | 1 // OK_1
   | 2 // LOCAL_2
@@ -3732,7 +3732,7 @@ export type ProofStatus =
   | 307 // BAD_HINT_TEXT_307
   | 308 // INVALID_PVL_308
 
-export type ProofType = 
+export type ProofType =
     0 // NONE_0
   | 1 // KEYBASE_1
   | 2 // TWITTER_2
@@ -3752,7 +3752,7 @@ export type Proofs = {
   publicKeys?: ?Array<PublicKey>,
 }
 
-export type ProvisionMethod = 
+export type ProvisionMethod =
     0 // DEVICE_0
   | 1 // PAPER_KEY_1
   | 2 // PASSPHRASE_2
@@ -3773,7 +3773,7 @@ export type PublicKey = {
   eTime: Time,
 }
 
-export type PushReason = 
+export type PushReason =
     0 // NONE_0
   | 1 // RECONNECTED_1
   | 2 // NEW_DATA_2
@@ -3782,7 +3782,7 @@ export type Reachability = {
   reachable: Reachable,
 }
 
-export type Reachable = 
+export type Reachable =
     0 // UNKNOWN_0
   | 1 // YES_1
   | 2 // NO_2
@@ -3797,7 +3797,7 @@ export type RekeyEvent = {
   interruptType: int,
 }
 
-export type RekeyEventType = 
+export type RekeyEventType =
     0 // NONE_0
   | 1 // NOT_LOGGED_IN_1
   | 2 // API_ERROR_2
@@ -3870,7 +3870,7 @@ export type SaltpackSender = {
   senderType: SaltpackSenderType,
 }
 
-export type SaltpackSenderType = 
+export type SaltpackSenderType =
     0 // NOT_TRACKED_0
   | 1 // UNKNOWN_1
   | 2 // ANONYMOUS_2
@@ -4016,7 +4016,7 @@ export type SigTypes = {
   isSelf: boolean,
 }
 
-export type SignMode = 
+export type SignMode =
     0 // ATTACHED_0
   | 1 // DETACHED_1
   | 2 // CLEAR_2
@@ -4045,7 +4045,7 @@ export type Status = {
   fields?: ?Array<StringKVPair>,
 }
 
-export type StatusCode = 
+export type StatusCode =
     0 // SCOk_0
   | 100 // SCInputError_100
   | 201 // SCLoginRequired_201
@@ -4155,7 +4155,7 @@ export type TLFBreak = {
 
 export type TLFID = string
 
-export type TLFIdentifyBehavior = 
+export type TLFIdentifyBehavior =
     0 // DEFAULT_KBFS_0
   | 1 // CHAT_CLI_1
   | 2 // CHAT_GUI_2
@@ -4187,7 +4187,7 @@ export type TrackDiff = {
   displayMarkup: string,
 }
 
-export type TrackDiffType = 
+export type TrackDiffType =
     0 // NONE_0
   | 1 // ERROR_1
   | 2 // CLASH_2
@@ -4214,7 +4214,7 @@ export type TrackProof = {
   idString: string,
 }
 
-export type TrackStatus = 
+export type TrackStatus =
     1 // NEW_OK_1
   | 2 // NEW_ZERO_PROOFS_2
   | 3 // NEW_FAIL_PROOFS_3

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -593,10 +593,10 @@ export type Asset = {
   tag: AssetTag,
 }
 
-export type AssetMetadata = 
-    { assetType : 1, image : ?AssetMetadataImage }
-  | { assetType : 2, video : ?AssetMetadataVideo }
-  | { assetType : 3, audio : ?AssetMetadataAudio }
+export type AssetMetadata =
+    { assetType: 1, image: ?AssetMetadataImage }
+  | { assetType: 2, video: ?AssetMetadataVideo }
+  | { assetType: 3, audio: ?AssetMetadataAudio }
 
 export type AssetMetadataAudio = {
   durationMs: int,
@@ -607,7 +607,7 @@ export type AssetMetadataImage = {
   height: int,
 }
 
-export type AssetMetadataType = 
+export type AssetMetadataType =
     0 // NONE_0
   | 1 // IMAGE_1
   | 2 // VIDEO_2
@@ -619,12 +619,13 @@ export type AssetMetadataVideo = {
   durationMs: int,
 }
 
-export type AssetTag = 
+export type AssetTag =
     0 // PRIMARY_0
 
-export type BodyPlaintext = 
-    { version : 1, v1 : ?BodyPlaintextV1 }
-  | { version : 2, v2 : ?BodyPlaintextV2 }
+export type BodyPlaintext =
+    { version: 1, v1: ?BodyPlaintextV1 }
+  | { version: 2, v2: ?BodyPlaintextV2 }
+  | { version: any, 'default': ?BodyPlaintextUnsupported }
 
 export type BodyPlaintextUnsupported = {
   vi: BodyPlaintextVersionInfo,
@@ -638,7 +639,7 @@ export type BodyPlaintextV2 = {
   messageBody: MessageBody,
 }
 
-export type BodyPlaintextVersion = 
+export type BodyPlaintextVersion =
     1 // V1_1
   | 2 // V2_2
 
@@ -646,14 +647,14 @@ export type BodyPlaintextVersionInfo = {
   crit: boolean,
 }
 
-export type ChatActivity = 
-    { activityType : 1, incomingMessage : ?IncomingMessage }
-  | { activityType : 2, readMessage : ?ReadMessageInfo }
-  | { activityType : 3, newConversation : ?NewConversationInfo }
-  | { activityType : 4, setStatus : ?SetStatusInfo }
-  | { activityType : 5, failedMessage : ?FailedMessageInfo }
+export type ChatActivity =
+    { activityType: 1, incomingMessage: ?IncomingMessage }
+  | { activityType: 2, readMessage: ?ReadMessageInfo }
+  | { activityType: 3, newConversation: ?NewConversationInfo }
+  | { activityType: 4, setStatus: ?SetStatusInfo }
+  | { activityType: 5, failedMessage: ?FailedMessageInfo }
 
-export type ChatActivityType = 
+export type ChatActivityType =
     0 // RESERVED_0
   | 1 // INCOMING_MESSAGE_1
   | 2 // READ_MESSAGE_2
@@ -685,7 +686,7 @@ export type ConversationErrorRekey = {
   readerNames?: ?Array<string>,
 }
 
-export type ConversationErrorType = 
+export type ConversationErrorType =
     0 // MISC_0
   | 1 // MISSINGINFO_1
   | 2 // SELFREKEYNEEDED_2
@@ -750,7 +751,7 @@ export type ConversationResolveInfo = {
   newTLFName: string,
 }
 
-export type ConversationStatus = 
+export type ConversationStatus =
     0 // UNFILED_0
   | 1 // FAVORITE_1
   | 2 // IGNORED_2
@@ -911,8 +912,8 @@ export type GetThreadRemoteRes = {
 
 export type Hash = bytes
 
-export type HeaderPlaintext = 
-    { version : 1, v1 : ?HeaderPlaintextV1 }
+export type HeaderPlaintext =
+    { version: 1, v1: ?HeaderPlaintextV1 }
 
 export type HeaderPlaintextV1 = {
   conv: ConversationIDTriple,
@@ -928,7 +929,7 @@ export type HeaderPlaintextV1 = {
   headerSignature?: ?SignatureInfo,
 }
 
-export type HeaderPlaintextVersion = 
+export type HeaderPlaintextVersion =
     1 // V1_1
 
 export type Inbox = {
@@ -938,15 +939,15 @@ export type Inbox = {
   pagination?: ?Pagination,
 }
 
-export type InboxResType = 
+export type InboxResType =
     0 // VERSIONHIT_0
   | 1 // FULL_1
 
 export type InboxVers = uint64
 
-export type InboxView = 
-    { rtype : 0 }
-  | { rtype : 1, full : ?InboxViewFull }
+export type InboxView =
+    { rtype: 0 }
+  | { rtype: 1, full: ?InboxViewFull }
 
 export type InboxViewFull = {
   vers: InboxVers,
@@ -999,22 +1000,22 @@ export type MessageAttachmentV1 = {
   metadata: bytes,
 }
 
-export type MessageBody = 
-    { messageType : 1, text : ?MessageText }
-  | { messageType : 2, attachment : ?MessageAttachment }
-  | { messageType : 3, edit : ?MessageEdit }
-  | { messageType : 4, delete : ?MessageDelete }
-  | { messageType : 5, metadata : ?MessageConversationMetadata }
-  | { messageType : 7, headline : ?MessageHeadline }
-  | { messageType : 8, attachmentuploaded : ?MessageAttachmentUploaded }
+export type MessageBody =
+    { messageType: 1, text: ?MessageText }
+  | { messageType: 2, attachment: ?MessageAttachment }
+  | { messageType: 3, edit: ?MessageEdit }
+  | { messageType: 4, delete: ?MessageDelete }
+  | { messageType: 5, metadata: ?MessageConversationMetadata }
+  | { messageType: 7, headline: ?MessageHeadline }
+  | { messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded }
 
-export type MessageBodyV1 = 
-    { messageType : 1, text : ?MessageText }
-  | { messageType : 2, attachment : ?MessageAttachmentV1 }
-  | { messageType : 3, edit : ?MessageEdit }
-  | { messageType : 4, delete : ?MessageDelete }
-  | { messageType : 5, metadata : ?MessageConversationMetadata }
-  | { messageType : 7, headline : ?MessageHeadline }
+export type MessageBodyV1 =
+    { messageType: 1, text: ?MessageText }
+  | { messageType: 2, attachment: ?MessageAttachmentV1 }
+  | { messageType: 3, edit: ?MessageEdit }
+  | { messageType: 4, delete: ?MessageDelete }
+  | { messageType: 5, metadata: ?MessageConversationMetadata }
+  | { messageType: 7, headline: ?MessageHeadline }
 
 export type MessageBoxed = {
   serverHeader?: ?MessageServerHeader,
@@ -1078,7 +1079,7 @@ export type MessageText = {
   body: string,
 }
 
-export type MessageType = 
+export type MessageType =
     0 // NONE_0
   | 1 // TEXT_1
   | 2 // ATTACHMENT_2
@@ -1089,10 +1090,10 @@ export type MessageType =
   | 7 // HEADLINE_7
   | 8 // ATTACHMENTUPLOADED_8
 
-export type MessageUnboxed = 
-    { state : 1, valid : ?MessageUnboxedValid }
-  | { state : 2, error : ?MessageUnboxedError }
-  | { state : 3, outbox : ?OutboxRecord }
+export type MessageUnboxed =
+    { state: 1, valid: ?MessageUnboxedValid }
+  | { state: 2, error: ?MessageUnboxedError }
+  | { state: 3, outbox: ?OutboxRecord }
 
 export type MessageUnboxedError = {
   errMsg: string,
@@ -1100,7 +1101,7 @@ export type MessageUnboxedError = {
   messageType: MessageType,
 }
 
-export type MessageUnboxedState = 
+export type MessageUnboxedState =
     1 // VALID_1
   | 2 // ERROR_2
   | 3 // OUTBOX_3
@@ -1178,7 +1179,7 @@ export type NotifyChatNewChatActivityRpcParam = Exact<{
   activity: ChatActivity
 }>
 
-export type OutboxErrorType = 
+export type OutboxErrorType =
     0 // MISC_0
   | 1 // OFFLINE_1
   | 2 // IDENTIFY_2
@@ -1200,16 +1201,16 @@ export type OutboxRecord = {
   identifyBehavior: keybase1.TLFIdentifyBehavior,
 }
 
-export type OutboxState = 
-    { state : 0, sending : ?int }
-  | { state : 1, error : ?OutboxStateError }
+export type OutboxState =
+    { state: 0, sending: ?int }
+  | { state: 1, error: ?OutboxStateError }
 
 export type OutboxStateError = {
   message: string,
   typ: OutboxErrorType,
 }
 
-export type OutboxStateType = 
+export type OutboxStateType =
     0 // SENDING_0
   | 1 // ERROR_1
 
@@ -1310,7 +1311,7 @@ export type TLFResolveUpdate = {
   inboxVers: InboxVers,
 }
 
-export type TLFVisibility = 
+export type TLFVisibility =
     0 // ANY_0
   | 1 // PUBLIC_1
   | 2 // PRIVATE_2
@@ -1329,7 +1330,7 @@ export type ThreadViewBoxed = {
 
 export type TopicID = bytes
 
-export type TopicType = 
+export type TopicType =
     0 // NONE_0
   | 1 // CHAT_1
   | 2 // DEV_2

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -2882,12 +2882,12 @@ export type CheckResult = {
   freshness: CheckResultFreshness,
 }
 
-export type CheckResultFreshness = 
+export type CheckResultFreshness =
     0 // FRESH_0
   | 1 // AGED_1
   | 2 // RANCID_2
 
-export type ChooseType = 
+export type ChooseType =
     0 // EXISTING_DEVICE_0
   | 1 // NEW_DEVICE_1
 
@@ -2906,7 +2906,7 @@ export type ClientDetails = {
   version: string,
 }
 
-export type ClientType = 
+export type ClientType =
     0 // NONE_0
   | 1 // CLI_1
   | 2 // GUI_2
@@ -2974,7 +2974,7 @@ export type DbKey = {
   key: string,
 }
 
-export type DbType = 
+export type DbType =
     0 // MAIN_0
   | 1 // CHAT_1
 
@@ -3005,7 +3005,7 @@ export type DeviceDetail = {
 
 export type DeviceID = string
 
-export type DeviceType = 
+export type DeviceType =
     0 // DESKTOP_0
   | 1 // MOBILE_1
 
@@ -3015,7 +3015,7 @@ export type DismissReason = {
   resource: string,
 }
 
-export type DismissReasonType = 
+export type DismissReasonType =
     0 // NONE_0
   | 1 // HANDLED_ELSEWHERE_1
 
@@ -3042,7 +3042,7 @@ export type Email = {
 
 export type EncryptedBytes32 = any
 
-export type ExitCode = 
+export type ExitCode =
     0 // OK_0
   | 2 // NOTOK_2
   | 4 // RESTART_4
@@ -3073,7 +3073,7 @@ export type FSEditListRequest = {
   requestID: int,
 }
 
-export type FSErrorType = 
+export type FSErrorType =
     0 // ACCESS_DENIED_0
   | 1 // USER_NOT_FOUND_1
   | 2 // REVOKED_DATA_DETECTED_2
@@ -3099,7 +3099,7 @@ export type FSNotification = {
   localTime: Time,
 }
 
-export type FSNotificationType = 
+export type FSNotificationType =
     0 // ENCRYPTING_0
   | 1 // DECRYPTING_1
   | 2 // SIGNING_2
@@ -3120,7 +3120,7 @@ export type FSPathSyncStatus = {
   syncedBytes: int64,
 }
 
-export type FSStatusCode = 
+export type FSStatusCode =
     0 // START_0
   | 1 // FINISH_1
   | 2 // ERROR_2
@@ -3157,7 +3157,7 @@ export type FileDescriptor = {
   type: FileType,
 }
 
-export type FileType = 
+export type FileType =
     0 // UNKNOWN_0
   | 1 // DIRECTORY_1
   | 2 // FILE_2
@@ -3173,7 +3173,7 @@ export type Folder = {
   created: boolean,
 }
 
-export type ForkType = 
+export type ForkType =
     0 // NONE_0
   | 1 // AUTO_1
   | 2 // WATCHDOG_2
@@ -3205,7 +3205,7 @@ export type GPGKey = {
   identities?: ?Array<PGPIdentity>,
 }
 
-export type GPGMethod = 
+export type GPGMethod =
     0 // GPG_NONE_0
   | 1 // GPG_IMPORT_1
   | 2 // GPG_SIGN_2
@@ -3299,7 +3299,7 @@ export type IdentifyReason = {
   resource: string,
 }
 
-export type IdentifyReasonType = 
+export type IdentifyReasonType =
     0 // NONE_0
   | 1 // ID_1
   | 2 // TRACK_2
@@ -3337,7 +3337,7 @@ export type Identity = {
   breaksTracking: boolean,
 }
 
-export type InstallAction = 
+export type InstallAction =
     0 // UNKNOWN_0
   | 1 // NONE_1
   | 2 // UPGRADE_2
@@ -3350,7 +3350,7 @@ export type InstallResult = {
   fatal: boolean,
 }
 
-export type InstallStatus = 
+export type InstallStatus =
     0 // UNKNOWN_0
   | 1 // ERROR_1
   | 2 // NOT_INSTALLED_2
@@ -3433,7 +3433,7 @@ export type LoadDeviceErr = {
   desc: string,
 }
 
-export type LogLevel = 
+export type LogLevel =
     0 // NONE_0
   | 1 // DEBUG_1
   | 2 // INFO_2
@@ -3454,7 +3454,7 @@ export type MerkleRoot = {
   root: bytes,
 }
 
-export type MerkleTreeID = 
+export type MerkleTreeID =
     0 // MASTER_0
   | 1 // KBFS_PUBLIC_1
   | 2 // KBFS_PRIVATE_2
@@ -3559,7 +3559,7 @@ export type OutOfDateInfo = {
   criticalClockSkew: long,
 }
 
-export type Outcome = 
+export type Outcome =
     0 // NONE_0
   | 1 // FIXED_1
   | 2 // IGNORED_2
@@ -3622,7 +3622,7 @@ export type PassphraseStream = {
   generation: int,
 }
 
-export type PassphraseType = 
+export type PassphraseType =
     0 // NONE_0
   | 1 // PAPER_KEY_1
   | 2 // PASS_PHRASE_2
@@ -3662,12 +3662,12 @@ export type Process = {
   fileDescriptors?: ?Array<FileDescriptor>,
 }
 
-export type PromptDefault = 
+export type PromptDefault =
     0 // NONE_0
   | 1 // YES_1
   | 2 // NO_2
 
-export type PromptOverwriteType = 
+export type PromptOverwriteType =
     0 // SOCIAL_0
   | 1 // SITE_1
 
@@ -3677,7 +3677,7 @@ export type ProofResult = {
   desc: string,
 }
 
-export type ProofState = 
+export type ProofState =
     0 // NONE_0
   | 1 // OK_1
   | 2 // TEMP_FAILURE_2
@@ -3691,7 +3691,7 @@ export type ProofState =
   | 10 // SIG_HINT_MISSING_10
   | 11 // UNCHECKED_11
 
-export type ProofStatus = 
+export type ProofStatus =
     0 // NONE_0
   | 1 // OK_1
   | 2 // LOCAL_2
@@ -3732,7 +3732,7 @@ export type ProofStatus =
   | 307 // BAD_HINT_TEXT_307
   | 308 // INVALID_PVL_308
 
-export type ProofType = 
+export type ProofType =
     0 // NONE_0
   | 1 // KEYBASE_1
   | 2 // TWITTER_2
@@ -3752,7 +3752,7 @@ export type Proofs = {
   publicKeys?: ?Array<PublicKey>,
 }
 
-export type ProvisionMethod = 
+export type ProvisionMethod =
     0 // DEVICE_0
   | 1 // PAPER_KEY_1
   | 2 // PASSPHRASE_2
@@ -3773,7 +3773,7 @@ export type PublicKey = {
   eTime: Time,
 }
 
-export type PushReason = 
+export type PushReason =
     0 // NONE_0
   | 1 // RECONNECTED_1
   | 2 // NEW_DATA_2
@@ -3782,7 +3782,7 @@ export type Reachability = {
   reachable: Reachable,
 }
 
-export type Reachable = 
+export type Reachable =
     0 // UNKNOWN_0
   | 1 // YES_1
   | 2 // NO_2
@@ -3797,7 +3797,7 @@ export type RekeyEvent = {
   interruptType: int,
 }
 
-export type RekeyEventType = 
+export type RekeyEventType =
     0 // NONE_0
   | 1 // NOT_LOGGED_IN_1
   | 2 // API_ERROR_2
@@ -3870,7 +3870,7 @@ export type SaltpackSender = {
   senderType: SaltpackSenderType,
 }
 
-export type SaltpackSenderType = 
+export type SaltpackSenderType =
     0 // NOT_TRACKED_0
   | 1 // UNKNOWN_1
   | 2 // ANONYMOUS_2
@@ -4016,7 +4016,7 @@ export type SigTypes = {
   isSelf: boolean,
 }
 
-export type SignMode = 
+export type SignMode =
     0 // ATTACHED_0
   | 1 // DETACHED_1
   | 2 // CLEAR_2
@@ -4045,7 +4045,7 @@ export type Status = {
   fields?: ?Array<StringKVPair>,
 }
 
-export type StatusCode = 
+export type StatusCode =
     0 // SCOk_0
   | 100 // SCInputError_100
   | 201 // SCLoginRequired_201
@@ -4155,7 +4155,7 @@ export type TLFBreak = {
 
 export type TLFID = string
 
-export type TLFIdentifyBehavior = 
+export type TLFIdentifyBehavior =
     0 // DEFAULT_KBFS_0
   | 1 // CHAT_CLI_1
   | 2 // CHAT_GUI_2
@@ -4187,7 +4187,7 @@ export type TrackDiff = {
   displayMarkup: string,
 }
 
-export type TrackDiffType = 
+export type TrackDiffType =
     0 // NONE_0
   | 1 // ERROR_1
   | 2 // CLASH_2
@@ -4214,7 +4214,7 @@ export type TrackProof = {
   idString: string,
 }
 
-export type TrackStatus = 
+export type TrackStatus =
     1 // NEW_OK_1
   | 2 // NEW_ZERO_PROOFS_2
   | 3 // NEW_FAIL_PROOFS_3


### PR DESCRIPTION
I used this to test that flow is able to handle this correctly with this

```
import type {BodyPlaintext, BodyPlaintextV1, BodyPlaintextV2, BodyPlaintextUnsupported} from '../constants/types/flow-types-chat'
const bodyPlaintext1: BodyPlaintext = {
  version: 1,
  v1: {
    messageBody: {
      messageType: 1, text: null,
    },
  },
}
const bodyPlaintext2: BodyPlaintext = {
  version: 2,
  v2: {
    messageBody: {
      messageType: 8,
      attachmentuploaded: null,
    },
  },
}
const bodyPlaintextDefault: BodyPlaintext = {
  version: 3,
  'default': {
    vi: {
      crit: true,
    },
  },
}
const all = [bodyPlaintext1, bodyPlaintext2, bodyPlaintextDefault]

all.forEach(a => {
  switch (a.version) {
    case 1:
      const v1: ?BodyPlaintextV1 = a.v1
      console.log(a.v1, v1)
      break
    case 2:
      const v2: ?BodyPlaintextV2 = a.v2
      console.log(a.v2, v2)
      break
    default:
      const unsup: ?BodyPlaintextUnsupported = a.default
      console.log(a.default.vi.crit, unsup)
      break
  }
})
```
