### PR TITLE
add GetThreadNonblock for the purpose of showing an offline version of the thread CORE-4780

### DIFF
--- a/go/client/chat_ui.go
+++ b/go/client/chat_ui.go
@@ -222,3 +222,15 @@ func (c *ChatUI) ChatInboxUnverified(ctx context.Context, arg chat1.ChatInboxUnv
 
 	return nil
 }
+
+func (c *ChatUI) ChatThreadCached(ctx context.Context, arg chat1.ChatThreadCachedArg) error {
+	return nil
+}
+
+func (c *ChatUI) ChatThreadFull(ctx context.Context, arg chat1.ChatThreadFullArg) error {
+	return nil
+}
+
+func (c *ChatUI) ChatThreadFailed(ctx context.Context, arg chat1.ChatThreadFailedArg) error {
+	return nil
+}

--- a/go/client/chat_ui.go
+++ b/go/client/chat_ui.go
@@ -230,7 +230,3 @@ func (c *ChatUI) ChatThreadCached(ctx context.Context, arg chat1.ChatThreadCache
 func (c *ChatUI) ChatThreadFull(ctx context.Context, arg chat1.ChatThreadFullArg) error {
 	return nil
 }
-
-func (c *ChatUI) ChatThreadFailed(ctx context.Context, arg chat1.ChatThreadFailedArg) error {
-	return nil
-}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -351,7 +351,6 @@ type ChatUI interface {
 	ChatInboxFailed(context.Context, chat1.ChatInboxFailedArg) error
 	ChatThreadCached(context.Context, chat1.ChatThreadCachedArg) error
 	ChatThreadFull(context.Context, chat1.ChatThreadFullArg) error
-	ChatThreadFailed(context.Context, chat1.ChatThreadFailedArg) error
 }
 
 type PromptDefault int

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -349,6 +349,9 @@ type ChatUI interface {
 	ChatInboxUnverified(context.Context, chat1.ChatInboxUnverifiedArg) error
 	ChatInboxConversation(context.Context, chat1.ChatInboxConversationArg) error
 	ChatInboxFailed(context.Context, chat1.ChatInboxFailedArg) error
+	ChatThreadCached(context.Context, chat1.ChatThreadCachedArg) error
+	ChatThreadFull(context.Context, chat1.ChatThreadFullArg) error
+	ChatThreadFailed(context.Context, chat1.ChatThreadFailedArg) error
 }
 
 type PromptDefault int

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -63,6 +63,21 @@ type ChatInboxFailedArg struct {
 	Error     ConversationErrorLocal `codec:"error" json:"error"`
 }
 
+type ChatThreadCachedArg struct {
+	SessionID int        `codec:"sessionID" json:"sessionID"`
+	Thread    ThreadView `codec:"thread" json:"thread"`
+}
+
+type ChatThreadFullArg struct {
+	SessionID int        `codec:"sessionID" json:"sessionID"`
+	Thread    ThreadView `codec:"thread" json:"thread"`
+}
+
+type ChatThreadFailedArg struct {
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	Message   string `codec:"message" json:"message"`
+}
+
 type ChatUiInterface interface {
 	ChatAttachmentUploadStart(context.Context, ChatAttachmentUploadStartArg) error
 	ChatAttachmentUploadProgress(context.Context, ChatAttachmentUploadProgressArg) error
@@ -75,6 +90,9 @@ type ChatUiInterface interface {
 	ChatInboxUnverified(context.Context, ChatInboxUnverifiedArg) error
 	ChatInboxConversation(context.Context, ChatInboxConversationArg) error
 	ChatInboxFailed(context.Context, ChatInboxFailedArg) error
+	ChatThreadCached(context.Context, ChatThreadCachedArg) error
+	ChatThreadFull(context.Context, ChatThreadFullArg) error
+	ChatThreadFailed(context.Context, ChatThreadFailedArg) error
 }
 
 func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
@@ -257,6 +275,54 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"chatThreadCached": {
+				MakeArg: func() interface{} {
+					ret := make([]ChatThreadCachedArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ChatThreadCachedArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ChatThreadCachedArg)(nil), args)
+						return
+					}
+					err = i.ChatThreadCached(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodNotify,
+			},
+			"chatThreadFull": {
+				MakeArg: func() interface{} {
+					ret := make([]ChatThreadFullArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ChatThreadFullArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ChatThreadFullArg)(nil), args)
+						return
+					}
+					err = i.ChatThreadFull(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodNotify,
+			},
+			"chatThreadFailed": {
+				MakeArg: func() interface{} {
+					ret := make([]ChatThreadFailedArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ChatThreadFailedArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ChatThreadFailedArg)(nil), args)
+						return
+					}
+					err = i.ChatThreadFailed(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodNotify,
+			},
 		},
 	}
 }
