### PR TITLE
Pull non-summarized MaxMsgs

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -3,7 +3,6 @@ package chat
 import (
 	"errors"
 	"fmt"
-	"runtime/debug"
 
 	"strings"
 
@@ -457,8 +456,6 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, query *chat1.G
 		rquery.SummarizeMaxMsgs = false
 	}
 
-	s.logStack(ctx)
-
 	ib, err := s.getChatInterface().GetInboxRemote(ctx, chat1.GetInboxRemoteArg{
 		Query:      &rquery,
 		Pagination: p,
@@ -472,12 +469,6 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, query *chat1.G
 		ConvsUnverified: ib.Inbox.Full().Conversations,
 		Pagination:      ib.Inbox.Full().Pagination,
 	}, ib.RateLimit, nil
-}
-
-func (s *HybridInboxSource) logStack(ctx context.Context) {
-	for _, line := range strings.Split(string(debug.Stack()), "\n") {
-		s.Debug(ctx, "@@@ %s", line)
-	}
 }
 
 func (s *HybridInboxSource) Read(ctx context.Context, uid gregor1.UID,

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 
 	"strings"
 
@@ -301,7 +302,7 @@ func (b *baseInboxSource) getInboxQueryLocalToRemote(ctx context.Context,
 	rquery.ConvIDs = lquery.ConvIDs
 	rquery.OneChatTypePerTLF = lquery.OneChatTypePerTLF
 	rquery.Status = lquery.Status
-	rquery.SummarizeMaxMsgs = true
+	rquery.SummarizeMaxMsgs = false
 
 	return rquery, info, nil
 }
@@ -448,13 +449,15 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, query *chat1.G
 	if query == nil {
 		rquery = chat1.GetInboxQuery{
 			ComputeActiveList: true,
-			SummarizeMaxMsgs:  true,
+			SummarizeMaxMsgs:  false,
 		}
 	} else {
 		rquery = *query
 		rquery.ComputeActiveList = true
-		rquery.SummarizeMaxMsgs = true
+		rquery.SummarizeMaxMsgs = false
 	}
+
+	s.logStack(ctx)
 
 	ib, err := s.getChatInterface().GetInboxRemote(ctx, chat1.GetInboxRemoteArg{
 		Query:      &rquery,
@@ -469,6 +472,12 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, query *chat1.G
 		ConvsUnverified: ib.Inbox.Full().Conversations,
 		Pagination:      ib.Inbox.Full().Pagination,
 	}, ib.RateLimit, nil
+}
+
+func (s *HybridInboxSource) logStack(ctx context.Context) {
+	for _, line := range strings.Split(string(debug.Stack()), "\n") {
+		s.Debug(ctx, "@@@ %s", line)
+	}
 }
 
 func (s *HybridInboxSource) Read(ctx context.Context, uid gregor1.UID,
@@ -804,7 +813,7 @@ func (s *localizerPipeline) getMessagesOffline(ctx context.Context, convID chat1
 		return nil, chat1.ConversationErrorType_LOCALMAXMESSAGENOTFOUND, err
 	}
 
-	// Make sure we legit msgs
+	// Make sure we got legit msgs
 	var foundMsgs []chat1.MessageUnboxed
 	for _, msg := range res {
 		if msg != nil {
@@ -820,8 +829,33 @@ func (s *localizerPipeline) getMessagesOffline(ctx context.Context, convID chat1
 	return foundMsgs, chat1.ConversationErrorType_MISC, nil
 }
 
+// fillSummaries uses MaxMsgs to fill in MaxMsgSummaries.
+// After this call MaxMsgSummaries is a superset of MaxMsgs.
+func (s *localizerPipeline) fillSummaries(ctx context.Context, conversationRemote *chat1.Conversation) {
+	summaries := make(map[chat1.MessageID]chat1.MessageSummary)
+
+	// Collect the existing summaries
+	for _, m := range conversationRemote.MaxMsgSummaries {
+		summaries[m.MsgID] = m
+	}
+
+	// Collect the locally-grown summaries
+	for _, m := range conversationRemote.MaxMsgs {
+		summaries[m.GetMessageID()] = m.Summary()
+	}
+
+	// Insert all the summaries
+	conversationRemote.MaxMsgSummaries = nil
+	for _, m := range summaries {
+		conversationRemote.MaxMsgSummaries = append(conversationRemote.MaxMsgSummaries, m)
+	}
+}
+
 func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor1.UID,
 	conversationRemote chat1.Conversation) (conversationLocal chat1.ConversationLocal) {
+
+	// Fill MaxMsgSummaries from MaxMsgs.
+	s.fillSummaries(ctx, &conversationRemote)
 
 	unverifiedTLFName := getUnverifiedTlfNameForErrors(conversationRemote)
 	s.Debug(ctx, "localizing: TLF: %s convID: %s offline: %v", unverifiedTLFName,
@@ -865,12 +899,19 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		}
 	}
 
-	// Fetch max messages unboxed, using either a custom function or through
-	// the conversation source configured in the global context
-	var err error
-	if s.offline {
-		msgs, errTyp, err := s.getMessagesOffline(ctx, conversationRemote.GetConvID(),
-			uid, conversationRemote.MaxMsgSummaries, conversationRemote.Metadata.FinalizeInfo)
+	if len(conversationRemote.MaxMsgs) == 0 {
+		// Fetch max messages unboxed, using either a custom function or through
+		// the conversation source configured in the global context
+		var err error
+		errTyp := chat1.ConversationErrorType_MISC
+		var msgs []chat1.MessageUnboxed
+		if s.offline {
+			msgs, errTyp, err = s.getMessagesOffline(ctx, conversationRemote.GetConvID(),
+				uid, conversationRemote.MaxMsgSummaries, conversationRemote.Metadata.FinalizeInfo)
+		} else {
+			msgs, err = s.G().ConvSource.GetMessages(ctx, conversationRemote.Metadata.ConversationID,
+				uid, utils.PluckMessageIDs(conversationRemote.MaxMsgSummaries), conversationRemote.Metadata.FinalizeInfo)
+		}
 		if err != nil {
 			convErr := s.checkRekeyError(ctx, err, conversationRemote, unverifiedTLFName)
 			if convErr != nil {
@@ -885,19 +926,16 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		}
 		conversationLocal.MaxMessages = msgs
 	} else {
-		conversationLocal.MaxMessages, err = s.G().ConvSource.GetMessages(ctx,
-			conversationRemote.Metadata.ConversationID, uid, utils.PluckMessageIDs(conversationRemote.MaxMsgSummaries), conversationRemote.Metadata.FinalizeInfo)
+		// Use the attached MaxMsgs
+		msgs, err := s.G().ConvSource.GetMessagesWithRemotes(ctx, conversationRemote.Metadata.ConversationID,
+			uid, conversationRemote.MaxMsgs, conversationRemote.Metadata.FinalizeInfo)
 		if err != nil {
-			convErr := s.checkRekeyError(ctx, err, conversationRemote, unverifiedTLFName)
-			if convErr != nil {
-				conversationLocal.Error = convErr
-				return conversationLocal
-			}
-
 			conversationLocal.Error = chat1.NewConversationErrorLocal(
-				err.Error(), conversationRemote, s.isErrPermanent(err), unverifiedTLFName, chat1.ConversationErrorType_MISC, nil)
+				err.Error(), conversationRemote, s.isErrPermanent(err), unverifiedTLFName,
+				chat1.ConversationErrorType_MISC, nil)
 			return conversationLocal
 		}
+		conversationLocal.MaxMessages = msgs
 	}
 
 	var maxValidID chat1.MessageID
@@ -984,6 +1022,7 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		uloader = s.G().GetUPAKLoader()
 	}
 
+	var err error
 	conversationLocal.Info.WriterNames, conversationLocal.Info.ReaderNames, err = utils.ReorderParticipants(
 		ctx,
 		uloader,

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -30,6 +30,8 @@ type ConversationSource interface {
 	PullLocalOnly(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
 		query *chat1.GetThreadQuery, p *chat1.Pagination) (chat1.ThreadView, error)
 	GetMessages(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgIDs []chat1.MessageID, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
+	GetMessagesWithRemotes(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
+		msgs []chat1.MessageBoxed, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
 	Clear(convID chat1.ConversationID, uid gregor1.UID) error
 	TransformSupersedes(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageUnboxed, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
 

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -406,3 +406,34 @@ func PluckMessageIDs(msgs []chat1.MessageSummary) []chat1.MessageID {
 	}
 	return res
 }
+
+// UniqueifyMessageIDs removes duplicates and returns a presence map.
+func UniqueifyMessageIDs(ids []chat1.MessageID) ([]chat1.MessageID, map[chat1.MessageID]bool) {
+	var res []chat1.MessageID
+	m := make(map[chat1.MessageID]bool)
+	for _, id := range ids {
+		if !m[id] {
+			m[id] = true
+			res = append(res, id)
+		}
+	}
+	return res, m
+}
+
+func GetBoxedIDs(msgs []chat1.MessageBoxed) ([]chat1.MessageID, map[chat1.MessageID]bool) {
+	var ids []chat1.MessageID
+	for _, m := range msgs {
+		ids = append(ids, m.GetMessageID())
+	}
+	return UniqueifyMessageIDs(ids)
+}
+
+func GetUnboxedIDs(msgs []*chat1.MessageUnboxed) ([]chat1.MessageID, map[chat1.MessageID]bool) {
+	var ids []chat1.MessageID
+	for _, m := range msgs {
+		if m != nil {
+			ids = append(ids, m.GetMessageID())
+		}
+	}
+	return UniqueifyMessageIDs(ids)
+}


### PR DESCRIPTION
Always pull non-summarized MaxMessages. Seems like the summaries come down as well. This should work as long as at least one of `MaxMsgs` or `MaxMsgsSummaries` comes down.

