### PR TITLE
chat input fixes

### DIFF
--- a/shared/chat/conversation/header.native.js
+++ b/shared/chat/conversation/header.native.js
@@ -19,7 +19,7 @@ const Header = ({muted, onBack, onOpenFolder, onShowProfile, onToggleSidePanel, 
         onUsernameClicked={onShowProfile} />
       {muted && <Icon type='iconfont-shh' style={{...styleCenter, ...styleLeft}} />}
     </Box>
-    <Icon type={sidePanelOpen ? 'iconfont-close' : 'iconfont-info'} style={{...styleLeft, flexShrink: 0, padding: 4}} onClick={onToggleSidePanel} />
+    <Icon type={sidePanelOpen ? 'iconfont-close' : 'iconfont-info'} style={{...styleLeft, flexShrink: 0, padding: globalMargins.xtiny}} onClick={onToggleSidePanel} />
   </Box>
 )
 

--- a/shared/chat/conversation/header.native.js
+++ b/shared/chat/conversation/header.native.js
@@ -19,7 +19,7 @@ const Header = ({muted, onBack, onOpenFolder, onShowProfile, onToggleSidePanel, 
         onUsernameClicked={onShowProfile} />
       {muted && <Icon type='iconfont-shh' style={{...styleCenter, ...styleLeft}} />}
     </Box>
-    <Icon type={sidePanelOpen ? 'iconfont-close' : 'iconfont-info'} style={{...styleLeft, flexShrink: 0, marginTop: 4}} onClick={onToggleSidePanel} />
+    <Icon type={sidePanelOpen ? 'iconfont-close' : 'iconfont-info'} style={{...styleLeft, flexShrink: 0, padding: 4}} onClick={onToggleSidePanel} />
   </Box>
 )
 

--- a/shared/chat/conversation/input.native.js
+++ b/shared/chat/conversation/input.native.js
@@ -1,10 +1,10 @@
 // @flow
 /* eslint-env browser */
-import React, {Component} from 'react'
-import {Box, Icon, Input, Text} from '../../common-adapters'
-import {globalMargins, globalStyles} from '../../styles'
-import {isIOS} from '../../constants/platform'
 import ImagePicker from 'react-native-image-picker'
+import React, {Component} from 'react'
+import {Box, Icon, Input, Text, ClickableBox} from '../../common-adapters'
+import {globalMargins, globalStyles, globalColors} from '../../styles'
+import {isIOS} from '../../constants/platform'
 
 import type {AttachmentInput} from '../../constants/chat'
 import type {Props} from './input'
@@ -77,7 +77,10 @@ class ConversationInput extends Component<void, Props, State> {
   }
 
   _openFilePicker = () => {
-    ImagePicker.showImagePicker({}, (response) => {
+    ImagePicker.showImagePicker({}, response => {
+      if (response.didCancel) {
+        return
+      }
       const filename = isIOS ? response.uri.replace('file://', '') : response.path
       const conversationIDKey = this.props.selectedConversation
       if (!response.didCancel && conversationIDKey) {
@@ -96,44 +99,57 @@ class ConversationInput extends Component<void, Props, State> {
     // Auto-growing multiline doesn't work smoothly on Android yet.
     const multilineOpts = isIOS ? {rowsMax: 3, rowsMin: 1} : {rowsMax: 2, rowsMin: 2}
 
-    return (
-      <Box style={{...globalStyles.flexBoxColumn}}>
-        <Box style={{...globalStyles.flexBoxRow, alignItems: 'flex-start'}}>
-          <Input
-            autoCorrect={true}
-            autoFocus={true}
-            small={true}
-            style={styleInput}
-            ref={this._setRef}
-            hintText='Write a message'
-            hideUnderline={true}
-            onChangeText={this._onChangeText}
-            onBlur={this._onBlur}
-            value={this.state.text}
-            multiline={true}
-            {...multilineOpts}
-          />
-          <Box style={styleRight}>
-            {!this.state.text && <Icon onClick={this._openFilePicker} type='iconfont-attachment' />}
-            {!!this.state.text && <Text type='BodyBigLink' onClick={this._onSubmit}>Send</Text>}
+    const action = this.state.text
+      ? (
+        <ClickableBox feedback={false} onClick={this._onSubmit}>
+          <Box style={{padding: globalMargins.small}}>
+            <Text type='BodyBigLink'>Send</Text>
           </Box>
-        </Box>
+        </ClickableBox>
+        )
+      : <Icon onClick={this._openFilePicker} type='iconfont-attachment' style={{padding: globalMargins.small}} />
+
+    return (
+      <Box style={styleContainer}>
+        <Input
+          autoCorrect={true}
+          autoFocus={true}
+          hideUnderline={true}
+          hintText='Write a message'
+          inputStyle={styleInputText}
+          multiline={true}
+          onBlur={this._onBlur}
+          onChangeText={this._onChangeText}
+          ref={this._setRef}
+          small={true}
+          style={styleInput}
+          value={this.state.text}
+          {...multilineOpts}
+        />
+        {action}
       </Box>
     )
   }
+}
+
+const styleInputText = {
+  ...globalStyles.fontRegular,
+  fontSize: 14,
+  lineHeight: 18,
+}
+
+const styleContainer = {
+  ...globalStyles.flexBoxRow,
+  alignItems: 'center',
+  borderTopColor: globalColors.black_05,
+  borderTopWidth: 1,
+  height: 48,
 }
 
 const styleInput = {
   flex: 1,
   marginLeft: globalMargins.tiny,
   marginRight: globalMargins.tiny,
-  marginTop: globalMargins.tiny,
-}
-
-const styleRight = {
-  alignSelf: 'center',
-  marginRight: globalMargins.tiny,
-  marginTop: globalMargins.tiny,
 }
 
 export default ConversationInput

--- a/shared/chat/conversations-list/index.native.js
+++ b/shared/chat/conversations-list/index.native.js
@@ -9,7 +9,7 @@ import type {Props, RowProps} from './'
 const AddNewRow = ({onNewChat}: {onNewChat: () => void}) => (
   <Box
     style={{...globalStyles.flexBoxRow, alignItems: 'center', flexShrink: 0, justifyContent: 'center', minHeight: 48}}>
-    <ClickableBox style={{...globalStyles.flexBoxColumn}} onClick={onNewChat}>
+    <ClickableBox style={{...globalStyles.flexBoxColumn, padding: 8}} onClick={onNewChat}>
       <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', justifyContent: 'center'}}>
         <Icon type='iconfont-new' style={{color: globalColors.blue, marginRight: 9}} />
         <Text type='BodyBigLink'>New chat</Text>

--- a/shared/common-adapters/avatar.render.native.js
+++ b/shared/common-adapters/avatar.render.native.js
@@ -2,7 +2,7 @@
 import Icon from './icon'
 import React, {PureComponent} from 'react'
 import {globalColors} from '../styles'
-import {NativeTouchableWithoutFeedback, NativeImage, Box} from './index.native'
+import {ClickableBox, NativeImage, Box} from './index.native'
 
 import type {AvatarSize} from './avatar'
 import type {IconType} from './icon'
@@ -119,7 +119,7 @@ class AvatarRender extends PureComponent<void, Props, State> {
     const {url, onClick, style, size, loadingColor, borderColor, opacity, followIconType, followIconStyle, children} = this.props
 
     return (
-      <NativeTouchableWithoutFeedback onPress={onClick}>
+      <ClickableBox onPress={onClick} feedback={false}>
         <Box style={{
           height: size,
           position: 'relative',
@@ -136,7 +136,7 @@ class AvatarRender extends PureComponent<void, Props, State> {
           {followIconType && <Icon type={followIconType} style={followIconStyle} />}
           {children}
         </Box>
-      </NativeTouchableWithoutFeedback>
+      </ClickableBox>
     )
   }
 }

--- a/shared/common-adapters/avatar.render.native.js
+++ b/shared/common-adapters/avatar.render.native.js
@@ -119,7 +119,7 @@ class AvatarRender extends PureComponent<void, Props, State> {
     const {url, onClick, style, size, loadingColor, borderColor, opacity, followIconType, followIconStyle, children} = this.props
 
     return (
-      <ClickableBox onPress={onClick} feedback={false}>
+      <ClickableBox onClick={onClick} feedback={false}>
         <Box style={{
           height: size,
           position: 'relative',

--- a/shared/common-adapters/clickable-box.js.flow
+++ b/shared/common-adapters/clickable-box.js.flow
@@ -4,7 +4,7 @@ import React, {Component} from 'react'
 export type Props = {
   children?: any,
   style?: Object,
-  onClick: ?(event: SyntheticEvent) => void,
+  onClick?: ?(event: SyntheticEvent) => void,
   onPress?: void,
   underlayColor?: any,
   onPressIn?: ?() => void,

--- a/shared/common-adapters/clickable-box.js.flow
+++ b/shared/common-adapters/clickable-box.js.flow
@@ -9,6 +9,7 @@ export type Props = {
   underlayColor?: any,
   onPressIn?: ?() => void,
   onPressOut?: ?() => void,
+  feedback?: boolean,
 }
 
 declare export default class ClickableBox extends Component<void, Props, void> { }

--- a/shared/common-adapters/clickable-box.native.js
+++ b/shared/common-adapters/clickable-box.native.js
@@ -1,20 +1,34 @@
 // @flow
 import React from 'react'
 import type {Props} from './clickable-box'
-import {TouchableHighlight} from 'react-native'
+import {TouchableHighlight, TouchableWithoutFeedback} from 'react-native'
 import {globalColors} from '../styles'
 
-const ClickableBox = ({onClick, style, children, underlayColor, onPressIn, onPressOut}: Props) => (
-  <TouchableHighlight
-    disabled={!onClick}
-    onPress={onClick}
-    onPressIn={onPressIn}
-    onPressOut={onPressOut}
-    style={{...boxStyle, ...style}}
-    underlayColor={underlayColor || globalColors.black_10}>
-    {children}
-  </TouchableHighlight>
-)
+const ClickableBox = ({onClick, style, children, underlayColor, onPressIn, onPressOut, feedback = true}: Props) => {
+  if (onClick) {
+    if (feedback) {
+      return <TouchableHighlight
+        disabled={!onClick}
+        onPress={onClick}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+        style={{...boxStyle, ...style}}
+        underlayColor={underlayColor || globalColors.black_10}>
+        {children}
+      </TouchableHighlight>
+    } else {
+      return <TouchableWithoutFeedback
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+        style={{...boxStyle, ...style}}
+        onPress={onClick}>
+        {children}
+      </TouchableWithoutFeedback>
+    }
+  } else {
+    return children
+  }
+}
 
 const boxStyle = {
   borderRadius: 3,

--- a/shared/common-adapters/icon.native.js
+++ b/shared/common-adapters/icon.native.js
@@ -1,8 +1,9 @@
 // @flow
 import * as shared from './icon.shared'
+import Box from './box'
+import ClickableBox from './clickable-box'
 import React, {Component} from 'react'
 import {NativeText, NativeImage} from './native-wrappers.native'
-import {TouchableHighlight} from 'react-native'
 import {globalColors} from '../styles'
 import {iconMeta} from './icon.constants'
 
@@ -50,14 +51,14 @@ class Icon extends Component<void, Exact<Props>, void> {
       : <NativeImage source={iconMeta[iconType].require} style={{resizeMode: 'contain', ...width, ...height, ...backgroundColor}} />
 
     return (
-      <TouchableHighlight
+      <ClickableBox
         activeOpacity={0.8}
         underlayColor={this.props.underlayColor || globalColors.white}
-        onPress={this.props.onClick || (() => {})}
-        disabled={!(this.props.onClick)}
-        style={{...containerProps}}>
-        {icon}
-      </TouchableHighlight>
+        onClick={this.props.onClick}>
+        <Box style={containerProps}>
+          {icon}
+        </Box>
+      </ClickableBox>
     )
   }
 }

--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -339,7 +339,7 @@ export type ResponseType = {
 let engine
 const makeEngine = () => {
   if (__DEV__ && engine) {
-    throw new Error('makeEngine called multiple times')
+    console.warn('makeEngine called multiple times')
   }
 
   if (!engine) {


### PR DESCRIPTION
- [x] Input styling closer to zeplin
- [x] Fixes hit areas for attachments, info pane, send
- [x] Dont make clickable areas for icons/avatars w/o onClick handlers
- [x] Click attachments then cancel crashes JS
- [x] multiple makeengine uses yellowbox instead of throwing

@keybase/react-hackers 