### PR TITLE
include API= log tags

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -224,6 +224,8 @@ func doRequestShared(api Requester, arg APIArg, req *http.Request, wantJSONRes b
 		ctx = context.Background()
 	}
 	ctx = WithLogTag(ctx, "API")
+	arg.NetContext = ctx
+
 	api.G().Log.CDebugf(ctx, "+ API %s %s", req.Method, req.URL)
 
 	if err = api.fixHeaders(arg, req); err != nil {


### PR DESCRIPTION
this will make it a lot easier to match client logs with API server logs.