### PR TITLE
Add team rename post and parse

### DIFF
--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -250,10 +250,12 @@ func SigchainV2TypeFromV1TypeTeams(s string) (ret SigchainV2Type, err error) {
 		ret = SigchainV2TypeTeamLeave
 	case LinkTypeSubteamHead:
 		ret = SigchainV2TypeTeamSubteamHead
-	case LinkTypeSubteamRename:
+	case LinkTypeRenameSubteam:
 		ret = SigchainV2TypeTeamRenameSubteam
 	case LinkTypeInvite:
 		ret = SigchainV2TypeTeamInvite
+	case LinkTypeRenameUpPointer:
+		ret = SigchainV2TypeTeamRenameUpPointer
 	default:
 		return SigchainV2TypeNone, ChainLinkError{fmt.Sprintf("Unknown team sig v1 type: %s", s)}
 	}

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -283,7 +283,8 @@ const (
 	LinkTypeRotateKey        LinkType = "team.rotate_key"
 	LinkTypeLeave            LinkType = "team.leave"
 	LinkTypeInvite           LinkType = "team.invite"
-	LinkTypeSubteamRename    LinkType = "team.subteam_rename"
+	LinkTypeRenameSubteam    LinkType = "team.rename_subteam"
+	LinkTypeRenameUpPointer  LinkType = "team.rename_up_pointer"
 
 	DelegationTypeEldest    DelegationType = "eldest"
 	DelegationTypePGPUpdate DelegationType = "pgp_update"

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1563,6 +1563,26 @@ func (t TeamName) RootAncestorName() TeamName {
 	}
 }
 
+func (t TeamName) Parent() (TeamName, error) {
+	if len(t.Parts) == 0 {
+		return t, fmt.Errorf("empty team name")
+	}
+	if t.IsRootTeam() {
+		return t, fmt.Errorf("root team has no parent")
+	}
+	return TeamName{
+		Parts: t.Parts[:len(t.Parts)-1],
+	}, nil
+}
+
+func (t TeamName) SwapLastPart(newLast string) (TeamName, error) {
+	parent, err := t.Parent()
+	if err != nil {
+		return t, err
+	}
+	return parent.Append(newLast)
+}
+
 // The number of parts in a team name.
 // Root teams have 1.
 func (t TeamName) Depth() int {

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -324,7 +324,7 @@ func (t *TeamSigChainState) getLastSubteamPoint(id keybase1.TeamID) *keybase1.Su
 }
 
 // Inform the SubteamLog of a subteam name change.
-// Links must be added in order by seqno for each subteam.
+// Links must be added in order by seqno for each subteam (asserted here).
 // Links for different subteams can interleave.
 // Mutates the SubteamLog.
 func (t *TeamSigChainState) informSubteam(id keybase1.TeamID, name keybase1.TeamName, seqno keybase1.Seqno) error {
@@ -365,6 +365,29 @@ func (t *TeamSigChainState) checkSubteamCollision(id keybase1.TeamID, name keyba
 		}
 	}
 	return nil
