### PR TITLE
use list trackers 2 engine when fetching followers/followees CORE-4709

### DIFF
--- a/go/engine/list_trackers2.go
+++ b/go/engine/list_trackers2.go
@@ -67,13 +67,10 @@ func (e *ListTrackers2Engine) Run(ctx *Context) error {
 	if err := e.lookupUID(); err != nil {
 		return err
 	}
-	ts := libkb.NewTracker2Syncer(e.G(), e.arg.Reverse)
-	var err error
-	aerr := e.G().LoginState().Account(func(a *libkb.Account) {
-		err = libkb.RunSyncer(ts, e.uid, a.LoggedIn(), a.LocalSession())
-	}, "ListTrackers2Engine - Run")
-	if aerr != nil {
-		return aerr
+	callerUID := e.G().Env.GetUID()
+	ts := libkb.NewTracker2Syncer(e.G(), callerUID, e.arg.Reverse)
+	if err := libkb.RunSyncer(ts, e.uid, false, nil); err != nil {
+		return err
 	}
 	e.res = ts.Result()
 	return nil

--- a/go/engine/list_trackers2.go
+++ b/go/engine/list_trackers2.go
@@ -67,9 +67,13 @@ func (e *ListTrackers2Engine) Run(ctx *Context) error {
 	if err := e.lookupUID(); err != nil {
 		return err
 	}
-	ts := libkb.NewTracker2Syncer(e.G())
-	if err := libkb.RunSyncer(ts, e.uid, false, nil); err != nil {
-		return err
+	ts := libkb.NewTracker2Syncer(e.G(), e.arg.Reverse)
+	var err error
+	aerr := e.G().LoginState().Account(func(a *libkb.Account) {
+		err = libkb.RunSyncer(ts, e.uid, a.LoggedIn(), a.LocalSession())
+	}, "ListTrackers2Engine - Run")
+	if aerr != nil {
+		return aerr
 	}
 	e.res = ts.Result()
 	return nil

--- a/go/libkb/sync_trackers2.go
+++ b/go/libkb/sync_trackers2.go
@@ -14,9 +14,10 @@ import (
 type Tracker2Syncer struct {
 	sync.Mutex
 	Contextified
-	res     *keybase1.UserSummary2Set
-	reverse bool
-	dirty   bool
+	res       *keybase1.UserSummary2Set
+	reverse   bool
+	dirty     bool
+	callerUID keybase1.UID
 }
 
 const cacheTimeout = 10 * time.Minute
@@ -64,9 +65,10 @@ func (t *Tracker2Syncer) syncFromServer(uid keybase1.UID, sr SessionReader) (err
 	defer t.G().Trace(fmt.Sprintf("syncFromServer(%s)", uid), func() error { return err })()
 
 	hargs := HTTPArgs{
-		"uid":       UIDArg(uid),
-		"reverse":   B{t.reverse},
-		"autoCamel": B{true},
+		"uid":        UIDArg(uid),
+		"reverse":    B{t.reverse},
+		"autoCamel":  B{true},
+		"caller_uid": UIDArg(t.callerUID),
 	}
 	lv := t.getLoadedVersion()
 	if lv >= 0 {
@@ -123,9 +125,10 @@ func (t *Tracker2Syncer) Result() keybase1.UserSummary2Set {
 	return *t.res
 }
 
-func NewTracker2Syncer(g *GlobalContext, reverse bool) *Tracker2Syncer {
+func NewTracker2Syncer(g *GlobalContext, callerUID keybase1.UID, reverse bool) *Tracker2Syncer {
 	return &Tracker2Syncer{
 		Contextified: NewContextified(g),
 		reverse:      reverse,
+		callerUID:    callerUID,
 	}
 }

--- a/go/libkb/sync_trackers2.go
+++ b/go/libkb/sync_trackers2.go
@@ -74,10 +74,9 @@ func (t *Tracker2Syncer) syncFromServer(uid keybase1.UID, sr SessionReader) (err
 	}
 	var res *APIRes
 	res, err = t.G().API.Get(APIArg{
-		Endpoint:    "user/list_followers_for_display",
-		Args:        hargs,
-		SessionR:    sr,
-		NeedSession: true,
+		Endpoint: "user/list_followers_for_display",
+		Args:     hargs,
+		SessionR: sr,
 	})
 	t.G().Log.Debug("| syncFromServer() -> %s", ErrToOk(err))
 	if err != nil {

--- a/go/libkb/sync_trackers2.go
+++ b/go/libkb/sync_trackers2.go
@@ -76,7 +76,8 @@ func (t *Tracker2Syncer) syncFromServer(uid keybase1.UID, sr SessionReader) (err
 	res, err = t.G().API.Get(APIArg{
 		Endpoint:    "user/list_followers_for_display",
 		Args:        hargs,
-		NeedSession: false,
+		SessionR:    sr,
+		NeedSession: true,
 	})
 	t.G().Log.Debug("| syncFromServer() -> %s", ErrToOk(err))
 	if err != nil {
@@ -123,8 +124,9 @@ func (t *Tracker2Syncer) Result() keybase1.UserSummary2Set {
 	return *t.res
 }
 
-func NewTracker2Syncer(g *GlobalContext) *Tracker2Syncer {
+func NewTracker2Syncer(g *GlobalContext, reverse bool) *Tracker2Syncer {
 	return &Tracker2Syncer{
 		Contextified: NewContextified(g),
+		reverse:      reverse,
 	}
 }

--- a/go/service/apiserver.go
+++ b/go/service/apiserver.go
@@ -75,24 +75,29 @@ func (a *APIServerHandler) setupArg(arg GenericArg) libkb.APIArg {
 	return kbarg
 }
 
-func (a *APIServerHandler) doGet(arg keybase1.GetArg) (keybase1.APIRes, error) {
-	res, err := a.G().API.Get(a.setupArg(arg))
+func (a *APIServerHandler) doGet(arg keybase1.GetArg) (res keybase1.APIRes, err error) {
+	a.G().Trace("APIServerHandler::Get", func() error { return err })()
+	var ires *libkb.APIRes
+	ires, err = a.G().API.Get(a.setupArg(arg))
 	if err != nil {
-		return keybase1.APIRes{}, err
+		return res, err
 	}
-	return a.convertRes(res), nil
+	return a.convertRes(ires), nil
 }
 
-func (a *APIServerHandler) doPost(arg keybase1.PostArg) (keybase1.APIRes, error) {
-	res, err := a.G().API.Post(a.setupArg(arg))
+func (a *APIServerHandler) doPost(arg keybase1.PostArg) (res keybase1.APIRes, err error) {
+	a.G().Trace("APIServerHandler::Post", func() error { return err })()
+	var ires *libkb.APIRes
+	ires, err = a.G().API.Post(a.setupArg(arg))
 	if err != nil {
-		return keybase1.APIRes{}, err
+		return res, err
 	}
-	return a.convertRes(res), nil
+	return a.convertRes(ires), nil
 }
 
-func (a *APIServerHandler) doPostJSON(rawarg keybase1.PostJSONArg) (keybase1.APIRes, error) {
-
+func (a *APIServerHandler) doPostJSON(rawarg keybase1.PostJSONArg) (res keybase1.APIRes, err error) {
+	a.G().Trace("APIServerHandler::PostJSON", func() error { return err })()
+	var ires *libkb.APIRes
 	arg := a.setupArg(rawarg)
 	jsonPayload := make(libkb.JSONPayload)
 	for _, kvpair := range rawarg.JSONPayload {
@@ -105,12 +110,12 @@ func (a *APIServerHandler) doPostJSON(rawarg keybase1.PostJSONArg) (keybase1.API
 	}
 	arg.JSONPayload = jsonPayload
 
-	res, err := a.G().API.PostJSON(arg)
+	ires, err = a.G().API.PostJSON(arg)
 	if err != nil {
 		return keybase1.APIRes{}, err
 	}
 
-	return a.convertRes(res), nil
+	return a.convertRes(ires), nil
 }
 
 func (a *APIServerHandler) convertRes(res *libkb.APIRes) keybase1.APIRes {

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -4,6 +4,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -193,6 +195,8 @@ func (h *UserHandler) LoadAllPublicKeysUnverified(ctx context.Context,
 }
 
 func (h *UserHandler) ListTrackers2(_ context.Context, arg keybase1.ListTrackers2Arg) (res keybase1.UserSummary2Set, err error) {
+	h.G().Trace(fmt.Sprintf("ListTrackers2(assertion=%s,reverse=%v)", arg.Assertion, arg.Reverse),
+		func() error { return err })()
 	eng := engine.NewListTrackers2(h.G(), arg)
 	ctx := &engine.Context{
 		LogUI:     h.getLogUI(arg.SessionID),


### PR DESCRIPTION
The point of this patch is to use the `ListTrackers2` endpoint on the service instead of just hitting the API server directly. This has the advantage of hitting a LevelDB cache which will both make things faster, as well as provide a better story for offline mode. 

cc @maxtaco since you created this engine, but it seems to have sat dormant for awhile.