### PR TITLE
Add the --saltpack-version flag to sign and encrypt

### DIFF
--- a/go/client/cmd_encrypt.go
+++ b/go/client/cmd_encrypt.go
@@ -23,6 +23,7 @@ type CmdEncrypt struct {
 	anonymousSender    bool
 	currentDevicesOnly bool // the public-facing term for "encryption-only mode"
 	noSelfEncrypt      bool
+	saltpackVersion    int
 }
 
 func NewCmdEncrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -54,6 +55,10 @@ func NewCmdEncrypt(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 		cli.BoolFlag{
 			Name:  "no-self",
 			Usage: "Don't encrypt for yourself. Requires --current-devices-only.",
+		},
+		cli.IntFlag{
+			Name:  "saltpack-version",
+			Usage: "Force a specific saltpack version",
 		},
 	}
 
@@ -106,6 +111,7 @@ func (c *CmdEncrypt) Run() error {
 		EncryptionOnlyMode: c.currentDevicesOnly,
 		NoSelfEncrypt:      c.noSelfEncrypt,
 		Binary:             c.binary,
+		SaltpackVersion:    c.saltpackVersion,
 	}
 	arg := keybase1.SaltpackEncryptArg{Source: src, Sink: snk, Opts: opts}
 	err = cli.SaltpackEncrypt(context.TODO(), arg)
@@ -140,6 +146,7 @@ func (c *CmdEncrypt) ParseArgv(ctx *cli.Context) error {
 		// return errors.New("--no-self requires --current-devices-only")
 	}
 	c.binary = ctx.Bool("binary")
+	c.saltpackVersion = ctx.Int("saltpack-version")
 	if err := c.filter.FilterInit(msg, infile, outfile); err != nil {
 		return err
 	}

--- a/go/client/cmd_sign.go
+++ b/go/client/cmd_sign.go
@@ -41,6 +41,10 @@ func NewCmdSign(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 				Name:  "o, outfile",
 				Usage: "Specify an outfile (default is STDOUT).",
 			},
+			cli.IntFlag{
+				Name:  "saltpack-version",
+				Usage: "Force a specific saltpack version",
+			},
 		},
 	}
 }
