### PR TITLE
Add secretless teams for subteam reader loads

### DIFF
--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -350,6 +350,8 @@ func (t *teamLookup) GetAppStatus() *AppStatus {
 }
 
 func (r *Resolver) resolveTeamViaServerLookup(ctx context.Context, au AssertionURL) (res ResolveResult) {
+	r.G().Log.CDebugf(ctx, "resolveTeamViaServerLookup")
+
 	res.queriedByTeamID = au.IsTeamID()
 	key, val, err := au.ToLookup()
 	if err != nil {

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -397,6 +397,7 @@ func (o TeamPlusApplicationKeys) DeepCopy() TeamPlusApplicationKeys {
 }
 
 type TeamData struct {
+	Secretless      bool                                                 `codec:"secretless" json:"secretless"`
 	Chain           TeamSigChainState                                    `codec:"chain" json:"chain"`
 	PerTeamKeySeeds map[PerTeamKeyGeneration]PerTeamKeySeedItem          `codec:"perTeamKeySeeds" json:"perTeamKeySeeds"`
 	ReaderKeyMasks  map[TeamApplication]map[PerTeamKeyGeneration]MaskB64 `codec:"readerKeyMasks" json:"readerKeyMasks"`
@@ -405,7 +406,8 @@ type TeamData struct {
 
 func (o TeamData) DeepCopy() TeamData {
 	return TeamData{
-		Chain: o.Chain.DeepCopy(),
+		Secretless: o.Secretless,
+		Chain:      o.Chain.DeepCopy(),
 		PerTeamKeySeeds: (func(x map[PerTeamKeyGeneration]PerTeamKeySeedItem) map[PerTeamKeyGeneration]PerTeamKeySeedItem {
 			ret := make(map[PerTeamKeyGeneration]PerTeamKeySeedItem)
 			for k, v := range x {

--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -31,6 +31,9 @@ type rawTeam struct {
 	Box            *TeamBox                                               `json:"box"`
 	Prevs          map[keybase1.PerTeamKeyGeneration]prevKeySealedEncoded `json:"prevs"`
 	ReaderKeyMasks []keybase1.ReaderKeyMask                               `json:"reader_key_masks"`
+	// Whether the user is only being allowed to view the chain
+	// because they are a member of a descendent team.
+	SubteamReader bool `json:"subteam_reader"`
 }
 
 func (r *rawTeam) GetAppStatus() *libkb.AppStatus {

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -19,7 +19,7 @@ import (
 // Does not ask for any links above state's seqno, those will be fetched by getNewLinksFromServer.
 func (l *TeamLoader) fillInStubbedLinks(ctx context.Context,
 	me keybase1.UserVersion, teamID keybase1.TeamID, state *keybase1.TeamData,
-	needSeqnos []keybase1.Seqno,
+	needSeqnos []keybase1.Seqno, readSubteamID keybase1.TeamID,
 	proofSet *proofSetT, parentChildOperations []*parentChildOperation) (
 	*keybase1.TeamData, *proofSetT, []*parentChildOperation, error) {
 
@@ -41,7 +41,7 @@ func (l *TeamLoader) fillInStubbedLinks(ctx context.Context,
 		return state, proofSet, parentChildOperations, nil
 	}
 
-	teamUpdate, err := l.getLinksFromServer(ctx, state.Chain.Id, requestSeqnos)
+	teamUpdate, err := l.getLinksFromServer(ctx, state.Chain.Id, requestSeqnos, &readSubteamID)
 	if err != nil {
 		return state, proofSet, parentChildOperations, err
 	}
@@ -57,7 +57,7 @@ func (l *TeamLoader) fillInStubbedLinks(ctx context.Context,
 		}
 
 		var signer *keybase1.UserVersion
-		signer, proofSet, err = l.verifyLink(ctx, teamID, state, link, proofSet)
+		signer, proofSet, err = l.verifyLink(ctx, teamID, state, link, readSubteamID, proofSet)
 		if err != nil {
 			return state, proofSet, parentChildOperations, err
 		}
@@ -86,7 +86,8 @@ func (l *TeamLoader) fillInStubbedLinks(ctx context.Context,
 
 // Get new links from the server.
 func (l *TeamLoader) getNewLinksFromServer(ctx context.Context,
-	teamID keybase1.TeamID, lowSeqno keybase1.Seqno, lowGen keybase1.PerTeamKeyGeneration) (*rawTeam, error) {
+	teamID keybase1.TeamID, lowSeqno keybase1.Seqno, lowGen keybase1.PerTeamKeyGeneration,
+	readSubteamID *keybase1.TeamID) (*rawTeam, error) {
 
 	arg := libkb.NewRetryAPIArg("team/get")
 	arg.NetContext = ctx
@@ -95,6 +96,9 @@ func (l *TeamLoader) getNewLinksFromServer(ctx context.Context,
 		"id":               libkb.S{Val: teamID.String()},
 		"low":              libkb.I{Val: int(lowSeqno)},
 		"per_team_key_low": libkb.I{Val: int(lowGen)},
+	}
+	if readSubteamID != nil {
+		arg.Args["read_subteam_id"] = libkb.S{Val: readSubteamID.String()}
 	}
 
 	var rt rawTeam
@@ -110,7 +114,7 @@ func (l *TeamLoader) getNewLinksFromServer(ctx context.Context,
 // Get full links from the server.
 // Does not guarantee that the server returned the correct links, nor that they are unstubbed.
 func (l *TeamLoader) getLinksFromServer(ctx context.Context,
-	teamID keybase1.TeamID, requestSeqnos []keybase1.Seqno) (*rawTeam, error) {
+	teamID keybase1.TeamID, requestSeqnos []keybase1.Seqno, readSubteamID *keybase1.TeamID) (*rawTeam, error) {
 
 	var seqnoStrs []string
 	for _, seqno := range requestSeqnos {
@@ -124,6 +128,9 @@ func (l *TeamLoader) getLinksFromServer(ctx context.Context,
 	arg.Args = libkb.HTTPArgs{
 		"id":     libkb.S{Val: teamID.String()},
 		"seqnos": libkb.S{Val: seqnoCommas},
+	}
+	if readSubteamID != nil {
+		arg.Args["read_subteam_id"] = libkb.S{Val: readSubteamID.String()}
 	}
 
 	var rt rawTeam
@@ -141,9 +148,14 @@ func (l *TeamLoader) checkStubbed(ctx context.Context, arg load2ArgT, link *chai
 	if !link.isStubbed() {
 		return nil
 	}
-	if l.seqnosContains(arg.needSeqnos, link.Seqno()) || arg.needAdmin ||
-		!link.outerLink.LinkType.TeamAllowStubWithAdminFlag(arg.needAdmin) {
-		return NewStubbedError(link)
+	if l.seqnosContains(arg.needSeqnos, link.Seqno()) {
+		return NewStubbedErrorWithNote(link, "need seqno")
+	}
+	if arg.needAdmin {
+		return NewStubbedErrorWithNote(link, "need admin")
+	}
+	if !link.outerLink.LinkType.TeamAllowStubWithAdminFlag(arg.needAdmin) {
+		return NewStubbedErrorWithNote(link, "disallowed")
 	}
 	return nil
 }
@@ -198,8 +210,9 @@ func addProofsForKeyInUserSigchain(teamID keybase1.TeamID, teamLinkMap map[keyba
 // - Apply the link nor modify state
 // - Check the rest of the format of the inner link
 // Returns the signer, or nil if the link was stubbed
-func (l *TeamLoader) verifyLink(ctx context.Context, teamID keybase1.TeamID,
-	state *keybase1.TeamData, link *chainLinkUnpacked, proofSet *proofSetT) (*keybase1.UserVersion, *proofSetT, error) {
+func (l *TeamLoader) verifyLink(ctx context.Context,
+	teamID keybase1.TeamID, state *keybase1.TeamData, link *chainLinkUnpacked,
+	readSubteamID keybase1.TeamID, proofSet *proofSetT) (*keybase1.UserVersion, *proofSetT, error) {
 
 	if link.isStubbed() {
 		return nil, proofSet, nil
@@ -243,7 +256,7 @@ func (l *TeamLoader) verifyLink(ctx context.Context, teamID keybase1.TeamID,
 	}
 
 	if link.outerLink.LinkType.RequiresAdminPermission() {
-		proofSet, err = l.verifyAdminPermissions(ctx, state, link, user.ToUserVersion(), proofSet)
+		proofSet, err = l.verifyAdminPermissions(ctx, state, link, readSubteamID, user.ToUserVersion(), proofSet)
 	} else {
 		err = l.verifyWriterOrReaderPermissions(ctx, state, link, user.ToUserVersion())
 	}
@@ -256,7 +269,11 @@ func (l *TeamLoader) verifyWriterOrReaderPermissions(ctx context.Context,
 	return (TeamSigChainState{state.Chain}).AssertWasReaderAt(uv, link.SigChainLocation())
 }
 
-func (l *TeamLoader) walkUpToAdmin(ctx context.Context, team *keybase1.TeamData, uv keybase1.UserVersion, admin SCTeamAdmin) (ret *keybase1.TeamData, err error) {
+// Does not return a full TeamData because it might get a subteam-reader version.
+func (l *TeamLoader) walkUpToAdmin(
+	ctx context.Context, team *keybase1.TeamData, readSubteamID keybase1.TeamID,
+	uv keybase1.UserVersion, admin SCTeamAdmin) (*TeamSigChainState, error) {
+
 	target, err := admin.TeamID.ToTeamID()
 	if err != nil {
 		return nil, err
@@ -267,7 +284,12 @@ func (l *TeamLoader) walkUpToAdmin(ctx context.Context, team *keybase1.TeamData,
 		if parent == nil {
 			return nil, NewAdminNotFoundError(admin)
 		}
-		arg := load2ArgT{teamID: *parent, me: uv, staleOK: true}
+		arg := load2ArgT{
+			teamID:        *parent,
+			me:            uv,
+			staleOK:       true,
+			readSubteamID: &readSubteamID,
+		}
 		if target.Eq(*parent) {
 			arg.needSeqnos = []keybase1.Seqno{admin.Seqno}
 		}
@@ -276,7 +298,10 @@ func (l *TeamLoader) walkUpToAdmin(ctx context.Context, team *keybase1.TeamData,
 			return nil, err
 		}
 	}
-	return team, nil
+	if team == nil {
+		return nil, fmt.Errorf("teamloader fault: nil team after admin walk")
+	}
+	return &TeamSigChainState{inner: team.Chain}, nil
 }
 
 func addProofsForAdminPermission(t keybase1.TeamSigChainState, link *chainLinkUnpacked, bookends proofTermBookends, proofSet *proofSetT) *proofSetT {
@@ -291,7 +316,8 @@ func addProofsForAdminPermission(t keybase1.TeamSigChainState, link *chainLinkUn
 }
 
 func (l *TeamLoader) verifyAdminPermissions(ctx context.Context,
-	state *keybase1.TeamData, link *chainLinkUnpacked, uv keybase1.UserVersion, proofSet *proofSetT) (*proofSetT, error) {
+	state *keybase1.TeamData, link *chainLinkUnpacked, readSubteamID keybase1.TeamID,
+	uv keybase1.UserVersion, proofSet *proofSetT) (*proofSetT, error) {
 
 	explicitAdmin := link.inner.TeamAdmin()
 
@@ -304,11 +330,11 @@ func (l *TeamLoader) verifyAdminPermissions(ctx context.Context,
 
 	// The more complicated case is that there's an explicit admin permssion given, perhaps
 	// of a parent team.
-	adminTeam, err := l.walkUpToAdmin(ctx, state, uv, *explicitAdmin)
+	adminTeam, err := l.walkUpToAdmin(ctx, state, readSubteamID, uv, *explicitAdmin)
 	if err != nil {
 		return proofSet, err
 	}
-	adminBookends, err := (TeamSigChainState{inner: adminTeam.Chain}).AssertBecameAdminAt(uv, explicitAdmin.SigChainLocation())
+	adminBookends, err := adminTeam.AssertBecameAdminAt(uv, explicitAdmin.SigChainLocation())
 	if err != nil {
 		return proofSet, err
 	}
@@ -444,7 +470,7 @@ func (l *TeamLoader) inflateLink(ctx context.Context,
 
 // Check that the parent-child operations appear in the parent sigchains.
 func (l *TeamLoader) checkParentChildOperations(ctx context.Context,
-	me keybase1.UserVersion, parentID *keybase1.TeamID,
+	me keybase1.UserVersion, parentID *keybase1.TeamID, readSubteamID keybase1.TeamID,
 	parentChildOperations []*parentChildOperation) error {
 
 	if len(parentChildOperations) == 0 {
@@ -469,7 +495,8 @@ func (l *TeamLoader) checkParentChildOperations(ctx context.Context,
 		forceRepoll:       false,
 		staleOK:           true, // stale is fine, as long as get those seqnos.
 
-		needSeqnos: needParentSeqnos,
+		needSeqnos:    needParentSeqnos,
+		readSubteamID: &readSubteamID,
 
 		me: me,
 	})

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -377,8 +377,6 @@ func TestLoaderFillStubbed(t *testing.T) {
 // Test loading a team and when not a member of the parent.
 // User loads a team T1.T2 but has never been a member of T1.
 func TestLoaderNotInParent(t *testing.T) {
-	t.Skip("TODO: awaiting non-member parent read")
-
 	fus, tcs, cleanup := setupNTests(t, 2)
 	defer cleanup()
 
@@ -402,11 +400,9 @@ func TestLoaderNotInParent(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// Test loading a sub-sub-team.
-// When not a member of the ancestors.
+// Test loading a sub-sub-team: a.b.c.
+// When not a member of the ancestors: a, a.b.
 func TestLoaderMultilevel(t *testing.T) {
-	t.Skip("TODO: awaiting non-member parent read")
-
 	fus, tcs, cleanup := setupNTests(t, 2)
 	defer cleanup()
 
@@ -414,16 +410,16 @@ func TestLoaderMultilevel(t *testing.T) {
 	parentName, _ := createTeam2(*tcs[0])
 
 	t.Logf("create a subteam")
-	subteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "abc", parentName)
+	_, err := CreateSubteam(context.TODO(), tcs[0].G, "abc", parentName)
 	require.NoError(t, err)
 
 	t.Logf("create a sub-subteam")
-	subsubteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "def", parentName)
+	subTeamName, err := parentName.Append("abc")
+	require.NoError(t, err)
+	subsubteamID, err := CreateSubteam(context.TODO(), tcs[0].G, "def", subTeamName)
 	require.NoError(t, err)
 
-	expectedSubsubTeamName, err := parentName.Append("abc")
-	require.NoError(t, err)
-	expectedSubsubTeamName, err = parentName.Append("def")
+	expectedSubsubTeamName, err := subTeamName.Append("def")
 	require.NoError(t, err)
 
 	t.Logf("add the other user to the subsubteam")
@@ -435,7 +431,6 @@ func TestLoaderMultilevel(t *testing.T) {
 		ID: *subsubteamID,
 	})
 	require.NoError(t, err)
-	require.Equal(t, team.Chain.Id, *subteamID)
+	require.Equal(t, *subsubteamID, team.Chain.Id)
 	require.Equal(t, expectedSubsubTeamName, TeamSigChainState{inner: team.Chain}.GetName())
-	require.Equal(t, subteamID, *team.Chain.ParentID)
 }

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -113,6 +113,9 @@ protocol teams {
 
   // Snapshot of a loaded team.
   record TeamData {
+    // Whether this snapshot is entirely missing secrets.
+    boolean secretless;
+
     TeamSigChainState chain;
     // generation -> seed
     map<PerTeamKeyGeneration,PerTeamKeySeedItem> perTeamKeySeeds;

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5948,6 +5948,7 @@ export type TeamChangeSet = {
 }
 
 export type TeamData = {
+  secretless: boolean,
   chain: TeamSigChainState,
   perTeamKeySeeds: {[key: string]: PerTeamKeySeedItem},
   readerKeyMasks: {[key: string]: {[key: string]: MaskB64}},

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -339,6 +339,10 @@
       "name": "TeamData",
       "fields": [
         {
+          "type": "boolean",
+          "name": "secretless"
+        },
+        {
           "type": "TeamSigChainState",
           "name": "chain"
         },

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5948,6 +5948,7 @@ export type TeamChangeSet = {
 }
 
 export type TeamData = {
+  secretless: boolean,
   chain: TeamSigChainState,
   perTeamKeySeeds: {[key: string]: PerTeamKeySeedItem},
   readerKeyMasks: {[key: string]: {[key: string]: MaskB64}},


### PR DESCRIPTION
Requires server-side https://github.com/keybase/keybase/pull/1448

Add the ability to read a subteam when you are not a member of the parent team. Enable those two tests `TestLoaderNotInParent` and `TestLoaderMultilevel`.

The way this works is if you're loading a team for the sake of loading its subteam then there is a chance you'll get a 'secretless' team which just skips `addSecrets` so its `perTeamKeySeeds` and `readerKeyMasks` are blank forever. Those can get cached, but they never get returned from `Load/load1`.