### PR TITLE
fix reading from public chats CORE-4670

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -310,8 +310,6 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 	rl = append(rl, ratelim)
 	if err == nil {
 		finalizeInfo = conv.Metadata.FinalizeInfo
-	} else {
-		s.Debug(ctx, "Pull: failed to get remote conv, not reading from cache: %s", err.Error())
 	}
 
 	// Post process thread before returning

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -1020,6 +1020,32 @@ func TestFindConversations(t *testing.T) {
 	require.Equal(t, 1, len(res.Conversations), "no conv found")
 	require.Equal(t, created.Id, res.Conversations[0].GetConvID(), "wrong conv")
 
+	t.Logf("simple post")
+	_, err = ctc.as(t, users[2]).chatLocalHandler().PostLocal(context.TODO(), chat1.PostLocalArg{
+		ConversationID:   created.Id,
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		Msg: chat1.MessagePlaintext{
+			ClientHeader: chat1.MessageClientHeader{
+				Conv:        created.Triple,
+				MessageType: chat1.MessageType_TEXT,
+				TlfName:     created.TlfName,
+				TlfPublic:   true,
+			},
+			MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+				Body: "PUBLIC",
+			}),
+		},
+	})
+	require.NoError(t, err)
+
+	t.Logf("read from conversation")
+	tres, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(context.TODO(), chat1.GetThreadLocalArg{
+		ConversationID:   res.Conversations[0].GetConvID(),
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(tres.Thread.Messages), "wrong length")
+
 	t.Logf("test topic name")
 	_, err = ctc.as(t, users[2]).chatLocalHandler().PostLocal(context.TODO(), chat1.PostLocalArg{
 		ConversationID:   created.Id,

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -1042,6 +1042,9 @@ func TestFindConversations(t *testing.T) {
 	tres, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(context.TODO(), chat1.GetThreadLocalArg{
 		ConversationID:   res.Conversations[0].GetConvID(),
 		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		Query: &chat1.GetThreadQuery{
+			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+		},
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(tres.Thread.Messages), "wrong length")


### PR DESCRIPTION
Problem was we were erroring out of `Pull` too aggressively as a result of a refactor. Improve the test case here too.