### PR TITLE
Factor out BackgroundTask engine

### DIFF
--- a/go/engine/background_task.go
+++ b/go/engine/background_task.go
@@ -1,0 +1,188 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// BackgroundTask runs a function in the background once in a while.
+// Note that this engine is long-lived and potentially has to deal with being
+// logged out and logged in as a different user, etc.
+
+package engine
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	context "golang.org/x/net/context"
+)
+
+// Function to run periodically.
+// The error is logged but otherwise ignored.
+type TaskFunc func(g *libkb.GlobalContext, ectx *Context) error
+
+type BackgroundTaskSettings struct {
+	// Wait after starting the app
+	Start time.Duration
+	// When waking up on mobile lots of timers will go off at once. We wait an additional
+	// delay so as not to add to that herd and slow down the mobile experience when opening the app.
+	WakeUp time.Duration
+	// Wait between runs
+	Interval time.Duration
+	// Time limit on each round
+	Limit time.Duration
+}
+
+// BackgroundTask is an engine.
+type BackgroundTask struct {
+	libkb.Contextified
+	sync.Mutex
+
+	args *BackgroundTaskArgs
+
+	shutdown bool
+	// Function to cancel the background context.
+	// Can be nil before RunEngine exits
+	shutdownFunc context.CancelFunc
+}
+
+type BackgroundTaskArgs struct {
+	Name     string
+	F        TaskFunc
+	Settings BackgroundTaskSettings
+
+	// Channels used for testing. Normally nil.
+	testingMetaCh     chan<- string
+	testingRoundResCh chan<- error
+}
+
+// NewBackgroundTask creates a BackgroundTask engine.
+func NewBackgroundTask(g *libkb.GlobalContext, args *BackgroundTaskArgs) *BackgroundTask {
+	return &BackgroundTask{
+		Contextified: libkb.NewContextified(g),
+		args:         args,
+		shutdownFunc: nil,
+	}
+}
+
+// Name is the unique engine name.
+func (e *BackgroundTask) Name() string {
+	if e.args != nil {
+		return fmt.Sprintf("BackgroundTask(%v)", e.args.Name)
+	}
+	return "BackgroundTask"
+}
+
+// GetPrereqs returns the engine prereqs.
+func (e *BackgroundTask) Prereqs() Prereqs {
+	return Prereqs{}
+}
+
+// RequiredUIs returns the required UIs.
+func (e *BackgroundTask) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *BackgroundTask) SubConsumers() []libkb.UIConsumer {
+	return []libkb.UIConsumer{}
+}
+
+// Run starts the engine.
+// Returns immediately, kicks off a background goroutine.
+func (e *BackgroundTask) Run(ectx *Context) (err error) {
+	defer e.G().CTrace(ectx.GetNetContext(), e.Name(), func() error { return err })()
+
+	// use a new background context with a saved cancel function
+	ectx = ectx.WithNetContext(context.Background())
+	ectx, cancel := ectx.WithCancel()
+
+	e.Lock()
+	defer e.Unlock()
+
+	e.shutdownFunc = cancel
+	if e.shutdown {
+		// Shutdown before started
+		cancel()
+		e.meta("early-shutdown")
+		return nil
+	}
+
+	// start the loop and return
+	go func() {
+		err := e.loop(ectx)
+		if err != nil {
+			e.log(ectx.GetNetContext(), "loop error: %s", err)
+		}
+		cancel()
+		e.meta("loop-exit")
+	}()
+
+	return nil
+}
+
+func (e *BackgroundTask) Shutdown() {
+	e.Lock()
+	defer e.Unlock()
+	e.shutdown = true
+	if e.shutdownFunc != nil {
+		e.shutdownFunc()
+	}
+}
+
+func (e *BackgroundTask) loop(ectx *Context) error {
+	// wakeAt times are calculated before a meta before their corresponding sleep.
+	// To avoid the race where the testing goroutine calls advance before
+	// this routine decides when to wake up. That led to this routine never waking.
+	wakeAt := e.G().Clock().Now().Add(e.args.Settings.Start)
+	e.meta("loop-start")
+	if err := libkb.SleepUntilWithContext(ectx.GetNetContext(), e.G().Clock(), wakeAt); err != nil {
+		return err
+	}
+	e.meta("woke-start")
+	var i int
+	for {
+		i++
+		err := e.round(ectx)
+		if err != nil {
+			e.log(ectx.GetNetContext(), "round(%v) error: %s", i, err)
+		} else {
+			e.log(ectx.GetNetContext(), "round(%v) complete", i)
+		}
+		if e.args.testingRoundResCh != nil {
+			e.args.testingRoundResCh <- err
+		}
+		wakeAt = e.G().Clock().Now().Add(e.args.Settings.Interval)
+		e.meta("loop-round-complete")
+		if err := libkb.SleepUntilWithContext(ectx.GetNetContext(), e.G().Clock(), wakeAt); err != nil {
+			return err
+		}
+		wakeAt = e.G().Clock().Now().Add(e.args.Settings.WakeUp)
+		e.meta("woke-interval")
+		if err := libkb.SleepUntilWithContext(ectx.GetNetContext(), e.G().Clock(), wakeAt); err != nil {
+			return err
+		}
+		e.meta("woke-wakeup")
+	}
+}
+
+func (e *BackgroundTask) round(ectx *Context) error {
+	ectx, cancel := ectx.WithTimeout(e.args.Settings.Limit)
+	defer cancel()
+
+	// Run the function.
+	if e.args.F == nil {
+		return fmt.Errorf("nil task function")
+	}
+	return e.args.F(e.G(), ectx)
+}
+
+func (e *BackgroundTask) meta(s string) {
+	if e.args.testingMetaCh != nil {
+		e.args.testingMetaCh <- s
+	}
+}
+
+func (e *BackgroundTask) log(ctx context.Context, format string, args ...interface{}) {
+	content := fmt.Sprintf(format, args)
+	e.G().Log.CDebugf(ctx, "%s %s", e.Name(), content)
+}

