### PR TITLE
kbnm: Fix chat messages, dev install script, whitelist published extension

### DIFF
--- a/go/kbnm/handler.go
+++ b/go/kbnm/handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"io"
 	"os/exec"
 )
 
@@ -24,8 +25,21 @@ func handleChat(req *Request) error {
 	}
 
 	// FIXME: Get the absolute path without a filled PATH var somehow?
-	cmd := exec.Command("/usr/local/bin/keybase", "chat", "send", "--private", req.To, req.Body)
+	cmd := exec.Command("/usr/local/bin/keybase", "chat", "send", "--private", req.To)
 
-	// TODO: Check/convert status code more precisely?
+	// Write message body over STDIN to avoid running up against bugs with
+	// super long messages.
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		io.WriteString(stdin, req.Body)
+		stdin.Close()
+	}()
+
+	// TODO: Check/convert status code more precisely? Maybe return stdout as
+	// part of the error if there is one?
 	return cmd.Run()
 }

--- a/go/kbnm/handler.go
+++ b/go/kbnm/handler.go
@@ -34,12 +34,15 @@ func handleChat(req *Request) error {
 		return err
 	}
 
-	go func() {
-		io.WriteString(stdin, req.Body)
+	if err := cmd.Start(); err != nil {
 		stdin.Close()
-	}()
+		return err
+	}
+
+	io.WriteString(stdin, req.Body)
+	stdin.Close()
 
 	// TODO: Check/convert status code more precisely? Maybe return stdout as
 	// part of the error if there is one?
-	return cmd.Run()
+	return cmd.Wait()
 }

--- a/go/kbnm/host_json.template
+++ b/go/kbnm/host_json.template
@@ -4,6 +4,7 @@
   "path": "@@HOST_PATH@@",
   "type": "stdio",
   "allowed_origins": [
-    "chrome-extension://kockbbfoibcdfibclaojljblnhpnjndg/"
+    "chrome-extension://kockbbfoibcdfibclaojljblnhpnjndg/",
+    "chrome-extension://gnjkbjlgkpiaehpibpdefaieklbfljjm/"
   ]
 }

--- a/go/kbnm/install_host
+++ b/go/kbnm/install_host
@@ -8,6 +8,14 @@
 #
 # It can be run multiple times. The whitelist will be overwritten each time.
 
+realpath() {
+  if [[ $1 = /* ]]; then
+    echo "$1"
+  else
+    echo "$PWD/${1#./}"
+  fi
+}
+
 detect() {
   # Find where the NativeMessagingHosts whitelist lives for this platform.
   whoami="$(whoami)"
@@ -32,9 +40,9 @@ install() {
   # Install the whitelist.
   declare target="$1"
 
-  local target_dir="$(dirname target)"
+  local target_dir="$(dirname "$target")"
   if [[ ! -d "$target_dir" ]]; then
-    mkdir -p "target_dir"
+    mkdir -p "$target_dir"
   fi
 
   local here="$(dirname $(realpath "$BASH_SOURCE"))"
@@ -47,7 +55,9 @@ install() {
 
   chmod +r "$target"
 
-  echo "Success: Installed Chrome NativeMessaging whitelist: "$host_path" for $host_name"
+  cat "$target"
+
+  echo "Success."
 }
 
 uninstall() {

--- a/go/kbnm/install_host
+++ b/go/kbnm/install_host
@@ -46,7 +46,17 @@ install() {
   fi
 
   local here="$(dirname $(realpath "$BASH_SOURCE"))"
-  local host_path="$(which kbnm || echo "$here/kbnm")"
+  local host_path="$(which "kbnm" || echo "$here/kbnm")"
+
+  if [[ ! -x "$host_path" ]]; then
+    # Is it in GOPATH, but not PATH?
+    host_path="$GOPATH/bin/kbnm"
+  fi
+
+  if [[ ! -x "$host_path" ]]; then
+    echo "failed to find kbnm executable, make sure it's in your \$PATH."
+    exit 2
+  fi
 
   echo "Writing: $target"
   cat "$here/host_json.template" \


### PR DESCRIPTION
Before, kbnm would exec to `keybase chat send $NAME $MSG` all in the commandline, which of course would explode when $MSG was sufficiently long. This change sends the $MSG over stdin.

Also, it fixes a few bugs in the dev install script, such as a builtin `realpath` (not available on osx) and looking for `kbnm` under `$GOPATH/bin`. (Coyne/Cecile ran into these issues last week.)

Finally, it also whitelists the pubkey id of the extension in our private Chrome store listing, for testing.