### PR TITLE
dont fail if we cant merge into disk inbox CORE-4585

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -504,7 +504,7 @@ func (s *HybridInboxSource) Read(ctx context.Context, uid gregor1.UID, localizer
 
 		// Write out to local storage
 		if cerr := inboxStore.Merge(ctx, inbox.Version, inbox.ConvsUnverified, rquery, p); cerr != nil {
-			return chat1.Inbox{}, rl, cerr
+			s.Debug(ctx, "Read: failed to write inbox to local storage: %s", cerr.Error())
 		}
 	} else {
 		s.Debug(ctx, "Read: hit local storage: uid: %s convs: %d", uid, len(convs))


### PR DESCRIPTION
This looks like the only spot where we can sabotage a call because a caching request failed.