### PR TITLE
Add PerUserKeyUpkeepBackground engine

### DIFF
--- a/go/engine/background_task.go
+++ b/go/engine/background_task.go
@@ -4,6 +4,8 @@
 // BackgroundTask runs a function in the background once in a while.
 // Note that this engine is long-lived and potentially has to deal with being
 // logged out and logged in as a different user, etc.
+// The timer uses the clock to sleep. So if there is a timezone change
+// it will probably wake up early or sleep for the extra hours.
 
 package engine
 

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	insecureTriplesec "github.com/keybase/go-triplesec-insecure"
+	"github.com/stretchr/testify/require"
 )
 
 func SetupEngineTest(tb testing.TB, name string) libkb.TestContext {
@@ -410,4 +411,21 @@ func ForcePUK(tc libkb.TestContext) {
 	if err := RunEngine(eng, ctx); err != nil {
 		tc.T.Fatal(err)
 	}
+}
+
+func getUserSeqno(tc *libkb.TestContext, uid keybase1.UID) keybase1.Seqno {
+	res, err := tc.G.API.Get(libkb.APIArg{
+		Endpoint: "user/lookup",
+		Args: libkb.HTTPArgs{
+			"uid": libkb.UIDArg(uid),
+		},
+	})
+	require.NoError(tc.T, err)
+	seqno, err := res.Body.AtKey("them").AtKey("sigs").AtKey("last").AtKey("seqno").GetInt()
+	require.NoError(tc.T, err)
+	return keybase1.Seqno(seqno)
+}
+
+func checkUserSeqno(tc *libkb.TestContext, uid keybase1.UID, expected keybase1.Seqno) {
+	require.Equal(tc.T, expected, getUserSeqno(tc, uid))
 }

--- a/go/engine/puk_upgrade_background.go
+++ b/go/engine/puk_upgrade_background.go
@@ -1,7 +1,7 @@
 // Copyright 2017 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
-// PerUserKeyBackground runs PerUserKeyUpgrade in the background once in a while.
+// PerUserKeyUpgradeBackground runs PerUserKeyUpgrade in the background once in a while.
 // It brings users without per-user-keys up to having them.
 // Note that this engine is long-lived and potentially has to deal with being
 // logged out and logged in as a different user, etc.
@@ -15,7 +15,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 )
 
