### PR TITLE
Linkify underscores in URLs

### DIFF
--- a/shared/common-adapters/dumb.js
+++ b/shared/common-adapters/dumb.js
@@ -846,16 +846,17 @@ else echo "bar";
     ftp://blah.com,
     gopher://blah.com,
     mailto:blah@blah.com
+    _http://keybase.io_
   Include:
     http://keybase.io
     *http://keybase.io*
-    *_http://keybase.io_*
     \`http://keybase.io\`
     https://keybase.io
     HTTP://cnn.com
     http://twitter.com
     google.com
     keybase.io/a/user/lookup?one=1&two=2
+    keybase.io/a/user/path_with_underscore
     keybase.io?blah=true
     http://keybase.io/blah/../up-one/index.html
   These should have the trailing punctuation outside the link:

--- a/shared/markdown/__test__/__snapshots__/parser.test.js.snap
+++ b/shared/markdown/__test__/__snapshots__/parser.test.js.snap
@@ -358,13 +358,7 @@ Object {
       "children": Array [
         Object {
           "children": Array [
-            Object {
-              "children": Array [
-                "http://keybase.io",
-              ],
-              "href": "http://keybase.io",
-              "type": "link",
-            },
+            "http://keybase.io",
           ],
           "type": "italic",
         },
@@ -422,6 +416,15 @@ Object {
         "keybase.io/a/user/lookup?one=1&two=2",
       ],
       "href": "http://keybase.io/a/user/lookup?one=1&two=2",
+      "type": "link",
+    },
+    "
+    ",
+    Object {
+      "children": Array [
+        "keybase.io/a/user/path_with_underscore",
+      ],
+      "href": "http://keybase.io/a/user/path_with_underscore",
       "type": "link",
     },
     "

--- a/shared/markdown/__test__/__snapshots__/parser.test.js.snap
+++ b/shared/markdown/__test__/__snapshots__/parser.test.js.snap
@@ -329,6 +329,14 @@ Object {
     ftp://blah.com,
     gopher://blah.com,
     mailto:blah@blah.com
+    ",
+    Object {
+      "children": Array [
+        "http://keybase.io",
+      ],
+      "type": "italic",
+    },
+    "
   Include:
     ",
     Object {
@@ -348,19 +356,6 @@ Object {
           ],
           "href": "http://keybase.io",
           "type": "link",
-        },
-      ],
-      "type": "bold",
-    },
-    "
-    ",
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [
-            "http://keybase.io",
-          ],
-          "type": "italic",
         },
       ],
       "type": "bold",

--- a/shared/markdown/__test__/parser.test.js
+++ b/shared/markdown/__test__/parser.test.js
@@ -99,6 +99,7 @@ this is a code block with two newline above\`\`\`
     http://twitter.com
     google.com
     keybase.io/a/user/lookup?one=1&two=2
+    keybase.io/a/user/path_with_underscore
     keybase.io?blah=true
     http://keybase.io/blah/../up-one/index.html
   These should have the trailing punctuation outside the link:

--- a/shared/markdown/__test__/parser.test.js
+++ b/shared/markdown/__test__/parser.test.js
@@ -89,10 +89,10 @@ this is a code block with two newline above\`\`\`
     ftp://blah.com,
     gopher://blah.com,
     mailto:blah@blah.com
+    _http://keybase.io_
   Include:
     http://keybase.io
     *http://keybase.io*
-    *_http://keybase.io_*
     \`http://keybase.io\`
     https://keybase.io
     HTTP://cnn.com

--- a/shared/markdown/parser.js
+++ b/shared/markdown/parser.js
@@ -2090,9 +2090,6 @@ function peg$parse(input, options) {
       s0 = peg$parseStrikeMarker();
       if (s0 === peg$FAILED) {
         s0 = peg$parseBoldMarker();
-        if (s0 === peg$FAILED) {
-          s0 = peg$parseItalicMarker();
-        }
       }
     }
 

--- a/shared/markdown/parser.pegjs
+++ b/shared/markdown/parser.pegjs
@@ -120,7 +120,7 @@ NativeEmoji
  }
 
 LinkSpecialChar
- = EscapeMarker / StrikeMarker / BoldMarker / ItalicMarker
+ = EscapeMarker / StrikeMarker / BoldMarker
 
 LinkChar
  = !LinkSpecialChar char:NonBlank { return char }


### PR DESCRIPTION
@keybase/react-hackers 

Here's a quick timeboxed fix that makes https://printf.net/foo_bar linkify the whole thing, instead of just the part up to the `_`.  It does this at the cost of no longer italicizing `_https://printf.net_`.  But having an underscore in a URL work seems more important than having italic URLs working.

If you don't like this change (it's my first time changing the peg grammar), let me know and I can at least insert a TODO to clean it up later.