### PR TITLE
change notification policy and implementation

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -1961,7 +1961,7 @@ function * _sendNotifications (action: AppendMessages): SagaGenerator<any, any> 
       if (message && message.type === 'Text') {
         const snippet = makeSnippet(serverMessageToMessageBody(message))
         yield put((dispatch: Dispatch) => {
-          NotifyPopup(message.author, {body: snippet}, -1, () => {
+          NotifyPopup(message.author, {body: snippet}, -1, message.author, () => {
             dispatch(selectConversation(action.payload.conversationIDKey, false))
             dispatch(switchTo([chatTab]))
             dispatch(showMainWindow())

--- a/shared/native/notifications.js.flow
+++ b/shared/native/notifications.js.flow
@@ -1,4 +1,2 @@
 // @flow
-import type {Dispatch} from '../constants/types/flux'
-
-export function NotifyPopup (title: string, opts: ?Object, rateLimitSeconds?: number): void {}
+export function NotifyPopup (title: string, opts: ?Object, rateLimitSeconds?: number, rateLimitKey?: string, onClick: ?() => void): void {}

--- a/shared/native/notifications.native.js
+++ b/shared/native/notifications.native.js
@@ -1,5 +1,5 @@
 // @flow
 
-export function NotifyPopup (title: string, opts: Object, rateLimitSeconds: number = -1): void {
+export function NotifyPopup (title: string, opts: Object, rateLimitSeconds: number = -1, rateLimitKey?: string): void {
   console.log('NotifyPopup: ', title, opts)
 }

--- a/shared/util/kbfs-notifications.js
+++ b/shared/util/kbfs-notifications.js
@@ -135,22 +135,21 @@ export function kbfsNotification (notification: FSNotification, notify: any, get
   let title = `KBFS: ${action}`
   let body = `Chat or files with ${usernames} ${notification.status}`
   let user = getState().config.username
+  let rateLimitKey
 
   const isError = notification.statusCode === KbfsCommonFSStatusCode.error
   // Don't show starting or finished, but do show error.
   if (isError) {
     ({title, body} = decodeKBFSError(user, notification))
-  }
-
-  let rateLimitKey
-
-  // limit all rekeys
-  switch (action) {
-    case 'Rekeying':
-      rateLimitKey = 'rekey'
-      break
-    default:
-      rateLimitKey = usernames
+    rateLimitKey = body // show unique errors
+  } else {
+    switch (action) {
+      case 'Rekeying': // limit all rekeys, no matter the tlf
+        rateLimitKey = 'rekey'
+        break
+      default:
+        rateLimitKey = usernames // by tlf
+    }
   }
 
   notify(title, {body}, 10, rateLimitKey)


### PR DESCRIPTION
This addresses some feedback from @malgorithms and a bug report from @mlsteele 
- [x] We leave the debouncing logic to the notify and don't have our own policy in kbfs notifications.
- [x] We're collapsing all rekey messages as they usually come in a flood and tend to be unique so now we only show the first and last
- [x] Use lodash debounce logic and not our own date managing scheme
