### PR TITLE
Handle push notification tap on iOS: open conversation

### DIFF
--- a/shared/actions/push.js
+++ b/shared/actions/push.js
@@ -3,6 +3,8 @@ import * as Constants from '../constants/push'
 import {isMobile} from '../constants/platform'
 import {apiserverPostRpcPromise} from '../constants/types/flow-types'
 import {call, put, take, select} from 'redux-saga/effects'
+import {chatTab} from '../constants/tabs'
+import {navigateTo} from './route-tree'
 import {safeTakeEvery, safeTakeLatest} from '../util/saga'
 
 import type {SagaGenerator} from '../constants/types/saga'
@@ -55,8 +57,21 @@ function * permissionsRequestSaga (): SagaGenerator<any, any> {
 }
 
 function * pushNotificationSaga (notification: PushNotification): SagaGenerator<any, any> {
-  // TODO: Handle push notifications
   console.warn('Push notification:', notification)
+  if (notification.payload && notification.payload.userInteraction) {
+    if (!notification.payload.data || !notification.payload.data.convID) {
+      console.warn('Push notification missing data', notification)
+      return
+    }
+
+    const {convID} = notification.payload.data
+    if (!convID) {
+      console.error('Push notification payload missing conversation ID')
+      return
+    }
+
+    yield put(navigateTo([chatTab, convID]))
+  }
 }
 
 function * pushTokenSaga (action: PushTokenAction): SagaGenerator<any, any> {

--- a/shared/actions/push.js
+++ b/shared/actions/push.js
@@ -59,7 +59,7 @@ function * permissionsRequestSaga (): SagaGenerator<any, any> {
 function * pushNotificationSaga (notification: PushNotification): SagaGenerator<any, any> {
   console.warn('Push notification:', notification)
   if (notification.payload && notification.payload.userInteraction) {
-    if (!notification.payload.data || !notification.payload.data.convID) {
+    if (!notification.payload.data) {
       console.warn('Push notification missing data', notification)
       return
     }

--- a/shared/constants/push.js
+++ b/shared/constants/push.js
@@ -6,7 +6,12 @@ export const tokenTypeApple: TokenType = 'apple'
 export const tokenTypeAndroidPlay: TokenType = 'androidplay'
 
 export type PushNotification = {
-  message: string,
+  payload?: {
+    userInteraction: boolean,
+    data?: {
+      convID?: string,
+    },
+  },
 }
 
 export const androidSenderID = '9603251415'


### PR DESCRIPTION
:eyeglasses: @keybase/react-hackers 

This now mostly works on iOS. Launching the app from the lock screen on iOS seems to crash the app -- not sure why yet. Having trouble getting `react-native-push-notification` to work on Android, so ticketing that separately.