### PR TITLE
Handle revocations in PGP better

### DIFF
--- a/go/engine/pgp_decrypt.go
+++ b/go/engine/pgp_decrypt.go
@@ -147,6 +147,12 @@ func (e *PGPDecrypt) Run(ctx *Context) (err error) {
 		return libkb.NoKeyError{Msg: fmt.Sprintf("In signature verification: no public key found for PGP ID %x", e.signStatus.KeyID)}
 	}
 
+	if entity := e.signStatus.Entity; len(entity.UnverifiedRevocations) > 0 {
+		return libkb.BadSigError{
+			E: fmt.Sprintf("Key %x belonging to %q has been revoked by its designated revoker.", entity.PrimaryKey.KeyId, e.signer.GetName()),
+		}
+	}
+
 	bundle := libkb.NewPGPKeyBundle(e.signStatus.Entity)
 	OutputSignatureSuccess(ctx, bundle.GetFingerprint(), e.signer, e.signStatus.SignatureTime)
 	return nil

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -147,7 +147,7 @@ func (e *PGPEncrypt) Run(ctx *Context) error {
 		}
 	}
 
-	if len(ks.keys) == 0 {
+	if len(e.arg.Recips) > 0 && len(ks.keys) == 0 {
 		return errors.New("Cannot encrypt - recipient does not have a non-revoked key.")
 	}
 

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -136,6 +136,21 @@ func (e *PGPEncrypt) Run(ctx *Context) error {
 	}
 
 	ks := newKeyset()
+
+	for _, up := range uplus {
+		for _, k := range up.Keys {
+			if len(k.Entity.Revocations)+len(k.Entity.UnverifiedRevocations) > 0 {
+				continue
+			}
+
+			ks.Add(k)
+		}
+	}
+
+	if len(ks.keys) == 0 {
+		return errors.New("Cannot encrypt - recipient does not have a non-revoked key.")
+	}
+
 	if !e.arg.NoSelf {
 		if mykey == nil {
 			// need to load the public key for the logged in user
@@ -148,12 +163,6 @@ func (e *PGPEncrypt) Run(ctx *Context) error {
 		// mykey could still be nil
 		if mykey != nil {
 			ks.Add(mykey)
-		}
-	}
-
-	for _, up := range uplus {
-		for _, k := range up.Keys {
-			ks.Add(k)
 		}
 	}
 

--- a/go/engine/pgp_verify.go
+++ b/go/engine/pgp_verify.go
@@ -136,6 +136,12 @@ func (e *PGPVerify) runDetached(ctx *Context) error {
 	e.signStatus = &libkb.SignatureStatus{IsSigned: true}
 
 	if signer != nil {
+		if len(signer.UnverifiedRevocations) > 0 {
+			return libkb.BadSigError{
+				E: fmt.Sprintf("Key %x belonging to %q has been revoked by its designated revoker.", signer.PrimaryKey.KeyId, e.signer.GetName()),
+			}
+		}
+
 		e.signStatus.Verified = true
 		e.signStatus.Entity = signer
 		if err := e.checkSignedBy(ctx); err != nil {

--- a/go/engine/pgp_verify.go
+++ b/go/engine/pgp_verify.go
@@ -199,6 +199,12 @@ func (e *PGPVerify) runClearsign(ctx *Context) error {
 	e.signStatus = &libkb.SignatureStatus{IsSigned: true}
 
 	if signer != nil {
+		if len(signer.UnverifiedRevocations) > 0 {
+			return libkb.BadSigError{
+				E: fmt.Sprintf("Key %x belonging to %q has been revoked by its designated revoker.", signer.PrimaryKey.KeyId, e.signer.GetName()),
+			}
+		}
+
 		e.signStatus.Verified = true
 		e.signStatus.Entity = signer
 		if err := e.checkSignedBy(ctx); err != nil {

--- a/go/libkb/gpg_index.go
+++ b/go/libkb/gpg_index.go
@@ -302,6 +302,7 @@ func (k *GpgPrimaryKey) AddLine(l *GpgIndexLine) (err error) {
 		case "uat", "grp": // ignore
 		case "sub", "ssb":
 			err = k.AddSubkey(l)
+		case "rvk": // designated revoker (ignore)
 		default:
 			err = GpgIndexError{l.lineno, fmt.Sprintf("Unknown subfield: %s", f)}
 		}

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -869,7 +869,7 @@ func (ckf ComputedKeyFamily) exportPublicKey(key GenericKey) (pk keybase1.Public
 			i++
 		}
 		pk.PGPIdentities = ids
-		pk.IsRevoked = len(pgpBundle.Revocations) > 0
+		pk.IsRevoked = len(pgpBundle.Revocations)+len(pgpBundle.UnverifiedRevocations) > 0
 	}
 	pk.DeviceID = ckf.cki.KIDToDeviceID[pk.KID]
 	device := ckf.cki.Devices[pk.DeviceID]

--- a/go/vendor/github.com/keybase/go-crypto/openpgp/keys.go
+++ b/go/vendor/github.com/keybase/go-crypto/openpgp/keys.go
@@ -6,12 +6,14 @@ package openpgp
 
 import (
 	"crypto/hmac"
+	"encoding/binary"
+	"io"
+	"time"
+
 	"github.com/keybase/go-crypto/openpgp/armor"
 	"github.com/keybase/go-crypto/openpgp/errors"
 	"github.com/keybase/go-crypto/openpgp/packet"
 	"github.com/keybase/go-crypto/rsa"
-	"io"
-	"time"
 )
 
 // PublicKeyType is the armor type for a PGP public key.
@@ -28,8 +30,13 @@ type Entity struct {
 	PrivateKey  *packet.PrivateKey
 	Identities  map[string]*Identity // indexed by Identity.Name
 	Revocations []*packet.Signature
-	Subkeys     []Subkey
-	BadSubkeys  []BadSubkey
+	// Revocations that are signed by designated revokers. Reading keys
+	// will not verify these revocations, because it won't have access to
+	// issuers' public keys, API consumers should do this instead (or
+	// not, and just assume that the key is probably revoked).
+	UnverifiedRevocations []*packet.Signature
+	Subkeys               []Subkey
+	BadSubkeys            []BadSubkey
 }
 
 // An Identity represents an identity claimed by an Entity and zero or more
@@ -39,6 +46,7 @@ type Identity struct {
 	UserId        *packet.UserId
 	SelfSignature *packet.Signature
 	Signatures    []*packet.Signature
+	Revocation    *packet.Signature
 }
 
 // A Subkey is an additional public key in an Entity. Subkeys can be used for
@@ -424,6 +432,8 @@ func ReadEntity(packets *packet.Reader) (*Entity, error) {
 
 	var current *Identity
 	var revocations []*packet.Signature
+
+	designatedRevokers := make(map[uint64]bool)
 EachPacket:
 	for {
 		p, err := packets.Next()
@@ -442,6 +452,14 @@ EachPacket:
 			current.Name = pkt.Id
 			current.UserId = pkt
 		case *packet.Signature:
+			if pkt.SigType == packet.SigTypeKeyRevocation {
+				// These revocations won't revoke UIDs (see
+				// SigTypeIdentityRevocation). Handle these first,
+				// because key might have revocation coming from
+				// another key (designated revoke).
+				revocations = append(revocations, pkt)
+				continue
+			}
 
 			// These are signatures by other people on this key. Let's just ignore them
 			// from the beginning, since they shouldn't affect our key decoding one way
@@ -500,13 +518,24 @@ EachPacket:
 					// We really should warn that there was a failure here. Not raise an error
 					// since this really shouldn't be a fail-stop error.
 				}
-			} else if pkt.SigType == packet.SigTypeKeyRevocation {
-				// These revocations won't revoke UIDs as handled above, so lookout!
-				revocations = append(revocations, pkt)
+			} else if current != nil && pkt.SigType == packet.SigTypeIdentityRevocation {
+				if err = e.PrimaryKey.VerifyUserIdSignature(current.Name, e.PrimaryKey, pkt); err == nil {
+					// Note: we are not removing the identity from
+					// e.Identities. Caller can always filter by Revocation
+					// field to ignore revoked identities.
+					current.Revocation = pkt
+				}
 			} else if pkt.SigType == packet.SigTypeDirectSignature {
-				// TODO: RFC4880 5.2.1 permits signatures
-				// directly on keys (eg. to bind additional
-				// revocation keys).
+				if err = e.PrimaryKey.VerifyRevocationSignature(e.PrimaryKey, pkt); err == nil {
+					if desig := pkt.DesignatedRevoker; desig != nil {
+						// If it's a designated revoker signature, take last 8 octects
+						// of fingerprint as Key ID and save it to designatedRevokers
+						// map. We consult this map later to see if a foreign
+						// revocation should be added to UnverifiedRevocations.
+						keyID := binary.BigEndian.Uint64(desig.Fingerprint[len(desig.Fingerprint)-8:])
+						designatedRevokers[keyID] = true
+					}
+				}
 			} else if current == nil {
 				// NOTE(maxtaco)
 				//
@@ -550,12 +579,20 @@ EachPacket:
 	}
 
 	for _, revocation := range revocations {
-		err = e.PrimaryKey.VerifyRevocationSignature(revocation)
-		if err == nil {
-			e.Revocations = append(e.Revocations, revocation)
-		} else {
-			// TODO: RFC 4880 5.2.3.15 defines revocation keys.
-			return nil, errors.StructuralError("revocation signature signed by alternate key")
+		if revocation.IssuerKeyId == nil || *revocation.IssuerKeyId == e.PrimaryKey.KeyId {
+			// Key revokes itself, something that we can verify.
+			err = e.PrimaryKey.VerifyRevocationSignature(e.PrimaryKey, revocation)
+			if err == nil {
+				e.Revocations = append(e.Revocations, revocation)
+			} else {
+				return nil, errors.StructuralError("revocation signature signed by alternate key")
+			}
+		} else if revocation.IssuerKeyId != nil {
+			if _, ok := designatedRevokers[*revocation.IssuerKeyId]; ok {
+				// Revocation is done by certified designated revoker,
+				// but we can't verify the revocation.
+				e.UnverifiedRevocations = append(e.UnverifiedRevocations, revocation)
+			}
 		}
 	}
 
@@ -600,8 +637,9 @@ func addSubkey(e *Entity, packets *packet.Reader, pub *packet.PublicKey, priv *p
 		}
 		switch sig.SigType {
 		case packet.SigTypeSubkeyBinding:
-			// First writer wins
-			if subKey.Sig == nil {
+			// Does the "new" sig set expiration to later date than
+			// "previous" sig?
+			if subKey.Sig == nil || subKey.Sig.ExpiresBeforeOther(sig) {
 				subKey.Sig = sig
 			}
 		case packet.SigTypeSubkeyRevocation:
@@ -837,4 +875,32 @@ func (e *Entity) CopySubkeyRevocations(src *Entity) {
 			e.Subkeys[i].Revocation = r
 		}
 	}
+}
+
+// CheckDesignatedRevokers will try to confirm any of designated
+// revocation of entity. For this function to work, revocation
+// issuer's key should be found in keyring. First successfully
+// verified designated revocation is returned along with the key that
+// verified it.
+func FindVerifiedDesignatedRevoke(keyring KeyRing, entity *Entity) (*packet.Signature, *Key) {
+	for _, sig := range entity.UnverifiedRevocations {
+		if sig.IssuerKeyId == nil {
+			continue
+		}
+
+		issuerKeyId := *sig.IssuerKeyId
+		issuerFingerprint := sig.IssuerFingerprint
+		keys := keyring.KeysByIdUsage(issuerKeyId, issuerFingerprint, packet.KeyFlagSign)
+		if len(keys) == 0 {
+			continue
+		}
+		for _, key := range keys {
+			err := key.PublicKey.VerifyRevocationSignature(entity.PrimaryKey, sig)
+			if err == nil {
+				return sig, &key
+			}
+		}
+	}
+
+	return nil, nil
 }

--- a/go/vendor/github.com/keybase/go-crypto/openpgp/packet/packet.go
+++ b/go/vendor/github.com/keybase/go-crypto/openpgp/packet/packet.go
@@ -387,17 +387,18 @@ func Read(r io.Reader) (p Packet, err error) {
 type SignatureType uint8
 
 const (
-	SigTypeBinary            SignatureType = 0
-	SigTypeText                            = 1
-	SigTypeGenericCert                     = 0x10
-	SigTypePersonaCert                     = 0x11
-	SigTypeCasualCert                      = 0x12
-	SigTypePositiveCert                    = 0x13
-	SigTypeSubkeyBinding                   = 0x18
-	SigTypePrimaryKeyBinding               = 0x19
-	SigTypeDirectSignature                 = 0x1F
-	SigTypeKeyRevocation                   = 0x20
-	SigTypeSubkeyRevocation                = 0x28
+	SigTypeBinary             SignatureType = 0
+	SigTypeText                             = 1
+	SigTypeGenericCert                      = 0x10
+	SigTypePersonaCert                      = 0x11
+	SigTypeCasualCert                       = 0x12
+	SigTypePositiveCert                     = 0x13
+	SigTypeSubkeyBinding                    = 0x18
+	SigTypePrimaryKeyBinding                = 0x19
+	SigTypeDirectSignature                  = 0x1F
+	SigTypeKeyRevocation                    = 0x20
+	SigTypeSubkeyRevocation                 = 0x28
+	SigTypeIdentityRevocation               = 0x30
 )
 
 // PublicKeyAlgorithm represents the different public key system specified for

--- a/go/vendor/github.com/keybase/go-crypto/openpgp/packet/private_key.go
+++ b/go/vendor/github.com/keybase/go-crypto/openpgp/packet/private_key.go
@@ -36,6 +36,7 @@ type PrivateKey struct {
 	PrivateKey    interface{} // An *rsa.PrivateKey or *dsa.PrivateKey.
 	sha1Checksum  bool
 	iv            []byte
+	s2kHeader     []byte
 }
 
 type EdDSAPrivateKey struct {
@@ -44,11 +45,17 @@ type EdDSAPrivateKey struct {
 }
 
 func (e *EdDSAPrivateKey) Sign(digest []byte) (R, S []byte, err error) {
-	secret := make([]byte, ed25519.PrivateKeySize)
-	copy(secret[:32], e.seed.bytes)
-	copy(secret[32:], e.PublicKey.edk.p.bytes[1:]) // [1:] because [0] is 0x40 mpi header
+	r := bytes.NewReader(e.seed.bytes)
+	publicKey, privateKey, err := ed25519.GenerateKey(r)
+	if err != nil {
+		return nil, nil, err
+	}
 
-	sig := ed25519.Sign(secret, digest)
+	if !bytes.Equal(publicKey, e.PublicKey.edk.p.bytes[1:]) { // [1:] because [0] is 0x40 mpi header
+		return nil, nil, errors.UnsupportedError("EdDSA: Private key does not match public key.")
+	}
+
+	sig := ed25519.Sign(privateKey, digest)
 
 	sigLen := ed25519.SignatureSize / 2
 	return sig[:sigLen], sig[sigLen:], nil
@@ -155,8 +162,66 @@ func mod64kHash(d []byte) uint16 {
 	return h
 }
 
+// Encrypt is the counterpart to the Decrypt() method below. It encrypts
+// the private key with the provided passphrase. If config is nil, then
+// the standard, and sensible, defaults apply.
+//
+// A key will be derived from the given passphrase using S2K Specifier
+// Type 3 (Iterated + Salted, see RFC-4880 Sec. 3.7.1.3). This choice
+// is hardcoded in s2k.Serialize(). S2KCount is hardcoded to 0, which is
+// equivalent to 65536. And the hash algorithm for key-derivation can be
+// set with config. The encrypted PrivateKey, using the algorithm specified
+// in config (if provided), is written out to the encryptedData member.
+// When Serialize() is called, this encryptedData member will be
+// serialized, using S2K Usage value of 254, and thus SHA1 checksum.
+func (pk *PrivateKey) Encrypt(passphrase []byte, config *Config) (err error) {
+	if pk.PrivateKey == nil {
+		return errors.InvalidArgumentError("there is no private key to encrypt")
+	}
+
+	pk.sha1Checksum = true
+	pk.cipher = config.Cipher()
+	s2kConfig := s2k.Config{
+		Hash:     config.Hash(),
+		S2KCount: 0,
+	}
+	s2kBuf := bytes.NewBuffer(nil)
+	derivedKey := make([]byte, pk.cipher.KeySize())
+	err = s2k.Serialize(s2kBuf, derivedKey, config.Random(), passphrase, &s2kConfig)
+	if err != nil {
+		return err
+	}
+
+	pk.s2kHeader = s2kBuf.Bytes()
+	// No good way to set pk.s2k but to call s2k.Parse(),
+	// even though we have all the information here, but
+	// most of the functions needed are private to s2k.
+	pk.s2k, err = s2k.Parse(s2kBuf)
+	pk.iv = make([]byte, pk.cipher.blockSize())
+	if _, err = config.Random().Read(pk.iv); err != nil {
+		return err
+	}
+
+	privateKeyBuf := bytes.NewBuffer(nil)
+	if err = pk.serializePrivateKey(privateKeyBuf); err != nil {
+		return err
+	}
+
+	checksum := sha1.Sum(privateKeyBuf.Bytes())
+	if _, err = privateKeyBuf.Write(checksum[:]); err != nil {
+		return err
+	}
+
+	pkData := privateKeyBuf.Bytes()
+	block := pk.cipher.new(derivedKey)
+	pk.encryptedData = make([]byte, len(pkData))
+	cfb := cipher.NewCFBEncrypter(block, pk.iv)
+	cfb.XORKeyStream(pk.encryptedData, pkData)
+	pk.Encrypted = true
+	return nil
+}
+
 func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
-	// TODO(agl): support encrypted private keys
 	buf := bytes.NewBuffer(nil)
 	err = pk.PublicKey.serializeWithoutHeaders(buf)
 	if err != nil {
@@ -174,27 +239,27 @@ func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
 			'G', 'N', 'U', // "GNU" as a string
 			1, // Extension type 1001 (minus 1000)
 		})
+	} else if pk.Encrypted {
+		_, err = buf.Write([]byte{
+			254,             // SHA-1 Convention
+			byte(pk.cipher), // Encryption scheme
+		})
+		if err != nil {
+			return err
+		}
+		if _, err = buf.Write(pk.s2kHeader); err != nil {
+			return err
+		}
+		if _, err = buf.Write(pk.iv); err != nil {
+			return err
+		}
+		if _, err = privateKeyBuf.Write(pk.encryptedData); err != nil {
+			return err
+		}
 	} else {
 		buf.WriteByte(0 /* no encryption */)
-
-		switch priv := pk.PrivateKey.(type) {
-		case *rsa.PrivateKey:
-			err = serializeRSAPrivateKey(privateKeyBuf, priv)
-		case *dsa.PrivateKey:
-			err = serializeDSAPrivateKey(privateKeyBuf, priv)
-		case *elgamal.PrivateKey:
-			err = serializeElGamalPrivateKey(privateKeyBuf, priv)
-		case *ecdsa.PrivateKey:
-			err = serializeECDSAPrivateKey(privateKeyBuf, priv)
-		case *ecdh.PrivateKey:
-			err = serializeECDHPrivateKey(privateKeyBuf, priv)
-		case *EdDSAPrivateKey:
-			err = serializeEdDSAPrivateKey(privateKeyBuf, priv)
-		default:
-			err = errors.InvalidArgumentError("unknown private key type")
-		}
-		if err != nil {
-			return
+		if err = pk.serializePrivateKey(privateKeyBuf); err != nil {
+			return err
 		}
 	}
 
@@ -204,7 +269,11 @@ func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
 	if pk.IsSubkey {
 		ptype = packetTypePrivateSubkey
 	}
-	err = serializeHeader(w, ptype, len(contents)+len(privateKeyBytes)+2)
+	totalLen := len(contents) + len(privateKeyBytes)
+	if !pk.Encrypted {
+		totalLen += 2
+	}
+	err = serializeHeader(w, ptype, totalLen)
 	if err != nil {
 		return
 	}
@@ -217,7 +286,7 @@ func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
 		return
 	}
 
-	if len(privateKeyBytes) > 0 {
+	if len(privateKeyBytes) > 0 && !pk.Encrypted {
 		checksum := mod64kHash(privateKeyBytes)
 		var checksumBytes [2]byte
 		checksumBytes[0] = byte(checksum >> 8)
@@ -226,6 +295,27 @@ func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
 	}
 
 	return
+}
+
+func (pk *PrivateKey) serializePrivateKey(w io.Writer) (err error) {
+	switch priv := pk.PrivateKey.(type) {
+	case *rsa.PrivateKey:
+		err = serializeRSAPrivateKey(w, priv)
+	case *dsa.PrivateKey:
+		err = serializeDSAPrivateKey(w, priv)
+	case *elgamal.PrivateKey:
+		err = serializeElGamalPrivateKey(w, priv)
+	case *ecdsa.PrivateKey:
+		err = serializeECDSAPrivateKey(w, priv)
+	case *ecdh.PrivateKey:
+		err = serializeECDHPrivateKey(w, priv)
+	case *EdDSAPrivateKey:
+		err = serializeEdDSAPrivateKey(w, priv)
+	default:
+		err = errors.InvalidArgumentError("unknown private key type")
+	}
+
+	return err
 }
 
 func serializeRSAPrivateKey(w io.Writer, priv *rsa.PrivateKey) error {

--- a/go/vendor/github.com/keybase/go-crypto/openpgp/packet/signature.go
+++ b/go/vendor/github.com/keybase/go-crypto/openpgp/packet/signature.go
@@ -36,6 +36,14 @@ type Signer interface {
 	PublicKeyAlgo() PublicKeyAlgorithm
 }
 
+// RevocationKey represents designated revoker packet. See RFC 4880
+// section 5.2.3.15 for details.
+type RevocationKey struct {
+	Class         byte
+	PublicKeyAlgo PublicKeyAlgorithm
+	Fingerprint   []byte
+}
+
 // Signature represents a signature. See RFC 4880, section 5.2.
 type Signature struct {
 	SigType    SignatureType
@@ -96,6 +104,11 @@ type Signature struct {
 	// when appearing in WoT-style cross signatures. But it should prevent a signature
 	// from being applied to a primary or subkey.
 	StubbedOutCriticalError error
+
+	// DesignaterRevoker will be present if this signature certifies a
+	// designated revoking key id (3rd party key that can sign
+	// revocation for this key).
+	DesignatedRevoker *RevocationKey
 
 	outSubpackets []outputSubpacket
 }
@@ -224,6 +237,7 @@ const (
 	regularExpressionSubpacket   signatureSubpacketType = 6
 	keyExpirationSubpacket       signatureSubpacketType = 9
 	prefSymmetricAlgosSubpacket  signatureSubpacketType = 11
+	revocationKey                signatureSubpacketType = 12
 	issuerSubpacket              signatureSubpacketType = 16
 	prefHashAlgosSubpacket       signatureSubpacketType = 21
 	prefCompressionSubpacket     signatureSubpacketType = 22
@@ -426,6 +440,18 @@ func parseSignatureSubpacket(sig *Signature, subpacket []byte, isHashed bool) (r
 		// The first byte is how many bytes the fingerprint is, but we'll just
 		// read until the end of the subpacket, so we'll ignore it.
 		sig.IssuerFingerprint = append([]byte{}, subpacket[1:]...)
+	case revocationKey:
+		// Authorizes the specified key to issue revocation signatures
+		// for a key.
+
+		// TODO: Class octet must have bit 0x80 set. If the bit 0x40
+		// is set, then this means that the revocation information is
+		// sensitive.
+		sig.DesignatedRevoker = &RevocationKey{
+			Class:         subpacket[0],
+			PublicKeyAlgo: PublicKeyAlgorithm(subpacket[1]),
+			Fingerprint:   append([]byte{}, subpacket[2:]...),
+		}
 	default:
 		if isCritical {
 			err = errors.UnsupportedError("unknown critical signature subpacket type " + strconv.Itoa(int(packetType)))
@@ -506,6 +532,26 @@ func (sig *Signature) KeyExpired(currentTime time.Time) bool {
 	}
 	expiry := sig.CreationTime.Add(time.Duration(*sig.KeyLifetimeSecs) * time.Second)
 	return currentTime.After(expiry)
+}
+
+// ExpiresBeforeOther checks if other signature has expiration at
+// later date than sig.
+func (sig *Signature) ExpiresBeforeOther(other *Signature) bool {
+	if sig.KeyLifetimeSecs == nil {
+		// This sig never expires, or has infinitely long expiration
+		// time.
+		return false
+	} else if other.KeyLifetimeSecs == nil {
+		// This sig expires at some non-infinite point, but the other
+		// sig never expires.
+		return true
+	}
+
+	getExpiryDate := func(s *Signature) time.Time {
+		return s.CreationTime.Add(time.Duration(*s.KeyLifetimeSecs) * time.Second)
+	}
+
+	return getExpiryDate(other).After(getExpiryDate(sig))
 }
 
 // buildHashSuffix constructs the HashSuffix member of sig in preparation for signing.

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -171,92 +171,92 @@
 		{
 			"checksumSHA1": "VJk3rOWfxEV9Ilig5lgzH1qg8Ss=",
 			"path": "github.com/keybase/go-crypto/brainpool",
-			"revision": "3535216ff45ffdef1adba71fdcb3fcdebbe49322",
-			"revisionTime": "2017-03-08T15:50:15Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
 			"checksumSHA1": "rnRjEJs5luF+DIXp2J6LFcQk8Gg=",
 			"path": "github.com/keybase/go-crypto/cast5",
-			"revision": "3535216ff45ffdef1adba71fdcb3fcdebbe49322",
-			"revisionTime": "2017-03-08T15:50:15Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
 			"checksumSHA1": "F5++ZQS5Vt7hd6lxPCKTffvph1A=",
 			"path": "github.com/keybase/go-crypto/curve25519",
-			"revision": "3535216ff45ffdef1adba71fdcb3fcdebbe49322",
-			"revisionTime": "2017-03-08T15:50:15Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
 			"checksumSHA1": "IvrDXwIixB5yPPbo6tq1/1cSn78=",
 			"path": "github.com/keybase/go-crypto/ed25519",
-			"revision": "9a8c377169f632b40aff7df06e9405003cf5dcec",
-			"revisionTime": "2017-03-08T13:33:35Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
 			"checksumSHA1": "4+fslB6pCbplNq4viy6CrOkkY6Y=",
 			"path": "github.com/keybase/go-crypto/ed25519/internal/edwards25519",
-			"revision": "9a8c377169f632b40aff7df06e9405003cf5dcec",
-			"revisionTime": "2017-03-08T13:33:35Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
-			"checksumSHA1": "tU/72BMqzPlbK6qMeq7cklYwLWY=",
+			"checksumSHA1": "5E4DLEAVDwFt//h5K23zHP1qCew=",
 			"path": "github.com/keybase/go-crypto/openpgp",
-			"revision": "3535216ff45ffdef1adba71fdcb3fcdebbe49322",
-			"revisionTime": "2017-03-08T15:50:15Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
 			"checksumSHA1": "y61I7+hCekP1Rk0qxgUQ+iozXak=",
 			"path": "github.com/keybase/go-crypto/openpgp/armor",
-			"revision": "3535216ff45ffdef1adba71fdcb3fcdebbe49322",
-			"revisionTime": "2017-03-08T15:50:15Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
 			"checksumSHA1": "cTboJNAg/so2wzlf6HscarfPlDE=",
 			"path": "github.com/keybase/go-crypto/openpgp/clearsign",
-			"revision": "3535216ff45ffdef1adba71fdcb3fcdebbe49322",
-			"revisionTime": "2017-03-08T15:50:15Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
 			"checksumSHA1": "nWhmwjBJqPSvkCWqaap2Z9EiS1k=",
 			"path": "github.com/keybase/go-crypto/openpgp/ecdh",
-			"revision": "3535216ff45ffdef1adba71fdcb3fcdebbe49322",
-			"revisionTime": "2017-03-08T15:50:15Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
 			"checksumSHA1": "uxXG9IC/XF8jwwvZUbW65+x8/+M=",
 			"path": "github.com/keybase/go-crypto/openpgp/elgamal",
-			"revision": "3535216ff45ffdef1adba71fdcb3fcdebbe49322",
-			"revisionTime": "2017-03-08T15:50:15Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
 			"checksumSHA1": "EyUf82Yknzc75m8RcA21CNQINw0=",
 			"path": "github.com/keybase/go-crypto/openpgp/errors",
-			"revision": "3535216ff45ffdef1adba71fdcb3fcdebbe49322",
-			"revisionTime": "2017-03-08T15:50:15Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
-			"checksumSHA1": "llmz8tksauJF10kIBqtB8RX601I=",
+			"checksumSHA1": "4Zdz92qXEB6rPFdkYBiqmHFce0A=",
 			"path": "github.com/keybase/go-crypto/openpgp/packet",
-			"revision": "3535216ff45ffdef1adba71fdcb3fcdebbe49322",
-			"revisionTime": "2017-03-08T15:50:15Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
 			"checksumSHA1": "BGDxg1Xtsz0DSPzdQGJLLQqfYc8=",
 			"path": "github.com/keybase/go-crypto/openpgp/s2k",
-			"revision": "3535216ff45ffdef1adba71fdcb3fcdebbe49322",
-			"revisionTime": "2017-03-08T15:50:15Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
 			"checksumSHA1": "rE3pp7b3gfcmBregzpIvN5IdFhY=",
 			"path": "github.com/keybase/go-crypto/rsa",
-			"revision": "3535216ff45ffdef1adba71fdcb3fcdebbe49322",
-			"revisionTime": "2017-03-08T15:50:15Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
 			"checksumSHA1": "orAH0wZ270S0Xef2B3DMnQFC+MI=",
 			"path": "github.com/keybase/go-crypto/ssh/terminal",
-			"revision": "3535216ff45ffdef1adba71fdcb3fcdebbe49322",
-			"revisionTime": "2017-03-08T15:50:15Z"
+			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
+			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
 			"checksumSHA1": "d2oUixwR6P1/pDb7NEu/cFmCKJc=",


### PR DESCRIPTION
This PR fixes CORE-4727, and partly CORE-4880

`pgp decrypt`, `encrypt`, and `verify` has been changed to check for the revocations of keys. `go-crypto` already refuses to select a key that is revoked for verification, but this is not the case for: 1) designated revocations, 2) encryption.

- `pgp decrypt` will check and fail the decryption if message is signed by a key that has designated revocation.
- `pgp encrypt` will no longer select keys that are revoked for encryption. If that leaves us with no keys to encrypt to, it fails with an error.
- `pgp verify` will fail with an error if there are designated revocations.

Work in progress for a bit more - I forgot to add checks to rest of pgp verify signature types (right now it only tests in clearsign).