### PR TITLE
context: propagate RPC tags as log tags

### DIFF
--- a/go/libkb/net_context.go
+++ b/go/libkb/net_context.go
@@ -10,6 +10,8 @@ import (
 type withLogTagKey string
 
 func WithLogTag(ctx context.Context, k string) context.Context {
+	ctx = logger.ConvertRPCTagsToLogTags(ctx)
+
 	addLogTags := true
 	tagKey := withLogTagKey(k)
 


### PR DESCRIPTION
This lets the service print KBFS log tags that are passed via RPC.

Issue: KBFS-2035