### PR TITLE
add parameter to cap unboxing in GetInboxNonblock, and allows lists of conv IDs as params CORE-4746

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -54,7 +54,7 @@ func (b *BlockingLocalizer) SetOffline() {
 
 func (b *BlockingLocalizer) Localize(ctx context.Context, uid gregor1.UID, inbox chat1.Inbox) (res []chat1.ConversationLocal, err error) {
 
-	res, err = b.pipeline.localizeConversationsPipeline(ctx, uid, inbox.ConvsUnverified, nil)
+	res, err = b.pipeline.localizeConversationsPipeline(ctx, uid, inbox.ConvsUnverified, nil, nil)
 	if err != nil {
 		return res, err
 	}
@@ -79,15 +79,17 @@ type NonblockingLocalizer struct {
 
 	pipeline   *localizerPipeline
 	localizeCb chan NonblockInboxResult
+	maxUnbox   *int
 }
 
 func NewNonblockingLocalizer(g *libkb.GlobalContext, localizeCb chan NonblockInboxResult,
-	getTlfInterface func() keybase1.TlfInterface) *NonblockingLocalizer {
+	maxUnbox *int, getTlfInterface func() keybase1.TlfInterface) *NonblockingLocalizer {
 	return &NonblockingLocalizer{
 		Contextified: libkb.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g, "NonblockingLocalizer", false),
 		pipeline:     newLocalizerPipeline(g, getTlfInterface, newBasicSupersedesTransform(g)),
 		localizeCb:   localizeCb,
+		maxUnbox:     maxUnbox,
 	}
 }
 
@@ -101,7 +103,7 @@ func (b *NonblockingLocalizer) filterInboxRes(ctx context.Context, inbox chat1.I
 	localizer := newLocalizerPipeline(b.G(), b.pipeline.getTlfInterface, newNullSupersedesTransform())
 	localizer.offline = true // Set this guy offline, so we are guaranteed to not do anything slow
 
-	convs, err := localizer.localizeConversationsPipeline(ctx, uid, inbox.ConvsUnverified, nil)
+	convs, err := localizer.localizeConversationsPipeline(ctx, uid, inbox.ConvsUnverified, nil, nil)
 	if err != nil {
 		// Any errors we just return original inbox
 		b.Debug(ctx, "filterInboxRes: error running localize pipeline: %s", err.Error())
@@ -158,7 +160,7 @@ func (b *NonblockingLocalizer) Localize(ctx context.Context, uid gregor1.UID, in
 		b.Debug(bctx, "Localize: starting background localization: convs: %d",
 			len(inbox.ConvsUnverified))
 		b.pipeline.localizeConversationsPipeline(bctx, uid, inbox.ConvsUnverified,
-			&b.localizeCb)
+			b.maxUnbox, &b.localizeCb)
 
 		// Shutdown localize channel
 		close(b.localizeCb)
@@ -672,7 +674,7 @@ func (s *HybridInboxSource) TlfFinalize(ctx context.Context, uid gregor1.UID, ve
 }
 
 func (s *localizerPipeline) localizeConversationsPipeline(ctx context.Context, uid gregor1.UID,
-	convs []chat1.Conversation, localizeCb *chan NonblockInboxResult) ([]chat1.ConversationLocal, error) {
+	convs []chat1.Conversation, maxUnbox *int, localizeCb *chan NonblockInboxResult) ([]chat1.ConversationLocal, error) {
 
 	// Fetch conversation local information in parallel
 	type jobRes struct {
@@ -694,6 +696,11 @@ func (s *localizerPipeline) localizeConversationsPipeline(ctx context.Context, u
 			case convCh <- job{conv: conv, index: i}:
 			case <-ctx.Done():
 				return ctx.Err()
+			}
+			if maxUnbox != nil && i >= *maxUnbox {
+				s.Debug(ctx, "localizeConversationsPipeline: maxUnbox set and reached, early exit: %d",
+					*maxUnbox)
+				break
 			}
 		}
 		return nil

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -294,7 +294,7 @@ func (b *baseInboxSource) getInboxQueryLocalToRemote(ctx context.Context,
 	rquery.UnreadOnly = lquery.UnreadOnly
 	rquery.ReadOnly = lquery.ReadOnly
 	rquery.ComputeActiveList = lquery.ComputeActiveList
-	rquery.ConvID = lquery.ConvID
+	rquery.ConvIDs = lquery.ConvIDs
 	rquery.OneChatTypePerTLF = lquery.OneChatTypePerTLF
 	rquery.Status = lquery.Status
 	rquery.SummarizeMaxMsgs = true
@@ -592,7 +592,7 @@ func (s *HybridInboxSource) getConvLocal(ctx context.Context, uid gregor1.UID,
 	convID chat1.ConversationID) (conv *chat1.ConversationLocal, err error) {
 	// Read back affected conversation so we can send it to the frontend
 	ib, _, err := s.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
-		ConvID: &convID,
+		ConvIDs: []chat1.ConversationID{convID},
 	}, nil)
 	if err != nil {
 		return conv, err

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -686,6 +686,9 @@ func (s *localizerPipeline) localizeConversationsPipeline(ctx context.Context, u
 		index int
 	}
 
+	if maxUnbox != nil {
+		s.Debug(ctx, "pipeline: maxUnbox set to: %d", *maxUnbox)
+	}
 	eg, ctx := errgroup.WithContext(ctx)
 	convCh := make(chan job)
 	retCh := make(chan jobRes)
@@ -698,9 +701,9 @@ func (s *localizerPipeline) localizeConversationsPipeline(ctx context.Context, u
 				return ctx.Err()
 			}
 			if maxUnbox != nil && i >= *maxUnbox {
-				s.Debug(ctx, "localizeConversationsPipeline: maxUnbox set and reached, early exit: %d",
+				s.Debug(ctx, "pipeline: maxUnbox set and reached, early exit: %d",
 					*maxUnbox)
-				break
+				return nil
 			}
 		}
 		return nil
@@ -814,6 +817,7 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 	conversationRemote chat1.Conversation) (conversationLocal chat1.ConversationLocal) {
 
 	unverifiedTLFName := getUnverifiedTlfNameForErrors(conversationRemote)
+	s.Debug(ctx, "localizing: TLF: %s convID: %s", unverifiedTLFName, conversationRemote.GetConvID())
 
 	conversationLocal.Info = chat1.ConversationInfoLocal{
 		Id:         conversationRemote.Metadata.ConversationID,

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -119,8 +119,7 @@ func (g *PushHandler) TlfResolve(ctx context.Context, m gregor.OutOfBandMessage)
 func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, badger *badges.Badger) (err error) {
 	defer g.Trace(ctx, func() error { return err }, "Activity")()
 	if m.Body() == nil {
-		err = errors.New("gregor handler for chat.activity: nil message body")
-		return err
+		return errors.New("gregor handler for chat.activity: nil message body")
 	}
 
 	var activity chat1.ChatActivity
@@ -274,8 +273,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 		}
 		if len(inbox.Convs) != 1 {
 			g.Debug(ctx, "chat activity: unable to find conversation")
-			err = fmt.Errorf("unable to find conversation")
-			return err
+			return fmt.Errorf("unable to find conversation")
 		}
 		updateConv := inbox.ConvsUnverified[0]
 		if err = g.G().InboxSource.NewConversation(ctx, uid, nm.InboxVers, updateConv); err != nil {
@@ -290,12 +288,10 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 			badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
 		}
 	default:
-		err = fmt.Errorf("unhandled chat.activity action %q", action)
-		return err
+		return fmt.Errorf("unhandled chat.activity action %q", action)
 	}
 
-	err = g.notifyNewChatActivity(ctx, m.UID(), &activity)
-	return err
+	return g.notifyNewChatActivity(ctx, m.UID(), &activity)
 }
 
 func (g *PushHandler) notifyNewChatActivity(ctx context.Context, uid gregor.UID, activity *chat1.ChatActivity) error {

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -95,7 +95,7 @@ func (g *PushHandler) TlfResolve(ctx context.Context, m gregor.OutOfBandMessage)
 
 	// Get and localize the conversation to get the new tlfname.
 	inbox, _, err := g.G().InboxSource.Read(ctx, m.UID().Bytes(), nil, true, &chat1.GetInboxLocalQuery{
-		ConvID: &update.ConvID,
+		ConvIDs: []chat1.ConversationID{update.ConvID},
 	}, nil)
 	if err != nil {
 		g.Debug(ctx, "resolve: unable to read conversation: %s", err.Error())
@@ -266,7 +266,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 		// We need to get this conversation and then localize it
 		var inbox chat1.Inbox
 		if inbox, _, err = g.G().InboxSource.Read(ctx, uid, nil, false, &chat1.GetInboxLocalQuery{
-			ConvID: &nm.ConvID,
+			ConvIDs: []chat1.ConversationID{nm.ConvID},
 		}, nil); err != nil {
 			g.Debug(ctx, "chat activity: unable to read conversation: %s", err.Error())
 			return err

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -119,7 +119,8 @@ func (g *PushHandler) TlfResolve(ctx context.Context, m gregor.OutOfBandMessage)
 func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, badger *badges.Badger) (err error) {
 	defer g.Trace(ctx, func() error { return err }, "Activity")()
 	if m.Body() == nil {
-		return errors.New("gregor handler for chat.activity: nil message body")
+		err = errors.New("gregor handler for chat.activity: nil message body")
+		return err
 	}
 
 	var activity chat1.ChatActivity
@@ -273,7 +274,8 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 		}
 		if len(inbox.Convs) != 1 {
 			g.Debug(ctx, "chat activity: unable to find conversation")
-			return fmt.Errorf("unable to find conversation")
+			err = fmt.Errorf("unable to find conversation")
+			return err
 		}
 		updateConv := inbox.ConvsUnverified[0]
 		if err = g.G().InboxSource.NewConversation(ctx, uid, nm.InboxVers, updateConv); err != nil {
@@ -288,10 +290,12 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 			badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
 		}
 	default:
-		return fmt.Errorf("unhandled chat.activity action %q", action)
+		err = fmt.Errorf("unhandled chat.activity action %q", action)
+		return err
 	}
 
-	return g.notifyNewChatActivity(ctx, m.UID(), &activity)
+	err = g.notifyNewChatActivity(ctx, m.UID(), &activity)
+	return err
 }
 
 func (g *PushHandler) notifyNewChatActivity(ctx context.Context, uid gregor.UID, activity *chat1.ChatActivity) error {

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -239,8 +239,8 @@ func (i *Inbox) applyQuery(ctx context.Context, query *chat1.GetInboxQuery, conv
 	for _, conv := range convs {
 		ok := true
 		// Basic checks
-		if query.ConvID != nil && !query.ConvID.Eq(conv.Metadata.ConversationID) {
-			ok = false
+		if query.ConvID != nil {
+			query.ConvIDs = append(query.ConvIDs, *query.ConvID)
 		}
 		if len(query.ConvIDs) > 0 {
 			found := false
@@ -294,7 +294,7 @@ func (i *Inbox) applyQuery(ctx context.Context, query *chat1.GetInboxQuery, conv
 		// If we are finalized and are superseded, then don't return this
 		if query.OneChatTypePerTLF == nil ||
 			(query.OneChatTypePerTLF != nil && *query.OneChatTypePerTLF) {
-			if conv.Metadata.FinalizeInfo != nil && len(conv.Metadata.SupersededBy) > 0 && query.ConvID == nil {
+			if conv.Metadata.FinalizeInfo != nil && len(conv.Metadata.SupersededBy) > 0 && len(query.ConvIDs) == 0 {
 				ok = false
 			}
 		}

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -768,7 +768,7 @@ func (c *chatServiceHandler) getExistingConvs(ctx context.Context, id chat1.Conv
 	if !id.IsNil() {
 		gilres, err := client.GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
 			Query: &chat1.GetInboxLocalQuery{
-				ConvID: &id,
+				ConvIDs: []chat1.ConversationID{id},
 			},
 			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 		})

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -247,6 +247,21 @@ func (m *ChatRemoteMock) GetInboxRemote(ctx context.Context, arg chat1.GetInboxR
 			continue
 		}
 		if arg.Query != nil {
+			if arg.Query.ConvID != nil {
+				arg.Query.ConvIDs = append(arg.Query.ConvIDs, *arg.Query.ConvID)
+			}
+			if len(arg.Query.ConvIDs) > 0 {
+				found := false
+				for _, convID := range arg.Query.ConvIDs {
+					if convID.Eq(conv.GetConvID()) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					continue
+				}
+			}
 			if arg.Query.ConvID != nil && !conv.Metadata.ConversationID.Eq(*arg.Query.ConvID) {
 				continue
 			}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1389,7 +1389,7 @@ type GetInboxLocalRes struct {
 type GetInboxLocalQuery struct {
 	TlfName           *string              `codec:"tlfName,omitempty" json:"tlfName,omitempty"`
 	TopicName         *string              `codec:"topicName,omitempty" json:"topicName,omitempty"`
-	ConvID            *ConversationID      `codec:"convID,omitempty" json:"convID,omitempty"`
+	ConvIDs           []ConversationID     `codec:"convIDs" json:"convIDs"`
 	TopicType         *TopicType           `codec:"topicType,omitempty" json:"topicType,omitempty"`
 	TlfVisibility     *TLFVisibility       `codec:"tlfVisibility,omitempty" json:"tlfVisibility,omitempty"`
 	Before            *gregor1.Time        `codec:"before,omitempty" json:"before,omitempty"`
@@ -1523,6 +1523,7 @@ type GetInboxAndUnboxLocalArg struct {
 
 type GetInboxNonblockLocalArg struct {
 	SessionID        int                          `codec:"sessionID" json:"sessionID"`
+	MaxUnbox         *int                         `codec:"maxUnbox,omitempty" json:"maxUnbox,omitempty"`
 	Query            *GetInboxLocalQuery          `codec:"query,omitempty" json:"query,omitempty"`
 	Pagination       *Pagination                  `codec:"pagination,omitempty" json:"pagination,omitempty"`
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -87,7 +87,7 @@ func (h *chatLocalHandler) GetInboxNonblockLocal(ctx context.Context, arg chat1.
 	localizeCb := make(chan chat.NonblockInboxResult, 1)
 
 	// Invoke nonblocking inbox read and get remote inbox version to send back as our result
-	localizer := chat.NewNonblockingLocalizer(h.G(), localizeCb,
+	localizer := chat.NewNonblockingLocalizer(h.G(), localizeCb, arg.MaxUnbox,
 		func() keybase1.TlfInterface { return h.tlf })
 	_, rl, err := h.G().InboxSource.Read(ctx, uid.ToBytes(), localizer, true, arg.Query, arg.Pagination)
 	if err != nil {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -407,7 +407,7 @@ func (h *chatLocalHandler) NewConversationLocal(ctx context.Context, arg chat1.N
 
 		ib, rl, err := h.G().InboxSource.Read(ctx, uid.ToBytes(), nil, false,
 			&chat1.GetInboxLocalQuery{
-				ConvID: &convID,
+				ConvIDs: []chat1.ConversationID{convID},
 			}, nil)
 		if err != nil {
 			return chat1.NewConversationLocalRes{}, err

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -223,7 +223,7 @@ func TestChatGetInboxAndUnboxLocal(t *testing.T) {
 
 	gilres, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxAndUnboxLocal(context.Background(), chat1.GetInboxAndUnboxLocalArg{
 		Query: &chat1.GetInboxLocalQuery{
-			ConvID: &created.Id,
+			ConvIDs: []chat1.ConversationID{created.Id},
 		},
 	})
 	if err != nil {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -466,7 +466,7 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
-  NonblockLocalRes getInboxNonblockLocal(int sessionID, union { null, int } maxUnbox, union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
+  NonblockFetchRes getInboxNonblockLocal(int sessionID, union { null, int } maxUnbox, union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
 
   PostLocalRes postLocal(ConversationID conversationID, MessagePlaintext msg, keybase1.TLFIdentifyBehavior identifyBehavior);
   record PostLocalRes {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -443,7 +443,7 @@ protocol local {
     union { null, string } tlfName;
     union { null, string } topicName;
 
-    union { null, ConversationID } convID;
+    array<ConversationID> convIDs;
     union { null, TopicType } topicType;
     union { null, TLFVisibility } tlfVisibility;
     union { null, gregor1.Time } before;
@@ -466,7 +466,7 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
-  NonblockFetchRes getInboxNonblockLocal(int sessionID, union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior); 
+  NonblockLocalRes getInboxNonblockLocal(int sessionID, union { null, int } maxUnbox, union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
 
   PostLocalRes postLocal(ConversationID conversationID, MessagePlaintext msg, keybase1.TLFIdentifyBehavior identifyBehavior);
   record PostLocalRes {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1483,9 +1483,9 @@ export type SignatureInfo = {
 }
 
 export type SyncInboxRes =
-    { typ: 0 }
+    { typ: 0, current: ?InboxVers }
   | { typ: 1, incremental: ?SyncIncrementalRes }
-  | { typ: 2 }
+  | { typ: 2, clear: ?InboxVers }
 
 export type SyncInboxResType =
     0 // CURRENT_0

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1483,9 +1483,9 @@ export type SignatureInfo = {
 }
 
 export type SyncInboxRes =
-    { typ: 0, current: ?InboxVers }
+    { typ: 0 }
   | { typ: 1, incremental: ?SyncIncrementalRes }
-  | { typ: 2, clear: ?InboxVers }
+  | { typ: 2 }
 
 export type SyncInboxResType =
     0 // CURRENT_0

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -930,7 +930,7 @@ export type GetInboxByTLFIDRemoteRes = {
 export type GetInboxLocalQuery = {
   tlfName?: ?string,
   topicName?: ?string,
-  convID?: ?ConversationID,
+  convIDs?: ?Array<ConversationID>,
   topicType?: ?TopicType,
   tlfVisibility?: ?TLFVisibility,
   before?: ?gregor1.Time,
@@ -1638,6 +1638,7 @@ export type localGetInboxAndUnboxLocalRpcParam = Exact<{
 }>
 
 export type localGetInboxNonblockLocalRpcParam = Exact<{
+  maxUnbox?: ?int,
   query?: ?GetInboxLocalQuery,
   pagination?: ?Pagination,
   identifyBehavior: keybase1.TLFIdentifyBehavior

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1284,11 +1284,11 @@
           "name": "topicName"
         },
         {
-          "type": [
-            null,
-            "ConversationID"
-          ],
-          "name": "convID"
+          "type": {
+            "type": "array",
+            "items": "ConversationID"
+          },
+          "name": "convIDs"
         },
         {
           "type": [
@@ -1829,6 +1829,13 @@
         {
           "name": "sessionID",
           "type": "int"
+        },
+        {
+          "name": "maxUnbox",
+          "type": [
+            null,
+            "int"
+          ]
         },
         {
           "name": "query",

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -339,7 +339,7 @@
             "name": "CURRENT",
             "def": false
           },
-          "body": null
+          "body": "InboxVers"
         },
         {
           "label": {
@@ -353,7 +353,7 @@
             "name": "CLEAR",
             "def": false
           },
-          "body": null
+          "body": "InboxVers"
         }
       ]
     }

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -339,7 +339,7 @@
             "name": "CURRENT",
             "def": false
           },
-          "body": "InboxVers"
+          "body": null
         },
         {
           "label": {
@@ -353,7 +353,7 @@
             "name": "CLEAR",
             "def": false
           },
-          "body": "InboxVers"
+          "body": null
         }
       ]
     }

--- a/shared/actions/chat.js
+++ b/shared/actions/chat.js
@@ -2098,7 +2098,7 @@ function * _getInboxAndUnbox ({payload: {conversationIDKey}}: Constants.GetInbox
   const param: ChatTypes.localGetInboxAndUnboxLocalRpcParam = {
     identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
     query: {
-      convID: keyToConversationID(conversationIDKey),
+      convIDs: [keyToConversationID(conversationIDKey)],
       computeActiveList: true,
       tlfVisibility: CommonTLFVisibility.private,
       topicType: CommonTopicType.chat,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1483,9 +1483,9 @@ export type SignatureInfo = {
 }
 
 export type SyncInboxRes =
-    { typ: 0 }
+    { typ: 0, current: ?InboxVers }
   | { typ: 1, incremental: ?SyncIncrementalRes }
-  | { typ: 2 }
+  | { typ: 2, clear: ?InboxVers }
 
 export type SyncInboxResType =
     0 // CURRENT_0

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1483,9 +1483,9 @@ export type SignatureInfo = {
 }
 
 export type SyncInboxRes =
-    { typ: 0, current: ?InboxVers }
+    { typ: 0 }
   | { typ: 1, incremental: ?SyncIncrementalRes }
-  | { typ: 2, clear: ?InboxVers }
+  | { typ: 2 }
 
 export type SyncInboxResType =
     0 // CURRENT_0

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -930,7 +930,7 @@ export type GetInboxByTLFIDRemoteRes = {
 export type GetInboxLocalQuery = {
   tlfName?: ?string,
   topicName?: ?string,
-  convID?: ?ConversationID,
+  convIDs?: ?Array<ConversationID>,
   topicType?: ?TopicType,
   tlfVisibility?: ?TLFVisibility,
   before?: ?gregor1.Time,
@@ -1638,6 +1638,7 @@ export type localGetInboxAndUnboxLocalRpcParam = Exact<{
 }>
 
 export type localGetInboxNonblockLocalRpcParam = Exact<{
+  maxUnbox?: ?int,
   query?: ?GetInboxLocalQuery,
   pagination?: ?Pagination,
   identifyBehavior: keybase1.TLFIdentifyBehavior


### PR DESCRIPTION
This patch does the following:

1.) Adds a new parameter to `GetInboxNonblock`, called `maxUnbox`, which limits the number of conversations that `GetInboxNonblock` will unbox. It will still send the entire unverified inbox, but only the top conversations up to `maxUnbox` will get callbacks.
2.) Change the `convID` parameter on `GetInboxLocalQuery` to be a list called `convIDs`. This way, subsequent calls of `GetInboxNonblock` will be able to take a list of conv IDs from the unverified inbox we sent up to the GUI in the first call.

@chrisnojima I made a JS change to accommodate point #2, so let me know if it looks ok to you. Also, this is how I imagine you will page through the inbox using this new change:

1.) On load, call `GetInboxNonblock` with `maxUnbox` set to whatever value makes sense for you. 
2.) When the user scrolls down, you can get the next page in the UI, and send the conv IDs into `GetInboxNonblock` again. You will get the same sequence of callbacks you did in the initial call, except they will just be for the conversations you pass in. It will cost nothing for us to do the full sequence of callbacks (since we will have all the unverified stuff locally), but if it is annoying to receive them all, I can add a parameter that skips sending you the untrusted view, although I thought it might be easier if everything just behaved the same to make your side of the code simpler. 

Let me know!