### PR TITLE
fix test race

### DIFF
--- a/go/engine/per_user_key_background_test.go
+++ b/go/engine/per_user_key_background_test.go
@@ -140,6 +140,7 @@ func TestPerUserKeyBackgroundShutdownMiddle(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			require.FailNow(t, "channel timed out")
 		}
+		expectMeta(t, metaCh, "loop-round-complete")
 		if i < n-1 {
 			advance(arg.Settings.Interval + time.Second)
 			expectMeta(t, metaCh, "woke-interval")
@@ -259,6 +260,7 @@ func TestPerUserKeyBackgroundWork(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		require.FailNow(t, "channel timed out")
 	}
+	expectMeta(t, metaCh, "loop-round-complete")
 
 	// second run that doesn't do anything
 	advance(arg.Settings.Interval + time.Second)
@@ -271,6 +273,7 @@ func TestPerUserKeyBackgroundWork(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		require.FailNow(t, "channel timed out")
 	}
+	expectMeta(t, metaCh, "loop-round-complete")
 
 	checkPerUserKeyCount(&tc, 1)
 	checkPerUserKeyCountLocal(&tc, 1)
@@ -323,6 +326,7 @@ func TestPerUserKeyBackgroundLoginLate(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		require.FailNow(t, "channel timed out")
 	}
+	expectMeta(t, metaCh, "loop-round-complete")
 
 	t.Logf("sign up and in")
 	tc.Tp.UpgradePerUserKey = false
@@ -342,6 +346,7 @@ func TestPerUserKeyBackgroundLoginLate(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		require.FailNow(t, "channel timed out")
 	}
+	expectMeta(t, metaCh, "loop-round-complete")
 
 	checkPerUserKeyCount(&tc, 1)
 	checkPerUserKeyCountLocal(&tc, 1)

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -611,17 +611,17 @@ func MakeByte32Soft(a []byte) ([32]byte, error) {
 	return b, nil
 }
 
-// Sleep for `duration` or until `ctx` is canceled, whichever occurs first.
+// Sleep until `deadline` or until `ctx` is canceled, whichever occurs first.
 // Returns an error BUT the error is not really an error.
 // It is nil if the sleep finished, and the non-nil result of Context.Err()
-func SleepWithContext(ctx context.Context, clock clockwork.Clock, duration time.Duration) error {
+func SleepUntilWithContext(ctx context.Context, clock clockwork.Clock, deadline time.Time) error {
 	if ctx == nil {
 		// should not happen
-		clock.Sleep(duration)
+		clock.AfterTime(deadline)
 		return nil
 	}
 	select {
-	case <-clock.After(duration):
+	case <-clock.AfterTime(deadline):
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()


### PR DESCRIPTION
Use `AfterTime` to fix a race in these `PerUserKeyBackground` tests. The problem was🤞 that the testing goroutine would advance before the tested goroutine went to sleep, so the tested routine would never wake up.