### PR TITLE
Attempt at fixing "Publicly follow? [Y/n]" when not logged in

### DIFF
--- a/go/client/cmd_pgp_encrypt.go
+++ b/go/client/cmd_pgp_encrypt.go
@@ -77,7 +77,7 @@ func (c *CmdPGPEncrypt) Run() error {
 	protocols := []rpc.Protocol{
 		NewStreamUIProtocol(c.G()),
 		NewSecretUIProtocol(c.G()),
-		NewIdentifyTrackUIProtocol(c.G()),
+		NewIdentifyMaybeTrackUIProtocol(c.G()),
 	}
 	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
 		return err

--- a/go/client/cmd_pgp_pull.go
+++ b/go/client/cmd_pgp_pull.go
@@ -28,7 +28,7 @@ func (v *CmdPGPPull) Run() (err error) {
 		return err
 	}
 	protocols := []rpc.Protocol{
-		NewIdentifyTrackUIProtocol(v.G()),
+		NewIdentifyMaybeTrackUIProtocol(v.G()),
 	}
 	if err = RegisterProtocolsWithContext(protocols, v.G()); err != nil {
 		return err

--- a/go/client/cmd_pgp_verify.go
+++ b/go/client/cmd_pgp_verify.go
@@ -59,7 +59,7 @@ func (c *CmdPGPVerify) Run() error {
 	protocols := []rpc.Protocol{
 		NewStreamUIProtocol(c.G()),
 		NewSecretUIProtocol(c.G()),
-		NewIdentifyTrackUIProtocol(c.G()),
+		NewIdentifyMaybeTrackUIProtocol(c.G()),
 		NewPgpUIProtocol(c.G()),
 	}
 	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {

--- a/go/client/identify_ui.go
+++ b/go/client/identify_ui.go
@@ -23,6 +23,30 @@ func NewIdentifyTrackUIProtocol(g *libkb.GlobalContext) rpc.Protocol {
 	return keybase1.IdentifyUiProtocol(&IdentifyUIServer{ui})
 }
 
+func cliIsLoggedIn(g *libkb.GlobalContext) bool {
+	configCli, err := GetConfigClient(g)
+	if err != nil {
+		return false
+	}
+
+	currentStatus, err := configCli.GetCurrentStatus(context.TODO(), 0)
+	if err != nil {
+		return false
+	}
+
+	return currentStatus.LoggedIn
+}
+
+// NewIdentifyMaybeTrackUIProtocol returns either IdentifyUiProtocol with
+// IdentifyTrackUI or IdentifyUI depending if user is logged in or not.
+func NewIdentifyMaybeTrackUIProtocol(g *libkb.GlobalContext) rpc.Protocol {
+	if !cliIsLoggedIn(g) {
+		return NewIdentifyUIProtocol(g)
+	}
+
+	return NewIdentifyTrackUIProtocol(g)
+}
+
 func (i *IdentifyUIServer) DelegateIdentifyUI(_ context.Context) (int, error) {
 	return 0, libkb.UIDelegationUnavailableError{}
 }

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -78,7 +78,7 @@ func (e *PGPEncrypt) Run(ctx *Context) error {
 
 		// or trying to encrypt for self
 		if !e.arg.NoSelf {
-			return libkb.LoginRequiredError{Context: "you must be logged in to encrypt for yourself"}
+			return libkb.LoginRequiredError{Context: "you must be logged in to encrypt for yourself (or use --no-self flag)"}
 		}
 	} else {
 		me, err := libkb.LoadMeByUID(ctx.GetNetContext(), e.G(), uid)


### PR DESCRIPTION
Decided to pick this one from PGP backlog yesterday.

Force TrackOptions.LocalOnly when not logged in. Fixes confusing message when doing `pgp encrypt` as unlogged user - "Publicly follow? [Y/n]", yes would not do anything anyway.

This might not be the best way to fix it, let me know.