### PR TITLE
change inbox handling to make it immune to cancel problems

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -208,6 +208,7 @@ function * untrustedInboxVisible (action: Constants.UntrustedInboxVisible): Saga
 
 // Loads the trusted inbox segments
 function * unboxConversations (conversationIDKeys: Array<Constants.ConversationIDKey>): Generator<any, any, any> {
+  conversationIDKeys = conversationIDKeys.filter(c => !Constants.isPendingConversationIDKey(c))
   yield put(Creators.setUnboxing(conversationIDKeys))
 
   const channelConfig = singleFixedChannelConfig([

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -2,10 +2,9 @@
 import * as ChatTypes from '../../constants/types/flow-types-chat'
 import * as Constants from '../../constants/chat'
 import * as Creators from './creators'
-import * as Shared from './shared'
 import {List, Map} from 'immutable'
 import {TlfKeysTLFIdentifyBehavior} from '../../constants/types/flow-types'
-import {call, put, select, race, fork, cancelled, take} from 'redux-saga/effects'
+import {call, put, select, race, cancelled, take, spawn} from 'redux-saga/effects'
 import {chatTab} from '../../constants/tabs'
 import {delay} from 'redux-saga'
 import {globalError} from '../../constants/config'
@@ -29,42 +28,41 @@ const _getInboxQuery = {
   unreadOnly: false,
 }
 
-let _inboxUntrustedError
 let _backgroundLoopTask
 
 // Load the inbox if we haven't yet, mostly done by the UI
 function * onInitialInboxLoad (): SagaGenerator<any, any> {
-  const inboxUntrustedState = yield select(Shared.inboxUntrustedStateSelector)
-  if (inboxUntrustedState === 'loading') {
-    return
-  }
-
-  if (inboxUntrustedState === 'unloaded' || _inboxUntrustedError) {
+  try {
     yield put(Creators.setInboxUntrustedState('loading'))
-    _inboxUntrustedError = null
     yield put(Creators.inboxStale())
     if (!isMobile) {
       // Only allow one loop at a time
       if (!_backgroundLoopTask) {
         yield take('chat:loadedInbox')
-        _backgroundLoopTask = yield fork(_backgroundUnboxLoop)
+        // Use spawn so this is never cancelled if this is
+        _backgroundLoopTask = yield spawn(_backgroundUnboxLoop)
       }
     }
+  } finally {
   }
 }
 
 // On desktop we passively unbox inbox items
 function * _backgroundUnboxLoop () {
-  while (true) {
-    yield call(delay, 10 * 1000)
-    const inboxes = yield select(state => state.chat.get('inbox'))
-    const conversationIDKeys = inboxes.filter(i => i.state === 'untrusted').take(10).map(i => i.conversationIDKey).toArray()
+  try {
+    while (true) {
+      yield call(delay, 10 * 1000)
+      const inboxes = yield select(state => state.chat.get('inbox'))
+      const conversationIDKeys = inboxes.filter(i => i.state === 'untrusted').take(10).map(i => i.conversationIDKey).toArray()
 
-    if (conversationIDKeys.length) {
-      yield call(unboxConversations, conversationIDKeys)
-    } else {
-      break
+      if (conversationIDKeys.length) {
+        yield call(unboxConversations, conversationIDKeys)
+      } else {
+        break
+      }
     }
+  } finally {
+    console.log('Background unboxing loop done')
   }
 }
 
@@ -83,7 +81,6 @@ function * _updateFinalized (inbox: ChatTypes.GetInboxLocalRes) {
 function * onInboxStale (): SagaGenerator<any, any> {
   try {
     yield put(Creators.setInboxUntrustedState('loading'))
-    _inboxUntrustedError = null
 
     const channelConfig = singleFixedChannelConfig(['chat.1.chatUi.chatInboxUnverified', 'finished'])
     const loadInboxChanMap: ChannelMap<any> = ChatTypes.localGetInboxNonblockLocalRpcChannelMap(channelConfig, {

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -696,6 +696,12 @@ function * _updateMetadata (action: Constants.UpdateMetadata): SagaGenerator<any
 
 function * _selectConversation (action: Constants.SelectConversation): SagaGenerator<any, any> {
   const {conversationIDKey, fromUser} = action.payload
+
+  // Load the inbox item always
+  if (conversationIDKey) {
+    yield put(Creators.getInboxAndUnbox([conversationIDKey]))
+  }
+
   const oldConversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
   if (oldConversationState && oldConversationState.get('isStale') && conversationIDKey) {
     yield put(Creators.clearMessages(conversationIDKey))


### PR DESCRIPTION
Fixes a problem @MarcoPolo and @jzila reported about. 

To repro, on master:
1. Open the desktop app
1. Click on Chat and as quickly as possible click on 'add a chat'
1. Search for someone you have a chat with and start a chat
1. Inbox should be dead and you can't type

Basically the takeLatest saga calls will cancel out the existing sagas (known) but the inbox saga was racy so when it loads up again it would bail and do nothing due to it thinking it didn't need to do anything. Instead letting the saga flow control this and remove the state checks. 
Additionally any children that are forked are also cancelled so this caused the background unboxing to fail permanently. I changed that to a spawn to avoid this behavior.

Additionally while testing I noticed that if you select a convo through add new (not scroll) its possible it'll sit there for awhile while its looping and unboxing everything instead of front-loading the selected conversation. Now when you select a convo it'll try and unbox the inbox item immediately.
