### PR TITLE
Update gradle to 3.3, circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ dependencies:
     - sudo apt-get install -y -qq yarn=0.24.5-1
     - sudo rm -rf $HOME/go* # Remove old go installation
     - sudo rm -rf /usr/local/go* # Remove old go installation
-    - wget https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz -O $HOME/go.tar.gz
+    - wget https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz -O $HOME/go.tar.gz
     - mkdir $HOME/go-path
     - (cd $HOME; tar -xzvf go.tar.gz)
     - sudo mv $HOME/go /usr/local
@@ -39,7 +39,7 @@ dependencies:
     # Install Yarn
   cache_directories:
     - /usr/local/android-sdk-linux/tools
-    - /usr/local/android-sdk-linux/build-tools/23.0.2
+    - /usr/local/android-sdk-linux/build-tools/25.0.0
     - /usr/local/android-sdk-linux/extras/android/m2repository
   override:
     # TODO(mm): use the emulator when we figure out a consistent way of getting this working

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ dependencies:
     - (cd $HOME; tar -xzvf go.tar.gz)
     - sudo mv $HOME/go /usr/local
     - if ! $(grep -q "Revision=24.4.1" $ANDROID_HOME/tools/source.properties); then echo y | android update sdk -u -a -t "tools"; fi
-    - if [ ! -e $ANDROID_HOME/build-tools/23.0.2 ]; then echo y | android update sdk -u -a -t "build-tools-23.0.2"; fi
+    - if [ ! -e $ANDROID_HOME/build-tools/25.0.0 ]; then echo y | android update sdk -u -a -t "build-tools-25.0.0"; fi
      # Android Support Repository, revision 35 / Local Maven repository for Support Libraries
     - if [ ! -d "/usr/local/android-sdk-linux/extras/android/m2repository/com/android/support/design/24.1.0" ]; then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
     # Accept android licenses

--- a/shared/react-native/android/app/build.gradle
+++ b/shared/react-native/android/app/build.gradle
@@ -86,7 +86,7 @@ def Integer timestamp() {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "io.keybase.ossifrage"

--- a/shared/react-native/android/build.gradle
+++ b/shared/react-native/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.2'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5' // To publish from gradle
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/shared/react-native/android/gradle/wrapper/gradle-wrapper.properties
+++ b/shared/react-native/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 19 16:09:49 EDT 2016
+#Mon Jun 05 11:34:43 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
I always hit "Remind Later" when getting message from Android Studio about out of date gradle. 

Should we update to 3.3?

Also, updates build tools and go to 1.8.3 on circleci.