### PR TITLE
Title screen for mobile attachments

### DIFF
--- a/shared/chat/conversation/attachment-input/index.js
+++ b/shared/chat/conversation/attachment-input/index.js
@@ -1,7 +1,7 @@
 // @flow
 import React, {Component} from 'react'
 import {Box, Button, Icon, Input, PopupDialog, Text} from '../../../common-adapters/index'
-import {globalColors, globalStyles} from '../../../styles'
+import {globalColors, globalMargins, globalStyles} from '../../../styles'
 
 import type {Props} from './'
 
@@ -48,7 +48,7 @@ class RenderAttachmentInput extends Component<void, Props, State> {
           <Input style={{marginTop: 70, width: 460}} autoFocus={true} floatingHintTextOverride='Title' value={this.state.title} onEnterKeyDown={this._onSelect} onChangeText={this._updateTitle} />
           <Box style={{...globalStyles.flexBoxRow, marginTop: 100}}>
             <Button type='Secondary' onClick={this.props.onClose} label='Cancel' />
-            <Button type='Primary' onClick={this._onSelect} label='Send' />
+            <Button type='Primary' style={{marginLeft: globalMargins.tiny}} onClick={this._onSelect} label='Send' />
           </Box>
         </Box>
       </PopupDialog>

--- a/shared/chat/conversation/attachment-input/index.native.js
+++ b/shared/chat/conversation/attachment-input/index.native.js
@@ -1,6 +1,0 @@
-// @flow
-import type {Props} from './'
-
-const RenderAttachmentInput = ({onClose, onSelect, title}: Props) => null  // TODO
-
-export default RenderAttachmentInput

--- a/shared/chat/conversation/input.native.js
+++ b/shared/chat/conversation/input.native.js
@@ -81,12 +81,13 @@ class ConversationInput extends Component<void, Props, State> {
       const filename = isIOS ? response.uri.replace('file://', '') : response.path
       const conversationIDKey = this.props.selectedConversation
       if (conversationIDKey) {
-        this.props.onSelectAttachment(({
+        const input: AttachmentInput = {
           conversationIDKey,
           filename,
           title: response.fileName,
           type: 'Image',
-        }: AttachmentInput))
+        }
+        this.props.onAttach([input])
       }
     })
   }


### PR DESCRIPTION
@keybase/react-hackers 

Keeping it simple -- directly reuses the desktop's `attachment-input` component with a slight spacing tweak.  Screenshot:

<img width="642" alt="screen shot 2017-03-03 at 5 36 34 pm" src="https://cloud.githubusercontent.com/assets/21217/23571579/1563512e-0038-11e7-8257-426c34530338.png">

Yay for common-adapters!