### PR TITLE
Bootstrap after installer

### DIFF
--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -156,6 +156,12 @@ let bootstrapSetup = false
 type BootstrapOptions = {isReconnect?: boolean}
 function bootstrap (opts?: BootstrapOptions = {}): AsyncAction {
   return (dispatch, getState) => {
+    const readyForConnect = getState().config.readyForConnect
+    if (!readyForConnect) {
+      console.log('Not ready for bootstrap/connect')
+      return
+    }
+
     if (!bootstrapSetup) {
       bootstrapSetup = true
       console.log('[bootstrap] registered bootstrap')

--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -156,8 +156,8 @@ let bootstrapSetup = false
 type BootstrapOptions = {isReconnect?: boolean}
 function bootstrap (opts?: BootstrapOptions = {}): AsyncAction {
   return (dispatch, getState) => {
-    const readyForConnect = getState().config.readyForConnect
-    if (!readyForConnect) {
+    const readyForBootstrap = getState().config.readyForBootstrap
+    if (!readyForBootstrap) {
       console.log('Not ready for bootstrap/connect')
       return
     }

--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -158,7 +158,7 @@ function bootstrap (opts?: BootstrapOptions = {}): AsyncAction {
   return (dispatch, getState) => {
     const readyForBootstrap = getState().config.readyForBootstrap
     if (!readyForBootstrap) {
-      console.log('Not ready for bootstrap/connect')
+      console.warn('Not ready for bootstrap/connect')
       return
     }
 

--- a/shared/desktop/app/index.js
+++ b/shared/desktop/app/index.js
@@ -10,7 +10,7 @@ import splash from '../../util/splash.desktop'
 import storeHelper from './store-helper'
 import urlHelper from './url-helper'
 import windowHelper from './window-helper'
-import {BrowserWindow, app, dialog} from 'electron'
+import {BrowserWindow, app, ipcMain, dialog} from 'electron'
 import {setupExecuteActionsListener, executeActionsForContext} from '../../util/quit-helper.desktop'
 import {setupTarget} from '../../util/forward-logs'
 
@@ -64,16 +64,19 @@ function start () {
 
   console.log('Version:', app.getVersion())
 
-  installer(err => {
-    if (err) {
-      console.log('Error: ', err)
-    }
-    splash()
-  })
-
   app.once('ready', () => {
     mainWindow = MainWindow()
     storeHelper(mainWindow)
+  })
+
+  ipcMain.on('installer', (event, arg) => {
+    installer(err => {
+      if (err) {
+        console.log('Error: ', err)
+      }
+      splash()
+      event.sender.send('installed')
+    })
   })
 
   // Called when the user clicks the dock icon

--- a/shared/desktop/app/index.js
+++ b/shared/desktop/app/index.js
@@ -69,7 +69,7 @@ function start () {
     storeHelper(mainWindow)
   })
 
-  ipcMain.on('installer', (event, arg) => {
+  ipcMain.on('install-check', (event, arg) => {
     installer(err => {
       if (err) {
         console.log('Error: ', err)

--- a/shared/desktop/app/installer.js
+++ b/shared/desktop/app/installer.js
@@ -5,6 +5,11 @@ import {appInstallerPath, appBundlePath} from './paths'
 import {quit} from './ctl'
 import {runMode} from '../../constants/platform.desktop'
 
+// Runs the installer.
+//
+// To test the installer from dev, you can point KEYBASE_GET_APP_PATH to
+// a place where the installer is bundled, for example:
+//   KEYBASE_GET_APP_PATH=/Applications/Keybase.app/Contents/Resources/app/ yarn run start-hot
 export default (callback: (err: any) => void): void => {
   const installerPath = appInstallerPath()
   if (!installerPath) {

--- a/shared/desktop/app/installer.js
+++ b/shared/desktop/app/installer.js
@@ -6,7 +6,7 @@ import {quit} from './ctl'
 import {runMode} from '../../constants/platform.desktop'
 
 // Runs the installer (on MacOS).
-// For other platforms, this immediately returns that there is installer.
+// For other platforms, this immediately returns that there is no installer.
 //
 // To test the installer from dev (on MacOS), you can point KEYBASE_GET_APP_PATH
 // to a place where the installer is bundled, for example:

--- a/shared/desktop/app/installer.js
+++ b/shared/desktop/app/installer.js
@@ -5,10 +5,11 @@ import {appInstallerPath, appBundlePath} from './paths'
 import {quit} from './ctl'
 import {runMode} from '../../constants/platform.desktop'
 
-// Runs the installer.
+// Runs the installer (on MacOS).
+// For other platforms, this immediately returns that there is installer.
 //
-// To test the installer from dev, you can point KEYBASE_GET_APP_PATH to
-// a place where the installer is bundled, for example:
+// To test the installer from dev (on MacOS), you can point KEYBASE_GET_APP_PATH
+// to a place where the installer is bundled, for example:
 //   KEYBASE_GET_APP_PATH=/Applications/Keybase.app/Contents/Resources/app/ yarn run start-hot
 export default (callback: (err: any) => void): void => {
   const installerPath = appInstallerPath()

--- a/shared/desktop/app/paths.js
+++ b/shared/desktop/app/paths.js
@@ -1,5 +1,6 @@
 // @flow
 import {app} from 'electron'
+import getenv from 'getenv'
 import path from 'path'
 import os from 'os'
 
@@ -8,6 +9,10 @@ function appPath () {
   // return '/Applications/Keybase.app/Contents/Resources/app/'
   // For testing running from DMG
   // return '/Volumes/Keybase/Keybase.app/Contents/Resources/app/'
+  const appPath = getenv.string('KEYBASE_GET_APP_PATH', '')
+  if (appPath !== '') {
+    return appPath
+  }
   return app.getAppPath()
 }
 

--- a/shared/desktop/renderer/index.js
+++ b/shared/desktop/renderer/index.js
@@ -88,6 +88,13 @@ function setupApp (store) {
     })
   })
 
+  // Run installer
+  ipcRenderer.on('installed', (event, message) => {
+    store.dispatch({payload: undefined, type: 'config:readyForConnect'})
+    store.dispatch(bootstrap())
+  })
+  ipcRenderer.send('installer')
+
   const currentWindow = electron.remote.getCurrentWindow()
   currentWindow.on('focus', () => { store.dispatch(changedFocus(true)) })
   currentWindow.on('blur', () => { store.dispatch(changedFocus(false)) })
@@ -124,7 +131,6 @@ function setupApp (store) {
   hello(process.pid, 'Main Renderer', process.argv, __VERSION__) // eslint-disable-line no-undef
 
   store.dispatch(updateDebugConfig(require('../../local-debug-live')))
-  store.dispatch(bootstrap())
 }
 
 const FontLoader = () => (

--- a/shared/desktop/renderer/index.js
+++ b/shared/desktop/renderer/index.js
@@ -90,7 +90,7 @@ function setupApp (store) {
 
   // Run installer
   ipcRenderer.on('installed', (event, message) => {
-    store.dispatch({payload: undefined, type: 'config:readyForConnect'})
+    store.dispatch({payload: undefined, type: 'config:readyForBootstrap'})
     store.dispatch(bootstrap())
   })
   ipcRenderer.send('installer')

--- a/shared/desktop/renderer/index.js
+++ b/shared/desktop/renderer/index.js
@@ -93,7 +93,7 @@ function setupApp (store) {
     store.dispatch({payload: undefined, type: 'config:readyForBootstrap'})
     store.dispatch(bootstrap())
   })
-  ipcRenderer.send('installer')
+  ipcRenderer.send('install-check')
 
   const currentWindow = electron.remote.getCurrentWindow()
   currentWindow.on('focus', () => { store.dispatch(changedFocus(true)) })

--- a/shared/reducers/config.js
+++ b/shared/reducers/config.js
@@ -2,6 +2,7 @@
 import * as Constants from '../constants/config'
 import type {BootStatus} from '../constants/config'
 import * as CommonConstants from '../constants/common'
+import {isMobile} from '../constants/platform'
 
 import type {Action} from '../constants/types/flux'
 import type {Config, GetCurrentStatusRes, ExtendedStatus} from '../constants/types/flow-types'
@@ -19,9 +20,14 @@ export type ConfigState = {
   error: ?any,
   bootstrapTriesRemaining: number,
   bootStatus: BootStatus,
+  readyForConnect: boolean,
   followers: {[key: string]: true},
   following: {[key: string]: true},
 }
+
+// Mobile is ready for connect automatically, desktop needs to wait for
+// the installer.
+const readyForConnect = isMobile
 
 const initialState: ConfigState = {
   globalError: null,
@@ -36,6 +42,7 @@ const initialState: ConfigState = {
   error: null,
   bootstrapTriesRemaining: Constants.MAX_BOOTSTRAP_TRIES,
   bootStatus: 'bootStatusLoading',
+  readyForConnect,
   followers: {},
   following: {},
 }
@@ -72,6 +79,12 @@ export default function (state: ConfigState = initialState, action: Action): Con
       }
       return state
 
+    case 'config:readyForConnect': {
+      return {
+        ...state,
+        readyForConnect: true,
+      }
+    }
     case Constants.statusLoaded:
       if (action.payload && action.payload.status) {
         const status = action.payload.status

--- a/shared/reducers/config.js
+++ b/shared/reducers/config.js
@@ -25,7 +25,7 @@ export type ConfigState = {
   following: {[key: string]: true},
 }
 
-// Mobile is ready for connect automatically, desktop needs to wait for
+// Mobile is ready for bootstrap automatically, desktop needs to wait for
 // the installer.
 const readyForBootstrap = isMobile
 

--- a/shared/reducers/config.js
+++ b/shared/reducers/config.js
@@ -20,14 +20,14 @@ export type ConfigState = {
   error: ?any,
   bootstrapTriesRemaining: number,
   bootStatus: BootStatus,
-  readyForConnect: boolean,
+  readyForBootstrap: boolean,
   followers: {[key: string]: true},
   following: {[key: string]: true},
 }
 
 // Mobile is ready for connect automatically, desktop needs to wait for
 // the installer.
-const readyForConnect = isMobile
+const readyForBootstrap = isMobile
 
 const initialState: ConfigState = {
   globalError: null,
@@ -42,7 +42,7 @@ const initialState: ConfigState = {
   error: null,
   bootstrapTriesRemaining: Constants.MAX_BOOTSTRAP_TRIES,
   bootStatus: 'bootStatusLoading',
-  readyForConnect,
+  readyForBootstrap,
   followers: {},
   following: {},
 }
@@ -79,10 +79,10 @@ export default function (state: ConfigState = initialState, action: Action): Con
       }
       return state
 
-    case 'config:readyForConnect': {
+    case 'config:readyForBootstrap': {
       return {
         ...state,
-        readyForConnect: true,
+        readyForBootstrap: true,
       }
     }
     case Constants.statusLoaded:


### PR DESCRIPTION
Waits for installer to run before calling bootstrap.

- Renderer process triggers 'install-check' event to run installer (on main process), instead of main process running installer async on startup.
- When installer finishes returns 'installed' to renderer process. On non-MacOS platforms, this returns immediately because we only run installer on start for MacOS.
- When 'installed' event received, we dispatch readyForBootstrap and then bootstrap.
- readForBootstrap defaults to true on mobile (it doesn't need to wait for anything)

Also added more comments and ability to test this behavior from dev by using `KEYBASE_GET_APP_PATH`:

```sh
KEYBASE_GET_APP_PATH=/Applications/Keybase.app/Contents/Resources/app/ yarn run start-hot
```

and you'll see the installer run on startup via the app bundle at /Applications/Keybase.app