### PR TITLE
remove mount icon on --kill-kbfs

### DIFF
--- a/go/client/cmd_ctl_stop_windows.go
+++ b/go/client/cmd_ctl_stop_windows.go
@@ -6,12 +6,13 @@
 package client
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	"golang.org/x/net/context"
-	"os"
-	"path/filepath"
 )
 
 func NewCmdCtlStop(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -73,5 +74,6 @@ func (s *CmdCtlStop) doKillKBFS() {
 		// open special "file". Errors not relevant.
 		s.G().Log.Debug("KillKBFS: opening .kbfs_unmount")
 		os.Open(filepath.Join(mountDir, "\\.kbfs_unmount"))
+		libkb.ChangeMountIcon(mountDir, "")
 	}
 }

--- a/go/libkb/util_nix.go
+++ b/go/libkb/util_nix.go
@@ -64,3 +64,7 @@ func RemoteSettingsRepairman(g *GlobalContext) error {
 func isUnicodeMark(b []byte) bool {
 	return false
 }
+
+func ChangeMountIcon(oldMount string, newMount string) error {
+	return nil
+}

--- a/go/libkb/util_windows.go
+++ b/go/libkb/util_windows.go
@@ -15,7 +15,10 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/kardianos/osext"
+
 	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
 )
 
 type GUID struct {
@@ -40,6 +43,7 @@ var (
 	modOle32                 = windows.NewLazySystemDLL("Ole32.dll")
 	procSHGetKnownFolderPath = modShell32.NewProc("SHGetKnownFolderPath")
 	procCoTaskMemFree        = modOle32.NewProc("CoTaskMemFree")
+	shChangeNotifyProc       = modShell32.NewProc("SHChangeNotify")
 )
 
 // LookPath searches for an executable binary named file
@@ -183,4 +187,48 @@ func RemoteSettingsRepairman(g *GlobalContext) error {
 		}
 	}
 	return nil
+}
+
+// Notify the shell that the thing located at path has changed
+func notifyShell(path string) {
+	shChangeNotifyProc.Call(
+		uintptr(0x00002000), // SHCNE_UPDATEITEM
+		uintptr(0x0005),     // SHCNF_PATHW
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(path))),
+		0)
+}
+
+// Manipulate registry entries to reflect the mount point icon in the shell
+func ChangeMountIcon(oldMount string, newMount string) error {
+	if oldMount != "" {
+		// DeleteKey doesn't work if there are subkeys
+		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+oldMount[:1]+`\DefaultIcon`)
+		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+oldMount[:1]+`\DefaultLabel`)
+		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+oldMount[:1])
+		notifyShell(oldMount)
+	}
+	if newMount == "" {
+		return nil
+	}
+	k, _, err := registry.CreateKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+newMount[:1]+`\DefaultIcon`, registry.SET_VALUE|registry.CREATE_SUB_KEY|registry.WRITE)
+	defer k.Close()
+	if err != nil {
+		return err
+	}
+	keybaseExe, err := osext.Executable()
+	if err != nil {
+		return err
+	}
+	// Use the second icon bound into keybase.exe - hence the 1
+	err = k.SetStringValue("", keybaseExe+",1")
+	if err != nil {
+		return err
+	}
+
+	// Also give a nice label
+	k2, _, err := registry.CreateKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+newMount[:1]+`\DefaultLabel`, registry.SET_VALUE|registry.CREATE_SUB_KEY|registry.WRITE)
+	defer k2.Close()
+	err = k2.SetStringValue("", "Keybase")
+	notifyShell(newMount)
+	return err
 }

--- a/go/service/kbfs_mount.go
+++ b/go/service/kbfs_mount.go
@@ -28,7 +28,7 @@ func (h *KBFSMountHandler) GetCurrentMountDir(ctx context.Context) (res string, 
 	if drive != "" && err == nil {
 		// Drive icon repairman: RemoteSettingsRepairman forgot about this, so let's set
 		// the registry again here for a few releases
-		doMountChange("", drive)
+		libkb.ChangeMountIcon("", drive)
 	}
 	return drive, err
 }
@@ -45,6 +45,6 @@ func (h *KBFSMountHandler) SetCurrentMountDir(_ context.Context, drive string) (
 		return err
 	}
 	h.G().ConfigReload()
-	doMountChange(oldMount, drive)
+	libkb.ChangeMountIcon(oldMount, drive)
 	return nil
 }

--- a/go/service/kbfs_mount_nix.go
+++ b/go/service/kbfs_mount_nix.go
@@ -12,7 +12,3 @@ import (
 func getMountDirs() ([]string, error) {
 	return []string{}, errors.New("getMountDirs is Windows only")
 }
-
-func doMountChange(oldMount string, newMount string) error {
-	return nil
-}

--- a/go/service/kbfs_mount_windows.go
+++ b/go/service/kbfs_mount_windows.go
@@ -7,20 +7,17 @@ package service
 
 import (
 	"fmt"
-	"github.com/kardianos/osext"
-	"golang.org/x/sys/windows"
-	"golang.org/x/sys/windows/registry"
 	"strings"
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 var (
 	kernel32DLL        = windows.NewLazySystemDLL("kernel32.dll")
 	getVolumeProc      = kernel32DLL.NewProc("GetVolumeInformationW")
 	queryDosDeviceProc = kernel32DLL.NewProc("QueryDosDeviceW")
-	shell32DLL         = windows.NewLazySystemDLL("shell32.dll")
-	shChangeNotifyProc = shell32DLL.NewProc("SHChangeNotify")
 )
 
 // getVolumeName requires a drive letter and colon with a
@@ -99,48 +96,4 @@ func getMountDirs() ([]string, error) {
 		err = fmt.Errorf("No drive letters available")
 	}
 	return drives, err
-}
-
-// Notify the shell that the thing located at path has changed
-func notifyShell(path string) {
-	shChangeNotifyProc.Call(
-		uintptr(0x00002000), // SHCNE_UPDATEITEM
-		uintptr(0x0005),     // SHCNF_PATHW
-		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(path))),
-		0)
-}
-
-// Manipulate registry entries to reflect the mount point icon in the shell
-func doMountChange(oldMount string, newMount string) error {
-	if oldMount != "" {
-		// DeleteKey doesn't work if there are subkeys
-		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+oldMount[:1]+`\DefaultIcon`)
-		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+oldMount[:1]+`\DefaultLabel`)
-		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+oldMount[:1])
-		notifyShell(oldMount)
-	}
-	if newMount == "" {
-		return nil
-	}
-	k, _, err := registry.CreateKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+newMount[:1]+`\DefaultIcon`, registry.SET_VALUE|registry.CREATE_SUB_KEY|registry.WRITE)
-	defer k.Close()
-	if err != nil {
-		return err
-	}
-	keybaseExe, err := osext.Executable()
-	if err != nil {
-		return err
-	}
-	// Use the second icon bound into keybase.exe - hence the 1
-	err = k.SetStringValue("", keybaseExe+",1")
-	if err != nil {
-		return err
-	}
-
-	// Also give a nice label
-	k2, _, err := registry.CreateKey(registry.CURRENT_USER, `SOFTWARE\Classes\Applications\Explorer.exe\Drives\`+newMount[:1]+`\DefaultLabel`, registry.SET_VALUE|registry.CREATE_SUB_KEY|registry.WRITE)
-	defer k2.Close()
-	err = k2.SetStringValue("", "Keybase")
-	notifyShell(newMount)
-	return err
 }


### PR DESCRIPTION
This is to remove the dangling mount icon on uninstall - which we'll need in any case when the filesystem is backed out. Tested by uninstalling.
@maxtaco @oconnor663 