### PR TITLE
add new conversations and keep order during inbox sync CORE-4858

### DIFF
--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -863,6 +863,14 @@ func (i *Inbox) ServerVersion(ctx context.Context) (vers int, err Error) {
 	return vers, nil
 }
 
+type ByConvMtime []chat1.Conversation
+
+func (b ByConvMtime) Len() int      { return len(b) }
+func (b ByConvMtime) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b ByConvMtime) Less(i, j int) bool {
+	return b[i].ReaderInfo.Mtime.After(b[j].ReaderInfo.Mtime)
+}
+
 func (i *Inbox) Sync(ctx context.Context, vers chat1.InboxVers, convs []chat1.Conversation) (err Error) {
 	locks.Inbox.Lock()
 	defer locks.Inbox.Unlock()
@@ -892,9 +900,9 @@ func (i *Inbox) Sync(ctx context.Context, vers chat1.InboxVers, convs []chat1.Co
 	for _, conv := range convMap {
 		ibox.Conversations = append(ibox.Conversations, conv)
 	}
+	sort.Sort(ByConvMtime(ibox.Conversations))
 
 	i.Debug(ctx, "Sync: old vers: %v new vers: %v convs: %d", oldVers, ibox.InboxVersion, len(convs))
-
 	if err = i.writeDiskInbox(ctx, ibox); err != nil {
 		return err
 	}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -21,7 +21,7 @@ import (
 	"github.com/keybase/client/go/protocol/gregor1"
 )
 
-const inboxVersion = 9
+const inboxVersion = 10
 
 type queryHash []byte
 

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -863,14 +863,6 @@ func (i *Inbox) ServerVersion(ctx context.Context) (vers int, err Error) {
 	return vers, nil
 }
 
-type ByConvMtime []chat1.Conversation
-
-func (b ByConvMtime) Len() int      { return len(b) }
-func (b ByConvMtime) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
-func (b ByConvMtime) Less(i, j int) bool {
-	return b[i].ReaderInfo.Mtime.After(b[j].ReaderInfo.Mtime)
-}
-
 func (i *Inbox) Sync(ctx context.Context, vers chat1.InboxVers, convs []chat1.Conversation) (err Error) {
 	locks.Inbox.Lock()
 	defer locks.Inbox.Unlock()
@@ -900,7 +892,7 @@ func (i *Inbox) Sync(ctx context.Context, vers chat1.InboxVers, convs []chat1.Co
 	for _, conv := range convMap {
 		ibox.Conversations = append(ibox.Conversations, conv)
 	}
-	sort.Sort(ByConvMtime(ibox.Conversations))
+	sort.Sort(ByDatabaseOrder(ibox.Conversations))
 
 	i.Debug(ctx, "Sync: old vers: %v new vers: %v convs: %d", oldVers, ibox.InboxVersion, len(convs))
 	if err = i.writeDiskInbox(ctx, ibox); err != nil {

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -561,7 +561,8 @@ func TestInboxSync(t *testing.T) {
 	convs[6].Metadata.Status = chat1.ConversationStatus_MUTED
 	syncConvs = append(syncConvs, convs[0])
 	syncConvs = append(syncConvs, convs[6])
-	syncConvs = append(syncConvs, makeConvo(gregor1.Time(60), 1, 1))
+	newConv := makeConvo(gregor1.Time(60), 1, 1)
+	syncConvs = append(syncConvs, newConv)
 
 	vers, err := inbox.Version(context.TODO())
 	require.NoError(t, err)
@@ -569,10 +570,12 @@ func TestInboxSync(t *testing.T) {
 	newVers, newRes, _, err := inbox.Read(context.TODO(), nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, vers+1, newVers)
-	require.Equal(t, chat1.ConversationStatus_MUTED, newRes[0].Metadata.Status)
-	require.Equal(t, chat1.ConversationStatus_MUTED, newRes[6].Metadata.Status)
-	require.Equal(t, chat1.ConversationStatus_UNFILED, newRes[3].Metadata.Status)
-	require.Equal(t, len(res), len(newRes))
+	require.Equal(t, len(res)+1, len(newRes))
+	require.Equal(t, newConv.GetConvID(), newRes[0].GetConvID())
+	require.Equal(t, chat1.ConversationStatus_MUTED, newRes[1].Metadata.Status)
+	require.Equal(t, chat1.ConversationStatus_MUTED, newRes[7].Metadata.Status)
+	require.Equal(t, chat1.ConversationStatus_UNFILED, newRes[4].Metadata.Status)
+
 }
 
 func TestInboxServerVersion(t *testing.T) {


### PR DESCRIPTION
This fixes the following two problems:

1.) New conversations were not added to local inbox on `Sync`.
2.) The order of the inbox was not preserved when calling `Sync.

Both of these should be properly tested for now as well.