### PR TITLE
Chat: Mobile header

### DIFF
--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -8,7 +8,7 @@ import {connect} from 'react-redux'
 import {deleteMessage, editMessage, loadMoreMessages, muteConversation, newChat, openFolder, postMessage, retryMessage, loadAttachment, retryAttachment} from '../../actions/chat'
 import {downloadFilePath} from '../../util/file'
 import {getProfile} from '../../actions/tracker'
-import {navigateAppend} from '../../actions/route-tree'
+import {navigateAppend, navigateUp} from '../../actions/route-tree'
 import {nothingSelected, getBrokenUsers} from '../../constants/chat'
 import {onUserClick} from '../../actions/profile'
 import {openDialog as openRekeyDialog} from '../../actions/unlock-folders'
@@ -123,6 +123,7 @@ export default connect(
   (dispatch: Dispatch, {setRouteState}) => ({
     onAddParticipant: (participants: Array<string>) => dispatch(newChat(participants)),
     onAttach: (selectedConversation, inputs: Array<AttachmentInput>) => { dispatch(navigateAppend([{props: {conversationIDKey: selectedConversation, inputs}, selected: 'attachmentInput'}])) },
+    onBack: () => dispatch(navigateUp()),
     onDeleteMessage: (message: Message) => { dispatch(deleteMessage(message)) },
     onEditMessage: (message: Message, body: string) => { dispatch(editMessage(message, new HiddenString(body))) },
     onLoadAttachment: (selectedConversation, messageID, filename) => dispatch(loadAttachment(selectedConversation, messageID, false, false, downloadFilePath(filename))),

--- a/shared/chat/conversation/header.desktop.js
+++ b/shared/chat/conversation/header.desktop.js
@@ -2,11 +2,10 @@
 import React from 'react'
 import {Box, Icon, Usernames} from '../../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../../styles'
-import {participantFilter, usernamesToUserListItem} from '../../constants/chat'
 
 import type {Props} from './header'
 
-const Header = ({participants, onOpenFolder, onToggleSidePanel, sidePanelOpen, you, metaDataMap, followingMap, onShowProfile, muted}: Props) => (
+const Header = ({muted, onOpenFolder, onShowProfile, onToggleSidePanel, sidePanelOpen, users}: Props) => (
   <Box style={containerStyle}>
     <Box style={{...globalStyles.flexBoxRow, flex: 1, justifyContent: 'center', marginLeft: 48}}>
       <Usernames
@@ -14,23 +13,32 @@ const Header = ({participants, onOpenFolder, onToggleSidePanel, sidePanelOpen, y
         inline={false}
         commaColor={globalColors.black_40}
         type='BodyBig'
-        users={usernamesToUserListItem(participantFilter(participants, you).toArray(), you, metaDataMap, followingMap)}
-        containerStyle={{textAlign: 'center', justifyContent: 'center'}}
+        users={users}
+        containerStyle={styleCenter}
         onUsernameClicked={onShowProfile} />
-      {muted && <Icon type='iconfont-shh' style={{marginLeft: globalMargins.tiny}} />}
+      {muted && <Icon type='iconfont-shh' style={styleLeft} />}
     </Box>
-    <Icon type='iconfont-folder-private' style={{marginLeft: globalMargins.tiny}} onClick={onOpenFolder} />
-    <Icon type={sidePanelOpen ? 'iconfont-close' : 'iconfont-info'} style={{marginLeft: globalMargins.tiny}} onClick={onToggleSidePanel} />
+    <Icon type='iconfont-folder-private' style={styleLeft} onClick={onOpenFolder} />
+    <Icon type={sidePanelOpen ? 'iconfont-close' : 'iconfont-info'} style={styleLeft} onClick={onToggleSidePanel} />
   </Box>
 )
 
 const containerStyle = {
   ...globalStyles.flexBoxRow,
-  minHeight: 32,
+  alignItems: 'center',
   borderBottom: `solid 1px ${globalColors.black_05}`,
   justifyContent: 'center',
-  alignItems: 'center',
+  minHeight: 32,
   padding: globalMargins.tiny,
+}
+
+const styleCenter = {
+  justifyContent: 'center',
+  textAlign: 'center',
+}
+
+const styleLeft = {
+  marginLeft: globalMargins.tiny,
 }
 
 export default Header

--- a/shared/chat/conversation/header.js.flow
+++ b/shared/chat/conversation/header.js.flow
@@ -2,6 +2,7 @@
 import {Component} from 'react'
 import {List} from 'immutable'
 import type {UserList} from '../../common-adapters/usernames'
+
 export type Props = {
   muted: boolean,
   onBack?: () => void,

--- a/shared/chat/conversation/header.js.flow
+++ b/shared/chat/conversation/header.js.flow
@@ -1,19 +1,14 @@
 // @flow
 import {Component} from 'react'
 import {List} from 'immutable'
-
-import type {MetaDataMap, FollowingMap} from '../../constants/chat'
-
+import type {UserList} from '../../common-adapters/usernames'
 export type Props = {
-  participants: List<string>,
-  metaDataMap: MetaDataMap,
-  followingMap: FollowingMap,
   muted: boolean,
-  you: string,
   onOpenFolder: () => void,
   onToggleSidePanel: () => void,
   sidePanelOpen: boolean,
   onShowProfile: (user: string) => void,
+  users: UserList,
 }
 
 export default class Header extends Component<void, Props, void> { }

--- a/shared/chat/conversation/header.js.flow
+++ b/shared/chat/conversation/header.js.flow
@@ -4,10 +4,11 @@ import {List} from 'immutable'
 import type {UserList} from '../../common-adapters/usernames'
 export type Props = {
   muted: boolean,
+  onBack?: () => void,
   onOpenFolder: () => void,
+  onShowProfile: (user: string) => void,
   onToggleSidePanel: () => void,
   sidePanelOpen: boolean,
-  onShowProfile: (user: string) => void,
   users: UserList,
 }
 

--- a/shared/chat/conversation/header.native.js
+++ b/shared/chat/conversation/header.native.js
@@ -1,13 +1,16 @@
 // @flow
 import React from 'react'
-import {Box, Icon, Usernames} from '../../common-adapters'
+import {BackButton, Box, Icon, Usernames} from '../../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../../styles'
 
 import type {Props} from './header'
 
-const Header = ({muted, onOpenFolder, onShowProfile, onToggleSidePanel, sidePanelOpen, users}: Props) => (
+const Header = ({muted, onBack, onOpenFolder, onShowProfile, onToggleSidePanel, sidePanelOpen, users}: Props) => (
   <Box style={containerStyle}>
-    <Box style={{...globalStyles.flexBoxRow, flex: 1, justifyContent: 'center', marginLeft: 48}}>
+    <Box style={{...globalStyles.flexBoxRow, flex: 1, justifyContent: 'flex-start'}}>
+      <BackButton title={null} onClick={onBack} iconStyle={{color: globalColors.blue}} textStyle={{color: globalColors.blue}} />
+    </Box>
+    <Box style={{...globalStyles.flexBoxRow, justifyContent: 'center'}}>
       <Usernames
         colorFollowing={true}
         inline={false}
@@ -18,15 +21,15 @@ const Header = ({muted, onOpenFolder, onShowProfile, onToggleSidePanel, sidePane
         onUsernameClicked={onShowProfile} />
       {muted && <Icon type='iconfont-shh' style={styleLeft} />}
     </Box>
-    <Icon type='iconfont-folder-private' style={styleLeft} onClick={onOpenFolder} />
-    <Icon type={sidePanelOpen ? 'iconfont-close' : 'iconfont-info'} style={styleLeft} onClick={onToggleSidePanel} />
+    <Box style={{...globalStyles.flexBoxRow, flex: 1, justifyContent: 'flex-end'}}>
+      <Icon type={sidePanelOpen ? 'iconfont-close' : 'iconfont-info'} style={styleLeft} onClick={onToggleSidePanel} />
+    </Box>
   </Box>
 )
 
 const containerStyle = {
   ...globalStyles.flexBoxRow,
   alignItems: 'center',
-  borderBottom: `solid 1px ${globalColors.black_05}`,
   justifyContent: 'center',
   minHeight: 32,
   padding: globalMargins.tiny,

--- a/shared/chat/conversation/header.native.js
+++ b/shared/chat/conversation/header.native.js
@@ -1,3 +1,44 @@
 // @flow
-const TODO = () => null
-export default TODO
+import React from 'react'
+import {Box, Icon, Usernames} from '../../common-adapters'
+import {globalStyles, globalColors, globalMargins} from '../../styles'
+
+import type {Props} from './header'
+
+const Header = ({muted, onOpenFolder, onShowProfile, onToggleSidePanel, sidePanelOpen, users}: Props) => (
+  <Box style={containerStyle}>
+    <Box style={{...globalStyles.flexBoxRow, flex: 1, justifyContent: 'center', marginLeft: 48}}>
+      <Usernames
+        colorFollowing={true}
+        inline={false}
+        commaColor={globalColors.black_40}
+        type='BodyBig'
+        users={users}
+        containerStyle={styleCenter}
+        onUsernameClicked={onShowProfile} />
+      {muted && <Icon type='iconfont-shh' style={styleLeft} />}
+    </Box>
+    <Icon type='iconfont-folder-private' style={styleLeft} onClick={onOpenFolder} />
+    <Icon type={sidePanelOpen ? 'iconfont-close' : 'iconfont-info'} style={styleLeft} onClick={onToggleSidePanel} />
+  </Box>
+)
+
+const containerStyle = {
+  ...globalStyles.flexBoxRow,
+  alignItems: 'center',
+  borderBottom: `solid 1px ${globalColors.black_05}`,
+  justifyContent: 'center',
+  minHeight: 32,
+  padding: globalMargins.tiny,
+}
+
+const styleCenter = {
+  justifyContent: 'center',
+  textAlign: 'center',
+}
+
+const styleLeft = {
+  marginLeft: globalMargins.tiny,
+}
+
+export default Header

--- a/shared/chat/conversation/header.native.js
+++ b/shared/chat/conversation/header.native.js
@@ -19,7 +19,7 @@ const Header = ({muted, onBack, onOpenFolder, onShowProfile, onToggleSidePanel, 
         users={users}
         containerStyle={styleCenter}
         onUsernameClicked={onShowProfile} />
-      {muted && <Icon type='iconfont-shh' style={styleLeft} />}
+      {muted && <Icon type='iconfont-shh' style={{...styleCenter, ...styleLeft}} />}
     </Box>
     <Box style={{...globalStyles.flexBoxRow, flex: 1, justifyContent: 'flex-end'}}>
       <Icon type={sidePanelOpen ? 'iconfont-close' : 'iconfont-info'} style={styleLeft} onClick={onToggleSidePanel} />

--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -141,18 +141,17 @@ class Conversation extends Component<void, Props & EditLastHandlerProps, State> 
         <Icon type='icon-file-dropping-48' />
       </Box>
     )
+    const users = usernamesToUserListItem(participantFilter(participants, you).toArray(), you, metaDataMap, followingMap)
+
     return (
       <Box className='conversation' style={containerStyle} onDragEnter={this._onDragEnter} onPaste={this._onPaste}>
         <Header
-          onOpenFolder={onOpenFolder}
-          onToggleSidePanel={onToggleSidePanel}
-          participants={participants}
           muted={muted}
-          sidePanelOpen={sidePanelOpen}
-          you={you}
-          metaDataMap={metaDataMap}
-          followingMap={followingMap}
+          onOpenFolder={onOpenFolder}
           onShowProfile={onShowProfile}
+          onToggleSidePanel={onToggleSidePanel}
+          sidePanelOpen={sidePanelOpen}
+          users={users}
         />
         <List
           you={you}

--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -11,7 +11,7 @@ import YouRekey from './you-rekey.desktop.js'
 import {Box, Icon} from '../../common-adapters'
 import {globalStyles, globalColors} from '../../styles'
 import {readImageFromClipboard} from '../../util/clipboard.desktop'
-import {nothingSelected} from '../../constants/chat'
+import {nothingSelected, participantFilter, usernamesToUserListItem} from '../../constants/chat'
 import {withHandlers, branch, renderComponent, compose} from 'recompose'
 
 import type {Props} from '.'
@@ -135,7 +135,6 @@ class Conversation extends Component<void, Props & EditLastHandlerProps, State> 
     } = this.props
 
     const banner = bannerMessage && <Banner {...bannerMessage} />
-
     const dropOverlay = this.state.showDropOverlay && (
       <Box style={dropOverlayStyle} onDragLeave={this._onDragLeave} onDrop={this._onDrop}>
         <Icon type='icon-file-dropping-48' />

--- a/shared/chat/dumb.js
+++ b/shared/chat/dumb.js
@@ -71,30 +71,23 @@ const messages = [
   },
 ]
 
-const metaData = {
-  'cjb': MetaDataRecord({fullname: 'Chris Ball', brokenTracker: true}),
-  'chris': MetaDataRecord({fullname: 'Chris Coyne'}),
-  'chrisnojima': MetaDataRecord({fullname: 'Chris Nojima'}),
-  'oconnor663': MetaDataRecord({fullname: `Jack O'Connor`}),
-}
-
-const followingMap = {
-  oconnor663: true,
-}
+const users = [
+  {broken: false, following: false, username: 'chris', you: true},
+  {broken: false, following: false, username: 'chrisnojima', you: false},
+  {broken: true, following: false, username: 'cjb', you: false},
+  {broken: false, following: true, username: 'oconnor663', you: false},
+]
 
 const commonConvoProps = {
   loadMoreMessages: () => console.log('load more'),
   messages: List(messages),
-  participants: List(participants),
+  users: users,
   moreToLoad: false,
   isRequesting: false,
   onPostMessage: (text: string) => console.log('on post', text),
   selectedConversation: 'convo1',
   emojiPickerOpen: false,
   onShowProfile: (username: string) => console.log('on show profile', username),
-  metaDataMap: Map(metaData),
-  followingMap,
-  you: 'chris',
 }
 
 const emptyConvoProps = {

--- a/shared/chat/dumb.js
+++ b/shared/chat/dumb.js
@@ -176,7 +176,7 @@ const header = {
     'Muted': {
       ...commonConvoProps,
       muted: true,
-    }
+    },
   },
 }
 

--- a/shared/chat/dumb.js
+++ b/shared/chat/dumb.js
@@ -8,7 +8,7 @@ import HiddenString from '../util/hidden-string'
 import ParticipantRekey from './conversation/participant-rekey'
 import YouRekey from './conversation/you-rekey'
 import {ConversationListContainer} from './conversations-list/container'
-import {InboxStateRecord, RekeyInfoRecord} from '../constants/chat'
+import {InboxStateRecord, MetaDataRecord, RekeyInfoRecord} from '../constants/chat'
 import {List, Map} from 'immutable'
 import {globalStyles} from '../styles'
 
@@ -76,6 +76,17 @@ const users = [
   {broken: false, following: true, username: 'oconnor663', you: false},
   {broken: true, following: false, username: 'cjb', you: false},
 ]
+
+const metaData = {
+  'cjb': MetaDataRecord({fullname: 'Chris Ball', brokenTracker: true}),
+  'chris': MetaDataRecord({fullname: 'Chris Coyne'}),
+  'chrisnojima': MetaDataRecord({fullname: 'Chris Nojima'}),
+  'oconnor663': MetaDataRecord({fullname: `Jack O'Connor`}),
+}
+
+const followingMap = {
+  oconnor663: true,
+}
 
 const commonConvoProps = {
   loadMoreMessages: () => console.log('load more'),
@@ -260,11 +271,15 @@ const list = {
 }
 
 const commonSidePanel = {
+  followingMap,
+  metaDataMap: Map(metaData),
   parentProps: {
     style: {
       width: 320,
     },
   },
+  participants: List(participants),
+  you: 'chris',
 }
 
 const sidePanel = {
@@ -274,9 +289,10 @@ const sidePanel = {
       ...commonConvoProps,
       ...commonSidePanel,
     },
-    'Empty': {
+    'Muted': {
       ...emptyConvoProps,
       ...commonSidePanel,
+      muted: true,
     },
   },
 }

--- a/shared/chat/dumb.js
+++ b/shared/chat/dumb.js
@@ -8,7 +8,7 @@ import HiddenString from '../util/hidden-string'
 import ParticipantRekey from './conversation/participant-rekey'
 import YouRekey from './conversation/you-rekey'
 import {ConversationListContainer} from './conversations-list/container'
-import {InboxStateRecord, MetaDataRecord, RekeyInfoRecord} from '../constants/chat'
+import {InboxStateRecord, RekeyInfoRecord} from '../constants/chat'
 import {List, Map} from 'immutable'
 import {globalStyles} from '../styles'
 
@@ -173,9 +173,10 @@ const header = {
     'Normal': {
       ...commonConvoProps,
     },
-    'Empty': {
-      ...emptyConvoProps,
-    },
+    'Muted': {
+      ...commonConvoProps,
+      muted: true,
+    }
   },
 }
 

--- a/shared/chat/dumb.js
+++ b/shared/chat/dumb.js
@@ -72,10 +72,9 @@ const messages = [
 ]
 
 const users = [
-  {broken: false, following: false, username: 'chris', you: true},
   {broken: false, following: false, username: 'chrisnojima', you: false},
-  {broken: true, following: false, username: 'cjb', you: false},
   {broken: false, following: true, username: 'oconnor663', you: false},
+  {broken: true, following: false, username: 'cjb', you: false},
 ]
 
 const commonConvoProps = {


### PR DESCRIPTION
@keybase/react-hackers 

Hi, this PR adds the chat header for mobile.  But before it does that, it refactors the Header component to avoid peeking into the inbox/metadata/participants structures from the store, making it a presentational component only, as @chrisnojima already did for the conversation-list.

The PR also adds a muted header to the dumb sheet (and removes the "empty" one -- the header doesn't do anything differently if the convo is empty of messages), and fixes up `dumb.js` to follow the props refactoring mentioned above.

:eyes:, thanks!