### PR TITLE
go-crypto revendor

### DIFF
--- a/go/vendor/github.com/keybase/go-crypto/curve25519/curve_impl.go
+++ b/go/vendor/github.com/keybase/go-crypto/curve25519/curve_impl.go
@@ -91,10 +91,10 @@ func initCv25519() {
 	// Some code relies on these parameters being available for
 	// checking Curve coordinate length. They should not be used
 	// directly for any calculations.
-	cv25519.P, _ = new(big.Int).SetString("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed", 16)
-	cv25519.N, _ = new(big.Int).SetString("1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed", 16)
-	cv25519.Gx, _ = new(big.Int).SetString("9", 16)
-	cv25519.Gy, _ = new(big.Int).SetString("20ae19a1b8a086b4e01edd2c7748d14c923d4d7e6d7c61b229e9c5a27eced3d9", 16)
+	cv25519.P, _ = new (big.Int).SetString("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed", 16)
+	cv25519.N, _ = new (big.Int).SetString("1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed", 16)
+	cv25519.Gx, _ = new (big.Int).SetString("9", 16)
+	cv25519.Gy, _ = new (big.Int).SetString("20ae19a1b8a086b4e01edd2c7748d14c923d4d7e6d7c61b229e9c5a27eced3d9", 16)
 	cv25519.BitSize = 256
 }
 

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -171,92 +171,92 @@
 		{
 			"checksumSHA1": "VJk3rOWfxEV9Ilig5lgzH1qg8Ss=",
 			"path": "github.com/keybase/go-crypto/brainpool",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
 			"checksumSHA1": "rnRjEJs5luF+DIXp2J6LFcQk8Gg=",
 			"path": "github.com/keybase/go-crypto/cast5",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
 			"checksumSHA1": "F5++ZQS5Vt7hd6lxPCKTffvph1A=",
 			"path": "github.com/keybase/go-crypto/curve25519",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
 			"checksumSHA1": "IvrDXwIixB5yPPbo6tq1/1cSn78=",
 			"path": "github.com/keybase/go-crypto/ed25519",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
 			"checksumSHA1": "4+fslB6pCbplNq4viy6CrOkkY6Y=",
 			"path": "github.com/keybase/go-crypto/ed25519/internal/edwards25519",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
 			"checksumSHA1": "5E4DLEAVDwFt//h5K23zHP1qCew=",
 			"path": "github.com/keybase/go-crypto/openpgp",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
-			"checksumSHA1": "y61I7+hCekP1Rk0qxgUQ+iozXak=",
+			"checksumSHA1": "VJxMm3tHSqWB9yKM8b4AoTvahIY=",
 			"path": "github.com/keybase/go-crypto/openpgp/armor",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
 			"checksumSHA1": "cTboJNAg/so2wzlf6HscarfPlDE=",
 			"path": "github.com/keybase/go-crypto/openpgp/clearsign",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
 			"checksumSHA1": "nWhmwjBJqPSvkCWqaap2Z9EiS1k=",
 			"path": "github.com/keybase/go-crypto/openpgp/ecdh",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
 			"checksumSHA1": "uxXG9IC/XF8jwwvZUbW65+x8/+M=",
 			"path": "github.com/keybase/go-crypto/openpgp/elgamal",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
 			"checksumSHA1": "EyUf82Yknzc75m8RcA21CNQINw0=",
 			"path": "github.com/keybase/go-crypto/openpgp/errors",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
-			"checksumSHA1": "4Zdz92qXEB6rPFdkYBiqmHFce0A=",
+			"checksumSHA1": "CXTLNDL5s+SONDJdwuI3kRFGyBk=",
 			"path": "github.com/keybase/go-crypto/openpgp/packet",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
 			"checksumSHA1": "BGDxg1Xtsz0DSPzdQGJLLQqfYc8=",
 			"path": "github.com/keybase/go-crypto/openpgp/s2k",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
 			"checksumSHA1": "rE3pp7b3gfcmBregzpIvN5IdFhY=",
 			"path": "github.com/keybase/go-crypto/rsa",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
 			"checksumSHA1": "orAH0wZ270S0Xef2B3DMnQFC+MI=",
 			"path": "github.com/keybase/go-crypto/ssh/terminal",
-			"revision": "0ee3e17034decab4941145296c0b0f4def213a7b",
-			"revisionTime": "2017-04-19T18:45:05Z"
+			"revision": "13107bbcdf2f5e2862f7b1b005335f8afca30a24",
+			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
 			"checksumSHA1": "VJXG0sarqZdiW3yV0WdtOMv3aRo=",


### PR DESCRIPTION
notably fixes:
`keybase id kid_icarus`
`keybase id samrushing`