### PR TITLE
timestamps again

### DIFF
--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -123,21 +123,10 @@ function * postMessage (action: Constants.PostMessage): SagaGenerator<any, any> 
       you: author,
     }
 
-    // Time to decide: should we add a timestamp before our new message?
-    const conversationState = yield select(Shared.conversationStateSelector, conversationIDKey)
-    let messages = []
-    if (conversationState && conversationState.messages !== null && conversationState.messages.size > 0) {
-      const timestamp = Shared.maybeAddTimestamp(conversationIDKey, message, conversationState.messages.toArray(), conversationState.messages.size - 1)
-      if (timestamp !== null) {
-        messages.push(timestamp)
-      }
-    }
-
-    messages.push(message)
     const selectedConversation = yield select(Constants.getSelectedConversation)
     const appFocused = yield select(Shared.focusedSelector)
 
-    yield put(Creators.appendMessages(conversationIDKey, conversationIDKey === selectedConversation, appFocused, messages))
+    yield put(Creators.appendMessages(conversationIDKey, conversationIDKey === selectedConversation, appFocused, [message]))
     if (hasPendingFailure) {
       yield put(Creators.removePendingFailure(outboxID))
     }

--- a/shared/chat/conversation/list/index.desktop.js
+++ b/shared/chat/conversation/list/index.desktop.js
@@ -72,6 +72,7 @@ class BaseList extends Component<void, Props, State> {
       // Force the grid to throw away its local index based cache. There might be a lighterway to do this but
       // this seems to fix the overlap problem. The cellCache has correct values inside it but the list itself has
       // another cache from row -> style which is out of sync
+      this._cellCache.clearAll()
       this._list && this._list.Grid && this._list.recomputeRowHeights(0)
     }
   }

