### PR TITLE
foce full ID on self with remote assertions

### DIFF
--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -431,7 +431,7 @@ func (e *Identify2WithUID) runReturnError(ctx *Context) (err error) {
 		return err
 	}
 
-	if e.isSelfLoad() && !e.arg.NoSkipSelf {
+	if e.isSelfLoad() && !e.arg.NoSkipSelf && !e.useRemoteAssertions() {
 		e.G().Log.CDebugf(netCtx, "| was a self load, short-circuiting")
 		e.maybeCacheSelf()
 		return nil


### PR DESCRIPTION
I can't imagine this is being used for much, but best to do the cautious this. @strib hit this bug in his testing.