### PR TITLE
Don't send the decoded QR code text to the service more than once

### DIFF
--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -392,7 +392,16 @@ const makeKex2IncomingMap = (dispatch, getState, onBack: SimpleCB, onProvisioner
     'keybase.1.provisionUi.DisplayAndPromptSecret': ({phrase, secret}, response) => {
       dispatch({payload: {textCode: new HiddenString(phrase)}, type: Constants.setTextCode})
       generateQRCode(dispatch, getState)
-      dispatch(askForCodePage(phrase => { response.result({phrase, secret: null}) }, () => onBack(response)))
+      let codeSent = false
+      dispatch(askForCodePage(phrase => {
+        if (!codeSent) {
+          // Without this lock, we would send hundreds of RPC replies as each
+          // camera frame with a QR code present gets interpreted, and that
+          // causes a "waitingForResponse" spinner on the next screen.
+          codeSent = true
+          response.result({phrase, secret: null})
+        }
+      }, () => onBack(response)))
     },
     'keybase.1.provisionUi.DisplaySecretExchanged': (param, response) => response.result(),
     'keybase.1.provisionUi.PromptNewDeviceName': ({existingDevices, errorMessage}, response) => {


### PR DESCRIPTION
@keybase/react-hackers 

This is the annoying QR code Continue button spinner bug I was chasing for a long time! \o/

We were calling `qrScanned(code)` on every frame from the camera that contained a QR code, and it was in turn calling `response.result(code)` for every frame.  They backed up our RPC connection to the service and resulted in the spinner (which correlates with `waitingForResponse` being true) on the next screen.