### PR TITLE
implement SimpleFS cancellation for copy and move

### DIFF
--- a/go/client/cmd_simplefs_copy.go
+++ b/go/client/cmd_simplefs_copy.go
@@ -22,7 +22,10 @@ type CmdSimpleFSCopy struct {
 	recurse     bool
 	interactive bool
 	force       bool
+	opCanceler  *OpCanceler
 }
+
+var _ Canceler = (*CmdSimpleFSCopy)(nil)
 
 // NewCmdSimpleFSCopy creates a new cli.Command.
 func NewCmdSimpleFSCopy(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -31,7 +34,10 @@ func NewCmdSimpleFSCopy(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.
 		ArgumentHelp: "<source> [source] <dest>",
 		Usage:        "copy one or more directory elements to dest",
 		Action: func(c *cli.Context) {
-			cl.ChooseCommand(&CmdSimpleFSCopy{Contextified: libkb.NewContextified(g)}, "cp", c)
+			cl.ChooseCommand(&CmdSimpleFSCopy{
+				Contextified: libkb.NewContextified(g),
+				opCanceler:   NewOpCanceler(g),
+			}, "cp", c)
 		},
 		Flags: []cli.Flag{
 			cli.BoolFlag{
@@ -74,7 +80,7 @@ func (c *CmdSimpleFSCopy) Run() error {
 		dest, err = makeDestPath(c.G(), ctx, cli, src, c.dest, isDestDir, destPathString)
 		c.G().Log.Debug("SimpleFSCopy %s -> %s, %v", pathToString(src), pathToString(dest), isDestDir)
 
-		if err == TargetFileExistsError {
+		if err == ErrTargetFileExists {
 			if c.interactive == true {
 				err = doOverwritePrompt(c.G(), pathToString(dest))
 			} else if c.force == true {
@@ -87,10 +93,17 @@ func (c *CmdSimpleFSCopy) Run() error {
 			return err
 		}
 
+		// Don't spawn new jobs if we've been cancelled.
+		// TODO: This is still a race condition, if we get cancelled immediately after.
+		if c.opCanceler.IsCancelled() {
+			break
+		}
+
 		opid, err := cli.SimpleFSMakeOpid(ctx)
 		if err != nil {
 			return err
 		}
+		c.opCanceler.AddOp(opid)
 
 		if c.recurse {
 			err = cli.SimpleFSCopyRecursive(ctx, keybase1.SimpleFSCopyRecursiveArg{
@@ -141,4 +154,8 @@ func (c *CmdSimpleFSCopy) GetUsage() libkb.Usage {
 		KbKeyring: true,
 		API:       true,
 	}
+}
+
+func (c *CmdSimpleFSCopy) Cancel() error {
+	return c.opCanceler.Cancel()
 }

--- a/go/client/cmd_simplefs_move.go
+++ b/go/client/cmd_simplefs_move.go
@@ -21,7 +21,10 @@ type CmdSimpleFSMove struct {
 	dest        keybase1.Path
 	interactive bool
 	force       bool
+	opCanceler  *OpCanceler
 }
+
+var _ Canceler = (*CmdSimpleFSMove)(nil)
 
 // NewCmdSimpleFSMove creates a new cli.Command.
 func NewCmdSimpleFSMove(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -30,7 +33,10 @@ func NewCmdSimpleFSMove(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.
 		ArgumentHelp: "<source> [source] <dest>",
 		Usage:        "move one or more directory elements to dest",
 		Action: func(c *cli.Context) {
-			cl.ChooseCommand(&CmdSimpleFSMove{Contextified: libkb.NewContextified(g)}, "mv", c)
+			cl.ChooseCommand(&CmdSimpleFSMove{
+				Contextified: libkb.NewContextified(g),
+				opCanceler:   NewOpCanceler(g),
+			}, "mv", c)
 		},
 		Flags: []cli.Flag{
 			cli.BoolFlag{
@@ -82,10 +88,17 @@ func (c *CmdSimpleFSMove) Run() error {
 		}
 		c.G().Log.Debug("SimpleFSMove %s -> %s", pathToString(src), pathToString(dest))
 
+		// Don't spawn new jobs if we've been cancelled.
+		// TODO: This is still a race condition, if we get cancelled immediately after.
+		if c.opCanceler.IsCancelled() {
+			break
+		}
+
 		opid, err := cli.SimpleFSMakeOpid(ctx)
 		if err != nil {
 			return err
 		}
+		c.opCanceler.AddOp(opid)
 		defer cli.SimpleFSClose(ctx, opid)
 
 		err = cli.SimpleFSMove(ctx, keybase1.SimpleFSMoveArg{
@@ -125,4 +138,8 @@ func (c *CmdSimpleFSMove) GetUsage() libkb.Usage {
 		KbKeyring: true,
 		API:       true,
 	}
+}
+
+func (c *CmdSimpleFSMove) Cancel() error {
+	return c.opCanceler.Cancel()
 }

--- a/go/client/cmd_simplefs_move.go
+++ b/go/client/cmd_simplefs_move.go
@@ -69,7 +69,7 @@ func (c *CmdSimpleFSMove) Run() error {
 
 		dest, err := makeDestPath(c.G(), ctx, cli, src, c.dest, isDestDir, destPathString)
 
-		if err == TargetFileExistsError {
+		if err == ErrTargetFileExists {
 			if c.interactive == true {
 				err = doOverwritePrompt(c.G(), pathToString(dest))
 			} else if c.force == true {

--- a/go/client/interfaces.go
+++ b/go/client/interfaces.go
@@ -2,3 +2,13 @@
 // this source code is governed by the included BSD license.
 
 package client
+
+import "github.com/keybase/client/go/protocol/keybase1"
+
+type Canceler interface {
+	Cancel() error
+}
+
+type Stopper interface {
+	Stop(exitcode keybase1.ExitCode)
+}

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -342,7 +342,7 @@ func TestSimpleFSLocalSrcDir(t *testing.T) {
 		true,
 		"/public/foobar")
 	assert.Equal(tc.T, filepath.ToSlash(filepath.Join("/public/foobar", filepath.Base(tempdir))), destPath.Kbfs())
-	assert.Equal(tc.T, err, TargetFileExistsError, "Expected that remote target path exists because of SimpleFSMock")
+	assert.Equal(tc.T, err, ErrTargetFileExists, "Expected that remote target path exists because of SimpleFSMock")
 	//	require.NoError(tc.T, err, "bad path type")
 
 	pathType, err := destPath.PathType()

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -132,6 +132,11 @@ func (s SimpleFSMock) SimpleFSClose(ctx context.Context, arg keybase1.OpID) erro
 	return nil
 }
 
+// SimpleFSCancel - Cancels a running operation, like copy.
+func (s SimpleFSMock) SimpleFSCancel(ctx context.Context, arg keybase1.OpID) error {
+	return nil
+}
+
 // SimpleFSCheck - Check progress of pending operation
 func (s SimpleFSMock) SimpleFSCheck(ctx context.Context, arg keybase1.OpID) (keybase1.Progress, error) {
 	return 0, nil

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -30,14 +30,6 @@ var G = libkb.G
 
 var cmd libcmdline.Command
 
-type Canceler interface {
-	Cancel() error
-}
-
-type Stopper interface {
-	Stop(exitcode keybase1.ExitCode)
-}
-
 func handleQuickVersion() bool {
 	if len(os.Args) == 3 && os.Args[1] == "version" && os.Args[2] == "-S" {
 		fmt.Printf("%s\n", libkb.VersionString())
@@ -317,14 +309,14 @@ func HandleSignals() {
 			// if the current command has a Stop function, then call it.
 			// It will do its own stopping of the process and calling
 			// shutdown
-			if stop, ok := cmd.(Stopper); ok {
+			if stop, ok := cmd.(client.Stopper); ok {
 				G.Log.Debug("Stopping command cleanly via stopper")
 				stop.Stop(keybase1.ExitCode_OK)
 				return
 			}
 
 			// if the current command has a Cancel function, then call it:
-			if canc, ok := cmd.(Canceler); ok {
+			if canc, ok := cmd.(client.Canceler); ok {
 				G.Log.Debug("canceling running command")
 				if err := canc.Cancel(); err != nil {
 					G.Log.Warning("error canceling command: %s", err)

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -496,6 +496,10 @@ type SimpleFSCloseArg struct {
 	OpID OpID `codec:"opID" json:"opID"`
 }
 
+type SimpleFSCancelArg struct {
+	OpID OpID `codec:"opID" json:"opID"`
+}
+
 type SimpleFSCheckArg struct {
 	OpID OpID `codec:"opID" json:"opID"`
 }
@@ -548,6 +552,8 @@ type SimpleFSInterface interface {
 	// Close OpID, cancels any pending operation.
 	// Must be called after list/copy/remove
 	SimpleFSClose(context.Context, OpID) error
+	// Cancels a running operation, like copy.
+	SimpleFSCancel(context.Context, OpID) error
 	// Check progress of pending operation
 	SimpleFSCheck(context.Context, OpID) (Progress, error)
 	// Get all the outstanding operations
@@ -795,6 +801,22 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"simpleFSCancel": {
+				MakeArg: func() interface{} {
+					ret := make([]SimpleFSCancelArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]SimpleFSCancelArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]SimpleFSCancelArg)(nil), args)
+						return
+					}
+					err = i.SimpleFSCancel(ctx, (*typedArgs)[0].OpID)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 			"simpleFSCheck": {
 				MakeArg: func() interface{} {
 					ret := make([]SimpleFSCheckArg, 1)
@@ -946,6 +968,13 @@ func (c SimpleFSClient) SimpleFSMakeOpid(ctx context.Context) (res OpID, err err
 func (c SimpleFSClient) SimpleFSClose(ctx context.Context, opID OpID) (err error) {
 	__arg := SimpleFSCloseArg{OpID: opID}
 	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSClose", []interface{}{__arg}, nil)
+	return
+}
+
+// Cancels a running operation, like copy.
+func (c SimpleFSClient) SimpleFSCancel(ctx context.Context, opID OpID) (err error) {
+	__arg := SimpleFSCancelArg{OpID: opID}
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCancel", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -179,6 +179,15 @@ func (s *SimpleFSHandler) SimpleFSClose(ctx context.Context, arg keybase1.OpID) 
 	return cli.SimpleFSClose(ctx, arg)
 }
 
+// SimpleFSCancel - Cancels a running operation, like copy.
+func (s *SimpleFSHandler) SimpleFSCancel(ctx context.Context, arg keybase1.OpID) error {
+	cli, err := s.client()
+	if err != nil {
+		return err
+	}
+	return cli.SimpleFSCancel(ctx, arg)
+}
+
 // SimpleFSCheck - Check progress of pending operation
 func (s *SimpleFSHandler) SimpleFSCheck(ctx context.Context, arg keybase1.OpID) (keybase1.Progress, error) {
 	cli, err := s.client()

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -217,6 +217,11 @@ protocol SimpleFS {
   void simpleFSClose(OpID opID);
 
   /**
+   Cancels a running operation, like copy.
+   */
+  void simpleFSCancel(OpID opID);
+
+  /**
    Check progress of pending operation
    */
   Progress simpleFSCheck(OpID opID);

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -616,6 +616,18 @@ export function SecretKeysGetSecretKeysRpcPromise (request: $Exact<requestCommon
   return new Promise((resolve, reject) => { SecretKeysGetSecretKeysRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function SimpleFSSimpleFSCancelRpc (request: Exact<requestCommon & requestErrorCallback & {param: SimpleFSSimpleFSCancelRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'keybase.1.SimpleFS.simpleFSCancel'})
+}
+
+export function SimpleFSSimpleFSCancelRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: SimpleFSSimpleFSCancelRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => SimpleFSSimpleFSCancelRpc({...request, incomingCallMap, callback}))
+}
+
+export function SimpleFSSimpleFSCancelRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: SimpleFSSimpleFSCancelRpcParam}>): Promise<any> {
+  return new Promise((resolve, reject) => { SimpleFSSimpleFSCancelRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function SimpleFSSimpleFSCheckRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSCheckResult) => void} & {param: SimpleFSSimpleFSCheckRpcParam}>) {
   engineRpcOutgoing({...request, method: 'keybase.1.SimpleFS.simpleFSCheck'})
 }
@@ -4414,6 +4426,10 @@ export type SimpleFSListResult = {
   progress: Progress,
 }
 
+export type SimpleFSSimpleFSCancelRpcParam = Exact<{
+  opID: OpID
+}>
+
 export type SimpleFSSimpleFSCheckRpcParam = Exact<{
   opID: OpID
 }>
@@ -6040,6 +6056,7 @@ export type rpc =
   | NotifyFSRequestFSSyncStatusRequestRpc
   | ScanProofsScanProofsRpc
   | SecretKeysGetSecretKeysRpc
+  | SimpleFSSimpleFSCancelRpc
   | SimpleFSSimpleFSCheckRpc
   | SimpleFSSimpleFSCloseRpc
   | SimpleFSSimpleFSCopyRecursiveRpc

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -522,6 +522,16 @@
       "response": null,
       "doc": "Close OpID, cancels any pending operation.\n   Must be called after list/copy/remove"
     },
+    "simpleFSCancel": {
+      "request": [
+        {
+          "name": "opID",
+          "type": "OpID"
+        }
+      ],
+      "response": null,
+      "doc": "Cancels a running operation, like copy."
+    },
     "simpleFSCheck": {
       "request": [
         {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -616,6 +616,18 @@ export function SecretKeysGetSecretKeysRpcPromise (request: $Exact<requestCommon
   return new Promise((resolve, reject) => { SecretKeysGetSecretKeysRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function SimpleFSSimpleFSCancelRpc (request: Exact<requestCommon & requestErrorCallback & {param: SimpleFSSimpleFSCancelRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'keybase.1.SimpleFS.simpleFSCancel'})
+}
+
+export function SimpleFSSimpleFSCancelRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: SimpleFSSimpleFSCancelRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => SimpleFSSimpleFSCancelRpc({...request, incomingCallMap, callback}))
+}
+
+export function SimpleFSSimpleFSCancelRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: SimpleFSSimpleFSCancelRpcParam}>): Promise<any> {
+  return new Promise((resolve, reject) => { SimpleFSSimpleFSCancelRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function SimpleFSSimpleFSCheckRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: SimpleFSSimpleFSCheckResult) => void} & {param: SimpleFSSimpleFSCheckRpcParam}>) {
   engineRpcOutgoing({...request, method: 'keybase.1.SimpleFS.simpleFSCheck'})
 }
@@ -4414,6 +4426,10 @@ export type SimpleFSListResult = {
   progress: Progress,
 }
 
+export type SimpleFSSimpleFSCancelRpcParam = Exact<{
+  opID: OpID
+}>
+
 export type SimpleFSSimpleFSCheckRpcParam = Exact<{
   opID: OpID
 }>
@@ -6040,6 +6056,7 @@ export type rpc =
   | NotifyFSRequestFSSyncStatusRequestRpc
   | ScanProofsScanProofsRpc
   | SecretKeysGetSecretKeysRpc
+  | SimpleFSSimpleFSCancelRpc
   | SimpleFSSimpleFSCheckRpc
   | SimpleFSSimpleFSCloseRpc
   | SimpleFSSimpleFSCopyRecursiveRpc


### PR DESCRIPTION
The current approach in this PR is a little bit error-prone, requiring each command's implementation to do several things:

- Initialize the canceler.
- Add OpIDs to the canceler as they're created.
- Break any loops if cancellation has already happened (because it happens in a separate goroutine, during signal handling)
- Call the canceler's Cancel method from the command's own

It's also vulnerable to a race condition: Cancellation could happen right after a loop checked the cancelled flag, but before a job is started. I think the right way to solve this one would be to make sure that there's a lock taken around the entire job-starting process, and the same lock that cancellation takes. But that would be deadlock-prone, as the lock would need to be released _before_ `SimpleFSWait`, and so early exits can't benefit from the usual `defer lock.Unlock()`.

So...yeah...I'm not super happy with this approach. What do you guys think?

r? @zanderz @taruti 