### PR TITLE
stop loadinbox from happening all the time

### DIFF
--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -55,10 +55,7 @@ export default compose(
       rows: getRows(state),
     }),
     (dispatch: Dispatch) => ({
-      loadInbox: () => {
-        console.log('aaa')
-        dispatch(loadInbox())
-      },
+      loadInbox: () => dispatch(loadInbox()),
       onNewChat: () => dispatch(newChat([])),
       onUntrustedInboxVisible: (converationIDKey, rowsVisible) =>
         dispatch(untrustedInboxVisible(converationIDKey, rowsVisible)),

--- a/shared/chat/inbox/container.js
+++ b/shared/chat/inbox/container.js
@@ -5,6 +5,8 @@ import ConversationList from './index'
 import {connect} from 'react-redux'
 import {createSelectorCreator, defaultMemoize} from 'reselect'
 import {loadInbox, newChat, untrustedInboxVisible} from '../../actions/chat/creators'
+import {compose, lifecycle} from 'recompose'
+import {throttle} from 'lodash'
 
 import type {TypedState} from '../../constants/reducer'
 
@@ -41,16 +43,32 @@ const getRows = createImmutableEqualSelector([filteredInbox, getPending], (inbox
   return I.List(pending.keys()).concat(inbox)
 })
 
-export default connect(
-  (state: TypedState) => ({
-    isLoading: state.chat.get('inboxUntrustedState') === 'loading',
-    showNewConversation: state.chat.inSearch && state.chat.inboxSearch.isEmpty(),
-    rows: getRows(state),
-  }),
-  (dispatch: Dispatch) => ({
-    loadInbox: () => dispatch(loadInbox()),
-    onNewChat: () => dispatch(newChat([])),
-    onUntrustedInboxVisible: (converationIDKey, rowsVisible) =>
-      dispatch(untrustedInboxVisible(converationIDKey, rowsVisible)),
+// Inbox is being loaded a ton by the navigator for some reason. we need a module-level helper
+// to not call loadInbox multiple times
+const throttleHelper = throttle(cb => cb(), 60 * 1000)
+
+export default compose(
+  connect(
+    (state: TypedState) => ({
+      isLoading: state.chat.get('inboxUntrustedState') === 'loading',
+      showNewConversation: state.chat.inSearch && state.chat.inboxSearch.isEmpty(),
+      rows: getRows(state),
+    }),
+    (dispatch: Dispatch) => ({
+      loadInbox: () => {
+        console.log('aaa')
+        dispatch(loadInbox())
+      },
+      onNewChat: () => dispatch(newChat([])),
+      onUntrustedInboxVisible: (converationIDKey, rowsVisible) =>
+        dispatch(untrustedInboxVisible(converationIDKey, rowsVisible)),
+    })
+  ),
+  lifecycle({
+    componentDidMount: function() {
+      throttleHelper(() => {
+        this.props.loadInbox()
+      })
+    },
   })
 )(ConversationList)

--- a/shared/chat/inbox/index.desktop.js
+++ b/shared/chat/inbox/index.desktop.js
@@ -293,10 +293,6 @@ const Row = RowConnector(_Row)
 class ConversationList extends PureComponent<void, Props, void> {
   _list: any
 
-  componentWillMount() {
-    this.props.loadInbox()
-  }
-
   componentWillReceiveProps(nextProps: Props) {
     if (this.props.rows !== nextProps.rows && nextProps.rows.count()) {
       this._onScroll()

--- a/shared/chat/inbox/index.native.js
+++ b/shared/chat/inbox/index.native.js
@@ -336,8 +336,7 @@ class ConversationList extends PureComponent<void, Props, {rows: Array<any>}> {
     }
   }, 1000)
 
-  componentWillMount() {
-    this.props.loadInbox()
+  componentDidMount() {
     this._setupDataSource(this.props)
     if (this.props.rows.count()) {
       this._askForUnboxing(this.props.rows.first(), 30)


### PR DESCRIPTION
@keybase/react-hackers this should hopefully fix chat from being hosed

for some reason the component is mounted over and over and over again. it seems like there's a bug in the navigator where it does this work waaaaay too much