### PR TITLE
Require prev pointers on post, check convID

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -1337,3 +1337,23 @@ func (b *Boxer) compareHeadersV1(ctx context.Context, hServer chat1.MessageClien
 
 	return nil
 }
+
+func (b *Boxer) CompareTlfNames(ctx context.Context, tlfName1, tlfName2 string, tlfPublic bool) (bool, error) {
+	get1 := func(tlfName string, tlfPublic bool) (string, error) {
+		cres, err := CtxKeyFinder(ctx).Find(ctx, b.tlfInfoSource, tlfName, tlfPublic)
+		if err != nil {
+			return "", err
+		}
+		return string(cres.NameIDBreaks.CanonicalName), nil
+	}
+
+	c1, err := get1(tlfName1, tlfPublic)
+	if err != nil {
+		return false, err
+	}
+	c2, err := get1(tlfName2, tlfPublic)
+	if err != nil {
+		return false, err
+	}
+	return c1 == c2, nil
+}

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -20,19 +20,9 @@ func TestInboxSourceUpdateRace(t *testing.T) {
 	u := world.GetUsers()[0]
 	tc := world.Tcs[u.Username]
 	trip := newConvTriple(t, tlf, u.Username)
-	res, err := ri.NewConversationRemote2(context.TODO(), chat1.NewConversationRemote2Arg{
-		IdTriple: trip,
-		TLFMessage: chat1.MessageBoxed{
-			ClientHeader: chat1.MessageClientHeader{
-				TlfName:   u.Username,
-				TlfPublic: false,
-			},
-			KeyGeneration: 1,
-		},
-	})
-	require.NoError(t, err)
+	res := startConv(t, u, trip, sender, ri, tc)
 
-	_, _, _, err = sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+	_, _, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        trip,
 			Sender:      u.User.GetUID().ToBytes(),
@@ -108,18 +98,7 @@ func TestInboxSourceSkipAhead(t *testing.T) {
 
 	t.Logf("new conv")
 	trip := newConvTriple(t, tlf, u.Username)
-	res, err := ri.NewConversationRemote2(context.TODO(), chat1.NewConversationRemote2Arg{
-		IdTriple: trip,
-		TLFMessage: chat1.MessageBoxed{
-			ClientHeader: chat1.MessageClientHeader{
-				TlfName:   u.Username,
-				TlfPublic: false,
-			},
-			KeyGeneration: 1,
-		},
-	})
-	_ = res
-	require.NoError(t, err)
+	res := startConv(t, u, trip, sender, ri, tc)
 
 	assertInboxVersion(0)
 

--- a/go/chat/prev.go
+++ b/go/chat/prev.go
@@ -35,13 +35,7 @@ func CheckPrevPointersAndGetUnpreved(thread *chat1.ThreadView) ([]chat1.MessageP
 			// Check that each prev pointer (if any) is a lower ID than the
 			// message itself.
 			for _, prev := range msg.ClientHeader.Prev {
-				if prev.Id == id {
-					return nil, NewChatThreadConsistencyError(
-						OutOfOrderID,
-						"MessageID %d thinks its own id is previous.",
-						id)
-				}
-				if prev.Id > id {
+				if prev.Id >= id {
 					return nil, NewChatThreadConsistencyError(
 						OutOfOrderID,
 						"MessageID %d thinks that message %d is previous.",

--- a/go/chat/prev.go
+++ b/go/chat/prev.go
@@ -35,6 +35,12 @@ func CheckPrevPointersAndGetUnpreved(thread *chat1.ThreadView) ([]chat1.MessageP
 			// Check that each prev pointer (if any) is a lower ID than the
 			// message itself.
 			for _, prev := range msg.ClientHeader.Prev {
+				if prev.Id == id {
+					return nil, NewChatThreadConsistencyError(
+						OutOfOrderID,
+						"MessageID %d thinks its own id is previous.",
+						id)
+				}
 				if prev.Id > id {
 					return nil, NewChatThreadConsistencyError(
 						OutOfOrderID,
@@ -52,7 +58,7 @@ func CheckPrevPointersAndGetUnpreved(thread *chat1.ThreadView) ([]chat1.MessageP
 	// Using the index we built above, check each prev pointer on each message
 	// to make sure its hash is correct. Some prev pointers might refer to
 	// messages we don't have locally, and in that case we just check that all
-	// prev pointers to that message are *consistent*.
+	// prev pointers to that message are *consistent* with each other.
 	seenHashes := make(map[chat1.MessageID]chat1.Hash)
 	for id, msg := range knownMessages {
 		for _, prev := range msg.ClientHeader.Prev {

--- a/go/chat/prev_test.go
+++ b/go/chat/prev_test.go
@@ -144,6 +144,24 @@ func TestPrevOutOfOrder(t *testing.T) {
 	expectCode(t, err, OutOfOrderID)
 }
 
+func TestPrevOutOfOrderEq(t *testing.T) {
+	thread := threadViewFromDummies([]dummyMessage{
+		dummyMessage{
+			id:   1,
+			hash: []byte("placeholder"),
+			prevs: []chat1.MessagePreviousPointer{
+				chat1.MessagePreviousPointer{
+					Id:   1, // Points to self!
+					Hash: []byte("placeholder"),
+				},
+			},
+		},
+	})
+
+	_, err := CheckPrevPointersAndGetUnpreved(&thread)
+	expectCode(t, err, OutOfOrderID)
+}
+
 func TestPrevIncorrectHash(t *testing.T) {
 	thread := threadViewFromDummies([]dummyMessage{
 		dummyMessage{

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
@@ -73,7 +74,7 @@ func (s *BlockingSender) addSenderToMessage(msg chat1.MessagePlaintext) (chat1.M
 	return updated, nil
 }
 
-func (s *BlockingSender) addPrevPointersToMessage(ctx context.Context, msg chat1.MessagePlaintext,
+func (s *BlockingSender) addPrevPointersAndCheckConvID(ctx context.Context, msg chat1.MessagePlaintext,
 	convID chat1.ConversationID) (chat1.MessagePlaintext, error) {
 
 	// Make sure the caller hasn't already assembled this list. For now, this
@@ -86,26 +87,36 @@ func (s *BlockingSender) addPrevPointersToMessage(ctx context.Context, msg chat1
 
 	var prevs []chat1.MessagePreviousPointer
 
-	res, err := s.G().ConvSource.PullLocalOnly(ctx, convID, msg.ClientHeader.Sender,
+	res, _, err := s.G().ConvSource.Pull(ctx, convID, msg.ClientHeader.Sender,
 		&chat1.GetThreadQuery{
 			DisableResolveSupersedes: true,
 		},
 		&chat1.Pagination{
-			Num: -1,
+			Num: 50,
 		})
-	switch err.(type) {
-	case storage.MissError:
-		s.Debug(ctx, "No local messages; skipping prev pointers")
-	case nil:
-		if len(res.Messages) == 0 {
-			s.Debug(ctx, "no local messages found for prev pointers")
-		}
-		prevs, err = CheckPrevPointersAndGetUnpreved(&res)
-		if err != nil {
-			return chat1.MessagePlaintext{}, err
-		}
-	default:
+	if err != nil {
 		return chat1.MessagePlaintext{}, err
+	}
+
+	if len(res.Messages) == 0 {
+		s.Debug(ctx, "no local messages found for prev pointers")
+	}
+	prevs, err = CheckPrevPointersAndGetUnpreved(&res)
+	if err != nil {
+		return chat1.MessagePlaintext{}, err
+	}
+
+	if len(prevs) == 0 {
+		return chat1.MessagePlaintext{}, fmt.Errorf("Could not find previous messsages for prev pointers")
+	}
+
+	for _, msg2 := range res.Messages {
+		if msg2.IsValid() {
+			err = s.checkConvID(ctx, convID, msg, msg2)
+			if err != nil {
+				return chat1.MessagePlaintext{}, err
+			}
+		}
 	}
 
 	// Make an attempt to avoid changing anything in the input message. There
@@ -117,6 +128,45 @@ func (s *BlockingSender) addPrevPointersToMessage(ctx context.Context, msg chat1
 		MessageBody:  msg.MessageBody,
 	}
 	return updated, nil
+}
+
+// Check that the {ConvID,ConvTriple,TlfName} of msgToSend matches both the ConvID and a an existing message from the questionable ConvID.
+// This check is necessary because msgToSend may have been constructed with an untrusted Conv{ID,Triple}.
+func (s *BlockingSender) checkConvID(ctx context.Context, convID chat1.ConversationID,
+	msgToSend chat1.MessagePlaintext, msgReference chat1.MessageUnboxed) error {
+
+	headerQ := msgToSend.ClientHeader
+	headerRef := msgReference.Valid().ClientHeader
+
+	fmtConv := func(conv chat1.ConversationIDTriple) string { return hex.EncodeToString(conv.Hash()) }
+
+	if !headerQ.Conv.Derivable(convID) {
+		s.Debug(ctx, "checkConvID: ConvID %s </- %s", fmtConv(headerQ.Conv), convID)
+		return fmt.Errorf("ConversationID does not match reference message")
+	}
+
+	if !headerQ.Conv.Eq(headerRef.Conv) {
+		s.Debug(ctx, "checkConvID: Conv %s != %s", fmtConv(headerQ.Conv), fmtConv(headerRef.Conv))
+		return fmt.Errorf("ConversationID does not match reference message")
+	}
+
+	if headerQ.TlfPublic != headerRef.TlfPublic {
+		s.Debug(ctx, "checkConvID: TlfPublic %s != %s", headerQ.TlfPublic, headerRef.TlfPublic)
+		return fmt.Errorf("Chat public-ness does not match reference message")
+	}
+	if headerQ.TlfName != headerRef.TlfName {
+		// Try normalizing both tlfnames if simple comparison fails because they may have resolved.
+		namesEq, err := s.boxer.CompareTlfNames(ctx, headerQ.TlfName, headerRef.TlfName, headerQ.TlfPublic)
+		if err != nil {
+			return err
+		}
+		if !namesEq {
+			s.Debug(ctx, "checkConvID: TlfName %s != %s", headerQ.TlfName, headerRef.TlfName)
+			return fmt.Errorf("TlfName does not match reference message")
+		}
+	}
+
+	return nil
 }
 
 // Get all messages to be deleted, and attachments to delete.
@@ -275,9 +325,9 @@ func (s *BlockingSender) Prepare(ctx context.Context, plaintext chat1.MessagePla
 		return nil, nil, err
 	}
 
-	// convID will be nil in makeFirstMessage, for example
+	// convID will be nil in makeFirstMessage
 	if convID != nil {
-		msg, err = s.addPrevPointersToMessage(ctx, msg, *convID)
+		msg, err = s.addPrevPointersAndCheckConvID(ctx, msg, *convID)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -107,7 +107,7 @@ func (s *BlockingSender) addPrevPointersAndCheckConvID(ctx context.Context, msg 
 	}
 
 	if len(prevs) == 0 {
-		return chat1.MessagePlaintext{}, fmt.Errorf("Could not find previous messsages for prev pointers")
+		return chat1.MessagePlaintext{}, fmt.Errorf("Could not find previous messsages for prev pointers (of %v)", len(res.Messages))
 	}
 
 	for _, msg2 := range res.Messages {

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -868,6 +868,7 @@ func (h *chatLocalHandler) PostTextNonblock(ctx context.Context, arg chat1.PostT
 }
 
 func (h *chatLocalHandler) PostLocalNonblock(ctx context.Context, arg chat1.PostLocalNonblockArg) (res chat1.PostLocalNonblockRes, err error) {
+
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = chat.Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "PostLocalNonblock")()


### PR DESCRIPTION
- Require prev pointers to be non-nil on sending (except for first message)
- Pull from convsource proper, not just local, when gathering prev pointers (maximum 50 msgs)
- Do an extra check to handle the case where frontend sends a message from an untrusted inbox view.