### PR TITLE
jenkinsfile: increase test timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -384,7 +384,7 @@ def testGo(prefix) {
                     tests[prefix + testName] = {
                         dir(dirPath) {
                             println "Running tests for $dirPath"
-                            shell ".${slash}test.test -test.timeout 15m"
+                            shell ".${slash}test.test -test.timeout 30m"
                         }
                     }
                 } else {


### PR DESCRIPTION
Sometimes when there's high contention for the macos machines, the tests can take longer. Increase the timeout so they don't fail for that reason.