### PR TITLE
check for URI before reconnecting on foreground CORE-5473

### DIFF
--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -221,9 +221,12 @@ func (g *gregorHandler) monitorAppState() {
 		case keybase1.AppState_BACKGROUNDACTIVE:
 			fallthrough
 		case keybase1.AppState_FOREGROUND:
-			g.chatLog.Debug(context.Background(), "foregrounded, reconnecting")
-			if err := g.Connect(g.uri); err != nil {
-				g.chatLog.Debug(context.Background(), "error reconnecting")
+			// Make sure the URI is set before attempting this (possible it isnt in a race)
+			if g.uri != nil {
+				g.chatLog.Debug(context.Background(), "foregrounded, reconnecting")
+				if err := g.Connect(g.uri); err != nil {
+					g.chatLog.Debug(context.Background(), "error reconnecting")
+				}
 			}
 		case keybase1.AppState_INACTIVE, keybase1.AppState_BACKGROUND:
 			g.chatLog.Debug(context.Background(), "backgrounded, shutting down connection")


### PR DESCRIPTION
It is possible to race into `monitorAppState` with the initial connection and try to reconnect before we have connected at all. In this case, `g.uri` will be `nil` and cause a crash. 