### PR TITLE
use package level locks for storage CORE-4681

### DIFF
--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -1,0 +1,74 @@
+package chat
+
+import (
+	"context"
+	"testing"
+
+	"sync"
+
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInboxSourceUpdateRace(t *testing.T) {
+	world, ri, _, sender, _, _, tlf := setupTest(t, 1)
+	defer world.Cleanup()
+
+	u := world.GetUsers()[0]
+	tc := world.Tcs[u.Username]
+	trip := newConvTriple(t, tlf, u.Username)
+	res, err := ri.NewConversationRemote2(context.TODO(), chat1.NewConversationRemote2Arg{
+		IdTriple: trip,
+		TLFMessage: chat1.MessageBoxed{
+			ClientHeader: chat1.MessageClientHeader{
+				TlfName:   u.Username,
+				TlfPublic: false,
+			},
+			KeyGeneration: 1,
+		},
+	})
+	require.NoError(t, err)
+
+	_, _, _, err = sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Conv:        trip,
+			Sender:      u.User.GetUID().ToBytes(),
+			TlfName:     u.Username,
+			TlfPublic:   false,
+			MessageType: chat1.MessageType_TEXT,
+		},
+		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+			Body: "HIHI",
+		}),
+	}, 0)
+	require.NoError(t, err)
+
+	ib, _, err := tc.G.InboxSource.Read(context.TODO(), u.User.GetUID().ToBytes(), nil, true, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, chat1.InboxVers(0), ib.Version, "wrong version")
+
+	// Spawn to goroutines to try and update the inbox at the same time with a self-update, and a
+	// Gregor style update
+	t.Logf("spawning update goroutines")
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		_, err = tc.G.InboxSource.SetStatus(context.TODO(), u.User.GetUID().ToBytes(), 0, res.ConvID,
+			chat1.ConversationStatus_UNFILED)
+		require.NoError(t, err)
+		wg.Done()
+	}()
+	wg.Add(1)
+	go func() {
+		_, err = tc.G.InboxSource.SetStatus(context.TODO(), u.User.GetUID().ToBytes(), 1, res.ConvID,
+			chat1.ConversationStatus_UNFILED)
+		require.NoError(t, err)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	ib, _, err = tc.G.InboxSource.Read(context.TODO(), u.User.GetUID().ToBytes(), nil, true, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, chat1.InboxVers(1), ib.Version, "wrong version")
+}

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -47,7 +47,7 @@ func TestInboxSourceUpdateRace(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, chat1.InboxVers(0), ib.Version, "wrong version")
 
