### PR TITLE
chat tracing through context

### DIFF
--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -6,7 +6,6 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 
 type identifyModeKey int
@@ -67,11 +66,6 @@ func CtxAddLogTags(ctx context.Context) context.Context {
 	tags := make(map[interface{}]string)
 	tags[chatTraceKey] = "chat-trace"
 	ctx = logger.NewContextWithLogTags(ctx, tags)
-
-	// Add RPC only log tags
-	rpcTags := make(map[string]interface{})
-	rpcTags["useragent"] = libkb.UserAgent
-	ctx = rpc.AddRpcTagsToContext(ctx, rpcTags)
 
 	return ctx
 }

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -40,6 +40,7 @@ func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid g
 	// Grab the latest inbox version, and compare it to what we have
 	// If we don't have the latest, then we clear the Inbox cache and
 	// send alerts to clients that they should refresh.
+	ctx = CtxAddLogTags(ctx)
 	vers, err := cli.GetInboxVersion(ctx, uid)
 	if err != nil {
 		s.Debug(ctx, "Connected: failed to sync inbox version: uid: %s error: %s", uid, err.Error())

--- a/go/logger/standard.go
+++ b/go/logger/standard.go
@@ -63,6 +63,14 @@ func LogTagsFromContext(ctx context.Context) (CtxLogTags, bool) {
 	return logTags, ok
 }
 
+// LogTagsFromContextRPC is a wrapper around LogTagsFromContext
+// that simply casts the result to the type expected by
+// rpc.Connection.
+func LogTagsFromContextRPC(ctx context.Context) (map[interface{}]string, bool) {
+	tags, ok := LogTagsFromContext(ctx)
+	return map[interface{}]string(tags), ok
+}
+
 type ExternalLogger interface {
 	Log(level keybase1.LogLevel, format string, args []interface{})
 }

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -19,6 +19,7 @@ import (
 	grclient "github.com/keybase/client/go/gregor/client"
 	"github.com/keybase/client/go/gregor/storage"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -1084,6 +1085,7 @@ func (g *gregorHandler) connectTLS() error {
 	g.Debug(ctx, "Using CA for gregor: %s", libkb.ShortCA(rawCA))
 
 	opts := rpc.ConnectionOpts{
+		TagsFunc:         logger.LogTagsFromContextRPC,
 		WrapErrorFunc:    libkb.WrapError,
 		ReconnectBackoff: backoff.NewConstantBackOff(GregorConnectionRetryInterval),
 	}
@@ -1119,6 +1121,7 @@ func (g *gregorHandler) connectNoTLS() error {
 	g.transportForTesting = t
 
 	opts := rpc.ConnectionOpts{
+		TagsFunc:         logger.LogTagsFromContextRPC,
 		WrapErrorFunc:    libkb.WrapError,
 		ReconnectBackoff: backoff.NewConstantBackOff(GregorConnectionRetryInterval),
 	}

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -515,7 +515,7 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 			len(replayedMsgs), len(consumedMsgs))
 	}
 
-	// Sync chat data using a Syncer object
+	// Sync chat data using a Syncer object in the background
 	gcli, err := g.getGregorCli()
 	if err == nil {
 		chatCli := chat1.RemoteClient{Cli: cli}

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -515,7 +515,7 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 			len(replayedMsgs), len(consumedMsgs))
 	}
 
-	// Sync chat data using a Syncer object in the background
+	// Sync chat data using a Syncer object
 	gcli, err := g.getGregorCli()
 	if err == nil {
 		chatCli := chat1.RemoteClient{Cli: cli}


### PR DESCRIPTION
Add log tags for all chat debug output. Also send user agent as a tag so we can inspect on server side. 

Locally, this seems to crash KBFS for me, I'm seeing what happens on CI (I also have a patch which fixes one crash...)