### PR TITLE
Fix rekey notifications, handle CI crash with nil gregor client

### DIFF
--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1324,3 +1324,15 @@ func (t *timeoutClient) Notify(ctx context.Context, method string, arg interface
 	}
 	return err
 }
+
+type errorClient struct{}
+
+var _ rpc.GenericClient = errorClient{}
+
+func (e errorClient) Call(ctx context.Context, method string, arg interface{}, res interface{}) error {
+	return fmt.Errorf("errorClient: Call %s", method)
+}
+
+func (e errorClient) Notify(ctx context.Context, method string, arg interface{}) error {
+	return fmt.Errorf("errorClient: Notify %s", method)
+}

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -4,9 +4,12 @@
 package service
 
 import (
+	"path/filepath"
+
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
@@ -25,6 +28,9 @@ func NewKBFSHandler(xp rpc.Transporter, g *libkb.GlobalContext) *KBFSHandler {
 
 func (h *KBFSHandler) FSEvent(_ context.Context, arg keybase1.FSNotification) error {
 	h.G().NotifyRouter.HandleFSActivity(arg)
+
+	h.checkConversationRekey(arg)
+
 	return nil
 }
 
@@ -46,4 +52,68 @@ func (h *KBFSHandler) FSSyncStatus(ctx context.Context, arg keybase1.FSSyncStatu
 func (h *KBFSHandler) FSSyncEvent(ctx context.Context, arg keybase1.FSPathSyncStatus) (err error) {
 	h.G().NotifyRouter.HandleFSSyncEvent(ctx, arg)
 	return nil
+}
+
+// checkConversationRekey looks for rekey finished notifications and tries to
+// find any conversations associated with the rekeyed TLF.  If it finds any,
+// it will send ChatThreadsStale notifcations for them.
+func (h *KBFSHandler) checkConversationRekey(arg keybase1.FSNotification) {
+	if arg.NotificationType != keybase1.FSNotificationType_REKEYING {
+		return
+	}
+	if arg.StatusCode == keybase1.FSStatusCode_FINISH {
+		return
+	}
+
+	uid := h.G().Env.GetUID()
+	if uid.IsNil() {
+		h.G().Log.Debug("received rekey finished notification for %s, but have no UID", arg.Filename)
+		return
+	}
+
+	h.G().Log.Debug("received rekey finished notification for %s, checking for conversations", arg.Filename)
+
+	go h.notifyConversation(uid, arg.Filename, arg.PublicTopLevelFolder)
+}
+
+func (h *KBFSHandler) notifyConversation(uid keybase1.UID, filename string, public bool) {
+	tlf := filepath.Base(filename)
+	convIDs, err := h.conversationIDs(uid, tlf, public)
+	if err != nil {
+		h.G().Log.Debug("error getting conversation IDs for tlf %q: %s", tlf, err)
+		return
+	}
+
+	if len(convIDs) == 0 {
+		h.G().Log.Debug("no conversations for tlf %s (public: %v)", tlf, public)
+		return
+	}
+
+	h.G().Log.Debug("sending ChatThreadsStale notification (conversations: %d)", len(convIDs))
+	h.G().NotifyRouter.HandleChatThreadsStale(context.Background(), uid, convIDs)
+}
+
+func (h *KBFSHandler) conversationIDs(uid keybase1.UID, tlf string, public bool) ([]chat1.ConversationID, error) {
+	vis := chat1.TLFVisibility_PRIVATE
+	if public {
+		vis = chat1.TLFVisibility_PUBLIC
+	}
+
+	toptype := chat1.TopicType_CHAT
+	query := chat1.GetInboxLocalQuery{
+		TlfName:       &tlf,
+		TlfVisibility: &vis,
+		TopicType:     &toptype,
+	}
+
+	ib, _, err := h.G().InboxSource.Read(context.Background(), uid.ToBytes(), nil, true, &query, nil)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]chat1.ConversationID, len(ib.Convs))
+	for i, c := range ib.Convs {
+		ids[i] = c.Info.Id
+	}
+
+	return ids, nil
 }

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -61,7 +61,8 @@ func (h *KBFSHandler) checkConversationRekey(arg keybase1.FSNotification) {
 	if arg.NotificationType != keybase1.FSNotificationType_REKEYING {
 		return
 	}
-	if arg.StatusCode == keybase1.FSStatusCode_FINISH {
+	h.G().Log.Debug("received rekey notification for %s, code: %v", arg.Filename, arg.StatusCode)
+	if arg.StatusCode != keybase1.FSStatusCode_FINISH {
 		return
 	}
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -250,7 +250,7 @@ func (d *Service) RunBackgroundOperations(uir *UIRouter) {
 
 func (d *Service) createMessageDeliverer() {
 	tlf := newTlfHandler(nil, d.G())
-	ri := func() chat1.RemoteInterface { return chat1.RemoteClient{Cli: d.gregor.cli} }
+	ri := d.chatRemoteClient
 	si := func() libkb.SecretUI { return chat.DelivererSecretUI{} }
 	ti := func() keybase1.TlfInterface { return tlf }
 
@@ -267,7 +267,7 @@ func (d *Service) startMessageDeliverer() {
 
 func (d *Service) createChatSources() {
 	tlf := newTlfHandler(nil, d.G())
-	ri := func() chat1.RemoteInterface { return chat1.RemoteClient{Cli: d.gregor.cli} }
+	ri := d.chatRemoteClient
 	si := func() libkb.SecretUI { return chat.DelivererSecretUI{} }
 	ti := func() keybase1.TlfInterface { return tlf }
 
@@ -283,6 +283,14 @@ func (d *Service) createChatSources() {
 	d.G().AddUserChangedHandler(chat.NewIdentifyChangedHandler(d.G(), func() keybase1.TlfInterface {
 		return tlf
 	}))
+}
+
+func (d *Service) chatRemoteClient() chat1.RemoteInterface {
+	if d.gregor.cli == nil {
+		d.G().Log.Debug("service not connected to gregor, using errorClient for chat1.RemoteClient")
+		return chat1.RemoteClient{Cli: errorClient{}}
+	}
+	return chat1.RemoteClient{Cli: d.gregor.cli}
 }
 
 func (d *Service) configureRekey(uir *UIRouter) {

--- a/go/service/rekey_master.go
+++ b/go/service/rekey_master.go
@@ -396,9 +396,6 @@ func (r *rekeyMaster) computeProblems() (nextWait time.Duration, problemsAndDevi
 
 	r.G().Log.Debug("| rekeyMaster#computeProblems: queried API server for rekey info")
 
-	// send notifications if problems changed since last iteration
-	// r.changeNotification(problems)
-
 	if len(problems.Tlfs) == 0 {
 		r.G().Log.Debug("| no problem TLFs found")
 

--- a/go/service/rekey_master.go
+++ b/go/service/rekey_master.go
@@ -397,7 +397,7 @@ func (r *rekeyMaster) computeProblems() (nextWait time.Duration, problemsAndDevi
 	r.G().Log.Debug("| rekeyMaster#computeProblems: queried API server for rekey info")
 
 	// send notifications if problems changed since last iteration
-	r.changeNotification(problems)
+	// r.changeNotification(problems)
 
 	if len(problems.Tlfs) == 0 {
 		r.G().Log.Debug("| no problem TLFs found")

--- a/go/service/rekey_master.go
+++ b/go/service/rekey_master.go
@@ -10,7 +10,6 @@ import (
 
 	gregor "github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/protocol/chat1"
 	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -39,10 +38,6 @@ type rekeyMaster struct {
 	// TLF rekey events. We should only be running if there are (since we want to respect
 	// the 3-minute delay on rekey harassment after a new key is added).
 	gregor *gregorHandler
-
-	// keep track of the previous problem set to see if any rekeys have occurred in
-	// an iteration
-	prevProblems keybase1.ProblemSet
 }
 
 type RekeyInterrupt int
@@ -399,8 +394,6 @@ func (r *rekeyMaster) computeProblems() (nextWait time.Duration, problemsAndDevi
 	if len(problems.Tlfs) == 0 {
 		r.G().Log.Debug("| no problem TLFs found")
 
-		r.prevProblems = keybase1.ProblemSet{}
-
 		nextWait = rekeyTimeoutBackground
 		return nextWait, nil, keybase1.RekeyEvent{EventType: keybase1.RekeyEventType_NO_PROBLEMS}, err
 	}
@@ -433,68 +426,8 @@ func (r *rekeyMaster) computeProblems() (nextWait time.Duration, problemsAndDevi
 
 	r.G().Log.Debug("| rekeyMaster#computeProblems: made problem set devices")
 
-	r.prevProblems = problems
-
 	nextWait = rekeyTimeoutActive
 	return nextWait, &tmp, keybase1.RekeyEvent{EventType: keybase1.RekeyEventType_HARASS}, err
-}
-
-func (r *rekeyMaster) changeNotification(newProblems keybase1.ProblemSet) {
-	newTLFIDs := make(map[keybase1.TLFID]bool)
-	for _, p := range newProblems.Tlfs {
-		newTLFIDs[p.Tlf.Id] = true
-	}
-
-	var cids []chat1.ConversationID
-	for _, p := range r.prevProblems.Tlfs {
-		if newTLFIDs[p.Tlf.Id] {
-			continue
-		}
-
-		// p.Tlf is no longer a problem, add its conversation id to the notification list.
-		ids, err := r.conversationIDs(p.Tlf)
-		if err != nil {
-			r.G().Log.Debug("changeNotification: error getting conversation id: %s", err)
-			continue
-		}
-		r.G().Log.Debug("rekeyMaster: will send notification for convs %v, tlf %s", ids, p.Tlf.Name)
-		cids = append(cids, ids...)
-	}
-
-	if len(cids) > 0 {
-		// notify clients about stale conversation threads
-		r.G().Log.Debug("rekeyMaster: sending ChatThreadsStale notification %v", cids)
-		r.G().NotifyRouter.HandleChatThreadsStale(context.Background(), r.G().Env.GetUID(), cids)
-	}
-
-	// to make sure we don't notify more than once, change prevProblems here
-	r.prevProblems = newProblems
-}
-
-func (r *rekeyMaster) conversationIDs(tlf keybase1.TLF) ([]chat1.ConversationID, error) {
-	uid := r.G().Env.GetUID()
-	if uid.IsNil() {
-		return nil, libkb.LoginRequiredError{}
-	}
-	vis := chat1.TLFVisibility_PUBLIC
-	if tlf.IsPrivate {
-		vis = chat1.TLFVisibility_PRIVATE
-	}
-	toptype := chat1.TopicType_CHAT
-	query := chat1.GetInboxLocalQuery{
-		TlfName:       &tlf.Name,
-		TlfVisibility: &vis,
-		TopicType:     &toptype,
-	}
-	ib, _, err := r.G().InboxSource.Read(context.Background(), uid.ToBytes(), nil, true, &query, nil)
-	if err != nil {
-		return nil, err
-	}
-	ids := make([]chat1.ConversationID, len(ib.Convs))
-	for i, c := range ib.Convs {
-		ids[i] = c.Info.Id
-	}
-	return ids, nil
 }
 
 // currentDeviceSolvesProblemSet returns true if the current device can fix all


### PR DESCRIPTION
Redo for the fix rekey notifications PR https://github.com/keybase/client/pull/6162

The CI crash was a result of a nil gregor client connection.  This checks for that and uses an errorClient in its place.

There is most likely a bigger underlying issue/race condition here with a slow connection to gregor in CI, but this should prevent these notifications from crashing the service when that race condition occurs.