### PR TITLE
kbnm: Cross-platform support

### DIFF
--- a/go/kbnm/findbin.go
+++ b/go/kbnm/findbin.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/kardianos/osext"
+)
+
+var errKeybaseNotFound = errors.New("failed to find the keybase binary")
+
+// findKeybaseBinary returns the path to the Keybase binary, if it finds it.
+func findKeybaseBinary() (string, error) {
+	// Is it near the kbnm binary?
+	dir, err := osext.ExecutableFolder()
+	if err == nil {
+		path := filepath.Join(dir, keybaseBinary)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			return path, nil
+		}
+	}
+
+	// Is it in our PATH?
+	path, err := exec.LookPath(keybaseBinary)
+	if err == nil {
+		return path, nil
+	}
+
+	// Last ditch effort!
+	path = guessKeybasePath()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		return path, nil
+	}
+
+	return "", errKeybaseNotFound
+}

--- a/go/kbnm/findbin_nix.go
+++ b/go/kbnm/findbin_nix.go
@@ -8,7 +8,9 @@ import (
 
 const keybaseBinary = "keybase"
 
-// guessKeybasePath makes a platform-specific guess to where the binary might be.
+// guessKeybasePath makes a platform-specific guess to where the binary might
+// be. This is only checked as a last-ditch effort when we can't find the
+// binary in other places.
 func guessKeybasePath() string {
 	return filepath.Join("/usr/local/bin", keybaseBinary)
 }

--- a/go/kbnm/findbin_nix.go
+++ b/go/kbnm/findbin_nix.go
@@ -1,0 +1,14 @@
+package main
+
+// +build !windows
+
+import (
+	"path/filepath"
+)
+
+const keybaseBinary = "keybase"
+
+// guessKeybasePath makes a platform-specific guess to where the binary might be.
+func guessKeybasePath() string {
+	return filepath.Join("/usr/local/bin", keybaseBinary)
+}

--- a/go/kbnm/findbin_windows.go
+++ b/go/kbnm/findbin_windows.go
@@ -1,0 +1,15 @@
+package main
+
+// +build windows
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const keybaseBinary = "keybase.exe"
+
+// guessKeybasePath makes a platform-specific guess to where the binary might be.
+func guessKeybasePath() string {
+	return filepath.Join(os.Getenv("LOCALAPPDATA"), "Keybase", keybaseBinary)
+}

--- a/go/kbnm/findbin_windows.go
+++ b/go/kbnm/findbin_windows.go
@@ -9,7 +9,9 @@ import (
 
 const keybaseBinary = "keybase.exe"
 
-// guessKeybasePath makes a platform-specific guess to where the binary might be.
+// guessKeybasePath makes a platform-specific guess to where the binary might
+// be. This is only checked as a last-ditch effort when we can't find the
+// binary in other places.
 func guessKeybasePath() string {
 	return filepath.Join(os.Getenv("LOCALAPPDATA"), "Keybase", keybaseBinary)
 }

--- a/go/kbnm/handler.go
+++ b/go/kbnm/handler.go
@@ -14,12 +14,6 @@ var errMissingField = errors.New("missing field")
 
 var errUserNotFound = errors.New("user not found")
 
-// findKeybaseBinary returns the path to the Keybase binary, if it finds it.
-func findKeybaseBinary() (string, error) {
-	// FIXME: Get the absolute path without a filled PATH var somehow?
-	return "/usr/local/bin/keybase", nil
-}
-
 func execRunner(cmd *exec.Cmd) error {
 	return cmd.Run()
 }


### PR DESCRIPTION
We had the keybase binary path hardcoded before, this version tries multiple paths and is Windows-friendly.

Note that when Chrome calls kbnm (at least on Mac), it does not pass along useful environment variables like $PATH, so we can't really rely on it.