### PR TITLE
Support opening a new chat from the Folders tab

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -55,6 +55,7 @@ import type {
   NewChat,
   OpenAttachmentPopup,
   OpenFolder,
+  OpenTlfInChat,
   OutboxIDKey,
   PostMessage,
   RemoveOutboxMessage,
@@ -204,6 +205,10 @@ function badgeAppForChat (conversations: List<ConversationBadgeState>): BadgeApp
 
 function openFolder (): OpenFolder {
   return {type: 'chat:openFolder', payload: undefined}
+}
+
+function openTlfInChat (tlf: string): OpenTlfInChat {
+  return {type: 'chat:openTlfInChat', payload: tlf}
 }
 
 function startConversation (users: Array<string>): StartConversation {
@@ -1173,6 +1178,12 @@ function _unboxedToMessage (message: MessageUnboxed, idx: number, yourName, your
   }
 }
 
+function * _openTlfInChat (action: OpenTlfInChat): SagaGenerator<any, any> {
+  const tlf = action.payload
+  const users = tlf.split(',')
+  yield put(startConversation(users))
+}
+
 function * _startConversation (action: StartConversation): SagaGenerator<any, any> {
   const result = yield call(localNewConversationLocalRpcPromise, {
     param: {
@@ -1647,6 +1658,7 @@ function * chatSaga (): SagaGenerator<any, any> {
     safeTakeLatest('chat:badgeAppForChat', _badgeAppForChat),
     safeTakeEvery(changedFocus, _changedFocus),
     safeTakeEvery('chat:deleteMessage', _deleteMessage),
+    safeTakeEvery('chat:openTlfInChat', _openTlfInChat),
   ]
 }
 
@@ -1663,6 +1675,7 @@ export {
   newChat,
   selectAttachment,
   openFolder,
+  openTlfInChat,
   postMessage,
   retryAttachment,
   retryMessage,

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -1180,7 +1180,9 @@ function _unboxedToMessage (message: MessageUnboxed, idx: number, yourName, your
 
 function * _openTlfInChat (action: OpenTlfInChat): SagaGenerator<any, any> {
   const tlf = action.payload
-  const users = tlf.split(',')
+  const me = yield select(usernameSelector)
+  const userlist = parseFolderNameToUsers(me, tlf)
+  const users = userlist.map(u => u.username)
   yield put(startConversation(users))
 }
 

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -2,6 +2,7 @@
 import * as Constants from '../constants/chat'
 import HiddenString from '../util/hidden-string'
 import engine from '../engine'
+import _ from 'lodash'
 import {List, Map} from 'immutable'
 import {NotifyPopup} from '../native/notifications'
 import {apiserverGetRpcPromise, TlfKeysTLFIdentifyBehavior} from '../constants/types/flow-types'
@@ -1183,6 +1184,10 @@ function * _openTlfInChat (action: OpenTlfInChat): SagaGenerator<any, any> {
   const me = yield select(usernameSelector)
   const userlist = parseFolderNameToUsers(me, tlf)
   const users = userlist.map(u => u.username)
+  if (_.some(userlist, 'readOnly')) {
+    console.warn('Bug: openTlfToChat should never be called on a convo with readOnly members.')
+    return
+  }
   yield put(startConversation(users))
 }
 

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -263,6 +263,7 @@ export type MuteConversation = NoErrorTypedAction<'chat:muteConversation', {conv
 export type NewChat = NoErrorTypedAction<'chat:newChat', {existingParticipants: Array<string>}>
 export type OpenAttachmentPopup = NoErrorTypedAction<'chat:openAttachmentPopup', {message: AttachmentMessage}>
 export type OpenFolder = NoErrorTypedAction<'chat:openFolder', void>
+export type OpenTlfInChat = NoErrorTypedAction<'chat:openTlfInChat', string>
 export type PostMessage = NoErrorTypedAction<'chat:postMessage', {conversationIDKey: ConversationIDKey, text: HiddenString}>
 export type PrependMessages = NoErrorTypedAction<'chat:prependMessages', {conversationIDKey: ConversationIDKey, messages: Array<ServerMessage>, moreToLoad: boolean, paginationNext: ?Buffer}>
 export type RemovePendingFailure = NoErrorTypedAction<'chat:removePendingFailure', {outboxID: OutboxIDKey}>

--- a/shared/folders/dumb.js
+++ b/shared/folders/dumb.js
@@ -288,7 +288,7 @@ const commonFiles = (isPrivate): FilesProps => ({
   theme: isPrivate ? 'private' : 'public',
   ignored: false,
   allowIgnore: true,
-  hasReaders: false,
+  hasReadOnlyUsers: false,
   visiblePopupMenu: false,
   popupMenuItems: filesMenuItems,
   selfUsername: 'cecileb',

--- a/shared/folders/dumb.js
+++ b/shared/folders/dumb.js
@@ -182,6 +182,7 @@ const onToggleShowIgnored = () => console.log('toggle')
 const commonFolders = {
   smallMode: false,
   onRekey: path => console.log(`open rekey page: ${path}`),
+  onChat: tlf => console.log(`open chat with tlf ${tlf}`),
   onToggleShowIgnored,
   username: 'cecileb',
   private: {tlfs, ignored, isPublic: false, parentProps, onToggleShowIgnored, showIgnored: true},
@@ -297,6 +298,7 @@ const commonFiles = (isPrivate): FilesProps => ({
   youCanUnlock: [],
   onBack: () => console.log('onBack:files'),
   openCurrentFolder: () => console.log('open current folder'),
+  openConversationFromFolder: () => console.log('open tlf in chat'),
   ignoreCurrentFolder: () => console.log('ignore current folder'),
   unIgnoreCurrentFolder: () => console.log('unignore current folder'),
   onTogglePopupMenu: () => console.log('onTogglePopupMenu'),

--- a/shared/folders/dumb.js
+++ b/shared/folders/dumb.js
@@ -288,6 +288,7 @@ const commonFiles = (isPrivate): FilesProps => ({
   theme: isPrivate ? 'private' : 'public',
   ignored: false,
   allowIgnore: true,
+  hasReaders: false,
   visiblePopupMenu: false,
   popupMenuItems: filesMenuItems,
   selfUsername: 'cecileb',

--- a/shared/folders/files/index.js
+++ b/shared/folders/files/index.js
@@ -9,6 +9,7 @@ import {connect} from 'react-redux'
 import {favoriteFolder, ignoreFolder} from '../../actions/favorite'
 import {navigateUp, navigateAppend} from '../../actions/route-tree'
 import {openInKBFS} from '../../actions/kbfs'
+import {openTlfInChat} from '../../actions/chat'
 
 type Props = $Shape<{
   folder: ?Folder,
@@ -20,6 +21,7 @@ type Props = $Shape<{
   ignoreFolder: (path: string) => void,
   favoriteFolder: (path: string) => void,
   openInKBFS: (path: string) => void,
+  openTlfInChat: (tlf: string) => void,
 }>
 
 type State = {
@@ -55,6 +57,10 @@ class Files extends Component<void, Props, State> {
     const {folder, username} = this.props
     if (!folder) return null // Protect from state where the folder to be displayed was removed
     const openCurrentFolder = () => { this.props.openInKBFS(this.props.path) }
+    const openConversationFromFolder = () => {
+      const tlf = this.props && this.props.folder && this.props.folder.sortName
+      tlf && this.props.openTlfInChat(tlf)
+    }
     const ignoreCurrentFolder = () => { this.props.ignoreFolder(this.props.path) }
     const unIgnoreCurrentFolder = () => { this.props.favoriteFolder(this.props.path) }
     const allowIgnore = folder.users.some(f => !f.you)
@@ -76,6 +82,7 @@ class Files extends Component<void, Props, State> {
         youCanUnlock={folder.youCanUnlock}
         onBack={() => this.props.navigateUp()}
         openCurrentFolder={openCurrentFolder}
+        openConversationFromFolder={openConversationFromFolder}
         onClickPaperkey={device => this.props.navigateAppend([{selected: 'paperkey', name: device.name}])}  // FIXME: does this name route prop get used anywhere?
         ignoreCurrentFolder={ignoreCurrentFolder}
         unIgnoreCurrentFolder={unIgnoreCurrentFolder}
@@ -103,7 +110,7 @@ const ConnectedFiles = connect(
       username: state.config && state.config.username,
     }
   },
-  (dispatch: any) => bindActionCreators({favoriteFolder, ignoreFolder, navigateUp, openInKBFS, navigateAppend}, dispatch)
+  (dispatch: any) => bindActionCreators({favoriteFolder, ignoreFolder, navigateAppend, navigateUp, openInKBFS, openTlfInChat}, dispatch)
 )(Files)
 
 export default ConnectedFiles

--- a/shared/folders/files/index.js
+++ b/shared/folders/files/index.js
@@ -78,6 +78,7 @@ class Files extends Component<void, Props, State> {
         selfUsername={username}
         allowIgnore={allowIgnore}
         users={folder.users}
+        hasReaders={folder.users && _.some(folder.users, 'readOnly')}
         waitingForParticipantUnlock={folder.waitingForParticipantUnlock}
         youCanUnlock={folder.youCanUnlock}
         onBack={() => this.props.navigateUp()}

--- a/shared/folders/files/index.js
+++ b/shared/folders/files/index.js
@@ -78,7 +78,7 @@ class Files extends Component<void, Props, State> {
         selfUsername={username}
         allowIgnore={allowIgnore}
         users={folder.users}
-        hasReaders={folder.users && _.some(folder.users, 'readOnly')}
+        hasReadOnlyUsers={folder.users && _.some(folder.users, 'readOnly')}
         waitingForParticipantUnlock={folder.waitingForParticipantUnlock}
         youCanUnlock={folder.youCanUnlock}
         onBack={() => this.props.navigateUp()}

--- a/shared/folders/files/render.desktop.js
+++ b/shared/folders/files/render.desktop.js
@@ -106,6 +106,10 @@ class FilesRender extends Component<void, Props, void> {
         <Box style={styleRecentFilesNotEnabled}>
           <Button key='open' type='Primary' onClick={this.props.openCurrentFolder}
             label='Open folder' style={{marginBottom: globalMargins.small}} />
+          {isPrivate && <Button key='chat' type='Secondary' onClick={this.props.openConversationFromFolder}
+            label='Open in chat' style={{marginBottom: globalMargins.small, marginRight: 0}} />
+          }
+
           {ignored
           ? allowIgnore && <Button type='Secondary' onClick={this.props.unIgnoreCurrentFolder} label='Unignore folder' style={{marginRight: 0}} />
           : allowIgnore && <Button type='Secondary' onClick={this.props.ignoreCurrentFolder} label='Ignore folder' style={{marginRight: 0}} />}

--- a/shared/folders/files/render.desktop.js
+++ b/shared/folders/files/render.desktop.js
@@ -81,7 +81,7 @@ const YouCanUnlock = ({youCanUnlock, isPrivate, backgroundMode, onClickPaperkey,
 }
 
 class FilesRender extends Component<void, Props, void> {
-  _renderContents (hasReaders: boolean, isPrivate: boolean, ignored: boolean, allowIgnore: boolean) {
+  _renderContents (hasReadOnlyUsers: boolean, isPrivate: boolean, ignored: boolean, allowIgnore: boolean) {
     const backgroundMode = isPrivate ? 'Terminal' : 'Normal'
 
     if (this.props.youCanUnlock.length) {
@@ -106,7 +106,7 @@ class FilesRender extends Component<void, Props, void> {
         <Box style={styleRecentFilesNotEnabled}>
           <Button key='open' type='Primary' onClick={this.props.openCurrentFolder}
             label='Open folder' style={{marginBottom: globalMargins.small}} />
-          {isPrivate && !hasReaders && <Button key='chat' type='Secondary' onClick={this.props.openConversationFromFolder}
+          {isPrivate && !hasReadOnlyUsers && <Button key='chat' type='Secondary' onClick={this.props.openConversationFromFolder}
             label='Open in chat' style={{marginBottom: globalMargins.small, marginRight: 0}} />
           }
 
@@ -161,7 +161,7 @@ class FilesRender extends Component<void, Props, void> {
           </Box>
         </Box>
         {this.props.visiblePopupMenu && <PopupMenu style={{marginLeft: 'auto', marginRight: 8, marginTop: 36, width: 320}} items={this.props.popupMenuItems} onHidden={this.props.onTogglePopupMenu} />}
-        {this._renderContents(this.props.hasReaders, isPrivate, this.props.ignored, this.props.allowIgnore)}
+        {this._renderContents(this.props.hasReadOnlyUsers, isPrivate, this.props.ignored, this.props.allowIgnore)}
       </Box>
     )
   }

--- a/shared/folders/files/render.desktop.js
+++ b/shared/folders/files/render.desktop.js
@@ -81,7 +81,7 @@ const YouCanUnlock = ({youCanUnlock, isPrivate, backgroundMode, onClickPaperkey,
 }
 
 class FilesRender extends Component<void, Props, void> {
-  _renderContents (isPrivate: boolean, ignored: boolean, allowIgnore: boolean) {
+  _renderContents (hasReaders: boolean, isPrivate: boolean, ignored: boolean, allowIgnore: boolean) {
     const backgroundMode = isPrivate ? 'Terminal' : 'Normal'
 
     if (this.props.youCanUnlock.length) {
@@ -106,7 +106,7 @@ class FilesRender extends Component<void, Props, void> {
         <Box style={styleRecentFilesNotEnabled}>
           <Button key='open' type='Primary' onClick={this.props.openCurrentFolder}
             label='Open folder' style={{marginBottom: globalMargins.small}} />
-          {isPrivate && <Button key='chat' type='Secondary' onClick={this.props.openConversationFromFolder}
+          {isPrivate && !hasReaders && <Button key='chat' type='Secondary' onClick={this.props.openConversationFromFolder}
             label='Open in chat' style={{marginBottom: globalMargins.small, marginRight: 0}} />
           }
 
@@ -161,7 +161,7 @@ class FilesRender extends Component<void, Props, void> {
           </Box>
         </Box>
         {this.props.visiblePopupMenu && <PopupMenu style={{marginLeft: 'auto', marginRight: 8, marginTop: 36, width: 320}} items={this.props.popupMenuItems} onHidden={this.props.onTogglePopupMenu} />}
-        {this._renderContents(isPrivate, this.props.ignored, this.props.allowIgnore)}
+        {this._renderContents(this.props.hasReaders, isPrivate, this.props.ignored, this.props.allowIgnore)}
       </Box>
     )
   }

--- a/shared/folders/files/render.js.flow
+++ b/shared/folders/files/render.js.flow
@@ -25,6 +25,7 @@ export type Props = {
   waitingForParticipantUnlock: Array<ParticipantUnlock>,
   youCanUnlock: Array<Device>,
   onClickPaperkey: (device: Device) => void,
+  hasReaders: boolean,
 }
 
 export default class Render extends Component<void, Props, void> { }

--- a/shared/folders/files/render.js.flow
+++ b/shared/folders/files/render.js.flow
@@ -19,6 +19,7 @@ export type Props = {
   recentFilesSection: Array<FileSection>,
   recentFilesEnabled: boolean, // TODO (AW): remove when recentFiles feature is finished
   openCurrentFolder: () => void,
+  openConversationFromFolder: () => void,
   ignoreCurrentFolder: () => void,
   unIgnoreCurrentFolder: () => void,
   waitingForParticipantUnlock: Array<ParticipantUnlock>,

--- a/shared/folders/files/render.js.flow
+++ b/shared/folders/files/render.js.flow
@@ -25,7 +25,7 @@ export type Props = {
   waitingForParticipantUnlock: Array<ParticipantUnlock>,
   youCanUnlock: Array<Device>,
   onClickPaperkey: (device: Device) => void,
-  hasReaders: boolean,
+  hasReadOnlyUsers: boolean,
 }
 
 export default class Render extends Component<void, Props, void> { }

--- a/shared/folders/index.js
+++ b/shared/folders/index.js
@@ -4,6 +4,8 @@ import Render from './render'
 import {connect} from 'react-redux'
 import {favoriteList} from '../actions/favorite'
 import {openInKBFS} from '../actions/kbfs'
+import {openTlfInChat} from '../actions/chat'
+
 import {switchTo, navigateAppend} from '../actions/route-tree'
 
 import type {RouteProps} from '../route-tree/render-route'
@@ -14,6 +16,7 @@ export type Props = {
   favoriteList: () => void,
   folderState: ?FolderState,
   openInKBFS: (path: string) => void,
+  openTlfInChat: (tlf: string) => void,
   showingPrivate: boolean,
   username: ?string,
   onOpenFolder: (path: any) => void,
@@ -35,6 +38,7 @@ class Folders extends Component<void, Props, void> {
         onClick={path => this.props.onOpenFolder(path)}
         onRekey={path => this.props.onRekeyFolder(path)}
         onOpen={path => this.props.openInKBFS(path)}
+        onChat={tlf => this.props.openTlfInChat(tlf)}
         onSwitchTab={showingPrivate => this.props.switchTab(showingPrivate)}
         showingPrivate={this.props.showingPrivate}
         username={this.props.username}
@@ -60,6 +64,7 @@ const ConnectedFolders = connect(
     onOpenFolder: path => { dispatch(navigateAppend([{selected: 'files', props: {path}}])) },
     onRekeyFolder: path => { dispatch(navigateAppend([{selected: 'files', props: {path}}])) },
     openInKBFS: path => { dispatch(openInKBFS(path)) },
+    openTlfInChat: tlf => { dispatch(openTlfInChat(tlf)) },
     switchTab: showingPrivate => { dispatch(switchTo(routePath.pop().push(showingPrivate ? 'private' : 'public'))) },
     onToggleShowIgnored: () => { setRouteState({showingIgnored: !routeState.showingIgnored}) },
   })

--- a/shared/folders/list.desktop.js
+++ b/shared/folders/list.desktop.js
@@ -38,7 +38,7 @@ const Rows = ({tlfs = [], isIgnored, isPublic, onOpen, onChat, onClick, onRekey,
         {...tlf}
         key={rowKey(tlf.users)}
         isPublic={isPublic}
-        hasReaders={tlf.users && _.some(tlf.users, 'readOnly')}
+        hasReadOnlyUsers={tlf.users && _.some(tlf.users, 'readOnly')}
         ignored={isIgnored}
         onChat={onChat}
         onClick={onClick}

--- a/shared/folders/list.desktop.js
+++ b/shared/folders/list.desktop.js
@@ -30,7 +30,7 @@ const Ignored = ({rows, showIgnored, styles, onToggle, isPublic, onClick}) => {
   )
 }
 
-const Rows = ({tlfs = [], isIgnored, isPublic, onOpen, onClick, onRekey, smallMode}: Props & {isIgnored: boolean, smallMode?: boolean, tlfs?: Array<Folder>}) => (
+const Rows = ({tlfs = [], isIgnored, isPublic, onOpen, onChat, onClick, onRekey, smallMode}: Props & {isIgnored: boolean, smallMode?: boolean, tlfs?: Array<Folder>}) => (
   <Box>
     {!!tlfs && tlfs.map((tlf) => (
       <Row
@@ -38,6 +38,7 @@ const Rows = ({tlfs = [], isIgnored, isPublic, onOpen, onClick, onRekey, smallMo
         key={rowKey(tlf.users)}
         isPublic={isPublic}
         ignored={isIgnored}
+        onChat={onChat}
         onClick={onClick}
         onRekey={onRekey}
         onOpen={onOpen}

--- a/shared/folders/list.desktop.js
+++ b/shared/folders/list.desktop.js
@@ -2,6 +2,7 @@
 import React, {Component} from 'react'
 import ReactDOM from 'react-dom'
 import Row from './row'
+import _ from 'lodash'
 import type {IconType} from '../common-adapters/icon'
 import type {Props, Folder} from './list'
 import {Box, Text, Icon} from '../common-adapters'
@@ -37,6 +38,7 @@ const Rows = ({tlfs = [], isIgnored, isPublic, onOpen, onChat, onClick, onRekey,
         {...tlf}
         key={rowKey(tlf.users)}
         isPublic={isPublic}
+        hasReaders={tlf.users && _.some(tlf.users, 'readOnly')}
         ignored={isIgnored}
         onChat={onChat}
         onClick={onClick}

--- a/shared/folders/list.js.flow
+++ b/shared/folders/list.js.flow
@@ -10,6 +10,7 @@ export type Props = {
   isPublic: boolean,
   style?: any,
   smallMode?: boolean,
+  onChat?: (tlf: string) => void,
   onClick?: (path: string) => void,
   onRekey?: (path: string) => void,
   onOpen?: (path: string) => void,

--- a/shared/folders/render.desktop.js
+++ b/shared/folders/render.desktop.js
@@ -40,6 +40,7 @@ class FoldersRender extends Component<void, Props, void> {
       smallMode: this.props.smallMode,
       onRekey: this.props.onRekey,
       onOpen: this.props.onOpen,
+      onChat: this.props.onChat,
       onClick: this.props.onClick,
     }
 

--- a/shared/folders/render.js.flow
+++ b/shared/folders/render.js.flow
@@ -14,6 +14,7 @@ export type Props = {
   listStyle?: any,
   smallMode?: boolean,
   onClick?: (path: string) => void,
+  onChat?: (tlf: string) => void,
   onOpen?: (path: string) => void,
   onRekey: (path: string) => void,
   onToggleShowIgnored: () => void,

--- a/shared/folders/row.desktop.js
+++ b/shared/folders/row.desktop.js
@@ -66,9 +66,9 @@ const RowMeta = ({ignored, meta, styles}) => {
   return <Meta {...metaProps} />
 }
 
-type RowType = {smallMode: boolean, sortName: string, onOpen: (path: string) => void, onChat: (tlf: string) => void, onClick: (path: string) => void, onRekey: (path: string) => void}
+type RowType = {hasReaders: boolean, smallMode: boolean, sortName: string, onOpen: (path: string) => void, onChat: (tlf: string) => void, onClick: (path: string) => void, onRekey: (path: string) => void}
 
-const Row = ({users, isPublic, ignored, meta, modified, hasData, smallMode,
+const Row = ({users, isPublic, hasReaders, ignored, meta, modified, hasData, smallMode,
   onChat, onOpen, onClick, groupAvatar, userAvatar, onRekey, path, sortName}: RowType & Folder) => {
   const onOpenClick = event => {
     event.preventDefault()
@@ -113,7 +113,7 @@ const Row = ({users, isPublic, ignored, meta, modified, hasData, smallMode,
           {(meta || ignored) && <RowMeta ignored={ignored} meta={meta} styles={styles} />}
           {!(meta || ignored) && modified && <Modified modified={modified} styles={styles} smallMode={smallMode} />}
         </Box>
-        {!smallMode && !isPublic && meta !== 'rekey' && <Box style={{...stylesActionContainer, width: smallMode ? undefined : 112}}>
+        {!smallMode && !isPublic && !hasReaders && meta !== 'rekey' && <Box style={{...stylesActionContainer, width: smallMode ? undefined : 112}}>
           <Text type='BodySmall' className='folder-row-hover-action' onClick={onChatClick} style={styles.action}>Chat</Text>
         </Box>
         }

--- a/shared/folders/row.desktop.js
+++ b/shared/folders/row.desktop.js
@@ -113,7 +113,7 @@ const Row = ({users, isPublic, ignored, meta, modified, hasData, smallMode,
           {(meta || ignored) && <RowMeta ignored={ignored} meta={meta} styles={styles} />}
           {!(meta || ignored) && modified && <Modified modified={modified} styles={styles} smallMode={smallMode} />}
         </Box>
-        {!smallMode && meta !== 'rekey' && <Box style={{...stylesActionContainer, width: smallMode ? undefined : 112}}>
+        {!smallMode && !isPublic && meta !== 'rekey' && <Box style={{...stylesActionContainer, width: smallMode ? undefined : 112}}>
           <Text type='BodySmall' className='folder-row-hover-action' onClick={onChatClick} style={styles.action}>Chat</Text>
         </Box>
         }

--- a/shared/folders/row.desktop.js
+++ b/shared/folders/row.desktop.js
@@ -66,9 +66,9 @@ const RowMeta = ({ignored, meta, styles}) => {
   return <Meta {...metaProps} />
 }
 
-type RowType = {hasReaders: boolean, smallMode: boolean, sortName: string, onOpen: (path: string) => void, onChat: (tlf: string) => void, onClick: (path: string) => void, onRekey: (path: string) => void}
+type RowType = {hasReadOnlyUsers: boolean, smallMode: boolean, sortName: string, onOpen: (path: string) => void, onChat: (tlf: string) => void, onClick: (path: string) => void, onRekey: (path: string) => void}
 
-const Row = ({users, isPublic, hasReaders, ignored, meta, modified, hasData, smallMode,
+const Row = ({users, isPublic, hasReadOnlyUsers, ignored, meta, modified, hasData, smallMode,
   onChat, onOpen, onClick, groupAvatar, userAvatar, onRekey, path, sortName}: RowType & Folder) => {
   const onOpenClick = event => {
     event.preventDefault()
@@ -113,7 +113,7 @@ const Row = ({users, isPublic, hasReaders, ignored, meta, modified, hasData, sma
           {(meta || ignored) && <RowMeta ignored={ignored} meta={meta} styles={styles} />}
           {!(meta || ignored) && modified && <Modified modified={modified} styles={styles} smallMode={smallMode} />}
         </Box>
-        {!smallMode && !isPublic && !hasReaders && meta !== 'rekey' && <Box style={{...stylesActionContainer, width: smallMode ? undefined : 112}}>
+        {!smallMode && !isPublic && !hasReadOnlyUsers && meta !== 'rekey' && <Box style={{...stylesActionContainer, width: smallMode ? undefined : 112}}>
           <Text type='BodySmall' className='folder-row-hover-action' onClick={onChatClick} style={styles.action}>Chat</Text>
         </Box>
         }

--- a/shared/folders/row.desktop.js
+++ b/shared/folders/row.desktop.js
@@ -66,10 +66,10 @@ const RowMeta = ({ignored, meta, styles}) => {
   return <Meta {...metaProps} />
 }
 
-type RowType = {smallMode: boolean, onOpen: (path: string) => void, onClick: (path: string) => void, onRekey: (path: string) => void}
+type RowType = {smallMode: boolean, sortName: string, onOpen: (path: string) => void, onChat: (tlf: string) => void, onClick: (path: string) => void, onRekey: (path: string) => void}
 
 const Row = ({users, isPublic, ignored, meta, modified, hasData, smallMode,
-  onOpen, onClick, groupAvatar, userAvatar, onRekey, path}: RowType & Folder) => {
+  onChat, onOpen, onClick, groupAvatar, userAvatar, onRekey, path, sortName}: RowType & Folder) => {
   const onOpenClick = event => {
     event.preventDefault()
     event.stopPropagation()
@@ -77,7 +77,13 @@ const Row = ({users, isPublic, ignored, meta, modified, hasData, smallMode,
       onOpen(path)
     }
   }
-
+  const onChatClick = event => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (onChat) {
+      onChat(sortName)
+    }
+  }
   const styles = isPublic ? stylesPublic : stylesPrivate
 
   let backgroundColor = styles.rowContainer.backgroundColor
@@ -107,6 +113,10 @@ const Row = ({users, isPublic, ignored, meta, modified, hasData, smallMode,
           {(meta || ignored) && <RowMeta ignored={ignored} meta={meta} styles={styles} />}
           {!(meta || ignored) && modified && <Modified modified={modified} styles={styles} smallMode={smallMode} />}
         </Box>
+        {!smallMode && meta !== 'rekey' && <Box style={{...stylesActionContainer, width: smallMode ? undefined : 112}}>
+          <Text type='BodySmall' className='folder-row-hover-action' onClick={onChatClick} style={styles.action}>Chat</Text>
+        </Box>
+        }
         <Box style={{...stylesActionContainer, width: smallMode ? undefined : 112}}>
           {!smallMode && meta !== 'rekey' && <Text
             type='BodySmall' className='folder-row-hover-action' onClick={onOpenClick} style={styles.action}>Open</Text>}


### PR DESCRIPTION
@keybase/react-hackers 

This PR adds two new buttons: A "Chat" button to each row in the main folders tab view of rows, and an "Open in chat" button inside the per-folder view.

Our startConversation() action takes a list of users (and is fine to call on an existing conversation), so we just take the TLF name from `folder.sortName` (e.g. cjb,chrisnojima,max) and call `tlf.split(',')` to get the users array.

The chat buttons are only shown on private folders, not public ones.  No implementation for mobile yet.