### PR TITLE
kbnm: Add KBNM to default components; add permission error instructions

### DIFF
--- a/go/client/cmd_install_osx.go
+++ b/go/client/cmd_install_osx.go
@@ -89,6 +89,7 @@ var defaultInstallComponents = []string{
 	install.ComponentNameService.String(),
 	install.ComponentNameMountDir.String(),
 	install.ComponentNameKBFS.String(),
+	install.ComponentNameKBNM.String(),
 }
 
 func (v *CmdInstall) ParseArgv(ctx *cli.Context) error {
@@ -146,6 +147,7 @@ func (v *CmdInstall) Run() error {
 var defaultUninstallComponents = []string{
 	install.ComponentNameService.String(),
 	install.ComponentNameKBFS.String(),
+	install.ComponentNameKBNM.String(),
 	install.ComponentNameMountDir.String(),
 	install.ComponentNameUpdater.String(),
 	install.ComponentNameFuse.String(),


### PR DESCRIPTION
Fixes https://github.com/keybase/client/issues/6637

Also adds a more useful error for the scenario where another app changed the permission of the NativeMessaging dir and KBNM fails to install. Looks like this:

```
▶ ERROR Error installing KBNM: open /Users/shazow/Library/Application Support/Google/Chrome/NativeMessagingHosts/io.keybase.kbnm.json:
permission denied: Make sure the directory is owned by shazow. You can run:
   sudo chown -R shazow:staff "/Users/shazow/Library/Application Support/Google/Chrome/NativeMessagingHosts"
```