### PR TITLE
Fix for going back taking you to the incorrect place during registration

### DIFF
--- a/shared/actions/login/saga.js
+++ b/shared/actions/login/saga.js
@@ -162,7 +162,12 @@ const kex2Sagas = (onBackSaga, provisionerSuccessSaga) => ({
 })
 
 function* cancelLogin() {
-  yield put(navigateTo(['login'], [loginTab]))
+  const getNumAccounts = (state: TypedState) =>
+    state.login.configuredAccounts && state.login.configuredAccounts.length
+  const numAccounts = yield select(getNumAccounts)
+
+  const route = numAccounts ? ['login'] : []
+  yield put(navigateTo(route, [loginTab]))
 }
 
 function* selectKeySaga() {
@@ -428,7 +433,7 @@ function* handleProvisioningError(error) {
     )
   )
   yield race({onBack: take(Constants.onBack), navUp: take(RouteConstants.navigateUp)})
-  yield put(navigateTo(['login'], [loginTab]))
+  yield call(cancelLogin)
 }
 
 function* loginFlowSaga(usernameOrEmail) {
@@ -488,7 +493,10 @@ function* initalizeMyCodeStateForAddingADevice() {
 }
 
 function* startLoginSaga() {
-  yield put(navigateAppend(['usernameOrEmail'], [loginTab, 'login']))
+  yield put(Creators.setLoginFromRevokedDevice(''))
+  yield put(Creators.setRevokedSelf(''))
+  yield put(Creators.setDeletedSelf(''))
+  yield put(navigateTo(['login', 'usernameOrEmail'], [loginTab]))
 
   yield call(initalizeMyCodeStateForLogin)
 

--- a/shared/actions/signup.js
+++ b/shared/actions/signup.js
@@ -14,7 +14,7 @@ import {
 import {isMobile} from '../constants/platform'
 import {isValidEmail, isValidName, isValidUsername} from '../util/simple-validators'
 import {loginTab} from '../constants/tabs'
-import {navBasedOnLoginState} from './login/creators'
+import * as Creators from './login/creators'
 import {navigateAppend, navigateTo} from '../actions/route-tree'
 
 import type {
@@ -84,11 +84,12 @@ function checkInviteCode(
     })
 }
 
-function requestAutoInvite(): TypedAsyncAction<
-  CheckInviteCode | NavigateAppend | NavigateTo | SignupWaiting
-> {
-  return dispatch =>
-    new Promise((resolve, reject) => {
+function requestAutoInvite(): AsyncAction {
+  return dispatch => {
+    dispatch(Creators.setLoginFromRevokedDevice(''))
+    dispatch(Creators.setRevokedSelf(''))
+    dispatch(Creators.setDeletedSelf(''))
+    return new Promise((resolve, reject) => {
       signupGetInvitationCodeRpc({
         callback: (err, inviteCode) => {
           // TODO: It would be better to book-keep having asked for an auto
@@ -109,6 +110,7 @@ function requestAutoInvite(): TypedAsyncAction<
         },
       })
     })
+  }
 }
 
 function requestInvite(
@@ -453,7 +455,7 @@ function restartSignup(): TypedAsyncAction<RestartSignup | NavigateTo> {
         payload: {},
         type: Constants.restartSignup,
       })
-      dispatch(navBasedOnLoginState())
+      dispatch(Creators.navBasedOnLoginState())
       resolve()
     })
 }

--- a/shared/login/forms/intro.js
+++ b/shared/login/forms/intro.js
@@ -2,8 +2,6 @@
 import * as Constants from '../../constants/config'
 import {Splash, Intro, Failure} from '.'
 import {connect} from 'react-redux'
-import {loginTab} from '../../constants/tabs'
-import {navigateTo} from '../../actions/route-tree'
 import {retryBootstrap} from '../../actions/config'
 import * as Creators from '../../actions/login/creators'
 import {requestAutoInvite} from '../../actions/signup'
@@ -24,19 +22,12 @@ const mapDispatchToProps = (dispatch: Dispatch, {navigateAppend}) => ({
     dispatch(navigateAppend(['feedback']))
   },
   onLogin: () => {
-    dispatch(Creators.setLoginFromRevokedDevice(''))
-    dispatch(Creators.setRevokedSelf(''))
-    dispatch(Creators.setDeletedSelf(''))
-    dispatch(navigateTo([loginTab, 'login']))
     dispatch(Creators.startLogin())
   },
   onRetry: () => {
     dispatch(retryBootstrap())
   },
   onSignup: () => {
-    dispatch(Creators.setLoginFromRevokedDevice(''))
-    dispatch(Creators.setRevokedSelf(''))
-    dispatch(Creators.setDeletedSelf(''))
     dispatch(requestAutoInvite())
   },
 })


### PR DESCRIPTION
@keybase/react-hackers this could use extra scrutiny from @chromakode and @MarcoPolo 
I'm fixing the case where you (on mobile)

1. Start clean (no users)
1. Try and provision as a device (click 'log in')
1. Click back button

It takes you to the loginTab/login (the relogin screen) and not the root loginTab.

I think the real fix is a larger overhaul of our routes in provisioning and something like
loginTab/reLogin
loginTab/newLogin
or something. This seemed like a smaller short term fix