### PR TITLE
Change chat teamloader calls

### DIFF
--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -1328,6 +1328,19 @@ func (k *KeyFinderMock) Find(ctx context.Context, tlfName string,
 	return res, nil
 }
 
+func (k *KeyFinderMock) FindForEncryption(ctx context.Context,
+	tlfName string, teamID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool) (res types.NameInfo, err error) {
+	return k.Find(ctx, tlfName, membersType, public)
+}
+
+func (k *KeyFinderMock) FindForDecryption(ctx context.Context,
+	tlfName string, teamID chat1.TLFID,
+	membersType chat1.ConversationMembersType, public bool,
+	keyGeneration int) (res types.NameInfo, err error) {
+	return k.Find(ctx, tlfName, membersType, public)
+}
+
 func (k *KeyFinderMock) SetNameInfoSourceOverride(ni types.NameInfoSource) {}
 
 func remarshalBoxed(t *testing.T, v chat1.MessageBoxed) *chat1.MessageBoxed {

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -392,6 +392,13 @@ func (s *HybridConversationSource) identifyTLF(ctx context.Context, conv chat1.C
 				return nil
 			}
 
+			switch conv.GetMembersType() {
+			case chat1.ConversationMembersType_TEAM:
+				// early out of team convs
+				return nil
+			default:
+			}
+
 			tlfName := msg.Valid().ClientHeader.TLFNameExpanded(conv.Metadata.FinalizeInfo)
 			s.Debug(ctx, "identifyTLF: identifying from msg ID: %d name: %s convID: %s",
 				msg.GetMessageID(), tlfName, conv.GetConvID())

--- a/go/teams/create_test.go
+++ b/go/teams/create_test.go
@@ -89,6 +89,6 @@ func TestCreateSubteam(t *testing.T) {
 		Name: subteamFQName.String(),
 	})
 	require.NoError(t, err)
-	require.Equal(t, subteamFQName, subteam.Name)
+	require.Equal(t, subteamFQName, subteam.Name())
 	require.Equal(t, keybase1.Seqno(1), subteam.chain().GetLatestSeqno())
 }

