### PR TITLE
Move asset deletion to Sender

### DIFF
--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -67,7 +67,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	if !ok {
 		t.Fatalf("user %s is not found", user.Username)
 	}
-	h := newChatLocalHandler(nil, tc.G, nil)
+	h := newChatLocalHandler(nil, tc.G, nil, nil)
 	mockRemote := kbtest.NewChatRemoteMock(c.world)
 	mockRemote.SetCurrentUser(user.User.GetUID().ToBytes())
 
@@ -87,7 +87,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	h.setTestRemoteClient(mockRemote)
 	h.gh, _ = newGregorHandler(tc.G)
 
-	baseSender := chat.NewBlockingSender(tc.G, h.boxer,
+	baseSender := chat.NewBlockingSender(tc.G, h.boxer, nil,
 		func() chat1.RemoteInterface { return mockRemote }, f)
 	tc.G.MessageDeliverer = chat.NewDeliverer(tc.G, baseSender)
 	tc.G.MessageDeliverer.Start(context.TODO(), user.User.GetUID().ToBytes())

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -78,7 +78,7 @@ protocol local {
   }
 
   record MessageAttachment {
-    Asset object;                // the primary attachment object
+    Asset object;                // the primary attachment object (can be empty)
     union {null, Asset} preview; // the (optional) preview of object    (V1)
     array<Asset> previews;       // the previews of object              (V2)
     bytes metadata;              // generic metadata (msgpack)


### PR DESCRIPTION
This PR moves the deletion of assets when posting a delete message into `Sender`. Before it was only on the codepath for the cli and api. Now it will happen when deleting from the gui as well.
 
`Prepare` hoovers up the assets, and `Send` tries to delete them. Failing to delete an asset not an error, as before.

A small side effect of this change is that the `AttachmentStore` instance is now attached to `Service` and passed into `Sender` instances from there and from `chatLocalHandler`.