### PR TITLE
Fix unread messages display for convos

### DIFF
--- a/shared/chat/inbox/row.js
+++ b/shared/chat/inbox/row.js
@@ -74,7 +74,7 @@ const makeSelector = (conversationIDKey) => {
         rekeyInfo,
         snippet: conversation.get('snippet'),
         timestamp: formatTimeForConversationList(conversation.get('time'), nowOverride),
-        unreadCount,
+        unreadCount: unreadCount || 0,
         ..._rowDerivedProps(rekeyInfo, finalizeInfo, unreadCount, isSelected),
       })
     )


### PR DESCRIPTION
@keybase/react-hackers 

Looks like at some point the service started only telling us about the unread status of a convo when it has unread messages, whereas before it also returned 0 for all the convos that don't, with the upshot that we're get an "undefined unread" tooltip fixed by this PR:

![image](https://cloud.githubusercontent.com/assets/21217/25592795/1cf9c82c-2e88-11e7-93ea-bd291ef36c21.png)
