### PR TITLE
use UIDs, not usernames, for all internal teams machinery

### DIFF
--- a/go/client/cmd_team_list_memberships.go
+++ b/go/client/cmd_team_list_memberships.go
@@ -62,7 +62,7 @@ func (c *CmdTeamListMemberships) Run() error {
 	return c.output(members)
 }
 
-func (c *CmdTeamListMemberships) output(members keybase1.TeamMembers) error {
+func (c *CmdTeamListMemberships) output(members keybase1.TeamMembersUsernames) error {
 	if c.json {
 		return c.outputJSON(members)
 	}
@@ -70,7 +70,7 @@ func (c *CmdTeamListMemberships) output(members keybase1.TeamMembers) error {
 	return c.outputTerminal(members)
 }
 
-func (c *CmdTeamListMemberships) outputJSON(members keybase1.TeamMembers) error {
+func (c *CmdTeamListMemberships) outputJSON(members keybase1.TeamMembersUsernames) error {
 	b, err := json.MarshalIndent(members, "", "    ")
 	if err != nil {
 		return err
@@ -80,7 +80,7 @@ func (c *CmdTeamListMemberships) outputJSON(members keybase1.TeamMembers) error 
 	return err
 }
 
-func (c *CmdTeamListMemberships) outputTerminal(members keybase1.TeamMembers) error {
+func (c *CmdTeamListMemberships) outputTerminal(members keybase1.TeamMembersUsernames) error {
 	c.outputRole("owner", members.Owners)
 	c.outputRole("admin", members.Admins)
 	c.outputRole("writer", members.Writers)

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -43,6 +43,10 @@ func (fu *FakeUser) NewSecretUI() *libkb.TestSecretUI {
 	return &libkb.TestSecretUI{Passphrase: fu.Passphrase}
 }
 
+func (fu *FakeUser) GetUID() keybase1.UID {
+	return libkb.UsernameToUID(fu.Username)
+}
+
 func (fu *FakeUser) Login(g *libkb.GlobalContext) error {
 	ctx := &engine.Context{
 		ProvisionUI: &testProvisionUI{},

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -113,6 +113,13 @@ func (u *User) GetCurrentEldestSeqno() keybase1.Seqno {
 	return u.sigChain().currentSubchainStart
 }
 
+func (u *User) ToUserVersion() keybase1.UserVersion {
+	return keybase1.UserVersion{
+		Uid:         u.GetUID(),
+		EldestSeqno: u.GetCurrentEldestSeqno(),
+	}
+}
+
 func (u *User) IsNewerThan(v *User) (bool, error) {
 	var idvU, idvV int64
 	var err error
@@ -791,20 +798,6 @@ func (u User) PartialCopy() *User {
 		ret.keyFamily = u.keyFamily.ShallowCopy()
 	}
 	return ret
-}
-
-// TODO: This and keybase1.UserVersion should be reconciled
-type NameWithEldestSeqno string
-
-func MakeNameWithEldestSeqno(name string, seqno keybase1.Seqno) (NameWithEldestSeqno, error) {
-	if seqno < 1 {
-		return "", EldestSeqnoMissingError{}
-	} else if seqno == 1 {
-		// For users that have never reset, we use their name unmodified.
-		return NameWithEldestSeqno(name), nil
-	} else {
-		return NameWithEldestSeqno(fmt.Sprintf("%s%%%d", name, seqno)), nil
-	}
 }
 
 func ValidateNormalizedUsername(username string) (NormalizedUsername, error) {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1273,9 +1273,9 @@ func UPAKFromUPKV2AI(uV2 UserPlusKeysV2AllIncarnations) UserPlusAllKeys {
 // "foo" for seqno 1 or "foo%6"
 func (u UserVersion) PercentForm() string {
 	if u.EldestSeqno == 1 {
-		return u.Username
+		return string(u.Uid)
 	}
-	return fmt.Sprintf("%s%%%d", u.Username, u.EldestSeqno)
+	return fmt.Sprintf("%s%%%d", u.Uid, u.EldestSeqno)
 }
 
 func (k CryptKey) Material() Bytes32 {
@@ -1294,21 +1294,21 @@ func (k TeamApplicationKey) Generation() int {
 	return k.KeyGeneration
 }
 
-func (t TeamMembers) AllUsernames() []string {
-	m := make(map[string]bool)
+func (t TeamMembers) AllUIDs() []UID {
+	m := make(map[UID]bool)
 	for _, u := range t.Owners {
-		m[u] = true
+		m[u.Uid] = true
 	}
 	for _, u := range t.Admins {
-		m[u] = true
+		m[u.Uid] = true
 	}
 	for _, u := range t.Writers {
-		m[u] = true
+		m[u.Uid] = true
 	}
 	for _, u := range t.Readers {
-		m[u] = true
+		m[u.Uid] = true
 	}
-	var all []string
+	var all []UID
 	for u := range m {
 		all = append(all, u)
 	}

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -128,14 +128,58 @@ func (o PerTeamKey) DeepCopy() PerTeamKey {
 }
 
 type TeamMembers struct {
+	Owners  []UserVersion `codec:"owners" json:"owners"`
+	Admins  []UserVersion `codec:"admins" json:"admins"`
+	Writers []UserVersion `codec:"writers" json:"writers"`
+	Readers []UserVersion `codec:"readers" json:"readers"`
+}
+
+func (o TeamMembers) DeepCopy() TeamMembers {
+	return TeamMembers{
+		Owners: (func(x []UserVersion) []UserVersion {
+			var ret []UserVersion
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Owners),
+		Admins: (func(x []UserVersion) []UserVersion {
+			var ret []UserVersion
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Admins),
+		Writers: (func(x []UserVersion) []UserVersion {
+			var ret []UserVersion
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Writers),
+		Readers: (func(x []UserVersion) []UserVersion {
+			var ret []UserVersion
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Readers),
+	}
+}
+
+type TeamMembersUsernames struct {
 	Owners  []string `codec:"owners" json:"owners"`
 	Admins  []string `codec:"admins" json:"admins"`
 	Writers []string `codec:"writers" json:"writers"`
 	Readers []string `codec:"readers" json:"readers"`
 }
 
-func (o TeamMembers) DeepCopy() TeamMembers {
-	return TeamMembers{
+func (o TeamMembersUsernames) DeepCopy() TeamMembersUsernames {
+	return TeamMembersUsernames{
 		Owners: (func(x []string) []string {
 			var ret []string
 			for _, v := range x {
@@ -172,51 +216,51 @@ func (o TeamMembers) DeepCopy() TeamMembers {
 }
 
 type TeamChangeReq struct {
-	Owners  []string `codec:"owners" json:"owners"`
-	Admins  []string `codec:"admins" json:"admins"`
-	Writers []string `codec:"writers" json:"writers"`
-	Readers []string `codec:"readers" json:"readers"`
-	None    []string `codec:"none" json:"none"`
+	Owners  []UID `codec:"owners" json:"owners"`
+	Admins  []UID `codec:"admins" json:"admins"`
+	Writers []UID `codec:"writers" json:"writers"`
+	Readers []UID `codec:"readers" json:"readers"`
+	None    []UID `codec:"none" json:"none"`
 }
 
 func (o TeamChangeReq) DeepCopy() TeamChangeReq {
 	return TeamChangeReq{
-		Owners: (func(x []string) []string {
-			var ret []string
+		Owners: (func(x []UID) []UID {
+			var ret []UID
 			for _, v := range x {
-				vCopy := v
+				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret
 		})(o.Owners),
-		Admins: (func(x []string) []string {
-			var ret []string
+		Admins: (func(x []UID) []UID {
+			var ret []UID
 			for _, v := range x {
-				vCopy := v
+				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret
 		})(o.Admins),
-		Writers: (func(x []string) []string {
-			var ret []string
+		Writers: (func(x []UID) []UID {
+			var ret []UID
 			for _, v := range x {
-				vCopy := v
+				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret
 		})(o.Writers),
-		Readers: (func(x []string) []string {
-			var ret []string
+		Readers: (func(x []UID) []UID {
+			var ret []UID
 			for _, v := range x {
-				vCopy := v
+				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret
 		})(o.Readers),
-		None: (func(x []string) []string {
-			var ret []string
+		None: (func(x []UID) []UID {
+			var ret []UID
 			for _, v := range x {
-				vCopy := v
+				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret
@@ -225,13 +269,13 @@ func (o TeamChangeReq) DeepCopy() TeamChangeReq {
 }
 
 type UserVersion struct {
-	Username    string `codec:"username" json:"username"`
-	EldestSeqno Seqno  `codec:"eldestSeqno" json:"eldestSeqno"`
+	Uid         UID   `codec:"uid" json:"uid"`
+	EldestSeqno Seqno `codec:"eldestSeqno" json:"eldestSeqno"`
 }
 
 func (o UserVersion) DeepCopy() UserVersion {
 	return UserVersion{
-		Username:    o.Username,
+		Uid:         o.Uid.DeepCopy(),
 		EldestSeqno: o.EldestSeqno.DeepCopy(),
 	}
 }
@@ -416,7 +460,7 @@ func (o TeamEditMemberArg) DeepCopy() TeamEditMemberArg {
 
 type TeamsInterface interface {
 	TeamCreate(context.Context, TeamCreateArg) error
-	TeamGet(context.Context, TeamGetArg) (TeamMembers, error)
+	TeamGet(context.Context, TeamGetArg) (TeamMembersUsernames, error)
 	TeamChangeMembership(context.Context, TeamChangeMembershipArg) error
 	TeamAddMember(context.Context, TeamAddMemberArg) error
 	TeamRemoveMember(context.Context, TeamRemoveMemberArg) error
@@ -536,7 +580,7 @@ func (c TeamsClient) TeamCreate(ctx context.Context, __arg TeamCreateArg) (err e
 	return
 }
 
-func (c TeamsClient) TeamGet(ctx context.Context, __arg TeamGetArg) (res TeamMembers, err error) {
+func (c TeamsClient) TeamGet(ctx context.Context, __arg TeamGetArg) (res TeamMembersUsernames, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamGet", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -36,7 +36,7 @@ func (h *TeamsHandler) TeamCreate(ctx context.Context, arg keybase1.TeamCreateAr
 	return teams.CreateRootTeam(ctx, h.G().ExternalG(), arg.Name)
 }
 
-func (h *TeamsHandler) TeamGet(ctx context.Context, arg keybase1.TeamGetArg) (keybase1.TeamMembers, error) {
+func (h *TeamsHandler) TeamGet(ctx context.Context, arg keybase1.TeamGetArg) (keybase1.TeamMembersUsernames, error) {
 	return teams.Members(ctx, h.G().ExternalG(), arg.Name)
 }
 

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -15,7 +15,7 @@ type SCTeamID string
 // A (username, seqno) pair.
 // The username is adorned with "%n" at the end
 // where n is the seqno IF the seqno is not 1.
-type SCTeamMember string
+type SCTeamMember keybase1.UserVersion
 
 type SCTeamSection struct {
 	ID         SCTeamID       `json:"id"`
@@ -49,6 +49,19 @@ type SCPerTeamKey struct {
 	EncKID     keybase1.KID `json:"encryption_kid"`
 	SigKID     keybase1.KID `json:"signing_kid"`
 	ReverseSig string       `json:"reverse_sig"`
+}
+
+func (s *SCTeamMember) UnmarshalJSON(b []byte) (err error) {
+	uv, err := ParseUserVersion(keybase1.Unquote(b))
+	if err != nil {
+		return err
+	}
+	*s = SCTeamMember(uv)
+	return nil
+}
+
+func (sc *SCTeamMember) MarshalJSON() (b []byte, err error) {
+	return keybase1.Quote(keybase1.UserVersion(*sc).PercentForm()), nil
 }
 
 // Non-team-specific stuff below the line

--- a/go/teams/chain_test.go
+++ b/go/teams/chain_test.go
@@ -2,7 +2,6 @@ package teams
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -15,13 +14,14 @@ import (
 )
 
 // A chain with a stubbed link
+// Output of `rotate_root_team_key` test in team_integration.iced
 const teamChain1 = `
-{"status":{"code":0,"name":"OK"},"chain":[{"seqno":1,"sig":"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEga6ttFJBQ4zcepPjjJNThT5zdiQqc8iLI0pFhVp0A57UKp3BheWxvYWTEJ5UCAcDEIOG5uUfGdP6m/3eDgDUVxssa2ismMBjbUuf0Sm/bfjlpIaNzaWfEQBOwbBmriWBOkf2FPZUcvi23R2fzLcmRQa/xb9Yf1u7C9FW+d/SMhD8X3hlS8Cd3Nf6AAzzkkTcXufyRnJhcIweoc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==","payload_json":"{\"body\":{\"key\":{\"eldest_kid\":\"01206bab6d149050e3371ea4f8e324d4e14f9cdd890a9cf222c8d29161569d00e7b50a\",\"host\":\"keybase.io\",\"kid\":\"01206bab6d149050e3371ea4f8e324d4e14f9cdd890a9cf222c8d29161569d00e7b50a\",\"uid\":\"e552cbc9f6951c2ea414cf098adbfa19\",\"username\":\"d_08827f78\"},\"team\":{\"id\":\"70b0e55838d4a3da62ef40b207e57b24\",\"members\":{\"admin\":[\"c_61002771\"],\"owner\":[\"d_08827f78\"],\"reader\":[\"a_1585f13b\"],\"writer\":[\"b_4a45388c\"]},\"name\":\"t_79351477\",\"per_team_key\":{\"encryption_kid\":\"012155545f16950e7fed04076b9e2f51bd53cd72e4abd1845c261ef9dcb581df67500a\",\"generation\":1,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgzXJbQHV7+E7N263CerYXxSdZuCU/wVjc1Sz/u94J92wKp3BheWxvYWTFAxx7ImJvZHkiOnsia2V5Ijp7ImVsZGVzdF9raWQiOiIwMTIwNmJhYjZkMTQ5MDUwZTMzNzFlYTRmOGUzMjRkNGUxNGY5Y2RkODkwYTljZjIyMmM4ZDI5MTYxNTY5ZDAwZTdiNTBhIiwiaG9zdCI6ImtleWJhc2UuaW8iLCJraWQiOiIwMTIwNmJhYjZkMTQ5MDUwZTMzNzFlYTRmOGUzMjRkNGUxNGY5Y2RkODkwYTljZjIyMmM4ZDI5MTYxNTY5ZDAwZTdiNTBhIiwidWlkIjoiZTU1MmNiYzlmNjk1MWMyZWE0MTRjZjA5OGFkYmZhMTkiLCJ1c2VybmFtZSI6ImRfMDg4MjdmNzgifSwidGVhbSI6eyJpZCI6IjcwYjBlNTU4MzhkNGEzZGE2MmVmNDBiMjA3ZTU3YjI0IiwibWVtYmVycyI6eyJhZG1pbiI6WyJjXzYxMDAyNzcxIl0sIm93bmVyIjpbImRfMDg4MjdmNzgiXSwicmVhZGVyIjpbImFfMTU4NWYxM2IiXSwid3JpdGVyIjpbImJfNGE0NTM4OGMiXX0sIm5hbWUiOiJ0Xzc5MzUxNDc3IiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMTU1NTQ1ZjE2OTUwZTdmZWQwNDA3NmI5ZTJmNTFiZDUzY2Q3MmU0YWJkMTg0NWMyNjFlZjlkY2I1ODFkZjY3NTAwYSIsImdlbmVyYXRpb24iOjEsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBjZDcyNWI0MDc1N2JmODRlY2RkYmFkYzI3YWI2MTdjNTI3NTliODI1M2ZjMTU4ZGNkNTJjZmZiYmRlMDlmNzZjMGEifX0sInR5cGUiOiJ0ZWFtLnJvb3QiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE0OTUyMjkwMjYsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJwcmV2IjpudWxsLCJzZXFfdHlwZSI6Mywic2Vxbm8iOjEsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RAwSxEArnauq5CfnQkf1pqJ3FPN7ebCTzcLex1xNBP/Kqp222xXaW9ZxcjeCbJqSJzFkzDa+emd1tSLreTK8rcCahzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B\",\"signing_kid\":\"0120cd725b40757bf84ecddbadc27ab617c52759b8253fc158dcd52cffbbde09f76c0a\"}},\"type\":\"team.root\",\"version\":2},\"ctime\":1495229026,\"expire_in\":157680000,\"prev\":null,\"seq_type\":3,\"seqno\":1,\"tag\":\"signature\"}","version":2,"uid":"e552cbc9f6951c2ea414cf098adbfa19"},{"seqno":2,"sig":"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEga6ttFJBQ4zcepPjjJNThT5zdiQqc8iLI0pFhVp0A57UKp3BheWxvYWTESJUCAsQgA5+oRvY4N+bV0j/Vb2tX65GOSG80ym8mRTqm/HVIj8vEIGFT/kXt6yq/sGf3MYjAFxl4ltZBh3xcC87MRX7kcVXkIqNzaWfEQJoKuDq+l0bapy47n4V+40/GmrihsZMDXk9aenmvrmqqI4sePcVpA6yE1H0Rhbdm1E5BPkqpODbaLxp9OOIQeAqoc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==","version":2,"uid":"e552cbc9f6951c2ea414cf098adbfa19"},{"seqno":3,"sig":"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg8E2SNuLyUHJAPCht43Htz5qwBmq084vUp6FaQc/BRIQKp3BheWxvYWTESJUCA8QgFAAdOlIqTvIFnNfsExgbDI1/BxWVS0w/bpB/DyscOCjEIDRb+fKIthdc8xHtXmpfK/2aMjipgIq9n+6IN2+Y+pWBJKNzaWfEQFypth82iu+gAkeo15m9vpobO1+gA+Kf/sE0mnLXkWoDTr17LaYwljebkj/VlqDP1NIAIRgMSeRfzVNaAPS4Pguoc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==","payload_json":"{\"body\":{\"key\":{\"eldest_kid\":\"0120f04d9236e2f25072403c286de371edcf9ab0066ab4f38bd4a7a15a41cfc144840a\",\"host\":\"keybase.io\",\"kid\":\"0120f04d9236e2f25072403c286de371edcf9ab0066ab4f38bd4a7a15a41cfc144840a\",\"uid\":\"130ea880070624ba5e0f0a6032cf0f19\",\"username\":\"b_4a45388c\"},\"team\":{\"id\":\"70b0e55838d4a3da62ef40b207e57b24\",\"per_team_key\":{\"encryption_kid\":\"0121015351e68bc98d256c190fbca5608c2b04a36d15f5e95896385f1b5b0c6dc1260a\",\"generation\":2,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg8Ug8hRXQisnsuKku7LoXzDXjEystpUgatdpjTaJ+jQ4Kp3BheWxvYWTFAuJ7ImJvZHkiOnsia2V5Ijp7ImVsZGVzdF9raWQiOiIwMTIwZjA0ZDkyMzZlMmYyNTA3MjQwM2MyODZkZTM3MWVkY2Y5YWIwMDY2YWI0ZjM4YmQ0YTdhMTVhNDFjZmMxNDQ4NDBhIiwiaG9zdCI6ImtleWJhc2UuaW8iLCJraWQiOiIwMTIwZjA0ZDkyMzZlMmYyNTA3MjQwM2MyODZkZTM3MWVkY2Y5YWIwMDY2YWI0ZjM4YmQ0YTdhMTVhNDFjZmMxNDQ4NDBhIiwidWlkIjoiMTMwZWE4ODAwNzA2MjRiYTVlMGYwYTYwMzJjZjBmMTkiLCJ1c2VybmFtZSI6ImJfNGE0NTM4OGMifSwidGVhbSI6eyJpZCI6IjcwYjBlNTU4MzhkNGEzZGE2MmVmNDBiMjA3ZTU3YjI0IiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMTAxNTM1MWU2OGJjOThkMjU2YzE5MGZiY2E1NjA4YzJiMDRhMzZkMTVmNWU5NTg5NjM4NWYxYjViMGM2ZGMxMjYwYSIsImdlbmVyYXRpb24iOjIsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBmMTQ4M2M4NTE1ZDA4YWM5ZWNiOGE5MmVlY2JhMTdjYzM1ZTMxMzJiMmRhNTQ4MWFiNWRhNjM0ZGEyN2U4ZDBlMGEifX0sInR5cGUiOiJ0ZWFtLnJvdGF0ZV9rZXkiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE0OTUyMjkwMjksImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJwcmV2IjoiMTQwMDFkM2E1MjJhNGVmMjA1OWNkN2VjMTMxODFiMGM4ZDdmMDcxNTk1NGI0YzNmNmU5MDdmMGYyYjFjMzgyOCIsInNlcV90eXBlIjozLCJzZXFubyI6MywidGFnIjoic2lnbmF0dXJlIn2jc2lnxEDBThqkZK4icWICDx/RLh7+KxANdojKETZX3Jl2KYG12PqDG7x9fZFbRVPSzOzY3UzPleQ0eUPAfIU4+DICnCIBqHNpZ190eXBlIKN0YWfNAgKndmVyc2lvbgE=\",\"signing_kid\":\"0120f1483c8515d08ac9ecb8a92eecba17cc35e3132b2da5481ab5da634da27e8d0e0a\"}},\"type\":\"team.rotate_key\",\"version\":2},\"ctime\":1495229029,\"expire_in\":157680000,\"prev\":\"14001d3a522a4ef2059cd7ec13181b0c8d7f0715954b4c3f6e907f0f2b1c3828\",\"seq_type\":3,\"seqno\":3,\"tag\":\"signature\"}","version":2,"uid":"130ea880070624ba5e0f0a6032cf0f19"}],"box":{"nonce":"pQSb5q+bdU8FALOApgtwaPrRgN8AAAAD","sender_kid":"01211520f0f37e835e8d98b4d19226a2632c0335b4cdc17273274f17fbdc2393f8240a","generation":2,"ctext":"0Tmgo0rWAYfug+X8V/EulDjGuYZeX5KowDifynQifDUjtDgZW21QSRHil+y4T/88","per_user_key_seqno":3},"prevs":{"2":"9301c418a5049be6af9b754f0500b380a60b7068fad180df00000000c43044eb2fdf163454eefb7caef5ed27c4e849d2ea2add23c4804247d1d3adb42997403a0d7aeb602f978d9c11338549ef9f"},"csrf_token":"lgHZIDEzMGVhODgwMDcwNjI0YmE1ZTBmMGE2MDMyY2YwZjE5zlkfYl7OAAFRgMDEIA/v+ErxmQdePfcGB8XrTKXEnrAZ7DUCr/tYuHWo3igE"}
+{"status":{"code":0,"name":"OK"},"chain":[{"seqno":1,"sig":"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgewPUgFaXvAjHWBC4BnTzSdMT3izYy89VX+4rjh2NlMkKp3BheWxvYWTEJ5UCAcDEIL95/rs8CFK3VSp4W4nYmxAdatMKJf+BB1xWH3eB/K7vIaNzaWfEQAez3e1PlPXJUg2vITA8/ZKeIKBp67DQQaNSKchzpPaMN8BFtvlY2qQStmk5Jn9mcN7m5x7xGBvRLksLkz4fOQSoc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==","payload_json":"{\"body\":{\"key\":{\"eldest_kid\":\"01207b03d4805697bc08c75810b80674f349d313de2cd8cbcf555fee2b8e1d8d94c90a\",\"host\":\"keybase.io\",\"kid\":\"01207b03d4805697bc08c75810b80674f349d313de2cd8cbcf555fee2b8e1d8d94c90a\",\"uid\":\"5bf82de4331b50b32cbbcfeadc2f3119\",\"username\":\"d_af8eac8c\"},\"team\":{\"id\":\"64d27654bef64bdb3d78d84f186c4224\",\"members\":{\"admin\":[\"53e315afb4b419931b0a6a1eaa09e219\"],\"owner\":[\"5bf82de4331b50b32cbbcfeadc2f3119\"],\"reader\":[\"13e18aeafa4df6c94bf6af7d7bb98d19\"],\"writer\":[\"4bf92804c02fb7d2cd36a6d420d6f619\"]},\"name\":\"t_9d6d1e37\",\"per_team_key\":{\"encryption_kid\":\"0121bf2085a5f1b4f8e0ad5095fb29ae65f7e52a4fa5d9bc90757515c7dd860767020a\",\"generation\":1,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgYr3LeU54Mu4AdjeZ3bG+7c0yEL51p2dfHxneCIxTVPEKp3BheWxvYWTFA3R7ImJvZHkiOnsia2V5Ijp7ImVsZGVzdF9raWQiOiIwMTIwN2IwM2Q0ODA1Njk3YmMwOGM3NTgxMGI4MDY3NGYzNDlkMzEzZGUyY2Q4Y2JjZjU1NWZlZTJiOGUxZDhkOTRjOTBhIiwiaG9zdCI6ImtleWJhc2UuaW8iLCJraWQiOiIwMTIwN2IwM2Q0ODA1Njk3YmMwOGM3NTgxMGI4MDY3NGYzNDlkMzEzZGUyY2Q4Y2JjZjU1NWZlZTJiOGUxZDhkOTRjOTBhIiwidWlkIjoiNWJmODJkZTQzMzFiNTBiMzJjYmJjZmVhZGMyZjMxMTkiLCJ1c2VybmFtZSI6ImRfYWY4ZWFjOGMifSwidGVhbSI6eyJpZCI6IjY0ZDI3NjU0YmVmNjRiZGIzZDc4ZDg0ZjE4NmM0MjI0IiwibWVtYmVycyI6eyJhZG1pbiI6WyI1M2UzMTVhZmI0YjQxOTkzMWIwYTZhMWVhYTA5ZTIxOSJdLCJvd25lciI6WyI1YmY4MmRlNDMzMWI1MGIzMmNiYmNmZWFkYzJmMzExOSJdLCJyZWFkZXIiOlsiMTNlMThhZWFmYTRkZjZjOTRiZjZhZjdkN2JiOThkMTkiXSwid3JpdGVyIjpbIjRiZjkyODA0YzAyZmI3ZDJjZDM2YTZkNDIwZDZmNjE5Il19LCJuYW1lIjoidF85ZDZkMWUzNyIsInBlcl90ZWFtX2tleSI6eyJlbmNyeXB0aW9uX2tpZCI6IjAxMjFiZjIwODVhNWYxYjRmOGUwYWQ1MDk1ZmIyOWFlNjVmN2U1MmE0ZmE1ZDliYzkwNzU3NTE1YzdkZDg2MDc2NzAyMGEiLCJnZW5lcmF0aW9uIjoxLCJyZXZlcnNlX3NpZyI6bnVsbCwic2lnbmluZ19raWQiOiIwMTIwNjJiZGNiNzk0ZTc4MzJlZTAwNzYzNzk5ZGRiMWJlZWRjZDMyMTBiZTc1YTc2NzVmMWYxOWRlMDg4YzUzNTRmMTBhIn19LCJ0eXBlIjoidGVhbS5yb290IiwidmVyc2lvbiI6Mn0sImN0aW1lIjoxNDk3MjM4NTMyLCJleHBpcmVfaW4iOjE1NzY4MDAwMCwicHJldiI6bnVsbCwic2VxX3R5cGUiOjMsInNlcW5vIjoxLCJ0YWciOiJzaWduYXR1cmUifaNzaWfEQLrzfIl+c/rDlaTL9hW5emLJSJOoyhWw0gKnShh4v5FzX0tunexOId0U87etEgT1P+uJ6KYCSQTh8ZdCmDWJ7Q6oc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==\",\"signing_kid\":\"012062bdcb794e7832ee00763799ddb1beedcd3210be75a7675f1f19de088c5354f10a\"}},\"type\":\"team.root\",\"version\":2},\"ctime\":1497238532,\"expire_in\":157680000,\"prev\":null,\"seq_type\":3,\"seqno\":1,\"tag\":\"signature\"}","version":2,"uid":"5bf82de4331b50b32cbbcfeadc2f3119"},{"seqno":2,"sig":"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgewPUgFaXvAjHWBC4BnTzSdMT3izYy89VX+4rjh2NlMkKp3BheWxvYWTESJUCAsQgYst2GtNGo9KL4e7RB8NVSKLdb63pIZo4WRhB9i1YbP7EICPQdqUmdeZU/gRJXd5+gUP8HSxtn4xMeZ7lssS3Pm+8IqNzaWfEQHkBp46skYqz62rMjoxZGq4HVjhJHCS4zYjmrMDhQQrl3fu76HeRqTeuLWCh0741OyvwXTjGNY7oCJiT5YvZSw+oc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==","version":2,"uid":"5bf82de4331b50b32cbbcfeadc2f3119"},{"seqno":3,"sig":"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgTqfhtGmmOGhixMw9YsHIrmrk0txnZBM4A/hqS1gWbzUKp3BheWxvYWTESJUCA8Qgg2TPT1Vbq+1yiOlYEFHqQYcccB4W6bevJFRK1jc1ov7EIHbADJMePlGQ1+JCJe9AQiftKeKwAIKLYLC1pPvcWyZmJKNzaWfEQPNVaBljU0mSO/27FfQDZiNaNYfbZ+lG1QF2WaOoUBgtChMxEek+3jKWTGkfWSvjL+MynM8ve+egRteBY8jhoQioc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==","payload_json":"{\"body\":{\"key\":{\"eldest_kid\":\"01204ea7e1b469a6386862c4cc3d62c1c8ae6ae4d2dc6764133803f86a4b58166f350a\",\"host\":\"keybase.io\",\"kid\":\"01204ea7e1b469a6386862c4cc3d62c1c8ae6ae4d2dc6764133803f86a4b58166f350a\",\"uid\":\"4bf92804c02fb7d2cd36a6d420d6f619\",\"username\":\"b_7804991a\"},\"team\":{\"id\":\"64d27654bef64bdb3d78d84f186c4224\",\"per_team_key\":{\"encryption_kid\":\"0121e2511cbfb0418187a8e19183a1cd92637bc83fe116d1eb8984f52394495b5f120a\",\"generation\":2,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEggC9V7V4U9hxzCHG16Z1jcFT/f1ugwbLMUrFU47r4CgAKp3BheWxvYWTFAuJ7ImJvZHkiOnsia2V5Ijp7ImVsZGVzdF9raWQiOiIwMTIwNGVhN2UxYjQ2OWE2Mzg2ODYyYzRjYzNkNjJjMWM4YWU2YWU0ZDJkYzY3NjQxMzM4MDNmODZhNGI1ODE2NmYzNTBhIiwiaG9zdCI6ImtleWJhc2UuaW8iLCJraWQiOiIwMTIwNGVhN2UxYjQ2OWE2Mzg2ODYyYzRjYzNkNjJjMWM4YWU2YWU0ZDJkYzY3NjQxMzM4MDNmODZhNGI1ODE2NmYzNTBhIiwidWlkIjoiNGJmOTI4MDRjMDJmYjdkMmNkMzZhNmQ0MjBkNmY2MTkiLCJ1c2VybmFtZSI6ImJfNzgwNDk5MWEifSwidGVhbSI6eyJpZCI6IjY0ZDI3NjU0YmVmNjRiZGIzZDc4ZDg0ZjE4NmM0MjI0IiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMWUyNTExY2JmYjA0MTgxODdhOGUxOTE4M2ExY2Q5MjYzN2JjODNmZTExNmQxZWI4OTg0ZjUyMzk0NDk1YjVmMTIwYSIsImdlbmVyYXRpb24iOjIsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjA4MDJmNTVlZDVlMTRmNjFjNzMwODcxYjVlOTlkNjM3MDU0ZmY3ZjViYTBjMWIyY2M1MmIxNTRlM2JhZjgwYTAwMGEifX0sInR5cGUiOiJ0ZWFtLnJvdGF0ZV9rZXkiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE0OTcyMzg1MzUsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJwcmV2IjoiODM2NGNmNGY1NTViYWJlZDcyODhlOTU4MTA1MWVhNDE4NzFjNzAxZTE2ZTliN2FmMjQ1NDRhZDYzNzM1YTJmZSIsInNlcV90eXBlIjozLCJzZXFubyI6MywidGFnIjoic2lnbmF0dXJlIn2jc2lnxECfcafw2CoIzFKtmN2nt3A28wYS7clrmEZvjLEziNmoWy525gvyxJEHiENfxQ5kt9Uxb0cCDChlktHvz23my6QAqHNpZ190eXBlIKN0YWfNAgKndmVyc2lvbgE=\",\"signing_kid\":\"0120802f55ed5e14f61c730871b5e99d637054ff7f5ba0c1b2cc52b154e3baf80a000a\"}},\"type\":\"team.rotate_key\",\"version\":2},\"ctime\":1497238535,\"expire_in\":157680000,\"prev\":\"8364cf4f555babed7288e9581051ea41871c701e16e9b7af24544ad63735a2fe\",\"seq_type\":3,\"seqno\":3,\"tag\":\"signature\"}","version":2,"uid":"4bf92804c02fb7d2cd36a6d420d6f619"}],"box":{"nonce":"5VPBQypqrcLiuW1i6fVROxmuBQUAAAAD","sender_kid":"012112f29aa42e14053a057a790a198a5b7fb25512c8458b4b32d7bbd04c0d52093b0a","generation":2,"ctext":"HgbVY5cswOvxu9PMOP75NdYqftGtgenRABKtjHgervLK6/oaF1vTW2U9vt+0JixD","per_user_key_seqno":3},"prevs":{"2":"9301c418e553c1432a6aadc2e2b96d62e9f5513b19ae050500000000c4304e966d60d2ccee5433fa1cf08f11de02b0d4e749798925d925896edc6c0b12288a975db3b29f6efed165b38775b64d42"},"reader_key_masks":[{"mask":"gKBbFV3J3L0j/gFtruyCKpZHf7Y837Q2ezFtrAK6xIE=","application":1,"generation":1},{"mask":"ZYdXI0jfXscYwgXO3J3A1T9YRJ+GlkNvtEZJ4nvmKbk=","application":2,"generation":1},{"mask":"Dq4iXhUs9BxX1DHYP7wE/vFOpG4SABwzHZRQeavnKjM=","application":1,"generation":2},{"mask":"AEedcZX7wZyvyAOyc9EQINr3MyqbKMKXLfZVHHZqz7U=","application":2,"generation":2}],"id":"64d27654bef64bdb3d78d84f186c4224","name":{"parts":["t_9d6d1e37"]},"csrf_token":"lgHZIDRiZjkyODA0YzAyZmI3ZDJjZDM2YTZkNDIwZDZmNjE5zlk+C/7OAAFRgMDEIFLYZSdoOin9JRKgyjN8z/JMVQ4Az3O1ZcUyT43DTlXV"}
 `
 
-// A chain with a change_membership link
+// A chain with a change_membership link, generated via: `change_membership_promote_to_writer_happy_path`
 const teamChain2 = `
-{"status":{"code":0,"name":"OK"},"chain":[{"uid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa19","seqno":1,"sig":"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgv8ORwb4IEcmx7hmp41snRd/lzamUgH3mDM/aZHzDQzIKp3BheWxvYWTEJ5UCAcDEIPdH/BvDT4wMchkyNbjL+CX30c+BcbpVJuzya06WYZ00IaNzaWfEQN/H6KW8RVFBQ9VRSwdY5b0bGD24sUOXeMama3A0iQVInX3zumc8ga7OkiFebOu/d23fci+PfcbJ8SBMQenMYQuoc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==","payload_json":"{\"body\":{\"key\":{\"eldest_kid\":\"0120bfc391c1be0811c9b1ee19a9e35b2745dfe5cda994807de60ccfda647cc343320a\",\"host\":\"keybase.io\",\"kid\":\"0120bfc391c1be0811c9b1ee19a9e35b2745dfe5cda994807de60ccfda647cc343320a\",\"uid\":\"13172150f9b0885abf4b576fdcf59019\",\"username\":\"d_b2809af7\"},\"team\":{\"id\":\"79715edef9320c851e50d44d52f4b324\",\"members\":{\"admin\":[\"c_ac088470\"],\"owner\":[\"d_b2809af7\"],\"reader\":[\"a_f0259e08\"],\"writer\":[\"b_ee111192\"]},\"name\":\"t_913dfbc3\",\"per_team_key\":{\"encryption_kid\":\"01212337961af637143545aa512b63393cd92c588d3e153fbd8c4c5c923c76cc410d0a\",\"generation\":1,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgjHQy6NZaSqWeZm5V7oVqj6QaIL3D7bW7B6t8rEojChcKp3BheWxvYWTFAxx7ImJvZHkiOnsia2V5Ijp7ImVsZGVzdF9raWQiOiIwMTIwYmZjMzkxYzFiZTA4MTFjOWIxZWUxOWE5ZTM1YjI3NDVkZmU1Y2RhOTk0ODA3ZGU2MGNjZmRhNjQ3Y2MzNDMzMjBhIiwiaG9zdCI6ImtleWJhc2UuaW8iLCJraWQiOiIwMTIwYmZjMzkxYzFiZTA4MTFjOWIxZWUxOWE5ZTM1YjI3NDVkZmU1Y2RhOTk0ODA3ZGU2MGNjZmRhNjQ3Y2MzNDMzMjBhIiwidWlkIjoiMTMxNzIxNTBmOWIwODg1YWJmNGI1NzZmZGNmNTkwMTkiLCJ1c2VybmFtZSI6ImRfYjI4MDlhZjcifSwidGVhbSI6eyJpZCI6Ijc5NzE1ZWRlZjkzMjBjODUxZTUwZDQ0ZDUyZjRiMzI0IiwibWVtYmVycyI6eyJhZG1pbiI6WyJjX2FjMDg4NDcwIl0sIm93bmVyIjpbImRfYjI4MDlhZjciXSwicmVhZGVyIjpbImFfZjAyNTllMDgiXSwid3JpdGVyIjpbImJfZWUxMTExOTIiXX0sIm5hbWUiOiJ0XzkxM2RmYmMzIiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMTIzMzc5NjFhZjYzNzE0MzU0NWFhNTEyYjYzMzkzY2Q5MmM1ODhkM2UxNTNmYmQ4YzRjNWM5MjNjNzZjYzQxMGQwYSIsImdlbmVyYXRpb24iOjEsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjA4Yzc0MzJlOGQ2NWE0YWE1OWU2NjZlNTVlZTg1NmE4ZmE0MWEyMGJkYzNlZGI1YmIwN2FiN2NhYzRhMjMwYTE3MGEifX0sInR5cGUiOiJ0ZWFtLnJvb3QiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE0OTU0NjU2MDMsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJwcmV2IjpudWxsLCJzZXFfdHlwZSI6Mywic2Vxbm8iOjEsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RAPV+uLLbPofl4eDHceJwbEFpSD0244Rk621nX75hmZm0v72jcuEmULQS8KNS+03jm2qIJ/W/+uPYqjllR7A8hB6hzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B\",\"signing_kid\":\"01208c7432e8d65a4aa59e666e55ee856a8fa41a20bdc3edb5bb07ab7cac4a230a170a\"}},\"type\":\"team.root\",\"version\":2},\"ctime\":1495465603,\"expire_in\":157680000,\"prev\":null,\"seq_type\":3,\"seqno\":1,\"tag\":\"signature\"}","version":2},{"uid":"bbbbbbbbbbbabbbbbbabbbbbbbabbb19","seqno":2,"sig":"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgv8ORwb4IEcmx7hmp41snRd/lzamUgH3mDM/aZHzDQzIKp3BheWxvYWTESJUCAsQgrfOWo7kRn9lXTll80AvHDYtRhNnYW3rOBHOWIuD7s9HEIFfJNYgYkmkf+ajkgryGkptpYGlBL8R9BqddzZhAZXcNI6NzaWfEQLu54sP2MVKNdxI/N3hnzfZiAg/Fdvi+Hn50LFr5iQunrlpiwnBrIIbF77drIr8ije+aEGvxFSqrU9AQYK3oGgaoc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==","payload_json":"{\"body\":{\"key\":{\"eldest_kid\":\"0120bfc391c1be0811c9b1ee19a9e35b2745dfe5cda994807de60ccfda647cc343320a\",\"host\":\"keybase.io\",\"kid\":\"0120bfc391c1be0811c9b1ee19a9e35b2745dfe5cda994807de60ccfda647cc343320a\",\"uid\":\"13172150f9b0885abf4b576fdcf59019\",\"username\":\"d_b2809af7\"},\"team\":{\"id\":\"79715edef9320c851e50d44d52f4b324\",\"members\":{\"writer\":[\"a_f0259e08\"]}},\"type\":\"team.change_membership\",\"version\":2},\"ctime\":1495465604,\"expire_in\":157680000,\"prev\":\"adf396a3b9119fd9574e597cd00bc70d8b5184d9d85b7ace04739622e0fbb3d1\",\"seq_type\":3,\"seqno\":2,\"tag\":\"signature\"}","version":2}],"box":{"nonce":"Hd/H/iI2Psy0CzsUliNwx2Jphy0AAAAB","sender_kid":"0121c85c6392c5071f938d7208ad04f8f47d24f1928fc6490bf1ad42078e67d2a7250a","generation":1,"ctext":"dY3olcXhVqfu0Xje+XEtsmKhygZf5AAxNOem8mPAe9GhjF5ZIbK6S7gdhfZAYaON","per_user_key_seqno":3},"prevs":{},"reader_key_masks":[{"mask":"Nbrttk8zZFA31vFu79A26nM2BR6hpCO+g9w7lW0K8/I=","application":1,"generation":1},{"mask":"6c9mAbxLz07Y6JN4t8xWDe+XZh7IDL8ACvtvRh3/hss=","application":2,"generation":1}],"csrf_token":"lgHZIDEzMTcyMTUwZjliMDg4NWFiZjRiNTc2ZmRjZjU5MDE5zlki/oLOAAFRgMDEIBYG/lf5vEPS1cj7x0lw0eO2lsU25CW9HOrwDnFcHE2Z"}
+{"status":{"code":0,"name":"OK"},"chain":[{"seqno":1,"sig":"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg0n4BukVK2MAN0FR3OKg2LjyIRb927JAVdNeKFKxDRTsKp3BheWxvYWTEJ5UCAcDEIKkpvmNu1RlxqBwYtqk4eG/jKv7KD/GllQ23k/Dd6VB1IaNzaWfEQCNHcFQwf9uDBjhzyXDydfUn/7QK1MgC4T2xW/4hywf9vXdVLJ3sPWb+gvk2ZoPCdiwmiAl3CCMiUIuaZrEIawSoc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==","payload_json":"{\"body\":{\"key\":{\"eldest_kid\":\"0120d27e01ba454ad8c00dd0547738a8362e3c8845bf76ec901574d78a14ac43453b0a\",\"host\":\"keybase.io\",\"kid\":\"0120d27e01ba454ad8c00dd0547738a8362e3c8845bf76ec901574d78a14ac43453b0a\",\"uid\":\"99759da4f968b16121ece44652f01a19\",\"username\":\"d_6d4e925d\"},\"team\":{\"id\":\"5d2c9db17c2309bf818ceefece77b624\",\"members\":{\"admin\":[\"b720a648e02b99c10d50de0c4f265419\"],\"owner\":[\"99759da4f968b16121ece44652f01a19\"],\"reader\":[\"c8f463c79c83fec675c398b6aa3fa719\"],\"writer\":[\"921f0e1f2632277cc1fa6600e0906819\"]},\"name\":\"t_bfaadb41\",\"per_team_key\":{\"encryption_kid\":\"01218ca00b08b4ee5729d957cf14155098b74199588bb5eee778ad1eae58bce26c370a\",\"generation\":1,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgiyRSCOiVHN56vT9eusVXlCTlHtCVH+FKyKeZbJzPiuUKp3BheWxvYWTFA3R7ImJvZHkiOnsia2V5Ijp7ImVsZGVzdF9raWQiOiIwMTIwZDI3ZTAxYmE0NTRhZDhjMDBkZDA1NDc3MzhhODM2MmUzYzg4NDViZjc2ZWM5MDE1NzRkNzhhMTRhYzQzNDUzYjBhIiwiaG9zdCI6ImtleWJhc2UuaW8iLCJraWQiOiIwMTIwZDI3ZTAxYmE0NTRhZDhjMDBkZDA1NDc3MzhhODM2MmUzYzg4NDViZjc2ZWM5MDE1NzRkNzhhMTRhYzQzNDUzYjBhIiwidWlkIjoiOTk3NTlkYTRmOTY4YjE2MTIxZWNlNDQ2NTJmMDFhMTkiLCJ1c2VybmFtZSI6ImRfNmQ0ZTkyNWQifSwidGVhbSI6eyJpZCI6IjVkMmM5ZGIxN2MyMzA5YmY4MThjZWVmZWNlNzdiNjI0IiwibWVtYmVycyI6eyJhZG1pbiI6WyJiNzIwYTY0OGUwMmI5OWMxMGQ1MGRlMGM0ZjI2NTQxOSJdLCJvd25lciI6WyI5OTc1OWRhNGY5NjhiMTYxMjFlY2U0NDY1MmYwMWExOSJdLCJyZWFkZXIiOlsiYzhmNDYzYzc5YzgzZmVjNjc1YzM5OGI2YWEzZmE3MTkiXSwid3JpdGVyIjpbIjkyMWYwZTFmMjYzMjI3N2NjMWZhNjYwMGUwOTA2ODE5Il19LCJuYW1lIjoidF9iZmFhZGI0MSIsInBlcl90ZWFtX2tleSI6eyJlbmNyeXB0aW9uX2tpZCI6IjAxMjE4Y2EwMGIwOGI0ZWU1NzI5ZDk1N2NmMTQxNTUwOThiNzQxOTk1ODhiYjVlZWU3NzhhZDFlYWU1OGJjZTI2YzM3MGEiLCJnZW5lcmF0aW9uIjoxLCJyZXZlcnNlX3NpZyI6bnVsbCwic2lnbmluZ19raWQiOiIwMTIwOGIyNDUyMDhlODk1MWNkZTdhYmQzZjVlYmFjNTU3OTQyNGU1MWVkMDk1MWZlMTRhYzhhNzk5NmM5Y2NmOGFlNTBhIn19LCJ0eXBlIjoidGVhbS5yb290IiwidmVyc2lvbiI6Mn0sImN0aW1lIjoxNDk3MjM5NTY2LCJleHBpcmVfaW4iOjE1NzY4MDAwMCwicHJldiI6bnVsbCwic2VxX3R5cGUiOjMsInNlcW5vIjoxLCJ0YWciOiJzaWduYXR1cmUifaNzaWfEQIhIqjwqQQFY8WglSLtvZu1hpncnMutA/jLaFmQJWcjdoMilr4ttLg3wlxKm6m+zWJC0Y9tiYBeHqGLYj5Mmkgaoc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==\",\"signing_kid\":\"01208b245208e8951cde7abd3f5ebac5579424e51ed0951fe14ac8a7996c9ccf8ae50a\"}},\"type\":\"team.root\",\"version\":2},\"ctime\":1497239566,\"expire_in\":157680000,\"prev\":null,\"seq_type\":3,\"seqno\":1,\"tag\":\"signature\"}","version":2,"uid":"99759da4f968b16121ece44652f01a19"},{"seqno":2,"sig":"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg0n4BukVK2MAN0FR3OKg2LjyIRb927JAVdNeKFKxDRTsKp3BheWxvYWTESJUCAsQgaCisMgGb2MAyfqV80hthgsO25NQIAYK7ARn5pjCDP1HEIKj3ZEpkyhQYH2mYtiHiXQVe7V5D4qgNwupJ5Nr/2nhcI6NzaWfEQNKql5dvPsQJK+pZKVGiLWS723t9SgaaDFx6NicXJzOM0VnLHKnql50wUcY/KsJOCqUIpKvJmNj6ogbwN/ljTwaoc2lnX3R5cGUgo3RhZ80CAqd2ZXJzaW9uAQ==","payload_json":"{\"body\":{\"key\":{\"eldest_kid\":\"0120d27e01ba454ad8c00dd0547738a8362e3c8845bf76ec901574d78a14ac43453b0a\",\"host\":\"keybase.io\",\"kid\":\"0120d27e01ba454ad8c00dd0547738a8362e3c8845bf76ec901574d78a14ac43453b0a\",\"uid\":\"99759da4f968b16121ece44652f01a19\",\"username\":\"d_6d4e925d\"},\"team\":{\"id\":\"5d2c9db17c2309bf818ceefece77b624\",\"members\":{\"writer\":[\"c8f463c79c83fec675c398b6aa3fa719\"]}},\"type\":\"team.change_membership\",\"version\":2},\"ctime\":1497239567,\"expire_in\":157680000,\"prev\":\"6828ac32019bd8c0327ea57cd21b6182c3b6e4d4080182bb0119f9a630833f51\",\"seq_type\":3,\"seqno\":2,\"tag\":\"signature\"}","version":2,"uid":"99759da4f968b16121ece44652f01a19"}],"box":{"nonce":"hdDTz9Scb6dWbe+BZsyZaXx76aQAAAAB","sender_kid":"0121a4f15b1009430ff69224c0c659eba66d61ca743b0d661a79075c8ca63a6e535d0a","generation":1,"ctext":"4Dz4i3Wzdj/BdH/kYCXvFnl1XKCqhxc58Z53j9VDloy/KG2ZzH204Sw5Q1xkzFkV","per_user_key_seqno":3},"prevs":{},"reader_key_masks":[{"mask":"tewSORjnVoyuHKR6ztsND+MNP2Pp9skEEEYmMBIQ5cY=","application":1,"generation":1},{"mask":"x7ZvY+WfK6WaJOCulxfOpdLgBEyuzSc8KgyIQGxT2uQ=","application":2,"generation":1}],"id":"5d2c9db17c2309bf818ceefece77b624","name":{"parts":["t_bfaadb41"]},"csrf_token":"lgHZIDk5NzU5ZGE0Zjk2OGIxNjEyMWVjZTQ0NjUyZjAxYTE5zlk+EA3OAAFRgMDEIKCIaEA5GV5wng89rpM0UlLiqxcOyNIVk8KdsEjQpmAm"}
 `
 
 type DeconstructJig struct {
@@ -73,8 +73,7 @@ func TestTeamSigChainPlay1(t *testing.T) {
 		chainLinks = append(chainLinks, chainLink)
 	}
 
-	helper := &chainHelper{}
-	player := NewTeamSigChainPlayer(tc.G, helper, NewUserVersion("a_1585f13b", 1), true)
+	player := NewTeamSigChainPlayer(tc.G, NewUserVersion(keybase1.UID("4bf92804c02fb7d2cd36a6d420d6f619"), 1), true)
 	err = player.AddChainLinks(context.TODO(), chainLinks)
 	require.NoError(t, err)
 
@@ -88,31 +87,31 @@ func TestTeamSigChainPlay1(t *testing.T) {
 			t.Logf("testing serde")
 		}
 
-		require.Equal(t, "t_79351477", string(state.GetName()))
+		require.Equal(t, "t_9d6d1e37", string(state.GetName()))
 		require.False(t, state.IsSubteam())
 		ptk, err := state.GetLatestPerTeamKey()
 		require.NoError(t, err)
 		require.Equal(t, 2, ptk.Gen)
 		require.Equal(t, keybase1.Seqno(3), ptk.Seqno)
-		require.Equal(t, "0120f1483c8515d08ac9ecb8a92eecba17cc35e3132b2da5481ab5da634da27e8d0e0a", string(ptk.SigKID))
-		require.Equal(t, "0121015351e68bc98d256c190fbca5608c2b04a36d15f5e95896385f1b5b0c6dc1260a", string(ptk.EncKID))
+		require.Equal(t, "0120802f55ed5e14f61c730871b5e99d637054ff7f5ba0c1b2cc52b154e3baf80a000a", string(ptk.SigKID))
+		require.Equal(t, "0121e2511cbfb0418187a8e19183a1cd92637bc83fe116d1eb8984f52394495b5f120a", string(ptk.EncKID))
 		require.Equal(t, keybase1.Seqno(3), state.GetLatestSeqno())
 
-		checkRole := func(username string, role keybase1.TeamRole) {
-			uv := NewUserVersion(username, 1)
+		checkRole := func(uid keybase1.UID, role keybase1.TeamRole) {
+			uv := NewUserVersion(uid, 1)
 			r, err := state.GetUserRole(uv)
 			require.NoError(t, err)
 			require.Equal(t, role, r)
 		}
 
-		checkRole("d_08827f78", keybase1.TeamRole_OWNER)
-		checkRole("c_61002771", keybase1.TeamRole_ADMIN)
-		checkRole("b_4a45388c", keybase1.TeamRole_WRITER)
-		checkRole("a_1585f13b", keybase1.TeamRole_READER)
+		checkRole("5bf82de4331b50b32cbbcfeadc2f3119", keybase1.TeamRole_OWNER)  // the "doug" user
+		checkRole("53e315afb4b419931b0a6a1eaa09e219", keybase1.TeamRole_ADMIN)  // the "charlie" user
+		checkRole("4bf92804c02fb7d2cd36a6d420d6f619", keybase1.TeamRole_WRITER) // the "bob" user
+		checkRole("13e18aeafa4df6c94bf6af7d7bb98d19", keybase1.TeamRole_READER) // the "alice" user
 		checkRole("popeye", keybase1.TeamRole_NONE)
 
 		linkIDProto := state.GetLatestLinkID()
-		require.Equal(t, "ef8bec278e661da9688207955a6c5f1067ac1489322cf454fd7aa1f1eab406ce", string(linkIDProto))
+		require.Equal(t, "c94234a4855e47d5833a7f43b221ca5e5ccf9970465b77167a793366acf39b16", string(linkIDProto))
 		linkIDLibkb, err := libkb.ImportLinkID(linkIDProto)
 		require.NoError(t, err)
 		require.Equal(t, linkIDProto, linkIDLibkb.Export())
@@ -145,7 +144,7 @@ func TestTeamSigChainPlay2(t *testing.T) {
 		chainLinks = append(chainLinks, chainLink)
 	}
 
-	player := NewTeamSigChainPlayer(tc.G, &chainHelper{}, NewUserVersion("a_f0259e08", 1), true)
+	player := NewTeamSigChainPlayer(tc.G, NewUserVersion("99759da4f968b16121ece44652f01a19", 1), true)
 	err = player.AddChainLinks(context.TODO(), chainLinks)
 	require.NoError(t, err)
 
@@ -153,27 +152,27 @@ func TestTeamSigChainPlay2(t *testing.T) {
 	state, err := player.GetState()
 	require.NoError(t, err)
 	for i := 0; i < 2; i++ {
-		require.Equal(t, "t_913dfbc3", string(state.GetName()))
+		require.Equal(t, "t_bfaadb41", string(state.GetName()))
 		require.False(t, state.IsSubteam())
 		ptk, err := state.GetLatestPerTeamKey()
 		require.NoError(t, err)
 		require.Equal(t, 1, ptk.Gen)
 		require.Equal(t, keybase1.Seqno(1), ptk.Seqno)
-		require.Equal(t, "01208c7432e8d65a4aa59e666e55ee856a8fa41a20bdc3edb5bb07ab7cac4a230a170a", string(ptk.SigKID))
-		require.Equal(t, "01212337961af637143545aa512b63393cd92c588d3e153fbd8c4c5c923c76cc410d0a", string(ptk.EncKID))
+		require.Equal(t, "01208b245208e8951cde7abd3f5ebac5579424e51ed0951fe14ac8a7996c9ccf8ae50a", string(ptk.SigKID))
+		require.Equal(t, "01218ca00b08b4ee5729d957cf14155098b74199588bb5eee778ad1eae58bce26c370a", string(ptk.EncKID))
 		require.Equal(t, keybase1.Seqno(2), state.GetLatestSeqno())
 
-		checkRole := func(username string, role keybase1.TeamRole) {
-			uv := NewUserVersion(username, 1)
+		checkRole := func(uid keybase1.UID, role keybase1.TeamRole) {
+			uv := NewUserVersion(uid, 1)
 			r, err := state.GetUserRole(uv)
 			require.NoError(t, err)
 			require.Equal(t, role, r)
 		}
 
-		checkRole("d_b2809af7", keybase1.TeamRole_OWNER)
-		checkRole("c_ac088470", keybase1.TeamRole_ADMIN)
-		checkRole("b_ee111192", keybase1.TeamRole_WRITER)
-		checkRole("a_f0259e08", keybase1.TeamRole_WRITER) // changed role
+		checkRole(keybase1.UID("99759da4f968b16121ece44652f01a19"), keybase1.TeamRole_OWNER)  // the 'doug' user
+		checkRole(keybase1.UID("b720a648e02b99c10d50de0c4f265419"), keybase1.TeamRole_ADMIN)  // the 'charlie' user
+		checkRole(keybase1.UID("921f0e1f2632277cc1fa6600e0906819"), keybase1.TeamRole_WRITER) // the 'bob' user
+		checkRole(keybase1.UID("c8f463c79c83fec675c398b6aa3fa719"), keybase1.TeamRole_WRITER) // changed role for 'alice'; used to be a reader
 
 		xs, err := state.GetUsersWithRole(keybase1.TeamRole_OWNER)
 		require.NoError(t, err)
@@ -190,23 +189,6 @@ func TestTeamSigChainPlay2(t *testing.T) {
 		state = TeamSigChainState{}
 		err = decode(bs, &state.inner)
 		require.NoError(t, err, "decode")
-	}
-}
-
-type chainHelper struct{}
-
-func (c *chainHelper) UsernameForUID(ctx context.Context, uid keybase1.UID) (string, error) {
-	switch uid {
-	case "e552cbc9f6951c2ea414cf098adbfa19":
-		return "d_08827f78", nil
-	case "130ea880070624ba5e0f0a6032cf0f19":
-		return "b_4a45388c", nil
-	case "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa19":
-		return "d_b2809af7", nil
-	case "bbbbbbbbbbbabbbbbbabbbbbbbabbb19":
-		return "c_ac088470", nil
-	default:
-		return "", errors.New("testing hit unknown uid")
 	}
 }
 

--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -85,19 +85,11 @@ func (f *finder) newPlayer(ctx context.Context, links []SCChainLink) (*TeamSigCh
 	if err != nil {
 		return nil, err
 	}
-	player := NewTeamSigChainPlayer(f.G(), f, uv, false)
+	player := NewTeamSigChainPlayer(f.G(), uv, false)
 	if err := player.AddChainLinks(ctx, links); err != nil {
 		return nil, err
 	}
 	return player, nil
-}
-
-func (f *finder) UsernameForUID(ctx context.Context, uid keybase1.UID) (string, error) {
-	name, err := f.G().GetUPAKLoader().LookupUsername(ctx, uid)
-	if err != nil {
-		return "", err
-	}
-	return name.String(), nil
 }
 
 type rawTeam struct {

--- a/go/teams/member.go
+++ b/go/teams/member.go
@@ -10,28 +10,93 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-func Members(ctx context.Context, g *libkb.GlobalContext, name string) (keybase1.TeamMembers, error) {
+func membersUIDsToUsernames(ctx context.Context, g *libkb.GlobalContext, m keybase1.TeamMembers) (keybase1.TeamMembersUsernames, error) {
+	var ret keybase1.TeamMembersUsernames
+	var err error
+	ret.Owners, err = userVersionsToUsernames(ctx, g, m.Owners)
+	if err != nil {
+		return ret, err
+	}
+	ret.Admins, err = userVersionsToUsernames(ctx, g, m.Admins)
+	if err != nil {
+		return ret, err
+	}
+	ret.Writers, err = userVersionsToUsernames(ctx, g, m.Writers)
+	if err != nil {
+		return ret, err
+	}
+	ret.Readers, err = userVersionsToUsernames(ctx, g, m.Readers)
+	if err != nil {
+		return ret, err
+	}
+	return ret, nil
+}
+
+func Members(ctx context.Context, g *libkb.GlobalContext, name string) (keybase1.TeamMembersUsernames, error) {
 	t, err := Get(ctx, g, name)
 	if err != nil {
-		return keybase1.TeamMembers{}, err
+		return keybase1.TeamMembersUsernames{}, err
 	}
-	return t.Members()
+	members, err := t.Members()
+	if err != nil {
+		return keybase1.TeamMembersUsernames{}, err
+	}
+	return membersUIDsToUsernames(ctx, g, members)
+}
+
+func usernameToUID(g *libkb.GlobalContext, username string) (uid keybase1.UID, err error) {
+	rres := g.Resolver.Resolve(username)
+	if err = rres.GetError(); err != nil {
+		return uid, err
+	}
+	return rres.GetUID(), nil
+}
+
+func uidToUsername(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID) (libkb.NormalizedUsername, error) {
+	return g.GetUPAKLoader().LookupUsername(ctx, uid)
+}
+
+func userVersionsToUsernames(ctx context.Context, g *libkb.GlobalContext, uvs []keybase1.UserVersion) (ret []string, err error) {
+	for _, uv := range uvs {
+		un, err := uidToUsername(ctx, g, uv.Uid)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, string(un))
+	}
+	return ret, nil
 }
 
 func SetRoleOwner(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
-	return ChangeRoles(ctx, g, teamname, keybase1.TeamChangeReq{Owners: []string{username}})
+	uid, err := usernameToUID(g, username)
+	if err != nil {
+		return err
+	}
+	return ChangeRoles(ctx, g, teamname, keybase1.TeamChangeReq{Owners: []keybase1.UID{uid}})
 }
 
 func SetRoleAdmin(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
-	return ChangeRoles(ctx, g, teamname, keybase1.TeamChangeReq{Admins: []string{username}})
+	uid, err := usernameToUID(g, username)
+	if err != nil {
+		return err
+	}
+	return ChangeRoles(ctx, g, teamname, keybase1.TeamChangeReq{Admins: []keybase1.UID{uid}})
 }
 
 func SetRoleWriter(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
-	return ChangeRoles(ctx, g, teamname, keybase1.TeamChangeReq{Writers: []string{username}})
+	uid, err := usernameToUID(g, username)
+	if err != nil {
+		return err
+	}
+	return ChangeRoles(ctx, g, teamname, keybase1.TeamChangeReq{Writers: []keybase1.UID{uid}})
 }
 
 func SetRoleReader(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
-	return ChangeRoles(ctx, g, teamname, keybase1.TeamChangeReq{Readers: []string{username}})
+	uid, err := usernameToUID(g, username)
+	if err != nil {
+		return err
+	}
+	return ChangeRoles(ctx, g, teamname, keybase1.TeamChangeReq{Readers: []keybase1.UID{uid}})
 }
 
 func AddMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string, role keybase1.TeamRole) error {
@@ -39,10 +104,14 @@ func AddMember(ctx context.Context, g *libkb.GlobalContext, teamname, username s
 	if err != nil {
 		return err
 	}
-	if t.IsMember(ctx, username) {
+	uid, err := usernameToUID(g, username)
+	if err != nil {
+		return err
+	}
+	if t.IsMember(ctx, uid) {
 		return fmt.Errorf("user %q is already a member of team %q", username, teamname)
 	}
-	req, err := reqFromRole(username, role)
+	req, err := reqFromRole(uid, role)
 	if err != nil {
 		return err
 	}
@@ -55,17 +124,22 @@ func EditMember(ctx context.Context, g *libkb.GlobalContext, teamname, username 
 	if err != nil {
 		return err
 	}
-	if !t.IsMember(ctx, username) {
+	uid, err := usernameToUID(g, username)
+	if err != nil {
+		return err
+	}
+	if !t.IsMember(ctx, uid) {
 		return fmt.Errorf("user %q is not a member of team %q", username, teamname)
 	}
-	existingRole, err := t.MemberRole(ctx, username)
+	existingRole, err := t.MemberRole(ctx, uid)
 	if err != nil {
 		return err
 	}
 	if existingRole == role {
 		return fmt.Errorf("user %q in team %q already has the role %s", username, teamname, role)
 	}
-	req, err := reqFromRole(username, role)
+
+	req, err := reqFromRole(uid, role)
 	if err != nil {
 		return err
 	}
@@ -78,7 +152,11 @@ func MemberRole(ctx context.Context, g *libkb.GlobalContext, teamname, username 
 	if err != nil {
 		return keybase1.TeamRole_NONE, err
 	}
-	return t.MemberRole(ctx, username)
+	uid, err := usernameToUID(g, username)
+	if err != nil {
+		return keybase1.TeamRole_NONE, err
+	}
+	return t.MemberRole(ctx, uid)
 }
 
 func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
@@ -86,10 +164,14 @@ func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, usernam
 	if err != nil {
 		return err
 	}
-	if !t.IsMember(ctx, username) {
+	uid, err := usernameToUID(g, username)
+	if err != nil {
+		return err
+	}
+	if !t.IsMember(ctx, uid) {
 		return libkb.NotFoundError{Msg: fmt.Sprintf("user %q is not a member of team %q", username, teamname)}
 	}
-	req := keybase1.TeamChangeReq{None: []string{username}}
+	req := keybase1.TeamChangeReq{None: []keybase1.UID{uid}}
 	return t.ChangeMembership(ctx, req)
 }
 
@@ -116,20 +198,22 @@ func loadUserVersionByUID(ctx context.Context, g *libkb.GlobalContext, uid keyba
 		return keybase1.UserVersion{}, err
 	}
 
-	return NewUserVersion(upak.Base.Username, upak.Base.EldestSeqno), nil
+	return NewUserVersion(upak.Base.Uid, upak.Base.EldestSeqno), nil
 }
 
-func reqFromRole(username string, role keybase1.TeamRole) (keybase1.TeamChangeReq, error) {
+func reqFromRole(uid keybase1.UID, role keybase1.TeamRole) (keybase1.TeamChangeReq, error) {
+
 	var req keybase1.TeamChangeReq
+	list := []keybase1.UID{uid}
 	switch role {
 	case keybase1.TeamRole_OWNER:
-		req.Owners = []string{username}
+		req.Owners = list
 	case keybase1.TeamRole_ADMIN:
-		req.Admins = []string{username}
+		req.Admins = list
 	case keybase1.TeamRole_WRITER:
-		req.Writers = []string{username}
+		req.Writers = list
 	case keybase1.TeamRole_READER:
-		req.Readers = []string{username}
+		req.Readers = list
 	default:
 		return keybase1.TeamChangeReq{}, errors.New("invalid team role")
 	}

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -18,11 +18,11 @@ type memberSet struct {
 	Writers    []member
 	Readers    []member
 	None       []member
-	recipients map[string]keybase1.PerUserKey
+	recipients map[keybase1.UID]keybase1.PerUserKey
 }
 
 func newMemberSet(ctx context.Context, g *libkb.GlobalContext, req keybase1.TeamChangeReq) (*memberSet, error) {
-	set := &memberSet{recipients: make(map[string]keybase1.PerUserKey)}
+	set := &memberSet{recipients: make(map[keybase1.UID]keybase1.PerUserKey)}
 	if err := set.loadMembers(ctx, g, req); err != nil {
 		return nil, err
 	}
@@ -54,11 +54,11 @@ func (m *memberSet) loadMembers(ctx context.Context, g *libkb.GlobalContext, req
 	return nil
 }
 
-func (m *memberSet) loadGroup(ctx context.Context, g *libkb.GlobalContext, group []string, storeRecipient bool) ([]member, error) {
+func (m *memberSet) loadGroup(ctx context.Context, g *libkb.GlobalContext, group []keybase1.UID, storeRecipient bool) ([]member, error) {
 	members := make([]member, len(group))
 	var err error
-	for i, username := range group {
-		members[i], err = m.loadMember(ctx, g, username, storeRecipient)
+	for i, uid := range group {
+		members[i], err = m.loadMember(ctx, g, uid, storeRecipient)
 		if err != nil {
 			return nil, err
 		}
@@ -66,15 +66,9 @@ func (m *memberSet) loadGroup(ctx context.Context, g *libkb.GlobalContext, group
 	return members, nil
 }
 
-func (m *memberSet) loadMember(ctx context.Context, g *libkb.GlobalContext, username string, storeRecipient bool) (member, error) {
-	// resolve the username
-	res := g.Resolver.ResolveWithBody(username)
-	if res.GetError() != nil {
-		return member{}, res.GetError()
-	}
-
+func (m *memberSet) loadMember(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID, storeRecipient bool) (member, error) {
 	// load upak for uid
-	arg := libkb.NewLoadUserByUIDArg(ctx, g, res.GetUID())
+	arg := libkb.NewLoadUserByUIDArg(ctx, g, uid)
 	upak, _, err := g.GetUPAKLoader().Load(arg)
 	if err != nil {
 		return member{}, err
@@ -90,19 +84,19 @@ func (m *memberSet) loadMember(ctx context.Context, g *libkb.GlobalContext, user
 
 	// store the key in a recipients table
 	if storeRecipient {
-		m.recipients[upak.Base.Username] = key
+		m.recipients[upak.Base.Uid] = key
 	}
 
 	// return a member with UserVersion and a PerUserKey
 	return member{
-		version:    NewUserVersion(upak.Base.Username, upak.Base.EldestSeqno),
+		version:    NewUserVersion(upak.Base.Uid, upak.Base.EldestSeqno),
 		perUserKey: key,
 	}, nil
 
 }
 
 type MemberChecker interface {
-	IsMember(context.Context, string) bool
+	IsMember(context.Context, keybase1.UID) bool
 }
 
 func (m *memberSet) removeExistingMembers(ctx context.Context, checker MemberChecker) {
@@ -117,12 +111,12 @@ func (m *memberSet) removeExistingMembers(ctx context.Context, checker MemberChe
 // AddRemainingRecipients adds everyone in existing to m.recipients that isn't in m.None.
 func (m *memberSet) AddRemainingRecipients(ctx context.Context, g *libkb.GlobalContext, existing keybase1.TeamMembers) error {
 	// make a map of the None members
-	noneMap := make(map[string]bool)
+	noneMap := make(map[keybase1.UID]bool)
 	for _, n := range m.None {
-		noneMap[n.version.Username] = true
+		noneMap[n.version.Uid] = true
 	}
 
-	for _, u := range existing.AllUsernames() {
+	for _, u := range existing.AllUIDs() {
 		if noneMap[u] {
 			continue
 		}
@@ -143,11 +137,7 @@ func (m *memberSet) nameSeqList(members []member) (*[]SCTeamMember, error) {
 	}
 	res := make([]SCTeamMember, len(members))
 	for i, m := range members {
-		nameSeq, err := libkb.MakeNameWithEldestSeqno(m.version.Username, m.version.EldestSeqno)
-		if err != nil {
-			return nil, err
-		}
-		res[i] = SCTeamMember(nameSeq)
+		res[i] = SCTeamMember(m.version)
 	}
 	return &res, nil
 }

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -162,7 +162,7 @@ func TestMemberAddHasBoxes(t *testing.T) {
 
 	// this change request should generate boxes since other.Username
 	// is not a member
-	req := keybase1.TeamChangeReq{Readers: []string{other.Username}}
+	req := keybase1.TeamChangeReq{Readers: []keybase1.UID{other.GetUID()}}
 	tm, err := Get(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
@@ -195,7 +195,7 @@ func TestMemberChangeRoleNoBoxes(t *testing.T) {
 	assertRole(tc, name, other.Username, keybase1.TeamRole_WRITER)
 
 	// this change request shouldn't generate any new boxes
-	req := keybase1.TeamChangeReq{Readers: []string{other.Username}}
+	req := keybase1.TeamChangeReq{Readers: []keybase1.UID{other.GetUID()}}
 	tm, err := Get(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -87,8 +87,8 @@ func (t *Team) ChatKey(ctx context.Context) (keybase1.TeamApplicationKey, error)
 	return t.ApplicationKey(ctx, keybase1.TeamApplication_CHAT)
 }
 
-func (t *Team) IsMember(ctx context.Context, username string) bool {
-	role, err := t.MemberRole(ctx, username)
+func (t *Team) IsMember(ctx context.Context, uid keybase1.UID) bool {
+	role, err := t.MemberRole(ctx, uid)
 	if err != nil {
 		t.G().Log.Debug("error getting user role: %s", err)
 		return false
@@ -99,52 +99,41 @@ func (t *Team) IsMember(ctx context.Context, username string) bool {
 	return true
 }
 
-func (t *Team) MemberRole(ctx context.Context, username string) (keybase1.TeamRole, error) {
-	uv, err := loadUserVersionByUsername(ctx, t.G(), username)
+func (t *Team) MemberRole(ctx context.Context, uid keybase1.UID) (keybase1.TeamRole, error) {
+	uv, err := loadUserVersionByUID(ctx, t.G(), uid)
 	if err != nil {
 		return keybase1.TeamRole_NONE, err
 	}
 	return t.Chain.GetUserRole(uv)
 }
 
-func (t *Team) UsernamesWithRole(role keybase1.TeamRole) ([]libkb.NormalizedUsername, error) {
-	uvs, err := t.Chain.GetUsersWithRole(role)
-	if err != nil {
-		return nil, err
-	}
-	names := make([]libkb.NormalizedUsername, len(uvs))
-	for i, uv := range uvs {
-		names[i] = libkb.NewNormalizedUsername(uv.Username)
-	}
-	return names, nil
+func (t *Team) UsersWithRole(role keybase1.TeamRole) ([]keybase1.UserVersion, error) {
+	return t.Chain.GetUsersWithRole(role)
 }
 
 func (t *Team) Members() (keybase1.TeamMembers, error) {
 	var members keybase1.TeamMembers
 
-	x, err := t.UsernamesWithRole(keybase1.TeamRole_OWNER)
+	x, err := t.UsersWithRole(keybase1.TeamRole_OWNER)
 	if err != nil {
 		return keybase1.TeamMembers{}, err
 	}
-	members.Owners = libkb.NormalizedUsernamesToStrings(x)
-
-	x, err = t.UsernamesWithRole(keybase1.TeamRole_ADMIN)
+	members.Owners = x
+	x, err = t.UsersWithRole(keybase1.TeamRole_ADMIN)
 	if err != nil {
 		return keybase1.TeamMembers{}, err
 	}
-	members.Admins = libkb.NormalizedUsernamesToStrings(x)
-
-	x, err = t.UsernamesWithRole(keybase1.TeamRole_WRITER)
+	members.Admins = x
+	x, err = t.UsersWithRole(keybase1.TeamRole_WRITER)
 	if err != nil {
 		return keybase1.TeamMembers{}, err
 	}
-	members.Writers = libkb.NormalizedUsernamesToStrings(x)
-
-	x, err = t.UsernamesWithRole(keybase1.TeamRole_READER)
+	members.Writers = x
+	x, err = t.UsersWithRole(keybase1.TeamRole_READER)
 	if err != nil {
 		return keybase1.TeamMembers{}, err
 	}
-	members.Readers = libkb.NormalizedUsernamesToStrings(x)
+	members.Readers = x
 
 	return members, nil
 }

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -19,9 +19,9 @@ protocol teams {
   record TeamApplicationKey {
     TeamApplication application;
     int keyGeneration;
-    Bytes32 key; 
+    Bytes32 key;
   }
-  
+
   @typedef("bytes")
   record MaskB64 {}
 
@@ -40,6 +40,13 @@ protocol teams {
   }
 
   record TeamMembers {
+    array<UserVersion> owners;
+    array<UserVersion> admins;
+    array<UserVersion> writers;
+    array<UserVersion> readers;
+  }
+
+  record TeamMembersUsernames {
     array<string> owners;
     array<string> admins;
     array<string> writers;
@@ -47,15 +54,15 @@ protocol teams {
   }
 
   record TeamChangeReq {
-    array<string> owners;
-    array<string> admins;
-    array<string> writers;
-    array<string> readers;
-    array<string> none;
+    array<UID> owners;
+    array<UID> admins;
+    array<UID> writers;
+    array<UID> readers;
+    array<UID> none;
   }
 
   record UserVersion {
-    string username;
+    UID uid;
     Seqno eldestSeqno;
   }
 
@@ -104,7 +111,7 @@ protocol teams {
   }
 
   void teamCreate(int sessionID, string name);
-  TeamMembers teamGet(int sessionID, string name);
+  TeamMembersUsernames teamGet(int sessionID, string name);
   void teamChangeMembership(int sessionID, string name, TeamChangeReq req);
   void teamAddMember(int sessionID, string name, string username, TeamRole role, boolean sendChatNotification);
   void teamRemoveMember(int sessionID, string name, string username);

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5734,16 +5734,23 @@ export type TeamApplicationKey = {
 }
 
 export type TeamChangeReq = {
-  owners?: ?Array<string>,
-  admins?: ?Array<string>,
-  writers?: ?Array<string>,
-  readers?: ?Array<string>,
-  none?: ?Array<string>,
+  owners?: ?Array<UID>,
+  admins?: ?Array<UID>,
+  writers?: ?Array<UID>,
+  readers?: ?Array<UID>,
+  none?: ?Array<UID>,
 }
 
 export type TeamID = string
 
 export type TeamMembers = {
+  owners?: ?Array<UserVersion>,
+  admins?: ?Array<UserVersion>,
+  writers?: ?Array<UserVersion>,
+  readers?: ?Array<UserVersion>,
+}
+
+export type TeamMembersUsernames = {
   owners?: ?Array<string>,
   admins?: ?Array<string>,
   writers?: ?Array<string>,
@@ -5961,7 +5968,7 @@ export type UserSummary2Set = {
 }
 
 export type UserVersion = {
-  username: string,
+  uid: UID,
   eldestSeqno: Seqno,
 }
 
@@ -7138,7 +7145,7 @@ type sigsSigListJSONResult = string
 type sigsSigListResult = ?Array<Sig>
 type streamUiReadResult = bytes
 type streamUiWriteResult = int
-type teamsTeamGetResult = TeamMembers
+type teamsTeamGetResult = TeamMembersUsernames
 type testTestCallbackResult = string
 type testTestResult = Test
 type tlfCompleteAndCanonicalizePrivateTlfNameResult = CanonicalTLFNameAndIDWithBreaks

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -94,6 +94,40 @@
         {
           "type": {
             "type": "array",
+            "items": "UserVersion"
+          },
+          "name": "owners"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "UserVersion"
+          },
+          "name": "admins"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "UserVersion"
+          },
+          "name": "writers"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "UserVersion"
+          },
+          "name": "readers"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "TeamMembersUsernames",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
             "items": "string"
           },
           "name": "owners"
@@ -128,35 +162,35 @@
         {
           "type": {
             "type": "array",
-            "items": "string"
+            "items": "UID"
           },
           "name": "owners"
         },
         {
           "type": {
             "type": "array",
-            "items": "string"
+            "items": "UID"
           },
           "name": "admins"
         },
         {
           "type": {
             "type": "array",
-            "items": "string"
+            "items": "UID"
           },
           "name": "writers"
         },
         {
           "type": {
             "type": "array",
-            "items": "string"
+            "items": "UID"
           },
           "name": "readers"
         },
         {
           "type": {
             "type": "array",
-            "items": "string"
+            "items": "UID"
           },
           "name": "none"
         }
@@ -167,8 +201,8 @@
       "name": "UserVersion",
       "fields": [
         {
-          "type": "string",
-          "name": "username"
+          "type": "UID",
+          "name": "uid"
         },
         {
           "type": "Seqno",
@@ -289,7 +323,7 @@
           "type": "string"
         }
       ],
-      "response": "TeamMembers"
+      "response": "TeamMembersUsernames"
     },
     "teamChangeMembership": {
       "request": [

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5734,16 +5734,23 @@ export type TeamApplicationKey = {
 }
 
 export type TeamChangeReq = {
-  owners?: ?Array<string>,
-  admins?: ?Array<string>,
-  writers?: ?Array<string>,
-  readers?: ?Array<string>,
-  none?: ?Array<string>,
+  owners?: ?Array<UID>,
+  admins?: ?Array<UID>,
+  writers?: ?Array<UID>,
+  readers?: ?Array<UID>,
+  none?: ?Array<UID>,
 }
 
 export type TeamID = string
 
 export type TeamMembers = {
+  owners?: ?Array<UserVersion>,
+  admins?: ?Array<UserVersion>,
+  writers?: ?Array<UserVersion>,
+  readers?: ?Array<UserVersion>,
+}
+
+export type TeamMembersUsernames = {
   owners?: ?Array<string>,
   admins?: ?Array<string>,
   writers?: ?Array<string>,
@@ -5961,7 +5968,7 @@ export type UserSummary2Set = {
 }
 
 export type UserVersion = {
-  username: string,
+  uid: UID,
   eldestSeqno: Seqno,
 }
 
@@ -7138,7 +7145,7 @@ type sigsSigListJSONResult = string
 type sigsSigListResult = ?Array<Sig>
 type streamUiReadResult = bytes
 type streamUiWriteResult = int
-type teamsTeamGetResult = TeamMembers
+type teamsTeamGetResult = TeamMembersUsernames
 type testTestCallbackResult = string
 type testTestResult = Test
 type tlfCompleteAndCanonicalizePrivateTlfNameResult = CanonicalTLFNameAndIDWithBreaks


### PR DESCRIPTION
- upgrade AVDL TeamMember and TeamChangeReq to use UserVersions
- use UnmarshalJSON/MarshalJSON where possible
- various cleanups
- clean up chain parsing tests in chain_tests.go, and regenerate canned tests