### PR TITLE
Use new message key format in markSeenMessage action

### DIFF
--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -245,12 +245,13 @@ function reducer (state: State = initialState, action: Actions) {
     }
     case 'chat:markSeenMessage': {
       const {messageID, conversationIDKey} = action.payload
+      const messageKey = Constants.messageKey('messageID', messageID)
       // $FlowIssue
       return state.update('conversationStates', conversationStates => updateConversation(
         conversationStates,
         conversationIDKey,
         // $FlowIssue
-        conversation => conversation.update('seenMessages', seenMessages => seenMessages.add(messageID))
+        conversation => conversation.update('seenMessages', seenMessages => seenMessages.add(messageKey))
       ))
     }
     case 'chat:createPendingFailure': {


### PR DESCRIPTION
Fixes attachment upload duplicate message, and possibly other bugs.

:eyeglasses: @keybase/react-hackers 