### PR TITLE
Add nonsense extension to attachment preview files

### DIFF
--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -57,7 +57,7 @@ function tmpFileName (isHdPreview: boolean, conversationID: Constants.Conversati
     throw new Error('tmpFileName called without messageID!')
   }
 
-  return `kbchat-${isHdPreview ? 'hdPreview' : 'preview'}-${conversationID}-${messageID}`
+  return `kbchat-${conversationID}-${messageID}.${isHdPreview ? 'hdPreview' : 'preview'}`
 }
 
 function * clientHeader (messageType: ChatTypes.MessageType, conversationIDKey: Constants.ConversationIDKey): Generator<any, ?ChatTypes.MessageClientHeader, any> {


### PR DESCRIPTION
RN doesn't render images unless they have an extension. Any extension
seems to do!

:eyeglasses: @keybase/react-hackers 