### PR TITLE
Team sigchain player

### DIFF
--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -178,8 +178,13 @@ func SigchainV2TypeFromV1TypeAndRevocations(s string, hasRevocations bool) (ret 
 	case "pgp_update":
 		ret = SigchainV2TypePGPUpdate
 	default:
-		ret = SigchainV2TypeNone
-		err = ChainLinkError{fmt.Sprintf("Unknown sig v1 type: %s", s)}
+		teamRes, teamErr := SigchainV2TypeFromV1TypeTeams(s)
+		if teamErr == nil {
+			ret = teamRes
+		} else {
+			ret = SigchainV2TypeNone
+			err = ChainLinkError{fmt.Sprintf("Unknown sig v1 type: %s", s)}
+		}
 	}
 
 	if !ret.NeedsSignature() && hasRevocations {

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -729,6 +729,7 @@ type PerUserKeyChainLink struct {
 	generation keybase1.PerUserKeyGeneration
 }
 
+// TODO verify reverse sig
 func ParsePerUserKeyChainLink(b GenericChainLink) (ret *PerUserKeyChainLink, err error) {
 	var sigKID, encKID keybase1.KID
 	var g int

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -23,7 +23,7 @@ import (
 //    "inner" link. It persists in some cases and is elided for bandwidth
 //    savings in others.
 //
-//   V2 AKA Outer/Inner Split: In V2, the signer computers a signature over
+//   V2 AKA Outer/Inner Split: In V2, the signer computes a signature over
 //    a much smaller outer link (see OuterLinkV2 in chain_link_v2.go). The
 //    "curr" field in the outer link points to a V1 inner link by content hash.
 //    Essential fields from the V1 inner link are hoisted up into the V2 outer

--- a/go/libkb/team_chain.go
+++ b/go/libkb/team_chain.go
@@ -1,0 +1,730 @@
+package libkb
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// There are a lot of TODOs in this file. Many of them are critical before team sigchains can be used safely.
+
+// TODO merkle existence
+// TODO accept links from now-revoked keys if the sigs were made before their revocation.
+//      To check this, grab the merkle root previous to the revoke and make sure the link is in that tree.
+
+type TeamName string
+
+type UserVersion struct {
+	Username    NormalizedUsername
+	EldestSeqno Seqno
+}
+
+func NewUserVersion(username string, eldestSeqno Seqno) UserVersion {
+	return UserVersion{
+		Username:    NewNormalizedUsername(username),
+		EldestSeqno: eldestSeqno,
+	}
+}
+
+func ParseUserVersion(s string) (res UserVersion, err error) {
+	parts := strings.Split(s, "%")
+	if len(parts) == 1 {
+		// default to seqno 1
+		parts = append(parts, "1")
+	}
+	if len(parts) != 2 {
+		return res, fmt.Errorf("invalid user version: %s", s)
+	}
+	username, err := ValidateNormalizedUsername(parts[0])
+	if err != nil {
+		return res, err
+	}
+	eldestSeqno, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return res, fmt.Errorf("invalid eldest seqno: %s", err)
+	}
+	return UserVersion{
+		Username:    username,
+		EldestSeqno: Seqno(eldestSeqno),
+	}, nil
+}
+
+// "foo" for seqno 1 or "foo%6"
+func (u UserVersion) PercentForm() string {
+	if u.EldestSeqno == 1 {
+		return u.Username.String()
+	}
+	return fmt.Sprintf("%s%%%d", u.Username, u.EldestSeqno)
+}
+
+// Does not canonicalize the name
+func TeamNameFromString(s string) (res TeamName, err error) {
+	if len(s) == 0 {
+		return res, errors.New("zero length team name")
+	}
+	for _, part := range strings.Split(s, ".") {
+		if !(len(part) >= 2 && len(part) <= 16) {
+			return res, fmt.Errorf("team name wrong size:'%s' %v <= %v <= %v", part, 2, len(part), 16)
+		}
+		// underscores allowed, just not first or doubled
+		re := regexp.MustCompile(`^([a-z0-9][a-z0-9_]?)+$`)
+		if !re.MatchString(strings.ToLower(part)) {
+			return res, fmt.Errorf("invalid team name:'%s'", s)
+		}
+	}
+	return TeamName(s), nil
+}
+
+// Get the top level team id for this team name.
+// Only makes sense for non-sub teams.
+func (n TeamName) ToTeamID() keybase1.TeamID {
+	low := strings.ToLower(string(n))
+	sum := sha256.Sum256([]byte(low))
+	bs := append(sum[:15], keybase1.TEAMID_SUFFIX)
+	res, err := keybase1.TeamIDFromString(hex.EncodeToString(bs))
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+const TeamSigChainPlayerSupportedLinkVersion = 2
+
+// A user became this role at a point in time
+type UserTeamRoleCheckpoint struct {
+	// The new role. Including NONE if the user left the team.
+	Role keybase1.TeamRole
+	// The seqno at which the user became this role.
+	Seqno Seqno
+}
+
+type UserLog map[UserVersion][]UserTeamRoleCheckpoint
+
+func (ul *UserLog) getUserRole(u UserVersion) keybase1.TeamRole {
+	log := (*ul)[u]
+	if len(log) == 0 {
+		return keybase1.TeamRole_NONE
+	}
+	role := log[len(log)-1].Role
+	return role
+}
+
+// Inform the UserLog of a user's role.
+// Doesn't check anything, don't screw up.
+// Idempotent if called correctly.
+func (ul *UserLog) inform(u UserVersion, role keybase1.TeamRole, seqno Seqno) {
+	currentRole := ul.getUserRole(u)
+	if currentRole == role {
+		return
+	}
+	(*ul)[u] = append((*ul)[u], UserTeamRoleCheckpoint{
+		Role:  role,
+		Seqno: seqno,
+	})
+}
+
+// State of a parsed team sigchain.
+// Should be treated as immutable when returned from TeamSigChainPlayer.
+// Modified internally to TeamSigChainPlayer.
+type TeamSigChainState struct {
+	// The user who loaded this sigchain
+	Reader UserVersion
+
+	ID keybase1.TeamID
+	// Latest name of the team
+	Name TeamName
+	// The last link procesed
+	LastSeqno  Seqno
+	LastLinkID LinkID
+
+	// Present if a subteam
+	ParentID *keybase1.TeamID
+
+	// For each user, the timeline of their role status.
+	// The role checkpoints are always ordered by seqno.
+	// The latest role of the user is the role of their last checkpoint.
+	// When a user leaves the team a NONE checkpoint appears in their list.
+	UserLog UserLog
+
+	PerTeamKeys map[int]keybase1.PerTeamKey
+
+	// Set of types that were loaded stubbed-out and whose contents are missing.
+	StubbedTypes map[SigchainV2Type]bool
+}
+
+func (t TeamSigChainState) DeepCopy() TeamSigChainState {
+
+	stubbedTypes := make(map[SigchainV2Type]bool)
+	for k, v := range t.StubbedTypes {
+		stubbedTypes[k] = v
+	}
+
+	perTeamKeys := make(map[int]keybase1.PerTeamKey)
+	for k, v := range t.PerTeamKeys {
+		perTeamKeys[k] = v
+	}
+
+	userLog := make(UserLog)
+	for k, v := range t.UserLog {
+		userLog[k] = v
+	}
+
+	return TeamSigChainState{
+		Reader:       t.Reader,
+		ID:           t.ID,
+		Name:         t.Name,
+		LastSeqno:    t.LastSeqno,
+		LastLinkID:   t.LastLinkID,
+		ParentID:     t.ParentID,
+		UserLog:      userLog,
+		PerTeamKeys:  perTeamKeys,
+		StubbedTypes: stubbedTypes,
+	}
+}
+
+func (t *TeamSigChainState) GetName() TeamName {
+	return t.Name
+}
+
+func (t *TeamSigChainState) IsSubteam() bool {
+	return t.ParentID != nil
+}
+
+func (t *TeamSigChainState) GetLatestSeqno() Seqno {
+	return t.LastSeqno
+}
+
+func (t *TeamSigChainState) GetUserRole(user UserVersion) (keybase1.TeamRole, error) {
+	return t.UserLog.getUserRole(user), nil
+}
+
+func (t *TeamSigChainState) GetLatestPerTeamKey() (keybase1.PerTeamKey, error) {
+	res, ok := t.PerTeamKeys[len(t.PerTeamKeys)]
+	if !ok {
+		// if this happens it's a programming error
+		return res, errors.New("per-team-key not found")
+	}
+	return res, nil
+}
+
+// Implementations for TeamSigChainPlayer that can be mocked out for tests.
+type TeamSigChainPlayerHelper struct {
+	UsernameForUID func(keybase1.UID) (string, error)
+}
+
+type TeamSigChainPlayer struct {
+	sync.Mutex
+
+	helper *TeamSigChainPlayerHelper
+
+	// information about the reading user
+	reader UserVersion
+
+	isSubTeam bool
+
+	storedState *TeamSigChainState
+}
+
+// Load a team chain from the perspective of uid.
+func NewTeamSigChainPlayer(helper *TeamSigChainPlayerHelper, reader UserVersion, isSubTeam bool) *TeamSigChainPlayer {
+	return &TeamSigChainPlayer{
+		helper:      helper,
+		reader:      reader,
+		isSubTeam:   isSubTeam,
+		storedState: nil,
+	}
+}
+
+func (t *TeamSigChainPlayer) GetState() (res TeamSigChainState, err error) {
+	t.Lock()
+	defer t.Unlock()
+
+	if t.storedState != nil {
+		return t.storedState.DeepCopy(), nil
+	}
+	return res, fmt.Errorf("no links loaded")
+}
+
+func (t *TeamSigChainPlayer) AddChainLinks(links []SCChainLink) error {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.addChainLinksCommon(links, false)
+}
+
+// Add chain links from local storage. Skip verification checks that should have already been done.
+func (t *TeamSigChainPlayer) AddChainLinksVerified(links []SCChainLink) error {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.addChainLinksCommon(links, true)
+}
+
+// Add links.
+// Links must be added in batches because the check for what links are allowed to be stubbed
+// depends on the user's _eventual_ role in the team.
+// If this returns an error, the TeamSigChainPlayer was not modified.
+func (t *TeamSigChainPlayer) addChainLinksCommon(links []SCChainLink, alreadyVerified bool) error {
+	var err error
+	if len(links) == 0 {
+		return errors.New("no chainlinks to add")
+	}
+
+	var state *TeamSigChainState
+	if t.storedState != nil {
+		tmp := t.storedState.DeepCopy()
+		state = &tmp
+	}
+
+	for _, link := range links {
+		newState, err := t.addChainLinkCommon(state, link, alreadyVerified)
+		if err != nil {
+			return err
+		}
+		state = &newState
+	}
+
+	err = t.checkStubbed(*state)
+	if err != nil {
+		return fmt.Errorf("checking elided links: %s", err)
+	}
+
+	// Accept the new state
+	t.storedState = state
+	return nil
+}
+
+// Verify and add a chain link.
+// Does not modify self or any arguments.
+// The `prevState` argument is nil if this is the first chain link.
+func (t *TeamSigChainPlayer) addChainLinkCommon(prevState *TeamSigChainState, link SCChainLink, alreadyVerified bool) (res TeamSigChainState, err error) {
+	oRes, err := t.checkOuterLink(prevState, link, alreadyVerified)
+	if err != nil {
+		return res, fmt.Errorf("team sigchain outer link: %s", err)
+	}
+
+	stubbed := oRes.innerLink == nil
+
+	var newState *TeamSigChainState
+	if stubbed {
+		if prevState == nil {
+			return res, errors.New("first link cannot be stubbed")
+		}
+		newState2 := prevState.DeepCopy()
+		newState = &newState2
+	} else {
+		iRes, err := t.addInnerLink(prevState, link, oRes, alreadyVerified)
+		if err != nil {
+			return res, fmt.Errorf("team sigchain inner link: %s", err)
+		}
+		newState = &iRes.newState
+	}
+
+	newState.LastSeqno = oRes.outerLink.Seqno
+	newState.LastLinkID = oRes.outerLink.LinkID()
+
+	if stubbed {
+		newState.StubbedTypes[oRes.outerLink.LinkType] = true
+	}
+
+	return *newState, nil
+}
+
+type checkOuterLinkResult struct {
+	outerLink   OuterLinkV2WithMetadata
+	signingUser UserVersion
+
+	// optional inner link info
+	innerLink *SCChainLinkPayload
+}
+
+type checkInnerLinkResult struct {
+	oRes     checkOuterLinkResult
+	newState TeamSigChainState
+}
+
+func (t *TeamSigChainPlayer) checkOuterLink(prevState *TeamSigChainState, link SCChainLink, alreadyVerified bool) (res checkOuterLinkResult, err error) {
+	if prevState == nil {
+		if link.Seqno != 1 {
+			return res, fmt.Errorf("expected seqno:1 but got:%v", link.Seqno)
+		}
+	} else {
+		if link.Seqno != prevState.LastSeqno+1 {
+			return res, fmt.Errorf("expected seqno:%v but got:%v", prevState.LastSeqno+1, link.Seqno)
+		}
+	}
+
+	if link.Version != TeamSigChainPlayerSupportedLinkVersion {
+		return res, fmt.Errorf("expected version:%v but got:%v", TeamSigChainPlayerSupportedLinkVersion, link.Version)
+	}
+
+	if len(link.Sig) == 0 {
+		return res, errors.New("link has empty sig")
+	}
+	outerLink, err := DecodeOuterLinkV2(link.Sig)
+	if err != nil {
+		return res, err
+	}
+	res.outerLink = *outerLink
+
+	// TODO verify the sig. Without this this is all crazy.
+
+	// TODO verify the signers identity and authorization. Without this this is all crazy.
+
+	// TODO support validating signatures even after account reset.
+	// we need the specified eldest seqno from the server for this.
+	signerUID, err := keybase1.UIDFromString(string(link.UID))
+	if err != nil {
+		return res, err
+	}
+	username, err := t.helper.UsernameForUID(signerUID)
+	if err != nil {
+		return res, err
+	}
+	// TODO for now just assume seqno=1. Need to do something else to support links made by since-reset users.
+	res.signingUser = NewUserVersion(username, 1)
+
+	// check that the outer link matches the server info
+	err = outerLink.AssertSomeFields(link.Version, link.Seqno)
+	if err != nil {
+		return res, err
+	}
+
+	if prevState == nil {
+		if len(outerLink.Prev) != 0 {
+			return res, fmt.Errorf("expected outer nil prev but got:%s", outerLink.Prev)
+		}
+	} else {
+		if !outerLink.Prev.Eq(prevState.LastLinkID) {
+			return res, fmt.Errorf("wrong outer prev: %s != %s", outerLink.Prev, prevState.LastLinkID)
+		}
+	}
+
+	if link.Payload == "" {
+		// stubbed inner link
+		res.innerLink = nil
+	} else {
+		payload, err := link.UnmarshalPayload()
+		if err != nil {
+			return res, fmt.Errorf("error unmarshaling link payload: %s", err)
+		}
+		res.innerLink = &payload
+	}
+
+	return res, nil
+}
+
+// Check and add the inner link.
+// Does not modify `prevState` but returns a new state.
+func (t *TeamSigChainPlayer) addInnerLink(prevState *TeamSigChainState, link SCChainLink, oRes checkOuterLinkResult, alreadyVerified bool) (res checkInnerLinkResult, err error) {
+	res.oRes = oRes
+	payload := *oRes.innerLink
+
+	err = t.checkInnerOuterMatch(oRes.outerLink, payload, link.PayloadHash())
+	if err != nil {
+		return res, err
+	}
+
+	// completely ignore these fields
+	_ = payload.Ctime
+	_ = payload.ExpireIn
+	_ = payload.SeqType
+
+	if payload.Tag != "signature" {
+		return res, fmt.Errorf("unrecognized tag: '%s'", payload.Tag)
+	}
+
+	if payload.Body.Team == nil {
+		return res, errors.New("missing team section")
+	}
+	team := payload.Body.Team
+
+	// TODO check that the signer has enough role permissions to do each of the actions.
+
+	switch payload.Body.Type {
+	case "team.root":
+		if prevState != nil {
+			return res, fmt.Errorf("link type 'team.root' unexpected at seqno:%v", prevState.LastSeqno+1)
+		}
+		if team.ID == nil {
+			return res, errors.New("missing team id")
+		}
+		if team.Name == nil {
+			return res, errors.New("missing name")
+		}
+		if team.Members == nil {
+			return res, errors.New("missing members")
+		}
+		if team.Parent != nil {
+			return res, errors.New("unexpected parent")
+		}
+		if team.Subteam != nil {
+			return res, errors.New("unexpected subteam")
+		}
+		if team.PerTeamKey == nil {
+			return res, errors.New("per-team-key missing")
+		}
+
+		teamID, err := keybase1.TeamIDFromString(string(*team.ID))
+		if err != nil {
+			return res, err
+		}
+		teamName, err := TeamNameFromString(string(*team.Name))
+		if err != nil {
+			return res, err
+		}
+		// check that team_name = hash(team_id)
+		// this is only true for root teams
+		if !teamID.Equal(teamName.ToTeamID()) {
+			return res, fmt.Errorf("team id:%s does not match team name:%s", teamID, teamName)
+		}
+
+		err = t.sanityCheckMembers(*team.Members)
+		if err != nil {
+			return res, err
+		}
+
+		ownerFound := false
+		for _, u := range team.Members.Owners {
+			uv, err := ParseUserVersion(string(u))
+			if err != nil {
+				return res, err
+			}
+			if uv == oRes.signingUser {
+				ownerFound = true
+			}
+		}
+		if !ownerFound {
+			return res, fmt.Errorf("signer is not an owner: %v (%v)", oRes.signingUser, team.Members.Owners)
+			// return res, fmt.Errorf("signer is not an owner: %v", oRes.signingUser)
+		}
+
+		userLog, err := t.makeInitialUserLog(*team.Members)
+		if err != nil {
+			return res, err
+		}
+
+		perTeamKey, err := t.checkPerTeamKey(link, *team.PerTeamKey, 1)
+		if err != nil {
+			return res, err
+		}
+
+		perTeamKeys := make(map[int]keybase1.PerTeamKey)
+		perTeamKeys[1] = perTeamKey
+
+		res.newState = TeamSigChainState{
+			Reader:       t.reader,
+			ID:           teamID,
+			Name:         teamName,
+			LastSeqno:    1,
+			LastLinkID:   oRes.outerLink.LinkID(),
+			ParentID:     nil,
+			UserLog:      userLog,
+			PerTeamKeys:  perTeamKeys,
+			StubbedTypes: make(map[SigchainV2Type]bool),
+		}
+
+		return res, nil
+	case "team.change_membership":
+		return res, fmt.Errorf("todo implement parsing of: %s", payload.Body.Type)
+	case "team.rotate_key":
+		if prevState == nil {
+			return res, fmt.Errorf("link type 'team.rotate_key' unexpected at beginning of chain")
+		}
+		if team.ID == nil {
+			return res, errors.New("missing team id")
+		}
+		if team.Name != nil {
+			return res, errors.New("unexpected name")
+		}
+		if team.Members != nil {
+			return res, errors.New("unexpected members")
+		}
+		if team.Parent != nil {
+			return res, errors.New("unexpected parent")
+		}
+		if team.Subteam != nil {
+			return res, errors.New("unexpected subteam")
+		}
+		if team.PerTeamKey == nil {
+			return res, errors.New("missing per-team-key")
+		}
+
+		lastKey, err := prevState.GetLatestPerTeamKey()
+		if err != nil {
+			return res, fmt.Errorf("getting previous per-team-key: %s", err)
+		}
+		newKey, err := t.checkPerTeamKey(link, *team.PerTeamKey, lastKey.Gen+1)
+		if err != nil {
+			return res, err
+		}
+
+		res.newState = prevState.DeepCopy()
+		res.newState.PerTeamKeys[newKey.Gen] = newKey
+
+		return res, nil
+	case "team.leave":
+		return res, fmt.Errorf("todo implement parsing of: %s", payload.Body.Type)
+	case "team.subteam_head":
+		return res, fmt.Errorf("subteams not supported: %s", payload.Body.Type)
+	case "team.new_subteam":
+		return res, fmt.Errorf("subteams not supported: %s", payload.Body.Type)
+	case "team.subteam_rename":
+		return res, fmt.Errorf("subteams not supported: %s", payload.Body.Type)
+	case "":
+		return res, errors.New("empty body type")
+	default:
+		return res, fmt.Errorf("unsupported link type: %s", payload.Body.Type)
+	}
+}
+
+// check that the inner link matches the outer link
+func (t *TeamSigChainPlayer) checkInnerOuterMatch(outerLink OuterLinkV2WithMetadata, innerLink SCChainLinkPayload, innerLinkHash LinkID) (err error) {
+	var innerPrev LinkID
+	if innerLink.Prev != nil {
+		innerPrev, err = LinkIDFromHex(*innerLink.Prev)
+		if err != nil {
+			return err
+		}
+	}
+
+	innerLinkType, err := SigchainV2TypeFromV1TypeTeams(innerLink.Body.Type)
+	if err != nil {
+		return err
+	}
+
+	err = outerLink.AssertFields(innerLink.Body.Version, innerLink.Seqno, innerPrev, innerLinkHash, innerLinkType)
+	if err != nil {
+		return err
+	}
+
+	// TODO check that the key section refers to the same kid that really signed.
+
+	return nil
+}
+
+func (t *TeamSigChainPlayer) checkStubbed(state TeamSigChainState) error {
+	// TODO if you get kicked out of a team, that's special. The chain can't load.
+	// But you should get to know why without erroring out.
+
+	// Check that the server didn't stub out links it's not allowed to.
+	// In some circumstances, this error can be special.
+	// If the user's role was boosted then someone should trigger a reload of the chain with less links stubbed.
+	role, err := state.GetUserRole(t.reader)
+	if err != nil {
+		return err
+	}
+	if role == keybase1.TeamRole_NONE {
+		return errors.New("not a member of team")
+	}
+	for k, v := range state.StubbedTypes {
+		if v {
+			if !k.TeamAllowStub(role) {
+				return fmt.Errorf("link stubbed when not allowed allowed; linktype:%v role:%v", k, role)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Check that there are no duplicate members
+func (t *TeamSigChainPlayer) sanityCheckMembers(members SCTeamMembers) error {
+	var all []SCTeamMember
+
+	if len(members.Owners) < 1 {
+		return errors.New("team has no owners")
+	}
+
+	for _, m := range members.Owners {
+		all = append(all, m)
+	}
+	for _, m := range members.Admins {
+		all = append(all, m)
+	}
+	for _, m := range members.Writers {
+		all = append(all, m)
+	}
+	for _, m := range members.Readers {
+		all = append(all, m)
+	}
+
+	seen := make(map[NormalizedUsername]bool)
+
+	for _, m := range all {
+		uv, err := ParseUserVersion(string(m))
+		if err != nil {
+			return err
+		}
+		_, ok := seen[uv.Username]
+		if ok {
+			return fmt.Errorf("duplicate username in members: %s", uv.Username)
+		}
+		seen[uv.Username] = true
+	}
+
+	return nil
+}
+
+func (t *TeamSigChainPlayer) checkPerTeamKey(link SCChainLink, perTeamKey SCPerTeamKey, expectedGeneration int) (res keybase1.PerTeamKey, err error) {
+	// check the per-team-key
+	if perTeamKey.Generation != expectedGeneration {
+		return res, fmt.Errorf("per-team-key generation must start at 1 but got:%d", perTeamKey.Generation)
+	}
+	// TODO validate KIDs
+	// TODO validate the reverse sig
+
+	return keybase1.PerTeamKey{
+		Gen:    perTeamKey.Generation,
+		Seqno:  int(link.Seqno),
+		SigKID: perTeamKey.SigKID,
+		EncKID: perTeamKey.EncKID,
+	}, nil
+}
+
+func (t *TeamSigChainPlayer) makeInitialUserLog(members SCTeamMembers) (UserLog, error) {
+	userLog := make(UserLog)
+
+	add := func(member SCTeamMember, role keybase1.TeamRole) error {
+		uv, err := ParseUserVersion(string(member))
+		if err != nil {
+			return err
+		}
+		userLog.inform(uv, role, 1)
+		return nil
+	}
+
+	for _, m := range members.Readers {
+		err := add(m, keybase1.TeamRole_READER)
+		if err != nil {
+			return userLog, err
+		}
+	}
+	for _, m := range members.Writers {
+		err := add(m, keybase1.TeamRole_WRITER)
+		if err != nil {
+			return userLog, err
+		}
+	}
+	for _, m := range members.Admins {
+		err := add(m, keybase1.TeamRole_ADMIN)
+		if err != nil {
+			return userLog, err
+		}
+	}
+	for _, m := range members.Owners {
+		err := add(m, keybase1.TeamRole_OWNER)
+		if err != nil {
+			return userLog, err
+		}
+	}
+
+	return userLog, nil
+}

--- a/go/libkb/team_chain_parse.go
+++ b/go/libkb/team_chain_parse.go
@@ -1,0 +1,111 @@
+package libkb
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type SCTeamName string
+type SCTeamID string
+
+// A (username, seqno) pair.
+// The username is adorned with "%n" at the end
+// where n is the seqno IF the seqno is not 1.
+type SCTeamMember string
+
+type SCTeamSection struct {
+	ID         *SCTeamID      `json:"id,omitempty"`
+	Name       *SCTeamName    `json:"name,omitempty"`
+	Members    *SCTeamMembers `json:"members,omitempty"`
+	Parent     *SCTeamParent  `json:"parent,omitempty"`
+	Subteam    *SCSubteam     `json:"subteam,omitempty"`
+	PerTeamKey *SCPerTeamKey  `json:"per_team_key,omitempty"`
+}
+
+type SCTeamMembers struct {
+	Owners  []SCTeamMember `json:"owner,omitempty"`
+	Admins  []SCTeamMember `json:"admin,omitempty"`
+	Writers []SCTeamMember `json:"writer,omitempty"`
+	Readers []SCTeamMember `json:"reader,omitempty"`
+}
+
+type SCTeamParent struct {
+	ID    SCTeamID `json:"id"`
+	Seqno int      `json:"id"`
+}
+
+type SCSubteam struct {
+	ID   SCTeamID   `json:"id"`
+	Name SCTeamName `json:"name"`
+}
+
+type SCPerTeamKey struct {
+	Generation int          `json:"generation"`
+	EncKID     keybase1.KID `json:"encryption_kid"`
+	SigKID     keybase1.KID `json:"signing_kid"`
+	ReverseSig string       `json:"reverse_sig"`
+}
+
+// Non-team-specific stuff below the line
+// -------------------------
+
+type SCChainLink struct {
+	Seqno Seqno  `json:"seqno"`
+	Sig   string `json:"sig"`
+	// string containing json of a SCChainLinkPayload.
+	Payload string `json:"payload_json"`
+	// uid of the signer
+	UID     keybase1.UID `json:"uid"`
+	Version int          `json:"version"`
+}
+
+func (link *SCChainLink) PayloadHash() LinkID {
+	if link.Payload == "" {
+		return nil
+	}
+	h := sha256.Sum256([]byte(link.Payload))
+	return h[:]
+}
+
+func (link *SCChainLink) UnmarshalPayload() (res SCChainLinkPayload, err error) {
+	if len(link.Payload) == 0 {
+		return res, errors.New("empty payload")
+	}
+	err = json.Unmarshal([]byte(link.Payload), &res)
+	return res, err
+}
+
+type SCChainLinkPayload struct {
+	Body     SCPayloadBody `json:"body,omitempty"`
+	Ctime    int           `json:"ctime,omitempty"`
+	ExpireIn int           `json:"expire_in,omitempty"`
+	Prev     *string       `json:"prev,omitempty"`
+	SeqType  int           `json:"seq_type,omitempty"`
+	Seqno    Seqno         `json:"seqno,omitempty"`
+	Tag      string        `json:"tag,omitempty"`
+}
+
+type SCPayloadBody struct {
+	Key     *SCKeySection `json:"key,omitempty"`
+	Type    string        `json:"type,omitempty"`
+	Version int           `json:"version"`
+
+	Team *SCTeamSection `json:"team,omitempty"`
+}
+
+type SCKeySection struct {
+	KID       keybase1.KID `json:"kid"`
+	UID       keybase1.UID `json:"uid"`
+	Username  string       `json:"username,omitempty"`
+	EldestKID keybase1.KID `json:"eldest_kid"`
+	Host      string       `json:"host,omitempty"`
+}
+
+// Parse a chain link from a string. Just parses, does not validate.
+func ParseTeamChainLink(link string) (res SCChainLink, err error) {
+	err = json.Unmarshal([]byte(link), &res)
+	return res, err
+}

--- a/go/libkb/team_chain_test.go
+++ b/go/libkb/team_chain_test.go
@@ -1,0 +1,107 @@
+package libkb
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+const teamChain1 = `
+{"status":{"code":0,"name":"OK"},"chain":[{"seqno":1,"sig":"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEga6ttFJBQ4zcepPjjJNThT5zdiQqc8iLI0pFhVp0A57UKp3BheWxvYWTEJ5UCAcDEIOG5uUfGdP6m/3eDgDUVxssa2ismMBjbUuf0Sm/bfjlpIaNzaWfEQBOwbBmriWBOkf2FPZUcvi23R2fzLcmRQa/xb9Yf1u7C9FW+d/SMhD8X3hlS8Cd3Nf6AAzzkkTcXufyRnJhcIweoc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==","payload_json":"{\"body\":{\"key\":{\"eldest_kid\":\"01206bab6d149050e3371ea4f8e324d4e14f9cdd890a9cf222c8d29161569d00e7b50a\",\"host\":\"keybase.io\",\"kid\":\"01206bab6d149050e3371ea4f8e324d4e14f9cdd890a9cf222c8d29161569d00e7b50a\",\"uid\":\"e552cbc9f6951c2ea414cf098adbfa19\",\"username\":\"d_08827f78\"},\"team\":{\"id\":\"70b0e55838d4a3da62ef40b207e57b24\",\"members\":{\"admin\":[\"c_61002771\"],\"owner\":[\"d_08827f78\"],\"reader\":[\"a_1585f13b\"],\"writer\":[\"b_4a45388c\"]},\"name\":\"t_79351477\",\"per_team_key\":{\"encryption_kid\":\"012155545f16950e7fed04076b9e2f51bd53cd72e4abd1845c261ef9dcb581df67500a\",\"generation\":1,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgzXJbQHV7+E7N263CerYXxSdZuCU/wVjc1Sz/u94J92wKp3BheWxvYWTFAxx7ImJvZHkiOnsia2V5Ijp7ImVsZGVzdF9raWQiOiIwMTIwNmJhYjZkMTQ5MDUwZTMzNzFlYTRmOGUzMjRkNGUxNGY5Y2RkODkwYTljZjIyMmM4ZDI5MTYxNTY5ZDAwZTdiNTBhIiwiaG9zdCI6ImtleWJhc2UuaW8iLCJraWQiOiIwMTIwNmJhYjZkMTQ5MDUwZTMzNzFlYTRmOGUzMjRkNGUxNGY5Y2RkODkwYTljZjIyMmM4ZDI5MTYxNTY5ZDAwZTdiNTBhIiwidWlkIjoiZTU1MmNiYzlmNjk1MWMyZWE0MTRjZjA5OGFkYmZhMTkiLCJ1c2VybmFtZSI6ImRfMDg4MjdmNzgifSwidGVhbSI6eyJpZCI6IjcwYjBlNTU4MzhkNGEzZGE2MmVmNDBiMjA3ZTU3YjI0IiwibWVtYmVycyI6eyJhZG1pbiI6WyJjXzYxMDAyNzcxIl0sIm93bmVyIjpbImRfMDg4MjdmNzgiXSwicmVhZGVyIjpbImFfMTU4NWYxM2IiXSwid3JpdGVyIjpbImJfNGE0NTM4OGMiXX0sIm5hbWUiOiJ0Xzc5MzUxNDc3IiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMTU1NTQ1ZjE2OTUwZTdmZWQwNDA3NmI5ZTJmNTFiZDUzY2Q3MmU0YWJkMTg0NWMyNjFlZjlkY2I1ODFkZjY3NTAwYSIsImdlbmVyYXRpb24iOjEsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBjZDcyNWI0MDc1N2JmODRlY2RkYmFkYzI3YWI2MTdjNTI3NTliODI1M2ZjMTU4ZGNkNTJjZmZiYmRlMDlmNzZjMGEifX0sInR5cGUiOiJ0ZWFtLnJvb3QiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE0OTUyMjkwMjYsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJwcmV2IjpudWxsLCJzZXFfdHlwZSI6Mywic2Vxbm8iOjEsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RAwSxEArnauq5CfnQkf1pqJ3FPN7ebCTzcLex1xNBP/Kqp222xXaW9ZxcjeCbJqSJzFkzDa+emd1tSLreTK8rcCahzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B\",\"signing_kid\":\"0120cd725b40757bf84ecddbadc27ab617c52759b8253fc158dcd52cffbbde09f76c0a\"}},\"type\":\"team.root\",\"version\":2},\"ctime\":1495229026,\"expire_in\":157680000,\"prev\":null,\"seq_type\":3,\"seqno\":1,\"tag\":\"signature\"}","version":2,"uid":"e552cbc9f6951c2ea414cf098adbfa19"},{"seqno":2,"sig":"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEga6ttFJBQ4zcepPjjJNThT5zdiQqc8iLI0pFhVp0A57UKp3BheWxvYWTESJUCAsQgA5+oRvY4N+bV0j/Vb2tX65GOSG80ym8mRTqm/HVIj8vEIGFT/kXt6yq/sGf3MYjAFxl4ltZBh3xcC87MRX7kcVXkIqNzaWfEQJoKuDq+l0bapy47n4V+40/GmrihsZMDXk9aenmvrmqqI4sePcVpA6yE1H0Rhbdm1E5BPkqpODbaLxp9OOIQeAqoc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==","version":2,"uid":"e552cbc9f6951c2ea414cf098adbfa19"},{"seqno":3,"sig":"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg8E2SNuLyUHJAPCht43Htz5qwBmq084vUp6FaQc/BRIQKp3BheWxvYWTESJUCA8QgFAAdOlIqTvIFnNfsExgbDI1/BxWVS0w/bpB/DyscOCjEIDRb+fKIthdc8xHtXmpfK/2aMjipgIq9n+6IN2+Y+pWBJKNzaWfEQFypth82iu+gAkeo15m9vpobO1+gA+Kf/sE0mnLXkWoDTr17LaYwljebkj/VlqDP1NIAIRgMSeRfzVNaAPS4Pguoc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==","payload_json":"{\"body\":{\"key\":{\"eldest_kid\":\"0120f04d9236e2f25072403c286de371edcf9ab0066ab4f38bd4a7a15a41cfc144840a\",\"host\":\"keybase.io\",\"kid\":\"0120f04d9236e2f25072403c286de371edcf9ab0066ab4f38bd4a7a15a41cfc144840a\",\"uid\":\"130ea880070624ba5e0f0a6032cf0f19\",\"username\":\"b_4a45388c\"},\"team\":{\"id\":\"70b0e55838d4a3da62ef40b207e57b24\",\"per_team_key\":{\"encryption_kid\":\"0121015351e68bc98d256c190fbca5608c2b04a36d15f5e95896385f1b5b0c6dc1260a\",\"generation\":2,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg8Ug8hRXQisnsuKku7LoXzDXjEystpUgatdpjTaJ+jQ4Kp3BheWxvYWTFAuJ7ImJvZHkiOnsia2V5Ijp7ImVsZGVzdF9raWQiOiIwMTIwZjA0ZDkyMzZlMmYyNTA3MjQwM2MyODZkZTM3MWVkY2Y5YWIwMDY2YWI0ZjM4YmQ0YTdhMTVhNDFjZmMxNDQ4NDBhIiwiaG9zdCI6ImtleWJhc2UuaW8iLCJraWQiOiIwMTIwZjA0ZDkyMzZlMmYyNTA3MjQwM2MyODZkZTM3MWVkY2Y5YWIwMDY2YWI0ZjM4YmQ0YTdhMTVhNDFjZmMxNDQ4NDBhIiwidWlkIjoiMTMwZWE4ODAwNzA2MjRiYTVlMGYwYTYwMzJjZjBmMTkiLCJ1c2VybmFtZSI6ImJfNGE0NTM4OGMifSwidGVhbSI6eyJpZCI6IjcwYjBlNTU4MzhkNGEzZGE2MmVmNDBiMjA3ZTU3YjI0IiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMTAxNTM1MWU2OGJjOThkMjU2YzE5MGZiY2E1NjA4YzJiMDRhMzZkMTVmNWU5NTg5NjM4NWYxYjViMGM2ZGMxMjYwYSIsImdlbmVyYXRpb24iOjIsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBmMTQ4M2M4NTE1ZDA4YWM5ZWNiOGE5MmVlY2JhMTdjYzM1ZTMxMzJiMmRhNTQ4MWFiNWRhNjM0ZGEyN2U4ZDBlMGEifX0sInR5cGUiOiJ0ZWFtLnJvdGF0ZV9rZXkiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE0OTUyMjkwMjksImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJwcmV2IjoiMTQwMDFkM2E1MjJhNGVmMjA1OWNkN2VjMTMxODFiMGM4ZDdmMDcxNTk1NGI0YzNmNmU5MDdmMGYyYjFjMzgyOCIsInNlcV90eXBlIjozLCJzZXFubyI6MywidGFnIjoic2lnbmF0dXJlIn2jc2lnxEDBThqkZK4icWICDx/RLh7+KxANdojKETZX3Jl2KYG12PqDG7x9fZFbRVPSzOzY3UzPleQ0eUPAfIU4+DICnCIBqHNpZ190eXBlIKN0YWfNAgKndmVyc2lvbgE=\",\"signing_kid\":\"0120f1483c8515d08ac9ecb8a92eecba17cc35e3132b2da5481ab5da634da27e8d0e0a\"}},\"type\":\"team.rotate_key\",\"version\":2},\"ctime\":1495229029,\"expire_in\":157680000,\"prev\":\"14001d3a522a4ef2059cd7ec13181b0c8d7f0715954b4c3f6e907f0f2b1c3828\",\"seq_type\":3,\"seqno\":3,\"tag\":\"signature\"}","version":2,"uid":"130ea880070624ba5e0f0a6032cf0f19"}],"box":{"nonce":"pQSb5q+bdU8FALOApgtwaPrRgN8AAAAD","sender_kid":"01211520f0f37e835e8d98b4d19226a2632c0335b4cdc17273274f17fbdc2393f8240a","generation":2,"ctext":"0Tmgo0rWAYfug+X8V/EulDjGuYZeX5KowDifynQifDUjtDgZW21QSRHil+y4T/88","per_user_key_seqno":3},"prevs":{"2":"9301c418a5049be6af9b754f0500b380a60b7068fad180df00000000c43044eb2fdf163454eefb7caef5ed27c4e849d2ea2add23c4804247d1d3adb42997403a0d7aeb602f978d9c11338549ef9f"},"csrf_token":"lgHZIDEzMGVhODgwMDcwNjI0YmE1ZTBmMGE2MDMyY2YwZjE5zlkfYl7OAAFRgMDEIA/v+ErxmQdePfcGB8XrTKXEnrAZ7DUCr/tYuHWo3igE"}
+`
+
+type DeconstructJig struct {
+	Chain []json.RawMessage `json:"chain"`
+}
+
+func TestTeamSigChainParse(t *testing.T) {
+	tc := SetupTest(t, "test_team_chains", 1)
+	defer tc.Cleanup()
+
+	var jig DeconstructJig
+	err := json.Unmarshal([]byte(teamChain1), &jig)
+	require.NoError(t, err)
+
+	for _, link := range jig.Chain {
+		// t.Logf("link: %v", string(link))
+
+		chainLink, err := ParseTeamChainLink(string(link))
+		require.NoError(t, err)
+
+		t.Logf("chainLink: %v", spew.Sdump(chainLink))
+
+		if len(chainLink.Payload) > 0 {
+			payload, err := chainLink.UnmarshalPayload()
+			require.NoError(t, err)
+			t.Logf("payload: %v", spew.Sdump(payload))
+		} else {
+			t.Logf("payload stubbed")
+		}
+
+	}
+}
+
+func TestTeamSigChainPlay(t *testing.T) {
+	tc := SetupTest(t, "test_team_chains", 1)
+	defer tc.Cleanup()
+
+	var jig DeconstructJig
+	err := json.Unmarshal([]byte(teamChain1), &jig)
+	require.NoError(t, err)
+
+	var chainLinks []SCChainLink
+	for i, link := range jig.Chain {
+		// t.Logf("link: %v", string(link))
+
+		chainLink, err := ParseTeamChainLink(string(link))
+		require.NoError(t, err)
+
+		t.Logf("%v chainLink: %v", i, spew.Sdump(chainLink))
+		chainLinks = append(chainLinks, chainLink)
+	}
+
+	helper := TeamSigChainPlayerHelper{
+		UsernameForUID: func(uid keybase1.UID) (string, error) {
+			switch uid {
+			case "e552cbc9f6951c2ea414cf098adbfa19":
+				return "d_08827f78", nil
+			case "130ea880070624ba5e0f0a6032cf0f19":
+				return "b_4a45388c", nil
+			default:
+				return "", errors.New("testing hit unknown uid")
+			}
+		},
+	}
+	player := NewTeamSigChainPlayer(&helper, NewUserVersion("a_1585f13b", 1), true)
+	err = player.AddChainLinks(chainLinks)
+	require.NoError(t, err)
+
+	state, err := player.GetState()
+	require.NoError(t, err)
+	require.Equal(t, "t_79351477", string(state.GetName()))
+	require.False(t, state.IsSubteam())
+	ptk, err := state.GetLatestPerTeamKey()
+	require.NoError(t, err)
+	require.Equal(t, 2, ptk.Gen)
+	require.Equal(t, 3, ptk.Seqno)
+	require.Equal(t, "0120f1483c8515d08ac9ecb8a92eecba17cc35e3132b2da5481ab5da634da27e8d0e0a", string(ptk.SigKID))
+	require.Equal(t, "0121015351e68bc98d256c190fbca5608c2b04a36d15f5e95896385f1b5b0c6dc1260a", string(ptk.EncKID))
+	require.Equal(t, Seqno(3), state.GetLatestSeqno())
+
+	checkRole := func(username string, role keybase1.TeamRole) {
+		uv := NewUserVersion(username, 1)
+		r, err := state.GetUserRole(uv)
+		require.NoError(t, err)
+		require.Equal(t, role, r)
+	}
+
+	checkRole("d_08827f78", keybase1.TeamRole_OWNER)
+	checkRole("c_61002771", keybase1.TeamRole_ADMIN)
+	checkRole("b_4a45388c", keybase1.TeamRole_WRITER)
+	checkRole("a_1585f13b", keybase1.TeamRole_READER)
+	checkRole("popeye", keybase1.TeamRole_NONE)
+}

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -4,8 +4,10 @@
 package libkb
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"regexp"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	jsonw "github.com/keybase/go-jsonw"
@@ -803,4 +805,20 @@ func MakeNameWithEldestSeqno(name string, seqno Seqno) (NameWithEldestSeqno, err
 	} else {
 		return NameWithEldestSeqno(fmt.Sprintf("%s%%%d", name, seqno)), nil
 	}
+}
+
+func ValidateNormalizedUsername(username string) (NormalizedUsername, error) {
+	res := NormalizedUsername(username)
+	if len(username) < 2 {
+		return res, errors.New("username too short")
+	}
+	if len(username) > 16 {
+		return res, errors.New("username too long")
+	}
+	// underscores allowed, just not first or doubled
+	re := regexp.MustCompile(`^([a-z0-9][a-z0-9_]?)+$`)
+	if !re.MatchString(username) {
+		return res, errors.New("invalid username")
+	}
+	return res, nil
 }

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -195,6 +195,13 @@ type PerUserKey struct {
 	EncKID KID `codec:"encKID" json:"encKID"`
 }
 
+type PerTeamKey struct {
+	Gen    int `codec:"gen" json:"gen"`
+	Seqno  int `codec:"seqno" json:"seqno"`
+	SigKID KID `codec:"sigKID" json:"sigKID"`
+	EncKID KID `codec:"encKID" json:"encKID"`
+}
+
 type UserPlusKeys struct {
 	Uid               UID               `codec:"uid" json:"uid"`
 	Username          string            `codec:"username" json:"username"`
@@ -256,6 +263,39 @@ type SocialAssertion struct {
 type UserResolution struct {
 	Assertion SocialAssertion `codec:"assertion" json:"assertion"`
 	UserID    UID             `codec:"userID" json:"userID"`
+}
+
+type TeamRole int
+
+const (
+	TeamRole_NONE   TeamRole = 0
+	TeamRole_OWNER  TeamRole = 1
+	TeamRole_ADMIN  TeamRole = 2
+	TeamRole_WRITER TeamRole = 3
+	TeamRole_READER TeamRole = 4
+)
+
+var TeamRoleMap = map[string]TeamRole{
+	"NONE":   0,
+	"OWNER":  1,
+	"ADMIN":  2,
+	"WRITER": 3,
+	"READER": 4,
+}
+
+var TeamRoleRevMap = map[TeamRole]string{
+	0: "NONE",
+	1: "OWNER",
+	2: "ADMIN",
+	3: "WRITER",
+	4: "READER",
+}
+
+func (e TeamRole) String() string {
+	if v, ok := TeamRoleRevMap[e]; ok {
+		return v
+	}
+	return ""
 }
 
 type CommonInterface interface {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -19,12 +19,17 @@ import (
 )
 
 const (
-	UID_LEN          = 16
-	UID_SUFFIX       = 0x00
-	UID_SUFFIX_2     = 0x19
-	UID_SUFFIX_HEX   = "00"
-	UID_SUFFIX_2_HEX = "19"
-	PUBLIC_UID       = "ffffffffffffffffffffffffffffff00"
+	UID_LEN               = 16
+	UID_SUFFIX            = 0x00
+	UID_SUFFIX_2          = 0x19
+	UID_SUFFIX_HEX        = "00"
+	UID_SUFFIX_2_HEX      = "19"
+	TEAMID_LEN            = 16
+	TEAMID_SUFFIX         = 0x24
+	TEAMID_SUFFIX_HEX     = "24"
+	SUB_TEAMID_SUFFIX     = 0x25
+	SUB_TEAMID_SUFFIX_HEX = "25"
+	PUBLIC_UID            = "ffffffffffffffffffffffffffffff00"
 )
 
 // UID for the special "public" user.
@@ -301,6 +306,55 @@ func (u UID) GetShard(shardCount int) (int, error) {
 	}
 	n := binary.LittleEndian.Uint32(bytes)
 	return int(n % uint32(shardCount)), nil
+}
+
+func TeamIDFromString(s string) (TeamID, error) {
+	if len(s) != hex.EncodedLen(TEAMID_LEN) {
+		return "", fmt.Errorf("Bad TeamID '%s'; must be %d bytes long", s, TEAMID_LEN)
+	}
+	suffix := s[len(s)-2:]
+	if suffix != TEAMID_SUFFIX_HEX && suffix != SUB_TEAMID_SUFFIX_HEX {
+		return "", fmt.Errorf("Bad TeamID '%s': must end in 0x%x or 0x%x", s, TEAMID_SUFFIX, SUB_TEAMID_SUFFIX)
+	}
+	return TeamID(s), nil
+}
+
+// Can panic if invalid
+func (t TeamID) IsSubTeam() bool {
+	suffix := t[len(t)-2:]
+	return suffix == SUB_TEAMID_SUFFIX_HEX
+}
+
+func (t TeamID) String() string {
+	return string(t)
+}
+
+func (t TeamID) ToBytes() []byte {
+	b, err := hex.DecodeString(string(t))
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+func (t TeamID) IsNil() bool {
+	return len(t) == 0
+}
+
+func (t TeamID) Exists() bool {
+	return !t.IsNil()
+}
+
+func (t TeamID) Equal(v TeamID) bool {
+	return t == v
+}
+
+func (t TeamID) NotEqual(v TeamID) bool {
+	return !t.Equal(v)
+}
+
+func (t TeamID) Less(v TeamID) bool {
+	return t < v
 }
 
 func (s SigID) IsNil() bool {

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -152,6 +152,14 @@ protocol Common {
       KID encKID;
   }
 
+  @lint("ignore")
+  record PerTeamKey {
+      int gen;
+      int seqno;
+      KID sigKID;
+      KID encKID;
+  }
+
   record UserPlusKeys {
       UID uid;
       string username;
@@ -222,6 +230,14 @@ protocol Common {
   record UserResolution {
       SocialAssertion assertion;
       UID userID;
+  }
+
+  enum TeamRole {
+    NONE_0,
+    OWNER_1,
+    ADMIN_2,
+    WRITER_3,
+    READER_4
   }
 
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -97,6 +97,14 @@ export const CommonMerkleTreeID = {
   kbfsPrivate: 2,
 }
 
+export const CommonTeamRole = {
+  none: 0,
+  owner: 1,
+  admin: 2,
+  writer: 3,
+  reader: 4,
+}
+
 export const ConfigForkType = {
   none: 0,
   auto: 1,
@@ -4784,6 +4792,13 @@ export type PathType =
     0 // LOCAL_0
   | 1 // KBFS_1
 
+export type PerTeamKey = {
+  gen: int,
+  seqno: int,
+  sigKID: KID,
+  encKID: KID,
+}
+
 export type PerUserKey = {
   gen: int,
   seqno: int,
@@ -5455,6 +5470,13 @@ export type TLFQuery = {
 }
 
 export type TeamID = string
+
+export type TeamRole =
+    0 // NONE_0
+  | 1 // OWNER_1
+  | 2 // ADMIN_2
+  | 3 // WRITER_3
+  | 4 // READER_4
 
 export type Test = {
   reply: string,

--- a/protocol/json/keybase1/common.json
+++ b/protocol/json/keybase1/common.json
@@ -381,6 +381,29 @@
     },
     {
       "type": "record",
+      "name": "PerTeamKey",
+      "fields": [
+        {
+          "type": "int",
+          "name": "gen"
+        },
+        {
+          "type": "int",
+          "name": "seqno"
+        },
+        {
+          "type": "KID",
+          "name": "sigKID"
+        },
+        {
+          "type": "KID",
+          "name": "encKID"
+        }
+      ],
+      "lint": "ignore"
+    },
+    {
+      "type": "record",
       "name": "UserPlusKeys",
       "fields": [
         {
@@ -522,6 +545,17 @@
         }
       ],
       "doc": "UserResolution maps how an unresolved user assertion has been resolved."
+    },
+    {
+      "type": "enum",
+      "name": "TeamRole",
+      "symbols": [
+        "NONE_0",
+        "OWNER_1",
+        "ADMIN_2",
+        "WRITER_3",
+        "READER_4"
+      ]
     }
   ],
   "messages": {},

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -20,12 +20,7 @@ export type double = number
 export type bytes = Buffer
 export type WaitingHandlerType = (waiting: boolean, method: string, sessionID: number) => void
 
-const engineRpcOutgoing = (
-  method: string,
-  params: any,
-  callbackOverride: any,
-  incomingCallMapOverride: any
-) => engine()._rpcOutgoing(method, params, callbackOverride, incomingCallMapOverride)
+const engineRpcOutgoing = (method: string, params: any, callbackOverride: any, incomingCallMapOverride: any) => engine()._rpcOutgoing(method, params, callbackOverride, incomingCallMapOverride)
 
 type requestCommon = {
   waitingHandler?: WaitingHandlerType,
@@ -33,7 +28,7 @@ type requestCommon = {
 }
 
 type requestErrorCallback = {
-  callback?: ?(err: ?RPCError) => void,
+  callback?: ?(err: ?RPCError) => void
 }
 
 type RPCErrorHandler = (err: RPCError) => void
@@ -43,10 +38,7 @@ type CommonResponseHandler = {
   result: (...rest: Array<void>) => void,
 }
 
-function _channelMapRpcHelper(
-  channelConfig: ChannelConfig<*>,
-  partialRpcCall: (incomingCallMap: any, callback: Function) => void
-): ChannelMap<*> {
+function _channelMapRpcHelper(channelConfig: ChannelConfig<*>, partialRpcCall: (incomingCallMap: any, callback: Function) => void): ChannelMap<*> {
   const channelMap = createChannelMap(channelConfig)
   const incomingCallMap = Object.keys(channelMap).reduce((acc, k) => {
     acc[k] = (params, response) => {
@@ -61,6 +53,7 @@ function _channelMapRpcHelper(
   partialRpcCall(incomingCallMap, callback)
   return channelMap
 }
+
 
 export const CommonConversationStatus = {
   unfiled: 0,
@@ -199,2130 +192,694 @@ export const RemoteSyncInboxResType = {
   clear: 2,
 }
 
-export function localCancelPostRpc(
-  request: Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>
-) {
+export function localCancelPostRpc (request: Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>) {
   engineRpcOutgoing('chat.1.local.CancelPost', request)
 }
 
-export function localCancelPostRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>
-): EngineChannel {
+export function localCancelPostRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.CancelPost', request)
 }
-export function localCancelPostRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.CancelPost', request, callback, incomingCallMap)
-  })
+export function localCancelPostRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.CancelPost', request, callback, incomingCallMap) })
 }
 
-export function localCancelPostRpcPromise(
-  request: $Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>
-): Promise<void> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.CancelPost',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localCancelPostRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localCancelPostRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.CancelPost', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localDownloadAttachmentLocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {
-        param: localDownloadAttachmentLocalRpcParam,
-      }
-  >
-) {
+export function localDownloadAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {param: localDownloadAttachmentLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.DownloadAttachmentLocal', request)
 }
 
-export function localDownloadAttachmentLocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {
-        param: localDownloadAttachmentLocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localDownloadAttachmentLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {param: localDownloadAttachmentLocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.DownloadAttachmentLocal', request)
 }
-export function localDownloadAttachmentLocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {
-        param: localDownloadAttachmentLocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.DownloadAttachmentLocal', request, callback, incomingCallMap)
-  })
+export function localDownloadAttachmentLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {param: localDownloadAttachmentLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.DownloadAttachmentLocal', request, callback, incomingCallMap) })
 }
 
-export function localDownloadAttachmentLocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {
-        param: localDownloadAttachmentLocalRpcParam,
-      }
-  >
-): Promise<localDownloadAttachmentLocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.DownloadAttachmentLocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localDownloadAttachmentLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadAttachmentLocalResult) => void} & {param: localDownloadAttachmentLocalRpcParam}>): Promise<localDownloadAttachmentLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.DownloadAttachmentLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localDownloadFileAttachmentLocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localDownloadFileAttachmentLocalResult) => void} & {
-        param: localDownloadFileAttachmentLocalRpcParam,
-      }
-  >
-) {
+export function localDownloadFileAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadFileAttachmentLocalResult) => void} & {param: localDownloadFileAttachmentLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.DownloadFileAttachmentLocal', request)
 }
 
-export function localDownloadFileAttachmentLocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localDownloadFileAttachmentLocalResult) => void} & {
-        param: localDownloadFileAttachmentLocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localDownloadFileAttachmentLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadFileAttachmentLocalResult) => void} & {param: localDownloadFileAttachmentLocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.DownloadFileAttachmentLocal', request)
 }
-export function localDownloadFileAttachmentLocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localDownloadFileAttachmentLocalResult) => void} & {
-        param: localDownloadFileAttachmentLocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.DownloadFileAttachmentLocal', request, callback, incomingCallMap)
-  })
+export function localDownloadFileAttachmentLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadFileAttachmentLocalResult) => void} & {param: localDownloadFileAttachmentLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.DownloadFileAttachmentLocal', request, callback, incomingCallMap) })
 }
 
-export function localDownloadFileAttachmentLocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localDownloadFileAttachmentLocalResult) => void} & {
-        param: localDownloadFileAttachmentLocalRpcParam,
-      }
-  >
-): Promise<localDownloadFileAttachmentLocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.DownloadFileAttachmentLocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localDownloadFileAttachmentLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localDownloadFileAttachmentLocalResult) => void} & {param: localDownloadFileAttachmentLocalRpcParam}>): Promise<localDownloadFileAttachmentLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.DownloadFileAttachmentLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localFindConversationsLocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localFindConversationsLocalResult) => void} & {
-        param: localFindConversationsLocalRpcParam,
-      }
-  >
-) {
+export function localFindConversationsLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsLocalResult) => void} & {param: localFindConversationsLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.findConversationsLocal', request)
 }
 
