### PR TITLE
various inbox fixes CORE-4810 CORE-4858

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -618,7 +618,8 @@ func (s *HybridInboxSource) NewMessage(ctx context.Context, uid gregor1.UID, ver
 	defer s.Trace(ctx, func() error { return err }, "NewMessage")()
 
 	if cerr := storage.NewInbox(s.G(), uid).NewMessage(ctx, vers, convID, msg); cerr != nil {
-		return nil, s.handleInboxError(ctx, cerr, uid)
+		err = s.handleInboxError(ctx, cerr, uid)
+		return nil, err
 	}
 
 	if conv, err = s.getConvLocal(ctx, uid, convID); err != nil {

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -863,6 +863,14 @@ func (i *Inbox) ServerVersion(ctx context.Context) (vers int, err Error) {
 	return vers, nil
 }
 
+type ByConvMtime []chat1.Conversation
+
+func (b ByConvMtime) Len() int      { return len(b) }
+func (b ByConvMtime) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b ByConvMtime) Less(i, j int) bool {
+	return b[i].ReaderInfo.Mtime.After(b[j].ReaderInfo.Mtime)
+}
+
 func (i *Inbox) Sync(ctx context.Context, vers chat1.InboxVers, convs []chat1.Conversation) (err Error) {
 	locks.Inbox.Lock()
 	defer locks.Inbox.Unlock()
@@ -892,9 +900,9 @@ func (i *Inbox) Sync(ctx context.Context, vers chat1.InboxVers, convs []chat1.Co
 	for _, conv := range convMap {
 		ibox.Conversations = append(ibox.Conversations, conv)
 	}
+	sort.Sort(ByConvMtime(ibox.Conversations))
 
 	i.Debug(ctx, "Sync: old vers: %v new vers: %v convs: %d", oldVers, ibox.InboxVersion, len(convs))
-
 	if err = i.writeDiskInbox(ctx, ibox); err != nil {
 		return err
 	}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -21,7 +21,7 @@ import (
 	"github.com/keybase/client/go/protocol/gregor1"
 )
 
-const inboxVersion = 9
+const inboxVersion = 10
 
 type queryHash []byte
 

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -645,6 +645,12 @@ func (i *Inbox) NewMessage(ctx context.Context, vers chat1.InboxVers, convID cha
 		return err
 	}
 
+	// Check for a delete, if so just auto return a version mismatch to resync. The reason
+	// is it is tricky to update max messages in this case.
+	if msg.GetMessageType() == chat1.MessageType_DELETE {
+		return NewVersionMismatchError(ibox.InboxVersion, vers)
+	}
+
 	// Find conversation
 	index, conv := i.getConv(convID, ibox.Conversations)
 	if conv == nil {

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -561,7 +561,8 @@ func TestInboxSync(t *testing.T) {
 	convs[6].Metadata.Status = chat1.ConversationStatus_MUTED
 	syncConvs = append(syncConvs, convs[0])
 	syncConvs = append(syncConvs, convs[6])
-	syncConvs = append(syncConvs, makeConvo(gregor1.Time(60), 1, 1))
+	newConv := makeConvo(gregor1.Time(60), 1, 1)
+	syncConvs = append(syncConvs, newConv)
 
 	vers, err := inbox.Version(context.TODO())
 	require.NoError(t, err)
@@ -569,10 +570,12 @@ func TestInboxSync(t *testing.T) {
 	newVers, newRes, _, err := inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, vers+1, newVers)
-	require.Equal(t, chat1.ConversationStatus_MUTED, newRes[0].Metadata.Status)
-	require.Equal(t, chat1.ConversationStatus_MUTED, newRes[6].Metadata.Status)
-	require.Equal(t, chat1.ConversationStatus_UNFILED, newRes[3].Metadata.Status)
-	require.Equal(t, len(res), len(newRes))
+	require.Equal(t, len(res)+1, len(newRes))
+	require.Equal(t, newConv.GetConvID(), newRes[0].GetConvID())
+	require.Equal(t, chat1.ConversationStatus_MUTED, newRes[1].Metadata.Status)
+	require.Equal(t, chat1.ConversationStatus_MUTED, newRes[7].Metadata.Status)
+	require.Equal(t, chat1.ConversationStatus_UNFILED, newRes[4].Metadata.Status)
+
 }
 
 func TestInboxServerVersion(t *testing.T) {

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -96,7 +96,9 @@ function * _incomingMessage (action: Constants.IncomingMessage): SagaGenerator<a
           return
         }
 
-        yield call(Inbox.processConversation, incomingMessage.conv)
+        if (incomingMessage.conv) {
+          yield call(Inbox.processConversation, incomingMessage.conv)
+        }
 
         const messageUnboxed: ChatTypes.MessageUnboxed = incomingMessage.message
         const yourName = yield select(usernameSelector)


### PR DESCRIPTION
Patch does the following:

1.) Processes errors from `Sync` in `Inbox` better.
2.) Punts on incrementally updating a conversation from a new delete message, just resyncs conversation.
3.) Fixes `Inbox.Sync` to add new conversations, and to provide the proper ordering.

@chrisnojima, this makes handling deletes a lot better in the app. However, it does cause a screen flicker as a result of the thread stale message that gets generated. Is there anyway to avoid that? If not, we can come up with something better here (maybe a different message). Also there is a small JS change in here you should probably look at.