### PR TITLE
Split per-user-key feature flags

### DIFF
--- a/go/engine/device_add_test.go
+++ b/go/engine/device_add_test.go
@@ -61,16 +61,16 @@ func runDeviceAddTest(t *testing.T, wg *sync.WaitGroup, tcY *libkb.TestContext, 
 	}
 }
 
-func testDeviceAdd(t *testing.T, supportPerUserKey bool) {
+func testDeviceAdd(t *testing.T, upgradePerUserKey bool) {
 	// device X (provisioner) context:
 	tcX := SetupEngineTest(t, "kex2provision")
 	defer tcX.Cleanup()
-	tcX.Tp.SupportPerUserKey = supportPerUserKey
+	tcX.Tp.UpgradePerUserKey = upgradePerUserKey
 
 	// device Y (provisionee) context:
 	tcY := SetupEngineTest(t, "template")
 	defer tcY.Cleanup()
-	tcY.Tp.SupportPerUserKey = supportPerUserKey
+	tcY.Tp.UpgradePerUserKey = upgradePerUserKey
 
 	// provisioner needs to be logged in
 	userX := CreateAndSignupFakeUser(tcX, "login")

--- a/go/engine/kex2_test.go
+++ b/go/engine/kex2_test.go
@@ -21,11 +21,11 @@ func TestKex2ProvisionPUK(t *testing.T) {
 	subTestKex2Provision(t, true)
 }
 
-func subTestKex2Provision(t *testing.T, supportPerUserKey bool) {
+func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 	// device X (provisioner) context:
 	tcX := SetupEngineTest(t, "kex2provision")
 	defer tcX.Cleanup()
-	tcX.Tp.SupportPerUserKey = supportPerUserKey
+	tcX.Tp.UpgradePerUserKey = upgradePerUserKey
 
 	// provisioner needs to be logged in
 	userX := CreateAndSignupFakeUser(tcX, "login")
@@ -33,7 +33,7 @@ func subTestKex2Provision(t *testing.T, supportPerUserKey bool) {
 	// device Y (provisionee) context:
 	tcY := SetupEngineTest(t, "kex2provision")
 	defer tcY.Cleanup()
-	tcY.Tp.SupportPerUserKey = supportPerUserKey
+	tcY.Tp.UpgradePerUserKey = upgradePerUserKey
 
 	var secretX kex2.Secret
 	if _, err := rand.Read(secretX[:]); err != nil {

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -191,18 +191,18 @@ func TestProvisionDesktopPUK(t *testing.T) {
 	testProvisionDesktop(t, true)
 }
 
-func testProvisionDesktop(t *testing.T, supportPerUserKey bool) {
+func testProvisionDesktop(t *testing.T, upgradePerUserKey bool) {
 	// device X (provisioner) context:
 	t.Logf("setup X")
 	tcX := SetupEngineTest(t, "kex2provision")
 	defer tcX.Cleanup()
-	tcX.Tp.SupportPerUserKey = supportPerUserKey
+	tcX.Tp.UpgradePerUserKey = upgradePerUserKey
 
 	// device Y (provisionee) context:
 	t.Logf("setup Y")
 	tcY := SetupEngineTest(t, "template")
 	defer tcY.Cleanup()
-	tcY.Tp.SupportPerUserKey = supportPerUserKey
+	tcY.Tp.UpgradePerUserKey = upgradePerUserKey
 
 	// provisioner needs to be logged in
 	t.Logf("provisioner login")
@@ -422,10 +422,10 @@ func TestProvisionPassphraseNoKeysSoloPUK(t *testing.T) {
 }
 
 // If a user has no keys, provision via passphrase should work.
-func testProvisionPassphraseNoKeysSolo(t *testing.T, supportPerUserKey bool) {
+func testProvisionPassphraseNoKeysSolo(t *testing.T, upgradePerUserKey bool) {
 	tcWeb := SetupEngineTest(t, "web")
 	defer tcWeb.Cleanup()
-	tcWeb.Tp.SupportPerUserKey = supportPerUserKey
+	tcWeb.Tp.UpgradePerUserKey = upgradePerUserKey
 
 	username, passphrase := createFakeUserWithNoKeys(tcWeb)
 
@@ -435,7 +435,7 @@ func testProvisionPassphraseNoKeysSolo(t *testing.T, supportPerUserKey bool) {
 
 	tc := SetupEngineTest(t, "login")
 	defer tc.Cleanup()
-	tc.Tp.SupportPerUserKey = supportPerUserKey
+	tc.Tp.UpgradePerUserKey = upgradePerUserKey
 
 	ctx := &Context{
 		ProvisionUI: newTestProvisionUIPassphrase(),
@@ -2589,7 +2589,7 @@ func TestProvisionEnsureNoPaperKeyPUK(t *testing.T) {
 
 // Provisioning a new device when the user has no paper keys should work
 // and not generate a paper key.
-func testProvisionEnsureNoPaperKey(t *testing.T, supportPerUserKey bool) {
+func testProvisionEnsureNoPaperKey(t *testing.T, upgradePerUserKey bool) {
 	// This test is based on TestProvisionDesktop.
 
 	t.Logf("create 2 contexts")
@@ -2597,12 +2597,12 @@ func testProvisionEnsureNoPaperKey(t *testing.T, supportPerUserKey bool) {
 	// device X (provisioner) context:
 	tcX := SetupEngineTest(t, "kex2provision")
 	defer tcX.Cleanup()
-	tcX.Tp.SupportPerUserKey = supportPerUserKey
+	tcX.Tp.UpgradePerUserKey = upgradePerUserKey
 
 	// device Y (provisionee) context:
 	tcY := SetupEngineTest(t, "template")
 	defer tcY.Cleanup()
-	tcY.Tp.SupportPerUserKey = supportPerUserKey
+	tcY.Tp.UpgradePerUserKey = upgradePerUserKey
 
 	// provisioner needs to be logged in
 	userX := CreateAndSignupFakeUserPaper(tcX, "login")

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -80,7 +80,7 @@ func (e *PaperKeyGen) EncKey() libkb.NaclDHKeyPair {
 // Run starts the engine.
 func (e *PaperKeyGen) Run(ctx *Context) error {
 	if e.G().Env.GetSupportPerUserKey() && !e.arg.SkipPush {
-		err := e.syncSDH(ctx)
+		err := e.syncPUK(ctx)
 		if err != nil {
 			return err
 		}
@@ -119,8 +119,8 @@ func (e *PaperKeyGen) Run(ctx *Context) error {
 	return nil
 }
 
-func (e *PaperKeyGen) syncSDH(ctx *Context) error {
-	// Sync the sdh keyring before updating other things.
+func (e *PaperKeyGen) syncPUK(ctx *Context) error {
+	// Sync the per-user-key keyring before updating other things.
 	pukring, err := e.getPerUserKeyring()
 	if err != nil {
 		return err
@@ -134,7 +134,6 @@ func (e *PaperKeyGen) syncSDH(ctx *Context) error {
 	if err != nil {
 		return err
 	}
-	// TODO if PUK_UPGRADE: may want to add a key here.
 	return nil
 }
 
@@ -320,9 +319,7 @@ func (e *PaperKeyGen) makePerUserKeyBoxes(ctx *Context) ([]keybase1.PerUserKeyBo
 		if err != nil {
 			return nil, err
 		}
-		if !pukring.HasAnyKeys() {
-			// TODO if PUK_UPGRADE: may want to add a key here.
-		} else {
+		if pukring.HasAnyKeys() {
 			if e.arg.EncryptionKey.IsNil() {
 				return nil, errors.New("missing encryption key for creating paper key")
 			}

--- a/go/engine/paperkey_test.go
+++ b/go/engine/paperkey_test.go
@@ -119,10 +119,10 @@ func TestPaperKeyMultiPUK(t *testing.T) {
 }
 
 // Generate multiple paper keys
-func testPaperKeyMulti(t *testing.T, supportPerUserKey bool) {
+func testPaperKeyMulti(t *testing.T, upgradePerUserKey bool) {
 	tc := SetupEngineTest(t, "backup")
 	defer tc.Cleanup()
-	tc.Tp.SupportPerUserKey = supportPerUserKey
+	tc.Tp.UpgradePerUserKey = upgradePerUserKey
 
 	f := func(arg *SignupEngineRunArg) {
 		arg.SkipPaper = true
@@ -199,7 +199,7 @@ func TestPaperKeyAfterRevokePUK(t *testing.T) {
 
 	tc := SetupEngineTest(t, "backup")
 	defer tc.Cleanup()
-	tc.Tp.SupportPerUserKey = true
+	tc.Tp.UpgradePerUserKey = true
 
 	fu := CreateAndSignupFakeUser(tc, "login")
 

--- a/go/engine/per_user_key_test.go
+++ b/go/engine/per_user_key_test.go
@@ -21,7 +21,7 @@ func TestPerUserKeySignupAndPullKeys(t *testing.T) {
 	defer tc.Cleanup()
 	var err error
 
-	tc.Tp.SupportPerUserKey = true
+	tc.Tp.UpgradePerUserKey = true
 
 	fu := CreateAndSignupFakeUser(tc, "se")
 
@@ -59,7 +59,7 @@ func TestPerUserKeySignupPlusPaper(t *testing.T) {
 	defer tc.Cleanup()
 	var err error
 
-	tc.Tp.SupportPerUserKey = true
+	tc.Tp.UpgradePerUserKey = true
 
 	fu := CreateAndSignupFakeUserPaper(tc, "se")
 

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -77,10 +77,10 @@ func TestRevokeDevicePUK(t *testing.T) {
 	testRevokeDevice(t, true)
 }
 
-func testRevokeDevice(t *testing.T, supportPerUserKey bool) {
+func testRevokeDevice(t *testing.T, upgradePerUserKey bool) {
 	tc := SetupEngineTest(t, "rev")
 	defer tc.Cleanup()
-	tc.Tp.SupportPerUserKey = supportPerUserKey
+	tc.Tp.UpgradePerUserKey = upgradePerUserKey
 
 	u := CreateAndSignupFakeUserPaper(tc, "rev")
 
@@ -121,10 +121,10 @@ func TestRevokePaperDevicePUK(t *testing.T) {
 	testRevokePaperDevice(t, true)
 }
 
-func testRevokePaperDevice(t *testing.T, supportPerUserKey bool) {
+func testRevokePaperDevice(t *testing.T, upgradePerUserKey bool) {
 	tc := SetupEngineTest(t, "rev")
 	defer tc.Cleanup()
-	tc.Tp.SupportPerUserKey = supportPerUserKey
+	tc.Tp.UpgradePerUserKey = upgradePerUserKey
 
 	u := CreateAndSignupFakeUserPaper(tc, "rev")
 

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -21,12 +21,12 @@ func TestSignupEngine(t *testing.T) {
 	subTestSignupEngine(t, false)
 }
 
-func subTestSignupEngine(t *testing.T, supportPerUserKey bool) {
+func subTestSignupEngine(t *testing.T, upgradePerUserKey bool) {
 	tc := SetupEngineTest(t, "signup")
 	defer tc.Cleanup()
 	var err error
 
-	tc.Tp.SupportPerUserKey = supportPerUserKey
+	tc.Tp.UpgradePerUserKey = upgradePerUserKey
 
 	fu := CreateAndSignupFakeUser(tc, "se")
 

--- a/go/engine/team_test.go
+++ b/go/engine/team_test.go
@@ -15,7 +15,7 @@ func TestPostNewTeam(t *testing.T) {
 	defer tc.Cleanup()
 
 	// Magic to make the test user provision shared DH keys.
-	tc.Tp.SupportPerUserKey = true
+	tc.Tp.UpgradePerUserKey = true
 
 	// Note that the length limit for a team name, with the additional suffix
 	// below, is 16 characters. We have 5 to play with, including the implicit
@@ -40,7 +40,7 @@ func TestPostNewTeamAfterAccountReset(t *testing.T) {
 	defer tc.Cleanup()
 
 	// Magic to make the test user provision shared DH keys.
-	tc.Tp.SupportPerUserKey = true
+	tc.Tp.UpgradePerUserKey = true
 
 	// Note that the length limit for a team name, with the additional suffix
 	// below, is 16 characters. We have 5 to play with, including the implicit

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -102,6 +102,9 @@ func (p CommandLine) GetVDebugSetting() string {
 func (p CommandLine) GetSupportPerUserKey() (bool, bool) {
 	return p.GetBool("support-per-user-key", true)
 }
+func (p CommandLine) GetUpgradePerUserKey() (bool, bool) {
+	return p.GetBool("upgrade-per-user-key", true)
+}
 func (p CommandLine) GetPGPFingerprint() *libkb.PGPFingerprint {
 	return libkb.PGPFingerprintFromHexNoError(p.GetGString("fingerprint"))
 }
@@ -393,7 +396,11 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 		},
 		cli.BoolFlag{
 			Name:  "support-per-user-key",
-			Usage: "Use a shared per-user. Experimental, will break sigchain!",
+			Usage: "Support per-user keys. Experimental, may break sigchain!",
+		},
+		cli.BoolFlag{
+			Name:  "upgrade-per-user-key",
+			Usage: "Create new per-user-keys. Experimental, will break sigchain!",
 		},
 		cli.StringFlag{
 			Name:  "features",

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -117,6 +117,10 @@ func (f JSONConfigFile) GetSupportPerUserKey() (bool, bool) {
 	return false, false
 }
 
+func (f JSONConfigFile) GetUpgradePerUserKey() (bool, bool) {
+	return false, false
+}
+
 func (f JSONConfigFile) GetTopLevelString(s string) (ret string) {
 	var e error
 	f.jw.AtKey(s).GetStringVoid(&ret, &e)

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -659,12 +659,12 @@ func (e *Env) GetEmail() string {
 // Does not add per-user-keys to sigchains unless they are already there.
 // It is unwise to have this off and interact with sigchains that have per-user-keys.
 func (e *Env) GetSupportPerUserKey() bool {
-	if e.GetRunMode() != DevelRunMode {
-		return false
-	}
-
 	if e.GetUpgradePerUserKey() {
 		return true
+	}
+
+	if e.GetRunMode() != DevelRunMode {
+		return false
 	}
 
 	return e.GetBool(false,

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -29,6 +29,7 @@ func (n NullConfiguration) GetPvlKitFilename() string                           
 func (n NullConfiguration) GetUsername() NormalizedUsername                                { return NormalizedUsername("") }
 func (n NullConfiguration) GetEmail() string                                               { return "" }
 func (n NullConfiguration) GetSupportPerUserKey() (bool, bool)                             { return false, false }
+func (n NullConfiguration) GetUpgradePerUserKey() (bool, bool)                             { return false, false }
 func (n NullConfiguration) GetProxy() string                                               { return "" }
 func (n NullConfiguration) GetGpgHome() string                                             { return "" }
 func (n NullConfiguration) GetBundledCA(h string) string                                   { return "" }
@@ -151,6 +152,7 @@ type TestParameters struct {
 	DevelName         string
 	RuntimeDir        string
 	SupportPerUserKey bool
+	UpgradePerUserKey bool
 
 	// set to true to use production run mode in tests
 	UseProductionRunMode bool
@@ -652,9 +654,17 @@ func (e *Env) GetEmail() string {
 	)
 }
 
+// Whether to support per-user-keys in anyones sigchain.
+// Implied by UpgradePerUserKey.
+// Does not add per-user-keys to sigchains unless they are already there.
+// It is unwise to have this off and interact with sigchains that have per-user-keys.
 func (e *Env) GetSupportPerUserKey() bool {
 	if e.GetRunMode() != DevelRunMode {
 		return false
+	}
+
+	if e.GetUpgradePerUserKey() {
+		return true
 	}
 
 	return e.GetBool(false,
@@ -662,6 +672,21 @@ func (e *Env) GetSupportPerUserKey() bool {
 		func() (bool, bool) { return e.getEnvBool("KEYBASE_SUPPORT_PER_USER_KEY") },
 		func() (bool, bool) { return e.config.GetSupportPerUserKey() },
 		func() (bool, bool) { return e.cmd.GetSupportPerUserKey() },
+	)
+}
+
+// Upgrade sigchains to contain per-user-keys.
+// Implies SupportPerUserKey.
+func (e *Env) GetUpgradePerUserKey() bool {
+	if e.GetRunMode() != DevelRunMode {
+		return false
+	}
+
+	return e.GetBool(false,
+		func() (bool, bool) { return e.Test.UpgradePerUserKey, e.Test.UpgradePerUserKey },
+		func() (bool, bool) { return e.getEnvBool("KEYBASE_UPGRADE_PER_USER_KEY") },
+		func() (bool, bool) { return e.config.GetUpgradePerUserKey() },
+		func() (bool, bool) { return e.cmd.GetUpgradePerUserKey() },
 	)
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -39,6 +39,7 @@ type configGetter interface {
 	GetDbFilename() string
 	GetDebug() (bool, bool)
 	GetSupportPerUserKey() (bool, bool)
+	GetUpgradePerUserKey() (bool, bool)
 	GetGpg() string
 	GetGpgHome() string
 	GetGpgOptions() []string


### PR DESCRIPTION
Split the flag `--enable-shared-dh` into 2 flags: `--support-per-user-key` and `--upgrade-per-user-key`. Upgrade implies support. Rollout will involve turning these on one by one.

Right now the only path 'upgrade' affects is provisioning an eldest device. That's the only way to add a first per-user-key. In the future there will be one other path: a background task that upgrades your sigchain if 'upgrade' is enabled.