### PR TITLE
disable font scaling globally. allow on text messages in chat

### DIFF
--- a/shared/chat/conversation/messages/text/index.js
+++ b/shared/chat/conversation/messages/text/index.js
@@ -11,7 +11,7 @@ export type Props = {
 }
 
 const MessageText = ({text, type, isEditing}: Props) => (
-  <Markdown style={getStyle(type, isEditing)}>{text}</Markdown>
+  <Markdown style={getStyle(type, isEditing)} allowFontScaling={true}>{text}</Markdown>
 )
 
 // Encoding all 4 states as static objects so we don't re-render

--- a/shared/common-adapters/emoji.js.flow
+++ b/shared/common-adapters/emoji.js.flow
@@ -4,6 +4,7 @@ import {Component} from 'react'
 export type Props = {
   size?: number,
   emojiName: string,
+  allowFontScaling?: boolean,
 }
 
 declare function backgroundImageFn(set: string, sheetSize: string): string

--- a/shared/common-adapters/emoji.native.js
+++ b/shared/common-adapters/emoji.native.js
@@ -8,7 +8,11 @@ import type {Props} from './emoji'
 const EmojiWrapper = (props: Props) => {
   const {emojiName, size} = props
   const emojiVariantSuffx = '\ufe0f' // see http://mts.io/2015/04/21/unicode-symbol-render-text-emoji/
-  return <Text type="Body" style={{fontSize: size}}>{emojiIndexByName[emojiName] + emojiVariantSuffx}</Text>
+  return (
+    <Text type="Body" style={{fontSize: size}} allowFontScaling={props.allowFontScaling}>
+      {emojiIndexByName[emojiName] + emojiVariantSuffx}
+    </Text>
+  )
 }
 
 export default EmojiWrapper

--- a/shared/common-adapters/markdown.js.flow
+++ b/shared/common-adapters/markdown.js.flow
@@ -24,6 +24,7 @@ export type Props = {
   children?: string,
   preview?: boolean, // if true render a simplified version
   style?: Object,
+  allowFontScaling?: boolean,
 }
 
 export default class Markdown extends Component<void, Props, void> {}

--- a/shared/common-adapters/markdown.native.js
+++ b/shared/common-adapters/markdown.native.js
@@ -79,17 +79,24 @@ const _urlChooseOption = (url: ?string) => {
   ])
 }
 
