### PR TITLE
Fix RNPN function name

### DIFF
--- a/shared/main-shared.native.js
+++ b/shared/main-shared.native.js
@@ -63,7 +63,7 @@ class Main extends Component<void, any, void> {
   _setIconBadgeNumber (count: number) {
     RNPN.setApplicationIconBadgeNumber(count)
     if (count === 0) {
-      RNPN.clearLocalPushNotifications()
+      RNPN.cancelAllLocalNotifications()
     }
   }
 


### PR DESCRIPTION
Fixes "RNPN.clearLocalPushNotifications is not a function" error for me on startup. Tested on Android and it cleared notification when after I viewed all unread convos in another app.