### PR TITLE
various perf fixes

### DIFF
--- a/shared/common-adapters/avatar.render.native.js
+++ b/shared/common-adapters/avatar.render.native.js
@@ -3,6 +3,7 @@ import Icon from './icon'
 import React, {PureComponent} from 'react'
 import {globalColors} from '../styles'
 import {ClickableBox, NativeImage, Box} from './index.native'
+import {memoize} from 'lodash'
 
 import type {AvatarSize} from './avatar'
 import type {IconType} from './icon'
@@ -135,27 +136,36 @@ class AvatarRender extends PureComponent<void, Props, State> {
 
     return (
       <ClickableBox onClick={onClick} feedback={false}>
-        <Box
-          style={{
-            height: size,
-            position: 'relative',
-            width: size,
-            ...style,
-          }}
-        >
+        <Box style={boxStyle(size, style)}>
           <Background loaded={this.state.loaded} loadingColor={loadingColor} size={size} />
           {!!url && <UserImage opacity={opacity} onLoadEnd={this._onLoadOrError} size={size} url={url} />}
           {!!borderColor && <Border borderColor={borderColor} size={size} />}
           {followIconType &&
-            <Icon
-              type={followIconType}
-              style={{...followIconStyle, width: followIconSize, height: followIconSize}}
-            />}
+            <Icon type={followIconType} style={iconStyle(followIconSize, followIconStyle)} />}
           {children}
         </Box>
       </ClickableBox>
     )
   }
+}
+
+const _iconStyle = memoize(size => ({
+  height: size,
+  width: size,
+}))
+
+const iconStyle = (size, style) => {
+  return style ? {..._iconStyle(size), ...style} : _iconStyle(size)
+}
+
+const _boxStyle = memoize(size => ({
+  height: size,
+  position: 'relative',
+  width: size,
+}))
+
+const boxStyle = (size, style) => {
+  return style ? {..._boxStyle(size), ...style} : _boxStyle(size)
 }
 
 export default AvatarRender

