### PR TITLE
keybot should wait on CI before publishing iOS/Android builds

### DIFF
--- a/packaging/android/build_and_publish.sh
+++ b/packaging/android/build_and_publish.sh
@@ -42,7 +42,7 @@ fi
 
 if [ ! "$cache_go_lib" = "1" ]; then
   echo "Building Go library"
-  yarn run rn-gobuild-android
+  CHECK_CI=1 yarn run rn-gobuild-android
 fi
 
 # We can't currently automate this :(, we used to be able to `echo y | android update ...` but that no longer works

--- a/packaging/ios/build_and_publish.sh
+++ b/packaging/ios/build_and_publish.sh
@@ -43,7 +43,7 @@ fi
 
 if [ ! "$cache_go_lib" = "1" ]; then
   echo "Building Go library"
-  yarn run rn-gobuild-ios
+  CHECK_CI=1 yarn run rn-gobuild-ios
 fi
 
 "$client_dir/packaging/manage_react_native_packager.sh" &

--- a/shared/react-native/gobuild.sh
+++ b/shared/react-native/gobuild.sh
@@ -55,7 +55,6 @@ else
   cp -R "$kbfs_dir"/* "$go_kbfs_dir"
 fi
 if [ "$check_ci" = "1" ]; then
-  "$client_dir/packaging/goinstall.sh" "github.com/keybase/release"
   "$GOPATH/bin/release" wait-ci --repo="kbfs" --commit="$(git -C $kbfs_dir rev-parse HEAD)" --context="continuous-integration/jenkins/branch"
 fi
 


### PR DESCRIPTION
r? @gabriel 

The CI check ended up inside gobuild.sh, because KBFS isn't checked out until that script runs, and we need a checkout at the commit we're building in order to test CI.  `yarn run rn-gobuild-android` still works fine without a CI check locally, since you have to pass `CHECK_CI=1` to make the check happen.