### PR TITLE
handle message errors in a typed way CORE-4515

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -193,12 +193,6 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 	switch headerVersion {
 	case chat1.HeaderPlaintextVersion_V1:
 		headerSignature = header.V1().HeaderSignature
-	default:
-		return unboxMessageWithKeyRes{}, NewPermanentUnboxingError(NewHeaderVersionError(headerVersion))
-	}
-
-	switch headerVersion {
-	case chat1.HeaderPlaintextVersion_V1:
 		hp := header.V1()
 		clientHeader = chat1.MessageClientHeader{
 			Conv:         hp.Conv,
@@ -212,7 +206,8 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 			OutboxID:     hp.OutboxID,
 		}
 	default:
-		return unboxMessageWithKeyRes{}, NewPermanentUnboxingError(NewHeaderVersionError(headerVersion))
+		return unboxMessageWithKeyRes{},
+			NewPermanentUnboxingError(NewHeaderVersionError(headerVersion, header.Default()))
 	}
 
 	if skipBodyVerification {
@@ -226,7 +221,8 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 				senderDeviceRevokedAt: validity.senderDeviceRevokedAt,
 			}, nil
 		default:
-			return unboxMessageWithKeyRes{}, NewPermanentUnboxingError(NewHeaderVersionError(headerVersion))
+			return unboxMessageWithKeyRes{},
+				NewPermanentUnboxingError(NewHeaderVersionError(headerVersion, header.Default()))
 		}
 	}
 
@@ -247,7 +243,8 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 			senderDeviceRevokedAt: validity.senderDeviceRevokedAt,
 		}, nil
 	default:
-		return unboxMessageWithKeyRes{}, NewPermanentUnboxingError(NewBodyVersionError(bodyVersion))
+		return unboxMessageWithKeyRes{},
+			NewPermanentUnboxingError(NewBodyVersionError(bodyVersion, body.Default()))
 	}
 }
 
@@ -496,7 +493,8 @@ func (b *Boxer) verifyMessage(ctx context.Context, header chat1.HeaderPlaintext,
 	case chat1.HeaderPlaintextVersion_V1:
 		return b.verifyMessageHeaderV1(ctx, header.V1(), msg, skipBodyVerification)
 	default:
-		return verifyMessageRes{}, NewPermanentUnboxingError(NewHeaderVersionError(headerVersion))
+		return verifyMessageRes{},
+			NewPermanentUnboxingError(NewHeaderVersionError(headerVersion, header.Default()))
 	}
 }
 

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -137,6 +137,68 @@ type unboxMessageWithKeyRes struct {
 	senderDeviceRevokedAt *gregor1.Time
 }
 
+func (b *Boxer) headerUnsupported(ctx context.Context, headerVersion chat1.HeaderPlaintextVersion,
+	header chat1.HeaderPlaintext) chat1.HeaderPlaintextUnsupported {
+	switch headerVersion {
+	case chat1.HeaderPlaintextVersion_V2:
+		return header.V2()
+	case chat1.HeaderPlaintextVersion_V3:
+		return header.V3()
+	case chat1.HeaderPlaintextVersion_V4:
+		return header.V4()
+	case chat1.HeaderPlaintextVersion_V5:
+		return header.V5()
+	case chat1.HeaderPlaintextVersion_V6:
+		return header.V6()
+	case chat1.HeaderPlaintextVersion_V7:
+		return header.V7()
+	case chat1.HeaderPlaintextVersion_V8:
+		return header.V8()
+	case chat1.HeaderPlaintextVersion_V9:
+		return header.V9()
+	case chat1.HeaderPlaintextVersion_V10:
+		return header.V10()
+	default:
+		b.Debug(ctx, "headerUnsupported: unknown version: %v", headerVersion)
+		return chat1.HeaderPlaintextUnsupported{
+			Mi: chat1.HeaderPlaintextMetaInfo{
+				Crit: true,
+			},
+		}
+	}
+}
+
+func (b *Boxer) bodyUnsupported(ctx context.Context, bodyVersion chat1.BodyPlaintextVersion,
+	body chat1.BodyPlaintext) chat1.BodyPlaintextUnsupported {
+	switch bodyVersion {
+	case chat1.BodyPlaintextVersion_V2:
+		return body.V2()
+	case chat1.BodyPlaintextVersion_V3:
+		return body.V3()
+	case chat1.BodyPlaintextVersion_V4:
+		return body.V4()
+	case chat1.BodyPlaintextVersion_V5:
+		return body.V5()
+	case chat1.BodyPlaintextVersion_V6:
+		return body.V6()
+	case chat1.BodyPlaintextVersion_V7:
+		return body.V7()
+	case chat1.BodyPlaintextVersion_V8:
+		return body.V8()
+	case chat1.BodyPlaintextVersion_V9:
+		return body.V9()
+	case chat1.BodyPlaintextVersion_V10:
+		return body.V10()
+	default:
+		b.Debug(ctx, "bodyUnsupported: unknown version: %v", bodyVersion)
+		return chat1.BodyPlaintextUnsupported{
+			Mi: chat1.BodyPlaintextMetaInfo{
+				Crit: true,
+			},
+		}
+	}
+}
+
 // unboxMessageWithKey unboxes a chat1.MessageBoxed into a keybase1.Message given
 // a keybase1.CryptKey.
 func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed, key *keybase1.CryptKey) (unboxMessageWithKeyRes, UnboxingError) {
@@ -207,7 +269,8 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 		}
 	default:
 		return unboxMessageWithKeyRes{},
-			NewPermanentUnboxingError(NewHeaderVersionError(headerVersion, header.Default()))
+			NewPermanentUnboxingError(NewHeaderVersionError(headerVersion,
+				b.headerUnsupported(ctx, headerVersion, header)))
 	}
 
 	if skipBodyVerification {
@@ -222,7 +285,8 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 			}, nil
 		default:
 			return unboxMessageWithKeyRes{},
-				NewPermanentUnboxingError(NewHeaderVersionError(headerVersion, header.Default()))
+				NewPermanentUnboxingError(NewHeaderVersionError(headerVersion,
+					b.headerUnsupported(ctx, headerVersion, header)))
 		}
 	}
 
@@ -244,7 +308,8 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 		}, nil
 	default:
 		return unboxMessageWithKeyRes{},
-			NewPermanentUnboxingError(NewBodyVersionError(bodyVersion, body.Default()))
+			NewPermanentUnboxingError(NewBodyVersionError(bodyVersion,
+				b.bodyUnsupported(ctx, bodyVersion, body)))
 	}
 }
 
@@ -494,7 +559,8 @@ func (b *Boxer) verifyMessage(ctx context.Context, header chat1.HeaderPlaintext,
 		return b.verifyMessageHeaderV1(ctx, header.V1(), msg, skipBodyVerification)
 	default:
 		return verifyMessageRes{},
-			NewPermanentUnboxingError(NewHeaderVersionError(headerVersion, header.Default()))
+			NewPermanentUnboxingError(NewHeaderVersionError(headerVersion,
+				b.headerUnsupported(ctx, headerVersion, header)))
 	}
 }
 

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -57,8 +57,9 @@ func (b *Boxer) log() logger.Logger {
 	return b.G().GetLog()
 }
 
