### PR TITLE
Fix dropdown width

### DIFF
--- a/shared/common-adapters/dropdown.native.js
+++ b/shared/common-adapters/dropdown.native.js
@@ -165,7 +165,6 @@ const styleContainer = {
   ...globalStyles.flexBoxRow,
   alignItems: 'center',
   borderRadius: 100,
-  width: 329,
   height: 40,
   paddingLeft: 17,
   paddingRight: 17,

--- a/shared/login/login/index.render.native.js
+++ b/shared/login/login/index.render.native.js
@@ -58,6 +58,7 @@ const styles = {
   },
   card: {
     marginTop: globalMargins.tiny,
+    width: '100%',
   },
 }
 


### PR DESCRIPTION
Dropdown component had hardcoded width which was greater than min iPhone width (320).
Removing the width from the common component and setting `width: 100%` on login user card instead which is more flexible.

See https://keybase.atlassian.net/browse/DESKTOP-3368 for more info.

I double checked and this login form is the only place Dropdown component is currently being used.

![2017-04-24 at 12 51 pm](https://cloud.githubusercontent.com/assets/2669/25355926/4057f37a-28ed-11e7-8e93-9e83d5b14bd5.png)
