### PR TITLE
handle gregor messages off RPC path, and fix handling hard unbox errors in newMessage CORE-4617

### DIFF
--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -157,7 +157,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 		uid := m.UID().Bytes()
 
 		var conv *chat1.ConversationLocal
-		decmsg, appended, err := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
+		decmsg, appended, pushErr := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
 		if err != nil {
 			g.Debug(ctx, "chat activity: unable to storage message: %s", err.Error())
 		}
@@ -165,26 +165,35 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 			g.Debug(ctx, "chat activity: unable to update inbox: %s", err.Error())
 		}
 
-		// Make a pagination object so client can use it in GetThreadLocal
-		pmsgs := []pager.Message{nm.Message}
-		pager := pager.NewThreadPager()
-		page, err := pager.MakePage(pmsgs, 1)
-		if err != nil {
-			g.Debug(ctx, "chat activity: error making page: %s", err.Error())
+		// If we have no error on this message, then notify the frontend
+		if pushErr == nil {
+			// Make a pagination object so client can use it in GetThreadLocal
+			pmsgs := []pager.Message{nm.Message}
+			pager := pager.NewThreadPager()
+			page, err := pager.MakePage(pmsgs, 1)
+			if err != nil {
+				g.Debug(ctx, "chat activity: error making page: %s", err.Error())
+			}
+			activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
+				Message:    decmsg,
+				ConvID:     nm.ConvID,
+				Conv:       conv,
+				Pagination: page,
+			})
 		}
-
-		activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
-			Message:    decmsg,
-			ConvID:     nm.ConvID,
-			Conv:       conv,
-			Pagination: page,
-		})
 
 		// If this message was not "appended", meaning there is a hole between what we have in cache,
 		// and this message, then we send out a notification that this thread should be considered
-		// stale
-		if !appended {
-			g.Debug(ctx, "chat activity: newMessage: non-append message, alerting")
+		// stale.
+		// We also get here if we had an error unboxing the messages, it could be a temporal thing
+		// so the frontend should reload.
+		if !appended || pushErr != nil {
+			if !appended {
+				g.Debug(ctx, "chat activity: newMessage: non-append message, alerting")
+			}
+			if pushErr != nil {
+				g.Debug(ctx, "chat acitivity: newMessage: push error, alerting")
+			}
 			kuid := keybase1.UID(m.UID().String())
 			g.G().NotifyRouter.HandleChatThreadsStale(context.Background(), kuid,
 				[]chat1.ConversationID{nm.ConvID})

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -159,7 +159,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 		var conv *chat1.ConversationLocal
 		decmsg, appended, pushErr := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
 		if err != nil {
-			g.Debug(ctx, "chat activity: unable to storage message: %s", err.Error())
+			g.Debug(ctx, "chat activity: unable to push message: %s", err.Error())
 		}
 		if conv, err = g.G().InboxSource.NewMessage(ctx, uid, nm.InboxVers, nm.ConvID, nm.Message); err != nil {
 			g.Debug(ctx, "chat activity: unable to update inbox: %s", err.Error())
@@ -192,7 +192,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 				g.Debug(ctx, "chat activity: newMessage: non-append message, alerting")
 			}
 			if pushErr != nil {
-				g.Debug(ctx, "chat acitivity: newMessage: push error, alerting")
+				g.Debug(ctx, "chat activity: newMessage: push error, alerting")
 			}
 			kuid := keybase1.UID(m.UID().String())
 			g.G().NotifyRouter.HandleChatThreadsStale(context.Background(), kuid,

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -571,7 +571,7 @@ func (g *gregorHandler) ShouldRetryOnConnect(err error) bool {
 	return true
 }
 
-func (g *gregorHandler) broadtcastMessageOnce(ctx context.Context, m gregor1.Message) error {
+func (g *gregorHandler) broadcastMessageOnce(ctx context.Context, m gregor1.Message) error {
 	g.Lock()
 	defer g.Unlock()
 
@@ -629,8 +629,9 @@ func (g *gregorHandler) broadcastMessageHandler() {
 	ctx := context.Background()
 	for {
 		m := <-g.broadcastCh
-		err := g.broadtcastMessageOnce(ctx, m)
+		err := g.broadcastMessageOnce(ctx, m)
 
+		// Testing alerts
 		if g.testingEvents != nil {
 			g.testingEvents.broadcastSentCh <- err
 		}


### PR DESCRIPTION
This patch does two things:

1.) Handles incoming Gregor messages on a separate thread in order to avoid timing out Gregor's call into the service. If Gregor does this, then the call gets stopped because of the context being cancelled. Instead, process these messages in the background (still in order because of the channel).
2.) If we get a hard error out of `Boxer.UnboxMessage`, then don't send a normal new message call up to the frontend. Instead, just get them to reload the thread.

cc @cjb @malgorithms  (this fixes the problem we saw on Friday with phantom message)