### PR TITLE
Add tlf pseudonym interface

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -141,14 +141,18 @@ func (api *BaseAPIEngine) PrepareGet(url1 url.URL, arg APIArg) (*http.Request, e
 	return http.NewRequest("GET", ruri, nil)
 }
 
-func (api *BaseAPIEngine) PreparePost(url1 url.URL, arg APIArg, sendJSON bool) (*http.Request, error) {
+func (api *BaseAPIEngine) PreparePost(url1 url.URL, arg APIArg) (*http.Request, error) {
 	ruri := url1.String()
 	var body io.Reader
 
-	if sendJSON {
-		if len(arg.getHTTPArgs()) > 0 {
-			panic("PreparePost: sending JSON, but http args exist and they will be ignored. Fix your APIArg.")
-		}
+	useHTTPArgs := len(arg.getHTTPArgs()) > 0
+	useJSON := len(arg.JSONPayload) > 0
+
+	if useHTTPArgs && useJSON {
+		panic("PreparePost: Malformed APIArg: Both HTTP args and JSONPayload set on request.")
+	}
+
+	if useJSON {
 		jsonString, err := json.Marshal(arg.JSONPayload)
 		if err != nil {
 			return nil, err
@@ -164,7 +168,7 @@ func (api *BaseAPIEngine) PreparePost(url1 url.URL, arg APIArg, sendJSON bool) (
 	}
 
 	var typ string
-	if sendJSON {
+	if useJSON {
 		typ = "application/json"
 	} else {
 		typ = "application/x-www-form-urlencoded; charset=utf-8"
@@ -604,28 +608,25 @@ func (a *InternalAPIEngine) GetDecode(arg APIArg, v APIResponseWrapper) error {
 
 func (a *InternalAPIEngine) Post(arg APIArg) (*APIRes, error) {
 	url1 := a.getURL(arg)
-	req, err := a.PreparePost(url1, arg, false)
+	req, err := a.PreparePost(url1, arg)
 	if err != nil {
 		return nil, err
 	}
 	return a.DoRequest(arg, req)
 }
 
+// PostJSON does _not_ actually enforce the use of JSON.
+// That is now determined by APIArg's fields.
 func (a *InternalAPIEngine) PostJSON(arg APIArg) (*APIRes, error) {
-	url1 := a.getURL(arg)
-	req, err := a.PreparePost(url1, arg, true)
-	if err != nil {
-		return nil, err
-	}
-	return a.DoRequest(arg, req)
+	return a.Post(arg)
 }
 
 // postResp performs a POST request and returns the http response.
 // The returned response, if non-nil, should have
 // DiscardAndCloseBody() called on it.
-func (a *InternalAPIEngine) postResp(arg APIArg, sendJSON bool) (*http.Response, error) {
+func (a *InternalAPIEngine) postResp(arg APIArg) (*http.Response, error) {
 	url1 := a.getURL(arg)
-	req, err := a.PreparePost(url1, arg, sendJSON)
+	req, err := a.PreparePost(url1, arg)
 	if err != nil {
 		return nil, err
 	}
@@ -639,20 +640,7 @@ func (a *InternalAPIEngine) postResp(arg APIArg, sendJSON bool) (*http.Response,
 }
 
 func (a *InternalAPIEngine) PostDecode(arg APIArg, v APIResponseWrapper) error {
-	resp, err := a.postResp(arg, false)
-	if err != nil {
-		return err
-	}
-	defer DiscardAndCloseBody(resp)
-	dec := json.NewDecoder(resp.Body)
-	if err = dec.Decode(&v); err != nil {
-		return err
-	}
-	return a.checkAppStatus(arg, v.GetAppStatus())
-}
-
-func (a *InternalAPIEngine) PostDecodeJSON(arg APIArg, v APIResponseWrapper) error {
-	resp, err := a.postResp(arg, true)
+	resp, err := a.postResp(arg)
 	if err != nil {
 		return err
 	}
@@ -827,7 +815,7 @@ func (api *ExternalAPIEngine) postCommon(arg APIArg, restype XAPIResType) (
 	if err != nil {
 		return
 	}
-	req, err = api.PreparePost(*url1, arg, false)
+	req, err = api.PreparePost(*url1, arg)
 	if err != nil {
 		return
 	}

--- a/go/libkb/api_mock_test.go
+++ b/go/libkb/api_mock_test.go
@@ -17,8 +17,8 @@ func (n *NullMockAPI) GetResp(APIArg) (*http.Response, error)             { retu
 func (n *NullMockAPI) GetDecode(APIArg, APIResponseWrapper) error         { return nil }
 func (n *NullMockAPI) Post(APIArg) (*APIRes, error)                       { return nil, nil }
 func (n *NullMockAPI) PostJSON(APIArg) (*APIRes, error)                   { return nil, nil }
-func (n *NullMockAPI) PostResp(APIArg) (*http.Response, error)            { return nil, nil }
 func (n *NullMockAPI) PostDecode(APIArg, APIResponseWrapper) error        { return nil }
+func (n *NullMockAPI) PostDecodeJSON(APIArg, APIResponseWrapper) error    { return nil }
 func (n *NullMockAPI) PostRaw(APIArg, string, io.Reader) (*APIRes, error) { return nil, nil }
 
 type APIArgRecorder struct {

--- a/go/libkb/api_mock_test.go
+++ b/go/libkb/api_mock_test.go
@@ -18,7 +18,6 @@ func (n *NullMockAPI) GetDecode(APIArg, APIResponseWrapper) error         { retu
 func (n *NullMockAPI) Post(APIArg) (*APIRes, error)                       { return nil, nil }
 func (n *NullMockAPI) PostJSON(APIArg) (*APIRes, error)                   { return nil, nil }
 func (n *NullMockAPI) PostDecode(APIArg, APIResponseWrapper) error        { return nil }
-func (n *NullMockAPI) PostDecodeJSON(APIArg, APIResponseWrapper) error    { return nil }
 func (n *NullMockAPI) PostRaw(APIArg, string, io.Reader) (*APIRes, error) { return nil, nil }
 
 type APIArgRecorder struct {

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1825,3 +1825,17 @@ func (e DeviceNotFoundError) Error() string {
 }
 
 //=============================================================================
+
+// PseudonymGetError is sometimes written by unmarshaling (no fields of) a server response.
+type PseudonymGetError struct {
+	msg string
+}
+
+func (e PseudonymGetError) Error() string {
+	if e.msg == "" {
+		return "Pseudonym could not be resolved"
+	}
+	return e.msg
+}
+
+var _ error = (*PseudonymGetError)(nil)

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -245,7 +245,6 @@ type API interface {
 	Post(APIArg) (*APIRes, error)
 	PostJSON(APIArg) (*APIRes, error)
 	PostDecode(APIArg, APIResponseWrapper) error
-	PostDecodeJSON(APIArg, APIResponseWrapper) error
 	PostRaw(APIArg, string, io.Reader) (*APIRes, error)
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -244,8 +244,8 @@ type API interface {
 	GetDecode(APIArg, APIResponseWrapper) error
 	Post(APIArg) (*APIRes, error)
 	PostJSON(APIArg) (*APIRes, error)
-	PostResp(APIArg) (*http.Response, error)
 	PostDecode(APIArg, APIResponseWrapper) error
+	PostDecodeJSON(APIArg, APIResponseWrapper) error
 	PostRaw(APIArg, string, io.Reader) (*APIRes, error)
 }
 

--- a/go/libkb/login_session_test.go
+++ b/go/libkb/login_session_test.go
@@ -69,16 +69,16 @@ func (a *FakeAPI) PostJSON(APIArg) (*APIRes, error) {
 	return nil, fmt.Errorf("PostJSON is phony")
 }
 
-func (a *FakeAPI) PostResp(APIArg) (*http.Response, error) {
-	return nil, fmt.Errorf("PostResp is phony")
-}
-
 func (a *FakeAPI) PostRaw(APIArg, string, io.Reader) (*APIRes, error) {
 	return nil, fmt.Errorf("PostRaw is phony")
 }
 
 func (a *FakeAPI) PostDecode(APIArg, APIResponseWrapper) error {
 	return fmt.Errorf("GetDecode is phony")
+}
+
+func (a *FakeAPI) PostDecodeJSON(APIArg, APIResponseWrapper) error {
+	return fmt.Errorf("GetDecodeJSON is phony")
 }
 
 func TestLoginSessionTimeout(t *testing.T) {

--- a/go/libkb/login_session_test.go
+++ b/go/libkb/login_session_test.go
@@ -77,10 +77,6 @@ func (a *FakeAPI) PostDecode(APIArg, APIResponseWrapper) error {
 	return fmt.Errorf("GetDecode is phony")
 }
 
-func (a *FakeAPI) PostDecodeJSON(APIArg, APIResponseWrapper) error {
-	return fmt.Errorf("GetDecodeJSON is phony")
-}
-
 func TestLoginSessionTimeout(t *testing.T) {
 	tc := SetupTest(t, "login_session_test", 1)
 	tc.G.API = &FakeAPI{}

--- a/go/libkb/pseudonym.go
+++ b/go/libkb/pseudonym.go
@@ -163,7 +163,7 @@ func GetTlfPseudonyms(ctx context.Context, g *GlobalContext, pnyms []TlfPseudony
 	payload["tlf_pseudonyms"] = pnymStrings
 
 	var res getTlfPseudonymsRes
-	err := g.API.PostDecodeJSON(
+	err := g.API.PostDecode(
 		APIArg{
 			Endpoint:    "kbfs/pseudonym/get",
 			NeedSession: true,

--- a/go/libkb/pseudonym.go
+++ b/go/libkb/pseudonym.go
@@ -177,8 +177,8 @@ func GetTlfPseudonyms(ctx context.Context, g *GlobalContext, pnyms []TlfPseudony
 			len(res.TlfPseudonyms), len(pnyms))}
 	}
 	var resList []GetTlfPseudonymEither
-	for i, e := range res.TlfPseudonyms {
-		resList = append(resList, checkAndConvertTlfPseudonymFromServer(ctx, g, pnyms[i], e))
+	for i, received := range res.TlfPseudonyms {
+		resList = append(resList, checkAndConvertTlfPseudonymFromServer(ctx, g, pnyms[i], received))
 	}
 
 	return resList, nil
@@ -194,8 +194,12 @@ func checkAndConvertTlfPseudonymFromServer(ctx context.Context, g *GlobalContext
 
 	x := GetTlfPseudonymEither{}
 
+	// This check is necessary because of sneaky typed nil.
+	// received.Err's type is lower than x.Err
+	// So doing `x.Err = received.Err` is bad if received.Err is nil.
+	// https://golang.org/doc/faq#nil_error
+	// https://play.golang.org/p/BnjVTGh-gO
 	if received.Err != nil {
-		// This check is necessary because of https://golang.org/doc/faq#nil_error
 		x.Err = received.Err
 	}
 

--- a/go/libkb/pseudonym.go
+++ b/go/libkb/pseudonym.go
@@ -1,0 +1,260 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkb
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	context "golang.org/x/net/context"
+
+	"github.com/keybase/kbfs/kbfscodec"
+)
+
+// TLFPseudonym is an identifier for a key in a tlf
+type TlfPseudonym [32]byte
+
+type keyGen int
+type tlfID [16]byte
+
+const tlfPseudonymVersion = 1
+
+// TlfPseudonymInfo is what a pseudonym represents
+type TlfPseudonymInfo struct {
+	// TLF name like: /keybase/private/a,b
+	Name string
+	// TLF id
+	ID      tlfID
+	KeyGen  keyGen
+	HmacKey [32]byte
+}
+
+func (t TlfPseudonym) String() string {
+	return hex.EncodeToString(t[:])
+}
+
+func (t *TlfPseudonym) Eq(r *TlfPseudonym) bool {
+	if t != nil && r != nil {
+		return bytes.Equal(t[:], r[:])
+	}
+	return (t == nil) && (r == nil)
+}
+
+// tlfPseudonymReq is what the server needs to store a pseudonym
+type tlfPseudonymReq struct {
+	Pseudonym string `json:"tlf_pseudonym"` // hex
+	Name      string `json:"tlf_name"`
+	ID        string `json:"tlf_id"` // hex
+	KeyGen    int    `json:"tlf_key_gen"`
+	HmacKey   string `json:"hmac_key"` // hex
+}
+
+// tlfPseudonymContents is the data packed inside the HMAC
+type tlfPseudonymContents struct {
+	_struct bool `codec:",toarray"`
+	Version int
+	Name    string
+	ID      tlfID
+	KeyGen  keyGen
+}
+
+type getTlfPseudonymsRes struct {
+	TlfPseudonyms []getTlfPseudonymRes `json:"tlf_pseudonyms"`
+	Status        AppStatus            `json:"status"`
+}
+
+func (r *getTlfPseudonymsRes) GetAppStatus() *AppStatus {
+	return &r.Status
+}
+
+type getTlfPseudonymRes struct {
+	Err  *PseudonymGetError `json:"err"`
+	Info *struct {
+		Name    string `json:"tlf_name"`
+		ID      string `json:"tlf_id"` // hex
+		KeyGen  int    `json:"tlf_key_gen"`
+		HmacKey string `json:"hmac_key"` // hex
+	} `json:"info"`
+}
+
+type GetTlfPseudonymEither struct {
+	// Exactly one of these 2 fields is nil.
+	Err  error
+	Info *TlfPseudonymInfo
+}
+
+// MakePseudonym makes a TLF pseudonym from the given input.
+func MakePseudonym(info TlfPseudonymInfo) (TlfPseudonym, error) {
+	input := tlfPseudonymContents{
+		Version: tlfPseudonymVersion,
+		Name:    info.Name,
+		ID:      info.ID,
+		KeyGen:  info.KeyGen,
+	}
+	codec := kbfscodec.NewMsgpack()
+	buf, err := codec.Encode(input)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	mac := hmac.New(sha256.New, info.HmacKey[:])
+	mac.Write(buf)
+	hmacArr := mac.Sum(nil)
+	var hmac [32]byte
+	if len(hmacArr) != len(hmac) {
+		return [32]byte{}, fmt.Errorf(
+			"Expected array of size %d, got %d",
+			len(hmac), len(hmacArr))
+	}
+	copy(hmac[:], hmacArr)
+	return hmac, nil
+}
+
+func PostTlfPseudonyms(ctx context.Context, g *GlobalContext, pnymInfos []TlfPseudonymInfo) ([]TlfPseudonym, error) {
+	var pnymReqs []tlfPseudonymReq
+	var pnyms []TlfPseudonym
+	for _, info := range pnymInfos {
+		// Compute the pseudonym
+		pn, err := MakePseudonym(info)
+		if err != nil {
+			return nil, err
+		}
+		pnyms = append(pnyms, pn)
+		pnymReqs = append(pnymReqs, tlfPseudonymReq{
+			Pseudonym: pn.String(),
+			Name:      info.Name,
+			ID:        hex.EncodeToString(info.ID[:]),
+			KeyGen:    int(info.KeyGen),
+			HmacKey:   hex.EncodeToString(info.HmacKey[:]),
+		})
+	}
+
+	payload := make(JSONPayload)
+	payload["tlf_pseudonyms"] = pnymReqs
+
+	_, err := G.API.PostJSON(APIArg{
+		Endpoint:    "kbfs/pseudonym/put",
+		JSONPayload: payload,
+		NeedSession: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return pnyms, nil
+}
+
+// GetTlfPseudonyms fetches info for a list of pseudonyms.
+// The output structs are returned in the order corresponding to the inputs.
+// The top-level error is filled if the entire request fails.
+// The each-struct errors may be filled for per-pseudonym errors.
+func GetTlfPseudonyms(ctx context.Context, g *GlobalContext, pnyms []TlfPseudonym) ([]GetTlfPseudonymEither, error) {
+	var pnymStrings []string
+	for _, x := range pnyms {
+		pnymStrings = append(pnymStrings, x.String())
+	}
+
+	payload := make(JSONPayload)
+	payload["tlf_pseudonyms"] = pnymStrings
+
+	var res getTlfPseudonymsRes
+	err := g.API.PostDecodeJSON(
+		APIArg{
+			Endpoint:    "kbfs/pseudonym/get",
+			NeedSession: true,
+			JSONPayload: payload,
+			NetContext:  ctx,
+		},
+		&res)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate the response
+	if len(res.TlfPseudonyms) != len(pnyms) {
+		return nil, &PseudonymGetError{fmt.Sprintf("invalid server response for pseudonym get: len %v != %v",
+			len(res.TlfPseudonyms), len(pnyms))}
+	}
+	var resList []GetTlfPseudonymEither
+	for i, e := range res.TlfPseudonyms {
+		resList = append(resList, checkAndConvertTlfPseudonymFromServer(ctx, g, pnyms[i], e))
+	}
+
+	return resList, nil
+}
+
+func checkAndConvertTlfPseudonymFromServer(ctx context.Context, g *GlobalContext, req TlfPseudonym, received getTlfPseudonymRes) GetTlfPseudonymEither {
+	mkErr := func(err error) GetTlfPseudonymEither {
+		return GetTlfPseudonymEither{
+			Info: nil,
+			Err:  err,
+		}
+	}
+
+	x := GetTlfPseudonymEither{}
+
+	if received.Err != nil {
+		// This check is necessary because of https://golang.org/doc/faq#nil_error
+		x.Err = received.Err
+	}
+
+	if received.Info != nil {
+		info := TlfPseudonymInfo{}
+
+		info.Name = received.Info.Name
+
+		n, err := hex.Decode(info.ID[:], []byte(received.Info.ID))
+		if err != nil {
+			return mkErr(err)
+		}
+		if n != len(info.ID) {
+			return mkErr(fmt.Errorf("tlf id wrong length"))
+		}
+
+		info.KeyGen = keyGen(received.Info.KeyGen)
+
+		n, err = hex.Decode(info.HmacKey[:], []byte(received.Info.HmacKey))
+		if err != nil {
+			return mkErr(err)
+		}
+		if n != len(info.HmacKey) {
+			return mkErr(fmt.Errorf("hmac key wrong length"))
+		}
+
+		x.Info = &info
+	}
+
+	err := checkTlfPseudonymFromServer(ctx, g, req, x)
+	if err != nil {
+		return mkErr(err)
+	}
+	return x
+}
+
+func checkTlfPseudonymFromServer(ctx context.Context, g *GlobalContext, req TlfPseudonym, received GetTlfPseudonymEither) error {
+	// Exactly one of Info and Err should exist
+	if (received.Info == nil) == (received.Err == nil) {
+		return &PseudonymGetError{fmt.Sprintf("invalid server response for pseudonym get: %s", req)}
+	}
+
+	// Errors don't need validation
+	if received.Info == nil {
+		return nil
+	}
+
+	// Check that the pseudonym info matches the query.
+	pn, err := MakePseudonym(*received.Info)
+	if err != nil {
+		// Error creating pseudonym locally
+		return &PseudonymGetError{err.Error()}
+	}
+	if !req.Eq(&pn) {
+		return &PseudonymGetError{fmt.Sprintf("returned data does not match pseudonym: %s != %s",
+			req, pn)}
+	}
+
+	return nil
+}

--- a/go/libkb/pseudonym.go
+++ b/go/libkb/pseudonym.go
@@ -105,14 +105,10 @@ func MakePseudonym(info TlfPseudonymInfo) (TlfPseudonym, error) {
 	}
 	mac := hmac.New(sha256.New, info.HmacKey[:])
 	mac.Write(buf)
-	hmacArr := mac.Sum(nil)
-	var hmac [32]byte
-	if len(hmacArr) != len(hmac) {
-		return [32]byte{}, fmt.Errorf(
-			"Expected array of size %d, got %d",
-			len(hmac), len(hmacArr))
+	hmac, err := MakeByte32(mac.Sum(nil))
+	if err != nil {
+		return [32]byte{}, err
 	}
-	copy(hmac[:], hmacArr)
 	return hmac, nil
 }
 

--- a/go/libkb/pseudonym.go
+++ b/go/libkb/pseudonym.go
@@ -11,9 +11,9 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	context "golang.org/x/net/context"
+	"github.com/keybase/go-codec/codec"
 
-	"github.com/keybase/kbfs/kbfscodec"
+	context "golang.org/x/net/context"
 )
 
 // TLFPseudonym is an identifier for a key in a tlf
@@ -96,8 +96,10 @@ func MakePseudonym(info TlfPseudonymInfo) (TlfPseudonym, error) {
 		ID:      info.ID,
 		KeyGen:  info.KeyGen,
 	}
-	codec := kbfscodec.NewMsgpack()
-	buf, err := codec.Encode(input)
+	mh := codec.MsgpackHandle{WriteExt: true}
+	var buf []byte
+	enc := codec.NewEncoderBytes(&buf, &mh)
+	err := enc.Encode(input)
 	if err != nil {
 		return [32]byte{}, err
 	}

--- a/go/libkb/pseudonym_test.go
+++ b/go/libkb/pseudonym_test.go
@@ -1,0 +1,90 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkb
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testPseudonymName(name, idStr string, keyGen keyGen,
+	keyStr, expectedPseudonymStr string) string {
+	return fmt.Sprintf("%s,%s,%d,%s,%s", name, idStr, keyGen, keyStr, expectedPseudonymStr)
+}
+
+func testMakePseudonym(t *testing.T, name, idStr string, keyGen keyGen,
+	keyStr, expectedPseudonymStr string) {
+	idBytes, err := hex.DecodeString(idStr)
+	require.NoError(t, err)
+	var id tlfID
+	require.Equal(t, 16, copy(id[:], idBytes))
+
+	keyBytes, err := hex.DecodeString(keyStr)
+	require.NoError(t, err)
+	require.Equal(t, 32, len(keyBytes))
+	var key [32]byte
+	copy(key[:], keyBytes)
+
+	pseudonym, err := MakePseudonym(TlfPseudonymInfo{
+		Name:    name,
+		ID:      id,
+		KeyGen:  keyGen,
+		HmacKey: key,
+	})
+	require.NoError(t, err)
+	pseudonymStr := hex.EncodeToString(pseudonym[:])
+	require.Equal(t, expectedPseudonymStr, pseudonymStr)
+}
+
+func TestMakePseudonym(t *testing.T) {
+	names := []string{"/keybase/private/a1", "/keybase/private/zz"}
+	idStrs := []string{
+		"b070f968fdc9d1c8827d7e4953659416",
+		"0d399cb03bd1b59a07f92fffaaffa516",
+	}
+	keyGens := []keyGen{1, 50}
+	keyStrs := []string{
+		"9d13584d962bf1acebd1ccee109c8bb5d4a014e77f125302455477c53307cc14",
+		"ca7014befa7470d87129841c0f41c5b6ed548b9a6431d205b4ff44556bd51a42",
+	}
+
+	expectedPseudonymStrs := []string{
+		"dcec9bccde1b859cb355a9264bca56b91f07e7c831710ca945a0f7fe7b7e1191",
+		"66b38986a207c00b5f6b835af0ae8403f8bd07f7ef520dbbd4addf53d2b58edb",
+		"3d3cbb61788f87bfbc9d1d6c528600eccf4bbde4c3925b3f05a7692e54fd74ff",
+		"94c8152fb780041bbbb62df29a47f2579392927af73fa2dcfbccaac8718cce75",
+		"085075dc9ef14821e61c8e669286ad5031faa2ebf1b6e2b63d4f2d74fc7bb861",
+		"eeca52e9fe0b4699fe2f2baa834603ed5badc769bf99dd1f33d2863796d50142",
+		"42dcd4ce7eb97d6bea874bb2af2c7b3f5414c131decfd7e47213524dfd0c90a3",
+		"ebd2ff9eba99a09a5723f1dfab563596eef05213ab1af5f10d40ff102c4f0d69",
+		"d0e0031b1dc21fbb03312f26e6e8b4c1e5b5bed0a7b8902bffdbe467af7ee81c",
+		"2ddf845eebd66816f8f07aaf23901aa7a3ebb60b3be340573f2b05e8246d096d",
+		"4240789d970b301d3ede262f6f81f97efe42296ac83145d5c6de340188f73b2d",
+		"51786cb8605a4be7373363ed1a7a98b54df8c49e31397294996bf37de57f2f40",
+		"9046fac921597b06332a2655647f22eb7955b34a21a6d97e8e3a74e92ad9f149",
+		"529085af3111d1a64186e01f3a8b2607586060116b3db092e79b943a133ebb32",
+		"700cebb5f5e4360f12d97028e7ac96582a0f733aa54db23f9a19740efbf8d626",
+		"7531de864cbc313817c0107cfadaaddf01350f1b1cd8f1e497358166048b1a64",
+	}
+
+	i := 0
+	for _, name := range names {
+		for _, idStr := range idStrs {
+			for _, keyGen := range keyGens {
+				for _, keyStr := range keyStrs {
+					epStr := expectedPseudonymStrs[i]
+					t.Run(testPseudonymName(name, idStr, keyGen, keyStr, epStr),
+						func(t *testing.T) {
+							testMakePseudonym(t, name, idStr, keyGen, keyStr, epStr)
+						})
+					i++
+				}
+			}
+		}
+	}
+}

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -568,3 +568,15 @@ func LogTagsFromContext(ctx context.Context) (map[interface{}]string, bool) {
 	tags, ok := logger.LogTagsFromContext(ctx)
 	return map[interface{}]string(tags), ok
 }
+
+func MakeByte32(a []byte) ([32]byte, error) {
+	const n = 32
+	var b [n]byte
+	if len(a) != n {
+		return b, fmt.Errorf("MakeByte expected len %v but got %v slice", n, len(a))
+	}
+	if copy(b[:], a) != n {
+		return b, fmt.Errorf("MakeByte expected len %v but got %v slice", n, len(a))
+	}
+	return b, nil
+}

--- a/go/libkb/util_test.go
+++ b/go/libkb/util_test.go
@@ -6,6 +6,8 @@ package libkb
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type cmpTest struct {
@@ -64,4 +66,22 @@ func TestWhitespaceNormalize(t *testing.T) {
 		}
 	}
 
+}
+
+func TestMakeByte32(t *testing.T) {
+	var x1 [32]byte
+	var x2 [31]byte
+	var x3 [33]byte
+
+	x1[3] = 5
+
+	y, err := MakeByte32(x1[:])
+	require.NoError(t, err)
+	require.Equal(t, x1, y)
+
+	y, err = MakeByte32(x2[:])
+	require.Error(t, err)
+
+	y, err = MakeByte32(x3[:])
+	require.Error(t, err)
 }


### PR DESCRIPTION
Copied `MakePseudonym` from https://github.com/keybase/kbfs/pull/872
Added `likb.{Get,Post}TlfPseudonyms`

`MakePseudonym` is tested in `pseudonym_test.go`.
`likb.{Get,Post}TlfPseudonyms` was only tested manually ([using this](https://github.com/keybase/client/blob/miles/CORE-4786-tlf-pnym-Foo/go/engine/foo.go#L46)).