### PR TITLE
Remove ForceRepoll for kbfs

### DIFF
--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -746,9 +746,8 @@ func LoadTeamPlusApplicationKeys(ctx context.Context, g *libkb.GlobalContext, id
 	application keybase1.TeamApplication, refreshers keybase1.TeamRefreshers) (res keybase1.TeamPlusApplicationKeys, err error) {
 
 	team, err := Load(ctx, g, keybase1.LoadTeamArg{
-		ID:          id,
-		ForceRepoll: true, // TODO CORE-5607 remove this ForceRepoll after KBFS says it's ok.
-		Refreshers:  refreshers,
+		ID:         id,
+		Refreshers: refreshers,
 	})
 	if err != nil {
 		return res, err


### PR DESCRIPTION
@strib looks like it passed. I just want to make sure we're on the same page about races with this, so here's an example:

If you get something signed by a user who was added to a team within the last hour and then ask this RPC to find out whether the user is in the team without providing `Refreshers` with `WantMembers`, then you might get an outdated membership that doesn't include the user.