### PR TITLE
Pass ClientType in Context, allow PGP select to use GPGUI properly

### DIFF
--- a/go/engine/context.go
+++ b/go/engine/context.go
@@ -6,6 +6,7 @@ package engine
 import (
 	"fmt"
 	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
 )
 
@@ -22,6 +23,12 @@ type Context struct {
 	LoginContext libkb.LoginContext
 	NetContext   context.Context
 	SaltpackUI   libkb.SaltpackUI
+
+	// Usually set to `NONE`, meaning none specified.
+	// But if we know it, specify the end client type here
+	// since some things like GPG shell-out work differently
+	// depending.
+	ClientType keybase1.ClientType
 
 	SessionID int
 }

--- a/go/engine/gpg_import_key.go
+++ b/go/engine/gpg_import_key.go
@@ -184,6 +184,8 @@ func (e *GPGImportKeyEngine) Run(ctx *Context) (err error) {
 	if err != nil {
 		e.G().Log.Warning("error getting TTY for GPG: %s", err)
 		err = nil
+	} else {
+		gpg.SetTTY(tty)
 	}
 
 	bundle, err := gpg.ImportKey(true, *(selected.GetFingerprint()), tty)

--- a/go/engine/gpg_import_key.go
+++ b/go/engine/gpg_import_key.go
@@ -184,8 +184,6 @@ func (e *GPGImportKeyEngine) Run(ctx *Context) (err error) {
 	if err != nil {
 		e.G().Log.Warning("error getting TTY for GPG: %s", err)
 		err = nil
-	} else {
-		gpg.SetTTY(tty)
 	}
 
 	bundle, err := gpg.ImportKey(true, *(selected.GetFingerprint()), tty)

--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -333,11 +333,11 @@ func (e *PGPKeyImportEngine) push(ctx *Context) (err error) {
 	e.G().Log.Debug("+ PGP::Push")
 	if e.arg.GPGFallback {
 		e.bundle.GPGFallbackKey = libkb.NewGPGKey(
-			nil,
+			e.G(),
 			e.bundle.GetFingerprintP(),
 			e.bundle.GetKID(),
 			ctx.GPGUI,
-			keybase1.ClientType_CLI)
+			ctx.ClientType)
 	}
 	e.del.NewKey = e.bundle
 	e.del.EncodedPrivateKey = e.epk

--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -332,7 +332,12 @@ func (e *PGPKeyImportEngine) prepareSecretPush(ctx *Context) error {
 func (e *PGPKeyImportEngine) push(ctx *Context) (err error) {
 	e.G().Log.Debug("+ PGP::Push")
 	if e.arg.GPGFallback {
-		e.bundle.InitGPGKey()
+		e.bundle.GPGFallbackKey = libkb.NewGPGKey(
+			nil,
+			e.bundle.GetFingerprintP(),
+			e.bundle.GetKID(),
+			ctx.GPGUI,
+			keybase1.ClientType_CLI)
 	}
 	e.del.NewKey = e.bundle
 	e.del.EncodedPrivateKey = e.epk

--- a/go/libkb/gpg_cli.go
+++ b/go/libkb/gpg_cli.go
@@ -358,6 +358,8 @@ func (g *GpgCLI) MakeCmd(args []string, tty string) *exec.Cmd {
 	if tty != "" {
 		ret.Env = append(os.Environ(), "GPG_TTY="+tty)
 		g.logUI.Debug("| setting GPG_TTY=%s", tty)
+	} else {
+		g.logUI.Debug("| no tty provided, GPG_TTY will not be changed")
 	}
 	return ret
 }

--- a/go/libkb/log_send_test.go
+++ b/go/libkb/log_send_test.go
@@ -1,11 +1,11 @@
 package libkb
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
-	"os"
 
 	"github.com/keybase/client/go/logger"
 )
@@ -49,9 +49,9 @@ func TestTailMulti(t *testing.T) {
 	atime := time.Date(2017, time.March, 2, 4, 5, 6, 0, time.UTC)
 	// Force the fact the logs are from different times, since
 	// on windows on CI, we can't get the mtime set on git checkout.
-	for i, sffx := range([]string{"", ".1", ".2"}) {
-		mtime := time.Date(2017, time.February, 1, 3, (60-5*i), 0, 0, time.UTC)
-		if err := os.Chtimes(stem + sffx, atime, mtime);  err != nil {
+	for i, sffx := range []string{"", ".1", ".2"} {
+		mtime := time.Date(2017, time.February, 1, 3, (60 - 5*i), 0, 0, time.UTC)
+		if err := os.Chtimes(stem+sffx, atime, mtime); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -84,7 +84,7 @@ func (d *Service) RegisterProtocols(srv *rpc.Server, xp rpc.Transporter, connID 
 		keybase1.LogProtocol(NewLogHandler(xp, logReg, g)),
 		keybase1.LoginProtocol(NewLoginHandler(xp, g)),
 		keybase1.NotifyCtlProtocol(NewNotifyCtlHandler(xp, connID, g)),
-		keybase1.PGPProtocol(NewPGPHandler(xp, g)),
+		keybase1.PGPProtocol(NewPGPHandler(xp, connID, g)),
 		keybase1.ReachabilityProtocol(newReachabilityHandler(xp, g, d.reachability)),
 		keybase1.RevokeProtocol(NewRevokeHandler(xp, g)),
 		keybase1.ProveProtocol(NewProveHandler(xp, g)),

--- a/go/service/pgp.go
+++ b/go/service/pgp.go
@@ -47,12 +47,14 @@ func (u *RemotePgpUI) Finished(ctx context.Context, sessionID int) error {
 type PGPHandler struct {
 	*BaseHandler
 	libkb.Contextified
+	connID libkb.ConnectionID
 }
 
-func NewPGPHandler(xp rpc.Transporter, g *libkb.GlobalContext) *PGPHandler {
+func NewPGPHandler(xp rpc.Transporter, id libkb.ConnectionID, g *libkb.GlobalContext) *PGPHandler {
 	return &PGPHandler{
 		BaseHandler:  NewBaseHandler(xp),
 		Contextified: libkb.NewContextified(g),
+		connID:       id,
 	}
 }
 
@@ -258,6 +260,12 @@ func (h *PGPHandler) PGPSelect(nctx context.Context, sarg keybase1.PGPSelectArg)
 		LoginUI:    h.getLoginUI(sarg.SessionID),
 		SessionID:  sarg.SessionID,
 		NetContext: nctx,
+
+		// TODO: Pull this type from the connectionID, rather than always
+		// hardcoding CLI, which is all we use now. Note that if we did this, we'd
+		// have to send HelloIAm RPCs in Main() for the CLI commands. A bit of an
+		// annoying TODO, so postpone until we have a Desktop use for PGPSelect.
+		ClientType: keybase1.ClientType_CLI,
 	}
 	return engine.RunEngine(gpg, ctx)
 }


### PR DESCRIPTION
Keeping tty in GpgClient gives us a proper tty value for GPG_TTY when doing SignToString on GPGKey.

The TTY saved is one from `func (c GpgUiClient) GetTTY` which calls into cli with `keybase.1.gpgUi.getTTY`, because while importing we are already on the service, where there is no tty.