### PR TITLE
Retry GPGSwitchToSign

### DIFF
--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -1158,71 +1158,86 @@ func TestProvisionGPGSignSecretStore(t *testing.T) {
 // server). Import private key to lksec fails, switches to gpg
 // sign, which works.
 func TestProvisionGPGSwitchToSign(t *testing.T) {
-	tc := SetupEngineTest(t, "login")
-	defer tc.Cleanup()
-	skipOldGPG(tc)
+	tcCheck := SetupEngineTest(t, "check")
+	defer tcCheck.Cleanup()
+	skipOldGPG(tcCheck)
 
-	u1 := createFakeUserWithPGPPubOnly(t, tc)
-	Logout(tc)
+	// this test sometimes fails at the GPG level with a "Bad signature" error,
+	// so we're going to retry it several times to hopefully get past it.
+	attempts := 10
+	for i := 0; i < attempts; i++ {
+		tc := SetupEngineTest(t, "login")
+		defer tc.Cleanup()
 
-	// redo SetupEngineTest to get a new home directory...should look like a new device.
-	tc2 := SetupEngineTest(t, "login")
-	defer tc2.Cleanup()
+		u1 := createFakeUserWithPGPPubOnly(t, tc)
+		Logout(tc)
 
-	// we need the gpg keyring that's in the first homedir
-	if err := tc.MoveGpgKeyringTo(tc2); err != nil {
-		t.Fatal(err)
+		// redo SetupEngineTest to get a new home directory...should look like a new device.
+		tc2 := SetupEngineTest(t, "login")
+		defer tc2.Cleanup()
+
+		// we need the gpg keyring that's in the first homedir
+		if err := tc.MoveGpgKeyringTo(tc2); err != nil {
+			t.Fatal(err)
+		}
+
+		// now safe to cleanup first home
+		tc.Cleanup()
+
+		// load the user (bypassing LoginUsername for this test...)
+		user, err := libkb.LoadUser(libkb.NewLoadUserByNameArg(tc2.G, u1.Username))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// run login on new device
+		ctx := &Context{
+			ProvisionUI: newTestProvisionUIGPGImport(),
+			LogUI:       tc2.G.UI.GetLogUI(),
+			SecretUI:    u1.NewSecretUI(),
+			LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
+			GPGUI:       &gpgtestui{},
+		}
+
+		arg := loginProvisionArg{
+			DeviceType: libkb.DeviceTypeDesktop,
+			ClientType: keybase1.ClientType_CLI,
+			User:       user,
+		}
+
+		eng := newLoginProvision(tc2.G, &arg)
+		// use a gpg client that will fail to import any gpg key
+		eng.gpgCli = newGPGImportFailer(tc2.G)
+
+		if err := RunEngine(eng, ctx); err != nil {
+			t.Logf("test run %d:  RunEngine(Login) error: %s", i+1, err)
+			continue
+		}
+
+		t.Logf("test run %d: RunEngine(Login) succeeded", i+1)
+
+		testUserHasDeviceKey(tc2)
+
+		// highly possible they didn't have a paper key, so make sure they have one now:
+		hasOnePaperDev(tc2, u1)
+
+		if err := AssertProvisioned(tc2); err != nil {
+			t.Fatal(err)
+		}
+
+		// after provisioning, the secret should be stored
+		assertSecretStored(tc2, u1.Username)
+
+		// since they did not import their pgp key, they should not be able
+		// to pgp sign something:
+		if err := signString(tc2, "sign me", u1.NewSecretUI()); err == nil {
+			t.Fatal("pgp sign worked after gpg sign provisioning")
+		}
+		t.Logf("test run %d: all checks passed, returning", i+1)
+		return
 	}
 
-	// now safe to cleanup first home
-	tc.Cleanup()
-
-	// load the user (bypassing LoginUsername for this test...)
-	user, err := libkb.LoadUser(libkb.NewLoadUserByNameArg(tc2.G, u1.Username))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// run login on new device
-	ctx := &Context{
-		ProvisionUI: newTestProvisionUIGPGImport(),
-		LogUI:       tc2.G.UI.GetLogUI(),
-		SecretUI:    u1.NewSecretUI(),
-		LoginUI:     &libkb.TestLoginUI{Username: u1.Username},
-		GPGUI:       &gpgtestui{},
-	}
-
-	arg := loginProvisionArg{
-		DeviceType: libkb.DeviceTypeDesktop,
-		ClientType: keybase1.ClientType_CLI,
-		User:       user,
-	}
-
-	eng := newLoginProvision(tc2.G, &arg)
-	// use a gpg client that will fail to import any gpg key
-	eng.gpgCli = newGPGImportFailer(tc2.G)
-
-	if err := RunEngine(eng, ctx); err != nil {
-		t.Fatal(err)
-	}
-
-	testUserHasDeviceKey(tc2)
-
-	// highly possible they didn't have a paper key, so make sure they have one now:
-	hasOnePaperDev(tc2, u1)
-
-	if err := AssertProvisioned(tc2); err != nil {
-		t.Fatal(err)
-	}
-
-	// after provisioning, the secret should be stored
-	assertSecretStored(tc2, u1.Username)
-
-	// since they did not import their pgp key, they should not be able
-	// to pgp sign something:
-	if err := signString(tc2, "sign me", u1.NewSecretUI()); err == nil {
-		t.Fatal("pgp sign worked after gpg sign provisioning")
-	}
+	t.Fatalf("TestProvisionGPGSwitchToSign failed %d times", attempts)
 }
 
 // Try provision device using a private GPG key (not synced to keybase


### PR DESCRIPTION
Same retry as other GPGSign tests.  Took about 400 test runs, but saw it retry correctly:


	login_test.go:1213: test run 1:  RunEngine(Login) error: bad signature: Sig verify error: Didn't get two-byte header 0x00 0x01 (error 1002)
	login_test.go:1217: test run 2: RunEngine(Login) succeeded
	login_test.go:1236: test run 2: all checks passed, returning


cc @mmaxim 