### PR TITLE
forward ios console.logs

### DIFF
--- a/shared/settings/feedback-container.js
+++ b/shared/settings/feedback-container.js
@@ -7,7 +7,7 @@ import logSend from '../native/log-send'
 import {connect} from 'react-redux'
 import {compose, withState, withHandlers} from 'recompose'
 import {isElectron, isIOS} from '../constants/platform'
-import {dumpLoggers} from '../util/periodic-logger'
+import {dumpLoggers, getLogger} from '../util/periodic-logger'
 import {writeStream, cachesDirectoryPath} from '../util/file'
 import {serialPromises} from '../util/promise'
 
@@ -49,11 +49,24 @@ class FeedbackContainer extends Component<void, {}, State> {
       // We don't get the notification from the daemon so we have to do this ourselves
       const logs = []
       console.log('Starting log dump')
-      dumpLoggers((...args) => {
+
+      const logNames = ['actionLogger', 'storeLogger']
+
+      logNames.forEach(name => {
         try {
-          logs.push(args)
+          const logger = getLogger(name)
+          logger && logger.dumpAll((...args) => {
+            logs.push(args)
+          })
         } catch (_) {}
       })
+
+      logs.push(['=============CONSOLE.LOG START============='])
+      const logger = getLogger('iosConsoleLog')
+      logger && logger.dumpAll((...args) => {
+        logs.push([args[1], ...args.slice(2)])
+      })
+      logs.push(['=============CONSOLE.LOG END============='])
 
       const path = `${cachesDirectoryPath}/Keybase/rn.log`
       console.log('Starting log write')
@@ -61,7 +74,6 @@ class FeedbackContainer extends Component<void, {}, State> {
       writeStream(path, 'utf8').then(stream => {
         const writeLogsPromises = logs.map((log, idx) => {
           return () => {
-            console.log(`Writing log # ${idx + 1}`)
             return stream.write(JSON.stringify(log, null, 2))
           }
         })

--- a/shared/settings/feedback-container.js
+++ b/shared/settings/feedback-container.js
@@ -64,6 +64,7 @@ class FeedbackContainer extends Component<void, {}, State> {
       logs.push(['=============CONSOLE.LOG START============='])
       const logger = getLogger('iosConsoleLog')
       logger && logger.dumpAll((...args) => {
+        // Skip the extra prefixes that period-logger uses.
         logs.push([args[1], ...args.slice(2)])
       })
       logs.push(['=============CONSOLE.LOG END============='])

--- a/shared/store/action-logger.js
+++ b/shared/store/action-logger.js
@@ -19,7 +19,7 @@ const transform = (o: Array<any>) => {
   return [JSON.stringify(immutableToJS(o), null, 2)]
 }
 
-const logger = enableActionLogging ? setupLogger('actionLogger', 100, immediateStateLogging, transform, 50) : {log: () => {}}
+const logger = enableActionLogging ? setupLogger('actionLogger', 100, immediateStateLogging, transform, 50, true) : {log: () => {}}
 
 export const actionLogger = (store: any) => (next: any) => (action: any) => {
   const oldState = store.getState()

--- a/shared/store/configure-store.js
+++ b/shared/store/configure-store.js
@@ -32,7 +32,7 @@ const crashHandler = (error) => {
 let loggerMiddleware: any
 
 if (enableStoreLogging) {
-  const logger = setupLogger('storeLogger', 100, immediateStateLogging, immutableToJS, 50)
+  const logger = setupLogger('storeLogger', 100, immediateStateLogging, immutableToJS, 50, true)
   loggerMiddleware = createLogger({
     actionTransformer: (...args) => {
       console.log('Action:', ...args)

--- a/shared/util/forward-logs.native.js
+++ b/shared/util/forward-logs.native.js
@@ -20,17 +20,17 @@ function setupSource () {
 
   window.console.log = (...args) => {
     localLog(...args)
-    logger.info(args.join(', '))
+    logger.info(...args)
   }
 
   window.console.warn = (...args) => {
     localWarn(...args)
-    logger.warn(args.join(', '))
+    logger.warn(...args)
   }
 
   window.console.error = (...args) => {
     localError(...args)
-    logger.error(args.join(', '))
+    logger.error(...args)
   }
 }
 

--- a/shared/util/logger.android.js
+++ b/shared/util/logger.android.js
@@ -1,3 +1,10 @@
 // @flow
 import {NativeModules} from 'react-native'
-export default NativeModules.FileLogger
+
+const logger = {
+  info: (...args: Array<any>) => NativeModules.FileLogger.info(args.join(',')),
+  warn: (...args: Array<any>) => NativeModules.FileLogger.warn(args.join(',')),
+  error: (...args: Array<any>) => NativeModules.FileLogger.error(args.join(',')),
+}
+
+export default logger

--- a/shared/util/logger.ios.js
+++ b/shared/util/logger.ios.js
@@ -1,6 +1,12 @@
 // @flow
+
+import {setupLogger} from './periodic-logger'
+
+const MAX = 10000
+const iosConsoleLogger = setupLogger('iosConsoleLog', MAX, false, null, 0, false)
+
 export default {
-  info: () => {},
-  warn: () => {},
-  error: () => {},
+  info: (...args: Array<any>) => iosConsoleLogger.log(...args),
+  warn: (...args: Array<any>) => iosConsoleLogger.warn(...args),
+  error: (...args: Array<any>) => iosConsoleLogger.error(...args),
 }

--- a/shared/util/periodic-logger.js
+++ b/shared/util/periodic-logger.js
@@ -16,45 +16,48 @@ class PeriodicLogger {
   _messages: Array<Array<any>> = []
   _size: number
   _logIncoming: boolean
+  _logToConsole: boolean
   _logTransform: (Array<any>) => Array<any>
   _logAfterXActions: number
 
-  constructor (name: string, size: number, logIncoming: boolean, logTransform: ?(Array<any> => Array<any>), logAfterXActions: number) {
+  constructor (name: string, size: number, logIncoming: boolean, logTransform: ?(Array<any> => Array<any>), logAfterXActions: number, logToConsole: boolean) {
     if (size <= 0) {
       throw new Error(`PeriodLogger size must be positive: ${size}`)
     }
     this._size = size
     this._name = name
     this._logIncoming = logIncoming
+    this._logToConsole = logToConsole
     this._logTransform = logTransform || ((args: Array<any>) => args)
     this._logAfterXActions = logAfterXActions
   }
 
   _write (args: Array<any>) {
+    const argsWithTimestamp = [Date.now(), ...args]
     this._lastWrite++
-    this._messages[this._lastWrite % this._size] = args
+    this._messages[this._lastWrite % this._size] = argsWithTimestamp
 
     if (this._logIncoming) {
-      this._dump(null, PREFIX_DUMP_CURRENT, args)
+      this._dump(null, PREFIX_DUMP_CURRENT, argsWithTimestamp)
     } else if (this._logAfterXActions > 0) {
       if ((this._lastWrite % this._logAfterXActions) === 0) {
-        this._dump(null, PREFIX_DUMP_CURRENT, args)
+        this._dump(null, PREFIX_DUMP_CURRENT, argsWithTimestamp)
       }
     }
   }
 
   log (...args: Array<any>) {
-    !this._logIncoming && console.log(PREFIX_LOG, this._lastWrite + 1) // output current index so we can see the order of things and correlate a full dump
+    !this._logIncoming && this._logToConsole && console.log(PREFIX_LOG, this._lastWrite + 1) // output current index so we can see the order of things and correlate a full dump
     this._write(args)
   }
 
   warn (...args: Array<any>) {
-    !this._logIncoming && console.warn(PREFIX_WARN, this._lastWrite + 1)
+    !this._logIncoming && this._logToConsole && console.warn(PREFIX_WARN, this._lastWrite + 1)
     this._write(args)
   }
 
   error (...args: Array<any>) {
-    !this._logIncoming && console.error(PREFIX_ERROR, this._lastWrite + 1)
+    !this._logIncoming && this._logToConsole && console.error(PREFIX_ERROR, this._lastWrite + 1)
     this._write(args)
   }
 
@@ -108,12 +111,12 @@ function dumpLoggers (consoleLogOverwrite: any) {
   })
 }
 
-function setupLogger (name: string, size: number, logIncoming: boolean, logTransform: ?(Array<any>) => Array<any>, logAfterXActions: number): PeriodicLogger {
+function setupLogger (name: string, size: number, logIncoming: boolean, logTransform: ?(Array<any>) => Array<any>, logAfterXActions: number, logToConsole: boolean): PeriodicLogger {
   if (_loggers[name]) {
     throw new Error(`logger already named ${name} exists`)
   }
 
-  _loggers[name] = new PeriodicLogger(name, size, logIncoming, logTransform, logAfterXActions)
+  _loggers[name] = new PeriodicLogger(name, size, logIncoming, logTransform, logAfterXActions, logToConsole)
   return _loggers[name]
 }
 
@@ -128,7 +131,7 @@ function getLogger (name: string) {
 type ImmutableToJSType = ?Array<any>
 
 // $FlowIssue this is a generic mechanism where the caller is making sure it'll match. Not clear how to encode that simply
-const immutableToJS = ([prefix, state]: ImmutableToJSType) => { // eslint-disable-line
+const immutableToJS = ([prefix, timestamp, state]: ImmutableToJSType) => { // eslint-disable-line
   var newState = {}
 
   Object.keys(state).forEach(i => {
@@ -139,7 +142,7 @@ const immutableToJS = ([prefix, state]: ImmutableToJSType) => { // eslint-disabl
     }
   })
 
-  return [prefix, newState]
+  return [prefix, timestamp, newState]
 }
 
 export {


### PR DESCRIPTION
@keybase/react-hackers 
I mentioned this on slack. This is a super short term solution to the lack of console.logs in the log send. The console.log will also capture the actionLogger (since that calls console.log also) which will help with our debugging but also means the logs are like 3x the size they need to be.

Longer term I think we need a better holistic solution. Currently

- Console.log overwriting is very messy and flow hates it and its hard to understand what's really going on
- We handle the logs in 3 different ways between desktop/android/ios

Instead I think we should have some explicit logger that has the semantics we really want and just use that instead of console.log. Let's also unify how this all works so the flow is 100% the same across the platforms