### PR TITLE
Show inbox errors in red, and don't allow entering those conversations

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -259,6 +259,7 @@ function* _chatInboxFailedSubSaga(params) {
     participants: error.rekeyInfo
       ? List([].concat(error.rekeyInfo.writerNames, error.rekeyInfo.readerNames).filter(Boolean))
       : List(error.unverifiedTLFName.split(',')),
+    snippet: error.message,
     state: 'error',
     status: 'unfiled',
     time: error.remoteConv.readerInfo.mtime,
@@ -277,6 +278,10 @@ function* _chatInboxFailedSubSaga(params) {
     }
     case ChatTypes.LocalConversationErrorType.transient: {
       // Just ignore these, it is a transient error
+      break
+    }
+    case ChatTypes.LocalConversationErrorType.permanent: {
+      // Let's show it as failed in the inbox
       break
     }
     default:

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -785,20 +785,25 @@ function* _selectConversation(action: Constants.SelectConversation): SagaGenerat
     yield put(Creators.clearMessages(conversationIDKey))
   }
 
-  if (conversationIDKey) {
-    yield put(Creators.loadMoreMessages(conversationIDKey, true, fromUser))
-    yield put(navigateTo([conversationIDKey], [chatTab]))
-  } else {
-    yield put(navigateTo([], [chatTab]))
-  }
-
   const inbox = yield select(Shared.selectedInboxSelector, conversationIDKey)
   if (inbox) {
+    // Don't navigate into errored conversations
+    if (inbox.get('state') === 'error') {
+      return
+    }
+
     const participants = inbox.get('participants').toArray()
     yield put(Creators.updateMetadata(participants))
     // Update search but don't update the filter
     // TODO likely only do this if search is visible
     yield put(Creators.setInboxSearch(participants))
+  }
+
+  if (conversationIDKey) {
+    yield put(Creators.loadMoreMessages(conversationIDKey, true, fromUser))
+    yield put(navigateTo([conversationIDKey], [chatTab]))
+  } else {
+    yield put(navigateTo([], [chatTab]))
   }
 
   // Do this here because it's possible loadMoreMessages bails early


### PR DESCRIPTION
@keybase/react-hackers 

We were hiding failed conversations from the inbox, but we'd still show global errors if they failed to unbox.  Instead, show them in the inbox with a red snippet, and don't allow them to be selected.