### PR TITLE
Fix back button hit area for HeaderHOC

### DIFF
--- a/shared/common-adapters/header-hoc.native.js
+++ b/shared/common-adapters/header-hoc.native.js
@@ -15,8 +15,8 @@ function HeaderHoc<P> (WrappedComponent: ReactClass<P>) {
         <Box style={_titleStyle}>
           <Text type='Header'>{title}</Text>
         </Box>
-        {onCancel && <Text type='BodyBigLink' onClick={onCancel}>Cancel</Text>}
-        {onBack && <BackButton iconStyle={_backButtonIconStyle} onClick={onBack} />}
+        {onCancel && <Text type='BodyBigLink' style={_buttonStyle} onClick={onCancel}>Cancel</Text>}
+        {onBack && <BackButton iconStyle={_backButtonIconStyle} style={_buttonStyle} onClick={onBack} />}
       </Box>
       <WrappedComponent {...restProps} onBack={onBack} onCancel={onCancel} />
     </Box>
@@ -32,6 +32,13 @@ const _containerStyle = {
   flex: 1,
 }
 
+const _buttonStyle = {
+  paddingBottom: 8,
+  paddingLeft: globalMargins.small,
+  paddingRight: globalMargins.small,
+  paddingTop: 8,
+}
+
 const _headerStyle = {
   ...globalStyles.flexBoxRow,
   alignItems: 'center',
@@ -40,7 +47,6 @@ const _headerStyle = {
   justifyContent: 'flex-start',
   marginTop: statusBarHeight,
   minHeight: globalMargins.xlarge - statusBarHeight,
-  paddingLeft: globalMargins.small,
   paddingRight: globalMargins.small,
   position: 'relative',
 }


### PR DESCRIPTION
Moves padding into back button and cancel button on `HeaderHOC`.

Original hit area:
![2017-05-10 at 10 50 am](https://cloud.githubusercontent.com/assets/2669/25914075/d4e6dc28-3571-11e7-8fa0-62cbeba45f64.png)

Fixed:
![back](https://cloud.githubusercontent.com/assets/2669/25914079/d9050c3a-3571-11e7-8f64-963e38b157cc.png)

![cancel](https://cloud.githubusercontent.com/assets/2669/25914082/dc3e7738-3571-11e7-8d31-60698d2a9ff2.png)



In a later fix, the back button component itself should have this padding (or minWidth and minHeight), instead of being passed in.