### PR TITLE
Hide coinbase from ui

### DIFF
--- a/shared/actions/search.js
+++ b/shared/actions/search.js
@@ -147,7 +147,7 @@ function search (term: string, maybePlatform: ?SearchPlatforms) : TypedAsyncActi
     }
 
     const service = {
-      'Coinbase': 'coinbase',
+      'Coinbase': 'coinbase', // Coinbase is no longer supported
       'Facebook': 'facebook',
       'Github': 'github',
       'Hackernews': 'hackernews',

--- a/shared/constants/types/more.js
+++ b/shared/constants/types/more.js
@@ -9,7 +9,7 @@ const ProvablePlatformsMap = {
   'reddit': true,
   'facebook': true,
   'github': true,
-  'coinbase': true,
+  'coinbase': false, // Coinbase is no longer supported
   'hackernews': true,
   'dns': true,
   'http': true,
@@ -23,7 +23,7 @@ const PlatformsExpandedMap = {
   'reddit': true,
   'facebook': true,
   'github': true,
-  'coinbase': true,
+  'coinbase': false, // Coinbase is no longer supported
   'hackernews': true,
   'dns': true,
   'http': true,

--- a/shared/search/user-search/search-bar.desktop.js
+++ b/shared/search/user-search/search-bar.desktop.js
@@ -87,7 +87,7 @@ class SearchBar extends Component<void, Props, State> {
   }
 
   render () {
-    const services = ['Keybase', 'Twitter', 'Facebook', 'Github', 'Coinbase', 'Reddit', 'Hackernews']
+    const services = ['Keybase', 'Twitter', 'Facebook', 'Github', 'Reddit', 'Hackernews']
     const tooltips: {[key: string]: ?string} = {'Hackernews': 'Hacker News'}
 
     return (

--- a/shared/search/user-search/search-bar.native.js
+++ b/shared/search/user-search/search-bar.native.js
@@ -64,7 +64,7 @@ class SearchBar extends Component<void, Props, State> {
   }
 
   render () {
-    const services = ['Keybase', 'Twitter', 'Facebook', 'Github', 'Coinbase', 'Reddit', 'Hackernews']
+    const services = ['Keybase', 'Twitter', 'Facebook', 'Github', 'Reddit', 'Hackernews']
     const tooltips: {[key: string]: ?string} = {'Hackernews': 'Hacker News'}
 
     return (


### PR DESCRIPTION
venturing into desktop land.. Coinbase proofs are going away. The plan is to pretend it never existed. There are already some service changes in to stop processing proofs. This PR gets rid of proof creation and search for Coinbase. I didn't remove any now-unused code, just disabled stuff.

![image](https://cloud.githubusercontent.com/assets/705646/24014611/065244c8-0a5c-11e7-979a-4ac31440fe2a.png)

![image](https://cloud.githubusercontent.com/assets/705646/24014631/1952fa7c-0a5c-11e7-8eb0-961e4d8b7ef0.png)

![image](https://cloud.githubusercontent.com/assets/705646/24014500/921d46c0-0a5b-11e7-961c-4c3f57fb825d.png)

Tracker popups and profile entries are already handled by the service changes. Can you think of any other visible things left?