### PR TITLE
wait on inbox updates from the future, serialize them all with a timeout CORE-4994

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -37,7 +37,7 @@ func TestGetThreadSupersedes(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("basic test")
-	_, msgID, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+	_, msgBoxed, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        trip,
 			Sender:      u.User.GetUID().ToBytes(),
@@ -50,6 +50,7 @@ func TestGetThreadSupersedes(t *testing.T) {
 		}),
 	}, 0)
 	require.NoError(t, err)
+	msgID := msgBoxed.GetMessageID()
 	thread, _, err := tc.ChatG.ConvSource.Pull(context.TODO(), res.ConvID, u.User.GetUID().ToBytes(),
 		&chat1.GetThreadQuery{
 			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
@@ -58,7 +59,7 @@ func TestGetThreadSupersedes(t *testing.T) {
 	require.Equal(t, 1, len(thread.Messages), "wrong length")
 	require.Equal(t, msgID, thread.Messages[0].GetMessageID(), "wrong msgID")
 
-	_, editMsgID, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+	_, editMsgBoxed, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        trip,
 			Sender:      u.User.GetUID().ToBytes(),
@@ -73,6 +74,7 @@ func TestGetThreadSupersedes(t *testing.T) {
 		}),
 	}, 0)
 	require.NoError(t, err)
+	editMsgID := editMsgBoxed.GetMessageID()
 
 	t.Logf("testing an edit")
 	thread, _, err = tc.ChatG.ConvSource.Pull(context.TODO(), res.ConvID, u.User.GetUID().ToBytes(),

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -88,7 +88,7 @@ func TestGetThreadSupersedes(t *testing.T) {
 	require.Equal(t, "EDITED", thread.Messages[0].Valid().MessageBody.Text().Body, "wrong body")
 
 	t.Logf("testing a delete")
-	_, deleteMsgID, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+	_, deleteMsgBoxed, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        trip,
 			Sender:      u.User.GetUID().ToBytes(),
@@ -102,6 +102,7 @@ func TestGetThreadSupersedes(t *testing.T) {
 		}),
 	}, 0)
 	require.NoError(t, err)
+	deleteMsgID := deleteMsgBoxed.GetMessageID()
 	thread, _, err = tc.ChatG.ConvSource.Pull(context.TODO(), res.ConvID, u.User.GetUID().ToBytes(),
 		&chat1.GetThreadQuery{
 			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
@@ -335,7 +336,7 @@ func TestGetThreadCaching(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, msgID, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+	_, msgBoxed, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        trip,
 			Sender:      u.User.GetUID().ToBytes(),
@@ -348,6 +349,7 @@ func TestGetThreadCaching(t *testing.T) {
 		}),
 	}, 0)
 	require.NoError(t, err)
