### PR TITLE
Fix sending to new conversations

### DIFF
--- a/shared/chat/conversation/input/container.js
+++ b/shared/chat/conversation/input/container.js
@@ -16,11 +16,15 @@ const mapStateToProps = (state: TypedState, {focusInputCounter}: OwnProps) => {
 
   let isLoading = true
 
-  if (!Constants.isPendingConversationIDKey(selectedConversationIDKey || '') &&
-    selectedConversationIDKey !== Constants.nothingSelected) {
-    const conversationState = state.chat.get('conversationStates').get(selectedConversationIDKey)
-    if (conversationState) {
-      isLoading = conversationState.isLoading
+  if (selectedConversationIDKey !== Constants.nothingSelected) {
+    if (!Constants.isPendingConversationIDKey(selectedConversationIDKey || '')) {
+      const conversationState = state.chat.get('conversationStates').get(selectedConversationIDKey)
+      if (conversationState) {
+        isLoading = !conversationState.isLoaded
+      }
+    } else {
+      // A conversation can't be loading if it's pending -- it doesn't exist yet and we need to allow creating it.
+      isLoading = false
     }
   }
 

--- a/shared/chat/conversation/input/container.js
+++ b/shared/chat/conversation/input/container.js
@@ -23,7 +23,8 @@ const mapStateToProps = (state: TypedState, {focusInputCounter}: OwnProps) => {
         isLoading = !conversationState.isLoaded
       }
     } else {
-      // A conversation can't be loading if it's pending -- it doesn't exist yet and we need to allow creating it.
+      // A conversation can't be loading if it's pending -- it doesn't exist
+      // yet and we need to allow creating it.
       isLoading = false
     }
   }


### PR DESCRIPTION
@keybase/react-hackers 

CC @patrickxb 

PR #6486 broke creating new conversations.  I think there were two bugs:

* For non-pending conversations, the code checks `conversationState.isLoading`, but the actual store value is (negated) `conversationState.isLoaded`.  So all conversations were marked as not loading, because `isLoading` is always `undefined` since `isLoaded` never exists.  I guess Flow doesn't catch this because it's an immutable record?

* Pending conversations received the default case of `isLoading = true`, with no way for it to become untrue, because you have to submit a message to a conversation to convert it from pending to real, and you can't submit a message if `isLoading` is true.

Not sure what the intent of the original PR was regarding pending conversations, so I think best for @chrisnojima to review this one.