### PR TITLE
Unconditionally polyfill String#startsWith(), broken on Android

### DIFF
--- a/shared/globals.native.js
+++ b/shared/globals.native.js
@@ -1,5 +1,5 @@
 // @flow
-/* eslint-disable no-native-reassign, no-global-assign */
+/* eslint-disable no-native-reassign, no-global-assign, no-extend-native */
 
 // __DEV__
 //  set by react-native to true if the app is being run in a simulator, false otherwise
@@ -16,3 +16,10 @@ if (typeof __SCREENSHOT__ === 'undefined') {
 
 // Needed for purepack
 window.Buffer = require('buffer').Buffer
+
+// Native String.startswith() sometimes incorrectly returns false on Android!
+// $FlowIssue redefining startsWith
+String.prototype.startsWith = function (searchString, position) {
+  position = position || 0
+  return this.substr(position, searchString.length) === searchString
+}

--- a/shared/index.native.js
+++ b/shared/index.native.js
@@ -89,6 +89,13 @@ class Keybase extends Component {
 }
 
 function load () {
+  // Native String.startswith() sometimes incorrectly returns false on Android!
+  // $FlowIssue redefining startsWith
+  String.prototype.startsWith = function (searchString, position) { // eslint-disable-line no-extend-native
+    position = position || 0
+    return this.substr(position, searchString.length) === searchString
+  }
+
   AppRegistry.registerComponent('Keybase', () => Keybase)
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

This was fun! We were redboxing on creating a new Chat sometimes on Android, and it ultimately came down to `conversationIDKey.startsWith('__pendingConversation__')` returning false when it ought to return true (because the string really did start with that).

So let's polyfill.  @chrisnojima, is this the best place to do a polyfill?  Want it to happen pretty early.