### PR TITLE
SearchV3: Allow changing the selected search result using the mouse

### DIFF
--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -138,5 +138,8 @@ export default compose(
       props._onClickSearchResult(id)
       props._clearSearchResults()
     },
+    onMouseOverSearchResult: props => id => {
+      props.onUpdateSelectedSearchResult(id)
+    },
   })
 )(Conversation)

--- a/shared/chat/conversation/index.desktop.js
+++ b/shared/chat/conversation/index.desktop.js
@@ -134,6 +134,7 @@ class Conversation extends Component<void, Props, State> {
               ? <SearchResultsList
                   items={this.props.searchResultIds}
                   onClick={this.props.onClickSearchResult}
+                  onMouseOver={this.props.onMouseOverSearchResult}
                   onShowTracker={this.props.onShowTrackerInSearch}
                   selectedId={this.props.selectedSearchId}
                   showSearchSuggestions={this.props.showSearchSuggestions}

--- a/shared/chat/conversation/index.js.flow
+++ b/shared/chat/conversation/index.js.flow
@@ -25,6 +25,7 @@ export type Props = {|
   showSearchSuggestions: boolean,
   searchResultIds: Array<SearchConstants.SearchResultId>,
   onClickSearchResult: (id: string) => void,
+  onMouseOverSearchResult: (id: string) => void,
   onShowTrackerInSearch: (id: string) => void,
   searchText: string,
   onChangeSearchText: (s: string) => void,

--- a/shared/common-adapters/clickable-box.js.flow
+++ b/shared/common-adapters/clickable-box.js.flow
@@ -14,6 +14,8 @@ export type Props = {|
   feedback?: boolean,
   // mobile only
   activeOpacity?: number,
+  // desktop only
+  onMouseOver?: ?(event: SyntheticEvent) => void,
 |}
 
 declare export default class ClickableBox extends Component<void, Props, void> {}

--- a/shared/constants/searchv3.js
+++ b/shared/constants/searchv3.js
@@ -42,6 +42,7 @@ export type RowProps = {|
   showTrackerButton: boolean,
   onShowTracker: () => void,
   onClick: () => void,
+  onMouseOver?: () => void,
   selected: boolean,
 |}
 

--- a/shared/searchv3/result-row/container.js
+++ b/shared/searchv3/result-row/container.js
@@ -9,7 +9,12 @@ import type {SearchResultId} from '../../constants/searchv3'
 
 const mapStateToProps = (
   state: TypedState,
-  {id, onClick, onShowTracker}: {id: SearchResultId, onClick: () => void, onShowTracker: () => void}
+  {
+    id,
+    onClick,
+    onMouseOver,
+    onShowTracker,
+  }: {id: SearchResultId, onClick: () => void, onMouseOver: () => void, onShowTracker: () => void}
 ) => {
   const result = state.entities.getIn(['searchResults', id], Map()).toObject()
 
@@ -19,6 +24,7 @@ const mapStateToProps = (
   return {
     ...result,
     onClick,
+    onMouseOver,
     onShowTracker,
     showTrackerButton: !!onShowTracker,
     leftFollowingState,

--- a/shared/searchv3/result-row/index.js
+++ b/shared/searchv3/result-row/index.js
@@ -103,33 +103,32 @@ const Line = () => (
   />
 )
 
-const SearchResultRow = (props: Constants.RowProps) => {
-  return (
-    <ClickableBox
-      style={_clickableBoxStyle[(!!props.selected).toString()]}
-      underlayColor={globalColors.blue4}
-      onClick={props.onClick}
-    >
-      <Box style={_rowStyle}>
-        <Left
-          leftFollowingState={props.leftFollowingState}
-          leftIcon={props.leftIcon}
-          leftService={props.leftService}
-          leftUsername={props.leftUsername}
-        />
-        <Middle
-          rightFollowingState={props.rightFollowingState}
-          rightFullname={props.rightFullname}
-          rightIcon={props.rightIcon}
-          rightService={props.rightService}
-          rightUsername={props.rightUsername}
-        />
-        <Right showTrackerButton={props.showTrackerButton} onShowTracker={props.onShowTracker} />
-        <Line />
-      </Box>
-    </ClickableBox>
-  )
-}
+const SearchResultRow = (props: Constants.RowProps) => (
+  <ClickableBox
+    style={_clickableBoxStyle[(!!props.selected).toString()]}
+    underlayColor={globalColors.blue4}
+    onClick={props.onClick}
+    onMouseOver={props.onMouseOver}
+  >
+    <Box style={_rowStyle}>
+      <Left
+        leftFollowingState={props.leftFollowingState}
+        leftIcon={props.leftIcon}
+        leftService={props.leftService}
+        leftUsername={props.leftUsername}
+      />
+      <Middle
+        rightFollowingState={props.rightFollowingState}
+        rightFullname={props.rightFullname}
+        rightIcon={props.rightIcon}
+        rightService={props.rightService}
+        rightUsername={props.rightUsername}
+      />
+      <Right showTrackerButton={props.showTrackerButton} onShowTracker={props.onShowTracker} />
+      <Line />
+    </Box>
+  </ClickableBox>
+)
 
 const _clickableBoxStyleCommon = {
   ...globalStyles.flexBoxRow,

--- a/shared/searchv3/results-list/index.desktop.js
+++ b/shared/searchv3/results-list/index.desktop.js
@@ -11,12 +11,13 @@ import type {Props} from '.'
 class SearchResultsList extends Component<void, Props, void> {
   _itemRenderer = index => {
     const id = this.props.items[index]
-    const {onClick, onShowTracker} = this.props
+    const {onClick, onMouseOver, onShowTracker} = this.props
     return (
       <Row
         id={id}
         key={id}
         onClick={() => onClick(id)}
+        onMouseOver={() => onMouseOver && onMouseOver(id)}
         onShowTracker={onShowTracker ? () => onShowTracker(id) : undefined}
         selected={this.props.selectedId === id}
       />

--- a/shared/searchv3/results-list/index.js.flow
+++ b/shared/searchv3/results-list/index.js.flow
@@ -7,6 +7,7 @@ export type Props = {
   style?: any,
   items: Array<SearchResultId>,
   onClick: (id: SearchResultId) => void,
+  onMouseOver?: (id: SearchResultId) => void,
   onShowTracker?: (id: SearchResultId) => void,
   selectedId: ?SearchResultId,
   showSearchSuggestions: boolean,


### PR DESCRIPTION
@keybase/react-hackers 

Hooks mouseOver events up to our notion of the currently selected search result on desktop, so that you can:

 * hover over a search result
 * up and down arrow move from there instead of from the top
 * pressing enter chooses the selected (hovered) result