### PR TITLE
Don't use LoginState at all in Bootstrap

### DIFF
--- a/go/engine/login_offline.go
+++ b/go/engine/login_offline.go
@@ -67,7 +67,7 @@ func (e *LoginOffline) run(ctx *Context) error {
 		e.G().Log.Debug("LoginOffline: current user has a valid session file")
 
 		// check ActiveDevice cache
-		uid, deviceID, sigKey, encKey := e.G().ActiveDevice.AllFields()
+		uid, deviceID, _, sigKey, encKey := e.G().ActiveDevice.AllFields()
 		if sigKey != nil && encKey != nil {
 			if uid.Equal(a.GetUID()) && deviceID.Eq(a.GetDeviceID()) {
 				// since they match, good to go

--- a/go/engine/login_offline_test.go
+++ b/go/engine/login_offline_test.go
@@ -43,7 +43,7 @@ func TestLoginOffline(t *testing.T) {
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
-	uid, deviceID, skey, ekey := tc.G.ActiveDevice.AllFields()
+	uid, deviceID, deviceName, skey, ekey := tc.G.ActiveDevice.AllFields()
 	if uid.IsNil() {
 		t.Errorf("uid is nil, expected it to exist")
 	}
@@ -53,6 +53,10 @@ func TestLoginOffline(t *testing.T) {
 
 	if deviceID.IsNil() {
 		t.Errorf("deviceID is nil, expected it to exist")
+	}
+
+	if deviceName != defaultDeviceName {
+		t.Errorf("device name: %q, expected %q", deviceName, defaultDeviceName)
 	}
 
 	if skey == nil {
@@ -108,7 +112,7 @@ func TestLoginOfflineDelay(t *testing.T) {
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
-	uid, deviceID, skey, ekey := tc.G.ActiveDevice.AllFields()
+	uid, deviceID, deviceName, skey, ekey := tc.G.ActiveDevice.AllFields()
 	if uid.IsNil() {
 		t.Errorf("uid is nil, expected it to exist")
 	}
@@ -120,16 +124,16 @@ func TestLoginOfflineDelay(t *testing.T) {
 		t.Errorf("deviceID is nil, expected it to exist")
 	}
 
+	if deviceName != defaultDeviceName {
+		t.Errorf("device name: %q, expected %q", deviceName, defaultDeviceName)
+	}
+
 	if skey == nil {
 		t.Errorf("signing key is nil, expected it to exist")
 	}
 
 	if ekey == nil {
 		t.Errorf("encryption key is nil, expected it to exist")
-	}
-
-	if tc.G.ActiveDevice.Name() != defaultDeviceName {
-		t.Errorf("device name: %q, expected %q", tc.G.ActiveDevice.Name(), defaultDeviceName)
 	}
 }
 

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -3188,7 +3188,7 @@ func skipOldGPG(tc libkb.TestContext) {
 }
 
 func assertDeviceKeysCached(tc libkb.TestContext) {
-	_, _, sk, ek := tc.G.ActiveDevice.AllFields()
+	_, _, _, sk, ek := tc.G.ActiveDevice.AllFields()
 	if sk == nil {
 		tc.T.Error("cached signing key nil")
 	}

--- a/go/engine/login_with_paperkey_test.go
+++ b/go/engine/login_with_paperkey_test.go
@@ -191,7 +191,7 @@ func AssertLoggedInLPK(tc *libkb.TestContext, shouldBeLoggedIn bool) {
 }
 
 func AssertDeviceKeysLock(tc *libkb.TestContext, shouldBeUnlocked bool) {
-	_, _, sk, ek := tc.G.ActiveDevice.AllFields()
+	_, _, _, sk, ek := tc.G.ActiveDevice.AllFields()
 
 	if shouldBeUnlocked {
 		require.NotNil(tc.T, sk, "device signing key should be available")

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -100,7 +100,6 @@ func (a *ActiveDevice) internalUpdateUIDDeviceID(acct *Account, uid keybase1.UID
 	if a.uid.IsNil() && a.deviceID.IsNil() {
 		a.uid = uid
 		a.deviceID = deviceID
-
 	} else if a.uid.NotEqual(uid) {
 		return errors.New("ActiveDevice.set uid mismatch")
 	} else if !a.deviceID.Eq(deviceID) {
@@ -182,11 +181,11 @@ func (a *ActiveDevice) KeyByType(t SecretKeyType) (GenericKey, error) {
 
 // AllFields returns all the ActiveDevice fields via one lock for consistency.
 // Safe for use by concurrent goroutines.
-func (a *ActiveDevice) AllFields() (uid keybase1.UID, deviceID keybase1.DeviceID, sigKey GenericKey, encKey GenericKey) {
+func (a *ActiveDevice) AllFields() (uid keybase1.UID, deviceID keybase1.DeviceID, deviceName string, sigKey GenericKey, encKey GenericKey) {
 	a.RLock()
 	defer a.RUnlock()
 
-	return a.uid, a.deviceID, a.signingKey, a.encryptionKey
+	return a.uid, a.deviceID, a.deviceName, a.signingKey, a.encryptionKey
 }
 
 func (a *ActiveDevice) Name() string {

--- a/go/libkb/shared_dh.go
+++ b/go/libkb/shared_dh.go
@@ -151,7 +151,7 @@ func (s *SharedDHKeyring) SyncWithExtras(ctx context.Context, lctx LoginContext,
 
 // `lctx` and `upak` are optional
 func (s *SharedDHKeyring) syncAsConfiguredDevice(ctx context.Context, lctx LoginContext, upak *keybase1.UserPlusAllKeys) (err error) {
-	uid, deviceID, _, activeDecryptionKey := s.G().ActiveDevice.AllFields()
+	uid, deviceID, _, _, activeDecryptionKey := s.G().ActiveDevice.AllFields()
 	if !s.uid.Equal(uid) {
 		return fmt.Errorf("UID changed on SharedDHKeyring")
 	}

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -155,7 +155,7 @@ func (h ConfigHandler) GetExtendedStatus(ctx context.Context, sessionID int) (re
 	}
 
 	// cached device key status
-	_, _, sk, ek := h.G().ActiveDevice.AllFields()
+	_, _, _, sk, ek := h.G().ActiveDevice.AllFields()
 	res.DeviceSigKeyCached = sk != nil
 	res.DeviceEncKeyCached = ek != nil
 


### PR DESCRIPTION
It was only used to run LoggedInProvisioned, whose state
will always be the same as ActiveDevice.Valid().

And it was causing some issues where if the LoginState request
processing was blocked by offline API requests, Bootstrap
returned with no uid, username etc. after LoginState timeout.