### PR TITLE
Include KBNM in macOS installer

### DIFF
--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.51</string>
+	<string>1.1.52</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.51</string>
+	<string>1.1.52</string>
 	<key>KBFuseBuild</key>
 	<string>3.5.5</string>
 	<key>KBFuseVersion</key>

--- a/osx/Installer/Installer.m
+++ b/osx/Installer/Installer.m
@@ -38,6 +38,9 @@ typedef NS_ENUM (NSInteger, KBExit) {
   if ([arguments containsObject:@"--debug"]) {
     debug = YES;
   }
+#if DEBUG
+  debug = YES;
+#endif
 
   [KBWorkspace setupLogging:debug];
 

--- a/osx/KBKit/KBKit.xcodeproj/project.pbxproj
+++ b/osx/KBKit/KBKit.xcodeproj/project.pbxproj
@@ -116,7 +116,6 @@
 		00010D061BE19F8900A9C285 /* KBUserTrackStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = 00010BA51BE19F8800A9C285 /* KBUserTrackStatus.h */; };
 		00010D071BE19F8900A9C285 /* KBUserTrackStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = 00010BA61BE19F8800A9C285 /* KBUserTrackStatus.m */; };
 		00010D081BE19F8900A9C285 /* KBAppDebug.h in Headers */ = {isa = PBXBuildFile; fileRef = 00010BA91BE19F8900A9C285 /* KBAppDebug.h */; };
-		00010D091BE19F8900A9C285 /* KBAppDebug.m in Sources */ = {isa = PBXBuildFile; fileRef = 00010BAA1BE19F8900A9C285 /* KBAppDebug.m */; };
 		00010D0A1BE19F8900A9C285 /* KBConsoleView.h in Headers */ = {isa = PBXBuildFile; fileRef = 00010BAB1BE19F8900A9C285 /* KBConsoleView.h */; };
 		00010D0B1BE19F8900A9C285 /* KBConsoleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 00010BAC1BE19F8900A9C285 /* KBConsoleView.m */; };
 		00010D0C1BE19F8900A9C285 /* KBControlPanel.h in Headers */ = {isa = PBXBuildFile; fileRef = 00010BAD1BE19F8900A9C285 /* KBControlPanel.h */; };
@@ -333,6 +332,11 @@
 		00010DEB1BE1A0B900A9C285 /* KBEnvConfigTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 00010DE51BE1A0B900A9C285 /* KBEnvConfigTest.m */; };
 		00010DEC1BE1A0B900A9C285 /* KBFormatterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 00010DE61BE1A0B900A9C285 /* KBFormatterTest.m */; };
 		00010DEF1BE1A0B900A9C285 /* KBSemVersionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 00010DE91BE1A0B900A9C285 /* KBSemVersionTest.m */; };
+		002316D81E96B5480050091A /* KBNM.h in Headers */ = {isa = PBXBuildFile; fileRef = 002316D61E96B5480050091A /* KBNM.h */; };
+		002316D91E96B5480050091A /* KBNM.m in Sources */ = {isa = PBXBuildFile; fileRef = 002316D71E96B5480050091A /* KBNM.m */; };
+		002316DC1E96B9420050091A /* KBUpdaterService.m in Sources */ = {isa = PBXBuildFile; fileRef = 002316DA1E96B9420050091A /* KBUpdaterService.m */; };
+		002316DD1E96B9420050091A /* KBUpdaterService.h in Headers */ = {isa = PBXBuildFile; fileRef = 002316DB1E96B9420050091A /* KBUpdaterService.h */; };
+		002316DE1E96BC8C0050091A /* KBAppDebug.m in Sources */ = {isa = PBXBuildFile; fileRef = 00010BAA1BE19F8900A9C285 /* KBAppDebug.m */; };
 		0033F46E1C3F23AA00317C79 /* KBUIAppearance.h in Headers */ = {isa = PBXBuildFile; fileRef = 0033F46C1C3F23AA00317C79 /* KBUIAppearance.h */; };
 		0033F46F1C3F23AA00317C79 /* KBUIAppearance.m in Sources */ = {isa = PBXBuildFile; fileRef = 0033F46D1C3F23AA00317C79 /* KBUIAppearance.m */; };
 		0033F4751C3F271B00317C79 /* KBMemLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 0033F4731C3F271B00317C79 /* KBMemLogger.h */; };
