### PR TITLE
Run identifySelf on svc start, login

### DIFF
--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -146,6 +146,10 @@ func (i *identifyUser) isNil() bool {
 	return i.thin == nil && i.full == nil
 }
 
+func (i *identifyUser) Full() *libkb.User {
+	return i.full
+}
+
 func loadIdentifyUser(ctx *Context, g *libkb.GlobalContext, arg libkb.LoadUserArg, cache libkb.Identify2Cacher) (*identifyUser, error) {
 	arg.SetGlobalContext(g)
 	arg.NetContext = ctx.GetNetContext()
@@ -1097,4 +1101,18 @@ func (e *Identify2WithUID) TrackToken() keybase1.TrackToken {
 
 func (e *Identify2WithUID) ConfirmResult() keybase1.ConfirmResult {
 	return e.confirmResult
+}
+
+func (e *Identify2WithUID) FullMeUser() *libkb.User {
+	if e.me == nil {
+		return nil
+	}
+	return e.me.Full()
+}
+
+func (e *Identify2WithUID) FullThemUser() *libkb.User {
+	if e.them == nil {
+		return nil
+	}
+	return e.them.Full()
 }

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -292,6 +292,7 @@ func mergeIntoPath(g *libkb.GlobalContext, p2 string) error {
 }
 
 func (h ConfigHandler) HelloIAm(_ context.Context, arg keybase1.ClientDetails) error {
+	h.G().Log.Debug("HelloIAm: %d - %+v", h.connID, arg)
 	return h.G().ConnectionManager.Label(h.connID, arg)
 }
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -345,7 +345,26 @@ func (d *Service) identifySelf() {
 	if err := engine.RunEngine(eng, &engine.Context{NetContext: context.Background()}); err != nil {
 		d.G().Log.Debug("identifySelf: identify error %s", err)
 	}
-	d.G().Log.Debug("identifySelf: identify succes on uid %s", uid)
+	d.G().Log.Debug("identifySelf: identify success on uid %s", uid)
+
+	// identify2 did a load user for self, so find it and cache it in FullSelfer.
+	them := eng.FullThemUser()
+	me := eng.FullMeUser()
+	var u *libkb.User
+	if them != nil && them.GetUID().Equal(uid) {
+		d.G().Log.Debug("identifySelf: using them for full user")
+		u = them
+	} else if me != nil && me.GetUID().Equal(uid) {
+		d.G().Log.Debug("identifySelf: using me for full user")
+		u = me
+	}
+	if u != nil {
+		if err := d.G().GetFullSelfer().Update(context.Background(), u); err != nil {
+			d.G().Log.Debug("identifySelf: error updating full self cache: %s", err)
+		} else {
+			d.G().Log.Debug("identifySelf: updated full self cache for: %s", u.GetName())
+		}
+	}
 }
 
 func (d *Service) runBackgroundIdentifier() {


### PR DESCRIPTION
There's a high probability that an identify on self will be needed in gui/mobile.  The default page on cold start is the user profile, and it's one of the top-level tabs throughout.

This patch runs identify on the self user when the service starts up and on login to prime the id cache.  It includes checking all the proofs as this is what GUI identify call does.

