### PR TITLE
Fix chat banner on dumb sheet

### DIFF
--- a/shared/chat/dumb.js
+++ b/shared/chat/dumb.js
@@ -400,35 +400,47 @@ const conversationBanner = {
   component: ConversationBanner,
   mocks: {
     'Info': {
-      type: 'Info',
-      text: 'Some info',
+      message: {
+        type: 'Info',
+        text: 'Some info',
+      },
     },
     'Invite': {
-      type: 'Invite',
-      users: ['malg@twitter'],
-      inviteLink: 'keybase.io/inv/9999999999',
-      onClickInviteLink: () => { console.log('Clicked the invite link') },
+      message: {
+        type: 'Invite',
+        users: ['malg@twitter'],
+        inviteLink: 'keybase.io/inv/9999999999',
+        onClickInviteLink: () => { console.log('Clicked the invite link') },
+      },
     },
     'Error': {
-      type: 'Error',
-      text: 'Some error',
-      textLink: 'Some link',
-      textLinkOnClick: () => { console.log('Clicked the text link') },
+      message: {
+        type: 'Error',
+        text: 'Some error',
+        textLink: 'Some link',
+        textLinkOnClick: () => { console.log('Clicked the text link') },
+      },
     },
     'BrokenTracker 1': {
-      type: 'BrokenTracker',
-      users: ['jzila'],
-      onClick: (user: string) => { console.log('Clicked on ', user) },
+      message: {
+        type: 'BrokenTracker',
+        users: ['jzila'],
+        onClick: (user: string) => { console.log('Clicked on ', user) },
+      },
     },
     'BrokenTracker 2': {
-      type: 'BrokenTracker',
-      users: ['jzila', 'cjb'],
-      onClick: (user: string) => { console.log('Clicked on ', user) },
+      message: {
+        type: 'BrokenTracker',
+        users: ['jzila', 'cjb'],
+        onClick: (user: string) => { console.log('Clicked on ', user) },
+      },
     },
     'BrokenTracker 3': {
-      type: 'BrokenTracker',
-      users: ['jzila', 'cjb', 'bob'],
-      onClick: (user: string) => { console.log('Clicked on ', user) },
+      message: {
+        type: 'BrokenTracker',
+        users: ['jzila', 'cjb', 'bob'],
+        onClick: (user: string) => { console.log('Clicked on ', user) },
+      },
     },
   },
 }


### PR DESCRIPTION
@keybase/react-hackers 

Commit 34227b3c1ae2 in PR #6059 (CC @chromakode) broke the Chat banner component in visdiff, because the component's looking for attributes inside a `message` object but `chat/dumb.js` is passing the contents of the object directly.  This seems like the right fix but I'm not sure what the intention was.

@chromakode, perhaps we should make the visdiff "removed" message a stronger warning? It usually means that the component crashes during render and sometimes we don't notice that.  Or could we have visdiff tell the difference between a JS crash while rendering and a removal of the component from the `dumb.js`?