### PR TITLE
Add PerUserKeyUpgrade engine

### DIFF
--- a/go/engine/per_user_key_upgrade.go
+++ b/go/engine/per_user_key_upgrade.go
@@ -1,0 +1,197 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// PerUserKeyUpgrade creates a per-user-key for the active user
+// if they do not already have one.
+// It adds a per-user-key link to the sigchain and adds the key to the local keyring.
+package engine
+
+import (
+	"fmt"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// PerUserKeyUpgrade is an engine.
+type PerUserKeyUpgrade struct {
+	libkb.Contextified
+	args      *PerUserKeyUpgradeArgs
+	DidNewKey bool
+}
+
+type PerUserKeyUpgradeArgs struct {
+	LoginContext libkb.LoginContext // optional
+}
+
+// NewPerUserKeyUpgrade creates a PerUserKeyUpgrade engine.
+func NewPerUserKeyUpgrade(g *libkb.GlobalContext, args *PerUserKeyUpgradeArgs) *PerUserKeyUpgrade {
+	return &PerUserKeyUpgrade{
+		args:         args,
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+// Name is the unique engine name.
+func (e *PerUserKeyUpgrade) Name() string {
+	return "PerUserKeyUpgrade"
+}
+
+// GetPrereqs returns the engine prereqs.
+func (e *PerUserKeyUpgrade) Prereqs() Prereqs {
+	return Prereqs{
+		Session: true,
+	}
+}
+
+// RequiredUIs returns the required UIs.
+func (e *PerUserKeyUpgrade) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{
+		libkb.LogUIKind,
+		libkb.SecretUIKind,
+	}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *PerUserKeyUpgrade) SubConsumers() []libkb.UIConsumer {
+	return []libkb.UIConsumer{&PaperKeyGen{}}
+}
+
+// Run starts the engine.
+func (e *PerUserKeyUpgrade) Run(ctx *Context) (err error) {
+	defer e.G().CTrace(ctx.NetContext, "PerUserKeyUpgrade", func() error { return err })()
+	return e.inner(ctx)
+}
+
+func (e *PerUserKeyUpgrade) inner(ctx *Context) error {
+	if !e.G().Env.GetUpgradePerUserKey() {
+		return fmt.Errorf("per-user-key upgrade is disabled")
+	}
+
+	e.G().Log.CDebugf(ctx.NetContext, "PerUserKeyUpgrade load self")
+
+	uid := e.G().GetMyUID()
+	if uid.IsNil() {
+		return libkb.NoUIDError{}
+	}
+
+	loadArg := libkb.NewLoadUserArgBase(e.G()).WithNetContext(ctx.NetContext).WithUID(uid).WithPublicKeyOptional()
+	loadArg.LoginContext = e.args.LoginContext
+	upak, me, err := e.G().GetUPAKLoader().Load(*loadArg)
+	if err != nil {
+		return err
+	}
+
+	e.G().Log.CDebugf(ctx.NetContext, "PerUserKeyUpgrade check for key")
+	if len(upak.Base.PerUserKeys) > 0 {
+		e.G().Log.CDebugf(ctx.NetContext, "PerUserKeyUpgrade already has per-user-key")
+		e.DidNewKey = false
+		return nil
+	}
+	e.G().Log.CDebugf(ctx.NetContext, "PerUserKeyUpgrade has no per-user-key")
+
+	sigKey, encKey, err := e.getDeviceSecretKeys(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Get pukring
+	err = e.G().BumpPerUserKeyring()
+	if err != nil {
+		return err
+	}
+	pukring, err := e.G().GetPerUserKeyring()
+	if err != nil {
+		return err
+	}
+
+	gen1 := keybase1.PerUserKeyGeneration(1)
+
+	pukSeed, err := libkb.GeneratePerUserKeySeed()
+	if err != nil {
+		return err
+	}
+
+	pukReceivers, err := e.getPukReceivers(ctx, upak)
+	if err != nil {
+		return err
+	}
+	if len(pukReceivers) == 0 {
+		return fmt.Errorf("no receivers")
+	}
+
+	// Create boxes of the new per-user-key
+	pukBoxes, err := pukring.PrepareBoxesForDevices(ctx.NetContext,
+		pukSeed, gen1, pukReceivers, *encKey)
+	if err != nil {
+		return err
+	}
+
+	creationTime := e.G().Clock().Now().Unix()
+
+	sig1, err := libkb.PerUserKeyProofReverseSigned(me, pukSeed, gen1, sigKey, creationTime)
+	if err != nil {
+		return err
+	}
+
+	var sigsList []libkb.JSONPayload
+	sigsList = append(sigsList, sig1)
+
+	payload := make(libkb.JSONPayload)
+	payload["sigs"] = sigsList
+
+	libkb.AddPerUserKeyServerArg(payload, gen1, pukBoxes, nil)
+
+	_, err = e.G().API.PostJSON(libkb.APIArg{
+		Endpoint:    "key/multi",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		JSONPayload: payload,
+	})
+	if err != nil {
+		return err
+	}
+	e.DidNewKey = true
+
+	// Add the per-user-key locally
+	err = pukring.AddKey(ctx.NetContext, gen1, pukSeed)
+	if err != nil {
+		return err
+	}
+
+	e.G().UserChanged(uid)
+	return nil
+}
+
+// Get the full keys for this device.
+// Returns (sigKey, encKey, err)
+func (e *PerUserKeyUpgrade) getDeviceSecretKeys(ctx *Context) (libkb.GenericKey, *libkb.NaclDHKeyPair, error) {
+	ad := e.G().ActiveDevice
+	sigKey, err := ad.SigningKey()
+	if err != nil {
+		return nil, nil, err
+	}
+	encKeyGeneric, err := ad.EncryptionKey()
+	if err != nil {
+		return nil, nil, err
+	}
+	encKey, ok := encKeyGeneric.(libkb.NaclDHKeyPair)
+	if !ok {
+		return nil, nil, fmt.Errorf("Unexpected encryption key type: %T", encKeyGeneric)
+	}
+	return sigKey, &encKey, nil
+}
+
+// Get the receivers of the new per-user-key boxes.
+// Includes all the user's device subkeys.
+func (e *PerUserKeyUpgrade) getPukReceivers(ctx *Context, meUPAK *keybase1.UserPlusAllKeys) (res []libkb.NaclDHKeyPair, err error) {
+	for _, dk := range meUPAK.Base.DeviceKeys {
+		if dk.IsSibkey == false && !dk.IsRevoked {
+			receiver, err := libkb.ImportNaclDHKeyPairFromHex(dk.KID.String())
+			if err != nil {
+				return res, err
+			}
+			res = append(res, receiver)
+		}
+	}
+	return res, nil
+}

--- a/go/engine/per_user_key_upgrade_test.go
+++ b/go/engine/per_user_key_upgrade_test.go
@@ -1,0 +1,69 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPerUserKeyUpgrade(t *testing.T) {
+	tc := SetupEngineTest(t, "pukup")
+	defer tc.Cleanup()
+
+	tc.Tp.UpgradePerUserKey = false
+	tc.Tp.SupportPerUserKey = false
+
+	fu := CreateAndSignupFakeUserPaper(tc, "pukup")
+
+	checkPerUserKeyCount := func(n int) {
+		me, err := libkb.LoadMe(libkb.NewLoadUserForceArg(tc.G))
+		require.NoError(t, err)
+		require.Len(t, me.ExportToUserPlusKeys(keybase1.Time(0)).PerUserKeys, n, "per-user-key count")
+	}
+
+	checkPerUserKeyCountLocal := func(n int) {
+		pukring, err := tc.G.GetPerUserKeyring()
+		require.NoError(t, err)
+		if n == 0 {
+			require.False(t, pukring.HasAnyKeys(), "unexpectedly has per-user-key")
+		} else {
+			require.Equal(t, keybase1.PerUserKeyGeneration(n), pukring.CurrentGeneration(), "wrong latest per-user-key generation")
+		}
+	}
+
+	checkPerUserKeyCount(0)
+
+	tc.Tp.UpgradePerUserKey = true
+
+	t.Logf("upgrade")
+	upgrade := func() *PerUserKeyUpgrade {
+		arg := &PerUserKeyUpgradeArgs{}
+		eng := NewPerUserKeyUpgrade(tc.G, arg)
+		ctx := &Context{
+			LogUI:    tc.G.UI.GetLogUI(),
+			SecretUI: fu.NewSecretUI(),
+		}
+		err := RunEngine(eng, ctx)
+		require.NoError(t, err)
+		return eng
+	}
+	require.True(t, upgrade().DidNewKey, "created key")
+
+	checkPerUserKeyCountLocal(1)
+	checkPerUserKeyCount(1)
+
+	t.Logf("revoke paper key")
+	revokeAnyPaperKey(tc, fu)
+
+	t.Logf("should be on gen 2")
+	checkPerUserKeyCountLocal(2)
+	checkPerUserKeyCount(2)
+
+	t.Logf("run the upgrade engine again. Expect an error because the user is already up.")
+	require.False(t, upgrade().DidNewKey, "did not create key")
+}

--- a/go/engine/revoke.go
+++ b/go/engine/revoke.go
@@ -186,7 +186,7 @@ func (e *RevokeEngine) Run(ctx *Context) error {
 
 			// Create boxes of the new per-user-key
 			pukBoxesInner, err := pukring.PrepareBoxesForDevices(ctx.NetContext,
-				*newPukSeed, newPukGeneration, pukReceivers, *encKey)
+				*newPukSeed, newPukGeneration, pukReceivers, encKey)
 			if err != nil {
 				return err
 			}
@@ -249,8 +249,8 @@ func (e *RevokeEngine) Run(ctx *Context) error {
 
 // Get the full keys for this device.
 // Returns (sigKey, encKey, err)
-// encKey will be nil iff SharedDH is disabled
-func (e *RevokeEngine) getDeviceSecretKeys(ctx *Context, me *libkb.User) (libkb.GenericKey, *libkb.NaclDHKeyPair, error) {
+// encKey will be nil iff PerUserKey is disabled
+func (e *RevokeEngine) getDeviceSecretKeys(ctx *Context, me *libkb.User) (libkb.GenericKey, libkb.GenericKey, error) {
 	skaSig := libkb.SecretKeyArg{
 		Me:      me,
 		KeyType: libkb.DeviceSigningKeyType,
@@ -263,21 +263,17 @@ func (e *RevokeEngine) getDeviceSecretKeys(ctx *Context, me *libkb.User) (libkb.
 		return nil, nil, err
 	}
 
-	var encKey *libkb.NaclDHKeyPair
+	var encKey libkb.GenericKey
 	if e.G().Env.GetSupportPerUserKey() {
 		skaEnc := libkb.SecretKeyArg{
 			Me:      me,
 			KeyType: libkb.DeviceEncryptionKeyType,
 		}
-		encKeyGeneric, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(skaEnc, "to revoke another key"))
+		encKey2, err := e.G().Keyrings.GetSecretKeyWithPrompt(ctx.SecretKeyPromptArg(skaEnc, "to revoke another key"))
 		if err != nil {
 			return nil, nil, err
 		}
-		encKey2, ok := encKeyGeneric.(libkb.NaclDHKeyPair)
-		if !ok {
-			return nil, nil, fmt.Errorf("Unexpected encryption key type: %T", encKeyGeneric)
-		}
-		encKey = &encKey2
+		encKey = encKey2
 		if err = encKey.CheckSecretKey(); err != nil {
 			return nil, nil, err
 		}

--- a/go/libkb/per_user_key.go
+++ b/go/libkb/per_user_key.go
@@ -219,15 +219,20 @@ func (s *PerUserKeyring) PrepareBoxForNewDevice(ctx context.Context, receiverKey
 // Used when creating a new seed.
 func (s *PerUserKeyring) PrepareBoxesForDevices(ctx context.Context, contents PerUserKeySeed,
 	generation keybase1.PerUserKeyGeneration, receiverKeys []NaclDHKeyPair,
-	senderKey NaclDHKeyPair) (boxes []keybase1.PerUserKeyBox, err error) {
+	senderKey GenericKey) (boxes []keybase1.PerUserKeyBox, err error) {
 	// Do not lock self because we do not use self.
 
 	if contents.IsBlank() {
 		return nil, errors.New("attempt to box blank per-user-key")
 	}
 
+	senderKeyDH, ok := senderKey.(NaclDHKeyPair)
+	if !ok {
+		return nil, fmt.Errorf("Unexpected encryption key type: %T", senderKey)
+	}
+
 	for _, receiverKey := range receiverKeys {
-		box, err := NewPerUserKeyBox(contents, receiverKey, senderKey, generation)
+		box, err := NewPerUserKeyBox(contents, receiverKey, senderKeyDH, generation)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This `PerUserKeyUpgrade` engine figures out whether the current user has a per-user-key. If they do it just returns. If they don't, it generates one, posts a sigchain link, and stores the new key locally. 

This is half the battle of `CORE-4879 PUK: Client-side: Bring legacy user up-to-date on missing per-user-key via generation and post of new per-user-key`. The next half not in this PR is to run this once in a while in the background.

The engine bails unless `UpgradePerUserKey` is set.