### PR TITLE
Fix render thrasing jankiness on mobile

### DIFF
--- a/shared/chat/conversation/list/index.native.js
+++ b/shared/chat/conversation/list/index.native.js
@@ -2,10 +2,9 @@
 import * as Constants from '../../../constants/chat'
 import React, {Component} from 'react'
 import messageFactory from '../messages'
-import {Box} from '../../../common-adapters'
+import {Box, NativeScrollView} from '../../../common-adapters/index.native'
 // $FlowIssue
 import FlatList from '../../../fixme/Lists/FlatList'
-import InvertibleScrollView from 'react-native-invertible-scroll-view'
 
 import type {Props} from '.'
 
@@ -21,14 +20,6 @@ class ConversationList extends Component <void, Props, void> {
 
   // This is handled slightly differently on mobile, leave this blank
   _measure = () => {}
-
-  _renderRow = (rowData, sectionID, rowID, highlightRow) => {
-    const messageKey = rowData
-    const prevMessageKey = this.props.messageKeys.get(rowID - 1)
-    const isSelected = false
-
-    return messageFactory(messageKey, prevMessageKey, this._onAction, this._onShowEditor, isSelected, this._measure)
-  }
 
   _renderItem = ({item: messageKey, index}) => {
     const prevMessageKey = index !== 0 ? this.props.messageKeys.get(index - 1) : null
@@ -50,9 +41,17 @@ class ConversationList extends Component <void, Props, void> {
   componentDidUpdate (prevProps: Props) {
     // TODO do we need this? I think the list may work how we want w/o this
     if (this.props.listScrollDownCounter !== prevProps.listScrollDownCounter && this._scrollRef) {
-      this._scrollRef.scrollTo({y: 0, animated: false})
+      this._scrollRef.scrollTo({animated: false, y: 0})
     }
   }
+
+  _renderScrollComponent = (props) => (
+    <NativeScrollView
+      {...props}
+      ref={this._captureScrollRef}
+      style={[verticallyInvertedStyle, props.style]}
+    />
+  )
 
   _captureScrollRef = r => { this._scrollRef = r }
 
@@ -61,11 +60,10 @@ class ConversationList extends Component <void, Props, void> {
       <FlatList
         data={this.props.messageKeys.reverse().toArray()}
         renderItem={this._renderItem}
+        renderScrollComponent={this._renderScrollComponent}
         onEndReached={this._onEndReached}
         onEndReachedThreshold={0}
         keyExtractor={this._keyExtractor}
-        renderScrollComponent={props => <InvertibleScrollView {...props} ref={this._captureScrollRef} inverted={true} />}
-        initialNumToRender={30}
       />
     )
   }

--- a/shared/fixme/Lists/FlatList.js
+++ b/shared/fixme/Lists/FlatList.js
@@ -20,7 +20,7 @@ const invariant = require('fbjs/lib/invariant');
 
 import type {StyleObj} from 'StyleSheetTypes';
 import type {ViewabilityConfig, ViewToken} from './ViewabilityHelper';
-import type {Props as VirtualizedListProps} from 'VirtualizedList';
+import type {Props as VirtualizedListProps} from './VirtualizedList';
 
 type RequiredProps<ItemT> = {
   /**

--- a/shared/fixme/Lists/SectionList.js
+++ b/shared/fixme/Lists/SectionList.js
@@ -11,13 +11,13 @@
  */
 'use strict';
 
-const MetroListView = require('MetroListView');
+const MetroListView = require('./MetroListView');
 const Platform = require('Platform');
 const React = require('React');
-const VirtualizedSectionList = require('VirtualizedSectionList');
+const VirtualizedSectionList = require('./VirtualizedSectionList');
 
 import type {ViewToken} from './ViewabilityHelper';
-import type {Props as VirtualizedSectionListProps} from 'VirtualizedSectionList';
+import type {Props as VirtualizedSectionListProps} from './VirtualizedSectionList';
 
 type Item = any;
 

--- a/shared/fixme/Lists/VirtualizedList.js
+++ b/shared/fixme/Lists/VirtualizedList.js
@@ -23,7 +23,7 @@ const ViewabilityHelper = require('./ViewabilityHelper');
 const infoLog = require('infoLog');
 const invariant = require('fbjs/lib/invariant');
 
-const {computeWindowedRenderLimits} = require('VirtualizeUtils');
+const {computeWindowedRenderLimits} = require('./VirtualizeUtils');
 
 import type {ViewabilityConfig, ViewToken} from './ViewabilityHelper';
 

--- a/shared/fixme/Lists/VirtualizedSectionList.js
+++ b/shared/fixme/Lists/VirtualizedSectionList.js
@@ -13,13 +13,13 @@
 
 const React = require('React');
 const View = require('View');
-const VirtualizedList = require('VirtualizedList');
+const VirtualizedList = require('./VirtualizedList');
 
 const invariant = require('fbjs/lib/invariant');
 const warning = require('fbjs/lib/warning');
 
 import type {ViewToken} from './ViewabilityHelper';
-import type {Props as VirtualizedListProps} from 'VirtualizedList';
+import type {Props as VirtualizedListProps} from './VirtualizedList';
 
 type Item = any;
 type SectionItem = any;

--- a/shared/package.json
+++ b/shared/package.json
@@ -79,7 +79,6 @@
     "react-native-camera": "0.6.0",
     "react-native-fs": "2.1.0-rc.1",
     "react-native-image-picker": "0.25.7",
-    "react-native-invertible-scroll-view": "^1.0.0",
     "react-native-push-notification": "git://github.com/keybase/react-native-push-notification#eedae53f4346223b5aee60ef2702ecc47a01fcd2",
     "react-navigation": "1.0.0-beta.7",
     "react-redux": "5.0.3",

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -5847,20 +5847,9 @@ react-native-image-picker@0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-0.25.7.tgz#1475fd72111a74f434598f2c99453998ac21b599"
 
-react-native-invertible-scroll-view@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-invertible-scroll-view/-/react-native-invertible-scroll-view-1.0.0.tgz#60ceb384dc950c34eba3a5aeda39f97cdc7d4e23"
-  dependencies:
-    react-clone-referenced-element "^1.0.1"
-    react-native-scrollable-mixin "^1.0.1"
-
 "react-native-push-notification@git://github.com/keybase/react-native-push-notification#eedae53f4346223b5aee60ef2702ecc47a01fcd2":
   version "2.2.1"
   resolved "git://github.com/keybase/react-native-push-notification#eedae53f4346223b5aee60ef2702ecc47a01fcd2"
-
-react-native-scrollable-mixin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-scrollable-mixin/-/react-native-scrollable-mixin-1.0.1.tgz#34a32167b64248594154fd0d6a8b03f22740548e"
 
 react-native-tab-view@^0.0.57:
   version "0.0.57"


### PR DESCRIPTION
@keybase/react-hackers 

The InvertibleScrollView dependency was not letting the VirtualizedList attach onCellLayout to the cells it rendered. It uses that to predict the sizes of dynamic content so it can render things outside the current visible viewport.

If the onCellLayout isn't called, the virtualized list has no estimate for offsets so it'll render everything at the bottom. Then things get pushed up as more things are rendered.