### PR TITLE
surya/core 5625/userorteamid validation

### DIFF
--- a/go/protocol/keybase1/extras_test.go
+++ b/go/protocol/keybase1/extras_test.go
@@ -27,3 +27,61 @@ func TestTime(t *testing.T) {
 		t.Errorf("keybase time messed up: now = %s, rev = %s", now, rev)
 	}
 }
+
+// IsUser and co. should return false and
+// not crash on arbitrary input.
+func TestUserOrTeamIDChecking(t *testing.T) {
+	var invalidIDTestCases = [6]string{
+		"", "    ", "%%@#$", "223123",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+	var validUserIDTestCases = [4]string{
+		"bd9e818f230819d3ecc813522c71f600",
+		"bd9e818f230819d3ecc813522c71f619",
+		"2721c9d9a247028cf51efa0760af6d00",
+		"2721c9d9a247028cf51efa0760af6d19",
+	}
+	var validTeamIDTestCases = [2]string{
+		"bd9e818f230819d3ecc813522c71f624",
+		"2721c9d9a247028cf51efa0760af6d24",
+	}
+	var validSubteamIDTestCases = [2]string{
+		"bd9e818f230819d3ecc813522c71f625",
+		"2721c9d9a247028cf51efa0760af6d25",
+	}
+
+	for _, idCase := range invalidIDTestCases {
+		ut := UserOrTeamID(idCase)
+		if ut.IsUser() || ut.IsTeam() || ut.IsSubteam() || ut.IsTeamOrSubteam() {
+			t.Errorf("Invalid ID %s is incorrectly marked valid.", idCase)
+		}
+	}
+	for _, idCase := range validUserIDTestCases {
+		ut := UserOrTeamID(idCase)
+		if !ut.IsUser() {
+			t.Errorf("Valid UserID %s is incorrectly marked invalid.", idCase)
+		}
+		if ut.IsTeam() || ut.IsSubteam() || ut.IsTeamOrSubteam() {
+			t.Errorf("Valid UserID %s is incorrectly marked as valid for another kind of ID.", idCase)
+		}
+	}
+	for _, idCase := range validTeamIDTestCases {
+		ut := UserOrTeamID(idCase)
+		if !ut.IsTeam() || !ut.IsTeamOrSubteam() {
+			t.Errorf("Valid TeamID %s is incorrectly marked invalid.", idCase)
+		}
+		if ut.IsUser() || ut.IsSubteam() {
+			t.Errorf("Valid TeamID %s is incorrectly marked as valid for another kind of ID.", idCase)
+		}
+	}
+	for _, idCase := range validSubteamIDTestCases {
+		ut := UserOrTeamID(idCase)
+		if !ut.IsSubteam() || !ut.IsTeamOrSubteam() {
+			t.Errorf("Valid SubteamID %s is incorrectly marked invalid.", idCase)
+		}
+		if ut.IsUser() || ut.IsTeam() {
+			t.Errorf("Valid SubteamID %s is incorrectly marked as valid for another kind of ID.", idCase)
+		}
+	}
+}


### PR DESCRIPTION
Some discussion regarding using `IsUser` and related:

Current behavior is to return True if it is a valid user ID, False if anything else, including invalid ID.
This runs into issues with if/else statement code like in teams/proofs.go:
```
if p.a.leafID.IsUser() {
    ret = leaf.Public
} else {
    ret = leaf.Private
}
```
which is not quite correct in the case that leafID happens to be invalid. I went through a few different ideas on what IsUser should return with Jack but that cleanest seemed to be that we should make some sort of enum VariantID(UID(...) | TeamID(...) |SubteamID(...)), and immediately parse a server's UserOrTeamID into a VariantID before it goes anywhere else. Then we don't have to worry about any potential errors or cornercases later on. Thoughts?

cc @oconnor663 @patrickxb 