### PR TITLE
kbnm: Cross-platform support

### DIFF
--- a/go/kbnm/findbin.go
+++ b/go/kbnm/findbin.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/kardianos/osext"
+)
+
+var errKeybaseNotFound = errors.New("failed to find the keybase binary")
+
+// findKeybaseBinary returns the path to the Keybase binary, if it finds it.
+func findKeybaseBinary() (string, error) {
+	// Is it near the kbnm binary?
+	dir, err := osext.ExecutableFolder()
+	if err == nil {
+		path := filepath.Join(dir, keybaseBinary)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			return path, nil
+		}
+	}
+
+	// Is it in our PATH?
+	path, err := exec.LookPath(keybaseBinary)
+	if err == nil {
+		return path, nil
+	}
+
+	// Last ditch effort!
+	path = guessKeybasePath()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		return path, nil
+	}
+
+	return "", errKeybaseNotFound
+}

--- a/go/kbnm/findbin_nix.go
+++ b/go/kbnm/findbin_nix.go
@@ -8,7 +8,9 @@ import (
 
 const keybaseBinary = "keybase"
 
-// guessKeybasePath makes a platform-specific guess to where the binary might be.
+// guessKeybasePath makes a platform-specific guess to where the binary might
+// be. This is only checked as a last-ditch effort when we can't find the
+// binary in other places.
 func guessKeybasePath() string {
 	return filepath.Join("/usr/local/bin", keybaseBinary)
 }

--- a/go/kbnm/findbin_nix.go
+++ b/go/kbnm/findbin_nix.go
@@ -1,6 +1,6 @@
-package main
-
 // +build !windows
+
+package main
 
 import (
 	"path/filepath"

--- a/go/kbnm/findbin_nix.go
+++ b/go/kbnm/findbin_nix.go
@@ -1,0 +1,14 @@
+package main
+
+// +build !windows
+
+import (
+	"path/filepath"
+)
+
+const keybaseBinary = "keybase"
+
+// guessKeybasePath makes a platform-specific guess to where the binary might be.
+func guessKeybasePath() string {
+	return filepath.Join("/usr/local/bin", keybaseBinary)
+}

--- a/go/kbnm/findbin_windows.go
+++ b/go/kbnm/findbin_windows.go
@@ -1,0 +1,15 @@
+package main
+
+// +build windows
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const keybaseBinary = "keybase.exe"
+
+// guessKeybasePath makes a platform-specific guess to where the binary might be.
+func guessKeybasePath() string {
+	return filepath.Join(os.Getenv("LOCALAPPDATA"), "Keybase", keybaseBinary)
+}

--- a/go/kbnm/findbin_windows.go
+++ b/go/kbnm/findbin_windows.go
@@ -9,7 +9,9 @@ import (
 
 const keybaseBinary = "keybase.exe"
 
-// guessKeybasePath makes a platform-specific guess to where the binary might be.
+// guessKeybasePath makes a platform-specific guess to where the binary might
+// be. This is only checked as a last-ditch effort when we can't find the
+// binary in other places.
 func guessKeybasePath() string {
 	return filepath.Join(os.Getenv("LOCALAPPDATA"), "Keybase", keybaseBinary)
 }

--- a/go/kbnm/findbin_windows.go
+++ b/go/kbnm/findbin_windows.go
@@ -1,6 +1,6 @@
-package main
-
 // +build windows
+
+package main
 
 import (
 	"os"

--- a/go/kbnm/handler.go
+++ b/go/kbnm/handler.go
@@ -21,13 +21,16 @@ func execRunner(cmd *exec.Cmd) error {
 // Handler returns a request handler.
 func Handler() *handler {
 	return &handler{
-		Run: execRunner,
+		Run:               execRunner,
+		FindKeybaseBinary: findKeybaseBinary,
 	}
 }
 
 type handler struct {
 	// Run wraps the equivalent of cmd.Run(), allowing for mocking
 	Run func(cmd *exec.Cmd) error
+	// FindCmd returns the path of the keybase binary if it can find it
+	FindKeybaseBinary func() (string, error)
 }
 
 // Handle accepts a request, handles it, and returns an optional result if there was no error
@@ -47,7 +50,7 @@ func (h *handler) handleChat(req *Request) error {
 		return errMissingField
 	}
 
-	binPath, err := findKeybaseBinary()
+	binPath, err := h.FindKeybaseBinary()
 	if err != nil {
 		return err
 	}
@@ -74,7 +77,7 @@ func (h *handler) handleQuery(req *Request) (*resultQuery, error) {
 		return nil, errMissingField
 	}
 
-	binPath, err := findKeybaseBinary()
+	binPath, err := h.FindKeybaseBinary()
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbnm/handler.go
+++ b/go/kbnm/handler.go
@@ -14,12 +14,6 @@ var errMissingField = errors.New("missing field")
 
 var errUserNotFound = errors.New("user not found")
 
-// findKeybaseBinary returns the path to the Keybase binary, if it finds it.
-func findKeybaseBinary() (string, error) {
-	// FIXME: Get the absolute path without a filled PATH var somehow?
-	return "/usr/local/bin/keybase", nil
-}
-
 func execRunner(cmd *exec.Cmd) error {
 	return cmd.Run()
 }

--- a/go/kbnm/handler_test.go
+++ b/go/kbnm/handler_test.go
@@ -15,6 +15,9 @@ func TestHandlerChat(t *testing.T) {
 		ranCmd = strings.Join(cmd.Args, " ")
 		return nil
 	}
+	h.FindKeybaseBinary = func() (string, error) {
+		return "/mocked/test/path/keybase", nil
+	}
 
 	req := &Request{
 		Method: "chat",
@@ -26,7 +29,7 @@ func TestHandlerChat(t *testing.T) {
 		t.Errorf("request failed: %q", err)
 	}
 
-	if ranCmd != "/usr/local/bin/keybase chat send --private testkeybaseuser" {
+	if ranCmd != "/mocked/test/path/keybase chat send --private testkeybaseuser" {
 		t.Errorf("unexpected command: %q", ranCmd)
 	}
 }
@@ -53,6 +56,9 @@ func TestHandlerQuery(t *testing.T) {
 		io.WriteString(cmd.Stdout, queryResponse)
 		return nil
 	}
+	h.FindKeybaseBinary = func() (string, error) {
+		return "/mocked/test/path/keybase", nil
+	}
 
 	req := &Request{
 		Method: "query",
@@ -68,7 +74,7 @@ func TestHandlerQuery(t *testing.T) {
 		t.Errorf("result is not *resultQuery: %T", res)
 	}
 
-	if ranCmd != "/usr/local/bin/keybase sigs list --type=self --json testkeybaseuser" {
+	if ranCmd != "/mocked/test/path/keybase sigs list --type=self --json testkeybaseuser" {
 		t.Errorf("unexpected command: %q", ranCmd)
 	}
 

--- a/go/kbnm/main_test.go
+++ b/go/kbnm/main_test.go
@@ -17,6 +17,9 @@ func TestProcess(t *testing.T) {
 		ranCmd = strings.Join(cmd.Args, " ")
 		return nil
 	}
+	h.FindKeybaseBinary = func() (string, error) {
+		return "/mocked/test/path/keybase", nil
+	}
 
 	var inBuf, outBuf bytes.Buffer
 	in := json.NewDecoder(&inBuf)


### PR DESCRIPTION
This is a take-two of https://github.com/keybase/client/pull/6515

> We had the keybase binary path hardcoded before, this version tries multiple paths and is Windows-friendly.
> 
> Note that when Chrome calls kbnm (at least on Mac), it does not pass along useful environment variables like $PATH, so we can't really rely on it.

- [x] There is a remaining bug where the tests fail because the binary finder thing is not mocked out. Need to fix it before merging.