### PR TITLE
roll back auto correct fix to keep keyboard up

### DIFF
--- a/shared/chat/conversation/input/index.native.js
+++ b/shared/chat/conversation/input/index.native.js
@@ -9,9 +9,10 @@ import {isIOS} from '../../../constants/platform'
 import type {AttachmentInput} from '../../../constants/chat'
 import type {Props} from '.'
 
-class ConversationInput extends Component<void, Props, void> {
-  _waitingOnEndEditing: boolean = false
+// TODO we don't autocorrect the last word on submit. We had a solution using blur but this also dismisses they keyboard each time
+// See if there's a better workaround later
 
+class ConversationInput extends Component<void, Props, void> {
   componentWillReceiveProps(nextProps: Props) {
     if (this.props.editingMessage !== nextProps.editingMessage) {
       if (nextProps.editingMessage && nextProps.editingMessage.type === 'Text') {
@@ -29,13 +30,6 @@ class ConversationInput extends Component<void, Props, void> {
       this.props.onShowEditor(null)
       this.props.setText('')
     }
-  }
-
-  _onSubmit = () => {
-    // Force autocorrect
-    this._waitingOnEndEditing = true
-    // We want autocorrect to work when we click send, so we just blur the input and wait for it to be done updating its value
-    this.props.inputBlur()
   }
 
   _openFilePicker = () => {
@@ -56,14 +50,8 @@ class ConversationInput extends Component<void, Props, void> {
       }
     })
   }
-  _onEndEditing = (...args) => {
-    // We only submit when it got blurred and we're waiting for submission
-    if (!this._waitingOnEndEditing) {
-      return
-    }
 
-    this._waitingOnEndEditing = false
-
+  _onSubmit = () => {
     const text = this.props.text
     if (!text) {
       return
@@ -99,7 +87,6 @@ class ConversationInput extends Component<void, Props, void> {
           multiline={true}
           onBlur={this._onBlur}
           onChangeText={this.props.setText}
-          onEndEditing={this._onEndEditing}
           ref={this.props.inputSetRef}
           small={true}
           style={styleInput}


### PR DESCRIPTION
the fix to do an autocorrect if you misstype and then submit also has a side effect of when you hit submit it hides the keyboard. I spent a little time trying to fix that but it seems kinda difficult. There's open github issues against RN about this. So in the short term i'm just making it like it used to be so your typos will go out, but your keyboard will stay up, which i think is the right tradeoff

@keybase/react-hackers 

cc: @malgorithms 