### PR TITLE
fetch max messages on full inbox queries CORE-4793

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -301,7 +301,7 @@ func (b *baseInboxSource) getInboxQueryLocalToRemote(ctx context.Context,
 	rquery.ConvIDs = lquery.ConvIDs
 	rquery.OneChatTypePerTLF = lquery.OneChatTypePerTLF
 	rquery.Status = lquery.Status
-	rquery.SummarizeMaxMsgs = true
+	rquery.SummarizeMaxMsgs = false
 
 	return rquery, info, nil
 }
@@ -448,12 +448,12 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, query *chat1.G
 	if query == nil {
 		rquery = chat1.GetInboxQuery{
 			ComputeActiveList: true,
-			SummarizeMaxMsgs:  true,
+			SummarizeMaxMsgs:  false,
 		}
 	} else {
 		rquery = *query
 		rquery.ComputeActiveList = true
-		rquery.SummarizeMaxMsgs = true
+		rquery.SummarizeMaxMsgs = false
 	}
 
 	ib, err := s.getChatInterface().GetInboxRemote(ctx, chat1.GetInboxRemoteArg{
@@ -804,7 +804,7 @@ func (s *localizerPipeline) getMessagesOffline(ctx context.Context, convID chat1
 		return nil, chat1.ConversationErrorType_LOCALMAXMESSAGENOTFOUND, err
 	}
 
-	// Make sure we legit msgs
+	// Make sure we got legit msgs
 	var foundMsgs []chat1.MessageUnboxed
 	for _, msg := range res {
 		if msg != nil {
@@ -820,8 +820,33 @@ func (s *localizerPipeline) getMessagesOffline(ctx context.Context, convID chat1
 	return foundMsgs, chat1.ConversationErrorType_MISC, nil
 }
 
+// fillSummaries uses MaxMsgs to fill in MaxMsgSummaries.
+// After this call MaxMsgSummaries is a superset of MaxMsgs.
+func (s *localizerPipeline) fillSummaries(ctx context.Context, conversationRemote *chat1.Conversation) {
+	summaries := make(map[chat1.MessageID]chat1.MessageSummary)
+
+	// Collect the existing summaries
+	for _, m := range conversationRemote.MaxMsgSummaries {
+		summaries[m.MsgID] = m
+	}
+
+	// Collect the locally-grown summaries
+	for _, m := range conversationRemote.MaxMsgs {
+		summaries[m.GetMessageID()] = m.Summary()
+	}
+
+	// Insert all the summaries
+	conversationRemote.MaxMsgSummaries = nil
+	for _, m := range summaries {
+		conversationRemote.MaxMsgSummaries = append(conversationRemote.MaxMsgSummaries, m)
+	}
+}
+
 func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor1.UID,
 	conversationRemote chat1.Conversation) (conversationLocal chat1.ConversationLocal) {
+
+	// Fill MaxMsgSummaries from MaxMsgs.
+	s.fillSummaries(ctx, &conversationRemote)
 
 	unverifiedTLFName := getUnverifiedTlfNameForErrors(conversationRemote)
 	s.Debug(ctx, "localizing: TLF: %s convID: %s offline: %v", unverifiedTLFName,
@@ -865,12 +890,19 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		}
 	}
 
-	// Fetch max messages unboxed, using either a custom function or through
-	// the conversation source configured in the global context
-	var err error
-	if s.offline {
-		msgs, errTyp, err := s.getMessagesOffline(ctx, conversationRemote.GetConvID(),
-			uid, conversationRemote.MaxMsgSummaries, conversationRemote.Metadata.FinalizeInfo)
+	if len(conversationRemote.MaxMsgs) == 0 {
+		// Fetch max messages unboxed, using either a custom function or through
+		// the conversation source configured in the global context
+		var err error
+		errTyp := chat1.ConversationErrorType_MISC
+		var msgs []chat1.MessageUnboxed
+		if s.offline {
+			msgs, errTyp, err = s.getMessagesOffline(ctx, conversationRemote.GetConvID(),
+				uid, conversationRemote.MaxMsgSummaries, conversationRemote.Metadata.FinalizeInfo)
+		} else {
+			msgs, err = s.G().ConvSource.GetMessages(ctx, conversationRemote.Metadata.ConversationID,
+				uid, utils.PluckMessageIDs(conversationRemote.MaxMsgSummaries), conversationRemote.Metadata.FinalizeInfo)
+		}
 		if err != nil {
 			convErr := s.checkRekeyError(ctx, err, conversationRemote, unverifiedTLFName)
 			if convErr != nil {
@@ -885,19 +917,16 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		}
 		conversationLocal.MaxMessages = msgs
 	} else {
-		conversationLocal.MaxMessages, err = s.G().ConvSource.GetMessages(ctx,
-			conversationRemote.Metadata.ConversationID, uid, utils.PluckMessageIDs(conversationRemote.MaxMsgSummaries), conversationRemote.Metadata.FinalizeInfo)
+		// Use the attached MaxMsgs
+		msgs, err := s.G().ConvSource.GetMessagesWithRemotes(ctx, conversationRemote.Metadata.ConversationID,
+			uid, conversationRemote.MaxMsgs, conversationRemote.Metadata.FinalizeInfo)
 		if err != nil {
-			convErr := s.checkRekeyError(ctx, err, conversationRemote, unverifiedTLFName)
-			if convErr != nil {
-				conversationLocal.Error = convErr
-				return conversationLocal
-			}
-
 			conversationLocal.Error = chat1.NewConversationErrorLocal(
-				err.Error(), conversationRemote, s.isErrPermanent(err), unverifiedTLFName, chat1.ConversationErrorType_MISC, nil)
+				err.Error(), conversationRemote, s.isErrPermanent(err), unverifiedTLFName,
+				chat1.ConversationErrorType_MISC, nil)
 			return conversationLocal
 		}
+		conversationLocal.MaxMessages = msgs
 	}
 
 	var maxValidID chat1.MessageID
@@ -984,6 +1013,7 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		uloader = s.G().GetUPAKLoader()
 	}
 
+	var err error
 	conversationLocal.Info.WriterNames, conversationLocal.Info.ReaderNames, err = utils.ReorderParticipants(
 		ctx,
 		uloader,

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -581,6 +581,7 @@ func (i *Inbox) NewConversation(ctx context.Context, vers chat1.InboxVers, conv 
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
 
 	i.Debug(ctx, "NewConversation: vers: %d convID: %s", vers, conv.GetConvID())
+	i.summarizeConv(&conv)
 	ibox, err := i.readDiskInbox(ctx)
 	if err != nil {
 		if _, ok := err.(MissError); ok {
@@ -915,7 +916,7 @@ func (i *Inbox) ServerVersion(ctx context.Context) (vers int, err Error) {
 	return vers, nil
 }
 
-func (i *Inbox) Sync(ctx context.Context, vers chat1.InboxVers, convs []chat1.Conversation) (err Error) {
+func (i *Inbox) Sync(ctx context.Context, vers chat1.InboxVers, iconvs []chat1.Conversation) (err Error) {
 	locks.Inbox.Lock()
 	defer locks.Inbox.Unlock()
 	defer i.Trace(ctx, func() error { return err }, "Sync")()
@@ -931,6 +932,7 @@ func (i *Inbox) Sync(ctx context.Context, vers chat1.InboxVers, convs []chat1.Co
 	oldVers := ibox.InboxVersion
 	ibox.InboxVersion = vers
 	convMap := make(map[string]chat1.Conversation)
+	convs := i.summarizeConvs(iconvs)
 	for _, conv := range convs {
 		convMap[conv.GetConvID().String()] = conv
 	}

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -257,7 +257,7 @@ func TestInboxEmptySuperseder(t *testing.T) {
 	var convs []chat1.Conversation
 	for i := 0; i < numConvs; i++ {
 		conv := makeConvo(gregor1.Time(i), 1, 1)
-		conv.MaxMsgSummaries = []chat1.MessageSummary{}
+		conv.MaxMsgSummaries = nil
 		convs = append(convs, conv)
 	}
 	var full, superseded []chat1.Conversation

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -105,6 +105,28 @@ func TestInboxBasic(t *testing.T) {
 	convListCompare(t, convs[:numConvs/2], res, "half")
 }
 
+func TestInboxSummarize(t *testing.T) {
+	_, inbox, _ := setupInboxTest(t, "summarize")
+
+	conv := makeConvo(gregor1.Time(1), 1, 1)
+	maxMsgID := chat1.MessageID(6)
+	conv.MaxMsgs = []chat1.MessageBoxed{chat1.MessageBoxed{
+		ClientHeader: chat1.MessageClientHeader{
+			MessageType: chat1.MessageType_TEXT,
+		},
+		ServerHeader: &chat1.MessageServerHeader{
+			MessageID: maxMsgID,
+		},
+	}}
+
+	require.NoError(t, inbox.Merge(context.TODO(), 1, []chat1.Conversation{conv}, nil, nil))
+	_, res, _, err := inbox.Read(context.TODO(), nil, nil)
+	require.NoError(t, err)
+	require.Zero(t, len(res[0].MaxMsgs))
+	require.Equal(t, 1, len(res[0].MaxMsgSummaries))
+	require.Equal(t, maxMsgID, res[0].MaxMsgSummaries[0].GetMessageID())
+}
+
 func TestInboxQueries(t *testing.T) {
 
 	_, inbox, _ := setupInboxTest(t, "queries")

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -30,6 +30,8 @@ type ConversationSource interface {
 	PullLocalOnly(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
 		query *chat1.GetThreadQuery, p *chat1.Pagination) (chat1.ThreadView, error)
 	GetMessages(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgIDs []chat1.MessageID, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
+	GetMessagesWithRemotes(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
+		msgs []chat1.MessageBoxed, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
 	Clear(convID chat1.ConversationID, uid gregor1.UID) error
 	TransformSupersedes(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageUnboxed, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
 


### PR DESCRIPTION
The problem with snippets was related to the interaction of the max messages and summaries in the inbox cache. This is another attempt which should make it work a little better. For the review, you probably want to check out 1d8b739, since that is the stuff I changed.