### PR TITLE
fix crash on existing finalized conversation

### DIFF
--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -75,7 +75,7 @@ const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps) => {
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps, mergeProps),
-  branch((props: Props) => !props.selectedConversationIDKey, renderNothing()),
+  branch((props: Props) => !props.selectedConversationIDKey, renderNothing),
   branch((props: Props) => props.selectedConversationIDKey === Constants.nothingSelected, renderComponent(NoConversation)),
   branch((props: Props) => !props.finalizeInfo && props.rekeyInfo, renderComponent(Rekey)),
   withState('sidePanelOpen', 'setSidePanelOpen', false),

--- a/shared/chat/conversation/notices/old-profile-reset-notice/container.js
+++ b/shared/chat/conversation/notices/old-profile-reset-notice/container.js
@@ -3,7 +3,7 @@ import * as Constants from '../../../../constants/chat'
 import * as Creators from '../../../../actions/chat/creators'
 import OldProfileResetNotice from '.'
 import {List} from 'immutable'
-import {compose} from 'recompose'
+import {compose, branch, renderNothing} from 'recompose'
 import {connect} from 'react-redux'
 
 import type {TypedState} from '../../../../constants/reducer'
@@ -12,7 +12,7 @@ import type {StateProps, DispatchProps} from './container'
 const mapStateToProps = (state: TypedState) => {
   const selectedConversationIDKey = Constants.getSelectedConversation(state)
   if (!selectedConversationIDKey) {
-    throw new Error('no selected conversation')
+    return {}
   }
   const finalizeInfo = state.chat.get('finalizedState').get(selectedConversationIDKey)
   const _supersededBy = Constants.convSupersededByInfo(selectedConversationIDKey, state.chat)
@@ -41,5 +41,6 @@ const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps) => ({
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, mergeProps)
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  branch(props => !props.username, renderNothing)
 )(OldProfileResetNotice)


### PR DESCRIPTION
Selected can be null while backing out in mobile, allow that but render nothing
Also noticed we called renderNothing() in one case (thats likely impossible) but that shouldn't be called

@keybase/react-hackers 