### PR TITLE
Fix showing a first timestamp at the start of a convo

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -1109,7 +1109,7 @@ function * _loadMoreMessages (action: LoadMoreMessages): SagaGenerator<any, any>
   yield put({type: 'chat:loadingMessages', payload: {conversationIDKey}})
 
   // We receive the list with edit/delete/etc already applied so lets filter that out
-  const messageTypes = Object.keys(CommonMessageType).filter(k => !['edit', 'delete', 'tlfname', 'headline', 'attachmentuploaded'].includes(k)).map(k => CommonMessageType[k])
+  const messageTypes = Object.keys(CommonMessageType).filter(k => !['edit', 'delete', 'headline', 'attachmentuploaded'].includes(k)).map(k => CommonMessageType[k])
 
   const thread = yield call(localGetThreadLocalRpcPromise, {param: {
     conversationID,


### PR DESCRIPTION
We had this working before -- there's a "tlfName" type message at the start of every conversation, and we were using the fact that this is an Unhandled message to trigger showing a leading timestamp before the first message, even though a timestamp is normally between two messages.

But then we added a filter for the type of messages we want to be told about inside a conversation, and we removed "tlfName" from the list, so we didn't get that leading Unhandled message anymore, and the first timestamp went away.

This PR just adds tlfName messages back in.  I verified that this gives us a leading timestamp again and doesn't appear to have any negative effects (e.g. I don't see any new error messages in chats).