+}
+
+type TeamIDAndName struct {
+	ID   keybase1.TeamID
+	Name keybase1.TeamName
+}
+
+// Only call this on a Team that has been loaded with NeedAdmin.
+// Otherwise, you might get incoherent answers due to links that
+// were stubbed over the life of the cached object.
+func (t *TeamSigChainState) ListSubteams() (res []TeamIDAndName) {
+	for subteamID, points := range t.inner.SubteamLog {
+		if len(points) == 0 {
+			// this should never happen
+			continue
+		}
+		lastPoint := points[len(points)-1]
+		res = append(res, TeamIDAndName{
+			ID:   subteamID,
+			Name: lastPoint.Name,
+		})
+	}
+	return res
 }
 
 func (t *TeamSigChainState) HasActiveInvite(name, typ string) (bool, error) {
@@ -629,6 +652,9 @@ func (t *TeamSigChainPlayer) addInnerLink(
 	hasInvites := func(has bool) error {
 		return hasGeneric(has, team.Invites != nil, "invite")
 	}
+	hasCompletedInvites := func(has bool) error {
+		return hasGeneric(has, len(team.CompletedInvites) != 0, "completed_invites")
+	}
 	allowInflate := func(allow bool) error {
 		if isInflate && !allow {
 			return fmt.Errorf("inflating link type not supported: %v", payload.Body.Type)
@@ -646,8 +672,9 @@ func (t *TeamSigChainPlayer) addInnerLink(
 			hasParent(false),
 			hasSubteam(false),
 			hasPerTeamKey(true),
+			hasAdmin(false),
 			hasInvites(false),
-			hasAdmin(false))
+			hasCompletedInvites(false))
 		if err != nil {
 			return res, err
 		}
@@ -715,7 +742,8 @@ func (t *TeamSigChainPlayer) addInnerLink(
 			hasMembers(true),
 			hasParent(false),
 			hasInvites(false),
-			hasSubteam(false))
+			hasSubteam(false),
+			hasInvites(false))
 		if err != nil {
 			return res, err
 		}
@@ -766,7 +794,9 @@ func (t *TeamSigChainPlayer) addInnerLink(
 			hasMembers(false),
 			hasParent(false),
 			hasSubteam(false),
-			hasPerTeamKey(true))
+			hasPerTeamKey(true),
+			hasInvites(false),
+			hasCompletedInvites(false))
 		if err != nil {
 			return res, err
 		}
@@ -806,7 +836,9 @@ func (t *TeamSigChainPlayer) addInnerLink(
 			hasSubteam(false),
 			hasPerTeamKey(false),
 			hasInvites(false),
-			hasAdmin(false))
+			hasAdmin(false),
+			hasInvites(false),
+			hasCompletedInvites(false))
 		if err != nil {
 			return res, err
 		}
@@ -839,27 +871,21 @@ func (t *TeamSigChainPlayer) addInnerLink(
 			hasMembers(false),
 			hasParent(false),
 			hasSubteam(true),
+			hasPerTeamKey(false),
 			hasInvites(false),
-			hasPerTeamKey(false))
+			hasCompletedInvites(false))
 		if err != nil {
 			return res, err
 		}
 
 		// Check the subteam ID
-		subteamID, err := keybase1.TeamIDFromString(string(team.Subteam.ID))
+		subteamID, err := t.assertIsSubteamID(string(team.Subteam.ID))
 		if err != nil {
-			return res, fmt.Errorf("invalid subteam id: %v", err)
-		}
-		if !subteamID.IsSubTeam() {
-			return res, fmt.Errorf("malformed subteam id")
+			return res, err
 		}
 
 		// Check the subteam name
-		subteamName, err := keybase1.TeamNameFromString(string(team.Subteam.Name))
-		if err != nil {
-			return res, fmt.Errorf("invalid subteam team name '%s': %v", team.Subteam.Name, err)
-		}
-		err = t.assertSubteamName(prevState, subteamName)
+		subteamName, err := t.assertSubteamName(prevState, string(team.Subteam.Name))
 		if err != nil {
 			return res, err
 		}
@@ -882,8 +908,9 @@ func (t *TeamSigChainPlayer) addInnerLink(
 			hasMembers(true),
 			hasParent(true),
 			hasSubteam(false),
+			hasPerTeamKey(true),
 			hasInvites(false),
-			hasPerTeamKey(true))
+			hasCompletedInvites(false))
 		if err != nil {
 			return res, err
 		}
