### PR TITLE
Add DEBUGstore so we can inspect the store in devtools

### DIFF
--- a/shared/desktop/renderer/index.js
+++ b/shared/desktop/renderer/index.js
@@ -33,6 +33,7 @@ import {selector as unlockFoldersSelector} from '../../unlock-folders'
 import {setRouteDef} from '../../actions/route-tree'
 import {setupContextMenu} from '../app/menu-helper'
 import {setupSource} from '../../util/forward-logs'
+import flags from '../../util/feature-flags'
 import {updateDebugConfig} from '../../actions/dev'
 import {updateReloading} from '../../constants/dev'
 
@@ -40,7 +41,12 @@ let _store
 function setupStore () {
   if (!_store) {
     _store = configureStore()
+
+    if (flags.admin) {
+      window.DEBUGStore = _store
+    }
   }
+
   return _store
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

Same idea as `DEBUGengine` but this allows admins to inspect their store to better aid in debugging errors