### PR TITLE
Disable sudden termination plist flag

### DIFF
--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -185,7 +185,6 @@ update_plist() {(
   cd "$out_dir"
   # App shouldn't display dock icon on startup
   /usr/libexec/plistBuddy -c "Add :LSUIElement bool true" "$app_name.app/Contents/Info.plist"
-  /usr/libexec/plistBuddy -c "Add :NSSupportsSuddenTermination bool true" "$app_name.app/Contents/Info.plist"
 )}
 
 sign() {(


### PR DESCRIPTION
We don't really support sudden termination since we need to remove the mount dir on quit (the dir was being left behind on restarts).

This isn't a huge deal to support and the apps exits pretty fast so shouldn't have any negative impact.