### PR TITLE
retry all failures from nonblocking local RPCs CORE-4964

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -104,6 +104,8 @@ type RemoteConversationSource struct {
 	libkb.Contextified
 }
 
+var _ types.ConversationSource = (*RemoteConversationSource)(nil)
+
 func NewRemoteConversationSource(g *libkb.GlobalContext, b *Boxer, ri func() chat1.RemoteInterface) *RemoteConversationSource {
 	return &RemoteConversationSource{
 		Contextified:           libkb.NewContextified(g),
@@ -212,6 +214,8 @@ type HybridConversationSource struct {
 
 	storage *storage.Storage
 }
+
+var _ types.ConversationSource = (*HybridConversationSource)(nil)
 
 func NewHybridConversationSource(g *libkb.GlobalContext, b *Boxer, storage *storage.Storage,
 	ri func() chat1.RemoteInterface) *HybridConversationSource {

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -400,7 +400,7 @@ type HybridInboxSource struct {
 	*baseInboxSource
 }
 
-var _ types.InboxSource = (*RemoteInboxSource)(nil)
+var _ types.InboxSource = (*HybridInboxSource)(nil)
 
 func NewHybridInboxSource(g *libkb.GlobalContext,
 	getChatInterface func() chat1.RemoteInterface,

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -295,6 +295,8 @@ type RemoteInboxSource struct {
 	*baseInboxSource
 }
 
+var _ types.InboxSource = (*RemoteInboxSource)(nil)
+
 func NewRemoteInboxSource(g *libkb.GlobalContext, ri func() chat1.RemoteInterface,
 	tlfInfoSource types.TLFInfoSource) *RemoteInboxSource {
 	return &RemoteInboxSource{
@@ -397,6 +399,8 @@ type HybridInboxSource struct {
 	utils.DebugLabeler
 	*baseInboxSource
 }
+
+var _ types.InboxSource = (*RemoteInboxSource)(nil)
 
 func NewHybridInboxSource(g *libkb.GlobalContext,
 	getChatInterface func() chat1.RemoteInterface,

--- a/go/chat/remoteclient.go
+++ b/go/chat/remoteclient.go
@@ -1,0 +1,31 @@
+package chat
+
+import (
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	"golang.org/x/net/context"
+)
+
+type RemoteClient struct {
+	utils.DebugLabeler
+
+	cli rpc.GenericClient
+}
+
+func NewRemoteClient(g *libkb.GlobalContext, cli rpc.GenericClient) *RemoteClient {
+	return &RemoteClient{
+		DebugLabeler: utils.NewDebugLabeler(g, "RemoteClient", false),
+		cli:          cli,
+	}
+}
+
+func (c *RemoteClient) Call(ctx context.Context, method string, arg interface{}, res interface{}) (err error) {
+	defer c.Trace(ctx, func() error { return err }, method)()
+	return c.cli.Call(ctx, method, arg, res)
+}
+
+func (c *RemoteClient) Notify(ctx context.Context, method string, arg interface{}) (err error) {
+	defer c.Trace(ctx, func() error { return err }, method)()
+	return c.cli.Notify(ctx, method, arg)
+}

--- a/go/chat/retry.go
+++ b/go/chat/retry.go
@@ -1,0 +1,129 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/clockwork"
+	"time"
+)
+
+type FetchType int
+
+const (
+	InboxLoad FetchType = iota
+	ThreadLoad
+)
+
+
+
+type FetchRetrier struct {
+	libkb.Contextified
+	sync.Mutex
+	utils.DebugLabeler
+
+	clock clockwork.Clock
+}
+
+func NewFetchRetrier(g *libkb.GlobalContext) *FetchRetrier {
+	return &FetchRetrier{
+		Contextified: libkb.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "FetchRetrier", false),
+		clock: clockwork.NewRealClock(),
+	}
+}
+
+func (f *FetchRetrier) dbKey(uid gregor1.UID, kind FetchType) libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBChatFetchRetrier,
+		Key: fmt.Sprintf("%s:%d", uid, kind),
+	}
+}
+
+func (f *FetchRetrier) maybeNuke(ctx context.Context, err error, uid gregor1.UID, 
+	kind FetchType) {
+	if err != nil {
+		f.Debug(ctx, "maybeNuke: nuking local copy")
+		if err := f.G().LocalChatDb.Delete(f.dbKey(uid, kind)); err != nil {
+			f.Debug(ctx, "maybeNuke: error trying to nuke db: %s", err.Error())
+		}
+	}
+}
+
+type convModifyFunc func(chat1.ConversationID, failureLedger) failureLedge
+
+func (f *FetchRetrier) writeConversation(ctx context.Context, convID chat1.ConversationID,
+	uid gregor1.UID, kind FetchType, cmf convModifyFunc) error {
+	defer f.maybeNuke(ctx, err, uid, kind)
+
+	// Read current data (if any)
+	var failures failureLedger
+	key := f.dbKey(uid, kind)
+	_, err := f.G().LocalChatDb.GetInto(&failures, key)
+	if err != nil {
+		f.Debug(ctx, "writeConversation: failed to get current list, using empty: %s",
+			err.Error())
+		return err
+	}
+	failures = cmf(convID, failures)
+
+	if err := f.G().LocalChatDb.PutObj(key, nil, failures); err != nil {
+		f.Debug(ctx, "writeConversation: failed to write list: %s", err.Error())
+		return err
+	}
+
+	return nil
+}
+
+func (f *FetchRetrier) Failure(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
+	kind FetchType) (err error) {
+	f.Lock()
+	defer f.Unlock()
+	defer f.Trace(ctx, func() error { return err }, fmt.Sprintf("Failure(%s)", convID))()
+
+	return f.writeConversation(ctx, convID, uid, kind,
+		func(convID chat1.ConversationID, convIDs []chat1.ConversationID) []chat1.ConversationID {
+			return append(convIDs, convID)
+		},
+	)
+}
+
+func (f *FetchRetrier) Success(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
+	kind FetchType) (err error) {
+	f.Lock()
+	defer f.Unlock()
+	defer f.Trace(ctx, func() error { return err }, fmt.Sprintf("Success(%s)", convID))()
+
+	return f.writeConversation(ctx, convID, uid, kind,
+		func(convID chat1.ConversationID, convIDs []chat1.ConversationID) (res []chat1.ConversationID) {
+			for _, cid := range convIDs {
+				if !cid.Eq(convID) {
+					res = append(res, convID)
+				}
+			}
+			return res
+		},
+	)
+}
+
+func (f *FetchRetrier) Reconnect() {
+
+}
+
+func (f *FetchRetrier) retryLoop() {
+	for {
+		select {
+			case <-f.clock.After(
+		}
+
+	}
+}
+
+func (f *FetchRetrier) retryOnce() {
+
+}

--- a/go/chat/retry.go
+++ b/go/chat/retry.go
@@ -235,7 +235,6 @@ func (f *FetchRetrier) fixInboxFetches(ctx context.Context, uid gregor1.UID,
 			}
 		}
 	}
-
 	return fixed
 }
 
@@ -261,7 +260,6 @@ func (f *FetchRetrier) fixThreadFetches(ctx context.Context, uid gregor1.UID,
 			}
 		}
 	}
