### PR TITLE
use new SyncInbox RPC during reconnect CORE-4592

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -214,6 +214,10 @@ func (f failingRemote) PublishSetConversationStatus(context.Context, chat1.Publi
 	require.Fail(f.t, "PublicSetConversationStatus call")
 	return nil
 }
+func (f failingRemote) SyncInbox(ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
+	require.Fail(f.t, "SyncInbox")
+	return chat1.SyncInboxRes{}, nil
+}
 
 type failingTlf struct {
 	t *testing.T

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -569,7 +569,7 @@ func (s *HybridInboxSource) handleInboxError(ctx context.Context, err storage.Er
 	if verr, ok := err.(storage.VersionMismatchError); ok {
 		s.Debug(ctx, "handleInboxError: version mismatch, sending stale notifications: %s",
 			verr.Error())
-		s.syncer.SendChatStaleNotifications(uid)
+		s.syncer.SendChatStaleNotifications(uid, nil)
 		return nil
 	}
 	return err

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -119,8 +119,7 @@ func (g *PushHandler) TlfResolve(ctx context.Context, m gregor.OutOfBandMessage)
 func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, badger *badges.Badger) (err error) {
 	defer g.Trace(ctx, func() error { return err }, "Activity")()
 	if m.Body() == nil {
-		err = errors.New("gregor handler for chat.activity: nil message body")
-		return err
+		return errors.New("gregor handler for chat.activity: nil message body")
 	}
 
 	var activity chat1.ChatActivity
@@ -274,8 +273,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 		}
 		if len(inbox.Convs) != 1 {
 			g.Debug(ctx, "chat activity: unable to find conversation")
-			err = fmt.Errorf("unable to find conversation")
-			return err
+			return fmt.Errorf("unable to find conversation")
 		}
 		updateConv := inbox.ConvsUnverified[0]
 		if err = g.G().InboxSource.NewConversation(ctx, uid, nm.InboxVers, updateConv); err != nil {
@@ -290,12 +288,10 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 			badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
 		}
 	default:
-		err = fmt.Errorf("unhandled chat.activity action %q", action)
-		return err
+		return fmt.Errorf("unhandled chat.activity action %q", action)
 	}
 
