### PR TITLE
remove keepPaperKey option from PaperProvision, always do it

### DIFF
--- a/go/client/cmd_paperprovision.go
+++ b/go/client/cmd_paperprovision.go
@@ -23,23 +23,17 @@ func NewCmdPaperProvision(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cl
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdPaperProvisionRunner(g), "paperprovision", c)
 		},
-		Flags: []cli.Flag{
-			cli.BoolFlag{
-				Name:  "keep-paper-key, k",
-				Usage: "Keep paper key.",
-			},
-		},
+		Flags: []cli.Flag{},
 	}
 	return cmd
 }
 
 type CmdPaperProvision struct {
 	libkb.Contextified
-	username     string
-	deviceName   string
-	paperKey     string
-	SessionID    int
-	keepPaperKey bool
+	username   string
+	deviceName string
+	paperKey   string
+	SessionID  int
 }
 
 func NewCmdPaperProvisionRunner(g *libkb.GlobalContext) *CmdPaperProvision {
@@ -67,18 +61,16 @@ func (c *CmdPaperProvision) Run() (err error) {
 
 	err = client.PaperProvision(context.TODO(),
 		keybase1.PaperProvisionArg{
-			Username:     c.username,
-			DeviceName:   c.deviceName,
-			PaperKey:     c.paperKey,
-			SessionID:    c.SessionID,
-			KeepPaperKey: c.keepPaperKey,
+			Username:   c.username,
+			DeviceName: c.deviceName,
+			PaperKey:   c.paperKey,
+			SessionID:  c.SessionID,
 		})
 
 	return
 }
 
 func (c *CmdPaperProvision) ParseArgv(ctx *cli.Context) error {
-	c.keepPaperKey = ctx.Bool("keep-paper-key")
 	nargs := len(ctx.Args())
 	if nargs != 3 {
 		return errors.New("Username, devicename and paperkey arguments required")

--- a/go/client/cmd_paperprovision.go
+++ b/go/client/cmd_paperprovision.go
@@ -23,17 +23,23 @@ func NewCmdPaperProvision(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cl
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdPaperProvisionRunner(g), "paperprovision", c)
 		},
-		Flags: []cli.Flag{},
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "keep-paper-key, k",
+				Usage: "Keep paper key.",
+			},
+		},
 	}
 	return cmd
 }
 
 type CmdPaperProvision struct {
 	libkb.Contextified
-	username   string
-	deviceName string
-	paperKey   string
-	SessionID  int
+	username     string
+	deviceName   string
+	paperKey     string
+	SessionID    int
+	keepPaperKey bool
 }
 
 func NewCmdPaperProvisionRunner(g *libkb.GlobalContext) *CmdPaperProvision {
@@ -59,6 +65,10 @@ func (c *CmdPaperProvision) Run() (err error) {
 		return err
 	}
 
+	if c.keepPaperKey {
+		c.G().Log.Warning("'--keep-paper-key' has no effect")
+	}
+
 	err = client.PaperProvision(context.TODO(),
 		keybase1.PaperProvisionArg{
 			Username:   c.username,
@@ -71,6 +81,7 @@ func (c *CmdPaperProvision) Run() (err error) {
 }
 
 func (c *CmdPaperProvision) ParseArgv(ctx *cli.Context) error {
+	c.keepPaperKey = ctx.Bool("keep-paper-key")
 	nargs := len(ctx.Args())
 	if nargs != 3 {
 		return errors.New("Username, devicename and paperkey arguments required")

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -856,7 +856,7 @@ func TestProvisionPaperCommandLine(t *testing.T) {
 		GPGUI:       &gpgtestui{},
 	}
 
-	eng := NewPaperProvisionEngine(tc2.G, fu.Username, "fakedevice", loginUI.PaperPhrase, true)
+	eng := NewPaperProvisionEngine(tc2.G, fu.Username, "fakedevice", loginUI.PaperPhrase)
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/paperprovision.go
+++ b/go/engine/paperprovision.go
@@ -13,23 +13,21 @@ import (
 
 type PaperProvisionEngine struct {
 	libkb.Contextified
-	Username     string
-	DeviceName   string
-	PaperKey     string
-	keepPaperKey bool
-	result       error
-	lks          *libkb.LKSec
-	User         *libkb.User
+	Username   string
+	DeviceName string
+	PaperKey   string
+	result     error
+	lks        *libkb.LKSec
+	User       *libkb.User
 }
 
 func NewPaperProvisionEngine(g *libkb.GlobalContext, username, deviceName,
-	paperKey string, keepPaperKey bool) *PaperProvisionEngine {
+	paperKey string) *PaperProvisionEngine {
 	return &PaperProvisionEngine{
 		Contextified: libkb.NewContextified(g),
 		Username:     username,
 		DeviceName:   deviceName,
 		PaperKey:     paperKey,
-		keepPaperKey: keepPaperKey,
 	}
 }
 
@@ -161,11 +159,10 @@ func (e *PaperProvisionEngine) paper(ctx *Context, kp *keypair) error {
 			return err
 		}
 
+		lctx.SetUnlockedPaperKey(kp.sigKey, kp.encKey)
+
 		if err := e.makeDeviceKeysWithSigner(ctx, kp.sigKey); err != nil {
 			return err
-		}
-		if e.keepPaperKey {
-			lctx.SetUnlockedPaperKey(kp.sigKey, kp.encKey)
 		}
 		if err := lctx.LocalSession().SetDeviceProvisioned(e.G().Env.GetDeviceID()); err != nil {
 			// not a fatal error, session will stay in memory

--- a/go/engine/upak_loader_test.go
+++ b/go/engine/upak_loader_test.go
@@ -94,7 +94,7 @@ func TestLoadDeviceKeyNew(t *testing.T) {
 		GPGUI:       &gpgtestui{},
 	}
 
-	eng := NewPaperProvisionEngine(tc2.G, fu.Username, "fakedevice", loginUI.PaperPhrase, true)
+	eng := NewPaperProvisionEngine(tc2.G, fu.Username, "fakedevice", loginUI.PaperPhrase)
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -253,7 +253,7 @@ func TestFullSelfCacherFlushTwoMachines(t *testing.T) {
 		GPGUI:       &gpgtestui{},
 	}
 
-	eng := NewPaperProvisionEngine(tc2.G, fu.Username, "fakedevice", loginUI.PaperPhrase, true)
+	eng := NewPaperProvisionEngine(tc2.G, fu.Username, "fakedevice", loginUI.PaperPhrase)
 	if err := RunEngine(eng, ctx); err != nil {
 		t.Fatal(err)
 	}

--- a/go/protocol/keybase1/paperprovision.go
+++ b/go/protocol/keybase1/paperprovision.go
@@ -9,20 +9,18 @@ import (
 )
 
 type PaperProvisionArg struct {
-	SessionID    int    `codec:"sessionID" json:"sessionID"`
-	Username     string `codec:"username" json:"username"`
-	DeviceName   string `codec:"deviceName" json:"deviceName"`
-	PaperKey     string `codec:"paperKey" json:"paperKey"`
-	KeepPaperKey bool   `codec:"keepPaperKey" json:"keepPaperKey"`
+	SessionID  int    `codec:"sessionID" json:"sessionID"`
+	Username   string `codec:"username" json:"username"`
+	DeviceName string `codec:"deviceName" json:"deviceName"`
+	PaperKey   string `codec:"paperKey" json:"paperKey"`
 }
 
 func (o PaperProvisionArg) DeepCopy() PaperProvisionArg {
 	return PaperProvisionArg{
-		SessionID:    o.SessionID,
-		Username:     o.Username,
-		DeviceName:   o.DeviceName,
-		PaperKey:     o.PaperKey,
-		KeepPaperKey: o.KeepPaperKey,
+		SessionID:  o.SessionID,
+		Username:   o.Username,
+		DeviceName: o.DeviceName,
+		PaperKey:   o.PaperKey,
 	}
 }
 

--- a/go/service/paperprovision.go
+++ b/go/service/paperprovision.go
@@ -33,7 +33,7 @@ func (h *PaperProvisionHandler) PaperProvision(ctx context.Context, arg keybase1
 		ProvisionUI: h.getProvisionUI(arg.SessionID),
 		SessionID:   arg.SessionID,
 	}
-	eng := engine.NewPaperProvisionEngine(h.G(), arg.Username, arg.DeviceName, arg.PaperKey, arg.KeepPaperKey)
+	eng := engine.NewPaperProvisionEngine(h.G(), arg.Username, arg.DeviceName, arg.PaperKey)
 	err := engine.RunEngine(eng, &ectx)
 	if err != nil {
 		return err

--- a/protocol/avdl/keybase1/paperprovision.avdl
+++ b/protocol/avdl/keybase1/paperprovision.avdl
@@ -9,6 +9,6 @@ protocol paperprovision {
     If the current device isn't provisioned, this function will
     provision it.
     */
-  void paperProvision(int sessionID, string username, string deviceName, string paperKey, boolean keepPaperKey);
+  void paperProvision(int sessionID, string username, string deviceName, string paperKey);
 
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -6395,8 +6395,7 @@ export type notifyCtlSetNotificationsRpcParam = Exact<{
 export type paperprovisionPaperProvisionRpcParam = Exact<{
   username: string,
   deviceName: string,
-  paperKey: string,
-  keepPaperKey: boolean
+  paperKey: string
 }>
 
 export type pgpPgpDecryptRpcParam = Exact<{

--- a/protocol/json/keybase1/paperprovision.json
+++ b/protocol/json/keybase1/paperprovision.json
@@ -25,10 +25,6 @@
         {
           "name": "paperKey",
           "type": "string"
-        },
-        {
-          "name": "keepPaperKey",
-          "type": "boolean"
         }
       ],
       "response": null,

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -6395,8 +6395,7 @@ export type notifyCtlSetNotificationsRpcParam = Exact<{
 export type paperprovisionPaperProvisionRpcParam = Exact<{
   username: string,
   deviceName: string,
-  paperKey: string,
-  keepPaperKey: boolean
+  paperKey: string
 }>
 
 export type pgpPgpDecryptRpcParam = Exact<{


### PR DESCRIPTION
Get rid of the `--keep-paper-key` flag for `PaperProvisionEngine`. Default to true, always store the paper key. Also store it before signing in the new device (`makeDeviceKeysWithSigner`). This is motivated by enabling per-user-key support. I will need the paperkey to encrypt per-user-key boxes. Another option would be to pass it down through arguments and not affect this flag. This seemed cleaner to me.

cc @jzila 