### PR TITLE
Polyfill Map on Android

### DIFF
--- a/shared/index.android.js
+++ b/shared/index.android.js
@@ -1,8 +1,9 @@
 // @flow
 // React-native tooling assumes this file is here, so we just require our real entry point
 import 'core-js/es6/object'  // required for babel-plugin-transform-builtin-extend in RN Android
-import 'core-js/es6/array'  // required for emoji-mart in RN Android
+import 'core-js/es6/array'   // required for emoji-mart in RN Android
 import 'core-js/es6/string'  // required for emoji-mart in RN Android
+import 'core-js/es6/map'     // required for FlatList in RN Android
 import {load} from './index.native'
 
 load()


### PR DESCRIPTION
@keybase/react-hackers 

We've been seeing a crash on Android when you navigate *away* from the Chat tab:

![screenshot from 2017-05-09 12-36-11](https://cloud.githubusercontent.com/assets/21217/25861885/1c52b87a-34b4-11e7-8ca3-0688ee8ed56c.png)

At first this looked like we were missing a `Symbol.iterator` polyfill, but that's not it -- it's *using* a polyfilled version of Symbol, and trying to emulate it through `@@iterator` on the passed in `nextProps` object.  But despite the code in `FlatList` saying that this object should be a `Map()`:
```js
    const nextItems = new Map(
      viewableIndicesToCheck.map(ii => {
        const viewable = createViewToken(ii, true);
        return [viewable.key, viewable];
      })
    );

    const changed = [];
    for (const [key, viewable] of nextItems) {
```
 .. it shows up as a POJO and doesn't have that method, so we crash trying to use `of` on it.

@chrisnojima pointed me in the right direction by suggesting polyfilling Map instead of Symbol, and sure enough that fixes the crash.

Perhaps we should polyfill much more aggressively on Android if these issues are going to keep coming up.  We had a similar problem with emoji-mart?

(This sort of thing isn't a problem on recent iOS because its JSC has decent native ES6 support.)