### PR TITLE
Notifications: use server side notification groups

### DIFF
--- a/shared/constants/settings.js
+++ b/shared/constants/settings.js
@@ -35,7 +35,7 @@ export type NotificationsState = {
   allowSave: boolean,
   allowEdit: boolean,
   groups: {
-    email: NotificationsGroupState,
+    email?: NotificationsGroupState,
     app_push?: NotificationsGroupState,
     sms?: NotificationsGroupState,
   },

--- a/shared/constants/settings.js
+++ b/shared/constants/settings.js
@@ -20,15 +20,25 @@ export type InvitesState = {
   error: ?Error,
 }
 
+export type NotificationsSettingsState = {
+  name: string,
+  subscribed: boolean,
+  description: string,
+}
+
+export type NotificationsGroupState = {
+  settings: ?Array<NotificationsSettingsState>,
+  unsubscribedFromAll: boolean,
+}
+
 export type NotificationsState = {
-  settings: ?Array<{
-    name: string,
-    subscribed: boolean,
-    description: string,
-  }>,
-  unsubscribedFromAll: ?boolean,
   allowSave: boolean,
   allowEdit: boolean,
+  groups: {
+    email: NotificationsGroupState,
+    app_push?: NotificationsGroupState,
+    sms?: NotificationsGroupState,
+  },
 }
 
 export type PassphraseState = {
@@ -89,7 +99,10 @@ export const notificationsSaved = 'settings:notificationsSaved'
 export type NotificationsSaved = NoErrorTypedAction<'settings:notificationsSaved', void>
 
 export const notificationsToggle = 'settings:notificationsToggle'
-export type NotificationsToggle = NoErrorTypedAction<'settings:notificationsToggle', {name: ?string}>
+export type NotificationsToggle = NoErrorTypedAction<
+  'settings:notificationsToggle',
+  {group: string, name: ?string}
+>
 
 export const setAllowDeleteAccount = 'settings:setAllowDeleteAccount'
 export type SetAllowDeleteAccount = NoErrorTypedAction<'settings:setAllowDeleteAccount', boolean>

--- a/shared/reducers/settings.js
+++ b/shared/reducers/settings.js
@@ -83,7 +83,7 @@ function reducer(state: State = initialState, action: Actions): State {
 
       const {settings, unsubscribedFromAll} = state.notifications.groups[group]
       const changed = {
-        group: {
+        [group]: {
           settings: settings.map(s => updateSubscribe(s, group)),
           // No name means toggle the unsubscribe option
           unsubscribedFromAll: !name && !unsubscribedFromAll,
@@ -124,7 +124,9 @@ function reducer(state: State = initialState, action: Actions): State {
         notifications: {
           allowEdit: true,
           allowSave: false,
-          ...action.payload,
+          groups: {
+            ...action.payload,
+          },
         },
       }
     case Constants.invitesRefreshed:

--- a/shared/settings/dumb.desktop.js
+++ b/shared/settings/dumb.desktop.js
@@ -276,29 +276,43 @@ const deleteConfirmMap: DumbComponentMap<DeleteConfirm> = {
 }
 
 const commonSettings = {
-  settings: [
-    {
-      name: 'follow',
-      subscribed: true,
-      description: 'when someone follows me',
+  groups: {
+    app_push: {
+      settings: [
+        {
+          name: 'follow',
+          description: 'when someone follows me',
+          subscribed: true,
+        },
+      ],
+      unsubscribedFromAll: false,
     },
-    {
-      name: 'twitter_friend_joined',
-      subscribed: true,
-      description: 'when someone I follow on Twitter joins',
+    email: {
+      settings: [
+        {
+          name: 'follow',
+          description: 'when someone follows me',
+          subscribed: true,
+        },
+        {
+          name: 'twitter_friend_joined',
+          description: 'when someone I follow on Twitter joins',
+          subscribed: true,
+        },
+        {
+          name: 'filesystem_attention',
+          description: 'when the Keybase filesystem needs my attention',
+          subscribed: true,
+        },
+        {
+          name: 'newsletter',
+          description: 'Keybase news, once in a great while',
+          subscribed: true,
+        },
+      ],
+      unsubscribedFromAll: false,
     },
-    {
-      name: 'filesystem_attention',
-      subscribed: true,
-      description: 'when the Keybase filesystem needs my attention',
-    },
-    {
-      name: 'newsletter',
-      subscribed: true,
-      description: 'Keybase news, once in a great while',
-    },
-  ],
-  unsubscribedFromAll: false,
+  },
   allowSave: true,
   allowEdit: true,
   waitingForResponse: false,
@@ -308,6 +322,9 @@ const commonSettings = {
   onToggleUnsubscribeAll: () => console.log('on subscribe all'),
 }
 
+let unsubSettings = commonSettings
+unsubSettings.groups.email.unsubscribedFromAll = true
+
 const notificationsMap: DumbComponentMap<Notifications> = {
   component: Notifications,
   mocks: {
@@ -315,8 +332,7 @@ const notificationsMap: DumbComponentMap<Notifications> = {
       ...commonSettings,
     },
     UnsubAll: {
-      ...commonSettings,
-      unsubscribedFromAll: true,
+      ...unsubSettings,
     },
   },
 }

--- a/shared/settings/invites/container.js
+++ b/shared/settings/invites/container.js
@@ -1,13 +1,7 @@
 // @flow
 import React, {Component} from 'react'
 import Invites from './index'
-import {
-  invitesReclaim,
-  invitesRefresh,
-  invitesSend,
-  notificationsSave,
-  notificationsToggle,
-} from '../../actions/settings'
+import {invitesReclaim, invitesRefresh, invitesSend} from '../../actions/settings'
 import {openURLWithHelper} from '../../util/open-url'
 
 import {navigateAppend} from '../../actions/route-tree'
@@ -48,11 +42,6 @@ export default connector.connect((state, dispatch, ownProps) => {
     onReclaimInvitation: (inviteId: string) => {
       dispatch(invitesReclaim(inviteId))
     },
-    onSave: () => {
-      dispatch(notificationsSave())
-    },
-    onToggle: (name: string) => dispatch(notificationsToggle(name)),
-    onToggleUnsubscribeAll: () => dispatch(notificationsToggle()),
     onSelectUser: (username: string) => {
       openURLWithHelper('user', {username})
     },

--- a/shared/settings/notifications/container.js
+++ b/shared/settings/notifications/container.js
@@ -25,8 +25,8 @@ export default connect(
   (dispatch: any, ownProps: {}) => ({
     onBack: () => dispatch(navigateUp()),
     onSave: () => dispatch(notificationsSave()),
-    onToggle: (name: string) => dispatch(notificationsToggle(name)),
-    onToggleUnsubscribeAll: () => dispatch(notificationsToggle()),
+    onToggle: (group: string, name?: string) => dispatch(notificationsToggle(group, name)),
+    onToggleUnsubscribeAll: (group: string) => dispatch(notificationsToggle(group)),
     onRefresh: () => dispatch(notificationsRefresh()),
     title: 'Notifications',
   })

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import {Box, Button, Checkbox, HeaderHoc, ProgressIndicator, Text} from '../../common-adapters'
+import {Box, Button, Checkbox, HeaderHoc, NativeScrollView, ProgressIndicator, Text} from '../../common-adapters'
 import {isMobile} from '../../constants/platform'
 import {globalStyles, globalMargins} from '../../styles'
 
@@ -12,7 +12,7 @@ const makeCheckbox = (
   props: Props
 ) => (
   <Checkbox
-    style={{marginTop: globalMargins.small}}
+    style={{marginTop: globalMargins.small, marginRight: globalMargins.medium}}
     key={s.name}
     disabled={!props.allowEdit}
     onCheck={() => props.onToggle(group, s.name)}
@@ -20,6 +20,11 @@ const makeCheckbox = (
     label={s.description}
   />
 )
+
+const MobileNotifications = (props: Props) =>
+  <NativeScrollView style={{...globalStyles.flexBoxColumn, flex: 1}}>
+    <Notifications {...props} />
+  </NativeScrollView>
 
 const Notifications = (props: Props) =>
   !props.groups.email
@@ -66,4 +71,4 @@ const Notifications = (props: Props) =>
         />
       </Box>
 
-export default (isMobile ? HeaderHoc(Notifications) : Notifications)
+export default (isMobile ? HeaderHoc(MobileNotifications) : Notifications)

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -3,6 +3,7 @@ import React from 'react'
 import {Box, Button, Checkbox, ProgressIndicator, Text} from '../../common-adapters'
 import {globalStyles, globalMargins} from '../../styles'
 
+import type {NotificationsSettingsState} from '../../constants/settings'
 import type {Props} from './index'
 
 const SubscriptionCheckbox = (props: {
@@ -10,7 +11,7 @@ const SubscriptionCheckbox = (props: {
   description: string,
   groupName: string,
   name: string,
-  onToggle: () => void,
+  onToggle: (name: string) => void,
   subscribed: boolean,
 }) => (
   <Checkbox
@@ -23,7 +24,16 @@ const SubscriptionCheckbox = (props: {
   />
 )
 
-const Group = (props: any) => (
+const Group = (props: {
+  allowEdit: boolean,
+  groupName: string,
+  onToggle: (name: string) => void,
+  onToggleUnsubscribeAll: () => void,
+  settings: ?Array<NotificationsSettingsState>,
+  title: string,
+  unsub: string,
+  unsubscribedFromAll: boolean,
+}) => (
   <Box style={{...globalStyles.flexBoxColumn, marginBottom: globalMargins.medium}}>
     <Text type="BodyBig" style={{marginTop: globalMargins.medium}}>{props.title}</Text>
     <Box style={{...globalStyles.flexBoxColumn, marginBottom: globalMargins.small}}>
@@ -36,7 +46,7 @@ const Group = (props: any) => (
             key={props.groupName + s.name}
             name={s.name}
             onToggle={props.onToggle}
-            subscribed={s.name}
+            subscribed={s.subscribed}
           />
         ))}
     </Box>

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -21,11 +21,6 @@ const makeCheckbox = (
   />
 )
 
-const MobileNotifications = (props: Props) =>
-  <NativeScrollView style={{...globalStyles.flexBoxColumn, flex: 1}}>
-    <Notifications {...props} />
-  </NativeScrollView>
-
 const Notifications = (props: Props) =>
   !props.groups.email
     ? <Box style={{...globalStyles.flexBoxColumn, flex: 1, justifyContent: 'center', alignItems: 'center'}}>
@@ -71,4 +66,4 @@ const Notifications = (props: Props) =>
         />
       </Box>
 
-export default (isMobile ? HeaderHoc(MobileNotifications) : Notifications)
+export default Notifications

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -86,7 +86,7 @@ const Notifications = (props: Props) =>
             onToggle={props.onToggle}
             onToggleUnsubscribeAll={() => props.onToggleUnsubscribeAll('app_push')}
             title="Phone - push notifications:"
-            unsub="push notifications"
+            unsub="push"
             settings={props.groups.app_push.settings}
             unsubscribedFromAll={props.groups.app_push.unsubscribedFromAll}
           />}

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import {Box, Button, Checkbox, HeaderHoc, NativeScrollView, ProgressIndicator, Text} from '../../common-adapters'
+import {Box, Button, Checkbox, ProgressIndicator, Text} from '../../common-adapters'
 import {globalStyles, globalMargins} from '../../styles'
 
 import type {Props} from './index'

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -11,7 +11,7 @@ const makeCheckbox = (
   props: Props
 ) => (
   <Checkbox
-    style={{marginTop: globalMargins.small, marginRight: globalMargins.medium}}
+    style={{marginRight: globalMargins.medium, marginTop: globalMargins.tiny}}
     key={s.name}
     disabled={!props.allowEdit}
     onCheck={() => props.onToggle(group, s.name)}
@@ -20,41 +20,44 @@ const makeCheckbox = (
   />
 )
 
+const renderGroup = (groupName: string, props: Props) => {
+  const labels = {
+    title: {
+      app_push: 'Phone - push notifications:',
+      email: 'Email me:',
+    },
+    unsub: {
+      app_push: 'Unsubscribe me from all push notifications',
+      email: 'Unsubscribe me from all mail',
+    },
+  }
+
+  return (
+    <Box style={{...globalStyles.flexBoxColumn, marginBottom: globalMargins.medium}}>
+      <Text type="BodyBig" style={{marginTop: globalMargins.medium}}>{labels.title[groupName]}</Text>
+      <Box style={{...globalStyles.flexBoxColumn, marginBottom: globalMargins.small}}>
+        {props.groups[groupName].settings &&
+          props.groups[groupName].settings.map(s => makeCheckbox(groupName, s, props))}
+      </Box>
+      <Text type="BodyBig">Or:</Text>
+      <Checkbox
+        style={{marginTop: globalMargins.small}}
+        onCheck={() => props.onToggleUnsubscribeAll(groupName)}
+        disabled={!props.allowEdit}
+        checked={props.groups[groupName] && !!props.groups[groupName].unsubscribedFromAll}
+        label={labels.unsub[groupName]}
+      />
+    </Box>
+  )
+}
 const Notifications = (props: Props) =>
-  !props.groups.email
-    ? <Box style={{...globalStyles.flexBoxColumn, flex: 1, justifyContent: 'center', alignItems: 'center'}}>
+  !props.groups.email || !props.groups.email.settings
+    ? <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center', flex: 1, justifyContent: 'center'}}>
         <ProgressIndicator type="Small" style={{width: globalMargins.medium}} />
       </Box>
-    : <Box style={{...globalStyles.flexBoxColumn, padding: globalMargins.small, flex: 1}}>
-        <Text type="BodyBig" style={{marginTop: globalMargins.medium}}>Email me:</Text>
-        <Box style={globalStyles.flexBoxColumn}>
-          {props.groups.email.settings &&
-            props.groups.email.settings.map(s => makeCheckbox('email', s, props))}
-        </Box>
-        <Text type="BodyBig" style={{marginTop: globalMargins.medium}}>Or:</Text>
-        <Checkbox
-          style={{marginTop: globalMargins.small}}
-          onCheck={() => props.onToggleUnsubscribeAll('email')}
-          disabled={!props.allowEdit}
-          checked={props.groups.email && !!props.groups.email.unsubscribedFromAll}
-          label="Unsubscribe me from all mail"
-        />
-
-        {!!props.groups.app_push &&
-          props.groups.app_push.settings &&
-          <Box style={globalStyles.flexBoxColumn}>
-            <Text type="BodyBig" style={{marginTop: globalMargins.large}}>Phone - push notifications:</Text>
-            {props.groups.app_push.settings.map(s => makeCheckbox('app_push', s, props))}
-            <Text type="BodyBig" style={{marginTop: globalMargins.medium}}>Or:</Text>
-            <Checkbox
-              style={{marginTop: globalMargins.small}}
-              onCheck={() => props.onToggleUnsubscribeAll('app_push')}
-              disabled={!props.allowEdit}
-              checked={!!props.groups.app_push && !!props.groups.app_push.unsubscribedFromAll}
-              label="Unsubscribe me from all push notifications"
-            />
-          </Box>}
-
+    : <Box style={{...globalStyles.scrollable, padding: globalMargins.small, flex: 1}}>
+        {props.groups.email && props.groups.email.settings && renderGroup('email', props)}
+        {props.groups.app_push && props.groups.app_push.settings && renderGroup('app_push', props)}
         <Button
           style={{alignSelf: 'center', marginTop: globalMargins.small}}
           type="Primary"

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -49,7 +49,7 @@ const Notifications = (props: Props) =>
         {!!props.groups.app_push &&
           props.groups.app_push.settings &&
           <Box style={globalStyles.flexBoxColumn}>
-            <Text type="BodyBig" style={{marginTop: globalMargins.large}}>Push notifications:</Text>
+            <Text type="BodyBig" style={{marginTop: globalMargins.large}}>Phone - push notifications:</Text>
             {props.groups.app_push.settings.map(s => makeCheckbox('app_push', s, props))}
             <Text type="BodyBig" style={{marginTop: globalMargins.medium}}>Or:</Text>
             <Checkbox

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react'
 import {Box, Button, Checkbox, HeaderHoc, NativeScrollView, ProgressIndicator, Text} from '../../common-adapters'
-import {isMobile} from '../../constants/platform'
 import {globalStyles, globalMargins} from '../../styles'
 
 import type {Props} from './index'

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -6,36 +6,58 @@ import {globalStyles, globalMargins} from '../../styles'
 
 import type {Props} from './index'
 
+const makeCheckbox = (
+  group: string,
+  s: {name: string, description: string, subscribed: boolean},
+  props: Props
+) => (
+  <Checkbox
+    style={{marginTop: globalMargins.small}}
+    key={s.name}
+    disabled={!props.allowEdit}
+    onCheck={() => props.onToggle(group, s.name)}
+    checked={s.subscribed}
+    label={s.description}
+  />
+)
+
 const Notifications = (props: Props) =>
-  !props.settings
+  !props.groups.email
     ? <Box style={{...globalStyles.flexBoxColumn, flex: 1, justifyContent: 'center', alignItems: 'center'}}>
         <ProgressIndicator type="Small" style={{width: globalMargins.medium}} />
       </Box>
     : <Box style={{...globalStyles.flexBoxColumn, padding: globalMargins.small, flex: 1}}>
         <Text type="BodyBig" style={{marginTop: globalMargins.medium}}>Email me:</Text>
         <Box style={globalStyles.flexBoxColumn}>
-          {!!props.settings &&
-            props.settings.map(s => (
-              <Checkbox
-                style={{marginTop: globalMargins.small}}
-                key={s.name}
-                disabled={!props.allowEdit}
-                onCheck={() => props.onToggle(s.name)}
-                checked={s.subscribed}
-                label={s.description}
-              />
-            ))}
+          {props.groups.email.settings &&
+            props.groups.email.settings.map(s => makeCheckbox('email', s, props))}
         </Box>
         <Text type="BodyBig" style={{marginTop: globalMargins.medium}}>Or:</Text>
         <Checkbox
-          style={{marginTop: globalMargins.small, marginBottom: globalMargins.medium}}
-          onCheck={() => props.onToggleUnsubscribeAll()}
+          style={{marginTop: globalMargins.small}}
+          onCheck={() => props.onToggleUnsubscribeAll('email')}
           disabled={!props.allowEdit}
-          checked={!!props.unsubscribedFromAll}
+          checked={props.groups.email && !!props.groups.email.unsubscribedFromAll}
           label="Unsubscribe me from all mail"
         />
+
+        {!!props.groups.app_push &&
+          props.groups.app_push.settings &&
+          <Box style={globalStyles.flexBoxColumn}>
+            <Text type="BodyBig" style={{marginTop: globalMargins.large}}>Push notifications:</Text>
+            {props.groups.app_push.settings.map(s => makeCheckbox('app_push', s, props))}
+            <Text type="BodyBig" style={{marginTop: globalMargins.medium}}>Or:</Text>
+            <Checkbox
+              style={{marginTop: globalMargins.small}}
+              onCheck={() => props.onToggleUnsubscribeAll('app_push')}
+              disabled={!props.allowEdit}
+              checked={!!props.groups.app_push && !!props.groups.app_push.unsubscribedFromAll}
+              label="Unsubscribe me from all push notifications"
+            />
+          </Box>}
+
         <Button
-          style={{alignSelf: 'center'}}
+          style={{alignSelf: 'center', marginTop: globalMargins.small}}
           type="Primary"
           label="Save"
           disabled={!props.allowSave || !props.allowEdit}

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -6,46 +6,40 @@ import {globalStyles, globalMargins} from '../../styles'
 import type {Props} from './index'
 
 const makeCheckbox = (
-  group: string,
-  s: {name: string, description: string, subscribed: boolean},
+  groupName: string,
+  name: string,
+  description: string,
+  subscribed: boolean,
   props: Props
-) => (
-  <Checkbox
-    style={{marginRight: globalMargins.medium, marginTop: globalMargins.tiny}}
-    key={s.name}
-    disabled={!props.allowEdit}
-    onCheck={() => props.onToggle(group, s.name)}
-    checked={s.subscribed}
-    label={s.description}
-  />
-)
+) => {
+  return (
+    <Checkbox
+      style={{marginRight: globalMargins.medium, marginTop: globalMargins.tiny}}
+      key={name}
+      disabled={!props.allowEdit}
+      onCheck={() => props.onToggle(groupName, name)}
+      checked={subscribed}
+      label={description}
+    />
+  )
+}
 
-const renderGroup = (groupName: string, props: Props) => {
-  const labels = {
-    title: {
-      app_push: 'Phone - push notifications:',
-      email: 'Email me:',
-    },
-    unsub: {
-      app_push: 'Unsubscribe me from all push notifications',
-      email: 'Unsubscribe me from all mail',
-    },
-  }
-
+const Group = (props: any) => {
+  console.warn('props.ontoggle is', props.onToggle)
   return (
     <Box style={{...globalStyles.flexBoxColumn, marginBottom: globalMargins.medium}}>
-      <Text type="BodyBig" style={{marginTop: globalMargins.medium}}>{labels.title[groupName]}</Text>
+      <Text type="BodyBig" style={{marginTop: globalMargins.medium}}>{props.title}</Text>
       <Box style={{...globalStyles.flexBoxColumn, marginBottom: globalMargins.small}}>
-        {props.groups[groupName].settings &&
-          props.groups[groupName].settings.map(s => makeCheckbox(groupName, s, props))}
+        {props.settings &&
+          props.settings.map(s => makeCheckbox(props.groupName, s.name, s.description, s.subscribed, props))}
       </Box>
       <Text type="BodyBig">Or:</Text>
       <Checkbox
         style={{marginTop: globalMargins.small}}
-        onCheck={() => props.onToggleUnsubscribeAll(groupName)}
+        onCheck={props.onToggleUnsubscribeAll}
         disabled={!props.allowEdit}
-        checked={props.groups[groupName] && !!props.groups[groupName].unsubscribedFromAll}
-        label={labels.unsub[groupName]}
+        checked={!!props.unsubscribedFromAll}
+        label={`Unsubscribe me from all ${props.unsub} notifications.`}
       />
     </Box>
   )
@@ -55,9 +49,31 @@ const Notifications = (props: Props) =>
     ? <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center', flex: 1, justifyContent: 'center'}}>
         <ProgressIndicator type="Small" style={{width: globalMargins.medium}} />
       </Box>
-    : <Box style={{...globalStyles.scrollable, padding: globalMargins.small, flex: 1}}>
-        {props.groups.email && props.groups.email.settings && renderGroup('email', props)}
-        {props.groups.app_push && props.groups.app_push.settings && renderGroup('app_push', props)}
+    : <Box style={{...globalStyles.scrollable, flex: 1, padding: globalMargins.small}}>
+        <Group
+          allowEdit={props.allowEdit}
+          groupName="email"
+          onToggle={props.onToggle}
+          onToggleUnsubscribeAll={() => props.onToggleUnsubscribeAll('email')}
+          title="Email me:"
+          unsub="mail"
+          settings={props.groups.email && props.groups.email.settings}
+          unsubscribedFromAll={props.groups.email && props.groups.email.unsubscribedFromAll}
+        />
+
+        {props.groups.app_push &&
+          props.groups.app_push.settings &&
+          <Group
+            allowEdit={props.allowEdit}
+            groupName="app_push"
+            onToggle={props.onToggle}
+            onToggleUnsubscribeAll={() => props.onToggleUnsubscribeAll('app_push')}
+            title="Phone - push notifications:"
+            unsub="push notifications"
+            settings={props.groups.app_push.settings}
+            unsubscribedFromAll={props.groups.app_push.unsubscribedFromAll}
+          />}
+
         <Button
           style={{alignSelf: 'center', marginTop: globalMargins.small}}
           type="Primary"

--- a/shared/settings/notifications/index.js
+++ b/shared/settings/notifications/index.js
@@ -5,45 +5,52 @@ import {globalStyles, globalMargins} from '../../styles'
 
 import type {Props} from './index'
 
-const makeCheckbox = (
+const SubscriptionCheckbox = (props: {
+  allowEdit: boolean,
+  description: string,
   groupName: string,
   name: string,
-  description: string,
+  onToggle: () => void,
   subscribed: boolean,
-  props: Props
-) => {
-  return (
-    <Checkbox
-      style={{marginRight: globalMargins.medium, marginTop: globalMargins.tiny}}
-      key={name}
-      disabled={!props.allowEdit}
-      onCheck={() => props.onToggle(groupName, name)}
-      checked={subscribed}
-      label={description}
-    />
-  )
-}
+}) => (
+  <Checkbox
+    style={{marginRight: globalMargins.medium, marginTop: globalMargins.tiny}}
+    key={props.name}
+    disabled={!props.allowEdit}
+    onCheck={() => props.onToggle(props.groupName, props.name)}
+    checked={props.subscribed}
+    label={props.description}
+  />
+)
 
-const Group = (props: any) => {
-  console.warn('props.ontoggle is', props.onToggle)
-  return (
-    <Box style={{...globalStyles.flexBoxColumn, marginBottom: globalMargins.medium}}>
-      <Text type="BodyBig" style={{marginTop: globalMargins.medium}}>{props.title}</Text>
-      <Box style={{...globalStyles.flexBoxColumn, marginBottom: globalMargins.small}}>
-        {props.settings &&
-          props.settings.map(s => makeCheckbox(props.groupName, s.name, s.description, s.subscribed, props))}
-      </Box>
-      <Text type="BodyBig">Or:</Text>
-      <Checkbox
-        style={{marginTop: globalMargins.small}}
-        onCheck={props.onToggleUnsubscribeAll}
-        disabled={!props.allowEdit}
-        checked={!!props.unsubscribedFromAll}
-        label={`Unsubscribe me from all ${props.unsub} notifications.`}
-      />
+const Group = (props: any) => (
+  <Box style={{...globalStyles.flexBoxColumn, marginBottom: globalMargins.medium}}>
+    <Text type="BodyBig" style={{marginTop: globalMargins.medium}}>{props.title}</Text>
+    <Box style={{...globalStyles.flexBoxColumn, marginBottom: globalMargins.small}}>
+      {props.settings &&
+        props.settings.map(s => (
+          <SubscriptionCheckbox
+            allowEdit={props.allowEdit}
+            description={s.description}
+            groupName={props.groupName}
+            key={props.groupName + s.name}
+            name={s.name}
+            onToggle={props.onToggle}
+            subscribed={s.name}
+          />
+        ))}
     </Box>
-  )
-}
+    <Text type="BodyBig">Or:</Text>
+    <Checkbox
+      style={{marginTop: globalMargins.small}}
+      onCheck={props.onToggleUnsubscribeAll}
+      disabled={!props.allowEdit}
+      checked={!!props.unsubscribedFromAll}
+      label={`Unsubscribe me from all ${props.unsub} notifications.`}
+    />
+  </Box>
+)
+
 const Notifications = (props: Props) =>
   !props.groups.email || !props.groups.email.settings
     ? <Box style={{...globalStyles.flexBoxColumn, alignItems: 'center', flex: 1, justifyContent: 'center'}}>

--- a/shared/settings/notifications/index.js.flow
+++ b/shared/settings/notifications/index.js.flow
@@ -1,22 +1,30 @@
 // @flow
 import {Component} from 'react'
 
-export type Settings = {
-  name: string,
-  subscribed: boolean,
-  description: string,
+export type Group = {
+  settings: Settings,
+  unsubscribedFromAll: boolean,
 }
 
+export type Settings = Array<{
+  description: string,
+  name: string,
+  subscribed: boolean,
+}>
+
 export type Props = {
-  settings: ?Array<Settings>,
-  unsubscribedFromAll: ?boolean,
-  allowSave: boolean,
   allowEdit: boolean,
+  allowSave: boolean,
+  groups: {
+    app_push?: Group,
+    email?: Group,
+    sms?: Group,
+  },
+  onRefresh: () => void,
+  onSave: () => void,
   onToggle: (name: string) => void,
   onToggleUnsubscribeAll: () => void,
-  onSave: () => void,
   waitingForResponse: boolean,
-  onRefresh: () => void,
 }
 
 export default class Notifications extends Component<void, Props, void> {}

--- a/shared/settings/notifications/index.native.js
+++ b/shared/settings/notifications/index.native.js
@@ -1,0 +1,14 @@
+// @flow
+import React from 'react'
+import {HeaderHoc, NativeScrollView} from '../../common-adapters'
+import {globalStyles, globalMargins} from '../../styles'
+import Notifications from './index.js'
+
+import type {Props} from './index'
+
+const MobileNotifications = (props: Props) =>
+  <NativeScrollView style={{...globalStyles.flexBoxColumn, flex: 1}}>
+    <Notifications {...props} />
+  </NativeScrollView>
+
+export default HeaderHoc(MobileNotifications)

--- a/shared/settings/notifications/index.native.js
+++ b/shared/settings/notifications/index.native.js
@@ -1,14 +1,15 @@
 // @flow
 import React from 'react'
-import {HeaderHoc, NativeScrollView} from '../../common-adapters'
-import {globalStyles, globalMargins} from '../../styles'
+import {HeaderHoc, NativeScrollView} from '../../common-adapters/index.native'
+import {globalStyles} from '../../styles'
 import Notifications from './index.js'
 
 import type {Props} from './index'
 
-const MobileNotifications = (props: Props) =>
+const MobileNotifications = (props: Props) => (
   <NativeScrollView style={{...globalStyles.flexBoxColumn, flex: 1}}>
     <Notifications {...props} />
   </NativeScrollView>
+)
 
 export default HeaderHoc(MobileNotifications)


### PR DESCRIPTION
@keybase/react-hackers

Before this PR, the store looked like:
```
settings: {
  notifications: {
    follow: boolean,
    unsubscribedFromAll: boolean,
  }
}
```
After this PR, it looks like:
```
settings: {
  notifications: {
    groups: {
      app_push: {
        settings: {
          follow: boolean,
        },
        unsubscribedFromAll: boolean,
      },
      email: {
        settings: {
          follow: boolean,
        },
        unsubscribedFromAll: boolean,
      },
      ...
    }
  }
}
```
The "groups" (app_push, email, sms) and settings are sent by the server-side.

The display component chooses to display email, and app_push if it exists (which is the case only if you have a phone device).  It would be possible to make the display component iterate through groups without prior knowledge of which ones exist, but that seemed a step too far to me -- and if we wanted to do that we'd need the API server to start sending us more labels, e.g. app_push => "Push notifications" and unsubscribe text.  So this PR data-drives the store, but keeps the display components explicit about what they want to display.