### PR TITLE
SearchV3: Fix crash in the case of null searchSuggestions

### DIFF
--- a/shared/actions/searchv3/index.js
+++ b/shared/actions/searchv3/index.js
@@ -210,17 +210,14 @@ function* search<T>({
 }
 
 function* searchSuggestions<T>({payload: {actionTypeToFire, maxUsers}}: Constants.SearchSuggestions<T>) {
-  const suggestions: Array<InterestingPerson> = yield call(userInterestingPeopleRpcPromise, {
+  let suggestions: Array<InterestingPerson> = yield call(userInterestingPeopleRpcPromise, {
     param: {
       maxUsers,
     },
   })
 
-  if (!suggestions) {
-    // No search results (e.g. this user doesn't follow/chat anyone)
-    yield put(Creators.finishedSearch(actionTypeToFire, [], '', 'Keybase', true))
-    return
-  }
+  // No search results (e.g. this user doesn't follow/chat anyone)
+  suggestions = suggestions || []
 
   const rows = suggestions.map(person => _parseSuggestion(person.username))
   const ids = rows.map(r => r.id)

--- a/shared/actions/searchv3/index.js
+++ b/shared/actions/searchv3/index.js
@@ -186,8 +186,10 @@ function* search<T>({
     const rows = searchResults.list.map((result: RawResult) => {
       return _parseRawResultToRow(result, service || 'Keybase')
     })
+
     // Make a version that maps from keybase id to SearchResult.
-    // This is in case we want to lookup this data by their keybase id. (like the case of upgrading a 3rd party result to a kb result)
+    // This is in case we want to lookup this data by their keybase id.
+    // (like the case of upgrading a 3rd party result to a kb result)
     const kbRows: Array<Constants.SearchResult> = rows.filter(r => r.rightService === 'Keybase').map(r => ({
       id: r.rightUsername || '',
       leftService: 'Keybase',
@@ -213,6 +215,12 @@ function* searchSuggestions<T>({payload: {actionTypeToFire, maxUsers}}: Constant
       maxUsers,
     },
   })
+
+  if (!suggestions) {
+    // No search results (e.g. this user doesn't follow/chat anyone)
+    yield put(Creators.finishedSearch(actionTypeToFire, [], '', 'Keybase', true))
+    return
+  }
 
   const rows = suggestions.map(person => _parseSuggestion(person.username))
   const ids = rows.map(r => r.id)


### PR DESCRIPTION
@keybase/react-hackers 

The interestingPeople search suggestions RPC returns null in the case of no matches, and you have no matches if you haven't chatted or followed anyone, and this is the case that a fresh account is in.  We end up crashing with `TypeError: Cannot read property 'map' of null`.

This PR fixes the crash by synthesizing an empty search result when suggestions is null (and rewraps a comment).