### PR TITLE
Don't pad bottom on chat list (desktop)

### DIFF
--- a/shared/chat/conversation/list/index.desktop.js
+++ b/shared/chat/conversation/list/index.desktop.js
@@ -22,7 +22,6 @@ type State = {
 }
 
 const lockedToBottomSlop = 20
-const listBottomMargin = 10
 
 class BaseList extends Component<void, Props, State> {
   _cellCache = new Virtualized.CellMeasurerCache({
@@ -398,7 +397,6 @@ const containerStyle = {
 const listStyle = {
   outline: 'none',
   overflowX: 'hidden',
-  paddingBottom: listBottomMargin,
 }
 
 export default PopupEnabledList


### PR DESCRIPTION
Padding feels super annoying to me... maybe we should remove it?

I had a previous solution with a 10px footer cell, but it was removed because of performance issues?