### PR TITLE
Attempt a fix for undefined chatinboxunverified

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -103,11 +103,10 @@ function* onInboxStale(): SagaGenerator<any, any> {
     )
 
     const incoming = yield loadInboxChanMap.race()
-    incoming.chatInboxUnverified.response.result()
-
-    if (!incoming.chatInboxUnverified) {
+    if (!incoming.chatInboxUnverified || !incoming.chatInboxUnverified.response) {
       throw new Error("Can't load inbox")
     }
+    incoming.chatInboxUnverified.response.result()
 
     const inbox: ChatTypes.GetInboxLocalRes = incoming.chatInboxUnverified.params.inbox
     yield call(_updateFinalized, inbox)


### PR DESCRIPTION
@keybase/react-hackers 

Miles saw a `Global error "undefined is not an object (evaluating 't.chatInboxUnverified.response')"`, eyeballing the code I see we're checking for null after accessing a property, let's try switching the ordering.