### PR TITLE
Use LinkType type instead of strings

### DIFF
--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -236,24 +236,23 @@ func SigchainV2TypeFromV1TypeAndRevocations(s string, hasRevocations bool) (ret 
 	return ret, err
 }
 
-// XXX use LinkType constants
 func SigchainV2TypeFromV1TypeTeams(s string) (ret SigchainV2Type, err error) {
-	switch s {
-	case "team.root":
+	switch LinkType(s) {
+	case LinkTypeTeamRoot:
 		ret = SigchainV2TypeTeamRoot
-	case "team.new_subteam":
+	case LinkTypeNewSubteam:
 		ret = SigchainV2TypeTeamNewSubteam
-	case "team.change_membership":
+	case LinkTypeChangeMembership:
 		ret = SigchainV2TypeTeamChangeMembership
-	case "team.rotate_key":
+	case LinkTypeRotateKey:
 		ret = SigchainV2TypeTeamRotateKey
-	case "team.leave":
+	case LinkTypeLeave:
 		ret = SigchainV2TypeTeamLeave
-	case "team.subteam_head":
+	case LinkTypeSubteamHead:
 		ret = SigchainV2TypeTeamSubteamHead
-	case "team.rename_subteam":
+	case LinkTypeSubteamRename:
 		ret = SigchainV2TypeTeamRenameSubteam
-	case "team.invite":
+	case LinkTypeInvite:
 		ret = SigchainV2TypeTeamInvite
 	default:
 		return SigchainV2TypeNone, ChainLinkError{fmt.Sprintf("Unknown team sig v1 type: %s", s)}

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -283,6 +283,7 @@ const (
 	LinkTypeRotateKey        LinkType = "team.rotate_key"
 	LinkTypeLeave            LinkType = "team.leave"
 	LinkTypeInvite           LinkType = "team.invite"
+	LinkTypeSubteamRename    LinkType = "team.subteam_rename"
 
 	DelegationTypeEldest    DelegationType = "eldest"
 	DelegationTypePGPUpdate DelegationType = "pgp_update"

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -627,9 +627,8 @@ func (t *TeamSigChainPlayer) addInnerLink(
 		return nil
 	}
 
-	// XXX use LinkType constants
-	switch payload.Body.Type {
-	case "team.root":
+	switch libkb.LinkType(payload.Body.Type) {
+	case libkb.LinkTypeTeamRoot:
 		err = libkb.PickFirstError(
 			allowInflate(false),
 			hasPrevState(false),
@@ -699,7 +698,7 @@ func (t *TeamSigChainPlayer) addInnerLink(
 		}
 
 		return res, nil
-	case "team.change_membership":
+	case libkb.LinkTypeChangeMembership:
 		err = libkb.PickFirstError(
 			allowInflate(false),
 			hasPrevState(true),
@@ -748,7 +747,7 @@ func (t *TeamSigChainPlayer) addInnerLink(
 		}
 
 		return res, nil
-	case "team.rotate_key":
+	case libkb.LinkTypeRotateKey:
 		err = libkb.PickFirstError(
 			allowInflate(false),
 			hasPrevState(true),
@@ -786,7 +785,7 @@ func (t *TeamSigChainPlayer) addInnerLink(
 		res.newState.inner.PerTeamKeys[newKey.Gen] = newKey
 
 		return res, nil
-	case "team.leave":
+	case libkb.LinkTypeLeave:
 		err = libkb.PickFirstError(
 			allowInflate(false),
 			hasPrevState(true),
@@ -821,7 +820,7 @@ func (t *TeamSigChainPlayer) addInnerLink(
 		res.newState.inform(signer, keybase1.TeamRole_NONE, payload.SignatureMetadata())
 
 		return res, nil
-	case "team.new_subteam":
+	case libkb.LinkTypeNewSubteam:
 		err = libkb.PickFirstError(
 			allowInflate(true),
 			hasPrevState(true),
@@ -870,7 +869,7 @@ func (t *TeamSigChainPlayer) addInnerLink(
 		}
 
 		return res, nil
-	case "team.subteam_head":
+	case libkb.LinkTypeSubteamHead:
 		err = libkb.PickFirstError(
 			allowInflate(false),
 			hasPrevState(false),
@@ -935,9 +934,9 @@ func (t *TeamSigChainPlayer) addInnerLink(
 		t.updateMembership(&res.newState, roleUpdates, payload.SignatureMetadata())
 
 		return res, nil
-	case "team.subteam_rename":
+	case libkb.LinkTypeSubteamRename:
 		return res, fmt.Errorf("subteam renaming not yet supported: %s", payload.Body.Type)
-	case "team.invite":
+	case libkb.LinkTypeInvite:
 		err = libkb.PickFirstError(
 			allowInflate(false),
 			hasPrevState(true),


### PR DESCRIPTION
These strings were bugging me.

And notice that "team.subteam_rename" and "team.rename_subteam" were used.