### PR TITLE
Enable messageboxed v2

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -281,12 +281,19 @@ func (b *Boxer) checkInvariants(ctx context.Context, convID chat1.ConversationID
 }
 
 func (b *Boxer) unbox(ctx context.Context, boxed chat1.MessageBoxed, encryptionKey types.CryptKey) (*chat1.MessageUnboxedValid, UnboxingError) {
-	b.Debug(ctx, "Unboxing message version: %v", boxed.Version)
 	switch boxed.Version {
 	case chat1.MessageBoxedVersion_VNONE, chat1.MessageBoxedVersion_V1:
-		return b.unboxV1(ctx, boxed, encryptionKey)
+		res, err := b.unboxV1(ctx, boxed, encryptionKey)
+		if err != nil {
+			b.Debug(ctx, "error unboxing message version: %v", boxed.Version)
+		}
+		return res, err
 	case chat1.MessageBoxedVersion_V2:
-		return b.unboxV2(ctx, boxed, encryptionKey)
+		res, err := b.unboxV2(ctx, boxed, encryptionKey)
+		if err != nil {
+			b.Debug(ctx, "error unboxing message version: %v", boxed.Version)
+		}
+		return res, err
 	default:
 		return nil,
 			NewPermanentUnboxingError(NewMessageBoxedVersionError(boxed.Version))
@@ -955,12 +962,19 @@ func (b *Boxer) attachMerkleRoot(ctx context.Context, msg *chat1.MessagePlaintex
 
 func (b *Boxer) box(ctx context.Context, messagePlaintext chat1.MessagePlaintext, encryptionKey types.CryptKey,
 	signingKeyPair libkb.NaclSigningKeyPair, version chat1.MessageBoxedVersion) (*chat1.MessageBoxed, error) {
-	b.Debug(ctx, "Boxing message version: %v", version)
 	switch version {
 	case chat1.MessageBoxedVersion_V1:
-		return b.boxV1(messagePlaintext, encryptionKey, signingKeyPair)
+		res, err := b.boxV1(messagePlaintext, encryptionKey, signingKeyPair)
+		if err != nil {
+			b.Debug(ctx, "error boxing message version: %v", version)
+		}
+		return res, err
 	case chat1.MessageBoxedVersion_V2:
-		return b.boxV2(messagePlaintext, encryptionKey, signingKeyPair)
+		res, err := b.boxV2(messagePlaintext, encryptionKey, signingKeyPair)
+		if err != nil {
+			b.Debug(ctx, "error boxing message version: %v", version)
+		}
+		return res, err
 	default:
 		return nil, fmt.Errorf("invalid version for boxing: %v", version)
 	}

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -133,7 +133,7 @@ func TestChatMessageBox(t *testing.T) {
 		msg := textMsg(t, "hello", mbVersion)
 		tc, boxer := setupChatTest(t, "box")
 		defer tc.Cleanup()
-		boxed, err := boxer.box(msg, key, getSigningKeyPairForTest(t, tc, nil), mbVersion)
+		boxed, err := boxer.box(context.TODO(), msg, key, getSigningKeyPairForTest(t, tc, nil), mbVersion)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -162,7 +162,7 @@ func TestChatMessageUnbox(t *testing.T) {
 
 		signKP := getSigningKeyPairForTest(t, tc, u)
 
-		boxed, err := boxer.box(msg, key, signKP, mbVersion)
+		boxed, err := boxer.box(context.TODO(), msg, key, signKP, mbVersion)
 		require.NoError(t, err)
 		boxed = remarshalBoxed(t, *boxed)
 
@@ -210,7 +210,7 @@ func TestChatMessageMissingOutboxID(t *testing.T) {
 
 	signKP := getSigningKeyPairForTest(t, tc, u)
 
-	boxed, err := boxer.box(msg, key, signKP, mbVersion)
+	boxed, err := boxer.box(context.TODO(), msg, key, signKP, mbVersion)
 	require.NoError(t, err)
 	boxed = remarshalBoxed(t, *boxed)
 
@@ -256,7 +256,7 @@ func TestChatMessageInvalidBodyHash(t *testing.T) {
 			return sum[:]
 		}
 
-		boxed, err := boxer.box(msg, key, signKP, mbVersion)
+		boxed, err := boxer.box(context.TODO(), msg, key, signKP, mbVersion)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -390,7 +390,7 @@ func TestChatMessageInvalidHeaderSig(t *testing.T) {
 			return sig
 		}
 
-		boxed, err := boxer.box(msg, key, signKP, mbVersion)
+		boxed, err := boxer.box(context.TODO(), msg, key, signKP, mbVersion)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -439,7 +439,7 @@ func TestChatMessageInvalidSenderKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		boxed, err := boxer.box(msg, key, signKP, mbVersion)
+		boxed, err := boxer.box(context.TODO(), msg, key, signKP, mbVersion)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -502,7 +502,7 @@ func TestChatMessageRevokedKeyThenSent(t *testing.T) {
 		// Sign a message using a key of u's that has been revoked
 		t.Logf("signing message")
 		msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), mbVersion)
-		boxed, err := boxer.box(msg, key, signKP, mbVersion)
+		boxed, err := boxer.box(context.TODO(), msg, key, signKP, mbVersion)
 		require.NoError(t, err)
 
 		boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -557,7 +557,7 @@ func TestChatMessageSentThenRevokedSenderKey(t *testing.T) {
 		// Sign a message using a key of u's that has not yet been revoked
 		t.Logf("signing message")
 		msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), mbVersion)
-		boxed, err := boxer.box(msg, key, signKP, mbVersion)
+		boxed, err := boxer.box(context.TODO(), msg, key, signKP, mbVersion)
 		require.NoError(t, err)
 
 		boxed.ServerHeader = &chat1.MessageServerHeader{
@@ -665,7 +665,7 @@ func TestChatMessageSenderMismatch(t *testing.T) {
 
 		signKP := getSigningKeyPairForTest(t, tc, u)
 
-		boxed, err := boxer.box(msg, key, signKP, mbVersion)
+		boxed, err := boxer.box(context.TODO(), msg, key, signKP, mbVersion)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -704,7 +704,7 @@ func TestChatMessageDeletes(t *testing.T) {
 
 		signKP := getSigningKeyPairForTest(t, tc, u)
 
-		boxed, err := boxer.box(msg, key, signKP, mbVersion)
+		boxed, err := boxer.box(context.TODO(), msg, key, signKP, mbVersion)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -742,7 +742,7 @@ func TestChatMessageDeleted(t *testing.T) {
 
 		signKP := getSigningKeyPairForTest(t, tc, u)
 
-		boxed, err := boxer.box(msg, key, signKP, mbVersion)
+		boxed, err := boxer.box(context.TODO(), msg, key, signKP, mbVersion)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -783,7 +783,7 @@ func TestChatMessageDeletedNotSuperseded(t *testing.T) {
 
 		signKP := getSigningKeyPairForTest(t, tc, u)
 
-		boxed, err := boxer.box(msg, key, signKP, mbVersion)
+		boxed, err := boxer.box(context.TODO(), msg, key, signKP, mbVersion)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1148,7 +1148,7 @@ func TestChatMessageBodyHashReplay(t *testing.T) {
 				ConversationID: convID,
 			},
 		}
-		boxed, err := boxer.box(msg, key, signKP, mbVersion)
+		boxed, err := boxer.box(context.TODO(), msg, key, signKP, mbVersion)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1204,7 +1204,7 @@ func TestChatMessagePrevPointerInconsistency(t *testing.T) {
 		makeMsg := func(id chat1.MessageID, prevs []chat1.MessagePreviousPointer) *chat1.MessageBoxed {
 			msg := textMsgWithSender(t, "foo text", gregor1.UID(u.User.GetUID().ToBytes()), mbVersion)
 			msg.ClientHeader.Prev = prevs
-			boxed, err := boxer.box(msg, key, signKP, mbVersion)
+			boxed, err := boxer.box(context.TODO(), msg, key, signKP, mbVersion)
 			require.NoError(t, err)
 			boxed.ServerHeader = &chat1.MessageServerHeader{
 				Ctime:     gregor1.ToTime(time.Now()),
@@ -1285,7 +1285,7 @@ func TestChatMessageBadConvID(t *testing.T) {
 		// This message has an all zeros ConversationIDTriple, but that's fine. We
 		// can still extract the ConvID from it.
 		msg := textMsgWithSender(t, text, gregor1.UID(u.User.GetUID().ToBytes()), mbVersion)
-		boxed, err := boxer.box(msg, key, signKP, mbVersion)
+		boxed, err := boxer.box(context.TODO(), msg, key, signKP, mbVersion)
 		require.NoError(t, err)
 		boxed.ServerHeader = &chat1.MessageServerHeader{
 			Ctime:     gregor1.ToTime(time.Now()),

--- a/go/chat/storage/storage_blockengine.go
+++ b/go/chat/storage/storage_blockengine.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-const blockIndexVersion = 6
+const blockIndexVersion = 7
 const blockSize = 100
 
 type blockEngine struct {

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -113,6 +113,8 @@ const (
 	LocalTrackMaxAge = 48 * time.Hour
 
 	CriticalClockSkewLimit = time.Hour
+
+	ChatBoxerMerkleFreshness = time.Duration(10) * time.Minute
 )
 
 const RemoteIdentifyUITimeout = 5 * time.Second

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -674,6 +674,7 @@ type MessageClientHeaderVerified struct {
 	Prev         []MessagePreviousPointer `codec:"prev" json:"prev"`
 	Sender       gregor1.UID              `codec:"sender" json:"sender"`
 	SenderDevice gregor1.DeviceID         `codec:"senderDevice" json:"senderDevice"`
+	MerkleRoot   *MerkleRoot              `codec:"merkleRoot,omitempty" json:"merkleRoot,omitempty"`
 	OutboxID     *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	OutboxInfo   *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
 }
@@ -694,6 +695,13 @@ func (o MessageClientHeaderVerified) DeepCopy() MessageClientHeaderVerified {
 		})(o.Prev),
 		Sender:       o.Sender.DeepCopy(),
 		SenderDevice: o.SenderDevice.DeepCopy(),
+		MerkleRoot: (func(x *MerkleRoot) *MerkleRoot {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.MerkleRoot),
 		OutboxID: (func(x *OutboxID) *OutboxID {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -878,6 +878,7 @@ type HeaderPlaintextV1 struct {
 	OutboxInfo      *OutboxInfo              `codec:"outboxInfo,omitempty" json:"outboxInfo,omitempty"`
 	OutboxID        *OutboxID                `codec:"outboxID,omitempty" json:"outboxID,omitempty"`
 	HeaderSignature *SignatureInfo           `codec:"headerSignature,omitempty" json:"headerSignature,omitempty"`
+	MerkleRoot      *MerkleRoot              `codec:"merkleRoot,omitempty" json:"merkleRoot,omitempty"`
 }
 
 func (o HeaderPlaintextV1) DeepCopy() HeaderPlaintextV1 {
@@ -918,6 +919,13 @@ func (o HeaderPlaintextV1) DeepCopy() HeaderPlaintextV1 {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.HeaderSignature),
+		MerkleRoot: (func(x *MerkleRoot) *MerkleRoot {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.MerkleRoot),
 	}
 }
 

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -205,12 +205,20 @@ protocol common {
     boolean tlfPublic;
     MessageType messageType;
     MessageID supersedes;
+
+    // These 2 fields are hints for the server.
+    // They can be derived from the message body, and are not signed.
     array<MessageID> deletes;
     array<MessagePreviousPointer> prev;
+
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;
-    // Latest merkle root when sent. Can be nil.
+
+    // Latest merkle root when sent.
+    // Can be nil in MBv1 messages, ignored either way since not signed.
+    // Non-nil in MBv2 messages.
     union { null, MerkleRoot } merkleRoot;
+
     union { null, OutboxID } outboxID;
     union { null, OutboxInfo } outboxInfo;
   }
@@ -229,6 +237,9 @@ protocol common {
     array<MessagePreviousPointer> prev;
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;
+    // Latest merkle root when sent.
+    // Nil from v1 messages. Non-nil from v2 messages.
+    union { null, MerkleRoot } merkleRoot;
     union { null, OutboxID } outboxID;
     union { null, OutboxInfo } outboxInfo;
   }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -163,9 +163,11 @@ protocol local {
   }
 
   // HeaderPlaintextV1 is version 1 of HeaderPlaintext.
-  // The fields here cannot change.  To modify,
-  // create a new record type with a new version.
-  // CORE-4540: Update note about how compatibility works.
+  // Non-nullable fields may not be changed.
+  // Only nullable fields may be added.
+  // This is because unboxing MessageBoxedV1 reserializes
+  // using this struct and checks for equality of the reserialized form
+  // with the signature.
   record HeaderPlaintextV1 {
     ConversationIDTriple conv;
     string tlfName;
@@ -174,15 +176,22 @@ protocol local {
     array<MessagePreviousPointer> prev;
     gregor1.UID sender;
     gregor1.DeviceID senderDevice;
+
     // MessageBoxed.V1: Hash of the encrypted body ciphertext.
     // MessageBoxed.V2: Hash of encrypted body (.v || .n || .e)
     //                  Where V is a big-endian int32
     Hash bodyHash;
+
     union { null, OutboxInfo } outboxInfo;
     union { null, OutboxID } outboxID;
+
     // MessageBoxed.V1: Signature over the serialized HeaderPlaintextV1 (with headerSignature set to null).
     // MessageBoxed.V2: Null (because the header is signencrypted outside)
     union {null, SignatureInfo} headerSignature;
+
+    // Latest merkle root when sent.
+    // Nil in MBv1 messages. Non-nil in MBv2 messages.
+    union { null, MerkleRoot } merkleRoot;
   }
 
   // HeaderPlaintext is a variant container for all the

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1299,6 +1299,7 @@ export type HeaderPlaintextV1 = {
   outboxInfo?: ?OutboxInfo,
   outboxID?: ?OutboxID,
   headerSignature?: ?SignatureInfo,
+  merkleRoot?: ?MerkleRoot,
 }
 
 export type HeaderPlaintextVersion =
@@ -1436,6 +1437,7 @@ export type MessageClientHeaderVerified = {
   prev?: ?Array<MessagePreviousPointer>,
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
+  merkleRoot?: ?MerkleRoot,
   outboxID?: ?OutboxID,
   outboxInfo?: ?OutboxInfo,
 }

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -584,6 +584,13 @@
         {
           "type": [
             null,
+            "MerkleRoot"
+          ],
+          "name": "merkleRoot"
+        },
+        {
+          "type": [
+            null,
             "OutboxID"
           ],
           "name": "outboxID"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -557,6 +557,13 @@
             "SignatureInfo"
           ],
           "name": "headerSignature"
+        },
+        {
+          "type": [
+            null,
+            "MerkleRoot"
+          ],
+          "name": "merkleRoot"
         }
       ]
     },

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1299,6 +1299,7 @@ export type HeaderPlaintextV1 = {
   outboxInfo?: ?OutboxInfo,
   outboxID?: ?OutboxID,
   headerSignature?: ?SignatureInfo,
+  merkleRoot?: ?MerkleRoot,
 }
 
 export type HeaderPlaintextVersion =
@@ -1436,6 +1437,7 @@ export type MessageClientHeaderVerified = {
   prev?: ?Array<MessagePreviousPointer>,
   sender: gregor1.UID,
   senderDevice: gregor1.DeviceID,
+  merkleRoot?: ?MerkleRoot,
   outboxID?: ?OutboxID,
   outboxInfo?: ?OutboxInfo,
 }


### PR DESCRIPTION
Starting here, clients write `MBv2` messages. This PR simultaneously adds `MerkleRoot` to `HeaderPlaintextV1` (the signed struct).

There are no MBv1 messages with a non-nil `HeaderPlaintextV1.MerkleRoot`. There are some MBv1 messages with a `MessageClientHeader.MerkleRoot`, we'll discard those values because they're not mirrored in the signed header. All MBv2 messages will have `HeaderPlaintextV1.MerkleRoot` set and that will be required to unbox.

Also this discards the local message cache. Because a client running a previous version will have unboxed V2 messages but without knowledge of the `MerkleRoot` field. So it would have MBv2 messages with `MerkleRoot=nil` in its cache. So we bust the cache (by incrementing `blockIndexVersion`).

As a reminder the header structs are:
- `remote.MessageBoxed` contains a
  - Plaintext, non-versioned `common.MessageClientHeader`
  - Sealed, versioned `local.HeaderPlaintext[V1]` 
    - which gets transmogrified into a client-local, non-versioned `common.MessageClientHeaderVerified`

The tests do not test across versions. (Except for the canned tests which do test the new client unboxing some old messages). I tested locally talking and starting conversations across MBv1/MBv2 version boundary. And I talked to Jack on prod this MBv2 client and switched back with no problems.