### PR TITLE
Windows: detect taskbar location for menubar placement

### DIFF
--- a/shared/desktop/app/menu-bar.js
+++ b/shared/desktop/app/menu-bar.js
@@ -2,7 +2,7 @@
 import hotPath from '../hot-path'
 import menubar from 'menubar'
 import {injectReactQueryParams} from '../../util/dev'
-import electron, {ipcMain, systemPreferences, app} from 'electron'
+import {screen as electronScreen, ipcMain, systemPreferences, app} from 'electron'
 import {isDarwin, isWindows, isLinux} from '../../constants/platform'
 import {resolveImage, resolveRootAsURL} from '../resolve-root'
 import {showDevTools, skipSecondaryDevtools} from '../../local-debug.desktop'
@@ -128,8 +128,8 @@ export default function () {
     mb.on('show', () => {
       // Account for different taskbar positions on Windows
       if (isWindows) {
-        const cursorPoint = electron.screen.getCursorScreenPoint()
-        const screenSize = electron.screen.getDisplayNearestPoint(cursorPoint).workArea
+        const cursorPoint = electronScreen.getCursorScreenPoint()
+        const screenSize = electronScreen.getDisplayNearestPoint(cursorPoint).workArea
         if (screenSize.x > 0) {
           // start menu on left
           mb.setOption('windowPosition', 'trayBottomLeft')


### PR DESCRIPTION
relates to https://github.com/keybase/client/issues/6557

The real changes are in [electron-positioner](https://github.com/keybase/electron-positioner/commit/b69034d5f2e0db649d696c68752a4c4ea84a8187), a dependency of the 'menubar' module, which I also branched to easily build with these changes.

(although we could just move the changes into keybase and not worry about forking those)

There is still an outstanding bug in the electron side, as per https://github.com/electron/electron/issues/6312. This means that if someone moves their taskbar, keybase won't draw the menubar in the right place until it restarts. It seems like the underlying bug may be in Chromium.

Attached are before and after pics of menubar placement when the taskbar is on the left side.
<img width="388" alt="leftbar_new" src="https://cloud.githubusercontent.com/assets/862397/25027077/0261cbfe-205f-11e7-81a5-c3c3c773cf72.png">
<img width="312" alt="leftbar_old" src="https://cloud.githubusercontent.com/assets/862397/25027076/02600242-205f-11e7-8112-973076826dc2.png">

