### PR TITLE
add ctime to message unbox errors CORE-4542

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -63,6 +63,7 @@ func (b *Boxer) makeErrorMessage(msg chat1.MessageBoxed, err UnboxingError) chat
 		ErrMsg:      err.Error(),
 		MessageID:   msg.GetMessageID(),
 		MessageType: msg.GetMessageType(),
+		Ctime:       msg.ServerHeader.Ctime,
 	})
 }
 

--- a/go/chat/storage/storage_blockengine.go
+++ b/go/chat/storage/storage_blockengine.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-const blockIndexVersion = 2
+const blockIndexVersion = 3
 const blockSize = 100
 
 type blockEngine struct {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1186,6 +1186,7 @@ type MessageUnboxedError struct {
 	ErrMsg      string                  `codec:"errMsg" json:"errMsg"`
 	MessageID   MessageID               `codec:"messageID" json:"messageID"`
 	MessageType MessageType             `codec:"messageType" json:"messageType"`
+	Ctime       gregor1.Time            `codec:"ctime" json:"ctime"`
 }
 
 type MessageUnboxed struct {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -276,6 +276,7 @@ protocol local {
     string errMsg;
     MessageID messageID;
     MessageType messageType;
+    gregor1.Time ctime;
   }
 
   variant MessageUnboxed switch (MessageUnboxedState state) {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1150,6 +1150,7 @@ export type MessageUnboxedError = {
   errMsg: string,
   messageID: MessageID,
   messageType: MessageType,
+  ctime: gregor1.Time,
 }
 
 export type MessageUnboxedErrorType =

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -866,6 +866,10 @@
         {
           "type": "MessageType",
           "name": "messageType"
+        },
+        {
+          "type": "gregor1.Time",
+          "name": "ctime"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1150,6 +1150,7 @@ export type MessageUnboxedError = {
   errMsg: string,
   messageID: MessageID,
   messageType: MessageType,
+  ctime: gregor1.Time,
 }
 
 export type MessageUnboxedErrorType =


### PR DESCRIPTION
Add a ctime to message unbox errors, allows frontend to render them easier.