### PR TITLE
Fix proof checking on Android via UserAgent

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -494,7 +494,7 @@ func (a *InternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
 		}
 	}
 	if a.G().Env.GetTorMode().UseHeaders() {
-		req.Header.Set("User-Agent", UserAgent())
+		req.Header.Set("User-Agent", UserAgent)
 		identifyAs := GoClientID + " v" + VersionString() + " " + runtime.GOOS
 		req.Header.Set("X-Keybase-Client", identifyAs)
 		if a.G().Env.GetDeviceID().Exists() {
@@ -710,10 +710,15 @@ func (api *ExternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
 	// want in Tor mode. Clients that are actually using Tor will always be
 	// distinguishable from the rest, insofar as their originating IP will be a
 	// Tor exit node, but there may be other use cases where this matters more?
-	userAgent := UserAgent()
+	userAgent := UserAgent
 	// Awful hack to make reddit as happy as possible.
 	if isReddit(req) {
 		userAgent += " (by /u/oconnor663)"
+	} else {
+		// For non-reddit sites we don't want to be served mobile HTML.
+		if runtime.GOOS == "android" {
+			userAgent = strings.Replace(userAgent, "android", "linux", 1)
+		}
 	}
 	if api.G().Env.GetTorMode().UseHeaders() {
 		req.Header.Set("User-Agent", userAgent)

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -494,7 +494,7 @@ func (a *InternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
 		}
 	}
 	if a.G().Env.GetTorMode().UseHeaders() {
-		req.Header.Set("User-Agent", UserAgent)
+		req.Header.Set("User-Agent", UserAgent())
 		identifyAs := GoClientID + " v" + VersionString() + " " + runtime.GOOS
 		req.Header.Set("X-Keybase-Client", identifyAs)
 		if a.G().Env.GetDeviceID().Exists() {
@@ -710,15 +710,10 @@ func (api *ExternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
 	// want in Tor mode. Clients that are actually using Tor will always be
 	// distinguishable from the rest, insofar as their originating IP will be a
 	// Tor exit node, but there may be other use cases where this matters more?
-	userAgent := UserAgent
+	userAgent := UserAgent()
 	// Awful hack to make reddit as happy as possible.
 	if isReddit(req) {
 		userAgent += " (by /u/oconnor663)"
-	} else {
-		// For non-reddit sites we don't want to be served mobile HTML.
-		if runtime.GOOS == "android" {
-			userAgent = strings.Replace(userAgent, "android", "linux", 1)
-		}
 	}
 	if api.G().Env.GetTorMode().UseHeaders() {
 		req.Header.Set("User-Agent", userAgent)

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -494,7 +494,7 @@ func (a *InternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
 		}
 	}
 	if a.G().Env.GetTorMode().UseHeaders() {
-		req.Header.Set("User-Agent", UserAgent)
+		req.Header.Set("User-Agent", UserAgent())
 		identifyAs := GoClientID + " v" + VersionString() + " " + runtime.GOOS
 		req.Header.Set("X-Keybase-Client", identifyAs)
 		if a.G().Env.GetDeviceID().Exists() {
@@ -710,7 +710,7 @@ func (api *ExternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
 	// want in Tor mode. Clients that are actually using Tor will always be
 	// distinguishable from the rest, insofar as their originating IP will be a
 	// Tor exit node, but there may be other use cases where this matters more?
-	userAgent := UserAgent
+	userAgent := UserAgent()
 	// Awful hack to make reddit as happy as possible.
 	if isReddit(req) {
 		userAgent += " (by /u/oconnor663)"

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -71,15 +71,7 @@ const (
 // Right now reddit is the only site that seems to have any requirements for
 // our User-Agent string. (See https://github.com/reddit/reddit/wiki/API.)If
 // something else comes up, we'll want to make this more configurable.
-func UserAgent () string {
-	// Twitter and Facebook serve up mobile versions of their sites if
-	// our useragent contains "android", breaking PVL; pretend to be Linux.
-	var OS = runtime.GOOS
-	if runtime.GOOS == "android" {
-		OS = "linux"
-	}
-	return OS + ":" + "Keybase CLI (" + runtime.Version() + "):" + Version
-}
+var UserAgent = runtime.GOOS + ":" + "Keybase CLI (" + runtime.Version() + "):" + Version
 
 const (
 	PermFile          os.FileMode = 0600

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -71,7 +71,15 @@ const (
 // Right now reddit is the only site that seems to have any requirements for
 // our User-Agent string. (See https://github.com/reddit/reddit/wiki/API.)If
 // something else comes up, we'll want to make this more configurable.
-var UserAgent = runtime.GOOS + ":" + "Keybase CLI (" + runtime.Version() + "):" + Version
+func UserAgent () string {
+	// Twitter and Facebook serve up mobile versions of their sites if
+	// our useragent contains "android", breaking PVL; pretend to be Linux.
+	var OS = runtime.GOOS
+	if runtime.GOOS == "android" {
+		OS = "linux"
+	}
+	return OS + ":" + "Keybase CLI (" + runtime.Version() + "):" + Version
+}
 
 const (
 	PermFile          os.FileMode = 0600


### PR DESCRIPTION
r? @oconnor663  CC @keybase/react-hackers @mlsteele 

Our useragents at the moment look like this:
```
linux:   linux:Keybase CLI (go1.7.5):1.0.20
macos:   darwin:Keybase CLI (go1.7.5):1.0.20
iphone:  darwin:Keybase CLI (go1.7.5):1.0.20
android: android:Keybase CLI (go1.7.5):1.0.20
```
Facebook and Twitter detect "android" in the useragent and serve up mobile sites, breaking proof verification on Android.  Pretending to be Linux (which seems to match up with iOS being Darwin..) makes proofs work.