### PR TITLE
Resolve debounce timing bug

### DIFF
--- a/shared/actions/searchv3/creators.js
+++ b/shared/actions/searchv3/creators.js
@@ -24,11 +24,14 @@ function pendingSearch<T>(actionTypeToFire: T, pending: boolean): Constants.Pend
 function finishedSearch<T>(
   actionTypeToFire: T,
   searchResults: Array<Constants.SearchResultId>,
-  searchTerm: string,
+  searchResultTerm: string,
   service: Constants.Service = 'Keybase',
   searchShowingSuggestions: boolean = false
 ): Constants.FinishedSearch<T> {
-  return {type: actionTypeToFire, payload: {searchTerm, searchResults, service, searchShowingSuggestions}}
+  return {
+    type: actionTypeToFire,
+    payload: {searchResultTerm, searchResults, service, searchShowingSuggestions},
+  }
 }
 
 export {finishedSearch, pendingSearch, search, searchSuggestions}

--- a/shared/chat/search-header.js
+++ b/shared/chat/search-header.js
@@ -10,7 +10,7 @@ import {Box} from '../common-adapters'
 import {compose, withState, defaultProps, withHandlers, lifecycle} from 'recompose'
 import {connect} from 'react-redux'
 import {globalStyles, globalMargins} from '../styles'
-import {chatSearchResultArray} from '../constants/selectors'
+import {chatSearchResultArray, chatSearchResultTerm} from '../constants/selectors'
 import * as HocHelpers from '../searchv3/helpers'
 import {createSelector} from 'reselect'
 
@@ -28,10 +28,11 @@ type OwnProps = {
 }
 
 const mapStateToProps = createSelector(
-  [Constants.getUserItems, chatSearchResultArray],
-  (userItems, searchResultIds) => ({
+  [Constants.getUserItems, chatSearchResultArray, chatSearchResultTerm],
+  (userItems, searchResultIds, searchResultTerm) => ({
     userItems,
     searchResultIds,
+    searchResultTerm,
   })
 )
 

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -385,6 +385,7 @@ export const StateRecord: KBRecord<T> = Record({
   selectedUsersInSearch: List(),
   inSearch: false,
   tempPendingConversations: Map(),
+  searchResultTerm: '',
 })
 
 export type UntrustedState = 'unloaded' | 'loaded' | 'loading'
@@ -417,6 +418,7 @@ export type State = KBRecord<{
   searchShowingSuggestions: boolean,
   selectedUsersInSearch: List<SearchConstants.SearchResultId>,
   inSearch: boolean,
+  searchResultTerm: string,
 }>
 
 export const maxAttachmentPreviewSize = 320

--- a/shared/constants/searchv3.js
+++ b/shared/constants/searchv3.js
@@ -75,7 +75,7 @@ export type PendingSearch<TypeToFire> = NoErrorTypedAction<TypeToFire, {pending:
 
 export type FinishedSearch<TypeToFire> = NoErrorTypedAction<
   TypeToFire,
-  {searchResults: Array<SearchResultId>, searchTerm: string, service: Service}
+  {searchResults: Array<SearchResultId>, searchResultTerm: string, service: Service}
 >
 
 // Generic so others can make their own version

--- a/shared/constants/searchv3.js
+++ b/shared/constants/searchv3.js
@@ -81,7 +81,7 @@ export type FinishedSearch<TypeToFire> = NoErrorTypedAction<
 // Generic so others can make their own version
 export type UpdateSearchResultsGeneric<T> = NoErrorTypedAction<
   T,
-  {searchResults: List<SearchResultId>, searchShowingSuggestions: boolean}
+  {searchResultTerm: string, searchResults: List<SearchResultId>, searchShowingSuggestions: boolean}
 >
 export type PendingSearchGeneric<T> = NoErrorTypedAction<T, boolean>
 

--- a/shared/constants/selectors.js
+++ b/shared/constants/selectors.js
@@ -36,6 +36,8 @@ const chatSearchResultArray = createSelector(
 const chatSearchShowingSuggestions = ({chat: {searchShowingSuggestions}}: TypedState) =>
   searchShowingSuggestions
 
+const chatSearchResultTerm = ({chat: {searchResultTerm}}: TypedState) => searchResultTerm
+
 const profileSearchResultArray = createSelector(
   ({profile: {searchResults}}: TypedState) => searchResults,
   searchResults => (searchResults ? searchResults.toArray() : null)
@@ -51,6 +53,7 @@ export {
   cachedSearchResults,
   chatSearchPending,
   chatSearchShowingSuggestions,
+  chatSearchResultTerm,
   chatSearchResultArray,
   createShallowEqualSelector,
   inboxSearchSelector,

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -646,10 +646,11 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
       return state.set('inboxSearch', List(action.payload.search))
     }
     case 'chat:updateSearchResults': {
-      const {payload: {searchResults, searchShowingSuggestions}} = action
+      const {payload: {searchTerm, searchResults, searchShowingSuggestions}} = action
       return state
         .set('searchResults', List(searchResults))
         .set('searchShowingSuggestions', searchShowingSuggestions)
+        .set('searchResultTerm', searchTerm)
     }
     case 'chat:unstageUserForSearch': {
       const {payload: {user}} = action

--- a/shared/reducers/chat.js
+++ b/shared/reducers/chat.js
@@ -646,11 +646,11 @@ function reducer(state: Constants.State = initialState, action: Constants.Action
       return state.set('inboxSearch', List(action.payload.search))
     }
     case 'chat:updateSearchResults': {
-      const {payload: {searchTerm, searchResults, searchShowingSuggestions}} = action
+      const {payload: {searchResultTerm, searchResults, searchShowingSuggestions}} = action
       return state
         .set('searchResults', List(searchResults))
         .set('searchShowingSuggestions', searchShowingSuggestions)
-        .set('searchResultTerm', searchTerm)
+        .set('searchResultTerm', searchResultTerm)
     }
     case 'chat:unstageUserForSearch': {
       const {payload: {user}} = action

--- a/shared/searchv3/helpers.js
+++ b/shared/searchv3/helpers.js
@@ -73,6 +73,8 @@ const onChangeSelectedSearchResultHoc = compose(
   withHandlers(() => {
     let lastSearchTerm
     return {
+      // onAddSelectedUser happens on desktop when tab, enter or comma
+      // is typed, so we expedite the current search, if any
       onAddSelectedUser: (props: OwnPropsWithSearchDebounced) => () => {
         props._searchDebounced.flush()
         // See whether the current search result term matches the last one submitted


### PR DESCRIPTION
Bug was that the first user in the search results list would be selected immediately when hitting space, tab or comma, though the search was still being debounced, which lasts one second, causing the wrong result to be pilled.

Now, hitting those keys while typing will short-circuit the debuncer and not cause selection. After debouncing has elapsed, they will do the selection as before. In other words, if you quickly type "m-a-x-comma", max will be at the top of the list but not pilled. Hitting comma again will then pill it.

@keybase/react-hackers 