### PR TITLE
Enable test

### DIFF
--- a/go/engine/per_user_key_background_test.go
+++ b/go/engine/per_user_key_background_test.go
@@ -214,7 +214,6 @@ func TestPerUserKeyBackgroundUnnecessary(t *testing.T) {
 
 // The normal case of upgrading a user
 func TestPerUserKeyBackgroundWork(t *testing.T) {
-	t.Skip("disabled as flaky: see CORE-5410")
 	tc := SetupEngineTest(t, "pukup")
 	defer tc.Cleanup()
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
@@ -265,7 +264,7 @@ func TestPerUserKeyBackgroundWork(t *testing.T) {
 	advance(arg.Settings.Interval + time.Second)
 	expectMeta(t, metaCh, "woke-interval")
 	advance(arg.Settings.WakeUp + time.Second)
-	expectMeta(t, metaCh, "woke-wakeup")
+	expectMeta(t, metaCh, "woke-wakeup") // this line has flaked before (CORE-5410)
 	select {
 	case x := <-roundResCh:
 		require.Equal(t, nil, x, "round result")
@@ -367,7 +366,7 @@ func expectMeta(t *testing.T, metaCh <-chan string, s string) {
 		select {
 		case x := <-metaCh:
 			require.Equal(t, s, x)
-		case <-time.After(time.Second):
+		case <-time.After(5 * time.Second):
 			require.FailNow(t, "channel timed out")
 		}
 	}


### PR DESCRIPTION
It passed with the 1 second timeout 100x on my machine. I propose bump it to 5 seconds and re-enable. Weird thing is that by my reasoning there is no rpc in the codepath that timed out. 1 second for goroutine contention seems unreasonable.