-func (b *Boxer) makeErrorMessage(msg chat1.MessageBoxed, err error) chat1.MessageUnboxed {
+func (b *Boxer) makeErrorMessage(msg chat1.MessageBoxed, err UnboxingError) chat1.MessageUnboxed {
 	return chat1.NewMessageUnboxedWithError(chat1.MessageUnboxedError{
+		ErrType:     err.ExportType(),
 		ErrMsg:      err.Error(),
 		MessageID:   msg.GetMessageID(),
 		MessageType: msg.GetMessageType(),
@@ -98,7 +99,7 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, fina
 		b.Debug(ctx, "failed to unbox message: msgID: %d err: %s", boxed.ServerHeader.MessageID,
 			ierr.Error())
 		if ierr.IsPermanent() {
-			return b.makeErrorMessage(boxed, ierr.Inner()), nil
+			return b.makeErrorMessage(boxed, ierr), nil
 		}
 		return chat1.MessageUnboxed{}, ierr
 	}

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -11,6 +11,7 @@ type UnboxingError interface {
 	Error() string
 	Inner() error
 	IsPermanent() bool
+	ExportType() chat1.MessageUnboxedErrorType
 }
 
 var _ error = (UnboxingError)(nil)
@@ -29,6 +30,15 @@ func (e PermanentUnboxingError) IsPermanent() bool { return true }
 
 func (e PermanentUnboxingError) Inner() error { return e.inner }
 
+func (e PermanentUnboxingError) ExportType() chat1.MessageUnboxedErrorType {
+	switch e.inner.(type) {
+	case VersionError:
+		return chat1.MessageUnboxedErrorType_BADVERSION
+	default:
+		return chat1.MessageUnboxedErrorType_MISC
+	}
+}
+
 func NewTransientUnboxingError(inner error) UnboxingError {
 	return &TransientUnboxingError{inner}
 }
@@ -42,6 +52,10 @@ func (e TransientUnboxingError) Error() string {
 func (e TransientUnboxingError) IsPermanent() bool { return false }
 
 func (e TransientUnboxingError) Inner() error { return e.inner }
+
+func (e TransientUnboxingError) ExportType() chat1.MessageUnboxedErrorType {
+	return chat1.MessageUnboxedErrorType_MISC
+}
 
 //=============================================================================
 

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -515,12 +515,22 @@ func newMessageViewError(g *libkb.GlobalContext, conversationID chat1.Conversati
 	m chat1.MessageUnboxedError) (mv messageView, err error) {
 
 	mv.messageType = m.MessageType
-	mv.Body = fmt.Sprintf("<<chat read error: %s>>", m.ErrMsg)
 	mv.Renderable = true
 	mv.FromRevokedDevice = false
 	mv.MessageID = m.MessageID
 	mv.AuthorAndTime = "???"
 	mv.AuthorAndTimeWithDeviceName = "???"
+
+	critVersion := false
+	switch m.ErrType {
+	case chat1.MessageUnboxedErrorType_BADVERSION_CRITICAL:
+		critVersion = true
+		fallthrough
+	case chat1.MessageUnboxedErrorType_BADVERSION:
+		mv.Body = fmt.Sprintf("<<chat read error: invalid message version (critical: %v)>>", critVersion)
+	default:
+		mv.Body = fmt.Sprintf("<<chat read error: %s>>", m.ErrMsg)
+	}
 
 	return mv, nil
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -500,15 +500,42 @@ type Inbox struct {
 type HeaderPlaintextVersion int
 
 const (
-	HeaderPlaintextVersion_V1 HeaderPlaintextVersion = 1
+	HeaderPlaintextVersion_V1  HeaderPlaintextVersion = 1
+	HeaderPlaintextVersion_V2  HeaderPlaintextVersion = 2
+	HeaderPlaintextVersion_V3  HeaderPlaintextVersion = 3
+	HeaderPlaintextVersion_V4  HeaderPlaintextVersion = 4
+	HeaderPlaintextVersion_V5  HeaderPlaintextVersion = 5
+	HeaderPlaintextVersion_V6  HeaderPlaintextVersion = 6
+	HeaderPlaintextVersion_V7  HeaderPlaintextVersion = 7
+	HeaderPlaintextVersion_V8  HeaderPlaintextVersion = 8
+	HeaderPlaintextVersion_V9  HeaderPlaintextVersion = 9
+	HeaderPlaintextVersion_V10 HeaderPlaintextVersion = 10
 )
 
 var HeaderPlaintextVersionMap = map[string]HeaderPlaintextVersion{
-	"V1": 1,
+	"V1":  1,
+	"V2":  2,
+	"V3":  3,
+	"V4":  4,
+	"V5":  5,
+	"V6":  6,
+	"V7":  7,
+	"V8":  8,
+	"V9":  9,
+	"V10": 10,
 }
 
 var HeaderPlaintextVersionRevMap = map[HeaderPlaintextVersion]string{
-	1: "V1",
+	1:  "V1",
+	2:  "V2",
+	3:  "V3",
+	4:  "V4",
+	5:  "V5",
+	6:  "V6",
+	7:  "V7",
+	8:  "V8",
+	9:  "V9",
+	10: "V10",
 }
 
 func (e HeaderPlaintextVersion) String() string {
@@ -543,7 +570,15 @@ type HeaderPlaintextV1 struct {
 type HeaderPlaintext struct {
 	Version__ HeaderPlaintextVersion      `codec:"version" json:"version"`
 	V1__      *HeaderPlaintextV1          `codec:"v1,omitempty" json:"v1,omitempty"`
-	Default__ *HeaderPlaintextUnsupported `codec:"default,omitempty" json:"default,omitempty"`
+	V2__      *HeaderPlaintextUnsupported `codec:"v2,omitempty" json:"v2,omitempty"`
+	V3__      *HeaderPlaintextUnsupported `codec:"v3,omitempty" json:"v3,omitempty"`
+	V4__      *HeaderPlaintextUnsupported `codec:"v4,omitempty" json:"v4,omitempty"`
+	V5__      *HeaderPlaintextUnsupported `codec:"v5,omitempty" json:"v5,omitempty"`
+	V6__      *HeaderPlaintextUnsupported `codec:"v6,omitempty" json:"v6,omitempty"`
+	V7__      *HeaderPlaintextUnsupported `codec:"v7,omitempty" json:"v7,omitempty"`
+	V8__      *HeaderPlaintextUnsupported `codec:"v8,omitempty" json:"v8,omitempty"`
+	V9__      *HeaderPlaintextUnsupported `codec:"v9,omitempty" json:"v9,omitempty"`
+	V10__     *HeaderPlaintextUnsupported `codec:"v10,omitempty" json:"v10,omitempty"`
 }
 
 func (o *HeaderPlaintext) Version() (ret HeaderPlaintextVersion, err error) {
@@ -553,9 +588,49 @@ func (o *HeaderPlaintext) Version() (ret HeaderPlaintextVersion, err error) {
 			err = errors.New("unexpected nil value for V1__")
 			return ret, err
 		}
-	default:
-		if o.Default__ == nil {
-			err = errors.New("unexpected nil value for Default__")
+	case HeaderPlaintextVersion_V2:
+		if o.V2__ == nil {
+			err = errors.New("unexpected nil value for V2__")
+			return ret, err
+		}
+	case HeaderPlaintextVersion_V3:
+		if o.V3__ == nil {
+			err = errors.New("unexpected nil value for V3__")
+			return ret, err
+		}
+	case HeaderPlaintextVersion_V4:
+		if o.V4__ == nil {
+			err = errors.New("unexpected nil value for V4__")
+			return ret, err
+		}
+	case HeaderPlaintextVersion_V5:
+		if o.V5__ == nil {
+			err = errors.New("unexpected nil value for V5__")
+			return ret, err
+		}
+	case HeaderPlaintextVersion_V6:
+		if o.V6__ == nil {
+			err = errors.New("unexpected nil value for V6__")
+			return ret, err
+		}
+	case HeaderPlaintextVersion_V7:
+		if o.V7__ == nil {
+			err = errors.New("unexpected nil value for V7__")
+			return ret, err
+		}
+	case HeaderPlaintextVersion_V8:
+		if o.V8__ == nil {
+			err = errors.New("unexpected nil value for V8__")
+			return ret, err
+		}
+	case HeaderPlaintextVersion_V9:
+		if o.V9__ == nil {
+			err = errors.New("unexpected nil value for V9__")
+			return ret, err
+		}
+	case HeaderPlaintextVersion_V10:
+		if o.V10__ == nil {
+			err = errors.New("unexpected nil value for V10__")
 			return ret, err
 		}
 	}
@@ -572,14 +647,94 @@ func (o HeaderPlaintext) V1() HeaderPlaintextV1 {
 	return *o.V1__
 }
 
-func (o HeaderPlaintext) Default() HeaderPlaintextUnsupported {
-	if o.Version__ == HeaderPlaintextVersion_V1 {
+func (o HeaderPlaintext) V2() HeaderPlaintextUnsupported {
+	if o.Version__ != HeaderPlaintextVersion_V2 {
 		panic("wrong case accessed")
 	}
-	if o.Default__ == nil {
+	if o.V2__ == nil {
 		return HeaderPlaintextUnsupported{}
 	}
-	return *o.Default__
+	return *o.V2__
+}
+
+func (o HeaderPlaintext) V3() HeaderPlaintextUnsupported {
+	if o.Version__ != HeaderPlaintextVersion_V3 {
+		panic("wrong case accessed")
+	}
+	if o.V3__ == nil {
+		return HeaderPlaintextUnsupported{}
+	}
+	return *o.V3__
+}
+
+func (o HeaderPlaintext) V4() HeaderPlaintextUnsupported {
+	if o.Version__ != HeaderPlaintextVersion_V4 {
+		panic("wrong case accessed")
+	}
+	if o.V4__ == nil {
+		return HeaderPlaintextUnsupported{}
+	}
+	return *o.V4__
+}
+
+func (o HeaderPlaintext) V5() HeaderPlaintextUnsupported {
+	if o.Version__ != HeaderPlaintextVersion_V5 {
+		panic("wrong case accessed")
+	}
+	if o.V5__ == nil {
+		return HeaderPlaintextUnsupported{}
+	}
+	return *o.V5__
+}
+
+func (o HeaderPlaintext) V6() HeaderPlaintextUnsupported {
+	if o.Version__ != HeaderPlaintextVersion_V6 {
+		panic("wrong case accessed")
+	}
+	if o.V6__ == nil {
+		return HeaderPlaintextUnsupported{}
+	}
+	return *o.V6__
+}
+
+func (o HeaderPlaintext) V7() HeaderPlaintextUnsupported {
+	if o.Version__ != HeaderPlaintextVersion_V7 {
+		panic("wrong case accessed")
+	}
+	if o.V7__ == nil {
+		return HeaderPlaintextUnsupported{}
+	}
+	return *o.V7__
+}
+
+func (o HeaderPlaintext) V8() HeaderPlaintextUnsupported {
+	if o.Version__ != HeaderPlaintextVersion_V8 {
+		panic("wrong case accessed")
+	}
+	if o.V8__ == nil {
+		return HeaderPlaintextUnsupported{}
+	}
+	return *o.V8__
+}
+
+func (o HeaderPlaintext) V9() HeaderPlaintextUnsupported {
+	if o.Version__ != HeaderPlaintextVersion_V9 {
+		panic("wrong case accessed")
+	}
+	if o.V9__ == nil {
+		return HeaderPlaintextUnsupported{}
+	}
+	return *o.V9__
+}
+
+func (o HeaderPlaintext) V10() HeaderPlaintextUnsupported {
+	if o.Version__ != HeaderPlaintextVersion_V10 {
+		panic("wrong case accessed")
+	}
+	if o.V10__ == nil {
+		return HeaderPlaintextUnsupported{}
+	}
+	return *o.V10__
 }
 
 func NewHeaderPlaintextWithV1(v HeaderPlaintextV1) HeaderPlaintext {
@@ -589,25 +744,108 @@ func NewHeaderPlaintextWithV1(v HeaderPlaintextV1) HeaderPlaintext {
 	}
 }
 
-func NewHeaderPlaintextDefault(version HeaderPlaintextVersion, v HeaderPlaintextUnsupported) HeaderPlaintext {
+func NewHeaderPlaintextWithV2(v HeaderPlaintextUnsupported) HeaderPlaintext {
 	return HeaderPlaintext{
-		Version__: version,
-		Default__: &v,
+		Version__: HeaderPlaintextVersion_V2,
+		V2__:      &v,
+	}
+}
+
+func NewHeaderPlaintextWithV3(v HeaderPlaintextUnsupported) HeaderPlaintext {
+	return HeaderPlaintext{
+		Version__: HeaderPlaintextVersion_V3,
+		V3__:      &v,
+	}
+}
+
+func NewHeaderPlaintextWithV4(v HeaderPlaintextUnsupported) HeaderPlaintext {
+	return HeaderPlaintext{
+		Version__: HeaderPlaintextVersion_V4,
+		V4__:      &v,
+	}
+}
+
+func NewHeaderPlaintextWithV5(v HeaderPlaintextUnsupported) HeaderPlaintext {
+	return HeaderPlaintext{
+		Version__: HeaderPlaintextVersion_V5,
+		V5__:      &v,
+	}
+}
+
+func NewHeaderPlaintextWithV6(v HeaderPlaintextUnsupported) HeaderPlaintext {
+	return HeaderPlaintext{
+		Version__: HeaderPlaintextVersion_V6,
+		V6__:      &v,
+	}
+}
+
+func NewHeaderPlaintextWithV7(v HeaderPlaintextUnsupported) HeaderPlaintext {
+	return HeaderPlaintext{
+		Version__: HeaderPlaintextVersion_V7,
+		V7__:      &v,
+	}
+}
+
+func NewHeaderPlaintextWithV8(v HeaderPlaintextUnsupported) HeaderPlaintext {
+	return HeaderPlaintext{
+		Version__: HeaderPlaintextVersion_V8,
+		V8__:      &v,
+	}
+}
+
+func NewHeaderPlaintextWithV9(v HeaderPlaintextUnsupported) HeaderPlaintext {
+	return HeaderPlaintext{
+		Version__: HeaderPlaintextVersion_V9,
+		V9__:      &v,
+	}
+}
+
+func NewHeaderPlaintextWithV10(v HeaderPlaintextUnsupported) HeaderPlaintext {
+	return HeaderPlaintext{
+		Version__: HeaderPlaintextVersion_V10,
+		V10__:     &v,
 	}
 }
 
 type BodyPlaintextVersion int
 
 const (
-	BodyPlaintextVersion_V1 BodyPlaintextVersion = 1
+	BodyPlaintextVersion_V1  BodyPlaintextVersion = 1
+	BodyPlaintextVersion_V2  BodyPlaintextVersion = 2
+	BodyPlaintextVersion_V3  BodyPlaintextVersion = 3
+	BodyPlaintextVersion_V4  BodyPlaintextVersion = 4
+	BodyPlaintextVersion_V5  BodyPlaintextVersion = 5
+	BodyPlaintextVersion_V6  BodyPlaintextVersion = 6
+	BodyPlaintextVersion_V7  BodyPlaintextVersion = 7
+	BodyPlaintextVersion_V8  BodyPlaintextVersion = 8
+	BodyPlaintextVersion_V9  BodyPlaintextVersion = 9
+	BodyPlaintextVersion_V10 BodyPlaintextVersion = 10
 )
 
 var BodyPlaintextVersionMap = map[string]BodyPlaintextVersion{
-	"V1": 1,
+	"V1":  1,
+	"V2":  2,
+	"V3":  3,
+	"V4":  4,
+	"V5":  5,
+	"V6":  6,
+	"V7":  7,
+	"V8":  8,
+	"V9":  9,
+	"V10": 10,
 }
 
 var BodyPlaintextVersionRevMap = map[BodyPlaintextVersion]string{
-	1: "V1",
+	1:  "V1",
+	2:  "V2",
+	3:  "V3",
+	4:  "V4",
+	5:  "V5",
+	6:  "V6",
+	7:  "V7",
+	8:  "V8",
+	9:  "V9",
+	10: "V10",
 }
 
 func (e BodyPlaintextVersion) String() string {
@@ -632,7 +870,15 @@ type BodyPlaintextV1 struct {
 type BodyPlaintext struct {
 	Version__ BodyPlaintextVersion      `codec:"version" json:"version"`
 	V1__      *BodyPlaintextV1          `codec:"v1,omitempty" json:"v1,omitempty"`
-	Default__ *BodyPlaintextUnsupported `codec:"default,omitempty" json:"default,omitempty"`
+	V2__      *BodyPlaintextUnsupported `codec:"v2,omitempty" json:"v2,omitempty"`
+	V3__      *BodyPlaintextUnsupported `codec:"v3,omitempty" json:"v3,omitempty"`
+	V4__      *BodyPlaintextUnsupported `codec:"v4,omitempty" json:"v4,omitempty"`
+	V5__      *BodyPlaintextUnsupported `codec:"v5,omitempty" json:"v5,omitempty"`
+	V6__      *BodyPlaintextUnsupported `codec:"v6,omitempty" json:"v6,omitempty"`
+	V7__      *BodyPlaintextUnsupported `codec:"v7,omitempty" json:"v7,omitempty"`
+	V8__      *BodyPlaintextUnsupported `codec:"v8,omitempty" json:"v8,omitempty"`
+	V9__      *BodyPlaintextUnsupported `codec:"v9,omitempty" json:"v9,omitempty"`
+	V10__     *BodyPlaintextUnsupported `codec:"v10,omitempty" json:"v10,omitempty"`
 }
 
 func (o *BodyPlaintext) Version() (ret BodyPlaintextVersion, err error) {
@@ -642,9 +888,49 @@ func (o *BodyPlaintext) Version() (ret BodyPlaintextVersion, err error) {
 			err = errors.New("unexpected nil value for V1__")
 			return ret, err
 		}
-	default:
-		if o.Default__ == nil {
-			err = errors.New("unexpected nil value for Default__")
+	case BodyPlaintextVersion_V2:
+		if o.V2__ == nil {
+			err = errors.New("unexpected nil value for V2__")
+			return ret, err
+		}
+	case BodyPlaintextVersion_V3:
+		if o.V3__ == nil {
+			err = errors.New("unexpected nil value for V3__")
+			return ret, err
+		}
+	case BodyPlaintextVersion_V4:
+		if o.V4__ == nil {
+			err = errors.New("unexpected nil value for V4__")
+			return ret, err
+		}
+	case BodyPlaintextVersion_V5:
+		if o.V5__ == nil {
+			err = errors.New("unexpected nil value for V5__")
+			return ret, err
+		}
+	case BodyPlaintextVersion_V6:
+		if o.V6__ == nil {
+			err = errors.New("unexpected nil value for V6__")
+			return ret, err
+		}
+	case BodyPlaintextVersion_V7:
+		if o.V7__ == nil {
+			err = errors.New("unexpected nil value for V7__")
+			return ret, err
+		}
+	case BodyPlaintextVersion_V8:
+		if o.V8__ == nil {
+			err = errors.New("unexpected nil value for V8__")
+			return ret, err
+		}
+	case BodyPlaintextVersion_V9:
+		if o.V9__ == nil {
+			err = errors.New("unexpected nil value for V9__")
+			return ret, err
+		}
+	case BodyPlaintextVersion_V10:
+		if o.V10__ == nil {
+			err = errors.New("unexpected nil value for V10__")
 			return ret, err
 		}
 	}
@@ -661,14 +947,94 @@ func (o BodyPlaintext) V1() BodyPlaintextV1 {
 	return *o.V1__
 }
 
-func (o BodyPlaintext) Default() BodyPlaintextUnsupported {
-	if o.Version__ == BodyPlaintextVersion_V1 {
+func (o BodyPlaintext) V2() BodyPlaintextUnsupported {
+	if o.Version__ != BodyPlaintextVersion_V2 {
 		panic("wrong case accessed")
 	}
-	if o.Default__ == nil {
+	if o.V2__ == nil {
 		return BodyPlaintextUnsupported{}
 	}
-	return *o.Default__
+	return *o.V2__
+}
+
+func (o BodyPlaintext) V3() BodyPlaintextUnsupported {
+	if o.Version__ != BodyPlaintextVersion_V3 {
+		panic("wrong case accessed")
+	}
+	if o.V3__ == nil {
+		return BodyPlaintextUnsupported{}
+	}
+	return *o.V3__
+}
+
+func (o BodyPlaintext) V4() BodyPlaintextUnsupported {
+	if o.Version__ != BodyPlaintextVersion_V4 {
+		panic("wrong case accessed")
+	}
+	if o.V4__ == nil {
+		return BodyPlaintextUnsupported{}
+	}
+	return *o.V4__
+}
+
+func (o BodyPlaintext) V5() BodyPlaintextUnsupported {
+	if o.Version__ != BodyPlaintextVersion_V5 {
+		panic("wrong case accessed")
+	}
+	if o.V5__ == nil {
+		return BodyPlaintextUnsupported{}
+	}
+	return *o.V5__
+}
+
+func (o BodyPlaintext) V6() BodyPlaintextUnsupported {
+	if o.Version__ != BodyPlaintextVersion_V6 {
+		panic("wrong case accessed")
+	}
+	if o.V6__ == nil {
+		return BodyPlaintextUnsupported{}
+	}
+	return *o.V6__
+}
+
+func (o BodyPlaintext) V7() BodyPlaintextUnsupported {
+	if o.Version__ != BodyPlaintextVersion_V7 {
+		panic("wrong case accessed")
+	}
+	if o.V7__ == nil {
+		return BodyPlaintextUnsupported{}
+	}
+	return *o.V7__
+}
+
+func (o BodyPlaintext) V8() BodyPlaintextUnsupported {
+	if o.Version__ != BodyPlaintextVersion_V8 {
+		panic("wrong case accessed")
+	}
+	if o.V8__ == nil {
+		return BodyPlaintextUnsupported{}
+	}
+	return *o.V8__
+}
+
+func (o BodyPlaintext) V9() BodyPlaintextUnsupported {
+	if o.Version__ != BodyPlaintextVersion_V9 {
+		panic("wrong case accessed")
+	}
+	if o.V9__ == nil {
+		return BodyPlaintextUnsupported{}
+	}
+	return *o.V9__
+}
+
+func (o BodyPlaintext) V10() BodyPlaintextUnsupported {
+	if o.Version__ != BodyPlaintextVersion_V10 {
+		panic("wrong case accessed")
+	}
+	if o.V10__ == nil {
+		return BodyPlaintextUnsupported{}
+	}
+	return *o.V10__
 }
 
 func NewBodyPlaintextWithV1(v BodyPlaintextV1) BodyPlaintext {
@@ -678,10 +1044,66 @@ func NewBodyPlaintextWithV1(v BodyPlaintextV1) BodyPlaintext {
 	}
 }
 
-func NewBodyPlaintextDefault(version BodyPlaintextVersion, v BodyPlaintextUnsupported) BodyPlaintext {
+func NewBodyPlaintextWithV2(v BodyPlaintextUnsupported) BodyPlaintext {
 	return BodyPlaintext{
-		Version__: version,
-		Default__: &v,
+		Version__: BodyPlaintextVersion_V2,
+		V2__:      &v,
+	}
+}
+
+func NewBodyPlaintextWithV3(v BodyPlaintextUnsupported) BodyPlaintext {
+	return BodyPlaintext{
+		Version__: BodyPlaintextVersion_V3,
+		V3__:      &v,
+	}
+}
+
+func NewBodyPlaintextWithV4(v BodyPlaintextUnsupported) BodyPlaintext {
+	return BodyPlaintext{
+		Version__: BodyPlaintextVersion_V4,
+		V4__:      &v,
+	}
+}
+
+func NewBodyPlaintextWithV5(v BodyPlaintextUnsupported) BodyPlaintext {
+	return BodyPlaintext{
+		Version__: BodyPlaintextVersion_V5,
+		V5__:      &v,
+	}
+}
+
+func NewBodyPlaintextWithV6(v BodyPlaintextUnsupported) BodyPlaintext {
+	return BodyPlaintext{
+		Version__: BodyPlaintextVersion_V6,
+		V6__:      &v,
+	}
+}
+
+func NewBodyPlaintextWithV7(v BodyPlaintextUnsupported) BodyPlaintext {
+	return BodyPlaintext{
+		Version__: BodyPlaintextVersion_V7,
+		V7__:      &v,
+	}
+}
+
+func NewBodyPlaintextWithV8(v BodyPlaintextUnsupported) BodyPlaintext {
+	return BodyPlaintext{
+		Version__: BodyPlaintextVersion_V8,
+		V8__:      &v,
+	}
+}
+
+func NewBodyPlaintextWithV9(v BodyPlaintextUnsupported) BodyPlaintext {
+	return BodyPlaintext{
+		Version__: BodyPlaintextVersion_V9,
+		V9__:      &v,
+	}
+}
+
+func NewBodyPlaintextWithV10(v BodyPlaintextUnsupported) BodyPlaintext {
+	return BodyPlaintext{
+		Version__: BodyPlaintextVersion_V10,
+		V10__:     &v,
 	}
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -701,10 +701,38 @@ type MessageUnboxedValid struct {
 	SenderDeviceRevokedAt *gregor1.Time       `codec:"senderDeviceRevokedAt,omitempty" json:"senderDeviceRevokedAt,omitempty"`
 }
 
+type MessageUnboxedErrorType int
+
+const (
+	MessageUnboxedErrorType_MISC       MessageUnboxedErrorType = 0
+	MessageUnboxedErrorType_BADVERSION MessageUnboxedErrorType = 1
+	MessageUnboxedErrorType_IDENTIFY   MessageUnboxedErrorType = 2
+)
+
+var MessageUnboxedErrorTypeMap = map[string]MessageUnboxedErrorType{
+	"MISC":       0,
+	"BADVERSION": 1,
+	"IDENTIFY":   2,
+}
+
+var MessageUnboxedErrorTypeRevMap = map[MessageUnboxedErrorType]string{
+	0: "MISC",
+	1: "BADVERSION",
+	2: "IDENTIFY",
+}
+
+func (e MessageUnboxedErrorType) String() string {
+	if v, ok := MessageUnboxedErrorTypeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type MessageUnboxedError struct {
-	ErrMsg      string      `codec:"errMsg" json:"errMsg"`
-	MessageID   MessageID   `codec:"messageID" json:"messageID"`
-	MessageType MessageType `codec:"messageType" json:"messageType"`
+	ErrType     MessageUnboxedErrorType `codec:"errType" json:"errType"`
+	ErrMsg      string                  `codec:"errMsg" json:"errMsg"`
+	MessageID   MessageID               `codec:"messageID" json:"messageID"`
+	MessageType MessageType             `codec:"messageType" json:"messageType"`
 }
 
 type MessageUnboxed struct {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -518,6 +518,14 @@ func (e HeaderPlaintextVersion) String() string {
 	return ""
 }
 
+type HeaderPlaintextMetaInfo struct {
+	Crit bool `codec:"crit" json:"crit"`
+}
+
+type HeaderPlaintextUnsupported struct {
+	Mi HeaderPlaintextMetaInfo `codec:"mi" json:"mi"`
+}
+
 type HeaderPlaintextV1 struct {
 	Conv            ConversationIDTriple     `codec:"conv" json:"conv"`
 	TlfName         string                   `codec:"tlfName" json:"tlfName"`
@@ -533,8 +541,9 @@ type HeaderPlaintextV1 struct {
 }
 
 type HeaderPlaintext struct {
-	Version__ HeaderPlaintextVersion `codec:"version" json:"version"`
-	V1__      *HeaderPlaintextV1     `codec:"v1,omitempty" json:"v1,omitempty"`
+	Version__ HeaderPlaintextVersion      `codec:"version" json:"version"`
+	V1__      *HeaderPlaintextV1          `codec:"v1,omitempty" json:"v1,omitempty"`
+	Default__ *HeaderPlaintextUnsupported `codec:"default,omitempty" json:"default,omitempty"`
 }
 
 func (o *HeaderPlaintext) Version() (ret HeaderPlaintextVersion, err error) {
@@ -542,6 +551,11 @@ func (o *HeaderPlaintext) Version() (ret HeaderPlaintextVersion, err error) {
 	case HeaderPlaintextVersion_V1:
 		if o.V1__ == nil {
 			err = errors.New("unexpected nil value for V1__")
+			return ret, err
+		}
+	default:
+		if o.Default__ == nil {
+			err = errors.New("unexpected nil value for Default__")
 			return ret, err
 		}
 	}
@@ -558,6 +572,16 @@ func (o HeaderPlaintext) V1() HeaderPlaintextV1 {
 	return *o.V1__
 }
 
+func (o HeaderPlaintext) Default() HeaderPlaintextUnsupported {
+	if o.Version__ == HeaderPlaintextVersion_V1 {
+		panic("wrong case accessed")
+	}
+	if o.Default__ == nil {
+		return HeaderPlaintextUnsupported{}
+	}
+	return *o.Default__
+}
+
 func NewHeaderPlaintextWithV1(v HeaderPlaintextV1) HeaderPlaintext {
 	return HeaderPlaintext{
 		Version__: HeaderPlaintextVersion_V1,
@@ -565,21 +589,25 @@ func NewHeaderPlaintextWithV1(v HeaderPlaintextV1) HeaderPlaintext {
 	}
 }
 
+func NewHeaderPlaintextDefault(version HeaderPlaintextVersion, v HeaderPlaintextUnsupported) HeaderPlaintext {
+	return HeaderPlaintext{
+		Version__: version,
+		Default__: &v,
+	}
+}
+
 type BodyPlaintextVersion int
 
 const (
 	BodyPlaintextVersion_V1 BodyPlaintextVersion = 1
-	BodyPlaintextVersion_V2 BodyPlaintextVersion = 2
 )
 
 var BodyPlaintextVersionMap = map[string]BodyPlaintextVersion{
 	"V1": 1,
-	"V2": 2,
 }
 
 var BodyPlaintextVersionRevMap = map[BodyPlaintextVersion]string{
 	1: "V1",
-	2: "V2",
 }
 
 func (e BodyPlaintextVersion) String() string {
@@ -704,21 +732,24 @@ type MessageUnboxedValid struct {
 type MessageUnboxedErrorType int
 
 const (
-	MessageUnboxedErrorType_MISC       MessageUnboxedErrorType = 0
-	MessageUnboxedErrorType_BADVERSION MessageUnboxedErrorType = 1
-	MessageUnboxedErrorType_IDENTIFY   MessageUnboxedErrorType = 2
+	MessageUnboxedErrorType_MISC                MessageUnboxedErrorType = 0
+	MessageUnboxedErrorType_BADVERSION_CRITICAL MessageUnboxedErrorType = 1
+	MessageUnboxedErrorType_BADVERSION          MessageUnboxedErrorType = 2
+	MessageUnboxedErrorType_IDENTIFY            MessageUnboxedErrorType = 3
 )
 
 var MessageUnboxedErrorTypeMap = map[string]MessageUnboxedErrorType{
-	"MISC":       0,
-	"BADVERSION": 1,
-	"IDENTIFY":   2,
+	"MISC":                0,
+	"BADVERSION_CRITICAL": 1,
+	"BADVERSION":          2,
+	"IDENTIFY":            3,
 }
 
 var MessageUnboxedErrorTypeRevMap = map[MessageUnboxedErrorType]string{
 	0: "MISC",
-	1: "BADVERSION",
-	2: "IDENTIFY",
+	1: "BADVERSION_CRITICAL",
+	2: "BADVERSION",
+	3: "IDENTIFY",
 }
 
 func (e MessageUnboxedErrorType) String() string {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -142,7 +142,16 @@ protocol local {
   }
 
   enum HeaderPlaintextVersion {
-    V1_1
+    V1_1,
+    V2_2,
+    V3_3,
+    V4_4,
+    V5_5,
+    V6_6,
+    V7_7,
+    V8_8,
+    V9_9,
+    V10_10
   }
 
   record HeaderPlaintextMetaInfo {
@@ -218,7 +227,15 @@ protocol local {
   // versions of BodyPlaintext.
   variant BodyPlaintext switch (BodyPlaintextVersion version) {
     case V1: BodyPlaintextV1;
-    default: BodyPlaintextUnsupported;
+    case V2 : BodyPlaintextUnsupported;
+    case V3 : BodyPlaintextUnsupported;
+    case V4 : BodyPlaintextUnsupported;
+    case V5 : BodyPlaintextUnsupported;
+    case V6 : BodyPlaintextUnsupported;
+    case V7 : BodyPlaintextUnsupported;
+    case V8 : BodyPlaintextUnsupported;
+    case V9 : BodyPlaintextUnsupported;
+    case V10: BodyPlaintextUnsupported;
   }
 
   record MessagePlaintext {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -173,12 +173,29 @@ protocol local {
   // HeaderPlaintext is a variant container for all the
   // versions of HeaderPlaintext.
   variant HeaderPlaintext switch (HeaderPlaintextVersion version) {
-    case V1: HeaderPlaintextV1;
-    default: HeaderPlaintextUnsupported;
+    case V1 : HeaderPlaintextV1;
+    case V2 : HeaderPlaintextUnsupported;
+    case V3 : HeaderPlaintextUnsupported;
+    case V4 : HeaderPlaintextUnsupported;
+    case V5 : HeaderPlaintextUnsupported;
+    case V6 : HeaderPlaintextUnsupported;
+    case V7 : HeaderPlaintextUnsupported;
+    case V8 : HeaderPlaintextUnsupported;
+    case V9 : HeaderPlaintextUnsupported;
+    case V10: HeaderPlaintextUnsupported;
   }
 
   enum BodyPlaintextVersion {
-    V1_1
+    V1_1,
+    V2_2,
+    V3_3,
+    V4_4,
+    V5_5,
+    V6_6,
+    V7_7,
+    V8_8,
+    V9_9,
+    V10_10
   }
 
   record BodyPlaintextMetaInfo {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -222,7 +222,14 @@ protocol local {
     union {null, gregor1.Time} senderDeviceRevokedAt;
   }
 
+  enum MessageUnboxedErrorType {
+    MISC_0,
+    BADVERSION_1,
+    IDENTIFY_2
+  }
+
   record MessageUnboxedError {
+    MessageUnboxedErrorType errType;
     string errMsg;
     MessageID messageID;
     MessageType messageType;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -145,6 +145,14 @@ protocol local {
     V1_1
   }
 
+  record HeaderPlaintextMetaInfo {
+    boolean crit; // whether it is critical to support this message
+  }
+
+  record HeaderPlaintextUnsupported {
+    HeaderPlaintextMetaInfo mi;
+  }
+
   // HeaderPlaintextV1 is version 1 of HeaderPlaintext.
   // The fields here cannot change.  To modify,
   // create a new record type with a new version.
@@ -166,11 +174,11 @@ protocol local {
   // versions of HeaderPlaintext.
   variant HeaderPlaintext switch (HeaderPlaintextVersion version) {
     case V1: HeaderPlaintextV1;
+    default: HeaderPlaintextUnsupported;
   }
 
   enum BodyPlaintextVersion {
-    V1_1,
-    V2_2
+    V1_1
   }
 
   record BodyPlaintextMetaInfo {
@@ -224,8 +232,9 @@ protocol local {
 
   enum MessageUnboxedErrorType {
     MISC_0,
-    BADVERSION_1,
-    IDENTIFY_2
+    BADVERSION_CRITICAL_1,
+    BADVERSION_2,
+    IDENTIFY_3
   }
 
   record MessageUnboxedError {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -118,6 +118,12 @@ export const LocalHeaderPlaintextVersion = {
   v1: 1,
 }
 
+export const LocalMessageUnboxedErrorType = {
+  misc: 0,
+  badversion: 1,
+  identify: 2,
+}
+
 export const LocalMessageUnboxedState = {
   valid: 1,
   error: 2,
@@ -1080,10 +1086,16 @@ export type MessageUnboxed =
   | { state: 3, outbox: ?OutboxRecord }
 
 export type MessageUnboxedError = {
+  errType: MessageUnboxedErrorType,
   errMsg: string,
   messageID: MessageID,
   messageType: MessageType,
 }
+
+export type MessageUnboxedErrorType =
+    0 // MISC_0
+  | 1 // BADVERSION_1
+  | 2 // IDENTIFY_2
 
 export type MessageUnboxedState =
     1 // VALID_1

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -102,6 +102,15 @@ export const LocalAssetTag = {
 
 export const LocalBodyPlaintextVersion = {
   v1: 1,
+  v2: 2,
+  v3: 3,
+  v4: 4,
+  v5: 5,
+  v6: 6,
+  v7: 7,
+  v8: 8,
+  v9: 9,
+  v10: 10,
 }
 
 export const LocalConversationErrorType = {
@@ -115,6 +124,15 @@ export const LocalConversationErrorType = {
 
 export const LocalHeaderPlaintextVersion = {
   v1: 1,
+  v2: 2,
+  v3: 3,
+  v4: 4,
+  v5: 5,
+  v6: 6,
+  v7: 7,
+  v8: 8,
+  v9: 9,
+  v10: 10,
 }
 
 export const LocalMessageUnboxedErrorType = {
@@ -631,7 +649,15 @@ export type AssetTag =
 
 export type BodyPlaintext =
     { version: 1, v1: ?BodyPlaintextV1 }
-  | { version: any, 'default': ?BodyPlaintextUnsupported }
+  | { version: 2, v2: ?BodyPlaintextUnsupported }
+  | { version: 3, v3: ?BodyPlaintextUnsupported }
+  | { version: 4, v4: ?BodyPlaintextUnsupported }
+  | { version: 5, v5: ?BodyPlaintextUnsupported }
+  | { version: 6, v6: ?BodyPlaintextUnsupported }
+  | { version: 7, v7: ?BodyPlaintextUnsupported }
+  | { version: 8, v8: ?BodyPlaintextUnsupported }
+  | { version: 9, v9: ?BodyPlaintextUnsupported }
+  | { version: 10, v10: ?BodyPlaintextUnsupported }
 
 export type BodyPlaintextMetaInfo = {
   crit: boolean,
@@ -647,6 +673,15 @@ export type BodyPlaintextV1 = {
 
 export type BodyPlaintextVersion =
     1 // V1_1
+  | 2 // V2_2
+  | 3 // V3_3
+  | 4 // V4_4
+  | 5 // V5_5
+  | 6 // V6_6
+  | 7 // V7_7
+  | 8 // V8_8
+  | 9 // V9_9
+  | 10 // V10_10
 
 export type ChatActivity =
     { activityType: 1, incomingMessage: ?IncomingMessage }
@@ -916,7 +951,15 @@ export type Hash = bytes
 
 export type HeaderPlaintext =
     { version: 1, v1: ?HeaderPlaintextV1 }
-  | { version: any, 'default': ?HeaderPlaintextUnsupported }
+  | { version: 2, v2: ?HeaderPlaintextUnsupported }
+  | { version: 3, v3: ?HeaderPlaintextUnsupported }
+  | { version: 4, v4: ?HeaderPlaintextUnsupported }
+  | { version: 5, v5: ?HeaderPlaintextUnsupported }
+  | { version: 6, v6: ?HeaderPlaintextUnsupported }
+  | { version: 7, v7: ?HeaderPlaintextUnsupported }
+  | { version: 8, v8: ?HeaderPlaintextUnsupported }
+  | { version: 9, v9: ?HeaderPlaintextUnsupported }
+  | { version: 10, v10: ?HeaderPlaintextUnsupported }
 
 export type HeaderPlaintextMetaInfo = {
   crit: boolean,
@@ -942,6 +985,15 @@ export type HeaderPlaintextV1 = {
 
 export type HeaderPlaintextVersion =
     1 // V1_1
+  | 2 // V2_2
+  | 3 // V3_3
+  | 4 // V4_4
+  | 5 // V5_5
+  | 6 // V6_6
+  | 7 // V7_7
+  | 8 // V8_8
+  | 9 // V9_9
+  | 10 // V10_10
 
 export type Inbox = {
   version: InboxVers,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -102,7 +102,6 @@ export const LocalAssetTag = {
 
 export const LocalBodyPlaintextVersion = {
   v1: 1,
-  v2: 2,
 }
 
 export const LocalConversationErrorType = {
@@ -120,8 +119,9 @@ export const LocalHeaderPlaintextVersion = {
 
 export const LocalMessageUnboxedErrorType = {
   misc: 0,
-  badversion: 1,
-  identify: 2,
+  badversionCritical: 1,
+  badversion: 2,
+  identify: 3,
 }
 
 export const LocalMessageUnboxedState = {
@@ -647,7 +647,6 @@ export type BodyPlaintextV1 = {
 
 export type BodyPlaintextVersion =
     1 // V1_1
-  | 2 // V2_2
 
 export type ChatActivity =
     { activityType: 1, incomingMessage: ?IncomingMessage }
@@ -917,6 +916,15 @@ export type Hash = bytes
 
 export type HeaderPlaintext =
     { version: 1, v1: ?HeaderPlaintextV1 }
+  | { version: any, 'default': ?HeaderPlaintextUnsupported }
+
+export type HeaderPlaintextMetaInfo = {
+  crit: boolean,
+}
+
+export type HeaderPlaintextUnsupported = {
+  mi: HeaderPlaintextMetaInfo,
+}
 
 export type HeaderPlaintextV1 = {
   conv: ConversationIDTriple,
@@ -1094,8 +1102,9 @@ export type MessageUnboxedError = {
 
 export type MessageUnboxedErrorType =
     0 // MISC_0
-  | 1 // BADVERSION_1
-  | 2 // IDENTIFY_2
+  | 1 // BADVERSION_CRITICAL_1
+  | 2 // BADVERSION_2
+  | 3 // IDENTIFY_3
 
 export type MessageUnboxedState =
     1 // VALID_1

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -471,6 +471,26 @@
     },
     {
       "type": "record",
+      "name": "HeaderPlaintextMetaInfo",
+      "fields": [
+        {
+          "type": "boolean",
+          "name": "crit"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "HeaderPlaintextUnsupported",
+      "fields": [
+        {
+          "type": "HeaderPlaintextMetaInfo",
+          "name": "mi"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "HeaderPlaintextV1",
       "fields": [
         {
@@ -545,6 +565,12 @@
             "def": false
           },
           "body": "HeaderPlaintextV1"
+        },
+        {
+          "label": {
+            "def": true
+          },
+          "body": "HeaderPlaintextUnsupported"
         }
       ]
     },
@@ -552,8 +578,7 @@
       "type": "enum",
       "name": "BodyPlaintextVersion",
       "symbols": [
-        "V1_1",
-        "V2_2"
+        "V1_1"
       ]
     },
     {
@@ -685,8 +710,9 @@
       "name": "MessageUnboxedErrorType",
       "symbols": [
         "MISC_0",
-        "BADVERSION_1",
-        "IDENTIFY_2"
+        "BADVERSION_CRITICAL_1",
+        "BADVERSION_2",
+        "IDENTIFY_3"
       ]
     },
     {

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -681,9 +681,22 @@
       ]
     },
     {
+      "type": "enum",
+      "name": "MessageUnboxedErrorType",
+      "symbols": [
+        "MISC_0",
+        "BADVERSION_1",
+        "IDENTIFY_2"
+      ]
+    },
+    {
       "type": "record",
       "name": "MessageUnboxedError",
       "fields": [
+        {
+          "type": "MessageUnboxedErrorType",
+          "name": "errType"
+        },
         {
           "type": "string",
           "name": "errMsg"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -466,7 +466,16 @@
       "type": "enum",
       "name": "HeaderPlaintextVersion",
       "symbols": [
-        "V1_1"
+        "V1_1",
+        "V2_2",
+        "V3_3",
+        "V4_4",
+        "V5_5",
+        "V6_6",
+        "V7_7",
+        "V8_8",
+        "V9_9",
+        "V10_10"
       ]
     },
     {
@@ -568,7 +577,64 @@
         },
         {
           "label": {
-            "def": true
+            "name": "V2",
+            "def": false
+          },
+          "body": "HeaderPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V3",
+            "def": false
+          },
+          "body": "HeaderPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V4",
+            "def": false
+          },
+          "body": "HeaderPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V5",
+            "def": false
+          },
+          "body": "HeaderPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V6",
+            "def": false
+          },
+          "body": "HeaderPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V7",
+            "def": false
+          },
+          "body": "HeaderPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V8",
+            "def": false
+          },
+          "body": "HeaderPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V9",
+            "def": false
+          },
+          "body": "HeaderPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V10",
+            "def": false
           },
           "body": "HeaderPlaintextUnsupported"
         }
@@ -578,7 +644,16 @@
       "type": "enum",
       "name": "BodyPlaintextVersion",
       "symbols": [
-        "V1_1"
+        "V1_1",
+        "V2_2",
+        "V3_3",
+        "V4_4",
+        "V5_5",
+        "V6_6",
+        "V7_7",
+        "V8_8",
+        "V9_9",
+        "V10_10"
       ]
     },
     {
@@ -628,7 +703,64 @@
         },
         {
           "label": {
-            "def": true
+            "name": "V2",
+            "def": false
+          },
+          "body": "BodyPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V3",
+            "def": false
+          },
+          "body": "BodyPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V4",
+            "def": false
+          },
+          "body": "BodyPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V5",
+            "def": false
+          },
+          "body": "BodyPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V6",
+            "def": false
+          },
+          "body": "BodyPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V7",
+            "def": false
+          },
+          "body": "BodyPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V8",
+            "def": false
+          },
+          "body": "BodyPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V9",
+            "def": false
+          },
+          "body": "BodyPlaintextUnsupported"
+        },
+        {
+          "label": {
+            "name": "V10",
+            "def": false
           },
           "body": "BodyPlaintextUnsupported"
         }

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -118,6 +118,12 @@ export const LocalHeaderPlaintextVersion = {
   v1: 1,
 }
 
+export const LocalMessageUnboxedErrorType = {
+  misc: 0,
+  badversion: 1,
+  identify: 2,
+}
+
 export const LocalMessageUnboxedState = {
   valid: 1,
   error: 2,
@@ -1080,10 +1086,16 @@ export type MessageUnboxed =
   | { state: 3, outbox: ?OutboxRecord }
 
 export type MessageUnboxedError = {
+  errType: MessageUnboxedErrorType,
   errMsg: string,
   messageID: MessageID,
   messageType: MessageType,
 }
+
+export type MessageUnboxedErrorType =
+    0 // MISC_0
+  | 1 // BADVERSION_1
+  | 2 // IDENTIFY_2
 
 export type MessageUnboxedState =
     1 // VALID_1

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -102,6 +102,15 @@ export const LocalAssetTag = {
 
 export const LocalBodyPlaintextVersion = {
   v1: 1,
+  v2: 2,
+  v3: 3,
+  v4: 4,
+  v5: 5,
+  v6: 6,
+  v7: 7,
+  v8: 8,
+  v9: 9,
+  v10: 10,
 }
 
 export const LocalConversationErrorType = {
@@ -115,6 +124,15 @@ export const LocalConversationErrorType = {
 
 export const LocalHeaderPlaintextVersion = {
   v1: 1,
+  v2: 2,
+  v3: 3,
+  v4: 4,
+  v5: 5,
+  v6: 6,
+  v7: 7,
+  v8: 8,
+  v9: 9,
+  v10: 10,
 }
 
 export const LocalMessageUnboxedErrorType = {
@@ -631,7 +649,15 @@ export type AssetTag =
 
 export type BodyPlaintext =
     { version: 1, v1: ?BodyPlaintextV1 }
-  | { version: any, 'default': ?BodyPlaintextUnsupported }
+  | { version: 2, v2: ?BodyPlaintextUnsupported }
+  | { version: 3, v3: ?BodyPlaintextUnsupported }
+  | { version: 4, v4: ?BodyPlaintextUnsupported }
+  | { version: 5, v5: ?BodyPlaintextUnsupported }
+  | { version: 6, v6: ?BodyPlaintextUnsupported }
+  | { version: 7, v7: ?BodyPlaintextUnsupported }
+  | { version: 8, v8: ?BodyPlaintextUnsupported }
+  | { version: 9, v9: ?BodyPlaintextUnsupported }
+  | { version: 10, v10: ?BodyPlaintextUnsupported }
 
 export type BodyPlaintextMetaInfo = {
   crit: boolean,
@@ -647,6 +673,15 @@ export type BodyPlaintextV1 = {
 
 export type BodyPlaintextVersion =
     1 // V1_1
+  | 2 // V2_2
+  | 3 // V3_3
+  | 4 // V4_4
+  | 5 // V5_5
+  | 6 // V6_6
+  | 7 // V7_7
+  | 8 // V8_8
+  | 9 // V9_9
+  | 10 // V10_10
 
 export type ChatActivity =
     { activityType: 1, incomingMessage: ?IncomingMessage }
@@ -916,7 +951,15 @@ export type Hash = bytes
 
 export type HeaderPlaintext =
     { version: 1, v1: ?HeaderPlaintextV1 }
-  | { version: any, 'default': ?HeaderPlaintextUnsupported }
+  | { version: 2, v2: ?HeaderPlaintextUnsupported }
+  | { version: 3, v3: ?HeaderPlaintextUnsupported }
+  | { version: 4, v4: ?HeaderPlaintextUnsupported }
+  | { version: 5, v5: ?HeaderPlaintextUnsupported }
+  | { version: 6, v6: ?HeaderPlaintextUnsupported }
+  | { version: 7, v7: ?HeaderPlaintextUnsupported }
+  | { version: 8, v8: ?HeaderPlaintextUnsupported }
+  | { version: 9, v9: ?HeaderPlaintextUnsupported }
+  | { version: 10, v10: ?HeaderPlaintextUnsupported }
 
 export type HeaderPlaintextMetaInfo = {
   crit: boolean,
@@ -942,6 +985,15 @@ export type HeaderPlaintextV1 = {
 
 export type HeaderPlaintextVersion =
     1 // V1_1
+  | 2 // V2_2
+  | 3 // V3_3
+  | 4 // V4_4
+  | 5 // V5_5
+  | 6 // V6_6
+  | 7 // V7_7
+  | 8 // V8_8
+  | 9 // V9_9
+  | 10 // V10_10
 
 export type Inbox = {
   version: InboxVers,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -102,7 +102,6 @@ export const LocalAssetTag = {
 
 export const LocalBodyPlaintextVersion = {
   v1: 1,
-  v2: 2,
 }
 
 export const LocalConversationErrorType = {
@@ -120,8 +119,9 @@ export const LocalHeaderPlaintextVersion = {
 
 export const LocalMessageUnboxedErrorType = {
   misc: 0,
-  badversion: 1,
-  identify: 2,
+  badversionCritical: 1,
+  badversion: 2,
+  identify: 3,
 }
 
 export const LocalMessageUnboxedState = {
@@ -647,7 +647,6 @@ export type BodyPlaintextV1 = {
 
 export type BodyPlaintextVersion =
     1 // V1_1
-  | 2 // V2_2
 
 export type ChatActivity =
     { activityType: 1, incomingMessage: ?IncomingMessage }
@@ -917,6 +916,15 @@ export type Hash = bytes
 
 export type HeaderPlaintext =
     { version: 1, v1: ?HeaderPlaintextV1 }
+  | { version: any, 'default': ?HeaderPlaintextUnsupported }
+
+export type HeaderPlaintextMetaInfo = {
+  crit: boolean,
+}
+
+export type HeaderPlaintextUnsupported = {
+  mi: HeaderPlaintextMetaInfo,
+}
 
 export type HeaderPlaintextV1 = {
   conv: ConversationIDTriple,
@@ -1094,8 +1102,9 @@ export type MessageUnboxedError = {
 
 export type MessageUnboxedErrorType =
     0 // MISC_0
-  | 1 // BADVERSION_1
-  | 2 // IDENTIFY_2
+  | 1 // BADVERSION_CRITICAL_1
+  | 2 // BADVERSION_2
+  | 3 // IDENTIFY_3
 
 export type MessageUnboxedState =
     1 // VALID_1


### PR DESCRIPTION
Purpose of this is so the clients can respond more intelligently to message versions from the future. We tag each message error with a type to indicate what kind of error triggered it.

Also, build in some future proofing to handle versions in the future, and (right now), whether we should surface to clients information about errors from them.