### PR TITLE
parse out @ mentions and send separately on PostRemote CORE-5286

### DIFF
--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -25,7 +25,7 @@ func setupLoaderTest(t *testing.T) (*kbtest.ChatTestContext, *kbtest.ChatMockWor
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, err := baseSender.Prepare(ctx, firstMessagePlaintext,
+	firstMessageBoxed, _, _, err := baseSender.Prepare(ctx, firstMessagePlaintext,
 		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -32,7 +32,7 @@ func TestGetThreadSupersedes(t *testing.T) {
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, err := sender.Prepare(ctx, firstMessagePlaintext,
+	firstMessageBoxed, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
 		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
@@ -365,7 +365,7 @@ func TestGetThreadCaching(t *testing.T) {
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, err := sender.Prepare(ctx, firstMessagePlaintext,
+	firstMessageBoxed, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
 		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
@@ -478,7 +478,7 @@ func TestGetThreadHoleResolution(t *testing.T) {
 		pt.MessageBody = chat1.NewMessageBodyWithText(chat1.MessageText{
 			Body: fmt.Sprintf("MIKE: %d", i),
 		})
-		msg, _, err = sender.Prepare(ctx, pt, chat1.ConversationMembersType_KBFS, &conv)
+		msg, _, _, err = sender.Prepare(ctx, pt, chat1.ConversationMembersType_KBFS, &conv)
 		require.NoError(t, err)
 		require.NotNil(t, msg)
 

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -139,7 +139,7 @@ func (s *sendHelper) newConversation(ctx context.Context) error {
 
 	boxer := NewBoxer(s.G())
 	sender := NewBlockingSender(s.G(), boxer, nil, s.remoteInterface)
-	mbox, _, err := sender.Prepare(ctx, first, s.membersType, nil)
+	mbox, _, _, err := sender.Prepare(ctx, first, s.membersType, nil)
 	if err != nil {
 		return err
 	}

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -104,7 +104,7 @@ func TestInboxSourceSkipAhead(t *testing.T) {
 
 	t.Logf("add message but drop oobm")
 
-	boxed, _, err := sender.Prepare(ctx, chat1.MessagePlaintext{
+	boxed, _, _, err := sender.Prepare(ctx, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        conv.Metadata.IdTriple,
 			Sender:      u.User.GetUID().ToBytes(),

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -24,7 +24,7 @@ import (
 type Sender interface {
 	Send(ctx context.Context, convID chat1.ConversationID, msg chat1.MessagePlaintext, clientPrev chat1.MessageID) (chat1.OutboxID, *chat1.MessageBoxed, *chat1.RateLimit, error)
 	Prepare(ctx context.Context, msg chat1.MessagePlaintext, membersType chat1.ConversationMembersType,
-		conv *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, error)
+		conv *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, []gregor1.UID, error)
 }
 
 type BlockingSender struct {
@@ -330,22 +330,22 @@ func (s *BlockingSender) assetsForMessage(ctx context.Context, msgBody chat1.Mes
 // Prepare a message to be sent.
 // Returns (boxedMessage, pendingAssetDeletes, error)
 func (s *BlockingSender) Prepare(ctx context.Context, plaintext chat1.MessagePlaintext,
-	membersType chat1.ConversationMembersType, conv *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, error) {
+	membersType chat1.ConversationMembersType, conv *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, []gregor1.UID, error) {
 	// Make sure it is a proper length
 	if err := msgchecker.CheckMessagePlaintext(plaintext); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	msg, err := s.addSenderToMessage(plaintext)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// convID will be nil in makeFirstMessage
 	if conv != nil {
 		msg, err = s.addPrevPointersAndCheckConvID(ctx, msg, *conv)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 
@@ -355,24 +355,34 @@ func (s *BlockingSender) Prepare(ctx context.Context, plaintext chat1.MessagePla
 		// Be careful not to shadow (msg, pendingAssetDeletes) with this assignment.
 		msg, pendingAssetDeletes, err = s.getAllDeletedEdits(ctx, msg, *conv)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 
 	// encrypt the message
 	skp, err := s.getSigningKeyPair(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
+	}
+
+	// find @ mentions
+	var atMentions []gregor1.UID
+	if plaintext.ClientHeader.MessageType == chat1.MessageType_TEXT {
+		atMentions = utils.ParseAtMentionedUIDs(ctx, plaintext.MessageBody.Text().Body,
+			s.G().GetUPAKLoader(), &s.DebugLabeler)
+		if len(atMentions) > 0 {
+			s.Debug(ctx, "atMentions: %v", atMentions)
+		}
 	}
 
 	// For now, BoxMessage canonicalizes the TLF name. We should try to refactor
 	// it a bit to do it here.
 	boxed, err := s.boxer.BoxMessage(ctx, msg, membersType, skp)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return boxed, pendingAssetDeletes, nil
+	return boxed, pendingAssetDeletes, atMentions, nil
 }
 
 func (s *BlockingSender) getSigningKeyPair(ctx context.Context) (kp libkb.NaclSigningKeyPair, err error) {
@@ -443,7 +453,7 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	}
 
 	// Add a bunch of stuff to the message (like prev pointers, sender info, ...)
-	boxed, pendingAssetDeletes, err := s.Prepare(ctx, msg, conv.GetMembersType(), &conv)
+	boxed, pendingAssetDeletes, atMentions, err := s.Prepare(ctx, msg, conv.GetMembersType(), &conv)
 	if err != nil {
 		s.Debug(ctx, "error in Prepare: %s", err.Error())
 		return chat1.OutboxID{}, nil, nil, err
@@ -473,6 +483,7 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	rarg := chat1.PostRemoteArg{
 		ConversationID: convID,
 		MessageBoxed:   *boxed,
+		AtMentions:     atMentions,
 	}
 	plres, err := ri.PostRemote(ctx, rarg)
 	if err != nil {
@@ -781,7 +792,7 @@ func NewNonblockingSender(g *globals.Context, sender Sender) *NonblockingSender 
 }
 
 func (s *NonblockingSender) Prepare(ctx context.Context, msg chat1.MessagePlaintext,
-	membersType chat1.ConversationMembersType, conv *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, error) {
+	membersType chat1.ConversationMembersType, conv *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, []gregor1.UID, error) {
 	return s.sender.Prepare(ctx, msg, membersType, conv)
 }
 

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -488,7 +488,6 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	if _, err = s.G().InboxSource.NewMessage(ctx, boxed.ClientHeader.Sender, 0, convID, *boxed); err != nil {
 		return chat1.OutboxID{}, nil, nil, err
 	}
-
 	return []byte{}, boxed, plres.RateLimit, nil
 }
 

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/teams"
 	"github.com/stretchr/testify/require"
@@ -273,7 +274,7 @@ func TestNonblockTimer(t *testing.T) {
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, err := baseSender.Prepare(ctx, firstMessagePlaintext,
+	firstMessageBoxed, _, _, err := baseSender.Prepare(ctx, firstMessagePlaintext,
 		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
@@ -396,8 +397,8 @@ func (f FailingSender) Send(ctx context.Context, convID chat1.ConversationID,
 }
 
 func (f FailingSender) Prepare(ctx context.Context, msg chat1.MessagePlaintext,
-	membersType chat1.ConversationMembersType, convID *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, error) {
-	return nil, nil, nil
+	membersType chat1.ConversationMembersType, convID *chat1.Conversation) (*chat1.MessageBoxed, []chat1.Asset, []gregor1.UID, error) {
+	return nil, nil, nil, nil
 }
 
 func recordCompare(t *testing.T, obids []chat1.OutboxID, obrs []chat1.OutboxRecord) {
@@ -648,7 +649,7 @@ func TestDeletionHeaders(t *testing.T) {
 		},
 		MessageBody: chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: []chat1.MessageID{firstMessageID}}),
 	}
-	preparedDeletion, _, err := blockingSender.Prepare(ctx, deletion,
+	preparedDeletion, _, _, err := blockingSender.Prepare(ctx, deletion,
 		chat1.ConversationMembersType_KBFS, &conv)
 	require.NoError(t, err)
 
@@ -669,6 +670,36 @@ func TestDeletionHeaders(t *testing.T) {
 	if !deletedIDs[editID2] {
 		t.Fatalf("expected message #%d to be deleted", editID2)
 	}
+}
+
+func TestAtMentions(t *testing.T) {
+	ctx, world, ri, _, blockingSender, _ := setupTest(t, 3)
+	defer world.Cleanup()
+
+	u := world.GetUsers()[0]
+	u1 := world.GetUsers()[1]
+	u2 := world.GetUsers()[2]
+	uid := u.User.GetUID().ToBytes()
+	uid1 := u1.User.GetUID().ToBytes()
+	uid2 := u2.User.GetUID().ToBytes()
+	tc := userTc(t, world, u)
+	conv := newBlankConv(ctx, t, tc, uid, ri, blockingSender, u.Username)
+
+	text := fmt.Sprintf("@%s hello! From @%s. @ksjdskj", u1.Username, u2.Username)
+	t.Logf("text: %s", text)
+	_, _, atMentions, err := blockingSender.Prepare(ctx, chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Conv:        conv.Metadata.IdTriple,
+			Sender:      uid,
+			TlfName:     u.Username,
+			MessageType: chat1.MessageType_TEXT,
+		},
+		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
+			Body: text,
+		}),
+	}, chat1.ConversationMembersType_KBFS, &conv)
+	require.NoError(t, err)
+	require.Equal(t, []gregor1.UID{uid1, uid2}, atMentions)
 }
 
 func TestPrevPointerAddition(t *testing.T) {
@@ -704,7 +735,7 @@ func TestPrevPointerAddition(t *testing.T) {
 	require.NoError(t, err)
 
 	// Prepare a message and make sure it gets prev pointers
-	boxed, pendingAssetDeletes, err := blockingSender.Prepare(ctx, chat1.MessagePlaintext{
+	boxed, pendingAssetDeletes, _, err := blockingSender.Prepare(ctx, chat1.MessagePlaintext{
 		ClientHeader: chat1.MessageClientHeader{
 			Conv:        conv.Metadata.IdTriple,
 			Sender:      uid,
@@ -809,7 +840,7 @@ func TestDeletionAssets(t *testing.T) {
 		},
 		MessageBody: chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: []chat1.MessageID{firstMessageID}}),
 	}
-	preparedDeletion, pendingAssetDeletes, err := blockingSender.Prepare(ctx, deletion,
+	preparedDeletion, pendingAssetDeletes, _, err := blockingSender.Prepare(ctx, deletion,
 		chat1.ConversationMembersType_KBFS, &conv)
 	require.NoError(t, err)
 

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -637,7 +637,7 @@ func (h *Server) makeFirstMessage(ctx context.Context, triple chat1.Conversation
 	}
 
 	sender := NewBlockingSender(h.G(), h.boxer, h.store, h.remoteClient)
-	mbox, _, err := sender.Prepare(ctx, msg, membersType, nil)
+	mbox, _, _, err := sender.Prepare(ctx, msg, membersType, nil)
 	return mbox, err
 }
 

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -26,7 +26,7 @@ func newBlankConv(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext,
 		},
 		MessageBody: chat1.MessageBody{},
 	}
-	firstMessageBoxed, _, err := sender.Prepare(ctx, firstMessagePlaintext,
+	firstMessageBoxed, _, _, err := sender.Prepare(ctx, firstMessagePlaintext,
 		chat1.ConversationMembersType_KBFS, nil)
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -390,7 +390,7 @@ func GetSupersedes(msg chat1.MessageUnboxed) ([]chat1.MessageID, error) {
 	}
 }
 
-var atMentionRegExp = regexp.MustCompile(`\B@(([a-z][a-z0-9_]?)+)`)
+var atMentionRegExp = regexp.MustCompile(`\B@([a-z][a-z0-9_]+)`)
 
 func ParseAtMentionsNames(ctx context.Context, body string) (res []string) {
 	matches := atMentionRegExp.FindAllStringSubmatch(body, -1)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"regexp"
+
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -386,6 +388,22 @@ func GetSupersedes(msg chat1.MessageUnboxed) ([]chat1.MessageID, error) {
 	default:
 		return nil, nil
 	}
+}
+
+var atMentionRegExp = regexp.MustCompile(`\B@(([a-z][a-z0-9_]?)+)`)
+
+func ParseAtMentionsNames(body string) (res []string) {
+	matches := atMentionRegExp.FindAllStringSubmatch(body, -1)
+	for _, m := range matches {
+		if len(m) >= 2 {
+			res = append(res, m[1])
+		}
+	}
+	return res
+}
+
+func ParseAtMentionedUIDs(body string, upak libkb.UPAKLoader) []gregor1.UID {
+	names := ParseAtMentionsNames(body)
 }
 
 func PluckMessageIDs(msgs []chat1.MessageSummary) []chat1.MessageID {

--- a/go/chat/utils/utils_test.go
+++ b/go/chat/utils/utils_test.go
@@ -1,8 +1,11 @@
 package utils
 
 import (
+	"context"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseDurationExtended(t *testing.T) {
@@ -17,4 +20,11 @@ func TestParseDurationExtended(t *testing.T) {
 	}
 	test("1d", time.Hour*24)
 	test("123d12h2ns", 123*24*time.Hour+12*time.Hour+2*time.Nanosecond)
+}
+
+func TestParseAtMentionsNames(t *testing.T) {
+	text := "@chat_1e2263952c @9mike hello! @mike From @chat_5511c5e0ce. @ksjdskj 889@ds8 @_dskdjs @k1"
+	matches := ParseAtMentionsNames(context.TODO(), text)
+	expected := []string{"chat_1e2263952c", "mike", "chat_5511c5e0ce", "ksjdskj", "k1"}
+	require.Equal(t, expected, matches)
 }

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -695,21 +695,21 @@ func (o GetPublicConversationsArg) DeepCopy() GetPublicConversationsArg {
 type PostRemoteArg struct {
 	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
 	MessageBoxed   MessageBoxed   `codec:"messageBoxed" json:"messageBoxed"`
-	Atmentions     []gregor1.UID  `codec:"atmentions" json:"atmentions"`
+	AtMentions     []gregor1.UID  `codec:"atMentions" json:"atMentions"`
 }
 
 func (o PostRemoteArg) DeepCopy() PostRemoteArg {
 	return PostRemoteArg{
 		ConversationID: o.ConversationID.DeepCopy(),
 		MessageBoxed:   o.MessageBoxed.DeepCopy(),
-		Atmentions: (func(x []gregor1.UID) []gregor1.UID {
+		AtMentions: (func(x []gregor1.UID) []gregor1.UID {
 			var ret []gregor1.UID
 			for _, v := range x {
 				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
 			}
 			return ret
-		})(o.Atmentions),
+		})(o.AtMentions),
 	}
 }
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -695,12 +695,21 @@ func (o GetPublicConversationsArg) DeepCopy() GetPublicConversationsArg {
 type PostRemoteArg struct {
 	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
 	MessageBoxed   MessageBoxed   `codec:"messageBoxed" json:"messageBoxed"`
+	Atmentions     []gregor1.UID  `codec:"atmentions" json:"atmentions"`
 }
 
 func (o PostRemoteArg) DeepCopy() PostRemoteArg {
 	return PostRemoteArg{
 		ConversationID: o.ConversationID.DeepCopy(),
 		MessageBoxed:   o.MessageBoxed.DeepCopy(),
+		Atmentions: (func(x []gregor1.UID) []gregor1.UID {
+			var ret []gregor1.UID
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Atmentions),
 	}
 }
 

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -104,7 +104,7 @@ protocol remote {
   GetThreadRemoteRes getThreadRemote(ConversationID conversationID, union { null, GetThreadQuery } query, union { null, Pagination } pagination);
   GetPublicConversationsRes getPublicConversations(TLFID tlfID, TopicType topicType, boolean summarizeMaxMsgs);
 
-  PostRemoteRes postRemote(ConversationID conversationID, MessageBoxed messageBoxed, array<gregor1.UID> atmentions);
+  PostRemoteRes postRemote(ConversationID conversationID, MessageBoxed messageBoxed, array<gregor1.UID> atMentions);
   NewConversationRemoteRes newConversationRemote(ConversationIDTriple idTriple);
 
   // on duplication of idTriple, and error is returned and the conversation ID of the existing conversation is returned.

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -104,7 +104,7 @@ protocol remote {
   GetThreadRemoteRes getThreadRemote(ConversationID conversationID, union { null, GetThreadQuery } query, union { null, Pagination } pagination);
   GetPublicConversationsRes getPublicConversations(TLFID tlfID, TopicType topicType, boolean summarizeMaxMsgs);
 
-  PostRemoteRes postRemote(ConversationID conversationID, MessageBoxed messageBoxed);
+  PostRemoteRes postRemote(ConversationID conversationID, MessageBoxed messageBoxed, array<gregor1.UID> atmentions);
   NewConversationRemoteRes newConversationRemote(ConversationIDTriple idTriple);
 
   // on duplication of idTriple, and error is returned and the conversation ID of the existing conversation is returned.

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -2332,7 +2332,7 @@ export type remoteNewConversationRemoteRpcParam = Exact<{
 export type remotePostRemoteRpcParam = Exact<{
   conversationID: ConversationID,
   messageBoxed: MessageBoxed,
-  atmentions?: ?Array<gregor1.UID>
+  atMentions?: ?Array<gregor1.UID>
 }>
 
 export type remotePublishReadMessageRpcParam = Exact<{

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -2331,7 +2331,8 @@ export type remoteNewConversationRemoteRpcParam = Exact<{
 
 export type remotePostRemoteRpcParam = Exact<{
   conversationID: ConversationID,
-  messageBoxed: MessageBoxed
+  messageBoxed: MessageBoxed,
+  atmentions?: ?Array<gregor1.UID>
 }>
 
 export type remotePublishReadMessageRpcParam = Exact<{

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -548,7 +548,7 @@
           "type": "MessageBoxed"
         },
         {
-          "name": "atmentions",
+          "name": "atMentions",
           "type": {
             "type": "array",
             "items": "gregor1.UID"

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -546,6 +546,13 @@
         {
           "name": "messageBoxed",
           "type": "MessageBoxed"
+        },
+        {
+          "name": "atmentions",
+          "type": {
+            "type": "array",
+            "items": "gregor1.UID"
+          }
         }
       ],
       "response": "PostRemoteRes"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -2332,7 +2332,7 @@ export type remoteNewConversationRemoteRpcParam = Exact<{
 export type remotePostRemoteRpcParam = Exact<{
   conversationID: ConversationID,
   messageBoxed: MessageBoxed,
-  atmentions?: ?Array<gregor1.UID>
+  atMentions?: ?Array<gregor1.UID>
 }>
 
 export type remotePublishReadMessageRpcParam = Exact<{

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -2331,7 +2331,8 @@ export type remoteNewConversationRemoteRpcParam = Exact<{
 
 export type remotePostRemoteRpcParam = Exact<{
   conversationID: ConversationID,
-  messageBoxed: MessageBoxed
+  messageBoxed: MessageBoxed,
+  atmentions?: ?Array<gregor1.UID>
 }>
 
 export type remotePublishReadMessageRpcParam = Exact<{


### PR DESCRIPTION
Point of the patch is to parse out @ mentions from message text, and to send it to `PostRemote` as a separate argument. This will allow Gregor to handle push notifications properly for team chats.