### PR TITLE
Upgrade Search item to Keybase user if present

### DIFF
--- a/shared/chat/search-header.js
+++ b/shared/chat/search-header.js
@@ -97,8 +97,6 @@ export default compose(
   HocHelpers.clearSearchHoc,
   defaultProps({
     placeholder: 'Search for someone',
-    showAddButton: false,
-    onClickAddButton: () => console.log('todo'),
   }),
   lifecycle({
     componentWillReceiveProps(nextProps: OwnProps) {

--- a/shared/constants/searchv3.js
+++ b/shared/constants/searchv3.js
@@ -111,11 +111,11 @@ function maybeUpgradeSearchResultIdToKeybaseId(
     return id
   }
 
-  const searchResult = searchResultMap.get(id).toObject()
-  if (searchResult.leftService === 'Keybase') {
-    return searchResult.leftUsername
-  } else if (searchResult.rightService === 'Keybase') {
-    return searchResult.rightUsername || id
+  const searchResult = searchResultMap.get(id)
+  if (searchResult.get('leftService') === 'Keybase') {
+    return searchResult.get('leftUsername')
+  } else if (searchResult.get('rightService') === 'Keybase') {
+    return searchResult.get('rightUsername') || id
   }
 
   return id

--- a/shared/constants/searchv3.js
+++ b/shared/constants/searchv3.js
@@ -102,4 +102,23 @@ function followStateHelper(state: TypedState, username: string, service: Service
   return 'NoState'
 }
 
-export {serviceIdToService, followStateHelper}
+function maybeUpgradeSearchResultIdToKeybaseId(
+  searchResultMap: $PropertyType<$PropertyType<TypedState, 'entities'>, 'searchResults'>,
+  id: SearchResultId
+): SearchResultId {
+  if (!searchResultMap.get(id)) {
+    console.warn('search result id not found in enitites.', id)
+    return id
+  }
+
+  const searchResult = searchResultMap.get(id).toObject()
+  if (searchResult.leftService === 'Keybase') {
+    return searchResult.leftUsername
+  } else if (searchResult.rightService === 'Keybase') {
+    return searchResult.rightUsername || id
+  }
+
+  return id
+}
+
+export {serviceIdToService, followStateHelper, maybeUpgradeSearchResultIdToKeybaseId}

--- a/shared/constants/selectors.js
+++ b/shared/constants/selectors.js
@@ -19,6 +19,11 @@ const inboxSearchSelector = ({chat: {inboxSearch}}: TypedState) => inboxSearch
 const amIFollowing = ({config: {following}}: TypedState, otherUser: string) => following[otherUser]
 const amIBeingFollowed = ({config: {followers}}: TypedState, otherUser: string) => followers[otherUser]
 
+const searchResultMapSelector = createSelector(
+  ({entities: {searchResults}}: TypedState) => searchResults,
+  searchResults => searchResults
+)
+
 const chatSearchResultArray = createSelector(
   ({chat: {searchResults}}: TypedState) => searchResults,
   searchResults => (searchResults ? searchResults.toArray() : [])
@@ -34,14 +39,15 @@ const createShallowEqualSelector = createSelectorCreator(defaultMemoize, (a, b) 
 )
 
 export {
-  amIFollowing,
   amIBeingFollowed,
+  amIFollowing,
   cachedSearchResults,
   chatSearchResultArray,
   createShallowEqualSelector,
   inboxSearchSelector,
   loggedInSelector,
   profileSearchResultArray,
+  searchResultMapSelector,
   searchResultSelector,
   usernameSelector,
 }

--- a/shared/searchv3/helpers.js
+++ b/shared/searchv3/helpers.js
@@ -55,7 +55,7 @@ const clearSearchHoc = withHandlers({
     clearSearchResults,
     search,
   }) => () => {
-    if (userItems.count() === 0 && !searchText) {
+    if (userItems.length === 0 && !searchText) {
       onExitSearch()
     } else {
       userItems.forEach(({id}) => onRemoveUser(id))

--- a/shared/searchv3/user-input/index.desktop.js
+++ b/shared/searchv3/user-input/index.desktop.js
@@ -112,7 +112,7 @@ class UserInput extends Component<void, Props, State> {
     } = this.props
     const {isFocused} = this.state
 
-    const showAddButton = !!userItems.length && !usernameText.length
+    const showAddButton = !!userItems.length && !usernameText.length && onClickAddButton
     const inputLeftPadding = !!userItems.length && (!!usernameText.length || isFocused)
       ? globalMargins.xtiny
       : 0
@@ -139,6 +139,7 @@ class UserInput extends Component<void, Props, State> {
               onBlur={this._onBlur}
             />
             {showAddButton &&
+              onClickAddButton &&
               <Icon
                 onClick={onClickAddButton}
                 type="iconfont-add"

--- a/shared/searchv3/user-input/index.js.flow
+++ b/shared/searchv3/user-input/index.js.flow
@@ -18,7 +18,7 @@ export type Props = {|
   usernameText: string,
   onChangeText: (usernameText: string) => void,
   onRemoveUser: (id: string) => void,
-  onClickAddButton: () => void,
+  onClickAddButton: ?(() => void),
   onMoveSelectUp: () => void,
   onMoveSelectDown: () => void,
   onClearSearch?: () => void,

--- a/shared/searchv3/user-input/index.native.js
+++ b/shared/searchv3/user-input/index.native.js
@@ -127,7 +127,7 @@ class UserInput extends Component<void, Props, State> {
   render() {
     const {autoFocus, placeholder, userItems, usernameText, onChangeText, onClickAddButton} = this.props
 
-    const showAddButton = !!userItems.length && !usernameText.length
+    const showAddButton = !!userItems.length && !usernameText.length && onClickAddButton
     return (
       <ClickableBox feedback={false} onClick={this.focus}>
         <Box style={{...globalStyles.flexBoxRow, alignItems: 'center', flexWrap: 'wrap'}}>
@@ -159,6 +159,7 @@ class UserInput extends Component<void, Props, State> {
               onChangeText={onChangeText}
             />
             {showAddButton &&
+              onClickAddButton &&
               <Icon
                 onClick={onClickAddButton}
                 type="iconfont-add"


### PR DESCRIPTION
@keybase/react-hackers 

This makes it so if you click a search result that has a keybase user attached (i.e. you search "maxtaco" on twitter, and you click it). Then the user pill and filter logic and startConversation use the keybase id ("max" in the example) instead of the search result id (which would have been "maxtaco@twiiter").

If the user has no keybase attached, it's the same as before and does the SBS flow.