### PR TITLE
enforce PrevPtr/BodyHash/ConvID invariants in UnboxMessage

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/crypto/nacl/secretbox"
 	"golang.org/x/net/context"
 
+	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
@@ -77,13 +78,27 @@ func (b *Boxer) makeErrorMessage(msg chat1.MessageBoxed, err UnboxingError) chat
 	})
 }
 
-// UnboxMessage unboxes a chat1.MessageBoxed into a keybase1.Message.  It finds
-// the appropriate keybase1.CryptKey.
-// The first return value is unusable if the err != nil
-// Returns (_, err) for non-permanent errors, and (MessageUnboxedError, nil) for permanent errors.
-// Permanent errors can be cached and must be treated as a value to deal with.
-// Whereas temporary errors are transient failures.
-func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, finalizeInfo *chat1.ConversationFinalizeInfo) (chat1.MessageUnboxed, UnboxingError) {
+// UnboxMessage unboxes a chat1.MessageBoxed into a chat1.MessageUnboxed. It
+// finds the appropriate keybase1.CryptKey, decrypts the message, and verifies
+// several things:
+//   - The message's signature is valid.
+//   - (TODO) The signing KID was valid when the signature was made.
+//   - (TODO) The signing KID belongs to the sending device.
+//   - (TODO) The sending device belongs to the sender.
+//     [Note that we do currently check the KID -> UID relationship,
+//     independent of the device ID.]
+//   - (TODO) The sender has write permission in the TLF.
+//   - (TODO) The TLF name, public flag, and finalized info resolve to the TLF ID.
+//   - (TODO) The conversation ID derives from the ConversationIDTriple.
+//   - The body hash is not a replay from another message we know about.
+//   - The prev pointers are consistent with other messages we know about.
+//   - (TODO) The prev pointers are not absurdly ancient.
+//
+// The first return value is unusable if the err != nil Returns (_, err) for
+// non-permanent errors, and (MessageUnboxedError, nil) for permanent errors.
+// Permanent errors can be cached and must be treated as a value to deal with,
+// whereas temporary errors are transient failures.
+func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, convID chat1.ConversationID, finalizeInfo *chat1.ConversationFinalizeInfo) (chat1.MessageUnboxed, UnboxingError) {
 	tlfName := boxed.ClientHeader.TLFNameExpanded(finalizeInfo)
 	tlfPublic := boxed.ClientHeader.TlfPublic
 	keys, err := CtxKeyFinder(ctx).Find(ctx, b.tlf(), tlfName, tlfPublic)
@@ -114,6 +129,58 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, fina
 		}
 		return chat1.MessageUnboxed{}, ierr
 	}
+
+	// Make sure the body hash is unique to this message, and then record it.
+	// This detects attempts by the server to replay a message. Right now we
+	// use a "first writer wins" rule here, though we could also consider a
+	// "duplication invalidates both" rule if we wanted to be stricter. Note
+	// that this only prevents replays of messages you *know about*. There's
+	// currently nothing stopping the server from replaying an ancient message
+	// if you're never going to fetch enough history to notice.
+	//
+	// But...wait...why aren't we using the header hash here? It covers more
+	// stuff, and we're using it below, when we check the consistency of
+	// messages and prev pointers...
+	//
+	// The reason we can't use the header hash to prevent replays is that it's
+	// a hash *of* a signature, rather than a hash that's *been signed*.
+	// Unfortunately, most signature schemes are "malleable" in some way,
+	// depending on the implementation. See
+	// http://crypto.stackexchange.com/a/14719/21442. If I have the shared
+	// encryption key (and recall that in public chats, everyone does), I can
+	// decrypt the message, twiddle your signature into another valid signature
+	// over the same plaintext, reencrypt the whole thing, and pass it off as a
+	// new valid message with a seemingly new signature and therefore a unique
+	// header hash. Because the body hash is unique to each message (derived
+	// from a random nonce), and because it's *inside* the signature, we use
+	// that to detect replays instead.
+	replayErr := storage.CheckAndRecordBodyHash(b.G(), unboxed.BodyHash, boxed.ServerHeader.MessageID, convID)
+	if replayErr != nil {
+		b.Debug(ctx, "UnboxMessage found a replayed body hash: %s", replayErr)
+		return chat1.MessageUnboxed{}, NewPermanentUnboxingError(replayErr)
+	}
+
+	// Make sure the header hash and prev pointers of this message are
+	// consistent with every other message we've seen, and record them.
+	//
+	// The discussion above explains why we have to use the body hash there to
+	// prevent replays. But we need to use the header hash here, because it's
+	// the only thing that covers the entire message. The goal isn't to prevent
+	// the creation of new messages (as it was above), but to prevent an old
+	// message from changing.
+	prevPtrErr := storage.CheckAndRecordPrevPointer(b.G(), boxed.ServerHeader.MessageID, convID, unboxed.HeaderHash)
+	if prevPtrErr != nil {
+		b.Debug(ctx, "UnboxMessage found an inconsistent header hash: %s", prevPtrErr)
+		return chat1.MessageUnboxed{}, NewPermanentUnboxingError(prevPtrErr)
+	}
+	for _, prevPtr := range unboxed.ClientHeader.Prev {
+		prevPtrErr := storage.CheckAndRecordPrevPointer(b.G(), prevPtr.Id, convID, prevPtr.Hash)
+		if prevPtrErr != nil {
+			b.Debug(ctx, "UnboxMessage found an inconsistent prev pointer: %s", prevPtrErr)
+			return chat1.MessageUnboxed{}, NewPermanentUnboxingError(prevPtrErr)
+		}
+	}
+
 	return chat1.NewMessageUnboxedWithValid(*unboxed), nil
 }
 
