### PR TITLE
Re-use existing paperkey entry route on error

### DIFF
--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -16,7 +16,7 @@ import {loginRecoverAccountFromEmailAddressRpc, loginLoginRpc, loginLogoutRpc,
   PassphraseCommonPassphraseType,
   loginLoginProvisionedDeviceRpc,
 } from '../../constants/types/flow-types'
-import {navigateTo, navigateAppend} from '../route-tree'
+import {pathSelector, navigateTo, navigateAppend} from '../route-tree'
 import {overrideLoggedInTab} from '../../local-debug'
 
 import type {DeviceRole} from '../../constants/login'
@@ -503,14 +503,20 @@ function makeKex2IncomingMap (dispatch, getState, onBack: SimpleCB, onProvisione
     'keybase.1.secretUi.getPassphrase': ({pinentry: {type, prompt, username, retryLabel}}, response) => {
       switch (type) {
         case PassphraseCommonPassphraseType.paperKey:
-          dispatch(navigateAppend([{
+          const destination = {
             props: {
               error: retryLabel,
               onBack: () => onBack(response),
               onSubmit: (passphrase: string) => { response.result({passphrase, storeSecret: false}) },
             },
             selected: 'paperkey',
-          }], [loginTab, 'login']))
+          }
+          const currentPath = pathSelector(getState())
+          if (currentPath.last() === 'paperkey') {
+            dispatch(navigateTo(currentPath.pop(1).push(destination)))
+          } else {
+            dispatch(navigateAppend([destination], [loginTab, 'login']))
+          }
           break
         case PassphraseCommonPassphraseType.passPhrase:
           dispatch(navigateAppend([{

--- a/shared/actions/route-tree.js
+++ b/shared/actions/route-tree.js
@@ -1,6 +1,6 @@
 // @flow
 import * as Constants from '../constants/route-tree'
-import * as Immutable from 'immutable'
+import * as I from 'immutable'
 import {getPath} from '../route-tree'
 import {put, select} from 'redux-saga/effects'
 import {safeTakeEvery} from '../util/saga'
@@ -32,7 +32,7 @@ const pathActionTransformer = (action, oldState) => {
   }
 }
 
-export function pathSelector (state: TypedState): Path {
+export function pathSelector (state: TypedState): I.List<string> {
   return getPath(state.routeTree.routeState)
 }
 
@@ -132,7 +132,7 @@ export function resetRoute (path: Path): ResetRoute {
 
 function * _putActionIfOnPath ({payload: {otherAction, expectedPath}}: Constants.PutActionIfOnPath<*>) {
   const currentPath = yield select(pathSelector)
-  if (Immutable.is(expectedPath, currentPath)) {
+  if (I.is(expectedPath, currentPath)) {
     yield put(otherAction)
   }
 }

--- a/shared/actions/route-tree.js
+++ b/shared/actions/route-tree.js
@@ -32,7 +32,7 @@ const pathActionTransformer = (action, oldState) => {
   }
 }
 
-function _pathSelector (state: TypedState): Path {
+export function pathSelector (state: TypedState): Path {
   return getPath(state.routeTree.routeState)
 }
 
@@ -131,7 +131,7 @@ export function resetRoute (path: Path): ResetRoute {
 }
 
 function * _putActionIfOnPath ({payload: {otherAction, expectedPath}}: Constants.PutActionIfOnPath<*>) {
-  const currentPath = yield select(_pathSelector)
+  const currentPath = yield select(pathSelector)
   if (Immutable.is(expectedPath, currentPath)) {
     yield put(otherAction)
   }


### PR DESCRIPTION
This prevents us from appending a new screen which blanks out the
paperkey input state. Helpfully, navigating to the same route with
different props retains the same view and updates it, keeping the
uncontrolled paperkey input state.

:eyeglasses: @keybase/react-hackers 