### PR TITLE
init kbfs in a goroutine so we dont get stuck

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -91,11 +91,10 @@ func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride
 	// client and watching JS logs. Disabling until we have a root cause / fix.
 	kbfsParams := libkbfs.DefaultInitParams(kbCtx)
 	// Avoid lots of background routines.
-	kbfsParams.Mode = libkbfs.InitMinimalString
-	kbfsConfig, err = libkbfs.Init(kbCtx, kbfsParams, serviceCn{}, func() {}, kbCtx.Log)
-	if err != nil {
-		return err
-	}
+	go func() {
+		kbfsParams.Mode = libkbfs.InitMinimalString
+		kbfsConfig, _ = libkbfs.Init(kbCtx, kbfsParams, serviceCn{}, func() {}, kbCtx.Log)
+	}()
 
 	return Reset()
 }


### PR DESCRIPTION
Code from @mmaxim 
Otherwise when we do bind init() it gets stuck doing all this work

@keybase/react-hackers 