### PR TITLE
keep track of what conversations got offline results and send stales on reconnect CORE-4929

### DIFF
--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -185,7 +185,10 @@ func (s *Syncer) sendStoredStaleNotifications(ctx context.Context, uid gregor1.U
 	}
 	s.Debug(ctx, "sendStoredStaleNotifications: sending %d stale notifications", len(convIDs))
 	s.SendChatStaleNotifications(ctx, uid, convIDs, false)
-	s.G().LocalChatDb.Delete(key)
+
+	if err := s.G().LocalChatDb.Delete(key); err != nil {
+		s.Debug(ctx, "sendStoredStaleNotifications: error deleting record: %s", err.Error())
+	}
 }
 
 func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -95,5 +95,6 @@ type Syncer interface {
 	RegisterOfflinable(offlinable Offlinable)
 	SendChatStaleNotifications(ctx context.Context, uid gregor1.UID, convIDs []chat1.ConversationID,
 		immediate bool)
+	AddStaleConversation(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID)
 	Shutdown()
 }

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -189,6 +189,7 @@ const (
 	DBResolveUsernameToUID    = 0xfb
 	DBChatBodyHashIndex       = 0xfc
 	DBPvl                     = 0xfd
+	DBChatSyncer              = 0xfe
 )
 
 const (


### PR DESCRIPTION
If we serve a result from `GetThreadNonblock` in offline mode, then we want to make sure to coax the UI into reloading it when we reconnect. Do that by logging these in LevelDB in `Syncer`, and then running through them all in `Connected`.