### PR TITLE
kbnm: Use `keybase id` and parse log output

### DIFF
--- a/go/kbnm/README.md
+++ b/go/kbnm/README.md
@@ -2,3 +2,9 @@
 
 kbnm is a small shim for bridging communication between the Keybase daemon and
 browser extensions.
+
+## Develop
+
+**Warning**: Any changes to kbnm will likely break the browser extension that
+depends on it. Make sure that changes are backwards compatible and that there is
+an upgrade path.

--- a/go/kbnm/handler_test.go
+++ b/go/kbnm/handler_test.go
@@ -34,9 +34,17 @@ func TestHandlerChat(t *testing.T) {
 	}
 }
 
-const queryResponse = `2017-04-05T13:44:17.068898-04:00 ▶ [INFO keybase ui.go:64] 001 Identifying \x1b[1mshazow\x1b[22m\n`
+const queryResponse = `[INFO] 001 Identifying sometestuser
+✔ public key fingerprint: 9FCE A980 CCFD 3C13 E11E 88A9 3506 87D1 7E81 FD68
+✔ admin of sometestuser.net via HTTPS: https://sometestuser.net/keybase.txt
+✔ "sometestuser" on github: https://gist.github.com/10763855
+✔ "sometestuser" on twitter: https://twitter.com/sometestuser/status/456154521052274689 [cached 2017-04-06 10:20:10 EDT]
+✔ "sometestuser" on hackernews: https://news.ycombinator.com/user?id=sometestuser [cached 2017-04-06 10:20:09 EDT]
+✔ "sometestuser" on reddit: https://www.reddit.com/r/KeybaseProofs/comments/2o8dbv/my_keybase_proof_redditsometestuser_keybasesometestuser/ [cached 2017-04-06 10:20:10 EDT]
+`
 
