### PR TITLE
send up pagination info in newmessage

### DIFF
--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -166,9 +166,8 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 		}
 
 		// Make a pagination object so client can use it in GetThreadLocal
-		var pmsgs []pager.Message
+		pmsgs := []pager.Message{nm.Message}
 		pager := pager.NewThreadPager()
-		pmsgs = append(pmsgs, nm.Message)
 		page, err := pager.MakePage(pmsgs, 1)
 		if err != nil {
 			g.Debug(ctx, "chat activity: error making page: %s", err.Error())

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/keybase/client/go/badges"
+	"github.com/keybase/client/go/chat/pager"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/libkb"
@@ -156,7 +157,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 		uid := m.UID().Bytes()
 
 		var conv *chat1.ConversationLocal
-		decmsg, append, err := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
+		decmsg, appended, err := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
 		if err != nil {
 			g.Debug(ctx, "chat activity: unable to storage message: %s", err.Error())
 		}
@@ -164,16 +165,26 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 			g.Debug(ctx, "chat activity: unable to update inbox: %s", err.Error())
 		}
 
+		// Make a pagination object so client can use it in GetThreadLocal
+		var pmsgs []pager.Message
+		pager := pager.NewThreadPager()
+		pmsgs = append(pmsgs, nm.Message)
+		page, err := pager.MakePage(pmsgs, 1)
+		if err != nil {
+			g.Debug(ctx, "chat activity: error making pagge: %s", err.Error())
+		}
+
 		activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
-			Message: decmsg,
-			ConvID:  nm.ConvID,
-			Conv:    conv,
+			Message:    decmsg,
+			ConvID:     nm.ConvID,
+			Conv:       conv,
+			Pagination: page,
 		})
 
 		// If this message was not "appended", meaning there is a hole between what we have in cache,
 		// and this message, then we send out a notification that this thread should be considered
 		// stale
-		if !append {
+		if !appended {
 			g.Debug(ctx, "chat activity: newMessage: non-append message, alerting")
 			kuid := keybase1.UID(m.UID().String())
 			g.G().NotifyRouter.HandleChatThreadsStale(context.Background(), kuid,

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -171,7 +171,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 		pmsgs = append(pmsgs, nm.Message)
 		page, err := pager.MakePage(pmsgs, 1)
 		if err != nil {
-			g.Debug(ctx, "chat activity: error making pagge: %s", err.Error())
+			g.Debug(ctx, "chat activity: error making page: %s", err.Error())
 		}
 
 		activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -47,9 +47,10 @@ func (e ChatActivityType) String() string {
 }
 
 type IncomingMessage struct {
-	Message MessageUnboxed     `codec:"message" json:"message"`
-	ConvID  ConversationID     `codec:"convID" json:"convID"`
-	Conv    *ConversationLocal `codec:"conv,omitempty" json:"conv,omitempty"`
+	Message    MessageUnboxed     `codec:"message" json:"message"`
+	ConvID     ConversationID     `codec:"convID" json:"convID"`
+	Conv       *ConversationLocal `codec:"conv,omitempty" json:"conv,omitempty"`
+	Pagination *Pagination        `codec:"pagination,omitempty" json:"pagination,omitempty"`
 }
 
 type ReadMessageInfo struct {

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -17,6 +17,7 @@ protocol NotifyChat {
     MessageUnboxed message;
     ConversationID convID;
     union { null, ConversationLocal } conv;
+    union { null, Pagination } pagination;
   }
 
   record ReadMessageInfo {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1022,6 +1022,7 @@ export type IncomingMessage = {
   message: MessageUnboxed,
   convID: ConversationID,
   conv?: ?ConversationLocal,
+  pagination?: ?Pagination,
 }
 
 export type LocalFileSource = {

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -38,6 +38,13 @@
             "ConversationLocal"
           ],
           "name": "conv"
+        },
+        {
+          "type": [
+            null,
+            "Pagination"
+          ],
+          "name": "pagination"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1022,6 +1022,7 @@ export type IncomingMessage = {
   message: MessageUnboxed,
   convID: ConversationID,
   conv?: ?ConversationLocal,
+  pagination?: ?Pagination,
 }
 
 export type LocalFileSource = {


### PR DESCRIPTION
Send up a pagination object so the frontend can be intelligent about fetching messages when they invoke `GetThreadLocal`.

cc @chromakode @chrisnojima 