### PR TITLE
bail out of ID2 early in passive KBFS identify modes CORE-4899

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -1048,6 +1048,24 @@ func TestNoSelfHostedIdentifyInPassiveMode(t *testing.T) {
 	runTest(keybase1.TLFIdentifyBehavior_CHAT_GUI, true, true, libkb.ProofCheckerModeActive)
 }
 
+func TestSkipExternalChecks(t *testing.T) {
+	arg := &keybase1.Identify2Arg{
+		Uid:           tracyUID,
+		CanSuppressUI: true,
+	}
+	arg.IdentifyBehavior = keybase1.TLFIdentifyBehavior_KBFS_REKEY
+	_, err := identify2WithUIDWithBrokenTrackMakeEngine(t, arg)
+	require.NoError(t, err)
+
+	arg.IdentifyBehavior = keybase1.TLFIdentifyBehavior_KBFS_QR
+	_, err = identify2WithUIDWithBrokenTrackMakeEngine(t, arg)
+	require.NoError(t, err)
+
+	arg.IdentifyBehavior = keybase1.TLFIdentifyBehavior_CHAT_CLI
+	_, err = identify2WithUIDWithBrokenTrackMakeEngine(t, arg)
+	require.Error(t, err)
+}
+
 var aliceUID = keybase1.UID("295a7eea607af32040647123732bc819")
 var tracyUID = keybase1.UID("eb72f49f2dde6429e5d78003dae0c919")
 var trackingUID = keybase1.UID("92b3b3dbe457059f28c9f74e8e6b9419")

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -437,6 +437,13 @@ func (e *Identify2WithUID) runReturnError(ctx *Context) (err error) {
 		return nil
 	}
 
+	// If we are rekeying or reclaiming quota from KBFS, then let's
+	// skip the external checks.
+	if e.arg.IdentifyBehavior.SkipExternalChecks() {
+		e.G().Log.CDebugf(netCtx, "| skip external checks specified, short-circuiting")
+		return nil
+	}
+
 	if !e.useRemoteAssertions() && e.allowEarlyOuts() {
 
 		if e.untrackedFastPath(ctx) {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -804,6 +804,18 @@ func (b TLFIdentifyBehavior) ShouldSuppressTrackerPopups() bool {
 	}
 }
 
+// SkipExternalChecks indicates we do not want to run any external proof checkers in
+// identify modes that yield true.
+func (b TLFIdentifyBehavior) SkipExternalChecks() bool {
+	switch b {
+	case TLFIdentifyBehavior_KBFS_QR,
+		TLFIdentifyBehavior_KBFS_REKEY:
+		return true
+	default:
+		return false
+	}
+}
+
 func (c CanonicalTLFNameAndIDWithBreaks) Eq(r CanonicalTLFNameAndIDWithBreaks) bool {
 	if c.CanonicalName != r.CanonicalName {
 		return false


### PR DESCRIPTION
Add a new function to `TLFIdentifyBehavior` which tells us if we can bail out of ID2 after checking local assertions.