### PR TITLE
Dumb sheet needs default flex after I removed scroll view parent

### DIFF
--- a/shared/dev/dumb-sheet/render.native.js
+++ b/shared/dev/dumb-sheet/render.native.js
@@ -2,7 +2,7 @@
 import React, {Component} from 'react'
 import debounce from 'lodash/debounce'
 import dumbComponentMap from './component-map.native'
-import {Box, Button, Icon, Input, Text} from '../../common-adapters/index.native'
+import {Box, Button, Icon, Input, NativeScrollView, Text} from '../../common-adapters/index.native'
 import {Provider} from 'react-redux'
 import {createStore} from 'redux'
 import {globalStyles, globalColors} from '../../styles'
@@ -190,9 +190,6 @@ class DumbSheetRender extends Component<void, Props, any> {
       )
     }
 
-    // Default parent props style should be flex: 1
-    if (!mock.parentProps) mock.parentProps = {style: {flex: 1}}
-
     return (
       <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
         <Box style={globalStyles.flexBoxRow}>
@@ -218,12 +215,14 @@ class DumbSheetRender extends Component<void, Props, any> {
             this.props.onDebugConfigChange({dumbFullscreen: !this.props.dumbFullscreen})
           }} />
         </Box>
-        <Box style={styleBox}>
-          <Text type='BodySmall'>{key}: {mockKey}</Text>
-          <Box {...mock.parentProps}>
-            {this._makeStoreWrapper(component)}
+        <NativeScrollView>
+          <Box style={styleBox}>
+            <Text type='BodySmall'>{key}: {mockKey}</Text>
+            <Box {...mock.parentProps}>
+              {this._makeStoreWrapper(component)}
+            </Box>
           </Box>
-        </Box>
+        </NativeScrollView>
       </Box>
     )
   }

--- a/shared/dev/dumb-sheet/render.native.js
+++ b/shared/dev/dumb-sheet/render.native.js
@@ -2,7 +2,7 @@
 import React, {Component} from 'react'
 import debounce from 'lodash/debounce'
 import dumbComponentMap from './component-map.native'
-import {Box, Button, Icon, Input, NativeScrollView, Text} from '../../common-adapters/index.native'
+import {Box, Button, Icon, Input, Text} from '../../common-adapters/index.native'
 import {Provider} from 'react-redux'
 import {createStore} from 'redux'
 import {globalStyles, globalColors} from '../../styles'
@@ -190,6 +190,9 @@ class DumbSheetRender extends Component<void, Props, any> {
       )
     }
 
+    // Default parent props style should be flex: 1
+    if (!mock.parentProps) mock.parentProps = {style: {flex: 1}}
+
     return (
       <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
         <Box style={globalStyles.flexBoxRow}>
@@ -215,14 +218,12 @@ class DumbSheetRender extends Component<void, Props, any> {
             this.props.onDebugConfigChange({dumbFullscreen: !this.props.dumbFullscreen})
           }} />
         </Box>
-        <NativeScrollView>
-          <Box style={styleBox}>
-            <Text type='BodySmall'>{key}: {mockKey}</Text>
-            <Box {...mock.parentProps}>
-              {this._makeStoreWrapper(component)}
-            </Box>
+        <Box style={styleBox}>
+          <Text type='BodySmall'>{key}: {mockKey}</Text>
+          <Box {...mock.parentProps}>
+            {this._makeStoreWrapper(component)}
           </Box>
-        </NativeScrollView>
+        </Box>
       </Box>
     )
   }

--- a/shared/dev/dumb-sheet/render.native.js
+++ b/shared/dev/dumb-sheet/render.native.js
@@ -2,7 +2,7 @@
 import React, {Component} from 'react'
 import debounce from 'lodash/debounce'
 import dumbComponentMap from './component-map.native'
