### PR TITLE
typing notification support CORE-5074

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -233,6 +233,11 @@ func (f failingRemote) SyncAll(ctx context.Context, arg chat1.SyncAllArg) (chat1
 	return chat1.SyncAllResult{}, nil
 }
 
+func (f failingRemote) UpdateTypingRemote(ctx context.Context, arg chat1.UpdateTypingRemoteArg) error {
+	require.Fail(f.t, "UpdateTypingRemote")
+	return nil
+}
+
 type failingTlf struct {
 	t *testing.T
 }

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -371,6 +371,12 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				g.Debug(ctx, "chat activity: newMessage: outboxID is empty")
 			}
 
+			// Update typing status to stopped
+			g.typingMonitor.Update(ctx, chat1.TyperInfo{
+				Uid:      keybase1.UID(nm.Message.ClientHeader.Sender.String()),
+				DeviceID: keybase1.DeviceID(nm.Message.ClientHeader.SenderDevice.String()),
+			}, convID, false)
+
 			var conv *chat1.ConversationLocal
 			decmsg, appended, pushErr := g.G().ConvSource.Push(ctx, nm.ConvID, gregor1.UID(uid), nm.Message)
 			if pushErr != nil {

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -180,6 +180,7 @@ type PushHandler struct {
 	badger        *badges.Badger
 	identNotifier *IdentifyNotifier
 	orderer       *gregorMessageOrderer
+	typingMonitor *TypingMonitor
 }
 
 func NewPushHandler(g *globals.Context) *PushHandler {
@@ -188,6 +189,7 @@ func NewPushHandler(g *globals.Context) *PushHandler {
 		DebugLabeler:  utils.NewDebugLabeler(g, "PushHandler", false),
 		identNotifier: NewIdentifyNotifier(g),
 		orderer:       newGregorMessageOrderer(g),
+		typingMonitor: NewTypingMonitor(g),
 	}
 }
 
@@ -553,15 +555,12 @@ func (g *PushHandler) Typing(ctx context.Context, m gregor.OutOfBandMessage) (er
 	}
 
 	// Fire off update with all relevant info
-	nupdate := chat1.UserTypingUpdate{
+	g.typingMonitor.Update(ctx, chat1.TyperInfo{
 		Uid:        kuid,
 		DeviceID:   kdid,
 		Username:   user.String(),
 		DeviceName: device,
-		ConvID:     update.ConvID,
-		Typing:     update.Typing,
 		DeviceType: dtype,
-	}
-	g.G().NotifyRouter.HandleChatTypingUpdate(ctx, []chat1.UserTypingUpdate{nupdate})
+	}, update.ConvID, update.Typing)
 	return nil
 }

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1972,3 +1972,61 @@ func (h *Server) FindConversationsLocal(ctx context.Context,
 	res.RateLimits = utils.AggRateLimits(res.RateLimits)
 	return res, nil
 }
+
+func (h *Server) StartTyping(ctx context.Context, arg chat1.StartTypingArg) (err error) {
+	var identBreaks []keybase1.TLFIdentifyFailure
+	ctx = Context(ctx, h.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI,
+		&identBreaks, h.identNotifier)
+	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("StartTyping(%s)", arg.ConversationID))()
+	if err = h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
+	uid := h.G().Env.GetUID()
+	deviceID := make([]byte, libkb.DeviceIDLen)
+	if err := h.G().Env.GetDeviceID().ToBytes(deviceID); err != nil {
+		return err
+	}
+
+	// Just bail out if we are offline
+	if !h.G().Syncer.IsConnected(ctx) {
+		return nil
+	}
+	if err := h.remoteClient().StartTypingRemote(ctx, chat1.StartTypingRemoteArg{
+		Uid:      uid.ToBytes(),
+		DeviceID: deviceID,
+		ConvID:   arg.ConversationID,
+	}); err != nil {
+		h.Debug(ctx, "StartTyping: failed to hit the server: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (h *Server) StopTyping(ctx context.Context, arg chat1.StopTypingArg) (err error) {
+	var identBreaks []keybase1.TLFIdentifyFailure
+	ctx = Context(ctx, h.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI,
+		&identBreaks, h.identNotifier)
+	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("StopTyping(%s)", arg.ConversationID))()
+	if err = h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
+	uid := h.G().Env.GetUID()
+	deviceID := make([]byte, libkb.DeviceIDLen)
+	if err := h.G().Env.GetDeviceID().ToBytes(deviceID); err != nil {
+		return err
+	}
+
+	// Just bail out if we are offline
+	if !h.G().Syncer.IsConnected(ctx) {
+		return nil
+	}
+	if err := h.remoteClient().StopTypingRemote(ctx, chat1.StopTypingRemoteArg{
+		Uid:      uid.ToBytes(),
+		DeviceID: deviceID,
+		ConvID:   arg.ConversationID,
+	}); err != nil {
+		h.Debug(ctx, "StopTyping: failed to hit the server: %s", err.Error())
+	}
+
+	return nil
+}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1973,7 +1973,7 @@ func (h *Server) FindConversationsLocal(ctx context.Context,
 	return res, nil
 }
 
