### PR TITLE
Use merge-base as reference for CI checks/visdiff

### DIFF
--- a/go/test/jenkins_test.sh
+++ b/go/test/jenkins_test.sh
@@ -7,9 +7,10 @@ if [ "$2" == "null" ]; then
     against_master=1
 else
     against_master=0
+    change_base=$(git merge-base $change_target $commit_hash)
 fi
 
-echo "tests/jenkins_test.sh recieved commit_hash: ${commit_hash} change_target: ${change_target}"
+echo "tests/jenkins_test.sh recieved commit_hash: ${commit_hash} change_target: ${change_target} change_base: ${change_base}"
 
 check_rc() {
   # exit if passed in value is not = 0
@@ -32,9 +33,9 @@ has_go_files() {
     git fetch
     check_rc $? 'echo git fetch problem' 1
     echo 'git diff'
-    git diff --name-only "$change_target...$commit_hash"
+    git diff --name-only "$change_base...$commit_hash"
     # ignore test.sh for now
-    diff_files=`git diff --name-only "$change_target...$commit_hash" | grep -v '^shared/'`
+    diff_files=`git diff --name-only "$change_base...$commit_hash" | grep -v '^shared/'`
     check_rc $? 'no files go cares about' 0
     echo "continuing due to changes in $diff_files"
 }

--- a/shared/jenkins_test.sh
+++ b/shared/jenkins_test.sh
@@ -3,12 +3,12 @@
 test_type="$1"
 commit_hash="$2"
 change_target="origin/$3"
-change_base=$(git merge-base $change_target $commit_hash)
 
 if [ "$3" == "null" ]; then
     against_master=1
 else
     against_master=0
+    change_base=$(git merge-base $change_target $commit_hash)
 fi
 
 echo "shared/jenkins_test.sh recieved type: ${test_type} commit_hash: ${commit_hash} change_target: ${change_target} change_base: ${change_base}"

--- a/shared/jenkins_test.sh
+++ b/shared/jenkins_test.sh
@@ -3,6 +3,7 @@
 test_type="$1"
 commit_hash="$2"
 change_target="origin/$3"
+change_base=$(git merge-base $change_target $commit_hash)
 
 if [ "$3" == "null" ]; then
     against_master=1
@@ -10,7 +11,7 @@ else
     against_master=0
 fi
 
-echo "shared/jenkins_test.sh recieved type: ${test_type} commit_hash: ${commit_hash} change_target: ${change_target}"
+echo "shared/jenkins_test.sh recieved type: ${test_type} commit_hash: ${commit_hash} change_target: ${change_target} change_base: ${change_base}"
 
 check_rc() {
   # exit if passed in value is not = 0
@@ -33,9 +34,9 @@ has_js_files() {
     git fetch
     check_rc $? 'echo git fetch problem' 1
     echo 'git diff'
-    git diff --name-only "$change_target...$commit_hash"
+    git diff --name-only "$change_base...$commit_hash"
     # ignore test.sh for now
-    diff_files=`git diff --name-only "$change_target...$commit_hash" | grep '^shared/' | grep -v '^shared/jenkins_test\.sh'`
+    diff_files=`git diff --name-only "$change_base...$commit_hash" | grep '^shared/' | grep -v '^shared/jenkins_test\.sh'`
     check_rc $? 'no files js cares about' 0
     echo "continuing due to changes in $diff_files"
 }
@@ -66,7 +67,7 @@ visdiff() {
     if [ $against_master -eq 1 ]; then
         echo 'No $change_target, skipping visdiff'
     else
-        node ../visdiff/dist/index.js "$change_target...$commit_hash"
+        node ../visdiff/dist/index.js "$change_base...$commit_hash"
         check_rc $? 'visdiff fail' 1
     fi
 }


### PR DESCRIPTION
:eyeglasses: @keybase/react-hackers cc @chrisnojima 


```
       Given two commits A and B, git merge-base A B will output a commit which is
       reachable from both A and B through the parent relationship.

       For example, with this topology:

                    o---o---o---B
                   /
           ---o---1---o---o---o---A

       the merge base between A and B is 1.
```

We need to use the merge-base instead of the current state of
origin/master because master may be ahead of the start point of the
branch we're testing. Fixes visdiff regression, and should improve the
diff checking behavior.
