### PR TITLE
Add disconnected team storage and skeleton loader

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -84,6 +84,7 @@ func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride
 	kbCtx.Init()
 	kbCtx.SetServices(externals.GetServices())
 	pvlsource.NewPvlSourceAndInstall(kbCtx)
+	teams.NewTeamLoaderAndInstall(kbCtx)
 	usage := libkb.Usage{
 		Config:    true,
 		API:       true,

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -274,7 +274,7 @@ func TestChatMessageUnboxInvalidBodyHash(t *testing.T) {
 		tc, boxer := setupChatTest(t, "unbox")
 		defer tc.Cleanup()
 
-		world := kbtest.NewChatMockWorld(t, "unbox", 4)
+		world := NewChatMockWorld(t, "unbox", 4)
 		u := world.GetUsers()[0]
 		tc = world.Tcs[u.Username]
 		uid := u.User.GetUID().ToBytes()
@@ -336,7 +336,7 @@ func TestChatMessageUnboxNoCryptKey(t *testing.T) {
 		tc, boxer := setupChatTest(t, "unbox")
 		defer tc.Cleanup()
 
-		world := kbtest.NewChatMockWorld(t, "unbox", 4)
+		world := NewChatMockWorld(t, "unbox", 4)
 		u := world.GetUsers()[0]
 		uid := u.User.GetUID().ToBytes()
 		tc = world.Tcs[u.Username]
@@ -585,7 +585,7 @@ func TestChatMessagePublic(t *testing.T) {
 		tc, boxer := setupChatTest(t, "unbox")
 		defer tc.Cleanup()
 
-		world := kbtest.NewChatMockWorld(t, "unbox", 4)
+		world := NewChatMockWorld(t, "unbox", 4)
 		u := world.GetUsers()[0]
 		uid := u.User.GetUID().ToBytes()
 		tc = world.Tcs[u.Username]

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams"
 	"github.com/stretchr/testify/require"
 	context "golang.org/x/net/context"
 )
@@ -133,8 +134,16 @@ func userTc(t *testing.T, world *kbtest.ChatMockWorld, user *kbtest.FakeUser) *k
 	return &kbtest.ChatTestContext{}
 }
 
+func NewChatMockWorld(t *testing.T, name string, numUsers int) (world *kbtest.ChatMockWorld) {
+	res := kbtest.NewChatMockWorld(t, name, numUsers)
+	for _, w := range res.Tcs {
+		teams.NewTeamLoaderAndInstall(w.G)
+	}
+	return res
+}
+
 func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWorld, chat1.RemoteInterface, Sender, Sender, *chatListener) {
-	world := kbtest.NewChatMockWorld(t, "chatsender", numUsers)
+	world := NewChatMockWorld(t, "chatsender", numUsers)
 	ri := kbtest.NewChatRemoteMock(world)
 	tlf := kbtest.NewTlfMock(world)
 	u := world.GetUsers()[0]

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -132,7 +132,7 @@ type chatTestContext struct {
 
 func makeChatTestContext(t *testing.T, name string, numUsers int) *chatTestContext {
 	ctc := &chatTestContext{}
-	ctc.world = kbtest.NewChatMockWorld(t, name, numUsers)
+	ctc.world = NewChatMockWorld(t, name, numUsers)
 	ctc.userContextCache = make(map[string]*chatTestUserContext)
 	ctc.teamCache = make(map[string]string)
 	return ctc

--- a/go/encrypteddb/encrypteddb.go
+++ b/go/encrypteddb/encrypteddb.go
@@ -67,7 +67,7 @@ func (i *EncryptedDB) Get(ctx context.Context, key libkb.DbKey, res interface{})
 	}
 	pt, ok := secretbox.Open(nil, boxed.E, &boxed.N, &enckey)
 	if !ok {
-		return true, fmt.Errorf("failed to decrypt inxbox")
+		return true, fmt.Errorf("failed to decrypt item")
 	}
 
 	if err = decode(pt, res); err != nil {

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -22,6 +22,7 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/pvlsource"
 	"github.com/keybase/client/go/service"
+	"github.com/keybase/client/go/teams"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 
@@ -54,6 +55,9 @@ func main() {
 
 	// Set a pvl source
 	pvlsource.NewPvlSourceAndInstall(g)
+
+	// Set a team source
+	teams.NewTeamLoaderAndInstall(g)
 
 	// Don't abort here. This should not happen on any known version of Windows, but
 	// new MS platforms may create regressions.

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -517,8 +517,9 @@ const (
 )
 
 const (
-	EncryptionReasonChatLocalStorage EncryptionReason = "Keybase-Chat-Local-Storage-1"
-	EncryptionReasonChatMessage      EncryptionReason = "Keybase-Chat-Message-1"
+	EncryptionReasonChatLocalStorage  EncryptionReason = "Keybase-Chat-Local-Storage-1"
+	EncryptionReasonChatMessage       EncryptionReason = "Keybase-Chat-Message-1"
+	EncryptionReasonTeamsLocalStorage EncryptionReason = "Keybase-Teams-Local-Storage-1"
 )
 
 type DeriveReason string

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -164,8 +164,9 @@ func (j JSONLocalDbTransaction) Discard() {
 
 const (
 	DBUser                    = 0x00
-	DBUserPlusAllKeys         = 0x19
 	DBSig                     = 0x0f
+	DBTeamChain               = 0x10
+	DBUserPlusAllKeys         = 0x19
 	DBLink                    = 0xe0
 	DBLocalTrack              = 0xe1
 	DBPGPKey                  = 0xe3

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -68,6 +68,7 @@ type GlobalContext struct {
 	CardCache      *UserCardCache  // cache of keybase1.UserCard objects
 	fullSelfer     FullSelfer      // a loader that gets the full self object
 	pvlSource      PvlSource       // a cache and fetcher for pvl
+	teamLoader     TeamLoader
 
 	GpgClient        *GpgCLI        // A standard GPG-client (optional)
 	ShutdownHooks    []ShutdownHook // on shutdown, fire these...
@@ -271,6 +272,11 @@ func (g *GlobalContext) Logout() error {
 
 	g.GetFullSelfer().OnLogout()
 
+	tl := g.GetTeamLoader()
+	if tl != nil {
+		tl.OnLogout()
+	}
+
 	g.TrackCache = NewTrackCache()
 	g.Identify2Cache = NewIdentify2Cache(g.Env.GetUserCacheMaxAge())
 	g.CardCache = NewUserCardCache(g.Env.GetUserCacheMaxAge())
@@ -445,6 +451,10 @@ func (g *GlobalContext) GetPvlSource() PvlSource {
 // to implement ProofContext
 func (g *GlobalContext) GetAppType() AppType {
 	return g.Env.GetAppType()
+}
+
+func (g *GlobalContext) GetTeamLoader() TeamLoader {
+	return g.teamLoader
 }
 
 func (g *GlobalContext) ConfigureExportedStreams() error {
@@ -871,6 +881,10 @@ func (g *GlobalContext) SetServices(s ExternalServicesCollector) {
 
 func (g *GlobalContext) SetPvlSource(s PvlSource) {
 	g.pvlSource = s
+}
+
+func (g *GlobalContext) SetTeamLoader(l TeamLoader) {
+	g.teamLoader = l
 }
 
 func (g *GlobalContext) LoadUserByUID(uid keybase1.UID) (*User, error) {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -578,3 +578,30 @@ const (
 type ConnectivityMonitor interface {
 	IsConnected(ctx context.Context) ConnectivityMonitorResult
 }
+
+type LoadTeamArg struct {
+	// One of these must be specified.
+	// ID is preferred. Name will always hit the server.
+	// If both are specified ID will be used and Name will be checked.
+	ID   keybase1.TeamID
+	Name string
+
+	// Whether we need to be an admin.
+	// Will fail unless we are an admin in the returned Team.
+	// It is unreasonable to look at invites or list subteams with this set to false.
+	NeedAdmin bool
+	// Load at least up to the keygen. Returns an error if the keygen is not loaded.
+	NeedKeyGeneration int
+	// Refresh if these members are not current members of the team in the cache.
+	// Does not guarantee these members will be present in the returned team.
+	NeedMembers []keybase1.UserVersion
+
+	ForceFullReload bool // Ignore local data and fetch from the server.
+	ForceRepoll     bool // Force a sync with merkle.
+	StaleOK         bool // If a very stale cache hit is OK.
+}
+
+type TeamLoader interface {
+	Load(context.Context, LoadTeamArg) (*keybase1.TeamData, error)
+	OnLogout()
+}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -579,29 +579,7 @@ type ConnectivityMonitor interface {
 	IsConnected(ctx context.Context) ConnectivityMonitorResult
 }
 
-type LoadTeamArg struct {
-	// One of these must be specified.
-	// ID is preferred. Name will always hit the server.
-	// If both are specified ID will be used and Name will be checked.
-	ID   keybase1.TeamID
-	Name string
-
-	// Whether we need to be an admin.
-	// Will fail unless we are an admin in the returned Team.
-	// It is unreasonable to look at invites or list subteams with this set to false.
-	NeedAdmin bool
-	// Load at least up to the keygen. Returns an error if the keygen is not loaded.
-	NeedKeyGeneration int
-	// Refresh if these members are not current members of the team in the cache.
-	// Does not guarantee these members will be present in the returned team.
-	NeedMembers []keybase1.UserVersion
-
-	ForceFullReload bool // Ignore local data and fetch from the server.
-	ForceRepoll     bool // Force a sync with merkle.
-	StaleOK         bool // If a very stale cache hit is OK.
-}
-
 type TeamLoader interface {
-	Load(context.Context, LoadTeamArg) (*keybase1.TeamData, error)
+	Load(context.Context, keybase1.LoadTeamArg) (*keybase1.TeamData, error)
 	OnLogout()
 }

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -1148,7 +1148,7 @@ func (p PerUserKeysList) Less(i, j int) bool { return p[i].Gen < p[j].Gen }
 
 func (cki *ComputedKeyInfos) exportUPKV2Incarnation(uid keybase1.UID, username string, eldestSeqno keybase1.Seqno, kf *KeyFamily) keybase1.UserPlusKeysV2 {
 	if cki == nil {
-		cki.G().Log.Errorf("Found nil cached computed key infos for uid %s username %s, eldest seqno %s", uid.String(), username, eldestSeqno)
+		cki.G().Log.Errorf("Found nil cached computed key infos for uid %s username %s, eldest seqno %v", uid.String(), username, eldestSeqno)
 		return keybase1.UserPlusKeysV2{}
 	}
 

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -284,6 +284,10 @@ func (d DeviceID) Eq(d2 DeviceID) bool {
 	return d == d2
 }
 
+func (t TeamID) Eq(t2 TeamID) bool {
+	return t == t2
+}
+
 func UIDFromString(s string) (UID, error) {
 	if len(s) != hex.EncodedLen(UID_LEN) {
 		return "", fmt.Errorf("Bad UID '%s'; must be %d bytes long", s, UID_LEN)

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -493,6 +493,37 @@ func (o TeamCLKRMsg) DeepCopy() TeamCLKRMsg {
 	}
 }
 
+type LoadTeamArg struct {
+	ID                TeamID        `codec:"ID" json:"ID"`
+	Name              string        `codec:"name" json:"name"`
+	NeedAdmin         bool          `codec:"needAdmin" json:"needAdmin"`
+	NeedKeyGeneration int           `codec:"needKeyGeneration" json:"needKeyGeneration"`
+	NeedMembers       []UserVersion `codec:"needMembers" json:"needMembers"`
+	ForceFullReload   bool          `codec:"forceFullReload" json:"forceFullReload"`
+	ForceRepoll       bool          `codec:"forceRepoll" json:"forceRepoll"`
+	StaleOK           bool          `codec:"staleOK" json:"staleOK"`
+}
+
+func (o LoadTeamArg) DeepCopy() LoadTeamArg {
+	return LoadTeamArg{
+		ID:                o.ID.DeepCopy(),
+		Name:              o.Name,
+		NeedAdmin:         o.NeedAdmin,
+		NeedKeyGeneration: o.NeedKeyGeneration,
+		NeedMembers: (func(x []UserVersion) []UserVersion {
+			var ret []UserVersion
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.NeedMembers),
+		ForceFullReload: o.ForceFullReload,
+		ForceRepoll:     o.ForceRepoll,
+		StaleOK:         o.StaleOK,
+	}
+}
+
 type TeamCreateArg struct {
 	SessionID int    `codec:"sessionID" json:"sessionID"`
 	Name      string `codec:"name" json:"name"`

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -127,6 +127,28 @@ func (o PerTeamKey) DeepCopy() PerTeamKey {
 	}
 }
 
+type PerTeamKeySeed [32]byte
+
+func (o PerTeamKeySeed) DeepCopy() PerTeamKeySeed {
+	var ret PerTeamKeySeed
+	copy(ret[:], o[:])
+	return ret
+}
+
+type PerTeamKeySeedItem struct {
+	Seed       PerTeamKeySeed `codec:"seed" json:"seed"`
+	Generation int            `codec:"generation" json:"generation"`
+	Seqno      Seqno          `codec:"seqno" json:"seqno"`
+}
+
+func (o PerTeamKeySeedItem) DeepCopy() PerTeamKeySeedItem {
+	return PerTeamKeySeedItem{
+		Seed:       o.Seed.DeepCopy(),
+		Generation: o.Generation,
+		Seqno:      o.Seqno.DeepCopy(),
+	}
+}
+
 type TeamMember struct {
 	Uid         UID      `codec:"uid" json:"uid"`
 	Role        TeamRole `codec:"role" json:"role"`
@@ -332,6 +354,36 @@ func (o TeamPlusApplicationKeys) DeepCopy() TeamPlusApplicationKeys {
 			}
 			return ret
 		})(o.ApplicationKeys),
+	}
+}
+
+type TeamData struct {
+	Chain           TeamSigChainState    `codec:"chain" json:"chain"`
+	PerTeamKeySeeds []PerTeamKeySeedItem `codec:"perTeamKeySeeds" json:"perTeamKeySeeds"`
+	ReaderKeyMasks  []ReaderKeyMask      `codec:"readerKeyMasks" json:"readerKeyMasks"`
+	CachedAt        Time                 `codec:"cachedAt" json:"cachedAt"`
+}
+
+func (o TeamData) DeepCopy() TeamData {
+	return TeamData{
+		Chain: o.Chain.DeepCopy(),
+		PerTeamKeySeeds: (func(x []PerTeamKeySeedItem) []PerTeamKeySeedItem {
+			var ret []PerTeamKeySeedItem
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.PerTeamKeySeeds),
+		ReaderKeyMasks: (func(x []ReaderKeyMask) []ReaderKeyMask {
+			var ret []ReaderKeyMask
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.ReaderKeyMasks),
+		CachedAt: o.CachedAt.DeepCopy(),
 	}
 }
 

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -86,6 +86,10 @@ func (n TeamName) ToTeamID() keybase1.TeamID {
 	return res
 }
 
+func (n TeamName) IsSubTeam() bool {
+	return strings.Contains(string(n), ".")
+}
+
 const TeamSigChainPlayerSupportedLinkVersion = 2
 
 // Accessor wrapper for keybase1.TeamSigChainState
@@ -99,31 +103,31 @@ func (t TeamSigChainState) DeepCopy() TeamSigChainState {
 	}
 }
 
-func (t *TeamSigChainState) GetID() keybase1.TeamID {
+func (t TeamSigChainState) GetID() keybase1.TeamID {
 	return t.inner.Id
 }
 
-func (t *TeamSigChainState) GetName() string {
+func (t TeamSigChainState) GetName() string {
 	return t.inner.Name
 }
 
-func (t *TeamSigChainState) IsSubteam() bool {
+func (t TeamSigChainState) IsSubteam() bool {
 	return t.inner.ParentID != nil
 }
 
-func (t *TeamSigChainState) GetLatestSeqno() keybase1.Seqno {
+func (t TeamSigChainState) GetLatestSeqno() keybase1.Seqno {
 	return t.inner.LastSeqno
 }
 
-func (t *TeamSigChainState) GetLatestLinkID() keybase1.LinkID {
+func (t TeamSigChainState) GetLatestLinkID() keybase1.LinkID {
 	return t.inner.LastLinkID
 }
 
-func (t *TeamSigChainState) GetUserRole(user keybase1.UserVersion) (keybase1.TeamRole, error) {
+func (t TeamSigChainState) GetUserRole(user keybase1.UserVersion) (keybase1.TeamRole, error) {
 	return t.getUserRole(user), nil
 }
 
-func (t *TeamSigChainState) getUserRole(user keybase1.UserVersion) keybase1.TeamRole {
+func (t TeamSigChainState) getUserRole(user keybase1.UserVersion) keybase1.TeamRole {
 	points := t.inner.UserLog[user]
 	if len(points) == 0 {
 		return keybase1.TeamRole_NONE
@@ -132,7 +136,7 @@ func (t *TeamSigChainState) getUserRole(user keybase1.UserVersion) keybase1.Team
 	return role
 }
 
-func (t *TeamSigChainState) GetUsersWithRole(role keybase1.TeamRole) (res []keybase1.UserVersion, err error) {
+func (t TeamSigChainState) GetUsersWithRole(role keybase1.TeamRole) (res []keybase1.UserVersion, err error) {
 	if role == keybase1.TeamRole_NONE {
 		return nil, errors.New("cannot get users with NONE role")
 	}
@@ -144,7 +148,7 @@ func (t *TeamSigChainState) GetUsersWithRole(role keybase1.TeamRole) (res []keyb
 	return res, nil
 }
 
-func (t *TeamSigChainState) GetLatestPerTeamKey() (keybase1.PerTeamKey, error) {
+func (t TeamSigChainState) GetLatestPerTeamKey() (keybase1.PerTeamKey, error) {
 	res, ok := t.inner.PerTeamKeys[len(t.inner.PerTeamKeys)]
 	if !ok {
 		// if this happens it's a programming error
@@ -153,7 +157,7 @@ func (t *TeamSigChainState) GetLatestPerTeamKey() (keybase1.PerTeamKey, error) {
 	return res, nil
 }
 
-func (t *TeamSigChainState) GetPerTeamKeyAtGeneration(gen int) (keybase1.PerTeamKey, error) {
+func (t TeamSigChainState) GetPerTeamKeyAtGeneration(gen int) (keybase1.PerTeamKey, error) {
 	res, ok := t.inner.PerTeamKeys[gen]
 	if !ok {
 		return keybase1.PerTeamKey{}, libkb.NotFoundError{Msg: fmt.Sprintf("per-team-key not found for generation %d", gen)}
@@ -198,6 +202,12 @@ func NewTeamSigChainPlayer(g *libkb.GlobalContext, reader keybase1.UserVersion, 
 		isSubTeam:    isSubTeam,
 		storedState:  nil,
 	}
+}
+
+func NewTeamSigChainPlayerWithState(g *libkb.GlobalContext, reader keybase1.UserVersion, state TeamSigChainState) *TeamSigChainPlayer {
+	res := NewTeamSigChainPlayer(g, reader, state.IsSubteam())
+	res.storedState = &state
+	return res
 }
 
 func (t *TeamSigChainPlayer) GetState() (res TeamSigChainState, err error) {
@@ -466,6 +476,7 @@ func (t *TeamSigChainPlayer) addInnerLink(prevState *TeamSigChainState, link SCC
 			return res, err
 		}
 
+		// TODO check that team name has no dots
 		teamName, err := TeamNameFromString(string(*team.Name))
 		if err != nil {
 			return res, err

--- a/go/teams/chain_test.go
+++ b/go/teams/chain_test.go
@@ -29,7 +29,7 @@ type DeconstructJig struct {
 }
 
 func TestTeamSigChainParse(t *testing.T) {
-	tc := libkb.SetupTest(t, "test_team_chains", 1)
+	tc := SetupTest(t, "test_team_chains", 1)
 	defer tc.Cleanup()
 
 	var jig DeconstructJig
@@ -55,7 +55,7 @@ func TestTeamSigChainParse(t *testing.T) {
 }
 
 func TestTeamSigChainPlay1(t *testing.T) {
-	tc := libkb.SetupTest(t, "test_team_chains", 1)
+	tc := SetupTest(t, "test_team_chains", 1)
 	defer tc.Cleanup()
 
 	var jig DeconstructJig
@@ -126,7 +126,7 @@ func TestTeamSigChainPlay1(t *testing.T) {
 }
 
 func TestTeamSigChainPlay2(t *testing.T) {
-	tc := libkb.SetupTest(t, "test_team_chains", 1)
+	tc := SetupTest(t, "test_team_chains", 1)
 	defer tc.Cleanup()
 
 	var jig DeconstructJig

--- a/go/teams/common_test.go
+++ b/go/teams/common_test.go
@@ -1,0 +1,14 @@
+package teams
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+)
+
+func SetupTest(tb testing.TB, name string, depth int) (tc libkb.TestContext) {
+	ret := libkb.SetupTest(tb, name, depth+1)
+	ret.Tp.UpgradePerUserKey = true
+	NewTeamLoaderAndInstall(ret.G)
+	return ret
+}

--- a/go/teams/create_test.go
+++ b/go/teams/create_test.go
@@ -15,9 +15,6 @@ func TestCreateTeam(t *testing.T) {
 	tc := SetupTest(t, "team", 1)
 	defer tc.Cleanup()
 
-	// Magic to make the test user provision shared DH keys.
-	tc.Tp.UpgradePerUserKey = true
-
 	// Note that the length limit for a team name, with the additional suffix
 	// below, is 16 characters. We have 5 to play with, including the implicit
 	// underscore after the prefix.
@@ -33,9 +30,6 @@ func TestCreateTeam(t *testing.T) {
 func TestCreateTeamAfterAccountReset(t *testing.T) {
 	tc := SetupTest(t, "team", 1)
 	defer tc.Cleanup()
-
-	// Magic to make the test user provision shared DH keys.
-	tc.Tp.UpgradePerUserKey = true
 
 	// Note that the length limit for a team name, with the additional suffix
 	// below, is 16 characters. We have 5 to play with, including the implicit
@@ -63,8 +57,6 @@ func TestCreateSubteam(t *testing.T) {
 	tc := SetupTest(t, "team", 1)
 	defer tc.Cleanup()
 
-	// Magic to make the test user provision shared DH keys.
-	tc.Tp.UpgradePerUserKey = true
 	u, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
 	require.NoError(t, err)
 

--- a/go/teams/create_test.go
+++ b/go/teams/create_test.go
@@ -8,12 +8,11 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/kbtest"
-	"github.com/keybase/client/go/libkb"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCreateTeam(t *testing.T) {
-	tc := libkb.SetupTest(t, "team", 1)
+	tc := SetupTest(t, "team", 1)
 	defer tc.Cleanup()
 
 	// Magic to make the test user provision shared DH keys.
@@ -32,7 +31,7 @@ func TestCreateTeam(t *testing.T) {
 }
 
 func TestCreateTeamAfterAccountReset(t *testing.T) {
-	tc := libkb.SetupTest(t, "team", 1)
+	tc := SetupTest(t, "team", 1)
 	defer tc.Cleanup()
 
 	// Magic to make the test user provision shared DH keys.
@@ -61,7 +60,7 @@ func TestCreateTeamAfterAccountReset(t *testing.T) {
 }
 
 func TestCreateSubteam(t *testing.T) {
-	tc := libkb.SetupTest(t, "team", 1)
+	tc := SetupTest(t, "team", 1)
 	defer tc.Cleanup()
 
 	// Magic to make the test user provision shared DH keys.

--- a/go/teams/get_test.go
+++ b/go/teams/get_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestTeamGet(t *testing.T) {
 	tc := SetupTest(t, "team", 1)
-	tc.Tp.UpgradePerUserKey = true
 	defer tc.Cleanup()
 
 	kbtest.CreateAndSignupFakeUser("team", tc.G)
@@ -29,7 +28,6 @@ func TestTeamGet(t *testing.T) {
 
 func TestTeamApplicationKey(t *testing.T) {
 	tc := SetupTest(t, "team", 1)
-	tc.Tp.UpgradePerUserKey = true
 	defer tc.Cleanup()
 
 	kbtest.CreateAndSignupFakeUser("team", tc.G)
@@ -61,7 +59,6 @@ func TestTeamGetRepeat(t *testing.T) {
 	// in order to try to repro in CI, run this 10 times
 	for i := 0; i < 10; i++ {
 		tc := SetupTest(t, "team", 1)
-		tc.Tp.UpgradePerUserKey = true
 		defer tc.Cleanup()
 
 		kbtest.CreateAndSignupFakeUser("team", tc.G)
@@ -78,7 +75,6 @@ func TestTeamGetRepeat(t *testing.T) {
 func TestTeamGetWhileCreate(t *testing.T) {
 	t.Skip("this found create team bug")
 	tc := SetupTest(t, "team", 1)
-	tc.Tp.UpgradePerUserKey = true
 	defer tc.Cleanup()
 
 	kbtest.CreateAndSignupFakeUser("team", tc.G)
@@ -118,7 +114,6 @@ func TestTeamGetConcurrent(t *testing.T) {
 
 func teamGet(t *testing.T) {
 	tc := SetupTest(t, "team", 1)
-	tc.Tp.UpgradePerUserKey = true
 	defer tc.Cleanup()
 
 	kbtest.CreateAndSignupFakeUser("team", tc.G)

--- a/go/teams/get_test.go
+++ b/go/teams/get_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTeamGet(t *testing.T) {
-	tc := libkb.SetupTest(t, "team", 1)
+	tc := SetupTest(t, "team", 1)
 	tc.Tp.UpgradePerUserKey = true
 	defer tc.Cleanup()
 
@@ -28,7 +28,7 @@ func TestTeamGet(t *testing.T) {
 }
 
 func TestTeamApplicationKey(t *testing.T) {
-	tc := libkb.SetupTest(t, "team", 1)
+	tc := SetupTest(t, "team", 1)
 	tc.Tp.UpgradePerUserKey = true
 	defer tc.Cleanup()
 
@@ -60,7 +60,7 @@ func TestTeamGetRepeat(t *testing.T) {
 	t.Skip("not needed")
 	// in order to try to repro in CI, run this 10 times
 	for i := 0; i < 10; i++ {
-		tc := libkb.SetupTest(t, "team", 1)
+		tc := SetupTest(t, "team", 1)
 		tc.Tp.UpgradePerUserKey = true
 		defer tc.Cleanup()
 
@@ -77,7 +77,7 @@ func TestTeamGetRepeat(t *testing.T) {
 
 func TestTeamGetWhileCreate(t *testing.T) {
 	t.Skip("this found create team bug")
-	tc := libkb.SetupTest(t, "team", 1)
+	tc := SetupTest(t, "team", 1)
 	tc.Tp.UpgradePerUserKey = true
 	defer tc.Cleanup()
 
@@ -117,7 +117,7 @@ func TestTeamGetConcurrent(t *testing.T) {
 }
 
 func teamGet(t *testing.T) {
-	tc := libkb.SetupTest(t, "team", 1)
+	tc := SetupTest(t, "team", 1)
 	tc.Tp.UpgradePerUserKey = true
 	defer tc.Cleanup()
 

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -19,7 +19,7 @@ const (
 
 // Load a Team from the TeamLoader.
 // Can be called from inside the teams package.
-func Load(ctx context.Context, g *libkb.GlobalContext, lArg libkb.LoadTeamArg) (*Team, error) {
+func Load(ctx context.Context, g *libkb.GlobalContext, lArg keybase1.LoadTeamArg) (*Team, error) {
 	// teamData, err := g.GetTeamLoader().Load(ctx, lArg)
 	// if err != nil {
 	// 	return nil, err
@@ -54,7 +54,7 @@ func NewTeamLoaderAndInstall(g *libkb.GlobalContext) *TeamLoader {
 	return l
 }
 
-func (l *TeamLoader) Load(ctx context.Context, lArg libkb.LoadTeamArg) (res *keybase1.TeamData, err error) {
+func (l *TeamLoader) Load(ctx context.Context, lArg keybase1.LoadTeamArg) (res *keybase1.TeamData, err error) {
 	me, err := l.getMe(ctx)
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func (l *TeamLoader) getMe(ctx context.Context) (res keybase1.UserVersion, err e
 	return loadUserVersionByUID(ctx, l.G(), l.G().Env.GetUID())
 }
 
-func (l *TeamLoader) load(ctx context.Context, me keybase1.UserVersion, lArg libkb.LoadTeamArg) (res *keybase1.TeamData, err error) {
+func (l *TeamLoader) load(ctx context.Context, me keybase1.UserVersion, lArg keybase1.LoadTeamArg) (res *keybase1.TeamData, err error) {
 	return nil, fmt.Errorf("TODO: implement team loader")
 }
 

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -1,0 +1,75 @@
+package teams
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type LoadTeamFreshness int
+
+const (
+	LoadTeamFreshnessRANCID LoadTeamFreshness = 0
+	LoadTeamFreshnessAGED   LoadTeamFreshness = 1
+	LoadTeamFreshnessFRESH  LoadTeamFreshness = 2
+)
+
+// Load a Team from the TeamLoader.
+// Can be called from inside the teams package.
+func Load(ctx context.Context, g *libkb.GlobalContext, lArg libkb.LoadTeamArg) (*Team, error) {
+	// teamData, err := g.GetTeamLoader().Load(ctx, lArg)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	return nil, fmt.Errorf("TODO: implement team loader")
+}
+
+// Loader of keybase1.TeamData objects. Handles caching.
+// Because there is one of this global object and it is attached to G,
+// its Load interface must return a keybase1.TeamData not a teams.Team.
+// To load a teams.Team use the package-level function Load.
+// Threadsafe.
+type TeamLoader struct {
+	libkb.Contextified
+	storage *Storage
+	// Single-flight locks per team ID.
+	locktab libkb.LockTable
+}
+
+func NewTeamLoader(g *libkb.GlobalContext, storage *Storage) *TeamLoader {
+	return &TeamLoader{
+		Contextified: libkb.NewContextified(g),
+		storage:      storage,
+	}
+}
+
+// NewTeamLoaderAndInstall creates a new loader and installs it into G.
+func NewTeamLoaderAndInstall(g *libkb.GlobalContext) *TeamLoader {
+	st := NewStorage(g)
+	l := NewTeamLoader(g, st)
+	g.SetTeamLoader(l)
+	return l
+}
+
+func (l *TeamLoader) Load(ctx context.Context, lArg libkb.LoadTeamArg) (res *keybase1.TeamData, err error) {
+	me, err := l.getMe(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return l.load(ctx, me, lArg)
+}
+
+func (l *TeamLoader) getMe(ctx context.Context) (res keybase1.UserVersion, err error) {
+	return loadUserVersionByUID(ctx, l.G(), l.G().Env.GetUID())
+}
+
+func (l *TeamLoader) load(ctx context.Context, me keybase1.UserVersion, lArg libkb.LoadTeamArg) (res *keybase1.TeamData, err error) {
+	return nil, fmt.Errorf("TODO: implement team loader")
+}
+
+func (l *TeamLoader) OnLogout() {
+	l.storage.onLogout()
+}

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -1,0 +1,37 @@
+package teams
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	"github.com/stretchr/testify/require"
+)
+
+// Create n TestContexts with logged in users
+func setupNTests(t *testing.T, n int) ([]*kbtest.FakeUser, []*libkb.TestContext) {
+	require.True(t, n > 0, "must create at least 1 tc")
+	var fus []*kbtest.FakeUser
+	var tcs []*libkb.TestContext
+	for i := 0; i < n; i++ {
+		tc := SetupTest(t, "team", 1)
+		tcs = append(tcs, &tc)
+		fu, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
+		require.NoError(t, err)
+		fus = append(fus, fu)
+	}
+	return fus, tcs
+}
+
+func TestLoaderDoesntCrash(t *testing.T) {
+	tc := SetupTest(t, "team", 1)
+	_, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
+	require.NoError(t, err)
+
+	require.NotNil(t, tc.G.GetTeamLoader(), "team loader on G")
+	_, err = tc.G.GetTeamLoader().Load(context.TODO(), libkb.LoadTeamArg{})
+	require.Error(t, err, "load not implemented")
+	require.Equal(t, "TODO: implement team loader", err.Error())
+}

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,7 +32,7 @@ func TestLoaderDoesntCrash(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, tc.G.GetTeamLoader(), "team loader on G")
-	_, err = tc.G.GetTeamLoader().Load(context.TODO(), libkb.LoadTeamArg{})
+	_, err = tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{})
 	require.Error(t, err, "load not implemented")
 	require.Equal(t, "TODO: implement team loader", err.Error())
 }

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -12,7 +12,6 @@ import (
 
 func memberSetup(t *testing.T) (libkb.TestContext, *kbtest.FakeUser, string) {
 	tc := SetupTest(t, "team", 1)
-	tc.Tp.UpgradePerUserKey = true
 
 	u, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
 	if err != nil {
@@ -26,7 +25,6 @@ func memberSetup(t *testing.T) (libkb.TestContext, *kbtest.FakeUser, string) {
 
 func memberSetupMultiple(t *testing.T) (tc libkb.TestContext, owner, other *kbtest.FakeUser, name string) {
 	tc = SetupTest(t, "team", 1)
-	tc.Tp.UpgradePerUserKey = true
 
 	other, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
 	if err != nil {

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func memberSetup(t *testing.T) (libkb.TestContext, *kbtest.FakeUser, string) {
-	tc := libkb.SetupTest(t, "team", 1)
+	tc := SetupTest(t, "team", 1)
 	tc.Tp.UpgradePerUserKey = true
 
 	u, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
@@ -25,7 +25,7 @@ func memberSetup(t *testing.T) (libkb.TestContext, *kbtest.FakeUser, string) {
 }
 
 func memberSetupMultiple(t *testing.T) (tc libkb.TestContext, owner, other *kbtest.FakeUser, name string) {
-	tc = libkb.SetupTest(t, "team", 1)
+	tc = SetupTest(t, "team", 1)
 	tc.Tp.UpgradePerUserKey = true
 
 	other, err := kbtest.CreateAndSignupFakeUser("team", tc.G)

--- a/go/teams/merkle_test.go
+++ b/go/teams/merkle_test.go
@@ -6,15 +6,13 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/keybase/client/go/kbtest"
-	"github.com/keybase/client/go/libkb"
 	"github.com/stretchr/testify/require"
 )
 
 // Test getting the merkle leaf from the server.
 // This is a test of MerkleClient.
 func TestMerkle(t *testing.T) {
-	tc := libkb.SetupTest(t, "team", 1)
-	tc.Tp.UpgradePerUserKey = true
+	tc := SetupTest(t, "team", 1)
 	defer tc.Cleanup()
 
 	kbtest.CreateAndSignupFakeUser("team", tc.G)

--- a/go/teams/rpc_exim_test.go
+++ b/go/teams/rpc_exim_test.go
@@ -6,13 +6,11 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/kbtest"
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 func TestTeamPlusApplicationKeysExim(t *testing.T) {
-	tc := libkb.SetupTest(t, "TestTeamPlusApplicationKeysExim", 1)
-	tc.Tp.UpgradePerUserKey = true
+	tc := SetupTest(t, "TestTeamPlusApplicationKeysExim", 1)
 	_, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
 	if err != nil {
 		t.Fatal(err)

--- a/go/teams/rpc_exim_test.go
+++ b/go/teams/rpc_exim_test.go
@@ -1,8 +1,9 @@
 package teams
 
 import (
-	"golang.org/x/net/context"
 	"testing"
+
+	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
@@ -39,6 +40,6 @@ func TestTeamPlusApplicationKeysExim(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(exported.ApplicationKeys) != len(expectedKeys) {
-		t.Errorf("Got %s applicationKeys, expected %s", len(exported.ApplicationKeys), len(expectedKeys))
+		t.Errorf("Got %v applicationKeys, expected %v", len(exported.ApplicationKeys), len(expectedKeys))
 	}
 }

--- a/go/teams/storage.go
+++ b/go/teams/storage.go
@@ -1,0 +1,227 @@
+package teams
+
+import (
+	"fmt"
+	"log"
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru"
+	context "golang.org/x/net/context"
+
+	"github.com/keybase/client/go/encrypteddb"
+	"github.com/keybase/client/go/engine"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// Store TeamData's on memory and disk. Threadsafe.
+type Storage struct {
+	libkb.Contextified
+	sync.Mutex
+	mem  *MemoryStorage
+	disk *DiskStorage
+}
+
+func NewStorage(g *libkb.GlobalContext) *Storage {
+	return &Storage{
+		Contextified: libkb.NewContextified(g),
+		mem:          NewMemoryStorage(g),
+		disk:         NewDiskStorage(g),
+	}
+}
+
+func (s *Storage) Put(ctx context.Context, state *keybase1.TeamData) {
+	s.Lock()
+	defer s.Unlock()
+
+	state.CachedAt = keybase1.ToTime(s.G().Clock().Now())
+
+	s.mem.Put(ctx, state)
+
+	err := s.disk.Put(ctx, state)
+	if err != nil {
+		s.G().Log.CWarningf(ctx, "teams.Storage.Put err: %v", err)
+	}
+}
+
+// Can return nil.
+func (s *Storage) Get(ctx context.Context, teamID keybase1.TeamID) *keybase1.TeamData {
+	s.Lock()
+	defer s.Unlock()
+
+	item := s.mem.Get(ctx, teamID)
+	if item != nil {
+		// Mem hit
+		return item
+	}
+
+	res, found, err := s.disk.Get(ctx, teamID)
+	if found && err == nil {
+		// Disk hit
+		return res
+	}
+	if err != nil {
+		s.G().Log.Debug("teams.Storage#Get disk err: %v", err)
+	}
+
+	return nil
+}
+
+func (s *Storage) onLogout() {
+	s.mem.onLogout()
+}
+
+// --------------------------------------------------
+
+// Store TeamData's on disk. Threadsafe.
+type DiskStorage struct {
+	libkb.Contextified
+	sync.Mutex
+	encryptedDB *encrypteddb.EncryptedDB
+}
+
+// Increment to invalidate the disk cache.
+const diskStorageVersion = 1
+
+type DiskStorageItem struct {
+	Version int                `codec:"V"`
+	State   *keybase1.TeamData `codec:"S"`
+}
+
+func NewDiskStorage(g *libkb.GlobalContext) *DiskStorage {
+	keyFn := func(ctx context.Context) ([32]byte, error) {
+		return getLocalStorageSecretBoxKey(ctx, g)
+	}
+	return &DiskStorage{
+		Contextified: libkb.NewContextified(g),
+		encryptedDB:  encrypteddb.New(g, g.LocalDb, keyFn),
+	}
+}
+
+func (s *DiskStorage) Put(ctx context.Context, state *keybase1.TeamData) error {
+	s.Lock()
+	defer s.Unlock()
+
+	key := s.dbKey(ctx, state.Chain.Id)
+	item := DiskStorageItem{
+		Version: diskStorageVersion,
+		State:   state,
+	}
+
+	err := s.encryptedDB.Put(ctx, key, item)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Res is valid if (found && err == nil)
+func (s *DiskStorage) Get(ctx context.Context, teamID keybase1.TeamID) (res *keybase1.TeamData, found bool, err error) {
+	s.Lock()
+	defer s.Unlock()
+
+	key := s.dbKey(ctx, teamID)
+	var item DiskStorageItem
+	found, err = s.encryptedDB.Get(ctx, key, &item)
+	if (err != nil) || !found {
+		return res, found, err
+	}
+
+	if item.Version != diskStorageVersion {
+		// Pretend it wasn't found.
+		return res, false, nil
+	}
+
+	// Sanity check
+	if len(item.State.Chain.Id) == 0 {
+		return res, false, fmt.Errorf("decode from disk had empty team id")
+	}
+	if !item.State.Chain.Id.Eq(teamID) {
+		return res, false, fmt.Errorf("decode from disk had wrong team id %v != %v", item.State.Chain.Id, teamID)
+	}
+
+	return item.State, true, nil
+}
+
+func (s *DiskStorage) dbKey(ctx context.Context, teamID keybase1.TeamID) libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBChatInbox,
+		Key: fmt.Sprintf("tid:%s", teamID),
+	}
+}
+
+// --------------------------------------------------
+
+const MemCacheLRUSize = 50
+
+// Store some TeamSigChainState's in memory. Threadsafe.
+type MemoryStorage struct {
+	libkb.Contextified
+	lru *lru.Cache
+}
+
+func NewMemoryStorage(g *libkb.GlobalContext) *MemoryStorage {
+	nlru, err := lru.New(MemCacheLRUSize)
+	if err != nil {
+		// lru.New only panics if size <= 0
+		log.Panicf("Could not create lru cache: %v", err)
+	}
+	return &MemoryStorage{
+		Contextified: libkb.NewContextified(g),
+		lru:          nlru,
+	}
+}
+
+func (s *MemoryStorage) Put(ctx context.Context, state *keybase1.TeamData) {
+	s.lru.Add(state.Chain.Id, state)
+}
+
+// Can return nil.
+func (s *MemoryStorage) Get(ctx context.Context, teamID keybase1.TeamID) *keybase1.TeamData {
+	untyped, ok := s.lru.Get(teamID)
+	if !ok {
+		return nil
+	}
+	state, ok := untyped.(*keybase1.TeamData)
+	if !ok {
+		s.G().Log.Warning("Team MemoryStorage got bad type from lru: %T", untyped)
+		return nil
+	}
+	return state
+}
+
+func (s *MemoryStorage) onLogout() {
+	s.lru.Purge()
+}
+
+// --------------------------------------------------
+
+func getLocalStorageSecretBoxKey(ctx context.Context, g *libkb.GlobalContext) (fkey [32]byte, err error) {
+	// Get secret device key
+	encKey, err := engine.GetMySecretKey(ctx, g, getLameSecretUI, libkb.DeviceEncryptionKeyType,
+		"encrypt teams storage")
+	if err != nil {
+		return fkey, err
+	}
+	kp, ok := encKey.(libkb.NaclDHKeyPair)
+	if !ok || kp.Private == nil {
+		return fkey, libkb.KeyCannotDecryptError{}
+	}
+
+	// Derive symmetric key from device key
+	skey, err := encKey.SecretSymmetricKey(libkb.EncryptionReasonTeamsLocalStorage)
+	if err != nil {
+		return fkey, err
+	}
+
+	copy(fkey[:], skey[:])
+	return fkey, nil
+}
+
+type LameSecretUI struct{}
+
+func (d LameSecretUI) GetPassphrase(pinentry keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
+	return keybase1.GetPassphraseRes{}, fmt.Errorf("no secret UI available")
+}
+
+var getLameSecretUI = func() libkb.SecretUI { return LameSecretUI{} }

--- a/go/teams/storage_test.go
+++ b/go/teams/storage_test.go
@@ -1,0 +1,97 @@
+package teams
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func getStorageFromG(g *libkb.GlobalContext) *Storage {
+	tl := g.GetTeamLoader().(*TeamLoader)
+	return tl.storage
+}
+
+// Storage can get from memory
+func TestStorageMem(t *testing.T) {
+	tc := SetupTest(t, "team", 1)
+	_, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
+	require.NoError(t, err)
+
+	teamID := NewSubteamID()
+	st := getStorageFromG(tc.G)
+	obj := keybase1.TeamData{
+		Chain: keybase1.TeamSigChainState{
+			Id: teamID,
+		},
+	}
+
+	res := st.Get(context.TODO(), teamID)
+	require.Nil(t, res)
+	st.Put(context.TODO(), &obj)
+	res = st.Get(context.TODO(), teamID)
+	require.NotNil(t, res, "cache miss")
+	require.True(t, res == &obj, "should be the same obj from mem")
+}
+
+// Storage can get from disk.
+func TestStorageDisk(t *testing.T) {
+	tc := SetupTest(t, "team", 1)
+	_, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
+	require.NoError(t, err)
+
+	teamID := NewSubteamID()
+	st := getStorageFromG(tc.G)
+	obj := keybase1.TeamData{
+		Chain: keybase1.TeamSigChainState{
+			Id: teamID,
+		},
+	}
+
+	res := st.Get(context.TODO(), teamID)
+	require.Nil(t, res)
+	st.Put(context.TODO(), &obj)
+	t.Logf("throwing out mem storage")
+	st.mem.lru.Purge()
+	res = st.Get(context.TODO(), teamID)
+	require.NotNil(t, res, "cache miss")
+	require.False(t, res == &obj, "should be the a different object read from disk")
+	require.Equal(t, teamID, res.Chain.Id)
+}
+
+// Switching users should render other user's cache inaccessible.
+func TestStorageLogout(t *testing.T) {
+	tc := SetupTest(t, "team", 1)
+	_, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
+	require.NoError(t, err)
+
+	teamID := NewSubteamID()
+	st := getStorageFromG(tc.G)
+	obj := keybase1.TeamData{
+		Chain: keybase1.TeamSigChainState{
+			Id: teamID,
+		},
+	}
+	st.Put(context.TODO(), &obj)
+	res := st.Get(context.TODO(), teamID)
+	require.NotNil(t, res, "cache miss")
+	require.True(t, res == &obj, "should be the same obj from mem")
+
+	t.Logf("logout")
+	tc.G.Logout()
+
+	require.Equal(t, 0, st.mem.lru.Len(), "mem cache still populated")
+
+	res = st.Get(context.TODO(), teamID)
+	require.Nil(t, res, "got from cache, but should be gone")
+
+	t.Logf("login as someone else")
+	_, err = kbtest.CreateAndSignupFakeUser("team", tc.G)
+	require.NoError(t, err)
+
+	res = st.Get(context.TODO(), teamID)
+	require.Nil(t, res, "got from cache, but should be gone")
+}

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -39,6 +39,15 @@ protocol teams {
       KID encKID;
   }
 
+  fixed PerTeamKeySeed(32);
+
+  // Secret from which team keys are derived
+  record PerTeamKeySeedItem {
+    PerTeamKeySeed seed;
+    int generation;
+    Seqno seqno;
+  }
+
   record TeamMember {
     UID uid;
     TeamRole role;
@@ -81,6 +90,19 @@ protocol teams {
       array<UserVersion> onlyReaders;
 
       array<TeamApplicationKey> applicationKeys;
+  }
+
+  // This type is not really used yet.
+  // It is under the umbrella of the team loader refactor.
+  record TeamData {
+    TeamSigChainState chain;
+    // Sorted by generation ascending.
+    array<PerTeamKeySeedItem> perTeamKeySeeds;
+    array<ReaderKeyMask> readerKeyMasks;
+
+    // Should only be used by TeamLoader
+    // because it is the only mutated field, and thus is not threadsafe to read.
+    Time cachedAt;
   }
 
   // State of a parsed team sigchain.

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -133,7 +133,7 @@ protocol teams {
 
     // Set of types that were loaded stubbed-out and whose contents are missing.
     // Keyed by libkb.SigchainV2Type
-    map<int, bool> stubbedTypes;
+    map<int, boolean> stubbedTypes;
   }
 
   // A user became this role at a point in time
@@ -156,6 +156,30 @@ protocol teams {
     TeamID teamID;
     int generation;
     int score;
+  }
+
+
+  record LoadTeamArg {
+    // One of these must be specified.
+    // ID is preferred. Name will always hit the server.
+    // If both are specified ID will be used and Name will be checked.
+    @lint("ignore")
+    TeamID ID;
+    string name;
+
+    // Whether we need to be an admin.
+    // Will fail unless we are an admin in the returned Team.
+    // It is unreasonable to look at invites or list subteams with this set to false.
+    boolean needAdmin;
+    // Load at least up to the keygen. Returns an error if the keygen is not loaded.
+    int needKeyGeneration;
+    // Refresh if these members are not current members of the team in the cache.
+    // Does not guarantee these members will be present in the returned team.
+    array<UserVersion> needMembers;
+
+    boolean forceFullReload; // Ignore local data and fetch from the server.
+    boolean forceRepoll;     // Force a sync with merkle.
+    boolean staleOK;         // If a very stale cache hit is OK.
   }
 
   void teamCreate(int sessionID, string name);

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4775,6 +4775,17 @@ export type LoadDeviceErr = {
   desc: string,
 }
 
+export type LoadTeamArg = {
+  ID: TeamID,
+  name: string,
+  needAdmin: boolean,
+  needKeyGeneration: int,
+  needMembers?: ?Array<UserVersion>,
+  forceFullReload: boolean,
+  forceRepoll: boolean,
+  staleOK: boolean,
+}
+
 export type LogLevel =
     0 // NONE_0
   | 1 // DEBUG_1
@@ -5838,7 +5849,7 @@ export type TeamSigChainState = {
   parentID?: ?TeamID,
   userLog: {[key: string]: ?Array<UserLogPoint>},
   perTeamKeys: {[key: string]: PerTeamKey},
-  stubbedTypes: {[key: string]: bool},
+  stubbedTypes: {[key: string]: boolean},
 }
 
 export type Test = {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5033,6 +5033,14 @@ export type PerTeamKey = {
   encKID: KID,
 }
 
+export type PerTeamKeySeed = any
+
+export type PerTeamKeySeedItem = {
+  seed: PerTeamKeySeed,
+  generation: int,
+  seqno: Seqno,
+}
+
 export type PerUserKey = {
   gen: int,
   seqno: Seqno,
@@ -5770,6 +5778,13 @@ export type TeamChangeReq = {
   writers?: ?Array<UID>,
   readers?: ?Array<UID>,
   none?: ?Array<UID>,
+}
+
+export type TeamData = {
+  chain: TeamSigChainState,
+  perTeamKeySeeds?: ?Array<PerTeamKeySeedItem>,
+  readerKeyMasks?: ?Array<ReaderKeyMask>,
+  cachedAt: Time,
 }
 
 export type TeamID = string

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -371,7 +371,7 @@
         {
           "type": {
             "type": "map",
-            "values": "bool",
+            "values": "boolean",
             "keys": "int"
           },
           "name": "stubbedTypes"
@@ -424,6 +424,48 @@
         }
       ],
       "lint": "ignore"
+    },
+    {
+      "type": "record",
+      "name": "LoadTeamArg",
+      "fields": [
+        {
+          "type": "TeamID",
+          "name": "ID",
+          "lint": "ignore"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "boolean",
+          "name": "needAdmin"
+        },
+        {
+          "type": "int",
+          "name": "needKeyGeneration"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "UserVersion"
+          },
+          "name": "needMembers"
+        },
+        {
+          "type": "boolean",
+          "name": "forceFullReload"
+        },
+        {
+          "type": "boolean",
+          "name": "forceRepoll"
+        },
+        {
+          "type": "boolean",
+          "name": "staleOK"
+        }
+      ]
     }
   ],
   "messages": {

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -88,6 +88,29 @@
       "lint": "ignore"
     },
     {
+      "type": "fixed",
+      "name": "PerTeamKeySeed",
+      "size": "32"
+    },
+    {
+      "type": "record",
+      "name": "PerTeamKeySeedItem",
+      "fields": [
+        {
+          "type": "PerTeamKeySeed",
+          "name": "seed"
+        },
+        {
+          "type": "int",
+          "name": "generation"
+        },
+        {
+          "type": "Seqno",
+          "name": "seqno"
+        }
+      ]
+    },
+    {
       "type": "record",
       "name": "TeamMember",
       "fields": [
@@ -264,6 +287,34 @@
             "items": "TeamApplicationKey"
           },
           "name": "applicationKeys"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "TeamData",
+      "fields": [
+        {
+          "type": "TeamSigChainState",
+          "name": "chain"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "PerTeamKeySeedItem"
+          },
+          "name": "perTeamKeySeeds"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "ReaderKeyMask"
+          },
+          "name": "readerKeyMasks"
+        },
+        {
+          "type": "Time",
+          "name": "cachedAt"
         }
       ]
     },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4775,6 +4775,17 @@ export type LoadDeviceErr = {
   desc: string,
 }
 
+export type LoadTeamArg = {
+  ID: TeamID,
+  name: string,
+  needAdmin: boolean,
+  needKeyGeneration: int,
+  needMembers?: ?Array<UserVersion>,
+  forceFullReload: boolean,
+  forceRepoll: boolean,
+  staleOK: boolean,
+}
+
 export type LogLevel =
     0 // NONE_0
   | 1 // DEBUG_1
@@ -5838,7 +5849,7 @@ export type TeamSigChainState = {
   parentID?: ?TeamID,
   userLog: {[key: string]: ?Array<UserLogPoint>},
   perTeamKeys: {[key: string]: PerTeamKey},
-  stubbedTypes: {[key: string]: bool},
+  stubbedTypes: {[key: string]: boolean},
 }
 
 export type Test = {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5033,6 +5033,14 @@ export type PerTeamKey = {
   encKID: KID,
 }
 
+export type PerTeamKeySeed = any
+
+export type PerTeamKeySeedItem = {
+  seed: PerTeamKeySeed,
+  generation: int,
+  seqno: Seqno,
+}
+
 export type PerUserKey = {
   gen: int,
   seqno: Seqno,
@@ -5770,6 +5778,13 @@ export type TeamChangeReq = {
   writers?: ?Array<UID>,
   readers?: ?Array<UID>,
   none?: ?Array<UID>,
+}
+
+export type TeamData = {
+  chain: TeamSigChainState,
+  perTeamKeySeeds?: ?Array<PerTeamKeySeedItem>,
+  readerKeyMasks?: ?Array<ReaderKeyMask>,
+  cachedAt: Time,
 }
 
 export type TeamID = string


### PR DESCRIPTION
Adds some team storage code. It's not hooked up nor used. In this PR is what I think is still right from my troubled attempt to make the loader.

`TeamLoader` is attached to G and takes a `LoadTeamArg`. It's not implemented, but it's there. Eventually we'll switch stuff over from using `Get` to using `Load`.

`TeamData` is the avdl struct used to store and load teams. It will change, but not a huge amount, and either `Team` will become a wrapper around on of those, or there will be converters. I'm hoping for the former.

`Storage` stores `TeamData`s in a memory lru and on disk encrypted with a key derived from device keys. It's encrypted because the stored object contains the per team key secrets, as well as secret membership lists and stuff like that.