### PR TITLE
No need for a spinner on signup success page

### DIFF
--- a/shared/login/signup/success/index.render.desktop.js
+++ b/shared/login/signup/success/index.render.desktop.js
@@ -39,7 +39,7 @@ class SuccessRender extends Component<void, Props, State> {
         <Text type='Body' style={stylesBody}>Here is your unique paper key, it will allow you to perform important Keybase tasks in the future. This is the only time you'll see this so be sure to write it down.</Text>
         {contents}
         {this.props.onFinish && <Checkbox style={stylesCheck} label='Yes, I wrote this down.' checked={this.state.inWallet} onCheck={inWallet => this.setState({inWallet})} />}
-        {this.props.onFinish && <Button waiting={this.props.waiting} type='Primary' label='Done' onClick={this.props.onFinish} disabled={!this.state.inWallet} />}
+        {this.props.onFinish && <Button type='Primary' label='Done' onClick={this.props.onFinish} disabled={!this.state.inWallet} />}
       </Container>
     )
   }

--- a/shared/login/signup/success/index.render.native.js
+++ b/shared/login/signup/success/index.render.native.js
@@ -47,7 +47,6 @@ class SuccessRender extends Component<void, Props, State> {
         <Box style={{flex: 2, justifyContent: 'flex-end'}}>
           <Button style={buttonStyle}
             disabled={!this.state.checked}
-            waiting={this.props.waiting}
             onClick={this.props.onFinish}
             label='Done'
             type='Primary' />


### PR DESCRIPTION
@keybase/react-hackers 

It occurred to me that one answer to "The signup success page has a spinner on the continue button so I can't click it" is to just never show a spinner on that page -- if we get here, the signup is complete.

This isn't very satisfying because apparently we think there's an RPC request still outstanding.  But if we want to just ignore that, we could do this.  Happy to go either way.