### PR TITLE
Enable PUK support (does NOT add to sigchain, that's 'upgrade')

### DIFF
--- a/go/engine/device_keygen.go
+++ b/go/engine/device_keygen.go
@@ -18,7 +18,7 @@ type DeviceKeygenArgs struct {
 	DeviceType     string
 	Lks            *libkb.LKSec
 	IsEldest       bool
-	PerUserKeyring *libkb.PerUserKeyring // optional in some cases
+	PerUserKeyring *libkb.PerUserKeyring
 }
 
 // DeviceKeygenPushArgs determines how the push will run.  There are
@@ -374,6 +374,12 @@ func (e *DeviceKeygen) preparePerUserKeyBoxFromPaperkey(ctx *Context) ([]keybase
 	}
 	// Assuming this is a paperkey provision.
 
+	upak := e.args.Me.ExportToUserPlusAllKeys(keybase1.Time(0))
+	if len(upak.Base.PerUserKeys) == 0 {
+		e.G().Log.CDebugf(ctx.GetNetContext(), "DeviceKeygen skipping per-user-keys, none exist")
+		return nil, nil
+	}
+
 	pukring := e.args.PerUserKeyring
 	if pukring == nil {
 		return nil, errors.New("missing PerUserKeyring")
@@ -385,6 +391,9 @@ func (e *DeviceKeygen) preparePerUserKeyBoxFromPaperkey(ctx *Context) ([]keybase
 
 	paperSigKey := ctx.LoginContext.GetUnlockedPaperSigKey()
 	paperEncKeyGeneric := ctx.LoginContext.GetUnlockedPaperEncKey()
+	if paperSigKey == nil && paperEncKeyGeneric == nil {
+		return nil, errors.New("missing paper key in login context")
+	}
 	if paperSigKey == nil {
 		return nil, errors.New("missing paper sig key")
 	}
@@ -396,7 +405,6 @@ func (e *DeviceKeygen) preparePerUserKeyBoxFromPaperkey(ctx *Context) ([]keybase
 		return nil, errors.New("Unexpected encryption key type")
 	}
 
-	upak := e.args.Me.ExportToUserPlusAllKeys(keybase1.Time(0))
 	paperDeviceID, err := upak.GetDeviceID(paperSigKey.GetKID())
 	if err != nil {
 		return nil, err

--- a/go/engine/device_wrap.go
+++ b/go/engine/device_wrap.go
@@ -27,7 +27,7 @@ type DeviceWrapArgs struct {
 	IsEldest       bool
 	Signer         libkb.GenericKey
 	EldestKID      keybase1.KID
-	PerUserKeyring *libkb.PerUserKeyring // optional in some cases
+	PerUserKeyring *libkb.PerUserKeyring
 }
 
 // NewDeviceWrap creates a DeviceWrap engine.

--- a/go/engine/per_user_key_upgrade_test.go
+++ b/go/engine/per_user_key_upgrade_test.go
@@ -16,7 +16,6 @@ func TestPerUserKeyUpgrade(t *testing.T) {
 	defer tc.Cleanup()
 
 	tc.Tp.UpgradePerUserKey = false
-	tc.Tp.SupportPerUserKey = false
 
 	fu := CreateAndSignupFakeUserPaper(tc, "pukup")
 

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -134,8 +134,10 @@ func testRevokePaperDevice(t *testing.T, upgradePerUserKey bool) {
 
 	assertNumDevicesAndKeys(tc, u, 1, 2)
 
-	if tc.G.Env.GetSupportPerUserKey() {
+	if tc.G.Env.GetUpgradePerUserKey() {
 		checkPerUserKeyring(t, tc.G, 2)
+	} else {
+		checkPerUserKeyring(t, tc.G, 0)
 	}
 }
 
@@ -181,14 +183,16 @@ func testRevokerPaperDeviceTwice(t *testing.T, upgradePerUserKey bool) {
 	t.Logf("check")
 	assertNumDevicesAndKeys(tc, u, 1, 2)
 
-	if tc.G.Env.GetSupportPerUserKey() {
+	if tc.G.Env.GetUpgradePerUserKey() {
 		checkPerUserKeyring(t, tc.G, 3)
 	}
 }
 
 func checkPerUserKeyring(t *testing.T, g *libkb.GlobalContext, expectedCurrentGeneration int) {
 	pukring, err := g.GetPerUserKeyring()
-	if err == nil {
+	require.NoError(t, err)
+	// Weakly check. If the keyring was not initialized, don't worry about it.
+	if pukring.HasAnyKeys() == (expectedCurrentGeneration > 0) {
 		require.Equal(t, keybase1.PerUserKeyGeneration(expectedCurrentGeneration), pukring.CurrentGeneration())
 	}
 	pukring = nil

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -151,7 +151,6 @@ type TestParameters struct {
 	// suffix.
 	DevelName         string
 	RuntimeDir        string
-	SupportPerUserKey bool
 	UpgradePerUserKey bool
 
 	// set to true to use production run mode in tests
@@ -659,20 +658,7 @@ func (e *Env) GetEmail() string {
 // Does not add per-user-keys to sigchains unless they are already there.
 // It is unwise to have this off and interact with sigchains that have per-user-keys.
 func (e *Env) GetSupportPerUserKey() bool {
-	if e.GetUpgradePerUserKey() {
-		return true
-	}
-
-	if e.GetRunMode() != DevelRunMode {
-		return false
-	}
-
-	return e.GetBool(false,
-		func() (bool, bool) { return e.Test.SupportPerUserKey, e.Test.SupportPerUserKey },
-		func() (bool, bool) { return e.getEnvBool("KEYBASE_SUPPORT_PER_USER_KEY") },
-		func() (bool, bool) { return e.config.GetSupportPerUserKey() },
-		func() (bool, bool) { return e.cmd.GetSupportPerUserKey() },
-	)
+	return true
 }
 
 // Upgrade sigchains to contain per-user-keys.


### PR DESCRIPTION
Turn on the `GetSupportPerUserKey` flag.
When this turns out fine then more cleanup is due later:
- [ ] Remove the Env method `GetSupportPerUserKey` and collapse the code that switches on it.
- [ ] Go through and deduplicate tests which were duplicated to test both values of this setting.