### PR TITLE
Flatten extra level of login/signup routes

### DIFF
--- a/shared/login/login/routes.js
+++ b/shared/login/login/routes.js
@@ -50,9 +50,6 @@ const recursiveLazyRoutes = I.Seq({
   }))
   .toMap()
 
-const routeTree = new RouteDefNode({
-  defaultSelected: 'login',
-  children: recursiveLazyRoutes,
-})
+const routeTree = recursiveLazyRoutes.get('login')
 
 export default routeTree

--- a/shared/login/signup/routes.js
+++ b/shared/login/signup/routes.js
@@ -15,39 +15,34 @@ const signupError = new RouteDefNode({
 })
 
 const routeTree = new RouteDefNode({
-  defaultSelected: 'signup',
+  component: InviteCode,
   children: {
-    signup: {
-      component: InviteCode,
+    signupError,
+    requestInvite: {
+      component: RequestInvite,
       children: {
         signupError,
-        requestInvite: {
-          component: RequestInvite,
-          children: {
-            signupError,
-            requestInviteSuccess: {
-              component: RequestInviteSuccess,
-            },
-          },
+        requestInviteSuccess: {
+          component: RequestInviteSuccess,
         },
-        usernameAndEmail: {
-          component: UsernameEmailForm,
+      },
+    },
+    usernameAndEmail: {
+      component: UsernameEmailForm,
+      children: {
+        signupError,
+        passphraseSignup: {
+          component: PassphraseSignup,
           children: {
             signupError,
-            passphraseSignup: {
-              component: PassphraseSignup,
+            deviceName: {
+              component: DeviceName,
               children: {
                 signupError,
-                deviceName: {
-                  component: DeviceName,
+                success: {
+                  component: Success,
                   children: {
                     signupError,
-                    success: {
-                      component: Success,
-                      children: {
-                        signupError,
-                      },
-                    },
                   },
                 },
               },


### PR DESCRIPTION
When navigating up (due to back button or iOS left-to-right swipe), we'd
end up on the parent (e.g. loginTab/login/login -> loginTab/login),
which had a defaultSelected value that put us right back on the same
tab. This was confusing the navigation card stack, because it expected
the route to change on back swipe.