### PR TITLE
search v3 results list

### DIFF
--- a/shared/constants/entities.js
+++ b/shared/constants/entities.js
@@ -3,6 +3,7 @@ import {Map, Record} from 'immutable'
 
 import type {NoErrorTypedAction} from './types/flux'
 import type {DeviceDetailRecord} from './devices'
+import type {State as SearchState} from './searchv3'
 
 export type EntityType = any // TODO stronger typing?
 
@@ -22,10 +23,14 @@ export type Actions = Delete | Merge | Replace
 // State
 export type State = Record<{
   devices: Map<string, DeviceDetailRecord>,
+  searchv3Chat: Map<string, SearchState>,
+  searchv3Profile: Map<string, SearchState>,
 }>
 
 const StateRecord = Record({
   devices: Map(),
+  searchv3Chat: Map(),
+  searchv3Profile: Map(),
 })
 
 export {StateRecord}

--- a/shared/constants/searchv3.js
+++ b/shared/constants/searchv3.js
@@ -1,4 +1,8 @@
 // @flow
+import {List} from 'immutable'
+
+import type {IconType} from '../common-adapters/icon'
+
 const services: {[service: string]: true} = {
   Facebook: true,
   GitHub: true,
@@ -9,3 +13,29 @@ const services: {[service: string]: true} = {
 }
 
 export type Service = $Keys<typeof services>
+
+export type FollowingState = 'Following' | 'NotFollowing' | 'NoState' | 'You'
+
+export type RowProps = {|
+  id: string,
+
+  leftFollowingState: FollowingState,
+  leftIcon: IconType,
+  leftService: Service,
+  leftUsername: string,
+
+  rightFollowingState: FollowingState,
+  rightFullname: ?string,
+  rightIcon: ?IconType,
+  rightService: ?Service,
+  rightUsername: ?string,
+
+  showTrackerButton: boolean,
+
+  onShowTracker: () => void,
+|}
+
+export type State = {|
+  // TODO selected, typing, etc
+  rows: List<RowProps>,
+|}

--- a/shared/searchv3/dumb.js
+++ b/shared/searchv3/dumb.js
@@ -1,6 +1,10 @@
 // @flow
 import ServicesFilter from './services-filter'
 import ResultRow from './result-row'
+import ResultsList from './results-list'
+import {StateRecord as EntitiesStateRecord} from '../constants/entities'
+import {Map} from 'immutable'
+
 import type {DumbComponentMap} from '../constants/types/more'
 
 const commonServicesFilterMapProps = {
@@ -171,7 +175,86 @@ const servicesResultMap: DumbComponentMap<ResultRow> = {
   },
 }
 
+const servicesResultsListMapCommonRows = {
+  chris: {
+    ...commonServicesResultMapPropsKB,
+    leftFollowingState: 'Following',
+    leftUsername: 'chris',
+    rightFullname: 'chris on GitHub',
+    rightIcon: 'iconfont-identity-github',
+    rightService: 'GitHub',
+    rightUsername: 'chrisname',
+  },
+  cjb: {
+    ...commonServicesResultMapPropsKB,
+    leftFollowingState: 'NotFollowing',
+    leftUsername: 'cjb',
+    rightFullname: 'cjb on facebook',
+    rightIcon: 'iconfont-identity-facebook',
+    rightService: 'Facebook',
+    rightUsername: 'cjbname',
+  },
+  jzila: {
+    ...commonServicesResultMapPropsKB,
+    leftFollowingState: 'NoState',
+    leftUsername: 'jzila',
+    rightFullname: 'jzila on twitter',
+    rightIcon: 'iconfont-identity-twitter',
+    rightService: 'Twitter',
+    rightUsername: 'jzilatwit',
+  },
+}
+
+Object.keys(servicesResultsListMapCommonRows).forEach(name => {
+  servicesResultsListMapCommonRows[name + '-fb'] = {
+    ...servicesResultsListMapCommonRows[name],
+    leftFollowingState: 'NoState',
+    leftIcon: 'icon-facebook-logo-24',
+    leftService: 'Facebook',
+  }
+})
+
+const servicesResultsListMapCommon = {
+  mockStore: {
+    entities: new EntitiesStateRecord({
+      searchv3Chat: Map(servicesResultsListMapCommonRows),
+    }),
+  },
+  parentProps: {
+    style: {
+      width: 420,
+    },
+  },
+}
+
+const servicesResultsListMap: DumbComponentMap<ResultsList> = {
+  component: ResultsList,
+  mocks: {
+    keybaseResults: {
+      ...servicesResultsListMapCommon,
+      items: ['chris', 'cjb', 'jzila'],
+      keyPath: ['searchv3Chat'],
+    },
+    keybaseResultsOne: {
+      ...servicesResultsListMapCommon,
+      items: ['chris'],
+      keyPath: ['searchv3Chat'],
+    },
+    facebookResults: {
+      ...servicesResultsListMapCommon,
+      items: ['chris-fb', 'cjb-fb', 'jzila-fb'],
+      keyPath: ['searchv3Chat'],
+    },
+    noResults: {
+      ...servicesResultsListMapCommon,
+      items: [],
+      keyPath: ['searchv3Chat'],
+    },
+  },
+}
+
 export default {
   'SearchV3 filter': servicesFilterMap,
   'SearchV3 result': servicesResultMap,
+  'SearchV3 resultsList': servicesResultsListMap,
 }

--- a/shared/searchv3/result-row/container.js
+++ b/shared/searchv3/result-row/container.js
@@ -4,12 +4,19 @@ import SearchResultRow from '.'
 
 import type {TypedState} from '../../constants/reducer'
 
-// TODO use entities
-const mapStateToProps = (state: TypedState, id: string) => {
-  return {}
+const mapStateToProps = (state: TypedState, {id, keyPath}: {id: string, keyPath: Array<string>}) => {
+  return {
+    // $FlowIssue doesnt like getIn
+    ...state.entities.getIn(keyPath.concat([id])),
+  }
 }
 
 // TODO
 const mapDispatchToProps = (dispatch: Dispatch) => ({})
 
-export default connect(mapStateToProps, mapDispatchToProps)(SearchResultRow)
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  ...stateProps,
+  ...dispatchProps,
+})
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(SearchResultRow)

