### PR TITLE
initial chat team integration CORE-5285 CORE-5287

### DIFF
--- a/go/chat/context.go
+++ b/go/chat/context.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"context"
 
+	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -42,14 +43,14 @@ func IdentifyMode(ctx context.Context) (ib keybase1.TLFIdentifyBehavior, breaks 
 	return keybase1.TLFIdentifyBehavior_CHAT_CLI, nil, false
 }
 
-func CtxKeyFinder(ctx context.Context) KeyFinder {
+func CtxKeyFinder(ctx context.Context, g *globals.Context) KeyFinder {
 	var kf KeyFinder
 	var ok bool
 	val := ctx.Value(kfKey)
 	if kf, ok = val.(KeyFinder); ok {
 		return kf
 	}
-	return NewKeyFinder()
+	return NewKeyFinder(g)
 }
 
 func CtxIdentifyNotifier(ctx context.Context) *IdentifyNotifier {
@@ -91,22 +92,28 @@ func CtxAddLogTags(ctx context.Context, env appTypeSource) context.Context {
 	return ctx
 }
 
-func Context(ctx context.Context, env appTypeSource, mode keybase1.TLFIdentifyBehavior,
+func Context(ctx context.Context, g *globals.Context, mode keybase1.TLFIdentifyBehavior,
 	breaks *[]keybase1.TLFIdentifyFailure, notifier *IdentifyNotifier) context.Context {
+	if breaks == nil {
+		breaks = new([]keybase1.TLFIdentifyFailure)
+	}
 	res := IdentifyModeCtx(ctx, mode, breaks)
-	res = context.WithValue(res, kfKey, NewKeyFinder())
+	val := res.Value(kfKey)
+	if _, ok := val.(KeyFinder); !ok {
+		res = context.WithValue(res, kfKey, NewKeyFinder(g))
+	}
 	res = context.WithValue(res, inKey, notifier)
-	res = CtxAddLogTags(res, env)
+	res = CtxAddLogTags(res, g.GetEnv())
 	return res
 }
 
-func BackgroundContext(sourceCtx context.Context, env appTypeSource) context.Context {
+func BackgroundContext(sourceCtx context.Context, g *globals.Context) context.Context {
 
 	rctx := context.Background()
 
 	in := CtxIdentifyNotifier(sourceCtx)
 	if ident, breaks, ok := IdentifyMode(sourceCtx); ok {
-		rctx = Context(rctx, env, ident, breaks, in)
+		rctx = Context(rctx, g, ident, breaks, in)
 	}
 
 	// Overwrite trace tag
@@ -114,7 +121,7 @@ func BackgroundContext(sourceCtx context.Context, env appTypeSource) context.Con
 		rctx = context.WithValue(rctx, chatTraceKey, tr)
 	}
 
-	rctx = context.WithValue(rctx, kfKey, CtxKeyFinder(sourceCtx))
+	rctx = context.WithValue(rctx, kfKey, CtxKeyFinder(sourceCtx, g))
 	rctx = context.WithValue(rctx, inKey, in)
 
 	return rctx

--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -11,10 +11,11 @@ import (
 )
 
 func setupLoaderTest(t *testing.T) (*kbtest.ChatTestContext, *kbtest.ChatMockWorld, *chatListener, chat1.NewConversationRemoteRes) {
-	world, ri, _, baseSender, listener, tlf := setupTest(t, 1)
+	ctx, world, ri, _, baseSender, listener := setupTest(t, 1)
 
 	u := world.GetUsers()[0]
-	trip := newConvTriple(t, tlf, u.Username)
+	tc := world.Tcs[u.Username]
+	trip := newConvTriple(ctx, t, tc, u.Username)
 	firstMessagePlaintext := chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        trip,
@@ -24,16 +25,14 @@ func setupLoaderTest(t *testing.T) (*kbtest.ChatTestContext, *kbtest.ChatMockWor
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, err := baseSender.Prepare(context.TODO(), firstMessagePlaintext, nil)
+	firstMessageBoxed, _, err := baseSender.Prepare(ctx, firstMessagePlaintext,
+		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
-	res, err := ri.NewConversationRemote2(context.TODO(), chat1.NewConversationRemote2Arg{
+	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
 		IdTriple:   trip,
 		TLFMessage: *firstMessageBoxed,
 	})
 	require.NoError(t, err)
-
-	tc := userTc(t, world, u)
-
 	return tc, world, listener, res
 }
 

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -54,13 +54,9 @@ func (s *baseConversationSource) SetRemoteInterface(ri func() chat1.RemoteInterf
 	s.ri = ri
 }
 
-func (s *baseConversationSource) SetTLFInfoSource(tlfInfoSource types.TLFInfoSource) {
-	s.boxer.tlfInfoSource = tlfInfoSource
-}
-
 func (s *baseConversationSource) postProcessThread(ctx context.Context, uid gregor1.UID,
-	convID chat1.ConversationID, thread *chat1.ThreadView, q *chat1.GetThreadQuery,
-	finalizeInfo *chat1.ConversationFinalizeInfo, superXform supersedesTransform, checkPrev bool) (err error) {
+	conv chat1.Conversation, thread *chat1.ThreadView, q *chat1.GetThreadQuery,
+	superXform supersedesTransform, checkPrev bool) (err error) {
 
 	// Sanity check the prev pointers in this thread.
 	// TODO: We'll do this against what's in the cache once that's ready,
@@ -78,7 +74,7 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 		if superXform == nil {
 			superXform = newBasicSupersedesTransform(s.G())
 		}
-		if thread.Messages, err = superXform.Run(ctx, convID, uid, thread.Messages, finalizeInfo); err != nil {
+		if thread.Messages, err = superXform.Run(ctx, conv, uid, thread.Messages); err != nil {
 			return err
 		}
 	}
@@ -88,7 +84,7 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 
 	// Fetch outbox and tack onto the result
 	outbox := storage.NewOutbox(s.G(), uid)
-	if err = outbox.SprinkleIntoThread(ctx, convID, thread); err != nil {
+	if err = outbox.SprinkleIntoThread(ctx, conv.GetConvID(), thread); err != nil {
 		if _, ok := err.(storage.MissError); !ok {
 			return err
 		}
@@ -97,9 +93,9 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 	return nil
 }
 
-func (s *baseConversationSource) TransformSupersedes(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageUnboxed, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error) {
+func (s *baseConversationSource) TransformSupersedes(ctx context.Context, conv chat1.Conversation, uid gregor1.UID, msgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error) {
 	transform := newBasicSupersedesTransform(s.G())
-	return transform.Run(ctx, convID, uid, msgs, finalizeInfo)
+	return transform.Run(ctx, conv, uid, msgs)
 }
 
 type RemoteConversationSource struct {
@@ -140,7 +136,7 @@ func (s *RemoteConversationSource) Pull(ctx context.Context, convID chat1.Conver
 	var rl []*chat1.RateLimit
 
 	// Get conversation metadata
-	conv, ratelim, err := utils.GetUnverifiedConv(ctx, s.G(), uid, convID, true)
+	conv, ratelim, err := GetUnverifiedConv(ctx, s.G(), uid, convID, true)
 	rl = append(rl, ratelim)
 	if err != nil {
 		return chat1.ThreadView{}, rl, err
@@ -158,13 +154,13 @@ func (s *RemoteConversationSource) Pull(ctx context.Context, convID chat1.Conver
 		return chat1.ThreadView{}, rl, err
 	}
 
-	thread, err := s.boxer.UnboxThread(ctx, boxed.Thread, convID, conv.Metadata.FinalizeInfo)
+	thread, err := s.boxer.UnboxThread(ctx, boxed.Thread, conv)
 	if err != nil {
 		return chat1.ThreadView{}, rl, err
 	}
 
 	// Post process thread before returning
-	if err = s.postProcessThread(ctx, uid, convID, &thread, query, conv.Metadata.FinalizeInfo, nil, true); err != nil {
+	if err = s.postProcessThread(ctx, uid, conv, &thread, query, nil, true); err != nil {
 		return chat1.ThreadView{}, nil, err
 	}
 
@@ -180,8 +176,8 @@ func (s *RemoteConversationSource) Clear(convID chat1.ConversationID, uid gregor
 	return nil
 }
 
-func (s *RemoteConversationSource) GetMessages(ctx context.Context, convID chat1.ConversationID,
-	uid gregor1.UID, msgIDs []chat1.MessageID, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error) {
+func (s *RemoteConversationSource) GetMessages(ctx context.Context, conv chat1.Conversation,
+	uid gregor1.UID, msgIDs []chat1.MessageID) ([]chat1.MessageUnboxed, error) {
 
 	// Insta fail if we are offline
 	if s.IsOffline() {
@@ -189,11 +185,11 @@ func (s *RemoteConversationSource) GetMessages(ctx context.Context, convID chat1
 	}
 
 	rres, err := s.ri().GetMessagesRemote(ctx, chat1.GetMessagesRemoteArg{
-		ConversationID: convID,
+		ConversationID: conv.GetConvID(),
 		MessageIDs:     msgIDs,
 	})
 
-	msgs, err := s.boxer.UnboxMessages(ctx, rres.Msgs, convID, finalizeInfo)
+	msgs, err := s.boxer.UnboxMessages(ctx, rres.Msgs, conv)
 	if err != nil {
 		return nil, err
 	}
@@ -202,12 +198,11 @@ func (s *RemoteConversationSource) GetMessages(ctx context.Context, convID chat1
 }
 
 func (s *RemoteConversationSource) GetMessagesWithRemotes(ctx context.Context,
-	convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageBoxed,
-	finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error) {
+	conv chat1.Conversation, uid gregor1.UID, msgs []chat1.MessageBoxed) ([]chat1.MessageUnboxed, error) {
 	if s.IsOffline() {
 		return nil, OfflineError{}
 	}
-	return s.boxer.UnboxMessages(ctx, msgs, convID, finalizeInfo)
+	return s.boxer.UnboxMessages(ctx, msgs, conv)
 }
 
 type conversationLock struct {
@@ -338,6 +333,12 @@ func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.Conver
 	s.lockTab.Acquire(ctx, uid, convID)
 	defer s.lockTab.Release(ctx, uid, convID)
 
+	// Grab conversation information before pushing
+	conv, _, err := GetUnverifiedConv(ctx, s.G(), uid, convID, true)
+	if err != nil {
+		return decmsg, continuousUpdate, err
+	}
+
 	// Check to see if we are "appending" this message to the current record.
 	maxMsgID, err := s.storage.GetMaxMsgID(ctx, convID, uid)
 	switch err.(type) {
@@ -349,12 +350,7 @@ func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.Conver
 		return chat1.MessageUnboxed{}, continuousUpdate, err
 	}
 
-	// leaving this empty for message Push.
-	// In a rare case, this will result in an error if a push message
-	// coincides with an account reset.
-	var emptyFinalizeInfo *chat1.ConversationFinalizeInfo
-
-	decmsg, err = s.boxer.UnboxMessage(ctx, msg, convID, emptyFinalizeInfo)
+	decmsg, err = s.boxer.UnboxMessage(ctx, msg, conv)
 	if err != nil {
 		return decmsg, continuousUpdate, err
 	}
@@ -376,8 +372,8 @@ func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.Conver
 	return decmsg, continuousUpdate, nil
 }
 
-func (s *HybridConversationSource) identifyTLF(ctx context.Context, convID chat1.ConversationID,
-	uid gregor1.UID, msgs []chat1.MessageUnboxed, finalizeInfo *chat1.ConversationFinalizeInfo) error {
+func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv chat1.Conversation,
+	uid gregor1.UID, msgs []chat1.MessageUnboxed) error {
 
 	// If we are offline, then bail out of here with no error
 	if s.IsOffline() {
@@ -396,18 +392,14 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, convID chat1
 				return nil
 			}
 
-			tlfName := msg.Valid().ClientHeader.TLFNameExpanded(finalizeInfo)
+			tlfName := msg.Valid().ClientHeader.TLFNameExpanded(conv.Metadata.FinalizeInfo)
 			s.Debug(ctx, "identifyTLF: identifying from msg ID: %d name: %s convID: %s",
-				msg.GetMessageID(), tlfName, convID)
+				msg.GetMessageID(), tlfName, conv.GetConvID())
 
-			vis := chat1.TLFVisibility_PRIVATE
-			if msg.Valid().ClientHeader.TlfPublic {
-				vis = chat1.TLFVisibility_PUBLIC
-			}
-
-			_, err := s.boxer.tlfInfoSource.Lookup(ctx, tlfName, vis)
+			_, err := CtxKeyFinder(ctx, s.G()).Find(ctx, tlfName, conv.GetMembersType(),
+				msg.Valid().ClientHeader.TlfPublic)
 			if err != nil {
-				s.Debug(ctx, "identifyTLF: failure: name: %s convID: %s", tlfName, convID)
+				s.Debug(ctx, "identifyTLF: failure: name: %s convID: %s", tlfName, conv.GetConvID())
 				return err
 			}
 
@@ -448,7 +440,7 @@ func (s *HybridConversationSource) resolveHoles(ctx context.Context, uid gregor1
 	}
 
 	// Fetch all missing messages from server, and sub in the real ones into the placeholder slots
-	msgs, err := s.GetMessages(ctx, conv.GetConvID(), uid, msgIDs, conv.Metadata.FinalizeInfo)
+	msgs, err := s.GetMessages(ctx, conv, uid, msgIDs)
 	if err != nil {
 		s.Debug(ctx, "resolveHoles: failed to get missing messages: %s", err.Error())
 		return err
@@ -491,22 +483,19 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 	defer s.lockTab.Release(ctx, uid, convID)
 
 	// Get conversation metadata
-	var finalizeInfo *chat1.ConversationFinalizeInfo
-	conv, ratelim, err := utils.GetUnverifiedConv(ctx, s.G(), uid, convID, true)
+	conv, ratelim, err := GetUnverifiedConv(ctx, s.G(), uid, convID, true)
 	rl = append(rl, ratelim)
-	if err == nil {
-		finalizeInfo = conv.Metadata.FinalizeInfo
-	}
 
 	// Post process thread before returning
 	defer func() {
 		if err == nil {
-			err = s.postProcessThread(ctx, uid, convID, &thread, query,
-				finalizeInfo, nil, true)
+			err = s.postProcessThread(ctx, uid, conv, &thread, query, nil, true)
 		}
 	}()
 
+	var unboxConv unboxConversationInfo
 	if err == nil {
+		unboxConv = conv
 		// Try locally first
 		rc := storage.NewHoleyResultCollector(maxHolesForPull,
 			s.storage.ResultCollectorFromQuery(ctx, query, pagination))
@@ -522,7 +511,7 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 			if !s.IsOffline() {
 
 				// Identify this TLF by running crypt keys
-				if ierr := s.identifyTLF(ctx, convID, uid, thread.Messages, conv.Metadata.FinalizeInfo); ierr != nil {
+				if ierr := s.identifyTLF(ctx, conv, uid, thread.Messages); ierr != nil {
 					s.Debug(ctx, "Pull: identify failed: %s", ierr.Error())
 					return chat1.ThreadView{}, rl, ierr
 				}
@@ -560,6 +549,9 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 	} else {
 		s.Debug(ctx, "Pull: error fetching conv metadata: convID: %s uid: %s err: %s", convID, uid,
 			err.Error())
+		// Assume this is a public convo for unbox purposes, since it is the only way any unboxing
+		// will succeed here since we don't know the members type.
+		unboxConv = newPublicUnboxConverstionInfo(convID)
 	}
 
 	// Insta fail if we are offline
@@ -580,7 +572,7 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 	}
 
 	// Unbox
-	thread, err = s.boxer.UnboxThread(ctx, boxed.Thread, convID, conv.Metadata.FinalizeInfo)
+	thread, err = s.boxer.UnboxThread(ctx, boxed.Thread, unboxConv)
 	if err != nil {
 		return chat1.ThreadView{}, rl, err
 	}
@@ -688,10 +680,9 @@ func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID cha
 	defer func() {
 		if err == nil {
 			superXform := newBasicSupersedesTransform(s.G())
-			superXform.SetMessagesFunc(func(ctx context.Context, convID chat1.ConversationID,
-				uid gregor1.UID, msgIDs []chat1.MessageID,
-				finalizeInfo *chat1.ConversationFinalizeInfo) (res []chat1.MessageUnboxed, err error) {
-				msgs, err := storage.New(s.G()).FetchMessages(ctx, convID, uid, msgIDs)
+			superXform.SetMessagesFunc(func(ctx context.Context, conv chat1.Conversation,
+				uid gregor1.UID, msgIDs []chat1.MessageID) (res []chat1.MessageUnboxed, err error) {
+				msgs, err := storage.New(s.G()).FetchMessages(ctx, conv.GetConvID(), uid, msgIDs)
 				if err != nil {
 					return nil, err
 				}
@@ -702,7 +693,10 @@ func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID cha
 				}
 				return res, nil
 			})
-			err = s.postProcessThread(ctx, uid, convID, &tv, query, nil, superXform, false)
+			// Form a fake version of a conversation so we don't need to hit the network ever here
+			var conv chat1.Conversation
+			conv.Metadata.ConversationID = convID
+			err = s.postProcessThread(ctx, uid, conv, &tv, query, superXform, false)
 		}
 	}()
 
@@ -719,13 +713,6 @@ func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID cha
 		return chat1.ThreadView{}, err
 	}
 
-	// Identify this TLF by running crypt keys
-	// XXX might need finalize info
-	if ierr := s.identifyTLF(ctx, convID, uid, tv.Messages, nil); ierr != nil {
-		s.Debug(ctx, "PullLocalOnly: identify failed: %s", ierr.Error())
-		return chat1.ThreadView{}, ierr
-	}
-
 	return tv, nil
 }
 
@@ -739,8 +726,9 @@ func (m ByMsgID) Len() int           { return len(m) }
 func (m ByMsgID) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 func (m ByMsgID) Less(i, j int) bool { return m[i].GetMessageID() > m[j].GetMessageID() }
 
-func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1.ConversationID,
-	uid gregor1.UID, msgIDs []chat1.MessageID, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error) {
+func (s *HybridConversationSource) GetMessages(ctx context.Context, conv chat1.Conversation,
+	uid gregor1.UID, msgIDs []chat1.MessageID) ([]chat1.MessageUnboxed, error) {
+	convID := conv.GetConvID()
 	s.lockTab.Acquire(ctx, uid, convID)
 	defer s.lockTab.Release(ctx, uid, convID)
 
@@ -778,7 +766,7 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 		}
 
 		// Unbox all the remote messages
-		rmsgsUnboxed, err := s.boxer.UnboxMessages(ctx, rmsgs.Msgs, convID, finalizeInfo)
+		rmsgsUnboxed, err := s.boxer.UnboxMessages(ctx, rmsgs.Msgs, conv)
 		if err != nil {
 			return nil, err
 		}
@@ -805,7 +793,7 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 	}
 
 	// Identify this TLF by running crypt keys
-	if ierr := s.identifyTLF(ctx, convID, uid, res, finalizeInfo); ierr != nil {
+	if ierr := s.identifyTLF(ctx, conv, uid, res); ierr != nil {
 		s.Debug(ctx, "GetMessages: identify failed: %s", ierr.Error())
 		return nil, ierr
 	}
@@ -814,8 +802,8 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 }
 
 func (s *HybridConversationSource) GetMessagesWithRemotes(ctx context.Context,
-	convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageBoxed,
-	finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error) {
+	conv chat1.Conversation, uid gregor1.UID, msgs []chat1.MessageBoxed) ([]chat1.MessageUnboxed, error) {
+	convID := conv.GetConvID()
 	s.lockTab.Acquire(ctx, uid, convID)
 	defer s.lockTab.Release(ctx, uid, convID)
 
@@ -849,7 +837,7 @@ func (s *HybridConversationSource) GetMessagesWithRemotes(ctx context.Context,
 				return nil, OfflineError{}
 			}
 
-			unboxed, err := s.boxer.UnboxMessage(ctx, msg, convID, finalizeInfo)
+			unboxed, err := s.boxer.UnboxMessage(ctx, msg, conv)
 			if err != nil {
 				return res, err
 			}
@@ -865,7 +853,7 @@ func (s *HybridConversationSource) GetMessagesWithRemotes(ctx context.Context,
 	}
 
 	// Identify this TLF by running crypt keys
-	if ierr := s.identifyTLF(ctx, convID, uid, res, finalizeInfo); ierr != nil {
+	if ierr := s.identifyTLF(ctx, conv, uid, res); ierr != nil {
 		s.Debug(ctx, "Pull: identify failed: %s", ierr.Error())
 		return res, ierr
 	}

--- a/go/chat/identify_test.go
+++ b/go/chat/identify_test.go
@@ -9,15 +9,13 @@ import (
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/engine"
-	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/stretchr/testify/require"
 )
 
 func TestChatBackgroundIdentify(t *testing.T) {
-
-	world, _, _, _, listener, _ := setupTest(t, 2)
+	_, world, _, _, _, listener := setupTest(t, 2)
 	defer world.Cleanup()
 
 	u := world.GetUsers()[0]
@@ -47,7 +45,7 @@ func TestChatBackgroundIdentify(t *testing.T) {
 	}
 	require.NoError(t, inbox.Merge(context.TODO(), 1, []chat1.Conversation{conv}, nil, nil))
 
-	handler := NewIdentifyChangedHandler(g, kbtest.NewTlfMock(world))
+	handler := NewIdentifyChangedHandler(g)
 	require.NotNil(t, handler.G().NotifyRouter, "notify router")
 
 	t.Logf("new error job in inbox")

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -4,37 +4,65 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/types"
-	"github.com/keybase/client/go/protocol/keybase1"
-	context "golang.org/x/net/context"
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/protocol/chat1"
+	"golang.org/x/net/context"
 )
 
 // KeyFinder remembers results from previous calls to CryptKeys().
 type KeyFinder interface {
-	Find(ctx context.Context, tlf types.TLFInfoSource, tlfName string, tlfPublic bool) (keybase1.GetTLFCryptKeysRes, error)
+	Find(ctx context.Context, name string, membersType chat1.ConversationMembersType, public bool) (types.NameInfo, error)
+	SetNameInfoSourceOverride(types.NameInfoSource)
 }
 
 type KeyFinderImpl struct {
+	globals.Contextified
+	utils.DebugLabeler
 	sync.Mutex
-	keys map[string]keybase1.GetTLFCryptKeysRes
+
+	keys map[string]types.NameInfo
+
+	// Testing
+	testingNameInfoSource types.NameInfoSource
 }
 
 // NewKeyFinder creates a KeyFinder.
-func NewKeyFinder() KeyFinder {
+func NewKeyFinder(g *globals.Context) KeyFinder {
 	return &KeyFinderImpl{
-		keys: make(map[string]keybase1.GetTLFCryptKeysRes),
+		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "KeyFinder", false),
+		keys:         make(map[string]types.NameInfo),
 	}
 }
 
-func (k *KeyFinderImpl) cacheKey(tlfName string, tlfPublic bool) string {
-	return fmt.Sprintf("%s|%v", tlfName, tlfPublic)
+func (k *KeyFinderImpl) cacheKey(name string, membersType chat1.ConversationMembersType, public bool) string {
+	return fmt.Sprintf("%s|%v|%v", name, membersType, public)
+}
+
+func (k *KeyFinderImpl) createNameInfoSource(ctx context.Context,
+	membersType chat1.ConversationMembersType) types.NameInfoSource {
+	if k.testingNameInfoSource != nil {
+		k.Debug(ctx, "createNameInfoSource: warning: using overridden name info source")
+		return k.testingNameInfoSource
+	}
+	switch membersType {
+	case chat1.ConversationMembersType_KBFS:
+		return NewKBFSNameInfoSource(k.G())
+	case chat1.ConversationMembersType_TEAM:
+		return NewTeamsNameInfoSource(k.G())
+	}
+	k.Debug(ctx, "createNameInfoSource: unknown members type, using KBFS: %v", membersType)
+	return NewKBFSNameInfoSource(k.G())
 }
 
 // Find finds keybase1.TLFCryptKeys for tlfName, checking for existing
 // results.
-func (k *KeyFinderImpl) Find(ctx context.Context, tlf types.TLFInfoSource, tlfName string, tlfPublic bool) (keybase1.GetTLFCryptKeysRes, error) {
+func (k *KeyFinderImpl) Find(ctx context.Context, name string,
+	membersType chat1.ConversationMembersType, public bool) (types.NameInfo, error) {
 
-	ckey := k.cacheKey(tlfName, tlfPublic)
+	ckey := k.cacheKey(name, membersType, public)
 	k.Lock()
 	existing, ok := k.keys[ckey]
 	k.Unlock()
@@ -42,25 +70,26 @@ func (k *KeyFinderImpl) Find(ctx context.Context, tlf types.TLFInfoSource, tlfNa
 		return existing, nil
 	}
 
-	var keys keybase1.GetTLFCryptKeysRes
-	if tlfPublic {
-		res, err := tlf.PublicCanonicalTLFNameAndID(ctx, tlfName)
-		if err != nil {
-			return keybase1.GetTLFCryptKeysRes{}, err
-		}
-		keys.NameIDBreaks = res
-		keys.CryptKeys = []keybase1.CryptKey{publicCryptKey}
-	} else {
-		var err error
-		keys, err = tlf.CryptKeys(ctx, tlfName)
-		if err != nil {
-			return keybase1.GetTLFCryptKeysRes{}, err
-		}
+	vis := chat1.TLFVisibility_PRIVATE
+	if public {
+		vis = chat1.TLFVisibility_PUBLIC
+	}
+	nameSource := k.createNameInfoSource(ctx, membersType)
+	nameInfo, err := nameSource.Lookup(ctx, name, vis)
+	if err != nil {
+		return types.NameInfo{}, err
+	}
+	if public {
+		nameInfo.CryptKeys = append(nameInfo.CryptKeys, publicCryptKey)
 	}
 
 	k.Lock()
-	k.keys[ckey] = keys
+	k.keys[ckey] = nameInfo
 	k.Unlock()
 
-	return keys, nil
+	return nameInfo, nil
+}
+
+func (k *KeyFinderImpl) SetNameInfoSourceOverride(ni types.NameInfoSource) {
+	k.testingNameInfoSource = ni
 }

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -222,7 +222,7 @@ func (g *PushHandler) TlfFinalize(ctx context.Context, m gregor.OutOfBandMessage
 
 	// Order updates based on inbox version of the update from the server
 	cb := g.orderer.WaitForTurn(ctx, uid, update.InboxVers)
-	bctx := BackgroundContext(ctx, g.G().GetEnv())
+	bctx := BackgroundContext(ctx, g.G())
 	go func(ctx context.Context) {
 		defer g.Trace(ctx, func() error { return err }, "TlfFinalize(goroutine)")()
 		<-cb
@@ -282,7 +282,7 @@ func (g *PushHandler) TlfResolve(ctx context.Context, m gregor.OutOfBandMessage)
 
 	// Order updates based on inbox version of the update from the server
 	cb := g.orderer.WaitForTurn(ctx, uid, update.InboxVers)
-	bctx := BackgroundContext(ctx, g.G().GetEnv())
+	bctx := BackgroundContext(ctx, g.G())
 	go func(ctx context.Context) {
 		defer g.Trace(ctx, func() error { return nil }, "TlfResolve(goroutine)")()
 		<-cb
@@ -323,7 +323,7 @@ func (g *PushHandler) TlfResolve(ctx context.Context, m gregor.OutOfBandMessage)
 
 func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, g.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
+	ctx = Context(ctx, g.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
 		g.identNotifier)
 	defer g.Trace(ctx, func() error { return err }, "Activity")()
 	if m.Body() == nil {
@@ -345,7 +345,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 
 	// Order updates based on inbox version of the update from the server
 	cb := g.orderer.WaitForTurn(ctx, uid, gm.InboxVers)
-	bctx := BackgroundContext(ctx, g.G().GetEnv())
+	bctx := BackgroundContext(ctx, g.G())
 	go func(ctx context.Context) {
 		defer g.Trace(ctx, func() error { return nil }, "Activity(goroutine)")()
 		<-cb
@@ -542,7 +542,7 @@ func (g *PushHandler) notifyNewChatActivity(ctx context.Context, uid gregor.UID,
 
 func (g *PushHandler) Typing(ctx context.Context, m gregor.OutOfBandMessage) (err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = Context(ctx, g.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
+	ctx = Context(ctx, g.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
 		g.identNotifier)
 	defer g.Trace(ctx, func() error { return err }, "Typing")()
 	if m.Body() == nil {

--- a/go/chat/retry.go
+++ b/go/chat/retry.go
@@ -231,7 +231,7 @@ func (f *FetchRetrier) spawnRetrier(ctx context.Context, uid gregor1.UID, desc t
 
 	attempts := 1
 	nextTime := f.nextAttemptTime(attempts, f.clock.Now())
-	ctx = BackgroundContext(ctx, f.G().Env)
+	ctx = BackgroundContext(ctx, f.G())
 	go func() {
 		for {
 			select {

--- a/go/chat/retry_test.go
+++ b/go/chat/retry_test.go
@@ -24,7 +24,7 @@ func (e errorClient) Notify(ctx context.Context, method string, arg interface{})
 }
 
 func TestFetchRetry(t *testing.T) {
-	world, ri2, _, sender, list, tlf := setupTest(t, 3)
+	ctx, world, ri2, _, sender, list := setupTest(t, 3)
 	defer world.Cleanup()
 
 	ri := ri2.(*kbtest.ChatRemoteMock)
@@ -38,9 +38,9 @@ func TestFetchRetry(t *testing.T) {
 
 	var convIDs []chat1.ConversationID
 	var convs []chat1.Conversation
-	convs = append(convs, newConv(t, uid, ri, sender, tlf, u.Username+","+u1.Username))
-	convs = append(convs, newConv(t, uid, ri, sender, tlf, u.Username+","+u2.Username))
-	convs = append(convs, newConv(t, uid, ri, sender, tlf, u.Username+","+u2.Username+","+u1.Username))
+	convs = append(convs, newConv(ctx, t, tc, uid, ri, sender, u.Username+","+u1.Username))
+	convs = append(convs, newConv(ctx, t, tc, uid, ri, sender, u.Username+","+u2.Username))
+	convs = append(convs, newConv(ctx, t, tc, uid, ri, sender, u.Username+","+u2.Username+","+u1.Username))
 	for _, conv := range convs {
 		convIDs = append(convIDs, conv.GetConvID())
 	}
@@ -51,13 +51,13 @@ func TestFetchRetry(t *testing.T) {
 	errorRI := func() chat1.RemoteInterface { return chat1.RemoteClient{Cli: errorClient{}} }
 	tc.ChatG.ConvSource.SetRemoteInterface(errorRI)
 
-	inbox, _, err := tc.ChatG.InboxSource.Read(context.TODO(), uid, nil, true, &chat1.GetInboxLocalQuery{
+	inbox, _, err := tc.ChatG.InboxSource.Read(ctx, uid, nil, true, &chat1.GetInboxLocalQuery{
 		ConvIDs: convIDs,
 	}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, inbox.Convs[2].Error)
 	require.Nil(t, inbox.Convs[0].Error)
-	tc.ChatG.FetchRetrier.Failure(context.TODO(), uid,
+	tc.ChatG.FetchRetrier.Failure(ctx, uid,
 		NewConversationRetry(tc.Context(), inbox.Convs[2].GetConvID(), ThreadLoad))
 
 	// Advance clock and check for errors on all conversations
@@ -78,9 +78,9 @@ func TestFetchRetry(t *testing.T) {
 	}
 
 	t.Logf("trying to use Force")
-	tc.ChatG.FetchRetrier.Failure(context.TODO(), uid,
+	tc.ChatG.FetchRetrier.Failure(ctx, uid,
 		NewConversationRetry(tc.Context(), inbox.Convs[2].GetConvID(), ThreadLoad))
-	tc.ChatG.FetchRetrier.Force(context.TODO())
+	tc.ChatG.FetchRetrier.Force(ctx)
 	select {
 	case cids := <-list.threadsStale:
 		require.Equal(t, 1, len(cids))
@@ -90,11 +90,11 @@ func TestFetchRetry(t *testing.T) {
 
 	t.Logf("testing full inbox retry")
 	ttype := chat1.TopicType_CHAT
-	tc.Context().FetchRetrier.Failure(context.TODO(), uid,
+	tc.Context().FetchRetrier.Failure(ctx, uid,
 		NewFullInboxRetry(tc.Context(), &chat1.GetInboxLocalQuery{
 			TopicType: &ttype,
 		}, &chat1.Pagination{Num: 10}))
-	tc.Context().FetchRetrier.Force(context.TODO())
+	tc.Context().FetchRetrier.Force(ctx)
 	select {
 	case <-list.inboxStale:
 	case <-time.After(20 * time.Second):

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -4,6 +4,7 @@
 package chat
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 	"sort"
@@ -16,18 +17,98 @@ import (
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/msgchecker"
 	"github.com/keybase/client/go/chat/storage"
+	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams"
 	"github.com/keybase/go-codec/codec"
 	"github.com/stretchr/testify/require"
 )
 
+func newTestContext(tc *kbtest.ChatTestContext) context.Context {
+	return Context(context.Background(), tc.Context(), keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		nil, NewIdentifyNotifier(tc.Context()))
+}
+
+func newTestContextWithTlfMock(tc *kbtest.ChatTestContext, tlfMock types.NameInfoSource) context.Context {
+	ctx := newTestContext(tc)
+	CtxKeyFinder(ctx, tc.Context()).SetNameInfoSourceOverride(tlfMock)
+	return ctx
+}
+
+type testUISource struct {
+}
+
+func (t testUISource) GetChatUI(sessionID int) libkb.ChatUI {
+	return nil
+}
+
+func (t testUISource) GetStreamUICli() *keybase1.StreamUiClient {
+	return &keybase1.StreamUiClient{Cli: nil}
+}
+
+func createTeam(tc libkb.TestContext) string {
+	b, err := libkb.RandBytes(4)
+	if err != nil {
+		tc.T.Fatal(err)
+	}
+	name := hex.EncodeToString(b)
+	err = teams.CreateRootTeam(context.TODO(), tc.G, name)
+	if err != nil {
+		tc.T.Fatal(err)
+	}
+	return name
+}
+
+func createTeamWithUsers(tc libkb.TestContext, users []*kbtest.FakeUser) string {
+	name := createTeam(tc)
+	for _, u := range users {
+		teams.SetRoleWriter(context.TODO(), tc.G, name, u.Username)
+	}
+	return name
+}
+
+type byUsername []*kbtest.FakeUser
+
+func (b byUsername) Len() int      { return len(b) }
+func (b byUsername) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b byUsername) Less(i, j int) bool {
+	return strings.Compare(b[i].Username, b[j].Username) < 0
+}
+
+func teamKey(users []*kbtest.FakeUser) (res string) {
+	ucopy := make([]*kbtest.FakeUser, len(users))
+	copy(ucopy, users)
+	sort.Sort(byUsername(ucopy))
+	for _, u := range ucopy {
+		res += u.Username
+	}
+	return res
+}
+
+var useTLFMock = true
+
+func runWithMemberTypes(t *testing.T, f func(membersType chat1.ConversationMembersType)) {
+	useTLFMock = true
+	start := time.Now()
+	t.Logf("KBFS Stage Begin")
+	f(chat1.ConversationMembersType_KBFS)
+	t.Logf("KBFS Stage End: %v", time.Now().Sub(start))
+	useTLFMock = false
+	t.Logf("Team Stage Begin")
+	start = time.Now()
+	f(chat1.ConversationMembersType_TEAM)
+	t.Logf("Team Stage End: %v", time.Now().Sub(start))
+	useTLFMock = true
+}
+
 type chatTestUserContext struct {
-	u *kbtest.FakeUser
-	h *Server
+	startCtx context.Context
+	u        *kbtest.FakeUser
+	h        *Server
 }
 
 func (tuc *chatTestUserContext) user() *kbtest.FakeUser {
@@ -42,28 +123,19 @@ type chatTestContext struct {
 	world *kbtest.ChatMockWorld
 
 	userContextCache map[string]*chatTestUserContext
+	teamCache        map[string]string
 }
 
 func makeChatTestContext(t *testing.T, name string, numUsers int) *chatTestContext {
 	ctc := &chatTestContext{}
 	ctc.world = kbtest.NewChatMockWorld(t, name, numUsers)
 	ctc.userContextCache = make(map[string]*chatTestUserContext)
+	ctc.teamCache = make(map[string]string)
 	return ctc
 }
 
 func (c *chatTestContext) advanceFakeClock(d time.Duration) {
 	c.world.Fc.Advance(d)
-}
-
-type testUISource struct {
-}
-
-func (t testUISource) GetChatUI(sessionID int) libkb.ChatUI {
-	return nil
-}
-
-func (t testUISource) GetStreamUICli() *keybase1.StreamUiClient {
-	return &keybase1.StreamUiClient{Cli: nil}
 }
 
 func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserContext {
@@ -84,15 +156,20 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	mockRemote := kbtest.NewChatRemoteMock(c.world)
 	mockRemote.SetCurrentUser(user.User.GetUID().ToBytes())
 
-	h.tlfInfoSource = kbtest.NewTlfMock(c.world)
-	h.boxer = NewBoxer(g, h.tlfInfoSource)
+	var ctx context.Context
+	tlf := kbtest.NewTlfMock(c.world)
+	if useTLFMock {
+		ctx = newTestContextWithTlfMock(tc, tlf)
+	} else {
+		ctx = newTestContext(tc)
+	}
+
+	h.boxer = NewBoxer(g)
 
 	chatStorage := storage.New(g)
 	g.ConvSource = NewHybridConversationSource(g, h.boxer, chatStorage,
 		func() chat1.RemoteInterface { return mockRemote })
-	g.InboxSource = NewHybridInboxSource(g,
-		func() chat1.RemoteInterface { return mockRemote },
-		h.tlfInfoSource)
+	g.InboxSource = NewHybridInboxSource(g, func() chat1.RemoteInterface { return mockRemote })
 	g.ServerCacheVersions = storage.NewServerVersions(g)
 	chatSyncer := NewSyncer(g)
 	g.Syncer = chatSyncer
@@ -100,10 +177,12 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 
 	h.setTestRemoteClient(mockRemote)
 
-	baseSender := NewBlockingSender(g, h.boxer, nil,
-		func() chat1.RemoteInterface { return mockRemote })
+	baseSender := NewBlockingSender(g, h.boxer, nil, func() chat1.RemoteInterface { return mockRemote })
 	deliverer := NewDeliverer(g, baseSender)
 	deliverer.SetClock(c.world.Fc)
+	if useTLFMock {
+		deliverer.setTestingNameInfoSource(tlf)
+	}
 	g.MessageDeliverer = deliverer
 	g.MessageDeliverer.Start(context.TODO(), user.User.GetUID().ToBytes())
 	g.MessageDeliverer.Connected(context.TODO())
@@ -115,8 +194,9 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	g.FetchRetrier.Start(context.TODO(), user.User.GetUID().ToBytes())
 
 	tuc := &chatTestUserContext{
-		h: h,
-		u: user,
+		h:        h,
+		u:        user,
+		startCtx: ctx,
 	}
 	c.userContextCache[user.Username] = tuc
 	return tuc
@@ -133,27 +213,56 @@ func (c *chatTestContext) users() (users []*kbtest.FakeUser) {
 	return users
 }
 
-func mustCreatePublicConversationForTest(t *testing.T, ctc *chatTestContext, creator *kbtest.FakeUser, topicType chat1.TopicType, others ...string) (created chat1.ConversationInfoLocal) {
+func mustCreatePublicConversationForTest(t *testing.T, ctc *chatTestContext, creator *kbtest.FakeUser,
+	topicType chat1.TopicType, membersType chat1.ConversationMembersType, others ...*kbtest.FakeUser) (created chat1.ConversationInfoLocal) {
 	created = mustCreateConversationForTestNoAdvanceClock(t, ctc, creator, topicType,
-		chat1.TLFVisibility_PUBLIC, others...)
+		chat1.TLFVisibility_PUBLIC, membersType, others...)
 	ctc.advanceFakeClock(time.Second)
 	return created
 }
 
-func mustCreateConversationForTest(t *testing.T, ctc *chatTestContext, creator *kbtest.FakeUser, topicType chat1.TopicType, others ...string) (created chat1.ConversationInfoLocal) {
+func mustCreateConversationForTest(t *testing.T, ctc *chatTestContext, creator *kbtest.FakeUser,
+	topicType chat1.TopicType, membersType chat1.ConversationMembersType, others ...*kbtest.FakeUser) (created chat1.ConversationInfoLocal) {
 	created = mustCreateConversationForTestNoAdvanceClock(t, ctc, creator, topicType,
-		chat1.TLFVisibility_PRIVATE, others...)
+		chat1.TLFVisibility_PRIVATE, membersType, others...)
 	ctc.advanceFakeClock(time.Second)
 	return created
 }
 
-func mustCreateConversationForTestNoAdvanceClock(t *testing.T, ctc *chatTestContext, creator *kbtest.FakeUser, topicType chat1.TopicType, visibility chat1.TLFVisibility, others ...string) (created chat1.ConversationInfoLocal) {
+func mustCreateConversationForTestNoAdvanceClock(t *testing.T, ctc *chatTestContext,
+	creator *kbtest.FakeUser, topicType chat1.TopicType, visibility chat1.TLFVisibility,
+	membersType chat1.ConversationMembersType, others ...*kbtest.FakeUser) (created chat1.ConversationInfoLocal) {
 	var err error
-	ncres, err := ctc.as(t, creator).chatLocalHandler().NewConversationLocal(context.Background(), chat1.NewConversationLocalArg{
-		TlfName:       strings.Join(others, ",") + "," + creator.Username,
-		TopicType:     topicType,
-		TlfVisibility: visibility,
-	})
+
+	// Create conversation name based on list of users
+	var name string
+	switch membersType {
+	case chat1.ConversationMembersType_KBFS:
+		var othersStr []string
+		for _, other := range others {
+			othersStr = append(othersStr, other.Username)
+		}
+		name = strings.Join(othersStr, ",") + "," + creator.Username
+	case chat1.ConversationMembersType_TEAM:
+		tc := ctc.world.Tcs[creator.Username]
+		users := append(others, creator)
+		key := teamKey(users)
+		if tn, ok := ctc.teamCache[key]; !ok {
+			name = createTeamWithUsers(tc.TestContext, users)
+			ctc.teamCache[key] = name
+		} else {
+			name = tn
+		}
+	}
+
+	tc := ctc.as(t, creator)
+	ncres, err := tc.chatLocalHandler().NewConversationLocal(tc.startCtx,
+		chat1.NewConversationLocalArg{
+			TlfName:       name,
+			TopicType:     topicType,
+			TlfVisibility: visibility,
+			MembersType:   membersType,
+		})
 	if err != nil {
 		t.Fatalf("NewConversationLocal error: %v\n", err)
 	}
@@ -165,7 +274,8 @@ func postLocalForTestNoAdvanceClock(t *testing.T, ctc *chatTestContext, asUser *
 	if err != nil {
 		t.Fatalf("msg.MessageType() error: %v\n", err)
 	}
-	return ctc.as(t, asUser).chatLocalHandler().PostLocal(context.Background(), chat1.PostLocalArg{
+	tc := ctc.as(t, asUser)
+	return ctc.as(t, asUser).chatLocalHandler().PostLocal(tc.startCtx, chat1.PostLocalArg{
 		ConversationID: conv.Id,
 		Msg: chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
@@ -196,581 +306,654 @@ func mustPostLocalForTest(t *testing.T, ctc *chatTestContext, asUser *kbtest.Fak
 }
 
 func TestChatNewConversationLocal(t *testing.T) {
-	ctc := makeChatTestContext(t, "NewConversationLocal", 2)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "NewConversationLocal", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
+		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt,
+			ctc.as(t, users[1]).user())
 
-	conv := ctc.world.GetConversationByID(created.Id)
-	if len(conv.MaxMsgs) == 0 {
-		t.Fatalf("created conversation does not have a message")
-	}
-	if conv.MaxMsgs[0].ClientHeader.TlfName !=
-		string(kbtest.CanonicalTlfNameForTest(ctc.as(t, users[0]).user().Username+","+ctc.as(t, users[1]).user().Username)) {
-		t.Fatalf("unexpected TLF name in created conversation. expected %s, got %s", ctc.as(t, users[0]).user().Username+","+ctc.as(t, users[1]).user().Username, conv.MaxMsgs[0].ClientHeader.TlfName)
-	}
+		conv := ctc.world.GetConversationByID(created.Id)
+		if len(conv.MaxMsgs) == 0 {
+			t.Fatalf("created conversation does not have a message")
+		}
+
+		switch mt {
+		case chat1.ConversationMembersType_KBFS:
+			if conv.MaxMsgs[0].ClientHeader.TlfName !=
+				string(kbtest.CanonicalTlfNameForTest(ctc.as(t, users[0]).user().Username+","+ctc.as(t, users[1]).user().Username)) {
+				t.Fatalf("unexpected TLF name in created conversation. expected %s, got %s", ctc.as(t, users[0]).user().Username+","+ctc.as(t, users[1]).user().Username, conv.MaxMsgs[0].ClientHeader.TlfName)
+			}
+		case chat1.ConversationMembersType_TEAM:
+			teamName := ctc.teamCache[teamKey(ctc.users())]
+			require.Equal(t, teamName, conv.MaxMsgs[0].ClientHeader.TlfName)
+		}
+	})
 }
 
 func TestChatNewChatConversationLocalTwice(t *testing.T) {
-	ctc := makeChatTestContext(t, "NewConversationLocal", 2)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "NewConversationLocal", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	c1 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
-	c2 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
+		c1 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
+		c2 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
 
-	if !c2.Id.Eq(c1.Id) {
-		t.Fatalf("2nd call to NewConversationLocal for a chat conversation did not return the same conversation ID")
-	}
+		t.Logf("c1: %v c2: %v", c1, c2)
+		if !c2.Id.Eq(c1.Id) {
+			t.Fatalf("2nd call to NewConversationLocal for a chat conversation did not return the same conversation ID")
+		}
+	})
 }
 
 func TestChatNewDevConversationLocalTwice(t *testing.T) {
-	ctc := makeChatTestContext(t, "NewConversationLocal", 2)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "NewConversationLocal", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_DEV, ctc.as(t, users[1]).user().Username)
-	mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_DEV, ctc.as(t, users[1]).user().Username)
+		mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_DEV,
+			mt, ctc.as(t, users[1]).user())
+		mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_DEV,
+			mt, ctc.as(t, users[1]).user())
+	})
 }
 
 func TestChatGetInboxAndUnboxLocal(t *testing.T) {
-	ctc := makeChatTestContext(t, "ResolveConversationLocal", 2)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "ResolveConversationLocal", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
+		ctx := ctc.as(t, users[0]).startCtx
+		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
 
-	gilres, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxAndUnboxLocal(context.Background(), chat1.GetInboxAndUnboxLocalArg{
-		Query: &chat1.GetInboxLocalQuery{
-			ConvIDs: []chat1.ConversationID{created.Id},
-		},
+		gilres, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
+			Query: &chat1.GetInboxLocalQuery{
+				ConvIDs: []chat1.ConversationID{created.Id},
+			},
+		})
+		if err != nil {
+			t.Fatalf("GetInboxAndUnboxLocal error: %v", err)
+		}
+		conversations := gilres.Conversations
+		if len(conversations) != 1 {
+			t.Fatalf("unexpected response from GetInboxAndUnboxLocal. expected 1 items, got %d\n", len(conversations))
+		}
+		conv := ctc.world.GetConversationByID(created.Id)
+		if conversations[0].Info.TlfName != conv.MaxMsgs[0].ClientHeader.TlfName {
+			t.Fatalf("unexpected TlfName in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.TlfName, conv.MaxMsgs[0].ClientHeader.TlfName)
+		}
+		if !conversations[0].Info.Id.Eq(created.Id) {
+			t.Fatalf("unexpected Id in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.Id, created.Id)
+		}
+		if conversations[0].Info.Triple.TopicType != chat1.TopicType_CHAT {
+			t.Fatalf("unexpected topicType in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.Triple.TopicType, chat1.TopicType_CHAT)
+		}
 	})
-	if err != nil {
-		t.Fatalf("GetInboxAndUnboxLocal error: %v", err)
-	}
-	conversations := gilres.Conversations
-	if len(conversations) != 1 {
-		t.Fatalf("unexpected response from GetInboxAndUnboxLocal. expected 1 items, got %d\n", len(conversations))
-	}
-	conv := ctc.world.GetConversationByID(created.Id)
-	if conversations[0].Info.TlfName != conv.MaxMsgs[0].ClientHeader.TlfName {
-		t.Fatalf("unexpected TlfName in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.TlfName, conv.MaxMsgs[0].ClientHeader.TlfName)
-	}
-	if !conversations[0].Info.Id.Eq(created.Id) {
-		t.Fatalf("unexpected Id in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.Id, created.Id)
-	}
-	if conversations[0].Info.Triple.TopicType != chat1.TopicType_CHAT {
-		t.Fatalf("unexpected topicType in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.Triple.TopicType, chat1.TopicType_CHAT)
-	}
 }
 
 func TestGetInboxNonblock(t *testing.T) {
-	ctc := makeChatTestContext(t, "GetInboxNonblockLocal", 6)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "GetInboxNonblockLocal", 6)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	numconvs := 5
-	inboxCb := make(chan kbtest.NonblockInboxResult, 100)
-	threadCb := make(chan kbtest.NonblockThreadResult, 100)
-	ui := kbtest.NewChatUI(inboxCb, threadCb)
-	ctc.as(t, users[0]).h.mockChatUI = ui
+		numconvs := 5
+		inboxCb := make(chan kbtest.NonblockInboxResult, 100)
+		threadCb := make(chan kbtest.NonblockThreadResult, 100)
+		ui := kbtest.NewChatUI(inboxCb, threadCb)
+		ctc.as(t, users[0]).h.mockChatUI = ui
 
-	// Create a bunch of blank convos
-	convs := make(map[string]bool)
-	for i := 0; i < numconvs; i++ {
-		convs[mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[i+1]).user().Username).Id.String()] = true
-	}
-
-	t.Logf("blank convos test")
-	// Get inbox (should be blank)
-	_, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxNonblockLocal(context.TODO(),
-		chat1.GetInboxNonblockLocalArg{
-			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-		},
-	)
-	require.NoError(t, err)
-	select {
-	case ibox := <-inboxCb:
-		require.NotNil(t, ibox.InboxRes, "nil inbox")
-		require.Zero(t, len(ibox.InboxRes.ConversationsUnverified), "wrong size inbox")
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no inbox received")
-	}
-	// Get all convos
-	for i := 0; i < numconvs; i++ {
-		select {
-		case conv := <-inboxCb:
-			require.NotNil(t, conv.ConvRes, "no conv")
-			delete(convs, conv.ConvID.String())
-		case <-time.After(20 * time.Second):
-			require.Fail(t, "no conv received")
+		// Create a bunch of blank convos
+		convs := make(map[string]bool)
+		for i := 0; i < numconvs; i++ {
+			created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+				mt, ctc.as(t, users[i+1]).user())
+			convs[created.Id.String()] = true
 		}
-	}
-	require.Equal(t, 0, len(convs), "didnt get all convs")
 
-	// Send a bunch of messages
-	t.Logf("messages in convos test")
-	convs = make(map[string]bool)
-	for i := 0; i < numconvs; i++ {
-		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[i+1]).user().Username)
-		convs[conv.Id.String()] = true
-
-		_, err := ctc.as(t, users[0]).chatLocalHandler().PostLocal(context.TODO(), chat1.PostLocalArg{
-			ConversationID: conv.Id,
-			Msg: chat1.MessagePlaintext{
-				ClientHeader: chat1.MessageClientHeader{
-					Conv:        conv.Triple,
-					MessageType: chat1.MessageType_TEXT,
-					TlfName:     conv.TlfName,
-				},
-				MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
-					Body: "HI",
-				}),
+		ctx := ctc.as(t, users[0]).startCtx
+		t.Logf("blank convos test")
+		// Get inbox (should be blank)
+		_, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxNonblockLocal(ctx,
+			chat1.GetInboxNonblockLocalArg{
+				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 			},
-		})
+		)
 		require.NoError(t, err)
-	}
-
-	// Get inbox (should be blank)
-	_, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxNonblockLocal(context.TODO(),
-		chat1.GetInboxNonblockLocalArg{
-			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-		},
-	)
-	require.NoError(t, err)
-	select {
-	case ibox := <-inboxCb:
-		require.NotNil(t, ibox.InboxRes, "nil inbox")
-		require.Equal(t, len(convs), len(ibox.InboxRes.ConversationsUnverified), "wrong size inbox")
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no inbox received")
-	}
-	// Get all convos
-	for i := 0; i < numconvs; i++ {
 		select {
-		case conv := <-inboxCb:
-			require.NotNil(t, conv.ConvRes, "no conv")
-			delete(convs, conv.ConvID.String())
+		case ibox := <-inboxCb:
+			require.NotNil(t, ibox.InboxRes, "nil inbox")
+			require.Zero(t, len(ibox.InboxRes.ConversationsUnverified), "wrong size inbox")
 		case <-time.After(20 * time.Second):
-			require.Fail(t, "no conv received")
+			require.Fail(t, "no inbox received")
 		}
-	}
-	require.Equal(t, 0, len(convs), "didnt get all convs")
+		// Get all convos
+		for i := 0; i < numconvs; i++ {
+			select {
+			case conv := <-inboxCb:
+				require.NotNil(t, conv.ConvRes, "no conv")
+				delete(convs, conv.ConvID.String())
+			case <-time.After(20 * time.Second):
+				require.Fail(t, "no conv received")
+			}
+		}
+		require.Equal(t, 0, len(convs), "didnt get all convs")
 
-	// Make sure there is nothing left
-	select {
-	case <-inboxCb:
-		require.Fail(t, "should have drained channel")
-	default:
-	}
+		// Send a bunch of messages
+		t.Logf("messages in convos test")
+		convs = make(map[string]bool)
+		for i := 0; i < numconvs; i++ {
+			conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+				mt, ctc.as(t, users[i+1]).user())
+			convs[conv.Id.String()] = true
+
+			_, err := ctc.as(t, users[0]).chatLocalHandler().PostLocal(ctx, chat1.PostLocalArg{
+				ConversationID: conv.Id,
+				Msg: chat1.MessagePlaintext{
+					ClientHeader: chat1.MessageClientHeader{
+						Conv:        conv.Triple,
+						MessageType: chat1.MessageType_TEXT,
+						TlfName:     conv.TlfName,
+					},
+					MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+						Body: "HI",
+					}),
+				},
+			})
+			require.NoError(t, err)
+		}
+
+		// Get inbox (should be blank)
+		_, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxNonblockLocal(ctx,
+			chat1.GetInboxNonblockLocalArg{
+				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+			},
+		)
+		require.NoError(t, err)
+		select {
+		case ibox := <-inboxCb:
+			require.NotNil(t, ibox.InboxRes, "nil inbox")
+			require.Equal(t, len(convs), len(ibox.InboxRes.ConversationsUnverified), "wrong size inbox")
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no inbox received")
+		}
+		// Get all convos
+		for i := 0; i < numconvs; i++ {
+			select {
+			case conv := <-inboxCb:
+				require.NotNil(t, conv.ConvRes, "no conv")
+				delete(convs, conv.ConvID.String())
+			case <-time.After(20 * time.Second):
+				require.Fail(t, "no conv received")
+			}
+		}
+		require.Equal(t, 0, len(convs), "didnt get all convs")
+
+		// Make sure there is nothing left
+		select {
+		case <-inboxCb:
+			require.Fail(t, "should have drained channel")
+		default:
+		}
+	})
 }
 
 func TestChatGetInboxAndUnboxLocalTlfName(t *testing.T) {
-	ctc := makeChatTestContext(t, "ResolveConversationLocal", 2)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "ResolveConversationLocal", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
+		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
 
-	tlfName := ctc.as(t, users[1]).user().Username + "," + ctc.as(t, users[0]).user().Username // not canonical
-	visibility := chat1.TLFVisibility_PRIVATE
-	gilres, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxAndUnboxLocal(context.Background(), chat1.GetInboxAndUnboxLocalArg{
-		Query: &chat1.GetInboxLocalQuery{
-			TlfName:       &tlfName,
-			TlfVisibility: &visibility,
-		},
+		var name string
+		switch mt {
+		case chat1.ConversationMembersType_KBFS:
+			name = ctc.as(t, users[1]).user().Username + "," + ctc.as(t, users[0]).user().Username // not canonical
+		case chat1.ConversationMembersType_TEAM:
+			name = ctc.teamCache[teamKey(ctc.users())]
+		}
+
+		visibility := chat1.TLFVisibility_PRIVATE
+		ctx := ctc.as(t, users[0]).startCtx
+		gilres, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
+			Query: &chat1.GetInboxLocalQuery{
+				Name: &chat1.NameQuery{
+					Name:        name,
+					MembersType: mt,
+				},
+				TlfVisibility: &visibility,
+			},
+		})
+		if err != nil {
+			t.Fatalf("ResolveConversationLocal error: %v", err)
+		}
+		conversations := gilres.Conversations
+		if len(conversations) != 1 {
+			t.Fatalf("unexpected response from GetInboxAndUnboxLocal. expected 1 items, got %d\n", len(conversations))
+		}
+		conv := ctc.world.GetConversationByID(created.Id)
+		if conversations[0].Info.TlfName != conv.MaxMsgs[0].ClientHeader.TlfName {
+			t.Fatalf("unexpected TlfName in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.TlfName, conv.MaxMsgs[0].ClientHeader.TlfName)
+		}
+		if !conversations[0].Info.Id.Eq(created.Id) {
+			t.Fatalf("unexpected Id in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.Id, created.Id)
+		}
+		if conversations[0].Info.Triple.TopicType != chat1.TopicType_CHAT {
+			t.Fatalf("unexpected topicType in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.Triple.TopicType, chat1.TopicType_CHAT)
+		}
 	})
-	if err != nil {
-		t.Fatalf("ResolveConversationLocal error: %v", err)
-	}
-	conversations := gilres.Conversations
-	if len(conversations) != 1 {
-		t.Fatalf("unexpected response from GetInboxAndUnboxLocal. expected 1 items, got %d\n", len(conversations))
-	}
-	conv := ctc.world.GetConversationByID(created.Id)
-	if conversations[0].Info.TlfName != conv.MaxMsgs[0].ClientHeader.TlfName {
-		t.Fatalf("unexpected TlfName in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.TlfName, conv.MaxMsgs[0].ClientHeader.TlfName)
-	}
-	if !conversations[0].Info.Id.Eq(created.Id) {
-		t.Fatalf("unexpected Id in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.Id, created.Id)
-	}
-	if conversations[0].Info.Triple.TopicType != chat1.TopicType_CHAT {
-		t.Fatalf("unexpected topicType in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.Triple.TopicType, chat1.TopicType_CHAT)
-	}
 }
 
 func TestChatPostLocal(t *testing.T) {
-	ctc := makeChatTestContext(t, "PostLocal", 2)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "PostLocal", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
+		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
 
-	// un-canonicalize TLF name
-	parts := strings.Split(created.TlfName, ",")
-	sort.Sort(sort.Reverse(sort.StringSlice(parts)))
-	created.TlfName = strings.Join(parts, ",")
+		// un-canonicalize TLF name
+		t.Logf("TLF name: %s", created.TlfName)
+		parts := strings.Split(created.TlfName, ",")
+		sort.Sort(sort.Reverse(sort.StringSlice(parts)))
+		created.TlfName = strings.Join(parts, ",")
 
-	mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello!"}))
+		mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello!"}))
 
-	// we just posted this message, so should be the first one.
-	msg := ctc.world.Msgs[created.Id.String()][0]
+		// we just posted this message, so should be the first one.
+		msg := ctc.world.Msgs[created.Id.String()][0]
 
-	if msg.ClientHeader.TlfName == created.TlfName {
-		t.Fatalf("PostLocal didn't canonicalize TLF name")
-	}
-
-	if len(msg.ClientHeader.Sender.Bytes()) == 0 || len(msg.ClientHeader.SenderDevice.Bytes()) == 0 {
-		t.Fatalf("PostLocal didn't populate ClientHeader.Sender and/or ClientHeader.SenderDevice\n")
-	}
+		if mt == chat1.ConversationMembersType_KBFS {
+			require.NotEqual(t, created.TlfName, msg.ClientHeader.TlfName)
+		}
+		require.NotZero(t, len(msg.ClientHeader.Sender.Bytes()))
+		require.NotZero(t, len(msg.ClientHeader.SenderDevice.Bytes()))
+	})
 }
 
 func TestChatPostLocalLengthLimit(t *testing.T) {
-	ctc := makeChatTestContext(t, "PostLocal", 2)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "PostLocal", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
+		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
 
-	maxTextBody := strings.Repeat(".", msgchecker.TextMessageMaxLength)
-	_, err := postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: maxTextBody}))
-	if err != nil {
-		t.Fatalf("trying to post a text message with body length equal to the maximum failed")
-	}
-	_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: maxTextBody + "!"}))
-	if err == nil {
-		t.Fatalf("trying to post a text message with body length greater than the maximum did not fail")
-	}
+		maxTextBody := strings.Repeat(".", msgchecker.TextMessageMaxLength)
+		_, err := postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: maxTextBody}))
+		if err != nil {
+			t.Fatalf("trying to post a text message with body length equal to the maximum failed")
+		}
+		_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: maxTextBody + "!"}))
+		if err == nil {
+			t.Fatalf("trying to post a text message with body length greater than the maximum did not fail")
+		}
 
-	maxHeadlineBody := strings.Repeat(".", msgchecker.HeadlineMaxLength)
-	_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: maxHeadlineBody}))
-	if err != nil {
-		t.Fatalf("trying to post a headline message with headline length equal to the maximum failed")
-	}
-	_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: maxHeadlineBody + "!"}))
-	if err == nil {
-		t.Fatalf("trying to post a headline message with headline length greater than the maximum did not fail")
-	}
+		maxHeadlineBody := strings.Repeat(".", msgchecker.HeadlineMaxLength)
+		_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: maxHeadlineBody}))
+		if err != nil {
+			t.Fatalf("trying to post a headline message with headline length equal to the maximum failed")
+		}
+		_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithHeadline(chat1.MessageHeadline{Headline: maxHeadlineBody + "!"}))
+		if err == nil {
+			t.Fatalf("trying to post a headline message with headline length greater than the maximum did not fail")
+		}
 
-	maxTopicBody := strings.Repeat(".", msgchecker.TopicMaxLength)
-	_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{ConversationTitle: maxTopicBody}))
-	if err != nil {
-		t.Fatalf("trying to post a ConversationMetadata message with ConversationTitle length equal to the maximum failed")
-	}
-	_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{ConversationTitle: maxTopicBody + "!"}))
-	if err == nil {
-		t.Fatalf("trying to post a ConversationMetadata message with ConversationTitle length greater than the maximum did not fail")
-	}
+		maxTopicBody := strings.Repeat(".", msgchecker.TopicMaxLength)
+		_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{ConversationTitle: maxTopicBody}))
+		if err != nil {
+			t.Fatalf("trying to post a ConversationMetadata message with ConversationTitle length equal to the maximum failed")
+		}
+		_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{ConversationTitle: maxTopicBody + "!"}))
+		if err == nil {
+			t.Fatalf("trying to post a ConversationMetadata message with ConversationTitle length greater than the maximum did not fail")
+		}
+	})
 }
 
 func TestChatGetThreadLocal(t *testing.T) {
-	ctc := makeChatTestContext(t, "GetThreadLocal", 2)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "GetThreadLocal", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
-	mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello!"}))
+		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
+		mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello!"}))
 
-	tvres, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(context.Background(), chat1.GetThreadLocalArg{
-		ConversationID: created.Id,
+		ctx := ctc.as(t, users[0]).startCtx
+		tvres, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(ctx, chat1.GetThreadLocalArg{
+			ConversationID: created.Id,
+		})
+		if err != nil {
+			t.Fatalf("GetThreadLocal error: %v", err)
+		}
+		tv := tvres.Thread
+		if len(tv.Messages) != 2 {
+			t.Fatalf("unexpected response from GetThreadLocal . expected 2 items, got %d\n", len(tv.Messages))
+		}
+		if tv.Messages[0].Valid().MessageBody.Text().Body != "hello!" {
+			t.Fatalf("unexpected response from GetThreadLocal . expected 'hello!' got %#+v\n", tv.Messages[0])
+		}
 	})
-	if err != nil {
-		t.Fatalf("GetThreadLocal error: %v", err)
-	}
-	tv := tvres.Thread
-	if len(tv.Messages) != 2 {
-		t.Fatalf("unexpected response from GetThreadLocal . expected 2 items, got %d\n", len(tv.Messages))
-	}
-	if tv.Messages[0].Valid().MessageBody.Text().Body != "hello!" {
-		t.Fatalf("unexpected response from GetThreadLocal . expected 'hello!' got %#+v\n", tv.Messages[0])
-	}
 }
 
 func TestChatGetThreadLocalMarkAsRead(t *testing.T) {
-	// TODO: investigate LocalDb in TestContext and make it behave the same way
-	// as in real context / docker tests. This test should fail without the fix
-	// in ConvSource for marking is read, but does not currently.
-	ctc := makeChatTestContext(t, "GetThreadLocalMarkAsRead", 2)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		// TODO: investigate LocalDb in TestContext and make it behave the same way
+		// as in real context / docker tests. This test should fail without the fix
+		// in ConvSource for marking is read, but does not currently.
+		ctc := makeChatTestContext(t, "GetThreadLocalMarkAsRead", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	withUser1 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
-	mustPostLocalForTest(t, ctc, users[0], withUser1, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello0"}))
-	mustPostLocalForTest(t, ctc, users[1], withUser1, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello1"}))
-	mustPostLocalForTest(t, ctc, users[0], withUser1, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello2"}))
+		withUser1 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
 
-	res, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(context.Background(), chat1.GetInboxSummaryForCLILocalQuery{
-		TopicType: chat1.TopicType_CHAT,
-	})
-	if err != nil {
-		t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
-	}
-	if len(res.Conversations) != 1 {
-		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 1 items, got %d\n", len(res.Conversations))
-	}
-	if res.Conversations[0].Info.Id.String() != withUser1.Id.String() {
-		t.Fatalf("unexpected conversation returned. Expect %s, got %s", withUser1.Id.String(), res.Conversations[0].Info.Id.String())
-	}
+		mustPostLocalForTest(t, ctc, users[0], withUser1, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello0"}))
+		mustPostLocalForTest(t, ctc, users[1], withUser1, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello1"}))
+		mustPostLocalForTest(t, ctc, users[0], withUser1, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello2"}))
 
-	var found bool
-	for _, m := range res.Conversations[0].MaxMessages {
-		if m.GetMessageType() == chat1.MessageType_TEXT {
-			if res.Conversations[0].ReaderInfo.ReadMsgid == m.GetMessageID() {
-				t.Fatalf("conversation was marked as read before requesting so\n")
-			}
-			found = true
-			break
+		ctx := ctc.as(t, users[0]).startCtx
+		res, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(ctx, chat1.GetInboxSummaryForCLILocalQuery{
+			TopicType: chat1.TopicType_CHAT,
+		})
+		if err != nil {
+			t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
 		}
-	}
-	if !found {
-		t.Fatalf("no TEXT message in returned inbox")
-	}
-
-	// Do a get thread local without requesting marking as read first. This
-	// should cause HybridConversationSource to cache the thread. Then we do
-	// another call requesting marking as read before checking if the thread is
-	// marked as read. This is to ensure that when the query requests for a
-	// mark-as-read, and the thread gets a cache hit, the
-	// HybridConversationSource should not just return the thread, but also send
-	// a MarkAsRead RPC to remote. (Currently this is done in
-	// HybridConversationSource.Pull)
-	//
-	// TODO: This doesn't make sense! In integration tests, this isn't necessary
-	// since a Pull() is called during PostLocal (when populating the Prev
-	// pointers).  However it seems in this test, it doesn't do so. This first
-	// GetThreadLocal always gets a cache miss, resulting a remote call. If
-	// PostLocal had worked like integration, this shouldn't be necessary. We
-	// should find out where the problem is and fix it! Although after that fix,
-	// this should probably still stay here just in case.
-	_, err = ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(context.Background(), chat1.GetThreadLocalArg{
-		ConversationID: withUser1.Id,
-		Query: &chat1.GetThreadQuery{
-			MarkAsRead: false,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	tv, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(context.Background(), chat1.GetThreadLocalArg{
-		ConversationID: withUser1.Id,
-		Query: &chat1.GetThreadQuery{
-			MarkAsRead: true,
-		},
-	})
-	if err != nil {
-		t.Fatalf("GetThreadLocal error: %v", err)
-	}
-	if len(tv.Thread.Messages) != 4 {
-		// 3 messages and 1 TLF
-		t.Fatalf("unexpected response from GetThreadLocal. expected 2 items, got %d\n", len(tv.Thread.Messages))
-	}
-
-	res, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(context.Background(), chat1.GetInboxSummaryForCLILocalQuery{
-		TopicType: chat1.TopicType_CHAT,
-	})
-	if err != nil {
-		t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
-	}
-	if len(res.Conversations) != 1 {
-		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 1 items, got %d\n", len(res.Conversations))
-	}
-
-	found = false
-	for _, m := range res.Conversations[0].MaxMessages {
-		if m.GetMessageType() == chat1.MessageType_TEXT {
-			if res.Conversations[0].ReaderInfo.ReadMsgid != m.GetMessageID() {
-				t.Fatalf("conversation was not marked as read\n")
-			}
-			found = true
-			break
+		if len(res.Conversations) != 1 {
+			t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 1 items, got %d\n", len(res.Conversations))
 		}
-	}
-	if !found {
-		t.Fatalf("no TEXT message in returned inbox")
-	}
+		if res.Conversations[0].Info.Id.String() != withUser1.Id.String() {
+			t.Fatalf("unexpected conversation returned. Expect %s, got %s", withUser1.Id.String(), res.Conversations[0].Info.Id.String())
+		}
+
+		var found bool
+		for _, m := range res.Conversations[0].MaxMessages {
+			if m.GetMessageType() == chat1.MessageType_TEXT {
+				if res.Conversations[0].ReaderInfo.ReadMsgid == m.GetMessageID() {
+					t.Fatalf("conversation was marked as read before requesting so\n")
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("no TEXT message in returned inbox")
+		}
+
+		// Do a get thread local without requesting marking as read first. This
+		// should cause HybridConversationSource to cache the thread. Then we do
+		// another call requesting marking as read before checking if the thread is
+		// marked as read. This is to ensure that when the query requests for a
+		// mark-as-read, and the thread gets a cache hit, the
+		// HybridConversationSource should not just return the thread, but also send
+		// a MarkAsRead RPC to remote. (Currently this is done in
+		// HybridConversationSource.Pull)
+		//
+		// TODO: This doesn't make sense! In integration tests, this isn't necessary
+		// since a Pull() is called during PostLocal (when populating the Prev
+		// pointers).  However it seems in this test, it doesn't do so. This first
+		// GetThreadLocal always gets a cache miss, resulting a remote call. If
+		// PostLocal had worked like integration, this shouldn't be necessary. We
+		// should find out where the problem is and fix it! Although after that fix,
+		// this should probably still stay here just in case.
+		_, err = ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(ctx, chat1.GetThreadLocalArg{
+			ConversationID: withUser1.Id,
+			Query: &chat1.GetThreadQuery{
+				MarkAsRead: false,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		tv, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(ctx, chat1.GetThreadLocalArg{
+			ConversationID: withUser1.Id,
+			Query: &chat1.GetThreadQuery{
+				MarkAsRead: true,
+			},
+		})
+		if err != nil {
+			t.Fatalf("GetThreadLocal error: %v", err)
+		}
+		if len(tv.Thread.Messages) != 4 {
+			// 3 messages and 1 TLF
+			t.Fatalf("unexpected response from GetThreadLocal. expected 2 items, got %d\n", len(tv.Thread.Messages))
+		}
+
+		res, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(ctx, chat1.GetInboxSummaryForCLILocalQuery{
+			TopicType: chat1.TopicType_CHAT,
+		})
+		if err != nil {
+			t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
+		}
+		if len(res.Conversations) != 1 {
+			t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 1 items, got %d\n", len(res.Conversations))
+		}
+
+		found = false
+		for _, m := range res.Conversations[0].MaxMessages {
+			if m.GetMessageType() == chat1.MessageType_TEXT {
+				if res.Conversations[0].ReaderInfo.ReadMsgid != m.GetMessageID() {
+					t.Fatalf("conversation was not marked as read\n")
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("no TEXT message in returned inbox")
+		}
+	})
 }
 
 func TestChatGracefulUnboxing(t *testing.T) {
-	ctc := makeChatTestContext(t, "GracefulUnboxing", 2)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "GracefulUnboxing", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
-	mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "innocent hello"}))
-	mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "evil hello"}))
+		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
+		mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "innocent hello"}))
+		mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "evil hello"}))
 
-	// make evil hello evil
-	ctc.world.Tcs[users[0].Username].ChatG.ConvSource.Clear(created.Id, users[0].User.GetUID().ToBytes())
-	ctc.world.Msgs[created.Id.String()][0].BodyCiphertext.E[0]++
+		// make evil hello evil
+		ctc.world.Tcs[users[0].Username].ChatG.ConvSource.Clear(created.Id, users[0].User.GetUID().ToBytes())
+		ctc.world.Msgs[created.Id.String()][0].BodyCiphertext.E[0]++
 
-	tv, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(context.Background(), chat1.GetThreadLocalArg{
-		ConversationID: created.Id,
+		ctx := ctc.as(t, users[0]).startCtx
+		tv, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(ctx, chat1.GetThreadLocalArg{
+			ConversationID: created.Id,
+		})
+		if err != nil {
+			t.Fatalf("GetThreadLocal error: %v", err)
+		}
+		if len(tv.Thread.Messages) != 3 {
+			t.Fatalf("unexpected response from GetThreadLocal. expected 3 items, got %d\n", len(tv.Thread.Messages))
+		}
+		if tv.Thread.Messages[0].IsValid() || len(tv.Thread.Messages[0].Error().ErrMsg) == 0 {
+			t.Fatalf("unexpected response from GetThreadLocal. expected an error message from bad msg, got %#+v\n", tv.Thread.Messages[0])
+		}
+		if !tv.Thread.Messages[1].IsValid() || tv.Thread.Messages[1].Valid().MessageBody.Text().Body != "innocent hello" {
+			t.Fatalf("unexpected response from GetThreadLocal. expected 'innocent hello' got %#+v\n", tv.Thread.Messages[1].Valid())
+		}
 	})
-	if err != nil {
-		t.Fatalf("GetThreadLocal error: %v", err)
-	}
-	if len(tv.Thread.Messages) != 3 {
-		t.Fatalf("unexpected response from GetThreadLocal. expected 3 items, got %d\n", len(tv.Thread.Messages))
-	}
-	if tv.Thread.Messages[0].IsValid() || len(tv.Thread.Messages[0].Error().ErrMsg) == 0 {
-		t.Fatalf("unexpected response from GetThreadLocal. expected an error message from bad msg, got %#+v\n", tv.Thread.Messages[0])
-	}
-	if !tv.Thread.Messages[1].IsValid() || tv.Thread.Messages[1].Valid().MessageBody.Text().Body != "innocent hello" {
-		t.Fatalf("unexpected response from GetThreadLocal. expected 'innocent hello' got %#+v\n", tv.Thread.Messages[1].Valid())
-	}
 }
 
 func TestChatGetInboxSummaryForCLILocal(t *testing.T) {
-	ctc := makeChatTestContext(t, "GetInboxSummaryForCLILocal", 4)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "GetInboxSummaryForCLILocal", 4)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	withUser1 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
-	mustPostLocalForTest(t, ctc, users[0], withUser1, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello0"}))
-	mustPostLocalForTest(t, ctc, users[1], withUser1, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello1"}))
+		withUser1 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
+		mustPostLocalForTest(t, ctc, users[0], withUser1, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello0"}))
+		mustPostLocalForTest(t, ctc, users[1], withUser1, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello1"}))
 
-	withUser2 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[2]).user().Username)
-	mustPostLocalForTest(t, ctc, users[0], withUser2, chat1.NewMessageBodyWithText(chat1.MessageText{Body: fmt.Sprintf("Dude I just said hello to %s!", ctc.as(t, users[2]).user().Username)}))
+		withUser2 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[2]).user())
+		mustPostLocalForTest(t, ctc, users[0], withUser2, chat1.NewMessageBodyWithText(chat1.MessageText{Body: fmt.Sprintf("Dude I just said hello to %s!", ctc.as(t, users[2]).user().Username)}))
 
-	withUser3 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[3]).user().Username)
-	mustPostLocalForTest(t, ctc, users[0], withUser3, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "O_O"}))
+		withUser3 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[3]).user())
+		mustPostLocalForTest(t, ctc, users[0], withUser3, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "O_O"}))
 
-	withUser12 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username, ctc.as(t, users[2]).user().Username)
-	mustPostLocalForTest(t, ctc, users[0], withUser12, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "O_O"}))
+		withUser12 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user(), ctc.as(t, users[2]).user())
+		mustPostLocalForTest(t, ctc, users[0], withUser12, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "O_O"}))
 
