### PR TITLE
Fix feedback from login screen

### DIFF
--- a/shared/login/login/routes.js
+++ b/shared/login/login/routes.js
@@ -16,7 +16,6 @@ import Feedback from '../../settings/feedback-container'
 const recursiveLazyRoutes = I.Seq({
   feedback: {
     component: Feedback,
-    tags: {hideStatusBar: true, fullscreen: true},
   },
   login: {
     component: Login,


### PR DESCRIPTION
Removing fullscreen and hide status bar tags from login feedback route fixes issues on feedback screen.

Fixes:
![2017-07-10 at 12 07 pm](https://user-images.githubusercontent.com/2669/28035161-6ff65196-6568-11e7-8bac-17fc838cbeb3.gif)

![2017-07-10 at 12 20 pm](https://user-images.githubusercontent.com/2669/28035612-1ee3b256-656a-11e7-891d-884ac07da08f.png)
