### PR TITLE
Remove old accesses of config.status.*, and remove it from the store

### DIFF
--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as Constants from '../../constants/config'
 import engine from '../../engine'
-import {CommonClientType, configGetBootstrapStatusRpc, configGetConfigRpc, configGetExtendedStatusRpc, configGetCurrentStatusRpc, configWaitForClientRpc} from '../../constants/types/flow-types'
+import {CommonClientType, configGetBootstrapStatusRpc, configGetConfigRpc, configGetExtendedStatusRpc, configWaitForClientRpc} from '../../constants/types/flow-types'
 import {isMobile} from '../../constants/platform'
 import {listenForKBFSNotifications} from '../../actions/notifications'
 import {navBasedOnLoginState} from '../../actions/login/creators'
@@ -168,26 +168,6 @@ const getBootstrapStatus = (): AsyncAction => dispatch => (
   })
 )
 
-const getCurrentStatus = (): AsyncAction => dispatch => (
-  new Promise((resolve, reject) => {
-    configGetCurrentStatusRpc({
-      callback: (error, status) => {
-        if (error) {
-          reject(error)
-          return
-        }
-
-        dispatch({
-          payload: {status},
-          type: Constants.statusLoaded,
-        })
-
-        resolve(status && status.user && status.user.username)
-      },
-    })
-  })
-)
-
 const updateFollowing = (username: string, isTracking: boolean): UpdateFollowing => (
   {payload: {username, isTracking}, type: Constants.updateFollowing}
 )
@@ -195,7 +175,6 @@ const updateFollowing = (username: string, isTracking: boolean): UpdateFollowing
 export {
   bootstrap,
   getConfig,
-  getCurrentStatus,
   getExtendedStatus,
   isFollower,
   isFollowing,

--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -92,8 +92,7 @@ function getProfile (username: string, ignoreCache: boolean = false, forceDispla
 
 function getMyProfile (ignoreCache?: boolean): TrackerActionCreator {
   return (dispatch, getState) => {
-    const status = getState().config.status
-    const username = status && status.user && status.user.username
+    const username = getState().config.username
     if (username) {
       dispatch(getProfile(username, ignoreCache || false))
     }

--- a/shared/native/notification-listeners.shared.js
+++ b/shared/native/notification-listeners.shared.js
@@ -27,9 +27,7 @@ export default function (dispatch: Dispatch, getState: () => Object, notify: any
       lastLoggedInNotifyUsername = null
 
       // Do we actually think we're logged in?
-      if (getState().config &&
-        getState().config.status &&
-        getState().config.status.loggedIn) {
+      if (getState().config && getState().config.loggedIn) {
         notify('Logged out of Keybase')
         dispatch(logoutDone())
       }

--- a/shared/native/notification-listeners.shared.js
+++ b/shared/native/notification-listeners.shared.js
@@ -27,7 +27,7 @@ export default function (dispatch: Dispatch, getState: () => Object, notify: any
       lastLoggedInNotifyUsername = null
 
       // Do we actually think we're logged in?
-      if (getState().config && getState().config.loggedIn) {
+      if (getState().config.loggedIn) {
         notify('Logged out of Keybase')
         dispatch(logoutDone())
       }

--- a/shared/reducers/config.js
+++ b/shared/reducers/config.js
@@ -6,7 +6,7 @@ import {isMobile} from '../constants/platform'
 import type {Tab} from '../constants/tabs'
 import type {Action} from '../constants/types/flux'
 import type {BootStatus} from '../constants/config'
-import type {Config, DeviceID, GetCurrentStatusRes, ExtendedStatus} from '../constants/types/flow-types'
+import type {Config, DeviceID, ExtendedStatus} from '../constants/types/flow-types'
 
 export type ConfigState = {
   appFocused: boolean,
@@ -24,7 +24,6 @@ export type ConfigState = {
   loggedIn: boolean,
   registered: boolean,
   readyForBootstrap: boolean,
-  status: ?GetCurrentStatusRes,
   uid: ?string,
   username: ?string,
   initialTab: ?Tab,
@@ -53,7 +52,6 @@ const initialState: ConfigState = {
   loggedIn: false,
   registered: false,
   readyForBootstrap,
-  status: null,
   uid: null,
   username: null,
   deviceID: null,
@@ -112,15 +110,6 @@ export default function (state: ConfigState = initialState, action: Action): Con
         readyForBootstrap: true,
       }
     }
-    case Constants.statusLoaded:
-      if (action.payload && action.payload.status) {
-        const status = action.payload.status
-        return {
-          ...state,
-          status,
-        }
-      }
-      return state
 
     case Constants.bootstrapLoaded:
       const {bootstrapStatus} = action.payload


### PR DESCRIPTION
@keybase/react-hackers @chromakode 

When we started using cached bootstrap values, we moved `config.status.user.username => config.username` and `config.status.loggedIn => config.loggedIn`, but we have two accessing callsites that are still looking in the old locations.  And we still had the old path defined in the store/reducer even though nothing was writing to that path anymore, so flow didn't have a chance to complain to us.  One of the callsites was involved in the `keybase logout` path, and made it so that logouts were ignored by the GUI.

This PR fixes the two callsites to look in the right place, fixing `keybase logout`, and removes the dead code.