### PR TITLE
remove green arrow on mobile

### DIFF
--- a/shared/chat/conversation/attachment-popup/index.native.js
+++ b/shared/chat/conversation/attachment-popup/index.native.js
@@ -1,7 +1,6 @@
 // @flow
 import React, {Component} from 'react'
 import {Box, Icon, Text, ProgressIndicator, NativeImage} from '../../../common-adapters/index.native'
-import {ImageIcon as AttachmentStatusIcon} from '../messages/attachment'
 import {globalColors, globalMargins, globalStyles} from '../../../styles'
 import {formatTimeForPopup} from '../../../util/timestamp'
 
@@ -21,22 +20,15 @@ class AutoMaxSizeImage extends Component<void, any, {width: number, height: numb
   }
 }
 
-const AttachmentView = ({isZoomed, onToggleZoom, messageState, path}: {isZoomed: boolean, onToggleZoom: () => void, path: ?string}) => (
+const AttachmentView = ({isZoomed, onToggleZoom, path}: {isZoomed: boolean, onToggleZoom: () => void, path: ?string}) => (
   <Box style={{...globalStyles.flexBoxCenter, flex: 1}}>
-    {!!path && <AutoMaxSizeImage source={{uri: `file://${path}`}} style={{flex: 1, width: '100%', height: '100%', resizeMode: 'contain'}} />}
+    {!!path && <AutoMaxSizeImage source={{uri: `file://${path}`}} style={{flex: 1, width: '100%', height: '100%', resizeMode: 'contain', position: 'relative'}} />}
     {!path && <ProgressIndicator style={{width: 48}} white={true} />}
   </Box>
 )
 
 const AttachmentPopup = ({message, isZoomed, onClose, onDownloadAttachment, onDeleteMessage, onMessageAction, onToggleZoom, onOpenInFileUI, you}: Props) => {
-  const {messageState, previewType, title, author, timestamp} = message
-  let statusIcon
-  if (messageState === 'downloading' || messageState === 'downloaded') {
-    statusIcon = <AttachmentStatusIcon
-      style={{position: 'absolute', bottom: -3, right: -3}}
-      type={messageState === 'downloading' ? 'Downloading' : 'Downloaded'}
-    />
-  }
+  const {previewType, title, author, timestamp} = message
 
   if (!previewType || previewType === 'Other') {
     return (
@@ -56,7 +48,6 @@ const AttachmentPopup = ({message, isZoomed, onClose, onDownloadAttachment, onDe
         <Box style={styleHeaderFooter}>
           <Icon type='iconfont-ellipsis' onClick={onMessageAction} />
         </Box>
-        {statusIcon}
       </Box>
     )
   }
@@ -72,7 +63,6 @@ const AttachmentPopup = ({message, isZoomed, onClose, onDownloadAttachment, onDe
       <Box style={styleHeaderFooter}>
         <Icon type='iconfont-ellipsis' style={{color: globalColors.white}} onClick={onMessageAction} />
       </Box>
-      {statusIcon}
     </Box>
   )
 }


### PR DESCRIPTION
The image sizing story is kinda gross so to actually make this work is more code than is worth it. discussing w/ coyne it doesn't really make sense to show if you've happened to download a thing to your camera roll on mobile so lets just ditch this thing

@keybase/react-hackers 