### PR TITLE
Use the snippet message's timestamp for the inbox

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -323,9 +323,11 @@ function _inboxConversationToInboxState (convo: ?ConversationLocal): ?InboxState
 
   const conversationIDKey = conversationIDToKey(convo.info.id)
   let snippet
+  let time
 
   (convo.maxMessages || []).some(message => {
-    if (message.state === LocalMessageUnboxedState.valid && message.valid) {
+    if (message.state === LocalMessageUnboxedState.valid && message.valid && convo && convo.readerInfo) {
+      time = message.valid.serverHeader.ctime || convo.readerInfo.mtime
       snippet = makeSnippet(message.valid.messageBody)
       return !!snippet
     }
@@ -341,7 +343,7 @@ function _inboxConversationToInboxState (convo: ?ConversationLocal): ?InboxState
     conversationIDKey,
     participants,
     muted,
-    time: convo.readerInfo.mtime,
+    time,
     snippet,
     validated: true,
   })


### PR DESCRIPTION
@keybase/react-hackers 

Before this PR, we used `convo.readerInfo.mtime` to back the timestamp in the inbox.  But that's actually an *mtime-and-atime* -- it's updated when a conversation is *read*, not just written to.  So anytime you clicked on a conversation to read an unread message in it, you automatically moved it to the top of the inbox.

This PR takes the message we were already using for the conversation's snippet, and just uses its timestamp -- now the message you click on doesn't move in the inbox as a result of your click.

For the unverified conversation cases, we still use the mtime as before.