### PR TITLE
Fix `keybase chat` help string

### DIFF
--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -17,7 +17,7 @@ var chatFlags = map[string]cli.Flag{
 	"topic-type": cli.StringFlag{
 		Name:  "topic-type",
 		Value: "chat",
-		Usage: `Specify topic name of the conversation. Has to be chat or dev`,
+		Usage: `Specify topic type of the conversation. Has to be chat or dev`,
 	},
 	"topic-name": cli.StringFlag{
 		Name:  "topic-name",


### PR DESCRIPTION
I’m assuming this is a copy+paste error from `--topic-name`.