### PR TITLE
only send inbox stale message if need complete reload CORE-4807

### DIFF
--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -195,8 +195,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 			if pushErr != nil {
 				g.Debug(ctx, "chat activity: newMessage: push error, alerting")
 			}
-			kuid := keybase1.UID(m.UID().String())
-			g.G().NotifyRouter.HandleChatThreadsStale(context.Background(), kuid,
+			NewSyncer(g.G()).SendChatStaleNotifications(context.Background(), m.UID().Bytes(),
 				[]chat1.ConversationID{nm.ConvID})
 		}
 

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -115,8 +115,8 @@ func TestSyncerConnected(t *testing.T) {
 	require.NoError(t, syncer.Sync(context.TODO(), ri, uid))
 	select {
 	case <-list.inboxStale:
+		require.Fail(t, "should not receive inbox stale")
 	default:
-		require.Fail(t, "no inbox stale received")
 	}
 	select {
 	case cids := <-list.threadsStale:

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -92,7 +92,7 @@ func (h *KBFSHandler) notifyConversation(uid keybase1.UID, filename string, publ
 	}
 
 	h.G().Log.Debug("sending ChatThreadsStale notification (conversations: %d)", len(convIDs))
-	h.G().NotifyRouter.HandleChatThreadsStale(context.Background(), uid, convIDs)
+	chat.NewSyncer(h.G()).SendChatStaleNotifications(context.Background(), uid.ToBytes(), convIDs)
 }
 
 func (h *KBFSHandler) conversationIDs(uid keybase1.UID, tlf string, public bool) ([]chat1.ConversationID, error) {


### PR DESCRIPTION
It turns out that the frontend will load all the conversations that we pass up from the thread stale message. Because of this, we don't need to send the inbox stale message, since all of the conversations that have changed should get reloaded just from the thread message. 

Also, pump all these messages through `Syncer` in preparation for the next ticket which will attempt to batch them up.

cc @chrisnojima 