### PR TITLE
fix searchv3 username width for mobile

### DIFF
--- a/shared/searchv3/result-row/index.js
+++ b/shared/searchv3/result-row/index.js
@@ -15,8 +15,7 @@ const Left = ({leftService, leftIcon, leftUsername, leftFollowingState}) => {
         alignItems: 'center',
         height: '100%',
         paddingLeft: globalMargins.tiny,
-        // TODO we might want to change this for the mobile version. Will play around with it more
-        width: 215,
+        width: isMobile ? 170 : 215,
       }}
     >
       <Box style={{...globalStyles.flexBoxCenter, width: 32}}>
@@ -83,7 +82,10 @@ const Right = ({showTrackerButton, onShowTracker}) => {
     ? <Icon
         type="iconfont-usercard"
         onClick={onShowTracker}
-        style={{marginLeft: globalMargins.small, marginRight: globalMargins.small}}
+        style={{
+          marginLeft: globalMargins.small,
+          marginRight: isMobile ? globalMargins.xtiny : globalMargins.small,
+        }}
       />
     : null
 }


### PR DESCRIPTION
The username area on mobile was way too big.

before:
![screen shot 2017-07-10 at 11 26 53 am](https://user-images.githubusercontent.com/516435/28026610-9e5772b2-6564-11e7-8a8f-b8435d4d2390.png)

after:
![screen shot 2017-07-10 at 11 40 27 am](https://user-images.githubusercontent.com/516435/28026620-a757470c-6564-11e7-9024-58eeb84c8533.png)

@keybase/react-hackers 