### PR TITLE
Persist State on Navigate Up

### DIFF
--- a/shared/actions/route-tree.js
+++ b/shared/actions/route-tree.js
@@ -87,10 +87,10 @@ export function navigateAppend (path: PropsPath<*>, parentPath?: Path): Navigate
 }
 
 // Navigate one step up from the current path.
-export function navigateUp (): NavigateUp {
+export function navigateUp (persistState: ?boolean = false): NavigateUp {
   return {
     type: Constants.navigateUp,
-    payload: null,
+    payload: {persistState},
   }
 }
 

--- a/shared/actions/route-tree.js
+++ b/shared/actions/route-tree.js
@@ -90,7 +90,7 @@ export function navigateAppend (path: PropsPath<*>, parentPath?: Path): Navigate
 export function navigateUp (persistState: ?boolean = false): NavigateUp {
   return {
     type: Constants.navigateUp,
-    payload: {persistState},
+    payload: {persistState: !!persistState},
   }
 }
 

--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -159,7 +159,7 @@ export default connect(
   (dispatch: Dispatch, {setRouteState}) => ({
     onAddParticipant: (participants: Array<string>) => dispatch(newChat(participants)),
     onAttach: (selectedConversation, inputs: Array<AttachmentInput>) => { dispatch(navigateAppend([{props: {conversationIDKey: selectedConversation, inputs}, selected: 'attachmentInput'}])) },
-    onBack: () => dispatch(navigateUp()),
+    onBack: () => dispatch(navigateUp(true)),
     onDeleteMessage: (message: Message) => { dispatch(deleteMessage(message)) },
     onEditMessage: (message: Message, body: string) => { dispatch(editMessage(message, new HiddenString(body))) },
     onLoadAttachment: (selectedConversation, messageID, filename) => dispatch(loadAttachment(selectedConversation, messageID, false, false, downloadFilePath(filename))),

--- a/shared/chat/conversation/input.native.js
+++ b/shared/chat/conversation/input.native.js
@@ -34,8 +34,7 @@ class ConversationInput extends Component<void, Props, State> {
   }
 
   componentWillUnmount () {
-    // TODO(mm) fix this when we figure out a solution that will store this in the route state
-    // this.props.onUnmountText && this.props.onUnmountText(this.getValue())
+    this.props.onUnmountText && this.props.onUnmountText(this.getValue())
   }
 
   focusInput = () => {

--- a/shared/constants/route-tree.js
+++ b/shared/constants/route-tree.js
@@ -15,7 +15,7 @@ export const navigateAppend = 'routeTree:navigateAppend'
 export type NavigateAppend = NoErrorTypedAction<'routeTree:navigateAppend', {path: PropsPath<*>, parentPath: ?Path}>
 
 export const navigateUp = 'routeTree:navigateUp'
-export type NavigateUp = NoErrorTypedAction<'routeTree:navigateUp', null>
+export type NavigateUp = NoErrorTypedAction<'routeTree:navigateUp', {persistState: boolean}>
 
 export const setRouteState = 'routeTree:setRouteState'
 export type SetRouteState = NoErrorTypedAction<'routeTree:setRouteState', {path: Path, partialState: {}}>

--- a/shared/reducers/__tests__/route-tree.test.js
+++ b/shared/reducers/__tests__/route-tree.test.js
@@ -1,8 +1,9 @@
 // @flow
 /* eslint-env jest */
 
+import * as I from 'immutable'
 import routeTreeReducer, {State} from '../route-tree'
-import {RouteDefNode, routeSetProps, routeNavigate} from '../../route-tree'
+import {RouteDefNode, RouteStateNode, routeSetProps, routeNavigate} from '../../route-tree'
 import {
   navigateAppend,
   navigateUp,
@@ -48,6 +49,29 @@ describe('routeTree reducer', () => {
       const newState = routeTreeReducer(new State({routeDef, routeState}), action)
       expect(newState.routeDef).toBe(routeDef)
       expect(newState.routeState).toEqual(routeSetProps(routeDef, null, (['foo']: Array<string>)))
+    })
+
+    it('persists state correctly', () => {
+      const routeDef = demoRouteDef
+      const routeState = routeSetProps(routeDef, null, (['foo', 'bar']: PropsPath<*>))
+
+      const action = navigateUp(true)
+      const newState = routeTreeReducer(new State({routeDef, routeState}), action)
+      expect(newState.routeDef).toBe(routeDef)
+      expect(newState.routeState).toEqual(new RouteStateNode({
+        selected: 'foo',
+        children: I.Map({
+          foo: new RouteStateNode({
+            selected: null,
+            children: I.Map({
+              bar: new RouteStateNode({
+                selected: null,
+                props: I.Map({}),
+              }),
+            }),
+          }),
+        }),
+      }))
     })
   })
 

--- a/shared/reducers/route-tree.js
+++ b/shared/reducers/route-tree.js
@@ -61,7 +61,7 @@ function routeStateReducer (routeDef, routeState, action) {
 
     case Constants.navigateUp: {
       const path = getPath(routeState)
-      return routeNavigate(routeDef, routeState, path.skipLast(1))
+      return routeNavigate(routeDef, routeState, path.skipLast(1), null, action.payload.persistState)
     }
 
     case Constants.setRouteState:

--- a/shared/route-tree/__tests__/route-tree.test.js
+++ b/shared/route-tree/__tests__/route-tree.test.js
@@ -212,6 +212,40 @@ describe('routeNavigate', () => {
       }),
     }))
   })
