### PR TITLE
mark components online before doing long operations

### DIFF
--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -37,6 +37,11 @@ func (s *Syncer) SendChatStaleNotifications(uid gregor1.UID) {
 func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID) error {
 	s.Debug(ctx, "Connected: running")
 
+	// Let the Offlinables know that we are back online
+	for _, o := range s.offlinables {
+		o.Connected(ctx)
+	}
+
 	// Grab the latest inbox version, and compare it to what we have
 	// If we don't have the latest, then we clear the Inbox cache and
 	// send alerts to clients that they should refresh.
@@ -57,11 +62,6 @@ func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid g
 		s.SendChatStaleNotifications(uid)
 	} else {
 		s.Debug(ctx, "Connected: version sync success! version: %d", vers)
-	}
-
-	// Let the Offlinables know that we are back online
-	for _, o := range s.offlinables {
-		o.Connected(ctx)
 	}
 
 	return nil

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -506,15 +506,6 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 		return err
 	}
 
-	// Sync down events since we have been dead
-	replayedMsgs, consumedMsgs, err := g.serverSync(ctx, gregor1.IncomingClient{Cli: timeoutCli})
-	if err != nil {
-		g.Errorf("sync failure: %s", err)
-	} else {
-		g.Debug(ctx, "sync success: replayed: %d consumed: %d",
-			len(replayedMsgs), len(consumedMsgs))
-	}
-
 	// Sync chat data using a Syncer object
 	gcli, err := g.getGregorCli()
 	if err == nil {
@@ -523,6 +514,15 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 		if err := g.chatSync.Connected(ctx, chatCli, uid); err != nil {
 			return err
 		}
+	}
+
+	// Sync down events since we have been dead
+	replayedMsgs, consumedMsgs, err := g.serverSync(ctx, gregor1.IncomingClient{Cli: timeoutCli})
+	if err != nil {
+		g.Errorf("sync failure: %s", err)
+	} else {
+		g.Debug(ctx, "sync success: replayed: %d consumed: %d",
+			len(replayedMsgs), len(consumedMsgs))
 	}
 
 	// Sync badge state in the background


### PR DESCRIPTION
The problem here is that when Gregor restarts, all the `Sync` calls take forever since Gregor is slammed. We don't want the code to mark chat stuff as online behind that.