+	msgID := msgBoxed.GetMessageID()
 
 	tc.ChatG.ConvSource.Clear(res.ConvID, u.User.GetUID().ToBytes())
 	tc.ChatG.ConvSource.Disconnected(context.TODO())

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -117,7 +117,7 @@ func (g *gregorMessageOrderer) WaitForTurn(ctx context.Context, uid gregor1.UID,
 		select {
 		case <-g.waitOnWaiters(ctx, newVers, waiters):
 			g.Debug(ctx, "WaitForTurn: cleared by earlier messages: vers: %d", newVers)
-		case <-g.clock.After(time.Second):
+		case <-g.clock.AfterTime(g.clock.Now().Add(time.Second)):
 			g.Debug(ctx, "WaitForTurn: timeout reached, charging forward: vers: %d", newVers)
 		}
 		close(res)
@@ -130,6 +130,9 @@ func (g *gregorMessageOrderer) CompleteTurn(ctx context.Context, uid gregor1.UID
 	defer g.Unlock()
 	key := g.msgKey(uid, vers)
 	waiters := g.waiters[key]
+	if len(waiters) > 0 {
+		g.Debug(ctx, "CompleteTurn: clearing %d messages on vers %d", len(waiters), vers)
+	}
 	for _, w := range waiters {
 		close(w.cb)
 	}

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -132,6 +132,7 @@ func (g *gregorMessageOrderer) WaitForTurn(ctx context.Context, uid gregor1.UID,
 
 	// Out of order update, we are going to wait a fixed amount of time for the correctly
 	// ordered update
+	deadline := g.clock.Now().Add(time.Second)
 	go func() {
 		g.Lock()
 		waiters := g.addToWaitersLocked(ctx, uid, vers, newVers)
@@ -142,7 +143,7 @@ func (g *gregorMessageOrderer) WaitForTurn(ctx context.Context, uid gregor1.UID,
 		select {
 		case <-g.waitOnWaiters(ctx, newVers, waiters):
 			g.Debug(ctx, "WaitForTurn: cleared by earlier messages: vers: %d", newVers)
-		case <-g.clock.AfterTime(g.clock.Now().Add(time.Second)):
+		case <-g.clock.AfterTime(deadline):
 			g.Debug(ctx, "WaitForTurn: timeout reached, charging forward: vers: %d", newVers)
 			g.Lock()
 			g.cleanupAfterTimeoutLocked(uid, newVers)

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -305,7 +305,6 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 	}
 
 	// Decode into generic form
-	var activity chat1.ChatActivity
 	var gm chat1.GenericPayload
 	uid := m.UID().Bytes()
 	reader := bytes.NewReader(m.Body().Bytes())
@@ -327,6 +326,8 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, b
 		defer g.Unlock()
 		defer g.orderer.CompleteTurn(ctx, uid, gm.InboxVers)
 
+		var activity chat1.ChatActivity
+		var err error
 		action := gm.Action
 		reader.Reset(m.Body().Bytes())
 		switch action {

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -6,23 +6,136 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/keybase/client/go/badges"
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/pager"
+	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
 	"github.com/keybase/go-codec/codec"
 )
+
+type messageWaiterEntry struct {
+	vers chat1.InboxVers
+	cb   chan struct{}
+}
+
+type gregorMessageOrderer struct {
+	globals.Contextified
+	utils.DebugLabeler
+
+	clock   clockwork.Clock
+	waiters map[chat1.InboxVers][]messageWaiterEntry
+}
+
+func newGregorMessageOrderer(g *globals.Context) *gregorMessageOrderer {
+	return &gregorMessageOrderer{
+		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "gregorMessageOrderer", false),
+		waiters:      make(map[chat1.InboxVers][]messageWaiterEntry),
+		clock:        clockwork.NewRealClock(),
+	}
+}
+
+func (g *gregorMessageOrderer) latestInboxVersion(ctx context.Context, uid gregor1.UID) (chat1.InboxVers, error) {
+	ibox := storage.NewInbox(g.G(), uid)
+	vers, err := ibox.Version(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return vers, nil
+}
+
+func (g *gregorMessageOrderer) addToWaiters(ctx context.Context, msgVers, storedVers chat1.InboxVers) (res []messageWaiterEntry) {
+	for i := storedVers + 1; i < msgVers; i++ {
+		entry := messageWaiterEntry{
+			vers: msgVers,
+			cb:   make(chan struct{}),
+		}
+		res = append(res, entry)
+		g.waiters[i] = append(g.waiters[i], entry)
+	}
+	return res
+}
+
+func (g *gregorMessageOrderer) waitOnWaiters(ctx context.Context, vers chat1.InboxVers,
+	waiters []messageWaiterEntry) (res chan struct{}) {
+	res = make(chan struct{})
+	go func() {
+		for _, w := range waiters {
+			select {
+			case <-w.cb:
+			case <-ctx.Done():
+				g.Debug(ctx, "waitOnWaiters: context cancelled: waiter: %d target: %d", vers, w.vers)
+			}
+		}
+		close(res)
+	}()
+	return res
+}
+
+func (g *gregorMessageOrderer) WaitForTurn(ctx context.Context, uid gregor1.UID,
+	payload chat1.GenericPayload) (res chan struct{}) {
+	res = make(chan struct{})
+	// Grab latest inbox version if we can
+	vers, err := g.latestInboxVersion(ctx, uid)
+	if err != nil {
+		g.Debug(ctx, "WaitForTurn: failed to get current inbox version: %s", err.Error())
+		close(res)
+		return res
+	}
+
+	newVers := payload.InboxVers
+	// Check for an in-order update
+	if newVers <= vers+1 {
+		close(res)
+		return
+	}
+
+	// Out of order update, we are going to wait a fixed amount of time for the correctly
+	// ordered update
+	go func() {
+		waiters := g.addToWaiters(ctx, vers, newVers)
+		g.Debug(ctx, "WaitForTurn: out of order update received, waiting on %d updates: vers: %d",
+			len(waiters), newVers)
+		wctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		select {
+		case <-g.waitOnWaiters(wctx, newVers, waiters):
+		case <-g.clock.After(time.Second):
+			g.Debug(ctx, "WaitForTurn: timeout reached, charging forward: vers: %d", newVers)
+		}
+		close(res)
+	}()
+	return res
+}
+
+func (g *gregorMessageOrderer) CompleteTurn(ctx context.Context, vers chat1.InboxVers) {
+	waiters := g.waiters[vers]
+	for _, w := range waiters {
+		close(w.cb)
+	}
+	delete(g.waiters, vers)
+}
+
+func (g *gregorMessageOrderer) SetClock(clock clockwork.Clock) {
+	g.clock = clock
+}
 
 type PushHandler struct {
 	globals.Contextified
 	utils.DebugLabeler
+	sync.Mutex
 
 	identNotifier *IdentifyNotifier
+	orderer       *gregorMessageOrderer
 }
 
 func NewPushHandler(g *globals.Context) *PushHandler {
@@ -30,10 +143,17 @@ func NewPushHandler(g *globals.Context) *PushHandler {
 		Contextified:  globals.NewContextified(g),
 		DebugLabeler:  utils.NewDebugLabeler(g, "PushHandler", false),
 		identNotifier: NewIdentifyNotifier(g),
+		orderer:       newGregorMessageOrderer(g),
 	}
 }
 
+func (g *PushHandler) SetClock(clock clockwork.Clock) {
+	g.orderer.SetClock(clock)
+}
+
 func (g *PushHandler) TlfFinalize(ctx context.Context, m gregor.OutOfBandMessage) error {
+	g.Lock()
+	defer g.Unlock()
 	if m.Body() == nil {
 		return errors.New("gregor handler for chat.tlffinalize: nil message body")
 	}
@@ -77,6 +197,8 @@ func (g *PushHandler) TlfFinalize(ctx context.Context, m gregor.OutOfBandMessage
 }
 
 func (g *PushHandler) TlfResolve(ctx context.Context, m gregor.OutOfBandMessage) error {
+	g.Lock()
+	defer g.Unlock()
 	if m.Body() == nil {
 		return errors.New("gregor handler for chat.tlfresolve: nil message body")
 	}
@@ -117,181 +239,193 @@ func (g *PushHandler) TlfResolve(ctx context.Context, m gregor.OutOfBandMessage)
 }
 
 func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage, badger *badges.Badger) (err error) {
+	var identBreaks []keybase1.TLFIdentifyFailure
+	ctx = Context(ctx, g.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
+		g.identNotifier)
 	defer g.Trace(ctx, func() error { return err }, "Activity")()
 	if m.Body() == nil {
 		return errors.New("gregor handler for chat.activity: nil message body")
 	}
 
+	// Decode into generic form
 	var activity chat1.ChatActivity
 	var gm chat1.GenericPayload
+	uid := m.UID().Bytes()
 	reader := bytes.NewReader(m.Body().Bytes())
 	dec := codec.NewDecoder(reader, &codec.MsgpackHandle{WriteExt: true})
 	err = dec.Decode(&gm)
 	if err != nil {
+		g.Debug(ctx, "chat activity: failed to decode into generic payload: %s", err.Error())
 		return err
 	}
+	g.Debug(ctx, "chat activity: action %s vers: %d", gm.Action, gm.InboxVers)
 
-	g.Debug(ctx, "chat activity: action %s", gm.Action)
+	// Order updates based on inbox version of the update from the server
+	cb := g.orderer.WaitForTurn(ctx, uid, gm)
+	bctx := BackgroundContext(ctx, g.G().GetEnv())
+	go func() {
+		ctx := bctx
+		<-cb
+		g.Lock()
+		defer g.Unlock()
+		defer g.orderer.CompleteTurn(ctx, gm.InboxVers)
 
-	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, g.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
-		g.identNotifier)
-
-	action := gm.Action
-	reader.Reset(m.Body().Bytes())
-	switch action {
-	case "newMessage":
-		var nm chat1.NewMessagePayload
-		err = dec.Decode(&nm)
-		if err != nil {
-			g.Debug(ctx, "chat activity: error decoding newMessage: %s", err.Error())
-			return err
-		}
-
-		g.Debug(ctx, "chat activity: newMessage: convID: %s sender: %s",
-			nm.ConvID, nm.Message.ClientHeader.Sender)
-		if nm.Message.ClientHeader.OutboxID != nil {
-			g.Debug(ctx, "chat activity: newMessage: outboxID: %s",
-				hex.EncodeToString(*nm.Message.ClientHeader.OutboxID))
-		} else {
-			g.Debug(ctx, "chat activity: newMessage: outboxID is empty")
-		}
-		uid := m.UID().Bytes()
-
-		var conv *chat1.ConversationLocal
-		decmsg, appended, pushErr := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
-		if pushErr != nil {
-			g.Debug(ctx, "chat activity: unable to push message: %s", pushErr.Error())
-		}
-		if conv, err = g.G().InboxSource.NewMessage(ctx, uid, nm.InboxVers, nm.ConvID, nm.Message); err != nil {
-			g.Debug(ctx, "chat activity: unable to update inbox: %s", err.Error())
-		}
-
-		// If we have no error on this message, then notify the frontend
-		if pushErr == nil {
-			// Make a pagination object so client can use it in GetThreadLocal
-			pmsgs := []pager.Message{nm.Message}
-			pager := pager.NewThreadPager()
-			page, err := pager.MakePage(pmsgs, 1)
+		action := gm.Action
+		reader.Reset(m.Body().Bytes())
+		switch action {
+		case "newMessage":
+			var nm chat1.NewMessagePayload
+			err = dec.Decode(&nm)
 			if err != nil {
-				g.Debug(ctx, "chat activity: error making page: %s", err.Error())
+				g.Debug(ctx, "chat activity: error decoding newMessage: %s", err.Error())
+				return
 			}
-			activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
-				Message:    decmsg,
-				ConvID:     nm.ConvID,
-				Conv:       conv,
-				Pagination: page,
-			})
-		}
 
-		// If this message was not "appended", meaning there is a hole between what we have in cache,
-		// and this message, then we send out a notification that this thread should be considered
-		// stale.
-		// We also get here if we had an error unboxing the messages, it could be a temporal thing
-		// so the frontend should reload.
-		if !appended || pushErr != nil {
-			if !appended {
-				g.Debug(ctx, "chat activity: newMessage: non-append message, alerting")
+			g.Debug(ctx, "chat activity: newMessage: convID: %s sender: %s",
+				nm.ConvID, nm.Message.ClientHeader.Sender)
+			if nm.Message.ClientHeader.OutboxID != nil {
+				g.Debug(ctx, "chat activity: newMessage: outboxID: %s",
+					hex.EncodeToString(*nm.Message.ClientHeader.OutboxID))
+			} else {
+				g.Debug(ctx, "chat activity: newMessage: outboxID is empty")
 			}
+
+			var conv *chat1.ConversationLocal
+			decmsg, appended, pushErr := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
 			if pushErr != nil {
-				g.Debug(ctx, "chat activity: newMessage: push error, alerting")
+				g.Debug(ctx, "chat activity: unable to push message: %s", pushErr.Error())
 			}
-			g.G().Syncer.SendChatStaleNotifications(context.Background(), m.UID().Bytes(),
-				[]chat1.ConversationID{nm.ConvID}, true)
+			if conv, err = g.G().InboxSource.NewMessage(ctx, uid, nm.InboxVers, nm.ConvID, nm.Message); err != nil {
+				g.Debug(ctx, "chat activity: unable to update inbox: %s", err.Error())
+			}
+
+			// If we have no error on this message, then notify the frontend
+			if pushErr == nil {
+				// Make a pagination object so client can use it in GetThreadLocal
+				pmsgs := []pager.Message{nm.Message}
+				pager := pager.NewThreadPager()
+				page, err := pager.MakePage(pmsgs, 1)
+				if err != nil {
+					g.Debug(ctx, "chat activity: error making page: %s", err.Error())
+				}
+				activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
+					Message:    decmsg,
+					ConvID:     nm.ConvID,
+					Conv:       conv,
+					Pagination: page,
+				})
+			}
+
+			// If this message was not "appended", meaning there is a hole between what we have in cache,
+			// and this message, then we send out a notification that this thread should be considered
+			// stale.
+			// We also get here if we had an error unboxing the messages, it could be a temporal thing
+			// so the frontend should reload.
+			if !appended || pushErr != nil {
+				if !appended {
+					g.Debug(ctx, "chat activity: newMessage: non-append message, alerting")
+				}
+				if pushErr != nil {
+					g.Debug(ctx, "chat activity: newMessage: push error, alerting")
+				}
+				g.G().Syncer.SendChatStaleNotifications(context.Background(), m.UID().Bytes(),
+					[]chat1.ConversationID{nm.ConvID}, true)
+			}
+
+			if badger != nil && nm.UnreadUpdate != nil {
+				badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
+			}
+		case "readMessage":
+			var nm chat1.ReadMessagePayload
+			err = dec.Decode(&nm)
+			if err != nil {
+				g.Debug(ctx, "chat activity: error decoding: %s", err.Error())
+				return
+			}
+			g.Debug(ctx, "chat activity: readMessage: convID: %s msgID: %d",
+				nm.ConvID, nm.MsgID)
+
+			var conv *chat1.ConversationLocal
+			uid := m.UID().Bytes()
+			if conv, err = g.G().InboxSource.ReadMessage(ctx, uid, nm.InboxVers, nm.ConvID, nm.MsgID); err != nil {
+				g.Debug(ctx, "chat activity: unable to update inbox: %s", err.Error())
+			}
+
+			activity = chat1.NewChatActivityWithReadMessage(chat1.ReadMessageInfo{
+				MsgID:  nm.MsgID,
+				ConvID: nm.ConvID,
+				Conv:   conv,
+			})
+
+			if badger != nil && nm.UnreadUpdate != nil {
+				badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
+			}
+		case "setStatus":
+			var nm chat1.SetStatusPayload
+			err = dec.Decode(&nm)
+			if err != nil {
+				g.Debug(ctx, "chat activity: error decoding: %s", err.Error())
+				return
+			}
+			g.Debug(ctx, "chat activity: setStatus: convID: %s status: %d",
+				nm.ConvID, nm.Status)
+
+			var conv *chat1.ConversationLocal
+			uid := m.UID().Bytes()
+			if conv, err = g.G().InboxSource.SetStatus(ctx, uid, nm.InboxVers, nm.ConvID, nm.Status); err != nil {
+				g.Debug(ctx, "chat activity: unable to update inbox: %s", err.Error())
+			}
+			activity = chat1.NewChatActivityWithSetStatus(chat1.SetStatusInfo{
+				ConvID: nm.ConvID,
+				Status: nm.Status,
+				Conv:   conv,
+			})
+
+			if badger != nil && nm.UnreadUpdate != nil {
+				badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
+			}
+		case "newConversation":
+			var nm chat1.NewConversationPayload
+			err = dec.Decode(&nm)
+			if err != nil {
+				g.Debug(ctx, "chat activity: error decoding: %s", err.Error())
+				return
+			}
+			g.Debug(ctx, "chat activity: newConversation: convID: %s ", nm.ConvID)
+
+			uid := m.UID().Bytes()
+
+			// We need to get this conversation and then localize it
+			var inbox chat1.Inbox
+			if inbox, _, err = g.G().InboxSource.Read(ctx, uid, nil, false, &chat1.GetInboxLocalQuery{
+				ConvIDs: []chat1.ConversationID{nm.ConvID},
+			}, nil); err != nil {
+				g.Debug(ctx, "chat activity: unable to read conversation: %s", err.Error())
+				return
+			}
+			if len(inbox.Convs) != 1 {
+				g.Debug(ctx, "chat activity: unable to find conversation")
+				return
+			}
+			updateConv := inbox.ConvsUnverified[0]
+			if err = g.G().InboxSource.NewConversation(ctx, uid, nm.InboxVers, updateConv); err != nil {
+				g.Debug(ctx, "chat activity: unable to update inbox: %s", err.Error())
+			}
+
+			activity = chat1.NewChatActivityWithNewConversation(chat1.NewConversationInfo{
+				Conv: inbox.Convs[0],
+			})
+
+			if badger != nil && nm.UnreadUpdate != nil {
+				badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
+			}
+		default:
+			g.Debug(ctx, "unhandled chat.activity action %q", action)
 		}
 
-		if badger != nil && nm.UnreadUpdate != nil {
-			badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
-		}
-	case "readMessage":
-		var nm chat1.ReadMessagePayload
-		err = dec.Decode(&nm)
-		if err != nil {
-			g.Debug(ctx, "chat activity: error decoding: %s", err.Error())
-			return err
-		}
-		g.Debug(ctx, "chat activity: readMessage: convID: %s msgID: %d",
-			nm.ConvID, nm.MsgID)
-
-		var conv *chat1.ConversationLocal
-		uid := m.UID().Bytes()
-		if conv, err = g.G().InboxSource.ReadMessage(ctx, uid, nm.InboxVers, nm.ConvID, nm.MsgID); err != nil {
-			g.Debug(ctx, "chat activity: unable to update inbox: %s", err.Error())
-		}
-
-		activity = chat1.NewChatActivityWithReadMessage(chat1.ReadMessageInfo{
-			MsgID:  nm.MsgID,
-			ConvID: nm.ConvID,
-			Conv:   conv,
-		})
-
-		if badger != nil && nm.UnreadUpdate != nil {
-			badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
-		}
-	case "setStatus":
-		var nm chat1.SetStatusPayload
-		err = dec.Decode(&nm)
-		if err != nil {
-			g.Debug(ctx, "chat activity: error decoding: %s", err.Error())
-			return err
-		}
-		g.Debug(ctx, "chat activity: setStatus: convID: %s status: %d",
-			nm.ConvID, nm.Status)
-
-		var conv *chat1.ConversationLocal
-		uid := m.UID().Bytes()
-		if conv, err = g.G().InboxSource.SetStatus(ctx, uid, nm.InboxVers, nm.ConvID, nm.Status); err != nil {
-			g.Debug(ctx, "chat activity: unable to update inbox: %s", err.Error())
-		}
-		activity = chat1.NewChatActivityWithSetStatus(chat1.SetStatusInfo{
-			ConvID: nm.ConvID,
-			Status: nm.Status,
-			Conv:   conv,
-		})
-
-		if badger != nil && nm.UnreadUpdate != nil {
-			badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
-		}
-	case "newConversation":
-		var nm chat1.NewConversationPayload
-		err = dec.Decode(&nm)
-		if err != nil {
-			g.Debug(ctx, "chat activity: error decoding: %s", err.Error())
-			return err
-		}
-		g.Debug(ctx, "chat activity: newConversation: convID: %s ", nm.ConvID)
-
-		uid := m.UID().Bytes()
-
-		// We need to get this conversation and then localize it
-		var inbox chat1.Inbox
-		if inbox, _, err = g.G().InboxSource.Read(ctx, uid, nil, false, &chat1.GetInboxLocalQuery{
-			ConvIDs: []chat1.ConversationID{nm.ConvID},
-		}, nil); err != nil {
-			g.Debug(ctx, "chat activity: unable to read conversation: %s", err.Error())
-			return err
-		}
-		if len(inbox.Convs) != 1 {
-			g.Debug(ctx, "chat activity: unable to find conversation")
-			return fmt.Errorf("unable to find conversation")
-		}
-		updateConv := inbox.ConvsUnverified[0]
-		if err = g.G().InboxSource.NewConversation(ctx, uid, nm.InboxVers, updateConv); err != nil {
-			g.Debug(ctx, "chat activity: unable to update inbox: %s", err.Error())
-		}
-
-		activity = chat1.NewChatActivityWithNewConversation(chat1.NewConversationInfo{
-			Conv: inbox.Convs[0],
-		})
-
-		if badger != nil && nm.UnreadUpdate != nil {
-			badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
-		}
-	default:
-		return fmt.Errorf("unhandled chat.activity action %q", action)
-	}
-
-	return g.notifyNewChatActivity(ctx, m.UID(), &activity)
+		g.notifyNewChatActivity(ctx, m.UID(), &activity)
+	}()
+	return nil
 }
 
 func (g *PushHandler) notifyNewChatActivity(ctx context.Context, uid gregor.UID, activity *chat1.ChatActivity) error {

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -53,7 +53,7 @@ func (g *gregorMessageOrderer) latestInboxVersion(ctx context.Context, uid grego
 	return vers, nil
 }
 
-func (g *gregorMessageOrderer) addToWaiters(ctx context.Context, msgVers, storedVers chat1.InboxVers) (res []messageWaiterEntry) {
+func (g *gregorMessageOrderer) addToWaiters(ctx context.Context, storedVers, msgVers chat1.InboxVers) (res []messageWaiterEntry) {
 	for i := storedVers + 1; i < msgVers; i++ {
 		entry := messageWaiterEntry{
 			vers: msgVers,
@@ -103,8 +103,7 @@ func (g *gregorMessageOrderer) WaitForTurn(ctx context.Context, uid gregor1.UID,
 	// ordered update
 	go func() {
 		waiters := g.addToWaiters(ctx, vers, newVers)
-		g.Debug(ctx, "WaitForTurn: out of order update received, waiting on %d updates: vers: %d",
-			len(waiters), newVers)
+		g.Debug(ctx, "WaitForTurn: out of order update received, waiting on %d updates: vers: %d newVers: %d", len(waiters), vers, newVers)
 		wctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		select {

--- a/go/chat/push_test.go
+++ b/go/chat/push_test.go
@@ -105,6 +105,7 @@ func TestPushOrdering(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no notification received")
 	}
+	require.Zero(t, len(handler.orderer.waiters))
 
 	sendSimple(t, tc, handler, sender, conv, u,
 		func(vers chat1.InboxVers) chat1.InboxVers { return vers + 2 })

--- a/go/chat/push_test.go
+++ b/go/chat/push_test.go
@@ -122,4 +122,5 @@ func TestPushOrdering(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no notification received")
 	}
+	require.Zero(t, len(handler.orderer.waiters))
 }

--- a/go/chat/push_test.go
+++ b/go/chat/push_test.go
@@ -105,7 +105,9 @@ func TestPushOrdering(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no notification received")
 	}
+	handler.orderer.Lock()
 	require.Zero(t, len(handler.orderer.waiters))
+	handler.orderer.Unlock()
 
 	sendSimple(t, tc, handler, sender, conv, u,
 		func(vers chat1.InboxVers) chat1.InboxVers { return vers + 2 })
@@ -122,5 +124,7 @@ func TestPushOrdering(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no notification received")
 	}
+	handler.orderer.Lock()
 	require.Zero(t, len(handler.orderer.waiters))
+	handler.orderer.Unlock()
 }

--- a/go/chat/push_test.go
+++ b/go/chat/push_test.go
@@ -1,0 +1,124 @@
+package chat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/chat/storage"
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/go-codec/codec"
+	"github.com/stretchr/testify/require"
+)
+
+func sendSimple(t *testing.T, tc *kbtest.ChatTestContext, ph *PushHandler,
+	sender Sender, conv chat1.Conversation, user *kbtest.FakeUser,
+	iboxXform func(chat1.InboxVers) chat1.InboxVers) {
+	uid := gregor1.UID(user.User.GetUID().ToBytes())
+	convID := conv.GetConvID()
+	outboxID := chat1.OutboxID(randBytes(t, 8))
+	nr := tc.G.NotifyRouter
+	tc.G.NotifyRouter = nil
+	pt := chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Conv:        conv.Metadata.IdTriple,
+			Sender:      uid,
+			TlfName:     user.Username,
+			TlfPublic:   false,
+			MessageType: chat1.MessageType_TEXT,
+			OutboxID:    &outboxID,
+		},
+		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+			Body: "hi",
+		}),
+	}
+	_, boxed, _, err := sender.Send(context.TODO(), convID, pt, 0)
+	require.NoError(t, err)
+
+	ibox := storage.NewInbox(tc.Context(), uid)
+	vers, err := ibox.Version(context.TODO())
+	if err != nil {
+		require.IsType(t, storage.MissError{}, err)
+		vers = 0
+	}
+	newVers := iboxXform(vers)
+	t.Logf("newVers: %d vers: %d", newVers, vers)
+	nm := chat1.NewMessagePayload{
+		Action:    "newMessage",
+		ConvID:    conv.GetConvID(),
+		Message:   *boxed,
+		InboxVers: iboxXform(vers),
+	}
+	var data []byte
+	enc := codec.NewEncoderBytes(&data, &codec.MsgpackHandle{WriteExt: true})
+	require.NoError(t, enc.Encode(nm))
+	m := gregor1.OutOfBandMessage{
+		Uid_:    uid,
+		System_: "chat.activity",
+		Body_:   data,
+	}
+
+	tc.G.NotifyRouter = nr
+	require.NoError(t, ph.Activity(context.TODO(), m, nil))
+}
+
+func TestPushOrdering(t *testing.T) {
+	world, ri2, _, sender, list, tlf := setupTest(t, 1)
+	defer world.Cleanup()
+
+	ri := ri2.(*kbtest.ChatRemoteMock)
+	u := world.GetUsers()[0]
+	uid := u.User.GetUID().ToBytes()
+	tc := world.Tcs[u.Username]
+	handler := NewPushHandler(tc.Context())
+	handler.SetClock(world.Fc)
+
+	conv := newBlankConv(t, uid, ri, sender, tlf, u.Username)
+	sendSimple(t, tc, handler, sender, conv, u,
+		func(vers chat1.InboxVers) chat1.InboxVers { return vers + 1 })
+
+	select {
+	case <-list.incoming:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no notification received")
+	}
+
+	sendSimple(t, tc, handler, sender, conv, u,
+		func(vers chat1.InboxVers) chat1.InboxVers { return vers + 2 })
+	select {
+	case <-list.incoming:
+		require.Fail(t, "should not have gotten one of these")
+	default:
+	}
+
+	sendSimple(t, tc, handler, sender, conv, u,
+		func(vers chat1.InboxVers) chat1.InboxVers { return vers + 1 })
+	select {
+	case <-list.incoming:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no notification received")
+	}
+	select {
+	case <-list.incoming:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no notification received")
+	}
+
+	sendSimple(t, tc, handler, sender, conv, u,
+		func(vers chat1.InboxVers) chat1.InboxVers { return vers + 2 })
+	select {
+	case <-list.incoming:
+		require.Fail(t, "should not have gotten one of these")
+	default:
+	}
+
+	t.Logf("advancing clock")
+	world.Fc.Advance(time.Hour)
+	select {
+	case <-list.incoming:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no notification received")
+	}
+}

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -76,7 +76,7 @@ func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActi
 	defer n.Unlock()
 	typ, err := activity.ActivityType()
 	if err == nil {
-		if typ == chat1.ChatActivityType_INCOMING_MESSAGE {
+		if typ == chat1.ChatActivityType_INCOMING_MESSAGE && activity.IncomingMessage().Message.IsValid() {
 			header := activity.IncomingMessage().Message.Valid().ClientHeader
 			if header.OutboxID != nil {
 				n.obids = append(n.obids, *activity.IncomingMessage().Message.Valid().ClientHeader.OutboxID)
@@ -136,7 +136,7 @@ func setupTest(t *testing.T, numUsers int) (*kbtest.ChatMockWorld, chat1.RemoteI
 	baseSender := NewBlockingSender(g, boxer, nil, getRI)
 	sender := NewNonblockingSender(g, baseSender)
 	listener := chatListener{
-		incoming:       make(chan int),
+		incoming:       make(chan int, 100),
 		failing:        make(chan []chat1.OutboxRecord),
 		identifyUpdate: make(chan keybase1.CanonicalTLFNameAndIDWithBreaks),
 		inboxStale:     make(chan struct{}, 1),
@@ -275,7 +275,7 @@ func TestNonblockTimer(t *testing.T) {
 	// Send a bunch of nonblocking messages
 	var sentRef []sentRecord
 	for i := 0; i < 5; i++ {
-		_, msgID, _, err := baseSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+		_, msgBoxed, _, err := baseSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
 				Conv:        trip,
 				Sender:      u.User.GetUID().ToBytes(),
@@ -287,8 +287,9 @@ func TestNonblockTimer(t *testing.T) {
 				Body: "hi",
 			}),
 		}, 0)
-		t.Logf("generated msgID: %d", msgID)
 		require.NoError(t, err)
+		msgID := msgBoxed.GetMessageID()
+		t.Logf("generated msgID: %d", msgID)
 		sentRef = append(sentRef, sentRecord{msgID: &msgID})
 	}
 
@@ -324,7 +325,7 @@ func TestNonblockTimer(t *testing.T) {
 
 	// Send a bunch of nonblocking messages
 	for i := 0; i < 5; i++ {
-		_, msgID, _, err := baseSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+		_, msgBoxed, _, err := baseSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
 				Conv:        trip,
 				Sender:      u.User.GetUID().ToBytes(),
@@ -336,9 +337,10 @@ func TestNonblockTimer(t *testing.T) {
 				Body: "hi",
 			}),
 		}, 0)
+		require.NoError(t, err)
+		msgID = msgBoxed.GetMessageID()
 		t.Logf("generated msgID: %d", msgID)
 		sentRef = append(sentRef, sentRecord{msgID: &msgID})
-		require.NoError(t, err)
 	}
 
 	// Check get thread, make sure it makes sense
@@ -378,8 +380,8 @@ type FailingSender struct {
 }
 
 func (f FailingSender) Send(ctx context.Context, convID chat1.ConversationID,
-	msg chat1.MessagePlaintext, clientPrev chat1.MessageID) (chat1.OutboxID, chat1.MessageID, *chat1.RateLimit, error) {
-	return chat1.OutboxID{}, 0, nil, fmt.Errorf("I always fail!!!!")
+	msg chat1.MessagePlaintext, clientPrev chat1.MessageID) (chat1.OutboxID, *chat1.MessageBoxed, *chat1.RateLimit, error) {
+	return chat1.OutboxID{}, nil, nil, fmt.Errorf("I always fail!!!!")
 }
 
 func (f FailingSender) Prepare(ctx context.Context, msg chat1.MessagePlaintext, convID *chat1.ConversationID) (*chat1.MessageBoxed, []chat1.Asset, error) {
@@ -554,7 +556,7 @@ func TestDeletionHeaders(t *testing.T) {
 	res := startConv(t, u, trip, blockingSender, ri, tc)
 
 	// Send a message and two edits.
-	_, firstMessageID, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+	_, firstMessageBoxed, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        trip,
 			Sender:      u.User.GetUID().ToBytes(),
@@ -564,7 +566,8 @@ func TestDeletionHeaders(t *testing.T) {
 		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{Body: "foo"}),
 	}, 0)
 	require.NoError(t, err)
-	_, editID, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+	firstMessageID := firstMessageBoxed.GetMessageID()
+	_, editBoxed, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        trip,
 			Sender:      u.User.GetUID().ToBytes(),
@@ -575,7 +578,8 @@ func TestDeletionHeaders(t *testing.T) {
 		MessageBody: chat1.NewMessageBodyWithEdit(chat1.MessageEdit{MessageID: firstMessageID, Body: "bar"}),
 	}, 0)
 	require.NoError(t, err)
-	_, editID2, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+	editID := editBoxed.GetMessageID()
+	_, editBoxed2, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        trip,
 			Sender:      u.User.GetUID().ToBytes(),
@@ -586,6 +590,7 @@ func TestDeletionHeaders(t *testing.T) {
 		MessageBody: chat1.NewMessageBodyWithEdit(chat1.MessageEdit{MessageID: firstMessageID, Body: "baz"}),
 	}, 0)
 	require.NoError(t, err)
+	editID2 := editBoxed2.GetMessageID()
 
 	// Now prepare a deletion.
 	deletion := chat1.MessagePlaintext{
@@ -691,7 +696,7 @@ func TestDeletionAssets(t *testing.T) {
 
 	// Send an attachment message and 3 MessageAttachUploaded's.
 	tmp1 := mkAsset()
-	_, firstMessageID, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+	_, firstMessageBoxed, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        trip,
 			Sender:      u.User.GetUID().ToBytes(),
@@ -706,6 +711,8 @@ func TestDeletionAssets(t *testing.T) {
 		}),
 	}, 0)
 	require.NoError(t, err)
+	firstMessageID := firstMessageBoxed.GetMessageID()
+
 	editHeader := chat1.MessageClientHeader{
 		Conv:        trip,
 		Sender:      u.User.GetUID().ToBytes(),
@@ -713,7 +720,7 @@ func TestDeletionAssets(t *testing.T) {
 		MessageType: chat1.MessageType_ATTACHMENTUPLOADED,
 		Supersedes:  firstMessageID,
 	}
-	_, edit1ID, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+	_, edit1Boxed, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: editHeader,
 		MessageBody: chat1.NewMessageBodyWithAttachmentuploaded(chat1.MessageAttachmentUploaded{
 			MessageID: firstMessageID,
@@ -722,7 +729,8 @@ func TestDeletionAssets(t *testing.T) {
 		}),
 	}, 0)
 	require.NoError(t, err)
-	_, edit2ID, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+	edit1ID := edit1Boxed.GetMessageID()
+	_, edit2Boxed, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: editHeader,
 		MessageBody: chat1.NewMessageBodyWithAttachmentuploaded(chat1.MessageAttachmentUploaded{
 			MessageID: firstMessageID,
@@ -730,7 +738,8 @@ func TestDeletionAssets(t *testing.T) {
 			Previews:  []chat1.Asset{mkAsset(), mkAsset()},
 		}),
 	}, 0)
-	_, edit3ID, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+	edit2ID := edit2Boxed.GetMessageID()
+	_, edit3Boxed, _, err := blockingSender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 		ClientHeader: editHeader,
 		MessageBody: chat1.NewMessageBodyWithAttachmentuploaded(chat1.MessageAttachmentUploaded{
 			MessageID: firstMessageID,
@@ -739,6 +748,7 @@ func TestDeletionAssets(t *testing.T) {
 		}),
 	}, 0)
 	require.NoError(t, err)
