### PR TITLE
protocol: add UserOrTeamID type and IdentifyLite

### DIFF
--- a/go/protocol/keybase1/backend_common.go
+++ b/go/protocol/keybase1/backend_common.go
@@ -32,9 +32,9 @@ func (e BlockType) String() string {
 }
 
 type BlockIdCombo struct {
-	BlockHash string    `codec:"blockHash" json:"blockHash"`
-	ChargedTo UID       `codec:"chargedTo" json:"chargedTo"`
-	BlockType BlockType `codec:"blockType" json:"blockType"`
+	BlockHash string       `codec:"blockHash" json:"blockHash"`
+	ChargedTo UserOrTeamID `codec:"chargedTo" json:"chargedTo"`
+	BlockType BlockType    `codec:"blockType" json:"blockType"`
 }
 
 type ChallengeInfo struct {

--- a/go/protocol/keybase1/block.go
+++ b/go/protocol/keybase1/block.go
@@ -17,7 +17,7 @@ type BlockRefNonce [8]byte
 type BlockReference struct {
 	Bid       BlockIdCombo  `codec:"bid" json:"bid"`
 	Nonce     BlockRefNonce `codec:"nonce" json:"nonce"`
-	ChargedTo UID           `codec:"chargedTo" json:"chargedTo"`
+	ChargedTo UserOrTeamID  `codec:"chargedTo" json:"chargedTo"`
 }
 
 type BlockReferenceCount struct {

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -29,6 +29,7 @@ type LinkID string
 type BinaryKID []byte
 type TLFID string
 type TeamID string
+type UserOrTeamID string
 type Bytes32 [32]byte
 type Text struct {
 	Data   string `codec:"data" json:"data"`
@@ -212,6 +213,11 @@ type UserPlusKeys struct {
 	Uvv               UserVersionVector `codec:"uvv" json:"uvv"`
 	DeletedDeviceKeys []PublicKey       `codec:"deletedDeviceKeys" json:"deletedDeviceKeys"`
 	PerUserKeys       []PerUserKey      `codec:"perUserKeys" json:"perUserKeys"`
+}
+
+type UserOrTeamLite struct {
+	Id       UserOrTeamID `codec:"id" json:"id"`
+	Username string       `codec:"username" json:"username"`
 }
 
 type RemoteTrack struct {

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -216,8 +216,8 @@ type UserPlusKeys struct {
 }
 
 type UserOrTeamLite struct {
-	Id       UserOrTeamID `codec:"id" json:"id"`
-	Username string       `codec:"username" json:"username"`
+	Id   UserOrTeamID `codec:"id" json:"id"`
+	Name string       `codec:"name" json:"name"`
 }
 
 type RemoteTrack struct {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1090,11 +1090,27 @@ func (ut UserOrTeamID) AsUser() (UID, error) {
 	return UID(ut), nil
 }
 
+func (ut UserOrTeamID) AsUserOrBust() UID {
+	uid, err := ut.AsUser()
+	if err != nil {
+		panic(err)
+	}
+	return uid
+}
+
 func (ut UserOrTeamID) AsTeam() (TeamID, error) {
 	if !ut.IsTeamOrSubteam() {
 		return TeamID(""), errors.New("ID is not a team ID")
 	}
 	return TeamID(ut), nil
+}
+
+func (ut UserOrTeamID) AsTeamOrBust() TeamID {
+	tid, err := ut.AsTeam()
+	if err != nil {
+		panic(err)
+	}
+	return tid
 }
 
 func (ut UserOrTeamID) IsUser() bool {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -308,6 +308,10 @@ func (u UID) GetShard(shardCount int) (int, error) {
 	return int(n % uint32(shardCount)), nil
 }
 
+func (u UID) AsUserOrTeam() UserOrTeamID {
+	return UserOrTeamID(u)
+}
+
 func TeamIDFromString(s string) (TeamID, error) {
 	if len(s) != hex.EncodedLen(TEAMID_LEN) {
 		return "", fmt.Errorf("Bad TeamID '%s'; must be %d bytes long", s, TEAMID_LEN)
@@ -355,6 +359,10 @@ func (t TeamID) NotEqual(v TeamID) bool {
 
 func (t TeamID) Less(v TeamID) bool {
 	return t < v
+}
+
+func (t TeamID) AsUserOrTeam() UserOrTeamID {
+	return UserOrTeamID(t)
 }
 
 func (s SigID) IsNil() bool {
@@ -1041,4 +1049,70 @@ func (u UserPlusAllKeys) IsOlderThan(v UserPlusAllKeys) bool {
 		return true
 	}
 	return false
+}
+
+func (ut UserOrTeamID) String() string {
+	return string(ut)
+}
+
+func (ut UserOrTeamID) ToBytes() []byte {
+	b, err := hex.DecodeString(string(ut))
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+func (ut UserOrTeamID) IsNil() bool {
+	return len(ut) == 0
+}
+
+func (ut UserOrTeamID) Exists() bool {
+	return !ut.IsNil()
+}
+
+func (ut UserOrTeamID) Equal(v UserOrTeamID) bool {
+	return ut == v
+}
+
+func (ut UserOrTeamID) NotEqual(v UserOrTeamID) bool {
+	return !ut.Equal(v)
+}
+
+func (ut UserOrTeamID) Less(v UserOrTeamID) bool {
+	return ut < v
+}
+
+func (ut UserOrTeamID) AsUser() (UID, error) {
+	if !ut.IsUser() {
+		return UID(""), errors.New("ID is not a UID")
+	}
+	return UID(ut), nil
+}
+
+func (ut UserOrTeamID) AsTeam() (TeamID, error) {
+	if !ut.IsTeamOrSubteam() {
+		return TeamID(""), errors.New("ID is not a team ID")
+	}
+	return TeamID(ut), nil
+}
+
+func (ut UserOrTeamID) IsUser() bool {
+	suffix := ut[len(ut)-2:]
+	return suffix == UID_SUFFIX_HEX || suffix == UID_SUFFIX_2_HEX
+}
+
+func (ut UserOrTeamID) IsTeam() bool {
+	suffix := ut[len(ut)-2:]
+	return suffix == TEAMID_SUFFIX_HEX
+}
+
+func (ut UserOrTeamID) IsSubteam() bool {
+	suffix := ut[len(ut)-2:]
+	return suffix == SUB_TEAMID_SUFFIX_HEX
+}
+
+func (ut UserOrTeamID) IsTeamOrSubteam() bool {
+	suffix := ut[len(ut)-2:]
+	return suffix == TEAMID_SUFFIX_HEX || suffix == SUB_TEAMID_SUFFIX_HEX
 }

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -63,6 +63,53 @@ func (h *IdentifyHandler) Identify2(netCtx context.Context, arg keybase1.Identif
 	return res, err
 }
 
+func (h *IdentifyHandler) IdentifyLite(netCtx context.Context, arg keybase1.IdentifyLiteArg) (res keybase1.IdentifyLiteRes, err error) {
+	netCtx = libkb.WithLogTag(netCtx, "IDL")
+	defer h.G().CTrace(netCtx, "IdentifyHandler#IdentifyLite", func() error { return err })()
+
+	iui := h.NewRemoteIdentifyUI(arg.SessionID, h.G())
+	logui := h.getLogUI(arg.SessionID)
+	ctx := engine.Context{
+		LogUI:      logui,
+		IdentifyUI: iui,
+		SessionID:  arg.SessionID,
+		NetContext: netCtx,
+	}
+
+	// TODO: Make a real version of this that can distinguish UIDs and
+	// TeamIDs.  For now, only support UIDs.
+	uid, err := arg.Id.AsUser()
+	if err != nil {
+		return res, err
+	}
+	id2arg := keybase1.Identify2Arg{
+		SessionID:             arg.SessionID,
+		Uid:                   uid,
+		UserAssertion:         arg.Assertion,
+		Reason:                arg.Reason,
+		UseDelegateUI:         arg.UseDelegateUI,
+		AlwaysBlock:           arg.AlwaysBlock,
+		NoErrorOnTrackFailure: arg.NoErrorOnTrackFailure,
+		ForceRemoteCheck:      arg.ForceRemoteCheck,
+		NeedProofSet:          arg.NeedProofSet,
+		AllowEmptySelfID:      arg.AllowEmptySelfID,
+		NoSkipSelf:            arg.NoSkipSelf,
+		CanSuppressUI:         arg.CanSuppressUI,
+		IdentifyBehavior:      arg.IdentifyBehavior,
+		ForceDisplay:          arg.ForceDisplay,
+	}
+
+	eng := engine.NewResolveThenIdentify2(h.G(), &id2arg)
+	err = engine.RunEngine(eng, &ctx)
+	resp := eng.Result()
+	if resp != nil {
+		res.Ul.Id = keybase1.UserOrTeamID(resp.Upk.Uid)
+		res.Ul.Username = resp.Upk.Username
+	}
+	res.TrackBreaks = resp.TrackBreaks
+	return res, err
+}
+
 func (h *IdentifyHandler) Resolve(ctx context.Context, arg string) (uid keybase1.UID, err error) {
 	ctx = libkb.WithLogTag(ctx, "RSLV")
 	defer h.G().CTrace(ctx, fmt.Sprintf("IdentifyHandler#Resolve(%s)", arg), func() error { return err })()

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -104,7 +104,7 @@ func (h *IdentifyHandler) IdentifyLite(netCtx context.Context, arg keybase1.Iden
 	resp := eng.Result()
 	if resp != nil {
 		res.Ul.Id = keybase1.UserOrTeamID(resp.Upk.Uid)
-		res.Ul.Username = resp.Upk.Username
+		res.Ul.Name = resp.Upk.Username
 	}
 	res.TrackBreaks = resp.TrackBreaks
 	return res, err

--- a/protocol/avdl/keybase1/backend_common.avdl
+++ b/protocol/avdl/keybase1/backend_common.avdl
@@ -11,7 +11,7 @@ protocol backendCommon {
   @lint("ignore")
   record BlockIdCombo{
     string blockHash;
-    UID chargedTo;
+    UserOrTeamID chargedTo;
     BlockType blockType;
   }
 

--- a/protocol/avdl/keybase1/block.avdl
+++ b/protocol/avdl/keybase1/block.avdl
@@ -14,7 +14,7 @@ protocol block {
   record BlockReference {
     BlockIdCombo bid;
     BlockRefNonce nonce;
-    UID chargedTo;
+    UserOrTeamID chargedTo;
   }
 
   record BlockReferenceCount{

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -192,7 +192,7 @@ protocol Common {
 
   record UserOrTeamLite {
       UserOrTeamID id;
-      string username;
+      string name;
   }
 
   record RemoteTrack {

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -48,6 +48,9 @@ protocol Common {
   @typedef("string")
   record TeamID {}
 
+  @typedef("string")
+  record UserOrTeamID {}
+
   fixed Bytes32(32);
 
   record Text {
@@ -185,6 +188,11 @@ protocol Common {
       // per-user secrets one for every generation.
       @lint("ignore")
       array<PerUserKey> perUserKeys;
+  }
+
+  record UserOrTeamLite {
+      UserOrTeamID id;
+      string username;
   }
 
   record RemoteTrack {

--- a/protocol/avdl/keybase1/identify.avdl
+++ b/protocol/avdl/keybase1/identify.avdl
@@ -46,5 +46,15 @@ protocol identify {
    */
   Identify2Res identify2(int sessionID, UID uid, string userAssertion, IdentifyReason reason, boolean useDelegateUI=false, boolean alwaysBlock=false, boolean noErrorOnTrackFailure=false, boolean forceRemoteCheck=false, boolean needProofSet=false, boolean allowEmptySelfID=false, boolean noSkipSelf=true, boolean canSuppressUI=false, TLFIdentifyBehavior identifyBehavior=0, boolean forceDisplay=false);
 
+  record IdentifyLiteRes {
+    UserOrTeamLite ul;
+    union { null, IdentifyTrackBreaks } trackBreaks;
+  }
+
+  /*
+   * Note that UID can be empty, in which case a resolution is also forced.
+   */
+  IdentifyLiteRes identifyLite(int sessionID, UserOrTeamID id, string assertion, IdentifyReason reason, boolean useDelegateUI=false, boolean alwaysBlock=false, boolean noErrorOnTrackFailure=false, boolean forceRemoteCheck=false, boolean needProofSet=false, boolean allowEmptySelfID=false, boolean noSkipSelf=true, boolean canSuppressUI=false, TLFIdentifyBehavior identifyBehavior=0, boolean forceDisplay=false);
+
 
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5599,7 +5599,7 @@ export type UserOrTeamID = string
 
 export type UserOrTeamLite = {
   id: UserOrTeamID,
-  username: string,
+  name: string,
 }
 
 export type UserPlusAllKeys = {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -1972,6 +1972,21 @@ export function identifyIdentify2RpcPromise (request: $Exact<requestCommon & {ca
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.identify2', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function identifyIdentifyLiteRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: identifyIdentifyLiteResult) => void} & {param: identifyIdentifyLiteRpcParam}>) {
+  engineRpcOutgoing('keybase.1.identify.identifyLite', request)
+}
+
+export function identifyIdentifyLiteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: identifyIdentifyLiteResult) => void} & {param: identifyIdentifyLiteRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.identify.identifyLite', request)
+}
+export function identifyIdentifyLiteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: identifyIdentifyLiteResult) => void} & {param: identifyIdentifyLiteRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.identify.identifyLite', request, callback, incomingCallMap) })
+}
+
+export function identifyIdentifyLiteRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: identifyIdentifyLiteResult) => void} & {param: identifyIdentifyLiteRpcParam}>): Promise<identifyIdentifyLiteResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.identifyLite', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function identifyIdentifyRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: identifyIdentifyResult) => void} & {param: identifyIdentifyRpcParam}>) {
   engineRpcOutgoing('keybase.1.identify.identify', request)
 }
@@ -3906,7 +3921,7 @@ export type BinaryKID = bytes
 
 export type BlockIdCombo = {
   blockHash: string,
-  chargedTo: UID,
+  chargedTo: UserOrTeamID,
   blockType: BlockType,
 }
 
@@ -3917,7 +3932,7 @@ export type BlockRefNonce = any
 export type BlockReference = {
   bid: BlockIdCombo,
   nonce: BlockRefNonce,
-  chargedTo: UID,
+  chargedTo: UserOrTeamID,
 }
 
 export type BlockReferenceCount = {
@@ -4393,6 +4408,11 @@ export type IdentifyKey = {
   KID: KID,
   trackDiff?: ?TrackDiff,
   breaksTracking: boolean,
+}
+
+export type IdentifyLiteRes = {
+  ul: UserOrTeamLite,
+  trackBreaks?: ?IdentifyTrackBreaks,
 }
 
 export type IdentifyOutcome = {
@@ -5575,6 +5595,13 @@ export type UserCard = {
   theyFollowYou: boolean,
 }
 
+export type UserOrTeamID = string
+
+export type UserOrTeamLite = {
+  id: UserOrTeamID,
+  username: string,
+}
+
 export type UserPlusAllKeys = {
   base: UserPlusKeys,
   pgpKeys?: ?Array<PublicKey>,
@@ -5891,6 +5918,22 @@ export type gregorUIPushStateRpcParam = Exact<{
 export type identifyIdentify2RpcParam = Exact<{
   uid: UID,
   userAssertion: string,
+  reason: IdentifyReason,
+  useDelegateUI?: boolean,
+  alwaysBlock?: boolean,
+  noErrorOnTrackFailure?: boolean,
+  forceRemoteCheck?: boolean,
+  needProofSet?: boolean,
+  allowEmptySelfID?: boolean,
+  noSkipSelf?: boolean,
+  canSuppressUI?: boolean,
+  identifyBehavior?: TLFIdentifyBehavior,
+  forceDisplay?: boolean
+}>
+
+export type identifyIdentifyLiteRpcParam = Exact<{
+  id: UserOrTeamID,
+  assertion: string,
   reason: IdentifyReason,
   useDelegateUI?: boolean,
   alwaysBlock?: boolean,
@@ -6677,6 +6720,7 @@ type gpgUiSignResult = string
 type gpgUiWantToAddGPGKeyResult = boolean
 type gregorGetStateResult = gregor1.State
 type identifyIdentify2Result = Identify2Res
+type identifyIdentifyLiteResult = IdentifyLiteRes
 type identifyIdentifyResult = IdentifyRes
 type identifyResolve2Result = User
 type identifyResolveResult = UID
@@ -6860,6 +6904,7 @@ export type rpc =
   | fsListRpc
   | gregorGetStateRpc
   | identifyIdentify2Rpc
+  | identifyIdentifyLiteRpc
   | identifyIdentifyRpc
   | identifyResolve2Rpc
   | identifyResolveRpc

--- a/protocol/json/keybase1/backend_common.json
+++ b/protocol/json/keybase1/backend_common.json
@@ -24,7 +24,7 @@
           "name": "blockHash"
         },
         {
-          "type": "UID",
+          "type": "UserOrTeamID",
           "name": "chargedTo"
         },
         {

--- a/protocol/json/keybase1/block.json
+++ b/protocol/json/keybase1/block.json
@@ -39,7 +39,7 @@
           "name": "nonce"
         },
         {
-          "type": "UID",
+          "type": "UserOrTeamID",
           "name": "chargedTo"
         }
       ]

--- a/protocol/json/keybase1/common.json
+++ b/protocol/json/keybase1/common.json
@@ -102,6 +102,12 @@
       "typedef": "string"
     },
     {
+      "type": "record",
+      "name": "UserOrTeamID",
+      "fields": [],
+      "typedef": "string"
+    },
+    {
       "type": "fixed",
       "name": "Bytes32",
       "size": "32"
@@ -454,6 +460,20 @@
           },
           "name": "perUserKeys",
           "lint": "ignore"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "UserOrTeamLite",
+      "fields": [
+        {
+          "type": "UserOrTeamID",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "username"
         }
       ]
     },

--- a/protocol/json/keybase1/common.json
+++ b/protocol/json/keybase1/common.json
@@ -473,7 +473,7 @@
         },
         {
           "type": "string",
-          "name": "username"
+          "name": "name"
         }
       ]
     },

--- a/protocol/json/keybase1/identify.json
+++ b/protocol/json/keybase1/identify.json
@@ -61,6 +61,23 @@
           "name": "trackBreaks"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "IdentifyLiteRes",
+      "fields": [
+        {
+          "type": "UserOrTeamLite",
+          "name": "ul"
+        },
+        {
+          "type": [
+            null,
+            "IdentifyTrackBreaks"
+          ],
+          "name": "trackBreaks"
+        }
+      ]
     }
   ],
   "messages": {
@@ -188,6 +205,77 @@
         }
       ],
       "response": "Identify2Res"
+    },
+    "identifyLite": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "id",
+          "type": "UserOrTeamID"
+        },
+        {
+          "name": "assertion",
+          "type": "string"
+        },
+        {
+          "name": "reason",
+          "type": "IdentifyReason"
+        },
+        {
+          "name": "useDelegateUI",
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "name": "alwaysBlock",
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "name": "noErrorOnTrackFailure",
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "name": "forceRemoteCheck",
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "name": "needProofSet",
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "name": "allowEmptySelfID",
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "name": "noSkipSelf",
+          "type": "boolean",
+          "default": true
+        },
+        {
+          "name": "canSuppressUI",
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "TLFIdentifyBehavior",
+          "default": 0
+        },
+        {
+          "name": "forceDisplay",
+          "type": "boolean",
+          "default": false
+        }
+      ],
+      "response": "IdentifyLiteRes"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5599,7 +5599,7 @@ export type UserOrTeamID = string
 
 export type UserOrTeamLite = {
   id: UserOrTeamID,
-  username: string,
+  name: string,
 }
 
 export type UserPlusAllKeys = {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -1972,6 +1972,21 @@ export function identifyIdentify2RpcPromise (request: $Exact<requestCommon & {ca
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.identify2', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function identifyIdentifyLiteRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: identifyIdentifyLiteResult) => void} & {param: identifyIdentifyLiteRpcParam}>) {
+  engineRpcOutgoing('keybase.1.identify.identifyLite', request)
+}
+
+export function identifyIdentifyLiteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: identifyIdentifyLiteResult) => void} & {param: identifyIdentifyLiteRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.identify.identifyLite', request)
+}
+export function identifyIdentifyLiteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: identifyIdentifyLiteResult) => void} & {param: identifyIdentifyLiteRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.identify.identifyLite', request, callback, incomingCallMap) })
+}
+
+export function identifyIdentifyLiteRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: identifyIdentifyLiteResult) => void} & {param: identifyIdentifyLiteRpcParam}>): Promise<identifyIdentifyLiteResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.identify.identifyLite', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function identifyIdentifyRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: identifyIdentifyResult) => void} & {param: identifyIdentifyRpcParam}>) {
   engineRpcOutgoing('keybase.1.identify.identify', request)
 }
@@ -3906,7 +3921,7 @@ export type BinaryKID = bytes
 
 export type BlockIdCombo = {
   blockHash: string,
-  chargedTo: UID,
+  chargedTo: UserOrTeamID,
   blockType: BlockType,
 }
 
@@ -3917,7 +3932,7 @@ export type BlockRefNonce = any
 export type BlockReference = {
   bid: BlockIdCombo,
   nonce: BlockRefNonce,
-  chargedTo: UID,
+  chargedTo: UserOrTeamID,
 }
 
 export type BlockReferenceCount = {
@@ -4393,6 +4408,11 @@ export type IdentifyKey = {
   KID: KID,
   trackDiff?: ?TrackDiff,
   breaksTracking: boolean,
+}
+
+export type IdentifyLiteRes = {
+  ul: UserOrTeamLite,
+  trackBreaks?: ?IdentifyTrackBreaks,
 }
 
 export type IdentifyOutcome = {
@@ -5575,6 +5595,13 @@ export type UserCard = {
   theyFollowYou: boolean,
 }
 
+export type UserOrTeamID = string
+
+export type UserOrTeamLite = {
+  id: UserOrTeamID,
+  username: string,
+}
+
 export type UserPlusAllKeys = {
   base: UserPlusKeys,
   pgpKeys?: ?Array<PublicKey>,
@@ -5891,6 +5918,22 @@ export type gregorUIPushStateRpcParam = Exact<{
 export type identifyIdentify2RpcParam = Exact<{
   uid: UID,
   userAssertion: string,
+  reason: IdentifyReason,
+  useDelegateUI?: boolean,
+  alwaysBlock?: boolean,
+  noErrorOnTrackFailure?: boolean,
+  forceRemoteCheck?: boolean,
+  needProofSet?: boolean,
+  allowEmptySelfID?: boolean,
+  noSkipSelf?: boolean,
+  canSuppressUI?: boolean,
+  identifyBehavior?: TLFIdentifyBehavior,
+  forceDisplay?: boolean
+}>
+
+export type identifyIdentifyLiteRpcParam = Exact<{
+  id: UserOrTeamID,
+  assertion: string,
   reason: IdentifyReason,
   useDelegateUI?: boolean,
   alwaysBlock?: boolean,
@@ -6677,6 +6720,7 @@ type gpgUiSignResult = string
 type gpgUiWantToAddGPGKeyResult = boolean
 type gregorGetStateResult = gregor1.State
 type identifyIdentify2Result = Identify2Res
+type identifyIdentifyLiteResult = IdentifyLiteRes
 type identifyIdentifyResult = IdentifyRes
 type identifyResolve2Result = User
 type identifyResolveResult = UID
@@ -6860,6 +6904,7 @@ export type rpc =
   | fsListRpc
   | gregorGetStateRpc
   | identifyIdentify2Rpc
+  | identifyIdentifyLiteRpc
   | identifyIdentifyRpc
   | identifyResolve2Rpc
   | identifyResolveRpc


### PR DESCRIPTION
r? @maxtaco @oconnor663

KBFS wants to treat users and teams the same in most cases.  So this
adds a new type that can be either a UID or a TeamID, along with
helper methods for it.  It also adds a new `IdentifyLite` RPC that can
identify either a user or a team from an assertion, without needing to
return any keys. (For now, it only supports users.)

Issue: KBFS-2185
Issue: CORE-5273