### PR TITLE
hook up gregorHandler with Reachability CORE-4712

### DIFF
--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -83,7 +83,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	tc.G.ServerCacheVersions = storage.NewServerVersions(tc.G)
 
 	h.setTestRemoteClient(mockRemote)
-	h.gh, _ = newGregorHandler(tc.G)
+	h.gh = newGregorHandler(tc.G)
 
 	baseSender := chat.NewBlockingSender(tc.G, h.boxer, nil,
 		func() chat1.RemoteInterface { return mockRemote })

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1120,7 +1120,6 @@ func (g *gregorHandler) pingLoop() {
 
 			select {
 			case err = <-doneCh:
-				g.Debug(ctx, "ping loop: id %x ping", id)
 			case <-g.shutdownCh:
 				g.Debug(ctx, "ping loop: id: %x shutdown received", id)
 				shutdownCancel()

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -168,7 +168,7 @@ func (db *gregorLocalDb) Load(u gregor.UID) (res []byte, e error) {
 	return res, err
 }
 
-func newGregorHandler(g *libkb.GlobalContext) (*gregorHandler, error) {
+func newGregorHandler(g *libkb.GlobalContext) *gregorHandler {
 	gh := &gregorHandler{
 		Contextified:    libkb.NewContextified(g),
 		DebugLabeler:    utils.NewDebugLabeler(g, "PushHandler", false),
@@ -194,7 +194,7 @@ func newGregorHandler(g *libkb.GlobalContext) (*gregorHandler, error) {
 	// Start broadcast handler goroutine
 	go gh.broadcastMessageHandler()
 
-	return gh, nil
+	return gh
 }
 
 func (g *gregorHandler) resetGregorClient() (err error) {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -269,7 +269,7 @@ func (g *gregorHandler) SetPushStateFilter(f func(m gregor.Message) bool) {
 	g.pushStateFilter = f
 }
 
-func (g *gregorHandler) SetReachability(r *reachability) {
+func (g *gregorHandler) setReachability(r *reachability) {
 	g.reachability = r
 }
 

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -47,8 +47,7 @@ func TestGregorHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	var h *gregorHandler
-	h, err = newGregorHandler(tc.G)
-	require.NoError(t, err)
+	h = newGregorHandler(tc.G)
 	h.testingEvents = newTestingEvents()
 	require.Equal(t, "keybase service", h.HandlerName(), "wrong name")
 
@@ -182,8 +181,7 @@ func TestShowTrackerPopupMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	var h *gregorHandler
-	h, err = newGregorHandler(tc.G)
-	require.NoError(t, err)
+	h = newGregorHandler(tc.G)
 	h.testingEvents = newTestingEvents()
 
 	h.PushHandler(idhandler)
@@ -364,9 +362,7 @@ func setupSyncTests(t *testing.T, tc libkb.TestContext) (*gregorHandler, mockGre
 	uid := gregor1.UID(user.User.GetUID().ToBytes())
 
 	var h *gregorHandler
-	if h, err = newGregorHandler(tc.G); err != nil {
-		t.Fatal(err)
-	}
+	h = newGregorHandler(tc.G)
 	h.testingEvents = newTestingEvents()
 
 	server := newGregordMock(tc.G.Log)
@@ -497,9 +493,7 @@ func TestSyncSaveRestoreFresh(t *testing.T) {
 	}
 
 	// Create a new gregor handler, this will restore our saved state
-	if h, err = newGregorHandler(tc.G); err != nil {
-		t.Fatal(err)
-	}
+	h = newGregorHandler(tc.G)
 
 	// Sync from the server
 	replayedMessages, consumedMessages, err := h.serverSync(context.TODO(), server)
@@ -547,9 +541,7 @@ func TestSyncSaveRestoreNonFresh(t *testing.T) {
 	}
 
 	// Create a new gregor handler, this will restore our saved state
-	if h, err = newGregorHandler(tc.G); err != nil {
-		t.Fatal(err)
-	}
+	h = newGregorHandler(tc.G)
 
 	// Turn off fresh replay
 	h.freshReplay = false
@@ -777,9 +769,7 @@ func TestBroadcastRepeat(t *testing.T) {
 	}
 
 	var h *gregorHandler
-	if h, err = newGregorHandler(tc.G); err != nil {
-		t.Fatal(err)
-	}
+	h = newGregorHandler(tc.G)
 	h.testingEvents = newTestingEvents()
 
 	m, err := h.templateMessage()

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -315,12 +315,7 @@ func (d *Service) startupGregor() {
 		// Create gregorHandler instance first so any handlers can connect
 		// to it before we actually connect to gregor (either gregor is down
 		// or we aren't logged in)
-		var err error
-		if d.gregor, err = newGregorHandler(d.G()); err != nil {
-			d.G().Log.Warning("failed to create push service handler: %s", err)
-			return
-		}
-
+		d.gregor = newGregorHandler(d.G())
 		d.reachability = newReachability(d.G(), d.gregor)
 		d.gregor.SetReachability(d.reachability)
 		d.gregor.badger = d.badger

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -322,6 +322,7 @@ func (d *Service) startupGregor() {
 		}
 
 		d.reachability = newReachability(d.G(), d.gregor)
+		d.gregor.SetReachability(d.reachability)
 		d.gregor.badger = d.badger
 		d.G().GregorDismisser = d.gregor
 		d.G().GregorListener = d.gregor

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -317,7 +317,7 @@ func (d *Service) startupGregor() {
 		// or we aren't logged in)
 		d.gregor = newGregorHandler(d.G())
 		d.reachability = newReachability(d.G(), d.gregor)
-		d.gregor.SetReachability(d.reachability)
+		d.gregor.setReachability(d.reachability)
 		d.gregor.badger = d.badger
 		d.G().GregorDismisser = d.gregor
 		d.G().GregorListener = d.gregor

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -39,7 +39,6 @@ type Service struct {
 	gregor               *gregorHandler
 	rekeyMaster          *rekeyMaster
 	attachmentstore      *chat.AttachmentStore
-	messageDeliverer     *chat.Deliverer
 	badger               *badges.Badger
 	reachability         *reachability
 	backgroundIdentifier *BackgroundIdentifier
@@ -59,7 +58,6 @@ func NewService(g *libkb.GlobalContext, isDaemon bool) *Service {
 		rekeyMaster:     newRekeyMaster(g),
 		attachmentstore: chat.NewAttachmentStore(g.Log, g.Env.GetRuntimeDir()),
 		badger:          badges.NewBadger(g),
-		reachability:    newReachability(g),
 	}
 }
 
@@ -322,6 +320,8 @@ func (d *Service) startupGregor() {
 			d.G().Log.Warning("failed to create push service handler: %s", err)
 			return
 		}
+
+		d.reachability = newReachability(d.G(), d.gregor)
 		d.gregor.badger = d.badger
 		d.G().GregorDismisser = d.gregor
 		d.G().GregorListener = d.gregor
@@ -472,9 +472,7 @@ func (d *Service) OnLogout() (err error) {
 	}
 
 	log("shutting down message deliverer")
-	if d.messageDeliverer != nil {
-		d.messageDeliverer.Stop(context.Background())
-	}
+	d.G().MessageDeliverer.Stop(context.Background())
 
 	log("shutting down rekeyMaster")
 	d.rekeyMaster.Logout()


### PR DESCRIPTION
This patch does the following:

1.) Hooks up `reachability.go` with `gregor.go` so that they can help each other out. Specifically, we get the following two advantages:
  a.) `gregorHandler` now can try the `DialWithTimeout` when Electron detects a change in network state. This makes it more responsive to things like turning off Wi-Fi, or other sudden losses of connectivity. Additionally, it should help us avoid the annoying "can't assign requested address" error, since we will be more aggressive about terminating connections that are likely dead. In order to fully squash those errors, we will need to do something similar to this on the KBFS side.
  b.) Reachability no longer needs its own loop that checks the liveness of Gregor; instead it just gets called into by `gregorHandler` which is already tracking this.

2.) Clean up the `pingLoop` in `gregorHandler` so that it is more robust to the connection being shutdown.