### PR TITLE
shorter timeout and retry for calls on the KBFS critical path

### DIFF
--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -295,6 +295,9 @@ func (r *Resolver) resolveURLViaServerLookup(ctx context.Context, au AssertionUR
 		Args:           ha,
 		AppStatusCodes: []int{SCOk, SCNotFound, SCDeleted},
 		NetContext:     ctx,
+		RetryCount : 3,
+		InitialTimeout : 4 * time.Second,
+		RetryMultiplier : 1.5,
 	})
 
 	if res.err != nil {


### PR DESCRIPTION
- ran afoul of 19s timeout on OSX
- Thoughts? i'm not convinced this is the right idea but don't have any better ideas