-	withUser123 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username, ctc.as(t, users[2]).user().Username, ctc.as(t, users[3]).user().Username)
-	mustPostLocalForTest(t, ctc, users[0], withUser123, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "O_O"}))
+		withUser123 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user(), ctc.as(t, users[2]).user(), ctc.as(t, users[3]).user())
+		mustPostLocalForTest(t, ctc, users[0], withUser123, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "O_O"}))
 
-	res, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(context.Background(), chat1.GetInboxSummaryForCLILocalQuery{
-		After:     "1d",
-		TopicType: chat1.TopicType_CHAT,
-	})
-	if err != nil {
-		t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
-	}
-	if len(res.Conversations) != 5 {
-		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 3 items, got %d\n", len(res.Conversations))
-	}
-	if !res.Conversations[0].Info.Id.Eq(withUser123.Id) {
-		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal; newest updated conversation is not the first in response.\n")
-	}
-	// TODO: fix this when merging master back in
-	if len(res.Conversations[0].MaxMessages) != 2 {
-		for i, m := range res.Conversations[0].MaxMessages {
-			t.Logf("%d: %+v", i, m.Valid())
+		ctx := ctc.as(t, users[0]).startCtx
+		res, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(ctx, chat1.GetInboxSummaryForCLILocalQuery{
+			After:     "1d",
+			TopicType: chat1.TopicType_CHAT,
+		})
+		if err != nil {
+			t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
 		}
-		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 2 messages in the first conversation, got %d\n", len(res.Conversations[0].MaxMessages))
-	}
+		if len(res.Conversations) != 5 {
+			t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 3 items, got %d\n", len(res.Conversations))
+		}
+		if !res.Conversations[0].Info.Id.Eq(withUser123.Id) {
+			t.Fatalf("unexpected response from GetInboxSummaryForCLILocal; newest updated conversation is not the first in response.\n")
+		}
+		// TODO: fix this when merging master back in
+		if len(res.Conversations[0].MaxMessages) != 2 {
+			for i, m := range res.Conversations[0].MaxMessages {
+				t.Logf("%d: %+v", i, m.Valid())
+			}
+			t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 2 messages in the first conversation, got %d\n", len(res.Conversations[0].MaxMessages))
+		}
 
-	res, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(context.Background(), chat1.GetInboxSummaryForCLILocalQuery{
-		ActivitySortedLimit: 2,
-		TopicType:           chat1.TopicType_CHAT,
-	})
-	if err != nil {
-		t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
-	}
-	if len(res.Conversations) != 2 {
-		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 2 items, got %d\n", len(res.Conversations))
-	}
+		res, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(ctx, chat1.GetInboxSummaryForCLILocalQuery{
+			ActivitySortedLimit: 2,
+			TopicType:           chat1.TopicType_CHAT,
+		})
+		if err != nil {
+			t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
+		}
+		if len(res.Conversations) != 2 {
+			t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 2 items, got %d\n", len(res.Conversations))
+		}
 
-	res, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(context.Background(), chat1.GetInboxSummaryForCLILocalQuery{
-		ActivitySortedLimit: 2,
-		TopicType:           chat1.TopicType_CHAT,
-	})
-	if err != nil {
-		t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
-	}
-	if len(res.Conversations) != 2 {
-		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 2 items, got %d\n", len(res.Conversations))
-	}
+		res, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(ctx, chat1.GetInboxSummaryForCLILocalQuery{
+			ActivitySortedLimit: 2,
+			TopicType:           chat1.TopicType_CHAT,
+		})
+		if err != nil {
+			t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
+		}
+		if len(res.Conversations) != 2 {
+			t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 2 items, got %d\n", len(res.Conversations))
+		}
 
-	res, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(context.Background(), chat1.GetInboxSummaryForCLILocalQuery{
-		UnreadFirst: true,
-		UnreadFirstLimit: chat1.UnreadFirstNumLimit{
-			AtLeast: 0,
-			AtMost:  1000,
-			NumRead: 1,
-		},
-		TopicType: chat1.TopicType_CHAT,
-	})
-	if err != nil {
-		t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
-	}
-	if len(res.Conversations) != 2 {
-		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 2 items, got %d\n", len(res.Conversations))
-	}
-	if !res.Conversations[0].Info.Id.Eq(withUser1.Id) {
-		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal; unread conversation is not the first in response.\n")
-	}
+		res, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(ctx, chat1.GetInboxSummaryForCLILocalQuery{
+			UnreadFirst: true,
+			UnreadFirstLimit: chat1.UnreadFirstNumLimit{
+				AtLeast: 0,
+				AtMost:  1000,
+				NumRead: 1,
+			},
+			TopicType: chat1.TopicType_CHAT,
+		})
+		if err != nil {
+			t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
+		}
+		if len(res.Conversations) != 2 {
+			t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 2 items, got %d\n", len(res.Conversations))
+		}
+		if !res.Conversations[0].Info.Id.Eq(withUser1.Id) {
+			t.Fatalf("unexpected response from GetInboxSummaryForCLILocal; unread conversation is not the first in response.\n")
+		}
 
-	res, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(context.Background(), chat1.GetInboxSummaryForCLILocalQuery{
-		UnreadFirst: true,
-		UnreadFirstLimit: chat1.UnreadFirstNumLimit{
-			AtLeast: 0,
-			AtMost:  2,
-			NumRead: 5,
-		},
-		TopicType: chat1.TopicType_CHAT,
-	})
-	if err != nil {
-		t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
-	}
-	if len(res.Conversations) != 2 {
-		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 1 items, got %d\n", len(res.Conversations))
-	}
+		res, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(ctx, chat1.GetInboxSummaryForCLILocalQuery{
+			UnreadFirst: true,
+			UnreadFirstLimit: chat1.UnreadFirstNumLimit{
+				AtLeast: 0,
+				AtMost:  2,
+				NumRead: 5,
+			},
+			TopicType: chat1.TopicType_CHAT,
+		})
+		if err != nil {
+			t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
+		}
+		if len(res.Conversations) != 2 {
+			t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 1 items, got %d\n", len(res.Conversations))
+		}
 
-	res, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(context.Background(), chat1.GetInboxSummaryForCLILocalQuery{
-		UnreadFirst: true,
-		UnreadFirstLimit: chat1.UnreadFirstNumLimit{
-			AtLeast: 3,
-			AtMost:  100,
-			NumRead: 0,
-		},
-		TopicType: chat1.TopicType_CHAT,
+		res, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxSummaryForCLILocal(ctx, chat1.GetInboxSummaryForCLILocalQuery{
+			UnreadFirst: true,
+			UnreadFirstLimit: chat1.UnreadFirstNumLimit{
+				AtLeast: 3,
+				AtMost:  100,
+				NumRead: 0,
+			},
+			TopicType: chat1.TopicType_CHAT,
+		})
+		if err != nil {
+			t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
+		}
+		if len(res.Conversations) != 3 {
+			t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 1 items, got %d\n", len(res.Conversations))
+		}
 	})
-	if err != nil {
-		t.Fatalf("GetInboxSummaryForCLILocal error: %v", err)
-	}
-	if len(res.Conversations) != 3 {
-		t.Fatalf("unexpected response from GetInboxSummaryForCLILocal . expected 1 items, got %d\n", len(res.Conversations))
-	}
 }
 
 func TestGetMessagesLocal(t *testing.T) {
-	ctc := makeChatTestContext(t, "GetMessagesLocal", 2)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "GetMessagesLocal", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
-	mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "Sometimes you eat the bar"}))
-	mustPostLocalForTest(t, ctc, users[1], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "and sometimes"}))
-	mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "the bar eats you."}))
+		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
+		mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "Sometimes you eat the bar"}))
+		mustPostLocalForTest(t, ctc, users[1], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "and sometimes"}))
+		mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "the bar eats you."}))
 
