### PR TITLE
Regexp optimization

### DIFF
--- a/go/client/cmd_ca.go
+++ b/go/client/cmd_ca.go
@@ -4,14 +4,15 @@
 package client
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/auth"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	context "golang.org/x/net/context"
-	"regexp"
-	"strings"
 )
 
 type CmdCA struct {

--- a/go/client/markup.go
+++ b/go/client/markup.go
@@ -45,11 +45,13 @@ func makePad(l int) []byte {
 	return ret
 }
 
+var spaceRE = regexp.MustCompile(`[[:space:]]+`)
+
 // spacify replaces arbitrary strings of whitespace with
 // a single ' ' character. Also strips off leading and trailing
 // whitespace.
 func spacify(s string) string {
-	v := regexp.MustCompile(`[[:space:]]+`).Split(s, -1)
+	v := spaceRE.Split(s, -1)
 	if len(v) > 0 && v[0] == "" {
 		v = v[1:]
 	}

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -5,9 +5,11 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
 	"runtime"
+	"runtime/pprof"
 	"syscall"
 	"time"
 
@@ -39,6 +41,13 @@ type Stopper interface {
 
 func main() {
 	err := libkb.SaferDLLLoading()
+
+	f, err := os.Create("/tmp/service.profile")
+	if err != nil {
+		log.Fatal(err)
+	}
+	pprof.StartCPUProfile(f)
+	defer pprof.StopCPUProfile()
 
 	g := G
 	g.Init()

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -5,11 +5,9 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"runtime"
-	"runtime/pprof"
 	"syscall"
 	"time"
 
@@ -41,13 +39,6 @@ type Stopper interface {
 
 func main() {
 	err := libkb.SaferDLLLoading()
-
-	f, err := os.Create("/tmp/service.profile")
-	if err != nil {
-		log.Fatal(err)
-	}
-	pprof.StartCPUProfile(f)
-	defer pprof.StopCPUProfile()
 
 	g := G
 	g.Init()

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -6,7 +6,6 @@ package libcmdline
 import (
 	"fmt"
 	"io"
-	"regexp"
 	"strings"
 	"time"
 
@@ -206,7 +205,7 @@ func (p CommandLine) GetGpgOptions() []string {
 	var ret []string
 	s := p.GetGString("gpg-options")
 	if len(s) > 0 {
-		ret = regexp.MustCompile(`\s+`).Split(s, -1)
+		ret = strings.Fields(s)
 	}
 	return ret
 }

--- a/go/libkb/assertion.go
+++ b/go/libkb/assertion.go
@@ -322,10 +322,11 @@ func (a AssertionFingerprint) ToLookup() (key, value string, err error) {
 	return
 }
 
+var pairRE = regexp.MustCompile(`^[0-9a-zA-Z@:/_-]`)
+
 func parseToKVPair(s string) (key string, value string, err error) {
 
-	re := regexp.MustCompile(`^[0-9a-zA-Z@:/_-]`)
-	if !re.MatchString(s) {
+	if !pairRE.MatchString(s) {
 		err = fmt.Errorf("Invalid key-value identity: %s", s)
 		return
 	}

--- a/go/libkb/base64_finder.go
+++ b/go/libkb/base64_finder.go
@@ -11,14 +11,14 @@ import (
 
 type Base64Finder struct {
 	input        string
-	rxx          *regexp.Regexp
 	lines        []string
 	base64blocks []string
 }
 
+var b64FindRE = regexp.MustCompile(`^\s*(([a-zA-Z0-9/+_-]+)(={0,3}))\s*$`)
+
 func NewBase64Finder(i string) *Base64Finder {
-	rxx := regexp.MustCompile(`^\s*(([a-zA-Z0-9/+_-]+)(={0,3}))\s*$`)
-	return &Base64Finder{input: i, rxx: rxx}
+	return &Base64Finder{input: i}
 }
 
 func (s *Base64Finder) split() {
@@ -68,7 +68,7 @@ func (s *Base64Finder) findOne(i int) (string, int) {
 
 	for ; i < l; i++ {
 		line := s.lines[i]
-		match := s.rxx.FindStringSubmatch(line)
+		match := b64FindRE.FindStringSubmatch(line)
 		if match != nil {
 			state = 1
 			parts = append(parts, match[1])
@@ -109,8 +109,10 @@ func FindFirstBase64Block(s string) string {
 	return ""
 }
 
+var snipRE = regexp.MustCompile(`(([a-zA-Z0-9/+_-]+)(={0,3}))`)
+
 func FindBase64Snippets(s string) []string {
-	return regexp.MustCompile(`(([a-zA-Z0-9/+_-]+)(={0,3}))`).FindAllString(s, -1)
+	return snipRE.FindAllString(s, -1)
 }
 
 func FindBase64Block(s string, pattern []byte, url bool) bool {

--- a/go/libkb/checkers.go
+++ b/go/libkb/checkers.go
@@ -10,18 +10,21 @@ import (
 	"unicode"
 )
 
+var emailRE = regexp.MustCompile(`^\S+@\S+\.\S+$`)
+var usernameRE = regexp.MustCompile(`^([a-zA-Z0-9][a-zA-Z0-9_]?)+$`)
+var deviceRE = regexp.MustCompile(`^[a-zA-Z0-9][ _'a-zA-Z0-9+-]*$`)
+var badDeviceRE = regexp.MustCompile(`  |[ '+_-]$|['+_-][ ]?['+_-]`)
+
 var CheckEmail = Checker{
 	F: func(s string) bool {
-		re := regexp.MustCompile(`^\S+@\S+\.\S+$`)
-		return len(s) > 3 && re.MatchString(s)
+		return len(s) > 3 && emailRE.MatchString(s)
 	},
 	Hint: "must be a valid email address",
 }
 
 var CheckUsername = Checker{
 	F: func(s string) bool {
-		re := regexp.MustCompile(`^([a-zA-Z0-9][a-zA-Z0-9_]?)+$`)
-		return len(s) >= 2 && len(s) <= 16 && re.MatchString(s)
+		return len(s) >= 2 && len(s) <= 16 && usernameRE.MatchString(s)
 	},
 	Hint: "between 2 and 16 characters long",
 }
@@ -61,9 +64,7 @@ var CheckInviteCode = Checker{
 
 var CheckDeviceName = Checker{
 	F: func(s string) bool {
-		re := regexp.MustCompile(`^[a-zA-Z0-9][ _'a-zA-Z0-9+-]*$`)
-		bad := regexp.MustCompile(`  |[ '+_-]$|['+_-][ ]?['+_-]`)
-		return len(s) >= 3 && len(s) <= 64 && re.MatchString(s) && !bad.MatchString(s)
+		return len(s) >= 3 && len(s) <= 64 && deviceRE.MatchString(s) && !badDeviceRE.MatchString(s)
 	},
 	Hint: "between 3 and 64 characters long; use a-Z, 0-9, space, plus, underscore, dash and apostrophe",
 }

--- a/go/libkb/client.go
+++ b/go/libkb/client.go
@@ -34,9 +34,10 @@ type Client struct {
 	config *ClientConfig
 }
 
+var hostRE = regexp.MustCompile("^([^:]+)(:([0-9]+))?$")
+
 func SplitHost(joined string) (host string, port int, err error) {
-	re := regexp.MustCompile("^([^:]+)(:([0-9]+))?$")
-	match := re.FindStringSubmatch(joined)
+	match := hostRE.FindStringSubmatch(joined)
 	if match == nil {
 		err = fmt.Errorf("Invalid host/port found: %s", joined)
 	} else {

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -22,11 +22,7 @@ func (k DbKey) ToBytes(table string) []byte {
 	return []byte(k.ToString(table))
 }
 
-var fieldExp *regexp.Regexp
-
-func init() {
-	fieldExp = regexp.MustCompile(`[a-f0-9]{2}`)
-}
+var fieldExp = regexp.MustCompile(`[a-f0-9]{2}`)
 
 func DbKeyParse(s string) (string, *DbKey, error) {
 	v := strings.Split(s, ":")

--- a/go/libkb/home.go
+++ b/go/libkb/home.go
@@ -161,9 +161,10 @@ type Win32 struct {
 	Base
 }
 
+var win32SplitRE = regexp.MustCompile(`[/\\]`)
+
 func (w Win32) Split(s string) []string {
-	rxx := regexp.MustCompile(`[/\\]`)
-	return rxx.Split(s, -1)
+	return win32SplitRE.Split(s, -1)
 }
 
 func (w Win32) Normalize(s string) string {

--- a/go/libkb/identity.go
+++ b/go/libkb/identity.go
@@ -17,12 +17,13 @@ type Identity struct {
 	Email    string
 }
 
+var idRE = regexp.MustCompile("" +
+	`^"?([^(<]*?)"?` + // The beginning name of the user (no comment or key)
+	`(?:\s*\((.*?)\)"?)?` + // The optional comment
+	`(?:\s*<(.*?)>)?$`) // The optional email address
+
 func ParseIdentity(s string) (*Identity, error) {
-	rxx := regexp.MustCompile("" +
-		`^"?([^(<]*?)"?` + // The beginning name of the user (no comment or key)
-		`(?:\s*\((.*?)\)"?)?` + // The optional comment
-		`(?:\s*<(.*?)>)?$`) // The optional email address
-	v := rxx.FindStringSubmatch(s)
+	v := idRE.FindStringSubmatch(s)
 	if v == nil {
 		return nil, fmt.Errorf("Bad PGP-style identity: %s", s)
 	}

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -110,8 +110,9 @@ func (t BaseServiceType) BaseCheckProofTextFull(text string, id keybase1.SigID, 
 	return
 }
 
+var urlRxx = regexp.MustCompile(`https://(\S+)`)
+
 func (t BaseServiceType) BaseCheckProofForURL(text string, id keybase1.SigID) (err error) {
-	urlRxx := regexp.MustCompile(`https://(\S+)`)
 	target := id.ToMediumID()
 	urls := urlRxx.FindAllString(text, -1)
 	G.Log.Debug("Found urls %v", urls)

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -236,15 +236,17 @@ func IsIn(needle string, haystack []string, ci bool) bool {
 	return false
 }
 
+// Found regex here: http://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
+var hostnameRE = regexp.MustCompile("^(?i:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$")
+
 func IsValidHostname(s string) bool {
 	parts := strings.Split(s, ".")
 	// Found regex here: http://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
-	rxx := regexp.MustCompile("^(?i:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$")
 	if len(parts) < 2 {
 		return false
 	}
 	for _, p := range parts {
-		if !rxx.MatchString(p) {
+		if !hostnameRE.MatchString(p) {
 			return false
 		}
 	}
@@ -531,8 +533,10 @@ func CTimeLog(ctx context.Context, name string, start time.Time, out func(contex
 	out(ctx, "time> %s: %s", name, time.Since(start))
 }
 
+var wsRE = regexp.MustCompile(`\s+`)
+
 func WhitespaceNormalize(s string) string {
-	v := regexp.MustCompile(`\s+`).Split(s, -1)
+	v := wsRE.Split(s, -1)
 	if len(v) > 0 && len(v[0]) == 0 {
 		v = v[1:]
 	}

--- a/go/pvl/helpers.go
+++ b/go/pvl/helpers.go
@@ -29,11 +29,12 @@ func substituteExact(template string, state scriptState) (string, libkb.ProofErr
 	return substituteInner(template, state, false)
 }
 
+var nameRE = regexp.MustCompile(`%\{[\w]*\}`)
+
 func substituteInner(template string, state scriptState, regexEscape bool) (string, libkb.ProofError) {
 	var outerr libkb.ProofError
 	// Regex to find %{name} occurrences.
 	// Match broadly here so that even %{} is sent to the default case and reported as invalid.
-	re := regexp.MustCompile(`%\{[\w]*\}`)
 	substituteOne := func(vartag string) string {
 		// Strip off the %, {, and }
 		varname := vartag[2 : len(vartag)-1]
@@ -48,7 +49,7 @@ func substituteInner(template string, state scriptState, regexEscape bool) (stri
 		}
 		return value
 	}
-	res := re.ReplaceAllStringFunc(template, substituteOne)
+	res := nameRE.ReplaceAllStringFunc(template, substituteOne)
 	if outerr != nil {
 		return template, outerr
 	}
@@ -191,6 +192,8 @@ func stringsContains(xs []string, x string) bool {
 	return false
 }
 
+var hasalpha = regexp.MustCompile(`\D`)
+
 // Check that a url is valid and has only a domain and is not an ip.
 // No port, path, protocol, user, query, or any other junk is allowed.
 func validateDomain(s string) bool {
@@ -205,7 +208,6 @@ func validateDomain(s string) bool {
 	// To disallow the likes of "8.8.8.8."
 	dotsplit := strings.Split(strings.TrimSuffix(u.Host, "."), ".")
 	if len(dotsplit) > 0 {
-		hasalpha := regexp.MustCompile(`\D`)
 		group := dotsplit[len(dotsplit)-1]
 		if !hasalpha.MatchString(group) {
 			return false

--- a/go/pvl/registers.go
+++ b/go/pvl/registers.go
@@ -76,11 +76,12 @@ func (r *namedRegsStore) Ban(key string) libkb.ProofError {
 	return nil
 }
 
+var keyRE = regexp.MustCompile(`^[a-z0-9_]+$`)
+
 // Make sure a key is a simple snake case name.
 // Does not check whether it's banned.
 func (r *namedRegsStore) validateKey(key string) libkb.ProofError {
-	re := regexp.MustCompile(`^[a-z0-9_]+$`)
-	if !re.MatchString(key) {
+	if !keyRE.MatchString(key) {
 		return libkb.NewProofError(keybase1.ProofStatus_INVALID_PVL, "invalid register name '%v'", key)
 	}
 	return nil


### PR DESCRIPTION
This is pretty minor, but it did show up in the cpu and memory profiles.  There are lots of needless recompiling of regular expressions.  

The expressions in assertion_parser.go were the ones that showed up repeatedly in the profiles, but I took the opportunity to clean them up in other places too.  There's no need to recompile them, and regexps are safe for concurrent goroutine access.