### PR TITLE
Zanderz/core 4488

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseApps/Keybase.visualelementsmanifest.xml
+++ b/packaging/windows/WIXInstallers/KeybaseApps/Keybase.visualelementsmanifest.xml
@@ -1,0 +1,6 @@
+<Application xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <VisualElements
+        BackgroundColor="#33a0ff"
+        ShowNameOnSquare150x150Logo="on"     
+        ForegroundText="light"/>
+</Application>

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -24,6 +24,7 @@
       <ComponentGroupRef Id="PrompterComponents" />
       <ComponentGroupRef Id="ApplicationShortcuts" />
       <ComponentGroupRef Id="StartupShortcuts" />
+      <ComponentGroupRef Id="GuiStartMenuTileColors" />
     </Feature>
 
 
@@ -174,6 +175,10 @@
           <RegistryValue Name="ShortCutStartUpGUI" Type="integer" Value="1" KeyPath="yes"  />
         </RegistryKey>
       </Component>
+    </ComponentGroup>    
+  </Fragment>
+  <Fragment>
+    <ComponentGroup Id="GuiStartMenuTileColors" Directory="GuiDir">
       <Component Id="GUIShortcutVisualElementManifest" Guid="{CC9530CC-0A1B-4F92-829E-EBA66CA04FD8}">
         <CreateFolder />
         <RemoveFolder Id="RemoveGUIShortcutVisualElementManifest" On="uninstall" />
@@ -182,8 +187,7 @@
         </RegistryKey>
         <File Id="GUIShortcutVisualElementManifest.xml" Source="$(env.GOPATH)\src\github.com\keybase\client\packaging\windows\WIXInstallers\KeybaseApps\Keybase.visualelementsmanifest.xml" Checksum="yes"/>
       </Component>
-    </ComponentGroup>
-    
+    </ComponentGroup>    
   </Fragment>
   
   <Fragment>

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -174,6 +174,14 @@
           <RegistryValue Name="ShortCutStartUpGUI" Type="integer" Value="1" KeyPath="yes"  />
         </RegistryKey>
       </Component>
+      <Component Id="GUIShortcutVisualElementManifest" Guid="{CC9530CC-0A1B-4F92-829E-EBA66CA04FD8}">
+        <CreateFolder />
+        <RemoveFolder Id="RemoveGUIShortcutVisualElementManifest" On="uninstall" />
+        <RegistryKey Root="HKCU" Key="Software\Keybase\Keybase">
+          <RegistryValue Name="GUIShortcutVisualElementManifest" Value="1" KeyPath="yes" Type="integer" />
+        </RegistryKey>
+        <File Id="GUIShortcutVisualElementManifest.xml" Source="$(env.GOPATH)\src\github.com\keybase\client\packaging\windows\WIXInstallers\KeybaseApps\Keybase.visualelementsmanifest.xml" Checksum="yes"/>
+      </Component>
     </ComponentGroup>
     
   </Fragment>


### PR DESCRIPTION
Change the color of the start menu tile for the Keybase app. Note that Cecile wanted white, but it turned out the text has to be white, so she said this blue would be OK.

We can't change the shell icon color because it is a shortcut to the system's cmd.exe.

![image](https://cloud.githubusercontent.com/assets/862397/22706188/30164e18-ed23-11e6-8290-44173cadcc04.png)
@maxtaco @cecileboucheron 