### PR TITLE
browser: Minor fix for 1.6

### DIFF
--- a/browser/js/content.js
+++ b/browser/js/content.js
@@ -458,7 +458,7 @@ function findParentByClass(el, className) {
 
 // Convert a user input into a string that is safe for inlining into HTML.
 function safeHTML(s) {
-  if (s===undefined) return "";
+  if (!s) return "";
   return s.replace(/[&'"<>\/]/g, function (c) {
     // Per https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet#RULE_.231_-_HTML_Escape_Before_Inserting_Untrusted_Data_into_HTML_Element_Content
     return {

--- a/browser/manifest.json
+++ b/browser/manifest.json
@@ -2,7 +2,7 @@
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsc0yU3MTDhx+JC23YHwvWo/TD1Pynkdc9QekQ7S3jpl0isgro3I5K0ywANwBsZicIYhVq3OQTzV4jq53YoJSP9OFApMb3yzqzJ/QmcwpGvHjztD6I2zPoglMLnWj12VNqFqJtqVj5tT+/TQJ2MdY4eCQpuPweEwDLsR9mP2mxlpV1iCNzF2T61DAqnLmV8zeyjrwJ1QRZq/qd0lJR5JRI8+xBTTStOy2eQvnf8ngEXq2R+NXNq10MELtTpfAT0NPPS1lUbJwR9AYbm9f4wQWLxpeyl63WlmbBUsInM9jsfccDo0hULa59IWpgTdFVQFMBFlIEIN7St8QpF09OygMNQIDAQAB",
   "name": "Keybase for Reddit",
   "short_name": "Keybase",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "End-to-end encrypted replies on Reddit over Keybase Chat.",
   "icons": {
     "48": "images/icon-keybase-logo-48.png",


### PR DESCRIPTION
Right now the extension errors out when it runs into a deleted comment mid-thread because there is no author value (=== null). This makes the safeHTML check more lenient to short circuit all false-y values.