-import {Box, Button, Icon, Input, NativeScrollView, Text} from '../../common-adapters/index.native'
+import {Box, Button, Icon, Input, Text} from '../../common-adapters/index.native'
 import {Provider} from 'react-redux'
 import {createStore} from 'redux'
 import {globalStyles, globalColors} from '../../styles'
@@ -215,14 +215,14 @@ class DumbSheetRender extends Component<void, Props, any> {
             this.props.onDebugConfigChange({dumbFullscreen: !this.props.dumbFullscreen})
           }} />
         </Box>
-        <NativeScrollView>
-          <Box style={styleBox}>
-            <Text type='BodySmall'>{key}: {mockKey}</Text>
-            <Box {...mock.parentProps}>
+        <Box style={styleBox}>
+          <Text type='BodySmall'>{key}: {mockKey}</Text>
+          <Box style={styleSmallScreen}>
+            <Box style={{flex: 1}} {...mock.parentProps}>
               {this._makeStoreWrapper(component)}
             </Box>
           </Box>
-        </NativeScrollView>
+        </Box>
       </Box>
     )
   }
@@ -243,6 +243,14 @@ class DumbSheetRender extends Component<void, Props, any> {
 const styleBox = {
   ...globalStyles.flexBoxColumn,
   flex: 1,
+}
+
+const styleSmallScreen = {
+  ...globalStyles.flexBoxColumn,
+  borderColor: 'black',
+  borderWidth: 1,
+  flex: 1,
+  maxHeight: 528, // Wrap in max height screen, so we'll know if things get clipped on iPhone SE
 }
 const stylesButton = {
   borderRadius: 10,

--- a/shared/dev/dumb-sheet/render.native.js
+++ b/shared/dev/dumb-sheet/render.native.js
@@ -250,7 +250,7 @@ const styleSmallScreen = {
   borderColor: 'black',
   borderWidth: 1,
   flex: 1,
-  maxHeight: 528, // Wrap in max height screen, so we'll know if things get clipped on iPhone SE
+  maxHeight: 528, // Wrap in max height, so we'll know if things get clipped on iPhone SE
 }
 const stylesButton = {
   borderRadius: 10,

--- a/shared/dev/dumb-sheet/render.native.js
+++ b/shared/dev/dumb-sheet/render.native.js
@@ -2,7 +2,7 @@
 import React, {Component} from 'react'
 import debounce from 'lodash/debounce'
 import dumbComponentMap from './component-map.native'
-import {Box, Button, Icon, Input, Text} from '../../common-adapters/index.native'
+import {Box, Button, Icon, Input, NativeScrollView, Text} from '../../common-adapters/index.native'
 import {Provider} from 'react-redux'
 import {createStore} from 'redux'
 import {globalStyles, globalColors} from '../../styles'
@@ -215,12 +215,14 @@ class DumbSheetRender extends Component<void, Props, any> {
             this.props.onDebugConfigChange({dumbFullscreen: !this.props.dumbFullscreen})
           }} />
         </Box>
-        <Box style={styleBox}>
-          <Text type='BodySmall'>{key}: {mockKey}</Text>
-          <Box {...mock.parentProps}>
-            {this._makeStoreWrapper(component)}
+        <NativeScrollView>
+          <Box style={styleBox}>
+            <Text type='BodySmall'>{key}: {mockKey}</Text>
+            <Box {...mock.parentProps}>
+              {this._makeStoreWrapper(component)}
+            </Box>
           </Box>
-        </Box>
+        </NativeScrollView>
       </Box>
     )
   }


### PR DESCRIPTION
I removed scroll view parent in dumb sheet so that it will be obvious when a view won't fit on a smaller Android or iPhone SE.
https://github.com/keybase/client/pull/6824/files

We need to add default flex: 1 otherwise things get scrunched.

The dumb sheet view on iPhone 7 simulator shows view height as if it were iPhone SE.
So if anything is clipped at bottom there it will be clipped on iPhone SE and should be fixed.
This is why it was good to remove ScrollView parent in dumb sheet container.