### PR TITLE
Upgrade react-navigation to beta.9

### DIFF
--- a/shared/libs/flow-interface.js.flow
+++ b/shared/libs/flow-interface.js.flow
@@ -21,6 +21,7 @@ declare module 'react-native-android-permissions' { declare var exports: any; }
 declare module 'react-native-camera' { declare var exports: any; }
 declare module 'react-native/Libraries/CustomComponents/Navigator/NavigatorNavigationBarStylesIOS' { declare var exports: any; }
 declare module 'react-navigation' { declare var exports: any; }
+declare module 'react-navigation/lib/views/CardStackTransitioner' { declare var exports: any; }
 declare module 'react-redux' { declare var exports: any; }
 declare module 'react-tap-event-plugin' { declare var exports: any; }
 declare module 'redux' { declare var exports: any; }

--- a/shared/nav.native.js
+++ b/shared/nav.native.js
@@ -6,7 +6,8 @@ import {compose, lifecycle} from 'recompose'
 import TabBar, {tabBarHeight} from './tab-bar/index.render.native'
 import {Box, NativeKeyboard, NativeKeyboardAvoidingView} from './common-adapters/index.native'
 import {Dimensions, StatusBar} from 'react-native'
-import {CardStack, NavigationActions} from 'react-navigation'
+import {NavigationActions} from 'react-navigation'
+import CardStackTransitioner from 'react-navigation/lib/views/CardStackTransitioner'
 import {chatTab, loginTab} from './constants/tabs'
 import {connect} from 'react-redux'
 import {globalColors, globalStyles, statusBarHeight} from './styles/index.native'
@@ -22,7 +23,11 @@ import type {RouteProps} from './route-tree/render-route'
 type OwnProps = RouteProps<{}, {}>
 
 class CardStackShim extends Component {
-  getScreenConfig = () => null
+  getScreenOptions = () => ({})
+  getStateForAction = () => ({})
+  getActionForPathAndParams = () => ({})
+  getPathAndParamsForState = () => ({})
+  getComponentForState = () => ({})
 
   getComponentForRouteName = () => this.RenderRouteShim
 
@@ -49,10 +54,13 @@ class CardStackShim extends Component {
         }).toArray(),
       },
       dispatch: this._dispatchShim,
+      navigate: () => {},
+      goBack: () => {},
+      setParams: () => {},
     }
 
     return (
-      <CardStack
+      <CardStackTransitioner
         navigation={navigation}
         router={this}
         headerMode='none'

--- a/shared/package.json
+++ b/shared/package.json
@@ -80,7 +80,7 @@
     "react-native-fetch-blob": "0.10.4",
     "react-native-image-picker": "0.25.7",
     "react-native-push-notification": "git://github.com/keybase/react-native-push-notification#eedae53f4346223b5aee60ef2702ecc47a01fcd2",
-    "react-navigation": "1.0.0-beta.7",
+    "react-navigation": "1.0.0-beta.9",
     "react-redux": "5.0.3",
     "react-tap-event-plugin": "2.0.1",
     "react-virtualized": "9.7.3",

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -5597,7 +5597,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4:
+prop-types@^15.5.4, prop-types@^15.5.8:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
@@ -5824,15 +5824,15 @@ react-native-dismiss-keyboard@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-native-dismiss-keyboard/-/react-native-dismiss-keyboard-1.0.0.tgz#32886242b3f2317e121f3aeb9b0a585e2b879b49"
 
-react-native-drawer-layout-polyfill@^1.0.4:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-drawer-layout-polyfill/-/react-native-drawer-layout-polyfill-1.3.0.tgz#50ea3f1dceed360b06f24a33b5ef3701d5c1417a"
+react-native-drawer-layout-polyfill@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-drawer-layout-polyfill/-/react-native-drawer-layout-polyfill-1.2.0.tgz#0d77bd3af8964ffe7fd0f1f6550d6be328a5b567"
   dependencies:
-    react-native-drawer-layout "1.3.0"
+    react-native-drawer-layout "1.2.0"
 
-react-native-drawer-layout@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-drawer-layout/-/react-native-drawer-layout-1.3.0.tgz#3f9942c4c57e18bfe947a1a9b624365c91914280"
+react-native-drawer-layout@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-drawer-layout/-/react-native-drawer-layout-1.2.0.tgz#ae274ee17fadce58d9d7ecef4797d9fad672af74"
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
@@ -5851,9 +5851,11 @@ react-native-image-picker@0.25.7:
   version "2.2.1"
   resolved "git://github.com/keybase/react-native-push-notification#eedae53f4346223b5aee60ef2702ecc47a01fcd2"
 
-react-native-tab-view@^0.0.57:
-  version "0.0.57"
-  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.57.tgz#715e2ea4100fa50168e134df3947dd76ebd55743"
+react-native-tab-view@^0.0.61:
+  version "0.0.61"
+  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.61.tgz#9f5446c9ad33158b87f0bccf5004fbff79ca1f92"
+  dependencies:
+    prop-types "^15.5.8"
 
 react-native@0.42.3:
   version "0.42.3"
@@ -5935,16 +5937,17 @@ react-native@0.42.3:
     xmldoc "^0.4.0"
     yargs "^6.4.0"
 
-react-navigation@1.0.0-beta.7:
-  version "1.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-1.0.0-beta.7.tgz#acd89a01903ef0d1335f1ff364d1dbe67bc70039"
+react-navigation@1.0.0-beta.9:
+  version "1.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-1.0.0-beta.9.tgz#9fb1f8e4d15cee70cc8b5d58719a986ca443664d"
   dependencies:
     clamp "^1.0.1"
     fbjs "^0.8.5"
     hoist-non-react-statics "^1.2.0"
     path-to-regexp "^1.7.0"
-    react-native-drawer-layout-polyfill "^1.0.4"
-    react-native-tab-view "^0.0.57"
+    prop-types "^15.5.8"
+    react-native-drawer-layout-polyfill "1.2.0"
+    react-native-tab-view "^0.0.61"
 
 react-proxy@^1.1.7:
   version "1.1.8"


### PR DESCRIPTION
Lots more shim functions required to prevent PropTypes errors, unfortunately. We should explore implementing an integration without a shim in the future, but keeping the current approach was the quickest upgrade path.