### PR TITLE
Fix change membership reqs to not make new boxes for role change

### DIFF
--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -101,6 +101,19 @@ func (m *memberSet) loadMember(ctx context.Context, g *libkb.GlobalContext, user
 
 }
 
+type MemberChecker interface {
+	IsMember(context.Context, string) bool
+}
+
+func (m *memberSet) removeExistingMembers(ctx context.Context, checker MemberChecker) {
+	for k := range m.recipients {
+		if !checker.IsMember(ctx, k) {
+			continue
+		}
+		delete(m.recipients, k)
+	}
+}
+
 // AddRemainingRecipients adds everyone in existing to m.recipients that isn't in m.None.
 func (m *memberSet) AddRemainingRecipients(ctx context.Context, g *libkb.GlobalContext, existing keybase1.TeamMembers) error {
 	// make a map of the None members


### PR DESCRIPTION
The change membership requests were making new recipient boxes for role changes.

This patch only generates recipient boxes for new members.

Two new tests, slight refactoring to make it easy to see the boxes in a test.