### PR TITLE
Mobile: Removes duplicate onHidden calls in conversation Popup item handlers

### DIFF
--- a/shared/chat/conversation/messages/popup.native.js
+++ b/shared/chat/conversation/messages/popup.native.js
@@ -17,7 +17,6 @@ function _textMessagePopupHelper ({message, type, onDeleteMessage, onHidden, onS
   const edit = message.author === you ? [{
     onClick: () => {
       onShowEditor(message)
-      onHidden()
     },
     title: 'Edit',
   }] : []
@@ -25,7 +24,6 @@ function _textMessagePopupHelper ({message, type, onDeleteMessage, onHidden, onS
   const copy = [{
     onClick: () => {
       NativeClipboard.setString(message.message.stringValue())
-      onHidden()
     },
     title: 'Copy Text',
   }]
@@ -39,7 +37,6 @@ function _attachmentMessagePopupHelper ({message, onSaveAttachment, onShareAttac
   items.push({
     onClick: () => {
       onSaveAttachment && onSaveAttachment(attachment)
-      onHidden()
     },
     title: 'Save Image',
   })
@@ -48,7 +45,6 @@ function _attachmentMessagePopupHelper ({message, onSaveAttachment, onShareAttac
     items.push({
       onClick: () => {
         onShareAttachment && onShareAttachment(attachment)
-        onHidden()
       },
       title: 'Share Image',
     })
@@ -87,7 +83,6 @@ function MessagePopup (props: TextProps | AttachmentProps) {
       danger: true,
       onClick: () => {
         onDeleteMessage(message)
-        onHidden()
       },
       title: 'Delete',
     })


### PR DESCRIPTION
onHidden is already called for all items rendered in common-adapters/popup-menu.native.js so calling
them again would pop the view hierarchy back to the inbox for all items except for "Cancel".

Before, choosing an item from the popup popped the hierarchy to the inbox:

![broken](https://cloud.githubusercontent.com/assets/19795/25691272/04c5c144-304e-11e7-9bf3-3156e999d107.gif)

After, choosing an item keeps the conversation open:

![fixed](https://cloud.githubusercontent.com/assets/19795/25691273/04cb14aa-304e-11e7-9618-aa2250beb1f8.gif)


Note: editing messages is broken.