### PR TITLE
Mobile: Chat input

### DIFF
--- a/shared/chat/conversation/input.desktop.js
+++ b/shared/chat/conversation/input.desktop.js
@@ -13,7 +13,7 @@ type State = {
   text: string,
 }
 
-class Conversation extends Component<void, Props, State> {
+class ConversationInput extends Component<void, Props, State> {
   _input: any;
   _fileInput: any;
   state: State;
@@ -201,4 +201,4 @@ const styleFooter = {
   marginRight: globalMargins.tiny,
 }
 
-export default Conversation
+export default ConversationInput

--- a/shared/chat/conversation/input.native.js
+++ b/shared/chat/conversation/input.native.js
@@ -65,7 +65,7 @@ class ConversationInput extends Component<void, Props, State> {
             hintText='Write a message'
             hideUnderline={true}
             onChangeText={this._onChangeText}
-            onSubmitEditing={this._onSubmit}
+            onEnterKeyDown={this._onSubmit}
             value={this.state.text}
             multiline={false}
           />

--- a/shared/chat/conversation/input.native.js
+++ b/shared/chat/conversation/input.native.js
@@ -1,3 +1,91 @@
 // @flow
-const TODO = () => null
-export default TODO
+/* eslint-env browser */
+import React, {Component} from 'react'
+import {Box, Icon, Input} from '../../common-adapters'
+import {globalMargins, globalStyles} from '../../styles'
+
+import type {Props} from './input'
+
+type State = {
+  text: string,
+}
+
+class ConversationInput extends Component<void, Props, State> {
+  _input: any;
+  _fileInput: any;
+  state: State;
+
+  _setRef = r => {
+    this._input = r
+  }
+
+  constructor (props: Props) {
+    super(props)
+    this.state = {text: this.props.defaultText}
+  }
+
+  componentDidUpdate (prevProps: Props) {
+    if (!this.props.isLoading && prevProps.isLoading) {
+      this.focusInput()
+    }
+  }
+
+  focusInput = () => {
+    this._input && this._input.focus()
+  }
+
+  getValue () {
+    return this._input ? this._input.getValue() : ''
+  }
+
+  _onSubmit = () => {
+    if (this.state.text) {
+      this.props.onPostMessage(this.state.text)
+      this.setState({text: ''})
+    }
+  }
+
+  _onChangeText = text => {
+    this.setState({text})
+  }
+
+  _openFilePicker = () => {
+    console.log('openFilePicker')
+  }
+
+  render () {
+    return (
+      <Box style={{...globalStyles.flexBoxColumn}}>
+        <Box style={{...globalStyles.flexBoxRow, alignItems: 'flex-start'}}>
+          <Input
+            autoFocus={true}
+            small={true}
+            style={styleInput}
+            ref={this._setRef}
+            hintText='Write a message'
+            hideUnderline={true}
+            onChangeText={this._onChangeText}
+            onSubmitEditing={this._onSubmit}
+            value={this.state.text}
+            multiline={false}
+          />
+          <Icon onClick={this._openFilePicker} style={styleIcon} type='iconfont-attachment' />
+        </Box>
+      </Box>
+    )
+  }
+}
+
+const styleInput = {
+  flex: 1,
+  marginLeft: globalMargins.tiny,
+  marginRight: globalMargins.tiny,
+  marginTop: globalMargins.tiny,
+}
+
+const styleIcon = {
+  paddingRight: globalMargins.tiny,
+  paddingTop: globalMargins.tiny,
+}
+
+export default ConversationInput

--- a/shared/chat/dumb.js
+++ b/shared/chat/dumb.js
@@ -183,10 +183,12 @@ const header = {
   mocks: {
     'Normal': {
       ...commonConvoProps,
+      onBack: () => console.log('back clicked'),
     },
     'Muted': {
       ...commonConvoProps,
       muted: true,
+      onBack: () => console.log('back clicked'),
     },
   },
 }
@@ -204,9 +206,6 @@ const input = {
       parentProps: {style: {height: 370, paddingTop: 330}},
     },
     */
-    'Empty': {
-      ...emptyConvoProps,
-    },
   },
 }
 

--- a/shared/common-adapters/input.js.flow
+++ b/shared/common-adapters/input.js.flow
@@ -16,7 +16,6 @@ export type Props = Exact<{
   onClick?: (event: Event) => void,
   onChangeText?: (text: string) => void,
   onEnterKeyDown?: (event: Object) => void,
-  onSubmitEditing?: () => void,
   onKeyDown?: (event: Object) => void,
   rowsMax?: number,
   maxLength?: number,

--- a/shared/common-adapters/input.js.flow
+++ b/shared/common-adapters/input.js.flow
@@ -16,6 +16,7 @@ export type Props = Exact<{
   onClick?: (event: Event) => void,
   onChangeText?: (text: string) => void,
   onEnterKeyDown?: (event: Object) => void,
+  onSubmitEditing?: () => void,
   onKeyDown?: (event: Object) => void,
   rowsMax?: number,
   maxLength?: number,

--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -186,6 +186,7 @@ class Input extends Component<void, Props, State> {
       onChangeText: this._onChangeText,
       onFocus: this._onFocus,
       onKeyDown: this._onKeyDown,
+      onSubmitEditing: this.props.onSubmitEditing,
       placeholder: this.props.hintText,
       ref: r => { this._input = r },
       returnKeyType: this.props.returnKeyType,

--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -186,7 +186,7 @@ class Input extends Component<void, Props, State> {
       onChangeText: this._onChangeText,
       onFocus: this._onFocus,
       onKeyDown: this._onKeyDown,
-      onSubmitEditing: this.props.onSubmitEditing,
+      onSubmitEditing: this.props.onEnterKeyDown,
       placeholder: this.props.hintText,
       ref: r => { this._input = r },
       returnKeyType: this.props.returnKeyType,


### PR DESCRIPTION
@keybase/react-hackers 

Here's a simple implementation of the mobile chat input -- it's single line, since multiline would involve a separate button for submitting the written text and that's not in our screens.  It's hard to work on further until it's integrated, so let's get something basic in and iterate.

I found something surprising, maybe someone else knows the history here: we don't have anything bound to the `onSubmitEditing` prop (the callback for when you finish typing on an on-screen keyboard) on mobile, for any of our input widgets or in the common adapter.  So I added that prop to the Input component, and now pressing the return/finished button fires the callback.  Should we go through and add `onSubmitEditing` to our other mobile input components too, e.g. signup/login?  I think it's currently the case that you have to hit enter to make the keyboard go away on those screens, and then manually click the "Continue" button on each screen.