### PR TITLE
Fallback to home socket if XDG_RUNTIME_DIR's unset on Linux

### DIFF
--- a/shared/constants/platform.desktop.js
+++ b/shared/constants/platform.desktop.js
@@ -68,7 +68,7 @@ function linuxSocketDialPath (): string {
     console.warn("You don't have $HOME or $XDG_RUNTIME_DIR defined, so we can't find the Keybase service path.")
   }
 
-  return path.join(cacheDir, 'keybase', suffix, socketName)
+  return path.join(cacheDir, `keybase${suffix}`, socketName)
 }
 
 const darwinCacheRoot = `${getenv('HOME', '')}/Library/Caches/${envedPathOSX[runMode]}/`

--- a/shared/constants/platform.desktop.js
+++ b/shared/constants/platform.desktop.js
@@ -59,9 +59,9 @@ function linuxSocketDialPath (): string {
   // If XDG_RUNTIME_DIR is defined use that, else use $HOME/.config.
   const homeCacheDir = path.join(getenv('HOME', ''), '.config')
   const cacheDir = getenv('XDG_RUNTIME_DIR', homeCacheDir)
-  const suffix = runMode === 'prod' ? '' : `.${runMode}/`
+  const suffix = runMode === 'prod' ? '/' : `.${runMode}/`
 
-  return path.join(`${cacheDir}/keybase/${suffix}/`, socketName)
+  return path.join(`${cacheDir}/keybase/${suffix}`, socketName)
 }
 
 const darwinCacheRoot = `${getenv('HOME', '')}/Library/Caches/${envedPathOSX[runMode]}/`

--- a/shared/constants/platform.desktop.js
+++ b/shared/constants/platform.desktop.js
@@ -58,10 +58,10 @@ function win32SocketDialPath (): string {
 function linuxSocketDialPath (): string {
   // If XDG_RUNTIME_DIR is defined use that, else use $HOME/.config.
   const homeDir = getenv('HOME', '')
-  const homeCacheDir = path.join(homeDir, '.config')
+  const homeConfigDir = path.join(homeDir, '.config')
   const runtimeDir = getenv('XDG_RUNTIME_DIR', '')
 
-  const cacheDir = runtimeDir || homeCacheDir
+  const cacheDir = runtimeDir || homeConfigDir
   const suffix = runMode === 'prod' ? '' : `.${runMode}`
 
   if (!runtimeDir && !homeDir) {

--- a/shared/constants/platform.desktop.js
+++ b/shared/constants/platform.desktop.js
@@ -56,10 +56,12 @@ function win32SocketDialPath (): string {
 }
 
 function linuxSocketDialPath (): string {
-  if (runMode === 'prod') {
-    return path.join(`${getenv('XDG_RUNTIME_DIR', '')}/keybase/`, socketName)
-  }
-  return path.join(`${getenv('XDG_RUNTIME_DIR', '')}/keybase.${runMode}/`, socketName)
+  // If XDG_RUNTIME_DIR is defined use that, else use $HOME/.config.
+  const homeCacheDir = path.join(getenv('HOME', ''), '.config')
+  const cacheDir = getenv('XDG_RUNTIME_DIR', homeCacheDir)
+  const suffix = runMode === 'prod' ? '' : `.${runMode}/`
+
+  return path.join(`${cacheDir}/keybase/${suffix}/`, socketName)
 }
 
 const darwinCacheRoot = `${getenv('HOME', '')}/Library/Caches/${envedPathOSX[runMode]}/`

--- a/shared/constants/platform.desktop.js
+++ b/shared/constants/platform.desktop.js
@@ -57,11 +57,18 @@ function win32SocketDialPath (): string {
 
 function linuxSocketDialPath (): string {
   // If XDG_RUNTIME_DIR is defined use that, else use $HOME/.config.
-  const homeCacheDir = path.join(getenv('HOME', ''), '.config')
-  const cacheDir = getenv('XDG_RUNTIME_DIR', homeCacheDir)
-  const suffix = runMode === 'prod' ? '/' : `.${runMode}/`
+  const homeDir = getenv('HOME', '')
+  const homeCacheDir = path.join(homeDir, '.config')
+  const runtimeDir = getenv('XDG_RUNTIME_DIR', '')
 
-  return path.join(`${cacheDir}/keybase${suffix}`, socketName)
+  const cacheDir = runtimeDir || homeCacheDir
+  const suffix = runMode === 'prod' ? '' : `.${runMode}`
+
+  if (!runtimeDir && !homeDir) {
+    console.warn("You don't have $HOME or $XDG_RUNTIME_DIR defined, so we can't find the Keybase service path.")
+  }
+
+  return path.join(cacheDir, 'keybase', suffix, socketName)
 }
 
 const darwinCacheRoot = `${getenv('HOME', '')}/Library/Caches/${envedPathOSX[runMode]}/`

--- a/shared/constants/platform.desktop.js
+++ b/shared/constants/platform.desktop.js
@@ -61,7 +61,7 @@ function linuxSocketDialPath (): string {
   const cacheDir = getenv('XDG_RUNTIME_DIR', homeCacheDir)
   const suffix = runMode === 'prod' ? '/' : `.${runMode}/`
 
-  return path.join(`${cacheDir}/keybase/${suffix}`, socketName)
+  return path.join(`${cacheDir}/keybase${suffix}`, socketName)
 }
 
 const darwinCacheRoot = `${getenv('HOME', '')}/Library/Caches/${envedPathOSX[runMode]}/`


### PR DESCRIPTION
@keybase/react-hackers CC @oconnor663 

This matches the search routine that the service uses when deciding where to put its socket file -- use `$XDG_RUNTIME_DIR/keybase(.runMode)` if that's set, else use `$HOME/.config/keybase(.runMode)/`. 

Fixes #6110.