### PR TITLE
fix computation of previous team shared keys

### DIFF
--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -55,6 +55,7 @@ func (f *finder) playRaw(ctx context.Context, raw *rawTeam) (*Team, error) {
 	}
 	team.Box = *raw.Box
 	team.ReaderKeyMasks = raw.ReaderKeyMasks
+	team.Prevs = raw.Prevs
 
 	links, err := raw.parseLinks(ctx)
 	if err != nil {
@@ -120,13 +121,13 @@ func (f *finder) newPlayer(ctx context.Context, links []SCChainLink) (*TeamSigCh
 }
 
 type rawTeam struct {
-	ID             keybase1.TeamID                          `json:"id"`
-	Name           keybase1.TeamName                        `json:"name"`
-	Status         libkb.AppStatus                          `json:"status"`
-	Chain          []json.RawMessage                        `json:"chain"`
-	Box            *TeamBox                                 `json:"box"`
-	Prevs          map[keybase1.PerTeamKeyGeneration]string `json:"prevs"`
-	ReaderKeyMasks []keybase1.ReaderKeyMask                 `json:"reader_key_masks"`
+	ID             keybase1.TeamID                                        `json:"id"`
+	Name           keybase1.TeamName                                      `json:"name"`
+	Status         libkb.AppStatus                                        `json:"status"`
+	Chain          []json.RawMessage                                      `json:"chain"`
+	Box            *TeamBox                                               `json:"box"`
+	Prevs          map[keybase1.PerTeamKeyGeneration]prevKeySealedEncoded `json:"prevs"`
+	ReaderKeyMasks []keybase1.ReaderKeyMask                               `json:"reader_key_masks"`
 }
 
 func (r *rawTeam) GetAppStatus() *libkb.AppStatus {

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -145,7 +145,7 @@ func (l *TeamLoader) checkProofs(ctx context.Context,
 // Checks that the team keys match the published values on the chain.
 // Checks that the off-chain data ends up exactly in sync with the chain, generation-wise.
 func (l *TeamLoader) addSecrets(ctx context.Context,
-	state *keybase1.TeamData, box *TeamBox, prevs map[keybase1.PerTeamKeyGeneration]string,
+	state *keybase1.TeamData, box *TeamBox, prevs map[keybase1.PerTeamKeyGeneration]prevKeySealedEncoded,
 	readerKeyMasks []keybase1.ReaderKeyMask) (*keybase1.TeamData, error) {
 
 	latestReceivedGen, seeds, err := l.unboxPerTeamSecrets(ctx, box, prevs)
@@ -266,7 +266,7 @@ func (l *TeamLoader) checkPerTeamKeyAgainstChain(ctx context.Context,
 // Returns the generation of the box (the greatest generation),
 // and a list of the seeds in ascending generation order.
 func (l *TeamLoader) unboxPerTeamSecrets(ctx context.Context,
-	box *TeamBox, prevs map[keybase1.PerTeamKeyGeneration]string) (keybase1.PerTeamKeyGeneration, []keybase1.PerTeamKeySeed, error) {
+	box *TeamBox, prevs map[keybase1.PerTeamKeyGeneration]prevKeySealedEncoded) (keybase1.PerTeamKeyGeneration, []keybase1.PerTeamKeySeed, error) {
 
 	if box == nil {
 		return 0, nil, fmt.Errorf("no key box from server")

--- a/go/teams/rotate_test.go
+++ b/go/teams/rotate_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRotate(t *testing.T) {
@@ -23,6 +24,12 @@ func TestRotate(t *testing.T) {
 		t.Fatalf("initial team generation: %d, expected 1", team.Box.Generation)
 	}
 	ctextInitial := team.Box.Ctext
+	keys1, err := team.AllApplicationKeys(context.TODO(), keybase1.TeamApplication_CHAT)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, len(keys1), 1)
+	require.Equal(t, keys1[0].KeyGeneration, keybase1.PerTeamKeyGeneration(1))
 
 	if err := team.Rotate(context.TODO()); err != nil {
 		t.Fatal(err)
@@ -41,6 +48,12 @@ func TestRotate(t *testing.T) {
 
 	assertRole(tc, name, owner.Username, keybase1.TeamRole_OWNER)
 	assertRole(tc, name, other.Username, keybase1.TeamRole_WRITER)
+
+	keys2, err := after.AllApplicationKeys(context.TODO(), keybase1.TeamApplication_CHAT)
+	require.NoError(t, err)
+	require.Equal(t, len(keys2), 2)
+	require.Equal(t, keys2[0].KeyGeneration, keybase1.PerTeamKeyGeneration(1))
+	require.Equal(t, keys1[0].Key, keys2[0].Key)
 }
 
 func TestHandleRotateRequestOldGeneration(t *testing.T) {


### PR DESCRIPTION
- previously we weren't walking back the chain of encrypted previous keys
- make a test that broke before this fix
- clean up and refactor some of the encoding/decoding of prev encryptions
- introduce a fix
- cc: @mlsteele, this might conflict with some aspects of the new loader
- needs https://github.com/keybase/keybase/pull/1424 before it can work