### PR TITLE
clean up dead code in the Linux push script

### DIFF
--- a/packaging/linux/build_and_push_packages.sh
+++ b/packaging/linux/build_and_push_packages.sh
@@ -55,96 +55,60 @@ version="$(cat "$build_dir/VERSION")"
 if [ "$mode" = "devel" ] ; then
   echo "Devel mode does not push. Quitting."
   exit
+elif [ "$mode" != "prerelease" ] ; then
+  echo "Only the 'prerelease' mode is supported now."
+  exit 1
 fi
 
-# Two ways to release, server-ops and prerelease (S3).
+echo Doing a prerelease push to S3...
 
-release_serverops() {
-  echo Pushing to server-ops...
+# Parse the shared .s3cfg file and export the keys as environment variables.
+# (Our s3cmd commands would be happy to read that file directly if we put it
+# in /root, but the s3_index.sh script ends up running Go code that depends
+# on the variables.)
+export AWS_ACCESS_KEY="$(grep access_key ~/.s3cfg | awk '{print $3}')"
+export AWS_SECRET_KEY="$(grep secret_key ~/.s3cfg | awk '{print $3}')"
 
-  if [ "$mode" = staging ] ; then
-    deb_repo="$serverops_dir/prod/linux/deb_staging"
-    rpm_repo="$serverops_dir/prod/linux/rpm_staging"
-  elif [ "$mode" = production ] ; then
-    deb_repo="$serverops_dir/prod/linux/deb"
-    rpm_repo="$serverops_dir/prod/linux/rpm"
-  else
-    echo "WHAT IS '$mode' MODE? (╯°□°）╯︵ ┻━┻)"
-    exit 1
-  fi
+# Upload both repos to S3.
+echo Syncing the deb repo...
+s3cmd sync --add-header="Cache-Control:max-age=60" --delete-removed "$build_dir/deb_repo/repo/" "s3://$BUCKET_NAME/deb/"
+echo Syncing the rpm repo...
+s3cmd sync --add-header="Cache-Control:max-age=60" --delete-removed "$build_dir/rpm_repo/repo/" "s3://$BUCKET_NAME/rpm/"
 
-  "$here/../check_status_and_pull.sh" "$serverops_dir"
-  mkdir -p "$serverops_dir/prod/linux"
-  rm -rf "$deb_repo"
-  cp -r "$build_dir/deb_repo" "$deb_repo"
-  rm -rf "$rpm_repo"
-  cp -r "$build_dir/rpm_repo" "$rpm_repo"
-  git -C "$serverops_dir" add -A
-  git -C "$serverops_dir" commit -m "new Linux $mode packages, version $version"
-  git -C "$serverops_dir" push
+# For each .deb and .rpm file we just uploaded, unset the Cache-Control
+# header (because these files are large, and they have versioned names), and
+# also make a copy in /linux_binaries/{deb,rpm}.
+echo Unsetting .deb Cache-Control headers...
+dot_deb_blobs="$(s3cmd ls -r "s3://$BUCKET_NAME/deb" | awk '{print $4}' | grep '\.deb$')"
+for blob in $dot_deb_blobs ; do
+  s3cmd modify --remove-header "Cache-Control" "$blob"
+  s3cmd cp "$blob" "s3://$BUCKET_NAME/linux_binaries/deb/"
+done
+echo Unsetting .rpm Cache-Control headers...
+dot_rpm_blobs="$(s3cmd ls -r "s3://$BUCKET_NAME/rpm" | awk '{print $4}' | grep '\.rpm$')"
+for blob in $dot_rpm_blobs ; do
+  s3cmd modify --remove-header "Cache-Control" "$blob"
+  s3cmd cp "$blob" "s3://$BUCKET_NAME/linux_binaries/rpm/"
+done
 
-  echo "DON'T FORGET THE LAST STEP! ssh into dist and run:"
-  echo "  cd src/keybase/server-ops"
-  echo "  git pull"
-}
+# Make yet another copy of the .deb and .rpm packages we just made, in a
+# constant location for the friend-of-keybase instructions.
+s3cmd put --follow-symlinks "$build_dir/deb_repo/keybase-latest-amd64.deb" "s3://$BUCKET_NAME/keybase_amd64.deb"
+s3cmd put --follow-symlinks "$build_dir/deb_repo/keybase-latest-i386.deb" "s3://$BUCKET_NAME/keybase_i386.deb"
+s3cmd put --follow-symlinks "$build_dir/rpm_repo/keybase-latest-x86_64.rpm" "s3://$BUCKET_NAME/keybase_amd64.rpm"
+s3cmd put --follow-symlinks "$build_dir/rpm_repo/keybase-latest-i386.rpm" "s3://$BUCKET_NAME/keybase_i386.rpm"
 
