### PR TITLE
Multiline input for Chat including auto-grow, iOS only

### DIFF
--- a/shared/chat/conversation/input.native.js
+++ b/shared/chat/conversation/input.native.js
@@ -3,6 +3,7 @@
 import React, {Component} from 'react'
 import {Box, Icon, Input, Text} from '../../common-adapters'
 import {globalMargins, globalStyles} from '../../styles'
+import {isIOS} from '../../constants/platform'
 
 import type {Props} from './input'
 
@@ -54,6 +55,9 @@ class ConversationInput extends Component<void, Props, State> {
   }
 
   render () {
+    // Auto-growing multiline doesn't work smoothly on Android yet.
+    const multilineOpts = isIOS ? {rowsMax: 3, rowsMin: 1} : {rowsMax: 2, rowsMin: 2}
+
     return (
       <Box style={{...globalStyles.flexBoxColumn}}>
         <Box style={{...globalStyles.flexBoxRow, alignItems: 'flex-start'}}>
@@ -65,9 +69,9 @@ class ConversationInput extends Component<void, Props, State> {
             hintText='Write a message'
             hideUnderline={true}
             onChangeText={this._onChangeText}
-            onEnterKeyDown={this._onSubmit}
             value={this.state.text}
-            multiline={false}
+            multiline={true}
+            {...multilineOpts}
           />
           <Box style={styleRight}>
             {!this.state.text && <Icon onClick={this._openFilePicker} type='iconfont-attachment' />}
@@ -87,6 +91,7 @@ const styleInput = {
 }
 
 const styleRight = {
+  alignSelf: 'center',
   marginRight: globalMargins.tiny,
   marginTop: globalMargins.tiny,
 }


### PR DESCRIPTION
@keybase/react-hackers 

This sets us up with auto-growing 1->4 rows of multiline for Chat on iOS, and a fixed 2 rows of multiline on Android.

It doesn't feel good to have a bunch of conditionals in the code, hopefully it's temporary until `onContentSizeChange` is fixed on Android.