### PR TITLE
fix two badger cases where things can get stuck CORE-5156

### DIFF
--- a/shared/main-shared.native.js
+++ b/shared/main-shared.native.js
@@ -72,9 +72,7 @@ class Main extends Component<void, any, void> {
       this._persistRoute()
     }
 
-    if (this.props.mobileAppBadgeCount !== nextProps.mobileAppBadgeCount) {
-      this._setIconBadgeNumber(nextProps.mobileAppBadgeCount)
-    }
+    this._setIconBadgeNumber(nextProps.mobileAppBadgeCount)
   }
 
   componentDidMount() {

--- a/shared/native/notification-listeners.shared.js
+++ b/shared/native/notification-listeners.shared.js
@@ -17,7 +17,7 @@ export default function(dispatch: Dispatch, getState: () => Object, notify: any)
   const throttledDispatch = throttle(action => dispatch(action), 1000, {leading: false, trailing: true})
   return {
     'keybase.1.NotifyBadges.badgeState': ({badgeState}) => {
-      if (badgeState.inboxVers <= lastBadgeStateVersion) {
+      if (badgeState.inboxVers < lastBadgeStateVersion) {
         console.log(
           `Ignoring older badgeState, got ${badgeState.inboxVers} but have seen ${lastBadgeStateVersion}`
         )


### PR DESCRIPTION
Two changes here which will improve badger behavior:

1.) Change version check to strict inequality in case for some reason the badging info is wrong. Subsequent updates will fix it, or at least be at least as right as what is currently in there. You really only need to protect against truly old updates for this feature.
2.) Set the icon badge number always in the update for the main component. There seems to be some kind of race condition where the props value gets the updated value ahead of time and this update never happens. Furthermore, it will never happen until the badge state changes, so background/foregrounding the app does nothing. Change it so we always set the badge icon, I'm not sure why we would not want to always do this. Is it expensive? 