### PR TITLE
fix clickable box being too big. fix scrollview eating taps

### DIFF
--- a/shared/common-adapters/button.native.js
+++ b/shared/common-adapters/button.native.js
@@ -8,7 +8,7 @@ import Box from './box'
 import {globalColors, globalStyles, globalMargins} from '../styles'
 
 const Progress = () => (
-  <Box style={{...progress}}>
+  <Box style={progress}>
     <ProgressIndicator />
   </Box>
 )
@@ -58,30 +58,34 @@ class Button extends Component<void, Props, void> {
 
     // Need this nested view to get around this RN issue: https://github.com/facebook/react-native/issues/1040
     return (
-      <ClickableBox
-        style={borderRadius}
-        onClick={onPress}
-        underlayColor={style.backgroundColor}>
-        <Box style={{...style, ...this.props.style, alignItems: 'center', justifyContent: 'center'}}>
-          <Text type={this.props.small ? 'BodySemibold' : 'BodyBig'} style={{...labelStyle, ...this.props.labelStyle}}>{this.props.label}</Text>
-          {this.props.waiting && <Progress />}
-        </Box>
-      </ClickableBox>
+      <Box style={_containerStyle}>
+        <ClickableBox style={_clickableBoxStyle} onClick={onPress}>
+          <Box style={{...style, ...this.props.style, alignItems: 'center', justifyContent: 'center'}}>
+            <Text type={this.props.small ? 'BodySemibold' : 'BodyBig'} style={{...labelStyle, ...this.props.labelStyle}}>{this.props.label}</Text>
+            {this.props.waiting && <Progress />}
+          </Box>
+        </ClickableBox>
+      </Box>
     )
   }
+}
+
+const _containerStyle = {
+  alignItems: 'center',
 }
 
 const smallHeight = 32
 const regularHeight = 40
 const fullWidthHeight = 48
+const borderRadius = 50
 
-const borderRadius = {
-  borderRadius: 50,
+const _clickableBoxStyle = {
+  borderRadius,
 }
 
 const common = {
   ...globalStyles.flexBoxColumn,
-  ...borderRadius,
+  borderRadius,
   alignItems: 'center',
   justifyContent: 'center',
   height: regularHeight,

--- a/shared/common-adapters/native-wrappers.native.js
+++ b/shared/common-adapters/native-wrappers.native.js
@@ -15,7 +15,6 @@ import {
   Modal as NativeModal,
   Navigator as NativeNavigator,
   Picker as NativePicker,
-  ScrollView as NativeScrollView,
   StyleSheet as NativeStyleSheet,
   Switch as NativeSwitch,
   Text as NativeText,
@@ -24,6 +23,7 @@ import {
   TouchableWithoutFeedback as NativeTouchableWithoutFeedback,
   TouchableHighlight as NativeTouchableHighlight,
 } from 'react-native'
+import ScrollView from './scroll-view.native'
 
 export {
   NativeActivityIndicator,
@@ -41,7 +41,7 @@ export {
   NativeModal,
   NativeNavigator,
   NativePicker,
-  NativeScrollView,
+  ScrollView as NativeScrollView, // We set some useful default here
   NativeStyleSheet,
   NativeSwitch,
   NativeText,

--- a/shared/common-adapters/scroll-view.native.js
+++ b/shared/common-adapters/scroll-view.native.js
@@ -1,0 +1,14 @@
+// @flow
+import {ScrollView} from 'react-native'
+
+// Out of the box the ScrollView will consume taps of all children to dismiss the keyboard. This means if you have
+// an input with focus and a button, tapping the button won't work until you click it twice. Setting these defaults
+// changes this behavior: https://github.com/facebook/react-native/issues/4087
+class BetterScrollView extends ScrollView {
+  static defaultProps = {
+    keybaseDismissMode: 'on-drag',
+    keyboardShouldPersistTaps: 'handled',
+  }
+}
+
+export default BetterScrollView


### PR DESCRIPTION
@keybase/react-hackers this fixes a very annoying problem with RN!
If you have a scrollview with a button in it, the scrollview can eat taps. I think this has caused a bunch of subtly annoying ux where people think the app is slow on clicks or the tap areas are too small or etc etc.