### PR TITLE
remove sending deviceid and uid

### DIFF
--- a/shared/actions/chat/shared.js
+++ b/shared/actions/chat/shared.js
@@ -76,22 +76,14 @@ function * clientHeader (messageType: ChatTypes.MessageType, conversationIDKey: 
     return
   }
 
-  const configSelector = ({config: {deviceID, uid}}: TypedState) => ({deviceID, uid})
-  const {deviceID, uid}: {deviceID: string, uid: string} = ((yield select(configSelector)): any)
-
-  if (!deviceID || !uid) {
-    console.warn('No deviceid/uid to postmessage!')
-    return
-  }
-
   return {
     conv: info.triple,
     tlfName: info.tlfName,
     tlfPublic: info.visibility === ChatTypes.CommonTLFVisibility.public,
     messageType,
     supersedes: 0,
-    sender: Buffer.from(uid, 'hex'),
-    senderDevice: Buffer.from(deviceID, 'hex'),
+    sender: null,
+    senderDevice: null,
   }
 }
 


### PR DESCRIPTION
Likely the cause of the no tlf name specified errors. if we didn't have the uid or device id (not clear how that happens but lets not figure that out right now) we'd bail out and not send messages. there's no real point in sending this and mike verified we don't actually need to.

@keybase/react-hackers 