### PR TITLE
Add mobile OS version to mobile log sends

### DIFF
--- a/shared/constants/platform.desktop.js
+++ b/shared/constants/platform.desktop.js
@@ -11,6 +11,7 @@ const isElectron = true
 const isDarwin = process.platform === 'darwin'
 const isWindows = process.platform === 'win32'
 const isLinux = process.platform === 'linux'
+const mobileOsVersion = 'Not implemented on desktop'
 
 const fileUIName = isDarwin ? 'Finder' : isWindows ? 'Explorer' : 'File Explorer'
 
@@ -156,4 +157,5 @@ export {
   version,
   appVersionName,
   appVersionCode,
+  mobileOsVersion,
 }

--- a/shared/constants/platform.js.flow
+++ b/shared/constants/platform.js.flow
@@ -14,3 +14,5 @@ declare export var fileUIName: string
 declare export var version: string
 declare export var appVersionName: string
 declare export var appVersionCode: string
+declare export var mobileOsVersion: string
+

--- a/shared/constants/platform.native.js
+++ b/shared/constants/platform.native.js
@@ -16,6 +16,7 @@ const isElectron = false
 const isLinux = false
 const isWindows = false
 const fileUIName = 'File Explorer'
+const mobileOsVersion = Platform.Version
 
 // isLargeScreen means you have at larger screen like iPhone 6,7 or Pixel
 // See https://material.io/devices/
@@ -31,6 +32,7 @@ export {
   isLinux,
   isMobile,
   isWindows,
+  mobileOsVersion,
   runMode,
   version,
   appVersionName,

--- a/shared/settings/feedback-container.js
+++ b/shared/settings/feedback-container.js
@@ -6,7 +6,15 @@ import Feedback from './feedback'
 import logSend from '../native/log-send'
 import {connect} from 'react-redux'
 import {compose, withState, withHandlers} from 'recompose'
-import {isElectron, isIOS, isAndroid, appVersionName, appVersionCode, version} from '../constants/platform'
+import {
+  isElectron,
+  isIOS,
+  isAndroid,
+  appVersionName,
+  appVersionCode,
+  mobileOsVersion,
+  version,
+} from '../constants/platform'
 import {dumpLoggers, getLogger} from '../util/periodic-logger'
 import {writeStream, cachesDirectoryPath} from '../util/file'
 import {serialPromises} from '../util/promise'
@@ -155,6 +163,7 @@ export default compose(
           username: state.config.username,
           uid: state.config.uid,
           deviceID: state.config.deviceID,
+          mobileOsVersion,
           platform: isAndroid ? 'android' : isIOS ? 'ios' : 'desktop',
           version,
           appVersionName,


### PR DESCRIPTION
@keybase/react-hackers 

React Native exposes OS version as Platform.Version, but doesn't expose any other device info itself.  (We could make native calls through the bridge to get that if we want to.)