### PR TITLE
Rotate team key when member is removed from team

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -571,11 +571,12 @@ type PvlUnparsed struct {
 const SharedTeamKeyBoxVersion1 = 1
 
 const (
-	TeamDHDerivationString       = "Keybase-Derived-Team-NaCl-DH-1"
-	TeamEdDSADerivationString    = "Keybase-Derived-Team-NaCl-EdDSA-1"
-	TeamKBFSDerivationString     = "Keybase-Derived-Team-NaCl-KBFS-1"
-	TeamChatDerivationString     = "Keybase-Derived-Team-NaCl-Chat-1"
-	TeamSaltpackDerivationString = "Keybase-Derived-Team-NaCl-Saltpack-1"
+	TeamDHDerivationString               = "Keybase-Derived-Team-NaCl-DH-1"
+	TeamEdDSADerivationString            = "Keybase-Derived-Team-NaCl-EdDSA-1"
+	TeamKBFSDerivationString             = "Keybase-Derived-Team-NaCl-KBFS-1"
+	TeamChatDerivationString             = "Keybase-Derived-Team-NaCl-Chat-1"
+	TeamSaltpackDerivationString         = "Keybase-Derived-Team-NaCl-Saltpack-1"
+	TeamPrevKeySecretBoxDerivationString = "Keybase-Derived-Team-NaCl-SecretBox-1"
 )
 
 func CurrentSaltpackVersion() saltpack.Version {

--- a/go/libkb/vdebug.go
+++ b/go/libkb/vdebug.go
@@ -17,6 +17,7 @@ type VDebugLog struct {
 	log              logger.Logger
 	lev              VDebugLevel
 	dumpSiteLoadUser bool
+	dumpPayload      bool
 }
 
 type VDebugLevel int
@@ -52,6 +53,10 @@ func (v *VDebugLog) DumpSiteLoadUser() bool {
 	return v.dumpSiteLoadUser
 }
 
+func (v *VDebugLog) DumpPayload() bool {
+	return v.dumpPayload
+}
+
 func (v *VDebugLog) Configure(s string) {
 	if len(s) == 0 {
 		return
@@ -71,6 +76,8 @@ func (v *VDebugLog) Configure(s string) {
 			v.lev = VLog3
 		case "dump-site-load-user":
 			v.dumpSiteLoadUser = true
+		case "dump-payload":
+			v.dumpPayload = true
 		default:
 			v.log.Warning("Ignoring Vdebug log directive: %q", s)
 		}

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1269,7 +1269,7 @@ func (k TeamApplicationKey) Generation() int {
 	return k.KeyGeneration
 }
 
-func (t TeamMembers) All() []string {
+func (t TeamMembers) AllUsernames() []string {
 	m := make(map[string]bool)
 	for _, u := range t.Owners {
 		m[u] = true

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1268,3 +1268,24 @@ func (k TeamApplicationKey) Material() Bytes32 {
 func (k TeamApplicationKey) Generation() int {
 	return k.KeyGeneration
 }
+
+func (t TeamMembers) All() []string {
+	m := make(map[string]bool)
+	for _, u := range t.Owners {
+		m[u] = true
+	}
+	for _, u := range t.Admins {
+		m[u] = true
+	}
+	for _, u := range t.Writers {
+		m[u] = true
+	}
+	for _, u := range t.Readers {
+		m[u] = true
+	}
+	var all []string
+	for u := range m {
+		all = append(all, u)
+	}
+	return all
+}

--- a/go/teams/box.go
+++ b/go/teams/box.go
@@ -11,7 +11,7 @@ import (
 type TeamBox struct {
 	Nonce           string
 	SenderKID       keybase1.KID `json:"sender_kid"`
-	Generation      int
+	Generation      PerTeamSecretGeneration
 	Ctext           string
 	PerUserKeySeqno keybase1.Seqno `json:"per_user_key_seqno"`
 }

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -38,20 +38,20 @@ func CreateRootTeam(ctx context.Context, g *libkb.GlobalContext, name string) (e
 	}
 
 	// These boxes will get posted along with the sig below.
-	f, err := NewTeamKeyFactory(g)
+	m, err := NewTeamKeyManager(g)
 	if err != nil {
 		return err
 	}
-	secretboxes, err := f.SharedSecretBoxes(deviceEncryptionKey, secretboxRecipients)
+	secretboxes, err := m.SharedSecretBoxes(deviceEncryptionKey, secretboxRecipients)
 	if err != nil {
 		return err
 	}
 
-	perTeamSigningKey, err := f.SigningKey()
+	perTeamSigningKey, err := m.SigningKey()
 	if err != nil {
 		return err
 	}
-	perTeamEncryptionKey, err := f.EncryptionKey()
+	perTeamEncryptionKey, err := m.EncryptionKey()
 	if err != nil {
 		return err
 	}
@@ -311,20 +311,20 @@ func generateHeadSigForSubteamChain(g *libkb.GlobalContext, me *libkb.User, sign
 		me.GetName(): *ownerLatest,
 	}
 	// These boxes will get posted along with the sig below.
-	f, err := NewTeamKeyFactory(g)
+	m, err := NewTeamKeyManager(g)
 	if err != nil {
 		return nil, nil, err
 	}
-	boxes, err = f.SharedSecretBoxes(deviceEncryptionKey, secretboxRecipients)
+	boxes, err = m.SharedSecretBoxes(deviceEncryptionKey, secretboxRecipients)
 	if err != nil {
 		return
 	}
 
-	perTeamSigningKey, err := f.SigningKey()
+	perTeamSigningKey, err := m.SigningKey()
 	if err != nil {
 		return nil, nil, err
 	}
-	perTeamEncryptionKey, err := f.EncryptionKey()
+	perTeamEncryptionKey, err := m.EncryptionKey()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/teams/keys.go
+++ b/go/teams/keys.go
@@ -1,0 +1,262 @@
+package teams
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/crypto/nacl/box"
+)
+
+type PerTeamSecretGeneration int
+
+type PerTeamSharedSecretBoxes struct {
+	Generation    PerTeamSecretGeneration `json:"generation"`
+	EncryptingKid keybase1.KID            `json:"encrypting_kid"`
+	Nonce         string                  `json:"nonce"`
+	PrevKey       *string                 `json:"prev"`
+	Boxes         map[string]string       `json:"boxes"`
+}
+
+type PerTeamSharedSecretBox struct {
+	_struct         bool `codec:",toarray"`
+	Version         uint
+	PerUserKeySeqno keybase1.Seqno
+	NonceCounter    uint32
+	Ctext           []byte
+}
+
+type TeamKeyFactory struct {
+	sharedSecret []byte
+	generation   PerTeamSecretGeneration
+
+	encryptionKey *libkb.NaclDHKeyPair
+	signingKey    *libkb.NaclSigningKeyPair
+}
+
+func NewTeamKeyFactory() (*TeamKeyFactory, error) {
+	sharedSecret, err := newSharedSecret()
+	if err != nil {
+		return nil, err
+	}
+	return NewTeamKeyFactoryWithSecret(sharedSecret, 1)
+}
+
+func NewTeamKeyFactoryWithSecret(secret []byte, generation PerTeamSecretGeneration) (*TeamKeyFactory, error) {
+	if len(secret) != sharedSecretLen {
+		return nil, errors.New("invalid shared secret length")
+	}
+	return &TeamKeyFactory{
+		sharedSecret: secret,
+		generation:   generation,
+	}, nil
+}
+
+func (t *TeamKeyFactory) SigningKey() (libkb.NaclSigningKeyPair, error) {
+	if t.signingKey == nil {
+		key, err := libkb.MakeNaclSigningKeyPairFromSecretBytes(derivedSecret(t.sharedSecret, libkb.TeamEdDSADerivationString))
+		if err != nil {
+			return libkb.NaclSigningKeyPair{}, err
+		}
+		t.signingKey = &key
+	}
+	return *t.signingKey, nil
+}
+
+func (t *TeamKeyFactory) EncryptionKey() (libkb.NaclDHKeyPair, error) {
+	if t.encryptionKey == nil {
+		key, err := libkb.MakeNaclDHKeyPairFromSecretBytes(derivedSecret(t.sharedSecret, libkb.TeamDHDerivationString))
+		if err != nil {
+			return libkb.NaclDHKeyPair{}, err
+		}
+		t.encryptionKey = &key
+	}
+	return *t.encryptionKey, nil
+
+}
+
+func (t *TeamKeyFactory) SharedSecretBoxes(senderKey libkb.GenericKey, recipients map[string]keybase1.PerUserKey) (*PerTeamSharedSecretBoxes, error) {
+
+	// make the nonce prefix
+	n, err := newNonce24()
+	if err != nil {
+		return nil, err
+	}
+	// increment past the zero-counter since not rotating keys
+	// (0 used for previous key encryption nonce)
+	n.Inc()
+
+	// make the recipient boxes with the new secret and the nonce prefix
+	return t.sharedBoxes(t.sharedSecret, t.generation, n, senderKey, recipients)
+}
+
+func (t *TeamKeyFactory) RotateSharedSecretBoxes(senderKey libkb.GenericKey, recipients map[string]keybase1.PerUserKey) (*PerTeamSharedSecretBoxes, error) {
+
+	// make the nonce prefix
+	n, err := newNonce24()
+	if err != nil {
+		return nil, err
+	}
+	_ = n
+
+	// make a new secret
+
+	// derive new key from new secret for PrevKey
+
+	// encrypt existing secret with derived key and nonce counter 0
+
+	// store it in PrevKey field
+
+	// make the recipient boxes with the new secret and the nonce prefix
+
+	return nil, nil
+}
+
+func (t *TeamKeyFactory) sharedBoxes(secret []byte, generation PerTeamSecretGeneration, nonce *nonce24, senderKey libkb.GenericKey, recipients map[string]keybase1.PerUserKey) (*PerTeamSharedSecretBoxes, error) {
+	senderNaclDHKey, ok := senderKey.(libkb.NaclDHKeyPair)
+	if !ok {
+		return nil, fmt.Errorf("got an unexpected key type for device encryption key: %T", senderKey)
+	}
+
+	boxes, err := t.recipientBoxes(secret, nonce, senderNaclDHKey, recipients)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PerTeamSharedSecretBoxes{
+		Generation:    generation,
+		EncryptingKid: senderNaclDHKey.GetKID(),
+		Nonce:         nonce.PrefixEncoded(),
+		Boxes:         boxes,
+	}, nil
+}
+
+func (t *TeamKeyFactory) recipientBoxes(secret []byte, nonce *nonce24, senderKey libkb.NaclDHKeyPair, recipients map[string]keybase1.PerUserKey) (map[string]string, error) {
+	boxes := make(map[string]string)
+	for username, recipientPerUserKey := range recipients {
+		boxStruct, err := t.recipientBox(secret, nonce, senderKey, recipientPerUserKey)
+		if err != nil {
+			return nil, err
+		}
+
+		encodedArray, err := libkb.MsgpackEncode(boxStruct)
+		if err != nil {
+			return nil, err
+		}
+
+		boxes[username] = base64.StdEncoding.EncodeToString(encodedArray)
+
+		// increment nonce counter for next recipient
+		nonce.Inc()
+	}
+
+	return boxes, nil
+}
+
+func (t *TeamKeyFactory) recipientBox(secret []byte, nonce *nonce24, senderKey libkb.NaclDHKeyPair, recipient keybase1.PerUserKey) (*PerTeamSharedSecretBox, error) {
+	recipientPerUserGenericKeypair, err := libkb.ImportKeypairFromKID(recipient.EncKID)
+	if err != nil {
+		return nil, err
+	}
+	recipientPerUserNaclKeypair, ok := recipientPerUserGenericKeypair.(libkb.NaclDHKeyPair)
+	if !ok {
+		return nil, fmt.Errorf("got an unexpected key type for recipient KID in sharedTeamKeyBox: %T", recipientPerUserGenericKeypair)
+	}
+
+	nonceBytes := nonce.Nonce()
+	ctext := box.Seal(nil, secret, &nonceBytes, ((*[32]byte)(&recipientPerUserNaclKeypair.Public)), ((*[32]byte)(senderKey.Private)))
+
+	boxStruct := PerTeamSharedSecretBox{
+		Version:         libkb.SharedTeamKeyBoxVersion1,
+		PerUserKeySeqno: recipient.Seqno,
+		NonceCounter:    nonce.Counter(),
+		Ctext:           ctext,
+	}
+
+	return &boxStruct, nil
+}
+
+func boxTeamSharedSecret(secret []byte, senderKey libkb.GenericKey, recipients map[string]keybase1.PerUserKey) (*PerTeamSharedSecretBoxes, error) {
+	senderNaclDHKey, ok := senderKey.(libkb.NaclDHKeyPair)
+	if !ok {
+		return nil, fmt.Errorf("got an unexpected key type for device encryption key: %T", senderKey)
+	}
+	noncePrefix, err := libkb.RandBytes(20)
+	if err != nil {
+		return nil, err
+	}
+	// The counter starts at 1, because 0 will be the prev secretbox, which is
+	// omitted for the team root link, because this is the first shared key.
+	var counter uint32 = 1
+	boxes := make(map[string]string)
+	for username, recipientPerUserKey := range recipients {
+		recipientPerUserGenericKeypair, err := libkb.ImportKeypairFromKID(recipientPerUserKey.EncKID)
+		if err != nil {
+			return nil, err
+		}
+		recipientPerUserNaclKeypair, ok := recipientPerUserGenericKeypair.(libkb.NaclDHKeyPair)
+		if !ok {
+			return nil, fmt.Errorf("got an unexpected key type for recipient KID in sharedTeamKeyBox: %T", recipientPerUserGenericKeypair)
+		}
+		var nonce [24]byte
+		counterBytes := [4]byte{}
+		binary.BigEndian.PutUint32(counterBytes[:], counter)
+		copy(nonce[:20], noncePrefix)
+		copy(nonce[20:24], counterBytes[:])
+		ctext := box.Seal(nil, secret, &nonce, ((*[32]byte)(&recipientPerUserNaclKeypair.Public)), ((*[32]byte)(senderNaclDHKey.Private)))
+		boxStruct := PerTeamSharedSecretBox{
+			Version:         libkb.SharedTeamKeyBoxVersion1,
+			PerUserKeySeqno: recipientPerUserKey.Seqno,
+			NonceCounter:    counter,
+			Ctext:           ctext,
+		}
+		encodedArray, err := libkb.MsgpackEncode(boxStruct)
+		if err != nil {
+			return nil, err
+		}
+		base64Array := base64.StdEncoding.EncodeToString(encodedArray)
+		boxes[username] = base64Array
+
+		// increment nonce counter for next recipient
+		counter++
+	}
+
+	return &PerTeamSharedSecretBoxes{
+		Generation:    1,
+		EncryptingKid: senderNaclDHKey.GetKID(),
+		Nonce:         base64.StdEncoding.EncodeToString(noncePrefix),
+		Boxes:         boxes,
+	}, nil
+}
+
+func generatePerTeamKeys() (sharedSecret []byte, signingKey libkb.NaclSigningKeyPair, encryptionKey libkb.NaclDHKeyPair, err error) {
+	// This is the magical secret key, from which we derive a DH keypair and a
+	// signing keypair.
+	sharedSecret, err = libkb.RandBytes(32)
+	if err != nil {
+		return
+	}
+	signingKey, encryptionKey, err = generatePerTeamKeysFromSecret(sharedSecret)
+	return
+}
+
+func generatePerTeamKeysFromSecret(sharedSecret []byte) (signingKey libkb.NaclSigningKeyPair, encryptionKey libkb.NaclDHKeyPair, err error) {
+	encryptionKey, err = libkb.MakeNaclDHKeyPairFromSecretBytes(derivedSecret(sharedSecret, libkb.TeamDHDerivationString))
+	if err != nil {
+		return
+	}
+	signingKey, err = libkb.MakeNaclSigningKeyPairFromSecretBytes(derivedSecret(sharedSecret, libkb.TeamEdDSADerivationString))
+	if err != nil {
+		return
+	}
+	return
+}
+
+const sharedSecretLen = 32
+
+func newSharedSecret() ([]byte, error) {
+	return libkb.RandBytes(sharedSecretLen)
+}

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -143,3 +143,7 @@ func (m *memberSet) Section(teamID keybase1.TeamID) (SCTeamSection, error) {
 
 	return teamSection, nil
 }
+
+func (m *memberSet) HasRemoval() bool {
+	return len(m.None) > 0
+}

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -31,34 +31,34 @@ func newMemberSet(ctx context.Context, g *libkb.GlobalContext, req keybase1.Team
 
 func (m *memberSet) loadMembers(ctx context.Context, g *libkb.GlobalContext, req keybase1.TeamChangeReq) error {
 	var err error
-	m.Owners, err = m.loadGroup(ctx, g, req.Owners)
+	m.Owners, err = m.loadGroup(ctx, g, req.Owners, true)
 	if err != nil {
 		return err
 	}
-	m.Admins, err = m.loadGroup(ctx, g, req.Admins)
+	m.Admins, err = m.loadGroup(ctx, g, req.Admins, true)
 	if err != nil {
 		return err
 	}
-	m.Writers, err = m.loadGroup(ctx, g, req.Writers)
+	m.Writers, err = m.loadGroup(ctx, g, req.Writers, true)
 	if err != nil {
 		return err
 	}
-	m.Readers, err = m.loadGroup(ctx, g, req.Readers)
+	m.Readers, err = m.loadGroup(ctx, g, req.Readers, true)
 	if err != nil {
 		return err
 	}
-	m.None, err = m.loadGroup(ctx, g, req.None)
+	m.None, err = m.loadGroup(ctx, g, req.None, false)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *memberSet) loadGroup(ctx context.Context, g *libkb.GlobalContext, group []string) ([]member, error) {
+func (m *memberSet) loadGroup(ctx context.Context, g *libkb.GlobalContext, group []string, storeRecipient bool) ([]member, error) {
 	members := make([]member, len(group))
 	var err error
 	for i, username := range group {
-		members[i], err = m.loadMember(ctx, g, username)
+		members[i], err = m.loadMember(ctx, g, username, storeRecipient)
 		if err != nil {
 			return nil, err
 		}
@@ -66,7 +66,7 @@ func (m *memberSet) loadGroup(ctx context.Context, g *libkb.GlobalContext, group
 	return members, nil
 }
 
-func (m *memberSet) loadMember(ctx context.Context, g *libkb.GlobalContext, username string) (member, error) {
+func (m *memberSet) loadMember(ctx context.Context, g *libkb.GlobalContext, username string, storeRecipient bool) (member, error) {
 	// resolve the username
 	res := g.Resolver.ResolveWithBody(username)
 	if res.GetError() != nil {
@@ -89,7 +89,9 @@ func (m *memberSet) loadMember(ctx context.Context, g *libkb.GlobalContext, user
 	}
 
 	// store the key in a recipients table
-	m.recipients[upak.Base.Username] = key
+	if storeRecipient {
+		m.recipients[upak.Base.Username] = key
+	}
 
 	// return a member with UserVersion and a PerUserKey
 	return member{
@@ -97,6 +99,29 @@ func (m *memberSet) loadMember(ctx context.Context, g *libkb.GlobalContext, user
 		perUserKey: key,
 	}, nil
 
+}
+
+// AddRemainingRecipients adds everyone in existing to m.recipients that isn't in m.None.
+func (m *memberSet) AddRemainingRecipients(ctx context.Context, g *libkb.GlobalContext, existing keybase1.TeamMembers) error {
+	// make a map of the None members
+	noneMap := make(map[string]bool)
+	for _, n := range m.None {
+		noneMap[n.version.Username] = true
+	}
+
+	for _, u := range existing.All() {
+		if noneMap[u] {
+			continue
+		}
+		if _, ok := m.recipients[u]; ok {
+			continue
+		}
+		if _, err := m.loadMember(ctx, g, u, true); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (m *memberSet) nameSeqList(members []member) (*[]SCTeamMember, error) {

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -109,7 +109,7 @@ func (m *memberSet) AddRemainingRecipients(ctx context.Context, g *libkb.GlobalC
 		noneMap[n.version.Username] = true
 	}
 
-	for _, u := range existing.All() {
+	for _, u := range existing.AllUsernames() {
 		if noneMap[u] {
 			continue
 		}

--- a/go/teams/nonce.go
+++ b/go/teams/nonce.go
@@ -7,11 +7,17 @@ import (
 	"github.com/keybase/client/go/libkb"
 )
 
+// nonce24 manages a 24-byte nonce with a 20-byte prefix
+// and a 4-byte counter.  The counter is incremented every
+// time the full nonce is retrieved so that no nonces are
+// reused.
 type nonce24 struct {
 	prefix  []byte
 	counter uint32
 }
 
+// newNonce24 creates a nonce with a random 20 byte prefix and
+// a counter starting at 0.
 func newNonce24() (*nonce24, error) {
 	prefix, err := libkb.RandBytes(20)
 	if err != nil {
@@ -20,23 +26,31 @@ func newNonce24() (*nonce24, error) {
 	return &nonce24{prefix: prefix}, nil
 }
 
-func (n *nonce24) Nonce() [24]byte {
+// newNonce24 creates a nonce with a random 20 byte prefix and
+// a counter starting at 1.
+func newNonce24SkipZero() (*nonce24, error) {
+	n, err := newNonce24()
+	if err != nil {
+		return nil, err
+	}
+	n.counter = 1
+	return n, nil
+}
+
+// Nonce gets the 24 byte nonce prefix + counter and increments
+// the counter so that the nonce isn't reused.
+func (n *nonce24) Nonce() ([24]byte, uint32) {
 	var nonce [24]byte
 	copy(nonce[:20], n.prefix)
 	copy(nonce[20:24], n.counterBytes())
-	return nonce
+	counter := n.counter
+	n.counter++
+	return nonce, counter
 }
 
+// PrefixEncoded returns a base64 encoding of the 20 byte nonce prefix.
 func (n *nonce24) PrefixEncoded() string {
 	return base64.StdEncoding.EncodeToString(n.prefix)
-}
-
-func (n *nonce24) Counter() uint32 {
-	return n.counter
-}
-
-func (n *nonce24) Inc() {
-	n.counter++
 }
 
 func (n *nonce24) counterBytes() []byte {

--- a/go/teams/nonce.go
+++ b/go/teams/nonce.go
@@ -1,0 +1,46 @@
+package teams
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+
+	"github.com/keybase/client/go/libkb"
+)
+
+type nonce24 struct {
+	prefix  []byte
+	counter uint32
+}
+
+func newNonce24() (*nonce24, error) {
+	prefix, err := libkb.RandBytes(20)
+	if err != nil {
+		return nil, err
+	}
+	return &nonce24{prefix: prefix}, nil
+}
+
+func (n *nonce24) Nonce() [24]byte {
+	var nonce [24]byte
+	copy(nonce[:20], n.prefix)
+	copy(nonce[20:24], n.counterBytes())
+	return nonce
+}
+
+func (n *nonce24) PrefixEncoded() string {
+	return base64.StdEncoding.EncodeToString(n.prefix)
+}
+
+func (n *nonce24) Counter() uint32 {
+	return n.counter
+}
+
+func (n *nonce24) Inc() {
+	n.counter++
+}
+
+func (n *nonce24) counterBytes() []byte {
+	b := [4]byte{}
+	binary.BigEndian.PutUint32(b[:], n.counter)
+	return b[:]
+}

--- a/go/teams/sig.go
+++ b/go/teams/sig.go
@@ -9,6 +9,7 @@ package teams
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"strings"
 
 	"github.com/keybase/client/go/libkb"
@@ -121,6 +122,13 @@ func NewSubteamID() keybase1.TeamID {
 }
 
 func ChangeMembershipSig(me *libkb.User, prev libkb.LinkID, seqno keybase1.Seqno, key libkb.GenericKey, teamSection SCTeamSection) (*jsonw.Wrapper, error) {
+
+	if teamSection.PerTeamKey != nil {
+		if teamSection.PerTeamKey.ReverseSig != "" {
+			return nil, errors.New("ChangeMembershipSig called with PerTeamKey.ReverseSig already set")
+		}
+	}
+
 	ret, err := libkb.ProofMetadata{
 		Me:         me,
 		LinkType:   libkb.LinkTypeChangeMembership,

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -46,7 +46,7 @@ func (t *Team) SharedSecret(ctx context.Context) ([]byte, error) {
 			return nil, err
 		}
 
-		teamKey, err := t.Chain.GetPerTeamKeyAtGeneration(t.Box.Generation)
+		teamKey, err := t.Chain.GetPerTeamKeyAtGeneration(int(t.Box.Generation))
 		if err != nil {
 			return nil, err
 		}
@@ -369,7 +369,11 @@ func (t *Team) recipientBoxes(memSet *memberSet) (*PerTeamSharedSecretBoxes, err
 	if err != nil {
 		return nil, err
 	}
-	return boxTeamSharedSecret(t.secret, deviceEncryptionKey, memSet.recipients)
+	f, err := NewTeamKeyFactoryWithSecret(t.secret, t.Box.Generation)
+	if err != nil {
+		return nil, err
+	}
+	return f.SharedSecretBoxes(deviceEncryptionKey, memSet.recipients)
 }
 
 func (t *Team) sigPayload(sigMultiItem libkb.SigMultiItem, secretBoxes *PerTeamSharedSecretBoxes) libkb.JSONPayload {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1,6 +1,7 @@
 package teams
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -8,6 +9,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	jsonw "github.com/keybase/go-jsonw"
 )
 
 type Team struct {
@@ -18,9 +20,7 @@ type Team struct {
 	Box            TeamBox
 	ReaderKeyMasks []keybase1.ReaderKeyMask
 
-	secret        []byte
-	signingKey    libkb.NaclSigningKeyPair
-	encryptionKey libkb.NaclDHKeyPair
+	factory *TeamKeyFactory
 
 	me *libkb.User
 }
@@ -30,7 +30,7 @@ func NewTeam(g *libkb.GlobalContext, name string) *Team {
 }
 
 func (t *Team) SharedSecret(ctx context.Context) ([]byte, error) {
-	if t.secret == nil {
+	if t.factory == nil {
 		userEncKey, err := t.perUserEncryptionKeyForBox(ctx)
 		if err != nil {
 			return nil, err
@@ -41,7 +41,16 @@ func (t *Team) SharedSecret(ctx context.Context) ([]byte, error) {
 			return nil, err
 		}
 
-		signingKey, encryptionKey, err := generatePerTeamKeysFromSecret(secret)
+		factory, err := NewTeamKeyFactoryWithSecret(secret, t.Box.Generation)
+		if err != nil {
+			return nil, err
+		}
+
+		signingKey, err := factory.SigningKey()
+		if err != nil {
+			return nil, err
+		}
+		encryptionKey, err := factory.EncryptionKey()
 		if err != nil {
 			return nil, err
 		}
@@ -63,12 +72,11 @@ func (t *Team) SharedSecret(ctx context.Context) ([]byte, error) {
 		// user that signed the link.
 		// See CORE-5399
 
-		t.secret = secret
-		t.signingKey = signingKey
-		t.encryptionKey = encryptionKey
+		// all checks passed, ok to hold onto the factory for this secret
+		t.factory = factory
 	}
 
-	return t.secret, nil
+	return t.factory.SharedSecret(), nil
 }
 
 func (t *Team) KBFSKey(ctx context.Context) (keybase1.TeamApplicationKey, error) {
@@ -267,18 +275,18 @@ func (t *Team) ChangeMembership(ctx context.Context, req keybase1.TeamChangeReq)
 		return err
 	}
 
-	// if there are any removals happening, need to rotate the
-	// team key, and recipients will be all the users in the team
-	// after the removal.
-	if memSet.HasRemoval() {
-
-	}
-
 	// create the team section of the signature
 	section, err := memSet.Section(t.Chain.GetID())
 	if err != nil {
 		return err
 	}
+
+	// create secret boxes for recipients, possibly rotating the key
+	secretBoxes, perTeamKeySection, err := t.recipientBoxes(ctx, memSet)
+	if err != nil {
+		return err
+	}
+	section.PerTeamKey = perTeamKeySection
 
 	// create the change item
 	sigMultiItem, err := t.sigChangeItem(section)
@@ -286,14 +294,14 @@ func (t *Team) ChangeMembership(ctx context.Context, req keybase1.TeamChangeReq)
 		return err
 	}
 
-	// create secret boxes for recipients
-	secretBoxes, err := t.recipientBoxes(memSet)
+	// make the payload
+	payload := t.sigPayload(sigMultiItem, secretBoxes)
+
+	pretty, err := json.MarshalIndent(payload, "", "\t")
 	if err != nil {
 		return err
 	}
-
-	// make the payload
-	payload := t.sigPayload(sigMultiItem, secretBoxes)
+	t.G().Log.Info("payload: %s", pretty)
 
 	// send it to the server
 	return t.postMulti(payload)
@@ -329,6 +337,27 @@ func (t *Team) sigChangeItem(section SCTeamSection) (libkb.SigMultiItem, error) 
 		return libkb.SigMultiItem{}, err
 	}
 
+	signingKey, err := t.factory.SigningKey()
+	if err != nil {
+		return libkb.SigMultiItem{}, err
+	}
+	encryptionKey, err := t.factory.EncryptionKey()
+	if err != nil {
+		return libkb.SigMultiItem{}, err
+	}
+
+	if section.PerTeamKey != nil {
+		// need a reverse sig
+
+		// set a nil value (not empty) for reverse_sig (fails without this)
+		sig.SetValueAtPath("body.team.per_team_key.reverse_sig", jsonw.NewNil())
+		reverseSig, _, _, err := libkb.SignJSON(sig, signingKey)
+		if err != nil {
+			return libkb.SigMultiItem{}, err
+		}
+		sig.SetValueAtPath("body.team.per_team_key.reverse_sig", jsonw.NewString(reverseSig))
+	}
+
 	sigJSON, err := sig.Marshal()
 	if err != nil {
 		return libkb.SigMultiItem{}, err
@@ -357,23 +386,42 @@ func (t *Team) sigChangeItem(section SCTeamSection) (libkb.SigMultiItem, error) 
 		SigInner:   string(sigJSON),
 		TeamID:     t.Chain.GetID(),
 		PublicKeys: &libkb.SigMultiItemPublicKeys{
-			Encryption: t.encryptionKey.GetKID(),
-			Signing:    t.signingKey.GetKID(),
+			Encryption: encryptionKey.GetKID(),
+			Signing:    signingKey.GetKID(),
 		},
 	}
 	return sigMultiItem, nil
 }
 
-func (t *Team) recipientBoxes(memSet *memberSet) (*PerTeamSharedSecretBoxes, error) {
+func (t *Team) recipientBoxes(ctx context.Context, memSet *memberSet) (*PerTeamSharedSecretBoxes, *SCPerTeamKey, error) {
 	deviceEncryptionKey, err := t.G().ActiveDevice.EncryptionKey()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	f, err := NewTeamKeyFactoryWithSecret(t.secret, t.Box.Generation)
+
+	// if there are any removals happening, need to rotate the
+	// team key, and recipients will be all the users in the team
+	// after the removal.
+	if memSet.HasRemoval() {
+		// key is rotating, so recipients needs to be all the remaining members
+		// of the team after the removal (and including any new members in this
+		// change)
+		existing, err := t.Members()
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := memSet.AddRemainingRecipients(ctx, t.G(), existing); err != nil {
+			return nil, nil, err
+		}
+		return t.factory.RotateSharedSecretBoxes(deviceEncryptionKey, memSet.recipients)
+	}
+
+	boxes, err := t.factory.SharedSecretBoxes(deviceEncryptionKey, memSet.recipients)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return f.SharedSecretBoxes(deviceEncryptionKey, memSet.recipients)
+	// No SCPerTeamKey section when the key isn't rotated
+	return boxes, nil, err
 }
 
 func (t *Team) sigPayload(sigMultiItem libkb.SigMultiItem, secretBoxes *PerTeamSharedSecretBoxes) libkb.JSONPayload {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -267,6 +267,13 @@ func (t *Team) ChangeMembership(ctx context.Context, req keybase1.TeamChangeReq)
 		return err
 	}
 
+	// if there are any removals happening, need to rotate the
+	// team key, and recipients will be all the users in the team
+	// after the removal.
+	if memSet.HasRemoval() {
+
+	}
+
 	// create the team section of the signature
 	section, err := memSet.Section(t.Chain.GetID())
 	if err != nil {


### PR DESCRIPTION
This patch detects when a team membership change includes a member removal.  When that happens, it creates a new shared secret for the team and includes the appropriate per_team_key fields in the sig/multi post to the server.

A lot of the team shared secret code has been refactored to make it reusable.