### PR TITLE
Quick fixes to hdPreview/download happening concurrently

### DIFF
--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -289,7 +289,7 @@ function reducer (state: Constants.State = initialState, action: Constants.Actio
       } else if (isHdPreview) {
         toMerge = {hdPreviewPath: path, messageState: 'sent'}
       } else {
-        toMerge = {downloadedPath: path, messageState: 'downloaded'}
+        toMerge = {downloadedPath: path, hdPreviewPath: path, messageState: 'downloaded'}
       }
 
       // $FlowIssue


### PR DESCRIPTION
If you click the "download" action for an image message dropdown and then click the thumbnail, the "hdPreview" is loaded concurrently to the full download. They are actually the same file.

This is a quick fix to force the `loadAttachment` actions to be handled serially. If "download" happens after "hdPreview", it'll pick up the hdPreview that was already downloaded, and vice versa.

In the mid term, I think we should fix the underlying problem by making "hdPreview" and "download" more homologous: downloading to the same cache location, using the same status/progress, and copying from the cache location when we "download".