### PR TITLE
Fix use of wrong updateStateWithMessageChanged variant

### DIFF
--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -340,7 +340,7 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
     }
     case 'chat:updateMessage': {
       const {messageID, message, conversationIDKey} = action.payload
-      return updateStateWithMessageChanged(state, conversationIDKey, messageID, message)
+      return updateStateWithMessageIDChanged(state, conversationIDKey, messageID, message)
     }
     case 'chat:markSeenMessage': {
       const {messageKey, conversationIDKey} = action.payload


### PR DESCRIPTION
My bug! Didn't notice the middleware warning amidst other logs. 

Bummer that flow did not catch this.

PR to make errors like this more noticeable at https://github.com/keybase/client/pull/7288

![](https://media.giphy.com/media/ZWXdfjAF1zohG/giphy.gif)