### PR TITLE
Add support for SharedDH via kex

### DIFF
--- a/go/engine/device_keygen.go
+++ b/go/engine/device_keygen.go
@@ -129,13 +129,13 @@ func (e *DeviceKeygen) Push(ctx *Context, pargs *DeviceKeygenPushArgs) error {
 
 	e.G().Log.CDebugf(ctx.NetContext, "DeviceKeygen#Push SDH:%v", e.G().Env.GetEnableSharedDH())
 
-	var sdhBoxes = []libkb.SharedDHSecretKeyBox{}
+	var sdhBoxes = []keybase1.SharedDHSecretKeyBox{}
 	if e.G().Env.GetEnableSharedDH() {
 		sdh1, err := libkb.NewSharedDHSecretKeyBox(
 			e.sharedDHKey(),   // inner key to be encrypted (shared dh key)
 			e.EncryptionKey(), // receiver key (device enc key)
 			e.EncryptionKey(), // sender key   (device enc key)
-			libkb.SharedDHKeyGeneration(1))
+			keybase1.SharedDHKeyGeneration(1))
 		if err != nil {
 			return err
 		}
@@ -291,7 +291,7 @@ func (e *DeviceKeygen) appendSharedDHKey(ds []libkb.Delegator, ctx *Context, sig
 
 	var d libkb.Delegator
 	d, e.pushErr = e.naclSharedDHGen.Push(ctx.LoginContext, true)
-	d.SharedDHKeyGeneration = libkb.SharedDHKeyGeneration(1)
+	d.SharedDHKeyGeneration = keybase1.SharedDHKeyGeneration(1)
 	if e.pushErr == nil {
 		d.SetGlobalContext(e.G())
 		return append(ds, d)

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -116,9 +116,6 @@ func (e *Kex2Provisionee) Run(ctx *Context) error {
 		KexBaseArg:  karg,
 		Provisionee: e,
 	}
-	if e.v1Only {
-		parg.V1Only = true
-	}
 	if err := kex2.RunProvisionee(parg); err != nil {
 		return err
 	}

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -232,7 +232,7 @@ func (e *Kex2Provisionee) HandleDidCounterSign(sig []byte) (err error) {
 	return e.handleDidCounterSign(sig, nil)
 }
 
-func (e *Kex2Provisionee) handleDidCounterSign(sig []byte, sdhBoxes []keybase1.SharedDhSecretKeyBox) (err error) {
+func (e *Kex2Provisionee) handleDidCounterSign(sig []byte, sdhBoxes []keybase1.SharedDHSecretKeyBox) (err error) {
 	e.G().Log.Debug("+ HandleDidCounterSign()")
 	defer func() { e.G().Log.Debug("- HandleDidCounterSign() -> %s", libkb.ErrToOk(err)) }()
 
@@ -458,11 +458,9 @@ func (e *Kex2Provisionee) reverseSig(jw *jsonw.Wrapper) error {
 
 // postSigs takes the HTTP args for the signing key and encrypt
 // key and posts them to the api server.
-func (e *Kex2Provisionee) postSigs(signingArgs, encryptArgs *libkb.HTTPArgs, sdhKexBoxes []keybase1.SharedDhSecretKeyBox) error {
+func (e *Kex2Provisionee) postSigs(signingArgs, encryptArgs *libkb.HTTPArgs, sdhBoxes []keybase1.SharedDHSecretKeyBox) error {
 	payload := make(libkb.JSONPayload)
 	payload["sigs"] = []map[string]string{firstValues(signingArgs.ToValues()), firstValues(encryptArgs.ToValues())}
-
-	sdhBoxes := e.convertBoxes(sdhKexBoxes)
 
 	// Post the shared dh keys encrypted for the provisionee device by the provisioner.
 	if len(sdhBoxes) > 0 {
@@ -597,13 +595,6 @@ func (e *Kex2Provisionee) cacheKeys() (err error) {
 	}
 
 	return nil
-}
-
-func (e *Kex2Provisionee) convertBoxes(bks []keybase1.SharedDhSecretKeyBox) (res []libkb.SharedDHSecretKeyBox) {
-	for _, bk := range bks {
-		res = append(res, libkb.NewSharedDHSecretKeyBoxFromKex(bk))
-	}
-	return
 }
 
 func firstValues(vals url.Values) map[string]string {

--- a/go/engine/kex2_provisioner.go
+++ b/go/engine/kex2_provisioner.go
@@ -382,7 +382,7 @@ func (e *Kex2Provisioner) rememberDeviceInfo(jw *jsonw.Wrapper) error {
 	return nil
 }
 
-func (e *Kex2Provisioner) makeSdhBoxes(receiverKeyGeneric libkb.GenericKey) (res []keybase1.SharedDhSecretKeyBox, err error) {
+func (e *Kex2Provisioner) makeSdhBoxes(receiverKeyGeneric libkb.GenericKey) (res []keybase1.SharedDHSecretKeyBox, err error) {
 	receiverKey, ok := receiverKeyGeneric.(libkb.NaclDHKeyPair)
 	if !ok {
 		return res, fmt.Errorf("Unexpected receiver key type")
@@ -400,15 +400,5 @@ func (e *Kex2Provisioner) makeSdhBoxes(receiverKeyGeneric libkb.GenericKey) (res
 	sdhBoxes, err := sdhk.PrepareBoxesForNewDevice(e.ctx.NetContext,
 		receiverKey,     // receiver key: provisionee enc
 		e.encryptionKey) // sender key: this device enc
-	if err != nil {
-		return res, err
-	}
-	return e.convertBoxes(sdhBoxes), nil
-}
-
-func (e *Kex2Provisioner) convertBoxes(bs []libkb.SharedDHSecretKeyBox) (res []keybase1.SharedDhSecretKeyBox) {
-	for _, b := range bs {
-		res = append(res, b.ToKex())
-	}
-	return
+	return sdhBoxes, err
 }

--- a/go/engine/kex2_test.go
+++ b/go/engine/kex2_test.go
@@ -14,9 +14,18 @@ import (
 )
 
 func TestKex2Provision(t *testing.T) {
+	subTestKex2Provision(t, false)
+}
+
+func TestKex2ProvisionSDH(t *testing.T) {
+	subTestKex2Provision(t, true)
+}
+
+func subTestKex2Provision(t *testing.T, enableSharedDH bool) {
 	// device X (provisioner) context:
 	tcX := SetupEngineTest(t, "kex2provision")
 	defer tcX.Cleanup()
+	tcX.Tp.EnableSharedDH = enableSharedDH
 
 	// provisioner needs to be logged in
 	userX := CreateAndSignupFakeUser(tcX, "login")
@@ -24,6 +33,7 @@ func TestKex2Provision(t *testing.T) {
 	// device Y (provisionee) context:
 	tcY := SetupEngineTest(t, "kex2provision")
 	defer tcY.Cleanup()
+	tcY.Tp.EnableSharedDH = enableSharedDH
 
 	var secretX kex2.Secret
 	if _, err := rand.Read(secretX[:]); err != nil {

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -307,6 +307,7 @@ func (e *PaperKeyGen) push(ctx *Context) error {
 }
 
 func (e *PaperKeyGen) makeSharedDHSecretKeyBoxes(ctx *Context) ([]libkb.SharedDHSecretKeyBox, error) {
+	e.G().Log.CDebugf(ctx.NetContext, "PaperKeyGen#makeSharedDHSecretKeyBoxes(enabled:%v)", e.G().Env.GetEnableSharedDH())
 	var sdhBoxes = []libkb.SharedDHSecretKeyBox{}
 	if e.G().Env.GetEnableSharedDH() {
 		sdhk, err := e.getSharedDHKeyring()
@@ -316,7 +317,7 @@ func (e *PaperKeyGen) makeSharedDHSecretKeyBoxes(ctx *Context) ([]libkb.SharedDH
 		if !sdhk.HasAnyKeys() {
 			// TODO if SDH_UPGRADE: may want to add a key here.
 		} else {
-			sdhBoxes, err = sdhk.PrepareBoxesForNewDevice(
+			sdhBoxes, err = sdhk.PrepareBoxesForNewDevice(ctx.NetContext,
 				e.encKey,            // receiver key: new paper key enc
 				e.arg.EncryptionKey) // sender key: this device enc
 			if err != nil {
@@ -324,6 +325,7 @@ func (e *PaperKeyGen) makeSharedDHSecretKeyBoxes(ctx *Context) ([]libkb.SharedDH
 			}
 		}
 	}
+	e.G().Log.CDebugf(ctx.NetContext, "PaperKeyGen#makeSharedDHSecretKeyBoxes -> %v", len(sdhBoxes))
 	return sdhBoxes, nil
 }
 

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -306,9 +306,9 @@ func (e *PaperKeyGen) push(ctx *Context) error {
 	return libkb.DelegatorAggregator(ctx.LoginContext, []libkb.Delegator{sigDel, sigEnc}, sdhBoxes)
 }
 
-func (e *PaperKeyGen) makeSharedDHSecretKeyBoxes(ctx *Context) ([]libkb.SharedDHSecretKeyBox, error) {
+func (e *PaperKeyGen) makeSharedDHSecretKeyBoxes(ctx *Context) ([]keybase1.SharedDHSecretKeyBox, error) {
 	e.G().Log.CDebugf(ctx.NetContext, "PaperKeyGen#makeSharedDHSecretKeyBoxes(enabled:%v)", e.G().Env.GetEnableSharedDH())
-	var sdhBoxes = []libkb.SharedDHSecretKeyBox{}
+	var sdhBoxes = []keybase1.SharedDHSecretKeyBox{}
 	if e.G().Env.GetEnableSharedDH() {
 		sdhk, err := e.getSharedDHKeyring()
 		if err != nil {

--- a/go/engine/shared_dh_test.go
+++ b/go/engine/shared_dh_test.go
@@ -34,10 +34,41 @@ func TestSharedDHSignupAndPullKeys(t *testing.T) {
 	require.NoError(t, err)
 	gen := libkb.SharedDHKeyGeneration(1)
 	require.Equal(t, kr.CurrentGeneration(), gen)
-	key := kr.SharedDHKey(gen)
+	key := kr.SharedDHKey(context.TODO(), gen)
 	require.NotNil(t, key)
 	require.NotNil(t, key.Private)
-	key2 := kr.SharedDHKey(libkb.SharedDHKeyGeneration(2))
+	key2 := kr.SharedDHKey(context.TODO(), libkb.SharedDHKeyGeneration(2))
+	require.Nil(t, key2)
+
+	kr2, err := kr.Update(context.Background())
+	require.Nil(t, err)
+	require.Equal(t, kr2.CurrentGeneration(), gen)
+
+}
+
+func TestSharedDHSignupPlusPaper(t *testing.T) {
+	tc := SetupEngineTest(t, "signup")
+	defer tc.Cleanup()
+	var err error
+
+	tc.Tp.EnableSharedDH = true
+
+	fu := CreateAndSignupFakeUserPaper(tc, "se")
+
+	if err = AssertLoggedIn(tc); err != nil {
+		t.Fatal(err)
+	}
+
+	kr, err := libkb.NewSharedDHKeyring(tc.G, fu.UID(), tc.G.Env.GetDeviceID())
+	require.NoError(t, err)
+	err = kr.Sync(context.Background())
+	require.NoError(t, err)
+	gen := libkb.SharedDHKeyGeneration(1)
+	require.Equal(t, kr.CurrentGeneration(), gen)
+	key := kr.SharedDHKey(context.TODO(), gen)
+	require.NotNil(t, key)
+	require.NotNil(t, key.Private)
+	key2 := kr.SharedDHKey(context.TODO(), libkb.SharedDHKeyGeneration(2))
 	require.Nil(t, key2)
 
 	kr2, err := kr.Update(context.Background())

--- a/go/engine/shared_dh_test.go
+++ b/go/engine/shared_dh_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	libkb "github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
 	require "github.com/stretchr/testify/require"
 	context "golang.org/x/net/context"
 )
@@ -32,12 +33,12 @@ func TestSharedDHSignupAndPullKeys(t *testing.T) {
 	require.NoError(t, err)
 	err = kr.Sync(context.Background())
 	require.NoError(t, err)
-	gen := libkb.SharedDHKeyGeneration(1)
+	gen := keybase1.SharedDHKeyGeneration(1)
 	require.Equal(t, kr.CurrentGeneration(), gen)
 	key := kr.SharedDHKey(context.TODO(), gen)
 	require.NotNil(t, key)
 	require.NotNil(t, key.Private)
-	key2 := kr.SharedDHKey(context.TODO(), libkb.SharedDHKeyGeneration(2))
+	key2 := kr.SharedDHKey(context.TODO(), keybase1.SharedDHKeyGeneration(2))
 	require.Nil(t, key2)
 
 	kr2, err := kr.Update(context.Background())
@@ -63,12 +64,12 @@ func TestSharedDHSignupPlusPaper(t *testing.T) {
 	require.NoError(t, err)
 	err = kr.Sync(context.Background())
 	require.NoError(t, err)
-	gen := libkb.SharedDHKeyGeneration(1)
+	gen := keybase1.SharedDHKeyGeneration(1)
 	require.Equal(t, kr.CurrentGeneration(), gen)
 	key := kr.SharedDHKey(context.TODO(), gen)
 	require.NotNil(t, key)
 	require.NotNil(t, key.Private)
-	key2 := kr.SharedDHKey(context.TODO(), libkb.SharedDHKeyGeneration(2))
+	key2 := kr.SharedDHKey(context.TODO(), keybase1.SharedDHKeyGeneration(2))
 	require.Nil(t, key2)
 
 	kr2, err := kr.Update(context.Background())

--- a/go/kex2/provisionee.go
+++ b/go/kex2/provisionee.go
@@ -35,7 +35,6 @@ type Provisionee interface {
 type ProvisioneeArg struct {
 	KexBaseArg
 	Provisionee Provisionee
-	V1Only      bool
 }
 
 func newProvisionee(arg ProvisioneeArg) *provisionee {
@@ -134,11 +133,7 @@ func (p *provisionee) startServer(s Secret) (err error) {
 	prots := []rpc.Protocol{
 		keybase1.Kex2ProvisioneeProtocol(p),
 	}
-	if !p.arg.V1Only {
-		prots = append(prots, keybase1.Kex2Provisionee2Protocol(p))
-	} else {
-		p.debug("| provisionee#startServer: skipping protocol V2 support")
-	}
+	prots = append(prots, keybase1.Kex2Provisionee2Protocol(p))
 	p.xp = rpc.NewTransport(p.conn, p.arg.Provisionee.GetLogFactory(), nil)
 	srv := rpc.NewServer(p.xp, nil)
 	for _, prot := range prots {

--- a/go/libkb/delegatekey.go
+++ b/go/libkb/delegatekey.go
@@ -31,7 +31,7 @@ type Delegator struct {
 	Ctime                 int64
 	DelegationType        DelegationType
 	Aggregated            bool // During aggregation we skip some steps (posting, updating some state)
-	SharedDHKeyGeneration SharedDHKeyGeneration
+	SharedDHKeyGeneration keybase1.SharedDHKeyGeneration
 
 	// Optional precalculated values used by KeyProof
 	LastSeqno   Seqno     // kex2 HandleDidCounterSign needs to sign subkey without a user but we know what the last seqno was

--- a/go/libkb/delegatekeyaggregator.go
+++ b/go/libkb/delegatekeyaggregator.go
@@ -5,12 +5,14 @@ package libkb
 
 import (
 	"errors"
+
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 // DelegatorAggregator manages delegating multiple keys in one post to the server
 
 // Run posts an array of delegations to the server. Keeping this simple as we don't need any state (yet)
-func DelegatorAggregator(lctx LoginContext, ds []Delegator, sdhBoxes []SharedDHSecretKeyBox) (err error) {
+func DelegatorAggregator(lctx LoginContext, ds []Delegator, sdhBoxes []keybase1.SharedDHSecretKeyBox) (err error) {
 	if len(ds) == 0 {
 		return errors.New("Empty delegators to aggregator")
 	}

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -726,7 +726,7 @@ func (s *SubkeyChainLink) insertIntoTable(tab *IdentityTable) {
 type SharedDHKeyChainLink struct {
 	GenericChainLink
 	kid        keybase1.KID
-	generation SharedDHKeyGeneration
+	generation keybase1.SharedDHKeyGeneration
 }
 
 func ParseSharedDHKeyChainLink(b GenericChainLink) (ret *SharedDHKeyChainLink, err error) {
@@ -738,7 +738,7 @@ func ParseSharedDHKeyChainLink(b GenericChainLink) (ret *SharedDHKeyChainLink, e
 	} else if g, err = section.AtKey("generation").GetInt(); err != nil {
 		err = ChainLinkError{fmt.Sprintf("Can't get generation for shared_dh @%s: %s", b.ToDebugString(), err)}
 	} else {
-		ret = &SharedDHKeyChainLink{b, kid, SharedDHKeyGeneration(g)}
+		ret = &SharedDHKeyChainLink{b, kid, keybase1.SharedDHKeyGeneration(g)}
 	}
 	return ret, err
 }

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -39,7 +39,7 @@ type KeySection struct {
 	RevSig                string
 	SigningUser           UserBasic
 	IncludePGPHash        bool
-	SharedDHKeyGeneration SharedDHKeyGeneration
+	SharedDHKeyGeneration keybase1.SharedDHKeyGeneration
 }
 
 func (arg KeySection) ToJSON() (*jsonw.Wrapper, error) {

--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -90,7 +90,7 @@ type ComputedKeyInfos struct {
 	// For each generation, the public KID that corresponds to the shared
 	// DH key. We're not keeping these in ComputedKeyFamily for now. For generation=0,
 	// we expect a nil KID
-	SharedDHKeys map[SharedDHKeyGeneration]keybase1.KID
+	SharedDHKeys map[keybase1.SharedDHKeyGeneration]keybase1.KID
 }
 
 // As returned by user/lookup.json
@@ -207,7 +207,7 @@ func (cki ComputedKeyInfos) ShallowCopy() *ComputedKeyInfos {
 		Sigs:          make(map[keybase1.SigID]*ComputedKeyInfo, len(cki.Sigs)),
 		Devices:       make(map[keybase1.DeviceID]*Device, len(cki.Devices)),
 		KIDToDeviceID: make(map[keybase1.KID]keybase1.DeviceID, len(cki.KIDToDeviceID)),
-		SharedDHKeys:  make(map[SharedDHKeyGeneration]keybase1.KID),
+		SharedDHKeys:  make(map[keybase1.SharedDHKeyGeneration]keybase1.KID),
 	}
 	for k, v := range cki.Infos {
 		ret.Infos[k] = v
@@ -285,7 +285,7 @@ func NewComputedKeyInfos(g *GlobalContext) *ComputedKeyInfos {
 		Sigs:          make(map[keybase1.SigID]*ComputedKeyInfo),
 		Devices:       make(map[keybase1.DeviceID]*Device),
 		KIDToDeviceID: make(map[keybase1.KID]keybase1.DeviceID),
-		SharedDHKeys:  make(map[SharedDHKeyGeneration]keybase1.KID),
+		SharedDHKeys:  make(map[keybase1.SharedDHKeyGeneration]keybase1.KID),
 	}
 }
 

--- a/go/libkb/shared_dh.go
+++ b/go/libkb/shared_dh.go
@@ -69,6 +69,10 @@ func NewSharedDHKeyring(g *GlobalContext, uid keybase1.UID, deviceID keybase1.De
 	}, nil
 }
 
+func (s *SharedDHKeyring) GetOwner() (keybase1.UID, keybase1.DeviceID) {
+	return s.uid, s.deviceID
+}
+
 // PrepareBoxesForNewDevice encrypts the shared keys for a new device.
 // The result boxes will be pushed to the server.
 func (s *SharedDHKeyring) PrepareBoxesForNewDevice(ctx context.Context, receiverKey NaclDHKeyPair, senderKey NaclDHKeyPair) (boxes []keybase1.SharedDHSecretKeyBox, err error) {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -849,6 +849,7 @@ func (u *UserPlusKeys) DeepCopy() UserPlusKeys {
 		PGPKeyCount:       u.PGPKeyCount,
 		Uvv:               u.Uvv,
 		DeletedDeviceKeys: append([]PublicKey{}, u.DeletedDeviceKeys...),
+		SharedDHKeys:      append([]SharedDHKey{}, u.SharedDHKeys...),
 	}
 }
 

--- a/go/protocol/keybase1/kex2provisionee2.go
+++ b/go/protocol/keybase1/kex2provisionee2.go
@@ -11,13 +11,14 @@ import (
 type Hello2Res struct {
 	EncryptionKey KID                    `codec:"encryptionKey" json:"encryptionKey"`
 	SigPayload    HelloRes               `codec:"sigPayload" json:"sigPayload"`
-	SdhBoxes      []SharedDhSecretKeyBox `codec:"sdhBoxes" json:"sdhBoxes"`
+	SdhBoxes      []SharedDHSecretKeyBox `codec:"sdhBoxes" json:"sdhBoxes"`
 }
 
-type SharedDhSecretKeyBox struct {
-	Generation  int    `codec:"generation" json:"generation"`
-	Box         string `codec:"box" json:"box"`
-	ReceiverKID KID    `codec:"receiverKID" json:"receiverKID"`
+type SharedDHKeyGeneration int
+type SharedDHSecretKeyBox struct {
+	Generation  SharedDHKeyGeneration `codec:"generation" json:"generation"`
+	Box         string                `codec:"box" json:"box"`
+	ReceiverKID KID                   `codec:"receiverKID" json:"receiver_kid"`
 }
 
 type Hello2Arg struct {
@@ -30,7 +31,7 @@ type Hello2Arg struct {
 type DidCounterSign2Arg struct {
 	Sig          []byte                 `codec:"sig" json:"sig"`
 	PpsEncrypted string                 `codec:"ppsEncrypted" json:"ppsEncrypted"`
-	SdhBoxes     []SharedDhSecretKeyBox `codec:"sdhBoxes" json:"sdhBoxes"`
+	SdhBoxes     []SharedDHSecretKeyBox `codec:"sdhBoxes" json:"sdhBoxes"`
 }
 
 type Kex2Provisionee2Interface interface {

--- a/go/protocol/keybase1/kex2provisionee2.go
+++ b/go/protocol/keybase1/kex2provisionee2.go
@@ -9,8 +9,15 @@ import (
 )
 
 type Hello2Res struct {
-	EncryptionKey KID      `codec:"encryptionKey" json:"encryptionKey"`
-	SigPayload    HelloRes `codec:"sigPayload" json:"sigPayload"`
+	EncryptionKey KID                    `codec:"encryptionKey" json:"encryptionKey"`
+	SigPayload    HelloRes               `codec:"sigPayload" json:"sigPayload"`
+	SdhBoxes      []SharedDhSecretKeyBox `codec:"sdhBoxes" json:"sdhBoxes"`
+}
+
+type SharedDhSecretKeyBox struct {
+	Generation  int    `codec:"generation" json:"generation"`
+	Box         string `codec:"box" json:"box"`
+	ReceiverKID KID    `codec:"receiverKID" json:"receiverKID"`
 }
 
 type Hello2Arg struct {
@@ -21,8 +28,9 @@ type Hello2Arg struct {
 }
 
 type DidCounterSign2Arg struct {
-	Sig          []byte `codec:"sig" json:"sig"`
-	PpsEncrypted string `codec:"ppsEncrypted" json:"ppsEncrypted"`
+	Sig          []byte                 `codec:"sig" json:"sig"`
+	PpsEncrypted string                 `codec:"ppsEncrypted" json:"ppsEncrypted"`
+	SdhBoxes     []SharedDhSecretKeyBox `codec:"sdhBoxes" json:"sdhBoxes"`
 }
 
 type Kex2Provisionee2Interface interface {

--- a/protocol/avdl/keybase1/kex2provisionee2.avdl
+++ b/protocol/avdl/keybase1/kex2provisionee2.avdl
@@ -13,9 +13,9 @@ protocol Kex2Provisionee2 {
   void didCounterSign2(bytes sig, string ppsEncrypted, array<SharedDhSecretKeyBox> sdhBoxes);
 
   record SharedDhSecretKeyBox {
-    int generation;
-    string                box;
-    KID                   receiverKID;
+    int    generation;
+    string box;
+    KID    receiverKID;
   }
 
 }

--- a/protocol/avdl/keybase1/kex2provisionee2.avdl
+++ b/protocol/avdl/keybase1/kex2provisionee2.avdl
@@ -6,16 +6,25 @@ protocol Kex2Provisionee2 {
   record Hello2Res {
     KID encryptionKey;
     HelloRes sigPayload;
-    array<SharedDhSecretKeyBox> sdhBoxes;
+    array<SharedDHSecretKeyBox> sdhBoxes;
   }
 
   Hello2Res hello2(UID uid, SessionToken token, CsrfToken csrf, string sigBody);
-  void didCounterSign2(bytes sig, string ppsEncrypted, array<SharedDhSecretKeyBox> sdhBoxes);
+  void didCounterSign2(bytes sig, string ppsEncrypted, array<SharedDHSecretKeyBox> sdhBoxes);
 
-  record SharedDhSecretKeyBox {
-    int    generation;
+  // SharedDHKeyGeneration describes which generation of DH key we're talking about.
+  // The sequence starts at 1, and should increment every time the shared DH key
+  // rotates, which is everytime a device is revoked.
+  @typedef("int")
+  @lint("ignore")
+  record SharedDHKeyGeneration {}
+
+  @lint("ignore")
+  record SharedDHSecretKeyBox {
+    SharedDHKeyGeneration generation;
     string box;
-    KID    receiverKID;
+    @jsonkey("receiver_kid")
+    KID receiverKID;
   }
 
 }

--- a/protocol/avdl/keybase1/kex2provisionee2.avdl
+++ b/protocol/avdl/keybase1/kex2provisionee2.avdl
@@ -6,8 +6,16 @@ protocol Kex2Provisionee2 {
   record Hello2Res {
     KID encryptionKey;
     HelloRes sigPayload;
+    array<SharedDhSecretKeyBox> sdhBoxes;
   }
 
   Hello2Res hello2(UID uid, SessionToken token, CsrfToken csrf, string sigBody);
-  void didCounterSign2(bytes sig, string ppsEncrypted);
+  void didCounterSign2(bytes sig, string ppsEncrypted, array<SharedDhSecretKeyBox> sdhBoxes);
+
+  record SharedDhSecretKeyBox {
+    int generation;
+    string                box;
+    KID                   receiverKID;
+  }
+
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3619,7 +3619,7 @@ export type HasServerKeysRes = {
 export type Hello2Res = {
   encryptionKey: KID,
   sigPayload: HelloRes,
-  sdhBoxes?: ?Array<SharedDhSecretKeyBox>,
+  sdhBoxes?: ?Array<SharedDHSecretKeyBox>,
 }
 
 export type HelloRes = string
@@ -3726,7 +3726,7 @@ export type KID = string
 export type Kex2Provisionee2DidCounterSign2RpcParam = Exact<{
   sig: bytes,
   ppsEncrypted: string,
-  sdhBoxes?: ?Array<SharedDhSecretKeyBox>
+  sdhBoxes?: ?Array<SharedDHSecretKeyBox>
 }>
 
 export type Kex2Provisionee2Hello2RpcParam = Exact<{
@@ -4405,8 +4405,10 @@ export type SharedDHKey = {
   kid: KID,
 }
 
-export type SharedDhSecretKeyBox = {
-  generation: int,
+export type SharedDHKeyGeneration = int
+
+export type SharedDHSecretKeyBox = {
+  generation: SharedDHKeyGeneration,
   box: string,
   receiverKID: KID,
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3619,6 +3619,7 @@ export type HasServerKeysRes = {
 export type Hello2Res = {
   encryptionKey: KID,
   sigPayload: HelloRes,
+  sdhBoxes?: ?Array<SharedDhSecretKeyBox>,
 }
 
 export type HelloRes = string
@@ -3724,7 +3725,8 @@ export type KID = string
 
 export type Kex2Provisionee2DidCounterSign2RpcParam = Exact<{
   sig: bytes,
-  ppsEncrypted: string
+  ppsEncrypted: string,
+  sdhBoxes?: ?Array<SharedDhSecretKeyBox>
 }>
 
 export type Kex2Provisionee2Hello2RpcParam = Exact<{
@@ -4401,6 +4403,12 @@ export type SessionToken = string
 export type SharedDHKey = {
   gen: int,
   kid: KID,
+}
+
+export type SharedDhSecretKeyBox = {
+  generation: int,
+  box: string,
+  receiverKID: KID,
 }
 
 export type Sig = {

--- a/protocol/json/keybase1/kex2provisionee2.json
+++ b/protocol/json/keybase1/kex2provisionee2.json
@@ -22,7 +22,7 @@
         {
           "type": {
             "type": "array",
-            "items": "SharedDhSecretKeyBox"
+            "items": "SharedDHSecretKeyBox"
           },
           "name": "sdhBoxes"
         }
@@ -30,10 +30,17 @@
     },
     {
       "type": "record",
-      "name": "SharedDhSecretKeyBox",
+      "name": "SharedDHKeyGeneration",
+      "fields": [],
+      "typedef": "int",
+      "lint": "ignore"
+    },
+    {
+      "type": "record",
+      "name": "SharedDHSecretKeyBox",
       "fields": [
         {
-          "type": "int",
+          "type": "SharedDHKeyGeneration",
           "name": "generation"
         },
         {
@@ -42,9 +49,11 @@
         },
         {
           "type": "KID",
-          "name": "receiverKID"
+          "name": "receiverKID",
+          "jsonkey": "receiver_kid"
         }
-      ]
+      ],
+      "lint": "ignore"
     }
   ],
   "messages": {
@@ -83,7 +92,7 @@
           "name": "sdhBoxes",
           "type": {
             "type": "array",
-            "items": "SharedDhSecretKeyBox"
+            "items": "SharedDHSecretKeyBox"
           }
         }
       ],

--- a/protocol/json/keybase1/kex2provisionee2.json
+++ b/protocol/json/keybase1/kex2provisionee2.json
@@ -18,6 +18,31 @@
         {
           "type": "HelloRes",
           "name": "sigPayload"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "SharedDhSecretKeyBox"
+          },
+          "name": "sdhBoxes"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "SharedDhSecretKeyBox",
+      "fields": [
+        {
+          "type": "int",
+          "name": "generation"
+        },
+        {
+          "type": "string",
+          "name": "box"
+        },
+        {
+          "type": "KID",
+          "name": "receiverKID"
         }
       ]
     }
@@ -53,6 +78,13 @@
         {
           "name": "ppsEncrypted",
           "type": "string"
+        },
+        {
+          "name": "sdhBoxes",
+          "type": {
+            "type": "array",
+            "items": "SharedDhSecretKeyBox"
+          }
         }
       ],
       "response": null

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3619,7 +3619,7 @@ export type HasServerKeysRes = {
 export type Hello2Res = {
   encryptionKey: KID,
   sigPayload: HelloRes,
-  sdhBoxes?: ?Array<SharedDhSecretKeyBox>,
+  sdhBoxes?: ?Array<SharedDHSecretKeyBox>,
 }
 
 export type HelloRes = string
@@ -3726,7 +3726,7 @@ export type KID = string
 export type Kex2Provisionee2DidCounterSign2RpcParam = Exact<{
   sig: bytes,
   ppsEncrypted: string,
-  sdhBoxes?: ?Array<SharedDhSecretKeyBox>
+  sdhBoxes?: ?Array<SharedDHSecretKeyBox>
 }>
 
 export type Kex2Provisionee2Hello2RpcParam = Exact<{
@@ -4405,8 +4405,10 @@ export type SharedDHKey = {
   kid: KID,
 }
 
-export type SharedDhSecretKeyBox = {
-  generation: int,
+export type SharedDHKeyGeneration = int
+
+export type SharedDHSecretKeyBox = {
+  generation: SharedDHKeyGeneration,
   box: string,
   receiverKID: KID,
 }

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3619,6 +3619,7 @@ export type HasServerKeysRes = {
 export type Hello2Res = {
   encryptionKey: KID,
   sigPayload: HelloRes,
+  sdhBoxes?: ?Array<SharedDhSecretKeyBox>,
 }
 
 export type HelloRes = string
@@ -3724,7 +3725,8 @@ export type KID = string
 
 export type Kex2Provisionee2DidCounterSign2RpcParam = Exact<{
   sig: bytes,
-  ppsEncrypted: string
+  ppsEncrypted: string,
+  sdhBoxes?: ?Array<SharedDhSecretKeyBox>
 }>
 
 export type Kex2Provisionee2Hello2RpcParam = Exact<{
@@ -4401,6 +4403,12 @@ export type SessionToken = string
 export type SharedDHKey = {
   gen: int,
   kid: KID,
+}
+
+export type SharedDhSecretKeyBox = {
+  generation: int,
+  box: string,
+  receiverKID: KID,
 }
 
 export type Sig = {


### PR DESCRIPTION
Adds support for kex with SharedDH keys.

`keybase device add` and provisioning in the gui seem to work. Yesterday I had trouble with stale upaks and `LoginContext` locking, but today I haven't been able to trigger those problems, so they may be lurking.

How it works: In the `CounterSign` the provisioner (who now has the provisionee encryption kid) syncs its `SharedDHKeyring` and then prepares boxes for the provisioner. It then sends those boxes over the kex-channel to the provisioner who posts it along with the other sigchain stuff in their `sig/multi`. The boxes are already encrypted for the provisionee, so they are not encrypted again. They are also not checked by the provisionee, maybe that would be good.