### PR TITLE
No longer need -s for ldflags

### DIFF
--- a/packaging/prerelease/build_kbfs.sh
+++ b/packaging/prerelease/build_kbfs.sh
@@ -21,10 +21,7 @@ tags=${TAGS:-"prerelease production"}
 ldflags="-X github.com/keybase/kbfs/libkbfs.PrereleaseBuild=$kbfs_build"
 pkg="github.com/keybase/kbfs/kbfsfuse"
 
-if [ "$PLATFORM" = "darwin" ]; then
-  # To get codesign to work you have to use -ldflags "-s ...", see https://github.com/golang/go/issues/11887
-  ldflags="-s $ldflags"
-elif [ "$PLATFORM" = "windows" ]; then
+if [ "$PLATFORM" = "windows" ]; then
   pkg="github.com/keybase/kbfs/kbfsdokan"
 fi
 

--- a/packaging/prerelease/build_kbnm.sh
+++ b/packaging/prerelease/build_kbnm.sh
@@ -17,11 +17,6 @@ tags=${TAGS:-"prerelease production"}
 ldflags="-X main.Version=$kbnm_build"
 pkg="github.com/keybase/client/go/kbnm"
 
-if [ "$PLATFORM" = "darwin" ]; then
-  # To get codesign to work you have to use -ldflags "-s ...", see https://github.com/golang/go/issues/11887
-  ldflags="-s $ldflags"
-fi
-
 echo "Building $build_dir/kbnm ($kbnm_build)"
 go build -a -tags "$tags" -ldflags "$ldflags" -o "$build_dir/kbnm" "$pkg"
 

--- a/packaging/prerelease/build_keybase.sh
+++ b/packaging/prerelease/build_keybase.sh
@@ -17,7 +17,7 @@ tags=${TAGS:-"prerelease production"}
 ldflags="-X github.com/keybase/client/go/libkb.PrereleaseBuild=$keybase_build"
 
 echo "Building $build_dir/keybase ($keybase_build)"
-GO15VENDOREXPERIMENT=1 go build -a -tags "$tags" -ldflags "$ldflags" -o "$build_dir/keybase" "github.com/keybase/client/go/keybase"
+go build -a -tags "$tags" -ldflags "$ldflags" -o "$build_dir/keybase" "github.com/keybase/client/go/keybase"
 
 if [ "$PLATFORM" = "darwin" ]; then
   echo "Signing binary..."

--- a/packaging/prerelease/build_keybase.sh
+++ b/packaging/prerelease/build_keybase.sh
@@ -16,11 +16,6 @@ keybase_build=${KEYBASE_BUILD:-$build}
 tags=${TAGS:-"prerelease production"}
 ldflags="-X github.com/keybase/client/go/libkb.PrereleaseBuild=$keybase_build"
 
-if [ "$PLATFORM" = "darwin" ]; then
-  # To get codesign to work you have to use -ldflags "-s ...", see https://github.com/golang/go/issues/11887
-  ldflags="-s $ldflags"
-fi
-
 echo "Building $build_dir/keybase ($keybase_build)"
 GO15VENDOREXPERIMENT=1 go build -a -tags "$tags" -ldflags "$ldflags" -o "$build_dir/keybase" "github.com/keybase/client/go/keybase"
 

--- a/packaging/prerelease/build_updater.sh
+++ b/packaging/prerelease/build_updater.sh
@@ -16,7 +16,7 @@ cd "$src_dir"
 mkdir -p "$build_dir"
 
 echo "Building $build_dir/updater"
-GO15VENDOREXPERIMENT=1 go build -a -o "$dest" "$package"
+go build -a -o "$dest" "$package"
 
 if [ "$PLATFORM" = "darwin" ]; then
   echo "Signing binary..."

--- a/packaging/prerelease/build_updater.sh
+++ b/packaging/prerelease/build_updater.sh
@@ -15,15 +15,8 @@ cd "$src_dir"
 
 mkdir -p "$build_dir"
 
-ldflags=""
-
-if [ "$PLATFORM" = "darwin" ]; then
-  # To get codesign to work you have to use -ldflags "-s ...", see https://github.com/golang/go/issues/11887
-  ldflags="-s $ldflags"
-fi
-
 echo "Building $build_dir/updater"
-GO15VENDOREXPERIMENT=1 go build -a -ldflags "$ldflags" -o "$dest" "$package"
+GO15VENDOREXPERIMENT=1 go build -a -o "$dest" "$package"
 
 if [ "$PLATFORM" = "darwin" ]; then
   echo "Signing binary..."


### PR DESCRIPTION
Don't need -s for ldflags anymore. Fixed in go 1.8.1.