### PR TITLE
Use keybase-patched version of react-navigation

### DIFF
--- a/shared/libs/flow-interface.js.flow
+++ b/shared/libs/flow-interface.js.flow
@@ -60,10 +60,13 @@ declare module 'react-native-camera' {
 declare module 'react-native/Libraries/CustomComponents/Navigator/NavigatorNavigationBarStylesIOS' {
   declare var exports: any
 }
+declare module 'react-native/Libraries/StyleSheet/StyleSheetTypes' {
+  declare var exports: any
+}
 declare module 'react-navigation' {
   declare var exports: any
 }
-declare module 'react-navigation/lib/views/CardStackTransitioner' {
+declare module 'react-navigation/src/views/CardStackTransitioner' {
   declare var exports: any
 }
 declare module 'react-redux' {

--- a/shared/nav.native.js
+++ b/shared/nav.native.js
@@ -7,7 +7,7 @@ import TabBar, {tabBarHeight} from './tab-bar/index.render.native'
 import {Box, NativeKeyboard, NativeKeyboardAvoidingView} from './common-adapters/index.native'
 import {Dimensions, StatusBar} from 'react-native'
 import {NavigationActions} from 'react-navigation'
-import CardStackTransitioner from 'react-navigation/lib/views/CardStackTransitioner'
+import CardStackTransitioner from 'react-navigation/src/views/CardStackTransitioner'
 import {chatTab, loginTab} from './constants/tabs'
 import {connect} from 'react-redux'
 import {globalColors, globalStyles, statusBarHeight} from './styles/index.native'
@@ -23,7 +23,7 @@ import type {RouteProps} from './route-tree/render-route'
 type OwnProps = RouteProps<{}, {}>
 
 class CardStackShim extends Component {
-  getScreenOptions = () => ({})
+  getScreenOptions = () => ({transitionInteractivityThreshold: 0.9})
   getStateForAction = () => ({})
   getActionForPathAndParams = () => ({})
   getPathAndParamsForState = () => ({})

--- a/shared/package.json
+++ b/shared/package.json
@@ -86,7 +86,7 @@
     "react-native-fetch-blob": "0.10.4",
     "react-native-image-picker": "0.25.7",
     "react-native-push-notification": "git://github.com/keybase/react-native-push-notification#eedae53f4346223b5aee60ef2702ecc47a01fcd2",
-    "react-navigation": "1.0.0-beta.9",
+    "react-navigation": "git://github.com/keybase/react-navigation#89d3c8eaefe61739357065b93d053f54df39268f",
     "react-redux": "5.0.3",
     "react-tap-event-plugin": "2.0.1",
     "react-virtualized": "9.7.3",

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -2917,7 +2917,7 @@ fbjs-scripts@^0.7.0:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.6, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.12, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.6, fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
@@ -4558,7 +4558,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -5652,7 +5652,14 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4, prop-types@^15.5.8:
+prop-types@^15.5.10, prop-types@^15.5.8:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
+prop-types@^15.5.4:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
@@ -5879,15 +5886,15 @@ react-native-dismiss-keyboard@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-native-dismiss-keyboard/-/react-native-dismiss-keyboard-1.0.0.tgz#32886242b3f2317e121f3aeb9b0a585e2b879b49"
 
-react-native-drawer-layout-polyfill@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-drawer-layout-polyfill/-/react-native-drawer-layout-polyfill-1.2.0.tgz#0d77bd3af8964ffe7fd0f1f6550d6be328a5b567"
+react-native-drawer-layout-polyfill@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-drawer-layout-polyfill/-/react-native-drawer-layout-polyfill-1.3.0.tgz#50ea3f1dceed360b06f24a33b5ef3701d5c1417a"
   dependencies:
-    react-native-drawer-layout "1.2.0"
+    react-native-drawer-layout "1.3.0"
 
-react-native-drawer-layout@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-drawer-layout/-/react-native-drawer-layout-1.2.0.tgz#ae274ee17fadce58d9d7ecef4797d9fad672af74"
+react-native-drawer-layout@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-drawer-layout/-/react-native-drawer-layout-1.3.0.tgz#3f9942c4c57e18bfe947a1a9b624365c91914280"
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
@@ -5906,9 +5913,9 @@ react-native-image-picker@0.25.7:
   version "2.2.1"
   resolved "git://github.com/keybase/react-native-push-notification#eedae53f4346223b5aee60ef2702ecc47a01fcd2"
 
-react-native-tab-view@^0.0.61:
-  version "0.0.61"
-  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.61.tgz#9f5446c9ad33158b87f0bccf5004fbff79ca1f92"
+react-native-tab-view@^0.0.65:
+  version "0.0.65"
+  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.65.tgz#b685ea3081ff7c96486cd997361026c407302c59"
   dependencies:
     prop-types "^15.5.8"
 
@@ -5992,17 +5999,17 @@ react-native@0.42.3:
     xmldoc "^0.4.0"
     yargs "^6.4.0"
 
-react-navigation@1.0.0-beta.9:
+"react-navigation@git://github.com/keybase/react-navigation#89d3c8eaefe61739357065b93d053f54df39268f":
   version "1.0.0-beta.9"
-  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-1.0.0-beta.9.tgz#9fb1f8e4d15cee70cc8b5d58719a986ca443664d"
+  resolved "git://github.com/keybase/react-navigation#89d3c8eaefe61739357065b93d053f54df39268f"
   dependencies:
     clamp "^1.0.1"
-    fbjs "^0.8.5"
+    fbjs "^0.8.12"
     hoist-non-react-statics "^1.2.0"
     path-to-regexp "^1.7.0"
-    prop-types "^15.5.8"
-    react-native-drawer-layout-polyfill "1.2.0"
-    react-native-tab-view "^0.0.61"
+    prop-types "^15.5.10"
+    react-native-drawer-layout-polyfill "^1.3.0"
+    react-native-tab-view "^0.0.65"
 
 react-proxy@^1.1.7:
   version "1.1.8"


### PR DESCRIPTION
These patches fix:

 * DESKTOP-3750 -- "First inbox tap after back button is ignored"
 * DESKTOP-3611 -- "Chat tab frozen by switching convs iOS"