### PR TITLE
fix RN race on clearing input

### DIFF
--- a/shared/chat/conversation/input/container.js
+++ b/shared/chat/conversation/input/container.js
@@ -72,6 +72,7 @@ export default compose(
     props => {
       let input
       return {
+        inputClear: props => () => { input && input.setNativeProps({text: ''}) },
         inputFocus: props => () => input && input.focus(),
         inputSelections: props => () => input && input.selections() || {},
         inputSetRef: props => i => { input = i },

--- a/shared/chat/conversation/input/index.js.flow
+++ b/shared/chat/conversation/input/index.js.flow
@@ -6,6 +6,7 @@ export type Props = {
   defaultText: string,
   editingMessage: ?Constants.Message,
   focusInputCounter: number,
+  inputClear: () => void,
   inputFocus: () => void,
   inputSetRef: (r: any) => void,
   inputValue: () => string,

--- a/shared/chat/conversation/input/index.native.js
+++ b/shared/chat/conversation/input/index.native.js
@@ -37,7 +37,6 @@ class ConversationInput extends Component<void, Props, void> {
       return
     }
 
-    console.log('aaa submit text', text)
     this.props.setText('')
     this.props.inputClear()
     if (this.props.editingMessage) {

--- a/shared/chat/conversation/input/index.native.js
+++ b/shared/chat/conversation/input/index.native.js
@@ -27,7 +27,8 @@ class ConversationInput extends Component<void, Props, void> {
   }
 
   _onSubmit = () => {
-    if (!this.props.text) {
+    const text = this.props.text
+    if (!text) {
       return
     }
 
@@ -36,12 +37,14 @@ class ConversationInput extends Component<void, Props, void> {
       return
     }
 
-    if (this.props.editingMessage) {
-      this.props.onEditMessage(this.props.editingMessage, this.props.text)
-    } else {
-      this.props.onPostMessage(this.props.text)
-    }
+    console.log('aaa submit text', text)
     this.props.setText('')
+    this.props.inputClear()
+    if (this.props.editingMessage) {
+      this.props.onEditMessage(this.props.editingMessage, text)
+    } else {
+      this.props.onPostMessage(text)
+    }
   }
 
   _openFilePicker = () => {

--- a/shared/common-adapters/input.desktop.js
+++ b/shared/common-adapters/input.desktop.js
@@ -28,6 +28,10 @@ class Input extends Component<void, Props, State> {
     }
   }
 
+  setNativeProps (props: Object) {
+    throw new Error('Only implemented on RN')
+  }
+
   componentDidMount () {
     this._autoResize()
   }

--- a/shared/common-adapters/input.js.flow
+++ b/shared/common-adapters/input.js.flow
@@ -32,7 +32,9 @@ export type Props = {
   autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters',
   autoCorrect?: bool,
   keyboardType?: 'default' | 'email-address' | 'numeric' | 'phone-pad' | 'ascii-capable' | 'numbers-and-punctuation' | 'url' | 'number-pad' | 'name-phone-pad' | 'decimal-pad' | 'twitter' | 'web-search',
-  returnKeyType?: 'done' | 'go' | 'next' | 'search' | 'send'
+  returnKeyType?: 'done' | 'go' | 'next' | 'search' | 'send',
 }
 
-declare export default class Input extends Component<void, Props, void> { }
+declare export default class Input extends Component<void, Props, void> {
+  setNativeProps (props: Object): {}
+}

--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -30,6 +30,10 @@ class Input extends Component<void, Props, State> {
     }
   }
 
+  setNativeProps (props: Object) {
+    this._input && this._input.setNativeProps(props)
+  }
+
   componentWillReceiveProps (nextProps: Props) {
     if (nextProps.hasOwnProperty('value')) {
       this.setState({value: nextProps.value || ''})


### PR DESCRIPTION
If you type quickly and hit send you can keep typing and your input won't be cleared.
This is largely due to a race with the native component and calling setText (which uses state).
As a workaround I added an explicit inputClear helper which uses the native props (see https://facebook.github.io/react-native/docs/direct-manipulation.html)
So when we clear the input on submit (as the example in the above RN docs does) we explicitly also set the inner view's input to blank also so we're in sync.
Not something we'd commonly need but chat input is pretty special

@keybase/react-hackers 