### PR TITLE
 Zanderz/fs async 2017.02.24

### DIFF
--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -122,7 +122,7 @@ func (e DirentType) String() string {
 
 type Dirent struct {
 	Time       Time       `codec:"time" json:"time"`
-	Size       int        `codec:"size" json:"size"`
+	Size       int64      `codec:"size" json:"size"`
 	Name       string     `codec:"name" json:"name"`
 	DirentType DirentType `codec:"direntType" json:"direntType"`
 }
@@ -162,17 +162,6 @@ func (e OpenFlags) String() string {
 		return v
 	}
 	return ""
-}
-
-type Progress int
-type SimpleFSListResult struct {
-	Entries  []Dirent `codec:"entries" json:"entries"`
-	Progress Progress `codec:"progress" json:"progress"`
-}
-
-type FileContent struct {
-	Data     []byte   `codec:"data" json:"data"`
-	Progress Progress `codec:"progress" json:"progress"`
 }
 
 type AsyncOps int
@@ -420,6 +409,204 @@ func NewOpDescriptionWithRemove(v RemoveArgs) OpDescription {
 	}
 }
 
+type Progress int
+type ListResult struct {
+	Entries  []Dirent `codec:"entries" json:"entries"`
+	Progress Progress `codec:"progress" json:"progress"`
+}
+
+type ReadResult struct {
+	Data     []byte   `codec:"data" json:"data"`
+	Progress Progress `codec:"progress" json:"progress"`
+}
+
+type WriteResult struct {
+	Progress Progress `codec:"progress" json:"progress"`
+}
+
+type CopyResult struct {
+	Progress Progress `codec:"progress" json:"progress"`
+}
+
+type MoveResult struct {
+	Progress Progress `codec:"progress" json:"progress"`
+}
+
+type RemoveResult struct {
+	Progress Progress `codec:"progress" json:"progress"`
+}
+
+type SimpleFSOpResult struct {
+	AsyncOp__       AsyncOps      `codec:"asyncOp" json:"asyncOp"`
+	List__          *ListResult   `codec:"list,omitempty" json:"list,omitempty"`
+	ListRecursive__ *ListResult   `codec:"listRecursive,omitempty" json:"listRecursive,omitempty"`
+	Read__          *ReadResult   `codec:"read,omitempty" json:"read,omitempty"`
+	Write__         *WritResult   `codec:"write,omitempty" json:"write,omitempty"`
+	Copy__          *CopyResult   `codec:"copy,omitempty" json:"copy,omitempty"`
+	Move__          *MoveResult   `codec:"move,omitempty" json:"move,omitempty"`
+	Remove__        *RemoveResult `codec:"remove,omitempty" json:"remove,omitempty"`
+}
+
+func (o *SimpleFSOpResult) AsyncOp() (ret AsyncOps, err error) {
+	switch o.AsyncOp__ {
+	case AsyncOps_LIST:
+		if o.List__ == nil {
+			err = errors.New("unexpected nil value for List__")
+			return ret, err
+		}
+	case AsyncOps_LIST_RECURSIVE:
+		if o.ListRecursive__ == nil {
+			err = errors.New("unexpected nil value for ListRecursive__")
+			return ret, err
+		}
+	case AsyncOps_READ:
+		if o.Read__ == nil {
+			err = errors.New("unexpected nil value for Read__")
+			return ret, err
+		}
+	case AsyncOps_WRITE:
+		if o.Write__ == nil {
+			err = errors.New("unexpected nil value for Write__")
+			return ret, err
+		}
+	case AsyncOps_COPY:
+		if o.Copy__ == nil {
+			err = errors.New("unexpected nil value for Copy__")
+			return ret, err
+		}
+	case AsyncOps_MOVE:
+		if o.Move__ == nil {
+			err = errors.New("unexpected nil value for Move__")
+			return ret, err
+		}
+	case AsyncOps_REMOVE:
+		if o.Remove__ == nil {
+			err = errors.New("unexpected nil value for Remove__")
+			return ret, err
+		}
+	}
+	return o.AsyncOp__, nil
+}
+
+func (o SimpleFSOpResult) List() ListResult {
+	if o.AsyncOp__ != AsyncOps_LIST {
+		panic("wrong case accessed")
+	}
+	if o.List__ == nil {
+		return ListResult{}
+	}
+	return *o.List__
+}
+
+func (o SimpleFSOpResult) ListRecursive() ListResult {
+	if o.AsyncOp__ != AsyncOps_LIST_RECURSIVE {
+		panic("wrong case accessed")
+	}
+	if o.ListRecursive__ == nil {
+		return ListResult{}
+	}
+	return *o.ListRecursive__
+}
+
+func (o SimpleFSOpResult) Read() ReadResult {
+	if o.AsyncOp__ != AsyncOps_READ {
+		panic("wrong case accessed")
+	}
+	if o.Read__ == nil {
+		return ReadResult{}
+	}
+	return *o.Read__
+}
+
+func (o SimpleFSOpResult) Write() WritResult {
+	if o.AsyncOp__ != AsyncOps_WRITE {
+		panic("wrong case accessed")
+	}
+	if o.Write__ == nil {
+		return WritResult{}
+	}
+	return *o.Write__
+}
+
+func (o SimpleFSOpResult) Copy() CopyResult {
+	if o.AsyncOp__ != AsyncOps_COPY {
+		panic("wrong case accessed")
+	}
+	if o.Copy__ == nil {
+		return CopyResult{}
+	}
+	return *o.Copy__
+}
+
+func (o SimpleFSOpResult) Move() MoveResult {
+	if o.AsyncOp__ != AsyncOps_MOVE {
+		panic("wrong case accessed")
+	}
+	if o.Move__ == nil {
+		return MoveResult{}
+	}
+	return *o.Move__
+}
+
+func (o SimpleFSOpResult) Remove() RemoveResult {
+	if o.AsyncOp__ != AsyncOps_REMOVE {
+		panic("wrong case accessed")
+	}
+	if o.Remove__ == nil {
+		return RemoveResult{}
+	}
+	return *o.Remove__
+}
+
+func NewSimpleFSOpResultWithList(v ListResult) SimpleFSOpResult {
+	return SimpleFSOpResult{
+		AsyncOp__: AsyncOps_LIST,
+		List__:    &v,
+	}
+}
+
+func NewSimpleFSOpResultWithListRecursive(v ListResult) SimpleFSOpResult {
+	return SimpleFSOpResult{
+		AsyncOp__:       AsyncOps_LIST_RECURSIVE,
+		ListRecursive__: &v,
+	}
+}
+
+func NewSimpleFSOpResultWithRead(v ReadResult) SimpleFSOpResult {
+	return SimpleFSOpResult{
+		AsyncOp__: AsyncOps_READ,
+		Read__:    &v,
+	}
+}
+
+func NewSimpleFSOpResultWithWrite(v WritResult) SimpleFSOpResult {
+	return SimpleFSOpResult{
+		AsyncOp__: AsyncOps_WRITE,
+		Write__:   &v,
+	}
+}
+
+func NewSimpleFSOpResultWithCopy(v CopyResult) SimpleFSOpResult {
+	return SimpleFSOpResult{
+		AsyncOp__: AsyncOps_COPY,
+		Copy__:    &v,
+	}
+}
+
+func NewSimpleFSOpResultWithMove(v MoveResult) SimpleFSOpResult {
+	return SimpleFSOpResult{
+		AsyncOp__: AsyncOps_MOVE,
+		Move__:    &v,
+	}
+}
+
+func NewSimpleFSOpResultWithRemove(v RemoveResult) SimpleFSOpResult {
+	return SimpleFSOpResult{
+		AsyncOp__: AsyncOps_REMOVE,
+		Remove__:  &v,
+	}
+}
+
 type SimpleFSListArg struct {
 	OpID OpID `codec:"opID" json:"opID"`
 	Path Path `codec:"path" json:"path"`
@@ -430,7 +617,7 @@ type SimpleFSListRecursiveArg struct {
 	Path Path `codec:"path" json:"path"`
 }
 
-type SimpleFSReadListArg struct {
+type SimpleFSWaitListArg struct {
 	OpID OpID `codec:"opID" json:"opID"`
 }
 
@@ -509,14 +696,13 @@ type SimpleFSWaitArg struct {
 
 type SimpleFSInterface interface {
 	// Begin list of items in directory at path
-	// Retrieve results with readList()
+	// Retrieve results with check()
 	// Can be a single file to get flags/status
 	SimpleFSList(context.Context, SimpleFSListArg) error
 	// Begin recursive list of items in directory at path
 	SimpleFSListRecursive(context.Context, SimpleFSListRecursiveArg) error
-	// Get list of Paths in progress. Can indicate status of pending
-	// to get more entries.
-	SimpleFSReadList(context.Context, OpID) (SimpleFSListResult, error)
+	// Get list of Paths in progress. Can return partial results.
+	SimpleFSWaitList(context.Context, OpID) (SimpleFSListResult, error)
 	// Begin copy of file or directory
 	SimpleFSCopy(context.Context, SimpleFSCopyArg) error
 	// Begin recursive copy of directory
@@ -549,7 +735,7 @@ type SimpleFSInterface interface {
 	// Must be called after list/copy/remove
 	SimpleFSClose(context.Context, OpID) error
 	// Check progress of pending operation
-	SimpleFSCheck(context.Context, OpID) (Progress, error)
+	SimpleFSCheck(context.Context, OpID) (SimpleFSOpResult, error)
 	// Get all the outstanding operations
 	SimpleFSGetOps(context.Context) ([]OpDescription, error)
 	// Blocking wait for the pending operation to finish
@@ -592,18 +778,18 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"simpleFSReadList": {
+			"simpleFSWaitList": {
 				MakeArg: func() interface{} {
-					ret := make([]SimpleFSReadListArg, 1)
+					ret := make([]SimpleFSWaitListArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]SimpleFSReadListArg)
+					typedArgs, ok := args.(*[]SimpleFSWaitListArg)
 					if !ok {
-						err = rpc.NewTypeError((*[]SimpleFSReadListArg)(nil), args)
+						err = rpc.NewTypeError((*[]SimpleFSWaitListArg)(nil), args)
 						return
 					}
-					ret, err = i.SimpleFSReadList(ctx, (*typedArgs)[0].OpID)
+					ret, err = i.SimpleFSWaitList(ctx, (*typedArgs)[0].OpID)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -847,7 +1033,7 @@ type SimpleFSClient struct {
 }
 
 // Begin list of items in directory at path
-// Retrieve results with readList()
+// Retrieve results with check()
 // Can be a single file to get flags/status
 func (c SimpleFSClient) SimpleFSList(ctx context.Context, __arg SimpleFSListArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSList", []interface{}{__arg}, nil)
@@ -860,11 +1046,10 @@ func (c SimpleFSClient) SimpleFSListRecursive(ctx context.Context, __arg SimpleF
 	return
 }
 
-// Get list of Paths in progress. Can indicate status of pending
-// to get more entries.
-func (c SimpleFSClient) SimpleFSReadList(ctx context.Context, opID OpID) (res SimpleFSListResult, err error) {
-	__arg := SimpleFSReadListArg{OpID: opID}
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSReadList", []interface{}{__arg}, &res)
+// Get list of Paths in progress. Can return partial results.
+func (c SimpleFSClient) SimpleFSWaitList(ctx context.Context, opID OpID) (res SimpleFSListResult, err error) {
+	__arg := SimpleFSWaitListArg{OpID: opID}
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSWaitList", []interface{}{__arg}, &res)
 	return
 }
 
@@ -950,7 +1135,7 @@ func (c SimpleFSClient) SimpleFSClose(ctx context.Context, opID OpID) (err error
 }
 
 // Check progress of pending operation
-func (c SimpleFSClient) SimpleFSCheck(ctx context.Context, opID OpID) (res Progress, err error) {
+func (c SimpleFSClient) SimpleFSCheck(ctx context.Context, opID OpID) (res SimpleFSOpResult, err error) {
 	__arg := SimpleFSCheckArg{OpID: opID}
 	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCheck", []interface{}{__arg}, &res)
 	return

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -410,7 +410,7 @@ func NewOpDescriptionWithRemove(v RemoveArgs) OpDescription {
 }
 
 type Progress int
-type ListResult struct {
+type SimpleFSListResult struct {
 	Entries  []Dirent `codec:"entries" json:"entries"`
 	Progress Progress `codec:"progress" json:"progress"`
 }
@@ -437,14 +437,14 @@ type RemoveResult struct {
 }
 
 type SimpleFSOpResult struct {
-	AsyncOp__       AsyncOps      `codec:"asyncOp" json:"asyncOp"`
-	List__          *ListResult   `codec:"list,omitempty" json:"list,omitempty"`
-	ListRecursive__ *ListResult   `codec:"listRecursive,omitempty" json:"listRecursive,omitempty"`
-	Read__          *ReadResult   `codec:"read,omitempty" json:"read,omitempty"`
-	Write__         *WritResult   `codec:"write,omitempty" json:"write,omitempty"`
-	Copy__          *CopyResult   `codec:"copy,omitempty" json:"copy,omitempty"`
-	Move__          *MoveResult   `codec:"move,omitempty" json:"move,omitempty"`
-	Remove__        *RemoveResult `codec:"remove,omitempty" json:"remove,omitempty"`
+	AsyncOp__       AsyncOps            `codec:"asyncOp" json:"asyncOp"`
+	List__          *SimpleFSListResult `codec:"list,omitempty" json:"list,omitempty"`
+	ListRecursive__ *SimpleFSListResult `codec:"listRecursive,omitempty" json:"listRecursive,omitempty"`
+	Read__          *ReadResult         `codec:"read,omitempty" json:"read,omitempty"`
+	Write__         *WriteResult        `codec:"write,omitempty" json:"write,omitempty"`
+	Copy__          *CopyResult         `codec:"copy,omitempty" json:"copy,omitempty"`
+	Move__          *MoveResult         `codec:"move,omitempty" json:"move,omitempty"`
+	Remove__        *RemoveResult       `codec:"remove,omitempty" json:"remove,omitempty"`
 }
 
 func (o *SimpleFSOpResult) AsyncOp() (ret AsyncOps, err error) {
@@ -488,22 +488,22 @@ func (o *SimpleFSOpResult) AsyncOp() (ret AsyncOps, err error) {
 	return o.AsyncOp__, nil
 }
 
-func (o SimpleFSOpResult) List() ListResult {
+func (o SimpleFSOpResult) List() SimpleFSListResult {
 	if o.AsyncOp__ != AsyncOps_LIST {
 		panic("wrong case accessed")
 	}
 	if o.List__ == nil {
-		return ListResult{}
+		return SimpleFSListResult{}
 	}
 	return *o.List__
 }
 
-func (o SimpleFSOpResult) ListRecursive() ListResult {
+func (o SimpleFSOpResult) ListRecursive() SimpleFSListResult {
 	if o.AsyncOp__ != AsyncOps_LIST_RECURSIVE {
 		panic("wrong case accessed")
 	}
 	if o.ListRecursive__ == nil {
-		return ListResult{}
+		return SimpleFSListResult{}
 	}
 	return *o.ListRecursive__
 }
@@ -518,12 +518,12 @@ func (o SimpleFSOpResult) Read() ReadResult {
 	return *o.Read__
 }
 
-func (o SimpleFSOpResult) Write() WritResult {
+func (o SimpleFSOpResult) Write() WriteResult {
 	if o.AsyncOp__ != AsyncOps_WRITE {
 		panic("wrong case accessed")
 	}
 	if o.Write__ == nil {
-		return WritResult{}
+		return WriteResult{}
 	}
 	return *o.Write__
 }
@@ -558,14 +558,14 @@ func (o SimpleFSOpResult) Remove() RemoveResult {
 	return *o.Remove__
 }
 
-func NewSimpleFSOpResultWithList(v ListResult) SimpleFSOpResult {
+func NewSimpleFSOpResultWithList(v SimpleFSListResult) SimpleFSOpResult {
 	return SimpleFSOpResult{
 		AsyncOp__: AsyncOps_LIST,
 		List__:    &v,
 	}
 }
 
-func NewSimpleFSOpResultWithListRecursive(v ListResult) SimpleFSOpResult {
+func NewSimpleFSOpResultWithListRecursive(v SimpleFSListResult) SimpleFSOpResult {
 	return SimpleFSOpResult{
 		AsyncOp__:       AsyncOps_LIST_RECURSIVE,
 		ListRecursive__: &v,
@@ -579,7 +579,7 @@ func NewSimpleFSOpResultWithRead(v ReadResult) SimpleFSOpResult {
 	}
 }
 
-func NewSimpleFSOpResultWithWrite(v WritResult) SimpleFSOpResult {
+func NewSimpleFSOpResultWithWrite(v WriteResult) SimpleFSOpResult {
 	return SimpleFSOpResult{
 		AsyncOp__: AsyncOps_WRITE,
 		Write__:   &v,
@@ -719,9 +719,8 @@ type SimpleFSInterface interface {
 	SimpleFSSetStat(context.Context, SimpleFSSetStatArg) error
 	// Read (possibly partial) contents of open file,
 	// up to the amount specified by size.
-	// Repeat until zero bytes are returned or error.
 	// If size is zero, read an arbitrary amount.
-	SimpleFSRead(context.Context, SimpleFSReadArg) (FileContent, error)
+	SimpleFSRead(context.Context, SimpleFSReadArg) error
 	// Append content to opened file.
 	// May be repeated until OpID is closed.
 	SimpleFSWrite(context.Context, SimpleFSWriteArg) error
@@ -901,7 +900,7 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]SimpleFSReadArg)(nil), args)
 						return
 					}
-					ret, err = i.SimpleFSRead(ctx, (*typedArgs)[0])
+					err = i.SimpleFSRead(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -1093,10 +1092,9 @@ func (c SimpleFSClient) SimpleFSSetStat(ctx context.Context, __arg SimpleFSSetSt
 
 // Read (possibly partial) contents of open file,
 // up to the amount specified by size.
-// Repeat until zero bytes are returned or error.
 // If size is zero, read an arbitrary amount.
-func (c SimpleFSClient) SimpleFSRead(ctx context.Context, __arg SimpleFSReadArg) (res FileContent, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSRead", []interface{}{__arg}, &res)
+func (c SimpleFSClient) SimpleFSRead(ctx context.Context, __arg SimpleFSReadArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSRead", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -93,24 +93,27 @@ func NewPathWithKbfs(v string) Path {
 type DirentType int
 
 const (
-	DirentType_FILE DirentType = 0
-	DirentType_DIR  DirentType = 1
-	DirentType_SYM  DirentType = 2
-	DirentType_EXEC DirentType = 3
+	DirentType_NONE DirentType = 0
+	DirentType_FILE DirentType = 1
+	DirentType_DIR  DirentType = 2
+	DirentType_SYM  DirentType = 3
+	DirentType_EXEC DirentType = 4
 )
 
 var DirentTypeMap = map[string]DirentType{
-	"FILE": 0,
-	"DIR":  1,
-	"SYM":  2,
-	"EXEC": 3,
+	"NONE": 0,
+	"FILE": 1,
+	"DIR":  2,
+	"SYM":  3,
+	"EXEC": 4,
 }
 
 var DirentTypeRevMap = map[DirentType]string{
-	0: "FILE",
-	1: "DIR",
-	2: "SYM",
-	3: "EXEC",
+	0: "NONE",
+	1: "FILE",
+	2: "DIR",
+	3: "SYM",
+	4: "EXEC",
 }
 
 func (e DirentType) String() string {
@@ -167,33 +170,36 @@ func (e OpenFlags) String() string {
 type AsyncOps int
 
 const (
-	AsyncOps_LIST           AsyncOps = 0
-	AsyncOps_LIST_RECURSIVE AsyncOps = 1
-	AsyncOps_READ           AsyncOps = 2
-	AsyncOps_WRITE          AsyncOps = 3
-	AsyncOps_COPY           AsyncOps = 4
-	AsyncOps_MOVE           AsyncOps = 5
-	AsyncOps_REMOVE         AsyncOps = 6
+	AsyncOps_NONE           AsyncOps = 0
+	AsyncOps_LIST           AsyncOps = 1
+	AsyncOps_LIST_RECURSIVE AsyncOps = 2
+	AsyncOps_READ           AsyncOps = 3
+	AsyncOps_WRITE          AsyncOps = 4
+	AsyncOps_COPY           AsyncOps = 5
+	AsyncOps_MOVE           AsyncOps = 6
+	AsyncOps_REMOVE         AsyncOps = 7
 )
 
 var AsyncOpsMap = map[string]AsyncOps{
-	"LIST":           0,
-	"LIST_RECURSIVE": 1,
-	"READ":           2,
-	"WRITE":          3,
-	"COPY":           4,
-	"MOVE":           5,
-	"REMOVE":         6,
+	"NONE":           0,
+	"LIST":           1,
+	"LIST_RECURSIVE": 2,
+	"READ":           3,
+	"WRITE":          4,
+	"COPY":           5,
+	"MOVE":           6,
+	"REMOVE":         7,
 }
 
 var AsyncOpsRevMap = map[AsyncOps]string{
-	0: "LIST",
-	1: "LIST_RECURSIVE",
-	2: "READ",
-	3: "WRITE",
-	4: "COPY",
-	5: "MOVE",
-	6: "REMOVE",
+	0: "NONE",
+	1: "LIST",
+	2: "LIST_RECURSIVE",
+	3: "READ",
+	4: "WRITE",
+	5: "COPY",
+	6: "MOVE",
+	7: "REMOVE",
 }
 
 func (e AsyncOps) String() string {

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -54,14 +54,13 @@ func (s *SimpleFSHandler) SimpleFSListRecursive(ctx context.Context, arg keybase
 	return cli.SimpleFSListRecursive(ctx, arg)
 }
 
-// SimpleFSReadList - Get list of Paths in progress. Can indicate status of pending
-// to get more entries.
-func (s *SimpleFSHandler) SimpleFSReadList(ctx context.Context, arg keybase1.OpID) (keybase1.SimpleFSListResult, error) {
+// SimpleFSWaitList - Get list of Paths in progress.
+func (s *SimpleFSHandler) SimpleFSWaitList(ctx context.Context, arg keybase1.OpID) (keybase1.SimpleFSListResult, error) {
 	cli, err := s.client()
 	if err != nil {
 		return keybase1.SimpleFSListResult{}, err
 	}
-	return cli.SimpleFSReadList(ctx, arg)
+	return cli.SimpleFSWaitList(ctx, arg)
 }
 
 // SimpleFSCopy - Begin copy of file or directory
@@ -124,10 +123,10 @@ func (s *SimpleFSHandler) SimpleFSSetStat(ctx context.Context, arg keybase1.Simp
 // up to the amount specified by size.
 // Repeat until zero bytes are returned or error.
 // If size is zero, read an arbitrary amount.
-func (s *SimpleFSHandler) SimpleFSRead(ctx context.Context, arg keybase1.SimpleFSReadArg) (keybase1.FileContent, error) {
+func (s *SimpleFSHandler) SimpleFSRead(ctx context.Context, arg keybase1.SimpleFSReadArg) error {
 	cli, err := s.client()
 	if err != nil {
-		return keybase1.FileContent{}, err
+		return err
 	}
 	return cli.SimpleFSRead(ctx, arg)
 }
@@ -180,10 +179,10 @@ func (s *SimpleFSHandler) SimpleFSClose(ctx context.Context, arg keybase1.OpID) 
 }
 
 // SimpleFSCheck - Check progress of pending operation
-func (s *SimpleFSHandler) SimpleFSCheck(ctx context.Context, arg keybase1.OpID) (keybase1.Progress, error) {
+func (s *SimpleFSHandler) SimpleFSCheck(ctx context.Context, arg keybase1.OpID) (keybase1.SimpleFSOpResult, error) {
 	cli, err := s.client()
 	if err != nil {
-		return 0, err
+		return keybase1.SimpleFSOpResult{}, err
 	}
 	return cli.SimpleFSCheck(ctx, arg)
 }

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -14,14 +14,14 @@ protocol SimpleFS {
     simpleFSOpen
     simpleFSMove
     simpleFSRemove
-  then calls one of the following until until status is no longer pending
-  or operation is cancelled:
-    simpleFSReadList (after list or listRecursive)
-    simpleFSRead (after open)
-    simpleFSWrite (after open)
-    simpleFSCheck (after copy, move or remove)
-  Caller can optionally block by calling wait()
-  Operation must be closed by calling close
+    simpleFSRead
+    simpleFSWrite
+  then calls simpleFSWait to block until the operation is finished
+  or cancelled,
+  then callse simpleFSCheck to retrieve results.
+    simpleFSWaitList (after list or listRecursive) is used for partial results.
+  
+  Operation can be cancelled by calling simpleFSClose
 */
 
   // Random GUID provided by caller 
@@ -38,10 +38,11 @@ protocol SimpleFS {
   }
 
   enum DirentType {
-    FILE_0,
-    DIR_1,
-    SYM_2,
-    EXEC_3
+    NONE_0,
+    FILE_1,
+    DIR_2,
+    SYM_3,
+    EXEC_4
   }
   
   record Dirent {
@@ -64,13 +65,14 @@ protocol SimpleFS {
   }
 
   enum AsyncOps {
-    LIST_0,
-    LIST_RECURSIVE_1,
-    READ_2,
-    WRITE_3,
-    COPY_4,
-    MOVE_5,
-    REMOVE_6
+    NONE_0,
+    LIST_1,
+    LIST_RECURSIVE_2,
+    READ_3,
+    WRITE_4,
+    COPY_5,
+    MOVE_6,
+    REMOVE_7
   }
 
   record ListArgs {

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -121,7 +121,7 @@ protocol SimpleFS {
   @typedef("int")
   record Progress {}
 
-  record ListResult {
+  record SimpleFSListResult {
     array<Dirent> entries;
     Progress progress;
   }
@@ -148,10 +148,10 @@ protocol SimpleFS {
   }
 
   variant SimpleFSOpResult switch (AsyncOps asyncOp) {
-    case LIST: ListResult;
-    case LIST_RECURSIVE: ListResult;
+    case LIST: SimpleFSListResult;
+    case LIST_RECURSIVE: SimpleFSListResult;
     case READ: ReadResult;
-    case WRITE: WritResult;
+    case WRITE: WriteResult;
     case COPY: CopyResult;
     case MOVE: MoveResult;
     case REMOVE: RemoveResult;
@@ -209,10 +209,9 @@ protocol SimpleFS {
   /**
    Read (possibly partial) contents of open file,
    up to the amount specified by size.
-   Repeat until zero bytes are returned or error.
    If size is zero, read an arbitrary amount.
    */
-  FileContent simpleFSRead(OpID opID, long offset, int size);
+  void simpleFSRead(OpID opID, long offset, int size);
 
   /**
    Append content to opened file.

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -46,7 +46,7 @@ protocol SimpleFS {
   
   record Dirent {
     Time time;
-    int size;   // size of file or count of dir entries (TBD - mmay be expensive/unnecessary)
+    long size;   // size of file, undefined for dir entries
     string name;
     DirentType direntType;
   }
@@ -62,19 +62,6 @@ protocol SimpleFS {
     APPEND_8,
     DIRECTORY_16
   }
-
-  @typedef("int")
-  record Progress {}
-
-  record SimpleFSListResult {
-    array<Dirent> entries;
-    Progress progress;
-  }
-  
-  record FileContent {
-    bytes data;         // Zero bytes when read is complete
-    Progress progress;  // Amount of data copied so far during this and previous reads
-  }                     // (TBD: should this be percentage?)
 
   enum AsyncOps {
     LIST_0,
@@ -131,9 +118,48 @@ protocol SimpleFS {
     case REMOVE: RemoveArgs;
   }
 
+  @typedef("int")
+  record Progress {}
+
+  record ListResult {
+    array<Dirent> entries;
+    Progress progress;
+  }
+  
+  record ReadResult {
+    bytes data;         // Zero bytes when read is complete
+    Progress progress;  // Amount of data copied so far during this and previous reads
+  }                     // (TBD: should this be percentage?)
+
+  record WriteResult{
+    Progress progress;    
+  }
+
+  record CopyResult{
+    Progress progress;
+  }
+
+  record MoveResult{
+    Progress progress;    
+  }
+
+  record RemoveResult{
+    Progress progress;    
+  }
+
+  variant SimpleFSOpResult switch (AsyncOps asyncOp) {
+    case LIST: ListResult;
+    case LIST_RECURSIVE: ListResult;
+    case READ: ReadResult;
+    case WRITE: WritResult;
+    case COPY: CopyResult;
+    case MOVE: MoveResult;
+    case REMOVE: RemoveResult;
+  }
+
   /**
    Begin list of items in directory at path
-   Retrieve results with readList()
+   Retrieve results with check()
    Can be a single file to get flags/status
    */
   void simpleFSList(OpID opID, Path path);
@@ -144,10 +170,9 @@ protocol SimpleFS {
   void simpleFSListRecursive(OpID opID, Path path);
 
   /**
-   Get list of Paths in progress. Can indicate status of pending
-   to get more entries.
-   */
-  SimpleFSListResult simpleFSReadList(OpID opID);
+   Get list of Paths in progress. Can return partial results.
+  */
+   SimpleFSListResult simpleFSWaitList(OpID opID);
 
   /**
    Begin copy of file or directory 
@@ -219,7 +244,7 @@ protocol SimpleFS {
   /**
    Check progress of pending operation
    */
-  Progress simpleFSCheck(OpID opID);
+  SimpleFSOpResult simpleFSCheck(OpID opID);
 
   /**
    Get all the outstanding operations

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -445,20 +445,22 @@ export const SaltpackUiSaltpackSenderType = {
 }
 
 export const SimpleFSAsyncOps = {
-  list: 0,
-  listRecursive: 1,
-  read: 2,
-  write: 3,
-  copy: 4,
-  move: 5,
-  remove: 6,
+  none: 0,
+  list: 1,
+  listRecursive: 2,
+  read: 3,
+  write: 4,
+  copy: 5,
+  move: 6,
+  remove: 7,
 }
 
 export const SimpleFSDirentType = {
-  file: 0,
-  dir: 1,
-  sym: 2,
-  exec: 3,
+  none: 0,
+  file: 1,
+  dir: 2,
+  sym: 3,
+  exec: 4,
 }
 
 export const SimpleFSOpenFlags = {
@@ -3078,13 +3080,14 @@ export type APIRes = {
 }
 
 export type AsyncOps =
-    0 // LIST_0
-  | 1 // LIST_RECURSIVE_1
-  | 2 // READ_2
-  | 3 // WRITE_3
-  | 4 // COPY_4
-  | 5 // MOVE_5
-  | 6 // REMOVE_6
+    0 // NONE_0
+  | 1 // LIST_1
+  | 2 // LIST_RECURSIVE_2
+  | 3 // READ_3
+  | 4 // WRITE_4
+  | 5 // COPY_5
+  | 6 // MOVE_6
+  | 7 // REMOVE_7
 
 export type BTCRegisterBTCRpcParam = Exact<{
   address: string,
@@ -3307,10 +3310,11 @@ export type Dirent = {
 }
 
 export type DirentType =
-    0 // FILE_0
-  | 1 // DIR_1
-  | 2 // SYM_2
-  | 3 // EXEC_3
+    0 // NONE_0
+  | 1 // FILE_1
+  | 2 // DIR_2
+  | 3 // SYM_3
+  | 4 // EXEC_4
 
 export type DismissReason = {
   type: DismissReasonType,
@@ -3874,13 +3878,13 @@ export type NotifyUsersUserChangedRpcParam = Exact<{
 }>
 
 export type OpDescription =
-    { asyncOp: 0, list: ?ListArgs }
-  | { asyncOp: 1, listRecursive: ?ListArgs }
-  | { asyncOp: 2, read: ?ReadArgs }
-  | { asyncOp: 3, write: ?WriteArgs }
-  | { asyncOp: 4, copy: ?CopyArgs }
-  | { asyncOp: 5, move: ?MoveArgs }
-  | { asyncOp: 6, remove: ?RemoveArgs }
+    { asyncOp: 1, list: ?ListArgs }
+  | { asyncOp: 2, listRecursive: ?ListArgs }
+  | { asyncOp: 3, read: ?ReadArgs }
+  | { asyncOp: 4, write: ?WriteArgs }
+  | { asyncOp: 5, copy: ?CopyArgs }
+  | { asyncOp: 6, move: ?MoveArgs }
+  | { asyncOp: 7, remove: ?RemoveArgs }
 
 export type OpID = any
 
@@ -4404,13 +4408,13 @@ export type SimpleFSListResult = {
 }
 
 export type SimpleFSOpResult =
-    { asyncOp: 0, list: ?SimpleFSListResult }
-  | { asyncOp: 1, listRecursive: ?SimpleFSListResult }
-  | { asyncOp: 2, read: ?ReadResult }
-  | { asyncOp: 3, write: ?WriteResult }
-  | { asyncOp: 4, copy: ?CopyResult }
-  | { asyncOp: 5, move: ?MoveResult }
-  | { asyncOp: 6, remove: ?RemoveResult }
+    { asyncOp: 1, list: ?SimpleFSListResult }
+  | { asyncOp: 2, listRecursive: ?SimpleFSListResult }
+  | { asyncOp: 3, read: ?ReadResult }
+  | { asyncOp: 4, write: ?WriteResult }
+  | { asyncOp: 5, copy: ?CopyResult }
+  | { asyncOp: 6, move: ?MoveResult }
+  | { asyncOp: 7, remove: ?RemoveResult }
 
 export type SimpleFSSimpleFSCheckRpcParam = Exact<{
   opID: OpID

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -730,18 +730,6 @@ export function SimpleFSSimpleFSOpenRpcPromise (request: $Exact<requestCommon & 
   return new Promise((resolve, reject) => { SimpleFSSimpleFSOpenRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
-export function SimpleFSSimpleFSReadListRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSReadListResult) => void} & {param: SimpleFSSimpleFSReadListRpcParam}>) {
-  engineRpcOutgoing({...request, method: 'keybase.1.SimpleFS.simpleFSReadList'})
-}
-
-export function SimpleFSSimpleFSReadListRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSReadListResult) => void} & {param: SimpleFSSimpleFSReadListRpcParam}>): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => SimpleFSSimpleFSReadListRpc({...request, incomingCallMap, callback}))
-}
-
-export function SimpleFSSimpleFSReadListRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSReadListResult) => void} & {param: SimpleFSSimpleFSReadListRpcParam}>): Promise<SimpleFSSimpleFSReadListResult> {
-  return new Promise((resolve, reject) => { SimpleFSSimpleFSReadListRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
-}
-
 export function SimpleFSSimpleFSReadRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSReadResult) => void} & {param: SimpleFSSimpleFSReadRpcParam}>) {
   engineRpcOutgoing({...request, method: 'keybase.1.SimpleFS.simpleFSRead'})
 }
@@ -800,6 +788,18 @@ export function SimpleFSSimpleFSStatRpcChannelMap (channelConfig: ChannelConfig<
 
 export function SimpleFSSimpleFSStatRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSStatResult) => void} & {param: SimpleFSSimpleFSStatRpcParam}>): Promise<SimpleFSSimpleFSStatResult> {
   return new Promise((resolve, reject) => { SimpleFSSimpleFSStatRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
+export function SimpleFSSimpleFSWaitListRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSWaitListResult) => void} & {param: SimpleFSSimpleFSWaitListRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'keybase.1.SimpleFS.simpleFSWaitList'})
+}
+
+export function SimpleFSSimpleFSWaitListRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSWaitListResult) => void} & {param: SimpleFSSimpleFSWaitListRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => SimpleFSSimpleFSWaitListRpc({...request, incomingCallMap, callback}))
+}
+
+export function SimpleFSSimpleFSWaitListRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSWaitListResult) => void} & {param: SimpleFSSimpleFSWaitListRpcParam}>): Promise<SimpleFSSimpleFSWaitListResult> {
+  return new Promise((resolve, reject) => { SimpleFSSimpleFSWaitListRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function SimpleFSSimpleFSWaitRpc (request: Exact<requestCommon & requestErrorCallback & {param: SimpleFSSimpleFSWaitRpcParam}>) {
@@ -3238,6 +3238,10 @@ export type CopyArgs = {
   dest: Path,
 }
 
+export type CopyResult = {
+  progress: Progress,
+}
+
 export type CryptKey = {
   KeyGeneration: int,
   Key: Bytes32,
@@ -3297,7 +3301,7 @@ export type DeviceType =
 
 export type Dirent = {
   time: Time,
-  size: int,
+  size: long,
   name: string,
   direntType: DirentType,
 }
@@ -3451,11 +3455,6 @@ export type Feature = {
 
 export type File = {
   path: string,
-}
-
-export type FileContent = {
-  data: bytes,
-  progress: Progress,
 }
 
 export type FileDescriptor = {
@@ -3779,6 +3778,10 @@ export type MoveArgs = {
   opID: OpID,
   src: Path,
   dest: Path,
+}
+
+export type MoveResult = {
+  progress: Progress,
 }
 
 export type NaclDHKeyPrivate = any
@@ -4141,6 +4144,11 @@ export type ReadArgs = {
   size: int,
 }
 
+export type ReadResult = {
+  data: bytes,
+  progress: Progress,
+}
+
 export type RegisterAddressRes = {
   type: string,
   family: string,
@@ -4185,6 +4193,10 @@ export type RemoteTrack = {
 export type RemoveArgs = {
   opID: OpID,
   path: Path,
+}
+
+export type RemoveResult = {
+  progress: Progress,
 }
 
 export type RevokeWarning = {
@@ -4386,10 +4398,14 @@ export type SignupRes = {
   writeOk: boolean,
 }
 
-export type SimpleFSListResult = {
-  entries?: ?Array<Dirent>,
-  progress: Progress,
-}
+export type SimpleFSOpResult =
+    { asyncOp: 0, list: ?ListResult }
+  | { asyncOp: 1, listRecursive: ?ListResult }
+  | { asyncOp: 2, read: ?ReadResult }
+  | { asyncOp: 3, write: ?WritResult }
+  | { asyncOp: 4, copy: ?CopyResult }
+  | { asyncOp: 5, move: ?MoveResult }
+  | { asyncOp: 6, remove: ?RemoveResult }
 
 export type SimpleFSSimpleFSCheckRpcParam = Exact<{
   opID: OpID
@@ -4433,10 +4449,6 @@ export type SimpleFSSimpleFSOpenRpcParam = Exact<{
   flags: OpenFlags
 }>
 
-export type SimpleFSSimpleFSReadListRpcParam = Exact<{
-  opID: OpID
-}>
-
 export type SimpleFSSimpleFSReadRpcParam = Exact<{
   opID: OpID,
   offset: long,
@@ -4460,6 +4472,10 @@ export type SimpleFSSimpleFSSetStatRpcParam = Exact<{
 
 export type SimpleFSSimpleFSStatRpcParam = Exact<{
   path: Path
+}>
+
+export type SimpleFSSimpleFSWaitListRpcParam = Exact<{
+  opID: OpID
 }>
 
 export type SimpleFSSimpleFSWaitRpcParam = Exact<{
@@ -4791,6 +4807,10 @@ export type WriteArgs = {
   opID: OpID,
   path: Path,
   offset: long,
+}
+
+export type WriteResult = {
+  progress: Progress,
 }
 
 export type accountEmailChangeRpcParam = Exact<{
@@ -5743,17 +5763,17 @@ type Kex2ProvisioneeHelloResult = HelloRes
 
 type SecretKeysGetSecretKeysResult = SecretKeys
 
-type SimpleFSSimpleFSCheckResult = Progress
+type SimpleFSSimpleFSCheckResult = SimpleFSOpResult
 
 type SimpleFSSimpleFSGetOpsResult = ?Array<OpDescription>
 
 type SimpleFSSimpleFSMakeOpidResult = OpID
 
-type SimpleFSSimpleFSReadListResult = SimpleFSListResult
-
 type SimpleFSSimpleFSReadResult = FileContent
 
 type SimpleFSSimpleFSStatResult = Dirent
+
+type SimpleFSSimpleFSWaitListResult = SimpleFSListResult
 
 type accountHasServerKeysResult = HasServerKeysRes
 
@@ -6022,12 +6042,12 @@ export type rpc =
   | SimpleFSSimpleFSMakeOpidRpc
   | SimpleFSSimpleFSMoveRpc
   | SimpleFSSimpleFSOpenRpc
-  | SimpleFSSimpleFSReadListRpc
   | SimpleFSSimpleFSReadRpc
   | SimpleFSSimpleFSRemoveRpc
   | SimpleFSSimpleFSRenameRpc
   | SimpleFSSimpleFSSetStatRpc
   | SimpleFSSimpleFSStatRpc
+  | SimpleFSSimpleFSWaitListRpc
   | SimpleFSSimpleFSWaitRpc
   | SimpleFSSimpleFSWriteRpc
   | accountEmailChangeRpc

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -730,15 +730,15 @@ export function SimpleFSSimpleFSOpenRpcPromise (request: $Exact<requestCommon & 
   return new Promise((resolve, reject) => { SimpleFSSimpleFSOpenRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
-export function SimpleFSSimpleFSReadRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSReadResult) => void} & {param: SimpleFSSimpleFSReadRpcParam}>) {
+export function SimpleFSSimpleFSReadRpc (request: Exact<requestCommon & requestErrorCallback & {param: SimpleFSSimpleFSReadRpcParam}>) {
   engineRpcOutgoing({...request, method: 'keybase.1.SimpleFS.simpleFSRead'})
 }
 
-export function SimpleFSSimpleFSReadRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSReadResult) => void} & {param: SimpleFSSimpleFSReadRpcParam}>): ChannelMap<*> {
+export function SimpleFSSimpleFSReadRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: SimpleFSSimpleFSReadRpcParam}>): ChannelMap<*> {
   return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => SimpleFSSimpleFSReadRpc({...request, incomingCallMap, callback}))
 }
 
-export function SimpleFSSimpleFSReadRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSReadResult) => void} & {param: SimpleFSSimpleFSReadRpcParam}>): Promise<SimpleFSSimpleFSReadResult> {
+export function SimpleFSSimpleFSReadRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: SimpleFSSimpleFSReadRpcParam}>): Promise<any> {
   return new Promise((resolve, reject) => { SimpleFSSimpleFSReadRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
@@ -4398,11 +4398,16 @@ export type SignupRes = {
   writeOk: boolean,
 }
 
+export type SimpleFSListResult = {
+  entries?: ?Array<Dirent>,
+  progress: Progress,
+}
+
 export type SimpleFSOpResult =
-    { asyncOp: 0, list: ?ListResult }
-  | { asyncOp: 1, listRecursive: ?ListResult }
+    { asyncOp: 0, list: ?SimpleFSListResult }
+  | { asyncOp: 1, listRecursive: ?SimpleFSListResult }
   | { asyncOp: 2, read: ?ReadResult }
-  | { asyncOp: 3, write: ?WritResult }
+  | { asyncOp: 3, write: ?WriteResult }
   | { asyncOp: 4, copy: ?CopyResult }
   | { asyncOp: 5, move: ?MoveResult }
   | { asyncOp: 6, remove: ?RemoveResult }
@@ -5768,8 +5773,6 @@ type SimpleFSSimpleFSCheckResult = SimpleFSOpResult
 type SimpleFSSimpleFSGetOpsResult = ?Array<OpDescription>
 
 type SimpleFSSimpleFSMakeOpidResult = OpID
-
-type SimpleFSSimpleFSReadResult = FileContent
 
 type SimpleFSSimpleFSStatResult = Dirent
 

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -278,7 +278,7 @@
     },
     {
       "type": "record",
-      "name": "ListResult",
+      "name": "SimpleFSListResult",
       "fields": [
         {
           "type": {
@@ -360,14 +360,14 @@
             "name": "LIST",
             "def": false
           },
-          "body": "ListResult"
+          "body": "SimpleFSListResult"
         },
         {
           "label": {
             "name": "LIST_RECURSIVE",
             "def": false
           },
-          "body": "ListResult"
+          "body": "SimpleFSListResult"
         },
         {
           "label": {
@@ -381,7 +381,7 @@
             "name": "WRITE",
             "def": false
           },
-          "body": "WritResult"
+          "body": "WriteResult"
         },
         {
           "label": {
@@ -561,8 +561,8 @@
           "type": "int"
         }
       ],
-      "response": "FileContent",
-      "doc": "Read (possibly partial) contents of open file,\n   up to the amount specified by size.\n   Repeat until zero bytes are returned or error.\n   If size is zero, read an arbitrary amount."
+      "response": null,
+      "doc": "Read (possibly partial) contents of open file,\n   up to the amount specified by size.\n   If size is zero, read an arbitrary amount."
     },
     "simpleFSWrite": {
       "request": [

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -48,10 +48,11 @@
       "type": "enum",
       "name": "DirentType",
       "symbols": [
-        "FILE_0",
-        "DIR_1",
-        "SYM_2",
-        "EXEC_3"
+        "NONE_0",
+        "FILE_1",
+        "DIR_2",
+        "SYM_3",
+        "EXEC_4"
       ]
     },
     {
@@ -98,13 +99,14 @@
       "type": "enum",
       "name": "AsyncOps",
       "symbols": [
-        "LIST_0",
-        "LIST_RECURSIVE_1",
-        "READ_2",
-        "WRITE_3",
-        "COPY_4",
-        "MOVE_5",
-        "REMOVE_6"
+        "NONE_0",
+        "LIST_1",
+        "LIST_RECURSIVE_2",
+        "READ_3",
+        "WRITE_4",
+        "COPY_5",
+        "MOVE_6",
+        "REMOVE_7"
       ]
     },
     {

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -63,7 +63,7 @@
           "name": "time"
         },
         {
-          "type": "int",
+          "type": "long",
           "name": "size"
         },
         {
@@ -92,43 +92,6 @@
         "WRITE_4",
         "APPEND_8",
         "DIRECTORY_16"
-      ]
-    },
-    {
-      "type": "record",
-      "name": "Progress",
-      "fields": [],
-      "typedef": "int"
-    },
-    {
-      "type": "record",
-      "name": "SimpleFSListResult",
-      "fields": [
-        {
-          "type": {
-            "type": "array",
-            "items": "Dirent"
-          },
-          "name": "entries"
-        },
-        {
-          "type": "Progress",
-          "name": "progress"
-        }
-      ]
-    },
-    {
-      "type": "record",
-      "name": "FileContent",
-      "fields": [
-        {
-          "type": "bytes",
-          "name": "data"
-        },
-        {
-          "type": "Progress",
-          "name": "progress"
-        }
       ]
     },
     {
@@ -306,6 +269,142 @@
           "body": "RemoveArgs"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "Progress",
+      "fields": [],
+      "typedef": "int"
+    },
+    {
+      "type": "record",
+      "name": "ListResult",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "Dirent"
+          },
+          "name": "entries"
+        },
+        {
+          "type": "Progress",
+          "name": "progress"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "ReadResult",
+      "fields": [
+        {
+          "type": "bytes",
+          "name": "data"
+        },
+        {
+          "type": "Progress",
+          "name": "progress"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "WriteResult",
+      "fields": [
+        {
+          "type": "Progress",
+          "name": "progress"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "CopyResult",
+      "fields": [
+        {
+          "type": "Progress",
+          "name": "progress"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "MoveResult",
+      "fields": [
+        {
+          "type": "Progress",
+          "name": "progress"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "RemoveResult",
+      "fields": [
+        {
+          "type": "Progress",
+          "name": "progress"
+        }
+      ]
+    },
+    {
+      "type": "variant",
+      "name": "SimpleFSOpResult",
+      "switch": {
+        "type": "AsyncOps",
+        "name": "asyncOp"
+      },
+      "cases": [
+        {
+          "label": {
+            "name": "LIST",
+            "def": false
+          },
+          "body": "ListResult"
+        },
+        {
+          "label": {
+            "name": "LIST_RECURSIVE",
+            "def": false
+          },
+          "body": "ListResult"
+        },
+        {
+          "label": {
+            "name": "READ",
+            "def": false
+          },
+          "body": "ReadResult"
+        },
+        {
+          "label": {
+            "name": "WRITE",
+            "def": false
+          },
+          "body": "WritResult"
+        },
+        {
+          "label": {
+            "name": "COPY",
+            "def": false
+          },
+          "body": "CopyResult"
+        },
+        {
+          "label": {
+            "name": "MOVE",
+            "def": false
+          },
+          "body": "MoveResult"
+        },
+        {
+          "label": {
+            "name": "REMOVE",
+            "def": false
+          },
+          "body": "RemoveResult"
+        }
+      ]
     }
   ],
   "messages": {
@@ -321,7 +420,7 @@
         }
       ],
       "response": null,
-      "doc": "Begin list of items in directory at path\n   Retrieve results with readList()\n   Can be a single file to get flags/status"
+      "doc": "Begin list of items in directory at path\n   Retrieve results with check()\n   Can be a single file to get flags/status"
     },
     "simpleFSListRecursive": {
       "request": [
@@ -337,7 +436,7 @@
       "response": null,
       "doc": "Begin recursive list of items in directory at path"
     },
-    "simpleFSReadList": {
+    "simpleFSWaitList": {
       "request": [
         {
           "name": "opID",
@@ -345,7 +444,7 @@
         }
       ],
       "response": "SimpleFSListResult",
-      "doc": "Get list of Paths in progress. Can indicate status of pending\n   to get more entries."
+      "doc": "Get list of Paths in progress. Can return partial results."
     },
     "simpleFSCopy": {
       "request": [
@@ -529,7 +628,7 @@
           "type": "OpID"
         }
       ],
-      "response": "Progress",
+      "response": "SimpleFSOpResult",
       "doc": "Check progress of pending operation"
     },
     "simpleFSGetOps": {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -445,20 +445,22 @@ export const SaltpackUiSaltpackSenderType = {
 }
 
 export const SimpleFSAsyncOps = {
-  list: 0,
-  listRecursive: 1,
-  read: 2,
-  write: 3,
-  copy: 4,
-  move: 5,
-  remove: 6,
+  none: 0,
+  list: 1,
+  listRecursive: 2,
+  read: 3,
+  write: 4,
+  copy: 5,
+  move: 6,
+  remove: 7,
 }
 
 export const SimpleFSDirentType = {
-  file: 0,
-  dir: 1,
-  sym: 2,
-  exec: 3,
+  none: 0,
+  file: 1,
+  dir: 2,
+  sym: 3,
+  exec: 4,
 }
 
 export const SimpleFSOpenFlags = {
@@ -3078,13 +3080,14 @@ export type APIRes = {
 }
 
 export type AsyncOps =
-    0 // LIST_0
-  | 1 // LIST_RECURSIVE_1
-  | 2 // READ_2
-  | 3 // WRITE_3
-  | 4 // COPY_4
-  | 5 // MOVE_5
-  | 6 // REMOVE_6
+    0 // NONE_0
+  | 1 // LIST_1
+  | 2 // LIST_RECURSIVE_2
+  | 3 // READ_3
+  | 4 // WRITE_4
+  | 5 // COPY_5
+  | 6 // MOVE_6
+  | 7 // REMOVE_7
 
 export type BTCRegisterBTCRpcParam = Exact<{
   address: string,
@@ -3307,10 +3310,11 @@ export type Dirent = {
 }
 
 export type DirentType =
-    0 // FILE_0
-  | 1 // DIR_1
-  | 2 // SYM_2
-  | 3 // EXEC_3
+    0 // NONE_0
+  | 1 // FILE_1
+  | 2 // DIR_2
+  | 3 // SYM_3
+  | 4 // EXEC_4
 
 export type DismissReason = {
   type: DismissReasonType,
@@ -3874,13 +3878,13 @@ export type NotifyUsersUserChangedRpcParam = Exact<{
 }>
 
 export type OpDescription =
-    { asyncOp: 0, list: ?ListArgs }
-  | { asyncOp: 1, listRecursive: ?ListArgs }
-  | { asyncOp: 2, read: ?ReadArgs }
-  | { asyncOp: 3, write: ?WriteArgs }
-  | { asyncOp: 4, copy: ?CopyArgs }
-  | { asyncOp: 5, move: ?MoveArgs }
-  | { asyncOp: 6, remove: ?RemoveArgs }
+    { asyncOp: 1, list: ?ListArgs }
+  | { asyncOp: 2, listRecursive: ?ListArgs }
+  | { asyncOp: 3, read: ?ReadArgs }
+  | { asyncOp: 4, write: ?WriteArgs }
+  | { asyncOp: 5, copy: ?CopyArgs }
+  | { asyncOp: 6, move: ?MoveArgs }
+  | { asyncOp: 7, remove: ?RemoveArgs }
 
 export type OpID = any
 
@@ -4404,13 +4408,13 @@ export type SimpleFSListResult = {
 }
 
 export type SimpleFSOpResult =
-    { asyncOp: 0, list: ?SimpleFSListResult }
-  | { asyncOp: 1, listRecursive: ?SimpleFSListResult }
-  | { asyncOp: 2, read: ?ReadResult }
-  | { asyncOp: 3, write: ?WriteResult }
-  | { asyncOp: 4, copy: ?CopyResult }
-  | { asyncOp: 5, move: ?MoveResult }
-  | { asyncOp: 6, remove: ?RemoveResult }
+    { asyncOp: 1, list: ?SimpleFSListResult }
+  | { asyncOp: 2, listRecursive: ?SimpleFSListResult }
+  | { asyncOp: 3, read: ?ReadResult }
+  | { asyncOp: 4, write: ?WriteResult }
+  | { asyncOp: 5, copy: ?CopyResult }
+  | { asyncOp: 6, move: ?MoveResult }
+  | { asyncOp: 7, remove: ?RemoveResult }
 
 export type SimpleFSSimpleFSCheckRpcParam = Exact<{
   opID: OpID

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -730,18 +730,6 @@ export function SimpleFSSimpleFSOpenRpcPromise (request: $Exact<requestCommon & 
   return new Promise((resolve, reject) => { SimpleFSSimpleFSOpenRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
-export function SimpleFSSimpleFSReadListRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSReadListResult) => void} & {param: SimpleFSSimpleFSReadListRpcParam}>) {
-  engineRpcOutgoing({...request, method: 'keybase.1.SimpleFS.simpleFSReadList'})
-}
-
-export function SimpleFSSimpleFSReadListRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSReadListResult) => void} & {param: SimpleFSSimpleFSReadListRpcParam}>): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => SimpleFSSimpleFSReadListRpc({...request, incomingCallMap, callback}))
-}
-
-export function SimpleFSSimpleFSReadListRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSReadListResult) => void} & {param: SimpleFSSimpleFSReadListRpcParam}>): Promise<SimpleFSSimpleFSReadListResult> {
-  return new Promise((resolve, reject) => { SimpleFSSimpleFSReadListRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
-}
-
 export function SimpleFSSimpleFSReadRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSReadResult) => void} & {param: SimpleFSSimpleFSReadRpcParam}>) {
   engineRpcOutgoing({...request, method: 'keybase.1.SimpleFS.simpleFSRead'})
 }
@@ -800,6 +788,18 @@ export function SimpleFSSimpleFSStatRpcChannelMap (channelConfig: ChannelConfig<
 
 export function SimpleFSSimpleFSStatRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSStatResult) => void} & {param: SimpleFSSimpleFSStatRpcParam}>): Promise<SimpleFSSimpleFSStatResult> {
   return new Promise((resolve, reject) => { SimpleFSSimpleFSStatRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
+export function SimpleFSSimpleFSWaitListRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSWaitListResult) => void} & {param: SimpleFSSimpleFSWaitListRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'keybase.1.SimpleFS.simpleFSWaitList'})
+}
+
+export function SimpleFSSimpleFSWaitListRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSWaitListResult) => void} & {param: SimpleFSSimpleFSWaitListRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => SimpleFSSimpleFSWaitListRpc({...request, incomingCallMap, callback}))
+}
+
+export function SimpleFSSimpleFSWaitListRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSWaitListResult) => void} & {param: SimpleFSSimpleFSWaitListRpcParam}>): Promise<SimpleFSSimpleFSWaitListResult> {
+  return new Promise((resolve, reject) => { SimpleFSSimpleFSWaitListRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function SimpleFSSimpleFSWaitRpc (request: Exact<requestCommon & requestErrorCallback & {param: SimpleFSSimpleFSWaitRpcParam}>) {
@@ -3238,6 +3238,10 @@ export type CopyArgs = {
   dest: Path,
 }
 
+export type CopyResult = {
+  progress: Progress,
+}
+
 export type CryptKey = {
   KeyGeneration: int,
   Key: Bytes32,
@@ -3297,7 +3301,7 @@ export type DeviceType =
 
 export type Dirent = {
   time: Time,
-  size: int,
+  size: long,
   name: string,
   direntType: DirentType,
 }
@@ -3451,11 +3455,6 @@ export type Feature = {
 
 export type File = {
   path: string,
-}
-
-export type FileContent = {
-  data: bytes,
-  progress: Progress,
 }
 
 export type FileDescriptor = {
@@ -3779,6 +3778,10 @@ export type MoveArgs = {
   opID: OpID,
   src: Path,
   dest: Path,
+}
+
+export type MoveResult = {
+  progress: Progress,
 }
 
 export type NaclDHKeyPrivate = any
@@ -4141,6 +4144,11 @@ export type ReadArgs = {
   size: int,
 }
 
+export type ReadResult = {
+  data: bytes,
+  progress: Progress,
+}
+
 export type RegisterAddressRes = {
   type: string,
   family: string,
@@ -4185,6 +4193,10 @@ export type RemoteTrack = {
 export type RemoveArgs = {
   opID: OpID,
   path: Path,
+}
+
+export type RemoveResult = {
+  progress: Progress,
 }
 
 export type RevokeWarning = {
@@ -4386,10 +4398,14 @@ export type SignupRes = {
   writeOk: boolean,
 }
 
-export type SimpleFSListResult = {
-  entries?: ?Array<Dirent>,
-  progress: Progress,
-}
+export type SimpleFSOpResult =
+    { asyncOp: 0, list: ?ListResult }
+  | { asyncOp: 1, listRecursive: ?ListResult }
+  | { asyncOp: 2, read: ?ReadResult }
+  | { asyncOp: 3, write: ?WritResult }
+  | { asyncOp: 4, copy: ?CopyResult }
+  | { asyncOp: 5, move: ?MoveResult }
+  | { asyncOp: 6, remove: ?RemoveResult }
 
 export type SimpleFSSimpleFSCheckRpcParam = Exact<{
   opID: OpID
@@ -4433,10 +4449,6 @@ export type SimpleFSSimpleFSOpenRpcParam = Exact<{
   flags: OpenFlags
 }>
 
-export type SimpleFSSimpleFSReadListRpcParam = Exact<{
-  opID: OpID
-}>
-
 export type SimpleFSSimpleFSReadRpcParam = Exact<{
   opID: OpID,
   offset: long,
@@ -4460,6 +4472,10 @@ export type SimpleFSSimpleFSSetStatRpcParam = Exact<{
 
 export type SimpleFSSimpleFSStatRpcParam = Exact<{
   path: Path
+}>
+
+export type SimpleFSSimpleFSWaitListRpcParam = Exact<{
+  opID: OpID
 }>
 
 export type SimpleFSSimpleFSWaitRpcParam = Exact<{
@@ -4791,6 +4807,10 @@ export type WriteArgs = {
   opID: OpID,
   path: Path,
   offset: long,
+}
+
+export type WriteResult = {
+  progress: Progress,
 }
 
 export type accountEmailChangeRpcParam = Exact<{
@@ -5743,17 +5763,17 @@ type Kex2ProvisioneeHelloResult = HelloRes
 
 type SecretKeysGetSecretKeysResult = SecretKeys
 
-type SimpleFSSimpleFSCheckResult = Progress
+type SimpleFSSimpleFSCheckResult = SimpleFSOpResult
 
 type SimpleFSSimpleFSGetOpsResult = ?Array<OpDescription>
 
 type SimpleFSSimpleFSMakeOpidResult = OpID
 
-type SimpleFSSimpleFSReadListResult = SimpleFSListResult
-
 type SimpleFSSimpleFSReadResult = FileContent
 
 type SimpleFSSimpleFSStatResult = Dirent
+
+type SimpleFSSimpleFSWaitListResult = SimpleFSListResult
 
 type accountHasServerKeysResult = HasServerKeysRes
 
@@ -6022,12 +6042,12 @@ export type rpc =
   | SimpleFSSimpleFSMakeOpidRpc
   | SimpleFSSimpleFSMoveRpc
   | SimpleFSSimpleFSOpenRpc
-  | SimpleFSSimpleFSReadListRpc
   | SimpleFSSimpleFSReadRpc
   | SimpleFSSimpleFSRemoveRpc
   | SimpleFSSimpleFSRenameRpc
   | SimpleFSSimpleFSSetStatRpc
   | SimpleFSSimpleFSStatRpc
+  | SimpleFSSimpleFSWaitListRpc
   | SimpleFSSimpleFSWaitRpc
   | SimpleFSSimpleFSWriteRpc
   | accountEmailChangeRpc

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -730,15 +730,15 @@ export function SimpleFSSimpleFSOpenRpcPromise (request: $Exact<requestCommon & 
   return new Promise((resolve, reject) => { SimpleFSSimpleFSOpenRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
-export function SimpleFSSimpleFSReadRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSReadResult) => void} & {param: SimpleFSSimpleFSReadRpcParam}>) {
+export function SimpleFSSimpleFSReadRpc (request: Exact<requestCommon & requestErrorCallback & {param: SimpleFSSimpleFSReadRpcParam}>) {
   engineRpcOutgoing({...request, method: 'keybase.1.SimpleFS.simpleFSRead'})
 }
 
-export function SimpleFSSimpleFSReadRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSReadResult) => void} & {param: SimpleFSSimpleFSReadRpcParam}>): ChannelMap<*> {
+export function SimpleFSSimpleFSReadRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: SimpleFSSimpleFSReadRpcParam}>): ChannelMap<*> {
   return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => SimpleFSSimpleFSReadRpc({...request, incomingCallMap, callback}))
 }
 
-export function SimpleFSSimpleFSReadRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSReadResult) => void} & {param: SimpleFSSimpleFSReadRpcParam}>): Promise<SimpleFSSimpleFSReadResult> {
+export function SimpleFSSimpleFSReadRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: SimpleFSSimpleFSReadRpcParam}>): Promise<any> {
   return new Promise((resolve, reject) => { SimpleFSSimpleFSReadRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
@@ -4398,11 +4398,16 @@ export type SignupRes = {
   writeOk: boolean,
 }
 
+export type SimpleFSListResult = {
+  entries?: ?Array<Dirent>,
+  progress: Progress,
+}
+
 export type SimpleFSOpResult =
-    { asyncOp: 0, list: ?ListResult }
-  | { asyncOp: 1, listRecursive: ?ListResult }
+    { asyncOp: 0, list: ?SimpleFSListResult }
+  | { asyncOp: 1, listRecursive: ?SimpleFSListResult }
   | { asyncOp: 2, read: ?ReadResult }
-  | { asyncOp: 3, write: ?WritResult }
+  | { asyncOp: 3, write: ?WriteResult }
   | { asyncOp: 4, copy: ?CopyResult }
   | { asyncOp: 5, move: ?MoveResult }
   | { asyncOp: 6, remove: ?RemoveResult }
@@ -5768,8 +5773,6 @@ type SimpleFSSimpleFSCheckResult = SimpleFSOpResult
 type SimpleFSSimpleFSGetOpsResult = ?Array<OpDescription>
 
 type SimpleFSSimpleFSMakeOpidResult = OpID
-
-type SimpleFSSimpleFSReadResult = FileContent
 
 type SimpleFSSimpleFSStatResult = Dirent
 


### PR DESCRIPTION
The main thing this does is make read, write and stat so that are async and their results are retrieved separately. There are a couple of other tweaks too.

If we like this, I'll merge it into KBFS and my CLI PR and try to get them all working again.