### PR TITLE
show login screen so errors show

### DIFF
--- a/shared/actions/login/saga.js
+++ b/shared/actions/login/saga.js
@@ -88,13 +88,14 @@ function * setCodePageOtherDeviceRole (otherDeviceRole: DeviceRole) {
 }
 
 function * navBasedOnLoginState () {
-  const selector = ({config: {loggedIn, registered, initialTab, initialLink, launchedViaPush}, login: {justDeletedSelf}}: TypedState) => ({
+  const selector = ({config: {loggedIn, registered, initialTab, initialLink, launchedViaPush}, login: {justDeletedSelf, loginError}}: TypedState) => ({
     loggedIn,
     registered,
     initialTab,
     initialLink,
     justDeletedSelf,
     launchedViaPush,
+    loginError,
   })
 
   const {
@@ -104,6 +105,7 @@ function * navBasedOnLoginState () {
     initialLink,
     justDeletedSelf,
     launchedViaPush,
+    loginError,
   } = yield select(selector)
 
   if (justDeletedSelf) {
@@ -126,6 +128,8 @@ function * navBasedOnLoginState () {
     }
   } else if (registered) { // relogging in
     yield [put.resolve(getExtendedStatus()), put.resolve(getAccounts())]
+    yield put(navigateTo(['login'], [loginTab]))
+  } else if (loginError) { // show error on login screen
     yield put(navigateTo(['login'], [loginTab]))
   } else { // no idea
     yield put(navigateTo([loginTab]))


### PR DESCRIPTION
I tried to login w/ user+pass on an account w/ device keys but no online pgp key. This should error out but what happens is you get sent to Intro and no error before this PR. Now it shows the login screen which already plumbs through the loginError

@keybase/react-hackers 