### PR TITLE
Hide previews from app switcher - Android

### DIFF
--- a/shared/constants/settings.js
+++ b/shared/constants/settings.js
@@ -149,9 +149,11 @@ type AboutTab = 'settingsTabs:aboutTab'
 export const aboutTab = 'settingsTabs:aboutTab'
 type DevicesTab = 'settingsTabs:devicesTab'
 export const devicesTab = 'settingsTabs:devicesTab'
+type ScreenprotectorTab = 'settingsTabs:screenprotector'
+export const screenprotectorTab = 'settingsTabs:screenprotector'
 
 export type Tab = LandingTab | UpdatePaymentTab | InvitationsTab | NotificationsTab | DeleteMeTab | DevMenuTab
-  | FeedbackTab | AboutTab | DevicesTab
+  | FeedbackTab | AboutTab | DevicesTab | ScreenprotectorTab
 
 export type Actions = InvitesRefresh | NotificationsRefresh | NotificationsRefreshed | NotificationsSave | NotificationsSaved | NotificationsToggle | SetAllowDeleteAccount
 

--- a/shared/native/screenprotector.android.js
+++ b/shared/native/screenprotector.android.js
@@ -1,0 +1,10 @@
+// @flow
+import {NativeModules} from 'react-native'
+
+const setSecureFlagSetting = NativeModules.ScreenProtector.setSecureFlagSetting
+const getSecureFlagSetting = NativeModules.ScreenProtector.getSecureFlagSetting
+
+export {
+  setSecureFlagSetting,
+  getSecureFlagSetting,
+}

--- a/shared/native/screenprotector.ios.js
+++ b/shared/native/screenprotector.ios.js
@@ -1,0 +1,9 @@
+// @flow
+
+const setSecureFlagSetting = () => { Promise.resolve(true) }
+const getSecureFlagSetting = () => { Promise.resolve(true) }
+
+export {
+  setSecureFlagSetting,
+  getSecureFlagSetting,
+}

--- a/shared/native/screenprotector.js.flow
+++ b/shared/native/screenprotector.js.flow
@@ -1,0 +1,9 @@
+// @flow
+
+declare function setSecureFlagSetting (): Promise<boolean>;
+declare function getSecureFlagSetting (): Promise<boolean>;
+
+export {
+  setSecureFlagSetting,
+  getSecureFlagSetting,
+}

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KBReactPackage.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KBReactPackage.java
@@ -15,6 +15,7 @@ import io.keybase.ossifrage.modules.FileLogger;
 import io.keybase.ossifrage.modules.KeybaseEngine;
 import io.keybase.ossifrage.modules.KillableModule;
 import io.keybase.ossifrage.modules.LogSend;
+import io.keybase.ossifrage.modules.ScreenProtector;
 
 public class KBReactPackage implements com.facebook.react.ReactPackage {
     private final String logFilePath;
@@ -36,6 +37,7 @@ public class KBReactPackage implements com.facebook.react.ReactPackage {
         final KeybaseEngine kbEngine = new KeybaseEngine(reactApplicationContext);
         final FileLogger kbLogger = new FileLogger(reactApplicationContext, logFilePath);
         final LogSend logSend = new LogSend(reactApplicationContext, logFilePath);
+        final ScreenProtector screenProtector = new ScreenProtector(reactApplicationContext);
 
         killableModules.add(kbEngine);
 
@@ -43,6 +45,7 @@ public class KBReactPackage implements com.facebook.react.ReactPackage {
         modules.add(kbEngine);
         modules.add(kbLogger);
         modules.add(logSend);
+        modules.add(screenProtector);
 
         return modules;
     }

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -2,6 +2,8 @@ package io.keybase.ossifrage;
 
 import android.annotation.TargetApi;
 import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -9,6 +11,7 @@ import android.provider.Settings;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.Window;
+import android.view.WindowManager;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactInstanceManager;
@@ -52,6 +55,11 @@ public class MainActivity extends ReactActivity {
                 }
             },
         3000);
