### PR TITLE
Use ScrollView for login container

### DIFF
--- a/shared/dev/dumb-sheet/render.native.js
+++ b/shared/dev/dumb-sheet/render.native.js
@@ -2,7 +2,7 @@
 import React, {Component} from 'react'
 import debounce from 'lodash/debounce'
 import dumbComponentMap from './component-map.native'
-import {Box, Text, Input, Button, NativeScrollView, Icon} from '../../common-adapters/index.native'
+import {Box, Button, Icon, Input, Text} from '../../common-adapters/index.native'
 import {Provider} from 'react-redux'
 import {createStore} from 'redux'
 import {globalStyles, globalColors} from '../../styles'
@@ -215,14 +215,12 @@ class DumbSheetRender extends Component<void, Props, any> {
             this.props.onDebugConfigChange({dumbFullscreen: !this.props.dumbFullscreen})
           }} />
         </Box>
-        <NativeScrollView>
-          <Box style={styleBox}>
-            <Text type='BodySmall'>{key}: {mockKey}</Text>
-            <Box {...mock.parentProps}>
-              {this._makeStoreWrapper(component)}
-            </Box>
+        <Box style={styleBox}>
+          <Text type='BodySmall'>{key}: {mockKey}</Text>
+          <Box {...mock.parentProps}>
+            {this._makeStoreWrapper(component)}
           </Box>
-        </NativeScrollView>
+        </Box>
       </Box>
     )
   }

--- a/shared/login/forms/container.native.js
+++ b/shared/login/forms/container.native.js
@@ -3,15 +3,16 @@ import React from 'react'
 import type {Props} from './container'
 import {Box, BackButton} from '../../common-adapters'
 import {globalMargins, globalStyles} from '../../styles'
+import {NativeScrollView} from '../../common-adapters/index.native'
 
 const Container = ({children, onBack, style, outerStyle}: Props) => {
   return (
-    <Box style={{...styles.container, ...outerStyle}}>
+    <NativeScrollView style={{...styles.container, ...outerStyle}}>
       {onBack && <BackButton style={styles.button} onClick={onBack} />}
       <Box style={{...styles.innerContainer, ...style}}>
         {children}
       </Box>
-    </Box>
+    </NativeScrollView>
   )
 }
 

--- a/shared/login/signup/success/index.render.native.js
+++ b/shared/login/signup/success/index.render.native.js
@@ -1,5 +1,6 @@
 // @flow
 import React, {Component} from 'react'
+import Container from '../../forms/container'
 import type {Props} from './index.render'
 import {Box, Checkbox, Button, Text, Icon} from '../../../common-adapters'
 import {globalColors, globalStyles, globalMargins} from '../../../styles'
@@ -28,7 +29,7 @@ class SuccessRender extends Component<void, Props, State> {
 
   render () {
     return (
-      <Box style={{padding: globalMargins.large, flex: 1}}>
+      <Container style={{padding: globalMargins.large, flex: 1}}>
         <Text type='Header' style={textCenter}>{this.props.title || "Congratulations, you've just joined Keybase!"}</Text>
         <Text type='Body' style={{...textCenter, marginTop: globalMargins.medium}}>Here is your unique paper key, it will allow you to perform important Keybase tasks in the future. This is the only time you'll see this so be sure to write it down.</Text>
 
@@ -53,7 +54,7 @@ class SuccessRender extends Component<void, Props, State> {
             label='Done'
             type='Primary' />
         </Box>
-      </Box>
+      </Container>
     )
   }
 }


### PR DESCRIPTION
Workaround issues described in https://keybase.atlassian.net/browse/DESKTOP-3250

Use ScrollView for mobile form container. This allows the view to be scrollable if keyboard is up on Android.

Also updating signup success view to use form container. Double checked the other views all used the form container as well.

Also removing ScrollView from the dumb sheet container on mobile so we can test that these views would scroll properly on mobile with Android keyboard. The dumb sheet view on a screen should fit in that view if it doesn't have scroll view.