### PR TITLE
handle new per device type badging information in service and frontend CORE-5403

### DIFF
--- a/go/badges/badger.go
+++ b/go/badges/badger.go
@@ -139,7 +139,7 @@ func (b *Badger) log(state1 keybase1.BadgeState) {
 	state2 = state1
 	state2.Conversations = nil
 	for _, c1 := range state1.Conversations {
-		if !c1.HasUnreadMessages {
+		if c1.UnreadMessages == 0 {
 			continue
 		}
 		c2id := c1.ConvID
@@ -150,9 +150,9 @@ func (b *Badger) log(state1 keybase1.BadgeState) {
 		}
 
 		c2 := keybase1.BadgeConversationInfo{
-			ConvID:            c2id,
-			HasUnreadMessages: true,
-			BadgeCounts:       c1.BadgeCounts,
+			ConvID:         c2id,
+			UnreadMessages: c1.UnreadMessages,
+			BadgeCounts:    c1.BadgeCounts,
 		}
 		state2.Conversations = append(state2.Conversations, c2)
 	}

--- a/go/badges/badger.go
+++ b/go/badges/badger.go
@@ -139,7 +139,7 @@ func (b *Badger) log(state1 keybase1.BadgeState) {
 	state2 = state1
 	state2.Conversations = nil
 	for _, c1 := range state1.Conversations {
-		if c1.UnreadMessages == 0 {
+		if !c1.HasUnreadMessages {
 			continue
 		}
 		c2id := c1.ConvID
@@ -148,9 +148,11 @@ func (b *Badger) log(state1 keybase1.BadgeState) {
 			// Don't let this leave this method.
 			c2id = chat1.ConversationID([]byte(c1.ConvID)).DbShortForm()
 		}
+
 		c2 := keybase1.BadgeConversationInfo{
-			ConvID:         c2id,
-			UnreadMessages: c1.UnreadMessages,
+			ConvID:            c2id,
+			HasUnreadMessages: true,
+			BadgeCounts:       c1.BadgeCounts,
 		}
 		state2.Conversations = append(state2.Conversations, c2)
 	}

--- a/go/badges/badgestate.go
+++ b/go/badges/badgestate.go
@@ -152,7 +152,8 @@ func (b *BadgeState) Clear() {
 
 func (b *BadgeState) updateWithChat(update chat1.UnreadUpdate) {
 	b.chatUnreadMap[update.ConvID.String()] = keybase1.BadgeConversationInfo{
-		ConvID:         keybase1.ChatConversationID(update.ConvID),
-		UnreadMessages: update.UnreadMessages,
+		ConvID:            keybase1.ChatConversationID(update.ConvID),
+		HasUnreadMessages: update.UnreadMessages > 0,
+		BadgeCounts:       update.UnreadNotifyingMessages,
 	}
 }

--- a/go/badges/badgestate.go
+++ b/go/badges/badgestate.go
@@ -152,8 +152,8 @@ func (b *BadgeState) Clear() {
 
 func (b *BadgeState) updateWithChat(update chat1.UnreadUpdate) {
 	b.chatUnreadMap[update.ConvID.String()] = keybase1.BadgeConversationInfo{
-		ConvID:            keybase1.ChatConversationID(update.ConvID),
-		HasUnreadMessages: update.UnreadMessages > 0,
-		BadgeCounts:       update.UnreadNotifyingMessages,
+		ConvID:         keybase1.ChatConversationID(update.ConvID),
+		UnreadMessages: update.UnreadMessages,
+		BadgeCounts:    update.UnreadNotifyingMessages,
 	}
 }

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -341,7 +341,7 @@ func (g *PushHandler) shouldDisplayDesktopNotification(ctx context.Context,
 			g.Debug(ctx, "shouldDisplayDesktopNotification: failed to get message type: %s", err.Error())
 			return false
 		}
-		if typ == chat1.MessageType_TEXT {
+		if typ == chat1.MessageType_TEXT || typ == chat1.MessageType_ATTACHMENT {
 			atMentions := utils.ParseAtMentionedUIDs(ctx, msg.Valid().MessageBody.Text().Body,
 				g.G().GetUPAKLoader(), &g.DebugLabeler)
 			kind := chat1.NotificationKind_GENERIC

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -351,7 +351,7 @@ func (g *PushHandler) shouldDisplayDesktopNotification(ctx context.Context,
 					break
 				}
 			}
-			apptype := chat1.NotificationAppType_DESKTOP
+			apptype := keybase1.DeviceType_DESKTOP
 			return conv.Notifications.Settings[apptype][kind]
 		}
 	}

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -732,6 +732,11 @@ func (g *PushHandler) MembershipUpdate(ctx context.Context, m gregor.OutOfBandMe
 			g.notifyMembersUpdate(ctx, uid, cm, false)
 		}
 
+		// Fire off badger update
+		if g.badger != nil && update.UnreadUpdate != nil {
+			g.badger.PushChatUpdate(*update.UnreadUpdate, update.InboxVers)
+		}
+
 		return nil
 	}(bctx)
 

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -341,18 +341,23 @@ func (g *PushHandler) shouldDisplayDesktopNotification(ctx context.Context,
 			g.Debug(ctx, "shouldDisplayDesktopNotification: failed to get message type: %s", err.Error())
 			return false
 		}
-		if typ == chat1.MessageType_TEXT || typ == chat1.MessageType_ATTACHMENT {
+		apptype := keybase1.DeviceType_DESKTOP
+		kind := chat1.NotificationKind_GENERIC
+		switch typ {
+		case chat1.MessageType_TEXT:
 			atMentions := utils.ParseAtMentionedUIDs(ctx, msg.Valid().MessageBody.Text().Body,
 				g.G().GetUPAKLoader(), &g.DebugLabeler)
-			kind := chat1.NotificationKind_GENERIC
 			for _, at := range atMentions {
 				if at.Eq(uid) {
 					kind = chat1.NotificationKind_ATMENTION
 					break
 				}
 			}
-			apptype := keybase1.DeviceType_DESKTOP
 			return conv.Notifications.Settings[apptype][kind]
+		case chat1.MessageType_ATTACHMENT:
+			return conv.Notifications.Settings[apptype][kind]
+		default:
+			return false
 		}
 	}
 	return false

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2013,10 +2013,10 @@ func TestChatSrvSetAppNotificationSettings(t *testing.T) {
 		require.Equal(t, 1, len(gilres.Conversations))
 		require.Equal(t, conv.Id, gilres.Conversations[0].GetConvID())
 		gconv := gilres.Conversations[0]
-		require.True(t, gconv.Notifications.Settings[chat1.NotificationAppType_DESKTOP][chat1.NotificationKind_GENERIC])
+		require.True(t, gconv.Notifications.Settings[keybase1.DeviceType_DESKTOP][chat1.NotificationKind_GENERIC])
 		require.Equal(t, 2, len(gconv.Notifications.Settings))
-		require.Equal(t, 2, len(gconv.Notifications.Settings[chat1.NotificationAppType_DESKTOP]))
-		require.Equal(t, 2, len(gconv.Notifications.Settings[chat1.NotificationAppType_MOBILE]))
+		require.Equal(t, 2, len(gconv.Notifications.Settings[keybase1.DeviceType_DESKTOP]))
+		require.Equal(t, 2, len(gconv.Notifications.Settings[keybase1.DeviceType_MOBILE]))
 
 		mustPostLocalForTest(t, ctc, users[1], conv,
 			chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello!"}))
@@ -2028,7 +2028,7 @@ func TestChatSrvSetAppNotificationSettings(t *testing.T) {
 		}
 
 		var settings chat1.ConversationNotificationInfo
-		utils.NotificationInfoSet(&settings, chat1.NotificationAppType_DESKTOP,
+		utils.NotificationInfoSet(&settings, keybase1.DeviceType_DESKTOP,
 			chat1.NotificationKind_GENERIC, false)
 		_, err = ctc.as(t, users[0]).chatLocalHandler().SetAppNotificationSettingsLocal(ctx,
 			chat1.SetAppNotificationSettingsLocalArg{
@@ -2053,10 +2053,10 @@ func TestChatSrvSetAppNotificationSettings(t *testing.T) {
 		require.Equal(t, 1, len(gilres.Conversations))
 		require.Equal(t, conv.Id, gilres.Conversations[0].GetConvID())
 		gconv = gilres.Conversations[0]
-		require.False(t, gconv.Notifications.Settings[chat1.NotificationAppType_DESKTOP][chat1.NotificationKind_GENERIC])
+		require.False(t, gconv.Notifications.Settings[keybase1.DeviceType_DESKTOP][chat1.NotificationKind_GENERIC])
 		require.Equal(t, 2, len(gconv.Notifications.Settings))
-		require.Equal(t, 2, len(gconv.Notifications.Settings[chat1.NotificationAppType_DESKTOP]))
-		require.Equal(t, 2, len(gconv.Notifications.Settings[chat1.NotificationAppType_MOBILE]))
+		require.Equal(t, 2, len(gconv.Notifications.Settings[keybase1.DeviceType_DESKTOP]))
+		require.Equal(t, 2, len(gconv.Notifications.Settings[keybase1.DeviceType_MOBILE]))
 
 		mustPostLocalForTest(t, ctc, users[1], conv,
 			chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hello!"}))

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -493,10 +493,10 @@ func GetTopicName(conv chat1.ConversationLocal) string {
 }
 
 func NotificationInfoSet(settings *chat1.ConversationNotificationInfo,
-	apptype chat1.NotificationAppType,
+	apptype keybase1.DeviceType,
 	kind chat1.NotificationKind, enabled bool) {
 	if settings.Settings == nil {
-		settings.Settings = make(map[chat1.NotificationAppType]map[chat1.NotificationKind]bool)
+		settings.Settings = make(map[keybase1.DeviceType]map[chat1.NotificationKind]bool)
 	}
 	if settings.Settings[apptype] == nil {
 		settings.Settings[apptype] = make(map[chat1.NotificationKind]bool)

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -6,6 +6,7 @@ package chat1
 import (
 	"errors"
 	gregor1 "github.com/keybase/client/go/protocol/gregor1"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 
@@ -182,25 +183,6 @@ var TopicTypeRevMap = map[TopicType]string{
 	0: "NONE",
 	1: "CHAT",
 	2: "DEV",
-}
-
-type NotificationAppType int
-
-const (
-	NotificationAppType_DESKTOP NotificationAppType = 0
-	NotificationAppType_MOBILE  NotificationAppType = 1
-)
-
-func (o NotificationAppType) DeepCopy() NotificationAppType { return o }
-
-var NotificationAppTypeMap = map[string]NotificationAppType{
-	"DESKTOP": 0,
-	"MOBILE":  1,
-}
-
-var NotificationAppTypeRevMap = map[NotificationAppType]string{
-	0: "DESKTOP",
-	1: "MOBILE",
 }
 
 type NotificationKind int
@@ -566,14 +548,14 @@ func (o ConversationMetadata) DeepCopy() ConversationMetadata {
 
 type ConversationNotificationInfo struct {
 	ChannelWide bool                                              `codec:"channelWide" json:"channelWide"`
-	Settings    map[NotificationAppType]map[NotificationKind]bool `codec:"settings" json:"settings"`
+	Settings    map[keybase1.DeviceType]map[NotificationKind]bool `codec:"settings" json:"settings"`
 }
 
 func (o ConversationNotificationInfo) DeepCopy() ConversationNotificationInfo {
 	return ConversationNotificationInfo{
 		ChannelWide: o.ChannelWide,
-		Settings: (func(x map[NotificationAppType]map[NotificationKind]bool) map[NotificationAppType]map[NotificationKind]bool {
-			ret := make(map[NotificationAppType]map[NotificationKind]bool)
+		Settings: (func(x map[keybase1.DeviceType]map[NotificationKind]bool) map[keybase1.DeviceType]map[NotificationKind]bool {
+			ret := make(map[keybase1.DeviceType]map[NotificationKind]bool)
 			for k, v := range x {
 				kCopy := k.DeepCopy()
 				vCopy := (func(x map[NotificationKind]bool) map[NotificationKind]bool {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 type ByUID []gregor1.UID
@@ -596,4 +597,15 @@ func (o TLFConvOrdinal) Int() int {
 
 func (o TLFConvOrdinal) IsFirst() bool {
 	return o.Int() == 1
+}
+
+func MakeEmptyUnreadUpdate(convID ConversationID) UnreadUpdate {
+	counts := make(map[keybase1.DeviceType]int)
+	counts[keybase1.DeviceType_DESKTOP] = 0
+	counts[keybase1.DeviceType_MOBILE] = 0
+	return UnreadUpdate{
+		ConvID:                  convID,
+		UnreadMessages:          0,
+		UnreadNotifyingMessages: counts,
+	}
 }

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -5,6 +5,7 @@ package chat1
 
 import (
 	gregor1 "github.com/keybase/client/go/protocol/gregor1"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 
@@ -133,16 +134,24 @@ func (o SetAppNotificationSettingsPayload) DeepCopy() SetAppNotificationSettings
 }
 
 type UnreadUpdate struct {
-	ConvID                  ConversationID `codec:"convID" json:"convID"`
-	UnreadMessages          int            `codec:"UnreadMessages" json:"UnreadMessages"`
-	UnreadNotifyingMessages int            `codec:"UnreadNotifyingMessages" json:"UnreadNotifyingMessages"`
+	ConvID                  ConversationID              `codec:"convID" json:"convID"`
+	UnreadMessages          int                         `codec:"unreadMessages" json:"unreadMessages"`
+	UnreadNotifyingMessages map[keybase1.DeviceType]int `codec:"unreadNotifyingMessages" json:"unreadNotifyingMessages"`
 }
 
 func (o UnreadUpdate) DeepCopy() UnreadUpdate {
 	return UnreadUpdate{
-		ConvID:                  o.ConvID.DeepCopy(),
-		UnreadMessages:          o.UnreadMessages,
-		UnreadNotifyingMessages: o.UnreadNotifyingMessages,
+		ConvID:         o.ConvID.DeepCopy(),
+		UnreadMessages: o.UnreadMessages,
+		UnreadNotifyingMessages: (func(x map[keybase1.DeviceType]int) map[keybase1.DeviceType]int {
+			ret := make(map[keybase1.DeviceType]int)
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := v
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.UnreadNotifyingMessages),
 	}
 }
 

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -194,9 +194,10 @@ func (o RemoteUserTypingUpdate) DeepCopy() RemoteUserTypingUpdate {
 }
 
 type UpdateConversationMembership struct {
-	InboxVers InboxVers            `codec:"inboxVers" json:"inboxVers"`
-	Joined    []ConversationMember `codec:"joined" json:"joined"`
-	Removed   []ConversationMember `codec:"removed" json:"removed"`
+	InboxVers    InboxVers            `codec:"inboxVers" json:"inboxVers"`
+	Joined       []ConversationMember `codec:"joined" json:"joined"`
+	Removed      []ConversationMember `codec:"removed" json:"removed"`
+	UnreadUpdate *UnreadUpdate        `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
 }
 
 func (o UpdateConversationMembership) DeepCopy() UpdateConversationMembership {
@@ -218,6 +219,13 @@ func (o UpdateConversationMembership) DeepCopy() UpdateConversationMembership {
 			}
 			return ret
 		})(o.Removed),
+		UnreadUpdate: (func(x *UnreadUpdate) *UnreadUpdate {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.UnreadUpdate),
 	}
 }
 

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -133,14 +133,16 @@ func (o SetAppNotificationSettingsPayload) DeepCopy() SetAppNotificationSettings
 }
 
 type UnreadUpdate struct {
-	ConvID         ConversationID `codec:"convID" json:"convID"`
-	UnreadMessages int            `codec:"UnreadMessages" json:"UnreadMessages"`
+	ConvID                  ConversationID `codec:"convID" json:"convID"`
+	UnreadMessages          int            `codec:"UnreadMessages" json:"UnreadMessages"`
+	UnreadNotifyingMessages int            `codec:"UnreadNotifyingMessages" json:"UnreadNotifyingMessages"`
 }
 
 func (o UnreadUpdate) DeepCopy() UnreadUpdate {
 	return UnreadUpdate{
-		ConvID:         o.ConvID.DeepCopy(),
-		UnreadMessages: o.UnreadMessages,
+		ConvID:                  o.ConvID.DeepCopy(),
+		UnreadMessages:          o.UnreadMessages,
+		UnreadNotifyingMessages: o.UnreadNotifyingMessages,
 	}
 }
 

--- a/go/protocol/keybase1/notify_badges.go
+++ b/go/protocol/keybase1/notify_badges.go
@@ -45,9 +45,9 @@ func (o BadgeState) DeepCopy() BadgeState {
 }
 
 type BadgeConversationInfo struct {
-	ConvID            ChatConversationID `codec:"convID" json:"convID"`
-	BadgeCounts       map[DeviceType]int `codec:"badgeCounts" json:"badgeCounts"`
-	HasUnreadMessages bool               `codec:"hasUnreadMessages" json:"hasUnreadMessages"`
+	ConvID         ChatConversationID `codec:"convID" json:"convID"`
+	BadgeCounts    map[DeviceType]int `codec:"badgeCounts" json:"badgeCounts"`
+	UnreadMessages int                `codec:"unreadMessages" json:"unreadMessages"`
 }
 
 func (o BadgeConversationInfo) DeepCopy() BadgeConversationInfo {
@@ -62,7 +62,7 @@ func (o BadgeConversationInfo) DeepCopy() BadgeConversationInfo {
 			}
 			return ret
 		})(o.BadgeCounts),
-		HasUnreadMessages: o.HasUnreadMessages,
+		UnreadMessages: o.UnreadMessages,
 	}
 }
 

--- a/go/protocol/keybase1/notify_badges.go
+++ b/go/protocol/keybase1/notify_badges.go
@@ -45,14 +45,24 @@ func (o BadgeState) DeepCopy() BadgeState {
 }
 
 type BadgeConversationInfo struct {
-	ConvID         ChatConversationID `codec:"convID" json:"convID"`
-	UnreadMessages int                `codec:"UnreadMessages" json:"UnreadMessages"`
+	ConvID            ChatConversationID `codec:"convID" json:"convID"`
+	BadgeCounts       map[DeviceType]int `codec:"badgeCounts" json:"badgeCounts"`
+	HasUnreadMessages bool               `codec:"hasUnreadMessages" json:"hasUnreadMessages"`
 }
 
 func (o BadgeConversationInfo) DeepCopy() BadgeConversationInfo {
 	return BadgeConversationInfo{
-		ConvID:         o.ConvID.DeepCopy(),
-		UnreadMessages: o.UnreadMessages,
+		ConvID: o.ConvID.DeepCopy(),
+		BadgeCounts: (func(x map[DeviceType]int) map[DeviceType]int {
+			ret := make(map[DeviceType]int)
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := v
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.BadgeCounts),
+		HasUnreadMessages: o.HasUnreadMessages,
 	}
 }
 

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -2,6 +2,7 @@
 protocol common {
 
   import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
+  import idl "github.com/keybase/client/go/protocol/keybase1" as keybase1;
 
   @typedef("bytes")  record ThreadID {}
   @typedef("uint") @lint("ignore") record MessageID {}
@@ -37,12 +38,6 @@ protocol common {
     NONE_0,
     CHAT_1,
     DEV_2
-  }
-
-  @go("nostring")
-  enum NotificationAppType {
-    DESKTOP_0,
-    MOBILE_1
   }
 
   @go("nostring")
@@ -175,7 +170,7 @@ protocol common {
 
   record ConversationNotificationInfo {
     boolean channelWide;
-    map<NotificationAppType, map<NotificationKind, boolean>> settings;
+    map<keybase1.DeviceType, map<NotificationKind, boolean>> settings;
   }
 
   record ConversationReaderInfo {

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -59,6 +59,8 @@ protocol gregor {
         // Counts only visible types of messages deserving of a badge, no EDITs
         @lint("ignore")
         int UnreadMessages;
+        @lint("ignore")
+        int UnreadNotifyingMessages;
     }
 
     record TLFFinalizeUpdate {

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -2,6 +2,7 @@
 protocol gregor {
 
     import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
+    import idl "github.com/keybase/client/go/protocol/keybase1" as keybase1;
 
     record GenericPayload {
         @lint("ignore")
@@ -57,10 +58,8 @@ protocol gregor {
         ConversationID convID;
         // The count of unread messages to display
         // Counts only visible types of messages deserving of a badge, no EDITs
-        @lint("ignore")
-        int UnreadMessages;
-        @lint("ignore")
-        int UnreadNotifyingMessages;
+        int unreadMessages;
+        map<keybase1.DeviceType, int> unreadNotifyingMessages;
     }
 
     record TLFFinalizeUpdate {

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -83,5 +83,6 @@ protocol gregor {
         InboxVers inboxVers;
         array<ConversationMember> joined;
         array<ConversationMember> removed;
+        union { null, UnreadUpdate } unreadUpdate;
     }
 }

--- a/protocol/avdl/keybase1/notify_badges.avdl
+++ b/protocol/avdl/keybase1/notify_badges.avdl
@@ -17,7 +17,7 @@ protocol NotifyBadges {
   record BadgeConversationInfo {
     ChatConversationID convID;
     map<DeviceType, int> badgeCounts;
-    boolean hasUnreadMessages;
+    int unreadMessages;
   }
 
   @notify("")

--- a/protocol/avdl/keybase1/notify_badges.avdl
+++ b/protocol/avdl/keybase1/notify_badges.avdl
@@ -16,8 +16,8 @@ protocol NotifyBadges {
 
   record BadgeConversationInfo {
     ChatConversationID convID;
-    @lint("ignore")
-    int UnreadMessages;
+    map<DeviceType, int> badgeCounts;
+    boolean hasUnreadMessages;
   }
 
   @notify("")

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -2100,6 +2100,7 @@ export type UpdateConversationMembership = {
   inboxVers: InboxVers,
   joined?: ?Array<ConversationMember>,
   removed?: ?Array<ConversationMember>,
+  unreadUpdate?: ?UnreadUpdate,
 }
 
 export type chatUiChatAttachmentDownloadProgressRpcParam = Exact<{

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -93,11 +93,6 @@ export const CommonMessageType = {
   attachmentuploaded: 8,
 }
 
-export const CommonNotificationAppType = {
-  desktop: 0,
-  mobile: 1,
-}
-
 export const CommonNotificationKind = {
   generic: 0,
   atmention: 1,
@@ -1779,10 +1774,6 @@ export type NonblockFetchRes = {
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
 
-export type NotificationAppType =
-    0 // DESKTOP_0
-  | 1 // MOBILE_1
-
 export type NotificationKind =
     0 // GENERIC_0
   | 1 // ATMENTION_1
@@ -2087,8 +2078,8 @@ export type UnreadFirstNumLimit = {
 
 export type UnreadUpdate = {
   convID: ConversationID,
-  UnreadMessages: int,
-  UnreadNotifyingMessages: int,
+  unreadMessages: int,
+  unreadNotifyingMessages: {[key: string]: int},
 }
 
 export type UnreadUpdateFull = {

--- a/protocol/js/flow-types-chat.js
+++ b/protocol/js/flow-types-chat.js
@@ -2088,6 +2088,7 @@ export type UnreadFirstNumLimit = {
 export type UnreadUpdate = {
   convID: ConversationID,
   UnreadMessages: int,
+  UnreadNotifyingMessages: int,
 }
 
 export type UnreadUpdateFull = {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4183,7 +4183,8 @@ export type BTCRegisterBTCRpcParam = Exact<{
 
 export type BadgeConversationInfo = {
   convID: ChatConversationID,
-  UnreadMessages: int,
+  badgeCounts: {[key: string]: int},
+  hasUnreadMessages: boolean,
 }
 
 export type BadgeState = {

--- a/protocol/js/flow-types.js
+++ b/protocol/js/flow-types.js
@@ -4184,7 +4184,7 @@ export type BTCRegisterBTCRpcParam = Exact<{
 export type BadgeConversationInfo = {
   convID: ChatConversationID,
   badgeCounts: {[key: string]: int},
-  hasUnreadMessages: boolean,
+  unreadMessages: int,
 }
 
 export type BadgeState = {

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -5,6 +5,11 @@
       "path": "github.com/keybase/client/go/protocol/gregor1",
       "type": "idl",
       "import_as": "gregor1"
+    },
+    {
+      "path": "github.com/keybase/client/go/protocol/keybase1",
+      "type": "idl",
+      "import_as": "keybase1"
     }
   ],
   "types": [
@@ -97,15 +102,6 @@
         "NONE_0",
         "CHAT_1",
         "DEV_2"
-      ],
-      "go": "nostring"
-    },
-    {
-      "type": "enum",
-      "name": "NotificationAppType",
-      "symbols": [
-        "DESKTOP_0",
-        "MOBILE_1"
       ],
       "go": "nostring"
     },
@@ -419,7 +415,7 @@
               "values": "boolean",
               "keys": "NotificationKind"
             },
-            "keys": "NotificationAppType"
+            "keys": "keybase1.DeviceType"
           },
           "name": "settings"
         }

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -259,6 +259,13 @@
             "items": "ConversationMember"
           },
           "name": "removed"
+        },
+        {
+          "type": [
+            null,
+            "UnreadUpdate"
+          ],
+          "name": "unreadUpdate"
         }
       ]
     }

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -5,6 +5,11 @@
       "path": "github.com/keybase/client/go/protocol/gregor1",
       "type": "idl",
       "import_as": "gregor1"
+    },
+    {
+      "path": "github.com/keybase/client/go/protocol/keybase1",
+      "type": "idl",
+      "import_as": "keybase1"
     }
   ],
   "types": [
@@ -176,13 +181,15 @@
         },
         {
           "type": "int",
-          "name": "UnreadMessages",
-          "lint": "ignore"
+          "name": "unreadMessages"
         },
         {
-          "type": "int",
-          "name": "UnreadNotifyingMessages",
-          "lint": "ignore"
+          "type": {
+            "type": "map",
+            "values": "int",
+            "keys": "keybase1.DeviceType"
+          },
+          "name": "unreadNotifyingMessages"
         }
       ]
     },

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -178,6 +178,11 @@
           "type": "int",
           "name": "UnreadMessages",
           "lint": "ignore"
+        },
+        {
+          "type": "int",
+          "name": "UnreadNotifyingMessages",
+          "lint": "ignore"
         }
       ]
     },

--- a/protocol/json/keybase1/notify_badges.json
+++ b/protocol/json/keybase1/notify_badges.json
@@ -60,8 +60,8 @@
           "name": "badgeCounts"
         },
         {
-          "type": "boolean",
-          "name": "hasUnreadMessages"
+          "type": "int",
+          "name": "unreadMessages"
         }
       ]
     }

--- a/protocol/json/keybase1/notify_badges.json
+++ b/protocol/json/keybase1/notify_badges.json
@@ -52,9 +52,16 @@
           "name": "convID"
         },
         {
-          "type": "int",
-          "name": "UnreadMessages",
-          "lint": "ignore"
+          "type": {
+            "type": "map",
+            "values": "int",
+            "keys": "DeviceType"
+          },
+          "name": "badgeCounts"
+        },
+        {
+          "type": "boolean",
+          "name": "hasUnreadMessages"
         }
       ]
     }

--- a/shared/actions/chat/attachment.js
+++ b/shared/actions/chat/attachment.js
@@ -228,9 +228,13 @@ function* _appendAttachmentPlaceholder(
   const appFocused = yield select(Shared.focusedSelector)
 
   yield put(
-    Creators.appendMessages(conversationIDKey, conversationIDKey === selectedConversation, appFocused, [
-      message,
-    ])
+    Creators.appendMessages(
+      conversationIDKey,
+      conversationIDKey === selectedConversation,
+      appFocused,
+      [message],
+      false
+    )
   )
   yield put(Creators.attachmentLoaded(message.key, preview.filename, true))
   if (hasPendingFailure) {

--- a/shared/actions/chat/creators.js
+++ b/shared/actions/chat/creators.js
@@ -59,6 +59,7 @@ const appendMessageActionTransformer = (action: Constants.AppendMessages) => ({
   payload: {
     conversationIDKey: action.payload.conversationIDKey,
     messages: action.payload.messages.map(safeServerMessageMap),
+    svcShouldDisplayNotification: action.payload.svcShouldDisplayNotification,
   },
   type: action.type,
 })
@@ -176,7 +177,10 @@ function startConversation(
   forceImmediate?: boolean = false,
   temporary?: boolean = false
 ): Constants.StartConversation {
-  return {payload: {forceImmediate, users: uniq(users), temporary}, type: 'chat:startConversation'}
+  return {
+    payload: {forceImmediate, users: uniq(users), temporary},
+    type: 'chat:startConversation',
+  }
 }
 
 function newChat(existingParticipants: Array<string>): Constants.NewChat {
@@ -218,7 +222,10 @@ function loadMoreMessages(
   onlyIfUnloaded: boolean,
   fromUser?: boolean = false
 ): Constants.LoadMoreMessages {
-  return {payload: {conversationIDKey, onlyIfUnloaded, fromUser}, type: 'chat:loadMoreMessages'}
+  return {
+    payload: {conversationIDKey, onlyIfUnloaded, fromUser},
+    type: 'chat:loadMoreMessages',
+  }
 }
 
 function showEditor(message: ?Constants.Message): Constants.ShowEditor {
@@ -233,7 +240,10 @@ function muteConversation(
   conversationIDKey: Constants.ConversationIDKey,
   muted: boolean
 ): Constants.MuteConversation {
-  return {payload: {conversationIDKey, muted}, type: 'chat:muteConversation'}
+  return {
+    payload: {conversationIDKey, muted},
+    type: 'chat:muteConversation',
+  }
 }
 
 function blockConversation(
@@ -241,7 +251,10 @@ function blockConversation(
   conversationIDKey: Constants.ConversationIDKey,
   reportUser: boolean
 ): Constants.BlockConversation {
-  return {payload: {blocked, conversationIDKey, reportUser}, type: 'chat:blockConversation'}
+  return {
+    payload: {blocked, conversationIDKey, reportUser},
+    type: 'chat:blockConversation',
+  }
 }
 
 function deleteMessage(message: Constants.Message): Constants.DeleteMessage {
@@ -252,7 +265,10 @@ function addPending(
   participants: Array<string>,
   temporary: boolean = false
 ): Constants.AddPendingConversation {
-  return {payload: {participants, temporary}, type: 'chat:addPendingConversation'}
+  return {
+    payload: {participants, temporary},
+    type: 'chat:addPendingConversation',
+  }
 }
 
 function removeTempPendingConversations(): Constants.RemoveTempPendingConversations {
@@ -270,7 +286,10 @@ function updateSupersedesState(supersedesState: Constants.SupersedesState): Cons
 function updateSupersededByState(
   supersededByState: Constants.SupersededByState
 ): Constants.UpdateSupersededByState {
-  return {payload: {supersededByState}, type: 'chat:updateSupersededByState'}
+  return {
+    payload: {supersededByState},
+    type: 'chat:updateSupersededByState',
+  }
 }
 
 function updateInbox(conversation: Constants.InboxState): Constants.UpdateInbox {
@@ -281,32 +300,48 @@ function createPendingFailure(
   failureDescription: string,
   outboxID: Constants.OutboxIDKey
 ): Constants.CreatePendingFailure {
-  return {payload: {failureDescription, outboxID}, type: 'chat:createPendingFailure'}
+  return {
+    payload: {failureDescription, outboxID},
+    type: 'chat:createPendingFailure',
+  }
 }
 
 function updatePaginationNext(
   conversationIDKey: Constants.ConversationIDKey,
   paginationNext: Buffer
 ): Constants.UpdatePaginationNext {
-  return {payload: {conversationIDKey, paginationNext}, type: 'chat:updatePaginationNext'}
+  return {
+    payload: {conversationIDKey, paginationNext},
+    type: 'chat:updatePaginationNext',
+  }
 }
 
 function markSeenMessage(
   conversationIDKey: Constants.ConversationIDKey,
   messageKey: Constants.MessageKey
 ): Constants.MarkSeenMessage {
-  return {payload: {conversationIDKey, messageKey}, type: 'chat:markSeenMessage'}
+  return {
+    payload: {conversationIDKey, messageKey},
+    type: 'chat:markSeenMessage',
+  }
 }
 
 function appendMessages(
   conversationIDKey: Constants.ConversationIDKey,
   isSelected: boolean,
   isAppFocused: boolean,
-  messages: Array<Constants.Message>
+  messages: Array<Constants.Message>,
+  svcShouldDisplayNotification: boolean
 ): Constants.AppendMessages {
   return {
     logTransformer: appendMessageActionTransformer,
-    payload: {conversationIDKey, isAppFocused, isSelected, messages},
+    payload: {
+      conversationIDKey,
+      isAppFocused,
+      isSelected,
+      messages,
+      svcShouldDisplayNotification,
+    },
     type: 'chat:appendMessages',
   }
 }
@@ -328,7 +363,10 @@ function clearSearchResults(): Constants.ClearSearchResults {
 function updateConversationUnreadCounts(
   conversationUnreadCounts: Map<Constants.ConversationIDKey, number>
 ): Constants.UpdateConversationUnreadCounts {
-  return {payload: {conversationUnreadCounts}, type: 'chat:updateConversationUnreadCounts'}
+  return {
+    payload: {conversationUnreadCounts},
+    type: 'chat:updateConversationUnreadCounts',
+  }
 }
 
 function updateMetadata(users: Array<string>): Constants.UpdateMetadata {
@@ -391,7 +429,10 @@ function loadingMessages(
   conversationIDKey: Constants.ConversationIDKey,
   isRequesting: boolean
 ): Constants.LoadingMessages {
-  return {payload: {conversationIDKey, isRequesting}, type: 'chat:loadingMessages'}
+  return {
+    payload: {conversationIDKey, isRequesting},
+    type: 'chat:loadingMessages',
+  }
 }
 
 function retryAttachment(message: Constants.AttachmentMessage): Constants.RetryAttachment {
@@ -408,7 +449,10 @@ function retryAttachment(message: Constants.AttachmentMessage): Constants.RetryA
     title,
     type: previewType || 'Other',
   }
-  return {payload: {input, oldOutboxID: outboxID}, type: 'chat:retryAttachment'}
+  return {
+    payload: {input, oldOutboxID: outboxID},
+    type: 'chat:retryAttachment',
+  }
 }
 
 function selectAttachment(input: Constants.AttachmentInput): Constants.SelectAttachment {
@@ -476,7 +520,10 @@ function selectConversation(
   conversationIDKey: ?Constants.ConversationIDKey,
   fromUser: boolean
 ): Constants.SelectConversation {
-  return {payload: {conversationIDKey, fromUser}, type: 'chat:selectConversation'}
+  return {
+    payload: {conversationIDKey, fromUser},
+    type: 'chat:selectConversation',
+  }
 }
 
 function updateTempMessage(
@@ -505,7 +552,10 @@ function untrustedInboxVisible(
   conversationIDKey: Constants.ConversationIDKey,
   rowsVisible: number
 ): Constants.UntrustedInboxVisible {
-  return {payload: {conversationIDKey, rowsVisible}, type: 'chat:untrustedInboxVisible'}
+  return {
+    payload: {conversationIDKey, rowsVisible},
+    type: 'chat:untrustedInboxVisible',
+  }
 }
 
 function setUnboxing(
@@ -514,7 +564,11 @@ function setUnboxing(
 ): Constants.SetUnboxing {
   // Just to make flow happy
   if (errored) {
-    return {error: true, payload: {conversationIDKeys}, type: 'chat:setUnboxing'}
+    return {
+      error: true,
+      payload: {conversationIDKeys},
+      type: 'chat:setUnboxing',
+    }
   }
   return {payload: {conversationIDKeys}, type: 'chat:setUnboxing'}
 }
@@ -533,7 +587,10 @@ function updateInboxRekeyOthers(
   conversationIDKey: Constants.ConversationIDKey,
   rekeyers: Array<string>
 ): Constants.UpdateInboxRekeyOthers {
-  return {payload: {conversationIDKey, rekeyers}, type: 'chat:updateInboxRekeyOthers'}
+  return {
+    payload: {conversationIDKey, rekeyers},
+    type: 'chat:updateInboxRekeyOthers',
+  }
 }
 
 function updateInboxComplete(): Constants.UpdateInboxComplete {
@@ -544,7 +601,10 @@ function removeOutboxMessage(
   conversationIDKey: Constants.ConversationIDKey,
   outboxID: Constants.OutboxIDKey
 ): Constants.RemoveOutboxMessage {
-  return {payload: {conversationIDKey, outboxID}, type: 'chat:removeOutboxMessage'}
+  return {
+    payload: {conversationIDKey, outboxID},
+    type: 'chat:removeOutboxMessage',
+  }
 }
 
 function removePendingFailure(outboxID: Constants.OutboxIDKey): Constants.RemovePendingFailure {
@@ -571,7 +631,10 @@ function setInitialConversation(
 function setPreviousConversation(
   conversationIDKey: ?Constants.ConversationIDKey
 ): Constants.SetPreviousConversation {
-  return {payload: {conversationIDKey}, type: 'chat:setPreviousConversation'}
+  return {
+    payload: {conversationIDKey},
+    type: 'chat:setPreviousConversation',
+  }
 }
 
 function threadLoadedOffline(conversationIDKey: Constants.ConversationIDKey): Constants.ThreadLoadedOffline {
@@ -625,7 +688,10 @@ function updateThread(
   yourDeviceName: string,
   conversationIDKey: string
 ): Constants.UpdateThread {
-  return {payload: {thread, yourName, yourDeviceName, conversationIDKey}, type: 'chat:updateThread'}
+  return {
+    payload: {thread, yourName, yourDeviceName, conversationIDKey},
+    type: 'chat:updateThread',
+  }
 }
 
 export {

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -890,10 +890,10 @@ function* _badgeAppForChat(action: Constants.BadgeAppForChat): SagaGenerator<any
   const conversations = action.payload
   let conversationsWithKeys = {}
   conversations.map(conv => {
-    conversationsWithKeys[Constants.conversationIDToKey(conv.get('convID'))] = conv.get('UnreadMessages')
+    conversationsWithKeys[Constants.conversationIDToKey(conv.get('convID'))] = conv.get('unreadMessages')
   })
   const conversationUnreadCounts = conversations.reduce((map, conv) => {
-    const count = conv.get('UnreadMessages')
+    const count = conv.get('unreadMessages')
     if (!count) {
       return map
     } else {

--- a/shared/actions/chat/index.js
+++ b/shared/actions/chat/index.js
@@ -123,6 +123,7 @@ function* _incomingMessage(action: Constants.IncomingMessage): SagaGenerator<any
         const yourDeviceName = yield select(Shared.devicenameSelector)
         const conversationIDKey = Constants.conversationIDToKey(incomingMessage.convID)
         const message = _unboxedToMessage(messageUnboxed, yourName, yourDeviceName, conversationIDKey)
+        const svcShouldDisplayNotification = incomingMessage.displayDesktopNotification
 
         const pagination = incomingMessage.pagination
         if (pagination) {
@@ -189,7 +190,8 @@ function* _incomingMessage(action: Constants.IncomingMessage): SagaGenerator<any
               conversationIDKey,
               conversationIDKey === selectedConversationIDKey,
               appFocused,
-              [message]
+              [message],
+              svcShouldDisplayNotification
             )
           )
         }
@@ -908,10 +910,17 @@ function* _sendNotifications(action: Constants.AppendMessages): SagaGenerator<an
   const selectedTab = yield select(Shared.routeSelector)
   const chatTabSelected = selectedTab === chatTab
   const convoIsSelected = action.payload.isSelected
+  const svcDisplay = action.payload.svcShouldDisplayNotification
 
-  console.log('Deciding whether to notify new message:', convoIsSelected, appFocused, chatTabSelected)
-  // Only send if you're not looking at it
-  if (!convoIsSelected || !appFocused || !chatTabSelected) {
+  console.log(
+    'Deciding whether to notify new message:',
+    svcDisplay,
+    convoIsSelected,
+    appFocused,
+    chatTabSelected
+  )
+  // Only send if you're not looking at it and service wants us to
+  if (svcDisplay && (!convoIsSelected || !appFocused || !chatTabSelected)) {
     const me = yield select(usernameSelector)
     const message = action.payload.messages.reverse().find(m => m.type === 'Text' && m.author !== me)
     // Is this message part of a muted conversation? If so don't notify.

--- a/shared/actions/chat/messages.js
+++ b/shared/actions/chat/messages.js
@@ -66,7 +66,9 @@ function* deleteMessage(action: Constants.DeleteMessage): SagaGenerator<any, any
     const outboxID = message.outboxID
     if (!outboxID) throw new Error('No outboxID for pending message delete')
 
-    yield call(ChatTypes.localCancelPostRpcPromise, {param: {outboxID: Constants.keyToOutboxID(outboxID)}})
+    yield call(ChatTypes.localCancelPostRpcPromise, {
+      param: {outboxID: Constants.keyToOutboxID(outboxID)},
+    })
     // It's deleted, but we don't get notified that the conversation now has
     // one less outbox entry in it.  Gotta remove it from the store ourselves.
     yield put(Creators.removeOutboxMessage(conversationIDKey, outboxID))
@@ -141,9 +143,13 @@ function* postMessage(action: Constants.PostMessage): SagaGenerator<any, any> {
     const appFocused = yield select(Shared.focusedSelector)
 
     yield put(
-      Creators.appendMessages(conversationIDKey, conversationIDKey === selectedConversation, appFocused, [
-        message,
-      ])
+      Creators.appendMessages(
+        conversationIDKey,
+        conversationIDKey === selectedConversation,
+        appFocused,
+        [message],
+        false
+      )
     )
     if (hasPendingFailure) {
       yield put(Creators.removePendingFailure(outboxID))
@@ -198,7 +204,9 @@ function* editMessage(action: Constants.EditMessage): SagaGenerator<any, any> {
 function* retryMessage(action: Constants.RetryMessage): SagaGenerator<any, any> {
   const {conversationIDKey, outboxIDKey} = action.payload
   yield put(Creators.updateTempMessage(conversationIDKey, {messageState: 'pending'}, outboxIDKey))
-  yield call(ChatTypes.localRetryPostRpcPromise, {param: {outboxID: Constants.keyToOutboxID(outboxIDKey)}})
+  yield call(ChatTypes.localRetryPostRpcPromise, {
+    param: {outboxID: Constants.keyToOutboxID(outboxIDKey)},
+  })
 }
 
 export {deleteMessage, editMessage, postMessage, retryMessage}

--- a/shared/chat/conversation/messages/dumb.js
+++ b/shared/chat/conversation/messages/dumb.js
@@ -90,7 +90,10 @@ const followingMap = {
   other: true,
 }
 const metaDataMap = Map({
-  cecileb: new ChatConstants.MetaDataRecord({fullname: 'Cecile Bee', brokenTracker: false}),
+  cecileb: new ChatConstants.MetaDataRecord({
+    fullname: 'Cecile Bee',
+    brokenTracker: false,
+  }),
 })
 
 const mocks = followStates.reduce(
@@ -129,7 +132,10 @@ const mocks = followStates.reduce(
               you: 'cecileb',
               followingMap,
               metaDataMap: Map({
-                other: new ChatConstants.MetaDataRecord({fullname: 'other person', brokenTracker: true}),
+                other: new ChatConstants.MetaDataRecord({
+                  fullname: 'other person',
+                  brokenTracker: true,
+                }),
               }),
             },
           }
@@ -152,7 +158,9 @@ const mocks = followStates.reduce(
 
 mocks['from revoked device'] = {
   ...baseMock,
-  message: textMessageMock('sent', 'cecileb', 'other', {senderDeviceRevokedAt: 123456}),
+  message: textMessageMock('sent', 'cecileb', 'other', {
+    senderDeviceRevokedAt: 123456,
+  }),
   you: 'other',
   followingMap: {cecileb: true},
   metaDataMap,
@@ -174,7 +182,9 @@ mocks['first new message'] = {
 }
 mocks['failure reason'] = {
   ...baseMock,
-  message: textMessageMock('failed', 'cecileb', 'cecileb', {failureDescription: 'the flurble glurbled'}),
+  message: textMessageMock('failed', 'cecileb', 'cecileb', {
+    failureDescription: 'the flurble glurbled',
+  }),
   you: 'cecileb',
   followingMap: {},
   metaDataMap,
@@ -383,8 +393,12 @@ const attachmentMap: DumbComponentMap<AttachmentMessageComponent> = {
 */
 
 let mockState = new ChatConstants.StateRecord()
-const firstMsg = textMessageMock('sent', 'cecileb', 'cecileb', {text: 'Can you bring the lentils tomorrow?'})
-const secondMsg = textMessageMock('sent', 'cecileb', 'cecileb', {text: 'Thanks!'})
+const firstMsg = textMessageMock('sent', 'cecileb', 'cecileb', {
+  text: 'Can you bring the lentils tomorrow?',
+})
+const secondMsg = textMessageMock('sent', 'cecileb', 'cecileb', {
+  text: 'Thanks!',
+})
 const pendingMessage = textMessageMock('pending', 'cecileb', 'cecileb', {
   text: 'Sorry, my internet is kinda slow.',
 })
@@ -397,7 +411,8 @@ mockState = chatReducer(
     convID, // conv id
     true, // isSelected
     true, // isAppFocused
-    [firstMsg, secondMsg, pendingMessage, failedMessage] //  messages: Array<Constants.Message>
+    [firstMsg, secondMsg, pendingMessage, failedMessage], //  messages: Array<Constants.Message>
+    false
   )
 )
 
@@ -447,17 +462,29 @@ const stackedMessagesMap = {
     'Stacked - two messages, one edited': {
       mockStore,
       mock1: textContainerMock(firstMsg.key, {isYou: true}),
-      mock2: textContainerMock(secondMsg.key, {includeHeader: false, isEdited: true, isYou: true}),
+      mock2: textContainerMock(secondMsg.key, {
+        includeHeader: false,
+        isEdited: true,
+        isYou: true,
+      }),
     },
     'Stacked - one sent, one pending': {
       mockStore,
       mock1: textContainerMock(firstMsg.key, {isYou: true}),
-      mock2: textContainerMock(pendingMessage.key, {includeHeader: false, isEdited: false, isYou: true}),
+      mock2: textContainerMock(pendingMessage.key, {
+        includeHeader: false,
+        isEdited: false,
+        isYou: true,
+      }),
     },
     'Stacked - one sent, one failed': {
       mockStore,
       mock1: textContainerMock(firstMsg.key, {isYou: true}),
-      mock2: textContainerMock(failedMessage.key, {includeHeader: false, isEdited: false, isYou: true}),
+      mock2: textContainerMock(failedMessage.key, {
+        includeHeader: false,
+        isEdited: false,
+        isYou: true,
+      }),
     },
     'Stacked - someone else. two sent': {
       mockStore,

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -262,12 +262,12 @@ export type ConversationState = KBRecord<{
 
 export type ConversationBadgeState = KBRecord<{
   convID: ConversationID,
-  UnreadMessages: number,
+  unreadMessages: number,
 }>
 
 export const ConversationBadgeStateRecord = Record({
   convID: undefined,
-  UnreadMessages: 0,
+  unreadMessages: 0,
 })
 
 export type ConversationStateEnum = $Keys<typeof ChatTypes.CommonConversationStatus>

--- a/shared/constants/chat.js
+++ b/shared/constants/chat.js
@@ -434,12 +434,22 @@ export type AddPendingConversation = NoErrorTypedAction<
 
 export type AppendMessages = NoErrorTypedAction<
   'chat:appendMessages',
-  {conversationIDKey: ConversationIDKey, isAppFocused: boolean, isSelected: boolean, messages: Array<Message>}
+  {
+    conversationIDKey: ConversationIDKey,
+    isAppFocused: boolean,
+    isSelected: boolean,
+    messages: Array<Message>,
+    svcShouldDisplayNotification: boolean,
+  }
 >
 export type BadgeAppForChat = NoErrorTypedAction<'chat:badgeAppForChat', List<ConversationBadgeState>>
 export type BlockConversation = NoErrorTypedAction<
   'chat:blockConversation',
-  {blocked: boolean, conversationIDKey: ConversationIDKey, reportUser: boolean}
+  {
+    blocked: boolean,
+    conversationIDKey: ConversationIDKey,
+    reportUser: boolean,
+  }
 >
 export type ClearMessages = NoErrorTypedAction<'chat:clearMessages', {conversationIDKey: ConversationIDKey}>
 export type ClearSearchResults = NoErrorTypedAction<'chat:clearSearchResults', {}>
@@ -988,7 +998,11 @@ function messageKey(
 
 function splitMessageIDKey(
   key: MessageKey
-): {conversationIDKey: ConversationIDKey, keyKind: string, messageID: MessageID} {
+): {
+  conversationIDKey: ConversationIDKey,
+  keyKind: string,
+  messageID: MessageID,
+} {
   const [conversationIDKey, keyKind, messageIDStr] = key.split(':')
   const messageID: MessageID = Number(messageIDStr)
   return {conversationIDKey, keyKind, messageID}

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -2100,6 +2100,7 @@ export type UpdateConversationMembership = {
   inboxVers: InboxVers,
   joined?: ?Array<ConversationMember>,
   removed?: ?Array<ConversationMember>,
+  unreadUpdate?: ?UnreadUpdate,
 }
 
 export type chatUiChatAttachmentDownloadProgressRpcParam = Exact<{

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -93,11 +93,6 @@ export const CommonMessageType = {
   attachmentuploaded: 8,
 }
 
-export const CommonNotificationAppType = {
-  desktop: 0,
-  mobile: 1,
-}
-
 export const CommonNotificationKind = {
   generic: 0,
   atmention: 1,
@@ -1779,10 +1774,6 @@ export type NonblockFetchRes = {
   identifyFailures?: ?Array<keybase1.TLFIdentifyFailure>,
 }
 
-export type NotificationAppType =
-    0 // DESKTOP_0
-  | 1 // MOBILE_1
-
 export type NotificationKind =
     0 // GENERIC_0
   | 1 // ATMENTION_1
@@ -2087,8 +2078,8 @@ export type UnreadFirstNumLimit = {
 
 export type UnreadUpdate = {
   convID: ConversationID,
-  UnreadMessages: int,
-  UnreadNotifyingMessages: int,
+  unreadMessages: int,
+  unreadNotifyingMessages: {[key: string]: int},
 }
 
 export type UnreadUpdateFull = {

--- a/shared/constants/types/flow-types-chat.js
+++ b/shared/constants/types/flow-types-chat.js
@@ -2088,6 +2088,7 @@ export type UnreadFirstNumLimit = {
 export type UnreadUpdate = {
   convID: ConversationID,
   UnreadMessages: int,
+  UnreadNotifyingMessages: int,
 }
 
 export type UnreadUpdateFull = {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4183,7 +4183,8 @@ export type BTCRegisterBTCRpcParam = Exact<{
 
 export type BadgeConversationInfo = {
   convID: ChatConversationID,
-  UnreadMessages: int,
+  badgeCounts: {[key: string]: int},
+  hasUnreadMessages: boolean,
 }
 
 export type BadgeState = {

--- a/shared/constants/types/flow-types.js
+++ b/shared/constants/types/flow-types.js
@@ -4184,7 +4184,7 @@ export type BTCRegisterBTCRpcParam = Exact<{
 export type BadgeConversationInfo = {
   convID: ChatConversationID,
   badgeCounts: {[key: string]: int},
-  hasUnreadMessages: boolean,
+  unreadMessages: int,
 }
 
 export type BadgeState = {

--- a/shared/native/notification-listeners.native.js
+++ b/shared/native/notification-listeners.native.js
@@ -1,6 +1,7 @@
 // @flow
 import shared from './notification-listeners.shared'
 import RNPN from 'react-native-push-notification'
+import * as RPCTypes from '../constants/types/flow-types'
 
 import type {Dispatch} from '../constants/types/flux'
 import type {incomingCallMapType} from '../constants/types/flow-types'
@@ -14,7 +15,12 @@ export default function(dispatch: Dispatch, getState: () => Object, notify: any)
       const sharedBadgeState = fromShared['keybase.1.NotifyBadges.badgeState']
       sharedBadgeState({badgeState})
 
-      const count = (badgeState.conversations || []).reduce((total, c) => total + c.UnreadMessages, 0)
+      const count = (badgeState.conversations || [])
+        .reduce(
+          (total, c) =>
+            c.badgeCounts ? total + c.badgeCounts[`${RPCTypes.CommonDeviceType.mobile}`] : total,
+          0
+        )
 
       RNPN.setApplicationIconBadgeNumber(count)
       if (count === 0) {

--- a/shared/native/notification-listeners.shared.js
+++ b/shared/native/notification-listeners.shared.js
@@ -3,7 +3,6 @@ import {receivedBadgeState} from '../actions/notifications'
 import {bootstrap, updateFollowing} from '../actions/config'
 import {logoutDone} from '../actions/login/creators'
 import throttle from 'lodash/throttle'
-import * as RPCTypes from '../constants/types/flow-types'
 
 import type {Dispatch} from '../constants/types/flux'
 import type {incomingCallMapType} from '../constants/types/flow-types'
@@ -15,7 +14,10 @@ let lastLoggedInNotifyUsername = null
 let lastBadgeStateVersion = -1
 
 export default function(dispatch: Dispatch, getState: () => Object, notify: any): incomingCallMapType {
-  const throttledDispatch = throttle(action => dispatch(action), 1000, {leading: false, trailing: true})
+  const throttledDispatch = throttle(action => dispatch(action), 1000, {
+    leading: false,
+    trailing: true,
+  })
   return {
     'keybase.1.NotifyBadges.badgeState': ({badgeState}) => {
       if (badgeState.inboxVers < lastBadgeStateVersion) {
@@ -28,14 +30,7 @@ export default function(dispatch: Dispatch, getState: () => Object, notify: any)
       lastBadgeStateVersion = badgeState.inboxVers
 
       const conversations = badgeState.conversations
-      const computeBadgeCount = typ => {
-        return (conversations || [])
-          .reduce((total, c) => (c.badgeCounts ? total + c.badgeCounts[`${typ}`] : total), 0)
-      }
-      const totalMessagesDesktop = computeBadgeCount(RPCTypes.CommonDeviceType.desktop)
-      const totalMessagesMobile = computeBadgeCount(RPCTypes.CommonDeviceType.mobile)
-      const totalChats = totalMessagesDesktop + totalMessagesMobile
-
+      const totalChats = (conversations || []).reduce((total, c) => total + c.unreadMessages, 0)
       const action = receivedBadgeState(badgeState)
       if (totalChats > 0) {
         // Defer this slightly so we don't get flashing if we're quickly receiving and reading

--- a/shared/native/notification-listeners.shared.js
+++ b/shared/native/notification-listeners.shared.js
@@ -3,6 +3,7 @@ import {receivedBadgeState} from '../actions/notifications'
 import {bootstrap, updateFollowing} from '../actions/config'
 import {logoutDone} from '../actions/login/creators'
 import throttle from 'lodash/throttle'
+import * as RPCTypes from '../constants/types/flow-types'
 
 import type {Dispatch} from '../constants/types/flux'
 import type {incomingCallMapType} from '../constants/types/flow-types'
@@ -26,7 +27,14 @@ export default function(dispatch: Dispatch, getState: () => Object, notify: any)
 
       lastBadgeStateVersion = badgeState.inboxVers
 
-      const totalChats = (badgeState.conversations || []).reduce((total, c) => total + c.UnreadMessages, 0)
+      const conversations = badgeState.conversations
+      const computeBadgeCount = typ => {
+        return (conversations || [])
+          .reduce((total, c) => (c.badgeCounts ? total + c.badgeCounts[`${typ}`] : total), 0)
+      }
+      const totalMessagesDesktop = computeBadgeCount(RPCTypes.CommonDeviceType.desktop)
+      const totalMessagesMobile = computeBadgeCount(RPCTypes.CommonDeviceType.mobile)
+      const totalChats = totalMessagesDesktop + totalMessagesMobile
 
       const action = receivedBadgeState(badgeState)
       if (totalChats > 0) {

--- a/shared/reducers/notifications.js
+++ b/shared/reducers/notifications.js
@@ -2,6 +2,7 @@
 import * as Constants from '../constants/notifications'
 import * as CommonConstants from '../constants/common'
 import {chatTab, folderTab} from '../constants/tabs'
+import * as RPCTypes from '../constants/types/flow-types'
 
 const initialState: Constants.State = new Constants.StateRecord()
 
@@ -25,7 +26,8 @@ export default function(state: Constants.State = initialState, action: Constants
       const {conversations, newTlfs, rekeysNeeded} = action.payload.badgeState
 
       const navBadges = state.get('navBadges').withMutations(n => {
-        const totalMessages = (conversations || []).reduce((total, c) => total + c.UnreadMessages, 0)
+        const totalMessages = (conversations || []).reduce((total, c) => c.badgeCounts ? total + c.badgeCounts[`${RPCTypes.CommonDeviceType.desktop}`] : total, 0)
+        console.log("TOTAL: " + totalMessages)
         n.set(chatTab, totalMessages)
         n.set(folderTab, newTlfs + rekeysNeeded)
       })


### PR DESCRIPTION
Patch does the following in service @patrickxb:
1.) Handle the badger update on `MembershipUpdate` now, so that join/leave properly sets badging information on the frontend. 
2.) Don't rule out showing notifications on desktop for attachments (even though they are later not shown by frontend currently).

Patch does the following on the frontend @chrisnojima:
1.) Change the calculation of the chat tab badge number to use the current device type from the given badge state information.
2.) Change app icon badge calculation to user the mobile badge number.
3.) Change desktop notification showing logic to use the new parameter on `incomingMessage`, so that the service can control when these toasts get shown. This is just easier than having the frontend attempt to parse the notification settings. 