### PR TITLE
Fix statusbar / background / padding rendering of fullscreen routes

### DIFF
--- a/shared/nav.native.js
+++ b/shared/nav.native.js
@@ -61,7 +61,7 @@ class CardStackShim extends Component {
   }
 }
 
-function renderMainStackRoute (route) {
+function renderStackRoute (route) {
   const {underStatusBar, hideStatusBar} = route.tags
   return (
     <Box style={route.tags.underStatusBar ? sceneWrapStyleUnder : sceneWrapStyleOver}>
@@ -104,7 +104,7 @@ function MainNavStack (props: Props) {
       <CardStackShim
         key={props.routeSelected}
         stack={screens}
-        renderRoute={renderMainStackRoute}
+        renderRoute={renderStackRoute}
         onNavigateBack={props.navigateUp}
       />
       {![chatTab].includes(props.routeSelected) && <Offline reachability={props.reachability} appFocused={true} />}
@@ -123,14 +123,6 @@ function MainNavStack (props: Props) {
   return <Container hideNav={props.hideNav} shim={shim} tabBar={tabBar} />
 }
 
-function renderFullScreenStackRoute (route) {
-  return (
-    <Box style={globalStyles.fillAbsolute}>
-      {route.component}
-    </Box>
-  )
-}
-
 function Nav (props: Props) {
   const baseScreens = props.routeStack.filter(r => !r.tags.layerOnTop)
   if (!baseScreens.size) {
@@ -143,7 +135,7 @@ function Nav (props: Props) {
     .unshift({
       path: ['main'],
       component: <MainNavStack {...props} routeStack={mainScreens} />,
-      tags: {},
+      tags: {underStatusBar: true},  // don't pad nav stack (child screens have own padding)
     })
 
   const layerScreens = props.routeStack.filter(r => r.tags.layerOnTop)
@@ -152,7 +144,7 @@ function Nav (props: Props) {
     <Box style={globalStyles.fillAbsolute}>
       <CardStackShim
         stack={fullScreens}
-        renderRoute={renderFullScreenStackRoute}
+        renderRoute={renderStackRoute}
         onNavigateBack={props.navigateUp}
         mode='modal'
       />


### PR DESCRIPTION
Found this while investigating some other fixes... this fixes statusbar hiding in the attachment popup, because the fullscreen card renderer wasn't rendering the `StatusBar` component.