### PR TITLE
Revert "Add mobile route support for fullscreen views"

### DIFF
--- a/shared/chat/routes.native.js
+++ b/shared/chat/routes.native.js
@@ -11,7 +11,7 @@ const conversationRoute = new RouteDefNode({
   children: {
     attachment: {
       component: AttachmentPopup,
-      tags: {hideStatusBar: true, fullscreen: true},
+      tags: {hideStatusBar: true},
       children: {},
     },
     attachmentInput: {

--- a/shared/nav.native.js
+++ b/shared/nav.native.js
@@ -25,30 +25,28 @@ const StackWrapper = ({children}) => {
   }
 }
 
-function stackToNavigationState (stack) {
-  return {
-    index: stack.size - 1,
-    routes: stack.map(r => ({
+function Nav (props: Props) {
+  const visibleScreens = props.routeStack.filter(r => !r.tags.layerOnTop)
+  if (!visibleScreens.size) {
+    throw new Error('no route component to render without layerOnTop tag')
+  }
+  const navigationState = {
+    index: visibleScreens.size - 1,
+    routes: visibleScreens.map(r => ({
       component: r.component,
       key: r.path.join('/'),
       tags: r.tags,
     })).toArray(),
   }
-}
-
-function MainNavStack (props: Props) {
-  const baseScreens = props.routeStack.filter(r => !r.tags.layerOnTop)
-  if (!baseScreens.size) {
-    throw new Error('no route component to render without layerOnTop tag')
-  }
   const layerScreens = props.routeStack.filter(r => r.tags.layerOnTop)
+
   return (
     <Box style={flexOne}>
       <StackWrapper>
         <Box style={flexColumnOne}>
           <NavigationCardStack
-            key={props.routeSelected}  // don't transition when switching tabs
-            navigationState={stackToNavigationState(baseScreens)}
+            key={props.routeSelected}
+            navigationState={navigationState}
             renderScene={({scene}) => {
               return (
                 <Box style={scene.route.tags.underStatusBar ? sceneWrapStyleUnder : sceneWrapStyleOver}>
@@ -61,44 +59,20 @@ function MainNavStack (props: Props) {
           />
           {layerScreens.map(r => r.leafComponent)}
         </Box>
-        {!props.hideNav && !baseScreens.last().tags.fullscreen &&
-          <TabBar
-            onTabClick={props.switchTab}
-            selectedTab={props.routeSelected}
-            username={props.username}
-            badgeNumbers={{
-              [chatTab]: props.chatBadge,
-              [folderTab]: props.folderBadge,
-            }}
-          />
-        }
-        <GlobalError />
       </StackWrapper>
+      {!props.hideNav &&
+        <TabBar
+          onTabClick={props.switchTab}
+          selectedTab={props.routeSelected}
+          username={props.username}
+          badgeNumbers={{
+            [chatTab]: props.chatBadge,
+            [folderTab]: props.folderBadge,
+          }}
+        />
+      }
+      <GlobalError />
     </Box>
-  )
-}
-
-function Nav (props: Props) {
-  const mainScreens = props.routeStack.filter(r => !r.tags.fullscreen)
-  const fullScreens = props.routeStack.filter(r => r.tags.fullscreen)
-    .unshift({
-      path: ['main'],
-      component: <MainNavStack {...props} routeStack={mainScreens} />,
-      tags: {},
-    })
-
-  return (
-    <NavigationCardStack
-      navigationState={stackToNavigationState(fullScreens)}
-      renderScene={({scene}) => {
-        return (
-          <Box style={globalStyles.fillAbsolute}>
-            {scene.route.component}
-          </Box>
-        )
-      }}
-      enableGestures={false}
-    />
   )
 }
 

--- a/shared/route-tree/index.js
+++ b/shared/route-tree/index.js
@@ -10,7 +10,6 @@ type LeafTagsParams = {
   layerOnTop: boolean,
   underStatusBar: boolean,
   hideStatusBar: boolean,
-  fullscreen: boolean,
 }
 
 export const LeafTags: (spec?: LeafTagsParams) => LeafTagsParams & I.Record<LeafTagsParams> = I.Record({
@@ -19,7 +18,6 @@ export const LeafTags: (spec?: LeafTagsParams) => LeafTagsParams & I.Record<Leaf
   layerOnTop: false,
   underStatusBar: false,
   hideStatusBar: false,
-  fullscreen: false,
 })
 
 const _RouteDefNode = I.Record({


### PR DESCRIPTION
@keybase/react-hackers This reverts commit e6a885f6152938b134c5e82e0c8c473a4b0b7ec4, which crashes ("StackWrapper component returned null") on startup on Android.

We could wait to merge this until there's a real fix instead, am sharing what I had to do to get a dev environment working again.