### PR TITLE
increase typing throttle to 5 seconds

### DIFF
--- a/shared/chat/conversation/input/container.js
+++ b/shared/chat/conversation/input/container.js
@@ -74,7 +74,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps): Props => {
       dispatchProps.onUpdateTyping(stateProps.selectedConversationIDKey, typing)
     }
   }
-  const wrappedTyping = throttle(updateTyping, 2000)
+  const wrappedTyping = throttle(updateTyping, 5000)
 
   return {
     ...stateProps,


### PR DESCRIPTION
The timeout for typing notifications is 10 seconds in the service, so 2 seconds is overly aggressive  in that context. Increasing this to 5 seconds should keep the typer comfortably in the timeout range, but reduce typing traffic on Gregor. 