### PR TITLE
browser: v1.7

### DIFF
--- a/browser/html/options.html
+++ b/browser/html/options.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+
+<head>
+  <title>Keybase Options</title>
+  <style>
+    body {
+      color: rgba(0, 0, 0, 0.7);
+    }
+    label {
+      display: block;
+      margin-bottom: 1em;
+    }
+
+    input[type="checked"] {
+      float: left;
+    }
+  </style>
+</head>
+
+<body>
+
+  <form id="options">
+    <label>
+      <input type="checkbox" name="reddit-thread-reply" checked />
+      Reddit thread "keybase chat reply" buttons.
+    </label>
+
+    <label>
+      <input type="checkbox" name="profile-passive-queries" />
+      Query profiles passively while browsing.
+    </label>
+  </form>
+
+  <script src="../js/options.js"></script>
+
+</body>
+
+</html>

--- a/browser/html/popup.html
+++ b/browser/html/popup.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
     <head>
+        <script src="../js/identities.js"></script>
         <script src="../js/content.js"></script>
         <script src="../js/popup.js"></script>
         <link rel="stylesheet" type="text/css" href="../css/fonts.css" />

--- a/browser/js/background.js
+++ b/browser/js/background.js
@@ -2,10 +2,29 @@
 
 const KBNM_HOST = "io.keybase.kbnm";
 
