### PR TITLE
Mobile: Simple chat attachments for photos

### DIFF
--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -176,10 +176,7 @@ export default connect(
     onPostMessage: (selectedConversation, text) => dispatch(postMessage(selectedConversation, new HiddenString(text))),
     onRetryAttachment: (message: AttachmentMessage) => dispatch(retryAttachment(message)),
     onRetryMessage: (conversationIDKey: ConversationIDKey, outboxID: OutboxIDKey) => dispatch(retryMessage(conversationIDKey, outboxID)),
-    onSelectAttachment: (conversationIDKey: ConversationIDKey, input: AttachmentInput) => {
-      input.conversationIDKey = conversationIDKey
-      dispatch(selectAttachment(input))
-    },
+    onSelectAttachment: (conversationIDKey: ConversationIDKey, input: AttachmentInput) => dispatch(selectAttachment(input)),
     startConversation: (users: Array<string>) => dispatch(startConversation(users)),
     onStoreInputText: (inputText: string) => setRouteState({inputText}),
     onShowProfile: (username: string) => dispatch(onUserClick(username, '')),

--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -5,7 +5,7 @@ import React, {Component} from 'react'
 import {Box} from '../../common-adapters'
 import {List, Map} from 'immutable'
 import {connect} from 'react-redux'
-import {deleteMessage, editMessage, loadMoreMessages, muteConversation, newChat, openFolder, postMessage, retryMessage, startConversation, loadAttachment, retryAttachment} from '../../actions/chat'
+import {deleteMessage, editMessage, loadMoreMessages, muteConversation, newChat, openFolder, postMessage, retryMessage, selectAttachment, startConversation, loadAttachment, retryAttachment} from '../../actions/chat'
 import * as ChatConstants from '../../constants/chat'
 import {downloadFilePath} from '../../util/file'
 import {getProfile} from '../../actions/tracker'
@@ -176,6 +176,10 @@ export default connect(
     onPostMessage: (selectedConversation, text) => dispatch(postMessage(selectedConversation, new HiddenString(text))),
     onRetryAttachment: (message: AttachmentMessage) => dispatch(retryAttachment(message)),
     onRetryMessage: (conversationIDKey: ConversationIDKey, outboxID: OutboxIDKey) => dispatch(retryMessage(conversationIDKey, outboxID)),
+    onSelectAttachment: (conversationIDKey: ConversationIDKey, input: AttachmentInput) => {
+      input.conversationIDKey = conversationIDKey
+      dispatch(selectAttachment(input))
+    },
     startConversation: (users: Array<string>) => dispatch(startConversation(users)),
     onStoreInputText: (inputText: string) => setRouteState({inputText}),
     onShowProfile: (username: string) => dispatch(onUserClick(username, '')),
@@ -216,6 +220,7 @@ export default connect(
       onMuteConversation: (muted: boolean) => dispatchProps.onMuteConversation(stateProps.selectedConversation, muted),
       onPostMessage: text => dispatchProps.onPostMessage(stateProps.selectedConversation, text),
       onRetryMessage: (outboxID: OutboxIDKey) => dispatchProps.onRetryMessage(stateProps.selectedConversation, outboxID),
+      onSelectAttachment: (input) => dispatchProps.onSelectAttachment(stateProps.selectedConversation, input),
       restartConversation: () => dispatchProps.startConversation(stateProps.participants.toArray()),
     }
   },

--- a/shared/chat/conversation/index-hoc.js
+++ b/shared/chat/conversation/index-hoc.js
@@ -29,6 +29,7 @@ const hoc = withProps(
       onPostMessage,
       onRetryAttachment,
       onRetryMessage,
+      onSelectAttachment,
       selectedConversation,
       sidePanelOpen,
       validated,
@@ -67,6 +68,7 @@ const hoc = withProps(
       onEditMessage,
       onEditLastMessage: () => console.log('todo'),
       onPostMessage,
+      onSelectAttachment,
       selectedConversation,
     }
 

--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -159,6 +159,7 @@ class Conversation extends Component<void, Props & EditLastHandlerProps, State> 
       onRetryAttachment,
       onRetryMessage,
       onShowProfile,
+      onSelectAttachment,
       onToggleSidePanel,
       muted,
       participants,
@@ -227,6 +228,7 @@ class Conversation extends Component<void, Props & EditLastHandlerProps, State> 
             onAttach={onAttach}
             onEditLastMessage={onEditLastMessage}
             onPostMessage={onPostMessage}
+            onSelectAttachment={onSelectAttachment}
             selectedConversation={selectedConversation}
           /> }
         {sidePanelOpen && <div style={{...globalStyles.flexBoxColumn, bottom: 0, position: 'absolute', right: 0, top: 35, width: 320}}>

--- a/shared/chat/conversation/index.js.flow
+++ b/shared/chat/conversation/index.js.flow
@@ -31,6 +31,7 @@ export type Props = {
   onPostMessage: (text: string) => void,
   onRetryAttachment: (message: AttachmentMessage) => void,
   onRetryMessage: (outboxID: string) => void,
+  onSelectAttachment: (input: AttachmentInput) => void,
   onShowProfile: (username: string) => void,
   onStoreInputText: (inputText: string) => void,
   onToggleSidePanel: () => void,

--- a/shared/chat/conversation/input.js.flow
+++ b/shared/chat/conversation/input.js.flow
@@ -10,6 +10,7 @@ export type Props = {
   onAttach: (inputs: Array<AttachmentInput>) => void,
   onPostMessage: (text: string) => void,
   onEditLastMessage: () => void,
+  onSelectAttachment: (input: AttachmentInput) => void,
   selectedConversation: ?ConversationIDKey,
 }
 

--- a/shared/chat/conversation/input.native.js
+++ b/shared/chat/conversation/input.native.js
@@ -4,7 +4,9 @@ import React, {Component} from 'react'
 import {Box, Icon, Input, Text} from '../../common-adapters'
 import {globalMargins, globalStyles} from '../../styles'
 import {isIOS} from '../../constants/platform'
+import ImagePicker from 'react-native-image-picker'
 
+import type {AttachmentInput} from '../../constants/chat'
 import type {Props} from './input'
 
 type State = {
@@ -51,7 +53,18 @@ class ConversationInput extends Component<void, Props, State> {
   }
 
   _openFilePicker = () => {
-    console.log('openFilePicker')
+    ImagePicker.showImagePicker({}, (response) => {
+      const filename = isIOS ? response.uri.replace('file://', '') : response.path
+      const conversationIDKey = this.props.selectedConversation
+      if (conversationIDKey) {
+        this.props.onSelectAttachment(({
+          conversationIDKey,
+          filename,
+          title: response.fileName,
+          type: 'Image',
+        }: AttachmentInput))
+      }
+    })
   }
 
   render () {

--- a/shared/package.json
+++ b/shared/package.json
@@ -75,7 +75,7 @@
     "react-list": "0.8.0",
     "react-native": "0.41.2",
     "react-native-camera": "0.6.0",
-    "react-native-image-picker": "^0.25.6",
+    "react-native-image-picker": "0.25.6",
     "react-native-push-notification": "2.2.1",
     "react-redux": "5.0.2",
     "react-tap-event-plugin": "2.0.1",

--- a/shared/package.json
+++ b/shared/package.json
@@ -75,6 +75,7 @@
     "react-list": "0.8.0",
     "react-native": "0.41.2",
     "react-native-camera": "0.6.0",
+    "react-native-image-picker": "^0.25.6",
     "react-native-push-notification": "2.2.1",
     "react-redux": "5.0.2",
     "react-tap-event-plugin": "2.0.1",

--- a/shared/react-native/android/app/build.gradle
+++ b/shared/react-native/android/app/build.gradle
@@ -170,4 +170,5 @@ dependencies {
     compile project(':keybaselib')
     testCompile 'junit:junit:4.12'
     compile project(':react-native-camera')
+    compile project(':react-native-image-picker')
 }

--- a/shared/react-native/android/app/src/main/AndroidManifest.xml
+++ b/shared/react-native/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <permission
         android:name="${applicationId}.permission.C2D_MESSAGE"

--- a/shared/react-native/android/app/src/main/AndroidManifest.xml
+++ b/shared/react-native/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <permission
         android:name="${applicationId}.permission.C2D_MESSAGE"

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
@@ -7,6 +7,7 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.dieam.reactnativepushnotification.ReactNativePushNotificationPackage;
 import com.lwansbrough.RCTCamera.RCTCameraPackage;
+import com.imagepicker.ImagePickerPackage;
 
 import java.io.File;
 import java.util.Arrays;
@@ -35,7 +36,8 @@ public class MainApplication extends Application implements ReactApplication {
               new MainReactPackage(),
               new KBReactPackage(logFile.getAbsolutePath()),
               new ReactNativePushNotificationPackage(),
-              new RCTCameraPackage()
+              new RCTCameraPackage(),
+              new ImagePickerPackage()
       );
     }
 

--- a/shared/react-native/android/settings.gradle
+++ b/shared/react-native/android/settings.gradle
@@ -5,3 +5,5 @@ include ':react-native-push-notification', ':app'
 project(':react-native-push-notification').projectDir = new File(rootProject.projectDir, '../../node_modules/react-native-push-notification/android')
 include ':react-native-camera'
 project(':react-native-camera').projectDir = new File(rootProject.projectDir,   '../../node_modules/react-native-camera/android')
+include ':react-native-image-picker'
+project(':react-native-image-picker').projectDir = new File(rootProject.projectDir, '../../node_modules/react-native-image-picker/android')

--- a/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
+++ b/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
@@ -42,9 +42,17 @@
 		DBDC80111DE7CC8E005387B3 /* SourceCodePro-Semi_bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = DBDC80091DE7CC8E005387B3 /* SourceCodePro-Semi_bold.ttf */; };
 		DBDC80121DE7CC8E005387B3 /* SourceCodePro.ttf in Resources */ = {isa = PBXBuildFile; fileRef = DBDC800A1DE7CC8E005387B3 /* SourceCodePro.ttf */; };
 		DBDCF30E1B8D03DD00BA95D8 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DBDCF3081B8D03DD00BA95D8 /* Images.xcassets */; };
+		DCF5D67E98CE413A87F0068C /* libRNImagePicker.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A77BBAD7A94F4A2580CA3B23 /* libRNImagePicker.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		27429B071E64A7A90058A4F9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FE98B29CDF6C4C4085FF2315 /* RNImagePicker.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 014A3B5C1C6CF33500B6D375;
+			remoteInfo = RNImagePicker;
+		};
 		DB0417D91E200FC0000B4B1F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8A6B0997A42F4CC08AE6F28F /* RCTCamera.xcodeproj */;
@@ -250,6 +258,7 @@
 		00E356F21AD99517003FC87E /* KeybaseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KeybaseTests.m; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* Keybase.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Keybase.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A6B0997A42F4CC08AE6F28F /* RCTCamera.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTCamera.xcodeproj; path = "../../node_modules/react-native-camera/ios/RCTCamera.xcodeproj"; sourceTree = "<group>"; };
+		A77BBAD7A94F4A2580CA3B23 /* libRNImagePicker.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNImagePicker.a; sourceTree = "<group>"; };
 		A969A4091CF65C9C00F273F2 /* LogSend.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LogSend.m; sourceTree = "<group>"; };
 		A969A4161CF65CB200F273F2 /* LogSend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LogSend.h; sourceTree = "<group>"; };
 		D4D90F8FFC2D4682850A6803 /* libRCTCamera.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTCamera.a; sourceTree = "<group>"; };
@@ -290,6 +299,7 @@
 		DBDCF3081B8D03DD00BA95D8 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		DBDCF3091B8D03DD00BA95D8 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DBDCF3441B8D04FC00BA95D8 /* Keybase-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Keybase-Bridging-Header.h"; sourceTree = "<group>"; };
+		FE98B29CDF6C4C4085FF2315 /* RNImagePicker.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNImagePicker.xcodeproj; path = "../../node_modules/react-native-image-picker/ios/RNImagePicker.xcodeproj"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -311,6 +321,7 @@
 				DB2BD1EF1DE7D9A600BB7989 /* libReact.a in Frameworks */,
 				DB0846051BA75DC800F54960 /* keybase.framework in Frameworks */,
 				7608E936D0B84B4FB1849590 /* libRCTCamera.a in Frameworks */,
+				DCF5D67E98CE413A87F0068C /* libRNImagePicker.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -341,6 +352,14 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		27429AEA1E64A7A90058A4F9 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				27429B081E64A7A90058A4F9 /* libRNImagePicker.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
@@ -358,6 +377,7 @@
 				DB2BD17E1DE7D81C00BB7989 /* React.xcodeproj */,
 				DB0846041BA75DC800F54960 /* keybase.framework */,
 				8A6B0997A42F4CC08AE6F28F /* RCTCamera.xcodeproj */,
+				FE98B29CDF6C4C4085FF2315 /* RNImagePicker.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -693,6 +713,10 @@
 					ProductGroup = DB2BD17F1DE7D81C00BB7989 /* Products */;
 					ProjectRef = DB2BD17E1DE7D81C00BB7989 /* React.xcodeproj */;
 				},
+				{
+					ProductGroup = 27429AEA1E64A7A90058A4F9 /* Products */;
+					ProjectRef = FE98B29CDF6C4C4085FF2315 /* RNImagePicker.xcodeproj */;
+				},
 			);
 			projectRoot = "";
 			targets = (
@@ -703,6 +727,13 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		27429B081E64A7A90058A4F9 /* libRNImagePicker.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNImagePicker.a;
+			remoteRef = 27429B071E64A7A90058A4F9 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		DB0417DA1E200FC0000B4B1F /* libRCTCamera.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1055,12 +1086,14 @@
 					"$(SRCROOT)/KeybaseGo",
 					"$(SRCROOT)/../../node_modules/react-native/Libraries/PushNotificationIOS",
 					"$(SRCROOT)/../../node_modules/react-native-camera/ios/**",
+					"$(SRCROOT)/../../node_modules/react-native-image-picker/ios",
 				);
 				INFOPLIST_FILE = Keybase/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/Keybase\"",
 					"\"$(SRCROOT)/Keybase\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1099,12 +1132,14 @@
 					"$(SRCROOT)/KeybaseGo",
 					"$(SRCROOT)/../../node_modules/react-native/Libraries/PushNotificationIOS",
 					"$(SRCROOT)/../../node_modules/react-native-camera/ios/**",
+					"$(SRCROOT)/../../node_modules/react-native-image-picker/ios",
 				);
 				INFOPLIST_FILE = Keybase/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/Keybase\"",
 					"\"$(SRCROOT)/Keybase\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1162,6 +1197,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native-camera/ios/**",
+					"$(SRCROOT)/../../node_modules/react-native-image-picker/ios",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -1207,6 +1243,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native-camera/ios/**",
+					"$(SRCROOT)/../../node_modules/react-native-image-picker/ios",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
@@ -1233,6 +1270,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/KeybaseGo",
 					"$(SRCROOT)/../../node_modules/react-native-camera/ios/**",
+					"$(SRCROOT)/../../node_modules/react-native-image-picker/ios",
 				);
 				INFOPLIST_FILE = Keybase/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -1275,6 +1313,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/KeybaseGo",
 					"$(SRCROOT)/../../node_modules/react-native-camera/ios/**",
+					"$(SRCROOT)/../../node_modules/react-native-image-picker/ios",
 				);
 				INFOPLIST_FILE = Keybase/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;

--- a/shared/react-native/ios/Keybase/Info.plist
+++ b/shared/react-native/ios/Keybase/Info.plist
@@ -60,5 +60,7 @@
 	<false/>
 	<key>NSCameraUsageDescription</key>
 	<string>Scanning codes</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Attaching images to Chat messages</string>
 </dict>
 </plist>

--- a/shared/react-native/ios/Keybase/Info.plist
+++ b/shared/react-native/ios/Keybase/Info.plist
@@ -61,6 +61,6 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Scanning codes</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Attaching images to Chat messages</string>
+	<string>Attaching images to chat messages</string>
 </dict>
 </plist>

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -1180,6 +1180,10 @@ balanced-match@^0.4.1, balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
+base-64@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
+
 base16@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/base16/-/base16-1.0.0.tgz#e297f60d7ec1014a7a971a39ebc8a98c0b681e70"
@@ -3181,7 +3185,7 @@ glob@^6.0.1, glob@^6.0.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -5804,6 +5808,10 @@ react-list@0.8.0:
 react-native-camera@0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/react-native-camera/-/react-native-camera-0.6.0.tgz#dd2760b7857d660761c78f2da575b494fdc8dcb5"
+
+react-native-image-picker@^0.25.6:
+  version "0.25.6"
+  resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-0.25.6.tgz#7d594bf2f74b90ef24a13049dd7f5db665ea61c2"
 
 react-native-push-notification@2.2.1:
   version "2.2.1"


### PR DESCRIPTION
@keybase/react-hackers 

Here's a simple Chat uploader for Android and iOS -- it offers a choice between selecting an image from the Camera Roll and taking a new image with the camera. There's no way to change the image title so I've filed DESKTOP-2979 for adding that.

This PR plumbs onSelectAttachment() through to the main conversation view, since that's where it's needed on mobile.