### PR TITLE
Implement new searchv3 focus behavior

### DIFF
--- a/shared/chat/conversation/input/index.desktop.js
+++ b/shared/chat/conversation/input/index.desktop.js
@@ -136,7 +136,7 @@ class ConversationInput extends Component<void, InputProps, void> {
             multiple={true}
           />
           <Input
-            autoFocus={true}
+            autoFocus={false}
             small={true}
             style={styleInput}
             ref={this.props.inputSetRef}

--- a/shared/chat/search-header.js
+++ b/shared/chat/search-header.js
@@ -46,7 +46,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       dispatch(SearchCreators.searchSuggestions('chat:updateSearchResults'))
     }
   },
-  onEnter: id => dispatch(Creators.stageUserForSearch(id)),
+  onEnter: id => (id ? dispatch(Creators.stageUserForSearch(id)) : dispatch(Creators.exitSearch())),
 })
 
 const SearchHeader = props => {

--- a/shared/profile/search.js.flow
+++ b/shared/profile/search.js.flow
@@ -1,5 +1,6 @@
 // @flow
 import {Component} from 'react'
+import {List} from 'immutable'
 
 import type {SearchResultId} from '../constants/searchv3'
 import type {UserDetails} from '../searchv3/user-input'
@@ -25,7 +26,7 @@ export type Props = {
   selectedService: string,
   showAddButton: boolean,
   usernameText: string,
-  userItems: Array<UserDetails>,
+  userItems: List<UserDetails>,
 }
 
 export default class Render extends Component<void, Props, void> {}

--- a/shared/searchv3/dumb.js
+++ b/shared/searchv3/dumb.js
@@ -5,7 +5,7 @@ import ResultRow from './result-row'
 import ResultsList from './results-list'
 import UserInput from './user-input'
 import {StateRecord as EntitiesStateRecord} from '../constants/entities'
-import {Map} from 'immutable'
+import {List, Map} from 'immutable'
 import {isMobile} from '../constants/platform'
 
 import type {DumbComponentMap} from '../constants/types/more'
@@ -285,7 +285,7 @@ const commonUserInputMapProps = {
   onEnter: () => console.log('username input on enter'),
 }
 
-const maxUsers = [
+const maxUsers = List([
   {followingState: 'You', icon: null, service: 'Keybase', username: 'chromakode', id: 'chromakode'},
   {followingState: 'Following', icon: null, service: 'Keybase', username: 'max', id: 'max'},
   {
@@ -295,9 +295,9 @@ const maxUsers = [
     username: 'denormalize',
     id: 'denormalize@twitter',
   },
-]
+])
 
-const chrisUsers = [
+const chrisUsers = List([
   {followingState: 'You', icon: null, service: 'Keybase', username: 'chromakode', id: 'chromakode'},
   {followingState: 'Following', icon: null, service: 'Keybase', username: 'chris', id: 'chris'},
   {
@@ -335,14 +335,14 @@ const chrisUsers = [
     username: 'KeyserSosa',
     id: 'KeyserSosa@reddit',
   },
-]
+])
 
 const userInputMap: DumbComponentMap<UserInput> = {
   component: UserInput,
   mocks: {
     'Empty + Placeholder': {
       ...commonUserInputMapProps,
-      userItems: [],
+      userItems: List([]),
       usernameText: '',
     },
     'Users + Add': {

--- a/shared/searchv3/helpers.js
+++ b/shared/searchv3/helpers.js
@@ -12,7 +12,7 @@ type OwnProps = {
   searchResultIds: Array<Constants.SearchResultId>,
   selectedSearchId: ?Constants.SearchResultId,
   onUpdateSelectedSearchResult: (id: ?Constants.SearchResultId) => void,
-  onEnter: (id: Constants.SearchResultId) => void,
+  onEnter: (id: ?Constants.SearchResultId) => void,
 }
 
 // Which search result is highlighted
@@ -32,7 +32,7 @@ const selectedSearchIdHoc = compose(
 const onChangeSelectedSearchResultHoc = compose(
   withHandlers({
     onEnter: ({onChangeSearchText, onEnter, selectedSearchId}: OwnProps) => () => {
-      selectedSearchId && onEnter(selectedSearchId)
+      onEnter(selectedSearchId)
       onChangeSearchText('')
     },
     onMove: ({onUpdateSelectedSearchResult, selectedSearchId, searchResultIds}: OwnProps) => (

--- a/shared/searchv3/user-input/index.desktop.js
+++ b/shared/searchv3/user-input/index.desktop.js
@@ -1,5 +1,4 @@
 // @flow
-import {last} from 'lodash'
 import React, {Component} from 'react'
 import {AutosizeInput, Box, Text, Icon} from '../../common-adapters'
 import {globalColors, globalMargins, globalStyles} from '../../styles'
@@ -73,19 +72,19 @@ class UserInput extends Component<void, Props, State> {
 
   _onInputKeyDown = ev => {
     if (
-      this.props.userItems.length &&
+      this.props.userItems.size &&
       ev.key === 'Backspace' &&
       ev.target.selectionStart === 0 &&
       ev.target.selectionEnd === 0
     ) {
-      this.props.onRemoveUser(last(this.props.userItems).id)
+      this.props.onRemoveUser(this.props.userItems.get(-1).id)
     } else if (ev.key === 'ArrowUp') {
       this.props.onMoveSelectUp()
       ev.preventDefault()
     } else if (ev.key === 'ArrowDown') {
       this.props.onMoveSelectDown()
       ev.preventDefault()
-    } else if (ev.key === 'Enter') {
+    } else if (ev.key === 'Enter' || ev.key === 'Tab') {
       this.props.onEnter()
       ev.preventDefault()
     }

--- a/shared/searchv3/user-input/index.desktop.js
+++ b/shared/searchv3/user-input/index.desktop.js
@@ -72,7 +72,7 @@ class UserInput extends Component<void, Props, State> {
 
   _onInputKeyDown = ev => {
     if (
-      this.props.userItems.size &&
+      this.props.userItems.count() &&
       ev.key === 'Backspace' &&
       ev.target.selectionStart === 0 &&
       ev.target.selectionEnd === 0

--- a/shared/searchv3/user-input/index.js.flow
+++ b/shared/searchv3/user-input/index.js.flow
@@ -1,6 +1,7 @@
 // @flow
 import {Component} from 'react'
 import * as Constants from '../../constants/searchv3'
+import {List} from 'immutable'
 import type {IconType} from '../../common-adapters/icon'
 
 export type UserDetails = {
@@ -14,7 +15,7 @@ export type UserDetails = {
 export type Props = {
   autoFocus?: boolean,
   placeholder?: string,
-  userItems: Array<UserDetails>,
+  userItems: List<UserDetails>,
   usernameText: string,
   onChangeText: (usernameText: string) => void,
   onRemoveUser: (id: string) => void,


### PR DESCRIPTION
@keybase/react-hackers

Here's the new focus behavior for searchv3 in Chat:

* When you stage a user for chat, we retain focus on the search input box, so you can keep typing there to add someone else
* You can use enter or tab to choose the highlighted search result row
* Backspace works to delete someone (this was broken by the prop being an immutable List rather than JS array)
* If you hit enter or tab while *not* in the middle of adding another user, we close the search, focus the conversation input box, and go to that search's convo.