### PR TITLE
make PullLocalOnly play nicer with prev pointer addition

### DIFF
--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -91,7 +91,7 @@ func (s *BlockingSender) addPrevPointersToMessage(ctx context.Context, msg chat1
 			DisableResolveSupersedes: true,
 		},
 		&chat1.Pagination{
-			Num: 100,
+			Num: -1,
 		})
 	switch err.(type) {
 	case storage.MissError:

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -86,9 +86,12 @@ func (s *BlockingSender) addPrevPointersToMessage(ctx context.Context, msg chat1
 
 	var prevs []chat1.MessagePreviousPointer
 
-	res, err := s.G().ConvSource.PullLocalOnly(ctx, convID, msg.ClientHeader.Sender, nil,
+	res, err := s.G().ConvSource.PullLocalOnly(ctx, convID, msg.ClientHeader.Sender,
+		&chat1.GetThreadQuery{
+			DisableResolveSupersedes: true,
+		},
 		&chat1.Pagination{
-			Num: -1,
+			Num: 100,
 		})
 	switch err.(type) {
 	case storage.MissError:


### PR DESCRIPTION
This makes the new change to run `postProcessThread` on `PullLocalOnly` play nicer with prev pointer stuff.

Also limit prev pointer calculation to the last 100 messages. 