### PR TITLE
split attachments out of index.js

### DIFF
--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -1,0 +1,346 @@
+// @flow
+import * as ChatTypes from '../../constants/types/flow-types-chat'
+import * as Constants from '../../constants/chat'
+import * as RPCTypes from '../../constants/types/flow-types'
+import {call, put, select, cancel, fork, join} from 'redux-saga/effects'
+import {delay} from 'redux-saga'
+import {isMobile} from '../../constants/platform'
+import {loadAttachment as loadAttachmentAction, updateTempMessage} from './creators'
+import {navigateAppend} from '../route-tree'
+import {safeTakeEvery, singleFixedChannelConfig, closeChannelMap, takeFromChannelMap, effectOnChannelMap} from '../../util/saga'
+import {saveAttachment, showShareActionSheet} from '../platform.specific'
+import {tmpFile, downloadFilePath, copy, exists} from '../../util/file'
+import {tmpFileName, messageSelector, startNewConversation, appendMessageActionTransformer, getPostingIdentifyBehavior, clientHeader} from './shared'
+import {usernameSelector} from '../../constants/selectors'
+
+import type {SagaGenerator} from '../../constants/types/saga'
+
+function * onShareAttachment ({payload: {message}}: Constants.ShareAttachment): SagaGenerator<any, any> {
+  const {filename, messageID, conversationIDKey} = message
+  if (!filename || !messageID) {
+    return
+  }
+
+  const path = downloadFilePath(filename)
+  yield call(onLoadAttachment, ({
+    type: 'chat:loadAttachment',
+    payload: {
+      conversationIDKey,
+      messageID,
+      loadPreview: false,
+      isHdPreview: false,
+      filename: path,
+    },
+  }: Constants.LoadAttachment))
+  yield call(showShareActionSheet, {url: path})
+}
+
+function * onSaveAttachmentNative ({payload: {message}}: Constants.SaveAttachment): SagaGenerator<any, any> {
+  const {filename, messageID, conversationIDKey} = message
+  if (!filename || !messageID) {
+    return
+  }
+
+  const path = downloadFilePath(filename)
+  yield call(onLoadAttachment, ({
+    type: 'chat:loadAttachment',
+    payload: {
+      conversationIDKey,
+      messageID,
+      loadPreview: false,
+      isHdPreview: false,
+      filename: path,
+    },
+  }: Constants.LoadAttachment))
+  yield call(saveAttachment, path)
+}
+
+// Instead of redownloading the full attachment again, we may have it cached from an earlier hdPreview
+// returns cached filepath
+function * _isCached (conversationIDKey, messageID): Generator<any, ?string, any> {
+  try {
+    const message = yield select(messageSelector, conversationIDKey, messageID)
+    if (message.hdPreviewPath) {
+      return message.hdPreviewPath
+    }
+  } catch (e) {
+    console.warn('error in checking cached file', e)
+    return
+  }
+}
+
+// TODO load previews too
+function * onLoadAttachment ({payload: {conversationIDKey, messageID, loadPreview, isHdPreview, filename}}: Constants.LoadAttachment): SagaGenerator<any, any> {
+  // See if we already have this image cached
+  if (loadPreview || isHdPreview) {
+    const imageCached = yield call(exists, filename)
+    if (imageCached) {
+      const action: Constants.AttachmentLoaded = {
+        type: 'chat:attachmentLoaded',
+        payload: {conversationIDKey, messageID, path: filename, isPreview: loadPreview, isHdPreview: isHdPreview},
+      }
+      yield put(action)
+      return
+    }
+  }
+
+  // If we are loading the actual attachment,
+  // let's see if we've already downloaded it as an hdPreview
+  if (!loadPreview && !isHdPreview) {
+    const cachedPath = yield call(_isCached, conversationIDKey, messageID)
+
+    if (cachedPath) {
+      copy(cachedPath, filename)
+
+      // for visual feedback, we'll briefly display a progress bar
+      for (let i = 0; i < 5; i++) {
+        const fakeProgressAction: Constants.DownloadProgress = {
+          type: 'chat:downloadProgress',
+          payload: {conversationIDKey, messageID, isPreview: false, bytesComplete: i + 1, bytesTotal: 5},
+        }
+        yield put(fakeProgressAction)
+        yield delay(5)
+      }
+
+      const action: Constants.AttachmentLoaded = {
+        type: 'chat:attachmentLoaded',
+        payload: {conversationIDKey, messageID, path: filename, isPreview: loadPreview, isHdPreview: isHdPreview},
+      }
+      yield put(action)
+      return
+    }
+  }
+
+  const param = {
+    conversationID: Constants.keyToConversationID(conversationIDKey),
+    messageID,
+    filename,
+    preview: loadPreview,
+    identifyBehavior: RPCTypes.TlfKeysTLFIdentifyBehavior.chatGui,
+  }
+
+  const channelConfig = singleFixedChannelConfig([
+    'chat.1.chatUi.chatAttachmentDownloadStart',
+    'chat.1.chatUi.chatAttachmentDownloadProgress',
+    'chat.1.chatUi.chatAttachmentDownloadDone',
+  ])
+
+  const channelMap = ((yield call(ChatTypes.localDownloadFileAttachmentLocalRpcChannelMap, channelConfig, {param})): any)
+
+  const progressTask = yield effectOnChannelMap(c => safeTakeEvery(c, function * ({response}) {
+    const {bytesComplete, bytesTotal} = response.param
+    const action: Constants.DownloadProgress = {
+      type: 'chat:downloadProgress',
+      payload: {conversationIDKey, messageID, isPreview: loadPreview || isHdPreview, bytesTotal, bytesComplete},
+    }
+    yield put(action)
+    response.result()
+  }), channelMap, 'chat.1.chatUi.chatAttachmentDownloadProgress')
+
+  {
+    const {response} = yield takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentDownloadStart')
+    response.result()
+  }
+
+  {
+    const {response} = yield takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentDownloadDone')
+    response.result()
+  }
+
+  yield cancel(progressTask)
+  closeChannelMap(channelMap)
+
+  const action: Constants.AttachmentLoaded = {
+    type: 'chat:attachmentLoaded',
+    payload: {conversationIDKey, messageID, path: filename, isPreview: loadPreview, isHdPreview: isHdPreview},
+  }
+  yield put(action)
+}
+
+const _temporaryAttachmentMessageForUpload = (convID: Constants.ConversationIDKey, username: string, title: string, filename: string, outboxID: Constants.OutboxIDKey, previewType: $PropertyType<Constants.AttachmentMessage, 'previewType'>, previewSize: $PropertyType<Constants.AttachmentMessage, 'previewSize'>) => ({
+  type: 'Attachment',
+  timestamp: Date.now(),
+  conversationIDKey: convID,
+  followState: 'You',
+  author: username,
+  // TODO we should be able to fill this in
+  deviceName: '',
+  deviceType: isMobile ? 'mobile' : 'desktop',
+  filename,
+  title,
+  previewType,
+  previewSize,
+  previewPath: filename,
+  downloadedPath: null,
+  outboxID,
+  progress: 0,
+  messageState: 'uploading',
+  key: Constants.messageKey('tempAttachment', outboxID),
+})
+
+function * onSelectAttachment ({payload: {input}}: Constants.SelectAttachment): Generator<any, any, any> {
+  const {title, filename, type} = input
+  let {conversationIDKey} = input
+
+  if (Constants.isPendingConversationIDKey(conversationIDKey)) {
+    // Get a real conversationIDKey
+    conversationIDKey = yield call(startNewConversation, conversationIDKey)
+    if (!conversationIDKey) {
+      return
+    }
+  }
+
+  const outboxID = `attachmentUpload-${Math.ceil(Math.random() * 1e9)}`
+  const username = yield select(usernameSelector)
+
+  yield put({
+    logTransformer: appendMessageActionTransformer,
+    payload: {
+      conversationIDKey,
+      messages: [_temporaryAttachmentMessageForUpload(
+        conversationIDKey,
+        username,
+        title,
+        filename,
+        outboxID,
+        type,
+      )],
+    },
+    type: 'chat:appendMessages',
+  })
+
+  const header = yield call(clientHeader, ChatTypes.CommonMessageType.attachment, conversationIDKey)
+  const attachment = {
+    filename,
+  }
+  const param = {
+    conversationID: Constants.keyToConversationID(conversationIDKey),
+    clientHeader: header,
+    attachment,
+    title,
+    metadata: null,
+    identifyBehavior: yield call(getPostingIdentifyBehavior, conversationIDKey),
+  }
+
+  const channelConfig = singleFixedChannelConfig([
+    'chat.1.chatUi.chatAttachmentUploadStart',
+    'chat.1.chatUi.chatAttachmentPreviewUploadStart',
+    'chat.1.chatUi.chatAttachmentUploadProgress',
+    'chat.1.chatUi.chatAttachmentUploadDone',
+    'chat.1.chatUi.chatAttachmentPreviewUploadDone',
+    'finished',
+  ])
+
+  const channelMap = ((yield call(ChatTypes.localPostFileAttachmentLocalRpcChannelMap, channelConfig, {param})): any)
+
+  const uploadStart = yield takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentUploadStart')
+  uploadStart.response.result()
+
+  const finishedTask = yield fork(function * () {
+    const finished = yield takeFromChannelMap(channelMap, 'finished')
+    if (finished.error) {
+      yield put(updateTempMessage(
+        conversationIDKey,
+        {messageState: 'failed'},
+        outboxID
+      ))
+    }
+    return finished
+  })
+
+  const progressTask = yield effectOnChannelMap(c => safeTakeEvery(c, function * ({response}) {
+    const {bytesComplete, bytesTotal} = response.param
+    const action: Constants.UploadProgress = {
+      type: 'chat:uploadProgress',
+      payload: {bytesTotal, bytesComplete, conversationIDKey, outboxID},
+    }
+    yield put(action)
+    response.result()
+  }), channelMap, 'chat.1.chatUi.chatAttachmentUploadProgress')
+
+  const previewTask = yield fork(function * () {
+    const previewUploadStart = yield takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentPreviewUploadStart')
+    previewUploadStart.response.result()
+
+    const metadata = previewUploadStart.params && previewUploadStart.params.metadata
+    const previewSize = metadata && Constants.parseMetadataPreviewSize(metadata) || null
+
+    yield put({
+      logTransformer: appendMessageActionTransformer,
+      payload: {
+        conversationIDKey,
+        messages: [_temporaryAttachmentMessageForUpload(
+          conversationIDKey,
+          username,
+          title,
+          filename,
+          outboxID,
+          type,
+          previewSize,
+        )],
+      },
+      type: 'chat:appendMessages',
+    })
+
+    const previewUploadDone = yield takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentPreviewUploadDone')
+    previewUploadDone.response.result()
+  })
+
+  const uploadDone = yield takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentUploadDone')
+  uploadDone.response.result()
+
+  const finished = yield join(finishedTask)
+  yield cancel(progressTask)
+  yield cancel(previewTask)
+  closeChannelMap(channelMap)
+
+  if (!finished.error) {
+    const {params: {messageID}} = finished
+    const existingMessage = yield select(messageSelector, conversationIDKey, messageID)
+    // We already received a message for this attachment
+    if (existingMessage) {
+      yield put(({
+        type: 'chat:deleteTempMessage',
+        payload: {
+          conversationIDKey,
+          outboxID,
+        },
+      }: Constants.DeleteTempMessage))
+    } else {
+      yield put(updateTempMessage(
+        conversationIDKey,
+        {type: 'Attachment', messageState: 'sent', messageID, key: Constants.messageKey('messageID', messageID)},
+        outboxID,
+      ))
+    }
+
+    yield put(({
+      type: 'chat:markSeenMessage',
+      payload: {
+        conversationIDKey,
+        messageID: messageID,
+      },
+    }: Constants.MarkSeenMessage))
+  }
+}
+
+function * onOpenAttachmentPopup (action: Constants.OpenAttachmentPopup): SagaGenerator<any, any> {
+  const {message} = action.payload
+  const messageID = message.messageID
+  if (!messageID) {
+    throw new Error('Cannot open attachment popup for message missing ID')
+  }
+
+  yield put(navigateAppend([{props: {messageID, conversationIDKey: message.conversationIDKey}, selected: 'attachment'}]))
+  if (!message.hdPreviewPath && message.filename) {
+    yield put(loadAttachmentAction(message.conversationIDKey, messageID, false, true, tmpFile(tmpFileName(true, message.conversationIDKey, message.messageID, message.filename))))
+  }
+}
+
+export {
+  onLoadAttachment,
+  onOpenAttachmentPopup,
+  onSaveAttachmentNative,
+  onShareAttachment,
+  onSelectAttachment,
+}

