### PR TITLE
use actual gregor for chat server team tests CORe-5439

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
             - MYSQL_DSN=root:secret@tcp(mysql.local:3306)/keybase
             - CHAT_MYSQL_DSN=root:secret@tcp(mysql.local:3306)/keybase
             - GREGOR_TLF_SERVER=fmprpc+tls://kbweb.local:13010
+            - GREGOR_TEAM_SERVER=fmprpc+tls://kbweb.local:7890
+            - INSECURE_TLS_MODE=1
             - GREGOR_TLFAUTH_PRIVATE_SIGNING_KEY=e20589b8cd66d447aaee44b587305bd521f34f3085709b32b4e3bd479b20253e59ea153c88a8ea524d39e0ae58fa195749214b38a28fdb4229ba3390b2d33e86
             - GREGOR_TLFAUTH_PUBLIC_SIGNING_KEY=012059ea153c88a8ea524d39e0ae58fa195749214b38a28fdb4229ba3390b2d33e860a
         logging:

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -622,3 +622,24 @@ func (g *PushHandler) MembershipUpdate(ctx context.Context, m gregor.OutOfBandMe
 
 	return nil
 }
+
+func (g *PushHandler) HandleOobm(ctx context.Context, obm gregor.OutOfBandMessage) error {
+	if obm.System() == nil {
+		return errors.New("nil system in out of band message")
+	}
+
+	switch obm.System().String() {
+	case "chat.activity":
+		return g.Activity(ctx, obm)
+	case "chat.tlffinalize":
+		return g.TlfFinalize(ctx, obm)
+	case "chat.tlfresolve":
+		return g.TlfResolve(ctx, obm)
+	case "chat.typing":
+		return g.Typing(ctx, obm)
+	case "chat.membershipUpdate":
+		return g.MembershipUpdate(ctx, obm)
+	}
+
+	return nil
+}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -938,7 +938,6 @@ func (m messageSabotagerRemote) GetThreadRemote(ctx context.Context, arg chat1.G
 		return res, err
 	}
 	if len(res.Thread.Messages) > 0 {
-		fmt.Printf("SABOTAGING\n")
 		res.Thread.Messages[0].BodyCiphertext.E[0] += 50
 	}
 	return res, nil

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -18,15 +18,105 @@ import (
 	"github.com/keybase/client/go/chat/msgchecker"
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/types"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/teams"
 	"github.com/keybase/go-codec/codec"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"github.com/stretchr/testify/require"
 )