-func (h *Server) StartTyping(ctx context.Context, arg chat1.StartTypingArg) (err error) {
+func (h *Server) UpdateTyping(ctx context.Context, arg chat1.UpdateTypingArg) (err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = Context(ctx, h.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI,
 		&identBreaks, h.identNotifier)
@@ -1991,41 +1991,13 @@ func (h *Server) StartTyping(ctx context.Context, arg chat1.StartTypingArg) (err
 	if !h.G().Syncer.IsConnected(ctx) {
 		return nil
 	}
-	if err := h.remoteClient().StartTypingRemote(ctx, chat1.StartTypingRemoteArg{
+	if err := h.remoteClient().UpdateTypingRemote(ctx, chat1.UpdateTypingRemoteArg{
 		Uid:      uid.ToBytes(),
 		DeviceID: deviceID,
 		ConvID:   arg.ConversationID,
+		Typing:   arg.Typing,
 	}); err != nil {
 		h.Debug(ctx, "StartTyping: failed to hit the server: %s", err.Error())
-	}
-
-	return nil
-}
-
-func (h *Server) StopTyping(ctx context.Context, arg chat1.StopTypingArg) (err error) {
-	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, h.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI,
-		&identBreaks, h.identNotifier)
-	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("StopTyping(%s)", arg.ConversationID))()
-	if err = h.assertLoggedIn(ctx); err != nil {
-		return err
-	}
-	uid := h.G().Env.GetUID()
-	deviceID := make([]byte, libkb.DeviceIDLen)
-	if err := h.G().Env.GetDeviceID().ToBytes(deviceID); err != nil {
-		return err
-	}
-
-	// Just bail out if we are offline
-	if !h.G().Syncer.IsConnected(ctx) {
-		return nil
-	}
-	if err := h.remoteClient().StopTypingRemote(ctx, chat1.StopTypingRemoteArg{
-		Uid:      uid.ToBytes(),
-		DeviceID: deviceID,
-		ConvID:   arg.ConversationID,
-	}); err != nil {
-		h.Debug(ctx, "StopTyping: failed to hit the server: %s", err.Error())
 	}
 
 	return nil

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -939,6 +939,8 @@ func (n *serverChatListener) NewChatActivity(uid keybase1.UID, activity chat1.Ch
 		n.newMessage <- activity.IncomingMessage().Message
 	}
 }
+func (n *serverChatListener) ChatTypingUpdate(updates []chat1.ConvTypingUpdate) {
+}
 
 func newServerChatListener() *serverChatListener {
 	return &serverChatListener{

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -122,6 +122,7 @@ type PushHandler interface {
 	TlfFinalize(context.Context, gregor.OutOfBandMessage) error
 	TlfResolve(context.Context, gregor.OutOfBandMessage) error
 	Activity(context.Context, gregor.OutOfBandMessage) error
+	Typing(context.Context, gregor.OutOfBandMessage) error
 }
 
 type AppState interface {

--- a/go/chat/typingmonitor.go
+++ b/go/chat/typingmonitor.go
@@ -161,7 +161,6 @@ func (t *TypingMonitor) waitOnTyper(ctx context.Context, chans *typingControlCha
 	go func() {
 		extends := 0
 		for {
-			t.Debug(ctx, "waiting again: %v", deadline)
 			select {
 			case <-t.clock.AfterTime(deadline):
 				// Send notifications and bail

--- a/go/chat/typingmonitor.go
+++ b/go/chat/typingmonitor.go
@@ -1,0 +1,161 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"strings"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/clockwork"
+)
+
+const typingTimeout = 10 * time.Second
+const maxExtensions = 50
+
+type typingControlChans struct {
+	typer chat1.TyperInfo
+
+	stopCh   chan struct{}
+	extendCh chan struct{}
+}
+
+func newTypingControlChans(typer chat1.TyperInfo) *typingControlChans {
+	return &typingControlChans{
+		typer: typer,
+		// Might not need these buffers, but we really don't want to deadlock
+		stopCh:   make(chan struct{}, 5),
+		extendCh: make(chan struct{}, 5),
+	}
+}
+
+type TypingMonitor struct {
+	globals.Contextified
+	sync.Mutex
+	utils.DebugLabeler
+
+	clock  clockwork.Clock
+	typers map[string]*typingControlChans
+}
+
+func NewTypingMonitor(g *globals.Context) *TypingMonitor {
+	return &TypingMonitor{
+		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "TypingMonitor", false),
+		typers:       make(map[string]*typingControlChans),
+		clock:        clockwork.NewRealClock(),
+	}
+}
+
+func (t *TypingMonitor) SetClock(clock clockwork.Clock) {
+	t.clock = clock
+}
+
+func (t *TypingMonitor) key(typer chat1.TyperInfo, convID chat1.ConversationID) string {
+	return fmt.Sprintf("%s:%s:%s", typer.Uid, typer.DeviceID, convID)
+}
+
+func (t *TypingMonitor) convKey(key string, convID chat1.ConversationID) bool {
+	toks := strings.Split(key, ":")
+	if len(toks) != 3 {
+		return false
+	}
+	return toks[2] == convID.String()
+}
+
+func (t *TypingMonitor) notifyConvUpdateLocked(ctx context.Context, convID chat1.ConversationID) {
+	var typers []chat1.TyperInfo
+	for k, v := range t.typers {
+		if t.convKey(k, convID) {
+			typers = append(typers, v.typer)
+		}
+	}
+
+	update := chat1.ConvTypingUpdate{
+		ConvID: convID,
+		Typers: typers,
+	}
+	t.G().NotifyRouter.HandleChatTypingUpdate(ctx, []chat1.ConvTypingUpdate{update})
+}
+
+func (t *TypingMonitor) Update(ctx context.Context, typer chat1.TyperInfo, convID chat1.ConversationID,
+	typing bool) {
+
+	t.Debug(ctx, "Update: %s in convID: %s updated typing to: %v", typer, convID, typing)
+	key := t.key(typer, convID)
+
+	t.Lock()
+	chans, alreadyTyping := t.typers[key]
+	t.Unlock()
+	if typing {
+		if alreadyTyping {
+			// If this key is already typing, let's extend it
+			select {
+			case chans.extendCh <- struct{}{}:
+			default:
+				// This should never happen, but be safe
+				t.Debug(ctx, "Update: overflowed extend channel, dropping update: %s convID: %s", typer,
+					convID)
+			}
+		} else {
+			// Not typing yet, just add it in and spawn waiter
+			chans := newTypingControlChans(typer)
+			t.Lock()
+			t.typers[key] = chans
+			t.Unlock()
+			t.waitOnTyper(ctx, chans, convID)
+		}
+	} else {
+		if alreadyTyping {
+			// If they are typing, then stop it
+			select {
+			case chans.stopCh <- struct{}{}:
+			default:
+				// This should never happen, but be safe
+				t.Debug(ctx, "Update: overflowed stop channel, dropping update: %s convID: %s", typer,
+					convID)
+			}
+		}
+	}
+}
+
+func (t *TypingMonitor) removeFromTypers(ctx context.Context, key string, convID chat1.ConversationID) {
+	t.Lock()
+	defer t.Unlock()
+	delete(t.typers, key)
+	t.notifyConvUpdateLocked(ctx, convID)
+}
+
+func (t *TypingMonitor) waitOnTyper(ctx context.Context, chans *typingControlChans,
+	convID chat1.ConversationID) {
+	key := t.key(chans.typer, convID)
+	ctx = BackgroundContext(ctx, t.G().GetEnv())
+	go func() {
+		extends := 0
+		for {
+			select {
+			case <-t.clock.After(typingTimeout):
+				// Send notifications and bail
+				t.removeFromTypers(ctx, key, convID)
+				return
+			case <-chans.extendCh:
+				// Loop around to restart timer
+				extends++
+				if extends > maxExtensions {
+					t.Debug(ctx, "waitOnTyper: max extensions reached: uid: %s convID: %s", chans.typer.Uid, convID)
+					t.removeFromTypers(ctx, key, convID)
+					return
+				}
+				continue
+			case <-chans.stopCh:
+				// Stopped typing, just end it and remove entry in typers
+				t.removeFromTypers(ctx, key, convID)
+				return
+			}
+		}
+	}()
+}

--- a/go/engine/paperkey_submit_test.go
+++ b/go/engine/paperkey_submit_test.go
@@ -112,3 +112,4 @@ func (n *nlistener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID
 }
 func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                {}
 func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {}
+func (n *nlistener) ChatTypingUpdate(updates []chat1.ConvTypingUpdate)              {}

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -588,6 +588,10 @@ func (m *ChatRemoteMock) SyncAll(ctx context.Context, arg chat1.SyncAllArg) (res
 	}, nil
 }
 
+func (m *ChatRemoteMock) UpdateTypingRemote(ctx context.Context, arg chat1.UpdateTypingRemoteArg) error {
+	return nil
+}
+
 type convByNewlyUpdated struct {
 	mock *ChatRemoteMock
 }

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -48,7 +48,7 @@ type NotifyListener interface {
 		resolveInfo chat1.ConversationResolveInfo)
 	ChatInboxStale(uid keybase1.UID)
 	ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID)
-	ChatTypingUpdate([]chat1.UserTypingUpdate)
+	ChatTypingUpdate([]chat1.ConvTypingUpdate)
 	PGPKeyInSecretStoreFile()
 	BadgeState(badgeState keybase1.BadgeState)
 	ReachabilityChanged(r keybase1.Reachability)
@@ -644,7 +644,7 @@ func (n *NotifyRouter) HandleChatThreadsStale(ctx context.Context, uid keybase1.
 	n.G().Log.CDebugf(ctx, "- Sent ChatThreadsStale notification")
 }
 
-func (n *NotifyRouter) HandleChatTypingUpdate(ctx context.Context, updates []chat1.UserTypingUpdate) {
+func (n *NotifyRouter) HandleChatTypingUpdate(ctx context.Context, updates []chat1.ConvTypingUpdate) {
 	if n == nil {
 		return
 	}

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -513,3 +513,7 @@ func (r *DownloadAttachmentLocalRes) SetOffline() {
 func (r *FindConversationsLocalRes) SetOffline() {
 	r.Offline = true
 }
+
+func (t TyperInfo) String() string {
+	return fmt.Sprintf("typer(u:%s d:%s)", t.Username, t.DeviceName)
+}

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -4,6 +4,7 @@
 package chat1
 
 import (
+	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 
@@ -58,6 +59,13 @@ type TLFFinalizeUpdate struct {
 type TLFResolveUpdate struct {
 	ConvID    ConversationID `codec:"convID" json:"convID"`
 	InboxVers InboxVers      `codec:"inboxVers" json:"inboxVers"`
+}
+
+type RemoteUserTypingUpdate struct {
+	Uid      gregor1.UID      `codec:"uid" json:"uid"`
+	DeviceID gregor1.DeviceID `codec:"deviceID" json:"deviceID"`
+	ConvID   ConversationID   `codec:"convID" json:"convID"`
+	Typing   bool             `codec:"typing" json:"typing"`
 }
 
 type GregorInterface interface {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1686,14 +1686,9 @@ type FindConversationsLocalArg struct {
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
-type StartTypingArg struct {
-	SessionID      int            `codec:"sessionID" json:"sessionID"`
+type UpdateTypingArg struct {
 	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
-}
-
-type StopTypingArg struct {
-	SessionID      int            `codec:"sessionID" json:"sessionID"`
-	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
+	Typing         bool           `codec:"typing" json:"typing"`
 }
 
 type LocalInterface interface {
@@ -1721,8 +1716,7 @@ type LocalInterface interface {
 	RetryPost(context.Context, OutboxID) error
 	MarkAsReadLocal(context.Context, MarkAsReadLocalArg) (MarkAsReadLocalRes, error)
 	FindConversationsLocal(context.Context, FindConversationsLocalArg) (FindConversationsLocalRes, error)
-	StartTyping(context.Context, StartTypingArg) error
-	StopTyping(context.Context, StopTypingArg) error
+	UpdateTyping(context.Context, UpdateTypingArg) error
 }
 
 func LocalProtocol(i LocalInterface) rpc.Protocol {
@@ -2113,34 +2107,18 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"startTyping": {
+			"updateTyping": {
 				MakeArg: func() interface{} {
-					ret := make([]StartTypingArg, 1)
+					ret := make([]UpdateTypingArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]StartTypingArg)
+					typedArgs, ok := args.(*[]UpdateTypingArg)
 					if !ok {
-						err = rpc.NewTypeError((*[]StartTypingArg)(nil), args)
+						err = rpc.NewTypeError((*[]UpdateTypingArg)(nil), args)
 						return
 					}
-					err = i.StartTyping(ctx, (*typedArgs)[0])
-					return
-				},
-				MethodType: rpc.MethodCall,
-			},
-			"stopTyping": {
-				MakeArg: func() interface{} {
-					ret := make([]StopTypingArg, 1)
-					return &ret
-				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]StopTypingArg)
-					if !ok {
-						err = rpc.NewTypeError((*[]StopTypingArg)(nil), args)
-						return
-					}
-					err = i.StopTyping(ctx, (*typedArgs)[0])
+					err = i.UpdateTyping(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -2277,12 +2255,7 @@ func (c LocalClient) FindConversationsLocal(ctx context.Context, __arg FindConve
 	return
 }
 
-func (c LocalClient) StartTyping(ctx context.Context, __arg StartTypingArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.startTyping", []interface{}{__arg}, nil)
-	return
-}
-
-func (c LocalClient) StopTyping(ctx context.Context, __arg StopTypingArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.stopTyping", []interface{}{__arg}, nil)
+func (c LocalClient) UpdateTyping(ctx context.Context, __arg UpdateTypingArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.updateTyping", []interface{}{__arg}, nil)
 	return
 }

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -198,14 +198,17 @@ func NewChatActivityWithFailedMessage(v FailedMessageInfo) ChatActivity {
 	}
 }
 
-type UserTypingUpdate struct {
+type TyperInfo struct {
 	Uid        keybase1.UID      `codec:"uid" json:"uid"`
 	Username   string            `codec:"username" json:"username"`
 	DeviceID   keybase1.DeviceID `codec:"deviceID" json:"deviceID"`
 	DeviceName string            `codec:"deviceName" json:"deviceName"`
 	DeviceType string            `codec:"deviceType" json:"deviceType"`
-	ConvID     ConversationID    `codec:"convID" json:"convID"`
-	Typing     bool              `codec:"typing" json:"typing"`
+}
+
+type ConvTypingUpdate struct {
+	ConvID ConversationID `codec:"convID" json:"convID"`
+	Typers []TyperInfo    `codec:"typers" json:"typers"`
 }
 
 type NewChatActivityArg struct {
@@ -240,7 +243,7 @@ type ChatThreadsStaleArg struct {
 }
 
 type ChatTypingUpdateArg struct {
-	TypingUpdates []UserTypingUpdate `codec:"typingUpdates" json:"typingUpdates"`
+	TypingUpdates []ConvTypingUpdate `codec:"typingUpdates" json:"typingUpdates"`
 }
 
 type NotifyChatInterface interface {
@@ -250,7 +253,7 @@ type NotifyChatInterface interface {
 	ChatTLFResolve(context.Context, ChatTLFResolveArg) error
 	ChatInboxStale(context.Context, keybase1.UID) error
 	ChatThreadsStale(context.Context, ChatThreadsStaleArg) error
-	ChatTypingUpdate(context.Context, []UserTypingUpdate) error
+	ChatTypingUpdate(context.Context, []ConvTypingUpdate) error
 }
 
 func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
@@ -409,7 +412,7 @@ func (c NotifyChatClient) ChatThreadsStale(ctx context.Context, __arg ChatThread
 	return
 }
 
-func (c NotifyChatClient) ChatTypingUpdate(ctx context.Context, typingUpdates []UserTypingUpdate) (err error) {
+func (c NotifyChatClient) ChatTypingUpdate(ctx context.Context, typingUpdates []ConvTypingUpdate) (err error) {
 	__arg := ChatTypingUpdateArg{TypingUpdates: typingUpdates}
 	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatTypingUpdate", []interface{}{__arg})
 	return

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -198,6 +198,15 @@ func NewChatActivityWithFailedMessage(v FailedMessageInfo) ChatActivity {
 	}
 }
 
+type UserTypingUpdate struct {
+	Uid        keybase1.UID      `codec:"uid" json:"uid"`
+	Username   string            `codec:"username" json:"username"`
+	DeviceID   keybase1.DeviceID `codec:"deviceID" json:"deviceID"`
+	DeviceName string            `codec:"deviceName" json:"deviceName"`
+	ConvID     ConversationID    `codec:"convID" json:"convID"`
+	Typing     bool              `codec:"typing" json:"typing"`
+}
+
 type NewChatActivityArg struct {
 	Uid      keybase1.UID `codec:"uid" json:"uid"`
 	Activity ChatActivity `codec:"activity" json:"activity"`
@@ -229,6 +238,10 @@ type ChatThreadsStaleArg struct {
 	ConvIDs []ConversationID `codec:"convIDs" json:"convIDs"`
 }
 
+type ChatTypingUpdateArg struct {
+	TypingUpdates []UserTypingUpdate `codec:"typingUpdates" json:"typingUpdates"`
+}
+
 type NotifyChatInterface interface {
 	NewChatActivity(context.Context, NewChatActivityArg) error
 	ChatIdentifyUpdate(context.Context, keybase1.CanonicalTLFNameAndIDWithBreaks) error
@@ -236,6 +249,7 @@ type NotifyChatInterface interface {
 	ChatTLFResolve(context.Context, ChatTLFResolveArg) error
 	ChatInboxStale(context.Context, keybase1.UID) error
 	ChatThreadsStale(context.Context, ChatThreadsStaleArg) error
+	ChatTypingUpdate(context.Context, []UserTypingUpdate) error
 }
 
 func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
@@ -338,6 +352,22 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodNotify,
 			},
+			"ChatTypingUpdate": {
+				MakeArg: func() interface{} {
+					ret := make([]ChatTypingUpdateArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]ChatTypingUpdateArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]ChatTypingUpdateArg)(nil), args)
+						return
+					}
+					err = i.ChatTypingUpdate(ctx, (*typedArgs)[0].TypingUpdates)
+					return
+				},
+				MethodType: rpc.MethodNotify,
+			},
 		},
 	}
 }
@@ -375,5 +405,11 @@ func (c NotifyChatClient) ChatInboxStale(ctx context.Context, uid keybase1.UID) 
 
 func (c NotifyChatClient) ChatThreadsStale(ctx context.Context, __arg ChatThreadsStaleArg) (err error) {
 	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatThreadsStale", []interface{}{__arg})
+	return
+}
+
+func (c NotifyChatClient) ChatTypingUpdate(ctx context.Context, typingUpdates []UserTypingUpdate) (err error) {
+	__arg := ChatTypingUpdateArg{TypingUpdates: typingUpdates}
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.ChatTypingUpdate", []interface{}{__arg})
 	return
 }

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -203,6 +203,7 @@ type UserTypingUpdate struct {
 	Username   string            `codec:"username" json:"username"`
 	DeviceID   keybase1.DeviceID `codec:"deviceID" json:"deviceID"`
 	DeviceName string            `codec:"deviceName" json:"deviceName"`
+	DeviceType string            `codec:"deviceType" json:"deviceType"`
 	ConvID     ConversationID    `codec:"convID" json:"convID"`
 	Typing     bool              `codec:"typing" json:"typing"`
 }

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -397,6 +397,18 @@ type PublishSetConversationStatusArg struct {
 	Status ConversationStatus `codec:"status" json:"status"`
 }
 
+type StartTypingRemoteArg struct {
+	Uid      gregor1.UID      `codec:"uid" json:"uid"`
+	DeviceID gregor1.DeviceID `codec:"deviceID" json:"deviceID"`
+	ConvID   ConversationID   `codec:"convID" json:"convID"`
+}
+
+type StopTypingRemoteArg struct {
+	Uid      gregor1.UID      `codec:"uid" json:"uid"`
+	DeviceID gregor1.DeviceID `codec:"deviceID" json:"deviceID"`
+	ConvID   ConversationID   `codec:"convID" json:"convID"`
+}
+
 type RemoteInterface interface {
 	GetInboxRemote(context.Context, GetInboxRemoteArg) (GetInboxRemoteRes, error)
 	GetThreadRemote(context.Context, GetThreadRemoteArg) (GetThreadRemoteRes, error)
@@ -418,6 +430,8 @@ type RemoteInterface interface {
 	TlfResolve(context.Context, TlfResolveArg) error
 	PublishReadMessage(context.Context, PublishReadMessageArg) error
 	PublishSetConversationStatus(context.Context, PublishSetConversationStatusArg) error
+	StartTypingRemote(context.Context, StartTypingRemoteArg) error
+	StopTypingRemote(context.Context, StopTypingRemoteArg) error
 }
 
 func RemoteProtocol(i RemoteInterface) rpc.Protocol {
@@ -744,6 +758,38 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"startTypingRemote": {
+				MakeArg: func() interface{} {
+					ret := make([]StartTypingRemoteArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]StartTypingRemoteArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]StartTypingRemoteArg)(nil), args)
+						return
+					}
+					err = i.StartTypingRemote(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"stopTypingRemote": {
+				MakeArg: func() interface{} {
+					ret := make([]StopTypingRemoteArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]StopTypingRemoteArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]StopTypingRemoteArg)(nil), args)
+						return
+					}
+					err = i.StopTypingRemote(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -855,5 +901,15 @@ func (c RemoteClient) PublishReadMessage(ctx context.Context, __arg PublishReadM
 
 func (c RemoteClient) PublishSetConversationStatus(ctx context.Context, __arg PublishSetConversationStatusArg) (err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.publishSetConversationStatus", []interface{}{__arg}, nil)
+	return
+}
+
+func (c RemoteClient) StartTypingRemote(ctx context.Context, __arg StartTypingRemoteArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.remote.startTypingRemote", []interface{}{__arg}, nil)
+	return
+}
+
+func (c RemoteClient) StopTypingRemote(ctx context.Context, __arg StopTypingRemoteArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.remote.stopTypingRemote", []interface{}{__arg}, nil)
 	return
 }

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -397,16 +397,11 @@ type PublishSetConversationStatusArg struct {
 	Status ConversationStatus `codec:"status" json:"status"`
 }
 
-type StartTypingRemoteArg struct {
+type UpdateTypingRemoteArg struct {
 	Uid      gregor1.UID      `codec:"uid" json:"uid"`
 	DeviceID gregor1.DeviceID `codec:"deviceID" json:"deviceID"`
 	ConvID   ConversationID   `codec:"convID" json:"convID"`
-}
-
-type StopTypingRemoteArg struct {
-	Uid      gregor1.UID      `codec:"uid" json:"uid"`
-	DeviceID gregor1.DeviceID `codec:"deviceID" json:"deviceID"`
-	ConvID   ConversationID   `codec:"convID" json:"convID"`
+	Typing   bool             `codec:"typing" json:"typing"`
 }
 
 type RemoteInterface interface {
@@ -430,8 +425,7 @@ type RemoteInterface interface {
 	TlfResolve(context.Context, TlfResolveArg) error
 	PublishReadMessage(context.Context, PublishReadMessageArg) error
 	PublishSetConversationStatus(context.Context, PublishSetConversationStatusArg) error
-	StartTypingRemote(context.Context, StartTypingRemoteArg) error
-	StopTypingRemote(context.Context, StopTypingRemoteArg) error
+	UpdateTypingRemote(context.Context, UpdateTypingRemoteArg) error
 }
 
 func RemoteProtocol(i RemoteInterface) rpc.Protocol {
@@ -758,34 +752,18 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
-			"startTypingRemote": {
+			"updateTypingRemote": {
 				MakeArg: func() interface{} {
-					ret := make([]StartTypingRemoteArg, 1)
+					ret := make([]UpdateTypingRemoteArg, 1)
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]StartTypingRemoteArg)
+					typedArgs, ok := args.(*[]UpdateTypingRemoteArg)
 					if !ok {
-						err = rpc.NewTypeError((*[]StartTypingRemoteArg)(nil), args)
+						err = rpc.NewTypeError((*[]UpdateTypingRemoteArg)(nil), args)
 						return
 					}
-					err = i.StartTypingRemote(ctx, (*typedArgs)[0])
-					return
-				},
-				MethodType: rpc.MethodCall,
-			},
-			"stopTypingRemote": {
-				MakeArg: func() interface{} {
-					ret := make([]StopTypingRemoteArg, 1)
-					return &ret
-				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]StopTypingRemoteArg)
-					if !ok {
-						err = rpc.NewTypeError((*[]StopTypingRemoteArg)(nil), args)
-						return
-					}
-					err = i.StopTypingRemote(ctx, (*typedArgs)[0])
+					err = i.UpdateTypingRemote(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -904,12 +882,7 @@ func (c RemoteClient) PublishSetConversationStatus(ctx context.Context, __arg Pu
 	return
 }
 
-func (c RemoteClient) StartTypingRemote(ctx context.Context, __arg StartTypingRemoteArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.remote.startTypingRemote", []interface{}{__arg}, nil)
-	return
-}
-
-func (c RemoteClient) StopTypingRemote(ctx context.Context, __arg StopTypingRemoteArg) (err error) {
-	err = c.Cli.Call(ctx, "chat.1.remote.stopTypingRemote", []interface{}{__arg}, nil)
+func (c RemoteClient) UpdateTypingRemote(ctx context.Context, __arg UpdateTypingRemoteArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.remote.updateTypingRemote", []interface{}{__arg}, nil)
 	return
 }

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1055,6 +1055,8 @@ func (g *gregorHandler) handleOutOfBandMessage(ctx context.Context, obm gregor.O
 		return g.G().PushHandler.TlfFinalize(ctx, obm)
 	case "chat.tlfresolve":
 		return g.G().PushHandler.TlfResolve(ctx, obm)
+	case "chat.typing":
+		return g.G().PushHandler.Typing(ctx, obm)
 	case "internal.reconnect":
 		g.G().Log.Debug("reconnected to push server")
 		return nil

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -119,6 +119,8 @@ func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.Conversation
 		require.Fail(n.t, "thread send timeout")
 	}
 }
+func (n *nlistener) ChatTypingUpdate(updates []chat1.ConvTypingUpdate) {
+}
 func (n *nlistener) BadgeState(badgeState keybase1.BadgeState) {
 	select {
 	case n.badgeState <- badgeState:

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -1,6 +1,8 @@
 @namespace("chat.1")
 protocol gregor {
 
+    import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
+
     record GenericPayload {
         @lint("ignore")
         string Action;
@@ -62,4 +64,10 @@ protocol gregor {
         InboxVers inboxVers;
     }
 
+    record RemoteUserTypingUpdate {
+        gregor1.UID uid;
+        gregor1.DeviceID deviceID;
+        ConversationID convID;
+        boolean typing; 
+    }
 }

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -61,4 +61,5 @@ protocol gregor {
         ConversationID convID;
         InboxVers inboxVers;
     }
+
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -620,7 +620,6 @@ protocol local {
   FindConversationsLocalRes findConversationsLocal(string tlfName, TLFVisibility visibility, TopicType topicType, string topicName, union { null, bool } oneChatPerTLF, keybase1.TLFIdentifyBehavior identifyBehavior);
 
   // Typing API
-  void startTyping(int sessionID, ConversationID conversationID);
-  void stopTyping(int sessionID, ConversationID conversationID);
+  void updateTyping(ConversationID conversationID, boolean typing);
 
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -619,4 +619,8 @@ protocol local {
 
   FindConversationsLocalRes findConversationsLocal(string tlfName, TLFVisibility visibility, TopicType topicType, string topicName, union { null, bool } oneChatPerTLF, keybase1.TLFIdentifyBehavior identifyBehavior);
 
+  // Typing API
+  void startTyping(int sessionID, ConversationID conversationID);
+  void stopTyping(int sessionID, ConversationID conversationID);
+
 }

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -48,15 +48,17 @@ protocol NotifyChat {
     case FAILED_MESSAGE: FailedMessageInfo;
   }
 
-  record UserTypingUpdate {
+  record TyperInfo {
     keybase1.UID uid;
     string username;
     keybase1.DeviceID deviceID;
     string deviceName;
     string deviceType;
+  }
 
+  record ConvTypingUpdate {
     ConversationID convID;
-    boolean typing;
+    array<TyperInfo> typers;
   }
 
   @notify("")
@@ -86,5 +88,5 @@ protocol NotifyChat {
 
   @notify("")
   @lint("ignore")
-  void ChatTypingUpdate(array<UserTypingUpdate> typingUpdates);
+  void ChatTypingUpdate(array<ConvTypingUpdate> typingUpdates);
 }

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -53,6 +53,7 @@ protocol NotifyChat {
     string username;
     keybase1.DeviceID deviceID;
     string deviceName;
+    string deviceType;
 
     ConversationID convID;
     boolean typing;

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -47,7 +47,16 @@ protocol NotifyChat {
     case SET_STATUS: SetStatusInfo;
     case FAILED_MESSAGE: FailedMessageInfo;
   }
-  
+
+  record UserTypingUpdate {
+    keybase1.UID uid;
+    string username;
+    keybase1.DeviceID deviceID;
+    string deviceName;
+
+    ConversationID convID;
+    boolean typing;
+  }
 
   @notify("")
   @lint("ignore")
@@ -73,4 +82,8 @@ protocol NotifyChat {
   @notify("")
   @lint("ignore")
   void ChatThreadsStale(keybase1.UID uid, array<ConversationID> convIDs);
+
+  @notify("")
+  @lint("ignore")
+  void ChatTypingUpdate(array<UserTypingUpdate> typingUpdates);
 }

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -211,6 +211,5 @@ protocol remote {
   void publishSetConversationStatus(gregor1.UID uid, ConversationID convID, ConversationStatus status);
 
   // Typing endpoints
-  void startTypingRemote(gregor1.UID uid, gregor1.DeviceID deviceID, ConversationID convID);
-  void stopTypingRemote(gregor1.UID uid, gregor1.DeviceID deviceID, ConversationID convID);
+  void updateTypingRemote(gregor1.UID uid, gregor1.DeviceID deviceID, ConversationID convID, boolean typing);
 }

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -209,4 +209,8 @@ protocol remote {
   // Pubsub endpoints
   void publishReadMessage(gregor1.UID uid, ConversationID convID, MessageID msgID);
   void publishSetConversationStatus(gregor1.UID uid, ConversationID convID, ConversationStatus status);
+
+  // Typing endpoints
+  void startTypingRemote(gregor1.UID uid, gregor1.DeviceID deviceID, ConversationID convID);
+  void stopTypingRemote(gregor1.UID uid, gregor1.DeviceID deviceID, ConversationID convID);
 }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -551,6 +551,36 @@ export function localSetConversationStatusLocalRpcPromise (request: $Exact<reque
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.SetConversationStatusLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function localStartTypingRpc (request: Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>) {
+  engineRpcOutgoing('chat.1.local.startTyping', request)
+}
+
+export function localStartTypingRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.startTyping', request)
+}
+export function localStartTypingRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.startTyping', request, callback, incomingCallMap) })
+}
+
+export function localStartTypingRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.startTyping', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function localStopTypingRpc (request: Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>) {
+  engineRpcOutgoing('chat.1.local.stopTyping', request)
+}
+
+export function localStopTypingRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.stopTyping', request)
+}
+export function localStopTypingRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.stopTyping', request, callback, incomingCallMap) })
+}
+
+export function localStopTypingRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.stopTyping', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function remoteGetInboxRemoteRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxRemoteResult) => void} & {param: remoteGetInboxRemoteRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.getInboxRemote', request)
 }
@@ -1540,6 +1570,10 @@ export type NotifyChatChatThreadsStaleRpcParam = Exact<{
   convIDs?: ?Array<ConversationID>
 }>
 
+export type NotifyChatChatTypingUpdateRpcParam = Exact<{
+  typingUpdates?: ?Array<UserTypingUpdate>
+}>
+
 export type NotifyChatNewChatActivityRpcParam = Exact<{
   uid: keybase1.UID,
   activity: ChatActivity
@@ -1770,6 +1804,15 @@ export type UnreadUpdateFull = {
   updates?: ?Array<UnreadUpdate>,
 }
 
+export type UserTypingUpdate = {
+  uid: keybase1.UID,
+  username: string,
+  deviceID: keybase1.DeviceID,
+  deviceName: string,
+  convID: ConversationID,
+  typing: boolean,
+}
+
 export type chatUiChatAttachmentDownloadProgressRpcParam = Exact<{
   bytesComplete: long,
   bytesTotal: long
@@ -1984,6 +2027,14 @@ export type localSetConversationStatusLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
+export type localStartTypingRpcParam = Exact<{
+  conversationID: ConversationID
+}>
+
+export type localStopTypingRpcParam = Exact<{
+  conversationID: ConversationID
+}>
+
 export type remoteGetInboxRemoteRpcParam = Exact<{
   vers: InboxVers,
   query?: ?GetInboxQuery,
@@ -2154,6 +2205,8 @@ export type rpc =
   | localPostTextNonblockRpc
   | localRetryPostRpc
   | localSetConversationStatusLocalRpc
+  | localStartTypingRpc
+  | localStopTypingRpc
   | remoteGetInboxRemoteRpc
   | remoteGetInboxVersionRpc
   | remoteGetMessagesRemoteRpc
@@ -2319,6 +2372,13 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       uid: keybase1.UID,
       convIDs?: ?Array<ConversationID>
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatTypingUpdate'?: (
+    params: Exact<{
+      typingUpdates?: ?Array<UserTypingUpdate>
     }> /* ,
     response: {} // Notify call
     */

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -551,34 +551,19 @@ export function localSetConversationStatusLocalRpcPromise (request: $Exact<reque
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.SetConversationStatusLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localStartTypingRpc (request: Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>) {
-  engineRpcOutgoing('chat.1.local.startTyping', request)
+export function localUpdateTypingRpc (request: Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>) {
+  engineRpcOutgoing('chat.1.local.updateTyping', request)
 }
 
-export function localStartTypingRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.startTyping', request)
+export function localUpdateTypingRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.updateTyping', request)
 }
-export function localStartTypingRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.startTyping', request, callback, incomingCallMap) })
-}
-
-export function localStartTypingRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>): Promise<void> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.startTyping', request, (error, result) => error ? reject(error) : resolve(result)))
+export function localUpdateTypingRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.updateTyping', request, callback, incomingCallMap) })
 }
 
-export function localStopTypingRpc (request: Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>) {
-  engineRpcOutgoing('chat.1.local.stopTyping', request)
-}
-
-export function localStopTypingRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.stopTyping', request)
-}
-export function localStopTypingRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.stopTyping', request, callback, incomingCallMap) })
-}
-
-export function localStopTypingRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>): Promise<void> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.stopTyping', request, (error, result) => error ? reject(error) : resolve(result)))
+export function localUpdateTypingRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.updateTyping', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function remoteGetInboxRemoteRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxRemoteResult) => void} & {param: remoteGetInboxRemoteRpcParam}>) {
@@ -806,36 +791,6 @@ export function remoteSetConversationStatusRpcPromise (request: $Exact<requestCo
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.SetConversationStatus', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteStartTypingRemoteRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>) {
-  engineRpcOutgoing('chat.1.remote.startTypingRemote', request)
-}
-
-export function remoteStartTypingRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.startTypingRemote', request)
-}
-export function remoteStartTypingRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.startTypingRemote', request, callback, incomingCallMap) })
-}
-
-export function remoteStartTypingRemoteRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>): Promise<void> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.startTypingRemote', request, (error, result) => error ? reject(error) : resolve(result)))
-}
-
-export function remoteStopTypingRemoteRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>) {
-  engineRpcOutgoing('chat.1.remote.stopTypingRemote', request)
-}
-
-export function remoteStopTypingRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.stopTypingRemote', request)
-}
-export function remoteStopTypingRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.stopTypingRemote', request, callback, incomingCallMap) })
-}
-
-export function remoteStopTypingRemoteRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>): Promise<void> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.stopTypingRemote', request, (error, result) => error ? reject(error) : resolve(result)))
-}
-
 export function remoteSyncAllRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.syncAll', request)
 }
@@ -909,6 +864,21 @@ export function remoteTlfResolveRpcChannelMapOld (channelConfig: ChannelConfig<*
 
 export function remoteTlfResolveRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteTlfResolveRpcParam}>): Promise<void> {
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.tlfResolve', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function remoteUpdateTypingRemoteRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>) {
+  engineRpcOutgoing('chat.1.remote.updateTypingRemote', request)
+}
+
+export function remoteUpdateTypingRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.updateTypingRemote', request)
+}
+export function remoteUpdateTypingRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.updateTypingRemote', request, callback, incomingCallMap) })
+}
+
+export function remoteUpdateTypingRemoteRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.updateTypingRemote', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export type Asset = {
@@ -1007,6 +977,11 @@ export type ChatActivityType =
   | 3 // NEW_CONVERSATION_3
   | 4 // SET_STATUS_4
   | 5 // FAILED_MESSAGE_5
+
+export type ConvTypingUpdate = {
+  convID: ConversationID,
+  typers?: ?Array<TyperInfo>,
+}
 
 export type Conversation = {
   metadata: ConversationMetadata,
@@ -1601,7 +1576,7 @@ export type NotifyChatChatThreadsStaleRpcParam = Exact<{
 }>
 
 export type NotifyChatChatTypingUpdateRpcParam = Exact<{
-  typingUpdates?: ?Array<UserTypingUpdate>
+  typingUpdates?: ?Array<ConvTypingUpdate>
 }>
 
 export type NotifyChatNewChatActivityRpcParam = Exact<{
@@ -1824,6 +1799,14 @@ export type TopicType =
   | 1 // CHAT_1
   | 2 // DEV_2
 
+export type TyperInfo = {
+  uid: keybase1.UID,
+  username: string,
+  deviceID: keybase1.DeviceID,
+  deviceName: string,
+  deviceType: string,
+}
+
 export type UnreadFirstNumLimit = {
   NumRead: int,
   AtLeast: int,
@@ -1839,16 +1822,6 @@ export type UnreadUpdateFull = {
   ignore: boolean,
   inboxVers: InboxVers,
   updates?: ?Array<UnreadUpdate>,
-}
-
-export type UserTypingUpdate = {
-  uid: keybase1.UID,
-  username: string,
-  deviceID: keybase1.DeviceID,
-  deviceName: string,
-  deviceType: string,
-  convID: ConversationID,
-  typing: boolean,
 }
 
 export type chatUiChatAttachmentDownloadProgressRpcParam = Exact<{
@@ -2065,12 +2038,9 @@ export type localSetConversationStatusLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
-export type localStartTypingRpcParam = Exact<{
-  conversationID: ConversationID
-}>
-
-export type localStopTypingRpcParam = Exact<{
-  conversationID: ConversationID
+export type localUpdateTypingRpcParam = Exact<{
+  conversationID: ConversationID,
+  typing: boolean
 }>
 
 export type remoteGetInboxRemoteRpcParam = Exact<{
@@ -2149,18 +2119,6 @@ export type remoteSetConversationStatusRpcParam = Exact<{
   status: ConversationStatus
 }>
 
-export type remoteStartTypingRemoteRpcParam = Exact<{
-  uid: gregor1.UID,
-  deviceID: gregor1.DeviceID,
-  convID: ConversationID
-}>
-
-export type remoteStopTypingRemoteRpcParam = Exact<{
-  uid: gregor1.UID,
-  deviceID: gregor1.DeviceID,
-  convID: ConversationID
-}>
-
 export type remoteSyncAllRpcParam = Exact<{
   uid: gregor1.UID,
   deviceID: gregor1.DeviceID,
@@ -2190,6 +2148,13 @@ export type remoteTlfResolveRpcParam = Exact<{
   tlfID: TLFID,
   resolvedWriters?: ?Array<gregor1.UID>,
   resolvedReaders?: ?Array<gregor1.UID>
+}>
+
+export type remoteUpdateTypingRemoteRpcParam = Exact<{
+  uid: gregor1.UID,
+  deviceID: gregor1.DeviceID,
+  convID: ConversationID,
+  typing: boolean
 }>
 type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
@@ -2255,8 +2220,7 @@ export type rpc =
   | localPostTextNonblockRpc
   | localRetryPostRpc
   | localSetConversationStatusLocalRpc
-  | localStartTypingRpc
-  | localStopTypingRpc
+  | localUpdateTypingRpc
   | remoteGetInboxRemoteRpc
   | remoteGetInboxVersionRpc
   | remoteGetMessagesRemoteRpc
@@ -2272,13 +2236,12 @@ export type rpc =
   | remotePublishSetConversationStatusRpc
   | remoteS3SignRpc
   | remoteSetConversationStatusRpc
-  | remoteStartTypingRemoteRpc
-  | remoteStopTypingRemoteRpc
   | remoteSyncAllRpc
   | remoteSyncChatRpc
   | remoteSyncInboxRpc
   | remoteTlfFinalizeRpc
   | remoteTlfResolveRpc
+  | remoteUpdateTypingRemoteRpc
 
 export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatAttachmentUploadOutboxID'?: (
@@ -2430,7 +2393,7 @@ export type incomingCallMapType = Exact<{
   ) => void,
   'keybase.1.NotifyChat.ChatTypingUpdate'?: (
     params: Exact<{
-      typingUpdates?: ?Array<UserTypingUpdate>
+      typingUpdates?: ?Array<ConvTypingUpdate>
     }> /* ,
     response: {} // Notify call
     */

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -806,6 +806,36 @@ export function remoteSetConversationStatusRpcPromise (request: $Exact<requestCo
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.SetConversationStatus', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function remoteStartTypingRemoteRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>) {
+  engineRpcOutgoing('chat.1.remote.startTypingRemote', request)
+}
+
+export function remoteStartTypingRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.startTypingRemote', request)
+}
+export function remoteStartTypingRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.startTypingRemote', request, callback, incomingCallMap) })
+}
+
+export function remoteStartTypingRemoteRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.startTypingRemote', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function remoteStopTypingRemoteRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>) {
+  engineRpcOutgoing('chat.1.remote.stopTypingRemote', request)
+}
+
+export function remoteStopTypingRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.stopTypingRemote', request)
+}
+export function remoteStopTypingRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.stopTypingRemote', request, callback, incomingCallMap) })
+}
+
+export function remoteStopTypingRemoteRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.stopTypingRemote', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function remoteSyncAllRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.syncAll', request)
 }
@@ -2111,6 +2141,18 @@ export type remoteSetConversationStatusRpcParam = Exact<{
   status: ConversationStatus
 }>
 
+export type remoteStartTypingRemoteRpcParam = Exact<{
+  uid: gregor1.UID,
+  deviceID: gregor1.DeviceID,
+  convID: ConversationID
+}>
+
+export type remoteStopTypingRemoteRpcParam = Exact<{
+  uid: gregor1.UID,
+  deviceID: gregor1.DeviceID,
+  convID: ConversationID
+}>
+
 export type remoteSyncAllRpcParam = Exact<{
   uid: gregor1.UID,
   deviceID: gregor1.DeviceID,
@@ -2222,6 +2264,8 @@ export type rpc =
   | remotePublishSetConversationStatusRpc
   | remoteS3SignRpc
   | remoteSetConversationStatusRpc
+  | remoteStartTypingRemoteRpc
+  | remoteStopTypingRemoteRpc
   | remoteSyncAllRpc
   | remoteSyncChatRpc
   | remoteSyncInboxRpc

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1689,6 +1689,13 @@ export type ReadMessagePayload = {
   unreadUpdate?: ?UnreadUpdate,
 }
 
+export type RemoteUserTypingUpdate = {
+  uid: gregor1.UID,
+  deviceID: gregor1.DeviceID,
+  convID: ConversationID,
+  typing: boolean,
+}
+
 export type S3Params = {
   bucket: string,
   objectKey: string,
@@ -1839,6 +1846,7 @@ export type UserTypingUpdate = {
   username: string,
   deviceID: keybase1.DeviceID,
   deviceName: string,
+  deviceType: string,
   convID: ConversationID,
   typing: boolean,
 }

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -1,6 +1,12 @@
 {
   "protocol": "gregor",
-  "imports": [],
+  "imports": [
+    {
+      "path": "github.com/keybase/client/go/protocol/gregor1",
+      "type": "idl",
+      "import_as": "gregor1"
+    }
+  ],
   "types": [
     {
       "type": "record",
@@ -184,6 +190,28 @@
         {
           "type": "InboxVers",
           "name": "inboxVers"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "RemoteUserTypingUpdate",
+      "fields": [
+        {
+          "type": "gregor1.UID",
+          "name": "uid"
+        },
+        {
+          "type": "gregor1.DeviceID",
+          "name": "deviceID"
+        },
+        {
+          "type": "ConversationID",
+          "name": "convID"
+        },
+        {
+          "type": "boolean",
+          "name": "typing"
         }
       ]
     }

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2363,28 +2363,15 @@
       ],
       "response": "FindConversationsLocalRes"
     },
-    "startTyping": {
+    "updateTyping": {
       "request": [
-        {
-          "name": "sessionID",
-          "type": "int"
-        },
         {
           "name": "conversationID",
           "type": "ConversationID"
-        }
-      ],
-      "response": null
-    },
-    "stopTyping": {
-      "request": [
-        {
-          "name": "sessionID",
-          "type": "int"
         },
         {
-          "name": "conversationID",
-          "type": "ConversationID"
+          "name": "typing",
+          "type": "boolean"
         }
       ],
       "response": null

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2362,6 +2362,32 @@
         }
       ],
       "response": "FindConversationsLocalRes"
+    },
+    "startTyping": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        }
+      ],
+      "response": null
+    },
+    "stopTyping": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "conversationID",
+          "type": "ConversationID"
+        }
+      ],
+      "response": null
     }
   },
   "namespace": "chat.1"

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -160,7 +160,7 @@
     },
     {
       "type": "record",
-      "name": "UserTypingUpdate",
+      "name": "TyperInfo",
       "fields": [
         {
           "type": "keybase1.UID",
@@ -181,14 +181,23 @@
         {
           "type": "string",
           "name": "deviceType"
-        },
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "ConvTypingUpdate",
+      "fields": [
         {
           "type": "ConversationID",
           "name": "convID"
         },
         {
-          "type": "boolean",
-          "name": "typing"
+          "type": {
+            "type": "array",
+            "items": "TyperInfo"
+          },
+          "name": "typers"
         }
       ]
     }
@@ -300,7 +309,7 @@
           "name": "typingUpdates",
           "type": {
             "type": "array",
-            "items": "UserTypingUpdate"
+            "items": "ConvTypingUpdate"
           }
         }
       ],

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -179,6 +179,10 @@
           "name": "deviceName"
         },
         {
+          "type": "string",
+          "name": "deviceType"
+        },
+        {
           "type": "ConversationID",
           "name": "convID"
         },

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -157,6 +157,36 @@
           "body": "FailedMessageInfo"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "UserTypingUpdate",
