### PR TITLE
Use midnight blue background for navigation buttons on Android

### DIFF
--- a/shared/react-native/android/app/src/main/res/values/styles.xml
+++ b/shared/react-native/android/app/src/main/res/values/styles.xml
@@ -4,6 +4,7 @@
         <!-- Customize your theme here. -->
         <item name="android:windowBackground">@color/white</item>
         <item name="android:colorBackground">@color/white</item>
+        <item name="android:navigationBarColor">#FF082640</item>
     </style>
 
     <style name="SplashTheme" parent="AppTheme">


### PR DESCRIPTION
:eyeglasses: @keybase/react-hackers 

Perhaps a darker color might be appropriate. Will discuss w/ @cecileboucheron.

Screenshot (with https://github.com/keybase/client/pull/6223 too):
![screenshot_1489215544](https://cloud.githubusercontent.com/assets/16893/23821378/2c96867e-05e5-11e7-85f0-0cbef8416672.png)
