### PR TITLE
Add profiling options for service, mobile app

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -20,9 +20,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/client/go/pvlsource"
 	"github.com/keybase/client/go/service"
-	"github.com/keybase/client/go/teams"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"github.com/keybase/kbfs/fsrpc"
 	"github.com/keybase/kbfs/libkbfs"
@@ -90,8 +88,6 @@ func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride
 	kbCtx = libkb.G
 	kbCtx.Init()
 	kbCtx.SetServices(externals.GetServices())
-	pvlsource.NewPvlSourceAndInstall(kbCtx)
-	teams.NewTeamLoaderAndInstall(kbCtx)
 	usage := libkb.Usage{
 		Config:    true,
 		API:       true,

--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -77,7 +77,7 @@ func Init(homeDir string, logFile string, runModeStr string, accessGroupOverride
 		fmt.Printf("Go: Using log: %s\n", logFile)
 	}
 
-	startTrace()
+	startTrace(logFile)
 
 	dnsNSFetcher := newDNSNSFetcher(externalDNSNSFetcher)
 	dnsServers := dnsNSFetcher.GetServers()
@@ -235,7 +235,7 @@ func Version() string {
 	return libkb.VersionString()
 }
 
-func startTrace() {
+func startTrace(logFile string) {
 	if os.Getenv("KEYBASE_TRACE_MOBILE") != "1" {
 		return
 	}

--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -243,7 +243,8 @@ func startTrace() {
 	tname := filepath.Join(filepath.Dir(logFile), "svctrace.out")
 	f, err := os.Create(tname)
 	if err != nil {
-		return err
+		fmt.Printf("error creating %s\n", tname)
+		return
 	}
 	fmt.Printf("Go: starting trace %s\n", tname)
 	trace.Start(f)

--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -28,8 +28,13 @@ type levelDBOps interface {
 }
 
 func levelDbPut(ops levelDBOps, id DbKey, aliases []DbKey, value []byte) error {
-	batch := new(leveldb.Batch)
 	idb := id.ToBytes(levelDbTableKv)
+	if aliases == nil || len(aliases) == 0 {
+		// if no aliases, just do a put
+		return ops.Put(idb, value, nil)
+	}
+
+	batch := new(leveldb.Batch)
 	batch.Put(idb, value)
 	if aliases != nil {
 		for _, alias := range aliases {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"runtime/trace"
 	"sync"
 	"time"
 
@@ -182,6 +183,19 @@ func (d *Service) Handle(c net.Conn) {
 
 func (d *Service) Run() (err error) {
 	defer func() {
+
+		/*
+			f, err := os.Create("/tmp/svcmem.out")
+			if err != nil {
+				log.Fatal("could not create memory profile: ", err)
+			}
+			runtime.GC() // get up-to-date statistics
+			if err := pprof.WriteHeapProfile(f); err != nil {
+				log.Fatal("could not write memory profile: ", err)
+			}
+			f.Close()
+		*/
+
 		if d.startCh != nil {
 			close(d.startCh)
 		}
@@ -190,6 +204,37 @@ func (d *Service) Run() (err error) {
 	}()
 
 	d.G().Log.Debug("+ service starting up; forkType=%v", d.ForkType)
+
+	/*
+		cpu := os.Getenv("KEYBASE_CPUPROFILE")
+		if cpu != "" {
+			f, err := os.Create(cpu)
+			if err != nil {
+				return err
+			}
+			d.G().Log.Debug("+ started service cpu profile in %s", cpu)
+			pprof.StartCPUProfile(f)
+			defer pprof.StopCPUProfile()
+		}
+	*/
+
+	/*
+		cpu := "/tmp/svccpu.out"
+		f, err := os.Create(cpu)
+		if err != nil {
+			return err
+		}
+		d.G().Log.Debug("+ started service cpu profile in %s", cpu)
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	*/
+
+	f, err := os.Create("/tmp/svctrace.out")
+	if err != nil {
+		return err
+	}
+	trace.Start(f)
+	defer trace.Stop()
 
 	// Sets this global context to "service" mode which will toggle a flag
 	// and will also set in motion various go-routine based managers


### PR DESCRIPTION
All off by default, but can turn on with env vars.

There's a tiny leveldb tweak in here too, which I thought was in a separate PR.  I can move it if you prefer.