### PR TITLE
Fix no-paper-key provisioning

### DIFF
--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -21,20 +21,21 @@ import (
 // Kex2Provisionee is an engine.
 type Kex2Provisionee struct {
 	libkb.Contextified
-	device       *libkb.Device
-	secret       kex2.Secret
-	secretCh     chan kex2.Secret
-	eddsa        libkb.NaclKeyPair
-	dh           libkb.NaclKeyPair
-	uid          keybase1.UID
-	username     string
-	sessionToken keybase1.SessionToken
-	csrfToken    keybase1.CsrfToken
-	pps          keybase1.PassphraseStream
-	lks          *libkb.LKSec
-	kex2Cancel   func()
-	ctx          *Context
-	v1Only       bool // only support protocol v1 (for testing)
+	device          *libkb.Device
+	secret          kex2.Secret
+	secretCh        chan kex2.Secret
+	eddsa           libkb.NaclKeyPair
+	dh              libkb.NaclKeyPair
+	uid             keybase1.UID
+	username        string
+	sessionToken    keybase1.SessionToken
+	csrfToken       keybase1.CsrfToken
+	pps             keybase1.PassphraseStream
+	lks             *libkb.LKSec
+	kex2Cancel      func()
+	ctx             *Context
+	v1Only          bool                    // only support protocol v1 (for testing)
+	localDelegateFn func(*libkb.User) error // closure created after success to update a local user
 }
 
 // Kex2Provisionee implements kex2.Provisionee, libkb.UserBasic,
@@ -253,7 +254,7 @@ func (e *Kex2Provisionee) handleDidCounterSign(sig []byte, sdhBoxes []keybase1.S
 	}
 
 	// make a keyproof for the dh key, signed w/ e.eddsa
-	dhSig, dhSigID, err := e.dhKeyProof(e.dh, decSig.eldestKID, decSig.seqno, decSig.linkID)
+	dhSig, dhSigID, dhLinkID, err := e.dhKeyProof(e.dh, decSig.eldestKID, decSig.seqno, decSig.linkID)
 	if err != nil {
 		return err
 	}
@@ -286,6 +287,21 @@ func (e *Kex2Provisionee) handleDidCounterSign(sig []byte, sdhBoxes []keybase1.S
 
 	// post the key sigs to the api server
 	if err = e.postSigs(eddsaArgs, dhArgs, sdhBoxes); err != nil {
+		return err
+	}
+
+	// remember how to update a user with the new links
+	e.localDelegateFn = func(u *libkb.User) (err error) {
+		// Signing sibkey link
+		u.SigChainBump(decSig.linkID, decSig.sigID)
+		err = u.LocalDelegateKey(e.eddsa, decSig.sigID, decSig.signingKID, true /*isSibkey*/, false /*isEldest*/)
+		if err != nil {
+			return err
+		}
+
+		// Encryption subkey link
+		u.SigChainBump(dhLinkID, dhSigID)
+		err = u.LocalDelegateKey(e.dh, dhSigID, e.eddsa.GetKID(), false /*isSibkey*/, false /*isEldest*/)
 		return err
 	}
 
@@ -498,7 +514,7 @@ func makeKeyArgs(sigID keybase1.SigID, sig []byte, delType libkb.DelegationType,
 	return &args, nil
 }
 
-func (e *Kex2Provisionee) dhKeyProof(dh libkb.GenericKey, eldestKID keybase1.KID, seqno int, linkID libkb.LinkID) (sig string, sigID keybase1.SigID, err error) {
+func (e *Kex2Provisionee) dhKeyProof(dh libkb.GenericKey, eldestKID keybase1.KID, seqno int, linkID libkb.LinkID) (sig string, sigID keybase1.SigID, outLinkID libkb.LinkID, err error) {
 	delg := libkb.Delegator{
 		ExistingKey:    e.eddsa,
 		NewKey:         dh,
@@ -514,17 +530,17 @@ func (e *Kex2Provisionee) dhKeyProof(dh libkb.GenericKey, eldestKID keybase1.KID
 
 	jw, err := libkb.KeyProof(delg)
 	if err != nil {
-		return "", "", err
+		return "", "", libkb.LinkID{}, err
 	}
 
 	e.G().Log.Debug("dh key proof: %s", jw.MarshalPretty())
 
-	dhSig, dhSigID, _, err := libkb.SignJSON(jw, e.eddsa)
+	dhSig, dhSigID, dhLinkID, err := libkb.SignJSON(jw, e.eddsa)
 	if err != nil {
-		return "", "", err
+		return "", "", libkb.LinkID{}, err
 	}
 
-	return dhSig, dhSigID, nil
+	return dhSig, dhSigID, dhLinkID, nil
 
 }
 
@@ -600,20 +616,29 @@ func (e *Kex2Provisionee) cacheKeys() (err error) {
 
 func (e *Kex2Provisionee) SigningKey() (libkb.GenericKey, error) {
 	if e.eddsa == nil {
-		return nil, fmt.Errorf("provisionee missing signing key")
+		return nil, errors.New("provisionee missing signing key")
 	}
 	return e.eddsa, nil
 }
 
 func (e *Kex2Provisionee) EncryptionKey() (libkb.NaclDHKeyPair, error) {
 	if e.dh == nil {
-		return libkb.NaclDHKeyPair{}, fmt.Errorf("provisionee missing encryption key")
+		return libkb.NaclDHKeyPair{}, errors.New("provisionee missing encryption key")
 	}
 	ret, ok := e.dh.(libkb.NaclDHKeyPair)
 	if !ok {
-		return libkb.NaclDHKeyPair{}, fmt.Errorf("provisionee encryption key unexpected type")
+		return libkb.NaclDHKeyPair{}, fmt.Errorf("provisionee encryption key unexpected type %T", e.dh)
 	}
 	return ret, nil
+}
+
+// updateUser calls LocalDelegateKey on the local user.
+// Use it on a user right after successful provisioning to avoid a roundtrip for a full re-load.
+func (e *Kex2Provisionee) updateUser(u *libkb.User) error {
+	if e.localDelegateFn == nil {
+		return errors.New("updateUser called before successful provision")
+	}
+	return e.localDelegateFn(u)
 }
 
 func firstValues(vals url.Values) map[string]string {

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -6,6 +6,7 @@ package engine
 import (
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/url"
 	"time"
 
@@ -595,6 +596,24 @@ func (e *Kex2Provisionee) cacheKeys() (err error) {
 	}
 
 	return nil
+}
+
+func (e *Kex2Provisionee) SigningKey() (libkb.GenericKey, error) {
+	if e.eddsa == nil {
+		return nil, fmt.Errorf("provisionee missing signing key")
+	}
+	return e.eddsa, nil
+}
+
+func (e *Kex2Provisionee) EncryptionKey() (libkb.NaclDHKeyPair, error) {
+	if e.dh == nil {
+		return libkb.NaclDHKeyPair{}, fmt.Errorf("provisionee missing encryption key")
+	}
+	ret, ok := e.dh.(libkb.NaclDHKeyPair)
+	if !ok {
+		return libkb.NaclDHKeyPair{}, fmt.Errorf("provisionee encryption key unexpected type")
+	}
+	return ret, nil
 }
 
 func firstValues(vals url.Values) map[string]string {

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -251,8 +251,12 @@ func (e *loginProvision) deviceWithType(ctx *Context, provisionerType keybase1.D
 			return err
 		}
 
-		// Update our user object with the new sigchain links
-		provisionee.updateUser(e.arg.User)
+		// Load me again so that keys will be up to date.
+		loadArg := libkb.NewLoadUserArgBase(e.G()).WithSelf(true).WithUID(e.arg.User.GetUID()).WithNetContext(ctx.NetContext)
+		e.arg.User, err = libkb.LoadUser(*loadArg)
+		if err != nil {
+			return err
+		}
 
 		return nil
 	}
@@ -947,12 +951,12 @@ func (e *loginProvision) ensurePaperKey(ctx *Context) error {
 	// Check that there is a signing key present.
 	// If it were nil, PaperKeyGen would try to make an eldest sigchain link.
 	if e.signingKey == nil {
-		return fmt.Errorf("missing signing key for ensure paper key")
+		return errors.New("missing signing key for ensure paper key")
 	}
 
 	if e.encryptionKey.IsNil() {
 		if e.G().Env.GetEnableSharedDH() {
-			return fmt.Errorf("missing encryption key for ensure paper key")
+			return errors.New("missing encryption key for ensure paper key")
 		}
 		e.G().Log.CWarningf(ctx.NetContext, "missing encryption key for ensure paper key")
 	}

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -119,13 +119,6 @@ func (e *loginProvision) Run(ctx *Context) error {
 	// exit.
 	tx = nil
 
-	// TODO Can this be solved with local updates instead?
-	// Reload me so that keys will be up to date.
-	e.arg.User, err = libkb.LoadUser(libkb.LoadUserArg{Self: true, UID: e.arg.User.GetUID(), PublicKeyOptional: true, Contextified: libkb.NewContextified(e.G())})
-	if err != nil {
-		return err
-	}
-
 	if err := e.ensurePaperKey(ctx); err != nil {
 		return err
 	}
@@ -257,6 +250,9 @@ func (e *loginProvision) deviceWithType(ctx *Context, provisionerType keybase1.D
 		if err != nil {
 			return err
 		}
+
+		// Update our user object with the new sigchain links
+		provisionee.updateUser(e.arg.User)
 
 		return nil
 	}

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/keybase/clockwork"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/kex2"
@@ -241,6 +242,8 @@ func TestProvisionDesktop(t *testing.T) {
 
 	wg.Wait()
 
+	require.False(t, t.Failed(), "prior failure in a goroutine")
+
 	if err := AssertProvisioned(tcY); err != nil {
 		t.Fatal(err)
 	}
@@ -390,6 +393,8 @@ func TestProvisionPassphraseNoKeysSolo(t *testing.T) {
 	username, passphrase := createFakeUserWithNoKeys(tcWeb)
 
 	Logout(tcWeb)
+
+	hasZeroPaperDev(tcWeb, &FakeUser{Username: username, Passphrase: passphrase})
 
 	tc := SetupEngineTest(t, "login")
 	defer tc.Cleanup()
@@ -2440,6 +2445,141 @@ func TestProvisionGPGMobile(t *testing.T) {
 	if _, ok := err.(libkb.GPGUnavailableError); !ok {
 		t.Errorf("error type: %T, expected libkb.GPGUnavailableError", err)
 	}
+}
+
+// Provisioning a new device when the user has no paper keys should work
+// and generate a paper key.
+func TestProvisionEnsurePaperKey(t *testing.T) {
+	// This test is based on TestProvisionDesktop.
+
+	t.Logf("create 2 users")
+
+	// device X (provisioner) context:
+	tcX := SetupEngineTest(t, "kex2provision")
+	defer tcX.Cleanup()
+
+	// device Y (provisionee) context:
+	tcY := SetupEngineTest(t, "template")
+	defer tcY.Cleanup()
+
+	// provisioner needs to be logged in
+	userX := CreateAndSignupFakeUserPaper(tcX, "login")
+	var secretX kex2.Secret
+	if _, err := rand.Read(secretX[:]); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("check for initial paper key")
+	originalPaperKey := hasOnePaperDev(tcY, userX)
+
+	t.Logf("revoke paper keys")
+	{
+		ctx := &Context{
+			LoginUI:  &libkb.TestLoginUI{Username: userX.Username},
+			LogUI:    tcY.G.UI.GetLogUI(),
+			SecretUI: &libkb.TestSecretUI{},
+		}
+		eng := NewRevokeDeviceEngine(RevokeDeviceEngineArgs{
+			ID:    originalPaperKey,
+			Force: false,
+		}, tcX.G)
+		err := RunEngine(eng, ctx)
+		require.NoError(t, err, "revoke original paper key")
+	}
+
+	t.Logf("check for no paper key")
+	hasZeroPaperDev(tcX, userX)
+
+	t.Logf("do kex provision")
+
+	secretCh := make(chan kex2.Secret)
+
+	// provisionee calls login:
+	ctx := &Context{
+		ProvisionUI: newTestProvisionUISecretCh(secretCh),
+		LoginUI:     &libkb.TestLoginUI{Username: userX.Username},
+		LogUI:       tcY.G.UI.GetLogUI(),
+		SecretUI:    &libkb.TestSecretUI{},
+		GPGUI:       &gpgtestui{},
+	}
+	eng := NewLogin(tcY.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
+
+	var wg sync.WaitGroup
+
+	// start provisionee
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := RunEngine(eng, ctx); err != nil {
+			t.Errorf("provisionee login error: %s", err)
+			return
+		}
+	}()
+
+	// start provisioner
+	provisioner := NewKex2Provisioner(tcX.G, secretX, nil)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		ctx := &Context{
+			SecretUI:    userX.NewSecretUI(),
+			ProvisionUI: newTestProvisionUI(),
+		}
+		if err := RunEngine(provisioner, ctx); err != nil {
+			t.Errorf("provisioner error: %s", err)
+			return
+		}
+	}()
+	secretFromY := <-secretCh
+	provisioner.AddSecret(secretFromY)
+
+	wg.Wait()
+
+	require.False(t, t.Failed(), "prior failure in a goroutine")
+
+	if err := AssertProvisioned(tcY); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("kex finished")
+
+	// after provisioning, the passphrase stream should be cached
+	// (note that this just checks the passphrase stream, not 3sec)
+	assertPassphraseStreamCache(tcY)
+
+	// after provisioning, the device keys should be cached
+	assertDeviceKeysCached(tcY)
+
+	testTrack := func(whom string) {
+
+		// make sure that the provisioned device can use
+		// the passphrase stream cache (use an empty secret ui)
+		arg := &TrackEngineArg{
+			UserAssertion: whom,
+			Options:       keybase1.TrackOptions{BypassConfirm: true},
+		}
+		ctx = &Context{
+			LogUI:      tcY.G.UI.GetLogUI(),
+			IdentifyUI: &FakeIdentifyUI{},
+			SecretUI:   &libkb.TestSecretUI{},
+		}
+
+		teng := NewTrackEngine(arg, tcY.G)
+		if err := RunEngine(teng, ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Make sure that we can still track without a passphrase
+	// after a similated service restart.  In other words, that
+	// the full LKSec secret was written to the secret store.
+	simulateServiceRestart(t, tcY, userX)
+	testTrack("t_bob")
+
+	t.Logf("check for paper key")
+	hasOnePaperDev(tcY, userX)
+	hasOnePaperDev(tcX, userX)
 }
 
 type testProvisionUI struct {

--- a/go/engine/paperkey_test.go
+++ b/go/engine/paperkey_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
 )
 
 func paperDevs(tc libkb.TestContext, fu *FakeUser) (*libkb.User, []*libkb.Device) {
@@ -24,12 +25,15 @@ func paperDevs(tc libkb.TestContext, fu *FakeUser) (*libkb.User, []*libkb.Device
 	return u, cki.PaperDevices()
 }
 
+func hasZeroPaperDev(tc libkb.TestContext, fu *FakeUser) {
+	_, bdevs := paperDevs(tc, fu)
+	require.Equal(tc.T, 0, len(bdevs), "num backup devices")
+}
+
 func hasOnePaperDev(tc libkb.TestContext, fu *FakeUser) keybase1.DeviceID {
 	u, bdevs := paperDevs(tc, fu)
 
-	if len(bdevs) != 1 {
-		tc.T.Fatalf("num backup devices: %d, expected 1", len(bdevs))
-	}
+	require.Equal(tc.T, 1, len(bdevs), "num backup devices")
 
 	devid := bdevs[0].ID
 	sibkey, err := u.GetComputedKeyFamily().GetSibkeyForDevice(devid)

--- a/go/libkb/delegatekey.go
+++ b/go/libkb/delegatekey.go
@@ -224,7 +224,7 @@ func (d *Delegator) updateLocalState(linkid LinkID) (err error) {
 	d.Me.SigChainBump(linkid, d.sigID)
 	d.merkleTriple = MerkleTriple{LinkID: linkid, SigID: d.sigID}
 
-	return d.Me.localDelegateKey(d.NewKey, d.sigID, d.getExistingKID(), d.IsSibkeyOrEldest(), d.IsEldest())
+	return d.Me.LocalDelegateKey(d.NewKey, d.sigID, d.getExistingKID(), d.IsSibkeyOrEldest(), d.IsEldest())
 }
 
 func (d *Delegator) post(lctx LoginContext) (err error) {

--- a/go/libkb/delegatekey.go
+++ b/go/libkb/delegatekey.go
@@ -224,7 +224,7 @@ func (d *Delegator) updateLocalState(linkid LinkID) (err error) {
 	d.Me.SigChainBump(linkid, d.sigID)
 	d.merkleTriple = MerkleTriple{LinkID: linkid, SigID: d.sigID}
 
-	return d.Me.LocalDelegateKey(d.NewKey, d.sigID, d.getExistingKID(), d.IsSibkeyOrEldest(), d.IsEldest())
+	return d.Me.localDelegateKey(d.NewKey, d.sigID, d.getExistingKID(), d.IsSibkeyOrEldest(), d.IsEldest())
 }
 
 func (d *Delegator) post(lctx LoginContext) (err error) {

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -90,6 +90,11 @@ func NewLoadUserArgBase(g *GlobalContext) *LoadUserArg {
 	return &LoadUserArg{Contextified: NewContextified(g)}
 }
 
+func (arg *LoadUserArg) WithSelf(self bool) *LoadUserArg {
+	arg.Self = self
+	return arg
+}
+
 func (arg *LoadUserArg) WithNetContext(ctx context.Context) *LoadUserArg {
 	arg.NetContext = ctx
 	return arg

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -569,10 +569,10 @@ func (u *User) BaseProofSet() *ProofSet {
 	return NewProofSet(proofs)
 }
 
-// LocalDelegateKey takes the given GenericKey and provisions it locally so that
+// localDelegateKey takes the given GenericKey and provisions it locally so that
 // we can use the key without needing a refresh from the server.  The eventual
 // refresh we do get from the server will clobber our work here.
-func (u *User) LocalDelegateKey(key GenericKey, sigID keybase1.SigID, kid keybase1.KID, isSibkey bool, isEldest bool) (err error) {
+func (u *User) localDelegateKey(key GenericKey, sigID keybase1.SigID, kid keybase1.KID, isSibkey bool, isEldest bool) (err error) {
 	if err = u.keyFamily.LocalDelegate(key); err != nil {
 		return
 	}
@@ -580,7 +580,7 @@ func (u *User) LocalDelegateKey(key GenericKey, sigID keybase1.SigID, kid keybas
 		err = NoSigChainError{}
 		return
 	}
-	u.G().Log.Debug("User LocalDelegateKey signing kid: %s", kid)
+	u.G().Log.Debug("User LocalDelegateKey kid: %s", kid)
 	err = u.sigChain().LocalDelegate(u.keyFamily, key, sigID, kid, isSibkey)
 	if isEldest {
 		eldestKID := key.GetKID()

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -569,10 +569,10 @@ func (u *User) BaseProofSet() *ProofSet {
 	return NewProofSet(proofs)
 }
 
-// localDelegateKey takes the given GenericKey and provisions it locally so that
+// LocalDelegateKey takes the given GenericKey and provisions it locally so that
 // we can use the key without needing a refresh from the server.  The eventual
 // refresh we do get from the server will clobber our work here.
-func (u *User) localDelegateKey(key GenericKey, sigID keybase1.SigID, kid keybase1.KID, isSibkey bool, isEldest bool) (err error) {
+func (u *User) LocalDelegateKey(key GenericKey, sigID keybase1.SigID, kid keybase1.KID, isSibkey bool, isEldest bool) (err error) {
 	if err = u.keyFamily.LocalDelegate(key); err != nil {
 		return
 	}
@@ -580,7 +580,7 @@ func (u *User) localDelegateKey(key GenericKey, sigID keybase1.SigID, kid keybas
 		err = NoSigChainError{}
 		return
 	}
-	u.G().Log.Debug("User localDelegateKey signing kid: %s", kid)
+	u.G().Log.Debug("User LocalDelegateKey signing kid: %s", kid)
 	err = u.sigChain().LocalDelegate(u.keyFamily, key, sigID, kid, isSibkey)
 	if isEldest {
 		eldestKID := key.GetKID()


### PR DESCRIPTION
This fixes the problem where a non-eldest device provision would error out after device provisioning on the `ensurePaperKey` step. This adds a test for that case.

This involves two fixes:
- The signing key passed to `PaperKeyGen` was accidentally nil after kex provisionee. Now the key is exported by kex and stored on `e.signingKey` just like in the eldest device case.
- The `PaperKeyGen` was trying to sign on top of an old sigchain tip because its `*User` hadn't been updated. Now kex_provisionee stores a closure (ew) that knows how to use `LocalDelegateKey` to update the `*User`. That closure is used after provisioning succeeds. I used a closure because provisionee doesn't currently take a `*User` and does its own user loads. So I figured this might be less likely to make it confusing. I'm not attached to that decision.

(named this branch wrong, it's really for CORE-4997)

cc @maxtaco 