### PR TITLE
Add pvlhash to proof cache

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -101,7 +101,7 @@ func (i *Identify2WithUIDTester) MakeProofChecker(_ libkb.RemoteProofChainLink) 
 }
 func (i *Identify2WithUIDTester) GetServiceType(n string) libkb.ServiceType { return i }
 
-func (i *Identify2WithUIDTester) CheckStatus(_ libkb.ProofContext, h libkb.SigHint, pcm libkb.ProofCheckerMode) libkb.ProofError {
+func (i *Identify2WithUIDTester) CheckStatus(_ libkb.ProofContext, h libkb.SigHint, pcm libkb.ProofCheckerMode, _ libkb.PvlUnparsed) libkb.ProofError {
 	if i.checkStatusHook != nil {
 		return i.checkStatusHook(h, pcm)
 	}

--- a/go/engine/scanproofs.go
+++ b/go/engine/scanproofs.go
@@ -397,7 +397,16 @@ func (e *ScanProofsEngine) CheckOne(ctx *Context, rec map[string]string, tickers
 		<-tickers[ptype].C
 	}
 
-	perr := pc.CheckStatus(e.G(), *hint, libkb.ProofCheckerModeActive)
+	pvlSource := e.G().GetPvlSource()
+	if pvlSource == nil {
+		return nil, foundhint, fmt.Errorf("no pvl source for proof verification")
+	}
+	pvlU, err := pvlSource.GetPVL(ctx.GetNetContext())
+	if err != nil {
+		return nil, foundhint, fmt.Errorf("error getting pvl: %s", err)
+	}
+
+	perr := pc.CheckStatus(e.G(), *hint, libkb.ProofCheckerModeActive, pvlU)
 	if perr != nil {
 		return perr, foundhint, nil
 	}

--- a/go/externals/common.go
+++ b/go/externals/common.go
@@ -9,14 +9,6 @@ import (
 	"github.com/keybase/client/go/pvl"
 )
 
-func CheckProofPvl(ctx libkb.ProofContext, proofType keybase1.ProofType, proof libkb.RemoteProofChainLink, hint libkb.SigHint) libkb.ProofError {
-	pvlSource := ctx.GetPvlSource()
-	if pvlSource == nil {
-		return libkb.NewProofError(keybase1.ProofStatus_MISSING_PVL, "no pvl source for proof verification")
-	}
-	pvlString, err := pvlSource.GetPVL(ctx.GetNetContext(), pvl.SupportedVersion)
-	if err != nil {
-		return libkb.NewProofError(keybase1.ProofStatus_MISSING_PVL, "error getting pvl: %s", err)
-	}
-	return pvl.CheckProof(ctx, pvlString, proofType, pvl.NewProofInfo(proof, hint))
+func CheckProofPvl(ctx libkb.ProofContext, proofType keybase1.ProofType, proof libkb.RemoteProofChainLink, hint libkb.SigHint, pvlU libkb.PvlUnparsed) libkb.ProofError {
+	return pvl.CheckProof(ctx, string(pvlU.Pvl), proofType, pvl.NewProofInfo(proof, hint))
 }

--- a/go/externals/proof_support_dns.go
+++ b/go/externals/proof_support_dns.go
@@ -27,12 +27,12 @@ func NewDNSChecker(p libkb.RemoteProofChainLink) (*DNSChecker, libkb.ProofError)
 
 func (rc *DNSChecker) GetTorError() libkb.ProofError { return libkb.ProofErrorDNSOverTor }
 
-func (rc *DNSChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, pcm libkb.ProofCheckerMode) libkb.ProofError {
+func (rc *DNSChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, pcm libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
 	if pcm != libkb.ProofCheckerModeActive {
 		ctx.GetLog().CDebugf(ctx.GetNetContext(), "DNS check skipped since proof checking was not in active mode (%s)", h.GetAPIURL())
 		return libkb.ProofErrorUnchecked
 	}
-	return CheckProofPvl(ctx, keybase1.ProofType_DNS, rc.proof, h)
+	return CheckProofPvl(ctx, keybase1.ProofType_DNS, rc.proof, h, pvlU)
 }
 
 //

--- a/go/externals/proof_support_facebook.go
+++ b/go/externals/proof_support_facebook.go
@@ -30,8 +30,8 @@ func NewFacebookChecker(p libkb.RemoteProofChainLink) (*FacebookChecker, libkb.P
 
 func (rc *FacebookChecker) GetTorError() libkb.ProofError { return nil }
 
-func (rc *FacebookChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode) libkb.ProofError {
-	return CheckProofPvl(ctx, keybase1.ProofType_FACEBOOK, rc.proof, h)
+func (rc *FacebookChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
+	return CheckProofPvl(ctx, keybase1.ProofType_FACEBOOK, rc.proof, h, pvlU)
 }
 
 //

--- a/go/externals/proof_support_github.go
+++ b/go/externals/proof_support_github.go
@@ -28,8 +28,8 @@ func NewGithubChecker(p libkb.RemoteProofChainLink) (*GithubChecker, libkb.Proof
 
 func (rc *GithubChecker) GetTorError() libkb.ProofError { return nil }
 
-func (rc *GithubChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode) libkb.ProofError {
-	return CheckProofPvl(ctx, keybase1.ProofType_GITHUB, rc.proof, h)
+func (rc *GithubChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
+	return CheckProofPvl(ctx, keybase1.ProofType_GITHUB, rc.proof, h, pvlU)
 }
 
 //

--- a/go/externals/proof_support_hackernews.go
+++ b/go/externals/proof_support_hackernews.go
@@ -28,8 +28,8 @@ func NewHackerNewsChecker(p libkb.RemoteProofChainLink) (*HackerNewsChecker, lib
 	return &HackerNewsChecker{p}, nil
 }
 
-func (h *HackerNewsChecker) CheckStatus(ctx libkb.ProofContext, hint libkb.SigHint, _ libkb.ProofCheckerMode) libkb.ProofError {
-	return CheckProofPvl(ctx, keybase1.ProofType_HACKERNEWS, h.proof, hint)
+func (h *HackerNewsChecker) CheckStatus(ctx libkb.ProofContext, hint libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
+	return CheckProofPvl(ctx, keybase1.ProofType_HACKERNEWS, h.proof, hint, pvlU)
 }
 
 //=============================================================================

--- a/go/externals/proof_support_reddit.go
+++ b/go/externals/proof_support_reddit.go
@@ -34,8 +34,8 @@ func NewRedditChecker(p libkb.RemoteProofChainLink) (*RedditChecker, libkb.Proof
 
 func (rc *RedditChecker) GetTorError() libkb.ProofError { return nil }
 
-func (rc *RedditChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode) libkb.ProofError {
-	return CheckProofPvl(ctx, keybase1.ProofType_REDDIT, rc.proof, h)
+func (rc *RedditChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
+	return CheckProofPvl(ctx, keybase1.ProofType_REDDIT, rc.proof, h, pvlU)
 }
 
 //

--- a/go/externals/proof_support_rooter.go
+++ b/go/externals/proof_support_rooter.go
@@ -30,8 +30,8 @@ func NewRooterChecker(p libkb.RemoteProofChainLink) (*RooterChecker, libkb.Proof
 
 func (rc *RooterChecker) GetTorError() libkb.ProofError { return nil }
 
-func (rc *RooterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode) (perr libkb.ProofError) {
-	return CheckProofPvl(ctx, keybase1.ProofType_ROOTER, rc.proof, h)
+func (rc *RooterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) (perr libkb.ProofError) {
+	return CheckProofPvl(ctx, keybase1.ProofType_ROOTER, rc.proof, h, pvlU)
 }
 
 //

--- a/go/externals/proof_support_twitter.go
+++ b/go/externals/proof_support_twitter.go
@@ -28,8 +28,8 @@ func NewTwitterChecker(p libkb.RemoteProofChainLink) (*TwitterChecker, libkb.Pro
 
 func (rc *TwitterChecker) GetTorError() libkb.ProofError { return nil }
 
-func (rc *TwitterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode) libkb.ProofError {
-	return CheckProofPvl(ctx, keybase1.ProofType_TWITTER, rc.proof, h)
+func (rc *TwitterChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, _ libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
+	return CheckProofPvl(ctx, keybase1.ProofType_TWITTER, rc.proof, h, pvlU)
 }
 
 //

--- a/go/externals/proof_support_web.go
+++ b/go/externals/proof_support_web.go
@@ -41,12 +41,12 @@ func (rc *WebChecker) GetTorError() libkb.ProofError {
 	return nil
 }
 
-func (rc *WebChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, pcm libkb.ProofCheckerMode) libkb.ProofError {
+func (rc *WebChecker) CheckStatus(ctx libkb.ProofContext, h libkb.SigHint, pcm libkb.ProofCheckerMode, pvlU libkb.PvlUnparsed) libkb.ProofError {
 	if pcm != libkb.ProofCheckerModeActive {
 		ctx.GetLog().CDebugf(ctx.GetNetContext(), "Web check skipped since proof checking was not in active mode (%s)", h.GetAPIURL())
 		return libkb.ProofErrorUnchecked
 	}
-	return CheckProofPvl(ctx, keybase1.ProofType_GENERIC_WEB_SITE, rc.proof, h)
+	return CheckProofPvl(ctx, keybase1.ProofType_GENERIC_WEB_SITE, rc.proof, h, pvlU)
 }
 
 //

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -83,16 +83,24 @@ const (
 	UserCacheMaxAge      = 5 * time.Minute
 	PGPFingerprintHexLen = 40
 
-	ProofCacheSize              = 0x1000
-	ProofCacheLongDur           = 48 * time.Hour
-	ProofCacheMediumDur         = 6 * time.Hour
-	ProofCacheShortDur          = 30 * time.Minute
+	ProofCacheSize      = 0x1000
+	ProofCacheLongDur   = 48 * time.Hour
+	ProofCacheMediumDur = 6 * time.Hour
+	ProofCacheShortDur  = 30 * time.Minute
+
+	// How old the merkle root must be to ask for a refresh.
+	// Measures time since the root was fetched, not time since published.
+	PvlSourceShouldRefresh time.Duration = 1 * time.Hour
+	// An older merkle root than this is too old to use. All identifies will fail.
+	PvlSourceRequireRefresh time.Duration = 24 * time.Hour
+
 	Identify2CacheLongTimeout   = 6 * time.Hour
 	Identify2CacheBrokenTimeout = 1 * time.Hour
 	Identify2CacheShortTimeout  = 1 * time.Minute
-	CachedUserTimeout           = 10 * time.Minute // How long we'll go without rerequesting hints/merkle seqno
-	LinkCacheSize               = 0x10000
-	LinkCacheCleanDur           = 1 * time.Minute
+
+	CachedUserTimeout = 10 * time.Minute // How long we'll go without rerequesting hints/merkle seqno
+	LinkCacheSize     = 0x10000
+	LinkCacheCleanDur = 1 * time.Minute
 
 	SigShortIDBytes  = 27
 	LocalTrackMaxAge = 48 * time.Hour
@@ -513,3 +521,17 @@ func StringToAppType(s string) AppType {
 
 // UID of t_alice
 const TAliceUID = keybase1.UID("295a7eea607af32040647123732bc819")
+
+// Pvl kit hash, pegged to merkle tree.
+type PvlKitHash string
+
+// String containing a pvl kit.
+type PvlKitString string
+
+// String containing a pvl chunk.
+type PvlString string
+
+type PvlUnparsed struct {
+	Hash PvlKitHash
+	Pvl  PvlString
+}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -494,7 +494,7 @@ const (
 )
 
 type ProofChecker interface {
-	CheckStatus(ctx ProofContext, h SigHint, pcm ProofCheckerMode) ProofError
+	CheckStatus(ctx ProofContext, h SigHint, pcm ProofCheckerMode, pvlU PvlUnparsed) ProofError
 	GetTorError() ProofError
 }
 
@@ -541,7 +541,7 @@ type ExternalServicesCollector interface {
 }
 
 type PvlSource interface {
-	GetPVL(ctx context.Context, pvlVersion int) (string, error)
+	GetPVL(ctx context.Context) (PvlUnparsed, error)
 }
 
 // UserChangedHandler is a generic interface for handling user changed events.

--- a/go/libkb/proof_cache.go
+++ b/go/libkb/proof_cache.go
@@ -14,8 +14,9 @@ import (
 
 type CheckResult struct {
 	Contextified
-	Status ProofError // Or nil if it was a success
-	Time   time.Time  // When the last check was
+	Status  ProofError // Or nil if it was a success
+	Time    time.Time  // When the last check was
+	PvlHash string     // Added after other fields. Some entries may not have this packed.
 }
 
 func (cr CheckResult) Pack() *jsonw.Wrapper {
@@ -25,6 +26,7 @@ func (cr CheckResult) Pack() *jsonw.Wrapper {
 		s.SetKey("code", jsonw.NewInt(int(cr.Status.GetProofStatus())))
 		s.SetKey("desc", jsonw.NewString(cr.Status.GetDesc()))
 		p.SetKey("status", s)
+		p.SetKey("pvlhash", jsonw.NewString(cr.PvlHash))
 	}
 	p.SetKey("time", jsonw.NewInt64(cr.Time.Unix()))
 	return p
@@ -65,11 +67,14 @@ func NewNowCheckResult(g *GlobalContext, pe ProofError) *CheckResult {
 }
 
 func NewCheckResult(g *GlobalContext, jw *jsonw.Wrapper) (res *CheckResult, err error) {
+	var ignoreErr error
 	var t int64
 	var code int
 	var desc string
+	var pvlHash string
 
 	jw.AtKey("time").GetInt64Void(&t, &err)
+	jw.AtKey("pvlhash").GetStringVoid(&pvlHash, &ignoreErr)
 	status := jw.AtKey("status")
 	var pe ProofError
 
@@ -83,6 +88,7 @@ func NewCheckResult(g *GlobalContext, jw *jsonw.Wrapper) (res *CheckResult, err 
 			Contextified: NewContextified(g),
 			Status:       pe,
 			Time:         time.Unix(t, 0),
+			PvlHash:      pvlHash,
 		}
 	}
 	return
@@ -165,7 +171,7 @@ func (pc *ProofCache) memPut(sid keybase1.SigID, cr CheckResult) {
 	pc.lru.Add(sid, cr)
 }
 
-func (pc *ProofCache) Get(sid keybase1.SigID) *CheckResult {
+func (pc *ProofCache) Get(sid keybase1.SigID, pvlHash PvlKitHash) *CheckResult {
 	if pc == nil {
 		return nil
 	}
@@ -174,6 +180,19 @@ func (pc *ProofCache) Get(sid keybase1.SigID) *CheckResult {
 	if cr == nil {
 		cr = pc.dbGet(sid)
 	}
+	if cr == nil {
+		return nil
+	}
+
+	if cr.PvlHash == "" {
+		pc.G().Log.Debug("^ ProofCache ignoring entry with pvl-hash empty")
+		return nil
+	}
+	if cr.PvlHash != string(pvlHash) {
+		pc.G().Log.Debug("^ ProofCache ignoring entry with pvl-hash mismatch")
+		return nil
+	}
+
 	return cr
 }
 
@@ -233,7 +252,7 @@ func (pc *ProofCache) dbPut(sid keybase1.SigID, cr CheckResult) error {
 	return pc.G().LocalDb.Put(dbkey, []DbKey{}, jw)
 }
 
-func (pc *ProofCache) Put(sid keybase1.SigID, pe ProofError) error {
+func (pc *ProofCache) Put(sid keybase1.SigID, pe ProofError, pvlHash PvlKitHash) error {
 	if pc == nil {
 		return nil
 	}
@@ -241,6 +260,7 @@ func (pc *ProofCache) Put(sid keybase1.SigID, pe ProofError) error {
 		Contextified: pc.Contextified,
 		Status:       pe,
 		Time:         pc.G().Clock().Now(),
+		PvlHash:      string(pvlHash),
 	}
 	pc.memPut(sid, cr)
 	return pc.dbPut(sid, cr)


### PR DESCRIPTION
This invalidates the proof cache whenever pvl changes. The point of this is so that clients quickly respond to changes. Before this change, a client could cache a failing proof for 30min and a passing proof for 48 hours after being informed how to check them the new way.

The `ProofCache` stores `CheckResult`s. We can't blow away all results because of how the db works (as far as I can tell). Instead this PR adds `CheckResult.PvlHash` and whenever `Get(sigID, pvlHash)` is called it only returns the cached object is `pvlHash` is a match.

Most of the shuffling here is shuttling the pvl around so that we know which pvlHash was used in order to cache with it.