### PR TITLE
Fix draft inputs. Try and fix message overlap

### DIFF
--- a/shared/chat/conversation/input/container.js
+++ b/shared/chat/conversation/input/container.js
@@ -82,10 +82,15 @@ export default compose(
         this.props.inputFocus()
       }
     },
+    componentWillUnmount: function () {
+      this.props.onStoreInputText(this.props.inputValue())
+    },
     componentWillReceiveProps: function (nextProps) {
       if (this.props.selectedConversationIDKey &&
           this.props.selectedConversationIDKey !== nextProps.selectedConversationIDKey) {
         this.props.onStoreInputText(this.props.inputValue())
+        // withState won't get called again if props changes!
+        this.props.setText(nextProps.defaultText)
       }
     },
   })

--- a/shared/chat/conversation/list/index.desktop.js
+++ b/shared/chat/conversation/list/index.desktop.js
@@ -60,6 +60,7 @@ class BaseList extends Component<void, Props, State> {
   componentWillReceiveProps (nextProps: Props) {
     if (this.props.selectedConversation !== nextProps.selectedConversation ||
       this.props.listScrollDownCounter !== nextProps.listScrollDownCounter) {
+      this._cellCache.clearAll()
       this.setState({isLockedToBottom: true})
     }
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -84,7 +84,7 @@
     "react-navigation": "1.0.0-beta.7",
     "react-redux": "5.0.3",
     "react-tap-event-plugin": "2.0.1",
-    "react-virtualized": "9.7.0",
+    "react-virtualized": "9.7.3",
     "recompose": "0.22.0",
     "redux": "3.6.0",
     "redux-batched-subscribe": "0.1.6",

--- a/shared/route-tree/render-route.js
+++ b/shared/route-tree/render-route.js
@@ -113,13 +113,11 @@ function _RenderRoute ({routeDef, routeState, setRouteState, path}: _RenderRoute
 
     stack = childStack
     if (routeDef.containerComponent) {
-      const useKeys = stack.count() > 1 // Only use keys if we have siblings, else we'll render thrash if we keep unique state in here (like in chat)
       // If this route specifies a container component, compose it around every
       // view in the stack.
       stack = stack.map(r => (
         r.update('component', child => (
           <RenderRouteNode
-            key={useKeys ? pathToString(path) : undefined}
             isContainer={true}
             routeDef={routeDef}
             routeState={routeState}

--- a/shared/route-tree/render-route.js
+++ b/shared/route-tree/render-route.js
@@ -113,12 +113,13 @@ function _RenderRoute ({routeDef, routeState, setRouteState, path}: _RenderRoute
 
     stack = childStack
     if (routeDef.containerComponent) {
+      const useKeys = stack.count() > 1 // Only use keys if we have siblings, else we'll render thrash if we keep unique state in here (like in chat)
       // If this route specifies a container component, compose it around every
       // view in the stack.
       stack = stack.map(r => (
         r.update('component', child => (
           <RenderRouteNode
-            key={pathToString(path)}
+            key={useKeys ? pathToString(path) : undefined}
             isContainer={true}
             routeDef={routeDef}
             routeState={routeState}
@@ -138,7 +139,6 @@ function _RenderRoute ({routeDef, routeState, setRouteState, path}: _RenderRoute
     // If this path has a leaf component to render, add it to the stack.
     const routeComponent = (
       <RenderRouteNode
-        key={pathToString(path)}
         isContainer={false}
         routeDef={routeDef}
         routeState={routeState}

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -6001,14 +6001,15 @@ react-transform-hmr@^1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react-virtualized@9.7.0:
-  version "9.7.0"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.7.0.tgz#900ec246666796afabc0f9c9f6ae9764327afb30"
+react-virtualized@9.7.3:
+  version "9.7.3"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.7.3.tgz#5be2bbc0316151ee1c00d133f7a5f9727874f756"
   dependencies:
     babel-runtime "^6.11.6"
     classnames "^2.2.3"
     dom-helpers "^2.4.0 || ^3.0.0"
     loose-envify "^1.3.0"
+    prop-types "^15.5.4"
 
 react@15.4.2:
   version "15.4.2"


### PR DESCRIPTION
Having a hard time trying to reproduce the chat overlap messages. During the process of debugging i saw we're entirely re-creating our chat classes due to our router using unique keys for any route paths (which change when you change conversations). We no longer do this

A side effect of this is the input isn't torn down and recreated each time which means it kept its value (which is a bug anyways as we're supposed to keep the draft values, thats also fixed

I'm clearing the cellCache when convos change (likely doesn't do anything since the whole thing was being blown away, but let's just see). i also updated react-virtualized to latest (shouldn't affect anything)