### PR TITLE
hit the cache on ResolveFullExpressionNeedUsername(username)

### DIFF
--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -104,7 +104,13 @@ func (r *Resolver) resolveFullExpression(ctx context.Context, input string, with
 	return r.resolveURL(ctx, u, input, withBody, needUsername)
 }
 
-func (r *Resolver) getFromDiskCache(ctx context.Context, key string) (ret *ResolveResult) {
+func (res *ResolveResult) addKeybaseNameIfKnown(au AssertionURL) {
+	if au.IsKeybase() && len(res.resolvedKbUsername) == 0 {
+		res.resolvedKbUsername = au.GetValue()
+	}
+}
+
+func (r *Resolver) getFromDiskCache(ctx context.Context, key string, au AssertionURL) (ret *ResolveResult) {
 	defer r.G().CVTraceOK(ctx, VLog1, fmt.Sprintf("Resolver#getFromDiskCache(%q)", key), func() bool { return ret != nil })()
 	var uid keybase1.UID
 	found, err := r.G().LocalDb.GetInto(&uid, resolveDbKey(key))
@@ -121,6 +127,10 @@ func (r *Resolver) getFromDiskCache(ctx context.Context, key string) (ret *Resol
 	return &ResolveResult{uid: uid}
 }
 
+func isMutable(au AssertionURL) bool {
+	return !(au.IsUID() || au.IsKeybase())
+}
+
 func (r *Resolver) resolveURL(ctx context.Context, au AssertionURL, input string, withBody bool, needUsername bool) ResolveResult {
 
 	// A standard keybase UID, so it's already resolved... unless we explicitly
@@ -133,12 +143,12 @@ func (r *Resolver) resolveURL(ctx context.Context, au AssertionURL, input string
 
 	ck := au.CacheKey()
 
-	if p := r.getFromMemCache(ctx, ck); p != nil && (!needUsername || len(p.resolvedKbUsername) > 0) {
+	if p := r.getFromMemCache(ctx, ck, au); p != nil && (!needUsername || len(p.resolvedKbUsername) > 0) {
 		return *p
 	}
 
-	if p := r.getFromDiskCache(ctx, ck); p != nil && (!needUsername || len(p.resolvedKbUsername) > 0) {
-		p.mutable = !au.IsKeybase()
+	if p := r.getFromDiskCache(ctx, ck, au); p != nil && (!needUsername || len(p.resolvedKbUsername) > 0) {
+		p.mutable = isMutable(au)
 		r.putToMemCache(ck, *p)
 		return *p
 	}
@@ -146,9 +156,14 @@ func (r *Resolver) resolveURL(ctx context.Context, au AssertionURL, input string
 	res := r.resolveURLViaServerLookup(ctx, au, input, withBody)
 
 	// Cache for a shorter period of time if it's not a Keybase identity
-	res.mutable = !au.IsKeybase()
+	res.mutable = isMutable(au)
 	r.putToMemCache(ck, res)
-	r.putToDiskCache(ck, res)
+
+	// We only put to disk cache if it's a Keybase-type assertion. In particular, UIDs
+	// are **not** stored to disk.
+	if au.IsKeybase() {
+		r.putToDiskCache(ctx, ck, res)
+	}
 
 	return res
 }
@@ -247,6 +262,10 @@ func (s ResolveCacheStats) Eq(m, t, mt, et, h int) bool {
 	return (s.misses == m) && (s.timeouts == t) && (s.mutableTimeouts == mt) && (s.errorTimeouts == et) && (s.hits == h)
 }
 
+func (s ResolveCacheStats) EqWithDiskHits(m, t, mt, et, h, dh int) bool {
+	return (s.misses == m) && (s.timeouts == t) && (s.mutableTimeouts == mt) && (s.errorTimeouts == et) && (s.hits == h) && (s.diskGetHits == dh)
+}
+
 func NewResolver(g *GlobalContext) *Resolver {
 	return &Resolver{
 		Contextified: NewContextified(g),
@@ -269,7 +288,7 @@ func (r *Resolver) Shutdown() {
 	r.cache.Shutdown()
 }
 
-func (r *Resolver) getFromMemCache(ctx context.Context, key string) (ret *ResolveResult) {
+func (r *Resolver) getFromMemCache(ctx context.Context, key string, au AssertionURL) (ret *ResolveResult) {
 	defer r.G().CVTraceOK(ctx, VLog1, fmt.Sprintf("Resolver#getFromMemCache(%q)", key), func() bool { return ret != nil })()
 	if r.cache == nil {
 		return nil
@@ -298,6 +317,7 @@ func (r *Resolver) getFromMemCache(ctx context.Context, key string) (ret *Resolv
 		return nil
 	}
 	r.Stats.hits++
+	rres.addKeybaseNameIfKnown(au)
 	return rres
 }
 
@@ -308,7 +328,8 @@ func resolveDbKey(key string) DbKey {
 	}
 }
 
-func (r *Resolver) putToDiskCache(key string, res ResolveResult) {
+func (r *Resolver) putToDiskCache(ctx context.Context, key string, res ResolveResult) {
+	r.G().VDL.CLogf(ctx, VLog1, "| Resolver#putToDiskCache (attempt) %+v", res)
 	// Only cache immutable resolutions to disk
 	if res.mutable {
 		return
@@ -317,6 +338,7 @@ func (r *Resolver) putToDiskCache(key string, res ResolveResult) {
 	if res.err != nil {
 		return
 	}
+	r.G().VDL.CLogf(ctx, VLog1, "| Resolver#putToDiskCache (not short-circuited)")
 	r.Stats.diskPuts++
 	err := r.G().LocalDb.PutObj(resolveDbKey(key), nil, res.uid)
 	if err != nil {

--- a/go/systests/rpc_test.go
+++ b/go/systests/rpc_test.go
@@ -87,6 +87,14 @@ func testIdentifyResolve2(t *testing.T, g *libkb.GlobalContext) {
 	} else if _, ok := err.(libkb.ResolutionError); !ok {
 		t.Fatalf("Wrong error: wanted type %T but got (%v, %T)", libkb.ResolutionError{}, err, err)
 	}
+
+	if res, err := cli.Resolve2(context.TODO(), "t_tracy"); err != nil {
+		t.Fatalf("Resolve2 failed: %v\n", err)
+	} else if res.Username != "t_tracy" {
+		t.Fatalf("Wrong name: %s != 't_tracy", res.Username)
+	} else if !res.Uid.Equal(keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")) {
+		t.Fatalf("Wrong uid for tracy: %s\n", res.Uid)
+	}
 }
 
 func testCheckInvitationCode(t *testing.T, g *libkb.GlobalContext) {


### PR DESCRIPTION
- we were missing it since we didn't know the username!
- that's silly, we did know the username