### PR TITLE
disable admin checks on merkle skips

### DIFF
--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -690,10 +690,7 @@ func (mc *MerkleClient) LastRoot() *MerkleRoot {
 func (mc *MerkleClient) FirstSeqnoWithSkips() *Seqno {
 
 	if mc.G().Env.GetRunMode() == ProductionRunMode {
-		if mc.G().Env.GetFeatureFlags().Admin() {
-			return &FirstProdMerkleSeqnoWithSkips
-		}
-		return nil
+		return &FirstProdMerkleSeqnoWithSkips
 	}
 
 	mc.RLock()


### PR DESCRIPTION
- they were never actually disabled
- all users were using skip pointers as long as the server sent them back
- the one thing we weren't doing is making sure that the server sent them back. that check was disabled via `Admin()`-feature-flag checking.