### PR TITLE
stop the reachability screen from showing up on provision CORE-4944

### DIFF
--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -151,7 +151,7 @@ func setupTest(t *testing.T, numUsers int) (*kbtest.ChatMockWorld, chat1.RemoteI
 	chatSyncer := NewSyncer(tc.G)
 	chatSyncer.isConnected = true
 	tc.G.ChatSyncer = chatSyncer
-	tc.G.ConnectivityMonitor = chatSyncer
+	tc.G.ConnectivityMonitor = &libkb.NullConnectivityMonitor{}
 
 	return world, ri, sender, baseSender, &listener, tlf
 }

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -38,7 +38,7 @@ func NewSyncer(g *libkb.GlobalContext) *Syncer {
 	s := &Syncer{
 		Contextified:      libkb.NewContextified(g),
 		DebugLabeler:      utils.NewDebugLabeler(g, "Syncer", false),
-		isConnected:       false,
+		isConnected:       true,
 		clock:             clockwork.NewRealClock(),
 		shutdownCh:        make(chan struct{}),
 		fullReloadCh:      make(chan gregor1.UID),

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -38,7 +38,7 @@ func NewSyncer(g *libkb.GlobalContext) *Syncer {
 	s := &Syncer{
 		Contextified:      libkb.NewContextified(g),
 		DebugLabeler:      utils.NewDebugLabeler(g, "Syncer", false),
-		isConnected:       true,
+		isConnected:       false,
 		clock:             clockwork.NewRealClock(),
 		shutdownCh:        make(chan struct{}),
 		fullReloadCh:      make(chan gregor1.UID),

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -312,7 +312,7 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 	// connected to Gregor, then it is likely the case we are totally offline, or on a very bad
 	// connection. If that is the case, let's make these timeouts very aggressive, so we don't
 	// block up everything trying to succeed when we probably will not.
-	if !g.G().ConnectivityMonitor.IsConnected(ctx) {
+	if ConnectivityMonitor_NO == g.G().ConnectivityMonitor.IsConnected(ctx) {
 		arg.InitialTimeout = HTTPFastTimeout
 		arg.RetryCount = 0
 	}
@@ -350,7 +350,7 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 		timeout = time.Duration(float64(timeout) * multiplier)
 
 		// If chat goes offline during this retry loop, then let's bail out early
-		if !g.G().ConnectivityMonitor.IsConnected(ctx) {
+		if ConnectivityMonitor_NO == g.G().ConnectivityMonitor.IsConnected(ctx) {
 			g.G().Log.CDebugf(ctx, "retry loop aborting since chat went offline")
 			break
 		}

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -312,7 +312,7 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 	// connected to Gregor, then it is likely the case we are totally offline, or on a very bad
 	// connection. If that is the case, let's make these timeouts very aggressive, so we don't
 	// block up everything trying to succeed when we probably will not.
-	if ConnectivityMonitor_NO == g.G().ConnectivityMonitor.IsConnected(ctx) {
+	if ConnectivityMonitorNo == g.G().ConnectivityMonitor.IsConnected(ctx) {
 		arg.InitialTimeout = HTTPFastTimeout
 		arg.RetryCount = 0
 	}
@@ -350,7 +350,7 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 		timeout = time.Duration(float64(timeout) * multiplier)
 
 		// If chat goes offline during this retry loop, then let's bail out early
-		if ConnectivityMonitor_NO == g.G().ConnectivityMonitor.IsConnected(ctx) {
+		if ConnectivityMonitorNo == g.G().ConnectivityMonitor.IsConnected(ctx) {
 			g.G().Log.CDebugf(ctx, "retry loop aborting since chat went offline")
 			break
 		}

--- a/go/libkb/connectivity_monitor.go
+++ b/go/libkb/connectivity_monitor.go
@@ -8,7 +8,7 @@ type NullConnectivityMonitor struct {
 }
 
 func (s NullConnectivityMonitor) IsConnected(ctx context.Context) ConnectivityMonitorResult {
-	return ConnectivityMonitor_YES
+	return ConnectivityMonitorYes
 }
 
 var _ ConnectivityMonitor = NullConnectivityMonitor{}

--- a/go/libkb/connectivity_monitor.go
+++ b/go/libkb/connectivity_monitor.go
@@ -7,8 +7,8 @@ import (
 type NullConnectivityMonitor struct {
 }
 
-func (s NullConnectivityMonitor) IsConnected(ctx context.Context) bool {
-	return true
+func (s NullConnectivityMonitor) IsConnected(ctx context.Context) ConnectivityMonitorResult {
+	return ConnectivityMonitor_YES
 }
 
 var _ ConnectivityMonitor = NullConnectivityMonitor{}

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -345,7 +345,7 @@ const (
 	HTTPDefaultTimeout        = 60 * time.Second
 	HTTPDefaultScraperTimeout = 10 * time.Second
 	HTTPPollMaximum           = 5 * time.Second
-	HTTPFastTimeout           = 2 * time.Second
+	HTTPFastTimeout           = 5 * time.Second
 )
 
 // The following constants apply to APIArg parameters for

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -567,9 +567,9 @@ type UserChangedHandler interface {
 type ConnectivityMonitorResult int
 
 const (
-	ConnectivityMonitor_YES ConnectivityMonitorResult = iota
-	ConnectivityMonitor_NO
-	ConnectivityMonitor_UNKNOWN
+	ConnectivityMonitorYes ConnectivityMonitorResult = iota
+	ConnectivityMonitorNo
+	ConnectivityMonitorUnknown
 )
 
 type ConnectivityMonitor interface {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -564,6 +564,14 @@ type UserChangedHandler interface {
 	HandleUserChanged(uid keybase1.UID) error
 }
 
+type ConnectivityMonitorResult int
+
+const (
+	ConnectivityMonitor_YES ConnectivityMonitorResult = iota
+	ConnectivityMonitor_NO
+	ConnectivityMonitor_UNKNOWN
+)
+
 type ConnectivityMonitor interface {
-	IsConnected(ctx context.Context) bool
+	IsConnected(ctx context.Context) ConnectivityMonitorResult
 }

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -84,7 +84,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	tc.G.ServerCacheVersions = storage.NewServerVersions(tc.G)
 	chatSyncer := chat.NewSyncer(tc.G)
 	tc.G.ChatSyncer = chatSyncer
-	tc.G.ConnectivityMonitor = chatSyncer
+	tc.G.ConnectivityMonitor = &libkb.NullConnectivityMonitor{}
 
 	h.setTestRemoteClient(mockRemote)
 	h.gh = newGregorHandler(tc.G)

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -612,11 +612,15 @@ func (g *gregorHandler) OnConnectError(err error, reconnectThrottleDuration time
 func (g *gregorHandler) OnDisconnected(ctx context.Context, status rpc.DisconnectStatus) {
 	g.Debug(context.Background(), "disconnected: %v", status)
 
+	// We only want to run the reachability update if we are going offline, not just that the
+	// connection is starting up for the first time
+	connected := g.G().ChatSyncer.IsConnected(ctx)
+
 	// Alert chat syncer that we are now disconnected
 	g.G().ChatSyncer.Disconnected(ctx)
 
 	// Call out to reachability module if we have one
-	if g.reachability != nil {
+	if connected && g.reachability != nil {
 		g.reachability.setReachability(keybase1.Reachability{
 			Reachable: keybase1.Reachable_NO,
 		})

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -612,19 +612,15 @@ func (g *gregorHandler) OnConnectError(err error, reconnectThrottleDuration time
 func (g *gregorHandler) OnDisconnected(ctx context.Context, status rpc.DisconnectStatus) {
 	g.Debug(context.Background(), "disconnected: %v", status)
 
-	// We only want to run the reachability update if we are going offline, not just that the
-	// connection is starting up for the first time
-	connected := g.G().ChatSyncer.IsConnected(ctx)
-
-	// Alert chat syncer that we are now disconnected
-	g.G().ChatSyncer.Disconnected(ctx)
-
-	// Call out to reachability module if we have one
-	if connected && g.reachability != nil {
+	// Call out to reachability module if we have one (and we are currently connected)
+	if g.reachability != nil && status != rpc.StartingFirstConnection {
 		g.reachability.setReachability(keybase1.Reachability{
 			Reachable: keybase1.Reachable_NO,
 		})
 	}
+
+	// Alert chat syncer that we are now disconnected
+	g.G().ChatSyncer.Disconnected(ctx)
 }
 
 func (g *gregorHandler) OnDoCommandError(err error, nextTime time.Duration) {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1121,6 +1121,9 @@ func (g *gregorHandler) isReachable() bool {
 func (g *gregorHandler) Reconnect(ctx context.Context) error {
 	if g.IsConnected() {
 		g.Debug(ctx, "Reconnect: reconnecting to server")
+		g.reachability.setReachability(keybase1.Reachability{
+			Reachable: keybase1.Reachable_NO,
+		})
 		g.Shutdown()
 		return g.Connect(g.uri)
 	}

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -275,7 +275,6 @@ func (d *Service) createChatSources() {
 
 	chatSyncer := chat.NewSyncer(d.G())
 	d.G().ChatSyncer = chatSyncer
-	d.G().ConnectivityMonitor = chatSyncer
 
 	// Set up Offlinables on Syncer
 	chatSyncer.RegisterOfflinable(d.G().InboxSource)
@@ -326,6 +325,8 @@ func (d *Service) startupGregor() {
 		d.gregor = newGregorHandler(d.G())
 		d.reachability = newReachability(d.G(), d.gregor)
 		d.gregor.setReachability(d.reachability)
+		d.G().ConnectivityMonitor = d.reachability
+
 		d.gregor.badger = d.badger
 		d.G().GregorDismisser = d.gregor
 		d.G().GregorListener = d.gregor

--- a/go/service/reachability.go
+++ b/go/service/reachability.go
@@ -80,3 +80,14 @@ func (h *reachability) check() (k keybase1.Reachability) {
 	h.setReachability(k)
 	return k
 }
+
+func (h *reachability) IsConnected(ctx context.Context) libkb.ConnectivityMonitorResult {
+	switch h.lastReachability.Reachable {
+	case keybase1.Reachable_YES:
+		return libkb.ConnectivityMonitor_YES
+	case keybase1.Reachable_NO:
+		return libkb.ConnectivityMonitor_NO
+	default:
+		return libkb.ConnectivityMonitor_UNKNOWN
+	}
+}

--- a/go/service/reachability.go
+++ b/go/service/reachability.go
@@ -84,10 +84,10 @@ func (h *reachability) check() (k keybase1.Reachability) {
 func (h *reachability) IsConnected(ctx context.Context) libkb.ConnectivityMonitorResult {
 	switch h.lastReachability.Reachable {
 	case keybase1.Reachable_YES:
-		return libkb.ConnectivityMonitor_YES
+		return libkb.ConnectivityMonitorYes
 	case keybase1.Reachable_NO:
-		return libkb.ConnectivityMonitor_NO
+		return libkb.ConnectivityMonitorNo
 	default:
-		return libkb.ConnectivityMonitor_UNKNOWN
+		return libkb.ConnectivityMonitorUnknown
 	}
 }


### PR DESCRIPTION
Patch does the following:

1.) Replace `chat.Syncer` in `G` with `reachability`, and expand the interface to return an unknown state. This fixes the problem of having the aggressive API timeout on in the logged out state. 
2.) Increase timeout of API server to 5 seconds if we are not connected to Gregor.
3.) Don't trigger a reachability update in `OnDisconnected` if this is the first try to establish the connection.
4.) Send reachability update in `Reconnect`.