### PR TITLE
Fix clicking between old and new convo after making a new convo

### DIFF
--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -626,7 +626,8 @@ function * _startConversation (action: Constants.StartConversation): SagaGenerat
   const existing = yield select(inboxSelector, tlfName)
 
   if (forceImmediate && existing) {
-    yield call(Shared.startNewConversation, existing.get('conversationIDKey'))
+    const newID = yield call(Shared.startNewConversation, existing.get('conversationIDKey'))
+    yield put(Creators.selectConversation(newID, false))
   } else if (existing) { // Select existing conversations
     yield put(Creators.selectConversation(existing.get('conversationIDKey'), false))
     yield put(switchTo([chatTab]))

--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -131,7 +131,7 @@ function * startNewConversation (oldConversationIDKey: Constants.ConversationIDK
   // Replace any existing convo
   if (pendingTlfName) {
     yield put(pendingToRealConversation(oldConversationIDKey, newConversationIDKey))
-  } else {
+  } else if (oldConversationIDKey !== newConversationIDKey) {
     yield put(replaceConversation(oldConversationIDKey, newConversationIDKey))
   }
 


### PR DESCRIPTION
@keybase/react-hackers fixes if you

1. Reset an account
1. Go to that chat
1. click new Convo
1. type something
1. click to the old convo
1. click to the new convo (used to break here)