@@ -355,7 +359,7 @@
 		00B82BD31BE9424600C1FC72 /* KBTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 00B82BD11BE9424600C1FC72 /* KBTask.m */; };
 		00E206681C4DBD170095FD56 /* KBCommandLine.h in Headers */ = {isa = PBXBuildFile; fileRef = 00E206661C4DBD170095FD56 /* KBCommandLine.h */; };
 		00E206691C4DBD170095FD56 /* KBCommandLine.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E206671C4DBD170095FD56 /* KBCommandLine.m */; };
-		4735FB6F92C5AA795E84B432 /* Pods_KBKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D5143A47F2931F852E7FAC8 /* Pods_KBKit.framework */; };
+		5CF627053506EA5AD0D3EC32 /* libPods-KBKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B74D43B87E43EC9A7B5E254 /* libPods-KBKit.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -700,6 +704,10 @@
 		00010DE61BE1A0B900A9C285 /* KBFormatterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KBFormatterTest.m; sourceTree = "<group>"; };
 		00010DE91BE1A0B900A9C285 /* KBSemVersionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KBSemVersionTest.m; sourceTree = "<group>"; };
 		00010DF01BE1AC3D00A9C285 /* KBKit.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = KBKit.podspec; sourceTree = "<group>"; };
+		002316D61E96B5480050091A /* KBNM.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KBNM.h; sourceTree = "<group>"; };
+		002316D71E96B5480050091A /* KBNM.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KBNM.m; sourceTree = "<group>"; };
+		002316DA1E96B9420050091A /* KBUpdaterService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KBUpdaterService.m; sourceTree = "<group>"; };
+		002316DB1E96B9420050091A /* KBUpdaterService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KBUpdaterService.h; sourceTree = "<group>"; };
 		0033F46C1C3F23AA00317C79 /* KBUIAppearance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KBUIAppearance.h; sourceTree = "<group>"; };
 		0033F46D1C3F23AA00317C79 /* KBUIAppearance.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KBUIAppearance.m; sourceTree = "<group>"; };
 		0033F4731C3F271B00317C79 /* KBMemLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KBMemLogger.h; sourceTree = "<group>"; };
@@ -724,7 +732,7 @@
 		00E206671C4DBD170095FD56 /* KBCommandLine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KBCommandLine.m; sourceTree = "<group>"; };
 		09A69C34EE77C4A0563C93F3 /* Pods-KBKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KBKit.release.xcconfig"; path = "Pods/Target Support Files/Pods-KBKit/Pods-KBKit.release.xcconfig"; sourceTree = "<group>"; };
 		479C84E44E80724FA433EBC6 /* Pods-KBKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KBKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-KBKit/Pods-KBKit.debug.xcconfig"; sourceTree = "<group>"; };
-		7D5143A47F2931F852E7FAC8 /* Pods_KBKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KBKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9B74D43B87E43EC9A7B5E254 /* libPods-KBKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-KBKit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -732,7 +740,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4735FB6F92C5AA795E84B432 /* Pods_KBKit.framework in Frameworks */,
+				5CF627053506EA5AD0D3EC32 /* libPods-KBKit.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -844,6 +852,8 @@
 				00010B411BE19F8800A9C285 /* KBFuseComponent.m */,
 				00010B421BE19F8800A9C285 /* KBHelperTool.h */,
 				00010B431BE19F8800A9C285 /* KBHelperTool.m */,
+				002316D61E96B5480050091A /* KBNM.h */,
+				002316D71E96B5480050091A /* KBNM.m */,
 				00010B441BE19F8800A9C285 /* KBInstallable.h */,
 				00010B451BE19F8800A9C285 /* KBInstallable.m */,
 				00010B481BE19F8800A9C285 /* KBInstaller.h */,
@@ -860,6 +870,8 @@
 				00E206671C4DBD170095FD56 /* KBCommandLine.m */,
 				003634091C603E270089465B /* KBAppBundle.h */,
 				0036340A1C603E270089465B /* KBAppBundle.m */,
+				002316DB1E96B9420050091A /* KBUpdaterService.h */,
+				002316DA1E96B9420050091A /* KBUpdaterService.m */,
 			);
 			name = Component;
 			path = KBKit/Component;
@@ -1330,7 +1342,7 @@
 		C19DB60533860021894629B4 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				7D5143A47F2931F852E7FAC8 /* Pods_KBKit.framework */,
