### PR TITLE
SearchV3: QA #2

### DIFF
--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -568,6 +568,12 @@ function setInitialConversation(
   return {payload: {conversationIDKey}, type: 'chat:setInitialConversation'}
 }
 
+function setPreviousConversation(
+  conversationIDKey: ?Constants.ConversationIDKey
+): Constants.SetPreviousConversation {
+  return {payload: {conversationIDKey}, type: 'chat:setPreviousConversation'}
+}
+
 function threadLoadedOffline(conversationIDKey: Constants.ConversationIDKey): Constants.ThreadLoadedOffline {
   return {payload: {conversationIDKey}, type: 'chat:threadLoadedOffline'}
 }
@@ -675,6 +681,7 @@ export {
   setInboxUntrustedState,
   setInitialConversation,
   setLoaded,
+  setPreviousConversation,
   setSelectedRouteState,
   setTypers,
   setUnboxing,

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -31,7 +31,12 @@ import {searchTab, chatTab} from '../../constants/tabs'
 import {showMainWindow} from '../platform-specific'
 import {some} from 'lodash'
 import {toDeviceType} from '../../constants/types/more'
-import {usernameSelector, inboxSearchSelector, searchResultMapSelector} from '../../constants/selectors'
+import {
+  usernameSelector,
+  inboxSearchSelector,
+  previousConversationSelector,
+  searchResultMapSelector,
+} from '../../constants/selectors'
 import {maybeUpgradeSearchResultIdToKeybaseId} from '../../constants/searchv3'
 
 import type {Action} from '../../constants/types/flux'
@@ -712,6 +717,7 @@ function* _openFolder(): SagaGenerator<any, any> {
 function* _newChat(action: Constants.NewChat): SagaGenerator<any, any> {
   // TODO handle participants from action into the new chat
   if (featureFlags.searchv3Enabled) {
+    yield put(Creators.setPreviousConversation(yield select(Constants.getSelectedConversation)))
     yield put(Creators.selectConversation(null, false))
     yield put(SearchCreators.searchSuggestions('chat:updateSearchResults'))
     return
@@ -1009,10 +1015,14 @@ function* _updateTempSearchConversation(
 }
 
 function* _exitSearch() {
+  const inboxSearch = yield select(inboxSearchSelector)
   yield put(Creators.clearSearchResults())
   yield put(Creators.setInboxSearch([]))
   yield put(Creators.setInboxFilter([]))
   yield put(Creators.removeTempPendingConversations())
+  if (inboxSearch.count() === 0) {
+    yield put(Creators.selectConversation(yield select(previousConversationSelector), false))
+  }
 }
 
 function* chatSaga(): SagaGenerator<any, any> {

--- a/shared/actions/searchv3/creators.js
+++ b/shared/actions/searchv3/creators.js
@@ -3,14 +3,22 @@ import * as Constants from '../../constants/searchv3'
 
 function search<T>(
   term: string,
-  actionTypeToFire: T,
+  pendingActionTypeToFire: T,
+  finishedActionTypeToFire: T,
   service: Constants.Service = 'Keybase'
 ): Constants.Search<T> {
-  return {type: 'searchv3:search', payload: {actionTypeToFire, term, service}}
+  return {
+    type: 'searchv3:search',
+    payload: {finishedActionTypeToFire, pendingActionTypeToFire, service, term},
+  }
 }
 
 function searchSuggestions<T>(actionTypeToFire: T, maxUsers?: number = 10): Constants.SearchSuggestions<T> {
   return {type: 'searchv3:searchSuggestions', payload: {actionTypeToFire, maxUsers}}
+}
+
+function pendingSearch<T>(actionTypeToFire: T, pending: boolean): Constants.PendingSearch<T> {
+  return {type: actionTypeToFire, payload: {pending}}
 }
 
 function finishedSearch<T>(
@@ -22,4 +30,4 @@ function finishedSearch<T>(
   return {type: actionTypeToFire, payload: {searchTerm, searchResults, service}}
 }
 
-export {search, searchSuggestions, finishedSearch}
+export {finishedSearch, pendingSearch, search, searchSuggestions}

--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -27,6 +27,7 @@ type StateProps = {|
   inSearch: boolean,
   searchResultIds: Array<SearchConstants.SearchResultId>,
   showSearchResults: boolean,
+  showSearchPending: boolean,
 |}
 
 type DispatchProps = {|
@@ -66,8 +67,7 @@ const mapStateToProps = (state: TypedState, {routePath, routeState}): StateProps
     }
   }
 
-  const searchResults = state.chat.searchResults
-
+  const {inSearch, searchPending, searchResults} = state.chat
   return {
     finalizeInfo,
     rekeyInfo,
@@ -76,8 +76,9 @@ const mapStateToProps = (state: TypedState, {routePath, routeState}): StateProps
     supersededBy,
     supersedes,
     threadLoadedOffline,
-    inSearch: state.chat.inSearch,
+    inSearch,
     searchResultIds: chatSearchResultArray(state),
+    showSearchPending: searchPending,
     showSearchResults: !!searchResults,
   }
 }

--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -7,7 +7,7 @@ import List from './list/container'
 import OldProfileResetNotice from './notices/old-profile-reset-notice/container'
 import React, {Component} from 'react'
 import SidePanel from './side-panel/container'
-import {Box, Icon, Text, LoadingLine} from '../../common-adapters'
+import {Box, Icon, LoadingLine, ProgressIndicator, Text} from '../../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../../styles'
 import {readImageFromClipboard} from '../../util/clipboard.desktop'
 
@@ -116,46 +116,48 @@ class Conversation extends Component<void, Props, State> {
           selectedSearchId={this.props.selectedSearchId}
           onUpdateSelectedSearchResult={this.props.onUpdateSelectedSearchResult}
         />
-        {this.props.showSearchResults
-          ? <SearchResultsList
-              items={this.props.searchResultIds}
-              onClick={this.props.onClickSearchResult}
-              onShowTracker={this.props.onShowTrackerInSearch}
-              selectedId={this.props.selectedSearchId}
-            />
-          : <div style={{...globalStyles.flexBoxColumn, flex: 1}}>
-              <List
-                focusInputCounter={this.props.focusInputCounter}
-                listScrollDownCounter={this.props.listScrollDownCounter}
-                onEditLastMessage={this.props.onEditLastMessage}
-                onScrollDown={this.props.onScrollDown}
-                onFocusInput={this.props.onFocusInput}
-                editLastMessageCounter={this.props.editLastMessageCounter}
-              />
-              <Banner />
-              {this.props.showLoader && <LoadingLine />}
-              {this.props.finalizeInfo
-                ? <OldProfileResetNotice />
-                : <Input
+        {this.props.showSearchPending
+          ? <ProgressIndicator style={{width: globalMargins.xlarge}} />
+          : this.props.showSearchResults
+              ? <SearchResultsList
+                  items={this.props.searchResultIds}
+                  onClick={this.props.onClickSearchResult}
+                  onShowTracker={this.props.onShowTrackerInSearch}
+                  selectedId={this.props.selectedSearchId}
+                />
+              : <div style={{...globalStyles.flexBoxColumn, flex: 1}}>
+                  <List
                     focusInputCounter={this.props.focusInputCounter}
+                    listScrollDownCounter={this.props.listScrollDownCounter}
                     onEditLastMessage={this.props.onEditLastMessage}
                     onScrollDown={this.props.onScrollDown}
-                  />}
-              {this.props.sidePanelOpen &&
-                <div
-                  style={{
-                    ...globalStyles.flexBoxColumn,
-                    bottom: 0,
-                    position: 'absolute',
-                    right: 0,
-                    top: 35,
-                    width: 320,
-                  }}
-                >
-                  <SidePanel onToggleSidePanel={this.props.onToggleSidePanel} />
+                    onFocusInput={this.props.onFocusInput}
+                    editLastMessageCounter={this.props.editLastMessageCounter}
+                  />
+                  <Banner />
+                  {this.props.showLoader && <LoadingLine />}
+                  {this.props.finalizeInfo
+                    ? <OldProfileResetNotice />
+                    : <Input
+                        focusInputCounter={this.props.focusInputCounter}
+                        onEditLastMessage={this.props.onEditLastMessage}
+                        onScrollDown={this.props.onScrollDown}
+                      />}
+                  {this.props.sidePanelOpen &&
+                    <div
+                      style={{
+                        ...globalStyles.flexBoxColumn,
+                        bottom: 0,
+                        position: 'absolute',
+                        right: 0,
+                        top: 35,
+                        width: 320,
+                      }}
+                    >
+                      <SidePanel onToggleSidePanel={this.props.onToggleSidePanel} />
+                    </div>}
+                  {dropOverlay}
                 </div>}
-              {dropOverlay}
-            </div>}
       </Box>
     )
   }

--- a/shared/chat/conversation/index.js.flow
+++ b/shared/chat/conversation/index.js.flow
@@ -22,6 +22,7 @@ export type Props = {|
   threadLoadedOffline: boolean,
   searchV3Enabled: boolean,
   inSearch: boolean,
+  showSearchPending: boolean,
   showSearchResults: boolean,
   searchResultIds: Array<SearchConstants.SearchResultId>,
   onClickSearchResult: (id: string) => void,

--- a/shared/chat/conversation/index.native.js
+++ b/shared/chat/conversation/index.native.js
@@ -73,36 +73,6 @@ const Conversation = (props: Props) => (
 
               {props.sidePanelOpen && <SidePanel onToggleSidePanel={props.onToggleSidePanel} />}
             </Box>}
-    ?
-    {' '}
-    <SearchResultsList
-      items={props.searchResultIds}
-      onClick={props.onClickSearchResult}
-      onShowTracker={props.onShowTrackerInSearch}
-      selectedId={props.selectedSearchId}
-      style={{flex: 1}}
-    />
-    : <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
-      <List
-        focusInputCounter={props.focusInputCounter}
-        listScrollDownCounter={props.listScrollDownCounter}
-        onEditLastMessage={props.onEditLastMessage}
-        onScrollDown={props.onScrollDown}
-        onFocusInput={props.onFocusInput}
-        editLastMessageCounter={props.editLastMessageCounter}
-      />
-      <Banner />
-      {props.showLoader && <LoadingLine />}
-      {props.finalizeInfo
-        ? <OldProfileResetNotice />
-        : <Input
-            focusInputCounter={props.focusInputCounter}
-            onEditLastMessage={props.onEditLastMessage}
-            onScrollDown={props.onScrollDown}
-          />}
-
-      {props.sidePanelOpen && <SidePanel onToggleSidePanel={props.onToggleSidePanel} />}
-    </Box>}
   </Box>
 )
 

--- a/shared/chat/conversation/index.native.js
+++ b/shared/chat/conversation/index.native.js
@@ -7,7 +7,7 @@ import OldProfileResetNotice from './notices/old-profile-reset-notice/container'
 import React from 'react'
 import SidePanel from './side-panel/container'
 import Banner from './banner/container'
-import {Box, LoadingLine, Text} from '../../common-adapters'
+import {Box, LoadingLine, ProgressIndicator, Text} from '../../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../../styles'
 
 import type {Props} from './index'
@@ -42,35 +42,67 @@ const Conversation = (props: Props) => (
       selectedConversationIDKey={props.selectedConversationIDKey}
       onUpdateSelectedSearchResult={props.onUpdateSelectedSearchResult}
     />
-    {props.showSearchResults
-      ? <SearchResultsList
-          items={props.searchResultIds}
-          onClick={props.onClickSearchResult}
-          onShowTracker={props.onShowTrackerInSearch}
-          selectedId={props.selectedSearchId}
-          style={{flex: 1}}
-        />
-      : <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
-          <List
-            focusInputCounter={props.focusInputCounter}
-            listScrollDownCounter={props.listScrollDownCounter}
-            onEditLastMessage={props.onEditLastMessage}
-            onScrollDown={props.onScrollDown}
-            onFocusInput={props.onFocusInput}
-            editLastMessageCounter={props.editLastMessageCounter}
-          />
-          <Banner />
-          {props.showLoader && <LoadingLine />}
-          {props.finalizeInfo
-            ? <OldProfileResetNotice />
-            : <Input
+    {props.showSearchPending
+      ? <ProgressIndicator style={{width: globalMargins.xlarge}} />
+      : props.showSearchResults
+          ? <SearchResultsList
+              items={props.searchResultIds}
+              onClick={props.onClickSearchResult}
+              onShowTracker={props.onShowTrackerInSearch}
+              selectedId={props.selectedSearchId}
+              style={{flex: 1}}
+            />
+          : <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
+              <List
                 focusInputCounter={props.focusInputCounter}
+                listScrollDownCounter={props.listScrollDownCounter}
                 onEditLastMessage={props.onEditLastMessage}
                 onScrollDown={props.onScrollDown}
-              />}
+                onFocusInput={props.onFocusInput}
+                editLastMessageCounter={props.editLastMessageCounter}
+              />
+              <Banner />
+              {props.showLoader && <LoadingLine />}
+              {props.finalizeInfo
+                ? <OldProfileResetNotice />
+                : <Input
+                    focusInputCounter={props.focusInputCounter}
+                    onEditLastMessage={props.onEditLastMessage}
+                    onScrollDown={props.onScrollDown}
+                  />}
 
-          {props.sidePanelOpen && <SidePanel onToggleSidePanel={props.onToggleSidePanel} />}
-        </Box>}
+              {props.sidePanelOpen && <SidePanel onToggleSidePanel={props.onToggleSidePanel} />}
+            </Box>}
+    ?
+    {' '}
+    <SearchResultsList
+      items={props.searchResultIds}
+      onClick={props.onClickSearchResult}
+      onShowTracker={props.onShowTrackerInSearch}
+      selectedId={props.selectedSearchId}
+      style={{flex: 1}}
+    />
+    : <Box style={{...globalStyles.flexBoxColumn, flex: 1}}>
+      <List
+        focusInputCounter={props.focusInputCounter}
+        listScrollDownCounter={props.listScrollDownCounter}
+        onEditLastMessage={props.onEditLastMessage}
+        onScrollDown={props.onScrollDown}
+        onFocusInput={props.onFocusInput}
+        editLastMessageCounter={props.editLastMessageCounter}
+      />
+      <Banner />
+      {props.showLoader && <LoadingLine />}
+      {props.finalizeInfo
+        ? <OldProfileResetNotice />
+        : <Input
+            focusInputCounter={props.focusInputCounter}
+            onEditLastMessage={props.onEditLastMessage}
+            onScrollDown={props.onScrollDown}
+          />}
+
+      {props.sidePanelOpen && <SidePanel onToggleSidePanel={props.onToggleSidePanel} />}
+    </Box>}
   </Box>
 )
 

--- a/shared/chat/search-header.js
+++ b/shared/chat/search-header.js
@@ -15,6 +15,7 @@ import * as HocHelpers from '../searchv3/helpers'
 import {createSelector} from 'reselect'
 
 type OwnProps = {
+  clearSearchResults: () => void,
   selectedConversationIDKey: Constants.ConversationIDKey,
   searchText: string,
   onChangeSearchText: (s: string) => void,
@@ -40,7 +41,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   clearSearchResults: () => dispatch(Creators.clearSearchResults()),
   search: (term: string, service) => {
     if (term) {
-      dispatch(SearchCreators.search(term, 'chat:updateSearchResults', service))
+      dispatch(SearchCreators.search(term, 'chat:pendingSearchResults', 'chat:updateSearchResults', service))
     } else {
       dispatch(SearchCreators.searchSuggestions('chat:updateSearchResults'))
     }
@@ -91,6 +92,7 @@ export default compose(
       },
       onSelectService: (props: OwnProps & {_onSelectService: Function}) => nextService => {
         props._onSelectService(nextService)
+        props.clearSearchResults()
         props.search(props.searchText, nextService)
       },
     }

--- a/shared/chat/search.js
+++ b/shared/chat/search.js
@@ -7,19 +7,20 @@ import * as Constants from '../constants/chat'
 import UserInput from '../searchv3/user-input'
 import SearchResultsList from '../searchv3/results-list'
 import ServiceFilter from '../searchv3/services-filter'
-import {Box, Icon} from '../common-adapters'
+import {Box, Icon, ProgressIndicator} from '../common-adapters'
 import {compose, withState, defaultProps, withHandlers} from 'recompose'
 import {connect} from 'react-redux'
 import {globalStyles, globalMargins} from '../styles'
-import {chatSearchResultArray} from '../constants/selectors'
+import {chatSearchPending, chatSearchResultArray} from '../constants/selectors'
 import {onChangeSelectedSearchResultHoc, showServiceLogicHoc} from '../searchv3/helpers'
 import {createSelector} from 'reselect'
 
 const mapStateToProps = createSelector(
-  [Constants.getUserItems, chatSearchResultArray],
-  (userItems, searchResultIds) => ({
-    userItems,
+  [Constants.getUserItems, chatSearchResultArray, chatSearchPending],
+  (userItems, searchResultIds, searchPending) => ({
     searchResultIds,
+    showSearchPending: searchPending,
+    userItems,
   })
 )
 
@@ -29,7 +30,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   clearSearchResults: () => dispatch(Creators.clearSearchResults()),
   search: (term: string, service) => {
     if (term) {
-      dispatch(SearchCreators.search(term, 'chat:updateSearchResults', service))
+      dispatch(SearchCreators.search(term, 'chat:pendingSearchResults', 'chat:updateSearchResults', service))
     } else {
       dispatch(SearchCreators.searchSuggestions('chat:updateSearchResults'))
     }
@@ -71,13 +72,15 @@ const SearchHeader = props => {
         {props.showServiceFilter &&
           <ServiceFilter selectedService={props.selectedService} onSelectService={props.onSelectService} />}
       </Box>
-      <SearchResultsList
-        style={{flex: 1}}
-        items={props.searchResultIds}
-        onClick={props.onClickSearchResult}
-        onShowTracker={props.onShowTrackerInSearch}
-        selectedId={props.selectedSearchId}
-      />
+      {props.showSearchPending
+        ? <ProgressIndicator style={{width: globalMargins.xlarge}} />
+        : <SearchResultsList
+            style={{flex: 1}}
+            items={props.searchResultIds}
+            onClick={props.onClickSearchResult}
+            onShowTracker={props.onShowTrackerInSearch}
+            selectedId={props.selectedSearchId}
+          />}
     </Box>
   )
 }

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -377,6 +377,8 @@ export const StateRecord: KBRecord<T> = Record({
   editingMessage: null,
   initialConversation: null,
   inboxUntrustedState: 'unloaded',
+  previousConversation: null,
+  searchPending: false,
   searchResults: null,
   selectedUsersInSearch: List(),
   inSearch: false,
@@ -407,6 +409,8 @@ export type State = KBRecord<{
   editingMessage: ?Message,
   initialConversation: ?ConversationIDKey,
   inboxUntrustedState: UntrustedState,
+  previousConversation: ?ConversationIDKey,
+  searchPending: boolean,
   searchResults: ?List<SearchConstants.SearchResultId>,
   selectedUsersInSearch: List<SearchConstants.SearchResultId>,
   inSearch: boolean,
@@ -523,6 +527,10 @@ export type SetInboxUntrustedState = NoErrorTypedAction<
 >
 export type SetInitialConversation = NoErrorTypedAction<
   'chat:setInitialConversation',
+  {conversationIDKey: ?ConversationIDKey}
+>
+export type SetPreviousConversation = NoErrorTypedAction<
+  'chat:setPreviousConversation',
   {conversationIDKey: ?ConversationIDKey}
 >
 export type SetLoaded = NoErrorTypedAction<

--- a/shared/constants/profile.js
+++ b/shared/constants/profile.js
@@ -37,6 +37,7 @@ export type State = {
   username: string,
   usernameValid: boolean,
   waiting: boolean,
+  searchPending: boolean,
   searchResults: ?List<SearchConstants.SearchResultId>,
 }
 
@@ -129,11 +130,13 @@ export type UpdateUsername = TypedAction<'profile:updateUsername', {username: st
 export type Waiting = TypedAction<'profile:waiting', {waiting: boolean}, void>
 export type WaitingRevokeProof = TypedAction<'profile:revoke:waiting', {waiting: boolean}, void>
 
+export type PendingSearch = SearchConstants.PendingSearchGeneric<'profile:searchPending'>
 export type UpdateSearchResults = SearchConstants.UpdateSearchResultsGeneric<'profile:updateSearchResults'>
 
 export type Actions =
   | CleanupUsername
   | FinishRevokeProof
+  | PendingSearch
   | UpdateErrorText
   | UpdatePlatform
   | UpdateProofStatus

--- a/shared/constants/searchv3.js
+++ b/shared/constants/searchv3.js
@@ -63,13 +63,15 @@ export type SearchResult = {|
 // Actions
 export type Search<TypeToFire> = NoErrorTypedAction<
   'searchv3:search',
-  {term: string, service: Service, actionTypeToFire: TypeToFire}
+  {term: string, service: Service, pendingActionTypeToFire: TypeToFire, finishedActionTypeToFire: TypeToFire}
 >
 
 export type SearchSuggestions<TypeToFire> = NoErrorTypedAction<
   'searchv3:searchSuggestions',
   {actionTypeToFire: TypeToFire, maxUsers: number}
 >
+
+export type PendingSearch<TypeToFire> = NoErrorTypedAction<TypeToFire, {pending: boolean}>
 
 export type FinishedSearch<TypeToFire> = NoErrorTypedAction<
   TypeToFire,
@@ -78,6 +80,7 @@ export type FinishedSearch<TypeToFire> = NoErrorTypedAction<
 
 // Generic so others can make their own version
 export type UpdateSearchResultsGeneric<T> = NoErrorTypedAction<T, {searchResults: List<SearchResultId>}>
+export type PendingSearchGeneric<T> = NoErrorTypedAction<T, boolean>
 
 function serviceIdToService(serviceId: string): Service {
   return {

--- a/shared/constants/selectors.js
+++ b/shared/constants/selectors.js
@@ -16,6 +16,8 @@ const searchResultSelector = ({entities: {searchResults}}: TypedState, username:
 
 const inboxSearchSelector = ({chat: {inboxSearch}}: TypedState) => inboxSearch
 
+const previousConversationSelector = ({chat: {previousConversation}}: TypedState) => previousConversation
+
 const amIFollowing = ({config: {following}}: TypedState, otherUser: string) => following[otherUser]
 const amIBeingFollowed = ({config: {followers}}: TypedState, otherUser: string) => followers[otherUser]
 
@@ -23,6 +25,8 @@ const searchResultMapSelector = createSelector(
   ({entities: {searchResults}}: TypedState) => searchResults,
   searchResults => searchResults
 )
+
+const chatSearchPending = ({chat: {searchPending}}: TypedState) => searchPending
 
 const chatSearchResultArray = createSelector(
   ({chat: {searchResults}}: TypedState) => searchResults,
@@ -42,10 +46,12 @@ export {
   amIBeingFollowed,
   amIFollowing,
   cachedSearchResults,
+  chatSearchPending,
   chatSearchResultArray,
   createShallowEqualSelector,
   inboxSearchSelector,
   loggedInSelector,
+  previousConversationSelector,
   profileSearchResultArray,
   searchResultMapSelector,
   searchResultSelector,

--- a/shared/profile/search-container.js
+++ b/shared/profile/search-container.js
@@ -24,12 +24,15 @@ type HocIntermediateProps = {
 
 const mapStateToProps = (state: TypedState) => ({
   searchResultIds: profileSearchResultArray(state),
+  showSearchPending: state.profile.searchPending,
 })
 const mapDispatchToProps = (dispatch: Dispatch, {navigateUp, onBack, onToggleSidePanel}: Props) => ({
   _clearSearchResults: () => dispatch(clearSearchResults()),
   search: (term: string, service) => {
     if (term) {
-      dispatch(SearchCreators.search(term, 'profile:updateSearchResults', service))
+      dispatch(
+        SearchCreators.search(term, 'profile:pendingSearchResults', 'profile:updateSearchResults', service)
+      )
     } else {
       dispatch(SearchCreators.searchSuggestions('profile:updateSearchResults'))
     }

--- a/shared/profile/search.desktop.js
+++ b/shared/profile/search.desktop.js
@@ -3,7 +3,7 @@ import React from 'react'
 import ServiceFilter from '../searchv3/services-filter'
 import ResultsList from '../searchv3/results-list'
 import UserInput from '../searchv3/user-input'
-import {Box, Icon, Text} from '../common-adapters'
+import {Box, Icon, ProgressIndicator, Text} from '../common-adapters'
 import {globalStyles, globalColors, globalMargins} from '../styles'
 
 import type {Props} from './search'
@@ -36,11 +36,15 @@ const Search = (props: Props) => (
         <ServiceFilter selectedService={props.selectedService} onSelectService={props.onSelectService} />
       </Box>}
     <Box style={{...styleSearchRow, ...globalStyles.scrollable, justifyContent: 'center'}}>
-      <ResultsList
-        items={props.searchResultIds}
-        onClick={props.onClick}
-        selectedId={props.selectedSearchId}
-      />
+      {props.showSearchPending
+        ? <Box style={styleSpinner}>
+            <ProgressIndicator style={{width: globalMargins.xlarge}} />
+          </Box>
+        : <ResultsList
+            items={props.searchResultIds}
+            onClick={props.onClick}
+            selectedId={props.selectedSearchId}
+          />}
     </Box>
   </Box>
 )
@@ -66,6 +70,11 @@ const styleSearchIcon = {
 const styleSearchRow = {
   ...globalStyles.flexBoxRow,
   alignItems: 'center',
+}
+
+const styleSpinner = {
+  height: 256,
+  paddingTop: globalMargins.small,
 }
 
 export default Search

--- a/shared/profile/search.native.js
+++ b/shared/profile/search.native.js
@@ -3,7 +3,7 @@ import React from 'react'
 import ServiceFilter from '../searchv3/services-filter'
 import ResultsList from '../searchv3/results-list'
 import UserInput from '../searchv3/user-input'
-import {Box, StandardScreen, Text} from '../common-adapters'
+import {Box, ProgressIndicator, StandardScreen, Text} from '../common-adapters'
 import {globalStyles, globalMargins} from '../styles'
 
 import type {Props} from './search'
@@ -30,11 +30,15 @@ const Search = (props: Props) => (
         <ServiceFilter selectedService={props.selectedService} onSelectService={props.onSelectService} />
       </Box>}
     <Box>
-      <ResultsList
-        items={props.searchResultIds}
-        onClick={props.onClick}
-        selectedId={props.selectedSearchId}
-      />
+      {props.showSearchPending
+        ? <Box style={styleSpinner}>
+            <ProgressIndicator size="large" />
+          </Box>
+        : <ResultsList
+            items={props.searchResultIds}
+            onClick={props.onClick}
+            selectedId={props.selectedSearchId}
+          />}
     </Box>
   </StandardScreen>
 )
@@ -44,6 +48,10 @@ const styleSearchFilter = {
   alignItems: 'center',
   justifyContent: 'center',
   paddingTop: globalMargins.tiny,
+}
+
+const styleSpinner = {
+  paddingTop: globalMargins.small,
 }
 
 export default Search

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -607,6 +607,9 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
     case 'chat:setInitialConversation': {
       return state.set('initialConversation', action.payload.conversationIDKey)
     }
+    case 'chat:setPreviousConversation': {
+      return state.set('previousConversation', action.payload.conversationIDKey)
+    }
     case 'chat:stageUserForSearch': {
       const {payload: {user}} = action
       if (state.selectedUsersInSearch.includes(user)) {
@@ -658,6 +661,10 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
     }
     case 'chat:exitSearch': {
       return state.set('inSearch', false)
+    }
+    case 'chat:pendingSearchResults': {
+      const {payload: {pending}} = action
+      return state.set('searchPending', pending)
     }
   }
 

--- a/shared/reducers/profile.js
+++ b/shared/reducers/profile.js
@@ -27,6 +27,7 @@ const initialState: State = {
   username: '',
   usernameValid: true,
   waiting: false,
+  searchPending: false,
   searchResults: null,
 }
 
@@ -187,6 +188,13 @@ export default function(state: State = initialState, action: Actions) {
       return {
         ...state,
         searchResults: null,
+      }
+    }
+    case 'profile:pendingSearchResults': {
+      const {payload: {pending}} = action
+      return {
+        ...state,
+        searchPending: pending,
       }
     }
   }

--- a/shared/searchv3/helpers.js
+++ b/shared/searchv3/helpers.js
@@ -46,24 +46,7 @@ type OutProps = {
 }
 */
 const clearSearchHoc = withHandlers({
-  onClearSearch: ({
-    onRemoveUser,
-    onExitSearch,
-    userItems,
-    searchText,
-    onChangeSearchText,
-    clearSearchResults,
-    search,
-  }) => () => {
-    if (userItems.length === 0 && !searchText) {
-      onExitSearch()
-    } else {
-      userItems.forEach(({id}) => onRemoveUser(id))
-      onChangeSearchText('')
-      clearSearchResults()
-      search('', 'Keybase')
-    }
-  },
+  onClearSearch: ({onExitSearch}) => () => onExitSearch(),
 })
 
 const onChangeSelectedSearchResultHoc = compose(


### PR DESCRIPTION
@keybase/react-hackers 

* Leaving search mode should 1. (if a convo got selected through search) go to this conversation 2. (if not) go to the last conversation open

This PR adds a "previousConversation" entry to the chat store, set when we click New Chat, and restored to when we leave chat search without a user group selected.

* Add spinners to show when we're waiting on new search results from the network to:
  * Desktop searchv3 from chat
  * Mobile searchv3 from chat
  * Desktop searchv3 from profile
  * Mobile searchv3 from profile

For the spinners, we were already passing an action type for the searchv3 core to call on completion (`chat:updateSearchResults` and `profile:updateSearchResults`), and now we also give the searchv3 core an action type for updates to the pending state of the search, `chat:searchPending` and `profile:searchPending` = `{true, false}`.  These store values are passed down as props.