### PR TITLE
Fix timestamp not appearing if previous message isn't timestampable

### DIFF
--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -151,9 +151,7 @@ function * _incomingMessage (action: Constants.IncomingMessage): SagaGenerator<a
         } else {
           // How long was it between the previous message and this one?
           if (conversationState && conversationState.messages !== null && conversationState.messages.size > 0) {
-            const prevMessage = conversationState.messages.get(conversationState.messages.size - 1)
-
-            const timestamp = Shared.maybeAddTimestamp(message, prevMessage)
+            const timestamp = Shared.maybeAddTimestamp(message, conversationState.messages, conversationState.messages.size - 1)
             if (timestamp !== null) {
               yield put(Creators.appendMessages(conversationIDKey, conversationIDKey === selectedConversationIDKey, [timestamp]))
             }
@@ -319,7 +317,7 @@ function * _loadMoreMessages (action: Constants.LoadMoreMessages): SagaGenerator
     let newMessages = []
     messages.forEach((message, idx) => {
       if (idx > 0) {
-        const timestamp = Shared.maybeAddTimestamp(messages[idx], messages[idx - 1])
+        const timestamp = Shared.maybeAddTimestamp(messages[idx], messages, idx - 1)
         if (timestamp !== null) {
           newMessages.push(timestamp)
         }

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -127,8 +127,7 @@ function * postMessage (action: Constants.PostMessage): SagaGenerator<any, any> 
     const conversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
     let messages = []
     if (conversationState && conversationState.messages !== null && conversationState.messages.size > 0) {
-      const prevMessage = conversationState.messages.get(conversationState.messages.size - 1)
-      const timestamp = Shared.maybeAddTimestamp(message, prevMessage)
+      const timestamp = Shared.maybeAddTimestamp(message, conversationState.messages, conversationState.messages.size - 1)
       if (timestamp !== null) {
         messages.push(timestamp)
       }

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -177,10 +177,7 @@ function _filterTimestampableMessage (message: Constants.Message): ?Timestampabl
 }
 
 function _isTimestampableMessage (message: Constants.Message): boolean {
-  if (message && message.timestamp && !['Timestamp', 'Deleted', 'Unhandled', 'InvisibleError', 'Edit'].includes(message.type)) {
-    return true
-  }
-  return false
+  return !!(message && message.timestamp && !['Timestamp', 'Deleted', 'Unhandled', 'InvisibleError', 'Edit'].includes(message.type))
 }
 
 function _previousTimestampableMessage (messages: Array<Constants.Message>, prevIndex: number): ?Constants.Message {

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -178,7 +178,7 @@ function _filterTimestampableMessage (message: Constants.Message): ?Timestampabl
 }
 
 function _isTimestampableMessage (message: Constants.Message): boolean {
-  return !!(message && message.timestamp && !['Timestamp', 'Deleted', 'Unhandled', 'InvisibleError', 'Edit'].includes(message.type))
+  return (!!message && !!message.timestamp && !['Timestamp', 'Deleted', 'Unhandled', 'InvisibleError', 'Edit'].includes(message.type))
 }
 
 function _previousTimestampableMessage (messages: Array<Constants.Message>, prevIndex: number): ?Constants.Message {

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -177,11 +177,13 @@ function _filterTimestampableMessage (message: Constants.Message): ?Timestampabl
 }
 
 function _isTimestampableMessage (message: Constants.Message): boolean {
-  if (message && message.timestamp && !['Timestamp', 'Deleted', 'Unhandled', 'InvisibleError', 'Edit'].includes(message.type)) return true
+  if (message && message.timestamp && !['Timestamp', 'Deleted', 'Unhandled', 'InvisibleError', 'Edit'].includes(message.type)) {
+    return true
+  }
   return false
 }
 
-function _previousMessage (messages: Array<Constants.Message>, prevIndex: number): ?Constants.Message {
+function _previousTimestampableMessage (messages: Array<Constants.Message>, prevIndex: number): ?Constants.Message {
   for (var i = prevIndex; i >= 0; i--) {
     const prevMessage = messages[i]
     if (_isTimestampableMessage(prevMessage)) return prevMessage
@@ -190,7 +192,7 @@ function _previousMessage (messages: Array<Constants.Message>, prevIndex: number
 }
 
 function maybeAddTimestamp (_message: Constants.Message, messages: Array<Constants.Message>, prevIndex: number): Constants.MaybeTimestamp {
-  const prevMessage = _previousMessage(messages, prevIndex)
+  const prevMessage = _previousTimestampableMessage(messages, prevIndex)
   const message = _filterTimestampableMessage(_message)
   if (!message || !prevMessage) return null
 

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -1,6 +1,7 @@
 // @flow
 import * as ChatTypes from '../../constants/types/flow-types-chat'
 import * as Constants from '../../constants/chat'
+import {findLast} from 'lodash'
 import {Map} from 'immutable'
 import {TlfKeysTLFIdentifyBehavior} from '../../constants/types/flow-types'
 import {call, put, select} from 'redux-saga/effects'
@@ -181,11 +182,7 @@ function _isTimestampableMessage (message: Constants.Message): boolean {
 }
 
 function _previousTimestampableMessage (messages: Array<Constants.Message>, prevIndex: number): ?Constants.Message {
-  for (var i = prevIndex; i >= 0; i--) {
-    const prevMessage = messages[i]
-    if (_isTimestampableMessage(prevMessage)) return prevMessage
-  }
-  return null
+  return findLast(messages, message => _isTimestampableMessage(message) ? message : null, prevIndex)
 }
 
 function maybeAddTimestamp (_message: Constants.Message, messages: Array<Constants.Message>, prevIndex: number): Constants.MaybeTimestamp {

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -314,7 +314,7 @@ export type State = Record<{
 
 export const maxAttachmentPreviewSize = 320
 
-export const howLongBetweenTimestampsMs = 1000 // * 60 * 15
+export const howLongBetweenTimestampsMs = 1000 * 60 * 15
 export const maxMessagesToLoadAtATime = 50
 
 export const nothingSelected = 'chat:noneSelected'

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -314,7 +314,7 @@ export type State = Record<{
 
 export const maxAttachmentPreviewSize = 320
 
-export const howLongBetweenTimestampsMs = 1000 * 60 * 15
+export const howLongBetweenTimestampsMs = 1000 // * 60 * 15
 export const maxMessagesToLoadAtATime = 50
 
 export const nothingSelected = 'chat:noneSelected'


### PR DESCRIPTION
The timestamp wouldn't appear if the previous message was not a timestampable message (like `InvisibleError`?). Changed to find the previous timestampable message and then test maybe timestamp on that.

I tested by setting `howLongBetweenTimestampsMs` to 0 and then making sure every message correctly had a timestamp in between it and the previous message.