+    }
+
+    @Override
+    public boolean onCreateThumbnail(final Bitmap outBitmap, final Canvas canvas) {
+        return super.onCreateThumbnail(outBitmap, canvas);
     }
 
     @Override

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/ScreenProtector.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/ScreenProtector.java
@@ -1,0 +1,48 @@
+package io.keybase.ossifrage.modules;
+
+import android.os.Build;
+import android.view.Window;
+import android.view.WindowManager;
+
+import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+
+public class ScreenProtector extends ReactContextBaseJavaModule {
+    public ScreenProtector(final ReactApplicationContext reactContext) {
+        super(reactContext);
+
+        reactContext.addLifecycleEventListener(new LifecycleEventListener() {
+            @Override
+            public void onHostResume() {
+                final Window window = reactContext.getCurrentActivity().getWindow();
+                setSecureFlag(window, false);
+            }
+
+            @Override
+            public void onHostPause() {
+                final Window window = reactContext.getCurrentActivity().getWindow();
+                setSecureFlag(window, true);
+            }
+
+            @Override
+            public void onHostDestroy() {
+                final Window window = reactContext.getCurrentActivity().getWindow();
+                setSecureFlag(window, true);
+            }
+        });
+    }
+
+    private static void setSecureFlag(Window window, boolean setSecure) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH && setSecure) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE);
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "ScreenProtector";
+    }
+}

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/ScreenProtector.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/ScreenProtector.java
@@ -1,43 +1,75 @@
 package io.keybase.ossifrage.modules;
 
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Build;
+import android.os.Looper;
+import android.util.Log;
 import android.view.Window;
 import android.view.WindowManager;
 
 import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
 
 public class ScreenProtector extends ReactContextBaseJavaModule {
+    private ReactApplicationContext reactContext;
+
     public ScreenProtector(final ReactApplicationContext reactContext) {
         super(reactContext);
+        this.reactContext = reactContext;
+        this.setSecureFlag();
 
         reactContext.addLifecycleEventListener(new LifecycleEventListener() {
             @Override
             public void onHostResume() {
-                final Window window = reactContext.getCurrentActivity().getWindow();
-                setSecureFlag(window, false);
+                setSecureFlag();
             }
 
             @Override
             public void onHostPause() {
-                final Window window = reactContext.getCurrentActivity().getWindow();
-                setSecureFlag(window, true);
             }
 
             @Override
             public void onHostDestroy() {
-                final Window window = reactContext.getCurrentActivity().getWindow();
-                setSecureFlag(window, true);
             }
         });
     }
 
-    private static void setSecureFlag(Window window, boolean setSecure) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH && setSecure) {
-            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE);
-        } else {
-            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+    @ReactMethod
+    public void setSecureFlagSetting(boolean setSecure, Promise promise) {
+        final SharedPreferences prefs = reactContext.getSharedPreferences("SecureFlag", Context.MODE_PRIVATE);
+        final boolean success = prefs.edit().putBoolean("setSecure", setSecure).commit();
+        promise.resolve(success);
+        setSecureFlag();
+    }
+
+    @ReactMethod
+    public void getSecureFlagSetting(Promise promise) {
+        final SharedPreferences prefs = this.reactContext.getSharedPreferences("SecureFlag", Context.MODE_PRIVATE);
+        final boolean setSecure = prefs.getBoolean("setSecure", true);
+        promise.resolve(setSecure);
+    }
+
+    private void setSecureFlag() {
+        final SharedPreferences prefs = this.reactContext.getSharedPreferences("SecureFlag", Context.MODE_PRIVATE);
+        final boolean setSecure = prefs.getBoolean("setSecure", true);
+        final Activity activity = this.reactContext.getCurrentActivity();
+        if (activity != null) {
+            activity.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    final Window window = activity.getWindow();
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH && setSecure) {
+                        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE);
+                    } else {
+                        window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+                    }
+                }
+            });
         }
     }
 

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -126,4 +126,20 @@ const BOOL isDebug = NO;
   [RCTPushNotificationManager didReceiveLocalNotification:notification];
 }
 
