### PR TITLE
Load conversations in the background

### DIFF
--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -1,0 +1,63 @@
+package chat
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/types"
+	"github.com/keybase/client/go/protocol/gregor1"
+)
+
+type BackgroundConvLoader struct {
+	globals.Contextified
+	connected bool
+}
+
+var _ types.ConvLoader = (*BackgroundConvLoader)(nil)
+
+func NewBackgroundConvLoader(g *globals.Context) *BackgroundConvLoader {
+	return &BackgroundConvLoader{
+		Contextified: globals.NewContextified(g),
+	}
+}
+
+func (b *BackgroundConvLoader) Connected(ctx context.Context) {
+	b.connected = true
+
+	// Wake up loader loop on reconnect
+	// b.Debug(ctx, "reconnected: forcing deliver loop run")
+	// b.reconnectCh <- struct{}{}
+}
+
+func (b *BackgroundConvLoader) Disconnected(ctx context.Context) {
+	// s.Debug(ctx, "disconnected: all errors from now on will be permanent")
+	b.connected = false
+}
+
+func (b *BackgroundConvLoader) IsOffline() bool {
+	return !b.connected
+}
+
+func (b *BackgroundConvLoader) Start(ctx context.Context, uid gregor1.UID) {
+	/*
+		s.Lock()
+		defer s.Unlock()
+
+		<-s.doStop(ctx)
+
+		s.outbox = storage.NewOutbox(s.G(), uid)
+		s.outbox.SetClock(s.clock)
+
+		s.delivering = true
+		go s.deliverLoop()
+	*/
+}
+
+func (s *BackgroundConvLoader) Stop(ctx context.Context) chan struct{} {
+	/*
+		s.Lock()
+		defer s.Unlock()
+		return s.doStop(ctx)
+	*/
+	return make(chan struct{})
+}

--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"errors"
 	"sync"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -14,12 +15,23 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
