### PR TITLE
Image and non-image attachment popups on mobile

### DIFF
--- a/shared/chat/conversation/attachment-popup/container.js
+++ b/shared/chat/conversation/attachment-popup/container.js
@@ -3,6 +3,7 @@ import {compose, withState, withProps} from 'recompose'
 import RenderAttachmentPopup from './'
 import {connect} from 'react-redux'
 import {navigateUp} from '../../../actions/route-tree'
+import {deleteMessage} from '../../../actions/chat'
 import {downloadFilePath} from '../../../util/file'
 
 import type {RouteProps} from '../../../route-tree/render-route'
@@ -46,10 +47,12 @@ export default compose(
 
       return {
         ...ownProps,
+        you: state.config.username,
         message,
       }
     },
     (dispatch: Dispatch) => ({
+      deleteMessage: message => dispatch(deleteMessage(message)),
       onClose: () => dispatch(navigateUp()),
       onDownloadAttachment: (message: AttachmentMessage) => {
         const messageID = message.messageID
@@ -77,6 +80,10 @@ export default compose(
       return {
         ...stateProps,
         ...dispatchProps,
+        onDeleteMessage: () => {
+          dispatchProps.deleteMessage(message)
+          dispatchProps.onClose()
+        },
         onDownloadAttachment: () => dispatchProps.onDownloadAttachment(message),
         onOpenInFileUI: () => dispatchProps.onOpenInFileUI(message.downloadedPath),
       }

--- a/shared/chat/conversation/attachment-popup/index.native.js
+++ b/shared/chat/conversation/attachment-popup/index.native.js
@@ -1,6 +1,119 @@
 // @flow
+import React from 'react'
+import {Box, Icon, Text, PopupDialog, ProgressIndicator, NativeImage} from '../../../common-adapters/index.native'
+import {MessagePopup} from '../messages/popup.native'
+import {ImageIcon as AttachmentStatusIcon} from '../messages/attachment'
+import {globalColors, globalMargins, globalStyles} from '../../../styles'
+import {formatTimeForPopup} from '../../../util/timestamp'
+
 import type {Props} from './'
 
-const AttachmentPopup = ({message, onClose}: Props) => null  // TODO
+const AttachmentView = ({isZoomed, onToggleZoom, messageState, path}: {isZoomed: boolean, onToggleZoom: () => void, path: ?string}) => {
+  if (path) {
+    return <NativeImage resizeMode='contain' source={{uri: `file://${path}`}} style={{alignItems: 'center', flexGrow: 1, justifyContent: 'center'}} />
+  } else {
+    return (
+      <Box style={styleContentsCenter}>
+        <ProgressIndicator style={{width: 48}} white={true} />
+      </Box>
+    )
+  }
+}
+
+const AttachmentPopup = ({message, detailsPopupShowing, isZoomed, onCloseDetailsPopup, onClose, onDownloadAttachment, onDeleteMessage, onOpenDetailsPopup, onToggleZoom, onOpenInFileUI, you}: Props) => {
+  const {messageState, previewType, title, author, timestamp} = message
+  let statusIcon
+  if (messageState === 'downloading' || messageState === 'downloaded') {
+    statusIcon = <AttachmentStatusIcon
+      style={{position: 'absolute', bottom: -3, right: -3}}
+      type={messageState === 'downloading' ? 'Downloading' : 'Downloaded'}
+    />
+  }
+
+  if (!previewType || previewType === 'Other') {
+    return (
+      <PopupDialog onClose={onClose} fill={true} styleContainer={{
+        ...globalStyles.flexBoxColumn,
+        backgroundColor: globalColors.white,
+        borderRadius: 0,
+        bottom: 0,
+        left: 0,
+        position: 'absolute',
+        right: 0,
+        top: 20,
+      }}>
+        <Text type='Body' onClick={onClose} style={{color: globalColors.blue, marginLeft: globalMargins.small, marginTop: globalMargins.small, borderBottomWidth: 1, borderBottomColor: globalColors.black_40}}>Close</Text>
+        <Box style={{...globalStyles.flexBoxColumn, justifyContent: 'center', alignItems: 'center', flex: 1}}>
+          <Icon type='icon-file-48' />
+          <Text type='BodySemibold' style={{marginTop: globalMargins.large, marginBottom: globalMargins.tiny}}>{title}</Text>
+          <Text type='BodySmall'>Sent by {author}</Text>
+          <Text type='BodySmall'>{formatTimeForPopup(timestamp)}</Text>
+          <Text type='BodySmall' style={{color: globalColors.black, marginTop: globalMargins.large}}>Your device can not preview this file.</Text>
+        </Box>
+        <Box style={styleHeaderFooter}>
+          <Icon type='iconfont-ellipsis' onClick={detailsPopupShowing ? onCloseDetailsPopup : onOpenDetailsPopup} />
+        </Box>
+        {statusIcon}
+        {// $FlowIssue
+          detailsPopupShowing && <MessagePopup
+            you={you}
+            message={message}
+            onDeleteMessage={onDeleteMessage}
+            onShowEditor={() => {}}
+            onHidden={onCloseDetailsPopup}
+            style={{position: 'absolute', right: globalMargins.xtiny, bottom: 28}}
+          />}
+      </PopupDialog>
+    )
+  }
+
+  return (
+    <PopupDialog onClose={onClose} fill={true} styleContainer={{
+      backgroundColor: globalColors.black,
+      borderRadius: 0,
+      bottom: 0,
+      left: 0,
+      position: 'absolute',
+      right: 0,
+      top: 20,
+    }}>
+      <Text type='Body' onClick={onClose} style={{color: globalColors.white, marginLeft: globalMargins.small, marginTop: globalMargins.small}}>Close</Text>
+      <AttachmentView isZoomed={isZoomed} onToggleZoom={onToggleZoom} path={message.hdPreviewPath} />
+      <Box style={styleHeaderFooter}>
+        <Icon type='iconfont-ellipsis' style={{color: globalColors.white}} onClick={detailsPopupShowing ? onCloseDetailsPopup : onOpenDetailsPopup} />
+      </Box>
+      {statusIcon}
+      {// $FlowIssue
+        detailsPopupShowing && <MessagePopup
+          you={you}
+          message={message}
+          onDeleteMessage={onDeleteMessage}
+          onShowEditor={() => {}}
+          onHidden={onCloseDetailsPopup}
+          style={{position: 'absolute', right: globalMargins.xtiny, bottom: 28}}
+        />}
+    </PopupDialog>
+  )
+}
+
+const styleHeaderFooter = {
+  ...globalStyles.flexBoxRow,
+  alignItems: 'center',
+  flexShrink: 0,
+  height: 32,
+  marginLeft: globalMargins.small,
+  marginBottom: globalMargins.small,
+}
+
+const styleContentsFit = {
+  ...globalStyles.flexBoxRow,
+  flex: 1,
+}
+
+const styleContentsCenter = {
+  ...styleContentsFit,
+  alignItems: 'center',
+  justifyContent: 'center',
+}
 
 export default AttachmentPopup

--- a/shared/chat/conversation/messages/attachment.js
+++ b/shared/chat/conversation/messages/attachment.js
@@ -52,7 +52,11 @@ function PreviewImage ({message: {attachmentDurationMs, previewDurationMs, previ
 
     return (
       <ClickableBox style={style} onClick={onOpenInPopup}>
-        <Box>
+        <Box style={{
+          ...globalStyles.flexBoxRow,
+          position: 'relative',
+          alignItems: 'flex-end',
+        }}>
           <Box style={{...imgStyle, backgroundColor: globalColors.black_05}}>
             {previewPath && <ImageRender style={imgStyle} src={previewPath} />}
           </Box>

--- a/shared/chat/conversation/messages/attachment.js
+++ b/shared/chat/conversation/messages/attachment.js
@@ -3,7 +3,7 @@ import * as Constants from '../../../constants/chat'
 import MessageWrapper from './wrapper'
 import moment from 'moment'
 import React, {PureComponent} from 'react'
-import {Box, Icon, ProgressIndicator, Text} from '../../../common-adapters'
+import {Box, Icon, ProgressIndicator, Text, ClickableBox} from '../../../common-adapters'
 import {isMobile, fileUIName} from '../../../constants/platform'
 import {globalStyles, globalMargins, globalColors} from '../../../styles'
 import {ImageRender} from './attachment.render'
@@ -18,16 +18,18 @@ function _showPreviewProgress (messageState, progress) {
   return !!progress && (messageState === 'downloading-preview')
 }
 
-function AttachmentTitle ({messageState, title}: {messageState: Constants.AttachmentMessageState, title: ?string}) {
-  let style = {}
+function AttachmentTitle ({messageState, title, onOpenInPopup}: {messageState: Constants.AttachmentMessageState, title: ?string, onOpenInPopup: ?() => void}) {
+  let style = {
+    backgroundColor: globalColors.white,
+  }
   switch (messageState) {
     case 'uploading':
     case 'pending':
     case 'failed':
-      style = {color: globalColors.black_40}
+      style = {backgroundColor: globalColors.white, color: globalColors.black_40}
       break
   }
-  return <Text type='BodySemibold' style={style}>{title}</Text>
+  return <Text type='BodySemibold' style={style} onClick={onOpenInPopup}>{title}</Text>
 }
 
 function PreviewImage ({message: {attachmentDurationMs, previewDurationMs, previewPath, previewType, previewSize, messageState}, onOpenInPopup}: {message: Constants.AttachmentMessage, onOpenInPopup: ?() => void}) {
@@ -49,26 +51,28 @@ function PreviewImage ({message: {attachmentDurationMs, previewDurationMs, previ
     }
 
     return (
-      <Box style={style} onClick={onOpenInPopup}>
-        <Box style={{...imgStyle, backgroundColor: globalColors.black_05}}>
-          {previewPath && <ImageRender style={imgStyle} src={previewPath} />}
-        </Box>
-        {!isMobile && (messageState === 'downloading' || messageState === 'downloaded') &&
-          <ImageIcon
-            style={{position: 'relative', right: 19, top: 3}}
-            type={messageState === 'downloading' ? 'Downloading' : 'Downloaded'} />}
-        {attachmentDurationMs && !previewDurationMs &&
-          <Box style={{...globalStyles.flexBoxCenter, position: 'absolute', top: 0, left: 0, bottom: 0, right: 0}}>
-            <Icon type='icon-play-64' />
+      <ClickableBox style={style} onClick={onOpenInPopup}>
+        <Box>
+          <Box style={{...imgStyle, backgroundColor: globalColors.black_05}}>
+            {previewPath && <ImageRender style={imgStyle} src={previewPath} />}
           </Box>
-        }
-        {attachmentDurationMs && previewType === 'Video' &&
-          <Text
-            type='BodySemibold'
-            style={{position: 'absolute', backgroundColor: globalColors.transparent, color: 'white', fontSize: 12, right: globalMargins.tiny, bottom: globalMargins.xtiny}}
-          >{moment.utc(attachmentDurationMs).format('m:ss')}</Text>
-        }
-      </Box>
+          {!isMobile && (messageState === 'downloading' || messageState === 'downloaded') &&
+            <ImageIcon
+              style={{position: 'relative', right: 19, top: 3}}
+              type={messageState === 'downloading' ? 'Downloading' : 'Downloaded'} />}
+          {attachmentDurationMs && !previewDurationMs &&
+            <Box style={{...globalStyles.flexBoxCenter, position: 'absolute', top: 0, left: 0, bottom: 0, right: 0}}>
+              <Icon type='icon-play-64' />
+            </Box>
+          }
+          {attachmentDurationMs && previewType === 'Video' &&
+            <Text
+              type='BodySemibold'
+              style={{position: 'absolute', backgroundColor: globalColors.transparent, color: 'white', fontSize: 12, right: globalMargins.tiny, bottom: globalMargins.xtiny}}
+            >{moment.utc(attachmentDurationMs).format('m:ss')}</Text>
+          }
+        </Box>
+      </ClickableBox>
     )
   }
 
@@ -100,6 +104,7 @@ function ProgressBar ({text, progress, style}: ProgressBarProps) {
 function ImageIcon ({type, style}: ImageIconProps) {
   const iconStyle = {
     ...globalStyles.flexBoxColumn,
+    backgroundColor: globalColors.white,
     color: type === 'Downloading' ? globalColors.blue : globalColors.green,
   }
 
@@ -159,7 +164,7 @@ function PreviewImageWithInfo ({message, onOpenInFileUI, onOpenInPopup}: {messag
 
 function AttachmentIcon ({messageState}: {messageState: Constants.AttachmentMessageState}) {
   let iconType = 'icon-file-24'
-  let style = {marginTop: 8, marginBottom: 8, height: 24}
+  let style = {backgroundColor: globalColors.white, height: 24, marginBottom: 8, marginTop: 8}
   switch (messageState) {
     case 'downloading':
       iconType = 'icon-file-downloading-24'
@@ -175,13 +180,14 @@ function AttachmentIcon ({messageState}: {messageState: Constants.AttachmentMess
   return <Icon type={iconType} style={style} />
 }
 
-function AttachmentMessageGeneric ({message, onOpenInFileUI, onLoadAttachment}: {message: Constants.AttachmentMessage, onOpenInFileUI: () => void, onLoadAttachment: () => void}) {
+function AttachmentMessageGeneric ({message, onOpenInFileUI, onLoadAttachment, onOpenInPopup}: {message: Constants.AttachmentMessage, onOpenInFileUI: () => void, onLoadAttachment: () => void, onOpenInPopup: ?() => void}) {
   const {downloadedPath, messageState, progress} = message
+  const canOpen = messageState !== 'uploading'
   return (
     <Box style={{...globalStyles.flexBoxRow, ...(!message.downloadedPath ? globalStyles.clickable : {}), alignItems: 'center'}} onClick={!message.downloadedPath ? onLoadAttachment : undefined}>
       <AttachmentIcon messageState={messageState} />
       <Box style={{...globalStyles.flexBoxColumn, flex: 1, marginLeft: globalMargins.xtiny}}>
-        <AttachmentTitle {...message} />
+        <AttachmentTitle {...message} onOpenInPopup={canOpen ? onOpenInPopup : null} />
 
         {!isMobile && (_showProgressBar(messageState, progress) || downloadedPath) &&
           <Box style={{height: 14}}>
@@ -196,11 +202,11 @@ function AttachmentMessageGeneric ({message, onOpenInFileUI, onLoadAttachment}: 
   )
 }
 
-function AttachmentMessagePreviewImage ({message, onOpenInFileUI, onOpenInPopup}: {message: Constants.AttachmentMessage, onOpenInFileUI: () => void, onOpenInPopup: () => void}) {
+function AttachmentMessagePreviewImage ({message, onOpenInFileUI, onOpenInPopup}: {message: Constants.AttachmentMessage, onOpenInFileUI: () => void, onOpenInPopup: ?() => void}) {
   const canOpen = message.messageState !== 'uploading'
   return (
     <Box style={{...globalStyles.flexBoxColumn, ...(canOpen ? globalStyles.clickable : {}), flex: 1}}>
-      <AttachmentTitle {...message} />
+      <AttachmentTitle {...message} onOpenInPopup={canOpen ? onOpenInPopup : null} />
       <PreviewImageWithInfo message={message} onOpenInFileUI={onOpenInFileUI} onOpenInPopup={canOpen ? onOpenInPopup : null} />
     </Box>
   )
@@ -231,7 +237,7 @@ export default class AttachmentMessage extends PureComponent<void, Props, void> 
         attachment = <AttachmentMessagePreviewImage message={message} onOpenInPopup={this._onOpenInPopup} onOpenInFileUI={this._onOpenInFileUI} />
         break
       default:
-        attachment = <AttachmentMessageGeneric message={message} onOpenInFileUI={this._onOpenInFileUI} onLoadAttachment={this._onLoadAttachment} />
+        attachment = <AttachmentMessageGeneric message={message} onOpenInFileUI={this._onOpenInFileUI} onLoadAttachment={this._onLoadAttachment} onOpenInPopup={isMobile ? this._onOpenInPopup : null} />
     }
 
     return (

--- a/shared/chat/conversation/messages/popup.native.js
+++ b/shared/chat/conversation/messages/popup.native.js
@@ -53,7 +53,7 @@ function _attachmentMessagePopupHelper ({message, onSaveAttachment, onShareAttac
   return items
 }
 
-function MessagePopup (props: TextProps | AttachmentProps) {
+export function MessagePopup (props: TextProps | AttachmentProps) {
   const {message, onDeleteMessage, onHidden} = props
   if (message.type !== 'Text' && message.type !== 'Attachment') return null
 

--- a/shared/chat/conversation/messages/text.native.js
+++ b/shared/chat/conversation/messages/text.native.js
@@ -10,6 +10,7 @@ const MessageText = (props: Props) => {
   const {message, isEditing} = props
   const {messageState} = message
   const textStyle = {
+    backgroundColor: globalColors.white,
     ...(messageState === 'failed' || messageState === 'pending' ? pendingFailStyle : {}),
     ...(isEditing ? editingStyle : null),
   }

--- a/shared/chat/conversation/messages/wrapper.native.js
+++ b/shared/chat/conversation/messages/wrapper.native.js
@@ -16,15 +16,15 @@ class MessageWrapper extends PureComponent<void, MessageProps, void> {
     const {children, message, style, includeHeader, isFirstNewMessage, onAction, onRetry, isSelected, you, followingMap, metaDataMap} = this.props
     return (
       <NativeTouchableHighlight onLongPress={(event) => onAction(message, event)} underlayColor={globalColors.black_10}>
-        <Box style={{...globalStyles.flexBoxColumn, flex: 1, ...(isFirstNewMessage ? _stylesFirstNewMessage : null), ...(isSelected ? _stylesSelected : null), ...style}}>
+        <Box style={{...globalStyles.flexBoxColumn, flex: 1, ...(isFirstNewMessage ? _stylesFirstNewMessage : null), ...(isSelected ? _stylesSelected : _stylesUnselected), ...style}}>
           <Box style={_marginContainerStyle}>
             <Box style={{alignSelf: 'stretch', backgroundColor: marginColor(message.author, you, followingMap, metaDataMap), marginRight: globalMargins.tiny, width: 3}} />
-            <Box style={{...globalStyles.flexBoxRow, flex: 1, paddingTop: (includeHeader ? globalMargins.tiny : 0)}}>
+            <Box style={{...globalStyles.flexBoxRow, flex: 1, paddingTop: (includeHeader ? globalMargins.tiny : 0), backgroundColor: globalColors.white}}>
               {includeHeader
                 ? <Avatar size={32} username={message.author} style={_avatarStyle} />
                 : <Box style={_noHeaderStyle} />}
               <Box style={_bodyContainerStyle}>
-                {includeHeader && <Text type='BodySmallSemibold' style={{color: colorForAuthor(message.author, you, followingMap, metaDataMap), ...(message.author === you ? globalStyles.italic : null), marginBottom: 2}}>{message.author}</Text>}
+                {includeHeader && <Text type='BodySmallSemibold' style={{color: colorForAuthor(message.author, you, followingMap, metaDataMap), ...(message.author === you ? globalStyles.italic : null), marginBottom: 2, backgroundColor: globalColors.white}}>{message.author}</Text>}
                 <Box style={_textContainerStyle}>
                   <Box style={_childrenWrapStyle}>
                     {children}
@@ -55,7 +55,11 @@ const _stylesFirstNewMessage = {
 }
 
 const _stylesSelected = {
-  backgroundColor: `${globalColors.black_05}`,
+  backgroundColor: globalColors.black_05,
+}
+
+const _stylesUnselected = {
+  backgroundColor: globalColors.white,
 }
 
 const _exclamationStyle = {
@@ -71,6 +75,7 @@ const _textContainerStyle = {
 
 const _marginContainerStyle = {
   ...globalStyles.flexBoxRow,
+  backgroundColor: globalColors.white,
   flex: 1,
 }
 
@@ -85,6 +90,7 @@ const _noHeaderStyle = {
 
 const _avatarStyle = {
   marginRight: globalMargins.tiny,
+  backgroundColor: globalColors.white,
 }
 
 const _editedStyle = {

--- a/shared/chat/conversations-list/index.native.js
+++ b/shared/chat/conversations-list/index.native.js
@@ -41,7 +41,6 @@ const Avatars = ({participants, youNeedToRekey, participantNeedToRekey, isMuted,
   }
 
   const avatarProps = participants.slice(0, 2).map((username, idx) => ({
-    backgroundColor,
     borderColor: rowBorderColor(idx, idx === (avatarCount - 1), backgroundColor),
     loadingColor: globalColors.blue3_40,
     size: 24,
@@ -52,8 +51,8 @@ const Avatars = ({participants, youNeedToRekey, participantNeedToRekey, isMuted,
   })).toArray()
 
   return (
-    <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', flex: 1, justifyContent: 'flex-start', maxWidth: 48, paddingLeft: 4}}>
-      <MultiAvatar singleSize={32} multiSize={24} avatarProps={avatarProps} />
+    <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', flex: 1, justifyContent: 'flex-start', maxWidth: 48, paddingLeft: 4, backgroundColor}}>
+      <MultiAvatar singleSize={32} multiSize={24} avatarProps={avatarProps} style={{backgroundColor}} />
       {icon}
     </Box>
   )
@@ -81,7 +80,7 @@ const TopLine = ({hasUnread, showBold, participants, subColor, timestamp, userna
   )
 }
 
-const BottomLine = ({participantNeedToRekey, youNeedToRekey, isMuted, showBold, subColor, snippet}) => {
+const BottomLine = ({participantNeedToRekey, youNeedToRekey, isMuted, showBold, subColor, snippet, backgroundColor}) => {
   const boldOverride = showBold ? globalStyles.fontBold : null
 
   let content
@@ -97,8 +96,8 @@ const BottomLine = ({participantNeedToRekey, youNeedToRekey, isMuted, showBold, 
   }
 
   return (
-    <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', maxHeight: 17, minHeight: 17, position: 'relative'}}>
-      <Box style={{...globalStyles.flexBoxColumn, bottom: 0, justifyContent: 'flex-start', left: 0, position: 'absolute', right: 0, top: 0}}>
+    <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', maxHeight: 17, minHeight: 17, position: 'relative', backgroundColor}}>
+      <Box style={{...globalStyles.flexBoxColumn, bottom: 0, justifyContent: 'flex-start', left: 0, position: 'absolute', right: 0, top: 0, backgroundColor}}>
         {content}
       </Box>
     </Box>
@@ -107,7 +106,7 @@ const BottomLine = ({participantNeedToRekey, youNeedToRekey, isMuted, showBold, 
 
 const _Row = (props: RowProps) => {
   return (
-    <ClickableBox onClick={() => props.onSelectConversation(props.conversationIDKey)}>
+    <ClickableBox onClick={() => props.onSelectConversation(props.conversationIDKey)} style={{backgroundColor: props.backgroundColor}}>
       <Box
         style={{...rowContainerStyle, backgroundColor: props.backgroundColor}}
         title={`${props.unreadCount} unread`}>
@@ -123,7 +122,8 @@ const _Row = (props: RowProps) => {
         <Box style={{
           ...globalStyles.flexBoxColumn,
           ...conversationRowStyle,
-          borderBottomColor: (!props.isSelected && !props.hasUnread) ? globalColors.black_10 : globalColors.transparent,
+          backgroundColor: props.backgroundColor,
+          borderBottomColor: (!props.isSelected && !props.hasUnread) ? globalColors.black_10 : props.backgroundColor,
           borderBottomWidth: 1,
         }}>
           <TopLine
@@ -135,6 +135,7 @@ const _Row = (props: RowProps) => {
             usernameColor={props.usernameColor}
           />
           <BottomLine
+            backgroundColor={props.backgroundColor}
             isMuted={props.isMuted}
             participantNeedToRekey={props.participantNeedToRekey}
             showBold={props.showBold}

--- a/shared/common-adapters/avatar.render.native.js
+++ b/shared/common-adapters/avatar.render.native.js
@@ -2,7 +2,7 @@
 import Icon from './icon'
 import React, {PureComponent} from 'react'
 import {globalColors} from '../styles'
-import {ClickableBox, NativeImage, Box} from './index.native'
+import {NativeTouchableWithoutFeedback, NativeImage, Box} from './index.native'
 
 import type {AvatarSize} from './avatar'
 import type {IconType} from './icon'
@@ -119,15 +119,12 @@ class AvatarRender extends PureComponent<void, Props, State> {
     const {url, onClick, style, size, loadingColor, borderColor, opacity, followIconType, followIconStyle, children} = this.props
 
     return (
-      <ClickableBox
-        onClick={onClick}
-        style={{
+      <NativeTouchableWithoutFeedback onPress={onClick}>
+        <Box style={{
           height: size,
           position: 'relative',
           width: size,
-          ...style,
-        }}>
-        <Box style={{height: size, width: size}}>
+          ...style}}>
           <Background loaded={this.state.loaded} loadingColor={loadingColor} size={size} />
           {!!url && <UserImage
             opacity={opacity}
@@ -139,7 +136,7 @@ class AvatarRender extends PureComponent<void, Props, State> {
           {followIconType && <Icon type={followIconType} style={followIconStyle} />}
           {children}
         </Box>
-      </ClickableBox>
+      </NativeTouchableWithoutFeedback>
     )
   }
 }

--- a/shared/common-adapters/icon.native.js
+++ b/shared/common-adapters/icon.native.js
@@ -29,6 +29,7 @@ class Icon extends Component<void, Exact<Props>, void> {
     const fontSizeHint = shared.fontSize(iconType)
     const fontSize = (this.props.style && (this.props.style.fontSize || styleWidth) && {fontSize: this.props.style.fontSize || styleWidth}) || fontSizeHint
     const textAlign = this.props.style && this.props.style.textAlign
+    const backgroundColor = this.props.style && {backgroundColor: this.props.style.backgroundColor} || {}
 
     // Color is for our fontIcon and not the container
     let containerProps = {...this.props.style}
@@ -44,9 +45,9 @@ class Icon extends Component<void, Exact<Props>, void> {
     }
 
     const icon = iconMeta[iconType].isFont
-      ? <NativeText style={{color, textAlign, fontFamily: 'kb', ...fontSize, ...width}}>{
+      ? <NativeText style={{color, textAlign, fontFamily: 'kb', ...fontSize, ...width, ...backgroundColor}}>{
         String.fromCharCode(iconMeta[iconType].charCode || 0)}</NativeText>
-      : <NativeImage source={iconMeta[iconType].require} style={{resizeMode: 'contain', ...width, ...height}} />
+      : <NativeImage source={iconMeta[iconType].require} style={{resizeMode: 'contain', ...width, ...height, ...backgroundColor}} />
 
     return (
       <TouchableHighlight

--- a/shared/common-adapters/multi-avatar.js
+++ b/shared/common-adapters/multi-avatar.js
@@ -31,8 +31,10 @@ class MultiAvatar extends Component<void, Props, void> {
     const leftProps: AvatarProps = avatarProps[1]
     const rightProps: AvatarProps = avatarProps[0]
 
+    const backgroundColor = (this.props.style && this.props.style.backgroundColor && {backgroundColor: this.props.style.backgroundColor} || {})
+
     if (avatarProps.length === 1) {
-      return <Avatar {...rightProps} size={singleSize} />
+      return <Avatar style={{...backgroundColor, ...rightProps.style}} {...rightProps} size={singleSize} />
     }
 
     return (

--- a/shared/constants/types/more.js
+++ b/shared/constants/types/more.js
@@ -64,7 +64,7 @@ export function toDeviceType (s: string): DeviceType {
     case 'backup':
       return s
     default:
-      console.warn('Unknown Device Type %s. Defaulting to `desktop`', s)
+      console.log('Unknown Device Type %s. Defaulting to `desktop`', s)
       return 'desktop'
   }
 }

--- a/shared/react-native/ios/Keybase/Info.plist
+++ b/shared/react-native/ios/Keybase/Info.plist
@@ -20,6 +20,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>114</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<true/>
+	<key>ITSEncryptionExportComplianceCode</key>
+	<string>63ff6926-88f0-4db0-8886-a4bb56bd4ad5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -27,8 +31,12 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Scanning codes</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Attaching images to chat messages</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>OpenSans_bold.ttf</string>
@@ -49,18 +57,8 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<true/>
-	<key>ITSEncryptionExportComplianceCode</key>
-	<string>63ff6926-88f0-4db0-8886-a4bb56bd4ad5</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>NSCameraUsageDescription</key>
-	<string>Scanning codes</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Attaching images to chat messages</string>
 </dict>
 </plist>


### PR DESCRIPTION
This PR is split into 3 commits:

- [x] Forces portrait mode on ios and changes a console.warn to a log so i don't get yellowboxed on every inbox load (https://github.com/keybase/client/commit/fc1421b850da66892af7d3bd6c928539d3748112)
- [x] Reduces overdraw on mobile. This is due to transparent backgrounds on things blending that serve no purpose. The fix is to explicitly set background colors on the children so they're opaque and no longer need to blend (https://github.com/keybase/client/commit/b5552c5807b713b2160dff4f9549fc99fda6abc2)
- [x] The actual popup. https://github.com/keybase/client/commit/f42953cc4fff09de66c13e77b71284930b5d6dee