### PR TITLE
Add FacebookDescription component on mobile

### DIFF
--- a/shared/profile/facebook-description.js
+++ b/shared/profile/facebook-description.js
@@ -14,7 +14,7 @@ export default function FacebookDescription () {
       <Box>
         <Text type='BodySemibold' {...styleCentered}>Click the link below and post. The text can be whatever you like, but make sure the post is <Text type='BodySemiboldItalic'>public</Text>, like this:</Text>
       </Box>
-      <Box style={{padding: 20}}>
+      <Box style={{alignItems: 'center', padding: 20}}>
         <Icon type='icon-facebook-visibility' />
       </Box>
     </Box>

--- a/shared/profile/facebook-description.js
+++ b/shared/profile/facebook-description.js
@@ -2,19 +2,13 @@
 import React from 'react'
 import {Box, Icon, Text} from '../common-adapters'
 
-const styleCentered = {
-  style: {
-    textAlign: 'center',
-  },
-}
-
 export default function FacebookDescription () {
   return (
     <Box style={{flexDirection: 'column'}}>
       <Box>
-        <Text type='BodySemibold' {...styleCentered}>Click the link below and post. The text can be whatever you like, but make sure the post is <Text type='BodySemiboldItalic'>public</Text>, like this:</Text>
+        <Text style={{textAlign: 'center'}} type='BodySemibold'>Click the link below and post. The text can be whatever you like, but make sure the post is <Text type='BodySemiboldItalic'>public</Text>, like this:</Text>
       </Box>
-      <Box style={{alignItems: 'center', padding: 20}}>
+      <Box style={{alignItems: 'center'}}>
         <Icon type='icon-facebook-visibility' />
       </Box>
     </Box>

--- a/shared/profile/facebook-description.native.js
+++ b/shared/profile/facebook-description.native.js
@@ -1,5 +1,0 @@
-// @flow
-
-export default function FacebookDescription () {
-  return null
-}

--- a/shared/profile/post-proof.native.js
+++ b/shared/profile/post-proof.native.js
@@ -26,7 +26,7 @@ const PostProof = (props: Props) => {
   return (
     <StandardScreen {...notification} onClose={onCancel}>
       <PlatformIcon style={stylePlatformIcon} platform={platform} overlay='icon-proof-unfinished' overlayColor={globalColors.grey} size={48} />
-      <Text style={{...stylePlatformUsername, ...(stylePlatformSubtitle ? {} : {marginBottom: globalMargins.medium})}} type='Header'>{platformUserName}</Text>
+      <Text style={{...stylePlatformUsername, ...(stylePlatformSubtitle ? {} : {marginBottom: globalMargins.tiny})}} type='Header'>{platformUserName}</Text>
       {!!platformSubtitle && <Text style={stylePlatformSubtitle} type='Body'>{platformSubtitle}</Text>}
       {descriptionView || (descriptionText && <Text style={styleDescriptionText} type='Body'>{descriptionText}</Text>)}
       {!!proofText && <CopyableText style={styleProofContainer} value={proofText} textStyle={styleProofText} />}
@@ -48,7 +48,7 @@ const stylePlatformUsername = {
 
 const stylePlatformSubtitle = {
   color: globalColors.black_20,
-  marginBottom: globalMargins.large,
+  marginBottom: globalMargins.small,
   textAlign: 'center',
 }
 
@@ -71,12 +71,12 @@ const styleNoteText = {
 }
 
 const styleProofAction = {
-  marginTop: globalMargins.medium,
+  marginTop: globalMargins.tiny,
 }
 
 const styleContinueButton = {
   ...globalStyles.flexBoxRow,
-  marginTop: globalMargins.medium,
+  marginTop: globalMargins.small,
 }
 
 export default PostProof


### PR DESCRIPTION
@keybase/react-hackers 

The Facebook instructions were missing on native.  This PR shares them with desktop, and narrows vertically to fit on iPhone SE.