### PR TITLE
Add PerUserKeyBackground engine

### DIFF
--- a/go/engine/context.go
+++ b/go/engine/context.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"fmt"
+
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
@@ -66,6 +67,13 @@ func (c *Context) GetNetContext() context.Context {
 
 func (c *Context) SetNetContext(netCtx context.Context) {
 	c.NetContext = netCtx
+}
+
+// A copy of the Context with the NetContext swapped out
+func (c *Context) WithNetContext(netCtx context.Context) *Context {
+	c2 := *c
+	c2.NetContext = netCtx
+	return &c2
 }
 
 func (c *Context) SecretKeyPromptArg(ska libkb.SecretKeyArg, reason string) libkb.SecretKeyPromptArg {

--- a/go/engine/per_user_key_background.go
+++ b/go/engine/per_user_key_background.go
@@ -77,9 +77,7 @@ func (e *PerUserKeyBackground) Prereqs() Prereqs {
 
 // RequiredUIs returns the required UIs.
 func (e *PerUserKeyBackground) RequiredUIs() []libkb.UIKind {
-	return []libkb.UIKind{
-		libkb.LogUIKind,
-	}
+	return []libkb.UIKind{}
 }
 
 // SubConsumers returns the other UI consumers for this engine.
@@ -142,7 +140,7 @@ func (e *PerUserKeyBackground) loop(ctx context.Context, ectx *Context) error {
 		if err != nil {
 			e.G().Log.CDebugf(ctx, "PerUserKeyBackground round(%v) error: %s", i, err)
 		} else {
-			e.G().Log.CDebugf(ctx, "PerUserKeyBackground round(%v) complete", i, err)
+			e.G().Log.CDebugf(ctx, "PerUserKeyBackground round(%v) complete", i)
 		}
 		if e.args.testingRoundResCh != nil {
 			e.args.testingRoundResCh <- err

--- a/go/engine/per_user_key_background.go
+++ b/go/engine/per_user_key_background.go
@@ -1,0 +1,194 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// PerUserKeyBackground runs PerUserKeyUpgrade in the background once in a while.
+// It brings users without per-user-keys up to having them.
+// Note that this engine is long-lived and potentially has to deal with being
+// logged out and logged in as a different user, etc.
+
+package engine
+
+import (
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	context "golang.org/x/net/context"
+)
+
+type PerUserKeyBackgroundSettings struct {
+	Start    time.Duration
+	WakeUp   time.Duration
+	Interval time.Duration
+	Limit    time.Duration
+}
+
+var PerUserKeyBackgroundDefaultSettings = PerUserKeyBackgroundSettings{
+	// Wait after starting the app
+	Start: 30 * time.Second,
+	// When waking up on mobile lots of timers will go off at once. We wait an additional
+	// delay so as not to add to that herd and slow down the mobile experience when opening the app.
+	WakeUp: 10 * time.Second,
+	// Wait between checks
+	Interval: 1 * time.Hour,
+	// Time limit on each round
+	Limit: 5 * time.Minute,
+}
+
+// PerUserKeyBackground is an engine.
+type PerUserKeyBackground struct {
+	libkb.Contextified
+	sync.Mutex
+
+	args *PerUserKeyBackgroundArgs
+
+	shutdown bool
+	// Function to cancel the background context.
+	// Can be nil before RunEngine exits
+	shutdownFunc context.CancelFunc
+}
+
+type PerUserKeyBackgroundArgs struct {
+	Settings PerUserKeyBackgroundSettings
+
+	// Channels used for testing. Normally nil.
+	testingMetaCh     chan<- string
+	testingRoundResCh chan<- error
+}
+
+// NewPerUserKeyBackground creates a PerUserKeyBackground engine.
+func NewPerUserKeyBackground(g *libkb.GlobalContext, args *PerUserKeyBackgroundArgs) *PerUserKeyBackground {
+	return &PerUserKeyBackground{
+		Contextified: libkb.NewContextified(g),
+		args:         args,
+		shutdownFunc: nil,
+	}
+}
+
+// Name is the unique engine name.
+func (e *PerUserKeyBackground) Name() string {
+	return "PerUserKeyBackground"
+}
+
+// GetPrereqs returns the engine prereqs.
+func (e *PerUserKeyBackground) Prereqs() Prereqs {
+	return Prereqs{}
+}
+
+// RequiredUIs returns the required UIs.
+func (e *PerUserKeyBackground) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{
+		libkb.LogUIKind,
+	}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *PerUserKeyBackground) SubConsumers() []libkb.UIConsumer {
+	return []libkb.UIConsumer{&PerUserKeyUpgrade{}}
+}
+
+// Run starts the engine.
+// Returns immediately, kicks off a background goroutine.
+func (e *PerUserKeyBackground) Run(ectx *Context) (err error) {
+	ctx := ectx.NetContext
+	defer e.G().CTrace(ctx, "PerUserKeyBackground", func() error { return err })()
+
+	// use a new background context with a saved cancel function
+	ctx, cancel := context.WithCancel(context.Background())
+
+	e.Lock()
+	defer e.Unlock()
+
+	e.shutdownFunc = cancel
+	if e.shutdown {
+		// Shutdown before started
+		cancel()
+		e.meta("early-shutdown")
+		return nil
+	}
+
+	// start the loop and return
+	go func() {
+		e.meta("loop-start")
+		err := e.loop(ctx, ectx)
+		if err != nil {
+			e.G().Log.CDebugf(ctx, "PerUserKeyBackground loop error: %s", err)
+		}
+		cancel()
+		e.meta("loop-exit")
+	}()
+
+	return nil
+}
+
+func (e *PerUserKeyBackground) Shutdown() {
+	e.Lock()
+	defer e.Unlock()
+	e.shutdown = true
+	if e.shutdownFunc != nil {
+		e.shutdownFunc()
+	}
+}
+
+func (e *PerUserKeyBackground) loop(ctx context.Context, ectx *Context) error {
+	if err := libkb.SleepWithContext(ctx, e.G().Clock(), e.args.Settings.Start); err != nil {
+		return err
+	}
+	e.meta("woke-start")
+	var i int
+	for {
+		i++
+		err := e.round(ctx, ectx)
+		if err != nil {
+			e.G().Log.CDebugf(ctx, "PerUserKeyBackground round(%v) error: %s", i, err)
+		} else {
+			e.G().Log.CDebugf(ctx, "PerUserKeyBackground round(%v) complete", i, err)
+		}
+		if e.args.testingRoundResCh != nil {
+			e.args.testingRoundResCh <- err
+		}
+		if err := libkb.SleepWithContext(ctx, e.G().Clock(), e.args.Settings.Interval); err != nil {
+			return err
+		}
+		e.meta("woke-interval")
+		if err := libkb.SleepWithContext(ctx, e.G().Clock(), e.args.Settings.WakeUp); err != nil {
+			return err
+		}
+		e.meta("woke-wakeup")
+	}
+}
+
+func (e *PerUserKeyBackground) round(ctx context.Context, ectx *Context) error {
+	ctx, cancel := context.WithTimeout(ctx, e.args.Settings.Limit)
+	defer cancel()
+
+	if !e.G().Env.GetUpgradePerUserKey() {
+		e.G().Log.CDebugf(ctx, "CheckUpgradePerUserKey disabled")
+		return nil
+	}
+
+	if e.G().ConnectivityMonitor.IsConnected(ctx) == libkb.ConnectivityMonitorNo {
+		e.G().Log.CDebugf(ctx, "CheckUpgradePerUserKey giving up offline")
+		return nil
+	}
+
+	// Do a fast local check to see if our work is done.
+	pukring, err := e.G().GetPerUserKeyring()
+	if err == nil {
+		if pukring.HasAnyKeys() {
+			e.G().Log.CDebugf(ctx, "CheckUpgradePerUserKey already has keys")
+			return nil
+		}
+	}
+
+	arg := &PerUserKeyUpgradeArgs{}
+	eng := NewPerUserKeyUpgrade(e.G(), arg)
+	err = RunEngine(eng, ectx)
+	return err
+}
+
+func (e *PerUserKeyBackground) meta(s string) {
+	if e.args.testingMetaCh != nil {
+		e.args.testingMetaCh <- s
+	}
+}

--- a/go/engine/per_user_key_background.go
+++ b/go/engine/per_user_key_background.go
@@ -181,7 +181,7 @@ func (e *PerUserKeyBackground) round(ctx context.Context, ectx *Context) error {
 
 	arg := &PerUserKeyUpgradeArgs{}
 	eng := NewPerUserKeyUpgrade(e.G(), arg)
-	err = RunEngine(eng, ectx)
+	err = RunEngine(eng, ectx.WithNetContext(ctx))
 	return err
 }
 

--- a/go/engine/per_user_key_background_test.go
+++ b/go/engine/per_user_key_background_test.go
@@ -1,0 +1,373 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+// When stopped before RunEngine, the inner loop never runs.
+func TestPerUserKeyBackgroundShutdownFirst(t *testing.T) {
+	tc := SetupEngineTest(t, "pukup")
+	defer tc.Cleanup()
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
+	tc.G.SetClock(fakeClock)
+
+	tc.Tp.UpgradePerUserKey = true
+
+	advance := func(d time.Duration) {
+		tc.G.Log.Debug("+ fakeClock#advance(%s) start: %s", d, fakeClock.Now())
+		fakeClock.Advance(d)
+		tc.G.Log.Debug("- fakeClock#adance(%s) end: %s", d, fakeClock.Now())
+	}
+
+	metaCh := make(chan string, 100)
+	arg := &PerUserKeyBackgroundArgs{
+		Settings:      PerUserKeyBackgroundDefaultSettings,
+		testingMetaCh: metaCh,
+	}
+	eng := NewPerUserKeyBackground(tc.G, arg)
+	ctx := &Context{
+		LogUI: tc.G.UI.GetLogUI(),
+	}
+
+	// shut down before starting
+	eng.Shutdown()
+
+	err := RunEngine(eng, ctx)
+	require.NoError(t, err)
+
+	expectMeta(t, metaCh, "early-shutdown")
+
+	advance(arg.Settings.Start)
+	advance(arg.Settings.Interval)
+	advance(arg.Settings.Interval)
+	advance(arg.Settings.Interval)
+	advance(arg.Settings.Interval)
+
+	expectMeta(t, metaCh, "")
+}
+
+// When stopped before the Start wait time, the loop starts but a round never runs.
+func TestPerUserKeyBackgroundShutdownSoon(t *testing.T) {
+	tc := SetupEngineTest(t, "pukup")
+	defer tc.Cleanup()
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
+	tc.G.SetClock(fakeClock)
+
+	tc.Tp.UpgradePerUserKey = true
+
+	advance := func(d time.Duration) {
+		tc.G.Log.Debug("+ fakeClock#advance(%s) start: %s", d, fakeClock.Now())
+		fakeClock.Advance(d)
+		tc.G.Log.Debug("- fakeClock#adance(%s) end: %s", d, fakeClock.Now())
+	}
+
+	metaCh := make(chan string, 100)
+	roundResCh := make(chan error, 100)
+	arg := &PerUserKeyBackgroundArgs{
+		Settings:          PerUserKeyBackgroundDefaultSettings,
+		testingMetaCh:     metaCh,
+		testingRoundResCh: roundResCh,
+	}
+	eng := NewPerUserKeyBackground(tc.G, arg)
+	ctx := &Context{
+		LogUI: tc.G.UI.GetLogUI(),
+	}
+	err := RunEngine(eng, ctx)
+	require.NoError(t, err)
+
+	expectMeta(t, metaCh, "loop-start")
+
+	advance(arg.Settings.Start - time.Second)
+
+	eng.Shutdown()
+
+	expectMeta(t, metaCh, "loop-exit")
+
+	advance(arg.Settings.Interval)
+	advance(arg.Settings.Interval)
+
+	expectMeta(t, metaCh, "")
+}
+
+// Shutting down after a few loop rounds should work.
+// Also test that LoginRequired comes out when there is no user.
+func TestPerUserKeyBackgroundShutdownMiddle(t *testing.T) {
+	tc := SetupEngineTest(t, "pukup")
+	defer tc.Cleanup()
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
+	tc.G.SetClock(fakeClock)
+
+	tc.Tp.UpgradePerUserKey = true
+
+	advance := func(d time.Duration) {
+		tc.G.Log.Debug("+ fakeClock#advance(%s) start: %s", d, fakeClock.Now())
+		fakeClock.Advance(d)
+		tc.G.Log.Debug("- fakeClock#adance(%s) end: %s", d, fakeClock.Now())
+	}
+
+	metaCh := make(chan string, 100)
+	roundResCh := make(chan error, 100)
+	arg := &PerUserKeyBackgroundArgs{
+		Settings:          PerUserKeyBackgroundDefaultSettings,
+		testingMetaCh:     metaCh,
+		testingRoundResCh: roundResCh,
+	}
+	eng := NewPerUserKeyBackground(tc.G, arg)
+	ctx := &Context{
+		LogUI: tc.G.UI.GetLogUI(),
+	}
+	err := RunEngine(eng, ctx)
+	require.NoError(t, err)
+
+	expectMeta(t, metaCh, "loop-start")
+	advance(arg.Settings.Start + time.Second)
+	expectMeta(t, metaCh, "woke-start")
+
+	n := 3
+	for i := 0; i < n; i++ {
+		t.Logf("check %v", i)
+		select {
+		case x := <-roundResCh:
+			require.Equal(t, libkb.LoginRequiredError{}, x, "round result")
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "channel timed out")
+		}
+		if i < n-1 {
+			advance(arg.Settings.Interval + time.Second)
+			expectMeta(t, metaCh, "woke-interval")
+			advance(arg.Settings.WakeUp + time.Second)
+			expectMeta(t, metaCh, "woke-wakeup")
+		}
+	}
+
+	eng.Shutdown()
+	expectMeta(t, metaCh, "loop-exit")
+
+	for i := 0; i < 2; i++ {
+		advance(arg.Settings.Interval)
+		select {
+		case x := <-roundResCh:
+			require.FailNow(t, "unexpected", x)
+		default:
+			// expected
+		}
+	}
+
+	expectMeta(t, metaCh, "")
+}
+
+func TestPerUserKeyBackgroundUnnecessary(t *testing.T) {
+	tc := SetupEngineTest(t, "pukup")
+	defer tc.Cleanup()
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
+	tc.G.SetClock(fakeClock)
+
+	tc.Tp.UpgradePerUserKey = true
+
+	_ = CreateAndSignupFakeUser(tc, "track")
+
+	t.Logf("user already has per-user-key")
+	checkPerUserKeyCount(&tc, 1)
+
+	advance := func(d time.Duration) {
+		tc.G.Log.Debug("+ fakeClock#advance(%s) start: %s", d, fakeClock.Now())
+		fakeClock.Advance(d)
+		tc.G.Log.Debug("- fakeClock#adance(%s) end: %s", d, fakeClock.Now())
+	}
+
+	metaCh := make(chan string, 100)
+	arg := &PerUserKeyBackgroundArgs{
+		Settings:      PerUserKeyBackgroundDefaultSettings,
+		testingMetaCh: metaCh,
+	}
+	eng := NewPerUserKeyBackground(tc.G, arg)
+	ctx := &Context{
+		LogUI: tc.G.UI.GetLogUI(),
+	}
+
+	// shut down before starting
+	eng.Shutdown()
+
+	err := RunEngine(eng, ctx)
+	require.NoError(t, err)
+
+	expectMeta(t, metaCh, "early-shutdown")
+
+	advance(arg.Settings.Start)
+	advance(arg.Settings.Interval)
+	advance(arg.Settings.Interval)
+	advance(arg.Settings.Interval)
+	advance(arg.Settings.Interval)
+
+	expectMeta(t, metaCh, "")
+
+	checkPerUserKeyCount(&tc, 1)
+}
+
+// The normal case of upgrading a user
+func TestPerUserKeyBackgroundWork(t *testing.T) {
+	tc := SetupEngineTest(t, "pukup")
+	defer tc.Cleanup()
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
+	tc.G.SetClock(fakeClock)
+
+	tc.Tp.UpgradePerUserKey = false
+
+	_ = CreateAndSignupFakeUser(tc, "track")
+
+	tc.Tp.UpgradePerUserKey = true
+
+	t.Logf("user has no per-user-key")
+	checkPerUserKeyCount(&tc, 0)
+
+	advance := func(d time.Duration) {
+		tc.G.Log.Debug("+ fakeClock#advance(%s) start: %s", d, fakeClock.Now())
+		fakeClock.Advance(d)
+		tc.G.Log.Debug("- fakeClock#adance(%s) end: %s", d, fakeClock.Now())
+	}
+
+	metaCh := make(chan string, 100)
+	roundResCh := make(chan error, 100)
+	arg := &PerUserKeyBackgroundArgs{
+		Settings:          PerUserKeyBackgroundDefaultSettings,
+		testingMetaCh:     metaCh,
+		testingRoundResCh: roundResCh,
+	}
+	eng := NewPerUserKeyBackground(tc.G, arg)
+	ctx := &Context{
+		LogUI: tc.G.UI.GetLogUI(),
+	}
+
+	err := RunEngine(eng, ctx)
+	require.NoError(t, err)
+
+	expectMeta(t, metaCh, "loop-start")
+	advance(arg.Settings.Start + time.Second)
+	expectMeta(t, metaCh, "woke-start")
+
+	select {
+	case x := <-roundResCh:
+		require.Equal(t, nil, x, "round result")
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "channel timed out")
+	}
+
+	// second run that doesn't do anything
+	advance(arg.Settings.Interval + time.Second)
+	expectMeta(t, metaCh, "woke-interval")
+	advance(arg.Settings.WakeUp + time.Second)
+	expectMeta(t, metaCh, "woke-wakeup")
+	select {
+	case x := <-roundResCh:
+		require.Equal(t, nil, x, "round result")
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "channel timed out")
+	}
+
+	checkPerUserKeyCount(&tc, 1)
+	checkPerUserKeyCountLocal(&tc, 1)
+
+	eng.Shutdown()
+	expectMeta(t, metaCh, "loop-exit")
+	expectMeta(t, metaCh, "")
+}
+
+// Test upgrading after running for a while and then logging in.
+func TestPerUserKeyBackgroundLoginLate(t *testing.T) {
+	tc := SetupEngineTest(t, "pukup")
+	defer tc.Cleanup()
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
+	tc.G.SetClock(fakeClock)
+
+	tc.Tp.UpgradePerUserKey = true
+
+	t.Logf("user has no per-user-key")
+
+	advance := func(d time.Duration) {
+		tc.G.Log.Debug("+ fakeClock#advance(%s) start: %s", d, fakeClock.Now())
+		fakeClock.Advance(d)
+		tc.G.Log.Debug("- fakeClock#adance(%s) end: %s", d, fakeClock.Now())
+	}
+
+	metaCh := make(chan string, 100)
+	roundResCh := make(chan error, 100)
+	arg := &PerUserKeyBackgroundArgs{
+		Settings:          PerUserKeyBackgroundDefaultSettings,
+		testingMetaCh:     metaCh,
+		testingRoundResCh: roundResCh,
+	}
+	eng := NewPerUserKeyBackground(tc.G, arg)
+	ctx := &Context{
+		LogUI: tc.G.UI.GetLogUI(),
+	}
+
+	err := RunEngine(eng, ctx)
+	require.NoError(t, err)
+
+	expectMeta(t, metaCh, "loop-start")
+	advance(arg.Settings.Start + time.Second)
+	expectMeta(t, metaCh, "woke-start")
+
+	t.Logf("run once while not logged in")
+	select {
+	case x := <-roundResCh:
+		require.Equal(t, libkb.LoginRequiredError{}, x, "round result")
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "channel timed out")
+	}
+
+	t.Logf("sign up and in")
+	tc.Tp.UpgradePerUserKey = false
+	_ = CreateAndSignupFakeUser(tc, "track")
+	checkPerUserKeyCount(&tc, 0)
+
+	tc.Tp.UpgradePerUserKey = true
+
+	t.Logf("second run upgrades the user")
+	advance(arg.Settings.Interval + time.Second)
+	expectMeta(t, metaCh, "woke-interval")
+	advance(arg.Settings.WakeUp + time.Second)
+	expectMeta(t, metaCh, "woke-wakeup")
+	select {
+	case x := <-roundResCh:
+		require.Equal(t, nil, x, "round result")
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "channel timed out")
+	}
+
+	checkPerUserKeyCount(&tc, 1)
+	checkPerUserKeyCountLocal(&tc, 1)
+
+	eng.Shutdown()
+	expectMeta(t, metaCh, "loop-exit")
+	expectMeta(t, metaCh, "")
+}
+
+func expectMeta(t *testing.T, metaCh <-chan string, s string) {
+	t.Logf("expect meta: %q", s)
+	if s == "" {
+		// assert that there is nothing on the channel
+		// this can false-happy because it doesn't wait for the channel
+		select {
+		case x := <-metaCh:
+			require.FailNow(t, "unexpected", x)
+		default:
+			// expected
+		}
+	} else {
+		select {
+		case x := <-metaCh:
+			require.Equal(t, s, x)
+		case <-time.After(time.Second):
+			require.FailNow(t, "channel timed out")
+		}
+	}
+}

