### PR TITLE
Attachment UI fixes, Uploaded flag bug

### DIFF
--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -127,7 +127,7 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 					err = i.ChatAttachmentUploadDone(ctx, (*typedArgs)[0].SessionID)
 					return
 				},
-				MethodType: rpc.MethodNotify,
+				MethodType: rpc.MethodCall,
 			},
 			"chatAttachmentPreviewUploadStart": {
 				MakeArg: func() interface{} {
@@ -277,7 +277,7 @@ func (c ChatUiClient) ChatAttachmentUploadProgress(ctx context.Context, __arg Ch
 
 func (c ChatUiClient) ChatAttachmentUploadDone(ctx context.Context, sessionID int) (err error) {
 	__arg := ChatAttachmentUploadDoneArg{SessionID: sessionID}
-	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatAttachmentUploadDone", []interface{}{__arg})
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatAttachmentUploadDone", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -159,7 +159,7 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 					err = i.ChatAttachmentPreviewUploadDone(ctx, (*typedArgs)[0].SessionID)
 					return
 				},
-				MethodType: rpc.MethodNotify,
+				MethodType: rpc.MethodCall,
 			},
 			"chatAttachmentDownloadStart": {
 				MakeArg: func() interface{} {
@@ -288,7 +288,7 @@ func (c ChatUiClient) ChatAttachmentPreviewUploadStart(ctx context.Context, __ar
 
 func (c ChatUiClient) ChatAttachmentPreviewUploadDone(ctx context.Context, sessionID int) (err error) {
 	__arg := ChatAttachmentPreviewUploadDoneArg{SessionID: sessionID}
-	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatAttachmentPreviewUploadDone", []interface{}{__arg})
+	err = c.Cli.Call(ctx, "chat.1.chatUi.chatAttachmentPreviewUploadDone", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -886,6 +886,7 @@ func (h *chatLocalHandler) postAttachmentLocal(ctx context.Context, arg postAtta
 	attachment := chat1.MessageAttachment{
 		Object:   object,
 		Metadata: arg.Metadata,
+		Uploaded: true,
 	}
 	if preview != nil {
 		preview.Title = arg.Title
@@ -894,7 +895,6 @@ func (h *chatLocalHandler) postAttachmentLocal(ctx context.Context, arg postAtta
 		preview.Tag = chat1.AssetTag_PRIMARY
 		attachment.Previews = []chat1.Asset{*preview}
 		attachment.Preview = preview
-		attachment.Uploaded = true
 	}
 
 	// edit the placeholder  attachment message with the asset information

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -6,7 +6,7 @@ protocol chatUi {
   void chatAttachmentUploadDone(int sessionID) oneway;	
 
   void chatAttachmentPreviewUploadStart(int sessionID, AssetMetadata metadata) oneway;	
-  void chatAttachmentPreviewUploadDone(int sessionID) oneway;	
+  void chatAttachmentPreviewUploadDone(int sessionID);	
 
   void chatAttachmentDownloadStart(int sessionID) oneway;	
   void chatAttachmentDownloadProgress(int sessionID, int bytesComplete, int bytesTotal) oneway;     

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -3,7 +3,7 @@
 protocol chatUi {
   void chatAttachmentUploadStart(int sessionID, AssetMetadata metadata, MessageID placeholderMsgID) oneway;	
   void chatAttachmentUploadProgress(int sessionID, int bytesComplete, int bytesTotal) oneway;     
-  void chatAttachmentUploadDone(int sessionID) oneway;	
+  void chatAttachmentUploadDone(int sessionID);	
 
   void chatAttachmentPreviewUploadStart(int sessionID, AssetMetadata metadata) oneway;	
   void chatAttachmentPreviewUploadDone(int sessionID);	

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -70,8 +70,7 @@
           "type": "int"
         }
       ],
-      "response": null,
-      "oneway": true
+      "response": null
     },
     "chatAttachmentDownloadStart": {
       "request": [

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -46,8 +46,7 @@
           "type": "int"
         }
       ],
-      "response": null,
-      "oneway": true
+      "response": null
     },
     "chatAttachmentPreviewUploadStart": {
       "request": [


### PR DESCRIPTION
For non-image uploads without a preview, the 'Uploaded' flag wasn't set to true (for some reason)...

Also, this changes the UploadDone UI functions from oneway notifications to standard RPC calls to solve an issue where sometimes the attachment message was arriving before the UI notification (which is surprising, but possible).

cc @MarcoPolo 