### PR TITLE
add a short timeout to API calls if chat is offline CORE-4890

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -308,7 +308,7 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 	// connected to Gregor, then it is likely the case we are totally offline, or on a very bad
 	// connection. If that is the case, let's make these timeouts very aggressive, so we don't
 	// block up everything trying to succeed when we probably will not.
-	if g.G().Syncer != nil && !g.G().Syncer.IsConnected(ctx) {
+	if !g.G().Syncer.IsConnected(ctx) {
 		arg.InitialTimeout = HTTPFastTimeout
 		arg.RetryCount = 0
 	}
@@ -346,7 +346,7 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 		timeout = time.Duration(float64(timeout) * multiplier)
 
 		// If chat goes offline during this retry loop, then let's bail out early
-		if g.G().Syncer != nil && !g.G().Syncer.IsConnected(ctx) {
+		if !g.G().Syncer.IsConnected(ctx) {
 			g.G().Log.CDebugf(ctx, "retry loop aborting since chat went offline")
 			break
 		}

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -304,6 +304,15 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 // on this request; and an error. The canceler function is to clean up the timeout.
 func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *http.Request) (*http.Response, func(), error) {
 
+	// This serves as a proxy for checking the status of the Gregor connection. If we are not
+	// connected to Gregor, then it is likely the case we are totally offline, or on a very bad
+	// connection. If that is the case, let's make these timeouts very aggressive, so we don't
+	// block up everything trying to succeed when we probably will not.
+	if !g.G().Syncer.IsConnected(ctx) {
+		arg.InitialTimeout = 2 * time.Second
+		arg.RetryCount = 0
+	}
+
 	if arg.InitialTimeout == 0 && arg.RetryCount == 0 {
 		resp, err := ctxhttp.Do(ctx, cli.cli, req)
 		return resp, nil, err
@@ -335,6 +344,12 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 		}
 		lastErr = err
 		timeout = time.Duration(float64(timeout) * multiplier)
+
+		// If chat goes offline during this retry loop, then let's bail out early
+		if !g.G().Syncer.IsConnected(ctx) {
+			g.G().Log.CDebugf(ctx, "retry loop aborting since chat went offline")
+			break
+		}
 	}
 
 	return nil, nil, fmt.Errorf("doRetry failed, attempts: %d, timeout %s, last err: %s", retries, timeout, lastErr)

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -309,7 +309,7 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 	// connection. If that is the case, let's make these timeouts very aggressive, so we don't
 	// block up everything trying to succeed when we probably will not.
 	if !g.G().Syncer.IsConnected(ctx) {
-		arg.InitialTimeout = 2 * time.Second
+		arg.InitialTimeout = HTTPFastTimeout
 		arg.RetryCount = 0
 	}
 

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -308,7 +308,7 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 	// connected to Gregor, then it is likely the case we are totally offline, or on a very bad
 	// connection. If that is the case, let's make these timeouts very aggressive, so we don't
 	// block up everything trying to succeed when we probably will not.
-	if !g.G().Syncer.IsConnected(ctx) {
+	if g.G().Syncer != nil && !g.G().Syncer.IsConnected(ctx) {
 		arg.InitialTimeout = HTTPFastTimeout
 		arg.RetryCount = 0
 	}
@@ -346,7 +346,7 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 		timeout = time.Duration(float64(timeout) * multiplier)
 
 		// If chat goes offline during this retry loop, then let's bail out early
-		if !g.G().Syncer.IsConnected(ctx) {
+		if g.G().Syncer != nil && !g.G().Syncer.IsConnected(ctx) {
 			g.G().Log.CDebugf(ctx, "retry loop aborting since chat went offline")
 			break
 		}

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -338,6 +338,7 @@ const (
 	HTTPDefaultTimeout        = 60 * time.Second
 	HTTPDefaultScraperTimeout = 10 * time.Second
 	HTTPPollMaximum           = 5 * time.Second
+	HTTPFastTimeout           = 2 * time.Second
 )
 
 // The following constants apply to APIArg parameters for

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -20,8 +20,11 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -257,6 +260,7 @@ func setupTestContext(tb testing.TB, name string, tcPrev *TestContext) (tc TestC
 		return
 	}
 
+	g.Syncer = NullChatSyncer{}
 	g.GregorDismisser = &FakeGregorDismisser{}
 
 	tc.PrevGlobal = G
@@ -440,3 +444,38 @@ func (f *FakeGregorDismisser) DismissItem(id gregor.MsgID) error {
 	f.dismissedIDs = append(f.dismissedIDs, id)
 	return nil
 }
+
+type NullChatSyncer struct {
+}
+
+func (s NullChatSyncer) IsConnected(ctx context.Context) bool {
+	return true
+}
+
+func (s NullChatSyncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,
+	syncRes *chat1.SyncChatRes) error {
+	return nil
+}
+
+func (s NullChatSyncer) Disconnected(ctx context.Context) {
+
+}
+
+func (s NullChatSyncer) Sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,
+	syncRes *chat1.SyncChatRes) error {
+	return nil
+}
+
+func (s NullChatSyncer) RegisterOfflinable(offlinable types.Offlinable) {
+
+}
+
+func (s NullChatSyncer) SendChatStaleNotifications(ctx context.Context, uid gregor1.UID, convIDs []chat1.ConversationID, immediate bool) {
+
+}
+
+func (s NullChatSyncer) Shutdown() {
+
+}
+
+var _ types.Syncer = NullChatSyncer{}


### PR DESCRIPTION
The point of this is if we are on a high packet loss network, and chat has taken itself offline, that we raise the bar on API server response times. Requests to the API servers in these conditions will likely fail, but might take awhile since the connection might be nominally alive.