### PR TITLE
Wasn't loading the first row in inbox

### DIFF
--- a/shared/chat/inbox/index.native.js
+++ b/shared/chat/inbox/index.native.js
@@ -184,8 +184,8 @@ class ConversationList extends PureComponent<void, Props, {dataSource: any}> {
     if (this.props.rows !== nextProps.rows) {
       this._setupDataSource(nextProps)
 
-      if (nextProps.rows.count() > 1) {
-        const conversationIDKey = nextProps.rows.get(1)
+      if (nextProps.rows.count()) {
+        const conversationIDKey = nextProps.rows.get(0)
         this.props.onUntrustedInboxVisible(conversationIDKey, 20)
       }
     }


### PR DESCRIPTION
We inject a dummy value for the 'New Chat' item, but that exists in the data source but not props.rows, so we have an off by one error. This lead to not unboxing the first row

@keybase/react-hackers 

cc: @mmaxim 