### PR TITLE
Remove churn on the service <-> RN bridge

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
+	_ "net/http/pprof"
 	"sync"
 
 	"github.com/keybase/client/go/externals"
@@ -39,6 +41,11 @@ func InitOnce(homeDir string, logFile string, runModeStr string, accessGroupOver
 func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride bool) error {
 	fmt.Println("Go: Initializing")
 	fmt.Printf("Go: Using log: %s\n", logFile)
+
+	go func() {
+		fmt.Println(http.ListenAndServe(":6060", nil))
+	}()
+
 	kbCtx = libkb.G
 	kbCtx.Init()
 	kbCtx.SetServices(externals.GetServices())
@@ -138,11 +145,13 @@ const targetBufferSize = 50 * 1024
 // size.
 const bufferSize = targetBufferSize - (targetBufferSize % 3)
 
-// ReadB64 is a blocking read for base64 encoded msgpack rpc data.
-func ReadB64() (string, error) {
-	data := make([]byte, bufferSize)
+// buffer for the conn.Read
+var buffer = make([]byte, bufferSize)
 
-	n, err := conn.Read(data)
+// ReadB64 is a blocking read for base64 encoded msgpack rpc data.
+// It is called serially by the mobile run loops.
+func ReadB64() (string, error) {
+	n, err := conn.Read(buffer)
 	if n > 0 && err == nil {
 		str := base64.StdEncoding.EncodeToString(data[0:n])
 		return str, nil

--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -8,8 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/http"
-	_ "net/http/pprof"
 	"sync"
 
 	"github.com/keybase/client/go/externals"
@@ -41,10 +39,6 @@ func InitOnce(homeDir string, logFile string, runModeStr string, accessGroupOver
 func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride bool) error {
 	fmt.Println("Go: Initializing")
 	fmt.Printf("Go: Using log: %s\n", logFile)
-
-	go func() {
-		fmt.Println(http.ListenAndServe(":6060", nil))
-	}()
 
 	kbCtx = libkb.G
 	kbCtx.Init()

--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -153,7 +153,7 @@ var buffer = make([]byte, bufferSize)
 func ReadB64() (string, error) {
 	n, err := conn.Read(buffer)
 	if n > 0 && err == nil {
-		str := base64.StdEncoding.EncodeToString(data[0:n])
+		str := base64.StdEncoding.EncodeToString(buffer[0:n])
 		return str, nil
 	}
 


### PR DESCRIPTION
this data buffer can be reused, doesn't need to be created for every read.