### PR TITLE
do not trigger out-of-date check (and service connection) on version -S

### DIFF
--- a/go/client/cmd_version.go
+++ b/go/client/cmd_version.go
@@ -50,6 +50,7 @@ func NewCmdVersion(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 			cl.ChooseCommand(NewCmdVersionRunner(g), "version", c)
 			cl.SetForkCmd(libcmdline.NoFork)
 			cl.SetLogForward(libcmdline.LogForwardNone)
+			cl.SetSkipOutOfDateCheck()
 		},
 	}
 }

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -133,7 +133,7 @@ func mainInner(g *libkb.GlobalContext) error {
 	}
 
 	err = cmd.Run()
-	if !cl.IsService() {
+	if !cl.IsService() && !cl.SkipOutOfDateCheck() {
 		// Errors that come up in printing this warning are logged but ignored.
 		client.PrintOutOfDateWarnings(g)
 	}

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -35,18 +35,20 @@ const (
 )
 
 type CommandLine struct {
-	app          *cli.App
-	ctx          *cli.Context
-	cmd          Command
-	name         string     // the name of the chosen command
-	service      bool       // The server is a special command
-	fork         ForkCmd    // If the command is to stop (then don't start the server)
-	noStandalone bool       // On if this command can't run in standalone mode
-	logForward   LogForward // What do to about log forwarding
-	defaultCmd   string
+	app                *cli.App
+	ctx                *cli.Context
+	cmd                Command
+	name               string     // the name of the chosen command
+	service            bool       // The server is a special command
+	fork               ForkCmd    // If the command is to stop (then don't start the server)
+	noStandalone       bool       // On if this command can't run in standalone mode
+	logForward         LogForward // What do to about log forwarding
+	skipOutOfDateCheck bool       // don't try to check for service being out of date
+	defaultCmd         string
 }
 
 func (p CommandLine) IsService() bool             { return p.service }
+func (p CommandLine) SkipOutOfDateCheck() bool    { return p.skipOutOfDateCheck }
 func (p *CommandLine) SetService()                { p.service = true }
 func (p CommandLine) GetForkCmd() ForkCmd         { return p.fork }
 func (p *CommandLine) SetForkCmd(v ForkCmd)       { p.fork = v }
@@ -54,6 +56,7 @@ func (p *CommandLine) SetNoStandalone()           { p.noStandalone = true }
 func (p CommandLine) IsNoStandalone() bool        { return p.noStandalone }
 func (p *CommandLine) SetLogForward(f LogForward) { p.logForward = f }
 func (p *CommandLine) GetLogForward() LogForward  { return p.logForward }
+func (p *CommandLine) SetSkipOutOfDateCheck()     { p.skipOutOfDateCheck = true }
 
 func (p CommandLine) GetNoAutoFork() (bool, bool) {
 	return p.GetBool("no-auto-fork", true)


### PR DESCRIPTION
`keybase version -S` was triggering an out-of-date check, which was triggering a service connection.  No need for that.