### PR TITLE
Include non-truncated error in details view of global error

### DIFF
--- a/shared/global-errors/index.native.js
+++ b/shared/global-errors/index.native.js
@@ -95,7 +95,7 @@ class GlobalError extends Component<void, Props, State> {
           </Box>
         </NativeTouchableWithoutFeedback>
         <NativeScrollView>
-          <Text type='BodySmall' style={detailStyle}>{details}</Text>
+          <Text type='BodySmall' style={detailStyle}>{this.props.error && this.props.error.message}{'\n\n'}{details}</Text>
         </NativeScrollView>
       </Box>
     )


### PR DESCRIPTION
Include the whole error title in the expanded view so we can see more details

@keybase/react-hackers @cjb 