+      "fields": [
+        {
+          "type": "keybase1.UID",
+          "name": "uid"
+        },
+        {
+          "type": "string",
+          "name": "username"
+        },
+        {
+          "type": "keybase1.DeviceID",
+          "name": "deviceID"
+        },
+        {
+          "type": "string",
+          "name": "deviceName"
+        },
+        {
+          "type": "ConversationID",
+          "name": "convID"
+        },
+        {
+          "type": "boolean",
+          "name": "typing"
+        }
+      ]
     }
   ],
   "messages": {
@@ -253,6 +283,20 @@
           "type": {
             "type": "array",
             "items": "ConversationID"
+          }
+        }
+      ],
+      "response": null,
+      "notify": "",
+      "lint": "ignore"
+    },
+    "ChatTypingUpdate": {
+      "request": [
+        {
+          "name": "typingUpdates",
+          "type": {
+            "type": "array",
+            "items": "UserTypingUpdate"
           }
         }
       ],

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -753,7 +753,7 @@
       ],
       "response": null
     },
-    "startTypingRemote": {
+    "updateTypingRemote": {
       "request": [
         {
           "name": "uid",
@@ -766,23 +766,10 @@
         {
           "name": "convID",
           "type": "ConversationID"
-        }
-      ],
-      "response": null
-    },
-    "stopTypingRemote": {
-      "request": [
-        {
-          "name": "uid",
-          "type": "gregor1.UID"
         },
         {
-          "name": "deviceID",
-          "type": "gregor1.DeviceID"
-        },
-        {
-          "name": "convID",
-          "type": "ConversationID"
+          "name": "typing",
+          "type": "boolean"
         }
       ],
       "response": null

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -752,6 +752,40 @@
         }
       ],
       "response": null
+    },
+    "startTypingRemote": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "gregor1.UID"
+        },
+        {
+          "name": "deviceID",
+          "type": "gregor1.DeviceID"
+        },
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        }
+      ],
+      "response": null
+    },
+    "stopTypingRemote": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "gregor1.UID"
+        },
+        {
+          "name": "deviceID",
+          "type": "gregor1.DeviceID"
+        },
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        }
+      ],
+      "response": null
     }
   },
   "namespace": "chat.1"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -551,6 +551,36 @@ export function localSetConversationStatusLocalRpcPromise (request: $Exact<reque
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.SetConversationStatusLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function localStartTypingRpc (request: Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>) {
+  engineRpcOutgoing('chat.1.local.startTyping', request)
+}
+
+export function localStartTypingRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.startTyping', request)
+}
+export function localStartTypingRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.startTyping', request, callback, incomingCallMap) })
+}
+
+export function localStartTypingRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.startTyping', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function localStopTypingRpc (request: Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>) {
+  engineRpcOutgoing('chat.1.local.stopTyping', request)
+}
+
+export function localStopTypingRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.stopTyping', request)
+}
+export function localStopTypingRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.stopTyping', request, callback, incomingCallMap) })
+}
+
+export function localStopTypingRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.stopTyping', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function remoteGetInboxRemoteRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxRemoteResult) => void} & {param: remoteGetInboxRemoteRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.getInboxRemote', request)
 }
