### PR TITLE
enable and handle silent notifications on iOS for better performance CORE-5016

### DIFF
--- a/shared/actions/push/index.js
+++ b/shared/actions/push/index.js
@@ -37,12 +37,11 @@ function * pushNotificationSaga (notification: Constants.PushNotification): Saga
   console.warn('Push notification:', notification)
   const payload = notification.payload
   if (payload && payload.userInteraction) {
-    
     // If we have received a silent notification, then just sit around for a bit
-    // so that Go can sync from the server. 
+    // so that Go can sync from the server.
     if (payload.data && payload.data.silent) {
       console.info('Push notification: pausing on silent notification')
-      yield call(delay, 15 * 1000);
+      yield call(delay, 15 * 1000)
       console.info('Push notification: pause complete, returning')
       return
     }

--- a/shared/actions/push/index.js
+++ b/shared/actions/push/index.js
@@ -40,7 +40,7 @@ function * pushNotificationSaga (notification: Constants.PushNotification): Saga
     const convID = payload.data ? payload.data.convID : payload.convID
     if (payload.data && payload.data.silent) {
       console.info('Push notification: pausing on silent notification')
-      yield call(delay, 10 * 1000);
+      yield call(delay, 15 * 1000);
       console.info('Push notification: pause complete, returning')
       return
     }

--- a/shared/actions/push/index.js
+++ b/shared/actions/push/index.js
@@ -37,7 +37,10 @@ function * pushNotificationSaga (notification: Constants.PushNotification): Saga
   const payload = notification.payload
   if (payload && payload.userInteraction) {
     const convID = payload.data ? payload.data.convID : payload.convID
-
+    if (payload.data && payload.data.U) {
+      console.info('Skipping silent notification')
+      return
+    }
     if (!convID) {
       console.error('Push notification payload missing conversation ID')
       return

--- a/shared/actions/push/index.js
+++ b/shared/actions/push/index.js
@@ -4,6 +4,7 @@ import * as Creators from './creators'
 import {isMobile} from '../../constants/platform'
 import {apiserverDeleteRpcPromise, apiserverPostRpcPromise} from '../../constants/types/flow-types'
 import {call, put, take, select} from 'redux-saga/effects'
+import {delay} from 'redux-saga'
 import {chatTab} from '../../constants/tabs'
 import {navigateTo} from '../route-tree'
 import {safeTakeEvery, safeTakeLatest} from '../../util/saga'
@@ -37,8 +38,10 @@ function * pushNotificationSaga (notification: Constants.PushNotification): Saga
   const payload = notification.payload
   if (payload && payload.userInteraction) {
     const convID = payload.data ? payload.data.convID : payload.convID
-    if (payload.data && payload.data.U) {
-      console.info('Skipping silent notification')
+    if (payload.data && payload.data.silent) {
+      console.info('Push notification: pausing on silent notification')
+      yield call(delay, 10 * 1000);
+      console.info('Push notification: pause complete, returning')
       return
     }
     if (!convID) {

--- a/shared/actions/push/index.js
+++ b/shared/actions/push/index.js
@@ -37,13 +37,18 @@ function * pushNotificationSaga (notification: Constants.PushNotification): Saga
   console.warn('Push notification:', notification)
   const payload = notification.payload
   if (payload && payload.userInteraction) {
-    const convID = payload.data ? payload.data.convID : payload.convID
+    
+    // If we have received a silent notification, then just sit around for a bit
+    // so that Go can sync from the server. 
     if (payload.data && payload.data.silent) {
       console.info('Push notification: pausing on silent notification')
       yield call(delay, 15 * 1000);
       console.info('Push notification: pause complete, returning')
       return
     }
+
+    // Check for conversation ID so we know where to navigate to
+    const convID = payload.data ? payload.data.convID : payload.convID
     if (!convID) {
       console.error('Push notification payload missing conversation ID')
       return

--- a/shared/actions/push/index.js
+++ b/shared/actions/push/index.js
@@ -4,7 +4,6 @@ import * as Creators from './creators'
 import {isMobile} from '../../constants/platform'
 import {apiserverDeleteRpcPromise, apiserverPostRpcPromise} from '../../constants/types/flow-types'
 import {call, put, take, select} from 'redux-saga/effects'
-import {delay} from 'redux-saga'
 import {chatTab} from '../../constants/tabs'
 import {navigateTo} from '../route-tree'
 import {safeTakeEvery, safeTakeLatest} from '../../util/saga'
@@ -37,12 +36,10 @@ function * pushNotificationSaga (notification: Constants.PushNotification): Saga
   console.warn('Push notification:', notification)
   const payload = notification.payload
   if (payload && payload.userInteraction) {
-    // If we have received a silent notification, then just sit around for a bit
-    // so that Go can sync from the server.
+    // If we have received a silent notification, then just bail out of here, the service will
+    // wake up and do what it needs to do.
     if (payload.data && payload.data.silent) {
-      console.info('Push notification: pausing on silent notification')
-      yield call(delay, 15 * 1000)
-      console.info('Push notification: pause complete, returning')
+      console.info('Push notification: silent notification received')
       return
     }
 

--- a/shared/index.native.js
+++ b/shared/index.native.js
@@ -66,6 +66,8 @@ class Keybase extends Component {
       this.store.dispatch(changedFocus(true))
     } else if (nextAppState === 'inactive') {
       this.store.dispatch(changedFocus(false))
+    } else if (nextAppState === 'background') {
+      this.store.dispatch(changedFocus(false))
     }
   }
 

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -39,9 +39,9 @@ if (__DEV__ && true) {
   config.dumbChatOnly = false
   config.dumbSheetOnly = false
   config.enableActionLogging = false
-  config.enableStoreLogging = true
+  config.enableStoreLogging = false
   config.forwardLogs = true
-  config.immediateStateLogging = true
+  config.immediateStateLogging = false
   config.printOutstandingRPCs = true
   config.printRPC = true
   config.printRoutes = true

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -13,7 +13,7 @@ let config: {[key: string]: any} = {
   devStoreChangingFunctions: false,
   dumbChatOnly: false,
   dumbSheetOnly: false,
-  enableActionLogging: false,
+  enableActionLogging: true,
   enableStoreLogging: false,
   featureFlagsOverride: null,
   forceImmediateLogging: false,
@@ -33,15 +33,15 @@ let config: {[key: string]: any} = {
   showAllTrackers: false,
 }
 
-  config.isDevApplePushToken = true
 if (__DEV__ && true) {
+  config.isDevApplePushToken = true
   config.devStoreChangingFunctions = true
   config.dumbChatOnly = false
   config.dumbSheetOnly = false
   config.enableActionLogging = false
-  config.enableStoreLogging = false
+  config.enableStoreLogging = true
   config.forwardLogs = true
-  config.immediateStateLogging = false
+  config.immediateStateLogging = true
   config.printOutstandingRPCs = true
   config.printRPC = true
   config.printRoutes = true

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -33,8 +33,8 @@ let config: {[key: string]: any} = {
   showAllTrackers: false,
 }
 
-if (__DEV__ && true) {
   config.isDevApplePushToken = true
+if (__DEV__ && true) {
   config.devStoreChangingFunctions = true
   config.dumbChatOnly = false
   config.dumbSheetOnly = false

--- a/shared/local-debug.native.js
+++ b/shared/local-debug.native.js
@@ -13,7 +13,7 @@ let config: {[key: string]: any} = {
   devStoreChangingFunctions: false,
   dumbChatOnly: false,
   dumbSheetOnly: false,
-  enableActionLogging: true,
+  enableActionLogging: false,
   enableStoreLogging: false,
   featureFlagsOverride: null,
   forceImmediateLogging: false,

--- a/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
+++ b/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
@@ -714,6 +714,9 @@
 							com.apple.ApplicationGroups.iOS = {
 								enabled = 1;
 							};
+							com.apple.BackgroundModes = {
+								enabled = 1;
+							};
 							com.apple.DataProtection = {
 								enabled = 1;
 							};

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -45,7 +45,7 @@ const BOOL isDebug = NO;
   return success;
 }
 
-- (void) createLevelDBDir:(NSString*) path
+- (void) createBkgReadableDir:(NSString*) path
 {
   NSFileManager* fm = [NSFileManager defaultManager];
   // Setting NSFileProtectionCompleteUnlessOpen makes the directory accessible as long as the user has
@@ -72,8 +72,9 @@ const BOOL isDebug = NO;
   NSString * keybasePath = [@"~/Library/Application Support/Keybase" stringByExpandingTildeInPath];
   NSString * levelDBPath = [@"~/Library/Application Support/Keybase/keybase.leveldb" stringByExpandingTildeInPath];
   NSString * chatLevelDBPath = [@"~/Library/Application Support/Keybase/keybase.chat.leveldb" stringByExpandingTildeInPath];
-  NSString * serviceLogFile = skipLogFile ? @"" : [@"~/Library/Caches/Keybase/ios.log" stringByExpandingTildeInPath];
-  NSString * rnLogFile = [@"~/Library/Caches/Keybase/rn.log" stringByExpandingTildeInPath];
+  NSString * logPath = [@"~/Library/Caches/Keybase" stringByExpandingTildeInPath];
+  NSString * serviceLogFile = skipLogFile ? @"" : [logPath stringByAppendingString:@"/ios.log"];
+  NSString * rnLogFile = [logPath stringByAppendingString:@"/rn.log"];
   NSFileManager* fm = [NSFileManager defaultManager];
   
   // Make keybasePath if it doesn't exist
@@ -83,9 +84,10 @@ const BOOL isDebug = NO;
                             error:nil];
   [self addSkipBackupAttributeToItemAtPath:keybasePath];
   
-  // Create LevelDB directories with a slightly lower data protection mode so we can use them in the background
-  [self createLevelDBDir:chatLevelDBPath];
-  [self createLevelDBDir:levelDBPath];
+  // Create LevelDB and log directories with a slightly lower data protection mode so we can use them in the background
+  [self createBkgReadableDir:chatLevelDBPath];
+  [self createBkgReadableDir:levelDBPath];
+  [self createBkgReadableDir:logPath];
 
   NSError * err;
   self.engine = [[Engine alloc] initWithSettings:@{

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -48,6 +48,9 @@ UIBackgroundTaskIdentifier backgroundTask;
 - (void) createLevelDBDir:(NSString*) path
 {
   NSFileManager* fm = [NSFileManager defaultManager];
+  // Setting NSFileProtectionCompleteUnlessOpen makes the directory accessible as long as the user has
+  // opened it once unlocked. The files are still stored on the disk encrypted (note for the chat database, it
+  // means we are encrypting it twice), and are inaccessible otherwise.
   NSDictionary* noProt = [NSDictionary dictionaryWithObject:NSFileProtectionCompleteUnlessOpen forKey:NSFileProtectionKey];
   [fm createDirectoryAtPath:path withIntermediateDirectories:YES
                  attributes:noProt

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -50,7 +50,7 @@ const BOOL isDebug = NO;
 #endif
 
   BOOL securityAccessGroupOverride = isSimulator;
-  BOOL skipLogFile = false;
+  BOOL skipLogFile = true;
 
   NSString * home = NSHomeDirectory();
 
@@ -130,6 +130,12 @@ const BOOL isDebug = NO;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification
 {
   [RCTPushNotificationManager didReceiveRemoteNotification:notification];
+}
+// fetch notifications in the background and foreground
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+  [RCTPushNotificationManager didReceiveRemoteNotification:notification];
+  completionHandler(UIBackgroundFetchResultNewData);
+  NSLog(@"Silent Notification Body %@", notification);
 }
 // Required for the localNotification event.
 - (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -65,7 +65,7 @@ UIBackgroundTaskIdentifier backgroundTask;
 #endif
 
   BOOL securityAccessGroupOverride = isSimulator;
-  BOOL skipLogFile = true;
+  BOOL skipLogFile = false;
 
   NSString * home = NSHomeDirectory();
 

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -45,7 +45,7 @@ const BOOL isDebug = NO;
   return success;
 }
 
-- (void) createBkgReadableDir:(NSString*) path
+- (void) createBackgroundReadableDirectory:(NSString*) path
 {
   NSFileManager* fm = [NSFileManager defaultManager];
   // Setting NSFileProtectionCompleteUnlessOpen makes the directory accessible as long as the user has
@@ -85,9 +85,9 @@ const BOOL isDebug = NO;
   [self addSkipBackupAttributeToItemAtPath:keybasePath];
   
   // Create LevelDB and log directories with a slightly lower data protection mode so we can use them in the background
-  [self createBkgReadableDir:chatLevelDBPath];
-  [self createBkgReadableDir:levelDBPath];
-  [self createBkgReadableDir:logPath];
+  [self createBackgroundReadableDirectory:chatLevelDBPath];
+  [self createBackgroundReadableDirectory:levelDBPath];
+  [self createBackgroundReadableDirectory:logPath];
 
   NSError * err;
   self.engine = [[Engine alloc] initWithSettings:@{

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -16,6 +16,7 @@
 #import "RCTLinkingManager.h"
 
 @interface AppDelegate ()
+@property UIBackgroundTaskIdentifier backgroundTask;
 @end
 
 #if TARGET_OS_SIMULATOR
@@ -32,7 +33,6 @@ const BOOL isDebug = NO;
 
 @implementation AppDelegate
 
-UIBackgroundTaskIdentifier backgroundTask;
 
 - (BOOL)addSkipBackupAttributeToItemAtPath:(NSString *) filePathString
 {
@@ -152,14 +152,14 @@ UIBackgroundTaskIdentifier backgroundTask;
 {
   [RCTPushNotificationManager didReceiveRemoteNotification:notification];
 }
-// fetch notifications in the background and foreground
+// Require for handling silent notifications
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 
   // Mark a background task so we don't get insta killed by the OS
-  if (!backgroundTask || backgroundTask == UIBackgroundTaskInvalid) {
-    backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
-      [[UIApplication sharedApplication] endBackgroundTask:backgroundTask];
-      backgroundTask = UIBackgroundTaskInvalid;
+  if (!self.backgroundTask || self.backgroundTask == UIBackgroundTaskInvalid) {
+    self.backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
+      [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
+      self.backgroundTask = UIBackgroundTaskInvalid;
     }];
   }
   

--- a/shared/react-native/ios/Keybase/Info.plist
+++ b/shared/react-native/ios/Keybase/Info.plist
@@ -48,6 +48,10 @@
 		<string>SourceCodePro-Semi_bold.ttf</string>
 		<string>kb.ttf</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
Patch does the following:

1.) Enables "remote notifications" background mode on the iOS app, allowing it to be woken up by a silent push notification.
2.) ~~Adds code to handle them in JS, which just involves setting a timer for 15 seconds and hanging out. The purpose of this is to allow the Go code to re-sync all its data from the server (should take way less time than 15 seconds, and we technically get 30 from the OS).~~ Ignore these push notifications in the JS code.
3.) Create the LevelDB directories with a different data protection mode than the default for the application, `NSFileProtectionCompleteUnlessOpen`. This is required to allow us to update the chat caches after waking up in the background if the phone is locked. It basically means the app can read the contents of the directory if it has opened them while the phone was unlocked. The files are still stored encrypted on the disk (which for the chat DB means that data is encrypted twice). 

We send the silent push notifications whenever we will be generating a new message push. They get sent immediately, and will allow the app to bring in the relevant data before the user responds to the push notification. This reduces the amount of rendering and waiting that happens when you foreground the app after receiving a push, or from just sitting around and not having the app in the foreground.