+- (void)applicationDidEnterBackground:(UIApplication *)application
+{
+  UIImageView *imageView = [[UIImageView alloc] initWithFrame:self.window.bounds];
+  imageView.contentMode = UIViewContentModeCenter;
+  imageView.tag = 42;    // Give some decent tagvalue or keep a reference of imageView in self
+  imageView.backgroundColor = [UIColor whiteColor];
+  [imageView setImage:[UIImage imageNamed:@"LaunchImage"]];
+  [UIApplication.sharedApplication.keyWindow.subviews.lastObject addSubview:imageView];
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application
+ {
+  UIImageView *imageView = (UIImageView *)[UIApplication.sharedApplication.keyWindow.subviews.lastObject viewWithTag:42];   // search by the same tag value
+  [imageView removeFromSuperview];
+}
+
 @end

--- a/shared/settings/nav/index.native.js
+++ b/shared/settings/nav/index.native.js
@@ -3,11 +3,13 @@ import React from 'react'
 import {StyleSheet} from 'react-native'
 import {globalStyles, globalColors, globalMargins} from '../../styles'
 import {Box, Badge, ClickableBox, Text, HeaderHoc} from '../../common-adapters'
+import {isAndroid} from '../../constants/platform'
 import {
   devMenuTab,
   feedbackTab,
   aboutTab,
   devicesTab,
+  screenprotectorTab,
 } from '../../constants/settings'
 import {compose, defaultProps} from 'recompose'
 
@@ -42,6 +44,13 @@ function SettingsNav ({badgeNumbers, selectedTab, onTabChange, onLogout}: Props)
         badgeNumber={badgeNumbers[feedbackTab]}
         onClick={() => onTabChange(feedbackTab)}
       />
+      {isAndroid &&
+        <SettingsItem
+          text='Screen Protector'
+          badgeNumber={0}
+          onClick={() => onTabChange(screenprotectorTab)}
+        />
+      }
       <SettingsItem
         text='Sign out'
         badgeNumber={0}

--- a/shared/settings/routes.native.js
+++ b/shared/settings/routes.native.js
@@ -17,7 +17,7 @@ import DeleteContainer from './delete/container'
 import RemoveDevice from '../devices/device-revoke/container'
 import DeleteConfirm from './delete-confirm/container'
 import DevMenu from '../dev/dev-menu'
-import Screenprotector from './screenprotector'
+import Screenprotector from './screenprotector.native'
 
 import * as Constants from '../constants/settings'
 

--- a/shared/settings/routes.native.js
+++ b/shared/settings/routes.native.js
@@ -17,6 +17,7 @@ import DeleteContainer from './delete/container'
 import RemoveDevice from '../devices/device-revoke/container'
 import DeleteConfirm from './delete-confirm/container'
 import DevMenu from '../dev/dev-menu'
+import Screenprotector from './screenprotector'
 
 import * as Constants from '../constants/settings'
 
@@ -32,6 +33,9 @@ const routeTree = new RouteDefNode({
     [Constants.landingTab]: {
       // TODO
       component: About,
+    },
+    'screenprotector': {
+      component: Screenprotector,
     },
     [Constants.invitationsTab]: {
       component: InvitationsContainer,

--- a/shared/settings/routes.native.js
+++ b/shared/settings/routes.native.js
@@ -34,7 +34,7 @@ const routeTree = new RouteDefNode({
       // TODO
       component: About,
     },
-    'screenprotector': {
+    [Constants.screenprotectorTab]: {
       component: Screenprotector,
     },
     [Constants.invitationsTab]: {

--- a/shared/settings/screenprotector.native.js
+++ b/shared/settings/screenprotector.native.js
@@ -4,6 +4,7 @@ import React, {Component} from 'react'
 import {globalStyles} from '../styles'
 import {Box, Icon, Text, Checkbox} from '../common-adapters'
 import {getSecureFlagSetting, setSecureFlagSetting} from '../native/screenprotector'
+import {isAndroid} from '../constants/platform'
 
 type State = {
   secureFlag: boolean,
@@ -36,6 +37,10 @@ class Screenprotector extends Component {
   }
 
   render () {
+    if (!isAndroid) {
+      return <Text type='Body'>Screenprotector is only supported on android</Text>
+    }
+
     return (
       <Box style={{...globalStyles.flexBoxColumn, flex: 1, alignItems: 'center', justifyContent: 'center'}}>
         <Icon type='icon-keybase-logo-128' />

--- a/shared/settings/screenprotector.native.js
+++ b/shared/settings/screenprotector.native.js
@@ -5,7 +5,6 @@ import {globalStyles} from '../styles'
 import {Box, Icon, Text, Checkbox} from '../common-adapters'
 import {getSecureFlagSetting, setSecureFlagSetting} from '../native/screenprotector'
 
-type Props = {}
 type State = {
   secureFlag: boolean,
 }

--- a/shared/settings/screenprotector.native.js
+++ b/shared/settings/screenprotector.native.js
@@ -1,0 +1,54 @@
+// @flow
+
+import React, {Component} from 'react'
+import {globalStyles} from '../styles'
+import {Box, Icon, Text, Checkbox} from '../common-adapters'
+import {getSecureFlagSetting, setSecureFlagSetting} from '../native/screenprotector'
+
+type Props = {}
+type State = {
+  secureFlag: boolean,
+}
+
+class Screenprotector extends Component {
+  state: State = {secureFlag: false}
+  mounted = false
+
+  componentWillMount () {
+    getSecureFlagSetting().then(secureFlag => {
+      this.setState({secureFlag})
+    })
+  }
+
+  componentWillUnmount () {
+    this.mounted = false
+  }
+
+  componentDidMount () {
+    this.mounted = true
+  }
+
+  _changeSecureFlagOption = (nextValue: boolean) => {
+    setSecureFlagSetting(nextValue).then(success => {
+      if (success && this.mounted) {
+        this.setState({secureFlag: nextValue})
+      }
+    })
+  }
+
+  render () {
+    return (
+      <Box style={{...globalStyles.flexBoxColumn, flex: 1, alignItems: 'center', justifyContent: 'center'}}>
+        <Icon type='icon-keybase-logo-128' />
+        <Text style={{textAlign: 'center'}} type='Body'>By default, we prevent android from showing the screen on the App Switcher and we prevent screenshots.</Text>
+        <Text type='Body' style={{textAlign: 'center'}}>You can change this below</Text>
+        <Checkbox
+          label='Disable App switcher preview and screenshots.'
+          onCheck={this._changeSecureFlagOption}
+          checked={this.state.secureFlag} />
+      </Box>
+    )
+  }
+}
+
+export default Screenprotector


### PR DESCRIPTION
@keybase/react-hackers 

Adds a new module to android which controls the secure flag setting.
Adds a new settings tab that has a minimal setting for disabling app switcher preview and screenshots.

The design is pretty minimal but happy to iterate on it.