### PR TITLE
kbnm: Add "query" method, refactor with unit tests

### DIFF
--- a/go/kbnm/handler.go
+++ b/go/kbnm/handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -14,25 +15,41 @@ var errMissingField = errors.New("missing field")
 
 var errUserNotFound = errors.New("user not found")
 
-func handle(req *Request) error {
-	switch req.Method {
-	case "chat":
-		return handleChat(req)
-	case "query":
-		return handleQuery(req)
-	default:
-		return errInvalidMethod
-	}
-}
-
 // findKeybaseBinary returns the path to the Keybase binary, if it finds it.
 func findKeybaseBinary() (string, error) {
 	// FIXME: Get the absolute path without a filled PATH var somehow?
 	return "/usr/local/bin/keybase", nil
 }
 
+func execRunner(cmd *exec.Cmd) error {
+	return cmd.Run()
+}
+
+// Handler returns a request handler.
+func Handler() *handler {
+	return &handler{
+		Run: execRunner,
+	}
+}
+
+type handler struct {
+	// Run wraps the equivalent of cmd.Run(), allowing for mocking
+	Run func(cmd *exec.Cmd) error
+}
+
+// Handle accepts a request, handles it, and returns an optional result if there was no error
+func (h *handler) Handle(req *Request) (interface{}, error) {
+	switch req.Method {
+	case "chat":
+		return nil, h.handleChat(req)
+	case "query":
+		return h.handleQuery(req)
+	}
+	return nil, errInvalidMethod
+}
+
 // handleChat sends a chat message to a user.
