### PR TITLE
Fix up mobile signup/login flow styling again

### DIFF
--- a/shared/login/register/paper-key/index.render.native.js
+++ b/shared/login/register/paper-key/index.render.native.js
@@ -11,7 +11,7 @@ class PaperKeyRender extends Component<void, Props, void> {
       <Container
         style={stylesContainer}
         onBack={this.props.onBack}>
-        <Text type='Header' style={stylesHeader}>Type in your paper key:</Text>
+        <Text type='Header'>Type in your paper key:</Text>
         <Icon type='icon-paper-key-48' />
         <Input
           multiline={true}
@@ -26,7 +26,6 @@ class PaperKeyRender extends Component<void, Props, void> {
           type='passwordVisible'
           value={this.props.paperKey ? this.props.paperKey : null} />
         <Button
-          style={stylesButton}
           type='Primary'
           enabled={this.props.paperKey}
           label='Continue'
@@ -43,17 +42,8 @@ const stylesContainer = {
   paddingRight: globalMargins.medium,
 }
 
-const stylesButton = {
-  marginTop: globalMargins.tiny,
-}
-
 const stylesInput = {
   alignSelf: 'stretch',
-}
-
-const stylesHeader = {
-  marginBottom: globalMargins.small,
-  marginTop: globalMargins.small,
 }
 
 export default PaperKeyRender

--- a/shared/login/register/select-other-device/index.render.native.js
+++ b/shared/login/register/select-other-device/index.render.native.js
@@ -47,7 +47,6 @@ const stylesContainer = {
 }
 const stylesHeader = {
   marginBottom: globalMargins.small,
-  marginTop: globalMargins.tiny,
   textAlign: 'center',
 }
 const stylesDevicesContainer = {

--- a/shared/login/register/set-public-name/index.render.native.js
+++ b/shared/login/register/set-public-name/index.render.native.js
@@ -11,7 +11,7 @@ const SetPublicName = ({onBack, onSubmit, onChange, deviceNameError, deviceName,
     <Container
       style={stylesContainer}
       onBack={onBack}>
-      <Text type='Header' style={stylesHeader}>Set a public name for this device:</Text>
+      <Text type='Header'>Set a public name for this device:</Text>
       <Icon type='icon-phone-32' style={stylesIcon} />
       <Input
         autoFocus={true}
@@ -42,13 +42,8 @@ const stylesContainer = {
   marginRight: globalMargins.small,
 }
 
-const stylesHeader = {
-  marginTop: globalMargins.tiny,
-}
-
 const stylesButton = {
-  marginTop: 20,
-  marginBottom: 20,
+  marginTop: globalMargins.tiny,
 }
 
 const stylesInput = {

--- a/shared/login/register/username-or-email/index.render.native.js
+++ b/shared/login/register/username-or-email/index.render.native.js
@@ -3,7 +3,7 @@ import Container from '../../forms/container'
 import React, {Component} from 'react'
 import type {Props} from './index.render'
 import {Input, Button, UserCard} from '../../../common-adapters'
-import {globalColors} from '../../../styles'
+import {globalColors, globalMargins} from '../../../styles'
 
 type State = {usernameOrEmail: string}
 
@@ -30,7 +30,7 @@ class UsernameOrEmailRender extends Component<void, Props, State> {
     return (
       <Container
         style={stylesContainer}
-        outerStyle={{backgroundColor: globalColors.white, padding: 20}}
+        outerStyle={{backgroundColor: globalColors.white}}
         onBack={this.props.onBack}>
         <UserCard style={stylesCard}>
           <Input
@@ -61,8 +61,7 @@ const stylesContainer = {
 }
 const stylesInput = {
   flexGrow: 1,
-  marginTop: 25,
-  marginBottom: 55,
+  marginBottom: globalMargins.small,
 }
 const stylesCard = {
   alignItems: 'stretch',

--- a/shared/login/signup/passphrase/index.render.native.js
+++ b/shared/login/signup/passphrase/index.render.native.js
@@ -36,7 +36,7 @@ const stylesOuter = {
 }
 
 const stylesSecond = {
-  marginTop: globalMargins.medium,
+  marginTop: globalMargins.small,
   marginBottom: globalMargins.small,
 }
 

--- a/shared/login/signup/success/index.render.native.js
+++ b/shared/login/signup/success/index.render.native.js
@@ -29,7 +29,7 @@ class SuccessRender extends Component<void, Props, State> {
 
   render () {
     return (
-      <Container style={{padding: globalMargins.large, flex: 1}}>
+      <Container style={{flex: 1}}>
         <Text type='Header' style={textCenter}>{this.props.title || "Congratulations, you've just joined Keybase!"}</Text>
         <Text type='Body' style={{...textCenter, marginTop: globalMargins.medium}}>Here is your unique paper key, it will allow you to perform important Keybase tasks in the future. This is the only time you'll see this so be sure to write it down.</Text>
 
@@ -48,7 +48,7 @@ class SuccessRender extends Component<void, Props, State> {
         </Box>
 
         <Box style={{flex: 2, justifyContent: 'flex-end'}}>
-          <Button style={buttonStyle}
+          <Button
             disabled={!this.state.checked}
             onClick={this.props.onFinish}
             label='Done'
@@ -62,9 +62,7 @@ class SuccessRender extends Component<void, Props, State> {
 const confirmCheckboxStyle = {
   ...globalStyles.flexBoxRow,
   alignSelf: 'center',
-}
-
-const buttonStyle = {
+  paddingBottom: globalMargins.small,
 }
 
 const textCenter = {
@@ -74,7 +72,7 @@ const textCenter = {
 const paperKeyContainerStyle = {
   alignSelf: 'center',
   marginTop: globalMargins.large,
-  marginBottom: globalMargins.large,
+  marginBottom: globalMargins.medium,
   paddingTop: globalMargins.small,
   paddingBottom: globalMargins.small,
   paddingLeft: globalMargins.small,


### PR DESCRIPTION
@keybase/react-hackers 

The recent headerhoc changes messed up styling on iPhone SE and other small screen phones, e.g. here's how the end of signup looks:

![simulator screen shot may 10 2017 12 13 43 pm](https://cloud.githubusercontent.com/assets/21217/25909544/82dac1d8-357b-11e7-8f5f-bd67d5818ece.png)

(It's not clear the headerhoc should even be on that particular screen, since there's no back button..)

The headerhoc container's taking up more space than the back arrow by itself used to, so this PR just trims margins a little more for now.