### PR TITLE
Don't call MarkAsReadLocal on your own messages

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -859,7 +859,7 @@ function * _incomingMessage (action: IncomingMessage): SagaGenerator<any, any> {
         const conversationIsFocused = conversationIDKey === selectedConversationIDKey && appFocused && chatTabSelected
         const messageIsYours = (message.type === 'Text' || message.type === 'Attachment') && message.author === yourName
 
-        if (message && message.messageID && (conversationIsFocused || messageIsYours)) {
+        if (message && message.messageID && conversationIsFocused && !messageIsYours) {
           yield call(localMarkAsReadLocalRpcPromise, {
             param: {
               conversationID: incomingMessage.convID,


### PR DESCRIPTION
@keybase/react-hackers 

Tested that removing this call doesn't seem to break anything around our bookkeeping.