### PR TITLE
add new explicit leave member state CORE-5531

### DIFF
--- a/go/badges/badger.go
+++ b/go/badges/badger.go
@@ -94,7 +94,7 @@ func (b *Badger) Resync(ctx context.Context, chatRemote func() chat1.RemoteInter
 		b.G().Log.Debug("Badger: Resync(): skipping remote call, data previously obtained")
 	}
 
-	state, err := gcli.StateMachineState(nil)
+	state, err := gcli.StateMachineState(ctx, nil)
 	if err != nil {
 		b.G().Log.Debug("Badger: Resync(): unable to get state: %s", err.Error())
 		state = gregor1.State{}

--- a/go/gregor/interface.go
+++ b/go/gregor/interface.go
@@ -1,6 +1,7 @@
 package gregor
 
 import (
+	"context"
 	"net"
 	"time"
 
@@ -146,7 +147,7 @@ type MessageConsumer interface {
 	// perform state mutations, or might be "out-of-band" that just use the
 	// Gregor broadcast mechanism to make sure that all clients get the
 	// notification.
-	ConsumeMessage(m Message) (time.Time, error)
+	ConsumeMessage(ctx context.Context, m Message) (time.Time, error)
 }
 
 // StateMachine is the central interface of the Gregor system. Various parts of the
@@ -159,12 +160,12 @@ type StateMachine interface {
 	// d can be nil, in which case the global state (across all devices)
 	// is returned. If t is nil, then use Now, otherwise, return the state
 	// at the given time.
-	State(u UID, d DeviceID, t TimeOrOffset) (State, error)
+	State(ctx context.Context, u UID, d DeviceID, t TimeOrOffset) (State, error)
 
 	// StateByCategoryPrefix returns the IBMs in the given state that match
 	// the given category prefix. It's similar to calling State().ItemsInCategory()
 	// but results in less data transfer.
-	StateByCategoryPrefix(u UID, d DeviceID, t TimeOrOffset, cp Category) (State, error)
+	StateByCategoryPrefix(ctx context.Context, u UID, d DeviceID, t TimeOrOffset, cp Category) (State, error)
 
 	// IsEphemeral returns whether the backend storage needs to be saved/restored.
 	IsEphemeral() bool
@@ -175,7 +176,7 @@ type StateMachine interface {
 	InitState(s State) error
 
 	// LatestCTime returns the CTime of the newest item for the given user & device.
-	LatestCTime(u UID, d DeviceID) *time.Time
+	LatestCTime(ctx context.Context, u UID, d DeviceID) *time.Time
 
 	// Clear removes all existing state from the StateMachine.
 	Clear() error
@@ -184,13 +185,13 @@ type StateMachine interface {
 	// for the user u on device d.  If d is nil, then we'll return
 	// all messages across all devices.  If d is a device, then we'll
 	// return global messages and per-device messages for that device.
-	InBandMessagesSince(u UID, d DeviceID, t time.Time) ([]InBandMessage, error)
+	InBandMessagesSince(ctx context.Context, u UID, d DeviceID, t time.Time) ([]InBandMessage, error)
 
 	// Reminders returns a slice of non-dismissed items past their RemindTimes.
-	Reminders(maxReminders int) (ReminderSet, error)
+	Reminders(ctx context.Context, maxReminders int) (ReminderSet, error)
 
 	// DeleteReminder deletes a reminder so it won't be in the queue any longer.
-	DeleteReminder(r ReminderID) error
+	DeleteReminder(ctx context.Context, r ReminderID) error
 
 	// ObjFactory returns the ObjFactory used by this StateMachine.
 	ObjFactory() ObjFactory

--- a/go/gregor/interface.go
+++ b/go/gregor/interface.go
@@ -1,11 +1,11 @@
 package gregor
 
 import (
-	"context"
 	"net"
 	"time"
 
 	"github.com/keybase/clockwork"
+	"golang.org/x/net/context"
 )
 
 type InBandMsgType int

--- a/go/gregor/storage/mem_sm.go
+++ b/go/gregor/storage/mem_sm.go
@@ -2,13 +2,13 @@ package storage
 
 import (
 	"bytes"
-	"context"
 	"encoding/hex"
 	"sync"
 	"time"
 
 	"github.com/keybase/client/go/gregor"
 	"github.com/keybase/clockwork"
+	"golang.org/x/net/context"
 )
 
 // MemEngine is an implementation of a gregor StateMachine that just keeps

--- a/go/gregor/storage/mem_sm.go
+++ b/go/gregor/storage/mem_sm.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"sync"
 	"time"
@@ -284,7 +285,7 @@ func (m *MemEngine) consumeInBandMessage(uid gregor.UID, msg gregor.InBandMessag
 	return retTime, err
 }
 
-func (m *MemEngine) ConsumeMessage(msg gregor.Message) (time.Time, error) {
+func (m *MemEngine) ConsumeMessage(ctx context.Context, msg gregor.Message) (time.Time, error) {
 	m.Lock()
 	defer m.Unlock()
 
@@ -344,15 +345,15 @@ func (m *MemEngine) consumeStateUpdateMessage(u *user, now time.Time, msg gregor
 	return i, nil
 }
 
-func (m *MemEngine) State(u gregor.UID, d gregor.DeviceID, t gregor.TimeOrOffset) (gregor.State, error) {
+func (m *MemEngine) State(ctx context.Context, u gregor.UID, d gregor.DeviceID, t gregor.TimeOrOffset) (gregor.State, error) {
 	m.Lock()
 	defer m.Unlock()
 	user := m.getUser(u)
 	return user.state(m.clock.Now(), m.objFactory, d, t)
 }
 
-func (m *MemEngine) StateByCategoryPrefix(u gregor.UID, d gregor.DeviceID, t gregor.TimeOrOffset, cp gregor.Category) (gregor.State, error) {
-	state, err := m.State(u, d, t)
+func (m *MemEngine) StateByCategoryPrefix(ctx context.Context, u gregor.UID, d gregor.DeviceID, t gregor.TimeOrOffset, cp gregor.Category) (gregor.State, error) {
+	state, err := m.State(ctx, u, d, t)
 	if err != nil {
 		return nil, err
 	}
@@ -368,7 +369,7 @@ func (m *MemEngine) Clear() error {
 	return nil
 }
 
-func (m *MemEngine) LatestCTime(u gregor.UID, d gregor.DeviceID) *time.Time {
+func (m *MemEngine) LatestCTime(ctx context.Context, u gregor.UID, d gregor.DeviceID) *time.Time {
 	m.Lock()
 	defer m.Unlock()
 	log := m.getUser(u).log
@@ -384,7 +385,7 @@ func (m *MemEngine) LatestCTime(u gregor.UID, d gregor.DeviceID) *time.Time {
 	return nil
 }
 
-func (m *MemEngine) InBandMessagesSince(u gregor.UID, d gregor.DeviceID, t time.Time) ([]gregor.InBandMessage, error) {
+func (m *MemEngine) InBandMessagesSince(ctx context.Context, u gregor.UID, d gregor.DeviceID, t time.Time) ([]gregor.InBandMessage, error) {
 	m.Lock()
 	defer m.Unlock()
 	msgs, _ := m.getUser(u).replayLog(m.clock.Now(), d, t)
@@ -392,12 +393,12 @@ func (m *MemEngine) InBandMessagesSince(u gregor.UID, d gregor.DeviceID, t time.
 	return msgs, nil
 }
 
-func (m *MemEngine) Reminders(maxReminders int) (gregor.ReminderSet, error) {
+func (m *MemEngine) Reminders(ctx context.Context, maxReminders int) (gregor.ReminderSet, error) {
 	// Unimplemented for MemEngine
 	return nil, nil
 }
 
-func (m *MemEngine) DeleteReminder(r gregor.ReminderID) error {
+func (m *MemEngine) DeleteReminder(ctx context.Context, r gregor.ReminderID) error {
 	// Unimplemented for MemEngine
 	return nil
 }

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -26,6 +26,12 @@ func (o MessageID) DeepCopy() MessageID {
 	return o.DeepCopy()
 }
 
+type TLFConvOrdinal uint
+
+func (o TLFConvOrdinal) DeepCopy() TLFConvOrdinal {
+	return o.DeepCopy()
+}
+
 type TopicID []byte
 
 func (o TopicID) DeepCopy() TopicID {
@@ -221,6 +227,7 @@ type ConversationMemberStatus int
 const (
 	ConversationMemberStatus_ACTIVE  ConversationMemberStatus = 0
 	ConversationMemberStatus_REMOVED ConversationMemberStatus = 1
+	ConversationMemberStatus_LEFT    ConversationMemberStatus = 2
 )
 
 func (o ConversationMemberStatus) DeepCopy() ConversationMemberStatus { return o }
@@ -228,11 +235,13 @@ func (o ConversationMemberStatus) DeepCopy() ConversationMemberStatus { return o
 var ConversationMemberStatusMap = map[string]ConversationMemberStatus{
 	"ACTIVE":  0,
 	"REMOVED": 1,
+	"LEFT":    2,
 }
 
 var ConversationMemberStatusRevMap = map[ConversationMemberStatus]string{
 	0: "ACTIVE",
 	1: "REMOVED",
+	2: "LEFT",
 }
 
 func (e ConversationMemberStatus) String() string {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -560,3 +560,11 @@ func (r *FindConversationsLocalRes) SetOffline() {
 func (t TyperInfo) String() string {
 	return fmt.Sprintf("typer(u:%s d:%s)", t.Username, t.DeviceName)
 }
+
+func (o TLFConvOrdinal) Int() int {
+	return int(o)
+}
+
+func (o TLFConvOrdinal) IsFirst() bool {
+	return o.Int() == 1
+}

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -373,7 +373,7 @@ func (g *gregorHandler) PushHandler(handler libkb.GregorInBandMessageHandler) {
 		}
 
 		if g.badger != nil {
-			s, err := g.getState()
+			s, err := g.getState(context.Background())
 			if err != nil {
 				g.Warning(context.Background(), "Cannot get state in PushHandler: %s", err)
 				return
@@ -392,7 +392,7 @@ func (g *gregorHandler) PushFirehoseHandler(handler libkb.GregorFirehoseHandler)
 	defer g.Unlock()
 	g.firehoseHandlers = append(g.firehoseHandlers, handler)
 
-	s, err := g.getState()
+	s, err := g.getState(context.Background())
 	if err != nil {
 		g.Warning(context.Background(), "Cannot push state in firehose handler: %s", err)
 		return
@@ -415,7 +415,7 @@ func (g *gregorHandler) iterateOverFirehoseHandlers(f func(h libkb.GregorFirehos
 }
 
 func (g *gregorHandler) pushState(r keybase1.PushReason) {
-	s, err := g.getState()
+	s, err := g.getState(context.Background())
 	if err != nil {
 		g.Warning(context.Background(), "Cannot push state in firehose handler: %s", err)
 		return
@@ -450,7 +450,7 @@ func (g *gregorHandler) replayInBandMessages(ctx context.Context, cli gregor1.In
 
 	if t.IsZero() {
 		g.Debug(ctx, "replayInBandMessages: fresh replay: using state items")
-		state, err := gcli.StateMachineState(nil)
+		state, err := gcli.StateMachineState(ctx, nil)
 		if err != nil {
 			g.Debug(ctx, "unable to fetch state for replay: %s", err)
 			return nil, err
@@ -461,7 +461,7 @@ func (g *gregorHandler) replayInBandMessages(ctx context.Context, cli gregor1.In
 		}
 	} else {
 		g.Debug(ctx, "replayInBandMessages: incremental replay: using ibms since")
-		if msgs, err = gcli.StateMachineInBandMessagesSince(t); err != nil {
+		if msgs, err = gcli.StateMachineInBandMessagesSince(ctx, t); err != nil {
 			g.Debug(ctx, "unable to fetch messages for replay: %s", err)
 			return nil, err
 		}
@@ -509,7 +509,7 @@ func (g *gregorHandler) serverSync(ctx context.Context,
 	// Get time of the last message we synced (unless this is our first time syncing)
 	var t time.Time
 	if !g.firstConnect {
-		pt := gcli.StateMachineLatestCTime()
+		pt := gcli.StateMachineLatestCTime(ctx)
 		if pt != nil {
 			t = *pt
 		}
@@ -519,7 +519,7 @@ func (g *gregorHandler) serverSync(ctx context.Context,
 	}
 
 	// Sync down everything from the server
-	consumedMsgs, err := gcli.Sync(cli, syncRes)
+	consumedMsgs, err := gcli.Sync(ctx, cli, syncRes)
 	if err != nil {
 		g.Debug(ctx, "serverSync: error syncing from the server, reason: %s", err)
 		return nil, nil, err
@@ -568,7 +568,7 @@ func (g *gregorHandler) inboxParams(ctx context.Context, uid gregor1.UID) chat1.
 }
 
 func (g *gregorHandler) notificationParams(ctx context.Context, gcli *grclient.Client) (t gregor1.Time) {
-	pt := gcli.StateMachineLatestCTime()
+	pt := gcli.StateMachineLatestCTime(ctx)
 	if pt != nil {
 		t = gregor1.ToTime(*pt)
 	}
@@ -745,7 +745,7 @@ func (g *gregorHandler) broadcastMessageOnce(ctx context.Context, m gregor1.Mess
 		}
 		// Check to see if this is already in our state
 		msgID := ibm.Metadata().MsgID()
-		state, err := gcli.StateMachineState(nil)
+		state, err := gcli.StateMachineState(ctx, nil)
 		if err != nil {
 			g.Debug(ctx, "BroadcastMessage: no state machine available: %s", err.Error())
 			return err
@@ -759,7 +759,7 @@ func (g *gregorHandler) broadcastMessageOnce(ctx context.Context, m gregor1.Mess
 		err = g.handleInBandMessage(ctx, gregor1.IncomingClient{Cli: g.cli}, ibm)
 
 		// Send message to local state machine
-		gcli.StateMachineConsumeMessage(m)
+		gcli.StateMachineConsumeMessage(ctx, m)
 
 		// Forward to electron or whichever UI is listening for the new gregor state
 		if g.pushStateFilter(m) {
@@ -850,7 +850,7 @@ func (g *gregorHandler) handleInBandMessageWithHandler(ctx context.Context, cli 
 	if err != nil {
 		return false, err
 	}
-	state, err := gcli.StateMachineState(nil)
+	state, err := gcli.StateMachineState(ctx, nil)
 	if err != nil {
 		return false, err
 	}
@@ -1508,14 +1508,14 @@ func newGregorRPCHandler(xp rpc.Transporter, g *libkb.GlobalContext, gh *gregorH
 	}
 }
 
-func (g *gregorHandler) getState() (res gregor1.State, err error) {
+func (g *gregorHandler) getState(ctx context.Context) (res gregor1.State, err error) {
 	var s gregor.State
 
 	if g == nil || g.gregorCli == nil {
 		return res, errors.New("gregor service not available (are you in standalone?)")
 	}
 
-	s, err = g.gregorCli.StateMachineState(nil)
+	s, err = g.gregorCli.StateMachineState(ctx, nil)
 	if err != nil {
 		return res, err
 	}
@@ -1533,8 +1533,8 @@ func (g *gregorHandler) getState() (res gregor1.State, err error) {
 	return res, nil
 }
 
-func (g *gregorRPCHandler) GetState(_ context.Context) (res gregor1.State, err error) {
-	return g.gh.getState()
+func (g *gregorRPCHandler) GetState(ctx context.Context) (res gregor1.State, err error) {
+	return g.gh.getState(ctx)
 }
 
 func WrapGenericClientWithTimeout(client rpc.GenericClient, timeout time.Duration, timeoutErr error) rpc.GenericClient {

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -277,13 +277,13 @@ func (m mockGregord) SyncAll(ctx context.Context, arg chat1.SyncAllArg) (res cha
 	return res, nil
 }
 
-func (m mockGregord) Sync(_ context.Context, arg gregor1.SyncArg) (gregor1.SyncResult, error) {
+func (m mockGregord) Sync(ctx context.Context, arg gregor1.SyncArg) (gregor1.SyncResult, error) {
 	var res gregor1.SyncResult
-	msgs, err := m.sm.InBandMessagesSince(arg.UID(), arg.DeviceID(), arg.CTime())
+	msgs, err := m.sm.InBandMessagesSince(ctx, arg.UID(), arg.DeviceID(), arg.CTime())
 	if err != nil {
 		return res, err
 	}
-	state, err := m.sm.State(arg.UID(), arg.DeviceID(), nil)
+	state, err := m.sm.State(ctx, arg.UID(), arg.DeviceID(), nil)
 	if err != nil {
 		return res, err
 	}
@@ -302,10 +302,10 @@ func (m mockGregord) Sync(_ context.Context, arg gregor1.SyncArg) (gregor1.SyncR
 	return res, nil
 }
 
-func (m mockGregord) ConsumeMessage(_ context.Context, msg gregor1.Message) error {
+func (m mockGregord) ConsumeMessage(ctx context.Context, msg gregor1.Message) error {
 	m.log.Debug("mockGregord: ConsumeMessage: msgID: %s Ctime: %s", msg.ToInBandMessage().Metadata().MsgID(),
 		msg.ToInBandMessage().Metadata().CTime())
-	_, err := m.sm.ConsumeMessage(msg)
+	_, err := m.sm.ConsumeMessage(ctx, msg)
 	return err
 }
 func (m mockGregord) ConsumePublishMessage(_ context.Context, _ gregor1.Message) error {
@@ -314,8 +314,8 @@ func (m mockGregord) ConsumePublishMessage(_ context.Context, _ gregor1.Message)
 func (m mockGregord) Ping(_ context.Context) (string, error) {
 	return "pong", nil
 }
-func (m mockGregord) State(_ context.Context, arg gregor1.StateArg) (gregor1.State, error) {
-	state, err := m.sm.State(arg.Uid, arg.Deviceid, arg.TimeOrOffset)
+func (m mockGregord) State(ctx context.Context, arg gregor1.StateArg) (gregor1.State, error) {
+	state, err := m.sm.State(ctx, arg.Uid, arg.Deviceid, arg.TimeOrOffset)
 	if err != nil {
 		return gregor1.State{}, err
 	}
@@ -441,7 +441,7 @@ func checkMessages(t *testing.T, source string, msgs []gregor.InBandMessage,
 
 func doServerSync(t *testing.T, h *gregorHandler, srv mockGregord) ([]gregor.InBandMessage, []gregor.InBandMessage) {
 	_, token, _ := h.loggedIn(context.TODO())
-	pctime := h.gregorCli.StateMachineLatestCTime()
+	pctime := h.gregorCli.StateMachineLatestCTime(context.TODO())
 	ctime := gregor1.Time(0)
 	if pctime != nil {
 		ctime = gregor1.ToTime(*pctime)
@@ -547,7 +547,7 @@ func TestSyncSaveRestoreFresh(t *testing.T) {
 
 	// Try saving
 	var err error
-	if err = h.gregorCli.Save(); err != nil {
+	if err = h.gregorCli.Save(context.TODO()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -592,7 +592,7 @@ func TestSyncSaveRestoreNonFresh(t *testing.T) {
 
 	// Try saving
 	var err error
-	if err = h.gregorCli.Save(); err != nil {
+	if err = h.gregorCli.Save(context.TODO()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/service/rekey_master.go
+++ b/go/service/rekey_master.go
@@ -343,7 +343,7 @@ func (r *rekeyMaster) hasGregorTLFRekeyMessages() (ret bool, err error) {
 	defer r.G().Trace("hasGregorTLFRekeyMessages", func() error { return err })()
 
 	var state gregor1.State
-	state, err = r.gregor.getState()
+	state, err = r.gregor.getState(context.Background())
 	if err != nil {
 		return false, err
 	}

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -5,6 +5,7 @@ protocol common {
 
   @typedef("bytes")  record ThreadID {}
   @typedef("uint") @lint("ignore") record MessageID {}
+  @typedef("uint") @lint("ignore") record TLFConvOrdinal {}
   @typedef("bytes")  record TopicID {}
   @typedef("bytes")  record ConversationID {}
   @typedef("bytes")  record TLFID {}
@@ -68,8 +69,9 @@ protocol common {
   }
 
   enum ConversationMemberStatus {
-    ACTIVE_0,
-    REMOVED_1
+    ACTIVE_0,  // in the channel
+    REMOVED_1, // removed from channel forcibly
+    LEFT_2     // voluntarily left conversation
   }
 
   record Pagination {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -58,6 +58,7 @@ function _channelMapRpcHelper(channelConfig: ChannelConfig<*>, partialRpcCall: (
 export const CommonConversationMemberStatus = {
   active: 0,
   removed: 1,
+  left: 2,
 }
 
 export const CommonConversationMembersType = {
@@ -1070,6 +1071,7 @@ export type ConversationLocal = {
 export type ConversationMemberStatus =
     0 // ACTIVE_0
   | 1 // REMOVED_1
+  | 2 // LEFT_2
 
 export type ConversationMembersType =
     0 // KBFS_0
@@ -1799,6 +1801,8 @@ export type SyncIncrementalRes = {
   vers: InboxVers,
   convs?: ?Array<Conversation>,
 }
+
+export type TLFConvOrdinal = uint
 
 export type TLFFinalizeUpdate = {
   finalizeInfo: ConversationFinalizeInfo,

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -23,6 +23,13 @@
     },
     {
       "type": "record",
+      "name": "TLFConvOrdinal",
+      "fields": [],
+      "typedef": "uint",
+      "lint": "ignore"
+    },
+    {
+      "type": "record",
       "name": "TopicID",
       "fields": [],
       "typedef": "bytes"
@@ -110,7 +117,8 @@
       "name": "ConversationMemberStatus",
       "symbols": [
         "ACTIVE_0",
-        "REMOVED_1"
+        "REMOVED_1",
+        "LEFT_2"
       ]
     },
     {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -58,6 +58,7 @@ function _channelMapRpcHelper(channelConfig: ChannelConfig<*>, partialRpcCall: (
 export const CommonConversationMemberStatus = {
   active: 0,
   removed: 1,
+  left: 2,
 }
 
 export const CommonConversationMembersType = {
@@ -1070,6 +1071,7 @@ export type ConversationLocal = {
 export type ConversationMemberStatus =
     0 // ACTIVE_0
   | 1 // REMOVED_1
+  | 2 // LEFT_2
 
 export type ConversationMembersType =
     0 // KBFS_0
@@ -1799,6 +1801,8 @@ export type SyncIncrementalRes = {
   vers: InboxVers,
   convs?: ?Array<Conversation>,
 }
+
+export type TLFConvOrdinal = uint
 
 export type TLFFinalizeUpdate = {
   finalizeInfo: ConversationFinalizeInfo,


### PR DESCRIPTION
Patch does the following:

1.) Add new explicit leave member state.
2.) Add `TLFConvOrdinal`.
3.) Use `context` on all Gregor stuff.