### PR TITLE
Fix avatar overlay on Android

### DIFF
--- a/shared/common-adapters/multi-avatar.js
+++ b/shared/common-adapters/multi-avatar.js
@@ -40,7 +40,9 @@ class MultiAvatar extends Component<void, Props, void> {
     return (
       <Box style={{...containerStyle, ...style}}>
         <Avatar {...leftProps} style={{...leftAvatar, ...leftProps.style}} size={multiSize} />
-        <Avatar {...rightProps} style={{...rightAvatar, ...rightProps.style}} size={multiSize} />
+        <Box style={rightAvatarContainer}>
+          <Avatar {...rightProps} style={rightProps.style} size={multiSize} />
+        </Box>
       </Box>
     )
   }
@@ -53,7 +55,7 @@ const containerStyle = {
 const leftAvatar = {
 }
 
-const rightAvatar = {
+const rightAvatarContainer = {
   marginLeft: 8,
   marginTop: -16,
 }


### PR DESCRIPTION
Negative marginLeft was causing avatar to clip, see https://keybase.atlassian.net/browse/DESKTOP-3564

Setting the negative margin on a view parent container fixes the issue.

(It seems this issue is a known bug in our current version of RN, also along with absolute position being broken.)