### PR TITLE
export user to UserPlusKeysV2AllIncarnations

### DIFF
--- a/go/engine/upak2_test.go
+++ b/go/engine/upak2_test.go
@@ -1,0 +1,74 @@
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportAllIncarnationsAfterReset(t *testing.T) {
+	// One context for user that will be doing LoadUser, and another
+	// for user that will sign up and reset itself.
+	tc := SetupEngineTest(t, "clu")
+	defer tc.Cleanup()
+
+	resetUserTC := SetupEngineTest(t, "clu2")
+	defer resetUserTC.Cleanup()
+
+	// The first version of this user has just a PGP key. We'll assert that
+	// that's reflected in the export at the end.
+	t.Logf("create new user")
+	fu := createFakeUserWithPGPOnly(t, resetUserTC)
+
+	// Reset this user's account.
+	ResetAccount(resetUserTC, fu)
+
+	// Now provision it with regular device keys, and no PGP key.
+	fu.LoginOrBust(resetUserTC)
+	if err := AssertProvisioned(resetUserTC); err != nil {
+		t.Fatal(err)
+	}
+
+	arg := libkb.NewLoadUserByNameArg(tc.G, fu.Username)
+	arg.AllSubchains = true
+	u, err := libkb.LoadUser(arg)
+	require.NoError(t, err)
+
+	exported := u.ExportToUPKV2AllIncarnations(keybase1.ToTime(time.Now()))
+
+	if len(exported.PastIncarnations) != 1 {
+		t.Fatalf("Expected exactly 1 past incarnation, found %d", len(exported.PastIncarnations))
+	}
+
+	current := exported.Current
+	past := exported.PastIncarnations[0]
+
+	// Check that the current user has device keys and no PGP key.
+	if len(current.PGPKeys) != 0 {
+		t.Fatalf("Expected exactly 0 PGP keys in the current incarnation, found %d", len(current.PGPKeys))
+	}
+	if len(current.DeviceKeys) != 2 {
+		t.Fatalf("Expected exactly 2 device keys in the current incarnation, found %d", len(current.DeviceKeys))
+	}
+
+	// Check that the past version of the user has a PGP key but no device keys.
+	if len(past.PGPKeys) != 1 {
+		t.Fatalf("Expected exactly 1 PGP key in the past incarnation, found %d", len(past.PGPKeys))
+	}
+	if len(past.DeviceKeys) != 0 {
+		t.Fatalf("Expected exactly 0 device keys in the past incarnation, found %d", len(past.DeviceKeys))
+	}
+
+	// Make sure the timestamps on keys are exported properly.
+	for _, key := range current.DeviceKeys {
+		userKeyInfo := u.GetComputedKeyInfos().Infos[key.Base.Kid]
+		t1 := keybase1.FromTime(key.Base.CTime)
+		t2 := time.Unix(userKeyInfo.CTime, 0)
+		if !t1.Equal(t2) {
+			t.Fatalf("exported key ctime is not equal: %s != %s", t1, t2)
+		}
+	}
+}

--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -26,8 +26,12 @@ type KeybaseTime struct {
 	Chain int   // Merkle root chain time
 }
 