-export function localFindConversationsLocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localFindConversationsLocalResult) => void} & {
-        param: localFindConversationsLocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localFindConversationsLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsLocalResult) => void} & {param: localFindConversationsLocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.findConversationsLocal', request)
 }
-export function localFindConversationsLocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localFindConversationsLocalResult) => void} & {
-        param: localFindConversationsLocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.findConversationsLocal', request, callback, incomingCallMap)
-  })
+export function localFindConversationsLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsLocalResult) => void} & {param: localFindConversationsLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.findConversationsLocal', request, callback, incomingCallMap) })
 }
 
-export function localFindConversationsLocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localFindConversationsLocalResult) => void} & {
-        param: localFindConversationsLocalRpcParam,
-      }
-  >
-): Promise<localFindConversationsLocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.findConversationsLocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localFindConversationsLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localFindConversationsLocalResult) => void} & {param: localFindConversationsLocalRpcParam}>): Promise<localFindConversationsLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.findConversationsLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localGetCachedThreadRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {
-        param: localGetCachedThreadRpcParam,
-      }
-  >
-) {
+export function localGetCachedThreadRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {param: localGetCachedThreadRpcParam}>) {
   engineRpcOutgoing('chat.1.local.getCachedThread', request)
 }
 
-export function localGetCachedThreadRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {
-        param: localGetCachedThreadRpcParam,
-      }
-  >
-): EngineChannel {
+export function localGetCachedThreadRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {param: localGetCachedThreadRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.getCachedThread', request)
 }
-export function localGetCachedThreadRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {
-        param: localGetCachedThreadRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.getCachedThread', request, callback, incomingCallMap)
-  })
+export function localGetCachedThreadRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {param: localGetCachedThreadRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.getCachedThread', request, callback, incomingCallMap) })
 }
 
