### PR TITLE
Faster profile load

### DIFF
--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -452,6 +452,25 @@ function _serverCallMap(
     }
   }
 
+  // We queue up responses and handle them one at a time
+  let _idleResponseQueue = []
+
+  const addToIdleResponseQueue = (f: () => void) => {
+    _idleResponseQueue.push(f)
+    requestIdle(onRequestIdleQueueHandler)
+  }
+
+  const onRequestIdleQueueHandler = () => {
+    if (!_idleResponseQueue.length) {
+      return
+    }
+    const toHandle = _idleResponseQueue.pop()
+    toHandle()
+    if (_idleResponseQueue.length) {
+      requestIdle(onRequestIdleQueueHandler)
+    }
+  }
+
   return {
     'keybase.1.identifyUi.start': (
       {username: currentUsername, sessionID, reason, forceDisplay},
@@ -514,7 +533,7 @@ function _serverCallMap(
 
     'keybase.1.identifyUi.displayTLFCreateWithInvite': (args, response) => {
       response.result()
-      requestIdle(() => {
+      addToIdleResponseQueue(() => {
         dispatch({
           type: Constants.showNonUser,
           payload: {
@@ -530,7 +549,7 @@ function _serverCallMap(
     },
     'keybase.1.identifyUi.displayKey': ({key}, response) => {
       response.result()
-      requestIdle(() => {
+      addToIdleResponseQueue(() => {
         if (key.breaksTracking) {
           dispatch({type: Constants.updateEldestKidChanged, payload: {username}})
           dispatch({
@@ -549,7 +568,7 @@ function _serverCallMap(
     },
     'keybase.1.identifyUi.reportLastTrack': ({track}, response) => {
       response.result()
-      requestIdle(() => {
+      addToIdleResponseQueue(() => {
         dispatch({
           type: Constants.reportLastTrack,
           payload: {username, track},
@@ -562,7 +581,7 @@ function _serverCallMap(
     },
     'keybase.1.identifyUi.launchNetworkChecks': ({identity}, response) => {
       response.result()
-      requestIdle(() => {
+      addToIdleResponseQueue(() => {
         // This is the first spot that we have access to the user, so let's use that to get
         // The user information
 
@@ -582,7 +601,7 @@ function _serverCallMap(
 
     'keybase.1.identifyUi.dismiss': ({username, reason}, response) => {
       response.result()
-      requestIdle(() => {
+      addToIdleResponseQueue(() => {
         dispatch({
           type: Constants.remoteDismiss,
           payload: {username, reason},
@@ -592,7 +611,7 @@ function _serverCallMap(
 
     'keybase.1.identifyUi.finishWebProofCheck': ({rp, lcr}, response) => {
       response.result()
-      requestIdle(() => {
+      addToIdleResponseQueue(() => {
         dispatch(_updateProof(rp, lcr, username))
         dispatch({type: Constants.updateProofState, payload: {username}})
 
@@ -603,7 +622,7 @@ function _serverCallMap(
     },
     'keybase.1.identifyUi.finishSocialProofCheck': ({rp, lcr}, response) => {
       response.result()
-      requestIdle(() => {
+      addToIdleResponseQueue(() => {
         dispatch(_updateProof(rp, lcr, username))
         dispatch({type: Constants.updateProofState, payload: {username}})
 
@@ -614,7 +633,7 @@ function _serverCallMap(
     },
     'keybase.1.identifyUi.displayCryptocurrency': ({c: {address, sigID, type, family}}, response) => {
       response.result()
-      requestIdle(() => {
+      addToIdleResponseQueue(() => {
         if (family === 'zcash') {
           dispatch(_updateZcash(username, address, sigID))
         } else {
@@ -625,20 +644,19 @@ function _serverCallMap(
     },
     'keybase.1.identifyUi.displayUserCard': ({card}, response) => {
       response.result()
-      requestIdle(() => {
-        if (isGetProfile) {
-          // cache profile calls
-          dispatch({
-            type: Constants.cacheIdentify,
-            payload: {uid: card.uid, goodTill: Date.now() + cachedIdentifyGoodUntil},
-          })
-        }
-        dispatch(_updateUserInfo(card, username, getState))
-      })
+      // run this immediately
+      if (isGetProfile) {
+        // cache profile calls
+        dispatch({
+          type: Constants.cacheIdentify,
+          payload: {uid: card.uid, goodTill: Date.now() + cachedIdentifyGoodUntil},
+        })
+      }
+      dispatch(_updateUserInfo(card, username, getState))
     },
     'keybase.1.identifyUi.reportTrackToken': ({trackToken}, response) => {
       response.result()
-      requestIdle(() => {
+      addToIdleResponseQueue(() => {
         dispatch({type: Constants.updateTrackToken, payload: {username, trackToken}})
 
         const userState = getState().tracker.trackers[username]
@@ -666,7 +684,7 @@ function _serverCallMap(
     'keybase.1.identifyUi.cancel': ({sessionID}, response) => {
       response.result()
 
-      requestIdleCallback(
+      addToIdleResponseQueue(
         () => {
           // Check if there were any errors in the proofs
           dispatch({type: Constants.updateProofState, payload: {username}})

--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -460,12 +460,16 @@ function _serverCallMap(
     requestIdle(onRequestIdleQueueHandler)
   }
 
-  const onRequestIdleQueueHandler = () => {
+  const onRequestIdleQueueHandler = deadline => {
     if (!_idleResponseQueue.length) {
       return
     }
-    const toHandle = _idleResponseQueue.pop()
-    toHandle()
+
+    do {
+      const toHandle = _idleResponseQueue.pop()
+      toHandle()
+    } while (deadline.timeRemaining() > 10 && _idleResponseQueue.length)
+
     if (_idleResponseQueue.length) {
       requestIdle(onRequestIdleQueueHandler)
     }

--- a/shared/util/idle-callback.js
+++ b/shared/util/idle-callback.js
@@ -3,20 +3,19 @@ import {forceImmediateLogging} from '../local-debug'
 import {isAndroid} from '../constants/platform'
 
 function immediateCallback(cb: (info: {didTimeout: boolean, timeRemaining: () => number}) => void): number {
-  cb({didTimeout: false, timeRemaining: () => 0})
+  cb({didTimeout: true, timeRemaining: () => 0})
   return 0
 }
 
 function timeoutFallback(cb: (info: {didTimeout: boolean, timeRemaining: () => number}) => void): number {
-  var start = Date.now()
   return setTimeout(function() {
     cb({
-      didTimeout: false,
+      didTimeout: true,
       timeRemaining: function() {
-        return Math.max(0, 50 - (Date.now() - start))
+        return 0
       },
     })
-  }, 1)
+  }, 20)
 }
 
 function cancelIdleCallbackFallback(id: number) {


### PR DESCRIPTION
@keybase/react-hackers 
We were getting saturated cpu load due to handling these messages while they're streaming in. Even though we were using requestIdleCallback they'd all timeout and bundle up. Instead we now keep a little queue of them and execute them in a serialized fashion. This'll be a lot cleaner when saga-ized but until then this is simple.