### PR TITLE
keybase.1.user.LoadUserPlusKeys can ask to wait for a KID

### DIFF
--- a/go/engine/user_test.go
+++ b/go/engine/user_test.go
@@ -19,7 +19,7 @@ func TestLoadUserPlusKeysHasKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	up, err := libkb.LoadUserPlusKeys(nil, tc.G, me.GetUID())
+	up, err := libkb.LoadUserPlusKeys(nil, tc.G, me.GetUID(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestLoadUserPlusKeysRevoked(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	up, err := libkb.LoadUserPlusKeys(nil, tc.G, me.GetUID())
+	up, err := libkb.LoadUserPlusKeys(nil, tc.G, me.GetUID(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestLoadUserPlusKeysRevoked(t *testing.T) {
 	}
 	fakeClock.Advance(libkb.CachedUserTimeout + 2*time.Second)
 
-	up2, err := libkb.LoadUserPlusKeys(nil, tc.G, me.GetUID())
+	up2, err := libkb.LoadUserPlusKeys(nil, tc.G, me.GetUID(), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -438,6 +438,10 @@ func lookupMerkleLeaf(ctx context.Context, g *GlobalContext, uid keybase1.UID, l
 	return
 }
 
-func LoadUserPlusKeys(ctx context.Context, g *GlobalContext, uid keybase1.UID, kid keybase1.KID) (keybase1.UserPlusKeys, error) {
-	return g.GetUPAKLoader().LoadUserPlusKeys(ctx, uid, kid)
+// LoadUserPlusKeys loads user and keys for the given UID.  If `pollForKID` is provided, we'll request
+// this user potentially twice: the first time can hit the cache for the UID, but will force a repoll
+// unless the pollForKID is found for the user.  If pollForKID is empty, then just access the cache as
+// normal.
+func LoadUserPlusKeys(ctx context.Context, g *GlobalContext, uid keybase1.UID, pollForKID keybase1.KID) (keybase1.UserPlusKeys, error) {
+	return g.GetUPAKLoader().LoadUserPlusKeys(ctx, uid, pollForKID)
 }

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -438,6 +438,6 @@ func lookupMerkleLeaf(ctx context.Context, g *GlobalContext, uid keybase1.UID, l
 	return
 }
 
-func LoadUserPlusKeys(ctx context.Context, g *GlobalContext, uid keybase1.UID) (keybase1.UserPlusKeys, error) {
-	return g.GetUPAKLoader().LoadUserPlusKeys(ctx, uid)
+func LoadUserPlusKeys(ctx context.Context, g *GlobalContext, uid keybase1.UID, kid keybase1.KID) (keybase1.UserPlusKeys, error) {
+	return g.GetUPAKLoader().LoadUserPlusKeys(ctx, uid, kid)
 }

--- a/go/libkb/loaduser_test.go
+++ b/go/libkb/loaduser_test.go
@@ -14,7 +14,7 @@ func TestLoadUserPlusKeys(t *testing.T) {
 
 	// this is kind of pointless as there is no cache anymore
 	for i := 0; i < 10; i++ {
-		u, err := LoadUserPlusKeys(nil, tc.G, "295a7eea607af32040647123732bc819")
+		u, err := LoadUserPlusKeys(nil, tc.G, "295a7eea607af32040647123732bc819", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -27,7 +27,7 @@ func TestLoadUserPlusKeys(t *testing.T) {
 	}
 
 	for _, uid := range []keybase1.UID{"295a7eea607af32040647123732bc819", "afb5eda3154bc13c1df0189ce93ba119", "9d56bd0c02ac2711e142faf484ea9519", "c4c565570e7e87cafd077509abf5f619", "561247eb1cc3b0f5dc9d9bf299da5e19"} {
-		_, err := LoadUserPlusKeys(nil, tc.G, uid)
+		_, err := LoadUserPlusKeys(nil, tc.G, uid, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -39,7 +39,7 @@ func TestLoadUserPlusKeysNoKeys(t *testing.T) {
 	defer tc.Cleanup()
 
 	// t_ellen has no keys.  There should be no error loading her.
-	u, err := LoadUserPlusKeys(nil, tc.G, "561247eb1cc3b0f5dc9d9bf299da5e19")
+	u, err := LoadUserPlusKeys(nil, tc.G, "561247eb1cc3b0f5dc9d9bf299da5e19", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestRevokedKeys(t *testing.T) {
 	tc := SetupTest(t, "revoked keys", 1)
 	defer tc.Cleanup()
 
-	u, err := LoadUserPlusKeys(nil, tc.G, "ff261e3b26543a24ba6c0693820ead19")
+	u, err := LoadUserPlusKeys(nil, tc.G, "ff261e3b26543a24ba6c0693820ead19", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func BenchmarkLoadUserPlusKeys(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := LoadUserPlusKeys(nil, tc.G, uid)
+		_, err := LoadUserPlusKeys(nil, tc.G, uid, "")
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -16,7 +16,7 @@ type UPAKLoader interface {
 	ClearMemory()
 	Load(arg LoadUserArg) (ret *keybase1.UserPlusAllKeys, user *User, err error)
 	CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool, err error)
-	LoadUserPlusKeys(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (keybase1.UserPlusKeys, error)
+	LoadUserPlusKeys(ctx context.Context, uid keybase1.UID, pollForKID keybase1.KID) (keybase1.UserPlusKeys, error)
 	Invalidate(ctx context.Context, uid keybase1.UID)
 	LoadDeviceKey(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (upk *keybase1.UserPlusAllKeys, deviceKey *keybase1.PublicKey, revoked *keybase1.RevokedKey, err error)
 	LookupUsername(ctx context.Context, uid keybase1.UID) (NormalizedUsername, error)
@@ -319,7 +319,7 @@ func (u *CachedUPAKLoader) CheckKIDForUID(ctx context.Context, uid keybase1.UID,
 	return found, revokedAt, deleted, nil
 }
 
-func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (keybase1.UserPlusKeys, error) {
+func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UID, pollForKID keybase1.KID) (keybase1.UserPlusKeys, error) {
 	var up keybase1.UserPlusKeys
 	if uid.IsNil() {
 		return up, NoUIDError{}
@@ -330,11 +330,11 @@ func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UI
 	arg.PublicKeyOptional = true
 	arg.NetContext = ctx
 
-	forceRepoll := []bool{false, true}
+	forcePollValues := []bool{false, true}
 
-	for _, frp := range forceRepoll {
+	for _, fp := range forcePollValues {
 		// We need to force a reload to make KBFS tests pass
-		arg.ForcePoll = frp || (u.G().Env.GetRunMode() == DevelRunMode)
+		arg.ForcePoll = fp || (u.G().Env.GetRunMode() == DevelRunMode)
 
 		upak, _, err := u.Load(arg)
 		if err != nil {
@@ -344,7 +344,7 @@ func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UI
 			return up, fmt.Errorf("Nil user, nil error from LoadUser")
 		}
 		up = upak.Base
-		if kid.IsNil() || up.FindKID(kid) != nil {
+		if pollForKID.IsNil() || up.FindKID(pollForKID) != nil {
 			break
 		}
 

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -16,7 +16,7 @@ type UPAKLoader interface {
 	ClearMemory()
 	Load(arg LoadUserArg) (ret *keybase1.UserPlusAllKeys, user *User, err error)
 	CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool, err error)
-	LoadUserPlusKeys(ctx context.Context, uid keybase1.UID) (keybase1.UserPlusKeys, error)
+	LoadUserPlusKeys(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (keybase1.UserPlusKeys, error)
 	Invalidate(ctx context.Context, uid keybase1.UID)
 	LoadDeviceKey(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (upk *keybase1.UserPlusAllKeys, deviceKey *keybase1.PublicKey, revoked *keybase1.RevokedKey, err error)
 	LookupUsername(ctx context.Context, uid keybase1.UID) (NormalizedUsername, error)
@@ -319,7 +319,7 @@ func (u *CachedUPAKLoader) CheckKIDForUID(ctx context.Context, uid keybase1.UID,
 	return found, revokedAt, deleted, nil
 }
 
-func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UID) (keybase1.UserPlusKeys, error) {
+func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (keybase1.UserPlusKeys, error) {
 	var up keybase1.UserPlusKeys
 	if uid.IsNil() {
 		return up, NoUIDError{}
@@ -330,17 +330,25 @@ func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UI
 	arg.PublicKeyOptional = true
 	arg.NetContext = ctx
 
-	// We need to force a reload to make KBFS tests pass
-	arg.ForcePoll = (u.G().Env.GetRunMode() == DevelRunMode)
+	forceRepoll := []bool{false, true}
 
-	upak, _, err := u.Load(arg)
-	if err != nil {
-		return up, err
+	for _, frp := range forceRepoll {
+		// We need to force a reload to make KBFS tests pass
+		arg.ForcePoll = frp || (u.G().Env.GetRunMode() == DevelRunMode)
+
+		upak, _, err := u.Load(arg)
+		if err != nil {
+			return up, err
+		}
+		if upak == nil {
+			return up, fmt.Errorf("Nil user, nil error from LoadUser")
+		}
+		up = upak.Base
+		if kid.IsNil() || up.FindKID(kid) != nil {
+			break
+		}
+
 	}
-	if upak == nil {
-		return up, fmt.Errorf("Nil user, nil error from LoadUser")
-	}
-	up = upak.Base
 	return up, nil
 }
 

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -876,6 +876,15 @@ func (u UserPlusAllKeys) FindDevice(d DeviceID) *PublicKey {
 	return nil
 }
 
+func (u UserPlusKeys) FindKID(needle KID) *PublicKey {
+	for _, k := range u.DeviceKeys {
+		if k.KID.Equal(needle) {
+			return &k
+		}
+	}
+	return nil
+}
+
 func (s ChatConversationID) String() string {
 	return hex.EncodeToString(s)
 }

--- a/go/protocol/keybase1/user.go
+++ b/go/protocol/keybase1/user.go
@@ -110,8 +110,9 @@ type LoadUserByNameArg struct {
 }
 
 type LoadUserPlusKeysArg struct {
-	SessionID int `codec:"sessionID" json:"sessionID"`
-	Uid       UID `codec:"uid" json:"uid"`
+	SessionID  int `codec:"sessionID" json:"sessionID"`
+	Uid        UID `codec:"uid" json:"uid"`
+	PollForKID KID `codec:"pollForKID" json:"pollForKID"`
 }
 
 type LoadPublicKeysArg struct {

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -116,7 +116,7 @@ func (h *UserHandler) LoadUserByName(_ context.Context, arg keybase1.LoadUserByN
 }
 
 func (h *UserHandler) LoadUserPlusKeys(ctx context.Context, arg keybase1.LoadUserPlusKeysArg) (keybase1.UserPlusKeys, error) {
-	return libkb.LoadUserPlusKeys(ctx, h.G(), arg.Uid)
+	return libkb.LoadUserPlusKeys(ctx, h.G(), arg.Uid, arg.PollForKID)
 }
 
 func (h *UserHandler) Search(_ context.Context, arg keybase1.SearchArg) (results []keybase1.SearchResult, err error) {

--- a/protocol/avdl/keybase1/user.avdl
+++ b/protocol/avdl/keybase1/user.avdl
@@ -66,7 +66,7 @@ protocol user {
   /**
     Load a user + device keys from the server.
     */
-  UserPlusKeys loadUserPlusKeys(int sessionID, UID uid);
+  UserPlusKeys loadUserPlusKeys(int sessionID, UID uid, KID pollForKID);
 
   /**
     Load public keys for a user.

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5705,7 +5705,8 @@ export type userLoadUserByNameRpcParam = Exact<{
 }>
 
 export type userLoadUserPlusKeysRpcParam = Exact<{
-  uid: UID
+  uid: UID,
+  pollForKID: KID
 }>
 
 export type userLoadUserRpcParam = Exact<{

--- a/protocol/json/keybase1/user.json
+++ b/protocol/json/keybase1/user.json
@@ -352,6 +352,10 @@
         {
           "name": "uid",
           "type": "UID"
+        },
+        {
+          "name": "pollForKID",
+          "type": "KID"
         }
       ],
       "response": "UserPlusKeys",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5705,7 +5705,8 @@ export type userLoadUserByNameRpcParam = Exact<{
 }>
 
 export type userLoadUserPlusKeysRpcParam = Exact<{
-  uid: UID
+  uid: UID,
+  pollForKID: KID
 }>
 
 export type userLoadUserRpcParam = Exact<{


### PR DESCRIPTION
- In the case of provisinoing, KBFS knows/thinks that a new key is available for the user, but we have to bust through the UPAK cache to expose it to KBFS. There isn't a race-free way to do this, so better for KBFS to specify which key they're waiting on. Then we can repoll the server if our first (cached) attempt failed.