### PR TITLE
Load attachment previews when message rendered

### DIFF
--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -31,6 +31,14 @@ function * onSaveAttachmentNative ({payload: {message}}: Constants.SaveAttachmen
   }
 }
 
+function * onLoadAttachmentPreview ({payload: {message}}: Constants.LoadAttachmentPreview): SagaGenerator<any, any> {
+  const {filename, messageID, conversationIDKey} = message
+  if (filename && messageID) {
+    const path = tmpFile(Shared.tmpFileName(false, conversationIDKey, messageID, filename))
+    yield call(onLoadAttachment, Creators.loadAttachment(conversationIDKey, messageID, path, true, false))
+  }
+}
+
 // Instead of redownloading the full attachment again, we may have it cached from an earlier hdPreview
 // returns cached filepath
 function * _isCached (conversationIDKey, messageID): Generator<any, ?string, any> {
@@ -207,6 +215,7 @@ function * onOpenAttachmentPopup (action: Constants.OpenAttachmentPopup): SagaGe
 
 export {
   onLoadAttachment,
+  onLoadAttachmentPreview,
   onOpenAttachmentPopup,
   onSaveAttachmentNative,
   onShareAttachment,

--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -57,6 +57,11 @@ function * _isCached (conversationIDKey, messageID): Generator<any, ?string, any
 function * onLoadAttachment ({payload: {conversationIDKey, messageID, loadPreview, isHdPreview, filename}}: Constants.LoadAttachment): SagaGenerator<any, any> {
   // See if we already have this image cached
   if (loadPreview || isHdPreview) {
+    const existingMessage = yield select(Shared.messageSelector, conversationIDKey, messageID)
+    if (existingMessage && (loadPreview && existingMessage.previewPath || isHdPreview && existingMessage.hdPreviewPath)) {
+      return
+    }
+
     const imageCached = yield call(exists, filename)
     if (imageCached) {
       yield put(Creators.attachmentLoaded(conversationIDKey, messageID, filename, loadPreview, isHdPreview))

--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -54,9 +54,15 @@ function * _isCached (conversationIDKey, messageID): Generator<any, ?string, any
 }
 
 function * onLoadAttachment ({payload: {conversationIDKey, messageID, loadPreview, isHdPreview, filename}}: Constants.LoadAttachment): SagaGenerator<any, any> {
+  const existingMessage = yield select(Shared.messageSelector, conversationIDKey, messageID)
+  const existingMessageState = existingMessage && existingMessage.messageState
+
   // See if we already have this image cached
   if (loadPreview || isHdPreview) {
-    const existingMessage = yield select(Shared.messageSelector, conversationIDKey, messageID)
+    if (existingMessageState === 'downloading-preview') {
+      return
+    }
+
     if (existingMessage && (loadPreview && existingMessage.previewPath || isHdPreview && existingMessage.hdPreviewPath)) {
       return
     }
@@ -71,6 +77,10 @@ function * onLoadAttachment ({payload: {conversationIDKey, messageID, loadPrevie
   // If we are loading the actual attachment,
   // let's see if we've already downloaded it as an hdPreview
   if (!loadPreview && !isHdPreview) {
+    if (existingMessageState === 'downloading') {
+      return
+    }
+
     const cachedPath = yield call(_isCached, conversationIDKey, messageID)
 
     if (cachedPath) {
@@ -91,6 +101,9 @@ function * onLoadAttachment ({payload: {conversationIDKey, messageID, loadPrevie
     }
   }
 
+  // set message state to downloading or downloading-preview
+  yield put(Creators.downloadProgress(conversationIDKey, messageID, loadPreview || isHdPreview))
+
   const param = {
     conversationID: Constants.keyToConversationID(conversationIDKey),
     messageID,
@@ -105,24 +118,28 @@ function * onLoadAttachment ({payload: {conversationIDKey, messageID, loadPrevie
     'chat.1.chatUi.chatAttachmentDownloadDone',
   ])
 
-  const channelMap = ((yield call(ChatTypes.localDownloadFileAttachmentLocalRpcChannelMap, channelConfig, {param})): any)
+  try {
+    const channelMap = ((yield call(ChatTypes.localDownloadFileAttachmentLocalRpcChannelMap, channelConfig, {param})): any)
 
-  const progressTask = yield Saga.effectOnChannelMap(c => Saga.safeTakeEvery(c, function * ({response}) {
-    const {bytesComplete, bytesTotal} = response.param
-    yield put(Creators.downloadProgress(conversationIDKey, messageID, loadPreview || isHdPreview, bytesComplete, bytesTotal))
-    response.result()
-  }), channelMap, 'chat.1.chatUi.chatAttachmentDownloadProgress')
+    const progressTask = yield Saga.effectOnChannelMap(c => Saga.safeTakeEvery(c, function * ({response}) {
+      const {bytesComplete, bytesTotal} = response.param
+      yield put(Creators.downloadProgress(conversationIDKey, messageID, loadPreview || isHdPreview, bytesComplete, bytesTotal))
+      response.result()
+    }), channelMap, 'chat.1.chatUi.chatAttachmentDownloadProgress')
 
-  const start = yield Saga.takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentDownloadStart')
-  start.response.result()
+    const start = yield Saga.takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentDownloadStart')
+    start.response.result()
 
-  const done = yield Saga.takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentDownloadDone')
-  done.response.result()
+    const done = yield Saga.takeFromChannelMap(channelMap, 'chat.1.chatUi.chatAttachmentDownloadDone')
+    done.response.result()
 
-  yield cancel(progressTask)
-  Saga.closeChannelMap(channelMap)
+    yield cancel(progressTask)
+    Saga.closeChannelMap(channelMap)
 
-  yield put(Creators.attachmentLoaded(conversationIDKey, messageID, filename, loadPreview, isHdPreview))
+    yield put(Creators.attachmentLoaded(conversationIDKey, messageID, filename, loadPreview, isHdPreview))
+  } catch (err) {
+    yield put(Creators.attachmentLoaded(conversationIDKey, messageID, null, loadPreview, isHdPreview))
+  }
 }
 
 function * onSelectAttachment ({payload: {input}}: Constants.SelectAttachment): Generator<any, any, any> {

--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -53,7 +53,6 @@ function * _isCached (conversationIDKey, messageID): Generator<any, ?string, any
   }
 }
 
-// TODO load previews too
 function * onLoadAttachment ({payload: {conversationIDKey, messageID, loadPreview, isHdPreview, filename}}: Constants.LoadAttachment): SagaGenerator<any, any> {
   // See if we already have this image cached
   if (loadPreview || isHdPreview) {

--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -265,6 +265,10 @@ function loadAttachment (conversationIDKey: Constants.ConversationIDKey, message
   return {payload: {conversationIDKey, filename, isHdPreview, loadPreview, messageID}, type: 'chat:loadAttachment'}
 }
 
+function loadAttachmentPreview (message: Constants.AttachmentMessage): Constants.LoadAttachmentPreview {
+  return {payload: {message}, type: 'chat:loadAttachmentPreview'}
+}
+
 function attachmentLoaded (conversationIDKey: Constants.ConversationIDKey, messageID: Constants.MessageID, path: string, isPreview: boolean, isHdPreview: boolean): Constants.AttachmentLoaded {
   return {payload: {conversationIDKey, isHdPreview, isPreview, messageID, path}, type: 'chat:attachmentLoaded'}
 }
@@ -375,6 +379,7 @@ export {
   inboxStale,
   incomingMessage,
   loadAttachment,
+  loadAttachmentPreview,
   loadInbox,
   loadMoreMessages,
   loadedInbox,

--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -269,11 +269,11 @@ function loadAttachmentPreview (message: Constants.AttachmentMessage): Constants
   return {payload: {message}, type: 'chat:loadAttachmentPreview'}
 }
 
-function attachmentLoaded (conversationIDKey: Constants.ConversationIDKey, messageID: Constants.MessageID, path: string, isPreview: boolean, isHdPreview: boolean): Constants.AttachmentLoaded {
+function attachmentLoaded (conversationIDKey: Constants.ConversationIDKey, messageID: Constants.MessageID, path: ?string, isPreview: boolean, isHdPreview: boolean): Constants.AttachmentLoaded {
   return {payload: {conversationIDKey, isHdPreview, isPreview, messageID, path}, type: 'chat:attachmentLoaded'}
 }
 
-function downloadProgress (conversationIDKey: Constants.ConversationIDKey, messageID: Constants.MessageID, isPreview: boolean, bytesComplete: number, bytesTotal: number): Constants.DownloadProgress {
+function downloadProgress (conversationIDKey: Constants.ConversationIDKey, messageID: Constants.MessageID, isPreview: boolean, bytesComplete?: number, bytesTotal?: number): Constants.DownloadProgress {
   return {payload: {bytesComplete, bytesTotal, conversationIDKey, isPreview, messageID}, type: 'chat:downloadProgress'}
 }
 

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -9,7 +9,7 @@ import * as Shared from './shared'
 import * as Saga from '../../util/saga'
 import HiddenString from '../../util/hidden-string'
 import engine from '../../engine'
-import {List, Map} from 'immutable'
+import {Map} from 'immutable'
 import {NotifyPopup} from '../../native/notifications'
 import {apiserverGetRpcPromise, TlfKeysTLFIdentifyBehavior} from '../../constants/types/flow-types'
 import {badgeApp} from '../notifications'
@@ -24,7 +24,6 @@ import {reset as searchReset, addUsersToGroup as searchAddUsersToGroup} from '..
 import {searchTab, chatTab} from '../../constants/tabs'
 import {showMainWindow} from '../platform-specific'
 import {some} from 'lodash'
-import {tmpFile} from '../../util/file'
 import {toDeviceType} from '../../constants/types/more'
 import {usernameSelector} from '../../constants/selectors'
 
@@ -172,14 +171,6 @@ function * _incomingMessage (action: Constants.IncomingMessage): SagaGenerator<a
           }
 
           yield put(Creators.appendMessages(conversationIDKey, conversationIDKey === selectedConversationIDKey, [message]))
-
-          if ((message.type === 'Attachment' || message.type === 'UpdateAttachment') && !message.previewPath && message.messageID) {
-            const messageID = message.type === 'UpdateAttachment' ? message.targetMessageID : message.messageID
-            const filename = message.type === 'UpdateAttachment' ? message.updates.filename : message.filename
-            if (filename) {
-              yield put(Creators.loadAttachment(conversationIDKey, messageID, tmpFile(Shared.tmpFileName(false, conversationIDKey, messageID, filename)), true, false))
-            }
-          }
         }
       }
       break
@@ -334,20 +325,6 @@ function * _loadMoreMessages (action: Constants.LoadMoreMessages): SagaGenerator
     const pagination = _threadToPagination(thread)
 
     yield put(Creators.prependMessages(conversationIDKey, newMessages, !pagination.last, pagination.next))
-
-    // Load previews for attachments
-    const attachmentsOnly = messages.reduce((acc: List<Constants.AttachmentMessage>, m) => m && m.type === 'Attachment' && m.messageID ? acc.push(m) : acc, new List())
-    yield attachmentsOnly.map(({conversationIDKey, messageID, filename}: Constants.AttachmentMessage) => {
-      if (messageID && filename) {
-        return put(Creators.loadAttachment(
-          conversationIDKey,
-          messageID,
-          tmpFile(Shared.tmpFileName(false, conversationIDKey, messageID, filename)),
-          true,
-          false)
-        )
-      }
-    }).toArray().filter(Boolean)
   }
 
   const channelConfig = Saga.singleFixedChannelConfig([
@@ -885,6 +862,7 @@ function * chatSaga (): SagaGenerator<any, any> {
     Saga.safeTakeEvery('chat:openConversation', _openConversation),
     Saga.safeTakeEvery('chat:getInboxAndUnbox', Inbox.onGetInboxAndUnbox),
     Saga.safeTakeEvery('chat:loadAttachment', Attachment.onLoadAttachment),
+    Saga.safeTakeEvery('chat:loadAttachmentPreview', Attachment.onLoadAttachmentPreview),
     Saga.safeTakeEvery('chat:openAttachmentPopup', Attachment.onOpenAttachmentPopup),
     Saga.safeTakeLatest('chat:openFolder', _openFolder),
     Saga.safeTakeLatest('chat:badgeAppForChat', _badgeAppForChat),

--- a/shared/chat/conversation/list-hoc.js
+++ b/shared/chat/conversation/list-hoc.js
@@ -8,7 +8,7 @@ import type {Props, OptionsFn} from './list'
 import type {Options} from './messages'
 
 function propsToMessageOptionsFn (props: Props): OptionsFn {
-  return function (message, prevMessage, isFirstMessage, isSelected, isScrolling, key, style, onAction, onShowEditor, isEditing = false): Options {
+  return function (message, prevMessage, isFirstMessage, isSelected, isScrolling, isMeasuring, key, style, onAction, onShowEditor, isEditing = false): Options {
     const skipMsgHeader = (message.author != null && prevMessage && prevMessage.type === 'Text' && prevMessage.author === message.author)
     const isFirstNewMessage = message.messageID != null && props.firstNewMessageID ? props.firstNewMessageID === message.messageID : false
 
@@ -31,6 +31,7 @@ function propsToMessageOptionsFn (props: Props): OptionsFn {
       isEditing,
       isFirstNewMessage,
       isScrolling,
+      isMeasuring,
       isSelected,
       key,
       message,

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -343,7 +343,7 @@ class ConversationList extends Component<void, Props, State> {
   }
 
   _cellRenderer = ({rowIndex, ...rest}) => {
-    return this._rowRenderer({index: rowIndex, ...rest})
+    return this._rowRenderer({index: rowIndex, ...rest, isMeasuring: true})
   }
 
   _onShowEditor = (message: Message, event: any) => {
@@ -356,7 +356,7 @@ class ConversationList extends Component<void, Props, State> {
     }
   }
 
-  _rowRenderer = ({index, key, style, isScrolling}: {index: number, key: string, style: Object, isScrolling: boolean}) => {
+  _rowRenderer = ({index, key, style, isScrolling, isMeasuring}: {index: number, key: string, style: Object, isScrolling: boolean, isMeasuring?: boolean}) => {
     if (__DEV__ && DEBUG_ROW_RENDER && style) {
       style = {
         ...style,
@@ -371,7 +371,7 @@ class ConversationList extends Component<void, Props, State> {
     const isFirstMessage = index === 0
     const isSelected = message.messageID != null && this.state.selectedMessageID === message.messageID
 
-    const options = this.props.optionsFn(message, prevMessage, isFirstMessage, isSelected, isScrolling, key, style, this._onAction, this._onShowEditor, false)
+    const options = this.props.optionsFn(message, prevMessage, isFirstMessage, isSelected, isScrolling, !!isMeasuring, key, style, this._onAction, this._onShowEditor, false)
 
     return messageFactory(options)
   }

--- a/shared/chat/conversation/list.desktop.js
+++ b/shared/chat/conversation/list.desktop.js
@@ -490,7 +490,8 @@ class ConversationList extends Component<void, Props, State> {
               ref={this._setCellMeasurerRef}
               cellSizeCache={this._cellCache}
               rowCount={rowCount}
-              width={width - scrollbarWidth} >
+              width={width - scrollbarWidth}
+            >
               {({getRowHeight}) => (
                 <VirtualizedList
                   cellRangeRenderer={this._cellRangeRenderer}
@@ -504,7 +505,10 @@ class ConversationList extends Component<void, Props, State> {
                   rowCount={rowCount}
                   rowHeight={getRowHeight}
                   columnWidth={width}
-                  rowRenderer={this._rowRenderer} />)}</CellMeasurer>)}
+                  rowRenderer={this._rowRenderer} />
+              )}
+            </CellMeasurer>
+          )}
         </AutoSizer>
       </div>
     )

--- a/shared/chat/conversation/list.js.flow
+++ b/shared/chat/conversation/list.js.flow
@@ -5,7 +5,7 @@ import {List} from 'immutable'
 import type {ConversationIDKey, AttachmentMessage, Message, MessageID, MetaDataMap, ServerMessage, SupersedeInfo, FollowingMap} from '../../constants/chat'
 import type {Options} from './messages'
 
-export type OptionsFn = (message: Message, prevMessage: Message, isFirstMessage: boolean, isSelected: boolean, isScrolling: boolean, key: any, style: Object, onAction: (message: ServerMessage, event: any) => void, onShowEditor: (message: Message, event: any) => void, isEditing: boolean) => Options
+export type OptionsFn = (message: Message, prevMessage: Message, isFirstMessage: boolean, isSelected: boolean, isScrolling: boolean, isMeasuring: boolean, key: any, style: Object, onAction: (message: ServerMessage, event: any) => void, onShowEditor: (message: Message, event: any) => void, isEditing: boolean) => Options
 
 export type Props = {
   firstNewMessageID: ?MessageID,

--- a/shared/chat/conversation/list.native.js
+++ b/shared/chat/conversation/list.native.js
@@ -139,7 +139,8 @@ class ConversationList extends Component <void, Props, State> {
     const prevMessage = messages.get(rowID - 1)
     const isSelected = false
     const isScrolling = false
-    const options = this.props.optionsFn(message, prevMessage, isFirstMessage, isSelected, isScrolling, message.key || `other-${rowID}`, {}, this._onAction, this._onShowEditor, this.props.editingMessage === message)
+    const isMeasuring = false
+    const options = this.props.optionsFn(message, prevMessage, isFirstMessage, isSelected, isScrolling, isMeasuring, message.key || `other-${rowID}`, {}, this._onAction, this._onShowEditor, this.props.editingMessage === message)
 
     return messageFactory(options)
   }

--- a/shared/chat/conversation/messages/attachment.js
+++ b/shared/chat/conversation/messages/attachment.js
@@ -222,16 +222,14 @@ type ConnectedProps = Props & { onEnsurePreviewLoaded: () => void }
 
 export class AttachmentMessage extends PureComponent<void, ConnectedProps, void> {
   componentDidMount () {
-    this._ensurePreviewLoaded()
-  }
-
-  componentDidUpdate () {
-    this._ensurePreviewLoaded()
-  }
-
-  _ensurePreviewLoaded () {
     if (this.props.message && this.props.message.filename) {
-      this.props.onEnsurePreviewLoaded()
+      setImmediate(() => this.props.onEnsurePreviewLoaded())
+    }
+  }
+
+  componentDidUpdate (prevProps: ConnectedProps) {
+    if (this.props.message && prevProps.message && prevProps.message.filename != this.props.message.filename) {
+      setImmediate(() => this.props.onEnsurePreviewLoaded())
     }
   }
 

--- a/shared/chat/conversation/messages/attachment.js
+++ b/shared/chat/conversation/messages/attachment.js
@@ -232,8 +232,8 @@ export class AttachmentMessage extends PureComponent<void, ConnectedProps, void>
   }
 
   _ensurePreviewLoaded () {
-    const {message} = this.props
-    if (message && message.filename && !message.previewPath) {
+    const {isMeasuring, message} = this.props
+    if (!isMeasuring && message && message.filename && !message.previewPath) {
       setImmediate(() => this.props.onEnsurePreviewLoaded())
     }
   }

--- a/shared/chat/conversation/messages/attachment.js
+++ b/shared/chat/conversation/messages/attachment.js
@@ -226,7 +226,7 @@ export class AttachmentMessage extends PureComponent<void, ConnectedProps, void>
   }
 
   componentDidUpdate (prevProps: ConnectedProps) {
-    if (this.props.message && prevProps.message && prevProps.message.filename != this.props.message.filename) {
+    if (this.props.message && prevProps.message && prevProps.message.filename !== this.props.message.filename) {
       this._ensurePreviewLoaded()
     }
   }

--- a/shared/chat/conversation/messages/attachment.js
+++ b/shared/chat/conversation/messages/attachment.js
@@ -222,13 +222,18 @@ type ConnectedProps = Props & { onEnsurePreviewLoaded: () => void }
 
 export class AttachmentMessage extends PureComponent<void, ConnectedProps, void> {
   componentDidMount () {
-    if (this.props.message && this.props.message.filename) {
-      setImmediate(() => this.props.onEnsurePreviewLoaded())
-    }
+    this._ensurePreviewLoaded()
   }
 
   componentDidUpdate (prevProps: ConnectedProps) {
     if (this.props.message && prevProps.message && prevProps.message.filename != this.props.message.filename) {
+      this._ensurePreviewLoaded()
+    }
+  }
+
+  _ensurePreviewLoaded () {
+    const {message} = this.props
+    if (message && message.filename && !message.previewPath) {
       setImmediate(() => this.props.onEnsurePreviewLoaded())
     }
   }

--- a/shared/chat/conversation/messages/attachment.js
+++ b/shared/chat/conversation/messages/attachment.js
@@ -222,7 +222,9 @@ type ConnectedProps = Props & { onEnsurePreviewLoaded: () => void }
 
 export class AttachmentMessage extends PureComponent<void, ConnectedProps, void> {
   componentDidMount () {
-    this.props.onEnsurePreviewLoaded()
+    if (!this.props.isMeasuring) {
+      this.props.onEnsurePreviewLoaded()
+    }
   }
 
   _onOpenInPopup = () => {

--- a/shared/chat/conversation/messages/attachment.js
+++ b/shared/chat/conversation/messages/attachment.js
@@ -1,8 +1,10 @@
 // @flow
 import * as Constants from '../../../constants/chat'
+import * as Creators from '../../../actions/chat/creators'
 import MessageWrapper from './wrapper'
 import moment from 'moment'
 import React, {PureComponent} from 'react'
+import {connect} from 'react-redux'
 import {Box, Icon, ProgressIndicator, Text, ClickableBox} from '../../../common-adapters'
 import {isMobile, fileUIName} from '../../../constants/platform'
 import {globalStyles, globalMargins, globalColors} from '../../../styles'
@@ -216,7 +218,13 @@ function AttachmentMessagePreviewImage ({message, onMessageAction, onOpenInFileU
   )
 }
 
-export default class AttachmentMessage extends PureComponent<void, Props, void> {
+type ConnectedProps = Props & { onEnsurePreviewLoaded: () => void }
+
+export class AttachmentMessage extends PureComponent<void, ConnectedProps, void> {
+  componentDidMount () {
+    this.props.onEnsurePreviewLoaded()
+  }
+
   _onOpenInPopup = () => {
     this.props.onOpenInPopup(this.props.message)
   }
@@ -255,6 +263,13 @@ export default class AttachmentMessage extends PureComponent<void, Props, void> 
     )
   }
 }
+
+export default connect(
+  null,
+  (dispatch: Dispatch, {message}: Props) => ({
+    onEnsurePreviewLoaded: () => dispatch(Creators.loadAttachmentPreview(message)),
+  })
+)(AttachmentMessage)
 
 export {
   ProgressBar,

--- a/shared/chat/conversation/messages/attachment.js
+++ b/shared/chat/conversation/messages/attachment.js
@@ -222,7 +222,15 @@ type ConnectedProps = Props & { onEnsurePreviewLoaded: () => void }
 
 export class AttachmentMessage extends PureComponent<void, ConnectedProps, void> {
   componentDidMount () {
-    if (!this.props.isMeasuring) {
+    this._ensurePreviewLoaded()
+  }
+
+  componentDidUpdate () {
+    this._ensurePreviewLoaded()
+  }
+
+  _ensurePreviewLoaded () {
+    if (this.props.message && this.props.message.filename) {
       this.props.onEnsurePreviewLoaded()
     }
   }

--- a/shared/chat/conversation/messages/attachment.js.flow
+++ b/shared/chat/conversation/messages/attachment.js.flow
@@ -22,6 +22,7 @@ export type Props = {
   message: AttachmentMessage,
   includeHeader: boolean,
   isFirstNewMessage: boolean,
+  isMeasuring: boolean,
   onLoadAttachment: (messageID: MessageID, filename: string) => void,
   onAction: (message: ServerMessage, event: any) => void,
   onRetry: (message: ServerMessage) => void,

--- a/shared/chat/conversation/messages/dumb.js
+++ b/shared/chat/conversation/messages/dumb.js
@@ -218,6 +218,7 @@ const attachmentBaseMock = {
   you: 'marcopolo',
   followingMap,
   metaDataMap,
+  mockStore: {},
 }
 
 const attachmentMap: DumbComponentMap<AttachmentMessageComponent> = {

--- a/shared/chat/conversation/messages/dumb.js
+++ b/shared/chat/conversation/messages/dumb.js
@@ -208,6 +208,7 @@ const attachmentBaseMock = {
   message: attachmentBaseMessage,
   includeHeader: true,
   isFirstNewMessage: false,
+  isMeasuring: false,
   onLoadAttachment: () => console.log('onLoadAttachment'),
   onAction: () => console.log('onAction'),
   onRetry: () => console.log('onRetry'),

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -19,6 +19,7 @@ const factory = (options: Options) => {
     key,
     isEditing,
     isFirstNewMessage,
+    isMeasuring,
     isSelected,
     onAction,
     onLoadAttachment,
@@ -85,6 +86,7 @@ const factory = (options: Options) => {
         onOpenInPopup={onOpenInPopup}
         messageID={message.messageID}
         onAction={onAction}
+        isMeasuring={isMeasuring}
         />
     case 'LoadingMore':
       return <LoadingMore style={{...style}} key={key} hasMoreItems={moreToLoad} />

--- a/shared/chat/conversation/messages/index.js.flow
+++ b/shared/chat/conversation/messages/index.js.flow
@@ -11,6 +11,7 @@ export type Options = {
   isFirstNewMessage: boolean,
   style: Object,
   isScrolling: boolean,
+  isMeasuring: boolean,
   onAction: (message: ServerMessage, event: any) => void,
   isSelected: boolean,
   onLoadAttachment: (messageID: ChatConstants.MessageID, filename: string) => void,

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -396,8 +396,8 @@ export type UploadProgress = NoErrorTypedAction<'chat:uploadProgress', {
   conversationIDKey: ConversationIDKey,
 }>
 export type DownloadProgress = NoErrorTypedAction<'chat:downloadProgress', {
-  bytesComplete: number,
-  bytesTotal: number,
+  bytesComplete?: number,
+  bytesTotal?: number,
   conversationIDKey: ConversationIDKey,
   isPreview: boolean,
   messageID: MessageID,
@@ -417,7 +417,7 @@ export type AttachmentLoaded = NoErrorTypedAction<'chat:attachmentLoaded', {
   conversationIDKey: ConversationIDKey,
   isPreview: boolean,
   isHdPreview: boolean,
-  path: string,
+  path: ?string,
 }>
 export type UpdateTempMessage = TypedAction<'chat:updateTempMessage', {
   conversationIDKey: ConversationIDKey,

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -409,6 +409,9 @@ export type LoadAttachment = NoErrorTypedAction<'chat:loadAttachment', {
   isHdPreview: boolean,
   filename: string,
 }>
+export type LoadAttachmentPreview = NoErrorTypedAction<'chat:loadAttachmentPreview', {
+  message: AttachmentMessage,
+}>
 export type AttachmentLoaded = NoErrorTypedAction<'chat:attachmentLoaded', {
   messageID: MessageID,
   conversationIDKey: ConversationIDKey,

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -293,7 +293,10 @@ function reducer (state: Constants.State = initialState, action: Constants.Actio
     }
     case 'chat:downloadProgress': {
       const {conversationIDKey, messageID, isPreview, bytesComplete, bytesTotal} = action.payload
-      const progress = bytesComplete / bytesTotal
+      let progress = 0
+      if (bytesTotal != null) {
+        progress = bytesComplete / bytesTotal
+      }
 
       // $FlowIssue
       return state.update('conversationStates', conversationStates => updateConversationMessage(


### PR DESCRIPTION
This changes attachment messages to trigger loading their preview when the component mounts or updates. It works well on desktop but mobile needs further work with tracking visibility, since it appears to render/mount all of the messages in batches rather than having a concept of "measuring" like in react-virtualized. Also, this changeset ensures that `onLoadAttachment` bails if there's another saga already downloading the data.

:eyeglasses: @keybase/react-hackers 