### PR TITLE
Mobile iOS doesn't support MatchLimitAll on delete

### DIFF
--- a/go/libkb/secret_store_darwin.go
+++ b/go/libkb/secret_store_darwin.go
@@ -77,8 +77,13 @@ func (k KeychainSecretStore) RetrieveSecret(accountName NormalizedUsername) (LKS
 
 func (k KeychainSecretStore) ClearSecret(accountName NormalizedUsername) error {
 	k.context.GetLog().Debug("KeychainSecretStore.ClearSecret(%s)", accountName)
-	query := keychain.NewGenericPassword(k.serviceName(), string(accountName), "", nil, "")
-	query.SetMatchLimit(keychain.MatchLimitAll)
+	var query keychain.Item
+	if isIOS {
+		query = keychain.NewGenericPassword(k.serviceName(), string(accountName), "", nil, k.accessGroup())
+	} else {
+		query = keychain.NewGenericPassword(k.serviceName(), string(accountName), "", nil, "")
+		query.SetMatchLimit(keychain.MatchLimitAll)
+	}
 	err := keychain.DeleteItem(query)
 	if err == keychain.ErrorItemNotFound {
 		k.context.GetLog().Debug("KeychainSecretStore.ClearSecret(%s), item not found", accountName)


### PR DESCRIPTION
We also specify access group (which is empty on simulator).

This fixes the secret store getting cleared on mobile.

Care was made to not affect desktop at all (we special case iOS here on delete).