-	// Spawn to goroutines to try and update the inbox at the same time with a self-update, and a
+	// Spawn two goroutines to try and update the inbox at the same time with a self-update, and a
 	// Gregor style update
 	t.Logf("spawning update goroutines")
 	var wg sync.WaitGroup

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -426,7 +426,6 @@ type Deliverer struct {
 
 	sender        Sender
 	outbox        *storage.Outbox
-	storage       *storage.Storage
 	identNotifier *IdentifyNotifier
 	shutdownCh    chan chan struct{}
 	msgSentCh     chan struct{}
@@ -444,7 +443,6 @@ func NewDeliverer(g *libkb.GlobalContext, sender Sender) *Deliverer {
 		msgSentCh:     make(chan struct{}, 100),
 		reconnectCh:   make(chan struct{}, 100),
 		sender:        sender,
-		storage:       storage.New(g, func() libkb.SecretUI { return DelivererSecretUI{} }),
 		identNotifier: NewIdentifyNotifier(g),
 		clock:         clockwork.NewRealClock(),
 	}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"time"
 
@@ -75,7 +74,6 @@ type inboxDiskData struct {
 }
 
 type Inbox struct {
-	sync.Mutex
 	libkb.Contextified
 	*baseBox
 	utils.DebugLabeler
@@ -177,8 +175,8 @@ func (i *Inbox) hashQuery(ctx context.Context, query *chat1.GetInboxQuery) (quer
 
 func (i *Inbox) Merge(ctx context.Context, vers chat1.InboxVers, convsIn []chat1.Conversation,
 	query *chat1.GetInboxQuery, p *chat1.Pagination) (err Error) {
-	i.Lock()
-	defer i.Unlock()
+	locks.Inbox.Lock()
+	defer locks.Inbox.Unlock()
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
 
 	i.Debug(ctx, "Merge: vers: %d", vers)
@@ -393,8 +391,8 @@ func (i *Inbox) queryExists(ctx context.Context, ibox inboxDiskData, query *chat
 }
 
 func (i *Inbox) ReadAll(ctx context.Context) (vers chat1.InboxVers, res []chat1.Conversation, err Error) {
-	i.Lock()
-	defer i.Unlock()
+	locks.Inbox.Lock()
+	defer locks.Inbox.Unlock()
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
 
 	ibox, err := i.readDiskInbox(ctx)
@@ -409,8 +407,8 @@ func (i *Inbox) ReadAll(ctx context.Context) (vers chat1.InboxVers, res []chat1.
 }
 
 func (i *Inbox) Read(ctx context.Context, query *chat1.GetInboxQuery, p *chat1.Pagination) (vers chat1.InboxVers, res []chat1.Conversation, pagination *chat1.Pagination, err Error) {
-	i.Lock()
-	defer i.Unlock()
+	locks.Inbox.Lock()
+	defer locks.Inbox.Unlock()
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
 
 	ibox, err := i.readDiskInbox(ctx)
@@ -473,8 +471,8 @@ func (i *Inbox) handleVersion(ctx context.Context, ourvers chat1.InboxVers, upda
 }
 
 func (i *Inbox) NewConversation(ctx context.Context, vers chat1.InboxVers, conv chat1.Conversation) (err Error) {
-	i.Lock()
-	defer i.Unlock()
+	locks.Inbox.Lock()
+	defer locks.Inbox.Unlock()
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
 
 	i.Debug(ctx, "NewConversation: vers: %d convID: %s", vers, conv.GetConvID())
@@ -565,8 +563,8 @@ func (i *Inbox) promoteWriter(ctx context.Context, sender gregor1.UID, writers [
 
 func (i *Inbox) NewMessage(ctx context.Context, vers chat1.InboxVers, convID chat1.ConversationID,
 	msg chat1.MessageBoxed) (err Error) {
-	i.Lock()
-	defer i.Unlock()
+	locks.Inbox.Lock()
+	defer locks.Inbox.Unlock()
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
 
 	i.Debug(ctx, "NewMessage: vers: %d convID: %s", vers, convID)
@@ -645,8 +643,8 @@ func (i *Inbox) NewMessage(ctx context.Context, vers chat1.InboxVers, convID cha
 
 func (i *Inbox) ReadMessage(ctx context.Context, vers chat1.InboxVers, convID chat1.ConversationID,
 	msgID chat1.MessageID) (err Error) {
-	i.Lock()
-	defer i.Unlock()
+	locks.Inbox.Lock()
+	defer locks.Inbox.Unlock()
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
 
 	i.Debug(ctx, "ReadMessage: vers: %d convID: %s", vers, convID)
@@ -690,8 +688,8 @@ func (i *Inbox) ReadMessage(ctx context.Context, vers chat1.InboxVers, convID ch
 
 func (i *Inbox) SetStatus(ctx context.Context, vers chat1.InboxVers, convID chat1.ConversationID,
 	status chat1.ConversationStatus) (err Error) {
-	i.Lock()
-	defer i.Unlock()
+	locks.Inbox.Lock()
+	defer locks.Inbox.Unlock()
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
 
 	i.Debug(ctx, "SetStatus: vers: %d convID: %s", vers, convID)
@@ -730,8 +728,8 @@ func (i *Inbox) SetStatus(ctx context.Context, vers chat1.InboxVers, convID chat
 
 func (i *Inbox) TlfFinalize(ctx context.Context, vers chat1.InboxVers, convIDs []chat1.ConversationID,
 	finalizeInfo chat1.ConversationFinalizeInfo) (err Error) {
-	i.Lock()
-	defer i.Unlock()
+	locks.Inbox.Lock()
+	defer locks.Inbox.Unlock()
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
 
 	i.Debug(ctx, "TlfFinalize: vers: %d convIDs: %v finalizeInfo: %v", vers, convIDs, finalizeInfo)
@@ -770,8 +768,8 @@ func (i *Inbox) TlfFinalize(ctx context.Context, vers chat1.InboxVers, convIDs [
 }
 
 func (i *Inbox) VersionSync(ctx context.Context, vers chat1.InboxVers) (err Error) {
-	i.Lock()
-	defer i.Unlock()
+	locks.Inbox.Lock()
+	defer locks.Inbox.Unlock()
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
 
 	ibox, err := i.readDiskInbox(ctx)

--- a/go/chat/storage/locks.go
+++ b/go/chat/storage/locks.go
@@ -1,0 +1,9 @@
+package storage
+
+import "sync"
+
+type locksRepo struct {
+	Storage, Inbox, Outbox sync.Mutex
+}
+
+var locks locksRepo

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"sort"
 
@@ -16,7 +15,6 @@ import (
 )
 
 type Outbox struct {
-	sync.Mutex
 	libkb.Contextified
 	*baseBox
 	utils.DebugLabeler
@@ -105,8 +103,8 @@ func (o *Outbox) SetClock(cl clockwork.Clock) {
 
 func (o *Outbox) PushMessage(ctx context.Context, convID chat1.ConversationID,
 	msg chat1.MessagePlaintext, identifyBehavior keybase1.TLFIdentifyBehavior) (rec chat1.OutboxRecord, err Error) {
-	o.Lock()
-	defer o.Unlock()
+	locks.Outbox.Lock()
+	defer locks.Outbox.Unlock()
 
 	// Read outbox for the user
 	obox, err := o.readDiskOutbox(ctx)
@@ -153,8 +151,8 @@ func (o *Outbox) PushMessage(ctx context.Context, convID chat1.ConversationID,
 // PullAllConversations grabs all outbox entries for the current outbox, and optionally deletes them
 // from storage
 func (o *Outbox) PullAllConversations(ctx context.Context, includeErrors bool, remove bool) ([]chat1.OutboxRecord, error) {
-	o.Lock()
-	defer o.Unlock()
+	locks.Outbox.Lock()
+	defer locks.Outbox.Unlock()
 
 	// Read outbox for the user
 	obox, err := o.readDiskOutbox(ctx)
@@ -196,8 +194,8 @@ func (o *Outbox) PullAllConversations(ctx context.Context, includeErrors bool, r
 // RecordFailedAttempt will either modify an existing matching record (if sending) to next attempt
 // number, or if the record doesn't exist it adds it in.
 func (o *Outbox) RecordFailedAttempt(ctx context.Context, oldObr chat1.OutboxRecord) error {
-	o.Lock()
-	defer o.Unlock()
+	locks.Outbox.Lock()
+	defer locks.Outbox.Unlock()
 
 	// Read outbox for the user
 	obox, err := o.readDiskOutbox(ctx)
@@ -252,8 +250,8 @@ func (o *Outbox) RecordFailedAttempt(ctx context.Context, oldObr chat1.OutboxRec
 // MarkAsError will either mark an existing record as an error, or it will add the passed
 // record as an error with the specified error state
 func (o *Outbox) MarkAsError(ctx context.Context, obr chat1.OutboxRecord, errRec chat1.OutboxStateError) error {
-	o.Lock()
-	defer o.Unlock()
+	locks.Outbox.Lock()
+	defer locks.Outbox.Unlock()
 
 	// Read outbox for the user
 	obox, err := o.readDiskOutbox(ctx)
@@ -288,8 +286,8 @@ func (o *Outbox) MarkAsError(ctx context.Context, obr chat1.OutboxRecord, errRec
 }
 
 func (o *Outbox) RetryMessage(ctx context.Context, obid chat1.OutboxID) error {
-	o.Lock()
-	defer o.Unlock()
+	locks.Outbox.Lock()
+	defer locks.Outbox.Unlock()
 
 	// Read outbox for the user
 	obox, err := o.readDiskOutbox(ctx)
@@ -317,8 +315,8 @@ func (o *Outbox) RetryMessage(ctx context.Context, obid chat1.OutboxID) error {
 }
 
 func (o *Outbox) RemoveMessage(ctx context.Context, obid chat1.OutboxID) error {
-	o.Lock()
-	defer o.Unlock()
+	locks.Outbox.Lock()
+	defer locks.Outbox.Unlock()
 
 	// Read outbox for the user
 	obox, err := o.readDiskOutbox(ctx)
@@ -387,8 +385,8 @@ func (o *Outbox) insertMessage(ctx context.Context, thread *chat1.ThreadView, ob
 
 func (o *Outbox) SprinkleIntoThread(ctx context.Context, convID chat1.ConversationID,
 	thread *chat1.ThreadView) error {
-	o.Lock()
-	defer o.Unlock()
+	locks.Outbox.Lock()
+	defer locks.Outbox.Unlock()
 
 	// Read outbox for the user
 	obox, err := o.readDiskOutbox(ctx)

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/keybase/client/go/chat/pager"
 	"github.com/keybase/client/go/chat/utils"
@@ -24,7 +23,6 @@ type resultCollector interface {
 }
 
 type Storage struct {
-	sync.Mutex
 	libkb.Contextified
 	utils.DebugLabeler
 
@@ -188,8 +186,8 @@ func (s *Storage) MaybeNuke(force bool, err Error, convID chat1.ConversationID, 
 }
 
 func (s *Storage) GetMaxMsgID(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) (chat1.MessageID, error) {
-	s.Lock()
-	defer s.Unlock()
+	locks.Storage.Lock()
+	defer locks.Storage.Unlock()
 
 	maxMsgID, err := s.idtracker.getMaxMessageID(ctx, convID, uid)
 	if err != nil {
@@ -201,8 +199,8 @@ func (s *Storage) GetMaxMsgID(ctx context.Context, convID chat1.ConversationID, 
 func (s *Storage) Merge(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageUnboxed) Error {
 	// All public functions get locks to make access to the database single threaded.
 	// They should never be called from private functons.
-	s.Lock()
-	defer s.Unlock()
+	locks.Storage.Lock()
+	defer locks.Storage.Unlock()
 
 	var err Error
 	s.Debug(ctx, "Merge: convID: %s uid: %s num msgs: %d", convID, uid, len(msgs))
@@ -383,8 +381,8 @@ func (s *Storage) FetchUpToLocalMaxMsgID(ctx context.Context, convID chat1.Conve
 	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination) (chat1.ThreadView, Error) {
 	// All public functions get locks to make access to the database single threaded.
 	// They should never be called from private functons.
-	s.Lock()
-	defer s.Unlock()
+	locks.Storage.Lock()
+	defer locks.Storage.Unlock()
 
 	maxMsgID, err := s.idtracker.getMaxMessageID(ctx, convID, uid)
 	if err != nil {
@@ -399,8 +397,8 @@ func (s *Storage) Fetch(ctx context.Context, conv chat1.Conversation,
 	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination) (chat1.ThreadView, Error) {
 	// All public functions get locks to make access to the database single threaded.
 	// They should never be called from private functons.
-	s.Lock()
-	defer s.Unlock()
+	locks.Storage.Lock()
+	defer locks.Storage.Unlock()
 
 	return s.fetchUpToMsgIDLocked(ctx, conv.Metadata.ConversationID, uid, conv.ReaderInfo.MaxMsgid, query, pagination)
 }


### PR DESCRIPTION
The current way to use types from `chat/storage` is to be able to create things like `Inbox` and `Storage` such that there could be more than one of them. That is, `NewInbox` gets called a lot. Unfortunately, this meant the `Mutex` inside of `Inbox`, didn't really do anything, since `HybridInboxSource` creates a lot of them (and sometimes more than one on different threads trying to update at the same time). This would cause the full screen refresh we would see in chat a lot, since updates would stomp on each and cause us to tell Electron to reload. 

This patch creates package level locks for the three main components from `storage`, which replaces the mutexes attached to each struct. This way, each instance of `Inbox` is controlled by the same lock, and it is no longer possible for updates on `HybridInboxSource` to overlap each other. 

We also add a test which exposes the primary way one of these races can happen, which should help us guard against any regressions from this behavior in the future.