### PR TITLE
Add verified header type

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -238,7 +238,7 @@ func (b *Boxer) unboxV1(ctx context.Context, boxed chat1.MessageBoxed, encryptio
 	}
 
 	// create a chat1.MessageClientHeader from versioned HeaderPlaintext
-	var clientHeader chat1.MessageClientHeader
+	var clientHeader chat1.MessageClientHeaderVerified
 	headerVersion, err := header.Version()
 	if err != nil {
 		return nil, NewPermanentUnboxingError(err)
@@ -247,9 +247,10 @@ func (b *Boxer) unboxV1(ctx context.Context, boxed chat1.MessageBoxed, encryptio
 	var headerSignature *chat1.SignatureInfo
 	switch headerVersion {
 	case chat1.HeaderPlaintextVersion_V1:
+		// Verified above in verifyMessageV1
 		headerSignature = header.V1().HeaderSignature
 		hp := header.V1()
-		clientHeader = chat1.MessageClientHeader{
+		clientHeader = chat1.MessageClientHeaderVerified{
 			Conv:         hp.Conv,
 			TlfName:      hp.TlfName,
 			TlfPublic:    hp.TlfPublic,

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -732,12 +732,10 @@ func TestV1Message1(t *testing.T) {
 	require.Equal(t, "alice25,bob25", unboxed.ClientHeader.TlfName)
 	require.Equal(t, false, unboxed.ClientHeader.TlfPublic)
 	require.Equal(t, chat1.MessageType_TLFNAME, unboxed.ClientHeader.MessageType)
-	require.Equal(t, chat1.MessageID(0), unboxed.ClientHeader.Supersedes)
-	require.Nil(t, unboxed.ClientHeader.Deletes)
 	require.Nil(t, unboxed.ClientHeader.Prev)
 	require.Equal(t, canned.SenderUID(t), unboxed.ClientHeader.Sender)
 	require.Equal(t, canned.SenderDeviceID(t), unboxed.ClientHeader.SenderDevice)
-	require.Nil(t, unboxed.ClientHeader.MerkleRoot)
+	// require.Nil(t, unboxed.ClientHeader.MerkleRoot)
 	require.Nil(t, unboxed.ClientHeader.OutboxID)
 	require.Nil(t, unboxed.ClientHeader.OutboxInfo)
 
@@ -789,13 +787,11 @@ func TestV1Message2(t *testing.T) {
 	require.Equal(t, "alice25,bob25", unboxed.ClientHeader.TlfName)
 	require.Equal(t, false, unboxed.ClientHeader.TlfPublic)
 	require.Equal(t, chat1.MessageType_TEXT, unboxed.ClientHeader.MessageType)
-	require.Equal(t, chat1.MessageID(0), unboxed.ClientHeader.Supersedes)
-	require.Nil(t, unboxed.ClientHeader.Deletes)
 	expectedPrevs := []chat1.MessagePreviousPointer{chat1.MessagePreviousPointer{Id: 0x1, Hash: chat1.Hash{0xc9, 0x6e, 0x28, 0x6d, 0x88, 0x2e, 0xfc, 0x44, 0xdb, 0x80, 0xe5, 0x1d, 0x8e, 0x8, 0xf1, 0xde, 0x28, 0xb4, 0x93, 0x4c, 0xc8, 0x49, 0x1f, 0xbe, 0x88, 0x42, 0xf, 0x31, 0x10, 0x65, 0x14, 0xbe}}}
 	require.Equal(t, expectedPrevs, unboxed.ClientHeader.Prev)
 	require.Equal(t, canned.SenderUID(t), unboxed.ClientHeader.Sender)
 	require.Equal(t, canned.SenderDeviceID(t), unboxed.ClientHeader.SenderDevice)
-	require.Nil(t, unboxed.ClientHeader.MerkleRoot)
+	// require.Nil(t, unboxed.ClientHeader.MerkleRoot)
 	require.Nil(t, unboxed.ClientHeader.OutboxID)
 	require.Nil(t, unboxed.ClientHeader.OutboxInfo)
 

--- a/go/chat/prev_test.go
+++ b/go/chat/prev_test.go
@@ -29,7 +29,7 @@ func threadViewFromDummies(dummies []dummyMessage) chat1.ThreadView {
 			ServerHeader: chat1.MessageServerHeader{
 				MessageID: dummy.id,
 			},
-			ClientHeader: chat1.MessageClientHeader{
+			ClientHeader: chat1.MessageClientHeaderVerified{
 				Prev: dummy.prevs,
 			},
 			// no need for a body

--- a/go/chat/storage/storage_test.go
+++ b/go/chat/storage/storage_test.go
@@ -37,9 +37,8 @@ func makeEdit(id chat1.MessageID, supersedes chat1.MessageID) chat1.MessageUnbox
 		ServerHeader: chat1.MessageServerHeader{
 			MessageID: id,
 		},
-		ClientHeader: chat1.MessageClientHeader{
+		ClientHeader: chat1.MessageClientHeaderVerified{
 			MessageType: chat1.MessageType_EDIT,
-			Supersedes:  supersedes,
 		},
 		MessageBody: chat1.NewMessageBodyWithEdit(chat1.MessageEdit{
 			MessageID: supersedes,
@@ -54,9 +53,8 @@ func makeDelete(id chat1.MessageID, originalMessage chat1.MessageID, allEdits []
 		ServerHeader: chat1.MessageServerHeader{
 			MessageID: id,
 		},
-		ClientHeader: chat1.MessageClientHeader{
+		ClientHeader: chat1.MessageClientHeaderVerified{
 			MessageType: chat1.MessageType_DELETE,
-			Supersedes:  originalMessage,
 		},
 		MessageBody: chat1.NewMessageBodyWithDelete(chat1.MessageDelete{
 			MessageIDs: append([]chat1.MessageID{originalMessage}, allEdits...),
@@ -70,7 +68,7 @@ func makeText(id chat1.MessageID, text string) chat1.MessageUnboxed {
 		ServerHeader: chat1.MessageServerHeader{
 			MessageID: id,
 		},
-		ClientHeader: chat1.MessageClientHeader{
+		ClientHeader: chat1.MessageClientHeaderVerified{
 			MessageType: chat1.MessageType_TEXT,
 		},
 		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
@@ -80,14 +78,13 @@ func makeText(id chat1.MessageID, text string) chat1.MessageUnboxed {
 	return chat1.NewMessageUnboxedWithValid(msg)
 }
 
-func makeMsgWithType(id chat1.MessageID, supersedes chat1.MessageID, typ chat1.MessageType) chat1.MessageUnboxed {
+func makeMsgWithType(id chat1.MessageID, typ chat1.MessageType) chat1.MessageUnboxed {
 	msg := chat1.MessageUnboxedValid{
 		ServerHeader: chat1.MessageServerHeader{
 			MessageID: id,
 		},
-		ClientHeader: chat1.MessageClientHeader{
+		ClientHeader: chat1.MessageClientHeaderVerified{
 			MessageType: typ,
-			Supersedes:  supersedes,
 		},
 	}
 	return chat1.NewMessageUnboxedWithValid(msg)
@@ -401,11 +398,11 @@ func TestStorageTypeFilter(t *testing.T) {
 	_, storage, uid := setupStorageTest(t, "basic")
 
 	textmsgs := makeMsgRange(300)
-	msgs := append(mkarray(makeMsgWithType(chat1.MessageID(301), 0, chat1.MessageType_EDIT)), textmsgs...)
-	msgs = append(mkarray(makeMsgWithType(chat1.MessageID(302), 0, chat1.MessageType_TLFNAME)), msgs...)
-	msgs = append(mkarray(makeMsgWithType(chat1.MessageID(303), 0, chat1.MessageType_ATTACHMENT)), msgs...)
-	msgs = append(mkarray(makeMsgWithType(chat1.MessageID(304), 0, chat1.MessageType_TEXT)), msgs...)
-	textmsgs = append(mkarray(makeMsgWithType(chat1.MessageID(304), 0, chat1.MessageType_TEXT)), textmsgs...)
+	msgs := append(mkarray(makeMsgWithType(chat1.MessageID(301), chat1.MessageType_EDIT)), textmsgs...)
+	msgs = append(mkarray(makeMsgWithType(chat1.MessageID(302), chat1.MessageType_TLFNAME)), msgs...)
+	msgs = append(mkarray(makeMsgWithType(chat1.MessageID(303), chat1.MessageType_ATTACHMENT)), msgs...)
+	msgs = append(mkarray(makeMsgWithType(chat1.MessageID(304), chat1.MessageType_TEXT)), msgs...)
+	textmsgs = append(mkarray(makeMsgWithType(chat1.MessageID(304), chat1.MessageType_TEXT)), textmsgs...)
 	conv := makeConversation(msgs[0].GetMessageID())
 
 	query := chat1.GetThreadQuery{

--- a/go/client/chat_ui.go
+++ b/go/client/chat_ui.go
@@ -143,7 +143,6 @@ func (c *ChatUI) ChatInboxFailed(ctx context.Context, arg chat1.ChatInboxFailedA
 }
 
 func (c *ChatUI) getUnverifiedConvo(ctx context.Context, conv chat1.Conversation) (chat1.ConversationLocal, error) {
-
 	if len(conv.MaxMsgs) == 0 {
 		return chat1.ConversationLocal{}, fmt.Errorf("no max messages")
 	}
@@ -169,6 +168,8 @@ func (c *ChatUI) getUnverifiedConvo(ctx context.Context, conv chat1.Conversation
 	convLocal := chat1.ConversationLocal{
 		ReaderInfo: *conv.ReaderInfo,
 		MaxMessages: []chat1.MessageUnboxed{
+			// This is a fake unboxing, only used for `keybase chat ls --async`
+			// The contents have not been verified at all. Don't be fooled.
 			chat1.MessageUnboxed{
 				State__: chat1.MessageUnboxedState_VALID,
 				Valid__: &chat1.MessageUnboxedValid{
@@ -178,7 +179,14 @@ func (c *ChatUI) getUnverifiedConvo(ctx context.Context, conv chat1.Conversation
 							Body: "<pending>",
 						},
 					},
-					ClientHeader:   txtMsg.ClientHeader,
+					ClientHeader: chat1.MessageClientHeaderVerified{
+						Conv:         txtMsg.ClientHeader.Conv,
+						TlfName:      txtMsg.ClientHeader.TlfName,
+						TlfPublic:    txtMsg.ClientHeader.TlfPublic,
+						MessageType:  chat1.MessageType_TEXT,
+						Sender:       txtMsg.ClientHeader.Sender,
+						SenderDevice: txtMsg.ClientHeader.SenderDevice,
+					},
 					ServerHeader:   *txtMsg.ServerHeader,
 					SenderUsername: "???",
 				},

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -365,6 +365,20 @@ func (m *ChatRemoteMock) GetConversationMetadataRemote(ctx context.Context, conv
 	return res, err
 }
 
+func (m *ChatRemoteMock) headerToVerifiedForTesting(h chat1.MessageClientHeader) chat1.MessageClientHeaderVerified {
+	return chat1.MessageClientHeaderVerified{
+		Conv:         h.Conv,
+		TlfName:      h.TlfName,
+		TlfPublic:    h.TlfPublic,
+		MessageType:  h.MessageType,
+		Prev:         h.Prev,
+		Sender:       h.Sender,
+		SenderDevice: h.SenderDevice,
+		OutboxID:     h.OutboxID,
+		OutboxInfo:   h.OutboxInfo,
+	}
+}
+
 func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg) (res chat1.PostRemoteRes, err error) {
 	uid := arg.MessageBoxed.ClientHeader.Sender
 	conv := m.world.GetConversationByID(arg.ConversationID)
@@ -382,7 +396,7 @@ func (m *ChatRemoteMock) PostRemote(ctx context.Context, arg chat1.PostRemoteArg
 	if m.world.TcsByID[uid.String()].G.NotifyRouter != nil {
 		activity := chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
 			Message: chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
-				ClientHeader: inserted.ClientHeader,
+				ClientHeader: m.headerToVerifiedForTesting(inserted.ClientHeader),
 				ServerHeader: *inserted.ServerHeader,
 			}),
 		})

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -234,6 +234,18 @@ type MessageClientHeader struct {
 	OutboxInfo   *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
 }
 
+type MessageClientHeaderVerified struct {
+	Conv         ConversationIDTriple     `codec:"conv" json:"conv"`
+	TlfName      string                   `codec:"tlfName" json:"tlfName"`
+	TlfPublic    bool                     `codec:"tlfPublic" json:"tlfPublic"`
+	MessageType  MessageType              `codec:"messageType" json:"messageType"`
+	Prev         []MessagePreviousPointer `codec:"prev" json:"prev"`
+	Sender       gregor1.UID              `codec:"sender" json:"sender"`
+	SenderDevice gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
+	OutboxID     *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
+	OutboxInfo   *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
+}
+
 type EncryptedData struct {
 	V int    `codec:"v" json:"v"`
 	E []byte `codec:"e" json:"e"`

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -144,6 +144,9 @@ func (m MessageUnboxed) GetMessageType() MessageType {
 		if state == MessageUnboxedState_ERROR {
 			return m.Error().MessageType
 		}
+		if state == MessageUnboxedState_OUTBOX {
+			return m.Outbox().Msg.ClientHeader.MessageType
+		}
 	}
 	return MessageType_NONE
 }
@@ -208,6 +211,10 @@ func (o OutboxID) String() string {
 	return hex.EncodeToString(o)
 }
 
+func (p MessagePreviousPointer) Eq(other MessagePreviousPointer) bool {
+	return (p.Id == other.Id) && (p.Hash.Eq(other.Hash))
+}
+
 func (t TLFVisibility) Eq(r TLFVisibility) bool {
 	return int(t) == int(r)
 }
@@ -255,6 +262,10 @@ func (c ConversationInfoLocal) TLFNameExpandedSummary() string {
 // TLFNameExpanded returns a TLF name with a reset suffix if it exists.
 // This version can be used in requests to lookup the TLF.
 func (h MessageClientHeader) TLFNameExpanded(finalizeInfo *ConversationFinalizeInfo) string {
+	return ExpandTLFName(h.TlfName, finalizeInfo)
+}
+
+func (h MessageClientHeaderVerified) TLFNameExpanded(finalizeInfo *ConversationFinalizeInfo) string {
 	return ExpandTLFName(h.TlfName, finalizeInfo)
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1140,16 +1140,16 @@ func (e MessageUnboxedState) String() string {
 }
 
 type MessageUnboxedValid struct {
-	ClientHeader          MessageClientHeader `codec:"clientHeader" json:"clientHeader"`
-	ServerHeader          MessageServerHeader `codec:"serverHeader" json:"serverHeader"`
-	MessageBody           MessageBody         `codec:"messageBody" json:"messageBody"`
-	SenderUsername        string              `codec:"senderUsername" json:"senderUsername"`
-	SenderDeviceName      string              `codec:"senderDeviceName" json:"senderDeviceName"`
-	SenderDeviceType      string              `codec:"senderDeviceType" json:"senderDeviceType"`
-	HeaderHash            Hash                `codec:"headerHash" json:"headerHash"`
-	HeaderSignature       *SignatureInfo      `codec:"headerSignature,omitempty" json:"headerSignature,omitempty"`
-	VerificationKey       *[]byte             `codec:"verificationKey,omitempty" json:"verificationKey,omitempty"`
-	SenderDeviceRevokedAt *gregor1.Time       `codec:"senderDeviceRevokedAt,omitempty" json:"senderDeviceRevokedAt,omitempty"`
+	ClientHeader          MessageClientHeaderVerified `codec:"clientHeader" json:"clientHeader"`
+	ServerHeader          MessageServerHeader         `codec:"serverHeader" json:"serverHeader"`
+	MessageBody           MessageBody                 `codec:"messageBody" json:"messageBody"`
+	SenderUsername        string                      `codec:"senderUsername" json:"senderUsername"`
+	SenderDeviceName      string                      `codec:"senderDeviceName" json:"senderDeviceName"`
+	SenderDeviceType      string                      `codec:"senderDeviceType" json:"senderDeviceType"`
+	HeaderHash            Hash                        `codec:"headerHash" json:"headerHash"`
+	HeaderSignature       *SignatureInfo              `codec:"headerSignature,omitempty" json:"headerSignature,omitempty"`
+	VerificationKey       *[]byte                     `codec:"verificationKey,omitempty" json:"verificationKey,omitempty"`
+	SenderDeviceRevokedAt *gregor1.Time               `codec:"senderDeviceRevokedAt,omitempty" json:"senderDeviceRevokedAt,omitempty"`
 }
 
 type MessageUnboxedErrorType int

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -159,22 +159,8 @@ protocol common {
   }
 
   record MessageClientHeader {
-    // This type is used for 2 things:
-    // 1. Included in the clear on MessageBoxed's.
-    // 2. Passed internally after unboxing.
-    // When in use (1) the data is not verified at all.
-    // When in use (2) all contained data has been verified by unboxing.
-    // There are fields present in MessageClientHeader that are _not_
-    // signed into the message. Therefore they are always 0-valued in (2)
-    // for a message even though the values may be set in (1).
-
-    // Which fields are asserted to be the same between (1) and (2)
-    // is not trivial. So if you need verified info, never use (1).
-
-    // As of this note, those mismatched fields are:
-    // - Supersedes
-    // - Deletes
-    // - MerkleRoot
+    // This type is attached to MessageBoxed.
+    // When on a received message these fields are server-set and have not been verified.
 
     ConversationIDTriple conv;
     string tlfName;
@@ -187,6 +173,22 @@ protocol common {
     gregor1.DeviceID senderDevice;
     // Latest merkle root when sent. Can be nil.
     union { null, MerkleRoot } merkleRoot;
+    union { null, OutboxID } outboxID;
+    union { null, OutboxInfo } outboxInfo;
+  }
+
+  record MessageClientHeaderVerified {
+    // This type is the result of unboxing.
+    // And to be used locally to the client only.
+    // All fields have been verified signed by the sender.
+
+    ConversationIDTriple conv;
+    string tlfName;
+    boolean tlfPublic;
+    MessageType messageType;
+    array<MessagePreviousPointer> prev;
+    gregor1.UID sender;
+    gregor1.DeviceID senderDevice;
     union { null, OutboxID } outboxID;
     union { null, OutboxInfo } outboxInfo;
   }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -252,7 +252,7 @@ protocol local {
   }
 
   record MessageUnboxedValid {
-    MessageClientHeader clientHeader;
+    MessageClientHeaderVerified clientHeader;
     MessageServerHeader serverHeader;
     MessageBody messageBody;
     string senderUsername;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1138,6 +1138,18 @@ export type MessageClientHeader = {
   outboxInfo?: ?OutboxInfo,
 }
 
+export type MessageClientHeaderVerified = {
+  conv: ConversationIDTriple,
+  tlfName: string,
+  tlfPublic: boolean,
+  messageType: MessageType,
+  prev?: ?Array<MessagePreviousPointer>,
+  sender: gregor1.UID,
+  senderDevice: gregor1.DeviceID,
+  outboxID?: ?OutboxID,
+  outboxInfo?: ?OutboxInfo,
+}
+
 export type MessageConversationMetadata = {
   conversationTitle: string,
 }
@@ -1213,7 +1225,7 @@ export type MessageUnboxedState =
   | 3 // OUTBOX_3
 
 export type MessageUnboxedValid = {
-  clientHeader: MessageClientHeader,
+  clientHeader: MessageClientHeaderVerified,
   serverHeader: MessageServerHeader,
   messageBody: MessageBody,
   senderUsername: string,

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -482,6 +482,57 @@
     },
     {
       "type": "record",
+      "name": "MessageClientHeaderVerified",
+      "fields": [
+        {
+          "type": "ConversationIDTriple",
+          "name": "conv"
+        },
+        {
+          "type": "string",
+          "name": "tlfName"
+        },
+        {
+          "type": "boolean",
+          "name": "tlfPublic"
+        },
+        {
+          "type": "MessageType",
+          "name": "messageType"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "MessagePreviousPointer"
+          },
+          "name": "prev"
+        },
+        {
+          "type": "gregor1.UID",
+          "name": "sender"
+        },
+        {
+          "type": "gregor1.DeviceID",
+          "name": "senderDevice"
+        },
+        {
+          "type": [
+            null,
+            "OutboxID"
+          ],
+          "name": "outboxID"
+        },
+        {
+          "type": [
+            null,
+            "OutboxInfo"
+          ],
+          "name": "outboxInfo"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "EncryptedData",
       "fields": [
         {

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -794,7 +794,7 @@
       "name": "MessageUnboxedValid",
       "fields": [
         {
-          "type": "MessageClientHeader",
+          "type": "MessageClientHeaderVerified",
           "name": "clientHeader"
         },
         {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1138,6 +1138,18 @@ export type MessageClientHeader = {
   outboxInfo?: ?OutboxInfo,
 }
 
+export type MessageClientHeaderVerified = {
+  conv: ConversationIDTriple,
+  tlfName: string,
+  tlfPublic: boolean,
+  messageType: MessageType,
+  prev?: ?Array<MessagePreviousPointer>,
+  sender: gregor1.UID,
+  senderDevice: gregor1.DeviceID,
+  outboxID?: ?OutboxID,
+  outboxInfo?: ?OutboxInfo,
+}
+
 export type MessageConversationMetadata = {
   conversationTitle: string,
 }
@@ -1213,7 +1225,7 @@ export type MessageUnboxedState =
   | 3 // OUTBOX_3
 
 export type MessageUnboxedValid = {
-  clientHeader: MessageClientHeader,
+  clientHeader: MessageClientHeaderVerified,
   serverHeader: MessageServerHeader,
   messageBody: MessageBody,
   senderUsername: string,


### PR DESCRIPTION
Add `MessageClientHeaderVerified` which is like `MessageClientHeader`. `MessageClientHeader` is what you send and get from the server. `MessageClientHeaderVerified` is what you get after a successful unbox, all its fields come from verified signed stuff.

Compared to `MessageClientHeader`, `MessageClientHeaderVerified` is currently missing `MerkleRoot` and will forever be missing `Supersedes` and `Deletes`. `Supersedes` and `Deletes` are just hints to the server, that can be derived from the message body.