### PR TITLE
pass the TLFIdentifyBehavior all the way to the engine

### DIFF
--- a/go/engine/bg_identifier.go
+++ b/go/engine/bg_identifier.go
@@ -142,7 +142,7 @@ func (b *BackgroundIdentifier) RequiredUIs() []libkb.UIKind {
 func (b *BackgroundIdentifier) SubConsumers() []libkb.UIConsumer {
 	return []libkb.UIConsumer{
 		&Identify2WithUID{
-			arg: &keybase1.Identify2Arg{ChatGUIMode: true},
+			arg: &keybase1.Identify2Arg{IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_GUI},
 		},
 	}
 }
@@ -334,8 +334,8 @@ func (b *BackgroundIdentifier) runOne(ctx *Context, u keybase1.UID) (err error) 
 		Reason: keybase1.IdentifyReason{
 			Type: keybase1.IdentifyReasonType_BACKGROUND,
 		},
-		AlwaysBlock: true,
-		ChatGUIMode: true,
+		AlwaysBlock:      true,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_GUI,
 	}
 	eng := NewIdentify2WithUID(b.G(), &arg)
 	if b.testArgs != nil {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -757,6 +757,11 @@ func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
 	return b == TLFIdentifyBehavior_CHAT_GUI
 }
 
+// All of the chat modes want to prevent tracker popups.
+func (b TLFIdentifyBehavior) ShouldSuppressTrackerPopups() bool {
+	return b != TLFIdentifyBehavior_DEFAULT_KBFS
+}
+
 func (c CanonicalTLFNameAndIDWithBreaks) Eq(r CanonicalTLFNameAndIDWithBreaks) bool {
 	if c.CanonicalName != r.CanonicalName {
 		return false

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -759,7 +759,8 @@ func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
 
 // All of the chat modes want to prevent tracker popups.
 func (b TLFIdentifyBehavior) ShouldSuppressTrackerPopups() bool {
-	return b != TLFIdentifyBehavior_DEFAULT_KBFS
+	return b == TLFIdentifyBehavior_CHAT_GUI || b == TLFIdentifyBehavior_CHAT_CLI ||
+		b == TLFIdentifyBehavior_CHAT_GUI_STRICT
 }
 
 func (c CanonicalTLFNameAndIDWithBreaks) Eq(r CanonicalTLFNameAndIDWithBreaks) bool {

--- a/go/protocol/keybase1/identify.go
+++ b/go/protocol/keybase1/identify.go
@@ -41,20 +41,20 @@ type IdentifyArg struct {
 }
 
 type Identify2Arg struct {
-	SessionID             int            `codec:"sessionID" json:"sessionID"`
-	Uid                   UID            `codec:"uid" json:"uid"`
-	UserAssertion         string         `codec:"userAssertion" json:"userAssertion"`
-	Reason                IdentifyReason `codec:"reason" json:"reason"`
-	UseDelegateUI         bool           `codec:"useDelegateUI" json:"useDelegateUI"`
-	AlwaysBlock           bool           `codec:"alwaysBlock" json:"alwaysBlock"`
-	NoErrorOnTrackFailure bool           `codec:"noErrorOnTrackFailure" json:"noErrorOnTrackFailure"`
-	ForceRemoteCheck      bool           `codec:"forceRemoteCheck" json:"forceRemoteCheck"`
-	NeedProofSet          bool           `codec:"needProofSet" json:"needProofSet"`
-	AllowEmptySelfID      bool           `codec:"allowEmptySelfID" json:"allowEmptySelfID"`
-	NoSkipSelf            bool           `codec:"noSkipSelf" json:"noSkipSelf"`
-	CanSuppressUI         bool           `codec:"canSuppressUI" json:"canSuppressUI"`
-	ChatGUIMode           bool           `codec:"chatGUIMode" json:"chatGUIMode"`
-	ForceDisplay          bool           `codec:"forceDisplay" json:"forceDisplay"`
+	SessionID             int                 `codec:"sessionID" json:"sessionID"`
+	Uid                   UID                 `codec:"uid" json:"uid"`
+	UserAssertion         string              `codec:"userAssertion" json:"userAssertion"`
+	Reason                IdentifyReason      `codec:"reason" json:"reason"`
+	UseDelegateUI         bool                `codec:"useDelegateUI" json:"useDelegateUI"`
+	AlwaysBlock           bool                `codec:"alwaysBlock" json:"alwaysBlock"`
+	NoErrorOnTrackFailure bool                `codec:"noErrorOnTrackFailure" json:"noErrorOnTrackFailure"`
+	ForceRemoteCheck      bool                `codec:"forceRemoteCheck" json:"forceRemoteCheck"`
+	NeedProofSet          bool                `codec:"needProofSet" json:"needProofSet"`
+	AllowEmptySelfID      bool                `codec:"allowEmptySelfID" json:"allowEmptySelfID"`
+	NoSkipSelf            bool                `codec:"noSkipSelf" json:"noSkipSelf"`
+	CanSuppressUI         bool                `codec:"canSuppressUI" json:"canSuppressUI"`
+	IdentifyBehavior      TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
+	ForceDisplay          bool                `codec:"forceDisplay" json:"forceDisplay"`
 }
 
 type IdentifyInterface interface {

--- a/go/systests/rpc_test.go
+++ b/go/systests/rpc_test.go
@@ -196,16 +196,16 @@ func testIdentify2(t *testing.T, g *libkb.GlobalContext) {
 	}
 
 	_, err = cli.Identify2(context.TODO(), keybase1.Identify2Arg{
-		UserAssertion: "t_alice",
-		ChatGUIMode:   true,
+		UserAssertion:    "t_alice",
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_GUI,
 	})
 	if err != nil {
 		t.Fatalf("Identify2 failed: %v\n", err)
 	}
 
 	_, err = cli.Identify2(context.TODO(), keybase1.Identify2Arg{
-		UserAssertion: "t_weriojweroi",
-		ChatGUIMode:   true,
+		UserAssertion:    "t_weriojweroi",
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_GUI,
 	})
 	if _, ok := err.(libkb.NotFoundError); !ok {
 		t.Fatalf("Expected a not-found error, but got: %v (%T)", err, err)

--- a/protocol/avdl/keybase1/identify.avdl
+++ b/protocol/avdl/keybase1/identify.avdl
@@ -44,7 +44,7 @@ protocol identify {
   /*
    * Note that UID can be empty, in which case a resolution is also forced.
    */
-  Identify2Res identify2(int sessionID, UID uid, string userAssertion, IdentifyReason reason, boolean useDelegateUI=false, boolean alwaysBlock=false, boolean noErrorOnTrackFailure=false, boolean forceRemoteCheck=false, boolean needProofSet=false, boolean allowEmptySelfID=false, boolean noSkipSelf=true, boolean canSuppressUI=false, boolean chatGUIMode=false, boolean forceDisplay=false);
+  Identify2Res identify2(int sessionID, UID uid, string userAssertion, IdentifyReason reason, boolean useDelegateUI=false, boolean alwaysBlock=false, boolean noErrorOnTrackFailure=false, boolean forceRemoteCheck=false, boolean needProofSet=false, boolean allowEmptySelfID=false, boolean noSkipSelf=true, boolean canSuppressUI=false, TLFIdentifyBehavior identifyBehavior=0, boolean forceDisplay=false);
 
 
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4578,7 +4578,7 @@ export type identifyIdentify2RpcParam = Exact<{
   allowEmptySelfID?: boolean,
   noSkipSelf?: boolean,
   canSuppressUI?: boolean,
-  chatGUIMode?: boolean,
+  identifyBehavior?: TLFIdentifyBehavior,
   forceDisplay?: boolean
 }>
 

--- a/protocol/json/keybase1/identify.json
+++ b/protocol/json/keybase1/identify.json
@@ -177,9 +177,9 @@
           "default": false
         },
         {
-          "name": "chatGUIMode",
-          "type": "boolean",
-          "default": false
+          "name": "identifyBehavior",
+          "type": "TLFIdentifyBehavior",
+          "default": 0
         },
         {
           "name": "forceDisplay",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4578,7 +4578,7 @@ export type identifyIdentify2RpcParam = Exact<{
   allowEmptySelfID?: boolean,
   noSkipSelf?: boolean,
   canSuppressUI?: boolean,
-  chatGUIMode?: boolean,
+  identifyBehavior?: TLFIdentifyBehavior,
   forceDisplay?: boolean
 }>
 


### PR DESCRIPTION
Previously we were making a "ChatGuiMode" boolean out of it, but that
got us confused between two different concerns:

1. Should we suppress hard errors on an ID failure? This is only the
   case for "Chat GUI" mode, but not the other two chat modes.
2. Should we suppress tracker popups? This is the case for all chat
   modes.

Passing the entire enum down all the way lets the engine handle both of
those questions properly.

r? @mmaxim. I'm still testing this, and I want to make sure to take a careful look with you at the behavior changes in go/engine/identify2_with_uid.go.