-const queryResponseErr = `2017-04-05T12:48:09.203299-04:00 ‚M-^V∂ [ERRO keybase standard.go:230] 001 Not found$`
+const queryResponseErr = `[ERRO] 001 Not found
+`
 
 func TestHandlerQuery(t *testing.T) {
 	h := Handler()

--- a/go/kbnm/handler_test.go
+++ b/go/kbnm/handler_test.go
@@ -59,6 +59,9 @@ func TestHandlerQueryError(t *testing.T) {
 		io.WriteString(cmd.Stderr, queryResponseErr)
 		return nil
 	}
+	h.FindKeybaseBinary = func() (string, error) {
+		return "/mocked/test/path/keybase", nil
+	}
 
 	req := &Request{
 		Method: "query",
@@ -83,6 +86,9 @@ func TestHandlerQueryErrorUnexpected(t *testing.T) {
 		ranCmd = strings.Join(cmd.Args, " ")
 		io.WriteString(cmd.Stderr, queryResponseErrUnexpected)
 		return nil
+	}
+	h.FindKeybaseBinary = func() (string, error) {
+		return "/mocked/test/path/keybase", nil
 	}
 
 	req := &Request{

--- a/go/kbnm/handler_test.go
+++ b/go/kbnm/handler_test.go
@@ -46,6 +46,31 @@ const queryResponse = `[INFO] 001 Identifying sometestuser
 const queryResponseErr = `[ERRO] 001 Not found
 `
 
+func TestHandlerQueryError(t *testing.T) {
+	h := Handler()
+
+	var ranCmd string
+	h.Run = func(cmd *exec.Cmd) error {
+		ranCmd = strings.Join(cmd.Args, " ")
+		io.WriteString(cmd.Stderr, queryResponseErr)
+		return nil
+	}
+
+	req := &Request{
+		Method: "query",
+		To:     "doesnotexist",
+	}
+
+	_, err := h.Handle(req)
+	if err == nil {
+		t.Fatal("request succeeded when failure was expected")
+	}
+
+	if got, want := err.Error(), "user not found"; got != want {
+		t.Errorf("incorrect error; got: %q, want %q", got, want)
+	}
+}
+
 func TestHandlerQuery(t *testing.T) {
 	h := Handler()
 

--- a/go/kbnm/handler_test.go
+++ b/go/kbnm/handler_test.go
@@ -34,18 +34,9 @@ func TestHandlerChat(t *testing.T) {
 	}
 }
 
-const queryResponse = `[
-	{
-		"seqno": 1,
-		"sig_id": "c3f2b7c2b92e7e53b8d67542695ec26f5a8ea3b3abaa07764b14e453434471180f",
-		"type": "self",
-		"ctime": 1394236029,
-		"revoked": false,
-		"active": true,
-		"key_fingerprint": "9fcea980ccfd3c13e11e88a9350687d17e81fd68",
-		"statement": "testkeybaseuser"
-	}
-]`
+const queryResponse = `2017-04-05T13:44:17.068898-04:00 ▶ [INFO keybase ui.go:64] 001 Identifying \x1b[1mshazow\x1b[22m\n`
+
+const queryResponseErr = `2017-04-05T12:48:09.203299-04:00 ‚M-^V∂ [ERRO keybase standard.go:230] 001 Not found$`
 
 func TestHandlerQuery(t *testing.T) {
 	h := Handler()
@@ -53,7 +44,7 @@ func TestHandlerQuery(t *testing.T) {
 	var ranCmd string
 	h.Run = func(cmd *exec.Cmd) error {
 		ranCmd = strings.Join(cmd.Args, " ")
-		io.WriteString(cmd.Stdout, queryResponse)
+		io.WriteString(cmd.Stderr, queryResponse)
 		return nil
 	}
 	h.FindKeybaseBinary = func() (string, error) {
@@ -62,7 +53,7 @@ func TestHandlerQuery(t *testing.T) {
 
 	req := &Request{
 		Method: "query",
-		To:     "testkeybaseuser",
+		To:     "sometestuser",
 	}
 
 	res, err := h.Handle(req)
@@ -74,7 +65,7 @@ func TestHandlerQuery(t *testing.T) {
 		t.Errorf("result is not *resultQuery: %T", res)
 	}
 
-	if ranCmd != "/mocked/test/path/keybase sigs list --type=self --json testkeybaseuser" {
+	if ranCmd != "/mocked/test/path/keybase id sometestuser" {
 		t.Errorf("unexpected command: %q", ranCmd)
 	}
 
@@ -82,7 +73,7 @@ func TestHandlerQuery(t *testing.T) {
 		t.Fatal("result is nil")
 	}
 
-	if len(result.Sigs) != 1 || result.Sigs[0].Statement != "testkeybaseuser" {
+	if result.Username != "sometestuser" {
 		t.Errorf("invalid result value: %q", result)
 	}
 }

--- a/go/kbnm/host_json.template
+++ b/go/kbnm/host_json.template
@@ -4,6 +4,7 @@
   "path": "@@HOST_PATH@@",
   "type": "stdio",
   "allowed_origins": [
+    "chrome-extension://ognfafcpbkogffpmmdglhbjboeojlefj/",
     "chrome-extension://kockbbfoibcdfibclaojljblnhpnjndg/",
     "chrome-extension://gnjkbjlgkpiaehpibpdefaieklbfljjm/"
   ]


### PR DESCRIPTION
- Use `keybase id ...` instead of `keybase sigs ...` because sigs does not include a reliable mapping to the keybase username.
- Parse log output instead of JSON, because `id` does not support JSON.
- Parse error output to give more sensible errors (otherwise it's just exit status code 2 for everything).
- Capture logged out and not running states (we consume both stderr and stdout for that).
- Also added a whitelist id for our production extension (lmk if we prefer a separate PR for that, very minor).

Questions:

- [ ] Do I need to parse the reddit line of the `keybase id shazow@reddit` output specifically, or is it sufficient to just parse the first line (which is the keybase username for shazow@reddit? What happens when the reddit proof is broken?