### PR TITLE
Don't notify on muted conversations

### DIFF
--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -818,7 +818,7 @@ function * _sendNotifications (action: Constants.AppendMessages): SagaGenerator<
     const message = (action.payload.messages.reverse().find(m => m.type === 'Text' && m.author !== me))
     // Is this message part of a muted conversation? If so don't notify.
     const convo = yield select(Shared.selectedInboxSelector, action.payload.conversationIDKey)
-    if (convo && !convo.muted) {
+    if (convo && convo.get('status') !== 'muted') {
       if (message && message.type === 'Text') {
         const snippet = Constants.makeSnippet(Constants.serverMessageToMessageBody(message))
         yield put((dispatch: Dispatch) => {


### PR DESCRIPTION
@keybase/react-hackers CC @mmaxim 

This broke when moving from a `muted` field to a `status` field, Flow didn't notice.