### PR TITLE
Allow mobile to restart

### DIFF
--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -338,6 +338,7 @@ export type ResponseType = {
 
 let engine
 const makeEngine = () => {
+  debugger
   if (__DEV__ && engine) {
     console.warn('makeEngine called multiple times')
   }

--- a/shared/engine/index.js
+++ b/shared/engine/index.js
@@ -338,7 +338,6 @@ export type ResponseType = {
 
 let engine
 const makeEngine = () => {
-  debugger
   if (__DEV__ && engine) {
     console.warn('makeEngine called multiple times')
   }

--- a/shared/index.android.js
+++ b/shared/index.android.js
@@ -1,12 +1,8 @@
 // @flow
 // React-native tooling assumes this file is here, so we just require our real entry point
-
 import 'core-js/es6/object'  // required for babel-plugin-transform-builtin-extend in RN Android
 import 'core-js/es6/array'  // required for emoji-mart in RN Android
 import 'core-js/es6/string'  // required for emoji-mart in RN Android
+import {load} from './index.native'
 
-require('./index.native')
-
-module.hot && module.hot.accept(() => {
-  console.log('accepted update in entry index.android.js')
-})
+load()

--- a/shared/index.ios.js
+++ b/shared/index.ios.js
@@ -1,3 +1,5 @@
 // @flow
 // React-native tooling assumes this file is here, so we just require our real entry point
-require('./index.native')
+import {load} from './index.native'
+
+load()

--- a/shared/index.native.js
+++ b/shared/index.native.js
@@ -15,10 +15,7 @@ import routeDefs from './routes'
 import {setRouteDef} from './actions/route-tree'
 import {setupSource} from './util/forward-logs'
 
-debugger
-
 module.hot && module.hot.accept(() => {
-debugger
   console.log('accepted update in shared/index.native')
   if (global.store) {
     // We use global.devStore because module scope variables seem to be cleared
@@ -33,7 +30,6 @@ class Keybase extends Component {
 
   constructor (props: any) {
     super(props)
-debugger
 
     if (!global.keybaseLoaded) {
       global.keybaseLoaded = true
@@ -68,7 +64,6 @@ debugger
 }
 
 function load () {
-  debugger
   AppRegistry.registerComponent('Keybase', () => Keybase)
 }
 

--- a/shared/index.native.js
+++ b/shared/index.native.js
@@ -1,63 +1,51 @@
 // @flow
 import 'core-js/es6/reflect'  // required for babel-plugin-transform-builtin-extend in RN iOS and Android
 import './globals.native'
+
 import DumbSheet from './dev/dumb-sheet'
 import DumbChatOnly from './dev/chat-only.native'
 import Main from './main'
 import React, {Component} from 'react'
 import configureStore from './store/configure-store'
-import {AppRegistry, NativeAppEventEmitter, AsyncStorage} from 'react-native'
+import {AppRegistry} from 'react-native'
 import {Provider} from 'react-redux'
 import {makeEngine} from './engine'
-import {serializeRestore, serializeSave, timeTravel, timeTravelForward, timeTravelBack} from './constants/dev'
 import {setup as setupLocalDebug, dumbSheetOnly, dumbChatOnly} from './local-debug'
-import {stateKey} from './constants/reducer'
 import routeDefs from './routes'
 import {setRouteDef} from './actions/route-tree'
 import {setupSource} from './util/forward-logs'
 
+debugger
+
 module.hot && module.hot.accept(() => {
+debugger
   console.log('accepted update in shared/index.native')
-  if (global.devStore) {
+  if (global.store) {
     // We use global.devStore because module scope variables seem to be cleared
     // out after a hot reload. Wacky.
     console.log('updating route defs due to hot reload')
-    global.devStore.dispatch(setRouteDef(require('./routes').default))
+    global.store.dispatch(setRouteDef(require('./routes').default))
   }
 })
 
 class Keybase extends Component {
   store: any;
-  subscriptions: Array<{remove: () => void}>
-  componentWillMount () {
-    setupSource()
-    this.store = configureStore()
-    setupLocalDebug(this.store)
-    this.store.dispatch(setRouteDef(routeDefs))
-    makeEngine()
-    this.subscriptions = []
-    if (__DEV__) {
-      global.devStore = this.store
-      AsyncStorage.getItem(stateKey, (err, stateJSON) => {
-        if (err != null) {
-          console.warn('Error in reading state:', err)
-        }
-        if (stateJSON != null) {
-          this.store.dispatch({type: serializeRestore, payload: stateJSON})
-        }
-      })
 
-      this.subscriptions = [
-        NativeAppEventEmitter.addListener('backInTime', () => this.store.dispatch({type: timeTravel, payload: {direction: timeTravelBack}})),
-        NativeAppEventEmitter.addListener('forwardInTime', () => this.store.dispatch({type: timeTravel, payload: {direction: timeTravelForward}})),
-        NativeAppEventEmitter.addListener('saveState', () => this.store.dispatch({type: serializeSave})),
-        NativeAppEventEmitter.addListener('clearState', () => AsyncStorage.removeItem(stateKey)),
-      ]
+  constructor (props: any) {
+    super(props)
+debugger
+
+    if (!global.keybaseLoaded) {
+      global.keybaseLoaded = true
+      setupSource()
+      this.store = configureStore()
+      global.store = this.store
+      setupLocalDebug(this.store)
+      this.store.dispatch(setRouteDef(routeDefs))
+      makeEngine()
+    } else {
+      this.store = global.store
     }
-  }
-
-  componentWillUnmount () {
-    this.subscriptions.forEach(s => s.remove())
   }
 
   render () {
@@ -79,4 +67,11 @@ class Keybase extends Component {
   }
 }
 
-AppRegistry.registerComponent('Keybase', () => Keybase)
+function load () {
+  debugger
+  AppRegistry.registerComponent('Keybase', () => Keybase)
+}
+
+export {
+  load,
+}

--- a/shared/main.android.js
+++ b/shared/main.android.js
@@ -21,13 +21,16 @@ class Main extends Component {
   constructor (props) {
     super(props)
 
-    initAvatarLookup(getUserImageMap)
-    initAvatarLoad(loadUserImageMap)
-    this.props.bootstrap()
-    this.props.listenForNotifications()
+    if (!global.mainLoaded) {
+      global.mainLoaded = true
+      initAvatarLookup(getUserImageMap)
+      initAvatarLoad(loadUserImageMap)
+      this.props.bootstrap()
+      this.props.listenForNotifications()
 
-    // Introduce ourselves to the service
-    hello(0, 'Android app', [], '0.0.0', true) // TODO real version
+      // Introduce ourselves to the service
+      hello(0, 'Android app', [], '0.0.0', true) // TODO real version
+    }
   }
 
   componentWillMount () {

--- a/shared/main.ios.js
+++ b/shared/main.ios.js
@@ -20,13 +20,16 @@ class Main extends Component {
   constructor (props) {
     super(props)
 
-    initAvatarLookup(getUserImageMap)
-    initAvatarLoad(loadUserImageMap)
-    this.props.bootstrap()
-    this.props.listenForNotifications()
+    if (!global.mainLoaded) {
+      global.mainLoaded = true
+      initAvatarLookup(getUserImageMap)
+      initAvatarLoad(loadUserImageMap)
+      this.props.bootstrap()
+      this.props.listenForNotifications()
 
-    // Introduce ourselves to the service
-    hello(0, 'iOS app', [], '0.0.0', true) // TODO real version
+      // Introduce ourselves to the service
+      hello(0, 'iOS app', [], '0.0.0', true) // TODO real version
+    }
   }
 
   render () {

--- a/shared/push/push.native.js
+++ b/shared/push/push.native.js
@@ -17,7 +17,11 @@ class Push extends Component<void, Props, void> {
       console.log('Skipping push config due to simulator')
       return
     }
-    this.props.configurePush()
+
+    if (!global.pushLoaded) {
+      global.pushLoaded = true
+      this.props.configurePush()
+    }
   }
 
   render () {

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
@@ -24,7 +24,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
 
     private static final String NAME = "KeybaseEngine";
     private static final String RPC_EVENT_NAME = "RPC";
-    private final ExecutorService executor;
+    private ExecutorService executor;
 
     private class ReadFromKBLib implements Runnable {
         private final ReactApplicationContext reactContext;
@@ -56,12 +56,14 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
     public KeybaseEngine(final ReactApplicationContext reactContext) {
         super(reactContext);
 
-        executor = Executors.newSingleThreadExecutor();
-        executor.execute(new ReadFromKBLib(reactContext));
 
         reactContext.addLifecycleEventListener(new LifecycleEventListener() {
             @Override
             public void onHostResume() {
+                if (executor == null) {
+                    executor = Executors.newSingleThreadExecutor();
+                    executor.execute(new ReadFromKBLib(reactContext));
+                }
             }
 
             @Override
@@ -80,6 +82,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
             executor.shutdownNow();
             reset();
             executor.awaitTermination(30, TimeUnit.SECONDS);
+            executor = null;
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
This fixes issues on iOS and android where you could get into a state where the app wouldn't come back up correctly

- [x] On Android if you background the app and start up again the daemon would be dead and never restarted
- [x] On iOS if you turn on Touchables in inspector it'd remount the root and you'd get duplicate makeEngine errors and state would be bad

Now 
1. On Android if you resume it'll restart the daemon engine
1. On both we bookkeep some startup things and don't re-initialize them