### PR TITLE
Lower-case sharing before signup service name

### DIFF
--- a/shared/constants/search.js
+++ b/shared/constants/search.js
@@ -72,7 +72,7 @@ export function fullName (extraInfo: ExtraInfo): string {
 
 export function searchResultToAssertion (r: SearchResult): string {
   if (r.service === 'external') {
-    return `${r.username}@${r.serviceName}`
+    return `${r.username}@${r.serviceName.toLowerCase()}`
   }
 
   return r.username


### PR DESCRIPTION
This lowercases paths like "/keybase/private/chromakode,powerlanguage@Reddit" or chat titles like "powerlanguage@Reddit" obtained via platform-specific search.

:eyeglasses: @keybase/react-hackers 
