### PR TITLE
downgrade lease support in client for KID-driven revokes

### DIFF
--- a/go/libkb/downgrade_leases.go
+++ b/go/libkb/downgrade_leases.go
@@ -25,6 +25,14 @@ func sigIDsToString(sigIDs []keybase1.SigID) string {
 	return strings.Join(tmp, ",")
 }
 
+func uidsToString(uids []keybase1.UID) string {
+	var tmp []string
+	for _, u := range uids {
+		tmp = append(tmp, string(u))
+	}
+	return strings.Join(tmp, ",")
+}
+
 type Lease struct {
 	MerkleSeqno keybase1.Seqno    `json:"merkle_seqno"`
 	LeaseID     keybase1.LeaseID  `json:"downgrade_lease_id"`
@@ -72,15 +80,15 @@ func RequestDowngradeLeaseBySigIDs(ctx context.Context, g *GlobalContext, sigIDs
 	return leaseWithMerkleRoot(ctx, g, res)
 }
 
-func RequestDowngradeLeaseByTeam(ctx context.Context, g *GlobalContext, teamID keybase1.TeamID, users []string) (lease *Lease, mr *MerkleRoot, err error) {
+func RequestDowngradeLeaseByTeam(ctx context.Context, g *GlobalContext, teamID keybase1.TeamID, uids []keybase1.UID) (lease *Lease, mr *MerkleRoot, err error) {
 	var res leaseReply
 	err = g.API.PostDecode(APIArg{
 		Endpoint:    "downgrade/team",
 		SessionType: APISessionTypeREQUIRED,
 		NetContext:  ctx,
 		Args: HTTPArgs{
-			"team_id":   S{string(teamID)},
-			"usernames": S{strings.Join(users, ",")},
+			"team_id":     S{string(teamID)},
+			"member_uids": S{uidsToString(uids)},
 		},
 	}, &res)
 	if err != nil {

--- a/go/libkb/downgrade_leases.go
+++ b/go/libkb/downgrade_leases.go
@@ -1,0 +1,98 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package libkb
+
+import (
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	context "golang.org/x/net/context"
+	"strings"
+)
+
+func kidsToString(kids []keybase1.KID) string {
+	var tmp []string
+	for _, k := range kids {
+		tmp = append(tmp, string(k))
+	}
+	return strings.Join(tmp, ",")
+}
+
+func sigIDsToString(sigIDs []keybase1.SigID) string {
+	var tmp []string
+	for _, k := range sigIDs {
+		tmp = append(tmp, string(k))
+	}
+	return strings.Join(tmp, ",")
+}
+
+type Lease struct {
+	MerkleSeqno keybase1.Seqno    `json:"merkle_seqno"`
+	LeaseID     keybase1.LeaseID  `json:"downgrade_lease_id"`
+	HashMeta    keybase1.HashMeta `json:"hash_meta"`
+}
+
+type leaseReply struct {
+	Lease
+	Status AppStatus `json:"status"`
+}
+
+func (r *leaseReply) GetAppStatus() *AppStatus {
+	return &r.Status
+}
+
+func RequestDowngradeLeaseByKID(ctx context.Context, g *GlobalContext, kids []keybase1.KID) (lease *Lease, mr *MerkleRoot, err error) {
+	var res leaseReply
+	err = g.API.PostDecode(APIArg{
+		Endpoint:    "downgrade/key",
+		SessionType: APISessionTypeREQUIRED,
+		NetContext:  ctx,
+		Args: HTTPArgs{
+			"kids": S{kidsToString(kids)},
+		},
+	}, &res)
+	if err != nil {
+		return nil, nil, err
+	}
+	return leaseWithMerkleRoot(ctx, g, res)
+}
+
+func RequestDowngradeLeaseBySigIDs(ctx context.Context, g *GlobalContext, sigIDs []keybase1.SigID) (lease *Lease, mr *MerkleRoot, err error) {
+	var res leaseReply
+	err = g.API.PostDecode(APIArg{
+		Endpoint:    "downgrade/sig",
+		SessionType: APISessionTypeREQUIRED,
+		NetContext:  ctx,
+		Args: HTTPArgs{
+			"sig_ids": S{sigIDsToString(sigIDs)},
+		},
+	}, &res)
+	if err != nil {
+		return nil, nil, err
+	}
+	return leaseWithMerkleRoot(ctx, g, res)
+}
+
+func RequestDowngradeLeaseByTeam(ctx context.Context, g *GlobalContext, teamID keybase1.TeamID, users []string) (lease *Lease, mr *MerkleRoot, err error) {
+	var res leaseReply
+	err = g.API.PostDecode(APIArg{
+		Endpoint:    "downgrade/team",
+		SessionType: APISessionTypeREQUIRED,
+		NetContext:  ctx,
+		Args: HTTPArgs{
+			"team_id":   S{string(teamID)},
+			"usernames": S{strings.Join(users, ",")},
+		},
+	}, &res)
+	if err != nil {
+		return nil, nil, err
+	}
+	return leaseWithMerkleRoot(ctx, g, res)
+}
+
+func leaseWithMerkleRoot(ctx context.Context, g *GlobalContext, res leaseReply) (lease *Lease, mr *MerkleRoot, err error) {
+	mr, err = g.MerkleClient.FetchRootFromServerBySeqno(ctx, res.Lease.MerkleSeqno)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &res.Lease, mr, nil
+}

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -489,11 +489,12 @@ func (u *User) AuthenticationProof(key GenericKey, session string, ei int) (ret 
 	return
 }
 
-func (u *User) RevokeKeysProof(key GenericKey, kidsToRevoke []keybase1.KID, deviceToDisable keybase1.DeviceID) (*jsonw.Wrapper, error) {
+func (u *User) RevokeKeysProof(key GenericKey, kidsToRevoke []keybase1.KID, deviceToDisable keybase1.DeviceID, merkleRoot *MerkleRoot) (*jsonw.Wrapper, error) {
 	ret, err := ProofMetadata{
 		Me:         u,
 		LinkType:   LinkTypeRevoke,
 		SigningKey: key,
+		MerkleRoot: merkleRoot,
 	}.ToJSON(u.G())
 	if err != nil {
 		return nil, err
@@ -516,11 +517,12 @@ func (u *User) RevokeKeysProof(key GenericKey, kidsToRevoke []keybase1.KID, devi
 	return ret, nil
 }
 
-func (u *User) RevokeSigsProof(key GenericKey, sigIDsToRevoke []keybase1.SigID) (*jsonw.Wrapper, error) {
+func (u *User) RevokeSigsProof(key GenericKey, sigIDsToRevoke []keybase1.SigID, merkleRoot *MerkleRoot) (*jsonw.Wrapper, error) {
 	ret, err := ProofMetadata{
 		Me:         u,
 		LinkType:   LinkTypeRevoke,
 		SigningKey: key,
+		MerkleRoot: merkleRoot,
 	}.ToJSON(u.G())
 	if err != nil {
 		return nil, err

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -520,6 +520,16 @@ func importPathFromJSON(jw *jsonw.Wrapper) (out []*PathStep, err error) {
 	return
 }
 
+func (mc *MerkleClient) FetchRootFromServerBySeqno(ctx context.Context, lowerBound keybase1.Seqno) (mr *MerkleRoot, err error) {
+	defer mc.G().CTrace(ctx, "MerkleClient#FetchRootFromServerBySeqno", func() error { return err })()
+	root := mc.LastRoot()
+	if root != nil && *root.Seqno() >= lowerBound {
+		mc.G().Log.CDebugf(ctx, "seqno=%d, and was current enough, so returning non-nil previously fetched root", *root.Seqno())
+		return root, nil
+	}
+	return mc.fetchRootFromServer(ctx, root)
+}
+
 func (mc *MerkleClient) FetchRootFromServer(ctx context.Context, freshness time.Duration) (mr *MerkleRoot, err error) {
 	defer mc.G().CTrace(ctx, "MerkleClient#FetchRootFromServer", func() error { return err })()
 	root := mc.LastRoot()

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -72,6 +72,12 @@ func (o SigID) DeepCopy() SigID {
 	return o
 }
 
+type LeaseID string
+
+func (o LeaseID) DeepCopy() LeaseID {
+	return o
+}
+
 type KID string
 
 func (o KID) DeepCopy() KID {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -129,6 +129,15 @@ func (h *HashMeta) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+func (l *LeaseID) UnmarshalJSON(b []byte) error {
+	decoded, err := hex.DecodeString(Unquote(b))
+	if err != nil {
+		return err
+	}
+	*l = LeaseID(hex.EncodeToString(decoded))
+	return nil
+}
+
 func (h *HashMeta) MarshalJSON() ([]byte, error) {
 	return Quote(h.String()), nil
 }

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -33,6 +33,13 @@ func newMemberSetChange(ctx context.Context, g *libkb.GlobalContext, req keybase
 	return set, nil
 }
 
+func (m *memberSet) nonAdmins() []member {
+	var ret []member
+	ret = append(ret, m.Readers...)
+	ret = append(ret, m.Writers...)
+	return ret
+}
+
 func (m *memberSet) loadMembers(ctx context.Context, g *libkb.GlobalContext, req keybase1.TeamChangeReq) error {
 	var err error
 	m.Owners, err = m.loadGroup(ctx, g, req.Owners, true, false)

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -168,7 +168,7 @@ func TestMemberAddHasBoxes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, boxes, err := tm.changeMembershipSection(context.TODO(), req)
+	_, boxes, _, err := tm.changeMembershipSection(context.TODO(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func TestMemberChangeRoleNoBoxes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, boxes, err := tm.changeMembershipSection(context.TODO(), req)
+	_, boxes, _, err := tm.changeMembershipSection(context.TODO(), req)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/teams/sig.go
+++ b/go/teams/sig.go
@@ -121,7 +121,7 @@ func NewSubteamID() keybase1.TeamID {
 	return keybase1.TeamID(hex.EncodeToString(idBytes))
 }
 
-func ChangeSig(me *libkb.User, prev libkb.LinkID, seqno keybase1.Seqno, key libkb.GenericKey, teamSection SCTeamSection, linkType libkb.LinkType) (*jsonw.Wrapper, error) {
+func ChangeSig(me *libkb.User, prev libkb.LinkID, seqno keybase1.Seqno, key libkb.GenericKey, teamSection SCTeamSection, linkType libkb.LinkType, merkleRoot *libkb.MerkleRoot) (*jsonw.Wrapper, error) {
 
 	if teamSection.PerTeamKey != nil {
 		if teamSection.PerTeamKey.ReverseSig != "" {
@@ -137,6 +137,7 @@ func ChangeSig(me *libkb.User, prev libkb.LinkID, seqno keybase1.Seqno, key libk
 		PrevLinkID: prev,
 		SigVersion: libkb.KeybaseSignatureV2,
 		SeqType:    libkb.SeqTypeSemiprivate,
+		MerkleRoot: merkleRoot,
 	}.ToJSON(me.G())
 	if err != nil {
 		return nil, err

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -302,23 +302,25 @@ func (t *Team) isAdminOrOwner(m keybase1.UserVersion) (res bool, err error) {
 	return res, nil
 }
 
-func (t *Team) getDowngradedUsers(ms *memberSet) (users []string, err error) {
+func (t *Team) getDowngradedUsers(ms *memberSet) (uids []keybase1.UID, err error) {
 
 	for _, member := range ms.None {
-		users = append(users, member.version.Username)
+		uids = append(uids, member.version.Uid)
 	}
 
-	for _, member := range ms.Writers {
+	toCheck := append([]member{}, ms.Writers...)
+	toCheck = append(toCheck, ms.Readers...)
+	for _, member := range toCheck {
 		admin, err := t.isAdminOrOwner(member.version)
 		if err != nil {
 			return nil, err
 		}
 		if admin {
-			users = append(users, member.version.Username)
+			uids = append(uids, member.version.Uid)
 		}
 	}
 
-	return users, nil
+	return uids, nil
 }
 
 func (t *Team) ChangeMembership(ctx context.Context, req keybase1.TeamChangeReq) error {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -281,7 +281,7 @@ func (t *Team) Rotate(ctx context.Context) error {
 	section.PerTeamKey = perTeamKeySection
 
 	// post the change to the server
-	if err := t.postChangeItem(section, secretBoxes, libkb.LinkTypeRotateKey); err != nil {
+	if err := t.postChangeItem(section, secretBoxes, libkb.LinkTypeRotateKey, nil, nil); err != nil {
 		return err
 	}
 
@@ -291,15 +291,59 @@ func (t *Team) Rotate(ctx context.Context) error {
 	return nil
 }
 
+func (t *Team) isAdminOrOwner(m keybase1.UserVersion) (res bool, err error) {
+	role, err := t.Chain.GetUserRole(m)
+	if err != nil {
+		return false, err
+	}
+	if role == keybase1.TeamRole_OWNER || role == keybase1.TeamRole_ADMIN {
+		res = true
+	}
+	return res, nil
+}
+
+func (t *Team) getDowngradedUsers(ms *memberSet) (users []string, err error) {
+
+	for _, member := range ms.None {
+		users = append(users, member.version.Username)
+	}
+
+	for _, member := range ms.Writers {
+		admin, err := t.isAdminOrOwner(member.version)
+		if err != nil {
+			return nil, err
+		}
+		if admin {
+			users = append(users, member.version.Username)
+		}
+	}
+
+	return users, nil
+}
+
 func (t *Team) ChangeMembership(ctx context.Context, req keybase1.TeamChangeReq) error {
 	// create the change membership section + secretBoxes
-	section, secretBoxes, err := t.changeMembershipSection(ctx, req)
+	section, secretBoxes, memberSet, err := t.changeMembershipSection(ctx, req)
 	if err != nil {
 		return err
 	}
 
+	var merkleRoot *libkb.MerkleRoot
+	var lease *libkb.Lease
+
+	downgrades, err := t.getDowngradedUsers(memberSet)
+	if err != nil {
+		return err
+	}
+
+	if len(downgrades) != 0 {
+		lease, merkleRoot, err = libkb.RequestDowngradeLeaseByTeam(ctx, t.G(), t.Chain.GetID(), downgrades)
+		if err != nil {
+			return err
+		}
+	}
 	// post the change to the server
-	if err := t.postChangeItem(section, secretBoxes, libkb.LinkTypeChangeMembership); err != nil {
+	if err := t.postChangeItem(section, secretBoxes, libkb.LinkTypeChangeMembership, lease, merkleRoot); err != nil {
 		return err
 	}
 
@@ -307,47 +351,46 @@ func (t *Team) ChangeMembership(ctx context.Context, req keybase1.TeamChangeReq)
 		// send notification that team key rotated
 		t.G().NotifyRouter.HandleTeamKeyRotated(ctx, t.Chain.GetID(), t.Name)
 	}
-
 	return nil
 }
 
-func (t *Team) changeMembershipSection(ctx context.Context, req keybase1.TeamChangeReq) (SCTeamSection, *PerTeamSharedSecretBoxes, error) {
+func (t *Team) changeMembershipSection(ctx context.Context, req keybase1.TeamChangeReq) (SCTeamSection, *PerTeamSharedSecretBoxes, *memberSet, error) {
 	// make keys for the team
 	if _, err := t.SharedSecret(ctx); err != nil {
-		return SCTeamSection{}, nil, err
+		return SCTeamSection{}, nil, nil, err
 	}
 
 	// load the member set specified in req
 	memSet, err := newMemberSetChange(ctx, t.G(), req)
 	if err != nil {
-		return SCTeamSection{}, nil, err
+		return SCTeamSection{}, nil, nil, err
 	}
 
 	// create the team section of the signature
 	section, err := memSet.Section(t.Chain.GetID())
 	if err != nil {
-		return SCTeamSection{}, nil, err
+		return SCTeamSection{}, nil, nil, err
 	}
 
 	// create secret boxes for recipients, possibly rotating the key
 	secretBoxes, perTeamKeySection, err := t.recipientBoxes(ctx, memSet)
 	if err != nil {
-		return SCTeamSection{}, nil, err
+		return SCTeamSection{}, nil, nil, err
 	}
 	section.PerTeamKey = perTeamKeySection
 
-	return section, secretBoxes, nil
+	return section, secretBoxes, memSet, nil
 }
 
-func (t *Team) postChangeItem(section SCTeamSection, secretBoxes *PerTeamSharedSecretBoxes, linkType libkb.LinkType) error {
+func (t *Team) postChangeItem(section SCTeamSection, secretBoxes *PerTeamSharedSecretBoxes, linkType libkb.LinkType, lease *libkb.Lease, mr *libkb.MerkleRoot) error {
 	// create the change item
-	sigMultiItem, err := t.sigChangeItem(section, linkType)
+	sigMultiItem, err := t.sigChangeItem(section, linkType, merkleRoot)
 	if err != nil {
 		return err
 	}
 
 	// make the payload
-	payload := t.sigPayload(sigMultiItem, secretBoxes)
+	payload := t.sigPayload(sigMultiItem, secretBoxes, lease)
 
 	// send it to the server
 	return t.postMulti(payload)
@@ -365,7 +408,7 @@ func (t *Team) loadMe() (*libkb.User, error) {
 	return t.me, nil
 }
 
-func (t *Team) sigChangeItem(section SCTeamSection, linkType libkb.LinkType) (libkb.SigMultiItem, error) {
+func (t *Team) sigChangeItem(section SCTeamSection, linkType libkb.LinkType, merkleRoot *libkb.MerkleRoot) (libkb.SigMultiItem, error) {
 	me, err := t.loadMe()
 	if err != nil {
 		return libkb.SigMultiItem{}, err
@@ -378,7 +421,7 @@ func (t *Team) sigChangeItem(section SCTeamSection, linkType libkb.LinkType) (li
 	if err != nil {
 		return libkb.SigMultiItem{}, err
 	}
-	sig, err := ChangeSig(me, latestLinkID1, t.NextSeqno(), deviceSigningKey, section, linkType)
+	sig, err := ChangeSig(me, latestLinkID1, t.NextSeqno(), deviceSigningKey, section, linkType, merkleRoot)
 	if err != nil {
 		return libkb.SigMultiItem{}, err
 	}
@@ -494,10 +537,13 @@ func (t *Team) rotateBoxes(ctx context.Context, memSet *memberSet) (*PerTeamShar
 	return t.keyManager.RotateSharedSecretBoxes(deviceEncryptionKey, memSet.recipients)
 }
 
-func (t *Team) sigPayload(sigMultiItem libkb.SigMultiItem, secretBoxes *PerTeamSharedSecretBoxes) libkb.JSONPayload {
+func (t *Team) sigPayload(sigMultiItem libkb.SigMultiItem, secretBoxes *PerTeamSharedSecretBoxes, lease *libkb.Lease) libkb.JSONPayload {
 	payload := make(libkb.JSONPayload)
 	payload["sigs"] = []interface{}{sigMultiItem}
 	payload["per_team_key"] = secretBoxes
+	if lease != nil {
+		payload["downgrade_lease_id"] = lease.LeaseID
+	}
 
 	if t.G().VDL.DumpPayload() {
 		pretty, err := json.MarshalIndent(payload, "", "\t")

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -308,9 +308,7 @@ func (t *Team) getDowngradedUsers(ms *memberSet) (uids []keybase1.UID, err error
 		uids = append(uids, member.version.Uid)
 	}
 
-	toCheck := append([]member{}, ms.Writers...)
-	toCheck = append(toCheck, ms.Readers...)
-	for _, member := range toCheck {
+	for _, member := range ms.nonAdmins() {
 		admin, err := t.isAdminOrOwner(member.version)
 		if err != nil {
 			return nil, err
@@ -384,7 +382,7 @@ func (t *Team) changeMembershipSection(ctx context.Context, req keybase1.TeamCha
 	return section, secretBoxes, memSet, nil
 }
 
-func (t *Team) postChangeItem(section SCTeamSection, secretBoxes *PerTeamSharedSecretBoxes, linkType libkb.LinkType, lease *libkb.Lease, mr *libkb.MerkleRoot) error {
+func (t *Team) postChangeItem(section SCTeamSection, secretBoxes *PerTeamSharedSecretBoxes, linkType libkb.LinkType, lease *libkb.Lease, merkleRoot *libkb.MerkleRoot) error {
 	// create the change item
 	sigMultiItem, err := t.sigChangeItem(section, linkType, merkleRoot)
 	if err != nil {

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -30,6 +30,9 @@ protocol Common {
   @typedef("string")
   record SigID {}
 
+  @typedef("string")
+  record LeaseID {}
+
   // Most appearances of KIDs in protocol are in hex....
   @typedef("string")
   record KID {}

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4729,6 +4729,8 @@ export type KeybaseTime = {
   chain: int,
 }
 
+export type LeaseID = string
+
 export type LinkCheckResult = {
   proofId: int,
   proofResult: ProofResult,

--- a/protocol/json/keybase1/common.json
+++ b/protocol/json/keybase1/common.json
@@ -73,6 +73,12 @@
     },
     {
       "type": "record",
+      "name": "LeaseID",
+      "fields": [],
+      "typedef": "string"
+    },
+    {
+      "type": "record",
       "name": "KID",
       "fields": [],
       "typedef": "string"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4729,6 +4729,8 @@ export type KeybaseTime = {
   chain: int,
 }
 
+export type LeaseID = string
+
 export type LinkCheckResult = {
   proofId: int,
   proofResult: ProofResult,


### PR DESCRIPTION
This PR:
* Has the client ask the server for a downgrade lease by KID
* Reloads the merkle root to a seqno at or greater than the one mentioned in the lease
* threads the merkle root down through the sig generation path
* posts the lease ID along with the signature.

Relies on previous tests, which did in fact break before server bugs were fixed in this [PR over in server](https://github.com/keybase/keybase/pull/1379)