### PR TITLE
dont let images get too big on a 5s etc

### DIFF
--- a/shared/chat/conversation/messages/attachment/image.desktop.js
+++ b/shared/chat/conversation/messages/attachment/image.desktop.js
@@ -6,3 +6,7 @@ import type {ImageRenderProps} from './image'
 export function ImageRender({style, src}: ImageRenderProps) {
   return <img draggable="false" src={src} style={style} />
 }
+
+export function imgMaxWidth() {
+  return 320
+}

--- a/shared/chat/conversation/messages/attachment/image.js.flow
+++ b/shared/chat/conversation/messages/attachment/image.js.flow
@@ -6,8 +6,5 @@ export type ImageRenderProps = {
   style: Object,
 }
 
-export class ImageRender extends Component<void, ImageRenderProps, void> {}
-
-export function imgMaxWidth() {
-  return 0
-}
+declare export class ImageRender extends Component<void, ImageRenderProps, void> {}
+declare export function imgMaxWidth(): number

--- a/shared/chat/conversation/messages/attachment/image.js.flow
+++ b/shared/chat/conversation/messages/attachment/image.js.flow
@@ -7,3 +7,7 @@ export type ImageRenderProps = {
 }
 
 export class ImageRender extends Component<void, ImageRenderProps, void> {}
+
+export function imgMaxWidth() {
+  return 0
+}

--- a/shared/chat/conversation/messages/attachment/image.native.js
+++ b/shared/chat/conversation/messages/attachment/image.native.js
@@ -1,10 +1,15 @@
 // @flow
 import React from 'react'
-import {NativeImage} from '../../../../common-adapters/native-wrappers.native'
+import {NativeImage, NativeDimensions} from '../../../../common-adapters/native-wrappers.native'
 
 import type {ImageRenderProps} from './image'
 
 export function ImageRender({style, src}: ImageRenderProps) {
   const source = typeof src === 'string' ? {uri: 'file://' + src} : src
   return <NativeImage source={source} style={style} />
+}
+
+export function imgMaxWidth() {
+  const {width: maxWidth} = NativeDimensions.get('window')
+  return Math.min(320, maxWidth - 50)
 }

--- a/shared/chat/conversation/messages/attachment/index.js
+++ b/shared/chat/conversation/messages/attachment/index.js
@@ -63,10 +63,15 @@ function PreviewImage({
     }
 
     const imgWidth = imgMaxWidth()
+    // Don't exceed screen dimensions, keep it scaled
+    const previewRatio = previewSize && previewSize.width
+      ? Math.min(previewSize.width, imgWidth) / previewSize.width
+      : 1
+
     const imgStyle = {
       borderRadius: 4,
       ...(previewSize
-        ? {height: previewSize.height, width: Math.min(previewSize.width, imgWidth)}
+        ? {height: previewRatio * previewSize.height, width: previewRatio * previewSize.width}
         : {maxHeight: imgWidth, maxWidth: imgWidth}),
     }
 

--- a/shared/chat/conversation/messages/attachment/index.js
+++ b/shared/chat/conversation/messages/attachment/index.js
@@ -5,7 +5,7 @@ import React from 'react'
 import {Box, Icon, ProgressIndicator, Text, ClickableBox} from '../../../../common-adapters'
 import {isMobile, fileUIName} from '../../../../constants/platform'
 import {globalStyles, globalMargins, globalColors} from '../../../../styles'
-import {ImageRender} from './image'
+import {ImageRender, imgMaxWidth} from './image'
 
 import type {Props, ProgressBarProps, ImageIconProps} from '.'
 
@@ -61,11 +61,13 @@ function PreviewImage({
       marginTop: globalMargins.xtiny,
       position: 'relative',
     }
+
+    const imgWidth = imgMaxWidth()
     const imgStyle = {
       borderRadius: 4,
       ...(previewSize
-        ? {height: previewSize.height, width: previewSize.width}
-        : {maxHeight: 320, maxWidth: 320}),
+        ? {height: previewSize.height, width: Math.min(previewSize.width, imgWidth)}
+        : {maxHeight: imgWidth, maxWidth: imgWidth}),
     }
 
     switch (messageState) {


### PR DESCRIPTION
On a 5s preview images fixed width of 320 makes them go off the screen, this actually looks at the dimensions

@keybase/react-hackers 