### PR TITLE
more error logging for ErrBadPacketSequence

### DIFF
--- a/go/kex2/transport_test.go
+++ b/go/kex2/transport_test.go
@@ -394,7 +394,8 @@ func TestReorder(t *testing.T) {
 		}
 	}
 	buf := make([]byte, 1000)
-	if _, err := c2.Read(buf); err != ErrBadPacketSequence {
+	_, err := c2.Read(buf)
+	if _, ok := err.(ErrBadPacketSequence); !ok {
 		t.Fatalf("expected an ErrBadPacketSequence; got %v", err)
 	}
 }
@@ -417,7 +418,8 @@ func TestDrop(t *testing.T) {
 		}
 	}
 	buf := make([]byte, 1000)
-	if _, err := c2.Read(buf); err != ErrBadPacketSequence {
+	_, err := c2.Read(buf)
+	if _, ok := err.(ErrBadPacketSequence); !ok {
 		t.Fatalf("expected an ErrBadPacketSequence; got %v", err)
 	}
 }


### PR DESCRIPTION
- the keybase server is supposed to send kex2 messages in the right order, but @cjb found a case yesterday where one of these errors was thrown.
- introduce more error logging in case this happens again