### PR TITLE
better notifications for joining/leaving conversations, and maintain user list for channels CORE-5577

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	"strings"
 
@@ -1031,6 +1032,10 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 			conversationLocal.Info.WriterNames = append(conversationLocal.Info.WriterNames,
 				uname.String())
 		}
+		// Sort alphabetically
+		sort.Slice(conversationLocal.Info.WriterNames, func(i, j int) bool {
+			return conversationLocal.Info.WriterNames[i] < conversationLocal.Info.WriterNames[j]
+		})
 	case chat1.ConversationMembersType_KBFS:
 		var err error
 		conversationLocal.Info.WriterNames, conversationLocal.Info.ReaderNames, err = utils.ReorderParticipants(

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -611,8 +611,14 @@ func (g *PushHandler) MembershipUpdate(ctx context.Context, m gregor.OutOfBandMe
 		}()
 
 		// Write out changes to local storage
-		if err = g.G().InboxSource.MembershipUpdate(ctx, uid, update.InboxVers, update.Joined,
-			update.Removed); err != nil {
+		var joined, removed []chat1.ConversationID
+		for _, cm := range update.Joined {
+			joined = append(joined, cm.ConvID)
+		}
+		for _, cm := range update.Removed {
+			removed = append(removed, cm.ConvID)
+		}
+		if err = g.G().InboxSource.MembershipUpdate(ctx, uid, update.InboxVers, joined, removed); err != nil {
 			g.Debug(ctx, "MembershipUpdate: failed to update membership on inbox: %s", err.Error())
 			return err
 		}

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -111,6 +111,14 @@ func (n *chatListener) NewChatActivity(uid keybase1.UID, activity chat1.ChatActi
 	}
 }
 
+func (n *chatListener) ChatJoinedConversation(uid keybase1.UID, conv chat1.ConversationLocal) {
+
+}
+
+func (n *chatListener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID) {
+
+}
+
 func newConvTriple(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext, username string) chat1.ConversationIDTriple {
 	nameInfo, err := CtxKeyFinder(ctx, tc.Context()).Find(ctx, username,
 		chat1.ConversationMembersType_KBFS, false)

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -951,14 +951,15 @@ func (i *Inbox) Sync(ctx context.Context, vers chat1.InboxVers, convs []chat1.Co
 	return nil
 }
 
-func (i *Inbox) MembershipUpdate(ctx context.Context, vers chat1.InboxVers, joined []chat1.Conversation,
-	removed []chat1.ConversationID) (err Error) {
+func (i *Inbox) MembershipUpdate(ctx context.Context, vers chat1.InboxVers,
+	userJoined []chat1.Conversation, userRemoved []chat1.ConversationID,
+	othersJoined []chat1.ConversationMember, othersRemoved []chat1.ConversationMember) (err Error) {
 	locks.Inbox.Lock()
 	defer locks.Inbox.Unlock()
 	defer i.Trace(ctx, func() error { return err }, "MembershipUpdate")()
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
 
-	i.Debug(ctx, "MembershipUpdate: updating joined: %d removed: %d", len(joined), len(removed))
+	i.Debug(ctx, "MembershipUpdate: updating userJoined: %d userRemoved: %d othersJoined: %d othersRemoved: %d", len(userJoined), len(userRemoved), len(othersJoined), len(othersRemoved))
 	ibox, err := i.readDiskInbox(ctx)
 	if err != nil {
 		if _, ok := err.(MissError); ok {
@@ -967,9 +968,10 @@ func (i *Inbox) MembershipUpdate(ctx context.Context, vers chat1.InboxVers, join
 		return err
 	}
 
-	convs := i.mergeConvs(ibox.Conversations, joined)
+	// Process our own changes
+	convs := i.mergeConvs(ibox.Conversations, userJoined)
 	removedMap := make(map[string]bool)
-	for _, r := range removed {
+	for _, r := range userRemoved {
 		removedMap[r.String()] = true
 	}
 	ibox.Conversations = nil
@@ -979,8 +981,30 @@ func (i *Inbox) MembershipUpdate(ctx context.Context, vers chat1.InboxVers, join
 		}
 	}
 	sort.Sort(ByDatabaseOrder(ibox.Conversations))
-	ibox.InboxVersion = vers
 
+	// Update all lists with other people joining and leaving
+	convMap := make(map[string]*chat1.Conversation)
+	for _, c := range ibox.Conversations {
+		convMap[c.GetConvID().String()] = &c
+	}
+	for _, oj := range othersJoined {
+		if cp, ok := convMap[oj.ConvID.String()]; ok {
+			cp.Metadata.AllList = append(cp.Metadata.AllList, oj.Uid)
+		}
+	}
+	for _, or := range othersRemoved {
+		if cp, ok := convMap[or.ConvID.String()]; ok {
+			var newAllList []gregor1.UID
+			for _, u := range cp.Metadata.AllList {
+				if !u.Eq(or.Uid) {
+					newAllList = append(newAllList, u)
+				}
+			}
+			cp.Metadata.AllList = newAllList
+		}
+	}
+
+	ibox.InboxVersion = vers
 	if err = i.writeDiskInbox(ctx, ibox); err != nil {
 		return err
 	}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -984,8 +984,8 @@ func (i *Inbox) MembershipUpdate(ctx context.Context, vers chat1.InboxVers,
 
 	// Update all lists with other people joining and leaving
 	convMap := make(map[string]*chat1.Conversation)
-	for _, c := range ibox.Conversations {
-		convMap[c.GetConvID().String()] = &c
+	for index, c := range ibox.Conversations {
+		convMap[c.GetConvID().String()] = &ibox.Conversations[index]
 	}
 	for _, oj := range othersJoined {
 		if cp, ok := convMap[oj.ConvID.String()]; ok {

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -712,24 +712,48 @@ func TestInboxServerVersion(t *testing.T) {
 }
 
 func TestMembershipUpdate(t *testing.T) {
-	_, inbox, _ := setupInboxTest(t, "membership")
+	ctc, inbox, uid := setupInboxTest(t, "membership")
+
+	u2, err := kbtest.CreateAndSignupFakeUser("ib", ctc.G)
+	require.NoError(t, err)
+	uid2 := gregor1.UID(u2.User.GetUID().ToBytes())
+
+	u3, err := kbtest.CreateAndSignupFakeUser("ib", ctc.G)
+	require.NoError(t, err)
+	uid3 := gregor1.UID(u3.User.GetUID().ToBytes())
+
+	t.Logf("uid: %s uid2: %s uid3: %s", uid, uid2, uid3)
 
 	// Create an inbox with a bunch of convos, merge it and read it back out
 	numConvs := 10
 	var convs []chat1.Conversation
 	for i := numConvs - 1; i >= 0; i-- {
-		convs = append(convs, makeConvo(gregor1.Time(i), 1, 1))
+		conv := makeConvo(gregor1.Time(i), 1, 1)
+		conv.Metadata.AllList = []gregor1.UID{uid, uid3}
+		convs = append(convs, conv)
 	}
 
 	require.NoError(t, inbox.Merge(context.TODO(), 1, convs, nil, nil))
 	var joinedConvs []chat1.Conversation
 	numJoinedConvs := 5
 	for i := 0; i < numJoinedConvs; i++ {
-		joinedConvs = append(joinedConvs, makeConvo(gregor1.Time(i), 1, 1))
+		conv := makeConvo(gregor1.Time(i), 1, 1)
+		conv.Metadata.AllList = []gregor1.UID{uid, uid3}
+		joinedConvs = append(joinedConvs, conv)
 	}
 
+	otherJoinConvID := convs[0].GetConvID()
+	otherJoinedConvs := []chat1.ConversationMember{chat1.ConversationMember{
+		Uid:    uid2,
+		ConvID: otherJoinConvID,
+	}}
+	otherRemovedConvID := convs[1].GetConvID()
+	otherRemovedConvs := []chat1.ConversationMember{chat1.ConversationMember{
+		Uid:    uid3,
+		ConvID: otherRemovedConvID,
+	}}
 	require.NoError(t, inbox.MembershipUpdate(context.TODO(), 2, joinedConvs,
-		[]chat1.ConversationID{convs[5].GetConvID()}))
+		[]chat1.ConversationID{convs[5].GetConvID()}, otherJoinedConvs, otherRemovedConvs))
 
 	vers, res, err := inbox.ReadAll(context.TODO())
 	require.NoError(t, err)
@@ -743,5 +767,18 @@ func TestMembershipUpdate(t *testing.T) {
 	sort.Sort(utils.ConvByConvID(expected))
 	sort.Sort(utils.ConvByConvID(res))
 	require.Equal(t, len(expected), len(res))
-	require.Equal(t, expected, res)
+	for i := 0; i < len(res); i++ {
+		if res[i].GetConvID().Eq(otherJoinConvID) {
+			allUsers := []gregor1.UID{uid, uid2, uid3}
+			sort.Sort(chat1.ByUID(res[i].Metadata.AllList))
+			sort.Sort(chat1.ByUID(allUsers))
+			require.Equal(t, allUsers, res[i].Metadata.AllList)
+		} else if res[i].GetConvID().Eq(otherRemovedConvID) {
+			allUsers := []gregor1.UID{uid}
+			sort.Sort(chat1.ByUID(res[i].Metadata.AllList))
+			require.Equal(t, allUsers, res[i].Metadata.AllList)
+		} else {
+			require.Equal(t, expected[i], res[i])
+		}
+	}
 }

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -768,16 +768,19 @@ func TestMembershipUpdate(t *testing.T) {
 	sort.Sort(utils.ConvByConvID(res))
 	require.Equal(t, len(expected), len(res))
 	for i := 0; i < len(res); i++ {
+		sort.Sort(chat1.ByUID(res[i].Metadata.AllList))
+		sort.Sort(chat1.ByUID(expected[i].Metadata.AllList))
 		if res[i].GetConvID().Eq(otherJoinConvID) {
 			allUsers := []gregor1.UID{uid, uid2, uid3}
-			sort.Sort(chat1.ByUID(res[i].Metadata.AllList))
 			sort.Sort(chat1.ByUID(allUsers))
 			require.Equal(t, allUsers, res[i].Metadata.AllList)
 		} else if res[i].GetConvID().Eq(otherRemovedConvID) {
 			allUsers := []gregor1.UID{uid}
-			sort.Sort(chat1.ByUID(res[i].Metadata.AllList))
 			require.Equal(t, allUsers, res[i].Metadata.AllList)
 		} else {
+			allUsers := []gregor1.UID{uid, uid3}
+			sort.Sort(chat1.ByUID(allUsers))
+			require.Equal(t, allUsers, res[i].Metadata.AllList)
 			require.Equal(t, expected[i], res[i])
 		}
 	}

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -81,7 +81,7 @@ type InboxSource interface {
 	TlfFinalize(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 		convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) ([]chat1.ConversationLocal, error)
 	MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
-		joinedConvs []chat1.ConversationID, removedConvs []chat1.ConversationID) error
+		joined []chat1.ConversationMember, removed []chat1.ConversationMember) (MembershipUpdateRes, error)
 
 	GetInboxQueryLocalToRemote(ctx context.Context,
 		lquery *chat1.GetInboxLocalQuery) (*chat1.GetInboxQuery, NameInfo, error)

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -11,3 +11,10 @@ type NameInfo struct {
 	IdentifyFailures []keybase1.TLFIdentifyFailure
 	CryptKeys        []CryptKey
 }
+
+type MembershipUpdateRes struct {
+	UserJoinedConvs    []chat1.ConversationLocal
+	UserRemovedConvs   []chat1.ConversationID
+	OthersJoinedConvs  []chat1.ConversationMember
+	OthersRemovedConvs []chat1.ConversationMember
+}

--- a/go/client/cmd_chat.go
+++ b/go/client/cmd_chat.go
@@ -22,6 +22,7 @@ func NewCmdChat(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 			newCmdChatLeaveChannel(cl, g),
 			newCmdChatList(cl, g),
 			newCmdChatListChannels(cl, g),
+			newCmdChatListMembers(cl, g),
 			newCmdChatListUnread(cl, g),
 			newCmdChatMute(cl, g),
 			newCmdChatRead(cl, g),

--- a/go/client/cmd_chat_listmembers.go
+++ b/go/client/cmd_chat_listmembers.go
@@ -1,0 +1,102 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type CmdChatListMembers struct {
+	libkb.Contextified
+
+	tlfName, topicName string
+	topicType          chat1.TopicType
+	membersType        chat1.ConversationMembersType
+}
+
+func NewCmdChatListMembersRunner(g *libkb.GlobalContext) *CmdChatListMembers {
+	return &CmdChatListMembers{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func newCmdChatListMembers(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "list-members",
+		Usage:        "List members of a chat channel (must be a member of that channel)",
+		ArgumentHelp: "<channel name>",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdChatListMembersRunner(g), "list-members", c)
+		},
+		Flags: mustGetChatFlags("topic-type", "team"),
+	}
+}
+
+func (c *CmdChatListMembers) Run() error {
+	ui := c.G().UI.GetTerminalUI()
+	chatClient, err := GetChatLocalClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	inboxRes, err := chatClient.GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
+		Query: &chat1.GetInboxLocalQuery{
+			Name: &chat1.NameQuery{
+				Name:        c.tlfName,
+				MembersType: c.membersType,
+			},
+			TopicName: &c.topicName,
+			TopicType: &c.topicType,
+		},
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+	})
+	if err != nil {
+		return err
+	}
+	if len(inboxRes.Conversations) == 0 {
+		return fmt.Errorf("failed to find any matching conversation")
+	}
+	if len(inboxRes.Conversations) > 1 {
+		return fmt.Errorf("ambiguous channel description, more than one conversation matches")
+	}
+
+	ui.Printf("Listing members in %s [%s]:\n\n", c.tlfName, c.topicName)
+	for _, memb := range inboxRes.Conversations[0].Info.WriterNames {
+		ui.Printf("%s\n", memb)
+	}
+
+	return nil
+}
+
+func (c *CmdChatListMembers) ParseArgv(ctx *cli.Context) (err error) {
+	if len(ctx.Args()) != 2 {
+		cli.ShowCommandHelp(ctx, "list-members")
+		return fmt.Errorf("Incorrect usage.")
+	}
+
+	c.tlfName = ctx.Args().Get(0)
+	c.topicName = ctx.Args().Get(1)
+	if c.topicType, err = parseConversationTopicType(ctx); err != nil {
+		return err
+	}
+	if ctx.Bool("team") {
+		c.membersType = chat1.ConversationMembersType_TEAM
+	} else {
+		c.membersType = chat1.ConversationMembersType_KBFS
+	}
+
+	return nil
+}
+
+func (c *CmdChatListMembers) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/cmd_chat_listmembers.go
+++ b/go/client/cmd_chat_listmembers.go
@@ -16,7 +16,6 @@ type CmdChatListMembers struct {
 
 	tlfName, topicName string
 	topicType          chat1.TopicType
-	membersType        chat1.ConversationMembersType
 }
 
 func NewCmdChatListMembersRunner(g *libkb.GlobalContext) *CmdChatListMembers {
@@ -33,7 +32,7 @@ func newCmdChatListMembers(cl *libcmdline.CommandLine, g *libkb.GlobalContext) c
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatListMembersRunner(g), "list-members", c)
 		},
-		Flags: mustGetChatFlags("topic-type", "team"),
+		Flags: mustGetChatFlags("topic-type"),
 	}
 }
 
@@ -49,7 +48,7 @@ func (c *CmdChatListMembers) Run() error {
 		Query: &chat1.GetInboxLocalQuery{
 			Name: &chat1.NameQuery{
 				Name:        c.tlfName,
-				MembersType: c.membersType,
+				MembersType: chat1.ConversationMembersType_TEAM,
 			},
 			TopicName: &c.topicName,
 			TopicType: &c.topicType,
@@ -85,12 +84,6 @@ func (c *CmdChatListMembers) ParseArgv(ctx *cli.Context) (err error) {
 	if c.topicType, err = parseConversationTopicType(ctx); err != nil {
 		return err
 	}
-	if ctx.Bool("team") {
-		c.membersType = chat1.ConversationMembersType_TEAM
-	} else {
-		c.membersType = chat1.ConversationMembersType_KBFS
-	}
-
 	return nil
 }
 

--- a/go/engine/paperkey_submit_test.go
+++ b/go/engine/paperkey_submit_test.go
@@ -110,7 +110,9 @@ func (n *nlistener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationI
 }
 func (n *nlistener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationResolveInfo) {
 }
-func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                {}
-func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {}
-func (n *nlistener) ChatTypingUpdate(updates []chat1.ConvTypingUpdate)              {}
-func (n *nlistener) TeamKeyRotated(teamID keybase1.TeamID, teamName string)         {}
+func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                       {}
+func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID)        {}
+func (n *nlistener) ChatTypingUpdate(updates []chat1.ConvTypingUpdate)                     {}
+func (n *nlistener) ChatJoinedConversation(uid keybase1.UID, conv chat1.ConversationLocal) {}
+func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID)    {}
+func (n *nlistener) TeamKeyRotated(teamID keybase1.TeamID, teamName string)                {}

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -462,6 +462,7 @@ type ConversationMetadata struct {
 	Supersedes     []ConversationMetadata    `codec:"supersedes" json:"supersedes"`
 	SupersededBy   []ConversationMetadata    `codec:"supersededBy" json:"supersededBy"`
 	ActiveList     []gregor1.UID             `codec:"activeList" json:"activeList"`
+	AllList        []gregor1.UID             `codec:"allList" json:"allList"`
 }
 
 func (o ConversationMetadata) DeepCopy() ConversationMetadata {
@@ -502,6 +503,14 @@ func (o ConversationMetadata) DeepCopy() ConversationMetadata {
 			}
 			return ret
 		})(o.ActiveList),
+		AllList: (func(x []gregor1.UID) []gregor1.UID {
+			var ret []gregor1.UID
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.AllList),
 	}
 }
 

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -222,6 +222,18 @@ func (e ConversationStatus) String() string {
 	return ""
 }
 
+type ConversationMember struct {
+	Uid    gregor1.UID    `codec:"uid" json:"uid"`
+	ConvID ConversationID `codec:"convID" json:"convID"`
+}
+
+func (o ConversationMember) DeepCopy() ConversationMember {
+	return ConversationMember{
+		Uid:    o.Uid.DeepCopy(),
+		ConvID: o.ConvID.DeepCopy(),
+	}
+}
+
 type ConversationMemberStatus int
 
 const (

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -12,6 +12,14 @@ import (
 	"github.com/keybase/client/go/protocol/gregor1"
 )
 
+type ByUID []gregor1.UID
+
+func (b ByUID) Len() int      { return len(b) }
+func (b ByUID) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b ByUID) Less(i, j int) bool {
+	return bytes.Compare(b[i].Bytes(), b[j].Bytes()) < 0
+}
+
 // Eq compares two TLFIDs
 func (id TLFID) Eq(other TLFID) bool {
 	return bytes.Equal([]byte(id), []byte(other))

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -178,24 +178,24 @@ func (o RemoteUserTypingUpdate) DeepCopy() RemoteUserTypingUpdate {
 }
 
 type UpdateConversationMembership struct {
-	InboxVers InboxVers        `codec:"inboxVers" json:"inboxVers"`
-	Joined    []ConversationID `codec:"joined" json:"joined"`
-	Removed   []ConversationID `codec:"removed" json:"removed"`
+	InboxVers InboxVers            `codec:"inboxVers" json:"inboxVers"`
+	Joined    []ConversationMember `codec:"joined" json:"joined"`
+	Removed   []ConversationMember `codec:"removed" json:"removed"`
 }
 
 func (o UpdateConversationMembership) DeepCopy() UpdateConversationMembership {
 	return UpdateConversationMembership{
 		InboxVers: o.InboxVers.DeepCopy(),
-		Joined: (func(x []ConversationID) []ConversationID {
-			var ret []ConversationID
+		Joined: (func(x []ConversationMember) []ConversationMember {
+			var ret []ConversationMember
 			for _, v := range x {
 				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret
 		})(o.Joined),
-		Removed: (func(x []ConversationID) []ConversationID {
-			var ret []ConversationID
+		Removed: (func(x []ConversationMember) []ConversationMember {
+			var ret []ConversationMember
 			for _, v := range x {
 				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -111,8 +111,10 @@ func (n *nlistener) ChatTLFFinalize(uid keybase1.UID, convID chat1.ConversationI
 }
 func (n *nlistener) ChatTLFResolve(uid keybase1.UID, convID chat1.ConversationID, info chat1.ConversationResolveInfo) {
 }
-func (n *nlistener) ChatInboxStale(uid keybase1.UID)                        {}
-func (n *nlistener) TeamKeyRotated(teamID keybase1.TeamID, teamName string) {}
+func (n *nlistener) ChatJoinedConversation(uid keybase1.UID, conv chat1.ConversationLocal) {}
+func (n *nlistener) ChatLeftConversation(uid keybase1.UID, convID chat1.ConversationID)    {}
+func (n *nlistener) ChatInboxStale(uid keybase1.UID)                                       {}
+func (n *nlistener) TeamKeyRotated(teamID keybase1.TeamID, teamName string)                {}
 func (n *nlistener) ChatThreadsStale(uid keybase1.UID, cids []chat1.ConversationID) {
 	select {
 	case n.threadStale <- cids:

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -68,6 +68,11 @@ protocol common {
 
   }
 
+  record ConversationMember {
+    gregor1.UID uid;
+    ConversationID convID;
+  }
+
   enum ConversationMemberStatus {
     ACTIVE_0,  // in the channel
     REMOVED_1, // removed from channel forcibly
@@ -114,11 +119,6 @@ protocol common {
     boolean readOnly;
     boolean computeActiveList;
     boolean summarizeMaxMsgs; // if true, resulting conversation will only have summaries of max msgs
-  }
-
-  record ConversationMember {
-    gregor1.UID uid;
-    ConversationID convID;
   }
 
   record ConversationIDTriple {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -116,6 +116,11 @@ protocol common {
     boolean summarizeMaxMsgs; // if true, resulting conversation will only have summaries of max msgs
   }
 
+  record ConversationMember {
+    gregor1.UID uid;
+    ConversationID convID;
+  }
+
   record ConversationIDTriple {
     @lint("ignore")
     TLFID tlfid;
@@ -149,7 +154,11 @@ protocol common {
 
     // List of users sorted by recency of last [intentional] post.
     // Most recent first. May be incomplete or empty.
+    // *** Empty for TEAM chats. ***
     array<gregor1.UID> activeList;
+
+    // All of the users in the conversation, regardless of active status.
+    array<gregor1.UID> allList;
   }
 
   record ConversationReaderInfo {

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -70,10 +70,10 @@ protocol gregor {
         ConversationID convID;
         boolean typing; 
     }
-   
+
     record UpdateConversationMembership {
         InboxVers inboxVers;
-        array<ConversationID> joined;
-        array<ConversationID> removed;
+        array<ConversationMember> joined;
+        array<ConversationMember> removed;
     }
 }

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -10,7 +10,8 @@ protocol NotifyChat {
     READ_MESSAGE_2,
     NEW_CONVERSATION_3,
     SET_STATUS_4,
-    FAILED_MESSAGE_5
+    FAILED_MESSAGE_5,
+    MEMBERS_UPDATE_6
   } 
 
   record IncomingMessage {
@@ -40,12 +41,19 @@ protocol NotifyChat {
     array<OutboxRecord> outboxRecords;
   }
 
+  record MembersUpdateInfo {
+    ConversationID convID;
+    string member;
+    boolean joined;
+  }
+
   variant ChatActivity switch (ChatActivityType activityType) {
     case INCOMING_MESSAGE: IncomingMessage;
     case READ_MESSAGE: ReadMessageInfo;
     case NEW_CONVERSATION: NewConversationInfo;
     case SET_STATUS: SetStatusInfo;
     case FAILED_MESSAGE: FailedMessageInfo;
+    case MEMBERS_UPDATE: MembersUpdateInfo;
   }
 
   record TyperInfo {
@@ -89,4 +97,13 @@ protocol NotifyChat {
   @notify("")
   @lint("ignore")
   void ChatTypingUpdate(array<ConvTypingUpdate> typingUpdates);
+
+  @notify("")
+  @lint("ignore")
+  void ChatJoinedConversation(keybase1.UID uid, ConversationLocal conv);
+
+  @notify("")
+  @lint("ignore")
+  void ChatLeftConversation(keybase1.UID uid, ConversationID convID); 
+
 }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1193,6 +1193,7 @@ export type ConversationMetadata = {
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
   activeList?: ?Array<gregor1.UID>,
+  allList?: ?Array<gregor1.UID>,
 }
 
 export type ConversationReaderInfo = {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1173,6 +1173,11 @@ export type ConversationLocal = {
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
 
+export type ConversationMember = {
+  uid: gregor1.UID,
+  convID: ConversationID,
+}
+
 export type ConversationMemberStatus =
     0 // ACTIVE_0
   | 1 // REMOVED_1
@@ -1994,8 +1999,8 @@ export type UnreadUpdateFull = {
 
 export type UpdateConversationMembership = {
   inboxVers: InboxVers,
-  joined?: ?Array<ConversationID>,
-  removed?: ?Array<ConversationID>,
+  joined?: ?Array<ConversationMember>,
+  removed?: ?Array<ConversationMember>,
 }
 
 export type chatUiChatAttachmentDownloadProgressRpcParam = Exact<{

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -186,6 +186,7 @@ export const NotifyChatChatActivityType = {
   newConversation: 3,
   setStatus: 4,
   failedMessage: 5,
+  membersUpdate: 6,
 }
 
 export const RemoteMessageBoxedVersion = {
@@ -1088,6 +1089,7 @@ export type ChatActivity =
   | { activityType: 3, newConversation: ?NewConversationInfo }
   | { activityType: 4, setStatus: ?SetStatusInfo }
   | { activityType: 5, failedMessage: ?FailedMessageInfo }
+  | { activityType: 6, membersUpdate: ?MembersUpdateInfo }
 
 export type ChatActivityType =
     0 // RESERVED_0
@@ -1096,6 +1098,7 @@ export type ChatActivityType =
   | 3 // NEW_CONVERSATION_3
   | 4 // SET_STATUS_4
   | 5 // FAILED_MESSAGE_5
+  | 6 // MEMBERS_UPDATE_6
 
 export type ConvTypingUpdate = {
   convID: ConversationID,
@@ -1504,6 +1507,12 @@ export type MarkAsReadRes = {
   rateLimit?: ?RateLimit,
 }
 
+export type MembersUpdateInfo = {
+  convID: ConversationID,
+  member: string,
+  joined: boolean,
+}
+
 export type MerkleRoot = {
   seqno: long,
   hash: bytes,
@@ -1725,6 +1734,16 @@ export type NotifyChatChatIdentifyUpdateRpcParam = Exact<{
 
 export type NotifyChatChatInboxStaleRpcParam = Exact<{
   uid: keybase1.UID
+}>
+
+export type NotifyChatChatJoinedConversationRpcParam = Exact<{
+  uid: keybase1.UID,
+  conv: ConversationLocal
+}>
+
+export type NotifyChatChatLeftConversationRpcParam = Exact<{
+  uid: keybase1.UID,
+  convID: ConversationID
 }>
 
 export type NotifyChatChatTLFFinalizeRpcParam = Exact<{
@@ -2626,6 +2645,22 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatTypingUpdate'?: (
     params: Exact<{
       typingUpdates?: ?Array<ConvTypingUpdate>
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatJoinedConversation'?: (
+    params: Exact<{
+      uid: keybase1.UID,
+      conv: ConversationLocal
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatLeftConversation'?: (
+    params: Exact<{
+      uid: keybase1.UID,
+      convID: ConversationID
     }> /* ,
     response: {} // Notify call
     */

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -113,6 +113,20 @@
       ]
     },
     {
+      "type": "record",
+      "name": "ConversationMember",
+      "fields": [
+        {
+          "type": "gregor1.UID",
+          "name": "uid"
+        },
+        {
+          "type": "ConversationID",
+          "name": "convID"
+        }
+      ]
+    },
+    {
       "type": "enum",
       "name": "ConversationMemberStatus",
       "symbols": [

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -361,6 +361,13 @@
             "items": "gregor1.UID"
           },
           "name": "activeList"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "gregor1.UID"
+          },
+          "name": "allList"
         }
       ]
     },

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -226,14 +226,14 @@
         {
           "type": {
             "type": "array",
-            "items": "ConversationID"
+            "items": "ConversationMember"
           },
           "name": "joined"
         },
         {
           "type": {
             "type": "array",
-            "items": "ConversationID"
+            "items": "ConversationMember"
           },
           "name": "removed"
         }

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -17,7 +17,8 @@
         "READ_MESSAGE_2",
         "NEW_CONVERSATION_3",
         "SET_STATUS_4",
-        "FAILED_MESSAGE_5"
+        "FAILED_MESSAGE_5",
+        "MEMBERS_UPDATE_6"
       ]
     },
     {
@@ -114,6 +115,24 @@
       ]
     },
     {
+      "type": "record",
+      "name": "MembersUpdateInfo",
+      "fields": [
+        {
+          "type": "ConversationID",
+          "name": "convID"
+        },
+        {
+          "type": "string",
+          "name": "member"
+        },
+        {
+          "type": "boolean",
+          "name": "joined"
+        }
+      ]
+    },
+    {
       "type": "variant",
       "name": "ChatActivity",
       "switch": {
@@ -155,6 +174,13 @@
             "def": false
           },
           "body": "FailedMessageInfo"
+        },
+        {
+          "label": {
+            "name": "MEMBERS_UPDATE",
+            "def": false
+          },
+          "body": "MembersUpdateInfo"
         }
       ]
     },
@@ -311,6 +337,36 @@
             "type": "array",
             "items": "ConvTypingUpdate"
           }
+        }
+      ],
+      "response": null,
+      "notify": "",
+      "lint": "ignore"
+    },
+    "ChatJoinedConversation": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "keybase1.UID"
+        },
+        {
+          "name": "conv",
+          "type": "ConversationLocal"
+        }
+      ],
+      "response": null,
+      "notify": "",
+      "lint": "ignore"
+    },
+    "ChatLeftConversation": {
+      "request": [
+        {
+          "name": "uid",
+          "type": "keybase1.UID"
+        },
+        {
+          "name": "convID",
+          "type": "ConversationID"
         }
       ],
       "response": null,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1193,6 +1193,7 @@ export type ConversationMetadata = {
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
   activeList?: ?Array<gregor1.UID>,
+  allList?: ?Array<gregor1.UID>,
 }
 
 export type ConversationReaderInfo = {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1173,6 +1173,11 @@ export type ConversationLocal = {
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
 
+export type ConversationMember = {
+  uid: gregor1.UID,
+  convID: ConversationID,
+}
+
 export type ConversationMemberStatus =
     0 // ACTIVE_0
   | 1 // REMOVED_1
@@ -1994,8 +1999,8 @@ export type UnreadUpdateFull = {
 
 export type UpdateConversationMembership = {
   inboxVers: InboxVers,
-  joined?: ?Array<ConversationID>,
-  removed?: ?Array<ConversationID>,
+  joined?: ?Array<ConversationMember>,
+  removed?: ?Array<ConversationMember>,
 }
 
 export type chatUiChatAttachmentDownloadProgressRpcParam = Exact<{

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -186,6 +186,7 @@ export const NotifyChatChatActivityType = {
   newConversation: 3,
   setStatus: 4,
   failedMessage: 5,
+  membersUpdate: 6,
 }
 
 export const RemoteMessageBoxedVersion = {
@@ -1088,6 +1089,7 @@ export type ChatActivity =
   | { activityType: 3, newConversation: ?NewConversationInfo }
   | { activityType: 4, setStatus: ?SetStatusInfo }
   | { activityType: 5, failedMessage: ?FailedMessageInfo }
+  | { activityType: 6, membersUpdate: ?MembersUpdateInfo }
 
 export type ChatActivityType =
     0 // RESERVED_0
@@ -1096,6 +1098,7 @@ export type ChatActivityType =
   | 3 // NEW_CONVERSATION_3
   | 4 // SET_STATUS_4
   | 5 // FAILED_MESSAGE_5
+  | 6 // MEMBERS_UPDATE_6
 
 export type ConvTypingUpdate = {
   convID: ConversationID,
@@ -1504,6 +1507,12 @@ export type MarkAsReadRes = {
   rateLimit?: ?RateLimit,
 }
 
+export type MembersUpdateInfo = {
+  convID: ConversationID,
+  member: string,
+  joined: boolean,
+}
+
 export type MerkleRoot = {
   seqno: long,
   hash: bytes,
@@ -1725,6 +1734,16 @@ export type NotifyChatChatIdentifyUpdateRpcParam = Exact<{
 
 export type NotifyChatChatInboxStaleRpcParam = Exact<{
   uid: keybase1.UID
+}>
+
+export type NotifyChatChatJoinedConversationRpcParam = Exact<{
+  uid: keybase1.UID,
+  conv: ConversationLocal
+}>
+
+export type NotifyChatChatLeftConversationRpcParam = Exact<{
+  uid: keybase1.UID,
+  convID: ConversationID
 }>
 
 export type NotifyChatChatTLFFinalizeRpcParam = Exact<{
@@ -2626,6 +2645,22 @@ export type incomingCallMapType = Exact<{
   'keybase.1.NotifyChat.ChatTypingUpdate'?: (
     params: Exact<{
       typingUpdates?: ?Array<ConvTypingUpdate>
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatJoinedConversation'?: (
+    params: Exact<{
+      uid: keybase1.UID,
+      conv: ConversationLocal
+    }> /* ,
+    response: {} // Notify call
+    */
+  ) => void,
+  'keybase.1.NotifyChat.ChatLeftConversation'?: (
+    params: Exact<{
+      uid: keybase1.UID,
+      convID: ConversationID
     }> /* ,
     response: {} // Notify call
     */


### PR DESCRIPTION
Patch does the following:

1.) Localize `AllList` for `TEAM` conversations during inbox localization.
2.) Add new frontend notifications for join/leave (for yourself), and for member changes of conversations that the current user is a member of.
3.) Maintain `AllList` properly in the inbox cache.
4.) Add a CLI command for listing all members for a conversation.