### PR TITLE
Launchd status timeout from installer

### DIFF
--- a/osx/KBKit/KBKit/Component/KBFSService.m
+++ b/osx/KBKit/KBKit/Component/KBFSService.m
@@ -86,7 +86,7 @@
 }
 
 - (void)refreshComponent:(KBRefreshComponentCompletion)completion {
-  [KBKeybaseLaunchd status:[self.config serviceBinPathWithPathOptions:0 servicePath:_servicePath] name:@"kbfs" completion:^(NSError *error, KBRServiceStatus *serviceStatus) {
+  [KBKeybaseLaunchd status:[self.config serviceBinPathWithPathOptions:0 servicePath:_servicePath] name:@"kbfs" timeout:self.config.installTimeout completion:^(NSError *error, KBRServiceStatus *serviceStatus) {
     self.serviceStatus = serviceStatus;
     if (error) {
       self.componentStatus = [KBComponentStatus componentStatusWithError:error];

--- a/osx/KBKit/KBKit/Component/KBKeybaseLaunchd.h
+++ b/osx/KBKit/KBKit/Component/KBKeybaseLaunchd.h
@@ -19,7 +19,7 @@ typedef void (^KBOnServiceStatuses)(NSError *error, NSArray *serviceStatuses);
 
 + (void)list:(NSString *)binPath name:(NSString *)name completion:(KBOnServiceStatuses)completion;
 
-+ (void)status:(NSString *)binPath name:(NSString *)name completion:(KBOnServiceStatus)completion;
++ (void)status:(NSString *)binPath name:(NSString *)name timeout:(NSTimeInterval)timeout completion:(KBOnServiceStatus)completion;
 
 + (void)run:(NSString *)binPath args:(NSArray *)args completion:(KBCompletion)completion;
 

--- a/osx/KBKit/KBKit/Component/KBKeybaseLaunchd.m
+++ b/osx/KBKit/KBKit/Component/KBKeybaseLaunchd.m
@@ -33,9 +33,9 @@
   }];
 }
 
-+ (void)status:(NSString *)binPath name:(NSString *)name completion:(KBOnServiceStatus)completion {
++ (void)status:(NSString *)binPath name:(NSString *)name timeout:(NSTimeInterval)timeout completion:(KBOnServiceStatus)completion {
   DDLogDebug(@"Checking launchd status for %@", name);
-  [KBTask executeForJSONWithCommand:binPath args:@[@"--log-format=file", @"launchd", @"status", @"--format=json", name] timeout:KBDefaultTaskTimeout completion:^(NSError *error, id value) {
+  [KBTask executeForJSONWithCommand:binPath args:@[@"-d", @"--log-format=file", @"launchd", @"status", @"--format=json", NSStringWithFormat(@"--timeout=%@s", @(timeout)), name] timeout:KBDefaultTaskTimeout completion:^(NSError *error, id value) {
     if (error) {
       completion(error, nil);
       return;

--- a/osx/KBKit/KBKit/Component/KBService.m
+++ b/osx/KBKit/KBKit/Component/KBService.m
@@ -74,7 +74,7 @@
 }
 
 - (void)refreshComponent:(KBRefreshComponentCompletion)completion {
-  [KBKeybaseLaunchd status:[self.config serviceBinPathWithPathOptions:0 servicePath:self.servicePath] name:@"service" completion:^(NSError *error, KBRServiceStatus *serviceStatus) {
+  [KBKeybaseLaunchd status:[self.config serviceBinPathWithPathOptions:0 servicePath:self.servicePath] name:@"service" timeout:self.config.installTimeout completion:^(NSError *error, KBRServiceStatus *serviceStatus) {
     self.serviceStatus = serviceStatus;
     if (error) {
       self.componentStatus = [KBComponentStatus componentStatusWithError:error];

--- a/osx/KBKit/KBKit/Component/KBUpdaterService.m
+++ b/osx/KBKit/KBKit/Component/KBUpdaterService.m
@@ -60,7 +60,7 @@
 }
 
 - (void)refreshComponent:(KBRefreshComponentCompletion)completion {
-  [KBKeybaseLaunchd status:[self.config serviceBinPathWithPathOptions:0 servicePath:_servicePath] name:@"updater" completion:^(NSError *error, KBRServiceStatus *serviceStatus) {
+  [KBKeybaseLaunchd status:[self.config serviceBinPathWithPathOptions:0 servicePath:_servicePath] name:@"updater" timeout:self.config.installTimeout completion:^(NSError *error, KBRServiceStatus *serviceStatus) {
     self.serviceStatus = serviceStatus;
     if (error) {
       self.componentStatus = [KBComponentStatus componentStatusWithError:error];


### PR DESCRIPTION
The launchd status command used a default of 10s. On heavy load or slow machine, this could be exceeded: https://keybase.atlassian.net/browse/DESKTOP-2794

We'll pass a larger timeout from the installer like we do with install timeout (on boot it's 90s).