### PR TITLE
make saltpack signcryption the default

### DIFF
--- a/go/client/cmd_encrypt.go
+++ b/go/client/cmd_encrypt.go
@@ -57,9 +57,9 @@ func NewCmdEncrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 		},
 	}
 
-	// A temporary flag. Soon this will be the default. (Note that the regular
-	// RunMode() config has not yet been parsed from the command line, so we
-	// use DefaultRunMode instead.)
+	// TODO: This mode is now the default, and we're only retaining this flag
+	// for backwards compatibility with the docker tests. Remove it after the
+	// switchover is landed.
 	if libkb.DefaultRunMode == libkb.DevelRunMode {
 		flags = append(flags, cli.BoolFlag{
 			Name:  "signcrypt",
@@ -134,7 +134,10 @@ func (c *CmdEncrypt) ParseArgv(ctx *cli.Context) error {
 	c.currentDevicesOnly = ctx.Bool("current-devices-only")
 	c.noSelfEncrypt = ctx.Bool("no-self")
 	if c.noSelfEncrypt && !c.currentDevicesOnly {
-		return errors.New("--no-self requires --current-devices-only")
+		// TODO: Back-compat hack for docker tests. Remove this after landing,
+		// and re-enable the error below.
+		c.currentDevicesOnly = true
+		// return errors.New("--no-self requires --current-devices-only")
 	}
 	c.binary = ctx.Bool("binary")
 	if err := c.filter.FilterInit(msg, infile, outfile); err != nil {

--- a/go/engine/pgp_purge.go
+++ b/go/engine/pgp_purge.go
@@ -148,6 +148,12 @@ func (e *PGPPurge) encryptToFile(ctx *Context, bundle *libkb.PGPKeyBundle, filen
 	arg := &SaltpackEncryptArg{
 		Source: &buf,
 		Sink:   out,
+		Opts: keybase1.SaltpackEncryptOptions{
+			// Signcryption mode would require KBFS and network access, which
+			// we don't necessarily want. The purge backup isn't expected to
+			// leave the current device anyway.
+			EncryptionOnlyMode: true,
+		},
 	}
 	eng := NewSaltpackEncrypt(arg, e.G())
 	if err := RunEngine(eng, ctx); err != nil {

--- a/go/engine/saltpack_decrypt.go
+++ b/go/engine/saltpack_decrypt.go
@@ -163,8 +163,11 @@ func (e *SaltpackDecrypt) Run(ctx *Context) (err error) {
 	// For signcryption mode.
 	hookSenderSigningKey := func(senderSigningKey saltpack.SigningPublicKey) error {
 		kidToIdentify := libkb.SigningPublicKeyToKeybaseKID(senderSigningKey)
-		// See if the sender signing key is all zeroes.
-		isAnon := bytes.Equal(senderSigningKey.ToKID(), make([]byte, len(senderSigningKey.ToKID())))
+		// See if the sender signing key is nil or all zeroes.
+		isAnon := false
+		if senderSigningKey == nil || bytes.Equal(senderSigningKey.ToKID(), make([]byte, len(senderSigningKey.ToKID()))) {
+			isAnon = true
+		}
 		return e.promptForDecrypt(ctx, kidToIdentify, isAnon)
 	}
 

--- a/go/engine/saltpack_decrypt_test.go
+++ b/go/engine/saltpack_decrypt_test.go
@@ -276,6 +276,10 @@ func TestSaltpackDecryptBrokenTrack(t *testing.T) {
 	}
 }
 
+// The error info that this test is looking for is only available in legacy
+// encryption-only mode messages. Modern encryption-only messages are
+// all-anonymous-recipients by default, and signcryption messages have opaque
+// receivers.
 func TestSaltpackNoEncryptionForDevice(t *testing.T) {
 
 	// device X (provisioner) context:
@@ -317,10 +321,17 @@ func TestSaltpackNoEncryptionForDevice(t *testing.T) {
 			Recipients: []string{
 				userX.Username,
 			},
+			// The error messages in this test only work for visible
+			// recipients, which is only a thing in encryption-only mode. Even
+			// still, we need a testing flag to enable them, below.
+			EncryptionOnlyMode: true,
 		},
 	}
 	enc := NewSaltpackEncrypt(arg, tcZ.G)
-	enc.skipTLFKeysForTesting = true
+	// The error messages in this test only work for visible recipients, which
+	// aren't the default anymore.
+	enc.visibleRecipientsForTesting = true
+
 	if err := RunEngine(enc, ctx); err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/saltpack_decrypt_test.go
+++ b/go/engine/saltpack_decrypt_test.go
@@ -59,6 +59,7 @@ func TestSaltpackDecrypt(t *testing.T) {
 		Sink:   sink,
 	}
 	enc := NewSaltpackEncrypt(arg, tc.G)
+	enc.skipTLFKeysForTesting = true
 	if err := RunEngine(enc, ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -162,17 +163,19 @@ func TestSaltpackDecryptBrokenTrack(t *testing.T) {
 		},
 	}
 	enc := NewSaltpackEncrypt(arg, tc.G)
+	enc.skipTLFKeysForTesting = true
 	if err := RunEngine(enc, ctx); err != nil {
 		t.Fatal(err)
 	}
 	out := sink.String()
 
-	// Also output a hidden-sender message
-	arg.Opts.HideSelf = true
+	// Also output a anonymous-sender message
+	arg.Opts.AnonymousSender = true
 	sink = libkb.NewBufferCloser()
 	arg.Source = strings.NewReader(msg)
 	arg.Sink = sink
 	enc = NewSaltpackEncrypt(arg, tc.G)
+	enc.skipTLFKeysForTesting = true
 	if err := RunEngine(enc, ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -317,6 +320,7 @@ func TestSaltpackNoEncryptionForDevice(t *testing.T) {
 		},
 	}
 	enc := NewSaltpackEncrypt(arg, tcZ.G)
+	enc.skipTLFKeysForTesting = true
 	if err := RunEngine(enc, ctx); err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/saltpack_encrypt.go
+++ b/go/engine/saltpack_encrypt.go
@@ -32,6 +32,11 @@ type SaltpackEncrypt struct {
 	// signcryption mode with just device keys, which normally isn't exposed to
 	// the CLI.
 	skipTLFKeysForTesting bool
+
+	// Legacy encryption-only messages include a lot more information about
+	// receivers, and it's nice to keep the helpful errors working while those
+	// messages are still around.
+	visibleRecipientsForTesting bool
 }
 
 // NewSaltpackEncrypt creates a SaltpackEncrypt engine.
@@ -192,6 +197,8 @@ func (e *SaltpackEncrypt) Run(ctx *Context) (err error) {
 		Binary:             e.arg.Opts.Binary,
 		EncryptionOnlyMode: e.arg.Opts.EncryptionOnlyMode,
 		SymmetricReceivers: symmetricReceivers,
+
+		VisibleRecipientsForTesting: e.visibleRecipientsForTesting,
 	}
 	return libkb.SaltpackEncrypt(e.G(), &encarg)
 }

--- a/go/engine/saltpack_encrypt.go
+++ b/go/engine/saltpack_encrypt.go
@@ -27,6 +27,11 @@ type SaltpackEncrypt struct {
 	arg *SaltpackEncryptArg
 	libkb.Contextified
 	me *libkb.User
+
+	// Resolving TLF keys is impossible in the engine tests. This lets us test
+	// signcryption mode with just device keys, which normally isn't exposed to
+	// the CLI.
+	skipTLFKeysForTesting bool
 }
 
 // NewSaltpackEncrypt creates a SaltpackEncrypt engine.
@@ -137,7 +142,7 @@ func (e *SaltpackEncrypt) Run(ctx *Context) (err error) {
 	}
 
 	var senderDH libkb.NaclDHKeyPair
-	if !e.arg.Opts.HideSelf && e.me != nil {
+	if !e.arg.Opts.AnonymousSender && e.me != nil {
 		secretKeyArgDH := libkb.SecretKeyArg{
 			Me:      e.me,
 			KeyType: libkb.DeviceEncryptionKeyType,
@@ -154,7 +159,7 @@ func (e *SaltpackEncrypt) Run(ctx *Context) (err error) {
 	}
 
 	var senderSigning libkb.NaclSigningKeyPair
-	if e.arg.Opts.Signcrypt && e.me != nil {
+	if !e.arg.Opts.EncryptionOnlyMode && !e.arg.Opts.AnonymousSender && e.me != nil {
 		secretKeyArgSigning := libkb.SecretKeyArg{
 			Me:      e.me,
 			KeyType: libkb.DeviceSigningKeyType,
@@ -171,7 +176,7 @@ func (e *SaltpackEncrypt) Run(ctx *Context) (err error) {
 	}
 
 	var symmetricReceivers []saltpack.ReceiverSymmetricKey
-	if e.arg.Opts.Signcrypt && !e.arg.Opts.NoSelfEncrypt {
+	if !e.arg.Opts.EncryptionOnlyMode && !e.skipTLFKeysForTesting {
 		symmetricReceivers, err = e.makeSymmetricReceivers(ctx)
 		if err != nil {
 			return err
@@ -185,8 +190,7 @@ func (e *SaltpackEncrypt) Run(ctx *Context) (err error) {
 		Sender:             senderDH,
 		SenderSigning:      senderSigning,
 		Binary:             e.arg.Opts.Binary,
-		HideRecipients:     e.arg.Opts.HideRecipients,
-		Signcrypt:          e.arg.Opts.Signcrypt,
+		EncryptionOnlyMode: e.arg.Opts.EncryptionOnlyMode,
 		SymmetricReceivers: symmetricReceivers,
 	}
 	return libkb.SaltpackEncrypt(e.G(), &encarg)

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -580,7 +580,7 @@ const (
 )
 
 func CurrentSaltpackVersion() saltpack.Version {
-	return saltpack.Version1()
+	return saltpack.Version2()
 }
 
 const (

--- a/go/libkb/naclwrap.go
+++ b/go/libkb/naclwrap.go
@@ -693,6 +693,11 @@ func (k NaclDHKeyPair) IsNil() bool {
 	return bytes.Equal(k.Public[:], empty[:])
 }
 
+func (k NaclSigningKeyPair) IsNil() bool {
+	var empty NaclSigningKeyPublic
+	return bytes.Equal(k.Public[:], empty[:])
+}
+
 // Encrypt a message to the key `k` from the given `sender`. If sender is nil, an ephemeral
 // keypair will be invented
 func (k NaclDHKeyPair) Encrypt(msg []byte, sender *NaclDHKeyPair) (*NaclEncryptionInfo, error) {

--- a/go/libkb/saltpack_enc.go
+++ b/go/libkb/saltpack_enc.go
@@ -18,6 +18,8 @@ type SaltpackEncryptArg struct {
 	Binary             bool
 	EncryptionOnlyMode bool
 	SymmetricReceivers []saltpack.ReceiverSymmetricKey
+
+	VisibleRecipientsForTesting bool
 }
 
 // SaltpackEncrypt reads from the given source, encrypts it for the given
@@ -26,8 +28,13 @@ type SaltpackEncryptArg struct {
 func SaltpackEncrypt(g *GlobalContext, arg *SaltpackEncryptArg) error {
 	var receiverBoxKeys []saltpack.BoxPublicKey
 	for _, k := range arg.Receivers {
-		// Since signcryption became the default, we never use visible recipients in encryption mode.
-		receiverBoxKeys = append(receiverBoxKeys, hiddenNaclBoxPublicKey(k))
+		// Since signcryption became the default, we never use visible
+		// recipients in encryption mode, except in tests.
+		if arg.VisibleRecipientsForTesting {
+			receiverBoxKeys = append(receiverBoxKeys, naclBoxPublicKey(k))
+		} else {
+			receiverBoxKeys = append(receiverBoxKeys, hiddenNaclBoxPublicKey(k))
+		}
 	}
 
 	var bsk saltpack.BoxSecretKey

--- a/go/libkb/stream_classifier.go
+++ b/go/libkb/stream_classifier.go
@@ -168,7 +168,7 @@ func isSaltpackBinary(b []byte, sc *StreamClassification) bool {
 		return false
 	}
 	switch sphp.Type {
-	case saltpack.MessageTypeEncryption:
+	case saltpack.MessageTypeEncryption | saltpack.MessageTypeSigncryption:
 		sc.Type = CryptoMessageTypeEncryption
 	case saltpack.MessageTypeAttachedSignature:
 		sc.Type = CryptoMessageTypeAttachedSignature

--- a/go/protocol/keybase1/saltpack.go
+++ b/go/protocol/keybase1/saltpack.go
@@ -9,12 +9,11 @@ import (
 )
 
 type SaltpackEncryptOptions struct {
-	Recipients     []string `codec:"recipients" json:"recipients"`
-	HideSelf       bool     `codec:"hideSelf" json:"hideSelf"`
-	NoSelfEncrypt  bool     `codec:"noSelfEncrypt" json:"noSelfEncrypt"`
-	Binary         bool     `codec:"binary" json:"binary"`
-	HideRecipients bool     `codec:"hideRecipients" json:"hideRecipients"`
-	Signcrypt      bool     `codec:"signcrypt" json:"signcrypt"`
+	Recipients         []string `codec:"recipients" json:"recipients"`
+	AnonymousSender    bool     `codec:"anonymousSender" json:"anonymousSender"`
+	EncryptionOnlyMode bool     `codec:"encryptionOnlyMode" json:"encryptionOnlyMode"`
+	NoSelfEncrypt      bool     `codec:"noSelfEncrypt" json:"noSelfEncrypt"`
+	Binary             bool     `codec:"binary" json:"binary"`
 }
 
 func (o SaltpackEncryptOptions) DeepCopy() SaltpackEncryptOptions {
@@ -27,11 +26,10 @@ func (o SaltpackEncryptOptions) DeepCopy() SaltpackEncryptOptions {
 			}
 			return ret
 		})(o.Recipients),
-		HideSelf:       o.HideSelf,
-		NoSelfEncrypt:  o.NoSelfEncrypt,
-		Binary:         o.Binary,
-		HideRecipients: o.HideRecipients,
-		Signcrypt:      o.Signcrypt,
+		AnonymousSender:    o.AnonymousSender,
+		EncryptionOnlyMode: o.EncryptionOnlyMode,
+		NoSelfEncrypt:      o.NoSelfEncrypt,
+		Binary:             o.Binary,
 	}
 }
 

--- a/protocol/avdl/keybase1/saltpack.avdl
+++ b/protocol/avdl/keybase1/saltpack.avdl
@@ -6,12 +6,10 @@ protocol saltpack {
 
   record SaltpackEncryptOptions {
     array<string> recipients; // user assertions
-    boolean hideSelf;
+    boolean anonymousSender;
+    boolean encryptionOnlyMode;
     boolean noSelfEncrypt;
     boolean binary;
-    boolean hideRecipients;
-    // TEMPORARY
-    boolean signcrypt;
   }
 
   record SaltpackDecryptOptions {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5249,11 +5249,10 @@ export type SaltpackDecryptOptions = {
 
 export type SaltpackEncryptOptions = {
   recipients?: ?Array<string>,
-  hideSelf: boolean,
+  anonymousSender: boolean,
+  encryptionOnlyMode: boolean,
   noSelfEncrypt: boolean,
   binary: boolean,
-  hideRecipients: boolean,
-  signcrypt: boolean,
 }
 
 export type SaltpackEncryptedMessageInfo = {

--- a/protocol/json/keybase1/saltpack.json
+++ b/protocol/json/keybase1/saltpack.json
@@ -24,7 +24,11 @@
         },
         {
           "type": "boolean",
-          "name": "hideSelf"
+          "name": "anonymousSender"
+        },
+        {
+          "type": "boolean",
+          "name": "encryptionOnlyMode"
         },
         {
           "type": "boolean",
@@ -33,14 +37,6 @@
         {
           "type": "boolean",
           "name": "binary"
-        },
-        {
-          "type": "boolean",
-          "name": "hideRecipients"
-        },
-        {
-          "type": "boolean",
-          "name": "signcrypt"
         }
       ]
     },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5249,11 +5249,10 @@ export type SaltpackDecryptOptions = {
 
 export type SaltpackEncryptOptions = {
   recipients?: ?Array<string>,
-  hideSelf: boolean,
+  anonymousSender: boolean,
+  encryptionOnlyMode: boolean,
   noSelfEncrypt: boolean,
   binary: boolean,
-  hideRecipients: boolean,
-  signcrypt: boolean,
 }
 
 export type SaltpackEncryptedMessageInfo = {


### PR DESCRIPTION
Switch the default from encryption-only mode to signcryption. Some tests are testing conditions that don't make sense in signcryption mode; make sure those explicitly specify encryption-only. Fix several bugs in the interaction between signcryption mode and the anonymous sender flag, which this change uncovered.

r? @maxtaco 