@@ -321,5 +387,20 @@ func (c ChatUiClient) ChatInboxConversation(ctx context.Context, __arg ChatInbox
 
 func (c ChatUiClient) ChatInboxFailed(ctx context.Context, __arg ChatInboxFailedArg) (err error) {
 	err = c.Cli.Call(ctx, "chat.1.chatUi.chatInboxFailed", []interface{}{__arg}, nil)
+	return
+}
+
+func (c ChatUiClient) ChatThreadCached(ctx context.Context, __arg ChatThreadCachedArg) (err error) {
+	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatThreadCached", []interface{}{__arg})
+	return
+}
+
+func (c ChatUiClient) ChatThreadFull(ctx context.Context, __arg ChatThreadFullArg) (err error) {
+	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatThreadFull", []interface{}{__arg})
+	return
+}
+
+func (c ChatUiClient) ChatThreadFailed(ctx context.Context, __arg ChatThreadFailedArg) (err error) {
+	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatThreadFailed", []interface{}{__arg})
 	return
 }

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -73,11 +73,6 @@ type ChatThreadFullArg struct {
 	Thread    ThreadView `codec:"thread" json:"thread"`
 }
 
-type ChatThreadFailedArg struct {
-	SessionID int    `codec:"sessionID" json:"sessionID"`
-	Message   string `codec:"message" json:"message"`
-}
-
 type ChatUiInterface interface {
 	ChatAttachmentUploadStart(context.Context, ChatAttachmentUploadStartArg) error
 	ChatAttachmentUploadProgress(context.Context, ChatAttachmentUploadProgressArg) error
@@ -92,7 +87,6 @@ type ChatUiInterface interface {
 	ChatInboxFailed(context.Context, ChatInboxFailedArg) error
 	ChatThreadCached(context.Context, ChatThreadCachedArg) error
 	ChatThreadFull(context.Context, ChatThreadFullArg) error
-	ChatThreadFailed(context.Context, ChatThreadFailedArg) error
 }
 
 func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
@@ -307,22 +301,6 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodNotify,
 			},
-			"chatThreadFailed": {
-				MakeArg: func() interface{} {
-					ret := make([]ChatThreadFailedArg, 1)
-					return &ret
-				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]ChatThreadFailedArg)
-					if !ok {
-						err = rpc.NewTypeError((*[]ChatThreadFailedArg)(nil), args)
-						return
-					}
-					err = i.ChatThreadFailed(ctx, (*typedArgs)[0])
-					return
-				},
-				MethodType: rpc.MethodNotify,
-			},
 		},
 	}
 }