@@ -1540,6 +1570,10 @@ export type NotifyChatChatThreadsStaleRpcParam = Exact<{
   convIDs?: ?Array<ConversationID>
 }>
 
+export type NotifyChatChatTypingUpdateRpcParam = Exact<{
+  typingUpdates?: ?Array<UserTypingUpdate>
+}>
+
 export type NotifyChatNewChatActivityRpcParam = Exact<{
   uid: keybase1.UID,
   activity: ChatActivity
@@ -1770,6 +1804,15 @@ export type UnreadUpdateFull = {
   updates?: ?Array<UnreadUpdate>,
 }
 
+export type UserTypingUpdate = {
+  uid: keybase1.UID,
+  username: string,
+  deviceID: keybase1.DeviceID,
+  deviceName: string,
+  convID: ConversationID,
+  typing: boolean,
+}
+
 export type chatUiChatAttachmentDownloadProgressRpcParam = Exact<{
   bytesComplete: long,
   bytesTotal: long
@@ -1984,6 +2027,14 @@ export type localSetConversationStatusLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
+export type localStartTypingRpcParam = Exact<{
+  conversationID: ConversationID
+}>
+
+export type localStopTypingRpcParam = Exact<{
+  conversationID: ConversationID
+}>
+
 export type remoteGetInboxRemoteRpcParam = Exact<{
   vers: InboxVers,
   query?: ?GetInboxQuery,
@@ -2154,6 +2205,8 @@ export type rpc =
   | localPostTextNonblockRpc
   | localRetryPostRpc
   | localSetConversationStatusLocalRpc
+  | localStartTypingRpc
+  | localStopTypingRpc
   | remoteGetInboxRemoteRpc
   | remoteGetInboxVersionRpc
   | remoteGetMessagesRemoteRpc
@@ -2319,6 +2372,13 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       uid: keybase1.UID,
       convIDs?: ?Array<ConversationID>
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatTypingUpdate'?: (
+    params: Exact<{
+      typingUpdates?: ?Array<UserTypingUpdate>
     }> /* ,
     response: {} // Notify call
     */

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -551,34 +551,19 @@ export function localSetConversationStatusLocalRpcPromise (request: $Exact<reque
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.SetConversationStatusLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localStartTypingRpc (request: Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>) {
-  engineRpcOutgoing('chat.1.local.startTyping', request)
+export function localUpdateTypingRpc (request: Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>) {
+  engineRpcOutgoing('chat.1.local.updateTyping', request)
 }
 
-export function localStartTypingRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.startTyping', request)
+export function localUpdateTypingRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.updateTyping', request)
 }
-export function localStartTypingRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.startTyping', request, callback, incomingCallMap) })
-}
-
-export function localStartTypingRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localStartTypingRpcParam}>): Promise<void> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.startTyping', request, (error, result) => error ? reject(error) : resolve(result)))
+export function localUpdateTypingRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.updateTyping', request, callback, incomingCallMap) })
 }
 
