### PR TITLE
dont make calls w/o usernames

### DIFF
--- a/shared/util/pictures.js
+++ b/shared/util/pictures.js
@@ -41,6 +41,10 @@ const _getUserImages = throttle(() => {
     }
   })
 
+  if (!good.length) {
+    return
+  }
+
   apiserverGetRpc({
     callback: (error, response) => {
       if (error) {


### PR DESCRIPTION
@keybase/react-hackers noticed this when looking at some logs. if we don't have any valid usernames lets not make an empty api call