### PR TITLE
Don't log FSActivity messages

### DIFF
--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -305,7 +305,6 @@ func (n *NotifyRouter) HandleFSActivity(activity keybase1.FSNotification) {
 	if n == nil {
 		return
 	}
-	n.G().Log.Debug("FS activity: %v", activity)
 	// For all connections we currently have open...
 	n.cm.ApplyAll(func(id ConnectionID, xp rpc.Transporter) bool {
 		// If the connection wants the `Kbfs` notification type


### PR DESCRIPTION
These contain filenames, and don't seem necessary:

    2017-02-13T14:59:51.188798-06:00 ▶ [DEBU keybase notify_router.go:308] 3464c FS activity: {false /keybase/private/patrick/dropbox/Assets/icons/Pictos 1 PNGs/32/.10.png.pKIxSm  START ENCRYPTING ACCESS_DENIED map[]  0}
    2017-02-13T14:59:51.213971-06:00 ▶ [DEBU keybase notify_router.go:308] 3464d FS activity: {false /keybase/private/patrick/dropbox/Assets/icons/Pictos 1 PNGs/32/.10.png.pKIxSm  FINISH ENCRYPTING ACCESS_DENIED map[]  0}

