### PR TITLE
Revendor go-crypto (KeyFlags merging over userids)

### DIFF
--- a/go/vendor/github.com/keybase/go-crypto/openpgp/packet/public_key.go
+++ b/go/vendor/github.com/keybase/go-crypto/openpgp/packet/public_key.go
@@ -66,7 +66,7 @@ type edDSAkey struct {
 
 func copyFrontFill(dst, src []byte, length int) int {
 	if srcLen := len(src); srcLen < length {
-		return copy(dst[length - srcLen:], src[:])
+		return copy(dst[length-srcLen:], src[:])
 	} else {
 		return copy(dst[:], src[:])
 	}

--- a/go/vendor/github.com/keybase/go-crypto/openpgp/packet/signature.go
+++ b/go/vendor/github.com/keybase/go-crypto/openpgp/packet/signature.go
@@ -44,6 +44,13 @@ type RevocationKey struct {
 	Fingerprint   []byte
 }
 
+// KeyFlagBits holds boolean whether any usage flags were provided in
+// the signature and BitField with KeyFlag* flags.
+type KeyFlagBits struct {
+	Valid    bool
+	BitField byte
+}
+
 // Signature represents a signature. See RFC 4880, section 5.2.
 type Signature struct {
 	SigType    SignatureType
@@ -798,20 +805,7 @@ func (sig *Signature) buildSubpackets() (subpackets []outputSubpacket) {
 	// Key flags may only appear in self-signatures or certification signatures.
 
 	if sig.FlagsValid {
-		var flags byte
-		if sig.FlagCertify {
-			flags |= KeyFlagCertify
-		}
-		if sig.FlagSign {
-			flags |= KeyFlagSign
-		}
-		if sig.FlagEncryptCommunications {
-			flags |= KeyFlagEncryptCommunications
-		}
-		if sig.FlagEncryptStorage {
-			flags |= KeyFlagEncryptStorage
-		}
-		subpackets = append(subpackets, outputSubpacket{true, keyFlagsSubpacket, false, []byte{flags}})
+		subpackets = append(subpackets, outputSubpacket{true, keyFlagsSubpacket, false, []byte{sig.GetKeyFlags().BitField}})
 	}
 
 	// The following subpackets may only appear in self-signatures
@@ -839,4 +833,48 @@ func (sig *Signature) buildSubpackets() (subpackets []outputSubpacket) {
 	}
 
 	return
+}
+
+func (sig *Signature) GetKeyFlags() (ret KeyFlagBits) {
+	if !sig.FlagsValid {
+		return ret
+	}
+
+	ret.Valid = true
+	if sig.FlagCertify {
+		ret.BitField |= KeyFlagCertify
+	}
+	if sig.FlagSign {
+		ret.BitField |= KeyFlagSign
+	}
+	if sig.FlagEncryptCommunications {
+		ret.BitField |= KeyFlagEncryptCommunications
+	}
+	if sig.FlagEncryptStorage {
+		ret.BitField |= KeyFlagEncryptStorage
+	}
+	return ret
+}
+
+func (f *KeyFlagBits) HasFlagCertify() bool {
+	return f.BitField&KeyFlagCertify != 0
+}
+
+func (f *KeyFlagBits) HasFlagSign() bool {
+	return f.BitField&KeyFlagSign != 0
+}
+
+func (f *KeyFlagBits) HasFlagEncryptCommunications() bool {
+	return f.BitField&KeyFlagEncryptCommunications != 0
+}
+
+func (f *KeyFlagBits) HasFlagEncryptStorage() bool {
+	return f.BitField&KeyFlagEncryptStorage != 0
+}
+
+func (f *KeyFlagBits) Merge(other KeyFlagBits) {
+	if other.Valid {
+		f.Valid = true
+		f.BitField |= other.BitField
+	}
 }

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -199,10 +199,10 @@
 			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
-			"checksumSHA1": "5E4DLEAVDwFt//h5K23zHP1qCew=",
+			"checksumSHA1": "fgFlkfkaotUjBVhJik2979oCeJw=",
 			"path": "github.com/keybase/go-crypto/openpgp",
-			"revision": "b5f4c79208fa609f364833f8c356535100d602ad",
-			"revisionTime": "2017-05-22T12:28:10Z"
+			"revision": "00ac4db533f63ef97576cbc7b07939ff7daf7329",
+			"revisionTime": "2017-06-05T14:56:57Z"
 		},
 		{
 			"checksumSHA1": "+spfcEChljh3yeIg4K/xHOQ2pVM=",
@@ -235,10 +235,10 @@
 			"revisionTime": "2017-05-08T13:19:45Z"
 		},
 		{
-			"checksumSHA1": "CXTLNDL5s+SONDJdwuI3kRFGyBk=",
+			"checksumSHA1": "y16ATKgHL/k6rQZqdXP1sIAJxE0=",
 			"path": "github.com/keybase/go-crypto/openpgp/packet",
-			"revision": "b5f4c79208fa609f364833f8c356535100d602ad",
-			"revisionTime": "2017-05-22T12:28:10Z"
+			"revision": "00ac4db533f63ef97576cbc7b07939ff7daf7329",
+			"revisionTime": "2017-06-05T14:56:57Z"
 		},
 		{
 			"checksumSHA1": "BGDxg1Xtsz0DSPzdQGJLLQqfYc8=",


### PR DESCRIPTION
Fixes `keybase id emc2` 

cc @maxtaco go-crypto change has already been reviewed and this is only a revendor