### PR TITLE
Chat: Display message failure errors

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -1275,7 +1275,7 @@ function _decodeFailureDescription (typ: ChatTypes.OutboxErrorType): string {
     case ChatTypes.LocalOutboxErrorType.toolong:
       return 'message is too long'
   }
-  return 'unknown error'
+  return `unknown error type ${typ}`
 }
 
 function _unboxedToMessage (message: MessageUnboxed, yourName, yourDeviceName, conversationIDKey: ConversationIDKey): Message {

--- a/shared/chat/conversation/messages/dumb.js
+++ b/shared/chat/conversation/messages/dumb.js
@@ -114,6 +114,7 @@ const mocks = followStates.reduce((outerAcc, followState) => (
 mocks['from revoked device'] = {...baseMock, message: textMessageMock('sent', 'cecileb', 'other', {senderDeviceRevokedAt: 123456}), you: 'other', followingMap: {cecileb: true}, metaDataMap}
 mocks['edited'] = {...baseMock, message: textMessageMock('sent', 'cecileb', 'cecileb', {editedCount: 1}), you: 'cecileb', followingMap: {}, metaDataMap}
 mocks['first new message'] = {...baseMock, message: textMessageMock('sent', 'cecileb', 'cecileb'), you: 'cecileb', isFirstNewMessage: true, followingMap: {}, metaDataMap}
+mocks['failure reason'] = {...baseMock, message: textMessageMock('failed', 'cecileb', 'cecileb', {failureDescription: 'the flurble glurbled'}), you: 'cecileb', followingMap: {}, metaDataMap}
 
 const StackedMessages = ({mock1, mock2}: any) => (
   <Box>

--- a/shared/chat/conversation/messages/retry.js
+++ b/shared/chat/conversation/messages/retry.js
@@ -4,8 +4,7 @@ import {globalColors, globalStyles} from '../../../styles'
 import {Text} from '../../../common-adapters'
 
 const Retry = ({failureDescription, onRetry}: {failureDescription?: ?string, onRetry: () => void}) => {
-  const suffix = (failureDescription ? ' - ' + failureDescription : '') + '. '
-  const error = '> Failed to send' + suffix
+  const error = `> Failed to send${failureDescription ? ` -  ${failureDescription}` : ''}. `
   return (
     <Text type='BodySmall'>
       <Text type='BodySmall' style={{fontSize: 9, color: globalColors.red}}>{'┏(>_<)┓'}</Text>

--- a/shared/chat/conversation/messages/retry.js
+++ b/shared/chat/conversation/messages/retry.js
@@ -3,12 +3,16 @@ import React from 'react'
 import {globalColors, globalStyles} from '../../../styles'
 import {Text} from '../../../common-adapters'
 
-const Retry = ({onRetry}: {onRetry: () => void}) => (
-  <Text type='BodySmall'>
-    <Text type='BodySmall' style={{fontSize: 9, color: globalColors.red}}>{'┏(>_<)┓'}</Text>
-    <Text type='BodySmall' style={{color: globalColors.red}}> Failed to send. </Text>
-    <Text type='BodySmall' style={{color: globalColors.red, ...globalStyles.textDecoration('underline')}} onClick={onRetry}>Retry</Text>
-  </Text>
-)
+const Retry = ({failureDescription, onRetry}: {failureDescription?: ?string, onRetry: () => void}) => {
+  const suffix = (failureDescription ? ' - ' + failureDescription : '') + '. '
+  const error = '> Failed to send' + suffix
+  return (
+    <Text type='BodySmall'>
+      <Text type='BodySmall' style={{fontSize: 9, color: globalColors.red}}>{'┏(>_<)┓'}</Text>
+      <Text type='BodySmall' style={{color: globalColors.red}}>{error}</Text>
+      <Text type='BodySmall' style={{color: globalColors.red, ...globalStyles.textDecoration('underline')}} onClick={onRetry}>Retry</Text>
+    </Text>
+  )
+}
 
 export default Retry

--- a/shared/chat/conversation/messages/retry.js
+++ b/shared/chat/conversation/messages/retry.js
@@ -4,11 +4,11 @@ import {globalColors, globalStyles} from '../../../styles'
 import {Text} from '../../../common-adapters'
 
 const Retry = ({failureDescription, onRetry}: {failureDescription?: ?string, onRetry: () => void}) => {
-  const error = `> Failed to send${failureDescription ? ` -  ${failureDescription}` : ''}. `
+  const error = `Failed to send${failureDescription ? ` -  ${failureDescription}` : ''}. `
   return (
     <Text type='BodySmall'>
       <Text type='BodySmall' style={{fontSize: 9, color: globalColors.red}}>{'┏(>_<)┓'}</Text>
-      <Text type='BodySmall' style={{color: globalColors.red}}>{error}</Text>
+      <Text type='BodySmall' style={{color: globalColors.red}}> {error}</Text>
       <Text type='BodySmall' style={{color: globalColors.red, ...globalStyles.textDecoration('underline')}} onClick={onRetry}>Retry</Text>
     </Text>
   )

--- a/shared/chat/conversation/messages/wrapper.desktop.js
+++ b/shared/chat/conversation/messages/wrapper.desktop.js
@@ -28,7 +28,6 @@ class MessageWrapper extends PureComponent<void, MessageProps, void> {
   }
 
   render () {
-    // $FlowIssue
     const {children, message, style, includeHeader, isFirstNewMessage, onRetry, onIconClick, isSelected, you, followingMap, metaDataMap} = this.props
     return (
       <div style={{...globalStyles.flexBoxColumn, flex: 1, ...(isFirstNewMessage ? _stylesFirstNewMessage : null), ...(isSelected ? _stylesSelected : null), ...style}}>

--- a/shared/chat/conversation/messages/wrapper.desktop.js
+++ b/shared/chat/conversation/messages/wrapper.desktop.js
@@ -28,6 +28,7 @@ class MessageWrapper extends PureComponent<void, MessageProps, void> {
   }
 
   render () {
+    // $FlowIssue
     const {children, message, style, includeHeader, isFirstNewMessage, onRetry, onIconClick, isSelected, you, followingMap, metaDataMap} = this.props
     return (
       <div style={{...globalStyles.flexBoxColumn, flex: 1, ...(isFirstNewMessage ? _stylesFirstNewMessage : null), ...(isSelected ? _stylesSelected : null), ...style}}>
@@ -49,7 +50,7 @@ class MessageWrapper extends PureComponent<void, MessageProps, void> {
                   <Icon type='iconfont-ellipsis' style={_ellipsisStyle} onClick={onIconClick} />
                 </div>
               </div>
-              {message.messageState === 'failed' && <Retry onRetry={onRetry} />}
+              {message.messageState === 'failed' && <Retry failureDescription={message.failureDescription} onRetry={onRetry} />}
             </div>
           </div>
         </div>

--- a/shared/chat/conversation/messages/wrapper.native.js
+++ b/shared/chat/conversation/messages/wrapper.native.js
@@ -12,6 +12,7 @@ type MessageProps = Props & {onRetry: () => void}
 
 class MessageWrapper extends PureComponent<void, MessageProps, void> {
   render () {
+    // $FlowIssue
     const {children, message, style, includeHeader, isFirstNewMessage, onRetry, isSelected, you, followingMap, metaDataMap} = this.props
     return (
       <Box style={{...globalStyles.flexBoxColumn, flex: 1, ...(isFirstNewMessage ? _stylesFirstNewMessage : null), ...(isSelected ? _stylesSelected : null), ...style}}>
@@ -32,7 +33,7 @@ class MessageWrapper extends PureComponent<void, MessageProps, void> {
                   {message.senderDeviceRevokedAt && <Icon type='iconfont-exclamation' style={_exclamationStyle} />}
                 </Box>
               </Box>
-              {message.messageState === 'failed' && <Retry onRetry={onRetry} />}
+              {message.messageState === 'failed' && <Retry failureDescription={message.failureDescription} onRetry={onRetry} />}
             </Box>
           </Box>
         </Box>

--- a/shared/chat/conversation/messages/wrapper.native.js
+++ b/shared/chat/conversation/messages/wrapper.native.js
@@ -12,7 +12,6 @@ type MessageProps = Props & {onRetry: () => void}
 
 class MessageWrapper extends PureComponent<void, MessageProps, void> {
   render () {
-    // $FlowIssue
     const {children, message, style, includeHeader, isFirstNewMessage, onRetry, isSelected, you, followingMap, metaDataMap} = this.props
     return (
       <Box style={{...globalStyles.flexBoxColumn, flex: 1, ...(isFirstNewMessage ? _stylesFirstNewMessage : null), ...(isSelected ? _stylesSelected : null), ...style}}>

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -111,6 +111,7 @@ export type AttachmentMessage = {
   messageState: AttachmentMessageState,
   senderDeviceRevokedAt: ?number,
   key: MessageKey,
+  failureDescription?: ?string,
 }
 
 export type TimestampMessage = {

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -43,6 +43,7 @@ export type TextMessage = {
   messageID?: MessageID,
   you: string,
   messageState: MessageState,
+  failureDescription: ?string,
   outboxID?: ?OutboxIDKey,
   senderDeviceRevokedAt: ?number,
   key: MessageKey,
@@ -297,7 +298,7 @@ export type AppendMessages = NoErrorTypedAction<'chat:appendMessages', {conversa
 export type BadgeAppForChat = NoErrorTypedAction<'chat:badgeAppForChat', List<ConversationBadgeState>>
 export type ClearMessages = NoErrorTypedAction<'chat:clearMessages', {conversationIDKey: ConversationIDKey}>
 export type ConversationSetStatus = NoErrorTypedAction<'chat:conversationSetStatus', {conversationIDKey: ConversationIDKey, muted: boolean}>
-export type CreatePendingFailure = NoErrorTypedAction<'chat:createPendingFailure', {outboxID: OutboxIDKey}>
+export type CreatePendingFailure = NoErrorTypedAction<'chat:createPendingFailure', {failureDescription: string, outboxID: OutboxIDKey}>
 export type DeleteMessage = NoErrorTypedAction<'chat:deleteMessage', {message: Message}>
 export type EditMessage = NoErrorTypedAction<'chat:editMessage', {message: Message, text: HiddenString}>
 export type InboxStale = NoErrorTypedAction<'chat:inboxStale', void>


### PR DESCRIPTION
@keybase/react-hackers 

The service sends us a failure `typ` associated with failed messages.  This PR:

* adds a function that decodes the `typ` enum into an error string for display
* uses that function in the `incomingMessage->failedMessage` path for live updates
* uses that function in the `getThreadLocal` path for failed messages when getting new threads
* hooks up the Retry component to use the new description

There's a `// $FlowIssue` in the render functions that I'd really like to fix but haven't been able to figure out, maybe someone's up for checking out the branch and having a crack at it?  It's related to the whole `TextMessage` massive number of variants mess.

Screenshot:

![chatfailures](https://cloud.githubusercontent.com/assets/21217/23469628/18eefd74-fe72-11e6-98e8-74d7801f7005.png)