### PR TITLE
SearchV3: Hook up blue plus icon, gray remove cross

### DIFF
--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -126,8 +126,10 @@ export default compose(
   withState('editLastMessageCounter', 'setEditLastMessageCounter', 0),
   withState('listScrollDownCounter', 'setListScrollDownCounter', 0),
   withState('searchText', 'onChangeSearchText', ''),
+  withState('addNewParticipant', 'onAddNewParticipant', false),
   selectedSearchIdHoc,
   withHandlers({
+    onAddNewParticipant: props => () => props.onAddNewParticipant(true),
     onEditLastMessage: props => () => props.setEditLastMessageCounter(props.editLastMessageCounter + 1),
     onFocusInput: props => () => props.setFocusInputCounter(props.focusInputCounter + 1),
     onScrollDown: props => () => props.setListScrollDownCounter(props.listScrollDownCounter + 1),

--- a/shared/chat/conversation/header-or-search-header.js
+++ b/shared/chat/conversation/header-or-search-header.js
@@ -15,6 +15,8 @@ type Props = {
   infoPanelOpen: boolean,
   onToggleInfoPanel: () => void,
   onBack: () => void,
+  onAddNewParticipant: (clicked: boolean) => void,
+  addNewParticipant: boolean,
 }
 
 export default (props: Props) =>
@@ -25,6 +27,8 @@ export default (props: Props) =>
         selectedConversationIDKey={props.selectedConversationIDKey}
         selectedSearchId={props.selectedSearchId}
         onUpdateSelectedSearchResult={props.onUpdateSelectedSearchResult}
+        onAddNewParticipant={props.onAddNewParticipant}
+        addNewParticipant={props.addNewParticipant}
       />
     : <Header
         infoPanelOpen={props.infoPanelOpen}

--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -125,6 +125,8 @@ class Conversation extends Component<void, Props, State> {
           selectedConversationIDKey={this.props.selectedConversationIDKey}
           selectedSearchId={this.props.selectedSearchId}
           onUpdateSelectedSearchResult={this.props.onUpdateSelectedSearchResult}
+          onAddNewParticipant={this.props.onAddNewParticipant}
+          addNewParticipant={this.props.addNewParticipant}
         />
         {this.props.showSearchPending
           ? <ProgressIndicator style={{width: globalMargins.xlarge}} />

--- a/shared/chat/conversation/index.js.flow
+++ b/shared/chat/conversation/index.js.flow
@@ -31,6 +31,8 @@ export type Props = {|
   search: Function,
   selectedSearchId: ?SearchConstants.SearchResultId,
   onUpdateSelectedSearchResult: (id: ?SearchConstants.SearchResultId) => void,
+  onAddNewParticipant: (clicked: boolean) => void,
+  addNewParticipant: boolean,
 |}
 
 export default class Conversation extends Component<void, Props, void> {}

--- a/shared/chat/conversation/index.native.js
+++ b/shared/chat/conversation/index.native.js
@@ -40,6 +40,8 @@ const Conversation = (props: Props) => (
       selectedSearchId={props.selectedSearchId}
       selectedConversationIDKey={props.selectedConversationIDKey}
       onUpdateSelectedSearchResult={props.onUpdateSelectedSearchResult}
+      onAddNewParticipant={props.onAddNewParticipant}
+      addNewParticipant={props.addNewParticipant}
     />
     {props.showSearchPending
       ? <ProgressIndicator style={{width: globalMargins.xlarge}} />

--- a/shared/chat/search-header.js
+++ b/shared/chat/search-header.js
@@ -25,6 +25,8 @@ type OwnProps = {
   selectedSearchId: ?SearchConstants.SearchResultId,
   onUpdateSelectedSearchResult: (id: SearchConstants.SearchResultId) => void,
   showServiceFilter: boolean,
+  onAddNewParticipant: (clicked: boolean) => void,
+  addNewParticipant: boolean,
 }
 
 const mapStateToProps = createSelector(
@@ -49,32 +51,30 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   onAddSelectedUser: id => dispatch(Creators.stageUserForSearch(id)),
 })
 
-const SearchHeader = props => {
-  return (
-    <Box style={{...globalStyles.flexBoxColumn, marginLeft: globalMargins.medium}}>
-      <UserInput
-        ref={props.setInputRef}
-        autoFocus={true}
-        userItems={props.userItems}
-        onRemoveUser={props.onRemoveUser}
-        onClickAddButton={props.onClickAddButton}
-        placeholder={props.placeholder}
-        usernameText={props.searchText}
-        onChangeText={props.onChangeText}
-        onMoveSelectUp={props.onMoveSelectUp}
-        onMoveSelectDown={props.onMoveSelectDown}
-        onClearSearch={props.onClearSearch}
-        onAddSelectedUser={props.onAddSelectedUser}
-        onEnterEmptyText={props.onExitSearch}
-        onCancel={props.onExitSearch}
-      />
-      <Box style={{alignSelf: 'center'}}>
-        {props.showServiceFilter &&
-          <ServiceFilter selectedService={props.selectedService} onSelectService={props.onSelectService} />}
-      </Box>
+const SearchHeader = props => (
+  <Box style={{...globalStyles.flexBoxColumn, marginLeft: globalMargins.medium}}>
+    <UserInput
+      ref={props.setInputRef}
+      autoFocus={true}
+      userItems={props.userItems}
+      onRemoveUser={props.onRemoveUser}
+      onClickAddButton={props.onClickAddButton}
+      placeholder={props.placeholder}
+      usernameText={props.searchText}
+      onChangeText={props.onChangeText}
+      onMoveSelectUp={props.onMoveSelectUp}
+      onMoveSelectDown={props.onMoveSelectDown}
+      onClearSearch={props.onClearSearch}
+      onAddSelectedUser={props.onAddSelectedUser}
+      onEnterEmptyText={props.onExitSearch}
+      onCancel={props.onExitSearch}
+    />
+    <Box style={{alignSelf: 'center'}}>
+      {props.showServiceFilter &&
+        <ServiceFilter selectedService={props.selectedService} onSelectService={props.onSelectService} />}
     </Box>
-  )
-}
+  </Box>
+)
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),
@@ -94,6 +94,10 @@ export default compose(
         props._onSelectService(nextService)
         props.clearSearchResults()
         props.search(props.searchText, nextService)
+      },
+      onClickAddButton: (props: OwnProps) => () => {
+        props.onAddNewParticipant(true)
+        props.search('', props.selectedService)
       },
     }
   }),

--- a/shared/chat/search.js
+++ b/shared/chat/search.js
@@ -105,7 +105,5 @@ export default compose(
   }),
   defaultProps({
     placeholder: 'Search for someone',
-    showAddButton: false,
-    onClickAddButton: () => console.log('todo'),
   })
 )(SearchHeader)

