### PR TITLE
use the the untrusted_current_name for fetching signcryption keys

### DIFF
--- a/go/libkb/pseudonym.go
+++ b/go/libkb/pseudonym.go
@@ -43,13 +43,7 @@ func (t TlfPseudonym) String() string {
 	return hex.EncodeToString(t[:])
 }
 
-func (t *TlfPseudonym) Eq(r *TlfPseudonym) bool {
-	if t == nil || r == nil {
-		// It's unlikely that the caller wants to verify that two pseudonyms
-		// are both nil, and more likely that accepting nil values would cause
-		// a security bug.
-		return false
-	}
+func (t TlfPseudonym) Eq(r TlfPseudonym) bool {
 	return hmac.Equal(t[:], r[:])
 }
 
@@ -263,7 +257,7 @@ func checkTlfPseudonymFromServer(ctx context.Context, g *GlobalContext, req TlfP
 		// Error creating pseudonym locally
 		return &PseudonymGetError{err.Error()}
 	}
-	if !req.Eq(&pn) {
+	if !req.Eq(pn) {
 		return &PseudonymGetError{fmt.Sprintf("returned data does not match pseudonym: %s != %s",
 			req, pn)}
 	}

--- a/go/libkb/pseudonym.go
+++ b/go/libkb/pseudonym.go
@@ -5,7 +5,6 @@
 package libkb
 
 import (
-	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -32,6 +31,12 @@ type TlfPseudonymInfo struct {
 	ID      tlfID
 	KeyGen  KeyGen
 	HmacKey [32]byte
+
+	// Ignored in requests. Set in server responses. Using untrusted data
+	// during decryption is safe because we don't rely on TLF keys for sender
+	// authenticity. (Note however that senders must not use untrusted keys, or
+	// else they'd lose all privacy.)
+	UntrustedCurrentName string
 }
 
 func (t TlfPseudonym) String() string {
@@ -39,10 +44,13 @@ func (t TlfPseudonym) String() string {
 }
 
 func (t *TlfPseudonym) Eq(r *TlfPseudonym) bool {
-	if t != nil && r != nil {
-		return bytes.Equal(t[:], r[:])
+	if t == nil || r == nil {
+		// It's unlikely that the caller wants to verify that two pseudonyms
+		// are both nil, and more likely that accepting nil values would cause
+		// a security bug.
+		return false
 	}
-	return (t == nil) && (r == nil)
+	return hmac.Equal(t[:], r[:])
 }
 
 // tlfPseudonymReq is what the server needs to store a pseudonym
@@ -75,10 +83,11 @@ func (r *getTlfPseudonymsRes) GetAppStatus() *AppStatus {
 type getTlfPseudonymRes struct {
 	Err  *PseudonymGetError `json:"err"`
 	Info *struct {
-		Name    string `json:"tlf_name"`
-		ID      string `json:"tlf_id"` // hex
-		KeyGen  int    `json:"tlf_key_gen"`
-		HmacKey string `json:"hmac_key"` // hex
+		Name                 string `json:"tlf_name"`
+		UntrustedCurrentName string `json:"untrusted_current_name"`
+		ID                   string `json:"tlf_id"` // hex
+		KeyGen               int    `json:"tlf_key_gen"`
+		HmacKey              string `json:"hmac_key"` // hex
 	} `json:"info"`
 }
 
@@ -207,6 +216,7 @@ func checkAndConvertTlfPseudonymFromServer(ctx context.Context, g *GlobalContext
 		info := TlfPseudonymInfo{}
 
 		info.Name = received.Info.Name
+		info.UntrustedCurrentName = received.Info.UntrustedCurrentName
 
 		n, err := hex.Decode(info.ID[:], []byte(received.Info.ID))
 		if err != nil {

--- a/go/libkb/saltpack_dec.go
+++ b/go/libkb/saltpack_dec.go
@@ -199,7 +199,7 @@ func (r *TlfKeyResolver) ResolveKeys(identifiers [][]byte) ([]*saltpack.Symmetri
 	return symmetricKeys, nil
 }
 
-func (r *TlfKeyResolver) getSymmetricKey(info TlfPseudonymInfo) (*saltpack.SymmetricKey, error) {
+func (r *TlfKeyResolver) getSymmetricKey(info TlfPseudonymServerInfo) (*saltpack.SymmetricKey, error) {
 	// NOTE: In order to handle finalized TLFs (which is one of the main
 	// benefits of using TLF keys to begin with, for forward readability), we
 	// need the server to tell us what the current, potentially-finalized name

--- a/go/libkb/saltpack_dec.go
+++ b/go/libkb/saltpack_dec.go
@@ -182,7 +182,6 @@ func (r *TlfKeyResolver) ResolveKeys(identifiers [][]byte) ([]*saltpack.Symmetri
 		return nil, err
 	}
 
-	// TODO: Handle TLFs with finalized info.
 	symmetricKeys := []*saltpack.SymmetricKey{}
 	for _, result := range results {
 		if result.Err != nil {
@@ -201,10 +200,24 @@ func (r *TlfKeyResolver) ResolveKeys(identifiers [][]byte) ([]*saltpack.Symmetri
 }
 
 func (r *TlfKeyResolver) getSymmetricKey(info TlfPseudonymInfo) (*saltpack.SymmetricKey, error) {
+	// NOTE: In order to handle finalized TLFs (which is one of the main
+	// benefits of using TLF keys to begin with, for forward readability), we
+	// need the server to tell us what the current, potentially-finalized name
+	// of the TLF is. If that's not the same as what the name was when the
+	// message was sent, we can't necessarily check that the server is being
+	// honest. That's ok insofar as we're not relying on these keys for
+	// authenticity, but it's a drag to not be able to use the pseudonym
+	// machinery.
+
+	// TODO: Check as much as we can, if the original TLF was fully resolved.
+	// This is a little tricky, because the current TLF name parsing code lives
+	// in chat and depends on externals, and it would create a circular
+	// dependency if we pulled it directly into libkb.
+
 	// Strip "/keybase/private/" from the name.
-	basename := strings.TrimPrefix(info.Name, "/keybase/private/")
-	if len(basename) >= len(info.Name) {
-		return nil, fmt.Errorf("unexpected prefix, expected '/keybase/private/...', found %q", info.Name)
+	basename := strings.TrimPrefix(info.UntrustedCurrentName, "/keybase/private/")
+	if len(basename) >= len(info.UntrustedCurrentName) {
+		return nil, fmt.Errorf("unexpected prefix, expected '/keybase/private', found %q", info.UntrustedCurrentName)
 	}
 	breaks := []keybase1.TLFIdentifyFailure{}
 	identifyCtx := types.IdentifyModeCtx(r.ctx, keybase1.TLFIdentifyBehavior_CHAT_CLI, &breaks)


### PR DESCRIPTION
r? @akalin-keybase

I realize I didn't think far enough ahead with the pseudonyms: it's hard to make use of the info we've HMAC'd, because there might be unresolved identities in the original name that are resolved in the finalized name. Tell me what you think of the following limited checks (not yet included in this PR):

- If all the identities in the original name were resolved, we can confirm that they match the identities in the finalized name. (There's some difficulty lifting our TLF name parsing code out of `chat`, but we could figure that out.)
- Confirm that the TLF ID has not changed. (Though right now the server can create a new finalized TLF what whatever ID it wants? Eventually we expect to mitigate this with an extra merkle tree?)

(CI will fail on this PR until https://github.com/keybase/keybase/pull/1246 is in.)