### PR TITLE
Emoji name case insensitive

### DIFF
--- a/shared/common-adapters/emoji.desktop.js
+++ b/shared/common-adapters/emoji.desktop.js
@@ -12,10 +12,10 @@ const backgroundImageFn = (set: string, sheetSize: string) => emojiSet
 
 // Size 0 is cause we want the native emoji for copy/paste and not for rendering
 const EmojiWrapper = (props: Props) => {
-  const emojiText = String(props.children)
+  const {emojiName, size} = props
   return (
-    <Emoji {...props} emoji={emojiText} backgroundImageFn={backgroundImageFn}>
-      <Emoji emoji={emojiText} size={0} native={true} />
+    <Emoji emoji={emojiName} size={size} backgroundImageFn={backgroundImageFn}>
+      <Emoji emoji={emojiName} size={0} native={true} />
     </Emoji>
   )
 }

--- a/shared/common-adapters/emoji.js.flow
+++ b/shared/common-adapters/emoji.js.flow
@@ -3,7 +3,7 @@ import {Component} from 'react'
 
 export type Props = {
   size?: number,
-  children?: Array<string>,
+  emojiName: string,
 }
 
 declare function backgroundImageFn (set: string, sheetSize: string): string

--- a/shared/common-adapters/emoji.native.js
+++ b/shared/common-adapters/emoji.native.js
@@ -6,9 +6,9 @@ import Text from './text'
 import type {Props} from './emoji'
 
 const EmojiWrapper = (props: Props) => {
-  const emojiName = props.children ? props.children.join('') : ''
+  const {emojiName, size} = props
   const emojiVariantSuffx = '\ufe0f'  // see http://mts.io/2015/04/21/unicode-symbol-render-text-emoji/
-  return <Text type='Body' style={{fontSize: props.size}}>{emojiIndexByName[emojiName] + emojiVariantSuffx}</Text>
+  return <Text type='Body' style={{fontSize: size}}>{emojiIndexByName[emojiName] + emojiVariantSuffx}</Text>
 }
 
 export default EmojiWrapper

--- a/shared/common-adapters/markdown.desktop.js
+++ b/shared/common-adapters/markdown.desktop.js
@@ -50,9 +50,9 @@ const quoteStyle = {borderLeft: `3px solid ${globalColors.lightGrey2}`, paddingL
 function previewCreateComponent (type, key, children, options) {
   switch (type) {
     case 'emoji':
-      return <EmojiIfExists size={13} key={key} style={neutralPreviewStyle}>{children}</EmojiIfExists>
+      return <EmojiIfExists emojiName={String(children)} size={13} key={key} style={neutralPreviewStyle} />
     case 'native-emoji':
-      return <Emoji size={16} key={key}>{children}</Emoji>
+      return <Emoji emojiName={String(children)} size={16} key={key} />
     default:
       return <Text type='BodySmall' key={key} style={neutralPreviewStyle}>{children}</Text>
   }
@@ -77,9 +77,9 @@ function messageCreateComponent (type, key, children, options) {
     case 'strike':
       return <Text type='Body' key={key} style={strikeStyle}>{children}</Text>
     case 'emoji':
-      return <EmojiIfExists size={16} key={key}>{children}</EmojiIfExists>
+      return <EmojiIfExists emojiName={String(children)} size={16} key={key} />
     case 'native-emoji':
-      return <Emoji size={16} key={key}>{children}</Emoji>
+      return <Emoji emojiName={String(children)} size={16} key={key} />
     case 'quote-block':
       return <Box key={key} style={quoteStyle}>{children}</Box>
   }

--- a/shared/common-adapters/markdown.native.js
+++ b/shared/common-adapters/markdown.native.js
@@ -49,9 +49,9 @@ function previewCreateComponent (style) {
       case 'markup':
         return <Text type='Body' key={key} lineClamp={1} style={style}>{children}</Text>
       case 'emoji':
-        return <EmojiIfExists key={key}>{children}</EmojiIfExists>
+        return <EmojiIfExists emojiName={String(children)} size={16} key={key} />
       case 'native-emoji':
-        return <Emoji key={key}>{children}</Emoji>
+        return <Emoji emojiName={String(children)} size={16} key={key} />
       default:
         return <Text type='Body' key={key} style={{...neutralStyle, ...style}}>{children}</Text>
     }
@@ -82,9 +82,9 @@ function messageCreateComponent (style) {
       case 'strike':
         return <Text type='Body' key={key} style={strikeStyle}>{children}</Text>
       case 'emoji':
-        return <EmojiIfExists key={key}>{children}</EmojiIfExists>
+        return <EmojiIfExists emojiName={String(children)} key={key} />
       case 'native-emoji':
-        return <Emoji key={key}>{children}</Emoji>
+        return <Emoji emojiName={String(children)} key={key} />
       case 'quote-block':
         return <Box key={key} style={quoteBlockStyle}>{children}</Box>
     }

--- a/shared/common-adapters/markdown.shared.js
+++ b/shared/common-adapters/markdown.shared.js
@@ -39,8 +39,8 @@ export function parseMarkdown (markdown: string = '', markdownCreateComponent: M
 
 export class EmojiIfExists extends PureComponent<void, EmojiProps & {style?: Object}, void> {
   render () {
-    const emojiName = (this.props.children && this.props.children.join('')) || ''
-    const exists = !!emojiIndexByName[emojiName]
-    return exists ? <Emoji {...this.props} /> : <Text type='Body' style={this.props.style}>{emojiName}</Text>
+    const emojiNameLower = this.props.emojiName.toLowerCase()
+    const exists = !!emojiIndexByName[emojiNameLower]
+    return exists ? <Emoji emojiName={emojiNameLower} size={this.props.size} /> : <Text type='Body' style={this.props.style}>{this.props.emojiName}</Text>
   }
 }


### PR DESCRIPTION
We were parsing props.children a few times. We can parse once into emojiName and pass that through to the emoji components.

Properly handles `:heart:` or `:Heart:` or `:HEART:` for :heart:
If the emoji name doesn't exist, it retains the case, so :Blah: will properly come through as :Blah:

