### PR TITLE
set directory permissions recursively

### DIFF
--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -45,6 +45,22 @@ const BOOL isDebug = NO;
   return success;
 }
 
+- (void) setDirectoryAttributesRecursively:(NSString*) path attributes:(NSDictionary*)attributes
+{
+  NSFileManager* fm = [NSFileManager defaultManager];
+  NSArray *subPaths = [fm subpathsAtPath:path];
+  [fm setAttributes:attributes ofItemAtPath:path error:nil];
+  for (NSString *aPath in subPaths) {
+    BOOL isDirectory;
+    [fm fileExistsAtPath:aPath isDirectory:&isDirectory];
+    if (isDirectory) {
+      [self setDirectoryAttributesRecursively:aPath attributes:attributes];
+    } else {
+      [fm setAttributes:attributes ofItemAtPath:aPath error:nil];
+    }
+  }
+}
+
 - (void) createBackgroundReadableDirectory:(NSString*) path
 {
   NSFileManager* fm = [NSFileManager defaultManager];
@@ -55,7 +71,7 @@ const BOOL isDebug = NO;
   [fm createDirectoryAtPath:path withIntermediateDirectories:YES
                  attributes:noProt
                       error:nil];
-  [fm setAttributes:noProt ofItemAtPath:path error:nil];
+  [self setDirectoryAttributesRecursively:path attributes:noProt];
 }
 
 - (void) setupGo


### PR DESCRIPTION
Point of this is to pick up all the files with the different permissions, it doesn't appear that `setAttributes` does this. I noticed I'd get random permission errors on some files inside LevelDB, but with this change that seems to go away. Let me know what you think.