### PR TITLE
add support for multiple channels for team convos CORE-5288

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -479,7 +479,7 @@ func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversa
 	// NOTE: The CLI already does this. It is hard to move that code completely into the service, since
 	// there is a ton of logic in there to try and present a nice looking menu to help out the
 	// user and such. For the most part, the CLI just uses FindConversationsLocal though, so it
-	// should hopefully just result in a bunch of cache hits on the second invokation.
+	// should hopefully just result in a bunch of cache hits on the second invocation.
 	findRes, err := h.FindConversationsLocal(ctx, chat1.FindConversationsLocalArg{
 		TlfName:          arg.TlfName,
 		MembersType:      arg.MembersType,

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -475,6 +475,11 @@ func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversa
 
 	// Find any existing conversations that match this argument specifically. We need to do this check
 	// here in the client since we can't see the topic name on the server.
+
+	// NOTE: The CLI already does this. It is hard to move that code completely into the service, since
+	// there is a ton of logic in there to try and present a nice looking menu to help out the
+	// user and such. For the most part, the CLI just uses FindConversationsLocal though, so it
+	// should hopefully just result in a bunch of cache hits on the second invokation.
 	findRes, err := h.FindConversationsLocal(ctx, chat1.FindConversationsLocalArg{
 		TlfName:          arg.TlfName,
 		MembersType:      arg.MembersType,

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -537,8 +537,9 @@ func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversa
 				// This triple already exists.
 				h.Debug(ctx, "NewConversationLocal: conv exists: %v", cerr.ConvID)
 
-				if triple.TopicType != chat1.TopicType_CHAT {
-					// Not a chat conversation. Multiples are fine. Just retry with a
+				if triple.TopicType != chat1.TopicType_CHAT ||
+					arg.MembersType == chat1.ConversationMembersType_TEAM {
+					// Not a chat (or is a team) conversation. Multiples are fine. Just retry with a
 					// different topic ID.
 					continue
 				}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -462,6 +462,40 @@ func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversa
 		return chat1.NewConversationLocalRes{}, err
 	}
 
+	// Handle a nil topic name with default values for the members type specified
+	if arg.TopicName == nil {
+		// We never want a blank topic name in team chats, always default to the default team name
+		switch arg.MembersType {
+		case chat1.ConversationMembersType_TEAM:
+			arg.TopicName = &DefaultTeamTopic
+		default:
+			arg.TopicName = new(string)
+		}
+	}
+
+	// Find any existing conversations that match this argument specifically. We need to do this check
+	// here in the client since we can't see the topic name on the server.
+	findRes, err := h.FindConversationsLocal(ctx, chat1.FindConversationsLocalArg{
+		TlfName:          arg.TlfName,
+		MembersType:      arg.MembersType,
+		Visibility:       arg.TlfVisibility,
+		TopicType:        arg.TopicType,
+		TopicName:        *arg.TopicName,
+		IdentifyBehavior: arg.IdentifyBehavior,
+	})
+	if err != nil {
+		return chat1.NewConversationLocalRes{}, err
+	}
+	// If we find one conversation, then just return it as if we created it.
+	if len(findRes.Conversations) == 1 {
+		return chat1.NewConversationLocalRes{
+			Conv:             findRes.Conversations[0],
+			RateLimits:       findRes.RateLimits,
+			IdentifyFailures: findRes.IdentifyFailures,
+		}, nil
+	}
+	res.RateLimits = append(res.RateLimits, findRes.RateLimits...)
+
 	info, err := CtxKeyFinder(ctx, h.G()).Find(ctx, arg.TlfName, arg.MembersType,
 		arg.TlfVisibility == chat1.TLFVisibility_PUBLIC)
 	if err != nil {
@@ -552,6 +586,7 @@ func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversa
 			return chat1.NewConversationLocalRes{}, errors.New(res.Conv.Error.Message)
 		}
 
+		res.RateLimits = utils.AggRateLimits(res.RateLimits)
 		res.IdentifyFailures = identBreaks
 		return res, nil
 	}
@@ -559,11 +594,14 @@ func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversa
 	return chat1.NewConversationLocalRes{}, reserr
 }
 
+var DefaultTeamTopic = "#general"
+
 func (h *Server) makeFirstMessage(ctx context.Context, triple chat1.ConversationIDTriple,
 	tlfName string, membersType chat1.ConversationMembersType, tlfVisibility chat1.TLFVisibility,
 	topicName *string) (*chat1.MessageBoxed, error) {
 	var msg chat1.MessagePlaintext
-	if topicName != nil {
+
+	if topicName != nil || *topicName != "" {
 		msg = chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
 				Conv:        triple,

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -145,10 +145,6 @@ func parseConversationResolvingRequest(ctx *cli.Context, tlfName string) (req ch
 	if req.TopicType, err = parseConversationTopicType(ctx); err != nil {
 		return chatConversationResolvingRequest{}, err
 	}
-	if req.TopicType == chat1.TopicType_CHAT && len(req.TopicName) != 0 {
-		return chatConversationResolvingRequest{}, errors.New("multiple topics are not yet supported")
-	}
-
 	if ctx.Bool("private") {
 		req.Visibility = chat1.TLFVisibility_PRIVATE
 	} else if ctx.Bool("public") {
@@ -156,9 +152,13 @@ func parseConversationResolvingRequest(ctx *cli.Context, tlfName string) (req ch
 	} else {
 		req.Visibility = chat1.TLFVisibility_ANY
 	}
-
 	if ctx.Bool("team") {
 		req.MembersType = chat1.ConversationMembersType_TEAM
+	}
+
+	if req.TopicType == chat1.TopicType_CHAT && len(req.TopicName) != 0 &&
+		req.MembersType != chat1.ConversationMembersType_TEAM {
+		return chatConversationResolvingRequest{}, errors.New("multiple topics only supported for teams and dev channels")
 	}
 
 	return req, nil

--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -71,8 +71,11 @@ func (v conversationInfoListView) show(g *libkb.GlobalContext) error {
 
 type conversationListView []chat1.ConversationLocal
 
-// Make a name that looks like a tlfname but is sorted by activity and missing myUsername.
-func (v conversationListView) convName(g *libkb.GlobalContext, conv chat1.ConversationLocal, myUsername string) string {
+func (v conversationListView) convNameTeam(g *libkb.GlobalContext, conv chat1.ConversationLocal) string {
+	return fmt.Sprintf("%s [%s]", conv.Info.TlfName, conv.Info.TopicName)
+}
+
+func (v conversationListView) convNameKBFS(g *libkb.GlobalContext, conv chat1.ConversationLocal, myUsername string) string {
 	var name string
 	if conv.Info.Visibility == chat1.TLFVisibility_PUBLIC {
 		name = publicConvNamePrefix + strings.Join(conv.Info.WriterNames, ",")
@@ -92,6 +95,17 @@ func (v conversationListView) convName(g *libkb.GlobalContext, conv chat1.Conver
 	}
 
 	return name
+}
+
+// Make a name that looks like a tlfname but is sorted by activity and missing myUsername.
+func (v conversationListView) convName(g *libkb.GlobalContext, conv chat1.ConversationLocal, myUsername string) string {
+	switch conv.GetMembersType() {
+	case chat1.ConversationMembersType_TEAM:
+		return v.convNameTeam(g, conv)
+	case chat1.ConversationMembersType_KBFS:
+		return v.convNameKBFS(g, conv, myUsername)
+	}
+	return ""
 }
 
 // Make a name that looks like a tlfname but is sorted by activity and missing myUsername.

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -83,14 +83,16 @@ func (r *chatConversationResolver) completeAndCanonicalizeTLFName(ctx context.Co
 
 func (r *chatConversationResolver) makeGetInboxAndUnboxLocalArg(
 	ctx context.Context, req chatConversationResolvingRequest, identifyBehavior keybase1.TLFIdentifyBehavior) (chat1.GetInboxAndUnboxLocalArg, error) {
-	if len(req.TopicName) > 0 && req.TopicType == chat1.TopicType_CHAT {
-		return chat1.GetInboxAndUnboxLocalArg{},
-			errors.New("we are not supporting setting topic name for chat conversations yet")
-	}
 
 	var nameQuery *chat1.NameQuery
 	switch req.MembersType {
 	case chat1.ConversationMembersType_KBFS:
+
+		if len(req.TopicName) > 0 && req.TopicType == chat1.TopicType_CHAT {
+			return chat1.GetInboxAndUnboxLocalArg{},
+				errors.New("multiple topics only supported for teams and dev conversations")
+		}
+
 		if len(req.TlfName) > 0 {
 			err := r.completeAndCanonicalizeTLFName(ctx, req.TlfName, req)
 			if err != nil {

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -105,6 +105,7 @@ func (c *chatServiceHandler) ListV1(ctx context.Context, opts listOptionsV1) Rep
 			Public:      conv.Info.Visibility == chat1.TLFVisibility_PUBLIC,
 			TopicType:   strings.ToLower(conv.Info.Triple.TopicType.String()),
 			MembersType: strings.ToLower(conv.Info.MembersType.String()),
+			TopicName:   conv.Info.TopicName,
 		}
 
 		cl.Conversations = append(cl.Conversations, convSummary)

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -483,6 +483,7 @@ func (m *ChatRemoteMock) NewConversationRemote2(ctx context.Context, arg chat1.N
 			return res, libkb.ChatConvExistsError{ConvID: conv.Metadata.ConversationID}
 		}
 		if arg.IdTriple.TopicType == chat1.TopicType_CHAT &&
+			arg.MembersType != chat1.ConversationMembersType_TEAM &&
 			conv.Metadata.IdTriple.Tlfid.Eq(arg.IdTriple.Tlfid) &&
 			conv.Metadata.IdTriple.TopicType == arg.IdTriple.TopicType {
 			// Existing CHAT conv


### PR DESCRIPTION
Patch does the following:

1.) Removes all restrictions for creating multiple conversations for team member types.
2.) Forces topic name set to `#general` for team conversation creations that have no topic name set.
3.) Add a check with `FindConversationsLocal` to `NewConversationLocal` so we can find these `#general` convos and use them for any subsequent new blank topic name conv creation attempts.

cc @maxtaco 