### PR TITLE
Fix chat text leak

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -765,7 +765,7 @@ function * _incomingMessage (action: IncomingMessage): SagaGenerator<any, any> {
       }
       break
     default:
-      console.warn('Unsupported incoming message type for Chat:', action.payload.activity)
+      console.warn('Unsupported incoming message type for Chat of type:', action.payload.activity.activityType)
   }
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

Looks like this has been there for weeks -- we've been receiving unknown messages of type `readMessage` for a while (we don't have a handler for updating the latest read message because the badger drives this) and of type `setStatus` since muting support went in.  So this change only prints the type, but none of the payload.