--- a/shared/searchv3/helpers.js
+++ b/shared/searchv3/helpers.js
@@ -86,8 +86,11 @@ const onChangeSelectedSearchResultHoc = compose(
   })
 )
 
-const showServiceLogicHoc = withPropsOnChange(['searchText', 'userItems'], ({searchText, userItems}) => ({
-  showServiceFilter: !!searchText || userItems.length === 0,
-}))
+const showServiceLogicHoc = withPropsOnChange(
+  ['addNewParticipant', 'searchText', 'userItems'],
+  ({addNewParticipant, searchText, userItems}) => ({
+    showServiceFilter: !!searchText || userItems.length === 0 || addNewParticipant,
+  })
+)
 
 export {onChangeSelectedSearchResultHoc, selectedSearchIdHoc, showServiceLogicHoc, clearSearchHoc}

--- a/shared/searchv3/user-input/index.desktop.js
+++ b/shared/searchv3/user-input/index.desktop.js
@@ -162,7 +162,7 @@ class UserInput extends Component<void, Props, State> {
         </Box>
         {onClearSearch &&
           <Icon
-            type="iconfont-close"
+            type="iconfont-remove"
             style={{height: 16, width: 16, marginRight: 10}}
             onClick={onClearSearch}
           />}

--- a/shared/searchv3/user-input/index.native.js
+++ b/shared/searchv3/user-input/index.native.js
@@ -133,6 +133,7 @@ class UserInput extends Component<void, Props, State> {
       onChangeText,
       onClickAddButton,
       onAddSelectedUser,
+      onClearSearch,
     } = this.props
 
     const showAddButton = !!userItems.length && !usernameText.length && onClickAddButton
@@ -180,6 +181,12 @@ class UserInput extends Component<void, Props, State> {
                 }}
               />}
           </Box>
+          {onClearSearch &&
+            <Icon
+              type="iconfont-remove"
+              style={{height: 16, width: 16, marginRight: 16}}
+              onClick={onClearSearch}
+            />}
         </Box>
       </ClickableBox>
     )


### PR DESCRIPTION
@keybase/react-hackers 

 * The blue "add new participant" plus icon wasn't present -- its integration was still TODO
 * This hooks it up to a new state in the conversation container and makes it start a new search with suggestions when clicked
 * Adds the cancel cross to the end of the user-input line on mobile
 * Changes the cancel cross to the correct icon on desktop and mobile