-func handleChat(req *Request) error {
+func (h *handler) handleChat(req *Request) error {
 	if req.Body == "" || req.To == "" {
 		return errMissingField
 	}
@@ -47,29 +64,38 @@ func handleChat(req *Request) error {
 
 	// TODO: Check/convert status code more precisely? Maybe return stdout as
 	// part of the error if there is one?
-	err = cmd.Run()
+	err = h.Run(cmd)
 
 	return err
 }
 
+type resultQuery struct {
+	Sigs []struct {
+		Statement string `json:"statement"`
+	} `json:"sigs"`
+}
+
 // handleQuery searches whether a user is present in Keybase.
-func handleQuery(req *Request) error {
+func (h *handler) handleQuery(req *Request) (*resultQuery, error) {
 	if req.To == "" {
-		return errMissingField
+		return nil, errMissingField
 	}
 
 	binPath, err := findKeybaseBinary()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var out bytes.Buffer
 	cmd := exec.Command(binPath, "sigs", "list", "--type=self", "--json", req.To)
 	cmd.Stdout = &out
 
-	err = cmd.Run()
+	err = h.Run(cmd)
 
-	fmt.Println("out:", out.String())
+	fmt.Println("parsing: ", out.String())
 
-	return err
+	result := &resultQuery{}
+	json.Unmarshal(out.Bytes(), &result.Sigs)
+
+	return result, err
 }

--- a/go/kbnm/handler.go
+++ b/go/kbnm/handler.go
@@ -1,48 +1,75 @@
 package main
 
 import (
+	"bytes"
 	"errors"
-	"io"
+	"fmt"
 	"os/exec"
+	"strings"
 )
 
 var errInvalidMethod = errors.New("invalid method")
 
 var errMissingField = errors.New("missing field")
 
+var errUserNotFound = errors.New("user not found")
+
 func handle(req *Request) error {
 	switch req.Method {
 	case "chat":
 		return handleChat(req)
+	case "query":
+		return handleQuery(req)
 	default:
 		return errInvalidMethod
 	}
 }
 
+// findKeybaseBinary returns the path to the Keybase binary, if it finds it.
+func findKeybaseBinary() (string, error) {
+	// FIXME: Get the absolute path without a filled PATH var somehow?
+	return "/usr/local/bin/keybase", nil
+}
+
+// handleChat sends a chat message to a user.
 func handleChat(req *Request) error {
 	if req.Body == "" || req.To == "" {
 		return errMissingField
 	}
 
-	// FIXME: Get the absolute path without a filled PATH var somehow?
-	cmd := exec.Command("/usr/local/bin/keybase", "chat", "send", "--private", req.To)
-
-	// Write message body over STDIN to avoid running up against bugs with
-	// super long messages.
-	stdin, err := cmd.StdinPipe()
+	binPath, err := findKeybaseBinary()
 	if err != nil {
 		return err
 	}
 
-	if err := cmd.Start(); err != nil {
-		stdin.Close()
-		return err
-	}
-
-	io.WriteString(stdin, req.Body)
-	stdin.Close()
+	cmd := exec.Command(binPath, "chat", "send", "--private", req.To)
+	cmd.Stdin = strings.NewReader(req.Body)
 
 	// TODO: Check/convert status code more precisely? Maybe return stdout as
 	// part of the error if there is one?
-	return cmd.Wait()
+	err = cmd.Run()
+
+	return err
+}
+
+// handleQuery searches whether a user is present in Keybase.
+func handleQuery(req *Request) error {
+	if req.To == "" {
+		return errMissingField
+	}
+
+	binPath, err := findKeybaseBinary()
+	if err != nil {
+		return err
+	}
+
+	var out bytes.Buffer
+	cmd := exec.Command(binPath, "sigs", "list", "--type=self", "--json", req.To)
+	cmd.Stdout = &out
+
+	err = cmd.Run()
+
+	fmt.Println("out:", out.String())
+
+	return err
 }

--- a/go/kbnm/handler.go
+++ b/go/kbnm/handler.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -91,8 +90,6 @@ func (h *handler) handleQuery(req *Request) (*resultQuery, error) {
 	cmd.Stdout = &out
 
 	err = h.Run(cmd)
-
-	fmt.Println("parsing: ", out.String())
 
 	result := &resultQuery{}
 	json.Unmarshal(out.Bytes(), &result.Sigs)

--- a/go/kbnm/handler_test.go
+++ b/go/kbnm/handler_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestHandlerChat(t *testing.T) {
+	h := Handler()
+
+	var ranCmd string
+	h.Run = func(cmd *exec.Cmd) error {
+		ranCmd = strings.Join(cmd.Args, " ")
+		return nil
+	}
+
+	req := &Request{
+		Method: "chat",
+		Body:   "test message",
+		To:     "testkeybaseuser",
+	}
+
+	if _, err := h.Handle(req); err != nil {
+		t.Errorf("request failed: %q", err)
+	}
+
+	if ranCmd != "/usr/local/bin/keybase chat send --private testkeybaseuser" {
+		t.Errorf("unexpected command: %q", ranCmd)
+	}
+}
+
+const queryResponse = `[
+	{
+		"seqno": 1,
+		"sig_id": "c3f2b7c2b92e7e53b8d67542695ec26f5a8ea3b3abaa07764b14e453434471180f",
+		"type": "self",
+		"ctime": 1394236029,
+		"revoked": false,
+		"active": true,
+		"key_fingerprint": "9fcea980ccfd3c13e11e88a9350687d17e81fd68",
+		"statement": "testkeybaseuser"
+	}
+]`
+
+func TestHandlerQuery(t *testing.T) {
+	h := Handler()
+
+	var ranCmd string
+	h.Run = func(cmd *exec.Cmd) error {
+		ranCmd = strings.Join(cmd.Args, " ")
+		io.WriteString(cmd.Stdout, queryResponse)
+		return nil
+	}
+
+	req := &Request{
+		Method: "query",
+		To:     "testkeybaseuser",
+	}
+
+	res, err := h.Handle(req)
+	if err != nil {
+		t.Errorf("request failed: %q", err)
+	}
+	result, ok := res.(*resultQuery)
+	if !ok {
+		t.Errorf("result is not *resultQuery: %T", res)
+	}
+
+	if ranCmd != "/usr/local/bin/keybase sigs list --type=self --json testkeybaseuser" {
+		t.Errorf("unexpected command: %q", ranCmd)
+	}
+
+	if result == nil {
+		t.Fatal("result is nil")
+	}
+
+	if len(result.Sigs) != 1 || result.Sigs[0].Statement != "testkeybaseuser" {
+		t.Errorf("invalid result value: %q", result)
+	}
+}

--- a/go/kbnm/main.go
+++ b/go/kbnm/main.go
@@ -18,7 +18,7 @@ type Response struct {
 	Client  int         `json:"client"`
 	Status  string      `json:"status"`
 	Message string      `json:"message"`
-	Result  interface{} `json:"result",omitempty`
+	Result  interface{} `json:"result,omitempty"`
 }
 
 // Request to the kbnm service
@@ -32,10 +32,45 @@ type Request struct {
 var plainFlag = flag.Bool("plain", false, "newline-delimited JSON IO, no length prefix")
 var versionFlag = flag.Bool("version", false, "print the version and exit")
 
+// process consumes a single message
+func process(h *handler, in nativemessaging.JSONDecoder, out nativemessaging.JSONEncoder) error {
+	var resp Response
+	var req Request
+
+	// If input fails to parse, we can't guarantee future inputs will
+	// get into a parseable state so we abort after sending an error
+	// response.
+	abortErr := in.Decode(&req)
+
+	var err error
+	if abortErr == nil {
+		resp.Result, err = h.Handle(&req)
+	}
+
+	if err == io.EOF {
+		// Closed
+		return err
+	} else if err != nil {
+		resp.Status = "error"
+		resp.Message = err.Error()
+	} else {
+		// Success
+		resp.Status = "ok"
+	}
+	resp.Client = req.Client
+
+	err = out.Encode(resp)
+	if err != nil {
+		// TODO: Log this somewhere?
+		fmt.Fprintf(os.Stderr, "error: %s", err)
+		os.Exit(1)
+	}
+
+	return abortErr
+}
+
 func main() {
 	flag.Parse()
-
-	h := Handler()
 
 	// Native messages include a prefix which describes the length of each message.
 	var in nativemessaging.JSONDecoder
@@ -51,42 +86,17 @@ func main() {
 		out = nativemessaging.NewNativeJSONEncoder(os.Stdout)
 	}
 
-	abort := false
+	h := Handler()
+
 	for {
-		var resp Response
-		var req Request
-
-		err := in.Decode(&req)
-
-		if err != nil {
-			// Input failed to parse; we can't guarantee future inputs will
-			// get into a parseable state, so we abort after sending an error
-			// response.
-			abort = true
-		} else {
-			resp.Result, err = h.Handle(&req)
-		}
-
+		err := process(h, in, out)
 		if err == io.EOF {
-			// Closed
+			// Clean close
 			break
-		} else if err != nil {
-			resp.Status = "error"
-			resp.Message = err.Error()
-		} else {
-			// Success
-			resp.Status = "ok"
 		}
-		resp.Client = req.Client
-
-		err = out.Encode(resp)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %s", err)
 			os.Exit(1)
-		}
-
-		if abort {
-			os.Exit(2)
 		}
 	}
 }

--- a/go/kbnm/main.go
+++ b/go/kbnm/main.go
@@ -53,13 +53,16 @@ func main() {
 		out = nativemessaging.NewNativeJSONEncoder(os.Stdout)
 	}
 
+	abort := false
 	for {
 		var resp Response
 		var req Request
 
 		err := in.Decode(&req)
 
-		if err == nil {
+		if err != nil {
+			abort = true
+		} else {
 			err = handle(&req)
 		}
 
@@ -79,7 +82,10 @@ func main() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %s", err)
 			os.Exit(1)
-			return
+		}
+
+		if abort {
+			os.Exit(2)
 		}
 	}
 }

--- a/go/kbnm/main_test.go
+++ b/go/kbnm/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestProcess(t *testing.T) {
+	h := Handler()
+
+	var ranCmd string
+	h.Run = func(cmd *exec.Cmd) error {
+		ranCmd = strings.Join(cmd.Args, " ")
+		return nil
+	}
+
+	var inBuf, outBuf bytes.Buffer
+	in := json.NewDecoder(&inBuf)
+	out := json.NewEncoder(&outBuf)
+
+	// Check invalid JSON:
+	io.WriteString(&inBuf, "invalid json, hi\n")
+	err := process(h, in, out)
+	if _, ok := err.(*json.SyntaxError); !ok {
+		t.Errorf("incorrect error on invalid JSON: %T", err)
+	}
+	// Reset the decoder
+	inBuf.Reset()
+	in = json.NewDecoder(&inBuf)
+
+	testCases := []struct {
+		In        string
+		ExpectOut string
+	}{
+		{
+			`{"method": "foo"}` + "\n",
+			`{"client":0,"status":"error","message":"invalid method"}` + "\n",
+		},
+		{
+			`{"method": "chat", "to": "shazow", "body": "Hello, world."}` + "\n",
+			`{"client":0,"status":"ok","message":""}` + "\n",
+		},
+	}
+
+	for i, test := range testCases {
+		outBuf.Reset()
+
+		io.WriteString(&inBuf, test.In)
+		if err := process(h, in, out); err != nil {
+			t.Fatalf("[case #%d] processing failed early: %s", i, err)
+		}
+
+		if want, got := test.ExpectOut, outBuf.String(); want != got {
+			t.Errorf("[case #%d] want:\n%s\ngot:\n%s", i, want, got)
+		}
+	}
+}


### PR DESCRIPTION
- Refactored to allow mocking of the `exec.Cmd.Run()` bit.
- Added tests: 0% -> 61.3% test coverage (most of the uncovered bit is what's left in the main() method and a few minor error branches).
- Replaced the awkward `cmd.StdinPipe()` with much nicer `cmd.Stdin = buf`.
- Added a "query" method that will be used to check whether a user is already on keybase. If "to" is left empty, then it should return the current logged in user (any problems with this?). This method might also be used to ping and check if the keybase service is available/installed when the extension is first loaded.