### PR TITLE
Add signencrypt non-streaming interface

### DIFF
--- a/go/chat/attachment_crypt.go
+++ b/go/chat/attachment_crypt.go
@@ -65,7 +65,7 @@ func NewSignEncrypter() *SignEncrypter {
 }
 
 func (s *SignEncrypter) EncryptedLen(size int) int {
-	return signencrypt.GetSealedSize(size)
+	return signencrypt.GetSealedStreamSize(size)
 }
 
 func (s *SignEncrypter) Encrypt(r io.Reader) (io.Reader, error) {


### PR DESCRIPTION
Expose `SealSingle` and `OpenSingle` (open to better names). This seems like a good fit for chat headers because it's less moving parts than the streamers.

It has 2 warts:
- If you use both streaming and non-streaming with the same keys then using sequential nonces is a bad idea because they are likely to be the same. I think this is true even if you change the signaturePrefix.
- The ciphertext is the same for streaming and non-streaming (with the 'same' nonce) for messages that are too short to get chunked. This is potentially confusing.