@@ -48,8 +52,9 @@ func NewCmdSign(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 type CmdSign struct {
 	libkb.Contextified
 	UnixFilter
-	detached bool
-	binary   bool
+	detached        bool
+	binary          bool
+	saltpackVersion int
 }
 
 func (s *CmdSign) ParseArgv(ctx *cli.Context) error {
@@ -59,6 +64,7 @@ func (s *CmdSign) ParseArgv(ctx *cli.Context) error {
 
 	s.detached = ctx.Bool("detached")
 	s.binary = ctx.Bool("binary")
+	s.saltpackVersion = ctx.Int("saltpack-version")
 
 	msg := ctx.String("message")
 	outfile := ctx.String("outfile")
@@ -86,8 +92,9 @@ func (s *CmdSign) Run() (err error) {
 			Source: src,
 			Sink:   snk,
 			Opts: keybase1.SaltpackSignOptions{
-				Detached: s.detached,
-				Binary:   s.binary,
+				Detached:        s.detached,
+				Binary:          s.binary,
+				SaltpackVersion: s.saltpackVersion,
 			},
 		}
 		err = cli.SaltpackSign(context.TODO(), arg)

--- a/go/engine/saltpack_encrypt.go
+++ b/go/engine/saltpack_encrypt.go
@@ -188,6 +188,11 @@ func (e *SaltpackEncrypt) Run(ctx *Context) (err error) {
 		}
 	}
 
+	saltpackVersion, err := libkb.SaltpackVersionFromArg(e.arg.Opts.SaltpackVersion)
+	if err != nil {
+		return err
+	}
+
 	encarg := libkb.SaltpackEncryptArg{
 		Source:             e.arg.Source,
 		Sink:               e.arg.Sink,
@@ -197,6 +202,7 @@ func (e *SaltpackEncrypt) Run(ctx *Context) (err error) {
 		Binary:             e.arg.Opts.Binary,
 		EncryptionOnlyMode: e.arg.Opts.EncryptionOnlyMode,
 		SymmetricReceivers: symmetricReceivers,
+		SaltpackVersion:    saltpackVersion,
 
 		VisibleRecipientsForTesting: e.visibleRecipientsForTesting,
 	}

--- a/go/engine/saltpack_sign.go
+++ b/go/engine/saltpack_sign.go
@@ -61,11 +61,16 @@ func (e *SaltpackSign) Run(ctx *Context) error {
 		return err
 	}
 
-	if e.arg.Opts.Detached {
-		return libkb.SaltpackSignDetached(e.G(), e.arg.Source, e.arg.Sink, e.key, e.arg.Opts.Binary)
+	saltpackVersion, err := libkb.SaltpackVersionFromArg(e.arg.Opts.SaltpackVersion)
+	if err != nil {
+		return err
 	}
 
-	return libkb.SaltpackSign(e.G(), e.arg.Source, e.arg.Sink, e.key, e.arg.Opts.Binary)
+	if e.arg.Opts.Detached {
+		return libkb.SaltpackSignDetached(e.G(), e.arg.Source, e.arg.Sink, e.key, e.arg.Opts.Binary, saltpackVersion)
+	}
+
+	return libkb.SaltpackSign(e.G(), e.arg.Source, e.arg.Sink, e.key, e.arg.Opts.Binary, saltpackVersion)
 }
 
 func (e *SaltpackSign) loadKey(ctx *Context) error {

--- a/go/libkb/saltpack.go
+++ b/go/libkb/saltpack.go
@@ -5,6 +5,7 @@ package libkb
 
 import (
 	"bytes"
+	"fmt"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/saltpack"
@@ -212,4 +213,26 @@ func BoxPublicKeyToKeybaseKID(k saltpack.BoxPublicKey) (ret keybase1.KID) {
 func checkSaltpackBrand(b string) error {
 	// Everything is awesome!
 	return nil
+}
+
+func SaltpackVersionFromArg(saltpackVersionArg int) (saltpack.Version, error) {
+	if saltpackVersionArg == 0 {
+		return CurrentSaltpackVersion(), nil
+	}
+
+	// The arg specifies the major version we want, and the minor version is
+	// assumed to be the latest available. Make a map to accomplish that.
+	majorVersionMap := map[int]saltpack.Version{}
+	for _, v := range saltpack.KnownVersions() {
+		latestPair, found := majorVersionMap[v.Major]
+		if !found || (v.Minor > latestPair.Minor) {
+			majorVersionMap[v.Major] = v
+		}
+	}
+
+	ret, found := majorVersionMap[saltpackVersionArg]
+	if !found {
+		return saltpack.Version{}, fmt.Errorf("failed to find saltpack major version %d", saltpackVersionArg)
+	}
+	return ret, nil
 }

--- a/go/libkb/saltpack_sign.go
+++ b/go/libkb/saltpack_sign.go
@@ -15,29 +15,29 @@ import (
 
 type streamfn func(io.Writer, saltpack.SigningSecretKey, string) (io.WriteCloser, error)
 
-func SaltpackSign(g *GlobalContext, source io.ReadCloser, sink io.WriteCloser, key NaclSigningKeyPair, binary bool) error {
+func SaltpackSign(g *GlobalContext, source io.ReadCloser, sink io.WriteCloser, key NaclSigningKeyPair, binary bool, saltpackVersion saltpack.Version) error {
 	var s streamfn
 	if binary {
 		s = func(w io.Writer, k saltpack.SigningSecretKey, _ string) (io.WriteCloser, error) {
-			return saltpack.NewSignStream(CurrentSaltpackVersion(), w, k)
+			return saltpack.NewSignStream(saltpackVersion, w, k)
 		}
 	} else {
 		s = func(w io.Writer, k saltpack.SigningSecretKey, brand string) (io.WriteCloser, error) {
-			return saltpack.NewSignArmor62Stream(CurrentSaltpackVersion(), w, k, brand)
+			return saltpack.NewSignArmor62Stream(saltpackVersion, w, k, brand)
 		}
 	}
 	return saltpackSign(g, source, sink, key, s)
 }
 
-func SaltpackSignDetached(g *GlobalContext, source io.ReadCloser, sink io.WriteCloser, key NaclSigningKeyPair, binary bool) error {
+func SaltpackSignDetached(g *GlobalContext, source io.ReadCloser, sink io.WriteCloser, key NaclSigningKeyPair, binary bool, saltpackVersion saltpack.Version) error {
 	var s streamfn
 	if binary {
 		s = func(w io.Writer, k saltpack.SigningSecretKey, _ string) (io.WriteCloser, error) {
-			return saltpack.NewSignDetachedStream(CurrentSaltpackVersion(), w, k)
+			return saltpack.NewSignDetachedStream(saltpackVersion, w, k)
 		}
 	} else {
 		s = func(w io.Writer, k saltpack.SigningSecretKey, brand string) (io.WriteCloser, error) {
-			return saltpack.NewSignDetachedArmor62Stream(CurrentSaltpackVersion(), w, k, brand)
+			return saltpack.NewSignDetachedArmor62Stream(saltpackVersion, w, k, brand)
 		}
 	}
 	return saltpackSign(g, source, sink, key, s)

--- a/go/protocol/keybase1/saltpack.go
+++ b/go/protocol/keybase1/saltpack.go
@@ -14,6 +14,7 @@ type SaltpackEncryptOptions struct {
 	EncryptionOnlyMode bool     `codec:"encryptionOnlyMode" json:"encryptionOnlyMode"`
 	NoSelfEncrypt      bool     `codec:"noSelfEncrypt" json:"noSelfEncrypt"`
 	Binary             bool     `codec:"binary" json:"binary"`
+	SaltpackVersion    int      `codec:"saltpackVersion" json:"saltpackVersion"`
 }
 
 func (o SaltpackEncryptOptions) DeepCopy() SaltpackEncryptOptions {
@@ -30,6 +31,7 @@ func (o SaltpackEncryptOptions) DeepCopy() SaltpackEncryptOptions {
 		EncryptionOnlyMode: o.EncryptionOnlyMode,
 		NoSelfEncrypt:      o.NoSelfEncrypt,
 		Binary:             o.Binary,
+		SaltpackVersion:    o.SaltpackVersion,
 	}
 }
 
@@ -48,14 +50,16 @@ func (o SaltpackDecryptOptions) DeepCopy() SaltpackDecryptOptions {
 }
 
 type SaltpackSignOptions struct {
-	Detached bool `codec:"detached" json:"detached"`
-	Binary   bool `codec:"binary" json:"binary"`
+	Detached        bool `codec:"detached" json:"detached"`
+	Binary          bool `codec:"binary" json:"binary"`
+	SaltpackVersion int  `codec:"saltpackVersion" json:"saltpackVersion"`
 }
 
 func (o SaltpackSignOptions) DeepCopy() SaltpackSignOptions {
 	return SaltpackSignOptions{
-		Detached: o.Detached,
-		Binary:   o.Binary,
+		Detached:        o.Detached,
+		Binary:          o.Binary,
+		SaltpackVersion: o.SaltpackVersion,
 	}
 }
 

--- a/protocol/avdl/keybase1/saltpack.avdl
+++ b/protocol/avdl/keybase1/saltpack.avdl
@@ -10,6 +10,7 @@ protocol saltpack {
     boolean encryptionOnlyMode;
     boolean noSelfEncrypt;
     boolean binary;
+    int saltpackVersion;
   }
 
   record SaltpackDecryptOptions {
@@ -21,6 +22,7 @@ protocol saltpack {
   record SaltpackSignOptions {
     boolean detached;
     boolean binary;
+    int saltpackVersion;
   }
 
   record SaltpackVerifyOptions {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5372,6 +5372,7 @@ export type SaltpackEncryptOptions = {
   encryptionOnlyMode: boolean,
   noSelfEncrypt: boolean,
   binary: boolean,
+  saltpackVersion: int,
 }
 
 export type SaltpackEncryptedMessageInfo = {
@@ -5400,6 +5401,7 @@ export type SaltpackSenderType =
 export type SaltpackSignOptions = {
   detached: boolean,
   binary: boolean,
+  saltpackVersion: int,
 }
 
 export type SaltpackVerifyOptions = {

--- a/protocol/json/keybase1/saltpack.json
+++ b/protocol/json/keybase1/saltpack.json
@@ -37,6 +37,10 @@
         {
           "type": "boolean",
           "name": "binary"
+        },
+        {
+          "type": "int",
+          "name": "saltpackVersion"
         }
       ]
     },
@@ -69,6 +73,10 @@
         {
           "type": "boolean",
           "name": "binary"
+        },
+        {
+          "type": "int",
+          "name": "saltpackVersion"
         }
       ]
     },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5372,6 +5372,7 @@ export type SaltpackEncryptOptions = {
   encryptionOnlyMode: boolean,
   noSelfEncrypt: boolean,
   binary: boolean,
+  saltpackVersion: int,
 }
 
 export type SaltpackEncryptedMessageInfo = {
@@ -5400,6 +5401,7 @@ export type SaltpackSenderType =
 export type SaltpackSignOptions = {
   detached: boolean,
   binary: boolean,
+  saltpackVersion: int,
 }
 
 export type SaltpackVerifyOptions = {


### PR DESCRIPTION
This would've made it easier to do a graceful upgrade of the build machine, as we get the updater ready to support saltpack v2 signatures.

r? @maxtaco 
cc @mmaxim @cjb