### PR TITLE
fix long-standing bug in GetDecode

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -208,7 +208,7 @@ func noopFinisher() {}
 
 // doRequestShared returns an http.Response, which is a live streaming object that
 // escapes the function in which it was created.  It therefore also returns
-// a `finished func()` that *must always be called* after the response is no longer
+// a `finisher func()` that *must always be called* after the response is no longer
 // needed. This finisher is always non-nil (and just a noop in some cases),
 // so therefore it's fine to call it without checking for nil-ness.
 func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes bool) (_ *http.Response, finisher func(), jw *jsonw.Wrapper, err error) {

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -204,13 +204,17 @@ func (c *countingReader) numRead() int {
 // Shared code
 //
 
-// The returned response, if non-nil, should have
-// DiscardAndCloseBody() called on it.
-func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes bool) (_ *http.Response, jw *jsonw.Wrapper, err error) {
+func nullFinisher() {}
+
+// If finisher is returned non-nil, the finisher() should be called after the
+// response is no longer needed.
+func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes bool) (_ *http.Response, finisher func(), jw *jsonw.Wrapper, err error) {
 	if !api.G().Env.GetTorMode().UseSession() && arg.SessionType == APISessionTypeREQUIRED {
 		err = TorSessionRequiredError{}
 		return
 	}
+
+	finisher = nullFinisher
 
 	ctx := arg.NetContext
 	if ctx == nil {
@@ -251,19 +255,28 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 	timer := api.G().Timers.Start(timerType)
 	internalResp, canc, err := doRetry(ctx, api, arg, cli, req)
 
-	defer func() {
-		if internalResp != nil && err != nil {
+	finisher = func() {
+		if internalResp != nil {
 			DiscardAndCloseBody(internalResp)
+			internalResp = nil
 		}
 		if canc != nil {
 			canc()
+			canc = nil
+		}
+	}
+
+	defer func() {
+		if err != nil {
+			finisher()
+			finisher = nullFinisher
 		}
 	}()
 
 	timer.Report(req.Method + " " + arg.Endpoint)
 
 	if err != nil {
-		return nil, nil, APINetError{err: err}
+		return nil, finisher, nil, APINetError{err: err}
 	}
 	status = internalResp.Status
 
@@ -273,13 +286,13 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 	// handle headers *before* we abort based on status below.
 	err = api.consumeHeaders(internalResp)
 	if err != nil {
-		return nil, nil, err
+		return nil, finisher, nil, err
 	}
 
 	// Check for a code 200 or rather which codes were allowed in arg.HttpStatus
 	err = checkHTTPStatus(arg, internalResp)
 	if err != nil {
-		return nil, nil, err
+		return nil, finisher, nil, err
 	}
 
 	if wantJSONRes {
@@ -291,7 +304,7 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 		jsonBytes = reader.numRead()
 		if err != nil {
 			err = fmt.Errorf("Error in parsing JSON reply from server: %s", err)
-			return nil, nil, err
+			return nil, finisher, nil, err
 		}
 
 		jw = jsonw.NewWrapper(obj)
@@ -301,7 +314,7 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 		}
 	}
 
-	return internalResp, jw, nil
+	return internalResp, finisher, jw, nil
 }
 
 // doRetry will just call cli.cli.Do if arg.Timeout and arg.RetryCount aren't set.
@@ -636,33 +649,32 @@ func (a *InternalAPIEngine) Get(arg APIArg) (*APIRes, error) {
 	return a.DoRequest(arg, req)
 }
 
-// GetResp performs a GET request and returns the http response.  The
-// returned response, if non-nil, should have DiscardAndCloseBody()
-// called on it.
-func (a *InternalAPIEngine) GetResp(arg APIArg) (*http.Response, error) {
+// GetResp performs a GET request and returns the http response. The finisher
+// second arg should be called whenever we're done with the response (if it's non-nil).
+func (a *InternalAPIEngine) GetResp(arg APIArg) (*http.Response, func(), error) {
 	url1 := a.getURL(arg)
 	req, err := a.PrepareGet(url1, arg)
 	if err != nil {
-		return nil, err
+		return nil, nullFinisher, err
 	}
 
-	resp, _, err := doRequestShared(a, arg, req, false)
+	resp, finisher, _, err := doRequestShared(a, arg, req, false)
 	if err != nil {
-		return nil, err
+		return nil, finisher, err
 	}
 
-	return resp, nil
+	return resp, finisher, nil
 }
 
 // GetDecode performs a GET request and decodes the response via
 // JSON into the value pointed to by v.
 func (a *InternalAPIEngine) GetDecode(arg APIArg, v APIResponseWrapper) error {
-	resp, err := a.GetResp(arg)
+	resp, finisher, err := a.GetResp(arg)
 	if err != nil {
 		a.G().Log.CDebugf(arg.NetContext, "| API GetDecode, GetResp error: %s", err)
 		return err
 	}
-	defer DiscardAndCloseBody(resp)
+	defer finisher()
 	dec := json.NewDecoder(resp.Body)
 	if err = dec.Decode(&v); err != nil {
 		a.G().Log.CDebugf(arg.NetContext, "| API GetDecode, Decode error: %s", err)
@@ -692,29 +704,28 @@ func (a *InternalAPIEngine) PostJSON(arg APIArg) (*APIRes, error) {
 }
 
 // postResp performs a POST request and returns the http response.
-// The returned response, if non-nil, should have
-// DiscardAndCloseBody() called on it.
-func (a *InternalAPIEngine) postResp(arg APIArg) (*http.Response, error) {
+// The finisher() should be called after the response is no longer needed.
+func (a *InternalAPIEngine) postResp(arg APIArg) (*http.Response, func(), error) {
 	url1 := a.getURL(arg)
 	req, err := a.PrepareMethodWithBody("POST", url1, arg)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	resp, _, err := doRequestShared(a, arg, req, false)
+	resp, finisher, _, err := doRequestShared(a, arg, req, false)
 	if err != nil {
-		return nil, err
+		return nil, finisher, err
 	}
 
-	return resp, nil
+	return resp, finisher, nil
 }
 
 func (a *InternalAPIEngine) PostDecode(arg APIArg, v APIResponseWrapper) error {
-	resp, err := a.postResp(arg)
+	resp, finisher, err := a.postResp(arg)
 	if err != nil {
 		return err
 	}
-	defer DiscardAndCloseBody(resp)
+	defer finisher()
 	dec := json.NewDecoder(resp.Body)
 	if err = dec.Decode(&v); err != nil {
 		return err
@@ -744,11 +755,11 @@ func (a *InternalAPIEngine) Delete(arg APIArg) (*APIRes, error) {
 }
 
 func (a *InternalAPIEngine) DoRequest(arg APIArg, req *http.Request) (*APIRes, error) {
-	resp, jw, err := doRequestShared(a, arg, req, true)
+	resp, finisher, jw, err := doRequestShared(a, arg, req, true)
 	if err != nil {
 		return nil, err
 	}
-	defer DiscardAndCloseBody(resp)
+	defer finisher()
 
 	status, err := jw.AtKey("status").ToDictionary()
 	if err != nil {
@@ -824,12 +835,13 @@ func (api *ExternalAPIEngine) DoRequest(
 
 	var resp *http.Response
 	var jw *jsonw.Wrapper
+	var finisher func()
 
-	resp, jw, err = doRequestShared(api, arg, req, (restype == XAPIResJSON))
+	resp, finisher, jw, err = doRequestShared(api, arg, req, (restype == XAPIResJSON))
 	if err != nil {
 		return
 	}
-	defer DiscardAndCloseBody(resp)
+	defer finisher()
 
 	switch restype {
 	case XAPIResJSON:

--- a/go/libkb/api_mock_test.go
+++ b/go/libkb/api_mock_test.go
@@ -13,7 +13,7 @@ type NullMockAPI struct{}
 var _ API = (*NullMockAPI)(nil)
 
 func (n *NullMockAPI) Get(APIArg) (*APIRes, error)                        { return nil, nil }
-func (n *NullMockAPI) GetResp(APIArg) (*http.Response, func(), error)     { return nil, nullFinisher, nil }
+func (n *NullMockAPI) GetResp(APIArg) (*http.Response, func(), error)     { return nil, noopFinisher, nil }
 func (n *NullMockAPI) GetDecode(APIArg, APIResponseWrapper) error         { return nil }
 func (n *NullMockAPI) Post(APIArg) (*APIRes, error)                       { return nil, nil }
 func (n *NullMockAPI) PostJSON(APIArg) (*APIRes, error)                   { return nil, nil }

--- a/go/libkb/api_mock_test.go
+++ b/go/libkb/api_mock_test.go
@@ -13,7 +13,7 @@ type NullMockAPI struct{}
 var _ API = (*NullMockAPI)(nil)
 
 func (n *NullMockAPI) Get(APIArg) (*APIRes, error)                        { return nil, nil }
-func (n *NullMockAPI) GetResp(APIArg) (*http.Response, error)             { return nil, nil }
+func (n *NullMockAPI) GetResp(APIArg) (*http.Response, func(), error)     { return nil, nullFinisher, nil }
 func (n *NullMockAPI) GetDecode(APIArg, APIResponseWrapper) error         { return nil }
 func (n *NullMockAPI) Post(APIArg) (*APIRes, error)                       { return nil, nil }
 func (n *NullMockAPI) PostJSON(APIArg) (*APIRes, error)                   { return nil, nil }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -242,7 +242,7 @@ type ExternalAPIRes struct {
 
 type API interface {
 	Get(APIArg) (*APIRes, error)
-	GetResp(APIArg) (*http.Response, error)
+	GetResp(APIArg) (*http.Response, func(), error)
 	GetDecode(APIArg, APIResponseWrapper) error
 	Post(APIArg) (*APIRes, error)
 	PostJSON(APIArg) (*APIRes, error)

--- a/go/libkb/login_session_test.go
+++ b/go/libkb/login_session_test.go
@@ -57,8 +57,8 @@ func (a *FakeAPI) GetDecode(arg APIArg, v APIResponseWrapper) error {
 	return fmt.Errorf("GetDecode is phony")
 }
 
-func (a *FakeAPI) GetResp(APIArg) (*http.Response, error) {
-	return nil, fmt.Errorf("GetResp is phony")
+func (a *FakeAPI) GetResp(APIArg) (*http.Response, func(), error) {
+	return nil, nullFinisher, fmt.Errorf("GetResp is phony")
 }
 
 func (a *FakeAPI) Post(APIArg) (*APIRes, error) {

--- a/go/libkb/login_session_test.go
+++ b/go/libkb/login_session_test.go
@@ -58,7 +58,7 @@ func (a *FakeAPI) GetDecode(arg APIArg, v APIResponseWrapper) error {
 }
 
 func (a *FakeAPI) GetResp(APIArg) (*http.Response, func(), error) {
-	return nil, nullFinisher, fmt.Errorf("GetResp is phony")
+	return nil, noopFinisher, fmt.Errorf("GetResp is phony")
 }
 
 func (a *FakeAPI) Post(APIArg) (*APIRes, error) {

--- a/go/teams/get_test.go
+++ b/go/teams/get_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestTeamGet(t *testing.T) {
-	t.Skip("Flaky: CORE-5309")
 	tc := libkb.SetupTest(t, "team", 1)
 	tc.Tp.UpgradePerUserKey = true
 	defer tc.Cleanup()


### PR DESCRIPTION
- we were calling cancel() on an active http.Response, and so we sometimes failed to decode it via the JSON decoder
- band together `context.Cancel()` with `DiscardAndClose()`
- Reenable skipped tests