### PR TITLE
TeamPlusAllKeys RPC

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -294,6 +294,47 @@ func (o UserVersion) DeepCopy() UserVersion {
 	}
 }
 
+type TeamPlusApplicationKeys struct {
+	Id              TeamID               `codec:"id" json:"id"`
+	Name            string               `codec:"name" json:"name"`
+	Application     TeamApplication      `codec:"application" json:"application"`
+	Writers         []UserVersion        `codec:"writers" json:"writers"`
+	OnlyReaders     []UserVersion        `codec:"onlyReaders" json:"onlyReaders"`
+	ApplicationKeys []TeamApplicationKey `codec:"applicationKeys" json:"applicationKeys"`
+}
+
+func (o TeamPlusApplicationKeys) DeepCopy() TeamPlusApplicationKeys {
+	return TeamPlusApplicationKeys{
+		Id:          o.Id.DeepCopy(),
+		Name:        o.Name,
+		Application: o.Application.DeepCopy(),
+		Writers: (func(x []UserVersion) []UserVersion {
+			var ret []UserVersion
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Writers),
+		OnlyReaders: (func(x []UserVersion) []UserVersion {
+			var ret []UserVersion
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.OnlyReaders),
+		ApplicationKeys: (func(x []TeamApplicationKey) []TeamApplicationKey {
+			var ret []TeamApplicationKey
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.ApplicationKeys),
+	}
+}
+
 type TeamSigChainState struct {
 	Reader       UserVersion                    `codec:"reader" json:"reader"`
 	Id           TeamID                         `codec:"id" json:"id"`
@@ -486,6 +527,20 @@ func (o TeamEditMemberArg) DeepCopy() TeamEditMemberArg {
 	}
 }
 
+type LoadTeamPlusApplicationKeysArg struct {
+	SessionID   int             `codec:"sessionID" json:"sessionID"`
+	Id          TeamID          `codec:"id" json:"id"`
+	Application TeamApplication `codec:"application" json:"application"`
+}
+
+func (o LoadTeamPlusApplicationKeysArg) DeepCopy() LoadTeamPlusApplicationKeysArg {
+	return LoadTeamPlusApplicationKeysArg{
+		SessionID:   o.SessionID,
+		Id:          o.Id.DeepCopy(),
+		Application: o.Application.DeepCopy(),
+	}
+}
+
 type TeamsInterface interface {
 	TeamCreate(context.Context, TeamCreateArg) error
 	TeamGet(context.Context, TeamGetArg) (TeamMembersUsernames, error)
@@ -493,6 +548,7 @@ type TeamsInterface interface {
 	TeamAddMember(context.Context, TeamAddMemberArg) error
 	TeamRemoveMember(context.Context, TeamRemoveMemberArg) error
 	TeamEditMember(context.Context, TeamEditMemberArg) error
+	LoadTeamPlusApplicationKeys(context.Context, LoadTeamPlusApplicationKeysArg) (TeamPlusApplicationKeys, error)
 }
 
 func TeamsProtocol(i TeamsInterface) rpc.Protocol {
@@ -595,6 +651,22 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"loadTeamPlusApplicationKeys": {
+				MakeArg: func() interface{} {
+					ret := make([]LoadTeamPlusApplicationKeysArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]LoadTeamPlusApplicationKeysArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]LoadTeamPlusApplicationKeysArg)(nil), args)
+						return
+					}
+					ret, err = i.LoadTeamPlusApplicationKeys(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -630,5 +702,10 @@ func (c TeamsClient) TeamRemoveMember(ctx context.Context, __arg TeamRemoveMembe
 
 func (c TeamsClient) TeamEditMember(ctx context.Context, __arg TeamEditMemberArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamEditMember", []interface{}{__arg}, nil)
+	return
+}
+
+func (c TeamsClient) LoadTeamPlusApplicationKeys(ctx context.Context, __arg LoadTeamPlusApplicationKeysArg) (res TeamPlusApplicationKeys, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.loadTeamPlusApplicationKeys", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/merkle.go
+++ b/go/service/merkle.go
@@ -4,10 +4,10 @@
 package service
 
 import (
-	context "golang.org/x/net/context"
 	libkb "github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	rpc "github.com/keybase/go-framed-msgpack-rpc/rpc"
+	context "golang.org/x/net/context"
 	"time"
 )
 
@@ -24,7 +24,7 @@ func newMerkleHandler(xp rpc.Transporter, g *libkb.GlobalContext) *MerkleHandler
 }
 
 func (h *MerkleHandler) GetCurrentMerkleRoot(ctx context.Context, freshnessMsec int) (ret keybase1.MerkleRootAndTime, err error) {
-	obj, err := h.G().MerkleClient.FetchRootFromServer(ctx, time.Duration(freshnessMsec) * time.Millisecond)
+	obj, err := h.G().MerkleClient.FetchRootFromServer(ctx, time.Duration(freshnessMsec)*time.Millisecond)
 	if err != nil {
 		return ret, err
 	}

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -65,3 +65,9 @@ func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRe
 func (h *TeamsHandler) TeamEditMember(ctx context.Context, arg keybase1.TeamEditMemberArg) error {
 	return teams.EditMember(ctx, h.G().ExternalG(), arg.Name, arg.Username, arg.Role)
 }
+
+func (h *TeamsHandler) LoadTeamPlusApplicationKeys(netCtx context.Context, arg keybase1.LoadTeamPlusApplicationKeysArg) (keybase1.TeamPlusApplicationKeys, error) {
+	netCtx = libkb.WithLogTag(netCtx, "LTPAK")
+	h.G().Log.CDebugf(netCtx, "+ TeamHandler#LoadTeamPlusApplicationKeys(%+v)", arg)
+	return teams.LoadTeamPlusApplicationKeys(netCtx, h.G().ExternalG(), arg.Id, arg.Application)
+}

--- a/go/teams/rpc_exim.go
+++ b/go/teams/rpc_exim.go
@@ -1,0 +1,53 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// Export-Import for RPC for Teams
+
+package teams
+
+import (
+	"golang.org/x/net/context"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+func (t *Team) ExportToTeamPlusApplicationKeys(ctx context.Context, idTime keybase1.Time, application keybase1.TeamApplication) (teamPlusApplicationKeys keybase1.TeamPlusApplicationKeys, err error) {
+	applicationKeys, err := t.AllApplicationKeys(ctx, application)
+	if err != nil {
+		return
+	}
+
+	members, err := t.Members()
+	if err != nil {
+		return
+	}
+
+	writers := make([]keybase1.UserVersion, 0)
+	for _, writer := range members.Writers {
+		writers = append(writers, writer)
+	}
+
+	writersSet := make(map[keybase1.UserVersion]bool, 0)
+	for _, writer := range writers {
+		writersSet[writer] = true
+	}
+
+	onlyReaders := make([]keybase1.UserVersion, 0)
+	for _, reader := range members.Readers {
+		_, ok := writersSet[reader]
+		if !ok {
+			onlyReaders = append(onlyReaders, reader)
+		}
+	}
+
+	teamPlusApplicationKeys = keybase1.TeamPlusApplicationKeys{
+		Id:              t.Chain.GetID(),
+		Name:            t.Chain.GetName(),
+		Application:     application,
+		Writers:         writers,
+		OnlyReaders:     onlyReaders,
+		ApplicationKeys: applicationKeys,
+	}
+
+	return
+}

--- a/go/teams/rpc_exim_test.go
+++ b/go/teams/rpc_exim_test.go
@@ -1,0 +1,44 @@
+package teams
+
+import (
+	"golang.org/x/net/context"
+	"testing"
+
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+func TestTeamPlusApplicationKeysExim(t *testing.T) {
+	tc := libkb.SetupTest(t, "TestTeamPlusApplicationKeysExim", 1)
+	tc.Tp.UpgradePerUserKey = true
+	_, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tc.Cleanup()
+
+	name := createTeam(tc)
+	team, err := Get(context.TODO(), tc.G, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exported, err := team.ExportToTeamPlusApplicationKeys(context.TODO(), keybase1.Time(0), keybase1.TeamApplication_KBFS)
+	if err != nil {
+		t.Errorf("Error during export: %s", err)
+	}
+	if exported.Name != team.Name {
+		t.Errorf("Got name %s, expected %s", exported.Name, team.Name)
+	}
+	if exported.Id != team.Chain.GetID() {
+		t.Errorf("Got id %s, expected %s", exported.Id, team.Chain.GetID())
+	}
+	expectedKeys, err := team.AllApplicationKeys(context.TODO(), keybase1.TeamApplication_KBFS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.ApplicationKeys) != len(expectedKeys) {
+		t.Errorf("Got %s applicationKeys, expected %s", len(exported.ApplicationKeys), len(expectedKeys))
+	}
+}

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -568,3 +568,12 @@ func (t *Team) postMulti(payload libkb.JSONPayload) error {
 	}
 	return nil
 }
+
+func LoadTeamPlusApplicationKeys(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID, application keybase1.TeamApplication) (keybase1.TeamPlusApplicationKeys, error) {
+	var teamPlusApplicationKeys keybase1.TeamPlusApplicationKeys
+	teamByID, err := GetByID(ctx, g, id)
+	if err != nil {
+		return teamPlusApplicationKeys, err
+	}
+	return teamByID.ExportToTeamPlusApplicationKeys(ctx, keybase1.Time(0), application)
+}

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -204,7 +204,7 @@ protocol Common {
       array<PublicKey> pgpKeys;
       array<RemoteTrack> remoteTracks;
   }
-
+  
   @go("nostring")
   enum MerkleTreeID {
        MASTER_0,

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -72,6 +72,17 @@ protocol teams {
     Seqno eldestSeqno;
   }
 
+  record TeamPlusApplicationKeys {
+      TeamID id;
+      string name;
+      TeamApplication application;
+
+      array<UserVersion> writers;
+      array<UserVersion> onlyReaders;
+
+      array<TeamApplicationKey> applicationKeys;
+  }
+
   // State of a parsed team sigchain.
   // Should be treated as immutable when outside TeamSigChainPlayer.
   // Modified internally to TeamSigChainPlayer.
@@ -131,4 +142,5 @@ protocol teams {
   void teamAddMember(int sessionID, string name, string username, TeamRole role, boolean sendChatNotification);
   void teamRemoveMember(int sessionID, string name, string username);
   void teamEditMember(int sessionID, string name, string username, TeamRole role);
+  TeamPlusApplicationKeys loadTeamPlusApplicationKeys(int sessionID, TeamID id, TeamApplication application);
 }

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -3498,6 +3498,21 @@ export function sigsSigListRpcPromise (request: $Exact<requestCommon & {callback
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.sigs.sigList', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsLoadTeamPlusApplicationKeysRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: teamsLoadTeamPlusApplicationKeysResult) => void} & {param: teamsLoadTeamPlusApplicationKeysRpcParam}>) {
+  engineRpcOutgoing('keybase.1.teams.loadTeamPlusApplicationKeys', request)
+}
+
+export function teamsLoadTeamPlusApplicationKeysRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsLoadTeamPlusApplicationKeysResult) => void} & {param: teamsLoadTeamPlusApplicationKeysRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.loadTeamPlusApplicationKeys', request)
+}
+export function teamsLoadTeamPlusApplicationKeysRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsLoadTeamPlusApplicationKeysResult) => void} & {param: teamsLoadTeamPlusApplicationKeysRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.teams.loadTeamPlusApplicationKeys', request, callback, incomingCallMap) })
+}
+
+export function teamsLoadTeamPlusApplicationKeysRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsLoadTeamPlusApplicationKeysResult) => void} & {param: teamsLoadTeamPlusApplicationKeysRpcParam}>): Promise<teamsLoadTeamPlusApplicationKeysResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.loadTeamPlusApplicationKeys', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamAddMemberRpc (request: Exact<requestCommon & requestErrorCallback & {param: teamsTeamAddMemberRpcParam}>) {
   engineRpcOutgoing('keybase.1.teams.teamAddMember', request)
 }
@@ -5783,6 +5798,15 @@ export type TeamNameParts = {
   parts?: ?Array<string>,
 }
 
+export type TeamPlusApplicationKeys = {
+  id: TeamID,
+  name: string,
+  application: TeamApplication,
+  writers?: ?Array<UserVersion>,
+  onlyReaders?: ?Array<UserVersion>,
+  applicationKeys?: ?Array<TeamApplicationKey>,
+}
+
 export type TeamRole =
     0 // NONE_0
   | 1 // OWNER_1
@@ -6899,6 +6923,11 @@ export type streamUiWriteRpcParam = Exact<{
   buf: bytes
 }>
 
+export type teamsLoadTeamPlusApplicationKeysRpcParam = Exact<{
+  id: TeamID,
+  application: TeamApplication
+}>
+
 export type teamsTeamAddMemberRpcParam = Exact<{
   name: string,
   username: string,
@@ -7167,6 +7196,7 @@ type sigsSigListJSONResult = string
 type sigsSigListResult = ?Array<Sig>
 type streamUiReadResult = bytes
 type streamUiWriteResult = int
+type teamsLoadTeamPlusApplicationKeysResult = TeamPlusApplicationKeys
 type teamsTeamGetResult = TeamMembersUsernames
 type testTestCallbackResult = string
 type testTestResult = Test
@@ -7391,6 +7421,7 @@ export type rpc =
   | signupSignupRpc
   | sigsSigListJSONRpc
   | sigsSigListRpc
+  | teamsLoadTeamPlusApplicationKeysRpc
   | teamsTeamAddMemberRpc
   | teamsTeamChangeMembershipRpc
   | teamsTeamCreateRpc

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -230,6 +230,45 @@
     },
     {
       "type": "record",
+      "name": "TeamPlusApplicationKeys",
+      "fields": [
+        {
+          "type": "TeamID",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "TeamApplication",
+          "name": "application"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "UserVersion"
+          },
+          "name": "writers"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "UserVersion"
+          },
+          "name": "onlyReaders"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "TeamApplicationKey"
+          },
+          "name": "applicationKeys"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "TeamSigChainState",
       "fields": [
         {
@@ -442,6 +481,23 @@
         }
       ],
       "response": null
+    },
+    "loadTeamPlusApplicationKeys": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "id",
+          "type": "TeamID"
+        },
+        {
+          "name": "application",
+          "type": "TeamApplication"
+        }
+      ],
+      "response": "TeamPlusApplicationKeys"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -3498,6 +3498,21 @@ export function sigsSigListRpcPromise (request: $Exact<requestCommon & {callback
   return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.sigs.sigList', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function teamsLoadTeamPlusApplicationKeysRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: teamsLoadTeamPlusApplicationKeysResult) => void} & {param: teamsLoadTeamPlusApplicationKeysRpcParam}>) {
+  engineRpcOutgoing('keybase.1.teams.loadTeamPlusApplicationKeys', request)
+}
+
+export function teamsLoadTeamPlusApplicationKeysRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsLoadTeamPlusApplicationKeysResult) => void} & {param: teamsLoadTeamPlusApplicationKeysRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'keybase.1.teams.loadTeamPlusApplicationKeys', request)
+}
+export function teamsLoadTeamPlusApplicationKeysRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsLoadTeamPlusApplicationKeysResult) => void} & {param: teamsLoadTeamPlusApplicationKeysRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('keybase.1.teams.loadTeamPlusApplicationKeys', request, callback, incomingCallMap) })
+}
+
+export function teamsLoadTeamPlusApplicationKeysRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: teamsLoadTeamPlusApplicationKeysResult) => void} & {param: teamsLoadTeamPlusApplicationKeysRpcParam}>): Promise<teamsLoadTeamPlusApplicationKeysResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('keybase.1.teams.loadTeamPlusApplicationKeys', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function teamsTeamAddMemberRpc (request: Exact<requestCommon & requestErrorCallback & {param: teamsTeamAddMemberRpcParam}>) {
   engineRpcOutgoing('keybase.1.teams.teamAddMember', request)
 }
@@ -5783,6 +5798,15 @@ export type TeamNameParts = {
   parts?: ?Array<string>,
 }
 
+export type TeamPlusApplicationKeys = {
+  id: TeamID,
+  name: string,
+  application: TeamApplication,
+  writers?: ?Array<UserVersion>,
+  onlyReaders?: ?Array<UserVersion>,
+  applicationKeys?: ?Array<TeamApplicationKey>,
+}
+
 export type TeamRole =
     0 // NONE_0
   | 1 // OWNER_1
@@ -6899,6 +6923,11 @@ export type streamUiWriteRpcParam = Exact<{
   buf: bytes
 }>
 
+export type teamsLoadTeamPlusApplicationKeysRpcParam = Exact<{
+  id: TeamID,
+  application: TeamApplication
+}>
+
 export type teamsTeamAddMemberRpcParam = Exact<{
   name: string,
   username: string,
@@ -7167,6 +7196,7 @@ type sigsSigListJSONResult = string
 type sigsSigListResult = ?Array<Sig>
 type streamUiReadResult = bytes
 type streamUiWriteResult = int
+type teamsLoadTeamPlusApplicationKeysResult = TeamPlusApplicationKeys
 type teamsTeamGetResult = TeamMembersUsernames
 type testTestCallbackResult = string
 type testTestResult = Test
@@ -7391,6 +7421,7 @@ export type rpc =
   | signupSignupRpc
   | sigsSigListJSONRpc
   | sigsSigListRpc
+  | teamsLoadTeamPlusApplicationKeysRpc
   | teamsTeamAddMemberRpc
   | teamsTeamChangeMembershipRpc
   | teamsTeamCreateRpc


### PR DESCRIPTION
Just a in-progress commit to make sure I'm on the right track, with some questions

After this, I just need to write a loader and something like UPAK that caches the team objects? This involves writing a functions to take a uid, query the database and/or query the keybase server, build a Team object, then pass it to the Export function already written. Is there a case for making general cacher/loader functions that work with arbitrary objects?