### PR TITLE
Switch from attach icon to 'Send' label when text is entered in mobile chat

### DIFF
--- a/shared/chat/conversation/input.native.js
+++ b/shared/chat/conversation/input.native.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint-env browser */
 import React, {Component} from 'react'
-import {Box, Icon, Input} from '../../common-adapters'
+import {Box, Icon, Input, Text} from '../../common-adapters'
 import {globalMargins, globalStyles} from '../../styles'
 
 import type {Props} from './input'
@@ -69,7 +69,10 @@ class ConversationInput extends Component<void, Props, State> {
             value={this.state.text}
             multiline={false}
           />
-          <Icon onClick={this._openFilePicker} style={styleIcon} type='iconfont-attachment' />
+          <Box style={styleRight}>
+            {!this.state.text && <Icon onClick={this._openFilePicker} type='iconfont-attachment' />}
+            {!!this.state.text && <Text type='BodyBigLink' onClick={this._onSubmit}>Send</Text>}
+          </Box>
         </Box>
       </Box>
     )
@@ -83,9 +86,9 @@ const styleInput = {
   marginTop: globalMargins.tiny,
 }
 
-const styleIcon = {
-  paddingRight: globalMargins.tiny,
-  paddingTop: globalMargins.tiny,
+const styleRight = {
+  marginRight: globalMargins.tiny,
+  marginTop: globalMargins.tiny,
 }
 
 export default ConversationInput


### PR DESCRIPTION
@keybase/react-hackers 

Here's a part of the Mobile Chat UX that I missed in Zeplin the first time around -- once you start writing in the Chat input box, it should switch from the attachment icon to a "Send" label, this makes it possible to write multiline chat messages.

I'm not turning on multiline yet, though, would rather work on it in situ on the page once the conversation view's landed.