### PR TITLE
Fix loadedOffline on reachability changed

### DIFF
--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -490,13 +490,11 @@ function reducer (state: Constants.State = initialState, action: Constants.Actio
       return state.update('attachmentPlaceholderPreviews', previews => previews.delete(outboxID))
     }
     case 'gregor:updateReachability': { // reset this when we go online
-      if (action.payload.reachability.reachable === ReachabilityReachable.yes) {
-        const newConversationStates = state.get('conversationStates').map(
-          conversation => conversation.set('loadedOffline', false)
-        )
-        return state.set('conversationStates', newConversationStates)
-      }
-      break
+      const offline = action.payload.reachability.reachable === ReachabilityReachable.no
+      const newConversationStates = state.get('conversationStates').map(
+        conversation => conversation.set('loadedOffline', offline)
+      )
+      return state.set('conversationStates', newConversationStates)
     }
     case 'chat:inboxUntrustedState': {
       return state.set('inboxUntrustedState', action.payload.inboxUntrustedState)


### PR DESCRIPTION
The conversationState `loadedOffline` wasn't being set to true, when reachability updated.

Or is it that we are missing a `chat:threadLoadedOffline` call? @mmaxim 

To reproduce:
- Open app
- Go into conversation
- Turn off wifi, wait for offline
- Turn on wifi, wait for online
- Turn off wifi, wait for offline

At this point the offline header is missing and chat thread aren't marked offline