### PR TITLE
Better login check in bootstrap, don't return error if syncer fails

### DIFF
--- a/go/engine/bootstrap.go
+++ b/go/engine/bootstrap.go
@@ -85,12 +85,14 @@ func (e *Bootstrap) Run(ctx *Context) error {
 	if e.G().ConnectivityMonitor.IsConnected(context.Background()) == libkb.ConnectivityMonitorYes {
 		e.G().Log.Debug("connected, running full tracker2 syncer")
 		if err := libkb.RunSyncer(ts, e.status.Uid, false, nil); err != nil {
-			return err
+			e.G().Log.Warning("error running Tracker2Syncer: %s", err)
+			return nil
 		}
 	} else {
 		e.G().Log.Debug("not connected, running cached tracker2 syncer")
 		if err := libkb.RunSyncerCached(ts, e.status.Uid); err != nil {
-			return err
+			e.G().Log.Warning("error running Tracker2Syncer (cached): %s", err)
+			return nil
 		}
 	}
 	e.usums = ts.Result()

--- a/go/engine/bootstrap.go
+++ b/go/engine/bootstrap.go
@@ -50,14 +50,17 @@ func (e *Bootstrap) Run(ctx *Context) error {
 
 	var gerr error
 	e.G().LoginState().Account(func(a *libkb.Account) {
-		var in bool
-		in, gerr = a.LoggedInProvisioned()
+		var sessionOk bool
+		sessionOk, gerr = a.LoggedInProvisioned()
 		if gerr != nil {
 			e.G().Log.Debug("Bootstrap: LoggedInProvisioned error: %s", gerr)
 			return
 		}
 
-		e.status.LoggedIn = in
+		// if any Login engine  worked, then ActiveDevice will be valid:
+		validActiveDevice := e.G().ActiveDevice.Valid()
+
+		e.status.LoggedIn = sessionOk && validActiveDevice
 		if !e.status.LoggedIn {
 			e.G().Log.Debug("Bootstrap: not logged in")
 			return

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -2635,6 +2635,103 @@ func TestProvisionEnsurePaperKey(t *testing.T) {
 	hasOnePaperDev(tcX, userX)
 }
 
+// Test bootstrap, login offline after service restart when provisioned via
+// GPG sign.
+func TestBootstrapAfterGPGSign(t *testing.T) {
+	// use tcCheck just to check gpg version
+	tcCheck := SetupEngineTest(t, "check")
+	defer tcCheck.Cleanup()
+	skipOldGPG(tcCheck)
+
+	// this test sometimes fails at the GPG level with a "Bad signature" error,
+	// so we're going to retry it several times to hopefully get past it.
+	attempts := 10
+	for i := 0; i < attempts; i++ {
+		tc := SetupEngineTest(t, "login")
+		defer tc.Cleanup()
+
+		u1 := createFakeUserWithPGPPubOnly(t, tc)
+		Logout(tc)
+
+		// redo SetupEngineTest to get a new home directory...should look like a new device.
+		tc2 := SetupEngineTest(t, "login")
+		defer tc2.Cleanup()
+
+		// we need the gpg keyring that's in the first homedir
+		if err := tc.MoveGpgKeyringTo(tc2); err != nil {
+			t.Fatal(err)
+		}
+
+		// now safe to cleanup first home
+		tc.Cleanup()
+
+		// run login on new device
+		ctx := &Context{
+			ProvisionUI: newTestProvisionUIGPGSign(),
+			LogUI:       tc2.G.UI.GetLogUI(),
+			SecretUI:    u1.NewSecretUI(),
+			LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
+			GPGUI:       &gpgtestui{},
+		}
+		eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
+		if err := RunEngine(eng, ctx); err != nil {
+			t.Logf("test run %d:  RunEngine(Login) error: %s", i+1, err)
+			continue
+		}
+
+		t.Logf("test run %d: RunEngine(Login) succeeded", i+1)
+
+		testUserHasDeviceKey(tc2)
+
+		// highly possible they didn't have a paper key, so make sure they have one now:
+		hasOnePaperDev(tc2, u1)
+
+		if err := AssertProvisioned(tc2); err != nil {
+			t.Fatal(err)
+		}
+
+		// Simulate restarting the service by wiping out the
+		// passphrase stream cache and cached secret keys
+		tc2.G.LoginState().Account(func(a *libkb.Account) {
+			a.ClearStreamCache()
+			a.ClearCachedSecretKeys()
+			a.UnloadLocalSession()
+		}, "account - clear")
+		tc2.G.GetUPAKLoader().ClearMemory()
+
+		// LoginOffline will run when service restarts.
+		// Since this was GPG sign, there will be no secret stored.
+		oeng := NewLoginOffline(tc2.G)
+		octx := &Context{NetContext: context.Background()}
+		oerr := RunEngine(oeng, octx)
+		if oerr == nil {
+			t.Fatalf("LoginOffline worked after gpg sign + svc restart")
+		}
+		if oerr != libkb.ErrUnlockNotPossible {
+			t.Fatalf("LoginOffline error: %s, expected libkb.ErrUnlockNotPossible", oerr)
+		}
+
+		// GetBootstrapStatus should return without error and with LoggedIn set to false.
+		beng := NewBootstrap(tc2.G)
+		bctx := &Context{NetContext: context.Background()}
+		if err := RunEngine(beng, bctx); err != nil {
+			t.Fatal(err)
+		}
+		status := beng.Status()
+		if status.LoggedIn != false {
+			t.Error("bootstrap status -> logged in, expected logged out")
+		}
+		if !status.Registered {
+			t.Error("registered false")
+		}
+
+		t.Logf("test run %d: all checks passed, returning", i+1)
+		return
+	}
+
+	t.Fatalf("TestProvisionGPGSign failed %d times", attempts)
+}
+
 type testProvisionUI struct {
 	secretCh               chan kex2.Secret
 	method                 keybase1.ProvisionMethod

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -91,6 +91,12 @@ func (a *ActiveDevice) internalUpdateUIDDeviceID(acct *Account, uid keybase1.UID
 		return errors.New("ActiveDevice.set funcs must be called from inside a LoginState account request")
 	}
 	if a.uid.IsNil() && a.deviceID.IsNil() {
+		/*
+			if uid.IsNil() {
+				panic("uid is nil")
+				// XXX return error
+			}
+		*/
 		a.uid = uid
 		a.deviceID = deviceID
 

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -90,20 +90,21 @@ func (a *ActiveDevice) internalUpdateUIDDeviceID(acct *Account, uid keybase1.UID
 	if acct == nil {
 		return errors.New("ActiveDevice.set funcs must be called from inside a LoginState account request")
 	}
+	if uid.IsNil() {
+		return errors.New("ActiveDevice.set with nil uid")
+	}
+	if deviceID.IsNil() {
+		return errors.New("ActiveDevice.set with nil deviceID")
+	}
+
 	if a.uid.IsNil() && a.deviceID.IsNil() {
-		/*
-			if uid.IsNil() {
-				panic("uid is nil")
-				// XXX return error
-			}
-		*/
 		a.uid = uid
 		a.deviceID = deviceID
 
 	} else if a.uid.NotEqual(uid) {
-		return errors.New("ActiveDevice.setEncryptionKey uid mismatch")
+		return errors.New("ActiveDevice.set uid mismatch")
 	} else if !a.deviceID.Eq(deviceID) {
-		return errors.New("ActiveDevice.setEncryptionKey deviceID mismatch")
+		return errors.New("ActiveDevice.set deviceID mismatch")
 	}
 
 	return nil
@@ -200,4 +201,11 @@ func (a *ActiveDevice) HaveKeys() bool {
 	defer a.RUnlock()
 
 	return a.signingKey != nil && a.encryptionKey != nil
+}
+
+func (a *ActiveDevice) Valid() bool {
+	a.RLock()
+	defer a.RUnlock()
+
+	return a.signingKey != nil && a.encryptionKey != nil && !a.uid.IsNil() && !a.deviceID.IsNil() && a.deviceName != ""
 }


### PR DESCRIPTION
Haven't figured out how UID could be empty yet (none of our tests get into that state).

This patch will allow the bootstrap engine to return without an error if the syncer fails to run.

Still looking into the empty uid issue, but this patch should get the users who are hitting this into the app.

I'm also fine holding off until the real bug is fixed, but thought I would put this out there if you want to merge this first.

cc @malgorithms 