### PR TITLE
disable sdh tests

### DIFF
--- a/go/engine/device_add_test.go
+++ b/go/engine/device_add_test.go
@@ -21,6 +21,7 @@ func TestDeviceAdd(t *testing.T) {
 }
 
 func TestDeviceAddSDH(t *testing.T) {
+	t.Skip("TODO waiting for PerUserSecretRewrite")
 	testDeviceAdd(t, true)
 }
 

--- a/go/engine/kex2_test.go
+++ b/go/engine/kex2_test.go
@@ -18,6 +18,7 @@ func TestKex2Provision(t *testing.T) {
 }
 
 func TestKex2ProvisionSDH(t *testing.T) {
+	t.Skip("TODO waiting for PerUserSecretRewrite")
 	subTestKex2Provision(t, true)
 }
 

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -188,6 +188,7 @@ func TestProvisionDesktop(t *testing.T) {
 }
 
 func TestProvisionDesktopSDH(t *testing.T) {
+	t.Skip("TODO waiting for PerUserSecretRewrite")
 	testProvisionDesktop(t, true)
 }
 
@@ -404,6 +405,7 @@ func TestProvisionPassphraseNoKeysSolo(t *testing.T) {
 }
 
 func TestProvisionPassphraseNoKeysSoloSDH(t *testing.T) {
+	t.Skip("TODO waiting for PerUserSecretRewrite")
 	testProvisionPassphraseNoKeysSolo(t, true)
 }
 

--- a/go/engine/shared_dh_test.go
+++ b/go/engine/shared_dh_test.go
@@ -13,10 +13,14 @@ import (
 )
 
 func TestSignupEngineSharedDH(t *testing.T) {
+	t.Skip("TODO waiting for PerUserSecretRewrite")
+
 	subTestSignupEngine(t, true)
 }
 
 func TestSharedDHSignupAndPullKeys(t *testing.T) {
+	t.Skip("TODO waiting for PerUserSecretRewrite")
+
 	tc := SetupEngineTest(t, "signup")
 	defer tc.Cleanup()
 	var err error
@@ -48,6 +52,8 @@ func TestSharedDHSignupAndPullKeys(t *testing.T) {
 }
 
 func TestSharedDHSignupPlusPaper(t *testing.T) {
+	t.Skip("TODO waiting for PerUserSecretRewrite")
+
 	tc := SetupEngineTest(t, "signup")
 	defer tc.Cleanup()
 	var err error


### PR DESCRIPTION
Skip all SharedDH tests. While these are off server changes won't break CI. Gotta make sure to turn these back on later.

Running now locally with a server that rejects all shared dh posts to make sure to get all the tests.