### PR TITLE
resolve TLF keys in signcryption sending/receiving

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -276,7 +276,7 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, convID chat1
 		return nil
 	}
 
-	idMode, _, haveMode := IdentifyMode(ctx)
+	idMode, _, haveMode := types.IdentifyMode(ctx)
 	for _, msg := range msgs {
 		if msg.IsValid() {
 
@@ -479,8 +479,8 @@ func (p *pullLocalResultCollector) Name() string {
 	return "pulllocal"
 }
 
-func (s *pullLocalResultCollector) String() string {
-	return fmt.Sprintf("[ %s: t: %d ]", s.Name(), s.num)
+func (p *pullLocalResultCollector) String() string {
+	return fmt.Sprintf("[ %s: t: %d ]", p.Name(), p.num)
 }
 
 func (p *pullLocalResultCollector) Error(err storage.Error) storage.Error {

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keybase/client/go/chat/msgchecker"
 	"github.com/keybase/client/go/chat/storage"
+	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
@@ -722,7 +723,7 @@ func (s *NonblockingSender) Send(ctx context.Context, convID chat1.ConversationI
 		ComposeTime: gregor1.ToTime(time.Now()),
 	}
 
-	identifyBehavior, _, _ := IdentifyMode(ctx)
+	identifyBehavior, _, _ := types.IdentifyMode(ctx)
 	obr, err := s.G().MessageDeliverer.Queue(ctx, convID, msg, identifyBehavior)
 	return obr.OutboxID, 0, &chat1.RateLimit{}, err
 }

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -53,7 +53,7 @@ func (t *KBFSTLFInfoSource) Lookup(ctx context.Context, tlfName string,
 }
 
 func (t *KBFSTLFInfoSource) CryptKeys(ctx context.Context, tlfName string) (res keybase1.GetTLFCryptKeysRes, ferr error) {
-	identBehavior, breaks, ok := IdentifyMode(ctx)
+	identBehavior, breaks, ok := types.IdentifyMode(ctx)
 	if !ok {
 		return res, fmt.Errorf("invalid context with no chat metadata")
 	}
@@ -106,7 +106,7 @@ func (t *KBFSTLFInfoSource) CryptKeys(ctx context.Context, tlfName string) (res 
 }
 
 func (t *KBFSTLFInfoSource) PublicCanonicalTLFNameAndID(ctx context.Context, tlfName string) (res keybase1.CanonicalTLFNameAndIDWithBreaks, ferr error) {
-	identBehavior, breaks, ok := IdentifyMode(ctx)
+	identBehavior, breaks, ok := types.IdentifyMode(ctx)
 	if !ok {
 		return res, fmt.Errorf("invalid context with no chat metadata")
 	}

--- a/go/chat/types/context.go
+++ b/go/chat/types/context.go
@@ -1,0 +1,30 @@
+package types
+
+import (
+	"context"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type identifyModeKey int
+
+var identModeKey identifyModeKey
+
+type identModeData struct {
+	mode   keybase1.TLFIdentifyBehavior
+	breaks *[]keybase1.TLFIdentifyFailure
+}
+
+func IdentifyModeCtx(ctx context.Context, mode keybase1.TLFIdentifyBehavior,
+	breaks *[]keybase1.TLFIdentifyFailure) context.Context {
+	return context.WithValue(ctx, identModeKey, identModeData{mode: mode, breaks: breaks})
+}
+
+func IdentifyMode(ctx context.Context) (ib keybase1.TLFIdentifyBehavior, breaks *[]keybase1.TLFIdentifyFailure, ok bool) {
+	var imd identModeData
+	val := ctx.Value(identModeKey)
+	if imd, ok = val.(identModeData); ok {
+		return imd.mode, imd.breaks, ok
+	}
+	return keybase1.TLFIdentifyBehavior_CHAT_CLI, nil, false
+}

--- a/go/engine/saltpack_decrypt.go
+++ b/go/engine/saltpack_decrypt.go
@@ -4,6 +4,7 @@
 package engine
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/keybase/client/go/libkb"
@@ -58,12 +59,12 @@ func (e *SaltpackDecrypt) SubConsumers() []libkb.UIConsumer {
 	}
 }
 
-func (e *SaltpackDecrypt) promptForDecrypt(ctx *Context, mki *saltpack.MessageKeyInfo) (err error) {
+func (e *SaltpackDecrypt) promptForDecrypt(ctx *Context, publicKey keybase1.KID, isAnon bool) (err error) {
 	defer e.G().Trace("SaltpackDecrypt::promptForDecrypt", func() error { return err })()
 
 	spsiArg := SaltpackSenderIdentifyArg{
-		isAnon:           mki.SenderIsAnon,
-		publicKey:        libkb.BoxPublicKeyToKeybaseKID(mki.SenderKey),
+		isAnon:           isAnon,
+		publicKey:        publicKey,
 		interactive:      e.arg.Opts.Interactive,
 		forceRemoteCheck: e.arg.Opts.ForceRemoteCheck,
 		reason: keybase1.IdentifyReason{
@@ -155,13 +156,16 @@ func (e *SaltpackDecrypt) Run(ctx *Context) (err error) {
 
 	// For DH mode.
 	hookMki := func(mki *saltpack.MessageKeyInfo) error {
-		return e.promptForDecrypt(ctx, mki)
+		kidToIdentify := libkb.BoxPublicKeyToKeybaseKID(mki.SenderKey)
+		return e.promptForDecrypt(ctx, kidToIdentify, mki.SenderIsAnon)
 	}
 
 	// For signcryption mode.
 	hookSenderSigningKey := func(senderSigningKey saltpack.SigningPublicKey) error {
-		// TODO: implement sender checking/prompting
-		return nil
+		kidToIdentify := libkb.SigningPublicKeyToKeybaseKID(senderSigningKey)
+		// See if the sender signing key is all zeroes.
+		isAnon := bytes.Equal(senderSigningKey.ToKID(), make([]byte, len(senderSigningKey.ToKID())))
+		return e.promptForDecrypt(ctx, kidToIdentify, isAnon)
 	}
 
 	e.G().Log.Debug("| SaltpackDecrypt")

--- a/go/engine/saltpack_decrypt.go
+++ b/go/engine/saltpack_decrypt.go
@@ -170,7 +170,7 @@ func (e *SaltpackDecrypt) Run(ctx *Context) (err error) {
 
 	e.G().Log.Debug("| SaltpackDecrypt")
 	var mki *saltpack.MessageKeyInfo
-	mki, err = libkb.SaltpackDecrypt(e.G(), e.arg.Source, e.arg.Sink, kp, hookMki, hookSenderSigningKey)
+	mki, err = libkb.SaltpackDecrypt(ctx.GetNetContext(), e.G(), e.arg.Source, e.arg.Sink, kp, hookMki, hookSenderSigningKey)
 	if err == saltpack.ErrNoDecryptionKey {
 		err = libkb.NoDecryptionKeyError{Msg: "no suitable device key found"}
 	}

--- a/go/engine/saltpack_encrypt.go
+++ b/go/engine/saltpack_encrypt.go
@@ -236,7 +236,7 @@ func (e *SaltpackEncrypt) makeSymmetricReceivers(ctx *Context) ([]saltpack.Recei
 		return nil, err
 	}
 	if len(pseudonyms) != len(pseudonymInfos) {
-		return nil, fmt.Errorf("makeSymmetricReceivers got the wrong number of pseudonyms back")
+		return nil, fmt.Errorf("makeSymmetricReceivers got the wrong number of pseudonyms back (%d != %d)", len(pseudonyms), len(pseudonymInfos))
 	}
 
 	// Assemble the receivers.

--- a/go/engine/saltpack_encrypt.go
+++ b/go/engine/saltpack_encrypt.go
@@ -223,7 +223,7 @@ func (e *SaltpackEncrypt) makeSymmetricReceivers(ctx *Context) ([]saltpack.Recei
 		pseudonymInfo := libkb.TlfPseudonymInfo{
 			Name:    "/keybase/private/" + string(res.CanonicalName),
 			ID:      tlfID,
-			KeyGen:  maxKey.KeyGeneration,
+			KeyGen:  libkb.KeyGen(maxKey.KeyGeneration),
 			HmacKey: libkb.RandomHmacKey(),
 		}
 		cryptKeys = append(cryptKeys, maxKey)

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -111,6 +111,7 @@ type GlobalContext struct {
 	MessageDeliverer    chattypes.MessageDeliverer    // background message delivery service
 	ServerCacheVersions chattypes.ServerCacheVersions // server side versions for chat caches
 	ChatSyncer          chattypes.Syncer              // For syncing inbox with server
+	TlfInfoSource       chattypes.TLFInfoSource
 
 	// Can be overloaded by tests to get an improvement in performance
 	NewTriplesec func(pw []byte, salt []byte) (Triplesec, error)

--- a/go/libkb/pseudonym.go
+++ b/go/libkb/pseudonym.go
@@ -20,6 +20,9 @@ import (
 // TLFPseudonym is an identifier for a key in a tlf
 type TlfPseudonym [32]byte
 
+type KeyGen int
+type tlfID [16]byte
+
 const tlfPseudonymVersion = 1
 
 // TlfPseudonymInfo is what a pseudonym represents
@@ -27,8 +30,8 @@ type TlfPseudonymInfo struct {
 	// TLF name like: /keybase/private/a,b
 	Name string
 	// TLF id
-	ID      [16]byte
-	KeyGen  int
+	ID      tlfID
+	KeyGen  KeyGen
 	HmacKey [32]byte
 }
 
@@ -57,8 +60,8 @@ type tlfPseudonymContents struct {
 	_struct bool `codec:",toarray"`
 	Version int
 	Name    string
-	ID      [16]byte
-	KeyGen  int
+	ID      tlfID
+	KeyGen  KeyGen
 }
 
 type getTlfPseudonymsRes struct {
@@ -214,7 +217,7 @@ func checkAndConvertTlfPseudonymFromServer(ctx context.Context, g *GlobalContext
 			return mkErr(fmt.Errorf("tlf id wrong length"))
 		}
 
-		info.KeyGen = received.Info.KeyGen
+		info.KeyGen = KeyGen(received.Info.KeyGen)
 
 		n, err = hex.Decode(info.HmacKey[:], []byte(received.Info.HmacKey))
 		if err != nil {

--- a/go/libkb/pseudonym.go
+++ b/go/libkb/pseudonym.go
@@ -7,7 +7,6 @@ package libkb
 import (
 	"bytes"
 	"crypto/hmac"
-	cryptorand "crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -263,10 +262,13 @@ func checkTlfPseudonymFromServer(ctx context.Context, g *GlobalContext, req TlfP
 }
 
 func RandomHmacKey() [32]byte {
-	key := [32]byte{}
-	n, err := cryptorand.Read(key[:])
-	if err != nil || n < len(key) {
-		panic(fmt.Sprintf("error reading randoms (%d < %d): %s", n, len(key), err))
+	slice, err := RandBytes(32)
+	if err != nil {
+		panic(err)
 	}
-	return key
+	array, err := MakeByte32(slice)
+	if err != nil {
+		panic(err)
+	}
+	return array
 }

--- a/go/libkb/pseudonym_test.go
+++ b/go/libkb/pseudonym_test.go
@@ -12,16 +12,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testPseudonymName(name, idStr string, keyGen int,
+func testPseudonymName(name, idStr string, keyGen KeyGen,
 	keyStr, expectedPseudonymStr string) string {
 	return fmt.Sprintf("%s,%s,%d,%s,%s", name, idStr, keyGen, keyStr, expectedPseudonymStr)
 }
 
-func testMakePseudonym(t *testing.T, name, idStr string, keyGen int,
+func testMakePseudonym(t *testing.T, name, idStr string, keyGen KeyGen,
 	keyStr, expectedPseudonymStr string) {
 	idBytes, err := hex.DecodeString(idStr)
 	require.NoError(t, err)
-	var id [16]byte
+	var id tlfID
 	require.Equal(t, 16, copy(id[:], idBytes))
 
 	keyBytes, err := hex.DecodeString(keyStr)
@@ -47,7 +47,7 @@ func TestMakePseudonym(t *testing.T) {
 		"b070f968fdc9d1c8827d7e4953659416",
 		"0d399cb03bd1b59a07f92fffaaffa516",
 	}
-	keyGens := []int{1, 50}
+	keyGens := []KeyGen{1, 50}
 	keyStrs := []string{
 		"9d13584d962bf1acebd1ccee109c8bb5d4a014e77f125302455477c53307cc14",
 		"ca7014befa7470d87129841c0f41c5b6ed548b9a6431d205b4ff44556bd51a42",

--- a/go/libkb/pseudonym_test.go
+++ b/go/libkb/pseudonym_test.go
@@ -12,16 +12,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testPseudonymName(name, idStr string, keyGen keyGen,
+func testPseudonymName(name, idStr string, keyGen int,
 	keyStr, expectedPseudonymStr string) string {
 	return fmt.Sprintf("%s,%s,%d,%s,%s", name, idStr, keyGen, keyStr, expectedPseudonymStr)
 }
 
-func testMakePseudonym(t *testing.T, name, idStr string, keyGen keyGen,
+func testMakePseudonym(t *testing.T, name, idStr string, keyGen int,
 	keyStr, expectedPseudonymStr string) {
 	idBytes, err := hex.DecodeString(idStr)
 	require.NoError(t, err)
-	var id tlfID
+	var id [16]byte
 	require.Equal(t, 16, copy(id[:], idBytes))
 
 	keyBytes, err := hex.DecodeString(keyStr)
@@ -47,7 +47,7 @@ func TestMakePseudonym(t *testing.T) {
 		"b070f968fdc9d1c8827d7e4953659416",
 		"0d399cb03bd1b59a07f92fffaaffa516",
 	}
-	keyGens := []keyGen{1, 50}
+	keyGens := []int{1, 50}
 	keyStrs := []string{
 		"9d13584d962bf1acebd1ccee109c8bb5d4a014e77f125302455477c53307cc14",
 		"ca7014befa7470d87129841c0f41c5b6ed548b9a6431d205b4ff44556bd51a42",

--- a/go/libkb/saltpack_dec.go
+++ b/go/libkb/saltpack_dec.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -200,10 +201,10 @@ func (r *TlfKeyResolver) ResolveKeys(identifiers [][]byte) ([]*saltpack.Symmetri
 
 func (r *TlfKeyResolver) getSymmetricKey(info TlfPseudonymInfo) (*saltpack.SymmetricKey, error) {
 	// Strip "/keybase/private/" from the name.
-	if info.Name[:17] != "/keybase/private/" {
-		return nil, fmt.Errorf("unexpected prefix, expected %q, found %q", "/keybase/private/", info.Name[:17])
+	basename := strings.TrimPrefix(info.Name, "/keybase/private/")
+	if len(basename) >= len(info.Name) {
+		return nil, fmt.Errorf("unexpected prefix, expected '/keybase/private/...', found %q", info.Name)
 	}
-	basename := info.Name[17:]
 	breaks := []keybase1.TLFIdentifyFailure{}
 	identifyCtx := types.IdentifyModeCtx(context.TODO(), keybase1.TLFIdentifyBehavior_CHAT_CLI, &breaks)
 	res, err := r.G().TlfInfoSource.CryptKeys(identifyCtx, basename)

--- a/go/libkb/saltpack_dec.go
+++ b/go/libkb/saltpack_dec.go
@@ -211,7 +211,7 @@ func (r *TlfKeyResolver) getSymmetricKey(info TlfPseudonymInfo) (*saltpack.Symme
 		return nil, err
 	}
 	for _, key := range res.CryptKeys {
-		if key.KeyGeneration == info.KeyGen {
+		if KeyGen(key.KeyGeneration) == info.KeyGen {
 			// Success!
 			return (*saltpack.SymmetricKey)(&key.Key), nil
 		}

--- a/go/libkb/saltpack_enc.go
+++ b/go/libkb/saltpack_enc.go
@@ -18,7 +18,8 @@ type SaltpackEncryptArg struct {
 	Binary         bool
 	HideRecipients bool
 	// Temporary
-	Signcrypt bool
+	Signcrypt          bool
+	SymmetricReceivers []saltpack.ReceiverSymmetricKey
 }
 
 // SaltpackEncrypt reads from the given source, encrypts it for the given
@@ -43,9 +44,9 @@ func SaltpackEncrypt(g *GlobalContext, arg *SaltpackEncryptArg) error {
 	var err error
 	if arg.Signcrypt {
 		if arg.Binary {
-			plainsink, err = saltpack.NewSigncryptSealStream(arg.Sink, emptyKeyring{}, saltSigner{arg.SenderSigning}, receiverBoxKeys, nil)
+			plainsink, err = saltpack.NewSigncryptSealStream(arg.Sink, emptyKeyring{}, saltSigner{arg.SenderSigning}, receiverBoxKeys, arg.SymmetricReceivers)
 		} else {
-			plainsink, err = saltpack.NewSigncryptArmor62SealStream(arg.Sink, emptyKeyring{}, saltSigner{arg.SenderSigning}, receiverBoxKeys, nil, KeybaseSaltpackBrand)
+			plainsink, err = saltpack.NewSigncryptArmor62SealStream(arg.Sink, emptyKeyring{}, saltSigner{arg.SenderSigning}, receiverBoxKeys, arg.SymmetricReceivers, KeybaseSaltpackBrand)
 		}
 	} else {
 		if arg.Binary {

--- a/go/libkb/saltpack_test.go
+++ b/go/libkb/saltpack_test.go
@@ -5,6 +5,7 @@ package libkb
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 
@@ -68,7 +69,7 @@ func TestSaltpackEncDec(t *testing.T) {
 
 	for _, key := range receiverKPs {
 		buf.Reset()
-		_, err = SaltpackDecrypt(G,
+		_, err = SaltpackDecrypt(context.TODO(), G,
 			strings.NewReader(ciphertext),
 			&buf, key, nil, nil)
 		if err != nil {
@@ -87,7 +88,7 @@ func TestSaltpackEncDec(t *testing.T) {
 
 	for _, kp := range nonReceiverKPs {
 		buf.Reset()
-		_, err = SaltpackDecrypt(G,
+		_, err = SaltpackDecrypt(context.TODO(), G,
 			strings.NewReader(ciphertext), &buf, kp, nil, nil)
 		if err != saltpack.ErrNoDecryptionKey {
 			t.Fatal(err)

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -262,9 +262,15 @@ func IsValidHostname(s string) bool {
 }
 
 func RandBytes(length int) ([]byte, error) {
+	var n int
+	var err error
 	buf := make([]byte, length)
-	if _, err := rand.Read(buf); err != nil {
+	if n, err = rand.Read(buf); err != nil {
 		return nil, err
+	}
+	// rand.Read uses io.ReadFull internally, so this check should never fail.
+	if n != length {
+		return nil, fmt.Errorf("RandBytes got too few bytes, %d < %d", n, length)
 	}
 	return buf, nil
 }

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -272,6 +272,7 @@ func (d *Service) createChatSources() {
 	d.G().ConvSource = chat.NewConversationSource(d.G(), d.G().Env.GetConvSourceType(),
 		boxer, storage.New(d.G()), ri)
 	d.G().ServerCacheVersions = storage.NewServerVersions(d.G())
+	d.G().TlfInfoSource = tlf
 
 	chatSyncer := chat.NewSyncer(d.G())
 	d.G().ChatSyncer = chatSyncer


### PR DESCRIPTION
r? @maxtaco @akalin-keybase

One of the big changes here is that I'm exposing the `TlfInfoSource` through `G`. That also required moving a little bit of context code into `go/chat/types/context.go`, so that `libkb` could import it. Does that feel right to you guys?

Right now we're directly using the TLF Name that was encoded in the pseudonym, but that won't work for TLFs that have since been finalized. In a followup PR I'll add the current (server trust) name of the TLF to the info returned by the pseudonym resolver endpoint.