### PR TITLE
add ability to bust local chat caches from the server CORE-4797

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGetThreadSupersedes(t *testing.T) {
-	world, ri, _, sender, _, _, tlf := setupTest(t, 1)
+	world, ri, _, sender, _, tlf := setupTest(t, 1)
 	defer world.Cleanup()
 
 	u := world.GetUsers()[0]
@@ -220,6 +220,11 @@ func (f failingRemote) SyncInbox(ctx context.Context, vers chat1.InboxVers) (cha
 	return chat1.SyncInboxRes{}, nil
 }
 
+func (f failingRemote) SyncChat(ctx context.Context, vers chat1.InboxVers) (chat1.SyncChatRes, error) {
+	require.Fail(f.t, "SyncChat")
+	return chat1.SyncChatRes{}, nil
+}
+
 type failingTlf struct {
 	t *testing.T
 }
@@ -300,7 +305,7 @@ func (f failingUpak) PutUserToCache(ctx context.Context, user *libkb.User) error
 }
 
 func TestGetThreadCaching(t *testing.T) {
-	world, ri, _, sender, _, _, tlf := setupTest(t, 1)
+	world, ri, _, sender, _, tlf := setupTest(t, 1)
 	defer world.Cleanup()
 
 	u := world.GetUsers()[0]

--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -30,7 +30,7 @@ func NewIdentifyNotifier(g *libkb.GlobalContext) *IdentifyNotifier {
 		Contextified: libkb.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g, "IdentifyNotifier", false),
 		identCache:   make(map[string]keybase1.CanonicalTLFNameAndIDWithBreaks),
-		storage:      storage.New(g, func() libkb.SecretUI { return DelivererSecretUI{} }),
+		storage:      storage.New(g),
 	}
 }
 
