### PR TITLE
Fix clicking an attachment with no preview causing globalerror

### DIFF
--- a/shared/chat/conversation/messages/attachment/container.js
+++ b/shared/chat/conversation/messages/attachment/container.js
@@ -25,10 +25,8 @@ const mapStateToProps = (state: TypedState, {messageKey}: OwnProps) => {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  _onDownloadAttachment: (selectedConversation, messageID) => {
-    if (selectedConversation && messageID) {
-      dispatch(Creators.saveAttachment(selectedConversation, messageID))
-    }
+  _onDownloadAttachment: (messageKey: Constants.MessageKey) => {
+    dispatch(Creators.saveAttachment(messageKey))
   },
   _onEnsurePreviewLoaded: (messageKey: Constants.MessageKey) =>
     dispatch(Creators.loadAttachmentPreview(messageKey)),
@@ -49,7 +47,7 @@ const mergeProps = (stateProps, dispatchProps, {measure, onAction}: OwnProps) =>
     }
   },
   onDownloadAttachment: () => {
-    dispatchProps._onDownloadAttachment(stateProps.routePath.get(1), stateProps.message.messageID)
+    dispatchProps._onDownloadAttachment(stateProps.message.key)
   },
   onOpenInFileUI: () => {
     dispatchProps._onOpenInFileUI(stateProps.localMessageState.savedPath)


### PR DESCRIPTION
@keybase/react-hackers 

@chromakode r?

Seems like this code path just had a totally wrong function signature, sucks that Flow didn't catch it, maybe worth checking out why as part of the review?

`saveAttachment()` takes a messageKey, but we were passing a conversationIDKey (which fails to split on colons as a messageKey would) and a messageID (which was ignored).