### PR TITLE
Don't show FollowActions on your own profile on mobile

### DIFF
--- a/shared/profile/index.native.js
+++ b/shared/profile/index.native.js
@@ -174,7 +174,7 @@ class Profile extends Component<void, Props, State> {
               loadingComponent={this._makeUserBio(true)}
               doneLoadingComponent={this._makeUserBio(false)} />
           </Box>
-          {!this.props.loading &&
+          {!this.props.isYou && !this.props.loading &&
             <UserActions
               style={styleActions}
               trackerState={this.props.trackerState}


### PR DESCRIPTION
@keybase/react-hackers This now matches the same check that's done in the desktop render component.