### PR TITLE
handle not connected to kbfs better

### DIFF
--- a/shared/constants/config.js
+++ b/shared/constants/config.js
@@ -10,7 +10,8 @@ import type {NoErrorTypedAction} from './types/flux'
 const MAX_BOOTSTRAP_TRIES = 3
 const bootstrapAttemptFailed = 'config:bootstrapAttemptFailed'
 const bootstrapFailed = 'config:bootstrapFailed'
-const bootstrapLoaded = 'config:bootstrapLoaded'
+const bootstrapSuccess = 'config:bootstrapSuccess'
+const bootstrapStatusLoaded = 'config:bootstrapStatusLoaded'
 const bootstrapRetry = 'config:bootstrapRetry'
 const bootstrapRetryDelay = 10 * 1000
 const changeKBFSPath = 'config:changeKBFSPath'
@@ -29,7 +30,7 @@ const setLaunchedViaPush = 'config:setLaunchedViaPush'
 const statusLoaded = 'config:statusLoaded'
 const updateFollowing = 'config:updateFollowing'
 
-export type BootstrapLoaded = NoErrorTypedAction<'config:bootstrapLoaded', {bootstrapStatus: BootstrapStatus}>
+export type BootstrapStatusLoaded = NoErrorTypedAction<'config:bootstrapStatusLoaded', {bootstrapStatus: BootstrapStatus}>
 export type DaemonError = NoErrorTypedAction<'config:daemonError', {daemonError: ?Error}>
 export type UpdateFollowing = NoErrorTypedAction<'config:updateFollowing', {username: string, isTracking: boolean}>
 export type SetInitialTab = NoErrorTypedAction<'config:setInitialTab', {tab: ?Tab}>
@@ -51,7 +52,8 @@ export {
   MAX_BOOTSTRAP_TRIES,
   bootstrapAttemptFailed,
   bootstrapFailed,
-  bootstrapLoaded,
+  bootstrapSuccess,
+  bootstrapStatusLoaded,
   bootstrapRetry,
   bootstrapRetryDelay,
   changeKBFSPath,

--- a/shared/login/forms/dumb.js
+++ b/shared/login/forms/dumb.js
@@ -12,6 +12,7 @@ const props: Props = {
   onLogin: () => {},
   onRetry: () => {},
   onSignup: () => {},
+  retrying: false,
 }
 
 const intro: DumbComponentMap<Intro> = {

--- a/shared/login/forms/index.desktop.js
+++ b/shared/login/forms/index.desktop.js
@@ -5,11 +5,11 @@ import {globalColors, globalStyles, globalMargins} from '../../styles'
 
 import type {Props} from '.'
 
-const Splash = () => (
+const Splash = (props: Props) => (
   <Box style={stylesLoginForm}>
     <Icon type='icon-keybase-logo-128' />
     <Text style={stylesHeader} type='HeaderBig'>Keybase</Text>
-    <Text style={stylesHeaderSub} type='BodySmall'>Loading…</Text>
+    <Text style={stylesHeaderSub} type='BodySmall'>Loading…{props.retrying ? ' (still trying)' : ''}</Text>
   </Box>
 )
 

--- a/shared/login/forms/index.js.flow
+++ b/shared/login/forms/index.js.flow
@@ -9,6 +9,7 @@ export type Props = {
   justRevokedSelf: ?string,
   bootStatus: BootStatus,
   justDeletedSelf: ?string,
+  retrying: boolean,
 }
 
 export class Intro extends Component<void, Props, void> { }

--- a/shared/login/forms/intro.js
+++ b/shared/login/forms/intro.js
@@ -1,4 +1,5 @@
 // @flow
+import * as Constants from '../../constants/config'
 import {Splash, Intro, Failure} from '.'
 import {connect} from 'react-redux'
 import {loginTab} from '../../constants/tabs'
@@ -17,6 +18,7 @@ export default compose(
       justDeletedSelf: state.login.justDeletedSelf,
       justLoginFromRevokedDevice: state.login.justLoginFromRevokedDevice,
       justRevokedSelf: state.login.justRevokedSelf,
+      retrying: state.config.bootstrapTriesRemaining !== Constants.MAX_BOOTSTRAP_TRIES,
     }),
     (dispatch: Dispatch) => ({
       onLogin: () => {

--- a/shared/reducers/config.js
+++ b/shared/reducers/config.js
@@ -111,14 +111,20 @@ export default function (state: ConfigState = initialState, action: Action): Con
       }
     }
 
-    case Constants.bootstrapLoaded:
+    case Constants.bootstrapSuccess: {
+      return {
+        ...state,
+        bootStatus: 'bootStatusBootstrapped',
+      }
+    }
+
+    case Constants.bootstrapStatusLoaded:
       const {bootstrapStatus} = action.payload
       return {
         ...state,
         ...bootstrapStatus,
         following: arrayToObjectSet(bootstrapStatus.following),
         followers: arrayToObjectSet(bootstrapStatus.followers),
-        bootStatus: 'bootStatusBootstrapped',
       }
 
     case Constants.bootstrapAttemptFailed: {


### PR DESCRIPTION
@keybase/react-hackers this fixes issues @malgorithms was seeing w/ incorrect state being presented when you don't have a good connection to kbfs locally.

We set out bootstrapping state to loaded when we got the initial payload from the server, but we're still partway through the process. we still need to wait for kbfs to connect ,then we're really in.

I added comments to this file about us needing to saga-ize it. The majority of the code this thing has is cause we didn't have sagas. Doing that will clean this thing up a ton and reduce all the wackiness.

Until then, some more wackiness thrown on top

![appropriate image](https://68.media.tumblr.com/4f571a50094edc78378683399b0d478f/tumblr_onw0ddQYGR1vaqoiqo1_400.gif)