-export function localGetCachedThreadRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {
-        param: localGetCachedThreadRpcParam,
-      }
-  >
-): Promise<localGetCachedThreadResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.getCachedThread',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localGetCachedThreadRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetCachedThreadResult) => void} & {param: localGetCachedThreadRpcParam}>): Promise<localGetCachedThreadResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.getCachedThread', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localGetConversationForCLILocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {
-        param: localGetConversationForCLILocalRpcParam,
-      }
-  >
-) {
+export function localGetConversationForCLILocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {param: localGetConversationForCLILocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.getConversationForCLILocal', request)
 }
 
-export function localGetConversationForCLILocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {
-        param: localGetConversationForCLILocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localGetConversationForCLILocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {param: localGetConversationForCLILocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.getConversationForCLILocal', request)
 }
-export function localGetConversationForCLILocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {
-        param: localGetConversationForCLILocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.getConversationForCLILocal', request, callback, incomingCallMap)
-  })
+export function localGetConversationForCLILocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {param: localGetConversationForCLILocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.getConversationForCLILocal', request, callback, incomingCallMap) })
 }
 
-export function localGetConversationForCLILocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {
-        param: localGetConversationForCLILocalRpcParam,
-      }
-  >
-): Promise<localGetConversationForCLILocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.getConversationForCLILocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localGetConversationForCLILocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetConversationForCLILocalResult) => void} & {param: localGetConversationForCLILocalRpcParam}>): Promise<localGetConversationForCLILocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.getConversationForCLILocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localGetInboxAndUnboxLocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetInboxAndUnboxLocalResult) => void} & {
-        param: localGetInboxAndUnboxLocalRpcParam,
-      }
-  >
-) {
+export function localGetInboxAndUnboxLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxAndUnboxLocalResult) => void} & {param: localGetInboxAndUnboxLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.getInboxAndUnboxLocal', request)
 }
 
-export function localGetInboxAndUnboxLocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetInboxAndUnboxLocalResult) => void} & {
-        param: localGetInboxAndUnboxLocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localGetInboxAndUnboxLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxAndUnboxLocalResult) => void} & {param: localGetInboxAndUnboxLocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.getInboxAndUnboxLocal', request)
 }
-export function localGetInboxAndUnboxLocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetInboxAndUnboxLocalResult) => void} & {
-        param: localGetInboxAndUnboxLocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.getInboxAndUnboxLocal', request, callback, incomingCallMap)
-  })
+export function localGetInboxAndUnboxLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxAndUnboxLocalResult) => void} & {param: localGetInboxAndUnboxLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.getInboxAndUnboxLocal', request, callback, incomingCallMap) })
 }
 
-export function localGetInboxAndUnboxLocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetInboxAndUnboxLocalResult) => void} & {
-        param: localGetInboxAndUnboxLocalRpcParam,
-      }
-  >
-): Promise<localGetInboxAndUnboxLocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.getInboxAndUnboxLocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localGetInboxAndUnboxLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxAndUnboxLocalResult) => void} & {param: localGetInboxAndUnboxLocalRpcParam}>): Promise<localGetInboxAndUnboxLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.getInboxAndUnboxLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localGetInboxNonblockLocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {
-        param: localGetInboxNonblockLocalRpcParam,
-      }
-  >
-) {
+export function localGetInboxNonblockLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {param: localGetInboxNonblockLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.getInboxNonblockLocal', request)
 }
 
-export function localGetInboxNonblockLocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {
-        param: localGetInboxNonblockLocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localGetInboxNonblockLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {param: localGetInboxNonblockLocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.getInboxNonblockLocal', request)
 }
-export function localGetInboxNonblockLocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {
-        param: localGetInboxNonblockLocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.getInboxNonblockLocal', request, callback, incomingCallMap)
-  })
+export function localGetInboxNonblockLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {param: localGetInboxNonblockLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.getInboxNonblockLocal', request, callback, incomingCallMap) })
 }
 
-export function localGetInboxNonblockLocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {
-        param: localGetInboxNonblockLocalRpcParam,
-      }
-  >
-): Promise<localGetInboxNonblockLocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.getInboxNonblockLocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localGetInboxNonblockLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxNonblockLocalResult) => void} & {param: localGetInboxNonblockLocalRpcParam}>): Promise<localGetInboxNonblockLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.getInboxNonblockLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localGetInboxSummaryForCLILocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetInboxSummaryForCLILocalResult) => void} & {
-        param: localGetInboxSummaryForCLILocalRpcParam,
-      }
-  >
-) {
+export function localGetInboxSummaryForCLILocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxSummaryForCLILocalResult) => void} & {param: localGetInboxSummaryForCLILocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.getInboxSummaryForCLILocal', request)
 }
 
-export function localGetInboxSummaryForCLILocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetInboxSummaryForCLILocalResult) => void} & {
-        param: localGetInboxSummaryForCLILocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localGetInboxSummaryForCLILocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxSummaryForCLILocalResult) => void} & {param: localGetInboxSummaryForCLILocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.getInboxSummaryForCLILocal', request)
 }
-export function localGetInboxSummaryForCLILocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetInboxSummaryForCLILocalResult) => void} & {
-        param: localGetInboxSummaryForCLILocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.getInboxSummaryForCLILocal', request, callback, incomingCallMap)
-  })
+export function localGetInboxSummaryForCLILocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxSummaryForCLILocalResult) => void} & {param: localGetInboxSummaryForCLILocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.getInboxSummaryForCLILocal', request, callback, incomingCallMap) })
 }
 
-export function localGetInboxSummaryForCLILocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetInboxSummaryForCLILocalResult) => void} & {
-        param: localGetInboxSummaryForCLILocalRpcParam,
-      }
-  >
-): Promise<localGetInboxSummaryForCLILocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.getInboxSummaryForCLILocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localGetInboxSummaryForCLILocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetInboxSummaryForCLILocalResult) => void} & {param: localGetInboxSummaryForCLILocalRpcParam}>): Promise<localGetInboxSummaryForCLILocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.getInboxSummaryForCLILocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localGetMessagesLocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetMessagesLocalResult) => void} & {
-        param: localGetMessagesLocalRpcParam,
-      }
-  >
-) {
+export function localGetMessagesLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetMessagesLocalResult) => void} & {param: localGetMessagesLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.GetMessagesLocal', request)
 }
 
-export function localGetMessagesLocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetMessagesLocalResult) => void} & {
-        param: localGetMessagesLocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localGetMessagesLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetMessagesLocalResult) => void} & {param: localGetMessagesLocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.GetMessagesLocal', request)
 }
-export function localGetMessagesLocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetMessagesLocalResult) => void} & {
-        param: localGetMessagesLocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.GetMessagesLocal', request, callback, incomingCallMap)
-  })
+export function localGetMessagesLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetMessagesLocalResult) => void} & {param: localGetMessagesLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.GetMessagesLocal', request, callback, incomingCallMap) })
 }
 
-export function localGetMessagesLocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetMessagesLocalResult) => void} & {
-        param: localGetMessagesLocalRpcParam,
-      }
-  >
-): Promise<localGetMessagesLocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.GetMessagesLocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localGetMessagesLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetMessagesLocalResult) => void} & {param: localGetMessagesLocalRpcParam}>): Promise<localGetMessagesLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.GetMessagesLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localGetThreadLocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetThreadLocalResult) => void} & {
-        param: localGetThreadLocalRpcParam,
-      }
-  >
-) {
+export function localGetThreadLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadLocalResult) => void} & {param: localGetThreadLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.getThreadLocal', request)
 }
 
-export function localGetThreadLocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetThreadLocalResult) => void} & {
-        param: localGetThreadLocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localGetThreadLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadLocalResult) => void} & {param: localGetThreadLocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.getThreadLocal', request)
 }
-export function localGetThreadLocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetThreadLocalResult) => void} & {
-        param: localGetThreadLocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.getThreadLocal', request, callback, incomingCallMap)
-  })
+export function localGetThreadLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadLocalResult) => void} & {param: localGetThreadLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.getThreadLocal', request, callback, incomingCallMap) })
 }
 
-export function localGetThreadLocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetThreadLocalResult) => void} & {
-        param: localGetThreadLocalRpcParam,
-      }
-  >
-): Promise<localGetThreadLocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.getThreadLocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localGetThreadLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadLocalResult) => void} & {param: localGetThreadLocalRpcParam}>): Promise<localGetThreadLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.getThreadLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localGetThreadNonblockRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetThreadNonblockResult) => void} & {
-        param: localGetThreadNonblockRpcParam,
-      }
-  >
-) {
+export function localGetThreadNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadNonblockResult) => void} & {param: localGetThreadNonblockRpcParam}>) {
   engineRpcOutgoing('chat.1.local.getThreadNonblock', request)
 }
 
-export function localGetThreadNonblockRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetThreadNonblockResult) => void} & {
-        param: localGetThreadNonblockRpcParam,
-      }
-  >
-): EngineChannel {
+export function localGetThreadNonblockRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadNonblockResult) => void} & {param: localGetThreadNonblockRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.getThreadNonblock', request)
 }
-export function localGetThreadNonblockRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetThreadNonblockResult) => void} & {
-        param: localGetThreadNonblockRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.getThreadNonblock', request, callback, incomingCallMap)
-  })
+export function localGetThreadNonblockRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadNonblockResult) => void} & {param: localGetThreadNonblockRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.getThreadNonblock', request, callback, incomingCallMap) })
 }
 
-export function localGetThreadNonblockRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localGetThreadNonblockResult) => void} & {
-        param: localGetThreadNonblockRpcParam,
-      }
-  >
-): Promise<localGetThreadNonblockResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.getThreadNonblock',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localGetThreadNonblockRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localGetThreadNonblockResult) => void} & {param: localGetThreadNonblockRpcParam}>): Promise<localGetThreadNonblockResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.getThreadNonblock', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localMakePreviewRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localMakePreviewResult) => void} & {
-        param: localMakePreviewRpcParam,
-      }
-  >
-) {
+export function localMakePreviewRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localMakePreviewResult) => void} & {param: localMakePreviewRpcParam}>) {
   engineRpcOutgoing('chat.1.local.makePreview', request)
 }
 
-export function localMakePreviewRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localMakePreviewResult) => void} & {
-        param: localMakePreviewRpcParam,
-      }
-  >
-): EngineChannel {
+export function localMakePreviewRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localMakePreviewResult) => void} & {param: localMakePreviewRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.makePreview', request)
 }
-export function localMakePreviewRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localMakePreviewResult) => void} & {
-        param: localMakePreviewRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.makePreview', request, callback, incomingCallMap)
-  })
+export function localMakePreviewRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localMakePreviewResult) => void} & {param: localMakePreviewRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.makePreview', request, callback, incomingCallMap) })
 }
 
-export function localMakePreviewRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localMakePreviewResult) => void} & {
-        param: localMakePreviewRpcParam,
-      }
-  >
-): Promise<localMakePreviewResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.makePreview',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localMakePreviewRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localMakePreviewResult) => void} & {param: localMakePreviewRpcParam}>): Promise<localMakePreviewResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.makePreview', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localMarkAsReadLocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localMarkAsReadLocalResult) => void} & {
-        param: localMarkAsReadLocalRpcParam,
-      }
-  >
-) {
+export function localMarkAsReadLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localMarkAsReadLocalResult) => void} & {param: localMarkAsReadLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.markAsReadLocal', request)
 }
 
-export function localMarkAsReadLocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localMarkAsReadLocalResult) => void} & {
-        param: localMarkAsReadLocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localMarkAsReadLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localMarkAsReadLocalResult) => void} & {param: localMarkAsReadLocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.markAsReadLocal', request)
 }
-export function localMarkAsReadLocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localMarkAsReadLocalResult) => void} & {
-        param: localMarkAsReadLocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.markAsReadLocal', request, callback, incomingCallMap)
-  })
+export function localMarkAsReadLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localMarkAsReadLocalResult) => void} & {param: localMarkAsReadLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.markAsReadLocal', request, callback, incomingCallMap) })
 }
 
-export function localMarkAsReadLocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localMarkAsReadLocalResult) => void} & {
-        param: localMarkAsReadLocalRpcParam,
-      }
-  >
-): Promise<localMarkAsReadLocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.markAsReadLocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localMarkAsReadLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localMarkAsReadLocalResult) => void} & {param: localMarkAsReadLocalRpcParam}>): Promise<localMarkAsReadLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.markAsReadLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localNewConversationLocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localNewConversationLocalResult) => void} & {
-        param: localNewConversationLocalRpcParam,
-      }
-  >
-) {
+export function localNewConversationLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localNewConversationLocalResult) => void} & {param: localNewConversationLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.newConversationLocal', request)
 }
 
