### PR TITLE
fix caching deadlock introduced by improper lock release ordering

### DIFF
--- a/go/libkb/full_self_cacher.go
+++ b/go/libkb/full_self_cacher.go
@@ -57,8 +57,9 @@ func NewUncachedFullSelf(g *GlobalContext) *UncachedFullSelf {
 type CachedFullSelf struct {
 	Contextified
 	sync.Mutex
-	me       *User
-	cachedAt time.Time
+	me             *User
+	cachedAt       time.Time
+	TestDeadlocker func()
 }
 
 var _ FullSelfer = (*CachedFullSelf)(nil)
@@ -165,7 +166,13 @@ func (m *CachedFullSelf) WithUser(arg LoadUserArg, f func(u *User) error) (err e
 	}
 
 	if m.me == nil || !m.isSelfLoad(arg) {
+
+		if m.TestDeadlocker != nil {
+			m.TestDeadlocker()
+		}
+
 		u, err = LoadUser(arg)
+
 		if err != nil {
 			return err
 		}

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -212,7 +212,7 @@ func (u *CachedUPAKLoader) PutUserToCache(ctx context.Context, user *User) error
 // In some cases, that deep copy can be expensive, so as for users who have lots of
 // followees. So if you provide accessor, the UPAK won't be deep-copied, but you'll
 // be able to access it from inside the accessor with exclusion.
-func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInfo, accessor func(k *keybase1.UserPlusAllKeys) error, canUseFullUser bool) (ret *keybase1.UserPlusAllKeys, user *User, err error) {
+func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInfo, accessor func(k *keybase1.UserPlusAllKeys) error, shouldReturnFullUser bool) (ret *keybase1.UserPlusAllKeys, user *User, err error) {
 
 	// Shorthand
 	g := u.G()
@@ -231,7 +231,11 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 
 	defer func() {
 		lock.Release(ctx)
-		if user != nil && err == nil && !canUseFullUser {
+
+		if !shouldReturnFullUser {
+			user = nil
+		}
+		if user != nil && err == nil {
 			// Update the full-self cacher after the lock is released, to avoid
 			// any circular locking.
 			if fs := u.G().GetFullSelfer(); fs != nil {

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -30,10 +30,11 @@ type UPAKLoader interface {
 type CachedUPAKLoader struct {
 	sync.Mutex
 	Contextified
-	m         map[string]*keybase1.UserPlusAllKeys
-	locktab   LockTable
-	Freshness time.Duration
-	noCache   bool
+	m              map[string]*keybase1.UserPlusAllKeys
+	locktab        LockTable
+	Freshness      time.Duration
+	noCache        bool
+	TestDeadlocker func()
 }
 
 // NewCachedUPAKLoader constructs a new CachedUPAKLoader
@@ -211,7 +212,7 @@ func (u *CachedUPAKLoader) PutUserToCache(ctx context.Context, user *User) error
 // In some cases, that deep copy can be expensive, so as for users who have lots of
 // followees. So if you provide accessor, the UPAK won't be deep-copied, but you'll
 // be able to access it from inside the accessor with exclusion.
-func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInfo, accessor func(k *keybase1.UserPlusAllKeys) error) (ret *keybase1.UserPlusAllKeys, user *User, err error) {
+func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInfo, accessor func(k *keybase1.UserPlusAllKeys) error, canUseFullUser bool) (ret *keybase1.UserPlusAllKeys, user *User, err error) {
 
 	// Shorthand
 	g := u.G()
@@ -227,7 +228,17 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 	}
 
 	lock := u.locktab.AcquireOnName(ctx, g, arg.UID.String())
-	defer lock.Release(ctx)
+
+	defer func() {
+		lock.Release(ctx)
+		if user != nil && err == nil && !canUseFullUser {
+			// Update the full-self cacher after the lock is released, to avoid
+			// any circular locking.
+			if fs := u.G().GetFullSelfer(); fs != nil {
+				fs.Update(ctx, user)
+			}
+		}
+	}()
 
 	returnUPAK := func(upak *keybase1.UserPlusAllKeys, needCopy bool) (*keybase1.UserPlusAllKeys, *User, error) {
 		if accessor != nil {
@@ -314,10 +325,8 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 	ret.Base.Uvv.CachedAt = keybase1.ToTime(g.Clock().Now())
 	err = u.putUPAKToCache(ctx, ret)
 
-	if fs := u.G().GetFullSelfer(); fs != nil {
-		// Update the full-self cacher after the lock is released, to avoid
-		// any circular locking.
-		defer fs.Update(ctx, user)
+	if u.TestDeadlocker != nil {
+		u.TestDeadlocker()
 	}
 
 	return returnUPAK(ret, false)
@@ -328,7 +337,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 // but never both non-nil, nor never both nil. If we had to do a full LoadUser as part of the
 // request, it's returned too.
 func (u *CachedUPAKLoader) Load(arg LoadUserArg) (ret *keybase1.UserPlusAllKeys, user *User, err error) {
-	return u.loadWithInfo(arg, nil, nil)
+	return u.loadWithInfo(arg, nil, nil, true)
 }
 
 func (u *CachedUPAKLoader) CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool, err error) {
@@ -336,7 +345,7 @@ func (u *CachedUPAKLoader) CheckKIDForUID(ctx context.Context, uid keybase1.UID,
 	var info CachedUserLoadInfo
 	larg := NewLoadUserByUIDArg(ctx, u.G(), uid)
 	larg.PublicKeyOptional = true
-	upak, _, err := u.loadWithInfo(larg, &info, nil)
+	upak, _, err := u.loadWithInfo(larg, &info, nil, false)
 
 	if err != nil {
 		return false, nil, false, err
@@ -346,7 +355,7 @@ func (u *CachedUPAKLoader) CheckKIDForUID(ctx context.Context, uid keybase1.UID,
 		return found, revokedAt, deleted, nil
 	}
 	larg.ForceReload = true
-	upak, _, err = u.loadWithInfo(larg, nil, nil)
+	upak, _, err = u.loadWithInfo(larg, nil, nil, false)
 	if err != nil {
 		return false, nil, false, err
 	}
@@ -413,7 +422,7 @@ func (u *CachedUPAKLoader) Invalidate(ctx context.Context, uid keybase1.UID) {
 func (u *CachedUPAKLoader) LoadDeviceKey(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (upak *keybase1.UserPlusAllKeys, deviceKey *keybase1.PublicKey, revoked *keybase1.RevokedKey, err error) {
 	var info CachedUserLoadInfo
 	larg := NewLoadUserByUIDArg(ctx, u.G(), uid)
-	upak, _, err = u.loadWithInfo(larg, &info, nil)
+	upak, _, err = u.loadWithInfo(larg, &info, nil, false)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -426,7 +435,7 @@ func (u *CachedUPAKLoader) LoadDeviceKey(ctx context.Context, uid keybase1.UID, 
 
 	// Try again with a forced load in case the device is very new.
 	larg.ForcePoll = true
-	upak, _, err = u.loadWithInfo(larg, nil, nil)
+	upak, _, err = u.loadWithInfo(larg, nil, nil, false)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -446,7 +455,7 @@ func (u *CachedUPAKLoader) LookupUsername(ctx context.Context, uid keybase1.UID)
 		}
 		ret = NewNormalizedUsername(upak.Base.Username)
 		return nil
-	})
+	}, false)
 	return ret, err
 }
 
@@ -472,7 +481,7 @@ func (u *CachedUPAKLoader) lookupUsernameAndDeviceWithInfo(ctx context.Context, 
 				found = true
 			}
 			return nil
-		})
+		}, false)
 		if found {
 			return username, deviceName, deviceType, nil
 		}

--- a/go/libkb/upak_loader_test.go
+++ b/go/libkb/upak_loader_test.go
@@ -24,7 +24,7 @@ func TestCachedUserLoad(t *testing.T) {
 		UID: keybase1.UID("295a7eea607af32040647123732bc819"),
 	}
 	var info CachedUserLoadInfo
-	upk, user, err := tc.G.GetUPAKLoader().(*CachedUPAKLoader).loadWithInfo(arg, &info, nil)
+	upk, user, err := tc.G.GetUPAKLoader().(*CachedUPAKLoader).loadWithInfo(arg, &info, nil, true)
 
 	checkLoad := func(upk *keybase1.UserPlusAllKeys, err error) {
 		if err != nil {
@@ -43,7 +43,7 @@ func TestCachedUserLoad(t *testing.T) {
 
 	fakeClock.Advance(CachedUserTimeout / 100)
 	info = CachedUserLoadInfo{}
-	upk, user, err = tc.G.GetUPAKLoader().(*CachedUPAKLoader).loadWithInfo(arg, &info, nil)
+	upk, user, err = tc.G.GetUPAKLoader().(*CachedUPAKLoader).loadWithInfo(arg, &info, nil, true)
 	checkLoad(upk, err)
 	if user != nil {
 		t.Fatal("expected no full user load")
@@ -55,7 +55,7 @@ func TestCachedUserLoad(t *testing.T) {
 
 	fakeClock.Advance(2 * CachedUserTimeout)
 	info = CachedUserLoadInfo{}
-	upk, user, err = tc.G.GetUPAKLoader().(*CachedUPAKLoader).loadWithInfo(arg, &info, nil)
+	upk, user, err = tc.G.GetUPAKLoader().(*CachedUPAKLoader).loadWithInfo(arg, &info, nil, true)
 	checkLoad(upk, err)
 	if user != nil {
 		t.Fatal("expected no full user load")
@@ -110,7 +110,7 @@ func TestCacheFallbacks(t *testing.T) {
 		uid := keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")
 		var arg LoadUserArg
 		arg.UID = uid
-		upk, _, err := tc.G.GetUPAKLoader().(*CachedUPAKLoader).loadWithInfo(arg, &ret, nil)
+		upk, _, err := tc.G.GetUPAKLoader().(*CachedUPAKLoader).loadWithInfo(arg, &ret, nil, false)
 		require.NoError(t, err)
 		require.Equal(t, upk.Base.Username, "t_tracy", "tracy was right")
 		return &ret


### PR DESCRIPTION
- my bug was that i thought `defer`s would fire in FIFO order, but instead it's FILO order
- so we triggered exactly the deadlock we had hoped to avoid