### PR TITLE
identify2 unfollowed fast path

### DIFF
--- a/go/libkb/identify2_cache.go
+++ b/go/libkb/identify2_cache.go
@@ -23,6 +23,7 @@ type Identify2Cacher interface {
 	DidFullUserLoad(keybase1.UID)
 	Shutdown()
 	Delete(uid keybase1.UID) error
+	UseDiskCache() bool
 }
 
 type GetCheckTimeFunc func(keybase1.Identify2Res) keybase1.Time
@@ -92,3 +93,5 @@ func (c *Identify2Cache) Shutdown() {
 
 // DidFullUserLoad is a noop unless we're testing...
 func (c *Identify2Cache) DidFullUserLoad(_ keybase1.UID) {}
+
+func (c *Identify2Cache) UseDiskCache() bool { return true }

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -753,6 +753,17 @@ func (b TLFIdentifyBehavior) AlwaysRunIdentify() bool {
 		b == TLFIdentifyBehavior_CHAT_GUI_STRICT
 }
 
+func (b TLFIdentifyBehavior) CanUseUntrackedFastPath() bool {
+	switch b {
+	case TLFIdentifyBehavior_CHAT_GUI, TLFIdentifyBehavior_CHAT_GUI_STRICT:
+		return true
+	default:
+		// TLFIdentifyBehavior_DEFAULT_KBFS, for filesystem activity that
+		// doesn't have any other UI to report errors with.
+		return false
+	}
+}
+
 func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
 	// The chat GUI (in non-strict mode) is specifically exempted from broken
 	// track errors, because people need to be able to use it to ask each other


### PR DESCRIPTION
- if we're in CHAT GUI mode, and we're identifying someone we don't track, there's
  really not much to do.  Allow a "fast path" which does minimal work on the user.
- in reality, a lot of tests should be revamped with this change, but don't incur
  such a huge change, just test this behavior selectively.