### PR TITLE
Set message text color on mobile

### DIFF
--- a/shared/chat/conversation/messages/text/index.js
+++ b/shared/chat/conversation/messages/text/index.js
@@ -35,7 +35,9 @@ const sentStyle = {
   ...globalStyles.selectable,
   flex: 1,
   ...(isMobile
-    ? {}
+    ? {
+        color: globalColors.black_75,
+      }
     : {
         whiteSpace: 'pre-wrap',
       }),

--- a/shared/common-adapters/markdown.native.js
+++ b/shared/common-adapters/markdown.native.js
@@ -37,7 +37,8 @@ const codeSnippetBlockTextStyle = {
 
 const quoteBlockStyle = {borderLeftColor: globalColors.lightGrey2, borderLeftWidth: 3, paddingLeft: 8}
 
-// Setting undefined here overrides styles applied via Markdown
+// Override styles set by the Markdown component style so they aren't
+// applied to the Text component.
 const neutralStyle = {color: undefined, fontWeight: undefined}
 const linkStyle = {fontWeight: undefined}
 const boldStyle = {color: undefined}

--- a/shared/common-adapters/markdown.native.js
+++ b/shared/common-adapters/markdown.native.js
@@ -39,7 +39,8 @@ const quoteBlockStyle = {borderLeftColor: globalColors.lightGrey2, borderLeftWid
 
 // The Text component adds default styles which we need to unset so that
 // styles applied to Markdown parent take effect. For instance, we need
-// to unset the default color applied by so that works.
+// to unset the default color applied by <Text type="body"> so that
+// <Markdown style={{color: ...}}> works.
 const neutralStyle = {color: undefined, fontWeight: undefined}
 const linkStyle = {fontWeight: undefined}
 const boldStyle = {color: undefined}

--- a/shared/common-adapters/markdown.native.js
+++ b/shared/common-adapters/markdown.native.js
@@ -37,9 +37,9 @@ const codeSnippetBlockTextStyle = {
 
 const quoteBlockStyle = {borderLeftColor: globalColors.lightGrey2, borderLeftWidth: 3, paddingLeft: 8}
 
-// The styles are applied by the Text component. We want styles applied
-// to the Markdown component to cascade and not be overridden by the
-// Text component styles.
+// The Text component adds default styles which we need to unset so that
+// styles applied to Markdown parent take effect. For instance, we need
+// to unset the default color applied by so that works.
 const neutralStyle = {color: undefined, fontWeight: undefined}
 const linkStyle = {fontWeight: undefined}
 const boldStyle = {color: undefined}

--- a/shared/common-adapters/markdown.native.js
+++ b/shared/common-adapters/markdown.native.js
@@ -14,9 +14,9 @@ const codeSnippetStyle = {
   fontSize: 13,
   backgroundColor: globalColors.beige,
   // FIXME not yet supported for nested <Text>:
-  //...globalStyles.rounded,
-  //paddingLeft: globalMargins.xtiny,
-  //paddingRight: globalMargins.xtiny,
+  // ...globalStyles.rounded,
+  // paddingLeft: globalMargins.xtiny,
+  // paddingRight: globalMargins.xtiny,
 }
 
 const codeSnippetBlockStyle = {
@@ -37,7 +37,7 @@ const codeSnippetBlockTextStyle = {
 
 const quoteBlockStyle = {borderLeftColor: globalColors.lightGrey2, borderLeftWidth: 3, paddingLeft: 8}
 
-const neutralStyle = {color: undefined, fontWeight: undefined}
+const neutralStyle = {fontWeight: undefined}
 const linkStyle = {fontWeight: undefined}
 const boldStyle = {color: undefined}
 const italicStyle = {color: undefined, fontStyle: 'italic', fontWeight: undefined}

--- a/shared/common-adapters/markdown.native.js
+++ b/shared/common-adapters/markdown.native.js
@@ -37,7 +37,8 @@ const codeSnippetBlockTextStyle = {
 
 const quoteBlockStyle = {borderLeftColor: globalColors.lightGrey2, borderLeftWidth: 3, paddingLeft: 8}
 
-const neutralStyle = {fontWeight: undefined}
+// Setting undefined here overrides styles applied via Markdown
+const neutralStyle = {color: undefined, fontWeight: undefined}
 const linkStyle = {fontWeight: undefined}
 const boldStyle = {color: undefined}
 const italicStyle = {color: undefined, fontStyle: 'italic', fontWeight: undefined}

--- a/shared/common-adapters/markdown.native.js
+++ b/shared/common-adapters/markdown.native.js
@@ -37,8 +37,9 @@ const codeSnippetBlockTextStyle = {
 
 const quoteBlockStyle = {borderLeftColor: globalColors.lightGrey2, borderLeftWidth: 3, paddingLeft: 8}
 
-// Override styles set by the Markdown component style so they aren't
-// applied to the Text component.
+// The styles are applied by the Text component. We want styles applied
+// to the Markdown component to cascade and not be overridden by the
+// Text component styles.
 const neutralStyle = {color: undefined, fontWeight: undefined}
 const linkStyle = {fontWeight: undefined}
 const boldStyle = {color: undefined}

--- a/shared/common-adapters/text.native.js
+++ b/shared/common-adapters/text.native.js
@@ -27,6 +27,12 @@ class Text extends Component<void, Props, void> {
       ...this.props.style,
     }
 
+    if (style['color'] === undefined) {
+      console.warn(
+        'Text color is not being set propertly, might be Markdown overriding to undefined (common-adapters/text.native.js)'
+      )
+    }
+
     return (
       <NativeText
         ref={ref => {

--- a/shared/common-adapters/text.native.js
+++ b/shared/common-adapters/text.native.js
@@ -29,7 +29,7 @@ class Text extends Component<void, Props, void> {
 
     if (style['color'] === undefined) {
       console.warn(
-        'Text color is not being set propertly, might be Markdown overriding to undefined (common-adapters/text.native.js)'
+        'Text color is not being set properly, might be Markdown overriding to undefined (common-adapters/text.native.js)'
       )
     }
 

--- a/shared/styles/colors.js
+++ b/shared/styles/colors.js
@@ -1,6 +1,4 @@
 // @flow
-import {isAndroid} from '../constants/platform'
-
 const colors = {
   beige: '#f7f1eb',
   black: '#000000',
@@ -9,7 +7,7 @@ const colors = {
   black_20: 'rgba(0, 0, 0, 0.20)',
   black_40: 'rgba(0, 0, 0, 0.40)',
   black_60: 'rgba(0, 0, 0, 0.60)',
-  black_75: isAndroid ? '#000000' : 'rgba(0, 0, 0, 0.75)',
+  black_75: 'rgba(0, 0, 0, 0.75)',
   blue2: '#66b8ff',
   blue3: '#a8d7ff',
   blue3_60: 'rgba(168, 215, 255, 0.6)',


### PR DESCRIPTION
Fixes android font color which was being overridden to undefined in text.native.js via this.props.style.

**Before:**
![2017-06-07 at 2 11 pm](https://user-images.githubusercontent.com/2669/26901601-4a024a72-4b8b-11e7-98e4-8b760c24dc7a.png)

**After:**
![2017-06-07 at 2 08 pm](https://user-images.githubusercontent.com/2669/26901459-cd3298a8-4b8a-11e7-8d32-abf5a57b05ba.png)