-	err = g.notifyNewChatActivity(ctx, m.UID(), &activity)
-	return err
+	return g.notifyNewChatActivity(ctx, m.UID(), &activity)
 }
 
 func (g *PushHandler) notifyNewChatActivity(ctx context.Context, uid gregor.UID, activity *chat1.ChatActivity) error {

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -40,6 +40,7 @@ func (s *Syncer) SendChatStaleNotifications(uid gregor1.UID, convs []chat1.Conve
 }
 
 func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID) (err error) {
+	ctx = CtxAddLogTags(ctx)
 	s.Debug(ctx, "Connected: running")
 
 	// Let the Offlinables know that we are back online
@@ -60,7 +61,6 @@ func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid g
 	s.Debug(ctx, "Connected: current inbox version: %v", vers)
 
 	// Run the sync call on the server to see how current our local copy is
-	ctx = CtxAddLogTags(ctx)
 	if syncRes, err = cli.SyncInbox(ctx, vers); err != nil {
 		s.Debug(ctx, "Connected: failed to sync inbox: %s", err.Error())
 		return err

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -510,6 +510,10 @@ func (m *ChatRemoteMock) GetInboxVersion(ctx context.Context, uid gregor1.UID) (
 	return 1, nil
 }
 
+func (m *ChatRemoteMock) SyncInbox(ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
+	return chat1.SyncInboxRes{}, nil
+}
+
 type convByNewlyUpdated struct {
 	mock *ChatRemoteMock
 }

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -158,6 +158,7 @@ type GetInboxQuery struct {
 	After             *gregor1.Time        `codec:"after,omitempty" json:"after,omitempty"`
 	OneChatTypePerTLF *bool                `codec:"oneChatTypePerTLF,omitempty" json:"oneChatTypePerTLF,omitempty"`
 	Status            []ConversationStatus `codec:"status" json:"status"`
+	ConvIDs           []ConversationID     `codec:"convIDs" json:"convIDs"`
 	UnreadOnly        bool                 `codec:"unreadOnly" json:"unreadOnly"`
 	ReadOnly          bool                 `codec:"readOnly" json:"readOnly"`
 	ComputeActiveList bool                 `codec:"computeActiveList" json:"computeActiveList"`

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -4,6 +4,7 @@
 package chat1
 
 import (
+	"errors"
 	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
@@ -115,6 +116,83 @@ type S3Params struct {
 	RegionBucketEndpoint string `codec:"regionBucketEndpoint" json:"regionBucketEndpoint"`
 }
 
+type SyncInboxResType int
+
+const (
+	SyncInboxResType_CURRENT     SyncInboxResType = 0
+	SyncInboxResType_INCREMENTAL SyncInboxResType = 1
+	SyncInboxResType_CLEAR       SyncInboxResType = 2
+)
+
+var SyncInboxResTypeMap = map[string]SyncInboxResType{
+	"CURRENT":     0,
+	"INCREMENTAL": 1,
+	"CLEAR":       2,
+}
+
+var SyncInboxResTypeRevMap = map[SyncInboxResType]string{
+	0: "CURRENT",
+	1: "INCREMENTAL",
+	2: "CLEAR",
+}
+
+func (e SyncInboxResType) String() string {
+	if v, ok := SyncInboxResTypeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type SyncIncrementalRes struct {
+	Vers  InboxVers      `codec:"vers" json:"vers"`
+	Convs []Conversation `codec:"convs" json:"convs"`
+}
+
+type SyncInboxRes struct {
+	Typ__         SyncInboxResType    `codec:"typ" json:"typ"`
+	Incremental__ *SyncIncrementalRes `codec:"incremental,omitempty" json:"incremental,omitempty"`
+}
+
+func (o *SyncInboxRes) Typ() (ret SyncInboxResType, err error) {
+	switch o.Typ__ {
+	case SyncInboxResType_INCREMENTAL:
+		if o.Incremental__ == nil {
+			err = errors.New("unexpected nil value for Incremental__")
+			return ret, err
+		}
+	}
+	return o.Typ__, nil
+}
+
+func (o SyncInboxRes) Incremental() SyncIncrementalRes {
+	if o.Typ__ != SyncInboxResType_INCREMENTAL {
+		panic("wrong case accessed")
+	}
+	if o.Incremental__ == nil {
+		return SyncIncrementalRes{}
+	}
+	return *o.Incremental__
+}
+
+func NewSyncInboxResWithCurrent() SyncInboxRes {
+	return SyncInboxRes{
+		Typ__: SyncInboxResType_CURRENT,
+	}
+}
+
+func NewSyncInboxResWithIncremental(v SyncIncrementalRes) SyncInboxRes {
+	return SyncInboxRes{
+		Typ__:         SyncInboxResType_INCREMENTAL,
+		Incremental__: &v,
+	}
+}
+
+func NewSyncInboxResWithClear() SyncInboxRes {
+	return SyncInboxRes{
+		Typ__: SyncInboxResType_CLEAR,
+	}
+}
+
 type GetInboxRemoteArg struct {
 	Vers       InboxVers      `codec:"vers" json:"vers"`
 	Query      *GetInboxQuery `codec:"query,omitempty" json:"query,omitempty"`
@@ -179,6 +257,10 @@ type GetInboxVersionArg struct {
 	Uid gregor1.UID `codec:"uid" json:"uid"`
 }
 
+type SyncInboxArg struct {
+	Vers InboxVers `codec:"vers" json:"vers"`
+}
+
 type TlfFinalizeArg struct {
 	TlfID          TLFID        `codec:"tlfID" json:"tlfID"`
 	ResetUser      string       `codec:"resetUser" json:"resetUser"`
@@ -219,6 +301,7 @@ type RemoteInterface interface {
 	GetS3Params(context.Context, ConversationID) (S3Params, error)
 	S3Sign(context.Context, S3SignArg) ([]byte, error)
 	GetInboxVersion(context.Context, gregor1.UID) (InboxVers, error)
+	SyncInbox(context.Context, InboxVers) (SyncInboxRes, error)
 	TlfFinalize(context.Context, TlfFinalizeArg) error
 	TlfResolve(context.Context, TlfResolveArg) error
 	PublishReadMessage(context.Context, PublishReadMessageArg) error
@@ -437,6 +520,22 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"syncInbox": {
+				MakeArg: func() interface{} {
+					ret := make([]SyncInboxArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]SyncInboxArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]SyncInboxArg)(nil), args)
+						return
+					}
+					ret, err = i.SyncInbox(ctx, (*typedArgs)[0].Vers)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 			"tlfFinalize": {
 				MakeArg: func() interface{} {
 					ret := make([]TlfFinalizeArg, 1)
@@ -575,6 +674,12 @@ func (c RemoteClient) S3Sign(ctx context.Context, __arg S3SignArg) (res []byte, 
 func (c RemoteClient) GetInboxVersion(ctx context.Context, uid gregor1.UID) (res InboxVers, err error) {
 	__arg := GetInboxVersionArg{Uid: uid}
 	err = c.Cli.Call(ctx, "chat.1.remote.getInboxVersion", []interface{}{__arg}, &res)
+	return
+}
+
+func (c RemoteClient) SyncInbox(ctx context.Context, vers InboxVers) (res SyncInboxRes, err error) {
+	__arg := SyncInboxArg{Vers: vers}
+	err = c.Cli.Call(ctx, "chat.1.remote.syncInbox", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -150,40 +150,18 @@ type SyncIncrementalRes struct {
 
 type SyncInboxRes struct {
 	Typ__         SyncInboxResType    `codec:"typ" json:"typ"`
-	Current__     *InboxVers          `codec:"current,omitempty" json:"current,omitempty"`
 	Incremental__ *SyncIncrementalRes `codec:"incremental,omitempty" json:"incremental,omitempty"`
-	Clear__       *InboxVers          `codec:"clear,omitempty" json:"clear,omitempty"`
 }
 
 func (o *SyncInboxRes) Typ() (ret SyncInboxResType, err error) {
 	switch o.Typ__ {
-	case SyncInboxResType_CURRENT:
-		if o.Current__ == nil {
-			err = errors.New("unexpected nil value for Current__")
-			return ret, err
-		}
 	case SyncInboxResType_INCREMENTAL:
 		if o.Incremental__ == nil {
 			err = errors.New("unexpected nil value for Incremental__")
 			return ret, err
 		}
-	case SyncInboxResType_CLEAR:
-		if o.Clear__ == nil {
-			err = errors.New("unexpected nil value for Clear__")
-			return ret, err
-		}
 	}
 	return o.Typ__, nil
-}
-
-func (o SyncInboxRes) Current() InboxVers {
-	if o.Typ__ != SyncInboxResType_CURRENT {
-		panic("wrong case accessed")
-	}
-	if o.Current__ == nil {
-		return InboxVers{}
-	}
-	return *o.Current__
 }
 
 func (o SyncInboxRes) Incremental() SyncIncrementalRes {
@@ -196,20 +174,9 @@ func (o SyncInboxRes) Incremental() SyncIncrementalRes {
 	return *o.Incremental__
 }
 
-func (o SyncInboxRes) Clear() InboxVers {
-	if o.Typ__ != SyncInboxResType_CLEAR {
-		panic("wrong case accessed")
-	}
-	if o.Clear__ == nil {
-		return InboxVers{}
-	}
-	return *o.Clear__
-}
-
-func NewSyncInboxResWithCurrent(v InboxVers) SyncInboxRes {
+func NewSyncInboxResWithCurrent() SyncInboxRes {
 	return SyncInboxRes{
-		Typ__:     SyncInboxResType_CURRENT,
-		Current__: &v,
+		Typ__: SyncInboxResType_CURRENT,
 	}
 }
 
@@ -220,10 +187,9 @@ func NewSyncInboxResWithIncremental(v SyncIncrementalRes) SyncInboxRes {
 	}
 }
 
-func NewSyncInboxResWithClear(v InboxVers) SyncInboxRes {
+func NewSyncInboxResWithClear() SyncInboxRes {
 	return SyncInboxRes{
-		Typ__:   SyncInboxResType_CLEAR,
-		Clear__: &v,
+		Typ__: SyncInboxResType_CLEAR,
 	}
 }
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -150,18 +150,40 @@ type SyncIncrementalRes struct {
 
 type SyncInboxRes struct {
 	Typ__         SyncInboxResType    `codec:"typ" json:"typ"`
+	Current__     *InboxVers          `codec:"current,omitempty" json:"current,omitempty"`
 	Incremental__ *SyncIncrementalRes `codec:"incremental,omitempty" json:"incremental,omitempty"`
+	Clear__       *InboxVers          `codec:"clear,omitempty" json:"clear,omitempty"`
 }
 
 func (o *SyncInboxRes) Typ() (ret SyncInboxResType, err error) {
 	switch o.Typ__ {
+	case SyncInboxResType_CURRENT:
+		if o.Current__ == nil {
+			err = errors.New("unexpected nil value for Current__")
+			return ret, err
+		}
 	case SyncInboxResType_INCREMENTAL:
 		if o.Incremental__ == nil {
 			err = errors.New("unexpected nil value for Incremental__")
 			return ret, err
 		}
+	case SyncInboxResType_CLEAR:
+		if o.Clear__ == nil {
+			err = errors.New("unexpected nil value for Clear__")
+			return ret, err
+		}
 	}
 	return o.Typ__, nil
+}
+
+func (o SyncInboxRes) Current() InboxVers {
+	if o.Typ__ != SyncInboxResType_CURRENT {
+		panic("wrong case accessed")
+	}
+	if o.Current__ == nil {
+		return InboxVers{}
+	}
+	return *o.Current__
 }
 
 func (o SyncInboxRes) Incremental() SyncIncrementalRes {
@@ -174,9 +196,20 @@ func (o SyncInboxRes) Incremental() SyncIncrementalRes {
 	return *o.Incremental__
 }
 
-func NewSyncInboxResWithCurrent() SyncInboxRes {
+func (o SyncInboxRes) Clear() InboxVers {
+	if o.Typ__ != SyncInboxResType_CLEAR {
+		panic("wrong case accessed")
+	}
+	if o.Clear__ == nil {
+		return InboxVers{}
+	}
+	return *o.Clear__
+}
+
+func NewSyncInboxResWithCurrent(v InboxVers) SyncInboxRes {
 	return SyncInboxRes{
-		Typ__: SyncInboxResType_CURRENT,
+		Typ__:     SyncInboxResType_CURRENT,
+		Current__: &v,
 	}
 }
 
@@ -187,9 +220,10 @@ func NewSyncInboxResWithIncremental(v SyncIncrementalRes) SyncInboxRes {
 	}
 }
 
-func NewSyncInboxResWithClear() SyncInboxRes {
+func NewSyncInboxResWithClear(v InboxVers) SyncInboxRes {
 	return SyncInboxRes{
-		Typ__: SyncInboxResType_CLEAR,
+		Typ__:   SyncInboxResType_CLEAR,
+		Clear__: &v,
 	}
 }
 

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -88,6 +88,10 @@ protocol common {
     // If left empty, default is to show unfiled and favorite
     array<ConversationStatus> status;
 
+    // Extended list of conversation IDs to fetch (don't need to set convID, if convID is set then 
+    // this it will be like appending it to this list)
+    array<ConversationID> convIDs;
+
     boolean unreadOnly;
     boolean readOnly;
     boolean computeActiveList;

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -147,6 +147,26 @@ protocol remote {
   // Get the inbox version for a user
   InboxVers getInboxVersion(gregor1.UID uid); 
 
+  enum SyncInboxResType {
+    CURRENT_0,
+    INCREMENTAL_1,
+    CLEAR_2
+  }
+  
+  record SyncIncrementalRes {
+    InboxVers vers;
+    array<Conversation> convs;
+  } 
+
+  variant SyncInboxRes switch (SyncInboxResType typ) {
+    case CURRENT: InboxVers;
+    case INCREMENTAL: SyncIncrementalRes;
+    case CLEAR: InboxVers;
+  }
+
+  // Sync down the inbox given a current version
+  SyncInboxRes syncInbox(InboxVers vers);
+
   // tlfFinalize is an endpoint for kbfstlfd to notify Gregor that a TLF ID has been finalized.
   // Gregor keeps an internal record of these TLF IDs, so that it can always return the latest
   // conversation per TLF ID on GetInboxRemote.

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -159,9 +159,9 @@ protocol remote {
   } 
 
   variant SyncInboxRes switch (SyncInboxResType typ) {
-    case CURRENT: InboxVers;
+    case CURRENT: void;
     case INCREMENTAL: SyncIncrementalRes;
-    case CLEAR: InboxVers;
+    case CLEAR: void;
   }
 
   // Sync down the inbox given a current version

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1459,9 +1459,9 @@ export type SignatureInfo = {
 }
 
 export type SyncInboxRes =
-    { typ: 0, current: ?InboxVers }
+    { typ: 0 }
   | { typ: 1, incremental: ?SyncIncrementalRes }
-  | { typ: 2, clear: ?InboxVers }
+  | { typ: 2 }
 
 export type SyncInboxResType =
     0 // CURRENT_0

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1459,9 +1459,9 @@ export type SignatureInfo = {
 }
 
 export type SyncInboxRes =
-    { typ: 0 }
+    { typ: 0, current: ?InboxVers }
   | { typ: 1, incremental: ?SyncIncrementalRes }
-  | { typ: 2 }
+  | { typ: 2, clear: ?InboxVers }
 
 export type SyncInboxResType =
     0 // CURRENT_0

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -209,6 +209,13 @@
           "name": "status"
         },
         {
+          "type": {
+            "type": "array",
+            "items": "ConversationID"
+          },
+          "name": "convIDs"
+        },
+        {
           "type": "boolean",
           "name": "unreadOnly"
         },

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -299,6 +299,63 @@
           "name": "regionBucketEndpoint"
         }
       ]
+    },
+    {
+      "type": "enum",
+      "name": "SyncInboxResType",
+      "symbols": [
+        "CURRENT_0",
+        "INCREMENTAL_1",
+        "CLEAR_2"
+      ]
+    },
+    {
+      "type": "record",
+      "name": "SyncIncrementalRes",
+      "fields": [
+        {
+          "type": "InboxVers",
+          "name": "vers"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "Conversation"
+          },
+          "name": "convs"
+        }
+      ]
+    },
+    {
+      "type": "variant",
+      "name": "SyncInboxRes",
+      "switch": {
+        "type": "SyncInboxResType",
+        "name": "typ"
+      },
+      "cases": [
+        {
+          "label": {
+            "name": "CURRENT",
+            "def": false
+          },
+          "body": null
+        },
+        {
+          "label": {
+            "name": "INCREMENTAL",
+            "def": false
+          },
+          "body": "SyncIncrementalRes"
+        },
+        {
+          "label": {
+            "name": "CLEAR",
+            "def": false
+          },
+          "body": null
+        }
+      ]
     }
   ],
   "messages": {
@@ -484,6 +541,15 @@
         }
       ],
       "response": "InboxVers"
+    },
+    "syncInbox": {
+      "request": [
+        {
+          "name": "vers",
+          "type": "InboxVers"
+        }
+      ],
+      "response": "SyncInboxRes"
     },
     "tlfFinalize": {
       "request": [

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -339,7 +339,7 @@
             "name": "CURRENT",
             "def": false
           },
-          "body": null
+          "body": "InboxVers"
         },
         {
           "label": {
@@ -353,7 +353,7 @@
             "name": "CLEAR",
             "def": false
           },
-          "body": null
+          "body": "InboxVers"
         }
       ]
     }

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -339,7 +339,7 @@
             "name": "CURRENT",
             "def": false
           },
-          "body": "InboxVers"
+          "body": null
         },
         {
           "label": {
@@ -353,7 +353,7 @@
             "name": "CLEAR",
             "def": false
           },
-          "body": "InboxVers"
+          "body": null
         }
       ]
     }

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1459,9 +1459,9 @@ export type SignatureInfo = {
 }
 
 export type SyncInboxRes =
-    { typ: 0, current: ?InboxVers }
+    { typ: 0 }
   | { typ: 1, incremental: ?SyncIncrementalRes }
-  | { typ: 2, clear: ?InboxVers }
+  | { typ: 2 }
 
 export type SyncInboxResType =
     0 // CURRENT_0

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1459,9 +1459,9 @@ export type SignatureInfo = {
 }
 
 export type SyncInboxRes =
-    { typ: 0 }
+    { typ: 0, current: ?InboxVers }
   | { typ: 1, incremental: ?SyncIncrementalRes }
-  | { typ: 2 }
+  | { typ: 2, clear: ?InboxVers }
 
 export type SyncInboxResType =
     0 // CURRENT_0


### PR DESCRIPTION
This patch utilizes the new server RPC from https://github.com/keybase/gregor/pull/327, in order to minimize the amount of traffic for a reconnect to the chat server. The new protocol is the following:

1.) On reconnect, read the current on-disk inbox version.
2.) Call `SyncInbox` with this version.
3.) If we get an incremental response, merge the conversations returned into the on-disk inbox and write out the new version. A current response means we stand pat.
4.) If we get a clear, just nuke the on-disk inbox.

For incremental responses, we can now also limit the amount of thread reloading in the UI to only those that have changed.