-	// GetMessagesLocal currently seems to return messages descending ID order.
-	// It would probably be good if this changed to return either in req order or ascending.
-	getIDs := []chat1.MessageID{3, 2, 1}
+		// GetMessagesLocal currently seems to return messages descending ID order.
+		// It would probably be good if this changed to return either in req order or ascending.
+		getIDs := []chat1.MessageID{3, 2, 1}
 
-	res, err := ctc.as(t, users[0]).chatLocalHandler().GetMessagesLocal(context.Background(), chat1.GetMessagesLocalArg{
-		ConversationID: created.Id,
-		MessageIDs:     getIDs,
+		ctx := ctc.as(t, users[0]).startCtx
+		res, err := ctc.as(t, users[0]).chatLocalHandler().GetMessagesLocal(ctx, chat1.GetMessagesLocalArg{
+			ConversationID: created.Id,
+			MessageIDs:     getIDs,
+		})
+		if err != nil {
+			t.Fatalf("GetMessagesLocal error: %v", err)
+		}
+		for i, msg := range res.Messages {
+			if !msg.IsValid() {
+				t.Fatalf("Missing message: %v", getIDs[i])
+			}
+			msgID := msg.GetMessageID()
+			if msgID != getIDs[i] {
+				t.Fatalf("Wrong message ID: got %v but expected %v", msgID, getIDs[i])
+			}
+		}
+		if len(res.Messages) != len(getIDs) {
+			t.Fatalf("GetMessagesLocal got %v items but expected %v", len(res.Messages), len(getIDs))
+		}
 	})
