### PR TITLE
Use emoji variant when displaying native emoji characters on mobile

### DIFF
--- a/shared/common-adapters/emoji.native.js
+++ b/shared/common-adapters/emoji.native.js
@@ -7,7 +7,8 @@ import type {Props} from './emoji'
 
 const EmojiWrapper = (props: Props) => {
   const emojiName = props.children ? props.children.join('') : ''
-  return <Text type='Body' style={{fontSize: props.size}}>{emojiIndexByName[emojiName]}</Text>
+  const emojiVariantSuffx = '\ufe0f'  // see http://mts.io/2015/04/21/unicode-symbol-render-text-emoji/
+  return <Text type='Body' style={{fontSize: props.size}}>{emojiIndexByName[emojiName] + emojiVariantSuffx}</Text>
 }
 
 export default EmojiWrapper


### PR DESCRIPTION
Fixes :bangbang: display on mobile.

:eyeglasses: @keybase/react-hackers 