### PR TITLE
Get user summaries outside LoginState

### DIFF
--- a/go/engine/bootstrap.go
+++ b/go/engine/bootstrap.go
@@ -70,27 +70,25 @@ func (e *Bootstrap) Run(ctx *Context) error {
 
 		e.status.DeviceID = a.GetDeviceID()
 		e.status.DeviceName = e.G().ActiveDevice.Name()
-
-		ts := libkb.NewTracker2Syncer(e.G(), e.status.Uid, true)
-		if e.G().ConnectivityMonitor.IsConnected(context.Background()) == libkb.ConnectivityMonitorYes {
-			e.G().Log.Debug("connected, running full tracker2 syncer")
-			if err := libkb.RunSyncer(ts, e.status.Uid, true, a.LocalSession()); err != nil {
-				gerr = err
-				return
-			}
-		} else {
-			e.G().Log.Debug("not connected, running cached tracker2 syncer")
-			if err := libkb.RunSyncerCached(ts, e.status.Uid); err != nil {
-				gerr = err
-				return
-			}
-		}
-		e.usums = ts.Result()
-
 	}, "Bootstrap")
 	if gerr != nil {
 		return gerr
 	}
+
+	// get user summaries
+	ts := libkb.NewTracker2Syncer(e.G(), e.status.Uid, true)
+	if e.G().ConnectivityMonitor.IsConnected(context.Background()) == libkb.ConnectivityMonitorYes {
+		e.G().Log.Debug("connected, running full tracker2 syncer")
+		if err := libkb.RunSyncer(ts, e.status.Uid, true, a.LocalSession()); err != nil {
+			return err
+		}
+	} else {
+		e.G().Log.Debug("not connected, running cached tracker2 syncer")
+		if err := libkb.RunSyncerCached(ts, e.status.Uid); err != nil {
+			return err
+		}
+	}
+	e.usums = ts.Result()
 
 	// filter usums into followers, following
 	for _, u := range e.usums.Users {

--- a/go/engine/bootstrap.go
+++ b/go/engine/bootstrap.go
@@ -79,7 +79,7 @@ func (e *Bootstrap) Run(ctx *Context) error {
 	ts := libkb.NewTracker2Syncer(e.G(), e.status.Uid, true)
 	if e.G().ConnectivityMonitor.IsConnected(context.Background()) == libkb.ConnectivityMonitorYes {
 		e.G().Log.Debug("connected, running full tracker2 syncer")
-		if err := libkb.RunSyncer(ts, e.status.Uid, true, a.LocalSession()); err != nil {
+		if err := libkb.RunSyncer(ts, e.status.Uid, false, nil); err != nil {
 			return err
 		}
 	} else {


### PR DESCRIPTION
When GetBootstrapStatus originally written, it only got cached user summaries and thus that step was fast and negligible time spent in the LoginState request.

But now that it can use the full tracker syncer when online, that can bog down the LoginState request queue, so this patch moves the user summary sync outside the LoginState request loop.

@maxtaco's log had many LoginState request time outs because of an active GetBootstrapStatus request.