### PR TITLE
include header if we show a timestamp

### DIFF
--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -50,7 +50,7 @@ const mapStateToProps = (state: TypedState, {messageKey, prevMessageKey}: OwnPro
     )
 
   const timestamp = (firstMessageEver || firstVisibleMessage || oldEnough) ? formatTimeForMessages(message.timestamp) : null
-  const includeHeader = isFirstNewMessage || !skipMsgHeader
+  const includeHeader = isFirstNewMessage || !skipMsgHeader || !!timestamp
   const isEditing = message === Constants.getEditingMessage(state)
 
   return {


### PR DESCRIPTION
Simple fix. If we show a timestamp cause you're the only one talking, we should also show your avatar/name again

@keybase/react-hackers 
cc: @mmaxim 