### PR TITLE
dont allow multiple popup pushes

### DIFF
--- a/shared/chat/conversation/messages/attachment/container.js
+++ b/shared/chat/conversation/messages/attachment/container.js
@@ -26,7 +26,9 @@ const getProps = createCachedSelector(
 const mapStateToProps = (state: TypedState, {messageKey}: OwnProps) => {
   return {
     ...getProps(state, messageKey),
-    routePath: getPath(state.routeTree.routeState, [chatTab]),
+    // We derive the route path instead of having it passed in. We have to ensure its the path of this chat view and not any children so
+    // lets just extract the root path. This makes sure the openInPopup doesn't try and push multiple attachment views if you click quickly
+    routePath: getPath(state.routeTree.routeState, [chatTab]).slice(0, 2),
   }
 }
 


### PR DESCRIPTION
Normally we get the route state from the routeTree own props but the connected messages don't do this. We could pass that down (and maybe thats cleaner) but the way it was was that it derived it itself from the store. Problem is, once you actually push the popup, the connected gets called again and its own idea of its routestate gets updated incorrectly so the message thinks its in /chattabs/selectedconversation/attachment. This makes the navigateup (which uses the new putActionIfOnPath) fail cause it thinks it hasn't naved.

tldr; when the message derives it's routeState, it only extracts /chattab/selectedconversation. Goodnews is that this is the only place in the code where we do this

@keybase/react-hackers 