+				9B74D43B87E43EC9A7B5E254 /* libPods-KBKit.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1365,6 +1377,7 @@
 				00010CE81BE19F8900A9C285 /* KBPrefTextField.h in Headers */,
 				00010D441BE19F8900A9C285 /* KBStatusView.h in Headers */,
 				00010D501BE19F8900A9C285 /* KBGPGKeysView.h in Headers */,
+				002316D81E96B5480050091A /* KBNM.h in Headers */,
 				00010DBA1BE19F8900A9C285 /* KBSearcher.h in Headers */,
 				00010CB51BE19F8900A9C285 /* KBLaunchdPlist.h in Headers */,
 				00010D341BE19F8900A9C285 /* KBFolderAddView.h in Headers */,
@@ -1421,6 +1434,7 @@
 				00010DA61BE19F8900A9C285 /* KBSecretPromptView.h in Headers */,
 				00010D761BE19F8900A9C285 /* KBPGPEncryptActionView.h in Headers */,
 				00010CEA1BE19F8900A9C285 /* KBRMockClient.h in Headers */,
+				002316DD1E96B9420050091A /* KBUpdaterService.h in Headers */,
 				00010C951BE19F8900A9C285 /* KBAppExtension.h in Headers */,
 				00010CC91BE19F8900A9C285 /* KBDefines.h in Headers */,
 				00010D901BE19F8900A9C285 /* KBPGPSignFooterView.h in Headers */,
