### PR TITLE
handle conversation membership updates and upgrade team update prot CORE-5289

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -386,8 +386,8 @@ func (s *RemoteInboxSource) TlfFinalize(ctx context.Context, uid gregor1.UID, ve
 }
 
 func (s *RemoteInboxSource) MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
-	joined []chat1.Conversation, removed []chat1.ConversationID) ([]chat1.ConversationLocal, error) {
-	return nil, nil
+	joined []chat1.Conversation, removed []chat1.ConversationID) error {
+	return nil
 }
 
 type HybridInboxSource struct {
@@ -656,24 +656,15 @@ func (s *HybridInboxSource) TlfFinalize(ctx context.Context, uid gregor1.UID, ve
 }
 
 func (s *HybridInboxSource) MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
-	joinedConvs []chat1.Conversation, removedConvs []chat1.ConversationID) (joinedLocalConvs []chat1.ConversationLocal, err error) {
+	joinedConvs []chat1.Conversation, removedConvs []chat1.ConversationID) (err error) {
 	defer s.Trace(ctx, func() error { return err }, "MembershipUpdate")()
 
 	if cerr := storage.NewInbox(s.G(), uid).MembershipUpdate(ctx, vers, joinedConvs, removedConvs); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
-		return nil, err
+		return err
 	}
 
-	ibox := chat1.Inbox{
-		ConvsUnverified: joinedConvs,
-	}
-	localizer := NewBlockingLocalizer(s.G())
-	if joinedLocalConvs, err = localizer.Localize(ctx, uid, ibox); err != nil {
-		s.Debug(ctx, "MembershipUpdate: failed to localize joined conversations: %s", err.Error())
-		return nil, err
-	}
-
-	return joinedLocalConvs, nil
+	return nil
 }
 
 func (s *localizerPipeline) localizeConversationsPipeline(ctx context.Context, uid gregor1.UID,

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -386,7 +386,7 @@ func (s *RemoteInboxSource) TlfFinalize(ctx context.Context, uid gregor1.UID, ve
 }
 
 func (s *RemoteInboxSource) MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
-	joined []chat1.Conversation, removed []chat1.ConversationID) error {
+	joined []chat1.ConversationID, removed []chat1.ConversationID) error {
 	return nil
 }
 

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -576,3 +576,70 @@ func (g *PushHandler) Typing(ctx context.Context, m gregor.OutOfBandMessage) (er
 	}, update.ConvID, update.Typing)
 	return nil
 }
+
+func (g *PushHandler) MembershipUpdate(ctx context.Context, m gregor.OutOfBandMessage) (err error) {
+	var identBreaks []keybase1.TLFIdentifyFailure
+	ctx = Context(ctx, g.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
+		g.identNotifier)
+	defer g.Trace(ctx, func() error { return err }, "MembershipUpdate")()
+	if m.Body() == nil {
+		return errors.New("gregor handler for membership update: nil message body")
+	}
+
+	var update chat1.UpdateConversationMembership
+	reader := bytes.NewReader(m.Body().Bytes())
+	dec := codec.NewDecoder(reader, &codec.MsgpackHandle{WriteExt: true})
+	err = dec.Decode(&update)
+	if err != nil {
+		return err
+	}
+	uid := gregor1.UID(m.UID().Bytes())
+
+	// Order updates based on inbox version of the update from the server
+	cb := g.orderer.WaitForTurn(ctx, uid, update.InboxVers)
+	bctx := BackgroundContext(ctx, g.G())
+	go func(ctx context.Context) (err error) {
+		defer g.Trace(ctx, func() error { return err }, "MembershipUpdate(goroutine)")()
+		<-cb
+		g.Lock()
+		defer g.Unlock()
+		defer g.orderer.CompleteTurn(ctx, uid, update.InboxVers)
+		defer func() {
+			if err != nil {
+				g.Debug(ctx, "MembershipUpdate: sending inbox stale notification")
+				g.G().Syncer.SendChatStaleNotifications(ctx, uid, nil, true)
+			}
+		}()
+
+		// Load the joined conversations
+		var joinedConvs []chat1.Conversation
+		if len(update.Joined) > 0 {
+			var ibox chat1.Inbox
+			ibox, _, err = g.G().InboxSource.ReadUnverified(ctx, uid, false, &chat1.GetInboxQuery{
+				ConvIDs: update.Joined,
+			}, nil)
+			if err != nil {
+				g.Debug(ctx, "MembershipUpdate: failed to read joined convs: %s", err.Error())
+				return
+			}
+			for _, c := range ibox.ConvsUnverified {
+				joinedConvs = append(joinedConvs, c)
+			}
+		}
+
+		// Write out changes to local storage
+		joinedLocal, err := g.G().InboxSource.MembershipUpdate(ctx, uid, update.InboxVers, joinedConvs,
+			update.Removed)
+		if err != nil {
+			g.Debug(ctx, "MembershipUpdate: failed to update membership on inbox: %s", err.Error())
+			return err
+		}
+
+		// Send notifications for changed conversations (might need to make this better in the future)
+		convIDs := append(utils.PluckConvIDsLocal(joinedLocal), update.Removed...)
+		g.G().Syncer.SendChatStaleNotifications(ctx, uid, convIDs, false)
+		return nil
+	}(bctx)
+
+	return nil
+}

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -628,15 +628,14 @@ func (g *PushHandler) MembershipUpdate(ctx context.Context, m gregor.OutOfBandMe
 		}
 
 		// Write out changes to local storage