-	if err != nil {
-		t.Fatalf("GetMessagesLocal error: %v", err)
-	}
-	for i, msg := range res.Messages {
-		if !msg.IsValid() {
-			t.Fatalf("Missing message: %v", getIDs[i])
-		}
-		msgID := msg.GetMessageID()
-		if msgID != getIDs[i] {
-			t.Fatalf("Wrong message ID: got %v but expected %v", msgID, getIDs[i])
-		}
-	}
-	if len(res.Messages) != len(getIDs) {
-		t.Fatalf("GetMessagesLocal got %v items but expected %v", len(res.Messages), len(getIDs))
-	}
 }
 
 func extractOutbox(t *testing.T, msgs []chat1.MessageUnboxed) []chat1.MessageUnboxed {
@@ -786,121 +969,129 @@ func extractOutbox(t *testing.T, msgs []chat1.MessageUnboxed) []chat1.MessageUnb
 }
 
 func TestGetOutbox(t *testing.T) {
-	ctc := makeChatTestContext(t, "GetOutbox", 3)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "GetOutbox", 3)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	var err error
-	created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
-	created2 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[2]).user().Username)
+		var err error
+		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
+		created2 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[2]).user())
 
-	u := users[0]
-	h := ctc.as(t, users[0]).h
-	tc := ctc.world.Tcs[ctc.as(t, users[0]).user().Username]
-	outbox := storage.NewOutbox(tc.Context(), users[0].User.GetUID().ToBytes())
+		u := users[0]
+		h := ctc.as(t, users[0]).h
+		ctx := ctc.as(t, users[0]).startCtx
+		tc := ctc.world.Tcs[ctc.as(t, users[0]).user().Username]
+		outbox := storage.NewOutbox(tc.Context(), users[0].User.GetUID().ToBytes())
 
