### PR TITLE
Abridge logged badge state

### DIFF
--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -46,10 +46,12 @@ func (cid ConversationID) Less(c ConversationID) bool {
 	return bytes.Compare(cid, c) < 0
 }
 
+const DbShortFormLen = 10
+
 // DbShortForm should only be used when interacting with the database, and should
 // never leave Gregor
 func (cid ConversationID) DbShortForm() []byte {
-	return cid[:10]
+	return cid[:DbShortFormLen]
 }
 
 func MakeTLFID(val string) (TLFID, error) {


### PR DESCRIPTION
Log less madness. It will omit empty convs. Could still be long if you have lots of unread convs.

```
2017-02-08T13:44:08.666742 ▶ [DEBU keybase badger.go:108] a21 Badger send: {NewTlfs:0 RekeysNeeded:0 NewFollowers:16 Conversations:[{ConvID:0000d00dthisisnthex8 UnreadMessages:1}]}
```

r? @patrickxb 