### PR TITLE
linux installer: fix kbnm

### DIFF
--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -113,7 +113,7 @@ build_one_architecture() {
     "$layout_dir/usr/bin/kbnm" github.com/keybase/client/go/kbnm
 
   # Whitelist for NativeMessaging
-  kbnm_bin="/usr/bin/kbnm"
+  kbnm_bin="$layout_dir/usr/bin/kbnm"
 
   # Write whitelists into the overlay
   KBNM_INSTALL_ROOT=1 KBNM_INSTALL_OVERLAY="$layout_dir" $(kbnm_bin) install


### PR DESCRIPTION
Before, kbnm_bin was never actually executed; it was only used as a template value for the JSON.

Since we switched to using the kbnm's built-in installer, it now needs to call the actual binary and the path update was neglected in the previous PR.