### PR TITLE
add inbox version to badger update CORE-5148

### DIFF
--- a/go/badges/badger.go
+++ b/go/badges/badger.go
@@ -6,7 +6,6 @@ package badges
 import (
 	"golang.org/x/net/context"
 
-	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
@@ -32,17 +31,15 @@ func (n nullInboxVersionSource) GetInboxVersion(ctx context.Context, uid gregor1
 // - Logout
 type Badger struct {
 	libkb.Contextified
-	globals.ChatContextified
 	badgeState     *BadgeState
 	iboxVersSource InboxVersionSource
 }
 
-func NewBadger(g *libkb.GlobalContext, cg *globals.ChatContext) *Badger {
+func NewBadger(g *libkb.GlobalContext) *Badger {
 	return &Badger{
-		Contextified:     libkb.NewContextified(g),
-		ChatContextified: globals.NewChatContextified(cg),
-		badgeState:       NewBadgeState(g.Log),
-		iboxVersSource:   nullInboxVersionSource{},
+		Contextified:   libkb.NewContextified(g),
+		badgeState:     NewBadgeState(g.Log),
+		iboxVersSource: nullInboxVersionSource{},
 	}
 }
 

--- a/go/badges/badger.go
+++ b/go/badges/badger.go
@@ -7,12 +7,22 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/chat/globals"
-	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
+
+type InboxVersionSource interface {
+	GetInboxVersion(context.Context, gregor1.UID) (chat1.InboxVers, error)
+}
+
+type nullInboxVersionSource struct {
+}
+
+func (n nullInboxVersionSource) GetInboxVersion(ctx context.Context, uid gregor1.UID) (chat1.InboxVers, error) {
+	return chat1.InboxVers(0), nil
+}
 
 // Badger keeps a BadgeState up to date and broadcasts it to electron.
 // This is the client-specific glue.
@@ -23,7 +33,8 @@ import (
 type Badger struct {
 	libkb.Contextified
 	globals.ChatContextified
-	badgeState *BadgeState
+	badgeState     *BadgeState
+	iboxVersSource InboxVersionSource
 }
 
 func NewBadger(g *libkb.GlobalContext, cg *globals.ChatContext) *Badger {
@@ -31,7 +42,12 @@ func NewBadger(g *libkb.GlobalContext, cg *globals.ChatContext) *Badger {
 		Contextified:     libkb.NewContextified(g),
 		ChatContextified: globals.NewChatContextified(cg),
 		badgeState:       NewBadgeState(g.Log),
+		iboxVersSource:   nullInboxVersionSource{},
 	}
+}
+
+func (b *Badger) SetInboxVersionSource(s InboxVersionSource) {
+	b.iboxVersSource = s
 }
 
 func (b *Badger) PushState(state gregor1.State) {
@@ -54,7 +70,7 @@ func (b *Badger) PushChatUpdate(update chat1.UnreadUpdate, inboxVers chat1.Inbox
 
 func (b *Badger) inboxVersion(ctx context.Context) chat1.InboxVers {
 	uid := b.G().Env.GetUID()
-	vers, err := storage.NewInbox(globals.NewContext(b.G(), b.ChatG()), uid.ToBytes()).Version(ctx)
+	vers, err := b.iboxVersSource.GetInboxVersion(ctx, uid.ToBytes())
 	if err != nil {
 		b.G().Log.Debug("Badger: inboxVersion error: %s", err.Error())
 		return chat1.InboxVers(0)

--- a/go/badges/badgestate.go
+++ b/go/badges/badgestate.go
@@ -47,6 +47,7 @@ func (b *BadgeState) Export() (keybase1.BadgeState, error) {
 	for _, info := range b.chatUnreadMap {
 		b.state.Conversations = append(b.state.Conversations, info)
 	}
+	b.state.InboxVers = int(b.inboxVers)
 
 	return b.state, nil
 }

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -1,18 +1,12 @@
 package storage
 
 import (
-	"context"
-	"fmt"
-
-	"time"
-
 	"bytes"
-
-	"sort"
-
 	"crypto/sha1"
-
 	"encoding/hex"
+	"fmt"
+	"sort"
+	"time"
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/pager"
@@ -20,6 +14,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
+	"golang.org/x/net/context"
 )
 
 const inboxVersion = 11
@@ -954,4 +949,18 @@ func (i *Inbox) Sync(ctx context.Context, vers chat1.InboxVers, convs []chat1.Co
 	}
 
 	return nil
+}
+
+type InboxVersionSource struct {
+	globals.Contextified
+}
+
+func NewInboxVersionSource(g *globals.Context) *InboxVersionSource {
+	return &InboxVersionSource{
+		Contextified: globals.NewContextified(g),
+	}
+}
+
+func (i *InboxVersionSource) GetInboxVersion(ctx context.Context, uid gregor1.UID) (chat1.InboxVers, error) {
+	return NewInbox(i.G(), uid).Version(ctx)
 }

--- a/go/protocol/keybase1/notify_badges.go
+++ b/go/protocol/keybase1/notify_badges.go
@@ -13,6 +13,7 @@ type BadgeState struct {
 	NewTlfs       int                     `codec:"newTlfs" json:"newTlfs"`
 	RekeysNeeded  int                     `codec:"rekeysNeeded" json:"rekeysNeeded"`
 	NewFollowers  int                     `codec:"newFollowers" json:"newFollowers"`
+	InboxVers     int                     `codec:"inboxVers" json:"inboxVers"`
 	Conversations []BadgeConversationInfo `codec:"conversations" json:"conversations"`
 }
 

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -613,7 +613,7 @@ func TestGregorBadgesIBM(t *testing.T) {
 
 	// Set up client and server
 	h, server, uid := setupSyncTests(t, tc)
-	h.badger = badges.NewBadger(tc.G, nil)
+	h.badger = badges.NewBadger(tc.G)
 	t.Logf("client setup complete")
 
 	t.Logf("server message")
@@ -657,7 +657,7 @@ func TestGregorBadgesOOBM(t *testing.T) {
 
 	// Set up client and server
 	h, _, _ := setupSyncTests(t, tc)
-	h.badger = badges.NewBadger(tc.G, nil)
+	h.badger = badges.NewBadger(tc.G)
 	t.Logf("client setup complete")
 
 	t.Logf("sending first chat update")

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -62,7 +62,7 @@ func NewService(g *libkb.GlobalContext, isDaemon bool) *Service {
 		logForwarder:     newLogFwd(),
 		rekeyMaster:      newRekeyMaster(g),
 		attachmentstore:  chat.NewAttachmentStore(g.Log, g.Env.GetRuntimeDir()),
-		badger:           badges.NewBadger(g, chatG.ChatG()),
+		badger:           badges.NewBadger(g),
 		gregor:           newGregorHandler(globals.NewContext(g, chatG.ChatG())),
 	}
 }

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -291,6 +291,7 @@ func (d *Service) createChatModules() {
 	g.ConvLoader = chat.NewBackgroundConvLoader(g)
 
 	// Set up push handler with the badger
+	d.badger.SetInboxVersionSource(storage.NewInboxVersionSource(g))
 	pushHandler := chat.NewPushHandler(g)
 	pushHandler.SetBadger(d.badger)
 	g.PushHandler = pushHandler

--- a/protocol/avdl/keybase1/notify_badges.avdl
+++ b/protocol/avdl/keybase1/notify_badges.avdl
@@ -9,6 +9,7 @@ protocol NotifyBadges {
     int newTlfs;
     int rekeysNeeded;
     int newFollowers;
+    int inboxVers;
 
     array<BadgeConversationInfo> conversations;
   }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3872,6 +3872,7 @@ export type BadgeState = {
   newTlfs: int,
   rekeysNeeded: int,
   newFollowers: int,
+  inboxVers: int,
   conversations?: ?Array<BadgeConversationInfo>,
 }
 

--- a/protocol/json/keybase1/notify_badges.json
+++ b/protocol/json/keybase1/notify_badges.json
@@ -31,6 +31,10 @@
           "name": "newFollowers"
         },
         {
+          "type": "int",
+          "name": "inboxVers"
+        },
+        {
           "type": {
             "type": "array",
             "items": "BadgeConversationInfo"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3872,6 +3872,7 @@ export type BadgeState = {
   newTlfs: int,
   rekeysNeeded: int,
   newFollowers: int,
+  inboxVers: int,
   conversations?: ?Array<BadgeConversationInfo>,
 }
 


### PR DESCRIPTION
Patch does two things:

1.) Adds inbox version to the payload we send through `NotifyRouter` for badging updates.
2.) Breaks dependency of `badges` packages on any `chat` package.