### PR TITLE
fixes for finalized TLFs CORE-4514

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -95,7 +95,7 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, fina
 
 	umwkr, ierr := b.unboxMessageWithKey(ctx, boxed, matchKey)
 	if ierr != nil {
-		b.log().Warning("failed to unbox message: msgID: %d err: %s", boxed.ServerHeader.MessageID,
+		b.Debug(ctx, "failed to unbox message: msgID: %d err: %s", boxed.ServerHeader.MessageID,
 			ierr.Error())
 		if ierr.IsPermanent() {
 			return b.makeErrorMessage(boxed, ierr.Inner()), nil
@@ -106,9 +106,13 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, fina
 
 	username, deviceName, deviceType, err := b.getSenderInfoLocal(ctx, pt.ClientHeader)
 	if err != nil {
-		b.log().Warning("unable to fetch sender informaton: UID: %s deviceID: %s",
+		b.Debug(ctx, "unable to fetch sender and device informaton: UID: %s deviceID: %s",
 			pt.ClientHeader.Sender, pt.ClientHeader.SenderDevice)
-		// ignore non-fatal error
+		// try to jsut get username
+		username, err = b.getSenderUsername(ctx, pt.ClientHeader)
+		if err != nil {
+			b.Debug(ctx, "failed to fetch sender username after initial error: err: %s", err.Error())
+		}
 	}
 
 	return chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
@@ -266,6 +270,14 @@ func (b *Boxer) getUsernameAndDevice(ctx context.Context, uid keybase1.UID, devi
 		return "", "", "", err
 	}
 	return nun.String(), devName, devType, nil
+}
+
+func (b *Boxer) getSenderUsername(ctx context.Context, clientHeader chat1.MessageClientHeader) (string, error) {
+	name, err := b.G().GetUPAKLoader().LookupUsername(ctx, keybase1.UID(clientHeader.Sender.String()))
+	if err != nil {
+		return "", err
+	}
+	return name.String(), nil
 }
 
 func (b *Boxer) getSenderInfoLocal(ctx context.Context, clientHeader chat1.MessageClientHeader) (senderUsername string, senderDeviceName string, senderDeviceType string, err error) {
@@ -563,9 +575,11 @@ func (b *Boxer) ValidSenderKey(ctx context.Context, sender gregor1.UID, key []by
 	}
 
 	if deleted {
-		// XXX something else to flag as a deleted key?
-		b.log().Warning("sender %s key %s was deleted", kbSender, kid)
-		return true, true, nil, nil
+		b.Debug(ctx, "sender %s key %s was deleted", kbSender, kid)
+		// Set the key as being revoked since the beginning of time, so all messages will get labeled
+		// as suspect
+		zeroTime := gregor1.Time(0)
+		return true, true, &zeroTime, nil
 	}
 
 	validAtCtime := true

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -108,7 +108,7 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, fina
 	if err != nil {
 		b.Debug(ctx, "unable to fetch sender and device informaton: UID: %s deviceID: %s",
 			pt.ClientHeader.Sender, pt.ClientHeader.SenderDevice)
-		// try to jsut get username
+		// try to just get username
 		username, err = b.getSenderUsername(ctx, pt.ClientHeader)
 		if err != nil {
 			b.Debug(ctx, "failed to fetch sender username after initial error: err: %s", err.Error())

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -735,8 +735,8 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		return conversationLocal
 	}
 
-	// Set empty to an initial value before the real one in case we hit an error processing
-	// max messages
+	// Conversation is not empty as long as we have a visible message, even if they are
+	// errors
 	conversationLocal.IsEmpty = true
 	for _, maxMsg := range conversationRemote.MaxMsgs {
 		if utils.IsVisibleChatMessageType(maxMsg.GetMessageType()) {
@@ -786,9 +786,6 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		}
 	}
 
-	// Set to true later if visible messages are in max messages.
-	conversationLocal.IsEmpty = true
-
 	var maxValidID chat1.MessageID
 	superXform := newSupersedesTransform(s.G())
 
@@ -804,9 +801,6 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 			}
 			if typ == chat1.MessageType_METADATA {
 				conversationLocal.Info.TopicName = body.Metadata().ConversationTitle
-			}
-			if utils.IsVisibleChatMessageType(typ) {
-				conversationLocal.IsEmpty = false
 			}
 
 			if mm.GetMessageID() >= maxValidID {

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -284,7 +284,7 @@ func (i *Inbox) applyQuery(ctx context.Context, query *chat1.GetInboxQuery, conv
 		// If we are finalized and are superseded, then don't return this
 		if query.OneChatTypePerTLF == nil ||
 			(query.OneChatTypePerTLF != nil && *query.OneChatTypePerTLF) {
-			if conv.Metadata.FinalizeInfo != nil && len(conv.SupersededBy) > 0 {
+			if conv.Metadata.FinalizeInfo != nil && len(conv.SupersededBy) > 0 && query.ConvID == nil {
 				ok = false
 			}
 		}

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -182,23 +182,25 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 		// show the last TEXT message
 		var msg *chat1.MessageUnboxed
 		for _, m := range conv.MaxMessages {
-			if m.IsValid() {
-				if conv.ReaderInfo.ReadMsgid == m.GetMessageID() {
-					unread = ""
-				}
-				if m.GetMessageType() == chat1.MessageType_TEXT || m.GetMessageType() == chat1.MessageType_ATTACHMENT {
-					if msg == nil || m.GetMessageID() > msg.GetMessageID() {
-						mCopy := m
-						msg = &mCopy
-					}
+			if conv.ReaderInfo.ReadMsgid == m.GetMessageID() {
+				unread = ""
+			}
+			if m.GetMessageType() == chat1.MessageType_TEXT || m.GetMessageType() == chat1.MessageType_ATTACHMENT {
+				if msg == nil || m.GetMessageID() > msg.GetMessageID() {
+					mCopy := m
+					msg = &mCopy
 				}
 			}
 		}
 		if msg == nil {
-			// Skip conversations with no visible messages.
-			// This should never happen.
-			g.Log.Error("Skipped conversation with no visible messages: %s", conv.Info.Id)
-			continue
+			// Make a fake error in case we have a non-empty thread with no visible message
+			errMsg := chat1.NewMessageUnboxedWithError(chat1.MessageUnboxedError{
+				ErrMsg:      "<no snippet available>",
+				MessageID:   0,
+				MessageType: chat1.MessageType_TEXT,
+			})
+			msg = &errMsg
+			unread = ""
 		}
 
 		mv, err := newMessageView(g, conv.Info.Id, *msg)

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -131,6 +131,7 @@ func (r *chatConversationResolver) resolveWithService(ctx context.Context, req c
 		fcArg.TopicName = *arg.Query.TopicName
 	}
 	fcArg.IdentifyBehavior = identifyBehavior
+	fcArg.OneChatPerTLF = new(bool)
 
 	res, err := r.ChatClient.FindConversationsLocal(ctx, fcArg)
 	if err != nil {

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -194,10 +194,11 @@ func (c *chatServiceHandler) ReadV1(ctx context.Context, opts readOptionsV1) Rep
 				UID:      mv.ClientHeader.Sender.String(),
 				DeviceID: mv.ClientHeader.SenderDevice.String(),
 			},
-			SentAt:   mv.ServerHeader.Ctime.UnixSeconds(),
-			SentAtMs: mv.ServerHeader.Ctime.UnixMilliseconds(),
-			Prev:     prev,
-			Unread:   unread,
+			SentAt:        mv.ServerHeader.Ctime.UnixSeconds(),
+			SentAtMs:      mv.ServerHeader.Ctime.UnixMilliseconds(),
+			Prev:          prev,
+			Unread:        unread,
+			RevokedDevice: mv.SenderDeviceRevokedAt != nil,
 		}
 
 		msg.Content = c.convertMsgBody(mv.MessageBody)
@@ -946,14 +947,15 @@ type MsgContent struct {
 
 // MsgSummary is used to display JSON details for a message.
 type MsgSummary struct {
-	ID       chat1.MessageID                `json:"id"`
-	Channel  ChatChannel                    `json:"channel"`
-	Sender   MsgSender                      `json:"sender"`
-	SentAt   int64                          `json:"sent_at"`
-	SentAtMs int64                          `json:"sent_at_ms"`
-	Content  MsgContent                     `json:"content"`
-	Prev     []chat1.MessagePreviousPointer `json:"prev"`
-	Unread   bool                           `json:"unread"`
+	ID            chat1.MessageID                `json:"id"`
+	Channel       ChatChannel                    `json:"channel"`
+	Sender        MsgSender                      `json:"sender"`
+	SentAt        int64                          `json:"sent_at"`
+	SentAtMs      int64                          `json:"sent_at_ms"`
+	Content       MsgContent                     `json:"content"`
+	Prev          []chat1.MessagePreviousPointer `json:"prev"`
+	Unread        bool                           `json:"unread"`
+	RevokedDevice bool                           `json:"revoked_device,omitempty"`
 }
 
 // Message contains eiter a MsgSummary or an Error.  Used for JSON output.

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -54,9 +54,10 @@ func (c *chatServiceHandler) ListV1(ctx context.Context, opts listOptionsV1) Rep
 
 	res, err := client.GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
 		Query: &chat1.GetInboxLocalQuery{
-			Status:     utils.VisibleChatConversationStatuses(),
-			TopicType:  &topicType,
-			UnreadOnly: opts.UnreadOnly,
+			Status:            utils.VisibleChatConversationStatuses(),
+			TopicType:         &topicType,
+			UnreadOnly:        opts.UnreadOnly,
+			OneChatTypePerTLF: new(bool),
 		},
 		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	})
@@ -94,6 +95,13 @@ func (c *chatServiceHandler) ListV1(ctx context.Context, opts listOptionsV1) Rep
 				}
 				maxID = msg.GetMessageID()
 			}
+		}
+
+		for _, super := range conv.Supersedes {
+			cl.Conversations[i].Supersedes = append(cl.Conversations[i].Supersedes, super.String())
+		}
+		for _, super := range conv.SupersededBy {
+			cl.Conversations[i].SupersededBy = append(cl.Conversations[i].SupersededBy, super.String())
 		}
 	}
 	cl.RateLimits.RateLimits = c.aggRateLimits(rlimits)
@@ -968,6 +976,8 @@ type ConvSummary struct {
 	ActiveAt     int64                           `json:"active_at"`
 	ActiveAtMs   int64                           `json:"active_at_ms"`
 	FinalizeInfo *chat1.ConversationFinalizeInfo `json:"finalize_info,omitempty"`
+	Supersedes   []string                        `json:"supersedes,omitempty"`
+	SupersededBy []string                        `json:"superseded_by,omitempty"`
 }
 
 // ChatList is a list of conversations in the inbox.

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1121,6 +1121,7 @@ type FindConversationsLocalArg struct {
 	Visibility       TLFVisibility                `codec:"visibility" json:"visibility"`
 	TopicType        TopicType                    `codec:"topicType" json:"topicType"`
 	TopicName        string                       `codec:"topicName" json:"topicName"`
+	OneChatPerTLF    *bool                        `codec:"oneChatPerTLF,omitempty" json:"oneChatPerTLF,omitempty"`
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -374,6 +374,7 @@ func (h *chatLocalHandler) GetInboxSummaryForCLILocal(ctx context.Context, arg c
 
 	var queryBase chat1.GetInboxLocalQuery
 	queryBase.ComputeActiveList = true
+	queryBase.OneChatTypePerTLF = new(bool)
 	if !after.IsZero() {
 		gafter := gregor1.ToTime(after)
 		queryBase.After = &gafter
@@ -1481,10 +1482,11 @@ func (h *chatLocalHandler) FindConversationsLocal(ctx context.Context,
 
 	// First look in the local user inbox
 	query := chat1.GetInboxLocalQuery{
-		TlfName:       &arg.TlfName,
-		TlfVisibility: &arg.Visibility,
-		TopicType:     &arg.TopicType,
-		TopicName:     &arg.TopicName,
+		TlfName:           &arg.TlfName,
+		TlfVisibility:     &arg.Visibility,
+		TopicType:         &arg.TopicType,
+		TopicName:         &arg.TopicName,
+		OneChatTypePerTLF: arg.OneChatPerTLF,
 	}
 	inbox, err := h.GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
 		Query:            &query,

--- a/go/service/tlf.go
+++ b/go/service/tlf.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/chat"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -16,6 +17,7 @@ import (
 
 type tlfHandler struct {
 	*BaseHandler
+	utils.DebugLabeler
 	libkb.Contextified
 }
 
@@ -23,6 +25,7 @@ func newTlfHandler(xp rpc.Transporter, g *libkb.GlobalContext) *tlfHandler {
 	return &tlfHandler{
 		BaseHandler:  NewBaseHandler(xp),
 		Contextified: libkb.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "TlfHandler", false),
 	}
 }
 
@@ -57,8 +60,8 @@ func (h *tlfHandler) CryptKeys(ctx context.Context, arg keybase1.TLFQuery) (keyb
 	if ok {
 		arg.IdentifyBehavior = ident
 	}
-	defer h.G().CTrace(ctx, fmt.Sprintf("tlfHandler.CryptKeys(tlf=%s,mode=%v)", arg.TlfName,
-		arg.IdentifyBehavior), func() error { return err })()
+	defer h.Trace(ctx, func() error { return err },
+		fmt.Sprintf("CryptKeys(tlf=%s,mode=%v)", arg.TlfName, arg.IdentifyBehavior))()
 
 	tlfClient, err := h.tlfKeysClient()
 	if err != nil {
@@ -85,8 +88,10 @@ func (h *tlfHandler) PublicCanonicalTLFNameAndID(ctx context.Context, arg keybas
 	if ok {
 		arg.IdentifyBehavior = ident
 	}
-	defer h.G().CTrace(ctx, fmt.Sprintf("tlfHandler.PublicCanonicalTLFNameAndID(tlf=%s,mode=%v)",
-		arg.TlfName, arg.IdentifyBehavior), func() error { return err })()
+	defer h.Trace(ctx, func() error { return err },
+		fmt.Sprintf("PublicCanonicalTLFNameAndID(tlf=%s,mode=%v)", arg.TlfName,
+			arg.IdentifyBehavior))()
+
 	tlfClient, err := h.tlfKeysClient()
 	if err != nil {
 		return keybase1.CanonicalTLFNameAndIDWithBreaks{}, err

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -503,6 +503,6 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
-  FindConversationsLocalRes findConversationsLocal(string tlfName, TLFVisibility visibility, TopicType topicType, string topicName, keybase1.TLFIdentifyBehavior identifyBehavior);
+  FindConversationsLocalRes findConversationsLocal(string tlfName, TLFVisibility visibility, TopicType topicType, string topicName, union { null, bool } oneChatPerTLF, keybase1.TLFIdentifyBehavior identifyBehavior);
 
 }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1384,6 +1384,7 @@ export type localFindConversationsLocalRpcParam = Exact<{
   visibility: TLFVisibility,
   topicType: TopicType,
   topicName: string,
+  oneChatPerTLF?: ?bool,
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1971,6 +1971,13 @@
           "type": "string"
         },
         {
+          "name": "oneChatPerTLF",
+          "type": [
+            null,
+            "bool"
+          ]
+        },
+        {
           "name": "identifyBehavior",
           "type": "keybase1.TLFIdentifyBehavior"
         }

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1384,6 +1384,7 @@ export type localFindConversationsLocalRpcParam = Exact<{
   visibility: TLFVisibility,
   topicType: TopicType,
   topicName: string,
+  oneChatPerTLF?: ?bool,
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 


### PR DESCRIPTION
Patch does a bunch of things:

1.) Makes it possible to read from finalized TLFs that are superseded by changing inbox.go to allow them to be returned if the `ConvID` param is set.
2.) Render message errors cleaner in the CLI.
3.) Render sender username in finalized convs.
4.) Return finalized superseded convs from the JSON API, add ability for JSON API to return all hats on a TLF (even finalized ones).
5.) Add ability to JSON API to display device revoked status.
6.) Label all messages from a reset user as from a revoked device.