### PR TITLE
Fix clicking on non-image attachments

### DIFF
--- a/shared/chat/conversation/messages/attachment/container.js
+++ b/shared/chat/conversation/messages/attachment/container.js
@@ -56,7 +56,7 @@ const mergeProps = (stateProps, dispatchProps, {measure, onAction}: OwnProps) =>
     }
   },
   onDownloadAttachment: () => {
-    dispatchProps._onDownloadAttachment(stateProps.selectedConversation, stateProps.message.messageID)
+    dispatchProps._onDownloadAttachment(stateProps.routePath.get(1), stateProps.message.messageID)
   },
   onOpenInFileUI: () => {
     dispatchProps._onOpenInFileUI(stateProps.message.savedPath)


### PR DESCRIPTION
stateProps doesn't have selectedConversation, so use routePath instead

@keybase/react-hackers 