### PR TITLE
add fill stubbed

### DIFF
--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -394,7 +394,10 @@ func (t *TeamSigChainPlayer) addChainLinksCommon(ctx context.Context, links []SC
 // Verify and add a chain link.
 // Does not modify self or any arguments.
 // The `prevState` argument is nil if this is the first chain link. `prevState` must not be modified in this function.
-func (t *TeamSigChainPlayer) addChainLinkCommon(ctx context.Context, prevState *TeamSigChainState, link SCChainLink) (res TeamSigChainState, err error) {
+func (t *TeamSigChainPlayer) addChainLinkCommon(
+	ctx context.Context, prevState *TeamSigChainState, link SCChainLink) (
+	res TeamSigChainState, err error) {
+
 	oRes, err := t.checkOuterLink(ctx, prevState, link)
 	if err != nil {
 		return res, fmt.Errorf("team sigchain outer link: %s", err)

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -44,7 +44,7 @@ func (e InflateError) Error() string {
 	if e.note == nil {
 		return fmt.Sprintf("error inflating previously-stubbed link (seqno %d)", int(e.l.outerLink.Seqno))
 	}
-	return fmt.Sprintf("stubbed link when not expected (seqno %d) (%s)",
+	return fmt.Sprintf("error inflating previously-stubbed link (seqno %d) (%s)",
 		int(e.l.outerLink.Seqno), *e.note)
 }
 

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -2,19 +2,50 @@ package teams
 
 import (
 	"fmt"
+
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 func NewStubbedError(l *chainLinkUnpacked) StubbedError {
-	return StubbedError{l}
+	return StubbedError{l: l, note: nil}
+}
+
+func NewStubbedErrorWithNote(l *chainLinkUnpacked, note string) StubbedError {
+	return StubbedError{l: l, note: &note}
 }
 
 type StubbedError struct {
-	l *chainLinkUnpacked
+	l    *chainLinkUnpacked
+	note *string
 }
 
 func (e StubbedError) Error() string {
-	return fmt.Sprintf("stubbed link when not expected (seqno %d)", int(e.l.outerLink.Seqno))
+	if e.note == nil {
+		return fmt.Sprintf("stubbed link when not expected (seqno %d)", int(e.l.outerLink.Seqno))
+	}
+	return fmt.Sprintf("stubbed link when not expected (seqno %d) (%s)",
+		int(e.l.outerLink.Seqno), *e.note)
+}
+
+func NewInflateError(l *chainLinkUnpacked) InflateError {
+	return InflateError{l: l, note: nil}
+}
+
+func NewInflateErrorWithNote(l *chainLinkUnpacked, note string) InflateError {
+	return InflateError{l: l, note: &note}
+}
+
+type InflateError struct {
+	l    *chainLinkUnpacked
+	note *string
+}
+
+func (e InflateError) Error() string {
+	if e.note == nil {
+		return fmt.Sprintf("error inflating previously-stubbed link (seqno %d)", int(e.l.outerLink.Seqno))
+	}
+	return fmt.Sprintf("stubbed link when not expected (seqno %d) (%s)",
+		int(e.l.outerLink.Seqno), *e.note)
 }
 
 type AdminPermissionError struct {

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -233,7 +233,7 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 	// Backfill stubbed links that need to be filled now.
 	if ret != nil && len(arg.needSeqnos) > 0 {
 		ret, proofSet, parentChildOperations, err = l.fillInStubbedLinks(
-			ctx, arg.me, ret, arg.needSeqnos, proofSet, parentChildOperations)
+			ctx, arg.me, arg.teamID, ret, arg.needSeqnos, proofSet, parentChildOperations)
 		if err != nil {
 			return nil, err
 		}

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -87,7 +87,7 @@ func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg ke
 	// Resolve the name to team ID. Will always hit the server for subteams.
 	// It is safe for the answer to be wrong because the name is checked on the way out,
 	// and the merkle tree check guarantees one sigchain per team id.
-	if teamName != nil {
+	if !teamID.Exists() {
 		teamID, err = l.resolveNameToIDUntrusted(ctx, *teamName)
 		if err != nil {
 			return nil, err
@@ -120,6 +120,7 @@ func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg ke
 	// The snapshot may have already been written to cache, but that should be ok,
 	// because the cache is keyed by ID.
 	if teamName != nil {
+		// (TODO: this won't work for renamed level 3 teams or above. There's work on this in miles/teamloader-names)
 		if !teamName.Eq(ret.Chain.Name) {
 			return nil, fmt.Errorf("team name mismatch: %v != %v", ret.Chain.Name.String(), teamName.String())
 		}
@@ -130,7 +131,7 @@ func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg ke
 
 func (l *TeamLoader) checkArg(ctx context.Context, lArg keybase1.LoadTeamArg) error {
 	// TODO: stricter check on team ID format.
-	hasID := len(lArg.ID) > 0
+	hasID := lArg.ID.Exists()
 	hasName := len(lArg.Name) > 0
 	if !hasID && !hasName {
 		return fmt.Errorf("team load arg must have either ID or Name")
@@ -158,7 +159,8 @@ func (l *TeamLoader) resolveNameToIDUntrusted(ctx context.Context, teamName keyb
 	if err := l.G().API.GetDecode(arg, &rt); err != nil {
 		return id, err
 	}
-	if !rt.ID.Exists() {
+	id = rt.ID
+	if !id.Exists() {
 		return id, fmt.Errorf("could not resolve team name: %v", teamName.String())
 	}
 	return id, nil

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -230,7 +230,8 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 
 	// Backfill stubbed links that need to be filled now.
 	if ret != nil && len(arg.needSeqnos) > 0 {
-		ret, proofSet, err = l.fillInStubbedLinks(ctx, ret, arg.needSeqnos, proofSet)
+		ret, proofSet, parentChildOperations, err = l.fillInStubbedLinks(
+			ctx, arg.me, ret, arg.needSeqnos, proofSet, parentChildOperations)
 		if err != nil {
 			return nil, err
 		}
@@ -276,7 +277,7 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 			return nil, fmt.Errorf("team replay failed: prev chain broken at link %d", i)
 		}
 
-		proofSet, err = l.verifyLink(ctx, arg.teamID, ret, link, proofSet)
+		_, proofSet, err = l.verifyLink(ctx, arg.teamID, ret, link, proofSet)
 		if err != nil {
 			return nil, err
 		}

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -31,7 +31,8 @@ func (l *TeamLoader) fillInStubbedLinks(ctx context.Context,
 	// seqnos needed from the server
 	var requestSeqnos []keybase1.Seqno
 	for _, seqno := range needSeqnos {
-		if seqno <= upperLimit {
+		linkIsAlreadyFilled := TeamSigChainState{inner: state.Chain}.IsLinkFullyPresent(seqno)
+		if seqno <= upperLimit && !linkIsAlreadyFilled {
 			requestSeqnos = append(requestSeqnos, seqno)
 		}
 	}

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -3,6 +3,7 @@ package teams
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -17,11 +18,68 @@ import (
 // If links are needed in full that are stubbed in state, go out and get them from the server.
 // Does not ask for any links above state's seqno, those will be fetched by getNewLinksFromServer.
 func (l *TeamLoader) fillInStubbedLinks(ctx context.Context,
-	state *keybase1.TeamData, needSeqnos []keybase1.Seqno, proofSet *proofSetT) (*keybase1.TeamData, *proofSetT, error) {
+	me keybase1.UserVersion, state *keybase1.TeamData,
+	needSeqnos []keybase1.Seqno,
+	proofSet *proofSetT, parentChildOperations []*parentChildOperation) (
+	*keybase1.TeamData, *proofSetT, []*parentChildOperation, error) {
 
-	panic("TODO: implement")
+	upperLimit := keybase1.Seqno(0)
+	if state != nil {
+		upperLimit = state.Chain.LastSeqno
+	}
+
+	// seqnos needed from the server
+	var requestSeqnos []keybase1.Seqno
+	for _, seqno := range needSeqnos {
+		if seqno <= upperLimit {
+			requestSeqnos = append(requestSeqnos, seqno)
+		}
+	}
+	if len(requestSeqnos) == 0 {
+		// early out
+		return state, proofSet, parentChildOperations, nil
+	}
+
+	teamUpdate, err := l.getLinksFromServer(ctx, state.Chain.Id, requestSeqnos)
+	if err != nil {
+		return state, proofSet, parentChildOperations, err
+	}
+	newLinks, err := l.unpackLinks(ctx, teamUpdate)
+	if err != nil {
+		return state, proofSet, parentChildOperations, err
+	}
+
+	for _, link := range newLinks {
+		if link.isStubbed() {
+			return state, proofSet, parentChildOperations, NewStubbedErrorWithNote(
+				link, "filling stubbed link")
+		}
+
+		var signer keybase1.UserVersion
+		signer, proofSet, err = l.verifyLink(ctx, state, link, proofSet)
+		if err != nil {
+			return state, proofSet, parentChildOperations, err
+		}
+
+		state, err = l.inflateLink(ctx, state, link, signer, me)
+		if err != nil {
+			return state, proofSet, parentChildOperations, err
+		}
+
+		if l.isParentChildOperation(ctx, link) {
+			pco, err := l.toParentChildOperation(ctx, link)
+			if err != nil {
+				return state, proofSet, parentChildOperations, err
+			}
+			parentChildOperations = append(parentChildOperations, pco)
+		}
+	}
+
+	return state, proofSet, parentChildOperations, nil
+
 }
 
+// Get new links from the server.
 func (l *TeamLoader) getNewLinksFromServer(ctx context.Context,
 	teamID keybase1.TeamID, lowSeqno keybase1.Seqno, lowGen keybase1.PerTeamKeyGeneration) (*rawTeam, error) {
 
@@ -35,7 +93,32 @@ func (l *TeamLoader) getNewLinksFromServer(ctx context.Context,
 	}
 
 	var rt rawTeam
+	if err := l.G().API.GetDecode(arg, &rt); err != nil {
+		return nil, err
+	}
+	return &rt, nil
+}
 
+// Get full links from the server.
+// Does not guarantee that the server returned the correct links, nor that they are unstubbed.
+func (l *TeamLoader) getLinksFromServer(ctx context.Context,
+	teamID keybase1.TeamID, requestSeqnos []keybase1.Seqno) (*rawTeam, error) {
+
+	var seqnoStrs []string
+	for _, seqno := range requestSeqnos {
+		seqnoStrs = append(seqnoStrs, fmt.Sprintf("%d", int(seqno)))
+	}
+	seqnoCommas := strings.Join(seqnoStrs, ",")
+
+	arg := libkb.NewRetryAPIArg("team/get")
+	arg.NetContext = ctx
+	arg.SessionType = libkb.APISessionTypeREQUIRED
+	arg.Args = libkb.HTTPArgs{
+		"id":     libkb.S{Val: teamID.String()},
+		"seqnos": libkb.S{Val: seqnoCommas},
+	}
+
+	var rt rawTeam
 	if err := l.G().API.GetDecode(arg, &rt); err != nil {
 		return nil, err
 	}
@@ -94,16 +177,18 @@ func addProofsForKeyInUserSigchain(teamID keybase1.TeamID, link *chainLinkUnpack
 // Does not:
 // - Apply the link nor modify state
 // - Check the rest of the format of the inner link
+// Returns the signer
 func (l *TeamLoader) verifyLink(ctx context.Context, teamID keybase1.TeamID,
-	state *keybase1.TeamData, link *chainLinkUnpacked, proofSet *proofSetT) (*proofSetT, error) {
+	state *keybase1.TeamData, link *chainLinkUnpacked, proofSet *proofSetT) (keybase1.UserVersion, *proofSetT, error) {
+	var uv keybase1.UserVersion
 
 	if link.isStubbed() {
-		return proofSet, nil
+		return uv, proofSet, nil
 	}
 
 	err := link.AssertInnerOuterMatch()
 	if err != nil {
-		return proofSet, err
+		return uv, proofSet, err
 	}
 
 	if !teamID.Eq(link.ID) {
@@ -112,16 +197,16 @@ func (l *TeamLoader) verifyLink(ctx context.Context, teamID keybase1.TeamID,
 
 	kid, err := l.verifySignatureAndExtractKID(ctx, *link.outerLink)
 	if err != nil {
-		return proofSet, err
+		return uv, proofSet, err
 	}
 
 	user, key, err := l.loadUserAndKeyFromLinkInner(ctx, *link.inner)
 	if err != nil {
-		return proofSet, err
+		return uv, proofSet, err
 	}
 
 	if !kid.Equal(key.Base.Kid) {
-		return proofSet, libkb.NewWrongKidError(kid, key.Base.Kid)
+		return uv, proofSet, libkb.NewWrongKidError(kid, key.Base.Kid)
 	}
 
 	proofSet = addProofsForKeyInUserSigchain(teamID, link, user.Uid, key, proofSet)
@@ -129,7 +214,7 @@ func (l *TeamLoader) verifyLink(ctx context.Context, teamID keybase1.TeamID,
 	// For a root team link, or a subteam_head, there is no reason to check adminship
 	// or writership (or readership) for the team.
 	if state == nil {
-		return proofSet, nil
+		return uv, proofSet, nil
 	}
 
 	if link.outerLink.LinkType.RequiresAdminPermission() {
@@ -137,8 +222,7 @@ func (l *TeamLoader) verifyLink(ctx context.Context, teamID keybase1.TeamID,
 	} else {
 		err = l.verifyWriterOrReaderPermissions(ctx, state, link, user.ToUserVersion())
 	}
-	return proofSet, err
-
+	return user.ToUserVersion(), proofSet, err
 }
 
 func (l *TeamLoader) verifyWriterOrReaderPermissions(ctx context.Context,
@@ -301,6 +385,39 @@ func (l *TeamLoader) applyNewLink(ctx context.Context,
 	}
 
 	return newState, nil
+}
+
+// Inflate a link that was stubbed with its non-stubbed data.
+func (l *TeamLoader) inflateLink(ctx context.Context,
+	state *keybase1.TeamData, link *chainLinkUnpacked,
+	signer keybase1.UserVersion, me keybase1.UserVersion) (
+	*keybase1.TeamData, error) {
+
+	l.G().Log.CDebugf(ctx, "TeamLoader inflating link seqno:%v", link.Seqno())
+
+	if state == nil {
+		// The only reason state would be nil is if this is link 1.
+		// But link 1 can't be stubbed.
+		return nil, NewInflateErrorWithNote(link, "no prior state")
+	}
+
+	var player *TeamSigChainPlayer
+	player = NewTeamSigChainPlayerWithState(l.G(), me, TeamSigChainState{inner: state.Chain})
+
+	err := player.InflateLink(link, signer)
+	if err != nil {
+		return nil, err
+	}
+
+	newChainState, err := player.GetState()
+	if err != nil {
+		return nil, err
+	}
+
+	newState := state.DeepCopy()
+	newState.Chain = newChainState.inner
+
+	return &newState, nil
 }
 
 // Check that the parent-child operations appear in the parent sigchains.

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -2,6 +2,7 @@ package teams
 
 import (
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -340,12 +341,27 @@ func TestLoaderFillStubbed(t *testing.T) {
 	t.Logf("create a team")
 	parentName, parentID := createTeam2(*tcs[0])
 
+	// Hack to get around stale merkle root when creating subteam
+	// Michal's gonna fix this soon, then this line can go away.
+	_, err := tcs[0].G.GetMerkleClient().FetchRootFromServer(context.TODO(), time.Duration(-1))
+	require.NoError(t, err)
+
 	t.Logf("create a subteam")
 	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName)
 	require.NoError(t, err)
 
+	// Hack to get around stale merkle root when creating subteam
+	// Michal's gonna fix this soon, then this line can go away.
+	_, err = tcs[0].G.GetMerkleClient().FetchRootFromServer(context.TODO(), time.Duration(-1))
+	require.NoError(t, err)
+
 	t.Logf("add U1 to the parent")
 	err = AddMember(context.TODO(), tcs[0].G, parentName.String(), fus[1].Username, keybase1.TeamRole_WRITER)
+
+	// Hack to get around stale merkle root when creating subteam
+	// Michal's gonna fix this soon, then this line can go away.
+	_, err = tcs[0].G.GetMerkleClient().FetchRootFromServer(context.TODO(), time.Duration(-1))
+	require.NoError(t, err)
 
 	t.Logf("U1 loads the parent")
 	_, err = tcs[1].G.GetTeamLoader().(*TeamLoader).LoadTODO(context.TODO(), keybase1.LoadTeamArg{

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -271,7 +271,7 @@ func TestLoaderWantMembers(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, keybase1.TeamRole_WRITER, role)
 
-	t.Logf("U0 bumps the sigchain (setrole) (5)")
+	t.Logf("U0 bumps the sigchain (removemember) (5)")
 	err = RemoveMember(context.TODO(), tcs[0].G, teamName.String(), fus[3].Username)
 	require.NoError(t, err)
 
@@ -327,4 +327,107 @@ func TestLoaderSubteamEasy(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedSubteamName, TeamSigChainState{inner: team.Chain}.GetName())
 	require.Equal(t, parentID, *team.Chain.ParentID)
+}
+
+// Test loading a team and filling in links.
+// User loads a team T1 with subteam links stubbed out,
+// then gets added to T1.T2 and T1,
+// then loads T1.T2, which causes T1 to have to fill in the subteam links.
+func TestLoaderFillStubbed(t *testing.T) {
+	fus, tcs, cleanup := setupNTests(t, 2)
+	defer cleanup()
+
+	t.Logf("create a team")
+	parentName, parentID := createTeam2(*tcs[0])
+
+	t.Logf("create a subteam")
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName)
+	require.NoError(t, err)
+
+	t.Logf("add U1 to the parent")
+	err = AddMember(context.TODO(), tcs[0].G, parentName.String(), fus[1].Username, keybase1.TeamRole_WRITER)
+
+	t.Logf("U1 loads the parent")
+	_, err = tcs[1].G.GetTeamLoader().(*TeamLoader).LoadTODO(context.TODO(), keybase1.LoadTeamArg{
+		ID: parentID,
+	})
+	require.NoError(t, err)
+
+	t.Logf("add U1 to the subteam")
+	subteamName, err := parentName.Append("mysubteam")
+	require.NoError(t, err)
+	err = AddMember(context.TODO(), tcs[0].G, subteamName.String(), fus[1].Username, keybase1.TeamRole_WRITER)
+	require.NoError(t, err)
+
+	t.Logf("U1 loads the subteam")
+	_, err = tcs[1].G.GetTeamLoader().(*TeamLoader).LoadTODO(context.TODO(), keybase1.LoadTeamArg{
+		ID: *subteamID,
+	})
+	require.NoError(t, err)
+}
+
+// Test loading a team and when not a member of the parent.
+// User loads a team T1.T2 but has never been a member of T1.
+func TestLoaderNotInParent(t *testing.T) {
+	t.Skip("TODO: awaiting non-member parent read")
+
+	fus, tcs, cleanup := setupNTests(t, 2)
+	defer cleanup()
+
+	t.Logf("create a team")
+	parentName, _ := createTeam2(*tcs[0])
+
+	t.Logf("create a subteam")
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "mysubteam", parentName)
+	require.NoError(t, err)
+
+	t.Logf("add U1 to the subteam")
+	subteamName, err := parentName.Append("mysubteam")
+	require.NoError(t, err)
+	err = AddMember(context.TODO(), tcs[0].G, subteamName.String(), fus[1].Username, keybase1.TeamRole_WRITER)
+	require.NoError(t, err)
+
+	t.Logf("U1 loads the subteam")
+	_, err = tcs[1].G.GetTeamLoader().(*TeamLoader).LoadTODO(context.TODO(), keybase1.LoadTeamArg{
+		ID: *subteamID,
+	})
+	require.NoError(t, err)
+}
+
+// Test loading a sub-sub-team.
+// When not a member of the ancestors.
+func TestLoaderMultilevel(t *testing.T) {
+	t.Skip("TODO: awaiting non-member parent read")
+
+	fus, tcs, cleanup := setupNTests(t, 2)
+	defer cleanup()
+
+	t.Logf("create a team")
+	parentName, _ := createTeam2(*tcs[0])
+
+	t.Logf("create a subteam")
+	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "abc", parentName)
+	require.NoError(t, err)
+
+	t.Logf("create a sub-subteam")
+	subsubteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "def", parentName)
+	require.NoError(t, err)
+
+	expectedSubsubTeamName, err := parentName.Append("abc")
+	require.NoError(t, err)
+	expectedSubsubTeamName, err = parentName.Append("def")
+	require.NoError(t, err)
+
+	t.Logf("add the other user to the subsubteam")
+	err = AddMember(context.TODO(), tcs[0].G, expectedSubsubTeamName.String(), fus[1].Username, keybase1.TeamRole_WRITER)
+	require.NoError(t, err)
+
+	t.Logf("load the subteam")
+	team, err := tcs[1].G.GetTeamLoader().(*TeamLoader).LoadTODO(context.TODO(), keybase1.LoadTeamArg{
+		ID: *subsubteamID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, team.Chain.Id, *subteamID)
+	require.Equal(t, expectedSubsubTeamName, TeamSigChainState{inner: team.Chain}.GetName())
+	require.Equal(t, subteamID, *team.Chain.ParentID)
 }


### PR DESCRIPTION
Atop https://github.com/keybase/client/pull/7573

Add the ability to fill stubbed links, called inflating:
- inflating `new_subteam` works now.
- `subteam_rename` does not exist yet, but will be very similar.
- `invitation` does not exist yet, and could be similar, but the current plan is to just bust when you become admin, in which case it will never inflate.

The simplest case of this is tested by `TestLoaderFillStubbed`.

There are also two _skipped tests `TestLoaderNotInParent` and `TestLoaderMultilevel` which are waiting on waiting for the ability to load teams that are a parent of your subteam but you are not a member of it. (CORE-5565)