### PR TITLE
Include conversationId in attachment preview filenames

### DIFF
--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -200,7 +200,7 @@ const _pendingFailureSelector = (state: TypedState, outboxID: OutboxIDKey) => st
 const _devicenameSelector = (state: TypedState) => state.config && state.config.extendedConfig && state.config.extendedConfig.device && state.config.extendedConfig.device.name
 
 function _tmpFileName (isHdPreview: boolean, conversationID: ConversationIDKey, messageID: ?MessageID, filename: string) {
-  return `kbchat-${isHdPreview ? 'hdPreview' : 'preview'}-${messageID || ''}-${filename}`
+  return `kbchat-${isHdPreview ? 'hdPreview' : 'preview'}-${conversationID}-${messageID || ''}-${filename}`
 }
 
 function _pendingToRealConversation (oldKey: ConversationIDKey, newKey: ConversationIDKey): PendingToRealConversation {


### PR DESCRIPTION
This should prevent a colliding messageId + filename from conflicting.

:eyeglasses: @keybase/react-hackers 