### PR TITLE
Fix window events breaking after reload

### DIFF
--- a/shared/desktop/renderer/index.js
+++ b/shared/desktop/renderer/index.js
@@ -101,6 +101,7 @@ function setupApp (store) {
   ipcRenderer.send('install-check')
 
   const currentWindow = electron.remote.getCurrentWindow()
+  currentWindow.removeAllListeners() // Support reload
   currentWindow.on('focus', () => { store.dispatch({payload: {focused: true}, type: 'app:changedFocus'}) })
   currentWindow.on('blur', () => { store.dispatch({payload: {focused: false}, type: 'app:changedFocus'}) })
 

--- a/shared/desktop/renderer/index.js
+++ b/shared/desktop/renderer/index.js
@@ -101,8 +101,9 @@ function setupApp (store) {
   ipcRenderer.send('install-check')
 
   const currentWindow = electron.remote.getCurrentWindow()
-  currentWindow.removeAllListeners() // Support reload
+  currentWindow.removeAllListeners('focus')
   currentWindow.on('focus', () => { store.dispatch({payload: {focused: true}, type: 'app:changedFocus'}) })
+  currentWindow.removeAllListeners('blur')
   currentWindow.on('blur', () => { store.dispatch({payload: {focused: false}, type: 'app:changedFocus'}) })
 
   const _menubarSelector = menubarSelector()


### PR DESCRIPTION
Fixes the issue here window events would exception on reload:
```
Uncaught exception on main thread: Error: Attempting to call a function in a renderer window that has been closed or released.
```

This prevented focused events from firing after reload due to above error. This was only an issue in debug/development.
