### PR TITLE
Fix saving initial tab as loginTab

### DIFF
--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -10,231 +10,216 @@ import {resetSignup} from '../../actions/signup'
 
 import type {Tab} from '../../constants/tabs'
 import type {UpdateFollowing} from '../../constants/config'
-import type {AsyncAction, Action} from '../../constants/types/flux'
+import type {AsyncAction} from '../../constants/types/flux'
+
+// TODO convert to sagas
 
 isMobile && module.hot && module.hot.accept(() => {
   console.log('accepted update in actions/config')
 })
 
-function setInitialTab (tab: ?Tab) {
-  return {payload: {tab}, type: 'config:setInitialTab'}
-}
+const setInitialTab = (tab: ?Tab): Constants.SetInitialTab => (
+  {payload: {tab}, type: 'config:setInitialTab'}
+)
 
-function getConfig (): AsyncAction {
-  return (dispatch, getState) => {
-    return new Promise((resolve, reject) => {
-      configGetConfigRpc({
-        callback: (error, config) => {
-          if (error) {
-            reject(error)
-            return
-          }
+const getConfig = (): AsyncAction => (dispatch, getState) => (
+  new Promise((resolve, reject) => {
+    configGetConfigRpc({
+      callback: (error, config) => {
+        if (error) {
+          reject(error)
+          return
+        }
 
-          dispatch({payload: {config}, type: Constants.configLoaded})
-          resolve()
-        },
-      })
+        dispatch({payload: {config}, type: Constants.configLoaded})
+        resolve()
+      },
     })
-  }
-}
+  })
+)
 
 function isFollower (getState: any, username: string): boolean {
   return !!getState().config.followers[username]
 }
 
-function getMyFollowers (username: string): AsyncAction {
-  return dispatch => {
-    userListTrackersByNameRpc({
-      callback: (error, trackers) => {
-        if (error) {
-          return
-        }
+const getMyFollowers = (username: string): AsyncAction => dispatch => {
+  userListTrackersByNameRpc({
+    callback: (error, trackers) => {
+      if (error) {
+        return
+      }
 
-        if (trackers && trackers.length) {
-          const uids = trackers.map(t => t.tracker)
-          userLoadUncheckedUserSummariesRpc({
-            callback: (error, summaries) => {
-              if (error) {
-                return
-              }
+      if (trackers && trackers.length) {
+        const uids = trackers.map(t => t.tracker)
+        userLoadUncheckedUserSummariesRpc({
+          callback: (error, summaries) => {
+            if (error) {
+              return
+            }
 
-              const followers = {}
-              summaries && summaries.forEach(s => { followers[s.username] = true })
-              dispatch({
-                payload: {followers},
-                type: Constants.setFollowers,
-              })
-            },
-            param: {uids},
-          })
-        }
-      },
-      param: {username},
-    })
-  }
+            const followers = {}
+            summaries && summaries.forEach(s => { followers[s.username] = true })
+            dispatch({
+              payload: {followers},
+              type: Constants.setFollowers,
+            })
+          },
+          param: {uids},
+        })
+      }
+    },
+    param: {username},
+  })
 }
 
 function isFollowing (getState: () => any, username: string) : boolean {
   return !!getState().config.following[username]
 }
 
-function getMyFollowing (username: string): AsyncAction {
-  return dispatch => {
-    userListTrackingRpc({
-      callback: (error, summaries) => {
+const getMyFollowing = (username: string): AsyncAction => dispatch => {
+  userListTrackingRpc({
+    callback: (error, summaries) => {
+      if (error) {
+        return
+      }
+
+      const following = {}
+      summaries && summaries.forEach(s => { following[s.username] = true })
+      dispatch({
+        payload: {following},
+        type: Constants.setFollowing,
+      })
+    },
+    param: {assertion: username, filter: ''},
+  })
+}
+
+const waitForKBFS = (): AsyncAction => dispatch => (
+  new Promise((resolve, reject) => {
+    configWaitForClientRpc({
+      callback: (error, found) => {
         if (error) {
+          reject(error)
+          return
+        }
+        if (!found) {
+          reject(new Error('Waited for KBFS client, but it wasn\'t not found'))
+          return
+        }
+        resolve()
+      },
+      param: {clientType: CommonClientType.kbfs, timeout: 10.0},
+    })
+  })
+)
+
+const getExtendedStatus = (): AsyncAction => dispatch => (
+  new Promise((resolve, reject) => {
+    configGetExtendedStatusRpc({
+      callback: (error, extendedConfig) => {
+        if (error) {
+          reject(error)
           return
         }
 
-        const following = {}
-        summaries && summaries.forEach(s => { following[s.username] = true })
-        dispatch({
-          payload: {following},
-          type: Constants.setFollowing,
-        })
+        dispatch({payload: {extendedConfig}, type: Constants.extendedConfigLoaded})
+        resolve(extendedConfig)
       },
-      param: {assertion: username, filter: ''},
     })
-  }
+  })
+)
+
+const registerListeners = (): AsyncAction => dispatch => {
+  dispatch(listenForNativeReachabilityEvents)
+  dispatch(registerGregorListeners())
+  dispatch(registerReachability())
 }
 
-function waitForKBFS (): AsyncAction {
-  return dispatch => {
-    return new Promise((resolve, reject) => {
-      configWaitForClientRpc({
-        callback: (error, found) => {
-          if (error) {
-            reject(error)
-            return
-          }
-          if (!found) {
-            reject(new Error('Waited for KBFS client, but it wasn\'t not found'))
-            return
-          }
-          resolve()
-        },
-        param: {clientType: CommonClientType.kbfs, timeout: 10.0},
-      })
-    })
-  }
+const retryBootstrap = (): AsyncAction => (dispatch, getState) => {
+  dispatch({payload: null, type: Constants.bootstrapRetry})
+  dispatch(bootstrap())
 }
 
-function getExtendedStatus (): AsyncAction {
-  return dispatch => {
-    return new Promise((resolve, reject) => {
-      configGetExtendedStatusRpc({
-        callback: (error, extendedConfig) => {
-          if (error) {
-            reject(error)
-            return
-          }
-
-          dispatch({payload: {extendedConfig}, type: Constants.extendedConfigLoaded})
-          resolve(extendedConfig)
-        },
-      })
-    })
-  }
-}
-
-function registerListeners (): AsyncAction {
-  return dispatch => {
-    dispatch(listenForNativeReachabilityEvents)
-    dispatch(registerGregorListeners())
-    dispatch(registerReachability())
-  }
-}
-
-function retryBootstrap (): AsyncAction {
-  return (dispatch, getState) => {
-    dispatch({payload: null, type: Constants.bootstrapRetry})
-    dispatch(bootstrap())
-  }
-}
-
-function daemonError (error: ?string): Action {
-  return {payload: {daemonError: error ? new Error(error) : null}, type: Constants.daemonError}
-}
+const daemonError = (error: ?string): Constants.DaemonError => (
+  {payload: {daemonError: error ? new Error(error) : null}, type: Constants.daemonError}
+)
 
 let bootstrapSetup = false
 type BootstrapOptions = {isReconnect?: boolean}
-function bootstrap (opts?: BootstrapOptions = {}): AsyncAction {
-  return (dispatch, getState) => {
-    const readyForBootstrap = getState().config.readyForBootstrap
-    if (!readyForBootstrap) {
-      console.warn('Not ready for bootstrap/connect')
-      return
-    }
 
-    if (!bootstrapSetup) {
-      bootstrapSetup = true
-      console.log('[bootstrap] registered bootstrap')
-      engine().listenOnConnect('bootstrap', () => {
-        dispatch(daemonError(null))
-        dispatch(checkReachabilityOnConnect())
-        console.log('[bootstrap] bootstrapping on connect')
-        dispatch(bootstrap())
-      })
-      engine().listenOnDisconnect('daemonError', () => {
-        dispatch(daemonError('Disconnected'))
-      })
-      dispatch(registerListeners())
-    } else {
-      console.log('[bootstrap] performing bootstrap...')
-      Promise.all(
-        [dispatch(getCurrentStatus()), dispatch(getExtendedStatus()), dispatch(getConfig()), dispatch(waitForKBFS())]).then(([username]) => {
-          if (username) {
-            dispatch(getMyFollowers(username))
-            dispatch(getMyFollowing(username))
-          }
-          dispatch({payload: null, type: Constants.bootstrapped})
-          dispatch(listenForKBFSNotifications())
-          if (!opts.isReconnect) {
-            dispatch(navBasedOnLoginState())
-            dispatch(resetSignup())
-          }
-        }).catch(error => {
-          console.warn('[bootstrap] error bootstrapping: ', error)
-          const triesRemaining = getState().config.bootstrapTriesRemaining
-          dispatch({payload: null, type: Constants.bootstrapAttemptFailed})
-          if (triesRemaining > 0) {
-            const retryDelay = Constants.bootstrapRetryDelay / triesRemaining
-            console.log(`[bootstrap] resetting engine in ${retryDelay / 1000}s (${triesRemaining} tries left)`)
-            setTimeout(() => engine().reset(), retryDelay)
-          } else {
-            console.error('[bootstrap] exhausted bootstrap retries')
-            dispatch({payload: {error}, type: Constants.bootstrapFailed})
-          }
-        })
-    }
+const bootstrap = (opts?: BootstrapOptions = {}): AsyncAction => (dispatch, getState) => {
+  const readyForBootstrap = getState().config.readyForBootstrap
+  if (!readyForBootstrap) {
+    console.warn('Not ready for bootstrap/connect')
+    return
   }
-}
 
-function getCurrentStatus (): AsyncAction {
-  return dispatch => {
-    return new Promise((resolve, reject) => {
-      configGetCurrentStatusRpc({
-        callback: (error, status) => {
-          if (error) {
-            reject(error)
-            return
-          }
-
-          dispatch({
-            payload: {status},
-            type: Constants.statusLoaded,
-          })
-
-          resolve(status && status.user && status.user.username)
-        },
-      })
+  if (!bootstrapSetup) {
+    bootstrapSetup = true
+    console.log('[bootstrap] registered bootstrap')
+    engine().listenOnConnect('bootstrap', () => {
+      dispatch(daemonError(null))
+      dispatch(checkReachabilityOnConnect())
+      console.log('[bootstrap] bootstrapping on connect')
+      dispatch(bootstrap())
     })
+    engine().listenOnDisconnect('daemonError', () => {
+      dispatch(daemonError('Disconnected'))
+    })
+    dispatch(registerListeners())
+  } else {
+    console.log('[bootstrap] performing bootstrap...')
+    Promise.all(
+      [dispatch(getCurrentStatus()), dispatch(getExtendedStatus()), dispatch(getConfig()), dispatch(waitForKBFS())]).then(([username]) => {
+        if (username) {
+          dispatch(getMyFollowers(username))
+          dispatch(getMyFollowing(username))
+        }
+        dispatch({payload: null, type: Constants.bootstrapped})
+        dispatch(listenForKBFSNotifications())
+        if (!opts.isReconnect) {
+          dispatch(navBasedOnLoginState())
+          dispatch(resetSignup())
+        }
+      }).catch(error => {
+        console.warn('[bootstrap] error bootstrapping: ', error)
+        const triesRemaining = getState().config.bootstrapTriesRemaining
+        dispatch({payload: null, type: Constants.bootstrapAttemptFailed})
+        if (triesRemaining > 0) {
+          const retryDelay = Constants.bootstrapRetryDelay / triesRemaining
+          console.log(`[bootstrap] resetting engine in ${retryDelay / 1000}s (${triesRemaining} tries left)`)
+          setTimeout(() => engine().reset(), retryDelay)
+        } else {
+          console.error('[bootstrap] exhausted bootstrap retries')
+          dispatch({payload: {error}, type: Constants.bootstrapFailed})
+        }
+      })
   }
 }
 
-function updateFollowing (username: string, isTracking: boolean): UpdateFollowing {
-  return {payload: {username, isTracking}, type: Constants.updateFollowing}
-}
+const getCurrentStatus = (): AsyncAction => dispatch => (
+  new Promise((resolve, reject) => {
+    configGetCurrentStatusRpc({
+      callback: (error, status) => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        dispatch({
+          payload: {status},
+          type: Constants.statusLoaded,
+        })
+
+        resolve(status && status.user && status.user.username)
+      },
+    })
+  })
+)
+
+const updateFollowing = (username: string, isTracking: boolean): UpdateFollowing => (
+  {payload: {username, isTracking}, type: Constants.updateFollowing}
+)
 
 export {
   bootstrap,

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -25,153 +25,132 @@ module.hot && module.hot.accept(() => {
 
 const InputCancelError = {code: Types.ConstantsStatusCode.scinputcanceled, desc: 'Cancel Login'}
 
-function makeWaitingHandler (dispatch: Dispatch): {waitingHandler: (waiting: boolean) => void} {
-  return {
-    waitingHandler: (waiting: boolean) => { dispatch(waitingForResponse(waiting)) },
-  }
-}
+const makeWaitingHandler = (dispatch: Dispatch): {waitingHandler: (waiting: boolean) => void} => (
+  {waitingHandler: (waiting: boolean) => { dispatch(waitingForResponse(waiting)) }}
+)
 
-function waitingForResponse (waiting: boolean) : TypedAction<'login:waitingForResponse', boolean, void> {
-  return {
-    payload: waiting,
-    type: Constants.waitingForResponse,
-  }
-}
+const waitingForResponse = (waiting: boolean) : TypedAction<'login:waitingForResponse', boolean, void> => (
+  {payload: waiting, type: Constants.waitingForResponse}
+)
 
-export function navBasedOnLoginState (): AsyncAction {
-  return (dispatch, getState) => {
-    const {config: {status, extendedConfig, initialTab}, login: {justDeletedSelf}} = getState()
+const navBasedOnLoginState = (): AsyncAction => (dispatch, getState) => {
+  const {config: {status, extendedConfig, initialTab}, login: {justDeletedSelf}} = getState()
 
-    // No status?
-    if (!status || !Object.keys(status).length || !extendedConfig || !Object.keys(extendedConfig).length ||
-      !extendedConfig.defaultDeviceID || justDeletedSelf) { // Not provisioned?
-      dispatch(navigateTo([loginTab]))
-    } else {
-      if (status.loggedIn) { // logged in
-        if (overrideLoggedInTab) {
-          console.log('Loading overridden logged in tab')
-          dispatch(navigateTo([overrideLoggedInTab]))
-        } else if (initialTab) {
-          /// only do this once
-          dispatch(setInitialTab(null))
-          dispatch(navigateTo([initialTab]))
-        } else {
-          dispatch(navigateTo([profileTab]))
-        }
-      } else if (status.registered) { // relogging in
-        dispatch(getAccounts())
-        dispatch(navigateTo(['login'], [loginTab]))
-      } else { // no idea
-        dispatch(navigateTo([loginTab]))
+  // No status?
+  if (!status || !Object.keys(status).length || !extendedConfig || !Object.keys(extendedConfig).length ||
+    !extendedConfig.defaultDeviceID || justDeletedSelf) { // Not provisioned?
+    dispatch(navigateTo([loginTab]))
+  } else {
+    if (status.loggedIn) { // logged in
+      if (overrideLoggedInTab) {
+        console.log('Loading overridden logged in tab')
+        dispatch(navigateTo([overrideLoggedInTab]))
+      } else if (initialTab) {
+        /// only do this once
+        dispatch(setInitialTab(null))
+        dispatch(navigateTo([initialTab]))
+      } else {
+        dispatch(navigateTo([profileTab]))
       }
+    } else if (status.registered) { // relogging in
+      dispatch(getAccounts())
+      dispatch(navigateTo(['login'], [loginTab]))
+    } else { // no idea
+      dispatch(navigateTo([loginTab]))
     }
   }
 }
 
-function getAccounts (): AsyncAction {
-  return dispatch => {
-    Types.loginGetConfiguredAccountsRpc({
+const getAccounts = (): AsyncAction => dispatch => {
+  Types.loginGetConfiguredAccountsRpc({
+    ...makeWaitingHandler(dispatch),
+    callback: (error, accounts) => {
+      if (error) {
+        dispatch({error: true, payload: error, type: Constants.configuredAccounts})
+      } else {
+        dispatch({payload: {accounts}, type: Constants.configuredAccounts})
+      }
+    },
+  })
+}
+
+// See FIXME about HMR at the bottom of this file
+const login = (): AsyncAction => (dispatch, getState) => {
+  function loginSubmit (usernameOrEmail: string) {
+    const deviceType: DeviceType = isMobile ? 'mobile' : 'desktop'
+    const onBack = response => { dispatch(cancelLogin(response)) }
+    const onProvisionerSuccess = () => { dispatch(navBasedOnLoginState()) }
+    const incomingCallMap = makeKex2IncomingMap(dispatch, getState, onBack, onProvisionerSuccess)
+    Types.loginLoginRpc({
       ...makeWaitingHandler(dispatch),
-      callback: (error, accounts) => {
+      callback: (error, response) => {
         if (error) {
-          dispatch({error: true, payload: error, type: Constants.configuredAccounts})
+          dispatch({error: true, payload: error, type: Constants.loginDone})
+
+          if (error.code !== InputCancelError.code) {
+            dispatch(navigateAppend([{
+              props: {error, onBack: () => dispatch(cancelLogin())},
+              selected: 'error',
+            }], [loginTab, 'login']))
+          }
         } else {
-          dispatch({payload: {accounts}, type: Constants.configuredAccounts})
+          dispatch(loginSuccess())
         }
       },
-    })
-  }
-}
-
-export function login (): AsyncAction {
-  // See FIXME about HMR at the bottom of this file
-  return (dispatch, getState) => {
-    function loginSubmit (usernameOrEmail: string) {
-      const deviceType: DeviceType = isMobile ? 'mobile' : 'desktop'
-      const onBack = response => { dispatch(cancelLogin(response)) }
-      const onProvisionerSuccess = () => { dispatch(navBasedOnLoginState()) }
-      const incomingCallMap = makeKex2IncomingMap(dispatch, getState, onBack, onProvisionerSuccess)
-      Types.loginLoginRpc({
-        ...makeWaitingHandler(dispatch),
-        callback: (error, response) => {
-          if (error) {
-            dispatch({
-              error: true,
-              payload: error,
-              type: Constants.loginDone,
-            })
-
-            if (error.code !== InputCancelError.code) {
-              dispatch(navigateAppend([{
-                props: {
-                  error,
-                  onBack: () => dispatch(cancelLogin()),
-                },
-                selected: 'error',
-              }], [loginTab, 'login']))
-            }
-          } else {
-            dispatch(loginSuccess())
-          }
-        },
-        incomingCallMap,
-        param: {
-          clientType: Types.CommonClientType.guiMain,
-          deviceType,
-          usernameOrEmail: usernameOrEmail,
-        },
-      })
-    }
-
-    // We can either be a newDevice or an existingDevice.  Here in the login
-    // flow, let's set ourselves to be a newDevice.  If we were in the Devices
-    // tab flow, we'd want the opposite.
-    dispatch({
-      payload:
-        isMobile ? Constants.codePageDeviceRoleNewPhone : Constants.codePageDeviceRoleNewComputer,
-      type: Constants.setMyDeviceCodeState,
-    })
-    // We ask for user since the login will auto login with the last user which we don't always want
-    dispatch(navigateAppend([{
-      props: {
-        onBack: () => dispatch(cancelLogin()),
-        onSubmit: loginSubmit,
+      incomingCallMap,
+      param: {
+        clientType: Types.CommonClientType.guiMain,
+        deviceType,
+        usernameOrEmail: usernameOrEmail,
       },
-      selected: 'usernameOrEmail',
-    }], [loginTab, 'login']))
+    })
   }
+
+  // We can either be a newDevice or an existingDevice.  Here in the login
+  // flow, let's set ourselves to be a newDevice.  If we were in the Devices
+  // tab flow, we'd want the opposite.
+  dispatch({
+    payload:
+      isMobile ? Constants.codePageDeviceRoleNewPhone : Constants.codePageDeviceRoleNewComputer,
+    type: Constants.setMyDeviceCodeState,
+  })
+  // We ask for user since the login will auto login with the last user which we don't always want
+  dispatch(navigateAppend([{
+    props: {
+      onBack: () => dispatch(cancelLogin()),
+      onSubmit: loginSubmit,
+    },
+    selected: 'usernameOrEmail',
+  }], [loginTab, 'login']))
 }
 
-export function setRevokedSelf (revoked: string) {
-  return {payload: revoked, type: Constants.setRevokedSelf}
-}
+const setRevokedSelf = (revoked: string) => (
+  {payload: revoked, type: Constants.setRevokedSelf}
+)
 
-export function setDeletedSelf (deletedUsername: string) {
-  return {payload: deletedUsername, type: Constants.setDeletedSelf}
-}
+const setDeletedSelf = (deletedUsername: string) => (
+  {payload: deletedUsername, type: Constants.setDeletedSelf}
+)
 
-export function setLoginFromRevokedDevice (error: string) {
-  return {payload: error, type: Constants.setLoginFromRevokedDevice}
-}
+const setLoginFromRevokedDevice = (error: string) => (
+  {payload: error, type: Constants.setLoginFromRevokedDevice}
+)
 
-export function doneRegistering (): TypedAction<'login:doneRegistering', void, void> {
-  // this has to be undefined for flow to match it to void
-  return {payload: undefined, type: Constants.doneRegistering}
-}
+const doneRegistering = (): TypedAction<'login:doneRegistering', void, void> => (
+  {payload: undefined, type: Constants.doneRegistering}
+)
 
-function setCodePageOtherDeviceRole (otherDeviceRole: DeviceRole) : AsyncAction {
-  return (dispatch, getState) => {
-    const store = getState().login.codePage
-    if (store.myDeviceRole == null) {
-      console.warn("my device role is null, can't setCodePageOtherDeviceRole. Bailing")
-      return
-    }
-    dispatch(setCodePageMode(defaultModeForDeviceRoles(store.myDeviceRole, otherDeviceRole, false)))
-    dispatch({payload: otherDeviceRole, type: Constants.setOtherDeviceCodeState})
+const setCodePageOtherDeviceRole = (otherDeviceRole: DeviceRole) : AsyncAction => (dispatch, getState) => {
+  const store = getState().login.codePage
+  if (store.myDeviceRole == null) {
+    console.warn("my device role is null, can't setCodePageOtherDeviceRole. Bailing")
+    return
   }
+  dispatch(setCodePageMode(defaultModeForDeviceRoles(store.myDeviceRole, otherDeviceRole, false)))
+  dispatch({payload: otherDeviceRole, type: Constants.setOtherDeviceCodeState})
 }
 
-function generateQRCode (dispatch: Dispatch, getState: GetState) {
+const generateQRCode = (dispatch: Dispatch, getState: GetState) => {
   const store = getState().login.codePage
 
   if (store.textCode) {
@@ -179,203 +158,172 @@ function generateQRCode (dispatch: Dispatch, getState: GetState) {
   }
 }
 
-function setCodePageMode (mode) : AsyncAction {
-  return (dispatch, getState) => {
-    const store = getState().login.codePage
+const setCodePageMode = (mode) : AsyncAction => (dispatch, getState) => {
+  const store = getState().login.codePage
+  generateQRCode(dispatch, getState)
 
-    generateQRCode(dispatch, getState)
-
-    if (store.mode === mode) {
-      return // already in this mode
-    }
-
-    dispatch({payload: mode, type: Constants.setCodeMode})
+  if (store.mode === mode) {
+    return // already in this mode
   }
+
+  dispatch({payload: mode, type: Constants.setCodeMode})
 }
 
-function setCameraBrokenMode (broken) : AsyncAction {
-  return (dispatch, getState) => {
-    dispatch({payload: broken, type: Constants.cameraBrokenMode})
+const setCameraBrokenMode = (broken) : AsyncAction => (dispatch, getState) => {
+  dispatch({payload: broken, type: Constants.cameraBrokenMode})
 
-    const root = getState().login.codePage
-    if (root.myDeviceRole == null) {
-      console.warn("my device role is null, can't setCameraBrokenMode. Bailing")
-      return
-    }
-
-    if (root.otherDeviceRole == null) {
-      console.warn("other device role is null, can't setCameraBrokenMode. Bailing")
-      return
-    }
-
-    dispatch(setCodePageMode(defaultModeForDeviceRoles(root.myDeviceRole, root.otherDeviceRole, broken)))
+  const root = getState().login.codePage
+  if (root.myDeviceRole == null) {
+    console.warn("my device role is null, can't setCameraBrokenMode. Bailing")
+    return
   }
+
+  if (root.otherDeviceRole == null) {
+    console.warn("other device role is null, can't setCameraBrokenMode. Bailing")
+    return
+  }
+
+  dispatch(setCodePageMode(defaultModeForDeviceRoles(root.myDeviceRole, root.otherDeviceRole, broken)))
 }
 
-export function updateForgotPasswordEmail (email: string) : TypedAction<'login:actionUpdateForgotPasswordEmailAddress', string, void> {
-  return {payload: email, type: Constants.actionUpdateForgotPasswordEmailAddress}
+const updateForgotPasswordEmail = (email: string) : TypedAction<'login:actionUpdateForgotPasswordEmailAddress', string, void> => (
+  {payload: email, type: Constants.actionUpdateForgotPasswordEmailAddress}
+)
+
+const submitForgotPassword = () : AsyncAction => (dispatch, getState) => {
+  dispatch({payload: undefined, type: Constants.actionSetForgotPasswordSubmitting})
+
+  Types.loginRecoverAccountFromEmailAddressRpc({
+    ...makeWaitingHandler(dispatch),
+    callback: (error, response) => {
+      if (error) {
+        dispatch({
+          error: true,
+          payload: error,
+          type: Constants.actionForgotPasswordDone,
+        })
+      } else {
+        dispatch({
+          error: false,
+          payload: undefined,
+          type: Constants.actionForgotPasswordDone,
+        })
+      }
+    },
+    param: {email: getState().login.forgotPasswordEmailAddress},
+  })
 }
 
-export function submitForgotPassword () : AsyncAction {
-  return (dispatch, getState) => {
-    dispatch({payload: undefined, type: Constants.actionSetForgotPasswordSubmitting})
+const loginSuccess = (): AsyncAction => dispatch => {
+  dispatch({payload: undefined, type: Constants.loginDone})
+  dispatch(loadDevices())
+  dispatch(bootstrap())
+}
 
-    Types.loginRecoverAccountFromEmailAddressRpc({
-      ...makeWaitingHandler(dispatch),
-      callback: (error, response) => {
-        if (error) {
-          dispatch({
-            error: true,
-            payload: error,
-            type: Constants.actionForgotPasswordDone,
-          })
-        } else {
-          dispatch({
-            error: false,
-            payload: undefined,
-            type: Constants.actionForgotPasswordDone,
-          })
-        }
+const relogin = (username: string, passphrase: string) : AsyncAction => dispatch => {
+  Types.loginLoginProvisionedDeviceRpc({
+    ...makeWaitingHandler(dispatch),
+    callback: (error, status) => {
+      if (error) {
+        const message = 'This device is no longer provisioned.'
+        dispatch({
+          error: true,
+          payload: {message},
+          type: Constants.loginDone,
+        })
+        dispatch(setLoginFromRevokedDevice(message))
+        dispatch(navigateTo([loginTab]))
+      } else {
+        dispatch(loginSuccess())
+      }
+    },
+    incomingCallMap: {
+      'keybase.1.secretUi.getPassphrase': ({pinentry: {type}}, response) => {
+        response.result({passphrase, storeSecret: true})
       },
-      param: {email: getState().login.forgotPasswordEmailAddress},
-    })
+    },
+    param: {noPassphrasePrompt: false, username},
+  })
+}
+
+const logout = () : AsyncAction => dispatch => {
+  Types.loginLogoutRpc({
+    ...makeWaitingHandler(dispatch),
+    callback: (error, response) => {
+      if (error) {
+        console.log(error)
+      } else {
+        dispatch(logoutDone())
+      }
+    },
+  })
+}
+
+// We've logged out, let's check our current status
+const logoutDone = () : AsyncAction => (dispatch, getState) => {
+  dispatch({payload: undefined, type: Constants.logoutDone})
+  dispatch({payload: undefined, type: CommonConstants.resetStore})
+
+  dispatch(navBasedOnLoginState())
+  dispatch(bootstrap())
+}
+
+const cancelLogin = (response: ?ResponseType) : AsyncAction => (dispatch, getState) => {
+  dispatch(navBasedOnLoginState())
+  if (response) {
+    engine().cancelRPC(response, InputCancelError)
   }
 }
 
-function loginSuccess (): AsyncAction {
-  return dispatch => {
-    dispatch({payload: undefined, type: Constants.loginDone})
+const addNewPhone = () : AsyncAction => (
+  addNewDevice(Constants.codePageDeviceRoleNewPhone)
+)
+
+const addNewComputer = () : AsyncAction => (
+  addNewDevice(Constants.codePageDeviceRoleNewComputer)
+)
+
+const addNewDevice = (kind: DeviceRole) : AsyncAction => (dispatch, getState) => {
+  // We can either be a newDevice or an existingDevice.  Here in the add a
+  // device flow, let's set ourselves to be a existingDevice.  If login()
+  // starts in the future, it'll set us back to being a newDevice then.
+  dispatch({
+    payload:
+      isMobile ? Constants.codePageDeviceRoleExistingPhone : Constants.codePageDeviceRoleExistingComputer,
+    type: Constants.setMyDeviceCodeState,
+  })
+
+  const onBack = response => {
     dispatch(loadDevices())
-    dispatch(bootstrap())
-  }
-}
-
-export function relogin (username: string, passphrase: string) : AsyncAction {
-  return dispatch => {
-    Types.loginLoginProvisionedDeviceRpc({
-      ...makeWaitingHandler(dispatch),
-      callback: (error, status) => {
-        if (error) {
-          const message = 'This device is no longer provisioned.'
-          dispatch({
-            error: true,
-            payload: {message},
-            type: Constants.loginDone,
-          })
-          dispatch(setLoginFromRevokedDevice(message))
-          dispatch(navigateTo([loginTab]))
-        } else {
-          dispatch(loginSuccess())
-        }
-      },
-      incomingCallMap: {
-        'keybase.1.secretUi.getPassphrase': ({pinentry: {type}}, response) => {
-          response.result({
-            passphrase,
-            storeSecret: true,
-          })
-        },
-      },
-      param: {
-        noPassphrasePrompt: false,
-        username,
-      },
-    })
-  }
-}
-
-export function logout () : AsyncAction {
-  return dispatch => {
-    Types.loginLogoutRpc({
-      ...makeWaitingHandler(dispatch),
-      callback: (error, response) => {
-        if (error) {
-          console.log(error)
-        } else {
-          dispatch(logoutDone())
-        }
-      },
-    })
-  }
-}
-
-export function logoutDone () : AsyncAction {
-  // We've logged out, let's check our current status
-  return (dispatch, getState) => {
-    dispatch({payload: undefined, type: Constants.logoutDone})
-    dispatch({payload: undefined, type: CommonConstants.resetStore})
-
-    dispatch(navBasedOnLoginState())
-    dispatch(bootstrap())
-  }
-}
-
-function cancelLogin (response: ?ResponseType) : AsyncAction {
-  return (dispatch, getState) => {
-    dispatch(navBasedOnLoginState())
+    dispatch(navigateTo([devicesTab]))
     if (response) {
       engine().cancelRPC(response, InputCancelError)
     }
   }
-}
 
-export function addNewPhone () : AsyncAction {
-  return addNewDevice(Constants.codePageDeviceRoleNewPhone)
-}
-
-export function addNewComputer () : AsyncAction {
-  return addNewDevice(Constants.codePageDeviceRoleNewComputer)
-}
-
-function addNewDevice (kind: DeviceRole) : AsyncAction {
-  return (dispatch, getState) => {
-    // We can either be a newDevice or an existingDevice.  Here in the add a
-    // device flow, let's set ourselves to be a existingDevice.  If login()
-    // starts in the future, it'll set us back to being a newDevice then.
-    dispatch({
-      payload:
-        isMobile ? Constants.codePageDeviceRoleExistingPhone : Constants.codePageDeviceRoleExistingComputer,
-      type: Constants.setMyDeviceCodeState,
-    })
-
-    const onBack = response => {
-      dispatch(loadDevices())
-      dispatch(navigateTo([devicesTab]))
-      if (response) {
-        engine().cancelRPC(response, InputCancelError)
-      }
+  const incomingCallMap = makeKex2IncomingMap(dispatch, getState, onBack, onBack)
+  incomingCallMap['keybase.1.provisionUi.chooseDeviceType'] = ({sessionID}, response: {result: (type: Types.DeviceType) => void}) => {
+    const deviceTypeMap: {[key: string]: any} = {
+      [Constants.codePageDeviceRoleNewComputer]: Types.CommonDeviceType.desktop,
+      [Constants.codePageDeviceRoleNewPhone]: Types.CommonDeviceType.mobile,
     }
+    let deviceType = deviceTypeMap[kind]
 
-    const incomingCallMap = makeKex2IncomingMap(dispatch, getState, onBack, onBack)
-    incomingCallMap['keybase.1.provisionUi.chooseDeviceType'] = ({sessionID}, response: {result: (type: Types.DeviceType) => void}) => {
-      const deviceTypeMap: {[key: string]: any} = {
-        [Constants.codePageDeviceRoleNewComputer]: Types.CommonDeviceType.desktop,
-        [Constants.codePageDeviceRoleNewPhone]: Types.CommonDeviceType.mobile,
-      }
-      let deviceType = deviceTypeMap[kind]
-
-      dispatch(setCodePageOtherDeviceRole(kind))
-      response.result(deviceType)
-    }
-
-    Types.deviceDeviceAddRpc({
-      ...makeWaitingHandler(dispatch),
-      callback: (ignoredError, response) => {
-        onBack()
-      },
-      incomingCallMap,
-    })
+    dispatch(setCodePageOtherDeviceRole(kind))
+    response.result(deviceType)
   }
+
+  Types.deviceDeviceAddRpc({
+    ...makeWaitingHandler(dispatch),
+    callback: (ignoredError, response) => onBack(),
+    incomingCallMap,
+  })
 }
 
-export function openAccountResetPage () : AsyncAction {
-  return () => {
-    openURL('https://keybase.io/#password-reset')
-  }
-}
+const openAccountResetPage = () : AsyncAction => () => openURL('https://keybase.io/#password-reset')
 
 type SimpleCB = () => void
-function makeKex2IncomingMap (dispatch, getState, onBack: SimpleCB, onProvisionerSuccess: SimpleCB) : Types.incomingCallMapType {
+const makeKex2IncomingMap = (dispatch, getState, onBack: SimpleCB, onProvisionerSuccess: SimpleCB) : Types.incomingCallMapType => {
   // FIXME (mbg): The above usage of React components in the action code causes
   // a module dependency which prevents HMR. We can't hot reload action code,
   // so when these views (or more likely, their subcomponents from
@@ -384,38 +332,36 @@ function makeKex2IncomingMap (dispatch, getState, onBack: SimpleCB, onProvisione
   // won't hot reload properly until we decouple these action effects from the
   // view class implementations.
 
-  function askForCodePage (cb, onBack) : AsyncAction {
-    return dispatch => {
-      const mapStateToProps = state => {
-        const {
-          mode, codeCountDown, textCode, qrCode,
-          myDeviceRole, otherDeviceRole, cameraBrokenMode,
-        } = state.login.codePage
-        return {
-          cameraBrokenMode,
-          codeCountDown,
-          mode,
-          myDeviceRole,
-          otherDeviceRole,
-          qrCode: qrCode ? qrCode.stringValue() : '',
-          textCode: textCode ? textCode.stringValue() : '',
-        }
+  const askForCodePage = (cb, onBack) : AsyncAction => dispatch => {
+    const mapStateToProps = state => {
+      const {
+        mode, codeCountDown, textCode, qrCode,
+        myDeviceRole, otherDeviceRole, cameraBrokenMode,
+      } = state.login.codePage
+      return {
+        cameraBrokenMode,
+        codeCountDown,
+        mode,
+        myDeviceRole,
+        otherDeviceRole,
+        qrCode: qrCode ? qrCode.stringValue() : '',
+        textCode: textCode ? textCode.stringValue() : '',
       }
-
-      // This can be appended on either loginTab or devicesTab.
-      dispatch(navigateAppend([{
-        props: {
-          doneRegistering: () => dispatch(doneRegistering()),
-          mapStateToProps,
-          onBack: onBack,
-          qrScanned: code => cb(code.data),
-          setCameraBrokenMode: broken => dispatch(setCameraBrokenMode(broken)),
-          setCodePageMode: mode => dispatch(setCodePageMode(mode)),
-          textEntered: text => cb(text),
-        },
-        selected: 'codePage',
-      }]))
     }
+
+    // This can be appended on either loginTab or devicesTab.
+    dispatch(navigateAppend([{
+      props: {
+        doneRegistering: () => dispatch(doneRegistering()),
+        mapStateToProps,
+        onBack: onBack,
+        qrScanned: code => cb(code.data),
+        setCameraBrokenMode: broken => dispatch(setCameraBrokenMode(broken)),
+        setCodePageMode: mode => dispatch(setCodePageMode(mode)),
+        textEntered: text => cb(text),
+      },
+      selected: 'codePage',
+    }]))
   }
 
   return {
@@ -448,9 +394,7 @@ function makeKex2IncomingMap (dispatch, getState, onBack: SimpleCB, onProvisione
       generateQRCode(dispatch, getState)
       dispatch(askForCodePage(phrase => { response.result({phrase, secret: null}) }, () => onBack(response)))
     },
-    'keybase.1.provisionUi.DisplaySecretExchanged': (param, response) => {
-      response.result()
-    },
+    'keybase.1.provisionUi.DisplaySecretExchanged': (param, response) => response.result(),
     'keybase.1.provisionUi.PromptNewDeviceName': ({existingDevices, errorMessage}, response) => {
       dispatch(navigateAppend([{
         props: {
@@ -462,9 +406,7 @@ function makeKex2IncomingMap (dispatch, getState, onBack: SimpleCB, onProvisione
         selected: 'setPublicName',
       }], [loginTab, 'login']))
     },
-    'keybase.1.provisionUi.ProvisioneeSuccess': (param, response) => {
-      response.result()
-    },
+    'keybase.1.provisionUi.ProvisioneeSuccess': (param, response) => response.result(),
     'keybase.1.provisionUi.ProvisionerSuccess': (param, response) => {
       response.result()
       onProvisionerSuccess()
@@ -536,4 +478,21 @@ function makeKex2IncomingMap (dispatch, getState, onBack: SimpleCB, onProvisione
       }
     },
   }
+}
+
+export {
+  addNewComputer,
+  addNewPhone,
+  doneRegistering,
+  login,
+  logout,
+  logoutDone,
+  navBasedOnLoginState,
+  openAccountResetPage,
+  relogin,
+  setDeletedSelf,
+  setLoginFromRevokedDevice,
+  setRevokedSelf,
+  submitForgotPassword,
+  updateForgotPasswordEmail,
 }

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -8,7 +8,7 @@ import openURL from '../../util/open-url'
 import {RPCError} from '../../util/errors'
 import {bootstrap, setInitialTab} from '../config'
 import {defaultModeForDeviceRoles, qrGenerate} from './provision-helpers'
-import {devicesTab, loginTab, profileTab} from '../../constants/tabs'
+import {devicesTab, loginTab, profileTab, isValidInitialTab} from '../../constants/tabs'
 import {isMobile} from '../../constants/platform'
 import {load as loadDevices} from '../devices'
 import {pathSelector, navigateTo, navigateAppend} from '../route-tree'
@@ -45,7 +45,7 @@ const navBasedOnLoginState = (): AsyncAction => (dispatch, getState) => {
       if (overrideLoggedInTab) {
         console.log('Loading overridden logged in tab')
         dispatch(navigateTo([overrideLoggedInTab]))
-      } else if (initialTab) {
+      } else if (initialTab && isValidInitialTab(initialTab)) {
         /// only do this once
         dispatch(setInitialTab(null))
         dispatch(navigateTo([initialTab]))

--- a/shared/constants/config.js
+++ b/shared/constants/config.js
@@ -2,37 +2,34 @@
 import {uniq} from 'lodash'
 import {runMode} from './platform'
 
+import type {Tab} from './tabs'
 import type {NoErrorTypedAction} from './types/flux'
 
-// Constants
-export const defaultKBFSPath = runMode === 'prod' ? '/keybase' : `/keybase.${runMode}`
-export const defaultPrivatePrefix = '/private/'
-export const defaultPublicPrefix = '/public/'
-
-// Actions
-export const daemonError = 'config:daemonError'
-export const globalError = 'config:globalError'
-export const globalErrorDismiss = 'config:globalErrorDismiss'
-export const statusLoaded = 'config:statusLoaded'
-export const configLoaded = 'config:configLoaded'
-export const extendedConfigLoaded = 'config:extendedConfigLoaded'
-export const bootstrapped = 'config:bootstrapped'
-export const bootstrapAttemptFailed = 'config:bootstrapAttemptFailed'
-export const bootstrapFailed = 'config:bootstrapFailed'
-export const bootstrapRetry = 'config:bootstrapRetry'
-export const updateFollowing = 'config:updateFollowing'
-export const setFollowing = 'config:setFollowing'
-export const setFollowers = 'config:setFollowers'
-
-export const readAppVersion = 'config:readAppVersion'
-
-export const changeKBFSPath = 'config:changeKBFSPath'
-
-export const MAX_BOOTSTRAP_TRIES = 3
-export const bootstrapRetryDelay = 10 * 1000
+// TODO remove action type constants. Type actions
+const MAX_BOOTSTRAP_TRIES = 3
+const bootstrapAttemptFailed = 'config:bootstrapAttemptFailed'
+const bootstrapFailed = 'config:bootstrapFailed'
+const bootstrapRetry = 'config:bootstrapRetry'
+const bootstrapRetryDelay = 10 * 1000
+const bootstrapped = 'config:bootstrapped'
+const changeKBFSPath = 'config:changeKBFSPath'
+const configLoaded = 'config:configLoaded'
+const daemonError = 'config:daemonError'
+const defaultKBFSPath = runMode === 'prod' ? '/keybase' : `/keybase.${runMode}`
+const defaultPrivatePrefix = '/private/'
+const defaultPublicPrefix = '/public/'
+const extendedConfigLoaded = 'config:extendedConfigLoaded'
+const globalError = 'config:globalError'
+const globalErrorDismiss = 'config:globalErrorDismiss'
+const readAppVersion = 'config:readAppVersion'
+const setFollowers = 'config:setFollowers'
+const setFollowing = 'config:setFollowing'
+const statusLoaded = 'config:statusLoaded'
+const updateFollowing = 'config:updateFollowing'
 
 export type DaemonError = NoErrorTypedAction<'config:daemonError', {daemonError: ?Error}>
 export type UpdateFollowing = NoErrorTypedAction<'config:updateFollowing', {username: string, isTracking: boolean}>
+export type SetInitialTab = NoErrorTypedAction<'config:setInitialTab', {tab: ?Tab}>
 
 export type BootStatus = 'bootStatusLoading'
   | 'bootStatusBootstrapped'
@@ -44,4 +41,27 @@ export function privateFolderWithUsers (users: Array<string>): string {
 
 export function publicFolderWithUsers (users: Array<string>): string {
   return `${defaultKBFSPath}${defaultPublicPrefix}${uniq(users).join(',')}`
+}
+
+export {
+  MAX_BOOTSTRAP_TRIES,
+  bootstrapAttemptFailed,
+  bootstrapFailed,
+  bootstrapRetry,
+  bootstrapRetryDelay,
+  bootstrapped,
+  changeKBFSPath,
+  configLoaded,
+  daemonError,
+  defaultKBFSPath,
+  defaultPrivatePrefix,
+  defaultPublicPrefix,
+  extendedConfigLoaded,
+  globalError,
+  globalErrorDismiss,
+  readAppVersion,
+  setFollowers,
+  setFollowing,
+  statusLoaded,
+  updateFollowing,
 }

--- a/shared/constants/tabs.js
+++ b/shared/constants/tabs.js
@@ -1,20 +1,23 @@
 // @flow
+import {isMobile} from './platform'
+
+const chatTab = 'tabs:chatTab'
+const devicesTab = 'tabs:devicesTab'
+const folderTab = 'tabs:folderTab'
+const loginTab = 'tabs:loginTab'
+const peopleTab = 'tabs:peopleTab'
+const profileTab = 'tabs:profileTab'
+const searchTab = 'tabs:searchTab'
+const settingsTab = 'tabs:settingsTab'
+
 type ChatTab = 'tabs:chatTab'
-export const chatTab = 'tabs:chatTab'
-type LoginTab = 'tabs:loginTab'
-export const loginTab = 'tabs:loginTab'
-type ProfileTab = 'tabs:profileTab'
-export const profileTab = 'tabs:profileTab'
-type PeopleTab = 'tabs:peopleTab'
-export const peopleTab = 'tabs:peopleTab'
 type DevicesTab = 'tabs:devicesTab'
-export const devicesTab = 'tabs:devicesTab'
 type FolderTab = 'tabs:folderTab'
-export const folderTab = 'tabs:folderTab'
+type LoginTab = 'tabs:loginTab'
+type PeopleTab = 'tabs:peopleTab'
+type ProfileTab = 'tabs:profileTab'
 type SearchTab = 'tabs:searchTab'
-export const searchTab = 'tabs:searchTab'
 type SettingsTab = 'tabs:settingsTab'
-export const settingsTab = 'tabs:settingsTab'
 
 export type Tab = ChatTab
 | DevicesTab
@@ -24,3 +27,23 @@ export type Tab = ChatTab
 | ProfileTab
 | SettingsTab
 | SearchTab
+
+function isValidInitialTab (tab: ?Tab) {
+  if (isMobile) {
+    return [chatTab, folderTab, profileTab, searchTab, settingsTab].includes(tab)
+  } else {
+    return [chatTab, folderTab, profileTab, devicesTab, searchTab, settingsTab].includes(tab)
+  }
+}
+
+export {
+  chatTab,
+  devicesTab,
+  folderTab,
+  isValidInitialTab,
+  loginTab,
+  peopleTab,
+  profileTab,
+  searchTab,
+  settingsTab,
+}


### PR DESCRIPTION
There was a bug where if you were in the logintab then quit, when you started up it'd try and load you back into the logintab. Instead we have a whitelist of valid tabs you can reload

I also cleaned up the config and login actions (just using arrows and cleaning up some noise) in the first 2 commits. So this fix is really in the 3rd commit

@keybase/react-hackers 