### PR TITLE
Replace routeTree persistState parameter with persistChildren route tag

### DIFF
--- a/shared/actions/route-tree.js
+++ b/shared/actions/route-tree.js
@@ -67,10 +67,10 @@ export function switchTo (path: Path, parentPath?: Path): SwitchTo {
 //
 // If parentPath is provided, the path will be navigated to relative to
 // parentPath without navigating to it.
-export function navigateTo (path: PropsPath<*>, parentPath?: ?Path, persistState?: boolean = false): NavigateTo {
+export function navigateTo (path: PropsPath<*>, parentPath?: ?Path): NavigateTo {
   return {
     type: Constants.navigateTo,
-    payload: {path, parentPath, persistState},
+    payload: {path, parentPath},
     logTransformer: pathActionTransformer,
   }
 }
@@ -87,10 +87,10 @@ export function navigateAppend (path: PropsPath<*>, parentPath?: Path): Navigate
 }
 
 // Navigate one step up from the current path.
-export function navigateUp (persistState?: boolean = false): NavigateUp {
+export function navigateUp (): NavigateUp {
   return {
     type: Constants.navigateUp,
-    payload: {persistState: !!persistState},
+    payload: null,
   }
 }
 

--- a/shared/chat/routes.desktop.js
+++ b/shared/chat/routes.desktop.js
@@ -26,6 +26,7 @@ const routeTree = new RouteDefNode({
   containerComponent: Render,
   defaultSelected: nothingSelected,
   children: () => conversationRoute,
+  tags: {persistChildren: true},
 })
 
 export default routeTree

--- a/shared/chat/routes.native.js
+++ b/shared/chat/routes.native.js
@@ -29,6 +29,7 @@ const conversationRoute = new RouteDefNode({
 const routeTree = new RouteDefNode({
   component: ConversationList,
   children: () => conversationRoute,
+  tags: {persistChildren: true},
 })
 
 export default routeTree

--- a/shared/constants/route-tree.js
+++ b/shared/constants/route-tree.js
@@ -9,13 +9,13 @@ export const switchTo = 'routeTree:switchTo'
 export type SwitchTo = NoErrorTypedAction<'routeTree:switchTo', {path: Path, parentPath: ?Path}>
 
 export const navigateTo = 'routeTree:navigateTo'
-export type NavigateTo = NoErrorTypedAction<'routeTree:navigateTo', {path: PropsPath<*>, parentPath: ?Path, persistState: boolean}>
+export type NavigateTo = NoErrorTypedAction<'routeTree:navigateTo', {path: PropsPath<*>, parentPath: ?Path}>
 
 export const navigateAppend = 'routeTree:navigateAppend'
 export type NavigateAppend = NoErrorTypedAction<'routeTree:navigateAppend', {path: PropsPath<*>, parentPath: ?Path}>
 
 export const navigateUp = 'routeTree:navigateUp'
-export type NavigateUp = NoErrorTypedAction<'routeTree:navigateUp', {persistState: boolean}>
+export type NavigateUp = NoErrorTypedAction<'routeTree:navigateUp', null>
 
 export const setRouteState = 'routeTree:setRouteState'
 export type SetRouteState = NoErrorTypedAction<'routeTree:setRouteState', {path: Path, partialState: {}}>

--- a/shared/nav.native.js
+++ b/shared/nav.native.js
@@ -147,8 +147,7 @@ export default connect(
     navigateUp: () => dispatch(navigateUp()),
     switchTab: (tab: Tab) => {
       if (tab === chatTab && routeSelected === tab) {
-        // clicking the chat tab when already selected should persistState and nav to the chat tab
-        dispatch(navigateTo(routePath.push(tab), null, true))
+        dispatch(navigateTo(routePath.push(tab)))
         return
       }
 

--- a/shared/reducers/__tests__/route-tree.test.js
+++ b/shared/reducers/__tests__/route-tree.test.js
@@ -1,9 +1,8 @@
 // @flow
 /* eslint-env jest */
 
-import * as I from 'immutable'
 import routeTreeReducer, {State} from '../route-tree'
-import {RouteDefNode, RouteStateNode, routeSetProps, routeNavigate} from '../../route-tree'
+import {RouteDefNode, routeSetProps, routeNavigate} from '../../route-tree'
 import {
   navigateAppend,
   navigateUp,
@@ -49,29 +48,6 @@ describe('routeTree reducer', () => {
       const newState = routeTreeReducer(new State({routeDef, routeState}), action)
       expect(newState.routeDef).toBe(routeDef)
       expect(newState.routeState).toEqual(routeSetProps(routeDef, null, (['foo']: Array<string>)))
-    })
-
-    it('persists state correctly', () => {
-      const routeDef = demoRouteDef
-      const routeState = routeSetProps(routeDef, null, (['foo', 'bar']: PropsPath<*>))
-
-      const action = navigateUp(true)
-      const newState = routeTreeReducer(new State({routeDef, routeState}), action)
-      expect(newState.routeDef).toBe(routeDef)
-      expect(newState.routeState).toEqual(new RouteStateNode({
-        selected: 'foo',
-        children: I.Map({
-          foo: new RouteStateNode({
-            selected: null,
-            children: I.Map({
-              bar: new RouteStateNode({
-                selected: null,
-                props: I.Map({}),
-              }),
-            }),
-          }),
-        }),
-      }))
     })
   })
 

--- a/shared/reducers/route-tree.js
+++ b/shared/reducers/route-tree.js
@@ -43,7 +43,7 @@ function routeStateReducer (routeDef, routeState, action) {
       return routeSetProps(routeDef, routeState, action.payload.path, action.payload.parentPath)
 
     case Constants.navigateTo:
-      return routeNavigate(routeDef, routeState, action.payload.path, action.payload.parentPath, action.payload.persistState)
+      return routeNavigate(routeDef, routeState, action.payload.path, action.payload.parentPath)
 
     case Constants.navigateAppend: {
       const parentPath = I.List(action.payload.parentPath)
@@ -61,7 +61,7 @@ function routeStateReducer (routeDef, routeState, action) {
 
     case Constants.navigateUp: {
       const path = getPath(routeState)
-      return routeNavigate(routeDef, routeState, path.skipLast(1), null, action.payload.persistState)
+      return routeNavigate(routeDef, routeState, path.skipLast(1))
     }
 
     case Constants.setRouteState:

--- a/shared/route-tree/__tests__/route-tree.test.js
+++ b/shared/route-tree/__tests__/route-tree.test.js
@@ -100,6 +100,12 @@ const demoRouteDef = new RouteDefNode({
     etc: {
       children: {},
     },
+    persist: {
+      children: {
+        child: emptyRouteDef,
+      },
+      tags: {persistChildren: true},
+    },
   },
 })
 
@@ -213,15 +219,16 @@ describe('routeNavigate', () => {
     }))
   })
 
-  it('persist the state of the children if passed persistState = true', () => {
-    const startRouteState = routeNavigate(demoRouteDef, null, (['foo', {selected: 'bar', props: {hello: 'world'}}]: PropsPath<*>))
+  it('persist children for routes with persistChildren tag set', () => {
+    const startRouteState = routeNavigate(demoRouteDef, null, (['persist', {selected: 'child', props: {hello: 'world'}}]: PropsPath<*>))
+
     expect(startRouteState).toEqual(new RouteStateNode({
-      selected: 'foo',
+      selected: 'persist',
       children: I.Map({
-        foo: new RouteStateNode({
-          selected: 'bar',
+        persist: new RouteStateNode({
+          selected: 'child',
           children: I.Map({
-            bar: new RouteStateNode({
+            child: new RouteStateNode({
               selected: null,
               props: I.Map({hello: 'world'}),
             }),
@@ -230,14 +237,14 @@ describe('routeNavigate', () => {
       }),
     }))
 
-    const newRouteState = routeNavigate(demoRouteDef, startRouteState, (['foo']: Array<string>), null, true)
+    const newRouteState = routeNavigate(demoRouteDef, startRouteState, (['persist']: Array<string>))
     expect(newRouteState).toEqual(new RouteStateNode({
-      selected: 'foo',
+      selected: 'persist',
       children: I.Map({
-        foo: new RouteStateNode({
+        persist: new RouteStateNode({
           selected: null,
           children: I.Map({
-            bar: new RouteStateNode({
+            child: new RouteStateNode({
               selected: null,
               props: I.Map({hello: 'world'}),
             }),


### PR DESCRIPTION
Whether to persist children when navigating away from a route seems to
map consistently to the identity of the route, rather than the context
of the action fire. Moving this to a route tag makes the behavior
consistent with all forms of navigation (e.g. global back button
handler) and simplifies code.

:eyeglasses: @keybase/react-hackers 