### PR TITLE
move Syncer to G, and batch calls into send stale notifications CORE-4757

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -421,8 +421,6 @@ type HybridInboxSource struct {
 	libkb.Contextified
 	utils.DebugLabeler
 	*baseInboxSource
-
-	syncer *Syncer
 }
 
 func NewHybridInboxSource(g *libkb.GlobalContext,
@@ -433,7 +431,6 @@ func NewHybridInboxSource(g *libkb.GlobalContext,
 		Contextified:    libkb.NewContextified(g),
 		DebugLabeler:    utils.NewDebugLabeler(g, "HybridInboxSource", false),
 		baseInboxSource: newBaseInboxSource(g, getChatInterface, tlfInfoSource),
-		syncer:          NewSyncer(g),
 	}
 }
 
@@ -574,7 +571,7 @@ func (s *HybridInboxSource) handleInboxError(ctx context.Context, err storage.Er
 	if verr, ok := err.(storage.VersionMismatchError); ok {
 		s.Debug(ctx, "handleInboxError: version mismatch, syncing and sending stale notifications: %s",
 			verr.Error())
-		s.syncer.Sync(ctx, s.getChatInterface(), uid)
+		s.G().Syncer.Sync(ctx, s.getChatInterface(), uid)
 		return nil
 	}
 	return err

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -195,8 +195,8 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 			if pushErr != nil {
 				g.Debug(ctx, "chat activity: newMessage: push error, alerting")
 			}
-			NewSyncer(g.G()).SendChatStaleNotifications(context.Background(), m.UID().Bytes(),
-				[]chat1.ConversationID{nm.ConvID})
+			g.G().Syncer.SendChatStaleNotifications(context.Background(), m.UID().Bytes(),
+				[]chat1.ConversationID{nm.ConvID}, true)
 		}
 
 		if badger != nil && nm.UnreadUpdate != nil {

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -148,6 +148,7 @@ func setupTest(t *testing.T, numUsers int) (*kbtest.ChatMockWorld, chat1.RemoteI
 	tc.G.MessageDeliverer.(*Deliverer).SetClock(world.Fc)
 	tc.G.MessageDeliverer.Start(context.TODO(), u.User.GetUID().ToBytes())
 	tc.G.MessageDeliverer.Connected(context.TODO())
+	tc.G.Syncer = NewSyncer(tc.G)
 
 	return world, ri, sender, baseSender, &listener, tlf
 }

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -89,10 +89,12 @@ func (s *Syncer) sendNotificationLoop() {
 		case <-s.shutdownCh:
 			return
 		case uid := <-s.fullReloadCh:
+			s.notificationLock.Lock()
 			kuid := keybase1.UID(uid.String())
 			s.G().NotifyRouter.HandleChatInboxStale(context.Background(), kuid)
 			s.G().NotifyRouter.HandleChatThreadsStale(context.Background(), kuid, nil)
 			s.notificationQueue = make(map[string][]chat1.ConversationID)
+			s.notificationLock.Unlock()
 		case <-s.clock.After(s.sendDelay):
 			s.sendNotificationsOnce()
 		case <-s.flushCh:

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -1,8 +1,9 @@
 package chat
 
 import (
-	"context"
+	"encoding/hex"
 	"sync"
+	"time"
 
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/types"
@@ -11,6 +12,8 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
+	"golang.org/x/net/context"
 )
 
 type Syncer struct {
@@ -20,14 +23,83 @@ type Syncer struct {
 
 	isConnected bool
 	offlinables []types.Offlinable
+
+	notificationLock  sync.Mutex
+	clock             clockwork.Clock
+	sendDelay         time.Duration
+	shutdownCh        chan struct{}
+	fullReloadCh      chan gregor1.UID
+	flushCh           chan struct{}
+	notificationQueue map[string][]chat1.ConversationID
 }
 
 func NewSyncer(g *libkb.GlobalContext) *Syncer {
-	return &Syncer{
-		Contextified: libkb.NewContextified(g),
-		DebugLabeler: utils.NewDebugLabeler(g, "Syncer", false),
-		isConnected:  true,
+	s := &Syncer{
+		Contextified:      libkb.NewContextified(g),
+		DebugLabeler:      utils.NewDebugLabeler(g, "Syncer", false),
+		isConnected:       true,
+		clock:             clockwork.NewRealClock(),
+		shutdownCh:        make(chan struct{}),
+		fullReloadCh:      make(chan gregor1.UID),
+		flushCh:           make(chan struct{}),
+		notificationQueue: make(map[string][]chat1.ConversationID),
+		sendDelay:         time.Millisecond * 200,
 	}
+
+	go s.sendNotificationLoop()
+	return s
+}
+
+func (s *Syncer) SetClock(clock clockwork.Clock) {
+	s.clock = clock
+}
+
+func (s *Syncer) Shutdown() {
+	s.Debug(context.Background(), "shutting down")
+	close(s.shutdownCh)
+}
+
+func (s *Syncer) dedupConvIDs(convIDs []chat1.ConversationID) (res []chat1.ConversationID) {
+	m := make(map[string]bool)
+	for _, convID := range convIDs {
+		m[convID.String()] = true
+	}
+	for hexConvID := range m {
+		convID, _ := hex.DecodeString(hexConvID)
+		res = append(res, convID)
+	}
+	return res
+}
+
+func (s *Syncer) sendNotificationsOnce() {
+	s.notificationLock.Lock()
+	defer s.notificationLock.Unlock()
+	for uid, convIDs := range s.notificationQueue {
+		convIDs = s.dedupConvIDs(convIDs)
+		s.Debug(context.Background(), "flushing notifications: uid: %s len: %d", uid, len(convIDs))
+		s.G().NotifyRouter.HandleChatThreadsStale(context.Background(), keybase1.UID(uid), convIDs)
+	}
+	s.notificationQueue = make(map[string][]chat1.ConversationID)
+}
+
+func (s *Syncer) sendNotificationLoop() {
+	s.Debug(context.Background(), "starting notification loop")
+	for {
+		select {
+		case <-s.shutdownCh:
+			return
+		case uid := <-s.fullReloadCh:
+			kuid := keybase1.UID(uid.String())
+			s.G().NotifyRouter.HandleChatInboxStale(context.Background(), kuid)
+			s.G().NotifyRouter.HandleChatThreadsStale(context.Background(), kuid, nil)
+			s.notificationQueue = make(map[string][]chat1.ConversationID)
+		case <-s.clock.After(s.sendDelay):
+			s.sendNotificationsOnce()
+		case <-s.flushCh:
+			s.sendNotificationsOnce()
+		}
+	}
+
 }
 
 func (s *Syncer) getConvIDs(convs []chat1.Conversation) (res []chat1.ConversationID) {
@@ -38,15 +110,19 @@ func (s *Syncer) getConvIDs(convs []chat1.Conversation) (res []chat1.Conversatio
 }
 
 func (s *Syncer) SendChatStaleNotifications(ctx context.Context, uid gregor1.UID,
-	convIDs []chat1.ConversationID) {
-
-	kuid := keybase1.UID(uid.String())
+	convIDs []chat1.ConversationID, immediate bool) {
 	if len(convIDs) == 0 {
 		s.Debug(ctx, "sending inbox stale message")
-		s.G().NotifyRouter.HandleChatInboxStale(context.Background(), kuid)
+		s.fullReloadCh <- uid
+	} else {
+		s.Debug(ctx, "sending threads stale message: len: %d", len(convIDs))
+		s.notificationLock.Lock()
+		s.notificationQueue[uid.String()] = append(s.notificationQueue[uid.String()], convIDs...)
+		s.notificationLock.Unlock()
+		if immediate {
+			s.flushCh <- struct{}{}
+		}
 	}
-	s.Debug(ctx, "sending threads stale message: len: %d", len(convIDs))
-	s.G().NotifyRouter.HandleChatThreadsStale(context.Background(), kuid, convIDs)
 }
 
 func (s *Syncer) isServerInboxClear(ctx context.Context, inbox *storage.Inbox, srvVers int) bool {
@@ -146,7 +222,7 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 			s.Debug(ctx, "Sync: failed to clear inbox: %s", err.Error())
 		}
 		// Send notifications for a full clear
-		s.SendChatStaleNotifications(ctx, uid, nil)
+		s.SendChatStaleNotifications(ctx, uid, nil, true)
 	case chat1.SyncInboxResType_CURRENT:
 		s.Debug(ctx, "Sync: version is current, standing pat: %v", vers)
 	case chat1.SyncInboxResType_INCREMENTAL:
@@ -158,10 +234,10 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 			s.Debug(ctx, "Sync: failed to sync conversations to inbox: %s", err.Error())
 
 			// Send notifications for a full clear
-			s.SendChatStaleNotifications(ctx, uid, nil)
+			s.SendChatStaleNotifications(ctx, uid, nil, true)
 		} else {
 			// Send notifications for a successful partial sync
-			s.SendChatStaleNotifications(ctx, uid, s.getConvIDs(incr.Convs))
+			s.SendChatStaleNotifications(ctx, uid, s.getConvIDs(incr.Convs), true)
 		}
 	}
 

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -43,7 +43,7 @@ func NewSyncer(g *libkb.GlobalContext) *Syncer {
 		fullReloadCh:      make(chan gregor1.UID),
 		flushCh:           make(chan struct{}),
 		notificationQueue: make(map[string][]chat1.ConversationID),
-		sendDelay:         time.Millisecond * 200,
+		sendDelay:         time.Millisecond * 1000,
 	}
 
 	go s.sendNotificationLoop()

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -93,7 +93,7 @@ func (s *Syncer) sendNotificationLoop() {
 			kuid := keybase1.UID(uid.String())
 			s.G().NotifyRouter.HandleChatInboxStale(context.Background(), kuid)
 			s.G().NotifyRouter.HandleChatThreadsStale(context.Background(), kuid, nil)
-			s.notificationQueue = make(map[string][]chat1.ConversationID)
+			s.notificationQueue[uid.String()] = nil
 			s.notificationLock.Unlock()
 		case <-s.clock.After(s.sendDelay):
 			s.sendNotificationsOnce()

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"testing"
+	"time"
 
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/kbtest"
@@ -83,13 +84,13 @@ func TestSyncerConnected(t *testing.T) {
 	require.NoError(t, syncer.Sync(context.TODO(), ri, uid))
 	select {
 	case <-list.inboxStale:
-	default:
+	case <-time.After(20 * time.Second):
 		require.Fail(t, "no inbox stale received")
 	}
 	select {
 	case cids := <-list.threadsStale:
 		require.Zero(t, len(cids))
-	default:
+	case <-time.After(20 * time.Second):
 		require.Fail(t, "no threads stale received")
 	}
 	_, _, err := ibox.ReadAll(context.TODO())
@@ -122,7 +123,7 @@ func TestSyncerConnected(t *testing.T) {
 	case cids := <-list.threadsStale:
 		require.Equal(t, 1, len(cids))
 		require.Equal(t, convs[1].GetConvID(), cids[0])
-	default:
+	case <-time.After(20 * time.Second):
 		require.Fail(t, "no threads stale received")
 	}
 	vers, iconvs, err := ibox.ReadAll(context.TODO())
@@ -151,13 +152,13 @@ func TestSyncerConnected(t *testing.T) {
 	require.NoError(t, syncer.Sync(context.TODO(), ri, uid))
 	select {
 	case <-list.inboxStale:
-	default:
+	case <-time.After(20 * time.Second):
 		require.Fail(t, "no inbox stale received")
 	}
 	select {
 	case cids := <-list.threadsStale:
 		require.Zero(t, len(cids))
-	default:
+	case <-time.After(20 * time.Second):
 		require.Fail(t, "no threads stale received")
 	}
 	_, _, err = ibox.ReadAll(context.TODO())

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -82,3 +82,13 @@ type ServerCacheVersions interface {
 	MatchInbox(ctx context.Context, vers int) (int, error)
 	Fetch(ctx context.Context) (chat1.ServerCacheVers, error)
 }
+
+type Syncer interface {
+	Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID) error
+	Disconnected(ctx context.Context)
+	Sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID) error
+	RegisterOfflinable(offlinable Offlinable)
+	SendChatStaleNotifications(ctx context.Context, uid gregor1.UID, convIDs []chat1.ConversationID,
+		immediate bool)
+	Shutdown()
+}

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -106,6 +106,7 @@ type GlobalContext struct {
 	ConvSource          chattypes.ConversationSource  // source of remote message bodies for chat
 	MessageDeliverer    chattypes.MessageDeliverer    // background message delivery service
 	ServerCacheVersions chattypes.ServerCacheVersions // server side versions for chat caches
+	Syncer              chattypes.Syncer              // keeps various parts of chat system in sync
 
 	// Can be overloaded by tests to get an improvement in performance
 	NewTriplesec func(pw []byte, salt []byte) (Triplesec, error)
@@ -483,6 +484,9 @@ func (g *GlobalContext) Shutdown() error {
 		}
 		if g.MessageDeliverer != nil {
 			g.MessageDeliverer.Stop(context.Background())
+		}
+		if g.Syncer != nil {
+			g.Syncer.Shutdown()
 		}
 
 		for _, hook := range g.ShutdownHooks {

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -81,6 +81,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 		func() chat1.RemoteInterface { return mockRemote },
 		h.tlfInfoSource)
 	tc.G.ServerCacheVersions = storage.NewServerVersions(tc.G)
+	tc.G.Syncer = chat.NewSyncer(tc.G)
 
 	h.setTestRemoteClient(mockRemote)
 	h.gh = newGregorHandler(tc.G)

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -562,8 +562,7 @@ func (g *gregorHandler) OnDisconnected(ctx context.Context, status rpc.Disconnec
 	g.Debug(context.Background(), "disconnected: %v", status)
 
 	// Alert chat syncer that we are now disconnected
-<<<<<<< HEAD
-	g.chatSync.Disconnected(ctx)
+	g.G().Syncer.Disconnected(ctx)
 
 	// Call out to reachability module if we have one
 	if g.reachability != nil {
@@ -571,9 +570,6 @@ func (g *gregorHandler) OnDisconnected(ctx context.Context, status rpc.Disconnec
 			Reachable: keybase1.Reachable_NO,
 		})
 	}
-=======
-	g.G().Syncer.Disconnected(ctx)
->>>>>>> wip
 }
 
 func (g *gregorHandler) OnDoCommandError(err error, nextTime time.Duration) {

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -92,7 +92,7 @@ func (h *KBFSHandler) notifyConversation(uid keybase1.UID, filename string, publ
 	}
 
 	h.G().Log.Debug("sending ChatThreadsStale notification (conversations: %d)", len(convIDs))
-	chat.NewSyncer(h.G()).SendChatStaleNotifications(context.Background(), uid.ToBytes(), convIDs)
+	h.G().Syncer.SendChatStaleNotifications(context.Background(), uid.ToBytes(), convIDs, false)
 }
 
 func (h *KBFSHandler) conversationIDs(uid keybase1.UID, tlf string, public bool) ([]chat1.ConversationID, error) {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -252,6 +252,8 @@ func (d *Service) createMessageDeliverer() {
 
 	sender := chat.NewBlockingSender(d.G(), chat.NewBoxer(d.G(), tlf), d.attachmentstore, ri)
 	d.G().MessageDeliverer = chat.NewDeliverer(d.G(), sender)
+
+	d.G().Syncer.RegisterOfflinable(d.G().MessageDeliverer)
 }
 
 func (d *Service) startMessageDeliverer() {
@@ -275,7 +277,6 @@ func (d *Service) createChatSources() {
 	// Set up Offlinables on Syncer
 	d.G().Syncer.RegisterOfflinable(d.G().InboxSource)
 	d.G().Syncer.RegisterOfflinable(d.G().ConvSource)
-	d.G().Syncer.RegisterOfflinable(d.G().MessageDeliverer)
 
 	// Add a tlfHandler into the user changed handler group so we can keep identify info
 	// fresh

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -267,11 +267,15 @@ func (d *Service) createChatSources() {
 
 	boxer := chat.NewBoxer(d.G(), tlf)
 	d.G().InboxSource = chat.NewInboxSource(d.G(), d.G().Env.GetInboxSourceType(), ri, tlf)
-
 	d.G().ConvSource = chat.NewConversationSource(d.G(), d.G().Env.GetConvSourceType(),
 		boxer, storage.New(d.G()), ri)
-
 	d.G().ServerCacheVersions = storage.NewServerVersions(d.G())
+	d.G().Syncer = chat.NewSyncer(d.G())
+
+	// Set up Offlinables on Syncer
+	d.G().Syncer.RegisterOfflinable(d.G().InboxSource)
+	d.G().Syncer.RegisterOfflinable(d.G().ConvSource)
+	d.G().Syncer.RegisterOfflinable(d.G().MessageDeliverer)
 
 	// Add a tlfHandler into the user changed handler group so we can keep identify info
 	// fresh


### PR DESCRIPTION
This patch does the following:

1.) Moves `chat.Syncer` to `G`.
2.) Add a queue for sending the notifications on `NotifyRouter` on a per user basis. We send when either a timer comes up, or when an explicit flush is requested.  There is also an option to the send function to send immediately, in which the aforementioned flush is triggered.
3.) Fix `Syncer` test to not flake if things are broken.

cc @chrisnojima 