### PR TITLE
logsend android support

### DIFF
--- a/shared/dev/log-send/render.native.js
+++ b/shared/dev/log-send/render.native.js
@@ -40,7 +40,7 @@ class LogSendRender extends Component<void, Props, {copiedToClipboard: boolean}>
           throw new Error(`Couldn't log send! ${err}`)
         })
     } else {
-      console.warn('TODO better android logging')
+      dumpLoggers()
       this.props.onLogSend()
     }
   }

--- a/shared/index.native.js
+++ b/shared/index.native.js
@@ -14,6 +14,7 @@ import {setup as setupLocalDebug, dumbSheetOnly, dumbChatOnly} from './local-deb
 import {stateKey} from './constants/reducer'
 import routeDefs from './routes'
 import {setRouteDef} from './actions/route-tree'
+import {setupSource} from './util/forward-logs'
 
 module.hot && module.hot.accept(() => {
   console.log('accepted update in shared/index.native')
@@ -29,6 +30,7 @@ class Keybase extends Component {
   store: any;
   subscriptions: Array<{remove: () => void}>
   componentWillMount () {
+    setupSource()
     this.store = configureStore()
     setupLocalDebug(this.store)
     this.store.dispatch(setRouteDef(routeDefs))

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -38,7 +38,7 @@ public class MainActivity extends ReactActivity {
         }
 
         logFile = this.getFileStreamPath("android.log");
-        initOnce(this.getFilesDir().getPath(), logFile.getAbsolutePath(), "prod", false);
+        initOnce(this.getFilesDir().getPath(), this.getFileStreamPath("service.log").getAbsolutePath(), "prod", false);
 
         super.onCreate(savedInstanceState);
     }

--- a/shared/util/forward-logs.native.js
+++ b/shared/util/forward-logs.native.js
@@ -18,9 +18,20 @@ function setupSource () {
   }
   forwarded = true
 
-  window.console.log = (...args) => { localLog(...args); logger.info(args.join(', ')) }
-  window.console.warn = (...args) => { localWarn(...args); logger.warn(args.join(', ')) }
-  window.console.error = (...args) => { localError(...args); logger.error(args.join(', ')) }
+  window.console.log = (...args) => {
+    localLog(...args)
+    logger.info(args.join(', '))
+  }
+
+  window.console.warn = (...args) => {
+    localWarn(...args)
+    logger.warn(args.join(', '))
+  }
+
+  window.console.error = (...args) => {
+    localError(...args)
+    logger.error(args.join(', '))
+  }
 }
 
 export {


### PR DESCRIPTION
Android does plumb through the console logs to the native module (maybe not a good idea but that's how its designed currently).
That was actually not being inited
Added the period logger dumping and fixed the log file being overwritten

@keybase/react-hackers 