### PR TITLE
protocol: change PublicTopLevelFolder bool for a proper TLF type

### DIFF
--- a/go/protocol/keybase1/kbfs_common.go
+++ b/go/protocol/keybase1/kbfs_common.go
@@ -158,25 +158,24 @@ func (e FSErrorType) String() string {
 }
 
 type FSNotification struct {
-	PublicTopLevelFolder bool               `codec:"publicTopLevelFolder" json:"publicTopLevelFolder"`
-	Filename             string             `codec:"filename" json:"filename"`
-	Status               string             `codec:"status" json:"status"`
-	StatusCode           FSStatusCode       `codec:"statusCode" json:"statusCode"`
-	NotificationType     FSNotificationType `codec:"notificationType" json:"notificationType"`
-	ErrorType            FSErrorType        `codec:"errorType" json:"errorType"`
-	Params               map[string]string  `codec:"params" json:"params"`
-	WriterUid            UID                `codec:"writerUid" json:"writerUid"`
-	LocalTime            Time               `codec:"localTime" json:"localTime"`
+	Filename         string             `codec:"filename" json:"filename"`
+	Status           string             `codec:"status" json:"status"`
+	StatusCode       FSStatusCode       `codec:"statusCode" json:"statusCode"`
+	NotificationType FSNotificationType `codec:"notificationType" json:"notificationType"`
+	ErrorType        FSErrorType        `codec:"errorType" json:"errorType"`
+	Params           map[string]string  `codec:"params" json:"params"`
+	WriterUid        UID                `codec:"writerUid" json:"writerUid"`
+	LocalTime        Time               `codec:"localTime" json:"localTime"`
+	FolderType       FolderType         `codec:"folderType" json:"folderType"`
 }
 
 func (o FSNotification) DeepCopy() FSNotification {
 	return FSNotification{
-		PublicTopLevelFolder: o.PublicTopLevelFolder,
-		Filename:             o.Filename,
-		Status:               o.Status,
-		StatusCode:           o.StatusCode.DeepCopy(),
-		NotificationType:     o.NotificationType.DeepCopy(),
-		ErrorType:            o.ErrorType.DeepCopy(),
+		Filename:         o.Filename,
+		Status:           o.Status,
+		StatusCode:       o.StatusCode.DeepCopy(),
+		NotificationType: o.NotificationType.DeepCopy(),
+		ErrorType:        o.ErrorType.DeepCopy(),
 		Params: (func(x map[string]string) map[string]string {
 			ret := make(map[string]string)
 			for k, v := range x {
@@ -186,8 +185,9 @@ func (o FSNotification) DeepCopy() FSNotification {
 			}
 			return ret
 		})(o.Params),
-		WriterUid: o.WriterUid.DeepCopy(),
-		LocalTime: o.LocalTime.DeepCopy(),
+		WriterUid:  o.WriterUid.DeepCopy(),
+		LocalTime:  o.LocalTime.DeepCopy(),
+		FolderType: o.FolderType.DeepCopy(),
 	}
 }
 
@@ -214,20 +214,20 @@ func (o FSSyncStatusRequest) DeepCopy() FSSyncStatusRequest {
 }
 
 type FSPathSyncStatus struct {
-	PublicTopLevelFolder bool   `codec:"publicTopLevelFolder" json:"publicTopLevelFolder"`
-	Path                 string `codec:"path" json:"path"`
-	SyncingBytes         int64  `codec:"syncingBytes" json:"syncingBytes"`
-	SyncingOps           int64  `codec:"syncingOps" json:"syncingOps"`
-	SyncedBytes          int64  `codec:"syncedBytes" json:"syncedBytes"`
+	FolderType   FolderType `codec:"folderType" json:"folderType"`
+	Path         string     `codec:"path" json:"path"`
+	SyncingBytes int64      `codec:"syncingBytes" json:"syncingBytes"`
+	SyncingOps   int64      `codec:"syncingOps" json:"syncingOps"`
+	SyncedBytes  int64      `codec:"syncedBytes" json:"syncedBytes"`
 }
 
 func (o FSPathSyncStatus) DeepCopy() FSPathSyncStatus {
 	return FSPathSyncStatus{
-		PublicTopLevelFolder: o.PublicTopLevelFolder,
-		Path:                 o.Path,
-		SyncingBytes:         o.SyncingBytes,
-		SyncingOps:           o.SyncingOps,
-		SyncedBytes:          o.SyncedBytes,
+		FolderType:   o.FolderType.DeepCopy(),
+		Path:         o.Path,
+		SyncingBytes: o.SyncingBytes,
+		SyncingOps:   o.SyncingOps,
+		SyncedBytes:  o.SyncedBytes,
 	}
 }
 

--- a/protocol/avdl/keybase1/kbfs_common.avdl
+++ b/protocol/avdl/keybase1/kbfs_common.avdl
@@ -41,7 +41,6 @@ protocol kbfsCommon {
   }
 
   record FSNotification {
-    boolean publicTopLevelFolder;
     string filename;
     string status;
     FSStatusCode statusCode;
@@ -51,7 +50,8 @@ protocol kbfsCommon {
     @lint("ignore")
     UID writerUid;
     Time localTime;
-  }
+    FolderType folderType;
+}
 
   record FSEditListRequest {
     Folder folder;
@@ -63,7 +63,7 @@ protocol kbfsCommon {
   }
 
   record FSPathSyncStatus {
-    boolean publicTopLevelFolder;
+    FolderType folderType;
     string path;  // could be a file or directory
     // How many total encrypted, padded bytes are still syncing, as part of
     // operations on this path.

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4320,7 +4320,6 @@ export type FSErrorType =
   | 14 // DISK_CACHE_ERROR_LOG_SEND_14
 
 export type FSNotification = {
-  publicTopLevelFolder: boolean,
   filename: string,
   status: string,
   statusCode: FSStatusCode,
@@ -4329,6 +4328,7 @@ export type FSNotification = {
   params: {[key: string]: string},
   writerUid: UID,
   localTime: Time,
+  folderType: FolderType,
 }
 
 export type FSNotificationType =
@@ -4346,7 +4346,7 @@ export type FSNotificationType =
   | 11 // INITIALIZED_11
 
 export type FSPathSyncStatus = {
-  publicTopLevelFolder: boolean,
+  folderType: FolderType,
   path: string,
   syncingBytes: int64,
   syncingOps: int64,

--- a/protocol/json/kbfs_common.json
+++ b/protocol/json/kbfs_common.json
@@ -50,8 +50,8 @@
       "name": "FSNotification",
       "fields": [
         {
-          "type": "boolean",
-          "name": "publicTopLevelFolder"
+          "type": "FolderType",
+          "name": "folderType"
         },
         {
           "type": "string",

--- a/protocol/json/keybase1/kbfs_common.json
+++ b/protocol/json/keybase1/kbfs_common.json
@@ -55,10 +55,6 @@
       "name": "FSNotification",
       "fields": [
         {
-          "type": "boolean",
-          "name": "publicTopLevelFolder"
-        },
-        {
           "type": "string",
           "name": "filename"
         },
@@ -93,6 +89,10 @@
         {
           "type": "Time",
           "name": "localTime"
+        },
+        {
+          "type": "FolderType",
+          "name": "folderType"
         }
       ]
     },
@@ -125,8 +125,8 @@
       "name": "FSPathSyncStatus",
       "fields": [
         {
-          "type": "boolean",
-          "name": "publicTopLevelFolder"
+          "type": "FolderType",
+          "name": "folderType"
         },
         {
           "type": "string",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4320,7 +4320,6 @@ export type FSErrorType =
   | 14 // DISK_CACHE_ERROR_LOG_SEND_14
 
 export type FSNotification = {
-  publicTopLevelFolder: boolean,
   filename: string,
   status: string,
   statusCode: FSStatusCode,
@@ -4329,6 +4328,7 @@ export type FSNotification = {
   params: {[key: string]: string},
   writerUid: UID,
   localTime: Time,
+  folderType: FolderType,
 }
 
 export type FSNotificationType =
@@ -4346,7 +4346,7 @@ export type FSNotificationType =
   | 11 // INITIALIZED_11
 
 export type FSPathSyncStatus = {
-  publicTopLevelFolder: boolean,
+  folderType: FolderType,
   path: string,
   syncingBytes: int64,
   syncingOps: int64,


### PR DESCRIPTION
r? @patrickxb @mmaxim ?

The bool has been deprecated for a while, and is not set by KBFS.  KBFS
isn't yet setting the type, but will be soon (though it isn't required
that the service uses it, as the type should be derivable from the
filename path anyway).

Issue: KBFS-2216