### PR TITLE
Enable proxy for localhost in dev mode

### DIFF
--- a/go/libkb/client.go
+++ b/go/libkb/client.go
@@ -165,6 +165,22 @@ func NewClient(e *Env, config *ClientConfig, needCookie bool) *Client {
 			xprt.Proxy = http.ProxyFromEnvironment
 		}
 	}
+
+	if !e.GetTorMode().Enabled() && e.GetRunMode() == DevelRunMode {
+		xprt.Proxy = func(req *http.Request) (*url.URL, error) {
+			// Make a fake copy request with the url set to keybase.io
+			// Because ProxyFromEnvironment refuses to proxy for localhost.
+			// This makes localhost requests get proxied.
+			// The Host can be anything and is only used to != "localhost".
+			url2 := *req.URL
+			url2.Host = "keybase.io"
+			req2 := req
+			req2.URL = &url2
+			u, err := http.ProxyFromEnvironment(req2)
+			return u, err
+		}
+	}
+
 	if config == nil || config.Timeout == 0 {
 		timeout = HTTPDefaultTimeout
 	} else {


### PR DESCRIPTION
This again https://github.com/keybase/client/pull/6605. Slightly tweaked. Even setting `KEYBASE_SERVER_URI` to `127.0.0.1:3000` isn't an alternative to this because golang checks if the destination is a loopback.