### PR TITLE
Unify team name types

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -6,6 +6,7 @@ package keybase1
 import (
 	"bytes"
 	"crypto/hmac"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -1370,6 +1371,7 @@ func (t TeamName) IsNil() bool {
 	return len(t.Parts) == 0
 }
 
+// underscores allowed, just not first or doubled
 var namePartRxx = regexp.MustCompile(`([a-zA-Z0-9][a-zA-Z0-9_]?)+`)
 
 func TeamNameFromString(s string) (ret TeamName, err error) {
@@ -1379,6 +1381,9 @@ func TeamNameFromString(s string) (ret TeamName, err error) {
 	}
 	tmp := make([]TeamNamePart, len(parts))
 	for i, part := range parts {
+		if !(len(part) >= 2 && len(part) <= 16) {
+			return ret, fmt.Errorf("team name wrong size:'%s' %v <= %v <= %v", part, 2, len(part), 16)
+		}
 		if !namePartRxx.MatchString(part) {
 			return ret, fmt.Errorf("Bad name component: %s (at pos %d)", part, i)
 		}
@@ -1401,6 +1406,19 @@ func (t TeamName) Eq(t2 TeamName) bool {
 
 func (t TeamName) IsRootTeam() bool {
 	return len(t.Parts) == 1
+}
+
+// Get the top level team id for this team name.
+// Only makes sense for non-sub teams.
+func (t TeamName) ToTeamID() TeamID {
+	low := strings.ToLower(t.String())
+	sum := sha256.Sum256([]byte(low))
+	bs := append(sum[:15], TEAMID_SUFFIX)
+	res, err := TeamIDFromString(hex.EncodeToString(bs))
+	if err != nil {
+		panic(err)
+	}
+	return res
 }
 
 func (u UserPlusKeys) ToUserVersion() UserVersion {

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -406,7 +406,7 @@ func (o TeamData) DeepCopy() TeamData {
 type TeamSigChainState struct {
 	Reader       UserVersion                         `codec:"reader" json:"reader"`
 	Id           TeamID                              `codec:"id" json:"id"`
-	Name         string                              `codec:"name" json:"name"`
+	Name         TeamName                            `codec:"name" json:"name"`
 	LastSeqno    Seqno                               `codec:"lastSeqno" json:"lastSeqno"`
 	LastLinkID   LinkID                              `codec:"lastLinkID" json:"lastLinkID"`
 	ParentID     *TeamID                             `codec:"parentID,omitempty" json:"parentID,omitempty"`
@@ -419,7 +419,7 @@ func (o TeamSigChainState) DeepCopy() TeamSigChainState {
 	return TeamSigChainState{
 		Reader:     o.Reader.DeepCopy(),
 		Id:         o.Id.DeepCopy(),
-		Name:       o.Name,
+		Name:       o.Name.DeepCopy(),
 		LastSeqno:  o.LastSeqno.DeepCopy(),
 		LastLinkID: o.LastLinkID.DeepCopy(),
 		ParentID: (func(x *TeamID) *TeamID {

--- a/go/teams/chain_test.go
+++ b/go/teams/chain_test.go
@@ -87,7 +87,7 @@ func TestTeamSigChainPlay1(t *testing.T) {
 			t.Logf("testing serde")
 		}
 
-		require.Equal(t, "t_9d6d1e37", string(state.GetName()))
+		require.Equal(t, "t_9d6d1e37", state.GetName().String())
 		require.False(t, state.IsSubteam())
 		ptk, err := state.GetLatestPerTeamKey()
 		require.NoError(t, err)
@@ -152,7 +152,7 @@ func TestTeamSigChainPlay2(t *testing.T) {
 	state, err := player.GetState()
 	require.NoError(t, err)
 	for i := 0; i < 2; i++ {
-		require.Equal(t, "t_bfaadb41", string(state.GetName()))
+		require.Equal(t, "t_bfaadb41", state.GetName().String())
 		require.False(t, state.IsSubteam())
 		ptk, err := state.GetLatestPerTeamKey()
 		require.NoError(t, err)

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -129,9 +129,9 @@ func CreateRootTeam(ctx context.Context, g *libkb.GlobalContext, name string) (e
 	return nil
 }
 
-func CreateSubteam(ctx context.Context, g *libkb.GlobalContext, subteamBasename string, parentName TeamName) (err error) {
+func CreateSubteam(ctx context.Context, g *libkb.GlobalContext, subteamBasename string, parentName keybase1.TeamName) (err error) {
 	defer g.CTrace(ctx, "CreateSubteam", func() error { return err })()
-	subteamName, err := TeamNameFromString(string(parentName) + "." + subteamBasename)
+	subteamName, err := keybase1.TeamNameFromString(parentName.String() + "." + subteamBasename)
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func CreateSubteam(ctx context.Context, g *libkb.GlobalContext, subteamBasename 
 		return err
 	}
 
-	parentTeam, err := GetForTeamManagementByStringName(ctx, g, string(parentName))
+	parentTeam, err := GetForTeamManagementByStringName(ctx, g, parentName.String())
 	if err != nil {
 		return err
 	}
@@ -266,7 +266,7 @@ func makeSigchainV2OuterSig(
 	return sig, nil
 }
 
-func generateNewSubteamSigForParentChain(g *libkb.GlobalContext, me *libkb.User, signingKey libkb.GenericKey, parentTeam *TeamSigChainState, subteamName TeamName, subteamID keybase1.TeamID, admin *SCTeamAdmin) (item *libkb.SigMultiItem, err error) {
+func generateNewSubteamSigForParentChain(g *libkb.GlobalContext, me *libkb.User, signingKey libkb.GenericKey, parentTeam *TeamSigChainState, subteamName keybase1.TeamName, subteamID keybase1.TeamID, admin *SCTeamAdmin) (item *libkb.SigMultiItem, err error) {
 	newSubteamSigBody, err := NewSubteamSig(me, signingKey, parentTeam, subteamName, subteamID, admin)
 	newSubteamSigJSON, err := newSubteamSigBody.Marshal()
 	if err != nil {
@@ -299,7 +299,7 @@ func generateNewSubteamSigForParentChain(g *libkb.GlobalContext, me *libkb.User,
 	return
 }
 
-func generateHeadSigForSubteamChain(g *libkb.GlobalContext, me *libkb.User, signingKey libkb.GenericKey, parentTeam *TeamSigChainState, subteamName TeamName, subteamID keybase1.TeamID, admin *SCTeamAdmin) (item *libkb.SigMultiItem, boxes *PerTeamSharedSecretBoxes, err error) {
+func generateHeadSigForSubteamChain(g *libkb.GlobalContext, me *libkb.User, signingKey libkb.GenericKey, parentTeam *TeamSigChainState, subteamName keybase1.TeamName, subteamID keybase1.TeamID, admin *SCTeamAdmin) (item *libkb.SigMultiItem, boxes *PerTeamSharedSecretBoxes, err error) {
 	deviceEncryptionKey, err := g.ActiveDevice.EncryptionKey()
 	if err != nil {
 		return
@@ -388,11 +388,12 @@ func generateHeadSigForSubteamChain(g *libkb.GlobalContext, me *libkb.User, sign
 	return
 }
 
-func makeSubteamTeamSection(subteamName TeamName, subteamID keybase1.TeamID, parentTeam *TeamSigChainState, owner *libkb.User, perTeamSigningKID keybase1.KID, perTeamEncryptionKID keybase1.KID, admin *SCTeamAdmin) (SCTeamSection, error) {
+func makeSubteamTeamSection(subteamName keybase1.TeamName, subteamID keybase1.TeamID, parentTeam *TeamSigChainState, owner *libkb.User, perTeamSigningKID keybase1.KID, perTeamEncryptionKID keybase1.KID, admin *SCTeamAdmin) (SCTeamSection, error) {
 	ownerUserVersion := owner.ToUserVersion()
 
+	subteamName2 := subteamName.String()
 	teamSection := SCTeamSection{
-		Name: (*SCTeamName)(&subteamName),
+		Name: (*SCTeamName)(&subteamName2),
 		ID:   (SCTeamID)(subteamID),
 		Parent: &SCTeamParent{
 			ID:    SCTeamID(parentTeam.GetID()),

--- a/go/teams/create_test.go
+++ b/go/teams/create_test.go
@@ -73,9 +73,9 @@ func TestCreateSubteam(t *testing.T) {
 	u, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
 	require.NoError(t, err)
 
-	parentTeamName, err := TeamNameFromString(u.Username + "T")
+	parentTeamName, err := keybase1.TeamNameFromString(u.Username + "T")
 	require.NoError(t, err)
-	err = CreateRootTeam(context.TODO(), tc.G, string(parentTeamName))
+	err = CreateRootTeam(context.TODO(), tc.G, parentTeamName.String())
 	require.NoError(t, err)
 
 	subteamBasename := "mysubteam"

--- a/go/teams/get_test.go
+++ b/go/teams/get_test.go
@@ -140,9 +140,9 @@ func createTeam(tc libkb.TestContext) string {
 	return name
 }
 
-func createTeam2(tc libkb.TestContext) (TeamName, keybase1.TeamID) {
+func createTeam2(tc libkb.TestContext) (keybase1.TeamName, keybase1.TeamID) {
 	teamNameS := createTeam(tc)
-	teamName, err := TeamNameFromString(teamNameS)
+	teamName, err := keybase1.TeamNameFromString(teamNameS)
 	require.NoError(tc.T, err)
 	return teamName, teamName.ToTeamID()
 }

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -63,7 +63,7 @@ func TestLoaderBasic(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, teamID, team.Chain.Id)
-	require.Equal(t, teamName.String(), team.Chain.Name)
+	require.True(t, teamName.Eq(team.Chain.Name))
 
 	t.Logf("load the team again")
 	team, err = tc.G.GetTeamLoader().(*TeamLoader).LoadTODO(context.TODO(), keybase1.LoadTeamArg{
@@ -71,7 +71,7 @@ func TestLoaderBasic(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, teamID, team.Chain.Id)
-	require.Equal(t, teamName.String(), team.Chain.Name)
+	require.True(t, teamName.Eq(team.Chain.Name))
 }
 
 // Test that the loader works after the cache turns stale
@@ -93,7 +93,7 @@ func TestLoaderStaleNoUpdates(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, teamID, team.Chain.Id)
-	require.Equal(t, teamName.String(), team.Chain.Name)
+	require.True(t, teamName.Eq(team.Chain.Name))
 
 	t.Logf("make the cache look old")
 	st := getStorageFromG(tc.G)
@@ -110,5 +110,5 @@ func TestLoaderStaleNoUpdates(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, teamID, team.Chain.Id)
-	require.Equal(t, teamName.String(), team.Chain.Name)
+	require.True(t, teamName.Eq(team.Chain.Name))
 }

--- a/go/teams/rpc_exim.go
+++ b/go/teams/rpc_exim.go
@@ -40,7 +40,7 @@ func (t *Team) ExportToTeamPlusApplicationKeys(ctx context.Context, idTime keyba
 
 	ret = keybase1.TeamPlusApplicationKeys{
 		Id:              t.Chain.GetID(),
-		Name:            t.Chain.GetName(),
+		Name:            t.Chain.GetName().String(),
 		Application:     application,
 		Writers:         writers,
 		OnlyReaders:     onlyReaders,

--- a/go/teams/sig.go
+++ b/go/teams/sig.go
@@ -57,7 +57,7 @@ func RootTeamIDFromNameString(name string) keybase1.TeamID {
 	return keybase1.TeamID(hex.EncodeToString(idBytes))
 }
 
-func NewSubteamSig(me *libkb.User, key libkb.GenericKey, parentTeam *TeamSigChainState, subteamName TeamName, subteamID keybase1.TeamID, admin *SCTeamAdmin) (*jsonw.Wrapper, error) {
+func NewSubteamSig(me *libkb.User, key libkb.GenericKey, parentTeam *TeamSigChainState, subteamName keybase1.TeamName, subteamID keybase1.TeamID, admin *SCTeamAdmin) (*jsonw.Wrapper, error) {
 	prevLinkID, err := libkb.ImportLinkID(parentTeam.GetLatestLinkID())
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func NewSubteamSig(me *libkb.User, key libkb.GenericKey, parentTeam *TeamSigChai
 		ID: (SCTeamID)(parentTeam.GetID()),
 		Subteam: &SCSubteam{
 			ID:   (SCTeamID)(subteamID),
-			Name: (SCTeamName)(subteamName),
+			Name: (SCTeamName)(subteamName.String()),
 		},
 		Admin: admin,
 	}

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -119,7 +119,7 @@ protocol teams {
 
     TeamID id;
     // Latest name of the team
-    string name;
+    TeamName name;
     // The last link procesed
     Seqno lastSeqno;
     LinkID lastLinkID;

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5886,7 +5886,7 @@ export type TeamRole =
 export type TeamSigChainState = {
   reader: UserVersion,
   id: TeamID,
-  name: string,
+  name: TeamName,
   lastSeqno: Seqno,
   lastLinkID: LinkID,
   parentID?: ?TeamID,

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -343,7 +343,7 @@
           "name": "id"
         },
         {
-          "type": "string",
+          "type": "TeamName",
           "name": "name"
         },
         {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5886,7 +5886,7 @@ export type TeamRole =
 export type TeamSigChainState = {
   reader: UserVersion,
   id: TeamID,
-  name: string,
+  name: TeamName,
   lastSeqno: Seqno,
   lastLinkID: LinkID,
   parentID?: ?TeamID,


### PR DESCRIPTION
Get rid of `teams.TeamName` and use `keybase1.TeamName` everywhere.

If we ever want to preserve user's intended capitalization of team names, the way we're handling them could be a problem because it always lowers them. But that may not come up, happy to punt.