### PR TITLE
Add NoSessionError exported error type

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -143,6 +143,7 @@ const (
 	SCInputError             = int(keybase1.StatusCode_SCInputError)
 	SCLoginRequired          = int(keybase1.StatusCode_SCLoginRequired)
 	SCBadSession             = int(keybase1.StatusCode_SCBadSession)
+	SCNoSession              = int(keybase1.StatusCode_SCNoSession)
 	SCBadLoginUserNotFound   = int(keybase1.StatusCode_SCBadLoginUserNotFound)
 	SCBadLoginPassword       = int(keybase1.StatusCode_SCBadLoginPassword)
 	SCNotFound               = int(keybase1.StatusCode_SCNotFound)

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -518,6 +518,13 @@ func (e DeviceRequiredError) Error() string {
 	return "Login required"
 }
 
+type NoSessionError struct{}
+
+// KBFS currently matching on this string, so be careful changing this:
+func (e NoSessionError) Error() string {
+	return "no current session"
+}
+
 //=============================================================================
 
 type LogoutError struct{}

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -233,6 +233,8 @@ func ImportStatusAsError(s *keybase1.Status) error {
 		return NoSecretKeyError{}
 	case SCLoginRequired:
 		return LoginRequiredError{s.Desc}
+	case SCNoSession:
+		return NoSessionError{}
 	case SCKeyInUse:
 		var fp *PGPFingerprint
 		if len(s.Desc) > 0 {
@@ -1115,6 +1117,14 @@ func (u LoginRequiredError) ToStatus() (s keybase1.Status) {
 	s.Code = SCLoginRequired
 	s.Name = "LOGIN_REQUIRED"
 	s.Desc = u.Context
+	return
+}
+
+//=============================================================================
+
+func (u NoSessionError) ToStatus() (s keybase1.Status) {
+	s.Code = SCNoSession
+	s.Name = "NO_SESSION"
 	return
 }
 

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -32,7 +32,7 @@ const (
 	StatusCode_SCWrongCryptoFormat      StatusCode = 279
 	StatusCode_SCDecryptionError        StatusCode = 280
 	StatusCode_SCInvalidAddress         StatusCode = 281
-	StatusCode_SCNoSession              StatusCode = 282
+	StatusCode_SCNoSession              StatusCode = 283
 	StatusCode_SCBadEmail               StatusCode = 472
 	StatusCode_SCBadSignupUsernameTaken StatusCode = 701
 	StatusCode_SCBadInvitationCode      StatusCode = 707
@@ -122,7 +122,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCWrongCryptoFormat":      279,
 	"SCDecryptionError":        280,
 	"SCInvalidAddress":         281,
-	"SCNoSession":              282,
+	"SCNoSession":              283,
 	"SCBadEmail":               472,
 	"SCBadSignupUsernameTaken": 701,
 	"SCBadInvitationCode":      707,
@@ -212,7 +212,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	279:  "SCWrongCryptoFormat",
 	280:  "SCDecryptionError",
 	281:  "SCInvalidAddress",
-	282:  "SCNoSession",
+	283:  "SCNoSession",
 	472:  "SCBadEmail",
 	701:  "SCBadSignupUsernameTaken",
 	707:  "SCBadInvitationCode",

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -32,6 +32,7 @@ const (
 	StatusCode_SCWrongCryptoFormat      StatusCode = 279
 	StatusCode_SCDecryptionError        StatusCode = 280
 	StatusCode_SCInvalidAddress         StatusCode = 281
+	StatusCode_SCNoSession              StatusCode = 282
 	StatusCode_SCBadEmail               StatusCode = 472
 	StatusCode_SCBadSignupUsernameTaken StatusCode = 701
 	StatusCode_SCBadInvitationCode      StatusCode = 707
@@ -121,6 +122,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCWrongCryptoFormat":      279,
 	"SCDecryptionError":        280,
 	"SCInvalidAddress":         281,
+	"SCNoSession":              282,
 	"SCBadEmail":               472,
 	"SCBadSignupUsernameTaken": 701,
 	"SCBadInvitationCode":      707,
@@ -210,6 +212,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	279:  "SCWrongCryptoFormat",
 	280:  "SCDecryptionError",
 	281:  "SCInvalidAddress",
+	282:  "SCNoSession",
 	472:  "SCBadEmail",
 	701:  "SCBadSignupUsernameTaken",
 	707:  "SCBadInvitationCode",

--- a/go/service/session.go
+++ b/go/service/session.go
@@ -4,16 +4,12 @@
 package service
 
 import (
-	"errors"
-
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
-
-var ErrNoSession = errors.New("no current session")
 
 // SessionHandler is the RPC handler for the session interface.
 type SessionHandler struct {
@@ -51,7 +47,7 @@ func (h *SessionHandler) CurrentSession(_ context.Context, sessionID int) (keyba
 	}
 	if err != nil {
 		if _, ok := err.(libkb.LoginRequiredError); ok {
-			return s, ErrNoSession
+			return s, libkb.NoSessionError{}
 		}
 		return s, err
 	}

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -24,6 +24,7 @@ protocol constants {
     SCWrongCryptoFormat_279,
     SCDecryptionError_280,
     SCInvalidAddress_281,
+    SCNoSession_282,
     SCBadEmail_472,
     SCBadSignupUsernameTaken_701,
     SCBadInvitationCode_707,

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -24,7 +24,7 @@ protocol constants {
     SCWrongCryptoFormat_279,
     SCDecryptionError_280,
     SCInvalidAddress_281,
-    SCNoSession_282,
+    SCNoSession_283,
     SCBadEmail_472,
     SCBadSignupUsernameTaken_701,
     SCBadInvitationCode_707,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -117,6 +117,7 @@ export const ConstantsStatusCode = {
   scwrongcryptoformat: 279,
   scdecryptionerror: 280,
   scinvalidaddress: 281,
+  scnosession: 282,
   scbademail: 472,
   scbadsignupusernametaken: 701,
   scbadinvitationcode: 707,
@@ -4534,6 +4535,7 @@ export type StatusCode =
   | 279 // SCWrongCryptoFormat_279
   | 280 // SCDecryptionError_280
   | 281 // SCInvalidAddress_281
+  | 282 // SCNoSession_282
   | 472 // SCBadEmail_472
   | 701 // SCBadSignupUsernameTaken_701
   | 707 // SCBadInvitationCode_707

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -117,7 +117,7 @@ export const ConstantsStatusCode = {
   scwrongcryptoformat: 279,
   scdecryptionerror: 280,
   scinvalidaddress: 281,
-  scnosession: 282,
+  scnosession: 283,
   scbademail: 472,
   scbadsignupusernametaken: 701,
   scbadinvitationcode: 707,
@@ -4535,7 +4535,7 @@ export type StatusCode =
   | 279 // SCWrongCryptoFormat_279
   | 280 // SCDecryptionError_280
   | 281 // SCInvalidAddress_281
-  | 282 // SCNoSession_282
+  | 283 // SCNoSession_283
   | 472 // SCBadEmail_472
   | 701 // SCBadSignupUsernameTaken_701
   | 707 // SCBadInvitationCode_707

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -28,6 +28,7 @@
         "SCWrongCryptoFormat_279",
         "SCDecryptionError_280",
         "SCInvalidAddress_281",
+        "SCNoSession_282",
         "SCBadEmail_472",
         "SCBadSignupUsernameTaken_701",
         "SCBadInvitationCode_707",

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -28,7 +28,7 @@
         "SCWrongCryptoFormat_279",
         "SCDecryptionError_280",
         "SCInvalidAddress_281",
-        "SCNoSession_282",
+        "SCNoSession_283",
         "SCBadEmail_472",
         "SCBadSignupUsernameTaken_701",
         "SCBadInvitationCode_707",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -117,6 +117,7 @@ export const ConstantsStatusCode = {
   scwrongcryptoformat: 279,
   scdecryptionerror: 280,
   scinvalidaddress: 281,
+  scnosession: 282,
   scbademail: 472,
   scbadsignupusernametaken: 701,
   scbadinvitationcode: 707,
@@ -4534,6 +4535,7 @@ export type StatusCode =
   | 279 // SCWrongCryptoFormat_279
   | 280 // SCDecryptionError_280
   | 281 // SCInvalidAddress_281
+  | 282 // SCNoSession_282
   | 472 // SCBadEmail_472
   | 701 // SCBadSignupUsernameTaken_701
   | 707 // SCBadInvitationCode_707

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -117,7 +117,7 @@ export const ConstantsStatusCode = {
   scwrongcryptoformat: 279,
   scdecryptionerror: 280,
   scinvalidaddress: 281,
-  scnosession: 282,
+  scnosession: 283,
   scbademail: 472,
   scbadsignupusernametaken: 701,
   scbadinvitationcode: 707,
@@ -4535,7 +4535,7 @@ export type StatusCode =
   | 279 // SCWrongCryptoFormat_279
   | 280 // SCDecryptionError_280
   | 281 // SCInvalidAddress_281
-  | 282 // SCNoSession_282
+  | 283 // SCNoSession_283
   | 472 // SCBadEmail_472
   | 701 // SCBadSignupUsernameTaken_701
   | 707 // SCBadInvitationCode_707


### PR DESCRIPTION
service/session.go was returning non-exported error.  This adds an exportable error and uses that instead.

cc @strib 