### PR TITLE
Rely on GPGFallback when doing pgp select --no-import

### DIFF
--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -160,7 +160,7 @@ func (e *PGPKeyImportEngine) checkPregenPrivate() error {
 	if e.arg.Pregen == nil {
 		return nil
 	}
-	if e.arg.Pregen.HasSecretKey() {
+	if e.arg.Pregen.HasSecretKey() || e.arg.GPGFallback {
 		return nil
 	}
 	return libkb.NoSecretKeyError{}

--- a/go/libkb/sign.go
+++ b/go/libkb/sign.go
@@ -21,6 +21,10 @@ func SimpleSign(payload []byte, key PGPKeyBundle) (out string, id keybase1.SigID
 	var outb bytes.Buffer
 	var in io.WriteCloser
 	var h HashSummer
+	if !key.HasSecretKey() {
+		err = NoSecretKeyError{}
+		return
+	}
 	if in, h, err = ArmoredAttachedSign(NopWriteCloser{&outb}, *key.Entity, nil, nil); err != nil {
 		return
 	}


### PR DESCRIPTION
Related issue: https://github.com/keybase/keybase-issues/issues/1976

should also fix bunch of smart card related troubles.

Future work could include:
- review of other PGP operations to see if they could benefit from shelling out, e.g. IIRC you can't do `keybase pgp sign` unless you imported to KB keyring;
- add a flag to force (old) "sign with go-crypto" behavior