### PR TITLE
Recheck reachability on service connect

### DIFF
--- a/go/service/reachability.go
+++ b/go/service/reachability.go
@@ -94,7 +94,7 @@ func (h *reachability) check() (k keybase1.Reachability) {
 	// notifications.
 	u, err := url.Parse(h.G().Env.GetGregorURI())
 	if err != nil {
-		h.G().Log.Errorf("Invalid URL for reachability check: %s", err)
+		h.G().Log.Errorf("Invalid URI for reachability check: %s", err)
 		return
 	}
 

--- a/go/service/reachability.go
+++ b/go/service/reachability.go
@@ -46,7 +46,6 @@ type reachability struct {
 	libkb.Contextified
 	lastReachability keybase1.Reachability
 	started          bool
-	shutdownCh       chan bool
 	startMutex       sync.Mutex
 	setMutex         sync.Mutex
 }
@@ -54,7 +53,6 @@ type reachability struct {
 func newReachability(g *libkb.GlobalContext) *reachability {
 	return &reachability{
 		Contextified: libkb.NewContextified(g),
-		shutdownCh:   make(chan bool),
 	}
 }
 
@@ -82,10 +80,6 @@ func (h *reachability) start() keybase1.Reachability {
 				select {
 				case <-h.G().Clock().After(time.Second * 30):
 					h.check()
-				case <-h.shutdownCh:
-					h.G().Log.Debug("Shutdown")
-					h.setReachability(keybase1.Reachability{Reachable: keybase1.Reachable_NO})
-					return
 				}
 			}
 		}()
@@ -100,6 +94,7 @@ func (h *reachability) check() (k keybase1.Reachability) {
 	// notifications.
 	u, err := url.Parse(h.G().Env.GetGregorURI())
 	if err != nil {
+		h.G().Log.Errorf("Invalid URL for reachability check: %s", err)
 		return
 	}
 

--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -5,7 +5,7 @@ import {CommonClientType, configGetConfigRpc, configGetExtendedStatusRpc, config
 import {isMobile} from '../../constants/platform'
 import {listenForKBFSNotifications} from '../../actions/notifications'
 import {navBasedOnLoginState} from '../../actions/login'
-import {registerGregorListeners, registerReachability} from '../../actions/gregor'
+import {checkReachabilityOnConnect, registerGregorListeners, registerReachability} from '../../actions/gregor'
 import {resetSignup} from '../../actions/signup'
 
 import type {AsyncAction, Action} from '../../constants/types/flux'
@@ -160,6 +160,7 @@ export function bootstrap (opts?: BootstrapOptions = {}): AsyncAction {
       console.log('[bootstrap] registered bootstrap')
       engine().listenOnConnect('bootstrap', () => {
         dispatch(daemonError(null))
+        dispatch(checkReachabilityOnConnect())
         console.log('[bootstrap] bootstrapping on connect')
         dispatch(bootstrap())
       })
@@ -219,4 +220,3 @@ function getCurrentStatus (): AsyncAction {
     })
   }
 }
-

--- a/shared/actions/gregor.js
+++ b/shared/actions/gregor.js
@@ -71,6 +71,17 @@ function registerReachability () {
       }
     })
 
+    dispatch(checkReachabilityOnConnect())
+  }
+}
+
+function checkReachabilityOnConnect () {
+  return (dispatch: Dispatch) => {
+    // The startReachibility RPC call both starts and returns the current
+    // reachability state. Then we'll get updates of changes from this state
+    // via reachabilityChanged.
+    // This should be run on app start and service re-connect in case the
+    // service somehow crashed or was restarted manually.
     reachabilityStartReachabilityRpc({
       callback: (err, reachability) => {
         if (err) {
@@ -183,6 +194,7 @@ function * gregorSaga (): SagaGenerator<any, any> {
 
 export {
   checkReachability,
+  checkReachabilityOnConnect,
   pushState,
   registerGregorListeners,
   registerReachability,


### PR DESCRIPTION
The startReachability call ensures that reachability is started and gets the current state from which changes will be notified. We do this on app start, but we also need to do it on service connect (this PR fixes that) in case the service crashed or was manually restarted. There is an edge case where you will stop getting reachability notifications if the service was restarted manually or via crash, while the Electron app was running.

This is an edge case that shouldn't happen much in practice but I think happened to coyne here: https://keybase.atlassian.net/browse/DESKTOP-2694.

I also removed some shutdown code which wasn't used and was potentially misleading. Also added a log message for an url parse error that wasn't being logged (should never happen in practice though).