### PR TITLE
Report error saving plist

### DIFF
--- a/go/launchd/launchd.go
+++ b/go/launchd/launchd.go
@@ -277,7 +277,9 @@ func (s Service) savePlist(p Plist) error {
 }
 
 func (s Service) install(p Plist, wait time.Duration) error {
-	s.savePlist(p)
+	if err := s.savePlist(p); err != nil {
+		return err
+	}
 	return s.Start(wait)
 }
 


### PR DESCRIPTION
In certain rare scenarios, a user might not have permission to write to ~/Library/LaunchAgents (usually because of another program creating this folder as root).

This fixes so we have the correct error message which makes responding to these error reports way easier.