### PR TITLE
Change prompt to save non-image download

### DIFF
--- a/shared/actions/platform-specific.native.js
+++ b/shared/actions/platform-specific.native.js
@@ -8,6 +8,7 @@ import {isDevApplePushToken} from '../local-debug'
 import {chatTab} from '../constants/tabs'
 import {setInitialTab, setInitialLink} from './config'
 import {setInitialConversation} from './chat'
+import {isImageFileName} from '../constants/chat'
 
 import type {AsyncAction} from '../constants/types/flux'
 
@@ -37,7 +38,14 @@ function showShareActionSheet(options: {
 
 type NextURI = string
 function saveAttachmentDialog(filePath: string): Promise<NextURI> {
-  return CameraRoll.saveToCameraRoll(filePath)
+  console.log('saveAttachment: ', filePath)
+  if (isIOS || isImageFileName(filePath)) {
+    if (!isIOS) filePath = 'file://' + filePath
+    console.log('Saving to camera roll: ', filePath)
+    return CameraRoll.saveToCameraRoll(filePath)
+  }
+  console.log('Android: Leaving at ', filePath)
+  return Promise.resolve(filePath)
 }
 
 function configurePush() {

--- a/shared/chat/conversation/messages/popup.native.js
+++ b/shared/chat/conversation/messages/popup.native.js
@@ -45,11 +45,13 @@ function _attachmentMessagePopupHelper({
 }: AttachmentProps) {
   const attachment: ChatConstants.AttachmentMessage = message
   const items = []
+  let itemType = 'File'
+  if (attachment.filename != null && ChatConstants.isImageFileName(attachment.filename)) itemType = 'Image'
   items.push({
     onClick: () => {
       onSaveAttachment && onSaveAttachment(attachment)
     },
-    title: 'Save Image',
+    title: 'Save ' + itemType,
   })
 
   if (isIOS && onShareAttachment) {
@@ -57,7 +59,7 @@ function _attachmentMessagePopupHelper({
       onClick: () => {
         onShareAttachment && onShareAttachment(attachment)
       },
-      title: 'Share Image',
+      title: 'Share ' + itemType,
     })
   }
 

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -1007,6 +1007,10 @@ const getSupersedes = (state: TypedState): ?SupersedeInfo => {
   return selectedConversationIDKey ? convSupersedesInfo(selectedConversationIDKey, state.chat) : null
 }
 
+function isImageFileName(filename: string): boolean {
+  return filename.match(/[^/]+\.(jpg|png|gif|jpeg|bmp)$/) == null
+}
+
 const stateLoggerTransform = (state: State) => ({
   alwaysShow: state.get('alwaysShow').join(','),
   conversationUnreadCounts: state.get('conversationUnreadCounts').toObject(),
@@ -1072,4 +1076,5 @@ export {
   getSelectedInbox,
   getTLF,
   getMuted,
+  isImageFileName,
 }


### PR DESCRIPTION
Non-image downloads now have a different prompt and don't get put in the camera roll, but I haven't gotten them to show up yet.

Made some attempt to factor out the regexp test but couldn't make it work; open to suggestions.