@@ -1533,12 +1547,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00010B201BE19F2100A9C285 /* Build configuration list for PBXNativeTarget "KBKit" */;
 			buildPhases = (
-				5453793ACF6D6E2E0B3CD2BC /* Check Pods Manifest.lock */,
+				5453793ACF6D6E2E0B3CD2BC /* [CP] Check Pods Manifest.lock */,
 				00010B071BE19F2100A9C285 /* Sources */,
 				00010B081BE19F2100A9C285 /* Frameworks */,
 				00010B091BE19F2100A9C285 /* Headers */,
 				00010B0A1BE19F2100A9C285 /* Resources */,
-				6C23E77625FDB5CF6312A473 /* Copy Pods Resources */,
+				6C23E77625FDB5CF6312A473 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1573,7 +1587,7 @@
 		00010B031BE19F2100A9C285 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = "Gabriel Handford";
 				TargetAttributes = {
 					00010B0B1BE19F2100A9C285 = {
@@ -1620,29 +1634,29 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		5453793ACF6D6E2E0B3CD2BC /* Check Pods Manifest.lock */ = {
+		5453793ACF6D6E2E0B3CD2BC /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		6C23E77625FDB5CF6312A473 /* Copy Pods Resources */ = {
+		6C23E77625FDB5CF6312A473 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1664,6 +1678,7 @@
 				00010CE51BE19F8900A9C285 /* KBPrefOption.m in Sources */,
 				00010CD01BE19F8900A9C285 /* KBSemVersion.m in Sources */,
 				00010DE11BE19F8900A9C285 /* KBWaitFor.m in Sources */,
+				002316DC1E96B9420050091A /* KBUpdaterService.m in Sources */,
 				0036340C1C603E270089465B /* KBAppBundle.m in Sources */,
 				00010D7B1BE19F8900A9C285 /* KBPGPEncryptFilesView.m in Sources */,
 				00010DAD1BE19F8900A9C285 /* KBProofResult.m in Sources */,
@@ -1695,6 +1710,7 @@
 				00010DA31BE19F8900A9C285 /* KBPGPVerifyView.m in Sources */,
 				00010C961BE19F8900A9C285 /* KBAppExtension.m in Sources */,
 				00010D451BE19F8900A9C285 /* KBStatusView.m in Sources */,
+				002316DE1E96BC8C0050091A /* KBAppDebug.m in Sources */,
 				00010D3B1BE19F8900A9C285 /* KBFolderUsersListView.m in Sources */,
 				00010CAC1BE19F8900A9C285 /* KBHelperTool.m in Sources */,
 				00010CC81BE19F8900A9C285 /* KBWriter.m in Sources */,
@@ -1746,6 +1762,7 @@
 				00010D911BE19F8900A9C285 /* KBPGPSignFooterView.m in Sources */,
 				00010DA91BE19F8900A9C285 /* KBProofLabel.m in Sources */,
 				00010D871BE19F8900A9C285 /* KBPGPOutputView.m in Sources */,
+				002316D91E96B5480050091A /* KBNM.m in Sources */,
 				00010D331BE19F8900A9C285 /* KBFileSelectView.m in Sources */,
 				00010DD91BE19F8900A9C285 /* KBConvert.m in Sources */,
 				00010D811BE19F8900A9C285 /* KBPGPKeyGenView.m in Sources */,
@@ -1786,7 +1803,6 @@
 				004E09C91C28CA0F00E3A061 /* KBLoginItem.m in Sources */,
 				00010D051BE19F8900A9C285 /* KBPrivilegedTask.m in Sources */,
 				00010D991BE19F8900A9C285 /* KBPGPVerify.m in Sources */,
-				00010D091BE19F8900A9C285 /* KBAppDebug.m in Sources */,
 				00010CA41BE19F8900A9C285 /* KBComponentStatus.m in Sources */,
 				00010D9B1BE19F8900A9C285 /* KBPGPVerifyAppView.m in Sources */,
 				00010D311BE19F8900A9C285 /* KBFilePreviewView.m in Sources */,
@@ -1866,8 +1882,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -1912,8 +1930,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";

--- a/osx/KBKit/KBKit/Component/KBNM.h
+++ b/osx/KBKit/KBKit/Component/KBNM.h
@@ -1,0 +1,19 @@
+//
+//  KBNM.h
+//  KBKit
+//
+//  Created by Gabriel on 4/6/17.
+//  Copyright © 2017 Gabriel Handford. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "KBComponent.h"
+#import "KBInstallable.h"
+#import "KBHelperTool.h"
+
+@interface KBNM : KBInstallable
+
+- (instancetype)initWithConfig:(KBEnvConfig *)config servicePath:(NSString *)servicePath;
+
+@end

--- a/osx/KBKit/KBKit/Component/KBNM.m
+++ b/osx/KBKit/KBKit/Component/KBNM.m
@@ -1,0 +1,50 @@
+//
+//  KBNM.m
+//  KBKit
+//
+//  Created by Gabriel on 4/6/17.
+//  Copyright © 2017 Gabriel Handford. All rights reserved.
+//
+
+#import "KBNM.h"
+
+#import "KBTask.h"
+#import "KBIcons.h"
+
+@interface KBNM ()
+@property NSString *servicePath;
+@end
+
+@implementation KBNM
+
+- (instancetype)initWithConfig:(KBEnvConfig *)config servicePath:(NSString *)servicePath {
+  if ((self = [self initWithConfig:config name:@"KBNM" info:@"Chrome native messaging" image:[KBIcons imageForIcon:KBIconNetwork]])) {
+    _servicePath = servicePath;
+  }
+  return self;
+}
+
+- (KBInstallRuntimeStatus)runtimeStatus {
+  return KBInstallRuntimeStatusNone;
+}
+
+- (void)install:(KBCompletion)completion {
+  NSString *binPath = [self.config serviceBinPathWithPathOptions:0 servicePath:_servicePath];
+  [KBTask executeForJSONWithCommand:binPath args:@[@"-d", @"--log-format=file", @"install", @"--format=json", @"--components=kbnm", NSStringWithFormat(@"--timeout=%@s", @(self.config.installTimeout))] timeout:KBDefaultTaskTimeout completion:^(NSError *error, id response) {
+    if (!error) error = [KBInstallable checkForStatusErrorFromResponse:response];
+    completion(error);
+  }];
+}
+
+- (void)uninstall:(KBCompletion)completion {
+  NSString *binPath = [self.config serviceBinPathWithPathOptions:0 servicePath:_servicePath];
+  [KBTask execute:binPath args:@[@"-d", @"--log-format=file", @"uninstall", @"--components=kbnm"] timeout:KBDefaultTaskTimeout completion:^(NSError *error, NSData *outData, NSData *errData) {
+    completion(error);
+  }];
+}
+
+- (void)refreshComponent:(KBRefreshComponentCompletion)completion {
+  completion(nil);
+}
+
+@end

--- a/osx/KBKit/KBKit/System/KBEnvConfig.h
+++ b/osx/KBKit/KBKit/System/KBEnvConfig.h
@@ -26,8 +26,9 @@ typedef NS_OPTIONS (NSUInteger, KBInstallOptions) {
   KBInstallOptionMountDir = 1 << 6,
   KBInstallOptionCLI = 1 << 10,
   KBInstallOptionAppBundle = 1 << 11,
+  KBInstallOptionKBNM = 1 << 12,
 
-  KBInstallOptionAll = KBInstallOptionService | KBInstallOptionHelper | KBInstallOptionFuse | KBInstallOptionMountDir | KBInstallOptionKBFS | KBInstallOptionUpdater | KBInstallOptionCLI,
+  KBInstallOptionAll = KBInstallOptionService | KBInstallOptionHelper | KBInstallOptionFuse | KBInstallOptionMountDir | KBInstallOptionKBFS | KBInstallOptionUpdater | KBInstallOptionCLI | KBInstallOptionKBNM,
 };
 
 @interface KBEnvConfig : NSObject

--- a/osx/KBKit/KBKit/System/KBEnvironment.m
+++ b/osx/KBKit/KBKit/System/KBEnvironment.m
@@ -16,6 +16,7 @@
 #import "KBUpdaterService.h"
 #import "KBMountDir.h"
 #import "KBAppBundle.h"
+#import "KBNM.h"
 
 #import <ObjectiveSugar/ObjectiveSugar.h>
 
@@ -76,6 +77,11 @@
     if (config.installOptions&KBInstallOptionCLI) {
       KBCommandLine *cli = [[KBCommandLine alloc] initWithConfig:config helperTool:_helperTool servicePath:servicePath];
       [_installables addObject:cli];
+    }
+
+    if (config.installOptions&KBInstallOptionKBNM) {
+      KBNM *kbnm = [[KBNM alloc] initWithConfig:config servicePath:servicePath];
+      [_installables addObject:kbnm];
     }
 
     _services = [NSArray arrayWithObjects:_service, _kbfs, _updater, nil];

--- a/osx/KBKit/KBKit/UI/Debug/KBAppDebug.m
+++ b/osx/KBKit/KBKit/UI/Debug/KBAppDebug.m
@@ -10,6 +10,7 @@
 
 #import "KBStyleGuideView.h"
 #import "KBDefines.h"
+#import <CocoaLumberjack/CocoaLumberjack.h>
 
 @interface KBAppDebug ()
 @property BOOL running;

--- a/osx/KBKit/Podfile
+++ b/osx/KBKit/Podfile
@@ -1,5 +1,4 @@
 platform :osx, "10.10"
-use_frameworks!
 
 target "KBKit" do
   pod "YOLayout"

--- a/osx/KBKit/Podfile.lock
+++ b/osx/KBKit/Podfile.lock
@@ -17,13 +17,11 @@ PODS:
   - AFNetworking/Reachability (2.6.3)
   - AFNetworking/Security (2.6.3)
   - AFNetworking/Serialization (2.6.3)
-  - CocoaLumberjack (2.2.0):
-    - CocoaLumberjack/Default (= 2.2.0)
-    - CocoaLumberjack/Extensions (= 2.2.0)
-  - CocoaLumberjack/Core (2.2.0)
-  - CocoaLumberjack/Default (2.2.0):
-    - CocoaLumberjack/Core
-  - CocoaLumberjack/Extensions (2.2.0):
+  - CocoaLumberjack (3.1.0):
+    - CocoaLumberjack/Default (= 3.1.0)
+    - CocoaLumberjack/Extensions (= 3.1.0)
+  - CocoaLumberjack/Default (3.1.0)
+  - CocoaLumberjack/Extensions (3.1.0):
     - CocoaLumberjack/Default
   - GHKeychain (1.2.8)
   - GHKit (2.0.0)
@@ -35,19 +33,15 @@ PODS:
   - MPMessagePack (1.3.3):
     - GHODictionary
   - ObjectiveSugar (1.1.0)
-  - Slash (0.1.2):
-    - Slash/arc (= 0.1.2)
-    - Slash/no-arc (= 0.1.2)
-  - Slash/arc (0.1.2)
-  - Slash/no-arc (0.1.2)
-  - Tikppa (0.1.1):
+  - Slash (0.1.4)
+  - Tikppa (0.2.4):
     - AFNetworking
     - CocoaLumberjack
     - GHKit
     - ObjectiveSugar
     - Slash
     - YOLayout
-  - YOLayout (0.2.12)
+  - YOLayout (0.2.13)
 
 DEPENDENCIES:
   - AFNetworking (~> 2.0)
@@ -69,12 +63,12 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Slash:
-    :commit: 7f50cd7825f57af22d82e99e0aeec5d82724eb13
+    :commit: 1226fe873243a1100f328271263f2612f7095e6c
     :git: https://github.com/chrisdevereux/Slash
 
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
-  CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
+  CocoaLumberjack: 8311463ddf9ee86a06ef92a071dd656c89244500
   GHKeychain: 008cdb8bbab5b0dc1da3d0f06a67ce5203231e44
   GHKit: 29e5361c9d8a33343ae5ed4698057d1533ee590b
   GHODictionary: 1f7873492445e0f33ac19575a358c3c91926b564
@@ -82,10 +76,10 @@ SPEC CHECKSUMS:
   MDPSplitView: 127b4b371e813ec29333e515fb1c057126a75671
   MPMessagePack: 0de75102afb01a48cb312b9570336f46659b410f
   ObjectiveSugar: a6a25f23d657c19df0a0b972466d5b5ca9f5295c
-  Slash: fde91d6c2b9d985f50a00debffe804400dd9828c
-  Tikppa: 3d4fca3d897592397d33d28cf594a9ae53cf966e
-  YOLayout: 3f5b3ac64f9018f1e63a19223dbb8382c37d58cb
+  Slash: 7184f2a98e13ad62303037db3a706c88e98b197e
+  Tikppa: 77ac88aa89814a5ae9d18a773b4436ebef2235b7
+  YOLayout: 6728d890bab9b9e4962efd554cba16d677b30b0f
 
-PODFILE CHECKSUM: c9cf29c06b001e1ed3c226c1b3db4cf249ca5cd4
+PODFILE CHECKSUM: 63b8f4d71cbba2bc6adfb7e369a31a74bbbf7f8b
 
-COCOAPODS: 1.0.0.beta.2
+COCOAPODS: 1.2.0

--- a/osx/Keybase.xcodeproj/project.pbxproj
+++ b/osx/Keybase.xcodeproj/project.pbxproj
@@ -36,9 +36,9 @@
 		00DAF5C01B2F8969000D7F9A /* Social.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00DAF5BE1B2F885D000D7F9A /* Social.framework */; };
 		00E1CEEF1C44313B00ED3A35 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 00E1CEEE1C44313B00ED3A35 /* Media.xcassets */; };
 		00E1CEF01C44313B00ED3A35 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 00E1CEEE1C44313B00ED3A35 /* Media.xcassets */; };
-		140F37DCFE61D8AA9A83FF5C /* libPods-keybase.Helper.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AF01BC4A44FA5C6796C1C820 /* libPods-keybase.Helper.a */; };
-		2B53DDCDBBFA7E3B74F64EE3 /* libPods-Status.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ECBDAE14DC630518EBC27C76 /* libPods-Status.a */; };
-		E144464761C164A1896A2D78 /* libPods-Installer.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C3C8C0FAD444743EC88E6FF1 /* libPods-Installer.a */; };
+		514F60CA609E25C04C72FFC3 /* Pods_keybase_Helper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 534190DA47FF7757FABCC0F1 /* Pods_keybase_Helper.framework */; };
+		5AAE4172EC33DA8F19F8A42E /* Pods_Installer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69A6ACE60F73339BC6D789BA /* Pods_Installer.framework */; };
+		EAACDAA5E950F358EB5A14C6 /* Pods_Status.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4795B58002E8F344AF75FF0 /* Pods_Status.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -165,14 +165,14 @@
 		10F5D4AFBFC1E22180FEFFCD /* Pods-Installer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Installer.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Installer/Pods-Installer.debug.xcconfig"; sourceTree = "<group>"; };
 		398CF2F9A9EB653FFE008EB6 /* Pods-Installer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Installer.release.xcconfig"; path = "Pods/Target Support Files/Pods-Installer/Pods-Installer.release.xcconfig"; sourceTree = "<group>"; };
 		50CECECF69AD315C4D376EB8 /* Pods-keybase.Helper.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-keybase.Helper.release.xcconfig"; path = "Pods/Target Support Files/Pods-keybase.Helper/Pods-keybase.Helper.release.xcconfig"; sourceTree = "<group>"; };
+		534190DA47FF7757FABCC0F1 /* Pods_keybase_Helper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_keybase_Helper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		69A6ACE60F73339BC6D789BA /* Pods_Installer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Installer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A6B4620AD7904EFA1B59736 /* Pods-Status.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status.release.xcconfig"; path = "Pods/Target Support Files/Pods-Status/Pods-Status.release.xcconfig"; sourceTree = "<group>"; };
 		A15A4EEA7C37D549AE45695A /* Pods-Status.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Status/Pods-Status.debug.xcconfig"; sourceTree = "<group>"; };
-		AF01BC4A44FA5C6796C1C820 /* libPods-keybase.Helper.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-keybase.Helper.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C3C8C0FAD444743EC88E6FF1 /* libPods-Installer.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Installer.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B4795B58002E8F344AF75FF0 /* Pods_Status.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Status.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2BEDB094F7E7A69C2DD1031 /* Pods-Keybase.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Keybase.release.xcconfig"; path = "Pods/Target Support Files/Pods-Keybase/Pods-Keybase.release.xcconfig"; sourceTree = "<group>"; };
 		DA5BD47C7019FB979DD332FE /* libPods-Keybase.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Keybase.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF54D7C94B2D7756B784F46B /* Pods-keybase.Helper.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-keybase.Helper.debug.xcconfig"; path = "Pods/Target Support Files/Pods-keybase.Helper/Pods-keybase.Helper.debug.xcconfig"; sourceTree = "<group>"; };
-		ECBDAE14DC630518EBC27C76 /* libPods-Status.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Status.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FEBE5DD9D5816FD9CB306E1D /* Pods-Keybase.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Keybase.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Keybase/Pods-Keybase.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -189,7 +189,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2B53DDCDBBFA7E3B74F64EE3 /* libPods-Status.a in Frameworks */,
+				EAACDAA5E950F358EB5A14C6 /* Pods_Status.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -205,7 +205,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				140F37DCFE61D8AA9A83FF5C /* libPods-keybase.Helper.a in Frameworks */,
+				514F60CA609E25C04C72FFC3 /* Pods_keybase_Helper.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -227,7 +227,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E144464761C164A1896A2D78 /* libPods-Installer.a in Frameworks */,
+				5AAE4172EC33DA8F19F8A42E /* Pods_Installer.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -428,9 +428,9 @@
 				00DAF5BE1B2F885D000D7F9A /* Social.framework */,
 				004624CD1B2A3BE300E218AC /* FinderSync.framework */,
 				DA5BD47C7019FB979DD332FE /* libPods-Keybase.a */,
