### PR TITLE
Handle Navigate up in login sagas

### DIFF
--- a/shared/actions/login/saga.js
+++ b/shared/actions/login/saga.js
@@ -186,7 +186,7 @@ const kex2Sagas = (onBackSaga, provisionerSuccessSaga, finishedSaga) => {
 }
 
 function* cancelLogin(response) {
-  yield call(navBasedOnLoginState)
+  yield put(navigateTo(['login'], [loginTab]))
   if (response) {
     const engineInst = yield call(engine)
     yield put(Creators.waitingForResponse(true))

--- a/shared/login/register/error/index.render.js
+++ b/shared/login/register/error/index.render.js
@@ -198,6 +198,12 @@ const renderError = (error: RPCError) => {
           </Box>
         </Box>
       )
+    case ConstantsStatusCode.scinputcanceled:
+      return (
+        <Box style={styleContent}>
+          <Text type="Body">Login Cancelled</Text>
+        </Box>
+      )
     default:
       return (
         <Box style={styleContent}>


### PR DESCRIPTION
Going back is suppose to cancel the login rpc flow. We had a problem where if you go back by either:

sliding back on ios
native back button on android

You trigger a navigateUp which the login saga wasn't looking for to cancel the login.

Now we take on the navigateUp properly.

@keybase/react-hackers 