### PR TITLE
Fix slow android secret store

### DIFF
--- a/go/libkb/secret_store_external.go
+++ b/go/libkb/secret_store_external.go
@@ -67,7 +67,7 @@ var externalKeyStore ExternalKeyStore
 
 var externalKeyStoreMu sync.Mutex
 
-func (s secretStoreAccountName) serviceName() string {
+func (s *secretStoreAccountName) serviceName() string {
 	return s.context.GetStoredSecretServiceName()
 }
 
@@ -87,45 +87,42 @@ func getGlobalExternalKeyStore() ExternalKeyStore {
 type secretStoreAccountName struct {
 	externalKeyStore ExternalKeyStore
 	context          SecretStoreContext
+	setupOnce        sync.Once
 }
 
-var _ SecretStoreAll = secretStoreAccountName{}
-
-func (s secretStoreAccountName) StoreSecret(username NormalizedUsername, secret LKSecFullSecret) (err error) {
-	defer TraceTimed(s.context.GetLog(), "secret_store_external StoreSecret", func() error { return err })()
-	s.context.GetLog().Debug("+ secret_store_exteral StoreSecret SetupKeyStore")
-	s.externalKeyStore.SetupKeyStore(s.serviceName(), string(username))
-	s.context.GetLog().Debug("- secret_store_exteral StoreSecret SetupKeyStore")
-	return s.externalKeyStore.StoreSecret(s.serviceName(), string(username), secret)
-}
-
-func (s secretStoreAccountName) RetrieveSecret(username NormalizedUsername) (sec LKSecFullSecret, err error) {
-	defer TraceTimed(s.context.GetLog(), "secret_store_external RetrieveSecret", func() error { return err })()
-	s.externalKeyStore.SetupKeyStore(s.serviceName(), string(username))
-	return s.externalKeyStore.RetrieveSecret(s.serviceName(), string(username))
-}
-
-func (s secretStoreAccountName) ClearSecret(username NormalizedUsername) (err error) {
-	defer TraceTimed(s.context.GetLog(), "secret_store_external ClearSecret", func() error { return err })()
-	return s.externalKeyStore.ClearSecret(s.serviceName(), string(username))
-}
+var _ SecretStoreAll = &secretStoreAccountName{}
 
 func NewSecretStoreAll(g *GlobalContext) SecretStoreAll {
 	externalKeyStore := getGlobalExternalKeyStore()
 	if externalKeyStore == nil {
 		return nil
 	}
-	return secretStoreAccountName{
+	s := &secretStoreAccountName{
 		externalKeyStore: externalKeyStore,
 		context:          g,
 	}
+	go s.setup()
+	return s
 }
 
-func NewTestSecretStoreAll(c SecretStoreContext, g *GlobalContext) SecretStoreAll {
-	return nil
+func (s *secretStoreAccountName) StoreSecret(username NormalizedUsername, secret LKSecFullSecret) (err error) {
+	defer TraceTimed(s.context.GetLog(), "secret_store_external StoreSecret", func() error { return err })()
+	s.setup()
+	return s.externalKeyStore.StoreSecret(s.serviceName(), string(username), secret)
 }
 
-func (s secretStoreAccountName) GetUsersWithStoredSecrets() ([]string, error) {
+func (s *secretStoreAccountName) RetrieveSecret(username NormalizedUsername) (sec LKSecFullSecret, err error) {
+	defer TraceTimed(s.context.GetLog(), "secret_store_external RetrieveSecret", func() error { return err })()
+	s.setup()
+	return s.externalKeyStore.RetrieveSecret(s.serviceName(), string(username))
+}
+
+func (s *secretStoreAccountName) ClearSecret(username NormalizedUsername) (err error) {
+	defer TraceTimed(s.context.GetLog(), "secret_store_external ClearSecret", func() error { return err })()
+	return s.externalKeyStore.ClearSecret(s.serviceName(), string(username))
+}
+
+func (s *secretStoreAccountName) GetUsersWithStoredSecrets() ([]string, error) {
 	if s.externalKeyStore == nil {
 		return nil, nil
 	}
@@ -139,10 +136,23 @@ func (s secretStoreAccountName) GetUsersWithStoredSecrets() ([]string, error) {
 	return users, err
 }
 
-func (s secretStoreAccountName) GetTerminalPrompt() string {
+func (s *secretStoreAccountName) GetTerminalPrompt() string {
 	return "Store secret in Android's KeyStore?"
 }
 
-func (s secretStoreAccountName) GetApprovalPrompt() string {
+func (s *secretStoreAccountName) GetApprovalPrompt() string {
 	return "Store secret in Android's KeyStore?"
+}
+
+func (s *secretStoreAccountName) setup() {
+	s.setupOnce.Do(func() {
+		s.context.GetLog().Debug("+ secret_store_external:setup")
+		// username not required
+		s.externalKeyStore.SetupKeyStore(s.serviceName(), "")
+		s.context.GetLog().Debug("- secret_store_external:setup")
+	})
+}
+
+func NewTestSecretStoreAll(c SecretStoreContext, g *GlobalContext) SecretStoreAll {
+	return nil
 }

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -415,6 +415,12 @@ func Trace(log logger.Logger, msg string, f func() error) func() {
 	return func() { log.Debug("- %s -> %s", msg, ErrToOk(f())) }
 }
 
+func TraceTimed(log logger.Logger, msg string, f func() error) func() {
+	log.Debug("+ %s", msg)
+	start := time.Now()
+	return func() { log.Debug("- %s -> %s [time=%s]", msg, ErrToOk(f()), time.Since(start)) }
+}
+
 func CTrace(ctx context.Context, log logger.Logger, msg string, f func() error) func() {
 	log.CDebugf(ctx, "+ %s", msg)
 	return func() { log.CDebugf(ctx, "- %s -> %s", msg, ErrToOk(f())) }

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/keystore/KeyStoreHelper.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/keystore/KeyStoreHelper.java
@@ -46,7 +46,7 @@ public class KeyStoreHelper {
               .setCertificateSubject(new X500Principal("CN=" + keyAlias))
               .setKeyValidityStart(Calendar.getInstance().getTime())
               .setKeyValidityEnd(endTime.getTime())
-              .setKeySize(4096)
+              .setKeySize(2048)
               .build();
         } else {
             spec = new KeyPairGeneratorSpec.Builder(ctx)
@@ -56,7 +56,7 @@ public class KeyStoreHelper {
               .setSubject(new X500Principal("CN=" + keyAlias))
               .setStartDate(Calendar.getInstance().getTime())
               .setEndDate(endTime.getTime())
-              .setKeySize(4096)
+              .setKeySize(2048)
               .build();
         }
 


### PR DESCRIPTION
1. set it up when secret store initialized (at service startup)
2. change key size from 4096 -> 2048

cc @chrisnojima can you try this on your nexus 5?  I believe you need to uninstall keybase first to get a clean slate.