### PR TITLE
Don't use 'image.png' as a placeholder for a non-filename

### DIFF
--- a/shared/util/clipboard.desktop.js
+++ b/shared/util/clipboard.desktop.js
@@ -25,7 +25,7 @@ function readImage (): Promise<?ClipboardData> {
           reject(err)
           return
         }
-        resolve({path, title: 'image.png'})
+        resolve({path, title: 'Pasted image'})
       })
     })
   })


### PR DESCRIPTION
@keybase/react-hackers 

We don't use this string as a filename, just a title, so presenting it as if it's going to be the filename when downloaded confuses people.