-	obr, err := outbox.PushMessage(context.TODO(), created.Id, chat1.MessagePlaintext{
-		ClientHeader: chat1.MessageClientHeader{
-			Sender:    u.User.GetUID().ToBytes(),
-			TlfName:   u.Username,
-			TlfPublic: false,
-			OutboxInfo: &chat1.OutboxInfo{
-				Prev: 10,
+		obr, err := outbox.PushMessage(ctx, created.Id, chat1.MessagePlaintext{
+			ClientHeader: chat1.MessageClientHeader{
+				Sender:    u.User.GetUID().ToBytes(),
+				TlfName:   u.Username,
+				TlfPublic: false,
+				OutboxInfo: &chat1.OutboxInfo{
+					Prev: 10,
+				},
 			},
-		},
-	}, keybase1.TLFIdentifyBehavior_CHAT_CLI)
-	require.NoError(t, err)
+		}, keybase1.TLFIdentifyBehavior_CHAT_CLI)
+		require.NoError(t, err)
 
-	thread, err := h.GetThreadLocal(context.Background(), chat1.GetThreadLocalArg{
-		ConversationID: created.Id,
+		thread, err := h.GetThreadLocal(ctx, chat1.GetThreadLocalArg{
+			ConversationID: created.Id,
+		})
+		require.NoError(t, err)
+
+		routbox := extractOutbox(t, thread.Thread.Messages)
+		require.Equal(t, 1, len(routbox), "wrong size outbox")
+		require.Equal(t, obr.OutboxID, routbox[0].Outbox().OutboxID, "wrong outbox ID")
+
+		thread, err = h.GetThreadLocal(ctx, chat1.GetThreadLocalArg{
+			ConversationID: created2.Id,
+		})
+		require.NoError(t, err)
+		routbox = extractOutbox(t, thread.Thread.Messages)
+		require.Equal(t, 0, len(routbox), "non empty outbox")
 	})
-	require.NoError(t, err)
-
-	routbox := extractOutbox(t, thread.Thread.Messages)
-	require.Equal(t, 1, len(routbox), "wrong size outbox")
-	require.Equal(t, obr.OutboxID, routbox[0].Outbox().OutboxID, "wrong outbox ID")
-
-	thread, err = h.GetThreadLocal(context.Background(), chat1.GetThreadLocalArg{
-		ConversationID: created2.Id,
-	})
-	require.NoError(t, err)
-	routbox = extractOutbox(t, thread.Thread.Messages)
-	require.Equal(t, 0, len(routbox), "non empty outbox")
-
 }
 
 func TestChatGap(t *testing.T) {
-	ctc := makeChatTestContext(t, "GetOutbox", 2)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "GetOutbox", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	var err error
-	created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
+		var err error
+		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
 
-	res, err := postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "Sometimes you eat the bar"}))
-	require.NoError(t, err)
+		res, err := postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "Sometimes you eat the bar"}))
+		require.NoError(t, err)
 
-	u := users[0]
-	h := ctc.as(t, users[0]).h
-	tc := ctc.world.Tcs[ctc.as(t, users[0]).user().Username]
-	msgID := res.MessageID
-	mres, err := h.remoteClient().GetMessagesRemote(context.TODO(), chat1.GetMessagesRemoteArg{
-		ConversationID: created.Id,
-		MessageIDs:     []chat1.MessageID{msgID},
+		u := users[0]
+		h := ctc.as(t, users[0]).h
+		ctx := ctc.as(t, users[0]).startCtx
+		tc := ctc.world.Tcs[ctc.as(t, users[0]).user().Username]
+		msgID := res.MessageID
+		mres, err := h.remoteClient().GetMessagesRemote(ctx, chat1.GetMessagesRemoteArg{
+			ConversationID: created.Id,
+			MessageIDs:     []chat1.MessageID{msgID},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(mres.Msgs), "no msg returned")
+
+		ooMsg := mres.Msgs[0]
+		ooMsg.ServerHeader.MessageID = 4
+
+		payload := chat1.NewMessagePayload{
+			Action:  "newMessage",
+			ConvID:  created.Id,
+			Message: ooMsg,
+		}
+
+		listener := newServerChatListener()
+		tc.G.SetService()
+		tc.G.NotifyRouter.SetListener(listener)
+
+		mh := codec.MsgpackHandle{WriteExt: true}
+		var data []byte
+		enc := codec.NewEncoderBytes(&data, &mh)
+		require.NoError(t, enc.Encode(payload))
+		ph := NewPushHandler(tc.Context())
+		require.NoError(t, ph.Activity(ctx, &gregor1.OutOfBandMessage{
+			Uid_:    u.User.GetUID().ToBytes(),
+			System_: "chat.activity",
+			Body_:   data,
+		}))
+
+		select {
+		case cids := <-listener.threadsStale:
+			require.Equal(t, []chat1.ConversationID{created.Id}, cids, "wrong cids")
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "failed to receive stale event")
+		}
+
+		ooMsg.ServerHeader.MessageID = 5
+		payload = chat1.NewMessagePayload{
+			Action:  "newMessage",
+			ConvID:  created.Id,
+			Message: ooMsg,
+		}
+		enc = codec.NewEncoderBytes(&data, &mh)
+		require.NoError(t, enc.Encode(payload))
+		require.NoError(t, ph.Activity(ctx, &gregor1.OutOfBandMessage{
+			Uid_:    u.User.GetUID().ToBytes(),
+			System_: "chat.activity",
+			Body_:   data,
+		}))
+
+		select {
+		case <-listener.threadsStale:
+			require.Fail(t, "should not get stale event here")
+		default:
+		}
 	})