-export function localNewConversationLocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localNewConversationLocalResult) => void} & {
-        param: localNewConversationLocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localNewConversationLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localNewConversationLocalResult) => void} & {param: localNewConversationLocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.newConversationLocal', request)
 }
-export function localNewConversationLocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localNewConversationLocalResult) => void} & {
-        param: localNewConversationLocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.newConversationLocal', request, callback, incomingCallMap)
-  })
+export function localNewConversationLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localNewConversationLocalResult) => void} & {param: localNewConversationLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.newConversationLocal', request, callback, incomingCallMap) })
 }
 
-export function localNewConversationLocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localNewConversationLocalResult) => void} & {
-        param: localNewConversationLocalRpcParam,
-      }
-  >
-): Promise<localNewConversationLocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.newConversationLocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localNewConversationLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localNewConversationLocalResult) => void} & {param: localNewConversationLocalRpcParam}>): Promise<localNewConversationLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.newConversationLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localPostAttachmentLocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostAttachmentLocalResult) => void} & {
-        param: localPostAttachmentLocalRpcParam,
-      }
-  >
-) {
+export function localPostAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostAttachmentLocalResult) => void} & {param: localPostAttachmentLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.postAttachmentLocal', request)
 }
 
-export function localPostAttachmentLocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostAttachmentLocalResult) => void} & {
-        param: localPostAttachmentLocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localPostAttachmentLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostAttachmentLocalResult) => void} & {param: localPostAttachmentLocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postAttachmentLocal', request)
 }
-export function localPostAttachmentLocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostAttachmentLocalResult) => void} & {
-        param: localPostAttachmentLocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.postAttachmentLocal', request, callback, incomingCallMap)
-  })
+export function localPostAttachmentLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostAttachmentLocalResult) => void} & {param: localPostAttachmentLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.postAttachmentLocal', request, callback, incomingCallMap) })
 }
 
-export function localPostAttachmentLocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostAttachmentLocalResult) => void} & {
-        param: localPostAttachmentLocalRpcParam,
-      }
-  >
-): Promise<localPostAttachmentLocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.postAttachmentLocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localPostAttachmentLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostAttachmentLocalResult) => void} & {param: localPostAttachmentLocalRpcParam}>): Promise<localPostAttachmentLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postAttachmentLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localPostDeleteNonblockRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostDeleteNonblockResult) => void} & {
-        param: localPostDeleteNonblockRpcParam,
-      }
-  >
-) {
+export function localPostDeleteNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostDeleteNonblockResult) => void} & {param: localPostDeleteNonblockRpcParam}>) {
   engineRpcOutgoing('chat.1.local.postDeleteNonblock', request)
 }
 
-export function localPostDeleteNonblockRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostDeleteNonblockResult) => void} & {
-        param: localPostDeleteNonblockRpcParam,
-      }
-  >
-): EngineChannel {
+export function localPostDeleteNonblockRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostDeleteNonblockResult) => void} & {param: localPostDeleteNonblockRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postDeleteNonblock', request)
 }
-export function localPostDeleteNonblockRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostDeleteNonblockResult) => void} & {
-        param: localPostDeleteNonblockRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.postDeleteNonblock', request, callback, incomingCallMap)
-  })
+export function localPostDeleteNonblockRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostDeleteNonblockResult) => void} & {param: localPostDeleteNonblockRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.postDeleteNonblock', request, callback, incomingCallMap) })
 }
 
-export function localPostDeleteNonblockRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostDeleteNonblockResult) => void} & {
-        param: localPostDeleteNonblockRpcParam,
-      }
-  >
-): Promise<localPostDeleteNonblockResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.postDeleteNonblock',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localPostDeleteNonblockRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostDeleteNonblockResult) => void} & {param: localPostDeleteNonblockRpcParam}>): Promise<localPostDeleteNonblockResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postDeleteNonblock', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localPostEditNonblockRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostEditNonblockResult) => void} & {
-        param: localPostEditNonblockRpcParam,
-      }
-  >
-) {
+export function localPostEditNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostEditNonblockResult) => void} & {param: localPostEditNonblockRpcParam}>) {
   engineRpcOutgoing('chat.1.local.postEditNonblock', request)
 }
 
-export function localPostEditNonblockRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostEditNonblockResult) => void} & {
-        param: localPostEditNonblockRpcParam,
-      }
-  >
-): EngineChannel {
+export function localPostEditNonblockRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostEditNonblockResult) => void} & {param: localPostEditNonblockRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postEditNonblock', request)
 }
-export function localPostEditNonblockRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostEditNonblockResult) => void} & {
-        param: localPostEditNonblockRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.postEditNonblock', request, callback, incomingCallMap)
-  })
+export function localPostEditNonblockRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostEditNonblockResult) => void} & {param: localPostEditNonblockRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.postEditNonblock', request, callback, incomingCallMap) })
 }
 
-export function localPostEditNonblockRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostEditNonblockResult) => void} & {
-        param: localPostEditNonblockRpcParam,
-      }
-  >
-): Promise<localPostEditNonblockResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.postEditNonblock',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localPostEditNonblockRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostEditNonblockResult) => void} & {param: localPostEditNonblockRpcParam}>): Promise<localPostEditNonblockResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postEditNonblock', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localPostFileAttachmentLocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {
-        param: localPostFileAttachmentLocalRpcParam,
-      }
-  >
-) {
+export function localPostFileAttachmentLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {param: localPostFileAttachmentLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.postFileAttachmentLocal', request)
 }
 
-export function localPostFileAttachmentLocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {
-        param: localPostFileAttachmentLocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localPostFileAttachmentLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {param: localPostFileAttachmentLocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postFileAttachmentLocal', request)
 }
-export function localPostFileAttachmentLocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {
-        param: localPostFileAttachmentLocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.postFileAttachmentLocal', request, callback, incomingCallMap)
-  })
+export function localPostFileAttachmentLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {param: localPostFileAttachmentLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.postFileAttachmentLocal', request, callback, incomingCallMap) })
 }
 
-export function localPostFileAttachmentLocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {
-        param: localPostFileAttachmentLocalRpcParam,
-      }
-  >
-): Promise<localPostFileAttachmentLocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.postFileAttachmentLocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localPostFileAttachmentLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostFileAttachmentLocalResult) => void} & {param: localPostFileAttachmentLocalRpcParam}>): Promise<localPostFileAttachmentLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postFileAttachmentLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localPostLocalNonblockRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostLocalNonblockResult) => void} & {
-        param: localPostLocalNonblockRpcParam,
-      }
-  >
-) {
+export function localPostLocalNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalNonblockResult) => void} & {param: localPostLocalNonblockRpcParam}>) {
   engineRpcOutgoing('chat.1.local.postLocalNonblock', request)
 }
 
-export function localPostLocalNonblockRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostLocalNonblockResult) => void} & {
-        param: localPostLocalNonblockRpcParam,
-      }
-  >
-): EngineChannel {
+export function localPostLocalNonblockRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalNonblockResult) => void} & {param: localPostLocalNonblockRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postLocalNonblock', request)
 }
-export function localPostLocalNonblockRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostLocalNonblockResult) => void} & {
-        param: localPostLocalNonblockRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.postLocalNonblock', request, callback, incomingCallMap)
-  })
+export function localPostLocalNonblockRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalNonblockResult) => void} & {param: localPostLocalNonblockRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.postLocalNonblock', request, callback, incomingCallMap) })
 }
 
-export function localPostLocalNonblockRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostLocalNonblockResult) => void} & {
-        param: localPostLocalNonblockRpcParam,
-      }
-  >
-): Promise<localPostLocalNonblockResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.postLocalNonblock',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localPostLocalNonblockRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalNonblockResult) => void} & {param: localPostLocalNonblockRpcParam}>): Promise<localPostLocalNonblockResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postLocalNonblock', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localPostLocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {
-        param: localPostLocalRpcParam,
-      }
-  >
-) {
+export function localPostLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {param: localPostLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.postLocal', request)
 }
 
-export function localPostLocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {
-        param: localPostLocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localPostLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {param: localPostLocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postLocal', request)
 }
-export function localPostLocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {
-        param: localPostLocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.postLocal', request, callback, incomingCallMap)
-  })
+export function localPostLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {param: localPostLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.postLocal', request, callback, incomingCallMap) })
 }
 
-export function localPostLocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {
-        param: localPostLocalRpcParam,
-      }
-  >
-): Promise<localPostLocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.postLocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localPostLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostLocalResult) => void} & {param: localPostLocalRpcParam}>): Promise<localPostLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localPostTextNonblockRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {
-        param: localPostTextNonblockRpcParam,
-      }
-  >
-) {
+export function localPostTextNonblockRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {param: localPostTextNonblockRpcParam}>) {
   engineRpcOutgoing('chat.1.local.postTextNonblock', request)
 }
 
-export function localPostTextNonblockRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {
-        param: localPostTextNonblockRpcParam,
-      }
-  >
-): EngineChannel {
+export function localPostTextNonblockRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {param: localPostTextNonblockRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.postTextNonblock', request)
 }
-export function localPostTextNonblockRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {
-        param: localPostTextNonblockRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.postTextNonblock', request, callback, incomingCallMap)
-  })
+export function localPostTextNonblockRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {param: localPostTextNonblockRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.postTextNonblock', request, callback, incomingCallMap) })
 }
 
-export function localPostTextNonblockRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {
-        param: localPostTextNonblockRpcParam,
-      }
-  >
-): Promise<localPostTextNonblockResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.postTextNonblock',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localPostTextNonblockRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localPostTextNonblockResult) => void} & {param: localPostTextNonblockRpcParam}>): Promise<localPostTextNonblockResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.postTextNonblock', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localRetryPostRpc(
-  request: Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>
-) {
+export function localRetryPostRpc (request: Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>) {
   engineRpcOutgoing('chat.1.local.RetryPost', request)
 }
 
-export function localRetryPostRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>
-): EngineChannel {
+export function localRetryPostRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.RetryPost', request)
 }
-export function localRetryPostRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.RetryPost', request, callback, incomingCallMap)
-  })
+export function localRetryPostRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.RetryPost', request, callback, incomingCallMap) })
 }
 
-export function localRetryPostRpcPromise(
-  request: $Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>
-): Promise<void> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.RetryPost',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localRetryPostRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localRetryPostRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.RetryPost', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localSetConversationStatusLocalRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localSetConversationStatusLocalResult) => void} & {
-        param: localSetConversationStatusLocalRpcParam,
-      }
-  >
-) {
+export function localSetConversationStatusLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localSetConversationStatusLocalResult) => void} & {param: localSetConversationStatusLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.SetConversationStatusLocal', request)
 }
 
-export function localSetConversationStatusLocalRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localSetConversationStatusLocalResult) => void} & {
-        param: localSetConversationStatusLocalRpcParam,
-      }
-  >
-): EngineChannel {
+export function localSetConversationStatusLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localSetConversationStatusLocalResult) => void} & {param: localSetConversationStatusLocalRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.SetConversationStatusLocal', request)
 }
-export function localSetConversationStatusLocalRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localSetConversationStatusLocalResult) => void} & {
-        param: localSetConversationStatusLocalRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.SetConversationStatusLocal', request, callback, incomingCallMap)
-  })
+export function localSetConversationStatusLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localSetConversationStatusLocalResult) => void} & {param: localSetConversationStatusLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.SetConversationStatusLocal', request, callback, incomingCallMap) })
 }
 
-export function localSetConversationStatusLocalRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: localSetConversationStatusLocalResult) => void} & {
-        param: localSetConversationStatusLocalRpcParam,
-      }
-  >
-): Promise<localSetConversationStatusLocalResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.SetConversationStatusLocal',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localSetConversationStatusLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localSetConversationStatusLocalResult) => void} & {param: localSetConversationStatusLocalRpcParam}>): Promise<localSetConversationStatusLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.SetConversationStatusLocal', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function localUpdateTypingRpc(
-  request: Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>
-) {
+export function localUpdateTypingRpc (request: Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>) {
   engineRpcOutgoing('chat.1.local.updateTyping', request)
 }
 
-export function localUpdateTypingRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>
-): EngineChannel {
+export function localUpdateTypingRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.updateTyping', request)
 }
-export function localUpdateTypingRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.local.updateTyping', request, callback, incomingCallMap)
-  })
+export function localUpdateTypingRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.updateTyping', request, callback, incomingCallMap) })
 }
 
-export function localUpdateTypingRpcPromise(
-  request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>
-): Promise<void> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.local.updateTyping',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function localUpdateTypingRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: localUpdateTypingRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.updateTyping', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteGetInboxRemoteRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxRemoteResult) => void} & {
-        param: remoteGetInboxRemoteRpcParam,
-      }
-  >
-) {
+export function remoteGetInboxRemoteRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxRemoteResult) => void} & {param: remoteGetInboxRemoteRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.getInboxRemote', request)
 }
 
-export function remoteGetInboxRemoteRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxRemoteResult) => void} & {
-        param: remoteGetInboxRemoteRpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteGetInboxRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxRemoteResult) => void} & {param: remoteGetInboxRemoteRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getInboxRemote', request)
 }
-export function remoteGetInboxRemoteRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxRemoteResult) => void} & {
-        param: remoteGetInboxRemoteRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.getInboxRemote', request, callback, incomingCallMap)
-  })
+export function remoteGetInboxRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxRemoteResult) => void} & {param: remoteGetInboxRemoteRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.getInboxRemote', request, callback, incomingCallMap) })
 }
 
-export function remoteGetInboxRemoteRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxRemoteResult) => void} & {
-        param: remoteGetInboxRemoteRpcParam,
-      }
-  >
-): Promise<remoteGetInboxRemoteResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.getInboxRemote',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteGetInboxRemoteRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxRemoteResult) => void} & {param: remoteGetInboxRemoteRpcParam}>): Promise<remoteGetInboxRemoteResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.getInboxRemote', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteGetInboxVersionRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxVersionResult) => void} & {
-        param: remoteGetInboxVersionRpcParam,
-      }
-  >
-) {
+export function remoteGetInboxVersionRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxVersionResult) => void} & {param: remoteGetInboxVersionRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.getInboxVersion', request)
 }
 
-export function remoteGetInboxVersionRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxVersionResult) => void} & {
-        param: remoteGetInboxVersionRpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteGetInboxVersionRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxVersionResult) => void} & {param: remoteGetInboxVersionRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getInboxVersion', request)
 }
-export function remoteGetInboxVersionRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxVersionResult) => void} & {
-        param: remoteGetInboxVersionRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.getInboxVersion', request, callback, incomingCallMap)
-  })
+export function remoteGetInboxVersionRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxVersionResult) => void} & {param: remoteGetInboxVersionRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.getInboxVersion', request, callback, incomingCallMap) })
 }
 
-export function remoteGetInboxVersionRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxVersionResult) => void} & {
-        param: remoteGetInboxVersionRpcParam,
-      }
-  >
-): Promise<remoteGetInboxVersionResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.getInboxVersion',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteGetInboxVersionRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetInboxVersionResult) => void} & {param: remoteGetInboxVersionRpcParam}>): Promise<remoteGetInboxVersionResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.getInboxVersion', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteGetMessagesRemoteRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetMessagesRemoteResult) => void} & {
-        param: remoteGetMessagesRemoteRpcParam,
-      }
-  >
-) {
+export function remoteGetMessagesRemoteRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetMessagesRemoteResult) => void} & {param: remoteGetMessagesRemoteRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.getMessagesRemote', request)
 }
 
-export function remoteGetMessagesRemoteRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetMessagesRemoteResult) => void} & {
-        param: remoteGetMessagesRemoteRpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteGetMessagesRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetMessagesRemoteResult) => void} & {param: remoteGetMessagesRemoteRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getMessagesRemote', request)
 }
-export function remoteGetMessagesRemoteRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetMessagesRemoteResult) => void} & {
-        param: remoteGetMessagesRemoteRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.getMessagesRemote', request, callback, incomingCallMap)
-  })
+export function remoteGetMessagesRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetMessagesRemoteResult) => void} & {param: remoteGetMessagesRemoteRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.getMessagesRemote', request, callback, incomingCallMap) })
 }
 
-export function remoteGetMessagesRemoteRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetMessagesRemoteResult) => void} & {
-        param: remoteGetMessagesRemoteRpcParam,
-      }
-  >
-): Promise<remoteGetMessagesRemoteResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.getMessagesRemote',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteGetMessagesRemoteRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetMessagesRemoteResult) => void} & {param: remoteGetMessagesRemoteRpcParam}>): Promise<remoteGetMessagesRemoteResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.getMessagesRemote', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteGetPublicConversationsRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetPublicConversationsResult) => void} & {
-        param: remoteGetPublicConversationsRpcParam,
-      }
-  >
-) {
+export function remoteGetPublicConversationsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetPublicConversationsResult) => void} & {param: remoteGetPublicConversationsRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.getPublicConversations', request)
 }
 
-export function remoteGetPublicConversationsRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetPublicConversationsResult) => void} & {
-        param: remoteGetPublicConversationsRpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteGetPublicConversationsRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetPublicConversationsResult) => void} & {param: remoteGetPublicConversationsRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getPublicConversations', request)
 }
-export function remoteGetPublicConversationsRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetPublicConversationsResult) => void} & {
-        param: remoteGetPublicConversationsRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.getPublicConversations', request, callback, incomingCallMap)
-  })
+export function remoteGetPublicConversationsRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetPublicConversationsResult) => void} & {param: remoteGetPublicConversationsRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.getPublicConversations', request, callback, incomingCallMap) })
 }
 
-export function remoteGetPublicConversationsRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetPublicConversationsResult) => void} & {
-        param: remoteGetPublicConversationsRpcParam,
-      }
-  >
-): Promise<remoteGetPublicConversationsResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.getPublicConversations',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteGetPublicConversationsRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetPublicConversationsResult) => void} & {param: remoteGetPublicConversationsRpcParam}>): Promise<remoteGetPublicConversationsResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.getPublicConversations', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteGetS3ParamsRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetS3ParamsResult) => void} & {
-        param: remoteGetS3ParamsRpcParam,
-      }
-  >
-) {
+export function remoteGetS3ParamsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetS3ParamsResult) => void} & {param: remoteGetS3ParamsRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.getS3Params', request)
 }
 
-export function remoteGetS3ParamsRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetS3ParamsResult) => void} & {
-        param: remoteGetS3ParamsRpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteGetS3ParamsRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetS3ParamsResult) => void} & {param: remoteGetS3ParamsRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getS3Params', request)
 }
-export function remoteGetS3ParamsRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetS3ParamsResult) => void} & {
-        param: remoteGetS3ParamsRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.getS3Params', request, callback, incomingCallMap)
-  })
+export function remoteGetS3ParamsRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetS3ParamsResult) => void} & {param: remoteGetS3ParamsRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.getS3Params', request, callback, incomingCallMap) })
 }
 
-export function remoteGetS3ParamsRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetS3ParamsResult) => void} & {
-        param: remoteGetS3ParamsRpcParam,
-      }
-  >
-): Promise<remoteGetS3ParamsResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.getS3Params',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteGetS3ParamsRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetS3ParamsResult) => void} & {param: remoteGetS3ParamsRpcParam}>): Promise<remoteGetS3ParamsResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.getS3Params', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteGetThreadRemoteRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetThreadRemoteResult) => void} & {
-        param: remoteGetThreadRemoteRpcParam,
-      }
-  >
-) {
+export function remoteGetThreadRemoteRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetThreadRemoteResult) => void} & {param: remoteGetThreadRemoteRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.getThreadRemote', request)
 }
 
-export function remoteGetThreadRemoteRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetThreadRemoteResult) => void} & {
-        param: remoteGetThreadRemoteRpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteGetThreadRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetThreadRemoteResult) => void} & {param: remoteGetThreadRemoteRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.getThreadRemote', request)
 }
-export function remoteGetThreadRemoteRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetThreadRemoteResult) => void} & {
-        param: remoteGetThreadRemoteRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.getThreadRemote', request, callback, incomingCallMap)
-  })
+export function remoteGetThreadRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetThreadRemoteResult) => void} & {param: remoteGetThreadRemoteRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.getThreadRemote', request, callback, incomingCallMap) })
 }
 
-export function remoteGetThreadRemoteRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetThreadRemoteResult) => void} & {
-        param: remoteGetThreadRemoteRpcParam,
-      }
-  >
-): Promise<remoteGetThreadRemoteResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.getThreadRemote',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteGetThreadRemoteRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetThreadRemoteResult) => void} & {param: remoteGetThreadRemoteRpcParam}>): Promise<remoteGetThreadRemoteResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.getThreadRemote', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteGetUnreadUpdateFullRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetUnreadUpdateFullResult) => void} & {
-        param: remoteGetUnreadUpdateFullRpcParam,
-      }
-  >
-) {
+export function remoteGetUnreadUpdateFullRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetUnreadUpdateFullResult) => void} & {param: remoteGetUnreadUpdateFullRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.GetUnreadUpdateFull', request)
 }
 
-export function remoteGetUnreadUpdateFullRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetUnreadUpdateFullResult) => void} & {
-        param: remoteGetUnreadUpdateFullRpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteGetUnreadUpdateFullRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetUnreadUpdateFullResult) => void} & {param: remoteGetUnreadUpdateFullRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.GetUnreadUpdateFull', request)
 }
-export function remoteGetUnreadUpdateFullRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetUnreadUpdateFullResult) => void} & {
-        param: remoteGetUnreadUpdateFullRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.GetUnreadUpdateFull', request, callback, incomingCallMap)
-  })
+export function remoteGetUnreadUpdateFullRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetUnreadUpdateFullResult) => void} & {param: remoteGetUnreadUpdateFullRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.GetUnreadUpdateFull', request, callback, incomingCallMap) })
 }
 
-export function remoteGetUnreadUpdateFullRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteGetUnreadUpdateFullResult) => void} & {
-        param: remoteGetUnreadUpdateFullRpcParam,
-      }
-  >
-): Promise<remoteGetUnreadUpdateFullResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.GetUnreadUpdateFull',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteGetUnreadUpdateFullRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteGetUnreadUpdateFullResult) => void} & {param: remoteGetUnreadUpdateFullRpcParam}>): Promise<remoteGetUnreadUpdateFullResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.GetUnreadUpdateFull', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteMarkAsReadRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteMarkAsReadResult) => void} & {
-        param: remoteMarkAsReadRpcParam,
-      }
-  >
-) {
+export function remoteMarkAsReadRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteMarkAsReadResult) => void} & {param: remoteMarkAsReadRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.markAsRead', request)
 }
 
-export function remoteMarkAsReadRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteMarkAsReadResult) => void} & {
-        param: remoteMarkAsReadRpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteMarkAsReadRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteMarkAsReadResult) => void} & {param: remoteMarkAsReadRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.markAsRead', request)
 }
-export function remoteMarkAsReadRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteMarkAsReadResult) => void} & {
-        param: remoteMarkAsReadRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.markAsRead', request, callback, incomingCallMap)
-  })
+export function remoteMarkAsReadRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteMarkAsReadResult) => void} & {param: remoteMarkAsReadRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.markAsRead', request, callback, incomingCallMap) })
 }
 
-export function remoteMarkAsReadRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteMarkAsReadResult) => void} & {
-        param: remoteMarkAsReadRpcParam,
-      }
-  >
-): Promise<remoteMarkAsReadResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.markAsRead',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteMarkAsReadRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteMarkAsReadResult) => void} & {param: remoteMarkAsReadRpcParam}>): Promise<remoteMarkAsReadResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.markAsRead', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteNewConversationRemote2Rpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemote2Result) => void} & {
-        param: remoteNewConversationRemote2RpcParam,
-      }
-  >
-) {
+export function remoteNewConversationRemote2Rpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemote2Result) => void} & {param: remoteNewConversationRemote2RpcParam}>) {
   engineRpcOutgoing('chat.1.remote.newConversationRemote2', request)
 }
 
-export function remoteNewConversationRemote2RpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemote2Result) => void} & {
-        param: remoteNewConversationRemote2RpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteNewConversationRemote2RpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemote2Result) => void} & {param: remoteNewConversationRemote2RpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.newConversationRemote2', request)
 }
-export function remoteNewConversationRemote2RpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemote2Result) => void} & {
-        param: remoteNewConversationRemote2RpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.newConversationRemote2', request, callback, incomingCallMap)
-  })
+export function remoteNewConversationRemote2RpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemote2Result) => void} & {param: remoteNewConversationRemote2RpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.newConversationRemote2', request, callback, incomingCallMap) })
 }
 
-export function remoteNewConversationRemote2RpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemote2Result) => void} & {
-        param: remoteNewConversationRemote2RpcParam,
-      }
-  >
-): Promise<remoteNewConversationRemote2Result> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.newConversationRemote2',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteNewConversationRemote2RpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemote2Result) => void} & {param: remoteNewConversationRemote2RpcParam}>): Promise<remoteNewConversationRemote2Result> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.newConversationRemote2', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteNewConversationRemoteRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemoteResult) => void} & {
-        param: remoteNewConversationRemoteRpcParam,
-      }
-  >
-) {
+export function remoteNewConversationRemoteRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemoteResult) => void} & {param: remoteNewConversationRemoteRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.newConversationRemote', request)
 }
 
-export function remoteNewConversationRemoteRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemoteResult) => void} & {
-        param: remoteNewConversationRemoteRpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteNewConversationRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemoteResult) => void} & {param: remoteNewConversationRemoteRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.newConversationRemote', request)
 }
-export function remoteNewConversationRemoteRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemoteResult) => void} & {
-        param: remoteNewConversationRemoteRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.newConversationRemote', request, callback, incomingCallMap)
-  })
+export function remoteNewConversationRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemoteResult) => void} & {param: remoteNewConversationRemoteRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.newConversationRemote', request, callback, incomingCallMap) })
 }
 
-export function remoteNewConversationRemoteRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemoteResult) => void} & {
-        param: remoteNewConversationRemoteRpcParam,
-      }
-  >
-): Promise<remoteNewConversationRemoteResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.newConversationRemote',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteNewConversationRemoteRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteNewConversationRemoteResult) => void} & {param: remoteNewConversationRemoteRpcParam}>): Promise<remoteNewConversationRemoteResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.newConversationRemote', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remotePostRemoteRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remotePostRemoteResult) => void} & {
-        param: remotePostRemoteRpcParam,
-      }
-  >
-) {
+export function remotePostRemoteRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remotePostRemoteResult) => void} & {param: remotePostRemoteRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.postRemote', request)
 }
 
-export function remotePostRemoteRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remotePostRemoteResult) => void} & {
-        param: remotePostRemoteRpcParam,
-      }
-  >
-): EngineChannel {
+export function remotePostRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remotePostRemoteResult) => void} & {param: remotePostRemoteRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.postRemote', request)
 }
-export function remotePostRemoteRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remotePostRemoteResult) => void} & {
-        param: remotePostRemoteRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.postRemote', request, callback, incomingCallMap)
-  })
+export function remotePostRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remotePostRemoteResult) => void} & {param: remotePostRemoteRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.postRemote', request, callback, incomingCallMap) })
 }
 
-export function remotePostRemoteRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remotePostRemoteResult) => void} & {
-        param: remotePostRemoteRpcParam,
-      }
-  >
-): Promise<remotePostRemoteResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.postRemote',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remotePostRemoteRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remotePostRemoteResult) => void} & {param: remotePostRemoteRpcParam}>): Promise<remotePostRemoteResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.postRemote', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remotePublishReadMessageRpc(
-  request: Exact<requestCommon & requestErrorCallback & {param: remotePublishReadMessageRpcParam}>
-) {
+export function remotePublishReadMessageRpc (request: Exact<requestCommon & requestErrorCallback & {param: remotePublishReadMessageRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.publishReadMessage', request)
 }
 
-export function remotePublishReadMessageRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: remotePublishReadMessageRpcParam}>
-): EngineChannel {
+export function remotePublishReadMessageRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remotePublishReadMessageRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.publishReadMessage', request)
 }
-export function remotePublishReadMessageRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: remotePublishReadMessageRpcParam}>
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.publishReadMessage', request, callback, incomingCallMap)
-  })
+export function remotePublishReadMessageRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remotePublishReadMessageRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.publishReadMessage', request, callback, incomingCallMap) })
 }
 
-export function remotePublishReadMessageRpcPromise(
-  request: $Exact<requestCommon & requestErrorCallback & {param: remotePublishReadMessageRpcParam}>
-): Promise<void> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.publishReadMessage',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remotePublishReadMessageRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remotePublishReadMessageRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.publishReadMessage', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remotePublishSetConversationStatusRpc(
-  request: Exact<requestCommon & requestErrorCallback & {param: remotePublishSetConversationStatusRpcParam}>
-) {
+export function remotePublishSetConversationStatusRpc (request: Exact<requestCommon & requestErrorCallback & {param: remotePublishSetConversationStatusRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.publishSetConversationStatus', request)
 }
 
-export function remotePublishSetConversationStatusRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: remotePublishSetConversationStatusRpcParam}>
-): EngineChannel {
+export function remotePublishSetConversationStatusRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remotePublishSetConversationStatusRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.publishSetConversationStatus', request)
 }
-export function remotePublishSetConversationStatusRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: remotePublishSetConversationStatusRpcParam}>
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.publishSetConversationStatus', request, callback, incomingCallMap)
-  })
+export function remotePublishSetConversationStatusRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remotePublishSetConversationStatusRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.publishSetConversationStatus', request, callback, incomingCallMap) })
 }
 
-export function remotePublishSetConversationStatusRpcPromise(
-  request: $Exact<requestCommon & requestErrorCallback & {param: remotePublishSetConversationStatusRpcParam}>
-): Promise<void> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.publishSetConversationStatus',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remotePublishSetConversationStatusRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remotePublishSetConversationStatusRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.publishSetConversationStatus', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteS3SignRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteS3SignResult) => void} & {
-        param: remoteS3SignRpcParam,
-      }
-  >
-) {
+export function remoteS3SignRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteS3SignResult) => void} & {param: remoteS3SignRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.s3Sign', request)
 }
 
-export function remoteS3SignRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteS3SignResult) => void} & {
-        param: remoteS3SignRpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteS3SignRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteS3SignResult) => void} & {param: remoteS3SignRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.s3Sign', request)
 }
-export function remoteS3SignRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteS3SignResult) => void} & {
-        param: remoteS3SignRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.s3Sign', request, callback, incomingCallMap)
-  })
+export function remoteS3SignRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteS3SignResult) => void} & {param: remoteS3SignRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.s3Sign', request, callback, incomingCallMap) })
 }
 
-export function remoteS3SignRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteS3SignResult) => void} & {
-        param: remoteS3SignRpcParam,
-      }
-  >
-): Promise<remoteS3SignResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.s3Sign',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteS3SignRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteS3SignResult) => void} & {param: remoteS3SignRpcParam}>): Promise<remoteS3SignResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.s3Sign', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteSetConversationStatusRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSetConversationStatusResult) => void} & {
-        param: remoteSetConversationStatusRpcParam,
-      }
-  >
-) {
+export function remoteSetConversationStatusRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetConversationStatusResult) => void} & {param: remoteSetConversationStatusRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.SetConversationStatus', request)
 }
 
-export function remoteSetConversationStatusRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSetConversationStatusResult) => void} & {
-        param: remoteSetConversationStatusRpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteSetConversationStatusRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetConversationStatusResult) => void} & {param: remoteSetConversationStatusRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.SetConversationStatus', request)
 }
-export function remoteSetConversationStatusRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSetConversationStatusResult) => void} & {
-        param: remoteSetConversationStatusRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.SetConversationStatus', request, callback, incomingCallMap)
-  })
+export function remoteSetConversationStatusRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetConversationStatusResult) => void} & {param: remoteSetConversationStatusRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.SetConversationStatus', request, callback, incomingCallMap) })
 }
 
-export function remoteSetConversationStatusRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSetConversationStatusResult) => void} & {
-        param: remoteSetConversationStatusRpcParam,
-      }
-  >
-): Promise<remoteSetConversationStatusResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.SetConversationStatus',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteSetConversationStatusRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetConversationStatusResult) => void} & {param: remoteSetConversationStatusRpcParam}>): Promise<remoteSetConversationStatusResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.SetConversationStatus', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteSyncAllRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {
-        param: remoteSyncAllRpcParam,
-      }
-  >
-) {
+export function remoteSyncAllRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.syncAll', request)
 }
 
-export function remoteSyncAllRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {
-        param: remoteSyncAllRpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteSyncAllRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.syncAll', request)
 }
-export function remoteSyncAllRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {
-        param: remoteSyncAllRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.syncAll', request, callback, incomingCallMap)
-  })
+export function remoteSyncAllRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.syncAll', request, callback, incomingCallMap) })
 }
 
-export function remoteSyncAllRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {
-        param: remoteSyncAllRpcParam,
-      }
-  >
-): Promise<remoteSyncAllResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.syncAll',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteSyncAllRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncAllResult) => void} & {param: remoteSyncAllRpcParam}>): Promise<remoteSyncAllResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.syncAll', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteSyncChatRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {
-        param: remoteSyncChatRpcParam,
-      }
-  >
-) {
+export function remoteSyncChatRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {param: remoteSyncChatRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.syncChat', request)
 }
 
-export function remoteSyncChatRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {
-        param: remoteSyncChatRpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteSyncChatRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {param: remoteSyncChatRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.syncChat', request)
 }
-export function remoteSyncChatRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {
-        param: remoteSyncChatRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.syncChat', request, callback, incomingCallMap)
-  })
+export function remoteSyncChatRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {param: remoteSyncChatRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.syncChat', request, callback, incomingCallMap) })
 }
 
-export function remoteSyncChatRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {
-        param: remoteSyncChatRpcParam,
-      }
-  >
-): Promise<remoteSyncChatResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.syncChat',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteSyncChatRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncChatResult) => void} & {param: remoteSyncChatRpcParam}>): Promise<remoteSyncChatResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.syncChat', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteSyncInboxRpc(
-  request: Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSyncInboxResult) => void} & {
-        param: remoteSyncInboxRpcParam,
-      }
-  >
-) {
+export function remoteSyncInboxRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncInboxResult) => void} & {param: remoteSyncInboxRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.syncInbox', request)
 }
 
-export function remoteSyncInboxRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSyncInboxResult) => void} & {
-        param: remoteSyncInboxRpcParam,
-      }
-  >
-): EngineChannel {
+export function remoteSyncInboxRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncInboxResult) => void} & {param: remoteSyncInboxRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.syncInbox', request)
 }
-export function remoteSyncInboxRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSyncInboxResult) => void} & {
-        param: remoteSyncInboxRpcParam,
-      }
-  >
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.syncInbox', request, callback, incomingCallMap)
-  })
+export function remoteSyncInboxRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncInboxResult) => void} & {param: remoteSyncInboxRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.syncInbox', request, callback, incomingCallMap) })
 }
 
-export function remoteSyncInboxRpcPromise(
-  request: $Exact<
-    requestCommon & {callback?: ?(err: ?any, response: remoteSyncInboxResult) => void} & {
-        param: remoteSyncInboxRpcParam,
-      }
-  >
-): Promise<remoteSyncInboxResult> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.syncInbox',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteSyncInboxRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSyncInboxResult) => void} & {param: remoteSyncInboxRpcParam}>): Promise<remoteSyncInboxResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.syncInbox', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteTlfFinalizeRpc(
-  request: Exact<requestCommon & requestErrorCallback & {param: remoteTlfFinalizeRpcParam}>
-) {
+export function remoteTlfFinalizeRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteTlfFinalizeRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.tlfFinalize', request)
 }
 
