### PR TITLE
Make enter key work on mobile chat search v3

### DIFF
--- a/shared/chat/search.js
+++ b/shared/chat/search.js
@@ -12,7 +12,7 @@ import {compose, withState, defaultProps, withHandlers} from 'recompose'
 import {connect} from 'react-redux'
 import {globalMargins, globalStyles} from '../styles'
 import {chatSearchPending, chatSearchResultArray, chatSearchShowingSuggestions} from '../constants/selectors'
-import {onChangeSelectedSearchResultHoc, showServiceLogicHoc} from '../searchv3/helpers'
+import {onChangeSelectedSearchResultHoc, showServiceLogicHoc, selectedSearchIdHoc} from '../searchv3/helpers'
 import {createSelector} from 'reselect'
 
 const mapStateToProps = createSelector(
@@ -89,6 +89,7 @@ export default compose(
   connect(mapStateToProps, mapDispatchToProps),
   withState('selectedService', '_onSelectService', 'Keybase'),
   withState('searchText', 'onChangeSearchText', ''),
+  selectedSearchIdHoc,
   onChangeSelectedSearchResultHoc,
   showServiceLogicHoc,
   withHandlers({

--- a/shared/searchv3/user-input/index.native.js
+++ b/shared/searchv3/user-input/index.native.js
@@ -124,12 +124,16 @@ class UserInput extends Component<void, Props, State> {
     this.focus()
   }
 
-  _onSubmitEditing = () => {
-    this.props.onAddSelectedUser()
-  }
-
   render() {
-    const {autoFocus, placeholder, userItems, usernameText, onChangeText, onClickAddButton} = this.props
+    const {
+      autoFocus,
+      placeholder,
+      userItems,
+      usernameText,
+      onChangeText,
+      onClickAddButton,
+      onAddSelectedUser,
+    } = this.props
 
     const showAddButton = !!userItems.length && !usernameText.length && onClickAddButton
     return (
@@ -161,7 +165,7 @@ class UserInput extends Component<void, Props, State> {
               placeholder={userItems.length ? '' : placeholder}
               value={usernameText}
               onChangeText={onChangeText}
-              onSubmitEditing={this._onSubmitEditing}
+              onSubmitEditing={onAddSelectedUser}
               returnKeyType="next"
             />
             {showAddButton &&

--- a/shared/searchv3/user-input/index.native.js
+++ b/shared/searchv3/user-input/index.native.js
@@ -124,6 +124,10 @@ class UserInput extends Component<void, Props, State> {
     this.focus()
   }
 
+  _onSubmitEditing = () => {
+    this.props.onAddSelectedUser()
+  }
+
   render() {
     const {autoFocus, placeholder, userItems, usernameText, onChangeText, onClickAddButton} = this.props
 
@@ -157,6 +161,8 @@ class UserInput extends Component<void, Props, State> {
               placeholder={userItems.length ? '' : placeholder}
               value={usernameText}
               onChangeText={onChangeText}
+              onSubmitEditing={this._onSubmitEditing}
+              returnKeyType="next"
             />
             {showAddButton &&
               onClickAddButton &&


### PR DESCRIPTION
On master hitting enter does nothing. Now it'll add the user (like desktop)

This is due to a missing hoc. we should discuss this

@keybase/react-hackers 