### PR TITLE
Add 'Other person is typing' support on desktop and mobile

### DIFF
--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -307,6 +307,21 @@ function incomingMessage(activity: ChatTypes.ChatActivity): Constants.IncomingMe
   return {payload: {activity}, type: 'chat:incomingMessage'}
 }
 
+function incomingTyping(activity: ChatTypes.TyperInfo): Constants.IncomingTyping {
+  return {payload: {activity}, type: 'chat:incomingTyping'}
+}
+
+function updateTyping(
+  conversationIDKey: Constants.ConversationIDKey,
+  typing: boolean
+): Constants.UpdateTyping {
+  return {payload: {conversationIDKey, typing}, type: 'chat:updateTyping'}
+}
+
+function setTypers(conversationIDKey: Constants.ConversationIDKey, typing: Array<string>) {
+  return {payload: {conversationIDKey, typing}, type: 'chat:setTypers'}
+}
+
 function updateBrokenTracker(userToBroken: {[username: string]: boolean}): Constants.UpdateBrokenTracker {
   return {payload: {userToBroken}, type: 'chat:updateBrokenTracker'}
 }
@@ -549,6 +564,7 @@ export {
   getInboxAndUnbox,
   inboxStale,
   incomingMessage,
+  incomingTyping,
   loadAttachment,
   loadAttachmentPreview,
   loadInbox,
@@ -579,6 +595,7 @@ export {
   setInitialConversation,
   setLoaded,
   setSelectedRouteState,
+  setTypers,
   setUnboxing,
   setupChatHandlers,
   showEditor,
@@ -600,6 +617,7 @@ export {
   updateSupersededByState,
   updateSupersedesState,
   updateTempMessage,
+  updateTyping,
   updatedMetadata,
   uploadProgress,
 }

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -17,7 +17,7 @@ import {
   ConstantsStatusCode,
 } from '../../constants/types/flow-types'
 import {call, put, take, select, race} from 'redux-saga/effects'
-import {delay, throttle} from 'redux-saga'
+import {delay} from 'redux-saga'
 import {isMobile} from '../../constants/platform'
 import {navigateTo, switchTo} from '../route-tree'
 import {openInKBFS} from '../kbfs'
@@ -941,8 +941,7 @@ function* _openConversation({
 function* _updateTyping({
   payload: {conversationIDKey, typing},
 }: Constants.UpdateTyping): SagaGenerator<any, any> {
-  // Send we-are-typing info up to Gregor.  This is throttled in the saga to
-  // avoid spamming Gregor on every keypress.
+  // Send we-are-typing info up to Gregor.
   if (!Constants.isPendingConversationIDKey(conversationIDKey)) {
     const conversationID = Constants.keyToConversationID(conversationIDKey)
     yield call(ChatTypes.localUpdateTypingRpcPromise, {
@@ -983,7 +982,7 @@ function* chatSaga(): SagaGenerator<any, any> {
   yield Saga.safeTakeEvery('chat:updateBadging', _updateBadging)
   yield Saga.safeTakeEvery('chat:updateInboxComplete', _ensureValidSelectedChat, false, false)
   yield Saga.safeTakeEvery('chat:updateMetadata', _updateMetadata)
-  yield throttle(5000, 'chat:updateTyping', _updateTyping)
+  yield Saga.safeTakeEvery('chat:updateTyping', _updateTyping)
   yield Saga.safeTakeLatest('chat:badgeAppForChat', _badgeAppForChat)
   yield Saga.safeTakeLatest('chat:inboxStale', Inbox.onInboxStale)
   yield Saga.safeTakeLatest('chat:loadInbox', Inbox.onInitialInboxLoad)

--- a/shared/chat/conversation/input/container.js
+++ b/shared/chat/conversation/input/container.js
@@ -15,12 +15,14 @@ const mapStateToProps = (state: TypedState, {focusInputCounter}: OwnProps) => {
   const selectedConversationIDKey = Constants.getSelectedConversation(state)
 
   let isLoading = true
+  let typing = []
 
   if (selectedConversationIDKey !== Constants.nothingSelected) {
     if (!Constants.isPendingConversationIDKey(selectedConversationIDKey || '')) {
       const conversationState = state.chat.get('conversationStates').get(selectedConversationIDKey)
       if (conversationState) {
         isLoading = !conversationState.isLoaded
+        typing = conversationState.typing.toArray()
       }
     } else {
       // A conversation can't be loading if it's pending -- it doesn't exist
@@ -38,6 +40,7 @@ const mapStateToProps = (state: TypedState, {focusInputCounter}: OwnProps) => {
     isLoading,
     routeState,
     selectedConversationIDKey,
+    typing,
   }
 }
 
@@ -59,6 +62,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   },
   onStoreInputText: (selectedConversation: Constants.ConversationIDKey, inputText: string) =>
     dispatch(Creators.setSelectedRouteState(selectedConversation, {inputText: new HiddenString(inputText)})),
+  onUpdateTyping: (selectedConversation: Constants.ConversationIDKey, typing: boolean) => {
+    dispatch(Creators.updateTyping(selectedConversation, typing))
+  },
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps): Props => ({
@@ -75,6 +81,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps): Props => ({
     if (stateProps.selectedConversationIDKey) {
       // only write if we're in a convo
       dispatchProps.onStoreInputText(stateProps.selectedConversationIDKey, inputText)
+    }
+  },
+  onUpdateTyping: (typing: boolean) => {
+    if (stateProps.selectedConversationIDKey) {
+      dispatchProps.onUpdateTyping(stateProps.selectedConversationIDKey, typing)
     }
   },
 })

--- a/shared/chat/conversation/input/index.desktop.js
+++ b/shared/chat/conversation/input/index.desktop.js
@@ -118,6 +118,12 @@ class ConversationInput extends Component<void, InputProps, void> {
     }
   }
 
+  componentWillReceiveProps(nextProps: Props) {
+    if (this.props.text !== nextProps.text) {
+      this.props.onUpdateTyping(!!nextProps.text)
+    }
+  }
+
   render() {
     return (
       <Box style={{...globalStyles.flexBoxColumn, borderTop: `solid 1px ${globalColors.black_05}`}}>
@@ -149,11 +155,32 @@ class ConversationInput extends Component<void, InputProps, void> {
           <Icon onClick={this.props.emojiPickerToggle} style={styleIcon} type="iconfont-emoji" />
           <Icon onClick={this.props.filePickerOpen} style={styleIcon} type="iconfont-attachment" />
         </Box>
-        <Text type="BodySmall" style={styleFooter} onClick={this.props.inputFocus}>
-          *bold*, _italics_, `code`, >quote
-        </Text>
+        <Box style={{...globalStyles.flexBoxRow, alignItems: 'flex-start'}}>
+          <Text type="BodySmall" style={{...styleFooter, flexGrow: 1, textAlign: 'left'}}>
+            {isTyping(this.props.typing)}
+          </Text>
+          <Text type="BodySmall" style={{...styleFooter, textAlign: 'right'}} onClick={this.props.inputFocus}>
+            *bold*, _italics_, `code`, >quote
+          </Text>
+        </Box>
       </Box>
     )
+  }
+}
+
+const isTyping = typing => {
+  if (!typing || !typing.length) {
+    return ''
+  }
+  switch (typing.length) {
+    case 0:
+      return ''
+    case 1:
+      return `${typing[0]} is typing`
+    case 2:
+      return `${typing[0]} and ${typing[1]} are typing`
+    default:
+      return `${typing.join(', ')} are typing`
   }
 }
 
@@ -184,8 +211,8 @@ const styleIcon = {
 const styleFooter = {
   color: globalColors.black_20,
   cursor: 'text',
-  flex: 1,
   marginBottom: globalMargins.xtiny,
+  marginLeft: globalMargins.tiny,
   marginRight: globalMargins.tiny,
   marginTop: 0,
   textAlign: 'right',

--- a/shared/chat/conversation/input/index.desktop.js
+++ b/shared/chat/conversation/input/index.desktop.js
@@ -173,8 +173,6 @@ const isTyping = typing => {
     return ''
   }
   switch (typing.length) {
-    case 0:
-      return ''
     case 1:
       return `${typing[0]} is typing`
     case 2:

--- a/shared/chat/conversation/input/index.js.flow
+++ b/shared/chat/conversation/input/index.js.flow
@@ -17,9 +17,11 @@ export type Props = {
   onPostMessage: (text: string) => void,
   onShowEditor: (message: ?Constants.Message) => void,
   onStoreInputText: (text: string) => void,
+  onUpdateTyping: (typing: boolean) => void,
   selectedConversationIDKey: ?Constants.ConversationIDKey,
   setText: (text: string) => void,
   text: string,
+  typing: Array<Constants.Username>,
 }
 
 export default class Input extends Component<void, Props, void> {}

--- a/shared/chat/conversation/input/index.native.js
+++ b/shared/chat/conversation/input/index.native.js
@@ -17,6 +17,9 @@ class ConversationInput extends Component<void, Props, void> {
         this.props.inputFocus()
       }
     }
+    if (this.props.text !== nextProps.text) {
+      this.props.onUpdateTyping(!!nextProps.text)
+    }
   }
 
   _onBlur = () => {
@@ -87,6 +90,7 @@ class ConversationInput extends Component<void, Props, void> {
           value={this.props.text}
           {...multilineOpts}
         />
+        {this.props.typing && this.props.typing.length > 0 && <Typing typing={this.props.typing} />}
         <Action
           text={this.props.text}
           onSubmit={this._onSubmit}
@@ -98,6 +102,8 @@ class ConversationInput extends Component<void, Props, void> {
     )
   }
 }
+
+const Typing = ({typing}) => <Text type="BodySmall" style={{color: globalColors.grey}}>....</Text>
 
 const Action = ({text, onSubmit, editingMessage, openFilePicker, isLoading}) =>
   text

--- a/shared/chat/conversation/input/index.native.js
+++ b/shared/chat/conversation/input/index.native.js
@@ -90,7 +90,7 @@ class ConversationInput extends Component<void, Props, void> {
           value={this.props.text}
           {...multilineOpts}
         />
-        {this.props.typing && this.props.typing.length > 0 && <Typing typing={this.props.typing} />}
+        {this.props.typing.length > 0 && <Typing typing={this.props.typing} />}
         <Action
           text={this.props.text}
           onSubmit={this._onSubmit}

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -21,10 +21,12 @@ import type {
   MessageID as RPCMessageID,
   OutboxID as RPCOutboxID,
   ConversationID as RPCConversationID,
+  TyperInfo,
 } from './types/flow-types-chat'
 import type {DeviceType} from './types/more'
 import type {TypedState} from './reducer'
 
+export type Username = string
 export type MessageKey = string
 type MessageKeyKind =
   | 'chatSecured'
@@ -239,6 +241,7 @@ export const ConversationStateRecord = Record({
   paginationPrevious: undefined,
   firstNewMessageID: undefined,
   deletedIDs: Set(),
+  typing: List(),
 })
 
 export type ConversationState = Record<{
@@ -254,6 +257,7 @@ export type ConversationState = Record<{
   paginationPrevious: ?Buffer,
   firstNewMessageID: ?MessageID,
   deletedIDs: Set<MessageID>,
+  typing: List<Username>,
 }>
 
 export type ConversationBadgeState = Record<{
@@ -409,6 +413,7 @@ export type GetInboxAndUnbox = NoErrorTypedAction<
 >
 export type InboxStale = NoErrorTypedAction<'chat:inboxStale', void>
 export type IncomingMessage = NoErrorTypedAction<'chat:incomingMessage', {activity: ChatActivity}>
+export type IncomingTyping = NoErrorTypedAction<'chat:incomingTyping', {activity: TyperInfo}>
 export type LoadInbox = NoErrorTypedAction<'chat:loadInbox', void>
 export type LoadMoreMessages = NoErrorTypedAction<
   'chat:loadMoreMessages',
@@ -552,6 +557,10 @@ export type UpdateSupersedesState = NoErrorTypedAction<
   {supersedesState: SupersedesState}
 >
 export type UpdatedMetadata = NoErrorTypedAction<'chat:updatedMetadata', {updated: {[key: string]: MetaData}}>
+export type UpdateTyping = NoErrorTypedAction<
+  'chat:updateTyping',
+  {conversationIDKey: ConversationIDKey, typing: boolean}
+>
 
 export type ThreadLoadedOffline = NoErrorTypedAction<
   'chat:threadLoadedOffline',

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -241,7 +241,7 @@ export const ConversationStateRecord = Record({
   paginationPrevious: undefined,
   firstNewMessageID: undefined,
   deletedIDs: Set(),
-  typing: List(),
+  typing: Set(),
 })
 
 export type ConversationState = Record<{
@@ -257,7 +257,7 @@ export type ConversationState = Record<{
   paginationPrevious: ?Buffer,
   firstNewMessageID: ?MessageID,
   deletedIDs: Set<MessageID>,
-  typing: List<Username>,
+  typing: Set<Username>,
 }>
 
 export type ConversationBadgeState = Record<{

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -352,11 +352,8 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
       const {conversationIDKey, typing} = action.payload
       // $FlowIssue
       return state.update('conversationStates', conversationStates =>
-        updateConversation(
-          conversationStates,
-          conversationIDKey,
-          // $FlowIssue
-          conversation => conversation.update('typing', _ => Set(typing))
+        updateConversation(conversationStates, conversationIDKey, conversation =>
+          conversation.set('typing', Set(typing))
         )
       )
     }

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -356,7 +356,7 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
           conversationStates,
           conversationIDKey,
           // $FlowIssue
-          conversation => conversation.update('typing', _ => List(typing))
+          conversation => conversation.update('typing', _ => Set(typing))
         )
       )
     }

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -348,6 +348,18 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
         )
       )
     }
+    case 'chat:setTypers': {
+      const {conversationIDKey, typing} = action.payload
+      // $FlowIssue
+      return state.update('conversationStates', conversationStates =>
+        updateConversation(
+          conversationStates,
+          conversationIDKey,
+          // $FlowIssue
+          conversation => conversation.update('typing', _ => List(typing))
+        )
+      )
+    }
     case 'chat:createPendingFailure': {
       const {failureDescription, outboxID} = action.payload
       return state.set('pendingFailures', state.get('pendingFailures').set(outboxID, failureDescription))


### PR DESCRIPTION
@keybase/react-hackers CC @mmaxim 

Changes in this PR:
* when we type or finish typing in a non-pending conversation, we send the service an RPC (throttled to at most once every 5000ms) to tell it, and it tells the Gregor server.
* when Gregor tells us that there is typing activity in a conversation, we update the store's `conversationState` with a list of `typers`, and plumb that list through to the input display component.
* on desktop, we show e.g. "cjb is typing", "cjb and mikem are typing", "cjb, mikem, max are typing" next to the markdown hints
* on mobile, we just show "...." next to the Send button if anyone is typing.  I imagine we'll later replace this with a real design (pulsing spinner?) or put the same text as desktop in the messages area or something.