### PR TITLE
retry server inbox request on failure CORE-5122

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -249,7 +249,7 @@ func (b *baseInboxSource) SetTLFInfoSource(tlfInfoSource types.TLFInfoSource) {
 	b.tlfInfoSource = tlfInfoSource
 }
 
-func (b *baseInboxSource) getInboxQueryLocalToRemote(ctx context.Context,
+func (b *baseInboxSource) GetInboxQueryLocalToRemote(ctx context.Context,
 	lquery *chat1.GetInboxLocalQuery) (rquery *chat1.GetInboxQuery, info *types.TLFInfo, err error) {
 
 	if lquery == nil {
@@ -264,7 +264,7 @@ func (b *baseInboxSource) getInboxQueryLocalToRemote(ctx context.Context,
 			return nil, nil, err
 		}
 		rquery.TlfID = &info.ID
-		b.Debug(ctx, "getInboxQueryLocalToRemote: mapped TLF %q to TLFID %v", *lquery.TlfName, info.ID)
+		b.Debug(ctx, "GetInboxQueryLocalToRemote: mapped TLF %q to TLFID %v", *lquery.TlfName, info.ID)
 	}
 
 	rquery.After = lquery.After
@@ -319,7 +319,7 @@ func (s *RemoteInboxSource) Read(ctx context.Context, uid gregor1.UID,
 	}
 	s.Debug(ctx, "Read: using localizer: %s", localizer.Name())
 
-	rquery, tlfInfo, err := s.getInboxQueryLocalToRemote(ctx, query)
+	rquery, tlfInfo, err := s.GetInboxQueryLocalToRemote(ctx, query)
 	if err != nil {
 		return chat1.Inbox{}, nil, err
 	}
@@ -467,7 +467,7 @@ func (s *HybridInboxSource) Read(ctx context.Context, uid gregor1.UID,
 	s.Debug(ctx, "Read: using localizer: %s", localizer.Name())
 
 	// Read unverified inbox
-	rquery, tlfInfo, err := s.getInboxQueryLocalToRemote(ctx, query)
+	rquery, tlfInfo, err := s.GetInboxQueryLocalToRemote(ctx, query)
 	if err != nil {
 		return inbox, rl, err
 	}

--- a/go/chat/retry_test.go
+++ b/go/chat/retry_test.go
@@ -58,7 +58,8 @@ func TestFetchRetry(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, inbox.Convs[2].Error)
 	require.Nil(t, inbox.Convs[0].Error)
-	tc.ChatG.FetchRetrier.Failure(context.TODO(), inbox.Convs[2].GetConvID(), uid, types.ThreadLoad)
+	tc.ChatG.FetchRetrier.Failure(context.TODO(), uid,
+		NewConversationRetry(tc.Context(), inbox.Convs[2].GetConvID(), types.ThreadLoad))
 
 	// Advance clock and check for errors on all conversations
 	t.Logf("advancing clock and checking for stale")
@@ -78,7 +79,8 @@ func TestFetchRetry(t *testing.T) {
 	}
 
 	t.Logf("trying to use Force")
-	tc.ChatG.FetchRetrier.Failure(context.TODO(), inbox.Convs[2].GetConvID(), uid, types.ThreadLoad)
+	tc.ChatG.FetchRetrier.Failure(context.TODO(), uid,
+		NewConversationRetry(tc.Context(), inbox.Convs[2].GetConvID(), types.ThreadLoad))
 	tc.ChatG.FetchRetrier.Force(context.TODO())
 	select {
 	case cids := <-list.threadsStale:

--- a/go/chat/retry_test.go
+++ b/go/chat/retry_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/storage"
-	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/stretchr/testify/require"
@@ -59,7 +58,7 @@ func TestFetchRetry(t *testing.T) {
 	require.NotNil(t, inbox.Convs[2].Error)
 	require.Nil(t, inbox.Convs[0].Error)
 	tc.ChatG.FetchRetrier.Failure(context.TODO(), uid,
-		NewConversationRetry(tc.Context(), inbox.Convs[2].GetConvID(), types.ThreadLoad))
+		NewConversationRetry(tc.Context(), inbox.Convs[2].GetConvID(), ThreadLoad))
 
 	// Advance clock and check for errors on all conversations
 	t.Logf("advancing clock and checking for stale")
@@ -80,7 +79,7 @@ func TestFetchRetry(t *testing.T) {
 
 	t.Logf("trying to use Force")
 	tc.ChatG.FetchRetrier.Failure(context.TODO(), uid,
-		NewConversationRetry(tc.Context(), inbox.Convs[2].GetConvID(), types.ThreadLoad))
+		NewConversationRetry(tc.Context(), inbox.Convs[2].GetConvID(), ThreadLoad))
 	tc.ChatG.FetchRetrier.Force(context.TODO())
 	select {
 	case cids := <-list.threadsStale:

--- a/go/chat/retry_test.go
+++ b/go/chat/retry_test.go
@@ -89,4 +89,17 @@ func TestFetchRetry(t *testing.T) {
 		require.Fail(t, "timeout on inbox stale")
 	}
 
+	t.Logf("testing full inbox retry")
+	ttype := chat1.TopicType_CHAT
+	tc.Context().FetchRetrier.Failure(context.TODO(), uid,
+		NewFullInboxRetry(tc.Context(), &chat1.GetInboxLocalQuery{
+			TopicType: &ttype,
+		}, &chat1.Pagination{Num: 10}))
+	tc.Context().FetchRetrier.Force(context.TODO())
+	select {
+	case <-list.inboxStale:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no inbox full stale received")
+	}
+
 }

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -147,7 +147,7 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 	_, rl, err := h.G().InboxSource.Read(ctx, uid.ToBytes(), localizer, true, arg.Query, arg.Pagination)
 	if err != nil {
 		// If this is a convID based query, let's go ahead and drop those onto the retrier
-		if arg.Query != nil {
+		if arg.Query != nil && len(arg.Query.ConvIDs) > 0 {
 			h.Debug(ctx, "GetInboxNonblockLocal: failed to get unverified inbox, marking convIDs as failed")
 			for _, convID := range arg.Query.ConvIDs {
 				h.G().FetchRetrier.Failure(ctx, uid.ToBytes(),

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -150,8 +150,13 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 		if arg.Query != nil {
 			h.Debug(ctx, "GetInboxNonblockLocal: failed to get unverified inbox, marking convIDs as failed")
 			for _, convID := range arg.Query.ConvIDs {
-				h.G().FetchRetrier.Failure(ctx, convID, uid.ToBytes(), types.InboxLoad)
+				h.G().FetchRetrier.Failure(ctx, uid.ToBytes(),
+					NewConversationRetry(h.G(), convID, types.InboxLoad))
 			}
+		} else {
+			h.Debug(ctx, "GetInboxNonblockLocal: failed to load untrusted inbox, general query")
+			h.G().FetchRetrier.Failure(ctx, uid.ToBytes(),
+				NewFullInboxRetry(h.G(), arg.Query, arg.Pagination))
 		}
 		return res, err
 	}
@@ -196,7 +201,8 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 
 				// If we get a transient failure, add this to the retrier queue
 				if convRes.Err.Typ == chat1.ConversationErrorType_TRANSIENT {
-					h.G().FetchRetrier.Failure(ctx, convRes.ConvID, uid.ToBytes(), types.InboxLoad)
+					h.G().FetchRetrier.Failure(ctx, uid.ToBytes(),
+						NewConversationRetry(h.G(), convRes.ConvID, types.InboxLoad))
 				}
 			} else if convRes.ConvRes != nil {
 				h.Debug(ctx, "GetInboxNonblockLocal: verified conv: id: %s tlf: %s",
@@ -207,7 +213,8 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 				})
 
 				// Send a note to the retrier that we actually loaded this guy successfully
-				h.G().FetchRetrier.Success(ctx, convRes.ConvID, uid.ToBytes(), types.InboxLoad)
+				h.G().FetchRetrier.Success(ctx, uid.ToBytes(),
+					NewConversationRetry(h.G(), convRes.ConvID, types.InboxLoad))
 			}
 			wg.Done()
 		}(convRes)
@@ -339,9 +346,11 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 		// Detect any problem loading the thread, and queue it up in the retrier if there is a problem.
 		// Otherwise, send notice that we successfully loaded the conversation.
 		if res.Offline || fullErr != nil {
-			h.G().FetchRetrier.Failure(ctx, arg.ConversationID, uid.ToBytes(), types.ThreadLoad)
+			h.G().FetchRetrier.Failure(ctx, uid.ToBytes(),
+				NewConversationRetry(h.G(), arg.ConversationID, types.ThreadLoad))
 		} else {
-			h.G().FetchRetrier.Success(ctx, arg.ConversationID, uid.ToBytes(), types.ThreadLoad)
+			h.G().FetchRetrier.Success(ctx, uid.ToBytes(),
+				NewConversationRetry(h.G(), arg.ConversationID, types.ThreadLoad))
 		}
 	}()
 	if err := h.assertLoggedIn(ctx); err != nil {

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -151,7 +151,7 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 			h.Debug(ctx, "GetInboxNonblockLocal: failed to get unverified inbox, marking convIDs as failed")
 			for _, convID := range arg.Query.ConvIDs {
 				h.G().FetchRetrier.Failure(ctx, uid.ToBytes(),
-					NewConversationRetry(h.G(), convID, types.InboxLoad))
+					NewConversationRetry(h.G(), convID, InboxLoad))
 			}
 		} else {
 			h.Debug(ctx, "GetInboxNonblockLocal: failed to load untrusted inbox, general query")
@@ -202,7 +202,7 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 				// If we get a transient failure, add this to the retrier queue
 				if convRes.Err.Typ == chat1.ConversationErrorType_TRANSIENT {
 					h.G().FetchRetrier.Failure(ctx, uid.ToBytes(),
-						NewConversationRetry(h.G(), convRes.ConvID, types.InboxLoad))
+						NewConversationRetry(h.G(), convRes.ConvID, InboxLoad))
 				}
 			} else if convRes.ConvRes != nil {
 				h.Debug(ctx, "GetInboxNonblockLocal: verified conv: id: %s tlf: %s",
@@ -214,7 +214,7 @@ func (h *Server) GetInboxNonblockLocal(ctx context.Context, arg chat1.GetInboxNo
 
 				// Send a note to the retrier that we actually loaded this guy successfully
 				h.G().FetchRetrier.Success(ctx, uid.ToBytes(),
-					NewConversationRetry(h.G(), convRes.ConvID, types.InboxLoad))
+					NewConversationRetry(h.G(), convRes.ConvID, InboxLoad))
 			}
 			wg.Done()
 		}(convRes)
@@ -347,10 +347,10 @@ func (h *Server) GetThreadNonblock(ctx context.Context, arg chat1.GetThreadNonbl
 		// Otherwise, send notice that we successfully loaded the conversation.
 		if res.Offline || fullErr != nil {
 			h.G().FetchRetrier.Failure(ctx, uid.ToBytes(),
-				NewConversationRetry(h.G(), arg.ConversationID, types.ThreadLoad))
+				NewConversationRetry(h.G(), arg.ConversationID, ThreadLoad))
 		} else {
 			h.G().FetchRetrier.Success(ctx, uid.ToBytes(),
-				NewConversationRetry(h.G(), arg.ConversationID, types.ThreadLoad))
+				NewConversationRetry(h.G(), arg.ConversationID, ThreadLoad))
 		}
 	}()
 	if err := h.assertLoggedIn(ctx); err != nil {

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -906,6 +906,7 @@ func TestChatGap(t *testing.T) {
 type serverChatListener struct {
 	newMessage   chan chat1.MessageUnboxed
 	threadsStale chan []chat1.ConversationID
+	inboxStale   chan struct{}
 }
 
 func (n *serverChatListener) Logout()                                                             {}
@@ -929,7 +930,9 @@ func (n *serverChatListener) ChatTLFFinalize(uid keybase1.UID, convID chat1.Conv
 }
 func (n *serverChatListener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationResolveInfo) {
 }
-func (n *serverChatListener) ChatInboxStale(uid keybase1.UID) {}
+func (n *serverChatListener) ChatInboxStale(uid keybase1.UID) {
+	n.inboxStale <- struct{}{}
+}
 func (n *serverChatListener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {
 	n.threadsStale <- cids
 }
@@ -946,6 +949,7 @@ func newServerChatListener() *serverChatListener {
 	return &serverChatListener{
 		newMessage:   make(chan chat1.MessageUnboxed, 100),
 		threadsStale: make(chan []chat1.ConversationID, 100),
+		inboxStale:   make(chan struct{}, 100),
 	}
 }
 
@@ -1278,7 +1282,7 @@ func TestGetInboxNonblockError(t *testing.T) {
 		mustPostLocalForTest(t, ctc, users[0], conv, msg)
 	}
 	require.NoError(t, ctc.world.Tcs[users[0].Username].ChatG.ConvSource.Clear(conv.Id, uid))
-	g := ctc.world.Tcs[users[0].Username].ChatG
+	g := ctc.world.Tcs[users[0].Username].Context()
 	g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
 		return chat1.RemoteClient{Cli: errorClient{}}
 	})
@@ -1318,6 +1322,46 @@ func TestGetInboxNonblockError(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no threads stale message received")
 	}
+
+	t.Logf("testing untrusted inbox load failure")
+	ttype := chat1.TopicType_CHAT
+	require.NoError(t, storage.NewInbox(g, uid).Clear(context.TODO()))
+	g.InboxSource.SetRemoteInterface(func() chat1.RemoteInterface {
+		return chat1.RemoteClient{Cli: errorClient{}}
+	})
+	query := &chat1.GetInboxLocalQuery{
+		TopicType: &ttype,
+	}
+	p := &chat1.Pagination{Num: 10}
+	_, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxNonblockLocal(context.TODO(),
+		chat1.GetInboxNonblockLocalArg{
+			Query:            query,
+			Pagination:       p,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		})
+	require.Error(t, err)
+	g.InboxSource.SetRemoteInterface(func() chat1.RemoteInterface {
+		return kbtest.NewChatRemoteMock(ctc.world)
+	})
+	ctc.world.Fc.Advance(time.Hour)
+	select {
+	case <-listener.inboxStale:
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no threads stale message received")
+	}
+	select {
+	case cids := <-listener.threadsStale:
+		require.Zero(t, len(cids))
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "no thread stale msg")
+	}
+
+	rquery, _, err := g.InboxSource.GetInboxQueryLocalToRemote(context.TODO(), query)
+	require.NoError(t, err)
+	_, lconvs, _, err := storage.NewInbox(g, uid).Read(context.TODO(), rquery, p)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(lconvs))
+	require.Equal(t, lconvs[0].GetConvID(), conv.Id)
 }
 
 func TestMakePreview(t *testing.T) {

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -109,7 +109,6 @@ type Syncer interface {
 type RetryDescription interface {
 	Fix(ctx context.Context, uid gregor1.UID) error
 	SendStale(ctx context.Context, uid gregor1.UID)
-	GetKind() FetchType
 	String() string
 }
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -79,6 +79,9 @@ type InboxSource interface {
 	TlfFinalize(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 		convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) ([]chat1.ConversationLocal, error)
 
+	GetInboxQueryLocalToRemote(ctx context.Context,
+		lquery *chat1.GetInboxLocalQuery) (*chat1.GetInboxQuery, *TLFInfo, error)
+
 	SetRemoteInterface(func() chat1.RemoteInterface)
 	SetTLFInfoSource(tlfInfoSource TLFInfoSource)
 }
@@ -103,12 +106,19 @@ type Syncer interface {
 	Shutdown()
 }
 
+type RetryDescription interface {
+	Fix(ctx context.Context, uid gregor1.UID) error
+	SendStale(ctx context.Context, uid gregor1.UID)
+	GetKind() FetchType
+	String() string
+}
+
 type FetchRetrier interface {
 	Offlinable
 	Resumable
 
-	Failure(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, kind FetchType) error
-	Success(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, kind FetchType) error
+	Failure(ctx context.Context, uid gregor1.UID, desc RetryDescription) error
+	Success(ctx context.Context, uid gregor1.UID, desc RetryDescription) error
 	Force(ctx context.Context)
 }
 

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -5,14 +5,6 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-type FetchType int
-
-const (
-	InboxLoad FetchType = iota
-	ThreadLoad
-	FullInboxLoad
-)
-
 type TLFInfo struct {
 	ID               chat1.TLFID
 	CanonicalName    string

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -10,6 +10,7 @@ type FetchType int
 const (
 	InboxLoad FetchType = iota
 	ThreadLoad
+	FullInboxLoad
 )
 
 type TLFInfo struct {


### PR DESCRIPTION
Patch does the following:

1.) Adds ability to retry server inbox load failures.
2.) Generalize `FetchRetrier` so it isn't as tightly coupled to per conversation failures. 
3.) Add code in `GetInboxNonblockLocal` to spawn a full inbox retry for inbox queries that do not query specific conversation IDs.