### PR TITLE
Fix race conditions around loadAttachment state checks

### DIFF
--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -211,6 +211,7 @@ function* onLoadAttachment({
         yield put(Creators.attachmentLoaded(conversationIDKey, messageID, null, loadPreview))
       }
     } catch (err) {
+      console.warn('attachment failed to load:', err)
       yield put(Creators.attachmentLoaded(conversationIDKey, messageID, null, loadPreview))
     }
   })

--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -6,7 +6,7 @@ import * as Creators from './creators'
 import * as RPCTypes from '../../constants/types/flow-types'
 import * as Saga from '../../util/saga'
 import * as Shared from './shared'
-import {call, take, put, select, cancel, fork, join} from 'redux-saga/effects'
+import {call, take, put, select, cancel, fork, join, spawn} from 'redux-saga/effects'
 import {delay} from 'redux-saga'
 import {putActionIfOnPath, navigateAppend} from '../route-tree'
 import {saveAttachmentDialog, showShareActionSheet} from '../platform-specific'
@@ -43,7 +43,7 @@ function* onLoadAttachmentPreview({
 }: Constants.LoadAttachmentPreview): SagaGenerator<any, any> {
   const {filename, messageID, conversationIDKey} = message
   if (filename && messageID) {
-    yield call(onLoadAttachment, Creators.loadAttachment(conversationIDKey, messageID, true))
+    yield put(Creators.loadAttachment(conversationIDKey, messageID, true))
   }
 }
 
