### PR TITLE
send debug tags up to API server

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -499,7 +499,7 @@ func (a *InternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
 			req.Header.Set("X-Keybase-Install-ID", i.String())
 		}
 		if tags := LogTagsToString(arg.NetContext); tags != "" {
-			req.Header.Set("X-Keybase-Debug-Tags", tags)
+			req.Header.Set("X-Keybase-Log-Tags", tags)
 		}
 	}
 }

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -498,6 +498,9 @@ func (a *InternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
 		if i := a.G().Env.GetInstallID(); i.Exists() {
 			req.Header.Set("X-Keybase-Install-ID", i.String())
 		}
+		if tags := LogTagsToString(arg.NetContext); tags != "" {
+			req.Header.Set("X-Keybase-Debug-Tags", tags)
+		}
 	}
 }
 

--- a/go/libkb/net_context.go
+++ b/go/libkb/net_context.go
@@ -1,8 +1,10 @@
 package libkb
 
 import (
+	"fmt"
 	"github.com/keybase/client/go/logger"
 	"golang.org/x/net/context"
+	"strings"
 )
 
 type withLogTagKey string
@@ -28,4 +30,22 @@ func WithLogTag(ctx context.Context, k string) context.Context {
 		ctx = context.WithValue(ctx, tagKey, tag)
 	}
 	return ctx
+}
+
+func LogTagsToString(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+
+	tags, ok := logger.LogTagsFromContext(ctx)
+	if !ok || len(tags) == 0 {
+		return ""
+	}
+	var out []string
+	for key, tag := range tags {
+		if v := ctx.Value(key); v != nil {
+			out = append(out, fmt.Sprintf("%s=%s", tag, v))
+		}
+	}
+	return strings.Join(out, ",")
 }


### PR DESCRIPTION
IF we have debug tags in our context, send them up to the API server in the `X-Keybase-Debug-Tags` header.  It's a little more bandwidth is the big problem.