### PR TITLE
add PUK upkeep engine

### DIFF
--- a/go/engine/kex2_test.go
+++ b/go/engine/kex2_test.go
@@ -105,3 +105,91 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 
 	wg.Wait()
 }
+
+// Get a new device, test context and all, by provisioning it from an existing test context.
+// This was copied from subTestKex2Provision
+// Note that it uses Errorf in goroutines, so if it fails
+// the test will not fail until later.
+// Returns (tcY, CleanupFunction)
+func provisionNewDeviceKex(tcX *libkb.TestContext, userX *FakeUser) (*libkb.TestContext, func()) {
+	// tcX is the device X (provisioner) context:
+	// tcX should already have been logged in.
+
+	t := tcX.T
+
+	// device Y (provisionee) context:
+	tcY := SetupEngineTest(t, "kex2provision")
+	cleanup := func() { tcY.Cleanup() }
+
+	var secretX kex2.Secret
+	if _, err := rand.Read(secretX[:]); err != nil {
+		t.Fatal(err)
+	}
+
+	var secretY kex2.Secret
+	if _, err := rand.Read(secretY[:]); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+
+	// start provisionee
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		f := func(lctx libkb.LoginContext) error {
+
+			ctx := &Context{
+				ProvisionUI:  &testProvisionUI{secretCh: make(chan kex2.Secret, 1)},
+				LoginContext: lctx,
+			}
+			deviceID, err := libkb.NewDeviceID()
+			if err != nil {
+				t.Errorf("provisionee device id error: %s", err)
+				return err
+			}
+			suffix, err := libkb.RandBytes(5)
+			if err != nil {
+				t.Errorf("provisionee device suffix error: %s", err)
+				return err
+			}
+			dname := fmt.Sprintf("device_%x", suffix)
+			device := &libkb.Device{
+				ID:          deviceID,
+				Description: &dname,
+				Type:        libkb.DeviceTypeDesktop,
+			}
+			provisionee := NewKex2Provisionee(tcY.G, device, secretY)
+			if err := RunEngine(provisionee, ctx); err != nil {
+				t.Errorf("provisionee error: %s", err)
+				return err
+			}
+			return nil
+		}
+
+		if err := tcY.G.LoginState().ExternalFunc(f, "Test - Kex2Provision"); err != nil {
+			t.Errorf("kex2 provisionee error: %s", err)
+		}
+	}()
+
+	// start provisioner
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ctx := &Context{
+			SecretUI:    userX.NewSecretUI(),
+			ProvisionUI: &testProvisionUI{},
+		}
+		provisioner := NewKex2Provisioner(tcX.G, secretX, nil)
+		go provisioner.AddSecret(secretY)
+		if err := RunEngine(provisioner, ctx); err != nil {
+			t.Errorf("provisioner error: %s", err)
+			return
+		}
+	}()
+
+	wg.Wait()
+
+	return &tcY, cleanup
+}

