### PR TITLE
trim whitespace around proofs before handing them to the UI

### DIFF
--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -637,7 +637,8 @@ func (p ProveUI) OutputInstructions(_ context.Context, arg keybase1.OutputInstru
 	if p.outputHook != nil {
 		err = p.outputHook(arg.Proof)
 	} else {
-		p.parent.Output("\n" + arg.Proof + "\n")
+		// Whitespace is trimmed from proof text before it gets here.
+		p.parent.Output("\n" + arg.Proof + "\n\n")
 	}
 	return
 }

--- a/go/engine/prove.go
+++ b/go/engine/prove.go
@@ -4,6 +4,8 @@
 package engine
 
 import (
+	"strings"
+
 	libkb "github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	jsonw "github.com/keybase/go-jsonw"
@@ -210,7 +212,14 @@ func (p *Prove) instructAction(ctx *Context) (err error) {
 	}
 	err = ctx.ProveUI.OutputInstructions(context.TODO(), keybase1.OutputInstructionsArg{
 		Instructions: mkp.Export(),
-		Proof:        txt,
+		// If we don't trim newlines here, we'll run into an issue where e.g.
+		// Facebook links get corrupted on iOS. See:
+		// - https://keybase.atlassian.net/browse/DESKTOP-3335
+		// - https://keybase.atlassian.net/browse/CORE-4941
+		// All of our proof verifying code (PVL) should already be flexible
+		// with surrounding whitespace, because users are pasting proofs by
+		// hand anyway.
+		Proof: strings.TrimSpace(txt),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This fixes an issue where a newline in the Facebook URLs behaves
especially badly on iOS: https://keybase.atlassian.net/browse/CORE-4941

r? @maxtaco 

@cjb, are you able to check that this fixes the issue? Also, would it be better to trim the text on the iOS side?