@@ -939,8 +966,96 @@ func (t *TeamSigChainPlayer) addInnerLink(
 		t.updateMembership(&res.newState, roleUpdates, payload.SignatureMetadata())
 
 		return res, nil
-	case libkb.LinkTypeSubteamRename:
-		return res, fmt.Errorf("subteam renaming not yet supported: %s", payload.Body.Type)
+	case libkb.LinkTypeRenameSubteam:
+		err = libkb.PickFirstError(
+			allowInflate(true),
+			hasPrevState(true),
+			hasName(false),
+			hasMembers(false),
+			hasParent(false),
+			hasSubteam(true),
+			hasPerTeamKey(false),
+			hasInvites(false),
+			hasCompletedInvites(false))
+		if err != nil {
+			return res, err
+		}
+
+		// Check the subteam ID
+		subteamID, err := t.assertIsSubteamID(string(team.Subteam.ID))
+		if err != nil {
+			return res, err
+		}
+
+		// Check the subteam name
+		subteamName, err := t.assertSubteamName(prevState, string(team.Subteam.Name))
+		if err != nil {
+			return res, err
+		}
+
+		res.newState = prevState.DeepCopy()
+
+		// informSubteam will take care of asserting that these links are inflated
+		// in order for each subteam.
+		err = res.newState.informSubteam(subteamID, subteamName, link.Seqno())
+		if err != nil {
+			return res, fmt.Errorf("adding new subteam: %v", err)
+		}
+
+		return res, nil
+	case libkb.LinkTypeRenameUpPointer:
+		err = libkb.PickFirstError(
+			allowInflate(false),
+			hasPrevState(true),
+			hasName(true),
+			hasMembers(false),
+			hasParent(true),
+			hasSubteam(false),
+			hasPerTeamKey(false),
+			hasInvites(false),
+			hasCompletedInvites(false))
+		if err != nil {
+			return res, err
+		}
+
+		// These links only occur in subteam.
+		if !prevState.IsSubteam() {
+			return res, fmt.Errorf("got %v in root team", payload.Body.Type)
+		}
+
+		// Sanity check that the parent doesn't claim to have changed.
+		parentID, err := keybase1.TeamIDFromString(string(team.Parent.ID))
+		if err != nil {
+			return res, fmt.Errorf("invvalid parent team id: %v", err)
+		}
+		if !parentID.Eq(*prevState.GetParentID()) {
+			return res, fmt.Errorf("wrong parent team ID: %s != %s", parentID, prevState.GetParentID())
+		}
+
+		// Ideally we would assert that the name
+		// But we may not have an up-to-date picture at this time of the parent's name.
+		// So assert this:
+		// - The root team name is the same.
+		// - The depth of the new name is the same.
+		newName, err := keybase1.TeamNameFromString(string(*team.Name))
+		if err != nil {
+			return res, fmt.Errorf("invalid team name '%s': %v", *team.Name, err)
+		}
+		if newName.IsRootTeam() {
+			return res, fmt.Errorf("cannot rename to root team name: %v", newName.String())
+		}
+		if !newName.RootAncestorName().Eq(prevState.GetName().RootAncestorName()) {
+			return res, fmt.Errorf("rename cannot change root ancestor team name: %v -> %v", prevState.GetName(), newName)
+		}
+		if newName.Depth() != prevState.GetName().Depth() {
+			return res, fmt.Errorf("rename cannot change team nesting depth: %v -> %v", prevState.GetName(), newName)
+		}
+
+		res.newState = prevState.DeepCopy()
+
+		res.newState.inner.Name = newName
+
+		return res, nil
 	case libkb.LinkTypeInvite:
 		err = libkb.PickFirstError(
 			allowInflate(false),
@@ -949,6 +1064,7 @@ func (t *TeamSigChainPlayer) addInnerLink(
 			hasMembers(false),
 			hasParent(false),
 			hasSubteam(false),
+			hasPerTeamKey(false),
 			hasInvites(true))
 		if err != nil {
 			return res, err
@@ -1264,33 +1380,52 @@ func (t *TeamSigChainPlayer) completeInvites(stateToUpdate *TeamSigChainState, c
 	}
 }
 
-func (t *TeamSigChainPlayer) assertSubteamName(parent *TeamSigChainState, subteamName keybase1.TeamName) error {
+// Check that the subteam name is valid and kind of is a child of this chain.
+// Returns the parsed subteam name.
+func (t *TeamSigChainPlayer) assertSubteamName(parent *TeamSigChainState, subteamNameStr string) (keybase1.TeamName, error) {
 	// Ideally, we would assert the team name is a direct child of this team's name.
 	// But the middle parts of the names might be out of date.
 	// Instead assert:
 	// - The root team name is same.
 	// - The subteam is 1 level deeper.
-	// - The last part of this parent team's name matches.
+	// - The last part of the parent team's name matches.
 	//   (If the subteam is a.b.c.d then c should be the same.)
 
+	subteamName, err := keybase1.TeamNameFromString(subteamNameStr)
+	if err != nil {
+		return subteamName, fmt.Errorf("invalid subteam team name '%s': %v", subteamNameStr, err)
+	}
+
 	if !parent.GetName().RootAncestorName().Eq(subteamName.RootAncestorName()) {
-		return fmt.Errorf("subteam is of a different root team: %v != %v",
+		return subteamName, fmt.Errorf("subteam is of a different root team: %v != %v",
 			subteamName.RootAncestorName().String(),
 			parent.GetName().RootAncestorName().String())
 	}
 
 	expectedDepth := parent.GetName().Depth() + 1
 	if subteamName.Depth() != expectedDepth {
-		return fmt.Errorf("subteam name has depth %v but expected %v",
+		return subteamName, fmt.Errorf("subteam name has depth %v but expected %v",
 			subteamName.Depth(), expectedDepth)
 	}
 
 	subteamSecondToLastPart := subteamName.Parts[len(subteamName.Parts)-2]
 	parentLastPart := parent.GetName().LastPart()
 	if !subteamSecondToLastPart.Eq(parentLastPart) {
-		return fmt.Errorf("subteam name has wrong name for us: %v != %v",
+		return subteamName, fmt.Errorf("subteam name has wrong name for us: %v != %v",
 			subteamSecondToLastPart, parentLastPart)
 	}
 
-	return nil
+	return subteamName, nil
+}
+
+func (t *TeamSigChainPlayer) assertIsSubteamID(subteamIDStr string) (keybase1.TeamID, error) {
+	// Check the subteam ID
+	subteamID, err := keybase1.TeamIDFromString(string(subteamIDStr))
+	if err != nil {
+		return subteamID, fmt.Errorf("invalid subteam id: %v", err)
+	}
+	if !subteamID.IsSubTeam() {
+		return subteamID, fmt.Errorf("malformed subteam id")
+	}
+	return subteamID, nil
 }

--- a/go/teams/rename.go
+++ b/go/teams/rename.go
@@ -1,0 +1,188 @@
+package teams
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+func RenameSubteam(ctx context.Context, g *libkb.GlobalContext, prevName keybase1.TeamName, newNameLastPart string) error {
+	g.Log.CDebugf(ctx, "RenameSubteam")
+
+	if prevName.IsRootTeam() {
+		return fmt.Errorf("cannot rename root team: %s", prevName.String())
+	}
+	parentName, err := prevName.Parent()
+	if err != nil {
+		return err
+	}
+	newName, err := prevName.SwapLastPart(newNameLastPart)
+	if err != nil {
+		return err
+	}
+	g.Log.CDebugf(ctx, "RenameSubteam %v -> %v", prevName, newName)
+
+	g.Log.CDebugf(ctx, "RenameSubteam load teams: parent:'%v' subteam:'%v'",
+		parentName.String(), prevName.String())
+	parent, err := GetForTeamManagementByStringName(ctx, g, parentName.String(), true)
+	if err != nil {
+		return err
+	}
+	subteam, err := GetForTeamManagementByStringName(ctx, g, prevName.String(), false)
+	if err != nil {
+		return err
+	}
+
+	g.Log.CDebugf(ctx, "RenameSubteam load me")
+	me, err := libkb.LoadMe(libkb.NewLoadUserArg(g))
+	if err != nil {
+		return err
+	}
+	parent.me = me
+	subteam.me = me
+
+	deviceSigningKey, err := g.ActiveDevice.SigningKey()
+	if err != nil {
+		return err
+	}
+
+	admin, err := parent.getAdminPermission(ctx, true)
+
+	err = parent.ForceMerkleRootUpdate(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Subteam renaming involves two links, one `rename_subteam` in the parent
+	// team's chain, and one `rename_up_pointer` in the subteam's chain.
+
+	g.Log.CDebugf(ctx, "RenameSubteam make sigs")
+	renameSubteamSig, err := generateRenameSubteamSigForParentChain(
+		g, me, deviceSigningKey, parent.chain(), subteam.ID, newName, admin)
+	if err != nil {
+		return err
+	}
+
+	renameUpPointerSig, err := generateRenameUpPointerSigForSubteamChain(
+		g, me, deviceSigningKey, chainPair{parent: parent.chain(), subteam: subteam.chain()}, newName, admin)
+	if err != nil {
+		return err
+	}
+
+	payload := make(libkb.JSONPayload)
+	payload["sigs"] = []interface{}{renameSubteamSig, renameUpPointerSig}
+
+	g.Log.CDebugf(ctx, "RenameSubteam post")
+	_, err = g.API.PostJSON(libkb.APIArg{
+		Endpoint:    "sig/multi",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		JSONPayload: payload,
+	})
+	if err != nil {
+		return err
+	}
+
+	go g.GetTeamLoader().NotifyTeamRename(ctx, subteam.ID, newName.String())
+
+	return nil
+}
+
+func generateRenameSubteamSigForParentChain(g *libkb.GlobalContext, me *libkb.User, signingKey libkb.GenericKey, parentTeam *TeamSigChainState, subteamID keybase1.TeamID, newSubteamName keybase1.TeamName, admin *SCTeamAdmin) (item *libkb.SigMultiItem, err error) {
+	teamSection := SCTeamSection{
+		Admin: admin,
+		ID:    (SCTeamID)(parentTeam.GetID()),
+		Subteam: &SCSubteam{
+			ID:   (SCTeamID)(subteamID),
+			Name: (SCTeamName)(newSubteamName.String()),
+		},
+	}
+
+	sigBody, err := RenameSubteamSig(me, signingKey, parentTeam, teamSection)
+	if err != nil {
+		return nil, err
+	}
+	sigJSON, err := sigBody.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	prevLinkID, err := libkb.ImportLinkID(parentTeam.GetLatestLinkID())
+	if err != nil {
+		return nil, err
+	}
+	v2Sig, err := makeSigchainV2OuterSig(
+		signingKey,
+		libkb.LinkTypeRenameSubteam,
+		parentTeam.GetLatestSeqno()+1,
+		sigJSON,
+		prevLinkID,
+		false, /* hasRevokes */
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	item = &libkb.SigMultiItem{
+		Sig:        v2Sig,
+		SigningKID: signingKey.GetKID(),
+		Type:       string(libkb.LinkTypeRenameSubteam),
+		SigInner:   string(sigJSON),
+		TeamID:     parentTeam.GetID(),
+	}
+	return item, nil
+}
+
+type chainPair struct {
+	parent  *TeamSigChainState
+	subteam *TeamSigChainState
+}
+
+func generateRenameUpPointerSigForSubteamChain(g *libkb.GlobalContext, me *libkb.User, signingKey libkb.GenericKey, teams chainPair, newSubteamName keybase1.TeamName, admin *SCTeamAdmin) (item *libkb.SigMultiItem, err error) {
+	newSubteamNameStr := newSubteamName.String()
+	teamSection := SCTeamSection{
+		Admin: admin,
+		ID:    (SCTeamID)(teams.subteam.GetID()),
+		Name:  (*SCTeamName)(&newSubteamNameStr),
+		Parent: &SCTeamParent{
+			ID:      SCTeamID(teams.parent.GetID()),
+			Seqno:   teams.parent.GetLatestSeqno() + 1, // the seqno of the *new* parent link
+			SeqType: keybase1.SeqType_SEMIPRIVATE,
+		},
+	}
+
+	sigBody, err := RenameUpPointerSig(me, signingKey, teams.subteam, teamSection)
+	if err != nil {
+		return nil, err
+	}
+	sigJSON, err := sigBody.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	prevLinkID, err := libkb.ImportLinkID(teams.subteam.GetLatestLinkID())
+	if err != nil {
+		return nil, err
+	}
+	v2Sig, err := makeSigchainV2OuterSig(
+		signingKey,
+		libkb.LinkTypeRenameUpPointer,
+		teams.subteam.GetLatestSeqno()+1,
+		sigJSON,
+		prevLinkID,
+		false, /* hasRevokes */
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	item = &libkb.SigMultiItem{
+		Sig:        v2Sig,
+		SigningKID: signingKey.GetKID(),
+		Type:       string(libkb.LinkTypeRenameUpPointer),
+		SigInner:   string(sigJSON),
+		TeamID:     teams.subteam.GetID(),
+	}
+	return item, nil
+}

--- a/go/teams/rename_test.go
+++ b/go/teams/rename_test.go
@@ -1,0 +1,54 @@
+package teams
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenameSimple(t *testing.T) {
+	tc := SetupTest(t, "team", 1)
+	defer tc.Cleanup()
+
+	u, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
+	require.NoError(t, err)
+
+	parentTeamName, err := keybase1.TeamNameFromString(u.Username + "T")
+	require.NoError(t, err)
+	err = CreateRootTeam(context.TODO(), tc.G, parentTeamName.String())
+	require.NoError(t, err)
+
+	subteamBasename := "bb1"
+	subteamID, err := CreateSubteam(context.TODO(), tc.G, subteamBasename, parentTeamName)
+	require.NoError(t, err)
+	subteamName, err := parentTeamName.Append(subteamBasename)
+	require.NoError(t, err)
+
+	err = RenameSubteam(context.TODO(), tc.G, subteamName, "bb2")
+	require.NoError(t, err)
+
+	t.Logf("load the renamed team")
+	subteam, err := Load(context.TODO(), tc.G, keybase1.LoadTeamArg{
+		ID:          *subteamID,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, parentTeamName.String()+".bb2", subteam.Name().String(), "new name")
+
+	t.Logf("load the parent")
+	parent, err := Load(context.TODO(), tc.G, keybase1.LoadTeamArg{
+		Name:        parentTeamName.String(),
+		NeedAdmin:   true,
+		ForceRepoll: true,
+	})
+	require.NoError(t, err)
+	subteamList := parent.chain().ListSubteams()
+	require.Len(t, subteamList, 1, "has 1 subteam")
+	require.Equal(t, subteamList[0].Name.String(), parentTeamName.String()+".bb2")
+	require.Equal(t, subteamList[0].ID.String(), subteamID.String())
+	require.Len(t, parent.chain().inner.SubteamLog, 1, "subteam log has 1 series")
+	require.Len(t, parent.chain().inner.SubteamLog[*subteamID], 2, "subteam log has 2 entries")
+}

--- a/go/teams/sig.go
+++ b/go/teams/sig.go
@@ -119,6 +119,61 @@ func SubteamHeadSig(me *libkb.User, key libkb.GenericKey, subteamTeamSection SCT
 	return ret, nil
 }
 
+func RenameSubteamSig(me *libkb.User, key libkb.GenericKey, parentTeam *TeamSigChainState, teamSection SCTeamSection) (*jsonw.Wrapper, error) {
+	prev, err := parentTeam.GetLatestLibkbLinkID()
+	if err != nil {
+		return nil, err
+	}
+	ret, err := libkb.ProofMetadata{
+		Me:         me,
+		LinkType:   libkb.LinkTypeRenameSubteam,
+		SigningKey: key,
+		Seqno:      parentTeam.GetLatestSeqno() + 1,
+		PrevLinkID: prev,
+		SigVersion: libkb.KeybaseSignatureV2,
+		SeqType:    libkb.SeqTypeSemiprivate,
+	}.ToJSON(me.G())
+	if err != nil {
+		return nil, err
+	}
+
+	teamSectionJSON, err := jsonw.WrapperFromObject(teamSection)
+	if err != nil {
+		return nil, err
+	}
+
+	body := ret.AtKey("body")
+	body.SetKey("team", teamSectionJSON)
+
+	return ret, nil
+}
+
+func RenameUpPointerSig(me *libkb.User, key libkb.GenericKey, subteam *TeamSigChainState, teamSection SCTeamSection) (*jsonw.Wrapper, error) {
+	prev, err := subteam.GetLatestLibkbLinkID()
+	ret, err := libkb.ProofMetadata{
+		Me:         me,
+		LinkType:   libkb.LinkTypeRenameUpPointer,
+		SigningKey: key,
+		Seqno:      subteam.GetLatestSeqno() + 1,
+		PrevLinkID: prev,
+		SigVersion: libkb.KeybaseSignatureV2,
+		SeqType:    libkb.SeqTypeSemiprivate,
+	}.ToJSON(me.G())
+	if err != nil {
+		return nil, err
+	}
+
+	teamSectionJSON, err := jsonw.WrapperFromObject(teamSection)
+	if err != nil {
+		return nil, err
+	}
+
+	body := ret.AtKey("body")
+	body.SetKey("team", teamSectionJSON)
+
+	return ret, nil
+}
+
 // 15 random bytes, followed by the byte 0x25, encoded as hex
 func NewSubteamID() keybase1.TeamID {
 	idBytes, err := libkb.RandBytesWithSuffix(16, libkb.SubteamIDTag)


### PR DESCRIPTION
Add the ability to post and parse subteam renames. This tests only the simplest case. There is no CLI command yet.