### PR TITLE
Fix wrong assumption about type s/length/.count()

### DIFF
--- a/shared/app/nav.native.js
+++ b/shared/app/nav.native.js
@@ -183,7 +183,7 @@ function Nav(props: Props) {
   const layers = layerScreens.map(r => r.leafComponent)
 
   // If we have layers, lets add an extra box, else lets just pass through
-  if (layers.length) {
+  if (layers.count()) {
     return (
       <Box style={globalStyles.fillAbsolute}>
         {shim}

--- a/shared/libs/flow-interface.js.flow
+++ b/shared/libs/flow-interface.js.flow
@@ -1,5 +1,8 @@
 /*eslint-disable */
 
+declare module 'mousetrap' {
+  declare var exports: any
+}
 declare module 'Interpolation' {
   declare var exports: any
 }


### PR DESCRIPTION
@keybase/react-hackers 

Flow should catch this, but a lot of times it doesn't even know what type something is.

We could also consider adding some runtime checking in dev mode. I think doing this: 
```js
Object.defineProperty(Immutable.Collection.Indexed.prototype, 'length', {
  get: function() { console.warn('length is not supported on immutable objects'); },
});
```

should warn about these problems.