### PR TITLE
fix log rotation

### DIFF
--- a/go/logger/file.go
+++ b/go/logger/file.go
@@ -186,7 +186,7 @@ func scanOldLogFiles(path string) ([]string, error) {
 		return nil, err
 	}
 	var res []string
-	re, err := regexp.Compile(`^` + regexp.QuoteMeta(fname) + `-\d{8}T\d{6}-\d{8}T\d{6}$`)
+	re, err := regexp.Compile(`^` + regexp.QuoteMeta(fname) + `-\d{8}T\d{6}(?:[Z-]\d{4})?-\d{8}T\d{6}(?:[Z-]\d{4})?$`)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
r? @maxtaco @patrickxb 

regex is sort of tested:

```
package main

import (
	"fmt"
	"regexp"
)

func main() {
	re := regexp.MustCompile(`-\d{8}T\d{6}(?:[Z-]\d{4})?-\d{8}T\d{6}(?:[Z-]\d{4})?$`)
	fmt.Printf("%q\n", re.FindAllStringSubmatch("keybase.kbfs.log-20170213T162521-20170213T163321", -1))
	fmt.Printf("%q\n", re.FindAllStringSubmatch("keybase.kbfs.log-20170214T103310-0600-20170214T142129-0600", -1))
	fmt.Printf("%q\n", re.FindAllStringSubmatch("keybase.kbfs.log-20170214T103310-0600-20170214T142129Z0600", -1))
	
}
```
```
[["-20170213T162521-20170213T163321"]]
[["-20170214T103310-0600-20170214T142129-0600"]]
[["-20170214T103310-0600-20170214T142129Z0600"]]

Program exited.
```

Related: https://github.com/keybase/client/pull/5837