### PR TITLE
Move all Team Serializable objects to team.avdl

### DIFF
--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -794,6 +794,7 @@ func (u User) PartialCopy() *User {
 	return ret
 }
 
+// TODO: This and keybase1.UserVersion should be reconciled
 type NameWithEldestSeqno string
 
 func MakeNameWithEldestSeqno(name string, seqno keybase1.Seqno) (NameWithEldestSeqno, error) {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1244,3 +1244,11 @@ func UPAKFromUPKV2AI(uV2 UserPlusKeysV2AllIncarnations) UserPlusAllKeys {
 		RemoteTracks: uV2.Current.RemoteTracks,
 	}
 }
+
+// "foo" for seqno 1 or "foo%6"
+func (u UserVersion) PercentForm() string {
+	if u.EldestSeqno == 1 {
+		return u.Username
+	}
+	return fmt.Sprintf("%s%%%d", u.Username, u.EldestSeqno)
+}

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -166,6 +166,93 @@ func (o TeamMembers) DeepCopy() TeamMembers {
 	}
 }
 
+type UserVersion struct {
+	Username    string `codec:"username" json:"username"`
+	EldestSeqno Seqno  `codec:"eldestSeqno" json:"eldestSeqno"`
+}
+
+func (o UserVersion) DeepCopy() UserVersion {
+	return UserVersion{
+		Username:    o.Username,
+		EldestSeqno: o.EldestSeqno.DeepCopy(),
+	}
+}
+
+type TeamSigChainState struct {
+	Reader       UserVersion                    `codec:"reader" json:"reader"`
+	Id           TeamID                         `codec:"id" json:"id"`
+	Name         string                         `codec:"name" json:"name"`
+	LastSeqno    Seqno                          `codec:"lastSeqno" json:"lastSeqno"`
+	LastLinkID   LinkID                         `codec:"lastLinkID" json:"lastLinkID"`
+	ParentID     *TeamID                        `codec:"parentID,omitempty" json:"parentID,omitempty"`
+	UserLog      map[UserVersion][]UserLogPoint `codec:"userLog" json:"userLog"`
+	PerTeamKeys  map[int]PerTeamKey             `codec:"perTeamKeys" json:"perTeamKeys"`
+	StubbedTypes map[int]bool                   `codec:"stubbedTypes" json:"stubbedTypes"`
+}
+
+func (o TeamSigChainState) DeepCopy() TeamSigChainState {
+	return TeamSigChainState{
+		Reader:     o.Reader.DeepCopy(),
+		Id:         o.Id.DeepCopy(),
+		Name:       o.Name,
+		LastSeqno:  o.LastSeqno.DeepCopy(),
+		LastLinkID: o.LastLinkID.DeepCopy(),
+		ParentID: (func(x *TeamID) *TeamID {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.ParentID),
+		UserLog: (func(x map[UserVersion][]UserLogPoint) map[UserVersion][]UserLogPoint {
+			ret := make(map[UserVersion][]UserLogPoint)
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := (func(x []UserLogPoint) []UserLogPoint {
+					var ret []UserLogPoint
+					for _, v := range x {
+						vCopy := v.DeepCopy()
+						ret = append(ret, vCopy)
+					}
+					return ret
+				})(v)
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.UserLog),
+		PerTeamKeys: (func(x map[int]PerTeamKey) map[int]PerTeamKey {
+			ret := make(map[int]PerTeamKey)
+			for k, v := range x {
+				kCopy := k
+				vCopy := v.DeepCopy()
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.PerTeamKeys),
+		StubbedTypes: (func(x map[int]bool) map[int]bool {
+			ret := make(map[int]bool)
+			for k, v := range x {
+				kCopy := k
+				vCopy := v
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.StubbedTypes),
+	}
+}
+
+type UserLogPoint struct {
+	Role  TeamRole `codec:"role" json:"role"`
+	Seqno Seqno    `codec:"seqno" json:"seqno"`
+}
+
+func (o UserLogPoint) DeepCopy() UserLogPoint {
+	return UserLogPoint{
+		Role:  o.Role.DeepCopy(),
+		Seqno: o.Seqno.DeepCopy(),
+	}
+}
+
 type TeamCreateArg struct {
 	SessionID int    `codec:"sessionID" json:"sessionID"`
 	Name      string `codec:"name" json:"name"`

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -356,12 +356,16 @@ func generateNewSubteamSigForParentChain(g *libkb.GlobalContext, me *libkb.User,
 		return
 	}
 
+	prevLinkID, err := libkb.ImportLinkID(parentTeam.GetLatestLinkID())
+	if err != nil {
+		return nil, err
+	}
 	v2Sig, err := makeSigchainV2OuterSig(
 		signingKey,
 		libkb.LinkTypeNewSubteam,
 		parentTeam.GetLatestSeqno()+1,
 		newSubteamSigJSON,
-		parentTeam.GetLatestLinkID(),
+		prevLinkID,
 		false, /* hasRevokes */
 	)
 	if err != nil {

--- a/go/teams/member.go
+++ b/go/teams/member.go
@@ -43,19 +43,19 @@ func ChangeRoles(ctx context.Context, g *libkb.GlobalContext, teamname string, r
 	return t.ChangeMembership(ctx, req)
 }
 
-func loadUserVersionByUsername(ctx context.Context, g *libkb.GlobalContext, username string) (UserVersion, error) {
+func loadUserVersionByUsername(ctx context.Context, g *libkb.GlobalContext, username string) (keybase1.UserVersion, error) {
 	res := g.Resolver.ResolveWithBody(username)
 	if res.GetError() != nil {
-		return UserVersion{}, res.GetError()
+		return keybase1.UserVersion{}, res.GetError()
 	}
 	return loadUserVersionByUID(ctx, g, res.GetUID())
 }
 
-func loadUserVersionByUID(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID) (UserVersion, error) {
+func loadUserVersionByUID(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID) (keybase1.UserVersion, error) {
 	arg := libkb.NewLoadUserByUIDArg(ctx, g, uid)
 	upak, _, err := g.GetUPAKLoader().Load(arg)
 	if err != nil {
-		return UserVersion{}, err
+		return keybase1.UserVersion{}, err
 	}
 
 	return NewUserVersion(upak.Base.Username, upak.Base.EldestSeqno), nil

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -8,7 +8,7 @@ import (
 )
 
 type member struct {
-	version    UserVersion
+	version    keybase1.UserVersion
 	perUserKey keybase1.PerUserKey
 }
 
@@ -105,7 +105,7 @@ func (m *memberSet) nameSeqList(members []member) (*[]SCTeamMember, error) {
 	}
 	res := make([]SCTeamMember, len(members))
 	for i, m := range members {
-		nameSeq, err := libkb.MakeNameWithEldestSeqno(m.version.Username.String(), m.version.EldestSeqno)
+		nameSeq, err := libkb.MakeNameWithEldestSeqno(m.version.Username, m.version.EldestSeqno)
 		if err != nil {
 			return nil, err
 		}

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -219,7 +219,7 @@ func usernameRole(ctx context.Context, tc libkb.TestContext, team *Team, usernam
 	return uvRole(tc, team, uv)
 }
 
-func uvRole(tc libkb.TestContext, team *Team, uv UserVersion) keybase1.TeamRole {
+func uvRole(tc libkb.TestContext, team *Team, uv keybase1.UserVersion) keybase1.TeamRole {
 	role, err := team.Chain.GetUserRole(uv)
 	if err != nil {
 		tc.T.Fatal(err)

--- a/go/teams/sig.go
+++ b/go/teams/sig.go
@@ -50,6 +50,10 @@ func RootTeamIDFromName(name string) keybase1.TeamID {
 }
 
 func NewSubteamSig(me *libkb.User, key libkb.GenericKey, parentTeam *TeamSigChainState, subteamName TeamName, subteamID keybase1.TeamID) (*jsonw.Wrapper, error) {
+	prevLinkID, err := libkb.ImportLinkID(parentTeam.GetLatestLinkID())
+	if err != nil {
+		return nil, err
+	}
 	ret, err := libkb.ProofMetadata{
 		Me:         me,
 		LinkType:   libkb.LinkTypeNewSubteam,
@@ -57,7 +61,7 @@ func NewSubteamSig(me *libkb.User, key libkb.GenericKey, parentTeam *TeamSigChai
 		SigVersion: libkb.KeybaseSignatureV2,
 		SeqType:    libkb.SeqTypeSemiprivate,
 		Seqno:      parentTeam.GetLatestSeqno() + 1,
-		PrevLinkID: parentTeam.GetLatestLinkID(),
+		PrevLinkID: prevLinkID,
 	}.ToJSON(me.G())
 	if err != nil {
 		return nil, err

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -86,7 +86,7 @@ func (t *Team) UsernamesWithRole(role keybase1.TeamRole) ([]libkb.NormalizedUser
 	}
 	names := make([]libkb.NormalizedUsername, len(uvs))
 	for i, uv := range uvs {
-		names[i] = uv.Username
+		names[i] = libkb.NewNormalizedUsername(uv.Username)
 	}
 	return names, nil
 }
@@ -309,7 +309,11 @@ func (t *Team) sigChangeItem(section SCTeamSection) (libkb.SigMultiItem, error) 
 	if err != nil {
 		return libkb.SigMultiItem{}, err
 	}
-	sig, err := ChangeMembershipSig(me, t.Chain.GetLatestLinkID(), t.NextSeqno(), deviceSigningKey, section)
+	latestLinkID1, err := libkb.ImportLinkID(t.Chain.GetLatestLinkID())
+	if err != nil {
+		return libkb.SigMultiItem{}, err
+	}
+	sig, err := ChangeMembershipSig(me, latestLinkID1, t.NextSeqno(), deviceSigningKey, section)
 	if err != nil {
 		return libkb.SigMultiItem{}, err
 	}
@@ -319,12 +323,16 @@ func (t *Team) sigChangeItem(section SCTeamSection) (libkb.SigMultiItem, error) 
 		return libkb.SigMultiItem{}, err
 	}
 
+	latestLinkID2, err := libkb.ImportLinkID(t.Chain.GetLatestLinkID())
+	if err != nil {
+		return libkb.SigMultiItem{}, err
+	}
 	v2Sig, err := makeSigchainV2OuterSig(
 		deviceSigningKey,
 		libkb.LinkTypeChangeMembership,
 		t.NextSeqno(),
 		sigJSON,
-		t.Chain.GetLatestLinkID(),
+		latestLinkID2,
 		false, /* hasRevokes */
 	)
 	if err != nil {

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -50,4 +50,48 @@ protocol teams {
 
   TeamMembers teamGet(int sessionID, string name);
 
+  record UserVersion {
+    string username;
+    Seqno eldestSeqno;
+  }
+
+  // State of a parsed team sigchain.
+  // Should be treated as immutable when outside TeamSigChainPlayer.
+  // Modified internally to TeamSigChainPlayer.
+  record TeamSigChainState {
+    // The user who loaded this sigchain
+    UserVersion reader;
+
+    TeamID id;
+    // Latest name of the team
+    string name;
+    // The last link procesed
+    Seqno lastSeqno;
+    LinkID lastLinkID;
+
+    // Present if a subteam
+    union { null, TeamID } parentID;
+
+    // For each user; the timeline of their role status.
+    // The role checkpoints are always ordered by seqno.
+    // The latest role of the user is the role of their last checkpoint.
+    // When a user leaves the team a NONE checkpoint appears in their list.
+    map<UserVersion,array<UserLogPoint>> userLog;
+
+    // Keyed by per-team-key generation
+    map<int, PerTeamKey> perTeamKeys;
+
+    // Set of types that were loaded stubbed-out and whose contents are missing.
+    // Keyed by libkb.SigchainV2Type
+    map<int, bool> stubbedTypes;
+  }
+
+  // A user became this role at a point in time
+  record UserLogPoint {
+    // The new role. Including NONE if the user left the team.
+    TeamRole role;
+    // The seqno at which the user became this role.
+    Seqno seqno;
+  }
+
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5606,6 +5606,18 @@ export type TeamRole =
   | 3 // WRITER_3
   | 4 // READER_4
 
+export type TeamSigChainState = {
+  reader: UserVersion,
+  id: TeamID,
+  name: string,
+  lastSeqno: Seqno,
+  lastLinkID: LinkID,
+  parentID?: ?TeamID,
+  userLog: {[key: string]: ?Array<UserLogPoint>},
+  perTeamKeys: {[key: string]: PerTeamKey},
+  stubbedTypes: {[key: string]: bool},
+}
+
 export type Test = {
   reply: string,
 }
@@ -5711,6 +5723,11 @@ export type UserCard = {
   theyFollowYou: boolean,
 }
 
+export type UserLogPoint = {
+  role: TeamRole,
+  seqno: Seqno,
+}
+
 export type UserOrTeamID = string
 
 export type UserOrTeamLite = {
@@ -5786,6 +5803,11 @@ export type UserSummary2Set = {
   users?: ?Array<UserSummary2>,
   time: Time,
   version: int,
+}
+
+export type UserVersion = {
+  username: string,
+  eldestSeqno: Seqno,
 }
 
 export type UserVersionVector = {

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -120,6 +120,94 @@
           "name": "readers"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "UserVersion",
+      "fields": [
+        {
+          "type": "string",
+          "name": "username"
+        },
+        {
+          "type": "Seqno",
+          "name": "eldestSeqno"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "TeamSigChainState",
+      "fields": [
+        {
+          "type": "UserVersion",
+          "name": "reader"
+        },
+        {
+          "type": "TeamID",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "Seqno",
+          "name": "lastSeqno"
+        },
+        {
+          "type": "LinkID",
+          "name": "lastLinkID"
+        },
+        {
+          "type": [
+            null,
+            "TeamID"
+          ],
+          "name": "parentID"
+        },
+        {
+          "type": {
+            "type": "map",
+            "values": {
+              "type": "array",
+              "items": "UserLogPoint"
+            },
+            "keys": "UserVersion"
+          },
+          "name": "userLog"
+        },
+        {
+          "type": {
+            "type": "map",
+            "values": "PerTeamKey",
+            "keys": "int"
+          },
+          "name": "perTeamKeys"
+        },
+        {
+          "type": {
+            "type": "map",
+            "values": "bool",
+            "keys": "int"
+          },
+          "name": "stubbedTypes"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "UserLogPoint",
+      "fields": [
+        {
+          "type": "TeamRole",
+          "name": "role"
+        },
+        {
+          "type": "Seqno",
+          "name": "seqno"
+        }
+      ]
     }
   ],
   "messages": {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5606,6 +5606,18 @@ export type TeamRole =
   | 3 // WRITER_3
   | 4 // READER_4
 
+export type TeamSigChainState = {
+  reader: UserVersion,
+  id: TeamID,
+  name: string,
+  lastSeqno: Seqno,
+  lastLinkID: LinkID,
+  parentID?: ?TeamID,
+  userLog: {[key: string]: ?Array<UserLogPoint>},
+  perTeamKeys: {[key: string]: PerTeamKey},
+  stubbedTypes: {[key: string]: bool},
+}
+
 export type Test = {
   reply: string,
 }
@@ -5711,6 +5723,11 @@ export type UserCard = {
   theyFollowYou: boolean,
 }
 
+export type UserLogPoint = {
+  role: TeamRole,
+  seqno: Seqno,
+}
+
 export type UserOrTeamID = string
 
 export type UserOrTeamLite = {
@@ -5786,6 +5803,11 @@ export type UserSummary2Set = {
   users?: ?Array<UserSummary2>,
   time: Time,
   version: int,
+}
+
+export type UserVersion = {
+  username: string,
+  eldestSeqno: Seqno,
 }
 
 export type UserVersionVector = {


### PR DESCRIPTION
Moves `TeamSigChainState` into avdl so that it can be serialized for storage and maybe passing through rpcs. Note that the struct contains 'complex' map types which cannot be serialized to json at the moment.

I left the methods in `teams` so there's two structs. `teams.TeamSigChainState` which is just a wrapper around `keybase1.TeamSigChainState` that provides methods. My thought here is that the methods may one day want to use other code in `teams`. So the type 'belongs' in `teams` but the `keybase1` just exists to get us serialization for free.
