### PR TITLE
Use error severity for middleware error message

### DIFF
--- a/shared/store/configure-store.js
+++ b/shared/store/configure-store.js
@@ -73,7 +73,7 @@ const errorCatching = store => next => action => {
       return
     }
     lastError = error
-    console.warn(`Caught a middleware exception ${error}`)
+    console.error(`Caught a middleware exception ${error}`)
 
     try {
       crashHandler(error) // don't let this thing crash us forever


### PR DESCRIPTION
Now that a lot of our code is happening inside sagas, this warning can make fatal errors hard to spot. Is there any reason we shouldn't bump this up to error severity?