### PR TITLE
Use delegate ui for identify calls

### DIFF
--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -566,7 +566,7 @@ func (e *Identify2WithUID) maybeCacheResult() {
 		return
 	}
 	e.getCache().Insert(v)
-	e.G().Log.Debug("| insert %+v", v)
+	e.G().VDL.Log(libkb.VLog1, "| insert %+v", v)
 
 	// Don't write failures to the disk cache
 	if isOK {

--- a/shared/actions/tracker.js
+++ b/shared/actions/tracker.js
@@ -120,7 +120,7 @@ function triggerIdentify(
           noErrorOnTrackFailure: true,
           forceRemoteCheck: false,
           forceDisplay,
-          useDelegateUI: false,
+          useDelegateUI: true,
           needProofSet: true,
           reason: {
             type: RPCTypes.IdentifyCommonIdentifyReasonType.id,


### PR DESCRIPTION
This turns on the delegate UI for identify calls.  

Without this, identify calls don't return until all external proofs have been checked (which could take a long time).

At least in the iOS simulator, the spinners on the proofs look weird/positioned funny, so I think this needs some UI cleanup.

This should speed up profile loads as you will be able to see the basic info, picture while the proofs are being checked.

cc @maxtaco @malgorithms 