### PR TITLE
Don't consider edits when choosing a snippet

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -309,7 +309,6 @@ function _conversationLocalToInboxState (c: ?ChatTypes.ConversationLocal): ?Cons
     .map((m: any) => ({body: m.valid.messageBody, time: m.valid.serverHeader.ctime}))
     .filter(m => [
       ChatTypes.CommonMessageType.attachment,
-      ChatTypes.CommonMessageType.edit,
       ChatTypes.CommonMessageType.text,
     ].includes(m.body.messageType))
     .sort((a, b) => b.time - a.time)

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -521,8 +521,6 @@ function makeSnippet (messageBody: ?MessageBody): ?string {
       return textSnippet(messageBody.text && messageBody.text.body, 100)
     case ChatTypes.CommonMessageType.attachment:
       return messageBody.attachment ? textSnippet(messageBody.attachment.object.title, 100) : 'Attachment'
-    case ChatTypes.CommonMessageType.edit:
-      return textSnippet(messageBody.edit && messageBody.edit.body, 100)
     default:
       return null
   }


### PR DESCRIPTION
@keybase/react-hackers 

I didn't realize that the service will apply edits to the text messages in maxMessages itself, so when we're choosing a snippet we can totally ignore 'edit' type messages.

This has the advantage that if someone edits a message that isn't the latest one, we'll no longer make that old-but-edited message the conversation's snippet.