-		joinedLocal, err := g.G().InboxSource.MembershipUpdate(ctx, uid, update.InboxVers, joinedConvs,
-			update.Removed)
-		if err != nil {
+		if err = g.G().InboxSource.MembershipUpdate(ctx, uid, update.InboxVers, joinedConvs,
+			update.Removed); err != nil {
 			g.Debug(ctx, "MembershipUpdate: failed to update membership on inbox: %s", err.Error())
 			return err
 		}
 
 		// Send notifications for changed conversations (might need to make this better in the future)
-		convIDs := append(utils.PluckConvIDsLocal(joinedLocal), update.Removed...)
+		convIDs := append(utils.PluckConvIDs(joinedConvs), update.Removed...)
 		g.G().Syncer.SendChatStaleNotifications(ctx, uid, convIDs, false)
 		return nil
 	}(bctx)

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -80,6 +80,8 @@ type InboxSource interface {
 		status chat1.ConversationStatus) (*chat1.ConversationLocal, error)
 	TlfFinalize(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 		convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) ([]chat1.ConversationLocal, error)
+	MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
+		joinedConvs []chat1.Conversation, removedConvs []chat1.ConversationID) ([]chat1.ConversationLocal, error)
 
 	GetInboxQueryLocalToRemote(ctx context.Context,
 		lquery *chat1.GetInboxLocalQuery) (*chat1.GetInboxQuery, NameInfo, error)
@@ -133,6 +135,7 @@ type PushHandler interface {
 	TlfResolve(context.Context, gregor.OutOfBandMessage) error
 	Activity(context.Context, gregor.OutOfBandMessage) error
 	Typing(context.Context, gregor.OutOfBandMessage) error
+	MembershipUpdate(context.Context, gregor.OutOfBandMessage) error
 }
 
 type AppState interface {

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -81,7 +81,7 @@ type InboxSource interface {
 	TlfFinalize(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 		convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) ([]chat1.ConversationLocal, error)
 	MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
-		joinedConvs []chat1.Conversation, removedConvs []chat1.ConversationID) error
+		joinedConvs []chat1.ConversationID, removedConvs []chat1.ConversationID) error
 
 	GetInboxQueryLocalToRemote(ctx context.Context,
 		lquery *chat1.GetInboxLocalQuery) (*chat1.GetInboxQuery, NameInfo, error)

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -81,7 +81,7 @@ type InboxSource interface {
 	TlfFinalize(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 		convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) ([]chat1.ConversationLocal, error)
 	MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
-		joinedConvs []chat1.Conversation, removedConvs []chat1.ConversationID) ([]chat1.ConversationLocal, error)
+		joinedConvs []chat1.Conversation, removedConvs []chat1.ConversationID) error
 
 	GetInboxQueryLocalToRemote(ctx context.Context,
 		lquery *chat1.GetInboxLocalQuery) (*chat1.GetInboxQuery, NameInfo, error)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -418,3 +418,19 @@ func PluckConvIDs(convs []chat1.Conversation) (res []chat1.ConversationID) {
 	}
 	return res
 }