@@ -87,9 +87,7 @@ func (h *IdentifyChangedHandler) getUsername(ctx context.Context, uid keybase1.U
 func (h *IdentifyChangedHandler) getTLFtoCrypt(ctx context.Context, uid gregor1.UID) (string, chat1.TLFID, error) {
 
 	me := h.G().Env.GetUID()
-	inbox := storage.NewInbox(h.G(), me.ToBytes(), func() libkb.SecretUI {
-		return DelivererSecretUI{}
-	})
+	inbox := storage.NewInbox(h.G(), me.ToBytes())
 
 	_, allConvs, err := inbox.ReadAll(ctx)
 	if err != nil {

--- a/go/chat/identify_test.go
+++ b/go/chat/identify_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/kbtest"
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/stretchr/testify/require"
@@ -17,16 +16,14 @@ import (
 
 func TestChatBackgroundIdentify(t *testing.T) {
 
-	world, _, _, _, listener, _, _ := setupTest(t, 2)
+	world, _, _, _, listener, _ := setupTest(t, 2)
 	defer world.Cleanup()
 
 	u := world.GetUsers()[0]
 	u1 := world.GetUsers()[1]
 	tc := world.Tcs[u.Username]
 
-	inbox := storage.NewInbox(tc.G, u.User.GetUID().ToBytes(), func() libkb.SecretUI {
-		return &libkb.TestSecretUI{}
-	})
+	inbox := storage.NewInbox(tc.G, u.User.GetUID().ToBytes())
 
 	tlfName := u.Username
 	msg := chat1.MessageBoxed{

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -80,7 +80,7 @@ func TestInboxSourceUpdateRace(t *testing.T) {
 // a complete sync of the inbox occurs.
 func TestInboxSourceSkipAhead(t *testing.T) {
 	t.Logf("setup")
-	world, ri2, _, sender, _, _, tlf := setupTest(t, 1)
+	world, ri2, _, sender, _, tlf := setupTest(t, 1)
 	ri := ri2.(*kbtest.ChatRemoteMock)
 	defer world.Cleanup()
 	t.Logf("test's remoteInterface: %p[%T] -> %v", &ri, ri, ri)

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestInboxSourceUpdateRace(t *testing.T) {
-	world, ri, _, sender, _, _, tlf := setupTest(t, 1)
+	world, ri, _, sender, _, tlf := setupTest(t, 1)
 	defer world.Cleanup()
 
 	u := world.GetUsers()[0]

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -122,7 +122,7 @@ func setupTest(t *testing.T, numUsers int) (*kbtest.ChatMockWorld, chat1.RemoteI
 		failing:        make(chan []chat1.OutboxRecord),
 		identifyUpdate: make(chan keybase1.CanonicalTLFNameAndIDWithBreaks),
 	}
-	tc.G.ConvSource = NewHybridConversationSource(tc.G, boxer, storage.New(tc.G, getSecretUI), getRI)
+	tc.G.ConvSource = NewHybridConversationSource(tc.G, boxer, storage.New(tc.G), getRI)
 	tc.G.InboxSource = NewHybridInboxSource(tc.G, getRI, tlf)
 	tc.G.ServerCacheVersions = storage.NewServerVersions(tc.G)
 	tc.G.NotifyRouter.SetListener(&listener)

--- a/go/chat/storage/locks.go
+++ b/go/chat/storage/locks.go
@@ -3,7 +3,7 @@ package storage
 import "sync"
 
 type locksRepo struct {
-	Storage, Inbox, Outbox sync.Mutex
+	Storage, Inbox, Outbox, Version sync.Mutex
 }
 
 var locks locksRepo

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -30,11 +30,11 @@ type diskOutbox struct {
 	Records []chat1.OutboxRecord `codec:"O"`
 }
 
-func NewOutbox(g *libkb.GlobalContext, uid gregor1.UID, getSecretUI func() libkb.SecretUI) *Outbox {
+func NewOutbox(g *libkb.GlobalContext, uid gregor1.UID) *Outbox {
 	return &Outbox{
 		Contextified: libkb.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g, "Outbox", false),
-		baseBox:      newBaseBox(g, getSecretUI),
+		baseBox:      newBaseBox(g),
 		uid:          uid,
 		clock:        clockwork.NewRealClock(),
 	}

--- a/go/chat/storage/outbox_test.go
+++ b/go/chat/storage/outbox_test.go
@@ -20,12 +20,9 @@ func setupOutboxTest(t testing.TB, name string) (libkb.TestContext, *Outbox, gre
 	tc := externals.SetupTest(t, name, 2)
 	u, err := kbtest.CreateAndSignupFakeUser("ob", tc.G)
 	require.NoError(t, err)
-	f := func() libkb.SecretUI {
-		return &libkb.TestSecretUI{Passphrase: u.Passphrase}
-	}
 	uid := gregor1.UID(u.User.GetUID().ToBytes())
 	cl := clockwork.NewFakeClock()
-	ob := NewOutbox(tc.G, uid, f)
+	ob := NewOutbox(tc.G, uid)
 	ob.SetClock(cl)
 	return tc, ob, uid, cl
 }

--- a/go/chat/storage/storage_msgengine.go
+++ b/go/chat/storage/storage_msgengine.go
@@ -55,7 +55,7 @@ func (ms *msgEngine) makeMsgKey(convID chat1.ConversationID, uid gregor1.UID, ms
 	}
 }
 
-func (ms *msgEngine) writeMessages(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
+func (ms *msgEngine) WriteMessages(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
 	msgs []chat1.MessageUnboxed) Error {
 
 	// Sanity check
@@ -110,7 +110,7 @@ func (ms *msgEngine) writeMessages(ctx context.Context, convID chat1.Conversatio
 	return nil
 }
 
-func (ms *msgEngine) readMessages(ctx context.Context, rc resultCollector,
+func (ms *msgEngine) ReadMessages(ctx context.Context, rc resultCollector,
 	convID chat1.ConversationID, uid gregor1.UID, maxID chat1.MessageID) (err Error) {
 
 	// Run all errors through resultCollector
@@ -164,7 +164,7 @@ func (ms *msgEngine) readMessages(ctx context.Context, rc resultCollector,
 	return nil
 }
 
-func (ms *msgEngine) init(ctx context.Context, key [32]byte, convID chat1.ConversationID,
+func (ms *msgEngine) Init(ctx context.Context, key [32]byte, convID chat1.ConversationID,
 	uid gregor1.UID) (context.Context, Error) {
 	return context.WithValue(ctx, beskkey, key), nil
 }

--- a/go/chat/storage/version.go
+++ b/go/chat/storage/version.go
@@ -1,0 +1,113 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	context "golang.org/x/net/context"
+)
+
+type ServerVersions struct {
+	libkb.Contextified
+	utils.DebugLabeler
+
+	cached *chat1.ServerCacheVers
+}
+
+func NewServerVersions(g *libkb.GlobalContext) *ServerVersions {
+	return &ServerVersions{
+		Contextified: libkb.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "ServerVersions", false),
+	}
+}
+
+func (s *ServerVersions) makeKey() libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBChatBlocks,
+		Key: fmt.Sprintf("versions"),
+	}
+}
+
+func (s *ServerVersions) fetchLocked(ctx context.Context) (chat1.ServerCacheVers, error) {
+	// Check in memory first
+	if s.cached != nil {
+		return *s.cached, nil
+	}
+
+	// Read from LevelDb
+	raw, found, err := s.G().LocalChatDb.GetRaw(s.makeKey())
+	if err != nil {
+		s.Debug(ctx, "fetchLocked: failed to read: %s", err.Error())
+		return chat1.ServerCacheVers{}, err
+	}
+	if !found {
+		s.Debug(ctx, "no server version found, using defaults")
+		return chat1.ServerCacheVers{}, nil
+	}
+	var srvVers chat1.ServerCacheVers
+	if err = decode(raw, &srvVers); err != nil {
+		s.Debug(ctx, "fetchLocked: failed to decode: %s", err.Error())
+		return chat1.ServerCacheVers{}, err
+	}
+
+	// Store in memory
+	s.cached = &srvVers
+	return *s.cached, nil
+}
+
+func (s *ServerVersions) Fetch(ctx context.Context) (chat1.ServerCacheVers, error) {
+	locks.Version.Lock()
+	defer locks.Version.Unlock()
+
+	return s.fetchLocked(ctx)
+}
+
+func (s *ServerVersions) matchLocked(ctx context.Context, vers int,
+	versFunc func(chat1.ServerCacheVers) int) (int, error) {
+	srvVers, err := s.fetchLocked(ctx)
+	if err != nil {
+		return 0, err
+	}
+	retVers := versFunc(srvVers)
+	if retVers != vers {
+		return retVers, NewVersionMismatchError(chat1.InboxVers(vers), chat1.InboxVers(retVers))
+	}
+	return retVers, nil
+}
+
+func (s *ServerVersions) MatchInbox(ctx context.Context, vers int) (int, error) {
+	locks.Version.Lock()
+	defer locks.Version.Unlock()
+
+	return s.matchLocked(ctx, vers, func(srvVers chat1.ServerCacheVers) int { return srvVers.InboxVers })
+}
+
+func (s *ServerVersions) MatchBodies(ctx context.Context, vers int) (int, error) {
+	locks.Version.Lock()
+	defer locks.Version.Unlock()
+
+	return s.matchLocked(ctx, vers, func(srvVers chat1.ServerCacheVers) int { return srvVers.BodiesVers })
+}
+
+func (s *ServerVersions) Set(ctx context.Context, vers chat1.ServerCacheVers) (err error) {
+	locks.Version.Lock()
+	defer locks.Version.Unlock()
+
+	// Write in memory
+	s.cached = &vers
+
+	// Write out to LevelDB
+	dat, err := encode(vers)
+	if err != nil {
+		s.Debug(ctx, "Sync: failed to encode: %s", err.Error())
+		return err
+	}
+	if err = s.G().LocalChatDb.PutRaw(s.makeKey(), dat); err != nil {
+		s.Debug(ctx, "Sync: failed to write: %s", err.Error())
+		return err
+	}
+
+	return nil
+}

--- a/go/chat/storage/version_test.go
+++ b/go/chat/storage/version_test.go
@@ -1,0 +1,44 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerVersionSync(t *testing.T) {
+	tc := externals.SetupTest(t, "version", 2)
+	tc.G.ServerCacheVersions = NewServerVersions(tc.G)
+
+	err := tc.G.ServerCacheVersions.Set(context.TODO(), chat1.ServerCacheVers{
+		InboxVers:  10,
+		BodiesVers: 5,
+	})
+	require.NoError(t, err)
+
+	res, err := tc.G.ServerCacheVersions.Fetch(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, 10, res.InboxVers)
+	require.Equal(t, 5, res.BodiesVers)
+
+	err = tc.G.ServerCacheVersions.Set(context.TODO(), chat1.ServerCacheVers{
+		InboxVers:  10,
+		BodiesVers: 5,
+	})
+	require.NoError(t, err)
+
+	vers, err := tc.G.ServerCacheVersions.MatchInbox(context.TODO(), 10)
+	require.NoError(t, err)
+	require.Equal(t, 10, vers)
+
+	vers, err = tc.G.ServerCacheVersions.MatchBodies(context.TODO(), 5)
+	require.NoError(t, err)
+	require.Equal(t, 5, vers)
+
+	vers, err = tc.G.ServerCacheVersions.MatchInbox(context.TODO(), 11)
+	require.Error(t, err)
+	require.IsType(t, VersionMismatchError{}, err)
+}

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -43,6 +43,21 @@ func (s *Syncer) SendChatStaleNotifications(uid gregor1.UID, convs []chat1.Conve
 	s.G().NotifyRouter.HandleChatThreadsStale(context.Background(), kuid, s.getConvIDs(convs))
 }
 
+func (s *Syncer) isServerInboxClear(ctx context.Context, inbox *storage.Inbox) bool {
+	iboxSrvVers, err := inbox.ServerVersion(ctx)
+	if err != nil {
+		s.Debug(ctx, "isServerInboxClear: failed to get server version: %s", err.Error())
+		return true
+	}
+
+	if _, err := s.G().ServerCacheVersions.MatchInbox(ctx, iboxSrvVers); err != nil {
+		s.Debug(ctx, "isServerInboxClear: inbox server version match error: %s", err.Error())
+		return true
+	}
+
+	return false
+}
+
 func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID) (err error) {
 	ctx = CtxAddLogTags(ctx)
 	s.Debug(ctx, "Connected: running")
@@ -87,9 +102,8 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 	}
 
 	// Grab current on disk version
-	ibox := storage.NewInbox(s.G(), uid, func() libkb.SecretUI {
-		return DelivererSecretUI{}
-	})
+	ibox := storage.NewInbox(s.G(), uid)
+	var syncRes chat1.SyncChatRes
 	vers, err := ibox.Version(ctx)
 	if err != nil {
 		s.Debug(ctx, "Sync: failed to get current inbox version (using 0): %s", err.Error())
@@ -98,18 +112,28 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 	s.Debug(ctx, "Sync: current inbox version: %v", vers)
 
 	// Run the sync call on the server to see how current our local copy is
-	var syncRes chat1.SyncInboxRes
-	if syncRes, err = cli.SyncInbox(ctx, vers); err != nil {
+
+	if syncRes, err = cli.SyncChat(ctx, vers); err != nil {
 		s.Debug(ctx, "Sync: failed to sync inbox: %s", err.Error())
 		return err
 	}
 
+	// Set new server versions
+	if err = s.G().ServerCacheVersions.Set(ctx, syncRes.CacheVers); err != nil {
+		s.Debug(ctx, "Connected: failed to set new server versions: %s", err.Error())
+	}
+
 	// Process what the server has told us to do with the local inbox copy
-	rtyp, err := syncRes.Typ()
+	rtyp, err := syncRes.InboxRes.Typ()
 	if err != nil {
 		s.Debug(ctx, "Sync: strange type from SyncInbox: %s", err.Error())
 		return err
 	}
+	// Check if the server has cleared the inbox
+	if s.isServerInboxClear(ctx, ibox) {
+		rtyp = chat1.SyncInboxResType_CLEAR
+	}
+
 	switch rtyp {
 	case chat1.SyncInboxResType_CLEAR:
 		s.Debug(ctx, "Sync: version out of date, clearing inbox: %v", vers)
@@ -121,7 +145,7 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 	case chat1.SyncInboxResType_CURRENT:
 		s.Debug(ctx, "Sync: version is current, standing pat: %v", vers)
 	case chat1.SyncInboxResType_INCREMENTAL:
-		incr := syncRes.Incremental()
+		incr := syncRes.InboxRes.Incremental()
 		s.Debug(ctx, "Sync: version out of date, but can incrementally sync: old vers: %v vers: %v convs: %d",
 			vers, incr.Vers, len(incr.Convs))
 

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -1,0 +1,155 @@
+package chat
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/chat/storage"
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func newConv(t *testing.T, ri chat1.RemoteInterface, sender Sender, tlf kbtest.TlfMock, tlfName string) chat1.Conversation {
+	trip := newConvTriple(t, tlf, tlfName)
+	firstMessagePlaintext := chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Conv:        trip,
+			TlfName:     tlfName,
+			TlfPublic:   false,
+			MessageType: chat1.MessageType_TLFNAME,
+		},
+		MessageBody: chat1.MessageBody{},
+	}
+	firstMessageBoxed, _, err := sender.Prepare(context.TODO(), firstMessagePlaintext, nil)
+	require.NoError(t, err)
+	res, err := ri.NewConversationRemote2(context.TODO(), chat1.NewConversationRemote2Arg{
+		IdTriple:   trip,
+		TLFMessage: *firstMessageBoxed,
+	})
+	require.NoError(t, err)
+
+	ires, err := ri.GetInboxRemote(context.TODO(), chat1.GetInboxRemoteArg{
+		Query: &chat1.GetInboxQuery{
+			ConvID: &res.ConvID,
+		},
+	})
+	require.NoError(t, err)
+	return ires.Inbox.Full().Conversations[0]
+}
+
+func TestSyncerConnected(t *testing.T) {
+	world, ri2, _, sender, list, tlf := setupTest(t, 3)
+	defer world.Cleanup()
+
+	ri := ri2.(*kbtest.ChatRemoteMock)
+	u := world.GetUsers()[0]
+	u1 := world.GetUsers()[1]
+	u2 := world.GetUsers()[2]
+	uid := u.User.GetUID().ToBytes()
+	tc := world.Tcs[u.Username]
+	syncer := NewSyncer(tc.G)
+	ibox := storage.NewInbox(tc.G, uid)
+
+	var convs []chat1.Conversation
+	convs = append(convs, newConv(t, ri, sender, tlf, u.Username+","+u1.Username))
+	convs = append(convs, newConv(t, ri, sender, tlf, u.Username+","+u2.Username))
+	convs = append(convs, newConv(t, ri, sender, tlf, u.Username+","+u2.Username+","+u1.Username))
+
+	t.Logf("test current")
+	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
+		return chat1.NewSyncInboxResWithCurrent(), nil
+	}
+	require.NoError(t, syncer.Sync(context.TODO(), ri, uid))
+
+	t.Logf("test clear")
+	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
+		return chat1.NewSyncInboxResWithClear(), nil
+	}
+	require.NoError(t, syncer.Sync(context.TODO(), ri, uid))
+	select {
+	case <-list.inboxStale:
+	default:
+		require.Fail(t, "no inbox stale received")
+	}
+	select {
+	case cids := <-list.threadsStale:
+		require.Zero(t, len(cids))
+	default:
+		require.Fail(t, "no threads stale received")
+	}
+	_, _, err := ibox.ReadAll(context.TODO())
+	require.Error(t, err)
+	require.IsType(t, storage.MissError{}, err)
+
+	t.Logf("test incremental")
+	_, _, serr := tc.G.InboxSource.Read(context.TODO(), uid, nil, true, nil, nil)
+	require.NoError(t, serr)
+	_, iconvs, err := ibox.ReadAll(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, len(convs), len(iconvs))
+	mconv := convs[1]
+	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
+		mconv.Metadata.Status = chat1.ConversationStatus_MUTED
+		return chat1.NewSyncInboxResWithIncremental(chat1.SyncIncrementalRes{
+			Vers:  100,
+			Convs: []chat1.Conversation{mconv},
+		}), nil
+	}
+	require.NoError(t, syncer.Sync(context.TODO(), ri, uid))
+	select {
+	case <-list.inboxStale:
+	default:
+		require.Fail(t, "no inbox stale received")
+	}
+	select {
+	case cids := <-list.threadsStale:
+		require.Equal(t, 1, len(cids))
+		require.Equal(t, convs[1].GetConvID(), cids[0])
+	default:
+		require.Fail(t, "no threads stale received")
+	}
+	vers, iconvs, err := ibox.ReadAll(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, len(convs), len(iconvs))
+	for _, ic := range iconvs {
+		if ic.GetConvID().Eq(mconv.GetConvID()) {
+			require.Equal(t, chat1.ConversationStatus_MUTED, ic.Metadata.Status)
+		}
+	}
+	require.Equal(t, chat1.ConversationStatus_UNFILED, convs[1].Metadata.Status)
+	require.Equal(t, chat1.InboxVers(100), vers)
+
+	t.Logf("test server version")
+	srvVers, err := ibox.ServerVersion(context.TODO())
+	require.NoError(t, err)
+	require.Zero(t, srvVers)
+	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
+		return chat1.NewSyncInboxResWithCurrent(), nil
+	}
+	ri.CacheInboxVersion = 5
+	ri.CacheBodiesVersion = 5
+	require.NoError(t, syncer.Sync(context.TODO(), ri, uid))
+	select {
+	case <-list.inboxStale:
+	default:
+		require.Fail(t, "no inbox stale received")
+	}
+	select {
+	case cids := <-list.threadsStale:
+		require.Zero(t, len(cids))
+	default:
+		require.Fail(t, "no threads stale received")
+	}
+	_, _, err = ibox.ReadAll(context.TODO())
+	require.Error(t, err)
+	require.IsType(t, storage.MissError{}, err)
+	_, _, serr = tc.G.InboxSource.Read(context.TODO(), uid, nil, true, nil, nil)
+	require.NoError(t, serr)
+	_, iconvs, err = ibox.ReadAll(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, len(convs), len(iconvs))
+	srvVers, err = ibox.ServerVersion(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, 5, srvVers)
+}

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -75,3 +75,10 @@ type InboxSource interface {
 	SetRemoteInterface(func() chat1.RemoteInterface)
 	SetTLFInfoSource(tlfInfoSource TLFInfoSource)
 }
+
+type ServerCacheVersions interface {
+	Set(ctx context.Context, vers chat1.ServerCacheVers) error
+	MatchBodies(ctx context.Context, vers int) (int, error)
+	MatchInbox(ctx context.Context, vers int) (int, error)
+	Fetch(ctx context.Context) (chat1.ServerCacheVers, error)
+}

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -545,6 +545,10 @@ func (m *ChatRemoteMock) SyncInbox(ctx context.Context, vers chat1.InboxVers) (c
 	return m.SyncInboxFunc(m, ctx, vers)
 }
 
+func (m *ChatRemoteMock) SyncChat(ctx context.Context, vers chat1.InboxVers) (chat1.SyncChatRes, error) {
+	return chat1.SyncChatRes{}, nil
+}
+
 type convByNewlyUpdated struct {
 	mock *ChatRemoteMock
 }

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -216,6 +216,9 @@ type ChatRemoteMock struct {
 	readMsgid map[string]chat1.MessageID
 	uid       *gregor1.UID
 
+	CacheBodiesVersion int
+	CacheInboxVersion  int
+
 	SyncInboxFunc func(m *ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error)
 }
 
@@ -556,6 +559,10 @@ func (m *ChatRemoteMock) SyncChat(ctx context.Context, vers chat1.InboxVers) (ch
 	}
 	return chat1.SyncChatRes{
 		InboxRes: iboxRes,
+		CacheVers: chat1.ServerCacheVers{
+			InboxVers:  m.CacheInboxVersion,
+			BodiesVers: m.CacheBodiesVersion,
+		},
 	}, nil
 }
 

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -546,7 +546,17 @@ func (m *ChatRemoteMock) SyncInbox(ctx context.Context, vers chat1.InboxVers) (c
 }
 
 func (m *ChatRemoteMock) SyncChat(ctx context.Context, vers chat1.InboxVers) (chat1.SyncChatRes, error) {
-	return chat1.SyncChatRes{}, nil
+	if m.SyncInboxFunc == nil {
+		return chat1.SyncChatRes{}, nil
+	}
+
+	iboxRes, err := m.SyncInboxFunc(m, ctx, vers)
+	if err != nil {
+		return chat1.SyncChatRes{}, err
+	}
+	return chat1.SyncChatRes{
+		InboxRes: iboxRes,
+	}, nil
 }
 
 type convByNewlyUpdated struct {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -101,9 +101,11 @@ type GlobalContext struct {
 	uchMu               *sync.Mutex          // protects the UserChangedHandler array
 	UserChangedHandlers []UserChangedHandler // a list of handlers that deal generically with userchanged events
 
-	InboxSource      chattypes.InboxSource        // source of remote inbox entries for chat
-	ConvSource       chattypes.ConversationSource // source of remote message bodies for chat
-	MessageDeliverer chattypes.MessageDeliverer   // background message delivery service
+	// Chat globals
+	InboxSource         chattypes.InboxSource         // source of remote inbox entries for chat
+	ConvSource          chattypes.ConversationSource  // source of remote message bodies for chat
+	MessageDeliverer    chattypes.MessageDeliverer    // background message delivery service
+	ServerCacheVersions chattypes.ServerCacheVersions // server side versions for chat caches
 
 	// Can be overloaded by tests to get an improvement in performance
 	NewTriplesec func(pw []byte, salt []byte) (Triplesec, error)

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -476,7 +476,7 @@ func (h *chatLocalHandler) makeFirstMessage(ctx context.Context, triple chat1.Co
 		}
 	}
 
-	sender := chat.NewBlockingSender(h.G(), h.boxer, h.store, h.remoteClient, h.getSecretUI)
+	sender := chat.NewBlockingSender(h.G(), h.boxer, h.store, h.remoteClient)
 	mbox, _, err := sender.Prepare(ctx, msg, nil)
 	return mbox, err
 }
@@ -740,7 +740,7 @@ func (h *chatLocalHandler) PostLocal(ctx context.Context, arg chat1.PostLocalArg
 	arg.Msg.ClientHeader.Sender = uid.ToBytes()
 	arg.Msg.ClientHeader.SenderDevice = gregor1.DeviceID(db)
 
-	sender := chat.NewBlockingSender(h.G(), h.boxer, h.store, h.remoteClient, h.getSecretUI)
+	sender := chat.NewBlockingSender(h.G(), h.boxer, h.store, h.remoteClient)
 
 	_, msgID, rl, err := sender.Send(ctx, arg.ConversationID, arg.Msg, 0)
 	if err != nil {
@@ -843,7 +843,7 @@ func (h *chatLocalHandler) PostLocalNonblock(ctx context.Context, arg chat1.Post
 	}
 
 	// Create non block sender
-	sender := chat.NewBlockingSender(h.G(), h.boxer, h.store, h.remoteClient, h.getSecretUI)
+	sender := chat.NewBlockingSender(h.G(), h.boxer, h.store, h.remoteClient)
 	nonblockSender := chat.NewNonblockingSender(h.G(), sender)
 
 	obid, _, rl, err := nonblockSender.Send(ctx, arg.ConversationID, arg.Msg, arg.ClientPrev)
@@ -1293,7 +1293,7 @@ func (h *chatLocalHandler) CancelPost(ctx context.Context, outboxID chat1.Outbox
 	}
 
 	uid := h.G().Env.GetUID()
-	outbox := storage.NewOutbox(h.G(), uid.ToBytes(), h.getSecretUI)
+	outbox := storage.NewOutbox(h.G(), uid.ToBytes())
 	if err = outbox.RemoveMessage(ctx, outboxID); err != nil {
 		return err
 	}
@@ -1309,7 +1309,7 @@ func (h *chatLocalHandler) RetryPost(ctx context.Context, outboxID chat1.OutboxI
 
 	// Mark as retry in the outbox
 	uid := h.G().Env.GetUID()
-	outbox := storage.NewOutbox(h.G(), uid.ToBytes(), h.getSecretUI)
+	outbox := storage.NewOutbox(h.G(), uid.ToBytes())
 	if err = outbox.RetryMessage(ctx, outboxID); err != nil {
 		return err
 	}

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -74,21 +74,19 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	h.tlfInfoSource = kbtest.NewTlfMock(c.world)
 	h.boxer = chat.NewBoxer(tc.G, h.tlfInfoSource)
 
-	f := func() libkb.SecretUI {
-		return &libkb.TestSecretUI{Passphrase: user.Passphrase}
-	}
-	storage := storage.New(tc.G, f)
-	tc.G.ConvSource = chat.NewHybridConversationSource(tc.G, h.boxer, storage,
-		func() chat1.RemoteInterface { return mockRemote },
-		func() libkb.SecretUI { return &libkb.TestSecretUI{} })
+	chatStorage := storage.New(tc.G)
+	tc.G.ConvSource = chat.NewHybridConversationSource(tc.G, h.boxer, chatStorage,
+		func() chat1.RemoteInterface { return mockRemote })
 	tc.G.InboxSource = chat.NewHybridInboxSource(tc.G,
 		func() chat1.RemoteInterface { return mockRemote },
-		f, h.tlfInfoSource)
+		h.tlfInfoSource)
+	tc.G.ServerCacheVersions = storage.NewServerVersions(tc.G)
+
 	h.setTestRemoteClient(mockRemote)
 	h.gh, _ = newGregorHandler(tc.G)
 
 	baseSender := chat.NewBlockingSender(tc.G, h.boxer, nil,
-		func() chat1.RemoteInterface { return mockRemote }, f)
+		func() chat1.RemoteInterface { return mockRemote })
 	tc.G.MessageDeliverer = chat.NewDeliverer(tc.G, baseSender)
 	tc.G.MessageDeliverer.Start(context.TODO(), user.User.GetUID().ToBytes())
 	tc.G.MessageDeliverer.Connected(context.TODO())
@@ -776,7 +774,7 @@ func TestGetOutbox(t *testing.T) {
 	u := users[0]
 	h := ctc.as(t, users[0]).h
 	tc := ctc.world.Tcs[ctc.as(t, users[0]).user().Username]
-	outbox := storage.NewOutbox(tc.G, users[0].User.GetUID().ToBytes(), h.getSecretUI)
+	outbox := storage.NewOutbox(tc.G, users[0].User.GetUID().ToBytes())
 
 	obr, err := outbox.PushMessage(context.TODO(), created.Id, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -250,10 +250,9 @@ func (d *Service) RunBackgroundOperations(uir *UIRouter) {
 
 func (d *Service) createMessageDeliverer() {
 	ri := d.chatRemoteClient
-	si := func() libkb.SecretUI { return chat.DelivererSecretUI{} }
 	tlf := chat.NewKBFSTLFInfoSource(d.G())
 
-	sender := chat.NewBlockingSender(d.G(), chat.NewBoxer(d.G(), tlf), d.attachmentstore, ri, si)
+	sender := chat.NewBlockingSender(d.G(), chat.NewBoxer(d.G(), tlf), d.attachmentstore, ri)
 	d.G().MessageDeliverer = chat.NewDeliverer(d.G(), sender)
 }
 
@@ -266,14 +265,15 @@ func (d *Service) startMessageDeliverer() {
 
 func (d *Service) createChatSources() {
 	ri := d.chatRemoteClient
-	si := func() libkb.SecretUI { return chat.DelivererSecretUI{} }
 	tlf := chat.NewKBFSTLFInfoSource(d.G())
 
 	boxer := chat.NewBoxer(d.G(), tlf)
-	d.G().InboxSource = chat.NewInboxSource(d.G(), d.G().Env.GetInboxSourceType(), ri, si, tlf)
+	d.G().InboxSource = chat.NewInboxSource(d.G(), d.G().Env.GetInboxSourceType(), ri, tlf)
 
 	d.G().ConvSource = chat.NewConversationSource(d.G(), d.G().Env.GetConvSourceType(),
-		boxer, storage.New(d.G(), si), ri, si)
+		boxer, storage.New(d.G()), ri)
+
+	d.G().ServerCacheVersions = storage.NewServerVersions(d.G())
 
 	// Add a tlfHandler into the user changed handler group so we can keep identify info
 	// fresh

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -158,14 +158,26 @@ protocol remote {
     array<Conversation> convs;
   } 
 
+  record ServerCacheVers {
+    int inboxVers;
+    int bodiesVers;
+  }
+
   variant SyncInboxRes switch (SyncInboxResType typ) {
     case CURRENT: void;
     case INCREMENTAL: SyncIncrementalRes;
     case CLEAR: void;
   }
 
-  // Sync down the inbox given a current version
+  // (DEPRECATED) Sync down the inbox given a current version
   SyncInboxRes syncInbox(InboxVers vers);
+
+  record SyncChatRes {
+    ServerCacheVers cacheVers;
+    SyncInboxRes inboxRes;
+  }
+
+  SyncChatRes syncChat(InboxVers vers);
 
   // tlfFinalize is an endpoint for kbfstlfd to notify Gregor that a TLF ID has been finalized.
   // Gregor keeps an internal record of these TLF IDs, so that it can always return the latest

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -637,6 +637,18 @@ export function remoteSetConversationStatusRpcPromise (request: $Exact<requestCo
   return new Promise((resolve, reject) => { remoteSetConversationStatusRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function remoteSyncChatRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {param: remoteSyncChatRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.remote.syncChat'})
+}
+
+export function remoteSyncChatRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {param: remoteSyncChatRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => remoteSyncChatRpc({...request, incomingCallMap, callback}))
+}
+
+export function remoteSyncChatRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {param: remoteSyncChatRpcParam}>): Promise<remoteSyncChatResult> {
+  return new Promise((resolve, reject) => { remoteSyncChatRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function remoteSyncInboxRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncInboxResult) => void} & {param: remoteSyncInboxRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.remote.syncInbox'})
 }
@@ -1447,6 +1459,11 @@ export type SealedData = {
   n: bytes,
 }
 
+export type ServerCacheVers = {
+  inboxVers: int,
+  bodiesVers: int,
+}
+
 export type SetConversationStatusLocalRes = {
   rateLimits?: ?Array<RateLimit>,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
@@ -1480,6 +1497,11 @@ export type SignatureInfo = {
   v: int,
   s: bytes,
   k: bytes,
+}
+
+export type SyncChatRes = {
+  cacheVers: ServerCacheVers,
+  inboxRes: SyncInboxRes,
 }
 
 export type SyncInboxRes =
@@ -1832,6 +1854,10 @@ export type remoteSetConversationStatusRpcParam = Exact<{
   status: ConversationStatus
 }>
 
+export type remoteSyncChatRpcParam = Exact<{
+  vers: InboxVers
+}>
+
 export type remoteSyncInboxRpcParam = Exact<{
   vers: InboxVers
 }>
@@ -1918,6 +1944,8 @@ type remoteS3SignResult = bytes
 
 type remoteSetConversationStatusResult = SetConversationStatusRes
 
+type remoteSyncChatResult = SyncChatRes
+
 type remoteSyncInboxResult = SyncInboxRes
 
 export type rpc =
@@ -1959,6 +1987,7 @@ export type rpc =
   | remotePublishSetConversationStatusRpc
   | remoteS3SignRpc
   | remoteSetConversationStatusRpc
+  | remoteSyncChatRpc
   | remoteSyncInboxRpc
   | remoteTlfFinalizeRpc
   | remoteTlfResolveRpc

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -327,6 +327,20 @@
       ]
     },
     {
+      "type": "record",
+      "name": "ServerCacheVers",
+      "fields": [
+        {
+          "type": "int",
+          "name": "inboxVers"
+        },
+        {
+          "type": "int",
+          "name": "bodiesVers"
+        }
+      ]
+    },
+    {
       "type": "variant",
       "name": "SyncInboxRes",
       "switch": {
@@ -354,6 +368,20 @@
             "def": false
           },
           "body": null
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "SyncChatRes",
+      "fields": [
+        {
+          "type": "ServerCacheVers",
+          "name": "cacheVers"
+        },
+        {
+          "type": "SyncInboxRes",
+          "name": "inboxRes"
         }
       ]
     }
@@ -550,6 +578,15 @@
         }
       ],
       "response": "SyncInboxRes"
+    },
+    "syncChat": {
+      "request": [
+        {
+          "name": "vers",
+          "type": "InboxVers"
+        }
+      ],
+      "response": "SyncChatRes"
     },
     "tlfFinalize": {
       "request": [

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -637,6 +637,18 @@ export function remoteSetConversationStatusRpcPromise (request: $Exact<requestCo
   return new Promise((resolve, reject) => { remoteSetConversationStatusRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
 }
 
+export function remoteSyncChatRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {param: remoteSyncChatRpcParam}>) {
+  engineRpcOutgoing({...request, method: 'chat.1.remote.syncChat'})
+}
+
+export function remoteSyncChatRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {param: remoteSyncChatRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => remoteSyncChatRpc({...request, incomingCallMap, callback}))
+}
+
+export function remoteSyncChatRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {param: remoteSyncChatRpcParam}>): Promise<remoteSyncChatResult> {
+  return new Promise((resolve, reject) => { remoteSyncChatRpc({...request, callback: (error, result) => { if (error) { reject(error) } else { resolve(result) } }}) })
+}
+
 export function remoteSyncInboxRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncInboxResult) => void} & {param: remoteSyncInboxRpcParam}>) {
   engineRpcOutgoing({...request, method: 'chat.1.remote.syncInbox'})
 }
@@ -1447,6 +1459,11 @@ export type SealedData = {
   n: bytes,
 }
 
+export type ServerCacheVers = {
+  inboxVers: int,
+  bodiesVers: int,
+}
+
 export type SetConversationStatusLocalRes = {
   rateLimits?: ?Array<RateLimit>,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
@@ -1480,6 +1497,11 @@ export type SignatureInfo = {
   v: int,
   s: bytes,
   k: bytes,
+}
+
+export type SyncChatRes = {
+  cacheVers: ServerCacheVers,
+  inboxRes: SyncInboxRes,
 }
 
 export type SyncInboxRes =
@@ -1832,6 +1854,10 @@ export type remoteSetConversationStatusRpcParam = Exact<{
   status: ConversationStatus
 }>
 
+export type remoteSyncChatRpcParam = Exact<{
+  vers: InboxVers
+}>
+
 export type remoteSyncInboxRpcParam = Exact<{
   vers: InboxVers
 }>
@@ -1918,6 +1944,8 @@ type remoteS3SignResult = bytes
 
 type remoteSetConversationStatusResult = SetConversationStatusRes
 
+type remoteSyncChatResult = SyncChatRes
+
 type remoteSyncInboxResult = SyncInboxRes
 
 export type rpc =
@@ -1959,6 +1987,7 @@ export type rpc =
   | remotePublishSetConversationStatusRpc
   | remoteS3SignRpc
   | remoteSetConversationStatusRpc
+  | remoteSyncChatRpc
   | remoteSyncInboxRpc
   | remoteTlfFinalizeRpc
   | remoteTlfResolveRpc


### PR DESCRIPTION
This patch does the following:

1.) Adds a new server version value for both the `storage_blockengine.go` and `inbox.go` caches. These versions are checked against the new `ServerCacheVersions` type whenever we read them off the disk (and we clear if we miss).
2.) Utilize the new `SyncChat` RPC on Gregor which does the same thing as `SyncInbox`, but also returns the server cache versions.
3.) Get rid of all the `SecretUI` function passing around, and just drop a default one in the `storage` package.
