### PR TITLE
fix hmr for hot-server-dumb

### DIFF
--- a/shared/desktop/webpack.config.dumb.js
+++ b/shared/desktop/webpack.config.dumb.js
@@ -5,8 +5,12 @@ const getenv = require('getenv')
 const config = Object.assign({}, devConfig)
 
 if (getenv.boolish('HOT', false)) {
-  config.entry.index = ['react-hot-loader/patch'].concat(['./desktop/renderer/dumb.js'])
-  config.entry.main = []
+  config.entry = {
+    index: [
+      'react-hot-loader/patch',
+      'webpack-hot-middleware/client?path=http://localhost:4000/__webpack_hmr',
+    ].concat(['./desktop/renderer/dumb.js']),
+  }
 }
 
 module.exports = config


### PR DESCRIPTION
@keybase/react-hackers 
makes
`yarn run hot-server-dumb` actually HMR when you edit