### PR TITLE
always run identify in GUI mode, and throw error separately

### DIFF
--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -159,7 +159,7 @@ func (t *KBFSTLFInfoSource) PublicCanonicalTLFNameAndID(ctx context.Context, tlf
 		// skip identify:
 		query := keybase1.TLFQuery{
 			TlfName:          tlfName,
-			IdentifyBehavior: identBehavior,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_SKIP,
 		}
 
 		res, err = tlfClient.GetPublicCanonicalTLFNameAndID(ectx, query)

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -299,14 +299,15 @@ func (t *KBFSTLFInfoSource) identifyUser(ctx context.Context, assertion string, 
 		// Special treatment is needed for GUI strict mode, since we need to
 		// simultaneously plumb identify breaks up to the UI, and make sure the
 		// overall process returns an error. Swallow the error here so the rest of
-		// the identify can proceed, but we will check later for breaks with this
-		// mode and return an error
-		if idBehavior != keybase1.TLFIdentifyBehavior_CHAT_GUI_STRICT {
+		// the identify can proceed, but we will check later (in GetTLFCryptKeys) for breaks with this
+		// mode and return an error there.
+		if !(libkb.IsIdentifyProofError(err) &&
+			idBehavior == keybase1.TLFIdentifyBehavior_CHAT_GUI_STRICT) {
 			return keybase1.TLFIdentifyFailure{}, err
 		}
 	}
-
 	resp := eng.Result()
+
 	var frep keybase1.TLFIdentifyFailure
 	if resp != nil && resp.TrackBreaks != nil {
 		frep.User = keybase1.User{

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -290,10 +290,9 @@ func (e *Identify2WithUID) resetError(err error) error {
 		return nil
 	}
 
-	switch err.(type) {
-	case libkb.ProofError:
-	case libkb.IdentifySummaryError:
-	default:
+	// Check to see if this is an identify failure, and if not just return. If it is, we want
+	// to check what identify mode we are in here before returning an error.
+	if !libkb.IsIdentifyProofError(err) {
 		return err
 	}
 

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1349,6 +1349,18 @@ type IdentifySummaryError struct {
 	problems []string
 }
 
+func NewIdentifySummaryError(failure keybase1.TLFIdentifyFailure) IdentifySummaryError {
+	problem := "a followed proof failed"
+	if failure.Breaks != nil {
+		num := len(failure.Breaks.Proofs)
+		problem = fmt.Sprintf("%d followed proof%s failed", num, GiveMeAnS(num))
+	}
+	return IdentifySummaryError{
+		username: NewNormalizedUsername(failure.User.Username),
+		problems: []string{problem},
+	}
+}
+
 func (e IdentifySummaryError) Error() string {
 	return fmt.Sprintf("failed to identify %q: %s",
 		e.username,

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1371,6 +1371,17 @@ func (e IdentifySummaryError) IsImmediateFail() (chat1.OutboxErrorType, bool) {
 	return chat1.OutboxErrorType_IDENTIFY, true
 }
 
+func IsIdentifyProofError(err error) bool {
+	switch err.(type) {
+	case ProofError:
+	case IdentifySummaryError:
+		return true
+	default:
+		return false
+	}
+	return false
+}
+
 //=============================================================================
 
 type NotLatestSubchainError struct {


### PR DESCRIPTION
Always run the identify for `GetTLFCryptKeys` with `TLFIdentifyBehavior_CHAT_GUI` mode, and detect errors that we get back one level up if we are in some mode where breaks should be errors. This allows us to get the red banner on the screen on a chat send attempt with a proof failure. 