### PR TITLE
kbnm: Fix darwin installer + hardcode v1.3

### DIFF
--- a/go/install/install_darwin.go
+++ b/go/install/install_darwin.go
@@ -584,16 +584,15 @@ const kbnmHostName = "io.keybase.kbnm"
 // kbnmDescription is the description of the purpose for the manifest whitelist.
 const kbnmDescription = "Keybase Native Messaging API"
 
-// kbnmExtensionID is the
-const kbnmExtensionID = "chrome-extension://bddkhaigcjacfohdeklflaigfnebicfm/"
-
 // InstallKBNM installs the Keybase NativeMessaging whitelist
 func InstallKBNM(context Context, binPath string, log Log) error {
 	// Find path of the keybase binary
-	hostPath, err := chooseBinPath(binPath)
+	keybasePath, err := chooseBinPath(binPath)
 	if err != nil {
 		return err
 	}
+	// kbnm binary is next to the keybase binary, same dir
+	hostPath := filepath.Join(filepath.Dir(keybasePath), "kbnm")
 
 	// Host manifest, see: https://developer.chrome.com/extensions/nativeMessaging
 	hostManifest := struct {
@@ -608,7 +607,12 @@ func InstallKBNM(context Context, binPath string, log Log) error {
 		Path:        hostPath,
 		Type:        "stdio",
 		AllowedOrigins: []string{
-			kbnmExtensionID,
+			// Production public version in the store
+			"chrome-extension://ognfafcpbkogffpmmdglhbjboeojlefj/",
+			// Hard-coded key from the repo version
+			"chrome-extension://kockbbfoibcdfibclaojljblnhpnjndg/",
+			// Keybase-internal version
+			"chrome-extension://gnjkbjlgkpiaehpibpdefaieklbfljjm/",
 		},
 	}
 
@@ -633,7 +637,10 @@ func InstallKBNM(context Context, binPath string, log Log) error {
 	}
 	defer fp.Close()
 
+	// Truncate in case there is other stuff in the file already.
+	fp.Truncate(0)
 	encoder := json.NewEncoder(fp)
+	encoder.SetIndent("", "    ")
 	return encoder.Encode(&hostManifest)
 }
 

--- a/go/install/install_darwin.go
+++ b/go/install/install_darwin.go
@@ -638,7 +638,9 @@ func InstallKBNM(context Context, binPath string, log Log) error {
 	defer fp.Close()
 
 	// Truncate in case there is other stuff in the file already.
-	fp.Truncate(0)
+	// Unlikely error is ignored, let's try writing to it anyways.
+	_ = fp.Truncate(0)
+
 	encoder := json.NewEncoder(fp)
 	encoder.SetIndent("", "    ")
 	return encoder.Encode(&hostManifest)

--- a/go/kbnm/main.go
+++ b/go/kbnm/main.go
@@ -10,7 +10,10 @@ import (
 	"github.com/qrtz/nativemessaging"
 )
 
-// Version is the build version of kbnm, overwritten during build.
+// internalVersion is the logical version of this code (rather than build).
+const internalVersion = "1.3"
+
+// Version is the build version of kbnm, overwritten during build with metadata.
 var Version = "dev"
 
 // Response from the kbnm service
@@ -73,7 +76,7 @@ func main() {
 	flag.Parse()
 
 	if *versionFlag {
-		fmt.Println(Version)
+		fmt.Printf("%s-%s\n", internalVersion, Version)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
I noticed a couple of bugs with the latest prerelease:

1. There was leftover stuff in the tail of the JSON because I forgot to truncate.
2. Need to whitelist a couple more extension IDs for dev/internal
3. I misunderstood how our release process worked, I thought the major version would be set somewhere during build but that's not how it works. So I'm hardcoding the "internalVersion" to 1.3 and will increment based on code changes, which fill prefix the Version that gets written with metadata.