--- a/go/engine/context.go
+++ b/go/engine/context.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -74,6 +75,16 @@ func (c *Context) WithNetContext(netCtx context.Context) *Context {
 	c2 := *c
 	c2.NetContext = netCtx
 	return &c2
+}
+
+func (c *Context) WithCancel() (*Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(c.GetNetContext())
+	return c.WithNetContext(ctx), cancel
+}
+
+func (c *Context) WithTimeout(timeout time.Duration) (*Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(c.GetNetContext(), timeout)
+	return c.WithNetContext(ctx), cancel
 }
 
 func (c *Context) SecretKeyPromptArg(ska libkb.SecretKeyArg, reason string) libkb.SecretKeyPromptArg {

--- a/go/engine/puk_background_test.go
+++ b/go/engine/puk_background_test.go
@@ -27,7 +27,6 @@ func TestPerUserKeyBackgroundShutdownFirst(t *testing.T) {
 
 	metaCh := make(chan string, 100)
 	arg := &PerUserKeyBackgroundArgs{
-		Settings:      PerUserKeyBackgroundDefaultSettings,
 		testingMetaCh: metaCh,
 	}
 	eng := NewPerUserKeyBackground(tc.G, arg)
@@ -43,11 +42,11 @@ func TestPerUserKeyBackgroundShutdownFirst(t *testing.T) {
 
 	expectMeta(t, metaCh, "early-shutdown")
 
-	advance(arg.Settings.Start)
-	advance(arg.Settings.Interval)
-	advance(arg.Settings.Interval)
-	advance(arg.Settings.Interval)
-	advance(arg.Settings.Interval)
+	advance(PerUserKeyBackgroundSettings.Start)
+	advance(PerUserKeyBackgroundSettings.Interval)
+	advance(PerUserKeyBackgroundSettings.Interval)
+	advance(PerUserKeyBackgroundSettings.Interval)
+	advance(PerUserKeyBackgroundSettings.Interval)
 
 	expectMeta(t, metaCh, "")
 }
@@ -68,7 +67,6 @@ func TestPerUserKeyBackgroundShutdownSoon(t *testing.T) {
 	metaCh := make(chan string, 100)
 	roundResCh := make(chan error, 100)
 	arg := &PerUserKeyBackgroundArgs{
-		Settings:          PerUserKeyBackgroundDefaultSettings,
 		testingMetaCh:     metaCh,
 		testingRoundResCh: roundResCh,
 	}
@@ -81,14 +79,14 @@ func TestPerUserKeyBackgroundShutdownSoon(t *testing.T) {
 
 	expectMeta(t, metaCh, "loop-start")
 
-	advance(arg.Settings.Start - time.Second)
+	advance(PerUserKeyBackgroundSettings.Start - time.Second)
 
 	eng.Shutdown()
 
 	expectMeta(t, metaCh, "loop-exit")
 
-	advance(arg.Settings.Interval)
-	advance(arg.Settings.Interval)
+	advance(PerUserKeyBackgroundSettings.Interval)
+	advance(PerUserKeyBackgroundSettings.Interval)
 
 	expectMeta(t, metaCh, "")
 }
@@ -110,7 +108,6 @@ func TestPerUserKeyBackgroundShutdownMiddle(t *testing.T) {
 	metaCh := make(chan string, 100)
 	roundResCh := make(chan error, 100)
 	arg := &PerUserKeyBackgroundArgs{
-		Settings:          PerUserKeyBackgroundDefaultSettings,
 		testingMetaCh:     metaCh,
 		testingRoundResCh: roundResCh,
 	}
@@ -122,7 +119,7 @@ func TestPerUserKeyBackgroundShutdownMiddle(t *testing.T) {
 	require.NoError(t, err)
 
 	expectMeta(t, metaCh, "loop-start")
-	advance(arg.Settings.Start + time.Second)
+	advance(PerUserKeyBackgroundSettings.Start + time.Second)
 	expectMeta(t, metaCh, "woke-start")
 
 	n := 3
@@ -136,9 +133,9 @@ func TestPerUserKeyBackgroundShutdownMiddle(t *testing.T) {
 		}
 		expectMeta(t, metaCh, "loop-round-complete")
 		if i < n-1 {
-			advance(arg.Settings.Interval + time.Second)
+			advance(PerUserKeyBackgroundSettings.Interval + time.Second)
 			expectMeta(t, metaCh, "woke-interval")
-			advance(arg.Settings.WakeUp + time.Second)
+			advance(PerUserKeyBackgroundSettings.WakeUp + time.Second)
 			expectMeta(t, metaCh, "woke-wakeup")
 		}
 	}
@@ -147,7 +144,7 @@ func TestPerUserKeyBackgroundShutdownMiddle(t *testing.T) {
 	expectMeta(t, metaCh, "loop-exit")
 
 	for i := 0; i < 2; i++ {
-		advance(arg.Settings.Interval)
+		advance(PerUserKeyBackgroundSettings.Interval)
 		select {
 		case x := <-roundResCh:
 			require.FailNow(t, "unexpected", x)
@@ -178,7 +175,6 @@ func TestPerUserKeyBackgroundUnnecessary(t *testing.T) {
 
 	metaCh := make(chan string, 100)
 	arg := &PerUserKeyBackgroundArgs{
-		Settings:      PerUserKeyBackgroundDefaultSettings,
 		testingMetaCh: metaCh,
 	}
 	eng := NewPerUserKeyBackground(tc.G, arg)
@@ -194,11 +190,11 @@ func TestPerUserKeyBackgroundUnnecessary(t *testing.T) {
 
 	expectMeta(t, metaCh, "early-shutdown")
 
-	advance(arg.Settings.Start)
-	advance(arg.Settings.Interval)
-	advance(arg.Settings.Interval)
-	advance(arg.Settings.Interval)
-	advance(arg.Settings.Interval)
+	advance(PerUserKeyBackgroundSettings.Start)
+	advance(PerUserKeyBackgroundSettings.Interval)
+	advance(PerUserKeyBackgroundSettings.Interval)
+	advance(PerUserKeyBackgroundSettings.Interval)
+	advance(PerUserKeyBackgroundSettings.Interval)
 
 	expectMeta(t, metaCh, "")
 
@@ -228,7 +224,6 @@ func TestPerUserKeyBackgroundWork(t *testing.T) {
 	metaCh := make(chan string, 100)
 	roundResCh := make(chan error, 100)
 	arg := &PerUserKeyBackgroundArgs{
-		Settings:          PerUserKeyBackgroundDefaultSettings,
 		testingMetaCh:     metaCh,
 		testingRoundResCh: roundResCh,
 	}
@@ -241,7 +236,7 @@ func TestPerUserKeyBackgroundWork(t *testing.T) {
 	require.NoError(t, err)
 
 	expectMeta(t, metaCh, "loop-start")
-	advance(arg.Settings.Start + time.Second)
+	advance(PerUserKeyBackgroundSettings.Start + time.Second)
 	expectMeta(t, metaCh, "woke-start")
 
 	select {
@@ -253,9 +248,9 @@ func TestPerUserKeyBackgroundWork(t *testing.T) {
 	expectMeta(t, metaCh, "loop-round-complete")
 
 	// second run that doesn't do anything
-	advance(arg.Settings.Interval + time.Second)
+	advance(PerUserKeyBackgroundSettings.Interval + time.Second)
 	expectMeta(t, metaCh, "woke-interval")
-	advance(arg.Settings.WakeUp + time.Second)
+	advance(PerUserKeyBackgroundSettings.WakeUp + time.Second)
 	expectMeta(t, metaCh, "woke-wakeup") // this line has flaked before (CORE-5410)
 	select {
 	case x := <-roundResCh:
@@ -291,7 +286,6 @@ func TestPerUserKeyBackgroundLoginLate(t *testing.T) {
 	metaCh := make(chan string, 100)
 	roundResCh := make(chan error, 100)
 	arg := &PerUserKeyBackgroundArgs{
-		Settings:          PerUserKeyBackgroundDefaultSettings,
 		testingMetaCh:     metaCh,
 		testingRoundResCh: roundResCh,
 	}
@@ -304,7 +298,7 @@ func TestPerUserKeyBackgroundLoginLate(t *testing.T) {
 	require.NoError(t, err)
 
 	expectMeta(t, metaCh, "loop-start")
-	advance(arg.Settings.Start + time.Second)
+	advance(PerUserKeyBackgroundSettings.Start + time.Second)
 	expectMeta(t, metaCh, "woke-start")
 
 	t.Logf("run once while not logged in")
@@ -324,9 +318,9 @@ func TestPerUserKeyBackgroundLoginLate(t *testing.T) {
 	tc.Tp.DisableUpgradePerUserKey = false
 
 	t.Logf("second run upgrades the user")
-	advance(arg.Settings.Interval + time.Second)
+	advance(PerUserKeyBackgroundSettings.Interval + time.Second)
 	expectMeta(t, metaCh, "woke-interval")
-	advance(arg.Settings.WakeUp + time.Second)
+	advance(PerUserKeyBackgroundSettings.WakeUp + time.Second)
 	expectMeta(t, metaCh, "woke-wakeup")
 	select {
 	case x := <-roundResCh:

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -561,10 +561,7 @@ func (d *Service) runBackgroundPerUserKeyUpgrade() {
 		return
 	}
 
-	arg := &engine.PerUserKeyBackgroundArgs{
-		Settings: engine.PerUserKeyBackgroundDefaultSettings,
-	}
-	eng := engine.NewPerUserKeyBackground(d.G(), arg)
+	eng := engine.NewPerUserKeyBackground(d.G(), &engine.PerUserKeyBackgroundArgs{})
 	go func() {
 		ectx := &engine.Context{NetContext: context.Background()}
 		err := engine.RunEngine(eng, ectx)


### PR DESCRIPTION
On top of https://github.com/keybase/client/pull/7732

Factor out `BackgroundTask` into a second-order engine. I'm pulling this out because I want to re-use it for a `PerUserKeyUpkeepBackground` task.

What used to be `PerUserKeyBackground` outside of the `round` function became BackgroundTask. It's unchanged other than that I added `WithCancel` and `WithTimeout` in an effort to stop passing around both `(ctx context.Context, ectx engine.Context)`. It's still tested through `PerUserKeyBackground`.