### PR TITLE
display team conv names with channel info

### DIFF
--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -368,11 +368,24 @@ function _conversationLocalToInboxState(c: ?ChatTypes.ConversationLocal): ?Const
     }))
     .first() || {}
 
+  // Temporary hack to make team convos easier to parse in inbox view
+  const teamConvName = List(c.maxMessages || [])
+    .filter(m => m.valid && m.state === ChatTypes.LocalMessageUnboxedState.valid)
+    .map((m: any) => ({body: m.valid.messageBody, time: m.valid.serverHeader.ctime}))
+    .filter(m => [ChatTypes.CommonMessageType.metadata].includes(m.body.messageType))
+    .map((message: {time: number, body: ?ChatTypes.MessageBody}) => ({
+      title: Constants.makeTeamTitle(message.body) || '<none>',
+    }))
+    .first() || {}
+  const parts = c.info.membersType === ChatTypes.CommonConversationMembersType.team
+    ? List([teamConvName.title + ' ' + c.info.tlfName])
+    : List(c.info.writerNames || [])
+
   return new Constants.InboxStateRecord({
     conversationIDKey,
     info: c.info,
     isEmpty: c.isEmpty,
-    participants: List(c.info.writerNames || []),
+    participants: parts || [],
     snippet: toShow.snippet,
     state: 'unboxed',
     status: Constants.ConversationStatusByEnum[c.info ? c.info.status : 0],

--- a/shared/actions/chat/inbox.js
+++ b/shared/actions/chat/inbox.js
@@ -355,9 +355,10 @@ function _conversationLocalToInboxState(c: ?ChatTypes.ConversationLocal): ?Const
 
   const conversationIDKey = Constants.conversationIDToKey(c.info.id)
 
-  const toShow = List(c.maxMessages || [])
+  const validMaxMsgs = List(c.maxMessages || [])
     .filter(m => m.valid && m.state === ChatTypes.LocalMessageUnboxedState.valid)
     .map((m: any) => ({body: m.valid.messageBody, time: m.valid.serverHeader.ctime}))
+  const toShow = validMaxMsgs
     .filter(m =>
       [ChatTypes.CommonMessageType.attachment, ChatTypes.CommonMessageType.text].includes(m.body.messageType)
     )
@@ -369,17 +370,16 @@ function _conversationLocalToInboxState(c: ?ChatTypes.ConversationLocal): ?Const
     .first() || {}
 
   // Temporary hack to make team convos easier to parse in inbox view
-  const teamConvName = List(c.maxMessages || [])
-    .filter(m => m.valid && m.state === ChatTypes.LocalMessageUnboxedState.valid)
-    .map((m: any) => ({body: m.valid.messageBody, time: m.valid.serverHeader.ctime}))
-    .filter(m => [ChatTypes.CommonMessageType.metadata].includes(m.body.messageType))
-    .map((message: {time: number, body: ?ChatTypes.MessageBody}) => ({
-      title: Constants.makeTeamTitle(message.body) || '<none>',
-    }))
-    .first() || {}
-  const parts = c.info.membersType === ChatTypes.CommonConversationMembersType.team
-    ? List([teamConvName.title + ' ' + c.info.tlfName])
-    : List(c.info.writerNames || [])
+  let parts = List(c.info.writerNames || [])
+  if (c.info.membersType === ChatTypes.CommonConversationMembersType.team) {
+    const topicName = validMaxMsgs
+      .filter(m => [ChatTypes.CommonMessageType.metadata].includes(m.body && m.body.messageType))
+      .map((message: {time: number, body: ?ChatTypes.MessageBody}) => ({
+        title: Constants.makeTeamTitle(message.body) || '<none>',
+      }))
+      .first() || {}
+    parts = List([`${topicName.title} ${c.info.tlfName}`])
+  }
 
   return new Constants.InboxStateRecord({
     conversationIDKey,

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -755,7 +755,8 @@ function* _updateMetadata(action: Constants.UpdateMetadata): SagaGenerator<any, 
   // Don't send sharing before signup values
   const metaData = yield select(Shared.metaDataSelector)
   const usernames = action.payload.users.filter(
-    name => metaData.getIn([name, 'fullname']) === undefined && name.indexOf('@') === -1
+    name =>
+      metaData.getIn([name, 'fullname']) === undefined && name.indexOf('@') === -1 && name.indexOf('#') === -1
   )
   if (!usernames.length) {
     return

--- a/shared/chat/inbox/index.desktop.js
+++ b/shared/chat/inbox/index.desktop.js
@@ -172,7 +172,6 @@ const TopLine = ({hasUnread, showBold, participants, subColor, timestamp, userna
             plainDivider={',\u200a'}
             containerStyle={{...boldOverride, color: usernameColor, paddingRight: 6}}
             users={participants.map(p => ({username: p})).toArray()}
-            title={participants.join(', ')}
           />
         </div>
       </div>

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -810,6 +810,18 @@ function makeSnippet(messageBody: ?MessageBody): ?string {
   }
 }
 
+function makeTeamTitle(messageBody: ?MessageBody): ?string {
+  if (!messageBody) {
+    return null
+  }
+  switch (messageBody.messageType) {
+    case ChatTypes.CommonMessageType.metadata:
+      return messageBody.metadata ? messageBody.metadata.conversationTitle : '<none>'
+    default:
+      return null
+  }
+}
+
 // This is emoji aware hence all the weird ... stuff. See https://mathiasbynens.be/notes/javascript-unicode#iterating-over-symbols
 function textSnippet(message: ?string = '', max: number) {
   // $FlowIssue flow doesn't understand spread + strings
@@ -1141,6 +1153,7 @@ export {
   keyToConversationID,
   keyToOutboxID,
   makeSnippet,
+  makeTeamTitle,
   messageKey,
   messageKeyKind,
   messageKeyValue,


### PR DESCRIPTION
This makes the team displayname a "user", and gets the UI to display a useful title for team convos. Looks like this:

![image](https://user-images.githubusercontent.com/1250314/28132345-90b2a36e-670a-11e7-923b-60cbe4c6655c.png)