-release_prerelease() {
-  echo Doing a prerelease push to S3...
+json_tmp=`mktemp`
+echo "Writing version into JSON to $json_tmp"
 
-  # Parse the shared .s3cfg file and export the keys as environment variables.
-  # (Our s3cmd commands would be happy to read that file directly if we put it
-  # in /root, but the s3_index.sh script ends up running Go code that depends
-  # on the variables.)
-  export AWS_ACCESS_KEY="$(grep access_key ~/.s3cfg | awk '{print $3}')"
-  export AWS_SECRET_KEY="$(grep secret_key ~/.s3cfg | awk '{print $3}')"
+"$release_bin" update-json --version="$version" > "$json_tmp"
 
-  # Upload both repos to S3.
-  echo Syncing the deb repo...
-  s3cmd sync --add-header="Cache-Control:max-age=60" --delete-removed "$build_dir/deb_repo/repo/" "s3://$BUCKET_NAME/deb/"
-  echo Syncing the rpm repo...
-  s3cmd sync --add-header="Cache-Control:max-age=60" --delete-removed "$build_dir/rpm_repo/repo/" "s3://$BUCKET_NAME/rpm/"
+s3cmd put --mime-type application/json "$json_tmp" "s3://$BUCKET_NAME/update-linux-prod.json"
 
-  # For each .deb and .rpm file we just uploaded, unset the Cache-Control
-  # header (because these files are large, and they have versioned names), and
-  # also make a copy in /linux_binaries/{deb,rpm}.
-  echo Unsetting .deb Cache-Control headers...
-  dot_deb_blobs="$(s3cmd ls -r "s3://$BUCKET_NAME/deb" | awk '{print $4}' | grep '\.deb$')"
-  for blob in $dot_deb_blobs ; do
-    s3cmd modify --remove-header "Cache-Control" "$blob"
-    s3cmd cp "$blob" "s3://$BUCKET_NAME/linux_binaries/deb/"
-  done
-  echo Unsetting .rpm Cache-Control headers...
-  dot_rpm_blobs="$(s3cmd ls -r "s3://$BUCKET_NAME/rpm" | awk '{print $4}' | grep '\.rpm$')"
-  for blob in $dot_rpm_blobs ; do
-    s3cmd modify --remove-header "Cache-Control" "$blob"
-    s3cmd cp "$blob" "s3://$BUCKET_NAME/linux_binaries/rpm/"
-  done
+# Generate and push the index.html file. S3 pushes in this script can be
+# flakey, and on the Linux side of things all this does is update our
+# internal pages, so we suppress errors here.
+GOPATH="$release_gopath" PLATFORM="linux" "$here/../prerelease/s3_index.sh" || \
+  echo "ERROR in s3_index.sh. Internal pages might not be updated. Build continuing..."
 
-  # Make yet another copy of the .deb and .rpm packages we just made, in a
-  # constant location for the friend-of-keybase instructions.
-  s3cmd put --follow-symlinks "$build_dir/deb_repo/keybase-latest-amd64.deb" "s3://$BUCKET_NAME/keybase_amd64.deb"
-  s3cmd put --follow-symlinks "$build_dir/deb_repo/keybase-latest-i386.deb" "s3://$BUCKET_NAME/keybase_i386.deb"
-  s3cmd put --follow-symlinks "$build_dir/rpm_repo/keybase-latest-x86_64.rpm" "s3://$BUCKET_NAME/keybase_amd64.rpm"
-  s3cmd put --follow-symlinks "$build_dir/rpm_repo/keybase-latest-i386.rpm" "s3://$BUCKET_NAME/keybase_i386.rpm"
-
-  json_tmp=`mktemp`
-  echo "Writing version into JSON to $json_tmp"
-
-  "$release_bin" update-json --version="$version" > "$json_tmp"
-
-  s3cmd put --mime-type application/json "$json_tmp" "s3://$BUCKET_NAME/update-linux-prod.json"
-
-  # Generate and push the index.html file. S3 pushes in this script can be
-  # flakey, and on the Linux side of things all this does is update our
-  # internal pages, so we suppress errors here.
-  GOPATH="$release_gopath" PLATFORM="linux" "$here/../prerelease/s3_index.sh" || \
-    echo "ERROR in s3_index.sh. Internal pages might not be updated. Build continuing..."
-
-  "$here/arch/update_aur_packages.sh" "$build_dir"
-}
-
-if [ "$mode" = "prerelease" ] ; then
-  release_prerelease
-else
-  release_serverops
-fi
+"$here/arch/update_aur_packages.sh" "$build_dir"


### PR DESCRIPTION
~Clients with cached repo data might try to fetch older binaries, and we
prefer to let them do that rather than giving them nasty errors. They
should eventually get the latest stuff when they run the equivalent of
`apt-get update`.~

~Fixes https://github.com/keybase/keybase-issues/issues/2816.~

Also clean up some dead code while we're at it. Might be easiest to look one commit at a time.

I tested the changes on my own S3 bucket by setting BUCKET_NAME and deleting some of the other steps first, so it "might work". My current plan it to babysit the build tomorrow to make sure.

r? @cjb 