-	require.NoError(t, err)
-	require.Equal(t, 1, len(mres.Msgs), "no msg returned")
-
-	ooMsg := mres.Msgs[0]
-	ooMsg.ServerHeader.MessageID = 4
-
-	payload := chat1.NewMessagePayload{
-		Action:  "newMessage",
-		ConvID:  created.Id,
-		Message: ooMsg,
-	}
-
-	listener := newServerChatListener()
-	tc.G.SetService()
-	tc.G.NotifyRouter.SetListener(listener)
-
-	mh := codec.MsgpackHandle{WriteExt: true}
-	var data []byte
-	enc := codec.NewEncoderBytes(&data, &mh)
-	require.NoError(t, enc.Encode(payload))
-	ph := NewPushHandler(tc.Context())
-	require.NoError(t, ph.Activity(context.TODO(), &gregor1.OutOfBandMessage{
-		Uid_:    u.User.GetUID().ToBytes(),
-		System_: "chat.activity",
-		Body_:   data,
-	}))
-
-	select {
-	case cids := <-listener.threadsStale:
-		require.Equal(t, []chat1.ConversationID{created.Id}, cids, "wrong cids")
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "failed to receive stale event")
-	}
-
-	ooMsg.ServerHeader.MessageID = 5
-	payload = chat1.NewMessagePayload{
-		Action:  "newMessage",
-		ConvID:  created.Id,
-		Message: ooMsg,
-	}
-	enc = codec.NewEncoderBytes(&data, &mh)
-	require.NoError(t, enc.Encode(payload))
-	require.NoError(t, ph.Activity(context.TODO(), &gregor1.OutOfBandMessage{
-		Uid_:    u.User.GetUID().ToBytes(),
-		System_: "chat.activity",
-		Body_:   data,
-	}))
-
-	select {
-	case <-listener.threadsStale:
-		require.Fail(t, "should not get stale event here")
-	default:
-	}
 }
 
 type serverChatListener struct {
@@ -954,176 +1145,191 @@ func newServerChatListener() *serverChatListener {
 }
 
 func TestPostLocalNonblock(t *testing.T) {
-	ctc := makeChatTestContext(t, "PostLocalNonblock", 2)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "PostLocalNonblock", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	var err error
-	created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, ctc.as(t, users[1]).user().Username)
+		var err error
+		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
 
-	listener := newServerChatListener()
-	ctc.as(t, users[0]).h.G().SetService()
-	ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
+		listener := newServerChatListener()
+		ctc.as(t, users[0]).h.G().SetService()
+		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
 
-	t.Logf("send a text message")
-	arg := chat1.PostTextNonblockArg{
-		ConversationID:   created.Id,
-		Conv:             created.Triple,
-		TlfName:          created.TlfName,
-		TlfPublic:        created.Visibility == chat1.TLFVisibility_PUBLIC,
-		Body:             "hi",
-		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-	}
-	res, err := ctc.as(t, users[0]).chatLocalHandler().PostTextNonblock(context.TODO(), arg)
-	require.NoError(t, err)
-	var unboxed chat1.MessageUnboxed
-	select {
-	case unboxed = <-listener.newMessage:
-		require.True(t, unboxed.IsValid(), "invalid message")
-		require.NotNil(t, unboxed.Valid().ClientHeader.OutboxID, "no outbox ID")
-		require.Equal(t, res.OutboxID, *unboxed.Valid().ClientHeader.OutboxID, "mismatch outbox ID")
-		require.Equal(t, chat1.MessageType_TEXT, unboxed.GetMessageType(), "invalid type")
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no event received")
-	}
+		t.Logf("send a text message")
+		arg := chat1.PostTextNonblockArg{
+			ConversationID:   created.Id,
+			Conv:             created.Triple,
+			TlfName:          created.TlfName,
+			TlfPublic:        created.Visibility == chat1.TLFVisibility_PUBLIC,
+			Body:             "hi",
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		}
+		tc := ctc.as(t, users[0])
+		res, err := ctc.as(t, users[0]).chatLocalHandler().PostTextNonblock(tc.startCtx, arg)
+		require.NoError(t, err)
+		var unboxed chat1.MessageUnboxed
+		select {
+		case unboxed = <-listener.newMessage:
+			require.True(t, unboxed.IsValid(), "invalid message")
+			require.NotNil(t, unboxed.Valid().ClientHeader.OutboxID, "no outbox ID")
+			require.Equal(t, res.OutboxID, *unboxed.Valid().ClientHeader.OutboxID, "mismatch outbox ID")
+			require.Equal(t, chat1.MessageType_TEXT, unboxed.GetMessageType(), "invalid type")
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no event received")
+		}
 
-	t.Logf("edit the message")
-	earg := chat1.PostEditNonblockArg{
-		ConversationID:   created.Id,
-		Conv:             created.Triple,
-		TlfName:          created.TlfName,
-		TlfPublic:        created.Visibility == chat1.TLFVisibility_PUBLIC,
-		Supersedes:       unboxed.GetMessageID(),
-		Body:             "hi2",
-		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-	}
-	res, err = ctc.as(t, users[0]).chatLocalHandler().PostEditNonblock(context.TODO(), earg)
-	require.NoError(t, err)
-	select {
-	case unboxed = <-listener.newMessage:
-		require.True(t, unboxed.IsValid(), "invalid message")
-		require.NotNil(t, unboxed.Valid().ClientHeader.OutboxID, "no outbox ID")
-		require.Equal(t, res.OutboxID, *unboxed.Valid().ClientHeader.OutboxID, "mismatch outbox ID")
-		require.Equal(t, chat1.MessageType_EDIT, unboxed.GetMessageType(), "invalid type")
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no event received")
-	}
+		t.Logf("edit the message")
+		earg := chat1.PostEditNonblockArg{
+			ConversationID:   created.Id,
+			Conv:             created.Triple,
+			TlfName:          created.TlfName,
+			TlfPublic:        created.Visibility == chat1.TLFVisibility_PUBLIC,
+			Supersedes:       unboxed.GetMessageID(),
+			Body:             "hi2",
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		}
+		res, err = ctc.as(t, users[0]).chatLocalHandler().PostEditNonblock(tc.startCtx, earg)
+		require.NoError(t, err)
+		select {
+		case unboxed = <-listener.newMessage:
+			require.True(t, unboxed.IsValid(), "invalid message")
+			require.NotNil(t, unboxed.Valid().ClientHeader.OutboxID, "no outbox ID")
+			require.Equal(t, res.OutboxID, *unboxed.Valid().ClientHeader.OutboxID, "mismatch outbox ID")
+			require.Equal(t, chat1.MessageType_EDIT, unboxed.GetMessageType(), "invalid type")
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no event received")
+		}
 
-	t.Logf("delete the message")
-	darg := chat1.PostDeleteNonblockArg{
-		ConversationID:   created.Id,
-		Conv:             created.Triple,
-		TlfName:          created.TlfName,
-		TlfPublic:        created.Visibility == chat1.TLFVisibility_PUBLIC,
-		Supersedes:       unboxed.GetMessageID(),
-		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-	}
-	res, err = ctc.as(t, users[0]).chatLocalHandler().PostDeleteNonblock(context.TODO(), darg)
-	require.NoError(t, err)
-	select {
-	case unboxed = <-listener.newMessage:
-		require.True(t, unboxed.IsValid(), "invalid message")
-		require.NotNil(t, unboxed.Valid().ClientHeader.OutboxID, "no outbox ID")
-		require.Equal(t, res.OutboxID, *unboxed.Valid().ClientHeader.OutboxID, "mismatch outbox ID")
-		require.Equal(t, chat1.MessageType_DELETE, unboxed.GetMessageType(), "invalid type")
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no event received")
-	}
+		t.Logf("delete the message")
+		darg := chat1.PostDeleteNonblockArg{
+			ConversationID:   created.Id,
+			Conv:             created.Triple,
+			TlfName:          created.TlfName,
+			TlfPublic:        created.Visibility == chat1.TLFVisibility_PUBLIC,
+			Supersedes:       unboxed.GetMessageID(),
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		}
+		res, err = ctc.as(t, users[0]).chatLocalHandler().PostDeleteNonblock(tc.startCtx, darg)
+		require.NoError(t, err)
+		select {
+		case unboxed = <-listener.newMessage:
+			require.True(t, unboxed.IsValid(), "invalid message")
+			require.NotNil(t, unboxed.Valid().ClientHeader.OutboxID, "no outbox ID")
+			require.Equal(t, res.OutboxID, *unboxed.Valid().ClientHeader.OutboxID, "mismatch outbox ID")
+			require.Equal(t, chat1.MessageType_DELETE, unboxed.GetMessageType(), "invalid type")
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no event received")
+		}
+	})
 }
 
 func TestFindConversations(t *testing.T) {
-	ctc := makeChatTestContext(t, "FindConversations", 3)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		// XXX: Public chats can't work with teams yet
+		if mt == chat1.ConversationMembersType_TEAM {
+			return
+		}
+		ctc := makeChatTestContext(t, "FindConversations", 3)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	t.Logf("basic test")
-	created := mustCreatePublicConversationForTest(t, ctc, users[2], chat1.TopicType_CHAT,
-		users[1].Username)
-	convRemote := ctc.world.GetConversationByID(created.Id)
-	require.NotNil(t, convRemote)
-	convRemote.Metadata.Visibility = chat1.TLFVisibility_PUBLIC
-	convRemote.Metadata.ActiveList =
-		[]gregor1.UID{users[2].User.GetUID().ToBytes(), users[1].User.GetUID().ToBytes()}
+		t.Logf("basic test")
+		created := mustCreatePublicConversationForTest(t, ctc, users[2], chat1.TopicType_CHAT,
+			mt, users[1])
+		convRemote := ctc.world.GetConversationByID(created.Id)
+		require.NotNil(t, convRemote)
+		convRemote.Metadata.Visibility = chat1.TLFVisibility_PUBLIC
+		convRemote.Metadata.ActiveList =
+			[]gregor1.UID{users[2].User.GetUID().ToBytes(), users[1].User.GetUID().ToBytes()}
 
-	res, err := ctc.as(t, users[0]).chatLocalHandler().FindConversationsLocal(context.TODO(),
-		chat1.FindConversationsLocalArg{
-			TlfName:          created.TlfName,
-			Visibility:       chat1.TLFVisibility_PUBLIC,
-			TopicType:        chat1.TopicType_CHAT,
+		ctx := ctc.as(t, users[0]).startCtx
+		ctx2 := ctc.as(t, users[2]).startCtx
+		res, err := ctc.as(t, users[0]).chatLocalHandler().FindConversationsLocal(ctx,
+			chat1.FindConversationsLocalArg{
+				TlfName:          created.TlfName,
+				MembersType:      mt,
+				Visibility:       chat1.TLFVisibility_PUBLIC,
+				TopicType:        chat1.TopicType_CHAT,
+				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+			})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(res.Conversations), "no conv found")
+		require.Equal(t, created.Id, res.Conversations[0].GetConvID(), "wrong conv")
+
+		t.Logf("simple post")
+		_, err = ctc.as(t, users[2]).chatLocalHandler().PostLocal(ctx2, chat1.PostLocalArg{
+			ConversationID:   created.Id,
 			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-		})
-	require.NoError(t, err)
-	require.Equal(t, 1, len(res.Conversations), "no conv found")
-	require.Equal(t, created.Id, res.Conversations[0].GetConvID(), "wrong conv")
-
-	t.Logf("simple post")
-	_, err = ctc.as(t, users[2]).chatLocalHandler().PostLocal(context.TODO(), chat1.PostLocalArg{
-		ConversationID:   created.Id,
-		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-		Msg: chat1.MessagePlaintext{
-			ClientHeader: chat1.MessageClientHeader{
-				Conv:        created.Triple,
-				MessageType: chat1.MessageType_TEXT,
-				TlfName:     created.TlfName,
-				TlfPublic:   true,
+			Msg: chat1.MessagePlaintext{
+				ClientHeader: chat1.MessageClientHeader{
+					Conv:        created.Triple,
+					MessageType: chat1.MessageType_TEXT,
+					TlfName:     created.TlfName,
+					TlfPublic:   true,
+				},
+				MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+					Body: "PUBLIC",
+				}),
 			},
-			MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
-				Body: "PUBLIC",
-			}),
-		},
-	})
-	require.NoError(t, err)
+		})
+		require.NoError(t, err)
 
-	t.Logf("read from conversation")
-	tres, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(context.TODO(), chat1.GetThreadLocalArg{
-		ConversationID:   res.Conversations[0].GetConvID(),
-		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-		Query: &chat1.GetThreadQuery{
-			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
-		},
-	})
-	require.NoError(t, err)
-	require.Equal(t, 1, len(tres.Thread.Messages), "wrong length")
-
-	t.Logf("test topic name")
-	_, err = ctc.as(t, users[2]).chatLocalHandler().PostLocal(context.TODO(), chat1.PostLocalArg{
-		ConversationID:   created.Id,
-		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-		Msg: chat1.MessagePlaintext{
-			ClientHeader: chat1.MessageClientHeader{
-				Conv:        created.Triple,
-				MessageType: chat1.MessageType_METADATA,
-				TlfName:     created.TlfName,
-				TlfPublic:   true,
+		t.Logf("read from conversation")
+		tres, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(ctx, chat1.GetThreadLocalArg{
+			ConversationID:   res.Conversations[0].GetConvID(),
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+			Query: &chat1.GetThreadQuery{
+				MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
 			},
-			MessageBody: chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
-				ConversationTitle: "MIKE",
-			}),
-		},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(tres.Thread.Messages), "wrong length")
+
+		t.Logf("test topic name")
+		_, err = ctc.as(t, users[2]).chatLocalHandler().PostLocal(ctx2, chat1.PostLocalArg{
+			ConversationID:   created.Id,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+			Msg: chat1.MessagePlaintext{
+				ClientHeader: chat1.MessageClientHeader{
+					Conv:        created.Triple,
+					MessageType: chat1.MessageType_METADATA,
+					TlfName:     created.TlfName,
+					TlfPublic:   true,
+				},
+				MessageBody: chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
+					ConversationTitle: "MIKE",
+				}),
+			},
+		})
+		require.NoError(t, err)
+
+		res, err = ctc.as(t, users[0]).chatLocalHandler().FindConversationsLocal(ctx,
+			chat1.FindConversationsLocalArg{
+				TlfName:          created.TlfName,
+				MembersType:      mt,
+				Visibility:       chat1.TLFVisibility_PUBLIC,
+				TopicType:        chat1.TopicType_CHAT,
+				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+			})
+		require.NoError(t, err)
+		require.Equal(t, 0, len(res.Conversations), "conv found")
+
+		res, err = ctc.as(t, users[0]).chatLocalHandler().FindConversationsLocal(ctx,
+			chat1.FindConversationsLocalArg{
+				TlfName:          created.TlfName,
+				MembersType:      mt,
+				Visibility:       chat1.TLFVisibility_PUBLIC,
+				TopicType:        chat1.TopicType_CHAT,
+				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+				TopicName:        "MIKE",
+			})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(res.Conversations), "conv found")
+		require.Equal(t, created.Id, res.Conversations[0].GetConvID(), "wrong conv")
 	})
-	require.NoError(t, err)
-
-	res, err = ctc.as(t, users[0]).chatLocalHandler().FindConversationsLocal(context.TODO(),
-		chat1.FindConversationsLocalArg{
-			TlfName:          created.TlfName,
-			Visibility:       chat1.TLFVisibility_PUBLIC,
-			TopicType:        chat1.TopicType_CHAT,
-			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-		})
-	require.NoError(t, err)
-	require.Equal(t, 0, len(res.Conversations), "conv found")
-
-	res, err = ctc.as(t, users[0]).chatLocalHandler().FindConversationsLocal(context.TODO(),
-		chat1.FindConversationsLocalArg{
-			TlfName:          created.TlfName,
-			Visibility:       chat1.TLFVisibility_PUBLIC,
-			TopicType:        chat1.TopicType_CHAT,
-			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-			TopicName:        "MIKE",
-		})
-	require.NoError(t, err)
-	require.Equal(t, 1, len(res.Conversations), "conv found")
-	require.Equal(t, created.Id, res.Conversations[0].GetConvID(), "wrong conv")
 }
 
 func receiveThreadResult(t *testing.T, cb chan kbtest.NonblockThreadResult) (res *chat1.ThreadView) {
@@ -1147,221 +1353,232 @@ func receiveThreadResult(t *testing.T, cb chan kbtest.NonblockThreadResult) (res
 }
 
 func TestGetThreadNonblock(t *testing.T) {
-	ctc := makeChatTestContext(t, "GetThreadNonblock", 1)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "GetThreadNonblock", 1)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	inboxCb := make(chan kbtest.NonblockInboxResult, 100)
-	threadCb := make(chan kbtest.NonblockThreadResult, 100)
-	ui := kbtest.NewChatUI(inboxCb, threadCb)
-	ctc.as(t, users[0]).h.mockChatUI = ui
+		inboxCb := make(chan kbtest.NonblockInboxResult, 100)
+		threadCb := make(chan kbtest.NonblockThreadResult, 100)
+		ui := kbtest.NewChatUI(inboxCb, threadCb)
+		ctc.as(t, users[0]).h.mockChatUI = ui
 
-	t.Logf("test empty thread")
-	query := chat1.GetThreadQuery{
-		MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
-	}
-	conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, users[0].Username)
-	_, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadNonblock(context.TODO(),
-		chat1.GetThreadNonblockArg{
-			ConversationID:   conv.Id,
-			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-			Query:            &query,
-		},
-	)
-	require.NoError(t, err)
-	res := receiveThreadResult(t, threadCb)
-	require.Zero(t, len(res.Messages))
+		t.Logf("test empty thread")
+		query := chat1.GetThreadQuery{
+			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+		}
+		ctx := ctc.as(t, users[0]).startCtx
+		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, users[0])
+		_, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadNonblock(ctx,
+			chat1.GetThreadNonblockArg{
+				ConversationID:   conv.Id,
+				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+				Query:            &query,
+			},
+		)
+		require.NoError(t, err)
+		res := receiveThreadResult(t, threadCb)
+		require.Zero(t, len(res.Messages))
 
-	t.Logf("send a bunch of messages")
-	numMsgs := 20
-	msg := chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hi"})
-	for i := 0; i < numMsgs; i++ {
-		mustPostLocalForTest(t, ctc, users[0], conv, msg)
-	}
+		t.Logf("send a bunch of messages")
+		numMsgs := 20
+		msg := chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hi"})
+		for i := 0; i < numMsgs; i++ {
+			mustPostLocalForTest(t, ctc, users[0], conv, msg)
+		}
 
-	t.Logf("read back full thread")
-	_, err = ctc.as(t, users[0]).chatLocalHandler().GetThreadNonblock(context.TODO(),
-		chat1.GetThreadNonblockArg{
-			ConversationID:   conv.Id,
-			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-			Query:            &query,
-		},
-	)
-	require.NoError(t, err)
-	res = receiveThreadResult(t, threadCb)
-	require.Equal(t, numMsgs, len(res.Messages))
+		t.Logf("read back full thread")
+		_, err = ctc.as(t, users[0]).chatLocalHandler().GetThreadNonblock(ctx,
+			chat1.GetThreadNonblockArg{
+				ConversationID:   conv.Id,
+				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+				Query:            &query,
+			},
+		)
+		require.NoError(t, err)
+		res = receiveThreadResult(t, threadCb)
+		require.Equal(t, numMsgs, len(res.Messages))
 
-	t.Logf("read back with a delay on the local pull")
-	delay := time.Hour * 800
-	ctc.as(t, users[0]).h.cachedThreadDelay = &delay
-	_, err = ctc.as(t, users[0]).chatLocalHandler().GetThreadNonblock(context.TODO(),
-		chat1.GetThreadNonblockArg{
-			ConversationID:   conv.Id,
-			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-			Query:            &query,
-		},
-	)
-	require.NoError(t, err)
-	res = receiveThreadResult(t, threadCb)
-	require.Equal(t, numMsgs, len(res.Messages))
-
+		t.Logf("read back with a delay on the local pull")
+		delay := time.Hour * 800
+		ctc.as(t, users[0]).h.cachedThreadDelay = &delay
+		_, err = ctc.as(t, users[0]).chatLocalHandler().GetThreadNonblock(ctx,
+			chat1.GetThreadNonblockArg{
+				ConversationID:   conv.Id,
+				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+				Query:            &query,
+			},
+		)
+		require.NoError(t, err)
+		res = receiveThreadResult(t, threadCb)
+		require.Equal(t, numMsgs, len(res.Messages))
+	})
 }
 
 func TestGetThreadNonblockError(t *testing.T) {
-	ctc := makeChatTestContext(t, "GetThreadNonblock", 1)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "GetThreadNonblock", 1)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	listener := newServerChatListener()
-	ctc.as(t, users[0]).h.G().SetService()
-	ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
+		listener := newServerChatListener()
+		ctc.as(t, users[0]).h.G().SetService()
+		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
 
-	uid := users[0].User.GetUID().ToBytes()
-	inboxCb := make(chan kbtest.NonblockInboxResult, 100)
-	threadCb := make(chan kbtest.NonblockThreadResult, 100)
-	ui := kbtest.NewChatUI(inboxCb, threadCb)
-	ctc.as(t, users[0]).h.mockChatUI = ui
+		uid := users[0].User.GetUID().ToBytes()
+		inboxCb := make(chan kbtest.NonblockInboxResult, 100)
+		threadCb := make(chan kbtest.NonblockThreadResult, 100)
+		ui := kbtest.NewChatUI(inboxCb, threadCb)
+		ctc.as(t, users[0]).h.mockChatUI = ui
 
-	query := chat1.GetThreadQuery{
-		MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
-	}
-	conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, users[0].Username)
-	numMsgs := 20
-	msg := chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hi"})
-	for i := 0; i < numMsgs; i++ {
-		mustPostLocalForTest(t, ctc, users[0], conv, msg)
-	}
-	require.NoError(t, ctc.world.Tcs[users[0].Username].ChatG.ConvSource.Clear(conv.Id, uid))
-	g := ctc.world.Tcs[users[0].Username].ChatG
-	g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
-		return chat1.RemoteClient{Cli: errorClient{}}
+		query := chat1.GetThreadQuery{
+			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+		}
+		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, users[0])
+		numMsgs := 20
+		msg := chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hi"})
+		for i := 0; i < numMsgs; i++ {
+			mustPostLocalForTest(t, ctc, users[0], conv, msg)
+		}
+		require.NoError(t, ctc.world.Tcs[users[0].Username].ChatG.ConvSource.Clear(conv.Id, uid))
+		g := ctc.world.Tcs[users[0].Username].ChatG
+		g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
+			return chat1.RemoteClient{Cli: errorClient{}}
+		})
+
+		ctx := ctc.as(t, users[0]).startCtx
+		_, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadNonblock(ctx,
+			chat1.GetThreadNonblockArg{
+				ConversationID:   conv.Id,
+				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+				Query:            &query,
+			},
+		)
+		require.Error(t, err)
+
+		// Advance clock and look for stale
+		g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
+			return kbtest.NewChatRemoteMock(ctc.world)
+		})
+		ctc.world.Fc.Advance(time.Hour)
+
+		select {
+		case cids := <-listener.threadsStale:
+			require.Equal(t, 1, len(cids))
+		case <-time.After(2 * time.Second):
+			require.Fail(t, "no threads stale message received")
+		}
 	})
-
-	_, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadNonblock(context.TODO(),
-		chat1.GetThreadNonblockArg{
-			ConversationID:   conv.Id,
-			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-			Query:            &query,
-		},
-	)
-	require.Error(t, err)
-
-	// Advance clock and look for stale
-	g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
-		return kbtest.NewChatRemoteMock(ctc.world)
-	})
-	ctc.world.Fc.Advance(time.Hour)
-
-	select {
-	case cids := <-listener.threadsStale:
-		require.Equal(t, 1, len(cids))
-	case <-time.After(2 * time.Second):
-		require.Fail(t, "no threads stale message received")
-	}
 }
 
 func TestGetInboxNonblockError(t *testing.T) {
-	ctc := makeChatTestContext(t, "GetInboxNonblockLocal", 1)
-	defer ctc.cleanup()
-	users := ctc.users()
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "GetInboxNonblockLocal", 1)
+		defer ctc.cleanup()
+		users := ctc.users()
 
-	listener := newServerChatListener()
-	ctc.as(t, users[0]).h.G().SetService()
-	ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
+		listener := newServerChatListener()
+		ctc.as(t, users[0]).h.G().SetService()
+		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener)
 
