### PR TITLE
WIP: kbnm: Assume root if user.Current() fails

### DIFF
--- a/go/kbnm/hostmanifest/user.go
+++ b/go/kbnm/hostmanifest/user.go
@@ -19,17 +19,19 @@ type userPath struct {
 func (u *userPath) IsAdmin() bool      { return u.Admin }
 func (u *userPath) PrefixPath() string { return u.Path }
 
-// CurrentUser returns a User representing the current user.
-func CurrentUser() (*userPath, error) {
+// CurrentUser returns a User representing the current user. Assumes admin if
+// fails.
+func CurrentUser() *userPath {
+	var u userPath
 	current, err := user.Current()
 	if err != nil {
-		return nil, err
-	}
-	u := &userPath{
-		Admin: current.Uid == "0",
+		// Assume root.
+		u.Admin = true
+	} else {
+		u.Admin = (current.Uid == "0")
 	}
 	if !u.IsAdmin() {
 		u.Path = current.HomeDir
 	}
-	return u, nil
+	return &u
 }

--- a/go/kbnm/installer/installer.go
+++ b/go/kbnm/installer/installer.go
@@ -13,11 +13,8 @@ const kbnmAppName = "io.keybase.kbnm"
 // environment variables:
 // * KBNM_INSTALL_ROOT != "" will force the user paths to be root
 // * KBNM_INSTALL_OVERLAY will prefix the paths
-func CurrentUser() (hostmanifest.User, error) {
-	u, err := hostmanifest.CurrentUser()
-	if err != nil {
-		return nil, err
-	}
+func CurrentUser() hostmanifest.User {
+	u := hostmanifest.CurrentUser()
 	if os.Getenv("KBNM_INSTALL_ROOT") != "" {
 		u.Admin = true
 		u.Path = ""
@@ -26,15 +23,12 @@ func CurrentUser() (hostmanifest.User, error) {
 	if overlay != "" {
 		u.Path = filepath.Join(overlay, u.Path)
 	}
-	return u, err
+	return u
 }
 
 // UninstallKBNM removes NativeMessaging whitelisting for KBNM.
 func UninstallKBNM() error {
-	u, err := CurrentUser()
-	if err != nil {
-		return err
-	}
+	u := CurrentUser()
 
 	app := hostmanifest.App{
 		Name: kbnmAppName,
@@ -51,10 +45,7 @@ func UninstallKBNM() error {
 
 // UninstallKBNM writes NativeMessaging whitelisting for KBNM.
 func InstallKBNM(path string) error {
-	u, err := CurrentUser()
-	if err != nil {
-		return err
-	}
+	u := CurrentUser()
 
 	app := hostmanifest.App{
 		Name:        kbnmAppName,


### PR DESCRIPTION
Workaround for running as root in Docker where user.Current() fails.