+	edit3ID := edit3Boxed.GetMessageID()
 
 	require.Equal(t, len(doomedAssets), 10, "wrong number of assets created")
 

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -338,7 +338,7 @@ func TestNonblockTimer(t *testing.T) {
 			}),
 		}, 0)
 		require.NoError(t, err)
-		msgID = msgBoxed.GetMessageID()
+		msgID := msgBoxed.GetMessageID()
 		t.Logf("generated msgID: %d", msgID)
 		sentRef = append(sentRef, sentRecord{msgID: &msgID})
 	}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -835,14 +835,14 @@ func (h *Server) PostLocal(ctx context.Context, arg chat1.PostLocalArg) (res cha
 
 	sender := NewBlockingSender(h.G(), h.boxer, h.store, h.remoteClient)
 
-	_, msgID, rl, err := sender.Send(ctx, arg.ConversationID, arg.Msg, 0)
+	_, msgBoxed, rl, err := sender.Send(ctx, arg.ConversationID, arg.Msg, 0)
 	if err != nil {
 		return chat1.PostLocalRes{}, fmt.Errorf("PostLocal: unable to send message: %s", err.Error())
 	}
 
 	return chat1.PostLocalRes{
 		RateLimits:       utils.AggRateLimitsP([]*chat1.RateLimit{rl}),
-		MessageID:        msgID,
+		MessageID:        msgBoxed.GetMessageID(),
 		IdentifyFailures: identBreaks,
 	}, nil
 }

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -55,7 +55,14 @@ func newConv(t *testing.T, uid gregor1.UID, ri chat1.RemoteInterface, sender Sen
 		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{Body: "foo"}),
 	}, 0)
 	require.NoError(t, err)
