### PR TITLE
Change g.logUI calls in gpg_cli.go

### DIFF
--- a/go/libkb/gpg_cli.go
+++ b/go/libkb/gpg_cli.go
@@ -63,7 +63,7 @@ func (g *GpgCLI) Configure() (err error) {
 		return err
 	}
 
-	g.logUI.Debug("| configured GPG w/ path: %s", prog)
+	g.G().Log.Debug("| configured GPG w/ path: %s", prog)
 
 	g.path = prog
 	g.options = opts
@@ -219,10 +219,10 @@ func (g *GpgCLI) Version() (string, error) {
 func (g *GpgCLI) outputVersion() {
 	v, err := g.Version()
 	if err != nil {
-		g.logUI.Debug("error getting GPG version: %s", err)
+		g.G().Log.Debug("error getting GPG version: %s", err)
 		return
 	}
-	g.logUI.Debug("GPG version:\n%s", v)
+	g.G().Log.Debug("GPG version:\n%s", v)
 }
 
 func (g *GpgCLI) SemanticVersion() (*semver.Version, error) {
@@ -320,7 +320,7 @@ func (g *GpgCLI) Run2(arg RunGpg2Arg) (res RunGpg2Res) {
 	if !arg.Stdout {
 		out++
 		go func() {
-			ch <- DrainPipe(stdout, func(s string) { g.logUI.Debug(s) })
+			ch <- DrainPipe(stdout, func(s string) { g.G().Log.Debug(s) })
 		}()
 	} else {
 		res.Stdout = stdout
@@ -329,7 +329,7 @@ func (g *GpgCLI) Run2(arg RunGpg2Arg) (res RunGpg2Res) {
 	if !arg.Stderr {
 		out++
 		go func() {
-			ch <- DrainPipe(stderr, func(s string) { g.logUI.Debug(s) })
+			ch <- DrainPipe(stderr, func(s string) { g.G().Log.Debug(s) })
 		}()
 	} else {
 		res.Stderr = stderr
@@ -350,16 +350,16 @@ func (g *GpgCLI) MakeCmd(args []string, tty string) *exec.Cmd {
 	if g.G().Service {
 		nargs = append([]string{"--no-tty"}, nargs...)
 	}
-	g.logUI.Debug("| running Gpg: %s %s", g.path, strings.Join(nargs, " "))
+	g.G().Log.Debug("| running Gpg: %s %s", g.path, strings.Join(nargs, " "))
 	ret := exec.Command(g.path, nargs...)
 	if tty == "" {
 		tty = g.tty
 	}
 	if tty != "" {
 		ret.Env = append(os.Environ(), "GPG_TTY="+tty)
-		g.logUI.Debug("| setting GPG_TTY=%s", tty)
+		g.G().Log.Debug("| setting GPG_TTY=%s", tty)
 	} else {
-		g.logUI.Debug("| no tty provided, GPG_TTY will not be changed")
+		g.G().Log.Debug("| no tty provided, GPG_TTY will not be changed")
 	}
 	return ret
 }


### PR DESCRIPTION
It seems to bring back gpg related logging:
```
» grep -A 2 "GPG version" keybase.service.log
2017-05-12T21:49:05.728784+02:00 ▶ [DEBU keybase gpg_cli.go:225] 106 GPG version:
gpg (GnuPG) 2.1.15
```