--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -1,10 +1,8 @@
 // @flow
 import * as Constants from '../../constants/chat'
 import HiddenString from '../../util/hidden-string'
-import {uniq} from 'lodash'
 import {List} from 'immutable'
-
-import type {AddPendingConversation, AttachmentInput, BadgeAppForChat, BlockConversation, ConversationBadgeState, ConversationIDKey, DeleteMessage, EditMessage, InboxState, LoadInbox, LoadMoreMessages, LoadedInbox, Message, MuteConversation, NewChat, OpenFolder, OpenTlfInChat, PendingToRealConversation, PostMessage, ReplaceConversation, RetryMessage, SelectConversation, SetupChatHandlers, ShowEditor, StartConversation, UpdateBadging, UpdateLatestMessage} from '../../constants/chat'
+import {uniq} from 'lodash'
 
 // Whitelisted action loggers
 const updateTempMessageTransformer = ({type, payload: {conversationIDKey, outboxID}}: Constants.UpdateTempMessage) => ({
@@ -57,87 +55,87 @@ const retryMessageActionTransformer = action => ({
   type: action.type,
 })
 
-function loadedInbox (conversations: List<InboxState>): LoadedInbox {
+function loadedInbox (conversations: List<Constants.InboxState>): Constants.LoadedInbox {
   return {logTransformer: loadedInboxActionTransformer, payload: {inbox: conversations}, type: 'chat:loadedInbox'}
 }
 
-function pendingToRealConversation (oldKey: ConversationIDKey, newKey: ConversationIDKey): PendingToRealConversation {
+function pendingToRealConversation (oldKey: Constants.ConversationIDKey, newKey: Constants.ConversationIDKey): Constants.PendingToRealConversation {
   return {payload: {newKey, oldKey}, type: 'chat:pendingToRealConversation'}
 }
 
-function replaceConversation (oldKey: ConversationIDKey, newKey: ConversationIDKey): ReplaceConversation {
+function replaceConversation (oldKey: Constants.ConversationIDKey, newKey: Constants.ConversationIDKey): Constants.ReplaceConversation {
   return {payload: {newKey, oldKey}, type: 'chat:replaceConversation'}
 }
 
-function updateBadging (conversationIDKey: ConversationIDKey): UpdateBadging {
+function updateBadging (conversationIDKey: Constants.ConversationIDKey): Constants.UpdateBadging {
   return {payload: {conversationIDKey}, type: 'chat:updateBadging'}
 }
 
-function updateLatestMessage (conversationIDKey: ConversationIDKey): UpdateLatestMessage {
+function updateLatestMessage (conversationIDKey: Constants.ConversationIDKey): Constants.UpdateLatestMessage {
   return {payload: {conversationIDKey}, type: 'chat:updateLatestMessage'}
 }
 
-function badgeAppForChat (conversations: List<ConversationBadgeState>): BadgeAppForChat {
+function badgeAppForChat (conversations: List<Constants.ConversationBadgeState>): Constants.BadgeAppForChat {
   return {payload: conversations, type: 'chat:badgeAppForChat'}
 }
 
-function openFolder (): OpenFolder {
+function openFolder (): Constants.OpenFolder {
   return {payload: undefined, type: 'chat:openFolder'}
 }
 
-function openTlfInChat (tlf: string): OpenTlfInChat {
+function openTlfInChat (tlf: string): Constants.OpenTlfInChat {
   return {payload: tlf, type: 'chat:openTlfInChat'}
 }
 
-function startConversation (users: Array<string>, forceImmediate?: boolean = false): StartConversation {
+function startConversation (users: Array<string>, forceImmediate?: boolean = false): Constants.StartConversation {
   return {payload: {forceImmediate, users: uniq(users)}, type: 'chat:startConversation'}
 }
 
-function newChat (existingParticipants: Array<string>): NewChat {
+function newChat (existingParticipants: Array<string>): Constants.NewChat {
   return {payload: {existingParticipants}, type: 'chat:newChat'}
 }
 
-function postMessage (conversationIDKey: ConversationIDKey, text: HiddenString): PostMessage {
+function postMessage (conversationIDKey: Constants.ConversationIDKey, text: HiddenString): Constants.PostMessage {
   return {logTransformer: postMessageActionTransformer, payload: {conversationIDKey, text}, type: 'chat:postMessage'}
 }
 
-function setupChatHandlers (): SetupChatHandlers {
+function setupChatHandlers (): Constants.SetupChatHandlers {
   return {payload: undefined, type: 'chat:setupChatHandlers'}
 }
 
-function retryMessage (conversationIDKey: ConversationIDKey, outboxIDKey: string): RetryMessage {
+function retryMessage (conversationIDKey: Constants.ConversationIDKey, outboxIDKey: string): Constants.RetryMessage {
   return {logTransformer: retryMessageActionTransformer, payload: {conversationIDKey, outboxIDKey}, type: 'chat:retryMessage'}
 }
 
-function loadInbox (force?: boolean = false): LoadInbox {
+function loadInbox (force?: boolean = false): Constants.LoadInbox {
   return {payload: {force}, type: 'chat:loadInbox'}
 }
 
-function loadMoreMessages (conversationIDKey: ConversationIDKey, onlyIfUnloaded: boolean): LoadMoreMessages {
+function loadMoreMessages (conversationIDKey: Constants.ConversationIDKey, onlyIfUnloaded: boolean): Constants.LoadMoreMessages {
   return {payload: {conversationIDKey, onlyIfUnloaded}, type: 'chat:loadMoreMessages'}
 }
 
-function showEditor (message: Message): ShowEditor {
+function showEditor (message: Constants.Message): Constants.ShowEditor {
   return {payload: {message}, type: 'chat:showEditor'}
 }
 
-function editMessage (message: Message, text: HiddenString): EditMessage {
+function editMessage (message: Constants.Message, text: HiddenString): Constants.EditMessage {
   return {payload: {message, text}, type: 'chat:editMessage'}
 }
 
-function muteConversation (conversationIDKey: ConversationIDKey, muted: boolean): MuteConversation {
+function muteConversation (conversationIDKey: Constants.ConversationIDKey, muted: boolean): Constants.MuteConversation {
   return {payload: {conversationIDKey, muted}, type: 'chat:muteConversation'}
 }
 
-function blockConversation (blocked: boolean, conversationIDKey: ConversationIDKey): BlockConversation {
+function blockConversation (blocked: boolean, conversationIDKey: Constants.ConversationIDKey): Constants.BlockConversation {
   return {payload: {blocked, conversationIDKey}, type: 'chat:blockConversation'}
 }
 
-function deleteMessage (message: Message): DeleteMessage {
+function deleteMessage (message: Constants.Message): Constants.DeleteMessage {
   return {payload: {message}, type: 'chat:deleteMessage'}
 }
 
-function addPending (participants: Array<string>): AddPendingConversation {
+function addPending (participants: Array<string>): Constants.AddPendingConversation {
   return {payload: {participants}, type: 'chat:addPendingConversation'}
 }
 
@@ -156,20 +154,20 @@ function retryAttachment (message: Constants.AttachmentMessage): Constants.Selec
   return {payload: {input}, type: 'chat:selectAttachment'}
 }
 
-function selectAttachment (input: AttachmentInput): Constants.SelectAttachment {
+function selectAttachment (input: Constants.AttachmentInput): Constants.SelectAttachment {
   return {payload: {input}, type: 'chat:selectAttachment'}
 }
 
-function loadAttachment (conversationIDKey: ConversationIDKey, messageID: Constants.MessageID, loadPreview: boolean, isHdPreview: boolean, filename: string): Constants.LoadAttachment {
+function loadAttachment (conversationIDKey: Constants.ConversationIDKey, messageID: Constants.MessageID, loadPreview: boolean, isHdPreview: boolean, filename: string): Constants.LoadAttachment {
   return {payload: {conversationIDKey, filename, isHdPreview, loadPreview, messageID}, type: 'chat:loadAttachment'}
 }
 
 // Select conversation, fromUser indicates it was triggered by a user and not programatically
-function selectConversation (conversationIDKey: ?ConversationIDKey, fromUser: boolean): SelectConversation {
+function selectConversation (conversationIDKey: ?Constants.ConversationIDKey, fromUser: boolean): Constants.SelectConversation {
   return {payload: {conversationIDKey, fromUser}, type: 'chat:selectConversation'}
 }
 
-function updateTempMessage (conversationIDKey: ConversationIDKey, message: $Shape<Constants.AttachmentMessage> | $Shape<Constants.TextMessage>, outboxID: Constants.OutboxIDKey): Constants.UpdateTempMessage {
+function updateTempMessage (conversationIDKey: Constants.ConversationIDKey, message: $Shape<Constants.AttachmentMessage> | $Shape<Constants.TextMessage>, outboxID: Constants.OutboxIDKey): Constants.UpdateTempMessage {
   return {
     logTransformer: updateTempMessageTransformer,
     payload: {

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -4,6 +4,7 @@ import * as ChatTypes from '../../constants/types/flow-types-chat'
 import * as Constants from '../../constants/chat'
 import * as Creators from './creators'
 import * as Inbox from './inbox'
+import * as Messages from './messages'
 import * as Shared from './shared'
 import HiddenString from '../../util/hidden-string'
 import engine from '../../engine'
@@ -33,211 +34,6 @@ import type {ChangedFocus} from '../../constants/window'
 import type {TLFIdentifyBehavior} from '../../constants/types/flow-types'
 import type {SagaGenerator} from '../../constants/types/saga'
 import type {TypedState} from '../../constants/reducer'
-
-function * _retryMessage (action: Constants.RetryMessage): SagaGenerator<any, any> {
-  const {conversationIDKey, outboxIDKey} = action.payload
-
-  yield put(Creators.updateTempMessage(conversationIDKey, {messageState: 'pending'}, outboxIDKey))
-
-  yield call(ChatTypes.localRetryPostRpcPromise, {
-    param: {
-      outboxID: Constants.keyToOutboxID(outboxIDKey),
-    },
-  })
-}
-
-function * _editMessage (action: Constants.EditMessage): SagaGenerator<any, any> {
-  const {message} = action.payload
-  let messageID: ?Constants.MessageID
-  let conversationIDKey: Constants.ConversationIDKey = ''
-  switch (message.type) {
-    case 'Text':
-    case 'Attachment': // fallthrough
-      conversationIDKey = message.conversationIDKey
-      messageID = message.messageID
-      break
-  }
-
-  if (!messageID) {
-    console.warn('Editing unknown message type', message)
-    return
-  }
-
-  const clientHeader = yield call(Shared.clientHeader, ChatTypes.CommonMessageType.edit, conversationIDKey)
-  const conversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
-  let lastMessageID
-  if (conversationState) {
-    const message = conversationState.messages.findLast(m => !!m.messageID)
-    if (message) {
-      lastMessageID = message.messageID
-    }
-  }
-
-  yield call(ChatTypes.localPostEditNonblockRpcPromise, {
-    param: {
-      body: action.payload.text.stringValue(),
-      clientPrev: lastMessageID,
-      conv: clientHeader.conv,
-      conversationID: Constants.keyToConversationID(conversationIDKey),
-      identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
-      supersedes: messageID,
-      tlfName: clientHeader.tlfName,
-      tlfPublic: clientHeader.tlfPublic,
-    },
-  })
-}
-
-function * _postMessage (action: Constants.PostMessage): SagaGenerator<any, any> {
-  let {conversationIDKey} = action.payload
-
-  if (Constants.isPendingConversationIDKey(conversationIDKey)) {
-    // Get a real conversationIDKey
-    conversationIDKey = yield call(Shared.startNewConversation, conversationIDKey)
-    if (!conversationIDKey) {
-      return
-    }
-  }
-
-  const clientHeader = yield call(Shared.clientHeader, ChatTypes.CommonMessageType.text, conversationIDKey)
-  const conversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
-  let lastMessageID
-  if (conversationState) {
-    const message = conversationState.messages.findLast(m => !!m.messageID)
-    if (message) {
-      lastMessageID = message.messageID
-    }
-  }
-
-  const sent = yield call(ChatTypes.localPostLocalNonblockRpcPromise, {
-    param: {
-      conversationID: Constants.keyToConversationID(conversationIDKey),
-      identifyBehavior: yield call(Shared.getPostingIdentifyBehavior, conversationIDKey),
-      clientPrev: lastMessageID,
-      msg: {
-        clientHeader,
-        messageBody: {
-          messageType: ChatTypes.CommonMessageType.text,
-          text: {
-            body: action.payload.text.stringValue(),
-          },
-        },
-      },
-    },
-  })
-
-  const author = yield select(usernameSelector)
-  if (sent && author) {
-    const outboxID = Constants.outboxIDToKey(sent.outboxID)
-    const hasPendingFailure = yield select(Shared.pendingFailureSelector, outboxID)
-    const message: Constants.Message = {
-      author,
-      conversationIDKey: action.payload.conversationIDKey,
-      deviceName: '',
-      deviceType: isMobile ? 'mobile' : 'desktop',
-      editedCount: 0,
-      failureDescription: null,
-      key: Constants.messageKey('outboxID', outboxID),
-      message: new HiddenString(action.payload.text.stringValue()),
-      messageState: hasPendingFailure ? 'failed' : 'pending',
-      outboxID,
-      senderDeviceRevokedAt: null,
-      timestamp: Date.now(),
-      type: 'Text',
-      you: author,
-    }
-
-    // Time to decide: should we add a timestamp before our new message?
-    const conversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
-    let messages = []
-    if (conversationState && conversationState.messages !== null && conversationState.messages.size > 0) {
-      const prevMessage = conversationState.messages.get(conversationState.messages.size - 1)
-      const timestamp = _maybeAddTimestamp(message, prevMessage)
-      if (timestamp !== null) {
-        messages.push(timestamp)
-      }
-    }
-
-    messages.push(message)
-    const selectedConversation = yield select(Constants.getSelectedConversation)
-    yield put({
-      logTransformer: Shared.appendMessageActionTransformer,
-      payload: {
-        conversationIDKey,
-        isSelected: conversationIDKey === selectedConversation,
-        messages,
-      },
-      type: 'chat:appendMessages',
-    })
-    if (hasPendingFailure) {
-      yield put(({
-        payload: {
-          outboxID,
-        },
-        type: 'chat:removePendingFailure',
-      }: Constants.RemovePendingFailure))
-    }
-  }
-}
-
-function * _deleteMessage (action: Constants.DeleteMessage): SagaGenerator<any, any> {
-  const {message} = action.payload
-  let messageID: ?Constants.MessageID
-  let conversationIDKey: Constants.ConversationIDKey
-  switch (message.type) {
-    case 'Text':
-      conversationIDKey = message.conversationIDKey
-      messageID = message.messageID
-      break
-    case 'Attachment':
-      conversationIDKey = message.conversationIDKey
-      messageID = message.messageID
-      break
-  }
-
-  if (!conversationIDKey) throw new Error('No conversation for message delete')
-
-  if (messageID) {
-    // Deleting a server message.
-    const clientHeader = yield call(Shared.clientHeader, ChatTypes.CommonMessageType.delete, conversationIDKey)
-    const conversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
-    let lastMessageID
-    if (conversationState) {
-      const message = conversationState.messages.findLast(m => !!m.messageID)
-      if (message) {
-        lastMessageID = message.messageID
-      }
-    }
-
-    yield call(ChatTypes.localPostDeleteNonblockRpcPromise, {
-      param: {
-        clientPrev: lastMessageID,
-        conv: clientHeader.conv,
-        conversationID: Constants.keyToConversationID(conversationIDKey),
-        identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
-        supersedes: messageID,
-        tlfName: clientHeader.tlfName,
-        tlfPublic: clientHeader.tlfPublic,
-      },
-    })
-  } else {
-    // Deleting a local outbox message.
-    if (message.messageState !== 'failed') throw new Error('Tried to delete a non-failed message')
-    const outboxID = message.outboxID
-    if (!outboxID) throw new Error('No outboxID for pending message delete')
-
-    yield call(ChatTypes.localCancelPostRpcPromise, {
-      param: {
-        outboxID: Constants.keyToOutboxID(outboxID),
-      },
-    })
-    // It's deleted, but we don't get notified that the conversation now has
-    // one less outbox entry in it.  Gotta remove it from the store ourselves.
-    yield put(({
-      payload: {conversationIDKey, outboxID},
-      type: 'chat:removeOutboxMessage',
-    }: Constants.RemoveOutboxMessage))
-  }
-}
 
 function * _incomingMessage (action: Constants.IncomingMessage): SagaGenerator<any, any> {
   switch (action.payload.activity.activityType) {
@@ -375,7 +171,7 @@ function * _incomingMessage (action: Constants.IncomingMessage): SagaGenerator<a
           if (conversationState && conversationState.messages !== null && conversationState.messages.size > 0) {
             const prevMessage = conversationState.messages.get(conversationState.messages.size - 1)
 
-            const timestamp = _maybeAddTimestamp(message, prevMessage)
+            const timestamp = Shared.maybeAddTimestamp(message, prevMessage)
             if (timestamp !== null) {
               yield put({
                 logTransformer: Shared.appendMessageActionTransformer,
@@ -575,7 +371,7 @@ function * _loadMoreMessages (action: Constants.LoadMoreMessages): SagaGenerator
   let newMessages = []
   messages.forEach((message, idx) => {
     if (idx > 0) {
-      const timestamp = _maybeAddTimestamp(messages[idx], messages[idx - 1])
+      const timestamp = Shared.maybeAddTimestamp(messages[idx], messages[idx - 1])
       if (timestamp !== null) {
         newMessages.push(timestamp)
       }
@@ -610,47 +406,6 @@ function _threadToPagination (thread) {
     last: undefined,
     next: undefined,
   }
-}
-
-type TimestampableMessage = {
-  timestamp: number,
-  messageID: Constants.MessageID,
-  type: any,
-}
-
-function _filterTimestampableMessage (message: Constants.Message): ?TimestampableMessage {
-  if (message.messageID === 1) {
-    // $FlowIssue with casting todo(mm) can we fix this?
-    return message
-  }
-
-  if (message === null || message.type === 'Timestamp' || ['Timestamp', 'Deleted', 'Unhandled', 'InvisibleError', 'Edit'].includes(message.type)) {
-    return null
-  }
-
-  if (!message.timestamp) {
-    return null
-  }
-
-  // $FlowIssue with casting todo(mm) can we fix this?
-  return message
-}
-
-function _maybeAddTimestamp (_message: Constants.Message, _prevMessage: Constants.Message): Constants.MaybeTimestamp {
-  const prevMessage = _filterTimestampableMessage(_prevMessage)
-  const message = _filterTimestampableMessage(_message)
-  if (!message || !prevMessage) return null
-
-  // messageID 1 is an unhandled placeholder. We want to add a timestamp before
-  // the first message, as well as between any two messages with long duration.
-  if (prevMessage.messageID === 1 || message.timestamp - prevMessage.timestamp > Constants.howLongBetweenTimestampsMs) {
-    return {
-      type: 'Timestamp',
-      timestamp: message.timestamp,
-      key: Constants.messageKey('timestamp', message.timestamp),
-    }
-  }
-  return null
 }
 
 // used to key errors
@@ -1147,9 +902,9 @@ function * chatSaga (): SagaGenerator<any, any> {
     safeTakeEvery('chat:muteConversation', _muteConversation),
     safeTakeEvery('chat:blockConversation', _blockConversation),
     safeTakeEvery('chat:newChat', _newChat),
-    safeTakeEvery('chat:postMessage', _postMessage),
-    safeTakeEvery('chat:editMessage', _editMessage),
-    safeTakeEvery('chat:retryMessage', _retryMessage),
+    safeTakeEvery('chat:postMessage', Messages.postMessage),
+    safeTakeEvery('chat:editMessage', Messages.editMessage),
+    safeTakeEvery('chat:retryMessage', Messages.retryMessage),
     safeTakeEvery('chat:startConversation', _startConversation),
     safeTakeEvery('chat:updateMetadata', _updateMetadata),
     safeTakeEvery('chat:appendMessages', _sendNotifications),
@@ -1161,7 +916,7 @@ function * chatSaga (): SagaGenerator<any, any> {
     safeTakeLatest('chat:openFolder', _openFolder),
     safeTakeLatest('chat:badgeAppForChat', _badgeAppForChat),
     safeTakeEvery(changedFocus, _changedFocus),
-    safeTakeEvery('chat:deleteMessage', _deleteMessage),
+    safeTakeEvery('chat:deleteMessage', Messages.deleteMessage),
     safeTakeEvery('chat:openTlfInChat', _openTlfInChat),
     safeTakeEvery('chat:loadedInbox', _ensureValidSelectedChat, true, false),
     safeTakeEvery('chat:updateInboxComplete', _ensureValidSelectedChat, false, false),

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -1,0 +1,224 @@
+// @flow
+import * as ChatTypes from '../../constants/types/flow-types-chat'
+import * as Constants from '../../constants/chat'
+import * as Creators from './creators'
+import * as Shared from './shared'
+import HiddenString from '../../util/hidden-string'
+import {TlfKeysTLFIdentifyBehavior} from '../../constants/types/flow-types'
+import {call, put, select} from 'redux-saga/effects'
+import {isMobile} from '../../constants/platform'
+import {usernameSelector} from '../../constants/selectors'
+
+import type {SagaGenerator} from '../../constants/types/saga'
+
+function * deleteMessage (action: Constants.DeleteMessage): SagaGenerator<any, any> {
+  const {message} = action.payload
+  let messageID: ?Constants.MessageID
+  let conversationIDKey: Constants.ConversationIDKey
+  switch (message.type) {
+    case 'Text':
+      conversationIDKey = message.conversationIDKey
+      messageID = message.messageID
+      break
+    case 'Attachment':
+      conversationIDKey = message.conversationIDKey
+      messageID = message.messageID
+      break
+  }
+
+  if (!conversationIDKey) throw new Error('No conversation for message delete')
+
+  if (messageID) {
+    // Deleting a server message.
+    const clientHeader = yield call(Shared.clientHeader, ChatTypes.CommonMessageType.delete, conversationIDKey)
+    const conversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
+    let lastMessageID
+    if (conversationState) {
+      const message = conversationState.messages.findLast(m => !!m.messageID)
+      if (message) {
+        lastMessageID = message.messageID
+      }
+    }
+
+    yield call(ChatTypes.localPostDeleteNonblockRpcPromise, {
+      param: {
+        clientPrev: lastMessageID,
+        conv: clientHeader.conv,
+        conversationID: Constants.keyToConversationID(conversationIDKey),
+        identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
+        supersedes: messageID,
+        tlfName: clientHeader.tlfName,
+        tlfPublic: clientHeader.tlfPublic,
+      },
+    })
+  } else {
+    // Deleting a local outbox message.
+    if (message.messageState !== 'failed') throw new Error('Tried to delete a non-failed message')
+    const outboxID = message.outboxID
+    if (!outboxID) throw new Error('No outboxID for pending message delete')
+
+    yield call(ChatTypes.localCancelPostRpcPromise, {
+      param: {
+        outboxID: Constants.keyToOutboxID(outboxID),
+      },
+    })
+    // It's deleted, but we don't get notified that the conversation now has
+    // one less outbox entry in it.  Gotta remove it from the store ourselves.
+    yield put(({
+      payload: {conversationIDKey, outboxID},
+      type: 'chat:removeOutboxMessage',
+    }: Constants.RemoveOutboxMessage))
+  }
+}
+
+function * postMessage (action: Constants.PostMessage): SagaGenerator<any, any> {
+  let {conversationIDKey} = action.payload
+
+  if (Constants.isPendingConversationIDKey(conversationIDKey)) {
+    // Get a real conversationIDKey
+    conversationIDKey = yield call(Shared.startNewConversation, conversationIDKey)
+    if (!conversationIDKey) {
+      return
+    }
+  }
+
+  const clientHeader = yield call(Shared.clientHeader, ChatTypes.CommonMessageType.text, conversationIDKey)
+  const conversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
+  let lastMessageID
+  if (conversationState) {
+    const message = conversationState.messages.findLast(m => !!m.messageID)
+    if (message) {
+      lastMessageID = message.messageID
+    }
+  }
+
+  const sent = yield call(ChatTypes.localPostLocalNonblockRpcPromise, {
+    param: {
+      conversationID: Constants.keyToConversationID(conversationIDKey),
+      identifyBehavior: yield call(Shared.getPostingIdentifyBehavior, conversationIDKey),
+      clientPrev: lastMessageID,
+      msg: {
+        clientHeader,
+        messageBody: {
+          messageType: ChatTypes.CommonMessageType.text,
+          text: {
+            body: action.payload.text.stringValue(),
+          },
+        },
+      },
+    },
+  })
+
+  const author = yield select(usernameSelector)
+  if (sent && author) {
+    const outboxID = Constants.outboxIDToKey(sent.outboxID)
+    const hasPendingFailure = yield select(Shared.pendingFailureSelector, outboxID)
+    const message: Constants.Message = {
+      author,
+      conversationIDKey: action.payload.conversationIDKey,
+      deviceName: '',
+      deviceType: isMobile ? 'mobile' : 'desktop',
+      editedCount: 0,
+      failureDescription: null,
+      key: Constants.messageKey('outboxID', outboxID),
+      message: new HiddenString(action.payload.text.stringValue()),
+      messageState: hasPendingFailure ? 'failed' : 'pending',
+      outboxID,
+      senderDeviceRevokedAt: null,
+      timestamp: Date.now(),
+      type: 'Text',
+      you: author,
+    }
+
+    // Time to decide: should we add a timestamp before our new message?
+    const conversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
+    let messages = []
+    if (conversationState && conversationState.messages !== null && conversationState.messages.size > 0) {
+      const prevMessage = conversationState.messages.get(conversationState.messages.size - 1)
+      const timestamp = Shared.maybeAddTimestamp(message, prevMessage)
+      if (timestamp !== null) {
+        messages.push(timestamp)
+      }
+    }
+
+    messages.push(message)
+    const selectedConversation = yield select(Constants.getSelectedConversation)
+    yield put({
+      logTransformer: Shared.appendMessageActionTransformer,
+      payload: {
+        conversationIDKey,
+        isSelected: conversationIDKey === selectedConversation,
+        messages,
+      },
+      type: 'chat:appendMessages',
+    })
+    if (hasPendingFailure) {
+      yield put(({
+        payload: {
+          outboxID,
+        },
+        type: 'chat:removePendingFailure',
+      }: Constants.RemovePendingFailure))
+    }
+  }
+}
+
+function * editMessage (action: Constants.EditMessage): SagaGenerator<any, any> {
+  const {message} = action.payload
+  let messageID: ?Constants.MessageID
+  let conversationIDKey: Constants.ConversationIDKey = ''
+  switch (message.type) {
+    case 'Text':
+    case 'Attachment': // fallthrough
+      conversationIDKey = message.conversationIDKey
+      messageID = message.messageID
+      break
+  }
+
+  if (!messageID) {
+    console.warn('Editing unknown message type', message)
+    return
+  }
+
+  const clientHeader = yield call(Shared.clientHeader, ChatTypes.CommonMessageType.edit, conversationIDKey)
+  const conversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
+  let lastMessageID
+  if (conversationState) {
+    const message = conversationState.messages.findLast(m => !!m.messageID)
+    if (message) {
+      lastMessageID = message.messageID
+    }
+  }
+
+  yield call(ChatTypes.localPostEditNonblockRpcPromise, {
+    param: {
+      body: action.payload.text.stringValue(),
+      clientPrev: lastMessageID,
+      conv: clientHeader.conv,
+      conversationID: Constants.keyToConversationID(conversationIDKey),
+      identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
+      supersedes: messageID,
+      tlfName: clientHeader.tlfName,
+      tlfPublic: clientHeader.tlfPublic,
+    },
+  })
+}
+
+function * retryMessage (action: Constants.RetryMessage): SagaGenerator<any, any> {
+  const {conversationIDKey, outboxIDKey} = action.payload
+
+  yield put(Creators.updateTempMessage(conversationIDKey, {messageState: 'pending'}, outboxIDKey))
+
+  yield call(ChatTypes.localRetryPostRpcPromise, {
+    param: {
+      outboxID: Constants.keyToOutboxID(outboxIDKey),
+    },
+  })
+}
+
+export {
+  deleteMessage,
+  editMessage,
+  postMessage,
+  retryMessage,
+}

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -1,0 +1,205 @@
+// @flow
+import * as ChatTypes from '../../constants/types/flow-types-chat'
+import * as Constants from '../../constants/chat'
+import {Map} from 'immutable'
+import {TlfKeysTLFIdentifyBehavior} from '../../constants/types/flow-types'
+import {call, put, select} from 'redux-saga/effects'
+import {getInboxAndUnbox} from './inbox'
+import {pendingToRealConversation, replaceConversation, selectConversation} from './creators'
+import {usernameSelector} from '../../constants/selectors'
+
+import type {TypedState} from '../../constants/reducer'
+
+function followingSelector (state: TypedState) { return state.config.following }
+function alwaysShowSelector (state: TypedState) { return state.chat.get('alwaysShow') }
+function metaDataSelector (state: TypedState) { return state.chat.get('metaData') }
+function routeSelector (state: TypedState) { return state.routeTree.get('routeState').get('selected') }
+function focusedSelector (state: TypedState) { return state.chat.get('focused') }
+function pendingFailureSelector (state: TypedState, outboxID: Constants.OutboxIDKey) { return state.chat.get('pendingFailures').get(outboxID) }
+
+function conversationStateSelector (state: TypedState, conversationIDKey: Constants.ConversationIDKey) {
+  return state.chat.get('conversationStates', Map()).get(conversationIDKey)
+}
+
+function messageSelector (state: TypedState, conversationIDKey: Constants.ConversationIDKey, messageID: Constants.MessageID) {
+  return conversationStateSelector(state, conversationIDKey).get('messages').find(m => m.messageID === messageID)
+}
+
+function messageOutboxIDSelector (state: TypedState, conversationIDKey: Constants.ConversationIDKey, outboxID: Constants.OutboxIDKey) {
+  return conversationStateSelector(state, conversationIDKey).get('messages').find(m => m.outboxID === outboxID)
+}
+
+function devicenameSelector (state: TypedState) {
+  return state.config && state.config.extendedConfig && state.config.extendedConfig.device && state.config.extendedConfig.device.name
+}
+
+function selectedInboxSelector (state: TypedState, conversationIDKey: Constants.ConversationIDKey) {
+  return state.chat.get('inbox').find(convo => convo.get('conversationIDKey') === conversationIDKey)
+}
+
+function tmpFileName (isHdPreview: boolean, conversationID: Constants.ConversationIDKey, messageID: ?Constants.MessageID, filename: string) {
+  return `kbchat-${isHdPreview ? 'hdPreview' : 'preview'}-${conversationID}-${messageID || ''}-${filename}`
+}
+
+function * clientHeader (messageType: ChatTypes.MessageType, conversationIDKey: Constants.ConversationIDKey): Generator<any, ?ChatTypes.MessageClientHeader, any> {
+  const infoSelector = (state: TypedState) => {
+    const convo = state.chat.get('inbox').find(convo => convo.get('conversationIDKey') === conversationIDKey)
+    if (convo) {
+      return convo.get('info')
+    }
+    return null
+  }
+
+  const info = yield select(infoSelector)
+
+  if (!info) {
+    console.warn('No info to postmessage!')
+    return
+  }
+
+  const configSelector = (state: TypedState) => {
+    try {
+      return {
+        // $FlowIssue doesn't understand try
+        deviceID: state.config.extendedConfig.device.deviceID,
+        uid: state.config.uid,
+      }
+    } catch (_) {
+      return {
+        deviceID: '',
+        uid: '',
+      }
+    }
+  }
+
+  const {deviceID, uid}: {deviceID: string, uid: string} = ((yield select(configSelector)): any)
+
+  if (!deviceID || !uid) {
+    console.warn('No deviceid/uid to postmessage!')
+    return
+  }
+
+  return {
+    conv: info.triple,
+    tlfName: info.tlfName,
+    tlfPublic: info.visibility === ChatTypes.CommonTLFVisibility.public,
+    messageType,
+    supersedes: 0,
+    sender: Buffer.from(uid, 'hex'),
+    senderDevice: Buffer.from(deviceID, 'hex'),
+  }
+}
+
+const appendMessageActionTransformer = (action: Constants.AppendMessages) => ({
+  payload: {
+    conversationIDKey: action.payload.conversationIDKey,
+    messages: action.payload.messages.map(safeServerMessageMap),
+  },
+  type: action.type,
+})
+
+const safeServerMessageMap = (m: any) => ({
+  key: m.key,
+  messageID: m.messageID,
+  messageState: m.messageState,
+  outboxID: m.outboxID,
+  type: m.type,
+})
+
+const prependMessagesActionTransformer = (action: Constants.PrependMessages) => ({
+  payload: {
+    conversationIDKey: action.payload.conversationIDKey,
+    hasPaginationNext: !!action.payload.paginationNext,
+    messages: action.payload.messages.map(safeServerMessageMap),
+    moreToLoad: action.payload.moreToLoad,
+  },
+  type: action.type,
+})
+
+// Actually start a new conversation. conversationIDKey can be a pending one or a replacement
+function * startNewConversation (oldConversationIDKey: Constants.ConversationIDKey): Generator<any, ?Constants.ConversationIDKey, any> {
+  // Find the participants
+  const pendingTlfName = Constants.pendingConversationIDKeyToTlfName(oldConversationIDKey)
+  let tlfName
+  if (pendingTlfName) {
+    tlfName = pendingTlfName
+  } else {
+    const existing = yield select(selectedInboxSelector, oldConversationIDKey)
+    if (existing) {
+      tlfName = existing.get('participants').join(',')
+    }
+  }
+
+  if (!tlfName) {
+    console.warn("Shouldn't happen in practice")
+    return null
+  }
+
+  const result = yield call(ChatTypes.localNewConversationLocalRpcPromise, {
+    param: {
+      identifyBehavior: TlfKeysTLFIdentifyBehavior.chatGui,
+      tlfName,
+      tlfVisibility: ChatTypes.CommonTLFVisibility.private,
+      topicType: ChatTypes.CommonTopicType.chat,
+    }})
+
+  const newConversationIDKey = result ? Constants.conversationIDToKey(result.conv.info.id) : null
+  if (!newConversationIDKey) {
+    console.warn('No convoid from newConvoRPC')
+    return null
+  }
+
+  // Replace any existing convo
+  if (pendingTlfName) {
+    yield put(pendingToRealConversation(oldConversationIDKey, newConversationIDKey))
+  } else {
+    yield put(replaceConversation(oldConversationIDKey, newConversationIDKey))
+  }
+
+  // Select the new version if the old one was selected
+  const selectedConversation = yield select(Constants.getSelectedConversation)
+  if (selectedConversation === oldConversationIDKey) {
+    yield put(selectConversation(newConversationIDKey, false))
+  }
+  // Load the inbox so we can post, we wait till this is done
+  yield call(getInboxAndUnbox, {payload: {conversationIDKey: newConversationIDKey}, type: 'chat:getInboxAndUnbox'})
+  return newConversationIDKey
+}
+
+// If we're showing a banner we send chatGui, if we're not we send chatGuiStrict
+function * getPostingIdentifyBehavior (conversationIDKey: Constants.ConversationIDKey): Generator<any, any, any> {
+  const metaData = ((yield select(metaDataSelector)): any)
+  const inbox = yield select(selectedInboxSelector, conversationIDKey)
+  const you = yield select(usernameSelector)
+
+  if (inbox && you) {
+    const brokenUsers = Constants.getBrokenUsers(inbox.get('participants').toArray(), you, metaData)
+    return brokenUsers.length ? TlfKeysTLFIdentifyBehavior.chatGui : TlfKeysTLFIdentifyBehavior.chatGuiStrict
+  }
+
+  // Shouldn't happen but fallback to strict mode
+  if (__DEV__) {
+    console.warn('Missing inbox or you when posting')
+  }
+  return TlfKeysTLFIdentifyBehavior.chatGuiStrict
+}
+
+export {
+  appendMessageActionTransformer,
+  alwaysShowSelector,
+  clientHeader,
+  conversationStateSelector,
+  devicenameSelector,
+  focusedSelector,
+  followingSelector,
+  messageOutboxIDSelector,
+  messageSelector,
+  metaDataSelector,
+  pendingFailureSelector,
+  prependMessagesActionTransformer,
+  routeSelector,
+  selectedInboxSelector,
+  tmpFileName,
+  startNewConversation,
+  getPostingIdentifyBehavior,
+}


### PR DESCRIPTION
@keybase/react-hackers this pulls attachments out of index.js
Also I tried to unify how we handle imports in chat. We have a mix of ChatTypes. and Constants. and also importing into their own names. I figure if we import a ton of things (say  > 5) lets just stick to *. That makes the imports section smaller and kinda namespaces the the things. Also since the flow types and our names can collide this removes us renaming things and having things be ambiguous.