### PR TITLE
Reset last seen Gregor state when switching user/logging in/out

### DIFF
--- a/shared/native/notification-listeners.shared.js
+++ b/shared/native/notification-listeners.shared.js
@@ -39,6 +39,7 @@ export default function(dispatch: Dispatch, getState: () => Object, notify: any)
       }
     },
     'keybase.1.NotifySession.loggedIn': ({username}, response) => {
+      lastBadgeStateVersion = -1
       if (lastLoggedInNotifyUsername !== username) {
         lastLoggedInNotifyUsername = username
         notify('Logged in to Keybase as: ' + username)
@@ -48,6 +49,7 @@ export default function(dispatch: Dispatch, getState: () => Object, notify: any)
       response.result()
     },
     'keybase.1.NotifySession.loggedOut': params => {
+      lastBadgeStateVersion = -1
       lastLoggedInNotifyUsername = null
 
       // Do we actually think we're logged in?


### PR DESCRIPTION
@keybase/react-hackers CC @mmaxim 

Otherwise we can hit e.g.:

* logged in as user A, see badge state version 500

* log out, provision as user B, see badge state version 1

* reject future badge states for user B because we earlier saw a later version for user A.