### PR TITLE
Fix back button being centered on mobile

### DIFF
--- a/shared/profile/index.native.js
+++ b/shared/profile/index.native.js
@@ -215,7 +215,7 @@ class Profile extends Component<void, Props, State> {
             <BackButton
               title={null}
               onClick={this.props.onBack}
-              style={{marginLeft: 16}}
+              style={styleBack}
               iconStyle={{color: globalColors.white}}
             />}
           {featureFlags.searchv3Enabled &&
@@ -306,6 +306,12 @@ class Profile extends Component<void, Props, State> {
   }
 }
 
+const styleBack = {
+  left: globalMargins.tiny,
+  position: 'absolute',
+  top: 30,
+}
+
 const styleHeader = {
   ...globalStyles.flexBoxRow,
   height: HEADER_TOP_SPACE,
@@ -362,7 +368,7 @@ const styleSearchContainer = {
   borderRadius: 100,
   justifyContent: 'center',
   minHeight: 24,
-  minWidth: 273,
+  minWidth: 233,
   position: 'absolute',
   top: 30,
   zIndex: SEARCH_CONTAINER_ZINDEX,


### PR DESCRIPTION
@keybase/react-hackers

Was hoping to use relative positioning for this, but I'd need a way to override a `justifyContent`, like a `justifySelf`, which doesn't exist: `justifyContent: 'center'` for the container and `justifySelf: 'flex-start'` for the back button.

The web talks about using `margin: 'auto'` instead, which doesn't seem supported by RN yet but might be in the future.

Anyway, guess this works.  Curious what y'all would have done.