### PR TITLE
Change fixHeaders to return err if session required and session unavailable

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -44,7 +44,7 @@ type ExternalAPIEngine struct {
 // allowing us to share the request-making code below in doRequest
 type Requester interface {
 	Contextifier
-	fixHeaders(arg APIArg, req *http.Request)
+	fixHeaders(arg APIArg, req *http.Request) error
 	getCli(needSession bool) *Client
 	consumeHeaders(resp *http.Response) error
 	isExternal() bool
@@ -206,14 +206,23 @@ func (c *countingReader) numRead() int {
 
 // The returned response, if non-nil, should have
 // DiscardAndCloseBody() called on it.
-func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes bool) (
-	_ *http.Response, jw *jsonw.Wrapper, err error) {
+func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes bool) (_ *http.Response, jw *jsonw.Wrapper, err error) {
 	if !api.G().Env.GetTorMode().UseSession() && arg.SessionType == APISessionTypeREQUIRED {
 		err = TorSessionRequiredError{}
 		return
 	}
 
-	api.fixHeaders(arg, req)
+	ctx := arg.NetContext
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx = WithLogTag(ctx, "API")
+	api.G().Log.CDebugf(ctx, "+ API %s %s", req.Method, req.URL)
+
+	if err = api.fixHeaders(arg, req); err != nil {
+		api.G().Log.CDebugf(ctx, "- API %s %s: fixHeaders error: %s", req.Method, req.URL, err)
+		return
+	}
 	needSession := false
 	if arg.SessionType != APISessionTypeNONE {
 		needSession = true
@@ -225,12 +234,6 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 	if api.isExternal() {
 		timerType = TimerXAPI
 	}
-	ctx := arg.NetContext
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	ctx = WithLogTag(ctx, "API")
-	api.G().Log.CDebugf(ctx, "+ API %s %s", req.Method, req.URL)
 
 	var jsonBytes int
 	var status string
@@ -519,23 +522,34 @@ func (a *InternalAPIEngine) consumeHeaders(resp *http.Response) (err error) {
 	return
 }
 
-func (a *InternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
+func (a *InternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) error {
 	if arg.SessionType != APISessionTypeNONE {
 		tok, csrf, err := a.sessionArgs(arg)
 		if err != nil {
-			a.G().Log.Warning("fixHeaders: need session, but error getting sessionArgs: %s", err)
+			if arg.SessionType == APISessionTypeREQUIRED {
+				a.G().Log.Warning("fixHeaders: session required, but error getting sessionArgs: %s", err)
+				return err
+			}
+			a.G().Log.Debug("fixHeaders: session optional, error getting sessionArgs: %s", err)
 		}
-		if len(tok) > 0 && a.G().Env.GetTorMode().UseSession() {
-			req.Header.Add("X-Keybase-Session", tok)
-		} else if arg.SessionType == APISessionTypeREQUIRED {
-			a.G().Log.Warning("fixHeaders: need session, but session token empty")
+		if a.G().Env.GetTorMode().UseSession() {
+			if len(tok) > 0 {
+				req.Header.Add("X-Keybase-Session", tok)
+			} else if arg.SessionType == APISessionTypeREQUIRED {
+				a.G().Log.Warning("fixHeaders: need session, but session token empty")
+				return InternalError{Msg: "API request requires session, but session token empty"}
+			}
 		}
-		if len(csrf) > 0 && a.G().Env.GetTorMode().UseCSRF() {
-			req.Header.Add("X-CSRF-Token", csrf)
-		} else if arg.SessionType == APISessionTypeREQUIRED {
-			a.G().Log.Warning("fixHeaders: need session, but session csrf empty")
+		if a.G().Env.GetTorMode().UseCSRF() {
+			if len(csrf) > 0 {
+				req.Header.Add("X-CSRF-Token", csrf)
+			} else if arg.SessionType == APISessionTypeREQUIRED {
+				a.G().Log.Warning("fixHeaders: need session, but session csrf empty")
+				return InternalError{Msg: "API request requires session, but session csrf empty"}
+			}
 		}
 	}
+
 	if a.G().Env.GetTorMode().UseHeaders() {
 		req.Header.Set("User-Agent", UserAgent)
 		identifyAs := GoClientID + " v" + VersionString() + " " + runtime.GOOS
@@ -550,6 +564,8 @@ func (a *InternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
 			req.Header.Set("X-Keybase-Log-Tags", tags)
 		}
 	}
+
+	return nil
 }
 
 func (a *InternalAPIEngine) checkAppStatusFromJSONWrapper(arg APIArg, jw *jsonw.Wrapper) (*AppStatus, error) {
@@ -752,7 +768,7 @@ const (
 	XAPIResText
 )
 
-func (api *ExternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
+func (api *ExternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) error {
 	// TODO (here and in the internal API engine implementation): If we don't
 	// set the User-Agent, it will default to http.defaultUserAgent
 	// ("Go-http-client/1.1"). We should think about whether that's what we
@@ -772,6 +788,8 @@ func (api *ExternalAPIEngine) fixHeaders(arg APIArg, req *http.Request) {
 	if api.G().Env.GetTorMode().UseHeaders() {
 		req.Header.Set("User-Agent", userAgent)
 	}
+
+	return nil
 }
 
 func isReddit(req *http.Request) bool {

--- a/go/libkb/session.go
+++ b/go/libkb/session.go
@@ -259,7 +259,7 @@ func (s *Session) check() error {
 
 	arg := NewRetryAPIArg("sesscheck")
 	arg.SessionR = s
-	arg.SessionType = APISessionTypeREQUIRED
+	arg.SessionType = APISessionTypeOPTIONAL
 	arg.AppStatusCodes = []int{SCOk, SCBadSession}
 
 	res, err := s.G().API.Get(arg)


### PR DESCRIPTION
Previously, if an API request required a session and the service was unable to get the session args, it would proceed and send the API request.  When the API request returned, it would have a bad session error, which would cause the service to invalidate the local session and send a logout notification.

This patch changes it so that if an API request requires a session and the service is unable to get the session args, then it will return an error instead of making the API request.

API requests that have an optional session requirement will proceed without the session.

(This showed up in CORE-5023 by a LoginState request timeout getting the session args [due to a bug in the Bootstrap engine that was doing too much in the LoginState request].  The api request proceeded without session parameters, then a session invalidation + logout notification sent when the api request returned.)
