### PR TITLE
Implement client support for fast / offline bootstrap RPC

### DIFF
--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -37,7 +37,7 @@ function messageOutboxIDSelector (state: TypedState, conversationIDKey: Constant
 }
 
 function devicenameSelector (state: TypedState) {
-  return state.config && state.config.extendedConfig && state.config.extendedConfig.device && state.config.extendedConfig.device.name
+  return state.config && state.config.deviceName
 }
 
 function selectedInboxSelector (state: TypedState, conversationIDKey: Constants.ConversationIDKey) {
@@ -76,21 +76,7 @@ function * clientHeader (messageType: ChatTypes.MessageType, conversationIDKey: 
     return
   }
 
-  const configSelector = (state: TypedState) => {
-    try {
-      return {
-        // $FlowIssue doesn't understand try
-        deviceID: state.config.extendedConfig.device.deviceID,
-        uid: state.config.uid,
-      }
-    } catch (_) {
-      return {
-        deviceID: '',
-        uid: '',
-      }
-    }
-  }
-
+  const configSelector = ({config: {deviceID, uid}}: TypedState) => ({deviceID, uid})
   const {deviceID, uid}: {deviceID: string, uid: string} = ((yield select(configSelector)): any)
 
   if (!deviceID || !uid) {

--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as Constants from '../../constants/config'
 import engine from '../../engine'
-import {CommonClientType, configGetConfigRpc, configGetExtendedStatusRpc, configGetCurrentStatusRpc, configWaitForClientRpc, userListTrackingRpc, userListTrackersByNameRpc, userLoadUncheckedUserSummariesRpc} from '../../constants/types/flow-types'
+import {CommonClientType, configGetBootstrapStatusRpc, configGetConfigRpc, configGetExtendedStatusRpc, configGetCurrentStatusRpc, configWaitForClientRpc} from '../../constants/types/flow-types'
 import {isMobile} from '../../constants/platform'
 import {listenForKBFSNotifications} from '../../actions/notifications'
 import {navBasedOnLoginState} from '../../actions/login'
@@ -46,56 +46,8 @@ function isFollower (getState: any, username: string): boolean {
   return !!getState().config.followers[username]
 }
 
-const getMyFollowers = (username: string): AsyncAction => dispatch => {
-  userListTrackersByNameRpc({
-    callback: (error, trackers) => {
-      if (error) {
-        return
-      }
-
-      if (trackers && trackers.length) {
-        const uids = trackers.map(t => t.tracker)
-        userLoadUncheckedUserSummariesRpc({
-          callback: (error, summaries) => {
-            if (error) {
-              return
-            }
-
-            const followers = {}
-            summaries && summaries.forEach(s => { followers[s.username] = true })
-            dispatch({
-              payload: {followers},
-              type: Constants.setFollowers,
-            })
-          },
-          param: {uids},
-        })
-      }
-    },
-    param: {username},
-  })
-}
-
 function isFollowing (getState: () => any, username: string) : boolean {
   return !!getState().config.following[username]
-}
-
-const getMyFollowing = (username: string): AsyncAction => dispatch => {
-  userListTrackingRpc({
-    callback: (error, summaries) => {
-      if (error) {
-        return
-      }
-
-      const following = {}
-      summaries && summaries.forEach(s => { following[s.username] = true })
-      dispatch({
-        payload: {following},
-        type: Constants.setFollowing,
-      })
-    },
-    param: {assertion: username, filter: ''},
-  })
 }
 
 const waitForKBFS = (): AsyncAction => dispatch => (
@@ -174,12 +126,7 @@ const bootstrap = (opts?: BootstrapOptions = {}): AsyncAction => (dispatch, getS
   } else {
     console.log('[bootstrap] performing bootstrap...')
     Promise.all(
-      [dispatch(getCurrentStatus()), dispatch(getExtendedStatus()), dispatch(getConfig()), dispatch(waitForKBFS())]).then(([username]) => {
-        if (username) {
-          dispatch(getMyFollowers(username))
-          dispatch(getMyFollowing(username))
-        }
-        dispatch({payload: null, type: Constants.bootstrapped})
+      [dispatch(getBootstrapStatus()), dispatch(waitForKBFS())]).then(() => {
         dispatch(listenForKBFSNotifications())
         if (!opts.isReconnect) {
           dispatch(navBasedOnLoginState())
@@ -200,6 +147,26 @@ const bootstrap = (opts?: BootstrapOptions = {}): AsyncAction => (dispatch, getS
       })
   }
 }
+
+const getBootstrapStatus = (): AsyncAction => dispatch => (
+  new Promise((resolve, reject) => {
+    configGetBootstrapStatusRpc({
+      callback: (error, bootstrapStatus) => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        dispatch({
+          payload: {bootstrapStatus},
+          type: Constants.bootstrapLoaded,
+        })
+
+        resolve(bootstrapStatus)
+      },
+    })
+  })
+)
 
 const getCurrentStatus = (): AsyncAction => dispatch => (
   new Promise((resolve, reject) => {
@@ -227,6 +194,8 @@ const updateFollowing = (username: string, isTracking: boolean): UpdateFollowing
 
 export {
   bootstrap,
+  getConfig,
+  getCurrentStatus,
   getExtendedStatus,
   isFollower,
   isFollowing,

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -34,31 +34,28 @@ const waitingForResponse = (waiting: boolean) : TypedAction<'login:waitingForRes
 )
 
 const navBasedOnLoginState = (): AsyncAction => (dispatch, getState) => {
-  const {config: {extendedConfig, initialTab, launchedViaPush, status}, login: {justDeletedSelf}} = getState()
+  const {config: {loggedIn, registered, initialTab, launchedViaPush}, login: {justDeletedSelf}} = getState()
 
-  // No status?
-  if (!status || !Object.keys(status).length || !extendedConfig || !Object.keys(extendedConfig).length || justDeletedSelf) { // Not provisioned?
+  if (justDeletedSelf) {
     dispatch(navigateTo([loginTab]))
-  } else {
-    if (status.loggedIn) { // logged in
-      if (overrideLoggedInTab) {
-        console.log('Loading overridden logged in tab')
-        dispatch(navigateTo([overrideLoggedInTab]))
-      } else if (initialTab && isValidInitialTab(initialTab)) {
-        // only do this once
-        dispatch(setInitialTab(null))
-        if (!launchedViaPush) {
-          dispatch(navigateTo([initialTab]))
-        }
-      } else {
-        dispatch(navigateTo([profileTab]))
+  } else if (loggedIn) {
+    if (overrideLoggedInTab) {
+      console.log('Loading overridden logged in tab')
+      dispatch(navigateTo([overrideLoggedInTab]))
+    } else if (initialTab && isValidInitialTab(initialTab)) {
+      // only do this once
+      dispatch(setInitialTab(null))
+      if (!launchedViaPush) {
+        dispatch(navigateTo([initialTab]))
       }
-    } else if (status.registered) { // relogging in
-      dispatch(getAccounts())
-      dispatch(navigateTo(['login'], [loginTab]))
-    } else { // no idea
-      dispatch(navigateTo([loginTab]))
+    } else {
+      dispatch(navigateTo([profileTab]))
     }
+  } else if (registered) { // relogging in
+    dispatch(getAccounts())
+    dispatch(navigateTo(['login'], [loginTab]))
+  } else { // no idea
+    dispatch(navigateTo([loginTab]))
   }
 }
 

--- a/shared/actions/login/index.js
+++ b/shared/actions/login/index.js
@@ -37,8 +37,7 @@ const navBasedOnLoginState = (): AsyncAction => (dispatch, getState) => {
   const {config: {extendedConfig, initialTab, launchedViaPush, status}, login: {justDeletedSelf}} = getState()
 
   // No status?
-  if (!status || !Object.keys(status).length || !extendedConfig || !Object.keys(extendedConfig).length ||
-    !extendedConfig.defaultDeviceID || justDeletedSelf) { // Not provisioned?
+  if (!status || !Object.keys(status).length || !extendedConfig || !Object.keys(extendedConfig).length || justDeletedSelf) { // Not provisioned?
     dispatch(navigateTo([loginTab]))
   } else {
     if (status.loggedIn) { // logged in

--- a/shared/actions/push.js
+++ b/shared/actions/push.js
@@ -86,13 +86,12 @@ function * savePushTokenSaga (): SagaGenerator<any, any> {
     const pushSelector = ({push: {token, tokenType}}: TypedState) => ({token, tokenType})
     const {token, tokenType} = ((yield select(pushSelector)): any)
 
-    const extendedConfigSelector = ({config: {extendedConfig}}: TypedState) => extendedConfig
-    const extendedConfig = ((yield select(extendedConfigSelector)): any)
+    const deviceIDSelector = ({config: {deviceID}}: TypedState) => deviceID
+    const deviceID = ((yield select(deviceIDSelector)): any)
 
-    if (!extendedConfig || !extendedConfig.defaultDeviceID) {
-      throw new Error('No device available for saving push token:', extendedConfig)
+    if (!deviceID) {
+      throw new Error('No device available for saving push token')
     }
-    const deviceID = extendedConfig.defaultDeviceID
     if (!token) {
       throw new Error('No push token available to save')
     }

--- a/shared/constants/config.js
+++ b/shared/constants/config.js
@@ -3,15 +3,16 @@ import {uniq} from 'lodash'
 import {runMode} from './platform'
 
 import type {Tab} from './tabs'
+import type {BootstrapStatus} from './types/flow-types'
 import type {NoErrorTypedAction} from './types/flux'
 
 // TODO remove action type constants. Type actions
 const MAX_BOOTSTRAP_TRIES = 3
 const bootstrapAttemptFailed = 'config:bootstrapAttemptFailed'
 const bootstrapFailed = 'config:bootstrapFailed'
+const bootstrapLoaded = 'config:bootstrapLoaded'
 const bootstrapRetry = 'config:bootstrapRetry'
 const bootstrapRetryDelay = 10 * 1000
-const bootstrapped = 'config:bootstrapped'
 const changeKBFSPath = 'config:changeKBFSPath'
 const configLoaded = 'config:configLoaded'
 const daemonError = 'config:daemonError'
@@ -28,6 +29,7 @@ const setLaunchedViaPush = 'config:setLaunchedViaPush'
 const statusLoaded = 'config:statusLoaded'
 const updateFollowing = 'config:updateFollowing'
 
+export type BootstrapLoaded = NoErrorTypedAction<'config:bootstrapLoaded', {bootstrapStatus: BootstrapStatus}>
 export type DaemonError = NoErrorTypedAction<'config:daemonError', {daemonError: ?Error}>
 export type UpdateFollowing = NoErrorTypedAction<'config:updateFollowing', {username: string, isTracking: boolean}>
 export type SetInitialTab = NoErrorTypedAction<'config:setInitialTab', {tab: ?Tab}>
@@ -49,9 +51,9 @@ export {
   MAX_BOOTSTRAP_TRIES,
   bootstrapAttemptFailed,
   bootstrapFailed,
+  bootstrapLoaded,
   bootstrapRetry,
   bootstrapRetryDelay,
-  bootstrapped,
   changeKBFSPath,
   configLoaded,
   daemonError,

--- a/shared/login/login/index.js
+++ b/shared/login/login/index.js
@@ -49,7 +49,7 @@ class Login extends Component {
 export default connect(
   (state: TypedState) => {
     const users = state.login.configuredAccounts && state.login.configuredAccounts.map(c => c.username) || []
-    let lastUser = state.config.username
+    let lastUser = state.config.extendedConfig && state.config.extendedConfig.defaultUsername
 
     if (users.indexOf(lastUser) === -1 && users.length) {
       lastUser = users[0]

--- a/shared/main-shared.native.js
+++ b/shared/main-shared.native.js
@@ -98,7 +98,7 @@ const connector = connect(
     dumbFullscreen,
     folderBadge: privateBadge + publicBadge,
     menuBadgeCount,
-    mountPush: extendedConfig && !!extendedConfig.defaultDeviceID && loggedIn && bootStatus === 'bootStatusBootstrapped',
+    mountPush: loggedIn && bootStatus === 'bootStatusBootstrapped',
     routeDef,
     routeState,
     showPushPrompt: permissionsPrompt,

--- a/shared/main.desktop.js
+++ b/shared/main.desktop.js
@@ -10,7 +10,6 @@ import type {RouteDefNode, RouteStateNode, Path} from './route-tree'
 type Props = {
   menuBadge: boolean,
   menuBadgeCount: number,
-  provisioned: boolean,
   username: string,
   navigateUp: () => void,
   routeDef: RouteDefNode,
@@ -49,7 +48,6 @@ export default connect(
     notifications: {menuBadge, menuBadgeCount}}) => ({
       routeDef,
       routeState,
-      provisioned: extendedConfig && !!extendedConfig.defaultDeviceID,
       username,
       menuBadge,
       menuBadgeCount,

--- a/shared/nav.desktop.js
+++ b/shared/nav.desktop.js
@@ -53,7 +53,6 @@ export default connect(
     notifications: {menuBadge, menuNotifications},
     gregor: {reachability},
   }) => ({
-    provisioned: extendedConfig && !!extendedConfig.defaultDeviceID,
     username,
     folderBadge: menuNotifications.folderBadge,
     chatBadge: menuNotifications.chatBadge,

--- a/shared/nav.js.flow
+++ b/shared/nav.js.flow
@@ -8,7 +8,6 @@ import type {Tab} from './constants/tabs'
 export type Props = {
   appFocused: boolean,
   menuBadge: boolean,
-  provisioned: boolean,
   username: string,
   switchTab: (tab: Tab) => void,
   navigateUp: () => void,

--- a/shared/nav.native.js
+++ b/shared/nav.native.js
@@ -194,7 +194,6 @@ export default connect(
     chatBadge: menuNotifications.chatBadge,
     dumbFullscreen,
     folderBadge: menuNotifications.folderBadge,
-    provisioned: extendedConfig && !!extendedConfig.defaultDeviceID,
     username,
     hideNav: routeSelected === loginTab,
     reachability,


### PR DESCRIPTION
This replaces our old bootstrap process with a single RPC with a smaller response. This RPC also returns useful results while offline, allowing us to load the chat UI from a cold start without a connection.

@keybase/react-hackers 