-	uid := users[0].User.GetUID().ToBytes()
-	inboxCb := make(chan kbtest.NonblockInboxResult, 100)
-	threadCb := make(chan kbtest.NonblockThreadResult, 100)
-	ui := kbtest.NewChatUI(inboxCb, threadCb)
-	ctc.as(t, users[0]).h.mockChatUI = ui
+		uid := users[0].User.GetUID().ToBytes()
+		inboxCb := make(chan kbtest.NonblockInboxResult, 100)
+		threadCb := make(chan kbtest.NonblockThreadResult, 100)
+		ui := kbtest.NewChatUI(inboxCb, threadCb)
+		ctc.as(t, users[0]).h.mockChatUI = ui
 
-	conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, users[0].Username)
-	numMsgs := 20
-	msg := chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hi"})
-	for i := 0; i < numMsgs; i++ {
-		mustPostLocalForTest(t, ctc, users[0], conv, msg)
-	}
-	require.NoError(t, ctc.world.Tcs[users[0].Username].ChatG.ConvSource.Clear(conv.Id, uid))
-	g := ctc.world.Tcs[users[0].Username].Context()
-	g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
-		return chat1.RemoteClient{Cli: errorClient{}}
-	})
-
-	_, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxNonblockLocal(context.TODO(),
-		chat1.GetInboxNonblockLocalArg{
-			Query: &chat1.GetInboxLocalQuery{
-				ConvIDs: []chat1.ConversationID{conv.Id},
-			},
-			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, users[0])
+		numMsgs := 20
+		msg := chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hi"})
+		for i := 0; i < numMsgs; i++ {
+			mustPostLocalForTest(t, ctc, users[0], conv, msg)
+		}
+		require.NoError(t, ctc.world.Tcs[users[0].Username].ChatG.ConvSource.Clear(conv.Id, uid))
+		g := ctc.world.Tcs[users[0].Username].Context()
+		g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
+			return chat1.RemoteClient{Cli: errorClient{}}
 		})
-	require.NoError(t, err)
 
-	// Eat untrusted CB
-	select {
-	case <-inboxCb:
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no untrusted inbox")
-	}
+		ctx := ctc.as(t, users[0]).startCtx
+		_, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxNonblockLocal(ctx,
+			chat1.GetInboxNonblockLocalArg{
+				Query: &chat1.GetInboxLocalQuery{
+					ConvIDs: []chat1.ConversationID{conv.Id},
+				},
+				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+			})
+		require.NoError(t, err)
 
-	select {
-	case nbres := <-inboxCb:
-		require.Error(t, nbres.Err)
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no inbox load event")
-	}
+		// Eat untrusted CB
+		select {
+		case <-inboxCb:
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no untrusted inbox")
+		}
 
-	// Advance clock and look for stale
-	g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
-		return kbtest.NewChatRemoteMock(ctc.world)
-	})
-	ctc.world.Fc.Advance(time.Hour)
+		select {
+		case nbres := <-inboxCb:
+			require.Error(t, nbres.Err)
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no inbox load event")
+		}
 
-	select {
-	case cids := <-listener.threadsStale:
-		require.Equal(t, 1, len(cids))
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no threads stale message received")
-	}
-
-	t.Logf("testing untrusted inbox load failure")
-	ttype := chat1.TopicType_CHAT
-	require.NoError(t, storage.NewInbox(g, uid).Clear(context.TODO()))
-	g.InboxSource.SetRemoteInterface(func() chat1.RemoteInterface {
-		return chat1.RemoteClient{Cli: errorClient{}}
-	})
-	query := &chat1.GetInboxLocalQuery{
-		TopicType: &ttype,
-	}
-	p := &chat1.Pagination{Num: 10}
-	_, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxNonblockLocal(context.TODO(),
-		chat1.GetInboxNonblockLocalArg{
-			Query:            query,
-			Pagination:       p,
-			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		// Advance clock and look for stale
+		g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
+			return kbtest.NewChatRemoteMock(ctc.world)
 		})
-	require.Error(t, err)
-	g.InboxSource.SetRemoteInterface(func() chat1.RemoteInterface {
-		return kbtest.NewChatRemoteMock(ctc.world)
-	})
-	ctc.world.Fc.Advance(time.Hour)
-	select {
-	case <-listener.inboxStale:
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no threads stale message received")
-	}
-	select {
-	case cids := <-listener.threadsStale:
-		require.Zero(t, len(cids))
-	case <-time.After(20 * time.Second):
-		require.Fail(t, "no thread stale msg")
-	}
+		ctc.world.Fc.Advance(time.Hour)
 