-				AF01BC4A44FA5C6796C1C820 /* libPods-keybase.Helper.a */,
-				C3C8C0FAD444743EC88E6FF1 /* libPods-Installer.a */,
-				ECBDAE14DC630518EBC27C76 /* libPods-Status.a */,
+				69A6ACE60F73339BC6D789BA /* Pods_Installer.framework */,
+				B4795B58002E8F344AF75FF0 /* Pods_Status.framework */,
+				534190DA47FF7757FABCC0F1 /* Pods_keybase_Helper.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/osx/Podfile
+++ b/osx/Podfile
@@ -1,3 +1,5 @@
+use_frameworks!
+
 target "Installer" do
   platform :osx, "10.10"
   pod "ObjectiveSugar"
@@ -22,4 +24,13 @@ end
 target "keybase.Helper" do
   platform :osx, "10.10"
   pod "MPMessagePack"
+end
+
+# https://stackoverflow.com/questions/38446097/xcode-8-beta-3-use-legacy-swift-issue
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['SWIFT_VERSION'] = '3.0'
+    end
+  end
 end

--- a/osx/Podfile.lock
+++ b/osx/Podfile.lock
@@ -17,15 +17,13 @@ PODS:
   - AFNetworking/Reachability (2.6.3)
   - AFNetworking/Security (2.6.3)
   - AFNetworking/Serialization (2.6.3)
-  - CocoaLumberjack (2.4.0):
-    - CocoaLumberjack/Default (= 2.4.0)
-    - CocoaLumberjack/Extensions (= 2.4.0)
-  - CocoaLumberjack/Core (2.4.0)
-  - CocoaLumberjack/Default (2.4.0):
-    - CocoaLumberjack/Core
-  - CocoaLumberjack/Extensions (2.4.0):
+  - CocoaLumberjack (3.1.0):
+    - CocoaLumberjack/Default (= 3.1.0)
+    - CocoaLumberjack/Extensions (= 3.1.0)
+  - CocoaLumberjack/Default (3.1.0)
+  - CocoaLumberjack/Extensions (3.1.0):
     - CocoaLumberjack/Default
-  - GBCli (1.1)
+  - GBCli (1.2.1)
   - GHKeychain (1.2.8)
   - GHKit (2.0.3)
   - GHODictionary (1.1.0)
@@ -41,9 +39,9 @@ PODS:
     - ObjectiveSugar
     - Tikppa
     - YOLayout
-  - Mantle (2.0.7):
-    - Mantle/extobjc (= 2.0.7)
-  - Mantle/extobjc (2.0.7)
+  - Mantle (2.1.0):
+    - Mantle/extobjc (= 2.1.0)
+  - Mantle/extobjc (2.1.0)
   - MDPSplitView (1.0.2)
   - MPMessagePack (1.3.12):
     - GHODictionary
@@ -71,13 +69,13 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
-  CocoaLumberjack: aa9dcab71bdf9eaf2a63bbd9ddc87863efe45457
-  GBCli: e5f988fadb68e1e3c01919f134009fed9796fde0
+  CocoaLumberjack: 8311463ddf9ee86a06ef92a071dd656c89244500
+  GBCli: 3af947f1793263cda07c220aed0b4af46034d94d
   GHKeychain: 008cdb8bbab5b0dc1da3d0f06a67ce5203231e44
   GHKit: 2a20b51df9ce8f4355b2af2821805d369d610546
   GHODictionary: 225e042596a4b3d5b66b2b24250086b2f95514af
   KBKit: 9f139696e2cd916f05ee603e33aabfd558ac8ccd
-  Mantle: bc40bb061d8c2c6fb48d5083e04d928c3b7f73d9
+  Mantle: 2fa750afa478cd625a94230fbf1c13462f29395b
   MDPSplitView: 127b4b371e813ec29333e515fb1c057126a75671
   MPMessagePack: 078f8c3aed25079bac89003391fdb71f44bcf37a
   ObjectiveSugar: a6a25f23d657c19df0a0b972466d5b5ca9f5295c
@@ -85,6 +83,6 @@ SPEC CHECKSUMS:
   Tikppa: 77ac88aa89814a5ae9d18a773b4436ebef2235b7
   YOLayout: 6728d890bab9b9e4962efd554cba16d677b30b0f
 
-PODFILE CHECKSUM: 254d09634e37270f76c88d82cab3a560a72b79ed
+PODFILE CHECKSUM: 8a1b9dc7eb6fd442d174ea229f6d94220c90f64f
 
 COCOAPODS: 1.2.0

--- a/osx/Scripts/build.sh
+++ b/osx/Scripts/build.sh
@@ -51,7 +51,7 @@ set -o pipefail && xcodebuild archive -scheme $scheme -workspace $dir/../Keybase
 rm -rf $app_path
 
 echo "Exporting..."
-set -o pipefail && xcodebuild -exportArchive -archivePath $archive_path -exportFormat app -exportPath $app_path | xcpretty -c
+set -o pipefail && xcodebuild -exportArchive -archivePath $archive_path -exportOptionsPlist export.plist -exportPath $app_path | xcpretty -c
 
 echo "Done"
 echo ""

--- a/osx/Scripts/export.plist
+++ b/osx/Scripts/export.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/packaging/desktop/kbfuse.sh
+++ b/packaging/desktop/kbfuse.sh
@@ -15,7 +15,7 @@ cd $dir
 client_dir="$dir/../.."
 fuse_dir="$client_dir/osx/Fuse"
 tmp_dir="/tmp/desktop-kbfuse"
-installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.51-darwin.tgz"
+installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.52-darwin.tgz"
 
 if [ "$EUID" -ne 0 ]; then
   echo "Please run as root"

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -91,7 +91,7 @@ shared_support_dir="$out_dir/Keybase.app/Contents/SharedSupport"
 resources_dir="$out_dir/Keybase.app/Contents/Resources/"
 
 # The KeybaseInstaller.app installs KBFuse, keybase.Helper, services and CLI via a native app
-installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.51-darwin.tgz"
+installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.52-darwin.tgz"
 # KeybaseUpdater.app is the native updater UI (prompt dialogs)
 updater_url="https://prerelease.keybase.io/darwin-package/KeybaseUpdater-1.0.6-darwin.tgz"
 


### PR DESCRIPTION
Adds `KBNM.h/KBNM.m` component to macOS installer.
This will run `keybase install --components=kbnm`.

The other stuff was needed to update all the projects to the latest Xcode.