### PR TITLE
Lazy load images when messages rendered

### DIFF
--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -59,10 +59,6 @@ function * onLoadAttachment ({payload: {conversationIDKey, messageID, loadPrevie
 
   // See if we already have this image cached
   if (loadPreview || isHdPreview) {
-    if (existingMessageState === 'downloading-preview') {
-      return
-    }
-
     if (existingMessage && (loadPreview && existingMessage.previewPath || isHdPreview && existingMessage.hdPreviewPath)) {
       return
     }

--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -74,6 +74,7 @@ function * onLoadAttachment ({payload: {conversationIDKey, messageID, loadPrevie
   // let's see if we've already downloaded it as an hdPreview
   if (!loadPreview && !isHdPreview) {
     if (existingMessageState === 'downloading') {
+      console.log('onLoadAttachment: already downloading attachment, bailing:', conversationIDKey, messageID, filename)
       return
     }
 

--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -267,11 +267,15 @@ function loadAttachment (conversationIDKey: Constants.ConversationIDKey, message
   return {payload: {conversationIDKey, filename, isHdPreview, loadPreview, messageID}, type: 'chat:loadAttachment'}
 }
 
-function attachmentLoaded (conversationIDKey: Constants.ConversationIDKey, messageID: Constants.MessageID, path: string, isPreview: boolean, isHdPreview: boolean): Constants.AttachmentLoaded {
+function loadAttachmentPreview (message: Constants.AttachmentMessage): Constants.LoadAttachmentPreview {
+  return {payload: {message}, type: 'chat:loadAttachmentPreview'}
+}
+
+function attachmentLoaded (conversationIDKey: Constants.ConversationIDKey, messageID: Constants.MessageID, path: ?string, isPreview: boolean, isHdPreview: boolean): Constants.AttachmentLoaded {
   return {payload: {conversationIDKey, isHdPreview, isPreview, messageID, path}, type: 'chat:attachmentLoaded'}
 }
 
-function downloadProgress (conversationIDKey: Constants.ConversationIDKey, messageID: Constants.MessageID, isPreview: boolean, bytesComplete: number, bytesTotal: number): Constants.DownloadProgress {
+function downloadProgress (conversationIDKey: Constants.ConversationIDKey, messageID: Constants.MessageID, isPreview: boolean, bytesComplete?: number, bytesTotal?: number): Constants.DownloadProgress {
   return {payload: {bytesComplete, bytesTotal, conversationIDKey, isPreview, messageID}, type: 'chat:downloadProgress'}
 }
 
@@ -381,6 +385,7 @@ export {
   inboxStale,
   incomingMessage,
   loadAttachment,
+  loadAttachmentPreview,
   loadInbox,
   loadMoreMessages,
   loadedInbox,

--- a/shared/chat/conversation/list/index.native.js
+++ b/shared/chat/conversation/list/index.native.js
@@ -65,6 +65,8 @@ class ConversationList extends Component <void, Props, void> {
         onEndReached={this._onEndReached}
         onEndReachedThreshold={0}
         keyExtractor={this._keyExtractor}
+        // Limit the number of pages rendered ahead of time (which also limits attachment previews loaded)
+        windowSize={5}
       />
     )
   }

--- a/shared/chat/conversation/messages/attachment/container.js
+++ b/shared/chat/conversation/messages/attachment/container.js
@@ -40,7 +40,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   _onOpenInPopup: (message: Constants.AttachmentMessage, routePath: List<string>) => dispatch(Creators.openAttachmentPopup(message, routePath)),
 })
 
-const mergeProps = (stateProps, dispatchProps, {measure, onAction}, OwnProps) => ({
+const mergeProps = (stateProps, dispatchProps, {measure, onAction}: OwnProps) => ({
   ...stateProps,
   ...dispatchProps,
   measure,

--- a/shared/chat/conversation/messages/attachment/container.js
+++ b/shared/chat/conversation/messages/attachment/container.js
@@ -36,6 +36,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       dispatch(Creators.loadAttachment(selectedConversation, messageID, downloadFilePath(filename), false, false))
     }
   },
+  _onEnsurePreviewLoaded: (message: Constants.AttachmentMessage) => dispatch(Creators.loadAttachmentPreview(message)),
   _onOpenInFileUI: (path: string) => dispatch(({payload: {path}, type: 'fs:openInFileUI'}: OpenInFileUI)),
   _onOpenInPopup: (message: Constants.AttachmentMessage, routePath: List<string>) => dispatch(Creators.openAttachmentPopup(message, routePath)),
 })
@@ -45,6 +46,12 @@ const mergeProps = (stateProps, dispatchProps, {measure, onAction}: OwnProps) =>
   ...dispatchProps,
   measure,
   onAction,
+  onEnsurePreviewLoaded: () => {
+    const {message} = stateProps
+    if (message && message.filename && !message.previewPath) {
+      setImmediate(() => dispatchProps._onEnsurePreviewLoaded(stateProps.message))
+    }
+  },
   onLoadAttachment: () => { dispatchProps._onLoadAttachment(stateProps.selectedConversation, stateProps.message.messageID, stateProps.message.filename) },
   onOpenInFileUI: () => { dispatchProps._onOpenInFileUI(stateProps.message.downloadedPath) },
   onOpenInPopup: () => { dispatchProps._onOpenInPopup(stateProps.message, stateProps.routePath) },
@@ -53,11 +60,19 @@ const mergeProps = (stateProps, dispatchProps, {measure, onAction}: OwnProps) =>
 export default compose(
   connect(mapStateToProps, mapDispatchToProps, mergeProps),
   lifecycle({
+    componentDidMount: function () {
+      this.props.onEnsurePreviewLoaded()
+    },
+
     componentDidUpdate: function (prevProps: Props & {_editedCount: number}) {
       if (this.props.measure &&
         this.props.message.previewPath !== prevProps.message.previewPath &&
         !shallowEqual(this.props.message.previewSize !== prevProps.message.previewSize)) {
         this.props.measure()
+      }
+
+      if (this.props.message && prevProps.message && prevProps.message.filename !== this.props.message.filename) {
+        this.props.onEnsurePreviewLoaded()
       }
     },
   })

--- a/shared/chat/conversation/messages/attachment/container.js.flow
+++ b/shared/chat/conversation/messages/attachment/container.js.flow
@@ -6,6 +6,7 @@ export type OwnProps = {
   messageKey: Constants.MessageKey,
   measure: ?() => void,
   onAction: () => void,
+  onEnsurePreviewLoaded: () => void,
 }
 
 export default class Attachment extends Component<void, OwnProps, void> {}

--- a/shared/chat/conversation/messages/attachment/index.js.flow
+++ b/shared/chat/conversation/messages/attachment/index.js.flow
@@ -23,6 +23,7 @@ export type Props = {
   isFirstNewMessage: boolean,
   onLoadAttachment: () => void,
   onAction: (event: any) => void,
+  onEnsurePreviewLoaded: () => void,
   onOpenInFileUI: () => void,
   onOpenInPopup: () => void,
 }

--- a/shared/chat/conversation/messages/attachment/index.js.flow
+++ b/shared/chat/conversation/messages/attachment/index.js.flow
@@ -23,7 +23,6 @@ export type Props = {
   isFirstNewMessage: boolean,
   onLoadAttachment: () => void,
   onAction: (event: any) => void,
-  onEnsurePreviewLoaded: () => void,
   onOpenInFileUI: () => void,
   onOpenInPopup: () => void,
 }

--- a/shared/chat/conversation/messages/text/container.js
+++ b/shared/chat/conversation/messages/text/container.js
@@ -22,7 +22,7 @@ const mapStateToProps = (state: TypedState, {messageKey}: OwnProps) => {
   return getProps(state, messageKey)
 }
 
-const mergeProps = (stateProps, dispatchProps, {measure}, OwnProps) => ({
+const mergeProps = (stateProps, dispatchProps, {measure}: OwnProps) => ({
   ...stateProps,
   ...dispatchProps,
   measure,

--- a/shared/chat/conversation/messages/wrapper/shared.js
+++ b/shared/chat/conversation/messages/wrapper/shared.js
@@ -57,7 +57,7 @@ const MessageWrapper = (props: Props) => (
         <Username includeHeader={props.includeHeader} author={props.author} isYou={props.isYou} isFollowing={props.isFollowing} isBroken={props.isBroken} />
         <Box style={_textContainerStyle} className='message' data-message-key={props.messageKey}>
           <Box style={_flexOneColumn}>
-            <props.innerClass messageKey={props.messageKey} onAction={props.onAction} />
+            <props.innerClass messageKey={props.messageKey} measure={props.measure} onAction={props.onAction} />
             <EditedMark isEdited={props.isEdited} />
           </Box>
           <ActionButton isRevoked={props.isRevoked} onAction={props.onAction} />

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -421,8 +421,8 @@ export type UploadProgress = NoErrorTypedAction<'chat:uploadProgress', {
   conversationIDKey: ConversationIDKey,
 }>
 export type DownloadProgress = NoErrorTypedAction<'chat:downloadProgress', {
-  bytesComplete: number,
-  bytesTotal: number,
+  bytesComplete?: number,
+  bytesTotal?: number,
   conversationIDKey: ConversationIDKey,
   isPreview: boolean,
   messageID: MessageID,
@@ -434,12 +434,15 @@ export type LoadAttachment = NoErrorTypedAction<'chat:loadAttachment', {
   isHdPreview: boolean,
   filename: string,
 }>
+export type LoadAttachmentPreview = NoErrorTypedAction<'chat:loadAttachmentPreview', {
+  message: AttachmentMessage,
+}>
 export type AttachmentLoaded = NoErrorTypedAction<'chat:attachmentLoaded', {
   messageID: MessageID,
   conversationIDKey: ConversationIDKey,
   isPreview: boolean,
   isHdPreview: boolean,
-  path: string,
+  path: ?string,
 }>
 export type UpdateTempMessage = TypedAction<'chat:updateTempMessage', {
   conversationIDKey: ConversationIDKey,

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -308,7 +308,10 @@ function reducer (state: Constants.State = initialState, action: Constants.Actio
     }
     case 'chat:downloadProgress': {
       const {conversationIDKey, messageID, isPreview, bytesComplete, bytesTotal} = action.payload
-      const progress = bytesComplete / bytesTotal
+      let progress = 0
+      if (bytesTotal) {
+        progress = bytesComplete / bytesTotal
+      }
       const messageKey = Constants.messageKey(conversationIDKey, 'messageIDAttachment', messageID)
 
       // $FlowIssue

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -289,7 +289,7 @@ function reducer (state: Constants.State = initialState, action: Constants.Actio
       } else if (isHdPreview) {
         toMerge = {hdPreviewPath: path, messageState: 'sent'}
       } else {
-        toMerge = {downloadedPath: path, messageState: 'downloaded'}
+        toMerge = {downloadedPath: path, messageState: path ? 'downloaded' : 'sent'}
       }
 
       // $FlowIssue


### PR DESCRIPTION
This is working on desktop and mobile. Initially I tried having the images only load when visible on screen, but this caused an undesirable lag in which the image would be loading while visible. It turned out to be better to just load any images that were rendered offscreen (and make sure that isn't a huge number of them).

* Change `onLoadAttachment` to bail early if already loading/loaded an attachment
* Tweak mobile virtualized list to not pre-render as many screens (reduces number of attachments loaded)