### PR TITLE
Update chat avdl for MessageBoxed v2

### DIFF
--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -246,6 +246,12 @@ type SignatureInfo struct {
 	K []byte `codec:"k" json:"k"`
 }
 
+type SignEncryptedData struct {
+	V int    `codec:"v" json:"v"`
+	B []byte `codec:"b" json:"b"`
+	N []byte `codec:"n" json:"n"`
+}
+
 type MerkleRoot struct {
 	Seqno int64  `codec:"seqno" json:"seqno"`
 	Hash  []byte `codec:"hash" json:"hash"`

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1148,6 +1148,7 @@ type MessageUnboxedValid struct {
 	SenderDeviceType      string              `codec:"senderDeviceType" json:"senderDeviceType"`
 	HeaderHash            Hash                `codec:"headerHash" json:"headerHash"`
 	HeaderSignature       *SignatureInfo      `codec:"headerSignature,omitempty" json:"headerSignature,omitempty"`
+	VerificationKey       *[]byte             `codec:"verificationKey,omitempty" json:"verificationKey,omitempty"`
 	SenderDeviceRevokedAt *gregor1.Time       `codec:"senderDeviceRevokedAt,omitempty" json:"senderDeviceRevokedAt,omitempty"`
 }
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -10,11 +10,41 @@ import (
 )
 
 type MessageBoxed struct {
-	ServerHeader     *MessageServerHeader `codec:"serverHeader,omitempty" json:"serverHeader,omitempty"`
-	ClientHeader     MessageClientHeader  `codec:"clientHeader" json:"clientHeader"`
-	HeaderCiphertext EncryptedData        `codec:"headerCiphertext" json:"headerCiphertext"`
-	BodyCiphertext   EncryptedData        `codec:"bodyCiphertext" json:"bodyCiphertext"`
-	KeyGeneration    int                  `codec:"keyGeneration" json:"keyGeneration"`
+	Version               MessageBoxedVersion  `codec:"version" json:"version"`
+	ServerHeader          *MessageServerHeader `codec:"serverHeader,omitempty" json:"serverHeader,omitempty"`
+	ClientHeader          MessageClientHeader  `codec:"clientHeader" json:"clientHeader"`
+	HeaderCiphertext      EncryptedData        `codec:"headerCiphertext" json:"headerCiphertext"`
+	HeaderSealed          SignEncryptedData    `codec:"headerSealed" json:"headerSealed"`
+	BodyCiphertext        EncryptedData        `codec:"bodyCiphertext" json:"bodyCiphertext"`
+	HeaderVerificationKey []byte               `codec:"headerVerificationKey" json:"headerVerificationKey"`
+	KeyGeneration         int                  `codec:"keyGeneration" json:"keyGeneration"`
+}
+
+type MessageBoxedVersion int
+
+const (
+	MessageBoxedVersion_VNONE MessageBoxedVersion = 0
+	MessageBoxedVersion_V1    MessageBoxedVersion = 1
+	MessageBoxedVersion_V2    MessageBoxedVersion = 2
+)
+
+var MessageBoxedVersionMap = map[string]MessageBoxedVersion{
+	"VNONE": 0,
+	"V1":    1,
+	"V2":    2,
+}
+
+var MessageBoxedVersionRevMap = map[MessageBoxedVersion]string{
+	0: "VNONE",
+	1: "V1",
+	2: "V2",
+}
+
+func (e MessageBoxedVersion) String() string {
+	if v, ok := MessageBoxedVersionRevMap[e]; ok {
+		return v
+	}
+	return ""
 }
 
 type ThreadViewBoxed struct {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -187,6 +187,12 @@ protocol common {
     bytes k; // Verifying key
   }
 
+  record SignEncryptedData {
+    int   v; // version = 1
+    bytes b; // signEncryptedData (output of signencrypt.SealWhole)
+    bytes n; // nonce
+  }
+
   record MerkleRoot {
     long seqno;
     bytes hash;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -176,6 +176,8 @@ protocol local {
     Hash bodyHash;
     union { null, OutboxInfo } outboxInfo;
     union { null, OutboxID } outboxID;
+    // MessageBoxed.V1: Signature over the serialized HeaderPlaintextV1 (with headerSignature set to null).
+    // MessageBoxed.V2: Null (because the header is signencrypted outside)
     union {null, SignatureInfo} headerSignature;
   }
 
@@ -256,8 +258,22 @@ protocol local {
     string senderUsername;
     string senderDeviceName;
     string senderDeviceType;
+
+    // MessageBoxed.V1: Hash of the encrypted header ciphertext.
+    // MessageBoxed.V2: Hash of MessageBoxed.headerSealed (.v || .n || .b)
     Hash headerHash;
+
+    // TOOD Maybe get rid of this field in favor of verificationKey.
+    //      If so, bump-nuke the caches in storage_blockengine and any other persistent
+    //      storage of MessageUnboxedValid.
+    // MessageBoxed.V1: Header signature. Included for the verification key.
+    // MessageBoxed.V2: Null
     union {null, SignatureInfo} headerSignature;
+
+    // MessageBoxed.V1: Null
+    // MessageBoxed.V2: The verification key used to unbox.
+    union {null, bytes} verificationKey;
+
     // Whether the message was sent by a device that is now revoked.
     // We aren't sure whether the device was revoked when the message was sent.
     // Re-evaluated when unboxed or pulled from the cache.

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -272,6 +272,7 @@ protocol local {
 
     // MessageBoxed.V1: Null
     // MessageBoxed.V2: The verification key used to unbox.
+    //                  See MessageBoxed.headerVerificationKey
     union {null, bytes} verificationKey;
 
     // Whether the message was sent by a device that is now revoked.

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -4,18 +4,48 @@ protocol remote {
   import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
 
   record MessageBoxed {
-    // Only set when returned from the server; on the way up to the
+    // This was not present in most V1 messages.
+    MessageBoxedVersion version;
+
+    // [V1, V2]: Only set when returned from the server; on the way up to the
     // server, they are null.
     union { null, MessageServerHeader } serverHeader;
 
-    // MessageClientHeader is needed by clients to get keys via TLF name.
+    // [V1, V2]: MessageClientHeader is needed by clients to get keys via TLF name.
     // The server needs it as well for sender uid, device id.
     MessageClientHeader clientHeader;
 
+    // V1: Encrypted HeaderPlaintext
+    // V2: Empty
     EncryptedData headerCiphertext;
+
+    // V1: Missing
+    // V2: SignEncrypted HeaderPlaintext
+    SignEncryptedData headerSealed;
+
+    // [V1, V2]: Encrypted BodyPlaintext
     EncryptedData bodyCiphertext;
 
+    // V1: Missing
+    // V2: Public half of the signing key used on headerSealed
+    bytes headerVerificationKey;
+
+    // [V1, V2]: Key generation of the encryption key
     int keyGeneration;
+  }
+
+  enum MessageBoxedVersion {
+    // 0 exists from before the version field. It means V1.
+    VNONE_0,
+
+    // V1: Encrypted header and body.
+    // Hash of body inside header.
+    // Sig of header inside header.
+    V1_1,
+
+    // V2: SignEncrypted header, encrypted body.
+    // Hash of body inside header.
+    V2_2
   }
 
   record ThreadViewBoxed {

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -27,7 +27,9 @@ protocol remote {
     EncryptedData bodyCiphertext;
 
     // V1: Missing
-    // V2: Public half of the signing key used on headerSealed
+    // V2: Public half of the signing key used on headerSealed.
+    //     Used to open and verify headerSealed.
+    //     Must be asserted to belong to the sender when unboxing.
     bytes headerVerificationKey;
 
     // [V1, V2]: Key generation of the encryption key

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -169,6 +169,12 @@ export const NotifyChatChatActivityType = {
   failedMessage: 5,
 }
 
+export const RemoteMessageBoxedVersion = {
+  vnone: 0,
+  v1: 1,
+  v2: 2,
+}
+
 export function localCancelPostRpc (request: Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.CancelPost'})
 }
@@ -1102,12 +1108,20 @@ export type MessageBody =
   | { messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded }
 
 export type MessageBoxed = {
+  version: MessageBoxedVersion,
   serverHeader?: ?MessageServerHeader,
   clientHeader: MessageClientHeader,
   headerCiphertext: EncryptedData,
+  headerSealed: SignEncryptedData,
   bodyCiphertext: EncryptedData,
+  headerVerificationKey: bytes,
   keyGeneration: int,
 }
+
+export type MessageBoxedVersion =
+    0 // VNONE_0
+  | 1 // V1_1
+  | 2 // V2_2
 
 export type MessageClientHeader = {
   conv: ConversationIDTriple,
@@ -1207,6 +1221,7 @@ export type MessageUnboxedValid = {
   senderDeviceType: string,
   headerHash: Hash,
   headerSignature?: ?SignatureInfo,
+  verificationKey?: ?bytes,
   senderDeviceRevokedAt?: ?gregor1.Time,
 }
 
@@ -1382,6 +1397,12 @@ export type SetStatusPayload = {
   status: ConversationStatus,
   inboxVers: InboxVers,
   unreadUpdate?: ?UnreadUpdate,
+}
+
+export type SignEncryptedData = {
+  v: int,
+  b: bytes,
+  n: bytes,
 }
 
 export type SignatureInfo = {

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -518,6 +518,24 @@
     },
     {
       "type": "record",
+      "name": "SignEncryptedData",
+      "fields": [
+        {
+          "type": "int",
+          "name": "v"
+        },
+        {
+          "type": "bytes",
+          "name": "b"
+        },
+        {
+          "type": "bytes",
+          "name": "n"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "MerkleRoot",
       "fields": [
         {

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -831,6 +831,13 @@
         {
           "type": [
             null,
+            "bytes"
+          ],
+          "name": "verificationKey"
+        },
+        {
+          "type": [
+            null,
             "gregor1.Time"
           ],
           "name": "senderDeviceRevokedAt"

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -13,6 +13,10 @@
       "name": "MessageBoxed",
       "fields": [
         {
+          "type": "MessageBoxedVersion",
+          "name": "version"
+        },
+        {
           "type": [
             null,
             "MessageServerHeader"
@@ -28,13 +32,30 @@
           "name": "headerCiphertext"
         },
         {
+          "type": "SignEncryptedData",
+          "name": "headerSealed"
+        },
+        {
           "type": "EncryptedData",
           "name": "bodyCiphertext"
+        },
+        {
+          "type": "bytes",
+          "name": "headerVerificationKey"
         },
         {
           "type": "int",
           "name": "keyGeneration"
         }
+      ]
+    },
+    {
+      "type": "enum",
+      "name": "MessageBoxedVersion",
+      "symbols": [
+        "VNONE_0",
+        "V1_1",
+        "V2_2"
       ]
     },
     {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -169,6 +169,12 @@ export const NotifyChatChatActivityType = {
   failedMessage: 5,
 }
 
+export const RemoteMessageBoxedVersion = {
+  vnone: 0,
+  v1: 1,
+  v2: 2,
+}
+
 export function localCancelPostRpc (request: Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.CancelPost'})
 }
@@ -1102,12 +1108,20 @@ export type MessageBody =
   | { messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded }
 
 export type MessageBoxed = {
+  version: MessageBoxedVersion,
   serverHeader?: ?MessageServerHeader,
   clientHeader: MessageClientHeader,
   headerCiphertext: EncryptedData,
+  headerSealed: SignEncryptedData,
   bodyCiphertext: EncryptedData,
+  headerVerificationKey: bytes,
   keyGeneration: int,
 }
+
+export type MessageBoxedVersion =
+    0 // VNONE_0
+  | 1 // V1_1
+  | 2 // V2_2
 
 export type MessageClientHeader = {
   conv: ConversationIDTriple,
@@ -1207,6 +1221,7 @@ export type MessageUnboxedValid = {
   senderDeviceType: string,
   headerHash: Hash,
   headerSignature?: ?SignatureInfo,
+  verificationKey?: ?bytes,
   senderDeviceRevokedAt?: ?gregor1.Time,
 }
 
@@ -1382,6 +1397,12 @@ export type SetStatusPayload = {
   status: ConversationStatus,
   inboxVers: InboxVers,
   unreadUpdate?: ?UnreadUpdate,
+}
+
+export type SignEncryptedData = {
+  v: int,
+  b: bytes,
+  n: bytes,
 }
 
 export type SignatureInfo = {


### PR DESCRIPTION
Make avdl changes in preparation for MessageBoxed V2. The goal of MessageBoxed V2 is
1. Use signencryption. This is less susceptible to crypto layering problems like surreptitious forwarding, and probably cleaner as a way to encrypt the signature and the contents.
2. When V2 reading has been deployed for long enough, it should be possible to add nullable fields to HeaderSignatureV1 without bumping the version.

In this PR:
- Add `SignEncryptedData`
- Add a `Version` field to `MessageBoxed` and descriptions of how the fields change
- Add comments and fields to `HeaderPlaintextV1` and `MessageUnboxedValid` that will have to change with the outer version.