### PR TITLE
allow copy command to not change input

### DIFF
--- a/shared/chat/conversation/input.desktop.js
+++ b/shared/chat/conversation/input.desktop.js
@@ -52,13 +52,18 @@ class Conversation extends Component<void, Props, State> {
     }
   }
 
-  _globalKeyDownHandler = (ev: Event) => {
+  _globalKeyDownHandler = (ev: KeyboardEvent) => {
     if (!this._input) {
       return
     }
 
     const target = ev.target
     if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+      return
+    }
+
+    // Allow copy
+    if (ev.metaKey && ['Meta', 'c'].includes(ev.key)) {
       return
     }
 


### PR DESCRIPTION
The global handler would steal focus to the input box but we want to allow command+c copy in the chat body

@keybase/react-hackers 