### PR TITLE
workaround weird reflection explosion

### DIFF
--- a/go/kex2/transport.go
+++ b/go/kex2/transport.go
@@ -184,7 +184,8 @@ type ErrBadPacketSequence struct {
 }
 
 func (e ErrBadPacketSequence) Error() string {
-	return fmt.Sprintf("Unexpected out-of-order packet arrival (%+v)", e)
+	return fmt.Sprintf("Unexpected out-of-order packet arrival {SessionID: %v, SenderID: %v, ReceivedSeqno: %d, PrevSeqno: %d})",
+		e.SessionID, e.SenderID, e.ReceivedSeqno, e.PrevSeqno)
 }
 
 func (c *Conn) setReadError(e error) error {


### PR DESCRIPTION
Observed in the wild that this error message caused an infinite recursion. I don't understand how, but I'm guessing some sort of bug in reflection on iOS?  Anyways, workaround it for now.

When this is fixed, the error message will likely be ugly, but we'll have to check and see. We might need a special error message for this case.

Cc: @gabriel 