### PR TITLE
fix collision of markers

### DIFF
--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -623,16 +623,16 @@ function getAttachmentInfo (preview: ?Asset, object: ?Asset) {
 }
 
 function pendingConversationIDKey (tlfName: string) {
-  return `PendingConversation:${tlfName}`
+  return `__PendingConversation__${tlfName}`
 }
 
 function isPendingConversationIDKey (conversationIDKey: string) {
-  return conversationIDKey.startsWith('PendingConversation:')
+  return conversationIDKey.startsWith('__PendingConversation__')
 }
 
 function pendingConversationIDKeyToTlfName (conversationIDKey: string) {
   if (isPendingConversationIDKey(conversationIDKey)) {
-    return conversationIDKey.substring('PendingConversation:'.length)
+    return conversationIDKey.substring('__PendingConversation__'.length)
   }
 
   return null


### PR DESCRIPTION
Pending conversations used ':' as their dividers, as did the messagekeys so it did the wrong thing. After mobile i think we could do a bunch of stuff to cleanup the store part of this (so far not really touched while doing the other refactoring). that'll make the perf better and really clean up the reducers / actions, but not worth changing right now

@keybase/react-hackers 