### PR TITLE
Fix crash when rendering nonexistent mock in mobile dumb sheet

### DIFF
--- a/shared/dev/dumb-sheet/render.native.js
+++ b/shared/dev/dumb-sheet/render.native.js
@@ -84,7 +84,7 @@ class DumbSheetRender extends Component<void, Props, any> {
 
   _getComponent (filter: ?string, renderIdx: number): {component: any, mock: any, key: any} {
     let component = null
-    let mock = null
+    let mock = {}
     let key = null
 
     let currentIdx = 0


### PR DESCRIPTION
:eyeglasses: @keybase/react-hackers 