### PR TITLE
Allow users to make the app a little smaller than the default size

### DIFF
--- a/shared/styles/index.desktop.js
+++ b/shared/styles/index.desktop.js
@@ -5,8 +5,8 @@ import {resolveImageAsURL} from '../desktop/resolve-root'
 import path from 'path'
 
 const windowStyle = {
-  minWidth: 800,
-  minHeight: 600,
+  minWidth: 600,
+  minHeight: 400,
   width: 800, // Default width
   height: 600, // Default height
 }


### PR DESCRIPTION
@keybase/react-hackers 

We had a bug report from a user who couldn't fit the chat input box on to their 768px height screen, so this PR would allow them to make the window small enough for that to work, while still leaving the default dimensions the same as before.  Here's a screenshot of the extra small window, our components appear to resize just fine:

![screenshot from 2017-02-21 10-34-00](https://cloud.githubusercontent.com/assets/21217/23171812/9dc67d6c-f821-11e6-8ac1-62bbf4b61901.png)
