### PR TITLE
Fix team membership in player

### DIFF
--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -775,7 +775,8 @@ func (t *TeamSigChainPlayer) checkStubbed(state TeamSigChainState) error {
 
 // Check that all the users are formatted correctly.
 // Check that there are no duplicate members.
-// `firstLink` is whether this is seqno=1. In which case owners must exist.
+// Do not check that all removals are members. That should be true, but not strictly enforced when reading.
+// `firstLink` is whether this is seqno=1. In which case owners must exist. And removals must not exist.
 // Rotates to a map which has entries for the roles that actually appeared in the input, even if they are empty lists.
 // In other words, if the input has only `admin -> []` then the output will have only `admin` in the map.
 func (t *TeamSigChainPlayer) sanityCheckMembers(members SCTeamMembers, firstLink bool) (map[keybase1.TeamRole][]UserVersion, error) {
@@ -791,6 +792,9 @@ func (t *TeamSigChainPlayer) sanityCheckMembers(members SCTeamMembers, firstLink
 		}
 		if len(*members.Owners) < 1 {
 			return nil, fmt.Errorf("team has no owners: %+v", members)
+		}
+		if members.None != nil && len(*members.None) != 0 {
+			return nil, fmt.Errorf("team has removals in root link: %+v", members)
 		}
 	}
 
@@ -819,6 +823,12 @@ func (t *TeamSigChainPlayer) sanityCheckMembers(members SCTeamMembers, firstLink
 		res[keybase1.TeamRole_READER] = nil
 		for _, m := range *members.Readers {
 			all = append(all, assignment{m, keybase1.TeamRole_READER})
+		}
+	}
+	if members.None != nil {
+		res[keybase1.TeamRole_NONE] = nil
+		for _, m := range *members.None {
+			all = append(all, assignment{m, keybase1.TeamRole_NONE})
 		}
 	}
 
@@ -893,31 +903,12 @@ func (t *TeamSigChainPlayer) makeInitialUserLog(roleUpdates map[keybase1.TeamRol
 }
 
 // Update `userLog` with the membership in roleUpdates.
-// Users already in `userLog` who do not appear in `roleUpdates` and whose role does not appear in `roleUpdates` are unaffected.
-// Users already in `userLog` who do not appear in `roleUpdates` but whose role does appear in `roleUpdates` are kicked out the team.
-// Users already in `userLog` who appear with a different role than before are updated to that new role.
+// The `NONE` list removes users.
+// The other lists add users.
 func (t *TeamSigChainPlayer) updateMembership(userLog *UserLog, roleUpdates map[keybase1.TeamRole][]UserVersion, seqno keybase1.Seqno) {
-	// Set of users that were already processed
-	processed := make(map[UserVersion]bool)
-
 	for role, uvs := range roleUpdates {
 		for _, uv := range uvs {
 			userLog.inform(uv, role, seqno)
-			processed[uv] = true
 		}
 	}
-
-	// Kick users who were not processed and whose role is mentioned in roleUpdates.
-	for uv := range *userLog {
-		if !processed[uv] {
-			role := (*userLog).getUserRole(uv)
-			if role != keybase1.TeamRole_NONE {
-				_, mentioned := roleUpdates[role]
-				if mentioned {
-					userLog.inform(uv, keybase1.TeamRole_NONE, seqno)
-				}
-			}
-		}
-	}
-
 }

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -31,6 +31,7 @@ type SCTeamMembers struct {
 	Admins  *[]SCTeamMember `json:"admin,omitempty"`
 	Writers *[]SCTeamMember `json:"writer,omitempty"`
 	Readers *[]SCTeamMember `json:"reader,omitempty"`
+	None    *[]SCTeamMember `json:"none,omitempty"`
 }
 
 type SCTeamParent struct {

--- a/go/teams/chain_test.go
+++ b/go/teams/chain_test.go
@@ -148,7 +148,7 @@ func TestTeamSigChainPlay2(t *testing.T) {
 
 	checkRole("d_b2809af7", keybase1.TeamRole_OWNER)
 	checkRole("c_ac088470", keybase1.TeamRole_ADMIN)
-	checkRole("b_ee111192", keybase1.TeamRole_NONE)   // removed
+	checkRole("b_ee111192", keybase1.TeamRole_WRITER)
 	checkRole("a_f0259e08", keybase1.TeamRole_WRITER) // changed role
 
 	xs, err := state.GetUsersWithRole(keybase1.TeamRole_OWNER)
@@ -156,7 +156,7 @@ func TestTeamSigChainPlay2(t *testing.T) {
 	require.Len(t, xs, 1)
 	xs, err = state.GetUsersWithRole(keybase1.TeamRole_WRITER)
 	require.NoError(t, err)
-	require.Len(t, xs, 1)
+	require.Len(t, xs, 2)
 	xs, err = state.GetUsersWithRole(keybase1.TeamRole_READER)
 	require.Len(t, xs, 0)
 }


### PR DESCRIPTION
Make it so that membership lists are additions, except None which removes. (In other words all the lists just set the user to that role).

The code can be simplified further, since dealing with this way is simpler. This is the minimal fix.