### PR TITLE
don't insta fail send when offline unless we have been offline for awhile CORE-5128

### DIFF
--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -478,6 +478,7 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 }
 
 const deliverMaxAttempts = 5
+const deliverDisconnectLimitMinutes = 1
 
 type DelivererInfoError interface {
 	IsImmediateFail() (chat1.OutboxErrorType, bool)
@@ -496,6 +497,7 @@ type Deliverer struct {
 	reconnectCh   chan struct{}
 	delivering    bool
 	connected     bool
+	disconnTime   time.Time
 	clock         clockwork.Clock
 }
 
@@ -577,6 +579,14 @@ func (s *Deliverer) Connected(ctx context.Context) {
 func (s *Deliverer) Disconnected(ctx context.Context) {
 	s.Debug(ctx, "disconnected: all errors from now on will be permanent")
 	s.connected = false
+	s.disconnTime = s.clock.Now()
+}
+
+func (s *Deliverer) disconnectedTime() time.Duration {
+	if s.connected {
+		return 0
+	}
+	return s.clock.Now().Sub(s.disconnTime)
 }
 
 func (s *Deliverer) IsOffline() bool {
@@ -601,10 +611,18 @@ func (s *Deliverer) Queue(ctx context.Context, convID chat1.ConversationID, msg 
 	return obr, nil
 }
 
-func (s *Deliverer) doNotRetryFailure(obr chat1.OutboxRecord, err error) (chat1.OutboxErrorType, bool) {
+func (s *Deliverer) doNotRetryFailure(ctx context.Context, obr chat1.OutboxRecord, err error) (chat1.OutboxErrorType, bool) {
 
 	if !s.connected {
-		return chat1.OutboxErrorType_OFFLINE, true
+		// Check to see how long we have been disconnected to see if this should be retried
+		disconnTime := s.disconnectedTime()
+		noretry := false
+		if disconnTime.Minutes() > deliverDisconnectLimitMinutes {
+			noretry = true
+			s.Debug(ctx, "doNotRetryFailure: not retrying offline failure, disconnected for: %v",
+				disconnTime)
+		}
+		return chat1.OutboxErrorType_OFFLINE, noretry
 	}
 
 	// Check for an identify error
@@ -688,7 +706,7 @@ func (s *Deliverer) deliverLoop() {
 					s.outbox.GetUID(), obr.ConvID, err.Error(), obr.State.Sending())
 
 				// Process failure. If we determine that the message is unrecoverable, then bail out.
-				if errTyp, ok := s.doNotRetryFailure(obr, err); ok {
+				if errTyp, ok := s.doNotRetryFailure(bgctx, obr, err); ok {
 					// Record failure if we hit this case, and put the rest of this loop in a
 					// mode where all other entries also fail.
 					s.Debug(bgctx, "failure condition reached, marking all as errors and notifying: errTyp: %v attempts: %d", errTyp, obr.State.Sending())

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -478,7 +478,7 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 }
 
 const deliverMaxAttempts = 5
-const deliverDisconnectLimitMinutes = 1
+const deliverDisconnectLimitMinutes = 10 // need to be offline for at least 10 minutes before auto failing a send
 
 type DelivererInfoError interface {
 	IsImmediateFail() (chat1.OutboxErrorType, bool)

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -481,12 +481,42 @@ func TestDisconnectedFailure(t *testing.T) {
 	res := startConv(t, u, trip, baseSender, ri, tc)
 
 	tc.ChatG.MessageDeliverer.Disconnected(context.TODO())
+	tc.ChatG.MessageDeliverer.(*Deliverer).SetSender(baseSender)
+
+	// If not offline for long enough, we should be able to get a send by just reconnecting
+	obid, _, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Conv:      trip,
+			Sender:    u.User.GetUID().ToBytes(),
+			TlfName:   u.Username,
+			TlfPublic: false,
+		},
+	}, 0)
+	require.NoError(t, err)
+	cl.Advance(time.Millisecond)
+	select {
+	case <-listener.failing:
+		require.Fail(t, "no failed message")
+	default:
+	}
+	tc.ChatG.MessageDeliverer.Connected(context.TODO())
+	select {
+	case inc := <-listener.incoming:
+		require.Equal(t, 1, inc)
+		require.Equal(t, obid, listener.obids[0])
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no incoming message")
+	}
+	listener.obids = nil
+
+	tc.ChatG.MessageDeliverer.Disconnected(context.TODO())
 	tc.ChatG.MessageDeliverer.(*Deliverer).SetSender(FailingSender{})
+	cl.Advance(time.Hour)
 
 	// Send nonblock
 	obids := []chat1.OutboxID{}
 	for i := 0; i < 3; i++ {
-		obid, _, _, err := sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
+		obid, _, _, err = sender.Send(context.TODO(), res.ConvID, chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
 				Conv:      trip,
 				Sender:    u.User.GetUID().ToBytes(),

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -453,12 +453,15 @@ func TestFailingSender(t *testing.T) {
 	}
 
 	var recvd []chat1.OutboxRecord
-	for i := 0; i < 5; i++ {
+	for {
 		select {
 		case fid := <-listener.failing:
 			recvd = append(recvd, fid...)
 		case <-time.After(20 * time.Second):
-			require.Fail(t, "event not received")
+			require.Fail(t, "event not received", "len(recvd): %d", len(recvd))
+		}
+		if len(recvd) >= len(obids) {
+			break
 		}
 	}
 


### PR DESCRIPTION
It can be frustrating to send a message when offline and have it fail instantly, a lot of times a user will be coming back online soon (like in an elevator, or in a tunnel). With this change, the system will retry the message itself as long as we have been offline for less than 10 minutes.