+
+type gregorTestConnection struct {
+	globals.Contextified
+	utils.DebugLabeler
+
+	cli          rpc.GenericClient
+	uid          gregor1.UID
+	sessionToken string
+}
+
+var _ rpc.ConnectionHandler = (*gregorTestConnection)(nil)
+
+func newGregorTestConnection(g *globals.Context, uid gregor1.UID, sessionToken string) *gregorTestConnection {
+	return &gregorTestConnection{
+		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g, "gregorTestConnection", false),
+		uid:          uid,
+		sessionToken: sessionToken,
+	}
+}
+
+func (g *gregorTestConnection) Connect(ctx context.Context) error {
+	uri, err := rpc.ParseFMPURI(g.G().Env.GetGregorURI())
+	if err != nil {
+		return err
+	}
+	opts := rpc.ConnectionOpts{
+		TagsFunc:      logger.LogTagsFromContextRPC,
+		WrapErrorFunc: libkb.WrapError,
+	}
+	trans := rpc.NewConnectionTransport(uri, nil, libkb.WrapError)
+	conn := rpc.NewConnectionWithTransport(g, trans, libkb.ErrorUnwrapper{}, g.G().Log, opts)
+	g.cli = conn.GetClient()
+	return nil
+}
+
+func (g *gregorTestConnection) GetClient() chat1.RemoteClient {
+	return chat1.RemoteClient{Cli: g.cli}
+}
+
+func (g *gregorTestConnection) OnConnect(ctx context.Context, conn *rpc.Connection,
+	cli rpc.GenericClient, srv *rpc.Server) error {
+	g.Debug(ctx, "logged in: authenticating")
+	ac := gregor1.AuthClient{Cli: cli}
+	auth, err := ac.AuthenticateSessionToken(ctx, gregor1.SessionToken(g.sessionToken))
+	if err != nil {
+		g.Debug(ctx, "auth error: %s", err)
+		return err
+	}
+	if !auth.Uid.Eq(g.uid) {
+		return fmt.Errorf("wrong uid authed: auth: %s uid: %s", auth.Uid, g.uid)
+	}
+
+	if err := srv.Register(gregor1.OutgoingProtocol(g)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *gregorTestConnection) BroadcastMessage(ctx context.Context, m gregor1.Message) error {
+	if obm := m.ToOutOfBandMessage(); obm != nil {
+		return g.G().PushHandler.HandleOobm(ctx, obm)
+	}
+	return nil
+}
+
+func (g *gregorTestConnection) OnConnectError(err error, reconnectThrottleDuration time.Duration) {
+}
+
+func (g *gregorTestConnection) OnDoCommandError(err error, nextTime time.Duration) {
+}
+
+func (g *gregorTestConnection) OnDisconnected(ctx context.Context, status rpc.DisconnectStatus) {
+}
+
+func (g *gregorTestConnection) ShouldRetry(name string, err error) bool {
+	return false
+}
+
+func (g *gregorTestConnection) ShouldRetryOnConnect(err error) bool {
+	return false
+}
+
+func (g *gregorTestConnection) HandlerName() string {
+	return "gregorTestConnection"
+}
 
 func newTestContext(tc *kbtest.ChatTestContext) context.Context {
 	return Context(context.Background(), tc.Context(), keybase1.TLFIdentifyBehavior_CHAT_CLI,
@@ -93,26 +183,27 @@ func teamKey(users []*kbtest.FakeUser) (res string) {
 	return res
 }
 
-var useTLFMock = true
+var useRemoteMock = true
 
 func runWithMemberTypes(t *testing.T, f func(membersType chat1.ConversationMembersType)) {
-	useTLFMock = true
+	useRemoteMock = true
 	start := time.Now()
 	t.Logf("KBFS Stage Begin")
 	f(chat1.ConversationMembersType_KBFS)
 	t.Logf("KBFS Stage End: %v", time.Now().Sub(start))
-	useTLFMock = false
+	useRemoteMock = false
 	t.Logf("Team Stage Begin")
 	start = time.Now()
 	f(chat1.ConversationMembersType_TEAM)
 	t.Logf("Team Stage End: %v", time.Now().Sub(start))
-	useTLFMock = true
+	useRemoteMock = true
 }
 
 type chatTestUserContext struct {
 	startCtx context.Context
 	u        *kbtest.FakeUser
 	h        *Server
+	ri       chat1.RemoteInterface
 }
 
 func (tuc *chatTestUserContext) user() *kbtest.FakeUser {
@@ -143,6 +234,7 @@ func (c *chatTestContext) advanceFakeClock(d time.Duration) {
 }
 
 func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserContext {
+	var ctx context.Context
 	if user == nil {
 		t.Fatalf("user is nil")
 	}
@@ -157,50 +249,65 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	}
 	g := globals.NewContext(tc.G, tc.ChatG)
 	h := NewServer(g, nil, nil, testUISource{})
-	mockRemote := kbtest.NewChatRemoteMock(c.world)
-	mockRemote.SetCurrentUser(user.User.GetUID().ToBytes())
+	uid := gregor1.UID(user.User.GetUID().ToBytes())
 
-	var ctx context.Context
-	tlf := kbtest.NewTlfMock(c.world)
-	if useTLFMock {
+	var tlf kbtest.TlfMock
+	var ri chat1.RemoteInterface
+	if useRemoteMock {
+		mockRemote := kbtest.NewChatRemoteMock(c.world)
+		mockRemote.SetCurrentUser(user.User.GetUID().ToBytes())
+		tlf = kbtest.NewTlfMock(c.world)
+		ri = mockRemote
 		ctx = newTestContextWithTlfMock(tc, tlf)
 	} else {
+		var sessionToken string
 		ctx = newTestContext(tc)
+		tc.G.LoginState().LocalSession(func(s *libkb.Session) {
+			sessionToken = s.GetToken()
+		}, "test session")
+		gh := newGregorTestConnection(tc.Context(), uid, sessionToken)
+		require.NoError(t, gh.Connect(ctx))
+		ri = gh.GetClient()
 	}
 
 	h.boxer = NewBoxer(g)
 
 	chatStorage := storage.New(g)
 	g.ConvSource = NewHybridConversationSource(g, h.boxer, chatStorage,
-		func() chat1.RemoteInterface { return mockRemote })
-	g.InboxSource = NewHybridInboxSource(g, func() chat1.RemoteInterface { return mockRemote })
+		func() chat1.RemoteInterface { return ri })
+	g.InboxSource = NewHybridInboxSource(g, func() chat1.RemoteInterface { return ri })
 	g.ServerCacheVersions = storage.NewServerVersions(g)
 	chatSyncer := NewSyncer(g)
 	g.Syncer = chatSyncer
 	g.ConnectivityMonitor = &libkb.NullConnectivityMonitor{}
 
-	h.setTestRemoteClient(mockRemote)
+	h.setTestRemoteClient(ri)
 
-	baseSender := NewBlockingSender(g, h.boxer, nil, func() chat1.RemoteInterface { return mockRemote })
+	baseSender := NewBlockingSender(g, h.boxer, nil, func() chat1.RemoteInterface { return ri })
 	deliverer := NewDeliverer(g, baseSender)
 	deliverer.SetClock(c.world.Fc)
-	if useTLFMock {
+	if useRemoteMock {
 		deliverer.setTestingNameInfoSource(tlf)
 	}
 	g.MessageDeliverer = deliverer
-	g.MessageDeliverer.Start(context.TODO(), user.User.GetUID().ToBytes())
+	g.MessageDeliverer.Start(context.TODO(), uid)
 	g.MessageDeliverer.Connected(context.TODO())
 
 	retrier := NewFetchRetrier(g)
 	retrier.SetClock(c.world.Fc)
 	g.FetchRetrier = retrier
 	g.FetchRetrier.Connected(context.TODO())
-	g.FetchRetrier.Start(context.TODO(), user.User.GetUID().ToBytes())
+	g.FetchRetrier.Start(context.TODO(), uid)
+
+	pushHandler := NewPushHandler(g)
+	pushHandler.SetClock(c.world.Fc)
+	g.PushHandler = pushHandler
 
 	tuc := &chatTestUserContext{
 		h:        h,
 		u:        user,
 		startCtx: ctx,
+		ri:       ri,
 	}
 	c.userContextCache[user.Username] = tuc
 	return tuc
@@ -316,7 +423,7 @@ func mustPostLocalForTest(t *testing.T, ctc *chatTestContext, asUser *kbtest.Fak
 	ctc.advanceFakeClock(time.Second)
 }
 
-func TestChatNewConversationLocal(t *testing.T) {
+func TestChatSrvNewConversationLocal(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "NewConversationLocal", 2)
 		defer ctc.cleanup()
@@ -325,25 +432,29 @@ func TestChatNewConversationLocal(t *testing.T) {
 		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt,
 			ctc.as(t, users[1]).user())
 
-		conv := ctc.world.GetConversationByID(created.Id)
-		if len(conv.MaxMsgs) == 0 {
+		tc := ctc.world.Tcs[users[0].Username]
+		ctx := ctc.as(t, users[0]).startCtx
+		uid := users[0].User.GetUID().ToBytes()
+		conv, _, err := GetUnverifiedConv(ctx, tc.Context(), uid, created.Id, false)
+		require.NoError(t, err)
+		if len(conv.MaxMsgSummaries) == 0 {
 			t.Fatalf("created conversation does not have a message")
 		}
 
 		switch mt {
 		case chat1.ConversationMembersType_KBFS:
-			if conv.MaxMsgs[0].ClientHeader.TlfName !=
+			if conv.MaxMsgSummaries[0].TlfName !=
 				string(kbtest.CanonicalTlfNameForTest(ctc.as(t, users[0]).user().Username+","+ctc.as(t, users[1]).user().Username)) {
 				t.Fatalf("unexpected TLF name in created conversation. expected %s, got %s", ctc.as(t, users[0]).user().Username+","+ctc.as(t, users[1]).user().Username, conv.MaxMsgs[0].ClientHeader.TlfName)
 			}
 		case chat1.ConversationMembersType_TEAM:
 			teamName := ctc.teamCache[teamKey(ctc.users())]
-			require.Equal(t, teamName, conv.MaxMsgs[0].ClientHeader.TlfName)
+			require.Equal(t, teamName, conv.MaxMsgSummaries[0].TlfName)
 		}
 	})
 }
 
-func TestChatNewChatConversationLocalTwice(t *testing.T) {
+func TestChatSrvNewChatConversationLocalTwice(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "NewConversationLocal", 2)
 		defer ctc.cleanup()
@@ -374,7 +485,7 @@ func TestChatNewDevConversationLocalTwice(t *testing.T) {
 	})
 }
 
-func TestChatNewConversationMultiTeam(t *testing.T) {
+func TestChatSrvNewConversationMultiTeam(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "NewConversationLocalTeams", 2)
 		defer ctc.cleanup()
@@ -407,7 +518,7 @@ func TestChatNewConversationMultiTeam(t *testing.T) {
 	})
 }
 
-func TestChatGetInboxAndUnboxLocal(t *testing.T) {
+func TestChatSrvGetInboxAndUnboxLocal(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "ResolveConversationLocal", 2)
 		defer ctc.cleanup()
@@ -429,9 +540,13 @@ func TestChatGetInboxAndUnboxLocal(t *testing.T) {
 		if len(conversations) != 1 {
 			t.Fatalf("unexpected response from GetInboxAndUnboxLocal. expected 1 items, got %d\n", len(conversations))
 		}
-		conv := ctc.world.GetConversationByID(created.Id)
-		if conversations[0].Info.TlfName != conv.MaxMsgs[0].ClientHeader.TlfName {
-			t.Fatalf("unexpected TlfName in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.TlfName, conv.MaxMsgs[0].ClientHeader.TlfName)
+
+		tc := ctc.world.Tcs[users[0].Username]
+		uid := users[0].User.GetUID().ToBytes()
+		conv, _, err := GetUnverifiedConv(ctx, tc.Context(), uid, created.Id, false)
+		require.NoError(t, err)
+		if conversations[0].Info.TlfName != conv.MaxMsgSummaries[0].TlfName {
+			t.Fatalf("unexpected TlfName in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.TlfName, conv.MaxMsgSummaries[0].TlfName)
 		}
 		if !conversations[0].Info.Id.Eq(created.Id) {
 			t.Fatalf("unexpected Id in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.Id, created.Id)
@@ -442,7 +557,7 @@ func TestChatGetInboxAndUnboxLocal(t *testing.T) {
 	})
 }
 
-func TestGetInboxNonblock(t *testing.T) {
+func TestChatSrvGetInboxNonblock(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "GetInboxNonblockLocal", 6)
 		defer ctc.cleanup()
@@ -549,7 +664,7 @@ func TestGetInboxNonblock(t *testing.T) {
 	})
 }
 
-func TestChatGetInboxAndUnboxLocalTlfName(t *testing.T) {
+func TestChatSrvGetInboxAndUnboxLocalTlfName(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "ResolveConversationLocal", 2)
 		defer ctc.cleanup()
@@ -584,9 +699,13 @@ func TestChatGetInboxAndUnboxLocalTlfName(t *testing.T) {
 		if len(conversations) != 1 {
 			t.Fatalf("unexpected response from GetInboxAndUnboxLocal. expected 1 items, got %d\n", len(conversations))
 		}
-		conv := ctc.world.GetConversationByID(created.Id)
-		if conversations[0].Info.TlfName != conv.MaxMsgs[0].ClientHeader.TlfName {
-			t.Fatalf("unexpected TlfName in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.TlfName, conv.MaxMsgs[0].ClientHeader.TlfName)
+
+		tc := ctc.world.Tcs[users[0].Username]
+		uid := users[0].User.GetUID().ToBytes()
+		conv, _, err := GetUnverifiedConv(ctx, tc.Context(), uid, created.Id, false)
+		require.NoError(t, err)
+		if conversations[0].Info.TlfName != conv.MaxMsgSummaries[0].TlfName {
+			t.Fatalf("unexpected TlfName in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.TlfName, conv.MaxMsgSummaries[0].TlfName)
 		}
 		if !conversations[0].Info.Id.Eq(created.Id) {
 			t.Fatalf("unexpected Id in response from GetInboxAndUnboxLocal. %s != %s\n", conversations[0].Info.Id, created.Id)
@@ -597,7 +716,7 @@ func TestChatGetInboxAndUnboxLocalTlfName(t *testing.T) {
 	})
 }
 
-func TestChatPostLocal(t *testing.T) {
+func TestChatSrvPostLocal(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "PostLocal", 2)
 		defer ctc.cleanup()
@@ -615,17 +734,23 @@ func TestChatPostLocal(t *testing.T) {
 		mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello!"}))
 
 		// we just posted this message, so should be the first one.
-		msg := ctc.world.Msgs[created.Id.String()][0]
+		uid := users[0].User.GetUID().ToBytes()
+		tc := ctc.world.Tcs[users[0].Username]
+		tv, _, err := tc.Context().ConvSource.Pull(ctc.as(t, users[0]).startCtx, created.Id, uid, nil,
+			nil)
+		require.NoError(t, err)
+		require.NotZero(t, len(tv.Messages))
+		msg := tv.Messages[0]
 
 		if mt == chat1.ConversationMembersType_KBFS {
-			require.NotEqual(t, created.TlfName, msg.ClientHeader.TlfName)
+			require.NotEqual(t, created.TlfName, msg.Valid().ClientHeader.TlfName)
 		}
-		require.NotZero(t, len(msg.ClientHeader.Sender.Bytes()))
-		require.NotZero(t, len(msg.ClientHeader.SenderDevice.Bytes()))
+		require.NotZero(t, len(msg.Valid().ClientHeader.Sender.Bytes()))
+		require.NotZero(t, len(msg.Valid().ClientHeader.SenderDevice.Bytes()))
 	})
 }
 
-func TestChatPostLocalLengthLimit(t *testing.T) {
+func TestChatSrvPostLocalLengthLimit(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "PostLocal", 2)
 		defer ctc.cleanup()
@@ -666,7 +791,7 @@ func TestChatPostLocalLengthLimit(t *testing.T) {
 	})
 }
 
-func TestChatGetThreadLocal(t *testing.T) {
+func TestChatSrvGetThreadLocal(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "GetThreadLocal", 2)
 		defer ctc.cleanup()
@@ -693,7 +818,7 @@ func TestChatGetThreadLocal(t *testing.T) {
 	})
 }
 
-func TestChatGetThreadLocalMarkAsRead(t *testing.T) {
+func TestChatSrvGetThreadLocalMarkAsRead(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		// TODO: investigate LocalDb in TestContext and make it behave the same way
 		// as in real context / docker tests. This test should fail without the fix
@@ -803,7 +928,22 @@ func TestChatGetThreadLocalMarkAsRead(t *testing.T) {
 	})
 }
 
-func TestChatGracefulUnboxing(t *testing.T) {
+type messageSabotagerRemote struct {
+	chat1.RemoteInterface
+}
+
+func (m messageSabotagerRemote) GetThreadRemote(ctx context.Context, arg chat1.GetThreadRemoteArg) (chat1.GetThreadRemoteRes, error) {
+	res, err := m.RemoteInterface.GetThreadRemote(ctx, arg)
+	if err != nil {
+		return res, err
+	}
+	if len(res.Thread.Messages) > 0 {
+		res.Thread.Messages[0].BodyCiphertext.E[0]++
+	}
+	return res, nil
+}
+
+func TestChatSrvGracefulUnboxing(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "GracefulUnboxing", 2)
 		defer ctc.cleanup()
@@ -815,13 +955,18 @@ func TestChatGracefulUnboxing(t *testing.T) {
 		mustPostLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithText(chat1.MessageText{Body: "evil hello"}))
 
 		// make evil hello evil
-		ctc.world.Tcs[users[0].Username].ChatG.ConvSource.Clear(created.Id, users[0].User.GetUID().ToBytes())
-		ctc.world.Msgs[created.Id.String()][0].BodyCiphertext.E[0]++
+		tc := ctc.world.Tcs[users[0].Username]
+		uid := users[0].User.GetUID().ToBytes()
+		require.NoError(t, tc.Context().ConvSource.Clear(created.Id, uid))
 
+		ri := ctc.as(t, users[0]).ri
+		sabRemote := messageSabotagerRemote{RemoteInterface: ri}
+		tc.Context().ConvSource.SetRemoteInterface(func() chat1.RemoteInterface { return sabRemote })
 		ctx := ctc.as(t, users[0]).startCtx
 		tv, err := ctc.as(t, users[0]).chatLocalHandler().GetThreadLocal(ctx, chat1.GetThreadLocalArg{
 			ConversationID: created.Id,
 		})
+		tc.Context().ConvSource.SetRemoteInterface(func() chat1.RemoteInterface { return ri })
 		if err != nil {
 			t.Fatalf("GetThreadLocal error: %v", err)
 		}
@@ -837,7 +982,7 @@ func TestChatGracefulUnboxing(t *testing.T) {
 	})
 }
 
-func TestChatGetInboxSummaryForCLILocal(t *testing.T) {
+func TestChatSrvGetInboxSummaryForCLILocal(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "GetInboxSummaryForCLILocal", 4)
 		defer ctc.cleanup()
@@ -961,7 +1106,7 @@ func TestChatGetInboxSummaryForCLILocal(t *testing.T) {
 	})
 }
 
-func TestGetMessagesLocal(t *testing.T) {
+func TestChatSrvGetMessagesLocal(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "GetMessagesLocal", 2)
 		defer ctc.cleanup()
@@ -1012,7 +1157,7 @@ func extractOutbox(t *testing.T, msgs []chat1.MessageUnboxed) []chat1.MessageUnb
 	return routbox
 }
 
-func TestGetOutbox(t *testing.T) {
+func TestChatSrvGetOutbox(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "GetOutbox", 3)
 		defer ctc.cleanup()
@@ -1060,7 +1205,7 @@ func TestGetOutbox(t *testing.T) {
 	})
 }
 
-func TestChatGap(t *testing.T) {
+func TestChatSrvGap(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "GetOutbox", 2)
 		defer ctc.cleanup()
@@ -1189,7 +1334,7 @@ func newServerChatListener() *serverChatListener {
 	}
 }
 
-func TestPostLocalNonblock(t *testing.T) {
+func TestChatSrvPostLocalNonblock(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "PostLocalNonblock", 2)
 		defer ctc.cleanup()
@@ -1271,7 +1416,7 @@ func TestPostLocalNonblock(t *testing.T) {
 	})
 }
 
-func TestFindConversations(t *testing.T) {
+func TestChatSrvFindConversations(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		// XXX: Public chats can't work with teams yet
 		if mt == chat1.ConversationMembersType_TEAM {
@@ -1397,7 +1542,7 @@ func receiveThreadResult(t *testing.T, cb chan kbtest.NonblockThreadResult) (res
 	return res
 }
 
-func TestGetThreadNonblock(t *testing.T) {
+func TestChatSrvGetThreadNonblock(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "GetThreadNonblock", 1)
 		defer ctc.cleanup()
@@ -1460,7 +1605,7 @@ func TestGetThreadNonblock(t *testing.T) {
 	})
 }
 
-func TestGetThreadNonblockError(t *testing.T) {
+func TestChatSrvGetThreadNonblockError(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "GetThreadNonblock", 1)
 		defer ctc.cleanup()
@@ -1516,7 +1661,7 @@ func TestGetThreadNonblockError(t *testing.T) {
 	})
 }
 
-func TestGetInboxNonblockError(t *testing.T) {
+func TestChatSrvGetInboxNonblockError(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "GetInboxNonblockLocal", 1)
 		defer ctc.cleanup()
@@ -1540,6 +1685,7 @@ func TestGetInboxNonblockError(t *testing.T) {
 		}
 		require.NoError(t, ctc.world.Tcs[users[0].Username].ChatG.ConvSource.Clear(conv.Id, uid))
 		g := ctc.world.Tcs[users[0].Username].Context()
+		ri := ctc.as(t, users[0]).ri
 		g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
 			return chat1.RemoteClient{Cli: errorClient{}}
 		})
@@ -1570,7 +1716,7 @@ func TestGetInboxNonblockError(t *testing.T) {
 
 		// Advance clock and look for stale
 		g.ConvSource.SetRemoteInterface(func() chat1.RemoteInterface {
-			return kbtest.NewChatRemoteMock(ctc.world)
+			return ri
 		})
 		ctc.world.Fc.Advance(time.Hour)
 
@@ -1599,7 +1745,7 @@ func TestGetInboxNonblockError(t *testing.T) {
 			})
 		require.Error(t, err)
 		g.InboxSource.SetRemoteInterface(func() chat1.RemoteInterface {
-			return kbtest.NewChatRemoteMock(ctc.world)
+			return ri
 		})
 		ctc.world.Fc.Advance(time.Hour)
 		select {
@@ -1623,7 +1769,7 @@ func TestGetInboxNonblockError(t *testing.T) {
 	})
 }
 
-func TestMakePreview(t *testing.T) {
+func TestChatSrvMakePreview(t *testing.T) {
 	ctc := makeChatTestContext(t, "MakePreview", 1)
 	defer ctc.cleanup()
 	user := ctc.users()[0]

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -136,6 +136,7 @@ type PushHandler interface {
 	Activity(context.Context, gregor.OutOfBandMessage) error
 	Typing(context.Context, gregor.OutOfBandMessage) error
 	MembershipUpdate(context.Context, gregor.OutOfBandMessage) error
+	HandleOobm(context.Context, gregor.OutOfBandMessage) error
 }
 
 type AppState interface {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1046,19 +1046,12 @@ func (g *gregorHandler) handleOutOfBandMessage(ctx context.Context, obm gregor.O
 		g.G().Log.Warning("Got non-exportable out-of-band message")
 	}
 
+	// Send the oobm to that chat system so that it can potentially handle it
+	g.G().PushHandler.HandleOobm(ctx, obm)
+
 	switch obm.System().String() {
 	case "kbfs.favorites":
 		return g.kbfsFavorites(ctx, obm)
-	case "chat.activity":
-		return g.G().PushHandler.Activity(ctx, obm)
-	case "chat.tlffinalize":
-		return g.G().PushHandler.TlfFinalize(ctx, obm)
-	case "chat.tlfresolve":
-		return g.G().PushHandler.TlfResolve(ctx, obm)
-	case "chat.typing":
-		return g.G().PushHandler.Typing(ctx, obm)
-	case "chat.membershipUpdate":
-		return g.G().PushHandler.MembershipUpdate(ctx, obm)
 	case "internal.reconnect":
 		g.G().Log.Debug("reconnected to push server")
 		return nil

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1047,7 +1047,9 @@ func (g *gregorHandler) handleOutOfBandMessage(ctx context.Context, obm gregor.O
 	}
 
 	// Send the oobm to that chat system so that it can potentially handle it
-	g.G().PushHandler.HandleOobm(ctx, obm)
+	if g.G().PushHandler != nil {
+		g.G().PushHandler.HandleOobm(ctx, obm)
+	}
 
 	switch obm.System().String() {
 	case "kbfs.favorites":

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -48,7 +48,7 @@ func TestGregorHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	var h *gregorHandler
-	h = newGregorHandler(globals.NewContext(tc.G, nil))
+	h = newGregorHandler(globals.NewContext(tc.G, &globals.ChatContext{}))
 	h.Init()
 	h.testingEvents = newTestingEvents()
 	require.Equal(t, "keybase service", h.HandlerName(), "wrong name")
@@ -193,7 +193,7 @@ func TestShowTrackerPopupMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	var h *gregorHandler
-	h = newGregorHandler(globals.NewContext(tc.G, nil))
+	h = newGregorHandler(globals.NewContext(tc.G, &globals.ChatContext{}))
 	h.Init()
 	h.testingEvents = newTestingEvents()
 
@@ -409,7 +409,7 @@ func setupSyncTests(t *testing.T, tc libkb.TestContext) (*gregorHandler, mockGre
 	uid := gregor1.UID(user.User.GetUID().ToBytes())
 
 	var h *gregorHandler
-	h = newGregorHandler(globals.NewContext(tc.G, nil))
+	h = newGregorHandler(globals.NewContext(tc.G, &globals.ChatContext{}))
 	h.Init()
 	h.testingEvents = newTestingEvents()
 
@@ -552,7 +552,7 @@ func TestSyncSaveRestoreFresh(t *testing.T) {
 	}
 
 	// Create a new gregor handler, this will restore our saved state
-	h = newGregorHandler(globals.NewContext(tc.G, nil))
+	h = newGregorHandler(globals.NewContext(tc.G, &globals.ChatContext{}))
 	h.Init()
 
 	// Sync from the server


### PR DESCRIPTION
Gave up trying to refactor `service/gregor.go` so I could use it directly, and just made a trimmed down version just for testing. Had to make a few changes to tests, but for the most part this plugged in nicely. 