-
 	return fixed
 }
 

--- a/go/chat/retry.go
+++ b/go/chat/retry.go
@@ -144,7 +144,7 @@ func (f *FetchRetrier) retryLoop(uid gregor1.UID) {
 		case <-f.forceCh:
 			f.retryOnce(uid, true)
 		case cb := <-f.shutdownCh:
-			f.Debug(context.Background(), "shutting down retryLook: uid: %s", uid)
+			f.Debug(context.Background(), "shutting down retryLoop: uid: %s", uid)
 			defer close(cb)
 			return
 		}

--- a/go/chat/retry.go
+++ b/go/chat/retry.go
@@ -246,6 +246,7 @@ func (f *FetchRetrier) fixThreadFetches(ctx context.Context, uid gregor1.UID,
 func (f *FetchRetrier) retryOnce(uid gregor1.UID, force bool) {
 	if f.IsOffline() {
 		f.Debug(context.Background(), "retryOnce: currently offline, not attempting to fix errors")
+		return
 	}
 
 	var wg sync.WaitGroup

--- a/go/chat/retry.go
+++ b/go/chat/retry.go
@@ -1,129 +1,188 @@
 package chat
 
 import (
-	"context"
 	"fmt"
 	"sync"
+	"time"
 
+	"github.com/keybase/client/go/chat/storage"
+	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/clockwork"
-	"time"
+	context "golang.org/x/net/context"
 )
-
-type FetchType int
-
-const (
-	InboxLoad FetchType = iota
-	ThreadLoad
-)
-
-
 
 type FetchRetrier struct {
 	libkb.Contextified
-	sync.Mutex
 	utils.DebugLabeler
+	sync.Mutex
 
-	clock clockwork.Clock
+	forceCh    chan struct{}
+	shutdownCh chan chan struct{}
+	clock      clockwork.Clock
+	offline    bool
 }
 
 func NewFetchRetrier(g *libkb.GlobalContext) *FetchRetrier {
-	return &FetchRetrier{
+	f := &FetchRetrier{
 		Contextified: libkb.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g, "FetchRetrier", false),
-		clock: clockwork.NewRealClock(),
+		clock:        clockwork.NewRealClock(),
+		forceCh:      make(chan struct{}),
+		shutdownCh:   make(chan chan struct{}, 1),
 	}
+	return f
 }
 
-func (f *FetchRetrier) dbKey(uid gregor1.UID, kind FetchType) libkb.DbKey {
-	return libkb.DbKey{
-		Typ: libkb.DBChatFetchRetrier,
-		Key: fmt.Sprintf("%s:%d", uid, kind),
-	}
-}
-
-func (f *FetchRetrier) maybeNuke(ctx context.Context, err error, uid gregor1.UID, 
-	kind FetchType) {
-	if err != nil {
-		f.Debug(ctx, "maybeNuke: nuking local copy")
-		if err := f.G().LocalChatDb.Delete(f.dbKey(uid, kind)); err != nil {
-			f.Debug(ctx, "maybeNuke: error trying to nuke db: %s", err.Error())
-		}
-	}
-}
-
-type convModifyFunc func(chat1.ConversationID, failureLedger) failureLedge
-
-func (f *FetchRetrier) writeConversation(ctx context.Context, convID chat1.ConversationID,
-	uid gregor1.UID, kind FetchType, cmf convModifyFunc) error {
-	defer f.maybeNuke(ctx, err, uid, kind)
-
-	// Read current data (if any)
-	var failures failureLedger
-	key := f.dbKey(uid, kind)
-	_, err := f.G().LocalChatDb.GetInto(&failures, key)
-	if err != nil {
-		f.Debug(ctx, "writeConversation: failed to get current list, using empty: %s",
-			err.Error())
-		return err
-	}
-	failures = cmf(convID, failures)
-
-	if err := f.G().LocalChatDb.PutObj(key, nil, failures); err != nil {
-		f.Debug(ctx, "writeConversation: failed to write list: %s", err.Error())
-		return err
-	}
-
-	return nil
+func (f *FetchRetrier) boxKey(kind types.FetchType) string {
+	return fmt.Sprintf("%v", kind)
 }
 
 func (f *FetchRetrier) Failure(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
-	kind FetchType) (err error) {
-	f.Lock()
-	defer f.Unlock()
+	kind types.FetchType) (err error) {
 	defer f.Trace(ctx, func() error { return err }, fmt.Sprintf("Failure(%s)", convID))()
 
-	return f.writeConversation(ctx, convID, uid, kind,
-		func(convID chat1.ConversationID, convIDs []chat1.ConversationID) []chat1.ConversationID {
-			return append(convIDs, convID)
-		},
-	)
+	return storage.NewConversationFailureBox(f.G(), uid, f.boxKey(kind)).Failure(ctx, convID)
 }
 
 func (f *FetchRetrier) Success(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
-	kind FetchType) (err error) {
-	f.Lock()
-	defer f.Unlock()
+	kind types.FetchType) (err error) {
 	defer f.Trace(ctx, func() error { return err }, fmt.Sprintf("Success(%s)", convID))()
 
-	return f.writeConversation(ctx, convID, uid, kind,
-		func(convID chat1.ConversationID, convIDs []chat1.ConversationID) (res []chat1.ConversationID) {
-			for _, cid := range convIDs {
-				if !cid.Eq(convID) {
-					res = append(res, convID)
-				}
-			}
-			return res
-		},
-	)
+	return storage.NewConversationFailureBox(f.G(), uid, f.boxKey(kind)).Success(ctx, convID)
 }
 
-func (f *FetchRetrier) Reconnect() {
-
-}
-
-func (f *FetchRetrier) retryLoop() {
-	for {
-		select {
-			case <-f.clock.After(
-		}
-
+func (f *FetchRetrier) Connected(ctx context.Context) {
+	defer f.Trace(ctx, func() error { return nil }, "Reconnect")()
+	f.Lock()
+	f.offline = false
+	f.Unlock()
+	select {
+	case f.forceCh <- struct{}{}:
+	default:
 	}
 }
 
-func (f *FetchRetrier) retryOnce() {
+func (f *FetchRetrier) Disconnected(ctx context.Context) {
+	f.Lock()
+	defer f.Unlock()
+	f.offline = true
+}
 
+func (f *FetchRetrier) IsOffline() bool {
+	f.Lock()
+	defer f.Unlock()
+	return f.offline
+}
+
+func (f *FetchRetrier) Start(ctx context.Context, uid gregor1.UID) {
+	defer f.Trace(ctx, func() error { return nil }, "Start")()
+	go f.retryLoop(uid)
+}
+
+func (f *FetchRetrier) Stop(ctx context.Context) chan struct{} {
+	defer f.Trace(ctx, func() error { return nil }, "Stop")()
+	cb := make(chan struct{})
+	f.shutdownCh <- cb
+	return cb
+}
+
+func (f *FetchRetrier) retryLoop(uid gregor1.UID) {
+	for {
+		select {
+		case <-f.clock.After(time.Second * 3):
+			f.retryOnce(uid)
+		case <-f.forceCh:
+			f.retryOnce(uid)
+		case cb := <-f.shutdownCh:
+			defer close(cb)
+			return
+		}
+	}
+}
+
+func (f *FetchRetrier) retryInboxLoads(uid gregor1.UID) {
+	var err error
+	box := storage.NewConversationFailureBox(f.G(), uid, f.boxKey(types.InboxLoad))
+	ctx := context.Background()
+
+	var convIDs []chat1.ConversationID
+	convIDs, err = box.Read(ctx)
+	if err != nil {
+		f.Debug(ctx, "retryInboxLoads: failed to read failure box, giving up: %s", err.Error())
+		return
+	}
+
+	// Reload these all conversations and hope they work
+	inbox, _, err := f.G().InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
+		ConvIDs: convIDs,
+	}, nil)
+	if err != nil {
+		f.Debug(ctx, "retryInboxLoads: failed to read inbox: %s", err.Error())
+		return
+	}
+	var fixed []chat1.ConversationID
+	for _, conv := range inbox.Convs {
+		if conv.Error == nil {
+			f.Debug(ctx, "retryInboxLoads: fixed convID: %s", conv.GetConvID())
+			fixed = append(fixed, conv.GetConvID())
+			if err := f.Success(ctx, conv.GetConvID(), uid, types.InboxLoad); err != nil {
+				f.Debug(ctx, "retryInboxLoads: failure running Success: %s", err.Error())
+			}
+		}
+	}
+
+	f.Debug(ctx, "retryInboxLoads: sending %d stale notifications", len(fixed))
+	f.G().ChatSyncer.SendChatStaleNotifications(ctx, uid, fixed, false)
+}
+
+func (f *FetchRetrier) retryThreadLoads(uid gregor1.UID) {
+	var err error
+	box := storage.NewConversationFailureBox(f.G(), uid, f.boxKey(types.ThreadLoad))
+	ctx := context.Background()
+
+	var convIDs []chat1.ConversationID
+	convIDs, err = box.Read(ctx)
+	if err != nil {
+		f.Debug(ctx, "retryThreadLoads: failed to read failure box, giving up: %s", err.Error())
+		return
+	}
+
+	var fixed []chat1.ConversationID
+	for _, convID := range convIDs {
+		_, _, err := f.G().ConvSource.Pull(ctx, convID, uid, nil, &chat1.Pagination{
+			Num: 50,
+		})
+		if err == nil {
+			f.Debug(ctx, "retryThreadLoads: fixed convID: %s", convID)
+			fixed = append(fixed, convID)
+			if err := f.Success(ctx, convID, uid, types.ThreadLoad); err != nil {
+				f.Debug(ctx, "retryThreadLoads: failure running Success: %s", err.Error())
+			}
+		}
+	}
+
+	f.Debug(ctx, "retryThreadLoads: sending %d stale notifications", len(fixed))
+	f.G().ChatSyncer.SendChatStaleNotifications(ctx, uid, fixed, false)
+}
+
+func (f *FetchRetrier) retryOnce(uid gregor1.UID) {
+	if f.IsOffline() {
+		f.Debug(context.Background(), "retryOnce: currently offline, not attempting to fix errors")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		f.retryInboxLoads(uid)
+		wg.Done()
+	}()
+	go func() {
+		f.retryThreadLoads(uid)
+		wg.Done()
+	}()
+	wg.Wait()
 }

--- a/go/chat/retry.go
+++ b/go/chat/retry.go
@@ -42,6 +42,10 @@ func NewFetchRetrier(g *libkb.GlobalContext) *FetchRetrier {
 	return f
 }
 
+func (f *FetchRetrier) SetClock(clock clockwork.Clock) {
+	f.clock = clock
+}
+
 func (f *FetchRetrier) boxKey(kind types.FetchType) string {
 	return fmt.Sprintf("%v", kind)
 }
@@ -78,6 +82,11 @@ func (f *FetchRetrier) IsOffline() bool {
 	f.Lock()
 	defer f.Unlock()
 	return f.offline
+}
+
+func (f *FetchRetrier) Force(ctx context.Context) {
+	defer f.Trace(ctx, func() error { return nil }, "Force")()
+	f.forceCh <- struct{}{}
 }
 
 func (f *FetchRetrier) Start(ctx context.Context, uid gregor1.UID) {

--- a/go/chat/retry_test.go
+++ b/go/chat/retry_test.go
@@ -1,0 +1,89 @@
+package chat
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/chat/storage"
+	"github.com/keybase/client/go/chat/types"
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+type errorClient struct{}
+
+func (e errorClient) Call(ctx context.Context, method string, arg interface{}, res interface{}) error {
+	return fmt.Errorf("errorClient: Call %s", method)
+}
+
+func (e errorClient) Notify(ctx context.Context, method string, arg interface{}) error {
+	return fmt.Errorf("errorClient: Notify %s", method)
+}
+
+func TestFetchRetry(t *testing.T) {
+	world, ri2, _, sender, list, tlf := setupTest(t, 3)
+	defer world.Cleanup()
+
+	ri := ri2.(*kbtest.ChatRemoteMock)
+	rifunc := func() chat1.RemoteInterface { return ri }
+	u := world.GetUsers()[0]
+	u1 := world.GetUsers()[1]
+	u2 := world.GetUsers()[2]
+	uid := u.User.GetUID().ToBytes()
+	tc := world.Tcs[u.Username]
+	store := storage.New(tc.G)
+
+	var convIDs []chat1.ConversationID
+	var convs []chat1.Conversation
+	convs = append(convs, newConv(t, uid, ri, sender, tlf, u.Username+","+u1.Username))
+	convs = append(convs, newConv(t, uid, ri, sender, tlf, u.Username+","+u2.Username))
+	convs = append(convs, newConv(t, uid, ri, sender, tlf, u.Username+","+u2.Username+","+u1.Username))
+	for _, conv := range convs {
+		convIDs = append(convIDs, conv.GetConvID())
+	}
+
+	// Nuke body cache
+	require.NoError(t, store.MaybeNuke(true, nil, convs[0].GetConvID(), uid))
+
+	errorRI := func() chat1.RemoteInterface { return chat1.RemoteClient{Cli: errorClient{}} }
+	tc.G.ConvSource.SetRemoteInterface(errorRI)
+
+	inbox, _, err := tc.G.InboxSource.Read(context.TODO(), uid, nil, true, &chat1.GetInboxLocalQuery{
+		ConvIDs: convIDs,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, inbox.Convs[2].Error)
+	require.Nil(t, inbox.Convs[0].Error)
+	tc.G.ChatFetchRetrier.Failure(context.TODO(), inbox.Convs[2].GetConvID(), uid, types.ThreadLoad)
+
+	// Advance clock and check for errors on all conversations
+	t.Logf("advancing clock and checking for stale")
+	tc.G.ConvSource.SetRemoteInterface(rifunc)
+	world.Fc.Advance(time.Hour)
+	select {
+	case cids := <-list.threadsStale:
+		require.Equal(t, 1, len(cids))
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "timeout on inbox stale")
+	}
+	world.Fc.Advance(time.Hour)
+	select {
+	case <-list.threadsStale:
+		require.Fail(t, "invalid stale message")
+	default:
+	}
+
+	t.Logf("trying to use Force")
+	tc.G.ChatFetchRetrier.Failure(context.TODO(), inbox.Convs[2].GetConvID(), uid, types.ThreadLoad)
+	tc.G.ChatFetchRetrier.Force(context.TODO())
+	select {
+	case cids := <-list.threadsStale:
+		require.Equal(t, 1, len(cids))
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "timeout on inbox stale")
+	}
+
+}

--- a/go/chat/retry_test.go
+++ b/go/chat/retry_test.go
@@ -66,7 +66,7 @@ func TestFetchRetry(t *testing.T) {
 	select {
 	case cids := <-list.threadsStale:
 		require.Equal(t, 1, len(cids))
-	case <-time.After(5 * time.Second):
+	case <-time.After(20 * time.Second):
 		require.Fail(t, "timeout on inbox stale")
 	}
 	world.Fc.Advance(time.Hour)
@@ -82,7 +82,7 @@ func TestFetchRetry(t *testing.T) {
 	select {
 	case cids := <-list.threadsStale:
 		require.Equal(t, 1, len(cids))
-	case <-time.After(5 * time.Second):
+	case <-time.After(20 * time.Second):
 		require.Fail(t, "timeout on inbox stale")
 	}
 

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -489,6 +489,8 @@ type Deliverer struct {
 	clock         clockwork.Clock
 }
 
+var _ types.MessageDeliverer = (*Deliverer)(nil)
+
 func NewDeliverer(g *libkb.GlobalContext, sender Sender) *Deliverer {
 	d := &Deliverer{
 		Contextified:  libkb.NewContextified(g),

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -148,6 +148,10 @@ func setupTest(t *testing.T, numUsers int) (*kbtest.ChatMockWorld, chat1.RemoteI
 	tc.G.MessageDeliverer.(*Deliverer).SetClock(world.Fc)
 	tc.G.MessageDeliverer.Start(context.TODO(), u.User.GetUID().ToBytes())
 	tc.G.MessageDeliverer.Connected(context.TODO())
+	tc.G.ChatFetchRetrier = NewFetchRetrier(tc.G)
+	tc.G.ChatFetchRetrier.(*FetchRetrier).SetClock(world.Fc)
+	tc.G.ChatFetchRetrier.Start(context.TODO(), u.User.GetUID().ToBytes())
+	tc.G.ChatFetchRetrier.Connected(context.TODO())
 	chatSyncer := NewSyncer(tc.G)
 	chatSyncer.isConnected = true
 	tc.G.ChatSyncer = chatSyncer

--- a/go/chat/storage/basebox.go
+++ b/go/chat/storage/basebox.go
@@ -86,7 +86,7 @@ func (i *baseBox) writeDiskBox(ctx context.Context, key libkb.DbKey, data interf
 	}
 
 	if i.encrypted {
-		// Encrypt outbox
+		// Encrypt outbox if configure as such
 		enckey, err := getSecretBoxKey(ctx, i.G(), DefaultSecretUI)
 		if err != nil {
 			return err

--- a/go/chat/storage/basebox.go
+++ b/go/chat/storage/basebox.go
@@ -17,6 +17,7 @@ type boxedData struct {
 
 type baseBox struct {
 	libkb.Contextified
+	encrypted bool
 }
 
 type SecretUI struct {
@@ -28,9 +29,10 @@ func (d SecretUI) GetPassphrase(pinentry keybase1.GUIEntryArg, terminal *keybase
 
 var DefaultSecretUI = func() libkb.SecretUI { return SecretUI{} }
 
-func newBaseBox(g *libkb.GlobalContext) *baseBox {
+func newBaseBox(g *libkb.GlobalContext, encrypted bool) *baseBox {
 	return &baseBox{
 		Contextified: libkb.NewContextified(g),
+		encrypted:    encrypted,
 	}
 }
 
@@ -45,22 +47,29 @@ func (i *baseBox) readDiskBox(ctx context.Context, key libkb.DbKey, res interfac
 	}
 
 	// Decode encrypted box
-	var boxed boxedData
-	if err := decode(b, &boxed); err != nil {
-		return true, err
+	var pt []byte
+	if i.encrypted {
+		var boxed boxedData
+		if err := decode(b, &boxed); err != nil {
+			return true, err
+		}
+		if boxed.V > cryptoVersion {
+			return true, fmt.Errorf("bad crypto version: %d current: %d", boxed.V,
+				cryptoVersion)
+		}
+		enckey, err := getSecretBoxKey(ctx, i.G(), DefaultSecretUI)
+		if err != nil {
+			return true, err
+		}
+		var ok bool
+		pt, ok = secretbox.Open(nil, boxed.E, &boxed.N, &enckey)
+		if !ok {
+			return true, fmt.Errorf("failed to decrypt inxbox")
+		}
+	} else {
+		pt = b
 	}
-	if boxed.V > cryptoVersion {
-		return true, fmt.Errorf("bad crypto version: %d current: %d", boxed.V,
-			cryptoVersion)
-	}
-	enckey, err := getSecretBoxKey(ctx, i.G(), DefaultSecretUI)
-	if err != nil {
-		return true, err
-	}
-	pt, ok := secretbox.Open(nil, boxed.E, &boxed.N, &enckey)
-	if !ok {
-		return true, fmt.Errorf("failed to decrypt inxbox")
-	}
+
 	if err = decode(pt, res); err != nil {
 		return true, err
 	}
@@ -76,28 +85,30 @@ func (i *baseBox) writeDiskBox(ctx context.Context, key libkb.DbKey, data interf
 		return err
 	}
 
-	// Encrypt outbox
-	enckey, err := getSecretBoxKey(ctx, i.G(), DefaultSecretUI)
-	if err != nil {
-		return err
-	}
-	var nonce []byte
-	nonce, err = libkb.RandBytes(24)
-	if err != nil {
-		return err
-	}
-	var fnonce [24]byte
-	copy(fnonce[:], nonce)
-	sealed := secretbox.Seal(nil, dat, &fnonce, &enckey)
-	boxed := boxedBlock{
-		V: cryptoVersion,
-		E: sealed,
-		N: fnonce,
-	}
+	if i.encrypted {
+		// Encrypt outbox
+		enckey, err := getSecretBoxKey(ctx, i.G(), DefaultSecretUI)
+		if err != nil {
+			return err
+		}
+		var nonce []byte
+		nonce, err = libkb.RandBytes(24)
+		if err != nil {
+			return err
+		}
+		var fnonce [24]byte
+		copy(fnonce[:], nonce)
+		sealed := secretbox.Seal(nil, dat, &fnonce, &enckey)
+		boxed := boxedBlock{
+			V: cryptoVersion,
+			E: sealed,
+			N: fnonce,
+		}
 
-	// Encode encrypted outbox
-	if dat, err = encode(boxed); err != nil {
-		return err
+		// Encode encrypted outbox
+		if dat, err = encode(boxed); err != nil {
+			return err
+		}
 	}
 
 	// Write out

--- a/go/chat/storage/convfailurebox.go
+++ b/go/chat/storage/convfailurebox.go
@@ -95,7 +95,7 @@ func (f *ConversationFailureBox) Success(ctx context.Context, convID chat1.Conve
 	_, ierr := f.readDiskBox(ctx, f.dbKey(), &failures)
 	if ierr != nil {
 		return NewInternalError(ctx, f.DebugLabeler,
-			"failed to read conversation failure box: uid: %s err: %", f.uid, ierr.Error())
+			"failed to read conversation failure box: uid: %s err: %s", f.uid, ierr.Error())
 	}
 
 	var newFailures []ConversationFailureRecord

--- a/go/chat/storage/convfailurebox.go
+++ b/go/chat/storage/convfailurebox.go
@@ -1,0 +1,114 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+)
+
+const maxConvAttempts = 10
+
+type failureEntry struct {
+	ConvID   chat1.ConversationID `codec:"C"`
+	Attempts int                  `codec:"A"`
+}
+
+type ConversationFailureBox struct {
+	libkb.Contextified
+	*baseBox
+	utils.DebugLabeler
+
+	uid gregor1.UID
+	key string
+}
+
+func NewConversationFailureBox(g *libkb.GlobalContext, uid gregor1.UID, key string) *ConversationFailureBox {
+	return &ConversationFailureBox{
+		Contextified: libkb.NewContextified(g),
+		baseBox:      newBaseBox(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "ConversationFailureBox", false),
+		uid:          uid,
+		key:          key,
+	}
+}
+
+func (f *ConversationFailureBox) dbKey() libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBChatConvFailures,
+		Key: fmt.Sprintf("%s:%s", f.uid, f.key),
+	}
+}
+
+func (f *ConversationFailureBox) Failure(ctx context.Context, convID chat1.ConversationID,
+	uid gregor1.UID) (err Error) {
+	locks.ConvFailures.Lock()
+	defer locks.ConvFailures.Unlock()
+	defer f.maybeNukeFn(func() Error { return err }, f.dbKey())
+
+	var failures []failureEntry
+	_, ierr := f.readDiskBox(ctx, f.dbKey(), &failures)
+	if ierr != nil {
+		return NewInternalError(ctx, f.DebugLabeler,
+			"failed to read conversation failure box: uid: %s err: %", uid, ierr.Error())
+	}
+
+	var newFailures []failureEntry
+	found := false
+	for _, failure := range failures {
+		if failure.ConvID.Eq(convID) {
+			found = true
+			failure.Attempts++
+			if failure.Attempts > maxConvAttempts {
+				f.Debug(ctx, "Failure: conversation: %s over max failures, dropping...", convID)
+				continue
+			}
+		}
+		newFailures = append(newFailures, failure)
+	}
+	if !found {
+		newFailures = append(newFailures, failureEntry{
+			ConvID: convID,
+		})
+	}
+
+	if err := f.writeDiskBox(ctx, f.dbKey(), newFailures); err != nil {
+		return NewInternalError(ctx, f.DebugLabeler,
+			"failed to write conversation failure box: uid: %s err: %s", uid, err.Error())
+	}
+
+	return nil
+}
+
+func (f *ConversationFailureBox) Success(ctx context.Context, convID chat1.ConversationID,
+	uid gregor1.UID) (err Error) {
+	locks.ConvFailures.Lock()
+	defer locks.ConvFailures.Unlock()
+	defer f.maybeNukeFn(func() Error { return err }, f.dbKey())
+
+	var failures []failureEntry
+	_, ierr := f.readDiskBox(ctx, f.dbKey(), &failures)
+	if ierr != nil {
+		return NewInternalError(ctx, f.DebugLabeler,
+			"failed to read conversation failure box: uid: %s err: %", uid, ierr.Error())
+	}
+
+	var newFailures []failureEntry
+	for _, failure := range failures {
+		if failure.ConvID.Eq(convID) {
+			f.Debug(ctx, "Success: removing conversation: %d from failure list", convID)
+			continue
+		}
+		newFailures = append(newFailures, failure)
+	}
+
+	if err := f.writeDiskBox(ctx, f.dbKey(), newFailures); err != nil {
+		return NewInternalError(ctx, f.DebugLabeler,
+			"failed to write conversation failure box: uid: %s err: %s", uid, err.Error())
+	}
+
+	return nil
+}

--- a/go/chat/storage/convfailurebox.go
+++ b/go/chat/storage/convfailurebox.go
@@ -54,7 +54,7 @@ func (f *ConversationFailureBox) Failure(ctx context.Context, convID chat1.Conve
 	_, ierr := f.readDiskBox(ctx, f.dbKey(), &failures)
 	if ierr != nil {
 		return NewInternalError(ctx, f.DebugLabeler,
-			"failed to read conversation failure box: uid: %s err: %", f.uid, ierr.Error())
+			"failed to read conversation failure box: uid: %s err: %s", f.uid, ierr.Error())
 	}
 
 	var newFailures []ConversationFailureRecord

--- a/go/chat/storage/convfailurebox_test.go
+++ b/go/chat/storage/convfailurebox_test.go
@@ -1,0 +1,48 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvFailureBox(t *testing.T) {
+	tc := externals.SetupTest(t, "ConvFailureBox", 2)
+	u, err := kbtest.CreateAndSignupFakeUser("cf", tc.G)
+	require.NoError(t, err)
+	uid := gregor1.UID(u.User.GetUID().ToBytes())
+	cfb := NewConversationFailureBox(tc.G, uid, "mike")
+
+	convID := randBytes(8)
+	require.NoError(t, cfb.Failure(context.TODO(), convID))
+
+	res, err := cfb.Read(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, res[0].Attempts)
+
+	require.NoError(t, cfb.Failure(context.TODO(), convID))
+	res, err = cfb.Read(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+	require.Equal(t, 2, res[0].Attempts)
+
+	convID2 := randBytes(8)
+	require.NoError(t, cfb.Failure(context.TODO(), convID2))
+	res, err = cfb.Read(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, 2, len(res))
+
+	require.NoError(t, cfb.Success(context.TODO(), convID2))
+	res, err = cfb.Read(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+	require.Equal(t, 2, res[0].Attempts)
+	require.Equal(t, chat1.ConversationID(convID), res[0].ConvID)
+
+}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -86,7 +86,7 @@ func NewInbox(g *libkb.GlobalContext, uid gregor1.UID) *Inbox {
 	return &Inbox{
 		Contextified: libkb.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g, "Inbox", false),
-		baseBox:      newBaseBox(g),
+		baseBox:      newBaseBox(g, true),
 		uid:          uid,
 	}
 }

--- a/go/chat/storage/locks.go
+++ b/go/chat/storage/locks.go
@@ -3,7 +3,7 @@ package storage
 import "sync"
 
 type locksRepo struct {
-	Storage, Inbox, Outbox, Version sync.Mutex
+	Storage, Inbox, Outbox, Version, ConvFailures sync.Mutex
 }
 
 var locks locksRepo

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -34,7 +34,7 @@ func NewOutbox(g *libkb.GlobalContext, uid gregor1.UID) *Outbox {
 	return &Outbox{
 		Contextified: libkb.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g, "Outbox", false),
-		baseBox:      newBaseBox(g),
+		baseBox:      newBaseBox(g, true),
 		uid:          uid,
 		clock:        clockwork.NewRealClock(),
 	}

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -2,7 +2,6 @@ package chat
 
 import (
 	"encoding/hex"
-	"fmt"
 	"sync"
 	"time"
 
@@ -112,34 +111,6 @@ func (s *Syncer) getConvIDs(convs []chat1.Conversation) (res []chat1.Conversatio
 	return res
 }
 
-func (s *Syncer) dbKey(uid gregor1.UID) libkb.DbKey {
-	return libkb.DbKey{
-		Typ: libkb.DBChatSyncer,
-		Key: fmt.Sprintf("%s", uid),
-	}
-}
-
-func (s *Syncer) AddStaleConversation(ctx context.Context, uid gregor1.UID,
-	convID chat1.ConversationID) {
-	s.Lock()
-	defer s.Unlock()
-	defer s.Trace(ctx, func() error { return nil }, fmt.Sprintf("AddStaleConversation(%s)", convID))()
-
-	// Read current data (if any)
-	var convIDs []chat1.ConversationID
-	key := s.dbKey(uid)
-	_, err := s.G().LocalChatDb.GetInto(&convIDs, key)
-	if err != nil {
-		s.Debug(ctx, "AddStaleConversation: failed to get current stale list, using empty: %s",
-			err.Error())
-	}
-	convIDs = append(convIDs, convID)
-
-	if err := s.G().LocalChatDb.PutObj(key, nil, convIDs); err != nil {
-		s.Debug(ctx, "AddStaleConversation: failed to write stale list: %s", err.Error())
-	}
-}
-
 func (s *Syncer) SendChatStaleNotifications(ctx context.Context, uid gregor1.UID,
 	convIDs []chat1.ConversationID, immediate bool) {
 	if len(convIDs) == 0 {
@@ -171,25 +142,6 @@ func (s *Syncer) IsConnected(ctx context.Context) bool {
 	return s.isConnected
 }
 
-func (s *Syncer) sendStoredStaleNotifications(ctx context.Context, uid gregor1.UID) {
-	var convIDs []chat1.ConversationID
-	key := s.dbKey(uid)
-	found, err := s.G().LocalChatDb.GetInto(&convIDs, key)
-	if err != nil {
-		s.Debug(ctx, "sendStoredStaleNotifications: failed to read stale notifications: %s", err.Error())
-	}
-	if !found {
-		s.Debug(ctx, "sendStoredStaleNotifications: no notifications found, skipping")
-		return
-	}
-	s.Debug(ctx, "sendStoredStaleNotifications: sending %d stale notifications", len(convIDs))
-	s.SendChatStaleNotifications(ctx, uid, convIDs, false)
-
-	if err := s.G().LocalChatDb.Delete(key); err != nil {
-		s.Debug(ctx, "sendStoredStaleNotifications: error deleting record: %s", err.Error())
-	}
-}
-
 func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,
 	syncRes *chat1.SyncChatRes) (err error) {
 	ctx = CtxAddLogTags(ctx)
@@ -203,9 +155,6 @@ func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid g
 	for _, o := range s.offlinables {
 		o.Connected(ctx)
 	}
-
-	// Send stale notifications that have been registered with us
-	s.sendStoredStaleNotifications(ctx, uid)
 
 	// Run sync against the server
 	s.sync(ctx, cli, uid, syncRes)

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -95,6 +95,14 @@ type Syncer interface {
 	RegisterOfflinable(offlinable Offlinable)
 	SendChatStaleNotifications(ctx context.Context, uid gregor1.UID, convIDs []chat1.ConversationID,
 		immediate bool)
-	AddStaleConversation(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID)
 	Shutdown()
+}
+
+type FetchRetrier interface {
+	Offlinable
+	Failure(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, kind FetchType) error
+	Success(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, kind FetchType) error
+
+	Start(ctx context.Context, uid gregor1.UID)
+	Stop(ctx context.Context) chan struct{}
 }

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -13,6 +13,11 @@ type Offlinable interface {
 	Disconnected(ctx context.Context)
 }
 
+type Resumable interface {
+	Start(ctx context.Context, uid gregor1.UID)
+	Stop(ctx context.Context) chan struct{}
+}
+
 type TLFInfoSource interface {
 	Lookup(ctx context.Context, tlfName string, vis chat1.TLFVisibility) (*TLFInfo, error)
 	CryptKeys(ctx context.Context, tlfName string) (keybase1.GetTLFCryptKeysRes, error)
@@ -41,11 +46,10 @@ type ConversationSource interface {
 
 type MessageDeliverer interface {
 	Offlinable
+	Resumable
 
 	Queue(ctx context.Context, convID chat1.ConversationID, msg chat1.MessagePlaintext,
 		identifyBehavior keybase1.TLFIdentifyBehavior) (chat1.OutboxRecord, error)
-	Start(ctx context.Context, uid gregor1.UID)
-	Stop(ctx context.Context) chan struct{}
 	ForceDeliverLoop(ctx context.Context)
 }
 
@@ -100,9 +104,9 @@ type Syncer interface {
 
 type FetchRetrier interface {
 	Offlinable
+	Resumable
+
 	Failure(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, kind FetchType) error
 	Success(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, kind FetchType) error
-
-	Start(ctx context.Context, uid gregor1.UID)
-	Stop(ctx context.Context) chan struct{}
+	Force(ctx context.Context)
 }

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -10,3 +10,10 @@ type TLFInfo struct {
 	CanonicalName    string
 	IdentifyFailures []keybase1.TLFIdentifyFailure
 }
+
+type FetchType int
+
+const (
+	InboxLoad FetchType = iota
+	ThreadLoad
+)

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -28,6 +28,9 @@ func (c ChatTestContext) Cleanup() {
 	if c.G.MessageDeliverer != nil {
 		<-c.G.MessageDeliverer.Stop(context.TODO())
 	}
+	if c.G.ChatFetchRetrier != nil {
+		<-c.G.ChatFetchRetrier.Stop(context.TODO())
+	}
 	c.TestContext.Cleanup()
 }
 

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -189,7 +189,7 @@ const (
 	DBResolveUsernameToUID    = 0xfb
 	DBChatBodyHashIndex       = 0xfc
 	DBPvl                     = 0xfd
-	DBChatSyncer              = 0xfe
+	DBChatConvFailures        = 0xfe
 )
 
 const (

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -112,6 +112,7 @@ type GlobalContext struct {
 	ServerCacheVersions chattypes.ServerCacheVersions // server side versions for chat caches
 	ChatSyncer          chattypes.Syncer              // For syncing inbox with server
 	TlfInfoSource       chattypes.TLFInfoSource
+	ChatFetchRetrier    chattypes.FetchRetrier // For retrying failed fetch requests
 
 	// Can be overloaded by tests to get an improvement in performance
 	NewTriplesec func(pw []byte, salt []byte) (Triplesec, error)

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -515,6 +515,9 @@ func (g *GlobalContext) Shutdown() error {
 		if g.MessageDeliverer != nil {
 			g.MessageDeliverer.Stop(context.Background())
 		}
+		if g.ChatFetchRetrier != nil {
+			g.ChatFetchRetrier.Stop(context.Background())
+		}
 		if g.ChatSyncer != nil {
 			g.ChatSyncer.Shutdown()
 		}

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -1241,7 +1241,7 @@ func TestGetThreadNonblockError(t *testing.T) {
 	select {
 	case cids := <-listener.threadsStale:
 		require.Equal(t, 1, len(cids))
-	case <-time.After(20 * time.Second):
+	case <-time.After(2 * time.Second):
 		require.Fail(t, "no threads stale message received")
 	}
 }

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -1241,7 +1241,7 @@ func TestGetThreadNonblockError(t *testing.T) {
 	select {
 	case cids := <-listener.threadsStale:
 		require.Equal(t, 1, len(cids))
-	case <-time.After(5 * time.Second):
+	case <-time.After(20 * time.Second):
 		require.Fail(t, "no threads stale message received")
 	}
 }
@@ -1285,14 +1285,14 @@ func TestGetInboxNonblockError(t *testing.T) {
 	// Eat untrusted CB
 	select {
 	case <-inboxCb:
-	case <-time.After(5 * time.Second):
+	case <-time.After(20 * time.Second):
 		require.Fail(t, "no untrusted inbox")
 	}
 
 	select {
 	case nbres := <-inboxCb:
 		require.Error(t, nbres.Err)
-	case <-time.After(5 * time.Second):
+	case <-time.After(20 * time.Second):
 		require.Fail(t, "no inbox load event")
 	}
 
@@ -1305,7 +1305,7 @@ func TestGetInboxNonblockError(t *testing.T) {
 	select {
 	case cids := <-listener.threadsStale:
 		require.Equal(t, 1, len(cids))
-	case <-time.After(5 * time.Second):
+	case <-time.After(20 * time.Second):
 		require.Fail(t, "no threads stale message received")
 	}
 }

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -1177,6 +1177,10 @@ func TestGetThreadNonblock(t *testing.T) {
 
 }
 
+func TestFetchRetry(t *testing.T) {
+
+}
+
 func TestMakePreview(t *testing.T) {
 	ctc := makeChatTestContext(t, "MakePreview", 1)
 	defer ctc.cleanup()

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -1218,8 +1218,8 @@ func TestGetThreadNonblockError(t *testing.T) {
 		mustPostLocalForTest(t, ctc, users[0], conv, msg)
 	}
 	require.NoError(t, ctc.world.Tcs[users[0].Username].G.ConvSource.Clear(conv.Id, uid))
-	G := ctc.world.Tcs[users[0].Username].G
-	G.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
+	g := ctc.world.Tcs[users[0].Username].G
+	g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
 		return chat1.RemoteClient{Cli: errorClient{}}
 	})
 
@@ -1233,7 +1233,7 @@ func TestGetThreadNonblockError(t *testing.T) {
 	require.Error(t, err)
 
 	// Advance clock and look for stale
-	G.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
+	g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
 		return kbtest.NewChatRemoteMock(ctc.world)
 	})
 	ctc.world.Fc.Advance(time.Hour)
@@ -1268,8 +1268,8 @@ func TestGetInboxNonblockError(t *testing.T) {
 		mustPostLocalForTest(t, ctc, users[0], conv, msg)
 	}
 	require.NoError(t, ctc.world.Tcs[users[0].Username].G.ConvSource.Clear(conv.Id, uid))
-	G := ctc.world.Tcs[users[0].Username].G
-	G.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
+	g := ctc.world.Tcs[users[0].Username].G
+	g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
 		return chat1.RemoteClient{Cli: errorClient{}}
 	})
 
@@ -1297,7 +1297,7 @@ func TestGetInboxNonblockError(t *testing.T) {
 	}
 
 	// Advance clock and look for stale
-	G.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
+	g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
 		return kbtest.NewChatRemoteMock(ctc.world)
 	})
 	ctc.world.Fc.Advance(time.Hour)

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -95,6 +95,10 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	tc.G.MessageDeliverer.Start(context.TODO(), user.User.GetUID().ToBytes())
 	tc.G.MessageDeliverer.Connected(context.TODO())
 
+	tc.G.ChatFetchRetrier = chat.NewFetchRetrier(tc.G)
+	tc.G.ChatFetchRetrier.Start(context.TODO(), user.User.GetUID().ToBytes())
+	tc.G.ChatFetchRetrier.Connected(context.TODO())
+
 	tuc := &chatTestUserContext{
 		h: h,
 		u: user,

--- a/go/service/chat_local_test.go
+++ b/go/service/chat_local_test.go
@@ -1177,10 +1177,6 @@ func TestGetThreadNonblock(t *testing.T) {
 
 }
 
-func TestFetchRetry(t *testing.T) {
-
-}
-
 func TestMakePreview(t *testing.T) {
 	ctc := makeChatTestContext(t, "MakePreview", 1)
 	defer ctc.cleanup()

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -293,7 +293,7 @@ func (d *Service) chatRemoteClient() chat1.RemoteInterface {
 		d.G().Log.Debug("service not connected to gregor, using errorClient for chat1.RemoteClient")
 		return chat1.RemoteClient{Cli: errorClient{}}
 	}
-	return chat1.RemoteClient{Cli: d.gregor.cli}
+	return chat1.RemoteClient{Cli: chat.NewRemoteClient(d.G(), d.gregor.cli)}
 }
 
 func (d *Service) configureRekey(uir *UIRouter) {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -236,34 +236,30 @@ func (d *Service) RunBackgroundOperations(uir *UIRouter) {
 	// backgrounded.
 	d.tryLogin()
 	d.hourlyChecks()
-	d.createChatSources()
-	d.createMessageDeliverer()
+	d.createChatModules()
 	d.startupGregor()
-	d.startMessageDeliverer()
+	d.startChatModules()
 	d.addGlobalHooks()
 	d.configurePath()
 	d.configureRekey(uir)
 	d.runBackgroundIdentifier()
 }
 
-func (d *Service) createMessageDeliverer() {
-	ri := d.chatRemoteClient
-	tlf := chat.NewKBFSTLFInfoSource(d.G())
-
-	sender := chat.NewBlockingSender(d.G(), chat.NewBoxer(d.G(), tlf), d.attachmentstore, ri)
-	d.G().MessageDeliverer = chat.NewDeliverer(d.G(), sender)
-
-	d.G().ChatSyncer.RegisterOfflinable(d.G().MessageDeliverer)
-}
-
-func (d *Service) startMessageDeliverer() {
+func (d *Service) startChatModules() {
 	uid := d.G().Env.GetUID()
 	if !uid.IsNil() {
-		d.G().MessageDeliverer.Start(context.Background(), d.G().Env.GetUID().ToBytes())
+		uid := d.G().Env.GetUID().ToBytes()
+		d.G().MessageDeliverer.Start(context.Background(), uid)
+		d.G().ChatFetchRetrier.Start(context.Background(), uid)
 	}
 }
 
-func (d *Service) createChatSources() {
+func (d *Service) stopChatModules() {
+	<-d.G().MessageDeliverer.Stop(context.Background())
+	<-d.G().ChatFetchRetrier.Stop(context.Background())
+}
+
+func (d *Service) createChatModules() {
 	ri := d.chatRemoteClient
 	tlf := chat.NewKBFSTLFInfoSource(d.G())
 
@@ -276,10 +272,16 @@ func (d *Service) createChatSources() {
 
 	chatSyncer := chat.NewSyncer(d.G())
 	d.G().ChatSyncer = chatSyncer
+	d.G().ChatFetchRetrier = chat.NewFetchRetrier(d.G())
+
+	sender := chat.NewBlockingSender(d.G(), chat.NewBoxer(d.G(), tlf), d.attachmentstore, ri)
+	d.G().MessageDeliverer = chat.NewDeliverer(d.G(), sender)
 
 	// Set up Offlinables on Syncer
 	chatSyncer.RegisterOfflinable(d.G().InboxSource)
 	chatSyncer.RegisterOfflinable(d.G().ConvSource)
+	chatSyncer.RegisterOfflinable(d.G().ChatFetchRetrier)
+	chatSyncer.RegisterOfflinable(d.G().MessageDeliverer)
 
 	// Add a tlfHandler into the user changed handler group so we can keep identify info
 	// fresh
@@ -459,7 +461,7 @@ func (d *Service) OnLogin() error {
 	}
 	uid := d.G().Env.GetUID()
 	if !uid.IsNil() {
-		d.G().MessageDeliverer.Start(context.Background(), d.G().Env.GetUID().ToBytes())
+		d.startChatModules()
 		d.runBackgroundIdentifierWithUID(uid)
 	}
 	return nil
@@ -477,8 +479,8 @@ func (d *Service) OnLogout() (err error) {
 		d.gregor.Shutdown()
 	}
 
-	log("shutting down message deliverer")
-	d.G().MessageDeliverer.Stop(context.Background())
+	log("shutting down chat modules")
+	d.stopChatModules()
 
 	log("shutting down rekeyMaster")
 	d.rekeyMaster.Logout()


### PR DESCRIPTION
Extend the methods of a bunch of my previous patches to apply to all errors received from nonblocking calls for getting conversation message and inbox conversation metadata. 

1.) Introduce `FetchRetrier`, which stores all failures in LevelDB along with the number of attempts, and the last attempt time.
2.) Introduce `ConversationFailureBox`, which is responsible to recording failures and successes.
3.) Upgrade `baseBox` so it can store unencrypted data using the same interface.
4.) Feed more errors into `FetchRetrier`.
5.) Add a bunch of tests.