### PR TITLE
Remove padding from container into children (BackButton)

### DIFF
--- a/shared/chat/conversation/header/index.native.js
+++ b/shared/chat/conversation/header/index.native.js
@@ -7,8 +7,8 @@ import type {Props} from '.'
 
 const ConversationHeader = ({muted, onBack, onOpenFolder, onShowProfile, onToggleSidePanel, sidePanelOpen, users}: Props) => (
   <Box style={containerStyle}>
-    <BackButton title={null} onClick={onBack} iconStyle={{color: globalColors.blue}} textStyle={{color: globalColors.blue}} style={{flexShrink: 0}} />
-    <Box style={{...globalStyles.flexBoxRow, justifyContent: 'center', flex: 1, marginTop: 2}}>
+    <BackButton title={null} onClick={onBack} iconStyle={{color: globalColors.blue}} textStyle={{color: globalColors.blue}} style={{flexShrink: 0, padding: globalMargins.tiny}} />
+    <Box style={{...globalStyles.flexBoxRow, justifyContent: 'center', flex: 1, marginTop: 2, padding: globalMargins.tiny}}>
       <Usernames
         colorFollowing={true}
         inline={false}
@@ -19,7 +19,7 @@ const ConversationHeader = ({muted, onBack, onOpenFolder, onShowProfile, onToggl
         onUsernameClicked={onShowProfile} />
       {muted && <Icon type='iconfont-shh' style={{...styleCenter, ...styleLeft, color: globalColors.black_20, fontSize: 22}} />}
     </Box>
-    <Icon type={sidePanelOpen ? 'iconfont-close' : 'iconfont-info'} style={{...styleLeft, flexShrink: 0, padding: globalMargins.xtiny, fontSize: 21}} onClick={onToggleSidePanel} />
+    <Icon type={sidePanelOpen ? 'iconfont-close' : 'iconfont-info'} style={{...styleLeft, flexShrink: 0, padding: globalMargins.tiny, fontSize: 21}} onClick={onToggleSidePanel} />
   </Box>
 )
 
@@ -28,7 +28,6 @@ const containerStyle = {
   alignItems: 'flex-start',
   justifyContent: 'flex-start',
   minHeight: 32,
-  padding: globalMargins.tiny,
 }
 
 const styleCenter = {


### PR DESCRIPTION
Move padding from container into children. This allows the `BackButton` to have hit area which is as large as header itself (minHeight: 32).

Before the padding was on parent and was causing smaller hit area which made pressing back harder.

https://keybase.atlassian.net/browse/DESKTOP-3626
