### PR TITLE
full resolver for teams

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -16,9 +16,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/client/go/pvlsource"
 	"github.com/keybase/client/go/service"
-	"github.com/keybase/client/go/teams"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"github.com/keybase/kbfs/fsrpc"
 	"github.com/keybase/kbfs/libkbfs"
@@ -84,8 +82,6 @@ func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride
 	kbCtx = libkb.G
 	kbCtx.Init()
 	kbCtx.SetServices(externals.GetServices())
-	pvlsource.NewPvlSourceAndInstall(kbCtx)
-	teams.NewTeamLoaderAndInstall(kbCtx)
 	usage := libkb.Usage{
 		Config:    true,
 		API:       true,

--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -20,9 +20,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/client/go/pvlsource"
 	"github.com/keybase/client/go/service"
-	"github.com/keybase/client/go/teams"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 
@@ -52,12 +50,6 @@ func main() {
 
 	// Set our panel of external services.
 	g.SetServices(externals.GetServices())
-
-	// Set a pvl source
-	pvlsource.NewPvlSourceAndInstall(g)
-
-	// Set a team source
-	teams.NewTeamLoaderAndInstall(g)
 
 	// Don't abort here. This should not happen on any known version of Windows, but
 	// new MS platforms may create regressions.

--- a/go/libkb/assertion.go
+++ b/go/libkb/assertion.go
@@ -130,7 +130,9 @@ type AssertionURL interface {
 	IsUID() bool
 	ToUID() keybase1.UID
 	IsTeamID() bool
+	IsTeamName() bool
 	ToTeamID() keybase1.TeamID
+	ToTeamName() keybase1.TeamName
 	IsSocial() bool
 	IsRemote() bool
 	IsFingerprint() bool
@@ -172,30 +174,33 @@ func (b AssertionURLBase) matchSet(v AssertionURL, ps ProofSet) bool {
 func (b AssertionURLBase) NeedsParens() bool { return false }
 func (b AssertionURLBase) HasOr() bool       { return false }
 
-func (a AssertionUID) MatchSet(ps ProofSet) bool     { return a.matchSet(a, ps) }
-func (a AssertionTeamID) MatchSet(ps ProofSet) bool  { return a.matchSet(a, ps) }
-func (a AssertionKeybase) MatchSet(ps ProofSet) bool { return a.matchSet(a, ps) }
-func (a AssertionWeb) MatchSet(ps ProofSet) bool     { return a.matchSet(a, ps) }
-func (a AssertionSocial) MatchSet(ps ProofSet) bool  { return a.matchSet(a, ps) }
-func (a AssertionHTTP) MatchSet(ps ProofSet) bool    { return a.matchSet(a, ps) }
-func (a AssertionHTTPS) MatchSet(ps ProofSet) bool   { return a.matchSet(a, ps) }
-func (a AssertionDNS) MatchSet(ps ProofSet) bool     { return a.matchSet(a, ps) }
+func (a AssertionUID) MatchSet(ps ProofSet) bool      { return a.matchSet(a, ps) }
+func (a AssertionTeamID) MatchSet(ps ProofSet) bool   { return a.matchSet(a, ps) }
+func (a AssertionTeamName) MatchSet(ps ProofSet) bool { return a.matchSet(a, ps) }
+func (a AssertionKeybase) MatchSet(ps ProofSet) bool  { return a.matchSet(a, ps) }
+func (a AssertionWeb) MatchSet(ps ProofSet) bool      { return a.matchSet(a, ps) }
+func (a AssertionSocial) MatchSet(ps ProofSet) bool   { return a.matchSet(a, ps) }
+func (a AssertionHTTP) MatchSet(ps ProofSet) bool     { return a.matchSet(a, ps) }
+func (a AssertionHTTPS) MatchSet(ps ProofSet) bool    { return a.matchSet(a, ps) }
+func (a AssertionDNS) MatchSet(ps ProofSet) bool      { return a.matchSet(a, ps) }
 func (a AssertionFingerprint) MatchSet(ps ProofSet) bool {
 	return a.matchSet(a, ps)
 }
 func (a AssertionWeb) Keys() []string {
 	return []string{"dns", "http", "https"}
 }
-func (a AssertionHTTP) Keys() []string                     { return []string{"http", "https"} }
-func (b AssertionURLBase) Keys() []string                  { return []string{b.Key} }
-func (b AssertionURLBase) IsKeybase() bool                 { return false }
-func (b AssertionURLBase) IsSocial() bool                  { return false }
-func (b AssertionURLBase) IsRemote() bool                  { return false }
-func (b AssertionURLBase) IsFingerprint() bool             { return false }
-func (b AssertionURLBase) IsUID() bool                     { return false }
-func (b AssertionURLBase) ToUID() (ret keybase1.UID)       { return ret }
-func (b AssertionURLBase) IsTeamID() bool                  { return false }
-func (b AssertionURLBase) ToTeamID() (ret keybase1.TeamID) { return ret }
+func (a AssertionHTTP) Keys() []string                         { return []string{"http", "https"} }
+func (b AssertionURLBase) Keys() []string                      { return []string{b.Key} }
+func (b AssertionURLBase) IsKeybase() bool                     { return false }
+func (b AssertionURLBase) IsSocial() bool                      { return false }
+func (b AssertionURLBase) IsRemote() bool                      { return false }
+func (b AssertionURLBase) IsFingerprint() bool                 { return false }
+func (b AssertionURLBase) IsUID() bool                         { return false }
+func (b AssertionURLBase) ToUID() (ret keybase1.UID)           { return ret }
+func (b AssertionURLBase) IsTeamID() bool                      { return false }
+func (b AssertionURLBase) IsTeamName() bool                    { return false }
+func (b AssertionURLBase) ToTeamID() (ret keybase1.TeamID)     { return ret }
+func (b AssertionURLBase) ToTeamName() (ret keybase1.TeamName) { return ret }
 func (b AssertionURLBase) MatchProof(proof Proof) bool {
 	return (strings.ToLower(proof.Value) == b.Value)
 }
@@ -218,6 +223,7 @@ func (a AssertionFingerprint) MatchProof(proof Proof) bool {
 
 func (a AssertionUID) CollectUrls(v []AssertionURL) []AssertionURL         { return append(v, a) }
 func (a AssertionTeamID) CollectUrls(v []AssertionURL) []AssertionURL      { return append(v, a) }
+func (a AssertionTeamName) CollectUrls(v []AssertionURL) []AssertionURL    { return append(v, a) }
 func (a AssertionKeybase) CollectUrls(v []AssertionURL) []AssertionURL     { return append(v, a) }
 func (a AssertionWeb) CollectUrls(v []AssertionURL) []AssertionURL         { return append(v, a) }
 func (a AssertionSocial) CollectUrls(v []AssertionURL) []AssertionURL      { return append(v, a) }
@@ -237,6 +243,11 @@ type AssertionTeamID struct {
 	AssertionURLBase
 	tid keybase1.TeamID
 }
+type AssertionTeamName struct {
+	AssertionURLBase
+	name keybase1.TeamName
+}
+
 type AssertionHTTP struct{ AssertionURLBase }
 type AssertionHTTPS struct{ AssertionURLBase }
 type AssertionDNS struct{ AssertionURLBase }
@@ -366,6 +377,7 @@ func (a AssertionWeb) IsRemote() bool              { return true }
 func (a AssertionFingerprint) IsFingerprint() bool { return true }
 func (a AssertionUID) IsUID() bool                 { return true }
 func (a AssertionTeamID) IsTeamID() bool           { return true }
+func (a AssertionTeamName) IsTeamName() bool       { return true }
 func (a AssertionHTTP) IsRemote() bool             { return true }
 func (a AssertionHTTPS) IsRemote() bool            { return true }
 func (a AssertionDNS) IsRemote() bool              { return true }
@@ -388,6 +400,15 @@ func (a AssertionTeamID) ToTeamID() keybase1.TeamID {
 	return a.tid
 }
 
+func (a AssertionTeamName) ToTeamName() keybase1.TeamName {
+	if a.name.IsNil() {
+		if tmp, err := keybase1.TeamNameFromString(a.Value); err != nil {
+			a.name = tmp
+		}
+	}
+	return a.name
+}
+
 func (a AssertionKeybase) ToLookup() (key, value string, err error) {
 	return "username", a.Value, nil
 }
@@ -404,13 +425,24 @@ func (a AssertionUID) CheckAndNormalize(_ AssertionContext) (AssertionURL, error
 }
 
 func (a AssertionTeamID) ToLookup() (key, value string, err error) {
-	return "id", a.Value, nil
+	return "tid", a.Value, nil
+}
+
+func (a AssertionTeamName) ToLookup() (key, value string, err error) {
+	return "team", a.Value, nil
 }
 
 func (a AssertionTeamID) CheckAndNormalize(_ AssertionContext) (AssertionURL, error) {
 	var err error
 	a.tid, err = keybase1.TeamIDFromString(a.Value)
 	a.Value = strings.ToLower(a.Value)
+	return a, err
+}
+
+func (a AssertionTeamName) CheckAndNormalize(_ AssertionContext) (AssertionURL, error) {
+	var err error
+	a.name, err = keybase1.TeamNameFromString(a.Value)
+	a.Value = a.name.String()
 	return a, err
 }
 
@@ -451,6 +483,8 @@ func ParseAssertionURLKeyValue(ctx AssertionContext, key string, val string, str
 		ret = AssertionUID{AssertionURLBase: base}
 	case "tid":
 		ret = AssertionTeamID{AssertionURLBase: base}
+	case "team":
+		ret = AssertionTeamName{AssertionURLBase: base}
 	case "web":
 		ret = AssertionWeb{base}
 	case "http":
@@ -504,16 +538,22 @@ func FindBestIdentifyComponentURL(e AssertionExpression) AssertionURL {
 		return nil
 	}
 
-	var uid, kb, soc, fp, rooter AssertionURL
+	var uid, tid, kb, team, soc, fp, rooter AssertionURL
 
 	for _, u := range urls {
 		if u.IsUID() {
 			uid = u
 			break
 		}
+		if u.IsTeamID() {
+			tid = u
+			break
+		}
 
 		if u.IsKeybase() {
 			kb = u
+		} else if u.IsTeamName() {
+			team = u
 		} else if u.IsFingerprint() && fp == nil {
 			fp = u
 		} else if u.IsSocial() {
@@ -526,7 +566,7 @@ func FindBestIdentifyComponentURL(e AssertionExpression) AssertionURL {
 		}
 	}
 
-	order := []AssertionURL{uid, kb, fp, rooter, soc, urls[0]}
+	order := []AssertionURL{uid, tid, kb, team, fp, rooter, soc, urls[0]}
 	for _, p := range order {
 		if p != nil {
 			return p
@@ -553,4 +593,8 @@ func CollectAssertions(e AssertionExpression) (remotes AssertionAnd, locals Asse
 		}
 	}
 	return remotes, locals
+}
+
+func AssertionIsTeam(au AssertionURL) bool {
+	return au != nil && (au.IsTeamID() || au.IsTeamName())
 }

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -65,10 +65,10 @@ type GlobalContext struct {
 	Identify2Cache Identify2Cacher // cache of Identify2 results for fast-pathing identify2 RPCS
 	LinkCache      *LinkCache      // cache of ChainLinks
 	upakLoader     UPAKLoader      // Load flat users with the ability to hit the cache
+	teamLoader     TeamLoader      // Play back teams for id/name properties
 	CardCache      *UserCardCache  // cache of keybase1.UserCard objects
 	fullSelfer     FullSelfer      // a loader that gets the full self object
 	pvlSource      PvlSource       // a cache and fetcher for pvl
-	teamLoader     TeamLoader
 
 	GpgClient        *GpgCLI        // A standard GPG-client (optional)
 	ShutdownHooks    []ShutdownHook // on shutdown, fire these...
@@ -193,6 +193,7 @@ func (g *GlobalContext) Init() *GlobalContext {
 	g.Resolver = NewResolver(g)
 	g.RateLimits = NewRateLimits(g)
 	g.upakLoader = NewUncachedUPAKLoader(g)
+	g.teamLoader = newNullTeamLoader(g)
 	g.fullSelfer = NewUncachedFullSelf(g)
 	g.ConnectivityMonitor = NullConnectivityMonitor{}
 	g.AppState = NewAppState(g)
@@ -272,7 +273,7 @@ func (g *GlobalContext) Logout() error {
 
 	g.GetFullSelfer().OnLogout()
 
-	tl := g.GetTeamLoader()
+	tl := g.teamLoader
 	if tl != nil {
 		tl.OnLogout()
 	}
@@ -440,6 +441,12 @@ func (g *GlobalContext) GetUPAKLoader() UPAKLoader {
 	return g.upakLoader
 }
 
+func (g *GlobalContext) GetTeamLoader() TeamLoader {
+	g.cacheMu.RLock()
+	defer g.cacheMu.RUnlock()
+	return g.teamLoader
+}
+
 func (g *GlobalContext) GetFullSelfer() FullSelfer {
 	g.cacheMu.RLock()
 	defer g.cacheMu.RUnlock()
@@ -454,10 +461,6 @@ func (g *GlobalContext) GetPvlSource() PvlSource {
 // to implement ProofContext
 func (g *GlobalContext) GetAppType() AppType {
 	return g.Env.GetAppType()
-}
-
-func (g *GlobalContext) GetTeamLoader() TeamLoader {
-	return g.teamLoader
 }
 
 func (g *GlobalContext) ConfigureExportedStreams() error {
@@ -887,6 +890,8 @@ func (g *GlobalContext) SetPvlSource(s PvlSource) {
 }
 
 func (g *GlobalContext) SetTeamLoader(l TeamLoader) {
+	g.cacheMu.Lock()
+	defer g.cacheMu.Unlock()
 	g.teamLoader = l
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -580,6 +580,8 @@ type ConnectivityMonitor interface {
 }
 
 type TeamLoader interface {
+	VerifyTeamName(ctx context.Context, id keybase1.TeamID, name keybase1.TeamName) error
+	MapIDToName(ctx context.Context, id keybase1.TeamID) (keybase1.TeamName, error)
 	Load(context.Context, keybase1.LoadTeamArg) (*keybase1.TeamData, error)
 	OnLogout()
 }

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -53,9 +53,9 @@ func (res *ResolveResult) User() keybase1.User {
 
 func (res *ResolveResult) UserOrTeam() keybase1.UserOrTeamLite {
 	var u keybase1.UserOrTeamLite
-	if !res.GetUID().IsNil() {
+	if res.GetUID().Exists() {
 		u.Id, u.Name = res.GetUID().AsUserOrTeam(), res.GetNormalizedUsername().String()
-	} else if !res.GetTeamID().IsNil() {
+	} else if res.GetTeamID().Exists() {
 		u.Id, u.Name = res.GetTeamID().AsUserOrTeam(), res.GetTeamName().String()
 	}
 	return u

--- a/go/libkb/team_stub.go
+++ b/go/libkb/team_stub.go
@@ -1,0 +1,38 @@
+package libkb
+
+import (
+	"errors"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	context "golang.org/x/net/context"
+)
+
+type nullTeamLoader struct {
+	Contextified
+}
+
+func newNullTeamLoader(g *GlobalContext) *nullTeamLoader {
+	return &nullTeamLoader{NewContextified(g)}
+}
+
+// VerifyTeamName verifies that id corresponds to name and returns an error
+// if it doesn't. Right now, it is a Noop (and therefore insecure) to get
+// tests to pass. Once we have an actual implementation, we should change this
+// to error out in all cases.
+func (n nullTeamLoader) VerifyTeamName(ctx context.Context, id keybase1.TeamID, name keybase1.TeamName) error {
+	n.G().Log.Warning("Using nullTeamLoader -- INSECURE -- please implement")
+	return nil
+}
+
+// MapIDToName maps the team ID to the corresponding name, and can be serviced
+// from the team cache. If no entry is available in the cache, it is OK to return
+// an empty/nil TeamName, and callers are free to try again with a server access
+// (this actually happens in the Resolver).
+func (n nullTeamLoader) MapIDToName(ctx context.Context, id keybase1.TeamID) (keybase1.TeamName, error) {
+	return keybase1.TeamName{}, nil
+}
+
+func (n nullTeamLoader) Load(context.Context, keybase1.LoadTeamArg) (*keybase1.TeamData, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func (n nullTeamLoader) OnLogout() {}

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1340,22 +1340,22 @@ func TeamNameFromString(s string) (ret TeamName, err error) {
 	if len(parts) == 0 {
 		return ret, errors.New("need >= 1 part, got 0")
 	}
-	var tmp []TeamNamePart
+	tmp := make([]TeamNamePart, len(parts))
 	for i, part := range parts {
 		if !namePartRxx.MatchString(part) {
 			return ret, fmt.Errorf("Bad name component: %s (at pos %d)", part, i)
 		}
-		tmp = append(tmp, TeamNamePart(strings.ToLower(part)))
+		tmp[i] = TeamNamePart(strings.ToLower(part))
 	}
 	return TeamName{Parts: tmp}, nil
 }
 
 func (t TeamName) String() string {
-	var x []string
-	for _, p := range t.Parts {
-		x = append(x, string(p))
+	tmp := make([]string, len(t.Parts))
+	for i, p := range t.Parts {
+		tmp[i] = string(p)
 	}
-	return strings.Join(x, ".")
+	return strings.Join(tmp, ".")
 }
 
 func (t TeamName) Eq(t2 TeamName) bool {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -1328,6 +1329,39 @@ func (t TeamMembers) AllUIDs() []UID {
 	return all
 }
 
-func (t TeamNameParts) String() string {
-	return strings.Join(t.Parts, ".")
+func (t TeamName) IsNil() bool {
+	return len(t.Parts) == 0
+}
+
+var namePartRxx = regexp.MustCompile(`([a-zA-Z0-9][a-zA-Z0-9_]?)+`)
+
+func TeamNameFromString(s string) (ret TeamName, err error) {
+	parts := strings.Split(s, ".")
+	if len(parts) == 0 {
+		return ret, errors.New("need >= 1 part, got 0")
+	}
+	var tmp []TeamNamePart
+	for i, part := range parts {
+		if !namePartRxx.MatchString(part) {
+			return ret, fmt.Errorf("Bad name component: %s (at pos %d)", part, i)
+		}
+		tmp = append(tmp, TeamNamePart(strings.ToLower(part)))
+	}
+	return TeamName{Parts: tmp}, nil
+}
+
+func (t TeamName) String() string {
+	var x []string
+	for _, p := range t.Parts {
+		x = append(x, string(p))
+	}
+	return strings.Join(x, ".")
+}
+
+func (t TeamName) Eq(t2 TeamName) bool {
+	return t.String() == t2.String()
+}
+
+func (t TeamName) IsRootTeam() bool {
+	return len(t.Parts) == 1
 }

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1160,7 +1160,11 @@ func (ut UserOrTeamID) IsSubteam() bool {
 }
 
 func (ut UserOrTeamID) IsTeamOrSubteam() bool {
-	suffix := ut[len(ut)-2:]
+	suffixLen := 2
+	if ut.IsNil() || len(ut) < suffixLen {
+		return false
+	}
+	suffix := ut[len(ut)-suffixLen:]
 	return suffix == TEAMID_SUFFIX_HEX || suffix == SUB_TEAMID_SUFFIX_HEX
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -462,16 +462,22 @@ func (o UserLogPoint) DeepCopy() UserLogPoint {
 	}
 }
 
-type TeamNameParts struct {
-	Parts []string `codec:"parts" json:"parts"`
+type TeamNamePart string
+
+func (o TeamNamePart) DeepCopy() TeamNamePart {
+	return o
 }
 
-func (o TeamNameParts) DeepCopy() TeamNameParts {
-	return TeamNameParts{
-		Parts: (func(x []string) []string {
-			var ret []string
+type TeamName struct {
+	Parts []TeamNamePart `codec:"parts" json:"parts"`
+}
+
+func (o TeamName) DeepCopy() TeamName {
+	return TeamName{
+		Parts: (func(x []TeamNamePart) []TeamNamePart {
+			var ret []TeamNamePart
 			for _, v := range x {
-				vCopy := v
+				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -70,10 +70,9 @@ func (h *IdentifyHandler) IdentifyLite(netCtx context.Context, arg keybase1.Iden
 
 	var au libkb.AssertionURL
 	if len(arg.Assertion) > 0 {
-		au, err = libkb.ParseAssertionURL(h.G().MakeAssertionContext(), arg.Assertion, true)
-		if err != nil {
-			return res, err
-		}
+		// It's OK to fail this assertion; it will be off in the case of regular lookups
+		// for users like `t_ellen` without a `type` specification
+		au, _ = libkb.ParseAssertionURL(h.G().MakeAssertionContext(), arg.Assertion, true)
 	}
 
 	if arg.Id.IsTeamOrSubteam() || libkb.AssertionIsTeam(au) {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -237,7 +237,10 @@ func (d *Service) Run() (err error) {
 		return err
 	}
 
-	if err = d.setupGlobals(); err != nil {
+	if err = d.setupTeams(); err != nil {
+		return err
+	}
+	if err = d.setupPVL(); err != nil {
 		return err
 	}
 
@@ -248,10 +251,13 @@ func (d *Service) Run() (err error) {
 	return err
 }
 
-func (d *Service) setupGlobals() error {
-	g := d.G()
-	teams.NewTeamLoaderAndInstall(g)
-	pvlsource.NewPvlSourceAndInstall(g)
+func (d *Service) setupTeams() error {
+	teams.NewTeamLoaderAndInstall(d.G())
+	return nil
+}
+
+func (d *Service) setupPVL() error {
+	pvlsource.NewPvlSourceAndInstall(d.G())
 	return nil
 }
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -25,6 +25,8 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/pvlsource"
+	"github.com/keybase/client/go/teams"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 
@@ -232,7 +234,11 @@ func (d *Service) Run() (err error) {
 
 	var l net.Listener
 	if l, err = d.ConfigRPCServer(); err != nil {
-		return
+		return err
+	}
+
+	if err = d.setupGlobals(); err != nil {
+		return err
 	}
 
 	d.RunBackgroundOperations(uir)
@@ -240,6 +246,13 @@ func (d *Service) Run() (err error) {
 	d.G().ExitCode, err = d.ListenLoopWithStopper(l)
 
 	return err
+}
+
+func (d *Service) setupGlobals() error {
+	g := d.G()
+	teams.NewTeamLoaderAndInstall(g)
+	pvlsource.NewPvlSourceAndInstall(g)
+	return nil
 }
 
 func (d *Service) RunBackgroundOperations(uir *UIRouter) {

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -106,7 +106,7 @@ func CreateRootTeam(ctx context.Context, g *libkb.GlobalContext, name string) (e
 		SigningKID: deviceSigningKey.GetKID(),
 		Type:       string(libkb.LinkTypeTeamRoot),
 		SigInner:   string(sigJSONAfterReverse),
-		TeamID:     RootTeamIDFromName(name),
+		TeamID:     RootTeamIDFromNameString(name),
 		PublicKeys: &libkb.SigMultiItemPublicKeys{
 			Encryption: perTeamEncryptionKey.GetKID(),
 			Signing:    perTeamSigningKey.GetKID(),
@@ -195,7 +195,7 @@ func CreateSubteam(ctx context.Context, g *libkb.GlobalContext, subteamBasename 
 func makeRootTeamSection(teamName string, owner *libkb.User, perTeamSigningKID keybase1.KID, perTeamEncryptionKID keybase1.KID) (SCTeamSection, error) {
 	ownerUserVersion := owner.ToUserVersion()
 
-	teamID := RootTeamIDFromName(teamName)
+	teamID := RootTeamIDFromNameString(teamName)
 
 	teamSection := SCTeamSection{
 		Name: (*SCTeamName)(&teamName),

--- a/go/teams/create_test.go
+++ b/go/teams/create_test.go
@@ -8,12 +8,14 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateTeam(t *testing.T) {
+func createUserAndRootTeam(t *testing.T) (fu *kbtest.FakeUser, nm keybase1.TeamName, g *libkb.GlobalContext, cleanup func()) {
 	tc := SetupTest(t, "team", 1)
-	defer tc.Cleanup()
+	cleanup = func() { tc.Cleanup() }
 
 	// Note that the length limit for a team name, with the additional suffix
 	// below, is 16 characters. We have 5 to play with, including the implicit
@@ -21,10 +23,21 @@ func TestCreateTeam(t *testing.T) {
 	u, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
 	require.NoError(t, err)
 
-	teamName := u.Username + "T"
+	teamName := u.Username + "t"
 
 	err = CreateRootTeam(context.TODO(), tc.G, teamName)
 	require.NoError(t, err)
+
+	nm, err = keybase1.TeamNameFromString(teamName)
+	require.NoError(t, err)
+	require.Equal(t, nm.String(), teamName)
+
+	return u, nm, tc.G, cleanup
+}
+
+func TestCreateTeam(t *testing.T) {
+	_, _, _, cleanup := createUserAndRootTeam(t)
+	cleanup()
 }
 
 func TestCreateTeamAfterAccountReset(t *testing.T) {

--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -129,7 +129,7 @@ func (f *finder) newPlayer(ctx context.Context, links []SCChainLink) (*TeamSigCh
 
 type rawTeam struct {
 	ID             keybase1.TeamID          `json:"id"`
-	Name           keybase1.TeamNameParts   `json:"name"`
+	Name           keybase1.TeamName        `json:"name"`
 	Status         libkb.AppStatus          `json:"status"`
 	Chain          []json.RawMessage        `json:"chain"`
 	Box            TeamBox                  `json:"box"`

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -73,3 +73,12 @@ func (l *TeamLoader) load(ctx context.Context, me keybase1.UserVersion, lArg key
 func (l *TeamLoader) OnLogout() {
 	l.storage.onLogout()
 }
+
+func (l *TeamLoader) VerifyTeamName(ctx context.Context, id keybase1.TeamID, name keybase1.TeamName) error {
+	l.G().Log.Warning("Using stubbed out VerifyTeamName - INSECURE -- please implement")
+	return nil
+}
+
+func (l *TeamLoader) MapIDToName(ctx context.Context, id keybase1.TeamID) (keybase1.TeamName, error) {
+	return keybase1.TeamName{}, nil
+}

--- a/go/teams/resolve.go
+++ b/go/teams/resolve.go
@@ -1,0 +1,42 @@
+package teams
+
+import (
+	"context"
+	"fmt"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+// ResolveIDToName takes a team ID and resolve it to a name. It can use server-assist
+// but always cryptographically checks the result.
+func ResolveIDToName(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (name keybase1.TeamName, err error) {
+
+	rres := g.Resolver.ResolveFullExpression(ctx, fmt.Sprintf("tid:%s", id))
+	if err = rres.GetError(); err != nil {
+		return keybase1.TeamName{}, err
+	}
+	name = rres.GetTeamName()
+	err = g.GetTeamLoader().VerifyTeamName(ctx, id, name)
+	if err != nil {
+		return keybase1.TeamName{}, err
+	}
+
+	return name, nil
+}
+
+// ResolveNameToID takes a team name and resolve it to a team ID. It can use server-assist
+// but always cryptographically checks the result.
+func ResolveNameToID(ctx context.Context, g *libkb.GlobalContext, name keybase1.TeamName) (id keybase1.TeamID, err error) {
+	rres := g.Resolver.ResolveFullExpression(ctx, fmt.Sprintf("team:%s", name))
+	if err = rres.GetError(); err != nil {
+		return keybase1.TeamID(""), err
+	}
+	id = rres.GetTeamID()
+
+	err = g.GetTeamLoader().VerifyTeamName(ctx, id, name)
+	if err != nil {
+		return keybase1.TeamID(""), err
+	}
+
+	return id, nil
+}

--- a/go/teams/sig.go
+++ b/go/teams/sig.go
@@ -42,8 +42,15 @@ func TeamRootSig(me *libkb.User, key libkb.GenericKey, teamSection SCTeamSection
 	return ret, nil
 }
 
+func RootTeamIDFromName(n keybase1.TeamName) keybase1.TeamID {
+	if !n.IsRootTeam() {
+		panic("can't get a team ID from a subteam")
+	}
+	return RootTeamIDFromNameString(n.String())
+}
+
 // the first 15 bytes of the sha256 of the lowercase team name, followed by the byte 0x24, encoded as hex
-func RootTeamIDFromName(name string) keybase1.TeamID {
+func RootTeamIDFromNameString(name string) keybase1.TeamID {
 	sum := sha256.Sum256([]byte(strings.ToLower(name)))
 	idBytes := sum[0:16]
 	idBytes[15] = libkb.RootTeamIDTag

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -144,9 +144,12 @@ protocol teams {
     Seqno seqno;
   }
 
+  @typedef("string")
+  record TeamNamePart {}
+
   // matches the team name struct from api server
-  record TeamNameParts {
-    array<string> parts;
+  record TeamName {
+    array<TeamNamePart> parts;
   }
 
   // team.clkr gregor message body

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5831,9 +5831,11 @@ export type TeamMembersUsernames = {
   readers?: ?Array<string>,
 }
 
-export type TeamNameParts = {
-  parts?: ?Array<string>,
+export type TeamName = {
+  parts?: ?Array<TeamNamePart>,
 }
+
+export type TeamNamePart = string
 
 export type TeamPlusApplicationKeys = {
   id: TeamID,

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -394,12 +394,18 @@
     },
     {
       "type": "record",
-      "name": "TeamNameParts",
+      "name": "TeamNamePart",
+      "fields": [],
+      "typedef": "string"
+    },
+    {
+      "type": "record",
+      "name": "TeamName",
       "fields": [
         {
           "type": {
             "type": "array",
-            "items": "string"
+            "items": "TeamNamePart"
           },
           "name": "parts"
         }

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5831,9 +5831,11 @@ export type TeamMembersUsernames = {
   readers?: ?Array<string>,
 }
 
-export type TeamNameParts = {
-  parts?: ?Array<string>,
+export type TeamName = {
+  parts?: ?Array<TeamNamePart>,
 }
+
+export type TeamNamePart = string
 
 export type TeamPlusApplicationKeys = {
   id: TeamID,


### PR DESCRIPTION
- maps ID to names and names to ID
- as usually, the code in libkb.Resolver does not verify its replies
- use team.ResolveIDToName and team.ResolveNametoID for a verified resoltion in both cases.
- cleanups and code reorganization:
	- organization; move a lot of code out of service/identify and into teams/, where applicable
	- cleanup resolve+team integration in general
	- cleanup initial setting of the PVL and TeamLoader variables off of G; populate the real examples in service/ and not in client/
- tests for the new resolver