-export function remoteTlfFinalizeRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: remoteTlfFinalizeRpcParam}>
-): EngineChannel {
+export function remoteTlfFinalizeRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteTlfFinalizeRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.tlfFinalize', request)
 }
-export function remoteTlfFinalizeRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: remoteTlfFinalizeRpcParam}>
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.tlfFinalize', request, callback, incomingCallMap)
-  })
+export function remoteTlfFinalizeRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteTlfFinalizeRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.tlfFinalize', request, callback, incomingCallMap) })
 }
 
-export function remoteTlfFinalizeRpcPromise(
-  request: $Exact<requestCommon & requestErrorCallback & {param: remoteTlfFinalizeRpcParam}>
-): Promise<void> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.tlfFinalize',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteTlfFinalizeRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteTlfFinalizeRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.tlfFinalize', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteTlfResolveRpc(
-  request: Exact<requestCommon & requestErrorCallback & {param: remoteTlfResolveRpcParam}>
-) {
+export function remoteTlfResolveRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteTlfResolveRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.tlfResolve', request)
 }
 
-export function remoteTlfResolveRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: remoteTlfResolveRpcParam}>
-): EngineChannel {
+export function remoteTlfResolveRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteTlfResolveRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.tlfResolve', request)
 }
-export function remoteTlfResolveRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: remoteTlfResolveRpcParam}>
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.tlfResolve', request, callback, incomingCallMap)
-  })
+export function remoteTlfResolveRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteTlfResolveRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.tlfResolve', request, callback, incomingCallMap) })
 }
 
-export function remoteTlfResolveRpcPromise(
-  request: $Exact<requestCommon & requestErrorCallback & {param: remoteTlfResolveRpcParam}>
-): Promise<void> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.tlfResolve',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteTlfResolveRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteTlfResolveRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.tlfResolve', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
-export function remoteUpdateTypingRemoteRpc(
-  request: Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>
-) {
+export function remoteUpdateTypingRemoteRpc (request: Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.updateTypingRemote', request)
 }
 
-export function remoteUpdateTypingRemoteRpcChannelMap(
-  configKeys: Array<string>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>
-): EngineChannel {
+export function remoteUpdateTypingRemoteRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>): EngineChannel {
   return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.updateTypingRemote', request)
 }
-export function remoteUpdateTypingRemoteRpcChannelMapOld(
-  channelConfig: ChannelConfig<*>,
-  request: $Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>
-): ChannelMap<*> {
-  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => {
-    engineRpcOutgoing('chat.1.remote.updateTypingRemote', request, callback, incomingCallMap)
-  })
+export function remoteUpdateTypingRemoteRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.updateTypingRemote', request, callback, incomingCallMap) })
 }
 
