### PR TITLE
team read new_subteam

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1499,6 +1499,10 @@ func (t TeamName) Append(part string) (t3 TeamName, err error) {
 	return t3, err
 }
 
+func (t TeamName) LastPart() TeamNamePart {
+	return t.Parts[len(t.Parts)-1]
+}
+
 func (u UserPlusKeys) ToUserVersion() UserVersion {
 	return UserVersion{
 		Uid:         u.Uid,

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -437,6 +437,7 @@ type TeamSigChainState struct {
 	LastLinkID   LinkID                              `codec:"lastLinkID" json:"lastLinkID"`
 	ParentID     *TeamID                             `codec:"parentID,omitempty" json:"parentID,omitempty"`
 	UserLog      map[UserVersion][]UserLogPoint      `codec:"userLog" json:"userLog"`
+	SubteamLog   map[TeamID][]SubteamLogPoint        `codec:"subteamLog" json:"subteamLog"`
 	PerTeamKeys  map[PerTeamKeyGeneration]PerTeamKey `codec:"perTeamKeys" json:"perTeamKeys"`
 	StubbedTypes map[int]bool                        `codec:"stubbedTypes" json:"stubbedTypes"`
 }
@@ -471,6 +472,22 @@ func (o TeamSigChainState) DeepCopy() TeamSigChainState {
 			}
 			return ret
 		})(o.UserLog),
+		SubteamLog: (func(x map[TeamID][]SubteamLogPoint) map[TeamID][]SubteamLogPoint {
+			ret := make(map[TeamID][]SubteamLogPoint)
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := (func(x []SubteamLogPoint) []SubteamLogPoint {
+					var ret []SubteamLogPoint
+					for _, v := range x {
+						vCopy := v.DeepCopy()
+						ret = append(ret, vCopy)
+					}
+					return ret
+				})(v)
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.SubteamLog),
 		PerTeamKeys: (func(x map[PerTeamKeyGeneration]PerTeamKey) map[PerTeamKeyGeneration]PerTeamKey {
 			ret := make(map[PerTeamKeyGeneration]PerTeamKey)
 			for k, v := range x {
@@ -500,6 +517,18 @@ type UserLogPoint struct {
 func (o UserLogPoint) DeepCopy() UserLogPoint {
 	return UserLogPoint{
 		Role:  o.Role.DeepCopy(),
+		Seqno: o.Seqno.DeepCopy(),
+	}
+}
+
+type SubteamLogPoint struct {
+	Name  TeamName `codec:"name" json:"name"`
+	Seqno Seqno    `codec:"seqno" json:"seqno"`
+}
+
+func (o SubteamLogPoint) DeepCopy() SubteamLogPoint {
+	return SubteamLogPoint{
+		Name:  o.Name.DeepCopy(),
 		Seqno: o.Seqno.DeepCopy(),
 	}
 }

--- a/go/teams/create_test.go
+++ b/go/teams/create_test.go
@@ -79,7 +79,7 @@ func TestCreateSubteam(t *testing.T) {
 	require.NoError(t, err)
 
 	subteamBasename := "mysubteam"
-	err = CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName)
+	_, err = CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName)
 	require.NoError(t, err)
 
 	// TODO: Uncomment the rest here when Get() supports subteams.

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -108,8 +108,7 @@ protocol teams {
       array<TeamApplicationKey> applicationKeys;
   }
 
-  // This type is not really used yet.
-  // It is under the umbrella of the team loader refactor.
+  // Snapshot of a loaded team.
   record TeamData {
     TeamSigChainState chain;
     // generation -> seed
@@ -144,6 +143,11 @@ protocol teams {
     // When a user leaves the team a NONE checkpoint appears in their list.
     map<UserVersion,array<UserLogPoint>> userLog;
 
+    // For each subteam; the timeline of its name.
+    // The checkpoints are always ordered by seqno.
+    // The latest name of the subteam is the role of its last checkpoint.
+    map<TeamID,array<SubteamLogPoint>> subteamLog;
+
     // Keyed by per-team-key generation
     map<PerTeamKeyGeneration, PerTeamKey> perTeamKeys;
 
@@ -157,6 +161,14 @@ protocol teams {
     // The new role. Including NONE if the user left the team.
     TeamRole role;
     // The seqno at which the user became this role.
+    Seqno seqno;
+  }
+
+  // A subteam got this name at this point in time.
+  record SubteamLogPoint {
+  // The new subteam name.
+    TeamName name;
+    // The seqno at which the subteam got this name.
     Seqno seqno;
   }
 

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5789,6 +5789,11 @@ export type StringKVPair = {
   value: string,
 }
 
+export type SubteamLogPoint = {
+  name: TeamName,
+  seqno: Seqno,
+}
+
 export type TLF = {
   id: TLFID,
   name: string,
@@ -5922,6 +5927,7 @@ export type TeamSigChainState = {
   lastLinkID: LinkID,
   parentID?: ?TeamID,
   userLog: {[key: string]: ?Array<UserLogPoint>},
+  subteamLog: {[key: string]: ?Array<SubteamLogPoint>},
   perTeamKeys: {[key: string]: PerTeamKey},
   stubbedTypes: {[key: string]: boolean},
 }

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -407,6 +407,17 @@
         {
           "type": {
             "type": "map",
+            "values": {
+              "type": "array",
+              "items": "SubteamLogPoint"
+            },
+            "keys": "TeamID"
+          },
+          "name": "subteamLog"
+        },
+        {
+          "type": {
+            "type": "map",
             "values": "PerTeamKey",
             "keys": "PerTeamKeyGeneration"
           },
@@ -429,6 +440,20 @@
         {
           "type": "TeamRole",
           "name": "role"
+        },
+        {
+          "type": "Seqno",
+          "name": "seqno"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "SubteamLogPoint",
+      "fields": [
+        {
+          "type": "TeamName",
+          "name": "name"
         },
         {
           "type": "Seqno",

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5789,6 +5789,11 @@ export type StringKVPair = {
   value: string,
 }
 
+export type SubteamLogPoint = {
+  name: TeamName,
+  seqno: Seqno,
+}
+
 export type TLF = {
   id: TLFID,
   name: string,
@@ -5922,6 +5927,7 @@ export type TeamSigChainState = {
   lastLinkID: LinkID,
   parentID?: ?TeamID,
   userLog: {[key: string]: ?Array<UserLogPoint>},
+  subteamLog: {[key: string]: ?Array<SubteamLogPoint>},
   perTeamKeys: {[key: string]: PerTeamKey},
   stubbedTypes: {[key: string]: boolean},
 }


### PR DESCRIPTION
Now `TeamLoader` can now handle a simple example of a parent team. It cannot yet load the subteam, that's next.

`TeamData` now has a `SubteamLog` which is like the `UserLog`. It holds timelines for each subeam id of their name changes.