-export function localStopTypingRpc (request: Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>) {
-  engineRpcOutgoing('chat.1.local.stopTyping', request)
-}
-
-export function localStopTypingRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.stopTyping', request)
-}
-export function localStopTypingRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.stopTyping', request, callback, incomingCallMap) })
-}
-
-export function localStopTypingRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localStopTypingRpcParam}>): Promise<void> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.stopTyping', request, (error, result) => error ? reject(error) : resolve(result)))
+export function localUpdateTypingRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.updateTyping', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export function remoteGetInboxRemoteRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxRemoteResult) => void} & {param: remoteGetInboxRemoteRpcParam}>) {
@@ -806,36 +791,6 @@ export function remoteSetConversationStatusRpcPromise (request: $Exact<requestCo
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.SetConversationStatus', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteStartTypingRemoteRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>) {
-  engineRpcOutgoing('chat.1.remote.startTypingRemote', request)
-}
-
-export function remoteStartTypingRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.startTypingRemote', request)
-}
-export function remoteStartTypingRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.startTypingRemote', request, callback, incomingCallMap) })
-}
-
-export function remoteStartTypingRemoteRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>): Promise<void> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.startTypingRemote', request, (error, result) => error ? reject(error) : resolve(result)))
-}
-
-export function remoteStopTypingRemoteRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>) {
-  engineRpcOutgoing('chat.1.remote.stopTypingRemote', request)
-}
-
-export function remoteStopTypingRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>): EngineChannel {
-  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.stopTypingRemote', request)
-}
-export function remoteStopTypingRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.stopTypingRemote', request, callback, incomingCallMap) })
-}
-
-export function remoteStopTypingRemoteRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>): Promise<void> {
-  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.stopTypingRemote', request, (error, result) => error ? reject(error) : resolve(result)))
-}
-
 export function remoteSyncAllRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.syncAll', request)
 }
