### PR TITLE
Fix native Text eating onPress events

### DIFF
--- a/shared/common-adapters/text.native.js
+++ b/shared/common-adapters/text.native.js
@@ -29,7 +29,7 @@ class Text extends Component<void, Props, void> {
       ref={ref => { this._nativeText = ref }}
       style={style}
       {...lineClamp(this.props.lineClamp)}
-      onPress={this.props.onClick || (this.props.onClickURL && this._urlClick)}>{this.props.children}</NativeText>
+      onPress={this.props.onClick || (this.props.onClickURL ? this._urlClick : undefined)}>{this.props.children}</NativeText>
   }
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

We were always providing an `onPress` handler to our native text component -- in the case where the user doesn't supply an `onClick` to `<Text />`, we end up passing through `onPress=null` instead of having no `onPress` handler at all.

(This fixes the global error close cross not doing anything on mobile.)