--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -9,20 +9,6 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-func getInternalByStringName(ctx context.Context, g *libkb.GlobalContext, name string) (*Team, error) {
-	return Load(ctx, g, keybase1.LoadTeamArg{
-		Name:        name,
-		ForceRepoll: true,
-	})
-}
-
-func getInternal(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (*Team, error) {
-	return Load(ctx, g, keybase1.LoadTeamArg{
-		ID:          id,
-		ForceRepoll: true,
-	})
-}
-
 type rawTeam struct {
 	ID             keybase1.TeamID                                        `json:"id"`
 	Name           keybase1.TeamName                                      `json:"name"`
@@ -53,16 +39,18 @@ func (r *rawTeam) parseLinks(ctx context.Context) ([]SCChainLink, error) {
 }
 
 func GetForTeamManagementByStringName(ctx context.Context, g *libkb.GlobalContext, name string) (*Team, error) {
-	return getInternalByStringName(ctx, g, name)
-}
-
-func GetForTeamManagement(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (*Team, error) {
-	return getInternal(ctx, g, id)
+	return Load(ctx, g, keybase1.LoadTeamArg{
+		Name:        name,
+		ForceRepoll: true,
+	})
 }
 
 func GetForApplication(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID, app keybase1.TeamApplication, refreshers keybase1.TeamRefreshers) (*Team, error) {
 	// TODO -- use the `application` and `refreshers` arguments
-	return getInternal(ctx, g, id)
+	return Load(ctx, g, keybase1.LoadTeamArg{
+		ID:          id,
+		ForceRepoll: true,
+	})
 }
 
 func GetStale(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (*Team, error) {

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -13,7 +13,10 @@ func HandleRotateRequest(ctx context.Context, g *libkb.GlobalContext, teamID key
 	ctx = libkb.WithLogTag(ctx, "CLKR")
 	defer g.CTrace(ctx, fmt.Sprintf("HandleRotateRequest(%s,%d)", teamID, generation), func() error { return err })()
 
-	team, err := GetForTeamManagement(ctx, g, teamID)
+	team, err := Load(ctx, g, keybase1.LoadTeamArg{
+		ID:          teamID,
+		ForceRepoll: true,
+	})
 	if err != nil {
 		return err
 	}
@@ -23,13 +26,13 @@ func HandleRotateRequest(ctx context.Context, g *libkb.GlobalContext, teamID key
 		return nil
 	}
 
-	g.Log.CDebugf(ctx, "rotating team %s (%s)", team.Name, teamID)
+	g.Log.CDebugf(ctx, "rotating team %s (%s)", team.Name(), teamID)
 	if err := team.Rotate(ctx); err != nil {
-		g.Log.CDebugf(ctx, "rotating team %s (%s) error: %s", team.Name, teamID, err)
+		g.Log.CDebugf(ctx, "rotating team %s (%s) error: %s", team.Name(), teamID, err)
 		return err
 	}
 
-	g.Log.CDebugf(ctx, "sucess rotating team %s (%s)", team.Name, teamID)
+	g.Log.CDebugf(ctx, "sucess rotating team %s (%s)", team.Name(), teamID)
 	return nil
 }
 

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -241,7 +241,7 @@ func (l *TeamLoader) load2Inner(ctx context.Context, arg load2ArgT) (*keybase1.T
 	var lastSeqno keybase1.Seqno
 	var lastLinkID keybase1.LinkID
 	if (ret == nil) || repoll {
-		l.G().Log.CDebugf(ctx, "TeamLoader looking up merkle leaf")
+		l.G().Log.CDebugf(ctx, "TeamLoader looking up merkle leaf (force:%v)", arg.forceRepoll)
 		// Reference the merkle tree to fetch the sigchain tail leaf for the team.
 		lastSeqno, lastLinkID, err = l.lookupMerkle(ctx, arg.teamID)
 	} else {

--- a/go/teams/rpc_exim_test.go
+++ b/go/teams/rpc_exim_test.go
@@ -27,8 +27,8 @@ func TestTeamPlusApplicationKeysExim(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error during export: %s", err)
 	}
-	if exported.Name != team.Name.String() {
-		t.Fatalf("Got name %s, expected %s", exported.Name, team.Name)
+	if exported.Name != team.Name().String() {
+		t.Fatalf("Got name %s, expected %s", exported.Name, team.Name())
 	}
 	if !exported.Id.Eq(team.ID) {
 		t.Fatalf("Got id %q, expected %q", exported.Id, team.ID)

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -16,7 +16,6 @@ type Team struct {
 	libkb.Contextified
 
 	ID   keybase1.TeamID
-	Name keybase1.TeamName
 	Data *keybase1.TeamData
 
 	keyManager *TeamKeyManager
@@ -31,13 +30,16 @@ func NewTeam(ctx context.Context, g *libkb.GlobalContext, teamData *keybase1.Tea
 		Contextified: libkb.NewContextified(g),
 
 		ID:   chain.GetID(),
-		Name: chain.GetName(),
 		Data: teamData,
 	}
 }
 
 func (t *Team) chain() *TeamSigChainState {
 	return &TeamSigChainState{inner: t.Data.Chain}
+}
+
+func (t *Team) Name() keybase1.TeamName {
+	return t.chain().GetName()
 }
 
 func (t *Team) Generation() keybase1.PerTeamKeyGeneration {
@@ -215,7 +217,7 @@ func (t *Team) readerKeyMask(
 
 func (t *Team) Rotate(ctx context.Context) error {
 
-	// make keys for the team
+	// initialize key manager
 	if _, err := t.SharedSecret(ctx); err != nil {
 		return err
 	}
@@ -255,7 +257,7 @@ func (t *Team) Rotate(ctx context.Context) error {
 	// result of this work, so use `NextSeqno()` and not `CurrentSeqno()`. Note that we're going
 	// to be getting this same notification a second time, since it will bounce off a gregor and
 	// back to us. But they are idempotent, so it should be fine to be double-notified.
-	t.G().NotifyRouter.HandleTeamChanged(ctx, t.chain().GetID(), t.Name.String(), t.NextSeqno(), keybase1.TeamChangeSet{KeyRotated: true})
+	t.G().NotifyRouter.HandleTeamChanged(ctx, t.chain().GetID(), t.Name().String(), t.NextSeqno(), keybase1.TeamChangeSet{KeyRotated: true})
 
 	return nil
 }
@@ -323,7 +325,7 @@ func (t *Team) ChangeMembership(ctx context.Context, req keybase1.TeamChangeReq)
 
 	// send notification that team key rotated
 	changes := keybase1.TeamChangeSet{MembershipChanged: true, KeyRotated: t.rotated}
-	t.G().NotifyRouter.HandleTeamChanged(ctx, t.chain().GetID(), t.Name.String(), t.NextSeqno(), changes)
+	t.G().NotifyRouter.HandleTeamChanged(ctx, t.chain().GetID(), t.Name().String(), t.NextSeqno(), changes)
 	return nil
 }
 
@@ -352,7 +354,7 @@ func (t *Team) InviteMember(ctx context.Context, username string, role keybase1.
 }
 
 func (t *Team) InviteEmailMember(ctx context.Context, email string, role keybase1.TeamRole) error {
-	t.G().Log.Debug("team %s invite email member %s", t.Name, email)
+	t.G().Log.Debug("team %s invite email member %s", t.Name(), email)
 	invite := SCTeamInvite{
 		Type: "email",
 		Name: email,
@@ -362,7 +364,7 @@ func (t *Team) InviteEmailMember(ctx context.Context, email string, role keybase
 }
 
 func (t *Team) inviteKeybaseMember(ctx context.Context, uid keybase1.UID, role keybase1.TeamRole, resolvedUsername libkb.NormalizedUsername) (keybase1.TeamAddMemberResult, error) {
-	t.G().Log.Debug("team %s invite keybase member %s", t.Name, uid)
+	t.G().Log.Debug("team %s invite keybase member %s", t.Name(), uid)
 	invite := SCTeamInvite{
 		Type: "keybase",
 		Name: uid.String(),
@@ -384,7 +386,7 @@ func (t *Team) inviteSBSMember(ctx context.Context, username string, role keybas
 		return keybase1.TeamAddMemberResult{}, fmt.Errorf("invalid user assertion %q, keybase assertion should be handled earlier", username)
 	}
 	typ, name := assertion.ToKeyValuePair()
-	t.G().Log.Debug("team %s invite sbs member %s/%s", t.Name, typ, name)
+	t.G().Log.Debug("team %s invite sbs member %s/%s", t.Name(), typ, name)
 
 	invite := SCTeamInvite{
 		Type: typ,
@@ -459,7 +461,12 @@ func (t *Team) traverseUpUntil(ctx context.Context, validator func(t *Team) bool
 		if parentID == nil {
 			return nil, nil
 		}
-		targetTeam, err = GetForTeamManagement(ctx, t.G(), *parentID)
+		targetTeam, err = Load(ctx, t.G(), keybase1.LoadTeamArg{
+			ID: *parentID,
+			// This is in a cold path anyway, so might as well trade reliability
+			// at the expense of speed.
+			ForceRepoll: true,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -496,7 +503,7 @@ func (t *Team) getAdminPermission(ctx context.Context, required bool) (admin *SC
 }
 
 func (t *Team) changeMembershipSection(ctx context.Context, req keybase1.TeamChangeReq) (SCTeamSection, *PerTeamSharedSecretBoxes, *memberSet, error) {
-	// make keys for the team
+	// initialize key manager
 	if _, err := t.SharedSecret(ctx); err != nil {
 		return SCTeamSection{}, nil, nil, err
 	}


### PR DESCRIPTION
To avoid unnecessary RPCs when loading teams, this uses more informative `LoadTeamArg`s from inside chat. This leaves the `ForceRepoll` load in `KeyFinder.Find` but adds `FindForEncryption` and `FindForDecryption` that get used instead by boxer. More of this sort of thing could probably be done in other places. Whenever you see this line there's a good chance it's an unecessary RPC.
```
TeamLoader looking up merkle leaf (force:true)
```

The reduction in the number of RPCs from TeamLoader when sending and receiving a chat message on the happiest path:
```
send from CLI: 3 -> 1
recv from CLI: 1 -> 0
send from GUI: 2 -> 0
recv from GUI: 1 -> 0
```
