### PR TITLE
show loading while loading untrusted inbox

### DIFF
--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -28,6 +28,7 @@ const getRows = createImmutableEqualSelector(
 
 export default connect(
   (state: TypedState) => ({
+    isLoading: state.chat.get('inboxUntrustedState') === 'loading',
     rows: getRows(state),
   }),
   (dispatch: Dispatch) => ({

--- a/shared/chat/inbox/index.js.flow
+++ b/shared/chat/inbox/index.js.flow
@@ -24,6 +24,7 @@ export type RowProps = {
 }
 
 export type Props = {
+  isLoading: boolean,
   nowOverride?: number, // just for dumb rendering
   rows: List<ConversationIDKey>,
   onNewChat: () => void,

--- a/shared/chat/inbox/index.native.js
+++ b/shared/chat/inbox/index.native.js
@@ -1,7 +1,7 @@
 // @flow
 import React, {PureComponent} from 'react'
 import {Text, MultiAvatar, Icon, Usernames, Markdown, Box, ClickableBox, NativeListView, LoadingLine} from '../../common-adapters/index.native'
-import {globalStyles, globalColors, statusBarHeight} from '../../styles'
+import {globalStyles, globalColors, statusBarHeight, globalMargins} from '../../styles'
 import {RowConnector} from './row'
 import {debounce} from 'lodash'
 
@@ -151,6 +151,19 @@ const _Row = (props: RowProps) => {
 
 const Row = RowConnector(_Row)
 
+const NoChats = () => (
+  <Box style={{
+    ...globalStyles.flexBoxColumn,
+    ...globalStyles.fillAbsolute,
+    alignItems: 'center',
+    justifyContent: 'center',
+    top: 48,
+  }}>
+    <Icon type='icon-fancy-chat-72-x-52' style={{marginBottom: globalMargins.small}} />
+    <Text type='BodySmallSemibold' backgroundMode='Terminal' style={{color: globalColors.blue3_40}}>All conversations are end-to-end encrypted.</Text>
+  </Box>
+)
+
 class ConversationList extends PureComponent<void, Props, {dataSource: any}> {
   state = {dataSource: null}
 
@@ -202,6 +215,7 @@ class ConversationList extends PureComponent<void, Props, {dataSource: any}> {
           dataSource={this.state.dataSource}
           onChangeVisibleRows={this._onChangeVisibleRows}
           renderRow={this._itemRenderer} />
+        {!this.props.isLoading && !this.props.rows.count() && <NoChats />}
       </Box>
     )
   }

--- a/shared/common-adapters/loading-line.native.js
+++ b/shared/common-adapters/loading-line.native.js
@@ -19,7 +19,7 @@ class LoadingLine extends Component<void, Props, {fadeAnim: any}> {
   componentDidMount () { this._animate() }
   render () {
     return (
-      <Box style={{position: 'relative'}}>
+      <Box style={{position: 'relative', height: 1}}>
         <NativeAnimated.View style={{opacity: this.state.fadeAnim}}>
           <Box style={{...globalStyles.fillAbsolute, backgroundColor: globalColors.blue, height: 1, ...this.props.style}} />
         </NativeAnimated.View>


### PR DESCRIPTION
Spoke to Coyne about this. Primary goal is for people with empty inboxes showing some kind of loading state. Using untrusted for now as the async / background unboxing of various rows could create some confusing loading states

@keybase/react-hackers 