-export function remoteUpdateTypingRemoteRpcPromise(
-  request: $Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>
-): Promise<void> {
-  return new Promise((resolve, reject) =>
-    engineRpcOutgoing(
-      'chat.1.remote.updateTypingRemote',
-      request,
-      (error, result) => (error ? reject(error) : resolve(result))
-    )
-  )
+export function remoteUpdateTypingRemoteRpcPromise (request: $Exact<requestCommon & requestErrorCallback & {param: remoteUpdateTypingRemoteRpcParam}>): Promise<void> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.updateTypingRemote', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
 export type Asset = {
@@ -2343,9 +900,9 @@ export type Asset = {
 }
 
 export type AssetMetadata =
-  | {assetType: 1, image: ?AssetMetadataImage}
-  | {assetType: 2, video: ?AssetMetadataVideo}
-  | {assetType: 3, audio: ?AssetMetadataAudio}
+    { assetType: 1, image: ?AssetMetadataImage }
+  | { assetType: 2, video: ?AssetMetadataVideo }
+  | { assetType: 3, audio: ?AssetMetadataAudio }
 
 export type AssetMetadataAudio = {
   durationMs: int,
@@ -2357,7 +914,7 @@ export type AssetMetadataImage = {
 }
 
 export type AssetMetadataType =
-  | 0 // NONE_0
+    0 // NONE_0
   | 1 // IMAGE_1
   | 2 // VIDEO_2
   | 3 // AUDIO_3
@@ -2368,19 +925,20 @@ export type AssetMetadataVideo = {
   durationMs: int,
 }
 
-export type AssetTag = 0 // PRIMARY_0
+export type AssetTag =
+    0 // PRIMARY_0
 
 export type BodyPlaintext =
-  | {version: 1, v1: ?BodyPlaintextV1}
-  | {version: 2, v2: ?BodyPlaintextUnsupported}
-  | {version: 3, v3: ?BodyPlaintextUnsupported}
-  | {version: 4, v4: ?BodyPlaintextUnsupported}
-  | {version: 5, v5: ?BodyPlaintextUnsupported}
-  | {version: 6, v6: ?BodyPlaintextUnsupported}
-  | {version: 7, v7: ?BodyPlaintextUnsupported}
-  | {version: 8, v8: ?BodyPlaintextUnsupported}
-  | {version: 9, v9: ?BodyPlaintextUnsupported}
-  | {version: 10, v10: ?BodyPlaintextUnsupported}
+    { version: 1, v1: ?BodyPlaintextV1 }
+  | { version: 2, v2: ?BodyPlaintextUnsupported }
+  | { version: 3, v3: ?BodyPlaintextUnsupported }
+  | { version: 4, v4: ?BodyPlaintextUnsupported }
+  | { version: 5, v5: ?BodyPlaintextUnsupported }
+  | { version: 6, v6: ?BodyPlaintextUnsupported }
+  | { version: 7, v7: ?BodyPlaintextUnsupported }
+  | { version: 8, v8: ?BodyPlaintextUnsupported }
+  | { version: 9, v9: ?BodyPlaintextUnsupported }
+  | { version: 10, v10: ?BodyPlaintextUnsupported }
 
 export type BodyPlaintextMetaInfo = {
   crit: boolean,
@@ -2395,7 +953,7 @@ export type BodyPlaintextV1 = {
 }
 
 export type BodyPlaintextVersion =
-  | 1 // V1_1
+    1 // V1_1
   | 2 // V2_2
   | 3 // V3_3
   | 4 // V4_4
@@ -2407,14 +965,14 @@ export type BodyPlaintextVersion =
   | 10 // V10_10
 
 export type ChatActivity =
-  | {activityType: 1, incomingMessage: ?IncomingMessage}
-  | {activityType: 2, readMessage: ?ReadMessageInfo}
-  | {activityType: 3, newConversation: ?NewConversationInfo}
-  | {activityType: 4, setStatus: ?SetStatusInfo}
-  | {activityType: 5, failedMessage: ?FailedMessageInfo}
+    { activityType: 1, incomingMessage: ?IncomingMessage }
+  | { activityType: 2, readMessage: ?ReadMessageInfo }
+  | { activityType: 3, newConversation: ?NewConversationInfo }
+  | { activityType: 4, setStatus: ?SetStatusInfo }
+  | { activityType: 5, failedMessage: ?FailedMessageInfo }
 
 export type ChatActivityType =
-  | 0 // RESERVED_0
+    0 // RESERVED_0
   | 1 // INCOMING_MESSAGE_1
   | 2 // READ_MESSAGE_2
   | 3 // NEW_CONVERSATION_3
@@ -2450,7 +1008,7 @@ export type ConversationErrorRekey = {
 }
 
 export type ConversationErrorType =
-  | 0 // PERMANENT_0
+    0 // PERMANENT_0
   | 1 // MISSINGINFO_1
   | 2 // SELFREKEYNEEDED_2
   | 3 // OTHERREKEYNEEDED_3
@@ -2518,7 +1076,7 @@ export type ConversationResolveInfo = {
 }
 
 export type ConversationStatus =
-  | 0 // UNFILED_0
+    0 // UNFILED_0
   | 1 // FAVORITE_1
   | 2 // IGNORED_2
   | 3 // BLOCKED_3
@@ -2688,16 +1246,16 @@ export type GetThreadRemoteRes = {
 export type Hash = bytes
 
 export type HeaderPlaintext =
-  | {version: 1, v1: ?HeaderPlaintextV1}
-  | {version: 2, v2: ?HeaderPlaintextUnsupported}
-  | {version: 3, v3: ?HeaderPlaintextUnsupported}
-  | {version: 4, v4: ?HeaderPlaintextUnsupported}
-  | {version: 5, v5: ?HeaderPlaintextUnsupported}
-  | {version: 6, v6: ?HeaderPlaintextUnsupported}
-  | {version: 7, v7: ?HeaderPlaintextUnsupported}
-  | {version: 8, v8: ?HeaderPlaintextUnsupported}
-  | {version: 9, v9: ?HeaderPlaintextUnsupported}
-  | {version: 10, v10: ?HeaderPlaintextUnsupported}
+    { version: 1, v1: ?HeaderPlaintextV1 }
+  | { version: 2, v2: ?HeaderPlaintextUnsupported }
+  | { version: 3, v3: ?HeaderPlaintextUnsupported }
+  | { version: 4, v4: ?HeaderPlaintextUnsupported }
+  | { version: 5, v5: ?HeaderPlaintextUnsupported }
+  | { version: 6, v6: ?HeaderPlaintextUnsupported }
+  | { version: 7, v7: ?HeaderPlaintextUnsupported }
+  | { version: 8, v8: ?HeaderPlaintextUnsupported }
+  | { version: 9, v9: ?HeaderPlaintextUnsupported }
+  | { version: 10, v10: ?HeaderPlaintextUnsupported }
 
 export type HeaderPlaintextMetaInfo = {
   crit: boolean,
@@ -2722,7 +1280,7 @@ export type HeaderPlaintextV1 = {
 }
 
 export type HeaderPlaintextVersion =
-  | 1 // V1_1
+    1 // V1_1
   | 2 // V2_2
   | 3 // V3_3
   | 4 // V4_4
@@ -2741,12 +1299,14 @@ export type Inbox = {
 }
 
 export type InboxResType =
-  | 0 // VERSIONHIT_0
+    0 // VERSIONHIT_0
   | 1 // FULL_1
 
 export type InboxVers = uint64
 
-export type InboxView = {rtype: 0} | {rtype: 1, full: ?InboxViewFull}
+export type InboxView =
+    { rtype: 0 }
+  | { rtype: 1, full: ?InboxViewFull }
 
 export type InboxViewFull = {
   vers: InboxVers,
@@ -2808,13 +1368,13 @@ export type MessageAttachmentUploaded = {
 }
 
 export type MessageBody =
-  | {messageType: 1, text: ?MessageText}
-  | {messageType: 2, attachment: ?MessageAttachment}
-  | {messageType: 3, edit: ?MessageEdit}
-  | {messageType: 4, delete: ?MessageDelete}
-  | {messageType: 5, metadata: ?MessageConversationMetadata}
-  | {messageType: 7, headline: ?MessageHeadline}
-  | {messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded}
+    { messageType: 1, text: ?MessageText }
+  | { messageType: 2, attachment: ?MessageAttachment }
+  | { messageType: 3, edit: ?MessageEdit }
+  | { messageType: 4, delete: ?MessageDelete }
+  | { messageType: 5, metadata: ?MessageConversationMetadata }
+  | { messageType: 7, headline: ?MessageHeadline }
+  | { messageType: 8, attachmentuploaded: ?MessageAttachmentUploaded }
 
 export type MessageBoxed = {
   version: MessageBoxedVersion,
@@ -2827,7 +1387,7 @@ export type MessageBoxed = {
 }
 
 export type MessageBoxedVersion =
-  | 0 // VNONE_0
+    0 // VNONE_0
   | 1 // V1_1
   | 2 // V2_2
 
@@ -2906,7 +1466,7 @@ export type MessageText = {
 }
 
 export type MessageType =
-  | 0 // NONE_0
+    0 // NONE_0
   | 1 // TEXT_1
   | 2 // ATTACHMENT_2
   | 3 // EDIT_3
@@ -2917,10 +1477,10 @@ export type MessageType =
   | 8 // ATTACHMENTUPLOADED_8
 
 export type MessageUnboxed =
-  | {state: 1, valid: ?MessageUnboxedValid}
-  | {state: 2, error: ?MessageUnboxedError}
-  | {state: 3, outbox: ?OutboxRecord}
-  | {state: 4, placeholder: ?MessageUnboxedPlaceholder}
+    { state: 1, valid: ?MessageUnboxedValid }
+  | { state: 2, error: ?MessageUnboxedError }
+  | { state: 3, outbox: ?OutboxRecord }
+  | { state: 4, placeholder: ?MessageUnboxedPlaceholder }
 
 export type MessageUnboxedError = {
   errType: MessageUnboxedErrorType,
@@ -2931,7 +1491,7 @@ export type MessageUnboxedError = {
 }
 
 export type MessageUnboxedErrorType =
-  | 0 // MISC_0
+    0 // MISC_0
   | 1 // BADVERSION_CRITICAL_1
   | 2 // BADVERSION_2
   | 3 // IDENTIFY_3
@@ -2941,7 +1501,7 @@ export type MessageUnboxedPlaceholder = {
 }
 
 export type MessageUnboxedState =
-  | 1 // VALID_1
+    1 // VALID_1
   | 2 // ERROR_2
   | 3 // OUTBOX_3
   | 4 // PLACEHOLDER_4
@@ -2997,42 +1557,42 @@ export type NonblockFetchRes = {
 }
 
 export type NotifyChatChatIdentifyUpdateRpcParam = Exact<{
-  update: keybase1.CanonicalTLFNameAndIDWithBreaks,
+  update: keybase1.CanonicalTLFNameAndIDWithBreaks
 }>
 
 export type NotifyChatChatInboxStaleRpcParam = Exact<{
-  uid: keybase1.UID,
+  uid: keybase1.UID
 }>
 
 export type NotifyChatChatTLFFinalizeRpcParam = Exact<{
   uid: keybase1.UID,
   convID: ConversationID,
   finalizeInfo: ConversationFinalizeInfo,
-  conv?: ?ConversationLocal,
+  conv?: ?ConversationLocal
 }>
 
 export type NotifyChatChatTLFResolveRpcParam = Exact<{
   uid: keybase1.UID,
   convID: ConversationID,
-  resolveInfo: ConversationResolveInfo,
+  resolveInfo: ConversationResolveInfo
 }>
 
 export type NotifyChatChatThreadsStaleRpcParam = Exact<{
   uid: keybase1.UID,
-  convIDs?: ?Array<ConversationID>,
+  convIDs?: ?Array<ConversationID>
 }>
 
 export type NotifyChatChatTypingUpdateRpcParam = Exact<{
-  typingUpdates?: ?Array<ConvTypingUpdate>,
+  typingUpdates?: ?Array<ConvTypingUpdate>
 }>
 
 export type NotifyChatNewChatActivityRpcParam = Exact<{
   uid: keybase1.UID,
-  activity: ChatActivity,
+  activity: ChatActivity
 }>
 
 export type OutboxErrorType =
-  | 0 // MISC_0
+    0 // MISC_0
   | 1 // OFFLINE_1
   | 2 // IDENTIFY_2
   | 3 // TOOLONG_3
@@ -3053,7 +1613,9 @@ export type OutboxRecord = {
   identifyBehavior: keybase1.TLFIdentifyBehavior,
 }
 
-export type OutboxState = {state: 0, sending: ?int} | {state: 1, error: ?OutboxStateError}
+export type OutboxState =
+    { state: 0, sending: ?int }
+  | { state: 1, error: ?OutboxStateError }
 
 export type OutboxStateError = {
   message: string,
@@ -3061,7 +1623,7 @@ export type OutboxStateError = {
 }
 
 export type OutboxStateType =
-  | 0 // SENDING_0
+    0 // SENDING_0
   | 1 // ERROR_1
 
 export type Pagination = {
@@ -3173,11 +1735,11 @@ export type SignatureInfo = {
 }
 
 export type SyncAllNotificationRes =
-  | {typ: 0, state: ?gregor1.State}
-  | {typ: 1, incremental: ?gregor1.SyncResult}
+    { typ: 0, state: ?gregor1.State }
+  | { typ: 1, incremental: ?gregor1.SyncResult }
 
 export type SyncAllNotificationType =
-  | 0 // STATE_0
+    0 // STATE_0
   | 1 // INCREMENTAL_1
 
 export type SyncAllResult = {
@@ -3192,10 +1754,13 @@ export type SyncChatRes = {
   inboxRes: SyncInboxRes,
 }
 
-export type SyncInboxRes = {typ: 0} | {typ: 1, incremental: ?SyncIncrementalRes} | {typ: 2}
+export type SyncInboxRes =
+    { typ: 0 }
+  | { typ: 1, incremental: ?SyncIncrementalRes }
+  | { typ: 2 }
 
 export type SyncInboxResType =
-  | 0 // CURRENT_0
+    0 // CURRENT_0
   | 1 // INCREMENTAL_1
   | 2 // CLEAR_2
 
@@ -3218,7 +1783,7 @@ export type TLFResolveUpdate = {
 }
 
 export type TLFVisibility =
-  | 0 // ANY_0
+    0 // ANY_0
   | 1 // PUBLIC_1
   | 2 // PRIVATE_2
 
@@ -3237,7 +1802,7 @@ export type ThreadViewBoxed = {
 export type TopicID = bytes
 
 export type TopicType =
-  | 0 // NONE_0
+    0 // NONE_0
   | 1 // CHAT_1
   | 2 // DEV_2
 
@@ -3268,50 +1833,50 @@ export type UnreadUpdateFull = {
 
 export type chatUiChatAttachmentDownloadProgressRpcParam = Exact<{
   bytesComplete: long,
-  bytesTotal: long,
+  bytesTotal: long
 }>
 
 export type chatUiChatAttachmentPreviewUploadStartRpcParam = Exact<{
-  metadata: AssetMetadata,
+  metadata: AssetMetadata
 }>
 
 export type chatUiChatAttachmentUploadOutboxIDRpcParam = Exact<{
-  outboxID: OutboxID,
+  outboxID: OutboxID
 }>
 
 export type chatUiChatAttachmentUploadProgressRpcParam = Exact<{
   bytesComplete: long,
-  bytesTotal: long,
+  bytesTotal: long
 }>
 
 export type chatUiChatAttachmentUploadStartRpcParam = Exact<{
   metadata: AssetMetadata,
-  placeholderMsgID: MessageID,
+  placeholderMsgID: MessageID
 }>
 
 export type chatUiChatInboxConversationRpcParam = Exact<{
-  conv: ConversationLocal,
+  conv: ConversationLocal
 }>
 
 export type chatUiChatInboxFailedRpcParam = Exact<{
   convID: ConversationID,
-  error: ConversationErrorLocal,
+  error: ConversationErrorLocal
 }>
 
 export type chatUiChatInboxUnverifiedRpcParam = Exact<{
-  inbox: GetInboxLocalRes,
+  inbox: GetInboxLocalRes
 }>
 
 export type chatUiChatThreadCachedRpcParam = Exact<{
-  thread?: ?ThreadView,
+  thread?: ?ThreadView
 }>
 
 export type chatUiChatThreadFullRpcParam = Exact<{
-  thread: ThreadView,
+  thread: ThreadView
 }>
 
 export type localCancelPostRpcParam = Exact<{
-  outboxID: OutboxID,
+  outboxID: OutboxID
 }>
 
 export type localDownloadAttachmentLocalRpcParam = Exact<{
@@ -3319,7 +1884,7 @@ export type localDownloadAttachmentLocalRpcParam = Exact<{
   messageID: MessageID,
   sink: keybase1.Stream,
   preview: boolean,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localDownloadFileAttachmentLocalRpcParam = Exact<{
@@ -3327,7 +1892,7 @@ export type localDownloadFileAttachmentLocalRpcParam = Exact<{
   messageID: MessageID,
   filename: string,
   preview: boolean,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localFindConversationsLocalRpcParam = Exact<{
@@ -3335,67 +1900,67 @@ export type localFindConversationsLocalRpcParam = Exact<{
   visibility: TLFVisibility,
   topicType: TopicType,
   topicName: string,
-  oneChatPerTLF?: ?boolean,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  oneChatPerTLF?: ?bool,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetCachedThreadRpcParam = Exact<{
   conversationID: ConversationID,
   query?: ?GetThreadQuery,
   pagination?: ?Pagination,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetConversationForCLILocalRpcParam = Exact<{
-  query: GetConversationForCLILocalQuery,
+  query: GetConversationForCLILocalQuery
 }>
 
 export type localGetInboxAndUnboxLocalRpcParam = Exact<{
   query?: ?GetInboxLocalQuery,
   pagination?: ?Pagination,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetInboxNonblockLocalRpcParam = Exact<{
   maxUnbox?: ?int,
   query?: ?GetInboxLocalQuery,
   pagination?: ?Pagination,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetInboxSummaryForCLILocalRpcParam = Exact<{
-  query: GetInboxSummaryForCLILocalQuery,
+  query: GetInboxSummaryForCLILocalQuery
 }>
 
 export type localGetMessagesLocalRpcParam = Exact<{
   conversationID: ConversationID,
   messageIDs?: ?Array<MessageID>,
   disableResolveSupersedes: boolean,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetThreadLocalRpcParam = Exact<{
   conversationID: ConversationID,
   query?: ?GetThreadQuery,
   pagination?: ?Pagination,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localGetThreadNonblockRpcParam = Exact<{
   conversationID: ConversationID,
   query?: ?GetThreadQuery,
   pagination?: ?Pagination,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localMakePreviewRpcParam = Exact<{
   attachment: LocalFileSource,
-  outputDir: string,
+  outputDir: string
 }>
 
 export type localMarkAsReadLocalRpcParam = Exact<{
   conversationID: ConversationID,
-  msgID: MessageID,
+  msgID: MessageID
 }>
 
 export type localNewConversationLocalRpcParam = Exact<{
@@ -3403,7 +1968,7 @@ export type localNewConversationLocalRpcParam = Exact<{
   topicType: TopicType,
   tlfVisibility: TLFVisibility,
   topicName?: ?string,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localPostAttachmentLocalRpcParam = Exact<{
@@ -3413,7 +1978,7 @@ export type localPostAttachmentLocalRpcParam = Exact<{
   preview?: ?MakePreviewRes,
   title: string,
   metadata: bytes,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localPostDeleteNonblockRpcParam = Exact<{
@@ -3423,7 +1988,7 @@ export type localPostDeleteNonblockRpcParam = Exact<{
   tlfPublic: boolean,
   supersedes: MessageID,
   clientPrev: MessageID,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localPostEditNonblockRpcParam = Exact<{
@@ -3434,7 +1999,7 @@ export type localPostEditNonblockRpcParam = Exact<{
   supersedes: MessageID,
   body: string,
   clientPrev: MessageID,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localPostFileAttachmentLocalRpcParam = Exact<{
@@ -3444,20 +2009,20 @@ export type localPostFileAttachmentLocalRpcParam = Exact<{
   preview?: ?MakePreviewRes,
   title: string,
   metadata: bytes,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localPostLocalNonblockRpcParam = Exact<{
   conversationID: ConversationID,
   msg: MessagePlaintext,
   clientPrev: MessageID,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localPostLocalRpcParam = Exact<{
   conversationID: ConversationID,
   msg: MessagePlaintext,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localPostTextNonblockRpcParam = Exact<{
@@ -3467,98 +2032,98 @@ export type localPostTextNonblockRpcParam = Exact<{
   tlfPublic: boolean,
   body: string,
   clientPrev: MessageID,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localRetryPostRpcParam = Exact<{
-  outboxID: OutboxID,
+  outboxID: OutboxID
 }>
 
 export type localSetConversationStatusLocalRpcParam = Exact<{
   conversationID: ConversationID,
   status: ConversationStatus,
-  identifyBehavior: keybase1.TLFIdentifyBehavior,
+  identifyBehavior: keybase1.TLFIdentifyBehavior
 }>
 
 export type localUpdateTypingRpcParam = Exact<{
   conversationID: ConversationID,
-  typing: boolean,
+  typing: boolean
 }>
 
 export type remoteGetInboxRemoteRpcParam = Exact<{
   vers: InboxVers,
   query?: ?GetInboxQuery,
-  pagination?: ?Pagination,
+  pagination?: ?Pagination
 }>
 
 export type remoteGetInboxVersionRpcParam = Exact<{
-  uid: gregor1.UID,
+  uid: gregor1.UID
 }>
 
 export type remoteGetMessagesRemoteRpcParam = Exact<{
   conversationID: ConversationID,
-  messageIDs?: ?Array<MessageID>,
+  messageIDs?: ?Array<MessageID>
 }>
 
 export type remoteGetPublicConversationsRpcParam = Exact<{
   tlfID: TLFID,
   topicType: TopicType,
-  summarizeMaxMsgs: boolean,
+  summarizeMaxMsgs: boolean
 }>
 
 export type remoteGetS3ParamsRpcParam = Exact<{
-  conversationID: ConversationID,
+  conversationID: ConversationID
 }>
 
 export type remoteGetThreadRemoteRpcParam = Exact<{
   conversationID: ConversationID,
   query?: ?GetThreadQuery,
-  pagination?: ?Pagination,
+  pagination?: ?Pagination
 }>
 
 export type remoteGetUnreadUpdateFullRpcParam = Exact<{
-  inboxVers: InboxVers,
+  inboxVers: InboxVers
 }>
 
 export type remoteMarkAsReadRpcParam = Exact<{
   conversationID: ConversationID,
-  msgID: MessageID,
+  msgID: MessageID
 }>
 
 export type remoteNewConversationRemote2RpcParam = Exact<{
   idTriple: ConversationIDTriple,
-  TLFMessage: MessageBoxed,
+  TLFMessage: MessageBoxed
 }>
 
 export type remoteNewConversationRemoteRpcParam = Exact<{
-  idTriple: ConversationIDTriple,
+  idTriple: ConversationIDTriple
 }>
 
 export type remotePostRemoteRpcParam = Exact<{
   conversationID: ConversationID,
-  messageBoxed: MessageBoxed,
+  messageBoxed: MessageBoxed
 }>
 
 export type remotePublishReadMessageRpcParam = Exact<{
   uid: gregor1.UID,
   convID: ConversationID,
-  msgID: MessageID,
+  msgID: MessageID
 }>
 
 export type remotePublishSetConversationStatusRpcParam = Exact<{
   uid: gregor1.UID,
   convID: ConversationID,
-  status: ConversationStatus,
+  status: ConversationStatus
 }>
 
 export type remoteS3SignRpcParam = Exact<{
   version: int,
-  payload: bytes,
+  payload: bytes
 }>
 
 export type remoteSetConversationStatusRpcParam = Exact<{
   conversationID: ConversationID,
-  status: ConversationStatus,
+  status: ConversationStatus
 }>
 
 export type remoteSyncAllRpcParam = Exact<{
@@ -3567,15 +2132,15 @@ export type remoteSyncAllRpcParam = Exact<{
   session: gregor1.SessionToken,
   inboxVers: InboxVers,
   ctime: gregor1.Time,
-  fresh: boolean,
+  fresh: boolean
 }>
 
 export type remoteSyncChatRpcParam = Exact<{
-  vers: InboxVers,
+  vers: InboxVers
 }>
 
 export type remoteSyncInboxRpcParam = Exact<{
-  vers: InboxVers,
+  vers: InboxVers
 }>
 
 export type remoteTlfFinalizeRpcParam = Exact<{
@@ -3583,20 +2148,20 @@ export type remoteTlfFinalizeRpcParam = Exact<{
   resetUser: string,
   resetDate: string,
   resetTimestamp: gregor1.Time,
-  resetFull: string,
+  resetFull: string
 }>
 
 export type remoteTlfResolveRpcParam = Exact<{
   tlfID: TLFID,
   resolvedWriters?: ?Array<gregor1.UID>,
-  resolvedReaders?: ?Array<gregor1.UID>,
+  resolvedReaders?: ?Array<gregor1.UID>
 }>
 
 export type remoteUpdateTypingRemoteRpcParam = Exact<{
   uid: gregor1.UID,
   deviceID: gregor1.DeviceID,
   convID: ConversationID,
-  typing: boolean,
+  typing: boolean
 }>
 type localDownloadAttachmentLocalResult = DownloadAttachmentLocalRes
 type localDownloadFileAttachmentLocalResult = DownloadAttachmentLocalRes
@@ -3638,7 +2203,7 @@ type remoteSyncChatResult = SyncChatRes
 type remoteSyncInboxResult = SyncInboxRes
 
 export type rpc =
-  | localCancelPostRpc
+    localCancelPostRpc
   | localDownloadAttachmentLocalRpc
   | localDownloadFileAttachmentLocalRpc
   | localFindConversationsLocalRpc
@@ -3689,7 +2254,7 @@ export type incomingCallMapType = Exact<{
   'keybase.1.chatUi.chatAttachmentUploadOutboxID'?: (
     params: Exact<{
       sessionID: int,
-      outboxID: OutboxID,
+      outboxID: OutboxID
     }>,
     response: CommonResponseHandler
   ) => void,
@@ -3697,7 +2262,7 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       sessionID: int,
       metadata: AssetMetadata,
-      placeholderMsgID: MessageID,
+      placeholderMsgID: MessageID
     }>,
     response: CommonResponseHandler
   ) => void,
@@ -3705,32 +2270,32 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       sessionID: int,
       bytesComplete: long,
-      bytesTotal: long,
+      bytesTotal: long
     }>,
     response: CommonResponseHandler
   ) => void,
   'keybase.1.chatUi.chatAttachmentUploadDone'?: (
     params: Exact<{
-      sessionID: int,
+      sessionID: int
     }>,
     response: CommonResponseHandler
   ) => void,
   'keybase.1.chatUi.chatAttachmentPreviewUploadStart'?: (
     params: Exact<{
       sessionID: int,
-      metadata: AssetMetadata,
+      metadata: AssetMetadata
     }>,
     response: CommonResponseHandler
   ) => void,
   'keybase.1.chatUi.chatAttachmentPreviewUploadDone'?: (
     params: Exact<{
-      sessionID: int,
+      sessionID: int
     }>,
     response: CommonResponseHandler
   ) => void,
   'keybase.1.chatUi.chatAttachmentDownloadStart'?: (
     params: Exact<{
-      sessionID: int,
+      sessionID: int
     }>,
     response: CommonResponseHandler
   ) => void,
@@ -3738,27 +2303,27 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       sessionID: int,
       bytesComplete: long,
-      bytesTotal: long,
+      bytesTotal: long
     }>,
     response: CommonResponseHandler
   ) => void,
   'keybase.1.chatUi.chatAttachmentDownloadDone'?: (
     params: Exact<{
-      sessionID: int,
+      sessionID: int
     }>,
     response: CommonResponseHandler
   ) => void,
   'keybase.1.chatUi.chatInboxUnverified'?: (
     params: Exact<{
       sessionID: int,
-      inbox: GetInboxLocalRes,
+      inbox: GetInboxLocalRes
     }>,
     response: CommonResponseHandler
   ) => void,
   'keybase.1.chatUi.chatInboxConversation'?: (
     params: Exact<{
       sessionID: int,
-      conv: ConversationLocal,
+      conv: ConversationLocal
     }>,
     response: CommonResponseHandler
   ) => void,
@@ -3766,35 +2331,35 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       sessionID: int,
       convID: ConversationID,
-      error: ConversationErrorLocal,
+      error: ConversationErrorLocal
     }>,
     response: CommonResponseHandler
   ) => void,
   'keybase.1.chatUi.chatThreadCached'?: (
     params: Exact<{
       sessionID: int,
-      thread?: ?ThreadView,
+      thread?: ?ThreadView
     }>,
     response: CommonResponseHandler
   ) => void,
   'keybase.1.chatUi.chatThreadFull'?: (
     params: Exact<{
       sessionID: int,
-      thread: ThreadView,
+      thread: ThreadView
     }>,
     response: CommonResponseHandler
   ) => void,
   'keybase.1.NotifyChat.NewChatActivity'?: (
     params: Exact<{
       uid: keybase1.UID,
-      activity: ChatActivity,
+      activity: ChatActivity
     }> /* ,
     response: {} // Notify call
     */
   ) => void,
   'keybase.1.NotifyChat.ChatIdentifyUpdate'?: (
     params: Exact<{
-      update: keybase1.CanonicalTLFNameAndIDWithBreaks,
+      update: keybase1.CanonicalTLFNameAndIDWithBreaks
     }> /* ,
     response: {} // Notify call
     */
@@ -3804,7 +2369,7 @@ export type incomingCallMapType = Exact<{
       uid: keybase1.UID,
       convID: ConversationID,
       finalizeInfo: ConversationFinalizeInfo,
-      conv?: ?ConversationLocal,
+      conv?: ?ConversationLocal
     }> /* ,
     response: {} // Notify call
     */
@@ -3813,14 +2378,14 @@ export type incomingCallMapType = Exact<{
     params: Exact<{
       uid: keybase1.UID,
       convID: ConversationID,
-      resolveInfo: ConversationResolveInfo,
+      resolveInfo: ConversationResolveInfo
     }> /* ,
     response: {} // Notify call
     */
   ) => void,
   'keybase.1.NotifyChat.ChatInboxStale'?: (
     params: Exact<{
-      uid: keybase1.UID,
+      uid: keybase1.UID
     }> /* ,
     response: {} // Notify call
     */
@@ -3828,16 +2393,16 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatThreadsStale'?: (
     params: Exact<{
       uid: keybase1.UID,
-      convIDs?: ?Array<ConversationID>,
+      convIDs?: ?Array<ConversationID>
     }> /* ,
     response: {} // Notify call
     */
   ) => void,
   'keybase.1.NotifyChat.ChatTypingUpdate'?: (
     params: Exact<{
-      typingUpdates?: ?Array<ConvTypingUpdate>,
+      typingUpdates?: ?Array<ConvTypingUpdate>
     }> /* ,
     response: {} // Notify call
     */
-  ) => void,
+  ) => void
 }>

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -97,6 +97,14 @@ export const CommonMerkleTreeID = {
   kbfsPrivate: 2,
 }
 
+export const CommonTeamRole = {
+  none: 0,
+  owner: 1,
+  admin: 2,
+  writer: 3,
+  reader: 4,
+}
+
 export const ConfigForkType = {
   none: 0,
   auto: 1,
@@ -4784,6 +4792,13 @@ export type PathType =
     0 // LOCAL_0
   | 1 // KBFS_1
 
+export type PerTeamKey = {
+  gen: int,
+  seqno: int,
+  sigKID: KID,
+  encKID: KID,
+}
+
 export type PerUserKey = {
   gen: int,
   seqno: int,
@@ -5455,6 +5470,13 @@ export type TLFQuery = {
 }
 
 export type TeamID = string
+
+export type TeamRole =
+    0 // NONE_0
+  | 1 // OWNER_1
+  | 2 // ADMIN_2
+  | 3 // WRITER_3
+  | 4 // READER_4
 
 export type Test = {
   reply: string,


### PR DESCRIPTION
@maxtaco @oconnor663 

`TeamSigChainPlayer` can be fed chain links and will keep track of a `TeamSigChainState`. `TeamSigChainState` is immutable (except inside the player) and totally serializable so it should be easy to cache.

This is very rough, lots of todos. Hopefully it's enough of an interface to unblock some parallel work on e.g. loading from the server, caching, and doing the todos.

cc @patrickxb wanted to follow this