### PR TITLE
Add a throttle to the qr scanning

### DIFF
--- a/shared/login/register/code-page/qr/index.android.js
+++ b/shared/login/register/code-page/qr/index.android.js
@@ -5,6 +5,7 @@ import React, {Component} from 'react'
 import type {Props} from './index'
 import {NativeImage, Box, Text} from '../../../../common-adapters/index.native'
 import {globalStyles} from '../../../../styles'
+import {throttle} from 'lodash'
 
 type PermissionStatus = 'granted' | 'denied' | 'never_ask_again'
 
@@ -40,6 +41,10 @@ class QR extends Component<void, Props, State> {
     }
   }
 
+  _onBarCodeRead = throttle(data => {
+    this.props.onBarCodeRead(data)
+  }, 1000)
+
   render () {
     if (this.props.scanning) {
       if (this.state.permissionGranted) {
@@ -48,7 +53,7 @@ class QR extends Component<void, Props, State> {
             style={{...cameraStyle, ...this.props.style}}
             captureAudio={false}
             ref='cam'
-            onBarCodeRead={data => this.props.onBarCodeRead(data)}>
+            onBarCodeRead={this._onBarCodeRead}>
             {this.props.children}
           </Camera>
         )

--- a/shared/login/register/code-page/qr/index.ios.js
+++ b/shared/login/register/code-page/qr/index.ios.js
@@ -4,8 +4,13 @@ import React, {Component} from 'react'
 import type {Props} from './index'
 import {NativeImage, Box} from '../../../../common-adapters/index.native'
 import {globalStyles} from '../../../../styles'
+import {throttle} from 'lodash'
 
 class QR extends Component<void, Props, void> {
+  _onBarCodeRead = throttle(data => {
+    this.props.onBarCodeRead(data)
+  }, 1000)
+
   render () {
     if (this.props.scanning) {
       return (
@@ -13,7 +18,7 @@ class QR extends Component<void, Props, void> {
           style={{...cameraStyle, ...this.props.style}}
           captureAudio={false}
           ref='cam'
-          onBarCodeRead={data => this.props.onBarCodeRead(data)}>
+          onBarCodeRead={this._onBarCodeRead}>
           {this.props.children}
         </Camera>
       )


### PR DESCRIPTION
I noticed in the logs a bunch of store churn due to us sending un-flow-controlled qr codes. we could likely send a prop to tell it we scanned and it shouldn't send anymore, this just makes it scan at a slower rate (likely safest)

@keybase/react-hackers 