### PR TITLE
Fix avatars missing in chat on Android

### DIFF
--- a/shared/chat/conversation/messages/wrapper/shared.js
+++ b/shared/chat/conversation/messages/wrapper/shared.js
@@ -133,7 +133,6 @@ const _leftMarkerStyle = {
 }
 
 const _userAvatarStyle = {
-  height: 1, // don't let avatar size push down the whole row
   width: 32,
   paddingTop: globalMargins.tiny,
 }


### PR DESCRIPTION
@keybase/react-hackers 

Looks like this `height` isn't necessary anymore, and was causing avatars to be invisible on Android (but not iOS).