### PR TITLE
dont send UI notifications about chat activity on dev topic types

### DIFF
--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -357,12 +357,20 @@ func (c ConversationLocal) GetConvID() ConversationID {
 	return c.Info.Id
 }
 
+func (c ConversationLocal) GetTopicType() TopicType {
+	return c.Info.Triple.TopicType
+}
+
 func (c Conversation) GetMtime() gregor1.Time {
 	return c.ReaderInfo.Mtime
 }
 
 func (c Conversation) GetConvID() ConversationID {
 	return c.Metadata.ConversationID
+}
+
+func (c Conversation) GetTopicType() TopicType {
+	return c.Metadata.IdTriple.TopicType
 }
 
 func (c Conversation) GetMaxMessage(typ MessageType) (MessageSummary, error) {


### PR DESCRIPTION
Throwing these notifications causes the conversation to pop into the UI view, let's just not send any notifications if the topic type is `dev`.