### PR TITLE
Fix orange line disappearing leaving a gap

### DIFF
--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -100,7 +100,10 @@ export default compose(
   }),
   lifecycle({
     componentDidUpdate: function (prevProps: Props & {_editedCount: number}) {
-      if (this.props.measure && this.props._editedCount !== prevProps._editedCount) {
+      if (this.props.measure &&
+        (this.props._editedCount !== prevProps._editedCount) ||
+        (this.props.isFirstNewMessage !== prevProps.isFirstNewMessage)
+      ) {
         this.props.measure()
       }
     },


### PR DESCRIPTION
When the orange line changes the size changes so we should re-measure

@keybase/react-hackers 