@@ -397,10 +375,5 @@ func (c ChatUiClient) ChatThreadCached(ctx context.Context, __arg ChatThreadCach
 
 func (c ChatUiClient) ChatThreadFull(ctx context.Context, __arg ChatThreadFullArg) (err error) {
 	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatThreadFull", []interface{}{__arg})
-	return
-}
-
-func (c ChatUiClient) ChatThreadFailed(ctx context.Context, __arg ChatThreadFailedArg) (err error) {
-	err = c.Cli.Notify(ctx, "chat.1.chatUi.chatThreadFailed", []interface{}{__arg})
 	return
 }

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -281,6 +281,7 @@ func (h *chatLocalHandler) GetThreadNonblock(ctx context.Context, arg chat1.GetT
 		default:
 		}
 
+		h.Debug(ctx, "GetThreadNonblock: cached thread sent")
 		chatUI.ChatThreadCached(bctx, chat1.ChatThreadCachedArg{
 			SessionID: arg.SessionID,
 			Thread:    localThread,
@@ -309,6 +310,7 @@ func (h *chatLocalHandler) GetThreadNonblock(ctx context.Context, arg chat1.GetT
 		}
 		res.RateLimits = utils.AggRateLimitsP(rl)
 
+		h.Debug(ctx, "GetThreadNonblock: full thread sent")
 		chatUI.ChatThreadFull(bctx, chat1.ChatThreadFullArg{
 			SessionID: arg.SessionID,
 			Thread:    remoteThread,

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -331,6 +331,7 @@ func (h *chatLocalHandler) GetThreadNonblock(ctx context.Context, arg chat1.GetT
 	}()
 
 	wg.Wait()
+	res.Offline = h.G().ConvSource.IsOffline()
 	return res, fullErr
 }
 

--- a/go/service/remote_chat_ui.go
+++ b/go/service/remote_chat_ui.go
@@ -73,3 +73,15 @@ func (r *RemoteChatUI) ChatInboxFailed(ctx context.Context, arg chat1.ChatInboxF
 func (r *RemoteChatUI) ChatInboxUnverified(ctx context.Context, arg chat1.ChatInboxUnverifiedArg) error {
 	return r.cli.ChatInboxUnverified(ctx, arg)
 }
+
+func (r *RemoteChatUI) ChatThreadCached(ctx context.Context, arg chat1.ChatThreadCachedArg) error {
+	return r.cli.ChatThreadCached(ctx, arg)
+}
+
+func (r *RemoteChatUI) ChatThreadFull(ctx context.Context, arg chat1.ChatThreadFullArg) error {
+	return r.cli.ChatThreadFull(ctx, arg)
+}
+
+func (r *RemoteChatUI) ChatThreadFailed(ctx context.Context, arg chat1.ChatThreadFailedArg) error {
+	return r.cli.ChatThreadFailed(ctx, arg)
+}

--- a/go/service/remote_chat_ui.go
+++ b/go/service/remote_chat_ui.go
@@ -81,7 +81,3 @@ func (r *RemoteChatUI) ChatThreadCached(ctx context.Context, arg chat1.ChatThrea
 func (r *RemoteChatUI) ChatThreadFull(ctx context.Context, arg chat1.ChatThreadFullArg) error {
 	return r.cli.ChatThreadFull(ctx, arg)
 }
-
-func (r *RemoteChatUI) ChatThreadFailed(ctx context.Context, arg chat1.ChatThreadFailedArg) error {
-	return r.cli.ChatThreadFailed(ctx, arg)
-}

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -15,4 +15,8 @@ protocol chatUi {
   void chatInboxUnverified(int sessionID, GetInboxLocalRes inbox); 
   void chatInboxConversation(int sessionID, ConversationLocal conv);
   void chatInboxFailed(int sessionID, ConversationID convID, ConversationErrorLocal error);
+
+  void chatThreadCached(int sessionID, ThreadView thread) oneway;
+  void chatThreadFull(int sessionID, ThreadView thread) oneway;
+  void chatThreadFailed(int sessionID, string message) oneway; 
 }

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -18,5 +18,4 @@ protocol chatUi {
 
   void chatThreadCached(int sessionID, ThreadView thread) oneway;
   void chatThreadFull(int sessionID, ThreadView thread) oneway;
-  void chatThreadFailed(int sessionID, string message) oneway; 
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -391,6 +391,12 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
+  record NonblockFetchRes {
+    boolean offline;
+    array<RateLimit> rateLimits;
+    array<keybase1.TLFIdentifyFailure> identifyFailures;
+  }
+
   record ThreadView {
     array<MessageUnboxed> messages;
     union { null, Pagination } pagination;
@@ -412,6 +418,10 @@ protocol local {
     array<RateLimit> rateLimits;
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
+
+  GetThreadLocalRes getCachedThread(ConversationID conversationID, union { null, GetThreadQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
+
+  NonblockFetchRes getThreadNonblock(int sessionID, ConversationID conversationID, union { null, GetThreadQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior); 
 
   record GetInboxLocalRes {
     array<Conversation> conversationsUnverified;
@@ -456,12 +466,7 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
-  GetInboxNonblockLocalRes getInboxNonblockLocal(int sessionID, union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
-  record GetInboxNonblockLocalRes {
-    boolean offline;
-    array<RateLimit> rateLimits;
-    array<keybase1.TLFIdentifyFailure> identifyFailures;
-  }
+  NonblockFetchRes getInboxNonblockLocal(int sessionID, union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior); 
 
   PostLocalRes postLocal(ConversationID conversationID, MessagePlaintext msg, keybase1.TLFIdentifyBehavior identifyBehavior);
   record PostLocalRes {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1587,10 +1587,6 @@ export type chatUiChatThreadCachedRpcParam = Exact<{
   thread: ThreadView
 }>
 
-export type chatUiChatThreadFailedRpcParam = Exact<{
-  message: string
-}>
-
 export type chatUiChatThreadFullRpcParam = Exact<{
   thread: ThreadView
 }>
@@ -2054,13 +2050,6 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       sessionID: int,
       thread: ThreadView
-    }>,
-    response: CommonResponseHandler
-  ) => void,
-  'keybase.1.chatUi.chatThreadFailed'?: (
-    params: Exact<{
-      sessionID: int,
-      message: string
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -229,6 +229,18 @@ export function localFindConversationsLocalRpcPromise (request: $Exact<requestCo
   return new Promise((resolve, reject) => { localFindConversationsLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function localGetCachedThreadRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {param: localGetCachedThreadRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.getCachedThread'})
+}
+
+export function localGetCachedThreadRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {param: localGetCachedThreadRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localGetCachedThreadRpc({...request, incomingCallMap, callback}))
+}
+
+export function localGetCachedThreadRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {param: localGetCachedThreadRpcParam}>): Promise<localGetCachedThreadResult> {
+  return new Promise((resolve, reject) => { localGetCachedThreadRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function localGetConversationForCLILocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {param: localGetConversationForCLILocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.getConversationForCLILocal'})
 }
@@ -299,6 +311,18 @@ export function localGetThreadLocalRpcChannelMap (channelConfig: ChannelConfig<*
 
 export function localGetThreadLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadLocalResult) => void} & {param: localGetThreadLocalRpcParam}>): Promise<localGetThreadLocalResult> {
   return new Promise((resolve, reject) => { localGetThreadLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
+export function localGetThreadNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadNonblockResult) => void} & {param: localGetThreadNonblockRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.getThreadNonblock'})
+}
+
+export function localGetThreadNonblockRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadNonblockResult) => void} & {param: localGetThreadNonblockRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localGetThreadNonblockRpc({...request, incomingCallMap, callback}))
+}
+
+export function localGetThreadNonblockRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadNonblockResult) => void} & {param: localGetThreadNonblockRpcParam}>): Promise<localGetThreadNonblockResult> {
+  return new Promise((resolve, reject) => { localGetThreadNonblockRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function localMarkAsReadLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localMarkAsReadLocalResult) => void} & {param: localMarkAsReadLocalRpcParam}>) {
@@ -926,12 +950,6 @@ export type GetInboxLocalRes = {
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
 
-export type GetInboxNonblockLocalRes = {
-  offline: boolean,
-  rateLimits?: ?Array<RateLimit>,
-  identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
-}
-
 export type GetInboxQuery = {
   convID?: ?ConversationID,
   topicType?: ?TopicType,
@@ -1296,6 +1314,12 @@ export type NewMessagePayload = {
   unreadUpdate?: ?UnreadUpdate,
 }
 
+export type NonblockFetchRes = {
+  offline: boolean,
+  rateLimits?: ?Array<RateLimit>,
+  identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
+}
+
 export type NotifyChatChatIdentifyUpdateRpcParam = Exact<{
   update: keybase1.CanonicalTLFNameAndIDWithBreaks
 }>
@@ -1559,6 +1583,18 @@ export type chatUiChatInboxUnverifiedRpcParam = Exact<{
   inbox: GetInboxLocalRes
 }>
 
+export type chatUiChatThreadCachedRpcParam = Exact<{
+  thread: ThreadView
+}>
+
+export type chatUiChatThreadFailedRpcParam = Exact<{
+  message: string
+}>
+
+export type chatUiChatThreadFullRpcParam = Exact<{
+  thread: ThreadView
+}>
+
 export type localCancelPostRpcParam = Exact<{
   outboxID: OutboxID
 }>
@@ -1585,6 +1621,13 @@ export type localFindConversationsLocalRpcParam = Exact<{
   topicType: TopicType,
   topicName: string,
   oneChatPerTLF?: ?bool,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
+export type localGetCachedThreadRpcParam = Exact<{
+  conversationID: ConversationID,
+  query?: ?GetThreadQuery,
+  pagination?: ?Pagination,
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
@@ -1616,6 +1659,13 @@ export type localGetMessagesLocalRpcParam = Exact<{
 }>
 
 export type localGetThreadLocalRpcParam = Exact<{
+  conversationID: ConversationID,
+  query?: ?GetThreadQuery,
+  pagination?: ?Pagination,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
+export type localGetThreadNonblockRpcParam = Exact<{
   conversationID: ConversationID,
   query?: ?GetThreadQuery,
   pagination?: ?Pagination,
@@ -1809,17 +1859,21 @@ type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
 
 type localFindConversationsLocalResult = FindConversationsLocalRes
 
+type localGetCachedThreadResult = GetThreadLocalRes
+
 type localGetConversationForCLILocalResult = GetConversationForCLILocalRes
 
 type localGetInboxAndUnboxLocalResult = GetInboxAndUnboxLocalRes
 
-type localGetInboxNonblockLocalResult = GetInboxNonblockLocalRes
+type localGetInboxNonblockLocalResult = NonblockFetchRes
 
 type localGetInboxSummaryForCLILocalResult = GetInboxSummaryForCLILocalRes
 
 type localGetMessagesLocalResult = GetMessagesLocalRes
 
 type localGetThreadLocalResult = GetThreadLocalRes
+
+type localGetThreadNonblockResult = NonblockFetchRes
 
 type localMarkAsReadLocalResult = MarkAsReadRes
 
@@ -1874,12 +1928,14 @@ export type rpc =
   | localDownloadAttachmentLocalRpc
   | localDownloadFileAttachmentLocalRpc
   | localFindConversationsLocalRpc
+  | localGetCachedThreadRpc
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc
   | localGetInboxNonblockLocalRpc
   | localGetInboxSummaryForCLILocalRpc
   | localGetMessagesLocalRpc
   | localGetThreadLocalRpc
+  | localGetThreadNonblockRpc
   | localMarkAsReadLocalRpc
   | localNewConversationLocalRpc
   | localPostAttachmentLocalRpc
@@ -1984,6 +2040,27 @@ export type incomingCallMapType = Exact<{
       sessionID: int,
       convID: ConversationID,
       error: ConversationErrorLocal
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.chatUi.chatThreadCached'?: (
+    params: Exact<{
+      sessionID: int,
+      thread: ThreadView
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.chatUi.chatThreadFull'?: (
+    params: Exact<{
+      sessionID: int,
+      thread: ThreadView
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.chatUi.chatThreadFailed'?: (
+    params: Exact<{
+      sessionID: int,
+      message: string
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -151,6 +151,48 @@
         }
       ],
       "response": null
+    },
+    "chatThreadCached": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "thread",
+          "type": "ThreadView"
+        }
+      ],
+      "response": null,
+      "oneway": true
+    },
+    "chatThreadFull": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "thread",
+          "type": "ThreadView"
+        }
+      ],
+      "response": null,
+      "oneway": true
+    },
+    "chatThreadFailed": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "message",
+          "type": "string"
+        }
+      ],
+      "response": null,
+      "oneway": true
     }
   },
   "namespace": "chat.1"

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -179,20 +179,6 @@
       ],
       "response": null,
       "oneway": true
-    },
-    "chatThreadFailed": {
-      "request": [
-        {
-          "name": "sessionID",
-          "type": "int"
-        },
-        {
-          "name": "message",
-          "type": "string"
-        }
-      ],
-      "response": null,
-      "oneway": true
     }
   },
   "namespace": "chat.1"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1122,6 +1122,30 @@
     },
     {
       "type": "record",
+      "name": "NonblockFetchRes",
+      "fields": [
+        {
+          "type": "boolean",
+          "name": "offline"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFIdentifyFailure"
+          },
+          "name": "identifyFailures"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "ThreadView",
       "fields": [
         {
@@ -1340,30 +1364,6 @@
           ],
           "name": "pagination"
         },
-        {
-          "type": "boolean",
-          "name": "offline"
-        },
-        {
-          "type": {
-            "type": "array",
-            "items": "RateLimit"
-          },
-          "name": "rateLimits"
-        },
-        {
-          "type": {
-            "type": "array",
-            "items": "keybase1.TLFIdentifyFailure"
-          },
-          "name": "identifyFailures"
-        }
-      ]
-    },
-    {
-      "type": "record",
-      "name": "GetInboxNonblockLocalRes",
-      "fields": [
         {
           "type": "boolean",
           "name": "offline"
@@ -1743,6 +1743,64 @@
       ],
       "response": "GetThreadLocalRes"
     },
+    "getCachedThread": {
+      "request": [
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "query",
+          "type": [
+            null,
+            "GetThreadQuery"
+          ]
+        },
+        {
+          "name": "pagination",
+          "type": [
+            null,
+            "Pagination"
+          ]
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
+        }
+      ],
+      "response": "GetThreadLocalRes"
+    },
+    "getThreadNonblock": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "query",
+          "type": [
+            null,
+            "GetThreadQuery"
+          ]
+        },
+        {
+          "name": "pagination",
+          "type": [
+            null,
+            "Pagination"
+          ]
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
+        }
+      ],
+      "response": "NonblockFetchRes"
+    },
     "getInboxAndUnboxLocal": {
       "request": [
         {
@@ -1791,7 +1849,7 @@
           "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
-      "response": "GetInboxNonblockLocalRes"
+      "response": "NonblockFetchRes"
     },
     "postLocal": {
       "request": [

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1587,10 +1587,6 @@ export type chatUiChatThreadCachedRpcParam = Exact<{
   thread: ThreadView
 }>
 
-export type chatUiChatThreadFailedRpcParam = Exact<{
-  message: string
-}>
-
 export type chatUiChatThreadFullRpcParam = Exact<{
   thread: ThreadView
 }>
@@ -2054,13 +2050,6 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       sessionID: int,
       thread: ThreadView
-    }>,
-    response: CommonResponseHandler
-  ) => void,
-  'keybase.1.chatUi.chatThreadFailed'?: (
-    params: Exact<{
-      sessionID: int,
-      message: string
     }>,
     response: CommonResponseHandler
   ) => void,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -229,6 +229,18 @@ export function localFindConversationsLocalRpcPromise (request: $Exact<requestCo
   return new Promise((resolve, reject) => { localFindConversationsLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function localGetCachedThreadRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {param: localGetCachedThreadRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.getCachedThread'})
+}
+
+export function localGetCachedThreadRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {param: localGetCachedThreadRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localGetCachedThreadRpc({...request, incomingCallMap, callback}))
+}
+
+export function localGetCachedThreadRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {param: localGetCachedThreadRpcParam}>): Promise<localGetCachedThreadResult> {
+  return new Promise((resolve, reject) => { localGetCachedThreadRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function localGetConversationForCLILocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {param: localGetConversationForCLILocalRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.local.getConversationForCLILocal'})
 }
@@ -299,6 +311,18 @@ export function localGetThreadLocalRpcChannelMap (channelConfig: ChannelConfig<*
 
 export function localGetThreadLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadLocalResult) => void} & {param: localGetThreadLocalRpcParam}>): Promise<localGetThreadLocalResult> {
   return new Promise((resolve, reject) => { localGetThreadLocalRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
+export function localGetThreadNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadNonblockResult) => void} & {param: localGetThreadNonblockRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.local.getThreadNonblock'})
+}
+
+export function localGetThreadNonblockRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadNonblockResult) => void} & {param: localGetThreadNonblockRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => localGetThreadNonblockRpc({...request, incomingCallMap, callback}))
+}
+
+export function localGetThreadNonblockRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadNonblockResult) => void} & {param: localGetThreadNonblockRpcParam}>): Promise<localGetThreadNonblockResult> {
+  return new Promise((resolve, reject) => { localGetThreadNonblockRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
 export function localMarkAsReadLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localMarkAsReadLocalResult) => void} & {param: localMarkAsReadLocalRpcParam}>) {
@@ -926,12 +950,6 @@ export type GetInboxLocalRes = {
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
 
-export type GetInboxNonblockLocalRes = {
-  offline: boolean,
-  rateLimits?: ?Array<RateLimit>,
-  identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
-}
-
 export type GetInboxQuery = {
   convID?: ?ConversationID,
   topicType?: ?TopicType,
@@ -1296,6 +1314,12 @@ export type NewMessagePayload = {
   unreadUpdate?: ?UnreadUpdate,
 }
 
+export type NonblockFetchRes = {
+  offline: boolean,
+  rateLimits?: ?Array<RateLimit>,
+  identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
+}
+
 export type NotifyChatChatIdentifyUpdateRpcParam = Exact<{
   update: keybase1.CanonicalTLFNameAndIDWithBreaks
 }>
@@ -1559,6 +1583,18 @@ export type chatUiChatInboxUnverifiedRpcParam = Exact<{
   inbox: GetInboxLocalRes
 }>
 
+export type chatUiChatThreadCachedRpcParam = Exact<{
+  thread: ThreadView
+}>
+
+export type chatUiChatThreadFailedRpcParam = Exact<{
+  message: string
+}>
+
+export type chatUiChatThreadFullRpcParam = Exact<{
+  thread: ThreadView
+}>
+
 export type localCancelPostRpcParam = Exact<{
   outboxID: OutboxID
 }>
@@ -1585,6 +1621,13 @@ export type localFindConversationsLocalRpcParam = Exact<{
   topicType: TopicType,
   topicName: string,
   oneChatPerTLF?: ?bool,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
+export type localGetCachedThreadRpcParam = Exact<{
+  conversationID: ConversationID,
+  query?: ?GetThreadQuery,
+  pagination?: ?Pagination,
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
@@ -1616,6 +1659,13 @@ export type localGetMessagesLocalRpcParam = Exact<{
 }>
 
 export type localGetThreadLocalRpcParam = Exact<{
+  conversationID: ConversationID,
+  query?: ?GetThreadQuery,
+  pagination?: ?Pagination,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
+}>
+
+export type localGetThreadNonblockRpcParam = Exact<{
   conversationID: ConversationID,
   query?: ?GetThreadQuery,
   pagination?: ?Pagination,
@@ -1809,17 +1859,21 @@ type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
 
 type localFindConversationsLocalResult = FindConversationsLocalRes
 
+type localGetCachedThreadResult = GetThreadLocalRes
+
 type localGetConversationForCLILocalResult = GetConversationForCLILocalRes
 
 type localGetInboxAndUnboxLocalResult = GetInboxAndUnboxLocalRes
 
-type localGetInboxNonblockLocalResult = GetInboxNonblockLocalRes
+type localGetInboxNonblockLocalResult = NonblockFetchRes
 
 type localGetInboxSummaryForCLILocalResult = GetInboxSummaryForCLILocalRes
 
 type localGetMessagesLocalResult = GetMessagesLocalRes
 
 type localGetThreadLocalResult = GetThreadLocalRes
+
+type localGetThreadNonblockResult = NonblockFetchRes
 
 type localMarkAsReadLocalResult = MarkAsReadRes
 
@@ -1874,12 +1928,14 @@ export type rpc =
   | localDownloadAttachmentLocalRpc
   | localDownloadFileAttachmentLocalRpc
   | localFindConversationsLocalRpc
+  | localGetCachedThreadRpc
   | localGetConversationForCLILocalRpc
   | localGetInboxAndUnboxLocalRpc
   | localGetInboxNonblockLocalRpc
   | localGetInboxSummaryForCLILocalRpc
   | localGetMessagesLocalRpc
   | localGetThreadLocalRpc
+  | localGetThreadNonblockRpc
   | localMarkAsReadLocalRpc
   | localNewConversationLocalRpc
   | localPostAttachmentLocalRpc
@@ -1984,6 +2040,27 @@ export type incomingCallMapType = Exact<{
       sessionID: int,
       convID: ConversationID,
       error: ConversationErrorLocal
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.chatUi.chatThreadCached'?: (
+    params: Exact<{
+      sessionID: int,
+      thread: ThreadView
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.chatUi.chatThreadFull'?: (
+    params: Exact<{
+      sessionID: int,
+      thread: ThreadView
+    }>,
+    response: CommonResponseHandler
+  ) => void,
+  'keybase.1.chatUi.chatThreadFailed'?: (
+    params: Exact<{
+      sessionID: int,
+      message: string
     }>,
     response: CommonResponseHandler
   ) => void,


### PR DESCRIPTION
This patch adds `GetThreadNonblock`, the purpose of which is to deliver the result of a logical `GetThreadLocal` call in two stage: the on-disk version, and the "full" version. The full version is the result that would have been returned from a normal call to `GetThreadLocal`, and the disk version are those messages from the thread that we currently have stored locally.

The execution of `GetThreadNonblock` proceeds as follows:

1.) Spawn two goroutines: the first fetches the on-disk version, the second does the full call. The goroutines race each other to transmit the result to the client. If the full version wins, it stops the goroutine trying to get the local copy. 
2.) Each result sent to the client contains the full result of the query. That is, if the client asks for 20 messages of type `TEXT`, then it could potentially get two callbacks of size 20 messages. The frontend can choose to re-render, or append. Note, that depending on how old the on-disk messages are, the messages received from the callbacks could be totally disjoint. 

cc @chrisnojima 