### PR TITLE
Fix empty device name in ActiveDevice

### DIFF
--- a/go/engine/bootstrap_test.go
+++ b/go/engine/bootstrap_test.go
@@ -93,6 +93,9 @@ func TestBootstrapAfterSignup(t *testing.T) {
 	}
 	status := beng.Status()
 
+	uid := tc.G.Env.GetUID()
+	deviceID := tc.G.Env.GetDeviceID()
+
 	if !status.Registered {
 		t.Error("registered false")
 	}
@@ -102,22 +105,18 @@ func TestBootstrapAfterSignup(t *testing.T) {
 	if status.Uid.IsNil() {
 		t.Errorf("uid nil")
 	}
-	/*
-		if !status.Uid.Equal(u1.Uid) {
-			t.Errorf("uid: %s, expected %s", status.Uid, u1.uid)
-		}
-	*/
+	if !status.Uid.Equal(uid) {
+		t.Errorf("uid: %s, expected %s", status.Uid, uid)
+	}
 	if status.Username == "" {
 		t.Errorf("username empty")
 	}
 	if status.Username != u1.Username {
 		t.Errorf("username: %q, expected %q", status.Username, u1.Username)
 	}
-	/*
-		if !status.DeviceID.Eq(deviceID) {
-			t.Errorf("device id: %q, expected %q", status.DeviceID, deviceID)
-		}
-	*/
+	if !status.DeviceID.Eq(deviceID) {
+		t.Errorf("device id: %q, expected %q", status.DeviceID, deviceID)
+	}
 	if status.DeviceName != defaultDeviceName {
 		t.Errorf("device name: %q, expected %q", status.DeviceName, defaultDeviceName)
 	}

--- a/go/engine/bootstrap_test.go
+++ b/go/engine/bootstrap_test.go
@@ -80,6 +80,49 @@ func TestBootstrap(t *testing.T) {
 	}
 }
 
+func TestBootstrapAfterSignup(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	u1 := CreateAndSignupFakeUser(tc, "login")
+
+	beng := NewBootstrap(tc.G)
+	bctx := &Context{NetContext: context.Background()}
+	if err := RunEngine(beng, bctx); err != nil {
+		t.Fatal(err)
+	}
+	status := beng.Status()
+
+	if !status.Registered {
+		t.Error("registered false")
+	}
+	if !status.LoggedIn {
+		t.Error("not logged in")
+	}
+	if status.Uid.IsNil() {
+		t.Errorf("uid nil")
+	}
+	/*
+		if !status.Uid.Equal(u1.Uid) {
+			t.Errorf("uid: %s, expected %s", status.Uid, u1.uid)
+		}
+	*/
+	if status.Username == "" {
+		t.Errorf("username empty")
+	}
+	if status.Username != u1.Username {
+		t.Errorf("username: %q, expected %q", status.Username, u1.Username)
+	}
+	/*
+		if !status.DeviceID.Eq(deviceID) {
+			t.Errorf("device id: %q, expected %q", status.DeviceID, deviceID)
+		}
+	*/
+	if status.DeviceName != defaultDeviceName {
+		t.Errorf("device name: %q, expected %q", status.DeviceName, defaultDeviceName)
+	}
+}
+
 type OfflineConnectivityMonitor struct {
 }
 

--- a/go/engine/device_wrap.go
+++ b/go/engine/device_wrap.go
@@ -113,9 +113,11 @@ func (e *DeviceWrap) Run(ctx *Context) error {
 			e.G().Log.Warning("error saving session file: %s", err)
 		}
 
+		device := kgEng.device()
+
 		// cache the secret keys
-		ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType}, e.signingKey)
-		ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceEncryptionKeyType}, e.encryptionKey)
+		ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{Me: e.args.Me, KeyType: libkb.DeviceSigningKeyType}, e.signingKey, device)
+		ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{Me: e.args.Me, KeyType: libkb.DeviceEncryptionKeyType}, e.encryptionKey, device)
 	}
 
 	return nil

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -587,11 +587,11 @@ func (e *Kex2Provisionee) cacheKeys() (err error) {
 		return errors.New("cacheKeys called, but dh key is nil")
 	}
 
