### PR TITLE
Switch landing page 'Log in' from Text to Button

### DIFF
--- a/shared/devices/container.js
+++ b/shared/devices/container.js
@@ -50,7 +50,7 @@ const mapDispatchToProps = (dispatch: any, {routeState, setRouteState, navigateU
 })
 
 const menuItems = props => ([
-  ...flags.mobileAppsExist && [{onClick: props.addNewPhone, title: 'New phone [in beta]'}] || [],
+  ...flags.mobileAppsExist && [{onClick: props.addNewPhone, title: 'New phone'}] || [],
   {onClick: props.addNewComputer, title: 'New computer'},
   {onClick: props.addNewPaperKey, title: 'New paper key'},
 ])

--- a/shared/login/forms/index.native.js
+++ b/shared/login/forms/index.native.js
@@ -58,9 +58,9 @@ const Intro = (props: Props) => (
       <Icon type='icon-keybase-logo-80' />
       <Text style={stylesHeader} type='HeaderBig'>Join Keybase</Text>
       <Text style={stylesHeaderSub} type='Body'>Folders for anyone in the world.</Text>
-      <Button style={stylesButton} type='Primary' onClick={props.onSignup} label='Create an account' />
+      <Button style={stylesSignupButton} type='Primary' onClick={props.onSignup} label='Create an account' />
       <Text style={stylesLoginHeader} type='Body' onClick={props.onLogin}>Already on Keybase?</Text>
-      <Text type='BodyBigLink' style={{marginTop: globalMargins.tiny}} onClick={props.onLogin}>Log in</Text>
+      <Button style={stylesLoginButton} type='Secondary' onClick={props.onLogin} label='Log in' />
     </Box>
   </Box>
 )
@@ -71,6 +71,7 @@ const stylesLoginForm = {
   flex: 1,
   justifyContent: 'flex-start',
 }
+
 const stylesHeader = {
   color: globalColors.orange,
   marginTop: globalMargins.small,
@@ -79,12 +80,18 @@ const stylesHeader = {
 const stylesHeaderSub = {
   marginTop: globalMargins.tiny,
 }
+
 const stylesLoginHeader = {
   marginTop: 176,
   textAlign: 'center',
 }
-const stylesButton = {
+
+const stylesSignupButton = {
   marginTop: globalMargins.medium,
+}
+
+const stylesLoginButton = {
+  marginTop: globalMargins.small,
 }
 
 const stylesBannerBlue = {

--- a/shared/react-native/android/app/build.gradle
+++ b/shared/react-native/android/app/build.gradle
@@ -93,7 +93,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 23
         versionCode timestamp()
-        versionName "1.0.1"
+        versionName "1.0.2"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/shared/react-native/ios/Keybase/Info.plist
+++ b/shared/react-native/ios/Keybase/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
@keybase/react-hackers 

The initial landing page "Log in" link is hard to press because it's text with a small hitbox:

![screenshot from 2017-05-11 13-07-42](https://cloud.githubusercontent.com/assets/21217/25962195/d5a92150-364a-11e7-8315-6fd8bb6aa66c.png)

But looking at Zeplin, it's not supposed to be text on mobile, it's supposed to be a button.  (It's text on desktop.)