### PR TITLE
Hide Android background image after 3s

### DIFF
--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.view.Window;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactInstanceManager;
@@ -41,6 +42,18 @@ public class MainActivity extends ReactActivity {
         initOnce(this.getFilesDir().getPath(), logFile.getAbsolutePath(), "prod", false);
 
         super.onCreate(savedInstanceState);
+
+        // Hide splash screen background after 3s.
+        // This prevents the image from being visible behind the app, such as during a
+        // keyboard show animation.
+        final Window mainWindow = this.getWindow();
+        new android.os.Handler().postDelayed(
+            new Runnable() {
+                public void run() {
+                    mainWindow.setBackgroundDrawableResource(R.color.white);
+                }
+            },
+        3000);
     }
 
     @Override


### PR DESCRIPTION
I tried setting a background color on the top level react view, but the problem is that during keyboard shows the react view resizes before the keyboard arrives into place, making the main window background visible for a split second.

This change removes the image after a 3 second delay from startup. I looked into hooking into when the React view finished loading, but it seemed not worth the effort.

:eyeglasses: @keybase/react-hackers 