### PR TITLE
Fix chat snippet text height on Android

### DIFF
--- a/shared/chat/conversations-list/index.native.js
+++ b/shared/chat/conversations-list/index.native.js
@@ -91,7 +91,7 @@ const BottomLine = ({participantNeedToRekey, youNeedToRekey, isMuted, showBold, 
   } else if (participantNeedToRekey) {
     content = <Text type='BodySmall' backgroundMode='Terminal' style={{color: subColor}}>Waiting for participants to rekey</Text>
   } else if (snippet && !isMuted) {
-    content = <Markdown preview={true} style={{...boldOverride, color: subColor, fontSize: 11, lineHeight: 15, minHeight: 15}}>{snippet}</Markdown>
+    content = <Markdown preview={true} style={{...boldOverride, color: subColor, fontSize: 11, lineHeight: 20, minHeight: 20}}>{snippet}</Markdown>
   } else {
     return null
   }

--- a/shared/chat/conversations-list/index.native.js
+++ b/shared/chat/conversations-list/index.native.js
@@ -91,7 +91,7 @@ const BottomLine = ({participantNeedToRekey, youNeedToRekey, isMuted, showBold, 
   } else if (participantNeedToRekey) {
     content = <Text type='BodySmall' backgroundMode='Terminal' style={{color: subColor}}>Waiting for participants to rekey</Text>
   } else if (snippet && !isMuted) {
-    content = <Markdown preview={true} style={{...boldOverride, color: subColor, fontSize: 11, lineHeight: 20}}>{snippet}</Markdown>
+    content = <Markdown preview={true} style={{...boldOverride, color: subColor, fontSize: 11, lineHeight: 20, minHeight: 20}}>{snippet}</Markdown>
   } else {
     return null
   }

--- a/shared/chat/conversations-list/index.native.js
+++ b/shared/chat/conversations-list/index.native.js
@@ -91,7 +91,7 @@ const BottomLine = ({participantNeedToRekey, youNeedToRekey, isMuted, showBold, 
   } else if (participantNeedToRekey) {
     content = <Text type='BodySmall' backgroundMode='Terminal' style={{color: subColor}}>Waiting for participants to rekey</Text>
   } else if (snippet && !isMuted) {
-    content = <Markdown preview={true} style={{...boldOverride, color: subColor, fontSize: 11, lineHeight: 20, minHeight: 20}}>{snippet}</Markdown>
+    content = <Markdown preview={true} style={{...boldOverride, color: subColor, fontSize: 11, lineHeight: 20}}>{snippet}</Markdown>
   } else {
     return null
   }


### PR DESCRIPTION
@keybase/react-hackers 

Not sure why this was needed, but it seems to do the right thing and work fine.  Let me know if you think I should spend more time figuring this out vs. just taking this change.

Before this PR:

![device-2017-03-07-122638](https://cloud.githubusercontent.com/assets/21217/23669666/ececaca6-0332-11e7-802f-ae68b930d7cc.png)

After:

![device-2017-03-07-122441](https://cloud.githubusercontent.com/assets/21217/23669668/f0db4a16-0332-11e7-8d6f-d98521696df6.png)

