### PR TITLE
Ensure newline in 'pgp export'

### DIFF
--- a/go/client/cmd_pgp_export.go
+++ b/go/client/cmd_pgp_export.go
@@ -6,6 +6,7 @@ package client
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"golang.org/x/net/context"
 
@@ -100,7 +101,7 @@ func (s *CmdPGPExport) finish(res []keybase1.KeyInfo, inErr error) error {
 	if err := snk.Open(); err != nil {
 		return err
 	}
-	snk.Write([]byte(res[0].Key))
+	snk.Write([]byte(strings.TrimSpace(res[0].Key) + "\n"))
 	return snk.Close()
 }
 


### PR DESCRIPTION
From the looks of it; even though we add a newline during armoring in go-crypto, the keys that are being printed in `keybase pgp export` come from the server, and the newline is not guaranteed to be there (maybe it's even stripped? didn't dig that far). So `CmdPGPExport` engine will check if armor ends with `\n`, if not, it will be printed after printing the armor.

Also it should be fine to just print `"\n"`, portability is ensured by golang library.