### PR TITLE
stop doing a bunch of unnecessary work when filtering server inbox CORE-4661

### DIFF
--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -87,6 +87,12 @@ func BackgroundContext(sourceCtx context.Context) context.Context {
 	if ident, breaks, ok := IdentifyMode(sourceCtx); ok {
 		rctx = Context(rctx, ident, breaks, in)
 	}
+
+	// Overwrite trace tag
+	if tr, ok := sourceCtx.Value(chatTraceKey).(string); ok {
+		rctx = context.WithValue(rctx, chatTraceKey, tr)
+	}
+
 	rctx = context.WithValue(rctx, kfKey, CtxKeyFinder(sourceCtx))
 	rctx = context.WithValue(rctx, inKey, in)
 

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -72,8 +72,8 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 
 	// Resolve supersedes
 	if q == nil || !q.DisableResolveSupersedes {
-		transform := newSupersedesTransform(s.G())
-		if thread.Messages, err = transform.run(ctx, convID, uid, thread.Messages, finalizeInfo); err != nil {
+		transform := newBasicSupersedesTransform(s.G())
+		if thread.Messages, err = transform.Run(ctx, convID, uid, thread.Messages, finalizeInfo); err != nil {
 			return err
 		}
 	}
@@ -93,8 +93,8 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 }
 
 func (s *baseConversationSource) TransformSupersedes(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageUnboxed, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error) {
-	transform := newSupersedesTransform(s.G())
-	return transform.run(ctx, convID, uid, msgs, finalizeInfo)
+	transform := newBasicSupersedesTransform(s.G())
+	return transform.Run(ctx, convID, uid, msgs, finalizeInfo)
 }
 
 type RemoteConversationSource struct {

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -93,6 +93,7 @@ func (b *NonblockingLocalizer) SetOffline() {
 }
 
 func (b *NonblockingLocalizer) filterInboxRes(ctx context.Context, inbox chat1.Inbox, uid gregor1.UID) chat1.Inbox {
+	defer b.Trace(ctx, func() error { return nil }, "filterInboxRes")()
 
 	localizer := newLocalizerPipeline(b.G(), b.pipeline.getTlfInterface)
 	localizer.offline = true // Set this guy offline, so we are guaranteed to not do anything slow
@@ -137,7 +138,8 @@ func (b *NonblockingLocalizer) filterInboxRes(ctx context.Context, inbox chat1.I
 	}
 }
 
-func (b *NonblockingLocalizer) Localize(ctx context.Context, uid gregor1.UID, inbox chat1.Inbox) ([]chat1.ConversationLocal, error) {
+func (b *NonblockingLocalizer) Localize(ctx context.Context, uid gregor1.UID, inbox chat1.Inbox) (res []chat1.ConversationLocal, err error) {
+	defer b.Trace(ctx, func() error { return err }, "Localize")()
 
 	// Run some easy filters for empty messages and known errors to optimize UI drawing behavior
 	filteredInbox := b.filterInboxRes(ctx, inbox, uid)

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -782,7 +782,7 @@ func (s *localizerPipeline) getMessagesOffline(ctx context.Context, convID chat1
 		return nil, chat1.ConversationErrorType_LOCALMAXMESSAGENOTFOUND, err
 	}
 
-	// Make sure we get them all
+	// Make sure we legit msgs
 	var foundMsgs []chat1.MessageUnboxed
 	for _, msg := range res {
 		if msg != nil {
@@ -790,7 +790,7 @@ func (s *localizerPipeline) getMessagesOffline(ctx context.Context, convID chat1
 		}
 	}
 
-	if len(foundMsgs) != len(msgs) {
+	if len(foundMsgs) == 0 {
 		return nil, chat1.ConversationErrorType_LOCALMAXMESSAGENOTFOUND,
 			errors.New("missing messages locally")
 	}

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -320,10 +320,11 @@ func (d DebugLabeler) Debug(ctx context.Context, msg string, args ...interface{}
 
 func (d DebugLabeler) Trace(ctx context.Context, f func() error, msg string) func() {
 	if d.showLog() {
+		start := time.Now()
 		d.G().Log.CDebugf(ctx, "++Chat: + %s: %s", d.label, msg)
 		return func() {
-			d.G().Log.CDebugf(ctx, "++Chat: - %s: %s -> %s", d.label, msg,
-				libkb.ErrToOk(f()))
+			d.G().Log.CDebugf(ctx, "++Chat: - %s: %s -> %s (%v)", d.label, msg,
+				libkb.ErrToOk(f()), time.Since(start))
 		}
 	}
 	return func() {}

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -100,6 +100,8 @@ func (h *chatLocalHandler) GetInboxNonblockLocal(ctx context.Context, arg chat1.
 		if lres.InboxRes == nil {
 			return res, fmt.Errorf("invalid conversation localize callback received")
 		}
+		h.Debug(ctx, "GetInboxNonblockLocal: unverified inbox sent: %d convs",
+			len(lres.InboxRes.ConvsUnverified))
 		chatUI.ChatInboxUnverified(ctx, chat1.ChatInboxUnverifiedArg{
 			SessionID: arg.SessionID,
 			Inbox: chat1.GetInboxLocalRes{
@@ -121,12 +123,16 @@ func (h *chatLocalHandler) GetInboxNonblockLocal(ctx context.Context, arg chat1.
 		wg.Add(1)
 		go func(convRes chat.NonblockInboxResult) {
 			if convRes.Err != nil {
+				h.Debug(ctx, "GetInboxNonblockLocal: *** error conv: id: %s err: %s",
+					convRes.ConvID, convRes.Err.Message)
 				chatUI.ChatInboxFailed(ctx, chat1.ChatInboxFailedArg{
 					SessionID: arg.SessionID,
 					ConvID:    convRes.ConvID,
 					Error:     *convRes.Err,
 				})
 			} else if convRes.ConvRes != nil {
+				h.Debug(ctx, "GetInboxNonblockLocal: verified conv: id: %s tlf: %s",
+					convRes.ConvID, convRes.ConvRes.Info.TLFNameExpanded())
 				chatUI.ChatInboxConversation(ctx, chat1.ChatInboxConversationArg{
 					SessionID: arg.SessionID,
 					Conv:      *convRes.ConvRes,


### PR DESCRIPTION
This patch does the following:

1.) Stops running any "slow" operation during the initial filtering of the server inbox view. This includes running `LookupTLF` for SBS convos, running the supersedes xform, and reodering the participants. We essentially treat the localize that happens for filtering as if we are offline.
2.) Improve logging around `GetInboxNonblock` and add timing to chat trace logging.