### PR TITLE
Fix avatar border clipping on android

### DIFF
--- a/shared/common-adapters/avatar.render.native.js
+++ b/shared/common-adapters/avatar.render.native.js
@@ -85,6 +85,7 @@ const Border = ({borderColor, size}) => (
       position: 'absolute',
       right: borderOffset,
       top: borderOffset,
+      margin: borderSize / 2,
     }}
   />
 )


### PR DESCRIPTION
Before:

<img width="88" alt="screen shot 2017-04-28 at 2 54 38 pm" src="https://cloud.githubusercontent.com/assets/594035/25548932/c7def346-2c23-11e7-9207-fb6297876e17.png">


After:

<img width="81" alt="screen shot 2017-04-28 at 2 57 14 pm" src="https://cloud.githubusercontent.com/assets/594035/25548937/cb6d724e-2c23-11e7-9d8f-cecaa9d734d9.png">
