### PR TITLE
Fix pvl twitter username subst

### DIFF
--- a/go/pvl/hardcoded.go
+++ b/go/pvl/hardcoded.go
@@ -385,7 +385,7 @@ var hardcodedPVLString = `
           "assert_regex_match": {
             "error": [
               "CONTENT_FAILURE",
-              "Wanted a post of type 'Listing', but got %{kind}"
+              "Wanted a post of type 'Listing', but got '%{kind}'"
             ],
             "from": "kind",
             "pattern": "^Listing$"
@@ -411,7 +411,7 @@ var hardcodedPVLString = `
           "assert_regex_match": {
             "error": [
               "CONTENT_FAILURE",
-              "Wanted a child of type 't3' but got %{inner_kind}"
+              "Wanted a child of type 't3' but got '%{inner_kind}'"
             ],
             "from": "inner_kind",
             "pattern": "^t3$"
@@ -469,7 +469,7 @@ var hardcodedPVLString = `
             "cmp": "cicmp",
             "error": [
               "BAD_USERNAME",
-              "Bad post author; wanted '%{username_service} but got '%{author}'"
+              "Bad post author; wanted '%{username_service}' but got '%{author}'"
             ]
           }
         },
@@ -630,7 +630,7 @@ var hardcodedPVLString = `
             "cmp": "cicmp",
             "error": [
               "BAD_USERNAME",
-              "Bad post authored: wanted ${username_service} but got %{data_screen_name}"
+              "Bad post authored: wanted '%{username_service}' but got '%{data_screen_name}'"
             ]
           }
         },

--- a/pvl-tools/pvl.cson
+++ b/pvl-tools/pvl.cson
@@ -194,7 +194,7 @@ services:
     { assert_regex_match: {
       , pattern: "^Listing$"
       , from: "kind"
-      , error: ["CONTENT_FAILURE", "Wanted a post of type 'Listing', but got %{kind}"] } },
+      , error: ["CONTENT_FAILURE", "Wanted a post of type 'Listing', but got '%{kind}'"] } },
     # check that the inner thing is a t3
     { selector_json: {
       , selectors: [0, "data", "children", 0, "kind"]
@@ -203,7 +203,7 @@ services:
     { assert_regex_match: {
       , pattern: "^t3$"
       , from: "inner_kind"
-      , error: ["CONTENT_FAILURE", "Wanted a child of type 't3' but got %{inner_kind}"] } },
+      , error: ["CONTENT_FAILURE", "Wanted a child of type 't3' but got '%{inner_kind}'"] } },
     # check the subreddit
     { selector_json: {
       , selectors: [0, "data", "children", 0, "data", "subreddit"]
@@ -223,7 +223,7 @@ services:
       , cmp: "cicmp"
       , a: "author"
       , b: "username_service"
-      , error: ["BAD_USERNAME", "Bad post author; wanted '%{username_service} but got '%{author}'"] } },
+      , error: ["BAD_USERNAME", "Bad post author; wanted '%{username_service}' but got '%{author}'"] } },
     # check the title
     { selector_json: {
       , selectors: [0, "data", "children", 0, "data", "title"]
@@ -297,7 +297,7 @@ services:
       , cmp: "cicmp"
       , a: "data_screen_name"
       , b: "username_service"
-      , error: ["BAD_USERNAME", "Bad post authored: wanted ${username_service} but got %{data_screen_name}"] } },
+      , error: ["BAD_USERNAME", "Bad post authored: wanted '%{username_service}' but got '%{data_screen_name}'"] } },
     # Check the username in the tweet. Case insensitive.
     { selector_css: {
       , selectors: ["div.permalink-tweet-container div.permalink-tweet", 0, "p.tweet-text", 0]


### PR DESCRIPTION
Part of https://github.com/keybase/client/issues/5973

```
old:
✔ "resiak" on twitter failed: Bad post authored: wanted ${username_service} but got wjjjjt (code=203)
new:
✔ "resiak" on twitter failed: Bad post authored: wanted 'resiak' but got 'wjjjjt' (code=203)
```