### PR TITLE
when we receive a delete message, just resync from the server CORE-4810

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -616,12 +616,10 @@ func (s *HybridInboxSource) getConvLocal(ctx context.Context, uid gregor1.UID,
 func (s *HybridInboxSource) NewMessage(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 	convID chat1.ConversationID, msg chat1.MessageBoxed) (conv *chat1.ConversationLocal, err error) {
 	defer s.Trace(ctx, func() error { return err }, "NewMessage")()
-
 	if cerr := storage.NewInbox(s.G(), uid).NewMessage(ctx, vers, convID, msg); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
 		return nil, err
 	}
-
 	if conv, err = s.getConvLocal(ctx, uid, convID); err != nil {
 		s.Debug(ctx, "NewMessage: unable to load conversation: convID: %s err: %s", convID, err.Error())
 		return nil, nil

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -618,7 +618,8 @@ func (s *HybridInboxSource) NewMessage(ctx context.Context, uid gregor1.UID, ver
 	defer s.Trace(ctx, func() error { return err }, "NewMessage")()
 
 	if cerr := storage.NewInbox(s.G(), uid).NewMessage(ctx, vers, convID, msg); cerr != nil {
-		return nil, s.handleInboxError(ctx, cerr, uid)
+		err = s.handleInboxError(ctx, cerr, uid)
+		return nil, err
 	}
 
 	if conv, err = s.getConvLocal(ctx, uid, convID); err != nil {

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -645,6 +645,12 @@ func (i *Inbox) NewMessage(ctx context.Context, vers chat1.InboxVers, convID cha
 		return err
 	}
 
+	// Check for a delete, if so just auto return a version mismatch to resync. The reason
+	// is it is tricky to update max messages in this case.
+	if msg.GetMessageType() == chat1.MessageType_DELETE {
+		return NewVersionMismatchError(ibox.InboxVersion, vers)
+	}
+
 	// Find conversation
 	index, conv := i.getConv(convID, ibox.Conversations)
 	if conv == nil {

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -869,14 +869,6 @@ func (i *Inbox) ServerVersion(ctx context.Context) (vers int, err Error) {
 	return vers, nil
 }
 
-type ByConvMtime []chat1.Conversation
-
-func (b ByConvMtime) Len() int      { return len(b) }
-func (b ByConvMtime) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
-func (b ByConvMtime) Less(i, j int) bool {
-	return b[i].ReaderInfo.Mtime.After(b[j].ReaderInfo.Mtime)
-}
-
 func (i *Inbox) Sync(ctx context.Context, vers chat1.InboxVers, convs []chat1.Conversation) (err Error) {
 	locks.Inbox.Lock()
 	defer locks.Inbox.Unlock()

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -863,6 +863,14 @@ func (i *Inbox) ServerVersion(ctx context.Context) (vers int, err Error) {
 	return vers, nil
 }
 
+type ByConvMtime []chat1.Conversation
+
+func (b ByConvMtime) Len() int      { return len(b) }
+func (b ByConvMtime) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b ByConvMtime) Less(i, j int) bool {
+	return b[i].ReaderInfo.Mtime.After(b[j].ReaderInfo.Mtime)
+}
+
 func (i *Inbox) Sync(ctx context.Context, vers chat1.InboxVers, convs []chat1.Conversation) (err Error) {
 	locks.Inbox.Lock()
 	defer locks.Inbox.Unlock()

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -543,14 +543,16 @@ func (m *ChatRemoteMock) GetInboxVersion(ctx context.Context, uid gregor1.UID) (
 
 func (m *ChatRemoteMock) SyncInbox(ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
 	if m.SyncInboxFunc == nil {
-		return chat1.SyncInboxRes{}, nil
+		return chat1.NewSyncInboxResWithClear(), nil
 	}
 	return m.SyncInboxFunc(m, ctx, vers)
 }
 
 func (m *ChatRemoteMock) SyncChat(ctx context.Context, vers chat1.InboxVers) (chat1.SyncChatRes, error) {
 	if m.SyncInboxFunc == nil {
-		return chat1.SyncChatRes{}, nil
+		return chat1.SyncChatRes{
+			InboxRes: chat1.NewSyncInboxResWithClear(),
+		}, nil
 	}
 
 	iboxRes, err := m.SyncInboxFunc(m, ctx, vers)

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -96,7 +96,9 @@ function * _incomingMessage (action: Constants.IncomingMessage): SagaGenerator<a
           return
         }
 
-        yield call(Inbox.processConversation, incomingMessage.conv)
+        if (incomingMessage.conv) {
+          yield call(Inbox.processConversation, incomingMessage.conv)
+        }
 
         const messageUnboxed: ChatTypes.MessageUnboxed = incomingMessage.message
         const yourName = yield select(usernameSelector)


### PR DESCRIPTION
This PR is back! Upon further reflection, I think this is the right play for handling this case on the service. It is unfortunate it causes the screen flicker from the stale message, but that is strictly better than the current behavior. 

The options to fix the flicker are for the frontend to not redraw everything if nothing has changed in the thread, or to just have a different message that indicates only the inbox row has changed. 

@chrisnojima This still has the JS change from my original PR.