### PR TITLE
handle app notification settings, and set new field on new message frontend notifications about OS notifications CORE-5601

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -183,6 +183,10 @@ func (f failingRemote) SetConversationStatus(context.Context, chat1.SetConversat
 	require.Fail(f.t, "SetConversationStatus call")
 	return chat1.SetConversationStatusRes{}, nil
 }
+func (f failingRemote) SetAppNotificationSettings(context.Context, chat1.SetAppNotificationSettingsArg) (chat1.SetAppNotificationSettingsRes, error) {
+	require.Fail(f.t, "SetAppNotificationSettings call")
+	return chat1.SetAppNotificationSettingsRes{}, nil
+}
 func (f failingRemote) GetUnreadUpdateFull(context.Context, chat1.InboxVers) (chat1.UnreadUpdateFull, error) {
 
 	require.Fail(f.t, "GetUnreadUpdateFull call")

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -379,6 +379,11 @@ func (s *RemoteInboxSource) SetStatus(ctx context.Context, uid gregor1.UID, vers
 	return nil, nil
 }
 
+func (s *RemoteInboxSource) SetAppNotificationSettings(ctx context.Context, uid gregor1.UID,
+	vers chat1.InboxVers, convID chat1.ConversationID, settings chat1.ConversationNotificationInfo) (*chat1.ConversationLocal, error) {
+	return nil, nil
+}
+
 func (s *RemoteInboxSource) TlfFinalize(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 	convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) ([]chat1.ConversationLocal, error) {
 	// Notify rest of system about reset
@@ -626,6 +631,22 @@ func (s *HybridInboxSource) SetStatus(ctx context.Context, uid gregor1.UID, vers
 	}
 	if conv, err = s.getConvLocal(ctx, uid, convID); err != nil {
 		s.Debug(ctx, "SetStatus: unable to load conversation: convID: %s err: %s", convID, err.Error())
+		return nil, nil
+	}
+	return conv, nil
+}
+
+func (s *HybridInboxSource) SetAppNotificationSettings(ctx context.Context, uid gregor1.UID,
+	vers chat1.InboxVers, convID chat1.ConversationID, settings chat1.ConversationNotificationInfo) (conv *chat1.ConversationLocal, err error) {
+	defer s.Trace(ctx, func() error { return err }, "SetAppNotificationSettings")()
+	ib := storage.NewInbox(s.G(), uid)
+	if cerr := ib.SetAppNotificationSettings(ctx, vers, convID, settings); cerr != nil {
+		err = s.handleInboxError(ctx, cerr, uid)
+		return nil, err
+	}
+	if conv, err = s.getConvLocal(ctx, uid, convID); err != nil {
+		s.Debug(ctx, "SetAppNotificationSettings: unable to load conversation: convID: %s err: %s",
+			convID, err.Error())
 		return nil, nil
 	}
 	return conv, nil

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -890,6 +890,13 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		return conversationLocal
 	}
 	conversationLocal.ReaderInfo = *conversationRemote.ReaderInfo
+	if conversationRemote.Notifications == nil {
+		errMsg := "empty Notifications from server?"
+		conversationLocal.Error = chat1.NewConversationErrorLocal(
+			errMsg, conversationRemote, unverifiedTLFName, chat1.ConversationErrorType_TRANSIENT, nil)
+		return conversationLocal
+	}
+	conversationLocal.Notifications = *conversationRemote.Notifications
 
 	if len(conversationRemote.MaxMsgSummaries) == 0 {
 		errMsg := "conversation has an empty MaxMsgSummaries field"

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -890,13 +890,7 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		return conversationLocal
 	}
 	conversationLocal.ReaderInfo = *conversationRemote.ReaderInfo
-	if conversationRemote.Notifications == nil {
-		errMsg := "empty Notifications from server?"
-		conversationLocal.Error = chat1.NewConversationErrorLocal(
-			errMsg, conversationRemote, unverifiedTLFName, chat1.ConversationErrorType_TRANSIENT, nil)
-		return conversationLocal
-	}
-	conversationLocal.Notifications = *conversationRemote.Notifications
+	conversationLocal.Notifications = conversationRemote.Notifications
 
 	if len(conversationRemote.MaxMsgSummaries) == 0 {
 		errMsg := "conversation has an empty MaxMsgSummaries field"

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -326,6 +326,9 @@ func (g *PushHandler) shouldDisplayDesktopNotification(ctx context.Context,
 	if conv == nil {
 		return false
 	}
+	if !utils.GetConversationStatusBehavior(conv.Info.Status).DesktopNotifications {
+		return false
+	}
 	if msg.IsValid() {
 		body := msg.Valid().MessageBody
 		typ, err := body.MessageType()

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -321,6 +321,16 @@ func (g *PushHandler) TlfResolve(ctx context.Context, m gregor.OutOfBandMessage)
 	return nil
 }
 
+func (g *PushHandler) shouldDisplayDesktopNotification(ctx context.Context,
+	uid gregor1.UID, conv *chat1.ConversationLocal, msg chat1.MessageUnboxed) bool {
+	if conv == nil {
+		return false
+	}
+	atMentions := utils.ParseAtMentionedUIDs(ctx, msg.Valid().MessageBody.Text().Body,
+		g.G().GetUPAKLoader(), &g.DebugLabeler)
+	return false
+}
+
 func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = Context(ctx, g.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks,
@@ -399,11 +409,13 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				if err != nil {
 					g.Debug(ctx, "chat activity: error making page: %s", err.Error())
 				}
+				desktopNotification := g.shouldDisplayDesktopNotification(ctx, uid, conv, decmsg)
 				activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{
-					Message:    decmsg,
-					ConvID:     nm.ConvID,
-					Conv:       conv,
-					Pagination: page,
+					Message: decmsg,
+					ConvID:  nm.ConvID,
+					Conv:    conv,
+					DisplayDesktopNotification: desktopNotification,
+					Pagination:                 page,
 				})
 			}
 

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/pager"
 	"github.com/keybase/client/go/chat/storage"
+	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -395,7 +396,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 		action := gm.Action
 		reader.Reset(m.Body().Bytes())
 		switch action {
-		case "newMessage":
+		case types.ActionNewConversation:
 			var nm chat1.NewMessagePayload
 			err = dec.Decode(&nm)
 			if err != nil {
@@ -464,7 +465,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 			if g.badger != nil && nm.UnreadUpdate != nil {
 				g.badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
 			}
-		case "readMessage":
+		case types.ActionReadMessage:
 			var nm chat1.ReadMessagePayload
 			err = dec.Decode(&nm)
 			if err != nil {
@@ -488,7 +489,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 			if g.badger != nil && nm.UnreadUpdate != nil {
 				g.badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
 			}
-		case "setStatus":
+		case types.ActionSetStatus:
 			var nm chat1.SetStatusPayload
 			err = dec.Decode(&nm)
 			if err != nil {
@@ -511,7 +512,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 			if g.badger != nil && nm.UnreadUpdate != nil {
 				g.badger.PushChatUpdate(*nm.UnreadUpdate, nm.InboxVers)
 			}
-		case "setAppNotificationSettings":
+		case types.ActionSetAppNotificationSettings:
 			var nm chat1.SetAppNotificationSettingsPayload
 			err = dec.Decode(&nm)
 			if err != nil {
@@ -531,7 +532,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				Settings: nm.Settings,
 			}
 			activity = chat1.NewChatActivityWithSetAppNotificationSettings(info)
-		case "newConversation":
+		case types.ActionNewConversation:
 			var nm chat1.NewConversationPayload
 			err = dec.Decode(&nm)
 			if err != nil {
@@ -743,15 +744,15 @@ func (g *PushHandler) HandleOobm(ctx context.Context, obm gregor.OutOfBandMessag
 	}
 
 	switch obm.System().String() {
-	case "chat.activity":
+	case types.PushActivity:
 		return g.Activity(ctx, obm)
-	case "chat.tlffinalize":
+	case types.PushTLFFinalize:
 		return g.TlfFinalize(ctx, obm)
-	case "chat.tlfresolve":
+	case types.PushTLFResolve:
 		return g.TlfResolve(ctx, obm)
-	case "chat.typing":
+	case types.PushTyping:
 		return g.Typing(ctx, obm)
-	case "chat.membershipUpdate":
+	case types.PushMembershipUpdate:
 		return g.MembershipUpdate(ctx, obm)
 	}
 

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -396,7 +396,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 		action := gm.Action
 		reader.Reset(m.Body().Bytes())
 		switch action {
-		case types.ActionNewConversation:
+		case types.ActionNewMessage:
 			var nm chat1.NewMessagePayload
 			err = dec.Decode(&nm)
 			if err != nil {

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -323,7 +323,7 @@ func (g *PushHandler) TlfResolve(ctx context.Context, m gregor.OutOfBandMessage)
 
 func (g *PushHandler) shouldDisplayDesktopNotification(ctx context.Context,
 	uid gregor1.UID, conv *chat1.ConversationLocal, msg chat1.MessageUnboxed) bool {
-	if conv == nil {
+	if conv == nil || conv.Notifications == nil {
 		return false
 	}
 	if !utils.GetConversationStatusBehavior(conv.Info.Status).DesktopNotifications {

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -330,6 +330,10 @@ func (g *PushHandler) shouldDisplayDesktopNotification(ctx context.Context,
 		return false
 	}
 	if msg.IsValid() {
+		// No notifications for our own messages
+		if msg.Valid().ClientHeader.Sender.Eq(uid) {
+			return false
+		}
 		body := msg.Valid().MessageBody
 		typ, err := body.MessageType()
 		if err != nil {

--- a/go/chat/push_test.go
+++ b/go/chat/push_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/chat/storage"
+	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -48,7 +49,7 @@ func sendSimple(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext, p
 	newVers := iboxXform(vers)
 	t.Logf("newVers: %d vers: %d", newVers, vers)
 	nm := chat1.NewMessagePayload{
-		Action:    "newMessage",
+		Action:    types.ActionNewMessage,
 		ConvID:    conv.GetConvID(),
 		Message:   *boxed,
 		InboxVers: iboxXform(vers),

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2224,3 +2224,32 @@ func (h *Server) GetTLFConversationsLocal(ctx context.Context, arg chat1.GetTLFC
 	res.Offline = h.G().Syncer.IsConnected(ctx)
 	return res, nil
 }
+
+func (h *Server) SetAppNotificationSettingsLocal(ctx context.Context,
+	arg chat1.SetAppNotificationSettingsLocalArg) (res chat1.SetAppNotificationSettingsLocalRes, err error) {
+	var identBreaks []keybase1.TLFIdentifyFailure
+	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI,
+		&identBreaks, h.identNotifier)
+	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("SetAppNotificationSettings(%s)",
+		arg.ConvID))()
+	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
+	if err = h.assertLoggedIn(ctx); err != nil {
+		return res, err
+	}
+
+	setRes, err := h.remoteClient().SetAppNotificationSettings(ctx, chat1.SetAppNotificationSettingsArg{
+		ConvID:   arg.ConvID,
+		Settings: arg.Settings,
+	})
+	if err != nil {
+		h.Debug(ctx, "SetAppNotificationSettings: failed to post to remote: %s", err.Error())
+		return res, err
+	}
+	if setRes.RateLimit != nil {
+		res.RateLimits = append(res.RateLimits, *setRes.RateLimit)
+	}
+
+	res.RateLimits = utils.AggRateLimits(res.RateLimits)
+	res.Offline = h.G().Syncer.IsConnected(ctx)
+	return res, nil
+}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1254,7 +1254,7 @@ func TestChatSrvGap(t *testing.T) {
 		ooMsg.ServerHeader.MessageID = 4
 
 		payload := chat1.NewMessagePayload{
-			Action:  "newMessage",
+			Action:  types.ActionNewMessage,
 			ConvID:  created.Id,
 			Message: ooMsg,
 		}
@@ -1270,7 +1270,7 @@ func TestChatSrvGap(t *testing.T) {
 		ph := NewPushHandler(tc.Context())
 		require.NoError(t, ph.Activity(ctx, &gregor1.OutOfBandMessage{
 			Uid_:    u.User.GetUID().ToBytes(),
-			System_: "chat.activity",
+			System_: gregor1.System(types.PushActivity),
 			Body_:   data,
 		}))
 
@@ -1283,7 +1283,7 @@ func TestChatSrvGap(t *testing.T) {
 
 		ooMsg.ServerHeader.MessageID = 5
 		payload = chat1.NewMessagePayload{
-			Action:  "newMessage",
+			Action:  types.ActionNewMessage,
 			ConvID:  created.Id,
 			Message: ooMsg,
 		}
@@ -1291,7 +1291,7 @@ func TestChatSrvGap(t *testing.T) {
 		require.NoError(t, enc.Encode(payload))
 		require.NoError(t, ph.Activity(ctx, &gregor1.OutOfBandMessage{
 			Uid_:    u.User.GetUID().ToBytes(),
-			System_: "chat.activity",
+			System_: gregor1.System(types.PushActivity),
 			Body_:   data,
 		}))
 

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -867,7 +867,11 @@ func (i *Inbox) SetAppNotificationSettings(ctx context.Context, vers chat1.Inbox
 		i.Debug(ctx, "SetAppNotificationSettings: no conversation found: convID: %s, clearing", convID)
 		return i.Clear(ctx)
 	}
-	conv.Notifications = &settings
+	for apptype, kindMap := range settings.Settings {
+		for kind, enabled := range kindMap {
+			conv.Notifications.Settings[apptype][kind] = enabled
+		}
+	}
 
 	// Write out to disk
 	ibox.InboxVersion = vers

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -840,6 +840,44 @@ func (i *Inbox) SetStatus(ctx context.Context, vers chat1.InboxVers, convID chat
 	return nil
 }
 
+func (i *Inbox) SetAppNotificationSettings(ctx context.Context, vers chat1.InboxVers,
+	convID chat1.ConversationID, settings chat1.ConversationNotificationInfo) (err Error) {
+	locks.Inbox.Lock()
+	defer locks.Inbox.Unlock()
+	defer i.Trace(ctx, func() error { return err }, "SetAppNotificationSettings")()
+	defer i.maybeNukeFn(func() Error { return err }, i.dbKey())
+
+	i.Debug(ctx, "SetAppNotificationSettings: vers: %d convID: %s", vers, convID)
+	ibox, err := i.readDiskInbox(ctx)
+	if err != nil {
+		if _, ok := err.(MissError); !ok {
+			return nil
+		}
+		return err
+	}
+	// Check inbox versions, make sure it makes sense (clear otherwise)
+	var cont bool
+	if vers, cont, err = i.handleVersion(ctx, ibox.InboxVersion, vers); !cont {
+		return err
+	}
+
+	// Find conversation
+	_, conv := i.getConv(convID, ibox.Conversations)
+	if conv == nil {
+		i.Debug(ctx, "SetAppNotificationSettings: no conversation found: convID: %s, clearing", convID)
+		return i.Clear(ctx)
+	}
+	conv.Notifications = &settings
+
+	// Write out to disk
+	ibox.InboxVersion = vers
+	if err := i.writeDiskInbox(ctx, ibox); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (i *Inbox) TlfFinalize(ctx context.Context, vers chat1.InboxVers, convIDs []chat1.ConversationID,
 	finalizeInfo chat1.ConversationFinalizeInfo) (err Error) {
 	locks.Inbox.Lock()
@@ -965,6 +1003,11 @@ func (i *Inbox) MembershipUpdate(ctx context.Context, vers chat1.InboxVers,
 		if _, ok := err.(MissError); ok {
 			return nil
 		}
+		return err
+	}
+	// Check inbox versions, make sure it makes sense (clear otherwise)
+	var cont bool
+	if vers, cont, err = i.handleVersion(ctx, ibox.InboxVersion, vers); !cont {
 		return err
 	}
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -78,6 +78,8 @@ type InboxSource interface {
 		msgID chat1.MessageID) (*chat1.ConversationLocal, error)
 	SetStatus(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
 		status chat1.ConversationStatus) (*chat1.ConversationLocal, error)
+	SetAppNotificationSettings(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
+		convID chat1.ConversationID, settings chat1.ConversationNotificationInfo) (*chat1.ConversationLocal, error)
 	TlfFinalize(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 		convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) ([]chat1.ConversationLocal, error)
 	MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -5,6 +5,18 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
+var ActionNewConversation = "newConversation"
+var ActionNewMessage = "newMessage"
+var ActionReadMessage = "readMessage"
+var ActionSetStatus = "setStatus"
+var ActionSetAppNotificationSettings = "setAppNotificationSettings"
+
+var PushActivity = "chat.activity"
+var PushTyping = "chat.typing"
+var PushMembershipUpdate = "chat.membershipUpdate"
+var PushTLFFinalize = "chat.tlffinalize"
+var PushTLFResolve = "chat.tlfresolve"
+
 type NameInfo struct {
 	ID               chat1.TLFID
 	CanonicalName    string

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -491,3 +491,15 @@ func GetTopicName(conv chat1.ConversationLocal) string {
 	}
 	return maxTopicMsg.Valid().MessageBody.Metadata().ConversationTitle
 }
+
+func NotificationInfoSet(settings *chat1.ConversationNotificationInfo,
+	apptype chat1.NotificationAppType,
+	kind chat1.NotificationKind, enabled bool) {
+	if settings.Settings == nil {
+		settings.Settings = make(map[chat1.NotificationAppType]map[chat1.NotificationKind]bool)
+	}
+	if settings.Settings[apptype] == nil {
+		settings.Settings[apptype] = make(map[chat1.NotificationKind]bool)
+	}
+	settings.Settings[apptype][kind] = enabled
+}

--- a/go/client/cmd_chat_listchannels.go
+++ b/go/client/cmd_chat_listchannels.go
@@ -28,7 +28,7 @@ func newCmdChatListChannels(cl *libcmdline.CommandLine, g *libkb.GlobalContext) 
 	return cli.Command{
 		Name:         "list-channels",
 		Usage:        "List on channels on a team",
-		ArgumentHelp: "<channel name>",
+		ArgumentHelp: "<team name>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatListChannelsRunner(g), "list-channels", c)
 		},

--- a/go/client/cmd_chat_listmembers.go
+++ b/go/client/cmd_chat_listmembers.go
@@ -28,7 +28,7 @@ func newCmdChatListMembers(cl *libcmdline.CommandLine, g *libkb.GlobalContext) c
 	return cli.Command{
 		Name:         "list-members",
 		Usage:        "List members of a chat channel (must be a member of that channel)",
-		ArgumentHelp: "<channel name>",
+		ArgumentHelp: "[conversation [channel name]]",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatListMembersRunner(g), "list-members", c)
 		},

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -324,6 +324,7 @@ func (m *ChatRemoteMock) GetInboxRemote(ctx context.Context, arg chat1.GetInboxR
 		}
 		convToAppend := *conv
 		convToAppend.ReaderInfo = m.makeReaderInfo(convToAppend.Metadata.ConversationID)
+		convToAppend.Notifications = new(chat1.ConversationNotificationInfo)
 
 		ibfull.Conversations = append(ibfull.Conversations, convToAppend)
 		if arg.Pagination != nil && arg.Pagination.Num != 0 && arg.Pagination.Num == len(ibfull.Conversations) {

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -562,6 +562,11 @@ func (m *ChatRemoteMock) SetConversationStatus(ctx context.Context, arg chat1.Se
 	return chat1.SetConversationStatusRes{}, errors.New("not implemented")
 }
 
+func (m *ChatRemoteMock) SetAppNotificationSettings(ctx context.Context,
+	arg chat1.SetAppNotificationSettingsArg) (res chat1.SetAppNotificationSettingsRes, err error) {
+	return res, errors.New("not implemented")
+}
+
 func (m *ChatRemoteMock) TlfFinalize(ctx context.Context, arg chat1.TlfFinalizeArg) error {
 	return nil
 }

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -184,6 +184,44 @@ var TopicTypeRevMap = map[TopicType]string{
 	2: "DEV",
 }
 
+type NotificationAppType int
+
+const (
+	NotificationAppType_DESKTOP NotificationAppType = 0
+	NotificationAppType_MOBILE  NotificationAppType = 1
+)
+
+func (o NotificationAppType) DeepCopy() NotificationAppType { return o }
+
+var NotificationAppTypeMap = map[string]NotificationAppType{
+	"DESKTOP": 0,
+	"MOBILE":  1,
+}
+
+var NotificationAppTypeRevMap = map[NotificationAppType]string{
+	0: "DESKTOP",
+	1: "MOBILE",
+}
+
+type NotificationKind int
+
+const (
+	NotificationKind_GENERIC   NotificationKind = 0
+	NotificationKind_ATMENTION NotificationKind = 1
+)
+
+func (o NotificationKind) DeepCopy() NotificationKind { return o }
+
+var NotificationKindMap = map[string]NotificationKind{
+	"GENERIC":   0,
+	"ATMENTION": 1,
+}
+
+var NotificationKindRevMap = map[NotificationKind]string{
+	0: "GENERIC",
+	1: "ATMENTION",
+}
+
 type ConversationStatus int
 
 const (
@@ -526,6 +564,34 @@ func (o ConversationMetadata) DeepCopy() ConversationMetadata {
 	}
 }
 
+type ConversationNotificationInfo struct {
+	ChannelWide bool                                              `codec:"channelWide" json:"channelWide"`
+	Settings    map[NotificationAppType]map[NotificationKind]bool `codec:"settings" json:"settings"`
+}
+
+func (o ConversationNotificationInfo) DeepCopy() ConversationNotificationInfo {
+	return ConversationNotificationInfo{
+		ChannelWide: o.ChannelWide,
+		Settings: (func(x map[NotificationAppType]map[NotificationKind]bool) map[NotificationAppType]map[NotificationKind]bool {
+			ret := make(map[NotificationAppType]map[NotificationKind]bool)
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := (func(x map[NotificationKind]bool) map[NotificationKind]bool {
+					ret := make(map[NotificationKind]bool)
+					for k, v := range x {
+						kCopy := k.DeepCopy()
+						vCopy := v
+						ret[kCopy] = vCopy
+					}
+					return ret
+				})(v)
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.Settings),
+	}
+}
+
 type ConversationReaderInfo struct {
 	Mtime     gregor1.Time `codec:"mtime" json:"mtime"`
 	ReadMsgid MessageID    `codec:"readMsgid" json:"readMsgid"`
@@ -541,10 +607,11 @@ func (o ConversationReaderInfo) DeepCopy() ConversationReaderInfo {
 }
 
 type Conversation struct {
-	Metadata        ConversationMetadata    `codec:"metadata" json:"metadata"`
-	ReaderInfo      *ConversationReaderInfo `codec:"readerInfo,omitempty" json:"readerInfo,omitempty"`
-	MaxMsgs         []MessageBoxed          `codec:"maxMsgs" json:"maxMsgs"`
-	MaxMsgSummaries []MessageSummary        `codec:"maxMsgSummaries" json:"maxMsgSummaries"`
+	Metadata        ConversationMetadata          `codec:"metadata" json:"metadata"`
+	ReaderInfo      *ConversationReaderInfo       `codec:"readerInfo,omitempty" json:"readerInfo,omitempty"`
+	Notifications   *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
+	MaxMsgs         []MessageBoxed                `codec:"maxMsgs" json:"maxMsgs"`
+	MaxMsgSummaries []MessageSummary              `codec:"maxMsgSummaries" json:"maxMsgSummaries"`
 }
 
 func (o Conversation) DeepCopy() Conversation {
@@ -557,6 +624,13 @@ func (o Conversation) DeepCopy() Conversation {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.ReaderInfo),
+		Notifications: (func(x *ConversationNotificationInfo) *ConversationNotificationInfo {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Notifications),
 		MaxMsgs: (func(x []MessageBoxed) []MessageBoxed {
 			var ret []MessageBoxed
 			for _, v := range x {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -582,6 +582,10 @@ func (r *GetTLFConversationsLocalRes) SetOffline() {
 	r.Offline = true
 }
 
+func (r *SetAppNotificationSettingsLocalRes) SetOffline() {
+	r.Offline = true
+}
+
 func (t TyperInfo) String() string {
 	return fmt.Sprintf("typer(u:%s d:%s)", t.Username, t.DeviceName)
 }

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -116,6 +116,22 @@ func (o SetStatusPayload) DeepCopy() SetStatusPayload {
 	}
 }
 
+type SetAppNotificationSettingsPayload struct {
+	Action    string                       `codec:"Action" json:"Action"`
+	ConvID    ConversationID               `codec:"convID" json:"convID"`
+	InboxVers InboxVers                    `codec:"inboxVers" json:"inboxVers"`
+	Settings  ConversationNotificationInfo `codec:"settings" json:"settings"`
+}
+
+func (o SetAppNotificationSettingsPayload) DeepCopy() SetAppNotificationSettingsPayload {
+	return SetAppNotificationSettingsPayload{
+		Action:    o.Action,
+		ConvID:    o.ConvID.DeepCopy(),
+		InboxVers: o.InboxVers.DeepCopy(),
+		Settings:  o.Settings.DeepCopy(),
+	}
+}
+
 type UnreadUpdate struct {
 	ConvID         ConversationID `codec:"convID" json:"convID"`
 	UnreadMessages int            `codec:"UnreadMessages" json:"UnreadMessages"`

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -2107,7 +2107,7 @@ type ConversationLocal struct {
 	Error            *ConversationErrorLocal       `codec:"error,omitempty" json:"error,omitempty"`
 	Info             ConversationInfoLocal         `codec:"info" json:"info"`
 	ReaderInfo       ConversationReaderInfo        `codec:"readerInfo" json:"readerInfo"`
-	Notifications    ConversationNotificationInfo  `codec:"notifications" json:"notifications"`
+	Notifications    *ConversationNotificationInfo `codec:"notifications,omitempty" json:"notifications,omitempty"`
 	Supersedes       []ConversationMetadata        `codec:"supersedes" json:"supersedes"`
 	SupersededBy     []ConversationMetadata        `codec:"supersededBy" json:"supersededBy"`
 	MaxMessages      []MessageUnboxed              `codec:"maxMessages" json:"maxMessages"`
@@ -2124,9 +2124,15 @@ func (o ConversationLocal) DeepCopy() ConversationLocal {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Error),
-		Info:          o.Info.DeepCopy(),
-		ReaderInfo:    o.ReaderInfo.DeepCopy(),
-		Notifications: o.Notifications.DeepCopy(),
+		Info:       o.Info.DeepCopy(),
+		ReaderInfo: o.ReaderInfo.DeepCopy(),
+		Notifications: (func(x *ConversationNotificationInfo) *ConversationNotificationInfo {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Notifications),
 		Supersedes: (func(x []ConversationMetadata) []ConversationMetadata {
 			var ret []ConversationMetadata
 			for _, v := range x {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -2107,6 +2107,7 @@ type ConversationLocal struct {
 	Error            *ConversationErrorLocal       `codec:"error,omitempty" json:"error,omitempty"`
 	Info             ConversationInfoLocal         `codec:"info" json:"info"`
 	ReaderInfo       ConversationReaderInfo        `codec:"readerInfo" json:"readerInfo"`
+	Notifications    ConversationNotificationInfo  `codec:"notifications" json:"notifications"`
 	Supersedes       []ConversationMetadata        `codec:"supersedes" json:"supersedes"`
 	SupersededBy     []ConversationMetadata        `codec:"supersededBy" json:"supersededBy"`
 	MaxMessages      []MessageUnboxed              `codec:"maxMessages" json:"maxMessages"`
@@ -2123,8 +2124,9 @@ func (o ConversationLocal) DeepCopy() ConversationLocal {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Error),
-		Info:       o.Info.DeepCopy(),
-		ReaderInfo: o.ReaderInfo.DeepCopy(),
+		Info:          o.Info.DeepCopy(),
+		ReaderInfo:    o.ReaderInfo.DeepCopy(),
+		Notifications: o.Notifications.DeepCopy(),
 		Supersedes: (func(x []ConversationMetadata) []ConversationMetadata {
 			var ret []ConversationMetadata
 			for _, v := range x {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -2927,6 +2927,25 @@ func (o GetTLFConversationsLocalRes) DeepCopy() GetTLFConversationsLocalRes {
 	}
 }
 
+type SetAppNotificationSettingsLocalRes struct {
+	Offline    bool        `codec:"offline" json:"offline"`
+	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
+}
+
+func (o SetAppNotificationSettingsLocalRes) DeepCopy() SetAppNotificationSettingsLocalRes {
+	return SetAppNotificationSettingsLocalRes{
+		Offline: o.Offline,
+		RateLimits: (func(x []RateLimit) []RateLimit {
+			var ret []RateLimit
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.RateLimits),
+	}
+}
+
 type GetThreadLocalArg struct {
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
 	Query            *GetThreadQuery              `codec:"query,omitempty" json:"query,omitempty"`
@@ -3504,6 +3523,18 @@ func (o GetTLFConversationsLocalArg) DeepCopy() GetTLFConversationsLocalArg {
 	}
 }
 
+type SetAppNotificationSettingsLocalArg struct {
+	ConvID   ConversationID               `codec:"convID" json:"convID"`
+	Settings ConversationNotificationInfo `codec:"settings" json:"settings"`
+}
+
+func (o SetAppNotificationSettingsLocalArg) DeepCopy() SetAppNotificationSettingsLocalArg {
+	return SetAppNotificationSettingsLocalArg{
+		ConvID:   o.ConvID.DeepCopy(),
+		Settings: o.Settings.DeepCopy(),
+	}
+}
+
 type LocalInterface interface {
 	GetThreadLocal(context.Context, GetThreadLocalArg) (GetThreadLocalRes, error)
 	GetCachedThread(context.Context, GetCachedThreadArg) (GetThreadLocalRes, error)
@@ -3534,6 +3565,7 @@ type LocalInterface interface {
 	JoinConversationByIDLocal(context.Context, ConversationID) (JoinLeaveConversationLocalRes, error)
 	LeaveConversationLocal(context.Context, ConversationID) (JoinLeaveConversationLocalRes, error)
 	GetTLFConversationsLocal(context.Context, GetTLFConversationsLocalArg) (GetTLFConversationsLocalRes, error)
+	SetAppNotificationSettingsLocal(context.Context, SetAppNotificationSettingsLocalArg) (SetAppNotificationSettingsLocalRes, error)
 }
 
 func LocalProtocol(i LocalInterface) rpc.Protocol {
@@ -4004,6 +4036,22 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"setAppNotificationSettingsLocal": {
+				MakeArg: func() interface{} {
+					ret := make([]SetAppNotificationSettingsLocalArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]SetAppNotificationSettingsLocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]SetAppNotificationSettingsLocalArg)(nil), args)
+						return
+					}
+					ret, err = i.SetAppNotificationSettingsLocal(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -4160,5 +4208,10 @@ func (c LocalClient) LeaveConversationLocal(ctx context.Context, convID Conversa
 
 func (c LocalClient) GetTLFConversationsLocal(ctx context.Context, __arg GetTLFConversationsLocalArg) (res GetTLFConversationsLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.getTLFConversationsLocal", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) SetAppNotificationSettingsLocal(ctx context.Context, __arg SetAppNotificationSettingsLocalArg) (res SetAppNotificationSettingsLocalRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.setAppNotificationSettingsLocal", []interface{}{__arg}, &res)
 	return
 }

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -55,16 +55,18 @@ func (e ChatActivityType) String() string {
 }
 
 type IncomingMessage struct {
-	Message    MessageUnboxed     `codec:"message" json:"message"`
-	ConvID     ConversationID     `codec:"convID" json:"convID"`
-	Conv       *ConversationLocal `codec:"conv,omitempty" json:"conv,omitempty"`
-	Pagination *Pagination        `codec:"pagination,omitempty" json:"pagination,omitempty"`
+	Message                    MessageUnboxed     `codec:"message" json:"message"`
+	ConvID                     ConversationID     `codec:"convID" json:"convID"`
+	DisplayDesktopNotification bool               `codec:"displayDesktopNotification" json:"displayDesktopNotification"`
+	Conv                       *ConversationLocal `codec:"conv,omitempty" json:"conv,omitempty"`
+	Pagination                 *Pagination        `codec:"pagination,omitempty" json:"pagination,omitempty"`
 }
 
 func (o IncomingMessage) DeepCopy() IncomingMessage {
 	return IncomingMessage{
 		Message: o.Message.DeepCopy(),
 		ConvID:  o.ConvID.DeepCopy(),
+		DisplayDesktopNotification: o.DisplayDesktopNotification,
 		Conv: (func(x *ConversationLocal) *ConversationLocal {
 			if x == nil {
 				return nil

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -176,13 +176,14 @@ func (o MembersUpdateInfo) DeepCopy() MembersUpdateInfo {
 }
 
 type ChatActivity struct {
-	ActivityType__    ChatActivityType     `codec:"activityType" json:"activityType"`
-	IncomingMessage__ *IncomingMessage     `codec:"incomingMessage,omitempty" json:"incomingMessage,omitempty"`
-	ReadMessage__     *ReadMessageInfo     `codec:"readMessage,omitempty" json:"readMessage,omitempty"`
-	NewConversation__ *NewConversationInfo `codec:"newConversation,omitempty" json:"newConversation,omitempty"`
-	SetStatus__       *SetStatusInfo       `codec:"setStatus,omitempty" json:"setStatus,omitempty"`
-	FailedMessage__   *FailedMessageInfo   `codec:"failedMessage,omitempty" json:"failedMessage,omitempty"`
-	MembersUpdate__   *MembersUpdateInfo   `codec:"membersUpdate,omitempty" json:"membersUpdate,omitempty"`
+	ActivityType__               ChatActivityType                `codec:"activityType" json:"activityType"`
+	IncomingMessage__            *IncomingMessage                `codec:"incomingMessage,omitempty" json:"incomingMessage,omitempty"`
+	ReadMessage__                *ReadMessageInfo                `codec:"readMessage,omitempty" json:"readMessage,omitempty"`
+	NewConversation__            *NewConversationInfo            `codec:"newConversation,omitempty" json:"newConversation,omitempty"`
+	SetStatus__                  *SetStatusInfo                  `codec:"setStatus,omitempty" json:"setStatus,omitempty"`
+	FailedMessage__              *FailedMessageInfo              `codec:"failedMessage,omitempty" json:"failedMessage,omitempty"`
+	MembersUpdate__              *MembersUpdateInfo              `codec:"membersUpdate,omitempty" json:"membersUpdate,omitempty"`
+	SetAppNotificationSettings__ *SetAppNotificationSettingsInfo `codec:"setAppNotificationSettings,omitempty" json:"setAppNotificationSettings,omitempty"`
 }
 
 func (o *ChatActivity) ActivityType() (ret ChatActivityType, err error) {
@@ -215,6 +216,11 @@ func (o *ChatActivity) ActivityType() (ret ChatActivityType, err error) {
 	case ChatActivityType_MEMBERS_UPDATE:
 		if o.MembersUpdate__ == nil {
 			err = errors.New("unexpected nil value for MembersUpdate__")
+			return ret, err
+		}
+	case ChatActivityType_SET_APP_NOTIFICATION_SETTINGS:
+		if o.SetAppNotificationSettings__ == nil {
+			err = errors.New("unexpected nil value for SetAppNotificationSettings__")
 			return ret, err
 		}
 	}
@@ -281,6 +287,16 @@ func (o ChatActivity) MembersUpdate() (res MembersUpdateInfo) {
 	return *o.MembersUpdate__
 }
 
+func (o ChatActivity) SetAppNotificationSettings() (res SetAppNotificationSettingsInfo) {
+	if o.ActivityType__ != ChatActivityType_SET_APP_NOTIFICATION_SETTINGS {
+		panic("wrong case accessed")
+	}
+	if o.SetAppNotificationSettings__ == nil {
+		return
+	}
+	return *o.SetAppNotificationSettings__
+}
+
 func NewChatActivityWithIncomingMessage(v IncomingMessage) ChatActivity {
 	return ChatActivity{
 		ActivityType__:    ChatActivityType_INCOMING_MESSAGE,
@@ -320,6 +336,13 @@ func NewChatActivityWithMembersUpdate(v MembersUpdateInfo) ChatActivity {
 	return ChatActivity{
 		ActivityType__:  ChatActivityType_MEMBERS_UPDATE,
 		MembersUpdate__: &v,
+	}
+}
+
+func NewChatActivityWithSetAppNotificationSettings(v SetAppNotificationSettingsInfo) ChatActivity {
+	return ChatActivity{
+		ActivityType__:               ChatActivityType_SET_APP_NOTIFICATION_SETTINGS,
+		SetAppNotificationSettings__: &v,
 	}
 }
 
@@ -368,6 +391,13 @@ func (o ChatActivity) DeepCopy() ChatActivity {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.MembersUpdate__),
+		SetAppNotificationSettings__: (func(x *SetAppNotificationSettingsInfo) *SetAppNotificationSettingsInfo {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.SetAppNotificationSettings__),
 	}
 }
 

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -13,25 +13,27 @@ import (
 type ChatActivityType int
 
 const (
-	ChatActivityType_RESERVED         ChatActivityType = 0
-	ChatActivityType_INCOMING_MESSAGE ChatActivityType = 1
-	ChatActivityType_READ_MESSAGE     ChatActivityType = 2
-	ChatActivityType_NEW_CONVERSATION ChatActivityType = 3
-	ChatActivityType_SET_STATUS       ChatActivityType = 4
-	ChatActivityType_FAILED_MESSAGE   ChatActivityType = 5
-	ChatActivityType_MEMBERS_UPDATE   ChatActivityType = 6
+	ChatActivityType_RESERVED                      ChatActivityType = 0
+	ChatActivityType_INCOMING_MESSAGE              ChatActivityType = 1
+	ChatActivityType_READ_MESSAGE                  ChatActivityType = 2
+	ChatActivityType_NEW_CONVERSATION              ChatActivityType = 3
+	ChatActivityType_SET_STATUS                    ChatActivityType = 4
+	ChatActivityType_FAILED_MESSAGE                ChatActivityType = 5
+	ChatActivityType_MEMBERS_UPDATE                ChatActivityType = 6
+	ChatActivityType_SET_APP_NOTIFICATION_SETTINGS ChatActivityType = 7
 )
 
 func (o ChatActivityType) DeepCopy() ChatActivityType { return o }
 
 var ChatActivityTypeMap = map[string]ChatActivityType{
-	"RESERVED":         0,
-	"INCOMING_MESSAGE": 1,
-	"READ_MESSAGE":     2,
-	"NEW_CONVERSATION": 3,
-	"SET_STATUS":       4,
-	"FAILED_MESSAGE":   5,
-	"MEMBERS_UPDATE":   6,
+	"RESERVED":                      0,
+	"INCOMING_MESSAGE":              1,
+	"READ_MESSAGE":                  2,
+	"NEW_CONVERSATION":              3,
+	"SET_STATUS":                    4,
+	"FAILED_MESSAGE":                5,
+	"MEMBERS_UPDATE":                6,
+	"SET_APP_NOTIFICATION_SETTINGS": 7,
 }
 
 var ChatActivityTypeRevMap = map[ChatActivityType]string{
@@ -42,6 +44,7 @@ var ChatActivityTypeRevMap = map[ChatActivityType]string{
 	4: "SET_STATUS",
 	5: "FAILED_MESSAGE",
 	6: "MEMBERS_UPDATE",
+	7: "SET_APP_NOTIFICATION_SETTINGS",
 }
 
 func (e ChatActivityType) String() string {
@@ -126,6 +129,18 @@ func (o SetStatusInfo) DeepCopy() SetStatusInfo {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Conv),
+	}
+}
+
+type SetAppNotificationSettingsInfo struct {
+	ConvID   ConversationID               `codec:"convID" json:"convID"`
+	Settings ConversationNotificationInfo `codec:"settings" json:"settings"`
+}
+
+func (o SetAppNotificationSettingsInfo) DeepCopy() SetAppNotificationSettingsInfo {
+	return SetAppNotificationSettingsInfo{
+		ConvID:   o.ConvID.DeepCopy(),
+		Settings: o.Settings.DeepCopy(),
 	}
 }
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -626,6 +626,22 @@ func (o GetTLFConversationsRes) DeepCopy() GetTLFConversationsRes {
 	}
 }
 
+type SetAppNotificationSettingsRes struct {
+	RateLimit *RateLimit `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+}
+
+func (o SetAppNotificationSettingsRes) DeepCopy() SetAppNotificationSettingsRes {
+	return SetAppNotificationSettingsRes{
+		RateLimit: (func(x *RateLimit) *RateLimit {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.RateLimit),
+	}
+}
+
 type GetInboxRemoteArg struct {
 	Vers       InboxVers      `codec:"vers" json:"vers"`
 	Query      *GetInboxQuery `codec:"query,omitempty" json:"query,omitempty"`
@@ -993,6 +1009,18 @@ func (o GetTLFConversationsArg) DeepCopy() GetTLFConversationsArg {
 	}
 }
 
+type SetAppNotificationSettingsArg struct {
+	ConvID   ConversationID               `codec:"convID" json:"convID"`
+	Settings ConversationNotificationInfo `codec:"settings" json:"settings"`
+}
+
+func (o SetAppNotificationSettingsArg) DeepCopy() SetAppNotificationSettingsArg {
+	return SetAppNotificationSettingsArg{
+		ConvID:   o.ConvID.DeepCopy(),
+		Settings: o.Settings.DeepCopy(),
+	}
+}
+
 type RemoteInterface interface {
 	GetInboxRemote(context.Context, GetInboxRemoteArg) (GetInboxRemoteRes, error)
 	GetThreadRemote(context.Context, GetThreadRemoteArg) (GetThreadRemoteRes, error)
@@ -1018,6 +1046,7 @@ type RemoteInterface interface {
 	JoinConversation(context.Context, ConversationID) (JoinLeaveConversationRemoteRes, error)
 	LeaveConversation(context.Context, ConversationID) (JoinLeaveConversationRemoteRes, error)
 	GetTLFConversations(context.Context, GetTLFConversationsArg) (GetTLFConversationsRes, error)
+	SetAppNotificationSettings(context.Context, SetAppNotificationSettingsArg) (SetAppNotificationSettingsRes, error)
 }
 
 func RemoteProtocol(i RemoteInterface) rpc.Protocol {
@@ -1408,6 +1437,22 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"setAppNotificationSettings": {
+				MakeArg: func() interface{} {
+					ret := make([]SetAppNotificationSettingsArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]SetAppNotificationSettingsArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]SetAppNotificationSettingsArg)(nil), args)
+						return
+					}
+					ret, err = i.SetAppNotificationSettings(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -1541,5 +1586,10 @@ func (c RemoteClient) LeaveConversation(ctx context.Context, convID Conversation
 
 func (c RemoteClient) GetTLFConversations(ctx context.Context, __arg GetTLFConversationsArg) (res GetTLFConversationsRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.remote.getTLFConversations", []interface{}{__arg}, &res)
+	return
+}
+
+func (c RemoteClient) SetAppNotificationSettings(ctx context.Context, __arg SetAppNotificationSettingsArg) (res SetAppNotificationSettingsRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.remote.setAppNotificationSettings", []interface{}{__arg}, &res)
 	return
 }

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -39,6 +39,18 @@ protocol common {
     DEV_2
   }
 
+  @go("nostring")
+  enum NotificationAppType {
+    DESKTOP_0,
+    MOBILE_1
+  }
+
+  @go("nostring")
+  enum NotificationKind {
+    GENERIC_0,
+    ATMENTION_1
+  }
+
   enum ConversationStatus {
     // Default status of the conversation
     UNFILED_0,
@@ -161,6 +173,11 @@ protocol common {
     array<gregor1.UID> allList;
   }
 
+  record ConversationNotificationInfo {
+    boolean channelWide;
+    map<NotificationAppType, map<NotificationKind, boolean>> settings;
+  }
+
   record ConversationReaderInfo {
     gregor1.Time mtime; // The last time the convo was modified from the user perspective
     MessageID readMsgid; // The message ID the user has read up to in the convo
@@ -170,6 +187,7 @@ protocol common {
   record Conversation {
     ConversationMetadata metadata;
     union { null, ConversationReaderInfo } readerInfo; // information about the convo from a user perspective 
+    union { null, ConversationNotificationInfo } notifications; // user notification settings for the convo, will be null if it is just the default. Otherwise contains entries to modify default setting.
 
     // maxMsgs is the maximum message for each messageType in the conversation
     array<MessageBoxed> maxMsgs;

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -44,6 +44,14 @@ protocol gregor {
         InboxVers inboxVers;
         union { null, UnreadUpdate } unreadUpdate;
     }
+
+    record SetAppNotificationSettingsPayload {
+        @lint("ignore")
+        string Action;
+        ConversationID convID;
+        InboxVers inboxVers;
+        ConversationNotificationInfo settings;
+    }
     
     record UnreadUpdate {
         ConversationID convID;

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -395,6 +395,7 @@ protocol local {
     union { null, ConversationErrorLocal } error;
     ConversationInfoLocal info;
     ConversationReaderInfo readerInfo;
+    ConversationNotificationInfo notifications;
     array<ConversationMetadata> supersedes;
     array<ConversationMetadata> supersededBy;
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -660,4 +660,11 @@ protocol local {
   }
   GetTLFConversationsLocalRes getTLFConversationsLocal(string tlfName, TopicType topicType, ConversationMembersType membersType);
 
+  // Chat notification configuration endpoint. Does not need to be complete, just a delta on the 
+  // currently configured settings. 
+  record SetAppNotificationSettingsLocalRes {
+    boolean offline;
+    array<RateLimit> rateLimits; 
+  } 
+  SetAppNotificationSettingsLocalRes setAppNotificationSettingsLocal(ConversationID convID, ConversationNotificationInfo settings); 
 }

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -395,7 +395,7 @@ protocol local {
     union { null, ConversationErrorLocal } error;
     ConversationInfoLocal info;
     ConversationReaderInfo readerInfo;
-    ConversationNotificationInfo notifications;
+    union { null, ConversationNotificationInfo } notifications;
     array<ConversationMetadata> supersedes;
     array<ConversationMetadata> supersededBy;
 

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -18,6 +18,7 @@ protocol NotifyChat {
   record IncomingMessage {
     MessageUnboxed message;
     ConversationID convID;
+    boolean displayDesktopNotification;
     union { null, ConversationLocal } conv;
     union { null, Pagination } pagination;
   }

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -60,6 +60,7 @@ protocol NotifyChat {
     case SET_STATUS: SetStatusInfo;
     case FAILED_MESSAGE: FailedMessageInfo;
     case MEMBERS_UPDATE: MembersUpdateInfo;
+    case SET_APP_NOTIFICATION_SETTINGS: SetAppNotificationSettingsInfo;
   }
 
   record TyperInfo {

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -11,7 +11,8 @@ protocol NotifyChat {
     NEW_CONVERSATION_3,
     SET_STATUS_4,
     FAILED_MESSAGE_5,
-    MEMBERS_UPDATE_6
+    MEMBERS_UPDATE_6,
+    SET_APP_NOTIFICATION_SETTINGS_7
   } 
 
   record IncomingMessage {
@@ -35,6 +36,11 @@ protocol NotifyChat {
     ConversationID convID;
     ConversationStatus status;
     union { null, ConversationLocal } conv;
+  }
+
+  record SetAppNotificationSettingsInfo {
+    ConversationID convID;
+    ConversationNotificationInfo settings;
   }
 
   record FailedMessageInfo {

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -225,4 +225,12 @@ protocol remote {
     union { null, RateLimit } rateLimit;
   }
   GetTLFConversationsRes getTLFConversations(TLFID tlfID, TopicType topicType, ConversationMembersType membersType, boolean summarizeMaxMsgs);
+
+  // Chat notification configuration endpoint. Does not need to be complete, just a delta on the 
+  // currently configured settings.
+  record SetAppNotificationSettingsRes {
+    union { null, RateLimit } rateLimit; 
+  }
+  SetAppNotificationSettingsRes setAppNotificationSettings(ConversationID convID, ConversationNotificationInfo settings);
+
 }

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1213,6 +1213,7 @@ export type ConversationLocal = {
   error?: ?ConversationErrorLocal,
   info: ConversationInfoLocal,
   readerInfo: ConversationReaderInfo,
+  notifications: ConversationNotificationInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
   maxMessages?: ?Array<MessageUnboxed>,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -93,6 +93,16 @@ export const CommonMessageType = {
   attachmentuploaded: 8,
 }
 
+export const CommonNotificationAppType = {
+  desktop: 0,
+  mobile: 1,
+}
+
+export const CommonNotificationKind = {
+  generic: 0,
+  atmention: 1,
+}
+
 export const CommonTLFVisibility = {
   any: 0,
   public: 1,
@@ -1108,6 +1118,7 @@ export type ConvTypingUpdate = {
 export type Conversation = {
   metadata: ConversationMetadata,
   readerInfo?: ?ConversationReaderInfo,
+  notifications?: ?ConversationNotificationInfo,
   maxMsgs?: ?Array<MessageBoxed>,
   maxMsgSummaries?: ?Array<MessageSummary>,
 }
@@ -1202,6 +1213,11 @@ export type ConversationMetadata = {
   supersededBy?: ?Array<ConversationMetadata>,
   activeList?: ?Array<gregor1.UID>,
   allList?: ?Array<gregor1.UID>,
+}
+
+export type ConversationNotificationInfo = {
+  channelWide: boolean,
+  settings: {[key: string]: {[key: string]: boolean}},
 }
 
 export type ConversationReaderInfo = {
@@ -1727,6 +1743,14 @@ export type NonblockFetchRes = {
   rateLimits?: ?Array<RateLimit>,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
+
+export type NotificationAppType =
+    0 // DESKTOP_0
+  | 1 // MOBILE_1
+
+export type NotificationKind =
+    0 // GENERIC_0
+  | 1 // ATMENTION_1
 
 export type NotifyChatChatIdentifyUpdateRpcParam = Exact<{
   update: keybase1.CanonicalTLFNameAndIDWithBreaks

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1213,7 +1213,7 @@ export type ConversationLocal = {
   error?: ?ConversationErrorLocal,
   info: ConversationInfoLocal,
   readerInfo: ConversationReaderInfo,
-  notifications: ConversationNotificationInfo,
+  notifications?: ?ConversationNotificationInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
   maxMessages?: ?Array<MessageUnboxed>,

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -622,6 +622,21 @@ export function localRetryPostRpcPromise (request: $Exact<requestCommon & reques
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.RetryPost', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function localSetAppNotificationSettingsLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localSetAppNotificationSettingsLocalResult) => void} & {param: localSetAppNotificationSettingsLocalRpcParam}>) {
+  engineRpcOutgoing('chat.1.local.setAppNotificationSettingsLocal', request)
+}
+
+export function localSetAppNotificationSettingsLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localSetAppNotificationSettingsLocalResult) => void} & {param: localSetAppNotificationSettingsLocalRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.setAppNotificationSettingsLocal', request)
+}
+export function localSetAppNotificationSettingsLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localSetAppNotificationSettingsLocalResult) => void} & {param: localSetAppNotificationSettingsLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.setAppNotificationSettingsLocal', request, callback, incomingCallMap) })
+}
+
+export function localSetAppNotificationSettingsLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localSetAppNotificationSettingsLocalResult) => void} & {param: localSetAppNotificationSettingsLocalRpcParam}>): Promise<localSetAppNotificationSettingsLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.setAppNotificationSettingsLocal', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function localSetConversationStatusLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localSetConversationStatusLocalResult) => void} & {param: localSetConversationStatusLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.SetConversationStatusLocal', request)
 }
@@ -1928,6 +1943,11 @@ export type SetAppNotificationSettingsInfo = {
   settings: ConversationNotificationInfo,
 }
 
+export type SetAppNotificationSettingsLocalRes = {
+  offline: boolean,
+  rateLimits?: ?Array<RateLimit>,
+}
+
 export type SetAppNotificationSettingsPayload = {
   Action: string,
   convID: ConversationID,
@@ -2310,6 +2330,11 @@ export type localRetryPostRpcParam = Exact<{
   outboxID: OutboxID
 }>
 
+export type localSetAppNotificationSettingsLocalRpcParam = Exact<{
+  convID: ConversationID,
+  settings: ConversationNotificationInfo
+}>
+
 export type localSetConversationStatusLocalRpcParam = Exact<{
   conversationID: ConversationID,
   status: ConversationStatus,
@@ -2481,6 +2506,7 @@ type localPostFileAttachmentLocalResult = PostLocalRes
 type localPostLocalNonblockResult = PostLocalNonblockRes
 type localPostLocalResult = PostLocalRes
 type localPostTextNonblockResult = PostLocalNonblockRes
+type localSetAppNotificationSettingsLocalResult = SetAppNotificationSettingsLocalRes
 type localSetConversationStatusLocalResult = SetConversationStatusLocalRes
 type remoteGetInboxRemoteResult = GetInboxRemoteRes
 type remoteGetInboxVersionResult = InboxVers
@@ -2531,6 +2557,7 @@ export type rpc =
   | localPostLocalRpc
   | localPostTextNonblockRpc
   | localRetryPostRpc
+  | localSetAppNotificationSettingsLocalRpc
   | localSetConversationStatusLocalRpc
   | localUpdateTypingRpc
   | remoteGetInboxRemoteRpc

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1131,6 +1131,7 @@ export type ChatActivity =
   | { activityType: 4, setStatus: ?SetStatusInfo }
   | { activityType: 5, failedMessage: ?FailedMessageInfo }
   | { activityType: 6, membersUpdate: ?MembersUpdateInfo }
+  | { activityType: 7, setAppNotificationSettings: ?SetAppNotificationSettingsInfo }
 
 export type ChatActivityType =
     0 // RESERVED_0

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -197,6 +197,7 @@ export const NotifyChatChatActivityType = {
   setStatus: 4,
   failedMessage: 5,
   membersUpdate: 6,
+  setAppNotificationSettings: 7,
 }
 
 export const RemoteMessageBoxedVersion = {
@@ -906,6 +907,21 @@ export function remoteS3SignRpcPromise (request: $Exact<requestCommon & {callbac
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.s3Sign', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function remoteSetAppNotificationSettingsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetAppNotificationSettingsResult) => void} & {param: remoteSetAppNotificationSettingsRpcParam}>) {
+  engineRpcOutgoing('chat.1.remote.setAppNotificationSettings', request)
+}
+
+export function remoteSetAppNotificationSettingsRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetAppNotificationSettingsResult) => void} & {param: remoteSetAppNotificationSettingsRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.setAppNotificationSettings', request)
+}
+export function remoteSetAppNotificationSettingsRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetAppNotificationSettingsResult) => void} & {param: remoteSetAppNotificationSettingsRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.setAppNotificationSettings', request, callback, incomingCallMap) })
+}
+
+export function remoteSetAppNotificationSettingsRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetAppNotificationSettingsResult) => void} & {param: remoteSetAppNotificationSettingsRpcParam}>): Promise<remoteSetAppNotificationSettingsResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.setAppNotificationSettings', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function remoteSetConversationStatusRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetConversationStatusResult) => void} & {param: remoteSetConversationStatusRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.SetConversationStatus', request)
 }
@@ -1109,6 +1125,7 @@ export type ChatActivityType =
   | 4 // SET_STATUS_4
   | 5 // FAILED_MESSAGE_5
   | 6 // MEMBERS_UPDATE_6
+  | 7 // SET_APP_NOTIFICATION_SETTINGS_7
 
 export type ConvTypingUpdate = {
   convID: ConversationID,
@@ -1906,6 +1923,22 @@ export type ServerCacheVers = {
   bodiesVers: int,
 }
 
+export type SetAppNotificationSettingsInfo = {
+  convID: ConversationID,
+  settings: ConversationNotificationInfo,
+}
+
+export type SetAppNotificationSettingsPayload = {
+  Action: string,
+  convID: ConversationID,
+  inboxVers: InboxVers,
+  settings: ConversationNotificationInfo,
+}
+
+export type SetAppNotificationSettingsRes = {
+  rateLimit?: ?RateLimit,
+}
+
 export type SetConversationStatusLocalRes = {
   rateLimits?: ?Array<RateLimit>,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
@@ -2376,6 +2409,11 @@ export type remoteS3SignRpcParam = Exact<{
   payload: bytes
 }>
 
+export type remoteSetAppNotificationSettingsRpcParam = Exact<{
+  convID: ConversationID,
+  settings: ConversationNotificationInfo
+}>
+
 export type remoteSetConversationStatusRpcParam = Exact<{
   conversationID: ConversationID,
   status: ConversationStatus
@@ -2459,6 +2497,7 @@ type remoteNewConversationRemote2Result = NewConversationRemoteRes
 type remoteNewConversationRemoteResult = NewConversationRemoteRes
 type remotePostRemoteResult = PostRemoteRes
 type remoteS3SignResult = bytes
+type remoteSetAppNotificationSettingsResult = SetAppNotificationSettingsRes
 type remoteSetConversationStatusResult = SetConversationStatusRes
 type remoteSyncAllResult = SyncAllResult
 type remoteSyncChatResult = SyncChatRes
@@ -2511,6 +2550,7 @@ export type rpc =
   | remotePublishReadMessageRpc
   | remotePublishSetConversationStatusRpc
   | remoteS3SignRpc
+  | remoteSetAppNotificationSettingsRpc
   | remoteSetConversationStatusRpc
   | remoteSyncAllRpc
   | remoteSyncChatRpc

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -1518,6 +1518,7 @@ export type InboxViewFull = {
 export type IncomingMessage = {
   message: MessageUnboxed,
   convID: ConversationID,
+  displayDesktopNotification: boolean,
   conv?: ?ConversationLocal,
   pagination?: ?Pagination,
 }

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -102,6 +102,24 @@
     },
     {
       "type": "enum",
+      "name": "NotificationAppType",
+      "symbols": [
+        "DESKTOP_0",
+        "MOBILE_1"
+      ],
+      "go": "nostring"
+    },
+    {
+      "type": "enum",
+      "name": "NotificationKind",
+      "symbols": [
+        "GENERIC_0",
+        "ATMENTION_1"
+      ],
+      "go": "nostring"
+    },
+    {
+      "type": "enum",
       "name": "ConversationStatus",
       "symbols": [
         "UNFILED_0",
@@ -387,6 +405,28 @@
     },
     {
       "type": "record",
+      "name": "ConversationNotificationInfo",
+      "fields": [
+        {
+          "type": "boolean",
+          "name": "channelWide"
+        },
+        {
+          "type": {
+            "type": "map",
+            "values": {
+              "type": "map",
+              "values": "boolean",
+              "keys": "NotificationKind"
+            },
+            "keys": "NotificationAppType"
+          },
+          "name": "settings"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "ConversationReaderInfo",
       "fields": [
         {
@@ -417,6 +457,13 @@
             "ConversationReaderInfo"
           ],
           "name": "readerInfo"
+        },
+        {
+          "type": [
+            null,
+            "ConversationNotificationInfo"
+          ],
+          "name": "notifications"
         },
         {
           "type": {

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -145,6 +145,29 @@
     },
     {
       "type": "record",
+      "name": "SetAppNotificationSettingsPayload",
+      "fields": [
+        {
+          "type": "string",
+          "name": "Action",
+          "lint": "ignore"
+        },
+        {
+          "type": "ConversationID",
+          "name": "convID"
+        },
+        {
+          "type": "InboxVers",
+          "name": "inboxVers"
+        },
+        {
+          "type": "ConversationNotificationInfo",
+          "name": "settings"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "UnreadUpdate",
       "fields": [
         {

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1114,7 +1114,10 @@
           "name": "readerInfo"
         },
         {
-          "type": "ConversationNotificationInfo",
+          "type": [
+            null,
+            "ConversationNotificationInfo"
+          ],
           "name": "notifications"
         },
         {

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1114,6 +1114,10 @@
           "name": "readerInfo"
         },
         {
+          "type": "ConversationNotificationInfo",
+          "name": "notifications"
+        },
+        {
           "type": {
             "type": "array",
             "items": "ConversationMetadata"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1847,6 +1847,23 @@
           "name": "rateLimits"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "SetAppNotificationSettingsLocalRes",
+      "fields": [
+        {
+          "type": "boolean",
+          "name": "offline"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        }
+      ]
     }
   ],
   "messages": {
@@ -2524,6 +2541,19 @@
         }
       ],
       "response": "GetTLFConversationsLocalRes"
+    },
+    "setAppNotificationSettingsLocal": {
+      "request": [
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "settings",
+          "type": "ConversationNotificationInfo"
+        }
+      ],
+      "response": "SetAppNotificationSettingsLocalRes"
     }
   },
   "namespace": "chat.1"

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -18,7 +18,8 @@
         "NEW_CONVERSATION_3",
         "SET_STATUS_4",
         "FAILED_MESSAGE_5",
-        "MEMBERS_UPDATE_6"
+        "MEMBERS_UPDATE_6",
+        "SET_APP_NOTIFICATION_SETTINGS_7"
       ]
     },
     {
@@ -98,6 +99,20 @@
             "ConversationLocal"
           ],
           "name": "conv"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "SetAppNotificationSettingsInfo",
+      "fields": [
+        {
+          "type": "ConversationID",
+          "name": "convID"
+        },
+        {
+          "type": "ConversationNotificationInfo",
+          "name": "settings"
         }
       ]
     },

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -35,6 +35,10 @@
           "name": "convID"
         },
         {
+          "type": "boolean",
+          "name": "displayDesktopNotification"
+        },
+        {
           "type": [
             null,
             "ConversationLocal"

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -196,6 +196,13 @@
             "def": false
           },
           "body": "MembersUpdateInfo"
+        },
+        {
+          "label": {
+            "name": "SET_APP_NOTIFICATION_SETTINGS",
+            "def": false
+          },
+          "body": "SetAppNotificationSettingsInfo"
         }
       ]
     },

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -471,6 +471,19 @@
           "name": "rateLimit"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "SetAppNotificationSettingsRes",
+      "fields": [
+        {
+          "type": [
+            null,
+            "RateLimit"
+          ],
+          "name": "rateLimit"
+        }
+      ]
     }
   ],
   "messages": {
@@ -856,6 +869,19 @@
         }
       ],
       "response": "GetTLFConversationsRes"
+    },
+    "setAppNotificationSettings": {
+      "request": [
+        {
+          "name": "convID",
+          "type": "ConversationID"
+        },
+        {
+          "name": "settings",
+          "type": "ConversationNotificationInfo"
+        }
+      ],
+      "response": "SetAppNotificationSettingsRes"
     }
   },
   "namespace": "chat.1"

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1213,6 +1213,7 @@ export type ConversationLocal = {
   error?: ?ConversationErrorLocal,
   info: ConversationInfoLocal,
   readerInfo: ConversationReaderInfo,
+  notifications: ConversationNotificationInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
   maxMessages?: ?Array<MessageUnboxed>,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -93,6 +93,16 @@ export const CommonMessageType = {
   attachmentuploaded: 8,
 }
 
+export const CommonNotificationAppType = {
+  desktop: 0,
+  mobile: 1,
+}
+
+export const CommonNotificationKind = {
+  generic: 0,
+  atmention: 1,
+}
+
 export const CommonTLFVisibility = {
   any: 0,
   public: 1,
@@ -1108,6 +1118,7 @@ export type ConvTypingUpdate = {
 export type Conversation = {
   metadata: ConversationMetadata,
   readerInfo?: ?ConversationReaderInfo,
+  notifications?: ?ConversationNotificationInfo,
   maxMsgs?: ?Array<MessageBoxed>,
   maxMsgSummaries?: ?Array<MessageSummary>,
 }
@@ -1202,6 +1213,11 @@ export type ConversationMetadata = {
   supersededBy?: ?Array<ConversationMetadata>,
   activeList?: ?Array<gregor1.UID>,
   allList?: ?Array<gregor1.UID>,
+}
+
+export type ConversationNotificationInfo = {
+  channelWide: boolean,
+  settings: {[key: string]: {[key: string]: boolean}},
 }
 
 export type ConversationReaderInfo = {
@@ -1727,6 +1743,14 @@ export type NonblockFetchRes = {
   rateLimits?: ?Array<RateLimit>,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
+
+export type NotificationAppType =
+    0 // DESKTOP_0
+  | 1 // MOBILE_1
+
+export type NotificationKind =
+    0 // GENERIC_0
+  | 1 // ATMENTION_1
 
 export type NotifyChatChatIdentifyUpdateRpcParam = Exact<{
   update: keybase1.CanonicalTLFNameAndIDWithBreaks

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1213,7 +1213,7 @@ export type ConversationLocal = {
   error?: ?ConversationErrorLocal,
   info: ConversationInfoLocal,
   readerInfo: ConversationReaderInfo,
-  notifications: ConversationNotificationInfo,
+  notifications?: ?ConversationNotificationInfo,
   supersedes?: ?Array<ConversationMetadata>,
   supersededBy?: ?Array<ConversationMetadata>,
   maxMessages?: ?Array<MessageUnboxed>,

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -622,6 +622,21 @@ export function localRetryPostRpcPromise (request: $Exact<requestCommon & reques
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.RetryPost', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function localSetAppNotificationSettingsLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localSetAppNotificationSettingsLocalResult) => void} & {param: localSetAppNotificationSettingsLocalRpcParam}>) {
+  engineRpcOutgoing('chat.1.local.setAppNotificationSettingsLocal', request)
+}
+
+export function localSetAppNotificationSettingsLocalRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localSetAppNotificationSettingsLocalResult) => void} & {param: localSetAppNotificationSettingsLocalRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.local.setAppNotificationSettingsLocal', request)
+}
+export function localSetAppNotificationSettingsLocalRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localSetAppNotificationSettingsLocalResult) => void} & {param: localSetAppNotificationSettingsLocalRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.local.setAppNotificationSettingsLocal', request, callback, incomingCallMap) })
+}
+
+export function localSetAppNotificationSettingsLocalRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: localSetAppNotificationSettingsLocalResult) => void} & {param: localSetAppNotificationSettingsLocalRpcParam}>): Promise<localSetAppNotificationSettingsLocalResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.local.setAppNotificationSettingsLocal', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function localSetConversationStatusLocalRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: localSetConversationStatusLocalResult) => void} & {param: localSetConversationStatusLocalRpcParam}>) {
   engineRpcOutgoing('chat.1.local.SetConversationStatusLocal', request)
 }
@@ -1928,6 +1943,11 @@ export type SetAppNotificationSettingsInfo = {
   settings: ConversationNotificationInfo,
 }
 
+export type SetAppNotificationSettingsLocalRes = {
+  offline: boolean,
+  rateLimits?: ?Array<RateLimit>,
+}
+
 export type SetAppNotificationSettingsPayload = {
   Action: string,
   convID: ConversationID,
@@ -2310,6 +2330,11 @@ export type localRetryPostRpcParam = Exact<{
   outboxID: OutboxID
 }>
 
+export type localSetAppNotificationSettingsLocalRpcParam = Exact<{
+  convID: ConversationID,
+  settings: ConversationNotificationInfo
+}>
+
 export type localSetConversationStatusLocalRpcParam = Exact<{
   conversationID: ConversationID,
   status: ConversationStatus,
@@ -2481,6 +2506,7 @@ type localPostFileAttachmentLocalResult = PostLocalRes
 type localPostLocalNonblockResult = PostLocalNonblockRes
 type localPostLocalResult = PostLocalRes
 type localPostTextNonblockResult = PostLocalNonblockRes
+type localSetAppNotificationSettingsLocalResult = SetAppNotificationSettingsLocalRes
 type localSetConversationStatusLocalResult = SetConversationStatusLocalRes
 type remoteGetInboxRemoteResult = GetInboxRemoteRes
 type remoteGetInboxVersionResult = InboxVers
@@ -2531,6 +2557,7 @@ export type rpc =
   | localPostLocalRpc
   | localPostTextNonblockRpc
   | localRetryPostRpc
+  | localSetAppNotificationSettingsLocalRpc
   | localSetConversationStatusLocalRpc
   | localUpdateTypingRpc
   | remoteGetInboxRemoteRpc

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1131,6 +1131,7 @@ export type ChatActivity =
   | { activityType: 4, setStatus: ?SetStatusInfo }
   | { activityType: 5, failedMessage: ?FailedMessageInfo }
   | { activityType: 6, membersUpdate: ?MembersUpdateInfo }
+  | { activityType: 7, setAppNotificationSettings: ?SetAppNotificationSettingsInfo }
 
 export type ChatActivityType =
     0 // RESERVED_0

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -197,6 +197,7 @@ export const NotifyChatChatActivityType = {
   setStatus: 4,
   failedMessage: 5,
   membersUpdate: 6,
+  setAppNotificationSettings: 7,
 }
 
 export const RemoteMessageBoxedVersion = {
@@ -906,6 +907,21 @@ export function remoteS3SignRpcPromise (request: $Exact<requestCommon & {callbac
   return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.s3Sign', request, (error, result) => error ? reject(error) : resolve(result)))
 }
 
+export function remoteSetAppNotificationSettingsRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetAppNotificationSettingsResult) => void} & {param: remoteSetAppNotificationSettingsRpcParam}>) {
+  engineRpcOutgoing('chat.1.remote.setAppNotificationSettings', request)
+}
+
+export function remoteSetAppNotificationSettingsRpcChannelMap (configKeys: Array<string>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetAppNotificationSettingsResult) => void} & {param: remoteSetAppNotificationSettingsRpcParam}>): EngineChannel {
+  return engine()._channelMapRpcHelper(configKeys, 'chat.1.remote.setAppNotificationSettings', request)
+}
+export function remoteSetAppNotificationSettingsRpcChannelMapOld (channelConfig: ChannelConfig<*>, request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetAppNotificationSettingsResult) => void} & {param: remoteSetAppNotificationSettingsRpcParam}>): ChannelMap<*> {
+  return _channelMapRpcHelper(channelConfig, (incomingCallMap, callback) => { engineRpcOutgoing('chat.1.remote.setAppNotificationSettings', request, callback, incomingCallMap) })
+}
+
+export function remoteSetAppNotificationSettingsRpcPromise (request: $Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetAppNotificationSettingsResult) => void} & {param: remoteSetAppNotificationSettingsRpcParam}>): Promise<remoteSetAppNotificationSettingsResult> {
+  return new Promise((resolve, reject) => engineRpcOutgoing('chat.1.remote.setAppNotificationSettings', request, (error, result) => error ? reject(error) : resolve(result)))
+}
+
 export function remoteSetConversationStatusRpc (request: Exact<requestCommon & {callback?: ?(err: ?any, response: remoteSetConversationStatusResult) => void} & {param: remoteSetConversationStatusRpcParam}>) {
   engineRpcOutgoing('chat.1.remote.SetConversationStatus', request)
 }
@@ -1109,6 +1125,7 @@ export type ChatActivityType =
   | 4 // SET_STATUS_4
   | 5 // FAILED_MESSAGE_5
   | 6 // MEMBERS_UPDATE_6
+  | 7 // SET_APP_NOTIFICATION_SETTINGS_7
 
 export type ConvTypingUpdate = {
   convID: ConversationID,
@@ -1906,6 +1923,22 @@ export type ServerCacheVers = {
   bodiesVers: int,
 }
 
+export type SetAppNotificationSettingsInfo = {
+  convID: ConversationID,
+  settings: ConversationNotificationInfo,
+}
+
+export type SetAppNotificationSettingsPayload = {
+  Action: string,
+  convID: ConversationID,
+  inboxVers: InboxVers,
+  settings: ConversationNotificationInfo,
+}
+
+export type SetAppNotificationSettingsRes = {
+  rateLimit?: ?RateLimit,
+}
+
 export type SetConversationStatusLocalRes = {
   rateLimits?: ?Array<RateLimit>,
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
@@ -2376,6 +2409,11 @@ export type remoteS3SignRpcParam = Exact<{
   payload: bytes
 }>
 
+export type remoteSetAppNotificationSettingsRpcParam = Exact<{
+  convID: ConversationID,
+  settings: ConversationNotificationInfo
+}>
+
 export type remoteSetConversationStatusRpcParam = Exact<{
   conversationID: ConversationID,
   status: ConversationStatus
@@ -2459,6 +2497,7 @@ type remoteNewConversationRemote2Result = NewConversationRemoteRes
 type remoteNewConversationRemoteResult = NewConversationRemoteRes
 type remotePostRemoteResult = PostRemoteRes
 type remoteS3SignResult = bytes
+type remoteSetAppNotificationSettingsResult = SetAppNotificationSettingsRes
 type remoteSetConversationStatusResult = SetConversationStatusRes
 type remoteSyncAllResult = SyncAllResult
 type remoteSyncChatResult = SyncChatRes
@@ -2511,6 +2550,7 @@ export type rpc =
   | remotePublishReadMessageRpc
   | remotePublishSetConversationStatusRpc
   | remoteS3SignRpc
+  | remoteSetAppNotificationSettingsRpc
   | remoteSetConversationStatusRpc
   | remoteSyncAllRpc
   | remoteSyncChatRpc

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -1518,6 +1518,7 @@ export type InboxViewFull = {
 export type IncomingMessage = {
   message: MessageUnboxed,
   convID: ConversationID,
+  displayDesktopNotification: boolean,
   conv?: ?ConversationLocal,
   pagination?: ?Pagination,
 }


### PR DESCRIPTION
Patch does the following:

1.) Adds a new local endpoint for setting app notification settings.
2.) Handles new app notification changed Gregor message. Includes maintaining inbox cache correctly, and sending a message to the frontend that the settings have changed.
3.) Set a bit on new message frontend notifications informing it whether or not to show the desktop toast. cc @chrisnojima about this.
4.) Bunch of protocol changes. 