### PR TITLE
Fix inability to empty the bio/name/location field

### DIFF
--- a/shared/profile/edit-profile/index.js
+++ b/shared/profile/edit-profile/index.js
@@ -4,9 +4,23 @@ import {compose, withHandlers, withPropsOnChange, withState} from 'recompose'
 import {connect} from 'react-redux'
 import {editProfile} from '../../actions/profile'
 import {maxProfileBioChars} from '../../constants/profile'
+import type {TypedState} from '../../constants/reducer'
 import {navigateUp} from '../../actions/route-tree'
 
-const RenderWrapped = compose(
+const mapStateToProps = (state: TypedState) => {
+  // $FlowIssue
+  const userInfo = state.tracker.trackers[state.config.username].userInfo
+  const {bio, fullname, location} = userInfo
+  return {bio, fullname, location}
+}
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  onBack: () => dispatch(navigateUp()),
+  onEditProfile: ({bio, fullname, location}) => dispatch(editProfile(bio, fullname, location)),
+})
+
+export default compose(
+  connect(mapStateToProps, mapDispatchToProps),
   withState('bio', 'onBioChange', props => props.bio),
   withState('fullname', 'onFullnameChange', props => props.fullname),
   withState('location', 'onLocationChange', props => props.location),
@@ -17,26 +31,3 @@ const RenderWrapped = compose(
     onSubmit: ({bio, fullname, location, onSubmit}) => () => onSubmit({bio, fullname, location}),
   })
 )(Render)
-
-// $FlowIssue type this connector
-export default connect(
-  state => {
-    const userInfo = state.tracker.trackers[state.config.username].userInfo
-    const {bio, fullname, location} = userInfo
-    return {bio, fullname, location}
-  },
-  dispatch => {
-    return {
-      onBack: () => dispatch(navigateUp()),
-      onEditProfile: (bio, fullname, location) => dispatch(editProfile(bio, fullname, location)),
-    }
-  },
-  (stateProps, dispatchProps, ownProps) => ({
-    ...stateProps,
-    ...dispatchProps,
-    ...ownProps,
-    onEditProfile: ({bio, fullname, location}) => {
-      dispatchProps.onEditProfile(bio, fullname, location)
-    },
-  })
-)(RenderWrapped)

--- a/shared/profile/edit-profile/index.js
+++ b/shared/profile/edit-profile/index.js
@@ -1,7 +1,7 @@
 // @flow
-import React, {Component} from 'react'
+import React from 'react'
 import Render from './render'
-import {compose, lifecycle, withHandlers, withState} from 'recompose'
+import {compose, withHandlers, withPropsOnChange, withState} from 'recompose'
 import {connect} from 'react-redux'
 import {editProfile} from '../../actions/profile'
 import {maxProfileBioChars} from '../../constants/profile'
@@ -9,56 +9,29 @@ import {navigateUp} from '../../actions/route-tree'
 
 import type {Props} from './render'
 
-type State = {
-  bio: ?string,
-  fullname: ?string,
-  location: ?string,
-}
-
-const _bioLengthLeft = (bio: ?string) => {
-  return bio ? maxProfileBioChars - bio.length : maxProfileBioChars
-}
-
 const RenderWrapped = compose(
   withState('bio', 'onBioChange', props => props.bio),
   withState('fullname', 'onFullnameChange', props => props.fullname),
   withState('location', 'onLocationChange', props => props.location),
+  withPropsOnChange(['bio'], props => ({
+    bioLengthLeft: props.bio ? maxProfileBioChars - props.bio.length : maxProfileBioChars,
+  })),
   withHandlers({
     onSubmit: ({bio, fullname, location, onSubmit}) => () => onSubmit({bio, fullname, location}),
-  }),
-  lifecycle({
-    componentWillReceiveProps: function(nextProps) {
-      const bioLengthLeft = _bioLengthLeft(nextProps.bio)
-      this.setState({bioLengthLeft})
-    },
   })
 )(Render)
 
