### PR TITLE
Support non-basic value types in maps

### DIFF
--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -29,10 +29,4 @@ protocol teams {
 
   TeamMembers teamGet(int sessionID, string name);
 
-  /* record BugBuster { */
-  /*   map<PublicKey> m1; */
-  /*   map<TeamRole,PublicKey> m2; */
-  /*   map<TeamRole,array<PublicKey>> m3; */
-  /* } */
-
 }

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -28,4 +28,11 @@ protocol teams {
   void teamCreate(int sessionID, string name);
 
   TeamMembers teamGet(int sessionID, string name);
+
+  /* record BugBuster { */
+  /*   map<PublicKey> m1; */
+  /*   map<TeamRole,PublicKey> m2; */
+  /*   map<TeamRole,array<PublicKey>> m3; */
+  /* } */
+
 }

--- a/protocol/bin/flow.js
+++ b/protocol/bin/flow.js
@@ -141,7 +141,7 @@ function figureType (type) {
       case 'array':
         return `?Array<${type.items}>`
       case 'map':
-        return `{[key: string]: ${type.values}}`
+        return `{[key: string]: ${figureType(type.values)}}`
       default:
         console.log(`Unknown type: ${type}`)
         return 'unknown'

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/keybase/protocol",
   "dependencies": {
     "avdl-compiler": "1.3.16",
-    "avdl2json": "2.2.3",
+    "avdl2json": "2.2.4",
     "bluebird": "^2.10.0",
     "camelcase": "^4.0.0",
     "colors": "^1.1.2",


### PR DESCRIPTION
I'm going to need map types with non-basic values in a sec. This adds support for them to the avdl -> flow step. They're already supported in avdl.

avdl:
```
record BugBuster {
    map<PublicKey> m1; 
    map<TeamRole,PublicKey> m2; 
    map<TeamRole,array<PublicKey>> m3; 
  }
```

flow:
```
export type BugBuster = {
  m1: {[key: string]: PublicKey},
  m2: {[key: string]: PublicKey},
  m3: {[key: string]: ?Array<PublicKey>}, // was broken
}
```