### PR TITLE
Fix for 'always seeing securing' race

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -130,6 +130,7 @@ function * onInboxStale (): SagaGenerator<any, any> {
     if (initialConversation) {
       yield put(Creators.setInitialConversation(null))
       yield put(navigateTo([initialConversation], [chatTab]))
+      yield put(Creators.selectConversation(initialConversation, false))
     }
   } finally {
     if (yield cancelled()) {

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -240,9 +240,9 @@ function * _ensureValidSelectedChat (onlyIfNoSelection: boolean, forceSelectOnMo
 }
 
 function * _loadMoreMessages (action: Constants.LoadMoreMessages): SagaGenerator<any, any> {
-  try {
-    const conversationIDKey = action.payload.conversationIDKey
+  const conversationIDKey = action.payload.conversationIDKey
 
+  try {
     if (!conversationIDKey) {
       return
     }
@@ -338,7 +338,6 @@ function * _loadMoreMessages (action: Constants.LoadMoreMessages): SagaGenerator
         incoming.chatThreadFull.response.result()
         yield call(updateThread, incoming.chatThreadFull.params.thread)
       } else if (incoming.finished) {
-
         if (incoming.finished.params.offline) {
           yield put(Creators.threadLoadedOffline(conversationIDKey))
         }


### PR DESCRIPTION
This fixes a problem where you
1. Select a conversation
1. Entirely kill the app
1. Receive an incoming message to that conversation (stale message)
1. Start app
1. Click on Chat tab (will auto load the conversation after some inbox loading)
1. Empty conversation shown

Was a little hard to debug as its very timing related and with debug logging on and debug build it wasn't reproducible once for me.

The fundamental problem was a race where
1. Partial Inbox is loaded
1. Conversation is loaded as an 'initial load' (special case)

The 'normal' flow is we're in the inbox view and we 'select' a message, which loads it. Here we're skipping that. If you load the converation but the inbox load happens after it'll see if there's a selected message and will then load it, but if it happens the other way around (this case) it'll just sit there and not load.

If you scroll the view up /down it'll actually load!

We should make a fix for this kind of thing with our sagas later. I think if we have less specific flows and instead delegate actions and do less work in a single saga i think we can avoid this kind of breakage.
