### PR TITLE
Store secret after makeEldestDevice

### DIFF
--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -933,7 +933,8 @@ func (e *loginProvision) makeEldestDevice(ctx *Context) error {
 			return
 		}
 
-		// store the secret
+		// Store the secret.
+		// It is not stored in login_state.go/passphraseLogin because there is no device id at that time.
 		pps := a.PassphraseStreamCache().PassphraseStream()
 		if pps == nil {
 			err = errors.New("nil passphrase stream")

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -929,6 +929,18 @@ func (e *loginProvision) makeEldestDevice(ctx *Context) error {
 
 		// save provisioned device id in the session
 		err = a.LocalSession().SetDeviceProvisioned(e.G().Env.GetDeviceIDForUsername(e.arg.User.GetNormalizedName()))
+		if err != nil {
+			return
+		}
+
+		// store the secret
+		pps := a.PassphraseStreamCache().PassphraseStream()
+		if pps == nil {
+			err = errors.New("nil passphrase stream")
+			return
+		}
+		lks := libkb.NewLKSec(pps, e.arg.User.GetUID(), e.G())
+		err = saveToSecretStore(e.G(), a, e.arg.User.GetNormalizedName(), lks)
 	}, "makeEldestDevice")
 	if err != nil {
 		return err

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -440,6 +440,15 @@ func testProvisionPassphraseNoKeysSolo(t *testing.T, enableSharedDH bool) {
 	if err := AssertProvisioned(tc); err != nil {
 		t.Fatal(err)
 	}
+
+	// secret should be stored
+	secret, err := tc.G.SecretStoreAll.RetrieveSecret(libkb.NewNormalizedUsername(username))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secret.IsNil() {
+		t.Fatal("secret in secret store was nil")
+	}
 }
 
 // Test bad name input (not valid username or email address).


### PR DESCRIPTION
This patch stores the secret after the eldest device is created.  

Secret isn't stored in login_state/passphraseLogin because no device id at the time.