-	if err = e.ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType}, e.eddsa); err != nil {
+	if err = e.ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType}, e.eddsa, e.device); err != nil {
 		return err
 	}
 
-	if err = e.ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceEncryptionKeyType}, e.dh); err != nil {
+	if err = e.ctx.LoginContext.SetCachedSecretKey(libkb.SecretKeyArg{KeyType: libkb.DeviceEncryptionKeyType}, e.dh, e.device); err != nil {
 		return err
 	}
 

--- a/go/engine/login_offline.go
+++ b/go/engine/login_offline.go
@@ -166,23 +166,22 @@ func (e *LoginOffline) run(ctx *Context) error {
 			return
 		}
 
+		device := &libkb.Device{
+			ID:          deviceID,
+			Kid:         sibkey.KID,
+			Description: &sibkey.DeviceDescription,
+		}
+
 		// cache the unlocked secret keys
 		ska := libkb.SecretKeyArg{KeyType: libkb.DeviceSigningKeyType}
-		if err := a.SetCachedSecretKey(ska, unlockedSibkey); err != nil {
+		if err := a.SetCachedSecretKey(ska, unlockedSibkey, device); err != nil {
 			e.G().Log.Debug("LoginOffline: failed to cache sibkey: %s", err)
 			gerr = err
 			return
 		}
 		ska = libkb.SecretKeyArg{KeyType: libkb.DeviceEncryptionKeyType}
-		if err := a.SetCachedSecretKey(ska, unlockedSubkey); err != nil {
+		if err := a.SetCachedSecretKey(ska, unlockedSubkey, device); err != nil {
 			e.G().Log.Debug("LoginOffline: failed to cache subkey: %s", err)
-			gerr = err
-			return
-		}
-
-		// set the device name from the sibkey description
-		if err := a.SetDeviceName(sibkey.DeviceDescription); err != nil {
-			e.G().Log.Debug("LoginOffline: failed to set device name: %s", err)
 			gerr = err
 			return
 		}

--- a/go/engine/login_offline_test.go
+++ b/go/engine/login_offline_test.go
@@ -60,4 +60,8 @@ func TestLoginOffline(t *testing.T) {
 	if ekey == nil {
 		t.Errorf("encryption key is nil, expected it to exist")
 	}
+
+	if tc.G.ActiveDevice.Name() != defaultDeviceName {
+		t.Errorf("device name: %q, expected %q", tc.G.ActiveDevice.Name(), defaultDeviceName)
+	}
 }

--- a/go/libkb/keyring.go
+++ b/go/libkb/keyring.go
@@ -275,10 +275,10 @@ func (k *Keyrings) setCachedSecretKey(lctx LoginContext, ska SecretKeyArg, key G
 	k.G().Log.Debug("caching secret key for ska: %+v", ska)
 	var setErr error
 	if lctx != nil {
-		setErr = lctx.SetCachedSecretKey(ska, key)
+		setErr = lctx.SetCachedSecretKey(ska, key, nil)
 	} else {
 		aerr := k.G().LoginState().Account(func(a *Account) {
-			setErr = a.SetCachedSecretKey(ska, key)
+			setErr = a.SetCachedSecretKey(ska, key, nil)
 		}, "GetSecretKeyWithPrompt - SetCachedSecretKey")
 		if aerr != nil {
 			k.G().Log.Debug("Account error: %s", aerr)

--- a/go/libkb/login_state.go
+++ b/go/libkb/login_state.go
@@ -63,7 +63,7 @@ type LoginContext interface {
 	SecretSyncer() *SecretSyncer
 	RunSecretSyncer(uid keybase1.UID) error
 
-	SetCachedSecretKey(ska SecretKeyArg, key GenericKey) error
+	SetCachedSecretKey(ska SecretKeyArg, key GenericKey, device *Device) error
 	SetUnlockedPaperKey(sig GenericKey, enc GenericKey) error
 
 	SetLKSec(lksec *LKSec)


### PR DESCRIPTION
After signup (and perhaps through other paths) the device name wasn't found in the user's key family upon caching the device signing key.

In a lot of the paths, we already have the device ID and name (because they were just created).  This patch passes the libkb.Device to SetCachedDeviceKey so it can use that instead of ckf.  If there is no device object available, it will still try the ckf lookup.