-function messageCreateComponent(style) {
+function messageCreateComponent(style, allowFontScaling) {
   return function(type, key, children, options) {
+    console.log('aaa', type, key, children, options, allowFontScaling)
     switch (type) {
       case 'markup':
         return <Box key={key}>{children}</Box>
       case 'inline-code':
-        return <Text type="Body" key={key} style={codeSnippetStyle}>{children}</Text>
+        return (
+          <Text type="Body" key={key} style={codeSnippetStyle} allowFontScaling={allowFontScaling}>
+            {children}
+          </Text>
+        )
       case 'code-block':
         return (
           <Box key={key} style={codeSnippetBlockStyle}>
-            <Text type="Body" style={codeSnippetBlockTextStyle}>{children}</Text>
+            <Text type="Body" style={codeSnippetBlockTextStyle} allowFontScaling={allowFontScaling}>
+              {children}
+            </Text>
           </Box>
         )
       case 'link':
@@ -100,26 +107,46 @@ function messageCreateComponent(style) {
             style={linkStyle}
             onClickURL={options.href}
             onLongPress={() => _urlChooseOption(options.href)}
+            allowFontScaling={allowFontScaling}
           >
             {children}
           </Text>
         )
       case 'text-block':
         return (
-          <Text type="Body" key={key} style={{...neutralStyle, ...style}}>
+          <Text type="Body" key={key} style={{...neutralStyle, ...style}} allowFontScaling={allowFontScaling}>
             {children.length ? children : '\u200b'}
           </Text>
         )
       case 'bold':
-        return <Text type="BodySemibold" key={key} style={boldStyle}>{children}</Text>
+        return (
+          <Text type="BodySemibold" key={key} style={boldStyle} allowFontScaling={allowFontScaling}>
+            {children}
+          </Text>
+        )
       case 'italic':
-        return <Text type="Body" key={key} style={italicStyle}>{children}</Text>
+        return (
+          <Text type="Body" key={key} style={italicStyle} allowFontScaling={allowFontScaling}>
+            {children}
+          </Text>
+        )
       case 'strike':
-        return <Text type="Body" key={key} style={strikeStyle}>{children}</Text>
+        return (
+          <Text type="Body" key={key} style={strikeStyle} allowFontScaling={allowFontScaling}>
+            {children}
+          </Text>
+        )
       case 'emoji':
-        return <EmojiIfExists emojiName={String(children)} size={15} key={key} />
+        return (
+          <EmojiIfExists
+            emojiName={String(children)}
+            size={15}
+            key={key}
+            allowFontScaling={allowFontScaling}
+          />
+        )
       case 'native-emoji':
-        return <Emoji emojiName={String(children)} size={15} key={key} />
+        return <Emoji emojiName={String(children)} size={15} key={key} allowFontScaling={allowFontScaling} />
       case 'quote-block':
         return <Box key={key} style={quoteBlockStyle}>{children}</Box>
     }
@@ -130,10 +157,14 @@ class Markdown extends PureComponent<void, Props, void> {
   render() {
     const createComponent = this.props.preview
       ? previewCreateComponent(this.props.style)
-      : messageCreateComponent(this.props.style)
+      : messageCreateComponent(this.props.style, this.props.allowFontScaling)
     const content = parseMarkdown(this.props.children, createComponent)
     if (typeof content === 'string') {
-      return <Text type="Body" style={this.props.style}>{content}</Text>
+      return (
+        <Text type="Body" style={this.props.style} allowFontScaling={this.props.allowFontScaling}>
+          {content}
+        </Text>
+      )
     }
     return content
   }

--- a/shared/common-adapters/markdown.native.js
+++ b/shared/common-adapters/markdown.native.js
@@ -81,7 +81,6 @@ const _urlChooseOption = (url: ?string) => {
 
 function messageCreateComponent(style, allowFontScaling) {
   return function(type, key, children, options) {
-    console.log('aaa', type, key, children, options, allowFontScaling)
     switch (type) {
       case 'markup':
         return <Box key={key}>{children}</Box>

--- a/shared/common-adapters/markdown.shared.js
+++ b/shared/common-adapters/markdown.shared.js
@@ -39,12 +39,19 @@ export function parseMarkdown(markdown: ?string, markdownCreateComponent: Markdo
   }
 }
 
-export class EmojiIfExists extends PureComponent<void, EmojiProps & {style?: Object}, void> {
+export class EmojiIfExists
+  extends PureComponent<void, EmojiProps & {style?: Object, allowFontScaling?: boolean}, void> {
   render() {
     const emojiNameLower = this.props.emojiName.toLowerCase()
     const exists = !!emojiIndexByName[emojiNameLower]
     return exists
-      ? <Emoji emojiName={emojiNameLower} size={this.props.size} />
-      : <Text type="Body" style={this.props.style}>{this.props.emojiName}</Text>
+      ? <Emoji
+          emojiName={emojiNameLower}
+          size={this.props.size}
+          allowFontScaling={this.props.allowFontScaling}
+        />
+      : <Text type="Body" style={this.props.style} allowFontScaling={this.props.allowFontScaling}>
+          {this.props.emojiName}
+        </Text>
   }
 }

--- a/shared/common-adapters/text.js.flow
+++ b/shared/common-adapters/text.js.flow
@@ -52,6 +52,7 @@ type Props = {
   type: TextType,
   title?: ?string,
   allowHighlightText?: boolean, // if true, highlighttext through refs works
+  allowFontScaling?: boolean,
 }
 
 type MetaType = {

--- a/shared/common-adapters/text.native.js
+++ b/shared/common-adapters/text.native.js
@@ -42,6 +42,7 @@ class Text extends Component<void, Props, void> {
         {...lineClamp(this.props.lineClamp)}
         onPress={this.props.onClick || (this.props.onClickURL ? this._urlClick : undefined)}
         onLongPress={this.props.onLongPress}
+        allowFontScaling={this.props.allowFontScaling}
       >
         {this.props.children}
       </NativeText>

--- a/shared/index.native.js
+++ b/shared/index.native.js
@@ -8,7 +8,7 @@ import Main from './main'
 import React, {Component} from 'react'
 import {Box} from './common-adapters'
 import configureStore from './store/configure-store'
-import {AppRegistry, AppState, Linking} from 'react-native'
+import {AppRegistry, AppState, Linking, Text} from 'react-native'
 import {Provider} from 'react-redux'
 import {makeEngine} from './engine'
 import {setup as setupLocalDebug, dumbSheetOnly, dumbChatOnly} from './local-debug'
@@ -16,6 +16,13 @@ import routeDefs from './routes'
 import {setRouteDef} from './actions/route-tree'
 import {appLink, mobileAppStateChanged} from './actions/app'
 import {setupSource} from './util/forward-logs'
+
+// We don't want global font scaling as this messes up a TON of stuff. let's opt in
+function disallowFontScalingByDefault() {
+  Text.defaultProps.allowFontScaling = false
+}
+
+disallowFontScalingByDefault()
 
 module.hot &&
   module.hot.accept(() => {


### PR DESCRIPTION
@keybase/react-hackers 
if you go into system settings and accessibility you can globally increase the font on ios (and android). This disables this at a global level as this really messes up our app (font icons go all crazy etc). I did allow chats to be large (which seems to work fine). We can expand what is opted into this using the allowFontScaling prop on Text.
This may be the cause of some weird stuff people have complained about in the past we've had a hard time reproing