### PR TITLE
SimpleFS: Windows globbing

### DIFF
--- a/go/client/cmd_simplefs.go
+++ b/go/client/cmd_simplefs.go
@@ -20,16 +20,6 @@ import (
 
 var TargetFileExistsError = errors.New("target file exists")
 
-// so the test can implement a mock
-type SimpleFSInterface interface {
-	SimpleFSStat(ctx context.Context, path keybase1.Path) (keybase1.Dirent, error)
-	SimpleFSMakeOpid(ctx context.Context) (keybase1.OpID, error)
-	SimpleFSClose(ctx context.Context, arg keybase1.OpID) error
-	SimpleFSWait(ctx context.Context, arg keybase1.OpID) error
-	SimpleFSList(ctx context.Context, arg keybase1.SimpleFSListArg) error
-	SimpleFSReadList(ctx context.Context, arg keybase1.OpID) (keybase1.SimpleFSListResult, error)
-}
-
 // NewCmdSimpleFS creates the device command, which is just a holder
 // for subcommands.
 func NewCmdSimpleFS(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -106,7 +96,7 @@ func pathToString(path keybase1.Path) string {
 }
 
 // Cheeck whether the given path is a directory and return its string
-func checkPathIsDir(ctx context.Context, cli SimpleFSInterface, path keybase1.Path) (bool, string, error) {
+func checkPathIsDir(ctx context.Context, cli keybase1.SimpleFSInterface, path keybase1.Path) (bool, string, error) {
 	var isDir bool
 	var pathString string
 	var err error
@@ -145,7 +135,7 @@ func joinSimpleFSPaths(destType keybase1.PathType, destPathString, srcPathString
 	return keybase1.NewPathWithLocal(newDestString)
 }
 
-func checkElementExists(ctx context.Context, cli SimpleFSInterface, dest keybase1.Path) error {
+func checkElementExists(ctx context.Context, cli keybase1.SimpleFSInterface, dest keybase1.Path) error {
 	destType, _ := dest.PathType()
 	var err error
 
@@ -170,7 +160,7 @@ func checkElementExists(ctx context.Context, cli SimpleFSInterface, dest keybase
 func makeDestPath(
 	g *libkb.GlobalContext,
 	ctx context.Context,
-	cli SimpleFSInterface,
+	cli keybase1.SimpleFSInterface,
 	src keybase1.Path,
 	dest keybase1.Path,
 	isDestPath bool,

--- a/go/client/cmd_simplefs_copy.go
+++ b/go/client/cmd_simplefs_copy.go
@@ -54,10 +54,15 @@ func (c *CmdSimpleFSCopy) Run() error {
 
 	c.G().Log.Debug("SimpleFSCopy (recursive: %v) to: %s", c.recurse, pathToString(c.dest))
 
+	destPaths, err := doSimpleFSPlatformGlob(c.G(), ctx, c.src)
+	if err != nil {
+		return err
+	}
+
 	// Eat the error because it's ok here if the dest doesn't exist
 	isDestDir, destPathString, _ := checkPathIsDir(ctx, cli, c.dest)
 
-	for _, src := range c.src {
+	for _, src := range destPaths {
 		var dest keybase1.Path
 		dest, err = makeDestPath(c.G(), ctx, cli, src, c.dest, isDestDir, destPathString)
 		c.G().Log.Debug("SimpleFSCopy %s -> %s, %v", pathToString(src), pathToString(dest), isDestDir)

--- a/go/client/cmd_simplefs_copy.go
+++ b/go/client/cmd_simplefs_copy.go
@@ -54,7 +54,7 @@ func (c *CmdSimpleFSCopy) Run() error {
 
 	c.G().Log.Debug("SimpleFSCopy (recursive: %v) to: %s", c.recurse, pathToString(c.dest))
 
-	destPaths, err := doSimpleFSPlatformGlob(c.G(), ctx, c.src)
+	destPaths, err := doSimpleFSPlatformGlob(c.G(), ctx, cli, c.src)
 	if err != nil {
 		return err
 	}

--- a/go/client/cmd_simplefs_list.go
+++ b/go/client/cmd_simplefs_list.go
@@ -95,7 +95,6 @@ func (c *CmdSimpleFSList) Run() error {
 
 	ctx := context.TODO()
 
-	// TODO: listing an individual file does not work yet
 	paths, err := doSimpleFSPlatformGlob(c.G(), ctx, cli, c.paths)
 	if err != nil {
 		return err

--- a/go/client/cmd_simplefs_list.go
+++ b/go/client/cmd_simplefs_list.go
@@ -101,9 +101,9 @@ func (c *CmdSimpleFSList) Run() error {
 	}
 
 	for _, path := range paths {
-		if isTLFRequest, err := c.HandleTopLevelKeybaseList(path); isTLFRequest == true {
-			return err
-		}
+		//		if isTLFRequest, err := c.HandleTopLevelKeybaseList(path); isTLFRequest == true {
+		//			return err
+		//		}
 
 		c.G().Log.Debug("SimpleFSList %s", pathToString(path))
 

--- a/go/client/cmd_simplefs_list.go
+++ b/go/client/cmd_simplefs_list.go
@@ -88,10 +88,6 @@ func (c *CmdSimpleFSList) HandleTopLevelKeybaseList() (bool, error) {
 // Run runs the command in client/server mode.
 func (c *CmdSimpleFSList) Run() error {
 
-	if isTLFRequest, err := c.HandleTopLevelKeybaseList(); isTLFRequest == true {
-		return err
-	}
-
 	cli, err := GetSimpleFSClient(c.G())
 	if err != nil {
 		return err
@@ -99,7 +95,18 @@ func (c *CmdSimpleFSList) Run() error {
 
 	ctx := context.TODO()
 
-	c.G().Log.Debug("SimpleFSList %s", pathToString(c.path))
+	// TODO: listing an individual file does not work yet
+	paths, err := doSimpleFSPlatformGlob(c.G(), ctx, c.paths)
+	if err != nil {
+		return err
+	}
+
+	for _, path := range paths {
+		if isTLFRequest, err := c.HandleTopLevelKeybaseList(path); isTLFRequest == true {
+			return err
+		}
+
+		c.G().Log.Debug("SimpleFSList %s", pathToString(path))
 
 	opid, err := cli.SimpleFSMakeOpid(ctx)
 	if err != nil {

--- a/go/client/cmd_simplefs_list.go
+++ b/go/client/cmd_simplefs_list.go
@@ -4,7 +4,7 @@
 package client
 
 import (
-	"fmt"
+	"errors"
 	"path/filepath"
 	"strings"
 
@@ -19,7 +19,7 @@ import (
 // CmdSimpleFSList is the 'fs ls' command.
 type CmdSimpleFSList struct {
 	libkb.Contextified
-	path    keybase1.Path
+	paths   []keybase1.Path
 	recurse bool
 }
 
@@ -43,18 +43,18 @@ func NewCmdSimpleFSList(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.
 
 // HandleTopLevelKeybaseList - See if this is either /keybase/public or /keybase/private,
 // and request favorites accordingly.
-func (c *CmdSimpleFSList) HandleTopLevelKeybaseList() (bool, error) {
+func (c *CmdSimpleFSList) HandleTopLevelKeybaseList(path keybase1.Path) (bool, error) {
 	private := false
-	pathType, err := c.path.PathType()
+	pathType, err := path.PathType()
 	if err != nil {
 		return false, err
 	}
 	if pathType != keybase1.PathType_KBFS {
 		return false, nil
 	}
-	acc := filepath.Clean(strings.ToLower(c.path.Kbfs()))
+	acc := filepath.Clean(strings.ToLower(path.Kbfs()))
 	acc = filepath.ToSlash(acc)
-	c.G().Log.Debug("fs ls HandleTopLevelKeybaseList: %s -> %s", c.path.Kbfs(), acc)
+	c.G().Log.Debug("fs ls HandleTopLevelKeybaseList: %s -> %s", path.Kbfs(), acc)
 	if acc == "/private" {
 		private = true
 	} else if acc != "/public" {
@@ -108,39 +108,39 @@ func (c *CmdSimpleFSList) Run() error {
 
 		c.G().Log.Debug("SimpleFSList %s", pathToString(path))
 
-	opid, err := cli.SimpleFSMakeOpid(ctx)
-	if err != nil {
-		return err
-	}
-	defer cli.SimpleFSClose(ctx, opid)
-	if c.recurse {
-		err = cli.SimpleFSListRecursive(ctx, keybase1.SimpleFSListRecursiveArg{
-			OpID: opid,
-			Path: c.path,
-		})
-	} else {
-		err = cli.SimpleFSList(ctx, keybase1.SimpleFSListArg{
-			OpID: opid,
-			Path: c.path,
-		})
-	}
-	if err != nil {
-		return err
-	}
-
-	err = cli.SimpleFSWait(ctx, opid)
-	if err != nil {
-		return err
-	}
-
-	for {
-		listResult, err := cli.SimpleFSReadList(ctx, opid)
+		opid, err := cli.SimpleFSMakeOpid(ctx)
 		if err != nil {
-			break
+			return err
 		}
-		c.output(listResult)
-	}
+		defer cli.SimpleFSClose(ctx, opid)
+		if c.recurse {
+			err = cli.SimpleFSListRecursive(ctx, keybase1.SimpleFSListRecursiveArg{
+				OpID: opid,
+				Path: path,
+			})
+		} else {
+			err = cli.SimpleFSList(ctx, keybase1.SimpleFSListArg{
+				OpID: opid,
+				Path: path,
+			})
+		}
+		if err != nil {
+			return err
+		}
 
+		err = cli.SimpleFSWait(ctx, opid)
+		if err != nil {
+			return err
+		}
+
+		for {
+			listResult, err := cli.SimpleFSReadList(ctx, opid)
+			if err != nil {
+				break
+			}
+			c.output(listResult)
+		}
+	}
 	return err
 }
 
@@ -164,10 +164,20 @@ func (c *CmdSimpleFSList) ParseArgv(ctx *cli.Context) error {
 
 	c.recurse = ctx.Bool("recurse")
 
-	if nargs == 1 {
-		c.path = makeSimpleFSPath(c.G(), ctx.Args()[0])
-	} else {
-		err = fmt.Errorf("ls requires a path argument")
+	if nargs < 1 {
+		return errors.New("ls requires at least one KBFS path argument")
+	}
+
+	for _, src := range ctx.Args() {
+		argPath := makeSimpleFSPath(c.G(), src)
+		pathType, err := argPath.PathType()
+		if err != nil {
+			return err
+		}
+		if pathType != keybase1.PathType_KBFS {
+			return errors.New("ls requires KBFS path arguments")
+		}
+		c.paths = append(c.paths, argPath)
 	}
 
 	return err

--- a/go/client/cmd_simplefs_list.go
+++ b/go/client/cmd_simplefs_list.go
@@ -96,7 +96,7 @@ func (c *CmdSimpleFSList) Run() error {
 	ctx := context.TODO()
 
 	// TODO: listing an individual file does not work yet
-	paths, err := doSimpleFSPlatformGlob(c.G(), ctx, c.paths)
+	paths, err := doSimpleFSPlatformGlob(c.G(), ctx, cli, c.paths)
 	if err != nil {
 		return err
 	}

--- a/go/client/cmd_simplefs_move.go
+++ b/go/client/cmd_simplefs_move.go
@@ -52,7 +52,7 @@ func (c *CmdSimpleFSMove) Run() error {
 		return err
 	}
 
-	destPaths, err := doSimpleFSPlatformGlob(c.G(), ctx, c.src)
+	destPaths, err := doSimpleFSPlatformGlob(c.G(), ctx, cli, c.src)
 	if err != nil {
 		return err
 	}

--- a/go/client/cmd_simplefs_move.go
+++ b/go/client/cmd_simplefs_move.go
@@ -52,7 +52,12 @@ func (c *CmdSimpleFSMove) Run() error {
 		return err
 	}
 
-	for _, src := range c.src {
+	destPaths, err := doSimpleFSPlatformGlob(c.G(), ctx, c.src)
+	if err != nil {
+		return err
+	}
+
+	for _, src := range destPaths {
 		c.G().Log.Debug("SimpleFSMove %s -> %s, %v", pathToString(src), destPathString, isDestDir)
 
 		dest, err := makeDestPath(c.G(), ctx, cli, src, c.dest, isDestDir, destPathString)

--- a/go/client/cmd_simplefs_remove.go
+++ b/go/client/cmd_simplefs_remove.go
@@ -41,12 +41,18 @@ func (c *CmdSimpleFSRemove) Run() error {
 
 	ctx := context.TODO()
 
-	for _, path := range c.paths {
+	paths, err := doSimpleFSPlatformGlob(c.G(), ctx, c.paths)
+	if err != nil {
+		return err
+	}
+
+	for _, path := range paths {
 		opid, err := cli.SimpleFSMakeOpid(ctx)
 		if err != nil {
 			return err
 		}
 		defer cli.SimpleFSClose(ctx, opid)
+		c.G().Log.Debug("SimpleFSRemove %s", path.Kbfs())
 		err = cli.SimpleFSRemove(ctx, keybase1.SimpleFSRemoveArg{
 			OpID: opid,
 			Path: path,
@@ -75,7 +81,6 @@ func (c *CmdSimpleFSRemove) ParseArgv(ctx *cli.Context) error {
 		}
 		c.paths = append(c.paths, argPath)
 	}
-
 	return err
 }
 

--- a/go/client/cmd_simplefs_remove.go
+++ b/go/client/cmd_simplefs_remove.go
@@ -41,7 +41,7 @@ func (c *CmdSimpleFSRemove) Run() error {
 
 	ctx := context.TODO()
 
-	paths, err := doSimpleFSPlatformGlob(c.G(), ctx, c.paths)
+	paths, err := doSimpleFSPlatformGlob(c.G(), ctx, cli, c.paths)
 	if err != nil {
 		return err
 	}

--- a/go/client/simplefs_nix.go
+++ b/go/client/simplefs_nix.go
@@ -11,6 +11,6 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
-func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx *cli.Context, cli keybase1.SimpleFSInterface, paths []keybase1.path) ([]keybase1.Path, error) {
+func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx *cli.Context, cli SimpleFSInterface, paths []keybase1.path) ([]keybase1.Path, error) {
 	return paths, nil
 }

--- a/go/client/simplefs_nix.go
+++ b/go/client/simplefs_nix.go
@@ -7,10 +7,11 @@ package client
 
 import (
 	"context"
+
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
-func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx context.Context, cli SimpleFSInterface, paths []keybase1.Path) ([]keybase1.Path, error) {
+func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx context.Context, cli keybase1.SimpleFSInterface, paths []keybase1.Path) ([]keybase1.Path, error) {
 	return paths, nil
 }

--- a/go/client/simplefs_nix.go
+++ b/go/client/simplefs_nix.go
@@ -11,6 +11,6 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
-func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx *cli.Context, paths []keybase1.path) ([]keybase1.Path, error) {
+func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx *cli.Context, cli keybase1.SimpleFSInterface, paths []keybase1.path) ([]keybase1.Path, error) {
 	return paths, nil
 }

--- a/go/client/simplefs_nix.go
+++ b/go/client/simplefs_nix.go
@@ -1,0 +1,16 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
+
+package client
+
+import (
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx *cli.Context, paths []keybase1.path) ([]keybase1.Path, error) {
+	return paths, nil
+}

--- a/go/client/simplefs_nix.go
+++ b/go/client/simplefs_nix.go
@@ -6,11 +6,11 @@
 package client
 
 import (
-	"github.com/keybase/cli"
+	"context"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
-func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx *cli.Context, cli SimpleFSInterface, paths []keybase1.path) ([]keybase1.Path, error) {
+func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx context.Context, cli SimpleFSInterface, paths []keybase1.Path) ([]keybase1.Path, error) {
 	return paths, nil
 }

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package client
 
 import (

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -175,7 +175,7 @@ func TestSimpleFSPathRemote(t *testing.T) {
 	pathType, err = testPath.PathType()
 	require.NoError(tc.T, err, "bad path type")
 	assert.Equal(tc.T, keybase1.PathType_KBFS, pathType, "Expected remote path, got local")
-	assert.Equal(tc.T, "/private/", testPath.Kbfs())
+	assert.Equal(tc.T, "/private", testPath.Kbfs())
 
 }
 
@@ -448,15 +448,14 @@ func TestSimpleFSLocalExists(t *testing.T) {
 	assert.Equal(tc.T, keybase1.PathType_LOCAL, pathType, "Expected local path, got remote")
 
 	// check directory
-	err = checkElementExists(context.TODO(), SimpleFSTestStat{}, testPath)
+	err = checkElementExists(context.TODO(), SimpleFSMock{}, testPath)
 	require.Error(tc.T, err, "Should get an element exists error")
 
 	// check file
 	testPath = makeSimpleFSPath(tc.G, tempFile)
-	err = checkElementExists(context.TODO(), SimpleFSTestStat{}, testPath)
+	err = checkElementExists(context.TODO(), SimpleFSMock{}, testPath)
 	require.Error(tc.T, err, "Should get an element exists error")
 }
-
 
 func TestSimpleFSPlatformGlob(t *testing.T) {
 	if runtime.GOOS != "windows" {

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -231,7 +231,7 @@ func TestSimpleFSLocalSrcFile(t *testing.T) {
 	// Destination file given
 	destPath, err = makeDestPath(tc.G,
 		context.TODO(),
-		SimpleFSTestStat{},
+		SimpleFSMock{},
 		path1,
 		destPath,
 		true,
@@ -288,7 +288,7 @@ func TestSimpleFSRemoteSrcFile(t *testing.T) {
 	// Dest file included in path
 	destPath, err = makeDestPath(tc.G,
 		context.TODO(),
-		SimpleFSTestStat{remoteExists: true},
+		SimpleFSMock{remoteExists: true},
 		srcPath,
 		destPath,
 		true,

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -4,10 +4,12 @@
 package client
 
 import (
+	"crypto/rand"
 	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
@@ -16,6 +18,134 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
+
+type SimpleFSMock struct {
+	ListResult   *keybase1.SimpleFSListResult
+	remoteExists bool // for Stat
+	localExists  bool // for Stat
+}
+
+// SimpleFSList - Begin list of items in directory at path
+// Retrieve results with readList()
+// Can be a single file to get flags/status
+func (s SimpleFSMock) SimpleFSList(ctx context.Context, arg keybase1.SimpleFSListArg) error {
+	return nil
+}
+
+// SimpleFSListRecursive - Begin recursive list of items in directory at path
+func (s SimpleFSMock) SimpleFSListRecursive(ctx context.Context, arg keybase1.SimpleFSListRecursiveArg) error {
+	return nil
+}
+
+// SimpleFSReadList - Get list of Paths in progress. Can indicate status of pending
+// to get more entries.
+func (s SimpleFSMock) SimpleFSReadList(ctx context.Context, arg keybase1.OpID) (keybase1.SimpleFSListResult, error) {
+	if len(s.ListResult.Entries) > 0 {
+		retval := *s.ListResult
+		s.ListResult.Entries = nil
+		return retval, nil
+	}
+	return keybase1.SimpleFSListResult{}, errors.New("no more items to list")
+}
+
+// SimpleFSCopy - Begin copy of file or directory
+func (s SimpleFSMock) SimpleFSCopy(ctx context.Context, arg keybase1.SimpleFSCopyArg) error {
+	return nil
+}
+
+// SimpleFSCopyRecursive - Begin recursive copy of directory
+func (s SimpleFSMock) SimpleFSCopyRecursive(ctx context.Context, arg keybase1.SimpleFSCopyRecursiveArg) error {
+	return nil
+}
+
+// SimpleFSMove - Begin move of file or directory, from/to KBFS only
+func (s SimpleFSMock) SimpleFSMove(ctx context.Context, arg keybase1.SimpleFSMoveArg) error {
+	return nil
+}
+
+// SimpleFSRename - Rename file or directory, KBFS side only
+func (s SimpleFSMock) SimpleFSRename(ctx context.Context, arg keybase1.SimpleFSRenameArg) error {
+	return nil
+}
+
+// SimpleFSOpen - Create/open a file and leave it open
+// or create a directory
+// Files must be closed afterwards.
+func (s SimpleFSMock) SimpleFSOpen(ctx context.Context, arg keybase1.SimpleFSOpenArg) error {
+	return nil
+}
+
+// SimpleFSSetStat - Set/clear file bits - only executable for now
+func (s SimpleFSMock) SimpleFSSetStat(ctx context.Context, arg keybase1.SimpleFSSetStatArg) error {
+	return nil
+}
+
+// SimpleFSRead - Read (possibly partial) contents of open file,
+// up to the amount specified by size.
+// Repeat until zero bytes are returned or error.
+// If size is zero, read an arbitrary amount.
+func (s SimpleFSMock) SimpleFSRead(ctx context.Context, arg keybase1.SimpleFSReadArg) (keybase1.FileContent, error) {
+	return keybase1.FileContent{}, nil
+}
+
+// SimpleFSWrite - Append content to opened file.
+// May be repeated until OpID is closed.
+func (s SimpleFSMock) SimpleFSWrite(ctx context.Context, arg keybase1.SimpleFSWriteArg) error {
+	return nil
+}
+
+// SimpleFSRemove - Remove file or directory from filesystem
+func (s SimpleFSMock) SimpleFSRemove(ctx context.Context, arg keybase1.SimpleFSRemoveArg) error {
+	return nil
+}
+
+// SimpleFSStat - Get info about file
+func (s SimpleFSMock) SimpleFSStat(ctx context.Context, path keybase1.Path) (keybase1.Dirent, error) {
+	pathString := pathToString(path)
+	entType := keybase1.DirentType_DIR
+	// For a quick test, assume it's a file if there is a dot and 3 chars at the end
+	if len(filepath.Ext(filepath.Base(pathString))) == 4 {
+		entType = keybase1.DirentType_FILE
+	}
+	pathType, _ := path.PathType()
+	if (pathType == keybase1.PathType_KBFS && s.remoteExists == true) ||
+		(pathType == keybase1.PathType_LOCAL && s.localExists == true) {
+		return keybase1.Dirent{
+			Name:       pathString,
+			DirentType: entType,
+		}, nil
+	}
+	return keybase1.Dirent{}, errors.New(pathString + " does not exist")
+}
+
+// SimpleFSMakeOpid - Convenience helper for generating new random value
+func (s SimpleFSMock) SimpleFSMakeOpid(ctx context.Context) (keybase1.OpID, error) {
+	var opid keybase1.OpID
+	_, err := rand.Read(opid[:])
+
+	return opid, err
+}
+
+// SimpleFSClose - Close OpID, cancels any pending operation.
+// Must be called after list/copy/remove
+func (s SimpleFSMock) SimpleFSClose(ctx context.Context, arg keybase1.OpID) error {
+	return nil
+}
+
+// SimpleFSCheck - Check progress of pending operation
+func (s SimpleFSMock) SimpleFSCheck(ctx context.Context, arg keybase1.OpID) (keybase1.Progress, error) {
+	return 0, nil
+}
+
+// SimpleFSGetOps - Get all the outstanding operations
+func (s SimpleFSMock) SimpleFSGetOps(ctx context.Context) ([]keybase1.OpDescription, error) {
+	return nil, nil
+}
+
+// SimpleFSWait - Blocking wait for the pending operation to finish
+func (s SimpleFSMock) SimpleFSWait(ctx context.Context, arg keybase1.OpID) error {
+	return nil
+}
 
 /*
  file source cases:
@@ -45,7 +175,7 @@ func TestSimpleFSPathRemote(t *testing.T) {
 	pathType, err = testPath.PathType()
 	require.NoError(tc.T, err, "bad path type")
 	assert.Equal(tc.T, keybase1.PathType_KBFS, pathType, "Expected remote path, got local")
-	assert.Equal(tc.T, "/private", testPath.Kbfs())
+	assert.Equal(tc.T, "/private/", testPath.Kbfs())
 
 }
 
@@ -56,30 +186,6 @@ func TestSimpleFSPathLocal(t *testing.T) {
 	pathType, err := testPath.PathType()
 	require.NoError(tc.T, err, "bad path type")
 	assert.Equal(tc.T, keybase1.PathType_LOCAL, pathType, "Expected local path, got remote")
-}
-
-// CmdSimpleFSGetStatus is the 'fs get-status' command.
-type SimpleFSTestStat struct {
-	remoteExists bool
-	localExists  bool
-}
-
-func (s SimpleFSTestStat) SimpleFSStat(_ context.Context, path keybase1.Path) (keybase1.Dirent, error) {
-	pathString := pathToString(path)
-	entType := keybase1.DirentType_DIR
-	// For a quick test, assume it's a file if there is a dot and 3 chars at the end
-	if len(filepath.Ext(filepath.Base(pathString))) == 4 {
-		entType = keybase1.DirentType_FILE
-	}
-	pathType, _ := path.PathType()
-	if (pathType == keybase1.PathType_KBFS && s.remoteExists == true) ||
-		(pathType == keybase1.PathType_LOCAL && s.localExists == true) {
-		return keybase1.Dirent{
-			Name:       pathString,
-			DirentType: entType,
-		}, nil
-	}
-	return keybase1.Dirent{}, errors.New(pathString + " does not exist")
 }
 
 func TestSimpleFSLocalSrcFile(t *testing.T) {
@@ -93,7 +199,7 @@ func TestSimpleFSLocalSrcFile(t *testing.T) {
 	err = ioutil.WriteFile(path1.Local(), []byte("foo"), 0644)
 	require.NoError(t, err)
 
-	isSrcDir, srcPathString, err := checkPathIsDir(context.TODO(), SimpleFSTestStat{localExists: true}, path1)
+	isSrcDir, srcPathString, err := checkPathIsDir(context.TODO(), SimpleFSMock{localExists: true}, path1)
 	require.NoError(tc.T, err, "bad path type")
 	require.False(tc.T, isSrcDir)
 	require.Equal(tc.T, path1.Local(), srcPathString)
@@ -101,14 +207,14 @@ func TestSimpleFSLocalSrcFile(t *testing.T) {
 	// Destination file not given
 	destPath := makeSimpleFSPath(tc.G, "/keybase/public/foobar")
 
-	isDestDir, destPathString, err := checkPathIsDir(context.TODO(), SimpleFSTestStat{remoteExists: true}, destPath)
+	isDestDir, destPathString, err := checkPathIsDir(context.TODO(), SimpleFSMock{remoteExists: true}, destPath)
 	require.NoError(tc.T, err, "bad path type")
 	require.True(tc.T, isDestDir)
 	require.Equal(tc.T, "/public/foobar", destPathString)
 
 	destPath, err = makeDestPath(tc.G,
 		context.TODO(),
-		SimpleFSTestStat{},
+		SimpleFSMock{},
 		path1,
 		destPath,
 		true,
@@ -157,7 +263,7 @@ func TestSimpleFSRemoteSrcFile(t *testing.T) {
 	// Destination file not included in path
 	destPath, err = makeDestPath(tc.G,
 		context.TODO(),
-		SimpleFSTestStat{remoteExists: true},
+		SimpleFSMock{remoteExists: true},
 		srcPath,
 		destPath,
 		true,
@@ -167,7 +273,7 @@ func TestSimpleFSRemoteSrcFile(t *testing.T) {
 
 	require.NoError(tc.T, err, "makeDestPath returns %s", pathToString(destPath))
 
-	isSrcDir, srcPathString, err := checkPathIsDir(context.TODO(), SimpleFSTestStat{remoteExists: true}, srcPath)
+	isSrcDir, srcPathString, err := checkPathIsDir(context.TODO(), SimpleFSMock{remoteExists: true}, srcPath)
 	require.Equal(tc.T, "/public/foobar/test1.txt", srcPath.Kbfs())
 	require.False(tc.T, isSrcDir)
 	require.Equal(tc.T, "/public/foobar/test1.txt", srcPathString)
@@ -206,7 +312,7 @@ func TestSimpleFSLocalSrcDir(t *testing.T) {
 	require.NoError(t, err)
 	path1 := keybase1.NewPathWithLocal(tempdir)
 	require.NoError(t, err)
-	testStatter := SimpleFSTestStat{localExists: true}
+	testStatter := SimpleFSMock{localExists: true}
 
 	isSrcDir, srcPathString, err := checkPathIsDir(context.TODO(), testStatter, path1)
 	require.NoError(tc.T, err, "bad path type")
@@ -231,7 +337,7 @@ func TestSimpleFSLocalSrcDir(t *testing.T) {
 		true,
 		"/public/foobar")
 	assert.Equal(tc.T, filepath.ToSlash(filepath.Join("/public/foobar", filepath.Base(tempdir))), destPath.Kbfs())
-	assert.Equal(tc.T, err, TargetFileExistsError, "Expected that remote target path exists because of SimpleFSTestStat")
+	assert.Equal(tc.T, err, TargetFileExistsError, "Expected that remote target path exists because of SimpleFSMock")
 	//	require.NoError(tc.T, err, "bad path type")
 
 	pathType, err := destPath.PathType()
@@ -247,7 +353,7 @@ func TestSimpleFSLocalSrcDir(t *testing.T) {
 
 	destPath, err = makeDestPath(tc.G,
 		context.TODO(),
-		SimpleFSTestStat{},
+		SimpleFSMock{},
 		path1,
 		destPathInitial,
 		true,
@@ -270,7 +376,7 @@ func TestSimpleFSRemoteSrcDir(t *testing.T) {
 	require.NoError(t, err)
 	destPathInitial := keybase1.NewPathWithLocal(tempdir)
 	require.NoError(t, err)
-	testStatter := SimpleFSTestStat{remoteExists: true}
+	testStatter := SimpleFSMock{remoteExists: true}
 
 	srcPathInitial := makeSimpleFSPath(tc.G, "/keybase/public/foobar")
 
@@ -311,7 +417,7 @@ func TestSimpleFSRemoteSrcDir(t *testing.T) {
 
 	destPath, err = makeDestPath(tc.G,
 		context.TODO(),
-		SimpleFSTestStat{},
+		SimpleFSMock{},
 		srcPathInitial,
 		destPathInitial,
 		true,
@@ -349,4 +455,50 @@ func TestSimpleFSLocalExists(t *testing.T) {
 	testPath = makeSimpleFSPath(tc.G, tempFile)
 	err = checkElementExists(context.TODO(), SimpleFSTestStat{}, testPath)
 	require.Error(tc.T, err, "Should get an element exists error")
+}
+
+
+func TestSimpleFSPlatformGlob(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	tc := libkb.SetupTest(t, "simplefs_path", 0)
+
+	// make a temp local dest directory + files we will clean up later
+	tempdir, err := ioutil.TempDir("", "simpleFstest")
+	defer os.RemoveAll(tempdir)
+	require.NoError(t, err)
+	err = ioutil.WriteFile(filepath.Join(tempdir, "test1.txt"), []byte("foo"), 0644)
+	require.NoError(t, err)
+	err = ioutil.WriteFile(filepath.Join(tempdir, "test2.txt"), []byte("foo"), 0644)
+	require.NoError(t, err)
+	err = ioutil.WriteFile(filepath.Join(tempdir, "test3.txt"), []byte("foo"), 0644)
+	require.NoError(t, err)
+	path1 := keybase1.NewPathWithLocal(filepath.Join(tempdir, "*.txt"))
+
+	paths, err := doSimpleFSPlatformGlob(tc.G, context.TODO(), SimpleFSMock{}, []keybase1.Path{path1})
+	require.NoError(t, err)
+	assert.Equal(tc.T, filepath.Join(tempdir, "test1.txt"), paths[0].Local())
+	assert.Equal(tc.T, filepath.Join(tempdir, "test2.txt"), paths[1].Local())
+	assert.Equal(tc.T, filepath.Join(tempdir, "test3.txt"), paths[2].Local())
+
+	// mock some remote files
+	mockResults := keybase1.SimpleFSListResult{
+		Entries: []keybase1.Dirent{
+			{Name: "test1.txt"},
+			{Name: "test2.txt"},
+			{Name: "test3.txt"},
+		},
+	}
+	clientMock := SimpleFSMock{
+		ListResult: &mockResults,
+	}
+	path1 = keybase1.NewPathWithKbfs("/private/foobar/temp/*.txt")
+
+	paths, err = doSimpleFSPlatformGlob(tc.G, context.TODO(), clientMock, []keybase1.Path{path1})
+	require.NoError(t, err)
+	assert.Equal(tc.T, "/private/foobar/temp/test1.txt", paths[0].Kbfs())
+	assert.Equal(tc.T, "/private/foobar/temp/test2.txt", paths[1].Kbfs())
+	assert.Equal(tc.T, "/private/foobar/temp/test3.txt", paths[2].Kbfs())
+
 }

--- a/go/client/simplefs_windows.go
+++ b/go/client/simplefs_windows.go
@@ -15,7 +15,7 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
-func doSimpleFSRemoteGlob(g *libkb.GlobalContext, ctx context.Context, cli SimpleFSInterface, path keybase1.Path) ([]keybase1.Path, error) {
+func doSimpleFSRemoteGlob(g *libkb.GlobalContext, ctx context.Context, cli keybase1.SimpleFSInterface, path keybase1.Path) ([]keybase1.Path, error) {
 
 	var returnPaths []keybase1.Path
 	directory := filepath.ToSlash(filepath.Dir(path.Kbfs()))
@@ -26,7 +26,7 @@ func doSimpleFSRemoteGlob(g *libkb.GlobalContext, ctx context.Context, cli Simpl
 
 	g.Log.Debug("doSimpleFSRemoteGlob %s", path.Kbfs())
 
-	if strings.ContainsAny(filepath.Base(directory), "?*[]") == true {
+	if strings.ContainsAny(directory, "?*[]") == true {
 		return nil, errors.New("wildcards not supported in parent directories")
 	}
 
@@ -64,7 +64,7 @@ func doSimpleFSRemoteGlob(g *libkb.GlobalContext, ctx context.Context, cli Simpl
 	return returnPaths, err
 }
 
-func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx context.Context, cli SimpleFSInterface, paths []keybase1.Path) ([]keybase1.Path, error) {
+func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx context.Context, cli keybase1.SimpleFSInterface, paths []keybase1.Path) ([]keybase1.Path, error) {
 	var returnPaths []keybase1.Path
 	for _, path := range paths {
 		pathType, err := path.PathType()

--- a/go/client/simplefs_windows.go
+++ b/go/client/simplefs_windows.go
@@ -14,7 +14,7 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
-func doSimpleFSRemoteGlob(g *libkb.GlobalContext, ctx context.Context, path keybase1.Path) ([]keybase1.Path, error) {
+func doSimpleFSRemoteGlob(g *libkb.GlobalContext, ctx context.Context, cli SimpleFSInterface, path keybase1.Path) ([]keybase1.Path, error) {
 
 	var returnPaths []keybase1.Path
 	directory := filepath.ToSlash(filepath.Dir(path.Kbfs()))
@@ -23,11 +23,6 @@ func doSimpleFSRemoteGlob(g *libkb.GlobalContext, ctx context.Context, path keyb
 
 	// We know the filename has wildcards at this point.
 	// kbfs list only works on directories, so build a glob from a list result.
-
-	cli, err := GetSimpleFSClient(g)
-	if err != nil {
-		return nil, err
-	}
 
 	g.Log.Debug("doSimpleFSRemoteGlob %s", path.Kbfs())
 
@@ -65,7 +60,7 @@ func doSimpleFSRemoteGlob(g *libkb.GlobalContext, ctx context.Context, path keyb
 	return returnPaths, err
 }
 
-func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx context.Context, paths []keybase1.Path) ([]keybase1.Path, error) {
+func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx context.Context, cli SimpleFSInterface, paths []keybase1.Path) ([]keybase1.Path, error) {
 	var returnPaths []keybase1.Path
 	for _, path := range paths {
 		pathType, err := path.PathType()
@@ -81,7 +76,7 @@ func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx context.Context, paths [
 
 		if pathType == keybase1.PathType_KBFS {
 			// remote glob
-			globbed, err := doSimpleFSRemoteGlob(g, ctx, path)
+			globbed, err := doSimpleFSRemoteGlob(g, ctx, cli, path)
 			if err != nil {
 				return nil, err
 			}

--- a/go/client/simplefs_windows.go
+++ b/go/client/simplefs_windows.go
@@ -19,7 +19,6 @@ func doSimpleFSRemoteGlob(g *libkb.GlobalContext, ctx context.Context, cli Simpl
 	var returnPaths []keybase1.Path
 	directory := filepath.ToSlash(filepath.Dir(path.Kbfs()))
 	base := filepath.Base(path.Kbfs())
-	context.TODO()
 
 	// We know the filename has wildcards at this point.
 	// kbfs list only works on directories, so build a glob from a list result.
@@ -69,7 +68,7 @@ func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx context.Context, cli Sim
 		}
 
 		pathString := pathToString(path)
-		if strings.ContainsAny(filepath.Base(pathString), "?*") == false {
+		if strings.ContainsAny(filepath.Base(pathString), "?*[]") == false {
 			returnPaths = append(returnPaths, path)
 			continue
 		}

--- a/go/client/simplefs_windows.go
+++ b/go/client/simplefs_windows.go
@@ -1,0 +1,101 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build windows
+
+package client
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+func doSimpleFSRemoteGlob(g *libkb.GlobalContext, ctx context.Context, path keybase1.Path) ([]keybase1.Path, error) {
+
+	var returnPaths []keybase1.Path
+	directory := filepath.ToSlash(filepath.Dir(path.Kbfs()))
+	base := filepath.Base(path.Kbfs())
+	context.TODO()
+
+	// We know the filename has wildcards at this point.
+	// kbfs list only works on directories, so build a glob from a list result.
+
+	cli, err := GetSimpleFSClient(g)
+	if err != nil {
+		return nil, err
+	}
+
+	g.Log.Debug("doSimpleFSRemoteGlob %s", path.Kbfs())
+
+	opid, err := cli.SimpleFSMakeOpid(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cli.SimpleFSClose(ctx, opid)
+
+	err = cli.SimpleFSList(ctx, keybase1.SimpleFSListArg{
+		OpID: opid,
+		Path: keybase1.NewPathWithKbfs(directory),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = cli.SimpleFSWait(ctx, opid)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		listResult, err := cli.SimpleFSReadList(ctx, opid)
+		if err != nil {
+			break
+		}
+		for _, entry := range listResult.Entries {
+			match, err := filepath.Match(base, entry.Name)
+			if err == nil && match == true {
+				returnPaths = append(returnPaths, keybase1.NewPathWithKbfs(filepath.ToSlash(filepath.Join(directory, entry.Name))))
+			}
+		}
+	}
+	return returnPaths, err
+}
+
+func doSimpleFSPlatformGlob(g *libkb.GlobalContext, ctx context.Context, paths []keybase1.Path) ([]keybase1.Path, error) {
+	var returnPaths []keybase1.Path
+	for _, path := range paths {
+		pathType, err := path.PathType()
+		if err != nil {
+			return returnPaths, err
+		}
+
+		pathString := pathToString(path)
+		if strings.ContainsAny(filepath.Base(pathString), "?*") == false {
+			returnPaths = append(returnPaths, path)
+			continue
+		}
+
+		if pathType == keybase1.PathType_KBFS {
+			// remote glob
+			globbed, err := doSimpleFSRemoteGlob(g, ctx, path)
+			if err != nil {
+				return nil, err
+			}
+			returnPaths = append(returnPaths, globbed...)
+		} else {
+			// local glob
+			matches, err := filepath.Glob(pathString)
+			if err != nil {
+				return nil, err
+			}
+			for _, match := range matches {
+				returnPaths = append(returnPaths, keybase1.NewPathWithLocal(match))
+			}
+		}
+	}
+	return returnPaths, nil
+}

--- a/go/client/simplefs_windows.go
+++ b/go/client/simplefs_windows.go
@@ -7,6 +7,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 
@@ -24,6 +25,10 @@ func doSimpleFSRemoteGlob(g *libkb.GlobalContext, ctx context.Context, cli Simpl
 	// kbfs list only works on directories, so build a glob from a list result.
 
 	g.Log.Debug("doSimpleFSRemoteGlob %s", path.Kbfs())
+
+	if strings.ContainsAny(filepath.Base(directory), "?*[]") == true {
+		return nil, errors.New("wildcards not supported in parent directories")
+	}
 
 	opid, err := cli.SimpleFSMakeOpid(ctx)
 	if err != nil {


### PR DESCRIPTION
This is windows only for now, but as Max points out, the kbfs globbing should be included on other platforms. That part is TBI.

This introduces a pretty big mock interface for SimpleFS that can be filled out if we want.