### PR TITLE
add a per conversation lock to ConvSource to reduce contention CORE-5246

### DIFF
--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -62,6 +62,16 @@ func CtxIdentifyNotifier(ctx context.Context) *IdentifyNotifier {
 	return nil
 }
 
+func CtxTrace(ctx context.Context) (string, bool) {
+	var trace string
+	var ok bool
+	val := ctx.Value(chatTraceKey)
+	if trace, ok = val.(string); ok {
+		return trace, true
+	}
+	return "", false
+}
+
 func CtxAddLogTags(ctx context.Context, env appTypeSource) context.Context {
 
 	// Add trace context value

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -254,7 +254,7 @@ func (c *conversationLockTab) Acquire(ctx context.Context, uid gregor1.UID, conv
 	key := c.key(uid, convID)
 	if lock, ok := c.convLocks[key]; ok {
 		if lock.trace == trace {
-			// Our request holds the lock on this conversation ID already, do just plow through it
+			// Our request holds the lock on this conversation ID already, so just plow through it
 			lock.count++
 			return cb
 		}

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -236,6 +236,9 @@ func (c *conversationLockTab) key(uid gregor1.UID, convID chat1.ConversationID) 
 	return fmt.Sprintf("%s:%s", uid, convID)
 }
 
+// Acquire obtains a per user per conversation lock on a per trace basis. That is, the lock is a
+// shared lock for the current chat trace, and serves to synchronize large chat operations. If there is
+// no chat trace, this is a no-op.
 func (c *conversationLockTab) Acquire(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) chan struct{} {
 	c.Lock()
 	defer c.Unlock()

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -318,7 +318,7 @@ func NewHybridConversationSource(g *globals.Context, b *Boxer, storage *storage.
 
 func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.ConversationID,
 	uid gregor1.UID, msg chat1.MessageBoxed) (decmsg chat1.MessageUnboxed, continuousUpdate bool, err error) {
-	defer s.Trace(ctx, func() error { return err }, "Pull")()
+	defer s.Trace(ctx, func() error { return err }, "Push")()
 	<-s.lockTab.Acquire(ctx, uid, convID)
 	defer s.lockTab.Release(ctx, uid, convID)
 

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -555,4 +555,17 @@ func TestConversationLocking(t *testing.T) {
 	hcs.lockTab.Release(ctx, uid, conv.GetConvID())
 	<-cb
 	require.Zero(t, len(hcs.lockTab.convLocks))
+
+	t.Logf("No trace")
+	select {
+	case <-hcs.lockTab.Acquire(context.TODO(), uid, conv.GetConvID()):
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "locked")
+	}
+	select {
+	case <-hcs.lockTab.Acquire(context.TODO(), uid, conv.GetConvID()):
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "locked")
+	}
+	require.Zero(t, len(hcs.lockTab.convLocks))
 }


### PR DESCRIPTION
The point of this patch is to reduce the contention amongst threads of chat operations (especially on mobile where we only really get 1 core a lot of the time). The threads that often conflict are the following:

1.) RPC interface
2.) Gregor message handler
3.) Background thread loader
4.) Fetch retrier

I've seen `GetThreadNonblock` calls from the frontend get pre-empted by the background loader on app foreground, which serves no purpose other than to slow down the frontend request. It could also result in multiple requests to the server.

Patch does the following in order to address the situation:

1.) Adds a new struct `conversationLockTab`, which implements a lock table on uid x conv ID. It also comes with a special feature that it inspects the current context to see if the chat operation running has already obtained the lock. 
2.) Add checks for this new lock in all of the public operations of `HybridConversationSource`. 

@patrickxb I'm curious if you think this is a good idea at all, I'm not 100% convinced myself, maybe 90%.
