### PR TITLE
fix Gregor sync after a db nuke CORE-4930

### DIFF
--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -148,11 +148,13 @@ var _ libkb.GregorDismisser = (*gregorHandler)(nil)
 var _ libkb.GregorListener = (*gregorHandler)(nil)
 
 type gregorLocalDb struct {
-	db *libkb.JSONLocalDb
+	libkb.Contextified
 }
 
 func newLocalDB(g *libkb.GlobalContext) *gregorLocalDb {
-	return &gregorLocalDb{db: g.LocalDb}
+	return &gregorLocalDb{
+		Contextified: libkb.NewContextified(g),
+	}
 }
 
 func dbKey(u gregor.UID) libkb.DbKey {
@@ -160,11 +162,11 @@ func dbKey(u gregor.UID) libkb.DbKey {
 }
 
 func (db *gregorLocalDb) Store(u gregor.UID, b []byte) error {
-	return db.db.PutRaw(dbKey(u), b)
+	return db.G().LocalDb.PutRaw(dbKey(u), b)
 }
 
 func (db *gregorLocalDb) Load(u gregor.UID) (res []byte, e error) {
-	res, _, err := db.db.GetRaw(dbKey(u))
+	res, _, err := db.G().LocalDb.GetRaw(dbKey(u))
 	return res, err
 }
 


### PR DESCRIPTION
`LocalDb` can be swapped out after a `keybase db nuke`, so always reference it from `G` itself, and not a copy.