### PR TITLE
Skip empty icon paths

### DIFF
--- a/go/tools/winresource/main.go
+++ b/go/tools/winresource/main.go
@@ -76,8 +76,10 @@ func kbWriteSyso(vi *goversioninfo.VersionInfo, filename string, arch string, ic
 	}
 	// if extra icons were passed in
 	for _, i := range icons {
-		if err := addIcon(coff, i, newID); err != nil {
-			return err
+		if i != "" {
+			if err := addIcon(coff, i, newID); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Generating the resources for runquiet.exe wasn't working because the winresource utility was failing if the new kbfsicon wasn't explicitly specified, so it was using the old resource, which still had the dog icon.