@@ -140,6 +140,9 @@ const loadAttachmentSagaMap = (conversationIDKey, messageID, loadPreview) => ({
 function* onLoadAttachment({
   payload: {conversationIDKey, messageID, loadPreview},
 }: Constants.LoadAttachment): SagaGenerator<any, any> {
+  // Check if we should download the attachment. Only one instance of this saga
+  // should executes at any time, so that these checks don't interleave with
+  // updating initial progress on the download.
   const existingMessage = yield select(Shared.messageSelector, conversationIDKey, messageID)
   if (!existingMessage) {
     console.log('onLoadAttachment: message does not exist', conversationIDKey, messageID)
@@ -179,35 +182,38 @@ function* onLoadAttachment({
     return
   }
 
-  // set initial progress value
-  yield put(Creators.downloadProgress(conversationIDKey, messageID, loadPreview))
+  // Set initial progress value
+  yield put.resolve(Creators.downloadProgress(conversationIDKey, messageID, loadPreview))
 
-  const param = {
-    conversationID: Constants.keyToConversationID(conversationIDKey),
-    messageID,
-    filename: destPath,
-    preview: loadPreview,
-    identifyBehavior: RPCTypes.TlfKeysTLFIdentifyBehavior.chatGui,
-  }
+  // Perform the download in a fork so that the next loadAttachment action can be handled.
+  yield spawn(function*() {
+    const param = {
+      conversationID: Constants.keyToConversationID(conversationIDKey),
+      messageID,
+      filename: destPath,
+      preview: loadPreview,
+      identifyBehavior: RPCTypes.TlfKeysTLFIdentifyBehavior.chatGui,
+    }
 
-  const downloadFileRpc = new EngineRpc.EngineRpcCall(
-    loadAttachmentSagaMap(conversationIDKey, messageID, loadPreview),
-    ChatTypes.localDownloadFileAttachmentLocalRpcChannelMap,
-    `localDownloadFileAttachmentLocal-${conversationIDKey}-${messageID}`,
-    {param}
-  )
+    const downloadFileRpc = new EngineRpc.EngineRpcCall(
+      loadAttachmentSagaMap(conversationIDKey, messageID, loadPreview),
+      ChatTypes.localDownloadFileAttachmentLocalRpcChannelMap,
+      `localDownloadFileAttachmentLocal-${conversationIDKey}-${messageID}`,
+      {param}
+    )
 
-  try {
-    const result = yield call(downloadFileRpc.run)
-    if (EngineRpc.isFinished(result)) {
-      yield put(Creators.attachmentLoaded(conversationIDKey, messageID, destPath, loadPreview))
-    } else {
-      console.warn('downloadFileRpc bailed early')
+    try {
+      const result = yield call(downloadFileRpc.run)
+      if (EngineRpc.isFinished(result)) {
+        yield put(Creators.attachmentLoaded(conversationIDKey, messageID, destPath, loadPreview))
+      } else {
+        console.warn('downloadFileRpc bailed early')
+        yield put(Creators.attachmentLoaded(conversationIDKey, messageID, null, loadPreview))
+      }
+    } catch (err) {
       yield put(Creators.attachmentLoaded(conversationIDKey, messageID, null, loadPreview))
     }
-  } catch (err) {
-    yield put(Creators.attachmentLoaded(conversationIDKey, messageID, null, loadPreview))
-  }
+  })
 }
 
 function* _appendAttachmentPlaceholder(

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -982,7 +982,7 @@ function* chatSaga(): SagaGenerator<any, any> {
   yield Saga.safeTakeEvery('chat:getInboxAndUnbox', Inbox.onGetInboxAndUnbox)
   yield Saga.safeTakeEvery('chat:incomingMessage', _incomingMessage)
   yield Saga.safeTakeEvery('chat:incomingTyping', _incomingTyping)
-  yield Saga.safeTakeEvery('chat:loadAttachment', Attachment.onLoadAttachment)
+  yield Saga.safeTakeSerially('chat:loadAttachment', Attachment.onLoadAttachment)
   yield Saga.safeTakeEvery('chat:loadAttachmentPreview', Attachment.onLoadAttachmentPreview)
   yield Saga.safeTakeEvery('chat:loadMoreMessages', Saga.cancelWhen(_threadIsCleared, _loadMoreMessages))
   yield Saga.safeTakeEvery('chat:loadedInbox', _ensureValidSelectedChat, true, false)

--- a/shared/util/saga.js
+++ b/shared/util/saga.js
@@ -153,7 +153,7 @@ function safeTakeSerially(pattern: string | Array<any> | Function, worker: Funct
   }
 
   return fork(function* () {
-    const chan = yield actionChannel(pattern)
+    const chan = yield actionChannel(pattern, buffers.expanding(10))
     while (true) {
       const action = yield take(chan)
       yield call(wrappedWorker, action, ...args)

--- a/shared/util/saga.js
+++ b/shared/util/saga.js
@@ -1,7 +1,7 @@
 // @flow
 import _ from 'lodash'
 import {buffers, channel} from 'redux-saga'
-import {take, call, put, race, takeEvery, takeLatest, cancelled} from 'redux-saga/effects'
+import {actionChannel, take, call, put, race, fork, takeEvery, takeLatest, cancelled} from 'redux-saga/effects'
 import {globalError} from '../constants/config'
 import {convertToError} from '../util/errors'
 
@@ -133,6 +133,34 @@ function cancelWhen(predicate: (originalAction: Action, checkAction: Action) => 
   return wrappedWorker
 }
 
+function safeTakeSerially(pattern: string | Array<any> | Function, worker: Function, ...args: Array<any>) {
+  const wrappedWorker = function*(...args) {
+    try {
+      yield call(worker, ...args)
+    } catch (error) {
+      // Convert to global error so we don't kill the loop
+      yield put(dispatch => {
+        dispatch({
+          payload: convertToError(error),
+          type: globalError,
+        })
+      })
+    } finally {
+      if (yield cancelled()) {
+        console.log('safeTakeSerially cancelled')
+      }
+    }
+  }
+
+  return fork(function* () {
+    const chan = yield actionChannel(pattern)
+    while (true) {
+      const action = yield take(chan)
+      yield call(wrappedWorker, action, ...args)
+    }
+  })
+}
+
 export {
   cancelWhen,
   closeChannelMap,
@@ -143,6 +171,7 @@ export {
   safeTakeEvery,
   safeTakeLatest,
   safeTakeLatestWithCatch,
+  safeTakeSerially,
   singleFixedChannelConfig,
   takeFromChannelMap,
 }

--- a/shared/util/saga.js
+++ b/shared/util/saga.js
@@ -1,7 +1,17 @@
 // @flow
 import _ from 'lodash'
 import {buffers, channel} from 'redux-saga'
-import {actionChannel, take, call, put, race, fork, takeEvery, takeLatest, cancelled} from 'redux-saga/effects'
+import {
+  actionChannel,
+  take,
+  call,
+  put,
+  race,
+  fork,
+  takeEvery,
+  takeLatest,
+  cancelled,
+} from 'redux-saga/effects'
 import {globalError} from '../constants/config'
 import {convertToError} from '../util/errors'
 
@@ -152,7 +162,7 @@ function safeTakeSerially(pattern: string | Array<any> | Function, worker: Funct
     }
   }
 
-  return fork(function* () {
+  return fork(function*() {
     const chan = yield actionChannel(pattern, buffers.expanding(10))
     while (true) {
       const action = yield take(chan)


### PR DESCRIPTION
This fixes one cause of the "gray attachment preview" bug, but I've discovered another issue where the progress state is cleared out due to the conversation messages reloading. I will address that in a subsequent PR.