+const (
+	bgLoaderMaxAttempts = 4
+	bgLoaderDelay       = 300 * time.Millisecond
+)
+
+type clTask struct {
+	convID        chat1.ConversationID
+	attempt       int
+	lastAttemptAt time.Time
+}
+
 type BackgroundConvLoader struct {
 	globals.Contextified
 	utils.DebugLabeler
 
 	started       bool
-	queue         chan chat1.ConversationID
+	queue         chan clTask
 	stop          chan bool
 	identNotifier *IdentifyNotifier
 
@@ -71,14 +83,18 @@ func (b *BackgroundConvLoader) Stop(ctx context.Context) chan struct{} {
 }
 
 func (b *BackgroundConvLoader) Queue(ctx context.Context, convID chat1.ConversationID) error {
+	return b.enqueue(ctx, clTask{convID: convID})
+}
+
+func (b *BackgroundConvLoader) enqueue(ctx context.Context, task clTask) error {
 	b.Lock()
 	defer b.Unlock()
 
 	select {
-	case b.queue <- convID:
-		b.Debug(ctx, "added %s to queue", convID)
+	case b.queue <- task:
+		b.Debug(ctx, "added %s to queue", task.convID)
 	default:
-		b.Debug(ctx, "queue is full, not adding %s", convID)
+		b.Debug(ctx, "queue is full, not adding %s", task.convID)
 		return errors.New("queue is full")
 	}
 
@@ -91,8 +107,11 @@ func (b *BackgroundConvLoader) loop(uid gregor1.UID) {
 	for {
 		// get a convID from queue, or stop
 		select {
-		case convID := <-b.queue:
-			b.load(bgctx, convID, uid)
+		case task := <-b.queue:
+			if task.attempt > 0 {
+				time.Sleep(bgLoaderDelay - time.Since(task.lastAttemptAt))
+			}
+			b.load(bgctx, task, uid)
 		case <-b.stop:
 			b.Debug(bgctx, "shutting down conv loader loop for %s", uid)
 			return
@@ -104,27 +123,39 @@ func (b *BackgroundConvLoader) newQueue() {
 	if b.queue != nil {
 		close(b.queue)
 	}
-	b.queue = make(chan chat1.ConversationID, 200)
+	b.queue = make(chan clTask, 200)
 }
 
-func (b *BackgroundConvLoader) load(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) {
-	b.Debug(ctx, "loading conversation %s", convID)
+func (b *BackgroundConvLoader) load(ctx context.Context, task clTask, uid gregor1.UID) {
+	b.Debug(ctx, "loading conversation %s", task.convID)
 
 	var breaks []keybase1.TLFIdentifyFailure
 	ctx = Context(ctx, b.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &breaks, b.identNotifier)
 
 	query := &chat1.GetThreadQuery{MarkAsRead: false}
 	pagination := &chat1.Pagination{Num: 50}
-	_, _, err := b.G().ConvSource.Pull(ctx, convID, uid, query, pagination)
+	_, _, err := b.G().ConvSource.Pull(ctx, task.convID, uid, query, pagination)
 	if err != nil {
-		b.Debug(ctx, "ConvSource.Pull error: %s", err)
-	} else {
-		b.Debug(ctx, "loaded conversation %s", convID)
-
-		// if testing, put the convID on the loads channel
-		if b.loads != nil {
-			b.Debug(ctx, "putting convID %s on loads chan", convID)
-			b.loads <- convID
+		b.Debug(ctx, "ConvSource.Pull error: %s (%T)", err, err)
+		if _, ok := err.(*TransientUnboxingError); ok && task.attempt+1 < bgLoaderMaxAttempts {
+			b.Debug(ctx, "transient error, retrying")
+			task.attempt++
+			task.lastAttemptAt = time.Now()
+			b.enqueue(ctx, task)
+			return
 		}
+
+		b.Debug(ctx, "sending conv %s to FetchRetrier", task.convID)
+		b.G().FetchRetrier.Failure(ctx, task.convID, uid, types.ThreadLoad)
+
+		return
+	}
+
+	b.Debug(ctx, "loaded conversation %s", task.convID)
+
+	// if testing, put the convID on the loads channel
+	if b.loads != nil {
+		b.Debug(ctx, "putting convID %s on loads chan", task.convID)
+		b.loads <- task.convID
 	}
 }

--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -1,63 +1,177 @@
 package chat
 
 import (
+	"errors"
+	"sync"
+
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/types"
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 )
 
 type BackgroundConvLoader struct {
 	globals.Contextified
+	utils.DebugLabeler
+
 	connected bool
+	started   bool
+	queue     chan chat1.ConversationID
+	stop      chan bool
+	online    chan struct{} // closed when online
+	offline   chan struct{} // closed when offline
+
+	loads chan chat1.ConversationID // for testing, make this and can check conv load successes
+
+	sync.Mutex
 }
 
 var _ types.ConvLoader = (*BackgroundConvLoader)(nil)
 
 func NewBackgroundConvLoader(g *globals.Context) *BackgroundConvLoader {
-	return &BackgroundConvLoader{
+	b := &BackgroundConvLoader{
 		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "BackgroundConvLoader", false),
+		stop:         make(chan bool),
+		online:       make(chan struct{}),
+		offline:      make(chan struct{}),
 	}
+
+	// start offline
+	close(b.offline)
+
+	b.newQueue()
+
+	return b
 }
 
 func (b *BackgroundConvLoader) Connected(ctx context.Context) {
+	b.Lock()
+	defer b.Unlock()
+
+	if b.connected {
+		return
+	}
+
 	b.connected = true
 
-	// Wake up loader loop on reconnect
-	// b.Debug(ctx, "reconnected: forcing deliver loop run")
-	// b.reconnectCh <- struct{}{}
+	b.offline = make(chan struct{})
+	close(b.online)
 }
 
 func (b *BackgroundConvLoader) Disconnected(ctx context.Context) {
-	// s.Debug(ctx, "disconnected: all errors from now on will be permanent")
+	b.Lock()
+	defer b.Unlock()
+
+	if !b.connected {
+		return
+	}
+
 	b.connected = false
+
+	b.online = make(chan struct{})
+	close(b.offline)
 }
 
 func (b *BackgroundConvLoader) IsOffline() bool {
+	b.Lock()
+	defer b.Unlock()
+
 	return !b.connected
 }
 
 func (b *BackgroundConvLoader) Start(ctx context.Context, uid gregor1.UID) {
-	/*
-		s.Lock()
-		defer s.Unlock()
+	b.Lock()
+	defer b.Unlock()
 
-		<-s.doStop(ctx)
+	if b.started {
+		b.stop <- true
+	}
 
-		s.outbox = storage.NewOutbox(s.G(), uid)
-		s.outbox.SetClock(s.clock)
+	b.newQueue()
 
-		s.delivering = true
-		go s.deliverLoop()
-	*/
+	b.started = true
+	go b.loop(uid)
 }
 
-func (s *BackgroundConvLoader) Stop(ctx context.Context) chan struct{} {
-	/*
-		s.Lock()
-		defer s.Unlock()
-		return s.doStop(ctx)
-	*/
-	return make(chan struct{})
+func (b *BackgroundConvLoader) Stop(ctx context.Context) chan struct{} {
+	b.Lock()
+	defer b.Unlock()
+
+	if b.started {
+		b.stop <- true
+		b.started = false
+	}
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
+func (b *BackgroundConvLoader) Queue(ctx context.Context, convID chat1.ConversationID) error {
+	b.Lock()
+	defer b.Unlock()
+
+	select {
+	case b.queue <- convID:
+		b.Debug(ctx, "added %s to queue")
+	default:
+		b.Debug(ctx, "queue is full, not adding %s", convID)
+		return errors.New("queue is full")
+	}
+
+	return nil
+}
+
+func (b *BackgroundConvLoader) loop(uid gregor1.UID) {
+	bgctx := context.Background()
+	b.Debug(bgctx, "starting conv loader loop for %s", uid)
+	for {
+		// wait to come online (or stop)
+		select {
+		case <-b.online:
+		case <-b.stop:
+			b.Debug(bgctx, "shutting down (offline) conv loader loop for %s", uid)
+			return
+		}
+
+		// get a convID from queue, go offline, or stop
+		select {
+		case convID := <-b.queue:
+			b.load(bgctx, convID, uid)
+		case <-b.offline:
+			b.Debug(bgctx, "loop went offline")
+		case <-b.stop:
+			b.Debug(bgctx, "shutting down conv loader loop for %s", uid)
+			return
+		}
+	}
+}
+
+func (b *BackgroundConvLoader) newQueue() {
+	if b.queue != nil {
+		close(b.queue)
+	}
+	b.queue = make(chan chat1.ConversationID, 200)
+}
+
+func (b *BackgroundConvLoader) load(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) {
+	b.Debug(ctx, "loading conversation %s", convID)
+
+	query := &chat1.GetThreadQuery{MarkAsRead: false}
+	pagination := &chat1.Pagination{Num: 50}
+	_, _, err := b.G().ConvSource.Pull(ctx, convID, uid, query, pagination)
+	if err != nil {
+		b.Debug(ctx, "ConvSource.Pull error: %s", err)
+	} else {
+		b.Debug(ctx, "loaded conversation %s", convID)
+
+		// if testing, put the convID on the loads channel
+		if b.loads != nil {
+			b.Debug(ctx, "putting convID %s on loads chan", convID)
+			b.loads <- convID
+		}
+	}
 }

--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -121,7 +121,7 @@ func (b *BackgroundConvLoader) Queue(ctx context.Context, convID chat1.Conversat
 
 	select {
 	case b.queue <- convID:
-		b.Debug(ctx, "added %s to queue")
+		b.Debug(ctx, "added %s to queue", convID)
 	default:
 		b.Debug(ctx, "queue is full, not adding %s", convID)
 		return errors.New("queue is full")

--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -37,40 +37,13 @@ func setupLoaderTest(t *testing.T) (*kbtest.ChatTestContext, *kbtest.ChatMockWor
 	return tc, world, listener, res
 }
 
-func TestConvLoaderOnline(t *testing.T) {
+func TestConvLoader(t *testing.T) {
 	tc, world, listener, res := setupLoaderTest(t)
 	defer world.Cleanup()
 
 	if err := tc.Context().ConvLoader.Queue(context.TODO(), res.ConvID); err != nil {
 		t.Fatal(err)
 	}
-
-	select {
-	case convID := <-listener.bgConvLoads:
-		if !convID.Eq(res.ConvID) {
-			t.Errorf("loaded conv id: %s, expected %s", convID, res.ConvID)
-		}
-	case <-time.After(20 * time.Second):
-		t.Fatal("timeout waiting for conversation load")
-	}
-}
-
-func TestConvLoaderOffline(t *testing.T) {
-	tc, world, listener, res := setupLoaderTest(t)
-	defer world.Cleanup()
-	tc.Context().ConvLoader.Disconnected(context.TODO())
-
-	if err := tc.Context().ConvLoader.Queue(context.TODO(), res.ConvID); err != nil {
-		t.Fatal(err)
-	}
-
-	select {
-	case <-listener.bgConvLoads:
-		t.Fatal("conversation loaded offline")
-	case <-time.After(1 * time.Second):
-	}
-
-	tc.Context().ConvLoader.Connected(context.TODO())
 
 	select {
 	case convID := <-listener.bgConvLoads:

--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -1,0 +1,91 @@
+package chat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/stretchr/testify/require"
+)
+
+func setupLoaderTest(t *testing.T) (*kbtest.ChatTestContext, *kbtest.ChatMockWorld, *kbtest.FakeUser, chat1.NewConversationRemoteRes) {
+	world, ri, _, baseSender, _, tlf := setupTest(t, 1)
+
+	u := world.GetUsers()[0]
+	trip := newConvTriple(t, tlf, u.Username)
+	firstMessagePlaintext := chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Conv:        trip,
+			TlfName:     u.Username,
+			TlfPublic:   false,
+			MessageType: chat1.MessageType_TLFNAME,
+		},
+		MessageBody: chat1.MessageBody{},
+	}
+	firstMessageBoxed, _, err := baseSender.Prepare(context.TODO(), firstMessagePlaintext, nil)
+	require.NoError(t, err)
+	res, err := ri.NewConversationRemote2(context.TODO(), chat1.NewConversationRemote2Arg{
+		IdTriple:   trip,
+		TLFMessage: *firstMessageBoxed,
+	})
+	require.NoError(t, err)
+
+	tc := userTc(t, world, u)
+
+	return tc, world, u, res
+}
+
+func TestConvLoaderOnline(t *testing.T) {
+	tc, world, u, res := setupLoaderTest(t)
+	defer world.Cleanup()
+
+	loader := NewBackgroundConvLoader(tc.Context())
+	loader.loads = make(chan chat1.ConversationID, 10)
+	loader.Start(context.TODO(), u.User.GetUID().ToBytes())
+	loader.Connected(context.TODO())
+
+	if err := loader.Queue(context.TODO(), res.ConvID); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case convID := <-loader.loads:
+		if !convID.Eq(res.ConvID) {
+			t.Errorf("loaded conv id: %s, expected %s", convID, res.ConvID)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("timeout waiting for conversation load")
+	}
+}
+
+func TestConvLoaderOffline(t *testing.T) {
+	tc, world, u, res := setupLoaderTest(t)
+	defer world.Cleanup()
+	loader := NewBackgroundConvLoader(tc.Context())
+	loader.loads = make(chan chat1.ConversationID, 10)
+	loader.Start(context.TODO(), u.User.GetUID().ToBytes())
+	loader.Disconnected(context.TODO())
+
+	if err := loader.Queue(context.TODO(), res.ConvID); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-loader.loads:
+		t.Fatal("conversation loaded offline")
+	case <-time.After(1 * time.Second):
+	}
+
+	loader.Connected(context.TODO())
+
+	select {
+	case convID := <-loader.loads:
+		if !convID.Eq(res.ConvID) {
+			t.Errorf("loaded conv id: %s, expected %s", convID, res.ConvID)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("timeout waiting for conversation load")
+	}
+}

--- a/go/chat/globals/globals.go
+++ b/go/chat/globals/globals.go
@@ -12,6 +12,7 @@ type ChatContext struct {
 	ServerCacheVersions types.ServerCacheVersions // server side versions for chat caches
 	Syncer              types.Syncer              // For syncing inbox with server
 	FetchRetrier        types.FetchRetrier        // For retrying failed fetch requests
+	ConvLoader          types.ConvLoader          // background conversation loader
 }
 
 type Context struct {

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -160,7 +160,6 @@ func setupTest(t *testing.T, numUsers int) (*kbtest.ChatMockWorld, chat1.RemoteI
 	bgLoader.loads = listener.bgConvLoads
 	g.ConvLoader = bgLoader
 	g.ConvLoader.Start(context.TODO(), u.User.GetUID().ToBytes())
-	g.ConvLoader.Connected(context.TODO())
 	chatSyncer := NewSyncer(g)
 	chatSyncer.isConnected = true
 	g.Syncer = chatSyncer

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -28,6 +28,7 @@ type chatListener struct {
 	identifyUpdate chan keybase1.CanonicalTLFNameAndIDWithBreaks
 	inboxStale     chan struct{}
 	threadsStale   chan []chat1.ConversationID
+	bgConvLoads    chan chat1.ConversationID
 }
 
 var _ libkb.NotifyListener = (*chatListener)(nil)
@@ -141,6 +142,7 @@ func setupTest(t *testing.T, numUsers int) (*kbtest.ChatMockWorld, chat1.RemoteI
 		identifyUpdate: make(chan keybase1.CanonicalTLFNameAndIDWithBreaks),
 		inboxStale:     make(chan struct{}, 1),
 		threadsStale:   make(chan []chat1.ConversationID, 1),
+		bgConvLoads:    make(chan chat1.ConversationID, 10),
 	}
 	g.ConvSource = NewHybridConversationSource(g, boxer, storage.New(g), getRI)
 	g.InboxSource = NewHybridInboxSource(g, getRI, tlf)
@@ -154,6 +156,11 @@ func setupTest(t *testing.T, numUsers int) (*kbtest.ChatMockWorld, chat1.RemoteI
 	g.FetchRetrier.(*FetchRetrier).SetClock(world.Fc)
 	g.FetchRetrier.Start(context.TODO(), u.User.GetUID().ToBytes())
 	g.FetchRetrier.Connected(context.TODO())
+	bgLoader := NewBackgroundConvLoader(g)
+	bgLoader.loads = listener.bgConvLoads
+	g.ConvLoader = bgLoader
+	g.ConvLoader.Start(context.TODO(), u.User.GetUID().ToBytes())
+	g.ConvLoader.Connected(context.TODO())
 	chatSyncer := NewSyncer(g)
 	chatSyncer.isConnected = true
 	g.Syncer = chatSyncer

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -255,6 +255,15 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 			// Send notifications for a successful partial sync
 			s.SendChatStaleNotifications(ctx, uid, s.getConvIDs(incr.Convs), true)
 		}
+
+		// Queue background conversation loads
+		if s.G().ConvLoader != nil {
+			for _, convID := range s.getConvIDs(incr.Convs) {
+				if err := s.G().ConvLoader.Queue(ctx, convID); err != nil {
+					s.Debug(ctx, "Sync: failed to queue conversation load: %s", err)
+				}
+			}
+		}
 	}
 
 	return nil

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -257,11 +257,9 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 		}
 
 		// Queue background conversation loads
-		if s.G().ConvLoader != nil {
-			for _, convID := range s.getConvIDs(incr.Convs) {
-				if err := s.G().ConvLoader.Queue(ctx, convID); err != nil {
-					s.Debug(ctx, "Sync: failed to queue conversation load: %s", err)
-				}
+		for _, convID := range s.getConvIDs(incr.Convs) {
+			if err := s.G().ConvLoader.Queue(ctx, convID); err != nil {
+				s.Debug(ctx, "Sync: failed to queue conversation load: %s", err)
 			}
 		}
 	}

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -136,6 +136,12 @@ func TestSyncerConnected(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no threads stale received")
 	}
+	select {
+	case cid := <-list.bgConvLoads:
+		require.Equal(t, convs[1].GetConvID(), cid)
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no background conv loaded")
+	}
 	vers, iconvs, err := ibox.ReadAll(context.TODO())
 	require.NoError(t, err)
 	require.Equal(t, len(convs), len(iconvs))

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -115,7 +115,5 @@ type ConvLoader interface {
 	Offlinable
 	Resumable
 
-	// Queue(ctx context.Context, convID chat1.ConversationID, msg chat1.MessagePlaintext,
-	//	identifyBehavior keybase1.TLFIdentifyBehavior) (chat1.OutboxRecord, error)
-	// ForceDeliverLoop(ctx context.Context)
+	Queue(ctx context.Context, convID chat1.ConversationID) error
 }

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -112,7 +112,6 @@ type FetchRetrier interface {
 }
 
 type ConvLoader interface {
-	Offlinable
 	Resumable
 
 	Queue(ctx context.Context, convID chat1.ConversationID) error

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -110,3 +110,12 @@ type FetchRetrier interface {
 	Success(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, kind FetchType) error
 	Force(ctx context.Context)
 }
+
+type ConvLoader interface {
+	Offlinable
+	Resumable
+
+	// Queue(ctx context.Context, convID chat1.ConversationID, msg chat1.MessagePlaintext,
+	//	identifyBehavior keybase1.TLFIdentifyBehavior) (chat1.OutboxRecord, error)
+	// ForceDeliverLoop(ctx context.Context)
+}

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -285,11 +285,14 @@ func (d *Service) createChatModules() {
 	sender := chat.NewBlockingSender(g, chat.NewBoxer(g, tlf), d.attachmentstore, ri)
 	g.MessageDeliverer = chat.NewDeliverer(g, sender)
 
+	g.ConvLoader = chat.NewBackgroundConvLoader(g)
+
 	// Set up Offlinables on Syncer
 	chatSyncer.RegisterOfflinable(g.InboxSource)
 	chatSyncer.RegisterOfflinable(g.ConvSource)
 	chatSyncer.RegisterOfflinable(g.FetchRetrier)
 	chatSyncer.RegisterOfflinable(g.MessageDeliverer)
+	chatSyncer.RegisterOfflinable(g.ConvLoader)
 
 	// Add a tlfHandler into the user changed handler group so we can keep identify info
 	// fresh

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -294,7 +294,6 @@ func (d *Service) createChatModules() {
 	chatSyncer.RegisterOfflinable(g.ConvSource)
 	chatSyncer.RegisterOfflinable(g.FetchRetrier)
 	chatSyncer.RegisterOfflinable(g.MessageDeliverer)
-	chatSyncer.RegisterOfflinable(g.ConvLoader)
 
 	// Add a tlfHandler into the user changed handler group so we can keep identify info
 	// fresh

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -259,12 +259,14 @@ func (d *Service) startChatModules() {
 		g := globals.NewContext(d.G(), d.ChatG())
 		g.MessageDeliverer.Start(context.Background(), uid)
 		g.FetchRetrier.Start(context.Background(), uid)
+		g.ConvLoader.Start(context.Background(), uid)
 	}
 }
 
 func (d *Service) stopChatModules() {
 	<-d.ChatG().MessageDeliverer.Stop(context.Background())
 	<-d.ChatG().FetchRetrier.Stop(context.Background())
+	<-d.ChatG().ConvLoader.Stop(context.Background())
 }
 
 func (d *Service) createChatModules() {


### PR DESCRIPTION
This patch adds a background conversation loader.  The syncer puts stale conversation IDs in it and the conversations are loaded in a background thread to prime the disk cache.

