### PR TITLE
Windows: Give service spawned with ctl start its own console, so it w…

### DIFF
--- a/go/client/fork_server_windows.go
+++ b/go/client/fork_server_windows.go
@@ -43,9 +43,8 @@ func spawnServer(g *libkb.GlobalContext, cl libkb.CommandLine, forkType keybase1
 		files = append(files, nullfd, nullfd, nullfd)
 	}
 
-	// On 'nix this would include Setsid: true, which means
-	// the new process inherits the session/terminal from the parent.
-	// This is default on windows and need not be specified.
+	// Create the process with its own console, so it
+	// can outlive the parent process's console.
 	attr := syscall.ProcAttr{
 		Env:   os.Environ(),
 		Files: files,

--- a/go/client/fork_server_windows.go
+++ b/go/client/fork_server_windows.go
@@ -14,6 +14,8 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
+const flagCreateNewConsole = 0x00000010
+
 func spawnServer(g *libkb.GlobalContext, cl libkb.CommandLine, forkType keybase1.ForkType) (pid int, err error) {
 
 	var files []uintptr
@@ -47,6 +49,10 @@ func spawnServer(g *libkb.GlobalContext, cl libkb.CommandLine, forkType keybase1
 	attr := syscall.ProcAttr{
 		Env:   os.Environ(),
 		Files: files,
+		Sys: &syscall.SysProcAttr{
+			HideWindow:    true,
+			CreationFlags: flagCreateNewConsole,
+		},
 	}
 
 	cmd, args, err = makeServerCommandLine(g, cl, forkType)


### PR DESCRIPTION
…on't die if the client console is closed

Copied from runquiet/keybaserq, which doesn't have this problem

Thank you @zapu for running the Windows client and finding this.