### PR TITLE
add more metadata to chat remote calls CORE-3878

### DIFF
--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -9,6 +9,10 @@ import (
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 
+type appTypeSource interface {
+	GetAppType() libkb.AppType
+}
+
 type keyfinderKey int
 type identifyNotifierKey int
 type chatTrace int
@@ -58,7 +62,7 @@ func CtxIdentifyNotifier(ctx context.Context) *IdentifyNotifier {
 	return nil
 }
 
-func CtxAddLogTags(ctx context.Context, env *libkb.Env) context.Context {
+func CtxAddLogTags(ctx context.Context, env appTypeSource) context.Context {
 
 	// Add trace context value
 	ctx = context.WithValue(ctx, chatTraceKey, libkb.RandStringB64(3))
@@ -77,7 +81,7 @@ func CtxAddLogTags(ctx context.Context, env *libkb.Env) context.Context {
 	return ctx
 }
 
-func Context(ctx context.Context, env *libkb.Env, mode keybase1.TLFIdentifyBehavior,
+func Context(ctx context.Context, env appTypeSource, mode keybase1.TLFIdentifyBehavior,
 	breaks *[]keybase1.TLFIdentifyFailure, notifier *IdentifyNotifier) context.Context {
 	res := IdentifyModeCtx(ctx, mode, breaks)
 	res = context.WithValue(res, kfKey, NewKeyFinder())
@@ -86,7 +90,7 @@ func Context(ctx context.Context, env *libkb.Env, mode keybase1.TLFIdentifyBehav
 	return res
 }
 
-func BackgroundContext(sourceCtx context.Context, env *libkb.Env) context.Context {
+func BackgroundContext(sourceCtx context.Context, env appTypeSource) context.Context {
 
 	rctx := context.Background()
 

--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -170,7 +170,7 @@ func (h *IdentifyChangedHandler) HandleUserChanged(uid keybase1.UID) (err error)
 	var breaks []keybase1.TLFIdentifyFailure
 	ident := keybase1.TLFIdentifyBehavior_CHAT_GUI
 	notifier := NewIdentifyNotifier(h.G())
-	ctx := Context(context.Background(), ident, &breaks, notifier)
+	ctx := Context(context.Background(), h.G().Env, ident, &breaks, notifier)
 
 	// Find a TLF name from the local inbox that includes the user sent to us
 	tlfName, _, err := h.getTLFtoCrypt(ctx, uid.ToBytes())

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -136,7 +136,7 @@ func (b *NonblockingLocalizer) Localize(ctx context.Context, uid gregor1.UID, in
 	}
 
 	// Spawn off localization into its own goroutine and use cb to communicate with outside world
-	bctx := BackgroundContext(ctx)
+	bctx := BackgroundContext(ctx, b.G().GetEnv())
 	go func() {
 		b.Debug(bctx, "Localize: starting background localization: convs: %d",
 			len(inbox.ConvsUnverified))

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -134,7 +134,8 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 	g.Debug(ctx, "chat activity: action %s", gm.Action)
 
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks, g.identNotifier)
+	ctx = Context(ctx, g.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
+		g.identNotifier)
 
 	action := gm.Action
 	reader.Reset(m.Body().Bytes())

--- a/go/chat/retry.go
+++ b/go/chat/retry.go
@@ -185,7 +185,7 @@ func (f *FetchRetrier) retryFetch(uid gregor1.UID, force bool, kind types.FetchT
 	var err error
 	var breaks []keybase1.TLFIdentifyFailure
 	box := storage.NewConversationFailureBox(f.G(), uid, f.boxKey(kind))
-	ctx := Context(context.Background(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &breaks,
+	ctx := Context(context.Background(), f.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &breaks,
 		NewIdentifyNotifier(f.G()))
 
 	// Get all items that are ready to be retried.

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -676,7 +676,8 @@ func (s *Deliverer) deliverLoop() {
 		var breaks []keybase1.TLFIdentifyFailure
 		for _, obr := range obrs {
 
-			bctx := Context(context.Background(), obr.IdentifyBehavior, &breaks, s.identNotifier)
+			bctx := Context(context.Background(), s.G().GetEnv(), obr.IdentifyBehavior, &breaks,
+				s.identNotifier)
 			if !s.connected {
 				err = errors.New("disconnected from chat server")
 			} else {

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -125,7 +125,7 @@ func (h *Server) handleOfflineError(ctx context.Context, err error,
 
 func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNonblockLocalArg) (res chat1.NonblockFetchRes, err error) {
 	var breaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, arg.IdentifyBehavior, &breaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &breaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetInboxNonblockLocal")()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err = h.assertLoggedIn(ctx); err != nil {
@@ -213,7 +213,8 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 
 func (h *Server) MarkAsReadLocal(ctx context.Context, arg chat1.MarkAsReadLocalArg) (res chat1.MarkAsReadLocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
+		h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "MarkAsReadLocal")()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err = h.assertLoggedIn(ctx); err != nil {
@@ -235,7 +236,7 @@ func (h *Server) MarkAsReadLocal(ctx context.Context, arg chat1.MarkAsReadLocalA
 // GetInboxAndUnboxLocal implements keybase.chatLocal.getInboxAndUnboxLocal protocol.
 func (h *Server) GetInboxAndUnboxLocal(ctx context.Context, arg chat1.GetInboxAndUnboxLocalArg) (res chat1.GetInboxAndUnboxLocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetInboxAndUnboxLocal")()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err = h.assertLoggedIn(ctx); err != nil {
@@ -269,7 +270,7 @@ func (h *Server) GetInboxAndUnboxLocal(ctx context.Context, arg chat1.GetInboxAn
 
 func (h *Server) GetCachedThread(ctx context.Context, arg chat1.GetCachedThreadArg) (res chat1.GetThreadLocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetCachedThread")()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err = h.assertLoggedIn(ctx); err != nil {
@@ -294,7 +295,7 @@ func (h *Server) GetCachedThread(ctx context.Context, arg chat1.GetCachedThreadA
 // GetThreadLocal implements keybase.chatLocal.getThreadLocal protocol.
 func (h *Server) GetThreadLocal(ctx context.Context, arg chat1.GetThreadLocalArg) (res chat1.GetThreadLocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetThreadLocal")()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err = h.assertLoggedIn(ctx); err != nil {
@@ -319,7 +320,7 @@ func (h *Server) GetThreadLocal(ctx context.Context, arg chat1.GetThreadLocalArg
 
 func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonblockArg) (res chat1.NonblockFetchRes, fullErr error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	uid := h.G().Env.GetUID()
 	defer h.Trace(ctx, func() error { return fullErr },
 		fmt.Sprintf("GetThreadNonblock(%s)", arg.ConversationID))()
@@ -433,7 +434,7 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 // Create a new conversation. Or in the case of CHAT, create-or-get a conversation.
 func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversationLocalArg) (res chat1.NewConversationLocalRes, reserr error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return reserr }, "NewConversationLocal")()
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return chat1.NewConversationLocalRes{}, err
@@ -570,7 +571,8 @@ func (h *Server) makeFirstMessage(ctx context.Context, triple chat1.Conversation
 
 func (h *Server) GetInboxSummaryForCLILocal(ctx context.Context, arg chat1.GetInboxSummaryForCLILocalQuery) (res chat1.GetInboxSummaryForCLILocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, keybase1.TLFIdentifyBehavior_CHAT_CLI, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_CLI, &identBreaks,
+		h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetInboxSummaryForCLILocal")()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err = h.assertLoggedIn(ctx); err != nil {
@@ -670,7 +672,8 @@ func (h *Server) GetInboxSummaryForCLILocal(ctx context.Context, arg chat1.GetIn
 
 func (h *Server) GetConversationForCLILocal(ctx context.Context, arg chat1.GetConversationForCLILocalQuery) (res chat1.GetConversationForCLILocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, keybase1.TLFIdentifyBehavior_CHAT_CLI, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_CLI, &identBreaks,
+		h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetConversationForCLILocal")()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err := h.assertLoggedIn(ctx); err != nil {
@@ -738,7 +741,7 @@ func (h *Server) GetConversationForCLILocal(ctx context.Context, arg chat1.GetCo
 
 func (h *Server) GetMessagesLocal(ctx context.Context, arg chat1.GetMessagesLocalArg) (res chat1.GetMessagesLocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "GetMessagesLocal")()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	deflt := chat1.GetMessagesLocalRes{}
@@ -784,7 +787,7 @@ func (h *Server) GetMessagesLocal(ctx context.Context, arg chat1.GetMessagesLoca
 
 func (h *Server) SetConversationStatusLocal(ctx context.Context, arg chat1.SetConversationStatusLocalArg) (res chat1.SetConversationStatusLocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "SetConversationStatusLocal")()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return chat1.SetConversationStatusLocalRes{}, err
@@ -807,7 +810,7 @@ func (h *Server) SetConversationStatusLocal(ctx context.Context, arg chat1.SetCo
 // PostLocal implements keybase.chatLocal.postLocal protocol.
 func (h *Server) PostLocal(ctx context.Context, arg chat1.PostLocalArg) (res chat1.PostLocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "PostLocal")()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return chat1.PostLocalRes{}, err
@@ -899,7 +902,7 @@ func (h *Server) PostTextNonblock(ctx context.Context, arg chat1.PostTextNonbloc
 func (h *Server) PostLocalNonblock(ctx context.Context, arg chat1.PostLocalNonblockArg) (res chat1.PostLocalNonblockRes, err error) {
 
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "PostLocalNonblock")()
 	if err = h.assertLoggedIn(ctx); err != nil {
 		return chat1.PostLocalNonblockRes{}, err
@@ -1407,7 +1410,7 @@ func (h *Server) postAttachmentLocalInOrder(ctx context.Context, arg postAttachm
 // DownloadAttachmentLocal implements chat1.LocalInterface.DownloadAttachmentLocal.
 func (h *Server) DownloadAttachmentLocal(ctx context.Context, arg chat1.DownloadAttachmentLocalArg) (res chat1.DownloadAttachmentLocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "DownloadAttachmentLocal")()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	darg := downloadAttachmentArg{
@@ -1455,7 +1458,7 @@ type downloadAttachmentArg struct {
 func (h *Server) downloadAttachmentLocal(ctx context.Context, arg downloadAttachmentArg) (chat1.DownloadAttachmentLocalRes, error) {
 
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	chatUI := h.getChatUI(arg.SessionID)
 	progress := func(bytesComplete, bytesTotal int64) {
 		parg := chat1.ChatAttachmentDownloadProgressArg{
@@ -1839,7 +1842,7 @@ func (h *Server) deleteAssets(ctx context.Context, conversationID chat1.Conversa
 func (h *Server) FindConversationsLocal(ctx context.Context,
 	arg chat1.FindConversationsLocalArg) (res chat1.FindConversationsLocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, arg.IdentifyBehavior, &identBreaks, h.identNotifier)
+	ctx = Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "FindConversationsLocal")()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	if err = h.assertLoggedIn(ctx); err != nil {

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -144,7 +144,7 @@ func (s *Syncer) IsConnected(ctx context.Context) bool {
 
 func (s *Syncer) Connected(ctx context.Context, cli chat1.RemoteInterface, uid gregor1.UID,
 	syncRes *chat1.SyncChatRes) (err error) {
-	ctx = CtxAddLogTags(ctx)
+	ctx = CtxAddLogTags(ctx, s.G().GetEnv())
 	s.Lock()
 	defer s.Unlock()
 	defer s.Trace(ctx, func() error { return err }, "Connected")()

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -62,7 +62,7 @@ func (t *KBFSTLFInfoSource) CryptKeys(ctx context.Context, tlfName string) (res 
 		fmt.Sprintf("CryptKeys(tlf=%s,mode=%v)", tlfName, identBehavior))()
 
 	// call identifyTLF and GetTLFCryptKeys concurrently:
-	group, ectx := errgroup.WithContext(BackgroundContext(ctx))
+	group, ectx := errgroup.WithContext(BackgroundContext(ctx, t.G().GetEnv()))
 
 	var ib []keybase1.TLFIdentifyFailure
 	group.Go(func() error {
@@ -115,7 +115,7 @@ func (t *KBFSTLFInfoSource) PublicCanonicalTLFNameAndID(ctx context.Context, tlf
 		fmt.Sprintf("PublicCanonicalTLFNameAndID(tlf=%s,mode=%v)", tlfName, identBehavior))()
 
 	// call identifyTLF and CanonicalTLFNameAndIDWithBreaks concurrently:
-	group, ectx := errgroup.WithContext(BackgroundContext(ctx))
+	group, ectx := errgroup.WithContext(BackgroundContext(ctx, t.G().GetEnv()))
 
 	var ib []keybase1.TLFIdentifyFailure
 	group.Go(func() error {
@@ -186,7 +186,7 @@ func (t *KBFSTLFInfoSource) CompleteAndCanonicalizePrivateTlfName(ctx context.Co
 
 func (t *KBFSTLFInfoSource) identifyTLF(ctx context.Context, arg keybase1.TLFQuery, private bool) ([]keybase1.TLFIdentifyFailure, error) {
 	// need new context as errgroup will cancel it.
-	group, ectx := errgroup.WithContext(BackgroundContext(ctx))
+	group, ectx := errgroup.WithContext(BackgroundContext(ctx, t.G().GetEnv()))
 	assertions := make(chan string)
 
 	group.Go(func() error {

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -1198,3 +1198,10 @@ func (e *Env) GetKBFSInfoPath() string {
 func (e *Env) GetUpdateDefaultInstructions() (string, error) {
 	return PlatformSpecificUpgradeInstructionsString()
 }
+
+func GetPlatformString() string {
+	if isIOS {
+		return "ios"
+	}
+	return runtime.GOOS
+}

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -112,8 +112,8 @@ func (h *KBFSHandler) conversationIDs(uid keybase1.UID, tlf string, public bool)
 	}
 
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx := chat.Context(context.Background(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
-		chat.NewIdentifyNotifier(globals.NewContext(h.G(), h.ChatG())))
+	ctx := chat.Context(context.Background(), h.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI,
+		&identBreaks, chat.NewIdentifyNotifier(globals.NewContext(h.G(), h.ChatG())))
 	ib, _, err := h.ChatG().InboxSource.Read(ctx, uid.ToBytes(), nil, true, &query, nil)
 	if err != nil {
 		return nil, err

--- a/go/service/tlf.go
+++ b/go/service/tlf.go
@@ -37,7 +37,7 @@ func (h *tlfHandler) CryptKeys(ctx context.Context, arg keybase1.TLFQuery) (res 
 	defer h.Trace(ctx, func() error { return err },
 		fmt.Sprintf("CryptKeys(tlf=%s,mode=%v)", arg.TlfName, arg.IdentifyBehavior))()
 	var breaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
+	ctx = chat.Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
 	return h.tlfInfoSource.CryptKeys(ctx, arg.TlfName)
 }
 
@@ -46,7 +46,7 @@ func (h *tlfHandler) PublicCanonicalTLFNameAndID(ctx context.Context, arg keybas
 		fmt.Sprintf("PublicCanonicalTLFNameAndID(tlf=%s,mode=%v)", arg.TlfName,
 			arg.IdentifyBehavior))()
 	var breaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
+	ctx = chat.Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
 	return h.tlfInfoSource.PublicCanonicalTLFNameAndID(ctx, arg.TlfName)
 }
 
@@ -55,6 +55,6 @@ func (h *tlfHandler) CompleteAndCanonicalizePrivateTlfName(ctx context.Context, 
 		fmt.Sprintf("CompleteAndCanonicalizePrivateTlfName(tlf=%s,mode=%v)", arg.TlfName,
 			arg.IdentifyBehavior))()
 	var breaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
+	ctx = chat.Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
 	return h.tlfInfoSource.CompleteAndCanonicalizePrivateTlfName(ctx, arg.TlfName)
 }

--- a/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/connection.go
+++ b/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/connection.go
@@ -192,9 +192,6 @@ func (ct *ConnectionTransportTLS) Dial(ctx context.Context) (
 			return err
 		}
 		conn = tls.Client(baseConn, config)
-		if err := conn.(*tls.Conn).Handshake(); err != nil {
-			return err
-		}
 
 		// Disable SIGPIPE on platforms that require it (Darwin). See sigpipe_bsd.go.
 		return DisableSigPipe(baseConn)

--- a/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/connection.go
+++ b/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/connection.go
@@ -192,6 +192,9 @@ func (ct *ConnectionTransportTLS) Dial(ctx context.Context) (
 			return err
 		}
 		conn = tls.Client(baseConn, config)
+		if err := conn.(*tls.Conn).Handshake(); err != nil {
+			return err
+		}
 
 		// Disable SIGPIPE on platforms that require it (Darwin). See sigpipe_bsd.go.
 		return DisableSigPipe(baseConn)

--- a/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/context.go
+++ b/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/context.go
@@ -1,8 +1,6 @@
 package rpc
 
-import (
-	"golang.org/x/net/context"
-)
+import "golang.org/x/net/context"
 
 // CtxRpcKey is a type defining the context key for the RPC context
 type CtxRpcKey int
@@ -21,16 +19,23 @@ func AddRpcTagsToContext(ctx context.Context, logTagsToAdd CtxRpcTags) context.C
 	currTags, ok := RpcTagsFromContext(ctx)
 	if !ok {
 		currTags = make(CtxRpcTags)
-		ctx = context.WithValue(ctx, CtxRpcTagsKey, currTags)
 	}
 	for key, tag := range logTagsToAdd {
 		currTags[key] = tag
 	}
-	return ctx
+
+	return context.WithValue(ctx, CtxRpcTagsKey, currTags)
 }
 
 // RpcTagsFromContext returns the tags being passed along with the given context.
 func RpcTagsFromContext(ctx context.Context) (CtxRpcTags, bool) {
 	logTags, ok := ctx.Value(CtxRpcTagsKey).(CtxRpcTags)
-	return logTags, ok
+	if ok {
+		ret := make(CtxRpcTags)
+		for k, v := range logTags {
+			ret[k] = v
+		}
+		return ret, true
+	}
+	return nil, false
 }

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -259,10 +259,10 @@
 			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
-			"checksumSHA1": "d2oUixwR6P1/pDb7NEu/cFmCKJc=",
+			"checksumSHA1": "h5M/0X8u48IKcVyFg/bTBt2Q/EY=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc",
-			"revision": "68da9ff2336b22c496aa52a9e63f2589d7d4495e",
-			"revisionTime": "2017-04-03T19:16:51Z"
+			"revision": "ed0755654131895e6bdaa3fbd828a35f4c8db799",
+			"revisionTime": "2017-03-30T19:15:56Z"
 		},
 		{
 			"path": "github.com/keybase/go-jsonw",

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -259,10 +259,10 @@
 			"revisionTime": "2017-04-19T18:45:05Z"
 		},
 		{
-			"checksumSHA1": "h5M/0X8u48IKcVyFg/bTBt2Q/EY=",
+			"checksumSHA1": "VJXG0sarqZdiW3yV0WdtOMv3aRo=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc",
-			"revision": "ed0755654131895e6bdaa3fbd828a35f4c8db799",
-			"revisionTime": "2017-03-30T19:15:56Z"
+			"revision": "a78b83e7f6a00a4840651615fff80f34144dce9c",
+			"revisionTime": "2017-04-26T21:05:15Z"
 		},
 		{
 			"path": "github.com/keybase/go-jsonw",


### PR DESCRIPTION
Patch does the following:

1.) Adds some more RPC tags for platform specific values: user agent, platform, and app type. These all show up in the Gregor logs on the server side. It will also allow us to post platform specific stats for chat.
2.) Vendor in changes to the RPC library to make writing RPC tags safe for multiple goroutines. 