### PR TITLE
generate shared dh on signup

### DIFF
--- a/go/engine/device_keygen.go
+++ b/go/engine/device_keygen.go
@@ -111,14 +111,12 @@ func (e *DeviceKeygen) SigningKey() libkb.NaclKeyPair {
 	return e.naclSignGen.GetKeyPair()
 }
 
-func (e DeviceKeygen) EncryptionKey() *libkb.NaclDHKeyPair {
-	k := e.naclEncGen.GetKeyPair().(libkb.NaclDHKeyPair)
-	return &k
+func (e *DeviceKeygen) EncryptionKey() libkb.NaclDHKeyPair {
+	return e.naclEncGen.GetKeyPair().(libkb.NaclDHKeyPair)
 }
 
-func (e *DeviceKeygen) SharedDHKey() *libkb.NaclDHKeyPair {
-	k := e.naclSharedDHGen.GetKeyPair().(libkb.NaclDHKeyPair)
-	return &k
+func (e *DeviceKeygen) SharedDHKey() libkb.NaclDHKeyPair {
+	return e.naclSharedDHGen.GetKeyPair().(libkb.NaclDHKeyPair)
 }
 
 // Push pushes the generated keys to the api server and stores the

--- a/go/engine/device_keygen.go
+++ b/go/engine/device_keygen.go
@@ -135,7 +135,7 @@ func (e *DeviceKeygen) Push(ctx *Context, pargs *DeviceKeygenPushArgs) error {
 			e.SharedDHKey(),   // inner key to be encrypted (shared dh key)
 			e.EncryptionKey(), // receiver key (device enc key)
 			e.EncryptionKey(), // sender key   (device enc key)
-			1)
+			libkb.SharedDHGeneration(1))
 		if err != nil {
 			return err
 		}
@@ -304,8 +304,8 @@ func (e *DeviceKeygen) appendSharedDHKey(ds []libkb.Delegator, ctx *Context, sig
 
 	var d libkb.Delegator
 	d, e.pushErr = e.naclSharedDHGen.Push(ctx.LoginContext, true)
-	gen := 1
-	d.SharedDHGeneration = &gen
+	generation := libkb.SharedDHGeneration(1)
+	d.SharedDHGeneration = &generation
 	if e.pushErr == nil {
 		d.SetGlobalContext(e.G())
 		return append(ds, d)

--- a/go/engine/device_wrap.go
+++ b/go/engine/device_wrap.go
@@ -4,6 +4,8 @@
 package engine
 
 import (
+	"fmt"
+
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
@@ -11,11 +13,13 @@ import (
 // DeviceWrap is an engine that wraps DeviceRegister and
 // DeviceKeygen.
 type DeviceWrap struct {
+	libkb.Contextified
+
 	args *DeviceWrapArgs
 
 	signingKey    libkb.GenericKey
 	encryptionKey libkb.GenericKey
-	libkb.Contextified
+	sharedDHKey   libkb.GenericKey // can be nil
 }
 
 type DeviceWrapArgs struct {
@@ -79,6 +83,7 @@ func (e *DeviceWrap) Run(ctx *Context) error {
 		DeviceName: e.args.DeviceName,
 		DeviceType: e.args.DeviceType,
 		Lks:        e.args.Lks,
+		IsEldest:   e.args.IsEldest,
 	}
 	kgEng := NewDeviceKeygen(kgArgs, e.G())
 	if err := RunEngine(kgEng, ctx); err != nil {
@@ -86,7 +91,6 @@ func (e *DeviceWrap) Run(ctx *Context) error {
 	}
 
 	pargs := &DeviceKeygenPushArgs{
-		IsEldest:  e.args.IsEldest,
 		Signer:    e.args.Signer,
 		EldestKID: e.args.EldestKID,
 	}
@@ -96,6 +100,7 @@ func (e *DeviceWrap) Run(ctx *Context) error {
 
 	e.signingKey = kgEng.SigningKey()
 	e.encryptionKey = kgEng.EncryptionKey()
+	// TODO get the shared dh key and save it if it was generated
 
 	if ctx.LoginContext != nil {
 		// cache the secret keys
@@ -112,4 +117,11 @@ func (e *DeviceWrap) SigningKey() libkb.GenericKey {
 
 func (e *DeviceWrap) EncryptionKey() libkb.GenericKey {
 	return e.encryptionKey
+}
+
+func (e *DeviceWrap) SharedDHKey() (libkb.GenericKey, error) {
+	if e.sharedDHKey == nil {
+		return nil, fmt.Errorf("DeviceWrap: no shared DH key")
+	}
+	return e.sharedDHKey, nil
 }

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -264,5 +264,5 @@ func (e *PaperKeyGen) push(ctx *Context) error {
 		Contextified:   libkb.NewContextified(e.G()),
 	}
 
-	return libkb.DelegatorAggregator(ctx.LoginContext, []libkb.Delegator{sigDel, sigEnc})
+	return libkb.DelegatorAggregator(ctx.LoginContext, []libkb.Delegator{sigDel, sigEnc}, nil)
 }

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -18,9 +18,19 @@ func AssertDeviceID(g *libkb.GlobalContext) (err error) {
 }
 
 func TestSignupEngine(t *testing.T) {
+	subTestSignupEngine(t, false)
+}
+
+func TestSignupEngineSDH(t *testing.T) {
+	subTestSignupEngine(t, true)
+}
+
+func subTestSignupEngine(t *testing.T, enableSharedDH bool) {
 	tc := SetupEngineTest(t, "signup")
 	defer tc.Cleanup()
 	var err error
+
+	tc.Tp.EnableSharedDH = enableSharedDH
 
 	fu := CreateAndSignupFakeUser(tc, "se")
 

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -99,6 +99,9 @@ func (p CommandLine) GetDebug() (bool, bool) {
 func (p CommandLine) GetVDebugSetting() string {
 	return p.GetGString("vdebug")
 }
+func (p CommandLine) GetEnableSharedDH() (bool, bool) {
+	return p.GetBool("enable-shared-dh", true)
+}
 func (p CommandLine) GetPGPFingerprint() *libkb.PGPFingerprint {
 	return libkb.PGPFingerprintFromHexNoError(p.GetGString("fingerprint"))
 }
@@ -387,6 +390,10 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 		cli.BoolFlag{
 			Name:  "debug, d",
 			Usage: "Enable debugging mode.",
+		},
+		cli.BoolFlag{
+			Name:  "enable-shared-dh",
+			Usage: "Use a shared dh key. Experimental, will break sigchain.",
 		},
 		cli.StringFlag{
 			Name:  "features",

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -113,6 +113,10 @@ func (f JSONConfigFile) GetDurationAtPath(p string) (time.Duration, bool) {
 	return d, true
 }
 
+func (f JSONConfigFile) GetEnableSharedDH() (bool, bool) {
+	return false, false
+}
+
 func (f JSONConfigFile) GetTopLevelString(s string) (ret string) {
 	var e error
 	f.jw.AtKey(s).GetStringVoid(&ret, &e)

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -540,4 +540,4 @@ type PvlUnparsed struct {
 	Pvl  PvlString
 }
 
-type SharedDHGeneration int
+type SharedDHKeyGeneration int

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -253,10 +253,11 @@ const (
 	LinkTypeUpdateSettings             = "update_settings"
 	LinkTypeWebServiceBinding          = "web_service_binding"
 
-	DelegationTypeEldest    DelegationType = "eldest"
-	DelegationTypePGPUpdate                = "pgp_update"
-	DelegationTypeSibkey                   = "sibkey"
-	DelegationTypeSubkey                   = "subkey"
+	DelegationTypeEldest      DelegationType = "eldest"
+	DelegationTypePGPUpdate                  = "pgp_update"
+	DelegationTypeSibkey                     = "sibkey"
+	DelegationTypeSubkey                     = "subkey"
+	DelegationTypeSharedDHKey                = "shared_dh_key"
 )
 
 const (

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -539,3 +539,5 @@ type PvlUnparsed struct {
 	Hash PvlKitHash
 	Pvl  PvlString
 }
+
+type SharedDHGeneration int

--- a/go/libkb/delegatekey.go
+++ b/go/libkb/delegatekey.go
@@ -19,19 +19,19 @@ type Delegator struct {
 	Contextified
 
 	// Set these fields
-	NewKey             GenericKey
-	ExistingKey        GenericKey
-	EldestKID          keybase1.KID
-	Me                 *User
-	Expire             int
-	Device             *Device
-	RevSig             string
-	ServerHalf         []byte
-	EncodedPrivateKey  string
-	Ctime              int64
-	DelegationType     DelegationType
-	Aggregated         bool // During aggregation we skip some steps (posting, updating some state)
-	SharedDHGeneration *SharedDHGeneration
+	NewKey                GenericKey
+	ExistingKey           GenericKey
+	EldestKID             keybase1.KID
+	Me                    *User
+	Expire                int
+	Device                *Device
+	RevSig                string
+	ServerHalf            []byte
+	EncodedPrivateKey     string
+	Ctime                 int64
+	DelegationType        DelegationType
+	Aggregated            bool // During aggregation we skip some steps (posting, updating some state)
+	SharedDHKeyGeneration SharedDHKeyGeneration
 
 	// Optional precalculated values used by KeyProof
 	LastSeqno   Seqno     // kex2 HandleDidCounterSign needs to sign subkey without a user but we know what the last seqno was

--- a/go/libkb/delegatekey.go
+++ b/go/libkb/delegatekey.go
@@ -19,18 +19,19 @@ type Delegator struct {
 	Contextified
 
 	// Set these fields
-	NewKey            GenericKey
-	ExistingKey       GenericKey
-	EldestKID         keybase1.KID
-	Me                *User
-	Expire            int
-	Device            *Device
-	RevSig            string
-	ServerHalf        []byte
-	EncodedPrivateKey string
-	Ctime             int64
-	DelegationType    DelegationType
-	Aggregated        bool // During aggregation we skip some steps (posting, updating some state)
+	NewKey             GenericKey
+	ExistingKey        GenericKey
+	EldestKID          keybase1.KID
+	Me                 *User
+	Expire             int
+	Device             *Device
+	RevSig             string
+	ServerHalf         []byte
+	EncodedPrivateKey  string
+	Ctime              int64
+	DelegationType     DelegationType
+	Aggregated         bool // During aggregation we skip some steps (posting, updating some state)
+	SharedDHGeneration *int
 
 	// Optional precalculated values used by KeyProof
 	LastSeqno   Seqno     // kex2 HandleDidCounterSign needs to sign subkey without a user but we know what the last seqno was

--- a/go/libkb/delegatekey.go
+++ b/go/libkb/delegatekey.go
@@ -31,7 +31,7 @@ type Delegator struct {
 	Ctime              int64
 	DelegationType     DelegationType
 	Aggregated         bool // During aggregation we skip some steps (posting, updating some state)
-	SharedDHGeneration *int
+	SharedDHGeneration *SharedDHGeneration
 
 	// Optional precalculated values used by KeyProof
 	LastSeqno   Seqno     // kex2 HandleDidCounterSign needs to sign subkey without a user but we know what the last seqno was

--- a/go/libkb/delegatekeyaggregator.go
+++ b/go/libkb/delegatekeyaggregator.go
@@ -64,13 +64,13 @@ type SharedDHSecretBox struct {
 	Generation  SharedDHGeneration `json:"generation"`
 }
 
-func NewSharedDHSecretBox(innerKey *NaclDHKeyPair, receiverKey *NaclDHKeyPair, senderKey *NaclDHKeyPair, generation SharedDHGeneration) (SharedDHSecretBox, error) {
+func NewSharedDHSecretBox(innerKey NaclDHKeyPair, receiverKey NaclDHKeyPair, senderKey NaclDHKeyPair, generation SharedDHGeneration) (SharedDHSecretBox, error) {
 	_, secret, err := innerKey.ExportPublicAndPrivate()
 	if err != nil {
 		return SharedDHSecretBox{}, err
 	}
 
-	encInfo, err := receiverKey.Encrypt(secret, senderKey)
+	encInfo, err := receiverKey.Encrypt(secret, &senderKey)
 	if err != nil {
 		return SharedDHSecretBox{}, err
 	}

--- a/go/libkb/delegatekeyaggregator.go
+++ b/go/libkb/delegatekeyaggregator.go
@@ -60,11 +60,11 @@ type SharedDHSecretBox struct {
 	// Base64 armored KeybasePacket of NaclEncryptionInfo
 	Box string `json:"box"`
 
-	ReceiverKID keybase1.KID `json:"receiver_kid"`
-	Generation  int          `json:"generation"`
+	ReceiverKID keybase1.KID       `json:"receiver_kid"`
+	Generation  SharedDHGeneration `json:"generation"`
 }
 
-func NewSharedDHSecretBox(innerKey *NaclDHKeyPair, receiverKey *NaclDHKeyPair, senderKey *NaclDHKeyPair, generation int) (SharedDHSecretBox, error) {
+func NewSharedDHSecretBox(innerKey *NaclDHKeyPair, receiverKey *NaclDHKeyPair, senderKey *NaclDHKeyPair, generation SharedDHGeneration) (SharedDHSecretBox, error) {
 	_, secret, err := innerKey.ExportPublicAndPrivate()
 	if err != nil {
 		return SharedDHSecretBox{}, err

--- a/go/libkb/delegatekeyaggregator.go
+++ b/go/libkb/delegatekeyaggregator.go
@@ -60,11 +60,11 @@ type SharedDHSecretBox struct {
 	// Base64 armored KeybasePacket of NaclEncryptionInfo
 	Box string `json:"box"`
 
-	ReceiverKID keybase1.KID       `json:"receiver_kid"`
-	Generation  SharedDHGeneration `json:"generation"`
+	ReceiverKID keybase1.KID          `json:"receiver_kid"`
+	Generation  SharedDHKeyGeneration `json:"generation"`
 }
 
-func NewSharedDHSecretBox(innerKey NaclDHKeyPair, receiverKey NaclDHKeyPair, senderKey NaclDHKeyPair, generation SharedDHGeneration) (SharedDHSecretBox, error) {
+func NewSharedDHSecretBox(innerKey NaclDHKeyPair, receiverKey NaclDHKeyPair, senderKey NaclDHKeyPair, generation SharedDHKeyGeneration) (SharedDHSecretBox, error) {
 	_, secret, err := innerKey.ExportPublicAndPrivate()
 	if err != nil {
 		return SharedDHSecretBox{}, err
@@ -74,11 +74,7 @@ func NewSharedDHSecretBox(innerKey NaclDHKeyPair, receiverKey NaclDHKeyPair, sen
 	if err != nil {
 		return SharedDHSecretBox{}, err
 	}
-	packet, err := encInfo.ToPacket()
-	if err != nil {
-		return SharedDHSecretBox{}, err
-	}
-	boxStr, err := packet.ArmoredEncode()
+	boxStr, err := PacketArmoredEncode(encInfo)
 	if err != nil {
 		return SharedDHSecretBox{}, err
 	}

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -169,7 +169,7 @@ type Env struct {
 	config        ConfigReader
 	homeFinder    HomeFinder
 	writer        ConfigWriter
-	Test          TestParameters
+	Test          *TestParameters
 	updaterConfig UpdaterConfigReader
 }
 
@@ -251,7 +251,7 @@ func newEnv(cmd CommandLine, config ConfigReader, osname string) *Env {
 	if config == nil {
 		config = NullConfiguration{}
 	}
-	e := Env{cmd: cmd, config: config}
+	e := Env{cmd: cmd, config: config, Test: &TestParameters{}}
 
 	e.homeFinder = NewHomeFinder("keybase",
 		func() string { return e.getHomeFromCmdOrConfig() },

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -148,8 +148,9 @@ type TestParameters struct {
 	Devel bool
 	// If we're in dev mode, the name for this test, with a random
 	// suffix.
-	DevelName  string
-	RuntimeDir string
+	DevelName      string
+	RuntimeDir     string
+	EnableSharedDH bool
 
 	// set to true to use production run mode in tests
 	UseProductionRunMode bool
@@ -653,6 +654,7 @@ func (e *Env) GetEmail() string {
 
 func (e *Env) GetEnableSharedDH() bool {
 	return e.GetBool(false,
+		func() (bool, bool) { return e.Test.EnableSharedDH, e.Test.EnableSharedDH },
 		func() (bool, bool) { return e.getEnvBool("KEYBASE_ENABLE_SHARED_DH") },
 		func() (bool, bool) { return e.config.GetEnableSharedDH() },
 		func() (bool, bool) { return e.cmd.GetEnableSharedDH() },

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -28,6 +28,7 @@ func (n NullConfiguration) GetChatDbFilename() string                           
 func (n NullConfiguration) GetPvlKitFilename() string                                      { return "" }
 func (n NullConfiguration) GetUsername() NormalizedUsername                                { return NormalizedUsername("") }
 func (n NullConfiguration) GetEmail() string                                               { return "" }
+func (n NullConfiguration) GetEnableSharedDH() (bool, bool)                                { return false, false }
 func (n NullConfiguration) GetProxy() string                                               { return "" }
 func (n NullConfiguration) GetGpgHome() string                                             { return "" }
 func (n NullConfiguration) GetBundledCA(h string) string                                   { return "" }
@@ -647,6 +648,14 @@ func (e *Env) GetPidFile() (ret string, err error) {
 func (e *Env) GetEmail() string {
 	return e.GetString(
 		func() string { return os.Getenv("KEYBASE_EMAIL") },
+	)
+}
+
+func (e *Env) GetEnableSharedDH() bool {
+	return e.GetBool(false,
+		func() (bool, bool) { return e.getEnvBool("KEYBASE_ENABLE_SHARED_DH") },
+		func() (bool, bool) { return e.config.GetEnableSharedDH() },
+		func() (bool, bool) { return e.cmd.GetEnableSharedDH() },
 	)
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -38,6 +38,7 @@ type configGetter interface {
 	GetConfigFilename() string
 	GetDbFilename() string
 	GetDebug() (bool, bool)
+	GetEnableSharedDH() (bool, bool)
 	GetGpg() string
 	GetGpgHome() string
 	GetGpgOptions() []string

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -32,14 +32,14 @@ func merkleRootInfo(g *GlobalContext) (ret *jsonw.Wrapper) {
 }
 
 type KeySection struct {
-	Key                GenericKey
-	EldestKID          keybase1.KID
-	ParentKID          keybase1.KID
-	HasRevSig          bool
-	RevSig             string
-	SigningUser        UserBasic
-	IncludePGPHash     bool
-	SharedDHGeneration *SharedDHGeneration
+	Key                   GenericKey
+	EldestKID             keybase1.KID
+	ParentKID             keybase1.KID
+	HasRevSig             bool
+	RevSig                string
+	SigningUser           UserBasic
+	IncludePGPHash        bool
+	SharedDHKeyGeneration SharedDHKeyGeneration
 }
 
 func (arg KeySection) ToJSON() (*jsonw.Wrapper, error) {
@@ -71,8 +71,8 @@ func (arg KeySection) ToJSON() (*jsonw.Wrapper, error) {
 		ret.SetKey("username", jsonw.NewString(arg.SigningUser.GetName()))
 	}
 
-	if arg.SharedDHGeneration != nil {
-		ret.SetKey("generation", jsonw.NewInt(int(*arg.SharedDHGeneration)))
+	if arg.SharedDHKeyGeneration != 0 {
+		ret.SetKey("generation", jsonw.NewInt(int(arg.SharedDHKeyGeneration)))
 	}
 
 	if pgp, ok := arg.Key.(*PGPKeyBundle); ok {
@@ -368,7 +368,7 @@ func KeyProof(arg Delegator) (ret *jsonw.Wrapper, err error) {
 			keySection.RevSig = arg.RevSig
 			keySection.IncludePGPHash = true
 		case DelegationTypeSharedDHKey:
-			keySection.SharedDHGeneration = arg.SharedDHGeneration
+			keySection.SharedDHKeyGeneration = arg.SharedDHKeyGeneration
 		default:
 			keySection.ParentKID = arg.ExistingKey.GetKID()
 		}

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -32,13 +32,14 @@ func merkleRootInfo(g *GlobalContext) (ret *jsonw.Wrapper) {
 }
 
 type KeySection struct {
-	Key            GenericKey
-	EldestKID      keybase1.KID
-	ParentKID      keybase1.KID
-	HasRevSig      bool
-	RevSig         string
-	SigningUser    UserBasic
-	IncludePGPHash bool
+	Key                GenericKey
+	EldestKID          keybase1.KID
+	ParentKID          keybase1.KID
+	HasRevSig          bool
+	RevSig             string
+	SigningUser        UserBasic
+	IncludePGPHash     bool
+	SharedDHGeneration *int
 }
 
 func (arg KeySection) ToJSON() (*jsonw.Wrapper, error) {
@@ -68,6 +69,10 @@ func (arg KeySection) ToJSON() (*jsonw.Wrapper, error) {
 		ret.SetKey("host", jsonw.NewString(CanonicalHost))
 		ret.SetKey("uid", UIDWrapper(arg.SigningUser.GetUID()))
 		ret.SetKey("username", jsonw.NewString(arg.SigningUser.GetName()))
+	}
+
+	if arg.SharedDHGeneration != nil {
+		ret.SetKey("generation", jsonw.NewInt(*arg.SharedDHGeneration))
 	}
 
 	if pgp, ok := arg.Key.(*PGPKeyBundle); ok {
@@ -355,13 +360,16 @@ func KeyProof(arg Delegator) (ret *jsonw.Wrapper, err error) {
 		keySection := KeySection{
 			Key: arg.NewKey,
 		}
-		if arg.DelegationType == DelegationTypePGPUpdate {
+		switch arg.DelegationType {
+		case DelegationTypePGPUpdate:
 			keySection.IncludePGPHash = true
-		} else if arg.DelegationType == DelegationTypeSibkey {
+		case DelegationTypeSibkey:
 			keySection.HasRevSig = true
 			keySection.RevSig = arg.RevSig
 			keySection.IncludePGPHash = true
-		} else {
+		case DelegationTypeSharedDHKey:
+			keySection.SharedDHGeneration = arg.SharedDHGeneration
+		default:
 			keySection.ParentKID = arg.ExistingKey.GetKID()
 		}
 

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -39,7 +39,7 @@ type KeySection struct {
 	RevSig             string
 	SigningUser        UserBasic
 	IncludePGPHash     bool
-	SharedDHGeneration *int
+	SharedDHGeneration *SharedDHGeneration
 }
 
 func (arg KeySection) ToJSON() (*jsonw.Wrapper, error) {
@@ -72,7 +72,7 @@ func (arg KeySection) ToJSON() (*jsonw.Wrapper, error) {
 	}
 
 	if arg.SharedDHGeneration != nil {
-		ret.SetKey("generation", jsonw.NewInt(*arg.SharedDHGeneration))
+		ret.SetKey("generation", jsonw.NewInt(int(*arg.SharedDHGeneration)))
 	}
 
 	if pgp, ok := arg.Key.(*PGPKeyBundle); ok {

--- a/go/libkb/naclwrap.go
+++ b/go/libkb/naclwrap.go
@@ -666,7 +666,7 @@ func (k NaclDHKeyPair) IsNil() bool {
 	return bytes.Equal(k.Public[:], empty[:])
 }
 
-// Encrypt a message for the given sender.  If sender is nil, an ephemeral
+// Encrypt a message to the key `k` from the given `sender`. If sender is nil, an ephemeral
 // keypair will be invented
 func (k NaclDHKeyPair) Encrypt(msg []byte, sender *NaclDHKeyPair) (*NaclEncryptionInfo, error) {
 	if sender == nil {

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -84,7 +84,7 @@ func (to TestOutput) Write(p []byte) (n int, err error) {
 type TestContext struct {
 	G          *GlobalContext
 	PrevGlobal *GlobalContext
-	Tp         TestParameters
+	Tp         *TestParameters
 	// TODO: Rename this to TB.
 	T testing.TB
 }
@@ -187,6 +187,7 @@ var setupTestMu sync.Mutex
 func setupTestContext(tb testing.TB, name string, tcPrev *TestContext) (tc TestContext, err error) {
 	setupTestMu.Lock()
 	defer setupTestMu.Unlock()
+	tc.Tp = &TestParameters{}
 
 	g := NewGlobalContext()
 


### PR DESCRIPTION
Post an initial shared dh key. This is very much not complete. This works for the first half (before paperkey) of signing up with the first device, and probably breaks all other cases.

Disabled by default. Enabled by being in dev mode + `--enable-shared-dh`.