### PR TITLE
Fix scrollview on StandardScreen

### DIFF
--- a/shared/common-adapters/standard-screen.native.js
+++ b/shared/common-adapters/standard-screen.native.js
@@ -14,7 +14,7 @@ const StandardScreen = (props: Props) => {
         {!!props.onClose && <Text type='BodyBig' style={{...styleClose, ...props.styleClose}} onClick={props.onClose}>Cancel</Text>}
         {!!props.onBack && <Icon type='iconfont-back' style={{...styleClose, ...backArrowStyle, ...props.styleBack}} onClick={props.onBack} />}
       </Box>}
-      <NativeScrollView style={styleScrollContainer} contentContainerStyle={styleScrollContainer}>
+      <NativeScrollView>
         {!!props.notification &&
           <Box style={{...styleBanner(props.notification.type), ...props.styleBanner}}>
             {typeof props.notification.message === 'string' ? <Text style={styleBannerText} type='BodySemibold'>{props.notification.message}</Text> : props.notification.message}
@@ -64,10 +64,6 @@ const styleBanner = (type) => ({
 const styleBannerText = {
   color: globalColors.white,
   textAlign: 'center',
-}
-
-const styleScrollContainer = {
-  flex: 1,
 }
 
 const styleContentContainer = (isBannerShowing: boolean) => ({

--- a/shared/profile/post-proof.native.js
+++ b/shared/profile/post-proof.native.js
@@ -77,6 +77,7 @@ const styleProofAction = {
 const styleContinueButton = {
   ...globalStyles.flexBoxRow,
   marginTop: globalMargins.small,
+  marginBottom: globalMargins.small,
 }
 
 export default PostProof


### PR DESCRIPTION
NativeScrollView doesn't need to have these `flex: 1` passed in. It messes up ability for content to be scrolled.

Tested on both iPhone and Android.

For example, fixes this view, which was unable to scroll down to button before this change:
![2017-05-04 at 12 36 pm](https://cloud.githubusercontent.com/assets/2669/25721818/b5b1f220-30c6-11e7-9953-1fe529fbda47.png)
