### PR TITLE
vendor: include new RPC client tags func, and use in chat

### DIFF
--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -30,7 +30,8 @@ func (t *KBFSTLFInfoSource) tlfKeysClient() (*keybase1.TlfKeysClient, error) {
 		return nil, fmt.Errorf("KBFS client wasn't found")
 	}
 	return &keybase1.TlfKeysClient{
-		Cli: rpc.NewClient(xp, libkb.ErrorUnwrapper{}),
+		Cli: rpc.NewClient(
+			xp, libkb.ErrorUnwrapper{}, libkb.LogTagsFromContext),
 	}, nil
 }
 

--- a/go/client/rpc.go
+++ b/go/client/rpc.go
@@ -34,7 +34,7 @@ func getSocket(g *libkb.GlobalContext, clearError bool) (xp rpc.Transporter, err
 
 func GetRPCClientWithContext(g *libkb.GlobalContext) (ret *rpc.Client, xp rpc.Transporter, err error) {
 	if xp, err = getSocketNoRetry(g); err == nil {
-		ret = rpc.NewClient(xp, libkb.ErrorUnwrapper{})
+		ret = rpc.NewClient(xp, libkb.ErrorUnwrapper{}, nil)
 	}
 	return
 }
@@ -278,7 +278,7 @@ func GetChatLocalClient(g *libkb.GlobalContext) (cli chat1.LocalClient, err erro
 }
 
 func introduceMyself(g *libkb.GlobalContext, xp rpc.Transporter) error {
-	cli := rpc.NewClient(xp, libkb.ErrorUnwrapper{})
+	cli := rpc.NewClient(xp, libkb.ErrorUnwrapper{}, nil)
 	ccli := keybase1.ConfigClient{Cli: cli}
 	return ccli.HelloIAm(context.TODO(), g.GetMyClientDetails())
 }

--- a/go/client/versionfix.go
+++ b/go/client/versionfix.go
@@ -74,7 +74,7 @@ func FixVersionClash(g *libkb.GlobalContext, cl libkb.CommandLine) (err error) {
 	}
 	xp := libkb.NewTransportFromSocket(g, socket)
 	srv := rpc.NewServer(xp, libkb.WrapError)
-	gcli := rpc.NewClient(xp, libkb.ErrorUnwrapper{})
+	gcli := rpc.NewClient(xp, libkb.ErrorUnwrapper{}, nil)
 	cli = keybase1.ConfigClient{Cli: gcli}
 	srv.Register(NewLogUIProtocol())
 

--- a/go/kex2/provisionee.go
+++ b/go/kex2/provisionee.go
@@ -165,7 +165,8 @@ func (p *provisionee) pickFirstConnection() (err error) {
 		if err != nil {
 			return err
 		}
-		cli := keybase1.Kex2ProvisionerClient{Cli: rpc.NewClient(p.xp, nil)}
+		cli := keybase1.Kex2ProvisionerClient{
+			Cli: rpc.NewClient(p.xp, nil, nil)}
 		if err = cli.KexStart(p.arg.Ctx); err != nil {
 			return err
 		}

--- a/go/kex2/provisioner.go
+++ b/go/kex2/provisioner.go
@@ -186,7 +186,7 @@ func (p *provisioner) runProtocol() (err error) {
 }
 
 func (p *provisioner) runProtocolV2() (fallback bool, err error) {
-	cli := keybase1.Kex2Provisionee2Client{Cli: rpc.NewClient(p.xp, nil)}
+	cli := keybase1.Kex2Provisionee2Client{Cli: rpc.NewClient(p.xp, nil, nil)}
 	var helloArg keybase1.Hello2Arg
 	helloArg, err = p.arg.Provisioner.GetHello2Arg()
 	if err != nil {
@@ -214,7 +214,7 @@ func (p *provisioner) runProtocolV2() (fallback bool, err error) {
 }
 
 func (p *provisioner) runProtocolV1() (err error) {
-	cli := keybase1.Kex2ProvisioneeClient{Cli: rpc.NewClient(p.xp, nil)}
+	cli := keybase1.Kex2ProvisioneeClient{Cli: rpc.NewClient(p.xp, nil, nil)}
 	var helloArg keybase1.HelloArg
 	helloArg, err = p.arg.Provisioner.GetHelloArg()
 	if err != nil {

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -144,7 +144,7 @@ func (n *NotifyRouter) HandleLogout() {
 			go func() {
 				// A send of a `LoggedOut` RPC
 				(keybase1.NotifySessionClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).LoggedOut(context.Background())
 			}()
 		}
@@ -171,7 +171,7 @@ func (n *NotifyRouter) HandleLogin(u string) {
 			go func() {
 				// A send of a `LoggedIn` RPC
 				(keybase1.NotifySessionClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).LoggedIn(context.Background(), u)
 			}()
 		}
@@ -199,7 +199,7 @@ func (n *NotifyRouter) HandleClientOutOfDate(upgradeTo, upgradeURI, upgradeMsg s
 			go func() {
 				// A send of a `ClientOutOfDate` RPC
 				(keybase1.NotifySessionClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).ClientOutOfDate(context.Background(), keybase1.ClientOutOfDateArg{
 					UpgradeTo:  upgradeTo,
 					UpgradeURI: upgradeURI,
@@ -230,7 +230,7 @@ func (n *NotifyRouter) HandleUserChanged(uid keybase1.UID) {
 			go func() {
 				// A send of a `UserChanged` RPC with the user's UID
 				(keybase1.NotifyUsersClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).UserChanged(context.Background(), uid)
 			}()
 		}
@@ -262,7 +262,7 @@ func (n *NotifyRouter) HandleTrackingChanged(uid keybase1.UID, username Normaliz
 			go func() {
 				// A send of a `TrackingChanged` RPC with the user's UID
 				(keybase1.NotifyTrackingClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).TrackingChanged(context.Background(), arg)
 			}()
 		}
@@ -288,7 +288,7 @@ func (n *NotifyRouter) HandleBadgeState(badgeState keybase1.BadgeState) {
 			go func() {
 				// A send of a `BadgeState` RPC with the badge state
 				(keybase1.NotifyBadgesClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).BadgeState(context.Background(), badgeState)
 			}()
 		}
@@ -313,7 +313,7 @@ func (n *NotifyRouter) HandleFSActivity(activity keybase1.FSNotification) {
 			go func() {
 				// A send of a `FSActivity` RPC with the notification
 				(keybase1.NotifyFSClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).FSActivity(context.Background(), activity)
 			}()
 		}
@@ -344,7 +344,7 @@ func (n *NotifyRouter) HandleFSEditListResponse(ctx context.Context, arg keybase
 			go func() {
 				// A send of a `FSEditListResponse` RPC with the notification
 				(keybase1.NotifyFSClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).FSEditListResponse(ctx, keybase1.FSEditListResponseArg{
 					Edits:     arg.Edits,
 					RequestID: arg.RequestID,
@@ -378,7 +378,7 @@ func (n *NotifyRouter) HandleFSEditListRequest(ctx context.Context, arg keybase1
 			go func() {
 				// A send of a `FSEditListRequest` RPC with the notification
 				(keybase1.NotifyFSRequestClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).FSEditListRequest(ctx, arg)
 				wg.Done()
 			}()
@@ -406,7 +406,7 @@ func (n *NotifyRouter) HandleFSSyncStatus(ctx context.Context, arg keybase1.FSSy
 			go func() {
 				// A send of a `FSSyncStatusResponse` RPC with the notification
 				(keybase1.NotifyFSClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).FSSyncStatusResponse(ctx, keybase1.FSSyncStatusResponseArg{Status: arg.Status, RequestID: arg.RequestID})
 			}()
 		}
@@ -430,7 +430,7 @@ func (n *NotifyRouter) HandleFSSyncEvent(ctx context.Context, arg keybase1.FSPat
 			go func() {
 				// A send of a `FSSyncActivity` RPC with the notification
 				(keybase1.NotifyFSClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).FSSyncActivity(ctx, arg)
 			}()
 		}
@@ -458,7 +458,7 @@ func (n *NotifyRouter) HandleFavoritesChanged(uid keybase1.UID) {
 			go func() {
 				// A send of a `FavoritesChanged` RPC with the user's UID
 				(keybase1.NotifyFavoritesClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).FavoritesChanged(context.Background(), uid)
 			}()
 		}
@@ -488,7 +488,7 @@ func (n *NotifyRouter) HandleNewChatActivity(ctx context.Context, uid keybase1.U
 			go func() {
 				// A send of a `NewChatActivity` RPC with the user's UID
 				(chat1.NotifyChatClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).NewChatActivity(context.Background(), chat1.NewChatActivityArg{
 					Uid:      uid,
 					Activity: *activity,
@@ -516,7 +516,7 @@ func (n *NotifyRouter) HandleChatIdentifyUpdate(ctx context.Context, update keyb
 			wg.Add(1)
 			go func() {
 				(chat1.NotifyChatClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).ChatIdentifyUpdate(context.Background(), update)
 				wg.Done()
 			}()
@@ -541,7 +541,7 @@ func (n *NotifyRouter) HandleChatTLFFinalize(ctx context.Context, uid keybase1.U
 			wg.Add(1)
 			go func() {
 				(chat1.NotifyChatClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).ChatTLFFinalize(context.Background(), chat1.ChatTLFFinalizeArg{
 					Uid:          uid,
 					ConvID:       convID,
@@ -571,7 +571,7 @@ func (n *NotifyRouter) HandleChatTLFResolve(ctx context.Context, uid keybase1.UI
 			wg.Add(1)
 			go func() {
 				(chat1.NotifyChatClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).ChatTLFResolve(context.Background(), chat1.ChatTLFResolveArg{
 					Uid:         uid,
 					ConvID:      convID,
@@ -600,7 +600,7 @@ func (n *NotifyRouter) HandleChatInboxStale(ctx context.Context, uid keybase1.UI
 			wg.Add(1)
 			go func() {
 				(chat1.NotifyChatClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).ChatInboxStale(context.Background(), uid)
 				wg.Done()
 			}()
@@ -626,7 +626,7 @@ func (n *NotifyRouter) HandleChatThreadsStale(ctx context.Context, uid keybase1.
 			wg.Add(1)
 			go func() {
 				(chat1.NotifyChatClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).ChatThreadsStale(context.Background(), chat1.ChatThreadsStaleArg{
 					Uid:     uid,
 					ConvIDs: threads,
@@ -666,7 +666,7 @@ func (n *NotifyRouter) HandlePaperKeyCached(uid keybase1.UID, encKID keybase1.KI
 			// In the background do...
 			go func() {
 				(keybase1.NotifyPaperKeyClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).PaperKeyCached(context.Background(), arg)
 				wg.Done()
 			}()
@@ -694,7 +694,7 @@ func (n *NotifyRouter) HandleKeyfamilyChanged(uid keybase1.UID) {
 			// In the background do...
 			go func() {
 				(keybase1.NotifyKeyfamilyClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).KeyfamilyChanged(context.Background(), uid)
 			}()
 		}
@@ -724,7 +724,7 @@ func (n *NotifyRouter) HandleServiceShutdown() {
 			wg.Add(1)
 			go func() {
 				(keybase1.NotifyServiceClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).Shutdown(context.Background())
 				wg.Done()
 			}()
@@ -758,7 +758,7 @@ func (n *NotifyRouter) HandleAppExit() {
 		if n.getNotificationChannels(id).App {
 			go func() {
 				(keybase1.NotifyAppClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).Exit(context.Background())
 			}()
 		}
@@ -775,7 +775,7 @@ func (n *NotifyRouter) HandlePGPKeyInSecretStoreFile() {
 		if n.getNotificationChannels(id).PGP {
 			go func() {
 				(keybase1.NotifyPGPClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).PGPKeyInSecretStoreFile(context.Background())
 			}()
 		}
@@ -793,7 +793,7 @@ func (n *NotifyRouter) HandleReachability(r keybase1.Reachability) {
 		if n.getNotificationChannels(id).Reachability {
 			go func() {
 				(keybase1.ReachabilityClient{
-					Cli: rpc.NewClient(xp, ErrorUnwrapper{}),
+					Cli: rpc.NewClient(xp, ErrorUnwrapper{}, nil),
 				}).ReachabilityChanged(context.Background(), r)
 			}()
 		}

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -560,3 +560,11 @@ func JoinPredicate(arr []string, delimeter string, f func(s string) bool) string
 	}
 	return strings.Join(arrNew, delimeter)
 }
+
+// LogTagsFromContext is a wrapper around logger.LogTagsFromContext
+// that simply casts the result to the type expected by
+// rpc.Connection.
+func LogTagsFromContext(ctx context.Context) (map[interface{}]string, bool) {
+	tags, ok := logger.LogTagsFromContext(ctx)
+	return map[interface{}]string(tags), ok
+}

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -72,7 +72,7 @@ func newGregorFirehoseHandler(g *libkb.GlobalContext, connID libkb.ConnectionID,
 	return &gregorFirehoseHandler{
 		Contextified: libkb.NewContextified(g),
 		connID:       connID,
-		cli:          keybase1.GregorUIClient{Cli: rpc.NewClient(xp, libkb.ErrorUnwrapper{})},
+		cli:          keybase1.GregorUIClient{Cli: rpc.NewClient(xp, libkb.ErrorUnwrapper{}, nil)},
 	}
 }
 

--- a/go/service/handler.go
+++ b/go/service/handler.go
@@ -20,7 +20,7 @@ type BaseHandler struct {
 
 func NewBaseHandler(xp rpc.Transporter) *BaseHandler {
 	h := &BaseHandler{xp: xp}
-	h.cli = rpc.NewClient(h.xp, libkb.ErrorUnwrapper{})
+	h.cli = rpc.NewClient(h.xp, libkb.ErrorUnwrapper{}, nil)
 	h.loginCli = &keybase1.LoginUiClient{Cli: h.cli}
 	h.secretCli = &keybase1.SecretUiClient{Cli: h.cli}
 	h.logCli = &keybase1.LogUiClient{Cli: h.cli}

--- a/go/service/logsend.go
+++ b/go/service/logsend.go
@@ -30,7 +30,7 @@ func (h *LogsendHandler) PrepareLogsend(ctx context.Context) error {
 		return errors.New("GUI main process wasn't found")
 	}
 
-	cli := keybase1.LogsendClient{Cli: rpc.NewClient(xp, libkb.ErrorUnwrapper{})}
+	cli := keybase1.LogsendClient{Cli: rpc.NewClient(xp, libkb.ErrorUnwrapper{}, nil)}
 	var cancel func()
 	ctx, cancel = context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()

--- a/go/service/notify_fs_request.go
+++ b/go/service/notify_fs_request.go
@@ -22,7 +22,7 @@ func (h *notifyFSRequestHandler) client() (*keybase1.NotifyFSRequestClient, erro
 		return nil, errors.New("KBFS client wasn't found")
 	}
 	return &keybase1.NotifyFSRequestClient{
-		Cli: rpc.NewClient(xp, libkb.ErrorUnwrapper{}),
+		Cli: rpc.NewClient(xp, libkb.ErrorUnwrapper{}, nil),
 	}, nil
 }
 

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -30,7 +30,7 @@ func (s *SimpleFSHandler) client() (*keybase1.SimpleFSClient, error) {
 		return nil, errors.New("KBFS client wasn't found")
 	}
 	return &keybase1.SimpleFSClient{
-		Cli: rpc.NewClient(xp, libkb.ErrorUnwrapper{}),
+		Cli: rpc.NewClient(xp, libkb.ErrorUnwrapper{}, nil),
 	}, nil
 }
 

--- a/go/service/ui_router.go
+++ b/go/service/ui_router.go
@@ -94,7 +94,7 @@ func (u *UIRouter) GetIdentifyUI() (libkb.IdentifyUI, error) {
 	if x == nil {
 		return nil, nil
 	}
-	cli := rpc.NewClient(x, libkb.ErrorUnwrapper{})
+	cli := rpc.NewClient(x, libkb.ErrorUnwrapper{}, nil)
 	iuicli := keybase1.IdentifyUiClient{Cli: cli}
 	sessionID, err := iuicli.DelegateIdentifyUI(context.TODO())
 	if err != nil {
@@ -119,7 +119,7 @@ func (u *UIRouter) GetSecretUI(sessionID int) (ui libkb.SecretUI, err error) {
 		u.G().Log.Debug("| getUI(libkb.SecretUIKind) returned nil")
 		return nil, nil
 	}
-	cli := rpc.NewClient(x, libkb.ErrorUnwrapper{})
+	cli := rpc.NewClient(x, libkb.ErrorUnwrapper{}, nil)
 	scli := keybase1.SecretUiClient{Cli: cli}
 
 	u.G().Log.Debug("| returning delegated SecretUI with sessionID = %d", sessionID)
@@ -140,7 +140,7 @@ func (u *UIRouter) GetRekeyUI() (keybase1.RekeyUIInterface, int, error) {
 		u.G().Log.Debug("| getUI(libkb.RekeyUIKind) returned nil")
 		return nil, 0, nil
 	}
-	cli := rpc.NewClient(x, libkb.ErrorUnwrapper{})
+	cli := rpc.NewClient(x, libkb.ErrorUnwrapper{}, nil)
 	uicli := keybase1.RekeyUIClient{Cli: cli}
 	sessionID, err := uicli.DelegateRekeyUI(context.TODO())
 	if err != nil {
@@ -167,7 +167,7 @@ func (u *UIRouter) getOrReuseRekeyUI(prev *RekeyUI) (ret *RekeyUI, err error) {
 		return prev, nil
 	}
 
-	cli := rpc.NewClient(x, libkb.ErrorUnwrapper{})
+	cli := rpc.NewClient(x, libkb.ErrorUnwrapper{}, nil)
 	uicli := keybase1.RekeyUIClient{Cli: cli}
 	var sessionID int
 	sessionID, err = uicli.DelegateRekeyUI(context.TODO())

--- a/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/connection.go
+++ b/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/connection.go
@@ -368,7 +368,7 @@ func (c *Connection) connect(ctx context.Context) error {
 		return err
 	}
 
-	client := NewClient(transport, c.errorUnwrapper)
+	client := NewClient(transport, c.errorUnwrapper, c.tagsFunc)
 	server := NewServer(transport, c.wef)
 
 	for _, p := range c.protocols {
@@ -581,18 +581,6 @@ var _ GenericClient = connectionClient{}
 
 func (c connectionClient) Call(ctx context.Context, s string, args interface{}, res interface{}) error {
 	return c.conn.DoCommand(ctx, s, func(rawClient GenericClient) error {
-		if c.conn.tagsFunc != nil {
-			tags, ok := c.conn.tagsFunc(ctx)
-			if ok {
-				rpcTags := make(CtxRpcTags)
-				for key, tagName := range tags {
-					if v := ctx.Value(key); v != nil {
-						rpcTags[tagName] = v
-					}
-				}
-				ctx = AddRpcTagsToContext(ctx, rpcTags)
-			}
-		}
 		return rawClient.Call(ctx, s, args, res)
 	})
 }

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -259,10 +259,10 @@
 			"revisionTime": "2017-03-08T15:50:15Z"
 		},
 		{
-			"checksumSHA1": "IXitcIrP3o9YzQ+OjvNWWVX3QX0=",
+			"checksumSHA1": "JfG/DT0QIPFFHh9pB5uPZUXhO4w=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc",
-			"revision": "6df28f7bb1acfb3ab689a143c3e4d369c7f2df50",
-			"revisionTime": "2017-03-06T22:50:13Z"
+			"revision": "2641a997029da6b373ad1b4dd386aa1f8e28e216",
+			"revisionTime": "2017-03-21T20:26:42Z"
 		},
 		{
 			"path": "github.com/keybase/go-jsonw",


### PR DESCRIPTION
This allows chat to send tags for chat-related RPCs to KBFS and have
them logged there (and those same tags will make their way back to the
service in identify calls made by KBFS).

Issue: KBFS-2035