### PR TITLE
Fix log send crash. Fix attributes missing for keybase folder

### DIFF
--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -22,6 +22,20 @@
 
 @implementation AppDelegate
 
+- (BOOL)addSkipBackupAttributeToItemAtPath:(NSString *) filePathString
+{
+  NSURL* URL= [NSURL fileURLWithPath: filePathString];
+  assert([[NSFileManager defaultManager] fileExistsAtPath: [URL path]]);
+
+  NSError *error = nil;
+  BOOL success = [URL setResourceValue: [NSNumber numberWithBool: YES]
+                                forKey: NSURLIsExcludedFromBackupKey error: &error];
+  if(!success){
+    NSLog(@"Error excluding %@ from backup %@", [URL lastPathComponent], error);
+  }
+  return success;
+}
+
 - (void) setupGo
 {
 
@@ -36,7 +50,18 @@
 
 #if TESTING
 #else
-  NSString * logFile = [home stringByAppendingPathComponent:@"ios.log"];
+  NSString * library = [home stringByAppendingPathComponent:@"Library"];
+  NSString * appSupport = [library stringByAppendingPathComponent:@"Application Support"];
+  NSString * keybasePath = [appSupport stringByAppendingPathComponent:@"Keybase"];
+  NSString * logFile = [keybasePath stringByAppendingPathComponent:@"ios.log"];
+
+  // Make keybasePath if it doesn't exist
+  [[NSFileManager defaultManager] createDirectoryAtPath:keybasePath
+                            withIntermediateDirectories:YES
+                                             attributes:nil
+                                                  error:nil];
+  [self addSkipBackupAttributeToItemAtPath:keybasePath];
+
 
   NSError * err;
   self.engine = [[Engine alloc] initWithSettings:@{

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -24,12 +24,9 @@
 
 - (BOOL)addSkipBackupAttributeToItemAtPath:(NSString *) filePathString
 {
-  NSURL* URL= [NSURL fileURLWithPath: filePathString];
-  assert([[NSFileManager defaultManager] fileExistsAtPath: [URL path]]);
-
-  NSError *error = nil;
-  BOOL success = [URL setResourceValue: [NSNumber numberWithBool: YES]
-                                forKey: NSURLIsExcludedFromBackupKey error: &error];
+  NSURL * URL = [NSURL fileURLWithPath: filePathString];
+  NSError * error = nil;
+  BOOL success = [URL setResourceValue: @YES forKey: NSURLIsExcludedFromBackupKey error: &error];
   if(!success){
     NSLog(@"Error excluding %@ from backup %@", [URL lastPathComponent], error);
   }
@@ -50,10 +47,8 @@
 
 #if TESTING
 #else
-  NSString * library = [home stringByAppendingPathComponent:@"Library"];
-  NSString * appSupport = [library stringByAppendingPathComponent:@"Application Support"];
-  NSString * keybasePath = [appSupport stringByAppendingPathComponent:@"Keybase"];
-  NSString * logFile = [keybasePath stringByAppendingPathComponent:@"ios.log"];
+  NSString * keybasePath = [@"~/Library/ Application Support/Keybase" stringByExpandingTildeInPath];
+  NSString * logFile = [@"~/Library/Caches/ios.log" stringByExpandingTildeInPath];
 
   // Make keybasePath if it doesn't exist
   [[NSFileManager defaultManager] createDirectoryAtPath:keybasePath

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -47,8 +47,8 @@
 
 #if TESTING
 #else
-  NSString * keybasePath = [@"~/Library/ Application Support/Keybase" stringByExpandingTildeInPath];
-  NSString * logFile = [@"~/Library/Caches/ios.log" stringByExpandingTildeInPath];
+  NSString * keybasePath = [@"~/Library/Application Support/Keybase" stringByExpandingTildeInPath];
+  NSString * logFile = [@"~/Library/Caches/Keybase/ios.log" stringByExpandingTildeInPath];
 
   // Make keybasePath if it doesn't exist
   [[NSFileManager defaultManager] createDirectoryAtPath:keybasePath


### PR DESCRIPTION
- [x] The logs need to be under a folder and not the root in the homedir. This works on the sim but not on the device
- [x] We need to set flags to stop the keybase folder from being uploaded to icloud. I think the best way to verify this is to look into the sim folder data direction and run xattr. I see
```
xattr *
Keybase: com.apple.metadata:com_apple_backup_excludeItem
```  
which is correct

@keybase/react-hackers 