### PR TITLE
nondefault copyright in packaging step

### DIFF
--- a/shared/desktop/package.js
+++ b/shared/desktop/package.js
@@ -28,12 +28,14 @@ const shouldBuildAnArch = argv.arch || false
 const appVersion = argv.appVersion || '0.0.0'
 const comment = argv.comment || ''
 const outDir = argv.outDir || ''
+const appCopyright = 'Copyright (c) 2015, Keybase'
 
 const packagerOpts = {
   'app-bundle-id': 'keybase.Electron',
   'helper-bundle-id': 'keybase.ElectronHelper',
   'app-version': appVersion,
   'build-version': appVersion + comment,
+  'app-copyright': appCopyright,
   dir: desktopPath('./build'),
   name: appName,
   asar: shouldUseAsar,


### PR DESCRIPTION
Jack pointed out that someone pointed out that the copyright said Github
![image](https://cloud.githubusercontent.com/assets/862397/23181243/14715106-f829-11e6-961b-eafd1f7f9b57.png)