--- a/shared/searchv3/result-row/index.js
+++ b/shared/searchv3/result-row/index.js
@@ -4,35 +4,12 @@ import React from 'react'
 import {Avatar, Box, Icon, ClickableBox, Text} from '../../common-adapters'
 import {globalColors, globalStyles, globalMargins} from '../../styles'
 
-import type {IconType} from '../../common-adapters/icon'
-
-type FollowingState = 'Following' | 'NotFollowing' | 'NoState' | 'You'
-
-export type Props = {|
-  id: string,
-
-  leftFollowingState: FollowingState,
-  leftIcon: IconType,
-  leftService: Constants.Service,
-  leftUsername: string,
-
-  rightFollowingState: FollowingState,
-  rightFullname: ?string,
-  rightIcon: ?IconType,
-  rightService: ?Constants.Service,
-  rightUsername: ?string,
-
-  showTrackerButton: boolean,
-
-  onShowTracker: () => void,
-|}
-
 const IconOrAvatar = ({service, username, icon, avatarSize, style}) =>
   service === 'Keybase'
     ? <Avatar username={username} size={avatarSize} style={style} />
     : icon ? <Icon type={icon} style={style} /> : null
 
-const followingStateToStyle = (followingState: FollowingState) => {
+const followingStateToStyle = (followingState: Constants.FollowingState) => {
   return {
     Following: {
       color: globalColors.green2,
@@ -139,7 +116,7 @@ const Line = () => (
   />
 )
 
-const SearchResultRow = (props: Props) => {
+const SearchResultRow = (props: Constants.RowProps) => {
   return (
     <ClickableBox style={_clickableBoxStyle} underlayColor={globalColors.blue4}>
       <Box style={_rowStyle}>

--- a/shared/searchv3/results-list/container.js
+++ b/shared/searchv3/results-list/container.js
@@ -1,0 +1,15 @@
+// @flow
+import {connect} from 'react-redux'
+import SearchResultsList from '.'
+
+import type {TypedState} from '../../constants/reducer'
+
+// TODO use entities
+const mapStateToProps = (state: TypedState, id: string) => {
+  return {}
+}
+
+// TODO
+const mapDispatchToProps = (dispatch: Dispatch) => ({})
+
+export default connect(mapStateToProps, mapDispatchToProps)(SearchResultsList)

--- a/shared/searchv3/results-list/index.desktop.js
+++ b/shared/searchv3/results-list/index.desktop.js
@@ -1,0 +1,48 @@
+// @flow
+import React, {Component} from 'react'
+import ReactList from 'react-list'
+import Row from '../result-row/container'
+import {Box, Text} from '../../common-adapters'
+import {globalStyles} from '../../styles'
+
+import type {Props} from '.'
+
+const owl = `
+ ,___,
+ [O.o]
+ /)__)
+ -"--"-`
+
+class SearchResultsList extends Component<void, Props, void> {
+  _itemRenderer = index => {
+    const id = this.props.items[index]
+    return <Row id={id} key={id} keyPath={this.props.keyPath} />
+  }
+
+  render() {
+    const {style, items} = this.props
+
+    // TODO maybe move to container so this is shared
+    if (!items.length) {
+      return (
+        <Box style={{...globalStyles.flexBoxCenter, ...globalStyles.flexBoxColumn, height: 256, ...style}}>
+          <Text type="BodySmallSemibold">Sorry, no humans match this.</Text>
+          <Text type="BodySmallSemibold" style={{whiteSpace: 'pre', textAlign: 'center'}}>{owl}</Text>
+        </Box>
+      )
+    }
+    return (
+      <Box style={{width: '100%', height: 256, ...style}}>
+        <ReactList
+          useTranslate3d={true}
+          useStaticSize={true}
+          itemRenderer={this._itemRenderer}
+          length={items.length}
+          type="uniform"
+        />
+      </Box>
+    )
+  }
+}
+
+export default SearchResultsList

--- a/shared/searchv3/results-list/index.js.flow
+++ b/shared/searchv3/results-list/index.js.flow
@@ -1,0 +1,10 @@
+// @flow
+import {Component} from 'react'
+
+export type Props = {
+  style?: any,
+  keyPath: Array<string>,
+  items: Array<string>,
+}
+
+export default class ResultsList extends Component<void, Props, void> {}


### PR DESCRIPTION
This is the searchv3 results list. The implementation starts to make some assumption about the store state (entities) cc: @MarcoPolo 

Basically it knows about the keyPath in the entities map (so we can have chat/profile/etc not collide with each other) and holds the searchids. Then it holds connected rows (so this is very close to how it would actually work on a real page)

@keybase/react-hackers 