### PR TITLE
cleanup chain.go

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1400,6 +1400,10 @@ func (u UserVersion) String() string {
 	return fmt.Sprintf("%s%%%d", u.Uid, u.EldestSeqno)
 }
 
+func (u UserVersion) Eq(v UserVersion) bool {
+	return u.Uid.Equal(v.Uid) && u.EldestSeqno.Eq(v.EldestSeqno)
+}
+
 func (k CryptKey) Material() Bytes32 {
 	return k.Key
 }

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -406,7 +406,7 @@ func (t *TeamSigChainPlayer) appendChainLinkHelper(
 		newState2 := prevState.DeepCopy()
 		newState = &newState2
 	} else {
-		if signer == nil {
+		if signer == nil || !signer.Uid.Exists() {
 			return res, fmt.Errorf("signing user not provided for team link")
 		}
 		iRes, err := t.addInnerLink(prevState, link, *signer, false)
@@ -472,6 +472,10 @@ func (t *TeamSigChainPlayer) addInnerLink(
 		return res, NewStubbedError(link)
 	}
 	payload := *link.inner
+
+	if !signer.Uid.Exists() {
+		return res, fmt.Errorf("empty link signer: %v", signer)
+	}
 
 	// TODO: this may be superfluous.
 	err = link.AssertInnerOuterMatch()

--- a/go/teams/chain_test.go
+++ b/go/teams/chain_test.go
@@ -74,8 +74,20 @@ func TestTeamSigChainPlay1(t *testing.T) {
 	}
 
 	player := NewTeamSigChainPlayer(tc.G, NewUserVersion(keybase1.UID("4bf92804c02fb7d2cd36a6d420d6f619"), 1))
-	err = player.AddChainLinks(context.TODO(), chainLinks)
-	require.NoError(t, err)
+	for _, cLink := range chainLinks {
+		link, err := unpackChainLink(&cLink)
+		require.NoError(t, err)
+		var signer *keybase1.UserVersion
+		if !link.isStubbed() {
+			// Assume the signing user has never reset.
+			signer = &keybase1.UserVersion{
+				Uid:         link.inner.Body.Key.UID,
+				EldestSeqno: keybase1.Seqno(1),
+			}
+		}
+		err = player.AppendChainLink(context.TODO(), link, signer)
+		require.NoError(t, err)
+	}
 
 	// Check once before and after serializing and deserializing
 	state, err := player.GetState()
@@ -145,7 +157,20 @@ func TestTeamSigChainPlay2(t *testing.T) {
 	}
 
 	player := NewTeamSigChainPlayer(tc.G, NewUserVersion("99759da4f968b16121ece44652f01a19", 1))
-	err = player.AddChainLinks(context.TODO(), chainLinks)
+	for _, cLink := range chainLinks {
+		link, err := unpackChainLink(&cLink)
+		require.NoError(t, err)
+		var signer *keybase1.UserVersion
+		if !link.isStubbed() {
+			// Assume the signing user has never reset.
+			signer = &keybase1.UserVersion{
+				Uid:         link.inner.Body.Key.UID,
+				EldestSeqno: keybase1.Seqno(1),
+			}
+		}
+		err = player.AppendChainLink(context.TODO(), link, signer)
+		require.NoError(t, err)
+	}
 	require.NoError(t, err)
 
 	// Check once before and after serializing and deserializing

--- a/go/teams/create_test.go
+++ b/go/teams/create_test.go
@@ -82,13 +82,13 @@ func TestCreateSubteam(t *testing.T) {
 	_, err = CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName)
 	require.NoError(t, err)
 
-	// TODO: Uncomment the rest here when Get() supports subteams.
-
-	// // Fetch the subteam we just created, to make sure it's there.
-	// subteamFQName := parentTeamName + "." + subteamBasename
-	// subteam, err := Get(context.TODO(), tc.G, subteamFQName)
-	// require.NoError(t, err)
-
-	// require.Equal(t, subteamFQName, subteam.GetName())
-	// require.Equal(t, 1, subteam.GetLatestSeqno())
+	// Fetch the subteam we just created, to make sure it's there.
+	subteamFQName, err := parentTeamName.Append(subteamBasename)
+	require.NoError(t, err)
+	subteam, err := Load(context.TODO(), tc.G, keybase1.LoadTeamArg{
+		Name: subteamFQName.String(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, subteamFQName, subteam.Name)
+	require.Equal(t, keybase1.Seqno(1), subteam.chain().GetLatestSeqno())
 }

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -27,12 +27,31 @@ func (e StubbedError) Error() string {
 		int(e.l.outerLink.Seqno), *e.note)
 }
 
-func NewInflateError(l *chainLinkUnpacked) InflateError {
-	return InflateError{l: l, note: nil}
+type InvalidLink struct {
+	l    *chainLinkUnpacked
+	note string
 }
 
-func NewInflateErrorWithNote(l *chainLinkUnpacked, note string) InflateError {
-	return InflateError{l: l, note: &note}
+func (e InvalidLink) Error() string {
+	return fmt.Sprintf("invalid link (seqno %d): %s", e.l.Seqno(), e.note)
+}
+
+func NewInvalidLink(l *chainLinkUnpacked, format string, args ...interface{}) InvalidLink {
+	return InvalidLink{l, fmt.Sprintf(format, args...)}
+}
+
+type AppendLinkError struct {
+	prevSeqno keybase1.Seqno
+	l         *chainLinkUnpacked
+	inner     error
+}
+
+func (e AppendLinkError) Error() string {
+	return fmt.Sprintf("appending %v->%v: %v", e.prevSeqno, e.l.Seqno(), e.inner)
+}
+
+func NewAppendLinkError(l *chainLinkUnpacked, prevSeqno keybase1.Seqno, inner error) AppendLinkError {
+	return AppendLinkError{prevSeqno, l, inner}
 }
 
 type InflateError struct {
@@ -46,6 +65,27 @@ func (e InflateError) Error() string {
 	}
 	return fmt.Sprintf("error inflating previously-stubbed link (seqno %d) (%s)",
 		int(e.l.outerLink.Seqno), *e.note)
+}
+
+func NewInflateError(l *chainLinkUnpacked) InflateError {
+	return InflateError{l: l, note: nil}
+}
+
+func NewInflateErrorWithNote(l *chainLinkUnpacked, note string) InflateError {
+	return InflateError{l: l, note: &note}
+}
+
+type UnexpectedSeqnoError struct {
+	expected keybase1.Seqno
+	actual   keybase1.Seqno
+}
+
+func (e UnexpectedSeqnoError) Error() string {
+	return fmt.Sprintf("expected seqno:%v but got %v", e.expected, e.actual)
+}
+
+func NewUnexpectedSeqnoError(expected, actual keybase1.Seqno) UnexpectedSeqnoError {
+	return UnexpectedSeqnoError{expected, actual}
 }
 
 type AdminPermissionError struct {

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -283,7 +283,7 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 			return nil, fmt.Errorf("team replay failed: prev chain broken at link %d", i)
 		}
 
-		var signer keybase1.UserVersion
+		var signer *keybase1.UserVersion
 		signer, proofSet, err = l.verifyLink(ctx, arg.teamID, ret, link, proofSet)
 		if err != nil {
 			return nil, err

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -202,6 +202,13 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 		ret = l.storage.Get(ctx, arg.teamID)
 	}
 
+	if ret != nil && !ret.Chain.Reader.Eq(arg.me) {
+		// Check that we are the same person as when this team was last loaded as a courtesy.
+		// This should never happen. We shouldn't be able to decrypt someone else's snapshot.
+		l.G().Log.CWarningf(ctx, "team loader got someone else's snapshot, discarding.")
+		ret = nil
+	}
+
 	// Determine whether to repoll merkle.
 	discardCache, repoll := l.load2DecideRepoll(ctx, arg, ret)
 	if discardCache {
@@ -276,7 +283,8 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 			return nil, fmt.Errorf("team replay failed: prev chain broken at link %d", i)
 		}
 
-		_, proofSet, err = l.verifyLink(ctx, arg.teamID, ret, link, proofSet)
+		var signer keybase1.UserVersion
+		signer, proofSet, err = l.verifyLink(ctx, arg.teamID, ret, link, proofSet)
 		if err != nil {
 			return nil, err
 		}
@@ -289,7 +297,7 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 			parentChildOperations = append(parentChildOperations, pco)
 		}
 
-		ret, err = l.applyNewLink(ctx, ret, link, arg.me)
+		ret, err = l.applyNewLink(ctx, ret, link, signer, arg.me)
 		if err != nil {
 			return nil, err
 		}

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -350,16 +350,11 @@ func (l *TeamLoader) toParentChildOperation(ctx context.Context,
 }
 
 // Apply a new link to the sigchain state.
-// TODO: verify all sorts of things.
 func (l *TeamLoader) applyNewLink(ctx context.Context,
 	state *keybase1.TeamData, link *chainLinkUnpacked,
-	me keybase1.UserVersion) (*keybase1.TeamData, error) {
-	l.G().Log.CDebugf(ctx, "TeamLoader applying link seqno:%v", link.Seqno())
+	signer keybase1.UserVersion, me keybase1.UserVersion) (*keybase1.TeamData, error) {
 
-	// TODO: This uses chain.go now. But chain.go is not in line
-	// with the new approach. It has TODOs to check things that
-	// are checked by proofSet etc now.
-	// And it does not use pre-unpacked types.
+	l.G().Log.CDebugf(ctx, "TeamLoader applying link seqno:%v", link.Seqno())
 
 	var player *TeamSigChainPlayer
 	if state == nil {
@@ -368,7 +363,7 @@ func (l *TeamLoader) applyNewLink(ctx context.Context,
 		player = NewTeamSigChainPlayerWithState(l.G(), me, TeamSigChainState{inner: state.Chain})
 	}
 
-	err := player.AddChainLinks(ctx, []SCChainLink{*link.source})
+	err := player.AppendChainLink(ctx, link, &signer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Get rid of extra checks and double link unpacking. Make the interface a little cleaner.
Also make `verifyLink` return the signer for seqno=1. I don't see how anything worked without this.