### PR TITLE
Don't cache QR codes over different text code creations

### DIFF
--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -174,7 +174,7 @@ function setCodePageOtherDeviceRole (otherDeviceRole: DeviceRole) : AsyncAction 
 function generateQRCode (dispatch: Dispatch, getState: GetState) {
   const store = getState().login.codePage
 
-  if (!store.qrCode && store.textCode) {
+  if (store.textCode) {
     dispatch({payload: {qrCode: new HiddenString(qrGenerate(store.textCode.stringValue()))}, type: Constants.setQRCode})
   }
 }


### PR DESCRIPTION
@keybase/react-hackers 

When we're showing a QR code, we only generate one if there's a stored textCode but no stored qrCode.  This means that if the textCode changes because we ran kex again, we'll still be using an old qrCode.  Not sure why we did this -- I think it makes sense to generate a new qrCode every time.

CC @mmaxim 