### PR TITLE
Focus chat input and SearchV3 input when appropriate

### DIFF
--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -143,7 +143,6 @@ export default compose(
     componentWillReceiveProps: function(nextProps: Props) {
       if (this.props.selectedConversationIDKey !== nextProps.selectedConversationIDKey) {
         this.props.onCloseSidePanel()
-        this.props.onFocusInput()
       }
     },
   })

--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -143,6 +143,7 @@ export default compose(
     componentWillReceiveProps: function(nextProps: Props) {
       if (this.props.selectedConversationIDKey !== nextProps.selectedConversationIDKey) {
         this.props.onCloseSidePanel()
+        this.props.onFocusInput()
       }
     },
   })

--- a/shared/chat/conversation/header-or-search-header.js
+++ b/shared/chat/conversation/header-or-search-header.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Header from './header/container'
 import SearchHeader from '../search-header'
+import * as ChatConstants from '../../constants/chat'
 import * as SearchConstants from '../../constants/searchv3'
 
 type Props = {
@@ -9,6 +10,7 @@ type Props = {
   onChangeSearchText: (searchText: string) => void,
   searchText: string,
   selectedSearchId: ?SearchConstants.SearchResultId,
+  selectedConversationIDKey: ?ChatConstants.ConversationIDKey,
   onUpdateSelectedSearchResult: (id: ?SearchConstants.SearchResultId) => void,
   sidePanelOpen: boolean,
   onToggleSidePanel: () => void,
@@ -20,6 +22,7 @@ export default (props: Props) =>
     ? <SearchHeader
         onChangeSearchText={props.onChangeSearchText}
         usernameText={props.searchText}
+        selectedConversationIDKey={props.selectedConversationIDKey}
         selectedSearchId={props.selectedSearchId}
         onUpdateSelectedSearchResult={props.onUpdateSelectedSearchResult}
       />

--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -22,6 +22,14 @@ class Conversation extends Component<void, Props, State> {
     showDropOverlay: false,
   }
 
+  componentWillReceiveProps(nextProps: Props) {
+    const convoChanged = this.props.selectedConversationIDKey !== nextProps.selectedConversationIDKey
+    const inSearchChanged = this.props.inSearch !== nextProps.inSearch
+    if ((convoChanged || inSearchChanged) && !nextProps.inSearch) {
+      this.props.onFocusInput()
+    }
+  }
+
   _onDrop = e => {
     const fileList = e.dataTransfer.files
     if (!this.props.selectedConversationIDKey) throw new Error('No conversation')
@@ -104,6 +112,7 @@ class Conversation extends Component<void, Props, State> {
           onBack={this.props.onBack}
           onChangeSearchText={this.props.onChangeSearchText}
           searchText={this.props.searchText}
+          selectedConversationIDKey={this.props.selectedConversationIDKey}
           selectedSearchId={this.props.selectedSearchId}
           onUpdateSelectedSearchResult={this.props.onUpdateSelectedSearchResult}
         />

--- a/shared/chat/conversation/index.native.js
+++ b/shared/chat/conversation/index.native.js
@@ -39,6 +39,7 @@ const Conversation = (props: Props) => (
       onChangeSearchText={props.onChangeSearchText}
       searchText={props.searchText}
       selectedSearchId={props.selectedSearchId}
+      selectedConversationIDKey={props.selectedConversationIDKey}
       onUpdateSelectedSearchResult={props.onUpdateSelectedSearchResult}
     />
     {props.showSearchResults

--- a/shared/searchv3/user-input/index.desktop.js
+++ b/shared/searchv3/user-input/index.desktop.js
@@ -59,7 +59,7 @@ class UserInput extends Component<void, Props, State> {
     isFocused: false,
   }
 
-  _focusInput = () => {
+  focus = () => {
     this._textInput.focus()
   }
 
@@ -116,7 +116,7 @@ class UserInput extends Component<void, Props, State> {
     return (
       <Box
         style={{...globalStyles.flexBoxRow, alignItems: 'center', flexWrap: 'wrap'}}
-        onClick={this._focusInput}
+        onClick={this.focus}
         onMouseDown={this._preventInputDefocus}
       >
         {userItems.map(item => <UserItem {...item} onRemoveUser={onRemoveUser} key={item.id} />)}

--- a/shared/searchv3/user-input/index.js.flow
+++ b/shared/searchv3/user-input/index.js.flow
@@ -24,4 +24,6 @@ export type Props = {
   onEnter: () => void,
 }
 
-export default class UserInput extends Component<void, Props, void> {}
+export default class UserInput extends Component<void, Props, void> {
+  focus: () => void
+}

--- a/shared/searchv3/user-input/index.native.js
+++ b/shared/searchv3/user-input/index.native.js
@@ -107,8 +107,8 @@ class UserInput extends Component<void, Props, State> {
     isFocused: false,
   }
 
-  _focusInput = () => {
-    this._textInput.focus()
+  focus = () => {
+    this._textInput && this._textInput.focus()
   }
 
   _onFocus = () => {
@@ -121,7 +121,7 @@ class UserInput extends Component<void, Props, State> {
 
   _onRemoveUser = (username: string) => {
     this.props.onRemoveUser(username)
-    this._focusInput()
+    this.focus()
   }
 
   render() {
@@ -129,7 +129,7 @@ class UserInput extends Component<void, Props, State> {
 
     const showAddButton = !!userItems.length && !usernameText.length
     return (
-      <ClickableBox feedback={false} onClick={this._focusInput}>
+      <ClickableBox feedback={false} onClick={this.focus}>
         <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', flexWrap: 'wrap'}}>
           {userItems.map(item => <UserItem {...item} onRemoveUser={this._onRemoveUser} key={item.id} />)}
           <Box


### PR DESCRIPTION
* Focus chat input after switching conversations
* Focus search input after opening input or switching between filtered conversations
* Focus chat input after closing search

This got a bit hairy, but I think keying off the selectedConversation changing is the least messy way to trigger the need to focus down the component hierarchy. I don't like how this spreads the various `focus()` calls out, but after dabbling with hoisting up a focus method on `SearchHeader`, I felt this was simpler.