### PR TITLE
Check if account wasn't nuked when reading UPAK cache

### DIFF
--- a/go/engine/upak_loader_test.go
+++ b/go/engine/upak_loader_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/keybase/clockwork"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 func TestLoadDeviceKeyNew(t *testing.T) {
@@ -419,8 +417,6 @@ func TestLoadAfterAcctReset2(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-
-		_ = spew.Dump
 
 		t.Logf("loadUpak done: using username:%+v uid: %+v keys: %d", upak.Base.Username, upak.Base.Uid, len(upak.Base.DeviceKeys))
 		return upak, nil

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -289,7 +289,23 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		if info != nil {
 			info.LoadedLeaf = true
 		}
-		if leaf.public != nil && leaf.public.Seqno == Seqno(upak.Base.Uvv.SigChain) {
+
+		if leaf.eldest == "" {
+			g.Log.CDebugf(ctx, "%s: cache-hit; but user is nuked, evicting", culDebug(arg.UID))
+
+			// Our cached user turned out to be in reset state (without
+			// current sigchain), remove from cache, and then fall
+			// through. LoadUser shall return an error, which we will
+			// return to the caller.
+			u.Lock()
+			delete(u.m, arg.UID.String())
+			u.Unlock()
+
+			err := u.G().LocalDb.Delete(culDBKey(arg.UID))
+			if err != nil {
+				u.G().Log.Warning("Failed to remove %s from disk cache: %s", arg.UID, err)
+			}
+		} else if leaf.public != nil && leaf.public.Seqno == Seqno(upak.Base.Uvv.SigChain) {
 			g.Log.CDebugf(ctx, "%s: cache-hit; fresh after poll", culDebug(arg.UID))
 
 			upak.Base.Uvv.CachedAt = keybase1.ToTime(g.Clock().Now())


### PR DESCRIPTION
Work in progress, needs few more tests. Also locking during cache eviction might not be correct.