### PR TITLE
packaging: kbnm version default to keybase version

### DIFF
--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -74,8 +74,9 @@ if [ "$kbfs_version" = "" ]; then
 fi
 
 if [ "$kbnm_version" = "" ]; then
-  echo "Specify KBNM_VERSION for use (Github release/tag)"
-  exit 1
+  # TODO: Make KBNM_VERSION be injected during build.
+  kbnm_version="$keybase_version"
+  echo "KBNM_VERSION unspecified, defaulting to: $kbnm_version"
 fi
 
 # if [ "$comment" = "" ]; then


### PR DESCRIPTION
Right now it's skipping choosing a version and defaulting to `dev`.

We need to inject `KBNM_VERSION` env from the build process, same as we do for the other versions.

For now, this will use `KEYBASE_VERSION` which is pulled from the same repo so the timestamp/commit in that version is relevant.