-// ComputedKeyInfo is a set of annotations that we apply to a ServerKeyRecord.
-// Everything here has been checked by the client. Each ComputedKeyInfo
+// Struct for the DelegationsList
+type Delegation struct {
+	KID   keybase1.KID
+	SigID keybase1.SigID
+}
+
 // refers to exactly one ServerKeyInfo.
 type ComputedKeyInfo struct {
 	Contextified
@@ -53,6 +57,10 @@ type ComputedKeyInfo struct {
 
 	// Map of SigID -> KID
 	Delegations map[keybase1.SigID]keybase1.KID
+
+	// List of the same delegations as above, in a way that preserves ordering.
+	// NOTE: This is not populated in older cached CKI's.
+	DelegationsList []Delegation
 
 	// Merkle Timestamps and Friends for delegation. Suboptimal grouping of concerns
 	// due to backwards compatibility and sensitivity to preexisting ondisk representations.
@@ -601,6 +609,7 @@ func (cki *ComputedKeyInfos) Delegate(kid keybase1.KID, tm *KeybaseTime, sigid k
 		info.ETime = etime.Unix()
 	}
 	info.Delegations[sigid] = signingKid
+	info.DelegationsList = append(info.DelegationsList, Delegation{signingKid, sigid})
 	info.Sibkey = isSibkey
 	info.DelegatedAtHashMeta = merkleHashMeta.DeepCopy()
 	info.FirstAppearedUnverified = fau

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -25,6 +25,7 @@ type LoadUserArg struct {
 	StaleOK                  bool // if stale cached versions are OK (for immutable fields)
 	CachedOnly               bool // only return cached data (StaleOK should be true as well)
 	AllKeys                  bool
+	AllSubchains             bool
 	LoginContext             LoginContext
 	AbortIfSigchainUnchanged bool
 	ResolveBody              *jsonw.Wrapper // some load paths plumb this through
@@ -40,9 +41,9 @@ type LoadUserArg struct {
 }
 
 func (arg LoadUserArg) String() string {
-	return fmt.Sprintf("{UID:%s Name:%q PublicKeyOptional:%v NoCacheResult:%v Self:%v ForceReload:%v ForcePoll:%v StaleOK:%v AllKeys:%v AbortIfSigchainUnchanged:%v CachedOnly:%v}",
+	return fmt.Sprintf("{UID:%s Name:%q PublicKeyOptional:%v NoCacheResult:%v Self:%v ForceReload:%v ForcePoll:%v StaleOK:%v AllKeys:%v AllSubchains:%v AbortIfSigchainUnchanged:%v CachedOnly:%v}",
 		arg.UID, arg.Name, arg.PublicKeyOptional, arg.NoCacheResult, arg.Self, arg.ForceReload,
-		arg.ForcePoll, arg.StaleOK, arg.AllKeys, arg.AbortIfSigchainUnchanged, arg.CachedOnly)
+		arg.ForcePoll, arg.StaleOK, arg.AllKeys, arg.AllSubchains, arg.AbortIfSigchainUnchanged, arg.CachedOnly)
 }
 
 func NewLoadUserArg(g *GlobalContext) LoadUserArg {
@@ -269,7 +270,7 @@ func LoadUser(arg LoadUserArg) (ret *User, err error) {
 		return ret, err
 	}
 
-	if err = ret.LoadSigChains(ctx, arg.AllKeys, &ret.leaf, arg.Self); err != nil {
+	if err = ret.LoadSigChains(ctx, arg.AllKeys, arg.AllSubchains, &ret.leaf, arg.Self); err != nil {
 		return ret, err
 	}
 

--- a/go/libkb/loaduser_test.go
+++ b/go/libkb/loaduser_test.go
@@ -4,8 +4,9 @@
 package libkb
 
 import (
-	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"testing"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
 func TestLoadUserPlusKeys(t *testing.T) {
@@ -83,7 +84,7 @@ func BenchmarkLoadSigChains(b *testing.B) {
 	u.sigChainMem = nil
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err = u.LoadSigChains(nil, true, &u.leaf, false); err != nil {
+		if err = u.LoadSigChains(nil, true /* AllKeys */, false /* AllSubchains */, &u.leaf, false); err != nil {
 			b.Fatal(err)
 		}
 		u.sigChainMem = nil

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -905,6 +905,93 @@ func (ckf ComputedKeyFamily) exportPublicKey(key GenericKey) (pk keybase1.Public
 	return pk
 }
 
+func publicKeyV2BaseFromComputedKeyInfo(info ComputedKeyInfo) (base keybase1.PublicKeyV2Base) {
+	base = keybase1.PublicKeyV2Base{
+		Kid:      info.KID,
+		IsSibkey: info.Sibkey,
+		IsEldest: info.Eldest,
+		CTime:    keybase1.TimeFromSeconds(info.CTime),
+		ETime:    keybase1.TimeFromSeconds(info.ETime),
+	}
+	if info.DelegatedAt != nil {
+		base.Provisioning = keybase1.SignatureMetadata{
+			Time: keybase1.Time(info.DelegatedAt.Unix),
+			PrevMerkleRootSigned: keybase1.MerkleRootV2{
+				HashMeta: info.DelegatedAtHashMeta,
+				Seqno:    keybase1.Seqno(info.DelegatedAt.Chain),
+			},
+			FirstAppearedUnverified: info.FirstAppearedUnverified,
+		}
+		dLen := len(info.DelegationsList)
+		if dLen > 0 {
+			base.Provisioning.SigningKID = info.DelegationsList[dLen-1].KID
+		}
+	}
+	if info.RevokedAt != nil {
+		base.Revocation = &keybase1.SignatureMetadata{
+			Time: keybase1.Time(info.RevokedAt.Unix),
+			PrevMerkleRootSigned: keybase1.MerkleRootV2{
+				HashMeta: info.RevokedAtHashMeta,
+				Seqno:    keybase1.Seqno(info.RevokedAt.Chain),
+			},
+			FirstAppearedUnverified: info.FirstAppearedUnverified,
+			SigningKID:              info.RevokedBy,
+		}
+	}
+	return
+}
+
+func (cki ComputedKeyInfos) exportDeviceKeyV2(kid keybase1.KID) (key keybase1.PublicKeyV2NaCl) {
+	info := cki.Infos[kid]
+	if info == nil {
+		cki.G().Log.Errorf("Tried to export nonexistent KID: %s", kid.String())
+		return
+	}
+	key = keybase1.PublicKeyV2NaCl{
+		Base:     publicKeyV2BaseFromComputedKeyInfo(*info),
+		DeviceID: cki.KIDToDeviceID[kid],
+	}
+	if !info.Parent.IsNil() {
+		key.Parent = &info.Parent
+	}
+	if device := cki.Devices[key.DeviceID]; device != nil {
+		key.DeviceType = device.Type
+		if device.Description != nil {
+			key.DeviceDescription = *device.Description
+		}
+	}
+	return
+}
+
+func (cki ComputedKeyInfos) exportPGPKeyV2(kid keybase1.KID, kf *KeyFamily) (key keybase1.PublicKeyV2PGPSummary) {
+	info := cki.Infos[kid]
+	if info == nil {
+		cki.G().Log.Errorf("Tried to export nonexistent KID: %s", kid.String())
+		return
+	}
+	keySet := kf.PGPKeySets[kid]
+	if keySet == nil {
+		cki.G().Log.Errorf("Tried to export PGP key with no key set, KID: %s", kid.String())
+		return
+	}
+	var bundle *PGPKeyBundle
+	if info.ActivePGPHash != "" {
+		bundle = keySet.KeysByHash[info.ActivePGPHash]
+	} else {
+		bundle = keySet.PermissivelyMergedKey
+	}
+	if bundle == nil {
+		cki.G().Log.Errorf("Tried to export PGP key with no bundle, KID: %s", kid.String())
+		return
+	}
+	key = keybase1.PublicKeyV2PGPSummary{
+		Base:        publicKeyV2BaseFromComputedKeyInfo(*info),
+		Fingerprint: keybase1.PGPFingerprint(bundle.GetFingerprint()),
+		Identities:  bundle.Export().PGPIdentities,
+	}
+	return
+}
+
 // Export is used by IDRes.  It includes PGP keys.
 func (ckf ComputedKeyFamily) Export() []keybase1.PublicKey {
 	var exportedKeys []keybase1.PublicKey
@@ -1050,6 +1137,84 @@ func (u *User) ExportToUserPlusAllKeys(idTime keybase1.Time) keybase1.UserPlusAl
 		Base:         u.ExportToUserPlusKeys(idTime),
 		PGPKeys:      u.GetComputedKeyFamily().ExportAllPGPKeys(),
 		RemoteTracks: u.ExportRemoteTracks(),
+	}
+}
+
+type PerUserKeysList []keybase1.PerUserKey
+
+func (p PerUserKeysList) Len() int           { return len(p) }
+func (p PerUserKeysList) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p PerUserKeysList) Less(i, j int) bool { return p[i].Gen < p[j].Gen }
+
+func (cki *ComputedKeyInfos) exportUPKV2Incarnation(uid keybase1.UID, username string, eldestSeqno keybase1.Seqno, kf *KeyFamily) keybase1.UserPlusKeysV2 {
+	if cki == nil {
+		cki.G().Log.Errorf("Found nil cached computed key infos for uid %s username %s, eldest seqno %s", uid.String(), username, eldestSeqno)
+		return keybase1.UserPlusKeysV2{}
+	}
+
+	var perUserKeysList PerUserKeysList
+	for _, puk := range cki.PerUserKeys {
+		perUserKeysList = append(perUserKeysList, puk)
+	}
+	sort.Sort(perUserKeysList)
+
+	deviceKeysList := []keybase1.PublicKeyV2NaCl{}
+	pgpSummariesList := []keybase1.PublicKeyV2PGPSummary{}
+	for _, info := range cki.Infos {
+		if KIDIsPGP(info.KID) {
+			pgpSummariesList = append(pgpSummariesList, cki.exportPGPKeyV2(info.KID, kf))
+		} else {
+			deviceKeysList = append(deviceKeysList, cki.exportDeviceKeyV2(info.KID))
+		}
+	}
+
+	return keybase1.UserPlusKeysV2{
+		Uid:         uid,
+		Username:    username,
+		EldestSeqno: eldestSeqno,
+		PerUserKeys: perUserKeysList,
+		DeviceKeys:  deviceKeysList,
+		PGPKeys:     pgpSummariesList,
+		// Uvv and RemoteTracks are set later, and only for the current incarnation
+	}
+}
+
+func (u *User) ExportToUPKV2AllIncarnations(idTime keybase1.Time) keybase1.UserPlusKeysV2AllIncarnations {
+	// The KeyFamily holds all the PGP key bundles, and it applies to all
+	// generations of this user.
+	kf := u.GetKeyFamily()
+
+	uid := u.GetUID()
+	name := u.GetName()
+
+	// First assemble all the past versions of this user.
+	pastIncarnations := []keybase1.UserPlusKeysV2{}
+	for _, subchain := range u.sigChain().prevSubchains {
+		if len(subchain) == 0 {
+			u.G().Log.Errorf("Tried to export empty subchain for uid %s username %s", u.GetUID(), u.GetName())
+			continue
+		}
+		cki := subchain[len(subchain)-1].cki
+		pastIncarnations = append(pastIncarnations, cki.exportUPKV2Incarnation(uid, name, subchain[0].GetSeqno(), kf))
+	}
+
+	// Then assemble the current version. This one gets a couple extra fields, Uvv and RemoteTracks.
+	current := u.GetComputedKeyInfos().exportUPKV2Incarnation(uid, name, u.GetCurrentEldestSeqno(), kf)
+	current.Uvv = u.ExportToVersionVector(idTime)
+
+	remoteTracks := []keybase1.RemoteTrack{}
+	for _, track := range u.IDTable().GetTrackList() {
+		remoteTracks = append(remoteTracks, keybase1.RemoteTrack{
+			Username: string(track.whomUsername),
+			Uid:      track.whomUID,
+			LinkID:   keybase1.LinkID(hex.EncodeToString(track.LinkID())),
+		})
+	}
+	current.RemoteTracks = remoteTracks
+
+	return keybase1.UserPlusKeysV2AllIncarnations{
+		Current:          current,
+		PastIncarnations: pastIncarnations,
 	}
 }
 

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -712,7 +712,7 @@ func reverseListOfChainLinks(arr []ChainLinks) {
 	}
 }
 
-func (c ChainLinks) popNRightmostLinks(n int) ChainLinks {
+func (c ChainLinks) omittingNRightmostLinks(n int) ChainLinks {
 	return c[0 : len(c)-n]
 }
 
@@ -728,7 +728,7 @@ func (sc *SigChain) VerifySigsAndComputeKeys(ctx context.Context, eldest keybase
 	allCached := cached
 
 	// Now let's examine any historical subchains, if there are any.
-	historicalLinks := sc.chainLinks.popNRightmostLinks(numLinksConsumed)
+	historicalLinks := sc.chainLinks.omittingNRightmostLinks(numLinksConsumed)
 	if len(historicalLinks) > 0 {
 		sc.G().Log.CDebugf(ctx, "After consuming %d links, there are %d historical links left",
 			numLinksConsumed, len(historicalLinks))
@@ -780,7 +780,7 @@ func (sc *SigChain) verifySigsAndComputeKeysHistorical(ctx context.Context, allL
 			allCached = false
 		}
 		prevSubchains = append(prevSubchains, links)
-		allLinks = allLinks.popNRightmostLinks(len(links))
+		allLinks = allLinks.omittingNRightmostLinks(len(links))
 	}
 	reverseListOfChainLinks(prevSubchains)
 	sc.G().Log.CDebugf(ctx, "Loaded %d additional historical subchains", len(prevSubchains))

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -260,13 +260,14 @@ func (u *User) StoreSigChain(ctx context.Context) error {
 	return err
 }
 
-func (u *User) LoadSigChains(ctx context.Context, allKeys bool, f *MerkleUserLeaf, self bool) (err error) {
+func (u *User) LoadSigChains(ctx context.Context, allKeys bool, allSubchains bool, f *MerkleUserLeaf, self bool) (err error) {
 	defer TimeLog(fmt.Sprintf("LoadSigChains: %s", u.name), u.G().Clock().Now(), u.G().Log.Debug)
 
 	loader := SigChainLoader{
 		user:         u,
 		self:         self,
 		allKeys:      allKeys,
+		allSubchains: allSubchains,
 		leaf:         f,
 		chainType:    PublicChain,
 		Contextified: u.Contextified,


### PR DESCRIPTION
r? @maxtaco 

1ad1a3490 in particular adds a duplicate data structure to store the delegations, which is a little bit dirty, but it's probably the simplest way to preserve back-compat in the cache.