### PR TITLE
slightly cleaner fix for error spam

### DIFF
--- a/go/auth/credential_authority.go
+++ b/go/auth/credential_authority.go
@@ -228,13 +228,9 @@ func (v *CredentialAuthority) runWithCancel(body func(ctx context.Context) error
 // on the UserKeyAPIer once per iteration.
 func (v *CredentialAuthority) pollLoop() {
 	for {
-		// pollOnce will block for pollWait amount of time if there are no events
-		// to receive from the server, so we only have to sleep if there is an error
-		if err := v.pollOnce(); err != nil {
-			if err == ErrShutdown {
-				return
-			}
-			time.Sleep(pollWait)
+		// We rely on pollOnce to not return right away, so we don't busy loop.
+		if v.pollOnce() == ErrShutdown {
+			break
 		}
 	}
 }

--- a/go/auth/credential_authority.go
+++ b/go/auth/credential_authority.go
@@ -119,7 +119,11 @@ type UserKeyAPIer interface {
 	GetUser(context.Context, keybase1.UID) (
 		un libkb.NormalizedUsername, sibkeys, subkeys []keybase1.KID, err error)
 	// PollForChanges returns the UIDs that have recently changed on the server
-	// side. It will be called in a poll loop.
+	// side. It will be called in a poll loop. This call should function as
+	// a *long poll*, meaning, it should not return unless there is a change
+	// to report, or a sufficient amount of time has passed. If an error occurred,
+	// then PollForChanges should delay before return, so we don't wind up
+	// busy-waiting.
 	PollForChanges(context.Context) ([]keybase1.UID, error)
 }
 


### PR DESCRIPTION
In lieu of #6330, this fix is slightly cleaner -- put the delay logic in to the UserKeysAPI logic.