+// Set the default badge color
+chrome.browserAction.setBadgeBackgroundColor({
+  color: "#3dcc8e"
+});
+
 // Relay extension messages to native messages.
 chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse) {
+  if (msg["method"] === "query" && sender.tab) {
+    chrome.browserAction.setBadgeText({
+      text: "",
+      tabId: sender.tab.id,
+    });
+  }
+
   chrome.runtime.sendNativeMessage(KBNM_HOST, msg, function(r) {
     if (r) {
+      if (msg["method"] === "query" && sender.tab && r.status === "ok") {
+        // Set badge
+        chrome.browserAction.setBadgeText({
+          text: "✓",
+          tabId: sender.tab.id,
+        });
+      }
       return sendResponse(r);
     }
     const err = chrome.runtime.lastError;
@@ -81,3 +100,4 @@ chrome.runtime.onInstalled.addListener(function() {
     chrome.declarativeContent.onPageChanged.addRules(pageMatchRules);
   });
 });
+

--- a/browser/js/background.js
+++ b/browser/js/background.js
@@ -9,16 +9,24 @@ chrome.browserAction.setBadgeBackgroundColor({
 
 // Relay extension messages to native messages.
 chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse) {
-  if (msg["method"] === "query" && sender.tab) {
+  if (sender.tab) {
+    // Reset the tab state with each query
     chrome.browserAction.setBadgeText({
       text: "",
       tabId: sender.tab.id,
     });
   }
 
+  const isPassive = msg["method"] === "passivequery";
+  if (isPassive) {
+    // TODO: This will be a special method at some point, but for now we're
+    // prototyping this feature with the normal query method.
+    msg["method"] = "query";
+  }
+
   chrome.runtime.sendNativeMessage(KBNM_HOST, msg, function(r) {
     if (r) {
-      if (msg["method"] === "query" && sender.tab && r.status === "ok") {
+      if (isPassive && r.status === "ok") {
         // Set badge
         chrome.browserAction.setBadgeText({
           text: "✓",

--- a/browser/js/background.js
+++ b/browser/js/background.js
@@ -47,41 +47,35 @@ chrome.contextMenus.create({
 });
 
 
+// Convert matchers into the declarative matching format
+function generateConditions(matchers)  {
+  // Generate pageMatchRules conditions
+  const conditions = [];
+  for (const m of matchers) {
+    const cond = {
+      pageUrl: { originAndPathMatches: m.originAndPathMatches },
+    };
+    if (m.css !== undefined) {
+      cond.css = m.css;
+    }
+    conditions.push(new chrome.declarativeContent.PageStateMatcher(cond));
+  }
+  return conditions;
+}
+
 // Register browser_action icon state
 // Via: https://developer.chrome.com/extensions/examples/api/pageAction/pageaction_by_url/background.js
 const pageMatchRules = [
   {
-    conditions: [
-      // Match user pages that Keybase recognizes
-      // Extra css matchers added to avoid matching on non-profile URLs like /about or 404's
-      new chrome.declarativeContent.PageStateMatcher({
-          pageUrl: { originAndPathMatches: '\.keybase\.(io|pub)/[\\w]+[/]?' },
-          css: ['a[rel="me"]']
-      }),
-      new chrome.declarativeContent.PageStateMatcher({
-          pageUrl: { originAndPathMatches: '\.reddit.com/user/[\\w-]+$' },
-      }),
-      new chrome.declarativeContent.PageStateMatcher({
-          pageUrl: { originAndPathMatches: '\.twitter\.com/[\\w]+$' },
-          css: ['body.ProfilePage']
-      }),
-      new chrome.declarativeContent.PageStateMatcher({
-          pageUrl: { originAndPathMatches: '\.github\.com/[\\w]+$' },
-          css: ['body.page-profile']
-      }),
-      new chrome.declarativeContent.PageStateMatcher({
-          pageUrl: { originAndPathMatches: 'news\.ycombinator\.com/user' },
-          css: ['html[op="user"]']
-      })
-    ],
+    conditions: generateConditions(identityMatchers),
     actions: [
-      new chrome.declarativeContent.ShowPageAction(),
       new chrome.declarativeContent.SetIcon({
         path: "images/icon-keybase-logo-16@2x.png"
       })
     ]
   }
 ];
+
 chrome.runtime.onInstalled.addListener(function() {
   chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
     chrome.declarativeContent.onPageChanged.addRules(pageMatchRules);

--- a/browser/js/content.js
+++ b/browser/js/content.js
@@ -5,6 +5,20 @@
 const asset = chrome.runtime.getURL;
 
 function init() {
+  // Passive queries?
+  chrome.storage.local.get("profile-passive-queries", function(options) {
+    if (!options["profile-passive-queries"]) return;
+
+    const user = matchService(window.location, document);
+    chrome.runtime.sendMessage({
+      "method": "query",
+      "to": user.query(),
+    }, function(response) {
+      if (response.status !== "ok") return;
+      user.services["keybase"] = safeHTML(response.result["username"]);
+    });
+  });
+
   // Only do work on reddit.
   if (!location.hostname.endsWith('.reddit.com')) return;
 

--- a/browser/js/content.js
+++ b/browser/js/content.js
@@ -34,14 +34,6 @@ function init() {
   });
 }
 window.addEventListener('load', init);
-window.addEventListener('popstate', function() {
-  // Skip initial popstate
-  const isInitial = 'state' in window.history && window.history.state !== null;
-  if (isInitial) return;
-
-  // Forward the event to init
-  init(arguments);
-});
 
 const checkThread = /^\/r\/\w+\/comments\/\w+\//;
 function injectThread() {

--- a/browser/js/content.js
+++ b/browser/js/content.js
@@ -31,55 +31,6 @@ function injectThread() {
   }
 }
 
-// User keeps track of the original query and which services we resolved for
-// this user. It also handles formatting strings for each service.
-function User(username, service) {
-  if (service === undefined) service = "keybase";
-  this.origin = service;
-  this.services = {};
-  this.services[service] = username;
-}
-
-User.prototype.query = function() {
-  const name = this.services[this.origin];
-  if (this.origin === "keybase") {
-    return name;
-  }
-  return `${name}@${this.origin}`;
-}
-
-User.prototype.display = function(service) {
-  if (service === undefined) service = this.origin;
-  const name = this.services[this.origin];
-  switch (this.origin) {
-    case "reddit":
-      return `/u/${name}`;
-    case "twitter":
-      return `@${name}`;
-    default:
-      return name;
-  }
-}
-
-User.prototype.href = function(service) {
-  if (service === undefined) service = this.origin;
-  const name = this.services[this.origin];
-  switch (this.origin) {
-    case "keybase":
-      return `https://keybase.io/${name}`;
-    case "reddit":
-      return `https://www.reddit.com/user/${name}`;
-    case "twitter":
-      return `https://twitter.com/${name}`;
-    case "github":
-      return `https://github.com/${name}`;
-    case "hackernews":
-      return `https://news.ycombinator.com/user?id=${name}`;
-    default:
-      throw `unknown service: ${this.origin}`;
-  }
-}
-
 // Global state of which chat window is currently open.
 let openChat = null;
 

--- a/browser/js/content.js
+++ b/browser/js/content.js
@@ -8,7 +8,14 @@ function init() {
   // Only do work on reddit.
   if (!location.hostname.endsWith('.reddit.com')) return;
 
-  if (checkThread.test(location.pathname)) injectThread();
+  // Inject thread DOM changes?
+  if (!checkThread.test(location.pathname)) return;
+  chrome.storage.local.get("reddit-thread-reply", function(options) {
+    // Is this feature enabled?
+    if (options["reddit-thread-reply"]) {
+      injectThread();
+    }
+  });
 }
 window.addEventListener('load', init);
 

--- a/browser/js/content.js
+++ b/browser/js/content.js
@@ -10,6 +10,8 @@ function init() {
     if (!options["profile-passive-queries"]) return;
 
     const user = matchService(window.location, document);
+    if (!user) return;
+
     chrome.runtime.sendMessage({
       "method": "query",
       "to": user.query(),

--- a/browser/js/identities.js
+++ b/browser/js/identities.js
@@ -32,8 +32,8 @@ const identityMatchers = [
   {
     service: "reddit",
     getUsername: function(loc) { return loc.pathname.split('/')[2]; },
-    locationMatches: new RegExp('\.reddit.com/user/([\\w-]+)[/?]$'),
-    originAndPathMatches: '\.reddit.com/user/[\\w-]+$',
+    locationMatches: new RegExp('\.reddit.com/user/([\\w-]+)[/]?$'),
+    originAndPathMatches: '\.reddit.com/user/[\\w-]+[/]?$',
   },
   {
     service: "twitter",

--- a/browser/js/identities.js
+++ b/browser/js/identities.js
@@ -50,6 +50,13 @@ const identityMatchers = [
     css: ['body.page-profile']
   },
   {
+    service: "facebook",
+    getUsername: function(loc) { return loc.pathname.split('/')[1]; },
+    locationMatches: new RegExp('\.facebook\.com/([\\w]+)[/]?$'),
+    originAndPathMatches: '\.facebook\.com/[\\w]+[/]?$',
+    css: ['body.timelineLayout']
+  },
+  {
     service: "hackernews",
     getUsername: function(loc) { return parseLocationQuery(loc.search)["id"]; },
     locationMatches: new RegExp('news\.ycombinator\.com/user'),
@@ -121,6 +128,8 @@ User.prototype.href = function(service) {
       return `https://www.reddit.com/user/${name}`;
     case "twitter":
       return `https://twitter.com/${name}`;
+    case "facebook":
+      return `https://facebook.com/${name}`;
     case "github":
       return `https://github.com/${name}`;
     case "hackernews":

--- a/browser/js/identities.js
+++ b/browser/js/identities.js
@@ -1,0 +1,87 @@
+// All of our identity services and matchers are defined here.
+
+// identityMatchers is used to generate our declarative page match rules, but also
+// used to check for matches at runtime. Unfortunately, these mechanisms use different
+// implementations of regular expressions (re2 vs javascript's regexp) so there's
+// some redundancy but at least it's all in one place? :D
+const identityMatchers = [
+  {
+    service: "keybase",
+    locationMatches: new RegExp('\.keybase\.(io|pub)/[\\w]+[/]?'),
+    originAndPathMatches: '\.keybase\.(io|pub)/[\\w]+[/]?',
+    css: ['a[rel="me"]']
+  },
+  {
+    service: "reddit",
+    locationMatches: new RegExp('\.reddit.com/user/[\\w-]+$'),
+    originAndPathMatches: '\.reddit.com/user/[\\w-]+$',
+  },
+  {
+    service: "twitter",
+    locationMatches: new RegExp('\.twitter\.com/[\\w]+[/]?$'),
+    originAndPathMatches: '\.twitter\.com/[\\w]+[/]?$',
+    css: ['body.ProfilePage']
+  },
+  {
+    service: "github",
+    locationMatches: new RegExp('\.github\.com/[\\w]+[/]?$'),
+    originAndPathMatches: '\.github\.com/[\\w]+[/]?$',
+    css: ['body.page-profile']
+  },
+  {
+    service: "hackernews",
+    locationMatches: new RegExp('news\.ycombinator\.com/user'),
+    originAndPathMatches: 'news\.ycombinator\.com/user',
+    css: ['html[op="user"]']
+  }
+];
+
+// User keeps track of the original query and which services we resolved for
+// this user. It also handles formatting strings for each service.
+function User(username, service) {
+  if (service === undefined) service = "keybase";
+  this.origin = service;
+  this.services = {};
+  this.services[service] = username;
+}
+
+User.prototype.query = function() {
+  const name = this.services[this.origin];
+  if (this.origin === "keybase") {
+    return name;
+  }
+  return `${name}@${this.origin}`;
+}
+
+User.prototype.display = function(service) {
+  if (service === undefined) service = this.origin;
+  const name = this.services[this.origin];
+  switch (this.origin) {
+    case "reddit":
+      return `/u/${name}`;
+    case "twitter":
+      return `@${name}`;
+    default:
+      return name;
+  }
+}
+
+User.prototype.href = function(service) {
+  if (service === undefined) service = this.origin;
+  const name = this.services[this.origin];
+  switch (this.origin) {
+    case "keybase":
+      return `https://keybase.io/${name}`;
+    case "reddit":
+      return `https://www.reddit.com/user/${name}`;
+    case "twitter":
+      return `https://twitter.com/${name}`;
+    case "github":
+      return `https://github.com/${name}`;
+    case "hackernews":
+      return `https://news.ycombinator.com/user?id=${name}`;
+    default:
+      throw `unknown service: ${this.origin}`;
+  }
+}
+

--- a/browser/js/identities.js
+++ b/browser/js/identities.js
@@ -58,10 +58,13 @@ const identityMatchers = [
   }
 ];
 
-// Match a window.location and document against a service profile and return a User instance.
+// Match a window.location and document against a service profile and return
+// a User instance. Will skip matching CSS if no document is provided.
 function matchService(loc, doc) {
+  // Prefix the url with a period if there is no subdomain.
   const hasSubdomain = loc.hostname.indexOf(".") !== loc.hostname.lastIndexOf(".");
   const url = (!hasSubdomain && ".") + loc.hostname + loc.pathname;
+
   for (const m of identityMatchers) {
     const matched = url.match(m.locationMatches);
     if (!matched) continue;

--- a/browser/js/options.js
+++ b/browser/js/options.js
@@ -31,7 +31,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // Populate default initial values
   const initValues = get(f);
-  chrome.storage.local.get(initValues, function(options) {
+  chrome.storage.sync.get(initValues, function(options) {
     // Update form to match our storage values
     set(f, options);
   });
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', function() {
   // Save changes when our form changes.
   f.addEventListener('change', function(e) {
     const values = get(f);
-    chrome.storage.local.set(values);
+    chrome.storage.sync.set(values);
   });
 });
 

--- a/browser/js/options.js
+++ b/browser/js/options.js
@@ -1,0 +1,41 @@
+// Return form values as a key-value object.
+function get(f) {
+  const r = {};
+  for (const el of f.elements) {
+    switch (el.type) {
+      case "checkbox":
+        r[el.name] = el.checked;
+        break;
+      default:
+        r[el.name] = el.value;
+    }
+  }
+  return r;
+}
+
+// Set form values from a key-value object.
+function set(f, values) {
+  for (const k in values) {
+    switch (f[k].type) {
+      case "checkbox":
+        f[k].checked = !!values[k];
+        break;
+      default:
+        f[k] = values[k];
+    }
+  }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  const f = document.forms[0];
+  const initValues = get(f);
+  chrome.storage.local.get(initValues, function(items) {
+    set(f, items);
+  });
+
+  f.addEventListener('change', function(e) {
+    const values = get(f);
+    chrome.storage.local.set(values);
+  });
+});
+

--- a/browser/js/options.js
+++ b/browser/js/options.js
@@ -28,11 +28,15 @@ function set(f, values) {
 
 document.addEventListener('DOMContentLoaded', function() {
   const f = document.forms[0];
+
+  // Populate default initial values
   const initValues = get(f);
-  chrome.storage.local.get(initValues, function(items) {
-    set(f, items);
+  chrome.storage.local.get(initValues, function(options) {
+    // Update form to match our storage values
+    set(f, options);
   });
 
+  // Save changes when our form changes.
   f.addEventListener('change', function(e) {
     const values = get(f);
     chrome.storage.local.set(values);

--- a/browser/js/popup.js
+++ b/browser/js/popup.js
@@ -5,12 +5,17 @@
 
 chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
     const location = new URL(tabs[0].url);
-    const el = document.body;
-
-    // Clear children
-    while (el.firstChild) el.removeChild(el.firstChild);
 
     const user = matchService(location);
+    if (!user) {
+        window.close();
+        return;
+    }
+
+    // Clear children
+    const el = document.body;
+    while (el.firstChild) el.removeChild(el.firstChild);
+
     return renderPopup(el, user);
 });
 

--- a/browser/js/popup.js
+++ b/browser/js/popup.js
@@ -2,22 +2,6 @@
 "use strict";
 
 // Parse the location.search query string
-function parseLocationQuery(s) {
-    if (s.startsWith("?")) s = s.substr(1);
-    if (s == "") return {};
-    const params = {};
-    const parts = s.split('&');
-    for (let i = 0; i < parts.length; i++)
-    {
-        let p = parts[i].split('=', 2);
-        if (p.length == 1) {
-            params[p[0]] = "";
-        } else {
-            params[p[0]] = decodeURIComponent(p[1].replace(/\+/g, " "));
-        }
-    }
-    return params;
-}
 
 chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
     const location = new URL(tabs[0].url);
@@ -26,45 +10,15 @@ chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
     // Clear children
     while (el.firstChild) el.removeChild(el.firstChild);
 
-    routePopup(el, location);
+    const user = matchService(location);
+    return renderPopup(el, user);
 });
 
-function routePopup(el, location) {
-    // This query will only enter if the appropriate URL structure has already
-    // been matched, so we can make some assumptions about the structure of
-    // the URL.
-    if (location.hostname.startsWith('keybase.')) {
-        // For keybase.io and keybase.pub
-        const username = location.pathname.split('/')[1];
-        return renderPopup(el, username, 'keybase');
-
-    } else if (location.hostname.endsWith('reddit.com')) {
-        const username = location.pathname.split('/')[2];
-        return renderPopup(el, username, 'reddit');
-
-    } else if (location.hostname.endsWith('twitter.com')) {
-        const username = location.pathname.split('/')[1];
-        return renderPopup(el, username, 'twitter');
-
-    } else if (location.hostname.endsWith('github.com')) {
-        const username = location.pathname.split('/')[1];
-        return renderPopup(el, username, 'github');
-
-    } else if (location.hostname == "news.ycombinator.com") {
-        const qs = parseLocationQuery(location.search);
-        const username = qs["id"];
-        if (username) {
-            return renderPopup(el, username, 'hackernews');
-        }
-    }
-}
-
-function renderPopup(el, username, service) {
+function renderPopup(el, user) {
     const div = document.createElement("div");
     div.className = "keybase-reply";
     el.appendChild(div);
 
-    const user = new User(username, service)
     const f = renderChat(div, user, false /* nudgeSupported */, function closeCallback() {
         window.close();
     });

--- a/browser/manifest.json
+++ b/browser/manifest.json
@@ -2,7 +2,7 @@
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsc0yU3MTDhx+JC23YHwvWo/TD1Pynkdc9QekQ7S3jpl0isgro3I5K0ywANwBsZicIYhVq3OQTzV4jq53YoJSP9OFApMb3yzqzJ/QmcwpGvHjztD6I2zPoglMLnWj12VNqFqJtqVj5tT+/TQJ2MdY4eCQpuPweEwDLsR9mP2mxlpV1iCNzF2T61DAqnLmV8zeyjrwJ1QRZq/qd0lJR5JRI8+xBTTStOy2eQvnf8ngEXq2R+NXNq10MELtTpfAT0NPPS1lUbJwR9AYbm9f4wQWLxpeyl63WlmbBUsInM9jsfccDo0hULa59IWpgTdFVQFMBFlIEIN7St8QpF09OygMNQIDAQAB",
   "name": "Keybase for Reddit",
   "short_name": "Keybase",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "End-to-end encrypted replies on Reddit over Keybase Chat.",
   "icons": {
     "48": "images/icon-keybase-logo-48.png",
@@ -30,6 +30,7 @@
         "https://reddit.com/*",
         "https://*.reddit.com/*",
         "https://twitter.com/*",
+        "https://facebook.com/*",
         "https://github.com/*",
         "https://news.ycombinator.com/user",
         "https://keybase.io/*",

--- a/browser/manifest.json
+++ b/browser/manifest.json
@@ -8,7 +8,7 @@
     "48": "images/icon-keybase-logo-48.png",
     "128": "images/icon-keybase-logo-128.png"
   },
-  "page_action": {
+  "browser_action": {
     "default_icon": "images/icon-keybase-logo-logged-out-64.png",
     "default_title": "Keybase Chat",
     "default_popup": "html/popup.html"
@@ -18,11 +18,7 @@
     "contextMenus",
     "declarativeContent",
     "nativeMessaging",
-    "storage",
-    "http://reddit.com/*",
-    "https://reddit.com/*",
-    "http://*.reddit.com/*",
-    "https://*.reddit.com/*"
+    "storage"
   ],
   "web_accessible_resources": [
     "images/*",
@@ -31,12 +27,16 @@
   "content_scripts": [
     {
       "matches": [
-        "http://reddit.com/*",
         "https://reddit.com/*",
-        "http://*.reddit.com/*",
-        "https://*.reddit.com/*"
+        "https://*.reddit.com/*",
+        "https://twitter.com/*",
+        "https://github.com/*",
+        "https://news.ycombinator.com/user",
+        "https://keybase.io/*",
+        "https://keybase.pub/*"
       ],
       "js": [
+        "js/identities.js",
         "js/content.js"
       ],
       "css": [
@@ -47,7 +47,10 @@
     }
   ],
   "background": {
-    "scripts": ["js/background.js"]
+    "scripts": [
+      "js/identities.js",
+      "js/background.js"
+    ]
   },
   "options_ui": {
     "page": "html/options.html",

--- a/browser/manifest.json
+++ b/browser/manifest.json
@@ -2,7 +2,7 @@
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsc0yU3MTDhx+JC23YHwvWo/TD1Pynkdc9QekQ7S3jpl0isgro3I5K0ywANwBsZicIYhVq3OQTzV4jq53YoJSP9OFApMb3yzqzJ/QmcwpGvHjztD6I2zPoglMLnWj12VNqFqJtqVj5tT+/TQJ2MdY4eCQpuPweEwDLsR9mP2mxlpV1iCNzF2T61DAqnLmV8zeyjrwJ1QRZq/qd0lJR5JRI8+xBTTStOy2eQvnf8ngEXq2R+NXNq10MELtTpfAT0NPPS1lUbJwR9AYbm9f4wQWLxpeyl63WlmbBUsInM9jsfccDo0hULa59IWpgTdFVQFMBFlIEIN7St8QpF09OygMNQIDAQAB",
   "name": "Keybase for Reddit",
   "short_name": "Keybase",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "End-to-end encrypted replies on Reddit over Keybase Chat.",
   "icons": {
     "48": "images/icon-keybase-logo-48.png",

--- a/browser/manifest.json
+++ b/browser/manifest.json
@@ -2,7 +2,7 @@
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsc0yU3MTDhx+JC23YHwvWo/TD1Pynkdc9QekQ7S3jpl0isgro3I5K0ywANwBsZicIYhVq3OQTzV4jq53YoJSP9OFApMb3yzqzJ/QmcwpGvHjztD6I2zPoglMLnWj12VNqFqJtqVj5tT+/TQJ2MdY4eCQpuPweEwDLsR9mP2mxlpV1iCNzF2T61DAqnLmV8zeyjrwJ1QRZq/qd0lJR5JRI8+xBTTStOy2eQvnf8ngEXq2R+NXNq10MELtTpfAT0NPPS1lUbJwR9AYbm9f4wQWLxpeyl63WlmbBUsInM9jsfccDo0hULa59IWpgTdFVQFMBFlIEIN7St8QpF09OygMNQIDAQAB",
   "name": "Keybase for Reddit",
   "short_name": "Keybase",
-  "version": "1.6.5",
+  "version": "1.7",
   "description": "End-to-end encrypted replies on Reddit over Keybase Chat.",
   "icons": {
     "48": "images/icon-keybase-logo-48.png",
@@ -18,6 +18,7 @@
     "contextMenus",
     "declarativeContent",
     "nativeMessaging",
+    "storage",
     "http://reddit.com/*",
     "https://reddit.com/*",
     "http://*.reddit.com/*",
@@ -47,6 +48,10 @@
   ],
   "background": {
     "scripts": ["js/background.js"]
+  },
+  "options_ui": {
+    "page": "html/options.html",
+    "chrome_style": true
   },
   "manifest_version": 2
 }

--- a/browser/manifest.json
+++ b/browser/manifest.json
@@ -2,7 +2,7 @@
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsc0yU3MTDhx+JC23YHwvWo/TD1Pynkdc9QekQ7S3jpl0isgro3I5K0ywANwBsZicIYhVq3OQTzV4jq53YoJSP9OFApMb3yzqzJ/QmcwpGvHjztD6I2zPoglMLnWj12VNqFqJtqVj5tT+/TQJ2MdY4eCQpuPweEwDLsR9mP2mxlpV1iCNzF2T61DAqnLmV8zeyjrwJ1QRZq/qd0lJR5JRI8+xBTTStOy2eQvnf8ngEXq2R+NXNq10MELtTpfAT0NPPS1lUbJwR9AYbm9f4wQWLxpeyl63WlmbBUsInM9jsfccDo0hULa59IWpgTdFVQFMBFlIEIN7St8QpF09OygMNQIDAQAB",
   "name": "Keybase for Reddit",
   "short_name": "Keybase",
-  "version": "1.7",
+  "version": "1.7.1",
   "description": "End-to-end encrypted replies on Reddit over Keybase Chat.",
   "icons": {
     "48": "images/icon-keybase-logo-48.png",

--- a/browser/manifest.json
+++ b/browser/manifest.json
@@ -2,7 +2,7 @@
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsc0yU3MTDhx+JC23YHwvWo/TD1Pynkdc9QekQ7S3jpl0isgro3I5K0ywANwBsZicIYhVq3OQTzV4jq53YoJSP9OFApMb3yzqzJ/QmcwpGvHjztD6I2zPoglMLnWj12VNqFqJtqVj5tT+/TQJ2MdY4eCQpuPweEwDLsR9mP2mxlpV1iCNzF2T61DAqnLmV8zeyjrwJ1QRZq/qd0lJR5JRI8+xBTTStOy2eQvnf8ngEXq2R+NXNq10MELtTpfAT0NPPS1lUbJwR9AYbm9f4wQWLxpeyl63WlmbBUsInM9jsfccDo0hULa59IWpgTdFVQFMBFlIEIN7St8QpF09OygMNQIDAQAB",
   "name": "Keybase for Reddit",
   "short_name": "Keybase",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "End-to-end encrypted replies on Reddit over Keybase Chat.",
   "icons": {
     "48": "images/icon-keybase-logo-48.png",

--- a/browser/manifest.json
+++ b/browser/manifest.json
@@ -2,7 +2,7 @@
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsc0yU3MTDhx+JC23YHwvWo/TD1Pynkdc9QekQ7S3jpl0isgro3I5K0ywANwBsZicIYhVq3OQTzV4jq53YoJSP9OFApMb3yzqzJ/QmcwpGvHjztD6I2zPoglMLnWj12VNqFqJtqVj5tT+/TQJ2MdY4eCQpuPweEwDLsR9mP2mxlpV1iCNzF2T61DAqnLmV8zeyjrwJ1QRZq/qd0lJR5JRI8+xBTTStOy2eQvnf8ngEXq2R+NXNq10MELtTpfAT0NPPS1lUbJwR9AYbm9f4wQWLxpeyl63WlmbBUsInM9jsfccDo0hULa59IWpgTdFVQFMBFlIEIN7St8QpF09OygMNQIDAQAB",
   "name": "Keybase for Reddit",
   "short_name": "Keybase",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "End-to-end encrypted replies on Reddit over Keybase Chat.",
   "icons": {
     "48": "images/icon-keybase-logo-48.png",


### PR DESCRIPTION
- Some meaty refactors to generalize the piece which detects whether a given page is a profile or not (identities.js).
- Prototype for passive profile querying (default off): when you land on a profile page, we automatically query keybase and change the icon if they're on keybase.  
- Switched back from using pageAction to browserAction, which gives us more control over the popup icon state that we need for passive querying.
- Nasty hack for Twitter passive querying because I couldn't find a way to hook into page transition events. Ideas are very welcome.
- Support for Facebook
- Extension options to enable/disable features, specifically the DOM injection stuff (default on) and passive querying (default off).


Work remaining:
- ~Faster querying API method for passive querying. We don't need to validate the proofs for the passive querying.~ Deferring until later.

This is published internally as v1.7.x if anyone wants to give it a whirl.