### PR TITLE
Allow read access to active device keys outside of LoginState acctReq

### DIFF
--- a/go/engine/crypto.go
+++ b/go/engine/crypto.go
@@ -28,10 +28,7 @@ func GetMySecretKey(ctx context.Context, g *libkb.GlobalContext, getSecretUI fun
 
 	// check ActiveDevice cache after acquiring lock
 	key, err := g.ActiveDevice.KeyByType(secretKeyType)
-	if err != nil {
-		return nil, err
-	}
-	if key != nil {
+	if err == nil && key != nil {
 		g.Log.CDebugf(ctx, "found cached device key in ActiveDevice")
 		return key, nil
 	}
@@ -271,8 +268,8 @@ func getMatchingSecretKey(g *libkb.GlobalContext, getSecretUI func() libkb.Secre
 // check cached keys for arg.Bundles match.
 func matchingCachedKey(g *libkb.GlobalContext, arg keybase1.UnboxBytes32AnyArg) (key libkb.GenericKey, index int, err error) {
 	// check device key first
-	dkey := g.ActiveDevice.EncryptionKey()
-	if dkey != nil {
+	dkey, err := g.ActiveDevice.EncryptionKey()
+	if err == nil && dkey != nil {
 		if n, ok := kidMatch(dkey, arg.Bundles); ok {
 			return dkey, n, nil
 		}

--- a/go/engine/crypto_test.go
+++ b/go/engine/crypto_test.go
@@ -222,14 +222,7 @@ func TestCryptoUnboxBytes32NoEncryptionKey(t *testing.T) {
 }
 
 func cachedSecretKey(tc libkb.TestContext, ktype libkb.SecretKeyType) (key libkb.GenericKey, err error) {
-	aerr := tc.G.LoginState().Account(func(a *libkb.Account) {
-		key, err = a.CachedSecretKey(libkb.SecretKeyArg{KeyType: ktype})
-	}, "cachedSecretKey")
-
-	if aerr != nil {
-		return nil, aerr
-	}
-	return key, err
+	return tc.G.ActiveDevice.KeyByType(ktype)
 }
 
 func assertCachedSecretKey(tc libkb.TestContext, ktype libkb.SecretKeyType) {

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -2674,24 +2674,9 @@ func skipOldGPG(tc libkb.TestContext) {
 }
 
 func assertDeviceKeysCached(tc libkb.TestContext) {
-	var sk, ek libkb.GenericKey
-	var skerr, ekerr error
-
-	aerr := tc.G.LoginState().Account(func(a *libkb.Account) {
-		sk, skerr = a.CachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType})
-		ek, ekerr = a.CachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceEncryptionKeyType})
-	}, "assertDeviceKeysCached")
-	if aerr != nil {
-		tc.T.Fatal(aerr)
-	}
-	if skerr != nil {
-		tc.T.Fatalf("error getting cached signing key: %s", skerr)
-	}
+	_, _, sk, ek := tc.G.ActiveDevice.AllFields()
 	if sk == nil {
 		tc.T.Error("cached signing key nil")
-	}
-	if ekerr != nil {
-		tc.T.Fatalf("error getting cached encryption key: %s", ekerr)
 	}
 	if ek == nil {
 		tc.T.Error("cached encryption key nil")

--- a/go/engine/login_with_paperkey_test.go
+++ b/go/engine/login_with_paperkey_test.go
@@ -191,28 +191,14 @@ func AssertLoggedInLPK(tc *libkb.TestContext, shouldBeLoggedIn bool) {
 }
 
 func AssertDeviceKeysLock(tc *libkb.TestContext, shouldBeUnlocked bool) {
-	var err error
-	var err2 error
-	t := tc.T
+	_, _, sk, ek := tc.G.ActiveDevice.AllFields()
 
-	err = tc.G.LoginState().Account(func(a *libkb.Account) {
-		_, err2 = a.CachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType})
-	}, "test")
-	require.NoError(t, err)
 	if shouldBeUnlocked {
-		require.NoError(t, err2, "device signing key should be available")
+		require.NotNil(tc.T, sk, "device signing key should be available")
+		require.NotNil(tc.T, ek, "device encryption key should be available")
 	} else {
-		require.Error(t, err2, "device signing key should be unavailable")
-	}
-
-	err = tc.G.LoginState().Account(func(a *libkb.Account) {
-		_, err2 = a.CachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceEncryptionKeyType})
-	}, "test")
-	require.NoError(t, err)
-	if shouldBeUnlocked {
-		require.NoError(t, err2, "device encryption key should be available")
-	} else {
-		require.Error(t, err2, "device encryption key should be unavailable")
+		require.Nil(tc.T, sk, "device signing key should be unavailable")
+		require.Nil(tc.T, ek, "device encryption key should be unavailable")
 	}
 }
 

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -91,7 +91,7 @@ func (a *Account) LoggedIn() bool {
 	return a.LocalSession().IsLoggedIn()
 }
 
-func (a *Account) LoggedInAndProvisioined() bool {
+func (a *Account) LoggedInAndProvisioned() bool {
 	return a.LocalSession().IsLoggedInAndProvisioned()
 }
 
@@ -483,11 +483,17 @@ func (a *Account) SetCachedSecretKey(ska SecretKeyArg, key GenericKey) error {
 	if ska.KeyType == DeviceSigningKeyType {
 		a.G().Log.Debug("caching secret key for %d", ska.KeyType)
 		a.secSigKey = key
+		if err := a.G().ActiveDevice.setSigningKey(a.localSession.GetUID(), a.localSession.GetDeviceID(), key); err != nil {
+			return err
+		}
 		return nil
 	}
 	if ska.KeyType == DeviceEncryptionKeyType {
 		a.G().Log.Debug("caching secret key for %d", ska.KeyType)
 		a.secEncKey = key
+		if err := a.G().ActiveDevice.setEncryptionKey(a.localSession.GetUID(), a.localSession.GetDeviceID(), key); err != nil {
+			return err
+		}
 		return nil
 	}
 	return fmt.Errorf("attempt to cache invalid key type: %d", ska.KeyType)
@@ -518,6 +524,7 @@ func (a *Account) ClearCachedSecretKeys() {
 	a.secSigKey = nil
 	a.secEncKey = nil
 	a.ClearPaperKeys()
+	a.G().ActiveDevice.clear()
 }
 
 func (a *Account) ClearPaperKeys() {

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -464,11 +464,11 @@ func (a *Account) SetCachedSecretKey(ska SecretKeyArg, key GenericKey) error {
 	}
 	if ska.KeyType == DeviceSigningKeyType {
 		a.G().Log.Debug("caching secret device signing key")
-		return a.G().ActiveDevice.setSigningKey(a.localSession.GetUID(), a.localSession.GetDeviceID(), key)
+		return a.G().ActiveDevice.setSigningKey(a, a.localSession.GetUID(), a.localSession.GetDeviceID(), key)
 	}
 	if ska.KeyType == DeviceEncryptionKeyType {
 		a.G().Log.Debug("caching secret device encryption key")
-		return a.G().ActiveDevice.setEncryptionKey(a.localSession.GetUID(), a.localSession.GetDeviceID(), key)
+		return a.G().ActiveDevice.setEncryptionKey(a, a.localSession.GetUID(), a.localSession.GetDeviceID(), key)
 	}
 	return fmt.Errorf("attempt to cache invalid key type: %d", ska.KeyType)
 }
@@ -496,7 +496,9 @@ func (a *Account) GetUnlockedPaperEncKey() GenericKey {
 func (a *Account) ClearCachedSecretKeys() {
 	a.G().Log.Debug("clearing cached secret keys")
 	a.ClearPaperKeys()
-	a.G().ActiveDevice.clear()
+	if err := a.G().ActiveDevice.clear(a); err != nil {
+		a.G().Log.Warning("error clearing ActiveDevice: %s", err)
+	}
 }
 
 func (a *Account) ClearPaperKeys() {

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -47,9 +47,7 @@ type Account struct {
 	loginSession *LoginSession
 	streamCache  *PassphraseStreamCache
 	skbKeyring   *SKBKeyringFile
-	secSigKey    GenericKey // cached secret signing key
-	secEncKey    GenericKey // cached secret encryption key
-	lksec        *LKSec     // local key security (this member not currently used)
+	lksec        *LKSec // local key security (this member not currently used)
 
 	paperSigKey *timedGenericKey // cached, unlocked paper signing key
 	paperEncKey *timedGenericKey // cached, unlocked paper encryption key
@@ -460,43 +458,17 @@ func (a *Account) Dump() {
 	a.streamCache.Dump()
 }
 
-/*
-func (a *Account) CachedSecretKey(ska SecretKeyArg) (GenericKey, error) {
-	if ska.KeyType == DeviceSigningKeyType {
-		if a.secSigKey != nil {
-			return a.secSigKey, nil
-		}
-		return nil, NotFoundError{}
-	}
-	if ska.KeyType == DeviceEncryptionKeyType {
-		if a.secEncKey != nil {
-			return a.secEncKey, nil
-		}
-		return nil, NotFoundError{}
-	}
-	return nil, fmt.Errorf("invalid key type for cached secret key: %d", ska.KeyType)
-}
-*/
-
 func (a *Account) SetCachedSecretKey(ska SecretKeyArg, key GenericKey) error {
 	if key == nil {
 		return errors.New("cache of nil secret key attempted")
 	}
 	if ska.KeyType == DeviceSigningKeyType {
-		a.G().Log.Debug("caching secret key for %d", ska.KeyType)
-		a.secSigKey = key
-		if err := a.G().ActiveDevice.setSigningKey(a.localSession.GetUID(), a.localSession.GetDeviceID(), key); err != nil {
-			return err
-		}
-		return nil
+		a.G().Log.Debug("caching secret device signing key")
+		return a.G().ActiveDevice.setSigningKey(a.localSession.GetUID(), a.localSession.GetDeviceID(), key)
 	}
 	if ska.KeyType == DeviceEncryptionKeyType {
-		a.G().Log.Debug("caching secret key for %d", ska.KeyType)
-		a.secEncKey = key
-		if err := a.G().ActiveDevice.setEncryptionKey(a.localSession.GetUID(), a.localSession.GetDeviceID(), key); err != nil {
-			return err
-		}
-		return nil
+		a.G().Log.Debug("caching secret device encryption key")
+		return a.G().ActiveDevice.setEncryptionKey(a.localSession.GetUID(), a.localSession.GetDeviceID(), key)
 	}
 	return fmt.Errorf("attempt to cache invalid key type: %d", ska.KeyType)
 }
@@ -523,8 +495,6 @@ func (a *Account) GetUnlockedPaperEncKey() GenericKey {
 
 func (a *Account) ClearCachedSecretKeys() {
 	a.G().Log.Debug("clearing cached secret keys")
-	a.secSigKey = nil
-	a.secEncKey = nil
 	a.ClearPaperKeys()
 	a.G().ActiveDevice.clear()
 }

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -460,6 +460,7 @@ func (a *Account) Dump() {
 	a.streamCache.Dump()
 }
 
+/*
 func (a *Account) CachedSecretKey(ska SecretKeyArg) (GenericKey, error) {
 	if ska.KeyType == DeviceSigningKeyType {
 		if a.secSigKey != nil {
@@ -475,6 +476,7 @@ func (a *Account) CachedSecretKey(ska SecretKeyArg) (GenericKey, error) {
 	}
 	return nil, fmt.Errorf("invalid key type for cached secret key: %d", ska.KeyType)
 }
+*/
 
 func (a *Account) SetCachedSecretKey(ska SecretKeyArg, key GenericKey) error {
 	if key == nil {

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -2,6 +2,7 @@ package libkb
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -99,6 +100,17 @@ func (a *ActiveDevice) EncryptionKey() GenericKey {
 	a.RLock()
 	defer a.RUnlock()
 	return a.encryptionKey
+}
+
+func (a *ActiveDevice) KeyByType(t SecretKeyType) (GenericKey, error) {
+	switch t {
+	case DeviceSigningKeyType:
+		return a.SigningKey(), nil
+	case DeviceEncryptionKeyType:
+		return a.EncryptionKey(), nil
+	default:
+		return nil, fmt.Errorf("Invalid type %v", t)
+	}
 }
 
 func (a *ActiveDevice) AllFields() (uid keybase1.UID, deviceID keybase1.DeviceID, sigKey GenericKey, encKey GenericKey) {

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -1,0 +1,109 @@
+package libkb
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type ActiveDevice struct {
+	uid           keybase1.UID
+	deviceID      keybase1.DeviceID
+	signingKey    GenericKey // cached secret signing key
+	encryptionKey GenericKey // cached secret encryption key
+	sync.RWMutex
+}
+
+func (a *ActiveDevice) set(uid keybase1.UID, deviceID keybase1.DeviceID, sigKey, encKey GenericKey) error {
+	a.Lock()
+	defer a.Unlock()
+
+	if err := a.internalUpdateUIDDeviceID(uid, deviceID); err != nil {
+		return err
+	}
+
+	a.signingKey = sigKey
+	a.encryptionKey = encKey
+
+	return nil
+}
+
+func (a *ActiveDevice) setSigningKey(uid keybase1.UID, deviceID keybase1.DeviceID, sigKey GenericKey) error {
+	a.Lock()
+	defer a.Unlock()
+
+	if err := a.internalUpdateUIDDeviceID(uid, deviceID); err != nil {
+		return err
+	}
+
+	a.signingKey = sigKey
+	return nil
+}
+
+func (a *ActiveDevice) setEncryptionKey(uid keybase1.UID, deviceID keybase1.DeviceID, encKey GenericKey) error {
+	a.Lock()
+	defer a.Unlock()
+
+	if err := a.internalUpdateUIDDeviceID(uid, deviceID); err != nil {
+		return err
+	}
+
+	a.encryptionKey = encKey
+	return nil
+}
+
+// should only called by the functions in this type, with the write lock.
+func (a *ActiveDevice) internalUpdateUIDDeviceID(uid keybase1.UID, deviceID keybase1.DeviceID) error {
+	if a.uid.IsNil() && a.deviceID.IsNil() {
+		a.uid = uid
+		a.deviceID = deviceID
+	} else if a.uid.NotEqual(uid) {
+		return errors.New("ActiveDevice.setEncryptionKey uid mismatch")
+	} else if !a.deviceID.Eq(deviceID) {
+		return errors.New("ActiveDevice.setEncryptionKey deviceID mismatch")
+	}
+
+	return nil
+}
+
+func (a *ActiveDevice) clear() {
+	a.Lock()
+	defer a.Unlock()
+
+	a.uid = ""
+	a.deviceID = ""
+	a.signingKey = nil
+	a.encryptionKey = nil
+}
+
+func (a *ActiveDevice) UID() keybase1.UID {
+	a.RLock()
+	defer a.RUnlock()
+	return a.uid
+}
+
+func (a *ActiveDevice) DeviceID() keybase1.DeviceID {
+	a.RLock()
+	defer a.RUnlock()
+	return a.deviceID
+}
+
+func (a *ActiveDevice) SigningKey() GenericKey {
+	a.RLock()
+	defer a.RUnlock()
+	return a.signingKey
+}
+
+func (a *ActiveDevice) EncryptionKey() GenericKey {
+	a.RLock()
+	defer a.RUnlock()
+	return a.encryptionKey
+}
+
+func (a *ActiveDevice) AllFields() (uid keybase1.UID, deviceID keybase1.DeviceID, sigKey GenericKey, encKey GenericKey) {
+	a.RLock()
+	defer a.RUnlock()
+
+	return a.uid, a.deviceID, a.signingKey, a.encryptionKey
+}

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -90,24 +90,30 @@ func (a *ActiveDevice) DeviceID() keybase1.DeviceID {
 	return a.deviceID
 }
 
-func (a *ActiveDevice) SigningKey() GenericKey {
+func (a *ActiveDevice) SigningKey() (GenericKey, error) {
 	a.RLock()
 	defer a.RUnlock()
-	return a.signingKey
+	if a.signingKey == nil {
+		return nil, NotFoundError{}
+	}
+	return a.signingKey, nil
 }
 
-func (a *ActiveDevice) EncryptionKey() GenericKey {
+func (a *ActiveDevice) EncryptionKey() (GenericKey, error) {
 	a.RLock()
 	defer a.RUnlock()
-	return a.encryptionKey
+	if a.encryptionKey == nil {
+		return nil, NotFoundError{}
+	}
+	return a.encryptionKey, nil
 }
 
 func (a *ActiveDevice) KeyByType(t SecretKeyType) (GenericKey, error) {
 	switch t {
 	case DeviceSigningKeyType:
-		return a.SigningKey(), nil
+		return a.SigningKey()
 	case DeviceEncryptionKeyType:
-		return a.EncryptionKey(), nil
+		return a.EncryptionKey()
 	default:
 		return nil, fmt.Errorf("Invalid type %v", t)
 	}

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -210,6 +210,7 @@ func (g *GlobalContext) createLoginStateLocked() {
 		g.loginState.Shutdown()
 	}
 	g.loginState = NewLoginState(g)
+	g.ActiveDevice = new(ActiveDevice)
 }
 
 func (g *GlobalContext) createLoginState() {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -114,6 +114,8 @@ type GlobalContext struct {
 	// Options specified for testing only
 	TestOptions GlobalTestOptions
 
+	ActiveDevice *ActiveDevice
+
 	NetContext context.Context
 }
 
@@ -147,6 +149,7 @@ func NewGlobalContext() *GlobalContext {
 		lastUpgradeWarning: new(time.Time),
 		uchMu:              new(sync.Mutex),
 		NewTriplesec:       NewSecureTriplesec,
+		ActiveDevice:       new(ActiveDevice),
 		NetContext:         context.TODO(),
 	}
 }

--- a/go/libkb/keyring.go
+++ b/go/libkb/keyring.go
@@ -266,18 +266,21 @@ func (k *Keyrings) GetSecretKeyLocked(lctx LoginContext, ska SecretKeyArg) (ret 
 }
 
 func (k *Keyrings) cachedSecretKey(lctx LoginContext, ska SecretKeyArg) GenericKey {
-	var key GenericKey
-	var err error
-	if lctx != nil {
-		key, err = lctx.CachedSecretKey(ska)
-	} else {
-		aerr := k.G().LoginState().Account(func(a *Account) {
-			key, err = a.CachedSecretKey(ska)
-		}, "Keyrings - cachedSecretKey")
-		if aerr != nil {
-			k.G().Log.Debug("Account error: %s", aerr)
+	/*
+		var key GenericKey
+		var err error
+		if lctx != nil {
+			key, err = lctx.CachedSecretKey(ska)
+		} else {
+			aerr := k.G().LoginState().Account(func(a *Account) {
+				key, err = a.CachedSecretKey(ska)
+			}, "Keyrings - cachedSecretKey")
+			if aerr != nil {
+				k.G().Log.Debug("Account error: %s", aerr)
+			}
 		}
-	}
+	*/
+	key, err := k.G().ActiveDevice.KeyByType(ska.KeyType)
 
 	if key != nil && err == nil {
 		k.G().Log.Debug("found cached secret key for ska: %+v", ska)

--- a/go/libkb/keyring.go
+++ b/go/libkb/keyring.go
@@ -266,20 +266,6 @@ func (k *Keyrings) GetSecretKeyLocked(lctx LoginContext, ska SecretKeyArg) (ret 
 }
 
 func (k *Keyrings) cachedSecretKey(lctx LoginContext, ska SecretKeyArg) GenericKey {
-	/*
-		var key GenericKey
-		var err error
-		if lctx != nil {
-			key, err = lctx.CachedSecretKey(ska)
-		} else {
-			aerr := k.G().LoginState().Account(func(a *Account) {
-				key, err = a.CachedSecretKey(ska)
-			}, "Keyrings - cachedSecretKey")
-			if aerr != nil {
-				k.G().Log.Debug("Account error: %s", aerr)
-			}
-		}
-	*/
 	key, err := k.G().ActiveDevice.KeyByType(ska.KeyType)
 
 	if key != nil && err == nil {

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -62,7 +62,7 @@ type LoginContext interface {
 	SecretSyncer() *SecretSyncer
 	RunSecretSyncer(uid keybase1.UID) error
 
-	CachedSecretKey(ska SecretKeyArg) (GenericKey, error)
+	// CachedSecretKey(ska SecretKeyArg) (GenericKey, error)
 	SetCachedSecretKey(ska SecretKeyArg, key GenericKey) error
 	SetUnlockedPaperKey(sig GenericKey, enc GenericKey) error
 

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -62,7 +62,6 @@ type LoginContext interface {
 	SecretSyncer() *SecretSyncer
 	RunSecretSyncer(uid keybase1.UID) error
 
-	// CachedSecretKey(ska SecretKeyArg) (GenericKey, error)
 	SetCachedSecretKey(ska SecretKeyArg, key GenericKey) error
 	SetUnlockedPaperKey(sig GenericKey, enc GenericKey) error
 

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -6,10 +6,11 @@ package libkb
 import (
 	"errors"
 	"fmt"
-	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	"golang.org/x/net/context"
 	"runtime/debug"
 	"time"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
 )
 
 // PassphraseGeneration represents which generation of the passphrase is
@@ -900,7 +901,7 @@ func (s *LoginState) loginHandle(f loginHandler, after afterFn, name string) err
 // acctHandle creates an acctReq from an acctHandler and puts it
 // in the acctReqs channel.  It waits for the request handler to
 // close the done channel in the acctReq before returning.
-// For debugging purposes, there is a 10s timeout to help find any
+// For debugging purposes, there is a 5s timeout to help find any
 // cases where an account or login request is attempted while
 // another account or login request is in process.
 func (s *LoginState) acctHandle(f acctHandler, name string) error {

--- a/go/libkb/session.go
+++ b/go/libkb/session.go
@@ -80,6 +80,10 @@ func (s *Session) GetUID() keybase1.UID {
 	return s.uid
 }
 
+func (s *Session) GetDeviceID() keybase1.DeviceID {
+	return s.deviceID
+}
+
 func (s *Session) GetToken() string {
 	return s.token
 }

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -154,19 +154,16 @@ func (h ConfigHandler) GetExtendedStatus(ctx context.Context, sessionID int) (re
 		res.DeviceErr = &keybase1.LoadDeviceErr{Where: "libkb.LoadMe", Desc: err.Error()}
 	}
 
+	// cached device key status
+	_, _, sk, ek := h.G().ActiveDevice.AllFields()
+	res.DeviceSigKeyCached = sk != nil
+	res.DeviceEncKeyCached = ek != nil
+
 	h.G().LoginState().Account(func(a *libkb.Account) {
 		res.PassphraseStreamCached = a.PassphraseStreamCache().ValidPassphraseStream()
 		res.TsecCached = a.PassphraseStreamCache().ValidTsec()
 
-		// cached keys status
-		sk, err := a.CachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType})
-		if err == nil && sk != nil {
-			res.DeviceSigKeyCached = true
-		}
-		ek, err := a.CachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceEncryptionKeyType})
-		if err == nil && ek != nil {
-			res.DeviceEncKeyCached = true
-		}
+		// cached paper key status
 		if a.GetUnlockedPaperSigKey() != nil {
 			res.PaperSigKeyCached = true
 		}


### PR DESCRIPTION
This PR pulls the cached device keys out of the Account object and puts them in an ActiveDevice object.

The ActiveDevice object allows anything to have read access to the cached device keys without having to go through a LoginState account request (which could be blocked behind another account request).

The ActiveDevice object is protected by a RWMutex and its set functions are only called within LoginState account requests.

This should help chat function when offline as it will be able to get the device keys.