### PR TITLE
Allow tracking users with no keys

### DIFF
--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -179,6 +179,7 @@ type FakeIdentifyUI struct {
 	Confirmed       bool
 	Keys            map[libkb.PGPFingerprint]*keybase1.TrackDiff
 	DisplayKeyCalls int
+	DisplayKeyDiffs []*keybase1.TrackDiff
 	Outcome         *keybase1.IdentifyOutcome
 	StartCount      int
 	Token           keybase1.TrackToken
@@ -248,9 +249,16 @@ func (ui *FakeIdentifyUI) DisplayKey(ik keybase1.IdentifyKey) error {
 	if ui.Keys == nil {
 		ui.Keys = make(map[libkb.PGPFingerprint]*keybase1.TrackDiff)
 	}
-	fp := libkb.ImportPGPFingerprintSlice(ik.PGPFingerprint)
 
-	ui.Keys[*fp] = ik.TrackDiff
+	fp := libkb.ImportPGPFingerprintSlice(ik.PGPFingerprint)
+	if fp != nil {
+		ui.Keys[*fp] = ik.TrackDiff
+	}
+
+	if ik.TrackDiff != nil {
+		ui.DisplayKeyDiffs = append(ui.DisplayKeyDiffs, ik.TrackDiff)
+	}
+
 	ui.DisplayKeyCalls++
 	return nil
 }

--- a/go/engine/track.go
+++ b/go/engine/track.go
@@ -71,9 +71,8 @@ func (e *TrackEngine) Run(ctx *Context) error {
 
 	upk := ieng.Result().Upk
 	var err error
-	loadarg := libkb.NewLoadUserByUIDArg(ctx.GetNetContext(), e.G(), upk.Uid)
-	loadarg.PublicKeyOptional = true
-	e.them, err = libkb.LoadUser(loadarg)
+	loadarg := libkb.NewLoadUserArgBase(e.G()).WithNetContext(ctx.NetContext).WithUID(upk.Uid).WithPublicKeyOptional()
+	e.them, err = libkb.LoadUser(*loadarg)
 	if err != nil {
 		return err
 	}

--- a/go/engine/track.go
+++ b/go/engine/track.go
@@ -71,7 +71,9 @@ func (e *TrackEngine) Run(ctx *Context) error {
 
 	upk := ieng.Result().Upk
 	var err error
-	e.them, err = libkb.LoadUser(libkb.NewLoadUserByUIDArg(ctx.GetNetContext(), e.G(), upk.Uid))
+	loadarg := libkb.NewLoadUserByUIDArg(ctx.GetNetContext(), e.G(), upk.Uid)
+	loadarg.PublicKeyOptional = true
+	e.them, err = libkb.LoadUser(loadarg)
 	if err != nil {
 		return err
 	}

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -380,3 +380,15 @@ func TestIdentifyTrackRaceDetection(t *testing.T) {
 
 	runUntrack(dev1.G, user, trackee)
 }
+
+func TestTrackNoKeys(t *testing.T) {
+	tc := SetupEngineTest(t, "track")
+	defer tc.Cleanup()
+	nk, pp := createFakeUserWithNoKeys(tc)
+	_ = pp
+	Logout(tc)
+
+	fu := CreateAndSignupFakeUser(tc, "track")
+
+	trackUser(tc, fu, libkb.NewNormalizedUsername(nk))
+}

--- a/go/engine/track_test.go
+++ b/go/engine/track_test.go
@@ -82,6 +82,14 @@ func trackUser(tc libkb.TestContext, fu *FakeUser, un libkb.NormalizedUsername) 
 	}
 }
 
+func trackUserGetUI(tc libkb.TestContext, fu *FakeUser, un libkb.NormalizedUsername) *FakeIdentifyUI {
+	ui, _, err := runTrackWithOptions(tc, fu, un.String(), keybase1.TrackOptions{BypassConfirm: true}, fu.NewSecretUI(), false)
+	if err != nil {
+		tc.T.Fatal(err)
+	}
+	return ui
+}
+
 func trackAliceWithOptions(tc libkb.TestContext, fu *FakeUser, options keybase1.TrackOptions, secretUI libkb.SecretUI) {
 	idUI, res, err := runTrackWithOptions(tc, fu, "t_alice", options, secretUI, false)
 	if err != nil {
@@ -133,10 +141,10 @@ func TestTrack(t *testing.T) {
 	trackBob(tc, fu)
 	defer untrackBob(tc, fu)
 
-	// try tracking a user with no keys
+	// try tracking a user with no keys (which is now allowed)
 	_, _, err = runTrack(tc, fu, "t_ellen")
-	if err == nil {
-		t.Errorf("expected error tracking t_ellen, got nil")
+	if err != nil {
+		t.Errorf("expected no error tracking t_ellen (user with no keys), got %s", err)
 	}
 	return
 }
@@ -385,10 +393,30 @@ func TestTrackNoKeys(t *testing.T) {
 	tc := SetupEngineTest(t, "track")
 	defer tc.Cleanup()
 	nk, pp := createFakeUserWithNoKeys(tc)
-	_ = pp
 	Logout(tc)
 
 	fu := CreateAndSignupFakeUser(tc, "track")
-
 	trackUser(tc, fu, libkb.NewNormalizedUsername(nk))
+
+	// provision nk on a new device
+	Logout(tc)
+	nku := &FakeUser{Username: nk, Passphrase: pp}
+	if err := nku.Login(tc.G); err != nil {
+		t.Fatal(err)
+	}
+	Logout(tc)
+
+	// track nk again
+	if err := fu.Login(tc.G); err != nil {
+		t.Fatal(err)
+	}
+	ui := trackUserGetUI(tc, fu, libkb.NewNormalizedUsername(nk))
+
+	// ensure track diff for new eldest key
+	if len(ui.DisplayKeyDiffs) != 1 {
+		t.Fatal("no key diffs displayed")
+	}
+	if ui.DisplayKeyDiffs[0].Type != keybase1.TrackDiffType_NEW_ELDEST {
+		t.Errorf("track diff type: %v, expected NEW_ELDEST (%v)", ui.DisplayKeyDiffs[0].Type, keybase1.TrackDiffType_NEW_ELDEST)
+	}
 }

--- a/go/engine/track_token.go
+++ b/go/engine/track_token.go
@@ -181,7 +181,10 @@ func (e *TrackToken) loadMe() error {
 }
 
 func (e *TrackToken) loadThem(username libkb.NormalizedUsername) error {
-	them, err := libkb.LoadUser(libkb.NewLoadUserByNameArg(e.G(), username.String()))
+
+	arg := libkb.NewLoadUserByNameArg(e.G(), username.String())
+	arg.PublicKeyOptional = true
+	them, err := libkb.LoadUser(arg)
 	if err != nil {
 		return err
 	}

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -150,12 +150,11 @@ func (u *User) ToTrackingStatementSeqTail() *jsonw.Wrapper {
 func (u *User) ToTrackingStatement(w *jsonw.Wrapper, outcome *IdentifyOutcome) (err error) {
 
 	track := jsonw.NewDictionary()
-	var keyErr error
-	key := u.ToTrackingStatementKey(&keyErr)
-	if keyErr != nil {
-		u.G().Log.Debug("ignoring ToTrackingStatementKey error: %s", keyErr)
-	} else if key != nil {
-		track.SetKey("key", key)
+	if u.HasActiveKey() {
+		key := u.ToTrackingStatementKey(&err)
+		if key != nil {
+			track.SetKey("key", key)
+		}
 	}
 	if pgpkeys := u.ToTrackingStatementPGPKeys(&err); pgpkeys != nil {
 		track.SetKey("pgp_keys", pgpkeys)

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -150,7 +150,13 @@ func (u *User) ToTrackingStatementSeqTail() *jsonw.Wrapper {
 func (u *User) ToTrackingStatement(w *jsonw.Wrapper, outcome *IdentifyOutcome) (err error) {
 
 	track := jsonw.NewDictionary()
-	track.SetKey("key", u.ToTrackingStatementKey(&err))
+	var keyErr error
+	key := u.ToTrackingStatementKey(&keyErr)
+	if keyErr != nil {
+		u.G().Log.Debug("ignoring ToTrackingStatementKey error: %s", keyErr)
+	} else if key != nil {
+		track.SetKey("key", key)
+	}
 	if pgpkeys := u.ToTrackingStatementPGPKeys(&err); pgpkeys != nil {
 		track.SetKey("pgp_keys", pgpkeys)
 	}

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -5,11 +5,12 @@ package libkb
 
 import (
 	"fmt"
+	"runtime/debug"
+
+	"golang.org/x/net/context"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	jsonw "github.com/keybase/go-jsonw"
-	"golang.org/x/net/context"
-	"runtime/debug"
 )
 
 type LoadUserArg struct {
@@ -81,6 +82,25 @@ func NewLoadUserByUIDForceArg(g *GlobalContext, uid keybase1.UID) LoadUserArg {
 
 func NewLoadUserPubOptionalArg(g *GlobalContext) LoadUserArg {
 	arg := NewLoadUserArg(g)
+	arg.PublicKeyOptional = true
+	return arg
+}
+
+func NewLoadUserArgBase(g *GlobalContext) *LoadUserArg {
+	return &LoadUserArg{Contextified: NewContextified(g)}
+}
+
+func (arg *LoadUserArg) WithNetContext(ctx context.Context) *LoadUserArg {
+	arg.NetContext = ctx
+	return arg
+}
+
+func (arg *LoadUserArg) WithUID(uid keybase1.UID) *LoadUserArg {
+	arg.UID = uid
+	return arg
+}
+
+func (arg *LoadUserArg) WithPublicKeyOptional() *LoadUserArg {
 	arg.PublicKeyOptional = true
 	return arg
 }

--- a/go/libkb/track.go
+++ b/go/libkb/track.go
@@ -364,7 +364,7 @@ func (t TrackDiffNewEldest) GetTrackDiffType() keybase1.TrackDiffType {
 }
 func (t TrackDiffNewEldest) ToDisplayString() string {
 	if t.tracked.IsNil() {
-		return fmt.Sprintf("No key when tracked; established new eldest key %s", t.observed)
+		return fmt.Sprintf("No key when followed; established new eldest key %s", t.observed)
 	}
 	return fmt.Sprintf("Account reset! Old key was %s; new key is %s", t.tracked, t.observed)
 }

--- a/go/libkb/track.go
+++ b/go/libkb/track.go
@@ -363,6 +363,9 @@ func (t TrackDiffNewEldest) GetTrackDiffType() keybase1.TrackDiffType {
 	return keybase1.TrackDiffType_NEW_ELDEST
 }
 func (t TrackDiffNewEldest) ToDisplayString() string {
+	if t.tracked.IsNil() {
+		return fmt.Sprintf("No key when tracked; established new eldest key %s", t.observed)
+	}
 	return fmt.Sprintf("Account reset! Old key was %s; new key is %s", t.tracked, t.observed)
 }
 func (t TrackDiffNewEldest) ToDisplayMarkup() *Markup {


### PR DESCRIPTION
This patch allows tracking users with no keys and adds a test to ensure that after the user gets device keys via provisioning, the identify ui displays a new eldest key notice.