-var PerUserKeyBackgroundSettings = BackgroundTaskSettings{
+var PerUserKeyUpgradeBackgroundSettings = BackgroundTaskSettings{
 	// Wait after starting the app
 	Start: 30 * time.Second,
 	// When waking up on mobile lots of timers will go off at once. We wait an additional
@@ -27,32 +27,32 @@ var PerUserKeyBackgroundSettings = BackgroundTaskSettings{
 	Limit: 5 * time.Minute,
 }
 
-// PerUserKeyBackground is an engine.
-type PerUserKeyBackground struct {
+// PerUserKeyUpgradeBackground is an engine.
+type PerUserKeyUpgradeBackground struct {
 	libkb.Contextified
 	sync.Mutex
 
-	args *PerUserKeyBackgroundArgs
+	args *PerUserKeyUpgradeBackgroundArgs
 	task *BackgroundTask
 }
 
-type PerUserKeyBackgroundArgs struct {
+type PerUserKeyUpgradeBackgroundArgs struct {
 	// Channels used for testing. Normally nil.
 	testingMetaCh     chan<- string
 	testingRoundResCh chan<- error
 }
 
-// NewPerUserKeyBackground creates a PerUserKeyBackground engine.
-func NewPerUserKeyBackground(g *libkb.GlobalContext, args *PerUserKeyBackgroundArgs) *PerUserKeyBackground {
+// NewPerUserKeyUpgradeBackground creates a PerUserKeyUpgradeBackground engine.
+func NewPerUserKeyUpgradeBackground(g *libkb.GlobalContext, args *PerUserKeyUpgradeBackgroundArgs) *PerUserKeyUpgradeBackground {
 	task := NewBackgroundTask(g, &BackgroundTaskArgs{
-		Name:     "PerUserKeyBackground",
-		F:        PerUserKeyBackgroundRound,
-		Settings: PerUserKeyBackgroundSettings,
+		Name:     "PerUserKeyUpgradeBackground",
+		F:        PerUserKeyUpgradeBackgroundRound,
+		Settings: PerUserKeyUpgradeBackgroundSettings,
 
 		testingMetaCh:     args.testingMetaCh,
 		testingRoundResCh: args.testingRoundResCh,
 	})
-	return &PerUserKeyBackground{
+	return &PerUserKeyUpgradeBackground{
 		Contextified: libkb.NewContextified(g),
 		args:         args,
 		// Install the task early so that Shutdown can be called before RunEngine.
@@ -61,36 +61,36 @@ func NewPerUserKeyBackground(g *libkb.GlobalContext, args *PerUserKeyBackgroundA
 }
 
 // Name is the unique engine name.
-func (e *PerUserKeyBackground) Name() string {
-	return "PerUserKeyBackground"
+func (e *PerUserKeyUpgradeBackground) Name() string {
+	return "PerUserKeyUpgradeBackground"
 }
 
 // GetPrereqs returns the engine prereqs.
-func (e *PerUserKeyBackground) Prereqs() Prereqs {
+func (e *PerUserKeyUpgradeBackground) Prereqs() Prereqs {
 	return Prereqs{}
 }
 
 // RequiredUIs returns the required UIs.
-func (e *PerUserKeyBackground) RequiredUIs() []libkb.UIKind {
+func (e *PerUserKeyUpgradeBackground) RequiredUIs() []libkb.UIKind {
 	return []libkb.UIKind{}
 }
 
 // SubConsumers returns the other UI consumers for this engine.
-func (e *PerUserKeyBackground) SubConsumers() []libkb.UIConsumer {
+func (e *PerUserKeyUpgradeBackground) SubConsumers() []libkb.UIConsumer {
 	return []libkb.UIConsumer{&PerUserKeyUpgrade{}}
 }
 
 // Run starts the engine.
 // Returns immediately, kicks off a background goroutine.
-func (e *PerUserKeyBackground) Run(ctx *Context) (err error) {
+func (e *PerUserKeyUpgradeBackground) Run(ctx *Context) (err error) {
 	return RunEngine(e.task, ctx)
 }
 
-func (e *PerUserKeyBackground) Shutdown() {
+func (e *PerUserKeyUpgradeBackground) Shutdown() {
 	e.task.Shutdown()
 }
 
-func PerUserKeyBackgroundRound(g *libkb.GlobalContext, ectx *Context) error {
+func PerUserKeyUpgradeBackgroundRound(g *libkb.GlobalContext, ectx *Context) error {
 	if !g.Env.GetUpgradePerUserKey() {
 		g.Log.CDebugf(ectx.GetNetContext(), "CheckUpgradePerUserKey disabled")
 		return nil

--- a/go/engine/puk_upgrade_background_test.go
+++ b/go/engine/puk_upgrade_background_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // When stopped before RunEngine, the inner loop never runs.
-func TestPerUserKeyBackgroundShutdownFirst(t *testing.T) {
+func TestPerUserKeyUpgradeBackgroundShutdownFirst(t *testing.T) {
 	tc := SetupEngineTest(t, "pukup")
 	defer tc.Cleanup()
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
@@ -26,10 +26,10 @@ func TestPerUserKeyBackgroundShutdownFirst(t *testing.T) {
 	}
 
 	metaCh := make(chan string, 100)
-	arg := &PerUserKeyBackgroundArgs{
+	arg := &PerUserKeyUpgradeBackgroundArgs{
 		testingMetaCh: metaCh,
 	}
-	eng := NewPerUserKeyBackground(tc.G, arg)
+	eng := NewPerUserKeyUpgradeBackground(tc.G, arg)
 	ctx := &Context{
 		LogUI: tc.G.UI.GetLogUI(),
 	}
@@ -42,17 +42,17 @@ func TestPerUserKeyBackgroundShutdownFirst(t *testing.T) {
 
 	expectMeta(t, metaCh, "early-shutdown")
 
-	advance(PerUserKeyBackgroundSettings.Start)
-	advance(PerUserKeyBackgroundSettings.Interval)
-	advance(PerUserKeyBackgroundSettings.Interval)
-	advance(PerUserKeyBackgroundSettings.Interval)
-	advance(PerUserKeyBackgroundSettings.Interval)
+	advance(PerUserKeyUpgradeBackgroundSettings.Start)
+	advance(PerUserKeyUpgradeBackgroundSettings.Interval)
+	advance(PerUserKeyUpgradeBackgroundSettings.Interval)
+	advance(PerUserKeyUpgradeBackgroundSettings.Interval)
+	advance(PerUserKeyUpgradeBackgroundSettings.Interval)
 
 	expectMeta(t, metaCh, "")
 }
 
 // When stopped before the Start wait time, the loop starts but a round never runs.
-func TestPerUserKeyBackgroundShutdownSoon(t *testing.T) {
+func TestPerUserKeyUpgradeBackgroundShutdownSoon(t *testing.T) {
 	tc := SetupEngineTest(t, "pukup")
 	defer tc.Cleanup()
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
@@ -66,11 +66,11 @@ func TestPerUserKeyBackgroundShutdownSoon(t *testing.T) {
 
 	metaCh := make(chan string, 100)
 	roundResCh := make(chan error, 100)
-	arg := &PerUserKeyBackgroundArgs{
+	arg := &PerUserKeyUpgradeBackgroundArgs{
 		testingMetaCh:     metaCh,
 		testingRoundResCh: roundResCh,
 	}
-	eng := NewPerUserKeyBackground(tc.G, arg)
+	eng := NewPerUserKeyUpgradeBackground(tc.G, arg)
 	ctx := &Context{
 		LogUI: tc.G.UI.GetLogUI(),
 	}
@@ -79,21 +79,21 @@ func TestPerUserKeyBackgroundShutdownSoon(t *testing.T) {
 
 	expectMeta(t, metaCh, "loop-start")
 
-	advance(PerUserKeyBackgroundSettings.Start - time.Second)
+	advance(PerUserKeyUpgradeBackgroundSettings.Start - time.Second)
 
 	eng.Shutdown()
 
 	expectMeta(t, metaCh, "loop-exit")
 
-	advance(PerUserKeyBackgroundSettings.Interval)
-	advance(PerUserKeyBackgroundSettings.Interval)
+	advance(PerUserKeyUpgradeBackgroundSettings.Interval)
+	advance(PerUserKeyUpgradeBackgroundSettings.Interval)
 
 	expectMeta(t, metaCh, "")
 }
 
 // Shutting down after a few loop rounds should work.
 // Also test that LoginRequired comes out when there is no user.
-func TestPerUserKeyBackgroundShutdownMiddle(t *testing.T) {
+func TestPerUserKeyUpgradeBackgroundShutdownMiddle(t *testing.T) {
 	tc := SetupEngineTest(t, "pukup")
 	defer tc.Cleanup()
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
@@ -107,11 +107,11 @@ func TestPerUserKeyBackgroundShutdownMiddle(t *testing.T) {
 
 	metaCh := make(chan string, 100)
 	roundResCh := make(chan error, 100)
-	arg := &PerUserKeyBackgroundArgs{
+	arg := &PerUserKeyUpgradeBackgroundArgs{
 		testingMetaCh:     metaCh,
 		testingRoundResCh: roundResCh,
 	}
-	eng := NewPerUserKeyBackground(tc.G, arg)
+	eng := NewPerUserKeyUpgradeBackground(tc.G, arg)
 	ctx := &Context{
 		LogUI: tc.G.UI.GetLogUI(),
 	}
@@ -119,7 +119,7 @@ func TestPerUserKeyBackgroundShutdownMiddle(t *testing.T) {
 	require.NoError(t, err)
 
 	expectMeta(t, metaCh, "loop-start")
-	advance(PerUserKeyBackgroundSettings.Start + time.Second)
+	advance(PerUserKeyUpgradeBackgroundSettings.Start + time.Second)
 	expectMeta(t, metaCh, "woke-start")
 
 	n := 3
@@ -133,9 +133,9 @@ func TestPerUserKeyBackgroundShutdownMiddle(t *testing.T) {
 		}
 		expectMeta(t, metaCh, "loop-round-complete")
 		if i < n-1 {
-			advance(PerUserKeyBackgroundSettings.Interval + time.Second)
+			advance(PerUserKeyUpgradeBackgroundSettings.Interval + time.Second)
 			expectMeta(t, metaCh, "woke-interval")
-			advance(PerUserKeyBackgroundSettings.WakeUp + time.Second)
+			advance(PerUserKeyUpgradeBackgroundSettings.WakeUp + time.Second)
 			expectMeta(t, metaCh, "woke-wakeup")
 		}
 	}
@@ -144,7 +144,7 @@ func TestPerUserKeyBackgroundShutdownMiddle(t *testing.T) {
 	expectMeta(t, metaCh, "loop-exit")
 
 	for i := 0; i < 2; i++ {
-		advance(PerUserKeyBackgroundSettings.Interval)
+		advance(PerUserKeyUpgradeBackgroundSettings.Interval)
 		select {
 		case x := <-roundResCh:
 			require.FailNow(t, "unexpected", x)
@@ -156,7 +156,7 @@ func TestPerUserKeyBackgroundShutdownMiddle(t *testing.T) {
 	expectMeta(t, metaCh, "")
 }
 
-func TestPerUserKeyBackgroundUnnecessary(t *testing.T) {
+func TestPerUserKeyUpgradeBackgroundUnnecessary(t *testing.T) {
 	tc := SetupEngineTest(t, "pukup")
 	defer tc.Cleanup()
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
@@ -174,10 +174,10 @@ func TestPerUserKeyBackgroundUnnecessary(t *testing.T) {
 	}
 
 	metaCh := make(chan string, 100)
-	arg := &PerUserKeyBackgroundArgs{
+	arg := &PerUserKeyUpgradeBackgroundArgs{
 		testingMetaCh: metaCh,
 	}
-	eng := NewPerUserKeyBackground(tc.G, arg)
+	eng := NewPerUserKeyUpgradeBackground(tc.G, arg)
 	ctx := &Context{
 		LogUI: tc.G.UI.GetLogUI(),
 	}
@@ -190,11 +190,11 @@ func TestPerUserKeyBackgroundUnnecessary(t *testing.T) {
 
 	expectMeta(t, metaCh, "early-shutdown")
 
-	advance(PerUserKeyBackgroundSettings.Start)
-	advance(PerUserKeyBackgroundSettings.Interval)
-	advance(PerUserKeyBackgroundSettings.Interval)
-	advance(PerUserKeyBackgroundSettings.Interval)
-	advance(PerUserKeyBackgroundSettings.Interval)
+	advance(PerUserKeyUpgradeBackgroundSettings.Start)
+	advance(PerUserKeyUpgradeBackgroundSettings.Interval)
+	advance(PerUserKeyUpgradeBackgroundSettings.Interval)
+	advance(PerUserKeyUpgradeBackgroundSettings.Interval)
+	advance(PerUserKeyUpgradeBackgroundSettings.Interval)
 
 	expectMeta(t, metaCh, "")
 
@@ -202,7 +202,7 @@ func TestPerUserKeyBackgroundUnnecessary(t *testing.T) {
 }
 
 // The normal case of upgrading a user
-func TestPerUserKeyBackgroundWork(t *testing.T) {
+func TestPerUserKeyUpgradeBackgroundWork(t *testing.T) {
 	tc := SetupEngineTest(t, "pukup")
 	defer tc.Cleanup()
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
@@ -223,11 +223,11 @@ func TestPerUserKeyBackgroundWork(t *testing.T) {
 
 	metaCh := make(chan string, 100)
 	roundResCh := make(chan error, 100)
-	arg := &PerUserKeyBackgroundArgs{
+	arg := &PerUserKeyUpgradeBackgroundArgs{
 		testingMetaCh:     metaCh,
 		testingRoundResCh: roundResCh,
 	}
-	eng := NewPerUserKeyBackground(tc.G, arg)
+	eng := NewPerUserKeyUpgradeBackground(tc.G, arg)
 	ctx := &Context{
 		LogUI: tc.G.UI.GetLogUI(),
 	}
@@ -236,7 +236,7 @@ func TestPerUserKeyBackgroundWork(t *testing.T) {
 	require.NoError(t, err)
 
 	expectMeta(t, metaCh, "loop-start")
-	advance(PerUserKeyBackgroundSettings.Start + time.Second)
+	advance(PerUserKeyUpgradeBackgroundSettings.Start + time.Second)
 	expectMeta(t, metaCh, "woke-start")
 
 	select {
@@ -248,9 +248,9 @@ func TestPerUserKeyBackgroundWork(t *testing.T) {
 	expectMeta(t, metaCh, "loop-round-complete")
 
 	// second run that doesn't do anything
-	advance(PerUserKeyBackgroundSettings.Interval + time.Second)
+	advance(PerUserKeyUpgradeBackgroundSettings.Interval + time.Second)
 	expectMeta(t, metaCh, "woke-interval")
-	advance(PerUserKeyBackgroundSettings.WakeUp + time.Second)
+	advance(PerUserKeyUpgradeBackgroundSettings.WakeUp + time.Second)
 	expectMeta(t, metaCh, "woke-wakeup") // this line has flaked before (CORE-5410)
 	select {
 	case x := <-roundResCh:
@@ -269,7 +269,7 @@ func TestPerUserKeyBackgroundWork(t *testing.T) {
 }
 
 // Test upgrading after running for a while and then logging in.
-func TestPerUserKeyBackgroundLoginLate(t *testing.T) {
+func TestPerUserKeyUpgradeBackgroundLoginLate(t *testing.T) {
 	tc := SetupEngineTest(t, "pukup")
 	defer tc.Cleanup()
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
@@ -285,11 +285,11 @@ func TestPerUserKeyBackgroundLoginLate(t *testing.T) {
 
 	metaCh := make(chan string, 100)
 	roundResCh := make(chan error, 100)
-	arg := &PerUserKeyBackgroundArgs{
+	arg := &PerUserKeyUpgradeBackgroundArgs{
 		testingMetaCh:     metaCh,
 		testingRoundResCh: roundResCh,
 	}
-	eng := NewPerUserKeyBackground(tc.G, arg)
+	eng := NewPerUserKeyUpgradeBackground(tc.G, arg)
 	ctx := &Context{
 		LogUI: tc.G.UI.GetLogUI(),
 	}
@@ -298,7 +298,7 @@ func TestPerUserKeyBackgroundLoginLate(t *testing.T) {
 	require.NoError(t, err)
 
 	expectMeta(t, metaCh, "loop-start")
-	advance(PerUserKeyBackgroundSettings.Start + time.Second)
+	advance(PerUserKeyUpgradeBackgroundSettings.Start + time.Second)
 	expectMeta(t, metaCh, "woke-start")
 
 	t.Logf("run once while not logged in")
@@ -318,9 +318,9 @@ func TestPerUserKeyBackgroundLoginLate(t *testing.T) {
 	tc.Tp.DisableUpgradePerUserKey = false
 
 	t.Logf("second run upgrades the user")
-	advance(PerUserKeyBackgroundSettings.Interval + time.Second)
+	advance(PerUserKeyUpgradeBackgroundSettings.Interval + time.Second)
 	expectMeta(t, metaCh, "woke-interval")
-	advance(PerUserKeyBackgroundSettings.WakeUp + time.Second)
+	advance(PerUserKeyUpgradeBackgroundSettings.WakeUp + time.Second)
 	expectMeta(t, metaCh, "woke-wakeup")
 	select {
 	case x := <-roundResCh:

--- a/go/engine/puk_upkeep_background.go
+++ b/go/engine/puk_upkeep_background.go
@@ -1,0 +1,102 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// PerUserKeyUpkeepBackground runs PerUserKeyUpkeep in the background once in a while.
+// It rolls the per-user-key if the last one was involved in a deprovision.
+// See PerUserKeyUpkeep for more info.
+
+package engine
+
+import (
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+)
+
+var PerUserKeyUpkeepBackgroundSettings = BackgroundTaskSettings{
+	// Wait after starting the app
+	Start: 20 * time.Second,
+	// When waking up on mobile lots of timers will go off at once. We wait an additional
+	// delay so as not to add to that herd and slow down the mobile experience when opening the app.
+	WakeUp: 15 * time.Second,
+	// Wait between checks
+	Interval: 6 * time.Hour,
+	// Time limit on each round
+	Limit: 5 * time.Minute,
+}
+
+// PerUserKeyUpkeepBackground is an engine.
+type PerUserKeyUpkeepBackground struct {
+	libkb.Contextified
+	sync.Mutex
+
+	args *PerUserKeyUpkeepBackgroundArgs
+	task *BackgroundTask
+}
+
+type PerUserKeyUpkeepBackgroundArgs struct {
+	// Channels used for testing. Normally nil.
+	testingMetaCh     chan<- string
+	testingRoundResCh chan<- error
+}
+
+// NewPerUserKeyUpkeepBackground creates a PerUserKeyUpkeepBackground engine.
+func NewPerUserKeyUpkeepBackground(g *libkb.GlobalContext, args *PerUserKeyUpkeepBackgroundArgs) *PerUserKeyUpkeepBackground {
+	task := NewBackgroundTask(g, &BackgroundTaskArgs{
+		Name:     "PerUserKeyUpkeepBackground",
+		F:        PerUserKeyUpkeepBackgroundRound,
+		Settings: PerUserKeyUpkeepBackgroundSettings,
+
+		testingMetaCh:     args.testingMetaCh,
+		testingRoundResCh: args.testingRoundResCh,
+	})
+	return &PerUserKeyUpkeepBackground{
+		Contextified: libkb.NewContextified(g),
+		args:         args,
+		// Install the task early so that Shutdown can be called before RunEngine.
+		task: task,
+	}
+}
+
+// Name is the unique engine name.
+func (e *PerUserKeyUpkeepBackground) Name() string {
+	return "PerUserKeyUpkeepBackground"
+}
+
+// GetPrereqs returns the engine prereqs.
+func (e *PerUserKeyUpkeepBackground) Prereqs() Prereqs {
+	return Prereqs{}
+}
+
+// RequiredUIs returns the required UIs.
+func (e *PerUserKeyUpkeepBackground) RequiredUIs() []libkb.UIKind {
+	return []libkb.UIKind{}
+}
+
+// SubConsumers returns the other UI consumers for this engine.
+func (e *PerUserKeyUpkeepBackground) SubConsumers() []libkb.UIConsumer {
+	return []libkb.UIConsumer{&PerUserKeyUpkeep{}}
+}
+
+// Run starts the engine.
+// Returns immediately, kicks off a background goroutine.
+func (e *PerUserKeyUpkeepBackground) Run(ctx *Context) (err error) {
+	return RunEngine(e.task, ctx)
+}
+
+func (e *PerUserKeyUpkeepBackground) Shutdown() {
+	e.task.Shutdown()
+}
+
+func PerUserKeyUpkeepBackgroundRound(g *libkb.GlobalContext, ectx *Context) error {
+	if g.ConnectivityMonitor.IsConnected(ectx.GetNetContext()) == libkb.ConnectivityMonitorNo {
+		g.Log.CDebugf(ectx.GetNetContext(), "PerUserKeyUpkeepBackgroundRound giving up offline")
+		return nil
+	}
+
+	arg := &PerUserKeyUpkeepArgs{}
+	eng := NewPerUserKeyUpkeep(g, arg)
+	err := RunEngine(eng, ectx)
+	return err
+}

--- a/go/engine/puk_upkeep_background_test.go
+++ b/go/engine/puk_upkeep_background_test.go
@@ -1,0 +1,164 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPerUserKeyUpkeepBackgroundUnnecessary(t *testing.T) {
+	tc := SetupEngineTest(t, "pukup")
+	defer tc.Cleanup()
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
+	tc.G.SetClock(fakeClock)
+
+	fu := CreateAndSignupFakeUser(tc, "pukup")
+
+	t.Logf("user has a per-user-key")
+	startingSeqno := getUserSeqno(&tc, fu.UID())
+
+	advance := func(d time.Duration) {
+		tc.G.Log.Debug("+ fakeClock#advance(%s) start: %s", d, fakeClock.Now())
+		fakeClock.Advance(d)
+		tc.G.Log.Debug("- fakeClock#adance(%s) end: %s", d, fakeClock.Now())
+	}
+
+	metaCh := make(chan string, 100)
+	roundResCh := make(chan error, 100)
+	arg := &PerUserKeyUpgradeBackgroundArgs{
+		testingMetaCh:     metaCh,
+		testingRoundResCh: roundResCh,
+	}
+	eng := NewPerUserKeyUpgradeBackground(tc.G, arg)
+	ctx := &Context{
+		LogUI: tc.G.UI.GetLogUI(),
+	}
+
+	err := RunEngine(eng, ctx)
+	require.NoError(t, err)
+
+	expectMeta(t, metaCh, "loop-start")
+	advance(PerUserKeyUpgradeBackgroundSettings.Start + time.Second)
+	expectMeta(t, metaCh, "woke-start")
+
+	// first run doesn't do anything
+	select {
+	case x := <-roundResCh:
+		require.Equal(t, nil, x, "round result")
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "channel timed out")
+	}
+	expectMeta(t, metaCh, "loop-round-complete")
+
+	checkPerUserKeyCount(&tc, 1)
+	checkUserSeqno(&tc, fu.UID(), startingSeqno)
+
+	eng.Shutdown()
+	expectMeta(t, metaCh, "loop-exit")
+	expectMeta(t, metaCh, "")
+}
+
+// The useful case of rolling the key after a deprovision.
+func TestPerUserKeyUpkeepBackgroundWork(t *testing.T) {
+	tc := SetupEngineTest(t, "pukup")
+	defer tc.Cleanup()
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
+	tc.G.SetClock(fakeClock)
+
+	fu := CreateAndSignupFakeUser(tc, "pukup")
+
+	// Get a second device which will deprovision itself.
+	tc2 := SetupEngineTest(t, "login")
+	defer tc2.Cleanup()
+
+	t.Logf("provision second device")
+	tcY, cleanup := provisionNewDeviceKex(&tc, fu)
+	defer cleanup()
+
+	t.Logf("second device deprovisions itself")
+	{
+		eng := NewDeprovisionEngine(tcY.G, fu.Username, true /* doRevoke */)
+		ctx := &Context{
+			LogUI:    tcY.G.UI.GetLogUI(),
+			SecretUI: fu.NewSecretUI(),
+		}
+		err := RunEngine(eng, ctx)
+		require.NoError(t, err, "deprovision")
+	}
+
+	preUpkeepSeqno := getUserSeqno(&tc, fu.UID())
+
+	t.Logf("load self to bust the upak cache")
+	// Upkeep hits the cache. It's ok that upkeep doesn't notice a deprovision
+	// right away. Bust the upak cache as a way of simulating time passing
+	// for the sake of this test.
+	loadArg := libkb.NewLoadUserArgBase(tc.G).
+		WithUID(fu.UID()).
+		WithSelf(true).
+		WithForcePoll(). // <-
+		WithPublicKeyOptional()
+	_, _, err := tc.G.GetUPAKLoader().LoadV2(*loadArg)
+	require.NoError(t, err)
+
+	advance := func(d time.Duration) {
+		tc.G.Log.Debug("+ fakeClock#advance(%s) start: %s", d, fakeClock.Now())
+		fakeClock.Advance(d)
+		tc.G.Log.Debug("- fakeClock#adance(%s) end: %s", d, fakeClock.Now())
+	}
+
+	metaCh := make(chan string, 100)
+	roundResCh := make(chan error, 100)
+	arg := &PerUserKeyUpkeepBackgroundArgs{
+		testingMetaCh:     metaCh,
+		testingRoundResCh: roundResCh,
+	}
+	eng := NewPerUserKeyUpkeepBackground(tc.G, arg)
+	ctx := &Context{
+		LogUI: tc.G.UI.GetLogUI(),
+	}
+
+	err = RunEngine(eng, ctx)
+	require.NoError(t, err)
+
+	expectMeta(t, metaCh, "loop-start")
+	advance(PerUserKeyUpkeepBackgroundSettings.Start + time.Second)
+	expectMeta(t, metaCh, "woke-start")
+
+	select {
+	case x := <-roundResCh:
+		require.Equal(t, nil, x, "round result")
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "channel timed out")
+	}
+	expectMeta(t, metaCh, "loop-round-complete")
+
+	checkUserSeqno(&tc, fu.UID(), preUpkeepSeqno+keybase1.Seqno(1))
+
+	// second run that doesn't do anything
+	advance(PerUserKeyUpkeepBackgroundSettings.Interval + time.Second)
+	expectMeta(t, metaCh, "woke-interval")
+	advance(PerUserKeyUpkeepBackgroundSettings.WakeUp + time.Second)
+	expectMeta(t, metaCh, "woke-wakeup") // this line has flaked before (CORE-5410)
+	select {
+	case x := <-roundResCh:
+		require.Equal(t, nil, x, "round result")
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "channel timed out")
+	}
+	expectMeta(t, metaCh, "loop-round-complete")
+	checkUserSeqno(&tc, fu.UID(), preUpkeepSeqno+keybase1.Seqno(1))
+
+	checkPerUserKeyCount(&tc, 3)
+	checkPerUserKeyCountLocal(&tc, 3)
+
+	eng.Shutdown()
+	expectMeta(t, metaCh, "loop-exit")
+	expectMeta(t, metaCh, "")
+}

--- a/go/engine/puk_upkeep_test.go
+++ b/go/engine/puk_upkeep_test.go
@@ -40,7 +40,7 @@ func TestPerUserKeyUpkeep(t *testing.T) {
 	tcY, cleanup := provisionNewDeviceKex(&tc, fu)
 	defer cleanup()
 
-	t.Logf("second device revokes itself")
+	t.Logf("second device deprovisions itself")
 	{
 		eng := NewDeprovisionEngine(tcY.G, fu.Username, true /* doRevoke */)
 		ctx := &Context{

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -557,11 +557,11 @@ func (d *Service) runBackgroundIdentifierWithUID(u keybase1.UID) {
 
 func (d *Service) runBackgroundPerUserKeyUpgrade() {
 	if !d.G().Env.GetUpgradePerUserKey() {
-		d.G().Log.Debug("PerUserKeyBackground disabled (not starting)")
+		d.G().Log.Debug("PerUserKeyUpgradeBackground disabled (not starting)")
 		return
 	}
 
-	eng := engine.NewPerUserKeyBackground(d.G(), &engine.PerUserKeyBackgroundArgs{})
+	eng := engine.NewPerUserKeyUpgradeBackground(d.G(), &engine.PerUserKeyUpgradeBackgroundArgs{})
 	go func() {
 		ectx := &engine.Context{NetContext: context.Background()}
 		err := engine.RunEngine(eng, ectx)

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -290,6 +290,7 @@ func (d *Service) RunBackgroundOperations(uir *UIRouter) {
 	d.configureRekey(uir)
 	d.runBackgroundIdentifier()
 	d.runBackgroundPerUserKeyUpgrade()
+	d.runBackgroundPerUserKeyUpkeep()
 	go d.identifySelf()
 }
 
@@ -572,6 +573,23 @@ func (d *Service) runBackgroundPerUserKeyUpgrade() {
 
 	d.G().PushShutdownHook(func() error {
 		d.G().Log.Debug("stopping per-user-key background upgrade")
+		eng.Shutdown()
+		return nil
+	})
+}
+
+func (d *Service) runBackgroundPerUserKeyUpkeep() {
+	eng := engine.NewPerUserKeyUpkeepBackground(d.G(), &engine.PerUserKeyUpkeepBackgroundArgs{})
+	go func() {
+		ectx := &engine.Context{NetContext: context.Background()}
+		err := engine.RunEngine(eng, ectx)
+		if err != nil {
+			d.G().Log.Warning("per-user-key background upkeep error: %v", err)
+		}
+	}()
+
+	d.G().PushShutdownHook(func() error {
+		d.G().Log.Debug("stopping per-user-key background upkeep")
 		eng.Shutdown()
 		return nil
 	})


### PR DESCRIPTION
Rename `PerUserKeyBackground` -> `PerUserKey[Upgrade]Background` to get it out of the way. Add `PerUserKeyUpkeepBackground` which runs `PerUserKeyUpkeep` once a day-ish.

Upgrade vs Upkeep is too darned confusing so I'm going to rename upkeep to idk what after this settles.