-	return conv
+	convID := conv.GetConvID()
+	ires, err := ri.GetInboxRemote(context.TODO(), chat1.GetInboxRemoteArg{
+		Query: &chat1.GetInboxQuery{
+			ConvID: &convID,
+		},
+	})
+	require.NoError(t, err)
+	return ires.Inbox.Full().Conversations[0]
 }
 
 func doSync(t *testing.T, syncer types.Syncer, ri chat1.RemoteInterface, uid gregor1.UID) {

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -8,7 +8,8 @@ import (
 )
 
 type GenericPayload struct {
-	Action string `codec:"Action" json:"Action"`
+	Action    string    `codec:"Action" json:"Action"`
+	InboxVers InboxVers `codec:"inboxVers" json:"inboxVers"`
 }
 
 type NewConversationPayload struct {

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -4,6 +4,7 @@ protocol gregor {
     record GenericPayload {
         @lint("ignore")
         string Action;
+        InboxVers inboxVers;
     }
 
     record NewConversationPayload {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -937,6 +937,7 @@ export type FindConversationsLocalRes = {
 
 export type GenericPayload = {
   Action: string,
+  inboxVers: InboxVers,
 }
 
 export type GetConversationForCLILocalQuery = {

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -10,6 +10,10 @@
           "type": "string",
           "name": "Action",
           "lint": "ignore"
+        },
+        {
+          "type": "InboxVers",
+          "name": "inboxVers"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -937,6 +937,7 @@ export type FindConversationsLocalRes = {
 
 export type GenericPayload = {
   Action: string,
+  inboxVers: InboxVers,
 }
 
 export type GetConversationForCLILocalQuery = {


### PR DESCRIPTION
Patch solves the following scenario:

1.) Two clients are connected to two different Gregor instances. Both send a message at the same time. 
2.) The inbox updates from each are now racing over Gregor pubsub, and a client may receive inbox A before B where A > B.
3.) In the pre-patch case, this would cause the client to think it is out of date, and clear the inbox cache and re-sync from the server.

Patch does the following:

1.) All chat updates come with an inbox version, so upon reception of an update we compare it against the on-disk copy of the inbox version. 
2.) If it is contiguous with that version, then we charge forward and process the update.
3.) If the update looks like it is from the future, then we pause for one second while we give any past updated a chance to make it to the client (the loser of the race).
4.) If it does, then we process that guy, and then tell any waiting updates that they can now fire. 

I can explain in person if you want as well, just let me know!

cc @maxtaco  if you want to look.