### PR TITLE
make most errors transient and make sure we reload them on reconnect CORE-4931

### DIFF
--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -459,7 +459,6 @@ func (d *SignEncryptedData) AsSealed() SealedData {
 func NewConversationErrorLocal(
 	message string,
 	remoteConv Conversation,
-	permanent bool,
 	unverifiedTLFName string,
 	typ ConversationErrorType,
 	rekeyInfo *ConversationErrorRekey,
@@ -468,7 +467,6 @@ func NewConversationErrorLocal(
 		Typ:               typ,
 		Message:           message,
 		RemoteConv:        remoteConv,
-		Permanent:         permanent,
 		UnverifiedTLFName: unverifiedTLFName,
 		RekeyInfo:         rekeyInfo,
 	}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1297,6 +1297,7 @@ const (
 	ConversationErrorType_OTHERREKEYNEEDED        ConversationErrorType = 3
 	ConversationErrorType_IDENTIFY                ConversationErrorType = 4
 	ConversationErrorType_LOCALMAXMESSAGENOTFOUND ConversationErrorType = 5
+	ConversationErrorType_TRANSIENT               ConversationErrorType = 6
 )
 
 var ConversationErrorTypeMap = map[string]ConversationErrorType{
@@ -1306,6 +1307,7 @@ var ConversationErrorTypeMap = map[string]ConversationErrorType{
 	"OTHERREKEYNEEDED":        3,
 	"IDENTIFY":                4,
 	"LOCALMAXMESSAGENOTFOUND": 5,
+	"TRANSIENT":               6,
 }
 
 var ConversationErrorTypeRevMap = map[ConversationErrorType]string{
@@ -1315,6 +1317,7 @@ var ConversationErrorTypeRevMap = map[ConversationErrorType]string{
 	3: "OTHERREKEYNEEDED",
 	4: "IDENTIFY",
 	5: "LOCALMAXMESSAGENOTFOUND",
+	6: "TRANSIENT",
 }
 
 func (e ConversationErrorType) String() string {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1291,33 +1291,33 @@ type ConversationInfoLocal struct {
 type ConversationErrorType int
 
 const (
-	ConversationErrorType_MISC                    ConversationErrorType = 0
-	ConversationErrorType_MISSINGINFO             ConversationErrorType = 1
-	ConversationErrorType_SELFREKEYNEEDED         ConversationErrorType = 2
-	ConversationErrorType_OTHERREKEYNEEDED        ConversationErrorType = 3
-	ConversationErrorType_IDENTIFY                ConversationErrorType = 4
-	ConversationErrorType_LOCALMAXMESSAGENOTFOUND ConversationErrorType = 5
-	ConversationErrorType_TRANSIENT               ConversationErrorType = 6
+	ConversationErrorType_PERMANENT        ConversationErrorType = 0
+	ConversationErrorType_MISSINGINFO      ConversationErrorType = 1
+	ConversationErrorType_SELFREKEYNEEDED  ConversationErrorType = 2
+	ConversationErrorType_OTHERREKEYNEEDED ConversationErrorType = 3
+	ConversationErrorType_IDENTIFY         ConversationErrorType = 4
+	ConversationErrorType_TRANSIENT        ConversationErrorType = 5
+	ConversationErrorType_NONE             ConversationErrorType = 6
 )
 
 var ConversationErrorTypeMap = map[string]ConversationErrorType{
-	"MISC":                    0,
-	"MISSINGINFO":             1,
-	"SELFREKEYNEEDED":         2,
-	"OTHERREKEYNEEDED":        3,
-	"IDENTIFY":                4,
-	"LOCALMAXMESSAGENOTFOUND": 5,
-	"TRANSIENT":               6,
+	"PERMANENT":        0,
+	"MISSINGINFO":      1,
+	"SELFREKEYNEEDED":  2,
+	"OTHERREKEYNEEDED": 3,
+	"IDENTIFY":         4,
+	"TRANSIENT":        5,
+	"NONE":             6,
 }
 
 var ConversationErrorTypeRevMap = map[ConversationErrorType]string{
-	0: "MISC",
+	0: "PERMANENT",
 	1: "MISSINGINFO",
 	2: "SELFREKEYNEEDED",
 	3: "OTHERREKEYNEEDED",
 	4: "IDENTIFY",
-	5: "LOCALMAXMESSAGENOTFOUND",
-	6: "TRANSIENT",
+	5: "TRANSIENT",
+	6: "NONE",
 }
 
 func (e ConversationErrorType) String() string {
@@ -1331,7 +1331,6 @@ type ConversationErrorLocal struct {
 	Typ               ConversationErrorType   `codec:"typ" json:"typ"`
 	Message           string                  `codec:"message" json:"message"`
 	RemoteConv        Conversation            `codec:"remoteConv" json:"remoteConv"`
-	Permanent         bool                    `codec:"permanent" json:"permanent"`
 	UnverifiedTLFName string                  `codec:"unverifiedTLFName" json:"unverifiedTLFName"`
 	RekeyInfo         *ConversationErrorRekey `codec:"rekeyInfo,omitempty" json:"rekeyInfo,omitempty"`
 }

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -178,7 +178,7 @@ func (h *chatLocalHandler) GetInboxNonblockLocal(ctx context.Context, arg chat1.
 
 				// Log this guy into Syncer's stale store, so that we refresh it when we
 				// re-connect
-				if !convRes.Err.Permanent {
+				if convRes.Err.Typ == chat1.ConversationErrorType_TRANSIENT {
 					h.G().ChatSyncer.AddStaleConversation(ctx, uid.ToBytes(), convRes.ConvID)
 				}
 

--- a/go/service/chat_local.go
+++ b/go/service/chat_local.go
@@ -175,6 +175,13 @@ func (h *chatLocalHandler) GetInboxNonblockLocal(ctx context.Context, arg chat1.
 					ConvID:    convRes.ConvID,
 					Error:     *convRes.Err,
 				})
+
+				// Log this guy into Syncer's stale store, so that we refresh it when we
+				// re-connect
+				if !convRes.Err.Permanent {
+					h.G().ChatSyncer.AddStaleConversation(ctx, uid.ToBytes(), convRes.ConvID)
+				}
+
 			} else if convRes.ConvRes != nil {
 				h.Debug(ctx, "GetInboxNonblockLocal: verified conv: id: %s tlf: %s",
 					convRes.ConvID, convRes.ConvRes.Info.TLFNameExpanded())

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -347,7 +347,8 @@ protocol local {
     SELFREKEYNEEDED_2,
     OTHERREKEYNEEDED_3,
     IDENTIFY_4,
-    LOCALMAXMESSAGENOTFOUND_5 // special use-case internally
+    LOCALMAXMESSAGENOTFOUND_5, // special use-case internally
+    TRANSIENT_6
   }
 
   record ConversationErrorLocal {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -342,20 +342,19 @@ protocol local {
   }
 
   enum ConversationErrorType {
-    MISC_0,
+    PERMANENT_0,
     MISSINGINFO_1,
     SELFREKEYNEEDED_2,
     OTHERREKEYNEEDED_3,
     IDENTIFY_4,
-    LOCALMAXMESSAGENOTFOUND_5, // special use-case internally
-    TRANSIENT_6
+    TRANSIENT_5,
+    NONE_6
   }
 
   record ConversationErrorLocal {
     ConversationErrorType typ;
     string message;
     Conversation remoteConv;
-    boolean permanent;
     string unverifiedTLFName;
     // Only set if typ is for rekeying.
     union { null, ConversationErrorRekey} rekeyInfo;

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -121,6 +121,7 @@ export const LocalConversationErrorType = {
   otherrekeyneeded: 3,
   identify: 4,
   localmaxmessagenotfound: 5,
+  transient: 6,
 }
 
 export const LocalHeaderPlaintextVersion = {
@@ -843,6 +844,7 @@ export type ConversationErrorType =
   | 3 // OTHERREKEYNEEDED_3
   | 4 // IDENTIFY_4
   | 5 // LOCALMAXMESSAGENOTFOUND_5
+  | 6 // TRANSIENT_6
 
 export type ConversationFinalizeInfo = {
   resetUser: string,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -115,13 +115,13 @@ export const LocalBodyPlaintextVersion = {
 }
 
 export const LocalConversationErrorType = {
-  misc: 0,
+  permanent: 0,
   missinginfo: 1,
   selfrekeyneeded: 2,
   otherrekeyneeded: 3,
   identify: 4,
-  localmaxmessagenotfound: 5,
-  transient: 6,
+  transient: 5,
+  none: 6,
 }
 
 export const LocalHeaderPlaintextVersion = {
@@ -824,7 +824,6 @@ export type ConversationErrorLocal = {
   typ: ConversationErrorType,
   message: string,
   remoteConv: Conversation,
-  permanent: boolean,
   unverifiedTLFName: string,
   rekeyInfo?: ?ConversationErrorRekey,
 }
@@ -838,13 +837,13 @@ export type ConversationErrorRekey = {
 }
 
 export type ConversationErrorType =
-    0 // MISC_0
+    0 // PERMANENT_0
   | 1 // MISSINGINFO_1
   | 2 // SELFREKEYNEEDED_2
   | 3 // OTHERREKEYNEEDED_3
   | 4 // IDENTIFY_4
-  | 5 // LOCALMAXMESSAGENOTFOUND_5
-  | 6 // TRANSIENT_6
+  | 5 // TRANSIENT_5
+  | 6 // NONE_6
 
 export type ConversationFinalizeInfo = {
   resetUser: string,

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -996,7 +996,8 @@
         "SELFREKEYNEEDED_2",
         "OTHERREKEYNEEDED_3",
         "IDENTIFY_4",
-        "LOCALMAXMESSAGENOTFOUND_5"
+        "LOCALMAXMESSAGENOTFOUND_5",
+        "TRANSIENT_6"
       ]
     },
     {

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -991,13 +991,13 @@
       "type": "enum",
       "name": "ConversationErrorType",
       "symbols": [
-        "MISC_0",
+        "PERMANENT_0",
         "MISSINGINFO_1",
         "SELFREKEYNEEDED_2",
         "OTHERREKEYNEEDED_3",
         "IDENTIFY_4",
-        "LOCALMAXMESSAGENOTFOUND_5",
-        "TRANSIENT_6"
+        "TRANSIENT_5",
+        "NONE_6"
       ]
     },
     {
@@ -1015,10 +1015,6 @@
         {
           "type": "Conversation",
           "name": "remoteConv"
-        },
-        {
-          "type": "boolean",
-          "name": "permanent"
         },
         {
           "type": "string",

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -248,15 +248,11 @@ function * unboxConversations (conversationIDKeys: Array<Constants.ConversationI
       // Valid inbox item for rekey errors only
       const conversation = new Constants.InboxStateRecord({
         conversationIDKey,
-        participants: List(error.unverifiedTLFName.split(',')),
+        participants: error.rekeyInfo ? List([].concat(error.rekeyInfo.writerNames, error.rekeyInfo.readerNames).filter(Boolean)) : List(error.unverifiedTLFName.split(',')),
         state: 'error',
         status: 'unfiled',
         time: error.remoteConv.readerInfo.mtime,
       })
-
-      if (error.rekeyInfo) {
-         conversation = conversation.set('participants', List([].concat(error.rekeyInfo.writerNames, error.rekeyInfo.readerNames).filter(Boolean)))
-      }
 
       yield put(Creators.updateInbox(conversation))
       switch (error.typ) {

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -266,6 +266,10 @@ function * unboxConversations (conversationIDKeys: Array<Constants.ConversationI
           yield put(Creators.updateInboxRekeyOthers(conversationIDKey, rekeyers))
           break
         }
+        case ChatTypes.LocalConversationErrorType.localmaxmessagenotfound: {
+          // Just ignore these, it is a transient error
+          break
+        }
         default:
           yield put({
             payload: error,

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -248,25 +248,28 @@ function * unboxConversations (conversationIDKeys: Array<Constants.ConversationI
       // Valid inbox item for rekey errors only
       const conversation = new Constants.InboxStateRecord({
         conversationIDKey,
-        participants: List([].concat(error.rekeyInfo ? error.rekeyInfo.writerNames : [], error.rekeyInfo ? error.rekeyInfo.readerNames : []).filter(Boolean)),
+        participants: List(error.unverifiedTLFName.split(',')),
         state: 'error',
         status: 'unfiled',
         time: error.remoteConv.readerInfo.mtime,
       })
 
+      if (error.rekeyInfo) {
+         conversation = conversation.set('participants', List([].concat(error.rekeyInfo.writerNames, error.rekeyInfo.readerNames).filter(Boolean)))
+      }
+
+      yield put(Creators.updateInbox(conversation))
       switch (error.typ) {
         case ChatTypes.LocalConversationErrorType.selfrekeyneeded: {
-          yield put(Creators.updateInbox(conversation))
           yield put(Creators.updateInboxRekeySelf(conversationIDKey))
           break
         }
         case ChatTypes.LocalConversationErrorType.otherrekeyneeded: {
-          yield put(Creators.updateInbox(conversation))
           const rekeyers = error.rekeyInfo.rekeyers
           yield put(Creators.updateInboxRekeyOthers(conversationIDKey, rekeyers))
           break
         }
-        case ChatTypes.LocalConversationErrorType.localmaxmessagenotfound: {
+        case ChatTypes.LocalConversationErrorType.transient: {
           // Just ignore these, it is a transient error
           break
         }

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -121,6 +121,7 @@ export const LocalConversationErrorType = {
   otherrekeyneeded: 3,
   identify: 4,
   localmaxmessagenotfound: 5,
+  transient: 6,
 }
 
 export const LocalHeaderPlaintextVersion = {
@@ -843,6 +844,7 @@ export type ConversationErrorType =
   | 3 // OTHERREKEYNEEDED_3
   | 4 // IDENTIFY_4
   | 5 // LOCALMAXMESSAGENOTFOUND_5
+  | 6 // TRANSIENT_6
 
 export type ConversationFinalizeInfo = {
   resetUser: string,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -115,13 +115,13 @@ export const LocalBodyPlaintextVersion = {
 }
 
 export const LocalConversationErrorType = {
-  misc: 0,
+  permanent: 0,
   missinginfo: 1,
   selfrekeyneeded: 2,
   otherrekeyneeded: 3,
   identify: 4,
-  localmaxmessagenotfound: 5,
-  transient: 6,
+  transient: 5,
+  none: 6,
 }
 
 export const LocalHeaderPlaintextVersion = {
@@ -824,7 +824,6 @@ export type ConversationErrorLocal = {
   typ: ConversationErrorType,
   message: string,
   remoteConv: Conversation,
-  permanent: boolean,
   unverifiedTLFName: string,
   rekeyInfo?: ?ConversationErrorRekey,
 }
@@ -838,13 +837,13 @@ export type ConversationErrorRekey = {
 }
 
 export type ConversationErrorType =
-    0 // MISC_0
+    0 // PERMANENT_0
   | 1 // MISSINGINFO_1
   | 2 // SELFREKEYNEEDED_2
   | 3 // OTHERREKEYNEEDED_3
   | 4 // IDENTIFY_4
-  | 5 // LOCALMAXMESSAGENOTFOUND_5
-  | 6 // TRANSIENT_6
+  | 5 // TRANSIENT_5
+  | 6 // NONE_6
 
 export type ConversationFinalizeInfo = {
   resetUser: string,


### PR DESCRIPTION
The patch does two things:

1.) It reclassifies most errors as `TRANSIENT`, instead of `MISC`. We also replace `MISC` with `PERMANENT`, and remove the bool `permanent` off the `ConversationError` type.
2.) Add transient errors to the `Syncer` refresh cache, so we reload them on Gregor reconnect.
3.) Don't show black bars for transient errors, but make sure the TLF name gets rendered on the row.

cc @chrisnojima on point #3. Given that the black bar is supposed to be used for things we don't expect, and don't handle, then it seems like it should not be showing for errors of a transient nature. As of this patch, we have a better story for recovering from them. I am also going to hit you with a patch that renders something interesting for these errors, which you are free to reject :).