### PR TITLE
Fix LoginOffline to not use network if user not in cache

### DIFF
--- a/go/engine/bootstrap.go
+++ b/go/engine/bootstrap.go
@@ -86,6 +86,12 @@ func (e *Bootstrap) Run(ctx *Context) error {
 	// get user summaries
 	ts := libkb.NewTracker2Syncer(e.G(), e.status.Uid, true)
 	if e.G().ConnectivityMonitor.IsConnected(context.Background()) == libkb.ConnectivityMonitorYes {
+		e.G().Log.Debug("connected, loading self user upak for cache")
+		arg := libkb.NewLoadUserByUIDArg(context.Background(), e.G(), e.status.Uid)
+		if _, _, err := e.G().GetUPAKLoader().Load(arg); err != nil {
+			e.G().Log.Debug("Bootstrap: error loading upak user for cache priming: %s", err)
+		}
+
 		e.G().Log.Debug("connected, running full tracker2 syncer")
 		if err := libkb.RunSyncer(ts, e.status.Uid, false, nil); err != nil {
 			e.G().Log.Warning("error running Tracker2Syncer: %s", err)

--- a/go/engine/login_offline.go
+++ b/go/engine/login_offline.go
@@ -82,15 +82,17 @@ func (e *LoginOffline) run(ctx *Context) error {
 		uid = e.G().Env.GetUID()
 		deviceID = e.G().Env.GetDeviceIDForUID(uid)
 
-		// use the UPAKLoader with StaleOK in order to get cached upak
+		// use the UPAKLoader with StaleOK, CachedOnly in order to get cached upak
 		arg := libkb.NewLoadUserByUIDArg(ctx.NetContext, e.G(), uid)
 		arg.PublicKeyOptional = true
 		arg.StaleOK = true
+		arg.CachedOnly = true
 		arg.LoginContext = a
 		upak, _, err := e.G().GetUPAKLoader().Load(arg)
 		if err != nil {
 			e.G().Log.Debug("LoginOffline: upak.Load err: %s", err)
-			gerr = err
+			// if user load fails, login required
+			gerr = libkb.LoginRequiredError{}
 			return
 		}
 

--- a/go/engine/login_offline_test.go
+++ b/go/engine/login_offline_test.go
@@ -3,10 +3,12 @@ package engine
 import (
 	"os"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/clockwork"
 )
 
 func TestLoginOffline(t *testing.T) {
@@ -29,6 +31,128 @@ func TestLoginOffline(t *testing.T) {
 		a.UnloadLocalSession()
 	}, "account - clear")
 	tc.G.GetUPAKLoader().ClearMemory()
+
+	// set server uri to nonexistent ip so api calls will fail
+	prev := os.Getenv("KEYBASE_SERVER_URI")
+	os.Setenv("KEYBASE_SERVER_URI", "http://127.0.0.127:3333")
+	defer os.Setenv("KEYBASE_SERVER_URI", prev)
+	tc.G.ConfigureAPI()
+
+	eng := NewLoginOffline(tc.G)
+	ctx := &Context{NetContext: context.Background()}
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+	uid, deviceID, skey, ekey := tc.G.ActiveDevice.AllFields()
+	if uid.IsNil() {
+		t.Errorf("uid is nil, expected it to exist")
+	}
+	if !uid.Equal(u1.UID()) {
+		t.Errorf("uid: %q, expected %q", uid, u1.UID())
+	}
+
+	if deviceID.IsNil() {
+		t.Errorf("deviceID is nil, expected it to exist")
+	}
+
+	if skey == nil {
+		t.Errorf("signing key is nil, expected it to exist")
+	}
+
+	if ekey == nil {
+		t.Errorf("encryption key is nil, expected it to exist")
+	}
+
+	if tc.G.ActiveDevice.Name() != defaultDeviceName {
+		t.Errorf("device name: %q, expected %q", tc.G.ActiveDevice.Name(), defaultDeviceName)
+	}
+}
+
+// Use fake clock to test login offline after significant delay
+// (make sure upak loader won't use network)
+func TestLoginOfflineDelay(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
+	tc.G.SetClock(fakeClock)
+
+	u1 := CreateAndSignupFakeUser(tc, "login")
+	Logout(tc)
+	u1.LoginOrBust(tc)
+
+	// do a upak load to make sure it is cached
+	arg := libkb.NewLoadUserByUIDArg(context.TODO(), tc.G, u1.UID())
+	tc.G.GetUPAKLoader().Load(arg)
+
+	// Simulate restarting the service by wiping out the
+	// passphrase stream cache and cached secret keys
+	tc.G.LoginState().Account(func(a *libkb.Account) {
+		a.ClearStreamCache()
+		a.ClearCachedSecretKeys()
+		a.UnloadLocalSession()
+	}, "account - clear")
+	tc.G.GetUPAKLoader().ClearMemory()
+
+	// set server uri to nonexistent ip so api calls will fail
+	prev := os.Getenv("KEYBASE_SERVER_URI")
+	os.Setenv("KEYBASE_SERVER_URI", "http://127.0.0.127:3333")
+	defer os.Setenv("KEYBASE_SERVER_URI", prev)
+	tc.G.ConfigureAPI()
+
+	// advance the clock past the cache timeout
+	fakeClock.Advance(libkb.CachedUserTimeout * 10)
+
+	eng := NewLoginOffline(tc.G)
+	ctx := &Context{NetContext: context.Background()}
+	if err := RunEngine(eng, ctx); err != nil {
+		t.Fatal(err)
+	}
+	uid, deviceID, skey, ekey := tc.G.ActiveDevice.AllFields()
+	if uid.IsNil() {
+		t.Errorf("uid is nil, expected it to exist")
+	}
+	if !uid.Equal(u1.UID()) {
+		t.Errorf("uid: %q, expected %q", uid, u1.UID())
+	}
+
+	if deviceID.IsNil() {
+		t.Errorf("deviceID is nil, expected it to exist")
+	}
+
+	if skey == nil {
+		t.Errorf("signing key is nil, expected it to exist")
+	}
+
+	if ekey == nil {
+		t.Errorf("encryption key is nil, expected it to exist")
+	}
+
+	if tc.G.ActiveDevice.Name() != defaultDeviceName {
+		t.Errorf("device name: %q, expected %q", tc.G.ActiveDevice.Name(), defaultDeviceName)
+	}
+}
+
+// Login offline with nothing in upak cache for self user.
+func TestLoginOfflineNoUpak(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	u1 := CreateAndSignupFakeUser(tc, "login")
+	Logout(tc)
+	u1.LoginOrBust(tc)
+
+	// Simulate restarting the service by wiping out the
+	// passphrase stream cache and cached secret keys
+	tc.G.LoginState().Account(func(a *libkb.Account) {
+		a.ClearStreamCache()
+		a.ClearCachedSecretKeys()
+		a.UnloadLocalSession()
+	}, "account - clear")
+	tc.G.GetUPAKLoader().ClearMemory()
+
+	// invalidate the cache for uid
+	tc.G.GetUPAKLoader().Invalidate(context.Background(), u1.UID())
 
 	// set server uri to nonexistent ip so api calls will fail
 	prev := os.Getenv("KEYBASE_SERVER_URI")

--- a/go/engine/login_offline_test.go
+++ b/go/engine/login_offline_test.go
@@ -162,30 +162,11 @@ func TestLoginOfflineNoUpak(t *testing.T) {
 
 	eng := NewLoginOffline(tc.G)
 	ctx := &Context{NetContext: context.Background()}
-	if err := RunEngine(eng, ctx); err != nil {
-		t.Fatal(err)
+	err := RunEngine(eng, ctx)
+	if err == nil {
+		t.Fatal("LoginOffline worked after upak cache invalidation")
 	}
-	uid, deviceID, skey, ekey := tc.G.ActiveDevice.AllFields()
-	if uid.IsNil() {
-		t.Errorf("uid is nil, expected it to exist")
-	}
-	if !uid.Equal(u1.UID()) {
-		t.Errorf("uid: %q, expected %q", uid, u1.UID())
-	}
-
-	if deviceID.IsNil() {
-		t.Errorf("deviceID is nil, expected it to exist")
-	}
-
-	if skey == nil {
-		t.Errorf("signing key is nil, expected it to exist")
-	}
-
-	if ekey == nil {
-		t.Errorf("encryption key is nil, expected it to exist")
-	}
-
-	if tc.G.ActiveDevice.Name() != defaultDeviceName {
-		t.Errorf("device name: %q, expected %q", tc.G.ActiveDevice.Name(), defaultDeviceName)
+	if _, ok := err.(libkb.LoginRequiredError); !ok {
+		t.Fatalf("LoginOffline error: %s (%T) expected libkb.LoginRequiredError", err, err)
 	}
 }

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -2725,6 +2725,10 @@ func TestBootstrapAfterGPGSign(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// do a upak load to make sure it is cached
+		arg := libkb.NewLoadUserByUIDArg(context.TODO(), tc2.G, u1.UID())
+		tc2.G.GetUPAKLoader().Load(arg)
+
 		// Simulate restarting the service by wiping out the
 		// passphrase stream cache and cached secret keys
 		tc2.G.LoginState().Account(func(a *libkb.Account) {

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -23,6 +23,7 @@ type LoadUserArg struct {
 	ForceReload              bool
 	ForcePoll                bool // for cached user load, force a repoll
 	StaleOK                  bool // if stale cached versions are OK (for immutable fields)
+	CachedOnly               bool // only return cached data (StaleOK should be true as well)
 	AllKeys                  bool
 	LoginContext             LoginContext
 	AbortIfSigchainUnchanged bool
@@ -39,9 +40,9 @@ type LoadUserArg struct {
 }
 
 func (arg LoadUserArg) String() string {
-	return fmt.Sprintf("{UID:%s Name:%q PublicKeyOptional:%v NoCacheResult:%v Self:%v ForceReload:%v ForcePoll:%v StaleOK:%v AllKeys:%v AbortIfSigchainUnchanged:%v}",
+	return fmt.Sprintf("{UID:%s Name:%q PublicKeyOptional:%v NoCacheResult:%v Self:%v ForceReload:%v ForcePoll:%v StaleOK:%v AllKeys:%v AbortIfSigchainUnchanged:%v CachedOnly:%v}",
 		arg.UID, arg.Name, arg.PublicKeyOptional, arg.NoCacheResult, arg.Self, arg.ForceReload,
-		arg.ForcePoll, arg.StaleOK, arg.AllKeys, arg.AbortIfSigchainUnchanged)
+		arg.ForcePoll, arg.StaleOK, arg.AllKeys, arg.AbortIfSigchainUnchanged, arg.CachedOnly)
 }
 
 func NewLoadUserArg(g *GlobalContext) LoadUserArg {

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -305,6 +305,8 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		}
 		arg.SigHints = sigHints
 		arg.MerkleLeaf = leaf
+	} else if arg.CachedOnly {
+		return nil, nil, UserNotFoundError{UID: arg.UID, Msg: "no cached user found"}
 	}
 
 	g.Log.CDebugf(ctx, "%s: LoadUser", culDebug(arg.UID))


### PR DESCRIPTION
I noticed in the logs I've been reading that there have been some cases of LoginOffline using the network if there is nothing in the cache.  This patch adds a LoadUserArg flag so that if there's a cache miss, upak loader will short-circuit before the full LoadUser.

Also added test for LoginOffline after cache timeout (existing code already passed).