### PR TITLE
move app badge updating to notification listener

### DIFF
--- a/shared/main-shared.native.js
+++ b/shared/main-shared.native.js
@@ -1,7 +1,6 @@
 // @flow
 import DumbSheet from './dev/dumb-sheet'
 import Push from './push/push.native'
-import RNPN from 'react-native-push-notification'
 import React, {Component} from 'react'
 import RenderRoute from './route-tree/render-route'
 import loadPerf from './util/load-perf'
@@ -11,7 +10,7 @@ import {bootstrap} from './actions/config'
 import {connect} from 'react-redux'
 import {debounce} from 'lodash'
 import {getUserImageMap, loadUserImageMap} from './util/pictures'
-import {initAvatarLookup, initAvatarLoad} from './common-adapters'
+import {initAvatarLookup, initAvatarLoad} from './common-adapters/index.native'
 import {listenForNotifications} from './actions/notifications'
 import {persistRouteState, loadRouteState} from './actions/platform-specific.native'
 import {navigateUp, setRouteState} from './actions/route-tree'
@@ -21,7 +20,6 @@ import type {TypedState} from './constants/reducer'
 type Props = {
   dumbFullscreen: boolean,
   folderBadge: number,
-  mobileAppBadgeCount: number,
   mountPush: boolean,
   routeDef: any,
   routeState: any,
@@ -48,6 +46,7 @@ class Main extends Component<void, any, void> {
       global.mainLoaded = true
       initAvatarLookup(getUserImageMap)
       initAvatarLoad(loadUserImageMap)
+
       this.props.loadRouteState()
       this.props.bootstrap()
       this.props.listenForNotifications()
@@ -60,23 +59,10 @@ class Main extends Component<void, any, void> {
     this.props.persistRouteState()
   }, 200)
 
-  _setIconBadgeNumber(count: number) {
-    RNPN.setApplicationIconBadgeNumber(count)
-    if (count === 0) {
-      RNPN.cancelAllLocalNotifications()
-    }
-  }
-
   componentWillReceiveProps(nextProps: Props) {
     if (this.props.routeState !== nextProps.routeState) {
       this._persistRoute()
     }
-
-    this._setIconBadgeNumber(nextProps.mobileAppBadgeCount)
-  }
-
-  componentDidMount() {
-    this._setIconBadgeNumber(this.props.mobileAppBadgeCount)
   }
 
   render() {
@@ -103,7 +89,6 @@ class Main extends Component<void, any, void> {
 const mapStateToProps = (state: TypedState) => ({
   dumbFullscreen: state.dev.debugConfig.dumbFullscreen,
   folderBadge: state.favorite.folderState.privateBadge + state.favorite.folderState.publicBadge,
-  mobileAppBadgeCount: state.notifications.get('mobileAppBadgeCount'),
   mountPush: state.config.loggedIn && state.config.bootStatus === 'bootStatusBootstrapped',
   routeDef: state.routeTree.routeDef,
   routeState: state.routeTree.routeState,

--- a/shared/native/notification-listeners.native.js
+++ b/shared/native/notification-listeners.native.js
@@ -16,11 +16,9 @@ export default function(dispatch: Dispatch, getState: () => Object, notify: any)
 
       const count = (badgeState.conversations || []).reduce((total, c) => total + c.UnreadMessages, 0)
 
-      if (count !== -1) {
-        RNPN.setApplicationIconBadgeNumber(count)
-        if (count === 0) {
-          RNPN.cancelAllLocalNotifications()
-        }
+      RNPN.setApplicationIconBadgeNumber(count)
+      if (count === 0) {
+        RNPN.cancelAllLocalNotifications()
       }
     },
   }

--- a/shared/native/notification-listeners.native.js
+++ b/shared/native/notification-listeners.native.js
@@ -1,5 +1,6 @@
 // @flow
 import shared from './notification-listeners.shared'
+import RNPN from 'react-native-push-notification'
 
 import type {Dispatch} from '../constants/types/flux'
 import type {incomingCallMapType} from '../constants/types/flow-types'
@@ -9,5 +10,18 @@ export default function(dispatch: Dispatch, getState: () => Object, notify: any)
   const fromShared = shared(dispatch, getState, notify)
   return {
     ...fromShared,
+    'keybase.1.NotifyBadges.badgeState': ({badgeState}) => {
+      const sharedBadgeState = fromShared['keybase.1.NotifyBadges.badgeState']
+      sharedBadgeState({badgeState})
+
+      const count = (badgeState.conversations || []).reduce((total, c) => total + c.UnreadMessages, 0)
+
+      if (count !== -1) {
+        RNPN.setApplicationIconBadgeNumber(count)
+        if (count === 0) {
+          RNPN.cancelAllLocalNotifications()
+        }
+      }
+    },
   }
 }

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -107,8 +107,7 @@ const BOOL isDebug = NO;
 
   NSURL *jsCodeLocation;
 
-//  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
-  jsCodeLocation = [NSURL URLWithString:@"http://192.168.1.50:8081/index.ios.bundle?platform=ios&dev=true"];
+  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"Keybase"

--- a/shared/react-native/ios/Keybase/AppDelegate.m
+++ b/shared/react-native/ios/Keybase/AppDelegate.m
@@ -107,7 +107,8 @@ const BOOL isDebug = NO;
 
   NSURL *jsCodeLocation;
 
-  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
+//  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
+  jsCodeLocation = [NSURL URLWithString:@"http://192.168.1.50:8081/index.ios.bundle?platform=ios&dev=true"];
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"Keybase"


### PR DESCRIPTION
This moves the badge updating on mobile to the notification listener and out of the components hierarchy. On mobile what's being rendered can very so its possible we don't have `<Main>` even in the stack anywhere. This makes it so when the message comes in we always plumb it through to the native side to update the badge.
We are recalculating the total but its pretty trivial and i didn't want to plumb a bunch of crap around (like make a saga listener or something else that might break). This seems like a straight forward flow for this thing and not likely to be broken again

@keybase/react-hackers 
cc: @mmaxim 