### PR TITLE
fix ProofCache+PVL

### DIFF
--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -178,13 +178,19 @@ func configureProcesses(g *libkb.GlobalContext, cl *libcmdline.CommandLine, cmd 
 			err = fmt.Errorf("Can't run command in standalone mode")
 			return err
 		}
-		err := service.NewService(g, false /* isDaemon */).StartLoopbackServer()
+		svc := service.NewService(g, false /* isDaemon */)
+		err = svc.SetupCriticalSubServices()
 		if err != nil {
-			if pflerr, ok := err.(libkb.PIDFileLockError); ok {
-				err = fmt.Errorf("Can't run in standalone mode with a service running (see %q)",
-					pflerr.Filename)
-				return err
-			}
+			return err
+		}
+		err = svc.StartLoopbackServer()
+		if err != nil {
+			return err
+		}
+		if pflerr, ok := err.(libkb.PIDFileLockError); ok {
+			err = fmt.Errorf("Can't run in standalone mode with a service running (see %q)",
+				pflerr.Filename)
+			return err
 		}
 		return err
 	}

--- a/go/libkb/proof_cache.go
+++ b/go/libkb/proof_cache.go
@@ -26,9 +26,9 @@ func (cr CheckResult) Pack() *jsonw.Wrapper {
 		s.SetKey("code", jsonw.NewInt(int(cr.Status.GetProofStatus())))
 		s.SetKey("desc", jsonw.NewString(cr.Status.GetDesc()))
 		p.SetKey("status", s)
-		p.SetKey("pvlhash", jsonw.NewString(cr.PvlHash))
 	}
 	p.SetKey("time", jsonw.NewInt64(cr.Time.Unix()))
+	p.SetKey("pvlhash", jsonw.NewString(cr.PvlHash))
 	return p
 }
 


### PR DESCRIPTION
- previously, we never wrote the pvlhash to disk on a success, meaning when we loaded results back from disk, we had to throw away the results
- this fixes that by just always writing the PVL hash
- also fix PVL+standalone mode, which I broke