### PR TITLE
Set intialNumToRender to be a high enough to fill the screen.

### DIFF
--- a/shared/chat/conversation/list/index.native.js
+++ b/shared/chat/conversation/list/index.native.js
@@ -64,6 +64,7 @@ class ConversationList extends Component <void, Props, void> {
         renderScrollComponent={this._renderScrollComponent}
         onEndReached={this._onEndReached}
         onEndReachedThreshold={0}
+        initialNumToRender={30}
         keyExtractor={this._keyExtractor}
       />
     )


### PR DESCRIPTION
Ideally the flatlist would know how many things need to render to fill
the screen, but initially it has no estimate for the size of things.
So it only renders a small number. On first scroll it has the
estimations from the small number and is able to render to fill the
screen.

This is why you notice a bug where only some messages are rendered and
others appear when you start scrolling.

This is a quick fix to load more messages initially, ideally we wouldn't
have to do this.

@keybase/react-hackers 