### PR TITLE
fix cased/uncased username clash in cached track list

### DIFF
--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -28,22 +28,22 @@ type chatListener struct {
 
 var _ libkb.NotifyListener = (*chatListener)(nil)
 
-func (n *chatListener) Logout()                                                      {}
-func (n *chatListener) Login(username string)                                        {}
-func (n *chatListener) ClientOutOfDate(to, uri, msg string)                          {}
-func (n *chatListener) UserChanged(uid keybase1.UID)                                 {}
-func (n *chatListener) TrackingChanged(uid keybase1.UID, username string)            {}
-func (n *chatListener) FSActivity(activity keybase1.FSNotification)                  {}
-func (n *chatListener) FSEditListResponse(arg keybase1.FSEditListArg)                {}
-func (n *chatListener) FSEditListRequest(arg keybase1.FSEditListRequest)             {}
-func (n *chatListener) FSSyncStatusResponse(arg keybase1.FSSyncStatusArg)            {}
-func (n *chatListener) FSSyncEvent(arg keybase1.FSPathSyncStatus)                    {}
-func (n *chatListener) PaperKeyCached(uid keybase1.UID, encKID, sigKID keybase1.KID) {}
-func (n *chatListener) FavoritesChanged(uid keybase1.UID)                            {}
-func (n *chatListener) KeyfamilyChanged(uid keybase1.UID)                            {}
-func (n *chatListener) PGPKeyInSecretStoreFile()                                     {}
-func (n *chatListener) BadgeState(badgeState keybase1.BadgeState)                    {}
-func (n *chatListener) ReachabilityChanged(r keybase1.Reachability)                  {}
+func (n *chatListener) Logout()                                                             {}
+func (n *chatListener) Login(username string)                                               {}
+func (n *chatListener) ClientOutOfDate(to, uri, msg string)                                 {}
+func (n *chatListener) UserChanged(uid keybase1.UID)                                        {}
+func (n *chatListener) TrackingChanged(uid keybase1.UID, username libkb.NormalizedUsername) {}
+func (n *chatListener) FSActivity(activity keybase1.FSNotification)                         {}
+func (n *chatListener) FSEditListResponse(arg keybase1.FSEditListArg)                       {}
+func (n *chatListener) FSEditListRequest(arg keybase1.FSEditListRequest)                    {}
+func (n *chatListener) FSSyncStatusResponse(arg keybase1.FSSyncStatusArg)                   {}
+func (n *chatListener) FSSyncEvent(arg keybase1.FSPathSyncStatus)                           {}
+func (n *chatListener) PaperKeyCached(uid keybase1.UID, encKID, sigKID keybase1.KID)        {}
+func (n *chatListener) FavoritesChanged(uid keybase1.UID)                                   {}
+func (n *chatListener) KeyfamilyChanged(uid keybase1.UID)                                   {}
+func (n *chatListener) PGPKeyInSecretStoreFile()                                            {}
+func (n *chatListener) BadgeState(badgeState keybase1.BadgeState)                           {}
+func (n *chatListener) ReachabilityChanged(r keybase1.Reachability)                         {}
 func (n *chatListener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks) {
 	n.identifyUpdate <- update
 }

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -149,7 +149,7 @@ func loadIdentifyUser(ctx *Context, g *libkb.GlobalContext, arg libkb.LoadUserAr
 	return ret, err
 }
 
-func (i *identifyUser) trackChainLinkFor(ctx context.Context, name string, uid keybase1.UID, g *libkb.GlobalContext) (ret *libkb.TrackChainLink, err error) {
+func (i *identifyUser) trackChainLinkFor(ctx context.Context, name libkb.NormalizedUsername, uid keybase1.UID, g *libkb.GlobalContext) (ret *libkb.TrackChainLink, err error) {
 	defer g.CTrace(ctx, fmt.Sprintf("identifyUser#trackChainLinkFor(%s)", name), func() error { return err })()
 
 	if i.full != nil {
@@ -166,7 +166,7 @@ func (i *identifyUser) trackChainLinkFor(ctx context.Context, name string, uid k
 		// go ahead and load that chain link from local level DB, and it's almost
 		// always going to be there, since it was written as a side effect of
 		// fetching the full user. There's a corner case, see just below...
-		ret, err = libkb.TrackChainLinkFromUserPlusAllKeys(i.thin, libkb.NewNormalizedUsername(name), uid, g)
+		ret, err = libkb.TrackChainLinkFromUserPlusAllKeys(i.thin, name, uid, g)
 		if _, inconsistent := err.(libkb.InconsistentCacheStateError); !inconsistent {
 			g.Log.CDebugf(ctx, "| returning in common case -> (found=%v, err=%v)", (ret != nil), err)
 			return ret, err
@@ -745,7 +745,7 @@ func (e *Identify2WithUID) createIdentifyState(ctx *Context) (err error) {
 		return nil
 	}
 
-	tcl, err := e.me.trackChainLinkFor(ctx.GetNetContext(), them.GetName(), them.GetUID(), e.G())
+	tcl, err := e.me.trackChainLinkFor(ctx.GetNetContext(), them.GetNormalizedName(), them.GetUID(), e.G())
 	if tcl != nil {
 		e.G().Log.Debug("| using track token %s", tcl.LinkID())
 		e.useTracking = true

--- a/go/engine/list_tracking.go
+++ b/go/engine/list_tracking.go
@@ -241,7 +241,7 @@ func condenseRecord(l *libkb.TrackChainLink) (*jsonw.Wrapper, error) {
 	out.SetKey("uid", libkb.UIDWrapper(uid))
 	out.SetKey("keys", jsonw.NewString(strings.Join(fpsDisplay, ", ")))
 	out.SetKey("ctime", jsonw.NewInt64(l.GetCTime().Unix()))
-	out.SetKey("username", jsonw.NewString(un))
+	out.SetKey("username", jsonw.NewString(un.String()))
 	out.SetKey("proofs", rp)
 
 	return out, nil

--- a/go/engine/paperkey_submit_test.go
+++ b/go/engine/paperkey_submit_test.go
@@ -86,16 +86,16 @@ type nlistener struct {
 
 var _ libkb.NotifyListener = (*nlistener)(nil)
 
-func (n *nlistener) Logout()                                                       {}
-func (n *nlistener) Login(username string)                                         {}
-func (n *nlistener) ClientOutOfDate(to, uri, msg string)                           {}
-func (n *nlistener) UserChanged(uid keybase1.UID)                                  {}
-func (n *nlistener) TrackingChanged(uid keybase1.UID, username string)             {}
-func (n *nlistener) FSActivity(activity keybase1.FSNotification)                   {}
-func (n *nlistener) FSEditListResponse(arg keybase1.FSEditListArg)                 {}
-func (n *nlistener) FSEditListRequest(arg keybase1.FSEditListRequest)              {}
-func (n *nlistener) FavoritesChanged(uid keybase1.UID)                             {}
-func (n *nlistener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActivity) {}
+func (n *nlistener) Logout()                                                             {}
+func (n *nlistener) Login(username string)                                               {}
+func (n *nlistener) ClientOutOfDate(to, uri, msg string)                                 {}
+func (n *nlistener) UserChanged(uid keybase1.UID)                                        {}
+func (n *nlistener) TrackingChanged(uid keybase1.UID, username libkb.NormalizedUsername) {}
+func (n *nlistener) FSActivity(activity keybase1.FSNotification)                         {}
+func (n *nlistener) FSEditListResponse(arg keybase1.FSEditListArg)                       {}
+func (n *nlistener) FSEditListRequest(arg keybase1.FSEditListRequest)                    {}
+func (n *nlistener) FavoritesChanged(uid keybase1.UID)                                   {}
+func (n *nlistener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActivity)       {}
 func (n *nlistener) PaperKeyCached(uid keybase1.UID, encKID, sigKID keybase1.KID) {
 	n.paperEncKIDs = append(n.paperEncKIDs, encKID)
 }

--- a/go/engine/pgp_test.go
+++ b/go/engine/pgp_test.go
@@ -156,7 +156,7 @@ func (p *pgpPair) isTracking(meContext libkb.TestContext, username string) bool 
 	if err != nil {
 		p.t.Fatal(err)
 	}
-	s, err := me.TrackChainLinkFor(them.GetName(), them.GetUID())
+	s, err := me.TrackChainLinkFor(them.GetNormalizedName(), them.GetUID())
 	if err != nil {
 		p.t.Fatal(err)
 	}

--- a/go/engine/track_proof_test.go
+++ b/go/engine/track_proof_test.go
@@ -43,7 +43,7 @@ func checkTrackCommon(tc libkb.TestContext, blocks []sb, outcome *keybase1.Ident
 	if them == nil {
 		tc.T.Fatal("checkTrackCommon called with nil 'them' user")
 	}
-	s, err := me.TrackChainLinkFor(them.GetName(), them.GetUID())
+	s, err := me.TrackChainLinkFor(them.GetNormalizedName(), them.GetUID())
 	if err != nil {
 		return err
 	}

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -44,7 +44,7 @@ func assertTracking(tc libkb.TestContext, username string) {
 	if err != nil {
 		tc.T.Fatal(err)
 	}
-	s, err := me.TrackChainLinkFor(them.GetName(), them.GetUID())
+	s, err := me.TrackChainLinkFor(them.GetNormalizedName(), them.GetUID())
 	if err != nil {
 		tc.T.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func assertNotTracking(tc libkb.TestContext, username string) {
 	if err != nil {
 		tc.T.Fatal(err)
 	}
-	s, err := me.TrackChainLinkFor(them.GetName(), them.GetUID())
+	s, err := me.TrackChainLinkFor(them.GetNormalizedName(), them.GetUID())
 	if err != nil {
 		tc.T.Fatal(err)
 	}
@@ -282,7 +282,7 @@ func TestTrackLocal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := me.TrackChainLinkFor(them.GetName(), them.GetUID())
+	s, err := me.TrackChainLinkFor(them.GetNormalizedName(), them.GetUID())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/track_token.go
+++ b/go/engine/track_token.go
@@ -131,8 +131,8 @@ func (e *TrackToken) Run(ctx *Context) (err error) {
 		e.G().UserChanged(e.arg.Me.GetUID())
 
 		// Keep these:
-		e.G().NotifyRouter.HandleTrackingChanged(e.arg.Me.GetUID(), e.arg.Me.GetName(), false)
-		e.G().NotifyRouter.HandleTrackingChanged(e.them.GetUID(), e.them.GetName(), true)
+		e.G().NotifyRouter.HandleTrackingChanged(e.arg.Me.GetUID(), e.arg.Me.GetNormalizedName(), false)
+		e.G().NotifyRouter.HandleTrackingChanged(e.them.GetUID(), e.them.GetNormalizedName(), true)
 
 		// Dismiss any associated gregor item.
 		if outcome.ResponsibleGregorItem != nil {
@@ -180,8 +180,8 @@ func (e *TrackToken) loadMe() error {
 	return nil
 }
 
-func (e *TrackToken) loadThem(username string) error {
-	them, err := libkb.LoadUser(libkb.NewLoadUserByNameArg(e.G(), username))
+func (e *TrackToken) loadThem(username libkb.NormalizedUsername) error {
+	them, err := libkb.LoadUser(libkb.NewLoadUserByNameArg(e.G(), username.String()))
 	if err != nil {
 		return err
 	}

--- a/go/engine/untrack.go
+++ b/go/engine/untrack.go
@@ -9,7 +9,7 @@ import (
 )
 
 type UntrackEngineArg struct {
-	Username string
+	Username libkb.NormalizedUsername
 	Me       *libkb.User
 }
 
@@ -102,8 +102,8 @@ func (e *UntrackEngine) Run(ctx *Context) (err error) {
 	e.G().UserChanged(e.arg.Me.GetUID())
 	e.G().UserChanged(them.GetUID())
 
-	e.G().NotifyRouter.HandleTrackingChanged(e.arg.Me.GetUID(), e.arg.Me.GetName(), false)
-	e.G().NotifyRouter.HandleTrackingChanged(them.GetUID(), them.GetName(), false)
+	e.G().NotifyRouter.HandleTrackingChanged(e.arg.Me.GetUID(), e.arg.Me.GetNormalizedName(), false)
+	e.G().NotifyRouter.HandleTrackingChanged(them.GetUID(), them.GetNormalizedName(), false)
 
 	return
 }
@@ -129,7 +129,7 @@ func (e *UntrackEngine) loadThem() (them *libkb.User, remoteLink, localLink *lib
 	}
 
 	if uid.IsNil() {
-		res := e.G().Resolver.Resolve(e.arg.Username)
+		res := e.G().Resolver.Resolve(e.arg.Username.String())
 		if err = res.GetError(); err != nil {
 			return
 		}
@@ -158,13 +158,13 @@ func (e *UntrackEngine) loadThem() (them *libkb.User, remoteLink, localLink *lib
 			return
 		}
 
-		var trackedUsername string
+		var trackedUsername libkb.NormalizedUsername
 		trackedUsername, err = lLink.GetTrackedUsername()
 		if err != nil {
 			return
 		}
 
-		if e.arg.Username != trackedUsername {
+		if !e.arg.Username.Eq(trackedUsername) {
 			err = libkb.NewUntrackError("Username mismatch: expected @%s, got @%s", e.arg.Username, trackedUsername)
 			return
 		}
@@ -172,7 +172,7 @@ func (e *UntrackEngine) loadThem() (them *libkb.User, remoteLink, localLink *lib
 		uidTrusted = true
 	}
 
-	them = libkb.NewUserThin(e.arg.Username, uid)
+	them = libkb.NewUserThin(e.arg.Username.String(), uid)
 	remoteLink = rLink
 	localLink = lLink
 	return

--- a/go/engine/untrack_test.go
+++ b/go/engine/untrack_test.go
@@ -12,7 +12,7 @@ import (
 
 func runUntrack(g *libkb.GlobalContext, fu *FakeUser, username string) error {
 	arg := UntrackEngineArg{
-		Username: username,
+		Username: libkb.NewNormalizedUsername(username),
 	}
 	ctx := Context{
 		LogUI:    g.UI.GetLogUI(),
@@ -32,7 +32,7 @@ func assertUntracked(tc libkb.TestContext, username string) {
 		tc.T.Fatal(err)
 	}
 
-	s, err := me.TrackChainLinkFor(them.GetName(), them.GetUID())
+	s, err := me.TrackChainLinkFor(them.GetNormalizedName(), them.GetUID())
 	if err != nil {
 		tc.T.Fatal(err)
 	}

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1270,7 +1270,7 @@ func (e IdentifyFailedError) Error() string {
 //=============================================================================
 
 type IdentifySummaryError struct {
-	username string
+	username NormalizedUsername
 	problems []string
 }
 

--- a/go/libkb/identify_outcome.go
+++ b/go/libkb/identify_outcome.go
@@ -13,7 +13,7 @@ import (
 )
 
 type IdentifyOutcome struct {
-	Username              string
+	Username              NormalizedUsername
 	Error                 error
 	KeyDiffs              []TrackDiff
 	Revoked               []TrackDiff
@@ -31,7 +31,7 @@ func NewIdentifyOutcome() *IdentifyOutcome {
 	return &IdentifyOutcome{}
 }
 
-func NewIdentifyOutcomeWithUsername(u string) *IdentifyOutcome {
+func NewIdentifyOutcomeWithUsername(u NormalizedUsername) *IdentifyOutcome {
 	return &IdentifyOutcome{Username: u}
 }
 

--- a/go/libkb/identify_state.go
+++ b/go/libkb/identify_state.go
@@ -17,13 +17,13 @@ type IdentifyState struct {
 
 func NewIdentifyState(res *IdentifyOutcome, u *User) IdentifyState {
 	if res == nil {
-		res = NewIdentifyOutcomeWithUsername(u.GetName())
+		res = NewIdentifyOutcomeWithUsername(u.GetNormalizedName())
 	}
 	return IdentifyState{res: res, u: u}
 }
 
 func NewIdentifyStateWithGregorItem(item gregor.Item, u *User) IdentifyState {
-	res := NewIdentifyOutcomeWithUsername(u.GetName())
+	res := NewIdentifyOutcomeWithUsername(u.GetNormalizedName())
 	res.ResponsibleGregorItem = item
 	return IdentifyState{res: res, u: u}
 }

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -31,7 +31,7 @@ type NotifyListener interface {
 	Login(username string)
 	ClientOutOfDate(to, uri, msg string)
 	UserChanged(uid keybase1.UID)
-	TrackingChanged(uid keybase1.UID, username string)
+	TrackingChanged(uid keybase1.UID, username NormalizedUsername)
 	FSActivity(activity keybase1.FSNotification)
 	FSEditListResponse(arg keybase1.FSEditListArg)
 	FSSyncStatusResponse(arg keybase1.FSSyncStatusArg)
@@ -245,13 +245,13 @@ func (n *NotifyRouter) HandleUserChanged(uid keybase1.UID) {
 // untracking chain link related to a given user. It will broadcast the
 // messages to all curious listeners.
 // isTracking is set to true if current user is tracking uid.
-func (n *NotifyRouter) HandleTrackingChanged(uid keybase1.UID, username string, isTracking bool) {
+func (n *NotifyRouter) HandleTrackingChanged(uid keybase1.UID, username NormalizedUsername, isTracking bool) {
 	if n == nil {
 		return
 	}
 	arg := keybase1.TrackingChangedArg{
 		Uid:        uid,
-		Username:   username,
+		Username:   username.String(),
 		IsTracking: isTracking,
 	}
 	// For all connections we currently have open...

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -289,7 +289,7 @@ func ImportStatusAsError(s *keybase1.Status) error {
 		ret := IdentifySummaryError{}
 		for _, pair := range s.Fields {
 			if pair.Key == "username" {
-				ret.username = pair.Value
+				ret.username = NewNormalizedUsername(pair.Value)
 			} else {
 				// The other keys are expected to be "problem_%d".
 				ret.problems = append(ret.problems, pair.Value)
@@ -596,10 +596,10 @@ func (ir *IdentifyOutcome) Export() *keybase1.IdentifyOutcome {
 		del[i] = *ExportTrackDiff(d)
 	}
 	ret := &keybase1.IdentifyOutcome{
-		Username:          ir.Username,
+		Username:          ir.Username.String(),
 		Status:            ExportErrorAsStatus(ir.Error),
 		Warnings:          v,
-		TrackUsed:         ExportTrackSummary(ir.TrackUsed, ir.Username),
+		TrackUsed:         ExportTrackSummary(ir.TrackUsed, ir.Username.String()),
 		TrackStatus:       ir.TrackStatus(),
 		NumTrackFailures:  ir.NumTrackFailures(),
 		NumTrackChanges:   ir.NumTrackChanges(),
@@ -1035,7 +1035,7 @@ func (i LinkID) Export() keybase1.LinkID {
 func (t TrackChainLink) Export() keybase1.RemoteTrack {
 	return keybase1.RemoteTrack{
 		Uid:      t.whomUID,
-		Username: strings.ToLower(t.whomUsername),
+		Username: t.whomUsername.String(),
 		LinkID:   t.id.Export(),
 	}
 }
@@ -1272,7 +1272,7 @@ func (e IdentifyFailedError) ToStatus() keybase1.Status {
 
 func (e IdentifySummaryError) ToStatus() keybase1.Status {
 	kvpairs := []keybase1.StringKVPair{
-		keybase1.StringKVPair{Key: "username", Value: e.username},
+		keybase1.StringKVPair{Key: "username", Value: e.username.String()},
 	}
 	for index, problem := range e.problems {
 		kvpairs = append(kvpairs, keybase1.StringKVPair{

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -493,7 +493,7 @@ func TmpTrackChainLinkFor(me keybase1.UID, them keybase1.UID, g *GlobalContext) 
 	return tcl, err
 }
 
-func (u *User) TrackChainLinkFor(username string, uid keybase1.UID) (*TrackChainLink, error) {
+func (u *User) TrackChainLinkFor(username NormalizedUsername, uid keybase1.UID) (*TrackChainLink, error) {
 	u.G().Log.Debug("+ TrackChainLinkFor for %s", uid)
 	defer u.G().Log.Debug("- TrackChainLinkFor for %s", uid)
 	remote, e1 := u.remoteTrackChainLinkFor(username, uid)
@@ -532,7 +532,7 @@ func TrackChainLinkFor(me keybase1.UID, them keybase1.UID, remote *TrackChainLin
 	return local, nil
 }
 
-func (u *User) remoteTrackChainLinkFor(username string, uid keybase1.UID) (*TrackChainLink, error) {
+func (u *User) remoteTrackChainLinkFor(username NormalizedUsername, uid keybase1.UID) (*TrackChainLink, error) {
 	if u.IDTable() == nil {
 		return nil, nil
 	}

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -885,23 +885,23 @@ type chatListener struct {
 	newMessage chan chat1.MessageUnboxed
 }
 
-func (n *chatListener) Logout()                                                            {}
-func (n *chatListener) Login(username string)                                              {}
-func (n *chatListener) ClientOutOfDate(to, uri, msg string)                                {}
-func (n *chatListener) UserChanged(uid keybase1.UID)                                       {}
-func (n *chatListener) TrackingChanged(uid keybase1.UID, username string)                  {}
-func (n *chatListener) FSActivity(activity keybase1.FSNotification)                        {}
-func (n *chatListener) FSEditListResponse(arg keybase1.FSEditListArg)                      {}
-func (n *chatListener) FSEditListRequest(arg keybase1.FSEditListRequest)                   {}
-func (n *chatListener) FSSyncStatusResponse(arg keybase1.FSSyncStatusArg)                  {}
-func (n *chatListener) FSSyncEvent(arg keybase1.FSPathSyncStatus)                          {}
-func (n *chatListener) PaperKeyCached(uid keybase1.UID, encKID, sigKID keybase1.KID)       {}
-func (n *chatListener) FavoritesChanged(uid keybase1.UID)                                  {}
-func (n *chatListener) KeyfamilyChanged(uid keybase1.UID)                                  {}
-func (n *chatListener) PGPKeyInSecretStoreFile()                                           {}
-func (n *chatListener) BadgeState(badgeState keybase1.BadgeState)                          {}
-func (n *chatListener) ReachabilityChanged(r keybase1.Reachability)                        {}
-func (n *chatListener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks) {}
+func (n *chatListener) Logout()                                                             {}
+func (n *chatListener) Login(username string)                                               {}
+func (n *chatListener) ClientOutOfDate(to, uri, msg string)                                 {}
+func (n *chatListener) UserChanged(uid keybase1.UID)                                        {}
+func (n *chatListener) TrackingChanged(uid keybase1.UID, username libkb.NormalizedUsername) {}
+func (n *chatListener) FSActivity(activity keybase1.FSNotification)                         {}
+func (n *chatListener) FSEditListResponse(arg keybase1.FSEditListArg)                       {}
+func (n *chatListener) FSEditListRequest(arg keybase1.FSEditListRequest)                    {}
+func (n *chatListener) FSSyncStatusResponse(arg keybase1.FSSyncStatusArg)                   {}
+func (n *chatListener) FSSyncEvent(arg keybase1.FSPathSyncStatus)                           {}
+func (n *chatListener) PaperKeyCached(uid keybase1.UID, encKID, sigKID keybase1.KID)        {}
+func (n *chatListener) FavoritesChanged(uid keybase1.UID)                                   {}
+func (n *chatListener) KeyfamilyChanged(uid keybase1.UID)                                   {}
+func (n *chatListener) PGPKeyInSecretStoreFile()                                            {}
+func (n *chatListener) BadgeState(badgeState keybase1.BadgeState)                           {}
+func (n *chatListener) ReachabilityChanged(r keybase1.Reachability)                         {}
+func (n *chatListener) ChatIdentifyUpdate(update keybase1.CanonicalTLFNameAndIDWithBreaks)  {}
 func (n *chatListener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationFinalizeInfo) {
 }
 func (n *chatListener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationResolveInfo) {

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -87,15 +87,15 @@ func newNlistener(t *testing.T) *nlistener {
 	}
 }
 
-func (n *nlistener) Logout()                                                      {}
-func (n *nlistener) Login(username string)                                        {}
-func (n *nlistener) ClientOutOfDate(to, uri, msg string)                          {}
-func (n *nlistener) UserChanged(uid keybase1.UID)                                 {}
-func (n *nlistener) TrackingChanged(uid keybase1.UID, username string)            {}
-func (n *nlistener) FSActivity(activity keybase1.FSNotification)                  {}
-func (n *nlistener) FSEditListResponse(arg keybase1.FSEditListArg)                {}
-func (n *nlistener) FSEditListRequest(arg keybase1.FSEditListRequest)             {}
-func (n *nlistener) PaperKeyCached(uid keybase1.UID, encKID, sigKID keybase1.KID) {}
+func (n *nlistener) Logout()                                                             {}
+func (n *nlistener) Login(username string)                                               {}
+func (n *nlistener) ClientOutOfDate(to, uri, msg string)                                 {}
+func (n *nlistener) UserChanged(uid keybase1.UID)                                        {}
+func (n *nlistener) TrackingChanged(uid keybase1.UID, username libkb.NormalizedUsername) {}
+func (n *nlistener) FSActivity(activity keybase1.FSNotification)                         {}
+func (n *nlistener) FSEditListResponse(arg keybase1.FSEditListArg)                       {}
+func (n *nlistener) FSEditListRequest(arg keybase1.FSEditListRequest)                    {}
+func (n *nlistener) PaperKeyCached(uid keybase1.UID, encKID, sigKID keybase1.KID)        {}
 func (n *nlistener) FavoritesChanged(uid keybase1.UID) {
 	n.favoritesChanged = append(n.favoritesChanged, uid)
 }

--- a/go/service/track.go
+++ b/go/service/track.go
@@ -78,7 +78,7 @@ func (h *TrackHandler) DismissWithToken(_ context.Context, arg keybase1.DismissW
 // Untrack creates an UntrackEngine and runs it.
 func (h *TrackHandler) Untrack(_ context.Context, arg keybase1.UntrackArg) error {
 	earg := engine.UntrackEngineArg{
-		Username: arg.Username,
+		Username: libkb.NewNormalizedUsername(arg.Username),
 	}
 	ctx := engine.Context{
 		SecretUI:  h.getSecretUI(arg.SessionID, h.G()),
@@ -103,6 +103,6 @@ func (h *TrackHandler) FakeTrackingChanged(_ context.Context, arg keybase1.FakeT
 	if err != nil {
 		return err
 	}
-	h.G().NotifyRouter.HandleTrackingChanged(user.GetUID(), user.GetName(), arg.IsTracking)
+	h.G().NotifyRouter.HandleTrackingChanged(user.GetUID(), user.GetNormalizedName(), arg.IsTracking)
 	return nil
 }


### PR DESCRIPTION
- this burned chris who a long time ago tracked 'Michael' and later tracked 'michael'. He got unlucky and 'Michael' won
- this fix won't really help people in Chris's situation until their cache is busted, which will happen on any sort of change to their user
- i'd rather not fix that automatically, but we can if it's really required.