-class EditProfile extends Component<void, Props, State> {
-  state: State
-
-  constructor(props: Props) {
-    super(props)
-
-    const {bio, fullname, location} = this.props
-    this.state = {bio, fullname, location}
-  }
-
-  render() {
-    const bioLengthLeft = _bioLengthLeft(this.state.bio)
-    return (
-      <RenderWrapped
-        bio={this.state.bio}
-        bioLengthLeft={bioLengthLeft}
-        fullname={this.state.fullname}
-        location={this.state.location}
-        onBack={this.props.onBack}
-        onCancel={this.props.onBack}
-        onSubmit={this.props.onEditProfile}
-      />
-    )
-  }
-}
+// bio ? maxProfileBioChars - bio.length : maxProfileBioChars
+const EditProfile = ({bio, fullname, location, onBack, onEditProfile}: Props) => (
+  <RenderWrapped
+    bio={bio}
+    fullname={fullname}
+    location={location}
+    onBack={onBack}
+    onCancel={onBack}
+    onSubmit={onEditProfile}
+  />
+)
 
 // $FlowIssue type this connector
 export default connect(

--- a/shared/profile/edit-profile/index.js
+++ b/shared/profile/edit-profile/index.js
@@ -1,6 +1,7 @@
 // @flow
 import React, {Component} from 'react'
 import Render from './render'
+import {compose, lifecycle, withHandlers, withState} from 'recompose'
 import {connect} from 'react-redux'
 import {editProfile} from '../../actions/profile'
 import {maxProfileBioChars} from '../../constants/profile'
@@ -8,21 +9,51 @@ import {navigateUp} from '../../actions/route-tree'
 
 import type {Props} from './render'
 
-class EditProfile extends Component<void, Props, void> {
+type State = {
+  bio: ?string,
+  fullname: ?string,
+  location: ?string,
+}
+
+const _bioLengthLeft = (bio: ?string) => {
+  return bio ? maxProfileBioChars - bio.length : maxProfileBioChars
+}
+
+const RenderWrapped = compose(
+  withState('bio', 'onBioChange', props => props.bio),
+  withState('fullname', 'onFullnameChange', props => props.fullname),
+  withState('location', 'onLocationChange', props => props.location),
+  withHandlers({
+    onSubmit: ({bio, fullname, location, onSubmit}) => () => onSubmit({bio, fullname, location}),
+  }),
+  lifecycle({
+    componentWillReceiveProps: function(nextProps) {
+      const bioLengthLeft = _bioLengthLeft(nextProps.bio)
+      this.setState({bioLengthLeft})
+    },
+  })
+)(Render)
+
+class EditProfile extends Component<void, Props, State> {
+  state: State
+
+  constructor(props: Props) {
+    super(props)
+
+    const {bio, fullname, location} = this.props
+    this.state = {bio, fullname, location}
+  }
+
   render() {
-    const bioMaxChars = maxProfileBioChars
-    const bioLengthLeft = bioMaxChars - this.props.bio.length
+    const bioLengthLeft = _bioLengthLeft(this.state.bio)
     return (
-      <Render
-        bio={this.props.bio}
+      <RenderWrapped
+        bio={this.state.bio}
         bioLengthLeft={bioLengthLeft}
-        fullname={this.props.fullname}
-        location={this.props.location}
+        fullname={this.state.fullname}
+        location={this.state.location}
         onBack={this.props.onBack}
-        onBioChange={this.props.onBioChange}
         onCancel={this.props.onBack}
-        onFullnameChange={this.props.onFullnameChange}
-        onLocationChange={this.props.onLocationChange}
         onSubmit={this.props.onEditProfile}
       />
     )
@@ -31,35 +62,23 @@ class EditProfile extends Component<void, Props, void> {
 
 // $FlowIssue type this connector
 export default connect(
-  (state, {routeState}) => {
+  state => {
     const userInfo = state.tracker.trackers[state.config.username].userInfo
-    return {
-      bio: routeState.bio !== undefined ? routeState.bio : userInfo.bio,
-      fullname: routeState.fullname !== undefined ? routeState.fullname : userInfo.fullname,
-      location: routeState.location !== undefined ? routeState.location : userInfo.location,
-    }
+    const {bio, fullname, location} = userInfo
+    return {bio, fullname, location}
   },
-  (dispatch, {routeState, setRouteState}) => {
+  dispatch => {
     return {
       onBack: () => dispatch(navigateUp()),
-      onBioChange: bio => {
-        setRouteState({bio})
-      },
       onEditProfile: (bio, fullname, location) => dispatch(editProfile(bio, fullname, location)),
-      onFullnameChange: fullname => {
-        setRouteState({fullname})
-      },
-      onLocationChange: location => {
-        setRouteState({location})
-      },
     }
   },
   (stateProps, dispatchProps, ownProps) => ({
     ...stateProps,
     ...dispatchProps,
     ...ownProps,
-    onEditProfile: () => {
-      dispatchProps.onEditProfile(stateProps.bio, stateProps.fullname, stateProps.location)
+    onEditProfile: ({bio, fullname, location}) => {
+      dispatchProps.onEditProfile(bio, fullname, location)
     },
   })
 )(EditProfile)

--- a/shared/profile/edit-profile/index.js
+++ b/shared/profile/edit-profile/index.js
@@ -1,13 +1,10 @@
 // @flow
-import React from 'react'
 import Render from './render'
 import {compose, withHandlers, withPropsOnChange, withState} from 'recompose'
 import {connect} from 'react-redux'
 import {editProfile} from '../../actions/profile'
 import {maxProfileBioChars} from '../../constants/profile'
 import {navigateUp} from '../../actions/route-tree'
-
-import type {Props} from './render'
 
 const RenderWrapped = compose(
   withState('bio', 'onBioChange', props => props.bio),
@@ -20,18 +17,6 @@ const RenderWrapped = compose(
     onSubmit: ({bio, fullname, location, onSubmit}) => () => onSubmit({bio, fullname, location}),
   })
 )(Render)
-
-// bio ? maxProfileBioChars - bio.length : maxProfileBioChars
-const EditProfile = ({bio, fullname, location, onBack, onEditProfile}: Props) => (
-  <RenderWrapped
-    bio={bio}
-    fullname={fullname}
-    location={location}
-    onBack={onBack}
-    onCancel={onBack}
-    onSubmit={onEditProfile}
-  />
-)
 
 // $FlowIssue type this connector
 export default connect(
@@ -54,4 +39,4 @@ export default connect(
       dispatchProps.onEditProfile(bio, fullname, location)
     },
   })
-)(EditProfile)
+)(RenderWrapped)

--- a/shared/profile/edit-profile/index.js
+++ b/shared/profile/edit-profile/index.js
@@ -34,9 +34,9 @@ export default connect(
   (state, {routeState}) => {
     const userInfo = state.tracker.trackers[state.config.username].userInfo
     return {
-      bio: routeState.bio || userInfo.bio,
-      fullname: routeState.fullname || userInfo.fullname,
-      location: routeState.location || userInfo.location,
+      bio: routeState.bio !== undefined ? routeState.bio : userInfo.bio,
+      fullname: routeState.fullname !== undefined ? routeState.fullname : userInfo.fullname,
+      location: routeState.location !== undefined ? routeState.location : userInfo.location,
     }
   },
   (dispatch, {routeState, setRouteState}) => {

--- a/shared/profile/edit-profile/index.js
+++ b/shared/profile/edit-profile/index.js
@@ -8,8 +8,14 @@ import type {TypedState} from '../../constants/reducer'
 import {navigateUp} from '../../actions/route-tree'
 
 const mapStateToProps = (state: TypedState) => {
-  // $FlowIssue
-  const userInfo = state.tracker.trackers[state.config.username].userInfo
+  if (!state.config.username) {
+    throw new Error("Didn't get username")
+  }
+  const trackerInfo = state.tracker.trackers[state.config.username]
+  if (!trackerInfo || trackerInfo.type !== 'tracker') {
+    throw new Error("Didn't get trackerinfo")
+  }
+  const userInfo = trackerInfo.userInfo
   const {bio, fullname, location} = userInfo
   return {bio, fullname, location}
 }

--- a/shared/profile/edit-profile/render.desktop.js
+++ b/shared/profile/edit-profile/render.desktop.js
@@ -1,53 +1,49 @@
 // @flow
-import React, {Component} from 'react'
+import React from 'react'
 import {globalStyles, globalMargins} from '../../styles'
 import {StandardScreen, Box, Button, Input} from '../../common-adapters'
 
 import type {Props} from './render'
 
-class EditProfileRender extends Component<void, Props, void> {
-  render() {
-    return (
-      <StandardScreen onBack={this.props.onBack}>
-        <Box style={styleContainer}>
-          <Input
-            autoFocus={true}
-            style={styleEditProfile}
-            hintText="Full name"
-            value={this.props.fullname}
-            onEnterKeyDown={this.props.onSubmit}
-            onChangeText={fullname => this.props.onFullnameChange(fullname)}
-          />
-          <Input
-            style={styleEditProfile}
-            hintText="Location"
-            value={this.props.location}
-            onEnterKeyDown={this.props.onSubmit}
-            onChangeText={location => this.props.onLocationChange(location)}
-          />
-          <Input
-            style={styleEditProfile}
-            hintText="Bio"
-            value={this.props.bio}
-            multiline={true}
-            rowsMax={4}
-            errorText={this.props.bioLengthLeft <= 5 ? this.props.bioLengthLeft + ' characters left.' : ''}
-            onChangeText={bio => this.props.onBioChange(bio)}
-          />
-          <Box style={styleButtonContainer}>
-            <Button
-              type="Secondary"
-              onClick={this.props.onCancel}
-              label="Cancel"
-              style={{marginRight: globalMargins.tiny}}
-            />
-            <Button type="Primary" onClick={this.props.onSubmit} label="Save" />
-          </Box>
-        </Box>
-      </StandardScreen>
-    )
-  }
-}
+const EditProfileRender = (props: Props) => (
+  <StandardScreen onBack={props.onBack}>
+    <Box style={styleContainer}>
+      <Input
+        autoFocus={true}
+        style={styleEditProfile}
+        hintText="Full name"
+        value={props.fullname}
+        onEnterKeyDown={props.onSubmit}
+        onChangeText={fullname => props.onFullnameChange(fullname)}
+      />
+      <Input
+        style={styleEditProfile}
+        hintText="Location"
+        value={props.location}
+        onEnterKeyDown={props.onSubmit}
+        onChangeText={location => props.onLocationChange(location)}
+      />
+      <Input
+        style={styleEditProfile}
+        hintText="Bio"
+        value={props.bio}
+        multiline={true}
+        rowsMax={4}
+        errorText={props.bioLengthLeft <= 5 ? props.bioLengthLeft + ' characters left.' : ''}
+        onChangeText={bio => props.onBioChange(bio)}
+      />
+      <Box style={styleButtonContainer}>
+        <Button
+          type="Secondary"
+          onClick={props.onCancel}
+          label="Cancel"
+          style={{marginRight: globalMargins.tiny}}
+        />
+        <Button type="Primary" onClick={props.onSubmit} label="Save" />
+      </Box>
+    </Box>
+  </StandardScreen>
+)
 
 const styleButtonContainer = {
   ...globalStyles.flexBoxRow,

--- a/shared/profile/edit-profile/render.native.js
+++ b/shared/profile/edit-profile/render.native.js
@@ -35,7 +35,7 @@ const EditProfileRender = (props: Props) => (
       multiline={true}
       rowsMin={1}
       rowsMax={3}
-      errorText={props.bioLengthLeft <= 5 ? props.bioLengthLeft + ' chars left' : ''}
+      errorText={props.bioLengthLeft <= 5 ? props.bioLengthLeft + ' characters left' : ''}
       onChangeText={bio => props.onBioChange(bio)}
     />
     <Button style={styleButton} type="Primary" fullWidth={true} onClick={props.onSubmit} label="Save" />


### PR DESCRIPTION
@keybase/react-hackers 

Using truthiness (`routeState || userInfo`) caused the editing fields to reset to their original value when they were cleared to the empty string.  Since they start out `undefined` when they haven't been edited yet, use that instead.