### PR TITLE
Fix "pgp encrypt" tracking

### DIFF
--- a/go/client/cmd_pgp_encrypt.go
+++ b/go/client/cmd_pgp_encrypt.go
@@ -77,7 +77,7 @@ func (c *CmdPGPEncrypt) Run() error {
 	protocols := []rpc.Protocol{
 		NewStreamUIProtocol(c.G()),
 		NewSecretUIProtocol(c.G()),
-		NewIdentifyMaybeTrackUIProtocol(c.G()),
+		NewIdentifyTrackUIProtocol(c.G()),
 	}
 	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
 		return err

--- a/go/client/cmd_pgp_pull.go
+++ b/go/client/cmd_pgp_pull.go
@@ -28,7 +28,7 @@ func (v *CmdPGPPull) Run() (err error) {
 		return err
 	}
 	protocols := []rpc.Protocol{
-		NewIdentifyMaybeTrackUIProtocol(v.G()),
+		NewIdentifyTrackUIProtocol(v.G()),
 	}
 	if err = RegisterProtocolsWithContext(protocols, v.G()); err != nil {
 		return err

--- a/go/client/cmd_pgp_verify.go
+++ b/go/client/cmd_pgp_verify.go
@@ -59,7 +59,7 @@ func (c *CmdPGPVerify) Run() error {
 	protocols := []rpc.Protocol{
 		NewStreamUIProtocol(c.G()),
 		NewSecretUIProtocol(c.G()),
-		NewIdentifyMaybeTrackUIProtocol(c.G()),
+		NewIdentifyTrackUIProtocol(c.G()),
 		NewPgpUIProtocol(c.G()),
 	}
 	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {

--- a/go/client/identify_ui.go
+++ b/go/client/identify_ui.go
@@ -23,30 +23,6 @@ func NewIdentifyTrackUIProtocol(g *libkb.GlobalContext) rpc.Protocol {
 	return keybase1.IdentifyUiProtocol(&IdentifyUIServer{ui})
 }
 
-func cliIsLoggedIn(g *libkb.GlobalContext) bool {
-	configCli, err := GetConfigClient(g)
-	if err != nil {
-		return false
-	}
-
-	currentStatus, err := configCli.GetCurrentStatus(context.TODO(), 0)
-	if err != nil {
-		return false
-	}
-
-	return currentStatus.LoggedIn
-}
-
-// NewIdentifyMaybeTrackUIProtocol returns either IdentifyUiProtocol with
-// IdentifyTrackUI or IdentifyUI depending if user is logged in or not.
-func NewIdentifyMaybeTrackUIProtocol(g *libkb.GlobalContext) rpc.Protocol {
-	if !cliIsLoggedIn(g) {
-		return NewIdentifyUIProtocol(g)
-	}
-
-	return NewIdentifyTrackUIProtocol(g)
-}
-
 func (i *IdentifyUIServer) DelegateIdentifyUI(_ context.Context) (int, error) {
 	return 0, libkb.UIDelegationUnavailableError{}
 }

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"fmt"
 
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -243,6 +244,7 @@ func (ui *FakeIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (result key
 		result.IdentityConfirmed = outcome.TrackOptions.BypassConfirm
 		result.RemoteConfirmed = outcome.TrackOptions.BypassConfirm && !outcome.TrackOptions.ExpiringLocal
 	}
+	fmt.Printf("Fake confirm: %+v\n", result)
 	return
 }
 func (ui *FakeIdentifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency) error {

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -173,19 +173,20 @@ func TestIdPGPNotEldest(t *testing.T) {
 }
 
 type FakeIdentifyUI struct {
-	Proofs          map[string]string
-	ProofResults    map[string]keybase1.LinkCheckResult
-	User            *keybase1.User
-	Confirmed       bool
-	Keys            map[libkb.PGPFingerprint]*keybase1.TrackDiff
-	DisplayKeyCalls int
-	DisplayKeyDiffs []*keybase1.TrackDiff
-	Outcome         *keybase1.IdentifyOutcome
-	StartCount      int
-	Token           keybase1.TrackToken
-	BrokenTracking  bool
-	DisplayTLFArg   keybase1.DisplayTLFCreateWithInviteArg
-	DisplayTLFCount int
+	Proofs            map[string]string
+	ProofResults      map[string]keybase1.LinkCheckResult
+	User              *keybase1.User
+	Confirmed         bool
+	Keys              map[libkb.PGPFingerprint]*keybase1.TrackDiff
+	DisplayKeyCalls   int
+	DisplayKeyDiffs   []*keybase1.TrackDiff
+	Outcome           *keybase1.IdentifyOutcome
+	StartCount        int
+	Token             keybase1.TrackToken
+	BrokenTracking    bool
+	DisplayTLFArg     keybase1.DisplayTLFCreateWithInviteArg
+	DisplayTLFCount   int
+	FakeConfirmResult *keybase1.ConfirmResult
 	sync.Mutex
 }
 
@@ -235,8 +236,13 @@ func (ui *FakeIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (result key
 	time.Sleep(100 * time.Millisecond)
 
 	ui.Outcome = outcome
-	result.IdentityConfirmed = outcome.TrackOptions.BypassConfirm
-	result.RemoteConfirmed = outcome.TrackOptions.BypassConfirm && !outcome.TrackOptions.ExpiringLocal
+	if ui.FakeConfirmResult != nil {
+		result.IdentityConfirmed = ui.FakeConfirmResult.IdentityConfirmed
+		result.RemoteConfirmed = ui.FakeConfirmResult.RemoteConfirmed
+	} else {
+		result.IdentityConfirmed = outcome.TrackOptions.BypassConfirm
+		result.RemoteConfirmed = outcome.TrackOptions.BypassConfirm && !outcome.TrackOptions.ExpiringLocal
+	}
 	return
 }
 func (ui *FakeIdentifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency) error {

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -768,6 +768,7 @@ func (e *Identify2WithUID) runIdentifyUI(netContext context.Context, ctx *Contex
 	outcome := e.state.Result()
 	outcome.TrackOptions = e.trackOptions
 	e.confirmResult, err = iui.Confirm(outcome.Export())
+	e.G().Log.CDebugf(netContext, "identify2_with_uid.go confirm result %+v", e.confirmResult)
 	if err != nil {
 		e.G().Log.CDebugf(netContext, "| Failure in iui.Confirm")
 		return err

--- a/go/engine/pgp_decrypt_test.go
+++ b/go/engine/pgp_decrypt_test.go
@@ -38,6 +38,7 @@ func TestPGPDecrypt(t *testing.T) {
 		Sink:         sink,
 		NoSign:       true,
 		BinaryOutput: true,
+		BypassConfirm: true,
 	}
 	enc := NewPGPEncrypt(arg, tc.G)
 	if err := RunEngine(enc, ctx); err != nil {
@@ -80,6 +81,7 @@ func TestPGPDecryptArmored(t *testing.T) {
 		Source: strings.NewReader(msg),
 		Sink:   sink,
 		NoSign: true,
+		BypassConfirm: true,
 	}
 	enc := NewPGPEncrypt(arg, tc.G)
 	if err := RunEngine(enc, ctx); err != nil {
@@ -140,6 +142,7 @@ func TestPGPDecryptSignedSelf(t *testing.T) {
 		Source:       strings.NewReader(msg),
 		Sink:         sink,
 		BinaryOutput: true,
+		BypassConfirm: true,
 	}
 	enc := NewPGPEncrypt(arg, tc.G)
 	if err := RunEngine(enc, ctx); err != nil {
@@ -183,10 +186,11 @@ func TestPGPDecryptSignedOther(t *testing.T) {
 	ctx := decengctx(signer, tcSigner)
 	sink := libkb.NewBufferCloser()
 	arg := &PGPEncryptArg{
-		Recips:       []string{recipient.Username},
-		Source:       strings.NewReader(msg),
-		Sink:         sink,
-		BinaryOutput: true,
+		Recips:        []string{recipient.Username},
+		Source:        strings.NewReader(msg),
+		Sink:          sink,
+		BinaryOutput:  true,
+		BypassConfirm: true,
 	}
 	enc := NewPGPEncrypt(arg, tcSigner.G)
 	if err := RunEngine(enc, ctx); err != nil {
@@ -250,6 +254,7 @@ func TestPGPDecryptSignedIdentify(t *testing.T) {
 		Source:       strings.NewReader(msg),
 		Sink:         sink,
 		BinaryOutput: true,
+		BypassConfirm: true,
 	}
 	enc := NewPGPEncrypt(arg, tcSigner.G)
 	if err := RunEngine(enc, ctx); err != nil {
@@ -317,6 +322,7 @@ func TestPGPDecryptLong(t *testing.T) {
 		Sink:         sink,
 		NoSign:       true,
 		BinaryOutput: true,
+		BypassConfirm: true,
 	}
 	enc := NewPGPEncrypt(arg, tc.G)
 	if err := RunEngine(enc, ctx); err != nil {

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -6,6 +6,7 @@ package engine
 import (
 	"errors"
 	"io"
+	"fmt"
 
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -208,7 +209,6 @@ func (e *PGPEncrypt) verifyUsers(ctx *Context, assertions []string, loggedIn boo
 		arg := keybase1.Identify2Arg{
 			UserAssertion: userAssert,
 			AlwaysBlock:   true,
-			NeedProofSet:  true,
 		}
 		topts := keybase1.TrackOptions{
 			LocalOnly: me == nil,
@@ -219,8 +219,11 @@ func (e *PGPEncrypt) verifyUsers(ctx *Context, assertions []string, loggedIn boo
 			return nil, libkb.IdentifyFailedError{Assertion: userAssert, Reason: err.Error()}
 		}
 
+		_ = fmt.Printf
+
 		res := ieng.Result()
 		confirmResult := ieng.ConfirmResult()
+		fmt.Printf("%+v\n", confirmResult)
 		if !confirmResult.IdentityConfirmed {
 			return nil, libkb.IdentifyFailedError{Assertion: userAssert, Reason: "Not confirmed by user."}
 		}

--- a/go/engine/pgp_encrypt_test.go
+++ b/go/engine/pgp_encrypt_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
 func TestPGPEncrypt(t *testing.T) {
@@ -27,6 +28,7 @@ func TestPGPEncrypt(t *testing.T) {
 		Source: strings.NewReader("track and encrypt, track and encrypt"),
 		Sink:   sink,
 		NoSign: true,
+		BypassConfirm: true,
 	}
 
 	eng := NewPGPEncrypt(arg, tc.G)
@@ -58,6 +60,7 @@ func TestPGPEncryptNoPGPNaClOnly(t *testing.T) {
 		Source: strings.NewReader("track and encrypt, track and encrypt"),
 		Sink:   sink,
 		NoSign: true,
+		BypassConfirm: true,
 	}
 
 	eng := NewPGPEncrypt(arg, tc.G)
@@ -87,6 +90,7 @@ func TestPGPEncryptSelfNoKey(t *testing.T) {
 		Source: strings.NewReader("track and encrypt, track and encrypt"),
 		Sink:   sink,
 		NoSign: true,
+		BypassConfirm: true,
 	}
 
 	eng := NewPGPEncrypt(arg, tc.G)
@@ -106,6 +110,10 @@ func TestPGPEncryptNoTrack(t *testing.T) {
 	u := createFakeUserWithPGPSibkey(tc)
 	trackUI := &FakeIdentifyUI{
 		Proofs: make(map[string]string),
+		FakeConfirmResult: &keybase1.ConfirmResult {
+			IdentityConfirmed: true,
+			RemoteConfirmed: false,
+		},
 	}
 	ctx := &Context{IdentifyUI: trackUI, SecretUI: u.NewSecretUI()}
 
@@ -150,6 +158,7 @@ func TestPGPEncryptSelfTwice(t *testing.T) {
 		Source: strings.NewReader(msg),
 		Sink:   sink,
 		NoSign: true,
+		BypassConfirm: true,
 	}
 
 	eng := NewPGPEncrypt(arg, tc.G)

--- a/go/engine/pgp_pull.go
+++ b/go/engine/pgp_pull.go
@@ -147,6 +147,7 @@ func (e *PGPPullEngine) processUserWhenLoggedOut(ctx *Context, u string) error {
 	iarg := keybase1.Identify2Arg{
 		UserAssertion:    u,
 		ForceRemoteCheck: true,
+		AlwaysBlock:      true,
 	}
 	topts := keybase1.TrackOptions{
 		LocalOnly: true,

--- a/go/engine/pgp_pull.go
+++ b/go/engine/pgp_pull.go
@@ -148,9 +148,11 @@ func (e *PGPPullEngine) processUserWhenLoggedOut(ctx *Context, u string) error {
 		UserAssertion:    u,
 		ForceRemoteCheck: true,
 		AlwaysBlock:      true,
+		NeedProofSet:     true,
 	}
 	topts := keybase1.TrackOptions{
-		LocalOnly: true,
+		LocalOnly:  true,
+		ForPGPPull: true,
 	}
 	ieng := NewResolveThenIdentify2WithTrack(e.G(), &iarg, topts)
 	if err := RunEngine(ieng, ctx); err != nil {

--- a/go/engine/pgp_test.go
+++ b/go/engine/pgp_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
 func TestGenerateNewPGPKey(t *testing.T) {
@@ -164,7 +165,14 @@ func (p *pgpPair) isTracking(meContext libkb.TestContext, username string) bool 
 }
 
 func (p *pgpPair) encrypt(sign bool) (string, int) {
-	ctx := &Context{IdentifyUI: &FakeIdentifyUI{}, SecretUI: p.sender.NewSecretUI()}
+	trackUI := &FakeIdentifyUI{
+		Proofs: make(map[string]string),
+		FakeConfirmResult: &keybase1.ConfirmResult {
+			IdentityConfirmed: true,
+			RemoteConfirmed: false,
+		},
+	}
+	ctx := &Context{IdentifyUI: trackUI, SecretUI: p.sender.NewSecretUI()}
 	sink := libkb.NewBufferCloser()
 	arg := &PGPEncryptArg{
 		Recips: []string{p.recipient.Username},

--- a/go/engine/test.log
+++ b/go/engine/test.log
@@ -1,0 +1,1 @@
+ok  	github.com/keybase/client/go/engine	2.806s

--- a/go/engine/track.go
+++ b/go/engine/track.go
@@ -79,8 +79,8 @@ func (e *TrackEngine) Run(ctx *Context) error {
 	}
 
 	e.confirmResult = ieng.ConfirmResult()
+	e.G().Log.Debug("confirmResult: %+v", e.confirmResult)
 	if !e.confirmResult.IdentityConfirmed {
-		e.G().Log.Debug("confirmResult: %+v", e.confirmResult)
 		return errors.New("Follow not confirmed")
 	}
 


### PR DESCRIPTION
"pgp encrypt" used to ask for tracking confirmation but was not actually publishing tracking statements, so I've added code to do that.

Now the issue is with NewResolveThenIdentify2WithTrack or how it's ran by PGP engines. I needed to use `AlwaysBlock:   true, NeedProofSet:  true`. If `AlwaysBlock` was `false`, it would just exit before user has any chance to confirm or deny. If `NeedProofSet` was `false`, it would early-exit when it found a cached result, but the early exit would not set any return variables, so the callers (PGP engines) would see that the identity was not confirmed (`confirmResult.IdentityConfirmed == false`).

So the issue right now is that previous behavior would not ask for confirmation when recipient was already being tracked, even locally. I can imagine there might be people relying on non-blocking behavior of `pgp encrypt`. With this PR, it still does not ask when person is tracked remotely and proofs didn't change (`▶ INFO Your view is up-to-date`), but the local cache skip is gone because of `NeedProofSet`.

cc @patrickxb @maxtaco I'll appreciate any help! Thanks!