### PR TITLE
Bump CITimeMultiplier everywhere if running in CI

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -393,7 +393,7 @@ func doRetry(ctx context.Context, g Contextifier, arg APIArg, cli *Client, req *
 // a canceler, and an error. The canceler ought to be called before the caller (or its caller) is done
 // with this request.
 func doTimeout(origCtx context.Context, cli *Client, req *http.Request, timeout time.Duration) (*http.Response, func(), error) {
-	ctx, cancel := context.WithTimeout(origCtx, timeout)
+	ctx, cancel := context.WithTimeout(origCtx, timeout*CITimeMultiplier)
 	resp, err := ctxhttp.Do(ctx, cli.cli, req)
 	return resp, cancel, err
 }

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -602,3 +602,9 @@ const (
 )
 
 var CITimeMultiplier time.Duration = 1
+
+func init() {
+	if RunningInCI() {
+		CITimeMultiplier = 3
+	}
+}

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -627,3 +627,13 @@ func SleepWithContext(ctx context.Context, clock clockwork.Clock, duration time.
 		return ctx.Err()
 	}
 }
+
+// RunningInCI will return true if it appears we are running in a CI environment.
+func RunningInCI() bool {
+	// All these env vars are set by Jenkins: https://ci.keyba.se/pipeline-syntax/globals#env
+	if os.Getenv("JENKINS_URL") != "" {
+		return true
+	}
+
+	return false
+}

--- a/go/systests/account_deadlock_test.go
+++ b/go/systests/account_deadlock_test.go
@@ -22,11 +22,6 @@ func TestAccountDeadlock(t *testing.T) {
 
 	libkb.G.LocalDb = nil
 
-	libkb.CITimeMultiplier = 2
-	defer func() {
-		libkb.CITimeMultiplier = 1
-	}()
-
 	defer tc.Cleanup()
 
 	stopCh := make(chan error)


### PR DESCRIPTION
This should help all these CI timeouts from service -> API server.