@@ -909,6 +864,21 @@ export function remoteTlfResolveRpcChannelMapOld (channelConfig: ChannelConfig<*
 
 export function remoteTlfResolveRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteTlfResolveRpcParam}>): Promise<void> {
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.tlfResolve', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function remoteUpdateTypingRemoteRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>) {
+  engineRpcOutgoing('chat.1.remote.updateTypingRemote', request)
+}
+
+export function remoteUpdateTypingRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.updateTypingRemote', request)
+}
+export function remoteUpdateTypingRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.updateTypingRemote', request, callback, incomingCallMap) })
+}
+
+export function remoteUpdateTypingRemoteRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.updateTypingRemote', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export type Asset = {
@@ -1007,6 +977,11 @@ export type ChatActivityType =
   | 3 // NEW_CONVERSATION_3
   | 4 // SET_STATUS_4
   | 5 // FAILED_MESSAGE_5
+
+export type ConvTypingUpdate = {
+  convID: ConversationID,
+  typers?: ?Array<TyperInfo>,
+}
 
 export type Conversation = {
   metadata: ConversationMetadata,
@@ -1601,7 +1576,7 @@ export type NotifyChatChatThreadsStaleRpcParam = Exact<{
 }>
 
 export type NotifyChatChatTypingUpdateRpcParam = Exact<{
-  typingUpdates?: ?Array<UserTypingUpdate>
+  typingUpdates?: ?Array<ConvTypingUpdate>
 }>
 
 export type NotifyChatNewChatActivityRpcParam = Exact<{
@@ -1824,6 +1799,14 @@ export type TopicType =
   | 1 // CHAT_1
   | 2 // DEV_2
 
+export type TyperInfo = {
+  uid: keybase1.UID,
+  username: string,
+  deviceID: keybase1.DeviceID,
+  deviceName: string,
+  deviceType: string,
+}
+
 export type UnreadFirstNumLimit = {
   NumRead: int,
   AtLeast: int,
@@ -1839,16 +1822,6 @@ export type UnreadUpdateFull = {
   ignore: boolean,
   inboxVers: InboxVers,
   updates?: ?Array<UnreadUpdate>,
-}
-
-export type UserTypingUpdate = {
-  uid: keybase1.UID,
-  username: string,
-  deviceID: keybase1.DeviceID,
-  deviceName: string,
-  deviceType: string,
-  convID: ConversationID,
-  typing: boolean,
 }
 
 export type chatUiChatAttachmentDownloadProgressRpcParam = Exact<{
@@ -2065,12 +2038,9 @@ export type localSetConversationStatusLocalRpcParam = Exact<{
   identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
-export type localStartTypingRpcParam = Exact<{
-  conversationID: ConversationID
-}>
-
-export type localStopTypingRpcParam = Exact<{
-  conversationID: ConversationID
+export type localUpdateTypingRpcParam = Exact<{
+  conversationID: ConversationID,
+  typing: boolean
 }>
 
 export type remoteGetInboxRemoteRpcParam = Exact<{
@@ -2149,18 +2119,6 @@ export type remoteSetConversationStatusRpcParam = Exact<{
   status: ConversationStatus
 }>
 
-export type remoteStartTypingRemoteRpcParam = Exact<{
-  uid: gregor1.UID,
-  deviceID: gregor1.DeviceID,
-  convID: ConversationID
-}>
-
-export type remoteStopTypingRemoteRpcParam = Exact<{
-  uid: gregor1.UID,
-  deviceID: gregor1.DeviceID,
-  convID: ConversationID
-}>
-
 export type remoteSyncAllRpcParam = Exact<{
   uid: gregor1.UID,
   deviceID: gregor1.DeviceID,
@@ -2190,6 +2148,13 @@ export type remoteTlfResolveRpcParam = Exact<{
   tlfID: TLFID,
   resolvedWriters?: ?Array<gregor1.UID>,
   resolvedReaders?: ?Array<gregor1.UID>
+}>
+
+export type remoteUpdateTypingRemoteRpcParam = Exact<{
+  uid: gregor1.UID,
+  deviceID: gregor1.DeviceID,
+  convID: ConversationID,
+  typing: boolean
 }>
 type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
@@ -2255,8 +2220,7 @@ export type rpc =
   | localPostTextNonblockRpc
   | localRetryPostRpc
   | localSetConversationStatusLocalRpc
-  | localStartTypingRpc
-  | localStopTypingRpc
+  | localUpdateTypingRpc
   | remoteGetInboxRemoteRpc
   | remoteGetInboxVersionRpc
   | remoteGetMessagesRemoteRpc
@@ -2272,13 +2236,12 @@ export type rpc =
   | remotePublishSetConversationStatusRpc
   | remoteS3SignRpc
   | remoteSetConversationStatusRpc
-  | remoteStartTypingRemoteRpc
-  | remoteStopTypingRemoteRpc
   | remoteSyncAllRpc
   | remoteSyncChatRpc
   | remoteSyncInboxRpc
   | remoteTlfFinalizeRpc
   | remoteTlfResolveRpc
+  | remoteUpdateTypingRemoteRpc
 
 export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatAttachmentUploadOutboxID'?: (
@@ -2430,7 +2393,7 @@ export type incomingCallMapType = Exact<{
   ) => void,
   'keybase.1.NotifyChat.ChatTypingUpdate'?: (
     params: Exact<{
-      typingUpdates?: ?Array<UserTypingUpdate>
+      typingUpdates?: ?Array<ConvTypingUpdate>
     }> /* ,
     response: {} // Notify call
     */

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -806,6 +806,36 @@ export function remoteSetConversationStatusRpcPromise (request: $Exact<requestCo
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.SetConversationStatus', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function remoteStartTypingRemoteRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>) {
+  engineRpcOutgoing('chat.1.remote.startTypingRemote', request)
+}
+
+export function remoteStartTypingRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.startTypingRemote', request)
+}
+export function remoteStartTypingRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.startTypingRemote', request, callback, incomingCallMap) })
+}
+
+export function remoteStartTypingRemoteRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteStartTypingRemoteRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.startTypingRemote', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
+export function remoteStopTypingRemoteRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>) {
+  engineRpcOutgoing('chat.1.remote.stopTypingRemote', request)
+}
+
+export function remoteStopTypingRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.stopTypingRemote', request)
+}
+export function remoteStopTypingRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.stopTypingRemote', request, callback, incomingCallMap) })
+}
+
+export function remoteStopTypingRemoteRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteStopTypingRemoteRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.stopTypingRemote', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function remoteSyncAllRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.syncAll', request)
 }
@@ -2111,6 +2141,18 @@ export type remoteSetConversationStatusRpcParam = Exact<{
   status: ConversationStatus
 }>
 
+export type remoteStartTypingRemoteRpcParam = Exact<{
+  uid: gregor1.UID,
+  deviceID: gregor1.DeviceID,
+  convID: ConversationID
+}>
+
+export type remoteStopTypingRemoteRpcParam = Exact<{
+  uid: gregor1.UID,
+  deviceID: gregor1.DeviceID,
+  convID: ConversationID
+}>
+
 export type remoteSyncAllRpcParam = Exact<{
   uid: gregor1.UID,
   deviceID: gregor1.DeviceID,
@@ -2222,6 +2264,8 @@ export type rpc =
   | remotePublishSetConversationStatusRpc
   | remoteS3SignRpc
   | remoteSetConversationStatusRpc
+  | remoteStartTypingRemoteRpc
+  | remoteStopTypingRemoteRpc
   | remoteSyncAllRpc
   | remoteSyncChatRpc
   | remoteSyncInboxRpc

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1689,6 +1689,13 @@ export type ReadMessagePayload = {
   unreadUpdate?: ?UnreadUpdate,
 }
 
+export type RemoteUserTypingUpdate = {
+  uid: gregor1.UID,
+  deviceID: gregor1.DeviceID,
+  convID: ConversationID,
+  typing: boolean,
+}
+
 export type S3Params = {
   bucket: string,
   objectKey: string,
@@ -1839,6 +1846,7 @@ export type UserTypingUpdate = {
   username: string,
   deviceID: keybase1.DeviceID,
   deviceName: string,
+  deviceType: string,
   convID: ConversationID,
   typing: boolean,
 }


### PR DESCRIPTION
Support for implementing typing notifications. The patch works like the following:

1.) The goal is to generate `chat1.ConvTypingUpdate` lists for the frontend to consume. Anytime there is a change to the typing status of a conversation, we generate a `NotifyRouter` RPC call that lists the current typers for the conversation. If the list is empty, no one is typing. This should make it so the frontend needs to put very little in the store (if anything), and can rely on the service to maintain the state.
2.) `TypingMonitor` is responsible for timing out typing notifications. It will spawn a goroutine for each typing update (for starting typing) that will wait a maximum of 10 seconds for either a stop (in which case it will end and notify the frontend), or another start which will extend the wait time by another 10 seconds. We will extend a maximum of 50 times. If we hit the 10 second timer, we generate a notification to the frontend.
3.) If we receive a new message notification from Gregor, we will also generate a stop and typing update for that conversation.
4.) Typing notifications are per user per device. That way, if a user is typing on more than one device, we could display that info (if we wanted to). Device name and type are also plumbed in the notifications.
5.) The frontend just needs to call `UpdateTyping` on the service with either true or false to update the state of typing for the current user.

cc @cjb 