### PR TITLE
dont error out on no public key on tlf finalize path CORE-4622

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -266,7 +266,8 @@ func newBaseInboxSource(g *libkb.GlobalContext) *baseInboxSource {
 func (b *baseInboxSource) notifyTlfFinalize(ctx context.Context, username string) {
 	// Let the rest of the system know this user has changed
 	finalizeUser, err := libkb.LoadUser(libkb.LoadUserArg{
-		Name: username,
+		Name:              username,
+		PublicKeyOptional: true,
 	})
 	if err != nil {
 		b.Debug(ctx, "notifyTlfFinalize: failed to load finalize user, skipping user changed notification: err: %s", err.Error())


### PR DESCRIPTION
Users essentially never had public keys when we get to `notifyTlfFinalize`, because it triggers immediately after a user does an account reset. If we fail here, then we end up not calling `UserChanged` on `G`, and then as a result we do not clear out the users from the `CachedUPAKLoader`. This results in a bunch of `Bad Key Errors` for the reset user until we naturally clear the UPAK cache some other way. 

cc @maxtaco 