### PR TITLE
Fix auto-invite codes on signup

### DIFF
--- a/shared/actions/signup.js
+++ b/shared/actions/signup.js
@@ -71,7 +71,6 @@ function requestAutoInvite (): TypedAsyncAction<CheckInviteCode | NavigateAppend
           dispatch(checkInviteCode(inviteCode))
           // For navigateAppend to work in nextPhase(), need the right path.
           dispatch(navigateTo([loginTab, 'signup']))
-          dispatch(nextPhase())
           inviteCode ? resolve() : reject(err)
         }
       },

--- a/shared/login/forms/intro.js
+++ b/shared/login/forms/intro.js
@@ -6,6 +6,7 @@ import {loginTab} from '../../constants/tabs'
 import {navigateTo} from '../../actions/route-tree'
 import {retryBootstrap} from '../../actions/config'
 import {setRevokedSelf, setDeletedSelf, setLoginFromRevokedDevice, login} from '../../actions/login'
+import {requestAutoInvite} from '../../actions/signup'
 
 import type {TypedState} from '../../constants/reducer'
 
@@ -36,7 +37,7 @@ export default connect(
       dispatch(setLoginFromRevokedDevice(''))
       dispatch(setRevokedSelf(''))
       dispatch(setDeletedSelf(''))
-      dispatch(navigateTo([loginTab, 'signup']))
+      dispatch(requestAutoInvite())
     },
     onLogin: () => {
       dispatch(setLoginFromRevokedDevice(''))


### PR DESCRIPTION
@keybase/react-hackers 

* There are two paths for going into the signup flow, via the intro screen and via relogin, and we were only performing the auto-invite-code request for one of them.

* Also remove an unnecessary call to "nextPhase()".