### PR TITLE
Fix PGP purge message popup

### DIFF
--- a/shared/pgp/container.desktop.js
+++ b/shared/pgp/container.desktop.js
@@ -8,7 +8,7 @@ import type {Props} from './purge-message.desktop'
 const connector: TypedConnector<{}, any, {}, Props> = new TypedConnector()
 
 export default connector.connect(
-  ({unlockFolders: {devices, phase, paperkeyError, waiting}}, dispatch, ownProps) => ({
+  ({}, dispatch, ownProps) => ({
     onClose: () => { dispatch({type: Constants.pgpAckedMessage, payload: {hitOk: false}}) },
     onOk: () => { dispatch({type: Constants.pgpAckedMessage, payload: {hitOk: true}}) },
   }))(PurgeMessage)

--- a/shared/pgp/container.desktop.js
+++ b/shared/pgp/container.desktop.js
@@ -1,17 +1,15 @@
 // @flow
-import {TypedConnector} from '../util/typed-connect'
 import PurgeMessage from './purge-message.desktop'
+import {connect} from 'react-redux'
 import * as Constants from '../constants/pgp'
 
-import type {Props} from './purge-message.desktop'
-
-const connector: TypedConnector<{}, any, {}, Props> = new TypedConnector()
-
-export default connector.connect(
-  ({}, dispatch, ownProps) => ({
+export default connect(
+  (state: any) => ({}),
+  (dispatch: any) => ({
     onClose: () => { dispatch({type: Constants.pgpAckedMessage, payload: {hitOk: false}}) },
     onOk: () => { dispatch({type: Constants.pgpAckedMessage, payload: {hitOk: true}}) },
-  }))(PurgeMessage)
+  })
+)(PurgeMessage)
 
 export function selector (): (store: Object) => ?Object {
   return () => ({})


### PR DESCRIPTION
@keybase/react-hackers 

This is one of those "not sure how this ever worked" things.

The container tries to pull store entries out of `unlockFolders`.  But it doesn't select `unlockFolders` in its selector!  And it doesn't need those anyway -- they must have been copy/pasted over from the unlock folders popup.

Tested that I get a white screen and a crash accessing `devices` on `undefined` before this PR, and a correct rendering of the PGP purge message after it.