--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -41,7 +41,7 @@ const mapStateToProps = (state: TypedState, {messageKey, prevMessageKey}: OwnPro
   const skipMsgHeader = prevMessage && prevMessage.type === 'Text' && prevMessage.author === author
 
   const firstMessageEver = !prevMessage
-  const firstLegitMessage = prevMessage && Constants.messageKeyValue(prevMessage.key) === '1'
+  const firstVisibleMessage = prevMessage && Constants.messageKeyValue(prevMessage.key) === '1'
   const oldEnough = (
       prevMessage &&
       prevMessage.timestamp &&
@@ -49,7 +49,7 @@ const mapStateToProps = (state: TypedState, {messageKey, prevMessageKey}: OwnPro
       message.timestamp - prevMessage.timestamp > Constants.howLongBetweenTimestampsMs
     )
 
-  const timestamp = (firstMessageEver || firstLegitMessage || oldEnough) ? formatTimeForMessages(message.timestamp) : null
+  const timestamp = (firstMessageEver || firstVisibleMessage || oldEnough) ? formatTimeForMessages(message.timestamp) : null
   const includeHeader = isFirstNewMessage || !skipMsgHeader
   const isEditing = message === Constants.getEditingMessage(state)
 
@@ -114,12 +114,12 @@ export default compose(
   }),
   lifecycle({
     componentDidUpdate: function (prevProps: Props & {_editedCount: number}) {
-      if (this.props.measure && (
+      if (
         (this.props._editedCount !== prevProps._editedCount) ||
         (this.props.isFirstNewMessage !== prevProps.isFirstNewMessage) ||
         (this.props.timestamp !== prevProps.timestamp)
-      )) {
-        this.props.measure()
+      ) {
+        this.props.measure && this.props.measure()
       }
     },
   })

--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -114,12 +114,6 @@ export default compose(
   }),
   lifecycle({
     componentDidUpdate: function (prevProps: Props & {_editedCount: number}) {
-      if (this.props.messageKey === '0000a59283d07a54cf4be77e760ecc2d7306f4aa07c8d472444456f22311dded:messageIDText:1226') {
-        console.log(`aaa1 ${this.props.messageKey} ${prevProps.messageKey}`)
-      }
-      if (prevProps.messageKey === '0000a59283d07a54cf4be77e760ecc2d7306f4aa07c8d472444456f22311dded:messageIDText:1226') {
-        console.log(`aaa2 ${this.props.messageKey} ${prevProps.messageKey}`)
-      }
       if (this.props.measure && (
         (this.props._editedCount !== prevProps._editedCount) ||
         (this.props.isFirstNewMessage !== prevProps.isFirstNewMessage) ||

--- a/shared/chat/conversation/messages/wrapper/container.js.flow
+++ b/shared/chat/conversation/messages/wrapper/container.js.flow
@@ -26,6 +26,7 @@ export type StateProps = {|
   isFollowing: boolean,
   isRevoked: boolean,
   isYou: boolean,
+  timestamp: ?string,
 |}
 
 export type DispatchProps = {|

--- a/shared/chat/conversation/messages/wrapper/index.js.flow
+++ b/shared/chat/conversation/messages/wrapper/index.js.flow
@@ -18,6 +18,7 @@ export type Props = {|
   onAction: (event: any) => void,
   onRetry: () => void,
   onShowEditor: (event: any) => void,
+  timestamp: ?string,
 |}
 
 export default class Wrapper extends Component<void, Props, void> {}

--- a/shared/chat/conversation/messages/wrapper/shared.js
+++ b/shared/chat/conversation/messages/wrapper/shared.js
@@ -4,6 +4,7 @@ import {Avatar, Icon, Text, Box} from '../../../../common-adapters'
 import {globalStyles, globalMargins, globalColors} from '../../../../styles'
 import {isMobile} from '../../../../constants/platform'
 import {marginColor, colorForAuthor} from '../shared'
+import Timestamp from '../timestamp'
 
 import type {Props} from '.'
 
@@ -49,20 +50,23 @@ const Failure = ({failureDescription, onShowEditor, onRetry}) => {
 }
 
 const MessageWrapper = (props: Props) => (
-  <Box style={{..._flexOneRow, ...(props.isFirstNewMessage ? _stylesFirstNewMessage : null), ...(props.isSelected ? _stylesSelected : null)}}>
-    <LeftMarker author={props.author} isYou={props.isYou} isFollowing={props.isFollowing} isBroken={props.isBroken} />
-    <Box style={props.includeHeader ? _rightSideWithHeaderStyle : _rightSideNoHeaderStyle}>
-      <UserAvatar author={props.author} showImage={props.includeHeader} />
-      <Box style={_flexOneColumn} className='message-wrapper'>
-        <Username includeHeader={props.includeHeader} author={props.author} isYou={props.isYou} isFollowing={props.isFollowing} isBroken={props.isBroken} />
-        <Box style={_textContainerStyle} className='message' data-message-key={props.messageKey}>
-          <Box style={_flexOneColumn}>
-            <props.innerClass messageKey={props.messageKey} measure={props.measure} onAction={props.onAction} />
-            <EditedMark isEdited={props.isEdited} />
+  <Box style={globalStyles.flexBoxColumn}>
+    {props.timestamp && <Timestamp timestamp={props.timestamp} />}
+    <Box style={{..._flexOneRow, ...(props.isFirstNewMessage ? _stylesFirstNewMessage : null), ...(props.isSelected ? _stylesSelected : null)}}>
+      <LeftMarker author={props.author} isYou={props.isYou} isFollowing={props.isFollowing} isBroken={props.isBroken} />
+      <Box style={props.includeHeader ? _rightSideWithHeaderStyle : _rightSideNoHeaderStyle}>
+        <UserAvatar author={props.author} showImage={props.includeHeader} />
+        <Box style={_flexOneColumn} className='message-wrapper'>
+          <Username includeHeader={props.includeHeader} author={props.author} isYou={props.isYou} isFollowing={props.isFollowing} isBroken={props.isBroken} />
+          <Box style={_textContainerStyle} className='message' data-message-key={props.messageKey}>
+            <Box style={_flexOneColumn}>
+              <props.innerClass messageKey={props.messageKey} measure={props.measure} onAction={props.onAction} />
+              <EditedMark isEdited={props.isEdited} />
+            </Box>
+            <ActionButton isRevoked={props.isRevoked} onAction={props.onAction} />
           </Box>
-          <ActionButton isRevoked={props.isRevoked} onAction={props.onAction} />
+          <Failure failureDescription={props.failureDescription} onRetry={props.onRetry} onShowEditor={props.onShowEditor} />
         </Box>
-        <Failure failureDescription={props.failureDescription} onRetry={props.onRetry} onShowEditor={props.onShowEditor} />
       </Box>
     </Box>
   </Box>


### PR DESCRIPTION
tldr; This removes the timestamps entirely from the store and instead does it during rendering time

----------------------------------------------------

Ok, so
I wanted to investigate this as I was worried this was a list-rendering problem with the recent react-virtualized changes. It wasn't but I was thinking i'd spend < 1 hr on changing how this works.

I _think_ this is simpler and better.

Instead of injecting this (in 3 places) into the store, we instead just defer this until we draw. The Message wrappers already get the previous message to do things like the avatar rendering , so instead of just checking that we also check the timestamp of the item its rendering ahead of this. 
This is advantageous as its 1:1 connected to what we're drawing which is something we mostly had to keep in sync by checking the types (filtering out invisible messages to ignore in our calculations).

Additionally this handles when we load up and discover that the timestamp we previously put in there actually needs to be moved up further (like the top most message really was like 3 seconds after the new incoming messages we just loaded).

This also exposed a problem with clearing out a cache for cell heights on the desktop side, likely fixing some other 'gap' drawing issues.

