### PR TITLE
Swap load in for get, team wraps TeamData, enable caching

### DIFF
--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -32,11 +32,7 @@ func (t *TeamsNameInfoSource) Lookup(ctx context.Context, name string, vis chat1
 		return res, err
 	}
 	res.CanonicalName = name
-	if team.Chain == nil {
-		t.Debug(ctx, "Lookup: team chain is nil, not able to get ID: %s", name)
-		return res, fmt.Errorf("no team chain found")
-	}
-	res.ID = chat1.TLFID(team.Chain.GetID().ToBytes())
+	res.ID = chat1.TLFID(team.ID.ToBytes())
 	if vis == chat1.TLFVisibility_PRIVATE {
 		chatKeys, err := team.AllApplicationKeys(ctx, keybase1.TeamApplication_CHAT)
 		if err != nil {

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -43,6 +43,7 @@ func TestTeamRotateOnRevoke(t *testing.T) {
 	if before.Generation() != 1 {
 		t.Errorf("generation before rotate: %d, expected 1", before.Generation())
 	}
+	secretBefore := before.Data.PerTeamKeySeeds[before.Generation()].Seed.ToBytes()
 
 	tt.users[1].revokePaperKey()
 	tt.users[0].waitForRotate(team)
@@ -55,8 +56,9 @@ func TestTeamRotateOnRevoke(t *testing.T) {
 	if after.Generation() != 2 {
 		t.Errorf("generation after rotate: %d, expected 2", after.Generation())
 	}
-	if after.Box.Ctext == before.Box.Ctext {
-		t.Errorf("team box ctext did not change with rotation")
+	secretAfter := after.Data.PerTeamKeySeeds[after.Generation()].Seed.ToBytes()
+	if libkb.SecureByteArrayEq(secretAfter, secretBefore) {
+		t.Fatal("team secret did not change when rotated")
 	}
 }
 

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -72,6 +72,11 @@ func (t TeamSigChainState) IsSubteam() bool {
 	return t.inner.ParentID != nil
 }
 
+// Only non-nil if this is a subteam.
+func (t TeamSigChainState) GetParentID() *keybase1.TeamID {
+	return t.inner.ParentID
+}
+
 func (t TeamSigChainState) GetLatestSeqno() keybase1.Seqno {
 	return t.inner.LastSeqno
 }
@@ -397,7 +402,6 @@ func (t *TeamSigChainPlayer) addChainLinksCommon(ctx context.Context, links []SC
 func (t *TeamSigChainPlayer) addChainLinkCommon(
 	ctx context.Context, prevState *TeamSigChainState, link SCChainLink) (
 	res TeamSigChainState, err error) {
-
 	oRes, err := t.checkOuterLink(ctx, prevState, link)
 	if err != nil {
 		return res, fmt.Errorf("team sigchain outer link: %s", err)

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -168,12 +168,12 @@ func CreateSubteam(ctx context.Context, g *libkb.GlobalContext, subteamBasename 
 	// starts a root team, and so making that link is very similar to what the
 	// CreateTeamEngine does.
 
-	newSubteamSig, err := generateNewSubteamSigForParentChain(g, me, deviceSigningKey, parentTeam.Chain, subteamName, subteamID, admin)
+	newSubteamSig, err := generateNewSubteamSigForParentChain(g, me, deviceSigningKey, parentTeam.chain(), subteamName, subteamID, admin)
 	if err != nil {
 		return nil, err
 	}
 
-	subteamHeadSig, secretboxes, err := generateHeadSigForSubteamChain(ctx, g, me, deviceSigningKey, parentTeam.Chain, subteamName, subteamID, admin)
+	subteamHeadSig, secretboxes, err := generateHeadSigForSubteamChain(ctx, g, me, deviceSigningKey, parentTeam.chain(), subteamName, subteamID, admin)
 	if err != nil {
 		return nil, err
 	}

--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -2,7 +2,6 @@ package teams
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"golang.org/x/net/context"
 
@@ -11,113 +10,17 @@ import (
 )
 
 func getInternalByStringName(ctx context.Context, g *libkb.GlobalContext, name string) (*Team, error) {
-	f := newFinder(g)
-	return f.findByStringName(ctx, name)
+	return Load(ctx, g, keybase1.LoadTeamArg{
+		Name:        name,
+		ForceRepoll: true,
+	})
 }
 
 func getInternal(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (*Team, error) {
-	f := newFinder(g)
-	return f.findByID(ctx, id)
-}
-
-type finder struct {
-	libkb.Contextified
-}
-
-func newFinder(g *libkb.GlobalContext) *finder {
-	return &finder{
-		Contextified: libkb.NewContextified(g),
-	}
-}
-
-func (f *finder) findByID(ctx context.Context, id keybase1.TeamID) (*Team, error) {
-	raw, err := f.rawTeamByID(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-	return f.playRaw(ctx, raw)
-}
-
-func (f *finder) findByStringName(ctx context.Context, name string) (*Team, error) {
-	raw, err := f.rawTeam(ctx, name)
-	if err != nil {
-		return nil, err
-	}
-
-	return f.playRaw(ctx, raw)
-}
-
-func (f *finder) playRaw(ctx context.Context, raw *rawTeam) (*Team, error) {
-	team := NewTeam(f.G(), raw.Name.String())
-	team.ID = raw.ID
-	if raw.Box == nil {
-		return nil, fmt.Errorf("missing team box")
-	}
-	team.Box = *raw.Box
-	team.ReaderKeyMasks = raw.ReaderKeyMasks
-	team.Prevs = raw.Prevs
-
-	links, err := raw.parseLinks(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	player, err := f.newPlayer(ctx, links)
-	if err != nil {
-		return nil, err
-	}
-
-	state, err := player.GetState()
-	if err != nil {
-		return nil, err
-	}
-
-	team.Chain = &state
-
-	return team, nil
-}
-
-func (f *finder) rawTeam(ctx context.Context, name string) (*rawTeam, error) {
-	arg := f.getArg(ctx)
-	arg.Args = libkb.HTTPArgs{
-		"name": libkb.S{Val: name},
-	}
-	return f.getDecode(arg)
-}
-
-func (f *finder) rawTeamByID(ctx context.Context, id keybase1.TeamID) (*rawTeam, error) {
-	arg := f.getArg(ctx)
-	arg.Args = libkb.HTTPArgs{
-		"id": libkb.S{Val: id.String()},
-	}
-	return f.getDecode(arg)
-}
-
-func (f *finder) getArg(ctx context.Context) libkb.APIArg {
-	arg := libkb.NewRetryAPIArg("team/get")
-	arg.NetContext = ctx
-	arg.SessionType = libkb.APISessionTypeREQUIRED
-	return arg
-}
-
-func (f *finder) getDecode(arg libkb.APIArg) (*rawTeam, error) {
-	var rt rawTeam
-	if err := f.G().API.GetDecode(arg, &rt); err != nil {
-		return nil, err
-	}
-	return &rt, nil
-}
-
-func (f *finder) newPlayer(ctx context.Context, links []SCChainLink) (*TeamSigChainPlayer, error) {
-	uv, err := loadUserVersionByUID(ctx, f.G(), f.G().Env.GetUID())
-	if err != nil {
-		return nil, err
-	}
-	player := NewTeamSigChainPlayer(f.G(), uv)
-	if err := player.AddChainLinks(ctx, links); err != nil {
-		return nil, err
-	}
-	return player, nil
+	return Load(ctx, g, keybase1.LoadTeamArg{
+		ID:          id,
+		ForceRepoll: true,
+	})
 }
 
 type rawTeam struct {

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -16,11 +16,11 @@ const freshnessLimit = time.Duration(1) * time.Hour
 // Load a Team from the TeamLoader.
 // Can be called from inside the teams package.
 func Load(ctx context.Context, g *libkb.GlobalContext, lArg keybase1.LoadTeamArg) (*Team, error) {
-	// teamData, err := g.GetTeamLoader().Load(ctx, lArg)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	return nil, fmt.Errorf("TODO: implement team loader")
+	teamData, err := g.GetTeamLoader().Load(ctx, lArg)
+	if err != nil {
+		return nil, err
+	}
+	return NewTeam(ctx, g, teamData), nil
 }
 
 // Loader of keybase1.TeamData objects. Handles caching.
@@ -51,10 +51,6 @@ func NewTeamLoaderAndInstall(g *libkb.GlobalContext) *TeamLoader {
 }
 
 func (l *TeamLoader) Load(ctx context.Context, lArg keybase1.LoadTeamArg) (res *keybase1.TeamData, err error) {
-	return nil, fmt.Errorf("TODO: implement team loader")
-}
-
-func (l *TeamLoader) LoadTODO(ctx context.Context, lArg keybase1.LoadTeamArg) (res *keybase1.TeamData, err error) {
 	me, err := l.getMe(ctx)
 	if err != nil {
 		return nil, err
@@ -186,6 +182,7 @@ type load2ArgT struct {
 // Load2 does the rest of the work loading a team.
 // It is `playchain` described in the pseudocode in teamplayer.txt
 func (l *TeamLoader) load2(ctx context.Context, arg load2ArgT) (ret *keybase1.TeamData, err error) {
+	ctx = libkb.WithLogTag(ctx, "LT")
 	defer l.G().CTraceTimed(ctx, fmt.Sprintf("TeamLoader#load2(%v)", arg.teamID), func() error { return err })()
 	ret, err = l.load2Inner(ctx, arg)
 	return ret, err

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -126,6 +126,9 @@ func (l *TeamLoader) getLinksFromServer(ctx context.Context,
 	if err := l.G().API.GetDecode(arg, &rt); err != nil {
 		return nil, err
 	}
+	if !rt.ID.Eq(teamID) {
+		return nil, fmt.Errorf("server returned wrong team ID: %v != %v", rt.ID, teamID)
+	}
 	return &rt, nil
 }
 

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -222,8 +222,8 @@ func TestMemberRemoveRotatesKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if before.Box.Generation != 1 {
-		t.Fatalf("initial team generation: %d, expected 1", before.Box.Generation)
+	if before.Generation() != 1 {
+		t.Fatalf("initial team generation: %d, expected 1", before.Generation())
 	}
 
 	if err := SetRoleWriter(context.TODO(), tc.G, name, other.Username); err != nil {
@@ -240,12 +240,14 @@ func TestMemberRemoveRotatesKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if after.Box.Generation != 2 {
-		t.Errorf("after member remove: team generation: %d, expected 2", after.Box.Generation)
+	if after.Generation() != 2 {
+		t.Errorf("after member remove: team generation: %d, expected 2", after.Generation())
 	}
 
-	if after.Box.Ctext == before.Box.Ctext {
-		t.Error("TeamBox.Ctext did not change when member removed")
+	secretAfter := after.Data.PerTeamKeySeeds[after.Generation()].Seed.ToBytes()
+	secretBefore := before.Data.PerTeamKeySeeds[before.Generation()].Seed.ToBytes()
+	if libkb.SecureByteArrayEq(secretAfter, secretBefore) {
+		t.Error("Team secret did not change when member removed")
 	}
 }
 

--- a/go/teams/merkle_test.go
+++ b/go/teams/merkle_test.go
@@ -22,16 +22,16 @@ func TestMerkle(t *testing.T) {
 	team, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
 	require.NoError(t, err)
 
-	leaf, err := tc.G.MerkleClient.LookupTeam(context.TODO(), team.Chain.GetID())
+	leaf, err := tc.G.MerkleClient.LookupTeam(context.TODO(), team.ID)
 	require.NoError(t, err)
 	require.NotNil(t, leaf)
 	t.Logf("team merkle leaf: %v", spew.Sdump(leaf))
 	if leaf.TeamID.IsNil() {
 		t.Fatalf("nil teamID; likely merkle hasn't yet published and polling is busted")
 	}
-	require.Equal(t, team.Chain.GetID(), leaf.TeamID, "team id")
-	require.Equal(t, team.Chain.GetLatestSeqno(), leaf.Private.Seqno)
-	require.Equal(t, team.Chain.GetLatestLinkID(), leaf.Private.LinkID.Export())
+	require.Equal(t, team.ID, leaf.TeamID, "team id")
+	require.Equal(t, team.chain().GetLatestSeqno(), leaf.Private.Seqno)
+	require.Equal(t, team.chain().GetLatestLinkID(), leaf.Private.LinkID.Export())
 	// leaf.Private.SigID not checked
 	require.Nil(t, leaf.Public, "team public leaf")
 }

--- a/go/teams/rpc_exim.go
+++ b/go/teams/rpc_exim.go
@@ -39,8 +39,8 @@ func (t *Team) ExportToTeamPlusApplicationKeys(ctx context.Context, idTime keyba
 	}
 
 	ret = keybase1.TeamPlusApplicationKeys{
-		Id:              t.Chain.GetID(),
-		Name:            t.Chain.GetName().String(),
+		Id:              t.chain().GetID(),
+		Name:            t.chain().GetName().String(),
 		Application:     application,
 		Writers:         writers,
 		OnlyReaders:     onlyReaders,

--- a/go/teams/rpc_exim_test.go
+++ b/go/teams/rpc_exim_test.go
@@ -25,19 +25,19 @@ func TestTeamPlusApplicationKeysExim(t *testing.T) {
 
 	exported, err := team.ExportToTeamPlusApplicationKeys(context.TODO(), keybase1.Time(0), keybase1.TeamApplication_KBFS)
 	if err != nil {
-		t.Errorf("Error during export: %s", err)
+		t.Fatalf("Error during export: %s", err)
 	}
-	if exported.Name != team.Name {
-		t.Errorf("Got name %s, expected %s", exported.Name, team.Name)
+	if exported.Name != team.Name.String() {
+		t.Fatalf("Got name %s, expected %s", exported.Name, team.Name)
 	}
-	if exported.Id != team.Chain.GetID() {
-		t.Errorf("Got id %s, expected %s", exported.Id, team.Chain.GetID())
+	if !exported.Id.Eq(team.ID) {
+		t.Fatalf("Got id %q, expected %q", exported.Id, team.ID)
 	}
 	expectedKeys, err := team.AllApplicationKeys(context.TODO(), keybase1.TeamApplication_KBFS)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(exported.ApplicationKeys) != len(expectedKeys) {
-		t.Errorf("Got %v applicationKeys, expected %v", len(exported.ApplicationKeys), len(expectedKeys))
+		t.Fatalf("Got %v applicationKeys, expected %v", len(exported.ApplicationKeys), len(expectedKeys))
 	}
 }

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -37,7 +37,7 @@ func Details(ctx context.Context, g *libkb.GlobalContext, name string, forceRepo
 	if err != nil {
 		return res, err
 	}
-	res.KeyGeneration = t.Box.Generation
+	res.KeyGeneration = t.Generation()
 	res.Members, err = members(ctx, g, t, forceRepoll)
 	if err != nil {
 		return res, err


### PR DESCRIPTION
Swap in `TeamLoader`. Now teams are cached. The `Get*`s use `ForceRepoll` so they always roundtrip merkle. 

This change will cause these warnings to spit out whenever you use a team command.
```
2017-06-30 16:08:40.558115784 -0400 EDT loader2.go:696: [W] TODO: team verification not implemented, skipping verification
```