### PR TITLE
CardStack low hanging fruit

### DIFF
--- a/shared/app/nav.desktop.js
+++ b/shared/app/nav.desktop.js
@@ -37,7 +37,7 @@ function Nav(props: Props) {
       </Box>
       <div id="popupContainer" />
       {![chatTab, loginTab].includes(props.routeSelected) &&
-        <Offline reachability={props.reachability} appFocused={props.appFocused} />}
+        <Offline reachable={props.reachable} appFocused={props.appFocused} />}
       <GlobalError />
     </Box>
   )
@@ -51,7 +51,7 @@ const stylesTabsContainer = {
 const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ({
   appFocused: state.config.appFocused,
   navBadges: state.notifications.get('navBadges'),
-  reachability: state.gregor.reachability,
+  reachable: state.gregor.reachability.reachable,
   username: state.config.username,
 })
 

--- a/shared/app/nav.js.flow
+++ b/shared/app/nav.js.flow
@@ -3,7 +3,7 @@ import {Component} from 'react'
 import {Map} from 'immutable'
 
 import type {RouteRenderStack} from '../route-tree/render-route'
-import type {Reachability} from '../constants/types/flow-types'
+import type {Reachable} from '../constants/types/flow-types'
 import type {Tab} from '../constants/tabs'
 
 export type Props = {
@@ -16,7 +16,7 @@ export type Props = {
   routeSelected: Tab,
   routeStack: RouteRenderStack,
   hideNav: boolean,
-  reachability: ?Reachability,
+  reachable: Reachable,
   navBadges: Map<Tab, number>,
 }
 

--- a/shared/app/nav.native.js
+++ b/shared/app/nav.native.js
@@ -1,4 +1,5 @@
 // @flow
+import {is} from 'immutable'
 import GlobalError from './global-errors/container'
 import Offline from '../offline'
 import React, {Component} from 'react'
@@ -54,8 +55,7 @@ class CardStackShim extends Component<*, CardStackShimProps, *> {
       this.props.mode !== nextProps.mode ||
       this.props.renderRoute !== nextProps.renderRoute ||
       this.props.onNavigateBack !== nextProps.onNavigateBack ||
-      // $FlowIssue flow isn't accepting Stack.equals(Stack)
-      !this.props.stack.equals(nextProps.stack)
+      !is(this.props.stack, nextProps.stack)
     )
   }
 

--- a/shared/app/nav.native.js
+++ b/shared/app/nav.native.js
@@ -141,7 +141,7 @@ function MainNavStack(props: Props) {
       onNavigateBack={props.navigateUp}
     />,
     ![chatTab].includes(props.routeSelected) &&
-      <Offline key="offline" reachability={props.reachability} appFocused={true} />,
+      <Offline key="offline" reachable={props.reachable} appFocused={true} />,
     <GlobalError key="globalError" />,
   ].filter(Boolean)
 
@@ -224,7 +224,7 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ({
   hideNav: ownProps.routeSelected === loginTab,
   hideKeyboard: state.config.hideKeyboard,
   navBadges: state.notifications.get('navBadges'),
-  reachability: state.gregor.reachability,
+  reachable: state.gregor.reachability.reachable,
   username: state.config.username,
 })
 

--- a/shared/app/nav.native.js
+++ b/shared/app/nav.native.js
@@ -18,11 +18,18 @@ import type {Props} from './nav'
 import type {TypedState} from '../constants/reducer'
 import type {Tab} from '../constants/tabs'
 import type {NavigationAction} from 'react-navigation'
-import type {RouteProps} from '../route-tree/render-route'
+import type {RouteProps, RouteRenderStack, RenderRouteResult} from '../route-tree/render-route'
 
 type OwnProps = RouteProps<{}, {}>
 
-class CardStackShim extends Component {
+type CardStackShimProps = {
+  mode?: 'modal',
+  renderRoute: (route: RenderRouteResult) => React$Element<*>,
+  onNavigateBack: () => void,
+  stack: RouteRenderStack,
+}
+
+class CardStackShim extends Component<*, CardStackShimProps, *> {
   getScreenOptions = () => ({transitionInteractivityThreshold: 0.9})
   getStateForAction = emptyObj
   getActionForPathAndParams = emptyObj
@@ -40,6 +47,16 @@ class CardStackShim extends Component {
     if (action.type === NavigationActions.BACK) {
       this.props.onNavigateBack()
     }
+  }
+
+  shouldComponentUpdate(nextProps: CardStackShimProps) {
+    return (
+      this.props.mode !== nextProps.mode ||
+      this.props.renderRoute !== nextProps.renderRoute ||
+      this.props.onNavigateBack !== nextProps.onNavigateBack ||
+      // $FlowIssue flow isn't accepting Stack.equals(Stack)
+      !this.props.stack.equals(nextProps.stack)
+    )
   }
 
   render() {

--- a/shared/app/nav.native.js
+++ b/shared/app/nav.native.js
@@ -149,7 +149,6 @@ function MainNavStack(props: Props) {
     <TabBar
       onTabClick={props.switchTab}
       selectedTab={props.routeSelected}
-      username={props.username}
       badgeNumbers={props.navBadges.toJS()}
     />
   )
@@ -225,7 +224,6 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ({
   hideKeyboard: state.config.hideKeyboard,
   navBadges: state.notifications.get('navBadges'),
   reachable: state.gregor.reachability.reachable,
-  username: state.config.username,
 })
 
 const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => ({

--- a/shared/app/tab-bar/index.render.js.flow
+++ b/shared/app/tab-bar/index.render.js.flow
@@ -5,7 +5,7 @@ import type {Tab} from '../../constants/tabs'
 export type Props = {
   onTabClick: (tab: Tab) => void,
   selectedTab: Tab,
-  username: string,
+  username?: string,
   badgeNumbers: {[key: Tab]: number},
 }
 

--- a/shared/app/tab-bar/index.render.native.js
+++ b/shared/app/tab-bar/index.render.native.js
@@ -16,7 +16,7 @@ const _icons = {
 
 const _tabs = [Tabs.profileTab, Tabs.folderTab, Tabs.chatTab, Tabs.settingsTab].filter(Boolean)
 
-const TabBarRender = ({selectedTab, onTabClick, username, badgeNumbers}: Props) => (
+const TabBarRender = ({selectedTab, onTabClick, badgeNumbers}: Props) => (
   <Box style={stylesTabBar}>
     {_tabs.map(tab => (
       <TabBarButton

--- a/shared/offline/index.desktop.js
+++ b/shared/offline/index.desktop.js
@@ -7,8 +7,8 @@ import {ignoreDisconnectOverlay} from '../local-debug.desktop.js'
 
 import type {Props} from './index'
 
-const Offline = ({reachability, appFocused}: Props) => {
-  if (reachability && reachability.reachable !== ReachabilityReachable.no) {
+const Offline = ({reachable, appFocused}: Props) => {
+  if (reachable !== ReachabilityReachable.no) {
     return null
   }
 

--- a/shared/offline/index.js.flow
+++ b/shared/offline/index.js.flow
@@ -1,10 +1,10 @@
 // @flow
 import {Component} from 'react'
 
-import type {Reachability} from '../constants/types/flow-types'
+import type {Reachable} from '../constants/types/flow-types'
 
 export type Props = {
-  reachability: ?Reachability,
+  reachable: Reachable,
   appFocused: boolean,
 }
 

--- a/shared/offline/index.native.js
+++ b/shared/offline/index.native.js
@@ -7,8 +7,8 @@ import {ignoreDisconnectOverlay} from '../local-debug'
 
 import type {Props} from './index'
 
-const Offline = ({reachability}: Props) => {
-  if (reachability && reachability.reachable !== ReachabilityReachable.no) {
+const Offline = ({reachable}: Props) => {
+  if (reachable !== ReachabilityReachable.no) {
     return null
   }
 

--- a/shared/route-tree/render-route.js
+++ b/shared/route-tree/render-route.js
@@ -7,6 +7,24 @@ import {putActionIfOnPath, navigateUp, navigateAppend} from '../actions/route-tr
 import type {Action} from '../constants/types/flux'
 import type {RouteDefNode, RouteStateNode, Path} from './'
 
+type _RenderRouteResultParams = {
+  path: I.List<string>,
+  tags: LeafTags,
+  component: React$Element<any>,
+  leafComponent: React$Element<any>,
+}
+
+export const RenderRouteResult: (
+  spec?: _RenderRouteResultParams
+) => _RenderRouteResultParams & I.Record<_RenderRouteResultParams> = I.Record({
+  path: I.List(),
+  tags: LeafTags(),
+  component: null,
+  leafComponent: null,
+})
+
+export type RouteRenderStack = I.Stack<RenderRouteResult>
+
 // Components rendered by routes receive the following props:
 export type RouteProps<P, S> = {
   // Route props (query params)
@@ -25,7 +43,7 @@ export type RouteProps<P, S> = {
   routeLeafTags: LeafTags,
 
   // Stack of child views from this component.
-  routeStack: I.List<React$Element<any>>,
+  routeStack: RouteRenderStack,
 
   // Call to update the state of the route node that rendered this component.
   setRouteState: (partialState: $Shape<S>) => void,
@@ -42,7 +60,7 @@ type RenderRouteNodeProps<S> = {
   setRouteState: (path: Path, partialState: $Shape<S>) => void,
   path: I.List<string>,
   leafTags?: LeafTags,
-  stack?: I.List<React$Element<any>>,
+  stack?: RouteRenderStack,
   children?: React$Element<*>,
 }
 
@@ -76,24 +94,6 @@ type _RenderRouteProps<S> = {
   routeState: ?RouteStateNode,
   setRouteState: (partialState: $Shape<S>) => void,
 }
-
-type _RenderRouteResultParams = {
-  path: I.List<string>,
-  tags: LeafTags,
-  component: React$Element<any>,
-  leafComponent: React$Element<any>,
-}
-
-const _RenderRouteResult: (
-  spec?: _RenderRouteResultParams
-) => _RenderRouteResultParams & I.Record<_RenderRouteResultParams> = I.Record({
-  path: I.List(),
-  tags: LeafTags(),
-  component: null,
-  leafComponent: null,
-})
-
-export type RouteRenderStack = I.Stack<_RenderRouteResult>
 
 // Render a route tree recursively. Returns a stack of rendered components from
 // the bottom (the currently visible view) up through each parent path.
@@ -158,7 +158,7 @@ function _RenderRoute({routeDef, routeState, setRouteState, path}: _RenderRouteP
         setRouteState={setRouteState}
       />
     )
-    const result = new _RenderRouteResult({
+    const result = new RenderRouteResult({
       path,
       component: routeComponent,
       leafComponent: routeComponent,


### PR DESCRIPTION
This removes some, but not all, causes of wasted `CardStackTransitioner` renders. It adds a SCU to the shim and removes connect props causing unnecessary re-renders.

I feel like there may be some more big wins in here, but this is a start. Next things to do are:

 * Check for `Card` being re-rendered when it shouldn't
 * Try to find a way to prevent nesting two `CardStackShim` (causes top-level `CardStackShim` to re-render every time main one changes)
 * Move remaining extraneous connect stuff in `nav.native.js` to connected components (`navBadges`, `reachable`). https://github.com/keybase/client/pull/7645 gets rid of `hideKeyboard`.