### PR TITLE
Use cacheDir for attachments on desktop, not os.tmpDir

### DIFF
--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -200,7 +200,7 @@ function * onOpenAttachmentPopup (action: Constants.OpenAttachmentPopup): SagaGe
   }
 
   yield put(putActionIfOnPath(currentPath, navigateAppend([{props: {messageID, conversationIDKey: message.conversationIDKey}, selected: 'attachment'}])))
-  if (!message.hdPreviewPath && message.filename) {
+  if (!message.hdPreviewPath && message.filename && message.messageID) {
     yield put(Creators.loadAttachment(message.conversationIDKey, messageID, tmpFile(Shared.tmpFileName(true, message.conversationIDKey, message.messageID, message.filename)), false, true))
   }
 }

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -53,8 +53,9 @@ function inboxUntrustedStateSelector (state: TypedState) {
 }
 
 function tmpFileName (isHdPreview: boolean, conversationID: Constants.ConversationIDKey, messageID: ?Constants.MessageID, filename: string) {
-  if (!messageID)
+  if (!messageID) {
     throw new Error('tmpFileName called without messageID!')
+  }
 
   return `kbchat-${isHdPreview ? 'hdPreview' : 'preview'}-${conversationID}-${messageID}`
 }

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -52,7 +52,7 @@ function inboxUntrustedStateSelector (state: TypedState) {
   return state.chat.get('inboxUntrustedState')
 }
 
-function tmpFileName (isHdPreview: boolean, conversationID: Constants.ConversationIDKey, messageID: ?Constants.MessageID, filename: string) {
+function tmpFileName (isHdPreview: boolean, conversationID: Constants.ConversationIDKey, messageID: Constants.MessageID, filename: string) {
   if (!messageID) {
     throw new Error('tmpFileName called without messageID!')
   }

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -53,7 +53,10 @@ function inboxUntrustedStateSelector (state: TypedState) {
 }
 
 function tmpFileName (isHdPreview: boolean, conversationID: Constants.ConversationIDKey, messageID: ?Constants.MessageID, filename: string) {
-  return `kbchat-${isHdPreview ? 'hdPreview' : 'preview'}-${conversationID}-${messageID || ''}-${filename}`
+  if (!messageID)
+    throw new Error('tmpFileName called without messageID!')
+
+  return `kbchat-${isHdPreview ? 'hdPreview' : 'preview'}-${conversationID}-${messageID}`
 }
 
 function * clientHeader (messageType: ChatTypes.MessageType, conversationIDKey: Constants.ConversationIDKey): Generator<any, ?ChatTypes.MessageClientHeader, any> {

--- a/shared/constants/platform.js.flow
+++ b/shared/constants/platform.js.flow
@@ -9,6 +9,5 @@ export const isElectron: boolean = false
 export const isDarwin: boolean = false
 export const isWindows: boolean = false
 export const isLinux: boolean = false
-
 declare export var fileUIName: string
 declare export var version: string

--- a/shared/constants/platform.js.flow
+++ b/shared/constants/platform.js.flow
@@ -9,5 +9,6 @@ export const isElectron: boolean = false
 export const isDarwin: boolean = false
 export const isWindows: boolean = false
 export const isLinux: boolean = false
+
 declare export var fileUIName: string
 declare export var version: string

--- a/shared/util/file.desktop.js
+++ b/shared/util/file.desktop.js
@@ -5,7 +5,7 @@ import fsExtra from 'fs-extra'
 import os from 'os'
 import path from 'path'
 
-import {cacheRoot} from '../constants/platform'
+import {cacheRoot} from '../constants/platform.desktop'
 
 function tmpDir (): string {
   return cacheRoot

--- a/shared/util/file.desktop.js
+++ b/shared/util/file.desktop.js
@@ -5,12 +5,14 @@ import fsExtra from 'fs-extra'
 import os from 'os'
 import path from 'path'
 
+import {cacheRoot} from '../constants/platform'
+
 function tmpDir (): string {
-  return os.tmpdir()
+  return cacheRoot
 }
 
 function tmpFile (suffix: string): string {
-  return path.join(os.tmpdir(), suffix)
+  return path.join(tmpDir(), suffix)
 }
 
 function tmpRandFile (suffix: string): Promise<string> {
@@ -20,7 +22,7 @@ function tmpRandFile (suffix: string): Promise<string> {
         reject(err)
         return
       }
-      resolve(path.join(os.tmpdir(), buf.toString('hex') + suffix))
+      resolve(path.join(tmpDir(), buf.toString('hex') + suffix))
     })
   })
 }


### PR DESCRIPTION
@keybase/react-hackers 

Fixes attachment metadata leaking into os.tmpDir().  Will need a cleanup solution to remove previews over time, but that's not in this PR.  Also removes the actual filename from the preview filename.