### PR TITLE
Fix colors on profile view followers/following

### DIFF
--- a/shared/profile/friendships.desktop.js
+++ b/shared/profile/friendships.desktop.js
@@ -34,7 +34,7 @@ class UserEntry extends PureComponent<void, UserEntryProps, void> {
 
     return <Box style={userEntryContainerStyle} onClick={this._onClick}>
       <Avatar style={userEntryAvatarStyle} size={64} url={thumbnailUrl} followsYou={followsYou} following={following} />
-      <Text type='BodySemibold' style={userEntryUsernameStyle(followsYou)}>{username}</Text>
+      <Text type='BodySemibold' style={userEntryUsernameStyle(following)}>{username}</Text>
     </Box>
   }
 }
@@ -54,8 +54,8 @@ const userEntryAvatarStyle = {
   marginBottom: 2,
 }
 
-const userEntryUsernameStyle = followsYou => ({
-  color: followsYou ? globalColors.green : globalColors.blue,
+const userEntryUsernameStyle = following => ({
+  color: following ? globalColors.green : globalColors.blue,
   textAlign: 'center',
 })
 


### PR DESCRIPTION
@keybase/react-hackers

For the *Followers* tab in the profile, we were doing:
```
  green: they follow you (this is everyone, else they wouldn't be in the tab)
  blue: they don't follow you
```
When we should have been doing:
```
  green: you follow them
  blue: you don't follow them
```
This PR fixes that.

Now everyone in the *Following* tab is green instead, since if you didn't follow them they wouldn't be in that tab.  I can see an argument for doing:
```
  Followers tab:
    green: you follow them back
    blue: you don't follow them back

  Following tab:
    green: they follow you back
    blue: they don't follow you back
```
But I'm guessing we don't want to do that -- while it would make the colors more useful in both tabs, it changes the semantic meaning of green from "you follow them" to "there is a reciprocal follow relationship".  I'll assume we don't want to do that.