### PR TITLE
fix conneciton handling problems on the mobile app 

### DIFF
--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -10,6 +10,7 @@ import (
 )
 
 var ErrChatServerTimeout = errors.New("timeout calling chat server")
+var ErrDuplicateConnection = errors.New("duplicate chat server connection established, failing")
 
 type UnboxingError interface {
 	Error() string

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -99,6 +99,8 @@ func (h *Server) isOfflineError(err error) bool {
 		fallthrough
 	case ErrChatServerTimeout:
 		return true
+	case ErrDuplicateConnection:
+		return true
 	}
 
 	return false

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -227,7 +227,6 @@ func (g *gregorHandler) monitorAppState() {
 			if err := g.Connect(g.uri); err != nil {
 				g.chatLog.Debug(context.Background(), "error reconnecting")
 			}
-
 		case keybase1.AppState_INACTIVE, keybase1.AppState_BACKGROUND:
 			g.chatLog.Debug(context.Background(), "backgrounded, shutting down connection")
 			g.Shutdown()

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -227,7 +227,8 @@ func (g *gregorHandler) monitorAppState() {
 			if err := g.Connect(g.uri); err != nil {
 				g.chatLog.Debug(context.Background(), "error reconnecting")
 			}
-		case keybase1.AppState_INACTIVE:
+
+		case keybase1.AppState_INACTIVE, keybase1.AppState_BACKGROUND:
 			g.chatLog.Debug(context.Background(), "backgrounded, shutting down connection")
 			g.Shutdown()
 		}

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -35,8 +35,6 @@ import (
 const GregorRequestTimeout time.Duration = 30 * time.Second
 const GregorConnectionRetryInterval time.Duration = 2 * time.Second
 
-var errDuplicateConnection = errors.New("OnConnect called from duplicate connection, failing")
-
 type IdentifyUIHandler struct {
 	libkb.Contextified
 	connID      libkb.ConnectionID
@@ -583,7 +581,7 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 	// If we get a random OnConnect on some other connection that is not g.conn, then
 	// just reject it.
 	if conn != g.conn {
-		return errDuplicateConnection
+		return chat.ErrDuplicateConnection
 	}
 
 	timeoutCli := WrapGenericClientWithTimeout(cli, GregorRequestTimeout, chat.ErrChatServerTimeout)
@@ -715,7 +713,7 @@ func (g *gregorHandler) ShouldRetryOnConnect(err error) bool {
 
 	ctx := context.Background()
 	g.chatLog.Debug(ctx, "should retry on connect, err %v", err)
-	if err == errDuplicateConnection {
+	if err == chat.ErrDuplicateConnection {
 		g.chatLog.Debug(ctx, "duplicate connection error, not retrying")
 		return false
 	}


### PR DESCRIPTION
The point of this PR is to fix the following scenarios:

1.) Backgrounding on the Android app seems to skip `INACTIVE` all the time. Shutdown the connection on `INACTIVE` or `BACKGROUND`. 
2.) Stop the duplicate connection error from working its way into a black bar.

cc @chrisnojima 