--- a/go/engine/per_user_key_upgrade.go
+++ b/go/engine/per_user_key_upgrade.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
 // PerUserKeyUpgrade creates a per-user-key for the active user
@@ -48,7 +48,6 @@ func (e *PerUserKeyUpgrade) Prereqs() Prereqs {
 func (e *PerUserKeyUpgrade) RequiredUIs() []libkb.UIKind {
 	return []libkb.UIKind{
 		libkb.LogUIKind,
-		libkb.SecretUIKind,
 	}
 }
 

--- a/go/engine/per_user_key_upgrade.go
+++ b/go/engine/per_user_key_upgrade.go
@@ -46,9 +46,7 @@ func (e *PerUserKeyUpgrade) Prereqs() Prereqs {
 
 // RequiredUIs returns the required UIs.
 func (e *PerUserKeyUpgrade) RequiredUIs() []libkb.UIKind {
-	return []libkb.UIKind{
-		libkb.LogUIKind,
-	}
+	return []libkb.UIKind{}
 }
 
 // SubConsumers returns the other UI consumers for this engine.
@@ -91,11 +89,11 @@ func (e *PerUserKeyUpgrade) inner(ctx *Context) error {
 
 	sigKey, err := e.G().ActiveDevice.SigningKey()
 	if err != nil {
-		return err
+		return fmt.Errorf("signing key not found: (%v)", err)
 	}
 	encKey, err := e.G().ActiveDevice.EncryptionKey()
 	if err != nil {
-		return err
+		return fmt.Errorf("encryption key not found: (%v)", err)
 	}
 
 	pukring, err := e.G().GetPerUserKeyring()

--- a/go/engine/per_user_key_upgrade_test.go
+++ b/go/engine/per_user_key_upgrade_test.go
@@ -20,23 +20,7 @@ func TestPerUserKeyUpgrade(t *testing.T) {
 
 	fu := CreateAndSignupFakeUserPaper(tc, "pukup")
 
-	checkPerUserKeyCount := func(n int) {
-		me, err := libkb.LoadMe(libkb.NewLoadUserForceArg(tc.G))
-		require.NoError(t, err)
-		require.Len(t, me.ExportToUserPlusKeys(keybase1.Time(0)).PerUserKeys, n, "per-user-key count")
-	}
-
-	checkPerUserKeyCountLocal := func(n int) {
-		pukring, err := tc.G.GetPerUserKeyring()
-		require.NoError(t, err)
-		if n == 0 {
-			require.False(t, pukring.HasAnyKeys(), "unexpectedly has per-user-key")
-		} else {
-			require.Equal(t, keybase1.PerUserKeyGeneration(n), pukring.CurrentGeneration(), "wrong latest per-user-key generation")
-		}
-	}
-
-	checkPerUserKeyCount(0)
+	checkPerUserKeyCount(&tc, 0)
 
 	tc.Tp.UpgradePerUserKey = true
 
@@ -45,8 +29,7 @@ func TestPerUserKeyUpgrade(t *testing.T) {
 		arg := &PerUserKeyUpgradeArgs{}
 		eng := NewPerUserKeyUpgrade(tc.G, arg)
 		ctx := &Context{
-			LogUI:    tc.G.UI.GetLogUI(),
-			SecretUI: fu.NewSecretUI(),
+			LogUI: tc.G.UI.GetLogUI(),
 		}
 		err := RunEngine(eng, ctx)
 		require.NoError(t, err)
@@ -54,16 +37,38 @@ func TestPerUserKeyUpgrade(t *testing.T) {
 	}
 	require.True(t, upgrade().DidNewKey, "created key")
 
-	checkPerUserKeyCountLocal(1)
-	checkPerUserKeyCount(1)
+	checkPerUserKeyCountLocal(&tc, 1)
+	checkPerUserKeyCount(&tc, 1)
 
 	t.Logf("revoke paper key")
 	revokeAnyPaperKey(tc, fu)
 
 	t.Logf("should be on gen 2")
-	checkPerUserKeyCountLocal(2)
-	checkPerUserKeyCount(2)
+	checkPerUserKeyCountLocal(&tc, 2)
+	checkPerUserKeyCount(&tc, 2)
 
 	t.Logf("run the upgrade engine again. Expect an error because the user is already up.")
 	require.False(t, upgrade().DidNewKey, "did not create key")
+}
+
+func checkPerUserKeyCount(tc *libkb.TestContext, n int) {
+	t := tc.T
+	me, err := libkb.LoadMe(libkb.NewLoadUserForceArg(tc.G))
+	require.NoError(t, err)
+	require.Len(t, me.ExportToUserPlusKeys(keybase1.Time(0)).PerUserKeys, n, "per-user-key count")
+}
+
+func checkPerUserKeyCountLocal(tc *libkb.TestContext, n int) {
+	t := tc.T
+	pukring, err := tc.G.GetPerUserKeyring()
+	require.NoError(t, err)
+	hak := pukring.HasAnyKeys()
+	if n == 0 {
+		require.False(t, hak, "unexpectedly has per-user-key")
+	} else {
+		if !hak {
+			require.FailNow(t, "has no per-user-keys")
+		}
+		require.Equal(t, keybase1.PerUserKeyGeneration(n), pukring.CurrentGeneration(), "wrong latest per-user-key generation")
+	}
 }

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -610,3 +610,20 @@ func MakeByte32Soft(a []byte) ([32]byte, error) {
 	copy(b[:], a)
 	return b, nil
 }
+
+// Sleep for `duration` or until `ctx` is canceled, whichever occurs first.
+// Returns an error BUT the error is not really an error.
+// It is nil if the sleep finished, and the non-nil result of Context.Err()
+func SleepWithContext(ctx context.Context, clock clockwork.Clock, duration time.Duration) error {
+	if ctx == nil {
+		// should not happen
+		clock.Sleep(duration)
+		return nil
+	}
+	select {
+	case <-clock.After(duration):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -473,7 +473,7 @@ func (d *Service) runBackgroundIdentifierWithUID(u keybase1.UID) {
 
 func (d *Service) runBackgroundPerUserKeyUpgrade() {
 	if !d.G().Env.GetUpgradePerUserKey() {
-		d.G().Log.Debug("PerUserKeyBackground disabled")
+		d.G().Log.Debug("PerUserKeyBackground disabled (not starting)")
 		return
 	}
 
@@ -484,7 +484,9 @@ func (d *Service) runBackgroundPerUserKeyUpgrade() {
 	go func() {
 		ectx := &engine.Context{NetContext: context.Background()}
 		err := engine.RunEngine(eng, ectx)
-		d.G().Log.Warning("per-user-key background upgrade error: %s", err)
+		if err != nil {
+			d.G().Log.Warning("per-user-key background upgrade error: %v", err)
+		}
 	}()
 
 	d.G().PushShutdownHook(func() error {
@@ -492,9 +494,6 @@ func (d *Service) runBackgroundPerUserKeyUpgrade() {
 		eng.Shutdown()
 		return nil
 	})
-
-	// TODO consider other hooks
-	// d.G().AddUserChangedHandler(newBgi)
 }
 
 func (d *Service) OnLogin() error {


### PR DESCRIPTION
Adds an engine `PerUserKeyBackground` that `service/main` starts. That thing runs `PerUserKeyUpgrade` 30 seconds after startup and once an hour in the background. Most of the time it runs it should be a cheap  no-op because the local per-user-keyring will tell it to go to sleep.

The background engine has to deal with running while a logout or switching users could happen. I didn't put anything special in for that, do you think it's safe?