### PR TITLE
Mark revoked keys in `keybase pgp list`

### DIFF
--- a/go/client/cmd_pgp_list.go
+++ b/go/client/cmd_pgp_list.go
@@ -78,7 +78,11 @@ func (s *CmdPGPList) Run() error {
 				if len(id.Email) > 0 {
 					email = fmt.Sprintf(" <%s>", id.Email)
 				}
-				dui.Printf("   %s%s%s\n", id.Username, comment, email)
+				var revoked string
+				if key.IsRevoked {
+					revoked = "[Revoked] "
+				}
+				dui.Printf("   %s%s%s%s\n", revoked, id.Username, comment, email)
 			}
 		}
 		dui.Printf("\n")

--- a/go/libkb/gpg_index.go
+++ b/go/libkb/gpg_index.go
@@ -222,7 +222,7 @@ func (k *GpgPrimaryKey) AddUID(l *GpgIndexLine) (err error) {
 	var id *Identity
 	if f := l.At(9); len(f) == 0 {
 	} else if id, err = ParseIdentity(f); err != nil {
-	} else {
+	} else if l.At(1) != "r" { // is not revoked
 		k.identities = append(k.identities, id)
 	}
 	if err != nil {

--- a/go/libkb/gpg_index_test.go
+++ b/go/libkb/gpg_index_test.go
@@ -94,6 +94,23 @@ func TestGPGFindGreg(t *testing.T) {
 	}
 }
 
+func TestGPGRevokedID(t *testing.T) {
+	index := parse(t, keyringRevokedID)
+	if index == nil {
+		t.Fatal("parsing failed")
+	}
+	keys := index.Fingerprints.Get("582AB5DE7B6BB11F6E2B7075851B3498422B2DFA")
+	if len(keys) != 1 {
+		t.Fatal("expected to find one key")
+	}
+	if numIds := len(keys[0].identities); numIds != 1 {
+		t.Fatalf("expected to have one identity (got %v)", numIds)
+	}
+	if keys[0].identities[0].Format() != "This One WIll be rev0ked" {
+		t.Fatalf("Invalid identity: %v", keys[0].identities[0])
+	}
+}
+
 const myKeyring = `
 tru::1:1416474053:1439900531:3:1:5
 pub:u:2048:17:76D78F0500D026C4:1282220531:1439900531::u:::scESC:
@@ -269,4 +286,15 @@ uid:u::::1292846928::C9A8CEFCDA1CEF8706A5B815EE4027F1340F209F::Gregory Martin Pf
 ssb:u:2048:16:35259A50693B4429:1149381489::::::e:::+:::
 fpr:::::::::82E14B2AF315373CFFA88C8335259A50693B4429:
 grp:::::::::36714469BDCD99CD5748B39D9463E3DD06BEE2CC:
+`
+
+const keyringRevokedID = `
+sec:u:256:22:851B3498422B2DFA:1491212600:::u:::scESC:::+::ed25519::
+fpr:::::::::582AB5DE7B6BB11F6E2B7075851B3498422B2DFA:
+grp:::::::::45712C069D5ECB349A11DE7C7155E66D1D3E9BC3:
+uid:u::::1491212618::999BA342C3370F86AAE7A163C67EA2518F69ECFE::This One WIll be rev0ked:::::::::
+uid:r::::::30EC553EACC420881282218E39CEDA11E722D937::Hello AA:::::::::
+ssb:u:256:18:151E2B742F97B843:1491212600::::::e:::+::cv25519:
+fpr:::::::::2DEBE37BF89745512A87C69D151E2B742F97B843:
+grp:::::::::788233E7043694A6C4D9DE4562FEC67972C0CBF9:
 `

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -869,6 +869,7 @@ func (ckf ComputedKeyFamily) exportPublicKey(key GenericKey) (pk keybase1.Public
 			i++
 		}
 		pk.PGPIdentities = ids
+		pk.IsRevoked = len(pgpBundle.Revocations) > 0
 	}
 	pk.DeviceID = ckf.cki.KIDToDeviceID[pk.KID]
 	device := ckf.cki.Devices[pk.DeviceID]

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -52,6 +52,7 @@ type PublicKey struct {
 	DeviceType        string        `codec:"deviceType" json:"deviceType"`
 	CTime             Time          `codec:"cTime" json:"cTime"`
 	ETime             Time          `codec:"eTime" json:"eTime"`
+	IsRevoked         bool          `codec:"isRevoked" json:"isRevoked"`
 }
 
 type KeybaseTime struct {

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -73,6 +73,7 @@ protocol Common {
     string deviceType;
     Time cTime;
     Time eTime;
+    boolean isRevoked;
   }
 
   record KeybaseTime {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4153,6 +4153,7 @@ export type PublicKey = {
   deviceType: string,
   cTime: Time,
   eTime: Time,
+  isRevoked: boolean,
 }
 
 export type PushReason =

--- a/protocol/json/keybase1/common.json
+++ b/protocol/json/keybase1/common.json
@@ -185,6 +185,10 @@
         {
           "type": "Time",
           "name": "eTime"
+        },
+        {
+          "type": "boolean",
+          "name": "isRevoked"
         }
       ]
     },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4153,6 +4153,7 @@ export type PublicKey = {
   deviceType: string,
   cTime: Time,
   eTime: Time,
+  isRevoked: boolean,
 }
 
 export type PushReason =


### PR DESCRIPTION
Work in progress. Something similar should be done in profile page on the website, and probably in `keybase id`.