### PR TITLE
Preserve on-screen keyboard when performing a Chat edit

### DIFF
--- a/shared/chat/routes.native.js
+++ b/shared/chat/routes.native.js
@@ -31,7 +31,7 @@ const conversationRoute = new RouteDefNode({
     },
     messageAction: {
       component: MessagePopup,
-      tags: {layerOnTop: true},
+      tags: {keepKeyboard: true, layerOnTop: true},
     },
     showBlockConversationDialog: {
       component: BlockConversationWarning,

--- a/shared/chat/routes.native.js
+++ b/shared/chat/routes.native.js
@@ -31,7 +31,7 @@ const conversationRoute = new RouteDefNode({
     },
     messageAction: {
       component: MessagePopup,
-      tags: {keepKeyboard: true, layerOnTop: true},
+      tags: {keepKeyboardOnLeave: true, layerOnTop: true},
     },
     showBlockConversationDialog: {
       component: BlockConversationWarning,

--- a/shared/nav.native.js
+++ b/shared/nav.native.js
@@ -227,8 +227,8 @@ export default compose(
     componentWillReceiveProps (nextProps) {
       const nextPath = nextProps.routeStack.last().path
       const curPath = this.props.routeStack.last().path
-      const lastTags = this.props.routeStack.last().tags
-      if (!nextPath.equals(curPath) && !lastTags.keepKeyboard) {
+      const curTags = this.props.routeStack.last().tags
+      if (!nextPath.equals(curPath) && !curTags.keepKeyboardOnLeave) {
         NativeKeyboard.dismiss()
       } else if (this.props.hideKeyboard !== nextProps.hideKeyboard) {
         NativeKeyboard.dismiss()

--- a/shared/nav.native.js
+++ b/shared/nav.native.js
@@ -227,7 +227,8 @@ export default compose(
     componentWillReceiveProps (nextProps) {
       const nextPath = nextProps.routeStack.last().path
       const curPath = this.props.routeStack.last().path
-      if (!nextPath.equals(curPath)) {
+      const lastTags = this.props.routeStack.last().tags
+      if (!nextPath.equals(curPath) && !lastTags.keepKeyboard) {
         NativeKeyboard.dismiss()
       } else if (this.props.hideKeyboard !== nextProps.hideKeyboard) {
         NativeKeyboard.dismiss()

--- a/shared/route-tree/index.js
+++ b/shared/route-tree/index.js
@@ -12,7 +12,7 @@ type LeafTagsParams = {
   showStatusBarDarkContent: boolean,
   hideStatusBar: boolean,
   fullscreen: boolean,
-  keepKeyboard: boolean,
+  keepKeyboardOnLeave: boolean,
 }
 
 export const LeafTags: (spec?: LeafTagsParams) => LeafTagsParams & I.Record<LeafTagsParams> = I.Record({
@@ -23,7 +23,7 @@ export const LeafTags: (spec?: LeafTagsParams) => LeafTagsParams & I.Record<Leaf
   hideStatusBar: false,
   showStatusBarDarkContent: false,
   fullscreen: false,
-  keepKeyboard: false,
+  keepKeyboardOnLeave: false,
 })
 
 const _RouteDefNode = I.Record({

--- a/shared/route-tree/index.js
+++ b/shared/route-tree/index.js
@@ -12,6 +12,7 @@ type LeafTagsParams = {
   showStatusBarDarkContent: boolean,
   hideStatusBar: boolean,
   fullscreen: boolean,
+  keepKeyboard: boolean,
 }
 
 export const LeafTags: (spec?: LeafTagsParams) => LeafTagsParams & I.Record<LeafTagsParams> = I.Record({
@@ -22,6 +23,7 @@ export const LeafTags: (spec?: LeafTagsParams) => LeafTagsParams & I.Record<Leaf
   hideStatusBar: false,
   showStatusBarDarkContent: false,
   fullscreen: false,
+  keepKeyboard: false,
 })
 
 const _RouteDefNode = I.Record({


### PR DESCRIPTION
@keybase/react-hackers 

We're hitting weird behavior when trying to edit Chat messages:

* you choose Edit from the message popup
* the keyboard appears in editing mode in the conversation view very briefly
* the keyboard goes away
* editing mode disables itself

It's caused by the "dismiss keyboard on route change" PR.  You wouldn't expect that to cause this, because you'd think that the keyboard doesn't *appear* until after the route change has finished, making the dismiss on route change a no-op.  But it does cause this.

Rather than try to fix apparent asynchrony around this stuff and the NativeKeyboard.dismiss() native code, let's just tell the router not to dismiss the keyboard if the previous route asks it not to for now.