-	rquery, _, err := g.InboxSource.GetInboxQueryLocalToRemote(context.TODO(), query)
-	require.NoError(t, err)
-	_, lconvs, _, err := storage.NewInbox(g, uid).Read(context.TODO(), rquery, p)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(lconvs))
-	require.Equal(t, lconvs[0].GetConvID(), conv.Id)
+		select {
+		case cids := <-listener.threadsStale:
+			require.Equal(t, 1, len(cids))
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no threads stale message received")
+		}
+
+		t.Logf("testing untrusted inbox load failure")
+		ttype := chat1.TopicType_CHAT
+		require.NoError(t, storage.NewInbox(g, uid).Clear(context.TODO()))
+		g.InboxSource.SetRemoteInterface(func() chat1.RemoteInterface {
+			return chat1.RemoteClient{Cli: errorClient{}}
+		})
+		query := &chat1.GetInboxLocalQuery{
+			TopicType: &ttype,
+		}
+		p := &chat1.Pagination{Num: 10}
+		_, err = ctc.as(t, users[0]).chatLocalHandler().GetInboxNonblockLocal(ctx,
+			chat1.GetInboxNonblockLocalArg{
+				Query:            query,
+				Pagination:       p,
+				IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+			})
+		require.Error(t, err)
+		g.InboxSource.SetRemoteInterface(func() chat1.RemoteInterface {
+			return kbtest.NewChatRemoteMock(ctc.world)
+		})
+		ctc.world.Fc.Advance(time.Hour)
+		select {
+		case <-listener.inboxStale:
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no threads stale message received")
+		}
+		select {
+		case cids := <-listener.threadsStale:
+			require.Zero(t, len(cids))
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no thread stale msg")
+		}
+
+		rquery, _, err := g.InboxSource.GetInboxQueryLocalToRemote(context.TODO(), query)
+		require.NoError(t, err)
+		_, lconvs, _, err := storage.NewInbox(g, uid).Read(context.TODO(), rquery, p)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(lconvs))
+		require.Equal(t, lconvs[0].GetConvID(), conv.Id)
+	})
 }
 
 func TestMakePreview(t *testing.T) {

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -10,16 +10,14 @@ import (
 
 type supersedesTransform interface {
 	Run(ctx context.Context,
-		convID chat1.ConversationID, uid gregor1.UID, originalMsgs []chat1.MessageUnboxed,
-		finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
+		conv chat1.Conversation, uid gregor1.UID, originalMsgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error)
 }
 
 type nullSupersedesTransform struct {
 }
 
 func (t nullSupersedesTransform) Run(ctx context.Context,
-	convID chat1.ConversationID, uid gregor1.UID, originalMsgs []chat1.MessageUnboxed,
-	finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error) {
+	conv chat1.Conversation, uid gregor1.UID, originalMsgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error) {
 	return originalMsgs, nil
 }
 
@@ -27,8 +25,7 @@ func newNullSupersedesTransform() nullSupersedesTransform {
 	return nullSupersedesTransform{}
 }
 
-type getMessagesFunc func(context.Context, chat1.ConversationID, gregor1.UID, []chat1.MessageID,
-	*chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
+type getMessagesFunc func(context.Context, chat1.Conversation, gregor1.UID, []chat1.MessageID) ([]chat1.MessageUnboxed, error)
 
 type basicSupersedesTransform struct {
 	globals.Contextified
@@ -111,8 +108,7 @@ func (t *basicSupersedesTransform) SetMessagesFunc(f getMessagesFunc) {
 }
 
 func (t *basicSupersedesTransform) Run(ctx context.Context,
-	convID chat1.ConversationID, uid gregor1.UID, originalMsgs []chat1.MessageUnboxed,
-	finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error) {
+	conv chat1.Conversation, uid gregor1.UID, originalMsgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error) {
 
 	// MessageIDs that supersede
 	var superMsgIDs []chat1.MessageID
@@ -133,7 +129,7 @@ func (t *basicSupersedesTransform) Run(ctx context.Context,
 	}
 
 	// Get superseding messages
-	msgs, err := t.messagesFunc(ctx, convID, uid, superMsgIDs, finalizeInfo)
+	msgs, err := t.messagesFunc(ctx, conv, uid, superMsgIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -1,0 +1,49 @@
+package chat
+
+import (
+	"fmt"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/types"
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams"
+	context "golang.org/x/net/context"
+)
+
+type TeamsNameInfoSource struct {
+	globals.Contextified
+	utils.DebugLabeler
+}
+
+func NewTeamsNameInfoSource(g *globals.Context) *TeamsNameInfoSource {
+	return &TeamsNameInfoSource{
+		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "TeamsNameInfoSource", false),
+	}
+}
+
+func (t *TeamsNameInfoSource) Lookup(ctx context.Context, name string, vis chat1.TLFVisibility) (res types.NameInfo, err error) {
+	defer t.Trace(ctx, func() error { return err }, fmt.Sprintf("Lookup(%s)", name))()
+	team, err := teams.Get(ctx, t.G().ExternalG(), name)
+	if err != nil {
+		return res, err
+	}
+	res.CanonicalName = name
+	if team.Chain == nil {
+		t.Debug(ctx, "Lookup: team chain is nil, not able to get ID: %s", name)
+		return res, fmt.Errorf("no team chain found")
+	}
+	res.ID = chat1.TLFID(team.Chain.GetID().ToBytes())
+	if vis == chat1.TLFVisibility_PRIVATE {
+		chatKeys, err := team.AllApplicationKeys(ctx, keybase1.TeamApplication_CHAT)
+		if err != nil {
+			return res, err
+		}
+		for _, key := range chatKeys {
+			res.CryptKeys = append(res.CryptKeys, key)
+		}
+	}
+	return res, nil
+}

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -89,6 +89,15 @@ func (t *KBFSNameInfoSource) CryptKeys(ctx context.Context, tlfName string) (res
 	defer t.Trace(ctx, func() error { return ferr },
 		fmt.Sprintf("CryptKeys(tlf=%s,mode=%v)", tlfName, identBehavior))()
 
+	username := t.G().Env.GetUsername()
+	if len(username) == 0 {
+		return res, libkb.LoginRequiredError{}
+	}
+	// Prepend username in case it's not present. We don't need to check if it
+	// exists already since CryptKeys calls below transforms the TLF name into a
+	// canonical one.
+	tlfName = string(username) + "," + tlfName
+
 	// call identifyTLF and GetTLFCryptKeys concurrently:
 	group, ectx := errgroup.WithContext(BackgroundContext(ctx, t.G()))
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -19,11 +19,13 @@ type Resumable interface {
 	Stop(ctx context.Context) chan struct{}
 }
 
-type TLFInfoSource interface {
-	Lookup(ctx context.Context, tlfName string, vis chat1.TLFVisibility) (*TLFInfo, error)
-	CryptKeys(ctx context.Context, tlfName string) (keybase1.GetTLFCryptKeysRes, error)
-	PublicCanonicalTLFNameAndID(ctx context.Context, tlfName string) (keybase1.CanonicalTLFNameAndIDWithBreaks, error)
-	CompleteAndCanonicalizePrivateTlfName(ctx context.Context, tlfName string) (res keybase1.CanonicalTLFNameAndIDWithBreaks, err error)
+type CryptKey interface {
+	Material() keybase1.Bytes32
+	Generation() int
+}
+
+type NameInfoSource interface {
+	Lookup(ctx context.Context, name string, vis chat1.TLFVisibility) (NameInfo, error)
 }
 
 type ConversationSource interface {
@@ -35,14 +37,14 @@ type ConversationSource interface {
 		pagination *chat1.Pagination) (chat1.ThreadView, []*chat1.RateLimit, error)
 	PullLocalOnly(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
 		query *chat1.GetThreadQuery, p *chat1.Pagination) (chat1.ThreadView, error)
-	GetMessages(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgIDs []chat1.MessageID, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
-	GetMessagesWithRemotes(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
-		msgs []chat1.MessageBoxed, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
+	GetMessages(ctx context.Context, conv chat1.Conversation, uid gregor1.UID, msgIDs []chat1.MessageID) ([]chat1.MessageUnboxed, error)
+	GetMessagesWithRemotes(ctx context.Context, conv chat1.Conversation, uid gregor1.UID,
+		msgs []chat1.MessageBoxed) ([]chat1.MessageUnboxed, error)
 	Clear(convID chat1.ConversationID, uid gregor1.UID) error
-	TransformSupersedes(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageUnboxed, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
+	TransformSupersedes(ctx context.Context, conv chat1.Conversation, uid gregor1.UID,
+		msgs []chat1.MessageUnboxed) ([]chat1.MessageUnboxed, error)
 
 	SetRemoteInterface(func() chat1.RemoteInterface)
-	SetTLFInfoSource(tlfInfoSource TLFInfoSource)
 }
 
 type MessageDeliverer interface {
@@ -80,10 +82,9 @@ type InboxSource interface {
 		convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) ([]chat1.ConversationLocal, error)
 
 	GetInboxQueryLocalToRemote(ctx context.Context,
-		lquery *chat1.GetInboxLocalQuery) (*chat1.GetInboxQuery, *TLFInfo, error)
+		lquery *chat1.GetInboxLocalQuery) (*chat1.GetInboxQuery, NameInfo, error)
 
 	SetRemoteInterface(func() chat1.RemoteInterface)
-	SetTLFInfoSource(tlfInfoSource TLFInfoSource)
 }
 
 type ServerCacheVersions interface {

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -5,8 +5,9 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-type TLFInfo struct {
+type NameInfo struct {
 	ID               chat1.TLFID
 	CanonicalName    string
 	IdentifyFailures []keybase1.TLFIdentifyFailure
+	CryptKeys        []CryptKey
 }

--- a/go/chat/typingmonitor.go
+++ b/go/chat/typingmonitor.go
@@ -156,7 +156,7 @@ func (t *TypingMonitor) removeFromTypers(ctx context.Context, key string, convID
 func (t *TypingMonitor) waitOnTyper(ctx context.Context, chans *typingControlChans,
 	convID chat1.ConversationID) {
 	key := t.key(chans.typer, convID)
-	ctx = BackgroundContext(ctx, t.G().GetEnv())
+	ctx = BackgroundContext(ctx, t.G())
 	deadline := t.clock.Now().Add(t.timeout)
 	go func() {
 		extends := 0

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -334,21 +334,6 @@ func (d DebugLabeler) Trace(ctx context.Context, f func() error, msg string) fun
 	return func() {}
 }
 
-func GetUnverifiedConv(ctx context.Context, g *globals.Context, uid gregor1.UID,
-	convID chat1.ConversationID, useLocalData bool) (chat1.Conversation, *chat1.RateLimit, error) {
-
-	inbox, ratelim, err := g.InboxSource.ReadUnverified(ctx, uid, useLocalData, &chat1.GetInboxQuery{
-		ConvIDs: []chat1.ConversationID{convID},
-	}, nil)
-	if err != nil {
-		return chat1.Conversation{}, ratelim, fmt.Errorf("GetUnverifiedConv: %s", err.Error())
-	}
-	if len(inbox.ConvsUnverified) == 0 {
-		return chat1.Conversation{}, ratelim, fmt.Errorf("GetUnverifiedConv: no conv found: %s", convID)
-	}
-	return inbox.ConvsUnverified[0], ratelim, nil
-}
-
 // FilterByType filters messages based on a query.
 // If includeAllErrors then MessageUnboxedError are all returned. Otherwise, they are filtered based on type.
 // Messages whose type cannot be determined are considered errors.

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -87,13 +87,16 @@ func (r *chatConversationResolver) makeGetInboxAndUnboxLocalArg(
 			errors.New("we are not supporting setting topic name for chat conversations yet")
 	}
 
-	var tlfName *string
+	var nameQuery *chat1.NameQuery
 	if len(req.TlfName) > 0 {
 		err := r.completeAndCanonicalizeTLFName(ctx, req.TlfName, req)
 		if err != nil {
 			return chat1.GetInboxAndUnboxLocalArg{}, err
 		}
-		tlfName = &req.ctx.canonicalizedTlfName
+		nameQuery = &chat1.NameQuery{
+			Name:        req.ctx.canonicalizedTlfName,
+			MembersType: chat1.ConversationMembersType_KBFS,
+		}
 	}
 
 	var topicName *string
@@ -103,7 +106,7 @@ func (r *chatConversationResolver) makeGetInboxAndUnboxLocalArg(
 
 	return chat1.GetInboxAndUnboxLocalArg{
 		Query: &chat1.GetInboxLocalQuery{
-			TlfName:       tlfName,
+			Name:          nameQuery,
 			TopicName:     topicName,
 			TopicType:     &req.TopicType,
 			TlfVisibility: &req.Visibility,
@@ -120,8 +123,9 @@ func (r *chatConversationResolver) resolveWithService(ctx context.Context, req c
 
 	// Convert argument
 	var fcArg chat1.FindConversationsLocalArg
-	if arg.Query.TlfName != nil {
-		fcArg.TlfName = *arg.Query.TlfName
+	if arg.Query.Name != nil {
+		fcArg.TlfName = arg.Query.Name.Name
+		fcArg.MembersType = arg.Query.Name.MembersType
 	}
 	if arg.Query.TlfVisibility != nil {
 		fcArg.Visibility = *arg.Query.TlfVisibility

--- a/go/client/cmd_team_add_member.go
+++ b/go/client/cmd_team_add_member.go
@@ -95,7 +95,7 @@ func (c *CmdTeamAddMember) Run() error {
 	}
 
 	dui := c.G().UI.GetDumbOutputUI()
-	dui.Printf("Success! A keybase chat message has been sent to %s.", c.username)
+	dui.Printf("Success! A keybase chat message has been sent to %s.\n", c.username)
 
 	return nil
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -220,6 +220,9 @@ func (t ConversationIDTriple) ToConversationID(shardID [2]byte) ConversationID {
 
 func (t ConversationIDTriple) Derivable(cid ConversationID) bool {
 	h := t.Hash()
+	if len(h) <= 2 || len(cid) <= 2 {
+		return false
+	}
 	return bytes.Equal(h[2:], []byte(cid[2:]))
 }
 
@@ -361,6 +364,14 @@ func (c ConversationLocal) GetTopicType() TopicType {
 	return c.Info.Triple.TopicType
 }
 
+func (c ConversationLocal) GetMembersType() ConversationMembersType {
+	return c.Info.MembersType
+}
+
+func (c ConversationLocal) GetFinalizeInfo() *ConversationFinalizeInfo {
+	return c.Info.FinalizeInfo
+}
+
 func (c Conversation) GetMtime() gregor1.Time {
 	return c.ReaderInfo.Mtime
 }
@@ -371,6 +382,14 @@ func (c Conversation) GetConvID() ConversationID {
 
 func (c Conversation) GetTopicType() TopicType {
 	return c.Metadata.IdTriple.TopicType
+}
+
+func (c Conversation) GetMembersType() ConversationMembersType {
+	return c.Metadata.MembersType
+}
+
+func (c Conversation) GetFinalizeInfo() *ConversationFinalizeInfo {
+	return c.Metadata.FinalizeInfo
 }
 
 func (c Conversation) GetMaxMessage(typ MessageType) (MessageSummary, error) {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1917,6 +1917,7 @@ type ConversationInfoLocal struct {
 	TopicName    string                    `codec:"topicName" json:"topicName"`
 	Visibility   TLFVisibility             `codec:"visibility" json:"visibility"`
 	Status       ConversationStatus        `codec:"status" json:"status"`
+	MembersType  ConversationMembersType   `codec:"membersType" json:"membersType"`
 	WriterNames  []string                  `codec:"writerNames" json:"writerNames"`
 	ReaderNames  []string                  `codec:"readerNames" json:"readerNames"`
 	FinalizeInfo *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
@@ -1924,12 +1925,13 @@ type ConversationInfoLocal struct {
 
 func (o ConversationInfoLocal) DeepCopy() ConversationInfoLocal {
 	return ConversationInfoLocal{
-		Id:         o.Id.DeepCopy(),
-		Triple:     o.Triple.DeepCopy(),
-		TlfName:    o.TlfName,
-		TopicName:  o.TopicName,
-		Visibility: o.Visibility.DeepCopy(),
-		Status:     o.Status.DeepCopy(),
+		Id:          o.Id.DeepCopy(),
+		Triple:      o.Triple.DeepCopy(),
+		TlfName:     o.TlfName,
+		TopicName:   o.TopicName,
+		Visibility:  o.Visibility.DeepCopy(),
+		Status:      o.Status.DeepCopy(),
+		MembersType: o.MembersType.DeepCopy(),
 		WriterNames: (func(x []string) []string {
 			var ret []string
 			for _, v := range x {
@@ -2283,8 +2285,20 @@ func (o GetInboxLocalRes) DeepCopy() GetInboxLocalRes {
 	}
 }
 
+type NameQuery struct {
+	Name        string                  `codec:"name" json:"name"`
+	MembersType ConversationMembersType `codec:"membersType" json:"membersType"`
+}
+
+func (o NameQuery) DeepCopy() NameQuery {
+	return NameQuery{
+		Name:        o.Name,
+		MembersType: o.MembersType.DeepCopy(),
+	}
+}
+
 type GetInboxLocalQuery struct {
-	TlfName           *string              `codec:"tlfName,omitempty" json:"tlfName,omitempty"`
+	Name              *NameQuery           `codec:"name,omitempty" json:"name,omitempty"`
 	TopicName         *string              `codec:"topicName,omitempty" json:"topicName,omitempty"`
 	ConvIDs           []ConversationID     `codec:"convIDs" json:"convIDs"`
 	TopicType         *TopicType           `codec:"topicType,omitempty" json:"topicType,omitempty"`
@@ -2300,13 +2314,13 @@ type GetInboxLocalQuery struct {
 
 func (o GetInboxLocalQuery) DeepCopy() GetInboxLocalQuery {
 	return GetInboxLocalQuery{
-		TlfName: (func(x *string) *string {
+		Name: (func(x *NameQuery) *NameQuery {
 			if x == nil {
 				return nil
 			}
-			tmp := (*x)
+			tmp := (*x).DeepCopy()
 			return &tmp
-		})(o.TlfName),
+		})(o.Name),
 		TopicName: (func(x *string) *string {
 			if x == nil {
 				return nil
@@ -3304,6 +3318,7 @@ func (o MarkAsReadLocalArg) DeepCopy() MarkAsReadLocalArg {
 
 type FindConversationsLocalArg struct {
 	TlfName          string                       `codec:"tlfName" json:"tlfName"`
+	MembersType      ConversationMembersType      `codec:"membersType" json:"membersType"`
 	Visibility       TLFVisibility                `codec:"visibility" json:"visibility"`
 	TopicType        TopicType                    `codec:"topicType" json:"topicType"`
 	TopicName        string                       `codec:"topicName" json:"topicName"`
@@ -3313,10 +3328,11 @@ type FindConversationsLocalArg struct {
 
 func (o FindConversationsLocalArg) DeepCopy() FindConversationsLocalArg {
 	return FindConversationsLocalArg{
-		TlfName:    o.TlfName,
-		Visibility: o.Visibility.DeepCopy(),
-		TopicType:  o.TopicType.DeepCopy(),
-		TopicName:  o.TopicName,
+		TlfName:     o.TlfName,
+		MembersType: o.MembersType.DeepCopy(),
+		Visibility:  o.Visibility.DeepCopy(),
+		TopicType:   o.TopicType.DeepCopy(),
+		TopicName:   o.TopicName,
 		OneChatPerTLF: (func(x *bool) *bool {
 			if x == nil {
 				return nil

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1252,3 +1252,19 @@ func (u UserVersion) PercentForm() string {
 	}
 	return fmt.Sprintf("%s%%%d", u.Username, u.EldestSeqno)
 }
+
+func (k CryptKey) Material() Bytes32 {
+	return k.Key
+}
+
+func (k CryptKey) Generation() int {
+	return k.KeyGeneration
+}
+
+func (k TeamApplicationKey) Material() Bytes32 {
+	return k.Key
+}
+
+func (k TeamApplicationKey) Generation() int {
+	return k.KeyGeneration
+}

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -73,16 +73,16 @@ func (e TeamApplication) String() string {
 }
 
 type TeamApplicationKey struct {
-	Application TeamApplication `codec:"application" json:"application"`
-	Generation  int             `codec:"generation" json:"generation"`
-	Key         Bytes32         `codec:"key" json:"key"`
+	Application   TeamApplication `codec:"application" json:"application"`
+	KeyGeneration int             `codec:"keyGeneration" json:"keyGeneration"`
+	Key           Bytes32         `codec:"key" json:"key"`
 }
 
 func (o TeamApplicationKey) DeepCopy() TeamApplicationKey {
 	return TeamApplicationKey{
-		Application: o.Application.DeepCopy(),
-		Generation:  o.Generation,
-		Key:         o.Key.DeepCopy(),
+		Application:   o.Application.DeepCopy(),
+		KeyGeneration: o.KeyGeneration,
+		Key:           o.Key.DeepCopy(),
 	}
 }
 

--- a/go/service/bg_identifier.go
+++ b/go/service/bg_identifier.go
@@ -99,7 +99,7 @@ func (b *BackgroundIdentifier) completedIdentifyJob(ij engine.IdentifyJob) {
 
 	// Let the chat system know about this identify change
 	cg := globals.NewContext(b.G(), b.ChatG())
-	chat.NewIdentifyChangedHandler(cg, chat.NewKBFSTLFInfoSource(cg)).BackgroundIdentifyChanged(context.Background(), ij)
+	chat.NewIdentifyChangedHandler(cg).BackgroundIdentifyChanged(context.Background(), ij)
 }
 
 func (b *BackgroundIdentifier) populateWithFollowees() (err error) {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -609,7 +609,7 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 	// Run SyncAll to both authenticate, and grab all the data we will need to run the
 	// various resync procedures for chat and notifications
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, g.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
+	ctx = chat.Context(ctx, g.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
 		chat.NewIdentifyNotifier(g.G()))
 	syncAllRes, err := chatCli.SyncAll(ctx, chat1.SyncAllArg{
 		Uid:       uid,

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -106,14 +106,18 @@ func (h *KBFSHandler) conversationIDs(uid keybase1.UID, tlf string, public bool)
 
 	toptype := chat1.TopicType_CHAT
 	query := chat1.GetInboxLocalQuery{
-		TlfName:       &tlf,
+		Name: &chat1.NameQuery{
+			Name:        tlf,
+			MembersType: chat1.ConversationMembersType_KBFS,
+		},
 		TlfVisibility: &vis,
 		TopicType:     &toptype,
 	}
 
 	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx := chat.Context(context.Background(), h.G().GetEnv(), keybase1.TLFIdentifyBehavior_CHAT_GUI,
-		&identBreaks, chat.NewIdentifyNotifier(globals.NewContext(h.G(), h.ChatG())))
+	g := globals.NewContext(h.G(), h.ChatG())
+	ctx := chat.Context(context.Background(), g, keybase1.TLFIdentifyBehavior_CHAT_GUI,
+		&identBreaks, chat.NewIdentifyNotifier(g))
 	ib, _, err := h.ChatG().InboxSource.Read(ctx, uid.ToBytes(), nil, true, &query, nil)
 	if err != nil {
 		return nil, err

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -277,11 +277,10 @@ func (d *Service) stopChatModules() {
 func (d *Service) createChatModules() {
 	g := globals.NewContext(d.G(), d.ChatG())
 	ri := d.gregor.GetClient
-	tlf := chat.NewKBFSTLFInfoSource(g)
 
 	// Set up main chat data sources
-	boxer := chat.NewBoxer(g, tlf)
-	g.InboxSource = chat.NewInboxSource(g, g.Env.GetInboxSourceType(), ri, tlf)
+	boxer := chat.NewBoxer(g)
+	g.InboxSource = chat.NewInboxSource(g, g.Env.GetInboxSourceType(), ri)
 	g.ConvSource = chat.NewConversationSource(g, g.Env.GetConvSourceType(),
 		boxer, storage.New(g), ri)
 	g.ServerCacheVersions = storage.NewServerVersions(g)
@@ -299,7 +298,7 @@ func (d *Service) createChatModules() {
 	g.PushHandler = pushHandler
 
 	// Message sending apparatus
-	sender := chat.NewBlockingSender(g, chat.NewBoxer(g, tlf), d.attachmentstore, ri)
+	sender := chat.NewBlockingSender(g, chat.NewBoxer(g), d.attachmentstore, ri)
 	g.MessageDeliverer = chat.NewDeliverer(g, sender)
 
 	// Set up Offlinables on Syncer
@@ -310,7 +309,7 @@ func (d *Service) createChatModules() {
 
 	// Add a tlfHandler into the user changed handler group so we can keep identify info
 	// fresh
-	g.AddUserChangedHandler(chat.NewIdentifyChangedHandler(g, tlf))
+	g.AddUserChangedHandler(chat.NewIdentifyChangedHandler(g))
 }
 
 func (d *Service) configureRekey(uir *UIRouter) {

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -52,11 +52,10 @@ func (h *TeamsHandler) TeamAddMember(ctx context.Context, arg keybase1.TeamAddMe
 		return nil
 	}
 
-	var breaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, h.G().ExternalG().Env, keybase1.TLFIdentifyBehavior_CHAT_CLI, &breaks, nil)
 	body := fmt.Sprintf("Hi %s, I've invited you to a new team, %s.", arg.Username, arg.Name)
 	gregorCli := h.gregor.GetClient()
-	return chat.SendTextByName(ctx, h.G(), arg.Username, chat1.ConversationMembersType_KBFS, body, gregorCli)
+	return chat.SendTextByName(ctx, h.G(), arg.Username, chat1.ConversationMembersType_KBFS,
+		keybase1.TLFIdentifyBehavior_CHAT_CLI, body, gregorCli)
 }
 
 func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRemoveMemberArg) error {

--- a/go/service/tlf.go
+++ b/go/service/tlf.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/keybase/client/go/chat"
 	"github.com/keybase/client/go/chat/globals"
-	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -21,7 +20,7 @@ type tlfHandler struct {
 	utils.DebugLabeler
 	globals.Contextified
 
-	tlfInfoSource types.TLFInfoSource
+	tlfInfoSource *chat.KBFSNameInfoSource
 }
 
 func newTlfHandler(xp rpc.Transporter, g *globals.Context) *tlfHandler {
@@ -29,7 +28,7 @@ func newTlfHandler(xp rpc.Transporter, g *globals.Context) *tlfHandler {
 		BaseHandler:   NewBaseHandler(xp),
 		Contextified:  globals.NewContextified(g),
 		DebugLabeler:  utils.NewDebugLabeler(g, "TlfHandler", false),
-		tlfInfoSource: chat.NewKBFSTLFInfoSource(g),
+		tlfInfoSource: chat.NewKBFSNameInfoSource(g),
 	}
 }
 
@@ -37,7 +36,7 @@ func (h *tlfHandler) CryptKeys(ctx context.Context, arg keybase1.TLFQuery) (res 
 	defer h.Trace(ctx, func() error { return err },
 		fmt.Sprintf("CryptKeys(tlf=%s,mode=%v)", arg.TlfName, arg.IdentifyBehavior))()
 	var breaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
+	ctx = chat.Context(ctx, h.G(), arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
 	return h.tlfInfoSource.CryptKeys(ctx, arg.TlfName)
 }
 
@@ -46,7 +45,7 @@ func (h *tlfHandler) PublicCanonicalTLFNameAndID(ctx context.Context, arg keybas
 		fmt.Sprintf("PublicCanonicalTLFNameAndID(tlf=%s,mode=%v)", arg.TlfName,
 			arg.IdentifyBehavior))()
 	var breaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
+	ctx = chat.Context(ctx, h.G(), arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
 	return h.tlfInfoSource.PublicCanonicalTLFNameAndID(ctx, arg.TlfName)
 }
 
@@ -55,6 +54,6 @@ func (h *tlfHandler) CompleteAndCanonicalizePrivateTlfName(ctx context.Context, 
 		fmt.Sprintf("CompleteAndCanonicalizePrivateTlfName(tlf=%s,mode=%v)", arg.TlfName,
 			arg.IdentifyBehavior))()
 	var breaks []keybase1.TLFIdentifyFailure
-	ctx = chat.Context(ctx, h.G().GetEnv(), arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
+	ctx = chat.Context(ctx, h.G(), arg.IdentifyBehavior, &breaks, chat.NewIdentifyNotifier(h.G()))
 	return h.tlfInfoSource.CompleteAndCanonicalizePrivateTlfName(ctx, arg.TlfName)
 }

--- a/go/teams/get_test.go
+++ b/go/teams/get_test.go
@@ -48,7 +48,7 @@ func TestTeamApplicationKey(t *testing.T) {
 	if chatKey.Application != keybase1.TeamApplication_CHAT {
 		t.Errorf("key application: %d, expected %d", chatKey.Application, keybase1.TeamApplication_CHAT)
 	}
-	if chatKey.Generation != 1 {
+	if chatKey.Generation() != 1 {
 		t.Errorf("key generation: %d, expected 1", chatKey.Generation)
 	}
 	if len(chatKey.Key) != 32 {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -339,6 +339,7 @@ protocol local {
     string topicName;
     TLFVisibility visibility;
     ConversationStatus status;
+    ConversationMembersType membersType;
 
     // Lists of usernames, always complete, optionally sorted by activity.
     array<string> writerNames;
@@ -442,11 +443,16 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
+  record NameQuery {
+    string name;
+    ConversationMembersType membersType;
+  }
+
   GetInboxAndUnboxLocalRes getInboxAndUnboxLocal(union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
   record GetInboxLocalQuery {
     // Local analog of common:GetInboxQuery
 
-    union { null, string } tlfName;
+    union { null, NameQuery } name;
     union { null, string } topicName;
 
     array<ConversationID> convIDs;
@@ -623,7 +629,7 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
-  FindConversationsLocalRes findConversationsLocal(string tlfName, TLFVisibility visibility, TopicType topicType, string topicName, union { null, boolean } oneChatPerTLF, keybase1.TLFIdentifyBehavior identifyBehavior);
+  FindConversationsLocalRes findConversationsLocal(string tlfName, ConversationMembersType membersType, TLFVisibility visibility, TopicType topicType, string topicName, union { null, boolean } oneChatPerTLF, keybase1.TLFIdentifyBehavior identifyBehavior);
 
   // Typing API
   void updateTyping(ConversationID conversationID, boolean typing);

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -18,7 +18,7 @@ protocol teams {
 
   record TeamApplicationKey {
     TeamApplication application;
-    int generation;
+    int keyGeneration;
     Bytes32 key; 
   }
   

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1044,6 +1044,7 @@ export type ConversationInfoLocal = {
   topicName: string,
   visibility: TLFVisibility,
   status: ConversationStatus,
+  membersType: ConversationMembersType,
   writerNames?: ?Array<string>,
   readerNames?: ?Array<string>,
   finalizeInfo?: ?ConversationFinalizeInfo,
@@ -1158,7 +1159,7 @@ export type GetInboxByTLFIDRemoteRes = {
 }
 
 export type GetInboxLocalQuery = {
-  tlfName?: ?string,
+  name?: ?NameQuery,
   topicName?: ?string,
   convIDs?: ?Array<ConversationID>,
   topicType?: ?TopicType,
@@ -1530,6 +1531,11 @@ export type MessageUnboxedValid = {
   headerSignature?: ?SignatureInfo,
   verificationKey?: ?bytes,
   senderDeviceRevokedAt?: ?gregor1.Time,
+}
+
+export type NameQuery = {
+  name: string,
+  membersType: ConversationMembersType,
 }
 
 export type NewConversationInfo = {
@@ -1909,6 +1915,7 @@ export type localDownloadFileAttachmentLocalRpcParam = Exact<{
 
 export type localFindConversationsLocalRpcParam = Exact<{
   tlfName: string,
+  membersType: ConversationMembersType,
   visibility: TLFVisibility,
   topicType: TopicType,
   topicName: string,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5645,7 +5645,7 @@ export type TeamApplication =
 
 export type TeamApplicationKey = {
   application: TeamApplication,
-  generation: int,
+  keyGeneration: int,
   key: Bytes32,
 }
 

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -983,6 +983,10 @@
           "name": "status"
         },
         {
+          "type": "ConversationMembersType",
+          "name": "membersType"
+        },
+        {
           "type": {
             "type": "array",
             "items": "string"
@@ -1282,14 +1286,28 @@
     },
     {
       "type": "record",
+      "name": "NameQuery",
+      "fields": [
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "ConversationMembersType",
+          "name": "membersType"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "GetInboxLocalQuery",
       "fields": [
         {
           "type": [
             null,
-            "string"
+            "NameQuery"
           ],
-          "name": "tlfName"
+          "name": "name"
         },
         {
           "type": [
@@ -2358,6 +2376,10 @@
         {
           "name": "tlfName",
           "type": "string"
+        },
+        {
+          "name": "membersType",
+          "type": "ConversationMembersType"
         },
         {
           "name": "visibility",

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -32,7 +32,7 @@
         },
         {
           "type": "int",
-          "name": "generation"
+          "name": "keyGeneration"
         },
         {
           "type": "Bytes32",

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1044,6 +1044,7 @@ export type ConversationInfoLocal = {
   topicName: string,
   visibility: TLFVisibility,
   status: ConversationStatus,
+  membersType: ConversationMembersType,
   writerNames?: ?Array<string>,
   readerNames?: ?Array<string>,
   finalizeInfo?: ?ConversationFinalizeInfo,
@@ -1158,7 +1159,7 @@ export type GetInboxByTLFIDRemoteRes = {
 }
 
 export type GetInboxLocalQuery = {
-  tlfName?: ?string,
+  name?: ?NameQuery,
   topicName?: ?string,
   convIDs?: ?Array<ConversationID>,
   topicType?: ?TopicType,
@@ -1530,6 +1531,11 @@ export type MessageUnboxedValid = {
   headerSignature?: ?SignatureInfo,
   verificationKey?: ?bytes,
   senderDeviceRevokedAt?: ?gregor1.Time,
+}
+
+export type NameQuery = {
+  name: string,
+  membersType: ConversationMembersType,
 }
 
 export type NewConversationInfo = {
@@ -1909,6 +1915,7 @@ export type localDownloadFileAttachmentLocalRpcParam = Exact<{
 
 export type localFindConversationsLocalRpcParam = Exact<{
   tlfName: string,
+  membersType: ConversationMembersType,
   visibility: TLFVisibility,
   topicType: TopicType,
   topicName: string,

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5645,7 +5645,7 @@ export type TeamApplication =
 
 export type TeamApplicationKey = {
   application: TeamApplication,
-  generation: int,
+  keyGeneration: int,
   key: Bytes32,
 }
 


### PR DESCRIPTION
Point of the patch is to integrate teams with chat. The central change here is the removal of `TLFInfoSource`, and changing it into `NameInfoSource`. `NameInfoSource` is now much simpler, only exposing one function called `Lookup`. Other highlights are the following:

1.) Create new interface `chat.CryptKey` which abstracts the keys obtained from KBFS and teams. 
2.) Run all the key gathering from `KeyFinder`, chat globals types don't need a `TLFInfoSource` anymore.
3.) Pass a new `chat1.ConversationMembersType` variable around where it is relevant. This involves changing a lot of functions to now take `chat1.Conversation` instead of `chat1.ConversationID`. 
4.) Change `TlfName` query on `GetInboxLocalQuery` to take a members type.
5.) Changed all the tests to run both team and KBFS versions of themselves from `server_test.go`.