### PR TITLE
display nicer errors in CLI chat when identifies are failing

### DIFF
--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -22,7 +22,7 @@ import (
 	"github.com/keybase/client/go/protocol/gregor1"
 )
 
-const inboxVersion = 5
+const inboxVersion = 6
 
 type queryHash []byte
 

--- a/go/client/chat_cli_fetchers.go
+++ b/go/client/chat_cli_fetchers.go
@@ -40,7 +40,8 @@ func (f chatCLIConversationFetcher) fetch(ctx context.Context, g *libkb.GlobalCo
 		IdentifyBehavior:  keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	})
 	if err != nil {
-		return chat1.ConversationLocal{}, nil, fmt.Errorf("resolving conversation error: %v\n", err)
+		// Resolver errors should already by human readable.
+		return chat1.ConversationLocal{}, nil, err
 	}
 	if conversation == nil {
 		return chat1.ConversationLocal{}, nil, nil

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -14,6 +14,8 @@ import (
 	"github.com/keybase/client/go/protocol/gregor1"
 )
 
+const publicConvNamePrefix = "(public) "
+
 type conversationInfoListView []chat1.ConversationLocal
 
 func (v conversationInfoListView) show(g *libkb.GlobalContext) error {
@@ -73,7 +75,7 @@ type conversationListView []chat1.ConversationLocal
 func (v conversationListView) convName(g *libkb.GlobalContext, conv chat1.ConversationLocal, myUsername string) string {
 	var name string
 	if conv.Info.Visibility == chat1.TLFVisibility_PUBLIC {
-		name = "(public) " + strings.Join(conv.Info.WriterNames, ",")
+		name = publicConvNamePrefix + strings.Join(conv.Info.WriterNames, ",")
 	} else {
 		name = strings.Join(v.without(g, conv.Info.WriterNames, myUsername), ",")
 		if len(conv.Info.WriterNames) == 1 && conv.Info.WriterNames[0] == myUsername {
@@ -97,7 +99,7 @@ func (v conversationListView) convName(g *libkb.GlobalContext, conv chat1.Conver
 func (v conversationListView) convNameLite(g *libkb.GlobalContext, convErr chat1.ConversationErrorRekey, myUsername string) string {
 	var name string
 	if convErr.TlfPublic {
-		name = "(public) " + strings.Join(convErr.WriterNames, ",")
+		name = publicConvNamePrefix + strings.Join(convErr.WriterNames, ",")
 	} else {
 		name = strings.Join(v.without(g, convErr.WriterNames, myUsername), ",")
 		if len(convErr.WriterNames) == 1 && convErr.WriterNames[0] == myUsername {
@@ -110,6 +112,24 @@ func (v conversationListView) convNameLite(g *libkb.GlobalContext, convErr chat1
 	}
 
 	return name
+}
+
+// When we hit identify failures looking up a conversation, we short-circuit
+// before we get to parsing out readers and writers (which itself does more
+// identifying). Instead we get an untrusted TLF name string, and we have the
+// visiblity. Cobble together a poor man's conversation name from those, by
+// hacking out the current user's name. This should only be displayed next to
+// an indication that it's unverified.
+func formatUnverifiedConvName(unverifiedTLFName string, visibility chat1.TLFVisibility, myUsername string) string {
+	// Strip the user's name out if it's got a comma next to it. (Two cases to
+	// handle: leading and trailing.) This both takes care of dangling commas,
+	// and preserves the user's name if it's by itself.
+	strippedTLFName := strings.Replace(unverifiedTLFName, ","+myUsername, "", -1)
+	strippedTLFName = strings.Replace(strippedTLFName, myUsername+",", "", -1)
+	if visibility == chat1.TLFVisibility_PUBLIC {
+		return publicConvNamePrefix + strippedTLFName
+	}
+	return strippedTLFName
 }
 
 func (v conversationListView) without(g *libkb.GlobalContext, slice []string, el string) (res []string) {
@@ -133,6 +153,7 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 	for i, conv := range v {
 
 		if conv.Error != nil {
+			unverifiedConvName := formatUnverifiedConvName(conv.Error.UnverifiedTLFName, conv.Info.Visibility, myUsername)
 			row := flexibletable.Row{
 				flexibletable.Cell{
 					Frame:     [2]string{"[", "]"},
@@ -145,7 +166,7 @@ func (v conversationListView) show(g *libkb.GlobalContext, myUsername string, sh
 				},
 				flexibletable.Cell{
 					Alignment: flexibletable.Left,
-					Content:   flexibletable.SingleCell{Item: "???"},
+					Content:   flexibletable.SingleCell{Item: "(unverified) " + unverifiedConvName},
 				},
 				flexibletable.Cell{
 					Frame:     [2]string{"[", "]"},

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -66,7 +66,9 @@ func (r *chatConversationResolver) completeAndCanonicalizeTLFName(ctx context.Co
 		cname, err = r.TlfClient.CompleteAndCanonicalizePrivateTlfName(ctx, query)
 	}
 	if err != nil {
-		return fmt.Errorf("completing TLF name error: %v", err)
+		// When a recipient's proofs are failing, this is the error a CLI user
+		// will see. It needs to be human readable.
+		return fmt.Errorf("failed to open chat conversation: %v", err)
 	}
 	if string(cname.CanonicalName) != tlfName {
 		// If we auto-complete TLF name, we should let users know.

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1266,6 +1266,7 @@ func (e IdentifyFailedError) Error() string {
 //=============================================================================
 
 type IdentifySummaryError struct {
+	username string
 	problems []string
 }
 

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1271,7 +1271,9 @@ type IdentifySummaryError struct {
 }
 
 func (e IdentifySummaryError) Error() string {
-	return fmt.Sprintf("%s", strings.Join(e.problems, "; "))
+	return fmt.Sprintf("failed to identify \"%s\": %s",
+		e.username,
+		strings.Join(e.problems, "; "))
 }
 
 func (e IdentifySummaryError) IsImmediateFail() (chat1.OutboxErrorType, bool) {

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1271,7 +1271,7 @@ type IdentifySummaryError struct {
 }
 
 func (e IdentifySummaryError) Error() string {
-	return fmt.Sprintf("failed to identify \"%s\": %s",
+	return fmt.Sprintf("failed to identify %q: %s",
 		e.username,
 		strings.Join(e.problems, "; "))
 }

--- a/go/libkb/identify_outcome.go
+++ b/go/libkb/identify_outcome.go
@@ -225,7 +225,7 @@ func (i IdentifyOutcome) GetErrorAndWarnings(strict bool) (warnings Warnings, er
 
 	if ntf := i.NumTrackFailures(); ntf > 0 {
 		probs = append(probs,
-			fmt.Sprintf("%d track component%s failed",
+			fmt.Sprintf("%d tracked proof%s failed",
 				ntf, GiveMeAnS(ntf)))
 	}
 

--- a/go/libkb/identify_outcome.go
+++ b/go/libkb/identify_outcome.go
@@ -230,7 +230,7 @@ func (i IdentifyOutcome) GetErrorAndWarnings(strict bool) (warnings Warnings, er
 	}
 
 	if len(probs) > 0 {
-		err = IdentifySummaryError{probs}
+		err = IdentifySummaryError{i.Username, probs}
 	}
 
 	return warnings, err

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -350,3 +350,21 @@ func ConvertMessageBodyV1ToV2(v1 MessageBodyV1) (MessageBody, error) {
 	return MessageBody{}, fmt.Errorf("ConvertMessageBodyV1ToV2: unhandled message type %v", t)
 }
 */
+
+func NewConversationErrorLocal(
+	message string,
+	remoteConv Conversation,
+	permanent bool,
+	unverifiedTLFName string,
+	typ ConversationErrorType,
+	rekeyInfo *ConversationErrorRekey,
+) *ConversationErrorLocal {
+	return &ConversationErrorLocal{
+		Typ:               typ,
+		Message:           message,
+		RemoteConv:        remoteConv,
+		Permanent:         permanent,
+		UnverifiedTLFName: unverifiedTLFName,
+		RekeyInfo:         rekeyInfo,
+	}
+}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1323,11 +1323,12 @@ func (e ConversationErrorType) String() string {
 }
 
 type ConversationErrorLocal struct {
-	Typ        ConversationErrorType   `codec:"typ" json:"typ"`
-	Message    string                  `codec:"message" json:"message"`
-	RemoteConv Conversation            `codec:"remoteConv" json:"remoteConv"`
-	Permanent  bool                    `codec:"permanent" json:"permanent"`
-	RekeyInfo  *ConversationErrorRekey `codec:"rekeyInfo,omitempty" json:"rekeyInfo,omitempty"`
+	Typ               ConversationErrorType   `codec:"typ" json:"typ"`
+	Message           string                  `codec:"message" json:"message"`
+	RemoteConv        Conversation            `codec:"remoteConv" json:"remoteConv"`
+	Permanent         bool                    `codec:"permanent" json:"permanent"`
+	UnverifiedTLFName string                  `codec:"unverifiedTLFName" json:"unverifiedTLFName"`
+	RekeyInfo         *ConversationErrorRekey `codec:"rekeyInfo,omitempty" json:"rekeyInfo,omitempty"`
 }
 
 type ConversationErrorRekey struct {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -332,6 +332,7 @@ protocol local {
     string message;
     Conversation remoteConv;
     boolean permanent;
+    string unverifiedTLFName;
     // Only set if typ is for rekeying.
     union { null, ConversationErrorRekey} rekeyInfo;
   }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -709,6 +709,7 @@ export type ConversationErrorLocal = {
   message: string,
   remoteConv: Conversation,
   permanent: boolean,
+  unverifiedTLFName: string,
   rekeyInfo?: ?ConversationErrorRekey,
 }
 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1009,6 +1009,10 @@
           "name": "permanent"
         },
         {
+          "type": "string",
+          "name": "unverifiedTLFName"
+        },
+        {
           "type": [
             null,
             "ConversationErrorRekey"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -709,6 +709,7 @@ export type ConversationErrorLocal = {
   message: string,
   remoteConv: Conversation,
   permanent: boolean,
+  unverifiedTLFName: string,
   rekeyInfo?: ?ConversationErrorRekey,
 }
 


### PR DESCRIPTION
Before this PR, here's what you see when `testerralph`'s proof is failing:

```
$ keybase chat send testerralph "hey dude"
▶ ERROR completing TLF name error: ; 1 track component failed
$ keybase chat read testerralph
▶ ERROR resolving conversation error: completing TLF name error: ; 1 track component failed
$ keybase chat list
[1]   ???                        [???] ; 1 track component failed
```

After:
```
$ keybase chat send testerralph "hey dude"
▶ ERROR failed to open chat conversation: failed to identify "testerralph": 1 tracked proof failed
$ keybase chat read testerralph
▶ ERROR failed to open chat conversation: failed to identify "testerralph": 1 tracked proof failed
$ keybase chat list
[1]  (unverified) testerralph    [???] failed to identify "testerralph": 1 tracked proof failed
```

r? @maxtaco @mmaxim 