### PR TITLE
fix typos in docs: use "GnuPG" instead of "GnuGP"

### DIFF
--- a/go/client/cmd_pgp_export.go
+++ b/go/client/cmd_pgp_export.go
@@ -39,7 +39,7 @@ func NewCmdPGPExport(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Com
 		},
 		Description: `"keybase pgp export" exports public (and optionally private) PGP keys
    from Keybase, and into a file or to standard output. It doesn't access
-   the GnuGP keychain at all.`,
+   the GnuPG keychain at all.`,
 	}
 }
 

--- a/go/client/cmd_pgp_gen.go
+++ b/go/client/cmd_pgp_gen.go
@@ -184,7 +184,7 @@ func NewCmdPGPGen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comman
    'keybase pgp export -s | gpg --import'.)
 
    On subsequent secret key accesses --- say for PGP decryption or
-   for signing --- access to the local GnuGP keyring is not required.
+   for signing --- access to the local GnuPG keyring is not required.
    Rather, keybase will access the secret PGP key in its own local keychain.
 
    By default, the secret half of the PGP key is never exported off

--- a/go/client/cmd_pgp_pull.go
+++ b/go/client/cmd_pgp_pull.go
@@ -51,7 +51,7 @@ func NewCmdPGPPull(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 		Description: `"keybase pgp pull" pulls down all of the PGP keys for the people
    you track. On success, it imports those keys into your local GnuPG keychain.
    For existing keys, this means the local GnuPG keyring will get an updated,
-   merged copy, via GnuGP's default key merging strategy. For new keys, it
+   merged copy, via GnuPG's default key merging strategy. For new keys, it
    will be a plain import.
 
    If usernames (or user assertions) are supplied, only those tracked users


### PR DESCRIPTION
Minor docs fix, some of the --help strings misspell GnuPG.