### PR TITLE
Fix chat message MerkleRoot

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -264,6 +264,7 @@ func (b *Boxer) unboxMessageWithKey(ctx context.Context, msg chat1.MessageBoxed,
 			Prev:         hp.Prev,
 			Sender:       hp.Sender,
 			SenderDevice: hp.SenderDevice,
+			MerkleRoot:   hp.MerkleRoot,
 			OutboxInfo:   hp.OutboxInfo,
 			OutboxID:     hp.OutboxID,
 		}
@@ -453,6 +454,7 @@ func (b *Boxer) boxMessageWithKeys(msg chat1.MessagePlaintext, key *keybase1.Cry
 		Sender:       msg.ClientHeader.Sender,
 		SenderDevice: msg.ClientHeader.SenderDevice,
 		BodyHash:     bodyHash[:],
+		MerkleRoot:   msg.ClientHeader.MerkleRoot,
 		OutboxInfo:   msg.ClientHeader.OutboxInfo,
 		OutboxID:     msg.ClientHeader.OutboxID,
 	}

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -563,6 +563,56 @@ func TestChatMessagePublic(t *testing.T) {
 	}
 }
 
+// Test that the latest merkle root is included in the message.
+func TestChatMerkleRoot(t *testing.T) {
+	key := cryptKey(t)
+	text := "hi"
+	tc, boxer := setupChatTest(t, "unbox")
+	defer tc.Cleanup()
+
+	// need a real user
+	u, err := kbtest.CreateAndSignupFakeUser("unbox", tc.G)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()))
+	fakeMerkleRoot := chat1.MerkleRoot{
+		Seqno: 9,
+		Hash:  []byte{1, 2, 3, 4},
+	}
+	fakeMerkleRoot2 := fakeMerkleRoot
+	msg.ClientHeader.MerkleRoot = &fakeMerkleRoot2
+
+	signKP := getSigningKeyPairForTest(t, tc, u)
+
+	boxed, err := boxer.boxMessageWithKeys(msg, key, signKP)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// need to give it a server header...
+	boxed.ServerHeader = &chat1.MessageServerHeader{
+		Ctime: gregor1.ToTime(time.Now()),
+	}
+
+	umwkr, err := boxer.unboxMessageWithKey(context.TODO(), *boxed, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	messagePlaintext := umwkr.messagePlaintext
+	body := messagePlaintext.MessageBody
+	if typ, _ := body.MessageType(); typ != chat1.MessageType_TEXT {
+		t.Errorf("body type: %d, expected %d", typ, chat1.MessageType_TEXT)
+	}
+	if body.Text().Body != text {
+		t.Errorf("body text: %q, expected %q", body.Text().Body, text)
+	}
+
+	require.NotNil(t, messagePlaintext.ClientHeader.MerkleRoot, "required merkle root")
+	require.Equal(t, messagePlaintext.ClientHeader.MerkleRoot.Seqno, int64(9), "wrong merkle root seqno")
+	require.Equal(t, *messagePlaintext.ClientHeader.MerkleRoot, fakeMerkleRoot, "wrong merkle root")
+}
+
 type KeyFinderMock struct{}
 
 func NewKeyFinderMock() KeyFinder {

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -1156,7 +1156,7 @@ func (mr *MerkleRoot) ToSigJSON() (ret *jsonw.Wrapper) {
 func (mr *MerkleRoot) ToInfo() chat1.MerkleRoot {
 	return chat1.MerkleRoot{
 		Seqno: int64(*mr.Seqno()),
-		Hash:  mr.RootHash().bytes(),
+		Hash:  mr.payload.shortHash().bytes(),
 	}
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -562,6 +562,7 @@ type HeaderPlaintextV1 struct {
 	Sender          gregor1.UID              `codec:"sender" json:"sender"`
 	SenderDevice    gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
 	BodyHash        Hash                     `codec:"bodyHash" json:"bodyHash"`
+	MerkleRoot      *MerkleRoot              `codec:"merkleRoot,omitempty" json:"merkleRoot,omitempty"`
 	OutboxInfo      *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
 	OutboxID        *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	HeaderSignature *SignatureInfo           `codec:"headerSignature,omitempty" json:"headerSignature,omitempty"`

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -174,6 +174,7 @@ protocol local {
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;
     Hash bodyHash;
+    union { null, MerkleRoot } merkleRoot;
     union { null, OutboxInfo } outboxInfo;
     union { null, OutboxID } outboxID;
     union {null, SignatureInfo} headerSignature;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -978,6 +978,7 @@ export type HeaderPlaintextV1 = {
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
   bodyHash: Hash,
+  merkleRoot?: ?MerkleRoot,
   outboxInfo?: ?OutboxInfo,
   outboxID?: ?OutboxID,
   headerSignature?: ?SignatureInfo,

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -540,6 +540,13 @@
         {
           "type": [
             null,
+            "MerkleRoot"
+          ],
+          "name": "merkleRoot"
+        },
+        {
+          "type": [
+            null,
             "OutboxInfo"
           ],
           "name": "outboxInfo"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -978,6 +978,7 @@ export type HeaderPlaintextV1 = {
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
   bodyHash: Hash,
+  merkleRoot?: ?MerkleRoot,
   outboxInfo?: ?OutboxInfo,
   outboxID?: ?OutboxID,
   headerSignature?: ?SignatureInfo,


### PR DESCRIPTION
Try to add the latest known merkle root to outgoing chat messages. This was botched earlier in https://github.com/keybase/client/pull/5122 by only adding it to `MessageClientHeader` (non-wire, non-versioned). This one adds it to `HeaderPlaintext` (wire, versioned) as well, and adds the copy-over code.

Is adding a new field to `HeaderPlaintextV1` without bumping the version ok because `.MerkleRoot` is nullable? Breaking this would be bad and invalidate sigs. @patrickxb had doubts about whether this is safe.

r? @mmaxim 

@maxtaco this is the correct merkle root?