### PR TITLE
integrate the use of SyncAll into the reconnect process to Gregor CORE-4814

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -225,6 +225,11 @@ func (f failingRemote) SyncChat(ctx context.Context, vers chat1.InboxVers) (chat
 	return chat1.SyncChatRes{}, nil
 }
 
+func (f failingRemote) SyncAll(ctx context.Context, arg chat1.SyncAllArg) (chat1.SyncAllResult, error) {
+	require.Fail(f.t, "SyncAll")
+	return chat1.SyncAllResult{}, nil
+}
+
 type failingTlf struct {
 	t *testing.T
 }

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -571,7 +571,7 @@ func (s *HybridInboxSource) handleInboxError(ctx context.Context, err storage.Er
 	if verr, ok := err.(storage.VersionMismatchError); ok {
 		s.Debug(ctx, "handleInboxError: version mismatch, syncing and sending stale notifications: %s",
 			verr.Error())
-		s.G().Syncer.Sync(ctx, s.getChatInterface(), uid)
+		s.G().Syncer.Sync(ctx, s.getChatInterface(), uid, nil)
 		return nil
 	}
 	return err

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -817,7 +817,8 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 	conversationRemote chat1.Conversation) (conversationLocal chat1.ConversationLocal) {
 
 	unverifiedTLFName := getUnverifiedTlfNameForErrors(conversationRemote)
-	s.Debug(ctx, "localizing: TLF: %s convID: %s", unverifiedTLFName, conversationRemote.GetConvID())
+	s.Debug(ctx, "localizing: TLF: %s convID: %s offline: %v", unverifiedTLFName,
+		conversationRemote.GetConvID(), s.offline)
 
 	conversationLocal.Info = chat1.ConversationInfoLocal{
 		Id:         conversationRemote.Metadata.ConversationID,

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -382,9 +382,11 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 
 	// Delete assets associated with a delete operation.
 	// Logs instead of returning an error. Assets can be left undeleted.
-	err = s.deleteAssets(ctx, convID, pendingAssetDeletes)
-	if err != nil {
-		return chat1.OutboxID{}, 0, nil, err
+	if len(pendingAssetDeletes) > 0 {
+		err = s.deleteAssets(ctx, convID, pendingAssetDeletes)
+		if err != nil {
+			return chat1.OutboxID{}, 0, nil, err
+		}
 	}
 
 	rarg := chat1.PostRemoteArg{

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -136,7 +136,8 @@ func (s *Syncer) isServerInboxClear(ctx context.Context, inbox *storage.Inbox, s
 	return false
 }
 
-func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID) (err error) {
+func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,
+	syncRes *chat1.SyncChatRes) (err error) {
 	ctx = CtxAddLogTags(ctx)
 	s.Lock()
 	defer s.Unlock()
@@ -149,7 +150,7 @@ func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid g
 		o.Connected(ctx)
 	}
 
-	s.sync(ctx, cli, uid)
+	s.sync(ctx, cli, uid, syncRes)
 
 	return nil
 }
@@ -171,10 +172,11 @@ func (s *Syncer) Sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 	s.Lock()
 	defer s.Unlock()
 	defer s.Trace(ctx, func() error { return err }, "Sync")()
-	return s.sync(ctx, cli, uid)
+	return s.sync(ctx, cli, uid, nil)
 }
 
-func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID) (err error) {
+func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,
+	syncRes *chat1.SyncChatRes) (err error) {
 	if !s.isConnected {
 		s.Debug(ctx, "Sync: aborting because currently offline")
 		return OfflineError{}
@@ -182,7 +184,6 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 
 	// Grab current on disk version
 	ibox := storage.NewInbox(s.G(), uid)
-	var syncRes chat1.SyncChatRes
 	vers, err := ibox.Version(ctx)
 	if err != nil {
 		s.Debug(ctx, "Sync: failed to get current inbox version (using 0): %s", err.Error())
@@ -195,16 +196,20 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 	}
 	s.Debug(ctx, "Sync: current inbox version: %v server version: %d", vers, srvVers)
 
-	// Run the sync call on the server to see how current our local copy is
-
-	if syncRes, err = cli.SyncChat(ctx, vers); err != nil {
-		s.Debug(ctx, "Sync: failed to sync inbox: %s", err.Error())
-		return err
+	if syncRes == nil {
+		// Run the sync call on the server to see how current our local copy is
+		syncRes = new(chat1.SyncChatRes)
+		if *syncRes, err = cli.SyncChat(ctx, vers); err != nil {
+			s.Debug(ctx, "Sync: failed to sync inbox: %s", err.Error())
+			return err
+		}
+	} else {
+		s.Debug(ctx, "Sync: skipping sync call, data provided")
 	}
 
 	// Set new server versions
 	if err = s.G().ServerCacheVersions.Set(ctx, syncRes.CacheVers); err != nil {
-		s.Debug(ctx, "Connected: failed to set new server versions: %s", err.Error())
+		s.Debug(ctx, "Sync: failed to set new server versions: %s", err.Error())
 	}
 
 	// Process what the server has told us to do with the local inbox copy

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -168,7 +168,8 @@ func (s *Syncer) Disconnected(ctx context.Context) {
 	}
 }
 
-func (s *Syncer) Sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID) (err error) {
+func (s *Syncer) Sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,
+	syncRes *chat1.SyncChatRes) (err error) {
 	s.Lock()
 	defer s.Unlock()
 	defer s.Trace(ctx, func() error { return err }, "Sync")()

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -173,7 +173,7 @@ func (s *Syncer) Sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 	s.Lock()
 	defer s.Unlock()
 	defer s.Trace(ctx, func() error { return err }, "Sync")()
-	return s.sync(ctx, cli, uid, nil)
+	return s.sync(ctx, cli, uid, syncRes)
 }
 
 func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -84,7 +84,8 @@ type ServerCacheVersions interface {
 }
 
 type Syncer interface {
-	Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID) error
+	Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,
+		syncRes *chat1.SyncChatRes) error
 	Disconnected(ctx context.Context)
 	Sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID) error
 	RegisterOfflinable(offlinable Offlinable)

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -87,7 +87,8 @@ type Syncer interface {
 	Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,
 		syncRes *chat1.SyncChatRes) error
 	Disconnected(ctx context.Context)
