### PR TITLE
Check existence of pending message before updating it

### DIFF
--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -145,17 +145,18 @@ function* _incomingMessage(action: Constants.IncomingMessage): SagaGenerator<any
         const messageFromYou =
           message.deviceName === yourDeviceName && message.author && yourName === message.author
 
+        let pendingMessage
         if (
           (message.type === 'Text' || message.type === 'Attachment') &&
-          message.outboxID &&
-          messageFromYou
+          messageFromYou &&
+          message.outboxID
         ) {
+          pendingMessage = yield select(Shared.messageOutboxIDSelector, conversationIDKey, message.outboxID)
+        }
+
+        if (pendingMessage) {
           if (message.type === 'Attachment') {
-            const pendingMessage = yield select(
-              Shared.messageOutboxIDSelector,
-              conversationIDKey,
-              message.outboxID
-            )
+            // Copy locally-generated preview
             message.previewPath = pendingMessage.previewPath
           }
 

--- a/shared/chat/conversation/messages/attachment/index.js
+++ b/shared/chat/conversation/messages/attachment/index.js
@@ -11,10 +11,12 @@ import type {Props, ProgressBarProps, ImageIconProps} from '.'
 
 const AttachmentTitle = ({
   messageState,
+  filename,
   title,
   onOpenInPopup,
 }: {
   messageState: Constants.AttachmentMessageState,
+  filename: ?string,
   title: ?string,
   onOpenInPopup: ?() => void,
 }) => {
@@ -29,7 +31,7 @@ const AttachmentTitle = ({
       style = {backgroundColor: globalColors.white, color: globalColors.black_40}
       break
   }
-  return <Text type="BodySemibold" style={style} onClick={onOpenInPopup}>{title}</Text>
+  return <Text type="BodySemibold" style={style} onClick={onOpenInPopup}>{title || filename}</Text>
 }
 
 function PreviewImage({


### PR DESCRIPTION
Incoming text messages don't include an outboxID if they were sent from another client. Unfortunately, attachment messages do, and this breaks the existing code for updating pending messages.

This change looks up the pending message by outboxID before updating it. In theory this should work in both text and attachment message cases, because we append a pending/placeholder message to the store before receiving the incoming message.

:warning: This could cause dupe pending messages if the assumptions it makes are not correct. I've tested this and it seems to work, but we should give it some time and use before it makes into a release.