### PR TITLE
bust user cache on key changed notification

### DIFF
--- a/go/engine/device_add.go
+++ b/go/engine/device_add.go
@@ -118,10 +118,7 @@ func (e *DeviceAdd) Run(ctx *Context) (err error) {
 		return err
 	}
 
-	// provisioning was successful, so the user has changed:
-	e.G().NotifyRouter.HandleKeyfamilyChanged(e.G().Env.GetUID())
-	// TODO: Remove this after kbfs notification change complete
-	e.G().NotifyRouter.HandleUserChanged(e.G().Env.GetUID())
+	e.G().KeyfamilyChanged(e.G().Env.GetUID())
 
 	return nil
 }

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -126,12 +126,7 @@ func (e *loginProvision) Run(ctx *Context) error {
 		return err
 	}
 
-	// Remove this after kbfs notification change complete
-	// For now, call it before we let KBFS know there are new keys.
-	e.G().UserChanged(e.arg.User.GetUID())
-
-	// provisioning was successful, so the user has changed:
-	e.G().NotifyRouter.HandleKeyfamilyChanged(e.arg.User.GetUID())
+	e.G().KeyfamilyChanged(e.arg.User.GetUID())
 
 	return nil
 }

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -98,9 +98,8 @@ func (e *PaperKeyGen) Run(ctx *Context) error {
 	if e.arg.SkipPush {
 		return nil
 	}
-	e.G().NotifyRouter.HandleKeyfamilyChanged(e.arg.Me.GetUID())
-	// Remove this after kbfs notification change complete
-	e.G().UserChanged(e.arg.Me.GetUID())
+
+	e.G().KeyfamilyChanged(e.arg.Me.GetUID())
 
 	return nil
 }

--- a/go/libkb/full_self_cacher.go
+++ b/go/libkb/full_self_cacher.go
@@ -135,8 +135,10 @@ func (m *CachedFullSelf) HandleUserChanged(u keybase1.UID) error {
 	m.Lock()
 	defer m.Unlock()
 	if m.me != nil && m.me.GetUID().Equal(u) {
-		m.G().Log.Debug("| Invalidating me for UID=%s", u)
+		m.G().Log.Debug("| CachedFullSelf#HandleUserChanged: Invalidating me for UID=%s", u)
 		m.me = nil
+	} else {
+		m.G().Log.Debug("| CachedFullSelf#HandleUserChanged: Ignoring cache bust for UID=%s", u)
 	}
 	return nil
 }

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -370,7 +370,7 @@ func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UI
 
 func (u *CachedUPAKLoader) Invalidate(ctx context.Context, uid keybase1.UID) {
 
-	u.G().Log.Debug("CachedUPAKLoader#Invalidate(%s)", uid)
+	u.G().Log.Debug("| CachedUPAKLoader#Invalidate(%s)", uid)
 
 	if u.noCache {
 		return

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -349,8 +349,8 @@ func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UI
 	forcePollValues := []bool{false, true}
 
 	for _, fp := range forcePollValues {
-		// We need to force a reload to make KBFS tests pass
-		arg.ForcePoll = fp || (u.G().Env.GetRunMode() == DevelRunMode)
+
+		arg.ForcePoll = fp
 
 		upak, _, err := u.Load(arg)
 		if err != nil {

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -119,7 +119,16 @@ func (h *UserHandler) LoadUserPlusKeys(netCtx context.Context, arg keybase1.Load
 	netCtx = libkb.WithLogTag(netCtx, "LUPK")
 	h.G().Log.CDebugf(netCtx, "+ UserHandler#LoadUserPlusKeys(%+v)", arg)
 	ret, err := libkb.LoadUserPlusKeys(netCtx, h.G(), arg.Uid, arg.PollForKID)
-	h.G().Log.CDebugf(netCtx, "- UserHandler#LoadUserPlusKeys(%+v) -> (%+v,%s)", arg, ret, libkb.ErrToOk(err))
+
+	// for debugging purposes, output the returned KIDs (since this can be racy)
+	var kids []keybase1.KID
+	for _, key := range ret.DeviceKeys {
+		if !key.IsSibkey && key.PGPFingerprint == "" {
+			kids = append(kids, key.KID)
+		}
+	}
+
+	h.G().Log.CDebugf(netCtx, "- UserHandler#LoadUserPlusKeys(%+v) -> (UVV=%+v, KIDs=%v, err=%s)", arg, ret.Uvv, kids, libkb.ErrToOk(err))
 	return ret, err
 }
 

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -115,8 +115,12 @@ func (h *UserHandler) LoadUserByName(_ context.Context, arg keybase1.LoadUserByN
 	return
 }
 
-func (h *UserHandler) LoadUserPlusKeys(ctx context.Context, arg keybase1.LoadUserPlusKeysArg) (keybase1.UserPlusKeys, error) {
-	return libkb.LoadUserPlusKeys(ctx, h.G(), arg.Uid, arg.PollForKID)
+func (h *UserHandler) LoadUserPlusKeys(netCtx context.Context, arg keybase1.LoadUserPlusKeysArg) (keybase1.UserPlusKeys, error) {
+	netCtx = libkb.WithLogTag(netCtx, "LUPK")
+	h.G().Log.CDebugf(netCtx, "+ UserHandler#LoadUserPlusKeys(%+v)", arg)
+	ret, err := libkb.LoadUserPlusKeys(netCtx, h.G(), arg.Uid, arg.PollForKID)
+	h.G().Log.CDebugf(netCtx, "- UserHandler#LoadUserPlusKeys(%+v) -> (%+v,%s)", arg, ret, libkb.ErrToOk(err))
+	return ret, err
 }
 
 func (h *UserHandler) Search(_ context.Context, arg keybase1.SearchArg) (results []keybase1.SearchResult, err error) {

--- a/go/service/user_handler.go
+++ b/go/service/user_handler.go
@@ -37,9 +37,7 @@ func (r *userHandler) Create(ctx context.Context, cli gregor1.IncomingInterface,
 }
 
 func (r *userHandler) keyChange() error {
-	r.G().NotifyRouter.HandleKeyfamilyChanged(r.G().Env.GetUID())
-	// TODO: remove this when KBFS handles KeyfamilyChanged
-	r.G().NotifyRouter.HandleUserChanged(r.G().Env.GetUID())
+	r.G().KeyfamilyChanged(r.G().Env.GetUID())
 
 	// check if this device was just revoked and if so, logout
 	return r.G().LogoutIfRevoked()


### PR DESCRIPTION
- before it wasn't rigged up as we thought, it was only rigged up to user changed handler
- consolidate code for what to do when a rekey happens, either on gregor or because we know it happened locally