### PR TITLE
Reset QR code scanned on provisioning error

### DIFF
--- a/shared/actions/login/creators.js
+++ b/shared/actions/login/creators.js
@@ -100,6 +100,10 @@ function setOtherDeviceCodeState(otherDeviceRole: Constants.DeviceRole): Constan
   return {type: Constants.setOtherDeviceCodeState, payload: otherDeviceRole}
 }
 
+function provisioningError(error: Error) {
+  return {type: Constants.provisioningError, payload: {error}}
+}
+
 function loginDone(error?: {message: string}) {
   if (error) {
     return {type: Constants.loginDone, error: true, payload: error}
@@ -163,6 +167,7 @@ export {
   onFinish,
   onWont,
   openAccountResetPage,
+  provisioningError,
   provisionTextCodeEntered,
   qrScanned,
   relogin,

--- a/shared/actions/login/saga.js
+++ b/shared/actions/login/saga.js
@@ -414,6 +414,7 @@ const getPassphraseSaga = onBackSaga =>
   }
 
 function* handleProvisioningError(error) {
+  yield put(Creators.provisioningError(error))
   yield put(
     navigateAppend(
       [

--- a/shared/constants/login.js
+++ b/shared/constants/login.js
@@ -75,6 +75,9 @@ export type SetOtherDeviceCodeState = NoErrorTypedAction<'login:setOtherDeviceCo
 export const loginDone = 'login:loginDone'
 export type LoginDone = TypedAction<'login:relogin', {}, Error>
 
+export const provisioningError = 'login:provisioningError'
+export type ProvisioningError = NoErrorTypedAction<'login:provisioningError', {error: Error}>
+
 export const actionUpdateForgotPasswordEmailAddress = 'login:actionUpdateForgotPasswordEmailAddress'
 export type UpdateForgotPasswordEmail = NoErrorTypedAction<
   'login:actionUpdateForgotPasswordEmailAddress',

--- a/shared/login/register/code-page/index.render.native.js
+++ b/shared/login/register/code-page/index.render.native.js
@@ -50,7 +50,7 @@ class CodePageRender extends Component<void, Props, void> {
       const continueOnOtherDevice = this.props.myDeviceRole === codePageDeviceRoleExistingPhone
       const scanMessage = continueOnOtherDevice
         ? 'You should follow the instructions on the other device to continue.'
-        : null
+        : 'Please wait...'
       return (
         <Box
           style={{

--- a/shared/reducers/login.js
+++ b/shared/reducers/login.js
@@ -109,6 +109,9 @@ export default function(state: Constants.State = initialState, action: any): Con
         return state
       }
       break
+    case Constants.provisioningError:
+      toMerge = {codePage: {qrCodeScanned: false}}
+      break
     case Constants.setRevokedSelf:
       toMerge = {justRevokedSelf: action.payload}
       break


### PR DESCRIPTION
Reset QR scanned state on error.

I initially tried to reset codePage to initialState but that caused a crash since the component was still mounted.

Also added a "Please wait..." once the QR code has scanned since it might take a few seconds for it to proceed.