### PR TITLE
Update TeamLoader callers

### DIFF
--- a/go/teams/common_test.go
+++ b/go/teams/common_test.go
@@ -1,8 +1,9 @@
 package teams
 
 import (
-	"context"
 	"testing"
+
+	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"

--- a/go/teams/common_test.go
+++ b/go/teams/common_test.go
@@ -1,13 +1,22 @@
 package teams
 
 import (
+	"context"
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 func SetupTest(tb testing.TB, name string, depth int) (tc libkb.TestContext) {
 	ret := libkb.SetupTest(tb, name, depth+1)
 	NewTeamLoaderAndInstall(ret.G)
 	return ret
+}
+
+func GetForTestByStringName(ctx context.Context, g *libkb.GlobalContext, name string) (*Team, error) {
+	return Load(ctx, g, keybase1.LoadTeamArg{
+		Name:        name,
+		ForceRepoll: true,
+	})
 }

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -146,7 +146,7 @@ func CreateSubteam(ctx context.Context, g *libkb.GlobalContext, subteamBasename 
 		return nil, err
 	}
 
-	parentTeam, err := GetForTeamManagementByStringName(ctx, g, parentName.String())
+	parentTeam, err := GetForTeamManagementByStringName(ctx, g, parentName.String(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/go/teams/get.go
+++ b/go/teams/get.go
@@ -47,42 +47,6 @@ func GetForTeamManagementByStringName(ctx context.Context, g *libkb.GlobalContex
 	})
 }
 
-func GetForApplication(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID, app keybase1.TeamApplication, refreshers keybase1.TeamRefreshers) (*Team, error) {
-	// TODO -- use the `application` and `refreshers` arguments
-	return Load(ctx, g, keybase1.LoadTeamArg{
-		ID:          id,
-		ForceRepoll: true,
-	})
-}
-
-func GetStale(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (*Team, error) {
-	return Load(ctx, g, keybase1.LoadTeamArg{ID: id, StaleOK: true})
-}
-
-func GetStaleByStringName(ctx context.Context, g *libkb.GlobalContext, name string) (*Team, error) {
-	return Load(ctx, g, keybase1.LoadTeamArg{Name: name, StaleOK: true})
-}
-
-func GetForApplicationByStringName(ctx context.Context, g *libkb.GlobalContext, name string, app keybase1.TeamApplication, refreshers keybase1.TeamRefreshers) (*Team, error) {
-	teamName, err := keybase1.TeamNameFromString(name)
-	if err != nil {
-		return nil, err
-	}
-	return GetForApplicationByName(ctx, g, teamName, app, refreshers)
-}
-
-func GetForApplicationByName(ctx context.Context, g *libkb.GlobalContext, name keybase1.TeamName, app keybase1.TeamApplication, refreshers keybase1.TeamRefreshers) (*Team, error) {
-	id, err := ResolveNameToID(ctx, g, name)
-	if err != nil {
-		return nil, err
-	}
-	return GetForApplication(ctx, g, id, app, refreshers)
-}
-
-func GetForChatByStringName(ctx context.Context, g *libkb.GlobalContext, s string, refreshers keybase1.TeamRefreshers) (*Team, error) {
-	return GetForApplicationByStringName(ctx, g, s, keybase1.TeamApplication_CHAT, refreshers)
-}
-
 // Get a team with no stubbed links if we are an admin. Use this instead of NeedAdmin when you don't
 // know whether you are an admin. This always causes roundtrips.
 func GetMaybeAdminByStringName(ctx context.Context, g *libkb.GlobalContext, name string) (*Team, error) {

--- a/go/teams/get_test.go
+++ b/go/teams/get_test.go
@@ -35,7 +35,9 @@ func TestTeamApplicationKey(t *testing.T) {
 
 	name := createTeam(tc)
 
-	team, err := GetForApplicationByStringName(context.TODO(), tc.G, name, keybase1.TeamApplication_CHAT, keybase1.TeamRefreshers{})
+	team, err := Load(context.TODO(), tc.G, keybase1.LoadTeamArg{
+		Name: name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/teams/get_test.go
+++ b/go/teams/get_test.go
@@ -21,7 +21,7 @@ func TestTeamGet(t *testing.T) {
 
 	name := createTeam(tc)
 
-	_, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	_, err := GetForTestByStringName(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestTeamGetRepeat(t *testing.T) {
 
 		name := createTeam(tc)
 
-		_, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+		_, err := GetForTestByStringName(context.TODO(), tc.G, name)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -88,7 +88,7 @@ func TestTeamGetWhileCreate(t *testing.T) {
 	}
 
 	for i := 0; i < 100; i++ {
-		_, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+		_, err := GetForTestByStringName(context.TODO(), tc.G, name)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -121,7 +121,7 @@ func teamGet(t *testing.T) {
 
 	name := createTeam(tc)
 
-	_, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	_, err := GetForTestByStringName(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -232,10 +232,7 @@ func TestLoaderWantMembers(t *testing.T) {
 		team, err := tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 			ID: teamID,
 			Refreshers: keybase1.TeamRefreshers{
-				WantMembers: []keybase1.UserVersion{{
-					Uid:         fus[2].GetUID(),
-					EldestSeqno: keybase1.Seqno(1),
-				}},
+				WantMembers: []keybase1.UserVersion{fus[2].GetUserVersion()},
 			},
 		})
 		require.NoError(t, err)
@@ -251,10 +248,7 @@ func TestLoaderWantMembers(t *testing.T) {
 	t.Logf("U1 loads with WantMembers=U2 and it works")
 	team = loadAsU1WantU2()
 	requireSeqno(team, 4, "seqno should advance to pick up the new link")
-	role, err := TeamSigChainState{inner: team.Chain}.GetUserRole(keybase1.UserVersion{
-		Uid:         fus[2].GetUID(),
-		EldestSeqno: keybase1.Seqno(1),
-	})
+	role, err := TeamSigChainState{inner: team.Chain}.GetUserRole(fus[2].GetUserVersion())
 	require.NoError(t, err)
 	require.Equal(t, keybase1.TeamRole_WRITER, role)
 

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -168,7 +168,7 @@ func TestMemberAddHasBoxes(t *testing.T) {
 	// this change request should generate boxes since other.Username
 	// is not a member
 	req := keybase1.TeamChangeReq{Readers: []keybase1.UserVersion{other.GetUserVersion()}}
-	tm, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	tm, err := GetForTestByStringName(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func TestMemberChangeRoleNoBoxes(t *testing.T) {
 
 	// this change request shouldn't generate any new boxes
 	req := keybase1.TeamChangeReq{Readers: []keybase1.UserVersion{other.GetUserVersion()}}
-	tm, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	tm, err := GetForTestByStringName(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestMemberRemoveRotatesKeys(t *testing.T) {
 	tc, owner, other, _, name := memberSetupMultiple(t)
 	defer tc.Cleanup()
 
-	before, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	before, err := GetForTestByStringName(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,7 +237,7 @@ func TestMemberRemoveRotatesKeys(t *testing.T) {
 	assertRole(tc, name, owner.Username, keybase1.TeamRole_OWNER)
 	assertRole(tc, name, other.Username, keybase1.TeamRole_NONE)
 
-	after, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	after, err := GetForTestByStringName(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -391,7 +391,7 @@ func TestLeave(t *testing.T) {
 	if err := owner.Login(tc.G); err != nil {
 		t.Fatal(err)
 	}
-	team, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	team, err := GetForTestByStringName(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/teams/merkle_test.go
+++ b/go/teams/merkle_test.go
@@ -19,7 +19,7 @@ func TestMerkle(t *testing.T) {
 
 	name := createTeam(tc)
 
-	team, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	team, err := GetForTestByStringName(context.TODO(), tc.G, name)
 	require.NoError(t, err)
 
 	leaf, err := tc.G.MerkleClient.LookupTeam(context.TODO(), team.ID)

--- a/go/teams/rotate_test.go
+++ b/go/teams/rotate_test.go
@@ -17,7 +17,7 @@ func TestRotate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	team, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	team, err := GetForTestByStringName(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestRotate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	after, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	after, err := GetForTestByStringName(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestHandleRotateRequestOldGeneration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	team, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	team, err := GetForTestByStringName(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func TestHandleRotateRequestOldGeneration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	team, err = GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	team, err = GetForTestByStringName(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestHandleRotateRequestOldGeneration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	after, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	after, err := GetForTestByStringName(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestHandleRotateRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	team, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	team, err := GetForTestByStringName(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestHandleRotateRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	after, err := GetForTeamManagementByStringName(context.TODO(), tc.G, name)
+	after, err := GetForTestByStringName(context.TODO(), tc.G, name)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/teams/rpc_exim_test.go
+++ b/go/teams/rpc_exim_test.go
@@ -18,7 +18,9 @@ func TestTeamPlusApplicationKeysExim(t *testing.T) {
 	defer tc.Cleanup()
 
 	name := createTeam(tc)
-	team, err := GetForApplicationByStringName(context.TODO(), tc.G, name, keybase1.TeamApplication_KBFS, keybase1.TeamRefreshers{})
+	team, err := Load(context.TODO(), tc.G, keybase1.LoadTeamArg{
+		Name: name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -33,7 +33,7 @@ func membersUIDsToUsernames(ctx context.Context, g *libkb.GlobalContext, m keyba
 }
 
 func Details(ctx context.Context, g *libkb.GlobalContext, name string, forceRepoll bool) (res keybase1.TeamDetails, err error) {
-	t, err := GetForTeamManagementByStringName(ctx, g, name)
+	t, err := GetMaybeAdminByStringName(ctx, g, name)
 	if err != nil {
 		return res, err
 	}
@@ -114,7 +114,7 @@ func SetRoleReader(ctx context.Context, g *libkb.GlobalContext, teamname, userna
 }
 
 func AddMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string, role keybase1.TeamRole) (keybase1.TeamAddMemberResult, error) {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname)
+	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
 	if err != nil {
 		return keybase1.TeamAddMemberResult{}, err
 	}
@@ -140,7 +140,7 @@ func AddMember(ctx context.Context, g *libkb.GlobalContext, teamname, username s
 }
 
 func InviteEmailMember(ctx context.Context, g *libkb.GlobalContext, teamname, email string, role keybase1.TeamRole) error {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname)
+	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func InviteEmailMember(ctx context.Context, g *libkb.GlobalContext, teamname, em
 }
 
 func EditMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string, role keybase1.TeamRole) error {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname)
+	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func EditMember(ctx context.Context, g *libkb.GlobalContext, teamname, username 
 }
 
 func MemberRole(ctx context.Context, g *libkb.GlobalContext, teamname, username string) (keybase1.TeamRole, error) {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname)
+	t, err := GetForTeamManagementByStringName(ctx, g, teamname, false)
 	if err != nil {
 		return keybase1.TeamRole_NONE, err
 	}
@@ -189,7 +189,7 @@ func MemberRole(ctx context.Context, g *libkb.GlobalContext, teamname, username 
 }
 
 func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, username string) error {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname)
+	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
 	if err != nil {
 		return err
 	}
@@ -214,7 +214,7 @@ func RemoveMember(ctx context.Context, g *libkb.GlobalContext, teamname, usernam
 }
 
 func Leave(ctx context.Context, g *libkb.GlobalContext, teamname string, permanent bool) error {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname)
+	t, err := GetForTeamManagementByStringName(ctx, g, teamname, false)
 	if err != nil {
 		return err
 	}
@@ -222,7 +222,8 @@ func Leave(ctx context.Context, g *libkb.GlobalContext, teamname string, permane
 }
 
 func ChangeRoles(ctx context.Context, g *libkb.GlobalContext, teamname string, req keybase1.TeamChangeReq) error {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname)
+	// Don't needAdmin because we might be leaving, and this needs no information from stubbable links.
+	t, err := GetForTeamManagementByStringName(ctx, g, teamname, false)
 	if err != nil {
 		return err
 	}
@@ -358,7 +359,7 @@ func IdentifyLite(ctx context.Context, g *libkb.GlobalContext, arg keybase1.Iden
 }
 
 func MemberInvite(ctx context.Context, g *libkb.GlobalContext, teamname, username, typ string) (*keybase1.TeamInvite, error) {
-	t, err := GetForTeamManagementByStringName(ctx, g, teamname)
+	t, err := GetForTeamManagementByStringName(ctx, g, teamname, true)
 	if err != nil {
 		return nil, err
 	}

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -742,11 +742,16 @@ func (t *Team) ForceMerkleRootUpdate(ctx context.Context) error {
 	return err
 }
 
-func LoadTeamPlusApplicationKeys(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID, application keybase1.TeamApplication, refreshers keybase1.TeamRefreshers) (keybase1.TeamPlusApplicationKeys, error) {
-	var teamPlusApplicationKeys keybase1.TeamPlusApplicationKeys
-	teamByID, err := GetForApplication(ctx, g, id, application, refreshers)
+func LoadTeamPlusApplicationKeys(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID,
+	application keybase1.TeamApplication, refreshers keybase1.TeamRefreshers) (res keybase1.TeamPlusApplicationKeys, err error) {
+
+	team, err := Load(ctx, g, keybase1.LoadTeamArg{
+		ID:          id,
+		ForceRepoll: true, // TODO CORE-5607 remove this ForceRepoll after KBFS says it's ok.
+		Refreshers:  refreshers,
+	})
 	if err != nil {
-		return teamPlusApplicationKeys, err
+		return res, err
 	}
-	return teamByID.ExportToTeamPlusApplicationKeys(ctx, keybase1.Time(0), application)
+	return team.ExportToTeamPlusApplicationKeys(ctx, keybase1.Time(0), application)
 }


### PR DESCRIPTION
Pop some layers of abstraction around Get. This doesn't change much. Should make it race-free to list subteams from Details when the time comes.