### PR TITLE
Surface kex text code errors in the UI

### DIFF
--- a/shared/actions/login/creators.js
+++ b/shared/actions/login/creators.js
@@ -19,8 +19,8 @@ function logout (): Constants.Logout {
   return {type: Constants.logout, payload: null}
 }
 
-function setTextCode (phrase: string): Constants.SetTextCode {
-  return {type: Constants.setTextCode, payload: {textCode: new HiddenString(phrase)}}
+function setTextCode (phrase: string, previousErr: string): Constants.SetTextCode {
+  return {type: Constants.setTextCode, payload: {enterCodeErrorText: previousErr, textCode: new HiddenString(phrase)}}
 }
 
 function relogin (usernameOrEmail: string, passphrase: string): Constants.Relogin {

--- a/shared/actions/login/saga.js
+++ b/shared/actions/login/saga.js
@@ -209,8 +209,8 @@ function * passthroughResponseSaga ({response}) {
 
 // TODO type this
 type DisplayAndPromptSecretArgs = any
-const displayAndPromptSecretSaga = (onBackSaga) => function * ({params: {phrase}, response}: DisplayAndPromptSecretArgs) {
-  yield put(Creators.setTextCode(phrase))
+const displayAndPromptSecretSaga = (onBackSaga) => function * ({params: {phrase, previousErr}, response}: DisplayAndPromptSecretArgs) {
+  yield put(Creators.setTextCode(phrase, previousErr))
   yield call(generateQRCode)
   yield put(navigateAppend(['codePage']))
 

--- a/shared/actions/login/saga.js
+++ b/shared/actions/login/saga.js
@@ -212,7 +212,11 @@ type DisplayAndPromptSecretArgs = any
 const displayAndPromptSecretSaga = (onBackSaga) => function * ({params: {phrase, previousErr}, response}: DisplayAndPromptSecretArgs) {
   yield put(Creators.setTextCode(phrase, previousErr))
   yield call(generateQRCode)
-  yield put(navigateAppend(['codePage']))
+
+  // If we have an error, we're already on the right page.
+  if (!previousErr) {
+    yield put(navigateAppend(['codePage']))
+  }
 
   const {textEntered, qrScanned, onBack} = yield race({
     onBack: take(Constants.onBack),

--- a/shared/login/register/code-page/dumb.js
+++ b/shared/login/register/code-page/dumb.js
@@ -14,6 +14,7 @@ const baseMock = {
   textEntered: () => console.log('textEntered'),
   onChangeText: () => console.log('onChangeText'),
   onBack: () => console.log('onBack'),
+  enterCodeErrorText: '',
   enterText: 'Foo Enter Text',
 }
 

--- a/shared/login/register/code-page/index.js
+++ b/shared/login/register/code-page/index.js
@@ -31,6 +31,7 @@ class CodePage extends Component<void, Props, {enterText: string}> {
         setCodePageMode={this.props.setCodePageMode}
         qrScanned={this.props.qrScanned}
         setCameraBrokenMode={this.props.setCameraBrokenMode}
+        enterCodeErrorText={this.props.enterCodeErrorText}
         textEntered={() => this.props.textEntered(this.state.enterText)}
       />
     )
@@ -42,12 +43,18 @@ export default connect(
   ({
     login: {
       codePage: {
-        mode, textCode, qrCode,
-        myDeviceRole, otherDeviceRole, cameraBrokenMode,
+        cameraBrokenMode,
+        enterCodeErrorText,
+        mode,
+        myDeviceRole,
+        otherDeviceRole,
+        qrCode,
+        textCode,
       },
     },
   }: TypedState) => ({
     cameraBrokenMode,
+    enterCodeErrorText,
     mode,
     myDeviceRole,
     otherDeviceRole,

--- a/shared/login/register/code-page/index.render.desktop.js
+++ b/shared/login/register/code-page/index.render.desktop.js
@@ -55,7 +55,7 @@ const CodePageCode = ({onBack, otherDeviceRole, setCodePageMode, qrCode}) => (
   </Container>
 )
 
-const CodePageEnterText = ({onBack, otherDeviceRole, enterText, onChangeText, textEntered, setCodePageMode}) => (
+const CodePageEnterText = ({enterCodeErrorText, onBack, otherDeviceRole, enterText, onChangeText, textEntered, setCodePageMode}) => (
   <Container
     style={stylesContainer}
     onBack={onBack}>
@@ -63,6 +63,7 @@ const CodePageEnterText = ({onBack, otherDeviceRole, enterText, onChangeText, te
     <SubTitle usePhone={_otherIsPhone(otherDeviceRole)} />
     <Icon style={{marginBottom: 40, marginTop: 30}} type='icon-phone-text-code-32' />
     <Input
+      errorText={enterCodeErrorText}
       hintText='opp blezzard tofi pando agg whi pany yaga jocket daubt bruwnstane hubit yas'
       floatingHintTextOverride='Text code'
       multiline={true}

--- a/shared/login/register/code-page/index.render.js.flow
+++ b/shared/login/register/code-page/index.render.js.flow
@@ -16,7 +16,8 @@ export type Props = {
   textEntered: Function,
   onChangeText: Function,
   onBack: Function,
-  enterText: string
+  enterText: string,
+  enterCodeErrorText: string,
 }
 
 export default class CodePageRender extends Component<void, Props, void> {}

--- a/shared/login/register/code-page/index.render.native.js
+++ b/shared/login/register/code-page/index.render.native.js
@@ -62,6 +62,7 @@ class CodePageRender extends Component<void, Props, void> {
       <Box style={stylesEnterText}>
         <Icon type='icon-phone-text-code-32' style={{alignSelf: 'center'}} />
         <Input
+          errorText={this.props.enterCodeErrorText}
           hintText='opp blezzard tofi pando agg whi pany yaga jocket daubt bruwnstane hubit yas'
           floatingHintTextOverride='Text code'
           multiline={true}

--- a/shared/reducers/login.js
+++ b/shared/reducers/login.js
@@ -14,6 +14,7 @@ export type LoginState = {
   codePage: {
     cameraBrokenMode: boolean,
     codeCountDown: number,
+    enterCodeErrorText: string,
     mode: ?Mode,
     myDeviceRole: ?DeviceRole,
     otherDeviceRole: ?DeviceRole,
@@ -39,6 +40,7 @@ const initialState: LoginState = {
   codePage: {
     cameraBrokenMode: false,
     codeCountDown: 0,
+    enterCodeErrorText: '',
     mode: null,
     myDeviceRole: null,
     otherDeviceRole: null,
@@ -87,7 +89,7 @@ export default function (state: LoginState = initialState, action: any): LoginSt
       toMerge = {codePage: {mode: action.payload}}
       break
     case Constants.setTextCode:
-      toMerge = {codePage: {textCode: action.payload.textCode}}
+      toMerge = {codePage: {enterCodeErrorText: action.payload.enterCodeErrorText, textCode: action.payload.textCode}}
       break
     case Constants.setQRCode:
       toMerge = {codePage: {qrCode: action.payload.qrCode}}


### PR DESCRIPTION
@keybase/react-hackers CC @patrickxb 

The service now tells us if we enter an incorrect text code, by calling the DisplayAndPromptSecret RPC again with a `previousErr` string set.  This PR plumbs that string through to our state and props, and uses it as an `<Input errorText=''>` param on desktop and mobile.