### PR TITLE
Add PerUserKey.SignedByKID

### DIFF
--- a/go/engine/puk_roll.go
+++ b/go/engine/puk_roll.go
@@ -40,7 +40,7 @@ func (e *PerUserKeyRoll) Name() string {
 // GetPrereqs returns the engine prereqs.
 func (e *PerUserKeyRoll) Prereqs() Prereqs {
 	return Prereqs{
-		Session: true,
+		Device: true,
 	}
 }
 

--- a/go/engine/puk_roll.go
+++ b/go/engine/puk_roll.go
@@ -20,8 +20,7 @@ type PerUserKeyRoll struct {
 }
 
 type PerUserKeyRollArgs struct {
-	LoginContext libkb.LoginContext // optional
-	Me           *libkb.User        // optional
+	Me *libkb.User // optional
 }
 
 // NewPerUserKeyRoll creates a PerUserKeyRoll engine.
@@ -77,7 +76,6 @@ func (e *PerUserKeyRoll) inner(ctx *Context) error {
 			WithUID(uid).
 			WithSelf(true).
 			WithPublicKeyOptional()
-		loadArg.LoginContext = e.args.LoginContext
 		me, err = libkb.LoadUser(*loadArg)
 		if err != nil {
 			return err

--- a/go/engine/puk_upgrade.go
+++ b/go/engine/puk_upgrade.go
@@ -19,9 +19,7 @@ type PerUserKeyUpgrade struct {
 	DidNewKey bool
 }
 
-type PerUserKeyUpgradeArgs struct {
-	LoginContext libkb.LoginContext // optional
-}
+type PerUserKeyUpgradeArgs struct{}
 
 // NewPerUserKeyUpgrade creates a PerUserKeyUpgrade engine.
 func NewPerUserKeyUpgrade(g *libkb.GlobalContext, args *PerUserKeyUpgradeArgs) *PerUserKeyUpgrade {
@@ -76,7 +74,6 @@ func (e *PerUserKeyUpgrade) inner(ctx *Context) error {
 		WithUID(uid).
 		WithSelf(true).
 		WithPublicKeyOptional()
-	loadArg.LoginContext = e.args.LoginContext
 	upak, me, err := e.G().GetUPAKLoader().Load(*loadArg)
 	if err != nil {
 		return err
@@ -93,8 +90,7 @@ func (e *PerUserKeyUpgrade) inner(ctx *Context) error {
 
 	// Make the key
 	arg := &PerUserKeyRollArgs{
-		LoginContext: e.args.LoginContext,
-		Me:           me,
+		Me: me,
 	}
 	eng := NewPerUserKeyRoll(e.G(), arg)
 	err = RunEngine(eng, ctx)

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -781,10 +781,11 @@ func (s *PerUserKeyChainLink) insertIntoTable(tab *IdentityTable) {
 
 func (s *PerUserKeyChainLink) ToPerUserKey() keybase1.PerUserKey {
 	return keybase1.PerUserKey{
-		Gen:    int(s.generation),
-		Seqno:  s.GetSeqno(),
-		SigKID: s.sigKID,
-		EncKID: s.encKID,
+		Gen:         int(s.generation),
+		Seqno:       s.GetSeqno(),
+		SigKID:      s.sigKID,
+		EncKID:      s.encKID,
+		SignedByKID: s.GetKID(),
 	}
 }
 

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -681,10 +681,11 @@ func PerUserKeyProofReverseSigned(me *User, perUserKeySeed PerUserKeySeed, gener
 	// Update the user locally
 	me.SigChainBump(linkID, sigID)
 	me.localDelegatePerUserKey(keybase1.PerUserKey{
-		Gen:    int(generation),
-		Seqno:  me.GetSigChainLastKnownSeqno(),
-		SigKID: pukSigKey.GetKID(),
-		EncKID: pukEncKey.GetKID(),
+		Gen:         int(generation),
+		Seqno:       me.GetSigChainLastKnownSeqno(),
+		SigKID:      pukSigKey.GetKID(),
+		EncKID:      pukEncKey.GetKID(),
+		SignedByKID: signer.GetKID(),
 	})
 
 	publicKeysEntry := make(JSONPayload)

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -84,7 +84,7 @@ func (u *CachedUPAKLoader) ClearMemory() {
 	u.m = make(map[string]*keybase1.UserPlusKeysV2AllIncarnations)
 }
 
-const UPK2MinorVersionCurrent = keybase1.UPK2MinorVersion_V1
+const UPK2MinorVersionCurrent = keybase1.UPK2MinorVersion_V2
 
 func (u *CachedUPAKLoader) getCachedUPAK(ctx context.Context, uid keybase1.UID, info *CachedUserLoadInfo) (*keybase1.UserPlusKeysV2AllIncarnations, bool) {
 

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -415,19 +415,27 @@ func (o UserVersionVector) DeepCopy() UserVersionVector {
 	}
 }
 
+type PerUserKeyGeneration int
+
+func (o PerUserKeyGeneration) DeepCopy() PerUserKeyGeneration {
+	return o
+}
+
 type PerUserKey struct {
-	Gen    int   `codec:"gen" json:"gen"`
-	Seqno  Seqno `codec:"seqno" json:"seqno"`
-	SigKID KID   `codec:"sigKID" json:"sigKID"`
-	EncKID KID   `codec:"encKID" json:"encKID"`
+	Gen         int   `codec:"gen" json:"gen"`
+	Seqno       Seqno `codec:"seqno" json:"seqno"`
+	SigKID      KID   `codec:"sigKID" json:"sigKID"`
+	EncKID      KID   `codec:"encKID" json:"encKID"`
+	SignedByKID KID   `codec:"signedByKID" json:"signedByKID"`
 }
 
 func (o PerUserKey) DeepCopy() PerUserKey {
 	return PerUserKey{
-		Gen:    o.Gen,
-		Seqno:  o.Seqno.DeepCopy(),
-		SigKID: o.SigKID.DeepCopy(),
-		EncKID: o.EncKID.DeepCopy(),
+		Gen:         o.Gen,
+		Seqno:       o.Seqno.DeepCopy(),
+		SigKID:      o.SigKID.DeepCopy(),
+		EncKID:      o.EncKID.DeepCopy(),
+		SignedByKID: o.SignedByKID.DeepCopy(),
 	}
 }
 

--- a/go/protocol/keybase1/kex2provisionee2.go
+++ b/go/protocol/keybase1/kex2provisionee2.go
@@ -20,12 +20,6 @@ func (o Hello2Res) DeepCopy() Hello2Res {
 	}
 }
 
-type PerUserKeyGeneration int
-
-func (o PerUserKeyGeneration) DeepCopy() PerUserKeyGeneration {
-	return o
-}
-
 type PerUserKeyBox struct {
 	Generation  PerUserKeyGeneration `codec:"generation" json:"generation"`
 	Box         string               `codec:"box" json:"box"`

--- a/go/protocol/keybase1/upk.go
+++ b/go/protocol/keybase1/upk.go
@@ -53,6 +53,7 @@ type UPK2MinorVersion int
 const (
 	UPK2MinorVersion_V0 UPK2MinorVersion = 0
 	UPK2MinorVersion_V1 UPK2MinorVersion = 1
+	UPK2MinorVersion_V2 UPK2MinorVersion = 2
 )
 
 func (o UPK2MinorVersion) DeepCopy() UPK2MinorVersion { return o }
@@ -60,11 +61,13 @@ func (o UPK2MinorVersion) DeepCopy() UPK2MinorVersion { return o }
 var UPK2MinorVersionMap = map[string]UPK2MinorVersion{
 	"V0": 0,
 	"V1": 1,
+	"V2": 2,
 }
 
 var UPK2MinorVersionRevMap = map[UPK2MinorVersion]string{
 	0: "V0",
 	1: "V1",
+	2: "V2",
 }
 
 func (e UPK2MinorVersion) String() string {

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -159,12 +159,20 @@ protocol Common {
       Time cachedAt;
   }
 
+  // PerUserKeyGeneration describes which generation of secret we're talking about.
+  // The sequence starts at 1, and should increment every time the per-user-secret
+  // rotates, which is everytime a device is revoked.
+  @typedef("int")
+  @lint("ignore")
+  record PerUserKeyGeneration {}
+
   @lint("ignore")
   record PerUserKey {
       int gen;
       Seqno seqno;
       KID sigKID;
       KID encKID;
+      KID signedByKID; // The sibkey that delegated this PUK.
   }
 
   record UserPlusKeys {

--- a/protocol/avdl/keybase1/kex2provisionee2.avdl
+++ b/protocol/avdl/keybase1/kex2provisionee2.avdl
@@ -16,13 +16,6 @@ protocol Kex2Provisionee2 {
     union { null, PerUserKeyBox } pukBox
   );
 
-  // PerUserKeyGeneration describes which generation of secret we're talking about.
-  // The sequence starts at 1, and should increment every time the per-user-secret
-  // rotates, which is everytime a device is revoked.
-  @typedef("int")
-  @lint("ignore")
-  record PerUserKeyGeneration {}
-
   @lint("ignore")
   record PerUserKeyBox {
     PerUserKeyGeneration generation;

--- a/protocol/avdl/keybase1/upk.avdl
+++ b/protocol/avdl/keybase1/upk.avdl
@@ -13,7 +13,8 @@ protocol UPK {
 
   enum UPK2MinorVersion {
     V0_0,
-    V1_1
+    V1_1,
+    V2_2
   }
 
   record MerkleRootV2 {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -5183,6 +5183,7 @@ export type PerUserKey = {
   seqno: Seqno,
   sigKID: KID,
   encKID: KID,
+  signedByKID: KID,
 }
 
 export type PerUserKeyBox = {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -560,6 +560,7 @@ export const UPKUPAKVersion = {
 export const UPKUPK2MinorVersion = {
   v0: 0,
   v1: 1,
+  v2: 2,
 }
 
 export const UiPromptDefault = {
@@ -6172,6 +6173,7 @@ export type UPAKVersioned =
 export type UPK2MinorVersion =
     0 // V0_0
   | 1 // V1_1
+  | 2 // V2_2
 
 export type UnboxAnyRes = {
   kid: KID,

--- a/protocol/json/keybase1/common.json
+++ b/protocol/json/keybase1/common.json
@@ -382,6 +382,13 @@
     },
     {
       "type": "record",
+      "name": "PerUserKeyGeneration",
+      "fields": [],
+      "typedef": "int",
+      "lint": "ignore"
+    },
+    {
+      "type": "record",
       "name": "PerUserKey",
       "fields": [
         {
@@ -399,6 +406,10 @@
         {
           "type": "KID",
           "name": "encKID"
+        },
+        {
+          "type": "KID",
+          "name": "signedByKID"
         }
       ],
       "lint": "ignore"

--- a/protocol/json/keybase1/kex2provisionee2.json
+++ b/protocol/json/keybase1/kex2provisionee2.json
@@ -23,13 +23,6 @@
     },
     {
       "type": "record",
-      "name": "PerUserKeyGeneration",
-      "fields": [],
-      "typedef": "int",
-      "lint": "ignore"
-    },
-    {
-      "type": "record",
       "name": "PerUserKeyBox",
       "fields": [
         {

--- a/protocol/json/keybase1/upk.json
+++ b/protocol/json/keybase1/upk.json
@@ -27,7 +27,8 @@
       "name": "UPK2MinorVersion",
       "symbols": [
         "V0_0",
-        "V1_1"
+        "V1_1",
+        "V2_2"
       ]
     },
     {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -5183,6 +5183,7 @@ export type PerUserKey = {
   seqno: Seqno,
   sigKID: KID,
   encKID: KID,
+  signedByKID: KID,
 }
 
 export type PerUserKeyBox = {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -560,6 +560,7 @@ export const UPKUPAKVersion = {
 export const UPKUPK2MinorVersion = {
   v0: 0,
   v1: 1,
+  v2: 2,
 }
 
 export const UiPromptDefault = {
@@ -6172,6 +6173,7 @@ export type UPAKVersioned =
 export type UPK2MinorVersion =
     0 // V0_0
   | 1 // V1_1
+  | 2 // V2_2
 
 export type UnboxAnyRes = {
   kid: KID,


### PR DESCRIPTION
On top of https://github.com/keybase/client/pull/7723

Add the `SignedByKID` field to `PerUserKey`. I really only need this for the latest PUK so this is some unnecessary storage. I grepped for `PerUserKey{` and found two, hopefully they're the only places these are being put together.

As a result of this I think I need to bust the upak v1 and v2 caches. Seems like overkill. What do you think? I just saw `UPK2MinorVersionCurrent` and curious what that is.