### PR TITLE
kbnm: Add --version support back in

### DIFF
--- a/go/kbnm/main.go
+++ b/go/kbnm/main.go
@@ -72,6 +72,11 @@ func process(h *handler, in nativemessaging.JSONDecoder, out nativemessaging.JSO
 func main() {
 	flag.Parse()
 
+	if *versionFlag {
+		fmt.Println(Version)
+		os.Exit(0)
+	}
+
 	// Native messages include a prefix which describes the length of each message.
 	var in nativemessaging.JSONDecoder
 	var out nativemessaging.JSONEncoder


### PR DESCRIPTION
It got removed accidentally at some point