### PR TITLE
test existence of conv IDs queries directly

### DIFF
--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -209,9 +209,19 @@ func TestInboxQueries(t *testing.T) {
 
 	t.Logf("merging before query")
 	before := full[5:]
+	var beforeConvIDs []chat1.ConversationID
+	for _, bconv := range before {
+		beforeConvIDs = append(beforeConvIDs, bconv.GetConvID())
+	}
 	btime := gregor1.Time(15)
 	q = &chat1.GetInboxQuery{Before: &btime}
 	mergeReadAndCheck(t, before, "before")
+
+	t.Logf("check conv IDs queries work")
+	q = &chat1.GetInboxQuery{Before: &btime, ConvIDs: beforeConvIDs}
+	_, cres, _, err := inbox.Read(context.TODO(), q, nil)
+	require.NoError(t, err)
+	require.Equal(t, before, cres)
 }
 
 func TestInboxPagination(t *testing.T) {


### PR DESCRIPTION
The `Inbox` works by testing if it thinks the query being run is up to date on the disk. However, `ConvIDs` queries miss a lot since the list of conv IDs in the query will move around a lot (change order, add new ones, etc). Since the inbox is just a list of conversations on disk, for these queries we can simply just check to see if all the conversations in the query are on the disk. If so, then we serve these requests. 