### PR TITLE
Fix snippet calculation for edits, deletes, attachments

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -5,6 +5,7 @@ import * as Creators from './creators'
 import * as Shared from './shared'
 import {List, Map} from 'immutable'
 import {TlfKeysTLFIdentifyBehavior} from '../../constants/types/flow-types'
+import {CommonMessageType} from '../../constants/types/flow-types-chat'
 import {call, put, select, race, fork} from 'redux-saga/effects'
 import {chatTab} from '../../constants/tabs'
 import {delay} from 'redux-saga'
@@ -295,6 +296,9 @@ function _conversationLocalToInboxState (c: ?ChatTypes.ConversationLocal): ?Cons
   const toShow = List(c.maxMessages || [])
     .filter(m => m.valid && m.state === ChatTypes.LocalMessageUnboxedState.valid)
     .map((m: any) => ({body: m.valid.messageBody, time: m.valid.serverHeader.ctime}))
+    .filter(m => m.body.messageType === CommonMessageType.text ||
+      m.body.messageType === CommonMessageType.attachment ||
+      m.body.messageType === CommonMessageType.edit)
     .sort((a, b) => b.time - a.time)
     .map((message: {time: number, body: ?ChatTypes.MessageBody}) => ({
       snippet: Constants.makeSnippet(message.body),

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -5,7 +5,6 @@ import * as Creators from './creators'
 import * as Shared from './shared'
 import {List, Map} from 'immutable'
 import {TlfKeysTLFIdentifyBehavior} from '../../constants/types/flow-types'
-import {CommonMessageType} from '../../constants/types/flow-types-chat'
 import {call, put, select, race, fork} from 'redux-saga/effects'
 import {chatTab} from '../../constants/tabs'
 import {delay} from 'redux-saga'
@@ -296,9 +295,9 @@ function _conversationLocalToInboxState (c: ?ChatTypes.ConversationLocal): ?Cons
   const toShow = List(c.maxMessages || [])
     .filter(m => m.valid && m.state === ChatTypes.LocalMessageUnboxedState.valid)
     .map((m: any) => ({body: m.valid.messageBody, time: m.valid.serverHeader.ctime}))
-    .filter(m => m.body.messageType === CommonMessageType.text ||
-      m.body.messageType === CommonMessageType.attachment ||
-      m.body.messageType === CommonMessageType.edit)
+    .filter(m => m.body.messageType === ChatTypes.CommonMessageType.text ||
+      m.body.messageType === ChatTypes.CommonMessageType.attachment ||
+      m.body.messageType === ChatTypes.CommonMessageType.edit)
     .sort((a, b) => b.time - a.time)
     .map((message: {time: number, body: ?ChatTypes.MessageBody}) => ({
       snippet: Constants.makeSnippet(message.body),

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -295,9 +295,11 @@ function _conversationLocalToInboxState (c: ?ChatTypes.ConversationLocal): ?Cons
   const toShow = List(c.maxMessages || [])
     .filter(m => m.valid && m.state === ChatTypes.LocalMessageUnboxedState.valid)
     .map((m: any) => ({body: m.valid.messageBody, time: m.valid.serverHeader.ctime}))
-    .filter(m => m.body.messageType === ChatTypes.CommonMessageType.text ||
-      m.body.messageType === ChatTypes.CommonMessageType.attachment ||
-      m.body.messageType === ChatTypes.CommonMessageType.edit)
+    .filter(m => [
+      ChatTypes.CommonMessageType.attachment,
+      ChatTypes.CommonMessageType.edit,
+      ChatTypes.CommonMessageType.text,
+    ].includes(m.body.messageType))
     .sort((a, b) => b.time - a.time)
     .map((message: {time: number, body: ?ChatTypes.MessageBody}) => ({
       snippet: Constants.makeSnippet(message.body),

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -496,6 +496,8 @@ function makeSnippet (messageBody: ?MessageBody): ?string {
       return textSnippet(messageBody.text && messageBody.text.body, 100)
     case ChatTypes.CommonMessageType.attachment:
       return messageBody.attachment ? textSnippet(messageBody.attachment.object.title, 100) : 'Attachment'
+    case ChatTypes.CommonMessageType.edit:
+      return textSnippet(messageBody.edit && messageBody.edit.body, 100)
     default:
       return null
   }


### PR DESCRIPTION
@keybase/react-hackers 

We were rendering blank snippets for:

* deletes: because we were using the deletion message as the snippet message, instead of ignoring it.

* edits: because we weren't pulling the edited text out of the edit message.

* attachments: because we used the "attachmentuploaded" message for the snippet rather than "attachment" message.

Deletes and attachments are fixed by limiting the types of message we consider for snippets, and edits are fixed by pulling the post-edit text out of the edit message.