### PR TITLE
protocol: add blockPing() method to the bserver protocol

### DIFF
--- a/go/protocol/keybase1/block.go
+++ b/go/protocol/keybase1/block.go
@@ -30,6 +30,9 @@ type DowngradeReferenceRes struct {
 	Failed    BlockReference        `codec:"failed" json:"failed"`
 }
 
+type BlockPingResponse struct {
+}
+
 type GetSessionChallengeArg struct {
 }
 
@@ -77,6 +80,9 @@ type ArchiveReferenceWithCountArg struct {
 type GetUserQuotaInfoArg struct {
 }
 
+type BlockPingArg struct {
+}
+
 type BlockInterface interface {
 	GetSessionChallenge(context.Context) (ChallengeInfo, error)
 	AuthenticateSession(context.Context, string) error
@@ -88,6 +94,7 @@ type BlockInterface interface {
 	DelReferenceWithCount(context.Context, DelReferenceWithCountArg) (DowngradeReferenceRes, error)
 	ArchiveReferenceWithCount(context.Context, ArchiveReferenceWithCountArg) (DowngradeReferenceRes, error)
 	GetUserQuotaInfo(context.Context) ([]byte, error)
+	BlockPing(context.Context) (BlockPingResponse, error)
 }
 
 func BlockProtocol(i BlockInterface) rpc.Protocol {
@@ -244,6 +251,17 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"blockPing": {
+				MakeArg: func() interface{} {
+					ret := make([]BlockPingArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					ret, err = i.BlockPing(ctx)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -300,5 +318,10 @@ func (c BlockClient) ArchiveReferenceWithCount(ctx context.Context, __arg Archiv
 
 func (c BlockClient) GetUserQuotaInfo(ctx context.Context) (res []byte, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.block.getUserQuotaInfo", []interface{}{GetUserQuotaInfoArg{}}, &res)
+	return
+}
+
+func (c BlockClient) BlockPing(ctx context.Context) (res BlockPingResponse, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.block.blockPing", []interface{}{BlockPingArg{}}, &res)
 	return
 }

--- a/protocol/avdl/keybase1/block.avdl
+++ b/protocol/avdl/keybase1/block.avdl
@@ -27,6 +27,12 @@ protocol block {
     BlockReference failed;
   }
 
+  record BlockPingResponse {
+    // In the future, we might want to respond with timestamps or
+    // ping intervals.
+  }
+
+
   ChallengeInfo getSessionChallenge();
   void authenticateSession(string signature);
 
@@ -41,5 +47,6 @@ protocol block {
   DowngradeReferenceRes archiveReferenceWithCount(string folder, array<BlockReference> refs);
 
   bytes getUserQuotaInfo();
- 
+
+  BlockPingResponse blockPing();
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -972,6 +972,18 @@ export function blockAuthenticateSessionRpcPromise (request: $Exact<requestCommo
   return new Promise((resolve, reject) => { blockAuthenticateSessionRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function blockBlockPingRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: blockBlockPingResult) => void}>) {
+  engineRpcOutgoing({...request, method: 'keybase.1.block.blockPing'})
+}
+
+export function blockBlockPingRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: blockBlockPingResult) => void}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => blockBlockPingRpc({...request, incomingCallMap, callback}))
+}
+
+export function blockBlockPingRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: blockBlockPingResult) => void}>): Promise<blockBlockPingResult> {
+  return new Promise((resolve, reject) => { blockBlockPingRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function blockDelReferenceRpc (request: Exact<requestCommon & requestErrorCallback & {param: blockDelReferenceRpcParam}>) {
   engineRpcOutgoing({...request, method: 'keybase.1.block.delReference'})
 }
@@ -3112,6 +3124,8 @@ export type BlockIdCombo = {
   chargedTo: UID,
   blockType: BlockType,
 }
+
+export type BlockPingResponse = {}
 
 export type BlockRefNonce = any
 
@@ -5773,6 +5787,8 @@ type blockArchiveReferenceResult = ?Array<BlockReference>
 
 type blockArchiveReferenceWithCountResult = DowngradeReferenceRes
 
+type blockBlockPingResult = BlockPingResponse
+
 type blockDelReferenceWithCountResult = DowngradeReferenceRes
 
 type blockGetBlockResult = GetBlockRes
@@ -6046,6 +6062,7 @@ export type rpc =
   | blockArchiveReferenceRpc
   | blockArchiveReferenceWithCountRpc
   | blockAuthenticateSessionRpc
+  | blockBlockPingRpc
   | blockDelReferenceRpc
   | blockDelReferenceWithCountRpc
   | blockGetBlockRpc

--- a/protocol/json/keybase1/block.json
+++ b/protocol/json/keybase1/block.json
@@ -74,6 +74,11 @@
           "name": "failed"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "BlockPingResponse",
+      "fields": []
     }
   ],
   "messages": {
@@ -204,6 +209,10 @@
     "getUserQuotaInfo": {
       "request": [],
       "response": "bytes"
+    },
+    "blockPing": {
+      "request": [],
+      "response": "BlockPingResponse"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -972,6 +972,18 @@ export function blockAuthenticateSessionRpcPromise (request: $Exact<requestCommo
   return new Promise((resolve, reject) => { blockAuthenticateSessionRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function blockBlockPingRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: blockBlockPingResult) => void}>) {
+  engineRpcOutgoing({...request, method: 'keybase.1.block.blockPing'})
+}
+
+export function blockBlockPingRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: blockBlockPingResult) => void}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => blockBlockPingRpc({...request, incomingCallMap, callback}))
+}
+
+export function blockBlockPingRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: blockBlockPingResult) => void}>): Promise<blockBlockPingResult> {
+  return new Promise((resolve, reject) => { blockBlockPingRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function blockDelReferenceRpc (request: Exact<requestCommon & requestErrorCallback & {param: blockDelReferenceRpcParam}>) {
   engineRpcOutgoing({...request, method: 'keybase.1.block.delReference'})
 }
@@ -3112,6 +3124,8 @@ export type BlockIdCombo = {
   chargedTo: UID,
   blockType: BlockType,
 }
+
+export type BlockPingResponse = {}
 
 export type BlockRefNonce = any
 
@@ -5773,6 +5787,8 @@ type blockArchiveReferenceResult = ?Array<BlockReference>
 
 type blockArchiveReferenceWithCountResult = DowngradeReferenceRes
 
+type blockBlockPingResult = BlockPingResponse
+
 type blockDelReferenceWithCountResult = DowngradeReferenceRes
 
 type blockGetBlockResult = GetBlockRes
@@ -6046,6 +6062,7 @@ export type rpc =
   | blockArchiveReferenceRpc
   | blockArchiveReferenceWithCountRpc
   | blockAuthenticateSessionRpc
+  | blockBlockPingRpc
   | blockDelReferenceRpc
   | blockDelReferenceWithCountRpc
   | blockGetBlockRpc


### PR DESCRIPTION
This is in preparation for timing out bserver connections at the application level if pings take too long.

Issue: KBFS-1982