+
+type ConvLocalByConvID []chat1.ConversationLocal
+
+func (c ConvLocalByConvID) Len() int      { return len(c) }
+func (c ConvLocalByConvID) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c ConvLocalByConvID) Less(i, j int) bool {
+	return c[i].GetConvID().Less(c[j].GetConvID())
+}
+
+type ConvByConvID []chat1.Conversation
+
+func (c ConvByConvID) Len() int      { return len(c) }
+func (c ConvByConvID) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c ConvByConvID) Less(i, j int) bool {
+	return c[i].GetConvID().Less(c[j].GetConvID())
+}

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -404,3 +404,17 @@ func IsConvEmpty(conv chat1.Conversation) bool {
 	}
 	return true
 }
+
+func PluckConvIDsLocal(convs []chat1.ConversationLocal) (res []chat1.ConversationID) {
+	for _, conv := range convs {
+		res = append(res, conv.GetConvID())
+	}
+	return res
+}
+
+func PluckConvIDs(convs []chat1.Conversation) (res []chat1.ConversationID) {
+	for _, conv := range convs {
+		res = append(res, conv.GetConvID())
+	}
+	return res
+}

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -216,6 +216,32 @@ func (e ConversationStatus) String() string {
 	return ""
 }
 
+type ConversationMemberStatus int
+
+const (
+	ConversationMemberStatus_ACTIVE  ConversationMemberStatus = 0
+	ConversationMemberStatus_REMOVED ConversationMemberStatus = 1
+)
+
+func (o ConversationMemberStatus) DeepCopy() ConversationMemberStatus { return o }
+
+var ConversationMemberStatusMap = map[string]ConversationMemberStatus{
+	"ACTIVE":  0,
+	"REMOVED": 1,
+}
+
+var ConversationMemberStatusRevMap = map[ConversationMemberStatus]string{
+	0: "ACTIVE",
+	1: "REMOVED",
+}
+
+func (e ConversationMemberStatus) String() string {
+	if v, ok := ConversationMemberStatusRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type Pagination struct {
 	Next     []byte `codec:"next" json:"next"`
 	Previous []byte `codec:"previous" json:"previous"`

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -27,6 +27,10 @@ func (id TLFID) String() string {
 	return hex.EncodeToString(id)
 }
 
+func (id TLFID) Bytes() []byte {
+	return []byte(id)
+}
+
 func MakeConvID(val string) (ConversationID, error) {
 	return hex.DecodeString(val)
 }

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -177,6 +177,34 @@ func (o RemoteUserTypingUpdate) DeepCopy() RemoteUserTypingUpdate {
 	}
 }
 
+type UpdateConversationMembership struct {
+	InboxVers InboxVers        `codec:"inboxVers" json:"inboxVers"`
+	Joined    []ConversationID `codec:"joined" json:"joined"`
+	Removed   []ConversationID `codec:"removed" json:"removed"`
+}
+
+func (o UpdateConversationMembership) DeepCopy() UpdateConversationMembership {
+	return UpdateConversationMembership{
+		InboxVers: o.InboxVers.DeepCopy(),
+		Joined: (func(x []ConversationID) []ConversationID {
+			var ret []ConversationID
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Joined),
+		Removed: (func(x []ConversationID) []ConversationID {
+			var ret []ConversationID
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Removed),
+	}
+}
+
 type GregorInterface interface {
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -127,6 +127,20 @@ func (o PerTeamKey) DeepCopy() PerTeamKey {
 	}
 }
 
+type TeamMember struct {
+	Uid         UID    `codec:"uid" json:"uid"`
+	Role        string `codec:"role" json:"role"`
+	EldestSeqno Seqno  `codec:"eldestSeqno" json:"eldestSeqno"`
+}
+
+func (o TeamMember) DeepCopy() TeamMember {
+	return TeamMember{
+		Uid:         o.Uid.DeepCopy(),
+		Role:        o.Role,
+		EldestSeqno: o.EldestSeqno.DeepCopy(),
+	}
+}
+
 type TeamMembers struct {
 	Owners  []UserVersion `codec:"owners" json:"owners"`
 	Admins  []UserVersion `codec:"admins" json:"admins"`

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -128,15 +128,15 @@ func (o PerTeamKey) DeepCopy() PerTeamKey {
 }
 
 type TeamMember struct {
-	Uid         UID    `codec:"uid" json:"uid"`
-	Role        string `codec:"role" json:"role"`
-	EldestSeqno Seqno  `codec:"eldestSeqno" json:"eldestSeqno"`
+	Uid         UID      `codec:"uid" json:"uid"`
+	Role        TeamRole `codec:"role" json:"role"`
+	EldestSeqno Seqno    `codec:"eldestSeqno" json:"eldestSeqno"`
 }
 
 func (o TeamMember) DeepCopy() TeamMember {
 	return TeamMember{
 		Uid:         o.Uid.DeepCopy(),
-		Role:        o.Role,
+		Role:        o.Role.DeepCopy(),
 		EldestSeqno: o.EldestSeqno.DeepCopy(),
 	}
 }

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1057,6 +1057,8 @@ func (g *gregorHandler) handleOutOfBandMessage(ctx context.Context, obm gregor.O
 		return g.G().PushHandler.TlfResolve(ctx, obm)
 	case "chat.typing":
 		return g.G().PushHandler.Typing(ctx, obm)
+	case "chat.membershipUpdate":
+		return g.G().PushHandler.MembershipUpdate(ctx, obm)
 	case "internal.reconnect":
 		g.G().Log.Debug("reconnected to push server")
 		return nil

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -67,6 +67,11 @@ protocol common {
 
   }
 
+  enum ConversationMemberStatus {
+    ACTIVE_0,
+    REMOVED_1
+  }
+
   record Pagination {
     bytes next;
     bytes previous;

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -44,7 +44,7 @@ protocol gregor {
         InboxVers inboxVers;
         union { null, UnreadUpdate } unreadUpdate;
     }
-
+    
     record UnreadUpdate {
         ConversationID convID;
         // The count of unread messages to display
@@ -69,5 +69,11 @@ protocol gregor {
         gregor1.DeviceID deviceID;
         ConversationID convID;
         boolean typing; 
+    }
+   
+    record UpdateConversationMembership {
+        InboxVers inboxVers;
+        array<ConversationID> joined;
+        array<ConversationID> removed;
     }
 }

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -39,6 +39,12 @@ protocol teams {
       KID encKID;
   }
 
+  record TeamMember {
+    UID uid;
+    string role;
+    Seqno eldestSeqno;
+  }
+
   record TeamMembers {
     array<UserVersion> owners;
     array<UserVersion> admins;

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -41,7 +41,7 @@ protocol teams {
 
   record TeamMember {
     UID uid;
-    string role;
+    TeamRole role;
     Seqno eldestSeqno;
   }
 

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -55,6 +55,11 @@ function _channelMapRpcHelper(channelConfig: ChannelConfig<*>, partialRpcCall: (
 }
 
 
+export const CommonConversationMemberStatus = {
+  active: 0,
+  removed: 1,
+}
+
 export const CommonConversationMembersType = {
   kbfs: 0,
   team: 1,
@@ -1061,6 +1066,10 @@ export type ConversationLocal = {
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
 
+export type ConversationMemberStatus =
+    0 // ACTIVE_0
+  | 1 // REMOVED_1
+
 export type ConversationMembersType =
     0 // KBFS_0
   | 1 // TEAM_1
@@ -1847,6 +1856,12 @@ export type UnreadUpdateFull = {
   ignore: boolean,
   inboxVers: InboxVers,
   updates?: ?Array<UnreadUpdate>,
+}
+
+export type UpdateConversationMembership = {
+  inboxVers: InboxVers,
+  joined?: ?Array<ConversationID>,
+  removed?: ?Array<ConversationID>,
 }
 
 export type chatUiChatAttachmentDownloadProgressRpcParam = Exact<{

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5745,6 +5745,12 @@ export type TeamChangeReq = {
 
 export type TeamID = string
 
+export type TeamMember = {
+  uid: UID,
+  role: string,
+  eldestSeqno: Seqno,
+}
+
 export type TeamMembers = {
   owners?: ?Array<UserVersion>,
   admins?: ?Array<UserVersion>,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5747,7 +5747,7 @@ export type TeamID = string
 
 export type TeamMember = {
   uid: UID,
-  role: string,
+  role: TeamRole,
   eldestSeqno: Seqno,
 }
 

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -106,6 +106,14 @@
       ]
     },
     {
+      "type": "enum",
+      "name": "ConversationMemberStatus",
+      "symbols": [
+        "ACTIVE_0",
+        "REMOVED_1"
+      ]
+    },
+    {
       "type": "record",
       "name": "Pagination",
       "fields": [

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -214,6 +214,30 @@
           "name": "typing"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "UpdateConversationMembership",
+      "fields": [
+        {
+          "type": "InboxVers",
+          "name": "inboxVers"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "ConversationID"
+          },
+          "name": "joined"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "ConversationID"
+          },
+          "name": "removed"
+        }
+      ]
     }
   ],
   "messages": {},

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -89,6 +89,24 @@
     },
     {
       "type": "record",
+      "name": "TeamMember",
+      "fields": [
+        {
+          "type": "UID",
+          "name": "uid"
+        },
+        {
+          "type": "string",
+          "name": "role"
+        },
+        {
+          "type": "Seqno",
+          "name": "eldestSeqno"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "TeamMembers",
       "fields": [
         {

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -96,7 +96,7 @@
           "name": "uid"
         },
         {
-          "type": "string",
+          "type": "TeamRole",
           "name": "role"
         },
         {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -55,6 +55,11 @@ function _channelMapRpcHelper(channelConfig: ChannelConfig<*>, partialRpcCall: (
 }
 
 
+export const CommonConversationMemberStatus = {
+  active: 0,
+  removed: 1,
+}
+
 export const CommonConversationMembersType = {
   kbfs: 0,
   team: 1,
@@ -1061,6 +1066,10 @@ export type ConversationLocal = {
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
 
+export type ConversationMemberStatus =
+    0 // ACTIVE_0
+  | 1 // REMOVED_1
+
 export type ConversationMembersType =
     0 // KBFS_0
   | 1 // TEAM_1
@@ -1847,6 +1856,12 @@ export type UnreadUpdateFull = {
   ignore: boolean,
   inboxVers: InboxVers,
   updates?: ?Array<UnreadUpdate>,
+}
+
+export type UpdateConversationMembership = {
+  inboxVers: InboxVers,
+  joined?: ?Array<ConversationID>,
+  removed?: ?Array<ConversationID>,
 }
 
 export type chatUiChatAttachmentDownloadProgressRpcParam = Exact<{

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5745,6 +5745,12 @@ export type TeamChangeReq = {
 
 export type TeamID = string
 
+export type TeamMember = {
+  uid: UID,
+  role: string,
+  eldestSeqno: Seqno,
+}
+
 export type TeamMembers = {
   owners?: ?Array<UserVersion>,
   admins?: ?Array<UserVersion>,

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5747,7 +5747,7 @@ export type TeamID = string
 
 export type TeamMember = {
   uid: UID,
-  role: string,
+  role: TeamRole,
   eldestSeqno: Seqno,
 }
 


### PR DESCRIPTION
Point of the patch is the following:

1.) Add handler for updates to conversation membership from Gregor. All this does right now is change the local inbox cache, and then send a full inbox reload to the frontend. Seems to work out of the box with no UI changes.
2.) Change a bunch of protocol files to make this pipeline better.
3.) Add new protocol definitions for the changes to `msg_reader` now that it has more states than just being in the conversation (`active` and `removed`).

cc @maxtaco 