### PR TITLE
only set mark as read if we have focus

### DIFF
--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -301,6 +301,7 @@ function * _loadMoreMessages (action: Constants.LoadMoreMessages): SagaGenerator
 
   yield put(Creators.loadingMessages(conversationIDKey, true))
 
+  const appFocused = yield select(Shared.focusedSelector)
   const yourName = yield select(usernameSelector)
   const yourDeviceName = yield select(Shared.devicenameSelector)
 
@@ -342,7 +343,7 @@ function * _loadMoreMessages (action: Constants.LoadMoreMessages): SagaGenerator
       },
       query: {
         disableResolveSupersedes: false,
-        markAsRead: true,
+        markAsRead: appFocused,
         messageTypes,
       },
     },

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -301,7 +301,6 @@ function * _loadMoreMessages (action: Constants.LoadMoreMessages): SagaGenerator
 
   yield put(Creators.loadingMessages(conversationIDKey, true))
 
-  const appFocused = yield select(Shared.focusedSelector)
   const yourName = yield select(usernameSelector)
   const yourDeviceName = yield select(Shared.devicenameSelector)
 
@@ -327,6 +326,7 @@ function * _loadMoreMessages (action: Constants.LoadMoreMessages): SagaGenerator
     yield put(Creators.prependMessages(conversationIDKey, newMessages, !pagination.last, pagination.next))
   }
 
+  const selectedConversationIDKeyPre = yield select(Constants.getSelectedConversation)
   const loadThreadChanMap = ChatTypes.localGetThreadNonblockRpcChannelMap([
     'chat.1.chatUi.chatThreadCached',
     'chat.1.chatUi.chatThreadFull',
@@ -343,7 +343,7 @@ function * _loadMoreMessages (action: Constants.LoadMoreMessages): SagaGenerator
       },
       query: {
         disableResolveSupersedes: false,
-        markAsRead: appFocused,
+        markAsRead: appFocused && selectedConversationIDKeyPre == conversationIDKey,
         messageTypes,
       },
     },
@@ -825,7 +825,7 @@ function * _markThreadsStale (action: Constants.MarkThreadsStale): SagaGenerator
 
   // Selected is stale?
   const selectedConversation = yield select(Constants.getSelectedConversation)
-  if (!selectedConversation) {
+  if (!(selectedConversation && convIDs.includes(selectedConversation))) {
     return
   }
   yield put(Creators.clearMessages(selectedConversation))


### PR DESCRIPTION
It seems if we call try to do a `GetThreadNonblock` in the background, we could mark a thread as read. Only set `markAsRead` if we are focused.