### PR TITLE
add the libxss dependency to Arch packages

### DIFF
--- a/packaging/linux/arch/PKGBUILD.bin.in
+++ b/packaging/linux/arch/PKGBUILD.bin.in
@@ -11,7 +11,7 @@ url='https://keybase.io'
 pkgver=@@PKGVER@@
 pkgrel=1
 arch=('i686' 'x86_64')
-depends=(fuse gconf)
+depends=(fuse gconf libxss)
 # keybase-release is a deprecated AUR package
 conflicts=(keybase keybase-release keybase-git)
 source_i686=(

--- a/packaging/linux/arch/PKGBUILD.git.in
+++ b/packaging/linux/arch/PKGBUILD.git.in
@@ -14,7 +14,7 @@ pkgver() {
 }
 pkgrel=1
 arch=('i686' 'x86_64')
-depends=(fuse gconf)
+depends=(fuse gconf libxss)
 makedepends=(go yarn npm git rsync)
 # keybase-release is a deprecated AUR package
 conflicts=(keybase keybase-release keybase-bin)


### PR DESCRIPTION
This mirrors what we've done in RPM. (We don't have this dependency in
Debian, but that might just be because it's more commonly installed by
default, and we just haven't run into anyone without it yet.)

This missing dependency was reported in RyanFlaherty's comment on the
keybase-bin AUR package.

r? @cjb 