+
+  it('persist the state of the children if passed persistState = true', () => {
+    const startRouteState = routeNavigate(demoRouteDef, null, (['foo', {selected: 'bar', props: {hello: 'world'}}]: PropsPath<*>))
+    expect(startRouteState).toEqual(new RouteStateNode({
+      selected: 'foo',
+      children: I.Map({
+        foo: new RouteStateNode({
+          selected: 'bar',
+          children: I.Map({
+            bar: new RouteStateNode({
+              selected: null,
+              props: I.Map({hello: 'world'}),
+            }),
+          }),
+        }),
+      }),
+    }))
+
+    const newRouteState = routeNavigate(demoRouteDef, startRouteState, (['foo']: Array<string>), null, true)
+    expect(newRouteState).toEqual(new RouteStateNode({
+      selected: 'foo',
+      children: I.Map({
+        foo: new RouteStateNode({
+          selected: null,
+          children: I.Map({
+            bar: new RouteStateNode({
+              selected: null,
+              props: I.Map({hello: 'world'}),
+            }),
+          }),
+        }),
+      }),
+    }))
+  })
 })
 
 describe('routeSetState', () => {

--- a/shared/route-tree/index.js
+++ b/shared/route-tree/index.js
@@ -154,8 +154,8 @@ export function routeSetProps (routeDef: RouteDefNode, routeState: ?RouteStateNo
   return _routeSet(routeDef, routeState, parentPathSeq.concat(pathSeq), persistState)
 }
 
-export function routeNavigate (routeDef: RouteDefNode, routeState: ?RouteStateNode, pathProps: PathParam<*>, parentPath: ?Path, persistState: ?boolean = false): RouteStateNode {
-  return routeSetProps(routeDef, routeState, I.List(pathProps).push({selected: null, props: {}}), parentPath, !!persistState)
+export function routeNavigate (routeDef: RouteDefNode, routeState: ?RouteStateNode, pathProps: PathParam<*>, parentPath: ?Path, persistState?: boolean = false): RouteStateNode {
+  return routeSetProps(routeDef, routeState, I.List(pathProps).push({selected: null, props: {}}), parentPath, persistState)
 }
 
 export function routeSetState (routeDef: RouteDefNode, routeState: RouteStateNode, path: Path, partialState: {}): RouteStateNode {

--- a/shared/route-tree/index.js
+++ b/shared/route-tree/index.js
@@ -108,13 +108,13 @@ type PathSetSpec<P> = I.IndexedIterable<{type: 'traverse' | 'navigate', next: st
 // the "next" props of each item in the pathSpec, then following any
 // defaultSelected from the routeDefs. It creates any routeState nodes that
 // don't exist along the way.
-function _routeSet (routeDef: RouteDefNode, routeState: ?RouteStateNode, pathSpec: PathSetSpec<*>): RouteStateNode {
+function _routeSet (routeDef: RouteDefNode, routeState: ?RouteStateNode, pathSpec: PathSetSpec<*>, persistState: ?boolean = false): RouteStateNode {
   const pathHead = pathSpec && pathSpec.first()
 
   let newRouteState = routeState || new RouteStateNode({selected: routeDef.defaultSelected})
   if (pathHead && pathHead.type === 'navigate') {
     newRouteState = newRouteState.set('selected', pathHead.next || routeDef.defaultSelected)
-    if (pathHead.next === null) {
+    if (pathHead.next === null && !persistState) {
       // Navigating to a route clears out the state of any children that may
       // have previously been displayed.
       newRouteState = newRouteState.delete('children')
@@ -129,7 +129,7 @@ function _routeSet (routeDef: RouteDefNode, routeState: ?RouteStateNode, pathSpe
     }
 
     newRouteState = newRouteState.updateChild(childName, childState => {
-      let newChild = _routeSet(childDef, childState, pathSpec.skip(1))
+      let newChild = _routeSet(childDef, childState, pathSpec.skip(1), persistState)
       if (pathHead && pathHead.hasOwnProperty('props')) {
         newChild = newChild.set('props', I.Map(pathHead.props))
       }
@@ -140,7 +140,7 @@ function _routeSet (routeDef: RouteDefNode, routeState: ?RouteStateNode, pathSpe
   return newRouteState
 }
 
-export function routeSetProps (routeDef: RouteDefNode, routeState: ?RouteStateNode, pathProps: PathParam<*>, parentPath: ?Path): RouteStateNode {
+export function routeSetProps (routeDef: RouteDefNode, routeState: ?RouteStateNode, pathProps: PathParam<*>, parentPath: ?Path, persistState: ?boolean = false): RouteStateNode {
   const pathSeq = I.Seq(pathProps).map(item => {
     if (typeof item === 'string') {
       return {type: 'navigate', next: item}
@@ -151,11 +151,11 @@ export function routeSetProps (routeDef: RouteDefNode, routeState: ?RouteStateNo
   const parentPathSeq = I.Seq(parentPath || []).map(item => {
     return {type: 'traverse', next: item}
   })
-  return _routeSet(routeDef, routeState, parentPathSeq.concat(pathSeq))
+  return _routeSet(routeDef, routeState, parentPathSeq.concat(pathSeq), persistState)
 }
 
-export function routeNavigate (routeDef: RouteDefNode, routeState: ?RouteStateNode, pathProps: PathParam<*>, parentPath: ?Path): RouteStateNode {
-  return routeSetProps(routeDef, routeState, I.List(pathProps).push({selected: null, props: {}}), parentPath)
+export function routeNavigate (routeDef: RouteDefNode, routeState: ?RouteStateNode, pathProps: PathParam<*>, parentPath: ?Path, persistState: ?boolean = false): RouteStateNode {
+  return routeSetProps(routeDef, routeState, I.List(pathProps).push({selected: null, props: {}}), parentPath, !!persistState)
 }
 
 export function routeSetState (routeDef: RouteDefNode, routeState: RouteStateNode, path: Path, partialState: {}): RouteStateNode {


### PR DESCRIPTION
@keybase/react-hackers @chromakode 

We used to blow away the state of the children when we navigate up. This adds an option to not do that.

Useful for storing the input text on chat for mobile