### PR TITLE
force grid recompute when cell # changes. fixes overlap issue

### DIFF
--- a/shared/chat/conversation/list/index.desktop.js
+++ b/shared/chat/conversation/list/index.desktop.js
@@ -69,6 +69,10 @@ class BaseList extends Component<void, Props, State> {
         const toFind = this.props.messageKeys.get(this._lastRowIdx)
         this._keepIdxVisible = nextProps.messageKeys.indexOf(toFind)
       }
+      // Force the grid to throw away its local index based cache. There might be a lighterway to do this but
+      // this seems to fix the overlap problem. The cellCache has correct values inside it but the list itself has
+      // another cache from row -> style which is out of sync
+      this._list && this._list.Grid && this._list.recomputeRowHeights(0)
     }
   }
 


### PR DESCRIPTION
@keybase/react-hackers this is mostly cause this cache in grid (https://github.com/bvaughn/react-virtualized/blob/master/source/Grid/defaultCellRangeRenderer.js#L57) is row based. Our cell cache (https://github.com/keybase/client/blob/master/shared/chat/conversation/list/index.desktop.js#L28) contains correct values. Short term fix is to just recompute the grid heights (doesn't necessarily mean to re-render everything, but def. throws away that cache).

cc: @mmaxim this should fix the overlap issue