### PR TITLE
Less conversation list thrash on append

### DIFF
--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -449,7 +449,11 @@ class ConversationList extends Component<void, Props, State> {
     }
   }
 
-  _cellRangeRenderer = options => chatCellRangeRenderer(this.state.messages.count(), this._cellCache, options)
+  _cellRangeRenderer = options => {
+    const message = this.state.messages.get(cellMessageStartIndex)
+    const firstKey = message.key || '0'
+    return chatCellRangeRenderer(firstKey, this._cellCache, options)
+  }
 
   render () {
     if (!this.props.validated) {
@@ -533,8 +537,8 @@ const listStyle = {
   paddingBottom: listBottomMargin,
 }
 
-let lastMessageCount
-function chatCellRangeRenderer (messageCount: number, cellSizeCache: any, {
+let lastFirstKey
+function chatCellRangeRenderer (firstKey: string, cellSizeCache: any, {
   cellCache,
   cellRenderer,
   columnSizeAndPositionManager,
@@ -556,8 +560,9 @@ function chatCellRangeRenderer (messageCount: number, cellSizeCache: any, {
   const offsetAdjusted = verticalOffsetAdjustment || horizontalOffsetAdjustment
   const canCacheStyle = !isScrolling || !offsetAdjusted
 
-  if (messageCount !== lastMessageCount) {
-    lastMessageCount = messageCount
+  // Only if the list is prepended to does it cause all this redrawing
+  if (firstKey !== lastFirstKey) {
+    lastFirstKey = firstKey
     rowSizeAndPositionManager.resetCell(0)
     cellSizeCache.clearAllRowHeights()
   }
@@ -574,7 +579,7 @@ function chatCellRangeRenderer (messageCount: number, cellSizeCache: any, {
         rowIndex <= visibleRowIndices.stop
       )
 
-      let key = `${rowIndex}-${messageCount}`
+      let key = `${rowIndex}-${firstKey}`
       let style
 
       // Cache style objects so shallow-compare doesn't re-render unnecessarily.


### PR DESCRIPTION
This is a short term fix. When we append the messageCount goes up, which causes the keys to thrash and all the calcs to be tossed out. We really only want that to happen (maybe) when the list is appended to (else the keys will get mixed up). Instead we key the second part of the key with the first item's key which doesn't mutate on an append.

Ultimately i think we should move away from this library or use it in a different way. 

@keybase/react-hackers 