### PR TITLE
Use derived encryption key in chat MessageBoxedV2

### DIFF
--- a/go/chat/storage/crypt.go
+++ b/go/chat/storage/crypt.go
@@ -29,6 +29,6 @@ func getSecretBoxKey(ctx context.Context, g *libkb.GlobalContext, getSecretUI fu
 		return fkey, err
 	}
 
-	copy(fkey[:], skey)
+	copy(fkey[:], skey[:])
 	return fkey, nil
 }

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -495,6 +495,7 @@ const (
 
 const (
 	EncryptionReasonChatLocalStorage EncryptionReason = "Keybase-Chat-Local-Storage-1"
+	EncryptionReasonChatMessage      EncryptionReason = "Keybase-Chat-Message-1"
 )
 
 // FirstPRodMerkleSeqnoWithSkips is the first merkle root on production that

--- a/go/libkb/generickey.go
+++ b/go/libkb/generickey.go
@@ -45,7 +45,7 @@ type GenericKey interface {
 	DecryptFromString(ciphertext string) (msg []byte, sender keybase1.KID, err error)
 
 	// Derive a secret key from a DH secret key
-	SecretSymmetricKey(reason EncryptionReason) ([]byte, error)
+	SecretSymmetricKey(reason EncryptionReason) (NaclSecretBoxKey, error)
 
 	VerboseDescription() string
 	CheckSecretKey() error

--- a/go/libkb/gpg_key.go
+++ b/go/libkb/gpg_key.go
@@ -121,6 +121,6 @@ func (g *GPGKey) Encode() (string, error) {
 	return "", errors.New("Encode not implemented")
 }
 
-func (g *GPGKey) SecretSymmetricKey(reason EncryptionReason) ([]byte, error) {
-	return nil, KeyCannotEncryptError{}
+func (g *GPGKey) SecretSymmetricKey(reason EncryptionReason) (NaclSecretBoxKey, error) {
+	return NaclSecretBoxKey{}, KeyCannotEncryptError{}
 }

--- a/go/libkb/naclwrap_test.go
+++ b/go/libkb/naclwrap_test.go
@@ -353,7 +353,7 @@ func TestDeriveSymmetricKeyKnown(t *testing.T) {
 	key2, err := DeriveSymmetricKey(key1, EncryptionReason("testing-testing"))
 	require.NoError(t, err)
 
-	expected := "dd1e44385ee9aae4d9194665d14712eb4de99ed3291bfd099bb00df4cacbecb4"
+	expected := "b72ed915c99394c24fc609f9eb794e032580d99c5dbb4f3505f8a6fc8fc6b22b"
 	require.Equal(t, expected, hex.EncodeToString(key2[:]))
 }
 

--- a/go/libkb/naclwrap_test.go
+++ b/go/libkb/naclwrap_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // Test that VerifyString accepts the output of SignToString.
@@ -277,4 +279,48 @@ func TestNaclPrefixedSigs(t *testing.T) {
 	if _, ok := err.(BadSignaturePrefixError); !ok {
 		t.Fatal("expected a BadSignaturePrefixError")
 	}
+}
+
+func TestDeriveSymmetricKeyTooShort(t *testing.T) {
+	key1 := generateNaclSecretboxKey(t)
+	_, err := DeriveSymmetricKey(key1, EncryptionReason("x"))
+	require.Error(t, err, "should error with short reason")
+	require.Contains(t, err.Error(), "must be at least 8 bytes")
+}
+
+func TestDeriveSymmetricKeyDifferentEquality(t *testing.T) {
+	key1 := generateNaclSecretboxKey(t)
+
+	key2, err := DeriveSymmetricKey(key1, EncryptionReasonChatLocalStorage)
+	require.NoError(t, err)
+
+	key2_2, err := DeriveSymmetricKey(key1, EncryptionReasonChatLocalStorage)
+	require.NoError(t, err)
+
+	key3, err := DeriveSymmetricKey(key1, EncryptionReasonChatMessage)
+	require.NoError(t, err)
+
+	require.NotEqual(t, key1, key2, "derived key must be different from original")
+	require.NotEqual(t, key2, key3, "derived keys must differ")
+	require.Equal(t, key2, key2_2, "two derivations must be equivalent")
+}
+
+func TestDeriveSymmetricKeyKnown(t *testing.T) {
+	bs, err := hex.DecodeString(
+		"aaba52a997cfa11b704c7272e986ad337c8b327baa4265fb024147c97e7b672f")
+	require.NoError(t, err)
+	var key1 NaclSecretBoxKey
+	require.Equal(t, NaclSecretBoxKeySize, copy(key1[:], bs))
+
+	key2, err := DeriveSymmetricKey(key1, EncryptionReason("testing-testing"))
+	require.NoError(t, err)
+
+	expected := "a637302de8593ca06d652c3dc8df15ae5eecc89f25718a367f24b28decaa916e"
+	require.Equal(t, expected, hex.EncodeToString(key2[:]))
+}
+
+func generateNaclSecretboxKey(t *testing.T) NaclSecretBoxKey {
+	keyPair, err := GenerateNaclDHKeyPair()
+	require.NoError(t, err, "generating key")
+	return NaclSecretBoxKey(*keyPair.Private)
 }

--- a/go/libkb/pgp_key.go
+++ b/go/libkb/pgp_key.go
@@ -813,8 +813,8 @@ func (k *PGPKeyBundle) ExportPublicAndPrivate() (public RawPublicKey, private Ra
 	return RawPublicKey(publicKey.Bytes()), RawPrivateKey(privateKey.Bytes()), nil
 }
 
-func (k *PGPKeyBundle) SecretSymmetricKey(reason EncryptionReason) ([]byte, error) {
-	return nil, KeyCannotEncryptError{}
+func (k *PGPKeyBundle) SecretSymmetricKey(reason EncryptionReason) (NaclSecretBoxKey, error) {
+	return NaclSecretBoxKey{}, KeyCannotEncryptError{}
 }
 
 //===================================================

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -16,10 +16,11 @@ protocol remote {
     MessageClientHeader clientHeader;
 
     // V1: Encrypted HeaderPlaintext
-    // V2: SignEncrypted HeaderPlaintext
+    // V2: SignEncrypted HeaderPlaintext (using derived encryption key)
     SealedData headerCiphertext;
 
-    // [V1, V2]: Encrypted BodyPlaintext
+    // V1: Encrypted BodyPlaintext
+    // V2: Encrypted BodyPlaintext (using derived key)
     EncryptedData bodyCiphertext;
 
     // V1: Missing


### PR DESCRIPTION
Use a derived key for encryption of body and in the signcryption of header in `MessageBoxedV2`. This does not affect any existing messages. 

Also adds `type NaclSecretBoxKey [NaclSecretBoxKeySize]byte`.