@@ -245,11 +312,13 @@ func (b *Boxer) unboxV1(ctx context.Context, boxed chat1.MessageBoxed, encryptio
 	}
 
 	var headerSignature *chat1.SignatureInfo
+	var bodyHash chat1.Hash
 	switch headerVersion {
 	case chat1.HeaderPlaintextVersion_V1:
 		// Verified above in verifyMessageV1
 		headerSignature = header.V1().HeaderSignature
 		hp := header.V1()
+		bodyHash = hp.BodyHash
 		clientHeader = chat1.MessageClientHeaderVerified{
 			Conv:         hp.Conv,
 			TlfName:      hp.TlfName,
@@ -305,6 +374,7 @@ func (b *Boxer) unboxV1(ctx context.Context, boxed chat1.MessageBoxed, encryptio
 		SenderUsername:        senderUsername,
 		SenderDeviceName:      senderDeviceName,
 		SenderDeviceType:      senderDeviceType,
+		BodyHash:              bodyHash,
 		HeaderHash:            headerHash,
 		HeaderSignature:       headerSignature,
 		VerificationKey:       nil,
@@ -323,7 +393,7 @@ func (b *Boxer) UnboxThread(ctx context.Context, boxed chat1.ThreadViewBoxed, co
 		Pagination: boxed.Pagination,
 	}
 
-	if thread.Messages, err = b.UnboxMessages(ctx, boxed.Messages, finalizeInfo); err != nil {
+	if thread.Messages, err = b.UnboxMessages(ctx, boxed.Messages, convID, finalizeInfo); err != nil {
 		return chat1.ThreadView{}, err
 	}
 
@@ -376,9 +446,9 @@ func (b *Boxer) getSenderInfoLocal(ctx context.Context, uid1 gregor1.UID, device
 	return username, deviceName, deviceType
 }
 
-func (b *Boxer) UnboxMessages(ctx context.Context, boxed []chat1.MessageBoxed, finalizeInfo *chat1.ConversationFinalizeInfo) (unboxed []chat1.MessageUnboxed, err error) {
+func (b *Boxer) UnboxMessages(ctx context.Context, boxed []chat1.MessageBoxed, convID chat1.ConversationID, finalizeInfo *chat1.ConversationFinalizeInfo) (unboxed []chat1.MessageUnboxed, err error) {
 	for _, msg := range boxed {
-		decmsg, err := b.UnboxMessage(ctx, msg, finalizeInfo)
+		decmsg, err := b.UnboxMessage(ctx, msg, convID, finalizeInfo)
 		if err != nil {
 			return unboxed, err
 		}

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -187,7 +187,7 @@ func (s *RemoteConversationSource) GetMessages(ctx context.Context, convID chat1
 		MessageIDs:     msgIDs,
 	})
 
-	msgs, err := s.boxer.UnboxMessages(ctx, rres.Msgs, finalizeInfo)
+	msgs, err := s.boxer.UnboxMessages(ctx, rres.Msgs, convID, finalizeInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (s *RemoteConversationSource) GetMessagesWithRemotes(ctx context.Context,
 	if s.IsOffline() {
 		return nil, nil
 	}
-	return s.boxer.UnboxMessages(ctx, msgs, finalizeInfo)
+	return s.boxer.UnboxMessages(ctx, msgs, convID, finalizeInfo)
 }
 
 type HybridConversationSource struct {
@@ -244,7 +244,7 @@ func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.Conver
 	// coincides with an account reset.
 	var emptyFinalizeInfo *chat1.ConversationFinalizeInfo
 
-	decmsg, err := s.boxer.UnboxMessage(ctx, msg, emptyFinalizeInfo)
+	decmsg, err := s.boxer.UnboxMessage(ctx, msg, convID, emptyFinalizeInfo)
 	if err != nil {
 		return decmsg, continuousUpdate, err
 	}
@@ -525,7 +525,7 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 		}
 
 		// Unbox all the remote messages
-		rmsgsUnboxed, err := s.boxer.UnboxMessages(ctx, rmsgs.Msgs, finalizeInfo)
+		rmsgsUnboxed, err := s.boxer.UnboxMessages(ctx, rmsgs.Msgs, convID, finalizeInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -589,7 +589,7 @@ func (s *HybridConversationSource) GetMessagesWithRemotes(ctx context.Context,
 		if lmsg, ok := lmsgsTab[msg.GetMessageID()]; ok {
 			res = append(res, lmsg)
 		} else if !s.IsOffline() {
-			unboxed, err := s.boxer.UnboxMessage(ctx, msg, finalizeInfo)
+			unboxed, err := s.boxer.UnboxMessage(ctx, msg, convID, finalizeInfo)
 			if err != nil {
 				return res, err
 			}

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -247,6 +247,7 @@ func TestNonblockTimer(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		obr, err := outbox.PushMessage(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
+				Conv:      trip,
 				Sender:    u.User.GetUID().ToBytes(),
 				TlfName:   u.Username,
 				TlfPublic: false,

--- a/go/chat/storage/checkers.go
+++ b/go/chat/storage/checkers.go
@@ -1,0 +1,93 @@
+package storage
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+)
+
+type BodyHashChecker func(bodyHash chat1.Hash, uniqueMsgID chat1.MessageID, uniqueConvID chat1.ConversationID) error
+type PrevChecker func(msgID chat1.MessageID, convID chat1.ConversationID, uniqueHeaderHash chat1.Hash) error
+
+// These are globally unique. They don't include the UID.
+func makeBodyHashIndexKey(bodyHash chat1.Hash) libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBChatBodyHashIndex,
+		Key: fmt.Sprintf("bodyhash:%s", bodyHash),
+	}
+}
+
+func makeBodyHashIndexValue(convID chat1.ConversationID, msgID chat1.MessageID) []byte {
+	return []byte(fmt.Sprintf("%s:%d", hex.EncodeToString(convID), msgID))
+}
+
+// Check the current message's body hash against all the body hashes we've
+// seen, to prevent replays. If the header hash is new, add it to the set.
+func CheckAndRecordBodyHash(g *libkb.GlobalContext, bodyHash chat1.Hash, uniqueMsgID chat1.MessageID, uniqueConvID chat1.ConversationID) error {
+	bodyHashKey := makeBodyHashIndexKey(bodyHash)
+	bodyHashValue := []byte(fmt.Sprintf("%s:%s", uniqueConvID, uniqueMsgID))
+	existingVal, found, err := g.LocalChatDb.GetRaw(bodyHashKey)
+	// Log errors as warnings, and skip this check. That prevents a corrupt
+	// leveldb cache from breaking chat.
+	if err != nil {
+		g.Log.Warning("error getting body hash key from chat db: %s", err)
+		return nil
+	}
+	if found {
+		if !bytes.Equal(existingVal, bodyHashValue) {
+			err := fmt.Errorf("chat message body hash replay detected, %s != %s", string(existingVal), string(bodyHashValue))
+			g.Log.Error("%s", err)
+			return err
+		}
+		return nil
+	}
+	err = g.LocalChatDb.PutRaw(bodyHashKey, bodyHashValue)
+	// Also suppress write errors.
+	if err != nil {
+		g.Log.Warning("error writing body hash key to chat db: %s", err)
+	}
+	return nil
+}
+
+// These are globally unique. They don't include the UID.
+func makePrevIndexKey(convID chat1.ConversationID, msgID chat1.MessageID) libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBChatBodyHashIndex,
+		Key: fmt.Sprintf("prev:%s:%s", hex.EncodeToString(convID), msgID),
+	}
+}
+
+func makePrevIndexValue(headerHash chat1.Hash) []byte {
+	return []byte(hex.EncodeToString(headerHash))
+}
+
+// Check the current message's header hash against all the prev pointers we've
+// ever seen. If the current message is new, add it to the set.
+func CheckAndRecordPrevPointer(g *libkb.GlobalContext, msgID chat1.MessageID, convID chat1.ConversationID, uniqueHeaderHash chat1.Hash) error {
+	prevKey := makePrevIndexKey(convID, msgID)
+	headerHashVal := makePrevIndexValue(uniqueHeaderHash)
+	existingVal, found, err := g.LocalChatDb.GetRaw(prevKey)
+	// Log errors as warnings, and skip this check. That prevents a corrupt
+	// leveldb cache from breaking chat.
+	if err != nil {
+		g.Log.Warning("error getting prev pointer key from chat db: %s", err)
+		return nil
+	}
+	if found {
+		if !bytes.Equal(existingVal, headerHashVal) {
+			err := fmt.Errorf("chat message prev pointer inconsistency detected, %s != %s", string(existingVal), string(headerHashVal))
+			g.Log.Error("%s", err)
+			return err
+		}
+		return nil
+	}
+	err = g.LocalChatDb.PutRaw(prevKey, headerHashVal)
+	// Also suppress write errors.
+	if err != nil {
+		g.Log.Warning("error writing body hash key to chat db: %s", err)
+	}
+	return nil
+}

--- a/go/chat/storage/storage_test.go
+++ b/go/chat/storage/storage_test.go
@@ -465,3 +465,42 @@ func TestStorageFetchMessages(t *testing.T) {
 	}
 	require.Equal(t, 1, nils, "wrong number of nils")
 }
+
+func TestStorageDetectBodyHashReplay(t *testing.T) {
+	tc, _, _ := setupStorageTest(t, "fetchMessages")
+
+	// The first time we encounter a body hash it's stored.
+	err := CheckAndRecordBodyHash(tc.G, chat1.Hash("foo"), 1, chat1.ConversationID("bar"))
+	require.NoError(t, err)
+
+	// Seeing the same body hash again in the same message is fine. That just
+	// means we uboxed it twice.
+	err = CheckAndRecordBodyHash(tc.G, chat1.Hash("foo"), 1, chat1.ConversationID("bar"))
+	require.NoError(t, err)
+
+	// But seeing the hash again with a different convID/msgID is a replay, and
+	// it must trigger an error.
+	err = CheckAndRecordBodyHash(tc.G, chat1.Hash("foo"), 1, chat1.ConversationID("bar2"))
+	require.Error(t, err)
+	err = CheckAndRecordBodyHash(tc.G, chat1.Hash("foo"), 2, chat1.ConversationID("bar"))
+	require.Error(t, err)
+}
+
+func TestStorageDetectPrevPtrInconsistency(t *testing.T) {
+	tc, _, _ := setupStorageTest(t, "fetchMessages")
+
+	// The first time we encounter a message ID (either in unboxing or in
+	// another message's prev pointer) its header hash is stored.
+	err := CheckAndRecordPrevPointer(tc.G, 1, chat1.ConversationID("bar"), chat1.Hash("foo"))
+	require.NoError(t, err)
+
+	// Seeing the same header hash again in the same message is fine. That just
+	// means we uboxed it twice.
+	err = CheckAndRecordPrevPointer(tc.G, 1, chat1.ConversationID("bar"), chat1.Hash("foo"))
+	require.NoError(t, err)
+
+	// But seeing the same convID/msgID with a different header hash is a
+	// consistency violation, and it must trigger an error.
+	err = CheckAndRecordPrevPointer(tc.G, 1, chat1.ConversationID("bar"), chat1.Hash("foo2"))
+	require.Error(t, err)
+}

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -191,6 +191,7 @@ const (
 	DBChatInbox               = 0xf9
 	DBIdentify                = 0xfa
 	DBResolveUsernameToUID    = 0xfb
+	DBChatBodyHashIndex       = 0xfc
 )
 
 const (

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1146,6 +1146,7 @@ type MessageUnboxedValid struct {
 	SenderUsername        string                      `codec:"senderUsername" json:"senderUsername"`
 	SenderDeviceName      string                      `codec:"senderDeviceName" json:"senderDeviceName"`
 	SenderDeviceType      string                      `codec:"senderDeviceType" json:"senderDeviceType"`
+	BodyHash              Hash                        `codec:"bodyHash" json:"bodyHash"`
 	HeaderHash            Hash                        `codec:"headerHash" json:"headerHash"`
 	HeaderSignature       *SignatureInfo              `codec:"headerSignature,omitempty" json:"headerSignature,omitempty"`
 	VerificationKey       *[]byte                     `codec:"verificationKey,omitempty" json:"verificationKey,omitempty"`

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -73,6 +73,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 
 	h.tlf = kbtest.NewTlfMock(c.world)
 	h.boxer = chat.NewBoxer(tc.G, func() keybase1.TlfInterface { return h.tlf })
+
 	f := func() libkb.SecretUI {
 		return &libkb.TestSecretUI{Passphrase: user.Passphrase}
 	}

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -158,6 +158,8 @@ protocol common {
     gregor1.Time composeTime;
   }
 
+  // The Boxer's compareClientHeaders function checks each of these fields. If
+  // we add a field here, it needs to be updated.
   record MessageClientHeader {
     // This type is attached to MessageBoxed.
     // When on a received message these fields are server-set and have not been verified.

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -258,6 +258,7 @@ protocol local {
     string senderUsername;
     string senderDeviceName;
     string senderDeviceType;
+    Hash bodyHash;
 
     // MessageBoxed.V1: Hash of the encrypted header ciphertext.
     // MessageBoxed.V2: Hash of MessageBoxed.headerSealed (.v || .n || .b)

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1231,6 +1231,7 @@ export type MessageUnboxedValid = {
   senderUsername: string,
   senderDeviceName: string,
   senderDeviceType: string,
+  bodyHash: Hash,
   headerHash: Hash,
   headerSignature?: ?SignatureInfo,
   verificationKey?: ?bytes,

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -819,6 +819,10 @@
         },
         {
           "type": "Hash",
+          "name": "bodyHash"
+        },
+        {
+          "type": "Hash",
           "name": "headerHash"
         },
         {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1231,6 +1231,7 @@ export type MessageUnboxedValid = {
   senderUsername: string,
   senderDeviceName: string,
   senderDeviceType: string,
+  bodyHash: Hash,
   headerHash: Hash,
   headerSignature?: ?SignatureInfo,
   verificationKey?: ?bytes,


### PR DESCRIPTION
r? @mlsteele @mmaxim (cc @maxtaco @patrickxb)

This adds a couple new indices to the chat local DB, to prevent replay attacks (of messages we've seen before, at least) and inconsistent prev pointers. It also adds a check to make sure that messages belong to the conversation we think we're unboxing them for. I've added a big comment on top of UnboxMessage listing all the things I think we need to be checking, about half of which we are checking now, and I'm curious to get yall's thoughts on those.

@mlsteele, is `UnboxMessage` still the right place for this stuff to live?

@mmaxim, some storage specific questions:

1) This is adding a lot more db rows than we had before, a couple for every message (compared to a couple for every hundred(?) messages with the block storage engine). Will we want to do a block storage trick again, or are we fine with this?
2) Do we have a story yet for what we're going to do when the cache gets too big? Not necessarily specific to this PR, but I want to make sure I'm not making anything harder for us in the future.
3) ~I should probably bump the cache version to bust existing caches as part of this change. What's the right  place to do that?~ Looks like @mlsteele is doing it in https://github.com/keybase/client/pull/6010. I think I can piggyback off of that.
4) I haven't been very permissive with storage errors here. What's our philosophy on handling a "disk write failed" sort of situation?