### PR TITLE
Handle zero length attachment files and reduce loadAttachmentPreview action thrashing

### DIFF
--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -10,7 +10,7 @@ import {call, take, put, select, cancel, fork, join, spawn} from 'redux-saga/eff
 import {delay} from 'redux-saga'
 import {putActionIfOnPath, navigateAppend} from '../route-tree'
 import {saveAttachmentDialog, showShareActionSheet} from '../platform-specific'
-import {tmpDir, tmpFile, downloadFilePath, copy, exists} from '../../util/file'
+import {tmpDir, tmpFile, downloadFilePath, copy, exists, stat} from '../../util/file'
 import {isMobile} from '../../constants/platform'
 import {usernameSelector} from '../../constants/selectors'
 
@@ -176,10 +176,20 @@ function* onLoadAttachment({
   }
 
   const destPath = tmpFile(Shared.tmpFileName(loadPreview, conversationIDKey, messageID))
-  const imageCached = yield call(exists, destPath)
-  if (imageCached) {
-    yield put(Creators.attachmentLoaded(conversationIDKey, messageID, destPath, loadPreview))
-    return
+  const fileExists = yield call(exists, destPath)
+  if (fileExists) {
+    try {
+      const fileStat = yield call(stat, destPath)
+      if (fileStat.size === 0) {
+        console.warn('attachment file had size 0. overwriting:', destPath)
+        // Fall through to download attachment
+      } else {
+        yield put(Creators.attachmentLoaded(conversationIDKey, messageID, destPath, loadPreview))
+        return
+      }
+    } catch (err) {
+      console.warn('unexpected error statting file:', destPath, err)
+    }
   }
 
   // Set initial progress value

--- a/shared/chat/conversation/messages/attachment/container.js
+++ b/shared/chat/conversation/messages/attachment/container.js
@@ -83,7 +83,9 @@ export default compose(
         this.props.measure()
       }
 
-      this.props.onEnsurePreviewLoaded()
+      if (this.props.message.filename !== prevProps.message.filename) {
+        this.props.onEnsurePreviewLoaded()
+      }
     },
   })
 )(Attachment)

--- a/shared/util/file.desktop.js
+++ b/shared/util/file.desktop.js
@@ -7,6 +7,8 @@ import path from 'path'
 import {findAvailableFilename} from './file.shared'
 import {cacheRoot} from '../constants/platform.desktop'
 
+import type {StatResult} from './file'
+
 function tmpDir(): string {
   return cacheRoot
 }
@@ -42,6 +44,17 @@ function exists(filepath: string): Promise<boolean> {
   })
 }
 
+function stat(filepath: string): Promise<StatResult> {
+  return new Promise((resolve, reject) => {
+    fs.stat(filepath, (err, stats) => {
+      if (err) {
+        return reject(err)
+      }
+      resolve({size: stats.size})
+    })
+  })
+}
+
 function copy(from: string, to: string) {
   fsExtra.copySync(from, to)
 }
@@ -63,6 +76,7 @@ export {
   copy,
   downloadFilePath,
   exists,
+  stat,
   tmpDir,
   tmpFile,
   tmpRandFile,

--- a/shared/util/file.js.flow
+++ b/shared/util/file.js.flow
@@ -1,13 +1,18 @@
 // @flow
 
+export type StatResult = {
+  size: number,
+}
+
 declare function tmpDir(): string
 declare function tmpFile(suffix: string): string
 declare function downloadFilePath(filename: string): Promise<string>
 declare function copy(from: string, to: string): void
 declare function exists(filename: string): Promise<boolean>
+declare function stat(filename: string): Promise<StatResult>
 declare function writeFile(filepath: string, contents: string, encoding?: string): Promise<void>
 declare function writeStream(filepath: string, encoding: string, append?: boolean): Promise<*>
 
 declare var cachesDirectoryPath: string
 
-export {cachesDirectoryPath, copy, exists, downloadFilePath, tmpDir, tmpFile, writeFile, writeStream}
+export {cachesDirectoryPath, copy, exists, downloadFilePath, stat, tmpDir, tmpFile, writeFile, writeStream}

--- a/shared/util/file.native.js
+++ b/shared/util/file.native.js
@@ -2,6 +2,8 @@
 import RNFetchBlob from 'react-native-fetch-blob'
 import {findAvailableFilename} from './file.shared'
 
+import type {StatResult} from './file'
+
 function tmpDir(): string {
   return RNFetchBlob.fs.dirs.CacheDir
 }
@@ -22,6 +24,10 @@ function exists(filepath: string): Promise<boolean> {
   return RNFetchBlob.fs.exists(filepath)
 }
 
+function stat(filepath: string): Promise<StatResult> {
+  return RNFetchBlob.fs.stat(filepath).then(stats => ({size: stats.size}))
+}
+
 function writeFile(filepath: string, contents: string, encoding?: string): Promise<void> {
   return RNFetchBlob.fs
     .createFile(filepath, '', encoding)
@@ -36,4 +42,4 @@ function writeStream(filepath: string, encoding: string, append?: boolean): Prom
 
 const cachesDirectoryPath = tmpDir()
 
-export {cachesDirectoryPath, copy, exists, downloadFilePath, tmpDir, tmpFile, writeFile, writeStream}
+export {cachesDirectoryPath, copy, exists, downloadFilePath, stat, tmpDir, tmpFile, writeFile, writeStream}


### PR DESCRIPTION
when you're expecting an attachment file but you get an empty one instead
![](https://68.media.tumblr.com/01d6906319d20e2c75d73ff37b428b4d/tumblr_or8eslb0OV1vaqoiqo1_500.gif)