--- a/shared/common-adapters/clickable-box.native.js
+++ b/shared/common-adapters/clickable-box.native.js
@@ -17,6 +17,9 @@ const ClickableBox = ({
   feedback = true,
 }: Props) => {
   if (onClick) {
+    const clickStyle = style
+      ? {...(clickableVisible ? visibleStyle : boxStyle), ...style}
+      : clickableVisible ? visibleStyle : boxStyle
     if (feedback) {
       return (
         <TouchableOpacity
@@ -25,7 +28,7 @@ const ClickableBox = ({
           onPressIn={onPressIn}
           onPressOut={onPressOut}
           onLongPress={onLongPress}
-          style={{...boxStyle, ...(clickableVisible ? visibleStyle : {}), ...style}}
+          style={clickStyle}
           underlayColor={underlayColor || globalColors.white}
           activeOpacity={0.7}
         >
@@ -37,7 +40,7 @@ const ClickableBox = ({
         <TouchableWithoutFeedback
           onPressIn={onPressIn}
           onPressOut={onPressOut}
-          style={{...boxStyle, ...(clickableVisible ? visibleStyle : {}), ...style}}
+          style={clickStyle}
           onPress={onClick}
           onLongPress={onLongPress}
         >
@@ -47,7 +50,7 @@ const ClickableBox = ({
     }
   } else {
     return (
-      <Box style={{...boxStyle, ...style}}>
+      <Box style={style}>
         {children}
       </Box>
     )
@@ -59,6 +62,7 @@ const boxStyle = {
 }
 
 const visibleStyle = {
+  ...boxStyle,
   backgroundColor: 'rgba(0, 255, 0, 0.1)',
 }
 

--- a/shared/common-adapters/header-hoc.native.js
+++ b/shared/common-adapters/header-hoc.native.js
@@ -9,7 +9,14 @@ import {globalStyles, globalColors, globalMargins, statusBarHeight} from '../sty
 import type {Props} from './header-hoc'
 
 function HeaderHoc<P>(WrappedComponent: ReactClass<P>) {
-  return ({onBack, onCancel, headerStyle, title, theme = 'light', ...restProps}: Props & P) => (
+  const HeaderHocWrapper = ({
+    onBack,
+    onCancel,
+    headerStyle,
+    title,
+    theme = 'light',
+    ...restProps
+  }: Props & P) => (
     <Box style={_containerStyle}>
       <Box style={{..._headerStyle, ..._headerStyleThemed[theme], ...headerStyle}}>
         <Box style={_titleStyle}>
@@ -22,6 +29,8 @@ function HeaderHoc<P>(WrappedComponent: ReactClass<P>) {
       <WrappedComponent {...restProps} theme={theme} onBack={onBack} onCancel={onCancel} />
     </Box>
   )
+
+  return HeaderHocWrapper
 }
 
 const _backButtonIconStyleThemed = {

--- a/shared/common-adapters/text.native.js
+++ b/shared/common-adapters/text.native.js
@@ -4,6 +4,7 @@ import openURL from '../util/open-url'
 import {NativeText} from './native-wrappers.native'
 import {defaultColor, fontSizeToSizeStyle, lineClamp, metaData} from './text.meta.native'
 import {clickableVisible} from '../local-debug'
+import shallowEqual from 'shallowequal'
 
 import type {Props, TextType, Background} from './text'
 
@@ -18,6 +19,18 @@ class Text extends Component<void, Props, void> {
 
   _urlClick = () => {
     openURL(this.props.onClickURL)
+  }
+
+  shouldComponentUpdate(nextProps: Props): boolean {
+    return !shallowEqual(this.props, nextProps, (obj, oth, key) => {
+      if (key === 'style') {
+        return shallowEqual(obj, oth)
+      } else if (key === 'children' && this.props.plainText && nextProps.plainText) {
+        // child will be plain text
+        return shallowEqual(obj, oth)
+      }
+      return undefined
+    })
   }
 
   render() {

--- a/shared/devices/container.js
+++ b/shared/devices/container.js
@@ -1,5 +1,5 @@
 // @flow
-import Render from '.'
+import Devices from '.'
 import {List} from 'immutable'
 import {addNewPhone, addNewComputer} from '../actions/login/creators'
 import {compose, lifecycle, mapProps, withState} from 'recompose'
@@ -58,7 +58,8 @@ const menuItems = props => [
   {onClick: props.addNewPaperKey, title: 'New paper key'},
 ]
 
-const Devices = compose(
+export default compose(
+  connect(mapStateToProps, mapDispatchToProps),
   lifecycle({
     componentWillMount: function() {
       this.props.loadDevices()
@@ -72,6 +73,4 @@ const Devices = compose(
     revokedDeviceIDs: props.revokedDeviceIDs.toArray(),
   })),
   withState('showingMenu', 'setShowingMenu', false)
-)(Render)
-
-export default connect(mapStateToProps, mapDispatchToProps)(Devices)
+)(Devices)

--- a/shared/nav.native.js
+++ b/shared/nav.native.js
@@ -24,10 +24,10 @@ type OwnProps = RouteProps<{}, {}>
 
 class CardStackShim extends Component {
   getScreenOptions = () => ({transitionInteractivityThreshold: 0.9})
-  getStateForAction = () => ({})
-  getActionForPathAndParams = () => ({})
-  getPathAndParamsForState = () => ({})
-  getComponentForState = () => ({})
+  getStateForAction = emptyObj
+  getActionForPathAndParams = emptyObj
+  getPathAndParamsForState = emptyObj
+  getComponentForState = emptyObj
 
   getComponentForRouteName = () => this.RenderRouteShim
 
@@ -56,9 +56,9 @@ class CardStackShim extends Component {
           .toArray(),
       },
       dispatch: this._dispatchShim,
-      navigate: () => {},
-      goBack: () => {},
-      setParams: () => {},
+      navigate: nop,
+      goBack: nop,
+      setParams: nop,
     }
 
     return (
@@ -66,6 +66,9 @@ class CardStackShim extends Component {
     )
   }
 }
+
+const nop = () => {}
+const emptyObj = () => ({})
 
 const barStyle = ({showStatusBarDarkContent, underStatusBar}) => {
   // android always uses light-content
@@ -104,7 +107,7 @@ function renderStackRoute(route) {
 
 const forIOS = ({hideNav, shim, tabBar}) => (
   <Box style={flexOne}>
-    <NativeKeyboardAvoidingView behavior={'padding'} style={sceneWrapStyleUnder}>
+    <NativeKeyboardAvoidingView behavior="padding" style={sceneWrapStyleUnder}>
       {shim}
     </NativeKeyboardAvoidingView>
     {!hideNav && tabBar}

--- a/shared/store/enhancer.platform.native.js
+++ b/shared/store/enhancer.platform.native.js
@@ -1,10 +1,6 @@
 // @flow
 import {compose, applyMiddleware} from 'redux'
-import {batchedSubscribe} from 'redux-batched-subscribe'
-import {throttle} from 'lodash'
-
-const throttleNotify = throttle(notify => notify(), 200)
 
 export default function storeEnhancer(middleware: Array<any>): Function {
-  return compose(applyMiddleware(...middleware), batchedSubscribe(throttleNotify))
+  return compose(applyMiddleware(...middleware))
 }


### PR DESCRIPTION
this was based on some testing around the nav

1. Memoizing some styles. So styling overrides often create new objects and that causes render thrash. i think the longer term fix is to use something like glamourous but shortterm i just use lodash memoize so we get the same objects back
1. I turned off the global subscription throttle. We had this on due to cpu issues but it just bakes in latency we can't remove so we should fix it up the correct way and not re-render
