### PR TITLE
allow autocorrect on last word on submit

### DIFF
--- a/shared/chat/conversation/input/container.js
+++ b/shared/chat/conversation/input/container.js
@@ -114,6 +114,7 @@ export default compose(
         input && input.setNativeProps({text: ''})
       },
       inputFocus: props => () => input && input.focus(),
+      inputBlur: props => () => input && input.blur(),
       inputSelections: props => () => (input && input.selections()) || {},
       inputSetRef: props => i => {
         input = i

--- a/shared/chat/conversation/input/index.js.flow
+++ b/shared/chat/conversation/input/index.js.flow
@@ -6,6 +6,7 @@ export type Props = {
   defaultText: string,
   editingMessage: ?Constants.Message,
   focusInputCounter: number,
+  inputBlur: () => void,
   inputClear: () => void,
   inputFocus: () => void,
   inputSetRef: (r: any) => void,

--- a/shared/chat/conversation/input/index.native.js
+++ b/shared/chat/conversation/input/index.native.js
@@ -10,6 +10,8 @@ import type {AttachmentInput} from '../../../constants/chat'
 import type {Props} from '.'
 
 class ConversationInput extends Component<void, Props, void> {
+  _waitingOnEndEditing: boolean = false
+
   componentWillReceiveProps(nextProps: Props) {
     if (this.props.editingMessage !== nextProps.editingMessage) {
       if (nextProps.editingMessage && nextProps.editingMessage.type === 'Text') {
@@ -30,23 +32,10 @@ class ConversationInput extends Component<void, Props, void> {
   }
 
   _onSubmit = () => {
-    const text = this.props.text
-    if (!text) {
-      return
-    }
-
-    if (this.props.isLoading) {
-      console.log('Ignoring chat submit while still loading')
-      return
-    }
-
-    this.props.setText('')
-    this.props.inputClear()
-    if (this.props.editingMessage) {
-      this.props.onEditMessage(this.props.editingMessage, text)
-    } else {
-      this.props.onPostMessage(text)
-    }
+    // Force autocorrect
+    this._waitingOnEndEditing = true
+    // We want autocorrect to work when we click send, so we just blur the input and wait for it to be done updating its value
+    this.props.inputBlur()
   }
 
   _openFilePicker = () => {
@@ -67,6 +56,32 @@ class ConversationInput extends Component<void, Props, void> {
       }
     })
   }
+  _onEndEditing = (...args) => {
+    // We only submit when it got blurred and we're waiting for submission
+    if (!this._waitingOnEndEditing) {
+      return
+    }
+
+    this._waitingOnEndEditing = false
+
+    const text = this.props.text
+    if (!text) {
+      return
+    }
+
+    if (this.props.isLoading) {
+      console.log('Ignoring chat submit while still loading')
+      return
+    }
+
+    this.props.setText('')
+    this.props.inputClear()
+    if (this.props.editingMessage) {
+      this.props.onEditMessage(this.props.editingMessage, text)
+    } else {
+      this.props.onPostMessage(text)
+    }
+  }
 
   render() {
     // Auto-growing multiline doesn't work smoothly on Android yet.
@@ -84,6 +99,7 @@ class ConversationInput extends Component<void, Props, void> {
           multiline={true}
           onBlur={this._onBlur}
           onChangeText={this.props.setText}
+          onEndEditing={this._onEndEditing}
           ref={this.props.inputSetRef}
           small={true}
           style={styleInput}

--- a/shared/common-adapters/input.js.flow
+++ b/shared/common-adapters/input.js.flow
@@ -29,6 +29,7 @@ export type Props = {
   value?: ?string,
 
   // Mobile only
+  onEndEditing?: ?() => void,
   autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters',
   autoCorrect?: boolean,
   keyboardType?:

--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -214,6 +214,7 @@ class Input extends Component<void, Props, State> {
       onFocus: this._onFocus,
       onKeyDown: this._onKeyDown,
       onSubmitEditing: this.props.onEnterKeyDown,
+      onEndEditing: this.props.onEndEditing,
       placeholder: this.props.hintText,
       ref: r => {
         this._input = r


### PR DESCRIPTION
The old method was when you click 'Send' we'd grab the current text value and send it and clear the input. This makes it such that if you see an autocorrect suggestion it will not apply it.

Instead we blur the input, which will apply the autocorrect, then that emits an onEndEditing, which we grab and submit instead

@keybase/react-hackers 
cc: @mmaxim 