### PR TITLE
fix icon layout issues. lets avoid splitting up these props.

### DIFF
--- a/shared/common-adapters/icon.js.flow
+++ b/shared/common-adapters/icon.js.flow
@@ -7,7 +7,7 @@ import type {Exact} from '../constants/types/more'
 export type Props = {
   type: IconType,
   hint?: string,
-  onClick?: (event: SyntheticMouseEvent) => void,
+  onClick?: (event: SyntheticEvent) => void,
   onPress?: void,
   onMouseEnter?: () => void,
   onMouseLeave?: () => void,

--- a/shared/common-adapters/icon.native.js
+++ b/shared/common-adapters/icon.native.js
@@ -1,8 +1,7 @@
 // @flow
 import * as shared from './icon.shared'
-import Box from './box'
 import ClickableBox from './clickable-box'
-import React, {Component} from 'react'
+import React from 'react'
 import {NativeText, NativeImage} from './native-wrappers.native'
 import {globalColors} from '../styles'
 import {iconMeta} from './icon.constants'
@@ -11,74 +10,47 @@ import {omit} from 'lodash'
 import type {Exact} from '../constants/types/more'
 import type {IconType, Props} from './icon'
 
-class Icon extends Component<void, Exact<Props>, void> {
-  render () {
-    let color = shared.defaultColor(this.props.type)
-    let iconType = shared.typeToIconMapper(this.props.type)
+const Icon = (props: Exact<Props>) => {
+  let iconType = shared.typeToIconMapper(props.type)
 
-    if (!iconType) {
-      console.warn('Null iconType passed')
-      return null
-    }
-
-    color = this.props.style && this.props.style.color || color || (this.props.opacity ? globalColors.lightGrey : globalColors.black_40)
-
-    const styleWidth = this.props.style && this.props.style.width
-
-    const width = styleWidth && {width: this.props.style.width}
-    const height = this.props.style && this.props.style.height && {height: this.props.style.height}
-
-    const fontSizeHint = shared.fontSize(iconType)
-    const fontSize = (this.props.style && (this.props.style.fontSize || styleWidth) && {fontSize: this.props.style.fontSize || styleWidth}) || fontSizeHint
-    const textAlign = this.props.style && this.props.style.textAlign
-    const backgroundColor = this.props.style && {backgroundColor: this.props.style.backgroundColor} || {}
-
-    // Extract style props for our container and box
-    let containerProps = omit(this.props.style, [
-      'bottom',
-      'color',
-      'fontSize',
-      'height',
-      'left',
-      'position',
-      'right',
-      'textAlign',
-      'top',
-      'width',
-    ])
-
-    const clickableBoxStyle = {
-      bottom: this.props.style && this.props.style.bottom,
-      height: this.props.style && this.props.style.height,
-      left: this.props.style && this.props.style.left,
-      position: this.props.style && this.props.style.position,
-      right: this.props.style && this.props.style.right,
-      top: this.props.style && this.props.style.top,
-      width: this.props.style && this.props.style.width,
-    }
-
-    if (!iconMeta[iconType]) {
-      console.warn(`Invalid icon type passed in: ${iconType}`)
-      return null
-    }
-
-    const icon = iconMeta[iconType].isFont
-      ? <NativeText style={{color, textAlign, fontFamily: 'kb', ...fontSize, ...width, ...backgroundColor}}>{
-        String.fromCharCode(iconMeta[iconType].charCode || 0)}</NativeText>
-      : <NativeImage source={iconMeta[iconType].require} style={{resizeMode: 'contain', ...width, ...height, ...backgroundColor}} />
-
-    return (
-      <ClickableBox
-        activeOpacity={0.8}
-        underlayColor={this.props.underlayColor || globalColors.white}
-        onClick={this.props.onClick}
-        style={clickableBoxStyle}>
-        <Box style={containerProps}>
-          {icon}
-        </Box>
-      </ClickableBox>
-    )
+  if (!iconType) {
+    console.warn('Null iconType passed')
+    return null
   }
+  if (!iconMeta[iconType]) {
+    console.warn(`Invalid icon type passed in: ${iconType}`)
+    return null
+  }
+
+  const color = props.style && props.style.color || shared.defaultColor(props.type) || (props.opacity ? globalColors.lightGrey : globalColors.black_40)
+  const styleWidth = props.style && props.style.width
+  const width = styleWidth && {width: props.style.width}
+  const backgroundColor = props.style && {backgroundColor: props.style.backgroundColor} || {}
+
+  let icon
+
+  if (iconMeta[iconType].isFont) {
+    const fontSizeHint = shared.fontSize(iconType)
+    const fontSize = (props.style && (props.style.fontSize || styleWidth) && {fontSize: props.style.fontSize || styleWidth}) || fontSizeHint
+    const textAlign = props.style && props.style.textAlign
+    const code = String.fromCharCode(iconMeta[iconType].charCode || 0)
+
+    icon = <NativeText style={{color, textAlign, fontFamily: 'kb', ...fontSize, ...width, ...backgroundColor}}>{code}</NativeText>
+  } else {
+    const height = props.style && props.style.height && {height: props.style.height}
+    icon = <NativeImage source={iconMeta[iconType].require} style={{resizeMode: 'contain', ...width, ...height, ...backgroundColor}} />
+  }
+
+  const boxStyle = omit(props.style || {}, ['color', 'fontSize', 'textAlign'])
+  return (
+    <ClickableBox
+      activeOpacity={0.8}
+      underlayColor={props.underlayColor || globalColors.white}
+      onClick={props.onClick}
+      style={boxStyle}>
+      {icon}
+    </ClickableBox>
+  )
 }
 
 export function iconTypeToImgSet (type: IconType) {


### PR DESCRIPTION
This pattern of splitting the style props into different children is super error prone. let's reduce how much of that we do

@keybase/react-hackers this is on top of a red-box fix which kept the the old behavior (but caused screens to be bad, like alignSelf being passed to the feedback icon but it not being applied)