### PR TITLE
Use shared-dh for full provision

### DIFF
--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -178,8 +178,8 @@ func SignupFakeUserStoreSecret(tc libkb.TestContext, prefix string) *FakeUser {
 	return fu
 }
 
-func CreateAndSignupFakeUserCustomArg(tc libkb.TestContext, prefix string, fmod func(*SignupEngineRunArg)) (*FakeUser, libkb.GenericKey) {
-	fu := NewFakeUserOrBust(tc.T, prefix)
+func CreateAndSignupFakeUserCustomArg(tc libkb.TestContext, prefix string, fmod func(*SignupEngineRunArg)) (fu *FakeUser, signingKey libkb.GenericKey, encryptionKey libkb.NaclDHKeyPair) {
+	fu = NewFakeUserOrBust(tc.T, prefix)
 	arg := MakeTestSignupEngineRunArg(fu)
 	fmod(&arg)
 	ctx := &Context{
@@ -193,7 +193,7 @@ func CreateAndSignupFakeUserCustomArg(tc libkb.TestContext, prefix string, fmod 
 	if err != nil {
 		tc.T.Fatal(err)
 	}
-	return fu, s.signingKey
+	return fu, s.signingKey, s.encryptionKey
 }
 
 func (fu *FakeUser) LoginWithSecretUI(secui libkb.SecretUI, g *libkb.GlobalContext) error {

--- a/go/engine/device_keygen.go
+++ b/go/engine/device_keygen.go
@@ -127,6 +127,8 @@ func (e *DeviceKeygen) Push(ctx *Context, pargs *DeviceKeygenPushArgs) error {
 
 	ds := []libkb.Delegator{}
 
+	e.G().Log.CDebugf(ctx.NetContext, "DeviceKeygen#Push SDH:%v", e.G().Env.GetEnableSharedDH())
+
 	var sdhBoxes = []libkb.SharedDHSecretKeyBox{}
 	if e.G().Env.GetEnableSharedDH() {
 		sdh1, err := libkb.NewSharedDHSecretKeyBox(

--- a/go/engine/device_keygen.go
+++ b/go/engine/device_keygen.go
@@ -128,8 +128,8 @@ func (e *DeviceKeygen) Push(ctx *Context, pargs *DeviceKeygenPushArgs) error {
 	ds := []libkb.Delegator{}
 
 	var sdhBoxes = []libkb.SharedDHSecretKeyBox{}
-	if e.GetEnabledSharedDHStrict() {
-		sdh1, err := libkb.NewSharedDHSecretBox(
+	if e.G().Env.GetEnableSharedDH() {
+		sdh1, err := libkb.NewSharedDHSecretKeyBox(
 			e.sharedDHKey(),   // inner key to be encrypted (shared dh key)
 			e.EncryptionKey(), // receiver key (device enc key)
 			e.EncryptionKey(), // sender key   (device enc key)
@@ -154,7 +154,7 @@ func (e *DeviceKeygen) Push(ctx *Context, pargs *DeviceKeygenPushArgs) error {
 
 	ds = e.appendEncKey(ds, ctx, encSigner, eldestKID, pargs.User)
 
-	if e.GetEnabledSharedDHStrict() && e.args.IsEldest {
+	if e.G().Env.GetEnableSharedDH() && e.args.IsEldest {
 		ds = e.appendSharedDHKey(ds, ctx, encSigner, eldestKID, pargs.User)
 	}
 
@@ -164,14 +164,6 @@ func (e *DeviceKeygen) Push(ctx *Context, pargs *DeviceKeygenPushArgs) error {
 	e.pushLKS(ctx)
 
 	return e.pushErr
-}
-
-func (e *DeviceKeygen) GetEnabledSharedDHStrict() bool {
-	if e.G().Env.GetRunMode() != libkb.DevelRunMode {
-		return false
-	}
-
-	return e.G().Env.GetEnableSharedDH()
 }
 
 func (e *DeviceKeygen) setup(ctx *Context) {
@@ -195,7 +187,7 @@ func (e *DeviceKeygen) setup(ctx *Context) {
 		return kp, nil
 	}, e.device(), libkb.NaclDHExpireIn)
 
-	if e.GetEnabledSharedDHStrict() && e.args.IsEldest {
+	if e.G().Env.GetEnableSharedDH() && e.args.IsEldest {
 		e.naclSharedDHGen = e.newNaclKeyGen(ctx, func() (libkb.NaclKeyPair, error) {
 			kp, err := libkb.GenerateNaclDHKeyPair()
 			if err != nil {

--- a/go/engine/device_wrap.go
+++ b/go/engine/device_wrap.go
@@ -18,7 +18,7 @@ type DeviceWrap struct {
 	args *DeviceWrapArgs
 
 	signingKey    libkb.GenericKey
-	encryptionKey libkb.GenericKey
+	encryptionKey libkb.NaclDHKeyPair
 	sharedDHKey   libkb.GenericKey // can be nil
 }
 
@@ -115,7 +115,7 @@ func (e *DeviceWrap) SigningKey() libkb.GenericKey {
 	return e.signingKey
 }
 
-func (e *DeviceWrap) EncryptionKey() libkb.GenericKey {
+func (e *DeviceWrap) EncryptionKey() libkb.NaclDHKeyPair {
 	return e.encryptionKey
 }
 

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -471,10 +471,11 @@ func (e *loginProvision) makeDeviceKeys(ctx *Context, args *DeviceWrapArgs) erro
 	e.signingKey = eng.SigningKey()
 	e.encryptionKey = eng.EncryptionKey()
 
-	did := e.G().Env.GetDeviceID()
-
-	e.sharedDHKeyring = libkb.NewSharedDHKeyring(e.G(), e.arg.User.GetUID())
-	e.sharedDHKeyring.SetDeviceID(did)
+	var err error
+	e.sharedDHKeyring, err = libkb.NewSharedDHKeyring(e.G(), e.arg.User.GetUID(), e.G().Env.GetDeviceID())
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/go/engine/paperkey.go
+++ b/go/engine/paperkey.go
@@ -119,7 +119,7 @@ func (e *PaperKey) Run(ctx *Context) error {
 		Me:      me,
 		KeyType: libkb.DeviceEncryptionKeyType,
 	}
-	encryptionKeyGeneric, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska2, "You must encrypted for your new paper key"))
+	encryptionKeyGeneric, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska2, "You must encrypt for your new paper key"))
 	if err != nil {
 		return err
 	}

--- a/go/engine/paperkey.go
+++ b/go/engine/paperkey.go
@@ -106,13 +106,26 @@ func (e *PaperKey) Run(ctx *Context) error {
 		}
 	}
 
-	ska := libkb.SecretKeyArg{
+	ska1 := libkb.SecretKeyArg{
 		Me:      me,
 		KeyType: libkb.DeviceSigningKeyType,
 	}
-	signingKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska, "You must sign your new paper key"))
+	signingKey, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska1, "You must sign your new paper key"))
 	if err != nil {
 		return err
+	}
+
+	ska2 := libkb.SecretKeyArg{
+		Me:      me,
+		KeyType: libkb.DeviceEncryptionKeyType,
+	}
+	encryptionKeyGeneric, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(ska2, "You must encrypted for your new paper key"))
+	if err != nil {
+		return err
+	}
+	encryptionKey, ok := encryptionKeyGeneric.(libkb.NaclDHKeyPair)
+	if !ok {
+		return fmt.Errorf("Unexpected encryption key type")
 	}
 
 	e.passphrase, err = libkb.MakePaperKeyPhrase(libkb.PaperKeyVersion)
@@ -121,9 +134,12 @@ func (e *PaperKey) Run(ctx *Context) error {
 	}
 
 	kgarg := &PaperKeyGenArg{
-		Passphrase: e.passphrase,
-		Me:         me,
-		SigningKey: signingKey,
+		Passphrase:      e.passphrase,
+		Me:              me,
+		SigningKey:      signingKey,
+		EncryptionKey:   encryptionKey,
+		LoginContext:    nil,
+		SharedDHKeyring: nil,
 	}
 	e.gen = NewPaperKeyGen(kgarg, e.G())
 	if err := RunEngine(e.gen, ctx); err != nil {

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -313,7 +313,7 @@ func (e *PaperKeyGen) makeSharedDHSecretKeyBoxes(ctx *Context) ([]libkb.SharedDH
 		if err != nil {
 			return nil, err
 		}
-		if sdhk.CurrentGeneration() == 0 {
+		if !sdhk.HasAnyKeys() {
 			// TODO if SDH_UPGRADE: may want to add a key here.
 		} else {
 			sdhBoxes, err = sdhk.PrepareBoxesForNewDevice(

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/crypto/scrypt"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 type PaperKeyGenArg struct {
@@ -124,7 +125,12 @@ func (e *PaperKeyGen) syncSDH(ctx *Context) error {
 	if err != nil {
 		return err
 	}
-	err = sdhk.SyncDuringSignup(ctx.NetContext, e.arg.LoginContext, e.arg.Me)
+	var upak *keybase1.UserPlusAllKeys
+	if e.arg.Me != nil {
+		tmp := e.arg.Me.ExportToUserPlusAllKeys(keybase1.Time(0))
+		upak = &tmp
+	}
+	err = sdhk.SyncDuringSignup(ctx.NetContext, e.arg.LoginContext, upak)
 	if err != nil {
 		return err
 	}

--- a/go/engine/paperkey_primary.go
+++ b/go/engine/paperkey_primary.go
@@ -21,8 +21,12 @@ type PaperKeyPrimary struct {
 }
 
 type PaperKeyPrimaryArgs struct {
-	SigningKey libkb.GenericKey
-	Me         *libkb.User
+	SigningKey    libkb.GenericKey
+	EncryptionKey libkb.NaclDHKeyPair
+	Me            *libkb.User
+
+	LoginContext    libkb.LoginContext     // optional
+	SharedDHKeyring *libkb.SharedDHKeyring // optional
 }
 
 // NewPaperKeyPrimary creates a PaperKeyPrimary engine.
@@ -66,9 +70,12 @@ func (e *PaperKeyPrimary) Run(ctx *Context) error {
 	}
 
 	kgarg := &PaperKeyGenArg{
-		Passphrase: e.passphrase,
-		Me:         e.args.Me,
-		SigningKey: e.args.SigningKey,
+		Passphrase:      e.passphrase,
+		Me:              e.args.Me,
+		SigningKey:      e.args.SigningKey,
+		EncryptionKey:   e.args.EncryptionKey,
+		LoginContext:    e.args.LoginContext,
+		SharedDHKeyring: e.args.SharedDHKeyring,
 	}
 	kgeng := NewPaperKeyGen(kgarg, e.G())
 	if err := RunEngine(kgeng, ctx); err != nil {

--- a/go/engine/paperkey_primary_test.go
+++ b/go/engine/paperkey_primary_test.go
@@ -17,7 +17,7 @@ func TestPaperKeyPrimary(t *testing.T) {
 		arg.SkipPaper = true
 	}
 
-	fu, signingKey := CreateAndSignupFakeUserCustomArg(tc, "paper", f)
+	fu, signingKey, encryptionKey := CreateAndSignupFakeUserCustomArg(tc, "paper", f)
 
 	me, err := libkb.LoadMe(libkb.NewLoadUserArg(tc.G))
 	if err != nil {
@@ -28,8 +28,9 @@ func TestPaperKeyPrimary(t *testing.T) {
 		LoginUI: &libkb.TestLoginUI{},
 	}
 	args := &PaperKeyPrimaryArgs{
-		Me:         me,
-		SigningKey: signingKey,
+		Me:            me,
+		SigningKey:    signingKey,
+		EncryptionKey: encryptionKey,
 	}
 	eng := NewPaperKeyPrimary(tc.G, args)
 	if err := RunEngine(eng, ctx); err != nil {

--- a/go/engine/paperkey_test.go
+++ b/go/engine/paperkey_test.go
@@ -58,7 +58,7 @@ func TestPaperKey(t *testing.T) {
 		arg.SkipPaper = true
 	}
 
-	fu, _ := CreateAndSignupFakeUserCustomArg(tc, "login", f)
+	fu, _, _ := CreateAndSignupFakeUserCustomArg(tc, "login", f)
 
 	userDeviceID := tc.G.Env.GetDeviceID()
 

--- a/go/engine/passphrase_change_test.go
+++ b/go/engine/passphrase_change_test.go
@@ -350,7 +350,7 @@ func TestPassphraseChangeUnknownNoPSCache(t *testing.T) {
 		arg.SkipPaper = true
 	}
 
-	u, _ := CreateAndSignupFakeUserCustomArg(tc, "paper", f)
+	u, _, _ := CreateAndSignupFakeUserCustomArg(tc, "paper", f)
 
 	tc.G.LoginState().Account(func(a *libkb.Account) {
 		a.ClearStreamCache()

--- a/go/engine/shared_dh_test.go
+++ b/go/engine/shared_dh_test.go
@@ -4,10 +4,11 @@
 package engine
 
 import (
+	"testing"
+
 	libkb "github.com/keybase/client/go/libkb"
 	require "github.com/stretchr/testify/require"
 	context "golang.org/x/net/context"
-	"testing"
 )
 
 func TestSignupEngineSharedDH(t *testing.T) {
@@ -27,14 +28,10 @@ func TestSharedDHSignupAndPullKeys(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	kr := libkb.NewSharedDHKeyring(tc.G, fu.UID())
-	if kr == nil {
-		t.Fatal("got null shared DH keyring")
-	}
+	kr, err := libkb.NewSharedDHKeyring(tc.G, fu.UID(), tc.G.Env.GetDeviceID())
+	require.NoError(t, err)
 	err = kr.Sync(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	gen := libkb.SharedDHKeyGeneration(1)
 	require.Equal(t, kr.CurrentGeneration(), gen)
 	key := kr.SharedDHKey(gen)

--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -221,8 +221,11 @@ func (s *SignupEngine) registerDevice(a libkb.LoginContext, ctx *Context, device
 		s.G().Log.Warning("error saving session file: %s", err)
 	}
 
-	s.sharedDHKeyring = libkb.NewSharedDHKeyring(s.G(), s.uid)
-	s.sharedDHKeyring.SetDeviceID(did)
+	var err error
+	s.sharedDHKeyring, err = libkb.NewSharedDHKeyring(s.G(), s.uid, did)
+	if err != nil {
+		return err
+	}
 
 	if s.arg.StoreSecret {
 		// Create the secret store as late as possible here

--- a/go/libkb/delegatekeyaggregator.go
+++ b/go/libkb/delegatekeyaggregator.go
@@ -40,6 +40,7 @@ func DelegatorAggregator(lctx LoginContext, ds []Delegator, sdhBoxes []SharedDHS
 	// Post the shared dh key encrypted for each active device.
 	if len(sdhBoxes) > 0 {
 		payload["shared_dh_secret_boxes"] = sdhBoxes
+		payload["shared_dh_generation"] = sdhBoxes[0].Generation
 	}
 
 	// Adopt most parameters from the first item
@@ -52,26 +53,4 @@ func DelegatorAggregator(lctx LoginContext, ds []Delegator, sdhBoxes []SharedDHS
 
 	_, err = apiArgBase.G().API.PostJSON(apiArg)
 	return err
-}
-
-func NewSharedDHSecretBox(innerKey NaclDHKeyPair, receiverKey NaclDHKeyPair, senderKey NaclDHKeyPair, generation SharedDHKeyGeneration) (SharedDHSecretKeyBox, error) {
-	_, secret, err := innerKey.ExportPublicAndPrivate()
-	if err != nil {
-		return SharedDHSecretKeyBox{}, err
-	}
-
-	encInfo, err := receiverKey.Encrypt(secret, &senderKey)
-	if err != nil {
-		return SharedDHSecretKeyBox{}, err
-	}
-	boxStr, err := PacketArmoredEncode(encInfo)
-	if err != nil {
-		return SharedDHSecretKeyBox{}, err
-	}
-
-	return SharedDHSecretKeyBox{
-		Box:         boxStr,
-		ReceiverKID: receiverKey.GetKID(),
-		Generation:  generation,
-	}, nil
 }

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -653,6 +653,10 @@ func (e *Env) GetEmail() string {
 }
 
 func (e *Env) GetEnableSharedDH() bool {
+	if e.GetRunMode() != DevelRunMode {
+		return false
+	}
+
 	return e.GetBool(false,
 		func() (bool, bool) { return e.Test.EnableSharedDH, e.Test.EnableSharedDH },
 		func() (bool, bool) { return e.getEnvBool("KEYBASE_ENABLE_SHARED_DH") },

--- a/go/libkb/keyring.go
+++ b/go/libkb/keyring.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/keybase/go-crypto/openpgp"
@@ -25,7 +24,6 @@ type KeyringFile struct {
 
 type Keyrings struct {
 	Contextified
-	sync.Mutex
 }
 
 func NewKeyrings(g *GlobalContext) *Keyrings {

--- a/go/libkb/keyring.go
+++ b/go/libkb/keyring.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/keybase/go-crypto/openpgp"
@@ -24,6 +25,7 @@ type KeyringFile struct {
 
 type Keyrings struct {
 	Contextified
+	sync.Mutex
 }
 
 func NewKeyrings(g *GlobalContext) *Keyrings {

--- a/go/libkb/shared_dh.go
+++ b/go/libkb/shared_dh.go
@@ -148,7 +148,7 @@ func (s *SharedDHKeyring) Sync(ctx context.Context) (err error) {
 	return s.sync(ctx, nil, nil)
 }
 
-func (s *SharedDHKeyring) SyncWithExtras(ctx context.Context, lctx LoginContext, me *User) (err error) {
+func (s *SharedDHKeyring) SyncDuringSignup(ctx context.Context, lctx LoginContext, me *User) (err error) {
 	return s.sync(ctx, lctx, me)
 }
 

--- a/go/libkb/shared_dh.go
+++ b/go/libkb/shared_dh.go
@@ -96,6 +96,10 @@ func (s *SharedDHKeyring) PrepareBoxesForNewDevice(receiverKey NaclDHKeyPair, se
 	return boxes, nil
 }
 
+func (s *SharedDHKeyring) HasAnyKeys() bool {
+	return s.CurrentGeneration() > 0
+}
+
 // CurrentGeneration returns what generation we're on. The version possible
 // Version is 1. Version 0 implies no keys are available.
 func (s *SharedDHKeyring) CurrentGeneration() SharedDHKeyGeneration {

--- a/go/libkb/shared_dh.go
+++ b/go/libkb/shared_dh.go
@@ -199,7 +199,7 @@ func (s *SharedDHKeyring) fetchBoxesLocked(ctx context.Context, lctx LoginContex
 		return nil, DeviceRequiredError{}
 	}
 
-	var sessionR *Session
+	var sessionR SessionReader
 	if lctx != nil {
 		sessionR = lctx.LocalSession()
 	}


### PR DESCRIPTION
`keybase signup` now works with shared dh keys. This PR mostly adds support for encrypting for the new paperkey.