### PR TITLE
kbnm: Firefox whitelisting and more Go-ness

### DIFF
--- a/go/kbnm/findbin.go
+++ b/go/kbnm/findbin.go
@@ -11,25 +11,25 @@ import (
 
 var errKeybaseNotFound = errors.New("failed to find the keybase binary")
 
-// findKeybaseBinary returns the path to the Keybase binary, if it finds it.
-func findKeybaseBinary() (string, error) {
+// findKeybaseBinary returns the path to a Keybase binary, if it finds it.
+func findKeybaseBinary(name string) (string, error) {
 	// Is it near the kbnm binary?
 	dir, err := osext.ExecutableFolder()
 	if err == nil {
-		path := filepath.Join(dir, keybaseBinary)
+		path := filepath.Join(dir, name)
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			return path, nil
 		}
 	}
 
 	// Is it in our PATH?
-	path, err := exec.LookPath(keybaseBinary)
+	path, err := exec.LookPath(name)
 	if err == nil {
 		return path, nil
 	}
 
 	// Last ditch effort!
-	path = guessKeybasePath()
+	path = guessKeybasePath(name)
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		return path, nil
 	}

--- a/go/kbnm/findbin_nix.go
+++ b/go/kbnm/findbin_nix.go
@@ -6,11 +6,12 @@ import (
 	"path/filepath"
 )
 
+const kbnmBinary = "kbnm"
 const keybaseBinary = "keybase"
 
 // guessKeybasePath makes a platform-specific guess to where the binary might
 // be. This is only checked as a last-ditch effort when we can't find the
 // binary in other places.
-func guessKeybasePath() string {
-	return filepath.Join("/usr/local/bin", keybaseBinary)
+func guessKeybasePath(name string) string {
+	return filepath.Join("/usr/local/bin", name)
 }

--- a/go/kbnm/findbin_windows.go
+++ b/go/kbnm/findbin_windows.go
@@ -7,11 +7,12 @@ import (
 	"path/filepath"
 )
 
+const kbnmBinary = "kbnm.exe"
 const keybaseBinary = "keybase.exe"
 
 // guessKeybasePath makes a platform-specific guess to where the binary might
 // be. This is only checked as a last-ditch effort when we can't find the
 // binary in other places.
-func guessKeybasePath() string {
-	return filepath.Join(os.Getenv("LOCALAPPDATA"), "Keybase", keybaseBinary)
+func guessKeybasePath(name string) string {
+	return filepath.Join(os.Getenv("LOCALAPPDATA"), "Keybase", name)
 }

--- a/go/kbnm/handler.go
+++ b/go/kbnm/handler.go
@@ -59,8 +59,10 @@ func checkUsernameQuery(s string) (string, error) {
 // Handler returns a request handler.
 func Handler() *handler {
 	return &handler{
-		Run:               execRunner,
-		FindKeybaseBinary: findKeybaseBinary,
+		Run: execRunner,
+		FindKeybaseBinary: func() (string, error) {
+			return findKeybaseBinary(keybaseBinary)
+		},
 	}
 }
 

--- a/go/kbnm/host_json.chrome.template
+++ b/go/kbnm/host_json.chrome.template
@@ -1,0 +1,11 @@
+{
+  "name": "io.keybase.kbnm",
+  "description": "Keybase Native Messaging API",
+  "path": "@@HOST_PATH@@",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://ognfafcpbkogffpmmdglhbjboeojlefj/",
+    "chrome-extension://kockbbfoibcdfibclaojljblnhpnjndg/",
+    "chrome-extension://gnjkbjlgkpiaehpibpdefaieklbfljjm/"
+  ]
+}

--- a/go/kbnm/host_json.firefox.template
+++ b/go/kbnm/host_json.firefox.template
@@ -1,0 +1,9 @@
+{
+  "name": "io.keybase.kbnm",
+  "description": "Keybase Native Messaging API",
+  "path": "@@HOST_PATH@@",
+  "type": "stdio",
+  "allowed_extensions": [
+    "keybase@keybase.io"
+  ]
+}

--- a/go/kbnm/hostmanifest/README.md
+++ b/go/kbnm/hostmanifest/README.md
@@ -1,0 +1,3 @@
+# Native Messaging Host Manifest
+
+This library handles installing and uninstalling NativeMessaging host manifests.

--- a/go/kbnm/hostmanifest/hostmanifest.go
+++ b/go/kbnm/hostmanifest/hostmanifest.go
@@ -1,0 +1,48 @@
+package hostmanifest
+
+import "os/user"
+
+// AppManifest is a serializable App metadata container
+type AppManifest interface {
+	// ID returns the app identifier, usually the same as the name.
+	ID() string
+	// Bin returns the path of the binary for the NativeMessaging app target.
+	BinPath() string
+}
+
+// App contains the metadata that defines a NativeMessaging app.
+type App struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Path        string `json:"path"`
+	Type        string `json:"type"`
+}
+
+// ID returns the app identifier
+func (app App) ID() string {
+	return app.Name
+}
+
+// Bin returns the path of the binary for the NativeMessaging app target.
+func (app App) BinPath() string {
+	return app.Path
+}
+
+// ChromeApp is the App metadata but includes Chrome-specific fields.
+type ChromeApp struct {
+	App
+	AllowedOrigins []string `json:"allowed_origins"`
+}
+
+// ChromeApp is the App metadata but includes Firefox-specific fields.
+type FirefoxApp struct {
+	App
+	AllowedExtensions []string `json:"allowed_extensions"`
+}
+
+// Installer handles writing whitelist information for enabling the
+// NativeMessaging app.
+type Installer interface {
+	Install(u *user.User, app AppManifest) error
+	Uninstall(u *user.User, app AppManifest) error
+}

--- a/go/kbnm/hostmanifest/hostmanifest.go
+++ b/go/kbnm/hostmanifest/hostmanifest.go
@@ -1,7 +1,5 @@
 package hostmanifest
 
-import "os/user"
-
 // AppManifest is a serializable App metadata container
 type AppManifest interface {
 	// ID returns the app identifier, usually the same as the name.
@@ -43,6 +41,6 @@ type FirefoxApp struct {
 // Installer handles writing whitelist information for enabling the
 // NativeMessaging app.
 type Installer interface {
-	Install(u *user.User, app AppManifest) error
-	Uninstall(u *user.User, app AppManifest) error
+	Install(u User, app AppManifest) error
+	Uninstall(u User, app AppManifest) error
 }

--- a/go/kbnm/hostmanifest/known_darwin.go
+++ b/go/kbnm/hostmanifest/known_darwin.go
@@ -1,26 +1,22 @@
 package hostmanifest
 
 // KnownInstallers returns a map of browser-to-Installer that this package
-// knows about for this platform. If overlay is not empty, then all paths are
-// prefixed with the overlay path.
-func KnownInstallers(overlay string) map[string]Installer {
+// knows about for this platform.
+func KnownInstallers() map[string]Installer {
 	return map[string]Installer{
 		// https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location-nix
 		"chrome": &whitelistPath{
-			Root:    "/Library/Google/Chrome/NativeMessagingHosts",
-			Home:    "Library/Application Support/Google/Chrome/NativeMessagingHosts",
-			Overlay: overlay,
+			Root: "/Library/Google/Chrome/NativeMessagingHosts",
+			Home: "Library/Application Support/Google/Chrome/NativeMessagingHosts",
 		},
 		"chromium": &whitelistPath{
-			Root:    "/Library/Application Support/Chromium/NativeMessagingHosts",
-			Home:    "Library/Application Support/Chromium/NativeMessagingHosts",
-			Overlay: overlay,
+			Root: "/Library/Application Support/Chromium/NativeMessagingHosts",
+			Home: "Library/Application Support/Chromium/NativeMessagingHosts",
 		},
 		// https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging
 		"firefox": &whitelistPath{
-			Root:    "/Library/Application Support/Mozilla/NativeMessagingHosts",
-			Home:    "Library/Application Support/Mozilla/NativeMessagingHosts",
-			Overlay: overlay,
+			Root: "/Library/Application Support/Mozilla/NativeMessagingHosts",
+			Home: "Library/Application Support/Mozilla/NativeMessagingHosts",
 		},
 	}
 }

--- a/go/kbnm/hostmanifest/known_darwin.go
+++ b/go/kbnm/hostmanifest/known_darwin.go
@@ -1,0 +1,26 @@
+package hostmanifest
+
+// KnownInstallers returns a map of browser-to-Installer that this package
+// knows about for this platform. If overlay is not empty, then all paths are
+// prefixed with the overlay path.
+func KnownInstallers(overlay string) map[string]Installer {
+	return map[string]Installer{
+		// https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location-nix
+		"chrome": &whitelistPath{
+			Root:    "/Library/Google/Chrome/NativeMessagingHosts",
+			Home:    "Library/Application Support/Google/Chrome/NativeMessagingHosts",
+			Overlay: overlay,
+		},
+		"chromium": &whitelistPath{
+			Root:    "/Library/Application Support/Chromium/NativeMessagingHosts",
+			Home:    "Library/Application Support/Chromium/NativeMessagingHosts",
+			Overlay: overlay,
+		},
+		// https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging
+		"firefox": &whitelistPath{
+			Root:    "/Library/Application Support/Mozilla/NativeMessagingHosts",
+			Home:    "Library/Application Support/Mozilla/NativeMessagingHosts",
+			Overlay: overlay,
+		},
+	}
+}

--- a/go/kbnm/hostmanifest/known_linux.go
+++ b/go/kbnm/hostmanifest/known_linux.go
@@ -1,26 +1,22 @@
 package hostmanifest
 
 // KnownInstallers returns a map of browser-to-Installer that this package
-// knows about for this platform. If overlay is not empty, then all paths are
-// prefixed with the overlay path.
-func KnownInstallers(overlay string) map[string]Installer {
+// knows about for this platform.
+func KnownInstallers() map[string]Installer {
 	return map[string]Installer{
 		// https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location-nix
 		"chrome": &whitelistPath{
-			Root:    "/etc/opt/chrome/native-messaging-hosts/",
-			Home:    ".config/google-chrome/NativeMessagingHosts",
-			Overlay: overlay,
+			Root: "/etc/opt/chrome/native-messaging-hosts/",
+			Home: ".config/google-chrome/NativeMessagingHosts",
 		},
 		"chromium": &whitelistPath{
-			Root:    "/etc/chromium/native-messaging-hosts",
-			Home:    ".config/chromium/NativeMessagingHosts",
-			Overlay: overlay,
+			Root: "/etc/chromium/native-messaging-hosts",
+			Home: ".config/chromium/NativeMessagingHosts",
 		},
 		// https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging
 		"firefox": &whitelistPath{
-			Root:    "/usr/lib/mozilla/native-messaging-hosts",
-			Home:    ".mozilla/native-messaging-hosts",
-			Overlay: overlay,
+			Root: "/usr/lib/mozilla/native-messaging-hosts",
+			Home: ".mozilla/native-messaging-hosts",
 		},
 	}
 }

--- a/go/kbnm/hostmanifest/known_linux.go
+++ b/go/kbnm/hostmanifest/known_linux.go
@@ -1,0 +1,26 @@
+package hostmanifest
+
+// KnownInstallers returns a map of browser-to-Installer that this package
+// knows about for this platform. If overlay is not empty, then all paths are
+// prefixed with the overlay path.
+func KnownInstallers(overlay string) map[string]Installer {
+	return map[string]Installer{
+		// https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location-nix
+		"chrome": &whitelistPath{
+			Root:    "/etc/opt/chrome/native-messaging-hosts/",
+			Home:    ".config/google-chrome/NativeMessagingHosts",
+			Overlay: overlay,
+		},
+		"chromium": &whitelistPath{
+			Root:    "/etc/chromium/native-messaging-hosts",
+			Home:    ".config/chromium/NativeMessagingHosts",
+			Overlay: overlay,
+		},
+		// https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging
+		"firefox": &whitelistPath{
+			Root:    "/usr/lib/mozilla/native-messaging-hosts",
+			Home:    ".mozilla/native-messaging-hosts",
+			Overlay: overlay,
+		},
+	}
+}

--- a/go/kbnm/hostmanifest/known_windows.go
+++ b/go/kbnm/hostmanifest/known_windows.go
@@ -1,0 +1,95 @@
+package hostmanifest
+
+import (
+	"encoding/json"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// KnownInstallers returns a map of browser-to-Installer that this package
+// knows about for this platform. Overlay is ignored on Windows.
+func KnownInstallers(overlay string) map[string]Installer {
+	return map[string]Installer{
+		"chrome": &whitelistRegistry{
+			Key: `SOFTWARE\Google\Chrome\NativeMessagingHosts`,
+		},
+		"chromium": &whitelistRegistry{
+			Key: `SOFTWARE\Chromium\NativeMessagingHosts`,
+		},
+		"firefox": &whitelistRegistry{
+			Key: `SOFTWARE\Mozilla\NativeMessagingHosts`,
+		},
+	}
+}
+
+// whitelistRegistry is used for installing the whitelist as a JSON into a given
+// registry entry. When Install is called, it will also write a JSON manifest to be adjacent to the app Path.
+type whitelistRegistry struct {
+	// Key is the path of the NativeMessage whitelist registry key
+	Key string
+}
+
+// writeJSON writes the whitelist manifest JSON file adjacent to the app's
+// binary.
+func (w *whitelistRegistry) writeJSON(path string, app AppManifest) error {
+	// Write the file
+	fp, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	encoder := json.NewEncoder(fp)
+	encoder.SetIndent("", "    ")
+	if err := encoder.Encode(&app); err != nil {
+		return err
+	}
+
+	return fp.Sync()
+}
+
+func (w *whitelistRegistry) paths(app AppManifest) (jsonPath string, keyPath string) {
+	parentDir := filepath.Dir(app.BinPath())
+	jsonPath = filepath.Join(parentDir, app.ID()+".json")
+	keyPath = filepath.Join(w.Key, app.ID())
+	return
+}
+
+func (w *whitelistRegistry) Install(u *user.User, app AppManifest) error {
+	// We assume that the parentDir already exists, where the binary lives.
+	jsonPath, keyPath := w.paths(app)
+	if err := w.writeJSON(jsonPath, app); err != nil {
+		return err
+	}
+
+	scope := registry.CURRENT_USER
+	if u.Uid == "0" {
+		scope = registry.LOCAL_MACHINE
+	}
+	k, _, err := registry.CreateKey(scope, keyPath, registry.SET_VALUE|registry.CREATE_SUB_KEY|registry.WRITE)
+	if err != nil {
+		return err
+	}
+	defer k.Close()
+
+	return k.SetStringValue("", jsonPath)
+}
+
+func (w *whitelistRegistry) Uninstall(u *user.User, app AppManifest) error {
+	scope := registry.CURRENT_USER
+	if u.Uid == "0" {
+		scope = registry.LOCAL_MACHINE
+	}
+	jsonPath, keyPath := w.paths(app)
+	if err := registry.DeleteKey(scope, keyPath); err != nil {
+		return err
+	}
+	if err := os.Remove(jsonPath); err != nil && !os.IsNotExist(err) {
+		// We don't care if it doesn't exist, but other errors should escalate
+		return err
+	}
+	return nil
+}

--- a/go/kbnm/hostmanifest/known_windows.go
+++ b/go/kbnm/hostmanifest/known_windows.go
@@ -66,9 +66,6 @@ func (w *whitelistRegistry) Install(u *user.User, app AppManifest) error {
 	}
 
 	scope := registry.CURRENT_USER
-	if u.Uid == "0" {
-		scope = registry.LOCAL_MACHINE
-	}
 	k, _, err := registry.CreateKey(scope, keyPath, registry.SET_VALUE|registry.CREATE_SUB_KEY|registry.WRITE)
 	if err != nil {
 		return err
@@ -80,9 +77,6 @@ func (w *whitelistRegistry) Install(u *user.User, app AppManifest) error {
 
 func (w *whitelistRegistry) Uninstall(u *user.User, app AppManifest) error {
 	scope := registry.CURRENT_USER
-	if u.Uid == "0" {
-		scope = registry.LOCAL_MACHINE
-	}
 	jsonPath, keyPath := w.paths(app)
 	if err := registry.DeleteKey(scope, keyPath); err != nil {
 		return err

--- a/go/kbnm/hostmanifest/user.go
+++ b/go/kbnm/hostmanifest/user.go
@@ -1,0 +1,35 @@
+package hostmanifest
+
+import (
+	"os/user"
+)
+
+type User interface {
+	// IsAdmin returns true if the user is root, usually uid == 0
+	IsAdmin() bool
+	// PrefixPath is where paths relative to that user should be. Usually $HOME.
+	PrefixPath() string
+}
+
+type userPath struct {
+	Admin bool
+	Path  string
+}
+
+func (u *userPath) IsAdmin() bool      { return u.Admin }
+func (u *userPath) PrefixPath() string { return u.Path }
+
+// CurrentUser returns a User representing the current user.
+func CurrentUser() (*userPath, error) {
+	current, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+	u := &userPath{
+		Admin: current.Uid == "0",
+	}
+	if !u.IsAdmin() {
+		u.Path = current.HomeDir
+	}
+	return u, nil
+}

--- a/go/kbnm/hostmanifest/whitelist.go
+++ b/go/kbnm/hostmanifest/whitelist.go
@@ -10,12 +10,12 @@ import (
 // whitelistPath is used for installing the whitelist as a JSON into a given
 // path on disk.
 type whitelistPath struct {
-	// Root is the path of the NativeMessage whitelists for root user.
+	// Root is the path of the machine-global NativeMessage whitelists.
 	Root string
 	// Home is the path of the NativeMessage whitelists for regular users.
 	Home string
 	// Overlay is an optional path to prefix all paths with. Useful for
-	// generating whitelists for Linux distributio packaging.
+	// generating whitelists for Linux distribution packaging.
 	Overlay string
 }
 

--- a/go/kbnm/hostmanifest/whitelist.go
+++ b/go/kbnm/hostmanifest/whitelist.go
@@ -1,0 +1,61 @@
+package hostmanifest
+
+import (
+	"encoding/json"
+	"os"
+	"os/user"
+	"path/filepath"
+)
+
+// whitelistPath is used for installing the whitelist as a JSON into a given
+// path on disk.
+type whitelistPath struct {
+	// Root is the path of the NativeMessage whitelists for root user.
+	Root string
+	// Home is the path of the NativeMessage whitelists for regular users.
+	Home string
+	// Overlay is an optional path to prefix all paths with. Useful for
+	// generating whitelists for Linux distributio packaging.
+	Overlay string
+}
+
+func (w *whitelistPath) path(u *user.User, appID string) string {
+	if u.Uid == "0" {
+		return filepath.Join(w.Overlay, w.Root, appID+".json")
+	}
+	return filepath.Join(w.Overlay, u.HomeDir, w.Home, appID+".json")
+}
+
+func (w *whitelistPath) Install(u *user.User, app AppManifest) error {
+	jsonPath := w.path(u, app.ID())
+	parentDir := filepath.Dir(jsonPath)
+
+	// Make the path if it doesn't exist
+	if err := os.MkdirAll(parentDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	// Write the file
+	fp, err := os.OpenFile(jsonPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	encoder := json.NewEncoder(fp)
+	encoder.SetIndent("", "    ")
+	if err := encoder.Encode(&app); err != nil {
+		return err
+	}
+
+	return fp.Sync()
+}
+
+func (w *whitelistPath) Uninstall(u *user.User, app AppManifest) error {
+	jsonPath := w.path(u, app.ID())
+	if err := os.Remove(jsonPath); err != nil && !os.IsNotExist(err) {
+		// We don't care if it doesn't exist, but other errors should escalate
+		return err
+	}
+	return nil
+}

--- a/go/kbnm/install_host
+++ b/go/kbnm/install_host
@@ -16,29 +16,54 @@ realpath() {
   fi
 }
 
-detect() {
+detect_chrome() {
+  declare filename="$1"
+
   # Find where the NativeMessagingHosts whitelist lives for this platform.
   whoami="$(whoami)"
   if [[ "$(uname -s)" == "Darwin" ]]; then
     # Mac
     if [[ "$whoami" == "root" ]]; then
-      echo "/Library/Google/Chrome/NativeMessagingHosts"
+      echo "/Library/Google/Chrome/NativeMessagingHosts/${filename}"
     else
-      echo "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+      echo "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/${filename}"
     fi
   else
     # Linux
     if [[ "$whoami" == "root" ]]; then
-      echo "/etc/opt/chrome/native-messaging-hosts"
+      echo "/etc/opt/chrome/native-messaging-hosts/${filename}"
     else
-      echo "$HOME/.config/google-chrome/NativeMessagingHosts"
+      echo "$HOME/.config/google-chrome/NativeMessagingHosts/${filename}"
+    fi
+  fi
+}
+
+detect_firefox() {
+  declare filename="$1"
+
+  # Find where the NativeMessagingHosts whitelist lives for this platform.
+  whoami="$(whoami)"
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    # Mac
+    if [[ "$whoami" == "root" ]]; then
+      echo "/Library/Application Support/Mozilla/NativeMessagingHosts/${filename}"
+    else
+      echo "$HOME/Library/Application Support/Mozilla/NativeMessagingHosts/${filename}"
+    fi
+  else
+    # Linux
+    if [[ "$whoami" == "root" ]]; then
+      echo "/usr/lib/mozilla/native-messaging-hosts/${filename}"
+    else
+      echo "$HOME/.mozilla/native-messaging-hosts/${filename}"
     fi
   fi
 }
 
 install() {
   # Install the whitelist.
-  declare target="$1"
+  declare template="$1"
+  declare target="$2"
 
   local target_dir="$(dirname "$target")"
   if [[ ! -d "$target_dir" ]]; then
@@ -59,7 +84,7 @@ install() {
   fi
 
   echo "Writing: $target"
-  cat "$here/host_json.template" \
+  cat "$template" \
     | sed "s|@@HOST_PATH@@|$host_path|g" \
     > "$target"
 
@@ -83,14 +108,19 @@ main() {
 
   declare cmd="${1:-}"
 
-  readonly host_name="io.keybase.kbnm"
-  local target="$(detect)/${host_name}.json"
+  local here="$(dirname $(realpath "$BASH_SOURCE"))"
+  local filename="io.keybase.kbnm.json"
 
-  if [[ "$cmd" == "uninstall" ]]; then
-    uninstall "$target"
-  else
-    install "$target"
-  fi
+  case "$cmd" in
+    "uninstall")
+      uninstall "$(detect_chrome "$filename")"
+      uninstall "$(detect_firefox "$filename")"
+      ;;
+    *)
+      install "$here/host_json.template" "$(detect_chrome "$filename")"
+      install "$here/host_json.firefox.template" "$(detect_firefox "$filename")"
+      ;;
+  esac
 }
 
 

--- a/go/kbnm/installer/installer.go
+++ b/go/kbnm/installer/installer.go
@@ -1,0 +1,167 @@
+package installer
+
+import (
+	"encoding/json"
+	"os"
+	"os/user"
+	"path/filepath"
+)
+
+type AppManifest interface {
+	ID() string
+}
+
+type App struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Path        string `json:"path"`
+	Type        string `json:"type"`
+}
+
+func (app App) ID() string {
+	return app.Name
+}
+
+type chromeApp struct {
+	App
+	AllowedOrigins []string `json:"allowed_origins"`
+}
+
+type firefoxApp struct {
+	App
+	AllowedExtensions []string `json:"allowed_extensions"`
+}
+
+func KnownInstallers() map[string]Installer {
+	return map[string]Installer{
+		// https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location-nix
+		"chrome": &WhitelistPath{
+			Root: "/Library/Google/Chrome/NativeMessagingHosts",
+			Home: "Library/Application Support/Google/Chrome/NativeMessagingHosts",
+		},
+		"chromium": &WhitelistPath{
+			Root: "/Library/Application Support/Chromium/NativeMessagingHosts",
+			Home: "Library/Application Support/Chromium/NativeMessagingHosts",
+		},
+		// TODO: MDN link
+		"firefox": &WhitelistPath{
+			Root: "/Library/Application Support/Mozilla/NativeMessagingHosts",
+			Home: "Library/Application Support/Mozilla/NativeMessagingHosts",
+		},
+	}
+}
+
+type Installer interface {
+	Install(u *user.User, app AppManifest) error
+	Uninstall(u *user.User, app AppManifest) error
+}
+
+type WhitelistPath struct {
+	Root string
+	Home string
+}
+
+func (w *WhitelistPath) Path(u *user.User, appID string) string {
+	if u.Uid == "0" {
+		return filepath.Join(w.Root, appID+".json")
+	}
+	return filepath.Join(u.HomeDir, w.Home, appID+".json")
+}
+
+func (w *WhitelistPath) Install(u *user.User, app AppManifest) error {
+	jsonPath := w.Path(u, app.ID())
+	parentDir := filepath.Dir(jsonPath)
+
+	// Make the path if it doesn't exist
+	if err := os.MkdirAll(parentDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	// Write the file
+	fp, err := os.OpenFile(jsonPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	encoder := json.NewEncoder(fp)
+	encoder.SetIndent("", "    ")
+	if err := encoder.Encode(&app); err != nil {
+		return err
+	}
+
+	return fp.Sync()
+}
+
+func (w *WhitelistPath) Uninstall(u *user.User, app AppManifest) error {
+	jsonPath := w.Path(u, app.ID())
+	if err := os.Remove(jsonPath); err != nil && !os.IsNotExist(err) {
+		// We don't care if it doesn't exist, but other errors should escalate
+		return err
+	}
+	return nil
+}
+
+const kbnmAppName = "io.keybase.kbnm"
+
+func UninstallKBNM() error {
+	u, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	app := App{
+		Name: kbnmAppName,
+	}
+
+	for _, whitelist := range KnownInstallers() {
+		if err := whitelist.Uninstall(u, app); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func InstallKBNM(path string) error {
+	u, err := user.Current()
+	if err != nil {
+		return err
+	}
+	app := App{
+		Name:        kbnmAppName,
+		Description: "Keybase Native Messaging API",
+		Path:        path,
+		Type:        "stdio",
+	}
+
+	var manifest AppManifest
+	for browser, whitelist := range KnownInstallers() {
+		switch browser {
+		case "chrome", "chromium":
+			manifest = chromeApp{
+				App: app,
+				AllowedOrigins: []string{
+					// Production public version in the store
+					"chrome-extension://ognfafcpbkogffpmmdglhbjboeojlefj/",
+					// Hard-coded key from the repo version
+					"chrome-extension://kockbbfoibcdfibclaojljblnhpnjndg/",
+					// Keybase-internal version
+					"chrome-extension://gnjkbjlgkpiaehpibpdefaieklbfljjm/",
+				},
+			}
+		case "firefox":
+			manifest = firefoxApp{
+				App: app,
+				AllowedExtensions: []string{
+					"keybase@keybase.io",
+				},
+			}
+		}
+
+		if err := whitelist.Install(u, manifest); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go/kbnm/installer/installer.go
+++ b/go/kbnm/installer/installer.go
@@ -1,120 +1,25 @@
 package installer
 
 import (
-	"encoding/json"
-	"os"
 	"os/user"
-	"path/filepath"
+
+	"github.com/keybase/client/go/kbnm/hostmanifest"
 )
-
-type AppManifest interface {
-	ID() string
-}
-
-type App struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Path        string `json:"path"`
-	Type        string `json:"type"`
-}
-
-func (app App) ID() string {
-	return app.Name
-}
-
-type chromeApp struct {
-	App
-	AllowedOrigins []string `json:"allowed_origins"`
-}
-
-type firefoxApp struct {
-	App
-	AllowedExtensions []string `json:"allowed_extensions"`
-}
-
-func KnownInstallers() map[string]Installer {
-	return map[string]Installer{
-		// https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location-nix
-		"chrome": &WhitelistPath{
-			Root: "/Library/Google/Chrome/NativeMessagingHosts",
-			Home: "Library/Application Support/Google/Chrome/NativeMessagingHosts",
-		},
-		"chromium": &WhitelistPath{
-			Root: "/Library/Application Support/Chromium/NativeMessagingHosts",
-			Home: "Library/Application Support/Chromium/NativeMessagingHosts",
-		},
-		// TODO: MDN link
-		"firefox": &WhitelistPath{
-			Root: "/Library/Application Support/Mozilla/NativeMessagingHosts",
-			Home: "Library/Application Support/Mozilla/NativeMessagingHosts",
-		},
-	}
-}
-
-type Installer interface {
-	Install(u *user.User, app AppManifest) error
-	Uninstall(u *user.User, app AppManifest) error
-}
-
-type WhitelistPath struct {
-	Root string
-	Home string
-}
-
-func (w *WhitelistPath) Path(u *user.User, appID string) string {
-	if u.Uid == "0" {
-		return filepath.Join(w.Root, appID+".json")
-	}
-	return filepath.Join(u.HomeDir, w.Home, appID+".json")
-}
-
-func (w *WhitelistPath) Install(u *user.User, app AppManifest) error {
-	jsonPath := w.Path(u, app.ID())
-	parentDir := filepath.Dir(jsonPath)
-
-	// Make the path if it doesn't exist
-	if err := os.MkdirAll(parentDir, os.ModePerm); err != nil {
-		return err
-	}
-
-	// Write the file
-	fp, err := os.OpenFile(jsonPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-	if err != nil {
-		return err
-	}
-	defer fp.Close()
-
-	encoder := json.NewEncoder(fp)
-	encoder.SetIndent("", "    ")
-	if err := encoder.Encode(&app); err != nil {
-		return err
-	}
-
-	return fp.Sync()
-}
-
-func (w *WhitelistPath) Uninstall(u *user.User, app AppManifest) error {
-	jsonPath := w.Path(u, app.ID())
-	if err := os.Remove(jsonPath); err != nil && !os.IsNotExist(err) {
-		// We don't care if it doesn't exist, but other errors should escalate
-		return err
-	}
-	return nil
-}
 
 const kbnmAppName = "io.keybase.kbnm"
 
-func UninstallKBNM() error {
+// UninstallKBNM removes NativeMessaging whitelisting for KBNM.
+func UninstallKBNM(overlay string) error {
 	u, err := user.Current()
 	if err != nil {
 		return err
 	}
 
-	app := App{
+	app := hostmanifest.App{
 		Name: kbnmAppName,
 	}
 
-	for _, whitelist := range KnownInstallers() {
+	for _, whitelist := range hostmanifest.KnownInstallers(overlay) {
 		if err := whitelist.Uninstall(u, app); err != nil {
 			return err
 		}
@@ -123,23 +28,24 @@ func UninstallKBNM() error {
 	return nil
 }
 
-func InstallKBNM(path string) error {
+// UninstallKBNM writes NativeMessaging whitelisting for KBNM.
+func InstallKBNM(overlay string, path string) error {
 	u, err := user.Current()
 	if err != nil {
 		return err
 	}
-	app := App{
+	app := hostmanifest.App{
 		Name:        kbnmAppName,
 		Description: "Keybase Native Messaging API",
 		Path:        path,
 		Type:        "stdio",
 	}
 
-	var manifest AppManifest
-	for browser, whitelist := range KnownInstallers() {
+	var manifest hostmanifest.AppManifest
+	for browser, whitelist := range hostmanifest.KnownInstallers(overlay) {
 		switch browser {
 		case "chrome", "chromium":
-			manifest = chromeApp{
+			manifest = hostmanifest.ChromeApp{
 				App: app,
 				AllowedOrigins: []string{
 					// Production public version in the store
@@ -151,7 +57,7 @@ func InstallKBNM(path string) error {
 				},
 			}
 		case "firefox":
-			manifest = firefoxApp{
+			manifest = hostmanifest.FirefoxApp{
 				App: app,
 				AllowedExtensions: []string{
 					"keybase@keybase.io",

--- a/go/kbnm/main.go
+++ b/go/kbnm/main.go
@@ -36,6 +36,7 @@ type Request struct {
 
 var plainFlag = flag.Bool("plain", false, "newline-delimited JSON IO, no length prefix")
 var versionFlag = flag.Bool("version", false, "print the version and exit")
+var overlayFlag = flag.String("overlay", "", "install/uninstall within an overlay path")
 
 // process consumes a single message
 func process(h *handler, in nativemessaging.JSONDecoder, out nativemessaging.JSONEncoder) error {
@@ -94,12 +95,12 @@ func main() {
 			exit(2, "error finding kbnm binary: %s", err)
 		}
 		log.Print("installing: ", kbnmPath)
-		if err := installer.InstallKBNM(kbnmPath); err != nil {
+		if err := installer.InstallKBNM(*overlayFlag, kbnmPath); err != nil {
 			exit(2, "error installing kbnm whitelist: %s", err)
 		}
 		exit(0, "Installed NativeMessaging whitelists.")
 	case "uninstall":
-		if err := installer.UninstallKBNM(); err != nil {
+		if err := installer.UninstallKBNM(*overlayFlag); err != nil {
 			exit(2, "error uninstalling kbnm whitelist: %s", err)
 		}
 		exit(0, "Uninstalled NativeMessaging whitelists.")

--- a/go/kbnm/main.go
+++ b/go/kbnm/main.go
@@ -87,7 +87,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	overlay := os.Getenv("OVERLAY")
 	switch flag.Arg(0) {
 	case "install":
 		kbnmPath, err := findKeybaseBinary(kbnmBinary)
@@ -95,12 +94,12 @@ func main() {
 			exit(2, "error finding kbnm binary: %s", err)
 		}
 		log.Print("installing: ", kbnmPath)
-		if err := installer.InstallKBNM(overlay, kbnmPath); err != nil {
+		if err := installer.InstallKBNM(kbnmPath); err != nil {
 			exit(2, "error installing kbnm whitelist: %s", err)
 		}
 		exit(0, "Installed NativeMessaging whitelists.")
 	case "uninstall":
-		if err := installer.UninstallKBNM(overlay); err != nil {
+		if err := installer.UninstallKBNM(); err != nil {
 			exit(2, "error uninstalling kbnm whitelist: %s", err)
 		}
 		exit(0, "Uninstalled NativeMessaging whitelists.")

--- a/go/kbnm/main.go
+++ b/go/kbnm/main.go
@@ -36,7 +36,6 @@ type Request struct {
 
 var plainFlag = flag.Bool("plain", false, "newline-delimited JSON IO, no length prefix")
 var versionFlag = flag.Bool("version", false, "print the version and exit")
-var overlayFlag = flag.String("overlay", "", "install/uninstall within an overlay path")
 
 // process consumes a single message
 func process(h *handler, in nativemessaging.JSONDecoder, out nativemessaging.JSONEncoder) error {
@@ -88,6 +87,7 @@ func main() {
 		os.Exit(0)
 	}
 
+	overlay := os.Getenv("OVERLAY")
 	switch flag.Arg(0) {
 	case "install":
 		kbnmPath, err := findKeybaseBinary(kbnmBinary)
@@ -95,12 +95,12 @@ func main() {
 			exit(2, "error finding kbnm binary: %s", err)
 		}
 		log.Print("installing: ", kbnmPath)
-		if err := installer.InstallKBNM(*overlayFlag, kbnmPath); err != nil {
+		if err := installer.InstallKBNM(overlay, kbnmPath); err != nil {
 			exit(2, "error installing kbnm whitelist: %s", err)
 		}
 		exit(0, "Installed NativeMessaging whitelists.")
 	case "uninstall":
-		if err := installer.UninstallKBNM(*overlayFlag); err != nil {
+		if err := installer.UninstallKBNM(overlay); err != nil {
 			exit(2, "error uninstalling kbnm whitelist: %s", err)
 		}
 		exit(0, "Uninstalled NativeMessaging whitelists.")


### PR DESCRIPTION
- [x] Port original dev install_host to support firefox
   - [ ] Delete the shell-based installer when Go-based one is done?
- Implement a platform-agnostic thing for installing KBNM whitelists: `hostmanifest`
  - [x] Windows
  - [x] Linux
  - [x] Darwin
- Overlay path support for *nix (specifically for prepackaging into .deb/arch/etc)
- Migrate existing installers:
  - [ ] Windows
  - [ ] Darwin
  - [ ] Linux


Usage:

```
$ ./kbnm install
$ ./kbnm uninstall
$ KBNM_INSTALL_ROOT=1 KBNM_INSTALL_OVERLAY=$PWD/overlay ./kbnm install
$ tree overlay/
overlay/
└── Library
    ├── Application Support
    │   ├── Chromium
    │   │   └── NativeMessagingHosts
    │   │       └── io.keybase.kbnm.json
    │   └── Mozilla
    │       └── NativeMessagingHosts
    │           └── io.keybase.kbnm.json
    └── Google
        └── Chrome
            └── NativeMessagingHosts
                └── io.keybase.kbnm.json
```