### PR TITLE
Better PGP errors, fix "Bad key found" for stubbed keys

### DIFF
--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -713,6 +713,12 @@ func (e *loginProvision) tryGPG(ctx *Context) error {
 		lctx.EnsureUsername(e.arg.User.GetNormalizedName())
 
 		if err := e.makeDeviceKeysWithSigner(ctx, signingKey); err != nil {
+			if appErr, ok := err.(libkb.AppStatusError); ok && appErr.Code == 905 {
+				// Propagate the error, but display a more descriptive message to the user.
+				e.G().Log.Error("during GPG provisioning.\n We were able to generate a PGP signature with " +
+					"gpg client, but it was rejected by the server. This often means that PGP key in your " +
+					"Keybase profile is expired or unusable. You can update your key on https://keybase.io")
+			}
 			return err
 		}
 		if err := lctx.LocalSession().SetDeviceProvisioned(e.G().Env.GetDeviceIDForUsername(e.arg.User.GetNormalizedName())); err != nil {

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -713,7 +713,7 @@ func (e *loginProvision) tryGPG(ctx *Context) error {
 		lctx.EnsureUsername(e.arg.User.GetNormalizedName())
 
 		if err := e.makeDeviceKeysWithSigner(ctx, signingKey); err != nil {
-			if appErr, ok := err.(libkb.AppStatusError); ok && appErr.Code == 905 {
+			if appErr, ok := err.(libkb.AppStatusError); ok && appErr.Code == libkb.SCKeyCorrupted {
 				// Propagate the error, but display a more descriptive message to the user.
 				e.G().Log.Error("during GPG provisioning.\n We were able to generate a PGP signature with " +
 					"gpg client, but it was rejected by the server. This often means that PGP key in your " +

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -715,9 +715,9 @@ func (e *loginProvision) tryGPG(ctx *Context) error {
 		if err := e.makeDeviceKeysWithSigner(ctx, signingKey); err != nil {
 			if appErr, ok := err.(libkb.AppStatusError); ok && appErr.Code == libkb.SCKeyCorrupted {
 				// Propagate the error, but display a more descriptive message to the user.
-				e.G().Log.Error("during GPG provisioning.\n We were able to generate a PGP signature with " +
-					"gpg client, but it was rejected by the server. This often means that PGP key in your " +
-					"Keybase profile is expired or unusable. You can update your key on https://keybase.io")
+				e.G().Log.Error("during GPG provisioning.\nWe were able to generate a PGP signature " +
+					"with gpg client, but it was rejected by the server. This often means that this " +
+					"PGP key is expired or unusable. You can update your key on https://keybase.io")
 			}
 			return err
 		}

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -184,7 +184,7 @@ func (e *PGPEncrypt) loadSelfKey() (*libkb.PGPKeyBundle, error) {
 
 	keys := me.FilterActivePGPKeys(true, e.arg.KeyQuery)
 	if len(keys) == 0 {
-		return nil, libkb.NoKeyError{Msg: "No PGP key found for encrypting for self"}
+		return nil, libkb.NoKeyError{Msg: "No PGP key found for encrypting for self (add a PGP key or use --no-self flag)"}
 	}
 	return keys[0], nil
 }

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -182,6 +182,7 @@ const (
 	SCBadInvitationCode      = int(keybase1.StatusCode_SCBadInvitationCode)
 	SCMissingResult          = int(keybase1.StatusCode_SCMissingResult)
 	SCKeyNotFound            = int(keybase1.StatusCode_SCKeyNotFound)
+	SCKeyCorrupted           = int(keybase1.StatusCode_SCKeyCorrupted)
 	SCKeyInUse               = int(keybase1.StatusCode_SCKeyInUse)
 	SCKeyBadGen              = int(keybase1.StatusCode_SCKeyBadGen)
 	SCKeyNoSecret            = int(keybase1.StatusCode_SCKeyNoSecret)

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -355,6 +355,20 @@ func (n NoSelectedKeyError) Error() string {
 
 //=============================================================================
 
+type KeyCorruptedError struct {
+	Msg string
+}
+
+func (e KeyCorruptedError) Error() string {
+	msg := "Key corrupted"
+	if len(e.Msg) != 0 {
+		msg = msg + ": " + e.Msg
+	}
+	return msg
+}
+
+//=============================================================================
+
 type KeyExistsError struct {
 	Key *PGPFingerprint
 }

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -244,7 +244,7 @@ func ImportStatusAsError(s *keybase1.Status) error {
 		}
 		return KeyExistsError{fp}
 	case SCKeyNotFound:
-		return NoKeyError{}
+		return NoKeyError{s.Desc}
 	case SCKeyNoEldest:
 		return NoSigChainError{}
 	case SCStreamExists:

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -235,6 +235,8 @@ func ImportStatusAsError(s *keybase1.Status) error {
 		return LoginRequiredError{s.Desc}
 	case SCNoSession:
 		return NoSessionError{}
+	case SCKeyCorrupted:
+		return KeyCorruptedError{s.Desc}
 	case SCKeyInUse:
 		var fp *PGPFingerprint
 		if len(s.Desc) > 0 {
@@ -736,6 +738,17 @@ func (e SkipSecretPromptError) ToStatus() (s keybase1.Status) {
 	s.Code = SCInputCanceled
 	s.Name = "CANCELED"
 	s.Desc = "Input canceled due to skip secret prompt"
+	return
+}
+
+//=============================================================================
+
+func (c KeyCorruptedError) ToStatus() (s keybase1.Status) {
+	s.Code = SCKeyCorrupted
+	s.Name = "KEY_CORRUPTED"
+	if c.Msg != "" {
+		s.Desc = c.Msg
+	}
 	return
 }
 

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -38,6 +38,7 @@ const (
 	StatusCode_SCBadInvitationCode      StatusCode = 707
 	StatusCode_SCMissingResult          StatusCode = 801
 	StatusCode_SCKeyNotFound            StatusCode = 901
+	StatusCode_SCKeyCorrupted           StatusCode = 905
 	StatusCode_SCKeyInUse               StatusCode = 907
 	StatusCode_SCKeyBadGen              StatusCode = 913
 	StatusCode_SCKeyNoSecret            StatusCode = 914
@@ -130,6 +131,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCBadInvitationCode":      707,
 	"SCMissingResult":          801,
 	"SCKeyNotFound":            901,
+	"SCKeyCorrupted":           905,
 	"SCKeyInUse":               907,
 	"SCKeyBadGen":              913,
 	"SCKeyNoSecret":            914,
@@ -220,6 +222,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	707:  "SCBadInvitationCode",
 	801:  "SCMissingResult",
 	901:  "SCKeyNotFound",
+	905:  "SCKeyCorrupted",
 	907:  "SCKeyInUse",
 	913:  "SCKeyBadGen",
 	914:  "SCKeyNoSecret",

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -30,6 +30,7 @@ protocol constants {
     SCBadInvitationCode_707,
     SCMissingResult_801,
     SCKeyNotFound_901,
+    SCKeyCorrupted_905,
     SCKeyInUse_907,
     SCKeyBadGen_913,
     SCKeyNoSecret_914,

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -134,6 +134,7 @@ export const ConstantsStatusCode = {
   scbadinvitationcode: 707,
   scmissingresult: 801,
   sckeynotfound: 901,
+  sckeycorrupted: 905,
   sckeyinuse: 907,
   sckeybadgen: 913,
   sckeynosecret: 914,
@@ -5620,6 +5621,7 @@ export type StatusCode =
   | 707 // SCBadInvitationCode_707
   | 801 // SCMissingResult_801
   | 901 // SCKeyNotFound_901
+  | 905 // SCKeyCorrupted_905
   | 907 // SCKeyInUse_907
   | 913 // SCKeyBadGen_913
   | 914 // SCKeyNoSecret_914

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -34,6 +34,7 @@
         "SCBadInvitationCode_707",
         "SCMissingResult_801",
         "SCKeyNotFound_901",
+        "SCKeyCorrupted_905",
         "SCKeyInUse_907",
         "SCKeyBadGen_913",
         "SCKeyNoSecret_914",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -134,6 +134,7 @@ export const ConstantsStatusCode = {
   scbadinvitationcode: 707,
   scmissingresult: 801,
   sckeynotfound: 901,
+  sckeycorrupted: 905,
   sckeyinuse: 907,
   sckeybadgen: 913,
   sckeynosecret: 914,
@@ -5620,6 +5621,7 @@ export type StatusCode =
   | 707 // SCBadInvitationCode_707
   | 801 // SCMissingResult_801
   | 901 // SCKeyNotFound_901
+  | 905 // SCKeyCorrupted_905
   | 907 // SCKeyInUse_907
   | 913 // SCKeyBadGen_913
   | 914 // SCKeyNoSecret_914

--- a/shared/login/register/error/index.render.js
+++ b/shared/login/register/error/index.render.js
@@ -204,6 +204,23 @@ const renderError = (error: RPCError) => {
           <Text type="Body">Login Cancelled</Text>
         </Box>
       )
+    case ConstantsStatusCode.sckeycorrupted:
+      return (
+        <Box style={styleContent}>
+          <Text type="Body">{error.message}</Text>
+          <Text type="Body">
+            {' '}
+            We were able to generate a PGP signature but it was rejected by the server.
+            This often means that PGP key in your Keybase profile is expired or unusable.
+            You can update your key on
+            {' '}
+            <Text type="BodyPrimaryLink" onClick={() => openURL('https://keybase.io/')}>
+              keybase.io
+            </Text>
+            .
+          </Text>
+        </Box>
+      )
     default:
       return (
         <Box style={styleContent}>

--- a/shared/login/register/error/index.render.js
+++ b/shared/login/register/error/index.render.js
@@ -210,9 +210,9 @@ const renderError = (error: RPCError) => {
           <Text type="Body">{error.message}</Text>
           <Text type="Body">
             {' '}
-            We were able to generate a PGP signature but it was rejected by the server.
-            This often means that PGP key in your Keybase profile is expired or unusable.
-            You can update your key on
+            We were able to generate a PGP signature but it was rejected
+            by the server. This often means that this PGP key is expired
+            or unusable. You can update your key on
             {' '}
             <Text type="BodyPrimaryLink" onClick={() => openURL('https://keybase.io/')}>
               keybase.io


### PR DESCRIPTION
Tickets: CORE-5389 CORE-5418 CORE-5457

Mainly better error plumbing/reporting for various PGP actions.

Also fix for "Bad key found" when provisioning with stubbed pgp keys that are exported to server.

https://github.com/keybase/client/issues/7343
https://github.com/keybase/client/issues/7265