--- a/go/engine/puk_background_test.go
+++ b/go/engine/puk_background_test.go
@@ -130,7 +130,7 @@ func TestPerUserKeyBackgroundShutdownMiddle(t *testing.T) {
 		t.Logf("check %v", i)
 		select {
 		case x := <-roundResCh:
-			require.Equal(t, libkb.LoginRequiredError{}, x, "round result")
+			require.Equal(t, libkb.DeviceRequiredError{}, x, "round result")
 		case <-time.After(5 * time.Second):
 			require.FailNow(t, "channel timed out")
 		}
@@ -310,7 +310,7 @@ func TestPerUserKeyBackgroundLoginLate(t *testing.T) {
 	t.Logf("run once while not logged in")
 	select {
 	case x := <-roundResCh:
-		require.Equal(t, libkb.LoginRequiredError{}, x, "round result")
+		require.Equal(t, libkb.DeviceRequiredError{}, x, "round result")
 	case <-time.After(5 * time.Second):
 		require.FailNow(t, "channel timed out")
 	}

--- a/go/engine/puk_upgrade.go
+++ b/go/engine/puk_upgrade.go
@@ -37,7 +37,7 @@ func (e *PerUserKeyUpgrade) Name() string {
 // GetPrereqs returns the engine prereqs.
 func (e *PerUserKeyUpgrade) Prereqs() Prereqs {
 	return Prereqs{
-		Session: true,
+		Device: true,
 	}
 }
 

--- a/go/engine/puk_upkeep.go
+++ b/go/engine/puk_upkeep.go
@@ -25,9 +25,7 @@ type PerUserKeyUpkeep struct {
 	DidRollKey bool
 }
 
-type PerUserKeyUpkeepArgs struct {
-	LoginContext libkb.LoginContext // optional
-}
+type PerUserKeyUpkeepArgs struct{}
 
 // NewPerUserKeyUpkeep creates a PerUserKeyUpkeep engine.
 func NewPerUserKeyUpkeep(g *libkb.GlobalContext, args *PerUserKeyUpkeepArgs) *PerUserKeyUpkeep {
@@ -78,7 +76,6 @@ func (e *PerUserKeyUpkeep) inner(ctx *Context) error {
 		WithUID(uid).
 		WithSelf(true).
 		WithPublicKeyOptional()
-	loadArg.LoginContext = e.args.LoginContext
 	upak, me, err := e.G().GetUPAKLoader().LoadV2(*loadArg)
 	if err != nil {
 		return err
@@ -98,8 +95,7 @@ func (e *PerUserKeyUpkeep) inner(ctx *Context) error {
 	// Roll the key
 	e.G().Log.CDebugf(ctx.GetNetContext(), "PerUserKeyUpkeep rolling key")
 	arg := &PerUserKeyRollArgs{
-		LoginContext: e.args.LoginContext,
-		Me:           me,
+		Me: me,
 	}
 	eng := NewPerUserKeyRoll(e.G(), arg)
 	err = RunEngine(eng, ctx)

--- a/go/engine/puk_upkeep.go
+++ b/go/engine/puk_upkeep.go
@@ -1,0 +1,135 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// PerUserKeyUpkeep rolls the user's per-user-key if the last PUK
+// was added by a now-revoked device.
+// Does not add a first per-user-key. Use PerUserKeyUpgrade for that.
+// This engine makes up for the fact that after a self-deprovision
+// the latest PUK for a user was generated on the very machine they
+// wanted to deprovision.
+// This will not notice if a device revoked another device but neglected
+// to roll the PUK. No clients should do that.
+package engine
+
+import (
+	"errors"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// PerUserKeyUpkeep is an engine.
+type PerUserKeyUpkeep struct {
+	libkb.Contextified
+	args       *PerUserKeyUpkeepArgs
+	DidRollKey bool
+}
+
+type PerUserKeyUpkeepArgs struct {
+	LoginContext libkb.LoginContext // optional
+}
+
+// NewPerUserKeyUpkeep creates a PerUserKeyUpkeep engine.
+func NewPerUserKeyUpkeep(g *libkb.GlobalContext, args *PerUserKeyUpkeepArgs) *PerUserKeyUpkeep {
+	return &PerUserKeyUpkeep{
+		args:         args,
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+// Name is the unique engine name.
+func (e *PerUserKeyUpkeep) Name() string {
+	return "PerUserKeyUpkeep"
+}
+
+// GetPrereqs returns the engine prereqs.
+func (e *PerUserKeyUpkeep) Prereqs() Prereqs {
+	return Prereqs{
+		Session: true,
+	}
+}
+
+// RequiredUIs returns the required UIs.
+func (e *PerUserKeyUpkeep) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *PerUserKeyUpkeep) SubConsumers() []libkb.UIConsumer {
+	return []libkb.UIConsumer{}
+}
+
+// Run starts the engine.
+func (e *PerUserKeyUpkeep) Run(ctx *Context) (err error) {
+	defer e.G().CTrace(ctx.GetNetContext(), "PerUserKeyUpkeep", func() error { return err })()
+	return e.inner(ctx)
+}
+
+func (e *PerUserKeyUpkeep) inner(ctx *Context) error {
+	e.G().Log.CDebugf(ctx.GetNetContext(), "PerUserKeyUpkeep load self")
+
+	uid := e.G().GetMyUID()
+	if uid.IsNil() {
+		return libkb.NoUIDError{}
+	}
+
+	loadArg := libkb.NewLoadUserArgBase(e.G()).
+		WithNetContext(ctx.GetNetContext()).
+		WithUID(uid).
+		WithSelf(true).
+		WithPublicKeyOptional()
+	loadArg.LoginContext = e.args.LoginContext
+	upak, me, err := e.G().GetUPAKLoader().LoadV2(*loadArg)
+	if err != nil {
+		return err
+	}
+	// `me` could be nil.
+
+	var shouldRollKey bool
+	shouldRollKey, err = e.shouldRollKey(ctx, uid, &upak.Current)
+	if err != nil {
+		return err
+	}
+	if !shouldRollKey {
+		e.G().Log.CDebugf(ctx.GetNetContext(), "PerUserKeyUpkeep skipping")
+		return nil
+	}
+
+	// Roll the key
+	e.G().Log.CDebugf(ctx.GetNetContext(), "PerUserKeyUpkeep rolling key")
+	arg := &PerUserKeyRollArgs{
+		LoginContext: e.args.LoginContext,
+		Me:           me,
+	}
+	eng := NewPerUserKeyRoll(e.G(), arg)
+	err = RunEngine(eng, ctx)
+	e.DidRollKey = eng.DidNewKey
+	return err
+}
+
+// Whether we should roll the per-user-key.
+func (e *PerUserKeyUpkeep) shouldRollKey(ctx *Context, uid keybase1.UID, upak *keybase1.UserPlusKeysV2) (bool, error) {
+
+	if len(upak.PerUserKeys) == 0 {
+		e.G().Log.CDebugf(ctx.GetNetContext(), "PerUserKeyUpkeep has no per-user-key")
+		return false, nil
+	}
+	e.G().Log.CDebugf(ctx.GetNetContext(), "PerUserKeyUpkeep has %v per-user-keys", len(upak.PerUserKeys))
+
+	lastPuk := upak.PerUserKeys[len(upak.PerUserKeys)-1]
+	if !lastPuk.SignedByKID.IsValid() {
+		return false, errors.New("latest per-user-key had invalid signed-by KID")
+	}
+	e.G().Log.CDebugf(ctx.GetNetContext(), "PerUserKeyUpkeep last key signed by KID: %v", lastPuk.SignedByKID.String())
+	return !e.keyIsActiveSibkey(ctx, lastPuk.SignedByKID, upak), nil
+}
+
+func (e *PerUserKeyUpkeep) keyIsActiveSibkey(ctx *Context, kid keybase1.KID, upak *keybase1.UserPlusKeysV2) bool {
+	for _, dkey := range upak.DeviceKeys {
+		active := dkey.Base.Revocation == nil
+		if active && dkey.Base.IsSibkey && dkey.Base.Kid.Equal(kid) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/engine/puk_upkeep.go
+++ b/go/engine/puk_upkeep.go
@@ -43,7 +43,7 @@ func (e *PerUserKeyUpkeep) Name() string {
 // GetPrereqs returns the engine prereqs.
 func (e *PerUserKeyUpkeep) Prereqs() Prereqs {
 	return Prereqs{
-		Session: true,
+		Device: true,
 	}
 }
 

--- a/go/engine/puk_upkeep_test.go
+++ b/go/engine/puk_upkeep_test.go
@@ -1,0 +1,93 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPerUserKeyUpkeep(t *testing.T) {
+	tc := SetupEngineTest(t, "pukup")
+	defer tc.Cleanup()
+
+	// Get a second device which will deprovision itself.
+	tc2 := SetupEngineTest(t, "login")
+	defer tc2.Cleanup()
+
+	fu := CreateAndSignupFakeUserPaper(tc, "pukup")
+	upkeep := func() *PerUserKeyUpkeep {
+		arg := &PerUserKeyUpkeepArgs{}
+		eng := NewPerUserKeyUpkeep(tc.G, arg)
+		ctx := &Context{
+			LogUI: tc.G.UI.GetLogUI(),
+		}
+		err := RunEngine(eng, ctx)
+		require.NoError(t, err)
+		return eng
+	}
+	require.False(t, upkeep().DidRollKey, "don't roll")
+
+	t.Logf("revoke paper key")
+	revokeAnyPaperKey(tc, fu)
+
+	require.False(t, upkeep().DidRollKey, "don't roll after revoke-other")
+
+	t.Logf("provision second device")
+	tcY, cleanup := provisionNewDeviceKex(&tc, fu)
+	defer cleanup()
+
+	t.Logf("second device revokes itself")
+	{
+		eng := NewDeprovisionEngine(tcY.G, fu.Username, true /* doRevoke */)
+		ctx := &Context{
+			LogUI:    tcY.G.UI.GetLogUI(),
+			SecretUI: fu.NewSecretUI(),
+		}
+		err := RunEngine(eng, ctx)
+		require.NoError(t, err, "deprovision")
+	}
+
+	t.Logf("load self to bust the upak cache")
+	// Upkeep hits the cache. It's ok that upkeep doesn't notice a deprovision
+	// right away. Bust the upak cache as a way of simulating time passing
+	// for the sake of this test.
+	loadArg := libkb.NewLoadUserArgBase(tc.G).
+		WithUID(fu.UID()).
+		WithSelf(true).
+		WithForcePoll(). // <-
+		WithPublicKeyOptional()
+	_, _, err := tc.G.GetUPAKLoader().LoadV2(*loadArg)
+	require.NoError(t, err)
+
+	require.True(t, upkeep().DidRollKey, "roll after deprovision")
+
+	require.False(t, upkeep().DidRollKey, "don't roll after just rolled")
+}
+
+// This engine no-ops when the user has no PUKs.
+func TestPerUserKeyUpkeepNoPUK(t *testing.T) {
+	tc := SetupEngineTest(t, "pukup")
+	defer tc.Cleanup()
+	tc.Tp.DisableUpgradePerUserKey = true
+
+	_ = CreateAndSignupFakeUser(tc, "pukup")
+
+	upkeep := func() *PerUserKeyUpkeep {
+		arg := &PerUserKeyUpkeepArgs{}
+		eng := NewPerUserKeyUpkeep(tc.G, arg)
+		ctx := &Context{
+			LogUI: tc.G.UI.GetLogUI(),
+		}
+		err := RunEngine(eng, ctx)
+		require.NoError(t, err)
+		return eng
+	}
+	require.False(t, upkeep().DidRollKey, "no puk, no roll")
+
+	checkPerUserKeyCountLocal(&tc, 0)
+	checkPerUserKeyCount(&tc, 0)
+}


### PR DESCRIPTION
On top of https://github.com/keybase/client/pull/7731

Adds the `PerUserKeyUpkeep` engine. It's not used yet, it will run in a background task once a day or so as part of a forthcoming PR.

```
// PerUserKeyUpkeep rolls the user's per-user-key if the last PUK
// was added by a now-revoked device.
// Does not add a first per-user-key. Use PerUserKeyUpgrade for that.
// This engine makes up for the fact that after a self-deprovision
// the latest PUK for a user was generated on the very machine they
// wanted to deprovision.
// This will not notice if a device revoked another device but neglected
// to roll the PUK. No clients should do that.
```