### PR TITLE
implement boxv2

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -417,6 +417,9 @@ func (b *Boxer) unboxV2(ctx context.Context, boxed chat1.MessageBoxed, encryptio
 	// Later it is asserted that the claimed and signing sender are the same.
 	// ValidSenderKey uses the server-given ctime, but emits senderDeviceRevokedAt as a workaround.
 	// See ValidSenderKey for details.
+	if boxed.VerifyKey == nil {
+		return nil, NewPermanentUnboxingError(libkb.NoKeyError{Msg: "sender key missing"})
+	}
 	senderKeyFound, senderKeyValidAtCtime, senderDeviceRevokedAt, ierr := b.ValidSenderKey(
 		ctx, boxed.ClientHeader.Sender, boxed.VerifyKey, boxed.ServerHeader.Ctime)
 	if ierr != nil {

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -656,17 +656,17 @@ func (b *Boxer) compareHeadersV2(ctx context.Context, hServer chat1.MessageClien
 	//            This check is disabled because MerkleRoot is not yet signed.
 	//            Simultaneously with enabling boxing MBV2, it will be added to the signed header.
 	//            And will match from then on.
-	// if hServer.MerkleRoot != hSigned.MerkleRoot {
+	// if hServer.MerkleRoot.Eq(hSigned.MerkleRoot) {
 	// 	return NewPermanentUnboxingError(NewHeaderMismatchError("MerkleRoot"))
 	// }
 
 	// OutboxID
-	if hServer.OutboxID != hSigned.OutboxID {
+	if !hServer.OutboxID.Eq(hSigned.OutboxID) {
 		return NewPermanentUnboxingError(NewHeaderMismatchError("OutboxID"))
 	}
 
 	// OutboxInfo
-	if hServer.OutboxInfo != hSigned.OutboxInfo {
+	if !hServer.OutboxInfo.Eq(hSigned.OutboxInfo) {
 		return NewPermanentUnboxingError(NewHeaderMismatchError("OutboxInfo"))
 	}
 

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -1287,7 +1287,7 @@ func (b *Boxer) compareHeadersV1(ctx context.Context, hServer chat1.MessageClien
 		return NewPermanentUnboxingError(NewHeaderMismatchError("SenderDevice"))
 	}
 
-	// CORE-4540: _Don't_ enable this check! There are V1 messages in the wild with
+	// CORE-4540: _Don't_ enable checking of MerkleRoot matching! There are V1 messages in the wild with
 	//            hServer.MerkleRoot set but nothing signed.
 
 	// OutboxID, OutboxInfo: Left unchecked as I'm not sure whether these hold in V1 messages.

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -364,9 +364,6 @@ func TestChatMessageInvalidHeaderSig(t *testing.T) {
 			Ctime: gregor1.ToTime(time.Now()),
 		}
 
-		// put original signing fn back
-		boxer.testingSignatureMangle = nil
-
 		_, ierr := boxer.unbox(context.TODO(), *boxed, key)
 		require.NotNil(t, ierr, "must have unbox error")
 		switch mbVersion {

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -198,6 +198,22 @@ func NewBodyVersionError(version chat1.BodyPlaintextVersion, defaultBody chat1.B
 
 //=============================================================================
 
+type HeaderMismatchError struct {
+	Field string
+}
+
+var _ error = (*HeaderMismatchError)(nil)
+
+func (e *HeaderMismatchError) Error() string {
+	return fmt.Sprintf("chat header mismatch on %q", e.Field)
+}
+
+func NewHeaderMismatchError(field string) *HeaderMismatchError {
+	return &HeaderMismatchError{Field: field}
+}
+
+//=============================================================================
+
 type OfflineError struct {
 }
 

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -204,12 +204,12 @@ type HeaderMismatchError struct {
 
 var _ error = (*HeaderMismatchError)(nil)
 
-func (e *HeaderMismatchError) Error() string {
+func (e HeaderMismatchError) Error() string {
 	return fmt.Sprintf("chat header mismatch on %q", e.Field)
 }
 
-func NewHeaderMismatchError(field string) *HeaderMismatchError {
-	return &HeaderMismatchError{Field: field}
+func NewHeaderMismatchError(field string) HeaderMismatchError {
+	return HeaderMismatchError{Field: field}
 }
 
 //=============================================================================

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -21,7 +21,7 @@ import (
 	"github.com/keybase/client/go/protocol/gregor1"
 )
 
-const inboxVersion = 6
+const inboxVersion = 7
 
 type queryHash []byte
 
@@ -107,7 +107,7 @@ func (i *Inbox) readDiskInbox(ctx context.Context) (inboxDiskData, Error) {
 	if !found {
 		return ibox, MissError{}
 	}
-	if ibox.Version > inboxVersion {
+	if ibox.Version != inboxVersion {
 		i.Debug(ctx, "on disk version not equal to program version, clearing: disk :%d program: %d",
 			ibox.Version, inboxVersion)
 		if cerr := i.clear(ctx); cerr != nil {

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -213,7 +213,7 @@ func (o *Outbox) RecordFailedAttempt(ctx context.Context, oldObr chat1.OutboxRec
 	var recs []chat1.OutboxRecord
 	added := false
 	for _, obr := range obox.Records {
-		if obr.OutboxID.Eq(oldObr.OutboxID) {
+		if obr.OutboxID.Eq(&oldObr.OutboxID) {
 			state, err := obr.State.State()
 			if err != nil {
 				return err
@@ -263,7 +263,7 @@ func (o *Outbox) MarkAsError(ctx context.Context, obr chat1.OutboxRecord, errRec
 	var recs []chat1.OutboxRecord
 	added := false
 	for _, iobr := range obox.Records {
-		if iobr.OutboxID.Eq(obr.OutboxID) {
+		if iobr.OutboxID.Eq(&obr.OutboxID) {
 			iobr.State = chat1.NewOutboxStateWithError(errRec)
 			added = true
 		}
@@ -298,7 +298,7 @@ func (o *Outbox) RetryMessage(ctx context.Context, obid chat1.OutboxID) error {
 	// Loop through and find record
 	var recs []chat1.OutboxRecord
 	for _, obr := range obox.Records {
-		if obr.OutboxID.Eq(obid) {
+		if obr.OutboxID.Eq(&obid) {
 			obr.State = chat1.NewOutboxStateWithSending(0)
 		}
 		recs = append(recs, obr)
@@ -327,7 +327,7 @@ func (o *Outbox) RemoveMessage(ctx context.Context, obid chat1.OutboxID) error {
 	// Scan to find the message and don't include it
 	var recs []chat1.OutboxRecord
 	for _, obr := range obox.Records {
-		if !obr.OutboxID.Eq(obid) {
+		if !obr.OutboxID.Eq(&obid) {
 			recs = append(recs, obr)
 		}
 	}

--- a/go/chat/storage/storage_blockengine.go
+++ b/go/chat/storage/storage_blockengine.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-const blockIndexVersion = 4
+const blockIndexVersion = 5
 const blockSize = 100
 
 type blockEngine struct {

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -468,10 +468,12 @@ const (
 
 const (
 	SignaturePrefixKBFS           SignaturePrefix = "Keybase-KBFS-1"
-	SignaturePrefixChat           SignaturePrefix = "Keybase-Chat-1"
 	SignaturePrefixSigchain       SignaturePrefix = "Keybase-Sigchain-1"
 	SignaturePrefixChatAttachment SignaturePrefix = "Keybase-Chat-Attachment-1"
 	SignaturePrefixTesting        SignaturePrefix = "Keybase-Testing-1"
+	// Chat prefixes for each MessageBoxedVersion.
+	SignaturePrefixChatMBv1 SignaturePrefix = "Keybase-Chat-1"
+	SignaturePrefixChatMBv2 SignaturePrefix = "Keybase-Chat-2"
 )
 
 const (

--- a/go/libkb/naclwrap_test.go
+++ b/go/libkb/naclwrap_test.go
@@ -234,7 +234,7 @@ func TestNaclPrefixedSigs(t *testing.T) {
 
 	msg := []byte("test message")
 
-	sig, err := keyPair.SignV2(msg, SignaturePrefixChat)
+	sig, err := keyPair.SignV2(msg, SignaturePrefixChatMBv1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -252,16 +252,22 @@ type EncryptedData struct {
 	N []byte `codec:"n" json:"n"`
 }
 
+type SignEncryptedData struct {
+	V int    `codec:"v" json:"v"`
+	E []byte `codec:"e" json:"e"`
+	N []byte `codec:"n" json:"n"`
+}
+
+type SealedData struct {
+	V int    `codec:"v" json:"v"`
+	E []byte `codec:"e" json:"e"`
+	N []byte `codec:"n" json:"n"`
+}
+
 type SignatureInfo struct {
 	V int    `codec:"v" json:"v"`
 	S []byte `codec:"s" json:"s"`
 	K []byte `codec:"k" json:"k"`
-}
-
-type SignEncryptedData struct {
-	V int    `codec:"v" json:"v"`
-	B []byte `codec:"b" json:"b"`
-	N []byte `codec:"n" json:"n"`
 }
 
 type MerkleRoot struct {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -401,6 +401,38 @@ func (a *MerkleRoot) Eq(b *MerkleRoot) bool {
 	return (a == nil) && (b == nil)
 }
 
+func (d *SealedData) AsEncrypted() EncryptedData {
+	return EncryptedData{
+		V: d.V,
+		E: d.E,
+		N: d.N,
+	}
+}
+
+func (d *SealedData) AsSignEncrypted() SignEncryptedData {
+	return SignEncryptedData{
+		V: d.V,
+		E: d.E,
+		N: d.N,
+	}
+}
+
+func (d *EncryptedData) AsSealed() SealedData {
+	return SealedData{
+		V: d.V,
+		E: d.E,
+		N: d.N,
+	}
+}
+
+func (d *SignEncryptedData) AsSealed() SealedData {
+	return SealedData{
+		V: d.V,
+		E: d.E,
+		N: d.N,
+	}
+}
+
 func NewConversationErrorLocal(
 	message string,
 	remoteConv Conversation,

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"flag"
 	"fmt"
 	"strconv"
 	"strings"
@@ -267,6 +268,23 @@ func (h MessageClientHeader) TLFNameExpanded(finalizeInfo *ConversationFinalizeI
 
 func (h MessageClientHeaderVerified) TLFNameExpanded(finalizeInfo *ConversationFinalizeInfo) string {
 	return ExpandTLFName(h.TlfName, finalizeInfo)
+}
+
+func (h MessageClientHeader) ToVerifiedForTesting() MessageClientHeaderVerified {
+	if flag.Lookup("test.v") == nil {
+		panic("MessageClientHeader.ToVerifiedForTesting used outside of test")
+	}
+	return MessageClientHeaderVerified{
+		Conv:         h.Conv,
+		TlfName:      h.TlfName,
+		TlfPublic:    h.TlfPublic,
+		MessageType:  h.MessageType,
+		Prev:         h.Prev,
+		Sender:       h.Sender,
+		SenderDevice: h.SenderDevice,
+		OutboxID:     h.OutboxID,
+		OutboxInfo:   h.OutboxInfo,
+	}
 }
 
 // ExpandTLFName returns a TLF name with a reset suffix if it exists.

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -204,12 +204,22 @@ func (t ConversationIDTriple) Derivable(cid ConversationID) bool {
 	return bytes.Equal(h[2:], []byte(cid[2:]))
 }
 
-func (o OutboxID) Eq(r OutboxID) bool {
-	return bytes.Equal(o, r)
+func (o *OutboxID) Eq(r *OutboxID) bool {
+	if o != nil && r != nil {
+		return bytes.Equal(*o, *r)
+	}
+	return (o == nil) && (r == nil)
 }
 
 func (o OutboxID) String() string {
 	return hex.EncodeToString(o)
+}
+
+func (o *OutboxInfo) Eq(r *OutboxInfo) bool {
+	if o != nil && r != nil {
+		return *o == *r
+	}
+	return (o == nil) && (r == nil)
 }
 
 func (p MessagePreviousPointer) Eq(other MessagePreviousPointer) bool {
@@ -383,6 +393,13 @@ func ConvertMessageBodyV1ToV2(v1 MessageBodyV1) (MessageBody, error) {
 	return MessageBody{}, fmt.Errorf("ConvertMessageBodyV1ToV2: unhandled message type %v", t)
 }
 */
+
+func (a *MerkleRoot) Eq(b *MerkleRoot) bool {
+	if a != nil && b != nil {
+		return (a.Seqno == b.Seqno) && bytes.Equal(a.Hash, b.Hash)
+	}
+	return (a == nil) && (b == nil)
+}
 
 func NewConversationErrorLocal(
 	message string,

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -10,14 +10,13 @@ import (
 )
 
 type MessageBoxed struct {
-	Version               MessageBoxedVersion  `codec:"version" json:"version"`
-	ServerHeader          *MessageServerHeader `codec:"serverHeader,omitempty" json:"serverHeader,omitempty"`
-	ClientHeader          MessageClientHeader  `codec:"clientHeader" json:"clientHeader"`
-	HeaderCiphertext      EncryptedData        `codec:"headerCiphertext" json:"headerCiphertext"`
-	HeaderSealed          SignEncryptedData    `codec:"headerSealed" json:"headerSealed"`
-	BodyCiphertext        EncryptedData        `codec:"bodyCiphertext" json:"bodyCiphertext"`
-	HeaderVerificationKey []byte               `codec:"headerVerificationKey" json:"headerVerificationKey"`
-	KeyGeneration         int                  `codec:"keyGeneration" json:"keyGeneration"`
+	Version          MessageBoxedVersion  `codec:"version" json:"version"`
+	ServerHeader     *MessageServerHeader `codec:"serverHeader,omitempty" json:"serverHeader,omitempty"`
+	ClientHeader     MessageClientHeader  `codec:"clientHeader" json:"clientHeader"`
+	HeaderCiphertext SealedData           `codec:"headerCiphertext" json:"headerCiphertext"`
+	BodyCiphertext   EncryptedData        `codec:"bodyCiphertext" json:"bodyCiphertext"`
+	VerifyKey        []byte               `codec:"verifyKey" json:"verifyKey"`
+	KeyGeneration    int                  `codec:"keyGeneration" json:"keyGeneration"`
 }
 
 type MessageBoxedVersion int

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -206,16 +206,25 @@ protocol common {
     bytes n;  // nonce
   }
 
+  record SignEncryptedData {
+    int   v; // version = 1
+    bytes e; // signEncryptedData (output of signencrypt.SealWhole)
+    bytes n; // nonce
+  }
+
+  // Encrypted or SignEncrypted. Must know which from context.
+  record SealedData {
+    int   v;  // version = 1
+    // Encrypted: output of secret box
+    // SignEncrypted: output of signencrypt.SealWhole
+    bytes e;
+    bytes n;  // nonce
+  }
+
   record SignatureInfo {
     int   v; // version = 1
     bytes s; // signature; output of EdDSA
     bytes k; // Verifying key
-  }
-
-  record SignEncryptedData {
-    int   v; // version = 1
-    bytes b; // signEncryptedData (output of signencrypt.SealWhole)
-    bytes n; // nonce
   }
 
   record MerkleRoot {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -163,6 +163,8 @@ protocol common {
   record MessageClientHeader {
     // This type is attached to MessageBoxed.
     // When on a received message these fields are server-set and have not been verified.
+    // If adding fields, consider whether they should be signed,
+    // and if so add them to MessageClientHeaderVerified as well.
 
     ConversationIDTriple conv;
     string tlfName;
@@ -183,6 +185,8 @@ protocol common {
     // This type is the result of unboxing.
     // And to be used locally to the client only.
     // All fields have been verified signed by the sender.
+    // If adding fields, consider updating Boxer's compareHeaders methods
+    // to check invariants early.
 
     ConversationIDTriple conv;
     string tlfName;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -174,6 +174,9 @@ protocol local {
     array<MessagePreviousPointer> prev;
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;
+    // MessageBoxed.V1: Hash of the encrypted body ciphertext.
+    // MessageBoxed.V2: Hash of encrypted body (.v || .n || .e)
+    //                  Where V is a big-endian int32
     Hash bodyHash;
     union { null, OutboxInfo } outboxInfo;
     union { null, OutboxID } outboxID;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -165,6 +165,7 @@ protocol local {
   // HeaderPlaintextV1 is version 1 of HeaderPlaintext.
   // The fields here cannot change.  To modify,
   // create a new record type with a new version.
+  // CORE-4540: Update note about how compatibility works.
   record HeaderPlaintextV1 {
     ConversationIDTriple conv;
     string tlfName;
@@ -262,6 +263,7 @@ protocol local {
 
     // MessageBoxed.V1: Hash of the encrypted header ciphertext.
     // MessageBoxed.V2: Hash of MessageBoxed.headerSealed (.v || .n || .b)
+    //                  Where V is a big-endian int32
     Hash headerHash;
 
     // TOOD Maybe get rid of this field in favor of verificationKey.

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -278,7 +278,7 @@ protocol local {
 
     // MessageBoxed.V1: Null
     // MessageBoxed.V2: The verification key used to unbox.
-    //                  See MessageBoxed.headerVerificationKey
+    //                  See MessageBoxed.verifyKey
     union {null, bytes} verificationKey;
 
     // Whether the message was sent by a device that is now revoked.

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -27,7 +27,7 @@ protocol remote {
     EncryptedData bodyCiphertext;
 
     // V1: Missing
-    // V2: Public half of the signing key used on headerSealed.
+    // V2: KID of the signing key used on headerSealed.
     //     Used to open and verify headerSealed.
     //     Must be asserted to belong to the sender when unboxing.
     bytes headerVerificationKey;

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -16,12 +16,8 @@ protocol remote {
     MessageClientHeader clientHeader;
 
     // V1: Encrypted HeaderPlaintext
-    // V2: Empty
-    EncryptedData headerCiphertext;
-
-    // V1: Missing
     // V2: SignEncrypted HeaderPlaintext
-    SignEncryptedData headerSealed;
+    SealedData headerCiphertext;
 
     // [V1, V2]: Encrypted BodyPlaintext
     EncryptedData bodyCiphertext;
@@ -30,7 +26,7 @@ protocol remote {
     // V2: KID of the signing key used on headerSealed.
     //     Used to open and verify headerSealed.
     //     Must be asserted to belong to the sender when unboxing.
-    bytes headerVerificationKey;
+    bytes verifyKey;
 
     // [V1, V2]: Key generation of the encryption key
     int keyGeneration;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1111,10 +1111,9 @@ export type MessageBoxed = {
   version: MessageBoxedVersion,
   serverHeader?: ?MessageServerHeader,
   clientHeader: MessageClientHeader,
-  headerCiphertext: EncryptedData,
-  headerSealed: SignEncryptedData,
+  headerCiphertext: SealedData,
   bodyCiphertext: EncryptedData,
-  headerVerificationKey: bytes,
+  verifyKey: bytes,
   keyGeneration: int,
 }
 
@@ -1389,6 +1388,12 @@ export type S3Params = {
   regionBucketEndpoint: string,
 }
 
+export type SealedData = {
+  v: int,
+  e: bytes,
+  n: bytes,
+}
+
 export type SetConversationStatusLocalRes = {
   rateLimits?: ?Array<RateLimit>,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
@@ -1414,7 +1419,7 @@ export type SetStatusPayload = {
 
 export type SignEncryptedData = {
   v: int,
-  b: bytes,
+  e: bytes,
   n: bytes,
 }
 

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -551,6 +551,42 @@
     },
     {
       "type": "record",
+      "name": "SignEncryptedData",
+      "fields": [
+        {
+          "type": "int",
+          "name": "v"
+        },
+        {
+          "type": "bytes",
+          "name": "e"
+        },
+        {
+          "type": "bytes",
+          "name": "n"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "SealedData",
+      "fields": [
+        {
+          "type": "int",
+          "name": "v"
+        },
+        {
+          "type": "bytes",
+          "name": "e"
+        },
+        {
+          "type": "bytes",
+          "name": "n"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "SignatureInfo",
       "fields": [
         {
@@ -564,24 +600,6 @@
         {
           "type": "bytes",
           "name": "k"
-        }
-      ]
-    },
-    {
-      "type": "record",
-      "name": "SignEncryptedData",
-      "fields": [
-        {
-          "type": "int",
-          "name": "v"
-        },
-        {
-          "type": "bytes",
-          "name": "b"
-        },
-        {
-          "type": "bytes",
-          "name": "n"
         }
       ]
     },

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -28,12 +28,8 @@
           "name": "clientHeader"
         },
         {
-          "type": "EncryptedData",
+          "type": "SealedData",
           "name": "headerCiphertext"
-        },
-        {
-          "type": "SignEncryptedData",
-          "name": "headerSealed"
         },
         {
           "type": "EncryptedData",
@@ -41,7 +37,7 @@
         },
         {
           "type": "bytes",
-          "name": "headerVerificationKey"
+          "name": "verifyKey"
         },
         {
           "type": "int",

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1111,10 +1111,9 @@ export type MessageBoxed = {
   version: MessageBoxedVersion,
   serverHeader?: ?MessageServerHeader,
   clientHeader: MessageClientHeader,
-  headerCiphertext: EncryptedData,
-  headerSealed: SignEncryptedData,
+  headerCiphertext: SealedData,
   bodyCiphertext: EncryptedData,
-  headerVerificationKey: bytes,
+  verifyKey: bytes,
   keyGeneration: int,
 }
 
@@ -1389,6 +1388,12 @@ export type S3Params = {
   regionBucketEndpoint: string,
 }
 
+export type SealedData = {
+  v: int,
+  e: bytes,
+  n: bytes,
+}
+
 export type SetConversationStatusLocalRes = {
   rateLimits?: ?Array<RateLimit>,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
@@ -1414,7 +1419,7 @@ export type SetStatusPayload = {
 
 export type SignEncryptedData = {
   v: int,
-  b: bytes,
+  e: bytes,
   n: bytes,
 }
 


### PR DESCRIPTION
Implement `boxV2` and `unboxV2`. Writing with `boxV2` is not used outside of tests.

This is the first client that can read V2 messages. So, if all goes well, once this version of the client has been out for long enough (~1 month) then we can enable writing V2 messages.

Sprinkled `CORE-4540` notes around for when in about a month we enable boxV2.

This has a `compareHeaders` method that is very similar to [this](https://github.com/keybase/client/pull/6044/files#diff-d1325d9a259c7d25092218f3fa0661d4R832). So I'll deal with that after that PR lands.

The plan:
- Release this client which can read v2.
- Wait a month.
- Critical out clients that can't read v2.
- Release a client in which
  - Sends only v2 messages
  - `HeaderPlaintextV1` has a *optional* `MerkleRoot` field added to it. Once we're not sending any more `MessageBoxedV1` messages, it should be safe to add `omitempty` fields to `HeaderPlaintextV1` without breaking V1 unboxing. V1 unboxing is finicky because it reserializes before checking the sig.
  - Set that MerkleRoot

I'll test that out manually before merging this.