-	Sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID) error
+	Sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,
+		syncRes *chat1.SyncChatRes) error
 	RegisterOfflinable(offlinable Offlinable)
 	SendChatStaleNotifications(ctx context.Context, uid gregor1.UID, convIDs []chat1.ConversationID,
 		immediate bool)

--- a/go/gregor/client/client.go
+++ b/go/gregor/client/client.go
@@ -146,7 +146,10 @@ func (c *Client) freshSync(cli gregor1.IncomingInterface, state *gregor.State) (
 		if err != nil {
 			return msgs, err
 		}
+	} else {
+		c.Log.Debug("Sync(): freshSync(): skipping State call, data previously obtained")
 	}
+
 	if msgs, err = c.InBandMessagesFromState(*state); err != nil {
 		return msgs, err
 	}

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -566,8 +566,14 @@ func (m *ChatRemoteMock) SyncChat(ctx context.Context, vers chat1.InboxVers) (ch
 	}, nil
 }
 
-func (m *ChatRemoteMock) SyncAll(ctx context.Context, arg chat1.SyncAllArg) (chat1.SyncAllResult, error) {
-	return chat1.SyncAllResult{}, nil
+func (m *ChatRemoteMock) SyncAll(ctx context.Context, arg chat1.SyncAllArg) (res chat1.SyncAllResult, err error) {
+	cres, err := m.SyncChat(ctx, arg.InboxVers)
+	if err != nil {
+		return res, err
+	}
+	return chat1.SyncAllResult{
+		Chat: cres,
+	}, nil
 }
 
 type convByNewlyUpdated struct {

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -566,6 +566,10 @@ func (m *ChatRemoteMock) SyncChat(ctx context.Context, vers chat1.InboxVers) (ch
 	}, nil
 }
 
+func (m *ChatRemoteMock) SyncAll(ctx context.Context, arg chat1.SyncAllArg) (chat1.SyncAllResult, error) {
+	return chat1.SyncAllResult{}, nil
+}
+
 type convByNewlyUpdated struct {
 	mock *ChatRemoteMock
 }

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -439,13 +439,6 @@ func (g *gregorHandler) IsConnected() bool {
 func (g *gregorHandler) serverSync(ctx context.Context,
 	cli gregor1.IncomingInterface, gcli *grclient.Client, syncRes *chat1.SyncAllNotificationRes) ([]gregor.InBandMessage, []gregor.InBandMessage, error) {
 
-	// Sync down everything from the server
-	consumedMsgs, err := gcli.Sync(cli, syncRes)
-	if err != nil {
-		g.Debug(ctx, "serverSync: error syncing from the server, reason: %s", err)
-		return nil, nil, err
-	}
-
 	// Get time of the last message we synced (unless this is our first time syncing)
 	var t time.Time
 	if !g.freshReplay {
@@ -456,6 +449,13 @@ func (g *gregorHandler) serverSync(ctx context.Context,
 		g.Debug(ctx, "serverSync: starting replay from: %s", t)
 	} else {
 		g.Debug(ctx, "serverSync: performing a fresh replay")
+	}
+
+	// Sync down everything from the server
+	consumedMsgs, err := gcli.Sync(cli, syncRes)
+	if err != nil {
+		g.Debug(ctx, "serverSync: error syncing from the server, reason: %s", err)
+		return nil, nil, err
 	}
 
 	// Replay in-band messages

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -566,10 +566,9 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 	replayedMsgs, consumedMsgs, err := g.serverSync(ctx, gregor1.IncomingClient{Cli: timeoutCli}, gcli,
 		&syncAllRes.Notification)
 	if err != nil {
-		g.Errorf("sync failure: %s", err)
+		g.Debug(ctx, "sync failure: %s", err)
 	} else {
-		g.Debug(ctx, "sync success: replayed: %d consumed: %d",
-			len(replayedMsgs), len(consumedMsgs))
+		g.Debug(ctx, "sync success: replayed: %d consumed: %d", len(replayedMsgs), len(consumedMsgs))
 	}
 
 	// Sync badge state in the background

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/backoff"
 	"github.com/keybase/client/go/badges"
 	"github.com/keybase/client/go/chat"
+	chatstorage "github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/gregor"
@@ -436,10 +437,12 @@ func (g *gregorHandler) IsConnected() bool {
 // gregord. This can happen either on initial startup, or after a reconnect. Needs
 // to be called with gregorHandler locked.
 func (g *gregorHandler) serverSync(ctx context.Context,
-	cli gregor1.IncomingInterface) ([]gregor.InBandMessage, []gregor.InBandMessage, error) {
+	cli gregor1.IncomingInterface, gcli *grclient.Client, syncRes *chat1.SyncAllNotificationRes) ([]gregor.InBandMessage, []gregor.InBandMessage, error) {
 
-	gcli, err := g.getGregorCli()
+	// Sync down everything from the server
+	consumedMsgs, err := gcli.Sync(cli, syncRes)
 	if err != nil {
+		g.Debug(ctx, "serverSync: error syncing from the server, reason: %s", err)
 		return nil, nil, err
 	}
 
@@ -450,16 +453,9 @@ func (g *gregorHandler) serverSync(ctx context.Context,
 		if pt != nil {
 			t = *pt
 		}
-		g.Debug(ctx, "starting replay from: %s", t)
+		g.Debug(ctx, "serverSync: starting replay from: %s", t)
 	} else {
-		g.Debug(ctx, "performing a fresh replay")
-	}
-
-	// Sync down everything from the server
-	consumedMsgs, err := gcli.Sync(cli)
-	if err != nil {
-		g.Errorf("error syncing from the server, reason: %s", err)
-		return nil, nil, err
+		g.Debug(ctx, "serverSync: performing a fresh replay")
 	}
 
 	// Replay in-band messages
@@ -473,7 +469,6 @@ func (g *gregorHandler) serverSync(ctx context.Context,
 	g.freshReplay = false
 
 	g.pushState(keybase1.PushReason_RECONNECTED)
-
 	return replayedMsgs, consumedMsgs, nil
 }
 
@@ -485,6 +480,37 @@ func (g *gregorHandler) makeReconnectOobm() gregor1.Message {
 	}
 }
 
+func (g *gregorHandler) authParams(ctx context.Context) (uid gregor1.UID, token gregor1.SessionToken, err error) {
+	var ok bool
+	var stoken string
+	var kuid keybase1.UID
+	if kuid, stoken, ok = g.loggedIn(ctx); !ok {
+		g.skipRetryConnect = true
+		return uid, token, errors.New("not logged in for auth")
+	}
+	return kuid.ToBytes(), gregor1.SessionToken(stoken), nil
+}
+
+func (g *gregorHandler) inboxParams(ctx context.Context, uid gregor1.UID) chat1.InboxVers {
+	// Grab current on disk version
+	ibox := chatstorage.NewInbox(g.G(), uid)
+	vers, err := ibox.Version(ctx)
+	if err != nil {
+		g.Debug(ctx, "inboxParams: failed to get current inbox version (using 0): %s", err.Error())
+		vers = chat1.InboxVers(0)
+	}
+	return vers
+}
+
+func (g *gregorHandler) notificationParams(ctx context.Context, gcli *grclient.Client) (t gregor1.Time) {
+	pt := gcli.StateMachineLatestCTime()
+	if pt != nil {
+		t = gregor1.ToTime(*pt)
+	}
+	g.Debug(ctx, "notificationParams: latest ctime: %s", t)
+	return t
+}
+
 // OnConnect is called by the rpc library to indicate we have connected to
 // gregord
 func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
@@ -493,37 +519,52 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 	defer g.Unlock()
 
 	timeoutCli := WrapGenericClientWithTimeout(cli, GregorRequestTimeout, ErrGregorTimeout)
+	chatCli := chat1.RemoteClient{Cli: cli}
 
 	g.Debug(ctx, "connected")
-	g.Debug(ctx, "registering protocols")
 	if err := srv.Register(gregor1.OutgoingProtocol(g)); err != nil {
-		return err
+		return fmt.Errorf("error registering protocol: %s", err.Error())
+	}
+
+	// Grab authentication and sync params
+	gcli, err := g.getGregorCli()
+	if err != nil {
+		return fmt.Errorf("failed to get gregor client: %s", err.Error())
+	}
+	uid, token, err := g.authParams(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to obtain auth params: %s", err.Error())
+	}
+	iboxVers := g.inboxParams(ctx, uid)
+	latestCtime := g.notificationParams(ctx, gcli)
+
+	// Run SyncAll to both authenticate, and grab all the data we will need to run the
+	// various resync procedures for chat and notifications
+	syncAllRes, err := chatCli.SyncAll(ctx, chat1.SyncAllArg{
+		Uid:       uid,
+		DeviceID:  gcli.Device.(gregor1.DeviceID),
+		Session:   token,
+		InboxVers: iboxVers,
+		Ctime:     latestCtime,
+	})
+	if err != nil {
+		return fmt.Errorf("error running SyncAll: %s", err.Error())
 	}
 
 	// Use the client parameter instead of conn.GetClient(), since we can get stuck
 	// in a recursive loop if we keep retrying on reconnect.
-	if err := g.auth(ctx, timeoutCli); err != nil {
-		return err
+	if err := g.auth(ctx, timeoutCli, &syncAllRes.Auth); err != nil {
+		return fmt.Errorf("error authenticating: %s", err.Error())
 	}
 
 	// Sync chat data using a Syncer object
-	gcli, err := g.getGregorCli()
-	if err == nil {
-		chatCli := chat1.RemoteClient{Cli: cli}
-		uid := gcli.User.(gregor1.UID)
-		if err := g.G().Syncer.Connected(ctx, chatCli, uid); err != nil {
-			return err
-		}
-	}
-	// Call out to reachability module if we have one
-	if g.reachability != nil {
-		g.reachability.setReachability(keybase1.Reachability{
-			Reachable: keybase1.Reachable_YES,
-		})
+	if err := g.G().Syncer.Connected(ctx, chatCli, uid, &syncAllRes.Chat); err != nil {
+		return fmt.Errorf("error running chat sync: %s", err.Error())
 	}
 
 	// Sync down events since we have been dead
-	replayedMsgs, consumedMsgs, err := g.serverSync(ctx, gregor1.IncomingClient{Cli: timeoutCli})
+	replayedMsgs, consumedMsgs, err := g.serverSync(ctx, gregor1.IncomingClient{Cli: timeoutCli}, gcli,
+		&syncAllRes.Notification)
 	if err != nil {
 		g.Errorf("sync failure: %s", err)
 	} else {
@@ -534,8 +575,15 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 	// Sync badge state in the background
 	if g.badger != nil {
 		go func(badger *badges.Badger) {
-			badger.Resync(context.Background(), &chat1.RemoteClient{Cli: g.cli})
+			badger.Resync(context.Background(), &chat1.RemoteClient{Cli: g.cli}, &syncAllRes.Badge)
 		}(g.badger)
+	}
+
+	// Call out to reachability module if we have one
+	if g.reachability != nil {
+		g.reachability.setReachability(keybase1.Reachability{
+			Reachable: keybase1.Reachable_YES,
+		})
 	}
 
 	// Broadcast reconnect oobm. Spawn this off into a goroutine so that we don't delay
@@ -1008,7 +1056,7 @@ func (g *gregorHandler) loggedIn(ctx context.Context) (uid keybase1.UID, token s
 	return uid, token, true
 }
 
-func (g *gregorHandler) auth(ctx context.Context, cli rpc.GenericClient) (err error) {
+func (g *gregorHandler) auth(ctx context.Context, cli rpc.GenericClient, auth *gregor1.AuthResult) (err error) {
 	var token string
 	var ok bool
 	var uid keybase1.UID
@@ -1018,15 +1066,20 @@ func (g *gregorHandler) auth(ctx context.Context, cli rpc.GenericClient) (err er
 		return errors.New("not logged in for auth")
 	}
 
-	g.Debug(ctx, "logged in: authenticating")
-	ac := gregor1.AuthClient{Cli: cli}
-	auth, err := ac.AuthenticateSessionToken(ctx, gregor1.SessionToken(token))
-	if err != nil {
-		g.Debug(ctx, "auth error: %s", err)
-		return err
+	if auth == nil {
+		g.Debug(ctx, "logged in: authenticating")
+		ac := gregor1.AuthClient{Cli: cli}
+		auth = new(gregor1.AuthResult)
+		*auth, err = ac.AuthenticateSessionToken(ctx, gregor1.SessionToken(token))
+		if err != nil {
+			g.Debug(ctx, "auth error: %s", err)
+			return err
+		}
+	} else {
+		g.Debug(ctx, "using previously obtained auth result")
 	}
 
-	g.Debug(ctx, "auth result: %+v", auth)
+	g.Debug(ctx, "auth result: %+v", *auth)
 	if !bytes.Equal(auth.Uid, uid.ToBytes()) {
 		g.skipRetryConnect = true
 		return fmt.Errorf("auth result uid %x doesn't match session uid %q", auth.Uid, uid)

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -180,6 +180,25 @@ protocol remote {
 
   SyncChatRes syncChat(InboxVers vers);
 
+  enum SyncAllNotificationType {
+    STATE_0,
+    INCREMENTAL_1
+  }
+
+  variant SyncAllNotificationRes switch(SyncAllNotificationType typ) {
+  case STATE: gregor1.State;
+  case INCREMENTAL: gregor1.SyncResult;
+  }
+
+  record SyncAllResult {
+    gregor1.AuthResult auth; 
+    SyncChatRes chat;
+    SyncAllNotificationRes notification;
+    UnreadUpdateFull badge;
+  }
+
+  SyncAllResult syncAll(gregor1.UID uid, gregor1.DeviceID deviceID, gregor1.SessionToken session, InboxVers inboxVers, gregor1.Time ctime);
+
   // tlfFinalize is an endpoint for kbfstlfd to notify Gregor that a TLF ID has been finalized.
   // Gregor keeps an internal record of these TLF IDs, so that it can always return the latest
   // conversation per TLF ID on GetInboxRemote.

--- a/protocol/avdl/gregor1/incoming.avdl
+++ b/protocol/avdl/gregor1/incoming.avdl
@@ -17,6 +17,5 @@ protocol incoming {
     categories are prefixed by the given prefix
    */
   State stateByCategoryPrefix(UID uid, DeviceID deviceid, TimeOrOffset timeOrOffset, Category categoryPrefix);
-
-
+ 
 }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -176,6 +176,11 @@ export const RemoteMessageBoxedVersion = {
   v2: 2,
 }
 
+export const RemoteSyncAllNotificationType = {
+  state: 0,
+  incremental: 1,
+}
+
 export const RemoteSyncInboxResType = {
   current: 0,
   incremental: 1,
@@ -636,6 +641,18 @@ export function remoteSetConversationStatusRpcChannelMap (channelConfig: Channel
 
 export function remoteSetConversationStatusRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetConversationStatusResult) => void} & {param: remoteSetConversationStatusRpcParam}>): Promise<remoteSetConversationStatusResult> {
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.SetConversationStatus', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function remoteSyncAllRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>) {
+  engineRpcOutgoing('chat.1.remote.syncAll', request)
+}
+
+export function remoteSyncAllRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.syncAll', request, callback, incomingCallMap) })
+}
+
+export function remoteSyncAllRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>): Promise<remoteSyncAllResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.syncAll', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function remoteSyncChatRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {param: remoteSyncChatRpcParam}>) {
@@ -1500,6 +1517,21 @@ export type SignatureInfo = {
   k: bytes,
 }
 
+export type SyncAllNotificationRes =
+    { typ: 0, state: ?gregor1.State }
+  | { typ: 1, incremental: ?gregor1.SyncResult }
+
+export type SyncAllNotificationType =
+    0 // STATE_0
+  | 1 // INCREMENTAL_1
+
+export type SyncAllResult = {
+  auth: gregor1.AuthResult,
+  chat: SyncChatRes,
+  notification: SyncAllNotificationRes,
+  badge: UnreadUpdateFull,
+}
+
 export type SyncChatRes = {
   cacheVers: ServerCacheVers,
   inboxRes: SyncInboxRes,
@@ -1855,6 +1887,14 @@ export type remoteSetConversationStatusRpcParam = Exact<{
   status: ConversationStatus
 }>
 
+export type remoteSyncAllRpcParam = Exact<{
+  uid: gregor1.UID,
+  deviceID: gregor1.DeviceID,
+  session: gregor1.SessionToken,
+  inboxVers: InboxVers,
+  ctime: gregor1.Time
+}>
+
 export type remoteSyncChatRpcParam = Exact<{
   vers: InboxVers
 }>
@@ -1910,6 +1950,7 @@ type remoteNewConversationRemoteResult = NewConversationRemoteRes
 type remotePostRemoteResult = PostRemoteRes
 type remoteS3SignResult = bytes
 type remoteSetConversationStatusResult = SetConversationStatusRes
+type remoteSyncAllResult = SyncAllResult
 type remoteSyncChatResult = SyncChatRes
 type remoteSyncInboxResult = SyncInboxRes
 
@@ -1952,6 +1993,7 @@ export type rpc =
   | remotePublishSetConversationStatusRpc
   | remoteS3SignRpc
   | remoteSetConversationStatusRpc
+  | remoteSyncAllRpc
   | remoteSyncChatRpc
   | remoteSyncInboxRpc
   | remoteTlfFinalizeRpc

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -384,6 +384,60 @@
           "name": "inboxRes"
         }
       ]
+    },
+    {
+      "type": "enum",
+      "name": "SyncAllNotificationType",
+      "symbols": [
+        "STATE_0",
+        "INCREMENTAL_1"
+      ]
+    },
+    {
+      "type": "variant",
+      "name": "SyncAllNotificationRes",
+      "switch": {
+        "type": "SyncAllNotificationType",
+        "name": "typ"
+      },
+      "cases": [
+        {
+          "label": {
+            "name": "STATE",
+            "def": false
+          },
+          "body": "gregor1.State"
+        },
+        {
+          "label": {
+            "name": "INCREMENTAL",
+            "def": false
+          },
+          "body": "gregor1.SyncResult"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "SyncAllResult",
+      "fields": [
+        {
+          "type": "gregor1.AuthResult",
+          "name": "auth"
+        },
+        {
+          "type": "SyncChatRes",
+          "name": "chat"
+        },
+        {
+          "type": "SyncAllNotificationRes",
+          "name": "notification"
+        },
+        {
+          "type": "UnreadUpdateFull",
+          "name": "badge"
+        }
+      ]
     }
   ],
   "messages": {
@@ -587,6 +641,31 @@
         }
       ],
       "response": "SyncChatRes"
+    },
+    "syncAll": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "gregor1.UID"
+        },
+        {
+          "name": "deviceID",
+          "type": "gregor1.DeviceID"
+        },
+        {
+          "name": "session",
+          "type": "gregor1.SessionToken"
+        },
+        {
+          "name": "inboxVers",
+          "type": "InboxVers"
+        },
+        {
+          "name": "ctime",
+          "type": "gregor1.Time"
+        }
+      ],
+      "response": "SyncAllResult"
     },
     "tlfFinalize": {
       "request": [

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -176,6 +176,11 @@ export const RemoteMessageBoxedVersion = {
   v2: 2,
 }
 
+export const RemoteSyncAllNotificationType = {
+  state: 0,
+  incremental: 1,
+}
+
 export const RemoteSyncInboxResType = {
   current: 0,
   incremental: 1,
@@ -636,6 +641,18 @@ export function remoteSetConversationStatusRpcChannelMap (channelConfig: Channel
 
 export function remoteSetConversationStatusRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetConversationStatusResult) => void} & {param: remoteSetConversationStatusRpcParam}>): Promise<remoteSetConversationStatusResult> {
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.SetConversationStatus', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function remoteSyncAllRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>) {
+  engineRpcOutgoing('chat.1.remote.syncAll', request)
+}
+
+export function remoteSyncAllRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.syncAll', request, callback, incomingCallMap) })
+}
+
+export function remoteSyncAllRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>): Promise<remoteSyncAllResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.syncAll', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function remoteSyncChatRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {param: remoteSyncChatRpcParam}>) {
@@ -1500,6 +1517,21 @@ export type SignatureInfo = {
   k: bytes,
 }
 
+export type SyncAllNotificationRes =
+    { typ: 0, state: ?gregor1.State }
+  | { typ: 1, incremental: ?gregor1.SyncResult }
+
+export type SyncAllNotificationType =
+    0 // STATE_0
+  | 1 // INCREMENTAL_1
+
+export type SyncAllResult = {
+  auth: gregor1.AuthResult,
+  chat: SyncChatRes,
+  notification: SyncAllNotificationRes,
+  badge: UnreadUpdateFull,
+}
+
 export type SyncChatRes = {
   cacheVers: ServerCacheVers,
   inboxRes: SyncInboxRes,
@@ -1855,6 +1887,14 @@ export type remoteSetConversationStatusRpcParam = Exact<{
   status: ConversationStatus
 }>
 
+export type remoteSyncAllRpcParam = Exact<{
+  uid: gregor1.UID,
+  deviceID: gregor1.DeviceID,
+  session: gregor1.SessionToken,
+  inboxVers: InboxVers,
+  ctime: gregor1.Time
+}>
+
 export type remoteSyncChatRpcParam = Exact<{
   vers: InboxVers
 }>
@@ -1910,6 +1950,7 @@ type remoteNewConversationRemoteResult = NewConversationRemoteRes
 type remotePostRemoteResult = PostRemoteRes
 type remoteS3SignResult = bytes
 type remoteSetConversationStatusResult = SetConversationStatusRes
+type remoteSyncAllResult = SyncAllResult
 type remoteSyncChatResult = SyncChatRes
 type remoteSyncInboxResult = SyncInboxRes
 
@@ -1952,6 +1993,7 @@ export type rpc =
   | remotePublishSetConversationStatusRpc
   | remoteS3SignRpc
   | remoteSetConversationStatusRpc
+  | remoteSyncAllRpc
   | remoteSyncChatRpc
   | remoteSyncInboxRpc
   | remoteTlfFinalizeRpc


### PR DESCRIPTION
The basic idea here is to add an extra parameter to all the sync functions to supply the data they would have received had they called the server. In fact, we retain the code to call the server and get the exact data we pass in from the result of `SyncAll`. This allows us to make a fairly minimal change, and keep the overall sync mechanics largely unchanged. The flow of reconnect is now the following:

1.) Call `SyncAll` and get the results for authentication, chat inbox state, badge state, and notification state machine sync info.
2.) Call all the old syncer functions for these various subsystems, and pass in the relevant part of the result from `SyncAll` to each of them.

All the old tests can be leveraged by making them call `SyncAll` first, and then force the syncing code down the code path that involves having the server data passed in.