### PR TITLE
Add autoCorrect for chat input

### DIFF
--- a/shared/chat/conversation/input.native.js
+++ b/shared/chat/conversation/input.native.js
@@ -62,6 +62,7 @@ class ConversationInput extends Component<void, Props, State> {
       <Box style={{...globalStyles.flexBoxColumn}}>
         <Box style={{...globalStyles.flexBoxRow, alignItems: 'flex-start'}}>
           <Input
+            autoCorrect={true}
             autoFocus={true}
             small={true}
             style={styleInput}


### PR DESCRIPTION
@keybase/react-hackers 

Use autoCorrect={true} for the main Chat conversation input on mobile.