### PR TITLE
detect offline errors from chat fetch endpoints and have them set offline CORE-4833

### DIFF
--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -136,6 +136,10 @@ func (s *Syncer) isServerInboxClear(ctx context.Context, inbox *storage.Inbox, s
 	return false
 }
 
+func (s *Syncer) IsConnected() bool {
+	return s.isConnected
+}
+
 func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,
 	syncRes *chat1.SyncChatRes) (err error) {
 	ctx = CtxAddLogTags(ctx)

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -136,7 +136,10 @@ func (s *Syncer) isServerInboxClear(ctx context.Context, inbox *storage.Inbox, s
 	return false
 }
 
-func (s *Syncer) IsConnected() bool {
+func (s *Syncer) IsConnected(ctx context.Context) bool {
+	s.Lock()
+	defer s.Unlock()
+	defer s.Trace(ctx, func() error { return nil }, "IsConnected")()
 	return s.isConnected
 }
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -84,6 +84,7 @@ type ServerCacheVersions interface {
 }
 
 type Syncer interface {
+	IsConnected() bool
 	Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,
 		syncRes *chat1.SyncChatRes) error
 	Disconnected(ctx context.Context)

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -84,7 +84,7 @@ type ServerCacheVersions interface {
 }
 
 type Syncer interface {
-	IsConnected() bool
+	IsConnected(ctx context.Context) bool
 	Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,
 		syncRes *chat1.SyncChatRes) error
 	Disconnected(ctx context.Context)

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -620,11 +620,7 @@ func (c *chatServiceHandler) MarkV1(ctx context.Context, opts markOptionsV1) Rep
 		return c.errReply(err)
 	}
 
-	allLimits := rlimits
-	if res.RateLimit != nil {
-		allLimits = append(allLimits, *res.RateLimit)
-	}
-
+	allLimits := append(rlimits, res.RateLimits...)
 	cres := EmptyRes{
 		RateLimits: RateLimits{
 			c.aggRateLimits(allLimits),

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -473,3 +473,43 @@ func NewConversationErrorLocal(
 		RekeyInfo:         rekeyInfo,
 	}
 }
+
+type OfflinableResult interface {
+	SetOffline()
+}
+
+func (r *NonblockFetchRes) SetOffline() {
+	r.Offline = true
+}
+
+func (r *MarkAsReadLocalRes) SetOffline() {
+	r.Offline = true
+}
+
+func (r *GetInboxAndUnboxLocalRes) SetOffline() {
+	r.Offline = true
+}
+
+func (r *GetThreadLocalRes) SetOffline() {
+	r.Offline = true
+}
+
+func (r *GetInboxSummaryForCLILocalRes) SetOffline() {
+	r.Offline = true
+}
+
+func (r *GetConversationForCLILocalRes) SetOffline() {
+	r.Offline = true
+}
+
+func (r *GetMessagesLocalRes) SetOffline() {
+	r.Offline = true
+}
+
+func (r *DownloadAttachmentLocalRes) SetOffline() {
+	r.Offline = true
+}
+
+func (r *FindConversationsLocalRes) SetOffline() {
+	r.Offline = true
+}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1482,8 +1482,14 @@ type LocalFileSource struct {
 }
 
 type DownloadAttachmentLocalRes struct {
+	Offline          bool                          `codec:"offline" json:"offline"`
 	RateLimits       []RateLimit                   `codec:"rateLimits" json:"rateLimits"`
 	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identifyFailures"`
+}
+
+type MarkAsReadLocalRes struct {
+	Offline    bool        `codec:"offline" json:"offline"`
+	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
 }
 
 type FindConversationsLocalRes struct {
@@ -1687,7 +1693,7 @@ type LocalInterface interface {
 	DownloadFileAttachmentLocal(context.Context, DownloadFileAttachmentLocalArg) (DownloadAttachmentLocalRes, error)
 	CancelPost(context.Context, OutboxID) error
 	RetryPost(context.Context, OutboxID) error
-	MarkAsReadLocal(context.Context, MarkAsReadLocalArg) (MarkAsReadRes, error)
+	MarkAsReadLocal(context.Context, MarkAsReadLocalArg) (MarkAsReadLocalRes, error)
 	FindConversationsLocal(context.Context, FindConversationsLocalArg) (FindConversationsLocalRes, error)
 }
 
@@ -2180,7 +2186,7 @@ func (c LocalClient) RetryPost(ctx context.Context, outboxID OutboxID) (err erro
 	return
 }
 
-func (c LocalClient) MarkAsReadLocal(ctx context.Context, __arg MarkAsReadLocalArg) (res MarkAsReadRes, err error) {
+func (c LocalClient) MarkAsReadLocal(ctx context.Context, __arg MarkAsReadLocalArg) (res MarkAsReadLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.markAsReadLocal", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -201,7 +201,7 @@ func (h *chatLocalHandler) MarkAsReadLocal(ctx context.Context, arg chat1.MarkAs
 		return res, err
 	}
 	return chat1.MarkAsReadLocalRes{
-		Offline:    h.G().Syncer.IsConnected(),
+		Offline:    h.G().Syncer.IsConnected(ctx),
 		RateLimits: utils.AggRateLimitsP([]*chat1.RateLimit{rres.RateLimit}),
 	}, nil
 }
@@ -1402,6 +1402,10 @@ func (h *chatLocalHandler) setTestRemoteClient(ri chat1.RemoteInterface) {
 func (h *chatLocalHandler) assertLoggedIn(ctx context.Context) error {
 	ok, err := h.G().LoginState().LoggedInProvisionedLoad()
 	if err != nil {
+		if _, ok := err.(libkb.APINetError); ok {
+			h.Debug(ctx, "assertLoggedIn: skipping API error and returning success")
+			return nil
+		}
 		return err
 	}
 	if !ok {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -71,6 +71,7 @@ func (h *chatLocalHandler) getChatUI(sessionID int) libkb.ChatUI {
 }
 
 func (h *chatLocalHandler) isOfflineError(err error) bool {
+	// Check type
 	switch terr := err.(type) {
 	case libkb.APINetError:
 		return true
@@ -79,9 +80,16 @@ func (h *chatLocalHandler) isOfflineError(err error) bool {
 	case chat.TransientUnboxingError:
 		return h.isOfflineError(terr.Inner())
 	}
-	if err == ErrGregorTimeout {
+	// Check error itself
+	switch err {
+	case context.DeadlineExceeded:
+		fallthrough
+	case context.Canceled:
+		fallthrough
+	case ErrGregorTimeout:
 		return true
 	}
+
 	return false
 }
 

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -70,10 +70,31 @@ func (h *chatLocalHandler) getChatUI(sessionID int) libkb.ChatUI {
 	return h.BaseHandler.getChatUI(sessionID)
 }
 
+func (h *chatLocalHandler) handleOfflineError(ctx context.Context, err error,
+	res chat1.OfflinableResult) error {
+
+	offline := false
+	switch err.(type) {
+	case libkb.APINetError:
+		offline = true
+	case chat.OfflineError:
+		offline = true
+	}
+
+	if offline {
+		h.Debug(ctx, "handleOfflineError: setting offline: err: %s", err.Error())
+		res.SetOffline()
+		return nil
+	}
+
+	return err
+}
+
 func (h *chatLocalHandler) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNonblockLocalArg) (res chat1.NonblockFetchRes, err error) {
 	var breaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, arg.IdentifyBehavior, &breaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetInboxNonblockLocal")()
+	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return res, err
 	}
@@ -149,17 +170,25 @@ func (h *chatLocalHandler) GetInboxNonblockLocal(ctx context.Context, arg chat1.
 	return res, nil
 }
 
-func (h *chatLocalHandler) MarkAsReadLocal(ctx context.Context, arg chat1.MarkAsReadLocalArg) (res chat1.MarkAsReadRes, err error) {
+func (h *chatLocalHandler) MarkAsReadLocal(ctx context.Context, arg chat1.MarkAsReadLocalArg) (res chat1.MarkAsReadLocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "MarkAsReadLocal")()
+	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err = h.assertLoggedIn(ctx); err != nil {
-		return chat1.MarkAsReadRes{}, err
+		return chat1.MarkAsReadLocalRes{}, err
 	}
-	return h.remoteClient().MarkAsRead(ctx, chat1.MarkAsReadArg{
+	rres, err := h.remoteClient().MarkAsRead(ctx, chat1.MarkAsReadArg{
 		ConversationID: arg.ConversationID,
 		MsgID:          arg.MsgID,
 	})
+	if err != nil {
+		return res, err
+	}
+	return chat1.MarkAsReadLocalRes{
+		Offline:    h.G().Syncer.IsConnected(),
+		RateLimits: utils.AggRateLimitsP([]*chat1.RateLimit{rres.RateLimit}),
+	}, nil
 }
 
 // GetInboxAndUnboxLocal implements keybase.chatLocal.getInboxAndUnboxLocal protocol.
@@ -167,6 +196,7 @@ func (h *chatLocalHandler) GetInboxAndUnboxLocal(ctx context.Context, arg chat1.
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetInboxAndUnboxLocal")()
+	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return res, err
 	}
@@ -200,6 +230,7 @@ func (h *chatLocalHandler) GetCachedThread(ctx context.Context, arg chat1.GetCac
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetCachedThread")()
+	defer h.handleOfflineError(ctx, err, &res)
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return chat1.GetThreadLocalRes{}, err
 	}
@@ -224,6 +255,7 @@ func (h *chatLocalHandler) GetThreadLocal(ctx context.Context, arg chat1.GetThre
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetThreadLocal")()
+	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return chat1.GetThreadLocalRes{}, err
 	}
@@ -248,6 +280,7 @@ func (h *chatLocalHandler) GetThreadNonblock(ctx context.Context, arg chat1.GetT
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return fullErr }, "GetThreadNonblock")()
+	defer func() { fullErr = h.handleOfflineError(ctx, fullErr, &res) }()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return res, err
 	}
@@ -487,6 +520,7 @@ func (h *chatLocalHandler) GetInboxSummaryForCLILocal(ctx context.Context, arg c
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, keybase1.TLFIdentifyBehavior_CHAT_CLI, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetInboxSummaryForCLILocal")()
+	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return chat1.GetInboxSummaryForCLILocalRes{}, err
 	}
@@ -586,6 +620,7 @@ func (h *chatLocalHandler) GetConversationForCLILocal(ctx context.Context, arg c
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, keybase1.TLFIdentifyBehavior_CHAT_CLI, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetConversationForCLILocal")()
+	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return chat1.GetConversationForCLILocalRes{}, err
 	}
@@ -653,6 +688,7 @@ func (h *chatLocalHandler) GetMessagesLocal(ctx context.Context, arg chat1.GetMe
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetMessagesLocal")()
+	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	deflt := chat1.GetMessagesLocalRes{}
 
 	if err := h.assertLoggedIn(ctx); err != nil {
@@ -1196,6 +1232,7 @@ func (h *chatLocalHandler) DownloadAttachmentLocal(ctx context.Context, arg chat
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "DownloadAttachmentLocal")()
+	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	darg := downloadAttachmentArg{
 		SessionID:        arg.SessionID,
 		ConversationID:   arg.ConversationID,
@@ -1212,6 +1249,7 @@ func (h *chatLocalHandler) DownloadAttachmentLocal(ctx context.Context, arg chat
 // DownloadFileAttachmentLocal implements chat1.LocalInterface.DownloadFileAttachmentLocal.
 func (h *chatLocalHandler) DownloadFileAttachmentLocal(ctx context.Context, arg chat1.DownloadFileAttachmentLocalArg) (res chat1.DownloadAttachmentLocalRes, err error) {
 	defer h.Trace(ctx, func() error { return err }, "DownloadFileAttachmentLocal")()
+	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	darg := downloadAttachmentArg{
 		SessionID:        arg.SessionID,
 		ConversationID:   arg.ConversationID,
@@ -1587,7 +1625,7 @@ func (h *chatLocalHandler) FindConversationsLocal(ctx context.Context,
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "FindConversationsLocal")()
-
+	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return res, err
 	}

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -101,12 +101,10 @@ func (h *chatLocalHandler) handleOfflineError(ctx context.Context, err error,
 		res.SetOffline()
 
 		// Disconnect Gregor if we think we are online
-		if h.gh.IsConnected() {
-			h.Debug(ctx, "handleOfflineError: inconsistent connected state: reconnecting to server")
-			if err := h.gh.Reconnect(ctx); err != nil {
-				h.Debug(ctx, "handleOfflineError: error reconnecting: %s", err.Error())
-			}
+		if err := h.gh.Reconnect(ctx); err != nil {
+			h.Debug(ctx, "handleOfflineError: error reconnecting: %s", err.Error())
 		}
+
 		return nil
 	}
 

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -251,7 +251,7 @@ func (h *chatLocalHandler) GetCachedThread(ctx context.Context, arg chat1.GetCac
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetCachedThread")()
-	defer h.handleOfflineError(ctx, err, &res)
+	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return chat1.GetThreadLocalRes{}, err
 	}

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -100,7 +100,7 @@ func (h *chatLocalHandler) handleOfflineError(ctx context.Context, err error,
 		h.Debug(ctx, "handleOfflineError: setting offline: err: %s", err.Error())
 		res.SetOffline()
 
-		// Disconnect Gregor if we think we are online
+		// Reconnect Gregor if we think we are online
 		if err := h.gh.Reconnect(ctx); err != nil {
 			h.Debug(ctx, "handleOfflineError: error reconnecting: %s", err.Error())
 		}

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -93,7 +93,7 @@ func (h *chatLocalHandler) handleOfflineError(ctx context.Context, err error,
 		res.SetOffline()
 
 		// Disconnect Gregor if we think we are online
-		if h.G().Syncer.IsConnected(ctx) && h.gh.IsConnected() {
+		if h.gh.IsConnected() {
 			h.Debug(ctx, "handleOfflineError: inconsistent connected state: reconnecting to server")
 			if err := h.gh.Reconnect(ctx); err != nil {
 				h.Debug(ctx, "handleOfflineError: error reconnecting: %s", err.Error())

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -430,6 +430,8 @@ func (g *gregorHandler) replayInBandMessages(ctx context.Context, cli gregor1.In
 }
 
 func (g *gregorHandler) IsConnected() bool {
+	g.connMutex.Lock()
+	defer g.connMutex.Unlock()
 	return g.conn != nil && g.conn.IsConnected()
 }
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1105,14 +1105,19 @@ func (g *gregorHandler) isReachable() bool {
 	}
 	if err != nil {
 		g.Debug(ctx, "isReachable: error: terminating connection: %s", err.Error())
-		g.Shutdown()
-		if err := g.Connect(g.uri); err != nil {
-			g.Debug(ctx, "isReachable: error connecting: %s", err.Error())
+		if err := g.Reconnect(ctx); err != nil {
+			g.Debug(ctx, "isReachable: error reconnecting: %s", err.Error())
 		}
 		return false
 	}
 
 	return true
+}
+
+func (g *gregorHandler) Reconnect(ctx context.Context) error {
+	g.Debug(ctx, "Reconnect: reconnecting to server")
+	g.Shutdown()
+	return g.Connect(g.uri)
 }
 
 func (g *gregorHandler) pingLoop() {
@@ -1174,10 +1179,8 @@ func (g *gregorHandler) pingLoop() {
 				g.Debug(ctx, "ping loop: id: %x error: %s", id, err.Error())
 				if err == context.DeadlineExceeded {
 					g.Debug(ctx, "ping loop: timeout: terminating connection")
-					g.Shutdown()
-
-					if err := g.Connect(g.uri); err != nil {
-						g.Debug(ctx, "ping loop: id: %x error connecting: %s", id, err.Error())
+					if err := g.Reconnect(ctx); err != nil {
+						g.Debug(ctx, "ping loop: id: %x error reconnecting: %s", id, err.Error())
 					}
 					shutdownCancel()
 					return

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1117,9 +1117,14 @@ func (g *gregorHandler) isReachable() bool {
 }
 
 func (g *gregorHandler) Reconnect(ctx context.Context) error {
-	g.Debug(ctx, "Reconnect: reconnecting to server")
-	g.Shutdown()
-	return g.Connect(g.uri)
+	if g.IsConnected() {
+		g.Debug(ctx, "Reconnect: reconnecting to server")
+		g.Shutdown()
+		return g.Connect(g.uri)
+	}
+
+	g.Debug(ctx, "Reconnect: skipping reconnect, already disconnected")
+	return nil
 }
 
 func (g *gregorHandler) pingLoop() {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -576,6 +576,7 @@ protocol local {
   PostLocalRes postFileAttachmentLocal(int sessionID, ConversationID conversationID, MessageClientHeader clientHeader, LocalFileSource attachment, union { null, LocalFileSource } preview, string title, bytes metadata, keybase1.TLFIdentifyBehavior identifyBehavior);
 
   record DownloadAttachmentLocalRes {
+    boolean offline;
     array<RateLimit> rateLimits;
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
@@ -594,7 +595,11 @@ protocol local {
   @lint("ignore")
   void RetryPost(OutboxID outboxID);
 
-  MarkAsReadRes markAsReadLocal(int sessionID, ConversationID conversationID, MessageID msgID);
+  record MarkAsReadLocalRes {
+     boolean offline;
+     array<RateLimit> rateLimits;
+  }
+  MarkAsReadLocalRes markAsReadLocal(int sessionID, ConversationID conversationID, MessageID msgID);
 
   record FindConversationsLocalRes {
     array<ConversationLocal> conversations;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -899,6 +899,7 @@ export type ConversationStatus =
   | 4 // MUTED_4
 
 export type DownloadAttachmentLocalRes = {
+  offline: boolean,
   rateLimits?: ?Array<RateLimit>,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
@@ -1141,6 +1142,11 @@ export type LocalSource = {
   source: keybase1.Stream,
   filename: string,
   size: int,
+}
+
+export type MarkAsReadLocalRes = {
+  offline: boolean,
+  rateLimits?: ?Array<RateLimit>,
 }
 
 export type MarkAsReadRes = {
@@ -1927,7 +1933,7 @@ type localGetInboxSummaryForCLILocalResult = GetInboxSummaryForCLILocalRes
 type localGetMessagesLocalResult = GetMessagesLocalRes
 type localGetThreadLocalResult = GetThreadLocalRes
 type localGetThreadNonblockResult = NonblockFetchRes
-type localMarkAsReadLocalResult = MarkAsReadRes
+type localMarkAsReadLocalResult = MarkAsReadLocalRes
 type localNewConversationLocalResult = NewConversationLocalRes
 type localPostAttachmentLocalResult = PostLocalRes
 type localPostDeleteNonblockResult = PostLocalNonblockRes

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1668,6 +1668,10 @@
       "name": "DownloadAttachmentLocalRes",
       "fields": [
         {
+          "type": "boolean",
+          "name": "offline"
+        },
+        {
           "type": {
             "type": "array",
             "items": "RateLimit"
@@ -1680,6 +1684,23 @@
             "items": "keybase1.TLFIdentifyFailure"
           },
           "name": "identifyFailures"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "MarkAsReadLocalRes",
+      "fields": [
+        {
+          "type": "boolean",
+          "name": "offline"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
         }
       ]
     },
@@ -2263,7 +2284,7 @@
           "type": "MessageID"
         }
       ],
-      "response": "MarkAsReadRes"
+      "response": "MarkAsReadLocalRes"
     },
     "findConversationsLocal": {
       "request": [

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -899,6 +899,7 @@ export type ConversationStatus =
   | 4 // MUTED_4
 
 export type DownloadAttachmentLocalRes = {
+  offline: boolean,
   rateLimits?: ?Array<RateLimit>,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
@@ -1141,6 +1142,11 @@ export type LocalSource = {
   source: keybase1.Stream,
   filename: string,
   size: int,
+}
+
+export type MarkAsReadLocalRes = {
+  offline: boolean,
+  rateLimits?: ?Array<RateLimit>,
 }
 
 export type MarkAsReadRes = {
@@ -1927,7 +1933,7 @@ type localGetInboxSummaryForCLILocalResult = GetInboxSummaryForCLILocalRes
 type localGetMessagesLocalResult = GetMessagesLocalRes
 type localGetThreadLocalResult = GetThreadLocalRes
 type localGetThreadNonblockResult = NonblockFetchRes
-type localMarkAsReadLocalResult = MarkAsReadRes
+type localMarkAsReadLocalResult = MarkAsReadLocalRes
 type localNewConversationLocalResult = NewConversationLocalRes
 type localPostAttachmentLocalResult = PostLocalRes
 type localPostDeleteNonblockResult = PostLocalNonblockRes


### PR DESCRIPTION
The patch does the following:

1.) Adds a function to detect errors that result from network problems. If an error like this is detected, then we set the `Offline` field on the response. This can happen if we think we are online, but lose that connectivity somewhere in the call. 
2.) Use the new error detector in chat endpoints that have some sort of offline functionality. Two exceptions are `DownloadAttachment` and `MarkThreadAsLocal`, which will just do nothing other than set `Offline` in this state.
3.) In `assertLoggedIn`, if we get an API network error, we just charge through and keep going.
4.) Change the superseder calculation for `PullLocalOnly` to use only messages we have cached. Otherwise, it delays the cached result from `GetThreadNonblock` if the thread has a superseded by message that we don't have the superseding message locally.

cc @chrisnojima 