### PR TITLE
Offline bootstrap, current session

### DIFF
--- a/go/engine/bootstrap.go
+++ b/go/engine/bootstrap.go
@@ -61,15 +61,8 @@ func (e *Bootstrap) Run(ctx *Context) error {
 			return
 		}
 
-		// e.status.Uid = a.GetUID()
 		e.status.Uid = e.G().ActiveDevice.UID()
 		e.G().Log.Debug("Bootstrap: uid = %s", e.status.Uid)
-		/*
-			unp := a.LocalSession().GetUsername()
-			if unp != nil {
-				e.status.Username = unp.String()
-			}
-		*/
 		e.status.Username = e.G().Env.GetUsername().String()
 		e.G().Log.Debug("Bootstrap: username = %s", e.status.Username)
 

--- a/go/engine/bootstrap.go
+++ b/go/engine/bootstrap.go
@@ -57,14 +57,21 @@ func (e *Bootstrap) Run(ctx *Context) error {
 
 		e.status.LoggedIn = in
 		if !e.status.LoggedIn {
+			e.G().Log.Debug("Bootstrap: not logged in")
 			return
 		}
 
-		e.status.Uid = a.GetUID()
-		unp := a.LocalSession().GetUsername()
-		if unp != nil {
-			e.status.Username = unp.String()
-		}
+		// e.status.Uid = a.GetUID()
+		e.status.Uid = e.G().ActiveDevice.UID()
+		e.G().Log.Debug("Bootstrap: uid = %s", e.status.Uid)
+		/*
+			unp := a.LocalSession().GetUsername()
+			if unp != nil {
+				e.status.Username = unp.String()
+			}
+		*/
+		e.status.Username = e.G().Env.GetUsername().String()
+		e.G().Log.Debug("Bootstrap: username = %s", e.status.Username)
 
 		e.status.DeviceID = a.GetDeviceID()
 		e.status.DeviceName = e.G().ActiveDevice.Name()

--- a/go/engine/bootstrap.go
+++ b/go/engine/bootstrap.go
@@ -41,9 +41,40 @@ func (e *Bootstrap) SubConsumers() []libkb.UIConsumer {
 	return nil
 }
 
+/*
+  record BootstrapStatus {
+    UID uid;
+    string username;
+    DeviceID deviceID;
+    string deviceName;
+    boolean loggedIn;
+    array<UserSummary> following;
+    array<UserSummary> followers;
+  }
+*/
+
 // Run starts the engine.
 func (e *Bootstrap) Run(ctx *Context) error {
-	panic("Run not yet implemented")
+	var gerr error
+	e.G().LoginState().Account(func(a *libkb.Account) {
+		var in bool
+		in, gerr = a.LoggedInProvisioned()
+		if gerr != nil {
+			e.G().Log.Debug("Bootstrap: LoggedInProvisioned error: %s", gerr)
+			return
+		}
+
+		e.status.LoggedIn = in
+
+		if !e.status.LoggedIn {
+			return
+		}
+	}, "Bootstrap")
+
+	if gerr != nil {
+		return gerr
+	}
+	return nil
 }
 
 func (e *Bootstrap) Status() keybase1.BootstrapStatus {

--- a/go/engine/bootstrap.go
+++ b/go/engine/bootstrap.go
@@ -1,0 +1,51 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import (
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// Bootstrap is an engine.
+type Bootstrap struct {
+	libkb.Contextified
+	status keybase1.BootstrapStatus
+}
+
+// NewBootstrap creates a Bootstrap engine.
+func NewBootstrap(g *libkb.GlobalContext) *Bootstrap {
+	return &Bootstrap{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+// Name is the unique engine name.
+func (e *Bootstrap) Name() string {
+	return "Bootstrap"
+}
+
+// GetPrereqs returns the engine prereqs.
+func (e *Bootstrap) Prereqs() Prereqs {
+	return Prereqs{}
+}
+
+// RequiredUIs returns the required UIs.
+func (e *Bootstrap) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *Bootstrap) SubConsumers() []libkb.UIConsumer {
+	return nil
+}
+
+// Run starts the engine.
+func (e *Bootstrap) Run(ctx *Context) error {
+	panic("Run not yet implemented")
+}
+
+func (e *Bootstrap) Status() keybase1.BootstrapStatus {
+	return e.status
+}

--- a/go/engine/bootstrap.go
+++ b/go/engine/bootstrap.go
@@ -44,6 +44,8 @@ func (e *Bootstrap) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *Bootstrap) Run(ctx *Context) error {
+	e.status.Registered = e.signedUp()
+
 	var gerr error
 	e.G().LoginState().Account(func(a *libkb.Account) {
 		var in bool
@@ -65,7 +67,7 @@ func (e *Bootstrap) Run(ctx *Context) error {
 		}
 
 		e.status.DeviceID = a.GetDeviceID()
-		// device name...get from ActiveDevice?
+		e.status.DeviceName = e.G().ActiveDevice.Name()
 
 		ts := libkb.NewTracker2Syncer(e.G(), e.status.Uid, true)
 		if err := libkb.RunSyncerCached(ts, e.status.Uid); err != nil {
@@ -90,6 +92,18 @@ func (e *Bootstrap) Run(ctx *Context) error {
 	}
 
 	return nil
+}
+
+// signedUp is true if there's a uid in config.json.
+func (e *Bootstrap) signedUp() bool {
+	cr := e.G().Env.GetConfig()
+	if cr == nil {
+		return false
+	}
+	if uid := cr.GetUID(); uid.Exists() {
+		return true
+	}
+	return false
 }
 
 func (e *Bootstrap) Status() keybase1.BootstrapStatus {

--- a/go/engine/bootstrap_test.go
+++ b/go/engine/bootstrap_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 )
 
-func TestLoginOffline(t *testing.T) {
+func TestBootstrap(t *testing.T) {
 	tc := SetupEngineTest(t, "login")
 	defer tc.Cleanup()
 
@@ -20,6 +20,11 @@ func TestLoginOffline(t *testing.T) {
 	// do a upak load to make sure it is cached
 	arg := libkb.NewLoadUserByUIDArg(context.TODO(), tc.G, u1.UID())
 	tc.G.GetUPAKLoader().Load(arg)
+
+	// get the status values
+	uid := tc.G.Env.GetUID()
+	username := tc.G.Env.GetUsername()
+	deviceID := tc.G.Env.GetDeviceID()
 
 	// Simulate restarting the service by wiping out the
 	// passphrase stream cache and cached secret keys
@@ -40,23 +45,30 @@ func TestLoginOffline(t *testing.T) {
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
-	uid, deviceID, skey, ekey := tc.G.ActiveDevice.AllFields()
-	if uid.IsNil() {
-		t.Errorf("uid is nil, expected it to exist")
-	}
-	if !uid.Equal(u1.UID()) {
-		t.Errorf("uid: %q, expected %q", uid, u1.UID())
-	}
 
-	if deviceID.IsNil() {
-		t.Errorf("deviceID is nil, expected it to exist")
+	beng := NewBootstrap(tc.G)
+	bctx := &Context{NetContext: context.Background()}
+	if err := RunEngine(beng, bctx); err != nil {
+		t.Fatal(err)
 	}
+	status := beng.Status()
 
-	if skey == nil {
-		t.Errorf("signing key is nil, expected it to exist")
+	if !status.Registered {
+		t.Error("registered false")
 	}
-
-	if ekey == nil {
-		t.Errorf("encryption key is nil, expected it to exist")
+	if !status.LoggedIn {
+		t.Error("not logged in")
+	}
+	if !status.Uid.Equal(uid) {
+		t.Errorf("uid: %s, expected %s", status.Uid, uid)
+	}
+	if status.Username != username.String() {
+		t.Errorf("username: %q, expected %q", status.Username, username)
+	}
+	if !status.DeviceID.Eq(deviceID) {
+		t.Errorf("device id: %q, expected %q", status.DeviceID, deviceID)
+	}
+	if status.DeviceName != defaultDeviceName {
+		t.Errorf("device name: %q, expected %q", status.DeviceName, defaultDeviceName)
 	}
 }

--- a/go/engine/bootstrap_test.go
+++ b/go/engine/bootstrap_test.go
@@ -59,8 +59,14 @@ func TestBootstrap(t *testing.T) {
 	if !status.LoggedIn {
 		t.Error("not logged in")
 	}
+	if status.Uid.IsNil() {
+		t.Errorf("uid nil")
+	}
 	if !status.Uid.Equal(uid) {
 		t.Errorf("uid: %s, expected %s", status.Uid, uid)
+	}
+	if status.Username == "" {
+		t.Errorf("username empty")
 	}
 	if status.Username != username.String() {
 		t.Errorf("username: %q, expected %q", status.Username, username)

--- a/go/engine/login_offline.go
+++ b/go/engine/login_offline.go
@@ -179,6 +179,13 @@ func (e *LoginOffline) run(ctx *Context) error {
 			gerr = err
 			return
 		}
+
+		// set the device name from the sibkey description
+		if err := a.SetDeviceName(sibkey.DeviceDescription); err != nil {
+			e.G().Log.Debug("LoginOffline: failed to set device name: %s", err)
+			gerr = err
+			return
+		}
 	}, "LoginOffline")
 
 	if aerr != nil {

--- a/go/engine/login_offline_test.go
+++ b/go/engine/login_offline_test.go
@@ -26,6 +26,7 @@ func TestLoginOffline(t *testing.T) {
 	tc.G.LoginState().Account(func(a *libkb.Account) {
 		a.ClearStreamCache()
 		a.ClearCachedSecretKeys()
+		a.UnloadLocalSession()
 	}, "account - clear")
 	tc.G.GetUPAKLoader().ClearMemory()
 

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -64,6 +64,29 @@ func TestLoginUnlocksDeviceKeys(t *testing.T) {
 	assertDeviceKeysCached(tc)
 }
 
+func TestLoginActiveDevice(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	u1 := CreateAndSignupFakeUser(tc, "login")
+	Logout(tc)
+	u1.LoginOrBust(tc)
+
+	assertDeviceKeysCached(tc)
+
+	if tc.G.ActiveDevice.Name() != defaultDeviceName {
+		t.Errorf("active device name: %q, expected %q", tc.G.ActiveDevice.Name(), defaultDeviceName)
+	}
+
+	simulateServiceRestart(t, tc, u1)
+
+	assertDeviceKeysCached(tc)
+
+	if tc.G.ActiveDevice.Name() != defaultDeviceName {
+		t.Errorf("after restart, active device name: %q, expected %q", tc.G.ActiveDevice.Name(), defaultDeviceName)
+	}
+}
+
 func TestCreateFakeUserNoKeys(t *testing.T) {
 	tc := SetupEngineTest(t, "login")
 	defer tc.Cleanup()

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -556,3 +556,7 @@ func (a *Account) SkipSecretPrompt() bool {
 func (a *Account) SecretPromptCanceled() {
 	a.secretPromptCanceledAt = a.G().Clock().Now()
 }
+
+func (a *Account) SetDeviceName(name string) error {
+	return a.G().ActiveDevice.setDeviceName(a, a.localSession.GetUID(), a.localSession.GetDeviceID(), name)
+}

--- a/go/libkb/account.go
+++ b/go/libkb/account.go
@@ -475,9 +475,10 @@ func (a *Account) SetCachedSecretKey(ska SecretKeyArg, key GenericKey) error {
 	if key == nil {
 		return errors.New("cache of nil secret key attempted")
 	}
+	uid := a.G().Env.GetUID()
 	if ska.KeyType == DeviceSigningKeyType {
 		a.G().Log.Debug("caching secret device signing key")
-		if err := a.G().ActiveDevice.setSigningKey(a, a.localSession.GetUID(), a.localSession.GetDeviceID(), key); err != nil {
+		if err := a.G().ActiveDevice.setSigningKey(a, uid, a.localSession.GetDeviceID(), key); err != nil {
 			return err
 		}
 
@@ -503,11 +504,11 @@ func (a *Account) SetCachedSecretKey(ska SecretKeyArg, key GenericKey) error {
 			return nil
 		}
 		a.G().Log.Debug("caching device name %q", *device.Description)
-		return a.G().ActiveDevice.setDeviceName(a, a.localSession.GetUID(), device.ID, *device.Description)
+		return a.G().ActiveDevice.setDeviceName(a, uid, device.ID, *device.Description)
 	}
 	if ska.KeyType == DeviceEncryptionKeyType {
 		a.G().Log.Debug("caching secret device encryption key")
-		return a.G().ActiveDevice.setEncryptionKey(a, a.localSession.GetUID(), a.localSession.GetDeviceID(), key)
+		return a.G().ActiveDevice.setEncryptionKey(a, uid, a.localSession.GetDeviceID(), key)
 	}
 	return fmt.Errorf("attempt to cache invalid key type: %d", ska.KeyType)
 }
@@ -584,5 +585,5 @@ func (a *Account) SecretPromptCanceled() {
 }
 
 func (a *Account) SetDeviceName(name string) error {
-	return a.G().ActiveDevice.setDeviceName(a, a.localSession.GetUID(), a.localSession.GetDeviceID(), name)
+	return a.G().ActiveDevice.setDeviceName(a, a.G().Env.GetUID(), a.localSession.GetDeviceID(), name)
 }

--- a/go/libkb/syncer.go
+++ b/go/libkb/syncer.go
@@ -48,3 +48,24 @@ func RunSyncer(s Syncer, uid keybase1.UID, loggedIn bool, sr SessionReader) (err
 
 	return
 }
+
+func RunSyncerCached(s Syncer, uid keybase1.UID) (err error) {
+	if uid.IsNil() {
+		return NotFoundError{"No UID given to syncer"}
+	}
+
+	// unnecessary for secret syncer, but possibly useful for tracker syncer.
+	s.Lock()
+	defer s.Unlock()
+
+	s.G().Log.Debug("+ Syncer.Load(%s)", uid)
+	defer func() {
+		s.G().Log.Debug("- Syncer.Load(%s) -> %s", uid, ErrToOk(err))
+	}()
+
+	if err = s.loadFromStorage(uid); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go/protocol/keybase1/config.go
+++ b/go/protocol/keybase1/config.go
@@ -127,11 +127,12 @@ type OutOfDateInfo struct {
 }
 
 type BootstrapStatus struct {
+	Registered bool     `codec:"registered" json:"registered"`
+	LoggedIn   bool     `codec:"loggedIn" json:"loggedIn"`
 	Uid        UID      `codec:"uid" json:"uid"`
 	Username   string   `codec:"username" json:"username"`
 	DeviceID   DeviceID `codec:"deviceID" json:"deviceID"`
 	DeviceName string   `codec:"deviceName" json:"deviceName"`
-	LoggedIn   bool     `codec:"loggedIn" json:"loggedIn"`
 	Following  []string `codec:"following" json:"following"`
 	Followers  []string `codec:"followers" json:"followers"`
 }

--- a/go/protocol/keybase1/config.go
+++ b/go/protocol/keybase1/config.go
@@ -126,6 +126,16 @@ type OutOfDateInfo struct {
 	CriticalClockSkew int64  `codec:"criticalClockSkew" json:"criticalClockSkew"`
 }
 
+type BootstrapStatus struct {
+	Uid        UID           `codec:"uid" json:"uid"`
+	Username   string        `codec:"username" json:"username"`
+	DeviceID   DeviceID      `codec:"deviceID" json:"deviceID"`
+	DeviceName string        `codec:"deviceName" json:"deviceName"`
+	LoggedIn   bool          `codec:"loggedIn" json:"loggedIn"`
+	Following  []UserSummary `codec:"following" json:"following"`
+	Followers  []UserSummary `codec:"followers" json:"followers"`
+}
+
 type GetCurrentStatusArg struct {
 	SessionID int `codec:"sessionID" json:"sessionID"`
 }
@@ -175,6 +185,10 @@ type WaitForClientArg struct {
 	Timeout    DurationSec `codec:"timeout" json:"timeout"`
 }
 
+type GetBootstrapStatusArg struct {
+	SessionID int `codec:"sessionID" json:"sessionID"`
+}
+
 type ConfigInterface interface {
 	GetCurrentStatus(context.Context, int) (GetCurrentStatusRes, error)
 	GetExtendedStatus(context.Context, int) (ExtendedStatus, error)
@@ -192,6 +206,7 @@ type ConfigInterface interface {
 	CheckAPIServerOutOfDateWarning(context.Context) (OutOfDateInfo, error)
 	// Wait for client type to connect to service.
 	WaitForClient(context.Context, WaitForClientArg) (bool, error)
+	GetBootstrapStatus(context.Context, int) (BootstrapStatus, error)
 }
 
 func ConfigProtocol(i ConfigInterface) rpc.Protocol {
@@ -369,6 +384,22 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"getBootstrapStatus": {
+				MakeArg: func() interface{} {
+					ret := make([]GetBootstrapStatusArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]GetBootstrapStatusArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]GetBootstrapStatusArg)(nil), args)
+						return
+					}
+					ret, err = i.GetBootstrapStatus(ctx, (*typedArgs)[0].SessionID)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -440,5 +471,11 @@ func (c ConfigClient) CheckAPIServerOutOfDateWarning(ctx context.Context) (res O
 // Wait for client type to connect to service.
 func (c ConfigClient) WaitForClient(ctx context.Context, __arg WaitForClientArg) (res bool, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.config.waitForClient", []interface{}{__arg}, &res)
+	return
+}
+
+func (c ConfigClient) GetBootstrapStatus(ctx context.Context, sessionID int) (res BootstrapStatus, err error) {
+	__arg := GetBootstrapStatusArg{SessionID: sessionID}
+	err = c.Cli.Call(ctx, "keybase.1.config.getBootstrapStatus", []interface{}{__arg}, &res)
 	return
 }

--- a/go/protocol/keybase1/config.go
+++ b/go/protocol/keybase1/config.go
@@ -127,13 +127,13 @@ type OutOfDateInfo struct {
 }
 
 type BootstrapStatus struct {
-	Uid        UID           `codec:"uid" json:"uid"`
-	Username   string        `codec:"username" json:"username"`
-	DeviceID   DeviceID      `codec:"deviceID" json:"deviceID"`
-	DeviceName string        `codec:"deviceName" json:"deviceName"`
-	LoggedIn   bool          `codec:"loggedIn" json:"loggedIn"`
-	Following  []UserSummary `codec:"following" json:"following"`
-	Followers  []UserSummary `codec:"followers" json:"followers"`
+	Uid        UID      `codec:"uid" json:"uid"`
+	Username   string   `codec:"username" json:"username"`
+	DeviceID   DeviceID `codec:"deviceID" json:"deviceID"`
+	DeviceName string   `codec:"deviceName" json:"deviceName"`
+	LoggedIn   bool     `codec:"loggedIn" json:"loggedIn"`
+	Following  []string `codec:"following" json:"following"`
+	Followers  []string `codec:"followers" json:"followers"`
 }
 
 type GetCurrentStatusArg struct {

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -310,5 +310,5 @@ func (h ConfigHandler) GetBootstrapStatus(ctx context.Context, sessionID int) (k
 		return keybase1.BootstrapStatus{}, err
 	}
 
-	return keybase1.BootstrapStatus{}, nil
+	return eng.Status(), nil
 }

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -302,3 +302,13 @@ func (h ConfigHandler) CheckAPIServerOutOfDateWarning(_ context.Context) (keybas
 func (h ConfigHandler) WaitForClient(_ context.Context, arg keybase1.WaitForClientArg) (bool, error) {
 	return h.G().ConnectionManager.WaitForClientType(arg.ClientType, arg.Timeout.Duration()), nil
 }
+
+func (h ConfigHandler) GetBootstrapStatus(ctx context.Context, sessionID int) (keybase1.BootstrapStatus, error) {
+	eng := engine.NewBootstrap(h.G())
+	ectx := &engine.Context{NetContext: ctx}
+	if err := engine.RunEngine(eng, ectx); err != nil {
+		return keybase1.BootstrapStatus{}, err
+	}
+
+	return keybase1.BootstrapStatus{}, nil
+}

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1045,9 +1045,19 @@ func (g *gregorHandler) loggedIn(ctx context.Context) (uid keybase1.UID, token s
 	}
 
 	// Continue on and authenticate
-	aerr := g.G().LoginState().LocalSession(func(s *libkb.Session) {
-		token = s.GetToken()
-		uid = s.GetUID()
+	aerr := g.G().LoginState().Account(func(a *libkb.Account) {
+		in, err := a.LoggedInLoad()
+		if err != nil {
+			g.G().Log.Debug("gregorHandler loggedIn check: LoggedInLoad error: %s", err)
+			return
+		}
+		if !in {
+			g.G().Log.Debug("gregorHandler loggedIn check: not logged in")
+			return
+		}
+		g.G().Log.Debug("gregorHandler: logged in, getting token and uid")
+		token = a.LocalSession().GetToken()
+		uid = a.LocalSession().GetUID()
 	}, "gregor handler - login session")
 	if token == "" || uid == "" {
 		return uid, token, ok

--- a/go/service/session.go
+++ b/go/service/session.go
@@ -4,6 +4,8 @@
 package service
 
 import (
+	"os"
+
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/libkb"
@@ -62,6 +64,12 @@ func (h *SessionHandler) CurrentSession(_ context.Context, sessionID int) (keyba
 	}
 	if err != nil {
 		if _, ok := err.(libkb.LoginRequiredError); ok {
+			return s, libkb.NoSessionError{}
+		}
+		if os.IsNotExist(err) {
+			return s, libkb.NoSessionError{}
+		}
+		if _, ok := err.(libkb.NotFoundError); ok {
 			return s, libkb.NoSessionError{}
 		}
 		return s, err

--- a/go/service/session.go
+++ b/go/service/session.go
@@ -26,41 +26,14 @@ func NewSessionHandler(xp rpc.Transporter, g *libkb.GlobalContext) *SessionHandl
 }
 
 // CurrentSession uses the global session to find the session.  If
-// the user isn't logged in, it returns ErrNoSession.
+// the user isn't logged in, it returns libkb.NoSessionError.
+//
+// This function was modified to use cached information instead
+// of loading the full self user and possibliy running sesscheck.
+// The only potential problem with that is that the session token
+// could be stale.  However, KBFS reports that they don't use
+// the session token, so not an issue currently.
 func (h *SessionHandler) CurrentSession(_ context.Context, sessionID int) (keybase1.Session, error) {
-	/*
-		var s keybase1.Session
-		var token string
-		var username libkb.NormalizedUsername
-		var uid keybase1.UID
-		var deviceSubkey, deviceSibkey libkb.GenericKey
-		var err error
-
-		aerr := h.G().LoginState().Account(func(a *libkb.Account) {
-			_, err = a.LoggedInProvisionedCheck()
-			if err != nil {
-				return
-			}
-			uid, username, token, deviceSubkey, deviceSibkey, err = a.UserInfo()
-		}, "Service - SessionHandler - UserInfo")
-		if aerr != nil {
-			return s, aerr
-		}
-		if err != nil {
-			if _, ok := err.(libkb.LoginRequiredError); ok {
-				return s, libkb.NoSessionError{}
-			}
-			return s, err
-		}
-
-		s.Uid = uid
-		s.Username = username.String()
-		s.Token = token
-		s.DeviceSubkeyKid = deviceSubkey.GetKID()
-		s.DeviceSibkeyKid = deviceSibkey.GetKID()
-
-		return s, nil
-	*/
 	var s keybase1.Session
 	var uid keybase1.UID
 	var username libkb.NormalizedUsername
@@ -83,7 +56,7 @@ func (h *SessionHandler) CurrentSession(_ context.Context, sessionID int) (keyba
 		if err != nil {
 			return
 		}
-	}, "Service - SessionHandler - UserInfo")
+	}, "Service - SessionHandler - CurrentSession")
 	if aerr != nil {
 		return s, aerr
 	}

--- a/protocol/avdl/keybase1/config.avdl
+++ b/protocol/avdl/keybase1/config.avdl
@@ -138,4 +138,15 @@ protocol config {
     Wait for client type to connect to service.
     */
   boolean waitForClient(ClientType clientType, DurationSec timeout);
+
+  record BootstrapStatus {
+    UID uid;
+    string username;
+    DeviceID deviceID;
+    string deviceName;
+    boolean loggedIn;
+    array<UserSummary> following;
+    array<UserSummary> followers;
+  }
+  BootstrapStatus getBootstrapStatus(int sessionID);
 }

--- a/protocol/avdl/keybase1/config.avdl
+++ b/protocol/avdl/keybase1/config.avdl
@@ -140,13 +140,13 @@ protocol config {
   boolean waitForClient(ClientType clientType, DurationSec timeout);
 
   record BootstrapStatus {
+    boolean loggedIn;
     UID uid;
     string username;
     DeviceID deviceID;
     string deviceName;
-    boolean loggedIn;
-    array<UserSummary> following;
-    array<UserSummary> followers;
+    array<string> following;
+    array<string> followers;
   }
   BootstrapStatus getBootstrapStatus(int sessionID);
 }

--- a/protocol/avdl/keybase1/config.avdl
+++ b/protocol/avdl/keybase1/config.avdl
@@ -140,13 +140,14 @@ protocol config {
   boolean waitForClient(ClientType clientType, DurationSec timeout);
 
   record BootstrapStatus {
-    boolean loggedIn;
-    UID uid;
-    string username;
-    DeviceID deviceID;
-    string deviceName;
-    array<string> following;
-    array<string> followers;
+    boolean registered;     // true if signed up at some point
+    boolean loggedIn;     // true if currently logged in
+    UID uid;        // current logged in user's UID
+    string username;      // current logged in user's username
+    DeviceID deviceID;      // current logged in user's device ID
+    string deviceName;      // current logged in user's device name
+    array<string> following;    // who current logged in user is following
+    array<string> followers;    // who follows current logged in user
   }
   BootstrapStatus getBootstrapStatus(int sessionID);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3179,8 +3179,8 @@ export type BootstrapStatus = {
   deviceID: DeviceID,
   deviceName: string,
   loggedIn: boolean,
-  following?: ?Array<UserSummary>,
-  followers?: ?Array<UserSummary>,
+  following?: ?Array<string>,
+  followers?: ?Array<string>,
 }
 
 export type BoxNonce = any

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3174,11 +3174,12 @@ export type BlockType =
   | 1 // MD_1
 
 export type BootstrapStatus = {
+  registered: boolean,
+  loggedIn: boolean,
   uid: UID,
   username: string,
   deviceID: DeviceID,
   deviceName: string,
-  loggedIn: boolean,
   following?: ?Array<string>,
   followers?: ?Array<string>,
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1097,6 +1097,18 @@ export function configClearValueRpcPromise (request: $Exact<requestCommon & requ
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.config.clearValue', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function configGetBootstrapStatusRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: configGetBootstrapStatusResult) => void}>) {
+  engineRpcOutgoing('keybase.1.config.getBootstrapStatus', request)
+}
+
+export function configGetBootstrapStatusRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: configGetBootstrapStatusResult) => void}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.config.getBootstrapStatus', request, callback, incomingCallMap) })
+}
+
+export function configGetBootstrapStatusRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: configGetBootstrapStatusResult) => void}>): Promise<configGetBootstrapStatusResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.config.getBootstrapStatus', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function configGetConfigRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: configGetConfigResult) => void}>) {
   engineRpcOutgoing('keybase.1.config.getConfig', request)
 }
@@ -3160,6 +3172,16 @@ export type BlockReferenceCount = {
 export type BlockType =
     0 // DATA_0
   | 1 // MD_1
+
+export type BootstrapStatus = {
+  uid: UID,
+  username: string,
+  deviceID: DeviceID,
+  deviceName: string,
+  loggedIn: boolean,
+  following?: ?Array<UserSummary>,
+  followers?: ?Array<UserSummary>,
+}
 
 export type BoxNonce = any
 
@@ -5810,6 +5832,7 @@ type blockGetBlockResult = GetBlockRes
 type blockGetSessionChallengeResult = ChallengeInfo
 type blockGetUserQuotaInfoResult = bytes
 type configCheckAPIServerOutOfDateWarningResult = OutOfDateInfo
+type configGetBootstrapStatusResult = BootstrapStatus
 type configGetConfigResult = Config
 type configGetCurrentStatusResult = GetCurrentStatusRes
 type configGetExtendedStatusResult = ExtendedStatus
@@ -5973,6 +5996,7 @@ export type rpc =
   | blockPutBlockRpc
   | configCheckAPIServerOutOfDateWarningRpc
   | configClearValueRpc
+  | configGetBootstrapStatusRpc
   | configGetConfigRpc
   | configGetCurrentStatusRpc
   | configGetExtendedStatusRpc

--- a/protocol/json/keybase1/config.json
+++ b/protocol/json/keybase1/config.json
@@ -353,6 +353,46 @@
           "name": "criticalClockSkew"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "BootstrapStatus",
+      "fields": [
+        {
+          "type": "UID",
+          "name": "uid"
+        },
+        {
+          "type": "string",
+          "name": "username"
+        },
+        {
+          "type": "DeviceID",
+          "name": "deviceID"
+        },
+        {
+          "type": "string",
+          "name": "deviceName"
+        },
+        {
+          "type": "boolean",
+          "name": "loggedIn"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "UserSummary"
+          },
+          "name": "following"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "UserSummary"
+          },
+          "name": "followers"
+        }
+      ]
     }
   ],
   "messages": {
@@ -476,6 +516,15 @@
       ],
       "response": "boolean",
       "doc": "Wait for client type to connect to service."
+    },
+    "getBootstrapStatus": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        }
+      ],
+      "response": "BootstrapStatus"
     }
   },
   "namespace": "keybase.1"

--- a/protocol/json/keybase1/config.json
+++ b/protocol/json/keybase1/config.json
@@ -381,14 +381,14 @@
         {
           "type": {
             "type": "array",
-            "items": "UserSummary"
+            "items": "string"
           },
           "name": "following"
         },
         {
           "type": {
             "type": "array",
-            "items": "UserSummary"
+            "items": "string"
           },
           "name": "followers"
         }

--- a/protocol/json/keybase1/config.json
+++ b/protocol/json/keybase1/config.json
@@ -359,6 +359,14 @@
       "name": "BootstrapStatus",
       "fields": [
         {
+          "type": "boolean",
+          "name": "registered"
+        },
+        {
+          "type": "boolean",
+          "name": "loggedIn"
+        },
+        {
           "type": "UID",
           "name": "uid"
         },
@@ -373,10 +381,6 @@
         {
           "type": "string",
           "name": "deviceName"
-        },
-        {
-          "type": "boolean",
-          "name": "loggedIn"
         },
         {
           "type": {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3179,8 +3179,8 @@ export type BootstrapStatus = {
   deviceID: DeviceID,
   deviceName: string,
   loggedIn: boolean,
-  following?: ?Array<UserSummary>,
-  followers?: ?Array<UserSummary>,
+  following?: ?Array<string>,
+  followers?: ?Array<string>,
 }
 
 export type BoxNonce = any

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3174,11 +3174,12 @@ export type BlockType =
   | 1 // MD_1
 
 export type BootstrapStatus = {
+  registered: boolean,
+  loggedIn: boolean,
   uid: UID,
   username: string,
   deviceID: DeviceID,
   deviceName: string,
-  loggedIn: boolean,
   following?: ?Array<string>,
   followers?: ?Array<string>,
 }

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1097,6 +1097,18 @@ export function configClearValueRpcPromise (request: $Exact<requestCommon & requ
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.config.clearValue', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function configGetBootstrapStatusRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: configGetBootstrapStatusResult) => void}>) {
+  engineRpcOutgoing('keybase.1.config.getBootstrapStatus', request)
+}
+
+export function configGetBootstrapStatusRpcChannelMap (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: configGetBootstrapStatusResult) => void}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.config.getBootstrapStatus', request, callback, incomingCallMap) })
+}
+
+export function configGetBootstrapStatusRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: configGetBootstrapStatusResult) => void}>): Promise<configGetBootstrapStatusResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.config.getBootstrapStatus', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function configGetConfigRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: configGetConfigResult) => void}>) {
   engineRpcOutgoing('keybase.1.config.getConfig', request)
 }
@@ -3160,6 +3172,16 @@ export type BlockReferenceCount = {
 export type BlockType =
     0 // DATA_0
   | 1 // MD_1
+
+export type BootstrapStatus = {
+  uid: UID,
+  username: string,
+  deviceID: DeviceID,
+  deviceName: string,
+  loggedIn: boolean,
+  following?: ?Array<UserSummary>,
+  followers?: ?Array<UserSummary>,
+}
 
 export type BoxNonce = any
 
@@ -5810,6 +5832,7 @@ type blockGetBlockResult = GetBlockRes
 type blockGetSessionChallengeResult = ChallengeInfo
 type blockGetUserQuotaInfoResult = bytes
 type configCheckAPIServerOutOfDateWarningResult = OutOfDateInfo
+type configGetBootstrapStatusResult = BootstrapStatus
 type configGetConfigResult = Config
 type configGetCurrentStatusResult = GetCurrentStatusRes
 type configGetExtendedStatusResult = ExtendedStatus
@@ -5973,6 +5996,7 @@ export type rpc =
   | blockPutBlockRpc
   | configCheckAPIServerOutOfDateWarningRpc
   | configClearValueRpc
+  | configGetBootstrapStatusRpc
   | configGetConfigRpc
   | configGetCurrentStatusRpc
   | configGetExtendedStatusRpc


### PR DESCRIPTION
This patch adds a new service endpoint, `GetBootstrapStatus`, which provides the information the frontend needs to start.  It takes care to provide this information without any network requests so that the app can start offline.

In addition, `CurrentStatus` changed to work without network requests as well.  KBFS calls this on initialization.

Combined, these changes allow the app to startup (cold) offline and get to the chat tab.

mgood/DESKTOP-3406 contains the frontend changes.