### PR TITLE
use net/Context in HTTP library; improve CA

### DIFF
--- a/go/auth/credential_authority.go
+++ b/go/auth/credential_authority.go
@@ -479,7 +479,7 @@ func (v *CredentialAuthority) CheckUserKey(ctx context.Context, uid keybase1.UID
 	v.checkCh <- checkArg{uid: uid, username: username, kid: kid, retCh: retCh}
 	select {
 	case <-ctx.Done():
-		err = ErrCanceled
+		err = ctx.Err()
 	case err = <-retCh:
 	}
 	return err
@@ -506,7 +506,7 @@ func (v *CredentialAuthority) CompareUserKeys(ctx context.Context, uid keybase1.
 	v.checkCh <- checkArg{uid: uid, sibkeys: sibkeys, subkeys: subkeys, retCh: retCh}
 	select {
 	case <-ctx.Done():
-		err = ErrCanceled
+		err = ctx.Err()
 	case err = <-retCh:
 	}
 	return err

--- a/go/auth/errors.go
+++ b/go/auth/errors.go
@@ -10,9 +10,6 @@ import (
 // ErrShutdown is raised when an operation is pending but the CA is shutting down
 var ErrShutdown = errors.New("shutting down")
 
-// ErrCanceled is raised when an API operation is canceled midstream.
-var ErrCanceled = errors.New("canceled")
-
 // BadUsernameError is raised when the given username disagreeds with the expected
 // username
 type BadUsernameError struct {

--- a/go/auth/user_keys_api.go
+++ b/go/auth/user_keys_api.go
@@ -72,6 +72,7 @@ func (u *userKeyAPI) GetUser(ctx context.Context, uid keybase1.UID) (
 		Args: libkb.HTTPArgs{
 			"uid": libkb.S{Val: uid.String()},
 		},
+		NetContext: ctx,
 	}, &ukr)
 	if err != nil {
 		return "", nil, nil, err
@@ -87,21 +88,17 @@ func (u *userKeyAPI) PollForChanges(ctx context.Context) (uids []keybase1.UID, e
 		}
 	}()
 
-	select {
-	case <-ctx.Done():
-		return nil, ErrCanceled
-	case <-time.After(pollWait):
-	}
-
 	var psb pubsubResponse
 	args := libkb.HTTPArgs{
 		"feed":            libkb.S{Val: "user.key_change"},
 		"last_sync_stamp": libkb.I{Val: u.lastSyncPoint},
 		"instance_id":     libkb.S{Val: u.instanceID},
+		"wait_for_msec":   libkb.I{Val: int(pollWait / time.Millisecond)},
 	}
 	err = u.api.GetDecode(libkb.APIArg{
-		Endpoint: "pubsub/poll",
-		Args:     args,
+		Endpoint:   "pubsub/poll",
+		Args:       args,
+		NetContext: ctx,
 	}, &psb)
 
 	if err != nil {

--- a/go/engine/context.go
+++ b/go/engine/context.go
@@ -57,6 +57,10 @@ func (c *Context) GetNetContext() context.Context {
 	return c.NetContext
 }
 
+func (c *Context) SetNetContext(netCtx context.Context) {
+	c.NetContext = netCtx
+}
+
 func (c *Context) SecretKeyPromptArg(ska libkb.SecretKeyArg, reason string) libkb.SecretKeyPromptArg {
 	return libkb.SecretKeyPromptArg{
 		LoginContext: c.LoginContext,

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -675,11 +675,11 @@ func (e *Identify2WithUID) runIdentifyPrecomputation() (err error) {
 	return nil
 }
 
-func (e *Identify2WithUID) displayUserCardAsync(iui libkb.IdentifyUI) <-chan error {
+func (e *Identify2WithUID) displayUserCardAsync(ctx context.Context, iui libkb.IdentifyUI) <-chan error {
 	if e.arg.IdentifyBehavior.WarningInsteadOfErrorOnBrokenTracks() {
 		return nil
 	}
-	return displayUserCardAsync(e.G(), iui, e.them.GetUID(), (e.me != nil))
+	return displayUserCardAsync(ctx, e.G(), iui, e.them.GetUID(), (e.me != nil))
 }
 
 func (e *Identify2WithUID) runIdentifyUI(ctx *Context) (err error) {
@@ -718,7 +718,7 @@ func (e *Identify2WithUID) runIdentifyUI(ctx *Context) (err error) {
 		return err
 	}
 
-	waiter := e.displayUserCardAsync(iui)
+	waiter := e.displayUserCardAsync(ctx.NetContext, iui)
 
 	e.G().Log.Debug("| IdentifyUI.Identify(%s)", e.them.GetName())
 	var them *libkb.User

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -718,7 +718,7 @@ func (e *Identify2WithUID) runIdentifyUI(ctx *Context) (err error) {
 		return err
 	}
 
-	waiter := e.displayUserCardAsync(ctx.NetContext, iui)
+	waiter := e.displayUserCardAsync(context.Background(), iui)
 
 	e.G().Log.Debug("| IdentifyUI.Identify(%s)", e.them.GetName())
 	var them *libkb.User

--- a/go/engine/user_card.go
+++ b/go/engine/user_card.go
@@ -6,6 +6,7 @@ package engine
 import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	context "golang.org/x/net/context"
 )
 
 type card struct {
@@ -29,29 +30,29 @@ func (c *card) GetAppStatus() *libkb.AppStatus {
 	return &c.Status
 }
 
-func getUserCard(g *libkb.GlobalContext, uid keybase1.UID, useSession bool) (ret *keybase1.UserCard, err error) {
-	defer g.Trace("getUserCard", func() error { return err })()
+func getUserCard(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID, useSession bool) (ret *keybase1.UserCard, err error) {
+	defer g.CTrace(ctx, "getUserCard", func() error { return err })()
 
 	cached, err := g.CardCache.Get(uid, useSession)
 	if err != nil {
-		g.Log.Debug("CardCache.Get error: %s", err)
+		g.Log.CDebugf(ctx, "CardCache.Get error: %s", err)
 	} else if cached != nil {
-		g.Log.Debug("CardCache.Get hit for %s", uid)
+		g.Log.CDebugf(ctx, "CardCache.Get hit for %s", uid)
 		return cached, nil
 	}
-	g.Log.Debug("CardCache.Get miss for %s", uid)
+	g.Log.CDebugf(ctx, "CardCache.Get miss for %s", uid)
 
 	arg := libkb.APIArg{
 		Endpoint:    "user/card",
 		NeedSession: useSession,
 		Args:        libkb.HTTPArgs{"uid": libkb.S{Val: uid.String()}},
-		NetContext:  g.NetContext,
+		NetContext:  ctx,
 	}
 
 	var card card
 
 	if err = g.API.GetDecode(arg, &card); err != nil {
-		g.Log.Warning("error getting user/card for %s: %s\n", uid, err)
+		g.Log.CWarningf(ctx, "error getting user/card for %s: %s\n", uid, err)
 		return nil, err
 	}
 
@@ -69,14 +70,14 @@ func getUserCard(g *libkb.GlobalContext, uid keybase1.UID, useSession bool) (ret
 	}
 
 	if err := g.CardCache.Set(ret, useSession); err != nil {
-		g.Log.Debug("CardCache.Set error: %s", err)
+		g.Log.CDebugf(ctx, "CardCache.Set error: %s", err)
 	}
 
 	return ret, nil
 }
 
-func displayUserCard(g *libkb.GlobalContext, iui libkb.IdentifyUI, uid keybase1.UID, useSession bool) error {
-	card, err := getUserCard(g, uid, useSession)
+func displayUserCard(ctx context.Context, g *libkb.GlobalContext, iui libkb.IdentifyUI, uid keybase1.UID, useSession bool) error {
+	card, err := getUserCard(ctx, g, uid, useSession)
 	if err != nil {
 		return err
 	}
@@ -87,10 +88,10 @@ func displayUserCard(g *libkb.GlobalContext, iui libkb.IdentifyUI, uid keybase1.
 	return iui.DisplayUserCard(*card)
 }
 
-func displayUserCardAsync(g *libkb.GlobalContext, iui libkb.IdentifyUI, uid keybase1.UID, useSession bool) <-chan error {
+func displayUserCardAsync(ctx context.Context, g *libkb.GlobalContext, iui libkb.IdentifyUI, uid keybase1.UID, useSession bool) <-chan error {
 	ch := make(chan error)
 	go func() {
-		ch <- displayUserCard(g, iui, uid, useSession)
+		ch <- displayUserCard(ctx, g, iui, uid, useSession)
 	}()
 	return ch
 }

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -220,7 +220,6 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 	ctx := arg.NetContext
 	if ctx == nil {
 		ctx = context.Background()
-		api.G().Log.CDebugf(ctx, "made a new one!")
 	}
 	ctx = WithLogTag(ctx, "API")
 	api.G().Log.CDebugf(ctx, "+ API %s %s", req.Method, req.URL)

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -238,7 +238,7 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 	}
 
 	timer := api.G().Timers.Start(timerType)
-	internalResp, err := doRetry(api, arg, cli, req)
+	internalResp, err := doRetry(ctx, api, arg, cli, req)
 
 	defer func() {
 		if internalResp != nil && err != nil {
@@ -293,11 +293,7 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 // doRetry will just call cli.cli.Do if arg.Timeout and arg.RetryCount aren't set.
 // If they are set, it will cancel requests that last longer than arg.Timeout and
 // retry them arg.RetryCount times.
-func doRetry(g Contextifier, arg APIArg, cli *Client, req *http.Request) (*http.Response, error) {
-	ctx := arg.NetContext
-	if ctx == nil {
-		ctx = context.Background()
-	}
+func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *http.Request) (*http.Response, error) {
 
 	if arg.InitialTimeout == 0 && arg.RetryCount == 0 {
 		return ctxhttp.Do(ctx, cli.cli, req)

--- a/go/libkb/net_context.go
+++ b/go/libkb/net_context.go
@@ -49,3 +49,17 @@ func LogTagsToString(ctx context.Context) string {
 	}
 	return strings.Join(out, ",")
 }
+
+func CopyTagsToBackground(ctx context.Context) context.Context {
+	ret := context.Background()
+	if tags, ok := logger.LogTagsFromContext(ctx); ok {
+		for key, _ := range tags {
+			if ctxKey, ok := key.(withLogTagKey); ok {
+				if val, ok := ctx.Value(ctxKey).(string); ok {
+					ret = context.WithValue(ret, ctxKey, val)
+				}
+			}
+		}
+	}
+	return ret
+}

--- a/go/libkb/net_context.go
+++ b/go/libkb/net_context.go
@@ -53,9 +53,10 @@ func LogTagsToString(ctx context.Context) string {
 func CopyTagsToBackground(ctx context.Context) context.Context {
 	ret := context.Background()
 	if tags, ok := logger.LogTagsFromContext(ctx); ok {
+		ctx = logger.NewContextWithLogTags(ctx, tags)
 		for key, _ := range tags {
 			if ctxKey, ok := key.(withLogTagKey); ok {
-				if val, ok := ctx.Value(ctxKey).(string); ok {
+				if val, ok := ctx.Value(ctxKey).(string); ok && len(val) > 0 {
 					ret = context.WithValue(ret, ctxKey, val)
 				}
 			}

--- a/go/vendor/golang.org/x/net/context/ctxhttp/ctxhttp.go
+++ b/go/vendor/golang.org/x/net/context/ctxhttp/ctxhttp.go
@@ -1,0 +1,74 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.7
+
+// Package ctxhttp provides helper functions for performing context-aware HTTP requests.
+package ctxhttp // import "golang.org/x/net/context/ctxhttp"
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
+)
+
+// Do sends an HTTP request with the provided http.Client and returns
+// an HTTP response.
+//
+// If the client is nil, http.DefaultClient is used.
+//
+// The provided ctx must be non-nil. If it is canceled or times out,
+// ctx.Err() will be returned.
+func Do(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req.WithContext(ctx))
+	// If we got an error, and the context has been canceled,
+	// the context's error is probably more useful.
+	if err != nil {
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+		default:
+		}
+	}
+	return resp, err
+}
+
+// Get issues a GET request via the Do function.
+func Get(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return Do(ctx, client, req)
+}
+
+// Head issues a HEAD request via the Do function.
+func Head(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return Do(ctx, client, req)
+}
+
+// Post issues a POST request via the Do function.
+func Post(ctx context.Context, client *http.Client, url string, bodyType string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", bodyType)
+	return Do(ctx, client, req)
+}
+
+// PostForm issues a POST request via the Do function.
+func PostForm(ctx context.Context, client *http.Client, url string, data url.Values) (*http.Response, error) {
+	return Post(ctx, client, url, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+}

--- a/go/vendor/golang.org/x/net/context/ctxhttp/ctxhttp_pre17.go
+++ b/go/vendor/golang.org/x/net/context/ctxhttp/ctxhttp_pre17.go
@@ -1,0 +1,147 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.7
+
+package ctxhttp // import "golang.org/x/net/context/ctxhttp"
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
+)
+
+func nop() {}
+
+var (
+	testHookContextDoneBeforeHeaders = nop
+	testHookDoReturned               = nop
+	testHookDidBodyClose             = nop
+)
+
+// Do sends an HTTP request with the provided http.Client and returns an HTTP response.
+// If the client is nil, http.DefaultClient is used.
+// If the context is canceled or times out, ctx.Err() will be returned.
+func Do(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	// TODO(djd): Respect any existing value of req.Cancel.
+	cancel := make(chan struct{})
+	req.Cancel = cancel
+
+	type responseAndError struct {
+		resp *http.Response
+		err  error
+	}
+	result := make(chan responseAndError, 1)
+
+	// Make local copies of test hooks closed over by goroutines below.
+	// Prevents data races in tests.
+	testHookDoReturned := testHookDoReturned
+	testHookDidBodyClose := testHookDidBodyClose
+
+	go func() {
+		resp, err := client.Do(req)
+		testHookDoReturned()
+		result <- responseAndError{resp, err}
+	}()
+
+	var resp *http.Response
+
+	select {
+	case <-ctx.Done():
+		testHookContextDoneBeforeHeaders()
+		close(cancel)
+		// Clean up after the goroutine calling client.Do:
+		go func() {
+			if r := <-result; r.resp != nil {
+				testHookDidBodyClose()
+				r.resp.Body.Close()
+			}
+		}()
+		return nil, ctx.Err()
+	case r := <-result:
+		var err error
+		resp, err = r.resp, r.err
+		if err != nil {
+			return resp, err
+		}
+	}
+
+	c := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			close(cancel)
+		case <-c:
+			// The response's Body is closed.
+		}
+	}()
+	resp.Body = &notifyingReader{resp.Body, c}
+
+	return resp, nil
+}
+
+// Get issues a GET request via the Do function.
+func Get(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return Do(ctx, client, req)
+}
+
+// Head issues a HEAD request via the Do function.
+func Head(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return Do(ctx, client, req)
+}
+
+// Post issues a POST request via the Do function.
+func Post(ctx context.Context, client *http.Client, url string, bodyType string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", bodyType)
+	return Do(ctx, client, req)
+}
+
+// PostForm issues a POST request via the Do function.
+func PostForm(ctx context.Context, client *http.Client, url string, data url.Values) (*http.Response, error) {
+	return Post(ctx, client, url, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+}
+
+// notifyingReader is an io.ReadCloser that closes the notify channel after
+// Close is called or a Read fails on the underlying ReadCloser.
+type notifyingReader struct {
+	io.ReadCloser
+	notify chan<- struct{}
+}
+
+func (r *notifyingReader) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	if err != nil && r.notify != nil {
+		close(r.notify)
+		r.notify = nil
+	}
+	return n, err
+}
+
+func (r *notifyingReader) Close() error {
+	err := r.ReadCloser.Close()
+	if r.notify != nil {
+		close(r.notify)
+		r.notify = nil
+	}
+	return err
+}

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -668,6 +668,12 @@
 			"revisionTime": "2016-06-20T16:30:30-04:00"
 		},
 		{
+			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
+			"path": "golang.org/x/net/context/ctxhttp",
+			"revision": "a6577fac2d73be281a500b310739095313165611",
+			"revisionTime": "2017-03-08T20:54:49Z"
+		},
+		{
 			"path": "golang.org/x/net/html",
 			"revision": "dfcbca9c45aeabb8971affa4f76b2d40f6f72328",
 			"revisionTime": "2015-06-09T11:52:15-07:00"


### PR DESCRIPTION
- use net/Context in our API HTTP library
- fix API interface implemention of the CA to use long-polling
 - this should speed up the timeout before the CA realizes that there's a change the user to about ~250ms