### PR TITLE
 dont focus on loading state change

### DIFF
--- a/shared/chat/conversation/input/container.js
+++ b/shared/chat/conversation/input/container.js
@@ -81,8 +81,7 @@ export default compose(
   ),
   lifecycle({
     componentDidUpdate: function (prevProps) {
-      if (!this.props.isLoading && prevProps.isLoading ||
-        this.props.focusInputCounter !== prevProps.focusInputCounter) {
+      if (this.props.focusInputCounter !== prevProps.focusInputCounter) {
         this.props.inputFocus()
       }
     },


### PR DESCRIPTION
@keybase/react-hackers don't show the keyboard as you click around the chats