### PR TITLE
add a new result collector that ignores miss errors CORE-4915

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 
 	"github.com/keybase/client/go/chat/storage"
@@ -471,9 +472,18 @@ func (s *HybridConversationSource) updateMessage(ctx context.Context, message ch
 
 type pullLocalResultCollector struct {
 	*storage.SimpleResultCollector
+	num int
 }
 
-func (p *pullLocalResultCollector) error(err storage.Error) storage.Error {
+func (p *pullLocalResultCollector) Name() string {
+	return "pulllocal"
+}
+
+func (s *pullLocalResultCollector) String() string {
+	return fmt.Sprintf("[ %s: t: %d ]", s.Name(), s.num)
+}
+
+func (p *pullLocalResultCollector) Error(err storage.Error) storage.Error {
 	// Swallow this error, we know we can miss if we get anything at all
 	if _, ok := err.(storage.MissError); ok && len(p.Result()) > 0 {
 		return nil
@@ -483,6 +493,7 @@ func (p *pullLocalResultCollector) error(err storage.Error) storage.Error {
 
 func newPullLocalResultCollector(num int) *pullLocalResultCollector {
 	return &pullLocalResultCollector{
+		num: num,
 		SimpleResultCollector: storage.NewSimpleResultCollector(num),
 	}
 }

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -473,7 +473,7 @@ func (i *Inbox) queryExists(ctx context.Context, ibox inboxDiskData, query *chat
 
 	// If the query is specifying a list of conversation IDs, just check to see if we have *all*
 	// of them on the disk
-	if query != nil && len(query.ConvIDs) > 0 {
+	if query != nil && (len(query.ConvIDs) > 0 || query.ConvID != nil) {
 		i.Debug(ctx, "Read: queryExists: convIDs query, checking list: len: %d", len(query.ConvIDs))
 		return i.queryConvIDsExist(ctx, ibox, query.ConvIDs)
 	}

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -18,6 +18,7 @@ type ResultCollector interface {
 	Done() bool
 	Result() []chat1.MessageUnboxed
 	Error(err Error) Error
+	Name() string
 
 	String() string
 }
@@ -99,8 +100,12 @@ func (s *SimpleResultCollector) Result() []chat1.MessageUnboxed {
 	return s.res
 }
 
+func (s *SimpleResultCollector) Name() string {
+	return "simple"
+}
+
 func (s *SimpleResultCollector) String() string {
-	return fmt.Sprintf("[ simple: t: %d c: %d ]", s.target, len(s.res))
+	return fmt.Sprintf("[ %s: t: %d c: %d ]", s.Name(), s.target, len(s.res))
 }
 
 func (s *SimpleResultCollector) Error(err Error) Error {
@@ -155,8 +160,12 @@ func (t *TypedResultCollector) Result() []chat1.MessageUnboxed {
 	return t.res
 }
 
+func (t *TypedResultCollector) Name() string {
+	return "typed"
+}
+
 func (t *TypedResultCollector) String() string {
-	return fmt.Sprintf("[ typed: t: %d c: %d (%d types) ]", t.target, t.cur, len(t.typmap))
+	return fmt.Sprintf("[ %s: t: %d c: %d (%d types) ]", t.Name(), t.target, t.cur, len(t.typmap))
 }
 
 func (t *TypedResultCollector) Error(err Error) Error {

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -13,11 +13,11 @@ import (
 	"golang.org/x/net/context"
 )
 
-type resultCollector interface {
-	push(msg chat1.MessageUnboxed)
-	done() bool
-	result() []chat1.MessageUnboxed
-	error(err Error) Error
+type ResultCollector interface {
+	Push(msg chat1.MessageUnboxed)
+	Done() bool
+	Result() []chat1.MessageUnboxed
+	Error(err Error) Error
 
 	String() string
 }
@@ -36,7 +36,7 @@ type storageEngine interface {
 		uid gregor1.UID) (context.Context, Error)
 	WriteMessages(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
 		msgs []chat1.MessageUnboxed) Error
-	ReadMessages(ctx context.Context, res resultCollector,
+	ReadMessages(ctx context.Context, res ResultCollector,
 		convID chat1.ConversationID, uid gregor1.UID, maxID chat1.MessageID) Error
 }
 
@@ -79,31 +79,31 @@ func decode(data []byte, res interface{}) error {
 }
 
 // simpleResultCollector aggregates all results in a the basic way. It is not thread safe.
-type simpleResultCollector struct {
+type SimpleResultCollector struct {
 	res    []chat1.MessageUnboxed
 	target int
 }
 
-func (s *simpleResultCollector) push(msg chat1.MessageUnboxed) {
+func (s *SimpleResultCollector) Push(msg chat1.MessageUnboxed) {
 	s.res = append(s.res, msg)
 }
 
-func (s *simpleResultCollector) done() bool {
+func (s *SimpleResultCollector) Done() bool {
 	if s.target < 0 {
 		return false
 	}
 	return len(s.res) >= s.target
 }
 
-func (s *simpleResultCollector) result() []chat1.MessageUnboxed {
+func (s *SimpleResultCollector) Result() []chat1.MessageUnboxed {
 	return s.res
 }
 
-func (s *simpleResultCollector) String() string {
+func (s *SimpleResultCollector) String() string {
 	return fmt.Sprintf("[ simple: t: %d c: %d ]", s.target, len(s.res))
 }
 
-func (s *simpleResultCollector) error(err Error) Error {
+func (s *SimpleResultCollector) Error(err Error) Error {
 	if s.target < 0 {
 		// Swallow this error if we are not looking for a target
 		if _, ok := err.(MissError); ok {
@@ -113,21 +113,21 @@ func (s *simpleResultCollector) error(err Error) Error {
 	return err
 }
 
-func newSimpleResultCollector(num int) *simpleResultCollector {
-	return &simpleResultCollector{
+func NewSimpleResultCollector(num int) *SimpleResultCollector {
+	return &SimpleResultCollector{
 		target: num,
 	}
 }
 
 // typedResultCollector aggregates results with a type contraints. It is not thread safe.
-type typedResultCollector struct {
+type TypedResultCollector struct {
 	res         []chat1.MessageUnboxed
 	target, cur int
 	typmap      map[chat1.MessageType]bool
 }
 
-func newTypedResultCollector(num int, typs []chat1.MessageType) *typedResultCollector {
-	c := typedResultCollector{
+func NewTypedResultCollector(num int, typs []chat1.MessageType) *TypedResultCollector {
+	c := TypedResultCollector{
 		target: num,
 		typmap: make(map[chat1.MessageType]bool),
 	}
@@ -137,29 +137,29 @@ func newTypedResultCollector(num int, typs []chat1.MessageType) *typedResultColl
 	return &c
 }
 
-func (t *typedResultCollector) push(msg chat1.MessageUnboxed) {
+func (t *TypedResultCollector) Push(msg chat1.MessageUnboxed) {
 	t.res = append(t.res, msg)
 	if t.typmap[msg.GetMessageType()] {
 		t.cur++
 	}
 }
 
-func (t *typedResultCollector) done() bool {
+func (t *TypedResultCollector) Done() bool {
 	if t.target < 0 {
 		return false
 	}
 	return t.cur >= t.target
 }
 
-func (t *typedResultCollector) result() []chat1.MessageUnboxed {
+func (t *TypedResultCollector) Result() []chat1.MessageUnboxed {
 	return t.res
 }
 
-func (t *typedResultCollector) String() string {
+func (t *TypedResultCollector) String() string {
 	return fmt.Sprintf("[ typed: t: %d c: %d (%d types) ]", t.target, t.cur, len(t.typmap))
 }
 
-func (t *typedResultCollector) error(err Error) Error {
+func (t *TypedResultCollector) Error(err Error) Error {
 	if t.target < 0 {
 		// Swallow this error if we are not looking for a target
 		if _, ok := err.(MissError); ok {
@@ -260,7 +260,7 @@ func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.Conver
 			s.Debug(ctx, "updateSupersededBy: supersedes: id: %d supersedes: %d", msgid, superID)
 			// Read super msg
 			var superMsgs []chat1.MessageUnboxed
-			rc := newSimpleResultCollector(1)
+			rc := NewSimpleResultCollector(1)
 			err := s.engine.ReadMessages(ctx, rc, convID, uid, superID)
 			if err != nil {
 				// If we don't have the message, just keep going
@@ -269,7 +269,7 @@ func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.Conver
 				}
 				return err
 			}
-			superMsgs = rc.result()
+			superMsgs = rc.Result()
 			if len(superMsgs) == 0 {
 				continue
 			}
@@ -299,8 +299,9 @@ func (s *Storage) updateAllSupersededBy(ctx context.Context, convID chat1.Conver
 	return nil
 }
 
-func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, convID chat1.ConversationID,
-	uid gregor1.UID, msgID chat1.MessageID, query *chat1.GetThreadQuery, pagination *chat1.Pagination) (chat1.ThreadView, Error) {
+func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, rc ResultCollector,
+	convID chat1.ConversationID, uid gregor1.UID, msgID chat1.MessageID, query *chat1.GetThreadQuery,
+	pagination *chat1.Pagination) (chat1.ThreadView, Error) {
 	// Fetch secret key
 	key, ierr := getSecretBoxKey(ctx, s.G(), DefaultSecretUI)
 	if ierr != nil {
@@ -344,13 +345,14 @@ func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, convID chat1.Convers
 	}
 	s.Debug(ctx, "Fetch: maxID: %d num: %d", maxID, num)
 
-	// Figure out how to determine we are done seeking
-	var rc resultCollector
-	if query != nil && len(query.MessageTypes) > 0 {
-		s.Debug(ctx, "Fetch: types: %v", query.MessageTypes)
-		rc = newTypedResultCollector(num, query.MessageTypes)
-	} else {
-		rc = newSimpleResultCollector(num)
+	// Figure out how to determine we are done seeking (unless client tells us how to)
+	if rc == nil {
+		if query != nil && len(query.MessageTypes) > 0 {
+			s.Debug(ctx, "Fetch: types: %v", query.MessageTypes)
+			rc = NewTypedResultCollector(num, query.MessageTypes)
+		} else {
+			rc = NewSimpleResultCollector(num)
+		}
 	}
 	s.Debug(ctx, "Fetch: using result collector: %s", rc)
 
@@ -359,7 +361,7 @@ func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, convID chat1.Convers
 	if err = s.engine.ReadMessages(ctx, rc, convID, uid, maxID); err != nil {
 		return chat1.ThreadView{}, err
 	}
-	res = rc.result()
+	res = rc.Result()
 
 	// Form paged result
 	var tres chat1.ThreadView
@@ -377,8 +379,9 @@ func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, convID chat1.Convers
 	return tres, nil
 }
 
-func (s *Storage) FetchUpToLocalMaxMsgID(ctx context.Context, convID chat1.ConversationID,
-	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination) (chat1.ThreadView, Error) {
+func (s *Storage) FetchUpToLocalMaxMsgID(ctx context.Context,
+	convID chat1.ConversationID, uid gregor1.UID, rc ResultCollector, query *chat1.GetThreadQuery,
+	pagination *chat1.Pagination) (chat1.ThreadView, Error) {
 	// All public functions get locks to make access to the database single threaded.
 	// They should never be called from private functons.
 	locks.Storage.Lock()
@@ -390,17 +393,18 @@ func (s *Storage) FetchUpToLocalMaxMsgID(ctx context.Context, convID chat1.Conve
 	}
 	s.Debug(ctx, "FetchUpToLocalMaxMsgID: using max msgID: %d", maxMsgID)
 
-	return s.fetchUpToMsgIDLocked(ctx, convID, uid, maxMsgID, query, pagination)
+	return s.fetchUpToMsgIDLocked(ctx, rc, convID, uid, maxMsgID, query, pagination)
 }
 
 func (s *Storage) Fetch(ctx context.Context, conv chat1.Conversation,
-	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination) (chat1.ThreadView, Error) {
+	uid gregor1.UID, rc ResultCollector, query *chat1.GetThreadQuery, pagination *chat1.Pagination) (chat1.ThreadView, Error) {
 	// All public functions get locks to make access to the database single threaded.
 	// They should never be called from private functons.
 	locks.Storage.Lock()
 	defer locks.Storage.Unlock()
 
-	return s.fetchUpToMsgIDLocked(ctx, conv.Metadata.ConversationID, uid, conv.ReaderInfo.MaxMsgid, query, pagination)
+	return s.fetchUpToMsgIDLocked(ctx, rc, conv.Metadata.ConversationID, uid, conv.ReaderInfo.MaxMsgid,
+		query, pagination)
 }
 
 func (s *Storage) FetchMessages(ctx context.Context, convID chat1.ConversationID,
@@ -422,7 +426,7 @@ func (s *Storage) FetchMessages(ctx context.Context, convID chat1.ConversationID
 	// Run seek looking for each message
 	var res []*chat1.MessageUnboxed
 	for _, msgID := range msgIDs {
-		rc := newSimpleResultCollector(1)
+		rc := NewSimpleResultCollector(1)
 		var sres []chat1.MessageUnboxed
 		if err = s.engine.ReadMessages(ctx, rc, convID, uid, msgID); err != nil {
 			if _, ok := err.(MissError); ok {
@@ -432,7 +436,7 @@ func (s *Storage) FetchMessages(ctx context.Context, convID chat1.ConversationID
 				return nil, s.MaybeNuke(false, err, convID, uid)
 			}
 		}
-		sres = rc.result()
+		sres = rc.Result()
 		res = append(res, &sres[0])
 	}
 

--- a/go/chat/storage/storage_blockengine.go
+++ b/go/chat/storage/storage_blockengine.go
@@ -367,13 +367,13 @@ func (be *blockEngine) WriteMessages(ctx context.Context, convID chat1.Conversat
 	return nil
 }
 
-func (be *blockEngine) ReadMessages(ctx context.Context, res resultCollector,
+func (be *blockEngine) ReadMessages(ctx context.Context, res ResultCollector,
 	convID chat1.ConversationID, uid gregor1.UID, maxID chat1.MessageID) (err Error) {
 
 	// Run all errors through resultCollector
 	defer func() {
 		if err != nil {
-			err = res.error(err)
+			err = res.Error(err)
 		}
 	}()
 
@@ -394,7 +394,7 @@ func (be *blockEngine) ReadMessages(ctx context.Context, res resultCollector,
 	maxPos := be.getBlockPosition(maxID)
 
 	be.Debug(ctx, "readMessages: BID: %d maxPos: %d maxID: %d rc: %s", b.BlockID, maxPos, maxID, res)
-	for index := maxPos; !res.done() && index >= 0; index-- {
+	for index := maxPos; !res.Done() && index >= 0; index-- {
 		if b.BlockID == 0 && index == 0 {
 			// Short circuit out of here if we are on the null message
 			break
@@ -416,11 +416,11 @@ func (be *blockEngine) ReadMessages(ctx context.Context, res resultCollector,
 		be.Debug(ctx, "readMessages: adding msg_id: %d (blockid: %d pos: %d)",
 			msg.GetMessageID(), b.BlockID, index)
 		lastAdded = msg.GetMessageID()
-		res.push(msg)
+		res.Push(msg)
 	}
 
 	// Check if we read anything, otherwise move to another block and try again
-	if !res.done() && b.BlockID > 0 {
+	if !res.Done() && b.BlockID > 0 {
 		return be.ReadMessages(ctx, res, convID, uid, lastAdded-1)
 	}
 	return nil

--- a/go/chat/storage/storage_msgengine.go
+++ b/go/chat/storage/storage_msgengine.go
@@ -110,18 +110,18 @@ func (ms *msgEngine) WriteMessages(ctx context.Context, convID chat1.Conversatio
 	return nil
 }
 
-func (ms *msgEngine) ReadMessages(ctx context.Context, rc resultCollector,
+func (ms *msgEngine) ReadMessages(ctx context.Context, rc ResultCollector,
 	convID chat1.ConversationID, uid gregor1.UID, maxID chat1.MessageID) (err Error) {
 
 	// Run all errors through resultCollector
 	defer func() {
 		if err != nil {
-			err = rc.error(err)
+			err = rc.Error(err)
 		}
 	}()
 
 	// Read all msgs in reverse order
-	for msgID := maxID; !rc.done() && msgID > 0; msgID-- {
+	for msgID := maxID; !rc.Done() && msgID > 0; msgID-- {
 		raw, found, err := ms.G().LocalChatDb.GetRaw(ms.makeMsgKey(convID, uid, msgID))
 		if err != nil {
 			return NewInternalError(ctx, ms.DebugLabeler, "readMessages: failed to read msg: %s", err.Error())
@@ -158,7 +158,7 @@ func (ms *msgEngine) ReadMessages(ctx context.Context, rc resultCollector,
 			return NewInternalError(ctx, ms.DebugLabeler, "readMessages: failed to decode: %s", err.Error())
 		}
 
-		rc.push(msg)
+		rc.Push(msg)
 	}
 
 	return nil

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -139,7 +139,6 @@ func (s *Syncer) isServerInboxClear(ctx context.Context, inbox *storage.Inbox, s
 func (s *Syncer) IsConnected(ctx context.Context) bool {
 	s.Lock()
 	defer s.Unlock()
-	defer s.Trace(ctx, func() error { return nil }, "IsConnected")()
 	return s.isConnected
 }
 

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -145,7 +145,7 @@ func TestSyncerConnected(t *testing.T) {
 	}
 	require.Equal(t, chat1.ConversationStatus_UNFILED, convs[1].Metadata.Status)
 	require.Equal(t, chat1.InboxVers(100), vers)
-	thread, cerr := store.Fetch(context.TODO(), mconv, uid, nil, nil)
+	thread, cerr := store.Fetch(context.TODO(), mconv, uid, nil, nil, nil)
 	require.NoError(t, cerr)
 	require.Equal(t, 2, len(thread.Messages))
 
@@ -173,7 +173,7 @@ func TestSyncerConnected(t *testing.T) {
 	_, _, err = ibox.ReadAll(context.TODO())
 	require.Error(t, err)
 	require.IsType(t, storage.MissError{}, err)
-	_, cerr = store.Fetch(context.TODO(), mconv, uid, nil, nil)
+	_, cerr = store.Fetch(context.TODO(), mconv, uid, nil, nil, nil)
 	require.Error(t, cerr)
 	require.IsType(t, storage.MissError{}, cerr)
 	_, _, serr = tc.G.InboxSource.Read(context.TODO(), uid, nil, true, nil, nil)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -334,7 +334,7 @@ func GetUnverifiedConv(ctx context.Context, g *libkb.GlobalContext, uid gregor1.
 	convID chat1.ConversationID, useLocalData bool) (chat1.Conversation, *chat1.RateLimit, error) {
 
 	inbox, ratelim, err := g.InboxSource.ReadUnverified(ctx, uid, useLocalData, &chat1.GetInboxQuery{
-		ConvID: &convID,
+		ConvIDs: []chat1.ConversationID{convID},
 	}, nil)
 	if err != nil {
 		return chat1.Conversation{}, ratelim, fmt.Errorf("GetUnverifiedConv: %s", err.Error())


### PR DESCRIPTION
This patch allows us to read as much of the local cache as we can up to the limit specified in the pagination object. If we fall short, then we just return what we have. 

This also fixes a bug when selecting a conversation from the thread view, where we would always miss the inbox cache. Now we hit it.